### PR TITLE
feat(tango): staked nodes shmem and ffi

### DIFF
--- a/ffi/rust/firedancer-sys/build.rs
+++ b/ffi/rust/firedancer-sys/build.rs
@@ -62,7 +62,7 @@ fn main() {
             .clang_arg(format!("-I{prefix}/"))
             .header(&format!("wrapper_{lib}.h"))
             .blocklist_type("schar|uchar|ushort|uint|ulong")
-            .blocklist_item("SORT_QUICK_ORDER_STYLE|SORT_MERGE_THRESH|SORT_QUICK_THRESH|SORT_QUICK_ORDER_STYLE|SORT_QUICK_SWAP_MINIMIZE");
+            .blocklist_item("SORT_QUICK_ORDER_STYLE|SORT_MERGE_THRESH|SORT_QUICK_THRESH|SORT_QUICK_ORDER_STYLE|SORT_QUICK_SWAP_MINIMIZE|MAP_MEMOIZE|MAP_QUERY_OPT|MAP_KEY_EQUAL_IS_SLOW");
 
         // Well this is a complete mess. We want to only include, say, functions
         // declared in the `ballet` directory in the ballet bindgen output. If

--- a/ffi/rust/firedancer-sys/src/tango/mod.rs
+++ b/ffi/rust/firedancer-sys/src/tango/mod.rs
@@ -3,15 +3,15 @@ mod dcache;
 mod fctl;
 mod fseq;
 mod mcache;
+mod stake;
 mod tcache;
 mod xdp;
-mod stake;
 
 pub use cnc::*;
 pub use dcache::*;
 pub use fctl::*;
 pub use fseq::*;
 pub use mcache::*;
+pub use stake::*;
 pub use tcache::*;
 pub use xdp::*;
-pub use stake::*;

--- a/ffi/rust/firedancer-sys/src/tango/mod.rs
+++ b/ffi/rust/firedancer-sys/src/tango/mod.rs
@@ -5,6 +5,7 @@ mod fseq;
 mod mcache;
 mod tcache;
 mod xdp;
+mod stake;
 
 pub use cnc::*;
 pub use dcache::*;
@@ -13,3 +14,4 @@ pub use fseq::*;
 pub use mcache::*;
 pub use tcache::*;
 pub use xdp::*;
+pub use stake::*;

--- a/ffi/rust/firedancer-sys/src/tango/stake.rs
+++ b/ffi/rust/firedancer-sys/src/tango/stake.rs
@@ -1,13 +1,13 @@
 pub use crate::generated::{
-    fd_stake_t,
     fd_stake_align,
+    fd_stake_deser,
+    fd_stake_dump,
     fd_stake_footprint,
     fd_stake_join,
     fd_stake_new,
+    fd_stake_read,
+    fd_stake_t,
     fd_stake_version,
     fd_stake_version_laddr,
-    fd_stake_deser,
-    fd_stake_read,
-    fd_stake_dump,
-    FD_STAKE_ALIGN
+    FD_STAKE_ALIGN,
 };

--- a/ffi/rust/firedancer-sys/src/tango/stake.rs
+++ b/ffi/rust/firedancer-sys/src/tango/stake.rs
@@ -6,7 +6,7 @@ pub use crate::generated::{
     fd_stake_new,
     fd_stake_version,
     fd_stake_version_laddr,
-    fd_stake_write,
+    fd_stake_deser,
     fd_stake_read,
     fd_stake_dump,
     FD_STAKE_ALIGN

--- a/ffi/rust/firedancer-sys/src/tango/stake.rs
+++ b/ffi/rust/firedancer-sys/src/tango/stake.rs
@@ -6,7 +6,8 @@ pub use crate::generated::{
     fd_stake_new,
     fd_stake_version,
     fd_stake_version_laddr,
-    fd_stake_update,
+    fd_stake_write,
+    fd_stake_read,
     fd_stake_dump,
     FD_STAKE_ALIGN
 };

--- a/ffi/rust/firedancer-sys/src/tango/stake.rs
+++ b/ffi/rust/firedancer-sys/src/tango/stake.rs
@@ -1,0 +1,12 @@
+pub use crate::generated::{
+    fd_stake_t,
+    fd_stake_align,
+    fd_stake_footprint,
+    fd_stake_join,
+    fd_stake_new,
+    fd_stake_version,
+    fd_stake_version_laddr,
+    fd_stake_update,
+    fd_stake_dump,
+    FD_STAKE_ALIGN
+};

--- a/src/tango/fd_tango.h
+++ b/src/tango/fd_tango.h
@@ -10,6 +10,7 @@
 #include "dcache/fd_dcache.h" /* Includes fd_tango_base.h */
 #include "tcache/fd_tcache.h" /* Includes fd_tango_base.h */
 #include "aio/fd_aio.h"       /* Includes fd_tango_base.h */
+#include "stake/fd_stake.h"   /* Includes fd_tango_base.h */
 
 #endif /* HEADER_fd_src_tango_fd_tango_h */
 

--- a/src/tango/mvcc/Local.mk
+++ b/src/tango/mvcc/Local.mk
@@ -1,0 +1,4 @@
+$(call add-hdrs,fd_mvcc.h)
+$(call add-objs,fd_mvcc,fd_tango)
+$(call make-unit-test,test_mvcc,test_mvcc,fd_tango fd_util)
+$(call run-unit-test,test_mvcc,)

--- a/src/tango/mvcc/fd_mvcc.c
+++ b/src/tango/mvcc/fd_mvcc.c
@@ -1,0 +1,38 @@
+#include "../../util/fd_util.h"
+#include "fd_mvcc.h"
+
+ulong *
+fd_mvcc_version_laddr( fd_mvcc_t * mvcc ) {
+  return &mvcc->version;
+}
+
+ulong
+fd_mvcc_begin_write( fd_mvcc_t * mvcc ) {
+  ulong version = FD_ATOMIC_FETCH_AND_ADD( fd_mvcc_version_laddr( mvcc ), 1 );
+  FD_COMPILER_MFENCE();
+  return version;
+}
+
+ulong
+fd_mvcc_end_write( fd_mvcc_t * mvcc ) {
+  FD_COMPILER_MFENCE();
+  return FD_ATOMIC_FETCH_AND_ADD( fd_mvcc_version_laddr( mvcc ), 1 );
+}
+
+ulong
+fd_mvcc_read( fd_mvcc_t * mvcc ) {
+  FD_COMPILER_MFENCE();
+  ulong version = FD_VOLATILE_CONST( mvcc->version );
+  FD_COMPILER_MFENCE();
+  return version;
+}
+
+ulong
+fd_mvcc_begin_read( fd_mvcc_t * mvcc ) {
+  return fd_mvcc_read( mvcc );
+}
+
+ulong
+fd_mvcc_end_read( fd_mvcc_t * mvcc ) {
+  return fd_mvcc_read( mvcc );
+}

--- a/src/tango/mvcc/fd_mvcc.h
+++ b/src/tango/mvcc/fd_mvcc.h
@@ -1,0 +1,64 @@
+#ifndef HEADER_fd_src_tango_mvcc_fd_mvcc_h
+#define HEADER_fd_src_tango_mvcc_fd_mvcc_h
+
+#include "../../util/fd_util.h"
+
+/* fd_mvcc ("Multiversion Concurrency Control") is a simple primitive for lock-free synchronization
+   of concurrent readers and writers. It is strictly less general than the MVCC used in various
+   DBMS [https://dl.acm.org/doi/pdf/10.1145/356842.356846], but it is conceptually similar in that
+   it uses a version number to detect conflicts.
+
+   Usage:
+   - Writer increments version number
+   - Writer does update
+   - Writer increments version number
+   - Therefore, if the version number is odd, a write is in progress.
+
+   - Reader reads version number
+   - Reader reads data
+   - Reader reads version number
+   - Therefore, if the version number has changed, the read is invalid.
+
+   fd_mvcc_begin_write()  // release-store
+   ... write ...
+   fd_mvcc_end_write()    // acquire-load
+
+   ulong begin = fd_mvcc_begin_read()  // acquire-load
+   ulong end = fd_mvcc_end_read()      // acquire-load
+   if (end != begin) {
+     ... read is invalid ...
+   }
+
+   Note this is similar to how producers / consumers synchronize across mcache / dcache.
+
+   TODO hardware fencing */
+
+struct fd_mvcc {
+  ulong version;
+};
+typedef struct fd_mvcc fd_mvcc_t;
+
+/* fd_mvcc_version_laddr returns a local pointer to the version number for the current joined
+ * process. Caller is responsible for fencing the dereference if necessary. */
+ulong *
+fd_mvcc_version_laddr( fd_mvcc_t * mvcc ); 
+
+/* fd_mvcc_begin_write increments then returns the version number, fencing preceding memory
+ * accesses. Corresponds to C++ memory_order_release. */
+ulong
+fd_mvcc_begin_write( fd_mvcc_t * mvcc ); 
+
+/* fd_mvcc_begin_write increments then returns the version number, fencing subsequent memory
+ * accesses. Corresponds to C++ memory_order_acquire. */
+ulong
+fd_mvcc_end_write( fd_mvcc_t * mvcc ); 
+
+/* fd_mvcc_{begin,end}_read are convenience exports for code readability assisting with
+   remembering to read back the version. */
+ulong
+fd_mvcc_begin_read( fd_mvcc_t * mvcc ); 
+
+ulong
+fd_mvcc_end_read( fd_mvcc_t * mvcc ); 
+
+#endif /* HEADER_fd_src_tango_mvcc_fd_mvcc_h */

--- a/src/tango/mvcc/test_mvcc.c
+++ b/src/tango/mvcc/test_mvcc.c
@@ -9,17 +9,17 @@ main( int argc, char ** argv ) {
 
   fd_mvcc_t mvcc = { .version = 0 };
   FD_TEST( fd_mvcc_begin_read( &mvcc ) == 0 );
-  FD_TEST( fd_mvcc_end_read( &mvcc ) != 0 );
+  FD_TEST( fd_mvcc_end_read( &mvcc ) == 0 );
 
-  FD_TEST( fd_mvcc_begin_write( &mvcc ) == 1 );
+  FD_TEST( fd_mvcc_begin_write( &mvcc ) == 0 );
   FD_TEST( fd_mvcc_begin_read( &mvcc ) == 1 );
   FD_TEST( fd_mvcc_end_read( &mvcc ) == 1 );
-  FD_TEST( fd_mvcc_end_write( &mvcc ) == 2 );
+  FD_TEST( fd_mvcc_end_write( &mvcc ) == 1 );
 
   FD_TEST( fd_mvcc_begin_read( &mvcc ) == 2 );
-  FD_TEST( fd_mvcc_begin_write( &mvcc ) == 3 );
+  FD_TEST( fd_mvcc_begin_write( &mvcc ) == 2 );
   FD_TEST( fd_mvcc_end_read( &mvcc ) == 3 );
-  FD_TEST( fd_mvcc_end_write( &mvcc ) == 4 );
+  FD_TEST( fd_mvcc_end_write( &mvcc ) == 3 );
 
   FD_LOG_NOTICE( ( "pass" ) );
   fd_halt();

--- a/src/tango/mvcc/test_mvcc.c
+++ b/src/tango/mvcc/test_mvcc.c
@@ -1,0 +1,27 @@
+#include "../../util/fd_util.h"
+#include "fd_mvcc.h"
+
+int
+main( int argc, char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  if ( FD_UNLIKELY( argc > 1 ) ) FD_LOG_ERR( ( "unrecognized argument: %s", argv[1] ) );
+
+  fd_mvcc_t mvcc = { .version = 0 };
+  FD_TEST( fd_mvcc_begin_read( &mvcc ) == 0 );
+  FD_TEST( fd_mvcc_end_read( &mvcc ) != 0 );
+
+  FD_TEST( fd_mvcc_begin_write( &mvcc ) == 1 );
+  FD_TEST( fd_mvcc_begin_read( &mvcc ) == 1 );
+  FD_TEST( fd_mvcc_end_read( &mvcc ) == 1 );
+  FD_TEST( fd_mvcc_end_write( &mvcc ) == 2 );
+
+  FD_TEST( fd_mvcc_begin_read( &mvcc ) == 2 );
+  FD_TEST( fd_mvcc_begin_write( &mvcc ) == 3 );
+  FD_TEST( fd_mvcc_end_read( &mvcc ) == 3 );
+  FD_TEST( fd_mvcc_end_write( &mvcc ) == 4 );
+
+  FD_LOG_NOTICE( ( "pass" ) );
+  fd_halt();
+  return 0;
+}

--- a/src/tango/stake/Local.mk
+++ b/src/tango/stake/Local.mk
@@ -1,0 +1,4 @@
+$(call add-hdrs,fd_stake.h)
+$(call add-objs,fd_stake,fd_tango)
+$(call make-unit-test,test_stake,test_stake,fd_tango fd_util)
+$(call run-unit-test,test_stake,)

--- a/src/tango/stake/fd_stake.c
+++ b/src/tango/stake/fd_stake.c
@@ -1,0 +1,133 @@
+#include "fd_stake.h"
+
+ulong
+fd_stake_align( void ) {
+  return FD_STAKE_ALIGN;
+}
+
+ulong
+fd_stake_footprint( int lg_slot_cnt ) {
+  if ( lg_slot_cnt <= 0 ) { return 0UL; }
+  ulong l;
+  l = FD_LAYOUT_INIT;
+  l = FD_LAYOUT_APPEND( l, fd_stake_align(), sizeof( fd_stake_t ) );
+  l = FD_LAYOUT_APPEND( l, fd_stake_node_align(), fd_stake_node_footprint( (int)lg_slot_cnt ) );
+  return FD_LAYOUT_FINI( l, fd_stake_align() );
+}
+
+void *
+fd_stake_new( void * shmem, int lg_slot_cnt ) {
+
+  if ( FD_UNLIKELY( !shmem ) ) {
+    FD_LOG_WARNING( ( "NULL shmem" ) );
+    return NULL;
+  }
+
+  if ( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, fd_stake_align() ) ) ) {
+    FD_LOG_WARNING( ( "misaligned shmem" ) );
+    return NULL;
+  }
+
+  ulong footprint = fd_stake_node_footprint( (int)lg_slot_cnt );
+  if ( FD_UNLIKELY( !footprint ) ) {
+    FD_LOG_WARNING( ( "bad lg_slot_cnt (%d): must be >=0", lg_slot_cnt ) );
+    return NULL;
+  }
+
+  fd_memset( shmem, 0, footprint );
+
+  fd_stake_t * stake = (fd_stake_t *)shmem;
+  fd_mvcc_t    mvcc  = { .version = 0 };
+  stake->mvcc        = mvcc;
+  stake->total_stake = 0;
+  /* note the map join happens inside `new`, because the offset from the start of the stake region
+   * to map slot0 is stable across joins */
+  fd_stake_node_t * staked_nodes =
+      fd_stake_node_join( fd_stake_node_new( stake + sizeof( fd_stake_t ), lg_slot_cnt ) );
+  stake->nodes_off = (ulong)staked_nodes - (ulong)stake;
+
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( stake->magic ) = FD_STAKE_MAGIC;
+  FD_COMPILER_MFENCE();
+
+  return shmem;
+}
+
+fd_stake_t *
+fd_stake_join( void * shstake ) {
+
+  if ( FD_UNLIKELY( !shstake ) ) {
+    FD_LOG_WARNING( ( "NULL shstake" ) );
+    return NULL;
+  }
+
+  if ( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shstake, fd_stake_align() ) ) ) {
+    FD_LOG_WARNING( ( "misaligned shmem" ) );
+    return NULL;
+  }
+
+  fd_stake_t * stake = (fd_stake_t *)shstake;
+  if ( FD_UNLIKELY( stake->magic != FD_STAKE_MAGIC ) ) {
+    FD_LOG_WARNING( ( "bad magic" ) );
+    return NULL;
+  }
+
+  fd_stake_node_t * map_ptr = fd_stake_nodes_laddr( stake );
+  fd_stake_node_join( map_ptr );
+
+  return stake;
+}
+
+ulong
+fd_stake_version( fd_stake_t * stake ) {
+  FD_COMPILER_MFENCE();
+  return stake->version;
+}
+
+ulong *
+fd_stake_version_laddr( fd_stake_t * stake ) {
+  return &stake->version;
+}
+
+fd_stake_node_t *
+fd_stake_nodes_laddr( fd_stake_t * stake ) {
+  return (fd_stake_node_t *)( (ulong)stake + stake->nodes_off );
+}
+
+/* fd_stake_version performs a fenced read of the version number. `fd_stake_t` is a single-producer,
+ * multiple-consumer concurrency structure and an odd version number indicates the writer is
+ * currently writing to the structure. */
+void
+fd_stake_update( fd_stake_t * stake, uchar * staked_nodes_ser, ulong sz ) {
+  fd_mvcc_begin_write( &stake->mvcc );
+
+  fd_stake_node_t * staked_nodes = fd_stake_nodes_laddr( stake );
+  fd_stake_node_clear( staked_nodes );
+  for ( ulong off = 0; off < sz; off += 40 ) {
+    /* 32-byte aligned. dcache is 128-byte aligned. 128 % 32 = 0. */
+    fd_stake_pubkey_t * pubkey = (fd_stake_pubkey_t *)( fd_type_pun( staked_nodes_ser + off ) );
+    /* 8-byte aligned. 32 + 8 = 40. 40 % 8 = 0. */
+    ulong * stake =
+        (ulong *)( fd_type_pun( staked_nodes_ser + off + sizeof( fd_stake_pubkey_t ) ) );
+    fd_stake_node_t * staked_node = fd_stake_node_insert( staked_nodes, *pubkey );
+    if ( staked_node == NULL ) staked_node = fd_stake_node_query( staked_nodes, *pubkey, NULL );
+    if ( staked_node == NULL ) {
+      FD_LOG_HEXDUMP_WARNING( ( "failed to insert pubkey", pubkey, sizeof( fd_stake_pubkey_t ) ) );
+      continue;
+    }
+    staked_node->stake = *stake;
+  }
+
+  fd_mvcc_end_write( &stake->mvcc );
+}
+
+void
+fd_stake_dump( fd_stake_t * stake ) {
+  fd_stake_node_t * staked_nodes = fd_stake_nodes_laddr( stake );
+  for ( ulong i = 0; i < fd_stake_node_slot_cnt( staked_nodes ); i++ ) {
+    fd_stake_node_t * staked_node = &staked_nodes[i];
+    if ( !fd_stake_node_key_inval( staked_node->key ) ) {
+      FD_LOG_NOTICE( ( "stake[%lu] = %lu", i, staked_node->stake ) );
+    }
+  }
+}

