### PR TITLE
build: add extra-brutality config

### DIFF
--- a/config/with-brutality.mk
+++ b/config/with-brutality.mk
@@ -12,21 +12,10 @@ ifdef FD_USING_CLANG
 
 CPPFLAGS+=-Wimplicit-fallthrough
 
-# Extra brutality
-#CPPFLAGS+=-Winline
-#CPPFLAGS+=-Wproperty-attribute-mismatch
-
 endif
 
 ifdef FD_USING_GCC
 
 CPPFLAGS+=-Wimplicit-fallthrough=2
-
-# Extra brutality
-#CPPFLAGS+=-Winline
-#CPPFLAGS+=-Wsuggest-attribute=pure
-#CPPFLAGS+=-Wsuggest-attribute=const
-#CPPFLAGS+=-Wsuggest-attribute=noreturn
-#CPPFLAGS+=-Wsuggest-attribute=format
 
 endif

--- a/config/with-extra-brutality.mk
+++ b/config/with-extra-brutality.mk
@@ -1,0 +1,16 @@
+ifdef FD_USING_CLANG
+
+CPPFLAGS+=-Winline
+CPPFLAGS+=-Wproperty-attribute-mismatch
+
+endif
+
+ifdef FD_USING_GCC
+
+CPPFLAGS+=-Winline
+CPPFLAGS+=-Wsuggest-attribute=pure
+CPPFLAGS+=-Wsuggest-attribute=const
+CPPFLAGS+=-Wsuggest-attribute=noreturn
+CPPFLAGS+=-Wsuggest-attribute=format
+
+endif


### PR DESCRIPTION
Moves some commented out flags into their own optional config.

To use this during build:

```
EXTRAS=extra-brutality make -j
```