### PR TITLE
firedancer-sys: fix "infinite symlink expansion detected" error

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -2,3 +2,4 @@ doc
 bazel-*
 genhtml
 .vscode
+ffi/rust/firedancer-sys/firedancer


### PR DESCRIPTION
Checking the `firedancer` symlink into git meant there was an infinite symlink chain, which causes problems with Bazel. To avoid this, we don't check the symlink into git but instead create it on-demand.