### PR TITLE
uchar SIMD implementation polishing

### DIFF
--- a/src/util/simd/fd_avx_wb.h
+++ b/src/util/simd/fd_avx_wb.h
@@ -5,7 +5,7 @@
 /* Vector byte API *****************************************************/
 
 /* A wb_t is a vector where each 8-bit wide lane holds an unsigned 8-bit
-   uchareger (a "uchar").
+   integer (a "uchar").
 
    These mirror the other APIs as much as possible.  Macros are
    preferred over static inlines when it is possible to do it robustly
@@ -15,31 +15,26 @@
 
 /* Constructors */
 
+/* TODO: update older SIMD modules to follow the more general convention
+   below. */
+
 /* Given the uchar values, return ... */
 
-#define wb(b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10,b11,b12,b13,b14,b15,\
-           b16,b17,b18,b19,b20,b21,b22,b23,b24,b25,b26,b27,b28,b29,b30,b31) /* [ b0 b1 b2 b3 b4 ... b31 ] */ \
+#define wb(b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10,b11,b12,b13,b14,b15,                                                 \
+           b16,b17,b18,b19,b20,b21,b22,b23,b24,b25,b26,b27,b28,b29,b30,b31) /* [ b0 b1 ... b31 ] */                         \
   _mm256_setr_epi8( (char)( b0), (char)( b1), (char)( b2), (char)( b3), (char)( b4), (char)( b5), (char)( b6), (char)( b7), \
                     (char)( b8), (char)( b9), (char)(b10), (char)(b11), (char)(b12), (char)(b13), (char)(b14), (char)(b15), \
                     (char)(b16), (char)(b17), (char)(b18), (char)(b19), (char)(b20), (char)(b21), (char)(b22), (char)(b23), \
                     (char)(b24), (char)(b25), (char)(b26), (char)(b27), (char)(b28), (char)(b29), (char)(b30), (char)(b31) )
 
-#define wb_bcast(b0) _mm256_set1_epi8( (char)(b0) ) /* [ b0 b0 b0 b0 ... b0 ] */
+#define wb_bcast(b0) _mm256_set1_epi8( (char)(b0) ) /* [ b0 b0 ... b0 ] */
 
-static inline wb_t /* [ b0 b1 b0 b1 b0 b1 ... b0 b1 ] */
+static inline wb_t /* [ b0 b1 b0 b1 ... b0 b1 ] */
 wb_bcast_pair( uchar b0, uchar b1 ) {
   return _mm256_setr_epi8( (char)(b0), (char)(b1), (char)(b0), (char)(b1), (char)(b0), (char)(b1), (char)(b0), (char)(b1),
                            (char)(b0), (char)(b1), (char)(b0), (char)(b1), (char)(b0), (char)(b1), (char)(b0), (char)(b1),
                            (char)(b0), (char)(b1), (char)(b0), (char)(b1), (char)(b0), (char)(b1), (char)(b0), (char)(b1),
                            (char)(b0), (char)(b1), (char)(b0), (char)(b1), (char)(b0), (char)(b1), (char)(b0), (char)(b1) );
-}
-
-static inline wb_t /* [ b0 b0 b0 ... b0 b1 b1 b1 ... b1 ] */
-wb_bcast_lohi( uchar b0, uchar b1 ) {
-  return _mm256_setr_epi8( (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0),
-                           (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0),
-                           (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1),
-                           (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1) );
 }
 
 static inline wb_t /* [ b0 b1 b2 b3 b0 b1 b2 b3 ... b0 b1 b2 b3 ] */
@@ -50,8 +45,49 @@ wb_bcast_quad( uchar b0, uchar b1, uchar b2, uchar b3 ) {
                            (char)(b0), (char)(b1), (char)(b2), (char)(b3), (char)(b0), (char)(b1), (char)(b2), (char)(b3) );
 }
 
-static inline wb_t /* [ b0 b0 b1 b1 b2 b2 b3 b3 ] */
-wb_bcast_wide( uchar b0, uchar b1, uchar  b2, uchar  b3, uchar  b4, uchar  b5, uchar  b6, uchar b7,
+static inline wb_t /* [ b0 b1 ... b7 b0 b1 ... b7 b0 b1 ... b7 b0 b1 ... b7 ] */
+wb_bcast_oct( uchar b0, uchar b1, uchar b2, uchar b3, uchar b4, uchar b5, uchar b6, uchar b7 ) {
+  return _mm256_setr_epi8( (char)(b0), (char)(b1), (char)(b2), (char)(b3), (char)(b4), (char)(b5), (char)(b6), (char)(b7),
+                           (char)(b0), (char)(b1), (char)(b2), (char)(b3), (char)(b4), (char)(b5), (char)(b6), (char)(b7),
+                           (char)(b0), (char)(b1), (char)(b2), (char)(b3), (char)(b4), (char)(b5), (char)(b6), (char)(b7),
+                           (char)(b0), (char)(b1), (char)(b2), (char)(b3), (char)(b4), (char)(b5), (char)(b6), (char)(b7) );
+}
+
+static inline wb_t /* [ b0 b1 ... b15 b0 b1 ... b15 ] */
+wb_bcast_hex( uchar b0, uchar b1, uchar b2,  uchar b3,  uchar b4,  uchar b5,  uchar b6,  uchar b7,
+              uchar b8, uchar b9, uchar b10, uchar b11, uchar b12, uchar b13, uchar b14, uchar b15 ) {
+  return _mm256_setr_epi8( (char)(b0), (char)(b1), (char)(b2),  (char)(b3),  (char)(b4),  (char)(b5),  (char)(b6),  (char)(b7),
+                           (char)(b8), (char)(b9), (char)(b10), (char)(b11), (char)(b12), (char)(b13), (char)(b14), (char)(b15),
+                           (char)(b0), (char)(b1), (char)(b2),  (char)(b3),  (char)(b4),  (char)(b5),  (char)(b6),  (char)(b7),
+                           (char)(b8), (char)(b9), (char)(b10), (char)(b11), (char)(b12), (char)(b13), (char)(b14), (char)(b15) );
+}
+
+static inline wb_t /* [ b0 b0 ... b0 b1 b1 ... b1 ] */
+wb_expand_pair( uchar b0, uchar b1 ) {
+  return _mm256_setr_epi8( (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0),
+                           (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0),
+                           (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1),
+                           (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1) );
+}
+
+static inline wb_t /* [ b0 b0 ... b0 b1 b1 ... b1 b2 b2 ... b2 b3 b3 ... b3 ] */
+wb_expand_quad( uchar b0, uchar b1, uchar b2, uchar b3 ) {
+  return _mm256_setr_epi8( (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0),
+                           (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1),
+                           (char)(b2), (char)(b2), (char)(b2), (char)(b2), (char)(b2), (char)(b2), (char)(b2), (char)(b2),
+                           (char)(b3), (char)(b3), (char)(b3), (char)(b3), (char)(b3), (char)(b3), (char)(b3), (char)(b3) );
+}
+
+static inline wb_t /* [ b0 b0 b0 b0 b1 b1 b1 b1 ... b7 b7 b7 b7 ] */
+wb_expand_oct( uchar b0, uchar b1, uchar b2, uchar b3, uchar b4, uchar b5, uchar b6, uchar b7 ) {
+  return _mm256_setr_epi8( (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b1), (char)(b1), (char)(b1), (char)(b1),
+                           (char)(b2), (char)(b2), (char)(b2), (char)(b2), (char)(b3), (char)(b3), (char)(b3), (char)(b3),
+                           (char)(b4), (char)(b4), (char)(b4), (char)(b4), (char)(b5), (char)(b5), (char)(b5), (char)(b5),
+                           (char)(b6), (char)(b6), (char)(b6), (char)(b6), (char)(b7), (char)(b7), (char)(b7), (char)(b7) );
+}
+
+static inline wb_t /* [ b0 b0 b1 b1 ... b15 b15 ] */
+wb_expand_hex( uchar b0, uchar b1, uchar  b2, uchar  b3, uchar  b4, uchar  b5, uchar  b6, uchar b7,
                uchar b8, uchar b9, uchar b10, uchar b11, uchar b12, uchar b13, uchar b14, uchar b15 ) {
   return _mm256_setr_epi8( (char)( b0), (char)( b0), (char)( b1), (char)( b1), (char)( b2), (char)( b2), (char)( b3), (char)( b3),
                            (char)( b4), (char)( b4), (char)( b5), (char)( b5), (char)( b6), (char)( b6), (char)( b7), (char)( b7),
@@ -60,30 +96,41 @@ wb_bcast_wide( uchar b0, uchar b1, uchar  b2, uchar  b3, uchar  b4, uchar  b5, u
 }
 
 /* No general wb_permute due to cross-128-bit lane limitations in AVX.
-   Useful cases are provided below.  Given [ b0 b1 b2 b3 b4 ... b31 ],
-   return ... */
+   Useful cases are provided below.  Given [ b0 b1 ... b31 ], return ...  */
 
-#define wb_bcast_even(x)      /* [ b0 b0 b2 b2 b4 b4 .. b28 b28 b30 b30 ] */ \
-  _mm256_shuffle_epi8( (x), wb_bcast_wide( 0, 2, 4, 6, 8, 10, 12, 14, 0, 2, 4, 6, 8, 10, 12, 14 ) )
-
-#define wb_bcast_odd(x)       /* [ b1 b1 b3 b3 b5 b5 .. b29 b29 b31 b31 ] */ \
-  _mm256_shuffle_epi8( (x), wb_bcast_wide( 1, 3, 5, 7, 9, 11, 13, 15, 1, 3, 5, 7, 9, 11, 13, 15 ) )
-
-#define wb_exch_adj(x)        /* [ b1 b0 b3 b2 ... b31 b30 ] */ \
+#define wb_exch_adj(x)      /* [ b1 b0 b3 b2 ... b31 b30 ] */ \
   _mm256_shuffle_epi8( (x), wb( 1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14, \
                                 1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14 ) )
 
-#define wb_exch_adj_pair(x)   /* [ b2 b3 b0 b1 .. b30 b31 b28 b29 ] */ \
+#define wb_exch_adj_pair(x) /* [ b2 b3 b0 b1 .. b30 b31 b28 b29 ] */ \
   _mm256_shuffle_epi8( (x), wb( 2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13, \
                                 2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13 ) )
 
-#define wb_exch_adj_quad(x)   /* [ b4 b5 b6 b7 b0 b1 b2 b3 .. b28 b29 b30 b31 ] */ \
+#define wb_exch_adj_quad(x) /* [ b4 b5 b6 b7 b0 b1 b2 b3 .. b28 b29 b30 b31 ] */      \
   _mm256_shuffle_epi8( (x), wb( 4, 5, 6, 7, 0, 1, 2, 3, 12, 13, 14, 15, 8, 9, 10, 11, \
                                 4, 5, 6, 7, 0, 1, 2, 3, 12, 13, 14, 15, 8, 9, 10, 11 ) )
+
+#define wb_exch_adj_oct(x)  /* [ b8 b9 ... b15 b0 b1 ... b7 b24 b25 ... b31 b16 b17 ... b23 ] */ \
+  _mm256_shuffle_epi8( (x), wb( 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7,            \
+                                8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7 ) )
+
+static inline wb_t          /* [ b16 b17 ... b31 b0 b1 ... b15 ] */
+wb_exch_adj_hex( wb_t x ) {
+  return _mm256_permute2f128_si256( x, x, 1 );
+}
+
+#define wb_bcast_even(x)    /* [ b0 b0 b2 b2 ... b30 b30 ] */                            \
+  _mm256_shuffle_epi8( (x), wb( 0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14,    \
+                                0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14 ) )
+
+#define wb_bcast_odd(x)     /* [ b1 b1 b3 b3 ... b31 b31 ] */                            \
+  _mm256_shuffle_epi8( (x), wb( 1, 1, 3, 3, 5, 5, 7, 7, 9, 9, 11, 11, 13, 13, 15, 15,    \
+                                1, 1, 3, 3, 5, 5, 7, 7, 9, 9, 11, 11, 13, 13, 15, 15 ) )
+
 /* Predefined constants */
 
-#define wb_zero() _mm256_setzero_si256() /* Return [ 0 0 0 0 0 ... 0 0 ] */
-#define wb_one()  _mm256_set1_epi8( 1 )  /* Return [ 1 1 1 1 1 ... 1 1 ] */
+#define wb_zero() _mm256_setzero_si256() /* Return [ 0 0 ... 0 ] */
+#define wb_one()  _mm256_set1_epi8( 1 )  /* Return [ 1 1 ... 1 ] */
 
 /* Memory operations */
 
@@ -91,28 +138,27 @@ wb_bcast_wide( uchar b0, uchar b1, uchar  b2, uchar  b3, uchar  b4, uchar  b5, u
    location p as a vector uchar.  wb_ldu is the same but p does not have
    to be aligned.  wb_st writes the vector uchar to the 32-byte aligned /
    32-byte sized location p as 32 uchars.  wb_stu is the same but p does not
-   have to be aligned.  In all these lane l will be at p[l].
+   have to be aligned.  In all these lane l will be at p[l].  FIXME: USE
+   ATTRIBUTES ON P PASSED TO THESE?
 
    Note: gcc knows a __m256i may alias. */
-
-/* FIXME: USE ATTRIBUTES ON P PASSED TO THESE? */
 
 static inline wb_t wb_ld(  uchar const * p   ) { return _mm256_load_si256(  (__m256i const *)p ); }
 static inline wb_t wb_ldu( uchar const * p   ) { return _mm256_loadu_si256( (__m256i const *)p ); }
 static inline void wb_st(  uchar * p, wb_t i ) { _mm256_store_si256(  (__m256i *)p, i ); }
 static inline void wb_stu( uchar * p, wb_t i ) { _mm256_storeu_si256( (__m256i *)p, i ); }
 
-/* Sadly, no maskload_epi8, so we can't provide a wb_ldif or wb_stif */
-
+/* Sadly, no maskload_epi8, so we can't provide a wb_ldif or wb_stif.
+   TODO: consider emulating this? */
 
 /* Element operations */
 
-/* wb_extract extracts the uchar in lane imm from the vector uchar as an uchar.
+/* wb_extract extracts the uchar in lane imm from the vector uchar.
    wb_insert returns the vector uchar formed by replacing the value in
-   lane imm of a wbth the provided uchar.  imm should be a compile time
-   constant in 0:7.  wb_extract_variable and wb_insert_variable are the
-   slower but the lane n does not have to be known at compile time
-   (should still be in 0:7).
+   lane imm of a wb_t with the provided uchar.  imm should be a compile
+   time constant in 0:31.  wb_extract_variable and wb_insert_variable
+   are the slower but the lane n does not have to be known at compile
+   time (should still be in 0:31).
 
    Note: C99 TC3 allows type punning through a union. */
 
@@ -134,57 +180,61 @@ wb_insert_variable( wb_t a, int n, uchar v ) {
   return _mm256_load_si256( t->m );
 }
 
-/* Given [a0 a1 a2 a3 a4 ... a30 a31] and/or [b0 b1 b2 b3 b4 ... b30 b31],
-   return ... */
+/* Given [a0 a1 ... a31] and/or [b0 b1 ... b31], return ... */
 
 /* Arithmetic operations */
 
 #define wb_neg(a) _mm256_sub_epi8( _mm256_setzero_si256(), (a) ) /* [ -a0  -a1  ... -a31  ] (twos complement handling) */
 #define wb_abs(a) (a)                                            /* [ |a0| |a1| ... |a31| ] (unsigned type, so identity) */
 
-#define wb_min(a,b) _mm256_min_epu8(   (a), (b) ) /* [ min(a0,b0) min(a1,b1) ... min(a31,b31) ] */
-#define wb_max(a,b) _mm256_max_epu8(   (a), (b) ) /* [ max(a0,b0) max(a1,b1) ... max(a31,b31) ] */
-#define wb_add(a,b) _mm256_add_epi8(   (a), (b) ) /* [ a0 +b0     a1 +b1     ... a31 +b31     ] */
-#define wb_sub(a,b) _mm256_sub_epi8(   (a), (b) ) /* [ a0 -b0     a1 -b1     ... a31 -b31     ] */
+#define wb_min(a,b) _mm256_min_epu8( (a), (b) ) /* [ min(a0,b0) min(a1,b1) ... min(a31,b31) ] */
+#define wb_max(a,b) _mm256_max_epu8( (a), (b) ) /* [ max(a0,b0) max(a1,b1) ... max(a31,b31) ] */
+#define wb_add(a,b) _mm256_add_epi8( (a), (b) ) /* [ a0 +b0     a1 +b1     ... a31 +b31     ] */
+#define wb_sub(a,b) _mm256_sub_epi8( (a), (b) ) /* [ a0 -b0     a1 -b1     ... a31 -b31     ] */
+
 /* No wb_mul because there's no instruction for multiplying uchars.  You
    can build one with two invocations to _mm_mullo_epi16, but it won't
    be particularly fast.  Multiplication by add and shift might be
-   faster honestly. */
+   faster honestly.  TODO: consider emulating for completeness? */
 
-/* Binary operations */
+/* Bit operations */
 
-/* Note: wb_shl/wb_shr/wb_shru is a left/signed right/unsigned right
-   shift by imm bits; imm must be a compile time constant in 0:63.  The
-   variable variants are slower but do not require the shift amount to
-   be known at compile time (should still be in 0:63). */
+/* Note: wb_shl/wb_shr is an unsigned left/right shift by imm bits; imm
+   must be a compile time constant in 0:7.  The variable variants are
+   slower but do not require the shift amount to be known at compile
+   time (should still be in 0:7).
+
+   vector shift amount variants are omitted for the time being as these
+   are rarely needed and there seems to be little support for it.
+   Probably could be done via two 16-wide vector shifts for the even/odd
+   lanes and some masking tricks. */
 
 #define wb_not(a) _mm256_xor_si256( _mm256_set1_epi32( -1 ), (a) ) /* [ ~a0 ~a1 ... ~a31 ] */
 
+#define wb_shl(a,imm) wb_and( _mm256_slli_epi16( (a), (imm) ), wb_bcast( (uchar)(0xFFUL << (imm)) ) ) /* [ a0<<imm a1<<imm ... a31<<imm ] */
+#define wb_shr(a,imm) wb_and( _mm256_srli_epi16( (a), (imm) ), wb_bcast( (uchar)(0xFFUL >> (imm)) ) ) /* [ a0>>imm a1>>imm ... a31>>imm ] */
 
-#define wb_shl(a,imm)  wb_and( _mm256_slli_epi16( (a), (imm) ), wb_bcast( (uchar)(0xFFUL << (imm)) ) ) /* [ a0<<imm a1<<imm ... a31<<imm ] */
-/* It's not easy to implement the full set of shifts given the
-   intrinsics. Could convert to 16b, do the shift, and convert back, but
-   that's terrible. */
-#define wb_shru(a,imm) wb_and( _mm256_srli_epi16( (a), (imm) ), wb_bcast( (uchar)(0xFFUL >> (imm)) ) ) /* [ a0>>imm a1>>imm ... a31>>imm ] (treat a as unsigned) */
-
-#define wb_shl_variable(a,n)  wb_and( _mm256_sll_epi16( (a), _mm_insert_epi64( _mm_setzero_si128(), (n), 0 ) ), \
-                                      wb_bcast( (uchar)(0xFFUL << (n)) ) )
-#define wb_shru_variable(a,n) wb_and( _mm256_srl_epi16( (a), _mm_insert_epi64( _mm_setzero_si128(), (n), 0 ) ), \
-                                      wb_bcast( (uchar)(0xFFUL >> (n)) ) )
+#define wb_shl_variable(a,n) wb_and( _mm256_sll_epi16( (a), _mm_insert_epi64( _mm_setzero_si128(), (n), 0 ) ), \
+                                     wb_bcast( (uchar)(0xFFUL << (n)) ) )
+#define wb_shr_variable(a,n) wb_and( _mm256_srl_epi16( (a), _mm_insert_epi64( _mm_setzero_si128(), (n), 0 ) ), \
+                                     wb_bcast( (uchar)(0xFFUL >> (n)) ) )
 
 #define wb_and(a,b)    _mm256_and_si256(    (a), (b) ) /* [   a0 &b0    a1& b1 ...   a31& b31 ] */
 #define wb_andnot(a,b) _mm256_andnot_si256( (a), (b) ) /* [ (~a0)&b0  (~a1)&b1 ... (~a31)&b31 ] */
 #define wb_or(a,b)     _mm256_or_si256(     (a), (b) ) /* [   a0 |b0    a1 |b1 ...   a31 |b31 ] */
 #define wb_xor(a,b)    _mm256_xor_si256(    (a), (b) ) /* [   a0 ^b0    a1 ^b1 ...   a31 ^b31 ] */
 
