### PR TITLE
config: support order-independent static linking

### DIFF
--- a/config/everything.mk
+++ b/config/everything.mk
@@ -201,7 +201,7 @@ $(OBJDIR)/$(4)/$(1): $(foreach obj,$(2),$(patsubst $(OBJDIR)/src/%,$(OBJDIR)/obj
 	# Creating $(4) $$@ from $$^
 	#######################################################################
 	$(MKDIR) $$(dir $$@) && \
-$(LD) -L$(OBJDIR)/lib $(foreach obj,$(2),$(patsubst $(OBJDIR)/src/%,$(OBJDIR)/obj/%,$(OBJDIR)/$(MKPATH)$(obj).o)) $(foreach lib,$(3),-l$(lib)) $(LDFLAGS) -o $$@
+$(LD) -L$(OBJDIR)/lib $(foreach obj,$(2),$(patsubst $(OBJDIR)/src/%,$(OBJDIR)/obj/%,$(OBJDIR)/$(MKPATH)$(obj).o)) -Wl,--start-group $(foreach lib,$(3),-l$(lib)) $(LDFLAGS) -Wl,--end-group -o $$@
 
 $(4): $(OBJDIR)/$(4)/$(1)
 


### PR DESCRIPTION
Uses a link group for internal libs such as fd_tango, fd_ballet, etc
to resolve "symbol not found" errors resulting from incorrect static
lib ordering.  Also useful for circular dependencies (which should be
avoided, but oh well...)
