### PR TITLE
quic bugfix - client streams don't transmit data 

### DIFF
--- a/src/app/fdctl/configure/frank.c
+++ b/src/app/fdctl/configure/frank.c
@@ -255,6 +255,7 @@ init( config_t * const config ) {
   ushort1( pod, "firedancer.quic_cfg.listen_port",     config->tiles.quic.listen_port, 0 );
   buf    ( pod, "firedancer.quic_cfg.src_mac_addr",    config->tiles.quic.mac_addr, 6 );
   ulong1 ( pod, "firedancer.quic_cfg.idle_timeout_ms", 1000 );
+  ulong1 ( pod, "firedancer.quic_cfg.initial_rx_max_stream_data", 1<<15 );
 
   char const * main_cnc = fd_pod_query_cstr( pod, "firedancer.main.cnc", NULL );
   if( FD_UNLIKELY( !main_cnc) )

--- a/src/app/frank/fd_frank_quic.c
+++ b/src/app/frank/fd_frank_quic.c
@@ -143,6 +143,10 @@ fd_frank_quic_task( int     argc,
   if( FD_UNLIKELY( !idle_timeout_ms ) ) FD_LOG_ERR(( "firedancer.quic_cfg.idle_timeout_ms not set" ));
   quic_cfg->idle_timeout = idle_timeout_ms * 1000000UL;
 
+  ulong initial_rx_max_stream_data = fd_pod_query_ulong( quic_cfg_pod, "initial_rx_max_stream_data", 1<<15 );
+  if( FD_UNLIKELY( !initial_rx_max_stream_data ) ) FD_LOG_ERR(( "firedancer.quic_cfg.initial_rx_max_stream_data not set" ));
+  quic_cfg->initial_rx_max_stream_data = initial_rx_max_stream_data;
+
   /* Attach to XSK */
 
   fd_xsk_aio_set_rx     ( xsk_aio, fd_quic_get_aio_net_rx( quic    ) );


### PR DESCRIPTION
initial_rx_max_stream_data was uninitialized in fd_frank_quic which caused streams to not transmit any data

pod configuration firedancer.quic_cfg.initial_rx_max_stream_data now defaults to 32k (1<<15)