### PR TITLE
elf: add structs

### DIFF
--- a/src/ballet/elf/Local.mk
+++ b/src/ballet/elf/Local.mk
@@ -1,0 +1,1 @@
+$(call add-hdrs,fd_elf.h fd_elf64.h)

--- a/src/ballet/elf/fd_elf.h
+++ b/src/ballet/elf/fd_elf.h
@@ -1,0 +1,104 @@
+#ifndef HEADER_fd_src_ballet_elf_fd_elf_h
+#define HEADER_fd_src_ballet_elf_fd_elf_h
+
+/* Executable and Linking Format (ELF) */
+
+#include "../../util/fd_util.h"
+#include <string.h>
+
+/* FD_ELF_EI: File type related */
+
+#define FD_ELF_EI_MAG0        0
+#define FD_ELF_EI_MAG1        1
+#define FD_ELF_EI_MAG2        2
+#define FD_ELF_EI_MAG3        3
+#define FD_ELF_EI_CLASS       4
+#define FD_ELF_EI_DATA        5
+#define FD_ELF_EI_VERSION     6
+#define FD_ELF_EI_OSABI       7
+#define FD_ELF_EI_ABIVERSION  8
+#define FD_ELF_EI_NIDENT     16
+
+/* FD_ELF_CLASS: 32-bit/64-bit architecture */
+
+#define FD_ELF_CLASS_NONE 0
+#define FD_ELF_CLASS_32   1
+#define FD_ELF_CLASS_64   2
+
+/* FD_ELF_DATA: Endianness */
+
+#define FD_ELF_DATA_NONE  0
+#define FD_ELF_DATA_LE    1
+#define FD_ELF_DATA_BE    2
+
+/* FD_ELF_ET: ELF file type */
+
+#define FD_ELF_ET_NONE 0
+#define FD_ELF_ET_REL  1 /* relocatable static object */
+#define FD_ELF_ET_EXEC 2 /* executable */
+#define FD_ELF_ET_DYN  3 /* shared object */
+#define FD_ELF_ET_CORE 4 /* core dump */
+
+/* FD_ELF_EM: Machine type */
+
+#define FD_ELF_EM_NONE   0
+#define FD_ELF_EM_BPF  247
+
+/* FD_ELF_SHT: Section header type */
+
+#define FD_ELF_SHT_NULL      0
+#define FD_ELF_SHT_PROGBITS  1
+#define FD_ELF_SHT_SYMTAB    2
+#define FD_ELF_SHT_STRTAB    3
+#define FD_ELF_SHT_RELA      4
+#define FD_ELF_SHT_HASH      5
+#define FD_ELF_SHT_DYNAMIC   6
+#define FD_ELF_SHT_REL       9
+#define FD_ELF_SHT_DYNSYM   11
+
+/* FD_ELF64_R_SYM extracts the symbol index from reloc r_info.
+   FD_ELF64_R_TYPE extracts the relocation type from reloc r_info. */
+
+#define FD_ELF64_R_SYM(i)  ((ulong)(i) >> 32)
+#define FD_ELF64_R_TYPE(i) ((ulong)(i) & 0xFFFFFFFF)
+
+/* FD_ELF_R_BPF: BPF relocation types */
+
+#define FD_ELF_R_BPF_64_64 1 /* 64-bit immediate (lddw form) */
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_elf_read_cstr: Validate cstr and return pointer.  Given memory
+   region buf of size buf_sz, attempt to read cstr at offset off in
+   [0,buf_sz)  If buf_sz is 0, buf may be an invalid pointer.  Returns
+   pointer to first byte of cstr in buf on success, and NULL on failure.
+   Reasons for failure include: off or cstr is out-of-bounds, footprint
+   of cstr (including NUL) greater than max_sz. */
+
+FD_FN_PURE static inline char const *
+fd_elf_read_cstr( void const * buf,
+                  ulong        buf_sz,
+                  ulong        off,
+                  ulong        max_sz ) {
+
+  if( FD_UNLIKELY( off>=buf_sz ) )
+    return NULL;
+
+  char const * str    = (char const *)( (ulong)buf + off );
+  ulong        str_sz = buf_sz - off;
+
+  ulong n = fd_ulong_min( str_sz, max_sz );
+  if( FD_UNLIKELY( strnlen( str, n )==max_sz ) )
+    return NULL;
+
+  return str;
+}
+
+FD_PROTOTYPES_END
+
+/* Re-export sibling headers for convenience */
+
+#include "fd_elf64.h"
+
+#endif /* HEADER_fd_src_ballet_elf_fd_elf_h */
+

