### PR TITLE
fdctl: support bonded interface

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -144,7 +144,7 @@ scratch_directory = "/home/{user}/.firedancer/{name}"
     [tiles.quic]
         # Which interface to bind to. If developing under a network namespace with [netns] enabled,
         # this should be the same as [development.netns.interface0].
-        interface = "ens4"
+        interface = ""
 
         # Which port to listen on.
         listen_port = 9001

--- a/src/app/fdctl/src/commands/configure/large_pages.rs
+++ b/src/app/fdctl/src/commands/configure/large_pages.rs
@@ -5,7 +5,7 @@ use crate::security::*;
 use crate::utility::*;
 use crate::Config;
 
-const NAME: &str = "large_pages";
+const NAME: &str = "large-pages";
 
 pub(super) const STAGE: Stage = Stage {
     name: NAME,

--- a/src/app/fdctl/src/commands/configure/netns.rs
+++ b/src/app/fdctl/src/commands/configure/netns.rs
@@ -36,8 +36,11 @@ pub(crate) fn listen_address(config: &Config) -> String {
         config.development.netns.interface0_addr.to_string()
     } else {
         let output = run!("ip address show dev {interface}");
-        output.lines().find(|x| x.contains("inet "))
-            .unwrap().trim().split(&['/', ' ']).nth(1).unwrap().into()
+        let line = match output.lines().find(|x| x.contains("inet ")) {
+            None => panic!("Couldn't get IP address for interface `{interface}`"),
+            Some(line) => line,
+        };
+        line.trim().split(&['/', ' ']).nth(1).unwrap().into()
     }
 }
 
@@ -49,8 +52,11 @@ pub(crate) fn src_mac_address(config: &Config) -> String {
         config.development.netns.interface0_mac.to_string()
     } else {
         let output = run!("ip address show dev {interface}");
-        output.lines().find(|x| x.contains("link/ether "))
-            .unwrap().split_whitespace().nth(1).unwrap().into()
+        let line = match output.lines().find(|x| x.contains("link/ether ")) {
+            None => panic!("Couldn't get mac address for interface `{interface}`"),
+            Some(line) => line,
+        };
+        line.split_whitespace().nth(1).unwrap().into()
     }
 }
 

--- a/src/app/fdctl/src/commands/configure/xdp_leftover.rs
+++ b/src/app/fdctl/src/commands/configure/xdp_leftover.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::Config;
 
 pub(super) const STAGE: Stage = Stage {
-    name: "xdp_leftover",
+    name: "xdp-leftover",
     enabled: None,
     always_recreate: false,
     explain_init_permissions: None,

--- a/src/app/fdctl/src/config.rs
+++ b/src/app/fdctl/src/config.rs
@@ -67,11 +67,22 @@ impl UserConfig {
             self.user
         };
 
+        let interface = &self.tiles.quic.interface;
+        assert!(
+            !interface.is_empty(),
+            "Configuration must specify an interface to listen to with [tiles.quic.interface]"
+        );
+
         if self.development.netns.enabled {
             assert_eq!(
-                self.tiles.quic.interface, self.development.netns.interface0,
-                "if using [netns] expect [quic.interface] to be the same as \
+                interface, &self.development.netns.interface0,
+                "if using [netns] expect [tiles.quic.interface] to be the same as \
                  [development.netns.interface0]"
+            );
+        } else {
+            assert!(
+                interface_exists(interface),
+                "Configuration specifies a network interface \"{interface}\" which does not exist"
             );
         }
 


### PR DESCRIPTION
If we are using a bonded device, we need to ensure the number of channels on the underlying ethernet devices is the same as the number of QUIC tiles or we may drop packets when they get put into a queue we are not reading.