### PR TITLE
Code maintenance

### DIFF
--- a/contrib/make-j
+++ b/contrib/make-j
@@ -6,7 +6,7 @@ if [ "$ISOLCPUS" = "" ]; then
 
         # No CPU isolation is setup ... just do a normal parallel make
 
-        make -j "$@"
+        make -j -Otarget "$@"
 
 else
 
@@ -32,7 +32,7 @@ else
 
         NP=$(nproc --all)
         NP_OS=$(nproc)
-        chrt -r 1 taskset -c "$ISOLCPUS" make -j$((NP-NP_OS)) "$@"
+        chrt -r 1 taskset -c "$ISOLCPUS" make -j$((NP-NP_OS)) -Otarget "$@"
 
 fi
 

--- a/src/app/frank/Local.mk
+++ b/src/app/frank/Local.mk
@@ -1,3 +1,5 @@
+ifdef FD_HAS_DOUBLE
 $(call make-bin,fd_frank_run.bin,fd_frank_main fd_frank_verify fd_frank_dedup fd_frank_pack fd_frank,fd_disco fd_ballet fd_tango fd_util)
 $(call make-bin,fd_frank_mon.bin,fd_frank_mon.bin fd_frank,fd_disco fd_ballet fd_tango fd_util)
 $(call add-scripts,fd_frank_init fd_frank_run fd_frank_mon fd_frank_fini)
+endif

--- a/src/ballet/chacha20/Local.mk
+++ b/src/ballet/chacha20/Local.mk
@@ -1,6 +1,8 @@
+ifdef FD_HAS_INT128
 $(call add-hdrs,fd_chacha20.h fd_chacha20rng.h)
 $(call add-objs,fd_chacha20 fd_chacha20rng,fd_ballet)
 $(call make-unit-test,test_chacha20,test_chacha20,fd_ballet fd_util)
 $(call make-unit-test,test_chacha20rng,test_chacha20rng,fd_ballet fd_util)
 $(call run-unit-test,test_chacha20)
 $(call run-unit-test,test_chacha20rng)
+endif

