### PR TITLE
Revert "nix: use gcc-9.3.0"

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,16 +2,14 @@
   pkgs ? import (fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/de408167ede9c2cab0a7831f4079ff9ba8c644d8.tar.gz";
     sha256 = "sha256:05xf26nd4ryyrx9xn3rzpzawf14r1pw8r0ljba0as852w63z4rh9";
-  }) {},
-  gcc930chan ? import (fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/3b05df1d13c1b315cecc610a2f3180f6669442f0.tar.gz";
   }) {}
 }:
 
 pkgs.mkShell {
   packages = with pkgs;[
     # Compiler (GCC)
-    gcc930chan.gcc-unwrapped
+    gcc9
+    gcc9Stdenv
 
     # Compiler (Clang)
     clang_15


### PR DESCRIPTION
This reverts commit df32e0463d6baa04a37c334be2c8d30e01b6fd6f.

I think I misunderstood how nix channels work. Their behavior makes the most sense. We need to revert this previous PR until we pick a path forward.