### PR TITLE
Housekeeping cleanups

### DIFF
--- a/src/util/Local.mk
+++ b/src/util/Local.mk
@@ -1,7 +1,15 @@
 $(call make-lib,fd_util)
 $(call add-hdrs,fd_util_base.h fd_util.h)
 $(call add-objs,fd_hash fd_util,fd_util)
-$(call make-unit-test,test_util_base,test_util_base,fd_util)
 $(call make-unit-test,test_util,test_util,fd_util)
-$(call run-unit-test,test_util_base,)
 $(call run-unit-test,test_util,)
+
+ifndef FD_HAS_UBSAN
+# The point of test_util_base is to diagnose compatibility of the build
+# target with the FD machine model.  It does this in part by extensively
+# probing the linguistic UB/IB behaviors of the target.  As such, we
+# expect this test to fail by design if running under ubsan and thus
+# don't bother building it if FD_HAS_UBSAN is defined.
+$(call make-unit-test,test_util_base,test_util_base,fd_util)
+$(call run-unit-test,test_util_base,)
+endif

--- a/src/util/bits/fd_bits.h
+++ b/src/util/bits/fd_bits.h
@@ -58,8 +58,10 @@ FD_PROTOTYPES_BEGIN
    fd_ulong_find_msb          ( x    ) returns the index of the most significant bit set in x, in [0,64).  U.B. if x is zero.
    fd_ulong_find_msb_w_default( x, d ) returns the index of the most significant bit set in x, in [0,64).  d if x is zero.
    fd_ulong_bswap             ( x    ) returns x with its bytes swapped
-   fd_ulong_pow2_up           ( x    ) returns y mod 2^64 where y is the smallest integer power of 2 >= x.
-                                       x returns 0 (U.B. behavior or 1 might arguable alternatives here)
+   fd_ulong_pow2_up           ( x    ) returns y mod 2^64 where y is the smallest integer power of 2 >= x.  U.B. if x is zero.
+                                       (current implementation returns 0 if x==0).
+   fd_ulong_pow2_dn           ( x    ) returns the largest integer power of 2 <= x.  U.B. if x is zero.
+                                       (current implementation returns 1 if x==0).
 
    Similarly for uchar,ushort,uint,uint128.  Note that the signed
    versions of shift_left, rotate_left, rotate_right operate on the bit
@@ -244,12 +246,25 @@ fd_uint128_bswap( uint128 x ) {
 }
 #endif
 
