### PR TITLE
ballet: add base58 utils

### DIFF
--- a/src/ballet/base58/BUILD
+++ b/src/ballet/base58/BUILD
@@ -1,0 +1,32 @@
+load("//bazel:fd_build_system.bzl", "fd_cc_library", "fd_cc_test")
+
+package(default_visibility = ["//src/ballet:__subpackages__"])
+
+fd_cc_library(
+    name = "base58",
+    srcs = [
+        "fd_base58.c",
+        "fd_base58_avx.h",
+    ],
+    hdrs = ["fd_base58.h"],
+    textual_hdrs = [
+        "fd_base58_tmpl.c",
+    ],
+    deps = [
+        "//src/ballet:base_lib",
+        "//src/util/simd",
+    ],
+)
+
+fd_cc_test(
+    size = "medium",
+    srcs = ["test_base58.c"],
+    args = [
+        "--cnt",
+        "10000",
+    ],
+    deps = [
+        "//src/ballet/base58",
+        "//src/util",
+    ],
+)

--- a/src/ballet/base58/Local.mk
+++ b/src/ballet/base58/Local.mk
@@ -1,0 +1,3 @@
+$(call add-hdrs,fd_base58.h)
+$(call add-objs,fd_base58,fd_ballet)
+$(call make-unit-test,test_base58,test_base58,fd_ballet fd_util)

--- a/src/ballet/base58/fd_base58.c
+++ b/src/ballet/base58/fd_base58.c
@@ -1,0 +1,125 @@
+#include "fd_base58.h"
+
+#if FD_HAS_AVX
+#include "fd_base58_avx.h"
+#endif
+
+/* base58_chars maps [0, 58) to the base58 character.  In the AVX case,
+   this lookup table is contained implicitly in raw_to_base58 */
+
+#if !FD_HAS_AVX
+static char const base58_chars[] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+#endif
+
+#define BASE58_INVALID_CHAR           ((uchar)255)
+#define BASE58_INVERSE_TABLE_OFFSET   ((uchar)'1')
+#define BASE58_INVERSE_TABLE_SENTINEL ((uchar)(1UL + (uchar)('z')-BASE58_INVERSE_TABLE_OFFSET))
+
+/* base58_inverse maps (character value - '1') to [0, 58).  Invalid
+   base58 characters map to BASE58_INVALID_CHAR.  The character after
+   what 'z' would map to also maps to BASE58_INVALID_CHAR to facilitate
+   branchless lookups.  Don't make it static so that it can be used from
+   tests. */
+
+#define BAD BASE58_INVALID_CHAR
+
+uchar const base58_inverse[] = {
+  (uchar)  0, (uchar)  1, (uchar)  2, (uchar)  3, (uchar)  4, (uchar)  5, (uchar)  6, (uchar)  7, (uchar)  8, (uchar)BAD,
+  (uchar)BAD, (uchar)BAD, (uchar)BAD, (uchar)BAD, (uchar)BAD, (uchar)BAD, (uchar)  9, (uchar) 10, (uchar) 11, (uchar) 12,
+  (uchar) 13, (uchar) 14, (uchar) 15, (uchar) 16, (uchar)BAD, (uchar) 17, (uchar) 18, (uchar) 19, (uchar) 20, (uchar) 21,
+  (uchar)BAD, (uchar) 22, (uchar) 23, (uchar) 24, (uchar) 25, (uchar )26, (uchar) 27, (uchar) 28, (uchar) 29, (uchar) 30,
+  (uchar) 31, (uchar) 32, (uchar)BAD, (uchar)BAD, (uchar)BAD, (uchar)BAD, (uchar)BAD, (uchar)BAD, (uchar) 33, (uchar) 34,
+  (uchar) 35, (uchar) 36, (uchar) 37, (uchar) 38, (uchar) 39, (uchar) 40, (uchar) 41, (uchar) 42, (uchar) 43, (uchar)BAD,
+  (uchar) 44, (uchar) 45, (uchar) 46, (uchar) 47, (uchar) 48, (uchar) 49, (uchar) 50, (uchar) 51, (uchar) 52, (uchar) 53,
+  (uchar) 54, (uchar) 55, (uchar) 56, (uchar) 57, (uchar)BAD
+};
+
+#undef BAD
+
+#define N                32
+#define INTERMEDIATE_SZ (9UL) /* Computed by ceil(log_(58^5) (256^32-1)) */
+#define BINARY_SZ       ((ulong)N/4UL)
+
+/* Contains the unique values less than 58^5 such that:
+     2^(32*(7-j)) = sum_k table[j][k]*58^(5*(7-k))
+
+   The second dimension of this table is actually ceil(log_(58^5)
+   (2^(32*(BINARY_SZ-1))), but that's almost always INTERMEDIATE_SZ-1 */
+
+static uint const enc_table_32[BINARY_SZ][INTERMEDIATE_SZ-1UL] = {
+  {   513735U,  77223048U, 437087610U, 300156666U, 605448490U, 214625350U, 141436834U, 379377856U},
+  {        0U,     78508U, 646269101U, 118408823U,  91512303U, 209184527U, 413102373U, 153715680U},
+  {        0U,         0U,     11997U, 486083817U,   3737691U, 294005210U, 247894721U, 289024608U},
+  {        0U,         0U,         0U,      1833U, 324463681U, 385795061U, 551597588U,  21339008U},
+  {        0U,         0U,         0U,         0U,       280U, 127692781U, 389432875U, 357132832U},
+  {        0U,         0U,         0U,         0U,         0U,        42U, 537767569U, 410450016U},
+  {        0U,         0U,         0U,         0U,         0U,         0U,         6U, 356826688U},
+  {        0U,         0U,         0U,         0U,         0U,         0U,         0U,         1U}
+};
+
+/* Contains the unique values less than 2^32 such that:
+     58^(5*(8-j)) = sum_k table[j][k]*2^(32*(7-k)) */
+
+static uint const dec_table_32[INTERMEDIATE_SZ][BINARY_SZ] = {
+  {      1277U, 2650397687U, 3801011509U, 2074386530U, 3248244966U,  687255411U, 2959155456U,          0U},
+  {         0U,       8360U, 1184754854U, 3047609191U, 3418394749U,  132556120U, 1199103528U,          0U},
+  {         0U,          0U,      54706U, 2996985344U, 1834629191U, 3964963911U,  485140318U, 1073741824U},
+  {         0U,          0U,          0U,     357981U, 1476998812U, 3337178590U, 1483338760U, 4194304000U},
+  {         0U,          0U,          0U,          0U,    2342503U, 3052466824U, 2595180627U,   17825792U},
+  {         0U,          0U,          0U,          0U,          0U,   15328518U, 1933902296U, 4063920128U},
+  {         0U,          0U,          0U,          0U,          0U,          0U,  100304420U, 3355157504U},
+  {         0U,          0U,          0U,          0U,          0U,          0U,          0U,  656356768U},
+  {         0U,          0U,          0U,          0U,          0U,          0U,          0U,          1U}
+};
+
+#include "fd_base58_tmpl.c"
+
+#define N                64
+#define INTERMEDIATE_SZ (18UL) /* Computed by ceil(log_(58^5) (256^64-1)) */
+#define BINARY_SZ       ((ulong)N/4UL)
+
+/* Contains the unique values less than 58^5 such that
+   2^(32*(15-j)) = sum_k table[j][k]*58^(5*(16-k)) */
+
+static uint const enc_table_64[BINARY_SZ][INTERMEDIATE_SZ-1UL] = {
+  {     2631U, 149457141U, 577092685U, 632289089U,  81912456U, 221591423U, 502967496U, 403284731U, 377738089U, 492128779U,    746799U, 366351977U, 190199623U,  38066284U, 526403762U, 650603058U, 454901440U},
+  {        0U,       402U,  68350375U,  30641941U, 266024478U, 208884256U, 571208415U, 337765723U, 215140626U, 129419325U, 480359048U, 398051646U, 635841659U, 214020719U, 136986618U, 626219915U,  49699360U},
+  {        0U,         0U,        61U, 295059608U, 141201404U, 517024870U, 239296485U, 527697587U, 212906911U, 453637228U, 467589845U, 144614682U,  45134568U, 184514320U, 644355351U, 104784612U, 308625792U},
+  {        0U,         0U,         0U,         9U, 256449755U, 500124311U, 479690581U, 372802935U, 413254725U, 487877412U, 520263169U, 176791855U,  78190744U, 291820402U,  74998585U, 496097732U,  59100544U},
+  {        0U,         0U,         0U,         0U,         1U, 285573662U, 455976778U, 379818553U, 100001224U, 448949512U, 109507367U, 117185012U, 347328982U, 522665809U,  36908802U, 577276849U,  64504928U},
+  {        0U,         0U,         0U,         0U,         0U,         0U, 143945778U, 651677945U, 281429047U, 535878743U, 264290972U, 526964023U, 199595821U, 597442702U, 499113091U, 424550935U, 458949280U},
+  {        0U,         0U,         0U,         0U,         0U,         0U,         0U,  21997789U, 294590275U, 148640294U, 595017589U, 210481832U, 404203788U, 574729546U, 160126051U, 430102516U,  44963712U},
+  {        0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,   3361701U, 325788598U,  30977630U, 513969330U, 194569730U, 164019635U, 136596846U, 626087230U, 503769920U},
+  {        0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,    513735U,  77223048U, 437087610U, 300156666U, 605448490U, 214625350U, 141436834U, 379377856U},
+  {        0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,     78508U, 646269101U, 118408823U,  91512303U, 209184527U, 413102373U, 153715680U},
+  {        0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,     11997U, 486083817U,   3737691U, 294005210U, 247894721U, 289024608U},
+  {        0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,      1833U, 324463681U, 385795061U, 551597588U,  21339008U},
+  {        0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,       280U, 127692781U, 389432875U, 357132832U},
+  {        0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,        42U, 537767569U, 410450016U},
+  {        0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         6U, 356826688U},
+  {        0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         0U,         1U}
+};
+
+static uint const dec_table_64[INTERMEDIATE_SZ][BINARY_SZ] = {
+  {    249448U, 3719864065U,  173911550U, 4021557284U, 3115810883U, 2498525019U, 1035889824U,  627529458U, 3840888383U, 3728167192U, 2901437456U, 3863405776U, 1540739182U, 1570766848U,          0U,          0U},
+  {         0U,    1632305U, 1882780341U, 4128706713U, 1023671068U, 2618421812U, 2005415586U, 1062993857U, 3577221846U, 3960476767U, 1695615427U, 2597060712U,  669472826U,  104923136U,          0U,          0U},
+  {         0U,          0U,   10681231U, 1422956801U, 2406345166U, 4058671871U, 2143913881U, 4169135587U, 2414104418U, 2549553452U,  997594232U,  713340517U, 2290070198U, 1103833088U,          0U,          0U},
+  {         0U,          0U,          0U,   69894212U, 1038812943U, 1785020643U, 1285619000U, 2301468615U, 3492037905U,  314610629U, 2761740102U, 3410618104U, 1699516363U,  910779968U,          0U,          0U},
+  {         0U,          0U,          0U,          0U,  457363084U,  927569770U, 3976106370U, 1389513021U, 2107865525U, 3716679421U, 1828091393U, 2088408376U,  439156799U, 2579227194U,          0U,          0U},
+  {         0U,          0U,          0U,          0U,          0U, 2992822783U,  383623235U, 3862831115U,  112778334U,  339767049U, 1447250220U,  486575164U, 3495303162U, 2209946163U,  268435456U,          0U},
+  {         0U,          0U,          0U,          0U,          0U,          4U, 2404108010U, 2962826229U, 3998086794U, 1893006839U, 2266258239U, 1429430446U,  307953032U, 2361423716U,  176160768U,          0U},
+  {         0U,          0U,          0U,          0U,          0U,          0U,         29U, 3596590989U, 3044036677U, 1332209423U, 1014420882U,  868688145U, 4264082837U, 3688771808U, 2485387264U,          0U},
+  {         0U,          0U,          0U,          0U,          0U,          0U,          0U,        195U, 1054003707U, 3711696540U,  582574436U, 3549229270U, 1088536814U, 2338440092U, 1468637184U,          0U},
+  {         0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,       1277U, 2650397687U, 3801011509U, 2074386530U, 3248244966U,  687255411U, 2959155456U,          0U},
+  {         0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,       8360U, 1184754854U, 3047609191U, 3418394749U,  132556120U, 1199103528U,          0U},
+  {         0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,      54706U, 2996985344U, 1834629191U, 3964963911U,  485140318U, 1073741824U},
+  {         0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,     357981U, 1476998812U, 3337178590U, 1483338760U, 4194304000U},
+  {         0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,    2342503U, 3052466824U, 2595180627U,   17825792U},
+  {         0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,   15328518U, 1933902296U, 4063920128U},
+  {         0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,  100304420U, 3355157504U},
+  {         0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,  656356768U},
+  {         0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          0U,          1U}
+};
+
+#include "fd_base58_tmpl.c"
+

