### PR TITLE
Always use 'all' as default Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ endif
 $(info Using MACHINE=$(MACHINE))
 $(info Using EXTRAS=$(EXTRAS))
 
+# Default target
+all:
+
 include config/$(MACHINE).mk
 include $(addprefix config/with-,$(addsuffix .mk,$(EXTRAS)))
 include config/everything.mk


### PR DESCRIPTION
`with-ffi.mk` currently breaks Make. Since it gets loaded after `everything.mk`, it defines the first target of the entire Make configuration. So `make -j MACHINE=linux_clang_x86_64_asan` will not build any binary targets. Fix is to specify a dummy target for `all` at the beginning of the Make configuration.