### PR TITLE
ffi: export static inline functions

### DIFF
--- a/config/everything.mk
+++ b/config/everything.mk
@@ -108,6 +108,24 @@ endef
 add-objs = $(eval $(call _add-objs,$(1),$(2)))
 
 ##############################
+# Usage: $(call maybe-add-env-obj,env,lib)
+
+define _maybe-add-env-obj
+
+ifdef $(1)
+OBJ_FILE = $(patsubst %.c,%.o,$($(1)))
+
+$(OBJDIR)/lib/lib$(2).a: $(OBJ_FILE)
+
+$(OBJ_FILE): $($(1))
+	$(CC) -I.. $(CPPFLAGS) $(CFLAGS) -c $$< -o $$@
+endif
+
+endef
+
+maybe-add-env-obj = $(eval $(call _maybe-add-env-obj,$(1),$(2)))
+
+##############################
 # Usage: $(call add-asms,asms,lib)
 
 define _add-asms

--- a/config/with-ffi.mk
+++ b/config/with-ffi.mk
@@ -1,1 +1,3 @@
-CPPFLAGS+=-DFD_HAS_FFI=1 -fPIC
+# -Wno-pedantic is needed because bindgen::wrap_static_fns spits out code that
+# triggers a warning.
+CPPFLAGS+=-DFD_HAS_FFI=1 -fPIC -flto=thin -Wno-pedantic

--- a/ffi/rust/firedancer-diff/Cargo.toml
+++ b/ffi/rust/firedancer-diff/Cargo.toml
@@ -13,7 +13,7 @@ fuzz-asan = ["firedancer-sys/fuzz-asan"]
 [dependencies]
 diff = "0.1.13"
 hxdmp = "0.2.1"
-firedancer-sys = { path = "../firedancer-sys", version = "0.2.0" }
+firedancer-sys = { path = "../firedancer-sys", version = "0.3.0" }
 solana_rbpf = "0.3.0"
 solana-bpf-loader-program = { git = "https://github.com/solana-labs/solana", rev = "a674ffc9bda0c4535812a1c5e37398db9ba7be53", version = "1.16.0" }
 solana-logger = { git = "https://github.com/solana-labs/solana", rev = "a674ffc9bda0c4535812a1c5e37398db9ba7be53", version = "1.16.0" }

--- a/ffi/rust/firedancer-sys/Cargo.toml
+++ b/ffi/rust/firedancer-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firedancer-sys"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Firedancer Contributors <firedancer-devs@jumptrading.com>"]
 description = "Low-level Rust bindings for Firedancer"
@@ -10,7 +10,10 @@ include = [
     "src",
     "firedancer",
     "build.rs",
-    "wrapper.h",
+    "wrapper_ballet.h",
+    "wrapper_disco.h",
+    "wrapper_tango.h",
+    "wrapper_util.h",
 ]
 
 [features]
@@ -21,4 +24,4 @@ fuzz-asan = []
 paste = "1.0.12"
 
 [build-dependencies]
-bindgen = "0.65.1"
+bindgen = { version = "0.65.1", features = ["experimental"] }

