### PR TITLE
util: add --netns flag to fd_boot()

### DIFF
--- a/src/util/fd_util.c
+++ b/src/util/fd_util.c
@@ -1,3 +1,7 @@
+#if defined(__linux__)
+#include "fd_util_linux.c"
+#endif
+
 #include "fd_util.h"
 
 void
@@ -6,6 +10,9 @@ fd_boot( int *    pargc,
   /* At this point, we are immediately after the program start, there is
      only one thread of execution and fd has not yet been booted. */
   fd_log_private_boot  ( pargc, pargv );
+# if defined(__linux__)
+  fd_linux_private_boot( pargc, pargv );
+# endif
   fd_shmem_private_boot( pargc, pargv );
   fd_tile_private_boot ( pargc, pargv ); /* The caller is now tile 0 */
 }

--- a/src/util/fd_util_linux.c
+++ b/src/util/fd_util_linux.c
@@ -1,0 +1,34 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <sched.h>
+
+#include "fd_util_base.h"
+#include "log/fd_log.h"
+
+/* fd_linux_enter_netns: Replaces the network namespace of the calling
+   thread with the namespace located at the given nsfs mount path. */
+static void
+fd_linux_enter_netns( char const * netns ) {
+  /* These syscalls mirror `ip netns exec` */
+  int ns_fd = open( netns, O_RDONLY|O_CLOEXEC );
+  if( FD_UNLIKELY( ns_fd<0 ) ) {
+    FD_LOG_WARNING(( "Entering netns failed: open(%s) returned (%d-%s)",
+                      netns, errno, strerror( errno ) ));
+    return;
+  }
+  if( FD_UNLIKELY( 0!=setns( ns_fd, CLONE_NEWNET ) ) ) {
+    FD_LOG_WARNING(( "setns(%s,CLONE_NEWNET) failed (%d-%s)",
+                      netns, errno, strerror( errno ) ));
+    return;
+  }
+  FD_LOG_INFO(( "Using netns %s", netns ));
+}
+
+static void
+fd_linux_private_boot( int  *   pargc,
+                       char *** pargv ) {
+  char const * netns = fd_env_strip_cmdline_cstr( pargc, pargv, "--netns", "NETNS", NULL );
+  if( netns ) fd_linux_enter_netns( netns );
+}
+


### PR DESCRIPTION
Allows entering persistent network namespaces (useful for tests and sandboxing)