### PR TITLE
contrib: add ubi9 Dockerfile

### DIFF
--- a/contrib/docker/ubi9.Dockerfile
+++ b/contrib/docker/ubi9.Dockerfile
@@ -1,0 +1,54 @@
+# Firedancer GNU/Linux build based on Red Hat Universal Base Image 9
+#
+# Build context is repo root.
+#
+# Not ready for production use.
+
+# FIXME Drop permissions
+# FIXME multi-arch support
+
+ARG BUILDER_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi:9.1.0-1817
+ARG RELEASE_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:9.1.0-1829
+
+# Set up build container
+
+FROM ${BUILDER_BASE_IMAGE} AS builder
+RUN dnf install -y \
+      gcc-toolset-12 \
+      git \
+      make \
+      pkgconf \
+      perl \
+      autoconf \
+      gettext-devel \
+      automake \
+      flex \
+      bison \
+      clang
+
+# Fetch and build source dependencies
+
+WORKDIR /firedancer
+COPY deps.sh activate-opt ./
+RUN scl run gcc-toolset-12 -- ./deps.sh install
+
+# Build source tree
+
+COPY config ./config
+COPY src ./src
+COPY Makefile ./
+RUN source ./activate-opt \
+ && scl run gcc-toolset-12 -- make -j all MACHINE=linux_gcc_x86_64 --output-sync=target
+
+# Set up release container
+
+FROM ${RELEASE_BASE_IMAGE} AS release
+
+COPY --from=builder /firedancer/build/linux/gcc/x86_64/bin /opt/firedancer/bin
+ENV FD_LOG_PATH=""
+ENV PATH="/opt/firedancer/bin:$PATH"
+
+LABEL org.opencontainers.image.title="Firedancer beta (ubi9 base)" \
+      org.opencontainers.image.url=https://firedancer.io \
+      org.opencontainers.image.source=https://github.com/firedancer-io/firedancer \
+      org.opencontainers.image.authors="Firedancer Contributors <firedancer-devs@jumptrading.com>"


### PR DESCRIPTION
adds ubi9-based Dockerfile. Requires https://github.com/firedancer-io/firedancer/pull/293