### PR TITLE
make: gracefully handle missing headers in depfile

### DIFF
--- a/config/everything.mk
+++ b/config/everything.mk
@@ -174,7 +174,7 @@ $(OBJDIR)/obj/%.d : src/%.c
 	# Generating dependencies for C source $< to $@
 	#######################################################################
 	$(MKDIR) $(dir $@) && \
-$(CC) $(CPPFLAGS) $(CFLAGS) -M $< -o $@.tmp && \
+$(CC) $(CPPFLAGS) $(CFLAGS) -M -MP $< -o $@.tmp && \
 $(SED) 's,\($(notdir $*)\)\.o[ :]*,$(OBJDIR)/obj/$*.o $(OBJDIR)/obj/$*.S $(OBJDIR)/obj/$*.i $@ : ,g' < $@.tmp > $@ && \
 $(RM) $@.tmp
 
@@ -183,7 +183,7 @@ $(OBJDIR)/obj/%.d : src/%.cxx
 	# Generating dependencies for C++ source $< to $@
 	#######################################################################
 	$(MKDIR) $(dir $@) && \
-$(CXX) $(CPPFLAGS) $(CXXFLAGS) -M $< -o $@.tmp && \
+$(CXX) $(CPPFLAGS) $(CXXFLAGS) -M -MP $< -o $@.tmp && \
 $(SED) 's,\($(notdir $*)\)\.o[ :]*,$(OBJDIR)/obj/$*.o $(OBJDIR)/obj/$*.S $(OBJDIR)/obj/$*.i $@ : ,g' < $@.tmp > $@ && \
 $(RM) $@.tmp
 


### PR DESCRIPTION
When switching branches via Make, stale depfiles sometimes depend on headers that do not exist in the current tree.

This causes Make to error out early, requiring a full rebuild.

Updates the depfile rule to use compiler flag `-MP` to generate dummy targets that allow Make to continue if a header file is missing.

Change-Id: I68eb55feb3ca21c44d9b9b638787f48be72420c7

Imported from https://git.firedancer.io/c/firedancer/+/461