### PR TITLE
ci: run tests as root

### DIFF
--- a/.github/workflows/make_test.yml
+++ b/.github/workflows/make_test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     defaults:
       run:
-        shell: bash --noprofile --norc -eo pipefail -c "set -ex; source /home/runner/firedancer-opts/activate-opt && chmod +x {0} && {0}"
+        shell: sudo bash --noprofile --norc -eo pipefail -c "set -ex; source /home/runner/firedancer-opts/activate-opt && chmod +x {0} && {0}"
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Does what it says on the tin. That's useful for the XDP tests.