### PR TITLE
fdctl: add combined run and monitor command

### DIFF
--- a/config/everything.mk
+++ b/config/everything.mk
@@ -84,7 +84,7 @@ check-lint:
 ifeq (run,$(firstword $(MAKECMDGOALS)))
   RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
   ifeq ($(RUN_ARGS),)
-    RUN_ARGS := dev
+    RUN_ARGS := dev --monitor
   endif
   $(eval $(RUN_ARGS):;@:)
 endif
@@ -94,7 +94,7 @@ endif
 cargo:
 
 solana/target/release/libsolana_validator_fd.a: cargo
-	cd ./solana && ./cargo build --release -p solana-validator-fd
+	cd ./solana && env --unset=LDFLAGS ./cargo build --release -p solana-validator-fd
 
 $(OBJDIR)/lib/libsolana_validator_fd.a: solana/target/release/libsolana_validator_fd.a
 	$(MKDIR) $(dir $@) && cp solana/target/release/libsolana_validator_fd.a $@

--- a/src/app/fdctl/fdctl.h
+++ b/src/app/fdctl/fdctl.h
@@ -21,6 +21,7 @@ typedef union {
     long duration;
     uint seed;
     double ns_per_tic;
+    int drain_output_fd;
   } monitor;
   struct {
     int                      command;
@@ -29,6 +30,9 @@ typedef union {
   struct {
     int tile;
   } run1;
+  struct {
+    int monitor;
+  } dev;
 } args_t;
 
 typedef struct security security_t;

--- a/src/app/fdctl/monitor/helper.h
+++ b/src/app/fdctl/monitor/helper.h
@@ -5,15 +5,10 @@
 
 /* TEXT_* are quick-and-dirty color terminal hacks.  Probably should
    do something more robust longer term. */
-#define TEXT_ALTBUF_ENABLE  "\033[?1049h"
-#define TEXT_ALTBUF_DISABLE "\033[?1049l"
-#define TEXT_CUP_HOME       "\033[H"
-#define TEXT_ED             "\033[J"
-#define TEXT_EL             "\033[K"
-#define TEXT_NEWLINE         TEXT_EL "\n"
-
-#define TEXT_NOCURSOR "\033[?25l"
-#define TEXT_CURSOR   "\033[?25h"
+#define TEXT_NOCURSOR   "\033[?25l"
+#define TEXT_CURSOR     "\033[?25h"
+#define TEXT_ERASE_LINE "\033[0K"
+#define TEXT_NEWLINE    TEXT_ERASE_LINE "\n"
 
 #define TEXT_NORMAL "\033[0m"
 #define TEXT_BLUE   "\033[34m"

--- a/src/app/fdctl/run.c
+++ b/src/app/fdctl/run.c
@@ -387,6 +387,10 @@ main_pid_namespace( void * args ) {
      bringing all of our processes down as a group. */
   int wstatus;
   pid_t exited_pid = wait4( -1, &wstatus, (int)__WCLONE, NULL );
+  if( FD_UNLIKELY( exited_pid == -1 ) ) {
+    fd_log_private_fprintf_0( STDERR_FILENO, "wait4() failed (%i-%s)", errno, strerror( errno ) );
+    exit_group( 1 );
+  }
 
   char * name = "unknown";
   ulong tile_idx = ULONG_MAX;

--- a/src/app/fddev/dev.c
+++ b/src/app/fddev/dev.c
@@ -7,7 +7,15 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <sched.h>
+#include <fcntl.h>
 #include <sys/wait.h>
+
+void
+dev_cmd_args( int *    pargc,
+              char *** pargv,
+              args_t * args ) {
+  args->dev.monitor = fd_env_strip_cmdline_contains( pargc, pargv, "--monitor" );
+}
 
 void
 dev_cmd_perm( args_t *         args,
@@ -27,11 +35,36 @@ dev_cmd_perm( args_t *         args,
   run_cmd_perm( NULL, security, config );
 }
 
+pid_t firedancer_pid, monitor_pid;
+extern char fd_log_private_path[ 1024 ]; /* empty string on start */
+
+static void
+parent_signal( int sig ) {
+  (void)sig;
+  int err = 0;
+  if( FD_LIKELY( firedancer_pid ) )
+    if( kill( firedancer_pid, SIGINT ) ) err = 1;
+  if( FD_LIKELY( monitor_pid ) )
+    if( kill( monitor_pid, SIGKILL ) ) err = 1;
+  fd_log_private_fprintf_0( STDERR_FILENO, "Log at \"%s\"\n", fd_log_private_path );
+  exit_group( err );
+}
+
+static void
+install_parent_signals( void ) {
+  struct sigaction sa = {
+    .sa_handler = parent_signal,
+    .sa_flags   = 0,
+  };
+  if( FD_UNLIKELY( sigaction( SIGTERM, &sa, NULL ) ) )
+    FD_LOG_ERR(( "sigaction(SIGTERM) failed (%i-%s)", errno, strerror( errno ) ));
+  if( FD_UNLIKELY( sigaction( SIGINT, &sa, NULL ) ) )
+    FD_LOG_ERR(( "sigaction(SIGINT) failed (%i-%s)", errno, strerror( errno ) ));
+}
+
 void
 dev_cmd_fn( args_t *         args,
             config_t * const config ) {
-  (void)args;
-
   args_t configure_args = {
     .configure.command = CONFIGURE_CMD_INIT,
   };
@@ -54,5 +87,59 @@ dev_cmd_fn( args_t *         args,
     leave_network_namespace();
   }
 
-  run_firedancer( config );
+  if( FD_LIKELY( !args->dev.monitor ) ) run_firedancer( config );
+  else {
+    install_parent_signals();
+
+    int pipefd[2];
+    if( FD_UNLIKELY( pipe2( pipefd, O_NONBLOCK ) ) ) FD_LOG_ERR(( "pipe2() failed (%d-%s)", errno, strerror( errno ) ));
+
+    firedancer_pid = fork();
+    if( !firedancer_pid ) {
+      if( FD_UNLIKELY( close( pipefd[0] ) ) ) FD_LOG_ERR(( "close() failed (%d-%s)", errno, strerror( errno ) ));
+      if( FD_UNLIKELY( dup2( pipefd[1], STDERR_FILENO ) == -1 ) ) FD_LOG_ERR(( "dup2() failed (%d-%s)", errno, strerror( errno ) ));
+      if( FD_UNLIKELY( close( pipefd[1] ) ) ) FD_LOG_ERR(( "close() failed (%d-%s)", errno, strerror( errno ) ));
+      if( FD_UNLIKELY( setenv( "RUST_LOG_STYLE", "always", 1 ) ) ) /* otherwise RUST_LOG will not be colorized to the pipe */
+        FD_LOG_ERR(( "setenv() failed (%d-%s)", errno, strerror( errno ) ));
+      run_firedancer( config );
+    } else {
+      if( FD_UNLIKELY( close( pipefd[1] ) ) ) FD_LOG_ERR(( "close() failed (%d-%s)", errno, strerror( errno ) ));
+    }
+
+    args_t monitor_args;
+    int argc = 0;
+    char * argv[] = { NULL };
+    char ** pargv = (char**)argv;
+    monitor_cmd_args( &argc, &pargv, &monitor_args );
+    monitor_args.monitor.drain_output_fd = pipefd[0];
+
+    monitor_pid = fork();
+    if( !monitor_pid ) monitor_cmd_fn( &monitor_args, config );
+    if( FD_UNLIKELY( close( pipefd[0] ) ) ) FD_LOG_ERR(( "close() failed (%d-%s)", errno, strerror( errno ) ));
+
+    int wstatus;
+    pid_t exited_pid = wait4( -1, &wstatus, (int)__WALL, NULL );
+    if( FD_UNLIKELY( exited_pid == -1 ) ) {
+      fd_log_private_fprintf_0( STDERR_FILENO, "wait4() failed (%i-%s)", errno, strerror( errno ) );
+      exit_group( 1 );
+    }
+
+    char * exited_child = exited_pid == firedancer_pid ? "firedancer" : exited_pid == monitor_pid ? "monitor" : "unknown";
+    int exit_code = 0;
+    if( FD_UNLIKELY( !WIFEXITED( wstatus ) ) ) {
+      FD_LOG_ERR(( "%s exited unexpectedly with signal %d (%s)", exited_child, WTERMSIG( wstatus ), strsignal( WTERMSIG( wstatus ) ) ));
+      exit_code = WTERMSIG( wstatus );
+    } else {
+      FD_LOG_ERR(( "%s exited unexpectedly with code %d", exited_child, WEXITSTATUS( wstatus ) ));
+      if( FD_UNLIKELY( exited_pid == monitor_pid && !WEXITSTATUS( wstatus ) ) ) exit_code = EXIT_FAILURE;
+      else exit_code = WEXITSTATUS( wstatus );
+    }
+
+    if( FD_UNLIKELY( exited_pid == monitor_pid ) ) {
+      if( FD_UNLIKELY( kill( firedancer_pid, SIGKILL ) ) ) FD_LOG_ERR(( "failed to kill all processes (%d-%s)", errno, strerror( errno ) ));
+    } else {
+      if( FD_UNLIKELY( kill( monitor_pid, SIGKILL ) ) ) FD_LOG_ERR(( "failed to kill all processes (%d-%s)", errno, strerror( errno ) ));
+    }
+    exit_group( exit_code );
+  }
 }

--- a/src/app/fddev/fddev.h
+++ b/src/app/fddev/fddev.h
@@ -4,6 +4,11 @@
 #include "../fdctl/fdctl.h"
 
 void
+dev_cmd_args( int *    pargc,
+              char *** pargv,
+              args_t * args );
+
+void
 dev_cmd_perm( args_t *         args,
               security_t *     security,
               config_t * const config );

--- a/src/app/fddev/main.c
+++ b/src/app/fddev/main.c
@@ -8,7 +8,7 @@
 #include <sys/stat.h>
 
 static action_t DEV_ACTIONS[] = {
-  { .name = "dev",  .args = NULL,          .fn = dev_cmd_fn,  .perm = dev_cmd_perm },
+  { .name = "dev",  .args = dev_cmd_args,  .fn = dev_cmd_fn,  .perm = dev_cmd_perm },
   { .name = "dev1", .args = dev1_cmd_args, .fn = dev1_cmd_fn, .perm = dev_cmd_perm },
 };
 


### PR DESCRIPTION
`fddev dev` gets an argument `--monitor` which combines both running and monitoring in one command. Basically, it spawns them each in a separate process, and wires stdout from Firedancer to a pipe in the monitor so the log messages can be cleanly written between output refreshes.