### PR TITLE
Command line allocation tool, including allocation analysis ...

### DIFF
--- a/src/tango/fd_tango_ctl.c
+++ b/src/tango/fd_tango_ctl.c
@@ -6,6 +6,8 @@
 
 #include <stdio.h>
 
+FD_IMPORT_CSTR( fd_tango_ctl_help, "src/tango/fd_tango_ctl_help" );
+
 int
 main( int     argc,
       char ** argv ) {
@@ -27,107 +29,8 @@ main( int     argc,
 
     if( !strcmp( cmd, "help" ) ) {
 
-      /* FIXME: USE FD_IMPORT_CSTR FOR THIS */
-      FD_LOG_NOTICE(( "\n\t"
-        "Usage: %s [cmd] [cmd args] [cmd] [cmd args] ...\n\t"
-        "Commands are:\n\t"
-        "\n\t"
-        "\thelp\n\t"
-        "\t- Prints this message\n\t"
-        "\n\t"
-        "\ttag val\n\t"
-        "\t- Sets the tag for subsequent wksp allocations to val.\n\t"
-        "\t  Default is 1.\n\t"
-        "\n\t"
-        "\tnew-mcache wksp depth app-sz seq0\n\t"
-        "\t- Creates a frag meta cache in wksp with the given depth,\n\t"
-        "\t  application region size app-sz and initial sequence number\n\t"
-        "\t  seq0.  Prints the wksp gaddr of the mcache to stdout.\n\t"
-        "\n\t"
-        "\tdelete-mcache gaddr\n\t"
-        "\t- Destroys the mcache at gaddr.\n\t"
-        "\n\t"
-        "\tquery-mcache gaddr verbose\n\t"
-        "\t- Queries the mcache at gaddr.  If verbose is 0, prints seq to\n\t"
-        "\t  stdout.  Otherwise, prints a detailed query to stdout.\n\t"
-        "\n\t"
-        "\tnew-dcache wksp mtu depth burst compact app-sz\n\t"
-        "\t- Creates a frag data cache in wksp optimized for frag payloads\n\t"
-        "\t  up to mtu bytes in size where up to depth frags can be\n\t"
-        "\t  available to consumers while the producer can be concurrently\n\t"
-        "\t  preparing up to burst frags.  A non-zero compact indicates\n\t"
-        "\t  the producer will write frag payloads linearly and compactly\n\t"
-        "\t  outside wrap around and will not split frags to wrap around.\n\t"
-        "\t  A zero compact indicates the producer will partition the data\n\t"
-        "\t  region into depth+burst mtu friendly slots and store frag\n\t"
-        "\t  payloads into them (potentially in a non-linear order).\n\t"
-        "\t  Prints the wksp gaddr of the dcache to stdout.\n\t"
-        "\n\t"
-        "\tnew-dcache-raw wksp data-sz app-sz\n\t"
-        "\t- Creates a frag data cache in wksp with a data region size of\n\t"
-        "\t  data-sz and an application region size of app-sz.  Prints\n\t"
-        "\t  the wksp gaddr of the dcache to stdout.\n\t"
-        "\n\t"
-        "\tdelete-dcache gaddr\n\t"
-        "\t- Destroys the dcache at gaddr.\n\t"
-        "\n\t"
-        "\tquery-dcache gaddr verbose\n\t"
-        "\t- Queries the dcache at gaddr.  If verbose is 0, prints 0\n\t"
-        "\t  to stdout (implicitly verifying gaddr is a dcache).\n\t"
-        "\t  Otherwise, prints a detailed query to stdout.\n\t" 
-        "\n\t"
-        "\tnew-fseq wksp seq0\n\t"
-        "\t- Creates a flow control variable in wksp initialized to seq0.\n\t"
-        "\t  Prints the wksp gaddr of the created fseq to stdout.\n\t"
-        "\n\t"
-        "\tdelete-fseq gaddr\n\t"
-        "\t- Destroys the fseq at gaddr.\n\t"
-        "\n\t"
-        "\tquery-fseq gaddr verbose\n\t"
-        "\t- Queries the fseq at gaddr.  If verbose is 0, prints seq to\n\t"
-        "\t  stdout.  Otherwise, prints a detailed query to stdout.\n\t"
-        "\n\t"
-        "\tupdate-fseq gaddr seq\n\t"
-        "\t- Updates the flow control variable at gaddr to seq.\n\t"
-        "\n\t"
-        "\tnew-cnc wksp type now app-sz\n\t"
-        "\t- Creates a command and control variable with the given type,\n\t"
-        "\t  initial heartbeat of now and an application region size of\n\t"
-        "\t  app-sz.  Prints the wksp gaddr of the cnc to stdout.\n\t"
-        "\t- If now is '-', the wallclock will be used for the initial\n\t"
-        "\t  heartbeat value.  If now is 'tic', the tickcounter will be\n\t"
-        "\t  used for the initial heartbeat value.\n\t"
-        "\n\t"
-        "\tdelete-cnc gaddr\n\t"
-        "\t- Destroys the cnc at gaddr.\n\t"
-        "\n\t"
-        "\tquery-cnc gaddr verbose\n\t"
-        "\t- Queries the cnc at gaddr.  If verbose is 0, prints signal to\n\t"
-        "\t  stdout.  Otherwise, prints a detailed query to stdout.\n\t"
-        "\n\t"
-        "\tsignal-cnc gaddr sig\n\t"
-        "\t- Sends signal sig to cnc at gaddr and waits for the response.\n\t"
-        "\t- Assumes sig is a valid signal to send.  E.g. halt (3).\n\t"
-        "\t- Blocking waits for sig to be processed and prints the\n\t"
-        "\t  response to stdout.  Typical responses are:\n\t"
-        "\t    run  (0): thread resumed running\n\t"
-        "\t    boot (1): thread halted and can be safely restarted.\n\t"
-        "\t    fail (2): thread halted and cannot be safely restated.\n\t"
-        "\n\t"
-        "\tnew-tcache wksp depth map-cnt\n\t"
-        "\t- Creates a tag cache with the given depth and map-cnt.\n\t"
-        "\t  A map-cnt of zero indicates to use a reasonable default.\n\t"
-        "\t  Prints the wksp gaddr of the tcache to stdout.\n\t"
-        "\n\t"
-        "\tdelete-tcache gaddr\n\t"
-        "\t- Destroys the tcache at gaddr.\n\t"
-        "\n\t"
-        "\tquery-tcache gaddr verbose\n\t"
-        "\t- Queries the tcache at gaddr.  verbose is currently ignored.\n\t"
-        "\n\t"
-        "\treset-tcache gaddr\n\t"
-        "\t- Resets the tcache at gaddr.\n\t"
-        "", bin ));
+      fputs( fd_tango_ctl_help, stdout );
+
       FD_LOG_NOTICE(( "%i: %s: success", cnt, cmd ));
 
     } else if( !strcmp( cmd, "tag" ) ) {
@@ -827,7 +730,8 @@ main( int     argc,
     cnt++;
   }
 
-  FD_LOG_NOTICE(( "processed %i commands", cnt ));
+  if( FD_UNLIKELY( cnt<1 ) ) FD_LOG_NOTICE(( "processed %i commands\n\tDo %s help for help", cnt, bin ));
+  else                       FD_LOG_NOTICE(( "processed %i commands", cnt ));
 
 # undef SHIFT
   fd_halt();

--- a/src/tango/fd_tango_ctl_help
+++ b/src/tango/fd_tango_ctl_help
@@ -1,0 +1,98 @@
+
+Usage: fd_tango_ctl [cmd] [cmd args] [cmd] [cmd args] ...
+
+Commands are:
+
+help
+- Prints this message.
+
+tag val
+- Sets the tag for subsequent wksp allocations to val.  Default is 1.
+
+new-mcache wksp depth app-sz seq0
+- Creates a frag meta cache in wksp with the given depth, application
+  region size app-sz and initial sequence number seq0.  Prints the wksp
+  gaddr of the mcache to stdout.
+
+delete-mcache gaddr
+- Destroys the mcache at gaddr.
+
+query-mcache gaddr verbose
+- Queries the mcache at gaddr.  If verbose is 0, prints seq to stdout.
+  Otherwise, prints a detailed query to stdout.
+
+new-dcache wksp mtu depth burst compact app-sz
+- Creates a frag data cache in wksp optimized for frag payloads up to
+  mtu bytes in size where up to depth frags can be available to
+  consumers while the producer can be concurrently preparing up to burst
+  frags.  A non-zero compact indicates the producer will write frag
+  payloads linearly and compactly outside wrap around and will not split
+  frags to wrap around.  A zero compact indicates the producer will
+  partition the data region into depth+burst mtu friendly slots and
+  store frag payloads into them (potentially in a non-linear order).
+  Prints the wksp gaddr of the dcache to stdout.
+
+new-dcache-raw wksp data-sz app-sz
+- Creates a frag data cache in wksp with a data region size of data-sz
+  and an application region size of app-sz.  Prints the wksp gaddr of
+  the dcache to stdout.
+
+delete-dcache gaddr
+- Destroys the dcache at gaddr.
+
+query-dcache gaddr verbose
+- Queries the dcache at gaddr.  If verbose is 0, prints 0 to stdout
+  (implicitly verifying gaddr is a dcache).  Otherwise, prints a
+  detailed query to stdout.
+
+new-fseq wksp seq0
+- Creates a flow control variable in wksp initialized to seq0.  Prints
+  the wksp gaddr of the created fseq to stdout.
+
+delete-fseq gaddr
+- Destroys the fseq at gaddr.
+
+query-fseq gaddr verbose
+- Queries the fseq at gaddr.  If verbose is 0, prints seq to stdout.
+  Otherwise, prints a detailed query to stdout.
+
+update-fseq gaddr seq
+- Updates the flow control variable at gaddr to seq.
+
+new-cnc wksp type now app-sz
+- Creates a command and control variable with the given type, initial
+  heartbeat of now and an application region size of app-sz.  Prints the
+  wksp gaddr of the cnc to stdout.  If now is '-', the wallclock will be
+  used for the initial heartbeat value.  If now is 'tic', the
+  tickcounter will be used for the initial heartbeat value.
+
+delete-cnc gaddr
+- Destroys the cnc at gaddr.
+
+query-cnc gaddr verbose
+- Queries the cnc at gaddr.  If verbose is 0, prints signal to stdout.
+  Otherwise, prints a detailed query to stdout.
+
+signal-cnc gaddr sig
+- Sends signal sig to cnc at gaddr and waits for the response.  Assumes
+  sig is a valid signal to send, e.g. halt (3).  Blocking waits for sig
+  to be processed and prints the response to stdout.  Typical responses
+  are:
+    run  (0): thread resumed running
+    boot (1): thread halted and can be safely restarted.
+    fail (2): thread halted and cannot be safely restated.
+
+new-tcache wksp depth map-cnt
+- Creates a tag cache with the given depth and map-cnt.  A map-cnt of
+  zero indicates to use a reasonable default.  Prints the wksp gaddr of
+  the tcache to stdout.
+
+delete-tcache gaddr
+- Destroys the tcache at gaddr.
+
+query-tcache gaddr verbose
+- Queries the tcache at gaddr.  verbose is currently ignored.
+
+reset-tcache gaddr
+- Resets the tcache at gaddr.
+

--- a/src/util/alloc/Local.mk
+++ b/src/util/alloc/Local.mk
@@ -1,4 +1,6 @@
 $(call add-objs,fd_alloc,fd_util)
 $(call add-hdrs,fd_alloc.h)
+$(call make-bin,fd_alloc_ctl,fd_alloc_ctl,fd_util)
 $(call make-unit-test,test_alloc,test_alloc,fd_util)
+$(call add-test-scripts,test_alloc_ctl)
 

--- a/src/util/alloc/fd_alloc.h
+++ b/src/util/alloc/fd_alloc.h
@@ -235,13 +235,17 @@ fd_alloc_leave( fd_alloc_t * join );
 void *
 fd_alloc_delete( void * shalloc );
 
-/* FIXME: CONSIDER API FOR GETTING WKSP BACKING FD_ALLOC? */
+/* fd_alloc_wksp returns a pointer to a local wksp join of the wksp
+   backing the fd_alloc with the current local join.  Caller should not
+   call fd_alloc_leave on the returned value.  Lifetime of the returned
+   wksp handle is as long as the shalloc used on the fd_alloc_join is
+   still mapped into the caller's address space.
 
-/* fd_alloc_tag returns the tag that will be used for allocations from
-   this workspace.  Will be in [0,FD_WKSP_ALLOC_TAG_MAX].  0 indicates
-   join was NULL. */
+   fd_alloc_tag returns the tag that will be used for allocations from
+   this workspace. */
 
-FD_FN_PURE ulong fd_alloc_tag( fd_alloc_t * join );
+FD_FN_PURE fd_wksp_t * fd_alloc_wksp( fd_alloc_t * join ); // NULL indicates NULL join
+FD_FN_PURE ulong       fd_alloc_tag ( fd_alloc_t * join ); // In [0,FD_WKSP_ALLOC_TAG_MAX].  0 indicates NULL join
 
 /* fd_alloc_malloc allocates sz bytes with alignment align from the wksp
    backing the fd_alloc.  join is a current local join to the fd_alloc.

--- a/src/util/alloc/fd_alloc_ctl.c
+++ b/src/util/alloc/fd_alloc_ctl.c
@@ -1,0 +1,214 @@
+#include "../fd_util.h"
+#include "../wksp/fd_wksp_private.h"
+
+#if FD_HAS_HOSTED && FD_HAS_X86
+
+#include <stdio.h>
+
+FD_IMPORT_CSTR( fd_alloc_ctl_help, "src/util/alloc/fd_alloc_ctl_help" );
+
+int
+fd_alloc_fprintf( fd_alloc_t * join,
+                  FILE *       stream );
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+# define SHIFT(n) argv+=(n),argc-=(n)
+
+  if( FD_UNLIKELY( argc<1 ) ) FD_LOG_ERR(( "no arguments" ));
+  char const * bin = argv[0];
+  SHIFT(1);
+
+  ulong tag = 1UL;
+
+  int cnt = 0;
+  while( argc ) {
+    char const * cmd = argv[0];
+    SHIFT(1);
+
+    if( !strcmp( cmd, "help" ) ) {
+
+      fputs( fd_alloc_ctl_help, stdout );
+
+      FD_LOG_NOTICE(( "%i: %s: success", cnt, cmd ));
+
+    } else if( !strcmp( cmd, "tag" ) ) {
+
+      if( FD_UNLIKELY( argc<1 ) ) FD_LOG_ERR(( "%i: %s: too few arguments\n\tDo %s help for help", cnt, cmd, bin ));
+
+      tag = fd_cstr_to_ulong( argv[0] );
+
+      FD_LOG_NOTICE(( "%i: %s %lu: success", cnt, cmd, tag ));
+      SHIFT(1);
+
+    } else if( !strcmp( cmd, "new" ) ) {
+
+      if( FD_UNLIKELY( argc<2 ) ) FD_LOG_ERR(( "%i: %s: too few arguments\n\tDo %s help for help", cnt, cmd, bin ));
+
+      char const * name     =                   argv[0];
+      ulong        wksp_tag = fd_cstr_to_ulong( argv[1] );
+
+      ulong align     = fd_alloc_align();
+      ulong footprint = fd_alloc_footprint();
+
+      fd_wksp_t * wksp = fd_wksp_attach( name ); /* logs details */
+      if( FD_UNLIKELY( !wksp ) ) FD_LOG_ERR(( "%i: %s: fd_wksp_attach( \"%s\" ) failed", cnt, cmd, name ));
+
+      ulong gaddr = fd_wksp_alloc( wksp, align, footprint, wksp_tag );
+      if( FD_UNLIKELY( !gaddr ) )
+        FD_LOG_ERR(( "%i: %s: fd_wksp_alloc(\"%s\",%lu,%lu,%lu) failed", cnt, cmd, name, align, footprint, wksp_tag ));
+
+      void * shmem = fd_wksp_laddr_fast( wksp, gaddr );
+      if( FD_UNLIKELY( !fd_alloc_new( shmem, wksp_tag ) ) ) /* logs details */
+        FD_LOG_ERR(( "%i: %s: fd_alloc_new(\"%s\",%lu) failed", cnt, cmd, name, wksp_tag ));
+
+      char cstr[ FD_WKSP_CSTR_MAX ];
+      printf( "%s\n", fd_wksp_cstr( wksp, gaddr, cstr ) );
+
+      fd_wksp_detach( wksp ); /* logs details */
+
+      FD_LOG_NOTICE(( "%i: %s %s %lu: success", cnt, cmd, name, wksp_tag ));
+      SHIFT(2);
+
+    } else if( !strcmp( cmd, "delete" ) ) {
+
+      if( FD_UNLIKELY( argc<2 ) ) FD_LOG_ERR(( "%i: %s: too few arguments\n\tDo %s help for help", cnt, cmd, bin ));
+
+      char const * cstr            =                 argv[0];
+      int          garbage_collect = fd_cstr_to_int( argv[1] );
+
+      void * shalloc = fd_wksp_map( cstr );
+      if( FD_UNLIKELY( !shalloc ) ) FD_LOG_ERR(( "%i: %s: fd_wksp_map(\"%s\") failed", cnt, cmd, cstr ));
+
+      fd_alloc_t * alloc = fd_alloc_join( shalloc, 0UL /* d/c */ );
+      if( FD_UNLIKELY( !alloc ) ) FD_LOG_ERR(( "%i: %s: fd_alloc_join(\"%s\",0UL) failed", cnt, cmd, cstr ));
+
+      fd_wksp_t * wksp     = fd_alloc_wksp( shalloc );
+      ulong       wksp_tag = fd_alloc_tag ( alloc   );
+
+      fd_alloc_delete( fd_alloc_leave( alloc ) ); /* logs details */
+
+      if( garbage_collect ) fd_wksp_tag_free( wksp, wksp_tag ); /* logs details */
+
+      fd_wksp_unmap( shalloc ); /* logs details */
+
+      FD_LOG_NOTICE(( "%i: %s %s %i: success", cnt, cmd, cstr, garbage_collect ));
+      SHIFT(2);
+
+    } else if( !strcmp( cmd, "malloc" ) ) {
+
+      if( FD_UNLIKELY( argc<4 ) ) FD_LOG_ERR(( "%i: %s: too few arguments\n\tDo %s help for help", cnt, cmd, bin ));
+
+      char const * cstr       =                   argv[0];
+      ulong        cgroup_idx = fd_cstr_to_ulong( argv[1] );
+      ulong        align      = fd_cstr_to_ulong( argv[2] );
+      ulong        sz         = fd_cstr_to_ulong( argv[3] );
+
+      void * shalloc = fd_wksp_map( cstr );
+      if( FD_UNLIKELY( !shalloc ) ) FD_LOG_ERR(( "%i: %s: fd_wksp_map(\"%s\") failed", cnt, cmd, cstr ));
+
+      fd_alloc_t * alloc = fd_alloc_join( shalloc, cgroup_idx );
+      if( FD_UNLIKELY( !alloc ) ) FD_LOG_ERR(( "%i: %s: fd_alloc_join(\"%s\",%lu) failed", cnt, cmd, cstr, cgroup_idx ));
+
+      fd_wksp_t * wksp  = fd_alloc_wksp( alloc );
+      void *      laddr = fd_alloc_malloc( alloc, align, sz );
+
+      char buf[ FD_WKSP_CSTR_MAX ];
+      if(      FD_LIKELY( laddr ) ) printf( "%s\n", fd_wksp_cstr( wksp, fd_wksp_gaddr_fast( wksp, laddr ), buf ) );
+      else if( FD_LIKELY( !sz   ) ) printf( "%s\n", fd_wksp_cstr( wksp, 0UL,                               buf ) );
+      else                          FD_LOG_ERR(( "%i: %s: fd_alloc_malloc(\"%s\":%lu,%lu,%lu) failed",
+                                                 cnt, cmd, cstr, cgroup_idx, align, sz ));
+
+      fd_wksp_unmap( fd_alloc_leave( alloc ) ); /* logs details */
+
+      FD_LOG_NOTICE(( "%i: %s %s %lu %lu %lu: success", cnt, cmd, cstr, cgroup_idx, align, sz ));
+      SHIFT(4);
+
+    } else if( !strcmp( cmd, "free" ) ) {
+
+      if( FD_UNLIKELY( argc<3 ) ) FD_LOG_ERR(( "%i: %s: too few arguments\n\tDo %s help for help", cnt, cmd, bin ));
+
+      char const * cstr       =                   argv[0];
+      ulong        cgroup_idx = fd_cstr_to_ulong( argv[1] );
+      char const * name_gaddr =                   argv[2];
+
+      void * laddr = fd_wksp_map( name_gaddr ); /* logs details */
+      if( FD_LIKELY( laddr ) ) {
+        void * shalloc = fd_wksp_map( cstr ); /* logs details */
+        if( FD_LIKELY( shalloc ) ) {
+          fd_alloc_t * alloc = fd_alloc_join( shalloc, cgroup_idx ); /* logs details */
+          if( FD_LIKELY( alloc ) ) {
+            if( FD_LIKELY( fd_wksp_containing( laddr )==fd_alloc_wksp( alloc ) ) ) fd_alloc_free( alloc, laddr );
+            else FD_LOG_WARNING(( "%i: %s: alloc %s was not used for %s", cnt, cmd, cstr, name_gaddr ));
+            fd_alloc_leave( alloc ); /* logs details */
+          }
+          fd_wksp_unmap( shalloc ); /* logs details */
+        }
+        fd_wksp_unmap( laddr ); /* logs details */
+      }
+
+      FD_LOG_NOTICE(( "%i: %s %s %lu %s: success", cnt, cmd, cstr, cgroup_idx, name_gaddr ));
+      SHIFT(3);
+
+    } else if( !strcmp( cmd, "query" ) ) {
+
+      if( FD_UNLIKELY( argc<2 ) ) FD_LOG_ERR(( "%i: %s: too few arguments\n\tDo %s help for help", cnt, cmd, bin ));
+
+      char const * what = argv[0];
+      char const * cstr = argv[1];
+
+      void *       shmem = NULL;
+      fd_alloc_t * alloc = NULL;
+      int          err   = -1;
+
+      shmem = fd_wksp_map( cstr );
+      if( FD_LIKELY( shmem ) ) {
+        alloc = fd_alloc_join( shmem, 0UL /* d/c */ );
+        if( FD_LIKELY( alloc ) ) err = 0;
+      }
+
+      if(      !strcmp( what, "test" ) ) printf( "%i\n", err );
+      else if( !strcmp( what, "tag"  ) ) printf( "%lu\n", FD_UNLIKELY( err ) ? 0UL : fd_alloc_tag( alloc ) );
+      else if( !strcmp( what, "full" ) ) fd_alloc_fprintf( alloc, stdout );
+      else                               FD_LOG_ERR(( "unknown query %s", what ));
+
+      if( FD_LIKELY( alloc ) ) fd_alloc_leave( alloc );
+      if( FD_LIKELY( shmem ) ) fd_wksp_unmap( shmem );
+
+      FD_LOG_NOTICE(( "%i: %s %s %s: success", cnt, cmd, what, cstr ));
+      SHIFT(2);
+
+    } else {
+
+      FD_LOG_ERR(( "%i: %s: unknown command\n\t"
+                   "Do %s help for help", cnt, cmd, bin ));
+
+    }
+    cnt++;
+  }
+
+  if( FD_UNLIKELY( cnt<1 ) ) FD_LOG_NOTICE(( "processed %i commands\n\tDo %s help for help", cnt, bin ));
+  else                       FD_LOG_NOTICE(( "processed %i commands", cnt ));
+
+# undef SHIFT
+  fd_halt();
+  return 0;
+}
+
+#else
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+  if( FD_UNLIKELY( argc<1 ) ) FD_LOG_ERR(( "No arguments" ));
+  if( FD_UNLIKELY( argc>1 ) ) FD_LOG_ERR(( "fd_alloc_ctl not supported on this platform" ));
+  FD_LOG_NOTICE(( "processed 0 commands" ));
+  fd_halt();
+  return 0;
+}
+
+#endif
+

