### PR TITLE
sandbox: sandbox implementation

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -320,6 +320,12 @@ scratch_directory = "/home/{user}/.firedancer/{name}"
         signature_cache_size = 4194302
 
 [development]
+    # For enhanced security, Firedancer runs itself in a restrictive sandbox in production. The
+    # sandbox prevents most system calls and restricts the capabilities of the process after
+    # initialization to make the attack surface smaller. This is required in production, but might
+    # be too restrictive during development.
+    sandbox = true
+
     # Firedancer requires some privileges for normal operation. In production it will not attempt
     # to acquire these, and must be either be run as root, or have the capabilities set on the
     # binary. During development it can be useful for Firedancer to rerun itself as root if it does

--- a/src/app/fdctl/config/development.toml
+++ b/src/app/fdctl/config/development.toml
@@ -1,5 +1,6 @@
 [development]
     sudo = true
+    sandbox = false
     [development.netns]
         enabled = true
 [tiles.quic]

--- a/src/app/fdctl/src/config.rs
+++ b/src/app/fdctl/src/config.rs
@@ -249,6 +249,7 @@ config_struct!(DedupConfig {
 
 config_struct!(DevelopmentConfig {
     {
+        sandbox: bool,
         sudo: bool
     }
     netns: NetNsConfig

--- a/src/app/frank/fd_frank_mon.bin.c
+++ b/src/app/frank/fd_frank_mon.bin.c
@@ -317,17 +317,22 @@ snap( ulong             tile_cnt,     /* Number of tiles to snapshot */
 int
 main( int     argc,
       char ** argv ) {
-  fd_boot( &argc, &argv );
+  fd_boot_secure1( &argc, &argv );
+
+  char const * pod_gaddr = fd_env_strip_cmdline_cstr( &argc, &argv, "--pod", NULL, NULL );
+  if( FD_UNLIKELY( !pod_gaddr ) ) FD_LOG_ERR(( "--pod not specified" ));
+  if( FD_UNLIKELY( !fd_wksp_preload( pod_gaddr ) ) )
+    FD_LOG_ERR(( "unable to preload workspace" ));
+
+  fd_boot_secure2( &argc, &argv );
 
   /* Parse command line arguments */
 
-  char const * pod_gaddr =       fd_env_strip_cmdline_cstr  ( &argc, &argv, "--pod",      NULL, NULL                 );
   long         dt_min    = (long)fd_env_strip_cmdline_double( &argc, &argv, "--dt-min",   NULL,   66666667.          );
   long         dt_max    = (long)fd_env_strip_cmdline_double( &argc, &argv, "--dt-max",   NULL, 1333333333.          );
   long         duration  = (long)fd_env_strip_cmdline_double( &argc, &argv, "--duration", NULL,          0.          );
   uint         seed      =       fd_env_strip_cmdline_uint  ( &argc, &argv, "--seed",     NULL, (uint)fd_tickcount() );
 
-  if( FD_UNLIKELY( !pod_gaddr   ) ) FD_LOG_ERR(( "--pod not specified"                  ));
   if( FD_UNLIKELY( dt_min<0L    ) ) FD_LOG_ERR(( "--dt-min should be positive"          ));
   if( FD_UNLIKELY( dt_max<dt_min) ) FD_LOG_ERR(( "--dt-max should be at least --dt-min" ));
   if( FD_UNLIKELY( duration<0L  ) ) FD_LOG_ERR(( "--duration should be non-negative"    ));

--- a/src/util/env/fd_env.c
+++ b/src/util/env/fd_env.c
@@ -55,6 +55,20 @@ FD_ENV_STRIP_CMDLINE_IMPL( double,       double )
 
 #undef FD_ENV_STRIP_CMDLINE_IMPL
 
+int
+fd_env_strip_cmdline_contains( int * pargc, char *** pargv, char const * key ) {
+  int new_argc = 0;
+  int found = 0;
+  if( key && pargc && pargv ) {
+    for( int arg=0; arg<(*pargc); arg++ )
+      if( strcmp( key, (*pargv)[arg] ) ) (*pargv)[new_argc++] = (*pargv)[arg];
+      else found = 1;
+    (*pargc)           = new_argc;
+    (*pargv)[new_argc] = NULL; /* ANSI - argv is NULL terminated */
+  }
+  return found;
+}
+
 #else
 #error "Unknown FD_ENV_STYLE"
 #endif

--- a/src/util/env/fd_env.h
+++ b/src/util/env/fd_env.h
@@ -59,4 +59,11 @@ FD_ENV_STRIP_CMDLINE_DECL( double,       double );
 
 FD_PROTOTYPES_END
 
+/* returns 1 if the command line contains the given key, and removes
+   it from the args, otherwise returns 0. */
+int
+fd_env_strip_cmdline_contains( int *        pargc,
+                               char ***     pargv,
+                               char const * key );
+
 #endif /* HEADER_fd_src_env_fd_env_h */

--- a/src/util/env/test_env.c
+++ b/src/util/env/test_env.c
@@ -106,6 +106,23 @@ main( int     argc,
   d    = fd_env_strip_cmdline_double( NULL, NULL, "double", NULL,          38.  ); FD_TEST( d   ==         38.  );
 # endif
 
+  int argc2 = 1;
+  char *hello = "--hello";
+  char **argv2 = (char*[]){ hello, NULL };
+  FD_TEST( !fd_env_strip_cmdline_contains ( &argc2, &argv2, "--hello2" ) );
+  FD_TEST( !fd_env_strip_cmdline_contains ( &argc2, &argv2, "hello" ) );
+  FD_TEST( argc2 == 1 );
+  FD_TEST( fd_env_strip_cmdline_contains ( &argc2, &argv2, "--hello" ) );
+  FD_TEST( argc2 == 0 );
+  FD_TEST( *argv2 == NULL );
+
+  argc2 = 3;
+  char *bye = "--bye";
+  argv2 = (char*[]){ hello, bye, hello, NULL };
+  FD_TEST( fd_env_strip_cmdline_contains ( &argc2, &argv2, "--hello" ) );
+  FD_TEST( argc2 == 1 );
+  FD_TEST( !strcmp(*argv2, "--bye") );
+
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();
   return 0;

--- a/src/util/fd_util.c
+++ b/src/util/fd_util.c
@@ -18,6 +18,38 @@ fd_boot( int *    pargc,
 }
 
 void
+fd_boot_secure1( int *    pargc,
+                 char *** pargv ) {
+  // 1. Initialize logging and some shared memory information. This
+  //    is done first because it requires opening /dev/null, the log
+  //    file, and some /proc/... info which will not be present after
+  //    the privileged step of sandboxing
+  //
+  //    It's also needed because the caller process might want to
+  //    initialize some privileged resources with code that does
+  //    logging, or needs information from the shared memory domain.
+  fd_log_private_boot          ( pargc, pargv );
+  fd_shmem_private_boot        ( pargc, pargv );
+}
+
+void
+fd_boot_secure2( int *    pargc,
+                 char *** pargv ) {
+  // 2. Do any sandboxing operations which require capabilities. This
+  //    enters a mount namespace and makes the filesystem unavailable.
+  //    When this returns the caller is in a new usernamespace and
+  //    has no capabilities.
+  fd_sandbox_private_privileged        ( pargc, pargv );
+
+  // 3. Boot the tiles. Must be done after dropping capabilities so
+  //    tiles start without any.
+  fd_tile_private_boot                 ( pargc, pargv ); /* The caller is now tile 0 */
+
+  // 4. Enter sandbox and restrict all system calls
+  fd_sandbox_private                   ( pargc, pargv );
+}
+
+void
 fd_halt( void ) {
   /* At this point, we are immediately before normal program
      termination, and fd has already been booted. */

--- a/src/util/fd_util.h
+++ b/src/util/fd_util.h
@@ -18,6 +18,7 @@
 #include "rng/fd_rng.h"             /* includes bits/fd_bits.h */
 #include "tpool/fd_tpool.h"         /* includes tile/fd_tile.h and scratch/fd_scratch.h */
 #include "alloc/fd_alloc.h"         /* includes wksp/fd_wksp.h */
+#include "sandbox/fd_sandbox.h"
 
 /* Additional fd_util APIs that are not included by default */
 
@@ -274,6 +275,31 @@ FD_PROTOTYPES_BEGIN
 void
 fd_boot( int *    pargc,
          char *** pargv );
+
+/* Booting securely means starting with a maximal sandbox. This is a
+   three step process,
+
+     1. Initialize logging and shared memory infrastructure
+     .... User code loads any resources it needs
+     2. Drop all privileges, initialize tiles, and enforce seccomp
+        syscall filter,
+
+  These boot_secure1 and boot_secure2 functions map to steps 1 and 2,
+  so that user code can run inbetween to load privileged resources
+  while using logging.
+
+  Once boot_secure2 is called, the process is fully sandboxed and
+  cannot make system calls, access the file system, or really do
+  much of anything. All resources needed in the program should be
+  initialized before calling it.
+   */
+void
+fd_boot_secure1( int *    pargc,
+                 char *** pargv );
+
+void
+fd_boot_secure2( int *    pargc,
+                 char *** pargv );
 
 void
 fd_halt( void );

--- a/src/util/log/fd_log.c
+++ b/src/util/log/fd_log.c
@@ -1065,7 +1065,8 @@ fd_log_private_boot( int  *   pargc,
     void * btrace[128];
     int btrace_cnt = backtrace( btrace, 128 );
     int fd = open( "/dev/null", O_WRONLY | O_APPEND );
-    if( FD_UNLIKELY( fd==-1 ) ) fprintf( stderr, "open( \"/dev/null\", O_WRONLY | O_APPEND ) failed; attempting to continue\n" );
+    if( FD_UNLIKELY( fd==-1 ) )
+      fprintf( stderr, "open( \"/dev/null\", O_WRONLY | O_APPEND ) failed (%i-%s); attempting to continue\n", errno, strerror( errno ) );
     else {
       backtrace_symbols_fd( btrace, btrace_cnt, fd );
       if( FD_UNLIKELY( close( fd ) ) )

--- a/src/util/sandbox/Local.mk
+++ b/src/util/sandbox/Local.mk
@@ -1,0 +1,4 @@
+$(call add-hdrs,fd_sandbox.h)
+$(call add-objs,fd_sandbox,fd_util)
+$(call make-unit-test,test_sandbox,test_sandbox,fd_util)
+$(call run-unit-test,test_sandbox,)

--- a/src/util/sandbox/fd_sandbox.c
+++ b/src/util/sandbox/fd_sandbox.c
@@ -1,0 +1,269 @@
+#if !defined(__linux__)
+# error "Target operating system is unsupported by seccomp."
+#endif
+
+#define _GNU_SOURCE
+
+#include "fd_sandbox.h"
+
+#include <string.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <errno.h>
+#include <linux/audit.h>
+#include <linux/securebits.h>
+#include <linux/seccomp.h>
+#include <linux/filter.h>
+#include <linux/capability.h>
+#include <dirent.h>
+#include <limits.h>
+#include <sched.h>        /* CLONE_*, setns, unshare */
+#include <stddef.h>
+#include <stdlib.h>       /* clearenv, mkdtemp*/
+#include <sys/mount.h>    /* MS_*, MNT_*, mount, umount2 */
+#include <sys/prctl.h>
+#include <sys/resource.h> /* RLIMIT_*, rlimit, setrlimit */
+#include <sys/stat.h>     /* mkdir */
+#include <sys/syscall.h>  /* SYS_* */
+#include <unistd.h>       /* set*id, sysconf, close, chdir, rmdir syscall */
+
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+
+#define X32_SYSCALL_BIT 0x40000000
+
+#define ALLOW_SYSCALL(name)                                \
+  /* If the syscall does not match, jump over RET_ALLOW */ \
+  BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_##name, 0, 1),  \
+  BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW)
+
+#if defined(__i386__)
+# define ARCH_NR  AUDIT_ARCH_I386
+#elif defined(__x86_64__)
+# define ARCH_NR  AUDIT_ARCH_X86_64
+#elif defined(__aarch64__)
+# define ARCH_NR AUDIT_ARCH_AARCH64
+#else
+# error "Target architecture is unsupported by seccomp."
+#endif
+
+#define FD_TESTV(c) do { if( FD_UNLIKELY( !(c) ) ) FD_LOG_ERR(( "FAIL: (%d:%s) %s", errno, strerror( errno ), #c )); } while(0)
+
+static void
+secure_clear_environment( void ) {
+  char** env = environ;
+  while ( *env ) {
+    size_t len = strlen( *env );
+    explicit_bzero( *env, len );
+    env++;
+  }
+  clearenv();
+}
+
+static void
+setup_mountns( void ) {
+  FD_TESTV( unshare ( CLONE_NEWNS ) == 0 );
+
+  char temp_dir [] = "/tmp/fd-sandbox-XXXXXX";
+  FD_TESTV( NULL != mkdtemp( temp_dir ) );
+  FD_TESTV( 0 == mount( NULL, "/", NULL, MS_SLAVE | MS_REC, NULL ) );
+  FD_TESTV( 0 == mount( temp_dir, temp_dir, NULL, MS_BIND | MS_REC, NULL ) );
+  FD_TESTV( 0 == chdir( temp_dir ) );
+  FD_TESTV( 0 == mkdir( "old-root", S_IRUSR | S_IWUSR ));
+  FD_TESTV( 0 == syscall( SYS_pivot_root, ".", "old-root" ) );
+  FD_TESTV( 0 == chdir( "/" ) );
+  FD_TESTV( 0 == umount2( "old-root", MNT_DETACH ) );
+  FD_TESTV( 0 == rmdir( "old-root" ) );
+}
+
+#define CLOSE_RANGE_UNSHARE (1U << 1)
+
+static void
+close_fds_proc( void ) {
+  DIR * dir = opendir( "/proc/self/fd" );
+  FD_TESTV( NULL != dir );
+  int dirfd1 = dirfd( dir );
+  FD_TESTV( dirfd1 >= 0 );
+
+  struct dirent *dp;
+  while( ( dp = readdir( dir ) ) != NULL ) {
+    char *end;
+    long fd = strtol( dp->d_name, &end, 10 );
+    FD_TESTV( fd < INT_MAX && fd > INT_MIN );
+    if ( *end != '\0' ) {
+      continue;
+    }
+
+    if ( fd >= 3 && fd != dirfd1 ) {
+      FD_TESTV( 0 == close( (int)fd ) );
+    }
+  }
+
+  FD_TESTV( 0 == closedir( dir ) );
+}
+
+static void
+close_fds( void ) {
+  if( syscall( SYS_close_range, 3, UINT_MAX, CLOSE_RANGE_UNSHARE ) ) {
+    // No SYS_close_range, close one by one
+    FD_TESTV( errno == ENOSYS );
+    close_fds_proc();
+  }
+}
+
+static void
+install_seccomp( void ) {
+  struct sock_filter filter [] = {
+    // [0] Validate architecture
+    // Load the arch number
+    BPF_STMT( BPF_LD | BPF_W | BPF_ABS, ( offsetof( struct seccomp_data, arch ) ) ),
+    // Do not jump (and die) if the compile arch is neq the runtime arch.
+    // Otherwise, jump over the SECCOMP_RET_KILL_PROCESS statement.
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, ARCH_NR, 1, 0 ),
+    BPF_STMT( BPF_RET | BPF_K, SECCOMP_RET_ALLOW ),
+
+    // [1] Verify that the syscall is allowed
+    // Load the syscall
+    BPF_STMT( BPF_LD | BPF_W | BPF_ABS, ( offsetof( struct seccomp_data, nr ) ) ),
+
+    // Attempt to sort syscalls by call frequency.
+    ALLOW_SYSCALL( writev       ),
+    ALLOW_SYSCALL( write        ),
+    ALLOW_SYSCALL( fsync        ),
+    ALLOW_SYSCALL( gettimeofday ),
+    ALLOW_SYSCALL( futex        ),
+    // sched_yield is useful for both floating threads and hyperthreaded pairs.
+    ALLOW_SYSCALL( sched_yield  ),
+    // The rules under this line are expected to be used in fewer occasions.
+    // exit is needed to let tiles exit gracefully.
+    ALLOW_SYSCALL( exit         ),
+    // exit_group is needed to let any tile crash the whole group.
+    ALLOW_SYSCALL( exit_group   ),
+    // munmap is needed for a clean exit.
+    ALLOW_SYSCALL( munmap       ),
+    // nanosleep is needed for a clean exit.
+    ALLOW_SYSCALL( nanosleep    ),
+    ALLOW_SYSCALL( rt_sigaction ),
+    ALLOW_SYSCALL( rt_sigreturn ),
+    ALLOW_SYSCALL( sync         ),
+    // close is needed for a clean exit and for closing logs.
+    ALLOW_SYSCALL( close        ),
+    ALLOW_SYSCALL( sendto       ),
+
+    // [2] None of the syscalls approved were matched: die
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS),
+  };
+
+  FD_TESTV( 0 == prctl( PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0 ) );
+
+  struct sock_fprog default_prog = {
+    .len = ARRAY_SIZE( filter ),
+    .filter = filter,
+  };
+  FD_TESTV( 0 == syscall( SYS_seccomp, SECCOMP_SET_MODE_FILTER, 0, &default_prog ) );
+}
+
+static void
+drop_capabilities( void ) {
+  FD_TESTV( 0 == prctl (
+    PR_SET_SECUREBITS,
+    SECBIT_KEEP_CAPS_LOCKED | SECBIT_NO_SETUID_FIXUP |
+      SECBIT_NO_SETUID_FIXUP_LOCKED | SECBIT_NOROOT |
+      SECBIT_NOROOT_LOCKED | SECBIT_NO_CAP_AMBIENT_RAISE |
+      SECBIT_NO_CAP_AMBIENT_RAISE_LOCKED ) );
+
+  struct __user_cap_header_struct hdr = { _LINUX_CAPABILITY_VERSION_3, 0 };
+  struct __user_cap_data_struct   data[2] = { { 0 } };
+  FD_TESTV( 0 == syscall( SYS_capset, &hdr, data ) );
+
+  FD_TESTV( 0 == prctl( PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0 ) );
+}
+
+static uint overflow_id(const char * path) {
+  int fd = open( path, O_RDONLY );
+  FD_TESTV( fd >= 0 );
+  char buf[16];
+  ssize_t len = read( fd, buf, sizeof(buf) );
+  FD_TESTV( len > 0 );
+  close( fd );
+  buf[len] = '\0';
+  int result = atoi( buf );
+  FD_TESTV( result >= 0 );
+  return (uint)result;
+}
+
+static void userns_map( uint id, const char * map ) {
+  char path[64];
+  FD_TESTV( sprintf( path, "/proc/self/%s", map ) > 0);
+  int fd = open( path, O_WRONLY );
+  FD_TESTV( fd >= 0 );
+  char line[64];
+  FD_TESTV( sprintf( line, "0 %u 1\n", id ) > 0 );
+  FD_TESTV( write( fd, line, strlen( line ) ) > 0 );
+  FD_TESTV( 0 == close( fd ) );
+}
+
+static void deny_setgroups( void ) {
+  int fd = open( "/proc/self/setgroups", O_WRONLY );
+  FD_TESTV( fd >= 0 );
+  FD_TESTV( write( fd, "deny", strlen( "deny" ) ) > 0 );
+  FD_TESTV( 0 == close( fd ) );
+}
+
+static void unshare_user( int *    pargc,
+                          char *** pargv ) {
+  uint overflow_uid = overflow_id( "/proc/sys/kernel/overflowuid" );
+  uint overflow_gid = overflow_id( "/proc/sys/kernel/overflowgid" );
+  uint uid = fd_env_strip_cmdline_uint( pargc, pargv, "--uid", "FD_UID", overflow_uid );
+  uint gid = fd_env_strip_cmdline_uint( pargc, pargv, "--gid", "FD_GID", overflow_gid );
+
+  FD_TESTV( uid != 0 && gid != 0 );
+
+  FD_TESTV( 0 == setresgid( gid, gid, gid ) );
+  FD_TESTV( 0 == setresuid( uid, uid, uid ) );
+  FD_TESTV( 0 == prctl( PR_SET_DUMPABLE, 1, 0, 0, 0 ) );
+
+  FD_TESTV( 0 == unshare( CLONE_NEWUSER | CLONE_NEWNS | CLONE_NEWNET ) );
+  deny_setgroups();
+  userns_map( getuid(), "uid_map" );
+  userns_map( getgid(), "gid_map" );
+
+  FD_TESTV( 0 == prctl( PR_SET_DUMPABLE, 0, 0, 0, 0 ) );
+  for ( int cap = 0; cap <= CAP_LAST_CAP; cap++ ) {
+    FD_TESTV( 0 == prctl( PR_CAPBSET_DROP, cap, 0, 0, 0 ) );
+  }
+}
+
+void
+fd_sandbox_private_privileged( int *    pargc,
+                               char *** pargv ) {
+  (void) pargc;
+  for( char ** argv = *pargv; *argv; argv++ ) {
+    if( !strcmp( *argv, "--no-sandbox" ) ) {
+      return;
+    }
+  }
+
+  unshare_user( pargc, pargv );
+  setup_mountns();
+  drop_capabilities();
+  secure_clear_environment();
+}
+
+void
+fd_sandbox_private( int *    pargc,
+                    char *** pargv ) {
+  if( fd_env_strip_cmdline_contains( pargc, pargv, "--no-sandbox" ) ) {
+    return;
+  }
+
+  fd_sandbox_private_no_seccomp();
+  install_seccomp();
+}
+
+void
+fd_sandbox_private_no_seccomp( void ) {
+  struct rlimit limit = { .rlim_cur = 3, .rlim_max = 3 };
+  FD_TESTV( 0 == setrlimit( RLIMIT_NOFILE, &limit ));
+
+  close_fds();
+}

--- a/src/util/sandbox/test_sandbox.c
+++ b/src/util/sandbox/test_sandbox.c
@@ -1,0 +1,208 @@
+#if !defined(__linux__)
+# error "Target operating system is unsupported by seccomp."
+#endif
+
+#define _GNU_SOURCE
+
+#include "../fd_util.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/capability.h> /* Definition of CAP_* and
+                                 _LINUX_CAPABILITY_* constants */
+#include <net/if.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>      /* Definition of SYS_* constants */
+
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include "fd_sandbox.c"
+
+#define TEST_FORK(child) do {                                       \
+    pid_t pid = fork();                                             \
+    if ( pid ) {                                                    \
+      int wstatus;                                                  \
+      FD_TEST( -1 != waitpid( pid, &wstatus, WUNTRACED ) );         \
+      FD_TEST( WIFEXITED( wstatus ) );                              \
+      FD_TEST( !WEXITSTATUS( wstatus ) );                           \
+      FD_TEST( !WIFSIGNALED( wstatus ) );                           \
+      FD_TEST( !WIFSTOPPED( wstatus ) );                            \
+    } else {                                                        \
+      do { child } while ( 0 );                                     \
+      exit( EXIT_SUCCESS );                                         \
+    }                                                               \
+} while( 0 )
+
+
+/* close_open_fds ensures that, after calling `fd_sandbox_private`, no FDs
+   beyond an allowed number are opened. */
+void
+close_open_fds( void ) {
+  int fd = open( "/etc/passwd", O_RDONLY );
+  FD_TEST( -1 != fd && fd >= 3 );
+
+  TEST_FORK(
+    FD_TEST( fcntl( fd, F_GETFD ) != -1 );
+    fd_sandbox_private_no_seccomp();
+    FD_TEST( fcntl( fd, F_GETFD ) == -1 );
+  );
+}
+
+/* close_open_fds_proc ensures that, after calling `fd_sandbox_private`, no FDs
+   beyond an allowed number are opened. Uses the /proc implementation
+   directly. */
+void
+close_open_fds2( void ) {
+  int fd = open( "/etc/passwd", O_RDONLY );
+  FD_TEST( -1 != fd && fd >= 3 );
+
+  TEST_FORK(
+    FD_TEST( fcntl( fd, F_GETFD ) != -1 );
+    close_fds_proc();
+    FD_TEST( fcntl( fd, F_GETFD ) == -1 );
+  );
+}
+
+/* resource_limits ensures that, after calling `fd_sandbox_private`,
+   the set limits cannot be exceeded. */
+void
+resource_limits( void ) {
+  TEST_FORK(
+    FD_TEST( -1 != open("/etc/passwd", O_RDONLY) );
+    fd_sandbox_private_no_seccomp();
+    FD_TEST( -1 == open("/etc/passwd", O_RDONLY) );
+    FD_TEST( EMFILE == errno );
+  );
+}
+
+void
+not_dumpable( void ) {
+  TEST_FORK(
+    FD_TEST( prctl( PR_GET_DUMPABLE ) );
+    fd_sandbox_private_privileged( (int[]){0}, (char**[]){&(char*[]){NULL}[0]} );
+    FD_TEST( !prctl( PR_GET_DUMPABLE ) );
+  );
+}
+
+void
+no_capabilities( void ) {
+  struct __user_cap_header_struct hdr = { _LINUX_CAPABILITY_VERSION_3, 0 };
+  struct __user_cap_data_struct   data[2] = { { 0 } };
+  TEST_FORK(
+    FD_TEST( 0 == syscall( SYS_capget, &hdr, data ) );
+    FD_TEST( data[0].effective || data[1].effective );
+
+    fd_sandbox_private_privileged( (int[]){0}, (char**[]){&(char*[]){NULL}[0]} );
+
+    FD_TEST( 0 == syscall( SYS_capget, &hdr, data ) );
+    FD_TEST( !data[0].effective && !data[1].effective );
+  );
+}
+
+/* change_userns ensures that, after calling `fd_sandbox_private_privileged`,
+   the process' {real,effective}x{uid,gid} are matching the desired user's. */
+void
+change_userns( void ) {
+  FD_TEST( getuid() != 65534 );
+  FD_TEST( geteuid() != 65534 );
+  FD_TEST( getgid() != 65534 );
+  FD_TEST( getegid() != 65534 );
+
+  TEST_FORK(
+    unshare_user( (int[]){0}, (char**[]){&(char*[]){NULL}[0]} );
+
+    // Inside the sandbox
+    FD_TEST( getuid() == 0 );
+    FD_TEST( geteuid() == 0 );
+    FD_TEST( getgid() == 0 );
+    FD_TEST( getegid() == 0 );
+
+    char buffer[34];
+    FILE * file = fopen( "/proc/self/uid_map", "r" );
+    FD_TEST( 33 == fread( buffer, 1, 34, file ) );
+    buffer[33] = '\0';
+    FD_TEST( strcmp( buffer, "         0      65534          1\n" ) == 0 );
+
+    file = fopen( "/proc/self/gid_map", "r" );
+    FD_TEST( 33 == fread( buffer, 1, 34, file ) );
+    buffer[33] = '\0';
+    FD_TEST( strcmp( buffer, "         0      65534          1\n" ) == 0 );
+  );
+}
+
+/* netns ensures that, after calling `fd_sandbox_private_privileged`,
+   the process' view of the network interfaces is limited to the expected. */
+void
+netns( void ) {
+  TEST_FORK(
+    struct if_nameindex * ifs = if_nameindex();
+    FD_TEST( ifs[1].if_name != NULL );
+
+    fd_sandbox_private_privileged( (int[]){0}, (char**[]){&(char*[]){NULL}[0]} );
+
+    ifs = if_nameindex();
+    FD_TEST( !strcmp(ifs[0].if_name, "lo") );
+    FD_TEST( ifs[1].if_name == NULL );
+  );
+}
+
+/* mountns_null ensures that, after calling `fd_sandbox_private`,
+   the root mount should be empty and belong to root. */
+void
+mountns_null( void ) {
+  TEST_FORK(
+    fd_sandbox_private_privileged( (int[]){0}, (char**[]){&(char*[]){NULL}[0]} );
+    DIR * dir = opendir( "/" );
+    FD_TEST( dir != NULL );
+
+    struct dirent * entry;
+    while(( entry = readdir( dir ) )) {
+      FD_TEST( !strcmp( entry->d_name, "." ) || !strcmp( entry->d_name, ".." ) );
+    }
+
+    struct stat sb;
+    FD_TEST( 0 == stat( "/", &sb ) );
+    FD_TEST( 0 == sb.st_uid );
+    FD_TEST( 0 == sb.st_gid );
+  );
+}
+
+/* test_seccomp_default_filter ensures that, after calling `fd_sandbox_private`,
+   seccomp is effective. */
+void
+seccomp_default_filter( void ) {
+  pid_t pid = fork();
+  if ( pid ) {
+    int wstatus;
+    FD_TEST( -1 != waitpid( pid, &wstatus, WUNTRACED ) );
+    FD_TEST( WIFSIGNALED( wstatus) && WTERMSIG( wstatus ) == SIGSYS );
+  } else { // child
+    fd_sandbox_private( NULL, NULL );
+    // This should fail with SIGSYS
+    execl( "/bin/true", "" );
+    exit( EXIT_FAILURE );
+  }
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  (void) argc;
+  (void) argv;
+
+  close_open_fds();
+  close_open_fds2();
+  resource_limits();
+  not_dumpable();
+  no_capabilities();
+  change_userns();
+  netns();
+  mountns_null();
+  seccomp_default_filter();
+}

--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -834,6 +834,15 @@ void
 fd_wksp_cstr_memset( char const * cstr,
                      int          c );
 
+/* fd_wksp_preload maps a workspace into memory in the process and
+   then "forgets" about it. This might be needed due to the security
+   architecture, where a privileged section of code can initialize
+   the memory map, not release it, and then all subsequent joins
+   for that workspace (who can no longer open a file or call mmap)
+   may reuse the same already-mapped memory. */
+void *
+fd_wksp_preload( char const * gaddr );
+
 /* fd_wksp_map returns a pointer in the caller's address space to
    the wksp allocation specified by a cstr containing [name]:[gaddr].
    [name] is the name of the shared memory region holding the wksp.

--- a/src/util/wksp/fd_wksp_helper.c
+++ b/src/util/wksp/fd_wksp_helper.c
@@ -436,6 +436,15 @@ fd_wksp_cstr_memset( char const * cstr,
 }
 
 void *
+fd_wksp_preload( char const * cstr ) {
+  char  name[ FD_SHMEM_NAME_MAX ];
+  ulong gaddr;
+  if( FD_UNLIKELY( !fd_wksp_private_cstr_parse( cstr, name, &gaddr ) ) ) return NULL;
+
+  return fd_shmem_join( name, FD_SHMEM_JOIN_MODE_READ_WRITE, NULL, NULL, NULL );
+}
+
+void *
 fd_wksp_map( char const * cstr ) {
   char  name[ FD_SHMEM_NAME_MAX ];
   ulong gaddr;


### PR DESCRIPTION
The purpose of the sandbox is to reduce the impact of a Firedancer compromise.

When starting, before executing any task code and/or processing user-provided input, a Firedancer process prepares everything it needs in order to function properly. This initialization mostly consists in:

 * Creating new tiles which will be used for task execution (clone syscall)
 * Opening the relevant workspaces which will be used to perform work and communicate (mmap syscall)
 * Immediately after performing those operations, Firedancer sandboxes itself. Note that firedancer has to be started as root or with various capabilities in order to be able to sandbox itself.

Here are the mechanisms currently used by Firedancer to achieve sandboxing:

 * The environment variable are cleared. Environment variables are commonly used to hold secrets. If Firedancer is compromised, no secrets living in the operator's environment will be leaked.
 * The process loses access to network interfaces. The process unshares the network namespace to keep the principle of least privilege: in the event where the process was able to interact with a network interface, it should not be able to perform any communication.
 * The process gets a restricted view of the filesystem. It is jailed into a mount namespace with a root of its own. The process should only be able to interact with files that it needs to function.
 * The process is restricted from opening any new files with restrictive resource limits. In the future, more resources types can be limited. Firedancer processes have well understood expected behaviors and resource needs. A process should not be able to exceed those limits, potentially leading to availability issues.
 * The process enters a new user namespace, and the user it runs as inside the namespace is mapped to the overflow user outside of the namespace. In the case where another control was to fail, the process should be interacting with the system as an unprivileged user.
 * All file descriptors above a specified number are forcefully closed. Similar to and more impactful than clearenv, an operator's process can have FDs opened that are 1. not relevant to Firedancer 2. references to sensitive resources. Those resources should not be made available to Firedancer.
 * We prevent the usage of most syscalls, only allowing those explicitly needed by the specific Firedancer component. Syscalls are used to interact with the operating system. There exists close to 400 syscalls. While running, A Firedancer process requires 14 syscalls out of those 400 in order to perform its functions. Firedancer will crash if it attempts to use a syscall that is not expected. Note: It also happens that the syscalls that Firedancer is using are ubiquitous and well understood. They have stood the test of time (not that time is an ultimate metric for greatness). We have the luxury of disallowing all of the syscalls that might have received less scrutiny.