### PR TITLE
sandbox: belt sanding sketch

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -320,6 +320,12 @@ scratch_directory = "/home/{user}/.firedancer/{name}"
         signature_cache_size = 4194302
 
 [development]
+    # For enhanced security, Firedancer runs itself in a restrictive sandbox in production. The
+    # sandbox prevents most system calls and restricts the capabilities of the process after
+    # initialization to make the attack surface smaller. This is required in production, but might
+    # be too restrictive during development.
+    sandbox = true
+
     # Firedancer requires some privileges for normal operation. In production it will not attempt
     # to acquire these, and must be either be run as root, or have the capabilities set on the
     # binary. During development it can be useful for Firedancer to rerun itself as root if it does

--- a/src/app/fdctl/config/development.toml
+++ b/src/app/fdctl/config/development.toml
@@ -1,5 +1,6 @@
 [development]
     sudo = true
+    sandbox = false
     [development.netns]
         enabled = true
 [tiles.quic]

--- a/src/app/fdctl/src/config.rs
+++ b/src/app/fdctl/src/config.rs
@@ -249,6 +249,7 @@ config_struct!(DedupConfig {
 
 config_struct!(DevelopmentConfig {
     {
+        sandbox: bool,
         sudo: bool
     }
     netns: NetNsConfig

--- a/src/app/frank/fd_frank_mon.bin.c
+++ b/src/app/frank/fd_frank_mon.bin.c
@@ -317,17 +317,22 @@ snap( ulong             tile_cnt,     /* Number of tiles to snapshot */
 int
 main( int     argc,
       char ** argv ) {
-  fd_boot( &argc, &argv );
+  fd_boot_secure1( &argc, &argv );
+
+  char const * pod_gaddr = fd_env_strip_cmdline_cstr( &argc, &argv, "--pod", NULL, NULL );
+  if( FD_UNLIKELY( !pod_gaddr ) ) FD_LOG_ERR(( "--pod not specified" ));
+  if( FD_UNLIKELY( !fd_wksp_preload( pod_gaddr ) ) )
+    FD_LOG_ERR(( "unable to preload workspace" ));
+
+  fd_boot_secure2( &argc, &argv );
 
   /* Parse command line arguments */
 
-  char const * pod_gaddr =       fd_env_strip_cmdline_cstr  ( &argc, &argv, "--pod",      NULL, NULL                 );
   long         dt_min    = (long)fd_env_strip_cmdline_double( &argc, &argv, "--dt-min",   NULL,   66666667.          );
   long         dt_max    = (long)fd_env_strip_cmdline_double( &argc, &argv, "--dt-max",   NULL, 1333333333.          );
   long         duration  = (long)fd_env_strip_cmdline_double( &argc, &argv, "--duration", NULL,          0.          );
   uint         seed      =       fd_env_strip_cmdline_uint  ( &argc, &argv, "--seed",     NULL, (uint)fd_tickcount() );
 
-  if( FD_UNLIKELY( !pod_gaddr   ) ) FD_LOG_ERR(( "--pod not specified"                  ));
   if( FD_UNLIKELY( dt_min<0L    ) ) FD_LOG_ERR(( "--dt-min should be positive"          ));
   if( FD_UNLIKELY( dt_max<dt_min) ) FD_LOG_ERR(( "--dt-max should be at least --dt-min" ));
   if( FD_UNLIKELY( duration<0L  ) ) FD_LOG_ERR(( "--duration should be non-negative"    ));

--- a/src/util/env/fd_env.c
+++ b/src/util/env/fd_env.c
@@ -55,6 +55,20 @@ FD_ENV_STRIP_CMDLINE_IMPL( double,       double )
 
 #undef FD_ENV_STRIP_CMDLINE_IMPL
 
+int
+fd_env_strip_cmdline_contains( int * pargc, char *** pargv, char const * key ) {
+  int new_argc = 0;
+  int found = 0;
+  if( key && pargc && pargv ) {
+    for( int arg=0; arg<(*pargc); arg++ )
+      if( strcmp( key, (*pargv)[arg] ) ) (*pargv)[new_argc++] = (*pargv)[arg];
+      else if( (++arg)<(*pargc) ) found = 1;
+    (*pargc)           = new_argc;
+    (*pargv)[new_argc] = NULL; /* ANSI - argv is NULL terminated */
+  }
+  return found;
+}
+
 #else
 #error "Unknown FD_ENV_STYLE"
 #endif

--- a/src/util/env/fd_env.h
+++ b/src/util/env/fd_env.h
@@ -59,4 +59,11 @@ FD_ENV_STRIP_CMDLINE_DECL( double,       double );
 
 FD_PROTOTYPES_END
 
+/* returns 1 if the command line contains the given key, and removes
+   it from the args, otherwise returns 0. */
+int
+fd_env_strip_cmdline_contains( int *        pargc,
+                               char ***     pargv,
+                               char const * key );
+
 #endif /* HEADER_fd_src_env_fd_env_h */

--- a/src/util/fd_util.c
+++ b/src/util/fd_util.c
@@ -11,6 +11,38 @@ fd_boot( int *    pargc,
 }
 
 void
+fd_boot_secure1( int *    pargc,
+                 char *** pargv ) {
+  // 1. Initialize logging and some shared memory information. This
+  //    is done first because it requires opening /dev/null, the log
+  //    file, and some /proc/... info which will not be present after
+  //    the privileged step of sandboxing
+  //
+  //    It's also needed because the caller process might want to
+  //    initialize some privileged resources with code that does
+  //    logging, or needs information from the shared memory domain.
+  fd_log_private_boot          ( pargc, pargv );
+  fd_shmem_private_boot        ( pargc, pargv );
+}
+
+void
+fd_boot_secure2( int *    pargc,
+                 char *** pargv ) {
+  // 2. Do any sandboxing operations which require capabilities. This
+  //    enters a mount namespace and makes the filesystem unavailable.
+  //    When this returns the caller is in a new usernamespace and
+  //    has no capabilities.
+  fd_sandbox_private_privileged        ( pargc, pargv );
+
+  // 3. Boot the tiles. Must be done after dropping capabilities so
+  //    tiles start without any.
+  fd_tile_private_boot                 ( pargc, pargv ); /* The caller is now tile 0 */
+
+  // 4. Enter sandbox and restrict all system calls
+  fd_sandbox_private                   ( pargc, pargv );
+}
+
+void
 fd_halt( void ) {
   /* At this point, we are immediately before normal program
      termination, and fd has already been booted. */

--- a/src/util/fd_util.h
+++ b/src/util/fd_util.h
@@ -18,6 +18,7 @@
 #include "rng/fd_rng.h"             /* includes bits/fd_bits.h */
 #include "tpool/fd_tpool.h"         /* includes tile/fd_tile.h and scratch/fd_scratch.h */
 #include "alloc/fd_alloc.h"         /* includes wksp/fd_wksp.h */
+#include "sandbox/fd_sandbox.h"
 
 /* Additional fd_util APIs that are not included by default */
 
@@ -274,6 +275,31 @@ FD_PROTOTYPES_BEGIN
 void
 fd_boot( int *    pargc,
          char *** pargv );
+
+/* Booting securely means starting with a maximal sandbox. This is a
+   three step process,
+
+     1. Initialize logging and shared memory infrastructure
+     .... User code loads any resources it needs
+     2. Drop all privileges, initialize tiles, and enforce seccomp
+        syscall filter,
+
+  These boot_secure1 and boot_secure2 functions map to steps 1 and 2,
+  so that user code can run inbetween to load privileged resources
+  while using logging.
+
+  Once boot_secure2 is called, the process is fully sandboxed and
+  cannot make system calls, access the file system, or really do
+  much of anything. All resources needed in the program should be
+  initialized before calling it.
+   */
+void
+fd_boot_secure1( int *    pargc,
+                 char *** pargv );
+
+void
+fd_boot_secure2( int *    pargc,
+                 char *** pargv );
 
 void
 fd_halt( void );

--- a/src/util/log/fd_log.c
+++ b/src/util/log/fd_log.c
@@ -1065,7 +1065,8 @@ fd_log_private_boot( int  *   pargc,
     void * btrace[128];
     int btrace_cnt = backtrace( btrace, 128 );
     int fd = open( "/dev/null", O_WRONLY | O_APPEND );
-    if( FD_UNLIKELY( fd==-1 ) ) fprintf( stderr, "open( \"/dev/null\", O_WRONLY | O_APPEND ) failed; attempting to continue\n" );
+    if( FD_UNLIKELY( fd==-1 ) )
+      fprintf( stderr, "open( \"/dev/null\", O_WRONLY | O_APPEND ) failed (%i-%s); attempting to continue\n", errno, strerror( errno ) );
     else {
       backtrace_symbols_fd( btrace, btrace_cnt, fd );
       if( FD_UNLIKELY( close( fd ) ) )

--- a/src/util/sandbox/Local.mk
+++ b/src/util/sandbox/Local.mk
@@ -1,0 +1,4 @@
+$(call add-hdrs,fd_sandbox.h)
+$(call add-objs,fd_sandbox,fd_util)
+# $(call make-unit-test,test_sandbox,test_sandbox,fd_util)
+# $(call run-unit-test,test_sandbox,)

--- a/src/util/sandbox/fd_sandbox.c
+++ b/src/util/sandbox/fd_sandbox.c
@@ -1,0 +1,234 @@
+#if !defined(__linux__)
+# error "Target operating system is unsupported by seccomp."
+#endif
+
+#define _GNU_SOURCE
+
+#include "fd_sandbox.h"
+
+#include <assert.h>
+#include <string.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <errno.h>
+#include <linux/audit.h>
+#include <linux/securebits.h>
+#include <linux/seccomp.h>
+#include <linux/filter.h>
+#include <linux/capability.h>
+#include <limits.h>
+#include <sched.h>        /* CLONE_*, setns, unshare */
+#include <stddef.h>
+#include <stdlib.h>       /* clearenv, mkdtemp*/
+#include <sys/mount.h>    /* MS_*, MNT_*, mount, umount2 */
+#include <sys/prctl.h>
+#include <sys/resource.h> /* RLIMIT_*, rlimit, setrlimit */
+#include <sys/stat.h>     /* mkdir */
+#include <sys/syscall.h>  /* SYS_* */
+#include <unistd.h>       /* set*id, sysconf, close, chdir, rmdir syscall */
+
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+
+#define X32_SYSCALL_BIT 0x40000000
+
+#define ALLOW_SYSCALL(name)                                \
+  /* If the syscall does not match, jump over RET_ALLOW */ \
+  BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_##name, 0, 1),  \
+  BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW)
+
+#if defined(__i386__)
+# define ARCH_NR  AUDIT_ARCH_I386
+#elif defined(__x86_64__)
+# define ARCH_NR  AUDIT_ARCH_X86_64
+#elif defined(__aarch64__)
+# define ARCH_NR AUDIT_ARCH_AARCH64
+#else
+# error "Target architecture is unsupported by seccomp."
+#endif
+
+static void
+secure_clear_environment( void ) {
+  char** env = environ;
+  while ( *env ) {
+    size_t len = strlen( *env );
+    explicit_bzero( *env, len );
+    env++;
+  }
+  clearenv();
+}
+
+static void
+setup_mountns( void ) {
+  assert( unshare ( CLONE_NEWNS ) == 0 );
+
+  char temp_dir [] = "/tmp/fd-sandbox-XXXXXX";
+  assert( mkdtemp( temp_dir ) );
+  assert( 0 == mount( NULL, "/", NULL, MS_SLAVE | MS_REC, NULL ) );
+  assert( 0 == mount( temp_dir, temp_dir, NULL, MS_BIND | MS_REC, NULL ) );
+  assert( 0 == chdir( temp_dir ) );
+  assert( 0 == mkdir( "old-root", S_IRUSR | S_IWUSR ));
+  assert( 0 == syscall( SYS_pivot_root, ".", "old-root" ) );
+  assert( 0 == chdir( "/" ) );
+  assert( 0 == umount2( "old-root", MNT_DETACH ) );
+  assert( 0 == rmdir( "old-root" ) );
+}
+
+static void
+close_fds( void ) {
+  if( syscall( SYS_close_range, 3, UINT_MAX ) ) {
+    // No SYS_close_range, close one by one
+    int max_fds = (int)sysconf( _SC_OPEN_MAX );
+    for ( int fd = 3; fd < max_fds; fd++ ) {
+      assert( 0 == close( fd ) );
+    }
+  }
+}
+
+static void
+install_seccomp( void ) {
+  struct sock_filter filter [] = {
+    // [0] Validate architecture
+    // Load the arch number
+    BPF_STMT( BPF_LD | BPF_W | BPF_ABS, ( offsetof( struct seccomp_data, arch ) ) ),
+    // Do not jump (and die) if the compile arch is neq the runtime arch.
+    // Otherwise, jump over the SECCOMP_RET_KILL_PROCESS statement.
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, ARCH_NR, 1, 0 ),
+    BPF_STMT( BPF_RET | BPF_K, SECCOMP_RET_ALLOW ),
+
+    // [1] Verify that the syscall is allowed
+    // Load the syscall
+    BPF_STMT( BPF_LD | BPF_W | BPF_ABS, ( offsetof( struct seccomp_data, nr ) ) ),
+
+    // Attempt to sort syscalls by call frequency.
+    ALLOW_SYSCALL( writev       ),
+    ALLOW_SYSCALL( write        ),
+    ALLOW_SYSCALL( fsync        ),
+    ALLOW_SYSCALL( gettimeofday ),
+    ALLOW_SYSCALL( futex        ),
+    // sched_yield is useful for both floating threads and hyperthreaded pairs.
+    ALLOW_SYSCALL( sched_yield  ),
+    // The rules under this line are expected to be used in fewer occasions.
+    // exit is needed to let tiles exit gracefully.
+    ALLOW_SYSCALL( exit         ),
+    // exit_group is needed to let any tile crash the whole group.
+    ALLOW_SYSCALL( exit_group   ),
+    // munmap is needed for a clean exit.
+    ALLOW_SYSCALL( munmap       ),
+    // nanosleep is needed for a clean exit.
+    ALLOW_SYSCALL( nanosleep    ),
+    ALLOW_SYSCALL( rt_sigaction ),
+    ALLOW_SYSCALL( rt_sigreturn ),
+    ALLOW_SYSCALL( sync         ),
+    // close is needed for a clean exit and for closing logs.
+    ALLOW_SYSCALL( close        ),
+    ALLOW_SYSCALL( sendto       ),
+
+    // [2] None of the syscalls approved were matched: die
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS),
+  };
+
+  assert( 0 == prctl( PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0 ) );
+
+  struct sock_fprog default_prog = {
+    .len = ARRAY_SIZE( filter ),
+    .filter = filter,
+  };
+  assert( 0 == syscall( SYS_seccomp, SECCOMP_SET_MODE_FILTER, 0, &default_prog ) );
+}
+
+static void
+drop_capabilities( void ) {
+  assert( 0 == prctl (
+    PR_SET_SECUREBITS,
+    SECBIT_KEEP_CAPS_LOCKED | SECBIT_NO_SETUID_FIXUP |
+      SECBIT_NO_SETUID_FIXUP_LOCKED | SECBIT_NOROOT |
+      SECBIT_NOROOT_LOCKED | SECBIT_NO_CAP_AMBIENT_RAISE |
+      SECBIT_NO_CAP_AMBIENT_RAISE_LOCKED ) );
+
+  struct __user_cap_header_struct hdr = { _LINUX_CAPABILITY_VERSION_3, 0 };
+  struct __user_cap_data_struct   data[2] = { { 0 } };
+  assert( 0 == syscall( SYS_capset, &hdr, data ) );
+
+  assert( 0 == prctl( PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0 ) );
+}
+
+static uint overflow_id(const char * path) {
+  int fd = open( path, O_RDONLY );
+  assert( fd >= 0 );
+  char buf[16];
+  ssize_t len = read( fd, buf, sizeof(buf) );
+  assert( len > 0 );
+  close( fd );
+  buf[len] = '\0';
+  int result = atoi( buf );
+  assert( result >= 0 );
+  return (uint)result;
+}
+
+static void userns_map( uint id, const char * map ) {
+  char path[64];
+  assert( sprintf( path, "/proc/self/%s", map ) > 0);
+  int fd = open( path, O_WRONLY );
+  assert( fd >= 0 );
+  char line[64];
+  assert( sprintf( line, "0 %u 1\n", id ) > 0 );
+  assert( write( fd, line, strlen( line ) ) > 0 );
+  assert( 0 == close( fd ) );
+}
+
+static void deny_setgroups() {
+  int fd = open( "/proc/self/setgroups", O_WRONLY );
+  assert( fd >= 0 );
+  assert( write( fd, "deny", strlen( "deny" ) ) > 0 );
+  assert( 0 == close( fd ) );
+}
+
+void
+fd_sandbox_private_privileged( int *    pargc,
+                               char *** pargv ) {
+  (void) pargc;
+  for( char ** argv = *pargv; *argv; argv++ ) {
+    if( !strcmp( *argv, "--no-sandbox" ) ) {
+      return;
+    }
+  }
+
+  uint overflow_uid = overflow_id( "/proc/sys/kernel/overflowuid" );
+  uint overflow_gid = overflow_id( "/proc/sys/kernel/overflowgid" );
+  uint uid = fd_env_strip_cmdline_uint( pargc, pargv, "--uid", "FD_UID", overflow_uid );
+  uint gid = fd_env_strip_cmdline_uint( pargc, pargv, "--gid", "FD_GID", overflow_gid );
+
+  assert( uid != 0 && gid != 0 );
+
+  assert( 0 == setresgid( gid, gid, gid ) );
+  assert( 0 == setresuid( uid, uid, uid ) );
+  assert( 0 == prctl( PR_SET_DUMPABLE, 1, 0, 0, 0 ) );
+
+  assert( 0 == unshare( CLONE_NEWUSER | CLONE_NEWNS | CLONE_NEWNET ) );
+  deny_setgroups();
+  userns_map( getuid(), "uid_map" );
+  userns_map( getgid(), "gid_map" );
+
+  assert( 0 == prctl( PR_SET_DUMPABLE, 0, 0, 0, 0 ) );
+  for ( int cap = 0; cap <= CAP_LAST_CAP; cap++ ) {
+    assert( 0 == prctl( PR_CAPBSET_DROP, cap, 0, 0, 0 ) );
+  }
+
+  setup_mountns();
+  drop_capabilities();
+  secure_clear_environment();
+}
+
+void
+fd_sandbox_private( int *    pargc,
+                    char *** pargv ) {
+  if( fd_env_strip_cmdline_contains( pargc, pargv, "--no-sandbox" ) ) {
+    return;
+  }
+
+  struct rlimit limit = { .rlim_cur = 3, .rlim_max = 3 };
+  assert( 0 == setrlimit( RLIMIT_NOFILE, &limit ));
+
+  close_fds();
+  install_seccomp();
+}

--- a/src/util/sandbox/fd_sandbox.h
+++ b/src/util/sandbox/fd_sandbox.h
@@ -1,0 +1,20 @@
+#ifndef HEADER_fd_src_util_sandbox_fd_sandbox_h
+#define HEADER_fd_src_util_sandbox_fd_sandbox_h
+
+#include "../env/fd_env.h"
+#include "../log/fd_log.h"
+
+void
+fd_sandbox_private_privileged( int *    pargc,
+                               char *** pargv );
+
+/* fd_sandbox sandboxes the current process. After calling, the process
+   has maximally restricted privileges we can enable given the host environment.
+   On Linux, seccomp is used to prevent any syscalls except select whitelisted
+   ones.
+*/
+void
+fd_sandbox_private( int *    pargc,
+                    char *** pargv );
+
+#endif /* HEADER_fd_src_util_sandbox_fd_sandbox_h */

--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -834,6 +834,15 @@ void
 fd_wksp_cstr_memset( char const * cstr,
                      int          c );
 
+/* fd_wksp_preload maps a workspace into memory in the process and
+   then "forgets" about it. This might be needed due to the security
+   architecture, where a privileged section of code can initialize
+   the memory map, not release it, and then all subsequent joins
+   for that workspace (who can no longer open a file or call mmap)
+   may reuse the same already-mapped memory. */
+void *
+fd_wksp_preload( char const * gaddr );
+
 /* fd_wksp_map returns a pointer in the caller's address space to
    the wksp allocation specified by a cstr containing [name]:[gaddr].
    [name] is the name of the shared memory region holding the wksp.

--- a/src/util/wksp/fd_wksp_helper.c
+++ b/src/util/wksp/fd_wksp_helper.c
@@ -436,6 +436,15 @@ fd_wksp_cstr_memset( char const * cstr,
 }
 
 void *
+fd_wksp_preload( char const * cstr ) {
+  char  name[ FD_SHMEM_NAME_MAX ];
+  ulong gaddr;
+  if( FD_UNLIKELY( !fd_wksp_private_cstr_parse( cstr, name, &gaddr ) ) ) return NULL;
+
+  return fd_shmem_join( name, FD_SHMEM_JOIN_MODE_READ_WRITE, NULL, NULL, NULL );
+}
+
+void *
 fd_wksp_map( char const * cstr ) {
   char  name[ FD_SHMEM_NAME_MAX ];
   ulong gaddr;


### PR DESCRIPTION
I wanted to highlight what a minimally invasive change looks like here. It's largely just a belt sanding / style change, but has a few notable changes,

 * Explicitly clear environment to prevent read from current process.
 * Pipe through "--no-sandbox" argument for development.
 * Update required capabilities for run binary.
 * The `sandbox_mountns` is switched to do what Firecracker does. I couldn't get the prior code to run.
 * The `drop_capabilities` ordering is also switched around, I couldn't get that to run before either.