### PR TITLE
Belting sanding pass on the fd_ar API.

### DIFF
--- a/src/util/archive/fd_ar.c
+++ b/src/util/archive/fd_ar.c
@@ -1,47 +1,152 @@
 #include "fd_ar.h"
 
+#if FD_HAS_HOSTED
+
+#include <stdio.h>
+#include <stdlib.h>
 #include <errno.h>
-#include <string.h>
 
-static const char magic_expected[ 8 ] =
-  { '!', '<', 'a', 'r', 'c', 'h', '>', '\n' };
+/* An fd_ar_hdr_t is the raw header of a file entry in the ar file.  It
+   is not clear how strict ar is about ASCII encoding in these fields
+   (is leading whitespace okay, is trailing whitespace okay, is garbage
+   allowed in trailing field, are explicit + allowed, are signed
+   quantities allowed, etc).  We currently handle the encoding:
 
-int
-fd_ar_open( FILE * stream ) {
-  /* Check archive header magic */
-  char magic[ 8 ];
-  size_t n = fread( magic, sizeof(magic), 1, stream );
-  if( FD_UNLIKELY( n!=1 ) ) return 0;
-  if( 0!=memcmp( magic, magic_expected, sizeof(magic) ) ) {
-    errno = EPROTO;
-    return 0;
-  }
-  return 1;
-}
+   field -> ^ [zero or more chars of whitespace]
+      width | [optional '+' or '-']
+      chars | [one or more chars of radix digits]
+            v [zero or more non-radix-digit chars (including '\0')]
 
