### PR TITLE
Re-enable sha256 tests

### DIFF
--- a/src/ballet/bmtree/Local.mk
+++ b/src/ballet/bmtree/Local.mk
@@ -1,2 +1,3 @@
 $(call add-hdrs,fd_bmtree.h)
 $(call make-unit-test,test_bmtree,test_bmtree,fd_ballet fd_util)
+$(call run-unit-test,test_bmtree)

--- a/src/ballet/poh/Local.mk
+++ b/src/ballet/poh/Local.mk
@@ -1,3 +1,4 @@
 $(call add-hdrs,fd_poh.h)
 $(call add-objs,fd_poh,fd_ballet)
 $(call make-unit-test,test_poh,test_poh,fd_ballet fd_util)
+$(call run-unit-test,test_poh)

--- a/src/ballet/sha256/Local.mk
+++ b/src/ballet/sha256/Local.mk
@@ -5,3 +5,4 @@ $(call add-asms,fd_sha256_core_shaext,fd_ballet)
 endif
 
 $(call make-unit-test,test_sha256,test_sha256,fd_ballet fd_util)
+$(call run-unit-test,test_sha256)


### PR DESCRIPTION
Now that our CI runner is on bare-metal, we can re-enable SHA-256 tests which previously failed due to lack of SHA-NI instructions. 