### PR TITLE
Eliminate superfluous FD_HAS_X86 requirements

### DIFF
--- a/config/linux_clang_minimal.mk
+++ b/config/linux_clang_minimal.mk
@@ -5,5 +5,9 @@ include config/with-clang.mk
 include config/with-debug.mk
 include config/with-brutality.mk
 include config/with-optimization.mk
-include config/with-hosted.mk
+
+# Turn on POSIX style logging in this target to facilitate
+# cross-platform development
+
+CPPFLAGS+=-DFD_ENV_STYLE=0 -DFD_LOG_STYLE=0
 

--- a/config/linux_gcc_minimal.mk
+++ b/config/linux_gcc_minimal.mk
@@ -5,5 +5,9 @@ include config/with-gcc.mk
 include config/with-debug.mk
 include config/with-brutality.mk
 include config/with-optimization.mk
-include config/with-hosted.mk
+
+# Turn on POSIX style logging in this target to facilitate
+# cross-platform development
+
+CPPFLAGS+=-DFD_ENV_STYLE=0 -DFD_LOG_STYLE=0
 

--- a/src/disco/dedup/fd_dedup.c
+++ b/src/disco/dedup/fd_dedup.c
@@ -1,7 +1,5 @@
 #include "fd_dedup.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
-
 /* A fd_dedup_tile_in has all the state needed for deduping frags from
    an in.  It fits on exactly one cache line. */
 
