### PR TITLE
quic: support loading key/cert from memory

### DIFF
--- a/src/app/fdctl/src/commands/configure/frank.rs
+++ b/src/app/fdctl/src/commands/configure/frank.rs
@@ -150,8 +150,8 @@ fn step(config: &mut Config) {
     let src_mac_address = super::netns::src_mac_address(config);
 
     run!("{bin}/fd_pod_ctl \
-        insert {pod} cstr {prefix}.quic_cfg.cert_file {cert_file} \
-        insert {pod} cstr {prefix}.quic_cfg.key_file {key_file} \
+        insert-file {pod} {prefix}.quic_cfg.cert_data {cert_file} \
+        insert-file {pod} {prefix}.quic_cfg.key_data {key_file} \
         insert {pod} cstr {prefix}.quic_cfg.ip_addr {ip_addr} \
         insert {pod} ushort {prefix}.quic_cfg.listen_port {listen_port} \
         insert {pod} cstr {prefix}.quic_cfg.src_mac_addr {src_mac_address} \

--- a/src/tango/quic/fd_quic.h
+++ b/src/tango/quic/fd_quic.h
@@ -221,10 +221,23 @@ struct __attribute__((aligned(16UL))) fd_quic_config {
 
   /* TLS config ********************************************/
 
-  /* cstrs containing TLS PEM cert and key file path */
 # define FD_QUIC_CERT_PATH_LEN (1023UL)
-  char cert_file  [ FD_QUIC_CERT_PATH_LEN+1UL ];
-  char key_file   [ FD_QUIC_CERT_PATH_LEN+1UL ];
+  struct { /* cert config */
+    void const * data;
+    int          data_sz;
+
+    /* cstrs containing TLS PEM cert file path */
+    char         file  [ FD_QUIC_CERT_PATH_LEN+1UL ];
+  } cert;
+
+  struct { /* key config */
+    void const * data;
+    int          data_sz;
+
+    /* cstrs containing TLS PEM key file path */
+    char         file  [ FD_QUIC_CERT_PATH_LEN+1UL ];
+  } key;
+
   char keylog_file[ FD_QUIC_CERT_PATH_LEN+1UL ];
 
   /* alpns: List of supported ALPN IDs in OpenSSL format.

--- a/src/tango/quic/tests/fd_quic_test_helpers.c
+++ b/src/tango/quic/tests/fd_quic_test_helpers.c
@@ -137,8 +137,10 @@ fd_quic_new_anonymous( fd_wksp_t *              wksp,
   /* Default settings */
   config->idle_timeout     = (ulong)100e6; /* 10ms */
   config->service_interval = (ulong) 10e6; /* 10ms */
-  strcpy( config->cert_file, "cert.pem" );
-  strcpy( config->key_file,  "key.pem"  );
+  config->cert.data = NULL;
+  config->key.data  = NULL;
+  strcpy( config->cert.file, "cert.pem" );
+  strcpy( config->key.file,  "key.pem"  );
   strcpy( config->sni,       "local"    );
 
   /* Default callbacks */

--- a/src/tango/quic/tests/test_handshake.c
+++ b/src/tango/quic/tests/test_handshake.c
@@ -91,8 +91,10 @@ main( int     argc,
 
     .max_concur_handshakes = 16,
 
-    .cert_file             = "cert.pem",
-    .key_file              = "key.pem",
+    .cert.data             = NULL,
+    .cert.file             = "cert.pem",
+    .key.data              = NULL,
+    .key.file              = "key.pem",
 
   };
 

--- a/src/tango/quic/tls/fd_quic_tls.h
+++ b/src/tango/quic/tls/fd_quic_tls.h
@@ -105,6 +105,13 @@ struct fd_quic_tls_secret {
   ulong                 secret_len;
 };
 
+typedef struct fd_quic_tls_cert_cfg {
+  void const * data;
+  int          data_sz;
+
+  char const * file;
+} fd_quic_tls_cert_cfg_t;
+
 struct fd_quic_tls_cfg {
   // callbacks ../crypto/fd_quic_crypto_suites
   fd_quic_tls_cb_client_hello_t        client_hello_cb;
@@ -115,8 +122,8 @@ struct fd_quic_tls_cfg {
 
   ulong          max_concur_handshakes;
 
-  char const *   cert_file;             /* certificate file */
-  char const *   key_file;              /* private key file */
+  fd_quic_tls_cert_cfg_t cert;      /* certificate data */
+  fd_quic_tls_cert_cfg_t key;       /* private key data */
 
   /* keylog_fd == 0 indicates no keylogger file */
   int            keylog_fd;             /* keylogger file */


### PR DESCRIPTION
With the sandbox changes in place, QUIC will not be able to open files so the cert/key need to provided in-memory. This makes sense anyway since these should always be generated on the fly and not persisted.