### PR TITLE
util: switch log to use posix file api

### DIFF
--- a/src/app/fdctl/monitor/monitor.c
+++ b/src/app/fdctl/monitor/monitor.c
@@ -393,7 +393,6 @@ monitor_cmd_fn( args_t *         args,
 
   long allow_syscalls[] = {
     __NR_write,       /* logging */
-    __NR_futex,       /* logging, glibc fprintf unfortunately uses a futex internally */
     __NR_nanosleep,   /* fd_log_wait_until */
     __NR_sched_yield, /* fd_log_wait_until */
     __NR_exit_group,  /* exit process */

--- a/src/app/fdctl/run.c
+++ b/src/app/fdctl/run.c
@@ -83,6 +83,7 @@ int
 tile_main( void * _args ) {
   tile_main_args_t * args = _args;
 
+  fd_log_private_tid_set( args->idx );
   fd_log_thread_set( args->tile->name );
 
   install_tile_signals();
@@ -343,7 +344,6 @@ main_pid_namespace( void * args ) {
 
   long allow_syscalls[] = {
     __NR_write,      /* logging */
-    __NR_futex,      /* logging, glibc fprintf unfortunately uses a futex internally */
     __NR_wait4,      /* wait for children */
     __NR_exit_group, /* exit process */
   };
@@ -372,10 +372,10 @@ main_pid_namespace( void * args ) {
   }
 
   if( FD_UNLIKELY( !WIFEXITED( wstatus ) ) ) {
-    fprintf( stderr, "tile %lu (%s) exited with signal %d (%s)\n", tile_idx, name, WTERMSIG( wstatus ), strsignal( WTERMSIG( wstatus ) ) );
+    fd_log_private_fprintf_0( STDERR_FILENO, "tile %lu (%s) exited with signal %d (%s)\n", tile_idx, name, WTERMSIG( wstatus ), strsignal( WTERMSIG( wstatus ) ) );
     exit_group( WTERMSIG( wstatus ) );
   }
-  fprintf( stderr, "tile %lu (%s) exited with code %d\n", tile_idx, name, WEXITSTATUS( wstatus ) );
+  fd_log_private_fprintf_0( STDERR_FILENO, "tile %lu (%s) exited with code %d\n", tile_idx, name, WEXITSTATUS( wstatus ) );
   exit_group( WEXITSTATUS( wstatus ) );
   return 0;
 }
@@ -387,7 +387,7 @@ static void
 parent_signal( int sig ) {
   (void)sig;
   if( pid_namespace ) kill( pid_namespace, SIGKILL );
-  fprintf( stderr, "Log at \"%s\"", fd_log_private_path );
+  fd_log_private_fprintf_0( STDERR_FILENO, "Log at \"%s\"", fd_log_private_path );
   exit_group( 0 );
 }
 
@@ -419,7 +419,6 @@ run_firedancer( config_t * const config ) {
 
   long allow_syscalls[] = {
     __NR_write,      /* logging */
-    __NR_futex,      /* logging, glibc fprintf unfortunately uses a futex internally */
     __NR_wait4,      /* wait for children */
     __NR_exit_group, /* exit process */
     __NR_kill,       /* kill the pid namespaced child process */
@@ -432,7 +431,7 @@ run_firedancer( config_t * const config ) {
 
   int wstatus;
   pid_t pid2 = wait4( pid_namespace, &wstatus, (int)__WCLONE, NULL );
-  fprintf( stderr, "Log at \"%s\"\n", fd_log_private_path );
+  fd_log_private_fprintf_0( STDERR_FILENO, "Log at \"%s\"\n", fd_log_private_path );
   if( FD_UNLIKELY( pid2 == -1 ) ) exit_group( 1 );
   if( FD_UNLIKELY( !WIFEXITED( wstatus ) ) ) exit_group( WTERMSIG( wstatus ) );
   exit_group( WEXITSTATUS( wstatus ) );

--- a/src/app/frank/fd_frank_dedup.c
+++ b/src/app/frank/fd_frank_dedup.c
@@ -81,7 +81,6 @@ run( fd_frank_args_t * args ) {
 
 static long allow_syscalls[] = {
   __NR_write,     /* logging */
-  __NR_futex,     /* logging, glibc fprintf unfortunately uses a futex internally */
   __NR_fsync,     /* logging, WARNING and above fsync immediately */
   __NR_nanosleep, /* fd_tempo_tick_per_ns calibration */
 };

--- a/src/app/frank/fd_frank_pack.c
+++ b/src/app/frank/fd_frank_pack.c
@@ -280,7 +280,6 @@ run( fd_frank_args_t * args ) {
 
 static long allow_syscalls[] = {
   __NR_write,     /* logging */
-  __NR_futex,     /* logging, glibc fprintf unfortunately uses a futex internally */
   __NR_fsync,     /* logging, WARNING and above fsync immediately */
   __NR_nanosleep, /* fd_tempo_tick_per_ns calibration */
 };

--- a/src/app/frank/fd_frank_quic.c
+++ b/src/app/frank/fd_frank_quic.c
@@ -128,7 +128,6 @@ run( fd_frank_args_t * args ) {
 
 static long allow_syscalls[] = {
   __NR_write,     /* logging */
-  __NR_futex,     /* logging, glibc fprintf unfortunately uses a futex internally */
   __NR_fsync,     /* logging, WARNING and above fsync immediately */
   __NR_nanosleep, /* fd_tempo_tick_per_ns calibration */
   __NR_getpid,    /* OpenSSL RAND_bytes checks pid, temporarily used as part of quic_init to generate a certificate */

--- a/src/app/frank/fd_frank_verify.c
+++ b/src/app/frank/fd_frank_verify.c
@@ -184,7 +184,6 @@ run( fd_frank_args_t * args ) {
 
 static long allow_syscalls[] = {
   __NR_write,     /* logging */
-  __NR_futex,     /* logging, glibc fprintf unfortunately uses a futex internally */
   __NR_fsync,     /* logging, WARNING and above fsync immediately */
   __NR_nanosleep, /* fd_tempo_tick_per_ns calibration */
 };

--- a/src/util/log/fd_log.h
+++ b/src/util/log/fd_log.h
@@ -208,7 +208,12 @@
 
    Note: fd_log_wallclock called outside the arg list to give it a
    linguistically strict point when it is called that is before logging
-   activities commence. */
+   activities commence.
+
+   This family of functions is not async-signal safe. Do not call log functions from
+   a signal handler, it may deadlock or corrupt the log. If you wish to write
+   emergency diagnostics, you can call `write(2)` directly to stderr or the log file,
+   which is safe. */
 
 #define FD_LOG_DEBUG(a)           do { long _fd_log_msg_now = fd_log_wallclock(); fd_log_private_1( 0, _fd_log_msg_now, __FILE__, __LINE__, __func__, fd_log_private_0           a ); } while(0)
 #define FD_LOG_INFO(a)            do { long _fd_log_msg_now = fd_log_wallclock(); fd_log_private_1( 1, _fd_log_msg_now, __FILE__, __LINE__, __func__, fd_log_private_0           a ); } while(0)
@@ -535,6 +540,9 @@ void fd_log_level_flush_set  ( int level );
 void fd_log_level_core_set   ( int level );
 
 /* These functions are for fd_log internal use only. */
+
+void
+fd_log_private_fprintf_0( int fd, char const * fmt, ... ) __attribute__((format(printf,2,3))); /* Type check the fmt string at compile time */
 
 char const *
 fd_log_private_0( char const * fmt, ... ) __attribute__((format(printf,1,2))); /* Type check the fmt string at compile time */


### PR DESCRIPTION
There's a few problems with the existing implementation,

 * `fprintf` is not async signal safe according to POSIX.1, but `write()` is. If we try to log from a signal handler (which we do), it might operate on a half written buffer and cause corruption.

 * `fprintf` uses a lock internally to sequence writes, but this lock is within a process, not across processes. Because all Firedancer tiles run in different processes the locking has no effect and messages may get interleaved.

 * `fprintf` uses a CAS spinlock internally, which is good, but if it spins too many times will switch to a futex which is bad for us. It requires whitelisting the `futex` syscall in our seccomp profile, and also has a performance overhead. We are already pinning cores so it is OK to spin until we can lock.

 * `fprintf` does some buffering internally which causes all kinds of problems when we are trying to terminate and need to call `fflush` and friends from signal handlers.

Instead, we switch to use a `write()` directly, along with a `mmap`ed (MAP_SHARED) lock primitive to sequence writes across processes. All of the flush related code is removed, since there is no buffering.