### PR TITLE
util, tango: add ASan poisoning

### DIFF
--- a/src/tango/fd_tango_ctl.c
+++ b/src/tango/fd_tango_ctl.c
@@ -67,7 +67,7 @@ main( int     argc,
         "\tquery-dcache gaddr verbose\n\t"
         "\t- Queries the dcache at gaddr.  If verbose is 0, prints 0\n\t"
         "\t  to stdout (implicitly verifying gaddr is a dcache).\n\t"
-        "\t  Otherwise, prints a detailed query to stdout.\n\t" 
+        "\t  Otherwise, prints a detailed query to stdout.\n\t"
         "\n\t"
         "\tnew-fseq wksp seq0\n\t"
         "\t- Creates a flow control variable in wksp initialized to seq0.\n\t"

--- a/src/util/shmem/BUILD
+++ b/src/util/shmem/BUILD
@@ -16,6 +16,7 @@ fd_cc_library(
         "//src/util/cstr",
         "//src/util/env",
         "//src/util/log",
+        "//src/util/sanitize",
         "//src/util/tmpl",
         "@numa//:libnuma_headers",
     ],

--- a/src/util/shmem/fd_shmem.h
+++ b/src/util/shmem/fd_shmem.h
@@ -8,6 +8,7 @@
    module. */
 
 #include "../log/fd_log.h"
+#include "../sanitize/fd_sanitize.h"
 
 #if FD_HAS_HOSTED && FD_HAS_X86
 

--- a/src/util/shmem/fd_shmem_user.c
+++ b/src/util/shmem/fd_shmem_user.c
@@ -220,6 +220,10 @@ fd_shmem_join( char const *               name,
   join_info->ref_cnt = 1UL;
   join_info->join    = join;
 
+  /* Mark region as unallocated zone */
+
+  ASAN_POISON_MEMORY_REGION( shmem, sz );
+
   if( opt_info ) *opt_info = *join_info;
   FD_SHMEM_UNLOCK;
   return join;

--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -2,6 +2,7 @@
 #define HEADER_fd_src_util_wksp_fd_wksp_h
 
 #include "../pod/fd_pod.h"
+#include "../sanitize/fd_sanitize.h"
 #include "../shmem/fd_shmem.h"
 
 #if FD_HAS_HOSTED && FD_HAS_X86
@@ -49,7 +50,7 @@
      fd_wksp_free( wksp, gaddr );
 
    Any join can free any allocation regardless of who made it.
-   
+
    When the application is done using a wksp, it should leave it.  The
    workspace will continue to exist (it just is no longer safe to access
    in the caller's address space).  E.g.
@@ -345,7 +346,7 @@ fd_wksp_name( fd_wksp_t const * wksp );
    FD_SHMEM_NORMAL_PAGE_SZ, footprint should be equal to sz.  This is to
    facilitate applications that prefer to specify workspace in terms of
    total number of pages to use. */
-   
+
 FD_FN_CONST ulong
 fd_wksp_align( void );
 
@@ -431,7 +432,7 @@ fd_wksp_gaddr( fd_wksp_t * wksp,
    up to FD_WKSP_ALLOC_ALIGN_MIN).  Returns the fd_wksp global address
    of the join on success and "NULL" (0UL) on failure (logs details).  A
    zero sz returns "NULL" (silent).
-   
+
    Note that fd_wksp_alloc / fd_wksp_free are neither algorithmically
    optimal nor HPC implementations.  Instead, they are designed to be
    akin to mmap / sbrk used as "last resort" allocators under the hood
@@ -458,7 +459,7 @@ fd_wksp_gaddr( fd_wksp_t * wksp,
    normally.  As the allocator has no way to tell the difference between
    such allocations and allocations that are intended to outlive the
    application, it is the callers responsibility to clean up such.
-   
+
    Priority inversion is not expected to be an issue practical as the
    expected use case is once at box startup, some non-latency critical
    processes will do a handful of operations to setup workspaces for
@@ -487,7 +488,7 @@ fd_wksp_gaddr( fd_wksp_t * wksp,
    normal pages but requiring much larger alignments), things like
    explicitly specifying the wksp virtual address location in the
    fd_shmem_join calls might be necessary to satisfy this constraint.
-   
+
    Theoretically, this implementation could accommodate
    FD_WKSP_ALLOC_ALIGN_MIN as low as 2 (it would be very silly though as
    the default metadata allocations would be insanely large).  For C/C++


### PR DESCRIPTION
Adds manual ASan poisoning to detect OOB memory accesses within a Firedancer shm workspace.

Depends on https://github.com/firedancer-io/firedancer/pull/49