### PR TITLE
monitor: improve performance and stability

### DIFF
--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -16,10 +16,12 @@ typedef struct {
     wksp_verify_dedup,
     wksp_dedup_pack,
     wksp_pack_bank,
+    wksp_bank_shred,
     wksp_quic,
     wksp_verify,
     wksp_dedup,
     wksp_pack,
+    wksp_bank,
   } kind;
   char * name;
   ulong kind_idx;

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -299,9 +299,7 @@ dynamic_port_range = "8000-10000"
     verify_tile_count = 4
 
     # How many bank tiles to run. Multiple banks can run in parallel, if they
-    # are not writing to the same accounts at the same time. Bank tile 0 is not
-    # managed by Firedancer, it is the Solana Labs thread receiving gossiped
-    # transactions.
+    # are not writing to the same accounts at the same time.
     bank_tile_count = 4
 
 # All memory that will be used in Firedancer is pre-allocated in two kinds of

--- a/src/app/fdctl/monitor/helper.c
+++ b/src/app/fdctl/monitor/helper.c
@@ -1,44 +1,57 @@
 #include "helper.h"
 
-#include "../../../disco/fd_disco.h"
-
 #include <stdio.h>
 
+#include "../../../disco/fd_disco.h"
+
+#define PRINT( ... ) do {                                                        \
+    int n = snprintf( *buf, *buf_sz, __VA_ARGS__ );                              \
+    if( FD_UNLIKELY( n<0 ) ) FD_LOG_ERR(( "snprintf failed" ));                  \
+    if( FD_UNLIKELY( (ulong)n>=*buf_sz ) ) FD_LOG_ERR(( "snprintf truncated" )); \
+    *buf += n; *buf_sz -= (ulong)n;                                              \
+  } while(0)
+
 void
