### PR TITLE
sanitize: add module

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,13 +19,11 @@ build:asan-gcc --platforms=//:linux_x86_64_gcc
 build:asan-gcc --features asan
 build:asan-gcc --strip never
 build:asan-gcc --action_env ASAN_OPTIONS=detect_leaks=0:color=always
-build:asan-gcc --copt -DADDRESS_SANITIZER
 build:asan-gcc --copt -fno-omit-frame-pointer
 
 build:asan-clang --platforms=//:linux_x86_64_llvm
 build:asan-clang --linkopt -fsanitize=address
 build:asan-clang --copt -fsanitize=address
-build:asan-clang --copt -DADDRESS_SANITIZER
 build:asan-clang --copt -fno-omit-frame-pointer
 build:asan-clang --action_env ASAN_OPTIONS=detect_leaks=0:color=always
 

--- a/NOTICE
+++ b/NOTICE
@@ -130,3 +130,13 @@ NIST-developed software is provided by NIST as a public service. You may use, co
 NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
 
 You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+
+=======================================================================
+
+//src/util/sanitizers is a modified version of LLVM project compiler-rt
+taken ca 2023-Jan.
+
+LLVM project mirror: https://github.com/llvm/llvm-project
+
+See https://llvm.org/LICENSE.txt for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/config/with-asan.mk
+++ b/config/with-asan.mk
@@ -1,0 +1,2 @@
+CPPFLAGS+=-fsanitize=address -fno-omit-frame-pointer
+LDFLAGS+=-fsanitize=address

