### PR TITLE
fdctl: fix some valgrind issues

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -293,16 +293,11 @@ replace( char *       in,
     if( FD_UNLIKELY( total_len >= PATH_MAX ) )
       FD_LOG_ERR(( "configuration scratch directory path too long: `%s`", in ));
 
-    uchar after[PATH_MAX];
-    fd_memcpy( after, replace + pat_len, strlen( replace + pat_len ) );
+    fd_memcpy( replace + pat_len, replace + sub_len, in_len - (ulong)( replace - in ) - sub_len + 1 );
     fd_memcpy( replace, sub, sub_len );
-    ulong after_len = strlen( ( const char * ) after );
-    fd_memcpy( replace + sub_len, after, after_len );
     in[ total_len ] = '\0';
   }
 }
-
-
 
 static void
 config_parse_array( config_t * config,
@@ -374,7 +369,7 @@ config_parse_line( uint       lineno,
 static void
 config_parse1( const char * config,
                config_t *   out ) {
-  char section[ 4096 ];
+  char section[ 4096 ] = {0};
   char key[ 4096 ];
   uint lineno = 0;
   int in_array = 0;
@@ -407,7 +402,7 @@ config_parse_file( const char * path,
   char line[ 4096 ];
   char key[ 4096 ];
   int in_array = 0;
-  char section[ 4096 ];
+  char section[ 4096 ] = {0};
   while( FD_LIKELY( fgets( line, 4096, fp ) ) ) {
     lineno++;
     ulong len = strlen( line );

--- a/src/app/fdctl/main.c
+++ b/src/app/fdctl/main.c
@@ -38,7 +38,9 @@ main1( int     argc,
 
   /* check if we are appropriate permissioned to run the desired command */
   if( FD_LIKELY( action->perm ) ) {
-    security_t security;
+    security_t security = {
+      .idx = 0,
+    };
     action->perm( &args, &security, &config );
     if( FD_UNLIKELY( security.idx ) ) {
       for( ulong i=0; i<security.idx; i++ ) FD_LOG_WARNING(( "%s", security.errors[ i ] ));

--- a/src/app/fddev/main.c
+++ b/src/app/fddev/main.c
@@ -74,6 +74,8 @@ main( int     argc,
   if( config.is_live_cluster )
     FD_LOG_ERR(( "fddev is for development and test environments but your configuration "
                  "targets a live cluster. use fdctl if this is a production environment" ));
+  int no_sandbox = fd_env_strip_cmdline_contains( &argc, &argv, "--no-sandbox" );
+  config.development.sandbox = config.development.sandbox && !no_sandbox;
 
   const char * action_name = "dev";
   if( FD_UNLIKELY( argc > 0 && argv[ 0 ][ 0 ] != '-' ) ) {
@@ -103,7 +105,9 @@ main( int     argc,
 
   /* check if we are appropriate permissioned to run the desired command */
   if( FD_LIKELY( action->perm ) ) {
-    security_t security;
+    security_t security = {
+      .idx = 0,
+    };
     action->perm( &args, &security, &config );
     if( FD_UNLIKELY( security.idx ) ) {
       execve_as_root( orig_argc, orig_argv );


### PR DESCRIPTION
A few uninitialized values that were getting used. Also plumbed --no-sandbox through to not create PID namespaces to make debugging easier.