--- a/src/ballet/base58/fd_base58.h
+++ b/src/ballet/base58/fd_base58.h
@@ -1,0 +1,62 @@
+#ifndef HEADER_fd_src_ballet_base58_fd_base58_h
+#define HEADER_fd_src_ballet_base58_fd_base58_h
+
+/* fd_base58.h provides methods for converting between binary and
+   base58. */
+
+#include "../fd_ballet_base.h"
+
+/* FD_BASE58_ENCODED_{32,64}_{LEN,SZ} give the maximum string length
+   (LEN) and size (SZ, which includes the '\0') of the base58 cstrs that
+   result from converting 32 or 64 bytes to base58. */
+
+#define FD_BASE58_ENCODED_32_LEN (44UL)                         /* Computed as ceil(log_58(256^32 - 1)) */
+#define FD_BASE58_ENCODED_64_LEN (88UL)                         /* Computed as ceil(log_58(256^64 - 1)) */
+#define FD_BASE58_ENCODED_32_SZ  (FD_BASE58_ENCODED_32_LEN+1UL) /* Including the nul terminator */
+#define FD_BASE58_ENCODED_64_SZ  (FD_BASE58_ENCODED_64_LEN+1UL) /* Including the nul terminator */
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_base58_encode_{32, 64}: Interprets the supplied 32 or 64 bytes
+   (respectively) as a large big-endian integer, and converts it to a
+   nul-terminated base58 string of:
+
+     32 to 44 characters, inclusive (not counting nul) for 32 B
+     64 to 88 characters, inclusive (not counting nul) for 64 B
+
+   Stores the output in the buffer pointed to by out.  If opt_len is
+   non-NULL, *opt_len == strlen( out ) on return.  Returns out.  out is
+   guaranteed to be nul teriminated on return.
+
+   Out must have enough space for FD_BASE58_ENCODED_{32,64}_SZ
+   characters, including the nul terminator.
+
+   The 32 byte conversion is suitable for printing Solana account
+   addresses, and the 64 byte conversion is suitable for printing Solana
+   transaction signatures.  This is high performance (~100ns for 32B and
+   ~200ns for 64B without AVX, and roughly twice as fast with AVX), but
+   base58 is an inherently slow format and should not be used in any
+   performance critical places except where absolutely necessary. */
+
+char * fd_base58_encode_32( uchar const * bytes, ulong * opt_len, char * out );
+char * fd_base58_encode_64( uchar const * bytes, ulong * opt_len, char * out );
+
+/* fd_base58_decode_{32, 64}: Converts the base58 encoded number stored
+   in the cstr `encoded` to a 32 or 64 byte number, which is written to
+   out in big endian.  out must have room for 32 and 64 bytes respective
+   on entry.  Returns out on success and NULL if the input string is
+   invalid in some way: illegal base58 character or decodes to something
+   other than 32 or 64 bytes (respectively).  The contents of out are
+   undefined on failure (i.e. out may be clobbered).
+
+   A similar note to the above applies: these are high performance
+   (~120ns for 32 byte and ~300ns for 64 byte), but base58 is an
+   inherently slow format and should not be used in any performance
+   critical places except where absolutely necessary. */
+
+uchar * fd_base58_decode_32( char const * encoded, uchar * out );
+uchar * fd_base58_decode_64( char const * encoded, uchar * out );
+
+FD_PROTOTYPES_BEGIN
+
+#endif /* HEADER_fd_src_ballet_base58_fd_base58_h */

