### PR TITLE
bazel: add `compile_data` arg to cc rules

### DIFF
--- a/bazel/fd_build_system.bzl
+++ b/bazel/fd_build_system.bzl
@@ -5,10 +5,28 @@ Defines wrapper rules for C/C++.
 load("//bazel:copts.bzl", "fd_copts", "fd_linkopts")
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
 
+def __cc_blob_helper(name, suffix, files = []):
+    """
+    Forces the inclusion of arbitrary files into the inputs of dependent C/C++ targets.
+
+    Returns a list of labels that can be included in cc_library.deps.
+    """
+
+    helper_name = name + "_" + suffix
+    native.cc_library(name = helper_name, textual_hdrs = files)
+    return [helper_name]
+
+def __default_kwargs(kwargs, key, default):
+    if not key in kwargs:
+        kwargs[key] = default
+
+def __enhance_kwargs(kwargs, key, default, fn):
+    kwargs[key] = fn(kwargs.get(key, default))
+
 def fd_cc_binary(
         name,
-        copts = [],
-        linkopts = [],
+        compile_data = [],
+        textual_hdrs = [],
         **kwargs):
     """
     Wraps cc_binary.
@@ -16,22 +34,26 @@ def fd_cc_binary(
     Prepends project-wide copts / linkopts.
 
     Reference: https://bazel.build/reference/be/c-cpp#cc_binary
+
+    Args:
+      name: Name of fuzz target
+      textual_hdrs: See cc_library.textual_hdrs
+      compile_data: Arbitrary files to include during build
+      **kwargs: Passed through to cc_binary
     """
 
-    native.cc_binary(
-        name = name,
-        copts = fd_copts() + copts,
-        linkopts = fd_linkopts() + linkopts,
-        **kwargs
-    )
+    __enhance_kwargs(kwargs, "copts", [], lambda x: fd_copts() + x)
+    __enhance_kwargs(kwargs, "linkopts", [], lambda x: fd_linkopts() + x)
 
-def fd_cc_fuzz_test(
-        name = None,
-        srcs = [],
-        copts = [],
-        linkopts = [],
-        target_compatible_with = None,
-        **kwargs):
+    # Helper to include arbitrary files in build tree
+    if len(compile_data) > 0:
+        __enhance_kwargs(kwargs, "deps", [], lambda x: x + __cc_blob_helper(name, "compile_data", compile_data))
+    if len(textual_hdrs) > 0:
+        __enhance_kwargs(kwargs, "deps", [], lambda x: x + __cc_blob_helper(name, "textual_hdrs", textual_hdrs))
+
+    native.cc_binary(name = name, **kwargs)
+
+def fd_cc_fuzz_test(name = None, srcs = [], **kwargs):
     """
     Wraps cc_fuzz_test, which itself wraps cc_test.
 
@@ -40,34 +62,29 @@ def fd_cc_fuzz_test(
     Args:
       name: Name of fuzz target
       srcs: List of sources
-      copts: Additional copts flags (plus project_wide flags)
-      linkopts: Additional linkopts flags (plus project wide flags)
-      target_compatible_with: Target constraints, defaults to LLVM-only
       **kwargs: Passed through to cc_fuzz_test
     """
 
     # Derive name from first source file
     if name == None:
         name = srcs[0].rsplit(".", 1)[0]
-    if target_compatible_with == None:
-        target_compatible_with = select({
-            "//bazel/compiler:llvm": [],
-            "//conditions:default": ["@platforms//:incompatible"],
-        })
+    __enhance_kwargs(kwargs, "copts", [], lambda x: fd_copts() + x)
+    __enhance_kwargs(kwargs, "linkopts", [], lambda x: fd_linkopts() + x)
+    __default_kwargs(kwargs, "target_compatible_with", select({
+        "//bazel/compiler:llvm": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }))
+
     cc_fuzz_test(
         name = name,
         srcs = srcs,
-        copts = fd_copts() + copts,
-        linkopts = fd_linkopts() + linkopts,
-        target_compatible_with = target_compatible_with,
         **kwargs
     )
 
 def fd_cc_library(
         name,
-        copts = [],
-        linkopts = [],
         linkstatic = True,
+        compile_data = [],
         **kwargs):
     """
     Wraps cc_library.
@@ -75,12 +92,19 @@ def fd_cc_library(
     Prepends project-wide copts / linkopts.
 
     Reference: https://bazel.build/reference/be/c-cpp#cc_library
+
+    Args:
+      name: Name of library target
+      linkstatic: See cc_library.linkstatic, now defaults to True
+      compile_data: Arbitrary files to include during build
+      **kwargs: Passed through to cc_library
     """
 
