### PR TITLE
Revert "config: enable compiler color output"

### DIFF
--- a/config/with-clang.mk
+++ b/config/with-clang.mk
@@ -30,10 +30,7 @@ LD:=clang++
 # there wasn't some subtle inconsistency created between them in the
 # process).
 
-CPPFLAGS+=-DFD_USING_CLANG=1 \
-  -Wno-address-of-packed-member \
-  -Wno-unused-command-line-argument \
-  -fdiagnostics-color=always
+CPPFLAGS+=-DFD_USING_CLANG=1 -Wno-address-of-packed-member -Wno-unused-command-line-argument
 
 # Sigh ... clang doesn't understand some important command line
 # arguments (a couple of the more esoteric warnings in the brutality,

--- a/config/with-gcc.mk
+++ b/config/with-gcc.mk
@@ -5,7 +5,7 @@ LD:=g++
 # See with-clang.mk FD_USING_CLANG for behavior.  FD_USING_GCC and
 # FD_USING_CLANG should not be both set simulateously
 
-CPPFLAGS+=-DFD_USING_GCC=1 -fdiagnostics-color=always
+CPPFLAGS+=-DFD_USING_GCC=1
 
 FD_USING_GCC:=1
 


### PR DESCRIPTION
Reverts firedancer-io/firedancer#170

Breaks a contributor's emacs. Oops.