### PR TITLE
ballet: add ChaCha20Rng

### DIFF
--- a/src/ballet/chacha20/Local.mk
+++ b/src/ballet/chacha20/Local.mk
@@ -1,0 +1,5 @@
+$(call add-hdrs,fd_chacha20.h)
+$(call add-objs,fd_chacha20_rng)
+
+$(call make-unit-test,test_fd_chacha20_rng,test_fd_chacha20_rng,fd_ballet fd_util)
+$(call run-unit-test,test_fd_chacha20_rng)

--- a/src/ballet/chacha20/README.md
+++ b/src/ballet/chacha20/README.md
@@ -1,0 +1,15 @@
+# fd_chacha20_rng
+
+## Testing (MacOS)
+
+Build binary by using the following command
+
+```
+gcc -o test_fd_chacha20_rng test_fd_chacha20_rng.c fd_chacha20_rng.c -I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib -lcrypto
+```
+
+Then, run test to generate random numbers (displayed on console output)
+
+```
+./test_fd_chacha20_rng
+```

--- a/src/ballet/chacha20/fd_chacha20.h
+++ b/src/ballet/chacha20/fd_chacha20.h
@@ -1,0 +1,14 @@
+#ifndef HEADER_fd_src_ballet_chacha20_fd_chacha20_h
+#define HEADER_fd_src_ballet_chacha20_fd_chacha20_h
+
+#include <openssl/evp.h>
+
+typedef unsigned int fd_chacha20_rng_t;
+
+#define FD_CHACHA20_KEY_SIZE 32   // 32 bytes, 256 bits
+#define FD_CHACHA20_NONCE_SIZE 12 // 12 bytes, 96 bits
+
+int fd_chacha20_rng_init(unsigned char *key, unsigned char *nonce);
+int fd_chacha20_rng_get_uint32(fd_chacha20_rng_t *num);
+
+#endif /* HEADER_fd_src_ballet_chacha20_fd_chacha20_h */

--- a/src/ballet/chacha20/fd_chacha20_rng.c
+++ b/src/ballet/chacha20/fd_chacha20_rng.c
@@ -1,0 +1,33 @@
+#include "fd_chacha20.h"
+
+static EVP_CIPHER_CTX *ctx = NULL;
+
+int fd_chacha20_rng_init(unsigned char *key, unsigned char *nonce)
+{
+  // Initialize the ChaCha20 context with the key and nonce
+  if (!(ctx = EVP_CIPHER_CTX_new()) ||
+      !EVP_EncryptInit_ex(ctx, EVP_chacha20(), NULL, key, nonce))
+  {
+    fprintf(stderr, "Error: EVP_EncryptInit_ex()\n");
+    return 1;
+  }
+
+  return 0;
+}
+
+int fd_chacha20_rng_get_uint32(fd_chacha20_rng_t *num)
+{
+  unsigned char buf[4];
+  int outlen;
+
+  // Generate a random 32-bit number
+  if (!EVP_EncryptUpdate(ctx, buf, &outlen, buf, sizeof(buf)))
+  {
+    fprintf(stderr, "Error: EVP_EncryptUpdate()\n");
+    return 1;
+  }
+
+  *num = *((unsigned int *)buf);
+
+  return 0;
+}

--- a/src/ballet/chacha20/test_fd_chacha20_rng.c
+++ b/src/ballet/chacha20/test_fd_chacha20_rng.c
@@ -1,0 +1,60 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include "fd_chacha20.h"
+
+#define TEST_KEY_SIZE FD_CHACHA20_KEY_SIZE
+#define TEST_NONCE_SIZE FD_CHACHA20_NONCE_SIZE
+
+/* Test fd_chacha20_rng_init function */
+void test_fd_chacha20_rng_init()
+{
+  unsigned char key[TEST_KEY_SIZE];
+  unsigned char nonce[TEST_NONCE_SIZE];
+
+  /* Generate key and nonce using /dev/urandom */
+  FILE *fp = fopen("/dev/urandom", "rb");
+  fread(key, sizeof(key), 1, fp);
+  fread(nonce, sizeof(nonce), 1, fp);
+  fclose(fp);
+
+  /* Initialize the random number generator */
+  assert(fd_chacha20_rng_init(key, nonce) == 0);
+}
+
+/* Test fd_chacha20_rng_get_uint32 function */
+void test_fd_chacha20_rng_get_uint32()
+{
+  unsigned char key[TEST_KEY_SIZE];
+  unsigned char nonce[TEST_NONCE_SIZE];
+  fd_chacha20_rng_t num1, num2;
+
+  /* Generate key and nonce using /dev/urandom */
+  FILE *fp = fopen("/dev/urandom", "rb");
+  fread(key, sizeof(key), 1, fp);
+  fread(nonce, sizeof(nonce), 1, fp);
+  fclose(fp);
+
+  /* Initialize the random number generator */
+  assert(fd_chacha20_rng_init(key, nonce) == 0);
+
+  /* Generate two random numbers and make sure they are different */
+  assert(fd_chacha20_rng_get_uint32(&num1) == 0);
+  assert(fd_chacha20_rng_get_uint32(&num2) == 0);
+  assert(num1 != num2);
+
+  /* Print random numbers */
+  printf("%u\n", num1);
+  printf("%u\n", num2);
+}
+
+int main()
+{
+  test_fd_chacha20_rng_init();
+  test_fd_chacha20_rng_get_uint32();
+
+  printf("All fd_chacha20_rng tests passed!\n");
+
+  return 0;
+}


### PR DESCRIPTION
This PR adds a `ChaCha20Rng` module to generate random number by using ChaCha20 algorithm 

It uses `openssl/evp.h` to implement ChaCha20

A test case (`test_fd_chacha20_rng.c`) has been added to verify its functionality, as well as a `README` explaining how to reproduce this on a MacOS machine