+    __enhance_kwargs(kwargs, "copts", [], lambda x: fd_copts() + x)
+    __enhance_kwargs(kwargs, "linkopts", [], lambda x: fd_linkopts() + x)
+    __enhance_kwargs(kwargs, "textual_hdrs", [], lambda x: x + compile_data)
     native.cc_library(
         name = name,
-        copts = fd_copts() + copts,
-        linkopts = fd_linkopts() + linkopts,
         linkstatic = linkstatic,
         **kwargs
     )
@@ -88,9 +112,8 @@ def fd_cc_library(
 def fd_cc_test(
         name = None,
         srcs = [],
-        copts = [],
-        linkopts = [],
-        env = {},
+        compile_data = [],
+        textual_hdrs = [],
         **kwargs):
     """
     Wraps cc_test.
@@ -99,19 +122,34 @@ def fd_cc_test(
     Defaults target name to stem of first entry in srcs.
 
     Reference: https://bazel.build/reference/be/c-cpp#cc_test
+
+    Args:
+      name: Name of library target
+      srcs: C/C++ headers and source files
+      textual_hdrs: See cc_library.textual_hdrs
+      compile_data: Arbitrary files to include during build
+      **kwargs: Passed through to cc_library
     """
 
     # Derive name from first source file
     if name == None:
         name = srcs[0].rsplit(".", 1)[0]
+
+    __enhance_kwargs(kwargs, "copts", [], lambda x: fd_copts() + x)
+    __enhance_kwargs(kwargs, "linkopts", [], lambda x: fd_linkopts() + x)
+    __enhance_kwargs(kwargs, "env", {}, lambda x: dict({
+        "FD_LOG_PATH": "-",
+        "FD_LOG_LEVEL_STDERR": "7",
+    }, **x))
+
+    # Helper to include arbitrary files in build tree
+    if len(compile_data) > 0:
+        __enhance_kwargs(kwargs, "deps", [], lambda x: x + __cc_blob_helper(name, "compile_data", compile_data))
+    if len(textual_hdrs) > 0:
+        __enhance_kwargs(kwargs, "deps", [], lambda x: x + __cc_blob_helper(name, "textual_hdrs", textual_hdrs))
+
     native.cc_test(
         name = name,
         srcs = srcs,
-        copts = fd_copts() + copts,
-        linkopts = fd_linkopts() + linkopts,
-        env = dict({
-            "FD_LOG_PATH": "-",
-            "FD_LOG_LEVEL_STDERR": "7",
-        }, **env),
         **kwargs
     )

--- a/src/ballet/sha512/BUILD
+++ b/src/ballet/sha512/BUILD
@@ -17,14 +17,6 @@ fd_cc_library(
     ],
 )
 
-# Required because textual_hdrs is not available in cc_test.
-fd_cc_library(
-    name = "test_sha512_static",
-    textual_hdrs = [
-        "fd_sha512_test_vector.c",
-    ],
-)
-
 cc_generate_cavp_test_vector(
     name = "cavp/sha512_short.inc",
     algorithm = "sha512",
@@ -41,11 +33,11 @@ cc_generate_cavp_test_vector(
 
 fd_cc_test(
     srcs = ["test_sha512.c"],
+    compile_data = ["fd_sha512_test_vector.c"],
     local_defines = ["HAS_CAVP_TEST_VECTORS"],
     deps = [
         ":cavp/sha512_long.inc",
         ":cavp/sha512_short.inc",
-        ":test_sha512_static",
         "//src/ballet",
     ],
 )


### PR DESCRIPTION
Adds new `compile_data` arg to `fd_cc_library`, `fd_cc_test`, and
`fd_cc_binary` that allows including arbitrary files in the build tree.

This is implemented via `cc_library.textual_hdrs`.

This is required because `srcs` refuses to accept non C/C++-related
source files. Such are mostly used with the `.incbin` trick to include
binary data in test builds (to test parsers etc.)
