### PR TITLE
config: add minimal eBPF build environment

### DIFF
--- a/config/base.mk
+++ b/config/base.mk
@@ -16,3 +16,8 @@ RMDIR:=rm -rfv
 SED:=sed
 FIND:=find
 SCRUB:=$(FIND) . -type f -name "*~" -o -name "\#*" | xargs $(RM)
+
+EBPF_CC:=clang
+EBPF_CPPFLAGS:=-target bpf -O2 -g
+EBPF_CFLAGS:=-std=c17
+

--- a/config/everything.mk
+++ b/config/everything.mk
@@ -37,6 +37,7 @@ help:
 	# Explicit goals are: all bin include lib unit-test help clean distclean asm ppp
 	# "make all" is equivalent to "make bin include lib unit-test"
 	# "make bin" makes all binaries for the current platform
+	# "make ebpf-bin" makes all eBPF binaries
 	# "make include" makes all include files for the current platform
 	# "make lib" makes all libraries for the current platform
 	# "make unit-test" makes all unit-tests for the current platform
@@ -165,6 +166,28 @@ endef
 
 make-bin       = $(eval $(call _make-exe,$(1),$(2),$(3),bin))
 make-unit-test = $(eval $(call _make-exe,$(1),$(2),$(3),unit-test))
+
+##############################
+# Usage: $(call make-ebpf-bin,obj)
+
+# TODO support depfiles
+
+EBPF_BINDIR:=$(BASEDIR)/ebpf/clang/bin
+
+define _make-ebpf-bin
+
+$(EBPF_BINDIR)/$(1).o: $(MKPATH)$(1).c
+	#######################################################################
+	# Creating ebpf-bin $$@ from $$^
+	#######################################################################
+	$(MKDIR) $$(dir $$@) && \
+$(EBPF_CC) $(EBPF_CPPFLAGS) $(EBPF_CFLAGS) -c $$< -o $$@
+
+ebpf-bin: $(EBPF_BINDIR)/$(1).o
+
+endef
+
+make-ebpf-bin = $(eval $(call _make-ebpf-bin,$(1)))
 
 ##############################
 ## GENERIC RULES

--- a/src/net/ebpf/fd_ebpf_base.h
+++ b/src/net/ebpf/fd_ebpf_base.h
@@ -1,0 +1,41 @@
+#ifndef HEADER_fd_src_net_ebpf_fd_ebpf_base_h
+#define HEADER_fd_src_net_ebpf_fd_ebpf_base_h
+#if defined(__bpf__)
+
+/* eBPF base development environment
+
+   This file is a minimal port of fd_util_base.h to a non-hosted
+   Clang/LLVM eBPF little endian target.  This is a temporary measure
+   working around the fact that eBPF does not support libc yet, which is
+   a dependency of fd_util_base.  For documentations, see fd_util_base.h */
+
+/* Minimal libc-like environment **************************************/
+
+/* Not even the pre-processor definition is NULL is available on eBPF.
+   We define the bare minimum to resemble libc. */
+
+#define NULL (void *)0
+
+#define asm    __asm__
+#define typeof __typeof__
+
+/* Integer types ******************************************************/
+
+typedef   signed char  schar;
+typedef unsigned char  uchar;
+typedef unsigned short ushort;
+typedef unsigned int   uint;
+typedef unsigned long  ulong;
+
+/* Optimizer tricks ***************************************************/
+
+/* FD_{LIKELY,UNLIKELY}(c):  Evaluates c and returns whether it is
+   logical true/false as long (1L/0L).  It also hints to the optimizer
+   whether it should optimize for the case of c evaluating as
+   true/false. */
+
+#define FD_LIKELY(c)   __builtin_expect( !!(c), 1L )
+#define FD_UNLIKELY(c) __builtin_expect( !!(c), 0L )
+
+#endif /* defined(__bpf__) */
+#endif /* HEADER_fd_src_net_ebpf_fd_ebpf_base_h */


### PR DESCRIPTION
Adds fd_ebpf_base.h mocking fd_util_base.h to provide a minimal C
programming environment for eBPF targets like XDP.
