### PR TITLE
bmtree: add module and bmtree{20,32}_commit2

### DIFF
--- a/src/ballet/BUILD
+++ b/src/ballet/BUILD
@@ -19,6 +19,7 @@ fd_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":base_lib",
+        "//src/ballet/bmtree",
         "//src/ballet/ed25519",
         "//src/ballet/poh",
         "//src/ballet/sha256",

--- a/src/ballet/bmtree/BUILD
+++ b/src/ballet/bmtree/BUILD
@@ -1,0 +1,30 @@
+load("//bazel:fd_build_system.bzl", "fd_cc_library", "fd_cc_test")
+
+package(default_visibility = ["//src/ballet:__subpackages__"])
+
+fd_cc_library(
+    name = "bmtree",
+    srcs = [
+        "fd_bmtree.c",
+        "fd_bmtree.inc",
+    ],
+    hdrs = [
+        "fd_bmtree.h",
+    ],
+    deps = [
+        "//src/ballet:base_lib",
+        "//src/ballet/sha256",
+    ],
+)
+
+fd_cc_test(
+    size = "small",
+    srcs = ["test_bmtree20.c"],
+    deps = ["//src/ballet"],
+)
+
+fd_cc_test(
+    size = "small",
+    srcs = ["test_bmtree32.c"],
+    deps = ["//src/ballet"],
+)

--- a/src/ballet/bmtree/Local.mk
+++ b/src/ballet/bmtree/Local.mk
@@ -1,0 +1,5 @@
+$(call add-hdrs,fd_bmtree.h)
+$(call add-objs,fd_bmtree,fd_ballet)
+
+$(call make-unit-test,test_bmtree20,test_bmtree20,fd_ballet fd_util)
+$(call make-unit-test,test_bmtree32,test_bmtree32,fd_ballet fd_util)

--- a/src/ballet/bmtree/fd_bmtree.c
+++ b/src/ballet/bmtree/fd_bmtree.c
@@ -1,0 +1,9 @@
+#include "fd_bmtree.h"
+
+#define BMTREE_VARIANT 20
+#include "fd_bmtree.inc"
+#undef BMTREE_VARIANT
+
+#define BMTREE_VARIANT 32
+#include "fd_bmtree.inc"
+#undef BMTREE_VARIANT

