### PR TITLE
Preliminary macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *ATTIC*
 /build
+/build_dir
 bin
 unit-test
 tmp
@@ -11,3 +12,5 @@ bazel-testlogs
 
 genhtml/
 target/
+
+settings.json

--- a/config/everything.mk
+++ b/config/everything.mk
@@ -6,7 +6,7 @@ MAKEFLAGS += --no-builtin-variables
 .SECONDARY:
 .SECONDEXPANSION:
 
-BASEDIR:=build
+BASEDIR:=build_dir
 OBJDIR:=$(BASEDIR)/$(BUILDDIR)
 
 all: bin include lib unit-test
@@ -174,7 +174,7 @@ $(OBJDIR)/obj/%.d : src/%.c
 	# Generating dependencies for C source $< to $@
 	#######################################################################
 	$(MKDIR) $(dir $@) && \
-$(CC) $(CPPFLAGS) $(CFLAGS) -M -MP $< -o $@.tmp && \
+$(CC) $(CPPFLAGS) $(CFLAGS) -M $< -o $@.tmp && \
 $(SED) 's,\($(notdir $*)\)\.o[ :]*,$(OBJDIR)/obj/$*.o $(OBJDIR)/obj/$*.S $(OBJDIR)/obj/$*.i $@ : ,g' < $@.tmp > $@ && \
 $(RM) $@.tmp
 
@@ -183,7 +183,7 @@ $(OBJDIR)/obj/%.d : src/%.cxx
 	# Generating dependencies for C++ source $< to $@
 	#######################################################################
 	$(MKDIR) $(dir $@) && \
-$(CXX) $(CPPFLAGS) $(CXXFLAGS) -M -MP $< -o $@.tmp && \
+$(CXX) $(CPPFLAGS) $(CXXFLAGS) -M $< -o $@.tmp && \
 $(SED) 's,\($(notdir $*)\)\.o[ :]*,$(OBJDIR)/obj/$*.o $(OBJDIR)/obj/$*.S $(OBJDIR)/obj/$*.i $@ : ,g' < $@.tmp > $@ && \
 $(RM) $@.tmp
 
@@ -300,4 +300,3 @@ ppp: $(DEPFILES:.d=.i)
 endif
 endif
 endif
-

--- a/config/macos_clang_arm64.mk
+++ b/config/macos_clang_arm64.mk
@@ -1,0 +1,23 @@
+BUILDDIR:=macos/clang/x86_64
+
+include config/base.mk
+include config/with-clang.mk
+include config/with-debug.mk
+include config/with-brutality.mk
+include config/with-optimization.mk
+include config/with-threads.mk
+
+# Clang sadly doesn't support important optimizations.  This practically
+# limits clang usage to code hygenine usage for the time being.  Here,
+# ideally would do:
+#
+# -falign-functions=32 -falign-jumps=32 -falign-labels=32 -falign-loops=32
+# -mbranch-cost=5
+
+CPPFLAGS+=-fomit-frame-pointer -march=native -mtune=skylake \
+	  -DFD_HAS_INT128=1 -DFD_HAS_DOUBLE=1 -DFD_HAS_ALLOCA=1 -DFD_HAS_X86=1
+
+FD_HAS_INT128:=1
+FD_HAS_DOUBLE:=1
+FD_HAS_ALLOCA:=1
+FD_HAS_X86:=1

--- a/config/macos_clang_x86_64.mk
+++ b/config/macos_clang_x86_64.mk
@@ -1,0 +1,25 @@
+BUILDDIR:=macos/clang/x86_64
+
+include config/base.mk
+include config/with-clang.mk
+include config/with-debug.mk
+include config/with-brutality.mk
+include config/with-optimization.mk
+include config/with-threads.mk
+
+# Clang sadly doesn't support important optimizations.  This practically
+# limits clang usage to code hygenine usage for the time being.  Here,
+# ideally would do:
+#
+# -falign-functions=32 -falign-jumps=32 -falign-labels=32 -falign-loops=32
+# -mbranch-cost=5
+
+CPPFLAGS+=-fomit-frame-pointer -march=haswell -mtune=skylake -mfpmath=sse \
+	  -DFD_HAS_INT128=1 -DFD_HAS_DOUBLE=1 -DFD_HAS_ALLOCA=1 -DFD_HAS_X86=1 -DFD_HAS_SSE=1 -DFD_HAS_AVX=1
+
+FD_HAS_INT128:=1
+FD_HAS_DOUBLE:=1
+FD_HAS_ALLOCA:=1
+FD_HAS_X86:=1
+FD_HAS_SSE:=1
+FD_HAS_AVX:=1

--- a/src/app/frank/fd_frank_init
+++ b/src/app/frank/fd_frank_init
@@ -18,8 +18,6 @@ shift 4
 CONF=tmp/$APP.cfg
 
 WKSP=$APP.wksp
-WKSP_PAGE_CNT=2
-WKSP_PAGE_SZ=gigantic
 WKSP_PERM=0600
 
 POD_SZ=16384
@@ -32,6 +30,38 @@ VERIFY_MTU=1542   # FIXME: recalibrate (probably smaller for today, larger for l
 DEDUP_TCACHE_DEPTH=4194302
 DEDUP_TCACHE_MAP_CNT=0
 DEDUP_DEPTH=$VERIFY_DEPTH
+
+# Set a sensible default for page size depending on OS and architecture platform in use;
+# Linux x64: gigantic
+# macOS x64 Intel: huge (superpages)
+# macOS ARM (M1/M2): normal
+UNAME_OUTPUT=`uname -a`
+if [[ "$UNAME_OUTPUT" == "Linux"* ]] && [[ "$UNAME_OUTPUT" == *"x86_64"* ]]; then
+  PLATFORM_DEFAULT_WKSP_PAGE_SZ=gigantic
+elif [[ "$UNAME_OUTPUT" == *"Darwin"* ]] && [[ "$UNAME_OUTPUT" == *"x86_64"* ]]; then
+  PLATFORM_DEFAULT_WKSP_PAGE_SZ=huge
+elif [[ "$UNAME_OUTPUT" == *"Darwin"* ]] && [[ "$UNAME_OUTPUT" == *"arm64"* ]]; then
+  PLATFORM_DEFAULT_WKSP_PAGE_SZ=normal
+else
+  echo "Firedancer is not supported on this platform"
+  exit 1
+fi
+
+# Allow override of platform's default page size via the FD_WKSP_PAGE_SIZE environment variable.
+WKSP_PAGE_SZ=${FD_WKSP_PAGE_SIZE:-$PLATFORM_DEFAULT_WKSP_PAGE_SZ}
+
+if [ "$WKSP_PAGE_SZ" != "huge" ] && [ "$WKSP_PAGE_SZ" == "gigantic" ] && [ "$WKSP_PAGE_SZ" == "normal" ]; then
+  echo "fd_frank_init $1 $2 $3 $4: fail, invalid page size for FD_WKSP_PAGE_SIZE"
+  exit 1
+fi
+
+if [[ "$WKSP_PAGE_SZ" == "gigantic" ]]; then
+  WKSP_PAGE_CNT=2
+elif [[ "$WKSP_PAGE_SZ" == "huge" ]]; then
+  WKSP_PAGE_CNT=500
+elif [[ "$WKSP_PAGE_SZ" == "normal" ]]; then
+  WKSP_PAGE_CNT=250000
+fi    
 
 #######################################################################
 
