### PR TITLE
base58: fix unsafe aliasing

### DIFF
--- a/src/ballet/base58/fd_base58.c
+++ b/src/ballet/base58/fd_base58.c
@@ -1,3 +1,4 @@
+#define FD_UNALIGNED_ACCESS_STYLE 0
 #include "fd_base58.h"
 
 #if FD_HAS_AVX

--- a/src/ballet/base58/fd_base58_tmpl.c
+++ b/src/ballet/base58/fd_base58_tmpl.c
@@ -56,8 +56,7 @@ SUFFIX(fd_base58_encode)( uchar const * bytes,
   /* Convert N to 32-bit limbs:
      X = sum_i binary[i] * 2^(32*(BINARY_SZ-1-i)) */
   uint binary[ BINARY_SZ ];
-  uint const * bytes_as_uint = (uint const *)bytes;
-  for( ulong i=0UL; i<BINARY_SZ; i++ ) binary[ i ] = fd_uint_bswap( bytes_as_uint[ i ] );
+  for( ulong i=0UL; i<BINARY_SZ; i++ ) binary[ i ] = fd_uint_bswap( fd_uint_load_4( &bytes[ i*sizeof(uint) ] ) );
 
   ulong R1div = 656356768UL; /* = 58^5 */
 

--- a/src/ballet/base58/test_base58.c
+++ b/src/ballet/base58/test_base58.c
@@ -495,8 +495,9 @@ test_encode_basic##name( void ) {                                               
 static inline void                                                                             \
 test_encode_bounds##name( void ) {                                                             \
   char  buf  [ FD_BASE58_ENCODED_##n##_SZ ];                                                   \
-  uchar bytes[ n ];                                                                            \
-  battery_encode_bounds( fd_base58_encode_##name, n, FD_BASE58_ENCODED_##n##_SZ, buf, bytes ); \
+  uchar bytes[ 1+(n) ]; /* force unaligned */                                                  \
+  battery_encode_bounds( fd_base58_encode_##name, n, FD_BASE58_ENCODED_##n##_SZ, buf,          \
+                         bytes+1 );                                                            \
 }                                                                                              \
                                                                                                \
 static inline void                                                                             \
@@ -505,8 +506,8 @@ test_decode_fail##name( void ) {                                                
 }                                                                                              \
                                                                                                \
 static inline void                                                                             \
-test_sample##name( void ) {                                                                 \
-  battery_sample##n( fd_base58_encode_##name, fd_base58_decode_##name );                    \
+test_sample##name( void ) {                                                                    \
+  battery_sample##n( fd_base58_encode_##name, fd_base58_decode_##name );                       \
 }                                                                                              \
                                                                                                \
 static inline void                                                                             \

--- a/src/util/bits/fd_bits.h
+++ b/src/util/bits/fd_bits.h
@@ -134,7 +134,7 @@ FD_FN_CONST static inline int fd_ushort_popcnt( ushort x ) { return __builtin_po
 FD_FN_CONST static inline int fd_uint_popcnt  ( uint   x ) { return __builtin_popcount (       x ); }
 FD_FN_CONST static inline int fd_ulong_popcnt ( ulong  x ) { return __builtin_popcountl(       x ); }
 
-#if FD_HAS_INT128 
+#if FD_HAS_INT128
 FD_FN_CONST static inline int
 fd_uint128_popcnt( uint128 x ) {
   return  __builtin_popcountl( (ulong) x ) + __builtin_popcountl( (ulong)(x>>64) );


### PR DESCRIPTION
Fixes aliasing of input buffer to base58 violating alignment