--- a/src/ballet/base58/fd_base58_avx.h
+++ b/src/ballet/base58/fd_base58_avx.h
@@ -1,0 +1,276 @@
+#include "../../util/simd/fd_avx.h"
+#include <immintrin.h>
+
+/* This is not a proper header and so should not be included from
+   anywhere besides fd_base58.c and test_base58_avx.c.  As such, it has
+   no include guard. */
+
+#define wuc_t __m256i
+static inline wuc_t wuc_ld(  uchar const * p   ) { return _mm256_load_si256(  (__m256i const *)p ); }
+static inline wuc_t wuc_ldu( uchar const * p   ) { return _mm256_loadu_si256( (__m256i const *)p ); }
+static inline void wuc_st(  uchar * p, wuc_t i ) { _mm256_store_si256(  (__m256i *)p, i ); }
+static inline void wuc_stu( uchar * p, wuc_t i ) { _mm256_storeu_si256( (__m256i *)p, i ); }
+
+/* Converts a vector with 4 terms in intermediate form ( digits in
+   [0,58^5) ) into 20 digits of raw base58 (<58) stored in two groups of
+   10 in the lower 10 bytes of each 128-bit half of the vector. */
+
+static inline wuc_t
+intermediate_to_raw( wl_t intermediate ) {
+
+  /* The computation we need to do here mathematically is
+     y=(floor(x/58^k) % 58) for various values of k.  It seems that the
+     best way to compute it (at least what the compiler generates in the
+     scalar case) is by computing z = floor(x/58^k). y = z -
+     58*floor(z/58).  Simplifying, gives, y = floor(x/58^k) -
+     58*floor(x/58^(k+1)) (Note, to see that the floors simplify like
+     that, represent x in its base58 expansion and then consider that
+     dividing by 58^k is just shifting right by k places.) This means we
+     can reuse a lot of values!
+
+     We can do the divisions with "magic multiplication" (i.e. multiply
+     and shift).  There's a tradeoff between ILP and register pressure
+     to make here: we can load a constant for each value of k and just
+     compute the division directly, or we could use one constant for
+     division by 58 and apply it repeatedly.  I don't know if this is
+     optimal, but I use two constants, one for /58 and the other for
+     /58^2.  We need to take advantage of the fact the input is
+     <58^5<2^32 to produce constants that fit in uints so that we can
+     use mul_epu32. */
+
+  wl_t cA  = wl_bcast( (long)2369637129U ); /* =2^37/58 */
+  wl_t cB  = wl_bcast( (long)1307386003U ); /* =2^42/58^2 */
+  wl_t _58 = wl_bcast( (long)58UL );
+
+  /* Divide each ulong in r by {58, 58^2=3364}, taking the floor of the
+     division.  I used gcc to convert the division to magic
+     multiplication. */
+
+# define DIV58(r)    wl_shru( _mm256_mul_epu32( r,               cA ), 37)
+# define DIV3364(r)  wl_shru( _mm256_mul_epu32( wl_shru( r, 2 ), cB ), 40)
+
+  /* div(k) stores floor(x/58^k). rem(k) stores div(k) % 58 */
+  wl_t div0 = intermediate;
+  wl_t div1 = DIV58(div0);
+  wl_t rem0 = wl_sub( div0, _mm256_mul_epu32( div1, _58 ) );
+
+  wl_t div2 = DIV3364(div0);
+  wl_t rem1 = wl_sub( div1, _mm256_mul_epu32( div2, _58 ) );
+
+  wl_t div3 = DIV3364(div1);
+  wl_t rem2 = wl_sub( div2, _mm256_mul_epu32( div3, _58 ) );
+
+  wl_t div4 = DIV3364(div2);
+  wl_t rem3 = wl_sub( div3, _mm256_mul_epu32( div4, _58 ) );
+
+  wl_t rem4 = div4; /* We know the values are less than 58 at this point */
+
+# undef DIV58
+# undef DIV3364
+
+  /* Okay, we have all 20 terms we need at this point, but they're
+     spread out over 5 registers. Each value is stored as an 8B long,
+     even though it's less than 58, so 7 of those bytes are 0.  That
+     means we're only taking up 4 bytes in each register.  We need to
+     get them to a more compact form, but the correct order (in terms of
+     place value and recalling where the input vector comes from) is:
+     (letters in the right column correspond to diagram below)
+
+        the first value in rem4  (a)
+        the first value in rem3  (b)
+        ...
+        the first value in rem0  (e)
+        the second value in rem4 (f)
+        ...
+        the fourth value in rem0 (t)
+
+     The fact that moves that cross the 128 bit boundary are tricky in
+     AVX makes this difficult, forcing an inconvenient output format.
+
+     First, we'll use _mm256_shuffle_epi8 to move the second value in
+     each half to byte 5:
+
+       [ a 0 0 0 0 0 0 0  f 0 0 0 0 0 0 0 | k 0 0 0 0 0 0 0  p 0 0 0 0 0 0 0 ] ->
+       [ a 0 0 0 0 f 0 0  0 0 0 0 0 0 0 0 | k 0 0 0 0 p 0 0  0 0 0 0 0 0 0 0 ]
+
+     Then for the vectors other than rem4, we'll shuffle them the same
+     way, but then shift them left (which corresponds to right in the
+     picture...) and OR them together.  */
+
+  __m256i shuffle1 = _mm256_setr_epi8( 0, 1, 1, 1, 1, 8, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                       0, 1, 1, 1, 1, 8, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 );
+
+  wuc_t shift4 =                    _mm256_shuffle_epi8( rem4, shuffle1);
+  wuc_t shift3 = _mm256_slli_si256( _mm256_shuffle_epi8( rem3, shuffle1), 1);
+  wuc_t shift2 = _mm256_slli_si256( _mm256_shuffle_epi8( rem2, shuffle1), 2);
+  wuc_t shift1 = _mm256_slli_si256( _mm256_shuffle_epi8( rem1, shuffle1), 3);
+  wuc_t shift0 = _mm256_slli_si256( _mm256_shuffle_epi8( rem0, shuffle1), 4);
+  wuc_t shift  = _mm256_or_si256( _mm256_or_si256(
+                                      _mm256_or_si256( shift4, shift3),
+                                      _mm256_or_si256( shift2, shift1) ),
+                                  shift0 );
+
+  /* The final value is:
+    [ a b c d e f g h i j 0 0 0 0 0 0 | k l m n o p q r s t 0 0 0 0 0 0 ]
+    */
+
+  return shift;
+}
+
+/* Converts each byte in the AVX2 register from raw base58 [0,58) to
+   base58 digits ('1'-'z', with some skips).  Anything not in the range
+   [0, 58) will be mapped arbitrarily, but won't affect other bytes. */
+
+static inline wuc_t raw_to_base58( wuc_t in ) {
+
+  /* <30 cycles for two vectors (64 conversions) */
+  /* We'll perform the map as an arithmetic expression,
+     b58ch(x) = '1' + x + 7*[x>8] + [x>16] + [x>21] + 6*[x>32] + [x>43]
+     (using Knuth bracket notation, which maps true/false to 1/0).
+
+     cmpgt uses 0xFF for true and 0x00 for false.  This is very
+     convenient, because most of the time we just want to skip one
+     character, so we can add 1 by subtracting 0xFF (=-1). */
+
+  __m256i gt0 = _mm256_cmpgt_epi8( in, _mm256_set1_epi8( 8) ); /* skip 7 */
+  __m256i gt1 = _mm256_cmpgt_epi8( in, _mm256_set1_epi8(16) );
+  __m256i gt2 = _mm256_cmpgt_epi8( in, _mm256_set1_epi8(21) );
+  __m256i gt3 = _mm256_cmpgt_epi8( in, _mm256_set1_epi8(32) ); /* skip 6*/
+  __m256i gt4 = _mm256_cmpgt_epi8( in, _mm256_set1_epi8(43) );
+
+  /* Intel doesn't give us an epi8 multiplication instruction, but since
+     we know the input is all in {0, -1}, we can just AND both values
+     with -7 to get {0, -7}. Similarly for 6. */
+
+  __m256i gt0_7 = _mm256_and_si256( gt0, _mm256_set1_epi8( -7 ) );
+  __m256i gt3_6 = _mm256_and_si256( gt3, _mm256_set1_epi8( -6 ) );
+
+  /* Add up all the negative offsets. */
+  __m256i sum = _mm256_add_epi8(
+                  _mm256_add_epi8(
+                    _mm256_add_epi8( _mm256_set1_epi8( -'1' ), gt1 ), /* Yes, that's the negative character value of '1' */
+                    _mm256_add_epi8( gt2,                      gt4 ) ),
+                  _mm256_add_epi8(   gt0_7,                    gt3_6 ) );
+
+  return _mm256_sub_epi8( in, sum );
+}
+
+/* count_leading_zeros_{n} counts the number of zero bytes prior to the
+   first non-zero byte in the first n bytes.  If all n bytes are zero,
+   returns n.  Return value is in [0, n].  For the two-vector cases, in0
+   contains the first 32 bytes and in1 contains the second 32 bytes. */
+
+static inline ulong
+count_leading_zeros_26( wuc_t in ) {
+  ulong mask0 = (ulong)(uint)_mm256_movemask_epi8( _mm256_cmpeq_epi8( in, _mm256_setzero_si256() ));
+  ulong mask  = fd_ulong_mask_lsb( 27 ) ^ (mask0 & fd_ulong_mask_lsb( 26 )); /* Flips the low 26 bits and puts a 1 in bit 26 */
+  return (ulong)fd_ulong_find_lsb( mask );
+}
+
+static inline ulong
+count_leading_zeros_32( wuc_t in ) {
+  ulong mask = fd_ulong_mask_lsb( 33 ) ^ (ulong)(uint)_mm256_movemask_epi8( _mm256_cmpeq_epi8( in, _mm256_setzero_si256() ));
+  return (ulong)fd_ulong_find_lsb( mask );
+}
+
+static inline ulong
+count_leading_zeros_45( wuc_t in0,
+                        wuc_t in1 ) {
+  ulong mask0 = (ulong)(uint)_mm256_movemask_epi8( _mm256_cmpeq_epi8( in0, _mm256_setzero_si256() ));
+  ulong mask1 = (ulong)(uint)_mm256_movemask_epi8( _mm256_cmpeq_epi8( in1, _mm256_setzero_si256() ));
+  ulong mask = fd_ulong_mask_lsb( 46 ) ^ (((mask1 & fd_ulong_mask_lsb( 13 ))<<32) | mask0);
+  return (ulong)fd_ulong_find_lsb( mask );
+}
+
+static inline ulong
+count_leading_zeros_64( wuc_t in0,
+                        wuc_t in1 ) {
+  ulong mask0 = (ulong)(uint)_mm256_movemask_epi8( _mm256_cmpeq_epi8( in0, _mm256_setzero_si256() ));
+  ulong mask1 = (ulong)(uint)_mm256_movemask_epi8( _mm256_cmpeq_epi8( in1, _mm256_setzero_si256() ));
+  ulong mask = ~((mask1<<32) | mask0);
+  return (ulong)fd_ulong_find_lsb_w_default( mask, 64 );
+}
+
+/* ten_per_slot_down_{32,64}: Packs {45,90} raw base58 digits stored in
+   the bizarre groups of 10 format from intermediate_to_raw into {2,3}
+   AVX2 registers with the digits stored contiguously. */
+
+/* In this diagram, one letter represents one byte.
+    [ aaaaaaaaaa000000 bbbbbbbbbb000000 ]
+                                        [ cccccccccc000000 dddddddddd000000 ]
+                                                                            [ eeeee00000000000 0 ]
+    [ aaaaaaaaaa000000 ]
+    [ 0000000000bbbbbb ] ( >> 10B)
+                     [ bbbb000000000000 ] (<< 6B)
+                     [ 0000cccccccccc00 ] (>> 4B)
+                     [ 00000000000000dd ] (>> 14B)
+                                        [ dddddddd00000000 ] (<< 2)
+                                        [ 00000000eeeee000 ] (>> 8)
+        0                   1                   2
+    In the diagram above, memory addresses increase from left to right.
+    AVX instructions see the world from a little-endian perspective,
+    where shifting left by one byte increases the numerical value, which
+    is equivalent to moving the data one byte later in memory, which
+    would show in the diagram as moving the values to the right. */
+
+#define ten_per_slot_down_32( in0, in1, in2, out0, out1 )                           \
+  do {                                                                              \
+    __m128i lo0 = _mm256_extractf128_si256( in0, 0 );                               \
+    __m128i hi0 = _mm256_extractf128_si256( in0, 1 );                               \
+    __m128i lo1 = _mm256_extractf128_si256( in1, 0 );                               \
+    __m128i hi1 = _mm256_extractf128_si256( in1, 1 );                               \
+    __m128i lo2 = _mm256_extractf128_si256( in2, 0 );                               \
+                                                                                    \
+    __m128i o0 = _mm_or_si128( lo0, _mm_slli_si128( hi0, 10 ));                     \
+    __m128i o1 = _mm_or_si128( _mm_or_si128(                                        \
+                                    _mm_srli_si128( hi0, 6 ),                       \
+                                    _mm_slli_si128( lo1, 4 )                        \
+                                    ), _mm_slli_si128( hi1, 14 ));                  \
+    __m128i o2 = _mm_or_si128( _mm_srli_si128( hi1, 2 ), _mm_slli_si128( lo2, 8 )); \
+    out0 = _mm256_set_m128i( o1, o0 );                                              \
+    out1 = _mm256_set_m128i( _mm_setzero_si128( ), o2 );                            \
+  } while( 0 )
+
+/* In this diagram, one letter represents one byte.
+   (... snip (see diagram above) ... )
+    [ eeeeeeeeee000000 ffffffffff000000 ]
+                                        [ gggggggggg000000 hhhhhhhhhh000000 ]
+                                                                            [ iiiiiiiiii000000 0 ]
+    [ 00000000eeeeeeee ] (>> 8)
+                     [ ee00000000000000 ] (<< 8)
+                     [ 00ffffffffff0000 ] (>> 2)
+                     [ 000000000000gggg ] (>> 12)
+                                        [ gggggg0000000000 ] (<< 4)
+                                        [ 000000hhhhhhhhhh ] (>> 6)
+                                                           [ iiiiiiiiii000000 ]
+          2               3                   4                   5
+*/
+
+#define ten_per_slot_down_64( in0, in1, in2, in3, in4, out0, out1, out2 )           \
+  do {                                                                              \
+    __m128i lo0 = _mm256_extractf128_si256( in0, 0 );                               \
+    __m128i hi0 = _mm256_extractf128_si256( in0, 1 );                               \
+    __m128i lo1 = _mm256_extractf128_si256( in1, 0 );                               \
+    __m128i hi1 = _mm256_extractf128_si256( in1, 1 );                               \
+    __m128i lo2 = _mm256_extractf128_si256( in2, 0 );                               \
+    __m128i hi2 = _mm256_extractf128_si256( in2, 1 );                               \
+    __m128i lo3 = _mm256_extractf128_si256( in3, 0 );                               \
+    __m128i hi3 = _mm256_extractf128_si256( in3, 1 );                               \
+    __m128i lo4 = _mm256_extractf128_si256( in4, 0 );                               \
+                                                                                    \
+    __m128i o0 = _mm_or_si128( lo0, _mm_slli_si128( hi0, 10 ));                     \
+    __m128i o1 = _mm_or_si128( _mm_or_si128(                                        \
+                                    _mm_srli_si128( hi0, 6 ),                       \
+                                    _mm_slli_si128( lo1, 4 )                        \
+                                    ), _mm_slli_si128( hi1, 14 ));                  \
+    __m128i o2 = _mm_or_si128( _mm_srli_si128( hi1, 2 ), _mm_slli_si128( lo2, 8 )); \
+    __m128i o3 = _mm_or_si128( _mm_or_si128(                                        \
+                                    _mm_srli_si128( lo2, 8 ),                       \
+                                    _mm_slli_si128( hi2, 2 )                        \
+                                    ), _mm_slli_si128( lo3, 12 ));                  \
+    __m128i o4 = _mm_or_si128( _mm_srli_si128( lo3, 4 ), _mm_slli_si128( hi3, 6 )); \
+    out0 = _mm256_set_m128i( o1, o0  );                                             \
+    out1 = _mm256_set_m128i( o3, o2  );                                             \
+    out2 = _mm256_set_m128i( lo4, o4 );                                             \
+  } while( 0 )
+

