### PR TITLE
fix: openssl-req v3 (for CA:false)

### DIFF
--- a/contrib/gen-pem-cert.sh
+++ b/contrib/gen-pem-cert.sh
@@ -7,4 +7,4 @@ set -e
 
 openssl req -x509 -newkey ed25519 -days 365 -nodes \
   -keyout key.pem -out cert.pem -subj "/CN=localhost" \
-  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1 -extensions v3-req"

--- a/src/app/fdctl/src/commands/configure/certs.rs
+++ b/src/app/fdctl/src/commands/configure/certs.rs
@@ -22,7 +22,7 @@ fn step(config: &mut Config) {
     run!(
         cwd = scratch,
         "openssl req -x509 -newkey ed25519 -days 365 -nodes -keyout key.pem -out cert.pem -subj \
-         /CN=localhost -addext subjectAltName=DNS:localhost,IP:127.0.0.1"
+         /CN=localhost -addext subjectAltName=DNS:localhost,IP:127.0.0.1 -extensions v3-req"
     );
     repermission(format!("{scratch}/key.pem"), config.uid, config.uid, 0o600);
     repermission(format!("{scratch}/cert.pem"), config.uid, config.uid, 0o664);


### PR DESCRIPTION
Add `-extensions v3_req` so that the generated cert is set to `CA:false`