### PR TITLE
ci: remove CodeQL from merge_group

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-  merge_group:
 
 jobs:
   analyze:


### PR DESCRIPTION
This check is broken on main. Should be readded once fixed.