### PR TITLE
nix: use gcc-9.3.0

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,14 +2,16 @@
   pkgs ? import (fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/de408167ede9c2cab0a7831f4079ff9ba8c644d8.tar.gz";
     sha256 = "sha256:05xf26nd4ryyrx9xn3rzpzawf14r1pw8r0ljba0as852w63z4rh9";
+  }) {},
+  gcc930chan ? import (fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/3b05df1d13c1b315cecc610a2f3180f6669442f0.tar.gz";
   }) {}
 }:
 
 pkgs.mkShell {
   packages = with pkgs;[
     # Compiler (GCC)
-    gcc9
-    gcc9Stdenv
+    gcc930chan.gcc-unwrapped
 
     # Compiler (Clang)
     clang_15


### PR DESCRIPTION
Rational: 
> gcc-9.3 is in some sense the "official" one for gcc builds

```
(marcus/use-gcc930) » nix-shell --run 'gcc --version'

gcc (GCC) 9.3.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```