### PR TITLE
config: remove with-libbpf.mk

### DIFF
--- a/config/linux_clang_x86_64.mk
+++ b/config/linux_clang_x86_64.mk
@@ -7,7 +7,6 @@ include config/with-debug.mk
 include config/with-brutality.mk
 include config/with-optimization.mk
 include config/with-threads.mk
-include config/with-libbpf.mk
 
 # Clang sadly doesn't support important optimizations.  This practically
 # limits clang usage to code hygenine usage for the time being.  Here,

--- a/config/linux_gcc_x86_64.mk
+++ b/config/linux_gcc_x86_64.mk
@@ -7,7 +7,6 @@ include config/with-debug.mk
 include config/with-brutality.mk
 include config/with-optimization.mk
 include config/with-threads.mk
-include config/with-libbpf.mk
 
 CPPFLAGS+=-fomit-frame-pointer -falign-functions=32 -falign-jumps=32 -falign-labels=32 -falign-loops=32 \
           -march=haswell -mtune=skylake -mfpmath=sse -mbranch-cost=5 \


### PR DESCRIPTION
Fixes regression from #136 
with-libbpf should not be enabled by default