### PR TITLE
set the default shell

### DIFF
--- a/.github/workflows/make_test.yml
+++ b/.github/workflows/make_test.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   make-test:
     runs-on: [self-hosted, Linux, X64]
+    defaults:
+      run:
+        shell: sudo bash --noprofile --norc -eo pipefail -c "set -ex; export MACHINE=linux_clang_x86_64; chmod +x {0} && {0}"
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
It seems that, by omitting to specify the shell, the GitHub action runner will set its own shell with its own limit, ignoring `/etc/security/limits.conf`.