### PR TITLE
Minor polishing of fd_asan.h API

### DIFF
--- a/config/with-asan.mk
+++ b/config/with-asan.mk
@@ -1,2 +1,9 @@
+# Note: This probably needs to after machine specific targets otherwise
+# the -fomit-frame-pointer that occurs there will be silently override
+# the -fno-omit-frame-pointer here.
+#
+# FIXME: CONSIDER MANUALLY SETTING FD_HAS_ASAN IN BOTH THE CPPFLAGS AND
+# IN THE MAKE ENVIRONMENT?
+
 CPPFLAGS+=-fsanitize=address -fno-omit-frame-pointer
 LDFLAGS+=-fsanitize=address

--- a/src/util/fd_util.h
+++ b/src/util/fd_util.h
@@ -1,18 +1,20 @@
 #ifndef HEADER_fd_src_util_fd_util_h
 #define HEADER_fd_src_util_fd_util_h
 
-//#include "fd_util_base.h"     /* includes stdalign.h, string.h, limits.h, float.h */
-//#include "bits/fd_bits.h"     /* includes fd_util_base.h */
-//#include "cstr/fd_cstr.h"     /* includes bits/fd_bits.h */
-//#include "pod/fd_pod.h"       /* includes cstr/fd_cstr.h */
-//#include "env/fd_env.h"       /* includes cstr/fd_cstr.h */
-//#include "log/fd_log.h"       /* includes env/fd_env.h */
-//#include "shmem/fd_shmem.h"   /* includes log/fd_log.h sanitize/fd_sanitize.h  */
-#include "math/fd_stat.h"       /* includes bits/fd_bits.h */
-#include "rng/fd_rng.h"         /* includes bits/fd_bits.h */
-#include "scratch/fd_scratch.h" /* includes log/fd_log.h */
-#include "tile/fd_tile.h"       /* includes shmem/fd_shmem.h */
-#include "wksp/fd_wksp.h"       /* includes shmem/fd_shmem.h pod/fd_pod.h */
+//#include "fd_util_base.h"         /* includes stdalign.h, string.h, limits.h, float.h */
+//#include "bits/fd_bits.h"         /* includes fd_util_base.h */
+//#include "sanitize/fd_asan.h"     /* includes fd_util_base.h" */
+//#include "sanitize/fd_sanitize.h" /* includes sanitize/fd_asan.h */
+//#include "cstr/fd_cstr.h"         /* includes bits/fd_bits.h */
+//#include "pod/fd_pod.h"           /* includes cstr/fd_cstr.h */
+//#include "env/fd_env.h"           /* includes cstr/fd_cstr.h */
+//#include "log/fd_log.h"           /* includes env/fd_env.h */
+//#include "shmem/fd_shmem.h"       /* includes log/fd_log.h sanitize/fd_sanitize.h  */
+#include "math/fd_stat.h"           /* includes bits/fd_bits.h */
+#include "rng/fd_rng.h"             /* includes bits/fd_bits.h */
+#include "scratch/fd_scratch.h"     /* includes log/fd_log.h */
+#include "tile/fd_tile.h"           /* includes shmem/fd_shmem.h */
+#include "wksp/fd_wksp.h"           /* includes shmem/fd_shmem.h pod/fd_pod.h */
 
 /* Additional fd_util APIs that are not included by default */
 

--- a/src/util/sanitize/fd_asan.h
+++ b/src/util/sanitize/fd_asan.h
@@ -1,12 +1,14 @@
 #ifndef HEADER_fd_src_util_sanitize_fd_asan_h
 #define HEADER_fd_src_util_sanitize_fd_asan_h
 
