### PR TITLE
sbpf: loader improvements

### DIFF
--- a/src/ballet/sbpf/fd_sbpf_loader.c
+++ b/src/ballet/sbpf/fd_sbpf_loader.c
@@ -3,6 +3,7 @@
 #include "../../util/fd_util.h"
 #include "../../util/bits/fd_sat.h"
 #include "../murmur3/fd_murmur3.h"
+#include "../utf8/fd_utf8.h"
 
 #include <stdio.h>
 
@@ -20,7 +21,7 @@ static FD_TLS char fd_sbpf_errbuf[ FD_SBPF_ERRBUF_SZ ] = {0};
 /* fd_sbpf_loader_seterr remembers the error ID and line number of the
    current file at which the last error occurred. */
 
-int
+__attribute__((cold,noinline)) int
 fd_sbpf_loader_seterr( int err,
                        int srcln ) {
   ldr_errno     = err;
@@ -45,61 +46,13 @@ fd_sbpf_strerror( void ) {
   return fd_sbpf_errbuf;
 }
 
-/* fd_sbpf_program ****************************************************/
+/* ELF loader, part 1 **************************************************
 
-FD_FN_CONST ulong
-fd_sbpf_program_align( void ) {
-  return alignof( fd_sbpf_program_info_t );
-}
+   Start with a static piece of scratch memory and do basic validation
+   of the file content.  Walk the section table once and remember
+   sections of interest.
 
-FD_FN_CONST ulong
-fd_sbpf_program_footprint( void ) {
-  return FD_LAYOUT_FINI( FD_LAYOUT_APPEND( FD_LAYOUT_APPEND( FD_LAYOUT_INIT,
-    alignof(fd_sbpf_program_info_t), sizeof(fd_sbpf_program_info_t) ),
-    fd_sbpf_calldests_align(),       fd_sbpf_calldests_footprint()  ),
-    alignof(fd_sbpf_program_info_t) );
-}
-
-fd_sbpf_program_t *
-fd_sbpf_program_new( void * mem ) {
-
-  if( FD_UNLIKELY( !mem ) ) return NULL;
-
-  ulong laddr = (ulong)mem;
-  laddr+=FD_LAYOUT_INIT;
-  memset( (void *)laddr, 0, sizeof(fd_sbpf_program_info_t) );
-  fd_sbpf_program_info_t * info = (fd_sbpf_program_info_t *)laddr;
-
-  laddr=FD_LAYOUT_APPEND( laddr, alignof( fd_sbpf_program_info_t ),
-                                 sizeof ( fd_sbpf_program_info_t ) );
-  /* fd_sbpf_calldests_align() < alignof( fd_sbpf_program_info_t ) */
-  info->calldests = fd_sbpf_calldests_new( (void *)laddr );
-
-  return (fd_sbpf_program_t *)fd_type_pun( mem );
-}
-
-
-void *
-fd_sbpf_program_delete( fd_sbpf_program_t * mem ) {
-  ulong laddr = (ulong)fd_type_pun( mem );
-  laddr+=FD_LAYOUT_INIT;
-  memset( (void *)laddr, 0, sizeof(fd_sbpf_program_info_t) );
-
-  laddr=FD_LAYOUT_APPEND( laddr, alignof( fd_sbpf_program_info_t ),
-                                 sizeof ( fd_sbpf_program_info_t ) );
-  /* fd_sbpf_calldests_align() < alignof( fd_sbpf_program_info_t ) */
-  fd_sbpf_calldests_delete( (void *)laddr );
-
-  return (void *)mem;
-}
-
-/* ELF loader **********************************************************
-
-   ### Logic
-
-   See the comments in fd_sbpf_prog_load below.
-
-   ### Code Style
+   ### Terminology
 
    This source follows common ELF naming practices.
 
@@ -108,63 +61,15 @@ fd_sbpf_program_delete( fd_sbpf_program_t * mem ) {
                (not necessarily contiguous in the ELF file)
 
      physical address (paddr): Byte offset into ELF file (uchar * bin)
-     virtual  address (vaddr): VM memory address
+     virtual  address (vaddr): VM memory address */
 
-   In relocations:
+/* Provide convenient access to file header and ELF content */
 
