### PR TITLE
sbpf: remove duplicate map typedefs

### DIFF
--- a/src/ballet/sbpf/fd_sbpf_maps.h
+++ b/src/ballet/sbpf/fd_sbpf_maps.h
@@ -1,20 +1,9 @@
 #ifndef HEADER_fd_src_ballet_sbpf_fd_sbpf_maps_h
 #define HEADER_fd_src_ballet_sbpf_fd_sbpf_maps_h
 
+#include "fd_sbpf_loader.h"
+
 /* fd_sbpf_maps defines map types that the loader and VM depend on. */
-
-/* fd_sbpf_calldests_t is a map type used to resolve sBPF call targets.
-   This is required because loaded sBPF bytecode does not directly call
-   relative addresses, but instead calls the Murmur3 hash of the
-   destination program counter.  This hash is not trivially reversible
-   thus we store all Murmur3(PC) => PC mappings in this map. */
-
-struct __attribute__((aligned(16UL))) fd_sbpf_calldests {
-  ulong key;  /* hash of PC */
-  /* FIXME salt map key with an add-rotate-xor */
-  ulong pc;
-};
-typedef struct fd_sbpf_calldests fd_sbpf_calldests_t;
 
 #define MAP_NAME         fd_sbpf_calldests
 #define MAP_T            fd_sbpf_calldests_t
@@ -48,12 +37,6 @@ fd_sbpf_calldests_upsert( fd_sbpf_calldests_t * calldests,
 
 /* FIXME */
 typedef void * fd_sbpf_syscall_func_t;
-
-struct __attribute__((aligned(16UL))) fd_sbpf_syscalls {
-  uint                   key;  /* Murmur3-32 hash of function name */
-  fd_sbpf_syscall_func_t func;
-};
-typedef struct fd_sbpf_syscalls fd_sbpf_syscalls_t;
 
 #define MAP_NAME              fd_sbpf_syscalls
 #define MAP_T                 fd_sbpf_syscalls_t


### PR DESCRIPTION
Types `fd_sbpf_calldests_t` and `fd_sbpf_syscalls_t` are defined twice.