+#include "../fd_util_base.h"
+
 /* AddressSanitizer (ASan) tracks allocated memory regions and
    instruments all memory accesses to detect possible out-of-bounds
    errors.
 
    This API is used to mark memory regions at runtime where default ASan
-   instrumentation is missing. Firedancer objects are mainly backed by
+   instrumentation is missing.  Firedancer objects are mainly backed by
    shared memory segments via huge pages managed by a custom memory
    allocator.
 
@@ -17,14 +19,15 @@
    For a guide on how to setup manual ASan memory posioning, see
    https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning */
 
-/* Copied from https://github.com/llvm/llvm-project/blob/main/compiler-rt/include/sanitizer/asan_interface.h
+/* Based on https://github.com/llvm/llvm-project/blob/main/compiler-rt/include/sanitizer/asan_interface.h
 
-   Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-   See https://llvm.org/LICENSE.txt for license information.
-   SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+   Part of the LLVM Project, under the Apache License v2.0 with LLVM
+   Exceptions.  See https://llvm.org/LICENSE.txt for license
+   information.  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
    This file was originally part of AddressSanitizer (ASan). */
 
+#ifndef FD_HAS_ASAN
 #if defined(__has_feature)
 #define FD_HAS_ASAN __has_feature(address_sanitizer)
 #elif defined(__SANITIZE_ADDRESS__)
@@ -32,74 +35,71 @@
 #else
 #define FD_HAS_ASAN 0
 #endif
+#endif
 
-/* Macros provided for convenience.
-   Defined as no-ops if ASan is not enabled. */
+/* FD_FN_NO_ASAN is a function attribute to disable ASan instrumentation
+   when FD_HAS_ASAN is set (and expands to nothing if not). */
 
 #if FD_HAS_ASAN
-
-/* FD_FN_NO_ASAN: function attribute to disable ASan instrumentation */
 #define FD_FN_NO_ASAN __attribute__((no_sanitize("address")))
-
-/* ASAN_POISON_MEMORY_REGION: Marks a memory region as unaddressable. */
-#define ASAN_POISON_MEMORY_REGION(addr, size) \
-  __asan_poison_memory_region((addr), (size))
-
-/* ASAN_UNPOISON_MEMORY_REGION: Marks a memory region as addressable. */
-#define ASAN_UNPOISON_MEMORY_REGION(addr, size) \
-  __asan_unpoison_memory_region((addr), (size))
-
 #else
-
 #define FD_FN_NO_ASAN
-
-#define ASAN_POISON_MEMORY_REGION(addr, size) \
-  ((void)(addr), (void)(size))
-#define ASAN_UNPOISON_MEMORY_REGION(addr, size) \
-  ((void)(addr), (void)(size))
-
 #endif
 
 FD_PROTOTYPES_BEGIN
 
-/* __asan_poison_memory_region:
-   Marks a memory region `[addr, addr+size)` as unaddressable.
+/* If FD_HAS_ASAN is set:
 
-   This memory must be previously allocated by your program. Instrumented
-   code is forbidden from accessing addresses in this region until it is
-   unpoisoned. This function is not guaranteed to poison the entire region -
-   it could poison only a subregion of `[addr, addr+size)` due to ASan
-   alignment restrictions. */
-void
-__asan_poison_memory_region( void const volatile * addr,
-                             ulong                 size );
+   fd_asan_poison marks a memory region `[addr,addr+sz)` as
+   unaddressable and returns addr.  This memory must be previously
+   allocated by your program.  Instrumented code is forbidden from
+   accessing addresses in this region until it is unpoisoned.  This
+   function is not guaranteed to poison the entire region; it might
+   poison only a sub-region of `[addr,addr+sz)` due to ASan alignment
+   restrictions.
 