--- a/src/tango/stake/fd_stake.h
+++ b/src/tango/stake/fd_stake.h
@@ -1,0 +1,105 @@
+#ifndef HEADER_fd_src_tango_stake_fd_stake_h
+#define HEADER_fd_src_tango_stake_fd_stake_h
+
+#include "../../ballet/txn/fd_txn.h"
+#include "../mvcc/fd_mvcc.h"
+
+/* double cache line */
+#define FD_STAKE_ALIGN ( 128 )
+
+/* maximum lg # of staked nodes we can track */
+#define FD_STAKE_LG_SLOT_CNT ( 16 )
+
+/* opaque */
+#define FD_STAKE_MAGIC ( 0xF17EDA2CE757A1E0 ) /* FIREDANCER STAKE V0 */
+
+struct fd_stake_private {
+  ulong     magic; /* == FD_STAKE_MAGIC */
+  fd_mvcc_t mvcc;
+  ulong     total_stake; /* total amount of stake */
+  ulong     nodes_off;   /* offset to map region */
+};
+typedef struct fd_stake_private fd_stake_t;
+
+struct fd_stake_pubkey {
+  uchar pubkey[FD_TXN_PUBKEY_SZ];
+};
+
+typedef struct fd_stake_pubkey fd_stake_pubkey_t;
+static fd_stake_pubkey_t       pubkey_null = { 0 };
+
+/* Staked node map */
+struct fd_stake_node {
+  fd_stake_pubkey_t key;
+  uint              hash;
+  ulong             stake;
+};
+typedef struct fd_stake_node fd_stake_node_t;
+
+#define MAP_NAME                fd_stake_node
+#define MAP_T                   fd_stake_node_t
+#define MAP_KEY_T               fd_stake_pubkey_t
+#define MAP_KEY_NULL            pubkey_null
+#define MAP_KEY_INVAL( k )      !( memcmp( &k, &pubkey_null, sizeof( fd_stake_pubkey_t ) ) )
+#define MAP_KEY_EQUAL( k0, k1 ) !( memcmp( ( k0.pubkey ), ( k1.pubkey ), FD_TXN_PUBKEY_SZ ) )
+// #define MAP_KEY_EQUAL( k0, k1 ) map_key_equal(k0, k1)
+// #define MAP_KEY_EQUAL( k0, k1 ) (sizeof(k0.pubkey) == sizeof(k1.pubkey))
+#define MAP_KEY_EQUAL_IS_SLOW 1
+#define MAP_KEY_HASH( key )   ( (uint)( fd_hash( 0UL, key.pubkey, FD_TXN_PUBKEY_SZ ) ) )
+// #define MAP_KEY_HASH( key ) ( fd_uint_load_4( fd_type_pun( &key.pubkey ) ) )
+// #define MAP_KEY_HASH( key )     ( *(uint *)( fd_type_pun( &key.pubkey ) ) )  /* FIXME UB */
+#include "../../util/tmpl/fd_map_dynamic.c"
+
+ulong
+fd_stake_align( void );
+
+ulong
+fd_stake_footprint( int lg_slot_cnt );
+
+/* fd_stake_new formats an unused memory region for use as an fd_stake_t. `nodes_off` points to the
+   first slot, which is past the map header. The layout is diagrammed below:
+
+   ------------------ <- (fd_stake_t * stake)
+   private hdr region
+   ------------------
+   nodes map region
+
+   .....   hdr  .....
+   ..... node 0 ..... <- (fd_stake_t * stake) + nodes_off
+   ..... node 1 .....
+   ..... ...... .....
+   ..... node n .....
+
+   ------------------ */
+void *
+fd_stake_new( void * mem, int lg_slot_cnt );
+
+/* fd_stake_t is designed to be shared across multiple joins.
+
+   Therefore, it maintains an offset for the staked nodes region (which itself requires a join),
+   which is located within the stake region itself. It uses an offset in lieu of pointers, because
+   the pointer addresses would otherwise be local to each joined process. Note this is a pointer to
+   the first slot in the map, rather than the start of the map region itself, as `fd_map_dynamic`
+   expects slot pointers in its API.
+
+   See `fd_stake_new` for the layout. */
+fd_stake_t *
+fd_stake_join( void * shstake );
+
+ulong
+fd_stake_version( fd_stake_t * stake );
+
+ulong *
+fd_stake_version_laddr( fd_stake_t * stake );
+
+fd_stake_node_t *
+fd_stake_nodes_laddr( fd_stake_t * stake );
+
+/* updates using the (serialized) staked nodes from the labs client */
+void
+fd_stake_update( fd_stake_t * stake, uchar * staked_nodes_ser, ulong sz );
+
+void
+fd_stake_dump( fd_stake_t * stake );
+
+#endif /* HEADER_fd_src_tango_stake_fd_stake_h */

