### PR TITLE
Round of SHA performance tuning

### DIFF
--- a/src/ballet/sha256/fd_sha256_batch_avx.c
+++ b/src/ballet/sha256/fd_sha256_batch_avx.c
@@ -1,5 +1,6 @@
 #include "fd_sha256.h"
 #include "../../util/simd/fd_avx.h"
+#include "../../util/simd/fd_sse.h"
 
 void
 fd_sha256_private_batch_avx( ulong                batch_cnt,
@@ -7,7 +8,7 @@ fd_sha256_private_batch_avx( ulong                batch_cnt,
                              ulong const *        batch_sz,
                              void * const *       _batch_hash ) {
 
-  if( FD_UNLIKELY( batch_cnt<7UL ) ) { /* FIXME: should be ~7 if fd_sha256_hash is using SHA-NI extensions, ~2 o.w. */
+  if( FD_UNLIKELY( batch_cnt<6UL ) ) { /* FIXME: should be ~6 if fd_sha256_hash is using SHA-NI extensions, ~2 o.w. */
     for( ulong batch_idx=0UL; batch_idx<batch_cnt; batch_idx++ )
       fd_sha256_hash( _batch_data[ batch_idx ], batch_sz[ batch_idx ], _batch_hash[ batch_idx ] );
     return;
@@ -29,7 +30,7 @@ fd_sha256_private_batch_avx( ulong                batch_cnt,
   ulong const * batch_data = (ulong const *)_batch_data;
   
   ulong batch_tail_data[ FD_SHA256_PRIVATE_BATCH_MAX ] __attribute__((aligned(32)));
-  ulong batch_tail_sz  [ FD_SHA256_PRIVATE_BATCH_MAX ] __attribute__((aligned(32)));
+  ulong batch_tail_rem [ FD_SHA256_PRIVATE_BATCH_MAX ] __attribute__((aligned(32)));
 
   uchar scratch[ FD_SHA256_PRIVATE_BATCH_MAX*2UL*FD_SHA256_PRIVATE_BUF_MAX ] __attribute__((aligned(64)));
   do {
@@ -50,7 +51,7 @@ fd_sha256_private_batch_avx( ulong                batch_cnt,
       ulong tail_sz       = fd_ulong_align_up( tail_data_sz+9UL, FD_SHA256_PRIVATE_BUF_MAX );
 
       batch_tail_data[ batch_idx ] = tail_data;
-      batch_tail_sz  [ batch_idx ] = tail_sz;
+      batch_tail_rem [ batch_idx ] = tail_sz >> FD_SHA256_PRIVATE_LG_BUF_MAX;
 
       scratch_free += tail_sz;
 
@@ -65,9 +66,30 @@ fd_sha256_private_batch_avx( ulong                batch_cnt,
       wv_st( (ulong *)(tail_data+64), zero );
       wv_st( (ulong *)(tail_data+96), zero );
 
+#     if 1
+      /* Quick experiments found that, once again, straight memcpy is
+         much slower than a fd_memcpy is slightly slower than a
+         site-optimized handrolled memcpy (fd_memcpy would be less L1I
+         cache footprint though).  They also found that doing the below
+         in a branchless way is slightly worse and an ILP optimized
+         version of the conditional calculation is about the same.  They
+         also found that vectorizing the overall loop and/or Duffing the
+         vectorized loop did not provide noticeable performance
+         improvements under various styles of memcpy. */
+      ulong src = data + tail_data_off;
+      ulong dst = tail_data;
+      ulong rem = tail_data_sz;
+      if( rem>=32UL ) { wv_st( (ulong *)dst, wv_ldu( (ulong const *)src ) ); dst += 32UL; src += 32UL; rem -= 32UL; }
+      if( rem>=16UL ) { vv_st( (ulong *)dst, vv_ldu( (ulong const *)src ) ); dst += 16UL; src += 16UL; rem -= 16UL; }
+      if( rem>= 8UL ) { *(ulong  *)dst = FD_LOAD( ulong,  src );             dst +=  8UL; src +=  8UL; rem -=  8UL; }
+      if( rem>= 4UL ) { *(uint   *)dst = FD_LOAD( uint,   src );             dst +=  4UL; src +=  4UL; rem -=  4UL; }
+      if( rem>= 2UL ) { *(ushort *)dst = FD_LOAD( ushort, src );             dst +=  2UL; src +=  2UL; rem -=  2UL; }
+      if( rem       ) { *(uchar  *)dst = FD_LOAD( uchar,  src );             dst++;                                 }
+      *(uchar *)dst = (uchar)0x80;
+#     else
       fd_memcpy( (void *)tail_data, (void const *)(data + tail_data_off), tail_data_sz );
-
       *((uchar *)(tail_data+tail_data_sz)) = (uchar)0x80;
+#     endif
 
       *((ulong *)(tail_data+tail_sz-8UL )) = fd_ulong_bswap( sz<<3 );
     }
@@ -82,172 +104,173 @@ fd_sha256_private_batch_avx( ulong                batch_cnt,
   wu_t s6 = wu_bcast( 0x1f83d9abU );
   wu_t s7 = wu_bcast( 0x5be0cd19U );
 
-  wc_t batch_lane    = wc_unpack( (1<<batch_cnt)-1 );
-  wc_t batch_lane_lo = wc_expand( batch_lane, 0 );
-  wc_t batch_lane_hi = wc_expand( batch_lane, 1 );
+  wv_t wv_64        = wv_bcast( FD_SHA256_PRIVATE_BUF_MAX );
+  wv_t W_sentinel   = wv_bcast( (ulong)scratch );
+  wc_t batch_lane   = wc_unpack( (1<<batch_cnt)-1 );
 
-  wv_t wv_64      = wv_bcast( FD_SHA256_PRIVATE_BUF_MAX );
-  wv_t W_sentinel = wv_bcast( (ulong)scratch );
+  wv_t tail_lo      = wv_ld( batch_tail_data   );
+  wv_t tail_hi      = wv_ld( batch_tail_data+4 );
 
-  /* pass 0 does the complete blocks of data and pass 1 does the
-     tail blocks computed above. */
+  wv_t tail_rem_lo  = wv_ld( batch_tail_rem    );
+  wv_t tail_rem_hi  = wv_ld( batch_tail_rem+4  );
 
-  ulong const * pass_data[2] = { batch_data, batch_tail_data };
-  ulong const * pass_sz  [2] = { batch_sz,   batch_tail_sz   };
-  for( ulong pass_idx=0UL; pass_idx<2UL; pass_idx++ ) {
-    ulong const * _W   = pass_data[ pass_idx ];
-    ulong const * _Wsz = pass_sz  [ pass_idx ];
+  wv_t W_lo         = wv_ld( batch_data        );
+  wv_t W_hi         = wv_ld( batch_data+4      );
 
-    wv_t W_lo = wv_ld( _W   );
-    wv_t W_hi = wv_ld( _W+4 );
+  wv_t block_rem_lo = wv_notczero( wc_expand( batch_lane, 0 ),
+                        wv_add( wv_shr( wv_ld( batch_sz   ), FD_SHA256_PRIVATE_LG_BUF_MAX ), tail_rem_lo ) );
+  wv_t block_rem_hi = wv_notczero( wc_expand( batch_lane, 1 ),
+                        wv_add( wv_shr( wv_ld( batch_sz+4 ), FD_SHA256_PRIVATE_LG_BUF_MAX ), tail_rem_hi ) );
+  for(;;) {
+    wc_t active_lane_lo = wv_to_wc( block_rem_lo );
+    wc_t active_lane_hi = wv_to_wc( block_rem_hi );
+    if( FD_UNLIKELY( !wc_any( wc_or( active_lane_lo, active_lane_hi ) ) ) ) break;
 
-    wv_t block_rem_lo = wv_notczero( batch_lane_lo, wv_shr( wv_ld( _Wsz   ), FD_SHA256_PRIVATE_LG_BUF_MAX ) );
-    wv_t block_rem_hi = wv_notczero( batch_lane_hi, wv_shr( wv_ld( _Wsz+4 ), FD_SHA256_PRIVATE_LG_BUF_MAX ) );
+    /* Switch lanes that have hit the end of their in-place bulk
+       processing to their out-of-place scratch tail regions as
+       necessary. */
 
-    for(;;) {
-      wc_t active_lane_lo = wv_to_wc( block_rem_lo );
-      wc_t active_lane_hi = wv_to_wc( block_rem_hi );
-      if( FD_UNLIKELY( !wc_any( wc_or( active_lane_lo, active_lane_hi ) ) ) ) break;
+    W_lo = wv_if( wv_eq( block_rem_lo, tail_rem_lo ), tail_lo, W_lo );
+    W_hi = wv_if( wv_eq( block_rem_hi, tail_rem_hi ), tail_hi, W_hi );
 
-      /* At this point, we have at least 1 block in this message segment
-         pass that has not been processed.  Load the next 64 bytes of
-         each unprocessed block.  Inactive lanes (e.g. message segments
-         in this pass for which we've already processed all the blocks)
-         will load garbage from a sentinel location (and the result of
-         the state computations for the inactive lane will be ignored). */
+    /* At this point, we have at least 1 block in this message segment
+       pass that has not been processed.  Load the next 64 bytes of
+       each unprocessed block.  Inactive lanes (e.g. message segments
+       in this pass for which we've already processed all the blocks)
+       will load garbage from a sentinel location (and the result of
+       the state computations for the inactive lane will be ignored). */
 
-      wv_t W03 = wv_if( active_lane_lo, W_lo, W_sentinel );
-      uint const * W0 = (uint const *)wv_extract( W03, 0 );
-      uint const * W1 = (uint const *)wv_extract( W03, 1 );
-      uint const * W2 = (uint const *)wv_extract( W03, 2 );
-      uint const * W3 = (uint const *)wv_extract( W03, 3 );
+    wv_t W03 = wv_if( active_lane_lo, W_lo, W_sentinel );
+    uint const * W0 = (uint const *)wv_extract( W03, 0 );
+    uint const * W1 = (uint const *)wv_extract( W03, 1 );
+    uint const * W2 = (uint const *)wv_extract( W03, 2 );
+    uint const * W3 = (uint const *)wv_extract( W03, 3 );
 
-      wv_t W47 = wv_if( active_lane_hi, W_hi, W_sentinel );
-      uint const * W4 = (uint const *)wv_extract( W47, 0 );
-      uint const * W5 = (uint const *)wv_extract( W47, 1 );
-      uint const * W6 = (uint const *)wv_extract( W47, 2 );
-      uint const * W7 = (uint const *)wv_extract( W47, 3 );
+    wv_t W47 = wv_if( active_lane_hi, W_hi, W_sentinel );
+    uint const * W4 = (uint const *)wv_extract( W47, 0 );
+    uint const * W5 = (uint const *)wv_extract( W47, 1 );
+    uint const * W6 = (uint const *)wv_extract( W47, 2 );
+    uint const * W7 = (uint const *)wv_extract( W47, 3 );
 
-      wu_t x0; wu_t x1; wu_t x2; wu_t x3; wu_t x4; wu_t x5; wu_t x6; wu_t x7;
-      wu_transpose_8x8( wu_bswap( wu_ldu(W0  ) ), wu_bswap( wu_ldu(W1  ) ), wu_bswap( wu_ldu(W2  ) ), wu_bswap( wu_ldu(W3  ) ),
-                        wu_bswap( wu_ldu(W4  ) ), wu_bswap( wu_ldu(W5  ) ), wu_bswap( wu_ldu(W6  ) ), wu_bswap( wu_ldu(W7  ) ),
-                        x0, x1, x2, x3, x4, x5, x6, x7 );
+    wu_t x0; wu_t x1; wu_t x2; wu_t x3; wu_t x4; wu_t x5; wu_t x6; wu_t x7;
+    wu_transpose_8x8( wu_bswap( wu_ldu(W0  ) ), wu_bswap( wu_ldu(W1  ) ), wu_bswap( wu_ldu(W2  ) ), wu_bswap( wu_ldu(W3  ) ),
+                      wu_bswap( wu_ldu(W4  ) ), wu_bswap( wu_ldu(W5  ) ), wu_bswap( wu_ldu(W6  ) ), wu_bswap( wu_ldu(W7  ) ),
+                      x0, x1, x2, x3, x4, x5, x6, x7 );
 
-      wu_t x8; wu_t x9; wu_t xa; wu_t xb; wu_t xc; wu_t xd; wu_t xe; wu_t xf;
-      wu_transpose_8x8( wu_bswap( wu_ldu(W0+8) ), wu_bswap( wu_ldu(W1+8) ), wu_bswap( wu_ldu(W2+8) ), wu_bswap( wu_ldu(W3+8) ),
-                        wu_bswap( wu_ldu(W4+8) ), wu_bswap( wu_ldu(W5+8) ), wu_bswap( wu_ldu(W6+8) ), wu_bswap( wu_ldu(W7+8) ),
-                        x8, x9, xa, xb, xc, xd, xe, xf );
+    wu_t x8; wu_t x9; wu_t xa; wu_t xb; wu_t xc; wu_t xd; wu_t xe; wu_t xf;
+    wu_transpose_8x8( wu_bswap( wu_ldu(W0+8) ), wu_bswap( wu_ldu(W1+8) ), wu_bswap( wu_ldu(W2+8) ), wu_bswap( wu_ldu(W3+8) ),
+                      wu_bswap( wu_ldu(W4+8) ), wu_bswap( wu_ldu(W5+8) ), wu_bswap( wu_ldu(W6+8) ), wu_bswap( wu_ldu(W7+8) ),
+                      x8, x9, xa, xb, xc, xd, xe, xf );
 
-      /* Compute the SHA-256 state updates */
+    /* Compute the SHA-256 state updates */
 
-      wu_t a = s0; wu_t b = s1; wu_t c = s2; wu_t d = s3; wu_t e = s4; wu_t f = s5; wu_t g = s6; wu_t h = s7;
+    wu_t a = s0; wu_t b = s1; wu_t c = s2; wu_t d = s3; wu_t e = s4; wu_t f = s5; wu_t g = s6; wu_t h = s7;
 
-      static uint const K[64] = { /* FIXME: Reuse with other functions */
-        0x428a2f98U, 0x71374491U, 0xb5c0fbcfU, 0xe9b5dba5U, 0x3956c25bU, 0x59f111f1U, 0x923f82a4U, 0xab1c5ed5U,
-        0xd807aa98U, 0x12835b01U, 0x243185beU, 0x550c7dc3U, 0x72be5d74U, 0x80deb1feU, 0x9bdc06a7U, 0xc19bf174U,
-        0xe49b69c1U, 0xefbe4786U, 0x0fc19dc6U, 0x240ca1ccU, 0x2de92c6fU, 0x4a7484aaU, 0x5cb0a9dcU, 0x76f988daU,
-        0x983e5152U, 0xa831c66dU, 0xb00327c8U, 0xbf597fc7U, 0xc6e00bf3U, 0xd5a79147U, 0x06ca6351U, 0x14292967U,
-        0x27b70a85U, 0x2e1b2138U, 0x4d2c6dfcU, 0x53380d13U, 0x650a7354U, 0x766a0abbU, 0x81c2c92eU, 0x92722c85U,
-        0xa2bfe8a1U, 0xa81a664bU, 0xc24b8b70U, 0xc76c51a3U, 0xd192e819U, 0xd6990624U, 0xf40e3585U, 0x106aa070U,
-        0x19a4c116U, 0x1e376c08U, 0x2748774cU, 0x34b0bcb5U, 0x391c0cb3U, 0x4ed8aa4aU, 0x5b9cca4fU, 0x682e6ff3U,
-        0x748f82eeU, 0x78a5636fU, 0x84c87814U, 0x8cc70208U, 0x90befffaU, 0xa4506cebU, 0xbef9a3f7U, 0xc67178f2U,
-      };
+    static uint const K[64] = { /* FIXME: Reuse with other functions */
+      0x428a2f98U, 0x71374491U, 0xb5c0fbcfU, 0xe9b5dba5U, 0x3956c25bU, 0x59f111f1U, 0x923f82a4U, 0xab1c5ed5U,
+      0xd807aa98U, 0x12835b01U, 0x243185beU, 0x550c7dc3U, 0x72be5d74U, 0x80deb1feU, 0x9bdc06a7U, 0xc19bf174U,
+      0xe49b69c1U, 0xefbe4786U, 0x0fc19dc6U, 0x240ca1ccU, 0x2de92c6fU, 0x4a7484aaU, 0x5cb0a9dcU, 0x76f988daU,
+      0x983e5152U, 0xa831c66dU, 0xb00327c8U, 0xbf597fc7U, 0xc6e00bf3U, 0xd5a79147U, 0x06ca6351U, 0x14292967U,
+      0x27b70a85U, 0x2e1b2138U, 0x4d2c6dfcU, 0x53380d13U, 0x650a7354U, 0x766a0abbU, 0x81c2c92eU, 0x92722c85U,
+      0xa2bfe8a1U, 0xa81a664bU, 0xc24b8b70U, 0xc76c51a3U, 0xd192e819U, 0xd6990624U, 0xf40e3585U, 0x106aa070U,
+      0x19a4c116U, 0x1e376c08U, 0x2748774cU, 0x34b0bcb5U, 0x391c0cb3U, 0x4ed8aa4aU, 0x5b9cca4fU, 0x682e6ff3U,
+      0x748f82eeU, 0x78a5636fU, 0x84c87814U, 0x8cc70208U, 0x90befffaU, 0xa4506cebU, 0xbef9a3f7U, 0xc67178f2U,
+    };
 
-#     define Sigma0(x)  wu_xor( wu_rol(x,30), wu_xor( wu_rol(x,19), wu_rol(x,10) ) )
-#     define Sigma1(x)  wu_xor( wu_rol(x,26), wu_xor( wu_rol(x,21), wu_rol(x, 7) ) )
-#     define sigma0(x)  wu_xor( wu_rol(x,25), wu_xor( wu_rol(x,14), wu_shr(x, 3) ) )
-#     define sigma1(x)  wu_xor( wu_rol(x,15), wu_xor( wu_rol(x,13), wu_shr(x,10) ) )
-#     define Ch(x,y,z)  wu_xor( wu_and(x,y), wu_andnot(x,z) )
-#     define Maj(x,y,z) wu_xor( wu_and(x,y), wu_xor( wu_and(x,z), wu_and(y,z) ) )
-#     define SHA_CORE(xi,ki)                                                       \
-      T1 = wu_add( wu_add(xi,ki), wu_add( wu_add( h, Sigma1(e) ), Ch(e, f, g) ) ); \
-      T2 = wu_add( Sigma0(a), Maj(a, b, c) );                                      \
-      h = g;                                                                       \
-      g = f;                                                                       \
-      f = e;                                                                       \
-      e = wu_add( d, T1 );                                                         \
-      d = c;                                                                       \
-      c = b;                                                                       \
-      b = a;                                                                       \
-      a = wu_add( T1, T2 )
+#   define Sigma0(x)  wu_xor( wu_rol(x,30), wu_xor( wu_rol(x,19), wu_rol(x,10) ) )
+#   define Sigma1(x)  wu_xor( wu_rol(x,26), wu_xor( wu_rol(x,21), wu_rol(x, 7) ) )
+#   define sigma0(x)  wu_xor( wu_rol(x,25), wu_xor( wu_rol(x,14), wu_shr(x, 3) ) )
+#   define sigma1(x)  wu_xor( wu_rol(x,15), wu_xor( wu_rol(x,13), wu_shr(x,10) ) )
+#   define Ch(x,y,z)  wu_xor( wu_and(x,y), wu_andnot(x,z) )
+#   define Maj(x,y,z) wu_xor( wu_and(x,y), wu_xor( wu_and(x,z), wu_and(y,z) ) )
+#   define SHA_CORE(xi,ki)                                                       \
+    T1 = wu_add( wu_add(xi,ki), wu_add( wu_add( h, Sigma1(e) ), Ch(e, f, g) ) ); \
+    T2 = wu_add( Sigma0(a), Maj(a, b, c) );                                      \
+    h = g;                                                                       \
+    g = f;                                                                       \
+    f = e;                                                                       \
+    e = wu_add( d, T1 );                                                         \
+    d = c;                                                                       \
+    c = b;                                                                       \
+    b = a;                                                                       \
+    a = wu_add( T1, T2 )
 
-      wu_t T1;
-      wu_t T2;
+    wu_t T1;
+    wu_t T2;
 
-      SHA_CORE( x0, wu_bcast( K[ 0] ) );
-      SHA_CORE( x1, wu_bcast( K[ 1] ) );
-      SHA_CORE( x2, wu_bcast( K[ 2] ) );
-      SHA_CORE( x3, wu_bcast( K[ 3] ) );
-      SHA_CORE( x4, wu_bcast( K[ 4] ) );
-      SHA_CORE( x5, wu_bcast( K[ 5] ) );
-      SHA_CORE( x6, wu_bcast( K[ 6] ) );
-      SHA_CORE( x7, wu_bcast( K[ 7] ) );
-      SHA_CORE( x8, wu_bcast( K[ 8] ) );
-      SHA_CORE( x9, wu_bcast( K[ 9] ) );
-      SHA_CORE( xa, wu_bcast( K[10] ) );
-      SHA_CORE( xb, wu_bcast( K[11] ) );
-      SHA_CORE( xc, wu_bcast( K[12] ) );
-      SHA_CORE( xd, wu_bcast( K[13] ) );
-      SHA_CORE( xe, wu_bcast( K[14] ) );
-      SHA_CORE( xf, wu_bcast( K[15] ) );
-      for( ulong i=16UL; i<64UL; i+=16UL ) {
-        x0 = wu_add( wu_add( x0, sigma0(x1) ), wu_add( sigma1(xe), x9 ) ); SHA_CORE( x0, wu_bcast( K[i     ] ) );
-        x1 = wu_add( wu_add( x1, sigma0(x2) ), wu_add( sigma1(xf), xa ) ); SHA_CORE( x1, wu_bcast( K[i+ 1UL] ) );
-        x2 = wu_add( wu_add( x2, sigma0(x3) ), wu_add( sigma1(x0), xb ) ); SHA_CORE( x2, wu_bcast( K[i+ 2UL] ) );
-        x3 = wu_add( wu_add( x3, sigma0(x4) ), wu_add( sigma1(x1), xc ) ); SHA_CORE( x3, wu_bcast( K[i+ 3UL] ) );
-        x4 = wu_add( wu_add( x4, sigma0(x5) ), wu_add( sigma1(x2), xd ) ); SHA_CORE( x4, wu_bcast( K[i+ 4UL] ) );
-        x5 = wu_add( wu_add( x5, sigma0(x6) ), wu_add( sigma1(x3), xe ) ); SHA_CORE( x5, wu_bcast( K[i+ 5UL] ) );
-        x6 = wu_add( wu_add( x6, sigma0(x7) ), wu_add( sigma1(x4), xf ) ); SHA_CORE( x6, wu_bcast( K[i+ 6UL] ) );
-        x7 = wu_add( wu_add( x7, sigma0(x8) ), wu_add( sigma1(x5), x0 ) ); SHA_CORE( x7, wu_bcast( K[i+ 7UL] ) );
-        x8 = wu_add( wu_add( x8, sigma0(x9) ), wu_add( sigma1(x6), x1 ) ); SHA_CORE( x8, wu_bcast( K[i+ 8UL] ) );
-        x9 = wu_add( wu_add( x9, sigma0(xa) ), wu_add( sigma1(x7), x2 ) ); SHA_CORE( x9, wu_bcast( K[i+ 9UL] ) );
-        xa = wu_add( wu_add( xa, sigma0(xb) ), wu_add( sigma1(x8), x3 ) ); SHA_CORE( xa, wu_bcast( K[i+10UL] ) );
-        xb = wu_add( wu_add( xb, sigma0(xc) ), wu_add( sigma1(x9), x4 ) ); SHA_CORE( xb, wu_bcast( K[i+11UL] ) );
-        xc = wu_add( wu_add( xc, sigma0(xd) ), wu_add( sigma1(xa), x5 ) ); SHA_CORE( xc, wu_bcast( K[i+12UL] ) );
-        xd = wu_add( wu_add( xd, sigma0(xe) ), wu_add( sigma1(xb), x6 ) ); SHA_CORE( xd, wu_bcast( K[i+13UL] ) );
-        xe = wu_add( wu_add( xe, sigma0(xf) ), wu_add( sigma1(xc), x7 ) ); SHA_CORE( xe, wu_bcast( K[i+14UL] ) );
-        xf = wu_add( wu_add( xf, sigma0(x0) ), wu_add( sigma1(xd), x8 ) ); SHA_CORE( xf, wu_bcast( K[i+15UL] ) );
-      }
-
-#     undef SHA_CORE
-#     undef Sigma0
-#     undef Sigma1
-#     undef sigma0
-#     undef sigma1
-#     undef Ch
-#     undef Maj
-
-      /* Apply the state updates to the active lanes */
-
-      wc_t active_lane = wc_narrow( active_lane_lo, active_lane_hi );
-      s0 = wu_add( s0, wu_notczero( active_lane, a ) );
-      s1 = wu_add( s1, wu_notczero( active_lane, b ) );
-      s2 = wu_add( s2, wu_notczero( active_lane, c ) );
-      s3 = wu_add( s3, wu_notczero( active_lane, d ) );
-      s4 = wu_add( s4, wu_notczero( active_lane, e ) );
-      s5 = wu_add( s5, wu_notczero( active_lane, f ) );
-      s6 = wu_add( s6, wu_notczero( active_lane, g ) );
-      s7 = wu_add( s7, wu_notczero( active_lane, h ) );
-
-      /* Advance to the next message segment blocks.  In pseudo code,
-         the below is:
-
-           W += 64; if( block_rem ) block_rem--;
-
-         Since wc_to_wv_raw(false/true) is 0UL/~0UL, we can use wv_add /
-         wc_to_wv_raw instead of wv_sub / wc_to_wv to save some ops.
-         (Consider conditional increment / decrement operations?)
-
-         Also since we do not load anything at W(lane) above unless
-         block_rem(lane) is non-zero, we can omit vector conditional
-         operations for W(lane) below to save some additional ops. */
-
-      W_lo = wv_add( W_lo, wv_64 );
-      W_hi = wv_add( W_hi, wv_64 );
-
-      block_rem_lo = wv_add( block_rem_lo, wc_to_wv_raw( active_lane_lo ) );
-      block_rem_hi = wv_add( block_rem_hi, wc_to_wv_raw( active_lane_hi ) );
+    SHA_CORE( x0, wu_bcast( K[ 0] ) );
+    SHA_CORE( x1, wu_bcast( K[ 1] ) );
+    SHA_CORE( x2, wu_bcast( K[ 2] ) );
+    SHA_CORE( x3, wu_bcast( K[ 3] ) );
+    SHA_CORE( x4, wu_bcast( K[ 4] ) );
+    SHA_CORE( x5, wu_bcast( K[ 5] ) );
+    SHA_CORE( x6, wu_bcast( K[ 6] ) );
+    SHA_CORE( x7, wu_bcast( K[ 7] ) );
+    SHA_CORE( x8, wu_bcast( K[ 8] ) );
+    SHA_CORE( x9, wu_bcast( K[ 9] ) );
+    SHA_CORE( xa, wu_bcast( K[10] ) );
+    SHA_CORE( xb, wu_bcast( K[11] ) );
+    SHA_CORE( xc, wu_bcast( K[12] ) );
+    SHA_CORE( xd, wu_bcast( K[13] ) );
+    SHA_CORE( xe, wu_bcast( K[14] ) );
+    SHA_CORE( xf, wu_bcast( K[15] ) );
+    for( ulong i=16UL; i<64UL; i+=16UL ) {
+      x0 = wu_add( wu_add( x0, sigma0(x1) ), wu_add( sigma1(xe), x9 ) ); SHA_CORE( x0, wu_bcast( K[i     ] ) );
+      x1 = wu_add( wu_add( x1, sigma0(x2) ), wu_add( sigma1(xf), xa ) ); SHA_CORE( x1, wu_bcast( K[i+ 1UL] ) );
+      x2 = wu_add( wu_add( x2, sigma0(x3) ), wu_add( sigma1(x0), xb ) ); SHA_CORE( x2, wu_bcast( K[i+ 2UL] ) );
+      x3 = wu_add( wu_add( x3, sigma0(x4) ), wu_add( sigma1(x1), xc ) ); SHA_CORE( x3, wu_bcast( K[i+ 3UL] ) );
+      x4 = wu_add( wu_add( x4, sigma0(x5) ), wu_add( sigma1(x2), xd ) ); SHA_CORE( x4, wu_bcast( K[i+ 4UL] ) );
+      x5 = wu_add( wu_add( x5, sigma0(x6) ), wu_add( sigma1(x3), xe ) ); SHA_CORE( x5, wu_bcast( K[i+ 5UL] ) );
+      x6 = wu_add( wu_add( x6, sigma0(x7) ), wu_add( sigma1(x4), xf ) ); SHA_CORE( x6, wu_bcast( K[i+ 6UL] ) );
+      x7 = wu_add( wu_add( x7, sigma0(x8) ), wu_add( sigma1(x5), x0 ) ); SHA_CORE( x7, wu_bcast( K[i+ 7UL] ) );
+      x8 = wu_add( wu_add( x8, sigma0(x9) ), wu_add( sigma1(x6), x1 ) ); SHA_CORE( x8, wu_bcast( K[i+ 8UL] ) );
+      x9 = wu_add( wu_add( x9, sigma0(xa) ), wu_add( sigma1(x7), x2 ) ); SHA_CORE( x9, wu_bcast( K[i+ 9UL] ) );
+      xa = wu_add( wu_add( xa, sigma0(xb) ), wu_add( sigma1(x8), x3 ) ); SHA_CORE( xa, wu_bcast( K[i+10UL] ) );
+      xb = wu_add( wu_add( xb, sigma0(xc) ), wu_add( sigma1(x9), x4 ) ); SHA_CORE( xb, wu_bcast( K[i+11UL] ) );
+      xc = wu_add( wu_add( xc, sigma0(xd) ), wu_add( sigma1(xa), x5 ) ); SHA_CORE( xc, wu_bcast( K[i+12UL] ) );
+      xd = wu_add( wu_add( xd, sigma0(xe) ), wu_add( sigma1(xb), x6 ) ); SHA_CORE( xd, wu_bcast( K[i+13UL] ) );
+      xe = wu_add( wu_add( xe, sigma0(xf) ), wu_add( sigma1(xc), x7 ) ); SHA_CORE( xe, wu_bcast( K[i+14UL] ) );
+      xf = wu_add( wu_add( xf, sigma0(x0) ), wu_add( sigma1(xd), x8 ) ); SHA_CORE( xf, wu_bcast( K[i+15UL] ) );
     }
+
+#   undef SHA_CORE
+#   undef Sigma0
+#   undef Sigma1
+#   undef sigma0
+#   undef sigma1
+#   undef Ch
+#   undef Maj
+
+    /* Apply the state updates to the active lanes */
+
+    wc_t active_lane = wc_narrow( active_lane_lo, active_lane_hi );
+    s0 = wu_add( s0, wu_notczero( active_lane, a ) );
+    s1 = wu_add( s1, wu_notczero( active_lane, b ) );
+    s2 = wu_add( s2, wu_notczero( active_lane, c ) );
+    s3 = wu_add( s3, wu_notczero( active_lane, d ) );
+    s4 = wu_add( s4, wu_notczero( active_lane, e ) );
+    s5 = wu_add( s5, wu_notczero( active_lane, f ) );
+    s6 = wu_add( s6, wu_notczero( active_lane, g ) );
+    s7 = wu_add( s7, wu_notczero( active_lane, h ) );
+
+    /* Advance to the next message segment blocks.  In pseudo code,
+       the below is:
+
+         W += 64; if( block_rem ) block_rem--;
+
+       Since wc_to_wv_raw(false/true) is 0UL/~0UL, we can use wv_add /
+       wc_to_wv_raw instead of wv_sub / wc_to_wv to save some ops.
+       (Consider conditional increment / decrement operations?)
+
+       Also since we do not load anything at W(lane) above unless
+       block_rem(lane) is non-zero, we can omit vector conditional
+       operations for W(lane) below to save some additional ops. */
+
+    W_lo = wv_add( W_lo, wv_64 );
+    W_hi = wv_add( W_hi, wv_64 );
+
+    block_rem_lo = wv_add( block_rem_lo, wc_to_wv_raw( active_lane_lo ) );
+    block_rem_hi = wv_add( block_rem_hi, wc_to_wv_raw( active_lane_hi ) );
   }
 
   /* Store the results.  FIXME: Probably could optimize the transpose

--- a/src/ballet/sha512/fd_sha512_batch_avx.c
+++ b/src/ballet/sha512/fd_sha512_batch_avx.c
@@ -1,5 +1,6 @@
 #include "fd_sha512.h"
 #include "../../util/simd/fd_avx.h"
+#include "../../util/simd/fd_sse.h"
 
 void
 fd_sha512_private_batch_avx( ulong                batch_cnt,
@@ -29,7 +30,7 @@ fd_sha512_private_batch_avx( ulong                batch_cnt,
   ulong const * batch_data = (ulong const *)_batch_data;
   
   ulong batch_tail_data[ FD_SHA512_PRIVATE_BATCH_MAX ] __attribute__((aligned(32)));
-  ulong batch_tail_sz  [ FD_SHA512_PRIVATE_BATCH_MAX ] __attribute__((aligned(32)));
+  ulong batch_tail_rem [ FD_SHA512_PRIVATE_BATCH_MAX ] __attribute__((aligned(32)));
 
   uchar scratch[ FD_SHA512_PRIVATE_BATCH_MAX*2UL*FD_SHA512_PRIVATE_BUF_MAX ] __attribute__((aligned(128)));
   do {
@@ -50,7 +51,7 @@ fd_sha512_private_batch_avx( ulong                batch_cnt,
       ulong tail_sz       = fd_ulong_align_up( tail_data_sz+17UL, FD_SHA512_PRIVATE_BUF_MAX );
 
       batch_tail_data[ batch_idx ] = tail_data;
-      batch_tail_sz  [ batch_idx ] = tail_sz;
+      batch_tail_rem [ batch_idx ] = tail_sz >> FD_SHA512_PRIVATE_LG_BUF_MAX;
 
       scratch_free += tail_sz;
 
@@ -65,9 +66,22 @@ fd_sha512_private_batch_avx( ulong                batch_cnt,
       wv_st( (ulong *)(tail_data+128), zero ); wv_st( (ulong *)(tail_data+160), zero );
       wv_st( (ulong *)(tail_data+192), zero ); wv_st( (ulong *)(tail_data+224), zero );
 
+#     if 1
+      /* See notes in fd_sha256_batch_avx.c for more details here */
+      ulong src = data + tail_data_off;
+      ulong dst = tail_data;
+      ulong rem = tail_data_sz;
+      while( rem>=32UL ) { wv_st( (ulong *)dst, wv_ldu( (ulong const *)src ) ); dst += 32UL; src += 32UL; rem -= 32UL; }
+      if(    rem>=16UL ) { vv_st( (ulong *)dst, vv_ldu( (ulong const *)src ) ); dst += 16UL; src += 16UL; rem -= 16UL; }
+      if(    rem>= 8UL ) { *(ulong  *)dst = FD_LOAD( ulong,  src );             dst +=  8UL; src +=  8UL; rem -=  8UL; }
+      if(    rem>= 4UL ) { *(uint   *)dst = FD_LOAD( uint,   src );             dst +=  4UL; src +=  4UL; rem -=  4UL; }
+      if(    rem>= 2UL ) { *(ushort *)dst = FD_LOAD( ushort, src );             dst +=  2UL; src +=  2UL; rem -=  2UL; }
+      if(    rem       ) { *(uchar  *)dst = FD_LOAD( uchar,  src );             dst++;                                 }
+      *(uchar *)dst = (uchar)0x80;
+#     else
       fd_memcpy( (void *)tail_data, (void const *)(data + tail_data_off), tail_data_sz );
-
       *((uchar *)(tail_data+tail_data_sz)) = (uchar)0x80;
+#     endif
 
       *((ulong *)(tail_data+tail_sz-16UL )) = fd_ulong_bswap( sz>>61 );
       *((ulong *)(tail_data+tail_sz- 8UL )) = fd_ulong_bswap( sz<< 3 );
@@ -83,172 +97,170 @@ fd_sha512_private_batch_avx( ulong                batch_cnt,
   wv_t s6 = wv_bcast( 0x1f83d9abfb41bd6bUL );
   wv_t s7 = wv_bcast( 0x5be0cd19137e2179UL );
 
-  wc_t batch_lane = wc_unpack( (1<<(2*batch_cnt))-1 );
-
   wv_t wv_128     = wv_bcast( FD_SHA512_PRIVATE_BUF_MAX );
   wv_t W_sentinel = wv_bcast( (ulong)scratch );
+  wc_t batch_lane = wc_unpack( (1<<(2*batch_cnt))-1 );
+  wv_t tail       = wv_ld( batch_tail_data );
+  wv_t tail_rem   = wv_ld( batch_tail_rem  );
+  wv_t W          = wv_ld( batch_data      );
+  wv_t block_rem  = wv_notczero( batch_lane, wv_add( wv_shr( wv_ld( batch_sz ), FD_SHA512_PRIVATE_LG_BUF_MAX ), tail_rem ) );
+  for(;;) {
+    wc_t active_lane = wv_to_wc( block_rem );
+    if( FD_UNLIKELY( !wc_any( active_lane ) ) ) break;
 
-  /* pass 0 does the complete blocks of data and pass 1 does the
-     tail blocks computed above. */
+    /* Switch lanes that have hit the end of their in-place bulk
+       processing to their out-of-place scratch tail regions as
+       necessary. */
 
-  ulong const * pass_data[2] = { batch_data, batch_tail_data };
-  ulong const * pass_sz  [2] = { batch_sz,   batch_tail_sz   };
-  for( ulong pass_idx=0UL; pass_idx<2UL; pass_idx++ ) {
-    wv_t W         = wv_ld( (ulong const *)pass_data[ pass_idx ] );
-    wv_t block_rem = wv_notczero( batch_lane, wv_shr( wv_ld( (ulong const *)pass_sz[ pass_idx ] ), FD_SHA512_PRIVATE_LG_BUF_MAX ) );
+    W = wv_if( wv_eq( block_rem, tail_rem ), tail, W );
 
-    for(;;) {
-      wc_t active_lane = wv_to_wc( block_rem );
-      if( FD_UNLIKELY( !wc_any( active_lane ) ) ) break;
+    /* At this point, we have at least 1 block in this message segment
+       pass that has not been processed.  Load the next 128 bytes of
+       each unprocessed block.  Inactive lanes (e.g. message segments
+       in this pass for which we've already processed all the blocks)
+       will load garbage from a sentinel location (and the result of
+       the state computations for the inactive lane will be ignored). */
 
-      /* At this point, we have at least 1 block in this message segment
-         pass that has not been processed.  Load the next 128 bytes of
-         each unprocessed block.  Inactive lanes (e.g. message segments
-         in this pass for which we've already processed all the blocks)
-         will load garbage from a sentinel location (and the result of
-         the state computations for the inactive lane will be ignored). */
+    wv_t W03 = wv_if( active_lane, W, W_sentinel );
+    ulong const * W0 = (ulong const *)wv_extract( W03, 0 );
+    ulong const * W1 = (ulong const *)wv_extract( W03, 1 );
+    ulong const * W2 = (ulong const *)wv_extract( W03, 2 );
+    ulong const * W3 = (ulong const *)wv_extract( W03, 3 );
 
-      wv_t W03 = wv_if( active_lane, W, W_sentinel );
-      ulong const * W0 = (ulong const *)wv_extract( W03, 0 );
-      ulong const * W1 = (ulong const *)wv_extract( W03, 1 );
-      ulong const * W2 = (ulong const *)wv_extract( W03, 2 );
-      ulong const * W3 = (ulong const *)wv_extract( W03, 3 );
+    wv_t x0; wv_t x1; wv_t x2; wv_t x3;
+    wv_transpose_4x4( wv_bswap( wv_ldu(W0   ) ), wv_bswap( wv_ldu(W1   ) ), wv_bswap( wv_ldu(W2   ) ), wv_bswap( wv_ldu(W3   ) ),
+                      x0, x1, x2, x3 );
 
-      wv_t x0; wv_t x1; wv_t x2; wv_t x3;
-      wv_transpose_4x4( wv_bswap( wv_ldu(W0   ) ), wv_bswap( wv_ldu(W1   ) ), wv_bswap( wv_ldu(W2   ) ), wv_bswap( wv_ldu(W3   ) ),
-                        x0, x1, x2, x3 );
+    wv_t x4; wv_t x5; wv_t x6; wv_t x7;
+    wv_transpose_4x4( wv_bswap( wv_ldu(W0+ 4) ), wv_bswap( wv_ldu(W1+ 4) ), wv_bswap( wv_ldu(W2+ 4) ), wv_bswap( wv_ldu(W3+ 4) ),
+                      x4, x5, x6, x7 );
 
-      wv_t x4; wv_t x5; wv_t x6; wv_t x7;
-      wv_transpose_4x4( wv_bswap( wv_ldu(W0+ 4) ), wv_bswap( wv_ldu(W1+ 4) ), wv_bswap( wv_ldu(W2+ 4) ), wv_bswap( wv_ldu(W3+ 4) ),
-                        x4, x5, x6, x7 );
+    wv_t x8; wv_t x9; wv_t xa; wv_t xb;
+    wv_transpose_4x4( wv_bswap( wv_ldu(W0+ 8) ), wv_bswap( wv_ldu(W1+ 8) ), wv_bswap( wv_ldu(W2+ 8) ), wv_bswap( wv_ldu(W3+ 8) ),
+                      x8, x9, xa, xb );
 
-      wv_t x8; wv_t x9; wv_t xa; wv_t xb;
-      wv_transpose_4x4( wv_bswap( wv_ldu(W0+ 8) ), wv_bswap( wv_ldu(W1+ 8) ), wv_bswap( wv_ldu(W2+ 8) ), wv_bswap( wv_ldu(W3+ 8) ),
-                        x8, x9, xa, xb );
+    wv_t xc; wv_t xd; wv_t xe; wv_t xf;
+    wv_transpose_4x4( wv_bswap( wv_ldu(W0+12) ), wv_bswap( wv_ldu(W1+12) ), wv_bswap( wv_ldu(W2+12) ), wv_bswap( wv_ldu(W3+12) ),
+                      xc, xd, xe, xf );
 
-      wv_t xc; wv_t xd; wv_t xe; wv_t xf;
-      wv_transpose_4x4( wv_bswap( wv_ldu(W0+12) ), wv_bswap( wv_ldu(W1+12) ), wv_bswap( wv_ldu(W2+12) ), wv_bswap( wv_ldu(W3+12) ),
-                        xc, xd, xe, xf );
+    /* Compute the SHA-512 state updates */
 
-      /* Compute the SHA-512 state updates */
+    wv_t a = s0; wv_t b = s1; wv_t c = s2; wv_t d = s3; wv_t e = s4; wv_t f = s5; wv_t g = s6; wv_t h = s7;
 
-      wv_t a = s0; wv_t b = s1; wv_t c = s2; wv_t d = s3; wv_t e = s4; wv_t f = s5; wv_t g = s6; wv_t h = s7;
+    static ulong const K[80] = { /* FIXME: Reuse with other functions */
+      0x428a2f98d728ae22UL, 0x7137449123ef65cdUL, 0xb5c0fbcfec4d3b2fUL, 0xe9b5dba58189dbbcUL,
+      0x3956c25bf348b538UL, 0x59f111f1b605d019UL, 0x923f82a4af194f9bUL, 0xab1c5ed5da6d8118UL,
+      0xd807aa98a3030242UL, 0x12835b0145706fbeUL, 0x243185be4ee4b28cUL, 0x550c7dc3d5ffb4e2UL,
+      0x72be5d74f27b896fUL, 0x80deb1fe3b1696b1UL, 0x9bdc06a725c71235UL, 0xc19bf174cf692694UL,
+      0xe49b69c19ef14ad2UL, 0xefbe4786384f25e3UL, 0x0fc19dc68b8cd5b5UL, 0x240ca1cc77ac9c65UL,
+      0x2de92c6f592b0275UL, 0x4a7484aa6ea6e483UL, 0x5cb0a9dcbd41fbd4UL, 0x76f988da831153b5UL,
+      0x983e5152ee66dfabUL, 0xa831c66d2db43210UL, 0xb00327c898fb213fUL, 0xbf597fc7beef0ee4UL,
+      0xc6e00bf33da88fc2UL, 0xd5a79147930aa725UL, 0x06ca6351e003826fUL, 0x142929670a0e6e70UL,
+      0x27b70a8546d22ffcUL, 0x2e1b21385c26c926UL, 0x4d2c6dfc5ac42aedUL, 0x53380d139d95b3dfUL,
+      0x650a73548baf63deUL, 0x766a0abb3c77b2a8UL, 0x81c2c92e47edaee6UL, 0x92722c851482353bUL,
+      0xa2bfe8a14cf10364UL, 0xa81a664bbc423001UL, 0xc24b8b70d0f89791UL, 0xc76c51a30654be30UL,
+      0xd192e819d6ef5218UL, 0xd69906245565a910UL, 0xf40e35855771202aUL, 0x106aa07032bbd1b8UL,
+      0x19a4c116b8d2d0c8UL, 0x1e376c085141ab53UL, 0x2748774cdf8eeb99UL, 0x34b0bcb5e19b48a8UL,
+      0x391c0cb3c5c95a63UL, 0x4ed8aa4ae3418acbUL, 0x5b9cca4f7763e373UL, 0x682e6ff3d6b2b8a3UL,
+      0x748f82ee5defb2fcUL, 0x78a5636f43172f60UL, 0x84c87814a1f0ab72UL, 0x8cc702081a6439ecUL,
+      0x90befffa23631e28UL, 0xa4506cebde82bde9UL, 0xbef9a3f7b2c67915UL, 0xc67178f2e372532bUL,
+      0xca273eceea26619cUL, 0xd186b8c721c0c207UL, 0xeada7dd6cde0eb1eUL, 0xf57d4f7fee6ed178UL,
+      0x06f067aa72176fbaUL, 0x0a637dc5a2c898a6UL, 0x113f9804bef90daeUL, 0x1b710b35131c471bUL,
+      0x28db77f523047d84UL, 0x32caab7b40c72493UL, 0x3c9ebe0a15c9bebcUL, 0x431d67c49c100d4cUL,
+      0x4cc5d4becb3e42b6UL, 0x597f299cfc657e2aUL, 0x5fcb6fab3ad6faecUL, 0x6c44198c4a475817UL
+    };
 
-      static ulong const K[80] = { /* FIXME: Reuse with other functions */
-        0x428a2f98d728ae22UL, 0x7137449123ef65cdUL, 0xb5c0fbcfec4d3b2fUL, 0xe9b5dba58189dbbcUL,
-        0x3956c25bf348b538UL, 0x59f111f1b605d019UL, 0x923f82a4af194f9bUL, 0xab1c5ed5da6d8118UL,
-        0xd807aa98a3030242UL, 0x12835b0145706fbeUL, 0x243185be4ee4b28cUL, 0x550c7dc3d5ffb4e2UL,
-        0x72be5d74f27b896fUL, 0x80deb1fe3b1696b1UL, 0x9bdc06a725c71235UL, 0xc19bf174cf692694UL,
-        0xe49b69c19ef14ad2UL, 0xefbe4786384f25e3UL, 0x0fc19dc68b8cd5b5UL, 0x240ca1cc77ac9c65UL,
-        0x2de92c6f592b0275UL, 0x4a7484aa6ea6e483UL, 0x5cb0a9dcbd41fbd4UL, 0x76f988da831153b5UL,
-        0x983e5152ee66dfabUL, 0xa831c66d2db43210UL, 0xb00327c898fb213fUL, 0xbf597fc7beef0ee4UL,
-        0xc6e00bf33da88fc2UL, 0xd5a79147930aa725UL, 0x06ca6351e003826fUL, 0x142929670a0e6e70UL,
-        0x27b70a8546d22ffcUL, 0x2e1b21385c26c926UL, 0x4d2c6dfc5ac42aedUL, 0x53380d139d95b3dfUL,
-        0x650a73548baf63deUL, 0x766a0abb3c77b2a8UL, 0x81c2c92e47edaee6UL, 0x92722c851482353bUL,
-        0xa2bfe8a14cf10364UL, 0xa81a664bbc423001UL, 0xc24b8b70d0f89791UL, 0xc76c51a30654be30UL,
-        0xd192e819d6ef5218UL, 0xd69906245565a910UL, 0xf40e35855771202aUL, 0x106aa07032bbd1b8UL,
-        0x19a4c116b8d2d0c8UL, 0x1e376c085141ab53UL, 0x2748774cdf8eeb99UL, 0x34b0bcb5e19b48a8UL,
-        0x391c0cb3c5c95a63UL, 0x4ed8aa4ae3418acbUL, 0x5b9cca4f7763e373UL, 0x682e6ff3d6b2b8a3UL,
-        0x748f82ee5defb2fcUL, 0x78a5636f43172f60UL, 0x84c87814a1f0ab72UL, 0x8cc702081a6439ecUL,
-        0x90befffa23631e28UL, 0xa4506cebde82bde9UL, 0xbef9a3f7b2c67915UL, 0xc67178f2e372532bUL,
-        0xca273eceea26619cUL, 0xd186b8c721c0c207UL, 0xeada7dd6cde0eb1eUL, 0xf57d4f7fee6ed178UL,
-        0x06f067aa72176fbaUL, 0x0a637dc5a2c898a6UL, 0x113f9804bef90daeUL, 0x1b710b35131c471bUL,
-        0x28db77f523047d84UL, 0x32caab7b40c72493UL, 0x3c9ebe0a15c9bebcUL, 0x431d67c49c100d4cUL,
-        0x4cc5d4becb3e42b6UL, 0x597f299cfc657e2aUL, 0x5fcb6fab3ad6faecUL, 0x6c44198c4a475817UL
-      };
+#   define Sigma0(x)  wv_xor( wv_ror(x,28), wv_xor( wv_ror(x,34), wv_ror(x,39) ) )
+#   define Sigma1(x)  wv_xor( wv_ror(x,14), wv_xor( wv_ror(x,18), wv_ror(x,41) ) )
+#   define sigma0(x)  wv_xor( wv_ror(x, 1), wv_xor( wv_ror(x, 8), wv_shr(x, 7) ) )
+#   define sigma1(x)  wv_xor( wv_ror(x,19), wv_xor( wv_ror(x,61), wv_shr(x, 6) ) )
+#   define Ch(x,y,z)  wv_xor( wv_and(x,y), wv_andnot(x,z) )
+#   define Maj(x,y,z) wv_xor( wv_and(x,y), wv_xor( wv_and(x,z), wv_and(y,z) ) )
+#   define SHA_CORE(xi,ki)                                                       \
+    T1 = wv_add( wv_add(xi,ki), wv_add( wv_add( h, Sigma1(e) ), Ch(e, f, g) ) ); \
+    T2 = wv_add( Sigma0(a), Maj(a, b, c) );                                      \
+    h = g;                                                                       \
+    g = f;                                                                       \
+    f = e;                                                                       \
+    e = wv_add( d, T1 );                                                         \
+    d = c;                                                                       \
+    c = b;                                                                       \
+    b = a;                                                                       \
+    a = wv_add( T1, T2 )
 
-#     define Sigma0(x)  wv_xor( wv_ror(x,28), wv_xor( wv_ror(x,34), wv_ror(x,39) ) )
-#     define Sigma1(x)  wv_xor( wv_ror(x,14), wv_xor( wv_ror(x,18), wv_ror(x,41) ) )
-#     define sigma0(x)  wv_xor( wv_ror(x, 1), wv_xor( wv_ror(x, 8), wv_shr(x, 7) ) )
-#     define sigma1(x)  wv_xor( wv_ror(x,19), wv_xor( wv_ror(x,61), wv_shr(x, 6) ) )
-#     define Ch(x,y,z)  wv_xor( wv_and(x,y), wv_andnot(x,z) )
-#     define Maj(x,y,z) wv_xor( wv_and(x,y), wv_xor( wv_and(x,z), wv_and(y,z) ) )
-#     define SHA_CORE(xi,ki)                                                       \
-      T1 = wv_add( wv_add(xi,ki), wv_add( wv_add( h, Sigma1(e) ), Ch(e, f, g) ) ); \
-      T2 = wv_add( Sigma0(a), Maj(a, b, c) );                                      \
-      h = g;                                                                       \
-      g = f;                                                                       \
-      f = e;                                                                       \
-      e = wv_add( d, T1 );                                                         \
-      d = c;                                                                       \
-      c = b;                                                                       \
-      b = a;                                                                       \
-      a = wv_add( T1, T2 )
+    wv_t T1;
+    wv_t T2;
 
-      wv_t T1;
-      wv_t T2;
-
-      SHA_CORE( x0, wv_bcast( K[ 0] ) );
-      SHA_CORE( x1, wv_bcast( K[ 1] ) );
-      SHA_CORE( x2, wv_bcast( K[ 2] ) );
-      SHA_CORE( x3, wv_bcast( K[ 3] ) );
-      SHA_CORE( x4, wv_bcast( K[ 4] ) );
-      SHA_CORE( x5, wv_bcast( K[ 5] ) );
-      SHA_CORE( x6, wv_bcast( K[ 6] ) );
-      SHA_CORE( x7, wv_bcast( K[ 7] ) );
-      SHA_CORE( x8, wv_bcast( K[ 8] ) );
-      SHA_CORE( x9, wv_bcast( K[ 9] ) );
-      SHA_CORE( xa, wv_bcast( K[10] ) );
-      SHA_CORE( xb, wv_bcast( K[11] ) );
-      SHA_CORE( xc, wv_bcast( K[12] ) );
-      SHA_CORE( xd, wv_bcast( K[13] ) );
-      SHA_CORE( xe, wv_bcast( K[14] ) );
-      SHA_CORE( xf, wv_bcast( K[15] ) );
-      for( ulong i=16UL; i<80UL; i+=16UL ) {
-        x0 = wv_add( wv_add( x0, sigma0(x1) ), wv_add( sigma1(xe), x9 ) ); SHA_CORE( x0, wv_bcast( K[i     ] ) );
-        x1 = wv_add( wv_add( x1, sigma0(x2) ), wv_add( sigma1(xf), xa ) ); SHA_CORE( x1, wv_bcast( K[i+ 1UL] ) );
-        x2 = wv_add( wv_add( x2, sigma0(x3) ), wv_add( sigma1(x0), xb ) ); SHA_CORE( x2, wv_bcast( K[i+ 2UL] ) );
-        x3 = wv_add( wv_add( x3, sigma0(x4) ), wv_add( sigma1(x1), xc ) ); SHA_CORE( x3, wv_bcast( K[i+ 3UL] ) );
-        x4 = wv_add( wv_add( x4, sigma0(x5) ), wv_add( sigma1(x2), xd ) ); SHA_CORE( x4, wv_bcast( K[i+ 4UL] ) );
-        x5 = wv_add( wv_add( x5, sigma0(x6) ), wv_add( sigma1(x3), xe ) ); SHA_CORE( x5, wv_bcast( K[i+ 5UL] ) );
-        x6 = wv_add( wv_add( x6, sigma0(x7) ), wv_add( sigma1(x4), xf ) ); SHA_CORE( x6, wv_bcast( K[i+ 6UL] ) );
-        x7 = wv_add( wv_add( x7, sigma0(x8) ), wv_add( sigma1(x5), x0 ) ); SHA_CORE( x7, wv_bcast( K[i+ 7UL] ) );
-        x8 = wv_add( wv_add( x8, sigma0(x9) ), wv_add( sigma1(x6), x1 ) ); SHA_CORE( x8, wv_bcast( K[i+ 8UL] ) );
-        x9 = wv_add( wv_add( x9, sigma0(xa) ), wv_add( sigma1(x7), x2 ) ); SHA_CORE( x9, wv_bcast( K[i+ 9UL] ) );
-        xa = wv_add( wv_add( xa, sigma0(xb) ), wv_add( sigma1(x8), x3 ) ); SHA_CORE( xa, wv_bcast( K[i+10UL] ) );
-        xb = wv_add( wv_add( xb, sigma0(xc) ), wv_add( sigma1(x9), x4 ) ); SHA_CORE( xb, wv_bcast( K[i+11UL] ) );
-        xc = wv_add( wv_add( xc, sigma0(xd) ), wv_add( sigma1(xa), x5 ) ); SHA_CORE( xc, wv_bcast( K[i+12UL] ) );
-        xd = wv_add( wv_add( xd, sigma0(xe) ), wv_add( sigma1(xb), x6 ) ); SHA_CORE( xd, wv_bcast( K[i+13UL] ) );
-        xe = wv_add( wv_add( xe, sigma0(xf) ), wv_add( sigma1(xc), x7 ) ); SHA_CORE( xe, wv_bcast( K[i+14UL] ) );
-        xf = wv_add( wv_add( xf, sigma0(x0) ), wv_add( sigma1(xd), x8 ) ); SHA_CORE( xf, wv_bcast( K[i+15UL] ) );
-      }
-
-#     undef SHA_CORE
-#     undef Sigma0
-#     undef Sigma1
-#     undef sigma0
-#     undef sigma1
-#     undef Ch
-#     undef Maj
-
-      /* Apply the state updates to the active lanes */
-
-      s0 = wv_add( s0, wv_notczero( active_lane, a ) );
-      s1 = wv_add( s1, wv_notczero( active_lane, b ) );
-      s2 = wv_add( s2, wv_notczero( active_lane, c ) );
-      s3 = wv_add( s3, wv_notczero( active_lane, d ) );
-      s4 = wv_add( s4, wv_notczero( active_lane, e ) );
-      s5 = wv_add( s5, wv_notczero( active_lane, f ) );
-      s6 = wv_add( s6, wv_notczero( active_lane, g ) );
-      s7 = wv_add( s7, wv_notczero( active_lane, h ) );
-
-      /* Advance to the next message segment blocks.  In pseudo code,
-         the below is:
-
-           W += 128; if( block_rem ) block_rem--;
-
-         Since wc_to_wv_raw(false/true) is 0UL/~0UL, we can use wv_add /
-         wc_to_wv_raw instead of wv_sub / wc_to_wv to save some ops.
-         (Consider conditional increment / decrement operations?)
-
-         Also since we do not load anything at W(lane) above unless
-         block_rem(lane) is non-zero, we can omit vector conditional
-         operations for W(lane) below to save some additional ops. */
-
-      W = wv_add( W, wv_128 );
-
-      block_rem = wv_add( block_rem, wc_to_wv_raw( active_lane ) );
+    SHA_CORE( x0, wv_bcast( K[ 0] ) );
+    SHA_CORE( x1, wv_bcast( K[ 1] ) );
+    SHA_CORE( x2, wv_bcast( K[ 2] ) );
+    SHA_CORE( x3, wv_bcast( K[ 3] ) );
+    SHA_CORE( x4, wv_bcast( K[ 4] ) );
+    SHA_CORE( x5, wv_bcast( K[ 5] ) );
+    SHA_CORE( x6, wv_bcast( K[ 6] ) );
+    SHA_CORE( x7, wv_bcast( K[ 7] ) );
+    SHA_CORE( x8, wv_bcast( K[ 8] ) );
+    SHA_CORE( x9, wv_bcast( K[ 9] ) );
+    SHA_CORE( xa, wv_bcast( K[10] ) );
+    SHA_CORE( xb, wv_bcast( K[11] ) );
+    SHA_CORE( xc, wv_bcast( K[12] ) );
+    SHA_CORE( xd, wv_bcast( K[13] ) );
+    SHA_CORE( xe, wv_bcast( K[14] ) );
+    SHA_CORE( xf, wv_bcast( K[15] ) );
+    for( ulong i=16UL; i<80UL; i+=16UL ) {
+      x0 = wv_add( wv_add( x0, sigma0(x1) ), wv_add( sigma1(xe), x9 ) ); SHA_CORE( x0, wv_bcast( K[i     ] ) );
+      x1 = wv_add( wv_add( x1, sigma0(x2) ), wv_add( sigma1(xf), xa ) ); SHA_CORE( x1, wv_bcast( K[i+ 1UL] ) );
+      x2 = wv_add( wv_add( x2, sigma0(x3) ), wv_add( sigma1(x0), xb ) ); SHA_CORE( x2, wv_bcast( K[i+ 2UL] ) );
+      x3 = wv_add( wv_add( x3, sigma0(x4) ), wv_add( sigma1(x1), xc ) ); SHA_CORE( x3, wv_bcast( K[i+ 3UL] ) );
+      x4 = wv_add( wv_add( x4, sigma0(x5) ), wv_add( sigma1(x2), xd ) ); SHA_CORE( x4, wv_bcast( K[i+ 4UL] ) );
+      x5 = wv_add( wv_add( x5, sigma0(x6) ), wv_add( sigma1(x3), xe ) ); SHA_CORE( x5, wv_bcast( K[i+ 5UL] ) );
+      x6 = wv_add( wv_add( x6, sigma0(x7) ), wv_add( sigma1(x4), xf ) ); SHA_CORE( x6, wv_bcast( K[i+ 6UL] ) );
+      x7 = wv_add( wv_add( x7, sigma0(x8) ), wv_add( sigma1(x5), x0 ) ); SHA_CORE( x7, wv_bcast( K[i+ 7UL] ) );
+      x8 = wv_add( wv_add( x8, sigma0(x9) ), wv_add( sigma1(x6), x1 ) ); SHA_CORE( x8, wv_bcast( K[i+ 8UL] ) );
+      x9 = wv_add( wv_add( x9, sigma0(xa) ), wv_add( sigma1(x7), x2 ) ); SHA_CORE( x9, wv_bcast( K[i+ 9UL] ) );
+      xa = wv_add( wv_add( xa, sigma0(xb) ), wv_add( sigma1(x8), x3 ) ); SHA_CORE( xa, wv_bcast( K[i+10UL] ) );
+      xb = wv_add( wv_add( xb, sigma0(xc) ), wv_add( sigma1(x9), x4 ) ); SHA_CORE( xb, wv_bcast( K[i+11UL] ) );
+      xc = wv_add( wv_add( xc, sigma0(xd) ), wv_add( sigma1(xa), x5 ) ); SHA_CORE( xc, wv_bcast( K[i+12UL] ) );
+      xd = wv_add( wv_add( xd, sigma0(xe) ), wv_add( sigma1(xb), x6 ) ); SHA_CORE( xd, wv_bcast( K[i+13UL] ) );
+      xe = wv_add( wv_add( xe, sigma0(xf) ), wv_add( sigma1(xc), x7 ) ); SHA_CORE( xe, wv_bcast( K[i+14UL] ) );
+      xf = wv_add( wv_add( xf, sigma0(x0) ), wv_add( sigma1(xd), x8 ) ); SHA_CORE( xf, wv_bcast( K[i+15UL] ) );
     }
+
+#   undef SHA_CORE
+#   undef Sigma0
+#   undef Sigma1
+#   undef sigma0
+#   undef sigma1
+#   undef Ch
+#   undef Maj
+
+    /* Apply the state updates to the active lanes */
+
+    s0 = wv_add( s0, wv_notczero( active_lane, a ) );
+    s1 = wv_add( s1, wv_notczero( active_lane, b ) );
+    s2 = wv_add( s2, wv_notczero( active_lane, c ) );
+    s3 = wv_add( s3, wv_notczero( active_lane, d ) );
+    s4 = wv_add( s4, wv_notczero( active_lane, e ) );
+    s5 = wv_add( s5, wv_notczero( active_lane, f ) );
+    s6 = wv_add( s6, wv_notczero( active_lane, g ) );
+    s7 = wv_add( s7, wv_notczero( active_lane, h ) );
+
+    /* Advance to the next message segment blocks.  In pseudo code,
+       the below is:
+
+         W += 128; if( block_rem ) block_rem--;
+
+       Since wc_to_wv_raw(false/true) is 0UL/~0UL, we can use wv_add /
+       wc_to_wv_raw instead of wv_sub / wc_to_wv to save some ops.
+       (Consider conditional increment / decrement operations?)
+
+       Also since we do not load anything at W(lane) above unless
+       block_rem(lane) is non-zero, we can omit vector conditional
+       operations for W(lane) below to save some additional ops. */
+
+    W = wv_add( W, wv_128 );
+
+    block_rem = wv_add( block_rem, wc_to_wv_raw( active_lane ) );
   }
 
   /* Store the results.  FIXME: Probably could optimize the transpose


### PR DESCRIPTION
Faster memcpy and single pass processing of combined in-place bulk message region and out-of-place scratch tail region.

Worth ~10% for sha256 in the small message limit (~22 Mhash/s/core on the same host from original checkin).