--- a/ffi/rust/firedancer-sys/build.rs
+++ b/ffi/rust/firedancer-sys/build.rs
@@ -10,8 +10,6 @@ fn main() {
     let dir = Path::new(&dir_env);
     let out_dir = Path::new(&out_dir_env);
 
-    let firedancer_dir = dir.join("firedancer");
-
     let (machine, build_dir) = if cfg!(feature = "fuzz-asan") {
         (
             "linux_clang_fuzz_asan",
@@ -24,19 +22,121 @@ fn main() {
         )
     };
 
+    for lib in ["ballet", "disco", "tango", "util"] {
+        // Generate bindings to the header files
+        let mut builder = bindgen::Builder::default()
+            .wrap_static_fns(true)
+            .wrap_static_fns_path(out_dir.join(&format!("gen_{lib}.c")))
+            .allowlist_recursively(false)
+            .default_non_copy_union_style(bindgen::NonCopyUnionStyle::ManuallyDrop)
+            .header(&format!("wrapper_{lib}.h"))
+            .blocklist_type("schar|uchar|ushort|uint|ulong")
+            .blocklist_item("SORT_QUICK_ORDER_STYLE|SORT_MERGE_THRESH|SORT_QUICK_THRESH|SORT_QUICK_ORDER_STYLE|SORT_QUICK_SWAP_MINIMIZE");
+
+        // Well this is a complete mess. We want to only include, say, functions
+        // declared in the `ballet` directory in the ballet bindgen output. If
+        // we include all the util stuff that it #includes, it will get defined
+        // by every lib in turn and produce errors.
+        //
+        // Unfortunately, the only control we have over this is a regex "blocklist
+        // file". There's an "allow list" but it can only cause otherwise blocked
+        // items to be included, not being on the allow list doesn't make you
+        // blocked.
+        //
+        // So we have to use this blocklist. It's Rust regex crate, so no
+        // lookbehind so this is going to be pretty painful...
+        //
+        // It's annoying to debug as well. The easiest way I found is editing
+        // `context/item.rs` in the local bindgen crate source to add println!
+        // when it blocks or allows, and then scanning the build output file.
+        // If one of the regular expressions is not valid, bingden will just
+        // silently ignore all of the other blocklists and allow everything.
+        //
+        // // context/item.rs:652
+        // if let Some(filename) = file.name() {
+        //     if ctx.options().blocklisted_files.matches(&filename) {
+        //         println!("BLOCK true {}", filename);
+        //         return true;
+        //     }
+        //     println!("BLOCK false {}", filename);
+        // }
+        //
+        // All of our headers and code are referenced like `./firedancer/src/..`
+        // so if something does not start with `./` it's a system header and we
+        // should block it. Both of these two rules check this.
+        builder = builder.blocklist_file("[^\\.].*");
+        builder = builder.blocklist_file("\\.[^/].*");
+
+        // Now basically we want to say, if we are building `tango` we allow
+        // anything that looks like `./firedancer/src/tango/...`
+        //
+        // To do this with the blocklist, we just look at all the directories
+        // in `./firedancer/src/` that are not `tango`, and block those.
+        for dir in std::fs::read_dir("firedancer/src").unwrap() {
+            let dir = dir.unwrap().file_name();
+            let dir = dir.to_str().unwrap();
+            if dir != lib {
+                // Block all top level uses of other libraries.
+                builder = builder.blocklist_file(&format!("\\.firedancer/src/{}/.*", dir));
+
+                // Most includes are actually going to look like `.firedancer/src/tango/../util/`
+                // so it's not enough to check the `src/other` path. We also need to check that
+                // there is no `../other` for these other libraries.
+                //
+                // Well.. except a special case. If we are in a template file like `tmpl/fd_map.c`
+                // it actually *should* be exported, because even though it's kind-of declared in
+                // the util folder, it's unique to the #including lib.
+                if lib == "util" || dir != "util" {
+                    // `util` just shouldn't include `../tango` or anything else. And there
+                    // are no templates in non-util subdirs so block those.
+                    builder = builder.blocklist_file(&format!(".*/\\.\\./{}/.*", dir));
+                } else {
+                    // For the other packages, block if it's not ending in `/tmpl/*`
+                    // ./firedancer/src/ballet/sbpf/../../util/tmpl/fd_map.c -> allow
+                    // ./firedancer/src/ballet/sbpf/../../util/fd_util_base.h -> deny
+                    builder = builder.blocklist_file(".*/\\.\\./util/[^/]+");
+                    builder = builder.blocklist_file(".*/\\.\\./util/(.*/)?[^t][^/]+/[^/]+");
+                    builder = builder.blocklist_file(".*/\\.\\./util/(.*/)?t[^m][^/]+/[^/]+");
+                    builder = builder.blocklist_file(".*/\\.\\./util/(.*/)?tm[^p][^/]+/[^/]+");
+                    builder = builder.blocklist_file(".*/\\.\\./util/(.*/)?tmp[^l][^/]+/[^/]+");
+                    builder = builder.blocklist_file(".*/\\.\\./util/(.*/)?tmpl[^/][^/]+/[^/]+");
+                }
+
+                // Only declare templates that are actually defined in this library,
+                // deny ones that come from some other include. Eg, below the template
+                // comes from util/math not ballet, so we don't want it.
+                // ./firedancer/src/ballet/../util/math/../tmpl/fd_sort.c -> deny
+                builder = builder.blocklist_file(&format!(".*\\.\\./{}/.*/tmpl/[^/]+", dir));
+            }
+        }
+
+        builder
+            .generate()
+            .expect("Unable to generate bindings")
+            .write_to_file(out_dir.join(&format!("bindings_{lib}.rs")))
+            .expect("Failed to write bindings to file");
+    }
+
     // Build the Firedancer sources
     let output = Command::new("make")
         .arg("-j")
         .arg("lib")
         .arg("include")
-        .current_dir(&firedancer_dir)
+        .current_dir(&dir.join("firedancer"))
+        .env("UTIL_STATIC_EXTERN_OBJECT", out_dir.join("gen_util.c"))
+        .env("TANGO_STATIC_EXTERN_OBJECT", out_dir.join("gen_tango.c"))
+        // No statics in disco yet so no extern wrapper file is produced
+        // .env("DISCO_STATIC_EXTERN_OBJECT", out_dir.join("gen_disco.c"))
+        .env("BALLET_STATIC_EXTERN_OBJECT", out_dir.join("gen_ballet.c"))
         .env("MACHINE", machine)
         .env("BASEDIR", out_dir.join("build"))
         .output()
-        .expect(&format!(
-            "failed to execute `make`, does it exist? PATH {:#?}",
-            std::env::var("PATH")
-        ));
+        .unwrap_or_else(|_| {
+            panic!(
+                "failed to execute `make`, does it exist? PATH {:#?}",
+                std::env::var("PATH")
+            )
+        });
     if !output.status.success() {
         panic!("{}", String::from_utf8(output.stderr).unwrap());
     }
@@ -51,7 +151,7 @@ fn main() {
     );
     println!(
         "cargo:rerun-if-changed={}",
-        build_dir
+        dir.join("firedancer")
             .to_str()
             .expect("failed to convert path to string")
     );
@@ -60,13 +160,4 @@ fn main() {
     println!("cargo:rustc-link-lib=static=fd_disco");
     println!("cargo:rustc-link-lib=static=fd_ballet");
     println!("cargo:rustc-link-lib=stdc++");
-
-    // Generate bindings to the header files
-    bindgen::Builder::default()
-        .header("wrapper.h")
-        .blocklist_type("schar|uchar|ushort|uint|ulong")
-        .generate()
-        .expect("Unable to generate bindings")
-        .write_to_file(out_dir.join("bindings.rs"))
-        .expect("Failed to write bindings to file");
 }

--- a/ffi/rust/firedancer-sys/src/ballet/sbpf.rs
+++ b/ffi/rust/firedancer-sys/src/ballet/sbpf.rs
@@ -1,5 +1,3 @@
-use std::ffi::c_void;
-
 pub use crate::generated::{
     fd_sbpf_calldests_t,
     fd_sbpf_elf_info_t,
@@ -11,25 +9,10 @@ pub use crate::generated::{
     fd_sbpf_program_new,
     fd_sbpf_program_t,
     fd_sbpf_strerror,
+    fd_sbpf_syscalls_align,
+    fd_sbpf_syscalls_delete,
+    fd_sbpf_syscalls_footprint,
+    fd_sbpf_syscalls_insert,
+    fd_sbpf_syscalls_new,
     fd_sbpf_syscalls_t,
 };
-
-extern "C" {
-    #[link_name = "fd_sbpf_syscalls_align_ext"]
-    pub fn fd_sbpf_syscalls_align() -> usize;
-
-    #[link_name = "fd_sbpf_syscalls_footprint_ext"]
-    pub fn fd_sbpf_syscalls_footprint() -> usize;
-
-    #[link_name = "fd_sbpf_syscalls_new_ext"]
-    pub fn fd_sbpf_syscalls_new(_: *mut c_void) -> *mut fd_sbpf_syscalls_t;
-
-    #[link_name = "fd_sbpf_syscalls_delete_ext"]
-    pub fn fd_sbpf_syscalls_delete(_: *mut fd_sbpf_syscalls_t) -> *mut c_void;
-
-    #[link_name = "fd_sbpf_syscalls_insert_ext"]
-    pub fn fd_sbpf_syscalls_insert(
-        syscalls: *mut fd_sbpf_syscalls_t,
-        syscall_id: u32,
-    ) -> *mut fd_sbpf_syscalls_t;
-}

--- a/ffi/rust/firedancer-sys/src/lib.rs
+++ b/ffi/rust/firedancer-sys/src/lib.rs
@@ -14,7 +14,13 @@ mod generated {
     type uint = u32;
     type ulong = u64;
 
-    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+    type __m128i = [::std::os::raw::c_longlong; 2usize];
+    type __m256i = [::std::os::raw::c_longlong; 4usize];
+
+    include!(concat!(env!("OUT_DIR"), "/bindings_util.rs"));
+    include!(concat!(env!("OUT_DIR"), "/bindings_ballet.rs"));
+    include!(concat!(env!("OUT_DIR"), "/bindings_disco.rs"));
+    include!(concat!(env!("OUT_DIR"), "/bindings_tango.rs"));
 }
 
 pub mod ballet;

--- a/ffi/rust/firedancer-sys/src/tango/cnc.rs
+++ b/ffi/rust/firedancer-sys/src/tango/cnc.rs
@@ -1,13 +1,14 @@
-use std::os::raw::c_void;
-use std::sync::atomic::{
-    compiler_fence,
-    Ordering,
-};
-
 pub use crate::generated::{
     fd_cnc_align,
+    fd_cnc_app_laddr,
+    fd_cnc_app_laddr_const,
+    fd_cnc_app_sz,
+    fd_cnc_close,
     fd_cnc_delete,
     fd_cnc_footprint,
+    fd_cnc_heartbeat,
+    fd_cnc_heartbeat0,
+    fd_cnc_heartbeat_query,
     fd_cnc_join,
     fd_cnc_leave,
     fd_cnc_new,
@@ -15,6 +16,7 @@ pub use crate::generated::{
     fd_cnc_signal_cstr,
     fd_cnc_strerror,
     fd_cnc_t,
+    fd_cnc_type,
     fd_cnc_wait,
     fd_cstr_to_cnc_signal,
     FD_CNC_ALIGN,
@@ -33,50 +35,3 @@ pub use crate::generated::{
     FD_CNC_SIGNAL_RUN,
     FD_CNC_SUCCESS,
 };
-
-#[inline(always)]
-pub unsafe fn fd_cnc_app_sz(cnc: *const fd_cnc_t) -> u64 {
-    (*cnc).app_sz
-}
-
-#[inline(always)]
-pub unsafe fn fd_cnc_app_laddr(cnc: *mut fd_cnc_t) -> *mut c_void {
-    (cnc as *mut u8).add(64usize) as *mut c_void
-}
-
-#[inline(always)]
-pub unsafe fn fd_cnc_app_laddr_const(cnc: *const fd_cnc_t) -> *const c_void {
-    (cnc as *const u8).add(64usize) as *const c_void
-}
-
-#[inline(always)]
-pub unsafe fn fd_cnc_type(cnc: *const fd_cnc_t) -> u64 {
-    (*cnc).type_
-}
-
-#[inline(always)]
-pub unsafe fn fd_cnc_heartbeat0(cnc: *const fd_cnc_t) -> i64 {
-    (*cnc).heartbeat0
-}
-
-#[inline(always)]
-pub unsafe fn fd_cnc_heartbeat_query(cnc: *const fd_cnc_t) -> i64 {
-    compiler_fence(Ordering::AcqRel);
-    let then = (*cnc).heartbeat;
-    compiler_fence(Ordering::AcqRel);
-    then
-}
-
-#[inline(always)]
-pub unsafe fn fd_cnc_heartbeat(cnc: *mut fd_cnc_t, now: i64) {
-    compiler_fence(Ordering::AcqRel);
-    (*cnc).heartbeat = now;
-    compiler_fence(Ordering::AcqRel);
-}
-
-#[inline(always)]
-pub unsafe fn fd_cnc_close(cnc: *mut fd_cnc_t) {
-    compiler_fence(Ordering::AcqRel);
-    (*cnc).lock = 0u64;
-    compiler_fence(Ordering::AcqRel);
-}

--- a/ffi/rust/firedancer-sys/src/tango/dcache.rs
+++ b/ffi/rust/firedancer-sys/src/tango/dcache.rs
@@ -1,11 +1,9 @@
-use std::os::raw::c_void;
-
-use crate::generated::FD_CHUNK_LG_SZ;
 pub use crate::generated::{
     fd_dcache_align,
     fd_dcache_app_laddr,
     fd_dcache_app_laddr_const,
     fd_dcache_app_sz,
+    fd_dcache_compact_chunk0,
     fd_dcache_compact_is_safe,
     fd_dcache_data_sz,
     fd_dcache_delete,
@@ -17,8 +15,3 @@ pub use crate::generated::{
     FD_DCACHE_ALIGN,
     FD_DCACHE_GUARD_FOOTPRINT,
 };
-
-#[inline(always)]
-pub fn fd_dcache_compact_chunk0(base: *const c_void, dcache: *const c_void) -> usize {
-    ((dcache as usize) - (base as usize)) >> FD_CHUNK_LG_SZ
-}

--- a/ffi/rust/firedancer-sys/src/tango/fseq.rs
+++ b/ffi/rust/firedancer-sys/src/tango/fseq.rs
@@ -1,16 +1,14 @@
-use std::ffi::c_void;
-use std::sync::atomic::{
-    compiler_fence,
-    Ordering,
-};
-
 pub use crate::generated::{
     fd_fseq_align,
+    fd_fseq_app_laddr_const,
     fd_fseq_delete,
     fd_fseq_footprint,
     fd_fseq_join,
     fd_fseq_leave,
     fd_fseq_new,
+    fd_fseq_query,
+    fd_fseq_seq0,
+    fd_fseq_update,
     FD_FSEQ_ALIGN,
     FD_FSEQ_APP_ALIGN,
     FD_FSEQ_APP_FOOTPRINT,
@@ -23,26 +21,3 @@ pub use crate::generated::{
     FD_FSEQ_DIAG_SLOW_CNT,
     FD_FSEQ_FOOTPRINT,
 };
-
-pub unsafe fn fd_fseq_app_laddr_const(fseq: *const u64) -> *const c_void {
-    fseq.add(2) as *const c_void
-}
-
-pub unsafe fn fd_fseq_seq0(fseq: *const u64) -> u64 {
-    *fseq.sub(1)
-}
-
-#[inline(always)]
-pub unsafe fn fd_fseq_query(fseq: *const u64) -> u64 {
-    compiler_fence(Ordering::AcqRel);
-    let res = *fseq;
-    compiler_fence(Ordering::AcqRel);
-    res
-}
-
-#[inline(always)]
-pub unsafe fn fd_fseq_update(fseq: *mut u64, seq: u64) {
-    compiler_fence(Ordering::AcqRel);
-    *fseq = seq;
-    compiler_fence(Ordering::AcqRel);
-}

--- a/ffi/rust/firedancer-sys/src/tango/mcache.rs
+++ b/ffi/rust/firedancer-sys/src/tango/mcache.rs
@@ -1,8 +1,3 @@
-use std::sync::atomic::{
-    compiler_fence,
-    Ordering,
-};
-
 pub use crate::generated::{
     fd_frag_meta_t,
     fd_mcache_align,
@@ -14,62 +9,17 @@ pub use crate::generated::{
     fd_mcache_footprint,
     fd_mcache_join,
     fd_mcache_leave,
+    fd_mcache_line_idx,
     fd_mcache_new,
+    fd_mcache_publish,
     fd_mcache_seq0,
     fd_mcache_seq_laddr,
     fd_mcache_seq_laddr_const,
+    fd_mcache_seq_query,
+    fd_mcache_seq_update,
     FD_MCACHE_ALIGN,
     FD_MCACHE_BLOCK,
     FD_MCACHE_LG_BLOCK,
     FD_MCACHE_LG_INTERLEAVE,
     FD_MCACHE_SEQ_CNT,
 };
-
-#[inline(always)]
-pub unsafe fn fd_mcache_seq_query(seq_ptr: *const u64) -> u64 {
-    compiler_fence(Ordering::AcqRel);
-    let ret = *seq_ptr;
-    compiler_fence(Ordering::AcqRel);
-    ret
-}
-
-#[inline(always)]
-pub unsafe fn fd_mcache_seq_update(seq_ptr: *mut u64, seq: u64) {
-    compiler_fence(Ordering::AcqRel);
-    *seq_ptr = seq;
-    compiler_fence(Ordering::AcqRel);
-}
-
-#[inline(always)]
-pub unsafe fn fd_mcache_line_idx(seq: u64, depth: u64) -> u64 {
-    seq & (depth.wrapping_sub(1u64))
-}
-
-#[inline]
-pub unsafe fn fd_mcache_publish(
-    mcache: *mut fd_frag_meta_t,
-    depth: u64,
-    seq: u64,
-    sig: u64,
-    chunk: u64,
-    sz: u64,
-    ctl: u64,
-    tsorig: u64,
-    tspub: u64,
-) {
-    let meta_union = mcache.add(fd_mcache_line_idx(seq, depth) as usize);
-    let meta = (*meta_union).__bindgen_anon_1.as_mut();
-
-    compiler_fence(Ordering::AcqRel);
-    meta.seq = seq.wrapping_sub(1u64);
-    compiler_fence(Ordering::AcqRel);
-    meta.sig = sig;
-    meta.chunk = chunk as u32;
-    meta.sz = sz as u16;
-    meta.ctl = ctl as u16;
-    meta.tsorig = tsorig as u32;
-    meta.tspub = tspub as u32;
-    compiler_fence(Ordering::AcqRel);
-    meta.seq = seq;
-    compiler_fence(Ordering::AcqRel);
-}

--- a/ffi/rust/firedancer-sys/src/util/bits.rs
+++ b/ffi/rust/firedancer-sys/src/util/bits.rs
@@ -1,43 +1,6 @@
-#[inline]
-pub unsafe fn fd_ulong_svw_dec_sz(b: *const u8) -> u64 {
-    (0x9131512181314121u64 >> ((*(b as *const u64) & 15u64) << 2)) & 15u64
-}
-
-#[inline]
-pub unsafe fn fd_ulong_svw_dec_fixed(b: *const u8, csz: u64) -> u64 {
-    match csz {
-        1 => (*b as u64) >> 1,
-        2 => ((*(b as *const u16) as u64) >> 3) & 1023,
-        3 => ((*(b as *const u16) as u64) >> 3) | (((*(b.offset(2)) as u64) & 0x1f) << 13),
-        4 => ((*(b as *const u32) as u64) >> 4) & 16777215,
-        5 => ((*(b as *const u32) as u64) >> 4) | (((*(b.offset(4)) as u64) & 0x0f) << 28),
-        8 => (*(b as *const u64) >> 4) & 72057594037927935,
-        _ => (*(b as *const u64) >> 4) | ((*(b.offset(8)) as u64) << 60),
-    }
-}
-
-#[inline]
-pub unsafe fn fd_ulong_svw_dec(b: *const u8, x: *mut u64) -> *const u8 {
-    let csz: u64 = fd_ulong_svw_dec_sz(b);
-    *x = fd_ulong_svw_dec_fixed(b, csz);
-    b.offset(csz as isize)
-}
-
-#[inline]
-pub fn fd_long_zz_dec(x: u64) -> i64 {
-    ((x >> 1) ^ (0u64.wrapping_sub(x & 1u64))) as i64
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_fd_long_zz_dec() {
-        assert_eq!(fd_long_zz_dec(0), 0);
-        assert_eq!(fd_long_zz_dec(1), -1);
-        assert_eq!(fd_long_zz_dec(2), 1);
-        assert_eq!(fd_long_zz_dec(u64::MAX), i64::MIN);
-        assert_eq!(fd_long_zz_dec(u64::MAX - 1), i64::MAX);
-    }
-}
+pub use crate::generated::{
+    fd_long_zz_dec,
+    fd_ulong_svw_dec,
+    fd_ulong_svw_dec_fixed,
+    fd_ulong_svw_dec_sz,
+};

--- a/ffi/rust/firedancer-sys/src/util/pod.rs
+++ b/ffi/rust/firedancer-sys/src/util/pod.rs
@@ -1,13 +1,19 @@
-use std::ffi::c_void;
-use std::ptr::{
-    null,
-    null_mut,
-};
-
 pub use crate::generated::{
     fd_pod_cnt_subpod,
     fd_pod_info_t,
     fd_pod_query,
+    fd_pod_query_buf,
+    fd_pod_query_char,
+    fd_pod_query_cstr,
+    fd_pod_query_int,
+    fd_pod_query_long,
+    fd_pod_query_schar,
+    fd_pod_query_short,
+    fd_pod_query_subpod,
+    fd_pod_query_uchar,
+    fd_pod_query_uint,
+    fd_pod_query_ulong,
+    fd_pod_query_ushort,
     FD_POD_VAL_TYPE_BUF,
     FD_POD_VAL_TYPE_CHAR,
     FD_POD_VAL_TYPE_CSTR,
@@ -25,115 +31,3 @@ pub use crate::generated::{
     FD_POD_VAL_TYPE_ULONG,
     FD_POD_VAL_TYPE_USHORT,
 };
-
-impl Default for fd_pod_info_t {
-    fn default() -> Self {
-        Self {
-            key_sz: 0,
-            key: null(),
-            val_type: 0,
-            val_sz: 0,
-            val: null(),
-            parent: null_mut(),
-        }
-    }
-}
-
-macro_rules! impl_query {
-    ( $name:ident, $type:ty, { $($value:tt)* }) => {
-        paste::paste! {
-            #[inline]
-            pub unsafe fn [<fd_pod_query_ $name>](
-                pod: *const u8,
-                path: *const i8,
-                default: $type
-            ) -> $type {
-                let mut info: fd_pod_info_t = fd_pod_info_t::default();
-                if fd_pod_query(pod, path, &mut info) != 0 || info.val_type != [<FD_POD_VAL_TYPE_ $name:upper>] as i32 {
-                    return default;
-                }
-                $($value)*
-                val(&info)
-            }
-        }
-    };
-}
-
-macro_rules! impl_query_pun {
-    ( $name:ident, $type:ty ) => {
-        impl_query!($name, $type, {
-            unsafe fn val(info: &fd_pod_info_t) -> $type {
-                *(info.val as *const $type)
-            }
-        });
-    };
-}
-
-impl_query_pun!(char, char);
-impl_query_pun!(schar, char);
-impl_query_pun!(uchar, u8);
-
-macro_rules! impl_query_svw_dec {
-    ( $name:ident, $type:ty ) => {
-        impl_query!($name, $type, {
-            unsafe fn val(info: &fd_pod_info_t) -> $type {
-                let mut u: u64 = 0;
-                let _ = super::bits::fd_ulong_svw_dec(info.val as *const u8, &mut u);
-                u as $type
-            }
-        });
-    };
-}
-
-impl_query_svw_dec!(ushort, u16);
-impl_query_svw_dec!(uint, u32);
-impl_query_svw_dec!(ulong, u64);
-
-macro_rules! impl_query_svw_zz_dec {
-    ( $name:ident, $type:ty ) => {
-        impl_query!($name, $type, {
-            unsafe fn val(info: &fd_pod_info_t) -> $type {
-                let mut u: u64 = 0;
-                let _ = super::bits::fd_ulong_svw_dec(info.val as *const u8, &mut u);
-                super::bits::fd_long_zz_dec(u) as $type
-            }
-        });
-    };
-}
-
-impl_query_svw_zz_dec!(short, i16);
-impl_query_svw_zz_dec!(int, i32);
-impl_query_svw_zz_dec!(long, i64);
-
-pub unsafe fn fd_pod_query_subpod(pod: *const u8, path: *const i8) -> *const u8 {
-    let mut info: fd_pod_info_t = fd_pod_info_t::default();
-    if fd_pod_query(pod, path, &mut info) != 0 || info.val_type != FD_POD_VAL_TYPE_SUBPOD as i32 {
-        return null();
-    }
-    info.val as *const u8
-}
-
-pub unsafe fn fd_pod_query_buf(
-    pod: *const u8,
-    path: *const i8,
-    opt_buf_sz: *mut u64,
-) -> *const c_void {
-    let mut info: fd_pod_info_t = fd_pod_info_t::default();
-    if fd_pod_query(pod, path, &mut info) != 0 || info.val_type != FD_POD_VAL_TYPE_BUF as i32 {
-        return null();
-    }
-    if !opt_buf_sz.is_null() {
-        *opt_buf_sz = info.val_sz;
-    }
-    info.val
-}
-
-impl_query!(cstr, *const char, {
-    unsafe fn val(info: &fd_pod_info_t) -> *const char {
-        if info.val_sz > 0 {
-            info.val as *const char
-        } else {
-            null()
-        }
-    }
-});

--- a/ffi/rust/firedancer-sys/src/util/shmem.rs
+++ b/ffi/rust/firedancer-sys/src/util/shmem.rs
@@ -10,6 +10,7 @@ pub use crate::generated::{
 };
 // Administrative APIs
 pub use crate::generated::{
+    fd_shmem_create,
     fd_shmem_create_multi,
     fd_shmem_info,
     fd_shmem_name_len,
@@ -29,14 +30,3 @@ pub use crate::generated::{
     fd_shmem_leave,
     fd_shmem_leave_anonymous,
 };
-
-#[inline]
-pub unsafe fn fd_shmem_create(
-    name: *const i8,
-    page_sz: u64,
-    page_cnt: u64,
-    cpu_idx: u64,
-    mode: u64,
-) -> i32 {
-    unsafe { fd_shmem_create_multi(name, page_sz, 1, &page_cnt, &cpu_idx, mode) }
-}

--- a/ffi/rust/firedancer-sys/src/util/wksp.rs
+++ b/ffi/rust/firedancer-sys/src/util/wksp.rs
@@ -1,5 +1,6 @@
 pub use crate::generated::{
     fd_wksp_align,
+    fd_wksp_alloc,
     fd_wksp_alloc_at_least,
     fd_wksp_alloc_laddr,
     fd_wksp_attach,
@@ -28,10 +29,3 @@ pub use crate::generated::{
     fd_wksp_t,
     fd_wksp_unmap,
 };
-
-#[inline]
-pub unsafe fn fd_wksp_alloc(wksp: *mut fd_wksp_t, align: u64, sz: u64, tag: u64) -> u64 {
-    let mut lo = 0u64;
-    let mut hi = 0u64;
-    unsafe { fd_wksp_alloc_at_least(wksp, align, sz, tag, &mut lo, &mut hi) }
-}

--- a/ffi/rust/firedancer-sys/wrapper_ballet.h
+++ b/ffi/rust/firedancer-sys/wrapper_ballet.h
@@ -4,16 +4,16 @@
 #define FD_HAS_ATOMIC    1
 #define FD_HAS_THREADS   1
 #define FD_USE_ATTR_WEAK 1
+#define FD_HAS_INT128    1
+#define FD_HAS_DOUBLE    1
+#define FD_HAS_ALLOCA    1
+#define FD_HAS_SSE       1
+#define FD_HAS_AVX       1
+#define FD_HAS_SHANI     1
+#define FD_HAS_GFNI      1
 
-#include "firedancer/src/util/fd_util.h"
-#include "firedancer/src/tango/fd_tango.h"
 #include "firedancer/src/ballet/fd_ballet.h"
 #include "firedancer/src/ballet/sbpf/fd_sbpf_loader.h"
+#include "firedancer/src/ballet/sbpf/fd_sbpf_maps.c"
 #include "firedancer/src/ballet/shred/fd_shred.h"
 #include "firedancer/src/ballet/txn/fd_txn.h"
-#include "firedancer/src/disco/fd_disco.h"
-#include "firedancer/src/tango/xdp/fd_xdp.h"
-
-#if FD_MCACHE_LG_INTERLEAVE
-#error "FD_MCACHE_LG_INTERLEAVE unsupported"
-#endif

--- a/ffi/rust/firedancer-sys/wrapper_disco.h
+++ b/ffi/rust/firedancer-sys/wrapper_disco.h
@@ -1,0 +1,15 @@
+// Define all C feature flags, as we'll manage features via Rust.
+#define FD_HAS_HOSTED    1
+#define FD_HAS_X86       1
+#define FD_HAS_ATOMIC    1
+#define FD_HAS_THREADS   1
+#define FD_USE_ATTR_WEAK 1
+#define FD_HAS_INT128    1
+#define FD_HAS_DOUBLE    1
+#define FD_HAS_ALLOCA    1
+#define FD_HAS_SSE       1
+#define FD_HAS_AVX       1
+#define FD_HAS_SHANI     1
+#define FD_HAS_GFNI      1
+
+#include "firedancer/src/disco/fd_disco.h"

--- a/ffi/rust/firedancer-sys/wrapper_tango.h
+++ b/ffi/rust/firedancer-sys/wrapper_tango.h
@@ -1,0 +1,16 @@
+// Define all C feature flags, as we'll manage features via Rust.
+#define FD_HAS_HOSTED    1
+#define FD_HAS_X86       1
+#define FD_HAS_ATOMIC    1
+#define FD_HAS_THREADS   1
+#define FD_USE_ATTR_WEAK 1
+#define FD_HAS_INT128    1
+#define FD_HAS_DOUBLE    1
+#define FD_HAS_ALLOCA    1
+#define FD_HAS_SSE       1
+#define FD_HAS_AVX       1
+#define FD_HAS_SHANI     1
+#define FD_HAS_GFNI      1
+
+#include "firedancer/src/tango/fd_tango.h"
+#include "firedancer/src/tango/xdp/fd_xdp.h"

--- a/ffi/rust/firedancer-sys/wrapper_util.h
+++ b/ffi/rust/firedancer-sys/wrapper_util.h
@@ -1,0 +1,19 @@
+// Define all C feature flags, as we'll manage features via Rust.
+#define FD_HAS_HOSTED    1
+#define FD_HAS_X86       1
+#define FD_HAS_ATOMIC    1
+#define FD_HAS_THREADS   1
+#define FD_USE_ATTR_WEAK 1
+#define FD_HAS_INT128    1
+#define FD_HAS_DOUBLE    1
+#define FD_HAS_ALLOCA    1
+#define FD_HAS_SSE       1
+#define FD_HAS_AVX       1
+#define FD_HAS_SHANI     1
+#define FD_HAS_GFNI      1
+
+#include "firedancer/src/util/fd_util.h"
+
+#if FD_MCACHE_LG_INTERLEAVE
+#error "FD_MCACHE_LG_INTERLEAVE unsupported"
+#endif

--- a/src/ballet/Local.mk
+++ b/src/ballet/Local.mk
@@ -1,3 +1,3 @@
 $(call make-lib,fd_ballet)
 $(call add-hdrs,fd_ballet_base.h fd_ballet.h)
-
+$(call maybe-add-env-obj,BALLET_STATIC_EXTERN_OBJECT,fd_ballet)

--- a/src/ballet/sbpf/fd_sbpf_loader.c
+++ b/src/ballet/sbpf/fd_sbpf_loader.c
@@ -1185,14 +1185,3 @@ fd_sbpf_program_load( fd_sbpf_program_t *  prog,
 #undef ERR
 #undef FAIL
 #undef REQUIRE
-
-/* Declare extern symbol definitions for static inlines */
-
-__attribute__((alias("fd_sbpf_syscalls_align"    ),const)) extern __typeof__(fd_sbpf_syscalls_align    ) fd_sbpf_syscalls_align_ext;
-__attribute__((alias("fd_sbpf_syscalls_footprint"),const)) extern __typeof__(fd_sbpf_syscalls_footprint) fd_sbpf_syscalls_footprint_ext;
-__attribute__((alias("fd_sbpf_syscalls_new"      )      )) extern __typeof__(fd_sbpf_syscalls_new      ) fd_sbpf_syscalls_new_ext;
-__attribute__((alias("fd_sbpf_syscalls_insert"   )      )) extern __typeof__(fd_sbpf_syscalls_insert   ) fd_sbpf_syscalls_insert_ext;
-__attribute__((alias("fd_sbpf_syscalls_delete"   )      )) extern __typeof__(fd_sbpf_syscalls_delete   ) fd_sbpf_syscalls_delete_ext;
-__attribute__((alias("fd_sbpf_program_align"     ),const)) extern __typeof__(fd_sbpf_program_align     ) fd_sbpf_program_align_ext;
-__attribute__((alias("fd_sbpf_program_footprint" ),pure )) extern __typeof__(fd_sbpf_program_footprint ) fd_sbpf_program_footprint_ext;
-

--- a/src/disco/Local.mk
+++ b/src/disco/Local.mk
@@ -1,5 +1,6 @@
 $(call make-lib,fd_disco)
 $(call add-hdrs,fd_disco_base.h fd_disco.h)
+$(call maybe-add-env-obj,DISCO_STATIC_EXTERN_OBJECT,fd_disco)
 $(call make-unit-test,test_disco_base,test_disco_base,fd_disco fd_tango fd_util)
 $(call run-unit-test,test_disco_base,)
 

--- a/src/tango/Local.mk
+++ b/src/tango/Local.mk
@@ -1,5 +1,6 @@
 $(call make-lib,fd_tango)
 $(call add-hdrs,fd_tango_base.h fd_tango.h)
+$(call maybe-add-env-obj,TANGO_STATIC_EXTERN_OBJECT,fd_tango)
 $(call make-bin,fd_tango_ctl,fd_tango_ctl,fd_tango fd_util)
 $(call make-unit-test,test_tango_base,test_tango_base,fd_tango fd_util)
 $(call make-unit-test,test_meta_tx,test_meta_tx,fd_tango fd_util)

--- a/src/util/Local.mk
+++ b/src/util/Local.mk
@@ -1,6 +1,7 @@
 $(call make-lib,fd_util)
 $(call add-hdrs,fd_util_base.h fd_util.h)
 $(call add-objs,fd_hash fd_util,fd_util)
+$(call maybe-add-env-obj,UTIL_STATIC_EXTERN_OBJECT,fd_util)
 $(call make-unit-test,test_util_base,test_util_base,fd_util)
 $(call make-unit-test,test_util,test_util,fd_util)
 $(call run-unit-test,test_util_base,)


### PR DESCRIPTION
An extreme pain. More painful than it should be. The problem here is we want to call static inline functions from Rust, but the Rust C ffi is link time, not compile time, so the static inline symbols do not exist.

Bindgen has an experimental `wrap_static_fns` flag which basically, for every `static inline fn()` it sees when parsing, spits out a `fn_extern()` implementation with extern linkage, which just calls the `static inline`. It dumps these functions into a translation unit we give it.

Here's a problem. It produces just one TU, but we have several libraries. If we include the same TU in each of the libraries, we won't be able to link them, since they redefine the same symbols.

To fix this, ideally we will just call bindgen four times, and produce four separate TUs, each with just the `extern inline` functions we want in that library, and then link the right one into each library.

This is ... possible, but bindgen just parses includes, it has no knowledge of our library structure. Maybe there's a better way to do this but the only way I found to have bindgen just produce output for the library was using a file name blocklist, blocking any symbols in a file not under the right directory. There's a few gotchas with this around templates which kind of should be exported even though they are "defined" by a file in another libraries directory.

This also fixes an issue with the existing ffi library, it was pretty big because it included a whole lot of garbage from system headers and so on. Now it just exports the Firedancer symbols.

Apparently, if using thinlto, which I enabled, these generated wrapper functions will also get optimized out but I haven't verified this.