### PR TITLE
contrib: add gen-pem-cert.sh

### DIFF
--- a/contrib/gen-pem-cert.sh
+++ b/contrib/gen-pem-cert.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+# Generates a self-signed Ed25519 PEM cert and key
+# in the current working dir.
+
+openssl req -x509 -newkey ed25519 -days 365 -nodes \
+  -keyout key.pem -out cert.pem -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"

--- a/contrib/gen-pem-cert.sh
+++ b/contrib/gen-pem-cert.sh
@@ -7,4 +7,4 @@ set -e
 
 openssl req -x509 -newkey ed25519 -days 365 -nodes \
   -keyout key.pem -out cert.pem -subj "/CN=localhost" \
-  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1 -extensions v3-req"

--- a/src/app/fdctl/src/commands/configure/certs.rs
+++ b/src/app/fdctl/src/commands/configure/certs.rs
@@ -22,7 +22,7 @@ fn step(config: &mut Config) {
     run!(
         cwd = scratch,
         "openssl req -x509 -newkey ed25519 -days 365 -nodes -keyout key.pem -out cert.pem -subj \
-         /CN=localhost -addext subjectAltName=DNS:localhost,IP:127.0.0.1"
+         /CN=localhost -addext subjectAltName=DNS:localhost,IP:127.0.0.1 -extensions v3-req"
     );
     repermission(format!("{scratch}/key.pem"), config.uid, config.uid, 0o600);
     repermission(format!("{scratch}/cert.pem"), config.uid, config.uid, 0o664);


### PR DESCRIPTION
- contrib: add gen-pem-cert.sh
- fix: openssl-req v3 (for CA:false) (#417)

Adds helper script generating a Solana-compatible PEM cert for QUIC-TLS. From milestone 1.1 branch