--- a/src/tango/stake/fd_stake.h
+++ b/src/tango/stake/fd_stake.h
@@ -56,16 +56,16 @@ fd_stake_align( void );
 ulong
 fd_stake_footprint( int lg_slot_cnt );
 
-/* fd_stake_new formats an unused memory region for use as an fd_stake_t. `nodes_off` points to the
+/* fd_stake_new formats an unused memory region for use as a stake object. `nodes_off` points to the
    first slot, which is past the map header. The layout is diagrammed below:
 
-   ------------------ <- (fd_stake_t * stake)
+   ------------------ <- (fd_stake_t * stake)  // returned by fd_stake_new
    private hdr region
    ------------------
    nodes map region
 
    .....   hdr  .....
-   ..... node 0 ..... <- (fd_stake_t * stake) + nodes_off
+   ..... node 0 .....
    ..... node 1 .....
    ..... ...... .....
    ..... node n .....
@@ -74,15 +74,26 @@ fd_stake_footprint( int lg_slot_cnt );
 void *
 fd_stake_new( void * mem, int lg_slot_cnt );
 
-/* fd_stake_t is designed to be shared across multiple joins.
+/* fd_stake_join joins the caller to the stake object.
 
-   Therefore, it maintains an offset for the staked nodes region (which itself requires a join),
-   which is located within the stake region itself. It uses an offset in lieu of pointers, because
-   the pointer addresses would otherwise be local to each joined process. Note this is a pointer to
-   the first slot in the map, rather than the start of the map region itself, as `fd_map_dynamic`
-   expects slot pointers in its API.
+   fd_stake_t is designed to be shared across multiple joins. Therefore, it maintains an offset for
+   the staked nodes region (which itself requires a join), which is located within the stake region
+   itself. It uses an offset in lieu of pointers, because the pointer addresses would otherwise be
+   local to each joined process. Note this is a pointer to the first slot in the map, rather than
+   the start of the map region itself, as `fd_map_dynamic` expects slot pointers in its API.
 
-   See `fd_stake_new` for the layout. */
+  -------------------
+   private hdr region
+   ------------------
+   nodes map region
+
+   .....   hdr  .....
+   ..... node 0 ..... <- (fd_stake_t * stake) + nodes_off  // set by fd_stake_join
+   ..... node 1 .....
+   ..... ...... .....
+   ..... node n .....
+
+   ------------------ */
 fd_stake_t *
 fd_stake_join( void * shstake );
 