--- a/src/util/alloc/fd_alloc_ctl_help
+++ b/src/util/alloc/fd_alloc_ctl_help
@@ -1,0 +1,51 @@
+
+Usage: fd_alloc_ctl [cmd] [cmd args] [cmd] [cmd args] ...
+
+Commands are:
+
+help
+- Prints this message.
+
+tag val
+- Sets the tag for subsequent wksp allocations to val.  Default is 1.
+
+new wksp wksp_tag
+- Create an alloc backed by wksp.  All wksp allocation done by this
+  alloc will be tagged with wksp_tag and all alloc backed by this wksp
+  should use a unique wksp_tag.  The wksp allocation for alloc itself
+  will be tagged with the tag set above, not wksp_tag, but  wksp_tag and
+  the above tag can be the same if desired.  Prints the new alloc's wksp
+  gaddr to stdout on success.
+
+delete alloc_gaddr garbage_collect
+- Delete the alloc at alloc_gaddr.  If garbage_collect is a non-zero
+  integer, this will also free any allocations done through this alloc
+  that have not yet been freed.  Otherwise, it will keep those
+  allocations around in the workspace (the user can still later clean
+  them doing a tag-free with the allocator's wksp_tag).  Technically
+  speaking, this always succeeds (logs any weirdness detected).
+
+malloc alloc_gaddr cgroup_idx align sz
+- Uses the alloc at alloc_gaddr to allocate sz bytes with alignment
+  align.  The alignment will be hinted to optimize for concurrency group
+  cgroup_idx.  Prints the malloc's wksp gaddr to stdout on success.
+
+free alloc_gaddr cgroup_idx malloc_gaddr
+- Frees the malloc whose first byte is pointed to by malloc_gaddr.
+  The malloc should have been done by the alloc at alloc_gaddr.  The
+  free will be hinted to optimize this memory for future reuse by
+  concurrency group cgroup_idx.  Technically speaking, this always
+  succeeds (logs any weirdness detected).
+
+query what alloc_gaddr
+- Query alloc at alloc_gaddr.  The "what" determines what will be
+  printed to stdout:
+
+    what \ alloc | exists              | does not exist
+    -------------+---------------------+----------------------
+    test         | 0                   | error code (negative)
+    tag          | wksp_tag (positive) | 0
+
+  Technically speaking, this always succeeds (logs any weirdness
+  detected).
+

--- a/src/util/alloc/test_alloc.c
+++ b/src/util/alloc/test_alloc.c
@@ -165,8 +165,8 @@ main( int     argc,
   fd_alloc_t * alloc = fd_alloc_join( shalloc, 0UL ); FD_TEST( alloc );
   FD_TEST( fd_alloc_leave( alloc )==shalloc );
 
-  FD_TEST( fd_alloc_tag( NULL  )==0UL );
-  FD_TEST( fd_alloc_tag( alloc )==tag );
+  FD_TEST( fd_alloc_wksp( NULL  )==NULL ); FD_TEST( fd_alloc_tag( NULL  )==0UL );
+  FD_TEST( fd_alloc_wksp( alloc )==wksp ); FD_TEST( fd_alloc_tag( alloc )==tag );
 
   FD_LOG_NOTICE(( "Running torture test with --alloc-cnt %lu, --align-max %lu, --sz-max %lu on %lu tile(s)",
                   alloc_cnt, align_max, sz_max, tile_cnt ));

--- a/src/util/alloc/test_alloc_ctl
+++ b/src/util/alloc/test_alloc_ctl
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+fail() {
+  echo FAIL: $1 unexpected exit code $2
+  echo Log N/A
+  exit 1
+}
+
+# Determine location of binaries
+
+UNIT_TEST=$(dirname -- "$BASH_SOURCE")
+BUILD=$(dirname -- "$UNIT_TEST")
+BIN=$BUILD/bin
+
+# Specify test details
+
+WKSP=test_fd_alloc_ctl.wksp
+PAGE_CNT=1
+PAGE_SZ=gigantic
+CPU_IDX=0
+MODE=0600
+
+TAG_META=1234
+TAG_ALLOC=2345
+
+# Disable the permanent log
+
+FD_LOG_PATH=""
+export FD_LOG_PATH
+
+# Try to clean up any leftovers from previous runs (including same name on multiple pages)
+
+$BIN/fd_wksp_ctl delete $WKSP delete $WKSP delete $WKSP > /dev/null 2>&1
+
+# Create the wksp that will be used by the alloc
+
+$BIN/fd_wksp_ctl new $WKSP $PAGE_CNT $PAGE_SZ $CPU_IDX $MODE || fail wksp $?
+
+echo Testing no-op
+
+$BIN/fd_alloc_ctl || fail no-op $?
+
+echo Testing unknown
+
+$BIN/fd_alloc_ctl unknown && fail unknown $?
+
+echo Testing help
+
+$BIN/fd_alloc_ctl help || fail help $?
+
+echo Testing tag
+
+$BIN/fd_alloc_ctl tag   && fail tag $?
+$BIN/fd_alloc_ctl tag 1 || fail tag $?
+
+echo Testing new
+
+$BIN/fd_alloc_ctl new                     && fail new $?
+$BIN/fd_alloc_ctl new $WKSP               && fail new $?
+$BIN/fd_alloc_ctl new bad/name $TAG_ALLOC && fail new $?
+$BIN/fd_alloc_ctl new $WKSP    0          && fail new $?
+ALLOC=$($BIN/fd_alloc_ctl tag $TAG_META new $WKSP $TAG_ALLOC || fail new $?)
+
+echo Testing query
+
+$BIN/fd_alloc_ctl query                 && fail query $?
+$BIN/fd_alloc_ctl query test            && fail query $?
+$BIN/fd_alloc_ctl query bad/what $ALLOC && fail query $?
+$BIN/fd_alloc_ctl query test $ALLOC query test bad/name \
+                  query tag  $ALLOC query tag  bad/name \
+|| fail query $?
+
+echo Testing alloc
+
+$BIN/fd_alloc_ctl malloc                   && fail alloc $?
+$BIN/fd_alloc_ctl malloc $ALLOC            && fail alloc $?
+$BIN/fd_alloc_ctl malloc bad/name  0  1  1 && fail alloc $?
+$BIN/fd_alloc_ctl malloc $ALLOC   -1  1  1 && fail alloc $?
+$BIN/fd_alloc_ctl malloc $ALLOC    0 -1  1 && fail alloc $?
+$BIN/fd_alloc_ctl malloc $ALLOC    0  1 -1 && fail alloc $?
+
+GADDR0=$($BIN/fd_alloc_ctl malloc $ALLOC 3 0  8 || fail alloc $?)
+GADDR1=$($BIN/fd_alloc_ctl malloc $ALLOC 5 1  9 || fail alloc $?)
+GADDR2=$($BIN/fd_alloc_ctl malloc $ALLOC 6 2 10 || fail alloc $?)
+GADDR3=$($BIN/fd_alloc_ctl malloc $ALLOC 7 4  0 || fail alloc $?)
+
+echo Testing free
+
+$BIN/fd_alloc_ctl free                      && fail free $?
+$BIN/fd_alloc_ctl free $ALLOC               && fail free $?
+$BIN/fd_alloc_ctl free $ALLOC    3          && fail free $?
+$BIN/fd_alloc_ctl free bad/name  3 $GADDR0  \
+                  free $ALLOC   -1 $GADDR0  \
+                  free $ALLOC    3 bad/name \
+                  free $ALLOC    3 $GADDR0  \
+                  free $ALLOC    5 $GADDR1  \
+                  free $ALLOC    6 $GADDR2  \
+                  free $ALLOC    7 $GADDR3  \
+|| fail alloc $?
+
+echo Testing delete
+
+$BIN/fd_alloc_ctl delete            && fail query $?
+$BIN/fd_alloc_ctl delete $ALLOC     && fail query $?
+$BIN/fd_alloc_ctl delete bad/name 0 && fail query $?
+$BIN/fd_alloc_ctl delete $ALLOC   0 || fail query $?
+$BIN/fd_alloc_ctl delete $ALLOC   0 && fail query $?
+
+ALLOC=$($BIN/fd_alloc_ctl tag $TAG_META new $WKSP $TAG_ALLOC || fail new $?)
+$BIN/fd_alloc_ctl delete $ALLOC   1 || fail query $?
+$BIN/fd_alloc_ctl delete $ALLOC   1 && fail query $?
+
+echo Log N/A
+echo pass
+exit 0
+

--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -371,7 +371,31 @@ __extension__ typedef unsigned __int128 uint128;
      extern ulong const name_sz;
 
    as necessary (that is, do the usual to use name and name_sz as shown
-   for the pseudo code above). */
+   for the pseudo code above).
+
+   Important safety tip!  gcc -M will generally not detect the
+   dependency this creates between the importing file and the imported
+   file.  This can cause incremental builds to miss changes to the
+   imported file.  Ideally, we would have FD_IMPORT automatically do
+   something like:
+
+     _Pragma( "GCC dependency \"" path "\" )
+
+   This doesn't work as is because _Pragma needs some macro expansion
+   hacks to accept this (this is doable).  After that workaround, this
+   still doesn't work because, due to tooling limitations, the pragma
+   path is relative to the source file directory and the FD_IMPORT path
+   is relative to the the make directory (working around this would
+   require a __FILE__-like directive for the source code directory base
+   path).  Even if that did exist, it might still not work because
+   out-of-tree builds often require some substitions to the gcc -M
+   generated dependencies that this might not pick up (at least not
+   without some build system surgery).  And then it still wouldn't work
+   because gcc -M seems to ignore all of this anyways (which is the
+   actual show stopper as this pragma does something subtly different
+   than what the name suggests and there isn't any obvious support for a
+   "pseudo-include".)  Another reminder that make clean and fast builds
+   are our friend. */
 
 #define FD_IMPORT( name, path, type, align, footer )         \
   __asm__( ".section .rodata,\"a\",@progbits\n"              \

--- a/src/util/pod/fd_pod_ctl.c
+++ b/src/util/pod/fd_pod_ctl.c
@@ -6,6 +6,8 @@
 #include <stdlib.h>
 #include <ctype.h>
 
+FD_IMPORT_CSTR( fd_pod_ctl_help, "src/util/pod/fd_pod_ctl_help" );
+
 static int
 supported_val_type( int val_type ) {
   return (val_type==FD_POD_VAL_TYPE_CSTR  ) | (val_type==FD_POD_VAL_TYPE_CHAR  )
@@ -184,113 +186,8 @@ main( int     argc,
 
     if( !strcmp( cmd, "help" ) ) {
 
-      /* FIXME: USE FD_IMPORT_CSTR FOR THIS */
-      FD_LOG_NOTICE(( "\n\t"
-        "Usage: %s [cmd] [cmd args] [cmd] [cmd args] ...\n\t"
-        "Commands are:\n\t"
-        "\n\t"
-        "\thelp\n\t"
-        "\t- Prints this message\n\t"
-        "\n\t"
-        "\ttag val\n\t"
-        "\t- Sets the tag for subsequent wksp allocations to val.\n\t"
-        "\t  Default is 1.\n\t"
-        "\n\t"
-        "\tnew wksp max\n\t"
-        "\t- Create a pod in wksp with a maximum size of max.  Prints the\n\t"
-        "\t  wksp cstr address of the (empty) pod to stdout on success.\n\t"
-        "\t  0 indicates to use a default of 4KiB.\n\t"
-        "\n\t"
-        "\tdelete pod\n\t"
-        "\t- Delete the pod at wksp cstr address pod.\n\t"
-        "\n\t"
-        "\treset pod\n\t"
-        "\t- Reset the pod at wksp cstr address pod.\n\t"
-        "\n\t"
-        "\tlist pod\n\t"
-        "\t- Lists (recursively) the contents of the pod at wksp cstr\n\t"
-        "\t  address pod to stdout.\n\t"
-        "\n\t"
-        "\tinsert pod type path val\n\t"
-        "\t- Inserts type into the pod at path with value val\n\t"
-        "\t- Fails if path already exists in the pod.\n\t"
-        "\t- Might change the locations of existing values in the pod\n\t"
-        "\n\t"
-        "\tremove pod path\n\t"
-        "\t- Remove the path (and any path.*) from the pod\n\t"
-        "\t- Fails if path does not already exist in the pod.\n\t"
-        "\t- Might change the locations of existing values in the pod\n\t"
-        "\n\t"
-        "\tupdate pod type path val\n\t"
-        "\t- Update path to val (failing if path to type does not already\n\t"
-        "\t  exist).  Specifically, in pseudocode:\n\t"
-        "\t    t = query type pod path  # check if path to type exists\n\t"
-        "\t    if t!=type, fail         # no\n\t"
-        "\t    remove pod path          # remove old val\n\t"
-        "\t    insert pod type path val # insert new val\n\t"
-        "\t- In the implementation currently, if the insert fails, the\n\t"
-        "\t  original value will be lost.\n\t"
-        "\t- Might change the locations of existing values in the pod\n\t"
-        "\n\t"
-        "\tset pod type path val\n\t"
-        "\t- Set path to val (inserting path if path does not already\n\t"
-        "\t  exist).  Will not change the type at end of an existing\n\t"
-        "\t  path.  Specifically, in pseudocode:\n\t"
-        "\t    t = query type pod path       # check if path exists\n\t"
-        "\t    if   t==type, remove pod path # yes and to right type \n\t"
-        "\t    elif t!=void, fail            # yes but to wrong type\n\t"
-        "\t    fi                            # no\n\t"
-        "\t    insert pod type val           # insert new val\n\t"
-        "\t- In the implementation currently, if the insert fails, the\n\t"
-        "\t  original value at path (if any) will be lost.\n\t"
-        "\t- Might change the locations of existing values in the pod\n\t"
-        "\n\t"
-        "\tcompact pod full\n\t"
-        "\t- Compacts the pod.  If full is non-zero, a full compaction is\n\t"
-        "\t  done (pod_max=pod_used and the pod header is compacted).\n\t"
-        "\t  Might change the locations of existing values in the pod.\n\t"
-        "", bin ));
-    FD_LOG_NOTICE(( "\n\t"
-        "\tquery-root what pod\n\t"
-        "\t- Query pod.  what determines what will be printed to\n\t"
-        "\t  stdout as a result of the query.\n\t"
-        "\t    test:       0 if pod exists, a negative error code if not\n\t"
-        "\t    max:        max bytes in pod if pod exists, 0 if not\n\t"
-        "\t    used:       used bytes in pod if pod exists, 0 if not\n\t"
-        "\t    avail:      free bytes in pod if pod exists, 0 if not\n\t"
-        "\t    cnt:        number of keys in pod if pod exists, 0 if not\n\t"
-        "\t    recursive:  number of keys (recursively) in pod if pod\n\t"
-        "\t                exists, 0 if not\n\t"
-        "\t    subpod-cnt: number of subpods in pod if pod exists, 0 if\n\t"
-        "\t                not\n\t"
-        "\n\t"
-        "\tquery what pod path\n\t"
-        "\t- Query pod for path.  what determines what will be printed to\n\t"
-        "\t  stdout as a result of the query.\n\t"
-        "\t    test:       0 if pod:path exists\n\t"
-        "\t                a negative error code if not\n\t"
-        "\t    type:       type of value at pod:path if it exists,\n\t"
-        "\t                void if not\n\t"
-        "\t    val:        pretty printed value at pod:path if it\n\t"
-        "\t                exists, void if not\n\t"
-        "\t    max:        max bytes in pod:path if pod:path exists and\n\t"
-        "\t                is a subpod, 0 if not\n\t"
-        "\t    used:       used bytes in pod:path if pod:path exists and\n\t"
-        "\t                is a subpod, 0 if not\n\t"
-        "\t    avail:      free bytes in pod:path if pod:path exists and\n\t"
-        "\t                is a subpod, 0 if not\n\t"
-        "\t    cnt:        number of keys in pod:path if pod:path exists\n\t"
-        "\t                and is a subpod, 0 if not\n\t"
-        "\t    recursive:  number of keys (recursively) in pod:path if\n\t"
-        "\t                pod:path exists and is a subpod, 0 if not\n\t"
-        "\t    subpod-cnt: number of subpods in pod:path if pod:path\n\t"
-        "\t                exists and is a subpod, 0 if not\n\t"
-        "\t    gaddr:      current location of the pod encoded value if\n\t"
-        "\t                pod:path exists, null if not\n\t"
-        "\t    full:       pretty printed verbose query\n\t"
-        "\n\t"
-        "\tThe current implementation assumes no concurrent pod users.\n\t"
-        "" ));
+      fputs( fd_pod_ctl_help, stdout );
+
       FD_LOG_NOTICE(( "%i: %s: success", cnt, cmd ));
 
     } else if( !strcmp( cmd, "tag" ) ) {
@@ -760,10 +657,10 @@ main( int     argc,
     cnt++;
   }
 
-  FD_LOG_NOTICE(( "processed %i commands", cnt ));
+  if( FD_UNLIKELY( cnt<1 ) ) FD_LOG_NOTICE(( "processed %i commands\n\tDo %s help for help", cnt, bin ));
+  else                       FD_LOG_NOTICE(( "processed %i commands", cnt ));
 
 # undef SHIFT
-
   fd_halt();
   return 0;
 }

--- a/src/util/pod/fd_pod_ctl_help
+++ b/src/util/pod/fd_pod_ctl_help
@@ -1,0 +1,112 @@
+
+Usage: fd_pod_ctl [cmd] [cmd args] [cmd] [cmd args] ...
+
+Commands are:
+
+help
+- Prints this message.
+
+tag val
+- Sets the tag for subsequent wksp allocations to val.  Default is 1.
+
+new wksp max
+- Create a pod in wksp with a maximum size of max.  Prints the wksp cstr
+  address of the (empty) pod to stdout on success.  0 indicates to use a
+  default of 4KiB.
+
+delete pod
+- Delete the pod at wksp cstr address pod.
+
+reset pod
+- Reset the pod at wksp cstr address pod.
+
+list pod
+- Lists (recursively) the contents of the pod at wksp cstr address pod
+  to stdout.
+
+insert pod type path val
+- Inserts type into the pod at path with value val.  Fails if path
+  already exists in the pod.  This might change the locations of
+  existing values in the pod.
+
+remove pod path
+- Remove the path (and any path.*) from the pod.  Fails if path does not
+  already exist in the pod.  This might change the locations of existing
+  values in the pod
+
+update pod type path val
+- Update path to val (failing if path to type does not already exist).
+  Specifically, in pseudocode:
+
+    t = query type pod path  ... check if path to type exists
+    if t!=type, fail         ... no
+    remove pod path          ... remove old val
+    insert pod type path val ... insert new val
+
+  In the current implementation, if the insert fails, the original value
+  will be lost.  This might change the locations of existing values in
+  the pod.
+
+set pod type path val
+- Set path to val (inserting path if path does not already exist).  Will
+  not change the type at end of any existing path.  Specifically, in
+  pseudocode:
+
+    t = query type pod path       ... check if path exists
+    if   t==type, remove pod path ... yes and to right type 
+    elif t!=void, fail            ... yes but to wrong type
+    fi                            ... no
+    insert pod type val           ... insert new val
+
+  In the current implementation, if the insert fails, the original value
+  at path (if any) will be lost.  This might change the locations of
+  existing values in the pod.
+
+compact pod full
+- Compacts the pod.  If full is non-zero, a full compaction is done
+  (pod_max set to pod_used and the pod header is compacted).  This might
+  change the locations of existing values in the pod.
+
+query-root what pod
+- Query pod.  The "what" determines what will be printed to stdout as a
+  result of the query.
+
+    what \ pod | exists             | does not exist
+    -----------+--------------------+---------------
+    test       | 0                  | neg error code
+    max        | max bytes in pod   | 0
+    used       | used bytes in pod  | 0
+    avail      | free bytes in pod  | 0
+    cnt        | num keys in pod    | 0
+    recursive  | num keys in pod    |
+               | (recursively)      | 0
+    subpod-cnt | num subpods in pod | 0
+
+  Technically speaking, this always succeeds but any weirdness detected
+  is logged.
+
+query what pod path
+- Query pod for path.  The "what" determines what will be printed to
+  stdout as a result of the query.
+
+    what \ pod:path | exists                  | does not exist
+    ----------------+-------------------------+---------------
+    test            | 0                       | neg error code
+    type            | value type              | void
+    val             | pretty print value      | void
+    max             | max bytes in pod:path   | 0
+    used            | used bytes in pod:path  | 0
+    avail           | free bytes in pod:path  | 0
+    cnt             | num keys in pod:path    | 0
+    recursive       | num keys in pod:path    |
+                    | (recursively)           | 0
+    subpod-cnt      | num subpods in pod:path | 0
+    gaddr           | wksp gaddr of the       |
+                    | pod encoded value       | null
+    full            |             pretty print verbose query
+
+  Technically speaking, this always succeeds but any weirdness detected
+  is logged.
+
+The current implementation assumes no concurrent pod users.
+

--- a/src/util/wksp/fd_wksp.c
+++ b/src/util/wksp/fd_wksp.c
@@ -322,6 +322,22 @@ fd_wksp_cstr_free( char const * cstr ) {
   fd_wksp_detach( wksp ); /* logs details */
 }
 
+ulong
+fd_wksp_cstr_tag( char const * cstr ) {
+  char  name[ FD_SHMEM_NAME_MAX ];
+  ulong gaddr;
+  if( FD_UNLIKELY( !fd_wksp_cstr_parse( cstr, name, &gaddr ) ) ) return 0UL; /* logs details */
+
+  fd_wksp_t * wksp = fd_wksp_attach( name ); /* logs details */
+  if( FD_UNLIKELY( !wksp ) ) return 0UL;
+
+  ulong tag = fd_wksp_tag( wksp, gaddr ); /* logs details */
+
+  fd_wksp_detach( wksp ); /* logs details */
+
+  return tag;
+}
+
 void
 fd_wksp_cstr_memset( char const * cstr,
                      int          c ) {

--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -203,6 +203,23 @@ fd_wksp_cstr_alloc( char const * name,
 void
 fd_wksp_cstr_free( char const * cstr );
 
+/* fd_wksp_cstr_tag queries the tag of a wksp allocation specified by a
+   cstr containing [name]:[gaddr].  Ignoring parsing and error trapping,
+   equivalent to:
+
+      fd_wksp_t * wksp = fd_wksp_attach( name );
+      ulong tag = fd_wksp_tag( wksp, gaddr );
+      fd_wksp_detach( wksp );
+      return tag;
+
+   As such, if doing many queries from the same wksp, it is faster to do
+   fd_wksp_attach upfront, followed by the deallocations and then a
+   fd_wksp_detach (and faster still to use the advanced APIs to further
+   amortize the fd_wksp_attach / fd_wksp_detach calls.) */
+
+ulong
+fd_wksp_cstr_tag( char const * cstr );
+
 /* fd_wksp_cstr_memset memsets a wksp allocation specified by a cstr
    containing [name]:[gaddr] to c.  Ignoring parsing and error trapping,
    equivalent to:

--- a/src/util/wksp/fd_wksp_ctl_help
+++ b/src/util/wksp/fd_wksp_ctl_help
@@ -1,0 +1,57 @@
+
+Usage: fd_wksp_ctl [cmd] [cmd args] [cmd] [cmd args] ...
+
+Commands are:
+
+help
+- Prints this message.
+
+tag val
+- Sets the tag for subsequent wksp allocations to val.  Default is 1.
+
+new wksp page_cnt page_sz cpu_idx mode
+- Create a workspace named wksp from page_cnt page_sz pages near logical
+  cpu_idx.  The region will have the unix permissions specified by mode
+  (assumed octal).
+
+delete wksp
+- Delete a workspace named wksp.  If multiple shmem regions exist with
+  same name, try to use the shmem region backed by the largest page size
+
+alloc wksp align sz
+- Allocates sz bytes with global address alignment align from the wksp
+  tagged with the tag value specified above.  align 0 means use the
+  default alignment.  Prints the wksp cstr address of the allocation to
+  stdout on success.
+
+free wksp_gaddr
+- Free allocation pointed to by wksp cstr address wksp_gaddr.
+  wksp_gaddr can point at any byte in the allocation.  Technically
+  speaking, this always succeeds but logs any weirdness detected.
+
+tag-query wksp_gaddr
+- Prints the tag associated with wksp_gaddr to stdout (tags are
+  positive).  If wksp_gaddr does not point to a byte in a wksp
+  allocation, prints 0.  Technically speaking, this always succeeds but
+  logs any weirdness detected.
+
+tag-free wksp tag
+- Free all wksp allocations with the given tag.  Technically speaking,
+  this always succeeds but logs any weirdness detected.
+
+memset wksp_gaddr c
+- Memset allocation pointed to by wksp cstr address wksp_gaddr to byte
+  c.  wksp_gaddr can point at any byte in the allocation.  Technically
+  speaking, this always succeeds but logs any weirdness detected.
+
+check wksp
+- Check if any processes that died in middle of workspace operations
+  (clean up if so) or are stalling other processes from doing workspace
+  operations (log if so).
+
+reset wksp
+- Free all allocations in a workspace.
+
+query wksp
+- Print the detailed workspace usage to stdout.
+

--- a/src/util/wksp/test_wksp_ctl
+++ b/src/util/wksp/test_wksp_ctl
@@ -72,6 +72,10 @@ $BIN/fd_wksp_ctl alloc $WKSP    4096 -1                         && fail alloc $?
 
 GADDR=$($BIN/fd_wksp_ctl alloc $WKSP 4096 2097152 || fail alloc $?)
 
+GADDR1=$($BIN/fd_wksp_ctl tag 1234 alloc $WKSP 4096 4096 || fail alloc $?)
+GADDR2=$($BIN/fd_wksp_ctl tag 1234 alloc $WKSP 4096 4096 || fail alloc $?)
+GADDR3=$($BIN/fd_wksp_ctl tag 2345 alloc $WKSP 4096 4096 || fail alloc $?)
+
 echo Testing memset
 
 $BIN/fd_wksp_ctl memset            && fail memset $?
@@ -90,6 +94,29 @@ echo Testing query
 $BIN/fd_wksp_ctl query          && fail query $?
 $BIN/fd_wksp_ctl query bad/name && fail query $?
 $BIN/fd_wksp_ctl query $WKSP    || fail query $?
+
+echo Testing tag-query
+
+$BIN/fd_wksp_ctl tag-query          && fail tag-query $?
+$BIN/fd_wksp_ctl tag-query bad/name \
+                 tag-query $GADDR   \
+                 tag-query $GADDR1  \
+                 tag-query $GADDR2  \
+                 tag-query $GADDR3  \
+|| fail tag-query $? # Yes ... a fail here is success from cmd exec POV (fail is logged)
+
+echo Testing tag-free
+
+$BIN/fd_wksp_ctl tag-free       && fail tag-free $?
+$BIN/fd_wksp_ctl tag-free $WKSP && fail tag-free $?
+$BIN/fd_wksp_ctl tag-free bad   1234 \
+                 tag-free $WKSP    0 \
+                 tag-free $WKSP 4096 \
+                 tag-free $WKSP    2 \
+                 tag-free $WKSP 1234 \
+                 tag-free $WKSP 2345 \
+                 tag-free $WKSP 1234 \
+|| fail tag-free $? # Yes ... a fail here is success from cmd exec POV (fail is logged)
 
 echo Testing free
 


### PR DESCRIPTION
... and related commits.  Of particular note:

- fd_alloc_ctl for command line and scripted interaction with interprocess shared allocation.  This includes a fd_alloc_ctl query command that will write out a very detailed post mortems of a shared fd_alloc (users can use it find corruption, leaks, etc), a supporting fd_alloc_hdr_t tweak for large allocations and a supporting fd_alloc_wksp API.
- Support for command line interaction with wksp allocation tagging.  This includes a supporting fd_wksp_cstr_tag API and the supporting fd_wksp_ctl commands tag-query and tag-free.
- Minor documentation cleanups to match above.