### PR TITLE
deps.sh: check for CMake on RHEL

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -113,7 +113,7 @@ fetch () {
 }
 
 check_fedora_pkgs () {
-  local REQUIRED_RPMS=( perl autoconf gettext-devel automake flex bison )
+  local REQUIRED_RPMS=( perl autoconf gettext-devel automake flex bison cmake )
 
   echo "[~] Checking for required RPM packages"
 
@@ -401,8 +401,8 @@ install_rocksdb () {
 }
 
 install () {
-  export CC=`which gcc` 
-  export cc=`which gcc` 
+  export CC=`which gcc`
+  export cc=`which gcc`
   ( install_zlib    )
   ( install_bzip2   )
   ( install_zstd    )


### PR DESCRIPTION
We sadly include RocksDB in our default deps.sh fetch,
so we should also mark CMake as a system-level tool dependency.