--- a/src/ballet/base58/fd_base58_tmpl.c
+++ b/src/ballet/base58/fd_base58_tmpl.c
@@ -1,0 +1,403 @@
+/* Declares conversion functions to/from base58 for a specific size of
+   binary data.
+
+   To use this template, define:
+
+     N: the length of the binary data (in bytes) to convert.  N must be
+         32 or 64 in the current implementation.
+     INTERMEDIATE_SZ: ceil(log_(58^5) ( (256^N) - 1)). In an ideal
+         world, this could be computed from N, but there's no way the
+         preprocessor can do math like that.
+     BINARY_SIZE: N/4.  Define it yourself to facilitate declaring the
+         required tables.
+
+   INTERMEIDATE_SZ and BINARY_SZ should expand to ulongs while N should
+   be an integer literal.
+
+   Expects that enc_table_N, dec_table_N, and FD_BASE58_ENCODED_N_SZ
+   exist (substituting the numeric value of N).
+
+   This file is safe for inclusion multiple times. */
+
+#define BYTE_CNT     ((ulong) N)
+#define SUFFIX(s)    FD_EXPAND_THEN_CONCAT3(s,_,N)
+#define ENCODED_SZ() FD_EXPAND_THEN_CONCAT3(FD_BASE58_ENCODED_, N, _SZ)
+#define RAW58_SZ     (INTERMEDIATE_SZ*5UL)
+
+#if FD_HAS_AVX
+#define INTERMEDIATE_SZ_W_PADDING FD_ULONG_ALIGN_UP( INTERMEDIATE_SZ, 4UL )
+#else
+#define INTERMEDIATE_SZ_W_PADDING INTERMEDIATE_SZ
+#endif
+
+char *
+SUFFIX(fd_base58_encode)( uchar const * bytes,
+                          ulong       * opt_len,
+                          char        * out    ){
+
+  /* Count leading zeros (needed for final output) */
+#if FD_HAS_AVX
+# if N==32
+  wuc_t _bytes = wuc_ldu( bytes );
+  ulong in_leading_0s = count_leading_zeros_32( _bytes );
+# elif N==64
+  wuc_t bytes_0 = wuc_ldu( bytes      );
+  wuc_t bytes_1 = wuc_ldu( bytes+32UL );
+  ulong in_leading_0s = count_leading_zeros_64( bytes_0, bytes_1 );
+# endif
+#else
+
+  ulong in_leading_0s = 0UL;
+  for( ; in_leading_0s<BYTE_CNT; in_leading_0s++ ) if( bytes[ in_leading_0s ] ) break;
+#endif
+
+  /* X = sum_i bytes[i] * 2^(8*(BYTE_CNT-1-i)) */
+
+  /* Convert N to 32-bit limbs:
+     X = sum_i binary[i] * 2^(32*(BINARY_SZ-1-i)) */
+  uint binary[ BINARY_SZ ];
+  uint const * bytes_as_uint = (uint const *)bytes;
+  for( ulong i=0UL; i<BINARY_SZ; i++ ) binary[ i ] = fd_uint_bswap( bytes_as_uint[ i ] );
+
+  ulong R1div = 656356768UL; /* = 58^5 */
+
+  /* Convert to the intermediate format:
+       X = sum_i intermediate[i] * 58^(5*(INTERMEDIATE_SZ-1-i))
+     Initially, we don't require intermediate[i] < 58^5, but we do want
+     to make sure the sums don't overflow. */
+
+#if FD_HAS_AVX
+  ulong W_ATTR intermediate[ INTERMEDIATE_SZ_W_PADDING ];
+#else
+  ulong intermediate[ INTERMEDIATE_SZ_W_PADDING ];
+#endif
+
+  fd_memset( intermediate, 0, INTERMEDIATE_SZ_W_PADDING * sizeof(ulong) );
+
+# if N==32
+
+  /* The worst case is if binary[7] is (2^32)-1. In that case
+     intermediate[8] will be be just over 2^63, which is fine. */
+
+  for( ulong i=0UL; i < BINARY_SZ; i++ )
+    for( ulong j=0UL; j < INTERMEDIATE_SZ-1UL; j++ )
+      intermediate[ j+1UL ] += (ulong)binary[ i ] * (ulong)SUFFIX(enc_table)[ i ][ j ];
+
+# elif N==64
+
+  /* If we do it the same way as the 32B conversion, intermediate[16]
+     can overflow when the input is sufficiently large.  We'll do a
+     mini-reduction after the first 8 steps.  After the first 8 terms,
+     the largest intermediate[16] can be is 2^63.87.  Then, after
+     reduction it'll be at most 58^5, and after adding the last terms,
+     it won't exceed 2^63.1.  We do need to be cautious that the
+     mini-reduction doesn't cause overflow in intermediate[15] though.
+     Pre-mini-reduction, it's at most 2^63.05.  The mini-reduction adds
+     at most 2^64/58^5, which is negligible.  With the final terms, it
+     won't exceed 2^63.69, which is fine. Other terms are less than
+     2^63.76, so no problems there. */
+
+  for( ulong i=0UL; i < 8UL; i++ )
+    for( ulong j=0UL; j < INTERMEDIATE_SZ-1UL; j++ )
+      intermediate[ j+1UL ] += (ulong)binary[ i ] * (ulong)SUFFIX(enc_table)[ i ][ j ];
+  /* Mini-reduction */
+  intermediate[ 15 ] += intermediate[ 16 ]/R1div;
+  intermediate[ 16 ] %= R1div;
+  /* Finish iterations */
+  for( ulong i=8UL; i < BINARY_SZ; i++ )
+    for( ulong j=0UL; j < INTERMEDIATE_SZ-1UL; j++ )
+      intermediate[ j+1UL ] += (ulong)binary[ i ] * (ulong)SUFFIX(enc_table)[ i ][ j ];
+
+# else
+# error "Add support for this N"
+# endif
+
+  /* Now we make sure each term is less than 58^5. Again, we have to be
+     a bit careful of overflow.
+
+     For N==32, in the worst case, as before, intermediate[8] will be
+     just over 2^63 and intermediate[7] will be just over 2^62.6.  In
+     the first step, we'll add floor(intermediate[8]/58^5) to
+     intermediate[7].  58^5 is pretty big though, so intermediate[7]
+     barely budges, and this is still fine.
+
+     For N==64, in the worst case, the biggest entry in intermediate at
+     this point is 2^63.87, and in the worst case, we add (2^64-1)/58^5,
+     which is still about 2^63.87. */
+
+  for( ulong i=INTERMEDIATE_SZ-1UL; i>0UL; i-- ) {
+    intermediate[ i-1UL ] += (intermediate[ i ]/R1div);
+    intermediate[ i     ] %= R1div;
+  }
+
+#if !FD_HAS_AVX
+  /* Convert intermediate form to base 58.  This form of conversion
+     exposes tons of ILP, but it's more than the CPU can take advantage
+     of.
+       X = sum_i raw_base58[i] * 58^(RAW58_SZ-1-i) */
+
+  uchar raw_base58[ RAW58_SZ ];
+  for( ulong i=0UL; i<INTERMEDIATE_SZ; i++) {
+    /* We know intermediate[ i ] < 58^5 < 2^32 for all i, so casting to
+       a uint is safe.  GCC doesn't seem to be able to realize this, so
+       when it converts ulong/ulong to a magic multiplication, it
+       generates the single-op 64b x 64b -> 128b mul instruction.  This
+       hurts the CPU's ability to take advantage of the ILP here. */
+    uint v = (uint)intermediate[ i ];
+    raw_base58[ 5UL*i+4UL ] = (uchar)((v/1U       )%58U);
+    raw_base58[ 5UL*i+3UL ] = (uchar)((v/58U      )%58U);
+    raw_base58[ 5UL*i+2UL ] = (uchar)((v/3364U    )%58U);
+    raw_base58[ 5UL*i+1UL ] = (uchar)((v/195112U  )%58U);
+    raw_base58[ 5UL*i+0UL ] = (uchar)( v/11316496U); /* We know this one is less than 58 */
+  }
+
+  /* Finally, actually convert to the string.  We have to ignore all the
+     leading zeros in raw_base58 and instead insert in_leading_0s
+     leading '1' characters.  We can show that raw_base58 actually has
+     at least in_leading_0s, so we'll do this by skipping the first few
+     leading zeros in raw_base58. */
+
+  ulong raw_leading_0s = 0UL;
+  for( ; raw_leading_0s<RAW58_SZ; raw_leading_0s++ ) if( raw_base58[ raw_leading_0s ] ) break;
+
+  /* It's not immediately obvious that raw_leading_0s >= in_leading_0s,
+     but it's true.  In base b, X has floor(log_b X)+1 digits.  That
+     means in_leading_0s = N-1-floor(log_256 X) and raw_leading_0s =
+     RAW58_SZ-1-floor(log_58 X).  Let X<256^N be given and consider:
+
+     raw_leading_0s - in_leading_0s =
+       =  RAW58_SZ-N + floor( log_256 X ) - floor( log_58 X )
+       >= RAW58_SZ-N - 1 + ( log_256 X - log_58 X ) .
+
+     log_256 X - log_58 X is monotonically decreasing for X>0, so it
+     achieves it minimum at the maximum possible value for X, i.e.
+     256^N-1.
+       >= RAW58_SZ-N-1 + log_256(256^N-1) - log_58(256^N-1)
+
+     When N==32, RAW58_SZ is 45, so this gives skip >= 0.29
+     When N==64, RAW58_SZ is 90, so this gives skip >= 1.59.
+
+     Regardless, raw_leading_0s - in_leading_0s >= 0. */
+
+  ulong skip = raw_leading_0s - in_leading_0s;
+  for( ulong i=0UL; i<RAW58_SZ-skip; i++ )  out[ i ] = base58_chars[ raw_base58[ skip+i ] ];
+
+#else /* FD_HAS_AVX */
+# if N==32
+  wl_t intermediate0 = wl_ld( (long*)intermediate     );
+  wl_t intermediate1 = wl_ld( (long*)intermediate+4UL );
+  wl_t intermediate2 = wl_ld( (long*)intermediate+8UL );
+  wuc_t raw0 = intermediate_to_raw( intermediate0 );
+  wuc_t raw1 = intermediate_to_raw( intermediate1 );
+  wuc_t raw2 = intermediate_to_raw( intermediate2 );
+
+  wuc_t compact0, compact1;
+  ten_per_slot_down_32( raw0, raw1, raw2, compact0, compact1 );
+
+  ulong raw_leading_0s = count_leading_zeros_45( compact0, compact1 );
+
+  wuc_t base58_0 = raw_to_base58( compact0 );
+  wuc_t base58_1 = raw_to_base58( compact1 );
+
+  ulong skip = raw_leading_0s - in_leading_0s;
+  /* We know the final string is between 32 and 44 characters, so skip
+     has to be in [1, 13].
+
+     Suppose base58_0 is [ a0 a1 a2 ... af | b0 b1 b2 ... bf ] and skip
+     is 2.
+     It would be nice if we had something like the 128-bit barrel shifts
+     we used in ten_per_slot_down, but they require immediates.
+     Instead, we'll shift each ulong right by (skip%8) bytes:
+
+     [ a2 a3 .. a7 0 0 aa ab .. af 0 0 | b2 b3 .. b7 0 0 ba .. bf 0 0 ]
+     and maskstore to write just 8 bytes, skipping the first
+     floor(skip/8) ulongs, to a starting address of out-8*floor(skip/8).
+
+           out
+             V
+           [ a2 a3 a4 a5 a6 a7  0  0 -- -- ... ]
+
+     Now we use another maskstore on the original base58_0, masking out
+     the first floor(skip/8)+1 ulongs, and writing to out-skip:
+           out
+             V
+     [ -- -- -- -- -- -- -- -- a8 a9 aa ab ... bd be bf ]
+
+     Finally, we need to write the low 13 bytes from base58_1 and a '\0'
+     terminator, starting at out-skip+32.  The easiest way to do this is
+     actually to shift in 3 more bytes, write the full 16B and do it
+     prior to the previous write:
+                                               out-skip+29
+                                                V
+                                              [ 0  0  0  c0 c1 c2 .. cc ]
+    */
+  wl_t w_skip    = wl_bcast( (long)skip );
+  wl_t mod8_mask = wl_bcast(       7L   );
+  wl_t compare   = wl( 0L, 1L, 2L, 3L );
+
+  wl_t shift_qty = wl_shl( wl_and( w_skip, mod8_mask ), 3 ); /* bytes->bits */
+  wl_t shifted = wl_shru_vector( base58_0, shift_qty );
+  wl_t skip_div8 = wl_shru( w_skip, 3 );
+
+  wc_t mask1 = wl_eq( skip_div8, compare );
+  _mm256_maskstore_epi64(  (long long int*)(out - 8UL*(skip/8UL)), mask1, shifted );
+
+  __m128i last = _mm_bslli_si128( _mm256_extractf128_si256( base58_1, 0 ), 3 );
+  _mm_storeu_si128( (__m128i*)(out+29UL-skip), last);
+
+  wc_t mask2 = wl_gt( compare, skip_div8 );
+  _mm256_maskstore_epi64(  (long long int*)(out - skip), mask2, base58_0 );
+
+# elif N==64
+  wuc_t raw0 = intermediate_to_raw( wl_ld( (long*)intermediate      ) );
+  wuc_t raw1 = intermediate_to_raw( wl_ld( (long*)intermediate+4UL  ) );
+  wuc_t raw2 = intermediate_to_raw( wl_ld( (long*)intermediate+8UL  ) );
+  wuc_t raw3 = intermediate_to_raw( wl_ld( (long*)intermediate+12UL ) );
+  wuc_t raw4 = intermediate_to_raw( wl_ld( (long*)intermediate+16UL ) );
+
+  wuc_t compact0, compact1, compact2;
+  ten_per_slot_down_64( raw0, raw1, raw2, raw3, raw4, compact0, compact1, compact2 );
+
+  ulong raw_leading_0s_part1 = count_leading_zeros_64( compact0, compact1 );
+  ulong raw_leading_0s_part2 = count_leading_zeros_26( compact2 );
+  ulong raw_leading_0s = fd_ulong_if( raw_leading_0s_part1<64UL, raw_leading_0s_part1, 64UL+raw_leading_0s_part2 );
+
+  wuc_t base58_0 = raw_to_base58( compact0 );
+  wuc_t base58_1 = raw_to_base58( compact1 );
+  wuc_t base58_2 = raw_to_base58( compact2 );
+
+  ulong skip = raw_leading_0s - in_leading_0s;
+  /* We'll do something similar.  The final string is between 64 and 88
+     characters, so skip is [2, 26].
+     */
+  wl_t w_skip    = wl_bcast( (long)skip );
+  wl_t mod8_mask = wl_bcast(       7L   );
+  wl_t compare   = wl( 0L, 1L, 2L, 3L );
+
+  wl_t shift_qty = wl_shl( wl_and( w_skip, mod8_mask ), 3 ); /* bytes->bits */
+  wl_t shifted = wl_shru_vector( base58_0, shift_qty );
+  wl_t skip_div8 = wl_shru( w_skip, 3 );
+
+  wc_t mask1 = wl_eq( skip_div8, compare );
+  wc_t mask2 = wl_gt( compare, skip_div8 );
+  _mm256_maskstore_epi64( (long long int*)(out - 8UL*(skip/8UL)), mask1, shifted  );
+
+  _mm256_maskstore_epi64( (long long int*)(out - skip),           mask2, base58_0 );
+
+  wuc_stu( (uchar*)out+32UL-skip, base58_1 );
+
+  __m128i last = _mm_bslli_si128( _mm256_extractf128_si256( base58_2, 1 ), 6 );
+  _mm_storeu_si128( (__m128i*)(out+64UL+16UL-6UL-skip), last                                    );
+  _mm_storeu_si128( (__m128i*)(out+64UL-skip),          _mm256_extractf128_si256( base58_2, 0 ) );
+# endif
+#endif
+
+  out[ RAW58_SZ-skip ] = '\0';
+  fd_ulong_store_if( !!opt_len, opt_len, RAW58_SZ-skip );
+  return out;
+}
+
+uchar *
+SUFFIX(fd_base58_decode)( char const * encoded,
+                          uchar      * out      ) {
+
+  /* Validate string and count characters before the nul terminator */
+
+  ulong char_cnt = 0UL;
+  for( ; char_cnt<ENCODED_SZ(); char_cnt++ ) {
+    char c = encoded[ char_cnt ];
+    if( !c ) break;
+    /* If c<'1', this will underflow and idx will be huge */
+    ulong idx = (ulong)(uchar)c - (ulong)BASE58_INVERSE_TABLE_OFFSET;
+    idx = fd_ulong_min( idx, BASE58_INVERSE_TABLE_SENTINEL );
+    if( FD_UNLIKELY( base58_inverse[ idx ] == BASE58_INVALID_CHAR ) ) return NULL;
+  }
+
+  if( FD_UNLIKELY( char_cnt == ENCODED_SZ() ) ) return NULL; /* too long */
+
+  /* X = sum_i raw_base58[i] * 58^(RAW58_SZ-1-i) */
+
+  uchar raw_base58[ RAW58_SZ ];
+
+  /* Prepend enough 0s to make it exactly RAW58_SZ characters */
+
+  ulong prepend_0 = RAW58_SZ-char_cnt;
+  for( ulong j=0UL; j<RAW58_SZ; j++ )
+    raw_base58[ j ] = (j<prepend_0) ? (uchar)0 : base58_inverse[ encoded[ j-prepend_0 ] - BASE58_INVERSE_TABLE_OFFSET ];
+
+  /* Convert to the intermediate format (base 58^5):
+       X = sum_i intermediate[i] * 58^(5*(INTERMEDIATE_SZ-1-i)) */
+
+  ulong intermediate[ INTERMEDIATE_SZ ];
+  for( ulong i=0UL; i<INTERMEDIATE_SZ; i++ )
+    intermediate[ i ] = (ulong)raw_base58[ 5UL*i+0UL ] * 11316496UL +
+                        (ulong)raw_base58[ 5UL*i+1UL ] * 195112UL   +
+                        (ulong)raw_base58[ 5UL*i+2UL ] * 3364UL     +
+                        (ulong)raw_base58[ 5UL*i+3UL ] * 58UL       +
+                        (ulong)raw_base58[ 5UL*i+4UL ] * 1UL;
+
+
+  /* Using the table, convert to overcomplete base 2^32 (terms can be
+     larger than 2^32).  We need to be careful about overflow.
+
+     For N==32, the largest anything in binary can get is binary[7]:
+     even if intermediate[i]==58^5-1 for all i, then binary[7] < 2^63.
+
+     For N==64, the largest anything in binary can get is binary[13]:
+     even if intermediate[i]==58^5-1 for all i, then binary[13] <
+     2^63.998.  Hanging in there, just by a thread! */
+
+  ulong binary[ BINARY_SZ ];
+  for( ulong j=0UL; j<BINARY_SZ; j++ ) {
+    ulong acc=0UL;
+    for( ulong i=0UL; i<INTERMEDIATE_SZ; i++ )
+      acc += (ulong)intermediate[ i ] * (ulong)SUFFIX(dec_table)[ i ][ j ];
+    binary[ j ] = acc;
+  }
+
+  /* Make sure each term is less than 2^32.
+
+     For N==32, we have plenty of headroom in binary, so overflow is
+     not a concern this time.
+
+     For N==64, even if we add 2^32 to binary[13], it is still 2^63.998,
+     so this won't overflow. */
+
+  for( ulong i=BINARY_SZ-1UL; i>0UL; i-- ) {
+    binary[ i-1UL ] += (binary[i] >> 32);
+    binary[ i     ] &= 0xFFFFFFFFUL;
+  }
+
+  /* If the largest term is 2^32 or bigger, it means N is larger than
+     what can fit in BYTE_CNT bytes.  This can be triggered, by passing
+     a base58 string of all 'z's for example. */
+
+  if( FD_UNLIKELY( binary[ 0UL ] > 0xFFFFFFFFUL ) ) return NULL;
+
+  /* Convert each term to big endian for the final output */
+
+  uint * out_as_uint = (uint*)out;
+  for( ulong i=0UL; i<BINARY_SZ; i++ ) {
+    out_as_uint[ i ] = fd_uint_bswap( (uint)binary[ i ] );
+  }
+  /* Make sure the encoded version has the same number of leading '1's
+     as the decoded version has leading 0s. The check doesn't read past
+     the end of encoded, because '\0' != '1', so it will return NULL. */
+
+  ulong leading_zero_cnt = 0UL;
+  for( ; leading_zero_cnt<BYTE_CNT; leading_zero_cnt++ ) {
+    if( out[ leading_zero_cnt ] ) break;
+    if( FD_UNLIKELY( encoded[ leading_zero_cnt ] != '1' ) ) return NULL;
+  }
+  if( FD_UNLIKELY( encoded[ leading_zero_cnt ] == '1' ) ) return NULL;
+  return out;
+}
+
+#undef RAW58_SZ
+#undef ENCODED_SZ
+#undef SUFFIX
+
+#undef BINARY_SZ
+#undef BYTE_CNT
+#undef INTERMEDIATE_SZ
+#undef N