--- a/src/util/BUILD
+++ b/src/util/BUILD
@@ -33,6 +33,7 @@ fd_cc_library(
         "//src/util/net",
         "//src/util/pod",
         "//src/util/rng",
+        "//src/util/sanitize",
         "//src/util/scratch",
         "//src/util/shmem",
         "//src/util/tile",

--- a/src/util/fd_util.h
+++ b/src/util/fd_util.h
@@ -7,7 +7,7 @@
 //#include "pod/fd_pod.h"       /* includes cstr/fd_cstr.h */
 //#include "env/fd_env.h"       /* includes cstr/fd_cstr.h */
 //#include "log/fd_log.h"       /* includes env/fd_env.h */
-//#include "shmem/fd_shmem.h"   /* includes log/fd_log.h */
+//#include "shmem/fd_shmem.h"   /* includes log/fd_log.h sanitize/fd_sanitize.h  */
 #include "math/fd_stat.h"       /* includes bits/fd_bits.h */
 #include "rng/fd_rng.h"         /* includes bits/fd_bits.h */
 #include "scratch/fd_scratch.h" /* includes log/fd_log.h */

--- a/src/util/sanitize/BUILD
+++ b/src/util/sanitize/BUILD
@@ -1,0 +1,14 @@
+load("//bazel:fd_build_system.bzl", "fd_cc_library")
+
+package(default_visibility = ["//src/util:__subpackages__"])
+
+fd_cc_library(
+    name = "sanitize",
+    hdrs = [
+        "fd_asan.h",
+        "fd_sanitize.h",
+    ],
+    deps = [
+        "//src/util:base_lib",
+    ],
+)

--- a/src/util/sanitize/Local.mk
+++ b/src/util/sanitize/Local.mk
@@ -1,0 +1,1 @@
+$(call add-hdrs,fd_asan.h fd_sanitize.h)

--- a/src/util/sanitize/fd_asan.h
+++ b/src/util/sanitize/fd_asan.h
@@ -1,0 +1,106 @@
+#ifndef HEADER_fd_src_util_sanitize_fd_asan_h
+#define HEADER_fd_src_util_sanitize_fd_asan_h
+
+/* AddressSanitizer (ASan) tracks allocated memory regions and
+   instruments all memory accesses to detect possible out-of-bounds
+   errors.
+
+   This API is used to mark memory regions at runtime where default ASan
+   instrumentation is missing. Firedancer objects are mainly backed by
+   shared memory segments via huge pages managed by a custom memory
+   allocator.
+
+   More info on ASan:
+     - https://clang.llvm.org/docs/AddressSanitizer.html
+     - https://github.com/google/sanitizers/wiki/AddressSanitizer
+
+   For a guide on how to setup manual ASan memory posioning, see
+   https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning */
+
+/* Copied from https://github.com/llvm/llvm-project/blob/main/compiler-rt/include/sanitizer/asan_interface.h
+
+   Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+   See https://llvm.org/LICENSE.txt for license information.
+   SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+   This file was originally part of AddressSanitizer (ASan). */
+
+#if defined(__has_feature)
+#define FD_HAS_ASAN __has_feature(address_sanitizer)
+#elif defined(__SANITIZE_ADDRESS__)
+#define FD_HAS_ASAN 1
+#else
+#define FD_HAS_ASAN 0
+#endif
+
+/* Macros provided for convenience.
+   Defined as no-ops if ASan is not enabled. */
+
+#if FD_HAS_ASAN
+
+/* FD_FN_NO_ASAN: function attribute to disable ASan instrumentation */
+#define FD_FN_NO_ASAN __attribute__((no_sanitize("address")))
+
+/* ASAN_POISON_MEMORY_REGION: Marks a memory region as unaddressable. */
+#define ASAN_POISON_MEMORY_REGION(addr, size) \
+  __asan_poison_memory_region((addr), (size))
+
+/* ASAN_UNPOISON_MEMORY_REGION: Marks a memory region as addressable. */
+#define ASAN_UNPOISON_MEMORY_REGION(addr, size) \
+  __asan_unpoison_memory_region((addr), (size))
+
+#else
+
+#define FD_FN_NO_ASAN
+
+#define ASAN_POISON_MEMORY_REGION(addr, size) \
+  ((void)(addr), (void)(size))
+#define ASAN_UNPOISON_MEMORY_REGION(addr, size) \
+  ((void)(addr), (void)(size))
+
+#endif
+
+FD_PROTOTYPES_BEGIN
+
+/* __asan_poison_memory_region:
+   Marks a memory region `[addr, addr+size)` as unaddressable.
+
+   This memory must be previously allocated by your program. Instrumented
+   code is forbidden from accessing addresses in this region until it is
+   unpoisoned. This function is not guaranteed to poison the entire region -
+   it could poison only a subregion of `[addr, addr+size)` due to ASan
+   alignment restrictions. */
+void
+__asan_poison_memory_region( void const volatile * addr,
+                             ulong                 size );
+
+/* __asan_unpoison_memory_region:
+   Marks a memory region as addressable.
+
+   This memory must be previously allocated by your program. Accessing
+   addresses in this region is allowed until this region is poisoned again.
+   This function could unpoison a super-region of `[addr, addr+size)` due
+   to ASan alignment restrictions. */
+void
+__asan_unpoison_memory_region( void const volatile * addr,
+                               ulong                 size );
+
+/* Checks if an address is poisoned.
+
+   Returns 1 if addr is poisoned (that is, 1-byte read/write
+   access to this address would result in an error report from ASan).
+   Otherwise returns 0. */
+int
+__asan_address_is_poisoned( void const volatile * addr );
+
+/* Checks if a region is poisoned.
+
+   If at least one byte in `[beg, beg+size)` is poisoned, returns the
+   address of the first such byte. Otherwise returns 0. */
+void *
+__asan_region_is_poisoned( void * beg,
+                           ulong  size );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_util_sanitize_fd_asan_h */

--- a/src/util/sanitize/fd_sanitize.h
+++ b/src/util/sanitize/fd_sanitize.h
@@ -1,0 +1,16 @@
+#ifndef HEADER_fd_src_util_sanitize_fd_sanitize_h
+#define HEADER_fd_src_util_sanitize_fd_sanitize_h
+
+/* APIs provided by compiler sanitizers.
+
+   Sanitizers are error detection tools built from a combination of
+   hardware facilities, hooks injected into compiled code,
+   special memory mappings, and library functions.
+
+   For example, the AddressSanitizer can be used to detect out-of-bounds
+   memory accesses that otherwise don't crash a process and various
+   other undefined behavior. */
+
+#include "fd_asan.h"
+
+#endif /* HEADER_fd_src_util_sanitize_fd_sanitize_h */


### PR DESCRIPTION
Imports `asan_interface.h` from LLVM compiler-rt.
Allows implementing proper ASan support for statically allocated
objects in shared memory.

Change-Id: I63779a3e59a1f99362110f94faa6edcf8baf2a30

Imported from https://git.firedancer.io/c/firedancer/+/409