@@ -110,4 +140,3 @@ echo ""
 
 echo success
 exit 0
-

--- a/src/ballet/sha256/Local.mk
+++ b/src/ballet/sha256/Local.mk
@@ -1,7 +1,10 @@
 $(call add-hdrs,fd_sha256.h)
 $(call add-objs,fd_sha256,fd_ballet)
 ifdef FD_HAS_AVX
+UNAME := $(shell uname)
+ifneq ($(UNAME), Darwin)
 $(call add-asms,fd_sha256_core_shaext,fd_ballet)
+endif
 endif
 
 $(call make-unit-test,test_sha256,test_sha256,fd_ballet fd_util)

--- a/src/ballet/sha256/fd_sha256.c
+++ b/src/ballet/sha256/fd_sha256.c
@@ -97,7 +97,7 @@ fd_sha256_delete( void * shsha ) {
 }
 
 #ifndef FD_SHA256_CORE_IMPL
-#if FD_HAS_AVX
+#if FD_HAS_AVX && !__APPLE__
 #define FD_SHA256_CORE_IMPL 1
 #else
 #define FD_SHA256_CORE_IMPL 0

--- a/src/ballet/sha512/Local.mk
+++ b/src/ballet/sha512/Local.mk
@@ -1,8 +1,10 @@
 $(call add-hdrs,fd_sha512.h)
 $(call add-objs,fd_sha512,fd_ballet)
 ifdef FD_HAS_AVX
+UNAME := $(shell uname)
+ifneq ($(UNAME), Darwin)
 $(call add-asms,fd_sha512_core_avx2,fd_ballet)
+endif
 endif
 
 $(call make-unit-test,test_sha512,test_sha512,fd_ballet fd_util)
-

--- a/src/ballet/sha512/fd_sha512.c
+++ b/src/ballet/sha512/fd_sha512.c
@@ -97,7 +97,7 @@ fd_sha512_delete( void * shsha ) {
 }
 
 #ifndef FD_SHA512_CORE_IMPL
-#if FD_HAS_AVX
+#if FD_HAS_AVX && !__APPLE__
 #define FD_SHA512_CORE_IMPL 1
 #else
 #define FD_SHA512_CORE_IMPL 0

