### PR TITLE
config: add llvm-cov profile

### DIFF
--- a/config/with-llvm-cov.mk
+++ b/config/with-llvm-cov.mk
@@ -1,0 +1,7 @@
+ifneq "$(FD_USING_CLANG)" "1"
+$(error llvm-cov requires clang)
+endif
+
+CPPFLAGS+=-fprofile-instr-generate -fcoverage-mapping
+LDFLAGS+=-fprofile-instr-generate -fcoverage-mapping
+


### PR DESCRIPTION
Adds build profile for LLVM-based code coverage.
