### PR TITLE
fdctl: remove nanosleep syscall

### DIFF
--- a/src/app/fdctl/fdctl.h
+++ b/src/app/fdctl/fdctl.h
@@ -20,6 +20,7 @@ typedef union {
     long dt_max;
     long duration;
     uint seed;
+    double ns_per_tic;
   } monitor;
   struct {
     int                      command;

--- a/src/app/fdctl/run.h
+++ b/src/app/fdctl/run.h
@@ -12,6 +12,7 @@ typedef struct {
   uid_t uid;
   gid_t gid;
   char * app_name;
+  double tick_per_ns;
 } tile_main_args_t;
 
 const uchar *

--- a/src/app/frank/fd_frank.h
+++ b/src/app/frank/fd_frank.h
@@ -33,6 +33,7 @@ typedef struct {
    uchar const * in_pod;
    uchar const * out_pod;
    fd_xsk_t    * xsk;
+   double        tick_per_ns;
 } fd_frank_args_t;
 
 typedef struct {

--- a/src/app/frank/fd_frank_dedup.c
+++ b/src/app/frank/fd_frank_dedup.c
@@ -75,7 +75,7 @@ run( fd_frank_args_t * args ) {
   /* Start deduping */
 
   FD_LOG_INFO(( "dedup run" ));
-  int err = fd_dedup_tile( cnc, in_cnt, in_mcache, in_fseq, tcache, mcache, 1UL, &out_fseq, cr_max, lazy, rng, scratch );
+  int err = fd_dedup_tile( cnc, in_cnt, in_mcache, in_fseq, tcache, mcache, 1UL, &out_fseq, cr_max, lazy, rng, scratch, args->tick_per_ns );
   if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "fd_dedup_tile failed (%i)", err ));
 }
 