--- a/src/ballet/chacha20/fd_chacha20rng.c
+++ b/src/ballet/chacha20/fd_chacha20rng.c
@@ -26,16 +26,28 @@ fd_chacha20rng_new( void * shmem ) {
 
 fd_chacha20rng_t *
 fd_chacha20rng_join( void * shrng ) {
+  if( FD_UNLIKELY( !shrng ) ) {
+    FD_LOG_WARNING(( "NULL shrng" ));
+    return NULL;
+  }
   return (fd_chacha20rng_t *)shrng;
 }
 
 void *
 fd_chacha20rng_leave( fd_chacha20rng_t * rng ) {
+  if( FD_UNLIKELY( !rng ) ) {
+    FD_LOG_WARNING(( "NULL rng" ));
+    return NULL;
+  }
   return (void *)rng;
 }
 
 void *
 fd_chacha20rng_delete( void * shrng ) {
+  if( FD_UNLIKELY( !shrng ) ) {
+    FD_LOG_WARNING(( "NULL shrng" ));
+    return NULL;
+  }
   memset( shrng, 0, sizeof(fd_chacha20rng_t) );
   return shrng;
 }

--- a/src/ballet/ebpf/Local.mk
+++ b/src/ballet/ebpf/Local.mk
@@ -1,3 +1,5 @@
+ifdef FD_HAS_HOSTED
 $(call add-hdrs,fd_ebpf.h)
 $(call add-objs,fd_ebpf,fd_ballet)
 $(call make-unit-test,test_ebpf,test_ebpf,fd_ballet fd_util,src/tango/xdp/fd_xdp_redirect_prog.o)
+endif

--- a/src/ballet/ed25519/avx/fd_ed25519_ge.c
+++ b/src/ballet/ed25519/avx/fd_ed25519_ge.c
@@ -379,7 +379,7 @@ static int *
 fd_ed25519_ge_slide( int *         r,
                      uchar const * a ) {
 
-  for( int i=0; i<256; i++ ) r[i] = 1 & (((uint)a[i >> 3]) >> (i & 7));
+  for( int i=0; i<256; i++ ) r[i] = (int)(1U & (((uint)a[i >> 3]) >> (i & 7)));
 
   for( int i=0; i<256; i++ ) {
     if( !r[i] ) continue;

--- a/src/ballet/ed25519/ref/fd_ed25519_ge.c
+++ b/src/ballet/ed25519/ref/fd_ed25519_ge.c
@@ -444,7 +444,7 @@ static int *
 fd_ed25519_ge_slide( int *         r,
                      uchar const * a ) {
 
-  for( int i=0; i<256; i++ ) r[i] = 1 & (((uint)a[i >> 3]) >> (i & 7));
+  for( int i=0; i<256; i++ ) r[i] = (int)(1U & (((uint)a[i >> 3]) >> (i & 7)));
 
   for( int i=0; i<256; i++ ) {
     if( !r[i] ) continue;

--- a/src/ballet/elf/fd_elf.h
+++ b/src/ballet/elf/fd_elf.h
@@ -124,7 +124,7 @@ fd_elf_read_cstr( void const * buf,
   ulong        str_sz = buf_sz - off;
 
   ulong n = fd_ulong_min( str_sz, max_sz );
-  if( FD_UNLIKELY( strnlen( str, n )==max_sz ) )
+  if( FD_UNLIKELY( fd_cstr_nlen( str, n )==max_sz ) )
     return NULL;
 
   return str;

--- a/src/ballet/pack/Local.mk
+++ b/src/ballet/pack/Local.mk
@@ -1,3 +1,4 @@
+ifdef FD_HAS_DOUBLE
 $(call add-hdrs,fd_pack.h fd_est_tbl.h fd_compute_budget_program.h)
 $(call add-objs,fd_pack,fd_ballet)
 $(call make-unit-test,test_compute_budget_program,test_compute_budget_program,fd_ballet fd_util)
@@ -6,3 +7,4 @@ $(call make-unit-test,test_pack,test_pack,fd_disco fd_ballet fd_util)
 $(call run-unit-test,test_compute_budget_program,)
 $(call run-unit-test,test_est_tbl,)
 $(call run-unit-test,test_pack,)
+endif

--- a/src/ballet/pack/fd_pack.c
+++ b/src/ballet/pack/fd_pack.c
@@ -110,9 +110,7 @@ typedef struct fd_pack_private fd_pack_t;
 #define MAP_KEY_HASH(key)     (*(uint*)(key))
 #include "../../util/tmpl/fd_map_dynamic.c"
 
-
-
-FD_FN_PURE ulong
+ulong
 fd_pack_footprint( ulong bank_cnt,
                    ulong bank_depth,
                    ulong pack_depth ) {
@@ -132,7 +130,7 @@ fd_pack_footprint( ulong bank_cnt,
   return FD_LAYOUT_FINI( l, FD_PACK_ALIGN );
 }
 
-FD_FN_PURE ulong
+ulong
 fd_pack_txnmem_footprint( ulong bank_cnt,
                           ulong bank_depth,
                           ulong pack_depth ) {
@@ -606,5 +604,5 @@ fd_pack_clear( fd_pack_t * pack,
 }
 
 
-void * fd_pack_leave(  fd_pack_t * pack ) { return (void *)pack; }
-void * fd_pack_delete( void      * mem  ) { return mem;          }
+void * fd_pack_leave ( fd_pack_t * pack ) { FD_COMPILER_MFENCE(); return (void *)pack; }
+void * fd_pack_delete( void      * mem  ) { FD_COMPILER_MFENCE(); return mem;          }

--- a/src/ballet/pack/fd_pack.h
+++ b/src/ballet/pack/fd_pack.h
@@ -77,12 +77,18 @@ typedef struct fd_pack_private fd_pack_t;
    pack_depth sets the maximum number of pending transactions that pack
    stores and may eventually schedule. */
 
-static inline ulong fd_pack_align(        void ) { return FD_PACK_ALIGN; }
-static inline ulong fd_pack_txnmem_align( void ) { return 128UL; }
+FD_FN_CONST static inline ulong fd_pack_align       ( void ) { return FD_PACK_ALIGN; }
+FD_FN_CONST static inline ulong fd_pack_txnmem_align( void ) { return 128UL;         }
 
-ulong fd_pack_footprint(        ulong bank_cnt, ulong bank_depth, ulong pack_depth );
-ulong fd_pack_txnmem_footprint( ulong bank_cnt, ulong bank_depth, ulong pack_depth );
+ulong /* FIXME: Not FD_FN_CONST because this logs errors (but probably shouldn't). */
+fd_pack_footprint( ulong bank_cnt,
+                   ulong bank_depth,
+                   ulong pack_depth );
 
+FD_FN_CONST ulong
+fd_pack_txnmem_footprint( ulong bank_cnt,
+                          ulong bank_depth,
+                          ulong pack_depth );
 
 /* fd_pack_new formats a region of memory to be suitable for use as a
    pack object.  mem and txnmem are non-NULL pointers to regions of
@@ -108,15 +114,18 @@ fd_pack_t * fd_pack_join( void * mem );
 
 
 /* fd_pack_bank_cnt returns the value used for bank_cnt when the pack
-   object was created.  pack must be a valid local join of a pack object
-   */
-ulong fd_pack_bank_cnt( fd_pack_t * pack );
+   object was created.  pack must be a valid local join of a pack object */
+
+FD_FN_PURE ulong
+fd_pack_bank_cnt( fd_pack_t * pack );
 
 /* fd_pack_avail_txn_cnt returns the number of transactions that this
    pack object has available to schedule but that have not been
    scheduled yet. pack must be a vaild local join.  The return value
    will be in [0, pack_depth). */
-ulong fd_pack_avail_txn_cnt( fd_pack_t * pack );
+
+FD_FN_PURE ulong
+fd_pack_avail_txn_cnt( fd_pack_t * pack );
 
 /* fd_pack_insert_txn_{init,fini,cancel} execute the process of
    inserting a new transaction into the pool of available transactions

--- a/src/ballet/pack/test_compute_budget_program.c
+++ b/src/ballet/pack/test_compute_budget_program.c
@@ -237,7 +237,7 @@ test_txn( uchar * payload,
   FD_TEST( (ulong)compute==expected_max_cu );
 }
 
-int
+FD_FN_CONST int
 test_duplicate( ulong request_units_deprecated_cnt,
                 ulong request_heap_frame_cnt,
                 ulong set_compute_unit_limit_cnt,

--- a/src/ballet/sbpf/Local.mk
+++ b/src/ballet/sbpf/Local.mk
@@ -1,4 +1,6 @@
 $(call add-hdrs,fd_sbpf_instr.h fd_sbpf_loader.h fd_sbpf_opcodes.h)
 $(call add-objs,fd_sbpf_loader,fd_ballet)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_sbpf_load_prog,test_sbpf_load_prog,fd_ballet fd_util)
+endif
 $(call make-fuzz-test,fuzz_sbpf_loader,fuzz_sbpf_loader,fd_ballet fd_util)

--- a/src/ballet/sbpf/fd_sbpf_loader.c
+++ b/src/ballet/sbpf/fd_sbpf_loader.c
@@ -491,7 +491,7 @@ fd_sbpf_program_align( void ) {
 
 ulong
 fd_sbpf_program_footprint( fd_sbpf_elf_info_t const * info ) {
-  (void)info;
+  FD_COMPILER_UNPREDICTABLE( info ); /* Make this appear as FD_FN_PURE (e.g. footprint might depened on info contents in future) */
   return FD_LAYOUT_FINI( FD_LAYOUT_APPEND( FD_LAYOUT_APPEND( FD_LAYOUT_INIT,
     alignof(fd_sbpf_program_t), sizeof(fd_sbpf_program_t) ),
     fd_sbpf_calldests_align(),  fd_sbpf_calldests_footprint() ),

--- a/src/ballet/sbpf/fd_sbpf_loader.c
+++ b/src/ballet/sbpf/fd_sbpf_loader.c
@@ -300,7 +300,7 @@ fd_sbpf_load_shdrs( fd_sbpf_elf_info_t *  info,
 
     /* Length check */
 
-    REQUIRE( strnlen( name, 16UL )<16UL );
+    REQUIRE( fd_cstr_nlen( name, 16UL )<16UL );
 
     /* Check name */
     /* TODO switch table for this? */
@@ -484,12 +484,12 @@ fd_sbpf_elf_peek( fd_sbpf_elf_info_t * info,
         previously stored */
 
 
-FD_FN_CONST ulong
+ulong
 fd_sbpf_program_align( void ) {
   return alignof( fd_sbpf_program_t );
 }
 
-FD_FN_PURE ulong
+ulong
 fd_sbpf_program_footprint( fd_sbpf_elf_info_t const * info ) {
   (void)info;
   return FD_LAYOUT_FINI( FD_LAYOUT_APPEND( FD_LAYOUT_APPEND( FD_LAYOUT_INIT,
@@ -900,7 +900,7 @@ fd_sbpf_r_bpf_64_32( fd_sbpf_loader_t   const * loader,
 
   /* Verify symbol name */
   ulong max_len  = fd_ulong_min( info->dynstr_sz - sym->st_name, FD_SBPF_SYM_NAME_SZ_MAX );
-  ulong name_len = strnlen( name, max_len );
+  ulong name_len = fd_cstr_nlen( name, max_len );
   REQUIRE( name_len<max_len );
 
   /* Value to write into relocated field */

--- a/src/flamenco/types/Local.mk
+++ b/src/flamenco/types/Local.mk
@@ -1,2 +1,4 @@
+ifdef FD_HAS_INT128
 $(call add-hdrs,fd_bincode.h fd_types.h fd_types_custom.h)
 $(call add-objs,fd_types,fd_flamenco)
+endif

--- a/src/flamenco/types/fd_types.c
+++ b/src/flamenco/types/fd_types.c
@@ -1,9 +1,18 @@
 #include "fd_types.h"
+
+/* FIXME: Temporary scaffolding */
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wunused-variable"
+#if FD_USING_GCC==1 /* Clang doesn't understand these options */
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=const"
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=pure"
+#endif
+
 #ifdef _DISABLE_OPTIMIZATION
 #pragma GCC optimize ("O0")
 #endif
+
 int fd_fee_calculator_decode(fd_fee_calculator_t* self, fd_bincode_decode_ctx_t * ctx) {
   int err;
   err = fd_bincode_uint64_decode(&self->lamports_per_signature, ctx);
@@ -8172,3 +8181,6 @@ long fd_serializable_account_storage_entry_t_map_compare(fd_serializable_account
 long fd_slot_account_pair_t_map_compare(fd_slot_account_pair_t_mapnode_t * left, fd_slot_account_pair_t_mapnode_t * right) {
   return (long)(left->elem.slot - right->elem.slot);
 }
+
+/* FIXME: SEE ABOVE PUSH */
+#pragma GCC diagnostic pop

--- a/src/flamenco/vm/Local.mk
+++ b/src/flamenco/vm/Local.mk
@@ -1,7 +1,9 @@
 $(call add-hdrs,fd_vm_context.h fd_vm_disasm.h fd_vm_interp.h fd_vm_log_collector.h fd_vm_stack.h fd_vm_syscalls.h)
 $(call add-objs,fd_vm_context fd_vm_disasm fd_vm_interp fd_vm_log_collector fd_vm_stack fd_vm_syscalls,fd_flamenco)
 
+ifdef FD_HAS_HOSTED
 $(call make-bin,fd_vm_tool,fd_vm_tool,fd_flamenco fd_ballet fd_util)
+endif
 
 $(call make-unit-test,test_vm_interp,test_vm_interp,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_vm_interp)

--- a/src/flamenco/vm/fd_vm_syscalls.c
+++ b/src/flamenco/vm/fd_vm_syscalls.c
@@ -9,6 +9,11 @@
 
 #include <stdio.h>
 
+/* FIXME: Temporary scaffolding */
+#pragma GCC diagnostic push
+#if FD_USING_GCC==1 /* Clang doesn't understand the below */
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=const"
+#endif
 
 void
 fd_vm_register_syscall( fd_sbpf_syscalls_t *    syscalls,
@@ -631,3 +636,6 @@ fd_vm_syscall_sol_get_processed_sibling_instruction(
 ) {
   return FD_VM_SYSCALL_ERR_UNIMPLEMENTED;
 }
+
+/* FIXME: SEE ABOVE PUSH */
+#pragma GCC diagnostic pop

--- a/src/tango/quic/crypto/fd_quic_crypto_suites.c
+++ b/src/tango/quic/crypto/fd_quic_crypto_suites.c
@@ -656,7 +656,7 @@ fd_quic_crypto_decrypt(
   fd_memcpy( nonce, quic_iv, nonce_tmp );
   for( uint k = 0; k < 4; ++k ) {
     uint j = nonce_tmp + k;
-    nonce[j] = quic_iv[j] ^ (uchar)( pkt_number >> ( (3u - k) * 8u ) );
+    nonce[j] = (uchar)(quic_iv[j] ^ (uchar)( pkt_number >> ( (3u - k) * 8u ) ));
   }
 
   EVP_CIPHER_CTX * cipher_ctx = keys->pkt_cipher_ctx;

--- a/src/tango/quic/templ/fd_quic_parse_util.h
+++ b/src/tango/quic/templ/fd_quic_parse_util.h
@@ -166,7 +166,7 @@ fd_quic_encode_bits( uchar * buf, ulong cur_bit, ulong val, ulong bits ) {
     /* j == 1 is the leftmost bit, which is val bit (bits-2) */
     /* so we want to shift val right by ( bits-1-j ) */
 
-    buf[byte_offs] = cur_byte | (uchar) ( ( (val >> (bits-1u-j)) & 1u ) << ( 7u - bit_offs ) );
+    buf[byte_offs] = (uchar)((uchar)cur_byte | (uchar) ( ( (val >> (bits-1u-j)) & 1u ) << ( 7u - bit_offs ) ));
   }
 
   return 0;

--- a/src/tango/udpsock/fd_udpsock.c
+++ b/src/tango/udpsock/fd_udpsock.c
@@ -196,6 +196,11 @@ fd_udpsock_t *
 fd_udpsock_join( void * shsock,
                  int    fd ) {
 
+  if( FD_UNLIKELY( !shsock ) ) {
+    FD_LOG_WARNING(( "NULL shsock" ));
+    return NULL;
+  }
+
   fd_udpsock_t * sock = (fd_udpsock_t *)shsock;
   sock->fd = fd;
 
@@ -220,12 +225,20 @@ fd_udpsock_join( void * shsock,
 
 void *
 fd_udpsock_leave( fd_udpsock_t * sock ) {
+  if( FD_UNLIKELY( !sock ) ) {
+    FD_LOG_WARNING(( "NULL sock" ));
+    return NULL;
+  }
   sock->fd = -1;
   return (void *)sock;
 }
 
 void *
 fd_udpsock_delete( void * shsock ) {
+  if( FD_UNLIKELY( !shsock ) ) {
+    FD_LOG_WARNING(( "NULL shsock" ));
+    return NULL;
+  }
   return shsock;
 }
 

--- a/src/tango/xdp/fd_xdp_redirect_user.c
+++ b/src/tango/xdp/fd_xdp_redirect_user.c
@@ -36,7 +36,7 @@ fd_xdp_validate_name_cstr( char const * s,
     FD_LOG_WARNING(( "empty %s", name ));
     return -1;
   }
-  if( FD_UNLIKELY( strnlen( s, bufsz )==bufsz ) ) {
+  if( FD_UNLIKELY( fd_cstr_nlen( s, bufsz )==bufsz ) ) {
     FD_LOG_WARNING(( "oversz %s", name ));
     return -1;
   }

--- a/src/tango/xdp/fd_xsk.c
+++ b/src/tango/xdp/fd_xsk.c
@@ -105,7 +105,7 @@ fd_xsk_bind( void *       shxsk,
     FD_LOG_WARNING(( "NULL app_name" ));
     return NULL;
   }
-  ulong app_name_len = strnlen( app_name, NAME_MAX );
+  ulong app_name_len = fd_cstr_nlen( app_name, NAME_MAX );
   if( FD_UNLIKELY( app_name_len==0UL ) ) {
     FD_LOG_WARNING(( "missing app_name" ));
     return NULL;
@@ -121,7 +121,7 @@ fd_xsk_bind( void *       shxsk,
     FD_LOG_WARNING(( "NULL ifname" ));
     return NULL;
   }
-  ulong if_name_len = strnlen( ifname, IF_NAMESIZE );
+  ulong if_name_len = fd_cstr_nlen( ifname, IF_NAMESIZE );
   if( FD_UNLIKELY( if_name_len==0UL ) ) {
     FD_LOG_WARNING(( "missing ifname" ));
     return NULL;
@@ -586,7 +586,7 @@ fd_xsk_ifidx( fd_xsk_t * const xsk ) {
 FD_FN_PURE char const *
 fd_xsk_ifname( fd_xsk_t * const xsk ) {
   /* cstr coherence check */
-  ulong len = strnlen( xsk->if_name_cstr, IF_NAMESIZE );
+  ulong len = fd_cstr_nlen( xsk->if_name_cstr, IF_NAMESIZE );
   if( FD_UNLIKELY( len==0UL || len==IF_NAMESIZE ) ) return NULL;
 
   return xsk->if_name_cstr;

--- a/src/util/cstr/fd_cstr.c
+++ b/src/util/cstr/fd_cstr.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include "fd_cstr.h"
 
 /* FIXME: WEAN THIS OFF STDLIB FOR NON-HOSTED TARGETS */
@@ -96,6 +97,12 @@ int
 fd_cstr_casecmp( char const * a,
                  char const * b ) {
   return strcasecmp( a, b );
+}
+
+ulong
+fd_cstr_nlen( char const * s,
+              ulong        m ) {
+  return strnlen( s, m );
 }
 
 char *

--- a/src/util/cstr/fd_cstr.h
+++ b/src/util/cstr/fd_cstr.h
@@ -101,12 +101,19 @@ fd_cstr_hash_append( ulong        hash,
 
 FD_FN_PURE static inline ulong fd_cstr_hash( char const * key ) { return fd_cstr_hash_append( 5381UL, key ); }
 
-/* fd_cstr_casecmp is equivalent to strcasecmp but doesn't require a
-   HOSTED (POSIX) support. */
+/* fd_cstr_casecmp is equivalent to strcasecmp but doesn't require
+   FD_HAS_HOSTED (POSIX) support. */
 
 FD_FN_PURE int
 fd_cstr_casecmp( char const * a,
                  char const * b );
+
+/* fd_cstr_nlen is equivalent to strnlen but doesn't require
+   FD_HAS_HOSTED (POSIX) support. */
+
+FD_FN_PURE ulong
+fd_cstr_nlen( char const * s,
+              ulong        m );
 
 /* cstr output ********************************************************/
 

--- a/src/util/net/Local.mk
+++ b/src/util/net/Local.mk
@@ -5,7 +5,9 @@ $(call make-unit-test,test_ip4,test_ip4,fd_util)
 $(call make-unit-test,test_igmp,test_igmp,fd_util)
 $(call make-unit-test,test_udp,test_udp,fd_util)
 $(call make-unit-test,test_pcap,test_pcap,fd_util)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_pcapng,test_pcapng,fd_util)
+endif
 $(call make-fuzz-test,fuzz_pcap,fuzz_pcap,fd_util)
 $(call make-fuzz-test,fuzz_pcapng,fuzz_pcapng,fd_util)
 $(call run-unit-test,test_eth,)

--- a/src/util/net/fd_eth.h
+++ b/src/util/net/fd_eth.h
@@ -285,9 +285,9 @@ fd_vlan_tag( void * _tag,
 
 /* fd_cstr_to_mac_addr parses a MAC address matching format
    FD_ETH_MAC_FMT from the given cstr and stores the result into mac.
-   On success returns mac.  On failure, returns NULL and leaves mac
-   in an undefined state.  Reasons for failure include that strlen
-   of s is not exactly 17 or that s is not formatted correctly. */
+   On success returns mac.  On failure, returns NULL and leaves mac in
+   an undefined state.  On success, exactly 17 characters of s were
+   processed. */
 
 uchar *
 fd_cstr_to_mac_addr( char const * s,

--- a/src/util/net/fd_pcapng.c
+++ b/src/util/net/fd_pcapng.c
@@ -634,16 +634,16 @@ fd_pcapng_fwrite_idb( uint                         link_type,
   if( opt ) {
 
     if( opt->name[0] )
-      FD_PCAPNG_FWRITE_OPT( FD_PCAPNG_IDB_OPT_NAME,      strnlen( opt->name, 16UL ),     opt->name      );
+      FD_PCAPNG_FWRITE_OPT( FD_PCAPNG_IDB_OPT_NAME,      fd_cstr_nlen( opt->name, 16UL ),     opt->name     );
     if( fd_uint_load_4( opt->ip4_addr ) )
-      FD_PCAPNG_FWRITE_OPT( FD_PCAPNG_IDB_OPT_IPV4_ADDR, 4UL,                            opt->ip4_addr  );
+      FD_PCAPNG_FWRITE_OPT( FD_PCAPNG_IDB_OPT_IPV4_ADDR, 4UL,                                 opt->ip4_addr );
     if( fd_ulong_load_6( opt->mac_addr ) )
-      FD_PCAPNG_FWRITE_OPT( FD_PCAPNG_IDB_OPT_MAC_ADDR,  6UL,                            opt->mac_addr  );
+      FD_PCAPNG_FWRITE_OPT( FD_PCAPNG_IDB_OPT_MAC_ADDR,  6UL,                                 opt->mac_addr );
 
-  /**/FD_PCAPNG_FWRITE_OPT( FD_PCAPNG_IDB_OPT_TSRESOL,   1UL,                            &opt->tsresol  );
+  /**/FD_PCAPNG_FWRITE_OPT( FD_PCAPNG_IDB_OPT_TSRESOL,   1UL,                                 &opt->tsresol );
 
     if( opt->hardware[0] )
-      FD_PCAPNG_FWRITE_OPT( FD_PCAPNG_IDB_OPT_HARDWARE,  strnlen( opt->hardware, 64UL ),  opt->hardware );
+      FD_PCAPNG_FWRITE_OPT( FD_PCAPNG_IDB_OPT_HARDWARE,  fd_cstr_nlen( opt->hardware, 64UL ), opt->hardware );
 
   }
   FD_PCAPNG_FWRITE_OPT( 0, 0, NULL );

--- a/src/util/net/test_eth.c
+++ b/src/util/net/test_eth.c
@@ -35,9 +35,10 @@ test_cstr_to_mac_addr( void ) {
 # define MAC_OK(str,num) FD_TEST( fd_ulong_bswap( fd_ulong_load_6( fd_cstr_to_mac_addr( str, mac ) )>>16UL ) )
 # define MAC_FAIL(str)   FD_TEST( !fd_cstr_to_mac_addr( str, mac ) );
 
-  MAC_OK( "01:34:56:78:9a:bc", 0x013456789abc );
-  MAC_OK( "12:34:56:78:9a:bc", 0x123456789abc );
-  MAC_OK( "12:34:56:78:9a:Bc", 0x123456789abc );
+  MAC_OK( "01:34:56:78:9a:bc",  0x013456789abc );
+  MAC_OK( "12:34:56:78:9a:bc",  0x123456789abc );
+  MAC_OK( "12:34:56:78:9a:Bc",  0x123456789abc );
+  MAC_OK( "12:34:56:78:9a:bcd", 0x123456789abc );
 
   /* Test invalid char and truncated string */
 
@@ -88,9 +89,6 @@ test_cstr_to_mac_addr( void ) {
   MAC_FAIL( "12:34:56:78:9a::c" );
   MAC_FAIL( "12:34:56:78:9a:b:" );
 
-  /* Test trailing string */
-
-  MAC_FAIL( "12:34:56:78:9a:bcd" );
 }
 
 int

--- a/src/util/tmpl/fd_redblack.c
+++ b/src/util/tmpl/fd_redblack.c
@@ -138,14 +138,14 @@ FD_PROTOTYPES_BEGIN
   Return the maximum number of nodes that will fit into a pool with
   the given footprint.
 */
-ulong REDBLK_(max_for_footprint)( ulong footprint );
+FD_FN_CONST ulong REDBLK_(max_for_footprint)( ulong footprint );
 
 /*
   E.g. ulong my_rb_align( void );
 
   Return the pool alignment.
 */
-ulong REDBLK_(align)( void );
+FD_FN_CONST ulong REDBLK_(align)( void );
 
 /*
   E.g. ulong my_rb_footprint( ulong max );
@@ -153,7 +153,7 @@ ulong REDBLK_(align)( void );
   Return the minimum memory footprint needed for a pool with the given
   number of nodes.
 */
-ulong REDBLK_(footprint)( ulong max );
+FD_FN_CONST ulong REDBLK_(footprint)( ulong max );
 
 /*
   E.g. void * my_rb_new( void * shmem, ulong max );
@@ -188,14 +188,14 @@ void * REDBLK_(delete)( void * shpool );
 
   Return the max value given when new was called.
 */
-ulong REDBLK_(max)( REDBLK_T const * pool );
+FD_FN_PURE ulong REDBLK_(max)( REDBLK_T const * pool );
 
 /*
   E.g. ulong my_rb_free( my_rb_node_t const * pool );
 
   Return the number of available nodes in the free pool.
 */
-ulong REDBLK_(free)( REDBLK_T const * pool );
+FD_FN_PURE ulong REDBLK_(free)( REDBLK_T const * pool );
 
 /*
   E.g. ulong my_rb_idx( my_rb_node_t const * pool, my_rb_node_t const * node );
@@ -203,7 +203,7 @@ ulong REDBLK_(free)( REDBLK_T const * pool );
   Return the logical index of the node in a pool. Useful when
   relocating a pool in memory.
   */
-ulong REDBLK_(idx)( REDBLK_T const * pool, REDBLK_T const * node );
+FD_FN_CONST ulong REDBLK_(idx)( REDBLK_T const * pool, REDBLK_T const * node );
 
 /*
   E.g. my_rb_node_t * my_rb_node( my_rb_node_t * pool, ulong idx );
@@ -211,7 +211,7 @@ ulong REDBLK_(idx)( REDBLK_T const * pool, REDBLK_T const * node );
   Return the node at a logical index in a pool. Useful when relocating
   a pool in memory.
 */
-REDBLK_T * REDBLK_(node)( REDBLK_T * pool, ulong idx );
+FD_FN_CONST REDBLK_T * REDBLK_(node)( REDBLK_T * pool, ulong idx );
 
 /*
   E.g. my_rb_node_t * my_rb_acquire( my_rb_node_t * pool );
@@ -390,8 +390,10 @@ int REDBLK_(verify)(REDBLK_T * pool, REDBLK_T * root);
     long my_rb_compare(my_node_t* left, my_node_t* right) {
       return (long)(left->key - right->key);
     }
+
+  Should be a pure function.  (FIXME: SHOULD TAKE CONST POINTERS?)
 */
-long REDBLK_(compare)(REDBLK_T * left, REDBLK_T * right);
+FD_FN_PURE long REDBLK_(compare)(REDBLK_T * left, REDBLK_T * right);
 
 FD_PROTOTYPES_END
 
@@ -463,14 +465,17 @@ void * REDBLK_(new)( void * shmem, ulong max ) {
 }
 
 REDBLK_T * REDBLK_(join)( void * shpool ) {
+  FD_COMPILER_MFENCE();
   return REDBLK_POOL_(join)(shpool);
 }
 
 void * REDBLK_(leave)( REDBLK_T * pool ) {
+  FD_COMPILER_MFENCE();
   return REDBLK_POOL_(leave)(pool);
 }
 
 void * REDBLK_(delete)( void * shpool ) {
+  FD_COMPILER_MFENCE();
   return REDBLK_POOL_(delete)(shpool);
 }
 


### PR DESCRIPTION
Marc pointed out some UBSAN warnings from CI that crept into main and cleaned up them most of them (all but some that look like ubsan bugs ... needs more investigation).

In the process, did a bunch of bit rot prevention cleanups and got main compiling clean under wide range of build targets with extra brutality enabled.  This touched a bunch of files but changes were generally the minimal one-liner changes necessary to get things compiling again under extra brutality (though in some cases this did uncover some potential longer term cleanups to do).  As such don't expect it to interfere much with code in development.

Passes all my local torture test in all build / toolchain combinations.  YMMV.