### PR TITLE
bazel: remove has_hosted

### DIFF
--- a/bazel/copts.bzl
+++ b/bazel/copts.bzl
@@ -107,10 +107,7 @@ def fd_copts():
     }) + select({
         "//bazel/cpu/x86_64:icelake_server": copts_icelake,
         "//conditions:default": [],
-    }) + select({
-        "//src:has_hosted": copts_hosted,
-        "//conditions:default": [],
-    }) + select({
+    }) + copts_hosted + select({
         "//src:has_threads": copts_threads,
         "//conditions:default": [],
     })

--- a/src/BUILD
+++ b/src/BUILD
@@ -38,16 +38,6 @@ config_setting(
 )
 
 config_setting(
-    name = "has_hosted",
-    constraint_values = [
-        "@platforms//os:linux",
-    ],
-    flag_values = {
-        "//:hosted": "True",
-    },
-)
-
-config_setting(
     name = "has_threads",
     constraint_values = [
         "@platforms//os:linux",

--- a/src/util/log/BUILD
+++ b/src/util/log/BUILD
@@ -10,10 +10,6 @@ fd_cc_library(
     hdrs = [
         "fd_log.h",
     ],
-    target_compatible_with = select({
-        "//src:has_hosted": [],
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
     deps = [
         "//src/util/bits",
         "//src/util/env",


### PR DESCRIPTION
The has_hosted build system feature is botched in its current form.
It should be removed to unblock work with Bazel and added back when Aspect/Leo can help me define appropriate target platforms.