-/* FIXME: CONSIDER FIND_MSB BASED SOLUTION? */
+/* FIXME: consider find_msb based solution (probably not as the combination
+   of FD_FN_CONST and the use of inline asm for find_msb on some targets
+   is probably less than ideal). */
 
 FD_FN_CONST static inline uchar
 fd_uchar_pow2_up( uchar _x ) {
   uint x = (uint)_x;
   x--;
+  x |= (x>> 1);
+  x |= (x>> 2);
+  x |= (x>> 4);
+  x++;
+  return (uchar)x;
+}
+
+FD_FN_CONST static inline uchar
+fd_uchar_pow2_dn( uchar _x ) {
+  uint x = (uint)_x;
+  x >>= 1;
   x |= (x>> 1);
   x |= (x>> 2);
   x |= (x>> 4);
@@ -269,9 +284,33 @@ fd_ushort_pow2_up( ushort _x ) {
   return (ushort)x;
 }
 
+FD_FN_CONST static inline ushort
+fd_ushort_pow2_dn( ushort _x ) {
+  uint x = (uint)_x;
+  x >>= 1;
+  x |= (x>> 1);
+  x |= (x>> 2);
+  x |= (x>> 4);
+  x |= (x>> 8);
+  x++;
+  return (ushort)x;
+}
+
 FD_FN_CONST static inline uint
 fd_uint_pow2_up( uint x ) {
   x--;
+  x |= (x>> 1);
+  x |= (x>> 2);
+  x |= (x>> 4);
+  x |= (x>> 8);
+  x |= (x>>16);
+  x++;
+  return x;
+}
+
+FD_FN_CONST static inline uint
+fd_uint_pow2_dn( uint x ) {
+  x >>= 1;
   x |= (x>> 1);
   x |= (x>> 2);
   x |= (x>> 4);
@@ -294,10 +333,37 @@ fd_ulong_pow2_up( ulong x ) {
   return x;
 }
 
+FD_FN_CONST static inline ulong
+fd_ulong_pow2_dn( ulong x ) {
+  x >>= 1;
+  x |= (x>> 1);
+  x |= (x>> 2);
+  x |= (x>> 4);
+  x |= (x>> 8);
+  x |= (x>>16);
+  x |= (x>>32);
+  x++;
+  return x;
+}
+
 #if FD_HAS_INT128
 FD_FN_CONST static inline uint128
 fd_uint128_pow2_up( uint128 x ) {
   x--;
+  x |= (x>> 1);
+  x |= (x>> 2);
+  x |= (x>> 4);
+  x |= (x>> 8);
+  x |= (x>>16);
+  x |= (x>>32);
+  x |= (x>>64);
+  x++;
+  return x;
+}
+
+FD_FN_CONST static inline uint128
+fd_uint128_pow2_dn( uint128 x ) {
+  x >>= 1;
   x |= (x>> 1);
   x |= (x>> 2);
   x |= (x>> 4);

--- a/src/util/bits/fd_bits.h
+++ b/src/util/bits/fd_bits.h
@@ -426,10 +426,12 @@ FD_SRC_UTIL_BITS_FD_BITS_IMPL(int128,uint128,128)
    can't provide a char_min/char_max between platforms as they don't
    necessarily produce the same results.  Likewise, we don't provide a
    fd_char_abs because it will not produce equivalent results between
-   platforms.  But it is useful to have a char_if to help with making
-   branchless string operation implementations. */
+   platforms.  But it is useful to have a char_if and char_store_if to
+   help with making branchless string operation implementations. */
 
 FD_FN_CONST static inline char fd_char_if( int c, char t, char f ) { return c ? t : f; }
+
+static inline void fd_char_store_if( int c, char * p, char v ) { char _[ 1 ]; *( c ? p : _ ) = v; /* cmov */ }
 
 /* FIXME: ADD HASHING PAIRS FOR UCHAR AND USHORT? */
 
@@ -549,6 +551,31 @@ fd_double_eq( double x,
   return tx.u==ty.u;
 }
 #endif
+
+/* fd_swap swaps the values in a and b.  Assumes a and b have the same
+   plain-old-data type.  Best if a and b are primitive types (e.g.
+   ulong).  This macro is robust (it evaluates a and b the minimal
+   number of times).  Note that compilers are pretty good about identify
+   swap operations and replacing them with more optimal assembly for
+   types and architectures where alternative implementations (like xor
+   tricks) might be faster. */
+
+#define fd_swap(a,b) do { __typeof__((a)) _fd_swap_tmp = (a); (a) = (b); (b) = _fd_swap_tmp; } while(0)
+
+/* fd_swap_if swaps the values in a and b if c is non-zero and leaves
+   them unchanged otherwise.  Assumes a and b have the same
+   plain-old-data type.  Best if a and b are primitive types (e.g.
+   ulong) as the compiler will likely replace the trinaries below with
+   cmovs, making this branchless.  This macro is robust (it evalutes a,
+   b and c the minimal number of times). */
+
+#define fd_swap_if(c,a,b) do {                                      \
+    int             _fd_swap_if_c = (c);                            \
+    __typeof__((a)) _fd_swap_if_a = (a);                            \
+    __typeof__((b)) _fd_swap_if_b = (b);                            \
+    (a) = _fd_swap_if_c ? _fd_swap_if_b : _fd_swap_if_a; /* cmov */ \
+    (b) = _fd_swap_if_c ? _fd_swap_if_a : _fd_swap_if_b; /* cmov */ \
+  } while(0)
 
 /* fd_ptr_if is a generic version of the above for pointers.  This macro
    is robust.

--- a/src/util/bits/test_bits.c
+++ b/src/util/bits/test_bits.c
@@ -95,7 +95,8 @@ main( int     argc,
     FD_TEST( fd_uchar_find_msb          ( ones      )==(w-1));
     FD_TEST( fd_uchar_find_msb_w_default( ones , -1 )==(w-1));
     FD_TEST( fd_uchar_find_msb_w_default( zeros, -1 )==-1   );
-    FD_TEST( fd_uchar_pow2_up ( zeros )==(uchar)0 ); FD_TEST( fd_uchar_pow2_up ( ones  )==(uchar)0 );
+    FD_TEST( fd_uchar_pow2_up ( zeros )==(uchar)0 ); FD_TEST( fd_uchar_pow2_up ( ones  )==(uchar)0          );
+    FD_TEST( fd_uchar_pow2_dn ( zeros )==(uchar)1 ); FD_TEST( fd_uchar_pow2_dn ( ones  )==(uchar)(1<<(w-1)) );
     for( int i=1; i<w; i++ ) {
       uchar x = (uchar)(1UL<<i);
       FD_TEST( fd_uchar_pop_lsb ( x )==zeros );
@@ -104,6 +105,7 @@ main( int     argc,
       FD_TEST( fd_uchar_find_lsb_w_default( x , -1 )==i );
       FD_TEST( fd_uchar_find_msb_w_default( x , -1 )==i );
       FD_TEST( fd_uchar_pow2_up ( x )==x     );
+      FD_TEST( fd_uchar_pow2_dn ( x )==x     );
       for( int j=0; j<i; j++ ) {
         uchar y = (uchar)(1UL<<j);
         uchar z = (uchar)(x|y);
@@ -113,6 +115,7 @@ main( int     argc,
         FD_TEST( fd_uchar_find_lsb_w_default( z , -1 )==j );
         FD_TEST( fd_uchar_find_msb_w_default( z , -1 )==i );
         FD_TEST( fd_uchar_pow2_up ( z )==(uchar)(x<<1) );
+        FD_TEST( fd_uchar_pow2_dn ( z )==(uchar) x     );
       }
     }
     for( int n=0; n<=w; n++ ) {
@@ -233,7 +236,8 @@ main( int     argc,
     FD_TEST( fd_ushort_find_msb          ( ones      )==(w-1));
     FD_TEST( fd_ushort_find_msb_w_default( ones , -1 )==(w-1));
     FD_TEST( fd_ushort_find_msb_w_default( zeros, -1 )==-1   );
-    FD_TEST( fd_ushort_pow2_up ( zeros )==(ushort)0 ); FD_TEST( fd_ushort_pow2_up ( ones )==(ushort)0 );
+    FD_TEST( fd_ushort_pow2_up ( zeros )==(ushort)0 ); FD_TEST( fd_ushort_pow2_up ( ones )==(ushort)0          );
+    FD_TEST( fd_ushort_pow2_dn ( zeros )==(ushort)1 ); FD_TEST( fd_ushort_pow2_dn ( ones )==(ushort)(1<<(w-1)) );
     for( int i=1; i<w; i++ ) {
       ushort x = (ushort)(1UL<<i);
       FD_TEST( fd_ushort_pop_lsb ( x )==zeros );
@@ -242,6 +246,7 @@ main( int     argc,
       FD_TEST( fd_ushort_find_lsb_w_default( x , -1 )==i );
       FD_TEST( fd_ushort_find_msb_w_default( x , -1 )==i );
       FD_TEST( fd_ushort_pow2_up ( x )==x     );
+      FD_TEST( fd_ushort_pow2_dn ( x )==x     );
       for( int j=0; j<i; j++ ) {
         ushort y = (ushort)(1UL<<j);
         ushort z = (ushort)(x|y);
@@ -251,6 +256,7 @@ main( int     argc,
         FD_TEST( fd_ushort_find_lsb_w_default( z , -1 )==j );
         FD_TEST( fd_ushort_find_msb_w_default( z , -1 )==i );
         FD_TEST( fd_ushort_pow2_up ( z )==(ushort)(x<<1) );
+        FD_TEST( fd_ushort_pow2_dn ( z )==(ushort) x     );
       }
     }
     for( int n=0; n<=w; n++ ) { 
@@ -369,7 +375,8 @@ main( int     argc,
     FD_TEST( fd_uint_find_msb          ( ones      )==(w-1));
     FD_TEST( fd_uint_find_msb_w_default( ones , -1 )==(w-1));
     FD_TEST( fd_uint_find_msb_w_default( zeros, -1 )==-1   );
-    FD_TEST( fd_uint_pow2_up ( zeros )==(uint)0 ); FD_TEST( fd_uint_pow2_up ( ones  )==(uint)0 );
+    FD_TEST( fd_uint_pow2_up ( zeros )==0U ); FD_TEST( fd_uint_pow2_up ( ones  )==0U          );
+    FD_TEST( fd_uint_pow2_dn ( zeros )==1U ); FD_TEST( fd_uint_pow2_dn ( ones  )==(1U<<(w-1)) );
     for( int i=1; i<w; i++ ) {
       uint x = (uint)(1UL<<i);
       FD_TEST( fd_uint_pop_lsb ( x )==zeros );
@@ -378,6 +385,7 @@ main( int     argc,
       FD_TEST( fd_uint_find_lsb_w_default( x , -1 )==i );
       FD_TEST( fd_uint_find_msb_w_default( x , -1 )==i );
       FD_TEST( fd_uint_pow2_up ( x )==x     );
+      FD_TEST( fd_uint_pow2_dn ( x )==x     );
       for( int j=0; j<i; j++ ) {
         uint y = (uint)(1UL<<j);
         uint z = (uint)(x|y);
@@ -387,6 +395,7 @@ main( int     argc,
         FD_TEST( fd_uint_find_lsb_w_default( z , -1 )==j );
         FD_TEST( fd_uint_find_msb_w_default( z , -1 )==i );
         FD_TEST( fd_uint_pow2_up ( z )==(x<<1) );
+        FD_TEST( fd_uint_pow2_dn ( z )== x     );
       }
     }
     for( int n=0; n<=w; n++ ) {  
@@ -507,7 +516,8 @@ main( int     argc,
     FD_TEST( fd_ulong_find_msb          ( ones      )==(w-1));
     FD_TEST( fd_ulong_find_msb_w_default( ones , -1 )==(w-1));
     FD_TEST( fd_ulong_find_msb_w_default( zeros, -1 )==-1   );
-    FD_TEST( fd_ulong_pow2_up ( zeros )==(ulong)0 ); FD_TEST( fd_ulong_pow2_up ( ones  )==(ulong)0 );
+    FD_TEST( fd_ulong_pow2_up ( zeros )==0UL ); FD_TEST( fd_ulong_pow2_up ( ones  )==0UL          );
+    FD_TEST( fd_ulong_pow2_dn ( zeros )==1UL ); FD_TEST( fd_ulong_pow2_dn ( ones  )==(1UL<<(w-1)) );
     for( int i=1; i<w; i++ ) {
       ulong x = (ulong)(1UL<<i);
       FD_TEST( fd_ulong_pop_lsb ( x )==zeros );
@@ -516,6 +526,7 @@ main( int     argc,
       FD_TEST( fd_ulong_find_lsb_w_default( x , -1 )==i );
       FD_TEST( fd_ulong_find_msb_w_default( x , -1 )==i );
       FD_TEST( fd_ulong_pow2_up ( x )==x     );
+      FD_TEST( fd_ulong_pow2_dn ( x )==x     );
       for( int j=0; j<i; j++ ) {
         ulong y = (ulong)(1UL<<j);
         ulong z = (ulong)(x|y);
@@ -525,6 +536,7 @@ main( int     argc,
         FD_TEST( fd_ulong_find_lsb_w_default( z , -1 )==j );
         FD_TEST( fd_ulong_find_msb_w_default( z , -1 )==i );
         FD_TEST( fd_ulong_pow2_up ( z )==(x<<1) );
+        FD_TEST( fd_ulong_pow2_dn ( z )== x     );
       }
     }
     for( int n=0; n<=w; n++ ) { int sl = n+(w-8)-((n>>3)<<4); 
@@ -674,7 +686,8 @@ main( int     argc,
     FD_TEST( fd_uint128_find_msb          ( ones      )==(w-1));
     FD_TEST( fd_uint128_find_msb_w_default( ones , -1 )==(w-1));
     FD_TEST( fd_uint128_find_msb_w_default( zeros, -1 )==-1   );
-    FD_TEST( fd_uint128_pow2_up ( zeros )==(uint128)0 ); FD_TEST( fd_uint128_pow2_up ( ones  )==(uint128)0 );
+    FD_TEST( fd_uint128_pow2_up ( zeros )==(uint128)0 ); FD_TEST( fd_uint128_pow2_up ( ones  )==(uint128)0            );
+    FD_TEST( fd_uint128_pow2_dn ( zeros )==(uint128)1 ); FD_TEST( fd_uint128_pow2_dn ( ones  )==(((uint128)1)<<(w-1)) );
     for( int i=1; i<w; i++ ) {
       uint128 x = ((uint128)1)<<i;
       FD_TEST( fd_uint128_pop_lsb ( x )==zeros );
@@ -683,6 +696,7 @@ main( int     argc,
       FD_TEST( fd_uint128_find_lsb_w_default( x , -1 )==i );
       FD_TEST( fd_uint128_find_msb_w_default( x , -1 )==i );
       FD_TEST( fd_uint128_pow2_up ( x )==x     );
+      FD_TEST( fd_uint128_pow2_dn ( x )==x     );
       for( int j=0; j<i; j++ ) {
         uint128 y = ((uint128)1)<<j;
         uint128 z = x|y;
@@ -692,6 +706,7 @@ main( int     argc,
         FD_TEST( fd_uint128_find_lsb_w_default( z , -1 )==j );
         FD_TEST( fd_uint128_find_msb_w_default( z , -1 )==i );
         FD_TEST( fd_uint128_pow2_up ( z )==(x<<1) );
+        FD_TEST( fd_uint128_pow2_dn ( z )== x     );
       }
     }
     for( int n=0; n<=w; n++ ) { int sl = n+(w-8)-((n>>3)<<4); 

--- a/src/util/bits/test_bits.c
+++ b/src/util/bits/test_bits.c
@@ -155,6 +155,10 @@ main( int     argc,
 
       uchar z = x; fd_uchar_store_if( c, &z, y ); FD_TEST( z==(c ? y : x) );
 
+      uchar xx; uchar yy;
+      xx = x; yy = y; fd_swap( xx, yy );       FD_TEST( (xx==y)           & (yy==x)           );
+      xx = x; yy = y; fd_swap_if( c, xx, yy ); FD_TEST( (xx==(c ? y : x)) & (yy==(c ? x : y)) );
+
       int n = (int)fd_rng_uint( rng );
       int s = n & 15;
       FD_TEST( fd_uchar_shift_left  ( x, s )==((s>7) ? ((uchar)0) : (uchar)(x<<s)) );
@@ -293,6 +297,12 @@ main( int     argc,
       FD_TEST( fd_ushort_abs  ( x       )==x                             );
       FD_TEST( fd_ushort_min  ( x, y    )==((x<y) ? x : y)               );
       FD_TEST( fd_ushort_max  ( x, y    )==((x>y) ? x : y)               );
+
+      ushort z = x; fd_ushort_store_if( c, &z, y ); FD_TEST( z==(c ? y : x) );
+
+      ushort xx; ushort yy;
+      xx = x; yy = y; fd_swap( xx, yy );       FD_TEST( (xx==y)           & (yy==x)           );
+      xx = x; yy = y; fd_swap_if( c, xx, yy ); FD_TEST( (xx==(c ? y : x)) & (yy==(c ? x : y)) );
 
       int n = (int)fd_rng_uint( rng );
       int s = n & 31;
@@ -434,6 +444,10 @@ main( int     argc,
       FD_TEST( fd_uint_max  ( x, y    )==((x>y) ? x : y)               );
 
       uint z = x; fd_uint_store_if( c, &z, y ); FD_TEST( z==(c ? y : x) );
+
+      uint xx; uint yy;
+      xx = x; yy = y; fd_swap( xx, yy );       FD_TEST( (xx==y)           & (yy==x)           );
+      xx = x; yy = y; fd_swap_if( c, xx, yy ); FD_TEST( (xx==(c ? y : x)) & (yy==(c ? x : y)) );
 
       int n = (int)y;
       int s = n & 63;
@@ -579,6 +593,10 @@ main( int     argc,
       FD_TEST( fd_ulong_max  ( x, y    )==((x>y) ? x : y)               );
 
       ulong z = x; fd_ulong_store_if( c, &z, y ); FD_TEST( z==(c ? y : x) );
+
+      ulong xx; ulong yy;
+      xx = x; yy = y; fd_swap( xx, yy );       FD_TEST( (xx==y)           & (yy==x)           );
+      xx = x; yy = y; fd_swap_if( c, xx, yy ); FD_TEST( (xx==(c ? y : x)) & (yy==(c ? x : y)) );
 
       FD_TEST( fd_ptr_if( c, (uchar *)x, (uchar *)y )==(uchar *)(c ? x : y) );
 
@@ -746,6 +764,10 @@ main( int     argc,
 
       uint128 z = x; fd_uint128_store_if( c, &z, y ); FD_TEST( z==(c ? y : x) );
 
+      uint128 xx; uint128 yy;
+      xx = x; yy = y; fd_swap( xx, yy );       FD_TEST( (xx==y)           & (yy==x)           );
+      xx = x; yy = y; fd_swap_if( c, xx, yy ); FD_TEST( (xx==(c ? y : x)) & (yy==(c ? x : y)) );
+
       int n = (int)(uint)y;
       int s = n & 255;
       FD_TEST( fd_uint128_shift_left  ( x, s )==((s>127) ? (uint128)0 : (uint128)(x<<s)) );
@@ -759,10 +781,16 @@ main( int     argc,
   if( 1 ) {
     FD_LOG_NOTICE(( "Testing char" ));
     for( int iter=0; iter<16777216; iter++ ) {
-      int c = (int)(fd_rng_ulong( rng ) & 1UL);
-      schar x = (schar)fd_rng_ulong( rng );
-      schar y = (schar)fd_rng_ulong( rng );
-      FD_TEST( fd_schar_if( c, x, y )==(c ? x : y) );
+      int  c = (int)(fd_rng_ulong( rng ) & 1UL);
+      char x = (char)fd_rng_ulong( rng );
+      char y = (char)fd_rng_ulong( rng );
+      FD_TEST( fd_char_if( c, x, y )==(c ? x : y) );
+
+      char z = x; fd_char_store_if( c, &z, y ); FD_TEST( z==(c ? y : x) );
+
+      char xx; char yy;
+      xx = x; yy = y; fd_swap( xx, yy );       FD_TEST( (xx==y)           & (yy==x)           );
+      xx = x; yy = y; fd_swap_if( c, xx, yy ); FD_TEST( (xx==(c ? y : x)) & (yy==(c ? x : y)) );
     }
   }
 
@@ -784,6 +812,10 @@ main( int     argc,
       FD_TEST( fd_schar_max( x, y    )==((x>y) ? x : y)                         );
 
       schar z = x; fd_schar_store_if( c, &z, y ); FD_TEST( z==(c ? y : x) );
+
+      schar xx; schar yy;
+      xx = x; yy = y; fd_swap( xx, yy );       FD_TEST( (xx==y)           & (yy==x)           );
+      xx = x; yy = y; fd_swap_if( c, xx, yy ); FD_TEST( (xx==(c ? y : x)) & (yy==(c ? x : y)) );
 
       int   n = (int)fd_rng_uint( rng );
       int   s = n & 15;
@@ -826,6 +858,10 @@ main( int     argc,
 
       short z = x; fd_short_store_if( c, &z, y ); FD_TEST( z==(c ? y : x) );
 
+      short xx; short yy;
+      xx = x; yy = y; fd_swap( xx, yy );       FD_TEST( (xx==y)           & (yy==x)           );
+      xx = x; yy = y; fd_swap_if( c, xx, yy ); FD_TEST( (xx==(c ? y : x)) & (yy==(c ? x : y)) );
+
       int    n = (int)fd_rng_uint( rng );
       int    s = n & 31;
       ushort m = (ushort)-(((ushort)x) >> 15);
@@ -866,6 +902,10 @@ main( int     argc,
       FD_TEST( fd_int_max( x, y    )==((x>y) ? x : y)                    );
 
       int z = x; fd_int_store_if( c, &z, y ); FD_TEST( z==(c ? y : x) );
+
+      int xx; int yy;
+      xx = x; yy = y; fd_swap( xx, yy );       FD_TEST( (xx==y)           & (yy==x)           );
+      xx = x; yy = y; fd_swap_if( c, xx, yy ); FD_TEST( (xx==(c ? y : x)) & (yy==(c ? x : y)) );
 
       int  n = (int)fd_rng_uint( rng );
       int  s = n & 63;
@@ -908,6 +948,10 @@ main( int     argc,
 
       long z = x; fd_long_store_if( c, &z, y ); FD_TEST( z==(c ? y : x) );
 
+      long xx; long yy;
+      xx = x; yy = y; fd_swap( xx, yy );       FD_TEST( (xx==y)           & (yy==x)           );
+      xx = x; yy = y; fd_swap_if( c, xx, yy ); FD_TEST( (xx==(c ? y : x)) & (yy==(c ? x : y)) );
+
       int   n = (int)fd_rng_uint( rng );
       int   s = n & 127;
       ulong m = (ulong)-(((ulong)x) >> 63);
@@ -949,6 +993,10 @@ main( int     argc,
       FD_TEST( fd_int128_max( x, y    )==((x>y) ? x : y)                   );
 
       int128 z = x; fd_int128_store_if( c, &z, y ); FD_TEST( z==(c ? y : x) );
+
+      int128 xx; int128 yy;
+      xx = x; yy = y; fd_swap( xx, yy );       FD_TEST( (xx==y)           & (yy==x)           );
+      xx = x; yy = y; fd_swap_if( c, xx, yy ); FD_TEST( (xx==(c ? y : x)) & (yy==(c ? x : y)) );
 
       int     n = (int)fd_rng_uint( rng );
       int     s = n & 255;
@@ -1015,6 +1063,10 @@ main( int     argc,
       FD_TEST( float_as_uint( fd_float_abs( x ) )==(((float_as_uint( x ))<<1)>>1) );
 
       float z = x; fd_float_store_if( c, &z, y ); FD_TEST( fd_float_eq( z, (c ? y : x) ) );
+
+      float xx; float yy;
+      xx = x; yy = y; fd_swap( xx, yy );       FD_TEST( (xx==y)           & (yy==x)           );
+      xx = x; yy = y; fd_swap_if( c, xx, yy ); FD_TEST( (xx==(c ? y : x)) & (yy==(c ? x : y)) );
     }
   }
 
@@ -1061,6 +1113,10 @@ main( int     argc,
       FD_TEST( double_as_ulong( fd_double_abs( x ) )==(((double_as_ulong( x ))<<1)>>1) );
 
       double z = x; fd_double_store_if( c, &z, y ); FD_TEST( fd_double_eq( z, (c ? y : x) ) );
+
+      double xx; double yy;
+      xx = x; yy = y; fd_swap( xx, yy );       FD_TEST( (xx==y)           & (yy==x)           );
+      xx = x; yy = y; fd_swap_if( c, xx, yy ); FD_TEST( (xx==(c ? y : x)) & (yy==(c ? x : y)) );
     }
   }
 # endif

--- a/src/util/log/fd_log.c
+++ b/src/util/log/fd_log.c
@@ -498,9 +498,11 @@ fd_log_private_fprintf_0( int fd, char const * fmt, ... ) {
   fd_log_private_log_msg0[ len ] = '\0';
   va_end( ap );
 
-  while(( FD_LIKELY( FD_ATOMIC_CAS( fd_log_private_shared_lock, 0, 1 ) ) )) ;
-
+# if FD_HAS_ATOMIC
   FD_COMPILER_MFENCE();
+  while(( FD_LIKELY( FD_ATOMIC_CAS( fd_log_private_shared_lock, 0, 1 ) ) )) ;
+  FD_COMPILER_MFENCE();
+# endif
 
   ulong written = 0;
   for(;;) {
@@ -509,9 +511,11 @@ fd_log_private_fprintf_0( int fd, char const * fmt, ... ) {
     written += (ulong)cnt;
   }
 
+# if FD_HAS_ATOMIC
   FD_COMPILER_MFENCE();
-
   *fd_log_private_shared_lock = 0;
+  FD_COMPILER_MFENCE();
+# endif
 }
 
 char const * 

--- a/src/util/pod/fd_pod_ctl_help
+++ b/src/util/pod/fd_pod_ctl_help
@@ -27,7 +27,23 @@ list pod
 insert pod type path val
 - Inserts type into the pod at path with value val.  Fails if path
   already exists in the pod.  This might change the locations of
-  existing values in the pod.
+  existing values in the pod.  If type is cstr, val is converted to a
+  c-style string and inserted into pod.  Similarly:
+    char  -> single character,
+    schar ->  8-bit signed integer (twos complement), uchar  ->  8-bit unsigned integer,
+    short -> 16-bit signed integer (twos complement), ushort -> 16-bit unsigned integer,
+    int   -> 32-bit signed integer (twos complement), uint   -> 32-bit unsigned integer,
+    long  -> 64-bit signed integer (twos complement), ulong  -> 64-bit unsigned integer,
+    float -> 32-bit real (IEEE-754),                  double -> 64-bit real (IEEE-754)
+
+insert-file pod path file
+- Inserts a "buf" type into the pod at path.  The buffer will contain the
+  entire contents of the file at path "file" into the pod.  Fails if
+  path already exists in the pod.  This might change the locations of
+  existing values in the pod.  The size of the buffer will be number of
+  bytes in the file and it is fine to insert a zero sized file into the
+  pod.  TODO: consider allowing users to specify other types and/or
+  regions of the file?
 
 remove pod path
 - Remove the path (and any path.*) from the pod.  Fails if path does not

--- a/src/util/pod/test_pod_ctl
+++ b/src/util/pod/test_pod_ctl
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 fail() {
+  rm -f "$EMPTYFILE" "$TMPFILE"
   echo FAIL: "$1" unexpected exit code "$2"
   echo Log N/A
   exit 1
@@ -21,6 +22,14 @@ PAGE_CNT=1
 PAGE_SZ=gigantic
 CPU_IDX=0
 MODE=0600
+
+BADFILE=$(mktemp)
+rm -f "$BADFILE"
+
+EMPTYFILE=$(mktemp)
+
+TMPFILE=$(mktemp)
+echo "The quick brown fox jumps over the lazy dog" > "$TMPFILE"
 
 # Disable the permanent log
 
@@ -78,6 +87,17 @@ echo Testing insert
                   insert "$POD" ulong  ulong.p4   4   \
                   insert "$POD" float  float.half 0.5 \
 || fail insert $?
+
+echo Testing insert-file
+"$BIN"/fd_pod_ctl insert-file                                && fail insert-file $?
+"$BIN"/fd_pod_ctl insert-file "$POD"                         && fail insert-file $?
+"$BIN"/fd_pod_ctl insert-file "$POD" tmpfile                 && fail insert-file $?
+"$BIN"/fd_pod_ctl insert-file bad    tmpfile    "$TMPFILE"   && fail insert-file $?
+"$BIN"/fd_pod_ctl insert-file "$POD" tmpfile    "$BADFILE"   && fail insert-file $?
+"$BIN"/fd_pod_ctl insert-file "$POD" tmpfile    "$TMPFILE"   \
+                  insert-file "$POD" empttyfile "$EMPTYFILE" || fail insert-file $?
+"$BIN"/fd_pod_ctl insert-file "$POD" tmpfile    "$TMPFILE"   && fail insert-file $?
+"$BIN"/fd_pod_ctl insert-file "$POD" tmpfile    "$EMPTYFILE" && fail insert-file $?
 
 echo Testing update
 
@@ -230,6 +250,7 @@ echo Fini
 
 "$BIN"/fd_wksp_ctl delete "$WKSP" > /dev/null 2>&1
 
+rm -f "$EMPTYFILE" "$TMPFILE"
 echo pass
 echo Log N/A
 exit 0

--- a/src/util/test_util_base.c
+++ b/src/util/test_util_base.c
@@ -1,6 +1,3 @@
-/* Tests in this file are not compatible with UBSAN. */
-#if !FD_HAS_UBSAN
-
 #include "fd_util.h"
 
 #if FD_HAS_HOSTED
@@ -428,8 +425,7 @@ main( int     argc,
   /* Test FD_IMPORT */
 
   FD_TEST( (strlen( quine_cstr )+1UL)==quine_cstr_sz              );
-  /* 75 bytes are skipped due to the preprocessor directive related to UBSAN. */
-  FD_TEST( !strncmp( quine_cstr+75U, "#include \"fd_util.h\"", 20UL ) );
+  FD_TEST( !strncmp( quine_cstr, "#include \"fd_util.h\"", 20UL ) );
 
   FD_TEST( (quine_binary_sz+1UL     )==quine_cstr_sz             );
   FD_TEST( fd_ulong_is_aligned( (ulong)quine_binary, 128UL )     );
@@ -445,14 +441,3 @@ main( int     argc,
   return 0;
 }
 
-#else /* FD_HAS_UBSAN */
-
-#include <stdio.h>
-int
-main ( int     argv,
-       char ** argc ) {
-  (void) argc;
-  (void) argv;
-  printf("not supported on this target\n");
-}
-#endif /* !FD_HAS_UBSAN */


### PR DESCRIPTION
Bunch of minor housekeeping cleanups to some recent PRs and some additional helpers for upcoming PRs.

- bits: pow2_dn support (for upcoming PRs)
- bits: swap / branchless conditional swap (for upcoming PRs)
- log: support for targets with FD_HAS_ATOMIC (related conversing to POSIX style I/O)
- pod: help docs and unit test coverage for insert-file command and minor optimization
- shmem: pedantic error trapping of mutex initializer (related to removal of the NP static initializer for musl support)
- test_util_base: do not build under UBSAN as this deliberately probes UB/IB behaviors (related to ubsan build targets)
- tile: set affinity after tile boot when not running under glibc (related to removal of NP pthread attr for musl support)