@@ -95,9 +106,28 @@ fd_stake_version_laddr( fd_stake_t * stake );
 fd_stake_node_t *
 fd_stake_nodes_laddr( fd_stake_t * stake );
 
-/* updates using the (serialized) staked nodes from the labs client */
+/* fd_stake_read performs an mvcc-fenced read of the stake structure. `fd_stake_t` is a single-producer,
+ * multiple-consumer concurrency structure and an odd version number indicates the writer is
+ * currently writing to the structure. */
+fd_stake_t *
+fd_stake_read( fd_stake_t * stake);
+
+/* fd_stake_write performs an mvcc-fenced write of the stake structure. Assumes there is a single
+   writer and does not check for safe concurrency with multiple writers.
+
+   `data` is a pointer to a bincode-serialized byte representation of stakes from the labs client.
+
+   Serialization format:
+   -----------
+   total stake  (8 bytes, le)
+   node0 pubkey (32 bytes, le)
+   node0 stake  (8 bytes, le)
+   node1 pubkey (32 bytes, le)
+   node1 stake  (8 bytes, le)
+   ...
+   ----------- */
 void
-fd_stake_update( fd_stake_t * stake, uchar * staked_nodes_ser, ulong sz );
+fd_stake_write( fd_stake_t * stake, uchar * data, ulong sz );
 
 void
 fd_stake_dump( fd_stake_t * stake );

