### PR TITLE
specify cflags for libbpf to avoid sys shadowing

### DIFF
--- a/config/with-libbpf.mk
+++ b/config/with-libbpf.mk
@@ -1,3 +1,4 @@
 CFLAGS+=-DFD_HAS_LIBBPF=1
+CFLAGS+=$(shell pkg-config --cflags libbpf)
 LDFLAGS+=$(shell pkg-config --libs libbpf)
 FD_HAS_LIBBPF:=1


### PR DESCRIPTION
This addition is needed to make the compile go through on a cascadelake redhat-8.3 box, specifically the compile command is: deps.sh && source activate-opt && source activate-gcc && make -j make -j EXTRAS="libbpf"