-/* __asan_unpoison_memory_region:
-   Marks a memory region as addressable.
+   fd_asan_unpoison marks a memory region `[addr,addr+sz)` as
+   addressable and returns addr.  This memory must be previously
+   allocated by your program.  Accessing addresses in this region is
+   allowed until this region is poisoned again.  This function might
+   unpoison a super-region of `[addr,addr+sz)` due to ASan alignment
+   restrictions.
 
-   This memory must be previously allocated by your program. Accessing
-   addresses in this region is allowed until this region is poisoned again.
-   This function could unpoison a super-region of `[addr, addr+size)` due
-   to ASan alignment restrictions. */
-void
-__asan_unpoison_memory_region( void const volatile * addr,
-                               ulong                 size );
+   fd_asan_test tests if an address is poisoned.  Returns 1 if addr is
+   poisoned (that is, a 1-byte read/write access to this address would
+   result in an error report from ASan).  Otherwise returns 0.
 
-/* Checks if an address is poisoned.
+   fd_asan_query checks if a region is poisoned.  If at least one byte
+   in `[addr,addr+sz)` is poisoned, returns the address of the first
+   such byte.  Otherwise returns NULL.
 
-   Returns 1 if addr is poisoned (that is, 1-byte read/write
-   access to this address would result in an error report from ASan).
-   Otherwise returns 0. */
-int
-__asan_address_is_poisoned( void const volatile * addr );
+   If FD_HAS_ASAN is not set fd_asan_{poison,unpoison} just return addr,
+   fd_asan_test returns 0 and fd_asan_query returns NULL.
 
-/* Checks if a region is poisoned.
+   FIXME: CONST CORRECT VERSIONS? */
 
-   If at least one byte in `[beg, beg+size)` is poisoned, returns the
-   address of the first such byte. Otherwise returns 0. */
-void *
-__asan_region_is_poisoned( void * beg,
-                           ulong  size );
+#if FD_HAS_ASAN
+
+/* These are for internal use only */
+
+void   __asan_poison_memory_region  ( void const volatile * addr, ulong sz );
+void   __asan_unpoison_memory_region( void const volatile * addr, ulong sz );
+int    __asan_address_is_poisoned   ( void const volatile * addr           );
+void * __asan_region_is_poisoned    ( void *                addr, ulong sz );
+
+static inline void * fd_asan_poison  ( void * addr, ulong sz ) { __asan_poison_memory_region  ( addr, sz ); return addr; }
+static inline void * fd_asan_unpoison( void * addr, ulong sz ) { __asan_unpoison_memory_region( addr, sz ); return addr; }
+static inline int    fd_asan_test    ( void * addr           ) { return __asan_address_is_poisoned( addr );     }
+static inline void * fd_asan_query   ( void * addr, ulong sz ) { return __asan_region_is_poisoned ( addr, sz ); }
+
+#else
+
+static inline void * fd_asan_poison  ( void * addr, ulong sz ) { (void)sz;             return addr; }
+static inline void * fd_asan_unpoison( void * addr, ulong sz ) { (void)sz;             return addr; }
+static inline int    fd_asan_test    ( void * addr           ) { (void)addr;           return 0;    }
+static inline void * fd_asan_query   ( void * addr, ulong sz ) { (void)addr; (void)sz; return NULL; }
+
+#endif
 
 FD_PROTOTYPES_END
 

--- a/src/util/sanitize/fd_sanitize.h
+++ b/src/util/sanitize/fd_sanitize.h
@@ -4,8 +4,8 @@
 /* APIs provided by compiler sanitizers.
 
    Sanitizers are error detection tools built from a combination of
-   hardware facilities, hooks injected into compiled code,
-   special memory mappings, and library functions.
+   hardware facilities, hooks injected into compiled code, special
+   memory mappings, and library functions.
 
    For example, the AddressSanitizer can be used to detect out-of-bounds
    memory accesses that otherwise don't crash a process and various


### PR DESCRIPTION
This is mostly an exercise post-Gerrit workflows and do some of the tweaks that were pending in Gerrit that didn't make it over in the conversion:
- Eliminate implicit dependencies on fd_util_base.h.
- Allow FD_HAS_ASAN to be manually specified.
- Use static inlines instead of macros where possible.
- Tweak poison / unpoison APIs to be composable
- Minor related cleanups (commenting / formatting / naming)