### PR TITLE
fdctl: determine bind interface automatically

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -144,6 +144,9 @@ scratch_directory = "/home/{user}/.firedancer/{name}"
     [tiles.quic]
         # Which interface to bind to. If developing under a network namespace with [netns] enabled,
         # this should be the same as [development.netns.interface0].
+        #
+        # If this is empty, the default is interface used to route to 8.8.8.8, you can check what
+        # this is with `ip route get 8.8.8.8`
         interface = ""
 
         # Which port to listen on.


### PR DESCRIPTION
If no interface is specified, we find a default one by looking at which device is used for the default route to 8.8.8.8