### PR TITLE
build, ci: improve cov reporting

### DIFF
--- a/.github/workflows/make_build.yml
+++ b/.github/workflows/make_build.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           sudo apt-get install -y \
             libnuma-dev           \
-            clang-15
+            ${{ matrix.compiler }}
 
       - name: Build everything
         run: make -j MACHINE=linux_${{ matrix.compiler }}_x86_64

--- a/.github/workflows/make_coverage.yml
+++ b/.github/workflows/make_coverage.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   make-test-coverage:
     runs-on: ubuntu-22.04
+    env:
+      MACHINE: linux_clang_x86_64
+      EXTRAS: llvm-cov
     steps:
       - uses: actions/checkout@v3
 
@@ -15,47 +18,20 @@ jobs:
         run: |
           sudo apt-get install -y \
             clang                 \
-            llvm-14               \
+            llvm                  \
             lcov                  \
-            libnuma-dev           \
-            parallel
+            libnuma-dev
 
       - name: Build everything
-        run: |
-          export MACHINE="linux_clang_x86_64"
-          export EXTRAS="llvm-cov"
-          make -j 
+        run: make -j
 
       - name: Run unit tests
-        run: |
-          export LLVM_PROFILE_FILE="build/linux/clang/x86_64/tmp/coverage/%p.profraw"
-          export MACHINE="linux_clang_x86_64"
-          export EXTRAS="llvm-cov"
-          make -kj --output-sync=target run-unit-test
+        run: make -kj --output-sync=target run-unit-test
 
-      - name: Index raw coverage profiles
+      - name: Make coverage report
         run: |
-          (
-            cd build/linux/clang/x86_64/tmp/coverage
-            llvm-profdata-14 merge \
-              -o coverage.profdata \
-              *.profraw
-          )
-
-      - name: Export lcov profile
-        run: |
-          BUILDDIR=build/linux/clang/x86_64
-          llvm-cov-14 export \
-            -format=lcov     \
-            -instr-profile=$BUILDDIR/tmp/coverage/coverage.profdata             \
-            $(find $BUILDDIR/obj -name '*.o' -exec printf "-object=%q\n" {} \;) \
-            > coverage.lcov
-
-      - name: Create coverage HTML report
-        run: |
-          genhtml                    \
-            --output coverage-report \
-            coverage.lcov
+          make cov-report
+          mv build/linux/clang/x86_64/cov/html coverage-report
 
       - name: Upload coverage HTML report as GitHub artifact
         uses: actions/upload-artifact@v3
@@ -67,7 +43,7 @@ jobs:
         uses: codecov/codecov-action@v3
         timeout-minutes: 5
         with:
-          files: coverage.lcov
+          files: build/linux/clang/x86_64/cov/cov.lcov
           name: codecov-make-linux_clang-14_x86_64
           fail_ci_if_error: false
           functionalities: search

--- a/.github/workflows/make_test.yml
+++ b/.github/workflows/make_test.yml
@@ -14,8 +14,7 @@ jobs:
       - name: Install deps
         run: |
           sudo apt-get install -y \
-            libnuma-dev           \
-            parallel
+            libnuma-dev
 
       - name: Build everything
         run: make -j

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tmp
 genhtml/
 target/
 *.lcov
+*.profraw
 
 # Nix
 /result

--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,5 @@ $(info Using EXTRAS=$(EXTRAS))
 include config/$(MACHINE).mk
 include $(addprefix config/with-,$(addsuffix .mk,$(EXTRAS)))
 include config/everything.mk
+include config/coverage.mk
 

--- a/config/base.mk
+++ b/config/base.mk
@@ -19,6 +19,13 @@ SCRUB:=$(FIND) . -type f -name "*~" -o -name "\#*" | xargs $(RM)
 DATE:=date
 CAT:=cat
 
+# LLVM toolchain
+LLVM_COV?=llvm-cov
+LLVM_PROFDATA?=llvm-profdata
+
+# lcov
+GENHTML=genhtml
+
 EBPF_CC:=clang
 EBPF_CPPFLAGS:=-target bpf -O2 -g
 EBPF_CFLAGS:=-std=c17

--- a/config/coverage.mk
+++ b/config/coverage.mk
@@ -1,0 +1,29 @@
+.PHONY: cov-report
+
+COVDIR:=$(OBJDIR)/cov
+
+cov-report: $(COVDIR)/html
+
+# Create HTML coverage report using lcov genhtml
+.PHONY: $(COVDIR)/html
+$(COVDIR)/html: $(COVDIR)/cov.lcov
+	rm -rf $@
+	$(GENHTML) --output $@ $<
+	@echo "Created coverage report at $@"
+
+# Export lcov report from indexed profile
+.PHONY: $(COVDIR)/cov.lcov
+$(COVDIR)/cov.lcov: $(COVDIR)/cov.profdata
+	$(LLVM_COV) export                         \
+	  -format=lcov                             \
+	  -instr-profile=$<                        \
+	  $(shell find $(OBJDIR)/obj               \
+	    -name '*.o'                            \
+	    -exec printf "-object=%q\n" {} \;)     \
+	  --ignore-filename-regex="test_.*\\.c"    \
+	> $@
+
+# Index raw profiles
+$(COVDIR)/cov.profdata: $(wildcard $(COVDIR)/raw/*.profraw)
+	@mkdir -p $(COVDIR)
+	$(LLVM_PROFDATA) merge -o $@ $^

--- a/config/everything.mk
+++ b/config/everything.mk
@@ -49,6 +49,7 @@ help:
 	# "make asm" makes all source files into assembly language files
 	# "make ppp" run all source files through the preprocessor
 	# "make show-deps" shows all the dependencies
+	# "make cov-report" creates an LCOV coverage report from LLVM profdata. Requires make run-unit-test EXTRAS="llvm-cov"
 
 clean:
 	#######################################################################
@@ -168,6 +169,7 @@ $(4): $(OBJDIR)/$(4)/$(1)
 endef
 
 UNIT_TEST_DATETIME := $(shell date -u +%Y%m%d-%H%M%S)
+export LLVM_PROFILE_FILE = $(OBJDIR)/cov/raw/%p.profraw
 
 define _run-unit-test
 
@@ -175,7 +177,7 @@ run-$(1):
 	#######################################################################
 	# Running $(3) from $(1)
 	#######################################################################
-	$(MKDIR) $(OBJDIR)/log/$(3)/$(1)
+	@$(MKDIR) $(OBJDIR)/log/$(3)/$(1)
 	$(OBJDIR)/$(3)/$(1) --log-path $(OBJDIR)/log/$(3)/$(1)/$(UNIT_TEST_DATETIME).log $(2) > /dev/null 2>&1 || \
 ($(CAT) $(OBJDIR)/log/$(3)/$(1)/$(UNIT_TEST_DATETIME).log && \
 exit 1)


### PR DESCRIPTION
- Move coverage script from GitHub workflow to config/coverage.mk
- Don't include test files in coverage report
