### PR TITLE
Eliminate dependency on procps-ng

### DIFF
--- a/src/util/shmem/fd_shmem_cfg
+++ b/src/util/shmem/fd_shmem_cfg
@@ -110,9 +110,14 @@ init() {
         exit 1
       fi
     else
-      msz=`free -b | grep Mem | awk '{ print $2 }'` # FIXME: Ugly
+      msz=`awk '/^MemTotal:/ {print $2}' /proc/meminfo` # In KiB
       psz=`get_page_size $t`
-      msz=$((psz*(msz/psz))) # Round down to whole pages to be on safe side
+      msz=$((psz*((1024*msz)/psz))) # Round down to whole pages to be on safe side
+      if [ $msz -le 0 ]; then
+        echo "init $1 $2 $3: fail, msz calculation failed"
+        echo "Do $0 help for help"
+        exit 1
+      fi
       mount -v -t hugetlbfs -o pagesize=$psz,size=$msz none $MNT_PATH
       if [ "$?" != "0" ]; then
         echo "init $1 $2 $3: fail, mount failed"


### PR DESCRIPTION
Some minimal cloud host setups do not install "free" utility in procps-ng by default.  But fd_shmem_cfg used this to get the total amount of system memory (used to size the huge and gigantic hugetlbfs mounts).  And every time a dependency is eliminated an angel gets its wings.

This extracts the amount of system memory from /proc/meminfo instead (and also traps if this does not work).

Feels like there should be a simple method to robustly, portably and script-friendly query the amount of memory in the system and then without needing to scrape via tools like awk the value from diagnostic strings meant to be read by people.