--- a/src/tango/stake/fd_stake.h
+++ b/src/tango/stake/fd_stake.h
@@ -1,17 +1,19 @@
 #ifndef HEADER_fd_src_tango_stake_fd_stake_h
 #define HEADER_fd_src_tango_stake_fd_stake_h
 
-#include "../../ballet/txn/fd_txn.h"
 #include "../mvcc/fd_mvcc.h"
 
 /* double cache line */
-#define FD_STAKE_ALIGN ( 128 )
+#define FD_STAKE_ALIGN 128UL
 
 /* maximum lg # of staked nodes we can track */
-#define FD_STAKE_LG_SLOT_CNT ( 16 )
+#define FD_STAKE_LG_SLOT_CNT 16UL
+
+/* 32-bytes, as with all Solana pubkeys */
+#define FD_STAKE_PUBKEY_SZ 32UL
 
 /* opaque */
-#define FD_STAKE_MAGIC ( 0xF17EDA2CE757A1E0 ) /* FIREDANCER STAKE V0 */
+#define FD_STAKE_MAGIC 0xF17EDA2CE757A1E0 /* FIREDANCER STAKE V0 */
 
 struct fd_stake_private {
   ulong     magic; /* == FD_STAKE_MAGIC */
@@ -22,7 +24,7 @@ struct fd_stake_private {
 typedef struct fd_stake_private fd_stake_t;
 
 struct fd_stake_pubkey {
-  uchar pubkey[FD_TXN_PUBKEY_SZ];
+  uchar pubkey[FD_STAKE_PUBKEY_SZ];
 };
 
 typedef struct fd_stake_pubkey fd_stake_pubkey_t;
@@ -41,13 +43,9 @@ typedef struct fd_stake_node fd_stake_node_t;
 #define MAP_KEY_T               fd_stake_pubkey_t
 #define MAP_KEY_NULL            pubkey_null
 #define MAP_KEY_INVAL( k )      !( memcmp( &k, &pubkey_null, sizeof( fd_stake_pubkey_t ) ) )
-#define MAP_KEY_EQUAL( k0, k1 ) !( memcmp( ( k0.pubkey ), ( k1.pubkey ), FD_TXN_PUBKEY_SZ ) )
-// #define MAP_KEY_EQUAL( k0, k1 ) map_key_equal(k0, k1)
-// #define MAP_KEY_EQUAL( k0, k1 ) (sizeof(k0.pubkey) == sizeof(k1.pubkey))
+#define MAP_KEY_EQUAL( k0, k1 ) !( memcmp( ( k0.pubkey ), ( k1.pubkey ), FD_STAKE_PUBKEY_SZ ) )
 #define MAP_KEY_EQUAL_IS_SLOW 1
-#define MAP_KEY_HASH( key )   ( (uint)( fd_hash( 0UL, key.pubkey, FD_TXN_PUBKEY_SZ ) ) )
-// #define MAP_KEY_HASH( key ) ( fd_uint_load_4( fd_type_pun( &key.pubkey ) ) )
-// #define MAP_KEY_HASH( key )     ( *(uint *)( fd_type_pun( &key.pubkey ) ) )  /* FIXME UB */
+#define MAP_KEY_HASH( key )   ( (uint)( fd_hash( 0UL, key.pubkey, FD_STAKE_PUBKEY_SZ ) ) )
 #include "../../util/tmpl/fd_map_dynamic.c"
 
 ulong
@@ -127,7 +125,7 @@ fd_stake_read( fd_stake_t * stake);
    ...
    ----------- */
 void
-fd_stake_write( fd_stake_t * stake, uchar * data, ulong sz );
+fd_stake_deser( fd_stake_t * stake, uchar * data, ulong sz );
 
 void
 fd_stake_dump( fd_stake_t * stake );

--- a/src/tango/stake/test_stake.c
+++ b/src/tango/stake/test_stake.c
@@ -1,0 +1,52 @@
+#include "../../util/fd_util.h"
+#include "fd_stake.h"
+
+#define LG_SLOT_CNT 10
+#define MAX_NODE_CNT    ( 1UL << LG_SLOT_CNT )
+#define NUM_PUBKEYS     4
+
+fd_stake_pubkey_t pubkeys[NUM_PUBKEYS] = {
+    { .pubkey = { 44, 174, 25,  39, 43, 255, 200, 81, 55, 73, 10,  113, 174, 91, 223, 80,
+                  50, 51,  102, 25, 63, 110, 36,  28, 51, 11, 174, 179, 110, 8,  25,  152 } },
+    { .pubkey = { 250, 56, 248, 84,  190, 46,  154, 76,  15, 72, 181, 205, 32, 96, 128, 213,
+                  158, 33, 81,  193, 63,  154, 93,  254, 15, 81, 32,  175, 54, 60, 179, 224 } },
+    { .pubkey = { 225, 102, 95, 246, 174, 91, 1,  240, 118, 174, 119, 113, 150, 146, 149, 29,
+                  253, 10,  69, 168, 188, 51, 31, 11,  67,  18,  201, 181, 189, 178, 159, 178 } },
+    { .pubkey = { 160, 58,  145, 16, 41,  55,  193, 27,  132, 112, 36, 109, 233, 125, 206,
+                  165, 200, 130, 76, 147, 173, 151, 180, 73,  248, 4,  165, 8,   163, 42 } } };
+
+void
+test_stake( void ) {
+  fd_wksp_t * wksp = fd_wksp_new_anonymous(
+      FD_SHMEM_GIGANTIC_PAGE_SZ, 1, fd_shmem_cpu_idx( fd_shmem_numa_idx( 0 ) ), "wksp", 0UL );
+  FD_TEST( wksp );
+  void * mem =
+      fd_wksp_alloc_laddr( wksp, fd_stake_align(), fd_stake_footprint( LG_SLOT_CNT ), 42UL );
+
+  fd_stake_t *      stake        = fd_stake_join( fd_stake_new( mem, LG_SLOT_CNT ) );
+  fd_stake_node_t * staked_nodes = fd_stake_nodes_laddr( stake );
+
+  for ( ulong i = 0; i < NUM_PUBKEYS; i++ ) {
+    fd_stake_node_t * staked_node = fd_stake_node_insert( staked_nodes, pubkeys[i] );
+    staked_node->stake            = i;
+    FD_TEST( staked_node );
+  }
+  for ( ulong i = 0; i < NUM_PUBKEYS; i++ ) {
+    fd_stake_node_t * staked_node = fd_stake_node_query( staked_nodes, pubkeys[i], NULL );
+    FD_TEST( staked_node );
+    FD_TEST( staked_node->stake == i );
+  }
+}
+
+int
+main( int argc, char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  if ( FD_UNLIKELY( argc > 1 ) ) FD_LOG_ERR( ( "unrecognized argument: %s", argv[1] ) );
+
+  test_stake();
+
+  FD_LOG_NOTICE( ( "pass" ) );
+  fd_halt();
+  return 0;
+}

--- a/src/tango/stake/test_stake.c
+++ b/src/tango/stake/test_stake.c
@@ -36,11 +36,6 @@ test_stake( void ) {
     FD_TEST( staked_node );
     FD_TEST( staked_node->stake == i );
   }
-
-  stake->mvcc.version = 0;
-  FD_TEST( fd_stake_read( stake ) );
-  stake->mvcc.version = 1;
-  FD_TEST( !fd_stake_read( stake ) );
 }
 
 int

--- a/src/tango/stake/test_stake.c
+++ b/src/tango/stake/test_stake.c
@@ -36,6 +36,11 @@ test_stake( void ) {
     FD_TEST( staked_node );
     FD_TEST( staked_node->stake == i );
   }
+
+  stake->mvcc.version = 0;
+  FD_TEST( fd_stake_read( stake ) );
+  stake->mvcc.version = 1;
+  FD_TEST( !fd_stake_read( stake ) );
 }
 
 int

