### PR TITLE
codecov: disable status checks

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project: off
+    patch: off


### PR DESCRIPTION
The CodeCov CI integration currently marks PRs with ~0.01% coverage regression as failed. This is obviously nonsense and causes lots of false positives.
Disable CodeCov status checks for now until we have
time to implement more sensible PR requirements.