### PR TITLE
Add FD_HAS_SHANI and FD_HAS_GFNI

### DIFF
--- a/config/linux_clang_icelake.mk
+++ b/config/linux_clang_icelake.mk
@@ -1,0 +1,28 @@
+BUILDDIR:=linux/clang/icelake
+
+include config/base.mk
+include config/with-clang.mk
+include config/with-debug.mk
+include config/with-brutality.mk
+include config/with-optimization.mk
+include config/with-threads.mk
+
+# Clang sadly doesn't support important optimizations.  This practically
+# limits clang usage to code hygenine usage for the time being.  Here,
+# ideally would do:
+#
+# -falign-functions=32 -falign-jumps=32 -falign-labels=32 -falign-loops=32
+# -mbranch-cost=5
+
+CPPFLAGS+=-fomit-frame-pointer -march=icelake-server -mtune=icelake-server -mfpmath=sse \
+	  -DFD_HAS_INT128=1 -DFD_HAS_DOUBLE=1 -DFD_HAS_ALLOCA=1 -DFD_HAS_X86=1 -DFD_HAS_SSE=1 -DFD_HAS_AVX=1 \
+		-DFD_HAS_SHANI=1 -DFD_HAS_GFNI=1
+
+FD_HAS_INT128:=1
+FD_HAS_DOUBLE:=1
+FD_HAS_ALLOCA:=1
+FD_HAS_X86:=1
+FD_HAS_SSE:=1
+FD_HAS_AVX:=1
+FD_HAS_SHANI:=1
+FD_HAS_GFNI:=1

--- a/config/linux_gcc_icelake.mk
+++ b/config/linux_gcc_icelake.mk
@@ -1,0 +1,22 @@
+BUILDDIR:=linux/gcc/icelake
+
+include config/base.mk
+include config/with-gcc.mk
+include config/with-debug.mk
+include config/with-brutality.mk
+include config/with-optimization.mk
+include config/with-threads.mk
+
+CPPFLAGS+=-fomit-frame-pointer -falign-functions=32 -falign-jumps=32 -falign-labels=32 -falign-loops=32 \
+          -march=icelake-server -mtune=icelake-server -mfpmath=sse -mbranch-cost=5 \
+	  -DFD_HAS_INT128=1 -DFD_HAS_DOUBLE=1 -DFD_HAS_ALLOCA=1 -DFD_HAS_X86=1 -DFD_HAS_SSE=1 -DFD_HAS_AVX=1 \
+		-DFD_HAS_SHANI=1 -DFD_HAS_GFNI=1
+
+FD_HAS_INT128:=1
+FD_HAS_DOUBLE:=1
+FD_HAS_ALLOCA:=1
+FD_HAS_X86:=1
+FD_HAS_SSE:=1
+FD_HAS_AVX:=1
+FD_HAS_SHANI:=1
+FD_HAS_GFNI:=1

--- a/src/ballet/sha256/Local.mk
+++ b/src/ballet/sha256/Local.mk
@@ -1,7 +1,9 @@
 $(call add-hdrs,fd_sha256.h)
 $(call add-objs,fd_sha256,fd_ballet)
-ifdef FD_HAS_AVX
+ifdef FD_HAS_SHANI
 $(call add-asms,fd_sha256_core_shaext,fd_ballet)
+endif
+ifdef FD_HAS_AVX
 $(call add-objs,fd_sha256_batch_avx,fd_ballet)
 endif
 

--- a/src/ballet/sha256/fd_sha256.c
+++ b/src/ballet/sha256/fd_sha256.c
@@ -97,7 +97,7 @@ fd_sha256_delete( void * shsha ) {
 }
 
 #ifndef FD_SHA256_CORE_IMPL
-#if FD_HAS_AVX
+#if FD_HAS_SHANI
 #define FD_SHA256_CORE_IMPL 1
 #else
 #define FD_SHA256_CORE_IMPL 0

--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -144,15 +144,29 @@
    (basically do the 256-bit wide parts of "x86intrin.h" work).
    Recommend using the simd/fd_avx.h APIs instead of raw Intel
    intrinsics for readability and to facilitate portability to non-x86
-   platforms.  Implies FD_HAS_SSE.
-
-   Note that the introduction of AVX2 circa 2013 was also around the
-   time SHA extensions were added.  Currently FD_HAS_AVX thus also
-   implies the availability of SHA extensions but we might be more
-   precise in the future. */
+   platforms.  Implies FD_HAS_SSE. */
 
 #ifndef FD_HAS_AVX
 #define FD_HAS_AVX 0
+#endif
+
+/* FD_HAS_SHANI indicates that the target supports Intel SHA extensions
+   which accelerate SHA-1 and SHA-256 computation.  This extension is
+   also called SHA-NI or SHA_NI (Secure Hash Algorithm New
+   Instructiosn).  Although proposed in 2013, they're only supported on
+   Intel Ice Lake and AMD Zen CPUs and newer.  Implies FD_HAS_AVX. */
+
+#ifndef FD_HAS_SHANI
+#define FD_HAS_SHANI 0
+#endif
+
+/* FD_HAS_GFNI indicates that the target supports Intel Galois Field
+ * extensions, which accelerate operations over binary extension fields,
+ * especially GF(2^8).  These instructions are supported on Intel Ice
+ * Lake and newer and AMD Zen4 and newer CPUs.  Implies FD_HAS_AVX. */
+
+#ifndef FD_HAS_GFNI
+#define FD_HAS_GFNI 0
 #endif
 
 /* Base development environment ***************************************/

--- a/src/util/test_util_base.c
+++ b/src/util/test_util_base.c
@@ -9,8 +9,10 @@
 FD_STATIC_ASSERT( !(FD_HAS_THREADS && !FD_HAS_ATOMIC), devenv );
 FD_STATIC_ASSERT( !(FD_HAS_THREADS && !FD_HAS_HOSTED), devenv );
 
-FD_STATIC_ASSERT( !(FD_HAS_SSE && !FD_HAS_X86), devenv );
-FD_STATIC_ASSERT( !(FD_HAS_AVX && !FD_HAS_SSE), devenv );
+FD_STATIC_ASSERT( !(FD_HAS_SSE   && !FD_HAS_X86), devenv );
+FD_STATIC_ASSERT( !(FD_HAS_AVX   && !FD_HAS_SSE), devenv );
+FD_STATIC_ASSERT( !(FD_HAS_SHANI && !FD_HAS_AVX), devenv );
+FD_STATIC_ASSERT( !(FD_HAS_GFNI  && !FD_HAS_AVX), devenv );
 
 /* Test size_t <> ulong, uintptr_t <> ulong, intptr_t <> long (which
    then further imply sizeof and alignof return a ulong and that


### PR DESCRIPTION
Adds flags for SHA-NI and GF-NI instructions, protected with `FD_HAS_SHANI` and `FD_HAS_GFNI` respectively. Adds the machine target `linux_{gcc/clang}_icelake` for e.g. Ice Lake that has both of these flags enabled.