+static inline wb_t wb_rol( wb_t a, int imm ) { return wb_or( wb_shl( a, imm & 7 ), wb_shr( a, (-imm) & 7 ) ); }
+static inline wb_t wb_ror( wb_t a, int imm ) { return wb_or( wb_shr( a, imm & 7 ), wb_shl( a, (-imm) & 7 ) ); }
+
+static inline wb_t wb_rol_variable( wb_t a, int n ) { return wb_or( wb_shl_variable( a, n&7 ), wb_shr_variable( a, (-n)&7 ) ); }
+static inline wb_t wb_ror_variable( wb_t a, int n ) { return wb_or( wb_shr_variable( a, n&7 ), wb_shl_variable( a, (-n)&7 ) ); }
+
 /* Logical operations */
 
 #define wb_lnot(a)    _mm256_cmpeq_epi8( (a), _mm256_setzero_si256() ) /* [  !a0  !a1 ...  !a31 ] */
 #define wb_lnotnot(a)                                                  /* [ !!a0 !!a1 ... !!a31 ] */ \
   _mm256_xor_si256( _mm256_set1_epi32( -1 ), wb_lnot( (a) ) )
-
-/* NOTE: These don't return proper wc_t values, but they are usable for
- * wb_czero, wb_notczero, wb_if, wb_any_fast, and wb_all_fast. */
 
 #define wb_eq(a,b) _mm256_cmpeq_epi8( (a), (b) )                                              /* [ a0==b0 a1==b1 ... a31==b31 ] */
 #define wb_gt(a,b)                                                                            /* [ a0> b0 a1> b1 ... a31> b31 ] */\
