### PR TITLE
vm: add log collector for vm

### DIFF
--- a/src/vm/Local.mk
+++ b/src/vm/Local.mk
@@ -1,0 +1,3 @@
+$(call make-lib,fd_vm)
+$(call add-hdrs,fd_vm_log_collector.h)
+$(call add-objs,fd_vm_log_collector,fd_vm)

--- a/src/vm/fd_vm_log_collector.c
+++ b/src/vm/fd_vm_log_collector.c
@@ -1,0 +1,23 @@
+#include "fd_vm_log_collector.h"
+
+fd_vm_log_collector_t * 
+fd_vm_log_collector_init( fd_vm_log_collector_t * log_collector ) {
+  log_collector->buf_used = 0;
+  return log_collector;
+}
+
+void
+fd_vm_log_collector_log( fd_vm_log_collector_t *  log_collector, 
+                         char *                   msg, 
+                         ulong                    msg_len ) {
+  ulong buf_used = log_collector->buf_used;
+  ulong buf_remaining = FD_VM_LOG_COLLECTOR_BYTES_LIMIT - buf_used;
+
+  if( buf_used==FD_VM_LOG_COLLECTOR_BYTES_LIMIT ) {
+    // No more space, message is not copied into collector.
+    return;
+  }
+
+  ulong bytes_to_copy = ( buf_remaining > msg_len ) ? msg_len : buf_remaining;
+  fd_memcpy( &log_collector->buf[ buf_used ], msg, bytes_to_copy );
+}

--- a/src/vm/fd_vm_log_collector.h
+++ b/src/vm/fd_vm_log_collector.h
@@ -1,0 +1,34 @@
+#ifndef HEADER_fd_src_vm_fd_vm_log_collector_h
+#define HEADER_fd_src_vm_fd_vm_log_collector_h
+
+#include "../util/fd_util.h"
+
+#define FD_VM_LOG_COLLECTOR_BYTES_LIMIT (10000UL)
+
+/* The fd_vm_log_collector_t is used within the vm for logging of text/bytes from within programs. 
+ * The logger can collect up to FD_VM_LOG_COLLECTOR_BYTES_LIMIT bytes of log data, beyond which the
+ * log is truncated.
+ */
+struct fd_vm_log_collector {
+  uchar buf[ FD_VM_LOG_COLLECTOR_BYTES_LIMIT ];
+  ulong buf_used;
+};
+typedef struct fd_vm_log_collector fd_vm_log_collector_t;
+
+FD_PROTOTYPES_BEGIN
+
+/* Initializes a log collector */
+fd_vm_log_collector_t * 
+fd_vm_log_collector_init( fd_vm_log_collector_t * log_collector );
+
+/* Appends a log message of some length to the log collector, truncating if the logger is already
+ * full.
+ */
+void
+fd_vm_log_collector_log( fd_vm_log_collector_t *  log_collector, 
+                         char *                   msg, 
+                         ulong                    msg_len );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_vm_fd_vm_log_collector_h */


### PR DESCRIPTION
Adds a minimal version of the log collector which is used within the VM. It will be tested and covered by syscall tests. 