### PR TITLE
fdctl: fix make run arguments

### DIFF
--- a/config/everything.mk
+++ b/config/everything.mk
@@ -82,38 +82,23 @@ check-lint:
 	#######################################################################
 	$(FIND) src/ -iname "*.c" -or -iname "*.h" | uncrustify -c lint.cfg -F - --check
 
-# If the first argument is "run"...
 ifeq (run,$(firstword $(MAKECMDGOALS)))
-	# use the rest as arguments for "run"
-	RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
-
-	# Set default RUN_ARGS if not already set
-	ifeq ($(RUN_ARGS),)
-		RUN_ARGS := --configure --sudo
-	endif
-
-	# ...and turn them into do-nothing targets
-	$(eval $(RUN_ARGS):;@:)
+  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  ifeq ($(RUN_ARGS),)
+    RUN_ARGS := --configure --sudo
+  endif
+  $(eval $(RUN_ARGS):;@:)
 endif
-
-# Set default RUN_ARGS if not already set
-RUN_ARGS ?= --configure --sudo
 
 run: bin
 	$(OBJDIR)/bin/fdctl $(RUN_ARGS)
 
-# If the first argument is "monitor"...
 ifeq (monitor,$(firstword $(MAKECMDGOALS)))
-	# use the rest as arguments for "monitor"
-	MONITOR_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
-
-  # Set default RUN_ARGS if not already set
-	ifeq ($(MONITOR_ARGS),)
-		MONITOR_ARGS := --sudo
-	endif
-
-	# ...and turn them into do-nothing targets
-	$(eval $(MONITOR_ARGS):;@:)
+  MONITOR_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  ifeq ($(MONITOR_ARGS),)
+    MONITOR_ARGS := --sudo
+  endif
+  $(eval $(MONITOR_ARGS):;@:)
 endif
 
 monitor: bin

--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -3,6 +3,7 @@ ifdef FD_HAS_ALLOCA
 ifdef FD_HAS_X86
 ifdef FD_HAS_DOUBLE
 $(call make-bin,fdctl,main config security utility run monitor configure/configure configure/large_pages configure/shmem configure/netns configure/xdp configure/xdp_leftover configure/ethtool configure/workspace_leftover configure/workspace configure/frank,fd_frank fd_disco fd_ballet fd_tango fd_util fd_quic)
+$(OBJDIR)/bin/fdctl: src/app/fdctl/config/default.toml
 endif
 endif
 endif


### PR DESCRIPTION
Had switched spaces to tabs in the Makefile during a last minute style lint, and this broke the behavior. Fixes that, and also makes fdctl depend on the embedded default.toml file so we rebuild if it changes.