### PR TITLE
nix: add hwloc

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -24,6 +24,9 @@ pkgs.mkShell {
     pkg-config
     quictls
     xdp-tools
+
+    # Utils
+    hwloc
   ];
 }
 


### PR DESCRIPTION
Adds a dependency on `hwloc` so that `hwloc-calc` can be used.