### PR TITLE
ci: speed up testing, fix ulimits

### DIFF
--- a/.github/scripts/run-ulimit.sh
+++ b/.github/scripts/run-ulimit.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Runs the given command with increased capabilities.
+# Expects cwd to be the repository root.
+
+if [[ $# == 0 ]]
+then
+    >&2 echo "usage: run-ulimit.sh <arguments...>"
+    exit 1
+fi
+
+disable_pam_limits () {
+    cat <<EOF > /etc/security/limits.conf
+* hard memlock unlimited
+* hard nice -20
+* hard rtprio unlimited
+EOF
+}
+
+increase_ulimits () {
+    ulimit -H -m unlimited -l unlimited
+    ulimit -S -m unlimited -l unlimited
+}
+
+if [[ "$(id -u)" -ne "0" ]]
+then
+    # Recurse into else branch of this if statement.
+    exec sudo -i -- /usr/bin/env "$(realpath "$0")" "$PATH" "$PWD" "$@"
+else
+    # Use superuser privileges to increase ulimits
+    if [[ ! -z "$CI" ]]; then disable_pam_limits; fi
+    increase_ulimits
+    # We are the target of recursion. Drop privileges.
+    if [[ -z "$SUDO_USER" ]]; then
+        >&2 echo "run-ulimit.sh should be called via sudo -E"
+        exit 1
+    fi
+    prlimit
+    # Restore env from given args.
+    ORIG_PATH="$1"
+    ORIG_PWD="$2"
+    shift 2
+    # Dispatch new user login shell.
+    exec sudo -i -u "$SUDO_USER" -- /usr/bin/env "PATH=$ORIG_PATH" sh -c "cd $(printf "%q" "$ORIG_PWD") && $(printf "%q " "$@")"
+fi

--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -1,4 +1,4 @@
-name: Bazel Build
+name: Bazel Test
 on:
   pull_request:
   push:
@@ -23,4 +23,4 @@ jobs:
         run: bazel build //...
 
       - name: Test everything
-        run: bazel test //...
+        run: .github/scripts/run-ulimit.sh bazel test --test_output=errors //...

--- a/.github/workflows/bazel_coverage.yml
+++ b/.github/workflows/bazel_coverage.yml
@@ -1,4 +1,4 @@
-name: Bazel Test
+name: Bazel Coverage
 on:
   pull_request:
   push:
@@ -20,7 +20,7 @@ jobs:
           key: bazel-coverage-ubuntu-2204
 
       - name: Test with coverage
-        run: bazel coverage --test_output=errors //...
+        run: .github/scripts/run-ulimit.sh bazel coverage --test_output=errors //...
 
       - name: Create coverage report
         run: |


### PR DESCRIPTION
Currently, merges are blocked until tests with coverage succeed.
However, running coverage tests often takes over 15 minutes.

This change modifies the Bazel build job to also run tests without
coverage enabled.  The branch protection config can be adjusted to only
require tests without coverage, to allow merging before the (slower)
tests with coverage pass.
