### PR TITLE
xdp: fix descriptor ring memory layout

### DIFF
--- a/src/tango/xdp/Local.mk
+++ b/src/tango/xdp/Local.mk
@@ -1,13 +1,14 @@
-$(call add-hdrs,fd_xdp_redirect_prog.h)
-
 ifdef FD_HAS_HOSTED
-ifdef FD_HAS_LIBBPF
-$(call make-lib,fd_xdp)
-$(call add-hdrs,fd_xdp.h fd_xsk.h fd_xsk_aio.h fd_xdp_redirect_user.h)
-$(call add-objs,fd_xsk fd_xsk_aio fd_xdp_redirect_user,fd_xdp)
 
+$(call make-lib,fd_xdp)
+$(call add-hdrs,fd_xdp.h fd_xsk.h fd_xsk_aio.h fd_xdp_redirect_prog.h fd_xdp_redirect_user.h)
+$(call add-objs,fd_xsk fd_xsk_aio,fd_xdp)
+
+ifdef FD_HAS_LIBBPF
+$(call add-objs,fd_xdp_redirect_user,fd_xdp)
 $(call make-unit-test,test_xsk,test_xsk,fd_xdp fd_util)
 $(call run-unit-test,test_xsk)
-endif
-endif
+endif # FD_HAS_LIBBPF
+
+endif # FD_HAS_HOSTED
 

--- a/src/tango/xdp/fd_xsk.c
+++ b/src/tango/xdp/fd_xsk.c
@@ -1,11 +1,9 @@
-#if !defined(__linux__) || !FD_HAS_LIBBPF
+#if !defined(__linux__)
 #error "fd_xsk requires Linux operating system with XDP support"
 #endif
 
 #include <linux/if_xdp.h>
 #include <linux/limits.h>
-#include <bpf/bpf.h>
-#include <bpf/libbpf.h>
 
 #include <net/if.h>
 #include <sys/socket.h>
@@ -16,6 +14,7 @@
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <sys/mman.h>
 
 #include "fd_xsk_private.h"
@@ -292,6 +291,11 @@ fd_xsk_mmap_ring( fd_ring_desc_t * ring,
   /* TODO: mmap was originally called with MAP_POPULATE,
            but this symbol isn't available with this build */
 
+  /* sanity check */
+  if( depth > (ulong)UINT_MAX ) {
+    return -1;
+  }
+
   ulong map_sz = ring_offset->desc + depth*elem_sz;
 
   void * res = mmap( NULL, map_sz, PROT_READ|PROT_WRITE, MAP_SHARED, xsk_fd, map_off );
@@ -301,12 +305,16 @@ fd_xsk_mmap_ring( fd_ring_desc_t * ring,
     return -1;
   }
 
+  /* TODO add unit test asserting that cached prod/cons seq gets
+          cleared on join */
+  fd_memset( ring, 0, sizeof(fd_ring_desc_t) );
+
   ring->mem   = res;
-  ring->depth = depth;
-  ring->ptr   = (void  *)( (ulong)res + ring_offset->desc     );
-  ring->flags = (ulong *)( (ulong)res + ring_offset->flags    );
-  ring->prod  = (ulong *)( (ulong)res + ring_offset->producer );
-  ring->cons  = (ulong *)( (ulong)res + ring_offset->consumer );
+  ring->depth = (uint)depth;
+  ring->ptr   = (void *)( (ulong)res + ring_offset->desc     );
+  ring->flags = (uint *)( (ulong)res + ring_offset->flags    );
+  ring->prod  = (uint *)( (ulong)res + ring_offset->producer );
+  ring->cons  = (uint *)( (ulong)res + ring_offset->consumer );
 
   return 0;
 }