-int
-fd_ar_next( FILE *    stream,
-            fd_ar_t * hdr ) {
-  long pos;
-  size_t n;
+   (That is, stuff strtol can convert and error trap.)
 
-  /* Headers are two-byte aligned */
-  pos = ftell( stream );
-  if( FD_UNLIKELY( pos<0L ) ) return 0;
-  if( FD_UNLIKELY( (pos&1L)==1L && fseek( stream, 1L, SEEK_CUR )<0L ) ) goto io_error;
+   Leading zeros are allowed as 'radix digits' and do not trigger radix
+   detection; the spec dictates whether a string is interpreted as decimal or
+   octal.
 
-  /* Read file header */
-  n = fread( hdr, sizeof(fd_ar_t), 1, stream );
-  if( FD_UNLIKELY( n!=1 ) ) goto io_error;
-  if( FD_UNLIKELY( hdr->magic!=FD_AR_FILE_MAGIC ) ) {
-    errno = EPROTO;
-    return 0;
-  }
+   We convert fields to a long.  Though the fields here clearly can be
+   stored more compactly, overflow / underflow is not possible into a
+   long and it is also readily apparent that the ar format cannot handle
+   routine things like very large files.  It is conceivable in the
+   future we might want to add support for variations on this file
+   format and would like to avoid requiring user facing changes to use a
+   different API.
 
-  /* Everything ok */
-  return 1;
+   We also debatably allow negative values for all fields but filesz and
+   kick the interpretation of that to the user (we might change this
+   behavior in the future to give stricter guarantees).  The filesz
+   field val is required to be non-negative but we still store it in a
+   long type for fseek friendliness (fseek with negative values for
+   filesz could generate unexpected results, including infinite loop ar
+   file iterations by using a filesz = -hdr_sz). */
 
-io_error:
-  if( FD_LIKELY( feof( stream ) ) ) errno = ENOENT;
+#define FD_AR_HDR_IDENT_SZ  (FD_AR_META_IDENT_SZ-1UL)
+#define FD_AR_HDR_MTIME_SZ  (12UL)
+#define FD_AR_HDR_UID_SZ    ( 6UL)
+#define FD_AR_HDR_GID_SZ    ( 6UL)
+#define FD_AR_HDR_MODE_SZ   ( 8UL)
+#define FD_AR_HDR_FILESZ_SZ (10UL)
+#define FD_AR_HDR_MAGIC     ((ushort)0x0a60)
+
+struct fd_ar_hdr {
+  char   ident     [ FD_AR_HDR_IDENT_SZ  ]; /* File identifier,                             WARNING: may not be '\0' terminated */
+  char   mtime_dec [ FD_AR_HDR_MTIME_SZ  ]; /* File modification timestamp (ASCII decimal), WARNING! may not be '\0' terminated */
+  char   uid_dec   [ FD_AR_HDR_UID_SZ    ]; /* Owner ID (ASCII decimal),                    WARNING: may not be '\0' terminated */
+  char   gid_dec   [ FD_AR_HDR_GID_SZ    ]; /* Group ID (ASCII decimal),                    WARNING: may not be '\0' terminated */
+  char   mode_oct  [ FD_AR_HDR_MODE_SZ   ]; /* File mode (ASCII octal),                     WARNING: may not be '\0' terminated */
+  char   filesz_dec[ FD_AR_HDR_FILESZ_SZ ]; /* File size (ASCII decimal),                   WARNING: may not be '\0' terminated */
+  ushort magic;                             /* ==FD_AR_HDR_MAGIC */
+};
+
+typedef struct fd_ar_hdr fd_ar_hdr_t;
+
+static int
+fd_ar_ascii_to_long( char const * field,
+                     ulong        width,   /* Should be less than 32 */
+                     int          base,    /* Should be a supported strtol base */
+                     long *       _val ) {
+
+  /* Turn field into a proper cstr */
+
+  if( FD_UNLIKELY( width>=32UL ) ) return EINVAL;
+  char cstr[ 32UL ];
+  memcpy( cstr, field, width );
+  cstr[ width ] = '\0';
+
+  /* Do the conversion.  Note: strtol will set errno to EINVAL is an
+     unsupported base (and maybe whitespace/empty string depending on
+     implementation) and ERANGE if overflow / underflow.  FIXME: This is
+     probably simple enough to ween off stdlib (it'd probably be
+     cleaner, faster and have less strtol weirdness to deal with). */
+
+  char * endptr;
+  errno = 0;
+  long val = strtol( cstr, &endptr, base );
+  if( FD_UNLIKELY( errno        ) ) return errno;
+  if( FD_UNLIKELY( cstr==endptr ) ) return EINVAL; /* Consistent handling of whitespace / empty string */
+
+  *_val = val;
   return 0;
 }
+
+int
+fd_ar_read_init( void * _stream ) {
+  FILE * stream = (FILE *)_stream;
+
+  /* Check input args */
+
+  if( FD_UNLIKELY( !stream ) ) return EINVAL;
+
+  /* Check archive header magic */
+
+  char magic[ 8 ];
+  if( FD_UNLIKELY( fread( magic, 8UL, 1UL, stream )!=1UL ) ) return FD_LIKELY( feof( stream ) ) ? ENOENT : EIO;
+  if( FD_UNLIKELY( memcmp( magic, "!<arch>\n", 8UL )     ) ) return EPROTO; /* Could do this single asm with ulong compare */
+
+  /* Everything ok */
+
+  return 0;
+}
+
+int
+fd_ar_read_next( void *         _stream,
+                 fd_ar_meta_t * opt_meta ) {
+  FILE * stream = (FILE *)_stream;
+
+  /* Check input args */
+
+  if( FD_UNLIKELY( !stream ) ) return EINVAL;
+
+  /* Read file header.  Note: Headers are two-byte aligned */
+
+  long pos = ftell( stream );
+  if( FD_UNLIKELY( pos<0L ) ) return EIO;
+  if( (pos&1L) && FD_UNLIKELY( fseek( stream, 1L, SEEK_CUR )<0L ) ) return FD_LIKELY( feof( stream ) ) ? ENOENT : EIO;
+
+  fd_ar_hdr_t hdr[1];
+  if( FD_UNLIKELY( fread( hdr, sizeof(fd_ar_hdr_t), 1UL, stream )!=1UL ) ) return FD_LIKELY( feof( stream ) ) ? ENOENT : EIO;
+  if( FD_UNLIKELY( hdr->magic!=FD_AR_HDR_MAGIC                         ) ) return EPROTO;
+
+  /* Parse the file header */
+
+  fd_ar_meta_t meta[1];
+  if( FD_UNLIKELY( fd_ar_ascii_to_long( hdr->mtime_dec,  FD_AR_HDR_MTIME_SZ,  10, &meta->mtime  ) ) ) return EPROTO;
+  if( FD_UNLIKELY( fd_ar_ascii_to_long( hdr->uid_dec,    FD_AR_HDR_UID_SZ,    10, &meta->uid    ) ) ) return EPROTO;
+  if( FD_UNLIKELY( fd_ar_ascii_to_long( hdr->gid_dec,    FD_AR_HDR_GID_SZ,    10, &meta->gid    ) ) ) return EPROTO;
+  if( FD_UNLIKELY( fd_ar_ascii_to_long( hdr->mode_oct,   FD_AR_HDR_MODE_SZ,    8, &meta->mode   ) ) ) return EPROTO;
+  if( FD_UNLIKELY( fd_ar_ascii_to_long( hdr->filesz_dec, FD_AR_HDR_FILESZ_SZ, 10, &meta->filesz ) ) ) return EPROTO;
+  if( FD_UNLIKELY( meta->filesz<0L ) ) return EPROTO;
+  memcpy( meta->ident, hdr->ident, FD_AR_HDR_IDENT_SZ );
+  meta->ident[ FD_AR_HDR_IDENT_SZ ] = '\0';
+
+  /* Everything ok */
+
+  if( opt_meta ) *opt_meta = *meta;
+  return 0;
+}
+
+#else /* Not supported on this target */
+
+int fd_ar_read_init( void * stream                      ) { (void)stream;             return 1; }
+int fd_ar_read_next( void * stream, fd_ar_meta_t * meta ) { (void)stream; (void)meta; return 1; }
+
+#endif

--- a/src/util/archive/fd_ar.h
+++ b/src/util/archive/fd_ar.h
@@ -28,84 +28,110 @@
 
    The `ar(1)` tool from GNU binutils can be used to create such archive files.
 
-      ar rcDS <archive_file> <file> <file> <file...> */
+      ar rcDS <archive_file> <file> <file> <file...>
 
-#include <stdio.h>
-#include <stdlib.h>
+   Basic usage:
+
+     ... at this point, stream should be pointed at the first byte
+     ... of the ar file magic
+
+     fd_ar_read_init( stream );
+     for(;;) {
+       fd_ar_meta_t meta[1];
+       if( fd_ar_read_next( stream, meta ) ) break;
+
+       ... at this point, stream is pointed at first byte of contents of
+       ... the next unprocessed file in the ar and there are
+       ... meta->filesz bytes ni this file
+       ... process next file here, advancing the stream position exactly
+
+       ... meta->filesz bytes before next iteration
+     }
+
+   More nuanced error handling and what not is possible.  See
+   descriptions below. */
 
 #include "../fd_util_base.h"
 
-#define FD_AR_IDENT_SZ  16
-#define FD_AR_MTIME_SZ  12
-#define FD_AR_UID_SZ     6
-#define FD_AR_GID_SZ     6
-#define FD_AR_MODE_SZ    8
-#define FD_AR_FILESZ_SZ 10
+/* See note in fd_ar.c for details on use of long for these fields. */
 
-#define FD_AR_FILE_MAGIC ((ushort)0x0a60)
+#define FD_AR_META_IDENT_SZ (17UL) /* 16 + 1 for '\0' termination */
 
-/* fd_ar is the header of each file entry in the ar file. */
-
-struct __attribute__((packed,aligned(2))) fd_ar {
-  /* File identifier */
-  char ident[ FD_AR_IDENT_SZ ];
-
-  /* File modification timestamp (ASCII decimal) */
-  char mtime_dec[ FD_AR_MTIME_SZ ];
-
-  /* Owner ID (ASCII decimal) */
-  char uid_dec[ FD_AR_UID_SZ ];
-
-  /* Group ID (ASCII decimal) */
-  char gid_dec[ FD_AR_GID_SZ ];
-
-  /* File mode (ASCII octal) */
-  char mode_oct[ FD_AR_MODE_SZ ];
-
-  /* File size (ASCII decimal) */
-  char filesz_dec[ FD_AR_FILESZ_SZ ];
-
-  /* File header magic (0x0a60) */
-  ushort magic;
+struct fd_ar_meta {
+  long mtime;
+  long uid;
+  long gid;
+  long mode;
+  long filesz;                       /* Guaranteed to be non-negative */
+  char ident[ FD_AR_META_IDENT_SZ ]; /* Guaranteed '\0' terminated */
 };
-typedef struct fd_ar fd_ar_t;
 
-FD_STATIC_ASSERT( __builtin_offsetof( fd_ar_t, ident      )== 0UL, alignment );
-FD_STATIC_ASSERT( __builtin_offsetof( fd_ar_t, mtime_dec  )==16UL, alignment );
-FD_STATIC_ASSERT( __builtin_offsetof( fd_ar_t, uid_dec    )==28UL, alignment );
-FD_STATIC_ASSERT( __builtin_offsetof( fd_ar_t, gid_dec    )==34UL, alignment );
-FD_STATIC_ASSERT( __builtin_offsetof( fd_ar_t, mode_oct   )==40UL, alignment );
-FD_STATIC_ASSERT( __builtin_offsetof( fd_ar_t, filesz_dec )==48UL, alignment );
-FD_STATIC_ASSERT( __builtin_offsetof( fd_ar_t, magic      )==58UL, alignment );
+typedef struct fd_ar_meta fd_ar_meta_t;
 
-FD_STATIC_ASSERT( sizeof(fd_ar_t)==60, alignment );
+FD_PROTOTYPES_BEGIN
 
-/* fd_ar_filesz returns the length of the data stream that follows
-   the given archive file header.
+/* fd_ar_read_init starts reading an ar archive in the given stream.  On
+   entry, assumes stream is positioned on the first byte of the ar
+   magic.  If FD_HAS_HOSTED, stream is FILE * pointer.  Otherwise stream
+   should be the equivalent for that target.
 
-   Returns a negative number on error.. */
-FD_FN_PURE static inline long
-fd_ar_filesz( fd_ar_t const * ar ) {
-  char * endptr;
-  long n = strtol( ar->filesz_dec, &endptr, 10 );
-  if( FD_UNLIKELY( ar->filesz_dec == endptr ) ) return -1;
-  return n;
-}
+   Returns 0 on success and non-zero strerror compatible error code on
+   failure.  If successful, the stream will be positioned on the first
+   byte immediately after the ar magic.  If not, the stream state is
+   undefined.
 
-/* fd_ar_open attaches to the given stream for reading.
+   Error codes include:
 
-   Sets `errno` on failure. Special `errno` values:
-     `EPROTO`: stream is not an AR file */
+   - EINVAL: NULL stream
+   - ENOENT: failed due to EOF
+   - EIO:    failed due to stream i/o failure
+   - EPROTO: failed due to malformed ar file (bad magic) */
+
 int
-fd_ar_open( FILE * stream );
+fd_ar_read_init( void * stream );
 
-/* fd_ar_next reads the next archive file header from the stream.
+/* fd_ar_read_next starts reading the archive file in the given stream.
+   On entry, assumes stream is positioned on the first byte immediately
+   after the archive magic or the first byte immediately after the just
+   processed archive file content.  If FD_HAS_HOSTED, stream should
+   point to an open FILE handle.  Otherwise stream should be to the
+   equivalent is provided for that target.
 
-   Sets `errno` on failure. Special `errno` values:
-     `ENOENT`: end of archive reached
-     `EPROTO`: malformed AR entry */
+   Returns 0 on success and non-zero strerror compatible error code on
+   failure.  If successful, the stream will be positioned on the first
+   byte of the file content to process next and meta will be populated
+   with details from the archive header.
+
+   If opt_meta is non-NULL, on success, *opt_meta will be populated with
+   archive file metadata on return.  Of note, the size of the file
+   contents is opt_meta->filesz bytes (a non-negative number).
+   Otherwise, *opt_meta will be untouched.
+
+   Before fd_ar_read_next is called on the get the next file, it should
+   position stream just after the last byte of the file contents.  E.g.
+   to skip over file contents in a hosted environment, provide opt_meta
+   and do:
+
+     fseek( stream, opt_meta->filesz, SEEK_CUR )
+
+   If the caller did not provide opt_meta to get the filesz, the caller
+   should know via other means how to position the stream after the file
+   contents.
+
+   Error codes include:
+
+   - EINVAL: NULL stream
+   - ENOENT: failed due to EOF
+   - EIO:    failed due to stream i/o failure
+   - EPROTO: failed due to malformed ar file (bad magic) */
+
 int
-fd_ar_next( FILE *    stream,
-            fd_ar_t * hdr );
+fd_ar_read_next( void *         stream,
+                 fd_ar_meta_t * opt_meta );
+
+/* FIXME: CONSIDER AN FD_AR_READ_FINI THAT WOULD MOVE THE STREAM POINTER
+   TO THE END OF THE AR FILE? */
+
+FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_archive_fd_ar_h */

--- a/src/util/archive/test_ar.c
+++ b/src/util/archive/test_ar.c
@@ -1,101 +1,87 @@
 #include "../fd_util.h"
 #include "fd_ar.h"
 
+#if FD_HAS_HOSTED
+
+#include <stdio.h>
 #include <errno.h>
 
-FD_IMPORT_BINARY(test_ar, "src/ballet/shred/fixtures/localnet-shreds-0.ar");
+FD_IMPORT_BINARY( test_ar, "src/ballet/shred/fixtures/localnet-shreds-0.ar" );
 
 /* test_valid_ar: Read all files from archive. */
-void
+
+static void
 test_valid_ar( void ) {
+
   /* Open a valid AR file */
 
   FILE * file = fmemopen( (void *)test_ar, test_ar_sz, "rb" );
   FD_TEST( file );
-  FD_TEST( fd_ar_open( file ) );
-
-  fd_ar_t hdr;
-  uchar buf[ 1500 ];
-
-# define CHECK_NEXT_AR(name, sz)                                               \
-  FD_TEST( fd_ar_next( file, &hdr ) );                                         \
-  FD_TEST( hdr.magic==FD_AR_FILE_MAGIC );                                      \
-  FD_TEST( 0==strncmp( hdr.ident,      name,           strlen(name)       ) ); \
-  FD_TEST( 0==strncmp( hdr.filesz_dec, #sz "  ",       strlen( #sz "  " ) ) ); \
-  FD_TEST( 0==memcmp ( hdr.mtime_dec,  "0           ", FD_AR_MTIME_SZ     ) ); \
-  FD_TEST( 0==memcmp ( hdr.uid_dec,    "0     ",       FD_AR_UID_SZ       ) ); \
-  FD_TEST( 0==memcmp ( hdr.gid_dec,    "0     ",       FD_AR_GID_SZ       ) ); \
-  FD_TEST( 0==memcmp ( hdr.mode_oct,   "644     ",     FD_AR_MODE_SZ      ) ); \
-  FD_TEST( (long)sz==fd_ar_filesz( &hdr )      );                              \
-  FD_TEST(       sz==fread( buf, 1, sz, file ) );
+  FD_TEST( !fd_ar_read_init( file ) );
 
   /* Read a few entries */
 
-  CHECK_NEXT_AR( "d0000/", 1203 );
-  FD_TEST( buf[ 0x49 ]==0x00 ); /* arbitrary byte in file payload */
+  fd_ar_meta_t meta[1];
+  uchar buf[1500];
 
-  CHECK_NEXT_AR( "d0001/", 1203 );
-  FD_TEST( buf[ 0x49 ]==0x01 );
+# define CHECK_NEXT_AR(name, sz, off, val )         \
+  FD_TEST( !fd_ar_read_next( file, meta )        ); \
+  FD_TEST( meta->mtime              ==0L         ); \
+  FD_TEST( meta->uid                ==0L         ); \
+  FD_TEST( meta->gid                ==0L         ); \
+  FD_TEST( meta->mode               ==0644L      ); \
+  FD_TEST( meta->filesz             ==(long)sz   ); \
+  FD_TEST( fread( buf, 1, sz, file )==sz         ); \
+  FD_TEST( buf[ off ]               ==(uchar)val )
 
-  CHECK_NEXT_AR( "d0002/", 1203 );
-  FD_TEST( buf[ 0x49 ]==0x02 );
+  CHECK_NEXT_AR( "d0000/", 1203, 0x49, 0x00 );
+  CHECK_NEXT_AR( "d0001/", 1203, 0x49, 0x01 );
+  CHECK_NEXT_AR( "d0002/", 1203, 0x49, 0x02 );
+  CHECK_NEXT_AR( "d0003/", 1203, 0x49, 0x03 );
 
-  CHECK_NEXT_AR( "d0003/", 1203 );
-  FD_TEST( buf[ 0x49 ]==0x03 );
+# undef CHECK_NEXT_AR
 
   /* Reached end of archive, expecting ENOENT */
 
-  FD_TEST( !fd_ar_next( file, &hdr ) );
-  FD_TEST( errno==ENOENT );
-
-  FD_TEST( 0==fclose( file ) );
+  FD_TEST( fd_ar_read_next( file, meta )==ENOENT );
+  FD_TEST( !fclose( file ) );
 }
 
 /* test_empty_ar: Gracefully handle empty archives */
-void
+
+static void
 test_empty_ar( void ) {
-  char empty[ 8 ] = { '!', '<', 'a', 'r', 'c', 'h', '>', '\n' };
-
-  FILE * file = fmemopen( (void *)empty, sizeof(empty), "rb" );
+  char buf[ 8 ];
+  FILE * file = fmemopen( fd_memcpy( buf, "!<arch>\n", 8UL ), 8UL, "rb" );
   FD_TEST( file );
-  FD_TEST( fd_ar_open( file ) );
-
-  fd_ar_t hdr;
-  FD_TEST( !fd_ar_next( file, &hdr ) );
-  FD_TEST( errno==ENOENT );
-
-  FD_TEST( 0==fclose( file ) );
+  FD_TEST( !fd_ar_read_init( file ) );
+  fd_ar_meta_t meta[1];
+  FD_TEST( fd_ar_read_next( file, meta )==ENOENT );
+  FD_TEST( !fclose( file ) );
 }
 
 /* test_invalid_ar_magic: Refuse to open files that are clearly not AR */
-void
-test_invalid_ar_magic( void ) {
-  char zeros[ 128 ] = {0};
 
-  FILE * file = fmemopen( (void *)zeros, sizeof(zeros), "rb" );
+static void
+test_invalid_ar_magic( void ) {
+  char buf[ 128 ];
+  FILE * file = fmemopen( fd_memset( buf, 0, 128UL ), 128UL, "rb" );
   FD_TEST( file );
-  FD_TEST( !fd_ar_open( file ) );
-  FD_TEST( errno==EPROTO );
-  FD_TEST( 0==fclose( file ) );
+  FD_TEST( fd_ar_read_init( file )==EPROTO );
+  FD_TEST( !fclose( file ) );
 }
 
 /* test_invalid_entry_magic: Abort stream on invalid file header magic */
-void
+
+static void
 test_invalid_entry_magic( void ) {
-  char zeros[ 128 ] = {
-    '!', '<', 'a', 'r', 'c', 'h', '>', '\n', /* archive header */
-    0, /* file header expected */
-  };
-
-  FILE * file = fmemopen( (void *)zeros, sizeof(zeros), "rb" );
+  char buf[ 128 ];
+  FILE * file = fmemopen( fd_memcpy( fd_memset( buf, 0, 128UL ), "!<arch>\n", 8UL ), 128UL, "rb" );
   FD_TEST( file );
-  FD_TEST( fd_ar_open( file ) );
-
-  fd_ar_t hdr;
-  FD_TEST( !fd_ar_next( file, &hdr ) );
-  FD_TEST( errno==EPROTO );
-
-  FD_TEST( 0==fclose( file ) );
+  FD_TEST( !fd_ar_read_init( file ) );
+  fd_ar_meta_t meta[1];
+  FD_TEST( fd_ar_read_next( file, meta )==EPROTO );
+  FD_TEST( !fclose( file ) );
 }
 
 int
@@ -109,6 +95,20 @@ main( int     argc,
   test_invalid_entry_magic();
 
   FD_LOG_NOTICE(( "pass" ));
+
   fd_halt();
   return 0;
 }
+
+#else
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+  FD_LOG_NOTICE(( "skip: unit test requires FD_HAS_HOSTED" ));
+  fd_halt();
+  return 0;
+}
+
+#endif

--- a/src/util/fd_util.h
+++ b/src/util/fd_util.h
@@ -18,7 +18,7 @@
 
 /* Additional fd_util APIs that are not included by default */
 
-//#include "archive/fd_ar.h"
+//#include "archive/fd_ar.h" /* includes fd_util_base.h */
 //#include "net/fd_eth.h"    /* includes bits/fd_bits.h */
 //#include "net/fd_ip4.h"    /* includes bits/fd_bits.h */
 //#include "net/fd_pcap.h"   /* includes net/fd_eth.h */


### PR DESCRIPTION
Opening PR from @kbowers-jump 

-------------------

This started as a quick review of the code but ended up more extensive polishing:

- Eliminated a number of security issues due to underspecification of AR file parsing for meta data (e.g. all whitespace fields in a header causing strtol to run off the end, using negative values for things like file size to trigger weird behavior like infinite loops in archive file iterators).

- Generalized API to take error prone parsing (due to the above) out of user hands and support extending this to obvious variations on the ar file form without requiring users update their code.

- Generalized API to support non-hosted platforms (no need for stdio.h or stdlib.h or FILE abstractions to be a user of the API).

- Consistent handling of EOF condintions between open and init.

- Extensive documentation of the above.

- Other minor stylistic tweaks and cleanups.