--- a/src/ballet/base58/test_base58.c
+++ b/src/ballet/base58/test_base58.c
@@ -1,0 +1,751 @@
+#include "fd_base58.h"
+
+extern uchar const base58_inverse[];
+
+static char const base58_chars[] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+/* fd_base58_encode_ref interprets byte_cnt bytes from bytes as a large
+   big-endian integer, and converts it to a nul-terminated base58
+   string, storing the output in out.
+
+   Requires byte_cnt <= 64 and out_cnt <= 128.
+
+   This writes at most out_cnt characters to out, including the nul
+   terminator.  Returns NULL if the supplied output buffer is not big
+   enough, and returns out otherwise.  The length of a base58 string is
+   data-dependent, but passing 1+1.5*byte_cnt is sufficient (the actual
+   coefficient is log_58(256)).
+
+   This method is slow and the optimized fixed-size conversion methods
+   should be used where possible.
+
+   fd_base58_decode_ref converts the base58-encoded number stored in the
+   `encoded_len` length cstr `encoded` to a large integer which is
+   written big-endian to out.
+
+   Requires encoded_len <= 88 and out_cnt <= 64.
+
+   This writes exactly out_cnt bytes to out.  Returns out on success.
+   Returns NULL if encoded was not a valid base58 integer or if it
+   decoded to a byte string with length not exactly out_cnt.
+
+   This method is slow and the optimized fixed-size conversion methods
+   should be used where possible. */
+
+static char *
+fd_base58_encode_ref( uchar const * bytes,
+                      ulong         byte_cnt,
+                      char *        out,
+                      ulong         out_cnt ) {
+
+  if( FD_UNLIKELY( (byte_cnt>64UL) | (out_cnt>128UL) ) ) return NULL;
+  if( FD_UNLIKELY( out_cnt<byte_cnt+1UL              ) ) return NULL;
+
+  /* Copy bytes to something we can clobber */
+  ulong quotient[ 64UL ];
+  for( ulong j=0UL; j<byte_cnt; j++ ) quotient[j] = bytes[j];
+  out_cnt--; /* Save room for nul */
+  ulong raw_base58[ 128UL ];
+
+  ulong zero_cnt = 0UL;
+  while( zero_cnt<byte_cnt && !bytes[ zero_cnt ] ) zero_cnt++;
+
+  ulong last_nonzero = 0UL;
+  /* Grade-school long division */
+  ulong start_j = 0UL;
+  for( ulong i=0UL; i<out_cnt; i++ ) {
+    ulong remainder = 0UL;
+    if( start_j<byte_cnt && !quotient[ start_j ] ) start_j++;
+    for( ulong j=start_j; j<byte_cnt; j++ ) {
+      remainder = remainder*256UL + quotient[j];
+      quotient[j] = remainder / 58UL;
+      remainder %= 58UL;
+    }
+    raw_base58[ i ] = remainder;
+    if( remainder ) last_nonzero = 1UL+i;
+  }
+
+  if( FD_UNLIKELY( last_nonzero + zero_cnt > out_cnt ) ) return NULL;
+  for( ulong j=0UL; j<byte_cnt; j++ ) if( FD_UNLIKELY( quotient[ j ] ) ) return NULL; /* Output too small */
+
+  /* Convert to base58 characters */
+  ulong out_i = 0UL;
+  ulong raw_j = 0UL;
+  for( ; out_i<zero_cnt;     out_i++ ) out[ out_i   ] = '1';
+  for( ; raw_j<last_nonzero; raw_j++ ) out[ out_i++ ] = base58_chars[ raw_base58[ last_nonzero-1UL-raw_j ] ];
+  out[ out_i ] = '\0';
+
+  return out;
+}
+
+static uchar *
+fd_base58_decode_ref( char const * encoded,
+                      ulong        encoded_len, /* excluding nul-terminator */
+                      uchar *      out,
+                      ulong        out_cnt ) {
+
+  ulong zero_cnt = 0UL;
+  for( ; zero_cnt<fd_ulong_min( encoded_len, out_cnt ); zero_cnt++ )
+    if( encoded[ zero_cnt ] == '1' ) out[ zero_cnt ] = (uchar)0;
+    else break;
+
+  out += zero_cnt;
+  encoded += zero_cnt;
+  encoded_len -= zero_cnt;
+  out_cnt -= zero_cnt;
+
+  if( FD_UNLIKELY( (out_cnt==0) & (encoded_len>0) ) ) return NULL; /* N '1's followed by trailing characters */
+
+  if( FD_UNLIKELY( encoded_len>128UL ) ) return NULL;
+  ulong raw_base58[ 128UL ];
+
+  for( ulong i=0UL; i<encoded_len; i++ ) {
+    char c = encoded[ i ];
+    if( FD_UNLIKELY( (c<'1') | (c>'z') ) ) return NULL;
+    uchar raw = base58_inverse[ (ulong)(c-'1') ];
+    if( FD_UNLIKELY( (ulong)raw==255UL ) ) return NULL;
+    raw_base58[ i ] = raw;
+  }
+
+  /* Grade-school long division */
+  ulong start_j = 0UL;
+  for( ulong i=0UL; i<out_cnt; i++ ) {
+    ulong remainder = 0UL;
+    while( FD_LIKELY( start_j<encoded_len ) && !raw_base58[ start_j ] ) start_j++;
+    for( ulong j=start_j; j<encoded_len; j++ ) {
+      remainder = remainder*58UL + raw_base58[j];
+      raw_base58[ j ] = remainder >> 8;
+      remainder &= 0xFF;
+    }
+    out[ out_cnt-1UL-i ] = (uchar)remainder;
+  }
+  if( FD_UNLIKELY( out_cnt && !out[ 0UL ] ) ) return NULL; /* Wrong number of leading 1s */
+
+  for( ulong j=start_j; j<encoded_len; j++ ) if( FD_UNLIKELY( raw_base58[ j ] ) ) return NULL; /* Output too small */
+
+  return out-zero_cnt;
+}
+
+/* Drop-in replacements for the non-suffixed versions, but using the ref
+   algorithm. */
+
+static char *
+fd_base58_encode_32_ref( uchar const * bytes,
+                         ulong *       opt_len,
+                         char *        out ) {
+  fd_base58_encode_ref( bytes, 32UL, out, FD_BASE58_ENCODED_32_SZ );
+  fd_ulong_store_if( !!opt_len, opt_len, strlen( out ) );
+  return out;
+}
+
+static char *
+fd_base58_encode_64_ref( uchar const * bytes,
+                         ulong *       opt_len,
+                         char *        out ) {
+  fd_base58_encode_ref( bytes, 64UL, out, FD_BASE58_ENCODED_64_SZ );
+  fd_ulong_store_if( !!opt_len, opt_len, strlen( out ) );
+  return out;
+}
+
+static uchar *
+fd_base58_decode_32_ref( char const * encoded,
+                         uchar *      out ) {
+  return fd_base58_decode_ref( encoded, strlen( encoded ), out, 32UL );
+}
+
+static uchar *
+fd_base58_decode_64_ref( char const * encoded,
+                         uchar *      out ) {
+  return fd_base58_decode_ref( encoded, strlen( encoded ), out, 64UL );
+}
+
+typedef char  *(*encode_func_t)( uchar const *, ulong *, char * );
+typedef uchar *(*decode_func_t)( char  const *, uchar * );
+
+static void
+battery_encode_basic32( encode_func_t encode_func ) {
+  char  buf  [ FD_BASE58_ENCODED_32_SZ ];
+  uchar bytes[ 32UL ];
+  ulong len  [ 1UL ];
+
+  fd_memset( bytes, '\0', 32UL );
+  FD_TEST( !strcmp( "11111111111111111111111111111111", encode_func( bytes, len, buf ) ) );
+  FD_TEST( *len==32UL );
+
+  bytes[ 31UL ]++;
+  FD_TEST( !strcmp( "11111111111111111111111111111112", encode_func( bytes, len, buf ) ) );
+  FD_TEST( *len==32UL );
+
+  bytes[ 30UL ]++;
+  /* 257 in base58 is 5S */
+  FD_TEST( !strcmp( "1111111111111111111111111111115S", encode_func( bytes, len, buf ) ) );
+  FD_TEST( *len==32UL );
+
+  fd_memset( bytes, '\xFF', 32UL );
+  FD_TEST( !strcmp( "JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG", encode_func( bytes, len, buf ) ) );
+  FD_TEST( *len==44UL );
+
+  bytes[ 31UL ]--;
+  FD_TEST( !strcmp( "JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFF", encode_func( bytes, len, buf ) ) );
+  FD_TEST( *len==44UL );
+}
+
+static void
+battery_encode_basic64( encode_func_t encode_func ) {
+  char  buf  [ FD_BASE58_ENCODED_64_SZ ];
+  uchar bytes[ 64UL ];
+  ulong len  [ 1UL ];
+
+  fd_memset( bytes, '\0', 64UL );
+  FD_TEST( !strcmp( "1111111111111111111111111111111111111111111111111111111111111111",
+                    encode_func( bytes, len, buf ) ) );
+  FD_TEST( *len==64UL );
+
+  bytes[ 63UL ]++;
+  FD_TEST( !strcmp( "1111111111111111111111111111111111111111111111111111111111111112",
+                    encode_func( bytes, len, buf ) ) );
+  FD_TEST( *len==64UL );
+
+  bytes[ 62UL ]++;
+  /* 257 in base58 is 5S */
+  FD_TEST( !strcmp( "111111111111111111111111111111111111111111111111111111111111115S",
+                    encode_func( bytes, len, buf ) ) );
+  FD_TEST( *len==64UL );
+
+  fd_memset( bytes, '\xFF', 64UL );
+  FD_TEST( !strcmp( "67rpwLCuS5DGA8KGZXKsVQ7dnPb9goRLoKfgGbLfQg9WoLUgNY77E2jT11fem3coV9nAkguBACzrU1iyZM4B8roQ",
+                    encode_func( bytes, len, buf ) ) );
+  FD_TEST( *len==88UL );
+
+  bytes[ 63UL ]--;
+  FD_TEST( !strcmp( "67rpwLCuS5DGA8KGZXKsVQ7dnPb9goRLoKfgGbLfQg9WoLUgNY77E2jT11fem3coV9nAkguBACzrU1iyZM4B8roP",
+                    encode_func( bytes, len, buf ) ) );
+  FD_TEST( *len==88UL );
+}
+
+static void
+battery_encode_bounds( encode_func_t encode_func,
+                       ulong         n,
+                       ulong         encode_sz,
+                       char *        buf,          /* indexed [0,encode_sz) */
+                       uchar *       bytes ) {     /* indexed [0,n) */
+  fd_memset( bytes, 0, n );
+  for( ulong i=0UL; i<n; i++ ) {
+    bytes[ n-1UL-i ] = (uchar)1;
+    fd_memset( buf, '\xCC', encode_sz );
+    ulong len[ 1 ];
+    FD_TEST( encode_func( bytes, len, buf )==buf );
+    FD_TEST( (n<=len[0]) & (len[0]<encode_sz) );
+    FD_TEST( strlen( buf )==len[0] );
+    for( ulong j=len[0]+1UL; j<encode_sz; j++ ) FD_TEST( buf[ j ]=='\xCC' );
+  }
+}
+
+static void
+battery_decode_fail32( decode_func_t decode_func ) {
+# define N_TESTS (15UL)
+  char const * encoded[ N_TESTS ] = {
+    "1",
+    "1111111111111111111111111111111",
+    "4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJz",         /* clearly too short */
+    "4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofL",     /* largest 31 byte value */
+    "4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofLRda4", /* clearly too long */
+    "111111111111111111111111111111111",               /* Smallest 33 byte value */
+    "JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFJ",    /* 2nd-smallest 33 byte value that doesn't start with 0x0 */
+    "11aEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWx",    /* Starts with too many '1's */
+    "11111111111111111111111111111110",                /* Invalid characters */
+    "1111111111111111111111111111111!",
+    "1111111111111111111111111111111;",
+    "1111111111111111111111111111111I",
+    "1111111111111111111111111111111O",
+    "1111111111111111111111111111111_",
+    "1111111111111111111111111111111l",
+  };
+
+  uchar buf[ 32UL ];
+  for( ulong i=0UL; i<N_TESTS; i++ ) FD_TEST( !decode_func( encoded[ i ], buf ) );
+# undef N_TESTS
+}
+
+static void
+battery_decode_fail64( decode_func_t decode_func ) {
+# define N_TESTS (15UL)
+  char const * encoded[ N_TESTS ] = {
+    "1",
+    "111111111111111111111111111111111111111111111111111111111111111",
+    "2AFv15MNPuA84RmU66xw2uMzGipcVxNpzAffoacGVvjFue3CBmf633fAWuiP9cwL9C3z3CJiGgRSFjJfeEcA",        /* clearly too short */
+    "2AFv15MNPuA84RmU66xw2uMzGipcVxNpzAffoacGVvjFue3CBmf633fAWuiP9cwL9C3z3CJiGgRSFjJfeEcA6QW",     /* largest 63 byte value */
+    "2AFv15MNPuA84RmU66xw2uMzGipcVxNpzAffoacGVvjFue3CBmf633fAWuiP9cwL9C3z3CJiGgRSFjJfeEcA6QWabc",  /* clearly too long */
+    "11111111111111111111111111111111111111111111111111111111111111111",                           /* Smallest 65 byte value */
+    "67rpwLCuS5DGA8KGZXKsVQ7dnPb9goRLoKfgGbLfQg9WoLUgNY77E2jT11fem3coV9nAkguBACzrU1iyZM4B8roS",    /* 2nd-smallest 65 byte value
+                                                                                                      that doesn't start with 0x0 */
+    "1114tjGcyzrfXw2deDmDAFFaFyss32WRgkYdDJuprrNEL8kc799TrHSQHfE9fv6ZDBUg2dsMJdfYr71hjE4EfjEN",    /* Start with too many '1's */
+    "1111111111111111111111111111111111111111111111111111111111111110",                            /* Invalid characters */
+    "111111111111111111111111111111111111111111111111111111111111111!",
+    "111111111111111111111111111111111111111111111111111111111111111;",
+    "111111111111111111111111111111111111111111111111111111111111111I",
+    "111111111111111111111111111111111111111111111111111111111111111O",
+    "111111111111111111111111111111111111111111111111111111111111111_",
+    "111111111111111111111111111111111111111111111111111111111111111l",
+  };
+
+  uchar buf[ 64UL ];
+  for( ulong i=0UL; i<N_TESTS; i++ ) FD_TEST( !decode_func( encoded[ i ], buf ) );
+# undef N_TESTS
+}
+
+static void
+battery_sample32( encode_func_t encode_func,
+                     decode_func_t decode_func ) {
+
+# define N_TESTS (7UL)
+  static char const * encoded[ N_TESTS ] = {
+    "XkCriyrNwS3G4rzAXtG5B1nnvb5Ka1JtCku93VqeKAr",
+    "Awes4Tr6TX8JDzEhCZY2QVNimT6iD1zWHzf1vNyGvpLM",
+    "DRpbCBMxVnDK7maPM5tGv6MvB3v1sRMC86PZ8okm21hy",
+    "EgxVyTgh2Msg781wt9EsqYx4fW8wSvfFAHGLaJQjghiL",
+    "EvnRmnMrd69kFdbLMxWkTn1icZ7DCceRhvmb2SJXqDo4",
+    "Certusm1sa411sMpV9FPqU5dXAYhmmhygvxJ23S6hJ24",
+    "11111111111111111111111111111111"
+  };
+
+  static uchar const binary[ N_TESTS ][ 32UL ] = {
+    { 0x07,0xe0,0x46,0x93,0x3c,0x70,0x90,0xfa,0x2e,0x3e,0x85,0x39,0xfc,0x95,0xdc,0x8f,
+      0xed,0x4d,0x15,0xd0,0xbf,0x3d,0x3a,0xce,0x98,0x88,0x81,0x67,0x81,0x30,0x8d,0x8b },
+    { 0x93,0xb9,0x5b,0xa3,0xdb,0x98,0x5d,0x8c,0xca,0xe4,0x90,0x69,0x42,0x8f,0xec,0xf2,
+      0xff,0x3b,0x7d,0xa6,0x62,0xa9,0x58,0xba,0x9e,0x0e,0x46,0xeb,0x0d,0xbd,0x16,0xf6 },
+    { 0xb8,0xa7,0xfd,0xff,0xf8,0x8b,0x18,0xcc,0x25,0x98,0x52,0x9d,0x0d,0xad,0x9b,0xf9,
+      0x69,0x7a,0x8a,0x20,0x8e,0xe9,0x68,0xd4,0x4e,0x61,0x8b,0x03,0x2e,0x04,0x65,0x10 },
+    { 0xcb,0x64,0x55,0xcb,0x03,0x29,0xc7,0x8f,0xea,0x65,0x57,0xa6,0x1b,0x97,0x9a,0x96,
+      0x5e,0xe7,0xe7,0x9a,0xc7,0x8c,0x8f,0xd9,0x89,0x37,0x92,0xf2,0x78,0x6d,0x0e,0xd5 },
+    { 0xce,0xef,0x13,0xd8,0x09,0x8b,0xf5,0xda,0x4b,0x19,0x59,0x6a,0xc9,0xad,0x36,0x7c,
+      0x9c,0x5e,0x1a,0xad,0xe0,0xae,0xc9,0xd7,0xc0,0x41,0x3a,0xeb,0xcc,0x62,0x3b,0xdf },
+    { 0xad,0x23,0x76,0x6d,0xde,0xe6,0xe9,0x9c,0xa3,0x34,0x0e,0xe5,0xbe,0xac,0x08,0x84,
+      0xc8,0x9d,0xdb,0xc7,0x4d,0xfe,0x24,0x8f,0xea,0x56,0x13,0x56,0x98,0xba,0xfd,0xd1 },
+    { 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+      0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 }
+  };
+
+  for( ulong i=0UL; i<N_TESTS; i++ ) {
+    char  buf [ FD_BASE58_ENCODED_32_SZ ];
+    uchar buf2[ 32 ];
+    FD_TEST( !strcmp( encoded[i], encode_func( binary [i], NULL, buf  )       ) );
+    FD_TEST( !memcmp( binary [i], decode_func( encoded[i],       buf2 ), 32UL ) );
+  }
+# undef N_TESTS
+}
+
+static void
+battery_sample64( encode_func_t encode_func,
+                     decode_func_t decode_func ) {
+# define N_TESTS (6UL)
+  static char const * encoded[ N_TESTS ] = {
+    "1111111111111111111111111111111111111111111111111111111111111111",
+    "5eQS44iKV8B4b4gTt4tPZLPSHtD7F78fFDhbHDknsrAE1vUipnDf3pK6h5eZ8CqWqFgZPoYY6XHKUuvyt7BLWHpb",
+    "4EZ6eZt7svb2gYEFFnf14KSpHMD9k6F57qjDwD7dDZhegkrn4e3EzoHNNV83Fjc9cN8BQgG2uRFGwDSivw9yk7Nx",
+    "so5VqLRtAF6RxQJ4BSv31SPQfcFhUU1rqCroUJSLCWSEPhZqAEEwiTrH1kdndyztYbTCdmE7qKavgApDqVjmrKQ",
+    "RSAtWLUiyEhWUrcBtqmFUgtBHQ2ghJz4poJdXyruFQJpbyfY9AQBfr3dZUP6xdBy7PRqzeXYGUsNai8gcEivZQL",
+    "11cgTH4D5e8S3snD444WbbGrkepjTvWMj2jkmCGJtgn3H7qrPb1BnwapxpbGdRtHQh9t9Wbn9t6ZDGHzWpL4df"
+  };
+
+  static uchar const binary[ N_TESTS ][ 64UL ] = {
+    { 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+      0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+      0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+      0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 },
+    { 0xe8,0x52,0xe3,0x69,0x0d,0xa0,0xeb,0xf5,0xb4,0x66,0xed,0x0c,0x89,0x6b,0x2c,0x8f,
+      0xea,0xe6,0x0e,0x3b,0x23,0xc0,0x37,0xfc,0xdd,0x68,0xbf,0xc2,0xe4,0x60,0x7b,0x47,
+      0xb9,0x79,0x02,0x2e,0x4c,0xf6,0x2a,0x04,0x26,0x4e,0xef,0x55,0x94,0x0e,0xc8,0x57,
+      0xb3,0x46,0xf1,0xa4,0x11,0x5b,0xaa,0x1a,0xc8,0x3d,0x3b,0x05,0xca,0xa8,0x23,0x00 },
+    { 0xa1,0xbd,0x2a,0xdf,0x4f,0x4f,0x9f,0xe0,0x6e,0xc2,0x88,0x0b,0x1b,0x53,0x0e,0x7c,
+      0xb7,0xbe,0x4c,0x22,0xda,0x1a,0x45,0x93,0x4f,0x5e,0x09,0x25,0x02,0x6d,0x9f,0xec,
+      0xed,0xa1,0xda,0xb7,0xdf,0x93,0xf1,0x20,0xf0,0x57,0xfc,0x57,0x00,0xf2,0x49,0x0c,
+      0xd2,0xd9,0x15,0x15,0xc4,0x12,0xaa,0x1e,0xec,0x57,0x2b,0x86,0x53,0x90,0xc2,0x09 },
+    { 0x2b,0xcd,0x9e,0x54,0xf5,0xde,0x5c,0xf0,0xbc,0xbe,0xa0,0x12,0xf8,0x13,0x7e,0x54,
+      0x7a,0x7d,0x41,0xc9,0xa0,0x7b,0xa1,0xbc,0x08,0x34,0xf2,0x8a,0x20,0xcf,0xff,0xdd,
+      0x4a,0x6c,0xcb,0xbf,0xe5,0x63,0x2f,0x4b,0x84,0x0f,0xda,0xbc,0xa3,0xf0,0x85,0x75,
+      0x7d,0xe8,0xa9,0xaf,0x10,0x0e,0xd7,0x1f,0xaf,0xb3,0x30,0xc2,0x0f,0xd2,0x60,0x0f },
+    { 0x15,0x12,0x28,0x92,0x1f,0xfb,0x04,0x22,0xa2,0x0e,0x3e,0xef,0x11,0x93,0x6f,0x52,
+      0x46,0x79,0x5a,0x91,0x2a,0xf2,0x66,0x76,0x88,0x1a,0x15,0x2d,0x64,0x1c,0xaf,0x69,
+      0x8f,0x69,0xda,0x82,0x89,0xcc,0x56,0x69,0x6c,0xa1,0xbe,0x23,0xbc,0xfb,0xb1,0xb4,
+      0xfc,0x90,0x2b,0xf0,0xfe,0x78,0x9f,0x7e,0xae,0xe9,0x4e,0x94,0x53,0xe6,0xb6,0x01 },
+    { 0x00,0x00,0x0a,0x55,0xc6,0xbf,0x47,0x12,0x05,0x36,0x06,0xff,0xb5,0x20,0xe3,0x96,
+      0xd0,0x03,0x9d,0x87,0xde,0x43,0x32,0x17,0xed,0x33,0xf0,0x7b,0x22,0x94,0x6f,0x54,
+      0x62,0xa2,0xec,0x85,0x1f,0x5d,0xb9,0x8e,0x6c,0x29,0xbf,0x01,0x8a,0x06,0xc0,0x00,
+      0x2e,0x5d,0x19,0x41,0xf3,0xdf,0xe1,0xe1,0x55,0x37,0x52,0xfb,0x6d,0x84,0xa5,0x02 }
+  };
+
+  for( ulong i=0UL; i<N_TESTS; i++ ) {
+    char  buf [ FD_BASE58_ENCODED_64_SZ ];
+    uchar buf2[ 64 ];
+    FD_TEST( !strcmp( encoded[i], encode_func( binary [i], NULL, buf  )       ) );
+    FD_TEST( !memcmp( binary [i], decode_func( encoded[i],       buf2 ), 64UL ) );
+  }
+# undef N_TESTS
+}
+
+static void
+battery_match( encode_func_t encode_func_ref,
+               encode_func_t encode_func,
+               decode_func_t decode_func,
+               ulong         n,            /* assumed power of 2 */
+               ulong         encode_sz,
+               fd_rng_t *    rng,
+               ulong         cnt,
+               char  *       buf_ref,      /* indexed [0,encode_sz) */
+               uchar *       bytes_ref,    /* indexed [0,n) */
+               char  *       buf,          /* indexed [0,encode_sz) */
+               uchar *       bytes ) {     /* indexed [0,n) */
+  ulong mask = n-1UL;
+
+  for( ulong i=0UL; i<cnt; i++ ) {
+
+    /* Create the reference bytes.  To stress out various edge cases, we
+       have a random bytes with a random length cyclic wrap around
+       streak of zeros. */
+    for( ulong j=0UL; j<n; j++ ) bytes_ref[ j ] = fd_rng_uchar( rng );
+    ulong off = fd_rng_ulong( rng ) & mask;
+    for( ulong rem = fd_rng_ulong( rng ) & mask; rem; rem-- ) {
+      bytes_ref[ off ] = (uchar)0;
+      off = (off+1UL) & mask;
+    }
+
+    /* Compute the reference encoding and validate that it looks sane */
+    ulong len_ref[1];
+    FD_TEST( encode_func_ref( bytes_ref, len_ref, buf_ref )==buf_ref );
+    FD_TEST( (n<=len_ref[0]) & (len_ref[0]<encode_sz) );
+    FD_TEST( strlen( buf_ref )==len_ref[0] );
+
+    /* Test encoding with NULL len */
+    FD_TEST( encode_func( bytes_ref, NULL, buf )==buf );
+    FD_TEST( !strcmp( buf, buf_ref ) );
+
+    /* Test encoding with non-NULL len */
+    ulong len[1];
+    fd_memset( buf, 0, encode_sz );
+    FD_TEST( encode_func( bytes_ref, len, buf )==buf );
+    FD_TEST( !strcmp( buf, buf_ref ) );
+    FD_TEST( len[0]==len_ref[0] );
+
+    /* Test decoding */
+    FD_TEST( decode_func( buf, bytes )==bytes );
+    FD_TEST( !memcmp( bytes, bytes_ref, n ) );
+  }
+}
+
+static void
+battery_performance( encode_func_t encode_func,
+                     decode_func_t decode_func,
+                     ulong         n,
+                     ulong         encode_sz,
+                     fd_rng_t *    rng,
+                     char  *       buf,          /* indexed [0,encode_sz) */
+                     uchar *       bytes ) {     /* indexed [0,n) */
+  ulong const test_count = 3000UL;
+
+  /* Count non-conversion work */
+  long overhead = -fd_log_wallclock();
+  for( ulong i=0UL; i<test_count; i++ ) {
+    for( ulong j=0UL; j<n;         j++ ) FD_VOLATILE( bytes[ j ] ) = fd_rng_uchar( rng );
+    for( ulong j=0UL; j<encode_sz; j++ ) FD_VOLATILE_CONST( buf[ j ] );
+  }
+  overhead += fd_log_wallclock();
+
+  /* Warm up instruction cache */
+  encode_func( bytes, NULL, buf );
+  encode_func( bytes, NULL, buf );
+  encode_func( bytes, NULL, buf );
+
+  /* Measure encode */
+  long encode = -fd_log_wallclock();
+  for( ulong i=0UL; i<test_count; i++ ) {
+    for( ulong j=0UL; j<n;         j++ ) FD_VOLATILE( bytes[ j ] ) = fd_rng_uchar( rng );
+    encode_func( bytes, NULL, buf );
+    for( ulong j=0UL; j<encode_sz; j++ ) FD_VOLATILE_CONST( buf[ j ] );
+  }
+  encode += fd_log_wallclock();
+
+  /* Warm up instruction cache */
+  decode_func( buf, bytes );
+  decode_func( buf, bytes );
+  decode_func( buf, bytes );
+
+  /* Measure encode-decode pair */
+  long encode_decode = -fd_log_wallclock();
+  for( ulong i=0UL; i<test_count; i++ ) {
+    for( ulong j=0UL; j<n; j++ ) FD_VOLATILE( bytes[ j ] ) = fd_rng_uchar( rng );
+    decode_func( encode_func( bytes, NULL, buf ), bytes );
+    for( ulong j=0UL; j<n; j++ ) FD_VOLATILE_CONST( bytes[ j ] );
+  }
+  encode_decode += fd_log_wallclock();
+
+  /* Note: the overhead subtraction for the decode is very slightly
+     inaccurate. */
+  FD_LOG_NOTICE(( "average time per encode call (excluding overhead) %f ns, average time per decode call %f ns",
+                  (double)(encode        - overhead)/(double)test_count,
+                  (double)(encode_decode - encode  )/(double)test_count  ));
+}
+
+#define MAKE_TESTS(n,name)                                                                     \
+static inline void                                                                             \
+test_encode_basic##name( void ) {                                                              \
+  battery_encode_basic##n( fd_base58_encode_##name );                                          \
+}                                                                                              \
+                                                                                               \
+static inline void                                                                             \
+test_encode_bounds##name( void ) {                                                             \
+  char  buf  [ FD_BASE58_ENCODED_##n##_SZ ];                                                   \
+  uchar bytes[ n ];                                                                            \
+  battery_encode_bounds( fd_base58_encode_##name, n, FD_BASE58_ENCODED_##n##_SZ, buf, bytes ); \
+}                                                                                              \
+                                                                                               \
+static inline void                                                                             \
+test_decode_fail##name( void ) {                                                               \
+  battery_decode_fail##n( fd_base58_decode_##name );                                           \
+}                                                                                              \
+                                                                                               \
+static inline void                                                                             \
+test_sample##name( void ) {                                                                 \
+  battery_sample##n( fd_base58_encode_##name, fd_base58_decode_##name );                    \
+}                                                                                              \
+                                                                                               \
+static inline void                                                                             \
+test_match##name( fd_rng_t * rng,                                                              \
+                  ulong      cnt ) {                                                           \
+  char  buf_ref  [ FD_BASE58_ENCODED_##n##_SZ ];                                               \
+  char  buf      [ FD_BASE58_ENCODED_##n##_SZ ];                                               \
+  uchar bytes_ref[ n ];                                                                        \
+  uchar bytes    [ n ];                                                                        \
+  battery_match( fd_base58_encode_##n##_ref, fd_base58_encode_##name, fd_base58_decode_##name, \
+                 n, FD_BASE58_ENCODED_##n##_SZ, rng, cnt, buf_ref, bytes_ref, buf, bytes );    \
+}                                                                                              \
+                                                                                               \
+static inline void                                                                             \
+test_performance##name( fd_rng_t * rng ) {                                                     \
+  char  buf  [ FD_BASE58_ENCODED_##n##_SZ ];                                                   \
+  uchar bytes[ n ];                                                                            \
+  battery_performance( fd_base58_encode_##name, fd_base58_decode_##name,                       \
+                       n, FD_BASE58_ENCODED_##n##_SZ, rng, buf, bytes );                       \
+}
+
+MAKE_TESTS(32,32_ref)
+MAKE_TESTS(64,64_ref)
+MAKE_TESTS(32,32    )
+MAKE_TESTS(64,64    )
+
+#undef MAKE_TESTS
+
+#if FD_HAS_AVX
+
+#include "fd_base58_avx.h"
+
+static void
+test_count_leading_zeros( void ) {
+  uchar buffer[ 64UL ] __attribute__((aligned(32)));
+
+  fd_memset( buffer, 0, 64UL );
+  FD_TEST( count_leading_zeros_32( wuc_ld( buffer ) )                        == 32UL );
+  FD_TEST( count_leading_zeros_45( wuc_ld( buffer ), wuc_ld( buffer+32UL ) ) == 45UL );
+
+  buffer[ 0UL ] = (uchar)2;
+  FD_TEST( count_leading_zeros_32( wuc_ld( buffer ) )                        == 0UL );
+  FD_TEST( count_leading_zeros_45( wuc_ld( buffer ), wuc_ld( buffer+32UL ) ) == 0UL );
+
+  buffer[ 0UL ] = (uchar)0;
+  buffer[ 1UL ] = (uchar)7;
+  FD_TEST( count_leading_zeros_32( wuc_ld( buffer ) )                        == 1UL );
+  FD_TEST( count_leading_zeros_45( wuc_ld( buffer ), wuc_ld( buffer+32UL ) ) == 1UL );
+
+  buffer[ 1UL ] = (uchar)255;
+  FD_TEST( count_leading_zeros_32( wuc_ld( buffer ) )                        == 1UL );
+  FD_TEST( count_leading_zeros_45( wuc_ld( buffer ), wuc_ld( buffer+32UL ) ) == 1UL );
+
+  fd_memset( buffer, 123, 64UL );
+  for( ulong i=0UL; i<32UL; i++ ) {
+    buffer[ i ] = (uchar)0;
+    FD_TEST( count_leading_zeros_32( wuc_ld( buffer ) )                        == i+1UL );
+    FD_TEST( count_leading_zeros_45( wuc_ld( buffer ), wuc_ld( buffer+32UL ) ) == i+1UL );
+  }
+
+  for( ulong i=32UL; i<45UL; i++ ) {
+    buffer[ i ] = (uchar)0;
+    FD_TEST( count_leading_zeros_32( wuc_ld( buffer ) )                        == 32UL  );
+    FD_TEST( count_leading_zeros_45( wuc_ld( buffer ), wuc_ld( buffer+32UL ) ) == i+1UL );
+  }
+
+  for( ulong i=45UL; i<64UL; i++ ) {
+    buffer[ i ] = (uchar)0;
+    FD_TEST( count_leading_zeros_32( wuc_ld( buffer ) )                        == 32UL );
+    FD_TEST( count_leading_zeros_45( wuc_ld( buffer ), wuc_ld( buffer+32UL ) ) == 45UL );
+  }
+}
+
+static void
+test_raw_to_base58( void ) {
+  uchar in [ 32UL ] __attribute__((aligned(32)));
+  uchar out[ 32UL ] __attribute__((aligned(32)));
+
+  for( ulong i=0UL; i<58UL; i++ ) {
+    for( ulong j=0UL; j<32UL; j++ ) in[ j ] = (uchar)((i+j)%58UL);
+    wuc_st( out, raw_to_base58( wuc_ld( in ) ) );
+    for( ulong j=0UL; j<32UL; j++ ) FD_TEST( out[ j ] == base58_chars[ in[ j ] ] );
+  }
+}
+
+static void
+test_intermediate_to_raw( void ) {
+  ulong c1 = 0UL; /* +     j */
+  ulong c2 = 1UL; /* +   3*j */
+  ulong c3 = 2UL; /* + 101*j */
+  ulong c4 = 3UL; /* + 503*j */
+  uchar out[ 32UL ] __attribute__((aligned(32)));
+
+  for( ulong j=0UL; j<1000000UL; j++ ) {
+    wl_t  intermediate = wl( (long)c1, (long)c2, (long)c3, (long)c4 );
+    wuc_t raw          = intermediate_to_raw( intermediate );
+    wuc_st( out, raw );
+
+    FD_TEST( out[  0UL ] == (uchar)( c1/11316496UL)       );
+    FD_TEST( out[  1UL ] == (uchar)((c1/195112UL  )%58UL) );
+    FD_TEST( out[  2UL ] == (uchar)((c1/3364UL    )%58UL) );
+    FD_TEST( out[  3UL ] == (uchar)((c1/58UL      )%58UL) );
+    FD_TEST( out[  4UL ] == (uchar)((c1/1UL       )%58UL) );
+    FD_TEST( out[  5UL ] == (uchar)( c2/11316496UL)       );
+    FD_TEST( out[  6UL ] == (uchar)((c2/195112UL  )%58UL) );
+    FD_TEST( out[  7UL ] == (uchar)((c2/3364UL    )%58UL) );
+    FD_TEST( out[  8UL ] == (uchar)((c2/58UL      )%58UL) );
+    FD_TEST( out[  9UL ] == (uchar)((c2/1UL       )%58UL) );
+    FD_TEST( out[ 10UL ] == (uchar)0                      );
+    FD_TEST( out[ 11UL ] == (uchar)0                      );
+    FD_TEST( out[ 12UL ] == (uchar)0                      );
+    FD_TEST( out[ 13UL ] == (uchar)0                      );
+    FD_TEST( out[ 14UL ] == (uchar)0                      );
+    FD_TEST( out[ 15UL ] == (uchar)0                      );
+    FD_TEST( out[ 16UL ] == (uchar)( c3/11316496UL)       );
+    FD_TEST( out[ 17UL ] == (uchar)((c3/195112UL  )%58UL) );
+    FD_TEST( out[ 18UL ] == (uchar)((c3/3364UL    )%58UL) );
+    FD_TEST( out[ 19UL ] == (uchar)((c3/58UL      )%58UL) );
+    FD_TEST( out[ 20UL ] == (uchar)((c3/1UL       )%58UL) );
+    FD_TEST( out[ 21UL ] == (uchar)( c4/11316496UL)       );
+    FD_TEST( out[ 22UL ] == (uchar)((c4/195112UL  )%58UL) );
+    FD_TEST( out[ 23UL ] == (uchar)((c4/3364UL    )%58UL) );
+    FD_TEST( out[ 24UL ] == (uchar)((c4/58UL      )%58UL) );
+    FD_TEST( out[ 25UL ] == (uchar)((c4/1UL       )%58UL) );
+    FD_TEST( out[ 26UL ] == (uchar)0                      );
+    FD_TEST( out[ 27UL ] == (uchar)0                      );
+    FD_TEST( out[ 28UL ] == (uchar)0                      );
+    FD_TEST( out[ 29UL ] == (uchar)0                      );
+    FD_TEST( out[ 30UL ] == (uchar)0                      );
+    FD_TEST( out[ 31UL ] == (uchar)0                      );
+
+    c1 +=   1UL;
+    c2 +=   3UL;
+    c3 += 101UL;
+    c4 += 503UL;
+  }
+}
+
+static void
+test_ten_per_slot_down( void ) {
+
+  /* Test 32B version */
+  {
+    uchar in [ 32UL*3UL ] __attribute__((aligned(32)));
+    uchar out[ 32UL*2UL ] __attribute__((aligned(32)));
+    fd_memset( in,  0, 32UL*3UL );
+    fd_memset( out, 0, 32UL*2UL );
+    for( ulong i=0UL; i<45UL; i++ ) in[ 16UL*(i/10UL) + (i%10UL) ] = (uchar)(i+1UL);
+
+    wuc_t a = wuc_ld( in+0UL  );
+    wuc_t b = wuc_ld( in+32UL );
+    wuc_t c = wuc_ld( in+64UL );
+    wuc_t out0;
+    wuc_t out1;
+    ten_per_slot_down_32( a, b, c, out0, out1 );
+    wuc_st( out+ 0UL, out0 );
+    wuc_st( out+32UL, out1 );
+
+    for( ulong i=0UL; i<45UL; i++ ) FD_TEST( out[ i ] == (uchar)(i+1UL) );
+  }
+
+  /* Test 64B version */
+  {
+    uchar in [ 32UL*5UL ] __attribute__((aligned(32)));
+    uchar out[ 32UL*3UL ] __attribute__((aligned(32)));
+    fd_memset( in,  0, 32UL*5UL );
+    fd_memset( out, 0, 32UL*3UL );
+    for( ulong i=0UL; i<90UL; i++ ) in[ 16UL*(i/10UL) + (i%10UL) ] = (uchar)(i+1UL);
+
+    wuc_t a = wuc_ld( in+  0UL );
+    wuc_t b = wuc_ld( in+ 32UL );
+    wuc_t c = wuc_ld( in+ 64UL );
+    wuc_t d = wuc_ld( in+ 96UL );
+    wuc_t e = wuc_ld( in+128UL );
+    wuc_t out0;
+    wuc_t out1;
+    wuc_t out2;
+    ten_per_slot_down_64( a, b, c, d, e, out0, out1, out2 );
+    wuc_st( out+ 0UL, out0 );
+    wuc_st( out+32UL, out1 );
+    wuc_st( out+64UL, out2 );
+
+    for( ulong i=0UL; i<90UL; i++ ) FD_TEST( out[ i ] == (uchar)(i+1UL) );
+  }
+}
+
+#endif /* FD_HAS_AVX */
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  ulong cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--cnt", NULL, 100000UL );
+  fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
+
+# if FD_HAS_AVX
+  FD_LOG_NOTICE(( "Testing AVX internals" ));
+  test_intermediate_to_raw();
+  test_raw_to_base58();
+  test_count_leading_zeros();
+  test_ten_per_slot_down();
+# endif
+
+  FD_LOG_NOTICE(( "Testing reference 256-bit conversion" ));
+  test_encode_basic32_ref();
+  test_encode_bounds32_ref();
+  test_decode_fail32_ref();
+  test_sample32_ref();
+  test_match32_ref( rng, cnt );
+  test_performance32_ref( rng );
+
+  FD_LOG_NOTICE(( "Testing reference 512-bit conversion" ));
+  test_encode_basic64_ref();
+  test_encode_bounds64_ref();
+  test_decode_fail64_ref();
+  test_sample64_ref();
+  test_match64_ref( rng, cnt );
+  test_performance64_ref( rng );
+
+  FD_LOG_NOTICE(( "Testing 256-bit conversion" ));
+  test_encode_basic32();
+  test_encode_bounds32();
+  test_decode_fail32();
+  test_sample32();
+  test_match32( rng, cnt );
+  test_performance32( rng );
+
+  FD_LOG_NOTICE(( "Testing 512-bit conversion" ));
+  test_encode_basic64();
+  test_encode_bounds64();
+  test_decode_fail64();
+  test_sample64();
+  test_match64( rng, cnt );
+  test_performance64( rng );
+
+  fd_rng_delete( fd_rng_leave( rng ) );
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
Add high performance base58 conversion functions (encode and decode) for 32 and 64 bytes.  The encoder functions have been especially optimized for AVX.