### PR TITLE
util: fd_shmem_cfg needs a guard if command not available

### DIFF
--- a/src/util/shmem/fd_shmem_cfg
+++ b/src/util/shmem/fd_shmem_cfg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Use FD_SHMEM_PATH from the environment if provided for hugetlbfs mount
 # path and fallback on "/mnt/.fd" if not
@@ -6,6 +6,11 @@
 SHMEM_PATH="${FD_SHMEM_PATH:-/mnt/.fd}"
 
 ALL_TYPES="gigantic huge normal"
+
+if ! [ -x "$(command -v hwloc-calc)" ]; then
+  echo "fd_shmem_cfg: command hwloc-calc not installed, please consult README for install instructions"
+  exit 1
+fi
 
 NUMA_CNT=`hwloc-calc -N numa machine:0 2> /dev/null`
 if [ "$NUMA_CNT" = "" ]; then # Handle boxes with no NUMA


### PR DESCRIPTION
If the specified command is not installed, tell the user to install it. I think there are other places where this is needed, but I just wanted to do one before I do it everywhere else.

TESTED=With and without the command installed.