--- a/src/disco/dedup/fd_dedup_tile.c
+++ b/src/disco/dedup/fd_dedup_tile.c
@@ -11,15 +11,16 @@ main( int     argc,
 
   FD_LOG_NOTICE(( "Init" ));
 
-  char const * _cnc        = fd_env_strip_cmdline_cstr ( &argc, &argv, "--cnc",        NULL, NULL );
-  char const * _in_mcaches = fd_env_strip_cmdline_cstr ( &argc, &argv, "--in-mcaches", NULL, ""   );
-  char const * _in_fseqs   = fd_env_strip_cmdline_cstr ( &argc, &argv, "--in-fseqs",   NULL, ""   );
-  char const * _tcache     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--tcache",     NULL, NULL );
-  char const * _mcache     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--mcache",     NULL, NULL );
-  char const * _out_fseqs  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--out-fseqs",  NULL, ""   );
-  ulong        cr_max      = fd_env_strip_cmdline_ulong( &argc, &argv, "--cr-max",     NULL, 0UL  ); /*   0 <> use default */
-  long         lazy        = fd_env_strip_cmdline_long ( &argc, &argv, "--lazy",       NULL, 0L   ); /* <=0 <> use default */
-  uint         seed        = fd_env_strip_cmdline_uint ( &argc, &argv, "--seed",       NULL, (uint)(ulong)fd_tickcount() );
+  char const * _cnc              = fd_env_strip_cmdline_cstr ( &argc, &argv, "--cnc",        NULL, NULL );
+  char const * _in_mcaches       = fd_env_strip_cmdline_cstr ( &argc, &argv, "--in-mcaches", NULL, ""   );
+  char const * _in_fseqs         = fd_env_strip_cmdline_cstr ( &argc, &argv, "--in-fseqs",   NULL, ""   );
+  char const * _tcache           = fd_env_strip_cmdline_cstr ( &argc, &argv, "--tcache",     NULL, NULL );
+  char const * _mcache           = fd_env_strip_cmdline_cstr ( &argc, &argv, "--mcache",     NULL, NULL );
+  char const * _out_fseqs        = fd_env_strip_cmdline_cstr ( &argc, &argv, "--out-fseqs",  NULL, ""   );
+  char const * _use_normal_pages = fd_env_strip_cmdline_cstr ( &argc, &argv, "--use-normal-pages", "FD_USE_NORMAL_PAGES", NULL );
+  ulong        cr_max            = fd_env_strip_cmdline_ulong( &argc, &argv, "--cr-max",     NULL, 0UL  ); /*   0 <> use default */
+  long         lazy              = fd_env_strip_cmdline_long ( &argc, &argv, "--lazy",       NULL, 0L   ); /* <=0 <> use default */
+  uint         seed              = fd_env_strip_cmdline_uint ( &argc, &argv, "--seed",       NULL, (uint)(ulong)fd_tickcount() );
 
   if( FD_UNLIKELY( !_cnc ) ) FD_LOG_ERR(( "--cnc not specified" ));
   FD_LOG_NOTICE(( "Joining --cnc %s", _cnc ));
@@ -78,7 +79,7 @@ main( int     argc,
   FD_LOG_NOTICE(( "Creating scratch" ));
   ulong footprint = fd_dedup_tile_scratch_footprint( in_cnt, out_cnt );
   if( FD_UNLIKELY( !footprint ) ) FD_LOG_ERR(( "fd_dedup_tile_scratch_footprint failed" ));
-  ulong  page_sz  = FD_SHMEM_HUGE_PAGE_SZ;
+  ulong  page_sz  = _use_normal_pages ? FD_SHMEM_NORMAL_PAGE_SZ : FD_SHMEM_HUGE_PAGE_SZ;  // default huge pages
   ulong  page_cnt = fd_ulong_align_up( footprint, page_sz ) / page_sz;
   ulong  cpu_idx  = fd_tile_cpu_id( fd_tile_idx() );
   void * scratch  = fd_shmem_acquire( page_sz, page_cnt, cpu_idx );

--- a/src/disco/mux/fd_mux_tile.c
+++ b/src/disco/mux/fd_mux_tile.c
@@ -11,14 +11,15 @@ main( int     argc,
 
   FD_LOG_NOTICE(( "Init" ));
 
-  char const * _cnc        = fd_env_strip_cmdline_cstr ( &argc, &argv, "--cnc",        NULL, NULL );
-  char const * _in_mcaches = fd_env_strip_cmdline_cstr ( &argc, &argv, "--in-mcaches", NULL, ""   );
-  char const * _in_fseqs   = fd_env_strip_cmdline_cstr ( &argc, &argv, "--in-fseqs",   NULL, ""   );
-  char const * _mcache     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--mcache",     NULL, NULL );
-  char const * _out_fseqs  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--out-fseqs",  NULL, ""   );
-  ulong        cr_max      = fd_env_strip_cmdline_ulong( &argc, &argv, "--cr-max",     NULL, 0UL  ); /*   0 <> use default */
-  long         lazy        = fd_env_strip_cmdline_long ( &argc, &argv, "--lazy",       NULL, 0L   ); /* <=0 <> use default */
-  uint         seed        = fd_env_strip_cmdline_uint ( &argc, &argv, "--seed",       NULL, (uint)(ulong)fd_tickcount() );
+  char const * _cnc             = fd_env_strip_cmdline_cstr ( &argc, &argv, "--cnc",        NULL, NULL );
+  char const * _in_mcaches      = fd_env_strip_cmdline_cstr ( &argc, &argv, "--in-mcaches", NULL, ""   );
+  char const * _in_fseqs        = fd_env_strip_cmdline_cstr ( &argc, &argv, "--in-fseqs",   NULL, ""   );
+  char const * _mcache          = fd_env_strip_cmdline_cstr ( &argc, &argv, "--mcache",     NULL, NULL );
+  char const * _out_fseqs       = fd_env_strip_cmdline_cstr ( &argc, &argv, "--out-fseqs",  NULL, ""   );
+  char const *_use_normal_pages = fd_env_strip_cmdline_cstr(&argc, &argv, "--use-normal-pages", "FD_USE_NORMAL_PAGES", NULL);
+  ulong        cr_max           = fd_env_strip_cmdline_ulong( &argc, &argv, "--cr-max",     NULL, 0UL  ); /*   0 <> use default */
+  long         lazy             = fd_env_strip_cmdline_long ( &argc, &argv, "--lazy",       NULL, 0L   ); /* <=0 <> use default */
+  uint         seed             = fd_env_strip_cmdline_uint ( &argc, &argv, "--seed",       NULL, (uint)(ulong)fd_tickcount() );
 
   if( FD_UNLIKELY( !_cnc ) ) FD_LOG_ERR(( "--cnc not specified" ));
   FD_LOG_NOTICE(( "Joining --cnc %s", _cnc ));
@@ -72,7 +73,7 @@ main( int     argc,
   FD_LOG_NOTICE(( "Creating scratch" ));
   ulong footprint = fd_mux_tile_scratch_footprint( in_cnt, out_cnt );
   if( FD_UNLIKELY( !footprint ) ) FD_LOG_ERR(( "fd_mux_tile_scratch_footprint failed" ));
-  ulong  page_sz  = FD_SHMEM_HUGE_PAGE_SZ;
+  ulong page_sz = _use_normal_pages ? FD_SHMEM_NORMAL_PAGE_SZ : FD_SHMEM_HUGE_PAGE_SZ; // default huge pages
   ulong  page_cnt = fd_ulong_align_up( footprint, page_sz ) / page_sz;
   ulong  cpu_idx  = fd_tile_cpu_id( fd_tile_idx() );
   void * scratch  = fd_shmem_acquire( page_sz, page_cnt, cpu_idx );

--- a/src/disco/mux/test_mux_ipc_full
+++ b/src/disco/mux/test_mux_ipc_full
@@ -20,6 +20,17 @@ fi
 FD_LOG_PATH=""
 export FD_LOG_PATH
 
+if [ -z "$FD_USE_NORMAL_PAGES" ]; then 
+  export FD_USE_NORMAL_PAGES=1;
+fi
+
+UNAME_OUTPUT=`uname -a`
+if [[ "$UNAME_OUTPUT" == "Linux"* ]]; then
+  TASKSET="taskset -c $CORE_NEXT "
+else
+  TASKSET=""
+fi
+
 tx_cnt=$1
 rx_cnt=$2
 shift 2
@@ -56,19 +67,19 @@ CORE_NEXT=$CORE_FIRST
 # Start up the receivers
 
 for((rx_idx=0;rx_idx<rx_cnt;rx_idx++)); do
-  taskset -c $CORE_NEXT $UNIT_TEST/test_frag_rx --tile-cpus $CORE_NEXT --cnc ${RX_CNC[rx_idx]} --mcache ${MUX_MCACHE[0]} --wksp $WKSP --fseq ${RX_FSEQ[rx_idx]} &
+  $(envsubst <<< $TASKSET) $UNIT_TEST/test_frag_rx --tile-cpus $CORE_NEXT --cnc ${RX_CNC[rx_idx]} --mcache ${MUX_MCACHE[0]} --wksp $WKSP --fseq ${RX_FSEQ[rx_idx]} &
   CORE_NEXT=$((CORE_NEXT+NUMA_STRIDE))
 done
 
 # Start up the mux
 
-taskset -c $CORE_NEXT $BIN/fd_mux_tile --tile-cpus $CORE_NEXT --cnc ${MUX_CNC[0]} --mcache ${MUX_MCACHE[0]} --in-mcaches ${IN_MCACHES} --in-fseqs ${IN_FSEQS} --out-fseqs ${OUT_FSEQS} &
+$(envsubst <<< $TASKSET) $BIN/fd_mux_tile --tile-cpus $CORE_NEXT --cnc ${MUX_CNC[0]} --mcache ${MUX_MCACHE[0]} --in-mcaches ${IN_MCACHES} --in-fseqs ${IN_FSEQS} --out-fseqs ${OUT_FSEQS} &
 CORE_NEXT=$((CORE_NEXT+NUMA_STRIDE))
 
 # Start up the transmitters
 
 for((tx_idx=0;tx_idx<tx_cnt;tx_idx++)); do
-  taskset -c $CORE_NEXT $UNIT_TEST/test_frag_tx --tile-cpus $CORE_NEXT --cnc ${TX_CNC[tx_idx]} --mcache ${TX_MCACHE[tx_idx]} --dcache ${TX_DCACHE[tx_idx]} --fseqs ${TX_FSEQ[tx_idx]} --tx-idx $tx_idx $* &
+  $(envsubst <<< $TASKSET) $UNIT_TEST/test_frag_tx --tile-cpus $CORE_NEXT --cnc ${TX_CNC[tx_idx]} --mcache ${TX_MCACHE[tx_idx]} --dcache ${TX_DCACHE[tx_idx]} --fseqs ${TX_FSEQ[tx_idx]} --tx-idx $tx_idx $* &
   CORE_NEXT=$((CORE_NEXT+NUMA_STRIDE))
 done
 

--- a/src/disco/mux/test_mux_ipc_init
+++ b/src/disco/mux/test_mux_ipc_init
@@ -3,8 +3,6 @@
 NUMA_IDX=0
 
 WKSP=test_mux_ipc
-WKSP_CNT=1
-WKSP_PAGE=gigantic
 
 TX_MAX=16
 MUX_MAX=1
@@ -18,6 +16,15 @@ MUX_DEPTH=32768
 APP_SZ=4032
 
 CONF=tmp/test_mux_ipc.conf
+
+WKSP_PAGE=${FD_PAGE_SIZE:-gigantic}
+if [[ "$WKSP_PAGE" == "gigantic" ]]; then
+  WKSP_CNT=1
+elif [[ "$WKSP_PAGE" == "huge" ]]; then
+  WKSP_CNT=500
+elif [[ "$WKSP_PAGE" == "normal" ]]; then
+  WKSP_CNT=250000
+fi
 
 ########################################################################
 

--- a/src/disco/mux/test_mux_ipc_meta
+++ b/src/disco/mux/test_mux_ipc_meta
@@ -20,6 +20,10 @@ fi
 FD_LOG_PATH=""
 export FD_LOG_PATH
 
+if [ -z "$FD_USE_NORMAL_PAGES" ]; then 
+  export FD_USE_NORMAL_PAGES=1;
+fi
+
 tx_cnt=$1
 rx_cnt=$2
 shift 2
@@ -56,19 +60,19 @@ CORE_NEXT=$CORE_FIRST
 # Start up the receivers
 
 for((rx_idx=0;rx_idx<rx_cnt;rx_idx++)); do
-  taskset -c $CORE_NEXT $UNIT_TEST/test_meta_rx --tile-cpus $CORE_NEXT --cnc ${RX_CNC[rx_idx]} --mcache ${MUX_MCACHE[0]} --fseq ${RX_FSEQ[rx_idx]} &
+  $(envsubst <<< $TASKSET) $UNIT_TEST/test_meta_rx --tile-cpus $CORE_NEXT --cnc ${RX_CNC[rx_idx]} --mcache ${MUX_MCACHE[0]} --fseq ${RX_FSEQ[rx_idx]} &
   CORE_NEXT=$((CORE_NEXT+NUMA_STRIDE))
 done
 
 # Start up the mux
 
-taskset -c $CORE_NEXT $BIN/fd_mux_tile --tile-cpus $CORE_NEXT --cnc ${MUX_CNC[0]} --mcache ${MUX_MCACHE[0]} --in-mcaches ${IN_MCACHES} --in-fseqs ${IN_FSEQS} --out-fseqs ${OUT_FSEQS} &
+$(envsubst <<< $TASKSET) $BIN/fd_mux_tile --tile-cpus $CORE_NEXT --cnc ${MUX_CNC[0]} --mcache ${MUX_MCACHE[0]} --in-mcaches ${IN_MCACHES} --in-fseqs ${IN_FSEQS} --out-fseqs ${OUT_FSEQS} &
 CORE_NEXT=$((CORE_NEXT+NUMA_STRIDE))
 
 # Start up the transmitters
 
 for((tx_idx=0;tx_idx<tx_cnt;tx_idx++)); do
-  taskset -c $CORE_NEXT $UNIT_TEST/test_meta_tx --tile-cpus $CORE_NEXT --cnc ${TX_CNC[tx_idx]} --mcache ${TX_MCACHE[tx_idx]} --fseqs ${TX_FSEQ[tx_idx]} --tx-idx $tx_idx $* &
+  $(envsubst <<< $TASKSET) $UNIT_TEST/test_meta_tx --tile-cpus $CORE_NEXT --cnc ${TX_CNC[tx_idx]} --mcache ${TX_MCACHE[tx_idx]} --fseqs ${TX_FSEQ[tx_idx]} --tx-idx $tx_idx $* &
   CORE_NEXT=$((CORE_NEXT+NUMA_STRIDE))
 done
 

--- a/src/disco/replay/fd_replay_tile.c
+++ b/src/disco/replay/fd_replay_tile.c
@@ -11,16 +11,17 @@ main( int     argc,
 
   FD_LOG_NOTICE(( "Init" ));
 
-  char const * _cnc       = fd_env_strip_cmdline_cstr ( &argc, &argv, "--cnc",       NULL, NULL   );
-  char const * _pcap      = fd_env_strip_cmdline_cstr ( &argc, &argv, "--pcap",      NULL, NULL   );
-  ulong        pkt_max    = fd_env_strip_cmdline_ulong( &argc, &argv, "--pkt-max",   NULL, 1522UL );
-  ulong        orig       = fd_env_strip_cmdline_ulong( &argc, &argv, "--orig",      NULL, 0UL    );
-  char const * _mcache    = fd_env_strip_cmdline_cstr ( &argc, &argv, "--mcache",    NULL, NULL   );
-  char const * _dcache    = fd_env_strip_cmdline_cstr ( &argc, &argv, "--dcache",    NULL, NULL   );
-  char const * _out_fseqs = fd_env_strip_cmdline_cstr ( &argc, &argv, "--out-fseqs", NULL, ""     );
-  ulong        cr_max     = fd_env_strip_cmdline_ulong( &argc, &argv, "--cr-max",    NULL, 0UL    ); /*   0 <> use default */
-  long         lazy       = fd_env_strip_cmdline_long ( &argc, &argv, "--lazy",      NULL, 0L     ); /* <=0 <> use default */
-  uint         seed       = fd_env_strip_cmdline_uint ( &argc, &argv, "--seed",      NULL, (uint)(ulong)fd_tickcount() );
+  char const * _cnc             = fd_env_strip_cmdline_cstr ( &argc, &argv, "--cnc",       NULL, NULL   );
+  char const * _pcap            = fd_env_strip_cmdline_cstr ( &argc, &argv, "--pcap",      NULL, NULL   );
+  ulong        pkt_max          = fd_env_strip_cmdline_ulong( &argc, &argv, "--pkt-max",   NULL, 1522UL );
+  ulong        orig             = fd_env_strip_cmdline_ulong( &argc, &argv, "--orig",      NULL, 0UL    );
+  char const * _mcache          = fd_env_strip_cmdline_cstr ( &argc, &argv, "--mcache",    NULL, NULL   );
+  char const * _dcache          = fd_env_strip_cmdline_cstr ( &argc, &argv, "--dcache",    NULL, NULL   );
+  char const * _out_fseqs       = fd_env_strip_cmdline_cstr ( &argc, &argv, "--out-fseqs", NULL, ""     );
+  char const *_use_normal_pages = fd_env_strip_cmdline_cstr(&argc, &argv, "--use-normal-pages", "FD_USE_NORMAL_PAGES", NULL);
+  ulong        cr_max           = fd_env_strip_cmdline_ulong( &argc, &argv, "--cr-max",    NULL, 0UL    ); /*   0 <> use default */
+  long         lazy             = fd_env_strip_cmdline_long ( &argc, &argv, "--lazy",      NULL, 0L     ); /* <=0 <> use default */
+  uint         seed             = fd_env_strip_cmdline_uint ( &argc, &argv, "--seed",      NULL, (uint)(ulong)fd_tickcount() );
 
   if( FD_UNLIKELY( !_cnc ) ) FD_LOG_ERR(( "--cnc not specified" ));
   FD_LOG_NOTICE(( "Joining --cnc %s", _cnc ));
@@ -60,7 +61,7 @@ main( int     argc,
   FD_LOG_NOTICE(( "Creating scratch" ));
   ulong footprint = fd_replay_tile_scratch_footprint( out_cnt );
   if( FD_UNLIKELY( !footprint ) ) FD_LOG_ERR(( "fd_replay_tile_scratch_footprint failed" ));
-  ulong  page_sz  = FD_SHMEM_HUGE_PAGE_SZ;
+  ulong page_sz = _use_normal_pages ? FD_SHMEM_NORMAL_PAGE_SZ : FD_SHMEM_HUGE_PAGE_SZ; // default huge pages
   ulong  page_cnt = fd_ulong_align_up( footprint, page_sz ) / page_sz;
   ulong  cpu_idx  = fd_tile_cpu_id( fd_tile_idx() );
   void * scratch  = fd_shmem_acquire( page_sz, page_cnt, cpu_idx );

--- a/src/tango/test_ipc_full
+++ b/src/tango/test_ipc_full
@@ -20,6 +20,13 @@ fi
 FD_LOG_PATH=""
 export FD_LOG_PATH
 
+UNAME_OUTPUT=`uname -a`
+if [[ "$UNAME_OUTPUT" == "Linux"* ]]; then
+  TASKSET="taskset -c $CORE_NEXT "
+else
+  TASKSET=""
+fi
+
 rx_cnt=$1
 shift 1
 
@@ -44,13 +51,13 @@ CORE_NEXT=$CORE_FIRST
 # Start up the receivers
 
 for((rx_idx=0;rx_idx<rx_cnt;rx_idx++)); do
-  taskset -c $CORE_NEXT $UNIT_TEST/test_frag_rx --tile-cpus $CORE_NEXT --cnc ${RX_CNC[rx_idx]} --mcache ${TX_MCACHE[0]} --dcache ${TX_DCACHE[0]} --fseq ${RX_FSEQ[rx_idx]} &
+  $(envsubst <<< $TASKSET) $UNIT_TEST/test_frag_rx --tile-cpus $CORE_NEXT --cnc ${RX_CNC[rx_idx]} --mcache ${TX_MCACHE[0]} --dcache ${TX_DCACHE[0]} --fseq ${RX_FSEQ[rx_idx]} &
   CORE_NEXT=$((CORE_NEXT+NUMA_STRIDE))
 done
 
 # Start up the transmitter
 
-taskset -c $CORE_NEXT $UNIT_TEST/test_frag_tx --tile-cpus $CORE_NEXT --cnc ${TX_CNC[0]} --mcache ${TX_MCACHE[0]} --dcache ${TX_DCACHE[0]} --fseqs ${RX_FSEQS} $* &
+$(envsubst <<< $TASKSET) $UNIT_TEST/test_frag_tx --tile-cpus $CORE_NEXT --cnc ${TX_CNC[0]} --mcache ${TX_MCACHE[0]} --dcache ${TX_DCACHE[0]} --fseqs ${RX_FSEQS} $* &
 CORE_NEXT=$((CORE_NEXT+NUMA_STRIDE))
 
 # Let run for a while

--- a/src/tango/test_ipc_init
+++ b/src/tango/test_ipc_init
@@ -3,8 +3,6 @@
 NUMA_IDX=0
 
 WKSP=test_ipc
-WKSP_CNT=1
-WKSP_PAGE=gigantic
 
 TX_MAX=1
 RX_MAX=16
@@ -15,6 +13,15 @@ TX_MTU=1542
 APP_SZ=4032
 
 CONF=tmp/test_ipc.conf
+
+WKSP_PAGE=${FD_PAGE_SIZE:-gigantic}
+if [[ "$WKSP_PAGE" == "gigantic" ]]; then
+  WKSP_CNT=1
+elif [[ "$WKSP_PAGE" == "huge" ]]; then
+  WKSP_CNT=500
+elif [[ "$WKSP_PAGE" == "normal" ]]; then
+  WKSP_CNT=250000
+fi
 
 ########################################################################
 

--- a/src/tango/test_ipc_meta
+++ b/src/tango/test_ipc_meta
@@ -20,6 +20,13 @@ fi
 FD_LOG_PATH=""
 export FD_LOG_PATH
 
+UNAME_OUTPUT=`uname -a`
+if [[ "$UNAME_OUTPUT" == "Linux"* ]]; then
+  TASKSET="taskset -c $CORE_NEXT "
+else
+  TASKSET=""
+fi
+
 rx_cnt=$1
 shift 1
 
@@ -44,13 +51,13 @@ CORE_NEXT=$CORE_FIRST
 # Start up the receivers
 
 for((rx_idx=0;rx_idx<rx_cnt;rx_idx++)); do
-  taskset -c $CORE_NEXT $UNIT_TEST/test_meta_rx --tile-cpus $CORE_NEXT --cnc ${RX_CNC[rx_idx]} --mcache ${TX_MCACHE[0]} --fseq ${RX_FSEQ[rx_idx]} &
+  $(envsubst <<< $TASKSET) $UNIT_TEST/test_meta_rx --tile-cpus $CORE_NEXT --cnc ${RX_CNC[rx_idx]} --mcache ${TX_MCACHE[0]} --fseq ${RX_FSEQ[rx_idx]} &
   CORE_NEXT=$((CORE_NEXT+NUMA_STRIDE))
 done
 
 # Start up the transmitter
 
-taskset -c $CORE_NEXT $UNIT_TEST/test_meta_tx --tile-cpus $CORE_NEXT --cnc ${TX_CNC[0]} --mcache ${TX_MCACHE[0]} --fseqs ${RX_FSEQS} $* &
+$(envsubst <<< $TASKSET) $UNIT_TEST/test_meta_tx --tile-cpus $CORE_NEXT --cnc ${TX_CNC[0]} --mcache ${TX_MCACHE[0]} --fseqs ${RX_FSEQS} $* &
 CORE_NEXT=$((CORE_NEXT+NUMA_STRIDE))
 
 # Let run for a while

--- a/src/tango/test_tango_ctl
+++ b/src/tango/test_tango_ctl
@@ -15,15 +15,23 @@ BIN=$BUILD/bin
 # Specify test details
 
 WKSP=test_fd_tango_ctl.wksp
-PAGE_CNT=1
-PAGE_SZ=gigantic
 CPU_IDX=0
 MODE=0600
+
+PAGE_SZ=${FD_PAGE_SIZE:-gigantic}
+if [[ "$PAGE_SZ" == "gigantic" ]]; then
+  PAGE_CNT=1
+elif [[ "$PAGE_SZ" == "huge" ]]; then
+  PAGE_CNT=500
+elif [[ "$PAGE_SZ" == "normal" ]]; then
+  PAGE_CNT=250000
+fi
 
 # Disable the permanent log
 
 FD_LOG_PATH=""
 export FD_LOG_PATH
+
 
 echo Init
 

--- a/src/util/fd_util.c
+++ b/src/util/fd_util.c
@@ -1,8 +1,15 @@
 #include "fd_util.h"
+#include "tile/fd_tile.h"
 
 void
 fd_boot( int *    pargc,
          char *** pargv ) {
+
+  /* Parse command line option/env variable for using normal size pages (4k) if present,
+     and set a global variable accordingly. */
+  char const *use_normal_pages = fd_env_strip_cmdline_cstr(pargc, pargv, "--use-normal-pages", "FD_USE_NORMAL_PAGES", NULL);
+  if ( FD_LIKELY( use_normal_pages ) ) using_normal_pages = 1;
+
   /* At this point, we are immediately after the program start, there is
      only one thread of execution and fd has not yet been booted. */
   fd_log_private_boot  ( pargc, pargv );

--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -328,7 +328,7 @@ __extension__ typedef unsigned __int128 uint128;
 #endif
 
 /* FD_INCBIN: include binary file as rodata */
-
+#ifndef __APPLE__
 #define __FD_INCBIN(name, path, type, footer)  \
   extern type const name [];                   \
   extern uchar const name##_end;               \
@@ -348,6 +348,7 @@ __extension__ typedef unsigned __int128 uint128;
 #define FD_INCBIN(name, path) __FD_INCBIN(name, path, uchar, "")
 
 #define FD_INCBIN_STR(name, path) __FD_INCBIN(name, path, char, ".byte 0")
+#endif
 
 /* Optimizer tricks ***************************************************/
 

--- a/src/util/pod/test_pod_ctl
+++ b/src/util/pod/test_pod_ctl
@@ -20,6 +20,15 @@ PAGE_SZ=gigantic
 CPU_IDX=0
 MODE=0600
 
+PAGE_SZ=${FD_PAGE_SIZE:-gigantic}
+if [[ "$PAGE_SZ" == "gigantic" ]]; then
+  PAGE_CNT=1
+elif [[ "$PAGE_SZ" == "huge" ]]; then
+  PAGE_CNT=500
+elif [[ "$PAGE_SZ" == "normal" ]]; then
+  PAGE_CNT=250000
+fi
+
 # Disable the permanent log
 
 FD_LOG_PATH=""

--- a/src/util/shmem/fd_numa_darwin.inc
+++ b/src/util/shmem/fd_numa_darwin.inc
@@ -2,11 +2,24 @@
 #error "Do not compile this file directly"
 #endif
 
+#define _DARWIN_C_SOURCE
+
 #include <unistd.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <pthread.h>
+#include <mach/thread_policy.h>
+#include <mach/thread_act.h>
+#include <mach/mach_init.h>
+#include "../fd_util.h"
 
 /* NUMA API support for macOS (without the N).
 
    Assume there is only one NUMA node. */
+
+#define _SC_NPROCESSORS_CONF 57
+#define _SC_NPROCESSORS_ONLN 58
 
 int
 fd_numa_available( void ) {
@@ -21,12 +34,12 @@ fd_shmem_numa_cnt_private( void ) {
 int
 fd_shmem_cpu_cnt_private( void ) {
   /* Arm devices can turn off CPUs to save power */
-  return sysconf( _SC_NPROCESSORS_ONLN );
+  return (int)sysconf( _SC_NPROCESSORS_ONLN );
 }
 
 int
 fd_numa_cpu_max_cnt( void ) {
-  return sysconf( _SC_NPROCESSORS_CONF );
+  return (int)sysconf( _SC_NPROCESSORS_CONF );
 }
 
 int
@@ -34,4 +47,20 @@ fd_numa_node_of_cpu( int cpu_idx ) {
   if( FD_UNLIKELY( cpu_idx<0 || cpu_idx>fd_shmem_cpu_cnt_private() ) )
     return -ENOENT;
   return 0;
+}
+
+__attribute__((weak)) long
+move_pages( int pid,
+            ulong count,
+            void **pages,
+            int const *nodes,
+            int *status,
+            int flags ) {
+    (void)pid;
+    (void)count;
+    (void)pages;
+    (void)nodes;
+    (void)status;
+    (void)flags;
+    return 0;
 }

--- a/src/util/shmem/fd_shmem_cfg
+++ b/src/util/shmem/fd_shmem_cfg
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # Use FD_SHMEM_PATH from the environment if provided for hugetlbfs mount
 # path and fallback on "/mnt/.fd" if not
@@ -6,11 +6,6 @@
 SHMEM_PATH="${FD_SHMEM_PATH:-/mnt/.fd}"
 
 ALL_TYPES="gigantic huge normal"
-
-if ! [ -x "$(command -v hwloc-calc)" ]; then
-  echo "fd_shmem_cfg: command hwloc-calc not installed, please consult README for install instructions"
-  exit 1
-fi
 
 NUMA_CNT=`hwloc-calc -N numa machine:0 2> /dev/null`
 if [ "$NUMA_CNT" = "" ]; then # Handle boxes with no NUMA
@@ -97,10 +92,21 @@ init() {
       exit 1
     fi
 
-    if grep -q $MNT_PATH /proc/mounts; then
-      echo "init $1 $2 $3: fail, internal error, mount $MNT_PATH already exists"
-      exit 1
+    if [ "$IS_LINUX_X64" == "1" ]; then
+      if grep -q $MNT_PATH /proc/mounts; then
+        echo "init $1 $2 $3: fail, internal error, mount $MNT_PATH already exists"
+        exit 1
+      fi
+    elif [ "$IS_MAC_ARM64" == "1" ] || [ "$IS_MAC_X64" == "1" ]; then
+      mount > ./mount_points
+      if grep -q $MNT_PATH ./mount_points; then
+        echo "init $1 $2 $3: fail, internal error, mount $MNT_PATH already exists"
+        rm -rf mount_points
+        exit 1
+      fi
+      rm -rf mount_points
     fi
+
     # mount point is large enough to cover the number of whole pages of
     # system DRAM (in the proc/meminfo total memory sense) for maximum
     # flexibility.  Since the pages themselves are large, the number of
@@ -108,24 +114,46 @@ init() {
     # For normal pages, we need to use a tmpfs.
     try_defrag_memory 2> /dev/null > /dev/null
     if [ "$t" = "normal" ]; then
-      mount -v -t tmpfs tmpfs $MNT_PATH
+      if [ "$IS_LINUX_X64" == "1" ]; then
+        mount -v -t tmpfs tmpfs $MNT_PATH
+      elif [ "$IS_MAC_X64" == "1" ] || [ "$IS_MAC_ARM64" == "1" ]; then
+        mount_tmpfs $MNT_PATH
+      fi
       if [ "$?" != "0" ]; then
         echo "init $1 $2 $3: fail, mount failed"
         echo "Do $0 help for help"
         exit 1
       fi
     else
-      msz=`free -b | grep Mem | awk '{ print $2 }'` # FIXME: Ugly
+      # macOS on the M1 and M2 architectures currently doesn't support superpages, so exit here
+      # if we're running on either of these platforms.
+      if [ "$IS_MAC_ARM64" ]; then
+        echo "init $1 $2 $3: fail, macOS on ARM64 (M1/M2) does not support large pages (superpages)"
+        exit 1
+      fi
+
+      if [ "$IS_LINUX_X64" == "1" ]; then
+        msz=`free -b | grep Mem | awk '{ print $2 }'` # FIXME: Ugly
+      elif [ "$IS_MAC_X64" == "1" ] || [ "$IS_MAC_ARM64" == "1" ]; then
+        msz=`sysctl hw.memsize | awk '{ print $2 }'`
+      fi
       psz=`get_page_size $t`
       msz=$((psz*(msz/psz))) # Round down to whole pages to be on safe side
-      mount -v -t hugetlbfs -o pagesize=$psz,size=$msz none $MNT_PATH
+      if [ "$IS_LINUX_X64" == "1" ]; then
+        mount -v -t hugetlbfs -o pagesize=$psz,size=$msz none $MNT_PATH
+      elif [ "$IS_MAC_X64" == "1" ]; then
+        mount_tmpfs $MNT_PATH
+      fi
+
       if [ "$?" != "0" ]; then
         echo "init $1 $2 $3: fail, mount failed"
         echo "Do $0 help for help"
         exit 1
       fi
     fi
-    try_defrag_memory 2> /dev/null > /dev/null
+    if [ "$IS_LINUX_X64" == "1" ]; then
+      try_defrag_memory 2> /dev/null > /dev/null
+    fi
   done
 
   chown -v -R $SHMEM_USER:$SHMEM_GROUP $SHMEM_PATH
@@ -204,8 +232,25 @@ alloc() {
   TYPE=$2
   NUMA=$3
 
+  # Check for cases that do not require any explicit allocation; 'normal' on all platforms,
+  # and 'huge' (superpages) on macOS.
   if [ "$TYPE" = "normal" ]; then
     echo "alloc $1 $2 $3: fail, normal pages do not require explicit allocation"
+    echo "Do $0 help for help"
+    exit 1
+  elif [ "$IS_MAC_X64" == "1" ] && [ "$TYPE" == "huge" ]; then
+    echo "alloc $1 $2 $3: fail, superpages do not require explicit allocation on macOS"
+    echo "Do $0 help for help"
+    exit 1
+  fi
+
+  # Check for options that are unsupported on the target platform.
+  if [ "$IS_MAC_ARM64" == "1" ] && ([ "$TYPE" == "huge" ] || [ "$TYPE" == "gigantic" ]); then
+    echo "alloc $1 $2 $3: fail, macOS on ARM64 (M1/M2) does not support neither superpages (hugepages) nor gigantic pages"
+    echo "Do $0 help for help"
+    exit 1
+  elif [ "$IS_MAC_X64" == "1" ] && [ "$TYPE" == "gigantic" ]; then
+    echo "alloc $1 $2 $3: fail, macOS on x64 does not support gigantic pages"
     echo "Do $0 help for help"
     exit 1
   fi
@@ -266,6 +311,18 @@ reset() {
 if [ $# -lt 1 ]; then
   echo "Commands not specified"
   echo "Do $0 help for help"
+  exit 1
+fi
+
+UNAME_OUTPUT=`uname -a`
+if [[ "$UNAME_OUTPUT" == "Linux"* ]] && [[ "$UNAME_OUTPUT" == *"x86_64"* ]]; then
+  export IS_LINUX_X64=1
+elif [[ "$UNAME_OUTPUT" == *"Darwin"* ]] && [[ "$UNAME_OUTPUT" == *"x86_64"* ]]; then
+  export IS_MAC_X64=1
+elif [[ "$UNAME_OUTPUT" == *"Darwin"* ]] && [[ "$UNAME_OUTPUT" == *"arm64"* ]]; then
+  export IS_MAC_ARM64=1
+else
+  echo "Firedancer is not supported on this platform"
   exit 1
 fi
 

--- a/src/util/shmem/fd_shmem_private.h
+++ b/src/util/shmem/fd_shmem_private.h
@@ -49,7 +49,11 @@
 
    This macro implements option 2. */
 
+#ifdef __APPLE__
 #include <sys/syscall.h>
+#else
+#include <sys/syscall.h>
+#endif
 #define fd_mlock(...)   syscall( __NR_mlock,   __VA_ARGS__ )
 #define fd_munlock(...) syscall( __NR_munlock, __VA_ARGS__ )
 

--- a/src/util/shmem/fd_shmem_user.c
+++ b/src/util/shmem/fd_shmem_user.c
@@ -161,6 +161,9 @@ fd_shmem_join( char const *               name,
     return NULL;
   }
 
+  /* There doesn't seem to be a way to get superpages when mapping a file into memory
+     in macOS at this time, so skip this alignment check. */
+#ifndef __APPLE__
   if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, page_sz ) ) ) {
     if( FD_UNLIKELY( munmap( shmem, sz ) ) )
       FD_LOG_WARNING(( "munmap(\"%s\",%lu KiB) failed (%i-%s); attempting to continue", path, sz>>10, errno, strerror( errno ) ));
@@ -173,6 +176,7 @@ fd_shmem_join( char const *               name,
                      path, fd_shmem_private_base ));
     return NULL;
   }
+#endif
 
   /* Lock this region in DRAM to prevent it going to swap and (try) to
      keep the virtual to physical DRAM mapping fixed for the join
@@ -184,8 +188,12 @@ fd_shmem_join( char const *               name,
   if( FD_UNLIKELY( fd_mlock( shmem, sz ) ) )
     FD_LOG_WARNING(( "fd_mlock(\"%s\",%lu KiB) failed (%i-%s); attempting to continue", path, sz>>10, errno, strerror( errno ) ));
 
+  /* TODO: MADV_DONTDUMP not supported by macOS at this time.
+     Change this if future releases support this flag. */
+#ifndef __APPLE__
   if( FD_UNLIKELY( madvise( shmem, sz, MADV_DONTDUMP ) ) )
     FD_LOG_WARNING(( "madvise(\"%s\",%lu KiB) failed (%i-%s); attempting to continue", path, sz>>10, errno, strerror( errno ) ));
+#endif
 
   /* We have mapped the region.  Try to complete the join.  Note:
      map_query above and map_insert could be combined to improve

--- a/src/util/test_util_base.c
+++ b/src/util/test_util_base.c
@@ -109,7 +109,9 @@ FD_STATIC_ASSERT( !(((long )+1)/((long )-2)), devenv );
 FD_STATIC_ASSERT( !(((long )-1)/((long )-2)), devenv );
 
 /* Test binary includes by including this source file. (A quine!) */
+#ifndef __APPLE__
 FD_INCBIN_STR( incbin_src, __FILE__ );
+#endif
 
 int
 main( int     argc,
@@ -406,9 +408,10 @@ main( int     argc,
 # endif
 
   /* Test FD_INCBIN */
-
+#ifndef __APPLE__
   FD_TEST( !strncmp( incbin_src, "#include \"fd_util.h\"", 20 ) );
   FD_TEST( strlen( incbin_src )+1UL == incbin_src_sz() );
+#endif
 
   /* FIXME: ADD HASH QUALITY CHECKER HERE */
 

--- a/src/util/tile/fd_tile.h
+++ b/src/util/tile/fd_tile.h
@@ -22,6 +22,11 @@ typedef int (*fd_tile_task_t)( int argc, char ** argv );
 struct fd_tile_exec_private;
 typedef struct fd_tile_exec_private fd_tile_exec_t;
 
+/* Store config option for using normal pages for all memory allocations
+   instead of huge and gigantic page sizes. */
+   
+extern int using_normal_pages;
+
 FD_PROTOTYPES_BEGIN
 
 /* fd_tile_{id0,id1,id,idx,cnt} return various information about the

--- a/src/util/tile/fd_tile_thread_utils_mac.h
+++ b/src/util/tile/fd_tile_thread_utils_mac.h
@@ -1,0 +1,89 @@
+#define _DARWIN_C_SOURCE
+
+#include <unistd.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <pthread.h>
+#include <mach/thread_policy.h>
+#include <mach/thread_act.h>
+#include <mach/mach_init.h>
+#include "../fd_util.h"
+
+#define CPU_SETSIZE 32
+#define SYSCTL_CORE_COUNT   "machdep.cpu.core_count"
+
+kern_return_t
+thread_policy_set( thread_act_t thread, thread_policy_flavor_t flavor, thread_policy_t policy_info, mach_msg_type_number_t count );
+
+typedef struct cpu_set_t
+{
+    unsigned int count;
+} cpu_set_t;
+
+void
+CPU_ZERO( cpu_set_t *arg ) { arg->count = 0; }
+
+void
+CPU_SET( int cpu, cpu_set_t *arg ) { arg->count |= (1 << cpu); }
+
+unsigned int
+CPU_ISSET( size_t cpu, cpu_set_t *arg ) { return arg->count & (1 << cpu); }
+
+void
+CPU_CLR( size_t cpu, cpu_set_t *arg ) { arg->count = arg->count & ~(1 << cpu); }
+
+unsigned long 
+CPU_COUNT( cpu_set_t *set ) {
+    unsigned long i, count = 0;
+    for (i = 0; i < CPU_SETSIZE; i++)
+    {
+        if (CPU_ISSET(i, set))
+        {
+            count++;
+        }
+    }
+    return count;
+}
+
+int
+sched_getaffinity( pid_t pid, size_t cpu_size, cpu_set_t *cpu_set ) {
+  (void)pid;
+  (void)cpu_size;
+  int32_t core_count = 0;
+  size_t  len = sizeof(core_count);
+  int ret = sysctlbyname(SYSCTL_CORE_COUNT, &core_count, &len, 0, 0);
+  if (ret) {
+    return -1;
+  }
+  cpu_set->count = 0;
+  for (int i = 0; i < core_count; i++) {
+    cpu_set->count |= (1 << i);
+  }
+
+  return 0;
+}
+
+int
+sched_setaffinity( pid_t pid, size_t cpusetsize, cpu_set_t *set ) {
+    (void)pid;
+    (void)cpusetsize;
+
+    thread_affinity_policy_data_t policy;
+    policy.affinity_tag = (integer_t)(set->count + 1); /* non-null affinity tag */
+
+    thread_policy_set( mach_thread_self(), THREAD_AFFINITY_POLICY, (thread_policy_t)&policy, 1 );
+    return 0;
+}
+
+int
+pthread_setaffinity_mac( ulong cpu_idx ) {
+  thread_affinity_policy_data_t policy;
+  policy.affinity_tag = (integer_t)(cpu_idx + 1);
+
+  mach_port_t thread = pthread_mach_thread_np( pthread_self() );
+  thread_policy_set( thread, THREAD_AFFINITY_POLICY, (thread_policy_t)&policy, 1 );
+  /* Don't bother returning error status here; this is best effort, and fails on some Macs
+    (e.g. M1/M2). */
+  return 0;
+}


### PR DESCRIPTION
Preliminary support for macOS.

There some few important differences between Linux and macOS machines in the context of firedancer's architecture and implementation, with some of the most important being huge page support and CPU pinning.

I've attempted to work around these problems, and I'll follow up with some more details (likely tomorrow), but recent Mac systems (i.e. M1 and M2) do not appear to offer a userland interface for allocation of memory using large page sizes. macOS running on Intel hardware does support huge pages, but seemingly 2MB only. I've attempted to work around these problems, such as by allowing the use of normal sized pages.

I'm putting this up as a draft for your review and for requesting changes whenever you've had time to take a look :slight_smile:

