### PR TITLE
tile: separate process per tile

### DIFF
--- a/src/app/fdctl/src/commands/run.rs
+++ b/src/app/fdctl/src/commands/run.rs
@@ -104,7 +104,7 @@ pub(crate) fn run(args: RunCli, config: &mut Config) {
     let prefix_gdb = if args.debug {
         format!("gdb --args {}/fd_frank_run.bin", config.binary_dir)
     } else if args.strace {
-        format!("strace {}/fd_frank_run.bin", config.binary_dir)
+        format!("strace -f {}/fd_frank_run.bin", config.binary_dir)
     } else {
         format!("{}/fd_frank_run.bin", config.binary_dir)
     };
@@ -131,7 +131,7 @@ pub(crate) fn run(args: RunCli, config: &mut Config) {
     ];
 
     let sandbox = if config.development.sandbox {
-        ""
+        "--tile-empty-groups"
     } else {
         "--no-sandbox"
     };

--- a/src/app/frank/fd_frank.c
+++ b/src/app/frank/fd_frank.c
@@ -1,1 +1,4 @@
+#include "fd_frank.h"
+
 char const * FD_FRANK_CONFIGURATION_PREFIX = "firedancer";
+char const * pod_gaddr = NULL;

--- a/src/app/frank/fd_frank.h
+++ b/src/app/frank/fd_frank.h
@@ -32,6 +32,10 @@
    prepend when looking up our configuration. */
 extern char const * FD_FRANK_CONFIGURATION_PREFIX;
 
+/* Pod gaddr specified in the command line and passed between
+   different memory isolated processes. */
+extern char const * pod_gaddr;
+
 FD_PROTOTYPES_BEGIN
 
 /* fd_frank_{verify,dedup,pack}_task is a fd_tile_task_t compatible

--- a/src/app/frank/fd_frank_dedup.c
+++ b/src/app/frank/fd_frank_dedup.c
@@ -6,13 +6,11 @@ int
 fd_frank_dedup_task( int     argc,
                      char ** argv ) {
   (void)argc;
-  fd_log_thread_set( argv[0] );
+  (void)argv;
+  fd_log_thread_set( "dedup" );
   FD_LOG_INFO(( "dedup init" ));
 
-  /* Parse "command line" arguments */
-
-  char const * pod_gaddr = argv[1];
-  char const * cfg_path  = argv[2];
+  char const * cfg_path  = FD_FRANK_CONFIGURATION_PREFIX;
 
   /* Load up the configuration for this frank instance */
 

--- a/src/app/frank/fd_frank_pack.c
+++ b/src/app/frank/fd_frank_pack.c
@@ -9,12 +9,12 @@ int
 fd_frank_pack_task( int     argc,
                     char ** argv ) {
   (void)argc;
-  fd_log_thread_set( argv[0] );
+  (void)argv;
+  fd_log_thread_set( "pack" );
   FD_LOG_INFO(( "pack init" ));
 
   /* Parse "command line" arguments */
 
-  char const * pod_gaddr = argv[1];
   char const * cfg_path  = FD_FRANK_CONFIGURATION_PREFIX;
 
   ulong tile_idx = fd_tile_idx();

--- a/src/app/frank/fd_frank_quic.c
+++ b/src/app/frank/fd_frank_quic.c
@@ -34,25 +34,21 @@ int
 fd_frank_quic_task( int     argc,
                     char ** argv ) {
   (void)argc;
-  fd_log_thread_set( argv[0] );
-  char const * quic_name = argv[0];
+
+  ulong idx = (ulong)argv;
+  char quic_name[10];
+  if( FD_UNLIKELY( snprintf( quic_name, sizeof(quic_name), "quic%lu", idx ) ) == 10 )
+    FD_LOG_ERR(( "snprintf failed" ));
+
+  fd_log_thread_set( quic_name );
   FD_LOG_INFO(( "quic.%s init", quic_name ));
 
-  /* Parse "command line" arguments */
-
-  char const * pod_gaddr = argv[1];
-  char const * cfg_path  = argv[2];
-  char const * idx_cstr  = argv[3];
-
-  char * endptr = NULL;
-  ulong idx = strtoul( idx_cstr, &endptr, 10 );
-  if( FD_UNLIKELY( *endptr!='\0' ) ) FD_LOG_ERR(( "idx %s not a number", idx_cstr ));
-  if( errno == ERANGE ) FD_LOG_ERR(( "idx %s out of range", idx_cstr ));
   if( FD_UNLIKELY( idx>=FD_TILE_MAX ) ) FD_LOG_ERR(( "idx %lu out of range", idx ));
   if( FD_UNLIKELY( !preload_xsks[ idx ] ) ) FD_LOG_ERR(( "preload_xsks[ %lu ] not set", idx ));
 
   /* Load up the configuration for this frank instance */
 
+  char const * cfg_path  = FD_FRANK_CONFIGURATION_PREFIX;
   FD_LOG_INFO(( "using configuration in pod %s at path %s", pod_gaddr, cfg_path ));
   uchar const * pod     = fd_wksp_pod_attach( pod_gaddr );
   uchar const * cfg_pod = fd_pod_query_subpod( pod, cfg_path );

--- a/src/app/frank/fd_frank_verify.c
+++ b/src/app/frank/fd_frank_verify.c
@@ -1,22 +1,25 @@
 #include "fd_frank.h"
 
+#include <stdio.h>
+
 #if FD_HAS_FRANK
 
 int
 fd_frank_verify_task( int     argc,
                       char ** argv ) {
   (void)argc;
-  fd_log_thread_set( argv[0] );
-  char const * verify_name = argv[0];
+
+  ulong idx = (ulong)argv;
+  char verify_name[10];
+  if( FD_UNLIKELY( snprintf( verify_name, sizeof(verify_name), "v%lu", idx ) == 10 ) )
+    FD_LOG_ERR(( "snprintf failed" ));
+
+  fd_log_thread_set( verify_name );
   FD_LOG_INFO(( "verify.%s init", verify_name ));
   
-  /* Parse "command line" arguments */
-
-  char const * pod_gaddr = argv[1];
-  char const * cfg_path  = FD_FRANK_CONFIGURATION_PREFIX;
-
   /* Load up the configuration for this frank instance */
 
+  char const * cfg_path  = FD_FRANK_CONFIGURATION_PREFIX;
   FD_LOG_INFO(( "using configuration in pod %s at path %s", pod_gaddr, cfg_path ));
   uchar const * pod     = fd_wksp_pod_attach( pod_gaddr );
   uchar const * cfg_pod = fd_pod_query_subpod( pod, cfg_path );

--- a/src/util/env/fd_env.h
+++ b/src/util/env/fd_env.h
@@ -57,13 +57,13 @@ FD_ENV_STRIP_CMDLINE_DECL( double,       double );
 
 #undef FD_ENV_STRIP_CMDLINE_DECL
 
-FD_PROTOTYPES_END
-
 /* returns 1 if the command line contains the given key, and removes
    it from the args, otherwise returns 0. */
 int
 fd_env_strip_cmdline_contains( int *        pargc,
                                char ***     pargv,
                                char const * key );
+
+FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_env_fd_env_h */

--- a/src/util/fd_util.c
+++ b/src/util/fd_util.c
@@ -46,7 +46,7 @@ fd_boot_secure2( int *    pargc,
   fd_tile_private_boot                 ( pargc, pargv ); /* The caller is now tile 0 */
 
   // 4. Enter sandbox and restrict all system calls
-  fd_sandbox_private                   ( pargc, pargv );
+  fd_sandbox_private                   ();
 }
 
 void

--- a/src/util/fd_util.h
+++ b/src/util/fd_util.h
@@ -252,8 +252,7 @@ FD_PROTOTYPES_BEGIN
        thread group with whatever priority was initially assigned the
        thread group.  Fixed tiles run on the specified tile with high
        scheduler priority.  Tile 0's stack is the default stack used by
-       the job launcher.  Floating tiles use the default stack provided
-       by pthread_create.  All other tiles (i.e. high performance fixed
+       the job launcher.  All other tiles (i.e. high performance fixed
        tiles) use an 8 MiB huge page backed numa optimized stack (if
        possible).
 
@@ -270,7 +269,26 @@ FD_PROTOTYPES_BEGIN
 
        If tile 0 is not a floating tile, recommend using
        "taskset -c [cpu for tile 0]" or equivalent at thread group launch
-       to have the OS place the booter on the correct cpu from the start. */
+       to have the OS place the booter on the correct cpu from the start.
+
+     --tile-empty-groups
+    
+        If this is specified, every tile runs in its own group with a
+        fully isolated process and virtual memory address space.
+
+     --tile-groups [group-list] / FD_TILE_GROUPS=[group-list]
+
+       If this is specified, tile groups can be specified which will
+       run in different processes with different virtual memory address
+       spaces. Tiles sharing memory space must have contiguous indexes.
+       For example, with 5 tiles,
+
+          --tile-groups 1,2,2,1
+
+       Tile 0 will be in a process with a unique virtual memory space.
+       Tiles 1 and 2 will share a memory space, tiles 3 and 4 will
+       share a process and address space, and tile 5 will have its own
+       process and address space. */
 
 void
 fd_boot( int *    pargc,

--- a/src/util/sandbox/fd_sandbox.h
+++ b/src/util/sandbox/fd_sandbox.h
@@ -4,6 +4,8 @@
 #include "../env/fd_env.h"
 #include "../log/fd_log.h"
 
+FD_PROTOTYPES_BEGIN
+
 /* The purpose of the sandbox is to reduce the impact of a Firedancer
    compromise.
 
@@ -74,12 +76,13 @@ fd_sandbox_private_privileged( int *    pargc,
    ones.
 */
 void
-fd_sandbox_private( int *    pargc,
-                    char *** pargv );
+fd_sandbox_private( void );
 
 /* Only used by test code. Install private sandbox without seccomp, used so
    we can test with some syscalls without bringing down the process. */
 void
 fd_sandbox_private_no_seccomp( void );
+
+FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_util_sandbox_fd_sandbox_h */

--- a/src/util/tile/fd_tile_nothreads.cxx
+++ b/src/util/tile/fd_tile_nothreads.cxx
@@ -8,6 +8,8 @@ ulong fd_tile_id0( void ) { return fd_tile_private_id0; }
 ulong fd_tile_id1( void ) { return fd_tile_private_id1; }
 ulong fd_tile_cnt( void ) { return fd_tile_private_cnt; }
 
+ulong fd_tile_cnt_boot( void ) { return fd_tile_private_cnt; }
+
 static ulong fd_tile_private_id;     /* 0 outside boot/halt, init on boot */
 static ulong fd_tile_private_idx;    /* " */
 /**/   ulong fd_tile_private_stack0; /* " */
@@ -72,6 +74,12 @@ fd_tile_private_boot( int *    pargc,
 
   if( fd_env_strip_cmdline_cstr( pargc, pargv, "--tile-cpus", "FD_TILE_CPUS", NULL ) )
     FD_LOG_INFO(( "fd_tile: ignoring --tile-cpus (group not threaded)" ));
+
+  if( fd_env_strip_cmdline_cstr( pargc, pargv, "--tile-groups", "FD_TILE_GROUPS", NULL ) )
+    FD_LOG_INFO(( "fd_tile: ignoring --tile-groups (group not threaded)" ));
+
+  if( fd_env_strip_cmdline_contains( pargc, pargv, "--tile-empty-groups" ) )
+    FD_LOG_INFO(( "fd_tile: ignoring --tile-empty-groups (group not threaded)" ));
 
   fd_tile_private_id0 = fd_log_thread_id();
   fd_tile_private_id1 = fd_tile_private_id0 + 1UL;


### PR DESCRIPTION
Tiles can now run in isolated groups where each group is a different
virtual memory space.  This is done for security isolation so that they
don't share memory and in future they can have different seccomp
profiles.  For now, the tiles still share a global workspace but using
the MAP_SHARED and MAP_ANONYMOUS semantics this can be finely controlled
going forward.  Currently, the tile private info area that allows task
dispatching is shared between the init tile (0) and the tile that can be
dispatched to, so this is already isolated.

The main change here is lifting certain statics and globals associated
with task-dispatch into shared memory.  Particularly gross is the
lifting of argv, for which I just set up a fixed size buffer area in the
shmem.

There's one annoying thing I couldn't figure out, which is the first
read from the gigantic page workspace in any cloned process takes about
half a second, presumably the kernel is doing some COW magic.