### PR TITLE
ci: add make build job

### DIFF
--- a/.github/workflows/make_build.yml
+++ b/.github/workflows/make_build.yml
@@ -1,0 +1,18 @@
+name: Make Build
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  make-build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install deps
+        run: sudo apt-get install -y libnuma-dev
+
+      - name: Build everything
+        run: make -j


### PR DESCRIPTION
Runs Make build on every commit.
CI currently only runs Bazel builds. Building with Make in CI too helps
ensure that there is no breakage to the Make config.

Blocked on #109 