@@ -206,71 +256,87 @@ wb_insert_variable( wb_t a, int n, uchar v ) {
 
 /* Summarizing:
 
-   wb_to_wc(a, 0)   returns [ !!a0  !!a1  ... !!a7 ]
+   wb_to_wc(a, 0)   returns [ !!a0  !!a1  ... !!a7  ]
    wb_to_wc(a, 1)   returns [ !!a8  !!a9  ... !!a15 ]
    wb_to_wc(a, 2)   returns [ !!a16 !!a17 ... !!a23 ]
    wb_to_wc(a, 3)   returns [ !!a24 !!a25 ... !!a31 ]
+   // TODO: wc varints for 8, 16, and 64 wide SIMD conditionals
 
-   wb_to_wf(a, 0)   returns [ (float)a0  (float)a1  ... (float)a7 ]
+   wb_to_wf(a, 0)   returns [ (float)a0  (float)a1  ... (float)a7  ]
    wb_to_wf(a, 1)   returns [ (float)a8  (float)a9  ... (float)a15 ]
    wb_to_wf(a, 2)   returns [ (float)a16 (float)a17 ... (float)a23 ]
    wb_to_wf(a, 3)   returns [ (float)a24 (float)a25 ... (float)a31 ]
 
-   wb_to_wi(a, 0)   returns [ (int)a0  (int)a1  ... (int)a7 ]
+   wb_to_wi(a, 0)   returns [ (int)a0  (int)a1  ... (int)a7  ]
    wb_to_wi(a, 1)   returns [ (int)a8  (int)a9  ... (int)a15 ]
    wb_to_wi(a, 2)   returns [ (int)a16 (int)a17 ... (int)a23 ]
    wb_to_wi(a, 3)   returns [ (int)a24 (int)a25 ... (int)a31 ]
 
-   wb_to_wd(a,0) returns [ (double)a0  (double)a1  (double)a2  (double)a3 ]
-   wb_to_wd(a,1) returns [ (double)a4  (double)a5  (double)a6  (double)a7 ]
+   wb_to_wu(a, 0)   returns [ (uint)a0  (uint)a1  ... (uint)a7  ]
+   wb_to_wu(a, 1)   returns [ (uint)a8  (uint)a9  ... (uint)a15 ]
+   wb_to_wu(a, 2)   returns [ (uint)a16 (uint)a17 ... (uint)a23 ]
+   wb_to_wu(a, 3)   returns [ (uint)a24 (uint)a25 ... (uint)a31 ]
+
+   wb_to_wd(a,0) returns [ (double)a0  (double)a1  (double)a2  (double)a3  ]
+   wb_to_wd(a,1) returns [ (double)a4  (double)a5  (double)a6  (double)a7  ]
    ...
    wb_to_wd(a,7) returns [ (double)a28 (double)a29 (double)a30 (double)a31 ]
 
-   wb_to_wl(a,0) returns [ (long)a0  (long)a1  (long)a2  (long)a3 ]
-   wb_to_wl(a,1) returns [ (long)a4  (long)a5  (long)a6  (long)a7 ]
+   wb_to_wl(a,0) returns [ (long)a0  (long)a1  (long)a2  (long)a3  ]
+   wb_to_wl(a,1) returns [ (long)a4  (long)a5  (long)a6  (long)a7  ]
    ...
    wb_to_wl(a,7) returns [ (long)a28 (long)a29 (long)a30 (long)a31 ]
 
-   where imm_hi should be a compile time constant. */
+   wb_to_wv(a,0) returns [ (ulong)a0  (ulong)a1  (ulong)a2  (ulong)a3  ]
+   wb_to_wv(a,1) returns [ (ulong)a4  (ulong)a5  (ulong)a6  (ulong)a7  ]
+   ...
+   wb_to_wv(a,7) returns [ (ulong)a28 (ulong)a29 (ulong)a30 (ulong)a31 ]
+
+   where the above values should be compile time constants. */
 
 /* wb_expand_internal_{4, 8} selects the right group of {4,8} x 32 bits
    (zero extending it) */
+
 static inline __m256i
-wb_expand_internal_8( wb_t a, int selector ) {
-  switch( selector ) {
-    case 0: return _mm256_cvtepu8_epi32( _mm256_extractf128_si256( a, 0 ) );
-    case 1: return _mm256_cvtepu8_epi32( _mm_bsrli_si128( _mm256_extractf128_si256( a, 0 ), 8 ) );
-    case 2: return _mm256_cvtepu8_epi32( _mm256_extractf128_si256( a, 1 ) );
-    case 3: return _mm256_cvtepu8_epi32( _mm_bsrli_si128( _mm256_extractf128_si256( a, 1 ), 8 ) );
+wb_expand_internal_8( wb_t a, int imm ) {
+  switch( imm ) {
+  case 0: return _mm256_cvtepu8_epi32( _mm256_extractf128_si256( a, 0 ) );
+  case 1: return _mm256_cvtepu8_epi32( _mm_bsrli_si128( _mm256_extractf128_si256( a, 0 ), 8 ) );
+  case 2: return _mm256_cvtepu8_epi32( _mm256_extractf128_si256( a, 1 ) );
+  case 3: return _mm256_cvtepu8_epi32( _mm_bsrli_si128( _mm256_extractf128_si256( a, 1 ), 8 ) );
   }
   return _mm256_setzero_si256(); /* Unreachable */
 }
+
 static inline __m128i
-wb_expand_internal_4( wb_t a, int selector ) {
-  switch( selector ) {
-    case 0: return _mm_cvtepu8_epi32( _mm256_extractf128_si256( a, 0 ) );
-    case 1: return _mm_cvtepu8_epi32( _mm_bsrli_si128( _mm256_extractf128_si256( a, 0 ),  4 ) );
-    case 2: return _mm_cvtepu8_epi32( _mm_bsrli_si128( _mm256_extractf128_si256( a, 0 ),  8 ) );
-    case 3: return _mm_cvtepu8_epi32( _mm_bsrli_si128( _mm256_extractf128_si256( a, 0 ), 12 ) );
-    case 4: return _mm_cvtepu8_epi32( _mm256_extractf128_si256( a, 1 ) );
-    case 5: return _mm_cvtepu8_epi32( _mm_bsrli_si128( _mm256_extractf128_si256( a, 1 ),  4 ) );
-    case 6: return _mm_cvtepu8_epi32( _mm_bsrli_si128( _mm256_extractf128_si256( a, 1 ),  8 ) );
-    case 7: return _mm_cvtepu8_epi32( _mm_bsrli_si128( _mm256_extractf128_si256( a, 1 ), 12 ) );
+wb_expand_internal_4( wb_t a, int imm ) {
+  switch( imm ) {
+  case 0: return _mm_cvtepu8_epi32( _mm256_extractf128_si256( a, 0 ) );
+  case 1: return _mm_cvtepu8_epi32( _mm_bsrli_si128( _mm256_extractf128_si256( a, 0 ),  4 ) );
+  case 2: return _mm_cvtepu8_epi32( _mm_bsrli_si128( _mm256_extractf128_si256( a, 0 ),  8 ) );
+  case 3: return _mm_cvtepu8_epi32( _mm_bsrli_si128( _mm256_extractf128_si256( a, 0 ), 12 ) );
+  case 4: return _mm_cvtepu8_epi32( _mm256_extractf128_si256( a, 1 ) );
+  case 5: return _mm_cvtepu8_epi32( _mm_bsrli_si128( _mm256_extractf128_si256( a, 1 ),  4 ) );
+  case 6: return _mm_cvtepu8_epi32( _mm_bsrli_si128( _mm256_extractf128_si256( a, 1 ),  8 ) );
+  case 7: return _mm_cvtepu8_epi32( _mm_bsrli_si128( _mm256_extractf128_si256( a, 1 ), 12 ) );
   }
   return _mm_setzero_si128(); /* Unreachable */
 }
 
-
-#define wb_to_wc(a, imm_hi)        _mm256_xor_si256( _mm256_set1_epi32( -1 ), _mm256_cmpeq_epi32( wb_expand_internal_8( a, imm_hi ) , _mm256_setzero_si256() ) )
-#define wb_to_wi(a, imm_hi)        wb_expand_internal_8( a, imm_hi )
-#define wb_to_wf(a, imm_hi)        _mm256_cvtepi32_ps( wb_expand_internal_8( a, imm_hi ) )
-#define wb_to_wd(a, imm_hi)        _mm256_cvtepi32_pd( wb_expand_internal_4( a, imm_hi ) )
-#define wb_to_wl(a, imm_hi)        _mm256_cvtepu32_epi64( wb_expand_internal_4( a, imm_hi ) ) /* This could be slightly faster with _mm256_cvtepu8_epi64 */
-#define wb_to_wv(a, imm_hi)        _mm256_cvtepu32_epi64( wb_expand_internal_4( a, imm_hi ) ) /* This could be slightly faster with _mm256_cvtepu8_epi64 */
+#define wb_to_wc( a, imm ) _mm256_xor_si256( _mm256_set1_epi32( -1 ), _mm256_cmpeq_epi32( wb_expand_internal_8( (a), (imm) ), _mm256_setzero_si256() ) )
+#define wb_to_wf( a, imm ) _mm256_cvtepi32_ps( wb_expand_internal_8( (a), (imm) ) )
+#define wb_to_wi( a, imm ) wb_expand_internal_8( (a), (imm) )
+#define wb_to_wu( a, imm ) wb_expand_internal_8( (a), (imm) )
+#define wb_to_wd( a, imm ) _mm256_cvtepi32_pd   ( wb_expand_internal_4( (a), (imm) ) )
+#define wb_to_wl( a, imm ) _mm256_cvtepu32_epi64( wb_expand_internal_4( (a), (imm) ) ) /* This could be slightly faster with _mm256_cvtepu8_epi64 */
+#define wb_to_wv( a, imm ) _mm256_cvtepu32_epi64( wb_expand_internal_4( (a), (imm) ) ) /* This could be slightly faster with _mm256_cvtepu8_epi64 */
 
 #define wb_to_wc_raw(a) (a)
 #define wb_to_wf_raw(a) _mm256_castsi256_ps( (a) )
+#define wb_to_wi_raw(a) (a)
+#define wb_to_wu_raw(a) (a)
 #define wb_to_wd_raw(a) _mm256_castsi256_pd( (a) )
+#define wb_to_wv_raw(a) (a)
 #define wb_to_wl_raw(a) (a)
 
 /* Reduction operations */
@@ -308,9 +374,13 @@ wb_max_all( wb_t x ) { /* Returns wb_bcast( max( x ) ) */
 
 /* Misc operations */
 
+/* TODO: These probably are actually part of the wc post generalization
+   to different width SIMD types. */
+
 /* wb_{any, all} return 1 if any/all of the elements are non-zero.  The
    _fast variants are suitable for use with the return value of any of
    the wb comparison functions (e.g. wb_gt ). */
+
 #define wb_any_fast( x ) ( 0 != _mm256_movemask_epi8( x ) )
 #define wb_any( x ) wb_any_fast( wb_ne( (x), wb_zero( ) ) )
 #define wb_all_fast( x ) ( -1 == _mm256_movemask_epi8( x ) )

--- a/src/util/simd/fd_avx_wc.h
+++ b/src/util/simd/fd_avx_wc.h
@@ -2,6 +2,10 @@
 #error "Do not include this directly; use fd_avx.h"
 #endif
 
+/* TODO: the below is much very designed for a 32-bit SIMD lane world
+   (with 64-bit SIMD lane support hacked on afterward).  Revamp these to
+   be more general for 8, 16, 32 and 64 bit lanes. */
+
 /* Vector conditional API *********************************************/
 
 /* A wc_t is a vector conditional.  This is, it is a vector of integers

--- a/src/util/simd/fd_avx_wu.h
+++ b/src/util/simd/fd_avx_wu.h
@@ -100,7 +100,7 @@ static inline void wu_stu( uint * p, wu_t i ) { _mm256_storeu_si256( (__m256i *)
 
 /* Element operations */
 
-/* wu_extract extracts the uint in lane imm from the vector uint as an uint.
+/* wu_extract extracts the uint in lane imm from the vector uint.
    wu_insert returns the vector uint formed by replacing the value in
    lane imm of a with the provided uint.  imm should be a compile time
    constant in 0:7.  wu_extract_variable and wu_insert_variable are the
@@ -143,10 +143,10 @@ wu_insert_variable( wu_t a, int n, uint v ) {
 
 /* Binary operations */
 
-/* Note: wu_shl/wu_shr/wu_shru is a left/signed right/unsigned right
-   shift by imm bits; imm must be a compile time constant in 0:63.  The
-   variable variants are slower but do not require the shift amount to
-   be known at compile time (should still be in 0:63). */
+/* Note: wu_shl/wu_shr is an unsigned left/right shift by imm bits; imm
+   must be a compile time constant in 0:63.  The variable variants are
+   slower but do not require the shift amount to be known at compile
+   time (should still be in 0:63). */
 
 #define wu_not(a) _mm256_xor_si256( _mm256_set1_epi32( -1 ), (a) ) /* [ ~a0 ~a1 ... ~a7 ] */
 

--- a/src/util/simd/fd_sse_vb.h
+++ b/src/util/simd/fd_sse_vb.h
@@ -5,7 +5,7 @@
 /* Vector byte API *****************************************************/
 
 /* A vb_t is a vector where each 8-bit wide lane holds an unsigned 8-bit
-   unsigned char (a "uchar").
+   integer (a "uchar").
 
    These mirror the other APIs as much as possible.  Macros are
    preferred over static inlines when it is possible to do it robustly
@@ -17,22 +17,16 @@
 
 /* Given the uchar values, return ... */
 
-#define vb(b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10,b11,b12,b13,b14,b15 ) /* [ b0 b1 b2 b3 b4 ... b15 ] */ \
+#define vb(b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10,b11,b12,b13,b14,b15 ) /* [ b0 b1 ... b15 ] */                     \
   _mm_setr_epi8( (char)( b0), (char)( b1), (char)( b2), (char)( b3), (char)( b4), (char)( b5), (char)( b6), (char)( b7), \
                  (char)( b8), (char)( b9), (char)(b10), (char)(b11), (char)(b12), (char)(b13), (char)(b14), (char)(b15) )
 
-#define vb_bcast(b0) _mm_set1_epi8( (char)(b0) ) /* [ b0 b0 b0 b0 ... b0 ] */
+#define vb_bcast(b0) _mm_set1_epi8( (char)(b0) ) /* [ b0 b0 ... b0 ] */
 
-static inline vb_t /* [ b0 b1 b0 b1 b0 b1 ... b0 b1 ] */
+static inline vb_t /* [ b0 b1 b0 b1 ... b0 b1 ] */
 vb_bcast_pair( uchar b0, uchar b1 ) {
   return _mm_setr_epi8( (char)(b0), (char)(b1), (char)(b0), (char)(b1), (char)(b0), (char)(b1), (char)(b0), (char)(b1),
                         (char)(b0), (char)(b1), (char)(b0), (char)(b1), (char)(b0), (char)(b1), (char)(b0), (char)(b1) );
-}
-
-static inline vb_t /* [ b0 b0 b0 ... b0 b1 b1 b1 ... b1 ] */
-vb_bcast_lohi( uchar b0, uchar b1 ) {
-  return _mm_setr_epi8( (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0),
-                        (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1) );
 }
 
 static inline vb_t /* [ b0 b1 b2 b3 b0 b1 b2 b3 ... b0 b1 b2 b3 ] */
@@ -41,23 +35,35 @@ vb_bcast_quad( uchar b0, uchar b1, uchar b2, uchar b3 ) {
                         (char)(b0), (char)(b1), (char)(b2), (char)(b3), (char)(b0), (char)(b1), (char)(b2), (char)(b3) );
 }
 
-static inline vb_t /* [ b0 b0 b1 b1 b2 b2 b3 b3 ] */
-vb_bcast_wide( uchar b0, uchar b1, uchar  b2, uchar  b3, uchar  b4, uchar  b5, uchar  b6, uchar b7 ) {
-  return _mm_setr_epi8( (char)( b0), (char)( b0), (char)( b1), (char)( b1), (char)( b2), (char)( b2), (char)( b3), (char)( b3),
-                        (char)( b4), (char)( b4), (char)( b5), (char)( b5), (char)( b6), (char)( b6), (char)( b7), (char)( b7) );
+static inline vb_t /* [ b0 b1 ... b7 b0 b1 ... b7 ] */
+vb_bcast_oct( uchar b0, uchar b1, uchar b2, uchar b3, uchar b4, uchar b5, uchar b6, uchar b7 ) {
+  return _mm_setr_epi8( (char)(b0), (char)(b1), (char)(b2), (char)(b3), (char)(b4), (char)(b5), (char)(b6), (char)(b7),
+                        (char)(b0), (char)(b1), (char)(b2), (char)(b3), (char)(b4), (char)(b5), (char)(b6), (char)(b7) );
 }
 
-/* vb_permute returns [ x[i0], x[i1], ... x[i15] ].
-   Other useful cases are provided below.  Given [ b0 b1 b2 b3 b4 ... b15 ],
-   return ... */
-#define vb_permute(x,i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14,i15) \
-  _mm_shuffle_epi8( (x), vb( (i0), (i1), (i2), (i3), (i4), (i5), (i6), (i7), (i8), (i9), (i10), (i11), (i12), (i13), (i14), (i15) ) )
+static inline vb_t /* [ b0 b0 ... b0 b1 b1 ... b1 ] */
+vb_expand_pair( uchar b0, uchar b1 ) {
+  return _mm_setr_epi8( (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b0),
+                        (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1), (char)(b1) );
+}
 
-#define vb_bcast_even(x)      /* [ b0 b0 b2 b2 b4 b4 .. b12 b12 b14 b14 ] */ \
-  _mm_shuffle_epi8( (x), vb_bcast_wide( 0, 2, 4, 6, 8, 10, 12, 14 ) )
+static inline vb_t /* [ b0 b0 b1 b1 ... b7 b7 ] */
+vb_expand_quad( uchar b0, uchar b1, uchar b2, uchar b3 ) {
+  return _mm_setr_epi8( (char)(b0), (char)(b0), (char)(b0), (char)(b0), (char)(b1), (char)(b1), (char)(b1), (char)(b1),
+                        (char)(b2), (char)(b2), (char)(b2), (char)(b2), (char)(b3), (char)(b3), (char)(b3), (char)(b3) );
+}
 
-#define vb_bcast_odd(x)       /* [ b1 b1 b3 b3 b5 b5 .. b13 b13 b15 b15 ] */ \
-  _mm_shuffle_epi8( (x), vb_bcast_wide( 1, 3, 5, 7, 9, 11, 13, 15 ) )
+static inline vb_t /* [ b0 b0 b1 b1 ... b7 b7 ] */
+vb_expand_oct( uchar b0, uchar b1, uchar b2, uchar b3, uchar b4, uchar b5, uchar b6, uchar b7 ) {
+  return _mm_setr_epi8( (char)(b0), (char)(b0), (char)(b1), (char)(b1), (char)(b2), (char)(b2), (char)(b3), (char)(b3),
+                        (char)(b4), (char)(b4), (char)(b5), (char)(b5), (char)(b6), (char)(b6), (char)(b7), (char)(b7) );
+}
+
+#define vb_permute(x,i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14,i15) /* [ x[i0] x[i1] ... x[i15] ] */ \
+  _mm_shuffle_epi8( (x), vb( (i0), (i1), (i2),  (i3),  (i4),  (i5),  (i6),  (i7),                            \
+                             (i8), (i9), (i10), (i11), (i12), (i13), (i14), (i15) ) )
+
+/* Useful cases are provided below.  Given [ b0 b1 b2 b3 b4 ... b15 ], return ... */
 
 #define vb_exch_adj(x)        /* [ b1 b0 b3 b2 ... b15 b14 ] */ \
   _mm_shuffle_epi8( (x), vb( 1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14 ) )
@@ -67,39 +73,48 @@ vb_bcast_wide( uchar b0, uchar b1, uchar  b2, uchar  b3, uchar  b4, uchar  b5, u
 
 #define vb_exch_adj_quad(x)   /* [ b4 b5 b6 b7 b0 b1 b2 b3 .. b8 b9 b10 b11 ] */ \
   _mm_shuffle_epi8( (x), vb( 4, 5, 6, 7, 0, 1, 2, 3, 12, 13, 14, 15, 8, 9, 10, 11 ) )
+
+#define vb_exch_adj_oct(x)    /* [ b8 b9 ... b15 b0 b1 ... b7 */ \
+  _mm_shuffle_epi8( (x), vb( 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7 ) )
+
+#define vb_bcast_even(x)      /* [ b0 b0 b2 b2 b4 b4 .. b12 b12 b14 b14 ] */ \
+  _mm_shuffle_epi8( (x), vb( 0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14 ) )
+
+#define vb_bcast_odd(x)       /* [ b1 b1 b3 b3 b5 b5 .. b13 b13 b15 b15 ] */ \
+  _mm_shuffle_epi8( (x), vb( 1, 1, 3, 3, 5, 5, 7, 7, 9, 9, 11, 11, 13, 13, 15, 15 ) )
+
 /* Predefined constants */
 
-#define vb_zero() _mm_setzero_si128() /* Return [ 0 0 0 0 0 ... 0 0 ] */
-#define vb_one()  _mm_set1_epi8( 1 )  /* Return [ 1 1 1 1 1 ... 1 1 ] */
+#define vb_zero() _mm_setzero_si128() /* Return [ 0 0 ... 0 ] */
+#define vb_one()  _mm_set1_epi8( 1 )  /* Return [ 1 1 ... 1 ] */
 
 /* Memory operations */
 
 /* vb_ld return the 16 uchars at the 16-byte aligned / 16-byte sized
    location p as a vector uchar.  vb_ldu is the same but p does not have
    to be aligned.  vb_st writes the vector uchar to the 16-byte aligned /
-   16-byte sized location p as 16 uchars.  vb_stu is the same but p does not
-   have to be aligned.  In all these lane l will be at p[l].
+   16-byte sized location p as 16 uchars.  vb_stu is the same but p does
+   not have to be aligned.  In all these lane l will be at p[l].  FIXME:
+   USE ATTRIBUTES ON P PASSED TO THESE?
 
    Note: gcc knows a __m128i may alias. */
-
-/* FIXME: USE ATTRIBUTES ON P PASSED TO THESE? */
 
 static inline vb_t vb_ld(  uchar const * p   ) { return _mm_load_si128(  (__m128i const *)p ); }
 static inline vb_t vb_ldu( uchar const * p   ) { return _mm_loadu_si128( (__m128i const *)p ); }
 static inline void vb_st(  uchar * p, vb_t i ) { _mm_store_si128(  (__m128i *)p, i ); }
 static inline void vb_stu( uchar * p, vb_t i ) { _mm_storeu_si128( (__m128i *)p, i ); }
 
-/* Sadly, no maskload_epi8, so we can't provide a vb_ldif or vb_stif */
-
+/* Sadly, no maskload_epi8, so we can't provide a vb_ldif or vb_stif.
+   TODO: consider emulating this? */
 
 /* Element operations */
 
-/* vb_extract extracts the uchar in lane imm from the vector uchar as an uchar.
+/* vb_extract extracts the uchar in lane imm from the vector uchar.
    vb_insert returns the vector uchar formed by replacing the value in
    lane imm of a vbth the provided uchar.  imm should be a compile time
-   constant in 0:7.  vb_extract_variable and vb_insert_variable are the
+   constant in 0:15.  vb_extract_variable and vb_insert_variable are the
    slower but the lane n does not have to be known at compile time
-   (should still be in 0:7).
+   (should still be in 0:15).
 
    Note: C99 TC3 allows type punning through a union. */
 
@@ -121,68 +136,64 @@ vb_insert_variable( vb_t a, int n, uchar v ) {
   return _mm_load_si128( t->m );
 }
 
-/* Given [a0 a1 a2 a3 a4 ... a14 a15] and/or [b0 b1 b2 b3 b4 ... b14 b15],
-   return ... */
+/* Given [a0 a1 ... a15] and/or [b0 b1 ... b15], return ... */
 
 /* Arithmetic operations */
 
 #define vb_neg(a) _mm_sub_epi8( _mm_setzero_si128(), (a) ) /* [ -a0  -a1  ... -a15  ] (twos complement handling) */
 #define vb_abs(a) (a)                                      /* [ |a0| |a1| ... |a15| ] (unsigned type, so identity) */
 
-#define vb_min(a,b) _mm_min_epu8(   (a), (b) ) /* [ min(a0,b0) min(a1,b1) ... min(a15,b15) ] */
-#define vb_max(a,b) _mm_max_epu8(   (a), (b) ) /* [ max(a0,b0) max(a1,b1) ... max(a15,b15) ] */
-#define vb_add(a,b) _mm_add_epi8(   (a), (b) ) /* [ a0 +b0     a1 +b1     ... a15 +b15     ] */
-#define vb_sub(a,b) _mm_sub_epi8(   (a), (b) ) /* [ a0 -b0     a1 -b1     ... a15 -b15     ] */
+#define vb_min(a,b) _mm_min_epu8( (a), (b) ) /* [ min(a0,b0) min(a1,b1) ... min(a15,b15) ] */
+#define vb_max(a,b) _mm_max_epu8( (a), (b) ) /* [ max(a0,b0) max(a1,b1) ... max(a15,b15) ] */
+#define vb_add(a,b) _mm_add_epi8( (a), (b) ) /* [ a0 +b0     a1 +b1     ... a15 +b15     ] */
+#define vb_sub(a,b) _mm_sub_epi8( (a), (b) ) /* [ a0 -b0     a1 -b1     ... a15 -b15     ] */
+
 /* No vb_mul because there's no instruction for multiplying uchars.  You
    can build one with two invocations to _mm_mullo_epi16, but it won't
    be particularly fast.  Multiplication by add and shift might be
-   faster honestly. */
+   faster honestly.  TODO: consider emulating for completeness? */
 
-/* Binary operations */
+/* Bit operations */
 
-/* Note: vb_shl/vb_shr/vb_shru is a left/signed right/unsigned right
-   shift by imm bits; imm must be a compile time constant in 0:63.  The
-   variable variants are slower but do not require the shift amount to
-   be known at compile time (should still be in 0:63). */
+/* Note: vb_shl/vb_shr is an unsigned left/right shift by imm bits; imm
+   must be a compile time constant in 0:7.  The variable variants are
+   slower but do not require the shift amount to be known at compile
+   time (should still be in 0:7). */
 
 #define vb_not(a) _mm_xor_si128( _mm_set1_epi32( -1 ), (a) ) /* [ ~a0 ~a1 ... ~a15 ] */
 
+#define vb_shl(a,imm) vb_and( _mm_slli_epi16( (a), (imm) ), vb_bcast( (uchar)(0xFFUL << (imm)) ) ) /* [ a0<<imm a1<<imm ... a15<<imm ] */
+#define vb_shr(a,imm) vb_and( _mm_srli_epi16( (a), (imm) ), vb_bcast( (uchar)(0xFFUL >> (imm)) ) ) /* [ a0>>imm a1>>imm ... a15>>imm ] (treat a as unsigned) */
 
-#define vb_shl(a,imm)  vb_and( _mm_slli_epi16( (a), (imm) ), vb_bcast( (uchar)(0xFFUL << (imm)) ) ) /* [ a0<<imm a1<<imm ... a15<<imm ] */
-/* It's not easy to implement the full set of shifts given the
-   intrinsics. Could convert to 16b, do the shift, and convert back, but
-   that's terrible. */
-#define vb_shru(a,imm) vb_and( _mm_srli_epi16( (a), (imm) ), vb_bcast( (uchar)(0xFFUL >> (imm)) ) ) /* [ a0>>imm a1>>imm ... a15>>imm ] (treat a as unsigned) */
-
-#define vb_shl_variable(a,n)  vb_and( _mm_sll_epi16( (a), _mm_insert_epi64( _mm_setzero_si128(), (n), 0 ) ), \
-                                      vb_bcast( (uchar)(0xFFUL << (n)) ) )
-#define vb_shru_variable(a,n) vb_and( _mm_srl_epi16( (a), _mm_insert_epi64( _mm_setzero_si128(), (n), 0 ) ), \
-                                      vb_bcast( (uchar)(0xFFUL >> (n)) ) )
-
+#define vb_shl_variable(a,n) vb_and( _mm_sll_epi16( (a), _mm_insert_epi64( _mm_setzero_si128(), (n), 0 ) ), \
+                                     vb_bcast( (uchar)(0xFFUL << (n)) ) )
+#define vb_shr_variable(a,n) vb_and( _mm_srl_epi16( (a), _mm_insert_epi64( _mm_setzero_si128(), (n), 0 ) ), \
+                                     vb_bcast( (uchar)(0xFFUL >> (n)) ) )
 
 #define vb_and(a,b)    _mm_and_si128(    (a), (b) ) /* [   a0 &b0    a1& b1 ...   a15& b15 ] */
 #define vb_andnot(a,b) _mm_andnot_si128( (a), (b) ) /* [ (~a0)&b0  (~a1)&b1 ... (~a15)&b15 ] */
 #define vb_or(a,b)     _mm_or_si128(     (a), (b) ) /* [   a0 |b0    a1 |b1 ...   a15 |b15 ] */
 #define vb_xor(a,b)    _mm_xor_si128(    (a), (b) ) /* [   a0 ^b0    a1 ^b1 ...   a15 ^b15 ] */
 
-/* Logical operations */
+static inline vb_t vb_rol( vb_t a, int imm ) { return vb_or( vb_shl( a, imm & 7 ), vb_shr( a, (-imm) & 7 ) ); }
+static inline vb_t vb_ror( vb_t a, int imm ) { return vb_or( vb_shr( a, imm & 7 ), vb_shl( a, (-imm) & 7 ) ); }
 
-/* NOTE: These don't return proper wc_t values, but they are usable for
- * vb_czero, vb_notczero, vb_if, vb_any_fast, and vb_all_fast. */
+static inline vb_t vb_rol_variable( vb_t a, int n ) { return vb_or( vb_shl_variable( a, n&7 ), vb_shr_variable( a, (-n)&7 ) ); }
+static inline vb_t vb_ror_variable( vb_t a, int n ) { return vb_or( vb_shr_variable( a, n&7 ), vb_shl_variable( a, (-n)&7 ) ); }
+
+/* Logical operations */
 
 #define vb_lnot(a)    _mm_cmpeq_epi8( (a), _mm_setzero_si128() ) /* [  !a0  !a1 ...  !a15 ] */
 #define vb_lnotnot(a)                                            /* [ !!a0 !!a1 ... !!a15 ] */ \
   _mm_xor_si128( _mm_set1_epi32( -1 ), vb_lnot( (a) ) )
 
-
-#define vb_eq(a,b) _mm_cmpeq_epi8( (a), (b) )                                              /* [ a0==b0 a1==b1 ... a15==b15 ] */
-#define vb_gt(a,b)                                                                         /* [ a0> b0 a1> b1 ... a15> b15 ] */\
-  _mm_cmpgt_epi8( _mm_sub_epi8( (a), _mm_set1_epi8( (char)(1U<<7) ) ),                                                         \
-                  _mm_sub_epi8( (b), _mm_set1_epi8( (char)(1U<<7) ) ) )
-#define vb_lt(a,b) vb_gt( (b), (a) )                                                 /* [ a0< b0 a1< b1 ... a15< b15 ] */
-#define vb_ne(a,b) _mm_xor_si128( _mm_set1_epi32( -1 ), _mm_cmpeq_epi8( (a), (b) ) ) /* [ a0!=b0 a1!=b1 ... a15!=b15 ] */
-#define vb_ge(a,b) _mm_xor_si128( _mm_set1_epi32( -1 ), vb_gt( (b), (a) ) )          /* [ a0>=b0 a1>=b1 ... a15>=b15 ] */
-#define vb_le(a,b) _mm_xor_si128( _mm_set1_epi32( -1 ), vb_gt( (a), (b) ) )          /* [ a0<=b0 a1<=b1 ... a15<=b15 ] */
+#define vb_eq(a,b) _mm_cmpeq_epi8( (a), (b) )                                            /* [ a0==b0 a1==b1 ... a15==b15 ] */
+#define vb_gt(a,b) _mm_cmpgt_epi8( _mm_sub_epi8( (a), _mm_set1_epi8( (char)(1U<<7) ) ),  /* [ a0> b0 a1> b1 ... a15> b15 ] */ \
+                                   _mm_sub_epi8( (b), _mm_set1_epi8( (char)(1U<<7) ) ) )
+#define vb_lt(a,b) vb_gt( (b), (a) )                                                     /* [ a0< b0 a1< b1 ... a15< b15 ] */
+#define vb_ne(a,b) _mm_xor_si128( _mm_set1_epi32( -1 ), _mm_cmpeq_epi8( (a), (b) ) )     /* [ a0!=b0 a1!=b1 ... a15!=b15 ] */
+#define vb_ge(a,b) _mm_xor_si128( _mm_set1_epi32( -1 ), vb_gt( (b), (a) ) )              /* [ a0>=b0 a1>=b1 ... a15>=b15 ] */
+#define vb_le(a,b) _mm_xor_si128( _mm_set1_epi32( -1 ), vb_gt( (a), (b) ) )              /* [ a0<=b0 a1<=b1 ... a15<=b15 ] */
 
 /* Conditional operations */
 
@@ -210,6 +221,10 @@ vb_insert_variable( vb_t a, int n, uchar v ) {
    vb_to_vi(a, 2)   returns [ (int)a8  (int)a9  (int)a10 (int)a11 ]
    vb_to_vi(a, 3)   returns [ (int)a12 (int)a13 (int)a14 (int)a15 ]
 
+   vb_to_vu(a, 0)   returns [ (uint)a0  (uint)a1  (uint)a2  (uint)a3  ]
+   vb_to_vu(a, 1)   returns [ (uint)a4  (uint)a5  (uint)a6  (uint)a7  ]
+   vb_to_vu(a, 2)   returns [ (uint)a8  (uint)a9  (uint)a10 (uint)a11 ]
+   vb_to_vu(a, 3)   returns [ (uint)a12 (uint)a13 (uint)a14 (uint)a15 ]
 
    vb_to_vd(a,0) returns [ (double)a0  (double)a1  ]
    vb_to_vd(a,1) returns [ (double)a2  (double)a3  ]
@@ -221,21 +236,28 @@ vb_insert_variable( vb_t a, int n, uchar v ) {
    ...
    vb_to_vl(a,7) returns [ (long)a14 (long)a15 ]
 
-   where imm_hi should be a compile time constant. */
+   vb_to_vv(a,0) returns [ (ulong)a0  (ulong)a1  ]
+   vb_to_vv(a,1) returns [ (ulong)a2  (ulong)a3  ]
+   ...
+   vb_to_vv(a,7) returns [ (ulong)a14 (ulong)a15 ]
 
+   where the above values should be compile time constants. */
 
-#define vb_to_vc(a, imm_hi)        _mm_xor_si128( _mm_set1_epi32( -1 ), _mm_cmpeq_epi32( _mm_cvtepu8_epi32( _mm_bsrli_si128( (a), 4*(imm_hi) ) ) , _mm_setzero_si128() ) )
-#define vb_to_vi(a, imm_hi)        _mm_cvtepu8_epi32( _mm_bsrli_si128( (a), 4*(imm_hi) ) )
-#define vb_to_vu(a, imm_hi)        _mm_cvtepu8_epi32( _mm_bsrli( (a), 4*(imm_hi) ) )
-#define vb_to_vf(a, imm_hi)        _mm_cvtepi32_ps( _mm_cvtepu8_epi32( _mm_bsrli_si128( (a), 4*(imm_hi) ) ) )
-#define vb_to_vd(a, imm_hi)        _mm_cvtepi32_pd( _mm_cvtepu8_epi32( _mm_bsrli_si128( (a), 2*(imm_hi) ) ) )
-#define vb_to_vl(a, imm_hi)        _mm_cvtepu8_epi64( _mm_bsrli_si128( (a), 2*(imm_hi) ) )
-#define vb_to_vv(a, imm_hi)        _mm_cvtepu8_epi64( _mm_bsrli_si128( (a), 2*(imm_hi) ) )
+#define vb_to_vc( a, imm ) _mm_xor_si128( _mm_set1_epi32( -1 ), _mm_cmpeq_epi32( _mm_cvtepu8_epi32( _mm_bsrli_si128( (a), 4*(imm) ) ) , _mm_setzero_si128() ) )
+#define vb_to_vf( a, imm ) _mm_cvtepi32_ps( _mm_cvtepu8_epi32( _mm_bsrli_si128( (a), 4*(imm) ) ) )
+#define vb_to_vi( a, imm ) _mm_cvtepu8_epi32( _mm_bsrli_si128( (a), 4*(imm) ) )
+#define vb_to_vu( a, imm ) _mm_cvtepu8_epi32( _mm_bsrli_si128( (a), 4*(imm) ) )
+#define vb_to_vd( a, imm ) _mm_cvtepi32_pd( _mm_cvtepu8_epi32( _mm_bsrli_si128( (a), 2*(imm) ) ) )
+#define vb_to_vl( a, imm ) _mm_cvtepu8_epi64( _mm_bsrli_si128( (a), 2*(imm) ) )
+#define vb_to_vv( a, imm ) _mm_cvtepu8_epi64( _mm_bsrli_si128( (a), 2*(imm) ) )
 
 #define vb_to_vc_raw(a) (a)
 #define vb_to_vf_raw(a) _mm_castsi128_ps( (a) )
+#define vb_to_vi_raw(a) (a)
+#define vb_to_vu_raw(a) (a)
 #define vb_to_vd_raw(a) _mm_castsi128_pd( (a) )
 #define vb_to_vl_raw(a) (a)
+#define vb_to_vv_raw(a) (a)
 
 /* Reduction operations */
 
@@ -265,9 +287,13 @@ vb_max_all( vb_t x ) { /* Returns vb_bcast( max( x ) ) */
 
 /* Misc operations */
 
+/* TODO: These are probably are actually part of the vc post
+   generalization to different width SIMD types. */
+
 /* vb_{any, all} return 1 if any/all of the elements are non-zero.  The
    _fast variants are suitable for use with the return value of any of
    the vb comparison functions (e.g. vb_gt ). */
+
 #define vb_any_fast( x ) ( 0 != _mm_movemask_epi8( x ) )
 #define vb_any( x ) vb_any_fast( vb_ne( (x), vb_zero( ) ) )
 #define vb_all_fast( x ) ( 0xFFFF == _mm_movemask_epi8( x ) )

--- a/src/util/simd/fd_sse_vc.h
+++ b/src/util/simd/fd_sse_vc.h
@@ -2,6 +2,10 @@
 #error "Do not include this directly; use fd_sse.h"
 #endif
 
+/* TODO: the below is much very designed for a 32-bit SIMD lane world
+   (with 64-bit SIMD lane support hacked on afterward).  Revamp these to
+   be more general for 8, 16, 32 and 64 bit lanes. */
+
 /* Vector conditional API *********************************************/
 
 /* A vc_t is a vector conditional.  This is, it is a vector of integers

--- a/src/util/simd/test_avx_32x8.c
+++ b/src/util/simd/test_avx_32x8.c
@@ -3,110 +3,7 @@
 #if FD_HAS_AVX
 
 #include "fd_avx.h"
-#include <math.h>
 
-static int
-wb_test( wb_t b, uchar bi[ 32 ] ) {
-  int volatile _[1];
-  uchar        m[295] W_ATTR;
-  wb_t         g;
-
-  if( wb_extract( b,  0 ) !=bi[ 0] ) return 0;
-  if( wb_extract( b,  1 ) !=bi[ 1] ) return 0;
-  if( wb_extract( b,  2 ) !=bi[ 2] ) return 0;
-  if( wb_extract( b,  3 ) !=bi[ 3] ) return 0;
-  if( wb_extract( b,  4 ) !=bi[ 4] ) return 0;
-  if( wb_extract( b,  5 ) !=bi[ 5] ) return 0;
-  if( wb_extract( b,  6 ) !=bi[ 6] ) return 0;
-  if( wb_extract( b,  7 ) !=bi[ 7] ) return 0;
-  if( wb_extract( b,  8 ) !=bi[ 8] ) return 0;
-  if( wb_extract( b,  9 ) !=bi[ 9] ) return 0;
-  if( wb_extract( b, 10 ) !=bi[10] ) return 0;
-  if( wb_extract( b, 11 ) !=bi[11] ) return 0;
-  if( wb_extract( b, 12 ) !=bi[12] ) return 0;
-  if( wb_extract( b, 13 ) !=bi[13] ) return 0;
-  if( wb_extract( b, 14 ) !=bi[14] ) return 0;
-  if( wb_extract( b, 15 ) !=bi[15] ) return 0;
-  if( wb_extract( b, 16 ) !=bi[16] ) return 0;
-  if( wb_extract( b, 17 ) !=bi[17] ) return 0;
-  if( wb_extract( b, 18 ) !=bi[18] ) return 0;
-  if( wb_extract( b, 19 ) !=bi[19] ) return 0;
-  if( wb_extract( b, 20 ) !=bi[20] ) return 0;
-  if( wb_extract( b, 21 ) !=bi[21] ) return 0;
-  if( wb_extract( b, 22 ) !=bi[22] ) return 0;
-  if( wb_extract( b, 23 ) !=bi[23] ) return 0;
-  if( wb_extract( b, 24 ) !=bi[24] ) return 0;
-  if( wb_extract( b, 25 ) !=bi[25] ) return 0;
-  if( wb_extract( b, 26 ) !=bi[26] ) return 0;
-  if( wb_extract( b, 27 ) !=bi[27] ) return 0;
-  if( wb_extract( b, 28 ) !=bi[28] ) return 0;
-  if( wb_extract( b, 29 ) !=bi[29] ) return 0;
-  if( wb_extract( b, 30 ) !=bi[30] ) return 0;
-  if( wb_extract( b, 31 ) !=bi[31] ) return 0;
-
-  for( int j=0; j<32; j++ ) { _[0]=j; if( wb_extract_variable( b, _[0] )!=bi[j] ) return 0; }
-
-  wb_st(  m,     b ); /*   Aligned store to aligned   */
-  wb_stu( m+32,  b ); /* Unaligned store to aligned   */
-  wb_stu( m+65,  b ); /* Unaligned store to aligned+1 */
-  wb_stu( m+98,  b ); /* Unaligned store to aligned+2 */
-  wb_stu( m+131, b ); /* Unaligned store to aligned+3 */
-  wb_stu( m+164, b ); /* Unaligned store to aligned+4 */
-  wb_stu( m+197, b ); /* Unaligned store to aligned+5 */
-  wb_stu( m+230, b ); /* Unaligned store to aligned+6 */
-  wb_stu( m+263, b ); /* Unaligned store to aligned+7 */
-
-  g = wb_ld ( m     ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
-  g = wb_ldu( m+32  ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
-  g = wb_ldu( m+65  ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
-  g = wb_ldu( m+98  ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
-  g = wb_ldu( m+131 ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
-  g = wb_ldu( m+164 ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
-  g = wb_ldu( m+197 ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
-  g = wb_ldu( m+230 ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
-  g = wb_ldu( m+263 ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
-
-  g = wb_zero();
-  g = wb_insert( g,  0, bi[ 0] );
-  g = wb_insert( g,  1, bi[ 1] );
-  g = wb_insert( g,  2, bi[ 2] );
-  g = wb_insert( g,  3, bi[ 3] );
-  g = wb_insert( g,  4, bi[ 4] );
-  g = wb_insert( g,  5, bi[ 5] );
-  g = wb_insert( g,  6, bi[ 6] );
-  g = wb_insert( g,  7, bi[ 7] );
-  g = wb_insert( g,  8, bi[ 8] );
-  g = wb_insert( g,  9, bi[ 9] );
-  g = wb_insert( g, 10, bi[10] );
-  g = wb_insert( g, 11, bi[11] );
-  g = wb_insert( g, 12, bi[12] );
-  g = wb_insert( g, 13, bi[13] );
-  g = wb_insert( g, 14, bi[14] );
-  g = wb_insert( g, 15, bi[15] );
-  g = wb_insert( g, 16, bi[16] );
-  g = wb_insert( g, 17, bi[17] );
-  g = wb_insert( g, 18, bi[18] );
-  g = wb_insert( g, 19, bi[19] );
-  g = wb_insert( g, 20, bi[20] );
-  g = wb_insert( g, 21, bi[21] );
-  g = wb_insert( g, 22, bi[22] );
-  g = wb_insert( g, 23, bi[23] );
-  g = wb_insert( g, 24, bi[24] );
-  g = wb_insert( g, 25, bi[25] );
-  g = wb_insert( g, 26, bi[26] );
-  g = wb_insert( g, 27, bi[27] );
-  g = wb_insert( g, 28, bi[28] );
-  g = wb_insert( g, 29, bi[29] );
-  g = wb_insert( g, 30, bi[30] );
-  g = wb_insert( g, 31, bi[31] ); if( wb_any( wb_ne( b, g ) ) ) return 0;
-
-  g = wb_zero();
-  for( int j=0; j<32; j++ ) { _[0]=j; g=wb_insert_variable( g, _[0], bi[j] ); }
-  if( wb_any( wb_ne( b, g ) ) ) return 0;
-
-  return 1;
-
-}
 int wc_test( wc_t c, int    c0, int    c1, int    c2, int    c3, int    c4, int    c5, int    c6, int    c7 );
 int wf_test( wf_t f, float  f0, float  f1, float  f2, float  f3, float  f4, float  f5, float  f6, float  f7 );
 int wi_test( wi_t i, int    i0, int    i1, int    i2, int    i3, int    i4, int    i5, int    i6, int    i7 );
@@ -114,115 +11,135 @@ int wu_test( wu_t u, uint   u0, uint   u1, uint   u2, uint   u3, uint   u4, uint
 int wd_test( wd_t d, double d0, double d1, double d2, double d3 );
 int wl_test( wl_t l, long   l0, long   l1, long   l2, long   l3 );
 int wv_test( wv_t v, ulong  v0, ulong  v1, ulong  v2, ulong  v3 );
+int wb_test( wb_t b, uchar const * bi );
 
 int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-#define EXPAND_4_INDICES( x, offset ) x[ (offset) ], x[ (offset)+1UL ], x[ (offset)+2UL ], x[ (offset)+3UL ]
-#define EXPAND_8_INDICES( x, offset )  EXPAND_4_INDICES(  x, offset ), EXPAND_4_INDICES(  x, (offset)+4UL  )
-#define EXPAND_16_INDICES( x, offset ) EXPAND_8_INDICES(  x, offset ), EXPAND_8_INDICES(  x, (offset)+8UL  )
-#define EXPAND_32_INDICES( x, offset ) EXPAND_16_INDICES( x, offset ), EXPAND_16_INDICES( x, (offset)+16UL )
-
-#define INVOKE_EXPAND( M, ... ) M(  __VA_ARGS__ )
-
-# define brand() (uchar)((fd_rng_uchar( rng ) % 7U)-3U)                /* [253,254,255,0,1,2,3] */
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
-  /* WB tests */
-  uchar xi[ 32 ], yi[ 32 ], ci[ 32 ];
+# define brand() ((uchar)((fd_rng_uint( rng ) % 7U)-3U)) /* [253,254,255,0,1,2,3] */
+
   uchar ti[ 32 ];
 
-  fd_memset( xi, 0, 32UL ); FD_TEST( wb_test( wb_zero(), xi ) );
-  fd_memset( xi, 1, 32UL ); FD_TEST( wb_test( wb_one(),  xi ) );
+# define INIT_TI( EXPR ) do { for( ulong j=0UL; j<32UL; j++ ) { ti[j] = (EXPR); } } while( 0 )
+
+  /* TODO: Proper typing */
+# define EXPAND_2_INDICES(  x, offset )                    x[ (offset) ],                    x[ (offset)+ 1UL ]
+# define EXPAND_4_INDICES(  x, offset ) EXPAND_2_INDICES(  x, (offset) ), EXPAND_2_INDICES(  x, (offset)+ 2UL )
+# define EXPAND_8_INDICES(  x, offset ) EXPAND_4_INDICES(  x, (offset) ), EXPAND_4_INDICES(  x, (offset)+ 4UL )
+# define EXPAND_16_INDICES( x, offset ) EXPAND_8_INDICES(  x, (offset) ), EXPAND_8_INDICES(  x, (offset)+ 8UL )
+# define EXPAND_32_INDICES( x, offset ) EXPAND_16_INDICES( x, (offset) ), EXPAND_16_INDICES( x, (offset)+16UL )
+
+# define INVOKE_EXPAND( M, ... ) M(  __VA_ARGS__ )
+
+  /* WB tests */
+
+  INIT_TI( (uchar)0 ); FD_TEST( wb_test( wb_zero(), ti ) );
+  INIT_TI( (uchar)1 ); FD_TEST( wb_test( wb_one(),  ti ) );
 
   for( int i=0; i<65536; i++ ) {
-    for( ulong j=0UL; j<32UL; j++ ) xi[ j ] = brand();
-    wb_t x = INVOKE_EXPAND( wb, EXPAND_32_INDICES( xi, 0 ) );
-
-    for( ulong j=0UL; j<32UL; j++ ) yi[ j ] = brand();
-    wb_t y = INVOKE_EXPAND( wb, EXPAND_32_INDICES( yi, 0 ) );
-
-    for( ulong j=0UL; j<32UL; j++ ) ci[ j ] = (uchar)(fd_rng_uint( rng ) & 1 ? 0xFF : 0);
-    wb_t c = INVOKE_EXPAND( wb, EXPAND_32_INDICES( ci, 0 ) );
-
-#   define INIT_TI( EXPR ) do { for( ulong j=0UL; j<32UL; j++ ) { ti[j] = (EXPR); } } while( 0 )
-#   define C(cond) (uchar)( (cond) ? 0xFF : 0 )
-#   define ROL(x,n) fd_uint_rotate_left ( (x),(n) )
-#   define ROR(x,n) fd_uint_rotate_right( (x),(n) )
-
 
     /* Constructors */
 
-    FD_TEST( wb_test( x, xi ) );
+    uchar xi[ 32 ]; for( ulong j=0UL; j<32UL; j++ ) xi[ j ] = brand();
+    uchar yi[ 32 ]; for( ulong j=0UL; j<32UL; j++ ) yi[ j ] = brand();
+    uchar ci[ 32 ]; for( ulong j=0UL; j<32UL; j++ ) ci[ j ] = (uchar)(-(fd_rng_uint( rng ) & 1U));
 
-    INIT_TI( yi[0]                        );       FD_TEST( wb_test( wb_bcast( yi[0] ), ti )                           );
+    wb_t x = INVOKE_EXPAND( wb, EXPAND_32_INDICES( xi, 0 ) ); FD_TEST( wb_test( x, xi ) );
+    wb_t y = INVOKE_EXPAND( wb, EXPAND_32_INDICES( yi, 0 ) ); FD_TEST( wb_test( y, yi ) );
+    wb_t c = INVOKE_EXPAND( wb, EXPAND_32_INDICES( ci, 0 ) ); FD_TEST( wb_test( c, ci ) );
 
-    INIT_TI( yi[j&1UL]                    );       FD_TEST( wb_test( wb_bcast_pair( yi[0], yi[1] ), ti )               );
-    INIT_TI( yi[j>>4 ]                    );       FD_TEST( wb_test( wb_bcast_lohi( yi[0], yi[1] ), ti )               );
+    INIT_TI( yi[ 0          ] ); FD_TEST( wb_test( wb_bcast( yi[0] ), ti ) );
 
-    INIT_TI( yi[j&3UL]                    );       FD_TEST( wb_test( wb_bcast_quad( yi[0], yi[1], yi[2], yi[3] ), ti ) );
-    INIT_TI( yi[j>>1 ]                    );       FD_TEST( wb_test( wb_bcast_wide( EXPAND_16_INDICES( yi, 0 ) ), ti ) );
+    INIT_TI( yi[ j &  1UL   ] ); FD_TEST( wb_test( wb_bcast_pair( EXPAND_2_INDICES ( yi, 0 ) ), ti ) );
+    INIT_TI( yi[ j &  3UL   ] ); FD_TEST( wb_test( wb_bcast_quad( EXPAND_4_INDICES ( yi, 0 ) ), ti ) );
+    INIT_TI( yi[ j &  7UL   ] ); FD_TEST( wb_test( wb_bcast_oct ( EXPAND_8_INDICES ( yi, 0 ) ), ti ) );
+    INIT_TI( yi[ j & 15UL   ] ); FD_TEST( wb_test( wb_bcast_hex ( EXPAND_16_INDICES( yi, 0 ) ), ti ) );
 
-    INIT_TI( yi[j & (~1UL)]               );       FD_TEST( wb_test( wb_bcast_even(     y ), ti )                      );
-    INIT_TI( yi[j |   1   ]               );       FD_TEST( wb_test( wb_bcast_odd(      y ), ti )                      );
-    INIT_TI( yi[j ^   1   ]               );       FD_TEST( wb_test( wb_exch_adj(       y ), ti )                      );
-    INIT_TI( yi[j ^   2   ]               );       FD_TEST( wb_test( wb_exch_adj_pair(  y ), ti )                      );
-    INIT_TI( yi[j ^   4   ]               );       FD_TEST( wb_test( wb_exch_adj_quad(  y ), ti )                      );
+    INIT_TI( yi[ j >> 4     ] ); FD_TEST( wb_test( wb_expand_pair( EXPAND_2_INDICES ( yi, 0 ) ), ti ) );
+    INIT_TI( yi[ j >> 3     ] ); FD_TEST( wb_test( wb_expand_quad( EXPAND_4_INDICES ( yi, 0 ) ), ti ) );
+    INIT_TI( yi[ j >> 2     ] ); FD_TEST( wb_test( wb_expand_oct ( EXPAND_8_INDICES ( yi, 0 ) ), ti ) );
+    INIT_TI( yi[ j >> 1     ] ); FD_TEST( wb_test( wb_expand_hex ( EXPAND_16_INDICES( yi, 0 ) ), ti ) );
+
+    INIT_TI( yi[ j ^  1     ] ); FD_TEST( wb_test( wb_exch_adj     ( y ), ti ) );
+    INIT_TI( yi[ j ^  2     ] ); FD_TEST( wb_test( wb_exch_adj_pair( y ), ti ) );
+    INIT_TI( yi[ j ^  4     ] ); FD_TEST( wb_test( wb_exch_adj_quad( y ), ti ) );
+    INIT_TI( yi[ j ^  8     ] ); FD_TEST( wb_test( wb_exch_adj_oct ( y ), ti ) );
+    INIT_TI( yi[ j ^ 16     ] ); FD_TEST( wb_test( wb_exch_adj_hex ( y ), ti ) );
+
+    INIT_TI( yi[ j & (~1UL) ] ); FD_TEST( wb_test( wb_bcast_even( y ), ti ) );
+    INIT_TI( yi[ j |   1UL  ] ); FD_TEST( wb_test( wb_bcast_odd ( y ), ti ) );
+
+    /* Arithmetic operations */
+
+    INIT_TI( (uchar)-xi[j]                ); FD_TEST( wb_test( wb_neg( x    ), ti ) );
+    INIT_TI( fd_uchar_abs( xi[j] )        ); FD_TEST( wb_test( wb_abs( x    ), ti ) );
+    INIT_TI( fd_uchar_min( xi[j], yi[j] ) ); FD_TEST( wb_test( wb_min( x, y ), ti ) );
+    INIT_TI( fd_uchar_max( xi[j], yi[j] ) ); FD_TEST( wb_test( wb_max( x, y ), ti ) );
+    INIT_TI( (uchar)(xi[j]+yi[j])         ); FD_TEST( wb_test( wb_add( x, y ), ti ) );
+    INIT_TI( (uchar)(xi[j]-yi[j])         ); FD_TEST( wb_test( wb_sub( x, y ), ti ) );
 
     /* Bit operations */
 
-    INIT_TI( (uchar)~yi[j]                );       FD_TEST( wb_test( wb_not( y ), ti )                                 );
+    INIT_TI( (uchar)~yi[j] ); FD_TEST( wb_test( wb_not( y ), ti ) );
 
+#   define ROL(x,n) fd_uchar_rotate_left ( (x), (n) )
+#   define ROR(x,n) fd_uchar_rotate_right( (x), (n) )
 
-#   define _(n)                                                                                                            \
-    INIT_TI( (uchar)(yi[j]<<n)            );       FD_TEST( wb_test( wb_shl ( y, n ), ti )                             );  \
-    INIT_TI( (uchar)(yi[j]>>n)            );       FD_TEST( wb_test( wb_shru( y, n ), ti )                             )
-    _( 0); _( 1); _( 2); _( 3); _( 4); _( 5); _( 6); _( 7); _( 8); _( 9); _(10); _(11); _(12); _(13); _(14); _(15); _(16);
+#   define _(n)                                                             \
+    INIT_TI( (uchar)(yi[j]<<n) ); FD_TEST( wb_test( wb_shl( y, n ), ti ) ); \
+    INIT_TI( (uchar)(yi[j]>>n) ); FD_TEST( wb_test( wb_shr( y, n ), ti ) ); \
+    INIT_TI( ROL( yi[j], n )   ); FD_TEST( wb_test( wb_rol( y, n ), ti ) ); \
+    INIT_TI( ROR( yi[j], n )   ); FD_TEST( wb_test( wb_ror( y, n ), ti ) )
+    _( 0); _( 1); _( 2); _( 3); _( 4); _( 5); _( 6); _( 7);
 #   undef _
 
     for( int n=0; n<8; n++ ) {
       int volatile m[1]; m[0] = n;
-      INIT_TI( (uchar)(yi[j]<<n)          );       FD_TEST( wb_test( wb_shl_variable(  y, m[0] ), ti )                 );
-      INIT_TI( (uchar)(yi[j]>>n)          );       FD_TEST( wb_test( wb_shru_variable( y, m[0] ), ti )                 );
+      INIT_TI( (uchar)(yi[j]<<n) ); FD_TEST( wb_test( wb_shl_variable( y, m[0] ), ti ) );
+      INIT_TI( (uchar)(yi[j]>>n) ); FD_TEST( wb_test( wb_shr_variable( y, m[0] ), ti ) );
+      INIT_TI( ROL( yi[j], n )   ); FD_TEST( wb_test( wb_rol_variable( y, m[0] ), ti ) );
+      INIT_TI( ROR( yi[j], n )   ); FD_TEST( wb_test( wb_ror_variable( y, m[0] ), ti ) );
     }
-
-
-    INIT_TI(   xi[j]  & yi[j]             );       FD_TEST( wb_test( wb_and(    x, y ), ti )                           );
-    INIT_TI( ((uchar)~xi[j]) & yi[j]      );       FD_TEST( wb_test( wb_andnot( x, y ), ti )                           );
-    INIT_TI(   xi[j]  | yi[j]             );       FD_TEST( wb_test( wb_or(     x, y ), ti )                           );
-    INIT_TI(   xi[j]  ^ yi[j]             );       FD_TEST( wb_test( wb_xor(    x, y ), ti )                           );
-
-    /* Arithmetic operations */
-
-    INIT_TI( (uchar)-xi[j]                );       FD_TEST( wb_test( wb_neg( x    ), ti )                              );
-    INIT_TI( fd_uchar_abs( xi[j] )        );       FD_TEST( wb_test( wb_abs( x    ), ti )                              );
-    INIT_TI( fd_uchar_min( xi[j], yi[j] ) );       FD_TEST( wb_test( wb_min( x, y ), ti )                              );
-    INIT_TI( fd_uchar_max( xi[j], yi[j] ) );       FD_TEST( wb_test( wb_max( x, y ), ti )                              );
-    INIT_TI( (uchar)(xi[j]+yi[j])         );       FD_TEST( wb_test( wb_add( x, y ), ti )                              );
-    INIT_TI( (uchar)(xi[j]-yi[j])         );       FD_TEST( wb_test( wb_sub( x, y ), ti )                              );
-
-    /* Logical operations */
-
-    INIT_TI( C( !xi[j])                   );       FD_TEST( wb_test( wb_lnot(    x ), ti )                             );
-    INIT_TI( C(!!xi[j])                   );       FD_TEST( wb_test( wb_lnotnot( x ), ti )                             );
-
-    INIT_TI( C(xi[j]==yi[j])              );       FD_TEST( wb_test( wb_eq( x, y ), ti )                               );
-    INIT_TI( C(xi[j]> yi[j])              );       FD_TEST( wb_test( wb_gt( x, y ), ti )                               );
-    INIT_TI( C(xi[j]< yi[j])              );       FD_TEST( wb_test( wb_lt( x, y ), ti )                               );
-    INIT_TI( C(xi[j]!=yi[j])              );       FD_TEST( wb_test( wb_ne( x, y ), ti )                               );
-    INIT_TI( C(xi[j]>=yi[j])              );       FD_TEST( wb_test( wb_ge( x, y ), ti )                               );
-    INIT_TI( C(xi[j]<=yi[j])              );       FD_TEST( wb_test( wb_le( x, y ), ti )                               );
-
-    INIT_TI( (uchar)(ci[j]?0:xi[j])       );       FD_TEST( wb_test( wb_czero(    c, x ), ti )                         );
-    INIT_TI( (uchar)(ci[j]?xi[j]:0)       );       FD_TEST( wb_test( wb_notczero( c, x ), ti )                         );
-    INIT_TI(        (ci[j]?xi[j]:yi[j])   );       FD_TEST( wb_test( wb_if( c, x, y ),    ti )                         );
 
 #   undef ROR
 #   undef ROL
+
+    INIT_TI(   xi[j]  & yi[j]        ); FD_TEST( wb_test( wb_and(    x, y ), ti ) );
+    INIT_TI( ((uchar)~xi[j]) & yi[j] ); FD_TEST( wb_test( wb_andnot( x, y ), ti ) );
+    INIT_TI(   xi[j]  | yi[j]        ); FD_TEST( wb_test( wb_or(     x, y ), ti ) );
+    INIT_TI(   xi[j]  ^ yi[j]        ); FD_TEST( wb_test( wb_xor(    x, y ), ti ) );
+
+    /* Logical operations */
+
+    /* TODO: eliminate this hack (see note in fd_avx_wc.h about
+       properly generalizing wc to 8/16/32/64-bit wide SIMD lanes). */
+
+#   define wc_to_wb_raw( x ) (x)
+
+#   define C(cond) ((uchar)(-(cond)))
+
+    INIT_TI( C( !xi[j]) ); FD_TEST( wb_test( wc_to_wb_raw( wb_lnot   ( x ) ), ti ) );
+    INIT_TI( C(!!xi[j]) ); FD_TEST( wb_test( wc_to_wb_raw( wb_lnotnot( x ) ), ti ) );
+
+    INIT_TI( C(xi[j]==yi[j]) ); FD_TEST( wb_test( wc_to_wb_raw( wb_eq( x, y ) ), ti ) );
+    INIT_TI( C(xi[j]> yi[j]) ); FD_TEST( wb_test( wc_to_wb_raw( wb_gt( x, y ) ), ti ) );
+    INIT_TI( C(xi[j]< yi[j]) ); FD_TEST( wb_test( wc_to_wb_raw( wb_lt( x, y ) ), ti ) );
+    INIT_TI( C(xi[j]!=yi[j]) ); FD_TEST( wb_test( wc_to_wb_raw( wb_ne( x, y ) ), ti ) );
+    INIT_TI( C(xi[j]>=yi[j]) ); FD_TEST( wb_test( wc_to_wb_raw( wb_ge( x, y ) ), ti ) );
+    INIT_TI( C(xi[j]<=yi[j]) ); FD_TEST( wb_test( wc_to_wb_raw( wb_le( x, y ) ), ti ) );
+
 #   undef C
-#   undef INIT_TI
+
+#   undef wc_to_wb_raw
+
+    INIT_TI( ci[j]?(uchar)0:xi[j] ); FD_TEST( wb_test( wb_czero   ( c, x ), ti ) );
+    INIT_TI( ci[j]?xi[j]:(uchar)0 ); FD_TEST( wb_test( wb_notczero( c, x ), ti ) );
+
+    INIT_TI( ci[j]?xi[j]:yi[j] ); FD_TEST( wb_test( wb_if( c, x, y ), ti ) );
 
     /* Conversion operations */
 
@@ -241,6 +158,10 @@ main( int     argc,
     FD_TEST( wi_test( wb_to_wi( x, 2 ), EXPAND_8_INDICES( (int)xi, 16 ) ) );
     FD_TEST( wi_test( wb_to_wi( x, 3 ), EXPAND_8_INDICES( (int)xi, 24 ) ) );
 
+    FD_TEST( wu_test( wb_to_wu( x, 0 ), EXPAND_8_INDICES( (uint)xi,  0 ) ) );
+    FD_TEST( wu_test( wb_to_wu( x, 1 ), EXPAND_8_INDICES( (uint)xi,  8 ) ) );
+    FD_TEST( wu_test( wb_to_wu( x, 2 ), EXPAND_8_INDICES( (uint)xi, 16 ) ) );
+    FD_TEST( wu_test( wb_to_wu( x, 3 ), EXPAND_8_INDICES( (uint)xi, 24 ) ) );
 
     FD_TEST( wd_test( wb_to_wd( x, 0 ), EXPAND_4_INDICES( (double)xi, 0 ) ) );
     FD_TEST( wd_test( wb_to_wd( x, 1 ), EXPAND_4_INDICES( (double)xi, 4 ) ) );
@@ -269,36 +190,34 @@ main( int     argc,
     FD_TEST( wv_test( wb_to_wv( x, 6 ), EXPAND_4_INDICES( (ulong)xi, 24 ) ) );
     FD_TEST( wv_test( wb_to_wv( x, 7 ), EXPAND_4_INDICES( (ulong)xi, 28 ) ) );
 
-
     /* Reduction operations */
+
     ulong acc;
-    acc=0UL;   for( ulong j=0UL; j<32UL; j++ ) acc += xi[j];
-                                                              FD_TEST( !wb_any( wb_ne( wb_sum_all( x ), wb_bcast( (uchar)acc ) )));
-    acc=255UL; for( ulong j=0UL; j<32UL; j++ ) acc =  fd_uchar_min( (uchar)acc, xi[j] );
-                                                              FD_TEST( !wb_any( wb_ne( wb_min_all( x ), wb_bcast( (uchar)acc ) )));
-    acc=0UL;   for( ulong j=0UL; j<32UL; j++ ) acc =  fd_uchar_max( (uchar)acc, xi[j] );
-                                                              FD_TEST( !wb_any( wb_ne( wb_max_all( x ), wb_bcast( (uchar)acc ) )));
+
+    acc=0UL; for( ulong j=0UL; j<32UL; j++ ) acc += xi[j];
+    FD_TEST( !wb_any( wb_ne( wb_sum_all( x ), wb_bcast( (uchar)acc ) )));
+
+    acc=255UL; for( ulong j=0UL; j<32UL; j++ ) acc = fd_uchar_min( (uchar)acc, xi[j] );
+    FD_TEST( !wb_any( wb_ne( wb_min_all( x ), wb_bcast( (uchar)acc ) )));
+
+    acc=0UL; for( ulong j=0UL; j<32UL; j++ ) acc = fd_uchar_max( (uchar)acc, xi[j] );
+    FD_TEST( !wb_any( wb_ne( wb_max_all( x ), wb_bcast( (uchar)acc ) )));
 
     /* Misc operations */
+
     FD_TEST( (!!xi[0] & !!xi[1]) == wb_all( wb_bcast_pair( xi[0], xi[1] ) ) );
     FD_TEST( (!!xi[0] | !!xi[1]) == wb_any( wb_bcast_pair( xi[0], xi[1] ) ) );
 
     FD_TEST( (!!ci[0] & !!ci[1]) == wb_all_fast( wb_bcast_pair( ci[0], ci[1] ) ) );
     FD_TEST( (!!ci[0] | !!ci[1]) == wb_any_fast( wb_bcast_pair( ci[0], ci[1] ) ) );
 
-
   }
 
+# undef INIT_TI
+
+# undef brand
 
   fd_rng_delete( fd_rng_leave( rng ) );
-
-# undef vrand
-# undef lrand
-# undef drand
-# undef urand
-# undef irand
-# undef frand
-# undef crand
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/util/simd/test_avx_common.c
+++ b/src/util/simd/test_avx_common.c
@@ -418,5 +418,106 @@ int wv_test( wv_t v, ulong v0, ulong v1, ulong v2, ulong v3 ) {
   return 1;
 }
 
+int wb_test( wb_t b, uchar const * bi ) {
+  int volatile _[1];
+  uchar        m[295] W_ATTR;
+  wb_t         g;
+
+  if( wb_extract( b,  0 ) !=bi[ 0] ) return 0;
+  if( wb_extract( b,  1 ) !=bi[ 1] ) return 0;
+  if( wb_extract( b,  2 ) !=bi[ 2] ) return 0;
+  if( wb_extract( b,  3 ) !=bi[ 3] ) return 0;
+  if( wb_extract( b,  4 ) !=bi[ 4] ) return 0;
+  if( wb_extract( b,  5 ) !=bi[ 5] ) return 0;
+  if( wb_extract( b,  6 ) !=bi[ 6] ) return 0;
+  if( wb_extract( b,  7 ) !=bi[ 7] ) return 0;
+  if( wb_extract( b,  8 ) !=bi[ 8] ) return 0;
+  if( wb_extract( b,  9 ) !=bi[ 9] ) return 0;
+  if( wb_extract( b, 10 ) !=bi[10] ) return 0;
+  if( wb_extract( b, 11 ) !=bi[11] ) return 0;
+  if( wb_extract( b, 12 ) !=bi[12] ) return 0;
+  if( wb_extract( b, 13 ) !=bi[13] ) return 0;
+  if( wb_extract( b, 14 ) !=bi[14] ) return 0;
+  if( wb_extract( b, 15 ) !=bi[15] ) return 0;
+  if( wb_extract( b, 16 ) !=bi[16] ) return 0;
+  if( wb_extract( b, 17 ) !=bi[17] ) return 0;
+  if( wb_extract( b, 18 ) !=bi[18] ) return 0;
+  if( wb_extract( b, 19 ) !=bi[19] ) return 0;
+  if( wb_extract( b, 20 ) !=bi[20] ) return 0;
+  if( wb_extract( b, 21 ) !=bi[21] ) return 0;
+  if( wb_extract( b, 22 ) !=bi[22] ) return 0;
+  if( wb_extract( b, 23 ) !=bi[23] ) return 0;
+  if( wb_extract( b, 24 ) !=bi[24] ) return 0;
+  if( wb_extract( b, 25 ) !=bi[25] ) return 0;
+  if( wb_extract( b, 26 ) !=bi[26] ) return 0;
+  if( wb_extract( b, 27 ) !=bi[27] ) return 0;
+  if( wb_extract( b, 28 ) !=bi[28] ) return 0;
+  if( wb_extract( b, 29 ) !=bi[29] ) return 0;
+  if( wb_extract( b, 30 ) !=bi[30] ) return 0;
+  if( wb_extract( b, 31 ) !=bi[31] ) return 0;
+
+  for( int j=0; j<32; j++ ) { _[0]=j; if( wb_extract_variable( b, _[0] )!=bi[j] ) return 0; }
+
+  wb_st(  m,     b ); /*   Aligned store to aligned   */
+  wb_stu( m+32,  b ); /* Unaligned store to aligned   */
+  wb_stu( m+65,  b ); /* Unaligned store to aligned+1 */
+  wb_stu( m+98,  b ); /* Unaligned store to aligned+2 */
+  wb_stu( m+131, b ); /* Unaligned store to aligned+3 */
+  wb_stu( m+164, b ); /* Unaligned store to aligned+4 */
+  wb_stu( m+197, b ); /* Unaligned store to aligned+5 */
+  wb_stu( m+230, b ); /* Unaligned store to aligned+6 */
+  wb_stu( m+263, b ); /* Unaligned store to aligned+7 */
+
+  g = wb_ld ( m     ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
+  g = wb_ldu( m+32  ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
+  g = wb_ldu( m+65  ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
+  g = wb_ldu( m+98  ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
+  g = wb_ldu( m+131 ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
+  g = wb_ldu( m+164 ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
+  g = wb_ldu( m+197 ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
+  g = wb_ldu( m+230 ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
+  g = wb_ldu( m+263 ); if( !wb_all( wb_eq( b, g ) ) ) return 0;
+
+  g = wb_zero();
+  g = wb_insert( g,  0, bi[ 0] );
+  g = wb_insert( g,  1, bi[ 1] );
+  g = wb_insert( g,  2, bi[ 2] );
+  g = wb_insert( g,  3, bi[ 3] );
+  g = wb_insert( g,  4, bi[ 4] );
+  g = wb_insert( g,  5, bi[ 5] );
+  g = wb_insert( g,  6, bi[ 6] );
+  g = wb_insert( g,  7, bi[ 7] );
+  g = wb_insert( g,  8, bi[ 8] );
+  g = wb_insert( g,  9, bi[ 9] );
+  g = wb_insert( g, 10, bi[10] );
+  g = wb_insert( g, 11, bi[11] );
+  g = wb_insert( g, 12, bi[12] );
+  g = wb_insert( g, 13, bi[13] );
+  g = wb_insert( g, 14, bi[14] );
+  g = wb_insert( g, 15, bi[15] );
+  g = wb_insert( g, 16, bi[16] );
+  g = wb_insert( g, 17, bi[17] );
+  g = wb_insert( g, 18, bi[18] );
+  g = wb_insert( g, 19, bi[19] );
+  g = wb_insert( g, 20, bi[20] );
+  g = wb_insert( g, 21, bi[21] );
+  g = wb_insert( g, 22, bi[22] );
+  g = wb_insert( g, 23, bi[23] );
+  g = wb_insert( g, 24, bi[24] );
+  g = wb_insert( g, 25, bi[25] );
+  g = wb_insert( g, 26, bi[26] );
+  g = wb_insert( g, 27, bi[27] );
+  g = wb_insert( g, 28, bi[28] );
+  g = wb_insert( g, 29, bi[29] );
+  g = wb_insert( g, 30, bi[30] );
+  g = wb_insert( g, 31, bi[31] ); if( wb_any( wb_ne( b, g ) ) ) return 0;
+
+  g = wb_zero();
+  for( int j=0; j<32; j++ ) { _[0]=j; g=wb_insert_variable( g, _[0], bi[j] ); }
+  if( wb_any( wb_ne( b, g ) ) ) return 0;
+
+  return 1;
+}
+
 #endif
 

--- a/src/util/simd/test_sse_16x8.c
+++ b/src/util/simd/test_sse_16x8.c
@@ -1,80 +1,8 @@
 #include "../fd_util.h"
 
-#if FD_HAS_AVX
+#if FD_HAS_SSE
 
 #include "fd_sse.h"
-#include <math.h>
-
-static int
-vb_test( vb_t b, uchar bi[ 16 ] ) {
-  int volatile _[1];
-  uchar        m[151] V_ATTR;
-  vb_t         g;
-
-  if( vb_extract( b,  0 ) !=bi[ 0] ) return 0;
-  if( vb_extract( b,  1 ) !=bi[ 1] ) return 0;
-  if( vb_extract( b,  2 ) !=bi[ 2] ) return 0;
-  if( vb_extract( b,  3 ) !=bi[ 3] ) return 0;
-  if( vb_extract( b,  4 ) !=bi[ 4] ) return 0;
-  if( vb_extract( b,  5 ) !=bi[ 5] ) return 0;
-  if( vb_extract( b,  6 ) !=bi[ 6] ) return 0;
-  if( vb_extract( b,  7 ) !=bi[ 7] ) return 0;
-  if( vb_extract( b,  8 ) !=bi[ 8] ) return 0;
-  if( vb_extract( b,  9 ) !=bi[ 9] ) return 0;
-  if( vb_extract( b, 10 ) !=bi[10] ) return 0;
-  if( vb_extract( b, 11 ) !=bi[11] ) return 0;
-  if( vb_extract( b, 12 ) !=bi[12] ) return 0;
-  if( vb_extract( b, 13 ) !=bi[13] ) return 0;
-  if( vb_extract( b, 14 ) !=bi[14] ) return 0;
-  if( vb_extract( b, 15 ) !=bi[15] ) return 0;
-
-  for( int j=0; j<16; j++ ) { _[0]=j; if( vb_extract_variable( b, _[0] )!=bi[j] ) return 0; }
-
-  vb_st(  m,     b ); /*   Aligned store to aligned   */
-  vb_stu( m+16,  b ); /* Unaligned store to aligned   */
-  vb_stu( m+33,  b ); /* Unaligned store to aligned+1 */
-  vb_stu( m+50,  b ); /* Unaligned store to aligned+2 */
-  vb_stu( m+67,  b ); /* Unaligned store to aligned+3 */
-  vb_stu( m+84,  b ); /* Unaligned store to aligned+4 */
-  vb_stu( m+101, b ); /* Unaligned store to aligned+5 */
-  vb_stu( m+118, b ); /* Unaligned store to aligned+6 */
-  vb_stu( m+135, b ); /* Unaligned store to aligned+7 */
-
-  g = vb_ld ( m     ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
-  g = vb_ldu( m+16  ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
-  g = vb_ldu( m+33  ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
-  g = vb_ldu( m+50  ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
-  g = vb_ldu( m+67  ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
-  g = vb_ldu( m+84  ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
-  g = vb_ldu( m+101 ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
-  g = vb_ldu( m+118 ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
-  g = vb_ldu( m+135 ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
-
-  g = vb_zero();
-  g = vb_insert( g,  0, bi[ 0] );
-  g = vb_insert( g,  1, bi[ 1] );
-  g = vb_insert( g,  2, bi[ 2] );
-  g = vb_insert( g,  3, bi[ 3] );
-  g = vb_insert( g,  4, bi[ 4] );
-  g = vb_insert( g,  5, bi[ 5] );
-  g = vb_insert( g,  6, bi[ 6] );
-  g = vb_insert( g,  7, bi[ 7] );
-  g = vb_insert( g,  8, bi[ 8] );
-  g = vb_insert( g,  9, bi[ 9] );
-  g = vb_insert( g, 10, bi[10] );
-  g = vb_insert( g, 11, bi[11] );
-  g = vb_insert( g, 12, bi[12] );
-  g = vb_insert( g, 13, bi[13] );
-  g = vb_insert( g, 14, bi[14] );
-  g = vb_insert( g, 15, bi[15] ); if( vb_any( vb_ne( b, g ) ) ) return 0;
-
-  g = vb_zero();
-  for( int j=0; j<16; j++ ) { _[0]=j; g=vb_insert_variable( g, _[0], bi[j] ); }
-  if( vb_any( vb_ne( b, g ) ) ) return 0;
-
-  return 1;
-
-}
 
 int vc_test( vc_t c, int    c0, int    c1, int    c2, int    c3 );
 int vf_test( vf_t f, float  f0, float  f1, float  f2, float  f3 );
@@ -83,115 +11,131 @@ int vu_test( vu_t u, uint   u0, uint   u1, uint   u2, uint   u3 );
 int vd_test( vd_t d, double d0, double d1 );
 int vl_test( vl_t l, long   l0, long   l1 );
 int vv_test( vv_t v, ulong  v0, ulong  v1 );
+int vb_test( vb_t b, uchar const * bi );
 
 int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-#define EXPAND_2_INDICES( x, offset ) x[ (offset) ], x[ (offset)+1UL ]
-#define EXPAND_4_INDICES( x, offset ) x[ (offset) ], x[ (offset)+1UL ], x[ (offset)+2UL ], x[ (offset)+3UL ]
-#define EXPAND_8_INDICES( x, offset )  EXPAND_4_INDICES(  x, offset ), EXPAND_4_INDICES(  x, (offset)+4UL  )
-#define EXPAND_16_INDICES( x, offset ) EXPAND_8_INDICES(  x, offset ), EXPAND_8_INDICES(  x, (offset)+8UL  )
-
-#define INVOKE_EXPAND( M, ... ) M(  __VA_ARGS__ )
-
-# define brand() (uchar)((fd_rng_uchar( rng ) % 7U)-3U)                /* [253,254,255,0,1,2,3] */
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
-  /* VB tests */
-  uchar xi[ 16 ], yi[ 16 ], ci[ 16 ];
+# define brand() ((uchar)((fd_rng_uint( rng ) % 7U)-3U)) /* [253,254,255,0,1,2,3] */
+
   uchar ti[ 16 ];
 
-  fd_memset( xi, 0, 16UL ); FD_TEST( vb_test( vb_zero(), xi ) );
-  fd_memset( xi, 1, 16UL ); FD_TEST( vb_test( vb_one(),  xi ) );
+# define INIT_TI( EXPR ) do { for( ulong j=0UL; j<16UL; j++ ) { ti[j] = (EXPR); } } while( 0 )
+
+  /* TODO: Proper typing */
+# define EXPAND_2_INDICES(  x, offset )                    x[ (offset) ],                    x[ (offset)+ 1UL ]
+# define EXPAND_4_INDICES(  x, offset ) EXPAND_2_INDICES(  x, (offset) ), EXPAND_2_INDICES(  x, (offset)+ 2UL )
+# define EXPAND_8_INDICES(  x, offset ) EXPAND_4_INDICES(  x, (offset) ), EXPAND_4_INDICES(  x, (offset)+ 4UL )
+# define EXPAND_16_INDICES( x, offset ) EXPAND_8_INDICES(  x, (offset) ), EXPAND_8_INDICES(  x, (offset)+ 8UL )
+
+# define INVOKE_EXPAND( M, ... ) M(  __VA_ARGS__ )
+
+  /* VB tests */
+
+  INIT_TI( (uchar)0 ); FD_TEST( vb_test( vb_zero(), ti ) );
+  INIT_TI( (uchar)1 ); FD_TEST( vb_test( vb_one(),  ti ) );
 
   for( int i=0; i<65536; i++ ) {
-    for( ulong j=0UL; j<16UL; j++ ) xi[ j ] = brand();
-    vb_t x = INVOKE_EXPAND( vb, EXPAND_16_INDICES( xi, 0 ) );
-
-    for( ulong j=0UL; j<16UL; j++ ) yi[ j ] = brand();
-    vb_t y = INVOKE_EXPAND( vb, EXPAND_16_INDICES( yi, 0 ) );
-
-    for( ulong j=0UL; j<16UL; j++ ) ci[ j ] = (uchar)(fd_rng_uint( rng ) & 1 ? 0xFF : 0);
-    vb_t c = INVOKE_EXPAND( vb, EXPAND_16_INDICES( ci, 0 ) );
-
-#   define INIT_TI( EXPR ) do { for( ulong j=0UL; j<16UL; j++ ) { ti[j] = (EXPR); } } while( 0 )
-#   define C(cond) (uchar)( (cond) ? 0xFF : 0 )
-#   define ROL(x,n) fd_uint_rotate_left ( (x),(n) )
-#   define ROR(x,n) fd_uint_rotate_right( (x),(n) )
-
 
     /* Constructors */
 
-    FD_TEST( vb_test( x, xi ) );
+    uchar xi[ 16 ]; for( ulong j=0UL; j<16UL; j++ ) xi[ j ] = brand();
+    uchar yi[ 16 ]; for( ulong j=0UL; j<16UL; j++ ) yi[ j ] = brand();
+    uchar ci[ 16 ]; for( ulong j=0UL; j<16UL; j++ ) ci[ j ] = (uchar)(fd_rng_uint( rng ) & 1 ? 0xFF : 0);
 
-    INIT_TI( yi[0]                        );       FD_TEST( vb_test( vb_bcast( yi[0] ), ti )                           );
+    vb_t x = INVOKE_EXPAND( vb, EXPAND_16_INDICES( xi, 0 ) ); FD_TEST( vb_test( x, xi ) );
+    vb_t y = INVOKE_EXPAND( vb, EXPAND_16_INDICES( yi, 0 ) ); FD_TEST( vb_test( y, yi ) );
+    vb_t c = INVOKE_EXPAND( vb, EXPAND_16_INDICES( ci, 0 ) ); FD_TEST( vb_test( c, ci ) );
 
-    INIT_TI( yi[j&1UL]                    );       FD_TEST( vb_test( vb_bcast_pair( yi[0], yi[1] ), ti )               );
-    INIT_TI( yi[j>>3 ]                    );       FD_TEST( vb_test( vb_bcast_lohi( yi[0], yi[1] ), ti )               );
+    INIT_TI( yi[ 0          ] ); FD_TEST( vb_test( vb_bcast( yi[0] ), ti ) );
 
-    INIT_TI( yi[j&3UL]                    );       FD_TEST( vb_test( vb_bcast_quad( yi[0], yi[1], yi[2], yi[3] ), ti ) );
-    INIT_TI( yi[j>>1 ]                    );       FD_TEST( vb_test( vb_bcast_wide( EXPAND_8_INDICES( yi, 0 ) ), ti )  );
+    INIT_TI( yi[ j & 1UL    ] ); FD_TEST( vb_test( vb_bcast_pair( EXPAND_2_INDICES( yi, 0 ) ), ti )  );
+    INIT_TI( yi[ j & 3UL    ] ); FD_TEST( vb_test( vb_bcast_quad( EXPAND_4_INDICES( yi, 0 ) ), ti )  );
+    INIT_TI( yi[ j & 7UL    ] ); FD_TEST( vb_test( vb_bcast_oct ( EXPAND_8_INDICES( yi, 0 ) ), ti )  );
 
-    INIT_TI( yi[j & (~1UL)]               );       FD_TEST( vb_test( vb_bcast_even(     y ), ti )                      );
-    INIT_TI( yi[j |   1   ]               );       FD_TEST( vb_test( vb_bcast_odd(      y ), ti )                      );
-    INIT_TI( yi[j ^   1   ]               );       FD_TEST( vb_test( vb_exch_adj(       y ), ti )                      );
-    INIT_TI( yi[j ^   2   ]               );       FD_TEST( vb_test( vb_exch_adj_pair(  y ), ti )                      );
-    INIT_TI( yi[j ^   4   ]               );       FD_TEST( vb_test( vb_exch_adj_quad(  y ), ti )                      );
+    INIT_TI( yi[ j >> 3     ] ); FD_TEST( vb_test( vb_expand_pair( EXPAND_2_INDICES( yi, 0 ) ), ti )  );
+    INIT_TI( yi[ j >> 2     ] ); FD_TEST( vb_test( vb_expand_quad( EXPAND_4_INDICES( yi, 0 ) ), ti )  );
+    INIT_TI( yi[ j >> 1     ] ); FD_TEST( vb_test( vb_expand_oct ( EXPAND_8_INDICES( yi, 0 ) ), ti )  );
+
+    INIT_TI( yi[ j ^ 1      ] ); FD_TEST( vb_test( vb_exch_adj     (  y ), ti ) );
+    INIT_TI( yi[ j ^ 2      ] ); FD_TEST( vb_test( vb_exch_adj_pair(  y ), ti ) );
+    INIT_TI( yi[ j ^ 4      ] ); FD_TEST( vb_test( vb_exch_adj_quad(  y ), ti ) );
+    INIT_TI( yi[ j ^ 8      ] ); FD_TEST( vb_test( vb_exch_adj_oct (  y ), ti ) );
+
+    INIT_TI( yi[ j & (~1UL) ] ); FD_TEST( vb_test( vb_bcast_even( y ), ti ) );
+    INIT_TI( yi[ j |   1UL  ] ); FD_TEST( vb_test( vb_bcast_odd ( y ), ti ) );
+
+    /* Arithmetic operations */
+
+    INIT_TI( (uchar)-xi[j]                ); FD_TEST( vb_test( vb_neg( x    ), ti ) );
+    INIT_TI( fd_uchar_abs( xi[j] )        ); FD_TEST( vb_test( vb_abs( x    ), ti ) );
+    INIT_TI( fd_uchar_min( xi[j], yi[j] ) ); FD_TEST( vb_test( vb_min( x, y ), ti ) );
+    INIT_TI( fd_uchar_max( xi[j], yi[j] ) ); FD_TEST( vb_test( vb_max( x, y ), ti ) );
+    INIT_TI( (uchar)(xi[j]+yi[j])         ); FD_TEST( vb_test( vb_add( x, y ), ti ) );
+    INIT_TI( (uchar)(xi[j]-yi[j])         ); FD_TEST( vb_test( vb_sub( x, y ), ti ) );
 
     /* Bit operations */
 
-    INIT_TI( (uchar)~yi[j]                );       FD_TEST( vb_test( vb_not( y ), ti )                                 );
+    INIT_TI( (uchar)~yi[j] ); FD_TEST( vb_test( vb_not( y ), ti ) );
 
+#   define ROL(x,n) fd_uchar_rotate_left ( (x), (n) )
+#   define ROR(x,n) fd_uchar_rotate_right( (x), (n) )
 
-#   define _(n)                                                                                                            \
-    INIT_TI( (uchar)(yi[j]<<n)            );       FD_TEST( vb_test( vb_shl ( y, n ), ti )                             );  \
-    INIT_TI( (uchar)(yi[j]>>n)            );       FD_TEST( vb_test( vb_shru( y, n ), ti )                             )
-    _( 0); _( 1); _( 2); _( 3); _( 4); _( 5); _( 6); _( 7); _( 8); _( 9); _(10); _(11); _(12); _(13); _(14); _(15); _(16);
+#   define _(n)                                                             \
+    INIT_TI( (uchar)(yi[j]<<n) ); FD_TEST( vb_test( vb_shl( y, n ), ti ) ); \
+    INIT_TI( (uchar)(yi[j]>>n) ); FD_TEST( vb_test( vb_shr( y, n ), ti ) ); \
+    INIT_TI( ROL( yi[j], n )   ); FD_TEST( vb_test( vb_rol( y, n ), ti ) ); \
+    INIT_TI( ROR( yi[j], n )   ); FD_TEST( vb_test( vb_ror( y, n ), ti ) )
+    _( 0); _( 1); _( 2); _( 3); _( 4); _( 5); _( 6); _( 7);
 #   undef _
 
     for( int n=0; n<8; n++ ) {
       int volatile m[1]; m[0] = n;
-      INIT_TI( (uchar)(yi[j]<<n)          );       FD_TEST( vb_test( vb_shl_variable(  y, m[0] ), ti )                 );
-      INIT_TI( (uchar)(yi[j]>>n)          );       FD_TEST( vb_test( vb_shru_variable( y, m[0] ), ti )                 );
+      INIT_TI( (uchar)(yi[j]<<n) ); FD_TEST( vb_test( vb_shl_variable( y, m[0] ), ti ) );
+      INIT_TI( (uchar)(yi[j]>>n) ); FD_TEST( vb_test( vb_shr_variable( y, m[0] ), ti ) );
+      INIT_TI( ROL( yi[j], n )   ); FD_TEST( vb_test( vb_rol_variable( y, m[0] ), ti ) );
+      INIT_TI( ROR( yi[j], n )   ); FD_TEST( vb_test( vb_ror_variable( y, m[0] ), ti ) );
     }
-
-
-    INIT_TI(   xi[j]  & yi[j]             );       FD_TEST( vb_test( vb_and(    x, y ), ti )                           );
-    INIT_TI( ((uchar)~xi[j]) & yi[j]      );       FD_TEST( vb_test( vb_andnot( x, y ), ti )                           );
-    INIT_TI(   xi[j]  | yi[j]             );       FD_TEST( vb_test( vb_or(     x, y ), ti )                           );
-    INIT_TI(   xi[j]  ^ yi[j]             );       FD_TEST( vb_test( vb_xor(    x, y ), ti )                           );
-
-    /* Arithmetic operations */
-
-    INIT_TI( (uchar)-xi[j]                );       FD_TEST( vb_test( vb_neg( x    ), ti )                              );
-    INIT_TI( fd_uchar_abs( xi[j] )        );       FD_TEST( vb_test( vb_abs( x    ), ti )                              );
-    INIT_TI( fd_uchar_min( xi[j], yi[j] ) );       FD_TEST( vb_test( vb_min( x, y ), ti )                              );
-    INIT_TI( fd_uchar_max( xi[j], yi[j] ) );       FD_TEST( vb_test( vb_max( x, y ), ti )                              );
-    INIT_TI( (uchar)(xi[j]+yi[j])         );       FD_TEST( vb_test( vb_add( x, y ), ti )                              );
-    INIT_TI( (uchar)(xi[j]-yi[j])         );       FD_TEST( vb_test( vb_sub( x, y ), ti )                              );
-
-    /* Logical operations */
-
-    INIT_TI( C( !xi[j])                   );       FD_TEST( vb_test( vb_lnot(    x ), ti )                             );
-    INIT_TI( C(!!xi[j])                   );       FD_TEST( vb_test( vb_lnotnot( x ), ti )                             );
-
-    INIT_TI( C(xi[j]==yi[j])              );       FD_TEST( vb_test( vb_eq( x, y ), ti )                               );
-    INIT_TI( C(xi[j]> yi[j])              );       FD_TEST( vb_test( vb_gt( x, y ), ti )                               );
-    INIT_TI( C(xi[j]< yi[j])              );       FD_TEST( vb_test( vb_lt( x, y ), ti )                               );
-    INIT_TI( C(xi[j]!=yi[j])              );       FD_TEST( vb_test( vb_ne( x, y ), ti )                               );
-    INIT_TI( C(xi[j]>=yi[j])              );       FD_TEST( vb_test( vb_ge( x, y ), ti )                               );
-    INIT_TI( C(xi[j]<=yi[j])              );       FD_TEST( vb_test( vb_le( x, y ), ti )                               );
-
-    INIT_TI( (uchar)(ci[j]?0:xi[j])       );       FD_TEST( vb_test( vb_czero(    c, x ), ti )                         );
-    INIT_TI( (uchar)(ci[j]?xi[j]:0)       );       FD_TEST( vb_test( vb_notczero( c, x ), ti )                         );
-    INIT_TI(        (ci[j]?xi[j]:yi[j])   );       FD_TEST( vb_test( vb_if( c, x, y ),    ti )                         );
 
 #   undef ROR
 #   undef ROL
+
+    INIT_TI(   xi[j]  & yi[j]        ); FD_TEST( vb_test( vb_and(    x, y ), ti ) );
+    INIT_TI( ((uchar)~xi[j]) & yi[j] ); FD_TEST( vb_test( vb_andnot( x, y ), ti ) );
+    INIT_TI(   xi[j]  | yi[j]        ); FD_TEST( vb_test( vb_or(     x, y ), ti ) );
+    INIT_TI(   xi[j]  ^ yi[j]        ); FD_TEST( vb_test( vb_xor(    x, y ), ti ) );
+
+    /* Logical operations */
+
+    /* TODO: eliminate this hack (see note in fd_sse_vc.h about
+       properly generalizing vc to 8/16/32/64-bit wide SIMD lanes). */
+
+#   define vc_to_vb_raw( x ) (x)
+
+#   define C(cond) ((uchar)(-(cond)))
+
+    INIT_TI( C( !xi[j]) ); FD_TEST( vb_test( vc_to_vb_raw( vb_lnot   ( x ) ), ti ) );
+    INIT_TI( C(!!xi[j]) ); FD_TEST( vb_test( vc_to_vb_raw( vb_lnotnot( x ) ), ti ) );
+
+    INIT_TI( C(xi[j]==yi[j]) ); FD_TEST( vb_test( vc_to_vb_raw( vb_eq( x, y ) ), ti ) );
+    INIT_TI( C(xi[j]> yi[j]) ); FD_TEST( vb_test( vc_to_vb_raw( vb_gt( x, y ) ), ti ) );
+    INIT_TI( C(xi[j]< yi[j]) ); FD_TEST( vb_test( vc_to_vb_raw( vb_lt( x, y ) ), ti ) );
+    INIT_TI( C(xi[j]!=yi[j]) ); FD_TEST( vb_test( vc_to_vb_raw( vb_ne( x, y ) ), ti ) );
+    INIT_TI( C(xi[j]>=yi[j]) ); FD_TEST( vb_test( vc_to_vb_raw( vb_ge( x, y ) ), ti ) );
+    INIT_TI( C(xi[j]<=yi[j]) ); FD_TEST( vb_test( vc_to_vb_raw( vb_le( x, y ) ), ti ) );
+
 #   undef C
-#   undef INIT_TI
+
+#   undef vc_to_vb_raw
+
+    INIT_TI( ci[j]?(uchar)0:xi[j] ); FD_TEST( vb_test( vb_czero(    c, x ), ti ) );
+    INIT_TI( ci[j]?xi[j]:(uchar)0 ); FD_TEST( vb_test( vb_notczero( c, x ), ti ) );
+
+    INIT_TI( ci[j]?xi[j]:yi[j] ); FD_TEST( vb_test( vb_if( c, x, y ),    ti ) );
 
     /* Conversion operations */
 
@@ -210,6 +154,10 @@ main( int     argc,
     FD_TEST( vi_test( vb_to_vi( x, 2 ), EXPAND_4_INDICES( (int)xi,  8 ) ) );
     FD_TEST( vi_test( vb_to_vi( x, 3 ), EXPAND_4_INDICES( (int)xi, 12 ) ) );
 
+    FD_TEST( vu_test( vb_to_vu( x, 0 ), EXPAND_4_INDICES( (uint)xi,  0 ) ) );
+    FD_TEST( vu_test( vb_to_vu( x, 1 ), EXPAND_4_INDICES( (uint)xi,  4 ) ) );
+    FD_TEST( vu_test( vb_to_vu( x, 2 ), EXPAND_4_INDICES( (uint)xi,  8 ) ) );
+    FD_TEST( vu_test( vb_to_vu( x, 3 ), EXPAND_4_INDICES( (uint)xi, 12 ) ) );
 
     FD_TEST( vd_test( vb_to_vd( x, 0 ), EXPAND_2_INDICES( (double)xi,  0 ) ) );
     FD_TEST( vd_test( vb_to_vd( x, 1 ), EXPAND_2_INDICES( (double)xi,  2 ) ) );
@@ -238,35 +186,34 @@ main( int     argc,
     FD_TEST( vv_test( vb_to_vv( x, 6 ), EXPAND_2_INDICES( (ulong)xi, 12 ) ) );
     FD_TEST( vv_test( vb_to_vv( x, 7 ), EXPAND_2_INDICES( (ulong)xi, 14 ) ) );
 
-
     /* Reduction operations */
+
     ulong acc;
-    acc=0UL;   for( ulong j=0UL; j<16UL; j++ ) acc += xi[j];  FD_TEST( !vb_any( vb_ne( vb_sum_all( x ), vb_bcast( (uchar)acc ) )));
-    acc=255UL; for( ulong j=0UL; j<16UL; j++ ) acc =  fd_uchar_min( (uchar)acc, xi[j] );
-                                                              FD_TEST( !vb_any( vb_ne( vb_min_all( x ), vb_bcast( (uchar)acc ) )));
-    acc=0UL;   for( ulong j=0UL; j<16UL; j++ ) acc =  fd_uchar_max( (uchar)acc, xi[j] );
-                                                              FD_TEST( !vb_any( vb_ne( vb_max_all( x ), vb_bcast( (uchar)acc ) )));
+
+    acc=0UL; for( ulong j=0UL; j<16UL; j++ ) acc += xi[j];
+    FD_TEST( !vb_any( vb_ne( vb_sum_all( x ), vb_bcast( (uchar)acc ) )));
+
+    acc=255UL; for( ulong j=0UL; j<16UL; j++ ) acc = fd_uchar_min( (uchar)acc, xi[j] );
+    FD_TEST( !vb_any( vb_ne( vb_min_all( x ), vb_bcast( (uchar)acc ) )));
+
+    acc=0UL; for( ulong j=0UL; j<16UL; j++ ) acc = fd_uchar_max( (uchar)acc, xi[j] );
+    FD_TEST( !vb_any( vb_ne( vb_max_all( x ), vb_bcast( (uchar)acc ) )));
 
     /* Misc operations */
+
     FD_TEST( (!!xi[0] & !!xi[1]) == vb_all( vb_bcast_pair( xi[0], xi[1] ) ) );
     FD_TEST( (!!xi[0] | !!xi[1]) == vb_any( vb_bcast_pair( xi[0], xi[1] ) ) );
 
     FD_TEST( (!!ci[0] & !!ci[1]) == vb_all_fast( vb_bcast_pair( ci[0], ci[1] ) ) );
     FD_TEST( (!!ci[0] | !!ci[1]) == vb_any_fast( vb_bcast_pair( ci[0], ci[1] ) ) );
 
-
   }
 
+# undef INIT_TI
+
+# undef brand
 
   fd_rng_delete( fd_rng_leave( rng ) );
-
-# undef vrand
-# undef lrand
-# undef drand
-# undef urand
-# undef irand
-# undef frand
-# undef crand
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();
@@ -279,7 +226,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
-  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_AVX capability" ));
+  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_SSE capability" ));
   fd_halt();
   return 0;
 }

--- a/src/util/simd/test_sse_common.c
+++ b/src/util/simd/test_sse_common.c
@@ -288,4 +288,73 @@ int vv_test( vv_t v, ulong v0, ulong v1 ) {
   return 1;
 }
 
+int vb_test( vb_t b, uchar const * bi ) {
+  int volatile _[1];
+  uchar        m[151] V_ATTR;
+  vb_t         g;
+
+  if( vb_extract( b,  0 ) !=bi[ 0] ) return 0;
+  if( vb_extract( b,  1 ) !=bi[ 1] ) return 0;
+  if( vb_extract( b,  2 ) !=bi[ 2] ) return 0;
+  if( vb_extract( b,  3 ) !=bi[ 3] ) return 0;
+  if( vb_extract( b,  4 ) !=bi[ 4] ) return 0;
+  if( vb_extract( b,  5 ) !=bi[ 5] ) return 0;
+  if( vb_extract( b,  6 ) !=bi[ 6] ) return 0;
+  if( vb_extract( b,  7 ) !=bi[ 7] ) return 0;
+  if( vb_extract( b,  8 ) !=bi[ 8] ) return 0;
+  if( vb_extract( b,  9 ) !=bi[ 9] ) return 0;
+  if( vb_extract( b, 10 ) !=bi[10] ) return 0;
+  if( vb_extract( b, 11 ) !=bi[11] ) return 0;
+  if( vb_extract( b, 12 ) !=bi[12] ) return 0;
+  if( vb_extract( b, 13 ) !=bi[13] ) return 0;
+  if( vb_extract( b, 14 ) !=bi[14] ) return 0;
+  if( vb_extract( b, 15 ) !=bi[15] ) return 0;
+
+  for( int j=0; j<16; j++ ) { _[0]=j; if( vb_extract_variable( b, _[0] )!=bi[j] ) return 0; }
+
+  vb_st(  m,     b ); /*   Aligned store to aligned   */
+  vb_stu( m+16,  b ); /* Unaligned store to aligned   */
+  vb_stu( m+33,  b ); /* Unaligned store to aligned+1 */
+  vb_stu( m+50,  b ); /* Unaligned store to aligned+2 */
+  vb_stu( m+67,  b ); /* Unaligned store to aligned+3 */
+  vb_stu( m+84,  b ); /* Unaligned store to aligned+4 */
+  vb_stu( m+101, b ); /* Unaligned store to aligned+5 */
+  vb_stu( m+118, b ); /* Unaligned store to aligned+6 */
+  vb_stu( m+135, b ); /* Unaligned store to aligned+7 */
+
+  g = vb_ld ( m     ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
+  g = vb_ldu( m+16  ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
+  g = vb_ldu( m+33  ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
+  g = vb_ldu( m+50  ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
+  g = vb_ldu( m+67  ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
+  g = vb_ldu( m+84  ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
+  g = vb_ldu( m+101 ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
+  g = vb_ldu( m+118 ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
+  g = vb_ldu( m+135 ); if( !vb_all( vb_eq( b, g ) ) ) return 0;
+
+  g = vb_zero();
+  g = vb_insert( g,  0, bi[ 0] );
+  g = vb_insert( g,  1, bi[ 1] );
+  g = vb_insert( g,  2, bi[ 2] );
+  g = vb_insert( g,  3, bi[ 3] );
+  g = vb_insert( g,  4, bi[ 4] );
+  g = vb_insert( g,  5, bi[ 5] );
+  g = vb_insert( g,  6, bi[ 6] );
+  g = vb_insert( g,  7, bi[ 7] );
+  g = vb_insert( g,  8, bi[ 8] );
+  g = vb_insert( g,  9, bi[ 9] );
+  g = vb_insert( g, 10, bi[10] );
+  g = vb_insert( g, 11, bi[11] );
+  g = vb_insert( g, 12, bi[12] );
+  g = vb_insert( g, 13, bi[13] );
+  g = vb_insert( g, 14, bi[14] );
+  g = vb_insert( g, 15, bi[15] ); if( vb_any( vb_ne( b, g ) ) ) return 0;
+
+  g = vb_zero();
+  for( int j=0; j<16; j++ ) { _[0]=j; g=vb_insert_variable( g, _[0], bi[j] ); }
+  if( vb_any( vb_ne( b, g ) ) ) return 0;
+
+  return 1;
+}
+
 #endif


### PR DESCRIPTION
(Part of the reedsol review)

- Completed the constructor family for making uchar SIMD vectors from 8 and/or 16 scalars and gave the constructors cleaned up consistent names (we should update existing SIMD constructors to use this more generalizable convention at some point).

- Naming consistency for right shifts shifts with wu_t and vu_t and filled in missing rotate support.

- Added some missing converters and made the converter macros robust (we should add converters from the other types into this type too at some point).

- Moved the vb_test to test_sse_common in anticipation of converters in the other direction.

- Test coverage updated to cover all the above.

- Minor comment cleanups.