-     S: Symbol value (typically an ELF physical address)
-     A: Implicit addend, i.e. the original value of the field that the
-        relocation handler is about to write to
-     V: Virtual address, i.e. the target value that the relocation
-        handler is about to write into where the implicit addend was
-        previously stored */
-
-/* fd_sbpf_elf_t contains various temporary state during loading */
-
-struct fd_sbpf_elf {
-  /* External objects */
-  fd_sbpf_calldests_t * calldests;  /* owned by program */
-  fd_sbpf_syscalls_t  * syscalls;   /* owned by caller */
-
-  /* File header */
+__extension__ union fd_sbpf_elf {
   fd_elf64_ehdr ehdr;
-
-  /* Segments */
-  fd_elf64_phdr const * phdrs;
-  ulong phndx_dyn;
-
-  /* Section table */
-  fd_elf64_shdr const * shdrs;
-  /* Read-only section headers */
-  fd_elf64_shdr const * shdr_text;
-  fd_elf64_shdr const * shdr_rodata;
-  fd_elf64_shdr const * shdr_data_rel_ro;
-  fd_elf64_shdr const * shdr_eh_frame;
-  /* Dynamic loading section headers */
-  fd_elf64_shdr const * shdr_dyn;
-  fd_elf64_shdr const * shdr_dynstr;
-  /* FIXME replace shdr pointers with ushort indices */
-
-  /* Dynamic table */
-  fd_elf64_dyn const * dyn;
-  ulong                dyn_cnt;
-
-  /* Dynamic table entries */
-  ulong dt_rel;
-  ulong dt_relent;
-  ulong dt_relsz;
-  ulong dt_symtab;
-
-  /* Dynamic symbol table */
-  fd_elf64_sym const * dynsym;
-  ulong                dynsym_cnt;
-  char const *         dynstr;
-  ulong                dynstr_sz;
+  uchar         bin[0];
 };
-typedef struct fd_sbpf_elf fd_sbpf_elf_t;
-
-/* FD_SBPF_PHNDX_UNDEF: placeholder for undefined program header index */
-#define FD_SBPF_PHNDX_UNDEF (ULONG_MAX)
+typedef union fd_sbpf_elf fd_sbpf_elf_t;
 
 /* FD_SBPF_MM_{...}_ADDR are hardcoded virtual addresses of segments
    in the sBPF virtual machine.
@@ -174,73 +79,91 @@ typedef struct fd_sbpf_elf fd_sbpf_elf_t;
 #define FD_SBPF_MM_PROGRAM_ADDR (0x100000000UL) /* readonly program data */
 #define FD_SBPF_MM_STACK_ADDR   (0x200000000UL) /* stack (with gaps) */
 
-/* FD_SBPF_SYM_NAME_SZ_MAX is the maximum length of a symbol name cstr
-   including zero terminator. */
+/* FD_SBPF_RODATA_GUARD is the size of the guard area after the rodata
+   segment.  This is required because relocations can be partially
+   out-of-bounds. The largest relocation type is 12 bytes of read/write,
+   so there should be 12 minus 1 bytes of guard area past the end.
+   Guard area at the beginning is not required, as the rodata segment
+   always starts at file offset zero.
 
-#define FD_SBPF_SYM_NAME_SZ_MAX (1024UL)
+   Example:
+
+     00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14
+     [ RODATA segment ....... ] [ Guard area .................... ]
+                    [ Relocation .................... ] */
+
+#define FD_SBPF_RODATA_GUARD (11UL)
+
+/* _fd_int_store_if_negative stores x to *p if *p is negative (branchless) */
+
+static inline int
+_fd_int_store_if_negative( int * p,
+                      int   x ) {
+  return (*p = fd_int_if( (*p)<0, x, *p ));
+}
 
 /* fd_sbpf_check_ehdr verifies the ELF file header. */
 
 static int
 fd_sbpf_check_ehdr( fd_elf64_ehdr const * ehdr,
-                    ulong                 bin_sz ) {
+                    ulong                 elf_sz ) {
 
   /* Validate ELF magic */
-  REQUIRE( fd_uint_load_4( ehdr->e_ident )==0x464c457fU );
-
+  REQUIRE( ( fd_uint_load_4( ehdr->e_ident )==0x464c457fU             )
   /* Validate file type/target identification */
-  REQUIRE( ehdr->e_ident[ FD_ELF_EI_CLASS      ]==FD_ELF_CLASS_64   );
-  REQUIRE( ehdr->e_ident[ FD_ELF_EI_DATA       ]==FD_ELF_DATA_LE    );
-  REQUIRE( ehdr->e_ident[ FD_ELF_EI_VERSION    ]==1                 );
-  REQUIRE( ehdr->e_ident[ FD_ELF_EI_OSABI      ]==FD_ELF_OSABI_NONE );
-
-  /* Validate ... */
-  REQUIRE( ehdr->e_type     ==FD_ELF_ET_DYN         );
-  REQUIRE( ehdr->e_machine  ==FD_ELF_EM_BPF         );
-  REQUIRE( ehdr->e_ehsize   ==sizeof(fd_elf64_ehdr) );
-  REQUIRE( ehdr->e_phentsize==sizeof(fd_elf64_phdr) );
-  REQUIRE( ehdr->e_shentsize==sizeof(fd_elf64_shdr) );
-  REQUIRE( ehdr->e_shstrndx < ehdr->e_shnum         );
+         & ( ehdr->e_ident[ FD_ELF_EI_CLASS      ]==FD_ELF_CLASS_64   )
+         & ( ehdr->e_ident[ FD_ELF_EI_DATA       ]==FD_ELF_DATA_LE    )
+         & ( ehdr->e_ident[ FD_ELF_EI_VERSION    ]==1                 )
+         & ( ehdr->e_ident[ FD_ELF_EI_OSABI      ]==FD_ELF_OSABI_NONE )
+         & ( ehdr->e_type                         ==FD_ELF_ET_DYN     )
+         & ( ehdr->e_machine                      ==FD_ELF_EM_BPF     )
+         & ( ehdr->e_version                      ==1                 )
+  /* Coherence checks */
+         & ( ehdr->e_ehsize   ==sizeof(fd_elf64_ehdr)                 )
+         & ( ehdr->e_phentsize==sizeof(fd_elf64_phdr)                 )
+         & ( ehdr->e_shentsize==sizeof(fd_elf64_shdr)                 )
+         & ( ehdr->e_shstrndx < ehdr->e_shnum                         ) );
 
   /* Bounds check program header table */
 
   ulong const phoff = ehdr->e_phoff;
   ulong const phnum = ehdr->e_phnum;
-  REQUIRE( fd_ulong_is_aligned( phoff, 8UL ) );
-  REQUIRE( phoff>=sizeof(fd_elf64_ehdr) ); /* overlaps file header */
-  REQUIRE( phoff< bin_sz ); /* out of bounds */
+  REQUIRE( ( fd_ulong_is_aligned( phoff, 8UL ) )
+         & ( phoff>=sizeof(fd_elf64_ehdr)      )    /* overlaps file header */
+         & ( phoff< elf_sz                     ) ); /* out of bounds */
 
   REQUIRE( phnum<=(ULONG_MAX/sizeof(fd_elf64_phdr)) ); /* overflow */
   ulong const phsz = phnum*sizeof(fd_elf64_phdr);
 
   ulong const phoff_end = phoff+phsz;
-  REQUIRE( phoff_end>=phoff  ); /* overflow */
-  REQUIRE( phoff_end<=bin_sz ); /* out of bounds */
+  REQUIRE( ( phoff_end>=phoff  )    /* overflow */
+         & ( phoff_end<=elf_sz ) ); /* out of bounds */
 
   /* Bounds check section header table */
 
   ulong const shoff = ehdr->e_shoff;
   ulong const shnum = ehdr->e_shnum;
-  REQUIRE( fd_ulong_is_aligned( shoff, 8UL ) );
-  REQUIRE( shoff>=sizeof(fd_elf64_ehdr) ); /* overlaps file header */
-  REQUIRE( shoff< bin_sz ); /* out of bounds */
-  REQUIRE( shnum> 0UL    ); /* not enough sections */
+  REQUIRE( ( fd_ulong_is_aligned( shoff, 8UL ) )
+         & ( shoff>=sizeof(fd_elf64_ehdr)      )    /* overlaps file header */
+         & ( shoff< elf_sz                     )    /* out of bounds */
+         & ( shnum> 0UL                        ) ); /* not enough sections */
 
   REQUIRE( shoff<=(ULONG_MAX/sizeof(fd_elf64_shdr)) ); /* overflow */
   ulong const shsz = shnum*sizeof(fd_elf64_shdr);
 
   ulong const shoff_end = shoff+shsz;
-  REQUIRE( shoff_end>=shoff  ); /* overflow */
-  REQUIRE( shoff_end<=bin_sz ); /* out of bounds */
+  REQUIRE( ( shoff_end>=shoff  )    /* overflow */
+         & ( shoff_end<=elf_sz ) ); /* out of bounds */
 
   /* Overlap checks */
 
-  REQUIRE( (phoff>shoff_end) | (shoff>phoff_end) ); /* overlap shdrs<>phdrs */
+  REQUIRE( (phoff>=shoff_end) | (shoff>=phoff_end) ); /* overlap shdrs<>phdrs */
 
   return 0;
 }
 
-/* fd_sbpf_load_shdrs parses the program header table.
+/* fd_sbpf_load_shdrs walks the program header table.  Remembers info
+   along the way, and performs various validations.
 
    Assumes that ...
    - table does not overlap with file header or section header table and
@@ -248,38 +171,31 @@ fd_sbpf_check_ehdr( fd_elf64_ehdr const * ehdr,
    - offset of program header table is 8 byte aligned */
 
 static int
-fd_sbpf_load_phdrs( fd_sbpf_elf_t * prog,
-                    uchar *         bin,
-                    ulong           bin_sz ) {
+fd_sbpf_load_phdrs( fd_sbpf_elf_info_t *  info,
+                    fd_sbpf_elf_t const * elf,
+                    ulong                 elf_sz ) {
 
-  /* Fill in placeholders */
-  prog->phndx_dyn  = FD_SBPF_PHNDX_UNDEF;
-
-  ulong const pht_offset = prog->ehdr.e_phoff;
-  ulong const pht_cnt    = prog->ehdr.e_phnum;
-
-  /* Read program header table */
-
-  fd_elf64_phdr * const phdr = (fd_elf64_phdr *)(bin+pht_offset);
-  prog->phdrs = phdr;
+  ulong const pht_offset = elf->ehdr.e_phoff;
+  ulong const pht_cnt    = elf->ehdr.e_phnum;
 
   /* Virtual address of last seen program header */
   ulong p_load_vaddr = 0UL;
 
+  /* Read program header table */
+  fd_elf64_phdr const * phdr = (fd_elf64_phdr const *)( elf->bin + pht_offset );
   for( ulong i=0; i<pht_cnt; i++ ) {
     switch( phdr[i].p_type ) {
     case FD_ELF_PT_DYNAMIC:
       /* Remember first PT_DYNAMIC segment */
-      if( FD_LIKELY( prog->phndx_dyn==FD_SBPF_PHNDX_UNDEF ) )
-        prog->phndx_dyn = i;
+      _fd_int_store_if_negative( &info->phndx_dyn, (int)i );
       break;
     case FD_ELF_PT_LOAD:
       /* LOAD segments must be ordered */
       REQUIRE( phdr[ i ].p_vaddr >= p_load_vaddr );
       p_load_vaddr = phdr[ i ].p_vaddr;
       /* Segment must be within bounds */
-      REQUIRE( phdr[ i ].p_offset + phdr[ i ].p_filesz >= phdr[ i ].p_offset );
-      REQUIRE( phdr[ i ].p_offset + phdr[ i ].p_filesz <= bin_sz             );
+      REQUIRE( ( phdr[ i ].p_offset + phdr[ i ].p_filesz >= phdr[ i ].p_offset )
+             & ( phdr[ i ].p_offset + phdr[ i ].p_filesz <= elf_sz             ) );
       /* No overlap checks */
       break;
     default:
@@ -291,7 +207,8 @@ fd_sbpf_load_phdrs( fd_sbpf_elf_t * prog,
   return 0;
 }
 
-/* fd_sbpf_load_shdrs parses the section header table.
+/* fd_sbpf_load_shdrs walks the section header table.  Remembers info
+   along the way, and performs various validations.
 
    Assumes that ...
    - table does not overlap with file header or program header table and
@@ -300,55 +217,63 @@ fd_sbpf_load_phdrs( fd_sbpf_elf_t * prog,
    - section header table has at least one entry */
 
 static int
-fd_sbpf_load_shdrs( fd_sbpf_elf_t * prog,
-                    uchar *         bin,
-                    ulong           bin_sz ) {
+fd_sbpf_load_shdrs( fd_sbpf_elf_info_t *  info,
+                    fd_sbpf_elf_t const * elf,
+                    ulong                 elf_sz ) {
 
   /* File Header */
   ulong const eh_offset = 0UL;
   ulong const eh_offend = sizeof(fd_elf64_ehdr);
 
   /* Section Header Table */
-  ulong const sht_offset = prog->ehdr.e_shoff;
-  ulong const sht_cnt    = prog->ehdr.e_shnum;
+  ulong const sht_offset = elf->ehdr.e_shoff;
+  ulong const sht_cnt    = elf->ehdr.e_shnum;
   ulong const sht_sz     = sht_cnt*sizeof(fd_elf64_shdr);
   ulong const sht_offend = sht_offset + sht_sz;
 
-  fd_elf64_shdr * const shdr = (fd_elf64_shdr *)(bin+sht_offset);
-  prog->shdrs = shdr;
+  fd_elf64_shdr const * shdr = (fd_elf64_shdr const *)( elf->bin + sht_offset );
 
   /* Program Header Table */
-  ulong const pht_offset = prog->ehdr.e_phoff;
-  ulong const pht_cnt    = prog->ehdr.e_phnum;
+  ulong const pht_offset = elf->ehdr.e_phoff;
+  ulong const pht_cnt    = elf->ehdr.e_phnum;
   ulong const pht_offend = pht_offset + (pht_cnt*sizeof(fd_elf64_phdr));
-
-  /* Require SHT_NULL at index 0 */
-
-  REQUIRE( shdr[ 0 ].sh_type==FD_ELF_SHT_NULL );
 
   /* Require SHT_STRTAB for section name table */
 
-  REQUIRE( prog->ehdr.e_shstrndx < sht_cnt ); /* out of bounds */
-  REQUIRE( shdr[ prog->ehdr.e_shstrndx ].sh_type==FD_ELF_SHT_STRTAB );
+  REQUIRE( elf->ehdr.e_shstrndx < sht_cnt ); /* out of bounds */
+  REQUIRE( shdr[ elf->ehdr.e_shstrndx ].sh_type==FD_ELF_SHT_STRTAB );
 
-  ulong shstr_off = shdr[ prog->ehdr.e_shstrndx ].sh_offset;
-  REQUIRE( shstr_off<bin_sz );
+  ulong shstr_off = shdr[ elf->ehdr.e_shstrndx ].sh_offset;
+  ulong shstr_sz  = shdr[ elf->ehdr.e_shstrndx ].sh_size;
+  REQUIRE( shstr_off<elf_sz );
+
+  /* Clear the "loaded sections" bitmap */
+
+  fd_memset( info->loaded_sections, 0, ((ulong)(elf->ehdr.e_shnum) + 63UL) / 64UL );
 
   /* Validate section header table.
      Check that all sections are in bounds, ordered, and don't overlap. */
 
   ulong min_sh_offset = 0UL;  /* lowest permitted section offset */
 
+  /* While validating section header table, also figure out size
+     of the rodata segment.  This is the minimal virtual address range
+     that spans all sections.  The offset of each section in virtual
+     addressing and file addressing is guaranteed to be the same. */
+  ulong segment_end    = 0UL;  /* Upper bound of segment virtual address */
+  ulong tot_section_sz = 0UL;  /* Size of all sections */
+
   for( ulong i=0UL; i<sht_cnt; i++ ) {
     uint  sh_type   = shdr[ i ].sh_type;
     uint  sh_name   = shdr[ i ].sh_name;
+    ulong sh_addr   = shdr[ i ].sh_addr;
     ulong sh_offset = shdr[ i ].sh_offset;
     ulong sh_size   = shdr[ i ].sh_size;
     ulong sh_offend = sh_offset + sh_size;
 
     /* check that physical range has no overflow and is within bounds */
     REQUIRE( sh_offend >= sh_offset );
-    REQUIRE( sh_offend <= bin_sz    );
+    REQUIRE( sh_offend <= elf_sz    );
 
     if( sh_type!=FD_ELF_SHT_NOBITS ) {
       /* Overlap checks */
@@ -362,96 +287,351 @@ fd_sbpf_load_shdrs( fd_sbpf_elf_t * prog,
 
     if( sh_type==FD_ELF_SHT_DYNAMIC ) {
       /* Remember first SHT_DYNAMIC segment */
-      if( FD_LIKELY( !prog->shdr_dyn ) )
-        prog->shdr_dyn = &shdr[ i ];
+      _fd_int_store_if_negative( &info->shndx_dyn, (int)i );
     }
 
     ulong name_off = shstr_off + (ulong)sh_name;
-    REQUIRE( name_off<=bin_sz ); /* out of bounds */
-    /* TODO Is it okay to create a zero-sz string at EOF? */
+    REQUIRE( ( name_off<elf_sz   ) /* out of bounds */
+           & ( sh_name <shstr_sz ) );
 
     /* Create name cstr */
 
-    char __attribute__((aligned(8UL))) name[ 17UL ]={0};
-    fd_cstr_fini( fd_cstr_append_cstr_safe( fd_cstr_init( name ),
-                                            (char const *)(bin+name_off), 16UL ) );
+    char __attribute__((aligned(8UL))) name[ 16UL ]={0};
+    fd_memcpy( name, elf->bin + name_off, fd_ulong_min( fd_ulong_min( shstr_sz-sh_name, elf_sz-name_off ), 16UL ) );
+
+    /* UTF-8 validation */
+
+    REQUIRE( fd_utf8_check_cstr( name, 16UL )>=0L );
 
     /* Check name */
     /* TODO switch table for this? */
     /* TODO reject duplicate sections */
 
-    /**/ if( 0==strcmp ( name, ".text"          ) ) {
-      REQUIRE( !prog->shdr_text ); /* check for duplicate */
-                                                    prog->shdr_text        = &shdr[ i ]; }
-    else if( 0==strcmp ( name, ".rodata"        ) ) prog->shdr_rodata      = &shdr[ i ];
-    else if( 0==strcmp ( name, ".data.rel.ro"   ) ) prog->shdr_data_rel_ro = &shdr[ i ];
-    else if( 0==strcmp ( name, ".eh_frame"      ) ) prog->shdr_eh_frame    = &shdr[ i ];
-    else if( 0==strcmp ( name, ".dynstr"        ) ) prog->shdr_dynstr      = &shdr[ i ];
-    else if( 0==strncmp( name, ".bss",      4UL ) ) FAIL();
-    else if( 0==strncmp( name, ".data.rel", 9UL ) ) {} /* ignore */
-    else if( 0==strncmp( name, ".data",     5UL ) && (shdr[ i ].sh_flags & FD_ELF_SHF_WRITE) ) FAIL();
+    int load = 0;  /* should section be loaded? */
+
+    /**/ if( 0==memcmp( name, ".text", 6UL /* equals */ ) ) {
+      REQUIRE( (info->shndx_text)<0 ); /* check for duplicate */
+      info->shndx_text = (int)i;
+      load = 1;
+    }
+    else if( (0==memcmp( name, ".rodata",       8UL /* equals */ ) )
+           | (0==memcmp( name, ".data.rel.ro", 13UL /* equals */ ) )
+           | (0==memcmp( name, ".eh_frame",    10UL /* equals */ ) ) ) {
+      load = 1;
+    }
+    else if( 0==memcmp( name, ".symtab",   8UL /* equals     */ ) ) {
+      REQUIRE( (info->shndx_symtab)<0 );
+      info->shndx_symtab = (int)i;
+    }
+    else if( 0==memcmp( name, ".strtab",   8UL /* equals     */ ) ) {
+      REQUIRE( (info->shndx_strtab)<0 );
+      info->shndx_strtab = (int)i;
+    }
+    else if( 0==memcmp( name, ".dynstr",   8UL /* equals     */ ) ) {
+      REQUIRE( (info->shndx_dynstr)<0 );
+      info->shndx_dynstr = (int)i;
+    }
+    else if( 0==memcmp( name, ".bss",      4UL /* has prefix */ ) ) {
+      FAIL();
+    }
+    else if( 0==memcmp( name, ".data.rel", 9UL  /* has prefix */ ) ) {} /* ignore */
+    else if( (0==memcmp( name, ".data",    5UL  /* has prefix */ ) )
+           & (shdr[ i ].sh_flags & FD_ELF_SHF_WRITE) ) FAIL();
     else                                            {} /* ignore */
     /* else ignore */
+
+    if( load ) {
+      /* Remember that section should be loaded */
+
+      info->loaded_sections[ i>>6UL ] |= (1UL)<<(i&63UL);
+
+      /* Check that virtual address range is in MM_PROGRAM bounds */
+
+      ulong sh_actual_size = fd_ulong_if( sh_type!=FD_ELF_SHT_NOBITS, sh_size, 0UL );
+      ulong sh_virtual_end = sh_addr + sh_actual_size;
+      REQUIRE( sh_addr        == sh_offset               );
+      REQUIRE( sh_addr        <  FD_SBPF_MM_PROGRAM_ADDR ); /* overflow check */
+      REQUIRE( sh_actual_size <  FD_SBPF_MM_PROGRAM_ADDR ); /* overflow check */
+      REQUIRE( sh_virtual_end <= FD_SBPF_MM_STACK_ADDR-FD_SBPF_MM_PROGRAM_ADDR ); /* check overlap with stack */
+
+      /* Check that physical address range is in bounds
+        (Seems redundant?) */
+      ulong paddr_end = sh_offset + sh_actual_size;
+      REQUIRE( paddr_end >= sh_offset );
+      REQUIRE( paddr_end <= elf_sz    );
+
+      /* Expand range to fit section */
+      segment_end = fd_ulong_max( segment_end, sh_virtual_end );
+
+      /* Coherence check sum of section sizes (used to detect overlap) */
+      REQUIRE( tot_section_sz + sh_size >= tot_section_sz ); /* overflow check */
+      tot_section_sz += sh_size;
+    }
   }
+
+  /* More coherence checks ... these should never fail */
+  REQUIRE( tot_section_sz> 0UL    );
+  REQUIRE( segment_end   <=elf_sz );
+  /* More overlap checks */
+  REQUIRE( tot_section_sz <= segment_end ); /* overlap check */
+
+  /* Require .text section */
 
   /* FIXME SHT_NULL implies zero size in the Rust ELF loader, which seems to be permitted for .text */
-  REQUIRE( (!!prog->shdr_text) && (prog->shdr_text->sh_type != FD_ELF_SHT_NULL) ); /* check for missing text section */
-  REQUIRE( (prog->shdr_text->sh_addr <= prog->ehdr.e_entry) & /* check that entrypoint is in text VM range */
-           (prog->ehdr.e_entry       <  fd_ulong_sat_add( prog->shdr_text->sh_addr, prog->shdr_text->sh_size ) ) );
+  REQUIRE( (info->shndx_text)>=0 );
+  fd_elf64_shdr const * shdr_text = &shdr[ info->shndx_text ];
+  REQUIRE( (shdr_text->sh_type != FD_ELF_SHT_NULL)
+           /* check for missing text section */
+         & (shdr_text->sh_addr <= elf->ehdr.e_entry)
+           /* check that entrypoint is in text VM range */
+         & (elf->ehdr.e_entry  <  fd_ulong_sat_add( shdr_text->sh_addr, shdr_text->sh_size ) ) );
 
-  if( prog->shdr_dynstr ) {
-    ulong sh_offset = prog->shdr_dynstr->sh_offset;
-    ulong sh_size   = prog->shdr_dynstr->sh_size;
-    REQUIRE( (sh_offset+sh_size>=sh_offset) & (sh_offset+sh_size<=bin_sz) );
-    prog->dynstr = (char *)( bin+sh_offset );
-    /* FIXME alignment check? */
-    prog->dynstr_sz = sh_size;
+  info->text_off = (uint)shdr_text->sh_offset;
+  info->text_cnt = (uint)(shdr_text->sh_size / 8UL);
+
+  /* Convert entrypoint offset to program counter */
+
+  ulong entry_off = fd_ulong_sat_sub( elf->ehdr.e_entry, shdr_text->sh_addr );
+  ulong entry_pc = entry_off / 8UL;
+  REQUIRE( fd_ulong_is_aligned( entry_off, 8UL ) );
+  info->entry_pc = (uint)entry_pc;
+
+  if( (info->shndx_dynstr)>=0 ) {
+    fd_elf64_shdr const * shdr_dynstr = &shdr[ info->shndx_dynstr ];
+    ulong sh_offset = shdr_dynstr->sh_offset;
+    ulong sh_size   = shdr_dynstr->sh_size;
+    REQUIRE( (sh_offset+sh_size>=sh_offset) & (sh_offset+sh_size<=elf_sz) );
+    info->dynstr_off = (uint)sh_offset;
+    info->dynstr_sz  = (uint)sh_size;
   }
+
+  info->rodata_sz        = (uint)segment_end;
+  info->rodata_footprint =
+      (uint)fd_ulong_min( segment_end+FD_SBPF_RODATA_GUARD, elf_sz );
 
   return 0;
 }
 
 static int
-fd_sbpf_find_dynamic( fd_sbpf_elf_t * prog,
-                      uchar const *   bin,
-                      ulong           bin_sz ) {
+_fd_sbpf_elf_peek( fd_sbpf_elf_info_t * info,
+                   void const *         bin,
+                   ulong                elf_sz ) {
+
+  /* ELFs must have a file header */
+  REQUIRE( elf_sz>sizeof(fd_elf64_ehdr) );
+
+  /* Reject overlong ELFs (using uint addressing internally).
+     This is well beyond Solana's max account size of 10 MB. */
+  REQUIRE( elf_sz<=UINT_MAX );
+
+  /* Initialize info struct */
+  *info = (fd_sbpf_elf_info_t) {
+    .text_off         = 0U,
+    .text_cnt         = 0U,
+    .dynstr_off       = 0U,
+    .dynstr_sz        = 0U,
+    .rodata_footprint = 0U,
+    .rodata_sz        = 0U,
+    .shndx_text       = -1,
+    .shndx_symtab     = -1,
+    .shndx_strtab     = -1,
+    .shndx_dyn        = -1,
+    .shndx_dynstr     = -1,
+    .phndx_dyn        = -1,
+    /* !!! Keep this in sync with -Werror=missing-field-initializers */
+  };
+
+  fd_sbpf_elf_t const * elf = (fd_sbpf_elf_t const *)bin;
+  int err;
+
+  /* Validate file header */
+  if( FD_UNLIKELY( (err=fd_sbpf_check_ehdr( &elf->ehdr, elf_sz ))!=0 ) )
+    return err;
+
+  /* Program headers */
+  if( FD_UNLIKELY( (err=fd_sbpf_load_phdrs( info, elf,  elf_sz ))!=0 ) )
+    return err;
+
+  /* Section headers */
+  if( FD_UNLIKELY( (err=fd_sbpf_load_shdrs( info, elf,  elf_sz ))!=0 ) )
+    return err;
+
+  return 0;
+}
+
+fd_sbpf_elf_info_t *
+fd_sbpf_elf_peek( fd_sbpf_elf_info_t * info,
+                  void const *         bin,
+                  ulong                elf_sz ) {
+  return _fd_sbpf_elf_peek( info, bin, elf_sz )==0 ? info : NULL;
+}
+
+
+/* ELF loader, part 2 **************************************************
+
+   Prepare a copy of a subrange of the ELF content: The rodata segment.
+   Mangle the copy by applying dynamic relocations.  Then, zero out
+   parts of the segment that are not interesting to the loader.
+
+   ### Terminology
+
+   Shorthands for relocation handling:
+
+     S: Symbol value (typically an ELF physical address)
+     A: Implicit addend, i.e. the original value of the field that the
+        relocation handler is about to write to
+     V: Virtual address, i.e. the target value that the relocation
+        handler is about to write into where the implicit addend was
+        previously stored */
+
+
+FD_FN_CONST ulong
+fd_sbpf_program_align( void ) {
+  return alignof( fd_sbpf_program_t );
+}
+
+FD_FN_PURE ulong
+fd_sbpf_program_footprint( fd_sbpf_elf_info_t const * info ) {
+  (void)info;
+  return FD_LAYOUT_FINI( FD_LAYOUT_APPEND( FD_LAYOUT_APPEND( FD_LAYOUT_INIT,
+    alignof(fd_sbpf_program_t), sizeof(fd_sbpf_program_t) ),
+    fd_sbpf_calldests_align(),  fd_sbpf_calldests_footprint() ),
+    alignof(fd_sbpf_program_t) );
+}
+
+fd_sbpf_program_t *
+fd_sbpf_program_new( void *                     prog_mem,
+                     fd_sbpf_elf_info_t const * elf_info,
+                     void *                     rodata ) {
+
+  if( FD_UNLIKELY( !prog_mem ) ) {
+    FD_LOG_WARNING(( "NULL prog_mem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !elf_info ) ) {
+    FD_LOG_WARNING(( "NULL elf_info" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( ((elf_info->rodata_footprint)>0U) & (!rodata)) ) {
+    FD_LOG_WARNING(( "NULL rodata" ));
+    return NULL;
+  }
+
+  /* Initialize program struct */
+
+  ulong laddr = (ulong)prog_mem;
+  laddr+=FD_LAYOUT_INIT;
+  memset( (void *)laddr, 0, sizeof(fd_sbpf_program_t) );
+  fd_sbpf_program_t * prog = (fd_sbpf_program_t *)fd_type_pun( (void *)laddr );
+
+  memcpy( &prog->info, elf_info, sizeof(fd_sbpf_elf_info_t) );
+  prog->rodata    = rodata;
+  prog->rodata_sz = elf_info->rodata_sz;
+  prog->text      = (ulong *)((ulong)rodata + elf_info->text_off);
+  prog->text_cnt  = elf_info->text_cnt;
+  prog->entry_pc  = elf_info->entry_pc;
+
+  /* Initialize calldests map */
+
+  laddr=FD_LAYOUT_APPEND( laddr, alignof( fd_sbpf_program_t ),
+                                 sizeof ( fd_sbpf_program_t ) );
+  /* fd_sbpf_calldests_align() < alignof( fd_sbpf_program_t ) */
+  prog->calldests = fd_sbpf_calldests_join( fd_sbpf_calldests_new( (void *)laddr ) );
+
+  /* TODO remove "entrypoint" from function registry */
+  /* FIXME check error */
+  fd_sbpf_calldests_upsert( prog->calldests, 0x71e3cf81, prog->entry_pc );
+
+  return prog;
+}
+
+void *
+fd_sbpf_program_delete( fd_sbpf_program_t * mem ) {
+
+  ulong laddr = (ulong)fd_type_pun( mem );
+  laddr+=FD_LAYOUT_INIT;
+  memset( (void *)laddr, 0, sizeof(fd_sbpf_program_t) );
+
+  fd_sbpf_calldests_delete( fd_sbpf_calldests_leave( mem->calldests ) );
+
+  return (void *)mem;
+}
+
+/* fd_sbpf_loader_t contains various temporary state during loading */
+
+struct fd_sbpf_loader {
+  /* External objects */
+  fd_sbpf_calldests_t * calldests;  /* owned by program */
+  fd_sbpf_syscalls_t  * syscalls;   /* owned by caller */
+
+  /* Dynamic table */
+  uint dyn_off;  /* File offset of dynamic table (UINT_MAX=missing) */
+  uint dyn_cnt;  /* Number of dynamic table entries */
+
+  /* Dynamic table entries */
+  ulong dt_rel;
+  ulong dt_relent;
+  ulong dt_relsz;
+  ulong dt_symtab;
+
+  /* Dynamic symbols */
+  uint dynsym_off;  /* File offset of .dynsym section (0=missing) */
+  uint dynsym_cnt;  /* Symbol count */
+};
+typedef struct fd_sbpf_loader fd_sbpf_loader_t;
+
+/* FD_SBPF_SYM_NAME_SZ_MAX is the maximum length of a symbol name cstr
+   including zero terminator. */
+
+#define FD_SBPF_SYM_NAME_SZ_MAX (1024UL)
+
+
+static int
+fd_sbpf_find_dynamic( fd_sbpf_loader_t *         loader,
+                      fd_sbpf_elf_t const *      elf,
+                      ulong                      elf_sz,
+                      fd_sbpf_elf_info_t const * info ) {
+
+  fd_elf64_shdr const * shdrs = (fd_elf64_shdr const *)( elf->bin + elf->ehdr.e_shoff );
+  fd_elf64_phdr const * phdrs = (fd_elf64_phdr const *)( elf->bin + elf->ehdr.e_phoff );
 
   /* Try first PT_DYNAMIC in program header table */
 
-  if( prog->phndx_dyn!=FD_SBPF_PHNDX_UNDEF ) {
-    ulong dyn_off = prog->phdrs[ prog->phndx_dyn ].p_offset;
-    ulong dyn_sz  = prog->phdrs[ prog->phndx_dyn ].p_filesz;
+  if( (info->phndx_dyn)>0 ) {
+    ulong dyn_off = phdrs[ info->phndx_dyn ].p_offset;
+    ulong dyn_sz  = phdrs[ info->phndx_dyn ].p_filesz;
     ulong dyn_end = dyn_off+dyn_sz;
 
     /* Fall through to SHT_DYNAMIC if invalid */
 
     if( FD_LIKELY(   ( dyn_end>=dyn_off )                /* overflow      */
-                   & ( dyn_end<=bin_sz  )                /* out of bounds */
+                   & ( dyn_end<=elf_sz  )                /* out of bounds */
                    & fd_ulong_is_aligned( dyn_off, 8UL ) /* misaligned    */
                    & fd_ulong_is_aligned( dyn_sz,  8UL ) /* misaligned sz */ ) ) {
-
-      prog->dyn     = (fd_elf64_dyn const *)(bin+dyn_off);
-      prog->dyn_cnt = dyn_sz / sizeof(fd_elf64_dyn);
+      loader->dyn_off = (uint)dyn_off;
+      loader->dyn_cnt = (uint)(dyn_sz / sizeof(fd_elf64_dyn));
       return 0;
     }
   }
 
   /* Try first SHT_DYNAMIC in section header table */
 
-  if( prog->shdr_dyn ) {
-    ulong dyn_off = prog->shdr_dyn->sh_offset;
-    ulong dyn_sz  = prog->shdr_dyn->sh_size;
+  if( (info->shndx_dyn)>0 ) {
+    ulong dyn_off = shdrs[ info->shndx_dyn ].sh_offset;
+    ulong dyn_sz  = shdrs[ info->shndx_dyn ].sh_size;
     ulong dyn_end = dyn_off+dyn_sz;
 
     /* This time, don't tolerate errors */
 
     REQUIRE( ( dyn_end>=dyn_off )                /* overflow      */
-           & ( dyn_end<=bin_sz  )                /* out of bounds */
+           & ( dyn_end<=elf_sz  )                /* out of bounds */
            & fd_ulong_is_aligned( dyn_off, 8UL ) /* misaligned    */
            & fd_ulong_is_aligned( dyn_sz,  8UL ) /* misaligned sz */ );
 
-    prog->dyn     = (fd_elf64_dyn const *)(bin+dyn_off);
-    prog->dyn_cnt = dyn_sz / sizeof(fd_elf64_dyn);
+    loader->dyn_off = (uint)dyn_off;
+    loader->dyn_cnt = (uint)(dyn_sz / sizeof(fd_elf64_dyn));
     return 0;
   }
 
@@ -460,45 +640,47 @@ fd_sbpf_find_dynamic( fd_sbpf_elf_t * prog,
 }
 
 static int
-fd_sbpf_load_dynamic( fd_sbpf_elf_t * prog,
-                      uchar const *   bin,
-                      ulong           bin_sz ) {
+fd_sbpf_load_dynamic( fd_sbpf_loader_t *         loader,
+                      fd_sbpf_elf_t const *      elf,
+                      ulong                      elf_sz ) {
 
-  /* Skip if no dynamic table was fonud */
+  fd_elf64_shdr const * shdrs = (fd_elf64_shdr const *)( elf->bin + elf->ehdr.e_shoff );
 
-  if( !prog->dyn_cnt ) return 0;
+  /* Skip if no dynamic table was found */
+
+  if( !loader->dyn_cnt ) return 0;
 
   /* Walk dynamic table */
 
-  fd_elf64_dyn const * dyn     = prog->dyn;
-  ulong const          dyn_cnt = prog->dyn_cnt;
+  fd_elf64_dyn const * dyn     = (fd_elf64_dyn const *)( elf->bin + loader->dyn_off );
+  ulong const          dyn_cnt = loader->dyn_cnt;
 
   for( ulong i=0; i<dyn_cnt; i++ ) {
     if( FD_UNLIKELY( dyn[i].d_tag==FD_ELF_DT_NULL ) ) break;
 
     ulong d_val = dyn[i].d_un.d_val;
     switch( dyn[i].d_tag ) {
-    case FD_ELF_DT_REL:    prog->dt_rel   =d_val; break;
-    case FD_ELF_DT_RELENT: prog->dt_relent=d_val; break;
-    case FD_ELF_DT_RELSZ:  prog->dt_relsz =d_val; break;
-    case FD_ELF_DT_SYMTAB: prog->dt_symtab=d_val; break;
+    case FD_ELF_DT_REL:    loader->dt_rel   =d_val; break;
+    case FD_ELF_DT_RELENT: loader->dt_relent=d_val; break;
+    case FD_ELF_DT_RELSZ:  loader->dt_relsz =d_val; break;
+    case FD_ELF_DT_SYMTAB: loader->dt_symtab=d_val; break;
     }
   }
 
   /* Load dynamic symbol table */
 
-  if( prog->dt_symtab ) {
+  if( loader->dt_symtab ) {
     /* Search for dynamic symbol table
-       FIXME unfortunate bounded O(n^2) -- could convert to binary search */
+      FIXME unfortunate bounded O(n^2) -- could convert to binary search */
 
     /* FIXME this could be clobbered by relocations, causing strict
              aliasing violations */
 
     fd_elf64_shdr const * shdr_dynsym = NULL;
 
-    for( ulong i=0; i<prog->ehdr.e_shnum; i++ ) {
-      if( prog->shdrs[ i ].sh_addr == prog->dt_symtab ) {
-        shdr_dynsym = &prog->shdrs[ i ];
+    for( ulong i=0; i<elf->ehdr.e_shnum; i++ ) {
+      if( shdrs[ i ].sh_addr == loader->dt_symtab ) {
+        shdr_dynsym = &shdrs[ i ];
         break;
       }
     }
@@ -515,11 +697,11 @@ fd_sbpf_load_dynamic( fd_sbpf_elf_t * prog,
     ulong sh_size   = shdr_dynsym->sh_size;
 
     REQUIRE( ( sh_offset+sh_size>=sh_offset )
-           & ( sh_offset+sh_size<=bin_sz    )
+           & ( sh_offset+sh_size<=elf_sz    )
            & fd_ulong_is_aligned( sh_offset, alignof(fd_elf64_sym) ) );
 
-    prog->dynsym = (fd_elf64_sym const *)( bin+sh_offset );
-    prog->dynsym_cnt = sh_size/sizeof(fd_elf64_sym);
+    loader->dynsym_off = (uint)sh_offset;
+    loader->dynsym_cnt = (uint)(sh_size/sizeof(fd_elf64_sym));
   }
 
   return 0;
@@ -574,66 +756,7 @@ fd_sbpf_load_dynamic( fd_sbpf_elf_t * prog,
    While this complex logic will probably stick around for the next few
    years, the Solana protocol is getting increasingly restrictive for
    newly deployed ELFs.  Another proposed change is upgrading to
-   position-dependent binaries without any dynamic relocations.
-
-   ### Memory Management
-
-   The solana-labs/rbpf v0.3.0 loader makes no restrictions on
-   relocation targets.  It even permits and applies relocations that
-   would corrupt ELF data structures (sections, relocs, etc).  No such
-   corruption is actually taking place in this other loader because it
-   creates a "shadow" copy of the ELF binary being loaded.  Any would-be
-   corruption is not visible to the loader as it is walking the reloc
-   table.
-
-   This code operates only on a single copy and thus needs to ensure
-   that maliciously crafted ELFs do not cause corruption or aliasing
-   violations (U.B.).
-
-   Thus, relocations are only applied when their side effects are
-   visible in VM memory.  Specifically, this includes all of the program
-   content mapped at MM_PROGRAM_START:  .text, .rodata, .eh_frame, and
-   .data.rel.ro.  Relocation writes outside of these sections are
-   silently discarded.
-
-   FIXME are there other sections for which writes are supported? */
-
-/* fd_sbpf_reloc_mask returns a mask for relocation writes at given ELF
-   file offset.  Each return value byte i in [0,8) is 0xFF is off+i is
-   writable and 0x00 if it isn't.  Assumes that off+8 <= ULONG_MAX. */
-
-static inline ulong
-fd_sbpf_reloc_submask( fd_elf64_shdr const * shdr,
-                       ulong                 off ) {
-
-  ulong end    = off+8UL;
-  ulong sh_off = shdr->sh_offset;
-  ulong sh_end = shdr->sh_size + sh_off;
-
-  /* 0 if relocation target is entirely out-of-bounds,
-     ULONG_MAX otherwise */
-  ulong oob_mask = (ulong)( (end<sh_off) | (off>sh_end) )-1UL;
-
-  /* Mask off low and high out-of-bounds areas */
-  ulong mask_lo = ULONG_MAX >> fd_ulong_if( off>=sh_off, 0UL, ((sh_off-off)<<3)&63 );
-  ulong mask_hi = ULONG_MAX << fd_ulong_if( end<=sh_end, 0UL, ((end-sh_end)<<3)&63 );
-
-  return oob_mask & mask_lo & mask_hi;
-}
-
-static ulong
-fd_sbpf_reloc_mask( fd_sbpf_elf_t const * elf,
-                    ulong                 off ) {
-  /* The following four sections is the only content exported to the
-     VM memory map.  Thus, discard relocations to all other parts of the
-     ELF file.
-     This assumes that these four sections do not overlap with any other
-     data structures in this ELF. */
-  return                          fd_sbpf_reloc_submask( elf->shdr_text,        off )
-       | (elf->shdr_rodata      ? fd_sbpf_reloc_submask( elf->shdr_rodata,      off ) : 0UL)
-       | (elf->shdr_eh_frame    ? fd_sbpf_reloc_submask( elf->shdr_eh_frame,    off ) : 0UL)
-       | (elf->shdr_data_rel_ro ? fd_sbpf_reloc_submask( elf->shdr_data_rel_ro, off ) : 0UL);
-}
+   position-dependent binaries without any dynamic relocations. */
 
 /* R_BPF_64_64 relocates an absolute address into the extended imm field
    of an lddw-form instruction.  (Two instruction slots, low 32 bits in
@@ -643,15 +766,19 @@ fd_sbpf_reloc_mask( fd_sbpf_elf_t const * elf,
          [ ... ] [ IMM_LO ] [ ... ] [ IMM_HI ] */
 
 static int
-fd_sbpf_r_bpf_64_64( fd_sbpf_elf_t *      elf,
-                     uchar *              bin,
-                     ulong                bin_sz,
-                     fd_elf64_rel const * rel ) {
+fd_sbpf_r_bpf_64_64( fd_sbpf_loader_t   const * loader,
+                     fd_sbpf_elf_t      const * elf,
+                     ulong                      elf_sz,
+                     uchar                    * rodata,
+                     fd_sbpf_elf_info_t const * info,
+                     fd_elf64_rel       const * rel ) {
 
   uint  r_sym    = FD_ELF64_R_SYM( rel->r_info );
   ulong r_offset = rel->r_offset;
+
+  /* Bounds check */
   REQUIRE( r_offset+16UL>r_offset );
-  REQUIRE( r_offset+16UL<bin_sz   );
+  REQUIRE( r_offset+16UL<elf_sz   );
 
   /* Offsets of implicit addend (immediate fields) */
   ulong A_off_lo = r_offset+ 4UL;
@@ -659,23 +786,25 @@ fd_sbpf_r_bpf_64_64( fd_sbpf_elf_t *      elf,
 
   /* Read implicit addend (imm field of first insn slot) */
   // SBF_V2: ulong A_off = is_text ? r_offset+4UL : r_offset;
-  REQUIRE( A_off_lo+4UL<bin_sz );
-  ulong A = *(uint *)( bin+A_off_lo );
+  REQUIRE( A_off_lo+4UL<elf_sz );
 
   /* Lookup symbol */
-  REQUIRE( r_sym < elf->dynsym_cnt );
-  fd_elf64_sym const * sym = &elf->dynsym[ r_sym ];
+  REQUIRE( r_sym < loader->dynsym_cnt );
+  fd_elf64_sym const * dynsyms = (fd_elf64_sym const *)( elf->bin + loader->dynsym_off );
+  fd_elf64_sym const * sym     = &dynsyms[ r_sym ];
   ulong S = sym->st_value;
 
+  /* Skip if side effects not visible in VM */
+  if( FD_UNLIKELY( A_off_lo > info->rodata_sz ) ) return 0;
+
   /* Relocate */
+  ulong A = FD_LOAD( uint, &rodata[ A_off_lo ] );
   if( S<FD_SBPF_MM_PROGRAM_ADDR ) S+=FD_SBPF_MM_PROGRAM_ADDR;
   ulong V = S+A;
 
   /* Write back */
-  uint mask_lo = (uint)fd_sbpf_reloc_mask( elf, A_off_lo );
-  uint mask_hi = (uint)fd_sbpf_reloc_mask( elf, A_off_hi );
-  FD_STORE( uint, bin+A_off_lo, ( FD_LOAD( uint, bin+A_off_lo ) & ~mask_lo ) | ( (uint)(V      ) & mask_lo ) );
-  FD_STORE( uint, bin+A_off_hi, ( FD_LOAD( uint, bin+A_off_hi ) & ~mask_hi ) | ( (uint)(V>>32UL) & mask_hi ) );
+  FD_STORE( uint, &rodata[ A_off_lo ], (uint)(V      ) );
+  FD_STORE( uint, &rodata[ A_off_hi ], (uint)(V>>32UL) );
 
   return 0;
 }
@@ -683,17 +812,21 @@ fd_sbpf_r_bpf_64_64( fd_sbpf_elf_t *      elf,
 /* R_BPF_64_RELATIVE is almost entirely Solana specific. */
 
 static int
-fd_sbpf_r_bpf_64_relative( fd_sbpf_elf_t *      elf,
-                           uchar *              bin,
-                           ulong                bin_sz,
-                           fd_elf64_rel const * rel ) {
+fd_sbpf_r_bpf_64_relative( fd_sbpf_elf_t      const * elf,
+                           ulong                      elf_sz,
+                           uchar                    * rodata,
+                           fd_sbpf_elf_info_t const * info,
+                           fd_elf64_rel       const * rel ) {
 
   ulong r_offset = rel->r_offset;
 
-  int is_text = ( ( !!elf->shdr_text                      ) &
-                  ( r_offset >= elf->shdr_text->sh_offset ) &
-                  ( r_offset <  elf->shdr_text->sh_offset +
-                                elf->shdr_text->sh_size   ) );
+  /* Is reloc target in .text section? */
+  fd_elf64_shdr const * shdrs     = (fd_elf64_shdr const *)( elf->bin + elf->ehdr.e_shoff );
+  fd_elf64_shdr const * shdr_text = &shdrs[ info->shndx_text ];
+  int is_text = ( ( r_offset >= shdr_text->sh_offset ) &
+                  ( r_offset <  shdr_text->sh_offset +
+                                shdr_text->sh_size   ) );
+
   if( is_text ) {
     /* If reloc target is in .text, behave like R_BPF_64_64, except:
        - R_SYM(r_info) is ignored
@@ -703,66 +836,74 @@ fd_sbpf_r_bpf_64_relative( fd_sbpf_elf_t *      elf,
        This relocation type seems to make little sense but is required
        for most programs. */
 
-    REQUIRE( r_offset+16UL<=bin_sz );
+    REQUIRE( r_offset+16UL<=elf_sz );
     ulong imm_lo_off = r_offset+ 4UL;
     ulong imm_hi_off = r_offset+12UL;
 
     /* Read implicit addend */
-    uint  va_lo = *(uint *)( bin + imm_lo_off );
-    uint  va_hi = *(uint *)( bin + imm_hi_off );
+    uint  va_lo = FD_LOAD( uint, rodata+imm_lo_off );
+    uint  va_hi = FD_LOAD( uint, rodata+imm_hi_off );
     ulong va    = ( (ulong)va_hi<<32UL ) | va_lo;
 
     REQUIRE( va!=0UL );
     va = va<FD_SBPF_MM_PROGRAM_ADDR ? va+FD_SBPF_MM_PROGRAM_ADDR : va;
 
+    /* Skip if side effects not visible in VM */
+    if( FD_UNLIKELY( imm_lo_off > info->rodata_sz ) ) return 0;
+
     /* Write back
        Skip bounds check as .text is guaranteed to be writable */
-    *(uint *)( bin + imm_lo_off ) = (uint)( va       );
-    *(uint *)( bin + imm_hi_off ) = (uint)( va>>32UL );
+    FD_STORE( uint, rodata+imm_lo_off, (uint)( va       ) );
+    FD_STORE( uint, rodata+imm_hi_off, (uint)( va>>32UL ) );
   } else {
     /* Outside .text do a 64-bit write */
 
     /* Bounds checks */
-    REQUIRE( (r_offset+12UL>r_offset) & (r_offset+12UL<=bin_sz) );
-    ulong mask = fd_sbpf_reloc_mask( elf, r_offset );
-    if( FD_UNLIKELY( mask==0UL ) ) return 0;  /* skip */
+    REQUIRE( (r_offset+12UL>r_offset) & (r_offset+12UL<=elf_sz) );
 
-    /* Read implicit addend
-       FIXME: Special case for EF_SBF_V2 currently not handled here. */
-    ulong va = *(uint *)( bin+r_offset+4UL );
+    /* Skip if side effects not visible in VM */
+    if( FD_UNLIKELY( r_offset > info->rodata_sz ) ) return 0;
+
+    /* Read implicit addend */
+    ulong va = FD_LOAD( uint, rodata+r_offset+4UL );
 
     /* Relocate */
     va = fd_ulong_sat_add( va, FD_SBPF_MM_PROGRAM_ADDR );
 
     /* Write back */
-    void * target = bin+r_offset;
-    FD_STORE( ulong, target, ( FD_LOAD( ulong, target ) & ~mask ) | ( va & mask ) );
+    FD_STORE( ulong, rodata+r_offset, va );
   }
 
   return 0;
 }
 
 static int
-fd_sbpf_r_bpf_64_32( fd_sbpf_elf_t *      elf,
-                     uchar *              bin,
-                     ulong                bin_sz,
-                     fd_elf64_rel const * rel ) {
+fd_sbpf_r_bpf_64_32( fd_sbpf_loader_t   const * loader,
+                     fd_sbpf_elf_t      const * elf,
+                     ulong                      elf_sz,
+                     uchar                    * rodata,
+                     fd_sbpf_elf_info_t const * info,
+                     fd_elf64_rel       const * rel ) {
 
   uint  r_sym    = FD_ELF64_R_SYM( rel->r_info );
   ulong r_offset = rel->r_offset;
 
   /* Lookup symbol */
-  REQUIRE( r_sym < elf->dynsym_cnt );
-  fd_elf64_sym const * sym = &elf->dynsym[ r_sym ];
+  REQUIRE( r_sym < loader->dynsym_cnt );
+  fd_elf64_sym const * dynsyms = (fd_elf64_sym const *)( elf->bin + loader->dynsym_off );
+  fd_elf64_sym const * sym     = &dynsyms[ r_sym ];
   ulong S = sym->st_value;
 
   /* Lookup symbol name */
-  REQUIRE( sym->st_name < elf->dynstr_sz );
-  char const * name = elf->dynstr + sym->st_name;
-  ulong max_len  = fd_ulong_min( elf->dynstr_sz - sym->st_name, FD_SBPF_SYM_NAME_SZ_MAX );
-  ulong name_len = strnlen( name, max_len );
-  REQUIRE( name_len<max_len );
-  /* FIXME missing UTF-8 validation */
+  REQUIRE( sym->st_name < info->dynstr_sz );
+  char const * dynstr = (char const *)( elf->bin + info->dynstr_off );
+  char const * name   = &dynstr[ sym->st_name ];
+
+  /* Verify symbol name */
+  ulong max_len      = fd_ulong_min( info->dynstr_sz - sym->st_name, FD_SBPF_SYM_NAME_SZ_MAX );
+  long  name_len_res = fd_utf8_check_cstr( name, max_len );
+  ulong name_len     = (ulong)name_len_res;
+  REQUIRE( (name_len_res>=0L) & (name_len<max_len) );
 
   /* Value to write into relocated field */
   uint V;
@@ -772,20 +913,21 @@ fd_sbpf_r_bpf_64_32( fd_sbpf_elf_t *      elf,
   if( is_func_call ) {
     /* Check whether function call is in
        virtual memory range of text section */
-    REQUIRE( elf->shdr_text );
-    ulong sh_addr = elf->shdr_text->sh_addr;
-    ulong sh_size = elf->shdr_text->sh_size;
+    fd_elf64_shdr const * shdrs     = (fd_elf64_shdr const *)( elf->bin + elf->ehdr.e_shoff );
+    fd_elf64_shdr const * shdr_text = &shdrs[ info->shndx_text ];
+    ulong sh_addr = shdr_text->sh_addr;
+    ulong sh_size = shdr_text->sh_size;
     REQUIRE( (S>=sh_addr) & (S<sh_addr+sh_size) );
 
     /* Register function call */
     ulong target_pc = (S-sh_addr) / 8UL;
 
     /* Check for collision with syscall ID */
-    REQUIRE( !fd_sbpf_syscalls_query( elf->syscalls, (uint)target_pc, NULL ) );
+    REQUIRE( !fd_sbpf_syscalls_query( loader->syscalls, (uint)target_pc, NULL ) );
 
     /* Register new entry */
     uint hash = fd_murmur3_32( &target_pc, 8UL, 0U );
-    REQUIRE( fd_sbpf_calldests_upsert( elf->calldests, hash, target_pc ) );
+    REQUIRE( fd_sbpf_calldests_upsert( loader->calldests, hash, target_pc ) );
 
     V = (uint)hash;
   } else {
@@ -795,35 +937,38 @@ fd_sbpf_r_bpf_64_32( fd_sbpf_elf_t *      elf,
              which results in 640MB hash input data without caching.  */
     uint hash = fd_murmur3_32( name, name_len, 0UL );
     /* Ensure that requested syscall ID exists */
-    REQUIRE( fd_sbpf_syscalls_query( elf->syscalls, hash, NULL ) );
+    REQUIRE( fd_sbpf_syscalls_query( loader->syscalls, hash, NULL ) );
 
     V = hash;
   }
 
   /* Bounds checks */
-  REQUIRE( (r_offset+8UL>r_offset) & (r_offset+8UL<=bin_sz) );
+  REQUIRE( (r_offset+8UL>r_offset) & (r_offset+8UL<=elf_sz) );
   ulong A_off = r_offset+4UL;
-  uint  mask  = (uint)fd_sbpf_reloc_mask( elf, A_off );
+
+  /* Skip if side effects not visible in VM */
+  if( FD_UNLIKELY( A_off > info->rodata_sz ) ) return 0;
 
   /* Apply relocation */
-  void * target = bin+A_off;
-  FD_STORE( uint, target, ( FD_LOAD( uint, target ) & ~mask ) | ( V & mask ) );
+  FD_STORE( uint, rodata+A_off, V );
 
   return 0;
 }
 
 static int
-fd_sbpf_apply_reloc( fd_sbpf_elf_t *      prog,
-                     uchar *              bin,
-                     ulong                bin_sz,
-                     fd_elf64_rel const * rel ) {
+fd_sbpf_apply_reloc( fd_sbpf_loader_t   const * loader,
+                     fd_sbpf_elf_t      const * elf,
+                     ulong                      elf_sz,
+                     uchar                    * rodata,
+                     fd_sbpf_elf_info_t const * info,
+                     fd_elf64_rel       const * rel ) {
   switch( FD_ELF64_R_TYPE( rel->r_info ) ) {
   case FD_ELF_R_BPF_64_64:
-    return fd_sbpf_r_bpf_64_64      ( prog, bin, bin_sz, rel );
+    return fd_sbpf_r_bpf_64_64      ( loader, elf, elf_sz, rodata, info, rel );
   case FD_ELF_R_BPF_64_RELATIVE:
-    return fd_sbpf_r_bpf_64_relative( prog, bin, bin_sz, rel );
+    return fd_sbpf_r_bpf_64_relative(         elf, elf_sz, rodata, info, rel );
   case FD_ELF_R_BPF_64_32:
-    return fd_sbpf_r_bpf_64_32      ( prog, bin, bin_sz, rel );
+    return fd_sbpf_r_bpf_64_32      ( loader, elf, elf_sz, rodata, info, rel );
   default:
     ERR( FD_SBPF_ERR_INVALID_ELF );
   }
@@ -839,13 +984,18 @@ fd_sbpf_apply_reloc( fd_sbpf_elf_t *      prog,
    section header table. */
 
 static int
-fd_sbpf_hash_calls( fd_sbpf_elf_t * prog,
-                    uchar *         bin ) {
+fd_sbpf_hash_calls( fd_sbpf_loader_t *    loader,
+                    fd_sbpf_program_t *   prog,
+                    fd_sbpf_elf_t const * elf ) {
 
-  fd_elf64_shdr const * shtext    = prog->shdr_text;
-  fd_sbpf_calldests_t * calldests = prog->calldests;
+  fd_elf64_shdr const * shdrs  = (fd_elf64_shdr const *)( elf->bin + elf->ehdr.e_shoff );
+  fd_sbpf_elf_info_t *  info   = &prog->info;
+  uchar *               rodata = prog->rodata;
 
-  uchar * ptr      = bin + shtext->sh_offset;
+  fd_elf64_shdr const * shtext    = &shdrs[ info->shndx_text ];
+  fd_sbpf_calldests_t * calldests = loader->calldests;
+
+  uchar * ptr      = rodata + shtext->sh_offset;
   ulong   insn_cnt = shtext->sh_type!=FD_ELF_SHT_NULL ? shtext->sh_size / 8UL : 0UL;
 
   for( ulong i=0; i<insn_cnt; i++, ptr+=8UL ) {
@@ -853,9 +1003,9 @@ fd_sbpf_hash_calls( fd_sbpf_elf_t * prog,
 
     /* Check for call instruction.  If immediate is UINT_MAX, assume
        that compiler generated a relocation instead. */
-    ulong opc = insn & 0xFF;
-    int   imm = (int)(insn >> 32UL);
-    if( (opc!=FD_SBPF_OP_CALL_IMM) | (imm==-1) )
+    ulong opc  = insn & 0xFF;
+    int   imm  = (int)(insn >> 32UL);
+    if( (opc!=0x85) | (imm==-1) )
       continue;
 
     /* Mark function call destination */
@@ -877,219 +1027,156 @@ fd_sbpf_hash_calls( fd_sbpf_elf_t * prog,
 }
 
 static int
-fd_sbpf_relocate( fd_sbpf_elf_t * prog,
-                  uchar *         bin,
-                  ulong           bin_sz ) {
+fd_sbpf_relocate( fd_sbpf_loader_t   const * loader,
+                  fd_sbpf_elf_t      const * elf,
+                  ulong                      elf_sz,
+                  uchar                    * rodata,
+                  fd_sbpf_elf_info_t const * info ) {
+
+  ulong const dt_rel    = loader->dt_rel;
+  ulong const dt_relent = loader->dt_relent;
+  ulong const dt_relsz  = loader->dt_relsz;
 
   /* Skip relocation if DT_REL is missing */
 
-  if( prog->dt_rel == 0UL ) return 0;
+  if( dt_rel == 0UL ) return 0;
 
   /* Validate reloc table params */
 
-  REQUIRE(  prog->dt_relent==sizeof(fd_elf64_rel)       );
-  REQUIRE(  prog->dt_relsz !=0UL                        );
-  REQUIRE( (prog->dt_relsz % sizeof(fd_elf64_rel))==0UL );
+  REQUIRE(  dt_relent==sizeof(fd_elf64_rel)       );
+  REQUIRE(  dt_relsz !=0UL                        );
+  REQUIRE( (dt_relsz % sizeof(fd_elf64_rel))==0UL );
 
-  /* Find section matching DT_REL, assuming section header table is
-     already validated.
+  /* Resolve DT_REL virtual address to file offset
+     First, attempt to find segment containing DT_REL */
 
-     FIXME The physical address matching DT_REL can be discovered by
-           bounds checking it against segments.  This is currently the
-           default behavior, falling back to section matching for ELFs
-           where DT_REL is not in a segment. */
+  ulong rel_off;
 
-  ulong rel_shnum;
-  for( rel_shnum=0; rel_shnum < prog->ehdr.e_shnum; rel_shnum++ )
-    if( prog->shdrs[ rel_shnum ].sh_addr==prog->dt_rel )
+  fd_elf64_phdr const * phdrs = (fd_elf64_phdr const *)( elf->bin + elf->ehdr.e_phoff );
+  ulong rel_phnum;
+  for( rel_phnum=0; rel_phnum < elf->ehdr.e_phnum; rel_phnum++ ) {
+    ulong va_lo = phdrs[ rel_phnum ].p_vaddr;
+    ulong va_hi = phdrs[ rel_phnum ].p_memsz + va_lo;
+    REQUIRE( va_hi>=va_lo );
+    if( (dt_rel>=va_lo) & (dt_rel<va_hi) ) {
+      /* Found */
+      ulong va_off = dt_rel - va_lo;
+      ulong pa_lo  = phdrs[ rel_phnum ].p_offset + va_off;
+      /* Overflow checks */
+      REQUIRE( (va_off<=dt_rel)
+             & (pa_lo >=va_off)
+             & (pa_lo < elf_sz) );
+      rel_off = pa_lo;
       break;
-  REQUIRE( rel_shnum < prog->ehdr.e_shnum );
+    }
+  }
 
-  /* Translate virtual address to file offset */
+  /* DT_REL not contained in any segment.  Fallback to section header
+     table for finding first dynamic reloc section. */
 
-  ulong rel_off = prog->shdrs[ rel_shnum ].sh_offset;
+  if( rel_phnum == elf->ehdr.e_phnum ) {
+    fd_elf64_shdr const * shdrs = (fd_elf64_shdr const *)( elf->bin + elf->ehdr.e_shoff );
+    ulong rel_shnum;
+    for( rel_shnum=0; rel_shnum < elf->ehdr.e_shnum; rel_shnum++ )
+      if( shdrs[ rel_shnum ].sh_addr==dt_rel )
+        break;
+    REQUIRE( rel_shnum < elf->ehdr.e_shnum );
+    rel_off = shdrs[ rel_shnum ].sh_offset;
+  }
+
   REQUIRE( fd_ulong_is_aligned( rel_off, alignof(fd_elf64_rel) ) );
-  REQUIRE( (rel_off<bin_sz) & (prog->dt_relsz <= bin_sz) & ((rel_off+prog->dt_relsz) <= bin_sz) );
+  REQUIRE( (rel_off            <  elf_sz)
+         & (dt_relsz           <= elf_sz)
+         & ((rel_off+dt_relsz) <= elf_sz) );
 
   /* Load section and reloc tables
      Assume section header already validated at this point */
 
-  fd_elf64_rel const * rel     = (fd_elf64_rel const *)(bin+rel_off);
-  ulong                rel_cnt = prog->dt_relsz/sizeof(fd_elf64_rel);
+  fd_elf64_rel const * rel     = (fd_elf64_rel const *)( elf->bin + rel_off );
+  ulong                rel_cnt = dt_relsz/sizeof(fd_elf64_rel);
 
   /* Apply each reloc */
 
   for( ulong i=0; i<rel_cnt; i++ ) {
-    int res = fd_sbpf_apply_reloc( prog, bin, bin_sz, &rel[ i ] );
+    int res = fd_sbpf_apply_reloc( loader, elf, elf_sz, rodata, info, &rel[ i ] );
     if( res!=0 ) return res;
   }
 
   return 0;
 }
 
-/* fd_sbpf_make_rodata prepares the read-only sections to be mapped into
-   memory into a single segment. */
-
 static int
-fd_sbpf_make_rodata( fd_sbpf_elf_t *          elf,
-                     fd_sbpf_program_info_t * info,
-                     uchar *                  bin,
-                     ulong                    bin_sz ) {
+fd_sbpf_zero_rodata( fd_sbpf_elf_t *            elf,
+                     uchar *                    rodata,
+                     fd_sbpf_elf_info_t const * info ) {
 
-  fd_elf64_shdr const * shdrs = elf->shdrs;
-
-  /* Indices of sections part of readonly segment.
-     TODO store section indices in fd_sbpf_elf_t instead. */
-# define INVALID_SECTION (0x100000)
-  uint shidx[ 4 ] = {
-    elf->shdr_text        ? (uint)( elf->shdr_text        - shdrs ) : INVALID_SECTION,
-    elf->shdr_rodata      ? (uint)( elf->shdr_rodata      - shdrs ) : INVALID_SECTION,
-    elf->shdr_data_rel_ro ? (uint)( elf->shdr_data_rel_ro - shdrs ) : INVALID_SECTION,
-    elf->shdr_eh_frame    ? (uint)( elf->shdr_eh_frame    - shdrs ) : INVALID_SECTION
-  };
-
-  /* Sort indices (optimal sorting network for 4 ints) */
-  { /* from fd_sort.c */
-    uint _k[2]; ulong _c;
-#   define ORDER(k0,k1) _k[0]=(k0); _k[1]=(k1); _c=(ulong)((k1)<(k0)); (k0)=_k[_c]; (k1)=_k[_c^1UL];
-    ORDER( shidx[ 0 ], shidx[ 1 ] ); /* O O | | */
-    ORDER( shidx[ 2 ], shidx[ 3 ] ); /* | | O O */
-    ORDER( shidx[ 0 ], shidx[ 2 ] ); /* O | O | */
-    ORDER( shidx[ 1 ], shidx[ 3 ] ); /* | O | O */
-    ORDER( shidx[ 1 ], shidx[ 2 ] ); /* | O O | */
-#   undef ORDER
-  }
-
-  /* Coherence check: .text section must exist
-     (This is already verified elsewhere) */
-  REQUIRE( shidx[ 0 ]!=INVALID_SECTION );
-
-  /* Virtual address range of segment */
-  ulong segment_end = 0UL;
-
-  /* Derive segment VA range by spanning all sections */
-  ulong tot_section_sz = 0UL;  /* Size of all sections */
-  ulong ro_section_cnt;        /* Number of sections in rodata segment */
-  for( ro_section_cnt=0UL; ro_section_cnt<4UL; ro_section_cnt++ ) {
-    uint idx = shidx[ ro_section_cnt ];
-    if( idx==INVALID_SECTION ) break;
-
-    fd_elf64_shdr const * shdr = &shdrs[ idx ];
-    ulong sh_size = fd_ulong_if( shdr->sh_type!=FD_ELF_SHT_NOBITS, shdr->sh_size, 0UL );
-
-    /* Check that virtual address range is in MM_PROGRAM bounds */
-    ulong sh_end = shdr->sh_addr + sh_size;
-    REQUIRE( shdr->sh_addr == shdr->sh_offset         );
-    REQUIRE( shdr->sh_addr <  FD_SBPF_MM_PROGRAM_ADDR ); /* overflow check */
-    REQUIRE(       sh_size <  FD_SBPF_MM_PROGRAM_ADDR ); /* overflow check */
-    REQUIRE( sh_end        <= FD_SBPF_MM_STACK_ADDR-FD_SBPF_MM_PROGRAM_ADDR ); /* check overlap with stack */
-
-    /* Check that physical address range is in bounds */
-    ulong paddr_end = shdr->sh_offset + sh_size;
-    REQUIRE( paddr_end >= shdr->sh_offset );
-    REQUIRE( paddr_end <= bin_sz          );
-
-    /* Expand range to fit section */
-    segment_end = fd_ulong_max( segment_end, sh_end );
-
-    /* Bounds check total section size */
-    REQUIRE( tot_section_sz + sh_size >= tot_section_sz ); /* overflow check */
-    tot_section_sz += sh_size;
-  }
-
-  /* More coherence checks ... these should never fail */
-  REQUIRE( ro_section_cnt>0UL    );
-  REQUIRE( segment_end  <=bin_sz );
-
-  /* More overlap checks */
-  REQUIRE( tot_section_sz <= segment_end ); /* overlap check */
-
-  /* Create segment */
-  uchar * rodata    = bin;
-  ulong   rodata_sz = segment_end;
+  fd_elf64_shdr const * shdrs = (fd_elf64_shdr const *)( elf->bin + elf->ehdr.e_shoff );
 
   /* memset gaps between sections to zero.
       Assume section sh_addrs are monotonically increasing.
       Assume section virtual address ranges equal physical address ranges.
       Assume ranges are not overflowing. */
   /* FIXME match Solana more closely here */
+  /* FIXME could be faster to walk bitmap instead */
 
   ulong cursor = 0UL;
-  for( uint i=0; i<ro_section_cnt; i++ ) {
-    fd_elf64_shdr const * shdr = &shdrs[ shidx[ i ] ];
-    if( FD_UNLIKELY( shdr->sh_type == FD_ELF_SHT_NOBITS ) ) continue;
-    fd_memset( rodata+cursor, 0, shdr->sh_addr - cursor );
-    cursor = shdr->sh_addr + shdr->sh_size;
+  for( ulong i=0; i<elf->ehdr.e_shnum; i++ ) {
+    fd_elf64_shdr const * shdr = &shdrs[ i ];
+    if( (info->loaded_sections[ i>>6UL ]) & (1UL<<(i&63UL)) ) {
+      fd_memset( rodata+cursor, 0, shdr->sh_addr - cursor );
+      cursor = shdr->sh_addr + fd_ulong_if( shdr->sh_type != FD_ELF_SHT_NOBITS, shdr->sh_size, 0UL );
+    }
   }
 
-  /* Convert entrypoint offset to program counter */
-
-  ulong entry_off = fd_ulong_sat_sub( elf->ehdr.e_entry, elf->shdr_text->sh_addr );
-  ulong entry_pc = entry_off / 8UL;
-  REQUIRE( fd_ulong_is_aligned( entry_off, 8UL ) );
-  /* TODO remove "entrypoint" from function registry */
-  REQUIRE( fd_sbpf_calldests_upsert( elf->calldests, 0x71e3cf81, entry_pc ) );
-
-  /* Write info */
-
-  info->rodata    = rodata;
-  info->rodata_sz = rodata_sz;
-
-  info->text     = (ulong const *)( rodata + elf->shdr_text->sh_offset );
-  info->text_cnt = elf->shdr_text->sh_size / 8UL;
-  info->entry_pc = entry_pc;
-
-# undef INVALID_SECTION
   return 0;
 }
 
 int
 fd_sbpf_program_load( fd_sbpf_program_t *  prog,
-                      void *               _bin,
-                      ulong                bin_sz,
+                      void const *         _bin,
+                      ulong                elf_sz,
                       fd_sbpf_syscalls_t * syscalls ) {
   int err;
-  uchar * bin = (uchar *)_bin;
+  fd_sbpf_elf_t * elf = (fd_sbpf_elf_t *)_bin;
 
-  fd_sbpf_program_info_t * info = (fd_sbpf_program_info_t *)prog;
-  fd_sbpf_elf_t elf = { .calldests=info->calldests,
-                        .syscalls =syscalls };
+  fd_sbpf_loader_t loader = {
+    .calldests = prog->calldests,
+    .syscalls  = syscalls,
 
-  /* Read file header */
-  if( FD_UNLIKELY( bin_sz<sizeof(fd_elf64_ehdr) ) ) FAIL();
-  memcpy( &elf.ehdr, bin, sizeof(fd_elf64_ehdr) );
+    .dyn_off   = 0U,
+    .dyn_cnt   = 0U,
 
-  /* Validate file header */
-  if( FD_UNLIKELY( (err=fd_sbpf_check_ehdr  ( &elf.ehdr, bin_sz ))!=0 ) )
-    return err;
+    .dt_rel    = 0UL,
+    .dt_relent = 0UL,
+    .dt_relsz  = 0UL,
+    .dt_symtab = 0UL,
 
-  /* Program headers */
-  if( FD_UNLIKELY( (err=fd_sbpf_load_phdrs  ( &elf, bin, bin_sz ))!=0 ) )
-    return err;
-
-  /* Section headers */
-  if( FD_UNLIKELY( (err=fd_sbpf_load_shdrs  ( &elf, bin, bin_sz ))!=0 ) )
-    return err;
+    .dynsym_off = 0U,
+    .dynsym_cnt = 0U,
+  };
 
   /* Find dynamic section */
-  if( FD_UNLIKELY( (err=fd_sbpf_find_dynamic( &elf, bin, bin_sz ))!=0 ) )
+  if( FD_UNLIKELY( (err=fd_sbpf_find_dynamic( &loader, elf, elf_sz, &prog->info ))!=0 ) )
     return err;
 
   /* Load dynamic section */
-  if( FD_UNLIKELY( (err=fd_sbpf_load_dynamic( &elf, bin, bin_sz ))!=0 ) )
+  if( FD_UNLIKELY( (err=fd_sbpf_load_dynamic( &loader, elf, elf_sz ))!=0 ) )
     return err;
 
+  /* Copy rodata segment */
+  fd_memcpy( prog->rodata, elf->bin, prog->info.rodata_footprint );
+
   /* Convert calls with PC relative immediate to hashes */
-  if( FD_UNLIKELY( (err=fd_sbpf_hash_calls  ( &elf, bin         ))!=0 ) )
+  if( FD_UNLIKELY( (err=fd_sbpf_hash_calls  ( &loader, prog, elf ))!=0 ) )
     return err;
 
   /* Apply relocations */
-  if( FD_UNLIKELY( (err=fd_sbpf_relocate    ( &elf, bin, bin_sz ))!=0 ) )
+  if( FD_UNLIKELY( (err=fd_sbpf_relocate    ( &loader, elf, elf_sz, prog->rodata, &prog->info ))!=0 ) )
     return err;
 
   /* Create read-only segment
      This mangles the ELF file */
-  if( FD_UNLIKELY( (err=fd_sbpf_make_rodata ( &elf, info, bin, bin_sz ))!=0 ) )
+  if( FD_UNLIKELY( (err=fd_sbpf_zero_rodata( elf, prog->rodata, &prog->info ))!=0 ) )
     return err;
 
   return 0;
@@ -1099,8 +1186,13 @@ fd_sbpf_program_load( fd_sbpf_program_t *  prog,
 #undef FAIL
 #undef REQUIRE
 
-/* Declare extern symbol definitions for inlines */
+/* Declare extern symbol definitions for static inlines */
 
-FD_FN_CONST extern inline fd_sbpf_program_info_t const *
-fd_sbpf_program_get_info( fd_sbpf_program_t const * program );
+__attribute__((alias("fd_sbpf_syscalls_align"    ),const)) extern __typeof__(fd_sbpf_syscalls_align    ) fd_sbpf_syscalls_align_ext;
+__attribute__((alias("fd_sbpf_syscalls_footprint"),const)) extern __typeof__(fd_sbpf_syscalls_footprint) fd_sbpf_syscalls_footprint_ext;
+__attribute__((alias("fd_sbpf_syscalls_new"      )      )) extern __typeof__(fd_sbpf_syscalls_new      ) fd_sbpf_syscalls_new_ext;
+__attribute__((alias("fd_sbpf_syscalls_insert"   )      )) extern __typeof__(fd_sbpf_syscalls_insert   ) fd_sbpf_syscalls_insert_ext;
+__attribute__((alias("fd_sbpf_syscalls_delete"   )      )) extern __typeof__(fd_sbpf_syscalls_delete   ) fd_sbpf_syscalls_delete_ext;
+__attribute__((alias("fd_sbpf_program_align"     ),const)) extern __typeof__(fd_sbpf_program_align     ) fd_sbpf_program_align_ext;
+__attribute__((alias("fd_sbpf_program_footprint" ),pure )) extern __typeof__(fd_sbpf_program_footprint ) fd_sbpf_program_footprint_ext;
 

--- a/src/ballet/sbpf/fuzz_sbpf_loader.c
+++ b/src/ballet/sbpf/fuzz_sbpf_loader.c
@@ -3,6 +3,7 @@
 #endif
 
 #include "fd_sbpf_loader.h"
+#include "fd_sbpf_maps.c"
 
 #include <stdlib.h>
 

--- a/src/ballet/sbpf/test_sbpf_loader.c
+++ b/src/ballet/sbpf/test_sbpf_loader.c
@@ -1,0 +1,85 @@
+#include "fd_sbpf_loader.h"
+#include "../../util/fd_util.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  /* Parse command line arguments */
+
+  char const * bin_path = fd_env_strip_cmdline_cstr( &argc, &argv, "--bin", NULL, NULL );
+
+  /* Validate command line arguments */
+
+  if( FD_UNLIKELY( !bin_path ) )
+    FD_LOG_ERR(( "--bin not specified" ));
+
+  /* Open file */
+
+  FILE * bin_file = fopen( bin_path, "rb" );
+  if( FD_UNLIKELY( !bin_file ) )
+    FD_LOG_ERR(( "Failed to open \"%s\": %s", bin_path, strerror( errno ) ));
+
+  /* Check file content */
+
+  struct stat bin_stat;
+  if( FD_UNLIKELY( 0!=fstat( fileno( bin_file ), &bin_stat ) ) )
+    FD_LOG_ERR(( "fstat() failed: %s", strerror( errno ) ));
+  if( FD_UNLIKELY( !S_ISREG( bin_stat.st_mode ) ) )
+    FD_LOG_ERR(( "File \"%s\" not a regular file", bin_path ));
+  if( FD_UNLIKELY( bin_stat.st_size<0L ) )
+    FD_LOG_ERR(( "File \"%s\" has invalid size %ld", bin_path, bin_stat.st_size ));
+
+  /* Allocate file */
+
+  long t_pre_read = fd_log_wallclock();
+
+  ulong  bin_sz  = (ulong)bin_stat.st_size;
+  void * bin_buf = malloc( bin_sz );
+  if( FD_UNLIKELY( !bin_buf ) )
+    FD_LOG_ERR(( "malloc() failed: %s", strerror( errno ) ));
+
+  /* Read file into memory */
+
+  FD_LOG_NOTICE(( "Loading sBPF program: %s", bin_path ));
+
+  if( FD_UNLIKELY( fread( bin_buf, bin_sz, 1UL, bin_file )!=1UL ) )
+    FD_LOG_ERR(( "fread() failed: %s", strerror( errno ) ));
+
+  long t_post_read = fd_log_wallclock();
+  long dt_read = t_post_read-t_pre_read;
+  FD_LOG_INFO(( "test_sbpf_loader: Read ELF into memory in %g ns", (double)dt_read ));
+
+  /* Load and reloc program */
+
+  long t_pre_load = fd_log_wallclock();
+
+  fd_sbpf_program_t prog;
+  int load_err = fd_sbpf_program_load( &prog, bin_buf, bin_sz );
+
+  long t_post_load = fd_log_wallclock();
+  long dt_load = t_post_load-t_pre_load;
+  FD_LOG_INFO(( "test_sbpf_loader: Loaded and relocated ELF in %g ns", (double)dt_load ));
+
+  /* Clean up */
+
+  free( bin_buf );
+
+  if( FD_UNLIKELY( 0!=fclose( bin_file ) ) )
+    FD_LOG_WARNING(( "fclose() failed: %s", strerror( errno ) ));
+
+  /* Yield result */
+
+  if( FD_UNLIKELY( load_err!=0 ) )
+    FD_LOG_ERR(( "FAIL: %s", fd_sbpf_strerror() ));
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}

--- a/src/ballet/utf8/Local.mk
+++ b/src/ballet/utf8/Local.mk
@@ -1,0 +1,5 @@
+$(call add-hdrs,fd_utf8.h)
+$(call add-objs,fd_utf8,fd_ballet)
+$(call make-unit-test,test_utf8,test_utf8,fd_ballet fd_util)
+$(call run-unit-test,test_utf8)
+$(call make-fuzz-test,fuzz_utf8_check_cstr,fuzz_utf8_check_cstr,fd_ballet fd_util)

--- a/src/ballet/utf8/fd_utf8.c
+++ b/src/ballet/utf8/fd_utf8.c
@@ -1,0 +1,103 @@
+#include "fd_utf8.h"
+
+/* Basic UTF-8 validator imported from Rust's core/src/str/validations.rs */
+
+/* FIXME: Add high-performance AVX version */
+
+static uchar const fd_utf8_char_width[ 256 ] = {
+  // 1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 1
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 2
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 3
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 4
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 5
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 6
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 7
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 8
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 9
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // A
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // B
+  0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // C
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // D
+  3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, // E
+  4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // F
+};
+
+FD_FN_PURE long
+fd_utf8_check_cstr( char const * cstr,
+                    ulong        sz ) {
+
+  char const *       cur     = cstr;
+  char const * const end     = cur+sz;
+  char const * const end_par = end-15UL;
+
+  while( cur<end ) {
+    uint c0 = (uchar)*cur;
+    if( c0==0x00U ) return cur-cstr;
+    if( c0>=0x80U ) {
+      cur++;
+      ulong width  = fd_utf8_char_width[ c0 ];
+      ulong extras = width-1UL;  /* number of continuation bytes */
+      if( FD_UNLIKELY( cur+extras >= end ) ) return -1L;
+
+      switch( width ) {
+      case 2: {
+        schar c1 = (schar)( *cur++ );
+        if( FD_UNLIKELY( (c1>=-64) ) )
+          return -1;
+        break;
+      }
+      case 3: {
+        uchar c1 = (uchar)( *cur++ );
+        schar c2 = (schar)( *cur++ );
+        if( FD_UNLIKELY(
+            !(   ( (c0==0xe0)&           (c1>=0xa0)&(c1<=0xbf) )
+               | ( (c0>=0xe1)&(c0<=0xec)&(c1>=0x80)&(c1<=0xbf) )
+               | ( (c0==0xed)&           (c1>=0x80)&(c1<=0x9f) )
+               | ( (c0>=0xee)&(c0<=0xef)&(c1>=0x80)&(c1<=0xbf) ) )
+            | (c2>=-64) ) )
+          return -1;
+        break;
+      }
+      case 4: {
+        uchar c1 = (uchar)( *cur++ );
+        schar c2 = (schar)( *cur++ );
+        schar c3 = (schar)( *cur++ );
+        if( FD_UNLIKELY(
+            !(   ( (c0==0xf0)&           (c1>=0x90)&(c1<=0xbf) )
+               | ( (c0>=0xf1)&(c0<=0xf3)&(c1>=0x80)&(c1<=0xbf) )
+               | ( (c0==0xf4)&           (c1>=0x80)&(c1<=0x8f) ) )
+            | (c2>=-64)
+            | (c3>=-64) ) )
+          return -1;
+        break;
+      }
+      default:
+        return -1L;
+      }
+    } else if( fd_ulong_is_aligned( (ulong)cur, 8UL ) ) {
+      /* Fast-forward until first non-ascii byte */
+      while( cur<end_par ) {
+        ulong u0 = *(ulong const *)( __builtin_assume_aligned( cur,     8UL ) );
+        ulong u1 = *(ulong const *)( __builtin_assume_aligned( cur+8UL, 8UL ) );
+        if(  (u0&0x8080808080808080UL)
+          |  (u1&0x8080808080808080UL)
+          | ((u0-0x0101010101010101UL) & ~u0 & 0x8080808080808080UL)
+          | ((u1-0x0101010101010101UL) & ~u1 & 0x8080808080808080UL) )
+          break;
+        cur += 16UL;
+      }
+      while( cur<end ) {
+        if( !*cur ) return cur-cstr;
+        if( (uchar)*cur >= 0x80U ) return -1L;
+        cur++;
+      }
+    } else {
+      cur++;
+    }
+  }
+
+  /* Missing null terminator */
+  return -1L;
+}

--- a/src/ballet/utf8/fd_utf8.h
+++ b/src/ballet/utf8/fd_utf8.h
@@ -1,0 +1,57 @@
+#ifndef HEADER_fd_src_ballet_utf8_fd_utf8_h
+#define HEADER_fd_src_ballet_utf8_fd_utf8_h
+
+#include "../fd_ballet_base.h"
+
+/* fd_utf8_check_cstr checks whether the given pointer is a valid UTF-8
+   encoded cstr.  That is, checks whether the string complies with UTF-8
+   encoding rules.  Does not whether the code points are defined in the
+   Unicode character set.
+
+   cstr points to the first byte of the UTF-8 string.  May read
+   from memory region [cstr,cstr+sz).  U.B. if cstr+sz overflows.
+   A zero byte is interpreted as the null terminator of the string.
+
+   For example, fd_utf8_check_cstr( "😃\x00ABC", 64UL ) returns 5UL.
+   Hex view:
+
+     F0 9F 98 83 00 41 42 43 00
+     ▲  ▲  ▲  ▲  ▲
+     │  │  │  │  └─────────────── Null terminator
+     │  └──┴──┴────────────────── Continuation char
+     └─────────────────────────── Control char
+
+   Returns the byte size of the cstr on success, such that the null
+   terminator is at `cstr[ fd_utf8_check_cstr( cstr, sz )-1UL ]`.
+
+   On failure, returns an undefined negative value.
+   TODO: Consider encoding the position at which verification failed
+         in the return value.
+
+   The validation rules are:
+
+     1. Each code point must be one to four bytes long.
+     1.1. 1-byte code points must be in [U+0001,U+0080) (US-ASCII)
+          The zero byte is not considered a code point.
+     1.2. 2-byte code points must be in [U+0080,U+0800)
+     1.3. 3-byte code points must be in [U+0800,U+10000)
+           excluding UTF-16 surrogates [U+D800,U+D900)
+     1.4. 4-byte code points must be in [U+10000,U+110000)
+
+     2. cstr is terminated by the first zero byte.
+        If there is no zero byte in [cstr,cstr+sz) then fail.
+        Note: This means that sz==0UL always fails.
+
+     3. Each encoded code point starts with a control char and is
+        followed by zero or more continuation chars.  The number of
+        continuation chars is indicated by the control char;  Out-of-
+        place continuation chars are treated as an error.
+
+   This matches the validation criteria of Rust's std::str::from_utf8
+   https://doc.rust-lang.org/std/str/fn.from_utf8.html */
+
+FD_FN_PURE long
+fd_utf8_check_cstr( char const * cstr,
+                    ulong        sz );
+
+#endif /* HEADER_fd_src_ballet_utf8_fd_utf8_h */

--- a/src/ballet/utf8/fuzz_utf8_check_cstr.c
+++ b/src/ballet/utf8/fuzz_utf8_check_cstr.c
@@ -1,0 +1,29 @@
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <stdlib.h>
+
+#include "fd_utf8.h"
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  /* Set up shell without signal handlers */
+  putenv( "FD_LOG_BACKTRACE=0" );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+
+  /* Disable parsing error logging */
+  fd_log_level_stderr_set(4);
+  return 0;
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         size ) {
+  long x = fd_utf8_check_cstr( (char const *)data, size );
+  __asm__ __volatile__( "" :: "r" (x) : );
+  return 0;
+}
+

--- a/src/ballet/utf8/test_utf8.c
+++ b/src/ballet/utf8/test_utf8.c
@@ -1,0 +1,58 @@
+#include "fd_utf8.h"
+
+struct fd_utf8_test_vector {
+  char const * input;
+  ulong        sz;
+  long         result;
+};
+
+typedef struct fd_utf8_test_vector fd_utf8_test_vector_t;
+
+/* Test vectors imported from
+   https://github.com/rust-lang/rust/blob/master/library/alloc/tests/str.rs */
+
+static fd_utf8_test_vector_t const _single_glyph_vec[] = {
+  { NULL,               0UL, -1L },
+  { "\xc0\x80",         3UL, -1L },
+  { "\xc0\xae",         3UL, -1L },
+  { "\xe0\x80\x80",     4UL, -1L },
+  { "\xe0\x80\xaf",     4UL, -1L },
+  { "\xe0\x81\x81",     4UL, -1L },
+  { "\xf0\x82\x82\xac", 5UL, -1L },
+  { "\xf4\x90\x80\x80", 5UL, -1L },
+  { "\xED\xA0\x80",     4UL, -1L },
+  { "\xED\xBF\xBF",     4UL, -1L },
+  { "\xC2\x80",         3UL,  2L },
+  { "\xDF\xBF",         3UL,  2L },
+  { "\xE0\xA0\x80",     4UL,  3L },
+  { "\xED\x9F\xBF",     4UL,  3L },
+  { "\xEE\x80\x80",     4UL,  3L },
+  { "\xEF\xBF\xBF",     4UL,  3L },
+  { "\xF0\x90\x80\x80", 5UL,  4L },
+  { "\xF4\x8F\xBF\xBF", 5UL,  4L },
+  {0}
+};
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  for( fd_utf8_test_vector_t const * vec = _single_glyph_vec; vec->input; vec++ ) {
+    for( ulong sz=1UL; sz < vec->sz; sz++ ) {
+      /* Smaller size */
+      FD_TEST( fd_utf8_check_cstr( vec->input, sz ) == -1 );
+      /* Insert null byte */
+      char input[ 8 ];
+      fd_memcpy( input, vec->input, vec->sz );
+      input[ sz-1UL ] = '\0';
+      FD_TEST( fd_utf8_check_cstr( input, vec->sz ) == -1 );
+    }
+    FD_TEST( fd_utf8_check_cstr( vec->input, vec->sz ) == vec->result );
+  }
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}
+


### PR DESCRIPTION
- utf8: add fd_utf8_check_cstr
- sbpf: loader refactor and improvements
  - add UTF-8 validation
  - move rodata segment into separate memory region
    and remove zero-copy / masking logic
  - fix various diff fuzz findings
