### PR TITLE
util: add FD_INCBIN macro

### DIFF
--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -327,6 +327,28 @@ __extension__ typedef unsigned __int128 uint128;
 #define FD_PROTOTYPES_END
 #endif
 
+/* FD_INCBIN: include binary file as rodata */
+
+#define __FD_INCBIN(name, path, type, footer)  \
+  extern type const name [];                   \
+  extern uchar const name##_end;               \
+  ulong name##_sz( void ) {                    \
+    return ((ulong)&name##_end - (ulong)name); \
+  }                                            \
+  __asm__(                                     \
+  ".section \".rodata\", \"a\", @progbits\n"   \
+  #name ":\n"                                  \
+  ".incbin \"" path "\"\n"                     \
+  footer "\n"                                  \
+  #name "_end:\n"                              \
+  ".byte 0\n"                                  \
+  ".previous\n"                                \
+  )
+
+#define FD_INCBIN(name, path) __FD_INCBIN(name, path, uchar, "")
+
+#define FD_INCBIN_STR(name, path) __FD_INCBIN(name, path, char, ".byte 0")
+
 /* Optimizer tricks ***************************************************/
 
 /* FD_RESTRICT is a pointer modifier for to designate a pointer as

--- a/src/util/test_util_base.c
+++ b/src/util/test_util_base.c
@@ -44,7 +44,7 @@ FD_STATIC_ASSERT( sizeof(double)==8UL, devenv );
 
 /* Test twos complement representation (the -1 is to work around a
    language flaw with large negative integer constants). */
-   
+
 /* Unqualified char types should be avoided outside of cstr
    representations. */
 
@@ -107,6 +107,9 @@ FD_STATIC_ASSERT( !(((long )+1)/((long )+2)), devenv );
 FD_STATIC_ASSERT( !(((long )-1)/((long )+2)), devenv );
 FD_STATIC_ASSERT( !(((long )+1)/((long )-2)), devenv );
 FD_STATIC_ASSERT( !(((long )-1)/((long )-2)), devenv );
+
+/* Test binary includes by including this source file. (A quine!) */
+FD_INCBIN_STR( incbin_src, __FILE__ );
 
 int
 main( int     argc,
@@ -401,6 +404,11 @@ main( int     argc,
   }
 
 # endif
+
+  /* Test FD_INCBIN */
+
+  FD_TEST( !strncmp( incbin_src, "#include \"fd_util.h\"", 20 ) );
+  FD_TEST( strlen( incbin_src )+1UL == incbin_src_sz() );
 
   /* FIXME: ADD HASH QUALITY CHECKER HERE */
 


### PR DESCRIPTION
Adds two macros, FD_INCBIN and FD_INCBIN_STR, that allow including arbitrary files in .rodata of a C source.

This is mainly intended for unit tests.

Change-Id: I771cf4a1b7ee01a532dc3bcefda0c63876c0d474