--- a/src/ballet/bmtree/fd_bmtree.h
+++ b/src/ballet/bmtree/fd_bmtree.h
@@ -1,0 +1,294 @@
+#ifndef HEADER_fd_src_ballet_bmtree_fd_bmtree_h
+#define HEADER_fd_src_ballet_bmtree_fd_bmtree_h
+
+#include "../sha256/fd_sha256.h"
+
+/* fd_bmtree{20,32} is a binary Merkle tree used in the Solana protocol.
+   It uses the SHA-256 hash function.
+
+   Specification:
+   https://github.com/solana-foundation/specs/blob/main/core/merkle-tree.md
+
+   It is generally used as a vector commitment scheme
+   wherein the root node of the tree commits the vector of leaf nodes.
+
+   All methods provided by this Merkle tree derive from these three
+   basic operations.
+
+     1. Construct leaf node:
+
+        (leaf blob) -> (node)
+
+     2. Construct branch node with two children:
+
+        (node, node) -> (node)
+
+     3. Construct branch node with one child:
+
+        (node) -> (node)
+
+   Example derived methods.
+   (TODO not all of them are provided by this header file yet)
+
+     4. Construct full tree:
+
+        (vector of leaf blobs) -> (tree of nodes)
+
+     5. Create inclusion proof from tree data
+
+        (tree of nodes, node index) -> (inclusion proof)
+
+     6. Verify node inclusion proof
+
+        (node, root node, inclusion proof) -> (bool)
+
+   **Topology**
+
+   Tree topology has the following constraints:
+
+    - All leaf nodes are in the bottom level
+
+    - If a given layer `L`
+      with number of nodes `L_n` ...
+
+      ... has exactly one node,
+          this one node is the root node
+          and forms the uppermost layer.
+
+      ... has more than one node
+          ... and `L_n % 2 == 0`,
+              the layer above contains n/2 nodes
+
+          ... and `L_n % 2 == 1`,
+              the layer above contains (n+1)/2 nodes.
+
+   A simple algorithm to approach such a a tree is as follows:
+   (Note that the code uses here uses an optimized approach)
+
+    - Start with the smallest complete binary tree that has at least
+       `n` leaf nodes.
+    - Label the leaf nodes from left to right `L_0`, `L_1`, ... `L_(n-1)`
+    - Delete any un-labeled leaf nodes, and then recursively delete any
+      nodes with no children.
+    - For any nodes with a single remaining child, duplicate the link to the child.
+    - Each non-leaf node now has exactly two children, counting duplicates.
+
+   Example: Tree with 1 leaf node (root node = leaf node)
+
+    L0
+
+   Example: Tree with 4 leaf nodes
+
+           Iδ
+          /  \
+         /    \
+       Iα      Iβ
+      /  \    /  \
+     L0  L1  L2  L3
+
+   Example: Tree with 5 leaf nodes
+
+              Iζ
+             /  \
+            /    \
+           Iδ     Iε
+          /  \     \\
+         /    \     \\
+       Iα      Iβ    Iγ
+      /  \    /  \   ||
+     L0  L1  L2  L3  L4
+
+   **Construction**
+
+   The input data is a vector of arbitrary-sized binary blobs.
+   First, each blob is converted to a fixed-size leaf node by hashing
+   the blob in the `FD_BMTREE_PREFIX_LEAF` hash domain.
+
+   Then, the hash function is recursively applied over pairs of nodes
+   until there is only one node left (the root).
+
+   `fd_bmtree_32` uses the full SHA-256 digest for each tree node
+   and is thus considered cryptographically secure.
+
+   `fd_bmtree_20` uses SHA-256 digests truncated to 160 bits.
+
+   **Inclusion Proofs**
+
+   Inclusion proofs are used to verify whether a set of leaf nodes is
+   part of a commitment (identified by the root node).
+
+   At a high level, inclusion proofs present a sequence of hash
+   instructions that when executed result in the root commitment.
+
+   Inclusion proof size is O(log n) with regards to tree node count.
+
+   Various types of inclusion proofs exist:
+
+     - Single inclusion proofs (over one leaf node)
+     - Range inclusion proofs (over a contiguous range of leaf nodes)
+     - Sparse inclusion proofs (over an arbitrary subset of leaf nodes) */
+
+#define FD_BMTREE_PREFIX_LEAF   (uchar)0x00
+#define FD_BMTREE_PREFIX_BRANCH (uchar)0x01
+
+/* FD_BMTREE20_NODE_SZ: Size in bytes of a SHA-256-160 tree node */
+#define FD_BMTREE20_NODE_SZ (20UL)
+
+/* FD_BMTREE32_NODE_SZ: Size in bytes of a SHA-256 tree node */
+#define FD_BMTREE32_NODE_SZ (32UL)
+
+/* fd_bmtree20_node_t is the hash of a SHA-256-160 tree node (20 bytes) */
+typedef uchar fd_bmtree20_node_t[FD_BMTREE20_NODE_SZ];
+
+/* fd_bmtree20_node_t is the hash of a SHA-256 tree node (32 bytes) */
+typedef uchar fd_bmtree32_node_t[FD_BMTREE32_NODE_SZ];
+
+/* fd_bmtree*_commit_t stores intermediate state used to compute the
+   root of a binary Merkle tree built incrementally.
+
+   It requires O(log n) space with regard to the number of nodes.
+
+   During the accumulation phase, the data structure consumes all
+   tree leaf nodes sequentially while calculating and buffering
+   branch nodes of upper layers along the way.
+
+   In the finalization phase, the buffered branch node data is hashed
+   to derive the final root hash.
+
+   The separation of the accumulation and finalization phases is
+   required for trees with leaf counts that are not powers of two.
+   Those contain at least one branch node with only one child node. */
+
+struct __attribute__((aligned(32))) fd_bmtree20_commit {
+  ulong leaf_idx;
+  ulong leaf_cnt;
+  fd_bmtree20_node_t node_buf[];
+};
+typedef struct fd_bmtree20_commit fd_bmtree20_commit_t;
+
+struct __attribute__((aligned(32))) fd_bmtree32_commit {
+  ulong leaf_idx;
+  ulong leaf_cnt;
+  fd_bmtree32_node_t node_buf[];
+};
+typedef struct fd_bmtree32_commit fd_bmtree32_commit_t;
+
+/* Explanation of the above internal state in fd_bmtree*_commit:
+
+   - `leaf_idx` contains the number of leaf nodes that have been
+     accumulated so far. It is synonymous to the index of within
+     the vector of leaf nodes.
+
+     This is used to check how many branch nodes in the upper layers
+     can be derived with the currently known information.
+
+      The current depth of the layers above the leaf nodes is the
+      number of times the `leaf_idx` is divisible by 2.
+
+   - `leaf_cnt` is the expected number of leaf nodes (constant).
+
+   - `node_buf` is indexed by layer, with 0 being the leaf layer.
+
+     Given a layer `L` containing a vector of nodes known so far,
+     `node_buf[L]` contains the right-most node in layer `L`
+     (counting from the bottom) that is a left child of its parent.
+
+     More precisely:
+     The subset `L_left` contains all nodes with index `i` within that
+     layer where `i%2==0`. Then, `node_buf[L]` contains the node with
+     the largest index `i`within `L_left`.
+
+   **Example**
+
+   Step-by-step walkthrough of the internal state in SSA notation:
+
+    Initialize
+     - leaf_idx    <- 0
+
+    Insert leaf `l_0`
+     - node_buf[0] <- l_0
+     - leaf_idx    <- 1
+
+    Insert leaf `l_1`
+     - b_0         <- hash_branch( node_buf[0], l_1 )
+     - node_buf[1] <- b_0
+     - leaf_idx    <- 2
+
+    Insert leaf `l_2`
+     - node_buf[0] <- l_2
+     - leaf_idx    <- 3
+
+    Insert leaf `l_3`
+     - b_0         <- hash_branch( node_buf[0], l_3 )
+     - b_1         <- hash_branch( node_buf[1], b_0 )
+     - node_buf[2] <- b_1
+     - leaf_idx    <- 4  */
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_bmtree_depth returns the number of layers in a binary Merkle tree. */
+
+FD_FN_CONST static inline ulong
+fd_bmtree_depth( ulong leaf_cnt ) {
+  if( FD_UNLIKELY( leaf_cnt<=1UL ) ) return leaf_cnt; /* optimize for non-trivial tree */
+
+  return (ulong)fd_ulong_find_msb( leaf_cnt-1UL ) + 2UL;
+}
+
+/* fd_bmtree_commit_buf_cnt returns the number of nodes that
+   a buffer minimally has to fit to compute the root. */
+
+#define fd_bmtree_commit_buf_cnt fd_bmtree_depth
+
+/* fd_bmtree*_commit_footprint returns the size
+   occupied by a fd_bmtree*_commit_t. */
+
+FD_FN_CONST static inline ulong
+fd_bmtree20_commit_footprint( ulong leaf_cnt ) {
+  return sizeof(fd_bmtree20_commit_t) + (fd_bmtree_commit_buf_cnt( leaf_cnt )*FD_BMTREE20_NODE_SZ);
+}
+
+FD_FN_CONST static inline ulong
+fd_bmtree32_commit_footprint( ulong leaf_cnt ) {
+  return sizeof(fd_bmtree32_commit_t) + (fd_bmtree_commit_buf_cnt( leaf_cnt )*FD_BMTREE32_NODE_SZ);
+}
+
+/* fd_bmtree*_commit_init: Initializes a vector commitment calculation */
+
+void
+fd_bmtree20_commit_init( fd_bmtree20_commit_t * commit,
+                         ulong                  leaf_cnt );
+
+void
+fd_bmtree32_commit_init( fd_bmtree32_commit_t * commit,
+                         ulong                  leaf_cnt );
+
+/* fd_bmtree*_commit_append: Accumulates a range of leaf nodes. */
+
+/* TODO: Provide an interface that allows the caller to extract
+         any branch nodes created while appending */
+
+void
+fd_bmtree20_commit_append( fd_bmtree20_commit_t *     FD_RESTRICT commit,
+                           fd_bmtree20_node_t const * FD_RESTRICT leaf,
+                           ulong                                  leaf_cnt );
+
+void
+fd_bmtree32_commit_append( fd_bmtree32_commit_t *     FD_RESTRICT commit,
+                           fd_bmtree32_node_t const * FD_RESTRICT leaf,
+                           ulong                                  leaf_cnt );
+
+/* fd_bmtree*_commit_fini: Seals the commitment calculation.
+
+   Returns a pointer to the root node (within `commit->node_buf`).
+   Returns NULL if the tree has no nodes or not all nodes have been appended. */
+
+fd_bmtree20_node_t *
+fd_bmtree20_commit_fini( fd_bmtree20_commit_t * FD_RESTRICT commit );
+
+fd_bmtree32_node_t *
+fd_bmtree32_commit_fini( fd_bmtree32_commit_t * FD_RESTRICT commit );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_ballet_bmtree_fd_bmtree_h */