--- a/src/util/shmem/fd_shmem_private.h
+++ b/src/util/shmem/fd_shmem_private.h
@@ -2,6 +2,7 @@
 #define HEADER_fd_src_util_shmem_fd_shmem_private_h
 
 #include "fd_shmem.h"
+#include <stdlib.h>
 
 #if FD_HAS_THREADS
 #include <pthread.h>
@@ -136,8 +137,18 @@ static inline char *                         /* ==buf always */
 fd_shmem_private_path( char const * name,    /* Valid name */
                        ulong        page_sz, /* Valid page size (normal, huge, gigantic) */
                        char *       buf ) {  /* Non-NULL with FD_SHMEM_PRIVATE_PATH_BUF_MAX bytes */
-  return fd_cstr_printf( buf, FD_SHMEM_PRIVATE_PATH_BUF_MAX, NULL, "%s/.%s/%s",
+                       
+  buf = fd_cstr_printf( buf, FD_SHMEM_PRIVATE_PATH_BUF_MAX, NULL, "%s/.%s/%s",
                          fd_shmem_private_base, fd_shmem_page_sz_to_cstr( page_sz ), name );
+  if ( getenv( "FD_FFI" ) ) {
+    char tmp[FD_SHMEM_PRIVATE_PATH_BUF_MAX];
+    char prefix[9] = "/mnt/.fd";
+    memcpy( tmp, prefix, 8 );
+    memcpy( tmp + 8, buf, FD_SHMEM_PRIVATE_PATH_BUF_MAX - 8 );
+    memset( buf, 0, FD_SHMEM_PRIVATE_PATH_BUF_MAX );
+    memcpy( buf, tmp, FD_SHMEM_PRIVATE_PATH_BUF_MAX );
+  }
+  return buf;
 }
 
 FD_PROTOTYPES_END


### PR DESCRIPTION
This PR introduces stakes.

`fd_mvcc` is an abstraction for concurrency control between the Solana writer and Firedancer reader (basically simplified mcache / dcache machinery).

`fd_stake` is designed for single-writer, multi-reader.

#### Writer usage
https://github.com/firedancer-io/solana/pull/4

#### Example of reader usage
See https://github.com/firedancer-io/firedancer/pull/512/files#diff-89801b19333be6fdd8b33cd6402d5c6cc1694047d80987eac53fe7fd257c0c50R88-R133

