### PR TITLE
Another binary Merkle tree belt sanding pass

### DIFF
--- a/src/ballet/bmtree/fd_bmtree.h
+++ b/src/ballet/bmtree/fd_bmtree.h
@@ -1,22 +1,27 @@
 #ifndef HEADER_fd_src_ballet_bmtree_fd_bmtree_h
 #define HEADER_fd_src_ballet_bmtree_fd_bmtree_h
 
-/* Doing this by default is arguable.  This is largely to provide
+/* FIXME: Doing this by default is arguable.  This is largely to provide
    backward compat with existing code that expects these to have been
    already declared (by the same token, if we are willing to further
    cleanup names and the like, we would probably rename things like
-   fd_bmtree20_commit_t -> fd_bmtree20_t). */
+   fd_bmtree20_commit_t -> fd_bmtree20_t).  Likewise, at this point,
+   there is literally no difference between the different widths except
+   for the size passed to SHA256 in the "private_merge" function.  (We
+   really don't need to do a templatized implementation at all.) */
 
-#define FD_BMTREE20_HASH_SZ      (20UL)
-#define FD_BMTREE20_COMMIT_ALIGN (8UL)
-#define BMTREE_NAME              fd_bmtree20
-#define BMTREE_HASH_SZ           FD_BMTREE20_HASH_SZ
+#define FD_BMTREE20_HASH_SZ          (20UL)
+#define FD_BMTREE20_COMMIT_ALIGN     (32UL)
+#define FD_BMTREE20_COMMIT_FOOTPRINT (2048UL)
+#define BMTREE_NAME                  fd_bmtree20
+#define BMTREE_HASH_SZ               FD_BMTREE20_HASH_SZ
 #include "fd_bmtree_tmpl.c"
 
-#define FD_BMTREE32_HASH_SZ      (32UL)
-#define FD_BMTREE32_COMMIT_ALIGN (8UL)
-#define BMTREE_NAME              fd_bmtree32
-#define BMTREE_HASH_SZ           FD_BMTREE32_HASH_SZ
+#define FD_BMTREE32_HASH_SZ          (32UL)
+#define FD_BMTREE32_COMMIT_ALIGN     (32UL)
+#define FD_BMTREE32_COMMIT_FOOTPRINT (2048UL)
+#define BMTREE_NAME                  fd_bmtree32
+#define BMTREE_HASH_SZ               FD_BMTREE32_HASH_SZ
 #include "fd_bmtree_tmpl.c"
 
 #endif /* HEADER_fd_src_ballet_bmtree_fd_bmtree_h */


### PR DESCRIPTION
This added new functionality, further simplified the usage and implementation and has some additional performance improvements.

- Users do not need to specify the number of leaves up front.  This allowed simplified constructor APIs, elimination of all edge cases under the hood, and allowed for commit state to be just simplify declared at compile time on the stack and/or data segment. Implementation still supports arbitrary sized trees (at least for trees that are computable on human-timescales and easily extensible if wanting to go further).

- Related to the above, added an API for getting the the number of leaves already appended to a calculation.

- Tweaked data structure layouts to eliminate additional unnecessary copies and make it easier for the compiler to hardware accelerate and/or add more advanced hardware accelerations in the future.

An interesting side effect is that, at this point, there is practically no difference under the hood between the different variants.  So, if wanting to go further, we could in detemplatized the code and simplify the naming too (not done currently to minimize impact on existing code).