### PR TITLE
fdctl: fix dev1 error about null workspace

### DIFF
--- a/src/app/fddev/dev1.c
+++ b/src/app/fddev/dev1.c
@@ -58,6 +58,9 @@ dev1_cmd_fn( args_t *         args,
   config->consensus.wait_for_vote_to_start_leader = 0;
 
   tile_main_args_t tile_args = {
+    .app_name = config->name,
+    .uid = config->uid,
+    .gid = config->gid,
     .tile_idx = 0,
     .idx = 0,
     .sandbox = config->development.sandbox,


### PR DESCRIPTION
Refactor had messed up the `dev1` command by not passing the correct arguments.