--- a/src/ballet/bmtree/fd_bmtree.inc
+++ b/src/ballet/bmtree/fd_bmtree.inc
@@ -1,0 +1,161 @@
+#include "fd_bmtree.h"
+
+#define BMTREE_(x)     FD_EXPAND_THEN_CONCAT4(fd_bmtree,BMTREE_VARIANT,_,x)
+#define BMTREEU_(x)    FD_EXPAND_THEN_CONCAT4(FD_BMTREE,BMTREE_VARIANT,_,x)
+#define BMTREE_NODE    BMTREE_(node_t)
+#define BMTREE_COMMIT  BMTREE_(commit_t)
+#define BMTREE_NODE_SZ BMTREEU_(NODE_SZ)
+
+FD_STATIC_ASSERT( sizeof(BMTREE_NODE)==BMTREE_NODE_SZ, BMTREE_NODE_SZ );
+
+void
+BMTREE_(commit_init)( BMTREE_COMMIT * state,
+                      ulong           leaf_cnt ) {
+  state->leaf_idx = 0UL;
+  state->leaf_cnt = leaf_cnt;
+}
+
+/* fd_bmtree*_merge: Derives a single branch node.
+
+   Computes `SHA-256([0x01] | A | B)` and writes the result into out.
+   Arbitrary pointer aliasing between out, A, B is permitted. */
+static void
+BMTREE_(merge)( BMTREE_NODE       * out,
+                BMTREE_NODE const * A,
+                BMTREE_NODE const * B ) {
+  fd_sha256_t sha;
+  fd_sha256_init( &sha );
+
+  /* Prepend static one-byte prefix identifying a branch node. */
+  uchar const prefix[1] = { FD_BMTREE_PREFIX_BRANCH };
+  fd_sha256_append( &sha, &prefix, 1UL );
+  /* Write tree nodes. */
+  fd_sha256_append( &sha, A, sizeof(BMTREE_NODE) );
+  fd_sha256_append( &sha, B, sizeof(BMTREE_NODE) );
+
+  /* Write 32-byte hash result into temporary buffer. */
+  uchar hash[FD_SHA256_HASH_SZ] __attribute__((aligned(FD_SHA256_ALIGN)));
+  fd_sha256_fini( &sha, hash );
+
+  /* Write tree node into out, discarding last few bytes. */
+  fd_memcpy( out, hash, sizeof(BMTREE_NODE) );
+}
+
+/* fd_bmtree*_commit_insert: Accumulates a single leaf node into the tree.
+
+   Updates `state->leaf_idx++`.
+   U.B. if `state->leaf_idx` >= `state->leaf_cnt`.
+
+   Maintains the invariant that the left node of the last node pair
+   for each layer is copied to `state->node_buf`.
+
+   This serves to allow the algorithm to derive a new parent branch node
+   for any pair of children, once the (previously missing) right node
+   becomes available. */
+static void
+BMTREE_(commit_insert)( BMTREE_COMMIT *     state,
+                        BMTREE_NODE const * leaf ) {
+  BMTREE_NODE tmp;
+  fd_memcpy( &tmp, leaf, sizeof(tmp) );
+
+  /* Walk the tree upwards from the bottom layer.
+
+     `tmp` contains a previously missing right node
+     which is used to derive a branch node,
+     together with the previously buffered value in `node_buf`.
+
+     Each iteration, merges that pair of nodes into a new branch node.
+     Terminates if the new branch node is the left node of a pair. */
+
+  ulong layer, cursor;
+  for(
+    /* `layer` starts at 0 (leaf nodes) and increments each iteration.
+       `cursor` is the number of known nodes in the current layer. */
+    layer=0UL, cursor=++state->leaf_idx;
+    /* Continue while the right node in the last pair is available. */
+              (cursor&1UL)==0UL;
+    /* Move up one layer. */
+    layer++,   cursor>>=1
+  ) {
+    BMTREE_(merge)( &tmp,
+                    (BMTREE_NODE const *)&state->node_buf[ layer ],
+                    (BMTREE_NODE const *)&tmp );
+  }
+
+  /* Note on correctness of the above loop:
+
+     The termination condition is that bit zero (LSB) of `cursor` is 1.
+     Because `cursor` shifts right every iteration, the loop terminates
+     as long as any bit in `cursor` is set to 1. (i.e. `cursor!=0UL`) */
+
+  /* Emplace left node (could be root node) into buffer. */
+  fd_memcpy( &state->node_buf[ layer ], &tmp, sizeof(tmp) );
+}
+
+void
+BMTREE_(commit_append)( BMTREE_COMMIT *     FD_RESTRICT state,
+                        BMTREE_NODE const * FD_RESTRICT leaf,
+                        ulong                           leaf_cnt ) {
+  /* Edge case: Caller supplied too many leaf nodes. */
+  if( FD_UNLIKELY( state->leaf_idx+leaf_cnt > state->leaf_cnt ) ) {
+    leaf_cnt = state->leaf_cnt - state->leaf_idx;
+  }
+
+  /* Insert nodes one-by-one.
+     Possible future optimization to hash pairs of two leaf nodes without copying. */
+  while( leaf_cnt-- ) {
+    BMTREE_(commit_insert)( state, leaf++ );
+  }
+}
+
+/* fd_bmtree*_commit_fini finalizes a commitment calculation by
+   deriving the root node. */
+
+BMTREE_NODE *
+BMTREE_(commit_fini)( BMTREE_COMMIT * FD_RESTRICT state ) {
+  /* Edge case: Tree is incomplete or empty (caller bug) */
+  if( FD_UNLIKELY( state->leaf_idx!=state->leaf_cnt ) ) return NULL;
+  if( FD_UNLIKELY( state->leaf_cnt==0 ) )               return NULL;
+
+  /* Pointer to root node. */
+  BMTREE_NODE * root = &state->node_buf[ fd_bmtree_commit_buf_cnt( state->leaf_cnt )-1UL ];
+
+  /* Further hashing required if leaf count is not a power of two. */
+  if( FD_LIKELY( fd_ulong_popcnt( state->leaf_cnt )>1 ) ) {
+    /* Start at the first layer where number of nodes is odd. */
+    ulong layer     = (ulong)fd_ulong_find_lsb( state->leaf_cnt );
+    ulong layer_cnt = state->leaf_cnt >> layer;
+
+    /* Allocate temporary node. */
+    BMTREE_NODE tmp;
+    memcpy( &tmp, &state->node_buf[layer], sizeof(BMTREE_NODE) );
+
+    /* Ascend until we reach the root node.
+       Calculate branch nodes along the way. */
+    while( layer_cnt>1UL ) {
+      if( (layer_cnt&1UL)==1UL ) {
+        /* Create branch nodes with one child node */
+        BMTREE_(merge)( &tmp,
+                        (BMTREE_NODE const *)&tmp,
+                        (BMTREE_NODE const *)&tmp );
+      } else {
+        /* Create branch nodes with two child nodes */
+        BMTREE_(merge)( &tmp,
+                        (BMTREE_NODE const *)&state->node_buf[ layer ],
+                        (BMTREE_NODE const *)&tmp );
+      }
+      layer++; layer_cnt=((layer_cnt+1UL)>>1);
+    }
+
+    /* Fix up root node. */
+    fd_memcpy( root, &tmp, sizeof(tmp) );
+  }
+
+  return root;
+}
+
+#undef BMTREE_
+#undef BMTREEU_
+#undef BMTREE_NODE
+#undef BMTREE_COMMIT
+#undef BMTREE_NODE_SZ