--- a/src/ballet/elf/fd_elf64.h
+++ b/src/ballet/elf/fd_elf64.h
@@ -1,0 +1,99 @@
+#ifndef HEADER_fd_src_ballet_elf_fd_elf64_h
+#define HEADER_fd_src_ballet_elf_fd_elf64_h
+
+/* Struct definitions for ELF64 file type. */
+
+#include "fd_elf.h"
+
+/* fd_elf64_ehdr: ELF file header  */
+
+struct __attribute__((packed)) fd_elf64_ehdr_ {
+  uchar  e_ident[ FD_ELF_EI_NIDENT ];
+  ushort e_type;
+  ushort e_machine;
+  uint   e_version;
+  ulong  e_entry;
+  ulong  e_phoff;
+  ulong  e_shoff;
+  uint   e_flags;
+  ushort e_ehsize;
+  ushort e_phentsize;
+  ushort e_phnum;
+  ushort e_shentsize;
+  ushort e_shnum;
+  ushort e_shstrndx;
+};
+typedef struct fd_elf64_ehdr_ fd_elf64_ehdr;
+
+/* fd_elf64_phdr: Segment header */
+
+struct __attribute__((packed)) fd_elf64_phdr_ {
+  uint  p_type;
+  uint  p_flags;
+  ulong p_offset;
+  ulong p_vaddr;
+  ulong p_paddr;
+  ulong p_filesz;
+  ulong p_memsz;
+  ulong p_align;
+};
+typedef struct fd_elf64_phdr_ fd_elf64_phdr;
+
+/* fd_elf64_shdr: Section header */
+
+struct __attribute__((packed)) fd_elf64_shdr_ {
+  uint  sh_name;
+  uint  sh_type;
+  ulong sh_flags;
+  ulong sh_addr;
+  ulong sh_offset;
+  ulong sh_size;
+  uint  sh_link;
+  uint  sh_info;
+  ulong sh_addralign;
+  ulong sh_entsize;
+};
+typedef struct fd_elf64_shdr_ fd_elf64_shdr;
+
+/* fd_elf64_sym: Symbol */
+
+struct __attribute__((packed)) fd_elf64_sym_ {
+  uint   st_name;
+  uchar  st_info;
+  uchar  st_other;
+  ushort st_shndx;
+  ulong  st_value;
+  ulong  st_size;
+};
+typedef struct fd_elf64_sym_ fd_elf64_sym;
+
+/* fd_elf64_rel: Relocation (implicit addend) */
+
+struct __attribute__((packed)) fd_elf64_rel_ {
+  ulong r_offset;
+  ulong r_info;
+};
+typedef struct fd_elf64_rel_ fd_elf64_rel;
+
+/* fd_elf64_rela: Relocation with addend */
+
+struct __attribute__((packed)) fd_elf64_rela_ {
+  ulong r_offset;
+  ulong r_info;    /* see FD_ELF64_R_{SYM,TYPE} */
+  long  r_addend;
+};
+typedef struct fd_elf64_rela_ fd_elf64_rela;
+
+/* fd_elf64_dyn: Dynamic section entry */
+
+struct __attribute__((packed)) fd_elf64_dyn_ {
+  long d_tag;
+  union {
+    ulong d_val;
+    ulong d_ptr;
+  } d_un;
+};
+typedef struct fd_elf64_dyn_ fd_elf64_dyn;
+
+#endif /* HEADER_fd_src_ballet_elf_fd_elf64_h */
+


### PR DESCRIPTION
Adds ELF file format headers. Used to load XDP and Solana BPF programs.

Not using `elf.h` here for portability reasons.