@@ -586,4 +584,3 @@ fd_dedup_tile( fd_cnc_t *              cnc,
 
 #undef SCRATCH_ALLOC
 
-#endif

--- a/src/disco/dedup/fd_dedup.h
+++ b/src/disco/dedup/fd_dedup.h
@@ -10,8 +10,6 @@
 
 #include "../fd_disco_base.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
-
 /* Beyond the standard FD_CNC_SIGNAL_HALT, FD_DEDUP_CNC_SIGNAL_ACK can
    be raised by a cnc thread with an open command session while the
    dedup is in the RUN state.  The dedup will transition from ACK->RUN
@@ -260,8 +258,6 @@ fd_dedup_tile( fd_cnc_t *              cnc,       /* Local join to the dedup's c
                void *                  scratch ); /* Tile scratch memory */
 
 FD_PROTOTYPES_END
-
-#endif
 
 #endif /* HEADER_fd_src_disco_dedup_fd_dedup_h */
 

--- a/src/disco/dedup/fd_dedup_tile.c
+++ b/src/disco/dedup/fd_dedup_tile.c
@@ -1,6 +1,6 @@
 #include "../fd_disco.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 FD_STATIC_ASSERT( FD_DEDUP_TILE_SCRATCH_ALIGN<=FD_SHMEM_HUGE_PAGE_SZ, alignment );
 

--- a/src/disco/mux/fd_mux.c
+++ b/src/disco/mux/fd_mux.c
@@ -1,7 +1,5 @@
 #include "fd_mux.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
-
 /* A fd_mux_tile_in has all the state needed for muxing frags from an
    in.  It fits on exactly one cache line. */
 
@@ -571,4 +569,3 @@ fd_mux_tile( fd_cnc_t *              cnc,
 
 #undef SCRATCH_ALLOC
 
-#endif

--- a/src/disco/mux/fd_mux.h
+++ b/src/disco/mux/fd_mux.h
@@ -10,8 +10,6 @@
 
 #include "../fd_disco_base.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
-
 /* Beyond the standard FD_CNC_SIGNAL_HALT, FD_MUX_CNC_SIGNAL_ACK can be
    raised by a cnc thread with an open command session while the mux is
    in the RUN state.  The mux will transition from ACK->RUN the next
@@ -219,8 +217,6 @@ fd_mux_tile( fd_cnc_t *              cnc,       /* Local join to the mux's comma
              void *                  scratch ); /* Tile scratch memory */
 
 FD_PROTOTYPES_END
-
-#endif
 
 #endif /* HEADER_fd_src_disco_mux_fd_mux_h */
 

--- a/src/disco/mux/fd_mux_tile.c
+++ b/src/disco/mux/fd_mux_tile.c
@@ -1,6 +1,6 @@
 #include "../fd_disco.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 FD_STATIC_ASSERT( FD_MUX_TILE_SCRATCH_ALIGN<=FD_SHMEM_HUGE_PAGE_SZ, alignment );
 

--- a/src/disco/replay/fd_replay.c
+++ b/src/disco/replay/fd_replay.c
@@ -1,7 +1,5 @@
 #include "fd_replay.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
-
 #include "../../util/net/fd_pcap.h"
 #include <stdio.h>
 #include <errno.h>
@@ -325,4 +323,3 @@ fd_replay_tile( fd_cnc_t *       cnc,
 
 #undef SCRATCH_ALLOC
 
-#endif

--- a/src/disco/replay/fd_replay.h
+++ b/src/disco/replay/fd_replay.h
@@ -6,8 +6,6 @@
 
 #include "../fd_disco_base.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
-
 /* Beyond the standard FD_CNC_SIGNAL_HALT, FD_REPLAY_CNC_SIGNAL_ACK can
    be raised by a cnc thread with an open command session while the
    replay is in the RUN state.  The replay will transition from ACK->RUN
@@ -156,8 +154,6 @@ fd_replay_tile( fd_cnc_t *       cnc,       /* Local join to the replay's comman
                 void *           scratch ); /* Tile scratch memory */
 
 FD_PROTOTYPES_END
-
-#endif
 
 #endif /* HEADER_fd_src_disco_replay_fd_replay_h */
 

--- a/src/disco/replay/fd_replay_tile.c
+++ b/src/disco/replay/fd_replay_tile.c
@@ -1,6 +1,6 @@
 #include "../fd_disco.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 FD_STATIC_ASSERT( FD_REPLAY_TILE_SCRATCH_ALIGN<=FD_SHMEM_HUGE_PAGE_SZ, alignment );
 

--- a/src/disco/replay/test_replay.c
+++ b/src/disco/replay/test_replay.c
@@ -1,6 +1,6 @@
 #include "../fd_disco.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 FD_STATIC_ASSERT( FD_REPLAY_CNC_SIGNAL_ACK==4UL, unit_test );
 
@@ -336,7 +336,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
-  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED and FD_HAS_X86 capabilities" ));
+  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED capabilities" ));
   fd_halt();
   return 0;
 }

--- a/src/funk/fd_funk.c
+++ b/src/funk/fd_funk.c
@@ -1,7 +1,5 @@
 #include "fd_funk.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
-
 ulong
 fd_funk_align( void ) {
   return alignof(fd_funk_t);
@@ -124,6 +122,7 @@ fd_funk_new( void * shmem,
   funk->funk_gaddr = fd_wksp_gaddr_fast( wksp, funk );
   funk->wksp_tag   = wksp_tag;
   funk->seed       = seed;
+  funk->cycle_tag  = 3UL; /* various verify functions use tags 0-2 */
 
   funk->txn_max         = txn_max;
   funk->txn_map_gaddr   = fd_wksp_gaddr_fast( wksp, txn_map ); /* Note that this persists the join until delete */
@@ -249,6 +248,8 @@ fd_funk_verify( fd_funk_t * funk ) {
 
   ulong seed = funk->seed; /* seed can be anything */
 
+  TEST( funk->cycle_tag>2UL );
+
   /* Test transaction map */
 
   ulong txn_max = funk->txn_max;
@@ -338,4 +339,3 @@ fd_funk_verify( fd_funk_t * funk ) {
   return FD_FUNK_SUCCESS;
 }
 
-#endif /* FD_HAS_HOSTED && FD_HAS_X86 */

--- a/src/funk/fd_funk.h
+++ b/src/funk/fd_funk.h
@@ -139,16 +139,10 @@
    be resized and what not to handle large needs than when the database
    was initially created and it all "just works". */
 
-#if FD_HAS_HOSTED && FD_HAS_X86
-
 //#include "fd_funk_base.h" /* Includes ../util/fd_util.h */
 //#include "fd_funk_txn.h"  /* Includes fd_funk_base.h */
 //#include "fd_funk_rec.h"  /* Includes fd_funk_txn.h */
 #include "fd_funk_val.h"    /* Includes fd_funk_rec.h */
-
-/* The HOSTED and X86 requirement is inherited from wksp (which
-   currently requires these).  There is very little in here that
-   actually requires HOSTED or X86 capabilities though. */
 
 /* FD_FUNK_{ALIGN,FOOTPRINT} describe the alignment and footprint needed
    for a funk.  ALIGN should be a positive integer power of 2.
@@ -171,6 +165,7 @@ struct __attribute__((aligned(FD_FUNK_ALIGN))) fd_funk_private {
   ulong funk_gaddr; /* wksp gaddr of this in the backing wksp, non-zero gaddr */
   ulong wksp_tag;   /* Tag to use for wksp allocations, in [1,FD_WKSP_ALLOC_TAG_MAX] */
   ulong seed;       /* Seed for various hashing function used under the hood, arbitrary */
+  ulong cycle_tag;  /* Next cycle_tag to use, used internally for various data integrity checks */
 
   /* The funk transaction map stores the details about transactions
      in preparation and their relationships to each other.  This is a
@@ -485,9 +480,5 @@ int
 fd_funk_verify( fd_funk_t * funk );
 
 FD_PROTOTYPES_END
-
-#else /* Target does not have funk support */
-#include "fd_funk_base.h"
-#endif
 
 #endif /* HEADER_fd_src_funk_fd_funk_h */

--- a/src/funk/fd_funk_rec.c
+++ b/src/funk/fd_funk_rec.c
@@ -1,7 +1,5 @@
 #include "fd_funk.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
-
 /* Provide the actual record map implementation */
 
 #define MAP_NAME              fd_funk_rec_map
@@ -397,7 +395,7 @@ fd_funk_rec_remove( fd_funk_t *     funk,
          number of records by flickering insert / remove-with-erase in
          an in-preparaton transaction with lots unique keys. */
 
-      ulong tag = ((ulong)fd_tickcount()) << 2; /* TODO: Use fd_funk_txn_cycle_tag from fd_funk_txn.c */
+      ulong tag = funk->cycle_tag++;
 
       ulong cur_idx = txn_idx;
       for(;;) {
@@ -681,4 +679,3 @@ fd_funk_rec_verify( fd_funk_t * funk ) {
   return FD_FUNK_SUCCESS;
 }
 
-#endif /* FD_HAS_HOSTED && FD_HAS_X86 */

--- a/src/funk/fd_funk_val.c
+++ b/src/funk/fd_funk_val.c
@@ -1,7 +1,5 @@
 #include "fd_funk.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
-
 fd_funk_rec_t *
 fd_funk_val_copy( fd_funk_rec_t * rec,
                   void const *    data,
@@ -309,4 +307,3 @@ fd_funk_val_verify( fd_funk_t * funk ) {
   return FD_FUNK_SUCCESS;
 }
 
-#endif /* FD_HAS_HOSTED && FD_HAS_X86 */

--- a/src/funk/fd_funk_val.h
+++ b/src/funk/fd_funk_val.h
@@ -107,7 +107,7 @@ fd_funk_val_read( fd_funk_rec_t const * rec,     /* Assumes pointer in caller's 
    completely, [data,data+sz) overlaps with [off,off+sz).  Assumes no
    concurrent operatons on rec or data. */
 
-static inline fd_funk_rec_t *                 /* Returns rec on success, NULL on failure */
+FD_FN_UNUSED static fd_funk_rec_t *           /* Returns rec on success, NULL on failure */ /* Workaround -Winline */
 fd_funk_val_write( fd_funk_rec_t *   rec,     /* Assumed in caller's address space to live funk record (NULL returns NULL) */
                    ulong             off,     /* First byte of record to write, in [0,val_sz], NULL if too large */
                    ulong             sz,      /* Number of bytes to write, 0 is a no-op, in [0,val_sz-off], NULL if too large */

--- a/src/funk/test_funk.c
+++ b/src/funk/test_funk.c
@@ -1,6 +1,6 @@
 #include "fd_funk.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 FD_STATIC_ASSERT( FD_FUNK_ALIGN    ==128UL,                unit-test );
 FD_STATIC_ASSERT( FD_FUNK_FOOTPRINT==256UL,                unit-test );
@@ -132,7 +132,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
-  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED and FD_HAS_X86 capabilities" ));
+  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED capabilities" ));
   fd_halt();
   return 0;
 }

--- a/src/funk/test_funk_base.c
+++ b/src/funk/test_funk_base.c
@@ -100,8 +100,8 @@ main( int     argc,
   FD_TEST( !(z->ul[0] | z->ul[1] | z->ul[2] | z->ul[3]) );
 
   for( ulong rem=1000000UL; rem; rem-- ) {
-    fd_funk_txn_xid_t a[1]={0}; fd_funk_txn_xid_set_unique( a );
-    fd_funk_txn_xid_t b[1]={0}; fd_funk_txn_xid_set_unique( b );
+    fd_funk_txn_xid_t a[1]; fd_funk_txn_xid_set_unique( a );
+    fd_funk_txn_xid_t b[1]; fd_funk_txn_xid_set_unique( b );
 
     ulong hash = fd_funk_txn_xid_hash( a, 1234UL ); FD_COMPILER_FORGET( hash );
     /**/  hash = fd_funk_txn_xid_hash( b, 1234UL ); FD_COMPILER_FORGET( hash );

--- a/src/funk/test_funk_rec.c
+++ b/src/funk/test_funk_rec.c
@@ -1,6 +1,6 @@
 #include "fd_funk.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 FD_STATIC_ASSERT( FD_FUNK_REC_ALIGN    == 32UL, unit_test );
 FD_STATIC_ASSERT( FD_FUNK_REC_FOOTPRINT==160UL, unit_test );
@@ -526,7 +526,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
-  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED and FD_HAS_X86 capabilities" ));
+  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED capabilities" ));
   fd_halt();
   return 0;
 }

--- a/src/funk/test_funk_txn.c
+++ b/src/funk/test_funk_txn.c
@@ -4,7 +4,7 @@
    fd_funk_txn_cancel_children (implicitly tested under the hood but the
    user wrappers aren't), coverage of fd_funk_txn_merge. */
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 FD_STATIC_ASSERT( FD_FUNK_TXN_ALIGN    ==32UL, unit_test );
 FD_STATIC_ASSERT( FD_FUNK_TXN_FOOTPRINT==96UL, unit_test );
@@ -20,7 +20,11 @@ fd_funk_txn_xid_set_unique( fd_funk_txn_xid_t * xid ) {
   xid->ul[0] = fd_log_app_id();
   xid->ul[1] = fd_log_thread_id();
   xid->ul[2] = ++tag;
+# if FD_HAS_X86
   xid->ul[3] = (ulong)fd_tickcount();
+# else
+  xid->ul[3] = 0UL;
+# endif
   return xid;
 }
 
@@ -327,7 +331,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
-  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED and FD_HAS_X86 capabilities" ));
+  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED capabilities" ));
   fd_halt();
   return 0;
 }

--- a/src/funk/test_funk_val.c
+++ b/src/funk/test_funk_val.c
@@ -1,6 +1,6 @@
 #include "fd_funk.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 #include "test_funk_common.h"
 
@@ -596,7 +596,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
-  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED and FD_HAS_X86 capabilities" ));
+  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED capabilities" ));
   fd_halt();
   return 0;
 }

--- a/src/tango/fd_tango_ctl.c
+++ b/src/tango/fd_tango_ctl.c
@@ -2,7 +2,7 @@
 #include "mcache/fd_mcache_private.h"
 #include "dcache/fd_dcache_private.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 #include <stdio.h>
 

--- a/src/tango/mcache/fd_mcache.h
+++ b/src/tango/mcache/fd_mcache.h
@@ -285,8 +285,6 @@ fd_mcache_line_idx( ulong seq,
 
 #endif
 
-#if FD_HAS_X86
-
 /* fd_mcache_publish inserts the metadata for frag seq into the given
    depth entry mcache in a way compatible with FD_MCACHE_WAIT and
    FD_MCACHE_WAIT_SSE (but not FD_MCACHE_WAIT_AVX ... see FD_MCACHE_WAIT
@@ -725,8 +723,6 @@ fd_mcache_publish_avx( fd_frag_meta_t * mcache,   /* Assumed a current local joi
     (seq_diff)  = _fd_mcache_wait_seq_diff;                                                                            \
     (poll_max)  = _fd_mcache_wait_poll_max;                                                                            \
   } while(0)
-
-#endif
 
 #endif
 

--- a/src/tango/mcache/test_mcache.c
+++ b/src/tango/mcache/test_mcache.c
@@ -180,19 +180,8 @@ main( int     argc,
 
     FD_TEST( fd_seq_gt( next, fd_mcache_query( mcache, depth, next ) ) );
 
-#   if FD_HAS_X86
     fd_mcache_publish( mcache, depth, next, 0UL, 1UL, 2UL, 3UL, 4UL, 5UL );
     /* FIXME: TEST SSE AND AVX VARIANTS AS WELL */
-#   else
-    fd_frag_meta_t * meta = &mcache[ fd_mcache_line_idx( next, depth ) ];
-    meta->seq    = next;        /* Not atomically correct but doesn't matter here */
-    meta->sig    =         0UL;
-    meta->chunk  = (uint)  1UL;
-    meta->sz     = (ushort)2UL;
-    meta->ctl    = (ushort)3UL;
-    meta->tsorig = (uint)  4UL;
-    meta->tspub  = (uint)  5UL;
-#   endif
 
     FD_TEST( fd_seq_eq( next, fd_mcache_query( mcache, depth, next ) ) );
     ulong evict = fd_seq_dec( next, depth );

--- a/src/tango/tcache/test_tcache.c
+++ b/src/tango/tcache/test_tcache.c
@@ -1,6 +1,6 @@
 #include "../fd_tango.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 FD_STATIC_ASSERT( FD_TCACHE_ALIGN==128UL,              unit_test );
 FD_STATIC_ASSERT( FD_TCACHE_FOOTPRINT(1UL,4UL)==128UL, unit_test );
@@ -254,7 +254,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
-  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED and FD_HAS_X86 capabilities" ));
+  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED capabilities" ));
   fd_halt();
   return 0;
 }

--- a/src/tango/tempo/fd_tempo.c
+++ b/src/tango/tempo/fd_tempo.c
@@ -57,8 +57,6 @@ fd_tempo_wallclock_model( double * opt_tau ) {
   return t0;
 }
 
-#if FD_HAS_X86
-
 double
 fd_tempo_tickcount_model( double * opt_tau ) {
   static double t0;
@@ -151,9 +149,6 @@ fd_tempo_tick_per_ns( double * opt_sigma ) {
 }
 
 #endif
-#endif
-
-#if FD_HAS_X86
 
 long
 fd_tempo_observe_pair( long * opt_now,
@@ -239,7 +234,6 @@ fd_tempo_observe_pair( long * opt_now,
   if( opt_tic ) opt_tic[0] = best_tc - (best_jt>>1); /* Use lower and upper bound midpoint (could be improved statistically) */
   return best_jt;
 }
-#endif
 
 ulong
 fd_tempo_async_min( long  lazy,

--- a/src/tango/tempo/fd_tempo.h
+++ b/src/tango/tempo/fd_tempo.h
@@ -7,8 +7,6 @@
 
 FD_PROTOTYPES_BEGIN
 
-#if FD_HAS_DOUBLE
-
 /* fd_tempo_wallclock_model returns an estimate of t0, the minimum cost
    of fd_log_wallclock() in ticks.  If opt_tau is non_NULL, on return,
    *opt_tau will contain an estimate of typical jitter associated with
@@ -24,8 +22,6 @@ FD_PROTOTYPES_BEGIN
 
 double
 fd_tempo_wallclock_model( double * opt_tau );
-
-#if FD_HAS_X86
 
 /* fd_tempo_tickcount_model does the same as fd_tempo_wallclock model
    for fd_tickcount().  The model parameter units will be in ticks
@@ -63,11 +59,6 @@ fd_tempo_tickcount_model( double * opt_tau );
 double
 fd_tempo_tick_per_ns( double * opt_sigma );
 
-#endif
-#endif
-
-#if FD_HAS_X86
-
 /* fd_tempo_observe_pair observes the fd_log_wallclock() and
    fd_tickcount() at the "same time".  More precisely, it alternately
    observes both a few times and estimates from the "best" wallclock
@@ -95,8 +86,6 @@ fd_tempo_tick_per_ns( double * opt_sigma );
 long
 fd_tempo_observe_pair( long * opt_now,
                        long * opt_tic );
-
-#endif
 
 /* fd_tempo_lazy_default returns a target interval between housekeeping
    events in ns (laziness) for a producer / consumer that has a maximum

--- a/src/tango/tempo/test_tempo.c
+++ b/src/tango/tempo/test_tempo.c
@@ -22,8 +22,6 @@ main( int     argc,
     FD_LOG_NOTICE(( "wallclock:   min %8.3f ns   tau %8.2e ns", t0, tau ));
   }
 
-# if FD_HAS_X86
-
   for( ulong iter=0; iter<10; iter++ ) {
     double tau;
     double t0 = fd_tempo_tickcount_model( &tau );
@@ -52,9 +50,6 @@ main( int     argc,
   }
 
 # endif
-# endif
-
-# if FD_HAS_X86
 
   long now;
   long toc;
@@ -85,23 +80,17 @@ main( int     argc,
                     then, tic, jit, now, toc, jot, now-then, toc-tic, jot-jit ));
   }
 
-# endif
-
   for( ulong cr_max=0UL; cr_max<10UL; cr_max++ ) FD_TEST( fd_tempo_lazy_default( cr_max )==(long)(1UL+((9UL*cr_max)/4UL)) );
   FD_TEST( fd_tempo_lazy_default( 954437175UL )==2147483644L );
   FD_TEST( fd_tempo_lazy_default( 954437176UL )==2147483647L );
   FD_TEST( fd_tempo_lazy_default( 954437177UL )==2147483647L );
   FD_TEST( fd_tempo_lazy_default( ULONG_MAX   )==2147483647L );
 
-# if FD_HAS_X86 && FD_HAS_DOUBLE
-
 //FD_TEST( !fd_tempo_async_min(   0L,     1UL, 1.f ) );
 //FD_TEST( !fd_tempo_async_min(   1L,     0UL, 1.f ) );
 //FD_TEST( !fd_tempo_async_min(   1L,     1UL, 0.f ) );
 //FD_TEST( !fd_tempo_async_min( 100L, 10000UL, 1.f ) );
   FD_TEST( fd_ulong_is_pow2( fd_tempo_async_min( 100000L, 1UL, 1.f ) ) );
-
-# endif
 
   for( ulong iter=0UL; iter<1000000UL; iter++ ) {
     ulong async_min = 1UL << (int)(fd_rng_uint( rng ) & 31U );

--- a/src/util/alloc/fd_alloc.c
+++ b/src/util/alloc/fd_alloc.c
@@ -1,7 +1,4 @@
 #include "fd_alloc.h"
-
-#if FD_HAS_HOSTED && FD_HAS_X86 /* This limitation is inherited from wksp */
-
 #include "fd_alloc_cfg.h"
 
 /* Note: this will still compile on platforms without FD_HAS_ATOMIC.  It
@@ -139,15 +136,31 @@ typedef struct fd_alloc_superblock fd_alloc_superblock_t;
 
 /* fd_alloc ***********************************************************/
 
+/* FD_ALLOC_MAGIC is an ideally unique number that specifies the precise
+   memory layout of a fd_alloc */
+
+#if FD_HAS_X86 /* Technically platforms with 16B compare-exchange */
+
+#define FD_ALLOC_MAGIC (0xF17EDA2C37A110C1UL) /* FIRE DANCER ALLOC version 1 */
+
 #define VOFF_NAME      fd_alloc_vgaddr
 #define VOFF_TYPE      uint128
 #define VOFF_VER_WIDTH 64
 #include "../tmpl/fd_voff.c"
 
-/* FD_ALLOC_MAGIC is an ideally unique number that specifies the precise
-   memory layout of a fd_wksp. */
+#else /* Platforms without 16B compare-exchange */
 
 #define FD_ALLOC_MAGIC (0xF17EDA2C37A110C0UL) /* FIRE DANCER ALLOC version 0 */
+
+/* TODO: Overaligning superblocks on these targets to get a wider
+   version width */
+
+#define VOFF_NAME      fd_alloc_vgaddr
+#define VOFF_TYPE      ulong
+#define VOFF_VER_WIDTH 4
+#include "../tmpl/fd_voff.c"
+
+#endif
 
 struct __attribute__((aligned(FD_ALLOC_ALIGN))) fd_alloc {
   ulong magic;    /* ==FD_ALLOC_MAGIC */
@@ -1433,5 +1446,3 @@ fd_alloc_fprintf( fd_alloc_t * join,
 }
 
 #undef TRAP
-
-#endif /* FD_HAS_HOSTED && FD_HAS_X86 */

--- a/src/util/alloc/fd_alloc.h
+++ b/src/util/alloc/fd_alloc.h
@@ -121,8 +121,6 @@
 
 #include "../wksp/fd_wksp.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86 /* This limitation is inherited from wksp */
-
 /* FD_ALLOC_{ALIGN,FOOTPRINT} give the required alignment and footprint
    needed for a wksp allocation to be suitable as a fd_alloc.  ALIGN is
    an integer pointer of 2 and FOOTPRINT is an integer multiple of
@@ -618,8 +616,6 @@ fd_alloc_max_expand( ulong max,
 }
 
 FD_PROTOTYPES_END
-
-#endif
 
 #endif /* HEADER_fd_src_util_alloc_fd_alloc_h */
 

--- a/src/util/alloc/fd_alloc_ctl.c
+++ b/src/util/alloc/fd_alloc_ctl.c
@@ -1,7 +1,7 @@
 #include "../fd_util.h"
 #include "../wksp/fd_wksp_private.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 #include <stdio.h>
 

--- a/src/util/alloc/test_alloc.c
+++ b/src/util/alloc/test_alloc.c
@@ -1,6 +1,6 @@
 #include "../fd_util.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 FD_STATIC_ASSERT( FD_ALLOC_ALIGN               == 4096UL, unit_test );
 FD_STATIC_ASSERT( FD_ALLOC_FOOTPRINT           ==20480UL, unit_test );
@@ -272,7 +272,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
-  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED and FD_HAS_X86 capabilities" ));
+  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED capabilities" ));
   fd_halt();
   return 0;
 }

--- a/src/util/alloc/test_alloc_ctl
+++ b/src/util/alloc/test_alloc_ctl
@@ -75,12 +75,11 @@ echo Testing query
 
 echo Testing alloc
 
-"$BIN"/fd_alloc_ctl malloc                     && fail alloc $?
-"$BIN"/fd_alloc_ctl malloc "$ALLOC"            && fail alloc $?
-"$BIN"/fd_alloc_ctl malloc bad/name  0  1  1   && fail alloc $?
-"$BIN"/fd_alloc_ctl malloc "$ALLOC"   -1  1  1 && fail alloc $?
-"$BIN"/fd_alloc_ctl malloc "$ALLOC"    0 -1  1 && fail alloc $?
-"$BIN"/fd_alloc_ctl malloc "$ALLOC"    0  1 -1 && fail alloc $?
+"$BIN"/fd_alloc_ctl malloc                   && fail alloc $?
+"$BIN"/fd_alloc_ctl malloc "$ALLOC"          && fail alloc $?
+"$BIN"/fd_alloc_ctl malloc bad/name  0  1  1 && fail alloc $?
+"$BIN"/fd_alloc_ctl malloc "$ALLOC"  0 -1  1 && fail alloc $?
+"$BIN"/fd_alloc_ctl malloc "$ALLOC"  0  1 -1 && fail alloc $?
 
 GADDR0=$("$BIN"/fd_alloc_ctl malloc "$ALLOC" 3 0  8 || fail alloc $?)
 GADDR1=$("$BIN"/fd_alloc_ctl malloc "$ALLOC" 5 1  9 || fail alloc $?)

--- a/src/util/archive/fd_ar.c
+++ b/src/util/archive/fd_ar.c
@@ -146,7 +146,7 @@ fd_ar_read_next( void *         _stream,
 
 #else /* Not supported on this target */
 
-int fd_ar_read_init( void * stream                      ) { (void)stream;             return 1; }
-int fd_ar_read_next( void * stream, fd_ar_meta_t * meta ) { (void)stream; (void)meta; return 1; }
+int fd_ar_read_init( void * stream                      ) { (void)stream;             FD_COMPILER_MFENCE(); return 1; }
+int fd_ar_read_next( void * stream, fd_ar_meta_t * meta ) { (void)stream; (void)meta; FD_COMPILER_MFENCE(); return 1; }
 
 #endif

--- a/src/util/archive/test_ar.c
+++ b/src/util/archive/test_ar.c
@@ -106,7 +106,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
-  FD_LOG_NOTICE(( "skip: unit test requires FD_HAS_HOSTED" ));
+  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED" ));
   fd_halt();
   return 0;
 }

--- a/src/util/env/fd_env.c
+++ b/src/util/env/fd_env.c
@@ -1,12 +1,16 @@
+#ifndef FD_ENV_STYLE
+#if FD_HAS_HOSTED /* Use POSIX */
+#define FD_ENV_STYLE 0
+#else
+#error "Define FD_ENV_STYLE for this build target"
+#endif
+#endif
+
+#if FD_ENV_STYLE==0
+
 #include "fd_env.h"
 
-#if FD_HAS_HOSTED
 #include <stdlib.h>
-char const * fd_env_get( char const * key ) { return getenv( key ); }
-#else
-/* Work around -Wsuggest-attribute=const */
-char const * fd_env_get( char const * key ) { key = NULL; return FD_VOLATILE_CONST( key ); }
-#endif
 
 #define FD_ENV_STRIP_CMDLINE_IMPL( T, what )                                   \
 T                                                                              \
@@ -19,7 +23,7 @@ fd_env_strip_cmdline_##what( int        *   pargc,                             \
   int arg;                                                                     \
                                                                                \
   if( env_key ) {                                                              \
-    char const * cstr = fd_env_get( env_key );                                 \
+    char const * cstr = getenv( env_key );                                     \
     if( cstr ) val = fd_cstr_to_##what( cstr );                                \
   }                                                                            \
                                                                                \
@@ -50,4 +54,8 @@ FD_ENV_STRIP_CMDLINE_IMPL( double,       double )
 #endif
 
 #undef FD_ENV_STRIP_CMDLINE_IMPL
+
+#else
+#error "Unknown FD_ENV_STYLE"
+#endif
 

--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -858,7 +858,19 @@ fd_hash_memcpy( ulong                    seed,
                 void const * FD_RESTRICT s,
                 ulong                    sz );
 
-#if FD_HAS_X86
+#ifndef FD_TICKCOUNT_STYLE
+#if FD_HAS_X86 /* Use RTDSC */
+#define FD_TICKCOUNT_STYLE 1
+#else /* Use portable fallback */
+#define FD_TICKCOUNT_STYLE 0
+#endif
+#endif
+
+#if FD_TICKCOUNT_STYLE==0 /* Portable fallback (slow).  Ticks at 1 ns / tick */
+
+#define fd_tickcount() fd_log_wallclock() /* TODO: fix ugly pre-log usage */
+
+#elif FD_TICKCOUNT_STYLE==1 /* RTDSC (fast) */
 
 /* fd_tickcount:  Reads the hardware invariant tickcounter ("RDTSC").
    This monotonically increases at an approximately constant rate
@@ -894,6 +906,8 @@ fd_hash_memcpy( ulong                    seed,
 
 #define fd_tickcount() ((long)__builtin_ia32_rdtsc())
 
+#else
+#error "Unknown FD_TICKCOUNT_STYLE"
 #endif
 
 #if FD_HAS_HOSTED

--- a/src/util/log/fd_log.c
+++ b/src/util/log/fd_log.c
@@ -1,6 +1,31 @@
-#if !FD_HAS_HOSTED
-#error "Implement logging support for this build target"
+#ifndef FD_LOG_STYLE
+#ifdef FD_HAS_HOSTED
+#define FD_LOG_STYLE 0
+#else
+#error "Define FD_LOG_STYLE for this platform"
 #endif
+#endif
+
+#if FD_LOG_STYLE==0 /* POSIX style */
+
+/* FIXME: SANITIZE VARIOUS USER SET STRINGS */
+
+#define _GNU_SOURCE
+
+#include "fd_log.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sched.h>
+#include <time.h>
+#include <syscall.h>
+#include <execinfo.h>
 
 /* TEXT_* are quick-and-dirty color terminal hacks.  Probably should
    do something more robust longer term. */
@@ -49,25 +74,6 @@
 #ifndef FD_LOG_FFLUSH_LOG_FILE
 #define FD_LOG_FFLUSH_LOG_FILE 0
 #endif
-
-/* FIXME: SANITIZE VARIOUS USER SET STRINGS */
-
-#define _GNU_SOURCE
-
-#include "fd_log.h"
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdarg.h>
-#include <ctype.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <signal.h>
-#include <sched.h>
-#include <time.h>
-#include <syscall.h>
-#include <execinfo.h>
 
 /* APPLICATION LOGICAL ID APIS ****************************************/
 
@@ -1143,7 +1149,8 @@ fd_log_private_boot( int  *   pargc,
 
   FD_LOG_INFO(( "fd_log: --log-path          %s",  fd_log_private_path    ));
   FD_LOG_INFO(( "fd_log: --log-dedup         %i",  fd_log_private_dedup   ));
-  FD_LOG_INFO(( "fd_log: --log-backtrace     %i",  log_backtrace          ));
+  FD_LOG_INFO(( "fd_log: --log-colorize      %i",  fd_log_colorize()      ));
+  FD_LOG_INFO(( "fd_log: --log-level-logfile %i",  fd_log_level_logfile() ));
   FD_LOG_INFO(( "fd_log: --log-level-logfile %i",  fd_log_level_logfile() ));
   FD_LOG_INFO(( "fd_log: --log-level-stderr  %i",  fd_log_level_stderr()  ));
   FD_LOG_INFO(( "fd_log: --log-level-flush   %i",  fd_log_level_flush()   ));
@@ -1216,3 +1223,6 @@ fd_log_private_halt( void ) {
 //FD_LOG_INFO(( "fd_log: halt success" )); /* Log not online anymore */
 }
 
+#else
+#error "Unknown FD_LOG_STYLE"
+#endif

--- a/src/util/pod/fd_pod_ctl.c
+++ b/src/util/pod/fd_pod_ctl.c
@@ -1,6 +1,6 @@
 #include "../fd_util.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/util/shmem/fd_shmem.h
+++ b/src/util/shmem/fd_shmem.h
@@ -9,8 +9,6 @@
 
 #include "../log/fd_log.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
-
 /* FD_SHMEM_JOIN_MAX gives the maximum number of unique fd shmem regions
    that can be in mapped concurrently into the thread group's local
    address space.  Should be positive.  Powers of two minus 1 have good
@@ -483,13 +481,7 @@ fd_cstr_to_shmem_page_sz( char const * cstr );
 FD_FN_CONST char const *
 fd_shmem_page_sz_to_cstr( ulong page_sz );
 
-FD_PROTOTYPES_END
-
-#endif /* FD_HAS_HOSTED && FD_HAS_X86 */
-
 /* These functions are for fd_shmem internal use only. */
-
-FD_PROTOTYPES_BEGIN
 
 void
 fd_shmem_private_boot( int *    pargc,

--- a/src/util/shmem/fd_shmem_admin.c
+++ b/src/util/shmem/fd_shmem_admin.c
@@ -1,10 +1,10 @@
-#if FD_HAS_THREADS && FD_HAS_X86 /* THREADS implies HOSTED */
+#if FD_HAS_THREADS /* THREADS implies HOSTED */
 #define _GNU_SOURCE
 #endif
 
 #include "fd_shmem_private.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 #include <ctype.h>
 #include <errno.h>
@@ -672,7 +672,7 @@ fd_shmem_private_halt( void ) {
   FD_LOG_INFO(( "fd_shmem: halt success" ));
 }
 
-#else /* unhosted or not x86 */
+#else /* unhosted */
 
 void
 fd_shmem_private_boot( int *    pargc,

--- a/src/util/shmem/fd_shmem_ctl.c
+++ b/src/util/shmem/fd_shmem_ctl.c
@@ -1,6 +1,6 @@
 #include "../fd_util.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 #include <stdio.h>
 #include <errno.h>

--- a/src/util/shmem/fd_shmem_private.h
+++ b/src/util/shmem/fd_shmem_private.h
@@ -3,8 +3,6 @@
 
 #include "fd_shmem.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
-
 #if FD_HAS_THREADS
 #include <pthread.h>
 #endif
@@ -143,7 +141,5 @@ fd_shmem_private_path( char const * name,    /* Valid name */
 }
 
 FD_PROTOTYPES_END
-
-#endif
 
 #endif /* HEADER_fd_src_util_shmem_fd_shmem_private_h */

--- a/src/util/shmem/fd_shmem_user.c
+++ b/src/util/shmem/fd_shmem_user.c
@@ -1,10 +1,10 @@
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 #define _GNU_SOURCE
 #endif
 
 #include "fd_shmem_private.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 #include <errno.h>
 #include <unistd.h>

--- a/src/util/shmem/test_shmem.c
+++ b/src/util/shmem/test_shmem.c
@@ -1,6 +1,6 @@
 #include "../fd_util.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 #include <ctype.h> /* For isalnum */
 #include <errno.h>
@@ -429,7 +429,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
-  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED and FD_HAS_X86 capabilities" ));
+  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED capabilities" ));
   fd_halt();
   return 0;
 }

--- a/src/util/test_util_base.c
+++ b/src/util/test_util_base.c
@@ -397,8 +397,6 @@ main( int     argc,
     }
   } while(0);
 
-# if FD_HAS_X86
-
   /* Test fd_tickcount (FIXME: TEST MORE THAN MONOTONICITY?) */
 
   long tic = fd_tickcount();
@@ -407,8 +405,6 @@ main( int     argc,
     FD_TEST( (toc - tic) > 0L );
     tic = toc;
   }
-
-# endif
 
   /* Test FD_IMPORT */
 

--- a/src/util/tile/fd_tile_threads.cxx
+++ b/src/util/tile/fd_tile_threads.cxx
@@ -80,7 +80,7 @@ fd_tile_private_cpu_restore( fd_tile_private_cpu_config_t * save ) {
     FD_LOG_WARNING(( "fd_tile: setpriority failed (%i-%s); attempting to continue", errno, strerror( errno ) ));
 }
 
-#if FD_HAS_X86
+#if FD_HAS_X86 /* TODO: Make stacks for non-x86 that support pthread set stack and huge page like structures */
 
 #define FD_TILE_PRIVATE_STACK_PAGE_SZ  FD_SHMEM_HUGE_PAGE_SZ
 #define FD_TILE_PRIVATE_STACK_PAGE_CNT (4UL)

--- a/src/util/tile/test_tile.c
+++ b/src/util/tile/test_tile.c
@@ -61,7 +61,7 @@ main( int     argc,
   FD_LOG_NOTICE(( "id  %lu", fd_tile_id () )); FD_TEST( fd_tile_id()==fd_tile_id0() );
   FD_LOG_NOTICE(( "idx %lu", fd_tile_idx() )); FD_TEST( fd_tile_idx()==0UL );
 
-# if FD_HAS_HOSTED && FD_HAS_X86 /* FIXME: MAKE SOME NUMA FUNCTIONALITY HERE MORE GENERIC */
+# if FD_HAS_HOSTED
   ulong cpu_cnt = fd_shmem_cpu_cnt();
 
   ulong cpu_seen = 0UL;

--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -4,8 +4,6 @@
 #include "../pod/fd_pod.h"
 #include "../shmem/fd_shmem.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
-
 /* API for creating NUMA-aware and TLB-efficient workspaces used for
    complex inter-thread and inter-process shared memory communication
    patterns.  fd must be booted to use the APIs in this module.
@@ -745,7 +743,5 @@ fd_wksp_usage( fd_wksp_t *       wksp,
                fd_wksp_usage_t * usage );
 
 FD_PROTOTYPES_END
-
-#endif
 
 #endif /* HEADER_fd_src_util_wksp_fd_wksp_h */

--- a/src/util/wksp/fd_wksp_ctl.c
+++ b/src/util/wksp/fd_wksp_ctl.c
@@ -1,7 +1,7 @@
 #include "../fd_util.h"
 #include "fd_wksp_private.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 #include <stdio.h>
 #include <sys/stat.h>

--- a/src/util/wksp/fd_wksp_pod.c
+++ b/src/util/wksp/fd_wksp_pod.c
@@ -1,7 +1,5 @@
 #include "fd_wksp_private.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
-
 uchar const *
 fd_wksp_pod_attach( char const * gaddr ) {
   if( FD_UNLIKELY( !gaddr ) ) FD_LOG_ERR(( "NULL gaddr" ));
@@ -46,6 +44,4 @@ fd_wksp_pod_unmap( void * obj ) {
 
   fd_wksp_unmap( obj ); /* logs details */
 }
-
-#endif
 

--- a/src/util/wksp/fd_wksp_private.h
+++ b/src/util/wksp/fd_wksp_private.h
@@ -3,8 +3,6 @@
 
 #include "fd_wksp.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
-
 /* FD_WKSP_MAGIC is an ideally unique number that specifies the precise
    memory layout of a fd_wksp. */
 
@@ -34,7 +32,8 @@ struct __attribute__((aligned(FD_WKSP_ALLOC_ALIGN_MIN))) fd_wksp_private {
   ulong owner;    /* ULONG_MAX if no process is operating on this workspace or pid of the process currently operating on this
                      workspace.  If pid is dead, the workspace is recoverable */
   ulong part_cnt; /* Number of partitions in the workspace.  0<part_cnt<=part_max.
-                     partition i is completely described by ( part[i].active, part[i].lo, part[i+1].hi ) */
+                     partition i is completely described by ( part[i].active, part[i].lo, part[i+1].hi ).
+                     Will be briefly 0 during a reset to aid in recoverability. */
   ulong part_max; /* Maximum number of partitions of the workspace.  Positive.  This will typically be large enough to accommodate
                      a worst case partitioning of the workspace. */
   ulong gaddr_lo; /* (Convenience==part[0       ].off), data region covers bytes [gaddr_lo,gaddr_hi) relative to wksp */
@@ -131,7 +130,5 @@ fd_wksp_private_unlock( fd_wksp_t * wksp ) {
 }
 
 FD_PROTOTYPES_END
-
-#endif
 
 #endif /* HEADER_fd_src_util_wksp_fd_wksp_private_h */

--- a/src/util/wksp/test_wksp.c
+++ b/src/util/wksp/test_wksp.c
@@ -1,6 +1,6 @@
 #include "../fd_util.h"
 
-#if FD_HAS_HOSTED && FD_HAS_X86
+#if FD_HAS_HOSTED
 
 FD_STATIC_ASSERT( FD_WKSP_CSTR_MAX           ==  61UL, unit_test );
 FD_STATIC_ASSERT( FD_WKSP_ALLOC_ALIGN_MIN    ==4096UL, unit_test );
@@ -280,7 +280,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
-  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED and FD_HAS_X86 capabilities" ));
+  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED capabilities" ));
   fd_halt();
   return 0;
 }


### PR DESCRIPTION
This PR largely eliminates unnecessary use of FD_HAS_X86 compile time switches.  This is prerequisite for supporting non-x86 targets (related to some long languishing PRs earlier in the repo) and something that was useful to do before starting to do some streamlining under the hood.

A cleanup pass was done on util, funk, tango, disco and ballet (but not on app).  This touches a lot of files in usually trivial ways. 
 At this point, every library piece of code  that can compile outside of a x86 specific environment should compile.  This also cleaned up some code that has unnecessary dependencies on FD_HAS_HOSTED in the process.  (There are still some remaining though and some additional unnecessary dependencies on FD_HAS_AVX that were not cleaned up.  Those will be done subsequently.)

Note that, if adding support for a non-x86 target, if a piece of code uses APIs that only have an x86 specific implementations, the code will fail to link and the unresolved symbol errors from the linker will be good sign of what needs implemented to get code complete on the port.  This should very little at this point for X86.

The same holds for porting to a non-hosted target (in this case, the main blanks that would need to be filled in are target suitable replacements implementations of the fd_log and fd_shmem APIs).

Filling in those blanks doesn't mean the end of porting but it is bulk of the coding work.  There is a fair amount of code (fd_tango in particular) that makes a lot of use of the ordering guarantees provided by Intel's caching model.  So lots of testing and the like will still be necessary after filling in those blanks, especially if it involves lots of IPC messaging.

Some other subtle nuances are also below in the commit comments (see in particular the notes about memory layout and cmpxch16b for fd_alloc).