### PR TITLE
ballet: add secp256k1 signing support

### DIFF
--- a/config/with-secp256k1.mk
+++ b/config/with-secp256k1.mk
@@ -1,0 +1,20 @@
+ifneq ($(SECP256K1),)
+
+ifneq (,$(wildcard $(SECP256K1)/lib/libsecp256k1.a))
+CFLAGS += -I$(SECP256K1)/include
+LDFLAGS += $(SECP256K1)/lib/libsecp256k1.a
+FD_HAS_SECP256K1:=1
+endif
+
+else
+
+LDFLAGS += $(shell pkg-config --libs secp256k1)
+FD_HAS_SECP256K1:=1
+
+endif
+
+ifneq ($(FD_HAS_SECP256K1),)
+
+CFLAGS += -DFD_HAS_SECP256K1=1
+
+endif

--- a/deps.sh
+++ b/deps.sh
@@ -99,9 +99,10 @@ checkout_repo () {
 fetch () {
   mkdir -pv ./opt/git
 
-  checkout_repo zlib    https://github.com/madler/zlib     "v1.2.13"
-  checkout_repo zstd    https://github.com/facebook/zstd   "v1.5.4"
-  checkout_repo openssl https://github.com/quictls/openssl "OpenSSL_1_1_1t-quic1"
+  checkout_repo zlib      https://github.com/madler/zlib            "v1.2.13"
+  checkout_repo zstd      https://github.com/facebook/zstd          "v1.5.4"
+  checkout_repo openssl   https://github.com/quictls/openssl        "OpenSSL_1_1_1t-quic1"
+  checkout_repo secp256k1 https://github.com/bitcoin-core/secp256k1 "v0.3.1"
 }
 
 check_fedora_pkgs () {
@@ -317,10 +318,37 @@ install_openssl () {
   echo "[~] Installed all dependencies"
 }
 
+install_secp256k1 () {
+  if pkg-config --exists libsecp256k1; then
+    echo "[~] secp256k1 already installed at $(pkg-config --path libsecp256k1), skipping installation"
+    return 0
+  fi
+
+  cd ./opt/git/secp256k1
+
+  
+  echo "[+] Configuring secp256k1"
+  ./autogen.sh
+  ./configure \
+    --prefix="$PREFIX"
+  echo "[+] Configured secp256k1"
+  
+  echo "[+] Building secp256k1"
+  "${MAKE[@]}"
+  echo "[+] Successfully built secp256k1"
+
+  echo "[+] Installing secp256k1 to $PREFIX"
+  "${MAKE[@]}" install
+  echo "[+] Successfully installed secp256k1"
+}
+
+
+
 install () {
-  ( install_zlib    )
-  ( install_zstd    )
-  ( install_openssl )
+  ( install_zlib      )
+  ( install_zstd      )
+  ( install_secp256k1 )
+  ( install_openssl   )
 
   echo "[~] Done! To wire up $(pwd)/opt with make, run:"
   echo "    source activate-opt"

--- a/shell.nix
+++ b/shell.nix
@@ -22,6 +22,7 @@ pkgs.mkShell {
     pkg-config
     quictls
     rocksdb
+    secp256k1
     xdp-tools
     zstd
 

--- a/src/ballet/secp256k1/Local.mk
+++ b/src/ballet/secp256k1/Local.mk
@@ -1,0 +1,12 @@
+ifneq ($(FD_HAS_SECP256K1),)
+
+$(call add-hdrs,fd_secp256k1.h)
+$(call add-objs,fd_secp256k1,fd_ballet)
+$(call make-unit-test,test_secp256k1,test_secp256k1,fd_ballet fd_util)
+$(call run-unit-test,test_secp256k1,)
+
+else
+
+$(warning secp256k1 disabled due to lack of libsecp256k1)
+
+endif

--- a/src/ballet/secp256k1/fd_secp256k1.c
+++ b/src/ballet/secp256k1/fd_secp256k1.c
@@ -1,0 +1,85 @@
+#include "fd_secp256k1.h"
+
+#include <secp256k1.h>
+#include <secp256k1_recovery.h>
+
+void *
+fd_secp256k1_public_from_private( void *       public_key,
+                                  void const * private_key ) {
+  // TODO: preallocate ctx
+  // TODO: randomize context to prevent side channel attacks
+  secp256k1_context * ctx = secp256k1_context_create( SECP256K1_CONTEXT_NONE );
+
+  if( !secp256k1_ec_seckey_verify( ctx, private_key ) ) {
+    return NULL;
+  }
+
+  if( !secp256k1_ec_pubkey_create( ctx, public_key, private_key ) ) {
+    return NULL;
+  }
+
+  secp256k1_context_destroy( ctx );
+
+  return public_key;
+}
+
+void *
+fd_secp256k1_sign( void *       sig,
+                   void const * msg_hash,
+                   void const * private_key ) {
+  // TODO: preallocate ctx
+  // TODO: randomize context to prevent side channel attacks
+  secp256k1_context * ctx = secp256k1_context_create( SECP256K1_CONTEXT_NONE );
+
+  if( !secp256k1_ecdsa_sign( ctx, (secp256k1_ecdsa_signature *) sig, msg_hash, private_key, NULL, 
+                             NULL ) ) {
+    return NULL;
+  }
+
+  secp256k1_context_destroy( ctx );
+
+  return sig;
+}
+
+int
+fd_secp256k1_verify( void const * msg_hash,
+                     void const * sig,
+                     void const * public_key ) {
+  if( !secp256k1_ecdsa_verify( secp256k1_context_static, (secp256k1_ecdsa_signature const *) sig, 
+                               msg_hash, (secp256k1_pubkey const *) public_key ) ) {
+    return FD_SECP256K1_ERR_SIG;
+  }
+
+  return FD_SECP256K1_SUCCESS;
+  
+}
+
+void *
+fd_secp256k1_recover( void *       public_key,
+                      void const * msg_hash,
+                      void const * sig,
+                      int          recovery_id ) {
+  secp256k1_ecdsa_recoverable_signature recoverable_sig;
+  if( !secp256k1_ecdsa_recoverable_signature_parse_compact( secp256k1_context_static, 
+                                                            &recoverable_sig, (uchar const *) sig, 
+                                                            recovery_id ) ) {
+    return NULL;
+  }
+
+  if( !secp256k1_ecdsa_recover( secp256k1_context_static, (secp256k1_pubkey *) public_key, 
+                                &recoverable_sig, msg_hash ) ) {
+    return NULL;
+  }
+
+  return public_key;
+}
+
+char const *
+fd_secp256k1_strerror( int err ) {
+  switch( err ) {
+  case FD_SECP256K1_SUCCESS:    return "success";
+  case FD_SECP256K1_ERR_SIG:    return "bad signature";
+  default: break;
+  }
+  return "unknown";
+}

--- a/src/ballet/secp256k1/fd_secp256k1.h
+++ b/src/ballet/secp256k1/fd_secp256k1.h
@@ -1,0 +1,124 @@
+#ifndef HEADER_fd_src_ballet_secp256k1_fd_secp256k1_h
+#define HEADER_fd_src_ballet_secp256k1_fd_secp256k1_h
+
+/* fd_secp256k1 provides APIs for secp256K1 signature computations. Currently this library wraps
+   libsecp256k1. */
+
+#include "../fd_ballet_base.h"
+
+/* FD_SECP256K1_ERR_* gives a number of error codes used by fd_secp256k1
+   APIs. */
+
+#define FD_SECP256K1_SUCCESS    ( 0) /* Operation was succesful */
+#define FD_SECP256K1_ERR_SIG    (-1) /* Operation failed because the signature was obviously invalid */
+
+/* FD_SECP256K1_SIG_SZ: the size of an secp256k1 signature in bytes. */
+#define FD_SECP256K1_SIG_SZ (32UL)
+
+/* An secp256k1 signature. */
+typedef uchar fd_secp256k1_sig_t[ FD_SECP256K1_SIG_SZ ];
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_secp256k1_public_from_private computes the public_key corresponding
+   to the given private key.
+
+   public_key is assumed to point to the first byte of a 64-byte memory
+   region which will hold the public key on return.
+
+   private_key assumed to point to first byte of a 32-byte memory region
+   private key for which the public key is desired.
+
+   sha is a handle of a local join to a sha256 calculator.
+
+   Does no input argument checking.  The caller takes a write interest
+   in public_key and a read interest in public_key for the
+   duration the call.  Sanitizes the sha and stack to minimize risk of
+   leaking private key info before returning.  Returns public_key. */
+
+void *
+fd_secp256k1_public_from_private( void *        public_key,
+                                  void const *  private_key );
+
+/* fd_secp256k1_sign signs a message according to the SECP256K1 standard.
+
+   sig is assumed to point to the first byte of a 64-byte memory region
+   which will hold the signature on return.
+
+   msg_hash is assumed to point to the first byte of a 32-byte memory region
+   which holds the message hash to sign.
+
+   public_key is assumed to point to first byte of a 64-byte memory
+   region that holds the public key to use to sign this message.
+
+   private_key is assumed to point to first byte of a 32-byte memory
+   region that holds the private key to use to sign this message.
+
+   Does no input argument checking.  Sanitizes the stack to
+   minimize risk of leaking private key info after return.  The caller
+   takes a write interest in sig and sha and a read interest in msg_hash,
+   public_key and private_key for the duration the call.  Returns sig. */
+
+void *
+fd_secp256k1_sign( void *        sig,
+                   void const *  msg_hash,
+                   void const *  private_key );
+
+/* fd_secp256k1_verify verifies message according to the SECP256K1 standard.
+
+   msg_hash is assumed to point to the first byte of a 32-byte memory region
+   which holds the message to verify.
+
+   sig is assumed to point to the first byte of a 32-byte memory region
+   which holds the signature of the message.
+
+   public_key is assumed to point to first byte of a 64-byte memory
+   region that holds the public key to use to verify this message.
+
+   Does no input argument checking.  This function takes a write
+   interest in sig and a read interest in msg_hash, public_key and
+   private_key for the duration the call.  Sanitizes the sha and stack
+   to minimize risk of leaking private key info after return.  Returns
+   FD_SECP256K1_SUCCESS (0) if the message verified successfully or a
+   FD_SECP256K1_ERR_* code indicating the failure reason otherwise. */
+
+int
+fd_secp256k1_verify( void const *  msg_hash,
+                     void const *  sig,
+                     void const *  public_key );
+
+/* fd_secp256k1_recover recovers a public key from a recoverable SECP256K1 signature.
+    
+   msg_hash is assumed to point to the first byte of a 32-byte memory region
+   which holds the message to verify.
+
+   sig is assumed to point to the first byte of a 64-byte memory region
+   which holds the recoverable signature of the message.
+
+   public_key is assumed to point to first byte of a 64-byte memory
+   region that will hold public key recovered from the signature.
+  
+   recovery_id is the recovery id number used in the signing process.
+
+   Does no input argument checking.  This function takes a write
+   interest in public_key and a read interest in msg_hash, public_key and
+   private_key for the duration the call.  Returns public_key on success and 
+   NULL on failure. */
+
+void *
+fd_secp256k1_recover( void *       public_key,
+                      void const * msg_hash,
+                      void const * sig,
+                      int          recovery_id );
+
+/* fd_secp256k1_strerror converts an FD_SECP256K1_SUCCESS / FD_SECP256K1_ERR_*
+   code into a human readable cstr.  The lifetime of the returned
+   pointer is infinite.  The returned pointer is always to a non-NULL
+   cstr. */
+
+FD_FN_CONST char const *
+fd_secp256k1_strerror( int err );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_ballet_secp256k1_fd_secp256k1_h */

--- a/src/ballet/secp256k1/test_secp256k1.c
+++ b/src/ballet/secp256k1/test_secp256k1.c
@@ -1,0 +1,153 @@
+#include "../fd_ballet.h"
+#include "fd_secp256k1.h"
+
+static uchar *
+fd_rng_b256( fd_rng_t * rng,
+             uchar *    r ) {
+  ulong * u = (ulong *)r;
+  u[0] = fd_rng_ulong( rng ); u[1] = fd_rng_ulong( rng ); u[2] = fd_rng_ulong( rng ); u[3] = fd_rng_ulong( rng );
+  return r;
+}
+
+static void
+log_bench( char const * descr,
+           ulong        iter,
+           long         dt ) {
+  float khz = 1e6f *(float)iter/(float)dt;
+  float tau = (float)dt /(float)iter;
+  FD_LOG_NOTICE(( "%-31s %11.3fK/s/core %10.3f ns/call", descr, (double)khz, (double)tau ));
+}
+
+
+static void
+test_public_from_private( fd_rng_t * rng ) {
+  uchar _prv[32]; uchar * prv = _prv;
+  uchar _pub[64]; uchar * pub = _pub;
+  
+  fd_rng_b256( rng, prv );
+  ulong iter = 10000UL;
+  long dt = fd_log_wallclock();
+  for( ulong rem=iter; rem; rem-- ) {
+    FD_COMPILER_FORGET( prv ); FD_COMPILER_FORGET( pub );
+    FD_TEST( fd_secp256k1_public_from_private( pub, prv ) != NULL );
+  }
+  dt = fd_log_wallclock() - dt;
+  log_bench( "fd_secp256k1_public_from_private", iter, dt );
+}
+
+static void
+test_sign( fd_rng_t * rng ) {
+  uchar _msg_hash[ 32 ]; uchar * msg_hash = _msg_hash;
+  uchar _pub[ 64 ]; uchar * pub = _pub;
+  uchar _prv[ 32 ]; uchar * prv = _prv;
+  uchar _sig[ 64 ]; uchar * sig = _sig;
+  
+  for( ulong b=0; b<32UL; b++ ) msg_hash[b] = fd_rng_uchar( rng );
+  fd_secp256k1_public_from_private( pub, fd_rng_b256( rng, prv ) );
+  ulong iter = 10000UL;
+
+  ulong sz = 32;
+  long dt = fd_log_wallclock();
+  for( ulong rem=iter; rem; rem-- ) {
+    FD_COMPILER_FORGET( sig ); FD_COMPILER_FORGET( msg_hash ); FD_COMPILER_FORGET( prv ); 
+    FD_COMPILER_FORGET( pub );
+    fd_secp256k1_sign( sig, msg_hash, prv );
+  }
+  dt = fd_log_wallclock() - dt;
+
+  char cstr[128];
+  log_bench( fd_cstr_printf( cstr, 128UL, NULL, "fd_secp256k1_sign(%lu)", sz ), iter, dt );
+}
+
+static void
+test_verify( fd_rng_t * rng ) {
+  uchar _msg_hash[ 32 ]; uchar * msg_hash = _msg_hash;
+  uchar _pub[ 64 ]; uchar * pub = _pub;
+  uchar _sig[ 64 ]; uchar * sig = _sig;
+  uchar _prv[ 32 ]; uchar * prv = _prv;
+  
+  for( ulong b=0; b<32UL; b++ ) msg_hash[b] = fd_rng_uchar( rng );
+  FD_TEST( fd_secp256k1_public_from_private( pub, fd_rng_b256( rng, prv ) )!=NULL );
+  ulong iter = 10000UL;
+  
+  ulong sz = 32;
+  {
+    fd_secp256k1_sign( sig, msg_hash, prv );
+    long dt = fd_log_wallclock();
+    for( ulong rem=iter; rem; rem-- ) {
+      FD_COMPILER_FORGET( sig ); FD_COMPILER_FORGET( msg_hash ); FD_COMPILER_FORGET( pub );
+      fd_secp256k1_verify( msg_hash, sig, pub );
+    }
+    dt = fd_log_wallclock() - dt;
+    char cstr[128];
+    log_bench( fd_cstr_printf( cstr, 128UL, NULL, "fd_secp256k1_verify(good %lu)", sz ), iter, dt );
+  }
+
+  {
+    fd_secp256k1_sign( sig, msg_hash, prv );
+    long dt = fd_log_wallclock();
+    for( ulong rem=iter; rem; rem-- ) {
+      FD_COMPILER_FORGET( sig ); FD_COMPILER_FORGET( msg_hash ); FD_COMPILER_FORGET( pub );
+      ulong idx  = (ulong)fd_rng_uint_roll( rng, 512UL );
+      ulong byte = idx>>3;
+      ulong bit  = idx & 7UL;
+      sig[ byte ] = (uchar)(((ulong)sig[ byte ]) ^ (1UL<<bit));
+      fd_secp256k1_verify( msg_hash, sig, pub );
+    }
+    dt = fd_log_wallclock() - dt;
+    char cstr[128];
+    log_bench( fd_cstr_printf( cstr, 128UL, NULL, "fd_secp256k1_verify(bad sig %lu)", sz ), iter, dt );
+  }
+
+  {
+    fd_secp256k1_sign( sig, msg_hash, prv );
+    long dt = fd_log_wallclock();
+    for( ulong rem=iter; rem; rem-- ) {
+      FD_COMPILER_FORGET( sig ); FD_COMPILER_FORGET( msg_hash ); FD_COMPILER_FORGET( pub );
+      ulong idx  = (ulong)fd_rng_uint_roll( rng, 8U*(uint)sz );
+      ulong byte = idx>>3;
+      ulong bit  = idx & 7UL;
+      msg_hash[ byte ] = (uchar)(((ulong)msg_hash[ byte ]) ^ (1UL<<bit));
+
+      fd_secp256k1_verify( msg_hash, sig, pub );
+    }
+    dt = fd_log_wallclock() - dt;
+    char cstr[128];
+    log_bench( fd_cstr_printf( cstr, 128UL, NULL, "fd_secp256k1_verify(bad msg %lu)", sz ), iter, dt );
+  }
+
+  {
+    fd_secp256k1_sign( sig, msg_hash, prv );
+    long dt = fd_log_wallclock();
+    for( ulong rem=iter; rem; rem-- ) {
+      FD_COMPILER_FORGET( sig ); FD_COMPILER_FORGET( msg_hash ); FD_COMPILER_FORGET( pub );
+      ulong idx  = (ulong)fd_rng_uint_roll( rng, 256UL );
+      ulong byte = idx>>3;
+      ulong bit  = idx & 7UL;
+      pub[ byte ] = (uchar)(((ulong)pub[ byte ]) ^ (1UL<<bit));
+
+      fd_secp256k1_verify( msg_hash, sig, pub );
+    }
+    dt = fd_log_wallclock() - dt;
+    char cstr[128];
+    log_bench( fd_cstr_printf( cstr, 128UL, NULL, "fd_secp256k1_verify(bad pub %lu)", sz ), iter, dt );
+  }
+}
+
+/**********************************************************************/
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+  fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
+
+  test_public_from_private( rng );
+  test_sign               ( rng );
+  test_verify             ( rng );
+
+  fd_rng_delete( fd_rng_leave( rng ) );
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
Adds secp256k1 signing algorithm support. For now this implementation is a wrapper around libsecp256k1. This will be used by the Secp256k1 native Solana program. 

There are some potential improvements to be made and those are documented in the code.