### PR TITLE
aio: add fd_aio_pcapng

### DIFF
--- a/src/tango/aio/Local.mk
+++ b/src/tango/aio/Local.mk
@@ -1,4 +1,4 @@
-$(call add-hdrs,fd_aio.h)
-$(call add-objs,fd_aio,fd_util)
+$(call add-hdrs,fd_aio.h fd_aio_pcapng.h)
+$(call add-objs,fd_aio fd_aio_pcapng,fd_util)
 $(call make-unit-test,test_aio,test_aio,fd_tango fd_util)
 $(call run-unit-test,test_aio)

--- a/src/tango/aio/fd_aio_pcapng.c
+++ b/src/tango/aio/fd_aio_pcapng.c
@@ -1,0 +1,73 @@
+#include "fd_aio_pcapng.h"
+#include "../../util/net/fd_pcapng_private.h"
+
+#include <errno.h>
+
+/* fd_aio_pcapng_send implements fd_aio_send_t */
+
+static int
+fd_aio_pcapng_send( void *                    ctx,
+                    fd_aio_pkt_info_t const * batch,
+                    ulong                     batch_cnt,
+                    ulong *                   opt_batch_idx,
+                    int                       flush ) {
+
+  long ts = fd_log_wallclock(); /* TODO allow custom clock */
+
+  fd_aio_pcapng_t * mitm = (fd_aio_pcapng_t *)ctx;
+
+  for( ulong i=0; i<batch_cnt; i++ ) {
+    if( FD_UNLIKELY( 1UL!=fd_pcapng_fwrite_pkt( ts, batch[ i ].buf, batch[ i ].buf_sz, mitm->pcapng ) ) ) {
+      FD_LOG_WARNING(( "fd_pcapng_fwrite_pkt failed (%d-%s)", errno, strerror( errno ) ));
+      break;
+    }
+  }
+
+  return fd_aio_send( mitm->dst, batch, batch_cnt, opt_batch_idx, flush );
+}
+
+FD_FN_CONST fd_aio_t const *
+fd_aio_pcapng_get_aio( fd_aio_pcapng_t const * mitm ) {
+  return &mitm->local;
+}
+
+
+ulong
+fd_aio_pcapng_start( void * pcapng ) {
+  fd_pcapng_shb_opts_t shb_opts = {0};
+  fd_pcapng_shb_defaults( &shb_opts );
+
+  if( FD_UNLIKELY( 1UL!=fd_pcapng_fwrite_shb( &shb_opts, pcapng ) ) )
+    return 0UL;
+
+  if( FD_UNLIKELY( 1UL!=fd_pcapng_fwrite_idb(
+        FD_PCAPNG_LINKTYPE_ETHERNET, NULL, pcapng ) ) )
+    return 0UL;
+
+  return 1UL;
+}
+
+
+fd_aio_pcapng_t *
+fd_aio_pcapng_join( void *           _mitm,
+                    fd_aio_t const * dst,
+                    void *           pcapng ) {
+
+  fd_aio_pcapng_t * mitm = (fd_aio_pcapng_t *)_mitm;
+  mitm->dst    = dst;
+  mitm->pcapng = pcapng;
+
+  FD_TEST( fd_aio_join( fd_aio_new( &mitm->local, mitm, fd_aio_pcapng_send ) ) );
+
+  return mitm;
+}
+
+void *
+fd_aio_pcapng_leave( fd_aio_pcapng_t * mitm ) {
+  fd_aio_delete( fd_aio_leave( &mitm->local ) );
+
+  mitm->dst    = NULL;
+  mitm->pcapng = NULL; /* FIXME flush? */
+
+  return (void *)mitm;
+}

--- a/src/tango/aio/fd_aio_pcapng.h
+++ b/src/tango/aio/fd_aio_pcapng.h
@@ -1,0 +1,71 @@
+#ifndef HEADER_fd_src_tango_aio_fd_aio_pcapng_h
+#define HEADER_fd_src_tango_aio_fd_aio_pcapng_h
+
+#include "fd_aio.h"
+
+/* fd_aio_pcapng implements a MitM aio that sits transparently between a
+   sender and receiver while capturing all packets to a file.
+
+   Multiple writers may be joined to the same pcapng stream on the same
+   thread, though sharing a pcapng across threads is unsupported.  (One
+   could still achieve multi-thread support by buffering all completed
+   writes to local memory-backed virtual files per thread and then
+   periodically flushing the records using atomic write() syscalls)
+
+   Capture happens unidirectionally -- for duplex create a pair (one for
+   RX, one for TX) (Refer to the above re safety of sharing a file
+   descriptor) */
+
+struct fd_aio_pcapng {
+  fd_aio_t         local;  /* abstract base class */
+  fd_aio_t const * dst;    /* aio in local address space */
+  void *           pcapng; /* stream object (typically FILE) */
+};
+typedef struct fd_aio_pcapng fd_aio_pcapng_t;
+
+#define FD_AIO_PCAPNG_ALIGN     (alignof(fd_aio_pcapng_t))
+#define FD_AIO_PCAPNG_FOOTPRINT (sizeof (fd_aio_pcapng_t))
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_aio_pcapng_start starts a new PCAPNG section (SHB) and defines a
+   single interface (IDB) on the given PCAPNG stream handle (typically
+   FILE). This is optional if the caller has already created such an
+   SHB/IDB pair.  Returns 1 on success. On failure, returns 0 and sets
+   errno.  Stream state is undefined on failure. */
+
+ulong
+fd_aio_pcapng_start( void * pcapng );
+
+
+/* fd_aio_pcapng_join formats the memory region at mitm for use as an
+   fd_aio_pcapng_t (with matching size and alignment requirements).
+   Returns mitm configured to forward traffic to dst and log traffic
+   passing through to stream handle pcapng (typically FILE).
+   pcapng must have valid SHB and IDB headers at this point
+   (fd_aio_pcapng_start creates such). */
+
+fd_aio_pcapng_t *
+fd_aio_pcapng_join( void *           mitm,
+                    fd_aio_t const * dst,
+                    void *           pcapng );
+
+/* fd_aio_pcapng_leave leaves the current join to the mitm object.
+   Caller should first disconnect all other objects configured to send
+   to the aio provided by this mitm. */
+
+void *
+fd_aio_pcapng_leave( fd_aio_pcapng_t * mitm );
+
+/* fd_aio_pcapng_get_aio returns the fd_aio base class of this
+   fd_aio_pcapng_join.  Valid for lifetime of join.  Each packet sent
+   to this aio will be written to pcapng.  If pcapng writes fail, will
+   continue to forward packets and log warnings.  Packets written refer
+   to the default interface in the current section, i.e. the first IDB. */
+
+FD_FN_CONST fd_aio_t const *
+fd_aio_pcapng_get_aio( fd_aio_pcapng_t const * mitm );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_tango_aio_fd_aio_pcapng_h */


### PR DESCRIPTION
Adds aio middleware for logging to pcapng. From milestone 1.1