### PR TITLE
util/tmpl: allow deleting from treap while iterating

### DIFF
--- a/src/util/tmpl/fd_treap.c
+++ b/src/util/tmpl/fd_treap.c
@@ -262,12 +262,12 @@
      //
      //     ... process i (or e) here
      //
-     //     ... Do not insert / remove any elements from treap and do
-     //     ... not change the element's parent, left, right, prio or
-     //     ... queries here.  It is fine to run queries and other
-     //     ... iterations concurrently.  Other fields are free to
-     //     ... modify (from the treap's POV, the application manages
-     //     ... concurrency for other fields).
+     //     ... Do not remove the element the iterator is currently
+     //     ... pointing to, and do not change the element's parent,
+     //     ... left, right, prio or queries here.  It is fine to run
+     //     ... queries and other iterations concurrently.  Other fields
+     //     ... are free to modify (from the treap's POV, the
+     //     ... application manages concurrency for other fields).
      //  }
      //
      // pool is a pointer in the caller's address space to the ele_max


### PR DESCRIPTION
Just changes the comment because it was actually already supported. Adds a test.
When you delete, other than the deleted element, none of the tree nodes change in binary search tree order. In particular, the heap adjustments don't change the order, even when elements have equal keys. Since the iteration only depends on binary search order, deleting an element does not affect iteration.
The behavior of deleting while iterating is pretty intuitive. If you delete something behind the iterator, there's no effect. If you delete something in front of the iterator, then you won't iterate over it when you would have gotten there. You can't delete the current position of the iterator.