@@ -425,11 +433,15 @@ static int
 fd_xsk_init( fd_xsk_t * xsk ) {
   /* Find interface index */
 
+  if( FD_UNLIKELY( !xsk->if_name_cstr[0] ) ) {
+    FD_LOG_WARNING(( "not bound to any interface" ));
+    return -1;
+  }
   uint if_idx = if_nametoindex( xsk->if_name_cstr );
   if( FD_UNLIKELY( if_idx )==0 ) {
-    FD_LOG_WARNING(( "if_nametoindex(%s) failed (%d-%s) (is XSK bound to interface?)",
+    FD_LOG_WARNING(( "if_nametoindex(%s) failed (%d-%s)",
                      xsk->if_name_cstr, errno, strerror( errno ) ));
-    return 0;
+    return -1;
   }
   xsk->if_idx = if_idx;
 
@@ -438,12 +450,12 @@ fd_xsk_init( fd_xsk_t * xsk ) {
   xsk->xsk_fd = socket( AF_XDP, SOCK_RAW, 0 );
   if( FD_UNLIKELY( xsk->xsk_fd<0 ) ) {
     FD_LOG_WARNING(( "Failed to create XSK: %s", strerror( errno ) ));
-    return 0;
+    return -1;
   }
 
   /* Associate UMEM region of fd_xsk_t with XSK via setsockopt() */
 
-  if( FD_UNLIKELY( 0!=fd_xsk_setup_umem( xsk ) ) ) return 0;
+  if( FD_UNLIKELY( 0!=fd_xsk_setup_umem( xsk ) ) ) return -1;
 
   /* Map XSK rings into local address space */
 
@@ -586,11 +598,11 @@ fd_xsk_rx_enqueue( fd_xsk_t * xsk,
   fd_ring_desc_t * fill = &xsk->ring_fr;
 
   /* fetch cached consumer, producer */
-  ulong prod = fill->cached_prod;
-  ulong cons = fill->cached_cons;
+  uint prod = fill->cached_prod;
+  uint cons = fill->cached_cons;
 
   /* ring capacity */
-  ulong cap  = fill->depth;
+  uint cap  = fill->depth;
 
   /* if not enough for batch, update cache */
   if( cap - ( prod - cons ) < count ) {
@@ -603,9 +615,9 @@ fd_xsk_rx_enqueue( fd_xsk_t * xsk,
 
   /* set ring[j] to the specified indices */
   ulong * ring = fill->frame_ring;
-  ulong mask = fill->depth - 1UL;
+  uint    mask = fill->depth - 1U;
   for( ulong j = 0; j < sz; ++j ) {
-    ulong k = prod & mask;
+    uint k = prod & mask;
     ring[k] = offset[j];
 
     prod++;
@@ -633,8 +645,8 @@ fd_xsk_rx_enqueue2( fd_xsk_t *            xsk,
   fd_ring_desc_t * fill = &xsk->ring_fr;
 
   /* fetch cached consumer, producer */
-  ulong prod = fill->cached_prod;
-  ulong cons = fill->cached_cons;
+  uint prod = fill->cached_prod;
+  uint cons = fill->cached_cons;
 
   /* assuming frame sizes are powers of 2 */
   ulong frame_mask = xsk->params.frame_sz - 1UL;
@@ -653,9 +665,9 @@ fd_xsk_rx_enqueue2( fd_xsk_t *            xsk,
 
   /* set ring[j] to the specified indices */
   ulong * ring = fill->frame_ring;
-  ulong mask = fill->depth - 1;
+  uint    mask = fill->depth - 1;
   for( ulong j = 0; j < sz; ++j ) {
-    ulong k = prod & mask;
+    uint k = prod & mask;
     ring[k] = meta[j].off & frame_mask;
 
     prod++;
@@ -683,30 +695,30 @@ fd_xsk_tx_enqueue( fd_xsk_t *            xsk,
   fd_ring_desc_t * tx = &xsk->ring_tx;
 
   /* fetch cached consumer, producer */
-  ulong prod = tx->cached_prod;
-  ulong cons = tx->cached_cons;
+  uint prod = tx->cached_prod;
+  uint cons = tx->cached_cons;
 
   /* ring capacity */
-  ulong cap  = tx->depth;
+  uint cap  = tx->depth;
 
   /* if not enough for batch, update cache */
-  if( cap - ( prod - cons ) < count ) {
+  if( cap - ( prod - cons ) < (uint)count ) {
     cons = tx->cached_cons = FD_VOLATILE_CONST( *tx->cons );
   }
 
   /* sz is min( available, count ) */
-  ulong sz = cap - ( prod - cons );
+  uint sz = cap - ( prod - cons );
   /* TODO this doesn't work as expected
      if we early exit here, no wakeup occurs, sendto doesn't get called again
      and the ring doesn't get serviced
      This implies we need to call sendto AGAIN even if the ring hasn't changed
   if( sz == 0 )    return 0;
   */
-  if( sz > count ) sz = count;
+  if( sz > (uint)count ) sz = (uint)count;
 
   /* set ring[j] to the specified indices */
   struct xdp_desc * ring = tx->packet_ring;
-  ulong mask = tx->depth - 1;
+  uint   mask            = tx->depth - 1;
   for( ulong j = 0; j < sz; ++j ) {
     ulong k = prod & mask;
     ring[k].addr    = meta[j].off;
@@ -738,14 +750,14 @@ fd_xsk_rx_complete( fd_xsk_t *            xsk,
   /* rx ring */
   fd_ring_desc_t * rx = &xsk->ring_rx;
 
-  ulong prod = rx->cached_prod;
-  ulong cons = rx->cached_cons;
+  uint prod = rx->cached_prod;
+  uint cons = rx->cached_cons;
 
   /* how many frames are available? */
-  ulong avail = prod - cons;
+  uint avail = prod - cons;
 
   /* should we update the cache */
-  if( avail < capacity ) {
+  if( (ulong)avail < capacity ) {
     /* we update cons (and keep cache up to date)
        they update prod
        so only need to fetch actual prod */
@@ -756,7 +768,7 @@ fd_xsk_rx_complete( fd_xsk_t *            xsk,
   ulong sz = avail;
   if( sz > capacity ) sz = capacity;
 
-  ulong mask = rx->depth - 1;
+  uint              mask = rx->depth - 1;
   struct xdp_desc * ring = rx->packet_ring;
   for( ulong j = 0; j < sz; ++j ) {
     ulong k = cons & mask;
@@ -780,14 +792,14 @@ fd_xsk_tx_complete( fd_xsk_t * xsk, ulong * batch, ulong capacity ) {
   /* cr ring */
   fd_ring_desc_t * cr = &xsk->ring_cr;
 
-  ulong prod = cr->cached_prod;
-  ulong cons = cr->cached_cons;
+  uint prod = cr->cached_prod;
+  uint cons = cr->cached_cons;
 
   /* how many frames are available? */
-  ulong avail = prod - cons;
+  uint avail = prod - cons;
 
   /* should we update the cache */
-  if( avail < capacity ) {
+  if( (ulong)avail < capacity ) {
     /* we update cons (and keep cache up to date)
        they update prod
        so only need to fetch actual prod */
@@ -798,7 +810,7 @@ fd_xsk_tx_complete( fd_xsk_t * xsk, ulong * batch, ulong capacity ) {
   ulong sz = avail;
   if( sz > capacity ) sz = capacity;
 
-  ulong mask = cr->depth - 1;
+  uint    mask = cr->depth - 1;
   ulong * ring = cr->frame_ring;
   for( ulong j = 0; j < sz; ++j ) {
     ulong k = cons & mask;
@@ -822,14 +834,14 @@ fd_xsk_tx_complete2( fd_xsk_t *            xsk,
   /* cr ring */
   fd_ring_desc_t * cr = &xsk->ring_cr;
 
-  ulong prod = cr->cached_prod;
-  ulong cons = cr->cached_cons;
+  uint prod = cr->cached_prod;
+  uint cons = cr->cached_cons;
 
   /* how many frames are available? */
-  ulong avail = prod - cons;
+  uint avail = prod - cons;
 
   /* should we update the cache */
-  if( avail < capacity ) {
+  if( (ulong)avail < capacity ) {
     /* we update cons (and keep cache up to date)
        they update prod
        so only need to fetch actual prod */
@@ -840,7 +852,7 @@ fd_xsk_tx_complete2( fd_xsk_t *            xsk,
   ulong sz = avail;
   if( sz > capacity ) sz = capacity;
 
-  ulong mask = cr->depth - 1;
+  uint    mask = cr->depth - 1;
   ulong * ring = cr->frame_ring;
   for( ulong j = 0; j < sz; ++j ) {
     ulong k = cons & mask;

--- a/src/tango/xdp/fd_xsk.h
+++ b/src/tango/xdp/fd_xsk.h
@@ -1,7 +1,7 @@
 #ifndef HEADER_fd_src_tango_xdp_fd_xsk_h
 #define HEADER_fd_src_tango_xdp_fd_xsk_h
 
-#if defined(__linux__) && FD_HAS_LIBBPF
+#if defined(__linux__)
 
 /* fd_xsk manages an XSK file descriptor and provides RX/TX buffers.
 

--- a/src/tango/xdp/fd_xsk_aio.h
+++ b/src/tango/xdp/fd_xsk_aio.h
@@ -1,7 +1,7 @@
 #ifndef HEADER_fd_src_tango_xdp_fd_xsk_aio_h
 #define HEADER_fd_src_tango_xdp_fd_xsk_aio_h
 
-#if defined(__linux__) && FD_HAS_LIBBPF
+#if defined(__linux__)
 
 #include "fd_xsk.h"
 #include "../aio/fd_aio.h"

--- a/src/tango/xdp/fd_xsk_aio_private.h
+++ b/src/tango/xdp/fd_xsk_aio_private.h
@@ -21,8 +21,8 @@ struct __attribute__((aligned(FD_XSK_AIO_ALIGN))) fd_xsk_aio_private {
   /* Join Config ******************************************************/
 
   fd_xsk_t * xsk;
-  fd_aio_t   rx;  /* from outside to user */
-  fd_aio_t   tx;  /* from user to outside */
+  fd_aio_t   rx;  /* from outside to user (externally owned) */
+  fd_aio_t   tx;  /* from user to outside (owned by fd_xsk_aio) */
   void *     frame_mem; /* Address of start of frame memory */
 
   /* {rx,tx}_off: Offset from frame_mem to {rx,tx} frames.

--- a/src/tango/xdp/fd_xsk_private.h
+++ b/src/tango/xdp/fd_xsk_private.h
@@ -1,7 +1,7 @@
 #ifndef HEADER_fd_src_tango_xdp_fd_xsk_private_h
 #define HEADER_fd_src_tango_xdp_fd_xsk_private_h
 
-#if defined(__linux__) && FD_HAS_LIBBPF
+#if defined(__linux__)
 
 #include "fd_xsk.h"
 #include "../../util/fd_util.h"
@@ -36,17 +36,17 @@ struct __attribute__((aligned(64UL))) fd_ring_desc {
     struct xdp_desc * packet_ring; /* For RX, TX rings */
     ulong *           frame_ring;  /* For FILL, COMPLETION rings */
   };
-  ulong * flags;       /* Points to flags in shared descriptor ring */
-  ulong * prod;        /* Points to producer seq in shared descriptor ring */
-  ulong * cons;        /* Points to consumer seq in shared descriptor ring */
+  uint *  flags;       /* Points to flags in shared descriptor ring */
+  uint *  prod;        /* Points to producer seq in shared descriptor ring */
+  uint *  cons;        /* Points to consumer seq in shared descriptor ring */
 
   /* This point is 64-byte aligned */
 
   /* Managed by fd_xsk_t */
 
-  ulong   depth;       /* Capacity of ring in no of entries */
-  ulong   cached_prod; /* Cached value of *prod */
-  ulong   cached_cons; /* Cached value of *cons */
+  uint    depth;       /* Capacity of ring in no of entries */
+  uint    cached_prod; /* Cached value of *prod */
+  uint    cached_cons; /* Cached value of *cons */
 };
 typedef struct fd_ring_desc fd_ring_desc_t;
 
@@ -137,5 +137,5 @@ fd_xsk_tx_need_wakeup( fd_xsk_t * xsk ) {
 
 FD_PROTOTYPES_END
 
-#endif /* defined(__linux__) && FD_HAS_LIBBPF */
+#endif /* defined(__linux__) */
 #endif /* HEADER_fd_src_tango_xdp_fd_xsk_private_h */

--- a/src/tango/xdp/test_xsk.c
+++ b/src/tango/xdp/test_xsk.c
@@ -23,9 +23,9 @@ static uchar _xsk[ 262144UL ] __attribute__((aligned(FD_XSK_ALIGN)));
 #define TEST_XSK_RING_DEPTH (8UL)
 
 struct test_xsk_ring_desc {
-  ulong flags;
-  ulong prod;
-  ulong cons;
+  uint flags;
+  uint prod;
+  uint cons;
   union {
     struct xdp_desc packets   [ TEST_XSK_RING_DEPTH ];
     ulong           frame_idxs[ TEST_XSK_RING_DEPTH ];


### PR DESCRIPTION
Fixes uint/ulong confusion in XSK shm layout causing erratic behavior after 2^32 packets.
