### PR TITLE
sandbox: rework open file descriptor closing

### DIFF
--- a/src/app/fdctl/main.c
+++ b/src/app/fdctl/main.c
@@ -11,6 +11,7 @@ int
 main1( int     argc,
       char ** _argv ) {
   fd_boot( &argc, &_argv );
+  fd_log_thread_set( "main" );
 
   char ** argv = _argv;
   argc--; argv++;

--- a/src/app/fdctl/monitor/monitor.c
+++ b/src/app/fdctl/monitor/monitor.c
@@ -242,7 +242,7 @@ run_monitor( config_t * const config,
         break;
       case wksp_dedup:
         tile_name[ tile_idx ] = "dedup";
-        tile_cnc[ tile_idx ] = fd_cnc_join( fd_wksp_pod_map( pod, "dedup.cnc" ) );
+        tile_cnc[ tile_idx ] = fd_cnc_join( fd_wksp_pod_map( pod, "cnc" ) );
         if( FD_UNLIKELY( !tile_cnc[ tile_idx ] ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
         if( FD_UNLIKELY( fd_cnc_app_sz( tile_cnc[ tile_idx ] )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
         tile_mcache[ tile_idx ] = fd_mcache_join( fd_wksp_pod_map( FIND(wksp_dedup_pack), "mcache" ) );
@@ -260,7 +260,7 @@ run_monitor( config_t * const config,
         tile_mcache[ tile_idx ] = NULL; /* pack currently has no mcache */
         // if( FD_UNLIKELY( !tile_mcache[ tile_idx ] ) ) FD_LOG_ERR(( "fd_mcache_join failed" ));
         tile_fseq[ tile_idx ] = NULL; /* pack currently has no fseq */
-        if( FD_UNLIKELY( !tile_fseq[ tile_idx ] ) ) FD_LOG_ERR(( "fd_fseq_join failed" ));
+        // if( FD_UNLIKELY( !tile_fseq[ tile_idx ] ) ) FD_LOG_ERR(( "fd_fseq_join failed" ));
         tile_idx++;
         break;
     }
@@ -398,10 +398,18 @@ monitor_cmd_fn( args_t *         args,
     __NR_exit_group,  /* exit process */
   };
 
+  int allow_fds[] = {
+    1, /* stdout */
+    2, /* stderr */
+    3, /* logfile */
+  };
+
+  if( FD_UNLIKELY( close( 0 ) ) ) FD_LOG_ERR(( "close(0) failed (%i-%s)", errno, strerror( errno ) ));
   if( config->development.sandbox )
     fd_sandbox( config->uid,
                 config->gid,
-                4, /* stdin, stdout, stderr, logfile */
+                sizeof(allow_fds)/sizeof(allow_fds[ 0 ]),
+                allow_fds,
                 sizeof(allow_syscalls)/sizeof(allow_syscalls[0]),
                 allow_syscalls );
 

--- a/src/app/fddev/dev.c
+++ b/src/app/fddev/dev.c
@@ -48,5 +48,11 @@ dev_cmd_fn( args_t *         args,
      validator will get stuck forever. */
   config->consensus.wait_for_vote_to_start_leader = 0;
 
+  if( FD_UNLIKELY( config->development.netns.enabled ) ) {
+    /* if we entered a network namespace during configuration, leave it
+       so that `run_firedancer` starts from a clean namespace */
+    leave_network_namespace();
+  }
+
   run_firedancer( config );
 }

--- a/src/app/fddev/main.c
+++ b/src/app/fddev/main.c
@@ -25,7 +25,7 @@ execve_as_root( int     argc,
   self_exe( self_exe_path );
 
   char * args[ MAX_ARGC+4 ];
-  for( int i=3; i<=argc; i++ ) args[i] = argv[i-2];
+  for( int i=1; i<argc; i++ ) args[i+2] = argv[i];
   args[ 0 ]      = "sudo";
   args[ 1 ]      = "-E";
   args[ 2 ]      = self_exe_path;
@@ -65,6 +65,7 @@ main( int     argc,
 
   /* initialize logging */
   fd_boot( &argc, &argv );
+  fd_log_thread_set( "main" );
 
   argc--; argv++;
 

--- a/src/app/frank/fd_frank.h
+++ b/src/app/frank/fd_frank.h
@@ -37,14 +37,14 @@ typedef struct {
 } fd_frank_args_t;
 
 typedef struct {
-   char * name;
-   char * in_wksp;
-   char * out_wksp;
-   uint   close_fd_start;
-   ushort allow_syscalls_sz;
-   long * allow_syscalls;
-   void (*init)( fd_frank_args_t * args );
-   void (*run )( fd_frank_args_t * args );
+   char *  name;
+   char *  in_wksp;
+   char *  out_wksp;
+   ushort  allow_syscalls_sz;
+   long *  allow_syscalls;
+   ulong (*allow_fds)( fd_frank_args_t * args, ulong out_fds_sz, int * out_fds );
+   void  (*init)( fd_frank_args_t * args );
+   void  (*run )( fd_frank_args_t * args );
 } fd_frank_task_t;
 
 extern fd_frank_task_t frank_verify;

--- a/src/app/frank/fd_frank_dedup.c
+++ b/src/app/frank/fd_frank_dedup.c
@@ -84,13 +84,24 @@ static long allow_syscalls[] = {
   __NR_fsync,     /* logging, WARNING and above fsync immediately */
 };
 
+static ulong
+allow_fds( fd_frank_args_t * args,
+           ulong out_fds_sz,
+           int * out_fds ) {
+  (void)args;
+  if( FD_UNLIKELY( out_fds_sz < 2 ) ) FD_LOG_ERR(( "out_fds_sz %lu", out_fds_sz ));
+  out_fds[ 0 ] = 2; /* stderr */
+  out_fds[ 1 ] = 3; /* logfile */
+  return 2;
+}
+
 fd_frank_task_t frank_dedup = {
-  .name     = "dedup",
-  .in_wksp  = "verify_dedup",
-  .out_wksp = "dedup_pack",
-  .close_fd_start = 4, /* stdin, stdout, stderr, logfile */
+  .name              = "dedup",
+  .in_wksp           = "verify_dedup",
+  .out_wksp          = "dedup_pack",
   .allow_syscalls_sz = sizeof(allow_syscalls)/sizeof(allow_syscalls[ 0 ]),
-  .allow_syscalls = allow_syscalls,
-  .init = NULL,
-  .run  = run,
+  .allow_syscalls    = allow_syscalls,
+  .allow_fds         = allow_fds,
+  .init              = NULL,
+  .run               = run,
 };

--- a/src/app/frank/fd_frank_pack.c
+++ b/src/app/frank/fd_frank_pack.c
@@ -345,13 +345,24 @@ static long allow_syscalls[] = {
   __NR_fsync,     /* logging, WARNING and above fsync immediately */
 };
 
+static ulong
+allow_fds( fd_frank_args_t * args,
+           ulong out_fds_sz,
+           int * out_fds ) {
+  (void)args;
+  if( FD_UNLIKELY( out_fds_sz < 2 ) ) FD_LOG_ERR(( "out_fds_sz %lu", out_fds_sz ));
+  out_fds[ 0 ] = 2; /* stderr */
+  out_fds[ 1 ] = 3; /* logfile */
+  return 2;
+}
+
 fd_frank_task_t frank_pack = {
-  .name     = "pack",
-  .in_wksp  = "dedup_pack",
-  .out_wksp = "pack_bank",
-  .close_fd_start = 4, /* stdin, stdout, stderr, logfile */
+  .name              = "pack",
+  .in_wksp           = "dedup_pack",
+  .out_wksp          = "pack_bank",
   .allow_syscalls_sz = sizeof(allow_syscalls)/sizeof(allow_syscalls[ 0 ]),
-  .allow_syscalls = allow_syscalls,
-  .init = NULL,
-  .run  = run,
+  .allow_syscalls    = allow_syscalls,
+  .allow_fds         = allow_fds,
+  .init              = NULL,
+  .run               = run,
 };

--- a/src/app/frank/fd_frank_verify.c
+++ b/src/app/frank/fd_frank_verify.c
@@ -407,13 +407,24 @@ static long allow_syscalls[] = {
   __NR_fsync,     /* logging, WARNING and above fsync immediately */
 };
 
+static ulong
+allow_fds( fd_frank_args_t * args,
+           ulong out_fds_sz,
+           int * out_fds ) {
+  (void)args;
+  if( FD_UNLIKELY( out_fds_sz < 2 ) ) FD_LOG_ERR(( "out_fds_sz %lu", out_fds_sz ));
+  out_fds[ 0 ] = 2; /* stderr */
+  out_fds[ 1 ] = 3; /* logfile */
+  return 2;
+}
+
 fd_frank_task_t frank_verify = {
-  .name     = "verify",
-  .in_wksp  = "quic_verify",
-  .out_wksp = "verify_dedup",
-  .close_fd_start = 4, /* stdin, stdout, stderr, logfile */
+  .name              = "verify",
+  .in_wksp           = "quic_verify",
+  .out_wksp          = "verify_dedup",
   .allow_syscalls_sz = sizeof(allow_syscalls)/sizeof(allow_syscalls[ 0 ]),
-  .allow_syscalls = allow_syscalls,
-  .init = NULL,
-  .run  = run,
+  .allow_syscalls    = allow_syscalls,
+  .allow_fds         = allow_fds,
+  .init              = NULL,
+  .run               = run,
 };

--- a/src/util/sandbox/fd_sandbox.h
+++ b/src/util/sandbox/fd_sandbox.h
@@ -64,41 +64,14 @@
       We have the luxury of disallowing all of the syscalls that might
       have received less scrutiny. */
 
-/* Sandbox the current process by dropping all privileges and entering various
-   restricted namespaces, but leave it able to make system calls. This should be
-   done as a first step before later calling`fd_sandbox_private_threaded`.
-
-   This call is meant to be paired with the nthreaded` version. You should
-   call `unthreaded` before creating any threads in the process, and `threaded`
-   afterwards. */
-void
-fd_sandbox_private_unthreaded( uint uid, uint gid );
-
-/* fd_sandbox_private_threaded sandboxes the current process. After calling, the
-   process has maximally restricted privileges we can enable given the host
-   environment. On Linux, seccomp is used to prevent any syscalls except select
-   whitelisted ones.
-
-   This call is meant to be paired with the `unthreaded` version. You should
-   call `unthreaded` before creating any threads in the process, and `threaded`
-   afterwards. */
-void
-fd_sandbox_private_threaded( uint close_fd_start,
-                             ushort allow_syscalls_sz,
-                             long * allow_syscalls );
-
 /* fd_sandbox sandboxes the current process, performing both privileged and
    private steps. */
 void
-fd_sandbox( uint uid,
-            uint gid,
-            uint close_fd_start,
+fd_sandbox( uint   uid,
+            uint   gid,
+            ulong  allow_fds_sz,
+            int *  allow_fds,
             ushort allow_syscalls_sz,
             long * allow_syscalls );
-
-/* Only used by test code. Install private sandbox without seccomp, used so
-   we can test with some syscalls without bringing down the process. */
-void
-fd_sandbox_private_no_seccomp( uint close_fds_from );
 
 #endif /* HEADER_fd_src_util_sandbox_fd_sandbox_h */


### PR DESCRIPTION
It makes more sense for tiles to specify what file descriptors they expect to be open, not to just randomly close stuff and hope its secure.