### PR TITLE
simplified the rec_write_prepare helper

### DIFF
--- a/src/funk/fd_funk_rec.c
+++ b/src/funk/fd_funk_rec.c
@@ -526,15 +526,13 @@ fd_funk_rec_write_prepare( fd_funk_t *               funk,
 
     } else {
       /* Copy the record into the transaction */
-      fd_funk_rec_t * rec_new = fd_funk_rec_modify( funk, fd_funk_rec_insert( funk, txn, key, opt_err ) );
-      if ( !rec_new )
+      rec = fd_funk_rec_modify( funk, fd_funk_rec_insert( funk, txn, key, opt_err ) );
+      if ( !rec )
         return NULL;
-      rec_new = fd_funk_val_copy( rec_new, fd_funk_val( rec, wksp ), fd_funk_val_sz( rec ),
-                                  fd_ulong_max( fd_funk_val_sz( rec ), min_val_size ),
-                                  fd_funk_alloc( funk, wksp ), wksp, opt_err );
-      if ( !rec_new )
+      rec = fd_funk_val_copy( rec, fd_funk_val_const(rec_con, wksp), fd_funk_val_sz(rec_con), 
+        fd_ulong_max( fd_funk_val_sz(rec_con), min_val_size ), fd_funk_alloc( funk, wksp ), wksp, opt_err );
+      if ( !rec )
         return NULL;
-      rec = rec_new;
     }
 
   } else {

--- a/src/funk/fd_funk_val.h
+++ b/src/funk/fd_funk_val.h
@@ -122,7 +122,7 @@ fd_funk_val_write( fd_funk_rec_t *   rec,     /* Assumed in caller's address spa
   ulong d1 = d0 + sz;
 
   if( FD_UNLIKELY( (!rec) | (end<off) | (!data) | (d1<d0) | (!wksp) ) || /* NULL rec, off+sz wrapped, NULL data w sz!=0, data wrapped, NULL wksp */
-      FD_UNLIKELY( end > (ulong)rec->val_sz                         ) ) return NULL; /* too large (covers marked ERASE case too) */
+      FD_UNLIKELY( end > (ulong)rec->val_max                         ) ) return NULL; /* too large (covers marked ERASE case too) */
 
   ulong v0 = (ulong)fd_wksp_laddr_fast( wksp, rec->val_gaddr + off );
   ulong v1 = v0 + sz;
@@ -130,6 +130,9 @@ fd_funk_val_write( fd_funk_rec_t *   rec,     /* Assumed in caller's address spa
   if( FD_UNLIKELY( !((d1<=v0) | (d0>=v1)) ) ) return NULL; /* data overlaps with val */
 
   fd_memcpy( (void *)v0, data, sz );
+
+  if ( FD_UNLIKELY( end > (ulong)rec->val_sz ) )
+    rec->val_sz = (uint)end;
 
   return rec;
 }


### PR DESCRIPTION
The fd_funk_val at line 532 was being called on rec, which was null and causing a core.

Also, the write call should be allowed to write upto the "max" of the record and should adjust the size as appropriate