### PR TITLE
quic: prevent quic tile from overwriting chunks owned by the verify tile

### DIFF
--- a/src/tango/fd_tango_base.h
+++ b/src/tango/fd_tango_base.h
@@ -275,6 +275,21 @@ fd_frag_meta_seq_query( fd_frag_meta_t const * meta ) { /* Assumed non-NULL */
   return seq;
 }
 
+#if FD_HAS_SSE
+
+/* fd_frag_met_seq_sig_query returns the sequence number and signature
+   pointed to by meta in one atomic read, same semantics as
+   fd_frag_meta_seq_query. */
+FD_STATIC_INLINE __m128i
+fd_frag_meta_seq_sig_query( fd_frag_meta_t const * meta ) { /* Assumed non-NULL */
+  FD_COMPILER_MFENCE();
+  __m128i sse0 = _mm_load_si128( &meta->sse0 );
+  FD_COMPILER_MFENCE();
+  return sse0;
+}
+
+#endif
+
 /* fd_frag_meta_ctl, fd_frag_meta_ctl_{som,eom,err} pack and unpack the
    fd_frag message reassembly control bits. */
 


### PR DESCRIPTION
The way read/write access to dcache chunks is synchronized is via. the mcache. The assumptions is if an mcache points at some chunk, it is valid to read (as long as the mcache stays pointing there). So to start writing to a chunk, we need to find whoever pointed to that chunk before and point them somewhere else (the mechanism for this is just incrementing their seq number.)

The process of "finding" who pointed there is simple, if the dcache is always larger than the mcache, then so long as we always increment the seq number of the next mcache entry before incrementing the chunk we are writing to, the readers will always be evicted before we write.

The QUIC tile here was writing to some dcache chunks without having to increment the mcache seq number which caused corrupt frags. The fix is a bit cheeky but we just push a dummy mcache entry to notify the readers their data isn't valid, if we detect that this condition occurs.