### PR TITLE
limit test run concurrency

### DIFF
--- a/.github/workflows/make_coverage.yml
+++ b/.github/workflows/make_coverage.yml
@@ -24,7 +24,7 @@ jobs:
         run: make -j
 
       - name: Run unit tests
-        run: make -kj --output-sync=target run-unit-test
+        run: make -k -j4 --output-sync=target run-unit-test
 
       - name: Make coverage report
         run: |

--- a/.github/workflows/make_test.yml
+++ b/.github/workflows/make_test.yml
@@ -21,4 +21,4 @@ jobs:
         run: make -j
 
       - name: Run unit tests
-        run: make -kj --output-sync=target run-unit-test
+        run: make -k -j4 --output-sync=target run-unit-test


### PR DESCRIPTION
Does what it says on the tin. This is done so that shared memory pages are not exhausted.