### PR TITLE
Added wksp usage summaries and related tweaks

### DIFF
--- a/src/util/alloc/fd_alloc_ctl.c
+++ b/src/util/alloc/fd_alloc_ctl.c
@@ -90,7 +90,7 @@ main( int     argc,
 
       fd_alloc_delete( fd_alloc_leave( alloc ) ); /* logs details */
 
-      if( garbage_collect ) fd_wksp_tag_free( wksp, wksp_tag ); /* logs details */
+      if( garbage_collect ) fd_wksp_tag_free( wksp, &wksp_tag, 1UL ); /* logs details */
 
       fd_wksp_unmap( shalloc ); /* logs details */
 

--- a/src/util/alloc/test_alloc.c
+++ b/src/util/alloc/test_alloc.c
@@ -130,25 +130,24 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * name      = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL,       NULL );
-  char const * _page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic" );
-  ulong        page_cnt  = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL,        1UL );
-  ulong        alloc_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--alloc-cnt", NULL,  1048576UL );
-  ulong        align_max = fd_env_strip_cmdline_ulong( &argc, &argv, "--align-max", NULL,      256UL );
-  ulong        sz_max    = fd_env_strip_cmdline_ulong( &argc, &argv, "--sz-max",    NULL,    73728UL );
-  ulong        tag       = fd_env_strip_cmdline_ulong( &argc, &argv, "--tag",       NULL,     1234UL );
+  char const * name      = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL,            NULL );
+  char const * _page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL,      "gigantic" );
+  ulong        page_cnt  = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL,             1UL );
+  ulong        near_cpu  = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
+  ulong        alloc_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--alloc-cnt", NULL,       1048576UL );
+  ulong        align_max = fd_env_strip_cmdline_ulong( &argc, &argv, "--align-max", NULL,           256UL );
+  ulong        sz_max    = fd_env_strip_cmdline_ulong( &argc, &argv, "--sz-max",    NULL,         73728UL );
+  ulong        tag       = fd_env_strip_cmdline_ulong( &argc, &argv, "--tag",       NULL,          1234UL );
   ulong        tile_cnt  = fd_tile_cnt();
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( page_sz==FD_SHMEM_UNKNOWN_PAGE_SZ ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
 
   fd_wksp_t * wksp;
   if( name ) {
     FD_LOG_NOTICE(( "Attaching to --wksp %s", name ));
     wksp = fd_wksp_attach( name );
   } else {
-    FD_LOG_NOTICE(( "--wksp not specified, using an anonymous local workspace" ));
-    wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_log_cpu_id(), "wksp", 0UL );
+    FD_LOG_NOTICE(( "--wksp not specified, using an anonymous local workspace, --page-sz %s, --page-cnt %lu, --near-cpu %lu",
+                    _page_sz, page_cnt, near_cpu ));
+    wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
   }
 
   if( FD_UNLIKELY( !wksp ) ) FD_LOG_ERR(( "Unable to attach to wksp" ));

--- a/src/util/wksp/fd_wksp_ctl.c
+++ b/src/util/wksp/fd_wksp_ctl.c
@@ -261,8 +261,8 @@ main( int     argc,
 
       fd_wksp_t * wksp = fd_wksp_attach( name ); /* logs details */
       if( FD_LIKELY( wksp ) ) {
-        fd_wksp_tag_free( wksp, tag ); /* logs details */
-        fd_wksp_detach( wksp );        /* logs details */
+        fd_wksp_tag_free( wksp, &tag, 1UL ); /* logs details */
+        fd_wksp_detach( wksp );              /* logs details */
       }
 
       FD_LOG_NOTICE(( "%i: %s %s %lu: success", cnt, cmd, name, tag ));
@@ -307,6 +307,35 @@ main( int     argc,
 
       FD_LOG_NOTICE(( "%i: %s %s: success", cnt, cmd, name ));
       SHIFT(1);
+
+    } else if( !strcmp( cmd, "usage" ) ) {
+
+      if( FD_UNLIKELY( argc<2 ) ) FD_LOG_ERR(( "%i: %s: too few arguments\n\tDo %s help for help", cnt, cmd, bin ));
+
+      char const * name =                   argv[0];
+      ulong        tag  = fd_cstr_to_ulong( argv[1] );
+
+      fd_wksp_t * wksp = fd_wksp_attach( name ); /* logs details */
+      if( FD_UNLIKELY( !wksp ) ) fprintf( stdout, "-\n" );
+      else {
+        fd_wksp_usage_t usage[1];
+        fd_wksp_usage( wksp, &tag, 1UL, usage );
+        fprintf( stdout,
+                 "wksp %s\n"
+                 "\t%20lu bytes max        (%lu blocks, %lu blocks max)\n"
+                 "\t%20lu bytes used       (%lu blocks)\n"
+                 "\t%20lu bytes avail      (%lu blocks)\n"
+                 "\t%20lu bytes w/tag %4lu (%lu blocks)\n",
+                 wksp->name,
+                 usage->total_sz,                  usage->total_cnt,                   usage->total_max,
+                 usage->total_sz - usage->free_sz, usage->total_cnt - usage->free_cnt,
+                 usage->free_sz,                   usage->free_cnt,
+                 usage->used_sz, tag,              usage->used_cnt );
+        fd_wksp_detach( wksp ); /* logs details */
+      }
+
+      FD_LOG_NOTICE(( "%i: %s %s %lu: success", cnt, cmd, name, tag ));
+      SHIFT(2);
 
     } else if( !strcmp( cmd, "query" ) ) {
 

--- a/src/util/wksp/fd_wksp_ctl_help
+++ b/src/util/wksp/fd_wksp_ctl_help
@@ -52,6 +52,13 @@ check wksp
 reset wksp
 - Free all allocations in a workspace.
 
+usage wksp tag
+- Prints a summary of workspace usage to stdout with total, used by
+  all allocs, free, and used by allocs with the given tag.  Technically
+  speaking, this always succeeds but logs any weirdness detected (if
+  wksp does not appear to be a wksp, prints a single line "-" to
+  stdout).
+
 query wksp
 - Print the detailed workspace usage to stdout.
 

--- a/src/util/wksp/test_wksp_ctl
+++ b/src/util/wksp/test_wksp_ctl
@@ -89,6 +89,16 @@ $BIN/fd_wksp_ctl check          && fail check $?
 $BIN/fd_wksp_ctl check bad/name && fail check $?
 $BIN/fd_wksp_ctl check $WKSP    || fail check $?
 
+echo Testing usage
+
+$BIN/fd_wksp_ctl usage               && fail usage $?
+$BIN/fd_wksp_ctl usage bad/name      && fail usage $?
+$BIN/fd_wksp_ctl usage bad/name    1 \
+                 usage $WKSP       1 \
+                 usage $WKSP    1234 \
+                 usage $WKSP    2345 \
+|| fail usage $?
+
 echo Testing query
 
 $BIN/fd_wksp_ctl query          && fail query $?


### PR DESCRIPTION
- By popular demand, added fd_wksp_usage API and "usage" command for getting summary usage reports programmatically and via command line.

- Tangentially related (because it could exploit the same tag set APIs added for usage), tweaked the fd_wksp_tag_free API to support freeing sets of tags at the same algo efficiency as a single tag.

- Tweaked test_wksp to allow unit tests to use an anonymous wksp to simplify CI integration and tweaked test_alloc unit test to match (which gives it some more flexibility to explore TLB and NUMA effects).