### PR TITLE
Memory leak detection and other fd_alloc features

### DIFF
--- a/src/util/alloc/fd_alloc_ctl.c
+++ b/src/util/alloc/fd_alloc_ctl.c
@@ -152,6 +152,25 @@ main( int     argc,
       FD_LOG_NOTICE(( "%i: %s %s %lu %s: success", cnt, cmd, cstr, cgroup_idx, name_gaddr ));
       SHIFT(3);
 
+    } else if( !strcmp( cmd, "compact" ) ) {
+
+      if( FD_UNLIKELY( argc<1 ) ) FD_LOG_ERR(( "%i: %s: too few arguments\n\tDo %s help for help", cnt, cmd, bin ));
+
+      char const * cstr = argv[0];
+
+      void * shalloc = fd_wksp_map( cstr );
+      if( FD_UNLIKELY( !shalloc ) ) FD_LOG_ERR(( "%i: %s: fd_wksp_map(\"%s\") failed", cnt, cmd, cstr ));
+
+      fd_alloc_t * alloc = fd_alloc_join( shalloc, 0 /*d/c*/ );
+      if( FD_UNLIKELY( !alloc ) ) FD_LOG_ERR(( "%i: %s: fd_alloc_join(\"%s\",0) failed", cnt, cmd, cstr ));
+
+      fd_alloc_compact( alloc ); /* logs details */
+
+      fd_wksp_unmap( fd_alloc_leave( alloc ) ); /* logs details */
+
+      FD_LOG_NOTICE(( "%i: %s %s: success", cnt, cmd, cstr ));
+      SHIFT(1);
+
     } else if( !strcmp( cmd, "query" ) ) {
 
       if( FD_UNLIKELY( argc<2 ) ) FD_LOG_ERR(( "%i: %s: too few arguments\n\tDo %s help for help", cnt, cmd, bin ));
@@ -171,6 +190,7 @@ main( int     argc,
 
       if(      !strcmp( what, "test" ) ) printf( "%i\n", err );
       else if( !strcmp( what, "tag"  ) ) printf( "%lu\n", FD_UNLIKELY( err ) ? 0UL : fd_alloc_tag( alloc ) );
+      else if( !strcmp( what, "leak" ) ) printf( "%i\n",  FD_UNLIKELY( err ) ? -1  : !fd_alloc_is_empty( alloc ) );
       else if( !strcmp( what, "full" ) ) fd_alloc_fprintf( alloc, stdout );
       else                               FD_LOG_ERR(( "unknown query %s", what ));
 

--- a/src/util/alloc/fd_alloc_ctl_help
+++ b/src/util/alloc/fd_alloc_ctl_help
@@ -37,6 +37,12 @@ free alloc_gaddr cgroup_idx malloc_gaddr
   concurrency group cgroup_idx.  Technically speaking, this always
   succeeds (logs any weirdness detected).
 
+compact alloc_gaddr
+- Frees up any wksp allocations that are not required for any
+  outstanding mallocs done by the alloc at alloc_gaddr (note that free
+  lazily returns unused memory from the underlying wksp to accelerate
+  potential future allocations).
+
 query what alloc_gaddr
 - Query alloc at alloc_gaddr.  The "what" determines what will be
   printed to stdout:
@@ -45,6 +51,18 @@ query what alloc_gaddr
     -------------+---------------------+----------------------
     test         | 0                   | error code (negative)
     tag          | wksp_tag (positive) | 0
+    leak         | 0 if empty          | error code (negative)
+                 | 1 if outstanding    |
+    full         |       pretty printed verbose details
+
+  "leak" should only be done when there are expected to be no
+  outstanding mallocs on the alloc and there are no concurrent users.
+  Concurrent use will not corrupt the alloc but the result might be
+  inaccurate.  Note also that leak might invoke compact on the alloc.
+
+  "full" should only be done when there are no concurrent users.
+  Concurrent use will not corrupt the alloc but the result might be
+  inaccurate.
 
   Technically speaking, this always succeeds (logs any weirdness
   detected).

--- a/src/util/alloc/test_alloc.c
+++ b/src/util/alloc/test_alloc.c
@@ -168,6 +168,31 @@ main( int     argc,
   FD_TEST( fd_alloc_wksp( NULL  )==NULL ); FD_TEST( fd_alloc_tag( NULL  )==0UL );
   FD_TEST( fd_alloc_wksp( alloc )==wksp ); FD_TEST( fd_alloc_tag( alloc )==tag );
 
+  FD_LOG_NOTICE(( "Testing is_empty" ));
+
+  do {
+    FD_TEST( fd_alloc_is_empty( alloc ) );
+    void * mem[64];
+    for( ulong idx=0UL; idx<64UL; idx++ ) mem[idx] = fd_alloc_malloc( alloc, 1UL, 1UL );
+    for( ulong idx=0UL; idx<64UL; idx++ ) {
+      FD_TEST( !fd_alloc_is_empty( alloc ) );
+      fd_alloc_free( alloc, mem[idx] );
+    }
+    FD_TEST( fd_alloc_is_empty( alloc ) );
+  } while(0);
+
+  FD_LOG_NOTICE(( "Testing compact" ));
+
+  do {
+    void * mem[64];
+    for( ulong idx=0UL; idx<64UL; idx++ ) mem[idx] = fd_alloc_malloc( alloc, 1UL, 1UL );
+    for( ulong idx=0UL; idx<64UL; idx++ ) {
+      fd_alloc_free( alloc, mem[idx] );
+      fd_alloc_compact( alloc );
+    }
+    FD_TEST( fd_alloc_is_empty( alloc ) );
+  } while(0);
+
   FD_LOG_NOTICE(( "Running torture test with --alloc-cnt %lu, --align-max %lu, --sz-max %lu on %lu tile(s)",
                   alloc_cnt, align_max, sz_max, tile_cnt ));
 

--- a/src/util/alloc/test_alloc_ctl
+++ b/src/util/alloc/test_alloc_ctl
@@ -68,6 +68,7 @@ $BIN/fd_alloc_ctl query test            && fail query $?
 $BIN/fd_alloc_ctl query bad/what $ALLOC && fail query $?
 $BIN/fd_alloc_ctl query test $ALLOC query test bad/name \
                   query tag  $ALLOC query tag  bad/name \
+                  query leak $ALLOC query leak bad/name \
 || fail query $?
 
 echo Testing alloc
@@ -97,6 +98,12 @@ $BIN/fd_alloc_ctl free bad/name  3 $GADDR0  \
                   free $ALLOC    6 $GADDR2  \
                   free $ALLOC    7 $GADDR3  \
 || fail alloc $?
+
+echo Testing compact
+
+$BIN/fd_alloc_ctl compact          && fail free $?
+$BIN/fd_alloc_ctl compact bad/name && fail free $?
+$BIN/fd_alloc_ctl compact $ALLOC   || fail free $?
 
 echo Testing delete
 


### PR DESCRIPTION
- fd_alloc_is_empty APIs and corresponding "query leak" fd_alloc_ctl command to allow programmatic, command line and/or scripted allocation leak detection of running and/or terminated programs.

- Related fd_alloc_compact and corresponding "compact" fd_alloc_ctl command to allow programmatic, command line and/or scripted optimization of wksp utilization.

- "query full" now can find all wksp partitions in use by the allocator, disambiguate large user wksp allocations from large superblock wksp allocations used to aggregate smaller user allocations and give complete statistics large user allocations.

- Slight implementation tweak and documentation update to cover optimally complex threading cases (e.g. malloc in one more producer threads and free in one more consumer threads).

- Other very minor cleanups

These all come at zero overhead (in space, time or concurrency) to the existing fd_alloc.