@@ -83,7 +83,6 @@ static long allow_syscalls[] = {
   __NR_write,     /* logging */
   __NR_futex,     /* logging, glibc fprintf unfortunately uses a futex internally */
   __NR_fsync,     /* logging, WARNING and above fsync immediately */
-  __NR_nanosleep, /* fd_tempo_tick_per_ns calibration */
 };
 
 fd_frank_task_t frank_dedup = {

--- a/src/app/frank/fd_frank_pack.c
+++ b/src/app/frank/fd_frank_pack.c
@@ -103,7 +103,7 @@ run( fd_frank_args_t * args ) {
   FD_LOG_INFO(( "configuring flow control (lazy %li)", lazy ));
   if( lazy<=0L ) lazy = fd_tempo_lazy_default( depth );
   FD_LOG_INFO(( "using lazy %li ns", lazy ));
-  ulong async_min = fd_tempo_async_min( lazy, 1UL /*event_cnt*/, (float)fd_tempo_tick_per_ns( NULL ) );
+  ulong async_min = fd_tempo_async_min( lazy, 1UL /*event_cnt*/, (float)args->tick_per_ns );
   if( FD_UNLIKELY( !async_min ) ) FD_LOG_ERR(( "bad lazy" ));
 
   uint seed = fd_pod_query_uint( args->tile_pod, "seed", (uint)fd_tile_id() ); /* use app tile_id as default */
@@ -129,7 +129,7 @@ run( fd_frank_args_t * args ) {
   // const ulong lamports_per_signature = 5000UL;
   const ulong block_duration_ns      = 400UL*1000UL*1000UL; /* 400ms */
 
-  long block_duration_ticks = (long)(fd_tempo_tick_per_ns( NULL ) * (double)block_duration_ns);
+  long block_duration_ticks = (long)(args->tick_per_ns * (double)block_duration_ns);
 
   int ctl_som = 1;
   int ctl_eom = 1;
@@ -282,7 +282,6 @@ static long allow_syscalls[] = {
   __NR_write,     /* logging */
   __NR_futex,     /* logging, glibc fprintf unfortunately uses a futex internally */
   __NR_fsync,     /* logging, WARNING and above fsync immediately */
-  __NR_nanosleep, /* fd_tempo_tick_per_ns calibration */
 };
 
 fd_frank_task_t frank_pack = {

--- a/src/app/frank/fd_frank_quic.c
+++ b/src/app/frank/fd_frank_quic.c
@@ -122,7 +122,7 @@ run( fd_frank_args_t * args ) {
   /* Start serving */
 
   FD_LOG_INFO(( "%s(%lu) run", args->tile_name, args->tile_idx ));
-  int err = fd_quic_tile( cnc, quic, xsk_aio, mcache, dcache, lazy, rng, scratch );
+  int err = fd_quic_tile( cnc, quic, xsk_aio, mcache, dcache, lazy, rng, scratch, args->tick_per_ns );
   if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "fd_quic_tile failed (%i)", err ));
 }
 
@@ -130,7 +130,6 @@ static long allow_syscalls[] = {
   __NR_write,     /* logging */
   __NR_futex,     /* logging, glibc fprintf unfortunately uses a futex internally */
   __NR_fsync,     /* logging, WARNING and above fsync immediately */
-  __NR_nanosleep, /* fd_tempo_tick_per_ns calibration */
   __NR_getpid,    /* OpenSSL RAND_bytes checks pid, temporarily used as part of quic_init to generate a certificate */
   __NR_getrandom, /* OpenSSL RAND_bytes reads getrandom, temporarily used as part of quic_init to generate a certificate */
   __NR_sendto,    /* fd_xsk requires sendto */

--- a/src/app/frank/fd_frank_verify.c
+++ b/src/app/frank/fd_frank_verify.c
@@ -78,7 +78,7 @@ run( fd_frank_args_t * args ) {
 
   if( lazy<=0L ) lazy = fd_tempo_lazy_default( depth );
   FD_LOG_INFO(( "using lazy %li ns", lazy ));
-  ulong async_min = fd_tempo_async_min( lazy, 1UL /*event_cnt*/, (float)fd_tempo_tick_per_ns( NULL ) );
+  ulong async_min = fd_tempo_async_min( lazy, 1UL /*event_cnt*/, (float)args->tick_per_ns );
   if( FD_UNLIKELY( !async_min ) ) FD_LOG_ERR(( "bad lazy" ));
 
   uint seed = fd_pod_query_uint( args->tile_pod, "seed", (uint)fd_tile_id() ); /* use app tile_id as default */
@@ -186,7 +186,6 @@ static long allow_syscalls[] = {
   __NR_write,     /* logging */
   __NR_futex,     /* logging, glibc fprintf unfortunately uses a futex internally */
   __NR_fsync,     /* logging, WARNING and above fsync immediately */
-  __NR_nanosleep, /* fd_tempo_tick_per_ns calibration */
 };
 
 fd_frank_task_t frank_verify = {

--- a/src/disco/dedup/fd_dedup.c
+++ b/src/disco/dedup/fd_dedup.c
@@ -102,7 +102,8 @@ fd_dedup_tile( fd_cnc_t *              cnc,
                ulong                   cr_max,
                long                    lazy,
                fd_rng_t *              rng,
-               void *                  scratch ) {
+               void *                  scratch,
+               double                  tick_per_ns ) {
 
   /* cnc state */
   ulong * cnc_diag;           /* ==fd_cnc_app_laddr( cnc ), local address of the dedup tile cnc diagnostic region */
@@ -319,7 +320,7 @@ fd_dedup_tile( fd_cnc_t *              cnc,
     for( ulong out_idx=0UL; out_idx<out_cnt; out_idx++ ) event_map[ event_seq++ ] = (ushort)out_idx;
     event_seq = 0UL;
 
-    async_min = fd_tempo_async_min( lazy, event_cnt, (float)fd_tempo_tick_per_ns( NULL ) );
+    async_min = fd_tempo_async_min( lazy, event_cnt, (float)tick_per_ns );
     if( FD_UNLIKELY( !async_min ) ) { FD_LOG_WARNING(( "bad lazy" )); return 1; }
 
   } while(0);

--- a/src/disco/dedup/fd_dedup.h
+++ b/src/disco/dedup/fd_dedup.h
@@ -244,18 +244,19 @@ fd_dedup_tile_scratch_footprint( ulong in_cnt,
                                  ulong out_cnt );
 
 int
-fd_dedup_tile( fd_cnc_t *              cnc,       /* Local join to the dedup's command-and-control */
-               ulong                   in_cnt,    /* Number of input mcaches to dedup, inputs are indexed [0,in_cnt) */
-               fd_frag_meta_t const ** in_mcache, /* in_mcache[in_idx] is the local join to input in_idx's mcache */
-               ulong **                in_fseq,   /* in_fseq  [in_idx] is the local join to input in_idx's fseq */
-               fd_tcache_t *           tcache,    /* Local join to the dedup's unique signature cache */
-               fd_frag_meta_t *        mcache,    /* Local join to the dedup's frag stream output mcache */
-               ulong                   out_cnt,   /* Number of reliable consumers, reliable consumers are indexed [0,out_cnt) */
-               ulong **                out_fseq,  /* out_fseq[out_idx] is the local join to reliable consumer out_idx's fseq */
-               ulong                   cr_max,    /* Maximum number of flow control credits, 0 means use a reasonable default */
-               long                    lazy,      /* Lazyiness, <=0 means use a reasonable default */
-               fd_rng_t *              rng,       /* Local join to the rng this dedup should use */
-               void *                  scratch ); /* Tile scratch memory */
+fd_dedup_tile( fd_cnc_t *              cnc,           /* Local join to the dedup's command-and-control */
+               ulong                   in_cnt,        /* Number of input mcaches to dedup, inputs are indexed [0,in_cnt) */
+               fd_frag_meta_t const ** in_mcache,     /* in_mcache[in_idx] is the local join to input in_idx's mcache */
+               ulong **                in_fseq,       /* in_fseq  [in_idx] is the local join to input in_idx's fseq */
+               fd_tcache_t *           tcache,        /* Local join to the dedup's unique signature cache */
+               fd_frag_meta_t *        mcache,        /* Local join to the dedup's frag stream output mcache */
+               ulong                   out_cnt,       /* Number of reliable consumers, reliable consumers are indexed [0,out_cnt) */
+               ulong **                out_fseq,      /* out_fseq[out_idx] is the local join to reliable consumer out_idx's fseq */
+               ulong                   cr_max,        /* Maximum number of flow control credits, 0 means use a reasonable default */
+               long                    lazy,          /* Lazyiness, <=0 means use a reasonable default */
+               fd_rng_t *              rng,           /* Local join to the rng this dedup should use */
+               void *                  scratch,       /* Tile scratch memory */
+               double                  tick_per_ns ); /* Result of fd_tempo_tick_per_ns( NULL ) */
 
 FD_PROTOTYPES_END
 

--- a/src/disco/dedup/fd_dedup_tile.c
+++ b/src/disco/dedup/fd_dedup_tile.c
@@ -87,7 +87,7 @@ main( int     argc,
 
   FD_LOG_NOTICE(( "Run" ));
 
-  int err = fd_dedup_tile( cnc, in_cnt, in_mcache, in_fseq, tcache, mcache, out_cnt, out_fseq, cr_max, lazy, rng, scratch );
+  int err = fd_dedup_tile( cnc, in_cnt, in_mcache, in_fseq, tcache, mcache, out_cnt, out_fseq, cr_max, lazy, rng, scratch, fd_tempo_tick_per_ns( NULL ) );
   if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "fd_dedup_tile failed (%i)", err ));
 
   FD_LOG_NOTICE(( "Fini" ));

--- a/src/disco/dedup/test_dedup.c
+++ b/src/disco/dedup/test_dedup.c
@@ -290,7 +290,7 @@ dedup_tile_main( int     argc,
   fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, cfg->dedup_seed, 0UL ) );
 
   int err = fd_dedup_tile( cnc, cfg->tx_cnt, tx_mcache, tx_fseq, dedup_tcache, dedup_mcache, cfg->rx_cnt, rx_fseq,
-                           cfg->dedup_cr_max, cfg->dedup_lazy, rng, cfg->dedup_scratch_mem );
+                           cfg->dedup_cr_max, cfg->dedup_lazy, rng, cfg->dedup_scratch_mem, fd_tempo_tick_per_ns( NULL ) );
   if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "fd_dedup_tile failed (%i)", err ));
 
   fd_rng_delete( fd_rng_leave( rng ) );

--- a/src/disco/quic/fd_quic.h
+++ b/src/disco/quic/fd_quic.h
@@ -118,14 +118,15 @@ FD_FN_CONST ulong
 fd_quic_tile_scratch_footprint( ulong depth );
 
 int
-fd_quic_tile( fd_cnc_t *         cnc,        /* Local join to the tile's command-and-control */
-              fd_quic_t *        quic,       /* QUIC without active join */
-              fd_xsk_aio_t *     xsk_aio,    /* Local join to QUIC XSK aio */
-              fd_frag_meta_t *   mcache,     /* Local join to the tile's txn output mcache */
-              uchar *            dcache,     /* Local join to the tile's txn output dcache */
-              long               lazy,       /* Laziness, <=0 means use a reasonable default */
-              fd_rng_t *         rng,        /* Local join to the rng this tile should use */
-              void *             scratch );  /* Tile scratch memory */
+fd_quic_tile( fd_cnc_t *         cnc,           /* Local join to the tile's command-and-control */
+              fd_quic_t *        quic,          /* QUIC without active join */
+              fd_xsk_aio_t *     xsk_aio,       /* Local join to QUIC XSK aio */
+              fd_frag_meta_t *   mcache,        /* Local join to the tile's txn output mcache */
+              uchar *            dcache,        /* Local join to the tile's txn output dcache */
+              long               lazy,          /* Laziness, <=0 means use a reasonable default */
+              fd_rng_t *         rng,           /* Local join to the rng this tile should use */
+              void *             scratch,       /* Tile scratch memory */
+              double             tick_per_ns ); /* Result of fd_tempo_tick_per_ns( NULL ) */
 
 FD_PROTOTYPES_END
 

--- a/src/disco/quic/fd_quic_tile.c
+++ b/src/disco/quic/fd_quic_tile.c
@@ -263,7 +263,8 @@ fd_quic_tile( fd_cnc_t *         cnc,
               uchar *            dcache,
               long               lazy,
               fd_rng_t *         rng,
-              void *             scratch ) {
+              void *             scratch,
+              double             tick_per_ns ) {
 
   /* cnc state */
   ulong * cnc_diag;
@@ -404,7 +405,7 @@ fd_quic_tile( fd_cnc_t *         cnc,
     if( lazy<=0L ) lazy = fd_tempo_lazy_default( depth );
     FD_LOG_INFO(( "Configuring housekeeping (lazy %li ns)", lazy ));
 
-    async_min = fd_tempo_async_min( lazy, 1UL /*event_cnt*/, (float)fd_tempo_tick_per_ns( NULL ) );
+    async_min = fd_tempo_async_min( lazy, 1UL /*event_cnt*/, (float)tick_per_ns );
     if( FD_UNLIKELY( !async_min ) ) { FD_LOG_WARNING(( "bad lazy" )); return 1; }
 
   } while(0);

--- a/src/disco/quic/test_quic_tile.c
+++ b/src/disco/quic/test_quic_tile.c
@@ -192,7 +192,8 @@ tx_tile_main( int     argc,
       cfg->tx_dcache,
       cfg->tx_lazy,
       rng,
-      scratch ) );
+      scratch,
+      fd_tempo_tick_per_ns( NULL ) ) );
 
   fd_rng_delete( fd_rng_leave( rng ) );
   return 0;


### PR DESCRIPTION
Nanosleep was only needed on these tiles due to fd_tempo calibration, which can happen once on boot before we enter the sandbox anyway.