-printf_age( long _dt ) {
-  if( FD_UNLIKELY( _dt< 0L ) ) { printf( "   invalid" ); return; }
-  if( FD_UNLIKELY( _dt==0L ) ) { printf( "        0s" ); return; }
+printf_age( char ** buf,
+            ulong * buf_sz,
+            long _dt ) {
+  if( FD_UNLIKELY( _dt< 0L ) ) { PRINT( "   invalid" ); return; }
+  if( FD_UNLIKELY( _dt==0L ) ) { PRINT( "        0s" ); return; }
   ulong rem = (ulong)_dt;
-  ulong ns = rem % 1000UL; rem /= 1000UL; if( !rem /*no u*/ ) { printf( "      %3lun",           ns                   ); return; }
-  ulong us = rem % 1000UL; rem /= 1000UL; if( !rem /*no m*/ ) { printf( "  %3lu.%03luu",         us, ns               ); return; }
-  ulong ms = rem % 1000UL; rem /= 1000UL; if( !rem /*no s*/ ) { printf( "%3lu.%03lu%02lum",      ms, us, ns/10UL      ); return; }
-  ulong  s = rem %   60UL; rem /=   60UL; if( !rem /*no m*/ ) { printf( "%2lu.%03lu%03lus",      s,  ms, us           ); return; }
-  ulong  m = rem %   60UL; rem /=   60UL; if( !rem /*no h*/ ) { printf( "%2lu:%02lu.%03lu%1lu",  m,  s,  ms, us/100UL ); return; }
-  ulong  h = rem %   24UL; rem /=   24UL; if( !rem /*no d*/ ) { printf( "%2lu:%02lu:%02lu.%1lu", h,  m,  s,  ms/100UL ); return; }
-  ulong  d = rem %    7UL; rem /=    7UL; if( !rem /*no w*/ ) { printf( "  %1lud %2lu:%02lu",    d,  h,  m            ); return; }
-  ulong  w = rem;                         if( w<=99UL       ) { printf( "%2luw %1lud %2luh",     w,  d,  h            ); return; }
-  /* note that this can handle LONG_MAX fine */                 printf( "%6luw %1lud",           w,  d                );
+  ulong ns = rem % 1000UL; rem /= 1000UL; if( !rem /*no u*/ ) { PRINT( "      %3lun",           ns                   ); return; }
+  ulong us = rem % 1000UL; rem /= 1000UL; if( !rem /*no m*/ ) { PRINT( "  %3lu.%03luu",         us, ns               ); return; }
+  ulong ms = rem % 1000UL; rem /= 1000UL; if( !rem /*no s*/ ) { PRINT( "%3lu.%03lu%02lum",      ms, us, ns/10UL      ); return; }
+  ulong  s = rem %   60UL; rem /=   60UL; if( !rem /*no m*/ ) { PRINT( "%2lu.%03lu%03lus",      s,  ms, us           ); return; }
+  ulong  m = rem %   60UL; rem /=   60UL; if( !rem /*no h*/ ) { PRINT( "%2lu:%02lu.%03lu%1lu",  m,  s,  ms, us/100UL ); return; }
+  ulong  h = rem %   24UL; rem /=   24UL; if( !rem /*no d*/ ) { PRINT( "%2lu:%02lu:%02lu.%1lu", h,  m,  s,  ms/100UL ); return; }
+  ulong  d = rem %    7UL; rem /=    7UL; if( !rem /*no w*/ ) { PRINT( "  %1lud %2lu:%02lu",    d,  h,  m            ); return; }
+  ulong  w = rem;                         if( w<=99UL       ) { PRINT( "%2luw %1lud %2luh",     w,  d,  h            ); return; }
+  /* note that this can handle LONG_MAX fine */                 PRINT( "%6luw %1lud",           w,  d                );
 }
 
 void
-printf_stale( long age,
+printf_stale( char ** buf,
+              ulong * buf_sz,
+              long age,
               long expire ) {
   if( FD_UNLIKELY( age>expire ) ) {
-    printf( TEXT_YELLOW );
-    printf_age( age );
-    printf( TEXT_NORMAL );
+    PRINT( TEXT_YELLOW );
+    printf_age( buf, buf_sz, age );
+    PRINT( TEXT_NORMAL );
     return;
   }
-  printf( TEXT_GREEN "         -" TEXT_NORMAL );
+  PRINT( TEXT_GREEN "         -" TEXT_NORMAL );
 }
 
 void
-printf_heart( long hb_now,
+printf_heart( char ** buf,
+              ulong * buf_sz,
+              long hb_now,
               long hb_then ) {
   long dt = hb_now - hb_then;
-  printf( "%s", (dt>0L) ? (TEXT_GREEN "    -" TEXT_NORMAL) :
-                (!dt)   ? (TEXT_RED   " NONE" TEXT_NORMAL) :
-                          (TEXT_BLUE  "RESET" TEXT_NORMAL) );
+  PRINT( "%s", (dt>0L) ? (TEXT_GREEN "    -" TEXT_NORMAL) :
+               (!dt)   ? (TEXT_RED   " NONE" TEXT_NORMAL) :
+                         (TEXT_BLUE  "RESET" TEXT_NORMAL) );
 }
 
 char const *
@@ -54,50 +67,60 @@ sig_color( ulong sig ) {
 }
 
 void
-printf_sig( ulong sig_now,
+printf_sig( char ** buf,
+            ulong * buf_sz,
+            ulong sig_now,
             ulong sig_then ) {
   char buf0[ FD_CNC_SIGNAL_CSTR_BUF_MAX ];
   char buf1[ FD_CNC_SIGNAL_CSTR_BUF_MAX ];
-  printf( "%s%4s" TEXT_NORMAL "(%s%4s" TEXT_NORMAL ")",
-          sig_color( sig_now  ), fd_cnc_signal_cstr( sig_now,  buf0 ),
-          sig_color( sig_then ), fd_cnc_signal_cstr( sig_then, buf1 ) );
+  PRINT( "%s%4s" TEXT_NORMAL "(%s%4s" TEXT_NORMAL ")",
+         sig_color( sig_now  ), fd_cnc_signal_cstr( sig_now,  buf0 ),
+         sig_color( sig_then ), fd_cnc_signal_cstr( sig_then, buf1 ) );
 }
 
 void
-printf_err_bool( ulong err_now,
+printf_err_bool( char ** buf,
+                 ulong * buf_sz,
+                 ulong err_now,
                  ulong err_then ) {
-  printf( "%5s(%5s)", err_now  ? TEXT_RED "err" TEXT_NORMAL : TEXT_GREEN "  -" TEXT_NORMAL,
-                      err_then ? TEXT_RED "err" TEXT_NORMAL : TEXT_GREEN "  -" TEXT_NORMAL );
+  PRINT( "%5s(%5s)", err_now  ? TEXT_RED "err" TEXT_NORMAL : TEXT_GREEN "  -" TEXT_NORMAL,
+                     err_then ? TEXT_RED "err" TEXT_NORMAL : TEXT_GREEN "  -" TEXT_NORMAL );
 }
 
 void
-printf_err_cnt( ulong cnt_now,
+printf_err_cnt( char ** buf,
+                ulong * buf_sz,
+                ulong cnt_now,
                 ulong cnt_then ) {
   long delta = (long)(cnt_now - cnt_then);
   char const * color = (!delta)   ? TEXT_GREEN  /* no new error counts */
                      : (delta>0L) ? TEXT_RED    /* new error counts */
                      : (cnt_now)  ? TEXT_YELLOW /* decrease of existing error counts?? */
                      :              TEXT_BLUE;  /* reset of the error counter */
-  if(      delta> 99999L ) printf( "%10u(%s>+99999" TEXT_NORMAL ")", (uint)cnt_now, color        );
-  else if( delta<-99999L ) printf( "%10u(%s<-99999" TEXT_NORMAL ")", (uint)cnt_now, color        );
-  else                     printf( "%10u(%s %+6li"  TEXT_NORMAL ")", (uint)cnt_now, color, delta );
+  if(      delta> 99999L ) PRINT( "%10u(%s>+99999" TEXT_NORMAL ")", (uint)cnt_now, color        );
+  else if( delta<-99999L ) PRINT( "%10u(%s<-99999" TEXT_NORMAL ")", (uint)cnt_now, color        );
+  else                     PRINT( "%10u(%s %+6li"  TEXT_NORMAL ")", (uint)cnt_now, color, delta );
 }
 
 void
-printf_seq( ulong seq_now,
+printf_seq( char ** buf,
+            ulong * buf_sz,
+            ulong seq_now,
             ulong seq_then ) {
   long delta = (long)(seq_now - seq_then);
   char const * color = (!delta)   ? TEXT_YELLOW /* no sequence numbers published */
                      : (delta>0L) ? TEXT_GREEN  /* new sequence numbers published */
                      : (seq_now)  ? TEXT_RED    /* sequence number went backward */
                      :              TEXT_BLUE;  /* sequence number reset */
-  if(      delta> 99999L ) printf( "%16lx(%s>+99999" TEXT_NORMAL ")", seq_now, color        );
-  else if( delta<-99999L ) printf( "%16lx(%s<-99999" TEXT_NORMAL ")", seq_now, color        );
-  else                     printf( "%16lx(%s %+6li"  TEXT_NORMAL ")", seq_now, color, delta );
+  if(      delta> 99999L ) PRINT( "%16lx(%s>+99999" TEXT_NORMAL ")", seq_now, color        );
+  else if( delta<-99999L ) PRINT( "%16lx(%s<-99999" TEXT_NORMAL ")", seq_now, color        );
+  else                     PRINT( "%16lx(%s %+6li"  TEXT_NORMAL ")", seq_now, color, delta );
 }
 
 void
-printf_rate( double cvt,
+printf_rate( char ** buf,
+             ulong * buf_sz,
+             double cvt,
              double overhead,
              ulong  cnt_now,
              ulong  cnt_then,
@@ -106,28 +129,30 @@ printf_rate( double cvt,
                    !((0.<=overhead) & (cvt<=DBL_MAX)) |
                    (cnt_now<cnt_then)                 |
                    (dt<=0L)                           ) ) {
-    printf( TEXT_RED " invalid" TEXT_NORMAL );
+    PRINT( TEXT_RED " invalid" TEXT_NORMAL );
     return;
   }
   double rate = cvt*(overhead+(double)(cnt_now-cnt_then)) / (double)dt;
   if( FD_UNLIKELY( !((0.<=rate) & (rate<=DBL_MAX)) ) ) {
-    printf( TEXT_RED "overflow" TEXT_NORMAL );
+    PRINT( TEXT_RED "overflow" TEXT_NORMAL );
     return;
   }
-  /**/          if( rate<=9999.9 ) { printf( " %6.1f ", rate ); return; }
-  rate *= 1e-3; if( rate<=9999.9 ) { printf( " %6.1fK", rate ); return; }
-  rate *= 1e-3; if( rate<=9999.9 ) { printf( " %6.1fM", rate ); return; }
-  rate *= 1e-3; if( rate<=9999.9 ) { printf( " %6.1fG", rate ); return; }
-  rate *= 1e-3; if( rate<=9999.9 ) { printf( " %6.1fT", rate ); return; }
-  rate *= 1e-3; if( rate<=9999.9 ) { printf( " %6.1fP", rate ); return; }
-  rate *= 1e-3; if( rate<=9999.9 ) { printf( " %6.1fE", rate ); return; }
-  rate *= 1e-3; if( rate<=9999.9 ) { printf( " %6.1fZ", rate ); return; }
-  rate *= 1e-3; if( rate<=9999.9 ) { printf( " %6.1fY", rate ); return; }
-  /**/                               printf( ">9999.9Y" );
+  /**/          if( rate<=9999.9 ) { PRINT( " %6.1f ", rate ); return; }
+  rate *= 1e-3; if( rate<=9999.9 ) { PRINT( " %6.1fK", rate ); return; }
+  rate *= 1e-3; if( rate<=9999.9 ) { PRINT( " %6.1fM", rate ); return; }
+  rate *= 1e-3; if( rate<=9999.9 ) { PRINT( " %6.1fG", rate ); return; }
+  rate *= 1e-3; if( rate<=9999.9 ) { PRINT( " %6.1fT", rate ); return; }
+  rate *= 1e-3; if( rate<=9999.9 ) { PRINT( " %6.1fP", rate ); return; }
+  rate *= 1e-3; if( rate<=9999.9 ) { PRINT( " %6.1fE", rate ); return; }
+  rate *= 1e-3; if( rate<=9999.9 ) { PRINT( " %6.1fZ", rate ); return; }
+  rate *= 1e-3; if( rate<=9999.9 ) { PRINT( " %6.1fY", rate ); return; }
+  /**/                               PRINT( ">9999.9Y" );
 }
 
 void
-printf_pct( ulong  num_now,
+printf_pct( char ** buf,
+            ulong * buf_sz,
+            ulong  num_now,
             ulong  num_then,
             double lhopital_num,
             ulong  den_now,
@@ -137,17 +162,17 @@ printf_pct( ulong  num_now,
                    (den_now<den_then)                              |
                    !((0.<=lhopital_num) & (lhopital_num<=DBL_MAX)) |
                    !((0.< lhopital_den) & (lhopital_den<=DBL_MAX)) ) ) {
-    printf( TEXT_RED " invalid" TEXT_NORMAL );
+    PRINT( TEXT_RED " invalid" TEXT_NORMAL );
     return;
   }
 
   double pct = 100.*(((double)(num_now - num_then) + lhopital_num) / ((double)(den_now - den_then) + lhopital_den));
 
   if( FD_UNLIKELY( !((0.<=pct) & (pct<=DBL_MAX)) ) ) {
-    printf( TEXT_RED "overflow" TEXT_NORMAL );
+    PRINT( TEXT_RED "overflow" TEXT_NORMAL );
     return;
   }
 
-  if( pct<=999.999 ) { printf( " %7.3f", pct ); return; }
-  /**/                 printf( ">999.999" );
+  if( pct<=999.999 ) { PRINT( " %7.3f", pct ); return; }
+  /**/                 PRINT( ">999.999" );
 }

--- a/src/app/fdctl/monitor/helper.h
+++ b/src/app/fdctl/monitor/helper.h
@@ -12,6 +12,9 @@
 #define TEXT_EL             "\033[K"
 #define TEXT_NEWLINE         TEXT_EL "\n"
 
+#define TEXT_NOCURSOR "\033[?25l"
+#define TEXT_CURSOR   "\033[?25h"
+
 #define TEXT_NORMAL "\033[0m"
 #define TEXT_BLUE   "\033[34m"
 #define TEXT_GREEN  "\033[32m"
@@ -22,19 +25,25 @@
    char wide.  Since pretty printing this value will often require
    rounding it, the rounding is in a round toward zero sense. */
 void
-printf_age( long _dt );
+printf_age( char ** buf,
+            ulong * buf_sz,
+            long _dt );
 
 /* printf_stale is printf_age with the tweak that ages less than or
    equal to expire (in ns) will be suppressed to limit visual chatter.
    Will be exactly 10 char wide and color coded. */
 void
-printf_stale( long age,
+printf_stale( char ** buf,
+              ulong * buf_sz,
+              long age,
               long expire );
 
 /* printf_heart will print to stdout whether or not a heartbeat was
    detected.  Will be exactly 5 char wide and color coded. */
 void
-printf_heart( long hb_now,
+printf_heart( char ** buf,
+              ulong * buf_sz,
+              long hb_now,
               long hb_then );
 
 char const *
@@ -43,25 +52,33 @@ sig_color( ulong sig );
 /* printf_sig will print the current and previous value of a cnc signal.
    to stdout.  Will be exactly 10 char wide and color coded. */
 void
-printf_sig( ulong sig_now,
+printf_sig( char ** buf,
+            ulong * buf_sz,
+            ulong sig_now,
             ulong sig_then );
 
 /* printf_err_bool will print to stdout a boolean flag that indicates
    if error condition was present now and then.  Will be exactly 12 char
    wide and color coded. */
 void
-printf_err_bool( ulong err_now,
+printf_err_bool( char ** buf,
+                 ulong * buf_sz,
+                 ulong err_now,
                  ulong err_then );
 
 void
-printf_err_cnt( ulong cnt_now,
+printf_err_cnt( char ** buf,
+                ulong * buf_sz,
+                ulong cnt_now,
                 ulong cnt_then );
 
 /* printf_seq will print to stdout a 64-bit sequence number and how it
    has changed between now and then.  Will be exactly 25 char wide and
    color coded. */
 void
-printf_seq( ulong seq_now,
+printf_seq( char ** buf,
+            ulong * buf_sz,
+            ulong seq_now,
             ulong seq_then );
 
 /* printf_rate prints to stdout:
@@ -77,14 +94,18 @@ printf_seq( ulong seq_now,
    rate*=1e-3 used below is not exact, but this is more than adequate
    for a quick-and-dirty low precision diagnostic. */
 void
-printf_rate( double cvt,
+printf_rate( char ** buf,
+             ulong * buf_sz,
+             double cvt,
              double overhead,
              ulong  cnt_now,
              ulong  cnt_then,
              long   dt  );
 
 void
-printf_pct( ulong  num_now,
+printf_pct( char ** buf,
+            ulong * buf_sz,
+            ulong  num_now,
             ulong  num_then,
             double lhopital_num,
             ulong  den_now,

--- a/src/app/fdctl/monitor/monitor.c
+++ b/src/app/fdctl/monitor/monitor.c
@@ -13,8 +13,8 @@ void
 monitor_cmd_args( int *    pargc,
                   char *** pargv,
                   args_t * args ) {
-  args->monitor.dt_min     = fd_env_strip_cmdline_long( pargc, pargv, "--dt-min",   NULL,   66666667.          );
-  args->monitor.dt_max     = fd_env_strip_cmdline_long( pargc, pargv, "--dt-max",   NULL, 1333333333.          );
+  args->monitor.dt_min     = fd_env_strip_cmdline_long( pargc, pargv, "--dt-min",   NULL,    6666667.          );
+  args->monitor.dt_max     = fd_env_strip_cmdline_long( pargc, pargv, "--dt-max",   NULL,  133333333.          );
   args->monitor.duration   = fd_env_strip_cmdline_long( pargc, pargv, "--duration", NULL,          0.          );
   args->monitor.seed       = fd_env_strip_cmdline_uint( pargc, pargv, "--seed",     NULL, (uint)fd_tickcount() );
   args->monitor.ns_per_tic = 1./fd_tempo_tick_per_ns( NULL ); /* calibrate during init */
@@ -38,12 +38,7 @@ monitor_cmd_perm( args_t *         args,
     check_cap( security, "monitor", CAP_SETGID, "switch gid by calling `setgid(2)`" );
 }
 
-/* snap reads all the IPC diagnostics in a frank instance and stores
-   them into the easy to process structure snap */
-
-struct snap {
-  ulong pmap; /* Bit {0,1,2} set <> {cnc,mcache,fseq} values are valid */
-
+typedef struct {
   long  cnc_heartbeat;
   ulong cnc_signal;
 
@@ -53,7 +48,9 @@ struct snap {
   ulong cnc_diag_ha_filt_sz;
   ulong cnc_diag_sv_filt_cnt;
   ulong cnc_diag_sv_filt_sz;
+} tile_snap_t;
 
+typedef struct {
   ulong mcache_seq;
 
   ulong fseq_seq;
@@ -65,116 +62,89 @@ struct snap {
   ulong fseq_diag_ovrnp_cnt;
   ulong fseq_diag_ovrnr_cnt;
   ulong fseq_diag_slow_cnt;
-};
+} link_snap_t;
 
-typedef struct snap snap_t;
+typedef struct {
+  char const *     name;
+  fd_cnc_t *       cnc;
+} tile_t;
+
+typedef struct {
+  char const *     src_name;
+  char const *     dst_name;
+  fd_frag_meta_t * mcache;
+  ulong *          fseq;
+} link_t;
 
 static void
-snap( ulong             tile_cnt,     /* Number of tiles to snapshot */
-      snap_t *          snap_cur,     /* Snaphot for each tile, indexed [0,tile_cnt) */
-      fd_cnc_t **       tile_cnc,     /* Local cnc    joins for each tile, NULL if n/a, indexed [0,tile_cnt) */
-      fd_frag_meta_t ** tile_mcache,  /* Local mcache joins for each tile, NULL if n/a, indexed [0,tile_cnt) */
-      ulong **          tile_fseq ) { /* Local fseq   joins for each tile, NULL if n/a, indexed [0,tile_cnt) */
-
+tile_snap( tile_snap_t *     snap_cur,     /* Snaphot for each tile, indexed [0,tile_cnt) */
+           ulong             tile_cnt,     /* Number of tiles to snapshot */
+           tile_t *          tiles ) {     /* Joined IPC objects for each tile, indexed [0,tile_cnt) */
   for( ulong tile_idx=0UL; tile_idx<tile_cnt; tile_idx++ ) {
-    snap_t * snap = &snap_cur[ tile_idx ];
+    tile_snap_t * snap = &snap_cur[ tile_idx ];
 
-    ulong pmap = 0UL;
+    fd_cnc_t const * cnc = tiles[ tile_idx ].cnc;
+    snap->cnc_heartbeat = fd_cnc_heartbeat_query( cnc );
+    snap->cnc_signal    = fd_cnc_signal_query   ( cnc );
+    ulong const * cnc_diag = (ulong const *)fd_cnc_app_laddr_const( cnc );
+    FD_COMPILER_MFENCE();
+    snap->cnc_diag_in_backp    = cnc_diag[ FD_FRANK_CNC_DIAG_IN_BACKP    ];
+    snap->cnc_diag_backp_cnt   = cnc_diag[ FD_FRANK_CNC_DIAG_BACKP_CNT   ];
+    snap->cnc_diag_ha_filt_cnt = cnc_diag[ FD_FRANK_CNC_DIAG_HA_FILT_CNT ];
+    snap->cnc_diag_ha_filt_sz  = cnc_diag[ FD_FRANK_CNC_DIAG_HA_FILT_SZ  ];
+    snap->cnc_diag_sv_filt_cnt = cnc_diag[ FD_FRANK_CNC_DIAG_SV_FILT_CNT ];
+    snap->cnc_diag_sv_filt_sz  = cnc_diag[ FD_FRANK_CNC_DIAG_SV_FILT_SZ  ];
+    FD_COMPILER_MFENCE();
+  }
+}
 
-    fd_cnc_t const * cnc = tile_cnc[ tile_idx ];
-    if( FD_LIKELY( cnc ) ) {
-      snap->cnc_heartbeat = fd_cnc_heartbeat_query( cnc );
-      snap->cnc_signal    = fd_cnc_signal_query   ( cnc );
-      ulong const * cnc_diag = (ulong const *)fd_cnc_app_laddr_const( cnc );
-      FD_COMPILER_MFENCE();
-      snap->cnc_diag_in_backp    = cnc_diag[ FD_FRANK_CNC_DIAG_IN_BACKP    ];
-      snap->cnc_diag_backp_cnt   = cnc_diag[ FD_FRANK_CNC_DIAG_BACKP_CNT   ];
-      snap->cnc_diag_ha_filt_cnt = cnc_diag[ FD_FRANK_CNC_DIAG_HA_FILT_CNT ];
-      snap->cnc_diag_ha_filt_sz  = cnc_diag[ FD_FRANK_CNC_DIAG_HA_FILT_SZ  ];
-      snap->cnc_diag_sv_filt_cnt = cnc_diag[ FD_FRANK_CNC_DIAG_SV_FILT_CNT ];
-      snap->cnc_diag_sv_filt_sz  = cnc_diag[ FD_FRANK_CNC_DIAG_SV_FILT_SZ  ];
-      FD_COMPILER_MFENCE();
+static void
+link_snap( link_snap_t * snap_cur,
+           ulong         link_cnt,
+           link_t *      links) {
+  for( ulong link_idx=0UL; link_idx<link_cnt; link_idx++ ) {
+    link_snap_t * snap = &snap_cur[ link_idx ];
 
-      pmap |= 1UL;
-    }
+    fd_frag_meta_t const * mcache = links[ link_idx ].mcache;
+    ulong const * seq = (ulong const *)fd_mcache_seq_laddr_const( mcache );
+    snap->mcache_seq = fd_mcache_seq_query( seq );
 
-    fd_frag_meta_t const * mcache = tile_mcache[ tile_idx ];
-    if( FD_LIKELY( mcache ) ) {
-      ulong const * seq = (ulong const *)fd_mcache_seq_laddr_const( mcache );
-      snap->mcache_seq = fd_mcache_seq_query( seq );
-
-      pmap |= 2UL;
-    }
-
-    ulong const * fseq = tile_fseq[ tile_idx ];
-    if( FD_LIKELY( fseq ) ) {
-      snap->fseq_seq = fd_fseq_query( fseq );
-      ulong const * fseq_diag = (ulong const *)fd_fseq_app_laddr_const( fseq );
-      FD_COMPILER_MFENCE();
-      snap->fseq_diag_tot_cnt   = fseq_diag[ FD_FSEQ_DIAG_PUB_CNT   ];
-      snap->fseq_diag_tot_sz    = fseq_diag[ FD_FSEQ_DIAG_PUB_SZ    ];
-      snap->fseq_diag_filt_cnt  = fseq_diag[ FD_FSEQ_DIAG_FILT_CNT  ];
-      snap->fseq_diag_filt_sz   = fseq_diag[ FD_FSEQ_DIAG_FILT_SZ   ];
-      snap->fseq_diag_ovrnp_cnt = fseq_diag[ FD_FSEQ_DIAG_OVRNP_CNT ];
-      snap->fseq_diag_ovrnr_cnt = fseq_diag[ FD_FSEQ_DIAG_OVRNR_CNT ];
-      snap->fseq_diag_slow_cnt  = fseq_diag[ FD_FSEQ_DIAG_SLOW_CNT  ];
-      FD_COMPILER_MFENCE();
-      snap->fseq_diag_tot_cnt += snap->fseq_diag_filt_cnt;
-      snap->fseq_diag_tot_sz  += snap->fseq_diag_filt_sz;
-      pmap |= 4UL;
-    }
-
-    snap->pmap = pmap;
+    ulong const * fseq = links[ link_idx ].fseq;
+    snap->fseq_seq = fd_fseq_query( fseq );
+    ulong const * fseq_diag = (ulong const *)fd_fseq_app_laddr_const( fseq );
+    FD_COMPILER_MFENCE();
+    snap->fseq_diag_tot_cnt   = fseq_diag[ FD_FSEQ_DIAG_PUB_CNT   ];
+    snap->fseq_diag_tot_sz    = fseq_diag[ FD_FSEQ_DIAG_PUB_SZ    ];
+    snap->fseq_diag_filt_cnt  = fseq_diag[ FD_FSEQ_DIAG_FILT_CNT  ];
+    snap->fseq_diag_filt_sz   = fseq_diag[ FD_FSEQ_DIAG_FILT_SZ   ];
+    snap->fseq_diag_ovrnp_cnt = fseq_diag[ FD_FSEQ_DIAG_OVRNP_CNT ];
+    snap->fseq_diag_ovrnr_cnt = fseq_diag[ FD_FSEQ_DIAG_OVRNR_CNT ];
+    snap->fseq_diag_slow_cnt  = fseq_diag[ FD_FSEQ_DIAG_SLOW_CNT  ];
+    FD_COMPILER_MFENCE();
+    snap->fseq_diag_tot_cnt += snap->fseq_diag_filt_cnt;
+    snap->fseq_diag_tot_sz  += snap->fseq_diag_filt_sz;
   }
 }
 
 /**********************************************************************/
 
-static void
-printf_link( snap_t *      snap_prv,
-             snap_t *      snap_cur,
-             char const ** tile_name,
-             ulong         src_tile_idx,
-             ulong         dst_tile_idx,
-             long          dt ) {
-  snap_t * prv = &snap_prv[ src_tile_idx ];
-  snap_t * cur = &snap_cur[ src_tile_idx ];
-  printf( " %6s->%-5s", tile_name[ src_tile_idx ], tile_name[ dst_tile_idx ] );
-  ulong cur_raw_cnt = cur->cnc_diag_ha_filt_cnt + cur->fseq_diag_tot_cnt;
-  ulong cur_raw_sz  = cur->cnc_diag_ha_filt_sz  + cur->fseq_diag_tot_sz;
-  ulong prv_raw_cnt = prv->cnc_diag_ha_filt_cnt + prv->fseq_diag_tot_cnt;
-  ulong prv_raw_sz  = prv->cnc_diag_ha_filt_sz  + prv->fseq_diag_tot_sz;
-
-  printf( " | " ); printf_rate( 1e9, 0., cur_raw_cnt,             prv_raw_cnt,             dt );
-  printf( " | " ); printf_rate( 8e9, 0., cur_raw_sz,              prv_raw_sz,              dt ); /* Assumes sz incl framing */
-  printf( " | " ); printf_rate( 1e9, 0., cur->fseq_diag_tot_cnt,  prv->fseq_diag_tot_cnt,  dt );
-  printf( " | " ); printf_rate( 8e9, 0., cur->fseq_diag_tot_sz,   prv->fseq_diag_tot_sz,   dt ); /* Assumes sz incl framing */
-
-  printf( " | " ); printf_pct ( cur->fseq_diag_tot_cnt,  prv->fseq_diag_tot_cnt, 0.,
-                                cur_raw_cnt,             prv_raw_cnt,            DBL_MIN );
-  printf( " | " ); printf_pct ( cur->fseq_diag_tot_sz,   prv->fseq_diag_tot_sz,  0.,
-                                cur_raw_sz,              prv_raw_sz,             DBL_MIN ); /* Assumes sz incl framing */
-  printf( " | " ); printf_pct ( cur->fseq_diag_filt_cnt, prv->fseq_diag_filt_cnt, 0.,
-                                cur->fseq_diag_tot_cnt,  prv->fseq_diag_tot_cnt,  DBL_MIN );
-  printf( " | " ); printf_pct ( cur->fseq_diag_filt_sz,  prv->fseq_diag_filt_sz, 0.,
-                                cur->fseq_diag_tot_sz,   prv->fseq_diag_tot_sz,  DBL_MIN ); /* Assumes sz incl framing */
-
-  printf( " | " ); printf_err_cnt( cur->fseq_diag_ovrnp_cnt, prv->fseq_diag_ovrnp_cnt );
-  printf( " | " ); printf_err_cnt( cur->fseq_diag_ovrnr_cnt, prv->fseq_diag_ovrnr_cnt );
-  printf( " | " ); printf_err_cnt( cur->fseq_diag_slow_cnt,  prv->fseq_diag_slow_cnt  );
-  printf( TEXT_NEWLINE );
-}
-
-const uchar *
-find_pod( config_t * const config,
-          int kind,
-          const uchar ** pods ) {
-  for( ulong i=0; i<config->shmem.workspaces_cnt; i++ ) {
-    workspace_config_t * wksp = &config->shmem.workspaces[ i ];
-    if( (int)wksp->kind == kind ) return pods[i];
+static void write_stdout( char * buf, ulong buf_sz ) {
+  ulong written = 0;
+  ulong total = buf_sz;
+  while( written < total ) {
+    long n = write( STDOUT_FILENO, buf + written, total - written );
+    if( FD_UNLIKELY( n < 0 ) ) {
+      if( errno == EINTR ) continue;
+      FD_LOG_ERR(( "error writing to stdout (%d-%s)", errno, strerror( errno ) ));
+    }
+    written += (ulong)n;
   }
-  FD_LOG_ERR(( "no pod of kind %d found", kind ));
 }
+
+static int stop1 = 0;
+
+#define FD_MONITOR_TEXT_BUF_SZ 16384
+char buffer[ FD_MONITOR_TEXT_BUF_SZ ];
 
 void
 run_monitor( config_t * const config,
@@ -184,116 +154,157 @@ run_monitor( config_t * const config,
              long             duration,
              uint             seed,
              double           ns_per_tic ) {
-  /* tile indices */
-  ulong tile_pack_idx    = 0UL;
-  ulong tile_dedup_idx   = tile_pack_idx +1UL;
-  ulong tile_verify_idx0 = tile_dedup_idx+1UL;
-  ulong tile_verify_idx1 = tile_verify_idx0 + config->layout.verify_tile_count;
-  ulong tile_quic_idx0   = tile_verify_idx1;
-  ulong tile_quic_idx1   = tile_quic_idx0 + config->layout.verify_tile_count;
+  ulong tile_cnt =
+    config->layout.verify_tile_count + // QUIC tiles
+    config->layout.verify_tile_count + // verify tiles
+    1 +                                // dedup tile
+    1 +                                // pack tile
+    config->layout.bank_tile_count;    // bank tiles
 
-  /* join all IPC objects for this frank instance */
-  ulong tile_cnt = tile_quic_idx1;
-  char const **     tile_name   = fd_alloca( alignof(char const *    ), sizeof(char const *    )*tile_cnt );
-  fd_cnc_t **       tile_cnc    = fd_alloca( alignof(fd_cnc_t *      ), sizeof(fd_cnc_t *      )*tile_cnt );
-  fd_frag_meta_t ** tile_mcache = fd_alloca( alignof(fd_frag_meta_t *), sizeof(fd_frag_meta_t *)*tile_cnt );
-  ulong **          tile_fseq   = fd_alloca( alignof(ulong *         ), sizeof(ulong *         )*tile_cnt );
-  if( FD_UNLIKELY( (!tile_name) | (!tile_cnc) | (!tile_mcache) | (!tile_fseq) ) ) FD_LOG_ERR(( "fd_alloca failed" )); /* paranoia */
+  ulong link_cnt =
+    config->layout.verify_tile_count + // quic <-> verify
+    config->layout.verify_tile_count + // verify <-> dedup
+    1 +                                // dedup <-> pack
+    config->layout.bank_tile_count;    // pack <-> bank
+
+  tile_t * tiles = fd_alloca( alignof(tile_t *), sizeof(tile_t)*tile_cnt );
+  link_t * links = fd_alloca( alignof(link_t *), sizeof(link_t)*link_cnt );
+  if( FD_UNLIKELY( (!tiles) | (!links)) ) FD_LOG_ERR(( "fd_alloca failed" )); /* paranoia */
 
   ulong tile_idx = 0;
+  ulong link_idx = 0;
   for( ulong j=0; j<config->shmem.workspaces_cnt; j++ ) {
     workspace_config_t * wksp = &config->shmem.workspaces[ j ];
     const uchar * pod = workspace_pod_join( config->name, wksp->name, wksp->kind_idx );
 
     char buf[ 64 ];
-#define FIND(kind) find_pod( config, kind, pods )
-#define IDX(fmt) snprintf1( buf, 64, fmt "%lu", wksp->kind_idx )
-
     switch( wksp->kind ) {
       case wksp_quic_verify:
+        for( ulong i=0; i<config->layout.verify_tile_count; i++ ) {
+          links[ link_idx ].src_name = "quic";
+          links[ link_idx ].dst_name = "verify";
+          links[ link_idx ].mcache = fd_mcache_join( fd_wksp_pod_map( pods[ j ], snprintf1( buf, 64, "mcache%lu", i ) ) );
+          if( FD_UNLIKELY( !links[ link_idx ].mcache ) ) FD_LOG_ERR(( "fd_mcache_join failed" ));
+          links[ link_idx ].fseq = fd_fseq_join( fd_wksp_pod_map( pods[ j ], snprintf1( buf, 64, "fseq%lu", i ) ) );
+          if( FD_UNLIKELY( !links[ link_idx ].fseq ) ) FD_LOG_ERR(( "fd_fseq_join failed" ));
+          link_idx++;
+        }
         break;
       case wksp_verify_dedup:
+        for( ulong i=0; i<config->layout.verify_tile_count; i++ ) {
+          links[ link_idx ].src_name = "verify";
+          links[ link_idx ].dst_name = "dedup";
+          links[ link_idx ].mcache = fd_mcache_join( fd_wksp_pod_map( pods[ j ], snprintf1( buf, 64, "mcache%lu", i ) ) );
+          if( FD_UNLIKELY( !links[ link_idx ].mcache ) ) FD_LOG_ERR(( "fd_mcache_join failed" ));
+          links[ link_idx ].fseq = fd_fseq_join( fd_wksp_pod_map( pods[ j ], snprintf1( buf, 64, "fseq%lu", i ) ) );
+          if( FD_UNLIKELY( !links[ link_idx ].fseq ) ) FD_LOG_ERR(( "fd_fseq_join failed" ));
+          link_idx++;
+        }
         break;
       case wksp_dedup_pack:
+        links[ link_idx ].src_name = "dedup";
+        links[ link_idx ].dst_name = "pack";
+        links[ link_idx ].mcache = fd_mcache_join( fd_wksp_pod_map( pods[ j ], "mcache" ) );
+        if( FD_UNLIKELY( !links[ link_idx ].mcache ) ) FD_LOG_ERR(( "fd_mcache_join failed" ));
+        links[ link_idx ].fseq = fd_fseq_join( fd_wksp_pod_map( pods[ j ], "fseq" ) );
+        if( FD_UNLIKELY( !links[ link_idx ].fseq ) ) FD_LOG_ERR(( "fd_fseq_join failed" ));
+        link_idx++;
         break;
       case wksp_pack_bank:
+        for( ulong i=0; i<config->layout.bank_tile_count; i++ ) {
+          links[ link_idx ].src_name = "pack";
+          links[ link_idx ].dst_name = "bank";
+          links[ link_idx ].mcache = fd_mcache_join( fd_wksp_pod_map( pods[ j ], snprintf1( buf, 64, "mcache%lu", i ) ) );
+          if( FD_UNLIKELY( !links[ link_idx ].mcache ) ) FD_LOG_ERR(( "fd_mcache_join failed" ));
+          links[ link_idx ].fseq = fd_fseq_join( fd_wksp_pod_map( pods[ j ], snprintf1( buf, 64, "fseq%lu", i ) ) );
+          if( FD_UNLIKELY( !links[ link_idx ].fseq ) ) FD_LOG_ERR(( "fd_fseq_join failed" ));
+          link_idx++;
+        }
+        break;
+      case wksp_bank_shred:
         break;
       case wksp_quic:
-        tile_name[ tile_idx ] = "quic";
-        tile_cnc [ tile_idx ] = fd_cnc_join( fd_wksp_pod_map( pod, "cnc" ) );
-        if( FD_UNLIKELY( !tile_cnc[tile_idx] ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
-        if( FD_UNLIKELY( fd_cnc_app_sz( tile_cnc[ tile_idx ] )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
-        tile_mcache[ tile_idx ] = fd_mcache_join( fd_wksp_pod_map( FIND(wksp_quic_verify), IDX("mcache") ) );
-        if( FD_UNLIKELY( !tile_mcache[ tile_idx ] ) ) FD_LOG_ERR(( "fd_mcache_join failed" ));
-        tile_fseq[ tile_idx ] = fd_fseq_join( fd_wksp_pod_map( FIND(wksp_quic_verify), IDX("fseq") ) );
-        if( FD_UNLIKELY( !tile_fseq[ tile_idx ] ) ) FD_LOG_ERR(( "fd_fseq_join failed" ));
+        tiles[ tile_idx ].name = "quic";
+        tiles[ tile_idx ].cnc = fd_cnc_join( fd_wksp_pod_map( pod, "cnc" ) );
+        if( FD_UNLIKELY( !tiles[ tile_idx ].cnc ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
+        if( FD_UNLIKELY( fd_cnc_app_sz( tiles[ tile_idx ].cnc )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
         tile_idx++;
         break;
       case wksp_verify:
-        tile_name[ tile_idx ] = "verify";
-        tile_cnc [ tile_idx ] = fd_cnc_join( fd_wksp_pod_map( pod, "cnc" ) );
-        if( FD_UNLIKELY( !tile_cnc[tile_idx] ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
-        if( FD_UNLIKELY( fd_cnc_app_sz( tile_cnc[ tile_idx ] )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
-        tile_mcache[ tile_idx ] = fd_mcache_join( fd_wksp_pod_map( FIND(wksp_verify_dedup), IDX("mcache") ) );
-        if( FD_UNLIKELY( !tile_mcache[ tile_idx ] ) ) FD_LOG_ERR(( "fd_mcache_join failed" ));
-        tile_fseq[ tile_idx ] = fd_fseq_join( fd_wksp_pod_map( FIND(wksp_verify_dedup), IDX("fseq") ) );
-        if( FD_UNLIKELY( !tile_fseq[ tile_idx ] ) ) FD_LOG_ERR(( "fd_fseq_join failed" ));
+        tiles[ tile_idx ].name = "verify";
+        tiles[ tile_idx ].cnc = fd_cnc_join( fd_wksp_pod_map( pod, "cnc" ) );
+        if( FD_UNLIKELY( !tiles[tile_idx].cnc ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
+        if( FD_UNLIKELY( fd_cnc_app_sz( tiles[ tile_idx ].cnc )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
         tile_idx++;
         break;
       case wksp_dedup:
-        tile_name[ tile_idx ] = "dedup";
-        tile_cnc[ tile_idx ] = fd_cnc_join( fd_wksp_pod_map( pod, "cnc" ) );
-        if( FD_UNLIKELY( !tile_cnc[ tile_idx ] ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
-        if( FD_UNLIKELY( fd_cnc_app_sz( tile_cnc[ tile_idx ] )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
-        tile_mcache[ tile_idx ] = fd_mcache_join( fd_wksp_pod_map( FIND(wksp_dedup_pack), "mcache" ) );
-        if( FD_UNLIKELY( !tile_mcache[ tile_idx ] ) ) FD_LOG_ERR(( "fd_mcache_join failed" ));
-        FD_LOG_INFO(( "joining firedancer.dedup.fseq" ));
-        tile_fseq[ tile_idx ] = fd_fseq_join( fd_wksp_pod_map( FIND(wksp_dedup_pack), "fseq" ) );
-        if( FD_UNLIKELY( !tile_fseq[ tile_idx ] ) ) FD_LOG_ERR(( "fd_fseq_join failed" ));
+        tiles[ tile_idx ].name = "dedup";
+        tiles[ tile_idx ].cnc = fd_cnc_join( fd_wksp_pod_map( pod, "cnc" ) );
+        if( FD_UNLIKELY( !tiles[ tile_idx ].cnc ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
+        if( FD_UNLIKELY( fd_cnc_app_sz( tiles[ tile_idx ].cnc )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
         tile_idx++;
         break;
       case wksp_pack:
-        tile_name[ tile_idx ] = "pack";
-        tile_cnc[ tile_idx ] = fd_cnc_join( fd_wksp_pod_map( pod, "cnc" ) );
-        if( FD_UNLIKELY( !tile_cnc[ tile_idx ] ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
-        if( FD_UNLIKELY( fd_cnc_app_sz( tile_cnc[ tile_idx ] )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
-        tile_mcache[ tile_idx ] = NULL; /* pack currently has no mcache */
-        // if( FD_UNLIKELY( !tile_mcache[ tile_idx ] ) ) FD_LOG_ERR(( "fd_mcache_join failed" ));
-        tile_fseq[ tile_idx ] = NULL; /* pack currently has no fseq */
-        // if( FD_UNLIKELY( !tile_fseq[ tile_idx ] ) ) FD_LOG_ERR(( "fd_fseq_join failed" ));
+        tiles[ tile_idx ].name = "pack";
+        tiles[ tile_idx ].cnc = fd_cnc_join( fd_wksp_pod_map( pod, "cnc" ) );
+        if( FD_UNLIKELY( !tiles[ tile_idx ].cnc ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
+        if( FD_UNLIKELY( fd_cnc_app_sz( tiles[ tile_idx ].cnc )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
+        tile_idx++;
+        break;
+      case wksp_bank:
+        tiles[ tile_idx ].name = "bank";
+        tiles[ tile_idx ].cnc = fd_cnc_join( fd_wksp_pod_map( pod, "cnc" ) );
+        if( FD_UNLIKELY( !tiles[ tile_idx ].cnc ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
+        if( FD_UNLIKELY( fd_cnc_app_sz( tiles[ tile_idx ].cnc )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
         tile_idx++;
         break;
     }
   }
 
+  FD_TEST( tile_idx == tile_cnt );
+  FD_TEST( link_idx == link_cnt );
+
   /* Setup local objects used by this app */
   fd_rng_t _rng[1];
   fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, seed, 0UL ) );
 
-  snap_t * snap_prv = (snap_t *)fd_alloca( alignof(snap_t), sizeof(snap_t)*2UL*tile_cnt );
-  if( FD_UNLIKELY( !snap_prv ) ) FD_LOG_ERR(( "fd_alloca failed" )); /* Paranoia */
-  snap_t * snap_cur = snap_prv + tile_cnt;
+  tile_snap_t * tile_snap_prv = (tile_snap_t *)fd_alloca( alignof(tile_snap_t), sizeof(tile_snap_t)*2UL*tile_cnt );
+  if( FD_UNLIKELY( !tile_snap_prv ) ) FD_LOG_ERR(( "fd_alloca failed" )); /* Paranoia */
+  tile_snap_t * tile_snap_cur = tile_snap_prv + tile_cnt;
+
+  link_snap_t * link_snap_prv = (link_snap_t *)fd_alloca( alignof(link_snap_t), sizeof(link_snap_t)*2UL*link_cnt );
+  if( FD_UNLIKELY( !link_snap_prv ) ) FD_LOG_ERR(( "fd_alloca failed" )); /* Paranoia */
+  link_snap_t * link_snap_cur = link_snap_prv + link_cnt;
 
   /* Get the inital reference diagnostic snapshot */
-  snap( tile_cnt, snap_prv, tile_cnc, tile_mcache, tile_fseq );
+  tile_snap( tile_snap_prv, tile_cnt, tiles );
+  link_snap( link_snap_prv, link_cnt, links );
   long then; long tic; fd_tempo_observe_pair( &then, &tic );
 
   /* Monitor for duration ns.  Note that for duration==0, this
      will still do exactly one pretty print. */
   FD_LOG_NOTICE(( "monitoring --dt-min %li ns, --dt-max %li ns, --duration %li ns, --seed %u", dt_min, dt_max, duration, seed ));
 
-  /* Setup TTY */
-  printf( TEXT_CUP_HOME );
-
   long stop = then + duration;
   if( duration == 0) stop = LONG_MAX;
+
+#define PRINT( ... ) do {                                                       \
+    int n = snprintf( buf, buf_sz, __VA_ARGS__ );                               \
+    if( FD_UNLIKELY( n<0 ) ) FD_LOG_ERR(( "snprintf failed" ));                 \
+    if( FD_UNLIKELY( (ulong)n>=buf_sz ) ) FD_LOG_ERR(( "snprintf truncated" )); \
+    buf += n; buf_sz -= (ulong)n;                                               \
+  } while(0)
+
+  write_stdout( TEXT_ALTBUF_ENABLE, sizeof(TEXT_ALTBUF_ENABLE)-1 );
+  write_stdout( TEXT_NOCURSOR, sizeof(TEXT_NOCURSOR)-1 );
 
   for(;;) {
     /* Wait a somewhat randomized amount and then make a diagnostic
        snapshot */
     fd_log_wait_until( then + dt_min + (long)fd_rng_ulong_roll( rng, 1UL+(ulong)(dt_max-dt_min) ) );
 
-    snap( tile_cnt, snap_cur, tile_cnc, tile_mcache, tile_fseq );
+    tile_snap( tile_snap_cur, tile_cnt, tiles );
+    link_snap( link_snap_cur, link_cnt, links );
     long now; long toc; fd_tempo_observe_pair( &now, &toc );
 
     /* Pretty print a comparison between this diagnostic snapshot and
@@ -303,73 +314,86 @@ run_monitor( config_t * const config,
     /* FIXME: CONSIDER INCLUDING TILE UPTIME */
     /* FIXME: CONSIDER ADDING INFO LIKE PID OF INSTANCE */
 
+    char * buf = buffer;
+    ulong buf_sz = FD_MONITOR_TEXT_BUF_SZ;
+
     char now_cstr[ FD_LOG_WALLCLOCK_CSTR_BUF_SZ ];
-    printf( "snapshot for %s" TEXT_NEWLINE, fd_log_wallclock_cstr( now, now_cstr ) );
-    printf( "  tile |      stale | heart |        sig | in backp |           backp cnt |         sv_filt cnt |                    tx seq |                    rx seq"  TEXT_NEWLINE );
-    printf( "-------+------------+-------+------------+----------+---------------------+---------------------+---------------------------+---------------------------" TEXT_NEWLINE );
+    PRINT( "snapshot for %s" TEXT_NEWLINE, fd_log_wallclock_cstr( now, now_cstr ) );
+    PRINT( "   tile |      stale | heart |        sig | in backp |           backp cnt |         sv_filt cnt " TEXT_NEWLINE );
+    PRINT( "--------+------------+-------+------------+----------+---------------------+---------------------" TEXT_NEWLINE );
     for( ulong tile_idx=0UL; tile_idx<tile_cnt; tile_idx++ ) {
-      snap_t * prv = &snap_prv[ tile_idx ];
-      snap_t * cur = &snap_cur[ tile_idx ];
-      printf( " %5s", tile_name[ tile_idx ] );
-      if( FD_LIKELY( cur->pmap & 1UL ) ) {
-        printf( " | " ); printf_stale   ( (long)(0.5+ns_per_tic*(double)(toc - cur->cnc_heartbeat)), dt_min );
-        printf( " | " ); printf_heart   ( cur->cnc_heartbeat,        prv->cnc_heartbeat        );
-        printf( " | " ); printf_sig     ( cur->cnc_signal,           prv->cnc_signal           );
-        printf( " | " ); printf_err_bool( cur->cnc_diag_in_backp,    prv->cnc_diag_in_backp    );
-        printf( " | " ); printf_err_cnt ( cur->cnc_diag_backp_cnt,   prv->cnc_diag_backp_cnt   );
-        printf( " | " ); printf_err_cnt ( cur->cnc_diag_sv_filt_cnt, prv->cnc_diag_sv_filt_cnt );
-      } else {
-        printf(       " |          - |     - |          - |        - |                   -" );
-      }
-      if( FD_LIKELY( cur->pmap & 2UL ) ) {
-        printf( " | " ); printf_seq( cur->mcache_seq, prv->mcache_seq );
-      } else {
-        printf( " |                         -" );
-      }
-      if( FD_LIKELY( cur->pmap & 4UL ) ) {
-        printf( " | " ); printf_seq( cur->fseq_seq, prv->fseq_seq );
-      } else {
-        printf( " |                         -" );
-      }
-      printf( TEXT_NEWLINE );
+      tile_snap_t * prv = &tile_snap_prv[ tile_idx ];
+      tile_snap_t * cur = &tile_snap_cur[ tile_idx ];
+      PRINT( " %6s", tiles[ tile_idx ].name );
+      PRINT( " | " ); printf_stale   ( &buf, &buf_sz, (long)(0.5+ns_per_tic*(double)(toc - cur->cnc_heartbeat)), 1e8 /* 100 millis */ );
+      PRINT( " | " ); printf_heart   ( &buf, &buf_sz, cur->cnc_heartbeat,        prv->cnc_heartbeat        );
+      PRINT( " | " ); printf_sig     ( &buf, &buf_sz, cur->cnc_signal,           prv->cnc_signal           );
+      PRINT( " | " ); printf_err_bool( &buf, &buf_sz, cur->cnc_diag_in_backp,    prv->cnc_diag_in_backp    );
+      PRINT( " | " ); printf_err_cnt ( &buf, &buf_sz, cur->cnc_diag_backp_cnt,   prv->cnc_diag_backp_cnt   );
+      PRINT( " | " ); printf_err_cnt ( &buf, &buf_sz, cur->cnc_diag_sv_filt_cnt, prv->cnc_diag_sv_filt_cnt );
+      PRINT( TEXT_NEWLINE );
     }
-    printf( TEXT_NEWLINE );
-    printf( "          link |  tot TPS |  tot bps | uniq TPS | uniq bps |   ha tr%% | uniq bw%% | filt tr%% | filt bw%% |           ovrnp cnt |           ovrnr cnt |            slow cnt" TEXT_NEWLINE );
-    printf( "---------------+----------+----------+----------+----------+----------+----------+-----------+----------+---------------------+---------------------+---------------------"    TEXT_NEWLINE );
+    PRINT( TEXT_NEWLINE );
+    PRINT( "           link |  tot TPS |  tot bps | uniq TPS | uniq bps |   ha tr%% | uniq bw%% | filt tr%% | filt bw%% |           ovrnp cnt |           ovrnr cnt |            slow cnt" TEXT_NEWLINE );
+    PRINT( "----------------+----------+----------+----------+----------+----------+----------+----------+----------+---------------------+---------------------+---------------------"    TEXT_NEWLINE );
     long dt = now-then;
-    for( ulong i=0; i<config->layout.verify_tile_count; i++ ) {
-      printf_link( snap_prv, snap_cur, tile_name, tile_quic_idx0+i, tile_verify_idx0+i, dt );
+    for( ulong link_idx=0UL; link_idx<link_cnt; link_idx++ ) {
+      link_snap_t * prv = &link_snap_prv[ link_idx ];
+      link_snap_t * cur = &link_snap_cur[ link_idx ];
+      PRINT( " %6s->%-6s", links[ link_idx ].src_name, links[ link_idx ].dst_name );
+      ulong cur_raw_cnt = /* cur->cnc_diag_ha_filt_cnt + */ cur->fseq_diag_tot_cnt;
+      ulong cur_raw_sz  = /* cur->cnc_diag_ha_filt_sz  + */ cur->fseq_diag_tot_sz;
+      ulong prv_raw_cnt = /* prv->cnc_diag_ha_filt_cnt + */ prv->fseq_diag_tot_cnt;
+      ulong prv_raw_sz  = /* prv->cnc_diag_ha_filt_sz  + */ prv->fseq_diag_tot_sz;
+
+      PRINT( " | " ); printf_rate( &buf, &buf_sz, 1e9, 0., cur_raw_cnt,             prv_raw_cnt,             dt );
+      PRINT( " | " ); printf_rate( &buf, &buf_sz, 8e9, 0., cur_raw_sz,              prv_raw_sz,              dt ); /* Assumes sz incl framing */
+      PRINT( " | " ); printf_rate( &buf, &buf_sz, 1e9, 0., cur->fseq_diag_tot_cnt,  prv->fseq_diag_tot_cnt,  dt );
+      PRINT( " | " ); printf_rate( &buf, &buf_sz, 8e9, 0., cur->fseq_diag_tot_sz,   prv->fseq_diag_tot_sz,   dt ); /* Assumes sz incl framing */
+
+      PRINT( " | " ); printf_pct ( &buf, &buf_sz, cur->fseq_diag_tot_cnt,  prv->fseq_diag_tot_cnt, 0.,
+                                   cur_raw_cnt,             prv_raw_cnt,            DBL_MIN );
+      PRINT( " | " ); printf_pct ( &buf, &buf_sz, cur->fseq_diag_tot_sz,   prv->fseq_diag_tot_sz,  0.,
+                                   cur_raw_sz,              prv_raw_sz,             DBL_MIN ); /* Assumes sz incl framing */
+      PRINT( " | " ); printf_pct ( &buf, &buf_sz, cur->fseq_diag_filt_cnt, prv->fseq_diag_filt_cnt, 0.,
+                                   cur->fseq_diag_tot_cnt,  prv->fseq_diag_tot_cnt,  DBL_MIN );
+      PRINT( " | " ); printf_pct ( &buf, &buf_sz, cur->fseq_diag_filt_sz,  prv->fseq_diag_filt_sz, 0.,
+                                   cur->fseq_diag_tot_sz,   prv->fseq_diag_tot_sz,  DBL_MIN ); /* Assumes sz incl framing */
+
+      PRINT( " | " ); printf_err_cnt( &buf, &buf_sz, cur->fseq_diag_ovrnp_cnt, prv->fseq_diag_ovrnp_cnt );
+      PRINT( " | " ); printf_err_cnt( &buf, &buf_sz, cur->fseq_diag_ovrnr_cnt, prv->fseq_diag_ovrnr_cnt );
+      PRINT( " | " ); printf_err_cnt( &buf, &buf_sz, cur->fseq_diag_slow_cnt,  prv->fseq_diag_slow_cnt  );
+      PRINT( TEXT_NEWLINE );
     }
-    for( ulong tile_idx=tile_verify_idx0; tile_idx<tile_verify_idx1; tile_idx++ ) {
-      printf_link( snap_prv, snap_cur, tile_name, tile_idx, tile_dedup_idx, dt );
+
+    if( FD_UNLIKELY( stop1 || (now-stop)>=0L ) ) {
+      /* Stop once we've been monitoring for duration ns */
+      write_stdout( TEXT_ALTBUF_DISABLE, sizeof(TEXT_ALTBUF_DISABLE)-1 );
+      write_stdout( buffer, sizeof(buffer) - buf_sz );
+      write_stdout( TEXT_CURSOR, sizeof(TEXT_CURSOR)-1 );
+      break;
     }
-    printf_link( snap_prv, snap_cur, tile_name, tile_dedup_idx, tile_pack_idx, dt );
-    printf( TEXT_NEWLINE );
 
-    /* Switch to alternate screen and erase junk below
-       TODO ideally we'd have the last iteration on the main buffer and only the rest on ALTBUF */
-
-    printf( TEXT_ALTBUF_ENABLE
-            TEXT_ED
-            TEXT_CUP_HOME );
-
-    /* Stop once we've been monitoring for duration ns */
-
-    if( FD_UNLIKELY( (now-stop)>=0L ) ) break;
+    /* clear terminal and write new buffer */
+    write_stdout( TEXT_ED
+                  TEXT_CUP_HOME,
+                  sizeof(TEXT_ED)-1
+                  + sizeof(TEXT_CUP_HOME)-1 );
+    write_stdout( buffer, sizeof(buffer) - buf_sz );
 
     /* Still more monitoring to do ... wind up for the next iteration by
        swaping the two snap arrays. */
 
     then = now; tic = toc;
-    snap_t * tmp = snap_prv; snap_prv = snap_cur; snap_cur = tmp;
+    tile_snap_t * tmp = tile_snap_prv; tile_snap_prv = tile_snap_cur; tile_snap_cur = tmp;
+    link_snap_t * tmp2 = link_snap_prv; link_snap_prv = link_snap_cur; link_snap_cur = tmp2;
   }
 }
 
 static void
 signal1( int sig ) {
   (void)sig;
-  printf( TEXT_ALTBUF_DISABLE );
-  exit_group( 0 );
+  stop1 = 1;
 }
 
 void
@@ -392,10 +416,12 @@ monitor_cmd_fn( args_t *         args,
     FD_LOG_ERR(( "sigaction(SIGINT) failed (%i-%s)", errno, strerror( errno ) ));
 
   long allow_syscalls[] = {
-    __NR_write,       /* logging */
-    __NR_nanosleep,   /* fd_log_wait_until */
-    __NR_sched_yield, /* fd_log_wait_until */
-    __NR_exit_group,  /* exit process */
+    __NR_write,        /* logging */
+    __NR_fsync,        /* logging, WARNING and above fsync immediately */
+    __NR_nanosleep,    /* fd_log_wait_until */
+    __NR_sched_yield,  /* fd_log_wait_until */
+    __NR_exit_group,   /* exit process */
+    __NR_rt_sigreturn, /* return from signal handler */
   };
 
   int allow_fds[] = {
@@ -421,6 +447,5 @@ monitor_cmd_fn( args_t *         args,
                args->monitor.seed,
                args->monitor.ns_per_tic );
 
-  printf( TEXT_ALTBUF_DISABLE );
   exit_group( 0 );
 }


### PR DESCRIPTION
Various issues with the monitor are fixed, including,

 * It would write to the terminal unbuffered using printf, which is slow but also would cause screen tearing. Switched to use a full size buffer for output. This also fixed the issues with xterm so it no longer flickers.

 * Fixed Ctrl+C to leave a clean terminal behind with just one buffer of output.

 * Removed cursor while drawing to prevent it blinking around randomly.

 * Increased default refresh rate 10x.

 * Tidied up the code structure to have `tile_t` and `link_t` types for the two output formats. Tiles no longer dump information that really belongs to links (in seq, out seq), since a tile can have multiple in/out links now it doesn't make sense.

 * Reworked the IPC object finding to be much cleaner using the workspace definitions in the config object.

 * Fixed up some of the alignment and formatting issues with the output.

 * Fixed some crashes related the seccomp filter.