--- a/src/ballet/bmtree/test_bmtree20.c
+++ b/src/ballet/bmtree/test_bmtree20.c
@@ -1,0 +1,78 @@
+#include "../fd_ballet.h"
+
+/* Convience macros for pretty-printing hex strings of 20 chars. */
+#define FD_LOG_HEX20_FMT "%02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x"
+#define FD_LOG_HEX20_FMT_ARGS(b)                                      \
+  (uint)(((uchar const *)(b))[ 0]), (uint)(((uchar const *)(b))[ 1]), \
+  (uint)(((uchar const *)(b))[ 2]), (uint)(((uchar const *)(b))[ 3]), \
+  (uint)(((uchar const *)(b))[ 4]), (uint)(((uchar const *)(b))[ 5]), \
+  (uint)(((uchar const *)(b))[ 6]), (uint)(((uchar const *)(b))[ 7]), \
+  (uint)(((uchar const *)(b))[ 8]), (uint)(((uchar const *)(b))[ 9]), \
+  (uint)(((uchar const *)(b))[10]), (uint)(((uchar const *)(b))[11]), \
+  (uint)(((uchar const *)(b))[12]), (uint)(((uchar const *)(b))[13]), \
+  (uint)(((uchar const *)(b))[14]), (uint)(((uchar const *)(b))[15]), \
+  (uint)(((uchar const *)(b))[16]), (uint)(((uchar const *)(b))[17]), \
+  (uint)(((uchar const *)(b))[18]), (uint)(((uchar const *)(b))[19])
+
+/* Test tree construction */
+static void
+test_bmtree20_commit( ulong        leaf_cnt,
+                       char const * expected_root ) {
+  fd_bmtree20_commit_t * tree = fd_alloca( alignof(fd_bmtree20_commit_t), fd_bmtree20_commit_footprint( leaf_cnt ) );
+  fd_bmtree20_commit_init( tree, leaf_cnt );
+
+  for( ulong i=0; i<leaf_cnt; i++ ) {
+    fd_bmtree20_node_t leaf = { 0 };
+    *(ulong *) leaf = i;
+    fd_bmtree20_commit_append( tree, (fd_bmtree20_node_t const *)&leaf, 1UL );
+  }
+
+  fd_bmtree20_node_t * root = fd_bmtree20_commit_fini( tree );
+  FD_TEST( root!=NULL );
+
+  if( FD_UNLIKELY( memcmp( root, expected_root, sizeof(fd_bmtree20_node_t) ) ) )
+    FD_LOG_ERR(( "FAIL (leaf_cnt %lu)"
+                 "\n\tGot"
+                 "\n\t\t" FD_LOG_HEX20_FMT
+                 "\n\tExpected"
+                 "\n\t\t" FD_LOG_HEX20_FMT,
+                 leaf_cnt, FD_LOG_HEX20_FMT_ARGS( root ), FD_LOG_HEX20_FMT_ARGS( expected_root ) ));
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  /* Sanity check fd_bmtree_depth */
+  FD_TEST( fd_bmtree_depth( 0UL )==0UL );
+  FD_TEST( fd_bmtree_depth( 1UL )==1UL );
+  FD_TEST( fd_bmtree_depth( 2UL )==2UL );
+  FD_TEST( fd_bmtree_depth( 3UL )==3UL );
+  FD_TEST( fd_bmtree_depth( 4UL )==3UL );
+  FD_TEST( fd_bmtree_depth( 5UL )==4UL );
+  FD_TEST( fd_bmtree_depth( 6UL )==4UL );
+  FD_TEST( fd_bmtree_depth( 7UL )==4UL );
+  FD_TEST( fd_bmtree_depth( 8UL )==4UL );
+  FD_TEST( fd_bmtree_depth( 9UL )==5UL );
+
+  /* Iterate test fd_bmtree_depth against naive division algorithm */
+  for( ulong node_cnt=2UL; node_cnt<10000000UL; node_cnt++ ) {
+    ulong layers = 1;
+    for( ulong i=node_cnt; i>1; i=(i+1)/2 ) {
+      layers++;
+    }
+    FD_TEST( fd_bmtree_depth( node_cnt )==layers );
+  }
+
+  /* Construct trees of different sizes. */
+  test_bmtree20_commit(       1UL, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" );
+  test_bmtree20_commit(       2UL, "\x08\x11\x80\xe2\x59\x04\xa6\x23\xe5\x5c\x4a\x60\xc7\xfe\xd6\x7e\xe3\xd6\x7c\x4c" );
+  test_bmtree20_commit(       3UL, "\x22\x50\xc2\x9d\x86\x90\xfa\x5c\x03\x94\x75\x17\x6d\x99\x06\xde\x2c\xc6\x0e\x79" );
+  test_bmtree20_commit(      10UL, "\x42\x69\x92\xf5\x19\xee\x7e\x7b\xc2\xb6\x77\x6d\xc7\x82\x2d\x42\x68\x6a\xde\x25" );
+  test_bmtree20_commit( 1000000UL, "\x20\x61\x9a\x7a\xe4\x65\x27\x5a\x70\x9c\xa5\xc2\x8a\x21\x91\x6c\xdf\xf9\x0e\x26" ); /* TODO verify */
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}

--- a/src/ballet/bmtree/test_bmtree32.c
+++ b/src/ballet/bmtree/test_bmtree32.c
@@ -1,0 +1,68 @@
+#include "../fd_ballet.h"
+
+static void
+hash_leaf( fd_bmtree32_node_t * out,
+           char const * str ) {
+  fd_sha256_t sha;
+  fd_sha256_init( &sha );
+
+  /* Prepend static one-byte prefix identifying a branch node. */
+  uchar const prefix[1] = { FD_BMTREE_PREFIX_LEAF };
+  fd_sha256_append( &sha, &prefix, 1UL );
+  /* Write leaf data. */
+  fd_sha256_append( &sha, str, strlen( str ) );
+
+  fd_sha256_fini( &sha, out );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  // Source: https://github.com/solana-foundation/specs/blob/main/core/merkle-tree.md
+
+  ulong leaf_cnt = 11UL;
+  fd_bmtree32_node_t leaves[leaf_cnt];
+  hash_leaf( &leaves[ 0], "my"     );
+  hash_leaf( &leaves[ 1], "very"   );
+  hash_leaf( &leaves[ 2], "eager"  );
+  hash_leaf( &leaves[ 3], "mother" );
+  hash_leaf( &leaves[ 4], "just"   );
+  hash_leaf( &leaves[ 5], "served" );
+  hash_leaf( &leaves[ 6], "us"     );
+  hash_leaf( &leaves[ 7], "nine"   );
+  hash_leaf( &leaves[ 8], "pizzas" );
+  hash_leaf( &leaves[ 9], "make"   );
+  hash_leaf( &leaves[10], "prime"  );
+
+  fd_bmtree32_commit_t * commit = fd_alloca( 32, fd_bmtree32_commit_footprint( leaf_cnt ) );
+
+  fd_bmtree32_commit_init( commit, leaf_cnt );
+
+  fd_bmtree32_commit_append( commit,
+                              (fd_bmtree32_node_t const *)leaves,
+                              leaf_cnt );
+
+  uchar * root = (uchar *)fd_bmtree32_commit_fini( commit );
+
+# define _(v) ((uchar)0x##v)
+  uchar const expected[FD_SHA256_HASH_SZ] = {
+    _(b4),_(0c),_(84),_(75),_(46),_(fd),_(ce),_(ea),_(16),_(6f),_(92),_(7f),_(c4),_(6c),_(5c),_(a3),
+    _(3c),_(36),_(38),_(23),_(6a),_(36),_(27),_(5c),_(13),_(46),_(d3),_(df),_(fb),_(84),_(e1),_(bc)
+  };
+# undef _
+
+  if( FD_UNLIKELY( memcmp( root, expected, FD_SHA256_HASH_SZ ) ) )
+      FD_LOG_ERR(( "FAIL"
+                   "\n\tGot"
+                   "\n\t\t" FD_LOG_HEX16_FMT "  " FD_LOG_HEX16_FMT
+                   "\n\tExpected"
+                   "\n\t\t" FD_LOG_HEX16_FMT "  " FD_LOG_HEX16_FMT,
+                   FD_LOG_HEX16_FMT_ARGS(     root ), FD_LOG_HEX16_FMT_ARGS(     root+16 ),
+                   FD_LOG_HEX16_FMT_ARGS( expected ), FD_LOG_HEX16_FMT_ARGS( expected+16 ) ));
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}

--- a/src/ballet/fd_ballet.h
+++ b/src/ballet/fd_ballet.h
@@ -7,5 +7,6 @@
 #include "ed25519/fd_ed25519.h" /* Includes sha512/fd_sha512.h */
 #include "poh/fd_poh.h"         /* Includes sha256/fd_sha256.h */
 #include "shred/fd_shred.h"
+#include "bmtree/fd_bmtree.h"   /* Includes sha256/fd_sha256.h */
 
 #endif /* HEADER_fd_src_ballet_fd_ballet_h */


### PR DESCRIPTION
- Adds new bmtree module to ballet (Binary Merkle tree)
- Adds tree template for 20 and 32 byte node variants
- Adds simple root derive algorithm

Change-Id: Ide93a837e3328c489a3a4c625bf1db0d4955e933

Imported from https://git.firedancer.io/c/firedancer/+/304