### PR TITLE
three bug fixes for fdctl

### DIFF
--- a/src/app/fdctl/fdctl.h
+++ b/src/app/fdctl/fdctl.h
@@ -2,6 +2,7 @@
 #define HEADER_fd_src_app_fdctl_fdctl_h
 
 #include "../../util/fd_util.h"
+#include "../../util/net/fd_ip4.h"
 
 #include "config.h"
 #include "security.h"

--- a/src/app/fdctl/utility.h
+++ b/src/app/fdctl/utility.h
@@ -30,17 +30,18 @@ snprintf1( char * s,
 /* RUN() executes the given string and formatting arguments as a
    subprocess, and waits for the child to complete. If the child does
    not exit successfully with code 0, the calling program is aborted. */
-#define RUN(...) do {                                     \
-    char cmd[ 4096 ];                                     \
-    snprintf1( cmd,                                       \
-               sizeof(cmd),                               \
-               __VA_ARGS__ );                             \
-    int ret = system( cmd );                              \
-    if( FD_UNLIKELY( !ret ) )                             \
-      FD_LOG_ERR(( "running command `%s` failed (%i-%s)", \
-                   cmd,                                   \
-                   errno,                                 \
-                   strerror( errno ) ));                  \
+#define RUN(...) do {                                                  \
+    char cmd[ 4096 ];                                                  \
+    snprintf1( cmd,                                                    \
+               sizeof(cmd),                                            \
+               __VA_ARGS__ );                                          \
+    int ret = system( cmd );                                           \
+    if( FD_UNLIKELY( ret ) )                                           \
+      FD_LOG_ERR(( "running command `%s` failed exit code=%d (%i-%s)", \
+                   cmd,                                                \
+                   ret,                                                \
+                   errno,                                              \
+                   strerror( errno ) ));                               \
   } while( 0 )
 
 /* OUTPUT() executes the given string and formatting arguments as a


### PR DESCRIPTION
  1 - config_parse did not correctly set quic ip address and mac address when development.netns.enabled = true
  2 - RUN failed when exit code was zero
  3 - replace did not substitute the pattern correctly

Testing output
```bash
llamb@emny-ossdev-firedancer11> /home/llamb/code/firedancer-public/build/native/gcc/bin/fdctl configure fini all
--log-path not specified; using autogenerated path
Log at "/tmp/fd-0.0.0_1894263_llamb_emny-ossdev-firedancer11_2023_07_19_18_43_23_056378245_GMT+00"
--log-path not specified; using autogenerated path
Log at "/tmp/fd-0.0.0_1894265_root_emny-ossdev-firedancer11_2023_07_19_18_43_23_067081830_GMT+00"
NOTICE  07-19 18:43:23.068052 1894265 f0   0    src/app/fdctl/configure/configure.c(148): large-pages ... finishing
NOTICE  07-19 18:43:23.068086 1894265 f0   0    src/app/fdctl/configure/configure.c(142): shmem ... not configured ... mounts `/mnt/.fd/.huge` and `/mnt/.fd/.gigantic` do not exist
NOTICE  07-19 18:43:23.068105 1894265 f0   0    src/app/fdctl/configure/configure.c(142): netns ... not configured ... netns `veth_test_xdp_0` and `veth_test_xdp_1` do not exist
NOTICE  07-19 18:43:23.068115 1894265 f0   0    src/app/fdctl/configure/configure.c(142): xdp ... not configured ... `/sys/fs/bpf/fd1` does not exist
NOTICE  07-19 18:43:23.068126 1894265 f0   0    src/app/fdctl/configure/configure.c(148): xdp-leftover ... finishing
NOTICE  07-19 18:43:23.068135 1894265 f0   0    src/app/fdctl/configure/configure.c(88): ethtool ... skipping .. not enabled
NOTICE  07-19 18:43:23.068149 1894265 f0   0    src/app/fdctl/configure/configure.c(148): workspace-leftover ... finishing
NOTICE  07-19 18:43:23.141935 1894265 f0   0    src/app/fdctl/configure/configure.c(142): workspace ... not configured ... no workspace file in `/mnt/.fd/.gigantic/fd1.wksp`
NOTICE  07-19 18:43:23.141974 1894265 f0   0    src/app/fdctl/configure/configure.c(148): frank ... finishing
Log at "/tmp/fd-0.0.0_1894265_root_emny-ossdev-firedancer11_2023_07_19_18_43_23_067081830_GMT+00"
llamb@emny-ossdev-firedancer11> /home/llamb/code/firedancer-public/build/native/gcc/bin/fdctl configure init all
--log-path not specified; using autogenerated path
Log at "/tmp/fd-0.0.0_1894267_llamb_emny-ossdev-firedancer11_2023_07_19_18_43_28_374986979_GMT+00"
--log-path not specified; using autogenerated path
Log at "/tmp/fd-0.0.0_1894269_root_emny-ossdev-firedancer11_2023_07_19_18_43_28_385881528_GMT+00"
NOTICE  07-19 18:43:28.386846 1894269 f0   0    src/app/fdctl/configure/configure.c(109): large-pages ... already valid
NOTICE  07-19 18:43:28.386862 1894269 f0   0    src/app/fdctl/configure/configure.c(96): shmem ... unconfigured ... mounts `/mnt/.fd/.huge` and `/mnt/.fd/.gigantic` do not exist
NOTICE  07-19 18:43:28.386869 1894269 f0   0    src/app/fdctl/configure/configure.c(113): shmem ... configuring
NOTICE  07-19 18:43:29.270601 1894269 f0   0    src/app/fdctl/configure/configure.c(96): netns ... unconfigured ... netns `veth_test_xdp_0` and `veth_test_xdp_1` do not exist
NOTICE  07-19 18:43:29.270635 1894269 f0   0    src/app/fdctl/configure/configure.c(113): netns ... configuring
NOTICE  07-19 18:43:29.437305 1894269 f0   0    src/app/fdctl/configure/configure.c(96): xdp ... unconfigured ... `/sys/fs/bpf/fd1` does not exist
NOTICE  07-19 18:43:29.437322 1894269 f0   0    src/app/fdctl/configure/configure.c(113): xdp ... configuring
NOTICE  07-19 18:43:29.437783 1894269 f0   0    src/tango/xdp/fd_xdp_redirect_user.c(124): Activated XDP environment at /sys/fs/bpf/fd1
NOTICE  07-19 18:43:29.438624 1894269 f0   0    src/app/fdctl/configure/configure.c(109): xdp-leftover ... already valid
NOTICE  07-19 18:43:29.438638 1894269 f0   0    src/app/fdctl/configure/configure.c(88): ethtool ... skipping .. not enabled
NOTICE  07-19 18:43:29.438647 1894269 f0   0    src/app/fdctl/configure/configure.c(109): workspace-leftover ... already valid
NOTICE  07-19 18:43:29.438656 1894269 f0   0    src/app/fdctl/configure/configure.c(96): workspace ... unconfigured ... no workspace file in `/mnt/.fd/.gigantic/fd1.wksp`
NOTICE  07-19 18:43:29.438662 1894269 f0   0    src/app/fdctl/configure/configure.c(113): workspace ... configuring
NOTICE  07-19 18:43:29.738069 1894269 f0   0    src/app/fdctl/configure/configure.c(113): frank ... configuring
Log at "/tmp/fd-0.0.0_1894269_root_emny-ossdev-firedancer11_2023_07_19_18_43_28_385881528_GMT+00"
llamb@emny-ossdev-firedancer11> ip netns list
veth_test_xdp_1
veth_test_xdp_0
```

