### PR TITLE
Wksp checkpt / restore support

### DIFF
--- a/config/linux_clang_minimal.mk
+++ b/config/linux_clang_minimal.mk
@@ -9,5 +9,5 @@ include config/with-optimization.mk
 # Turn on POSIX style logging in this target to facilitate
 # cross-platform development
 
-CPPFLAGS+=-DFD_ENV_STYLE=0 -DFD_LOG_STYLE=0
+CPPFLAGS+=-DFD_ENV_STYLE=0 -DFD_IO_STYLE=0 -DFD_LOG_STYLE=0 -D_XOPEN_SOURCE=700
 

--- a/config/linux_gcc_minimal.mk
+++ b/config/linux_gcc_minimal.mk
@@ -9,5 +9,5 @@ include config/with-optimization.mk
 # Turn on POSIX style logging in this target to facilitate
 # cross-platform development
 
-CPPFLAGS+=-DFD_ENV_STYLE=0 -DFD_LOG_STYLE=0
+CPPFLAGS+=-DFD_ENV_STYLE=0 -DFD_IO_STYLE=0 -DFD_LOG_STYLE=0 -D_XOPEN_SOURCE=700
 

--- a/config/with-extra-brutality.mk
+++ b/config/with-extra-brutality.mk
@@ -12,5 +12,6 @@ CPPFLAGS+=-Wsuggest-attribute=pure
 CPPFLAGS+=-Wsuggest-attribute=const
 CPPFLAGS+=-Wsuggest-attribute=noreturn
 CPPFLAGS+=-Wsuggest-attribute=format
+CPPFLAGS+=-fdiagnostics-color=always
 
 endif

--- a/src/util/alloc/test_alloc_ctl
+++ b/src/util/alloc/test_alloc_ctl
@@ -2,6 +2,7 @@
 
 fail() {
   echo FAIL: "$1" unexpected exit code "$2"
+  "$BIN"/fd_wksp_ctl delete "$WKSP" > /dev/null 2>&1
   echo Log N/A
   exit 1
 }
@@ -118,6 +119,7 @@ ALLOC=$("$BIN"/fd_alloc_ctl tag "$TAG_META" new "$WKSP" "$TAG_ALLOC" || fail new
 "$BIN"/fd_alloc_ctl delete "$ALLOC" 1 || fail query $?
 "$BIN"/fd_alloc_ctl delete "$ALLOC" 1 && fail query $?
 
+"$BIN"/fd_wksp_ctl delete "$WKSP" > /dev/null 2>&1
 echo Log N/A
 echo pass
 exit 0

--- a/src/util/fd_util.h
+++ b/src/util/fd_util.h
@@ -6,9 +6,10 @@
 //#include "sanitize/fd_asan.h"     /* includes fd_util_base.h" */
 //#include "sanitize/fd_sanitize.h" /* includes sanitize/fd_asan.h */
 //#include "cstr/fd_cstr.h"         /* includes bits/fd_bits.h */
+//#include "io/fd_io.h"             /* includes bits/fd_bits.h */
 //#include "pod/fd_pod.h"           /* includes cstr/fd_cstr.h */
 //#include "env/fd_env.h"           /* includes cstr/fd_cstr.h */
-//#include "log/fd_log.h"           /* includes env/fd_env.h */
+//#include "log/fd_log.h"           /* includes env/fd_env.h io/fd_io.h */
 //#include "shmem/fd_shmem.h"       /* includes log/fd_log.h */
 //#include "tile/fd_tile.h"         /* includes shmem/fd_shmem.h */
 //#include "wksp/fd_wksp.h"         /* includes shmem/fd_shmem.h pod/fd_pod.h */
@@ -171,6 +172,13 @@ FD_PROTOTYPES_BEGIN
        not provided, defaults to 0.  This is stripped but otherwise
        ignored on targets where the underlying OS assigns this (e.g. the
        tid of the process containing the caller).
+
+     --log-user-id [ulong] / FD_LOG_USER_ID=[ulong]
+
+       Provides the user id of the user responsible for the caller.  If
+       not provided, defaults to 0.  This is stripped but otherwise
+       ignored on targets where an underlying OS assigns this (e.g. the
+       user ID of the person who started the caller's process).
 
      --log-user [cstr] / FD_LOG_USER=[cstr]
 

--- a/src/util/io/Local.mk
+++ b/src/util/io/Local.mk
@@ -1,0 +1,4 @@
+$(call add-hdrs,fd_io.h)
+$(call add-objs,fd_io,fd_util)
+$(call make-unit-test,test_io,test_io,fd_util)
+$(call run-unit-test,test_io,)

--- a/src/util/io/fd_io.c
+++ b/src/util/io/fd_io.c
@@ -1,0 +1,412 @@
+#include "fd_io.h"
+
+/* TODO: try to eliminate use of FD_LOG_STYLE in log if possible in
+   favor of FD_IO_STYLE here. */
+
+#ifndef FD_IO_STYLE
+#if FD_HAS_HOSTED
+#define FD_IO_STYLE 0
+#else
+#error "Define FD_IO_STYLE for this platform"
+#endif
+#endif
+
+#if FD_IO_STYLE==0 /* POSIX style */
+
+#include <errno.h>
+#include <unistd.h>
+
+int
+fd_io_read( int     fd,
+            void *  _dst,
+            ulong   dst_min,
+            ulong   dst_max,
+            ulong * _dst_sz ) {
+
+  uchar * dst = (uchar *)_dst;
+
+  ulong dst_sz = 0UL;
+  do {
+
+    /* Note: POSIX indicates read with sz larger than SSIZE_MAX (which
+       is the same as LONG_MAX here) is IB.  While this is an
+       impractically large value nowadays, we don't take chances. */
+
+    long  ssz = read( fd, dst+dst_sz, fd_ulong_min( dst_max-dst_sz, (ulong)LONG_MAX ) );
+    ulong rsz = (ulong)ssz;
+
+    if( FD_UNLIKELY( !((0L<ssz) & (rsz<=(dst_max-dst_sz))) ) ) {
+
+      /* At this point, ssz is not in [1,dst_max-dst_sz] */
+
+      if( FD_LIKELY( !ssz ) ) { /* hit EOF */
+        *_dst_sz = dst_sz;
+        return -1;
+      }
+
+      /* At this point, ssz is not in [0,dst_max-dst_sz].  Thus, ssz
+         should be -1 and errno should be set.  If errno is set to
+         EAGAIN, it appears that fd is configured as non-blocking and,
+         because we have not yet read dst_min, we try again.  Because of
+         glitches in the POSIX spec, read is also allowed to use
+         EWOULDBLOCK for this and EWOULDBLOCK is not required to have
+         the same value as EAGAIN (if EAGAIN==EWOULDBLOCK on the target,
+         the compiler will almost certainly optimize out the unnecessary
+         cmov). */
+
+      int err = errno;
+      if( err==EWOULDBLOCK ) err = EAGAIN; /* cmov / no-op */
+      if( FD_UNLIKELY( (dst_sz<dst_min) & (err==EAGAIN) ) ) continue;
+
+      /* At this point, ssz is not in [0,dst_max-dst_sz].  ssz should be
+         -1 and errno set (and not EWOULDBLOCK).  If not, read does not
+         seem to be following POSIX and we flag such as EPROTO (which
+         should not be used as an errno case for read above and is at
+         least suggestive of the issue) to make a strong guarantee to
+         the caller. */
+
+      if( !err ) err = EPROTO; /* cmov */
+      *_dst_sz = 0UL;
+      return err;
+    }
+
+    /* At this point, rsz is in [1,dst_max-dst_sz] */
+
+    dst_sz += rsz;
+  } while( dst_sz<dst_min );
+
+  *_dst_sz = dst_sz;
+  return 0;
+}
+
+int
+fd_io_write( int          fd,
+             void const * _src,
+             ulong        src_min,
+             ulong        src_max,
+             ulong *      _src_sz ) {
+
+  /* Note: this is virtually identical to read.  See read for more
+     details. */
+
+  uchar const * src = (uchar const *)_src;
+
+  ulong src_sz = 0UL;
+  do {
+
+    long  ssz = write( fd, src+src_sz, fd_ulong_min( src_max-src_sz, (ulong)LONG_MAX ) );
+    ulong wsz = (ulong)ssz;
+
+    if( FD_UNLIKELY( !((0L<ssz) & (wsz<=(src_max-src_sz))) ) ) {
+
+      /* Note: The POSIX spec explicitly indicates _reads_ use ssz
+         -1 and errno EAGAIN/EWOULDBLOCK for no-data-available-now and
+         ssz 0 for end-of-file to explicitly disambiguate these cases.
+         It also specifically indicates that _writes_ follow the same
+         convention to keep read and write call return handling similar
+         even though there is no POSIX concept of an end-of-file for
+         writes.  At the same time, there seem to be no cases in the
+         standard where a write with a positive size (as it is above)
+         should return 0.  So, we skip "EOF" handling here.  If a zero
+         ssz unexpectedly occurs, it will be likely be treated as an
+         EPROTO below. */
+
+#     if 0
+      if( FD_UNLIKELY( !ssz ) ) {
+        *_src_sz = src_sz;
+        return -1;
+      }
+#     endif
+
+      int err = errno;
+      if( err==EWOULDBLOCK ) err = EAGAIN;
+      if( FD_UNLIKELY( (src_sz<src_min) & (err==EAGAIN) ) ) continue;
+
+      if( !err ) err = EPROTO;
+      *_src_sz = 0UL;
+      return err;
+    }
+
+    src_sz += wsz;
+  } while( src_sz<src_min );
+
+  *_src_sz = src_sz;
+  return 0;
+}
+
+int
+fd_io_buffered_read( int     fd,
+                     void *  _dst,
+                     ulong   dst_sz,
+                     void *  _rbuf,
+                     ulong   rbuf_sz,
+                     ulong * _rbuf_lo,
+                     ulong * _rbuf_ready ) {
+
+  if( FD_UNLIKELY( !dst_sz ) ) return 0; /* Nothing to do ... optimize for non-trivial read */
+
+  uchar * dst        = (uchar *)_dst;
+  uchar * rbuf       = (uchar *)_rbuf;
+  ulong   rbuf_lo    = *_rbuf_lo;
+  ulong   rbuf_ready = *_rbuf_ready;
+
+  ulong rsz;
+
+  if( FD_LIKELY( rbuf_ready ) ) { /* Optimize for lots of tiny reads */
+
+    /* At this point we have at least one byte already buffered and one
+       byte to write.  Copy as many bytes as possible from rbuf into
+       dst. */
+
+    ulong cpy_sz = fd_ulong_min( dst_sz, rbuf_ready ); /* At least 1 and either dst_sz or rbuf_ready */
+    fd_memcpy( dst, rbuf + rbuf_lo, cpy_sz );
+    dst    += cpy_sz;
+    dst_sz -= cpy_sz;
+
+    /* If this completed the read, we are done. */
+
+    if( FD_LIKELY( !dst_sz ) ) { /* Optimize for lots of tiny reads */
+      *_rbuf_lo    = rbuf_lo    + cpy_sz;
+      *_rbuf_ready = rbuf_ready - cpy_sz;
+      return 0;
+    }
+
+    /* At this point we have more bytes to read, which implies cpy_sz
+       was less than dst_sz, whcih implies cpy_sz was rbuf_ready, which
+       implies rbuf is empty because it was drained above. */
+  }
+
+  /* At this point, rbuf is empty and we have at least one byte to read. */
+
+  if( FD_UNLIKELY( dst_sz>=rbuf_sz ) ) { /* If we have a large amount of data to read ... (optimize for tiny reads) */
+
+#   if 0 /* This implementation guarantees at most one fd read per call but will not block fd reads */
+
+    /* Read it directly into dst */
+
+    *_rbuf_lo    = 0UL;
+    *_rbuf_ready = 0UL;
+    return fd_io_read( fd, dst, dst_sz, dst_sz, &rsz );
+
+#   else /* This implementation will block fd reads into multiples of rbuf_sz */
+
+    /* Read the largest rbuf_sz multiple directly into dst. */
+
+    ulong bulk_sz = rbuf_sz*(dst_sz/rbuf_sz); /* TODO: require rbuf_sz to be a power of 2 for faster performance here? */
+
+    int err = fd_io_read( fd, dst, bulk_sz, bulk_sz, &rsz );
+    if( FD_UNLIKELY( err ) ) {
+      *_rbuf_lo    = 0UL;
+      *_rbuf_ready = 0UL;
+      return err;
+    }
+
+    dst    += bulk_sz;
+    dst_sz -= bulk_sz;
+
+    /* If this completed the read, we are done. */
+
+    if( FD_LIKELY( !dst_sz ) ) { /* Optimize for tiny reads */
+      *_rbuf_lo    = 0UL;
+      *_rbuf_ready = 0UL;
+      return 0;
+    }
+
+    /* At this point, we have dst_sz in [1,rbuf_sz) bytes to read */
+
+#   endif
+
+  }
+
+  /* At this point, we have dst_sz in [1,rbuf_sz).  Fill up rbuf
+     as much as we can and return the results from there. */
+
+  int err = fd_io_read( fd, rbuf, dst_sz, rbuf_sz, &rsz );
+  if( FD_UNLIKELY( err ) ) { /* failed (err>0,rsz==0) or EOF (err<0,rsz<dst_sz), either way, we can't handle the request */
+    *_rbuf_lo    = 0UL;
+    *_rbuf_ready = 0UL;
+    return err;
+  }
+
+  fd_memcpy( dst, rbuf, dst_sz );
+  *_rbuf_lo    = dst_sz;
+  *_rbuf_ready = rsz - dst_sz;
+  return 0;
+}
+
+int
+fd_io_buffered_skip( int     fd,
+                     ulong   skip_sz,
+                     void *  rbuf,
+                     ulong   rbuf_sz,
+                     ulong * _rbuf_lo,
+                     ulong * _rbuf_ready ) {
+
+  /* For large skips, flush rbuf and lseek the fd for the remainder.
+     TODO: Consider a variant where fd lseek is aligned to a rbuf_sz
+     like the above (such might requre this function to do some
+     buffering of data if the skip_sz isn't an rbuf_sz multiple). */
+
+  ulong rbuf_ready = *_rbuf_ready;
+
+  if( FD_UNLIKELY( skip_sz>rbuf_ready ) ) { /* Optimize for tiny skips */
+
+    skip_sz -= rbuf_ready; /* At least 1 */
+    do {
+
+      /* Note: lseek allows seeking past EOF (even on a RDONLY fd). */
+
+      ulong lseek_sz = fd_ulong_min( skip_sz, (ulong)LONG_MAX ); /* Workaround POSIX sign / unsigned glitches */
+      if( FD_UNLIKELY( lseek( fd, (long)lseek_sz, SEEK_CUR )==-1L ) ) {
+
+        int err = errno;
+
+        if( FD_UNLIKELY( err==ESPIPE ) ) {
+
+          /* It appears the stream isn't seekable ... skip over via
+             actual reads.  It is kinda gross that we do this every time
+             we have to skip on an unseekable stream.  At the same time,
+             such usages are likely so low bandwidth and so rare that
+             the perf hit from just doing the spurious lseeks is
+             probably in the noise and not worth the extra overhead /
+             complexity to do more elaborate handling. */
+
+          do {
+            ulong read_sz = fd_ulong_min( rbuf_sz, skip_sz );
+            ulong rsz;
+            err = fd_io_read( fd, rbuf, read_sz, read_sz, &rsz );
+            if( FD_UNLIKELY( !((!err) | (err==EAGAIN)) ) ) break;
+            skip_sz -= rsz;
+          } while( skip_sz );
+
+          *_rbuf_lo    = 0UL;
+          *_rbuf_ready = 0UL;
+          return err;
+
+        }
+
+        if( !err ) err = EPROTO; /* cmov, paranoia for non-conform to provide strong guarantees to caller */
+        return err;
+      }
+
+      skip_sz -= lseek_sz;
+    } while( FD_UNLIKELY( skip_sz ) );
+
+    *_rbuf_lo    = 0UL;
+    *_rbuf_ready = 0UL;
+    return 0;
+  }
+
+  /* Skip is purely over buffered bytes */
+
+  *_rbuf_lo    += skip_sz;
+  *_rbuf_ready  = rbuf_ready - skip_sz;
+  return 0;
+}
+
+int
+fd_io_buffered_write( int          fd,
+                      void const * _src,
+                      ulong        src_sz,
+                      void *       _wbuf,
+                      ulong        wbuf_sz,
+                      ulong *      _wbuf_used ) {
+
+  if( FD_UNLIKELY( !src_sz ) ) return 0; /* Nothing to do ... optimize for non-trivial writes */
+
+  uchar const * src  = (uchar const *)_src;
+  uchar *       wbuf = (uchar *)      _wbuf;
+
+  ulong wsz;
+
+  ulong wbuf_used = *_wbuf_used;
+
+  if( FD_LIKELY( wbuf_used ) ) { /* Optimize for lots of tiny writes */
+
+    /* At this point, we have at least one byte already buffered and one
+       byte to write.  Copy as many bytes as possible from src into
+       wbuf. */
+
+    ulong cpy_sz = fd_ulong_min( wbuf_sz - wbuf_used, src_sz ); /* cpy_sz>=1, cpy_sz is either wbuf_free or src_sz */
+
+    if( FD_LIKELY( cpy_sz ) ) fd_memcpy( wbuf + wbuf_used, src, cpy_sz );
+
+    src       += cpy_sz;
+    src_sz    -= cpy_sz;
+    wbuf_used += cpy_sz;
+
+    /* If this filled up the buffer, flush it */
+
+    if( FD_UNLIKELY( wbuf_used >= wbuf_sz ) ) { /* Optimize for lots of tiny writes */
+      int err = fd_io_write( fd, wbuf, wbuf_sz, wbuf_sz, &wsz );
+      if( FD_UNLIKELY( err ) ) {
+        *_wbuf_used = 0UL;
+        return err;
+      }
+      wbuf_used = 0UL;
+    }
+
+    /* If this completed the write, we are done. */
+
+    if( FD_LIKELY( !src_sz ) ) { /* Optimize for lots of tiny writes */
+      *_wbuf_used = wbuf_used;
+      return 0;
+    }
+
+    /* At this point, we have more bytes to write, which implies cpy_sz
+       was less than src_sz, which implies cpy_sz was wbuf_free, which
+       implies wbuf is empty because it was flushed above. */
+
+  }
+
+  /* At this point, wbuf is empty and we have at least one byte to
+     write. */
+
+  if( FD_UNLIKELY( src_sz>=wbuf_sz ) ) { /* If we have a large amount of data to write ... (optimize for tiny writes) */
+
+#   if 0 /* This implementation guarantees at most one fd write per call but will not block fd writes */
+
+    /* Write it directly from src */
+
+    *_wbuf_used = 0UL;
+    return fd_io_write( fd, src, src_sz, src_sz, &wsz );
+
+#   else /* This implementation will block fd writes into multiples of wbuf_sz */
+
+    /* Write the largest wbuf_sz multiple directly into src. */
+
+    ulong bulk_sz = wbuf_sz*(src_sz/wbuf_sz); /* TODO: require wbuf_sz to be a power of 2 for faster performance here? */
+
+    int err = fd_io_write( fd, src, bulk_sz, bulk_sz, &wsz );
+    if( FD_UNLIKELY( err ) ) {
+      *_wbuf_used = 0UL;
+      return err;
+    }
+
+    src    += bulk_sz;
+    src_sz -= bulk_sz;
+
+    /* If this completed the write, we are done. */
+
+    if( FD_LIKELY( !src_sz ) ) { /* Optimize for tiny writes */
+      *_wbuf_used = 0UL;
+      return 0;
+    }
+
+    /* At this point, we have src_sz in [1,wbuf_sz) bytes to write. */
+
+#   endif
+
+  }
+
+  /* At this point, we have src_sz in [1,wbuf_sz) and an empty
+     buffer.  Buffer these bytes. */
+
+  fd_memcpy( wbuf, src, src_sz );
+  *_wbuf_used = src_sz;
+  return 0;
+}
+
+#else
+#error "Unknown FD_IO_STYLE"
+#endif

--- a/src/util/io/fd_io.h
+++ b/src/util/io/fd_io.h
@@ -1,0 +1,749 @@
+#ifndef HEADER_fd_src_util_io_fd_io_h
+#define HEADER_fd_src_util_io_fd_io_h
+
+/* API for platform agnostic high performance stream I/O.  Summary:
+
+   Read at least min bytes directly from stream fd into size max buffer
+   buf (1<=min<=max):
+
+     ulong rsz; int err = fd_io_read( fd, buf, min, max, &rsz );
+     if     ( FD_LIKELY( err==0 ) ) ... success, rsz in [min,max], buf updated
+     else if( FD_LIKELY( err< 0 ) ) ... EOF encountered, rsz is [0,min), buf updated
+     else                           ... I/O error, rsz is zero, buf clobbered
+                                    ... err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                                    ... fd should be considered failed
+
+   This usage will block (even if the stream is non-blocking) until min
+   bytes are read, EOF is encountered or there is an I/O error.  As
+   such, the min==1 case behaves like a POSIX read on a blocking stream.
+   The min==max case will read an exact number of bytes from the stream
+   and return an error if this is not possible.  The 1<min<max case is
+   useful for implementing buffered I/O.
+
+   A non-blocking read on a non-blocking stream is possible by setting
+   min==0:
+
+     ulong rsz; int err = fd_io_read( fd, buf, 0UL, max, &rsz );
+     if     ( FD_LIKELY( err==0      ) ) ... success, rsz in [1,max], buf updated
+     else if( FD_LIKELY( err==EAGAIN ) ) ... try again later, rsz is zero, buf unchanged
+     else if( FD_LIKELY( err< 0      ) ) ... EOF encountered, rsz is zero, buf unchanged
+     else                                ... I/O error, rsz is zero, buf clobbered
+                                         ... err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                                         ... fd should be considered failed
+
+   (If min==0 and stream fd is blocking, the EAGAIN case will never
+   occur.)
+
+   Write is nearly symmetrical to read.
+
+   Write at least min byte and at most max bytes from buf into stream fd
+   (1<=min<=max):
+
+     ulong wsz; int err = fd_io_write( fd, buf, min, max, &wsz );
+     if( FD_LIKELY( err==0 ) ) ... success, wsz in [min,max]
+     else                      ... I/O error, wsz is zero, how much of buf was streamed before the error is unknown
+                               ... err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                               ... fd should be considered failed
+
+   This usage will block (even if the stream is non-blocking) until min
+   bytes are written or there is an I/O error.  As such, the min==1 case
+   behaves like a POSIX write on a stream.  The min==max case will write
+   an exact number of bytes to fd and give an error if this is not
+   possible.  The 1<min<max case is useful for implementing buffered
+   I/O.
+
+   A non-blocking write on a non-blocking stream is possible by setting
+   min==0:
+
+     ulong wsz; int err = fd_io_write( fd, buf, 0UL, max, &wsz );
+     if     ( FD_LIKELY( err==0      ) ) ... success, wsz in [1,max]
+     else if( FD_LIKELY( err==EAGAIN ) ) ... try again later, wsz is zero
+     else                                ... I/O error, wsz is zero, how much of buf was streamed before the error is unknown
+                                         ... err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                                         ... fd should be considered failed
+
+   (If min==0 and stream fd is blocking, the EAGAIN case will never
+   occur.)
+
+   Each call above typically requires at least one system call.  This
+   can be inefficient if doing lots of tiny reads and writes.  For
+   higher performance usage in cases like this, buffered I/O APIs are
+   also provided.
+
+   Buffered reads:
+
+     ... setup buffered reads from stream fd using the rbuf_sz size
+     ... buffer rbuf (rbuf_sz>0) as the read buffer
+
+     fd_io_buffered_istream_t in[1];
+     fd_io_buffered_istream_init( in, fd, rbuf, rbuf_sz );
+     ... in is initialized and has ownership of fd and rbuf
+
+     ... accessors (these return the values used to init in)
+
+     int    fd      = fd_io_buffered_istream_fd     ( in );
+     void * rbuf    = fd_io_buffered_istream_rbuf   ( in );
+     ulong  rbuf_sz = fd_io_buffered_istream_rbuf_sz( in );
+
+     ... read sz bytes from a buffered stream
+
+     int err = fd_io_buffered_istream_read( in, buf, sz );
+     if     ( FD_LIKELY( err==0 ) ) ... success, buf holds the next sz bytes of stream
+     else if( FD_LIKELY( err< 0 ) ) ... EOF before sz bytes could be read, buf clobbered
+     else                           ... I/O error, buf clobbered
+                                    ... err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                                    ... in and fd should be considered failed
+
+     ... skip sz bytes in a buffered stream
+
+     int err = fd_io_buffered_istream_skip( in, sz );
+     if     ( FD_LIKELY( err==0 ) ) ... success, sz bytes skipped
+     else if( FD_LIKELY( err< 0 ) ) ... EOF before sz bytes could be skipped
+     else                           ... I/O error
+                                    ... err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                                    ... in and fd should be considered failed
+
+     ... zero-copy read bytes from a buffered stream
+
+     ulong        peek_sz = fd_io_buffered_istream_peek_sz( in ); ... returns number of bytes currently buffered
+     void const * peek    = fd_io_buffered_istream_peek   ( in ); ... returns location of current buffered bytes
+
+     fd_io_buffered_istream_seek( in, sz ); ... consume sz currently buffered bytes, sz in [0,peek_sz]
+
+     ... read buffering control
+
+     int err = fd_io_buffered_istream_fetch( in );
+     if     ( FD_LIKELY( err==0      ) ) ... success,         peek_sz updated to at most rbuf_sz
+     else if( FD_LIKELY( err< 0      ) ) ... end-of-file,     peek_sz updated to unconsumed bytes remaining (at most rbuf_sz)
+     else if( FD_LIKELY( err==EAGAIN ) ) ... try again later, peek_sz unchanged
+     else                                ... I/O error,       peek_sz unchanged
+                                         ... err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                                         ... in and fd should be considered failed
+
+     (The EAGAIN case only applies for a non-blocking stream.)
+
+     TODO: consider option to do block until a min level?
+
+     ... finish using buffered stream
+
+     fd_io_buffered_istream_fini( in );
+     ... in is not in use and no longer has ownership of fd and rbuf.
+     ... IMPORTANT! buffering might have pushed fd's file offset beyond
+     ... the bytes the user has actually consumed.  It is the user's
+     ... responsibility for handling this.  (Usually nothing needs to be
+     ... or can be done as either the next operation is to close fd or
+     ... the fd does not support seeking.)
+
+   There are nearly symmetric APIs for buffered writes.
+
+     ... start buffered writing to stream fd using the wbuf_sz size
+     ... buffer wbuf (wbuf_sz>0) as the write buffer
+
+     fd_io_buffered_ostream_t out[1];
+     fd_io_buffered_ostream_init( out, fd, wbuf, wbuf_sz );
+     ... out is initialized and has ownership of fd and wbuf
+
+     ... accessors (these return the values used to init in)
+
+     int    fd      = fd_io_buffered_ostream_fd     ( out );
+     void * wbuf    = fd_io_buffered_ostream_wbuf   ( out );
+     ulong  wbuf_sz = fd_io_buffered_ostream_wbuf_sz( out );
+
+     ... write sz bytes to a buffered stream
+
+     int err = fd_io_buffered_ostream_write( out, buf, sz );
+     if( FD_LIKELY( err==0 ) ) ... success, sz bytes from have been written from the caller's POV
+     else                      ... I/O error, err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                               ... out and fd should be considered failed
+
+     ... zero-copy write bytes to a buffered stream
+
+     ulong  peek_sz = fd_io_buffered_ostream_peek_sz( out ); ... returns amount of unused write buffer space, in [0,wbuf_sz]
+     void * peek    = fd_io_buffered_ostream_peek   ( out ); ... returns location of unused write buffer space
+
+     fd_io_buffered_ostream_seek( in, sz ); ... commit sz unused bytes of write buffer, sz in [0,peek_sz]
+
+     ... write buffer control
+
+     int err = fd_io_buffered_ostream_flush( out );
+     if( FD_LIKELY( err==0 ) ) ... success, all buffered bytes have been drained to fd
+     else                      ... I/O error, err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                               ... out and fd should be considered failed
+
+     (This will block even for a non-blocking stream.)
+
+     ... finish using buffered stream
+
+     fd_io_buffered_ostream_fini( out );
+     ... out is not in use and no longer has ownership of fd and wbuf.
+     ... IMPORTANT! fini does not do any flushing of buffered writes (as
+     ... such fini is guaranteed to always succeed, can be applied to
+     ... out's that have failed, etc).  It is the users responsibility
+     ... to do any final flush before calling fini.
+
+   More details below. */
+
+#include "../bits/fd_bits.h"
+
+/* fd_io_buffered_{istream,ostream}_t is an opaque handle of an
+   {input,output} stream with buffered {reads,writes}.  The internals
+   are visible here to facilitate inlining various operations.  This is
+   declaration friendly (e.g. usually should just do
+   "fd_io_buffered_istream_t in[1];" on the stack to get a suitable
+   memory region for the stream state).  These are not meant to be
+   persistent or shared IPC. */
+
+struct fd_io_buffered_istream_private {
+  int     fd;         /* Open normal-ish file descriptor of stream */
+  uchar * rbuf;       /* Read buffer, non-NULL, indexed [0,rbuf_sz), arb alignment */
+  ulong   rbuf_sz;    /* Read buffer size, positive */
+  ulong   rbuf_lo;    /* Buf bytes [0,rbuf_lo) have already been consumed */
+  ulong   rbuf_ready; /* Number of buffered byte that haven't been consumed, 0<=rbuf_lo<=(rbuf_lo+rbuf_ready)<=rbuf_sz */
+};
+
+typedef struct fd_io_buffered_istream_private fd_io_buffered_istream_t;
+
+struct fd_io_buffered_ostream_private {
+  int     fd;        /* Open normal-ish file descriptor of stream */
+  uchar * wbuf;      /* Write buffer, non-NULL, indexed [0,wbuf_sz), arb alignment */
+  ulong   wbuf_sz;   /* Write buffer size, positive */
+  ulong   wbuf_used; /* Number buffered bytes that haven't been written to fd, in [0,wbuf_sz] */
+};
+
+typedef struct fd_io_buffered_ostream_private fd_io_buffered_ostream_t;
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_io_read streams at least dst_min bytes from the given file
+   descriptor into the given memory region.  fd should be an open
+   normal-ish file descriptor (it is okay for fd to be non-blocking).
+   dst points in the caller's address space with arbitrary alignment to
+   the first byte of the dst_max byte memory region to use (assumes dst
+   non-NULL, dst_max is positive and dst_min is at most dst_max).  The
+   caller should not read or write this region during the call and no
+   interest in dst is retained on return.  If dst_min is 0, this will
+   try to read dst_max from the stream exactly once.
+
+   Returns 0 on success.  On success, *_dst_sz will be the number of
+   bytes read into dst.  Will be in [dst_min,dst_max].
+
+   Returns a negative number if end-of-file was encountered before
+   reading dst_min bytes.  *_dst_sz will be the number bytes read into
+   dst when the end-of-file was encountered.  Will be in [0,dst_min).
+
+   Returns an errno compatible error code on failure (note that all
+   errnos are positive).  If errno is anything other than EAGAIN, the
+   underlying fd should be considered to be in a failed state such that
+   the only valid operation on fd is to close it.  *_dst_sz will be zero
+   and the contents of dst will be undefined.  This API fixes up the
+   POSIX glitches around EWOULDBLOCK / EAGAIN: if the underlying target
+   has EWOULDBLOCK different from EAGAIN and read uses EWOULDBLOCK
+   instead of EAGAIN, this will still just return EAGAIN.  EAGAIN will
+   only be returned if the underlying fd is non-blocking and dst_min is
+   zero.
+
+   TL;DR
+
+   - dst_min is positive:
+
+       ulong dst_sz; int err = fd_io_read( fd, dst, dst_min, dst_max, &dst_sz );
+       if     ( FD_LIKELY( err==0 ) ) ... success, dst_sz in [dst_min,dst_max], dst updated
+       else if( FD_LIKELY( err< 0 ) ) ... EOF, dst_sz in [0,dst_min), dst updated
+       else                           ... I/O error, dst_sz is zero, dst clobbered
+                                      ... err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                                      ... fd should be considered failed
+
+     This is equivalent to looping over reads of up to dst_max in size
+     from fd until at least dst_min bytes are read.  It does not matter
+     if fd is blocking or not.
+
+   - dst_min is zero and fd is blocking:
+
+       ulong dst_sz; int err = fd_io_read( fd, dst, dst_min, dst_max, &dst_sz );
+       if     ( FD_LIKELY( err==0 ) ) ... success, dst_sz in [1,dst_max], dst updated
+       else if( FD_LIKELY( err< 0 ) ) ... EOF, dst_sz is zero, dst unchanged
+       else                           ... I/O error, dst_sz is zero, dst clobbered
+                                      ... err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                                      ... fd should be considered failed
+
+     This is equivalent to a single read of dst_max size on a blocking
+     fd.
+
+   - dst_min is zero and fd is non-blocking:
+
+       ulong dst_sz; int err = fd_io_read( fd, dst, dst_min, dst_max, &dst_sz );
+       if     ( FD_LIKELY( err==0      ) ) ... success, dst_sz in [1,dst_max], dst updated
+       else if( FD_LIKELY( err==EAGAIN ) ) ... no data available now, try again later, dst_sz is zero, dst unchanged
+       else if( FD_LIKELY( err< 0      ) ) ... EOF, dst_sz is zero, dst unchanged
+       else                                ... I/O error, dst_sz is zero, dst clobbered
+                                           ... err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                                           ... fd should be considered failed
+
+     This is equivalent to a single read of dst_max size on a
+     non-blocking fd (with the POSIX glitches around EAGAIN /
+     EWOULDBLOCK cleaned up). */
+
+int
+fd_io_read( int     fd,
+            void *  dst,
+            ulong   dst_min,
+            ulong   dst_max,
+            ulong * _dst_sz );
+
+/* fd_io_write behaves virtually identical to fd_io_read but the
+   direction of the transfer is from memory to the stream and there is
+   no notion of EOF handling.  Assumes src is non-NULL,
+   src_min<=src_max, src_max is positive, src_sz is non-NULL and
+   non-overlapping with src.  Summarizing:
+
+   - src_min is positive:
+
+       ulong src_sz; int err = fd_io_write( fd, src, src_min, src_max, &src_sz );
+       if( FD_LIKELY( err==0 ) ) ... success, src_sz in [src_min,src_max]
+       else                      ... I/O error, src_sz is zero
+                                 ... err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                                 ... fd should be considered failed
+
+     This is equivalent to looping over writes of up to src_max in size
+     to fd until at least src_min bytes are written.  It does not matter
+     if fd is blocking or not.
+
+   - src_min is zero and fd is blocking:
+
+       ulong src_sz; int err = fd_io_write( fd, src, src_min, src_max, &src_sz );
+       if( FD_LIKELY( err==0 ) ) ... success, src_sz in [1,src_max]
+       else                      ... I/O error, src_sz is zero
+                                 ... err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                                 ... fd should be considered failed
+
+     This is equivalent to a single write of src_max size on a blocking
+     fd.
+
+   - src_min is zero and fd is non-blocking:
+
+       ulong src_sz; int err = fd_io_write( fd, src, src_min, src_max, &src_sz );
+       if     ( FD_LIKELY( err==0      ) ) ... success, src_sz in [1,src_max]
+       else if( FD_LIKELY( err==EAGAIN ) ) ... no bytes written, try again later, src_sz is zero
+       else                                ... I/O error, src_sz is zero
+                                           ... err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                                           ... fd should be considered failed
+
+     This is equivalent to a single write of src_max size on a
+     non-blocking fd (with the POSIX glitches around EAGAIN /
+     EWOULDBLOCK fixed up). */
+
+int
+fd_io_write( int          fd,
+             void const * src,
+             ulong        src_min,
+             ulong        src_max,
+             ulong *      _src_sz );
+
+/* fd_io_buffered_read is like fd_io_read but can consolidate many
+   tiny reads into a larger fd_io_read via the given buffer.  Unlike
+   fd_io_read, dst NULL is okay if dst_sz is 0 (dst_sz 0 is a no-op that
+   immediately returns success).  Will block the caller until the read
+   is complete or an end-of-file was encountered.
+
+   rbuf points to the first byte of a rbuf_sz size memory region in the
+   caller's address space used for read buffering (assumes rbuf is
+   non-NULL with arbitrary alignment and rbuf_sz is positive).  On entry
+   *_rbuf_lo is where the first byte of unconsumed buffered reads are
+   located and *_rbuf_ready is number of unconsumed buffered bytes.
+   Assumes 0<=*_rbuf_lo<=(*_rbuf_lo+*_rbuf_ready)<=rbuf_sz.
+
+   Returns 0 on success.  dst will hold dst_sz bytes from the stream.
+   *_rbuf_lo and *_rbuf_ready will be updated and the above invariant on
+   *_rbuf_lo and *_rbuf_ready will still hold.
+
+   Returns non-zero on failure.  Failure indicates that dst_sz bytes
+   could not be read because of an I/O error (return will be a positive
+   errno compatible error code) or an end-of-file was encountered
+   (return will be a negative number).  dst should be assumed to have
+   been clobbered, *_rbuf_lo and *_rbuf_ready will be zero.  If an I/O
+   error, the fd should be considered to be in a failed state such that
+   the only valid operation on it is to close it.
+
+   IMPORTANT!  This function will only read from fd in multiples of
+   rbuf_sz (except for a potentially last incomplete block before an
+   end-of-file).  This can be useful for various ultra high performance
+   contexts.
+
+   This API usually should not be used directly.  It is mostly useful
+   for implementing higher level APIs like fd_io_buffered_istream below. */
+
+int
+fd_io_buffered_read( int     fd,
+                     void *  dst,
+                     ulong   dst_sz,
+                     void *  rbuf,
+                     ulong   rbuf_sz,
+                     ulong * _rbuf_lo,
+                     ulong * _rbuf_ready );
+
+/* fd_io_buffered_skip is like fd_io_buffered_read but will skip over
+   skip_sz bytes of the stream without copying them into a user buffer.
+   If stream fd is seekable (e.g. a normal file), this should be O(1).
+   If not (e.g. fd is pipe / socket / stdin / etc), this will block the
+   caller until skip_sz bytes have been skipped or an I/O error occurs.
+
+   IMPORTANT!  If stream fd is seekable, POSIX behaviors allow seeking
+   past end-of-file (apparently even if fd is read only).  Whether or
+   not this is a good idea is debatable.  The result though is this API
+   will usually not return an error if skip_sz moves past the
+   end-of-file (however, if skip_sz is so large that it causes the file
+   offset to overflow, this will return EOVERFLOW).  In particular, this
+   API cannot be used to detect end-of-file.
+
+   IMPORTANT!  This function makes no effort to skip in multiples of
+   rbuf_sz.  Such is up to the caller to do if such is desirable.
+
+   This API usually should not be used directly.  It is mostly useful
+   for implementing higher level APIs like fd_io_buffered_istream below. */
+
+int
+fd_io_buffered_skip( int     fd,
+                     ulong   skip_sz,
+                     void *  rbuf,
+                     ulong   rbuf_sz,
+                     ulong * _rbuf_lo,
+                     ulong * _rbuf_ready );
+
+/* fd_io_buffered_write is like fd_io_write but can consolidate many
+   tiny writes into a larger fd_io_write via the given buffer.  Unlike
+   fd_io_write, src NULL is okay if src_sz is 0 (src_sz 0 is a no-op
+   that immediately returns success).  Will block the caller until the
+   write is complete or an end-of-file was encountered.
+
+   wbuf points to the first byte of a wbuf_sz size memory region in the
+   caller's address space (assumes wbuf is non-NULL with arbitrary
+   alignment and wbuf_sz is positive).  On entry *_wbuf_used is the
+   number of bytes in wbuf from previous buffered writes that have not
+   yet been streamed out.  Assumes *_wbuf_used is in [0,wbuf_sz].
+
+   Returns 0 on success.  wbuf will hold *_wbuf_used bytes not yet
+   written to fd by write and/or previous buffered writes.  The above
+   invariant on *_wbuf_used will still hold.
+
+   Returns non-zero on failure.  Failure indicates that src_sz bytes
+   could not be written because of an I/O error (return will be a
+   positive errno compatible error code).  fd should be considered to be
+   in a failed state such that the only valid operation on it is to
+   close it.  *_wbuf_used will be 0 and the contents of wbuf will be
+   undefined.  Zero or more bytes of previously buffered writes and/or
+   src might have been written before the failure.
+
+   IMPORTANT!  This function will only write to fd in multiples of
+   wbuf_sz.  This can be useful for various ultra high performance
+   contexts.
+
+   This API usually should not be used directly.  It is mostly useful
+   for implementing higher level APIs like fd_io_buffered_ostream below. */
+
+int
+fd_io_buffered_write( int          fd,
+                      void const * src,
+                      ulong        src_sz,
+                      void *       wbuf,
+                      ulong        wbuf_sz,
+                      ulong *      _wbuf_used );
+
+/* fd_io_buffered_istream_init initializes in to do buffered reads from
+   the given file descriptor.  in is an unused location that should hold
+   the buffering state, fd is an open normal-ish file descriptor, rbuf
+   points to the first byte in the caller's address space to an unused
+   rbuf_sz size memory region to use for read buffering (assumes rbuf is
+   non-NULL with arbitrary alignment and rbuf_sz is positive).  Returns
+   in and on return in will be initialized.  in will have ownership of
+   fd and rbuf while initialized. */
+
+static inline fd_io_buffered_istream_t *
+fd_io_buffered_istream_init( fd_io_buffered_istream_t * in,
+                             int                        fd,
+                             void *                     rbuf,
+                             ulong                      rbuf_sz ) {
+  in->fd         = fd;
+  in->rbuf       = (uchar *)rbuf;
+  in->rbuf_sz    = rbuf_sz;
+  in->rbuf_lo    = 0UL;
+  in->rbuf_ready = 0UL;
+  return in;
+}
+
+/* fd_io_buffered_istream_{fd,rbuf,rbuf_sz} return the corresponding
+   value used to initialize in.  Assumes in is initialized. */
+
+FD_FN_PURE static inline int    fd_io_buffered_istream_fd     ( fd_io_buffered_istream_t const * in ) { return in->fd;      }
+FD_FN_PURE static inline void * fd_io_buffered_istream_rbuf   ( fd_io_buffered_istream_t const * in ) { return in->rbuf;    }
+FD_FN_PURE static inline ulong  fd_io_buffered_istream_rbuf_sz( fd_io_buffered_istream_t const * in ) { return in->rbuf_sz; }
+
+/* fd_io_buffered_istream_fini finalizes a buffered input stream.
+   Assumes in is initialized.  On return in will no longer be
+   initialized and ownership the underlying fd and rbuf will return to
+   the caller.
+
+   IMPORTANT!  THIS WILL NOT REPOSITION THE UNDERLYING FD FILE OFFSET
+   (SUCH MIGHT NOT EVEN BE POSSIBLE) TO "UNREAD" ANY UNCONSUMED BUFFERED
+   DATA. */
+
+static inline void
+fd_io_buffered_istream_fini( fd_io_buffered_istream_t * in ) {
+  (void)in;
+}
+
+/* fd_io_buffered_istream_read reads dst_sz bytes from in to dst,
+   reading ahead as convenient.  Assumes in is initialized.  dst /
+   dst_sz have the same meaning / restrictions as fd_io_buffered_read.
+   Returns 0 on success and non-zero on failure.  Failure intepretation
+   is the same as fd_io_buffered_read.  On failure, in and the
+   underlying file descriptor should be considered to be in a failed
+   state (e.g. the only valid thing to do to in is fini and the only
+   valid thing to do to fd is close).
+
+   IMPORTANT!  If fd_io_buffered_istream_{fetch,skip} below are never
+   used (or only used to skip in multiplies of rbuf_sz), all the reads
+   from the underlying stream will always be at multiples of rbuf_sz
+   from the file offset when the in was initialized and a multiple of
+   rbuf_sz in size (except possibly a final read to the end-of-file).
+   This can be beneficial in various high performance I/O regimes. */
+
+FD_FN_UNUSED static int /* Work around -Winline */
+fd_io_buffered_istream_read( fd_io_buffered_istream_t * in,
+                             void *                     dst,
+                             ulong                      dst_sz ) {
+  /* We destructure in to avoid pointer escapes that might inhibit
+     optimizations of other in inlines. */
+  ulong rbuf_lo    = in->rbuf_lo;
+  ulong rbuf_ready = in->rbuf_ready;
+  int err = fd_io_buffered_read( in->fd, dst, dst_sz, in->rbuf, in->rbuf_sz, &rbuf_lo, &rbuf_ready );
+  in->rbuf_lo    = rbuf_lo;
+  in->rbuf_ready = rbuf_ready;
+  return err;
+}
+
+/* fd_io_buffered_istream_skip skips skip_sz bytes from in.  Assumes in
+   is initialized.  Returns 0 on success and non-zero on failure.
+   Failure intepretation is the same as fd_io_buffered_read.  On a
+   failure, in and the underlying file descriptor should be considered
+   to be in a failed state (e.g. the only valid thing to do to in is
+   fini and the only valid thing to do to fd is close).
+
+   If the fd underlying in is seekable (e.g. a file), this will be very
+   fast.  If not (e.g. fd is pipe / socket / etc), this can block the
+   caller until skip_sz bytes have arrived or an I/O error is detected.
+
+   IMPORTANT!  See note in fd_io_buffered_istream_read above about the
+   impact of this on file pointer alignment. */
+
+static inline int
+fd_io_buffered_istream_skip( fd_io_buffered_istream_t * in,
+                             ulong                      skip_sz ) {
+  /* We destructure in to avoid pointer escapes that might inhibit
+     optimizations of other in inlines. */
+  ulong rbuf_lo    = in->rbuf_lo;
+  ulong rbuf_ready = in->rbuf_ready;
+  int err = fd_io_buffered_skip( in->fd, skip_sz, in->rbuf, in->rbuf_sz, &rbuf_lo, &rbuf_ready );
+  in->rbuf_lo    = rbuf_lo;
+  in->rbuf_ready = rbuf_ready;
+  return err;
+}
+
+/* fd_io_buffered_istream_peek returns a pointer in the caller's address
+   space to the first byte that has been read but not yet consumed.
+   Assumes in is initialized.  The returned pointer can have arbitrary
+   alignment and the returned pointer lifetime is until the next read,
+   fetch, or fini. */
+
+FD_FN_PURE static inline void const *
+fd_io_buffered_istream_peek( fd_io_buffered_istream_t * in ) {
+  return in->rbuf + in->rbuf_lo;
+}
+
+/* fd_io_buffered_istream_peek_sz returns the number of bytes that have
+   been read but not yet consumed.  Assumes in is initialized.  Returned
+   value will be in [0,rbuf_sz] and will be valid until the next read,
+   fetch, seek or fini. */
+
+FD_FN_PURE static inline ulong
+fd_io_buffered_istream_peek_sz( fd_io_buffered_istream_t * in ) {
+  return in->rbuf_ready;
+}
+
+/* fd_io_buffered_istream_seek consumes sz buffered bytes from in.
+   Assumes in is initialized and that sz is at most peek_sz. */
+
+static inline void
+fd_io_buffered_istream_seek( fd_io_buffered_istream_t * in,
+                             ulong                      sz ) {
+  in->rbuf_lo    += sz;
+  in->rbuf_ready -= sz;
+}
+
+/* fd_io_buffered_istream_fetch tries to fill up the stream's read
+   buffer with as many unconsumed bytes as possible.  Assumes in is
+   initialized.  Returns 0 on success (rbuf is filled to rbuf_sz with
+   unconsumed data) and non-zero on failure (see below for
+   interpretation).  On failure, in and the underlying file descriptor
+   should be considered to be in a failed state (e.g. the only valid
+   thing to do out on is fini and the only valid thing to do on fd is
+   close).  That is:
+
+     int err = fd_io_buffered_istream_fetch( in );
+     if(      FD_LIKELY( err==0      ) ) ... success,     peek_sz() updated to at most rbuf_sz
+     else if( FD_LIKELY( err< 0      ) ) ... end-of-file, peek_sz() updated to at most rbuf_sz and is num unconsumed bytes to EOF
+     else if( FD_LIKELY( err==EAGAIN ) ) ... try again,   peek_sz() unchanged, only possible if fd is non-blocking
+     else                                ... I/O error,   peek_sz() unchanged,
+                                         ... err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                                         ... in and fd should be considered failed
+
+   IMPORTANT!  See note in fd_io_buffered_istream_read above about the
+   impact of fetch on file pointer alignment. */
+
+FD_FN_UNUSED static int /* Work around -Winline */
+fd_io_buffered_istream_fetch( fd_io_buffered_istream_t * in ) {
+  uchar * rbuf       = in->rbuf;
+  ulong   rbuf_sz    = in->rbuf_sz;
+  ulong   rbuf_lo    = in->rbuf_lo;
+  ulong   rbuf_ready = in->rbuf_ready;
+  if( FD_UNLIKELY( rbuf_ready>=rbuf_sz ) ) return 0; /* buffer already full */
+  if( FD_LIKELY( (!!rbuf_ready) & (!!rbuf_lo) ) ) memmove( rbuf, rbuf+rbuf_lo, rbuf_ready ); /* Move unconsumed to beginning */
+  ulong   rsz;
+  int     err = fd_io_read( in->fd, rbuf+rbuf_ready, 0UL, rbuf_sz-rbuf_ready, &rsz );
+  in->rbuf_lo    = 0UL;
+  in->rbuf_ready = rbuf_ready + rsz;
+  return err;
+}
+
+/* fd_io_buffered_ostream_init initializes out to do buffered writes to
+   the given file descriptor.  out is an unused location that should
+   hold the stream state, fd is an open normal-ish file descriptor to
+   buffer, wbuf points to the first byte in the caller's address space
+   to an unused wbuf_sz size memory region to use for the buffering
+   (assumes wbuf is non-NULL with arbitrary alignment and wbuf_sz is
+   positive).  Returns out and on return out will be initialized.  On
+   return out will have ownership of fd and wbuf. */
+
+static inline fd_io_buffered_ostream_t *
+fd_io_buffered_ostream_init( fd_io_buffered_ostream_t * out,
+                             int                        fd,
+                             void *                     wbuf,
+                             ulong                      wbuf_sz ) {
+  out->fd        = fd;
+  out->wbuf      = (uchar *)wbuf;
+  out->wbuf_sz   = wbuf_sz;
+  out->wbuf_used = 0UL;
+  return out;
+}
+
+/* fd_io_buffered_ostream_{fd,wbuf,wbuf_sz} return the corresponding
+   value used to initialize out.  Assumes out is initialized. */
+
+FD_FN_PURE static inline int    fd_io_buffered_ostream_fd     ( fd_io_buffered_ostream_t const * out ) { return out->fd;      }
+FD_FN_PURE static inline void * fd_io_buffered_ostream_wbuf   ( fd_io_buffered_ostream_t const * out ) { return out->wbuf;    }
+FD_FN_PURE static inline ulong  fd_io_buffered_ostream_wbuf_sz( fd_io_buffered_ostream_t const * out ) { return out->wbuf_sz; }
+
+/* fd_io_buffered_ostream_fini finalizes a buffered output stream.
+   Assumes out is initialized.  On return out will no longer be
+   initialized and the caller will have ownership of the underlying fd
+   and wbuf.
+
+   IMPORTANT!  THIS WILL NOT DO ANY FINAL FLUSH OF BUFFERED BYTES.  IT
+   IS THE CALLER'S RESPONSIBILLITY TO DO THIS IN THE NORMAL FINI CASE. */
+
+static inline void
+fd_io_buffered_ostream_fini( fd_io_buffered_ostream_t * out ) {
+  (void)out;
+}
+
+/* fd_io_buffered_ostream_write writes src_sz bytes from src to the
+   stream, temporarily buffering zero or more bytes as convenient.
+   Assume out is initialized.  src / src_sz ahve the same meaning /
+   restrictions as fd_io_buffered_write.  Returns 0 on success and
+   non-zero on failure.  Failure interpretation is the same as
+   fd_io_buffered_write.  On failure, out and the underlying file
+   descriptor should be considered to be in a failed state (e.g.  the
+   only valid thing to do to out is fini and the only valid thing to do
+   to fd is close).
+
+   IMPORTANT!  If fd_io_buffered_ostream_flush is only used to do a
+   final flush before fini, all the writes to the underlying stream will
+   always be at multiples of wbuf_sz offset from the initial file offset
+   when the out was initialized and all the write sizes (except
+   potentially the final flush) will be a multiple of wbuf_sz in size.
+   This can be beneficial in various high performance I/O regimes. */
+
+static inline int
+fd_io_buffered_ostream_write( fd_io_buffered_ostream_t * out,
+                              void const *               src,
+                              ulong                      src_sz ) {
+  /* We destructure out to avoid pointer escapes that might inhibit
+     optimizations of other inlines that operate on out. */
+  ulong wsz = out->wbuf_used;
+  int   err = fd_io_buffered_write( out->fd, src, src_sz, out->wbuf, out->wbuf_sz, &wsz );
+  out->wbuf_used = wsz;
+  return err;
+}
+
+/* fd_io_buffered_ostream_peek returns a pointer in the caller's address
+   space where the caller can prepare bytes to be streamed out.  Assumes
+   out is initialized.  The returned pointer can have arbitrary
+   alignment and the returned pointer lifetime is until the next write,
+   flush, or fini. */
+
+FD_FN_PURE static inline void *
+fd_io_buffered_ostream_peek( fd_io_buffered_ostream_t * out ) {
+  return out->wbuf + out->wbuf_used;
+}
+
+/* fd_io_buffered_istream_peek_sz returns the number of bytes available
+   at the peek location.  Assumes out is initialized.  Returned value
+   will be in [0,wbuf_sz] and will be valid until the next write, fetch,
+   seek or fini. */
+
+FD_FN_PURE static inline ulong
+fd_io_buffered_ostream_peek_sz( fd_io_buffered_ostream_t * out ) {
+  return out->wbuf_sz - out->wbuf_used;
+}
+
+/* fd_io_buffered_istream_seek commits the next sz unused write buffer
+   bytes to be streamed out.  Assumes out is initialized and that sz is
+   at most peek_sz. */
+
+static inline void
+fd_io_buffered_ostream_seek( fd_io_buffered_ostream_t * out,
+                             ulong                      sz ) {
+  out->wbuf_used += sz;
+}
+
+/* fd_io_buffered_ostream_flush writes any buffered bytes in the stream's
+   write buffer to the underlying file descriptor.  Assume out is
+   initialized.  Returns 0 on success (all buffered bytes written to fd)
+   and non-zero on failure (see below for interpretation).  In both
+   cases, the write buffer will be empty on return.  On failure, out and
+   the underlying file descriptor should be considered to be in a failed
+   state (e.g. the only valid thing to do to out is fini and the only
+   valid thing to do to fd is close).
+
+     int err = fd_io_buffered_ostream_flush( out );
+     if( FD_LIKELY( err==0 ) ) ... success,   write buffer empty
+     else                      ... I/O error, write buffer empty
+                               ... err is strerror compat, err is neither EAGAIN nor EWOULDBLOCK
+                               ... in and fd should be considered failed
+
+   IMPORTANT!  See note in fd_io_buffered_ostream_write below about the
+   impact of doing this outside a final flush. */
+
+FD_FN_UNUSED static int /* Work around -Winline */
+fd_io_buffered_ostream_flush( fd_io_buffered_ostream_t * out ) {
+  ulong wbuf_used = out->wbuf_used;
+  if( FD_UNLIKELY( !wbuf_used ) ) return 0; /* optimize for lots of tiny writes */
+  out->wbuf_used = 0UL;
+  ulong wsz;
+  return fd_io_write( out->fd, out->wbuf, wbuf_used, wbuf_used, &wsz );
+}
+
+/* TODO: ASYNC IO APIS */
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_util_io_fd_io_h */

--- a/src/util/io/test_io.c
+++ b/src/util/io/test_io.c
@@ -1,0 +1,293 @@
+#include "../fd_util.h"
+#include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  char const * path  = fd_env_strip_cmdline_cstr( &argc, &argv, "--path", NULL, NULL   );
+  char const * _mode = fd_env_strip_cmdline_cstr( &argc, &argv, "--mode", NULL, "0600" );
+  int          keep  = fd_env_strip_cmdline_int ( &argc, &argv, "--keep", NULL, 0      );
+
+  fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
+
+  /* Create the temp file used for io test */
+
+  int fd;
+
+  char tmp_path[] = "/tmp/test_io.XXXXXX";
+  if( path ) {
+
+    ulong mode = fd_cstr_to_ulong_octal( _mode );
+    FD_LOG_NOTICE(( "Using --path %s (--mode 0%03lo --keep %i)", path, mode, keep ));
+    mode_t old_mask = umask( (mode_t)0 );
+    fd = open( path, O_CREAT | O_EXCL | O_RDWR, (mode_t)mode );
+    umask( old_mask );
+    if( FD_UNLIKELY( fd==-1 ) ) FD_LOG_ERR(( "open(O_CREATE | O_EXCL | O_RDWR) failed (%i-%s)", errno, strerror( errno ) ));
+
+  } else {
+
+    FD_LOG_NOTICE(( "--path not specified; using tmp file (--mode ignored, --keep %i)", keep ));
+    fd = mkstemp( tmp_path );
+    if( FD_UNLIKELY( fd==-1 ) ) FD_LOG_ERR(( "mkstemp(\"%s\")failed (%i-%s)", tmp_path, errno, strerror( errno ) ));
+    path = tmp_path;
+    FD_LOG_NOTICE(( "tmp file at %s", path ));
+
+  }
+
+  /* If keep is not set, we unlink the created file so it gets
+     automagically cleaned up at program termination (normal or not).
+     That is, as per usual UNIX semantics, the underlying file will
+     still exist it has any open file descriptors. */
+
+  if( FD_UNLIKELY( !keep && unlink( path ) ) ) FD_LOG_ERR(( "unlink( \"%s\" ) failed (%i-%s)", path,  errno, strerror( errno ) ));
+
+  /* Write a bunch of test data to the file */
+
+  char const * src     = "The quick brown fox jumps over the lazy dog.\n";
+  ulong        src_len = strlen( src );
+
+  ulong wsz;
+
+  /* Test simple write */
+
+  FD_TEST( !fd_io_write( fd, src, src_len, src_len, &wsz ) && wsz==src_len     );
+
+  /* Test compoound write */
+
+  FD_TEST( !fd_io_write( fd, src,     3UL,         3UL,         &wsz ) && wsz==3UL         );
+  FD_TEST( !fd_io_write( fd, src+3UL, src_len-3UL, src_len-3UL, &wsz ) && wsz==src_len-3UL );
+
+  /* Test buffered write constructor and accessors (deliberately uses a
+     massively undersized buffer to get good edge case coverage) */
+
+# define LG_WBUF_SZ (2)
+# define WBUF_SZ    (1UL<<LG_WBUF_SZ)
+  uchar wbuf[WBUF_SZ];
+
+  fd_io_buffered_ostream_t out[1];
+
+  FD_TEST( fd_io_buffered_ostream_init( out, fd, wbuf, WBUF_SZ )==out );
+
+  FD_TEST( fd_io_buffered_ostream_fd     ( out )==fd           );
+  FD_TEST( fd_io_buffered_ostream_wbuf   ( out )==(void *)wbuf );
+  FD_TEST( fd_io_buffered_ostream_wbuf_sz( out )==WBUF_SZ      );
+
+  /* Test basic buffered writes */
+
+  for( ulong iter=0UL; iter<30UL; iter++ ) {
+    char const * p   = src;
+    ulong        rem = src_len;
+    while( rem ) {
+      uint  r        = fd_rng_uint( rng );
+      ulong sz       = fd_ulong_min( (ulong)(r & 15U), rem ); r >>= 4;
+      int   do_flush = !(r & 15U);                            r >>= 4;
+
+      if( FD_UNLIKELY( do_flush ) ) FD_TEST( !fd_io_buffered_ostream_flush( out ) );
+
+      FD_TEST( !fd_io_buffered_ostream_write( out, p, sz ) );
+
+      p   += sz;
+      rem -= sz;
+    }
+  }
+
+  /* Test zero-copy buffered writes */
+
+  for( ulong iter=0UL; iter<32UL; iter++ ) {
+    char const * p   = src;
+    ulong        rem = src_len;
+    while( rem ) {
+      uint  r   = fd_rng_uint( rng );
+      ulong max = (ulong)(r & (uint)(WBUF_SZ-1UL)); r >>= LG_WBUF_SZ; max += (r & 1UL); r >>= 1; /* In [0,WBUF_SZ] */
+      ulong sz  = (ulong)(r & (uint)(WBUF_SZ-1UL)); r >>= LG_WBUF_SZ; sz  += (r & 1UL); r >>= 1; /* In [0,WBUF_SZ] */
+      fd_swap_if( sz>max, sz, max ); /* 0<=sz<=max */
+      sz = fd_ulong_min( sz, rem );  /* sz<=rem too */
+
+      ulong peek_sz = fd_io_buffered_ostream_peek_sz( out ); FD_TEST( peek_sz<=WBUF_SZ );
+      if( FD_UNLIKELY( peek_sz<max ) ) {
+        FD_TEST( !fd_io_buffered_ostream_flush( out ) );
+        FD_TEST( fd_io_buffered_ostream_peek_sz( out )==WBUF_SZ );
+      }
+
+      char * peek = fd_io_buffered_ostream_peek( out ); FD_TEST( peek );
+      fd_memcpy( peek, p, sz );
+      fd_io_buffered_ostream_seek( out, sz );
+
+      p   += sz;
+      rem -= sz;
+    }
+  }
+
+  /* Test buffered write destructor */
+
+  FD_TEST( !fd_io_buffered_ostream_flush( out ) ); /* Do final flush */
+  fd_io_buffered_ostream_fini( out );
+
+  /* At this point, we've written src to the file 64 times.  Test
+     reading it back in various ways. */
+
+  char  dst[ 64UL ];
+  ulong dst_max = 64UL; FD_TEST( dst_max >= src_len );
+  ulong rsz;
+  ulong off;
+
+# define REWIND \
+  if( FD_UNLIKELY( lseek( fd, (off_t)0, SEEK_SET )==-1 ) ) FD_LOG_ERR(( "lseek failed (%i-%s)", errno, strerror( errno ) ))
+
+  /* Test simple read */
+
+  REWIND;
+  for( ulong iter=0UL; iter<64UL; iter++ )
+    FD_TEST( !fd_io_read( fd, dst, src_len, src_len, &rsz ) && rsz==src_len && !memcmp( src, dst, src_len ) );
+  FD_TEST( fd_io_read( fd, dst, 1UL, dst_max, &rsz )<0 && rsz==0UL ); /* Test EOF */
+
+  /* Test static compound read */
+
+  REWIND;
+  for( ulong iter=0UL; iter<64UL; iter++ ) {
+    off = 1UL+fd_rng_ulong_roll( rng, src_len-1UL ); /* In [1,src_len-1] */
+    FD_TEST( !fd_io_read( fd, dst,     off,         off,         &rsz ) && rsz==off                                           );
+    FD_TEST( !fd_io_read( fd, dst+off, src_len-off, src_len-off, &rsz ) && rsz==(src_len-off) && !memcmp( src, dst, src_len ) );
+  }
+  FD_TEST( fd_io_read( fd, dst, 1UL, dst_max, &rsz )<0 && rsz==0UL ); /* Test EOF */
+
+  /* Test dynamic compound read */
+
+  REWIND;
+  for( ulong iter=0UL; iter<64UL; iter++ ) {
+    FD_TEST( !fd_io_read( fd, dst,     1UL,         src_len-1UL, &off ) && ((1UL<=off) & (off<=(src_len-1UL)))                );
+    FD_TEST( !fd_io_read( fd, dst+off, src_len-off, src_len-off, &rsz ) && rsz==(src_len-off) && !memcmp( src, dst, src_len ) );
+  }
+  FD_TEST( fd_io_read( fd, dst, 1UL, dst_max, &rsz )<0 && rsz==0UL ); /* Test EOF */
+
+  /* Test dynamic incremental read */
+
+  REWIND;
+  for( ulong iter=0UL; iter<64UL; iter++ ) {
+    off = 0UL;
+    while( off<src_len ) {
+      FD_TEST( !fd_io_read( fd, dst+off, 1UL, src_len-off, &rsz ) && ((1UL<=rsz) & (rsz<=src_len-off)) );
+      off += rsz;
+    }
+    FD_TEST( off==src_len && !memcmp( src, dst, src_len ) );
+  }
+  FD_TEST( fd_io_read( fd, dst, 1UL, dst_max, &rsz )<0 && rsz==0UL ); /* Test EOF */
+
+  /* Test non-blocking dynamic incremental read */
+  /* TODO: Set nonblocking IO on fd here */
+
+  REWIND;
+  for( ulong iter=0UL; iter<64UL; iter++ ) {
+    off = 0UL;
+    while( off<src_len ) {
+      int err = fd_io_read( fd, dst+off, 0UL, src_len-off, &rsz );
+      if( FD_LIKELY( !err ) ) FD_TEST( (!err) & ((1UL<=rsz) & (rsz<=src_len-off)) );
+      else                    FD_TEST( (err==EAGAIN) & (!rsz) );
+      off += rsz;
+    }
+    FD_TEST( off==src_len && !memcmp( src, dst, src_len ) );
+  }
+  FD_TEST( fd_io_read( fd, dst, 1UL, dst_max, &rsz )<0 && rsz==0UL ); /* Test EOF */
+
+  /* Test buffered read constructor and accessors (deliberately uses a
+     massively undersized buffer to get good edge case coverage) */
+
+# define LG_RBUF_SZ (2)
+# define RBUF_SZ    (1UL<<LG_RBUF_SZ)
+  uchar rbuf[RBUF_SZ];
+
+  fd_io_buffered_istream_t in[1];
+  FD_TEST( fd_io_buffered_istream_init( in, fd, rbuf, RBUF_SZ )==in );
+
+  FD_TEST( fd_io_buffered_istream_fd     ( in )==fd           );
+  FD_TEST( fd_io_buffered_istream_rbuf   ( in )==(void *)rbuf );
+  FD_TEST( fd_io_buffered_istream_rbuf_sz( in )==RBUF_SZ      );
+
+  /* Test basic buffered reads */
+
+  REWIND;
+  FD_TEST( !fd_io_buffered_istream_fetch( in ) );
+  FD_TEST( !fd_io_buffered_istream_fetch( in ) );
+  for( ulong iter=0UL; iter<64UL; iter++ ) {
+    off = 0UL;
+    while( off<src_len ) {
+      uint  r        = fd_rng_uint( rng );
+      ulong sz       = fd_ulong_min( (ulong)(r & 15U), src_len-off ); r >>= 4;
+      int   do_fetch = !(r & 15U);                                    r >>= 4;
+
+      if( FD_UNLIKELY( do_fetch ) ) FD_TEST( !fd_io_buffered_istream_fetch( in ) );
+
+      FD_TEST( !fd_io_buffered_istream_read( in, dst+off, sz ) );
+
+      off += sz;
+    }
+    FD_TEST( off==src_len && !memcmp( src, dst, src_len ) );
+  }
+  FD_TEST( fd_io_buffered_istream_read( in, dst, dst_max )<0 ); /* Test EOF */
+
+  /* Test zero-copy buffered reads */
+
+  REWIND;
+  for( ulong iter=0UL; iter<64UL; iter++ ) {
+    off = 0UL;
+    while( off<src_len ) {
+      uint  r   = fd_rng_uint( rng );
+      ulong max = (ulong)(r & (uint)(RBUF_SZ-1UL)); r >>= LG_RBUF_SZ; max += (r & 1UL); r >>= 1; /* In [0,RBUF_SZ] */
+      ulong sz  = (ulong)(r & (uint)(RBUF_SZ-1UL)); r >>= LG_RBUF_SZ; sz  += (r & 1UL); r >>= 1; /* In [0,RBUF_SZ] */
+      fd_swap_if( sz>max, sz, max );
+      max = fd_ulong_min( max, src_len-off );
+      sz  = fd_ulong_min( sz,  max         ); /* 0<=sz<=max<=min(rem,RBUF_SZ) */
+
+      ulong peek_sz = fd_io_buffered_istream_peek_sz( in ); FD_TEST( peek_sz<=RBUF_SZ );
+      if( FD_UNLIKELY( peek_sz<max ) ) {
+        FD_TEST( !fd_io_buffered_istream_fetch( in ) );
+        peek_sz = fd_io_buffered_istream_peek_sz( in );
+        FD_TEST( (max<=peek_sz) & (peek_sz<=RBUF_SZ) );
+      }
+
+      char const * peek = fd_io_buffered_istream_peek( in ); FD_TEST( peek );
+      fd_memcpy( dst+off, peek, sz );
+      fd_io_buffered_istream_seek( in, sz );
+
+      off += sz;
+    }
+    FD_TEST( off==src_len && !memcmp( src, dst, src_len ) );
+  }
+  FD_TEST( fd_io_buffered_istream_read( in, dst, dst_max )<0 ); /* Test EOF */
+
+  fd_io_buffered_istream_fini( in );
+
+  /* Test skip */
+
+  REWIND;
+  ulong skip_rem = 64UL*src_len;
+  while( skip_rem ) {
+    uint  r       = fd_rng_uint( rng );
+    ulong skip_sz = fd_ulong_min( (ulong)(r & 15U), skip_rem ); r >>= 4;
+    FD_TEST( !fd_io_buffered_istream_skip( in, skip_sz ) );
+    skip_rem -= skip_sz;
+  }
+  FD_TEST( fd_io_buffered_istream_read( in, dst, dst_max )<0 ); /* Test EOF */
+
+# undef REWIND
+
+  if( FD_UNLIKELY( close( fd ) ) ) FD_LOG_WARNING(( "close failed (%i-%s); attempting to continue", errno, strerror( errno ) ));
+
+  FD_TEST( fd_io_write( -1, src, src_len, src_len, &wsz )==EBADF );
+  FD_TEST( fd_io_write( fd, src, src_len, src_len, &wsz )==EBADF );
+
+  FD_TEST( fd_io_read ( -1, dst, src_len, src_len, &rsz )==EBADF );
+  FD_TEST( fd_io_read ( fd, dst, src_len, src_len, &rsz )==EBADF );
+
+  fd_rng_delete( fd_rng_leave( rng ) );
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}

--- a/src/util/log/fd_log.c
+++ b/src/util/log/fd_log.c
@@ -34,6 +34,13 @@
 #define FD_HAS_BACKTRACE 0
 #endif /* __has_include( <execinfo.h> ) */
 
+#ifdef FD_BUILD_INFO
+FD_IMPORT_CSTR( fd_log_build_info, FD_BUILD_INFO );
+#else
+char const  fd_log_build_info[1] __attribute__((aligned(1))) = { '\0' };
+ulong const fd_log_build_info_sz                             = 1UL;
+#endif
+
 /* TEXT_* are quick-and-dirty color terminal hacks.  Probably should
    do something more robust longer term. */
 
@@ -518,7 +525,7 @@ fd_log_private_fprintf_0( int fd, char const * fmt, ... ) {
 # endif
 }
 
-char const * 
+char const *
 fd_log_private_hexdump_msg ( char const * descr,
                              void const * mem,
                              ulong        sz ) {
@@ -858,7 +865,7 @@ fd_log_private_sig_abort( int         sig,
   fsync( STDERR_FILENO );
 
 # else /* !FD_HAS_BACKTRACE */
-  
+
   int log_fileno = FD_VOLATILE_CONST( fd_log_private_fileno );
   if( log_fileno ) fd_log_private_fprintf_0( log_fileno, "Caught signal %i.\n", sig );
 
@@ -1077,6 +1084,8 @@ fd_log_private_boot( int  *   pargc,
   if( atexit( fd_log_private_cleanup ) ) { fd_log_private_fprintf_0( STDERR_FILENO, "atexit failed; unable to boot\n" ); exit(1); }
 
   /* At this point, logging online */
+  if( fd_log_build_info_sz>1UL ) FD_LOG_INFO(( "fd_log: build info:\n%s", fd_log_build_info ));
+  else                           FD_LOG_INFO(( "fd_log: build info not available"           ));
   FD_LOG_INFO(( "fd_log: --log-path          %s",  fd_log_private_path    ));
   FD_LOG_INFO(( "fd_log: --log-dedup         %i",  fd_log_private_dedup   ));
   FD_LOG_INFO(( "fd_log: --log-colorize      %i",  fd_log_colorize()      ));

--- a/src/util/log/fd_log.c
+++ b/src/util/log/fd_log.c
@@ -536,12 +536,9 @@ fd_log_private_fprintf_0( int fd, char const * fmt, ... ) {
   FD_COMPILER_MFENCE();
 # endif
 
-  ulong written = 0;
-  for(;;) {
-    long cnt = write( fd, fd_log_private_log_msg0 + written, (ulong)len - written );
-    if( FD_LIKELY( cnt == len || cnt < 0 ) ) break;
-    written += (ulong)cnt;
-  }
+  ulong wsz;
+  fd_io_write( fd, fd_log_private_log_msg0, (ulong)len, (ulong)len, &wsz );
+  /* Note: we ignore errors because what are we doing to do, log them? */
 
 # if FD_HAS_ATOMIC
   FD_COMPILER_MFENCE();

--- a/src/util/log/fd_log.h
+++ b/src/util/log/fd_log.h
@@ -457,6 +457,30 @@ int fd_log_group_id_query( ulong group_id );
 
 /* FIXME: TID DESC? UID? UID_SET? */
 
+/* Build info APIs ****************************************************/
+
+/* fd_log_build_info points in the caller's address space to the first
+   byte of a memory region of size fd_log_build_info_sz containing a
+   cstr with information about the environment in which the calling code
+   was built.
+
+   If build information was not available at compile time, the build
+   info will be the empty string and size will be one.
+
+   The value in this field is the last time the build info file was
+   generated (such that, in a development compile-execute-debug
+   iteration, the build info reflect the build environment since the
+   last "make clean" or the developer manually deleted the build info).
+
+   Code that is meant to be general purpose should not assume any
+   particular format, contents, length, etc.  The build system,
+   packaging magner, distribution manager, etc might external impose
+   additional requirements on this string for application specific code
+   though. */
+
+extern char const  fd_log_build_info[] __attribute__((aligned(1)));
+extern ulong const fd_log_build_info_sz; /* == strlen( fd_log_build_info ) + 1UL */
+
 /* Logging helper APIs ************************************************/
 
 /* fd_log_wallclock() reads the host's wallclock as ns since the UNIX
@@ -601,4 +625,3 @@ void fd_log_private_user_set ( char const * user  ); /* Not thread safe */
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_util_log_fd_log_h */
-

--- a/src/util/log/fd_log.h
+++ b/src/util/log/fd_log.h
@@ -432,6 +432,15 @@ FD_FN_CONST char const * fd_log_group( void ); /* ptr is CONST, cstr pointed at 
 
 ulong fd_log_tid( void );
 
+/* fd_log_user_id() returns the user id of the thread group to which the
+   caller belongs.  The user id is intended, at a minimum, to be unique
+   over all users on a host.  In simple cases, this is the OS uid of the
+   process to which the caller belongs.  In general cases, this is
+   typically something provided to the caller when the caller started.
+   This is cheap after the first call. */
+
+FD_FN_PURE ulong fd_log_user_id( void );
+
 /* fd_log_user() returns a non-NULL pointer to a cstr describing the
    user that created the thread group to which the caller belongs.  In
    simple cases, this defaults to the LOGNAME / login that started the
@@ -455,7 +464,7 @@ FD_FN_CONST char const * fd_log_user( void ); /* ptr is CONST, cstr pointed at i
 
 int fd_log_group_id_query( ulong group_id );
 
-/* FIXME: TID DESC? UID? UID_SET? */
+/* FIXME: TID DESC? */
 
 /* Build info APIs ****************************************************/
 
@@ -616,6 +625,7 @@ void fd_log_private_host_id_set  ( ulong host_id   );
 void fd_log_private_cpu_id_set   ( ulong cpu_id    );
 void fd_log_private_group_id_set ( ulong group_id  );
 void fd_log_private_tid_set      ( ulong tid       );
+void fd_log_private_user_id_set  ( ulong user_id   );
 
 void fd_log_private_app_set  ( char const * app   ); /* Not thread safe */
 void fd_log_private_host_set ( char const * host  ); /* Not thread safe */

--- a/src/util/log/fd_log.h
+++ b/src/util/log/fd_log.h
@@ -141,6 +141,7 @@
      by message passing or via shared memory. */
 
 #include "../env/fd_env.h"
+#include "../io/fd_io.h"
 
 /* FD_LOG_NOTICE(( ... printf style arguments ... )) will send a message
    at the NOTICE level to the logger.  E.g. for a typical fd_log

--- a/src/util/log/test_log.c
+++ b/src/util/log/test_log.c
@@ -46,6 +46,7 @@ main( int     argc,
   FD_LOG_NOTICE(( "fd_log_cpu_id        %lu", fd_log_cpu_id()        ));
   FD_LOG_NOTICE(( "fd_log_group_id      %lu", fd_log_group_id()      ));
   FD_LOG_NOTICE(( "fd_log_tid           %lu", fd_log_tid()           ));
+  FD_LOG_NOTICE(( "fd_log_user_id       %lu", fd_log_user_id()       ));
   FD_LOG_NOTICE(( "fd_log_app           %s",  fd_log_app()           ));
   FD_LOG_NOTICE(( "fd_log_thread        %s",  fd_log_thread()        ));
   FD_LOG_NOTICE(( "fd_log_host          %s",  fd_log_host()          ));

--- a/src/util/log/test_log.c
+++ b/src/util/log/test_log.c
@@ -53,6 +53,14 @@ main( int     argc,
   FD_LOG_NOTICE(( "fd_log_group         %s",  fd_log_group()         ));
   FD_LOG_NOTICE(( "fd_log_user          %s",  fd_log_user()          ));
 
+  /* Make sure build info is a proper cstr */
+  FD_TEST( fd_log_build_info_sz>0UL                              );
+  FD_TEST( !fd_log_build_info[ fd_log_build_info_sz-1UL ]        );
+  FD_TEST( (strlen(fd_log_build_info)+1UL)==fd_log_build_info_sz );
+
+  if( FD_LIKELY( fd_log_build_info_sz>1UL ) ) FD_LOG_NOTICE(( "fd_log_build_info:\n%s", fd_log_build_info ));
+  else                                        FD_LOG_NOTICE(( "fd_log_build_info not available" ));
+
   if( cmode ) {
     fd_log_colorize_set( 0 );
     FD_LOG_NOTICE(( "disabled colorize" ));
@@ -192,4 +200,3 @@ main( int     argc,
   fd_halt();
   return 0;
 }
-

--- a/src/util/wksp/Local.mk
+++ b/src/util/wksp/Local.mk
@@ -1,5 +1,5 @@
 $(call add-hdrs,fd_wksp.h)
-$(call add-objs,fd_wksp_admin fd_wksp_user fd_wksp_helper fd_wksp_used_treap fd_wksp_free_treap,fd_util)
+$(call add-objs,fd_wksp_admin fd_wksp_user fd_wksp_helper fd_wksp_used_treap fd_wksp_free_treap fd_wksp_io,fd_util)
 $(call make-bin,fd_wksp_ctl,fd_wksp_ctl,fd_util) # Just a stub on HAS_HOSTED
 
 ifdef FD_HAS_HOSTED # This tests need fd_shmem API support currently only available on hosted targets

--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -47,7 +47,7 @@
      fd_wksp_free( wksp, gaddr );
 
    Any join can free any allocation regardless of who made it.
-   
+
    When the application is done using a wksp, it should leave it.  The
    workspace will continue to exist (it just is no longer safe to access
    in the caller's address space).  E.g.
@@ -195,7 +195,7 @@ fd_wksp_data_max_est( ulong footprint,
    Reasons for failure include zero part_max, part_max too large for
    this implementation, zero data_max, part_max/data_max requires a
    footprint that overflows a ULONG_MAX. */
-   
+
 FD_FN_CONST ulong
 fd_wksp_align( void );
 
@@ -503,6 +503,31 @@ ulong
 fd_wksp_tag( fd_wksp_t * wksp,
              ulong       gaddr );
 
+/* fd_wksp_tag_query queries the workspace for all partitions that match
+   one of the given tags.  The tag array is indexed [0,tag_cnt).
+   Returns info_cnt, the number of matching partitions.  Further, if
+   info_max is non-zero, will return detailed information for the first
+   (from low to high gaddr) min(info_cnt,info_max).  Returns 0 if no
+   partitions match any tags.  If any wonkiness encountered (e.g. wksp
+   is NULL, tag is not in postive, etc) returns 0 and logs details.
+   This is O(wksp_alloc_cnt*tag_cnt) currently (but could be made
+   O(wksp_alloc_cnt) with some additional work). */
+
+struct fd_wksp_tag_query_info {
+  ulong gaddr_lo; /* Partition covers workspace global addresses [gaddr_lo,gaddr_hi) */
+  ulong gaddr_hi; /* 0<gaddr_lo<gaddr_hi */
+  ulong tag;      /* Partition tag */
+};
+
+typedef struct fd_wksp_tag_query_info fd_wksp_tag_query_info_t;
+
+ulong
+fd_wksp_tag_query( fd_wksp_t *                wksp,
+                   ulong const *              tag,
+                   ulong                      tag_cnt,
+                   fd_wksp_tag_query_info_t * info,
+                   ulong                      info_max );
+
 /* fd_wksp_tag_free frees all allocations in wksp that match one of the
    given tags.  The tag array is indexed [0,tag_cnt).  Logs details if
    any wonkiness encountered (e.g. wksp is NULL, tag is not in postive.
@@ -647,7 +672,7 @@ fd_wksp_new_anon( char const *  name,
                   ulong         page_sz,
                   ulong         sub_cnt,
                   ulong const * sub_page_cnt,
-                  ulong const * sub_cpu_idx, 
+                  ulong const * sub_cpu_idx,
                   uint          seed,
                   ulong         opt_part_max );
 

--- a/src/util/wksp/fd_wksp_ctl_help
+++ b/src/util/wksp/fd_wksp_ctl_help
@@ -83,3 +83,28 @@ usage wksp tag
 query wksp
 - Print the detailed workspace usage to stdout.
 
+checkpt wksp checkpt mode style info
+- Create a checkpoint for the workspace named wksp at the path checkpt.
+  The checkpt will have the unix permissions specified by mode (assumed
+  octal).  The style of checkpt is given by style.  info is a string
+  that the user can use to provide additional information about the
+  checkpoint.  Supported styles include:
+    0 - default (currently this is raw)
+    1 - raw ... all workspace allocations (partitions with a non-zero
+        tag) will be checkpointed.  Minimal compression and hashing will
+        be done to the checkpoint file.
+
+checkpt-query checkpt verbose
+- Query the checkpoint at the path checkpt.  Verbose indicates the
+  desired verbosity:
+   <1 - low:    checkpoint metadata information
+    1 - medium: low plus original wksp metadata and summary usage
+   >1 - high:   medium plus detailed workspace usage
+
+restore wksp checkpt seed
+- Free all allocations in the workspace named wksp and replace them with
+  allocations in the checkpoint at path checkpt.  The restored wksp will
+  be rebuilt with the given seed.  A '-' indicates to rebuild using the
+  wksp's current seed.  TODO: consider options to rebuild with the
+  checkpt seed.
+

--- a/src/util/wksp/fd_wksp_ctl_help
+++ b/src/util/wksp/fd_wksp_ctl_help
@@ -25,6 +25,14 @@ alloc wksp align sz
   default alignment.  Prints the wksp cstr address of the allocation to
   stdout on success.
 
+info wksp tag
+- Prints the wksp_gaddr and sz of the wksp allocation matching tag to
+  stdout in the form "[wksp_gaddr] [sz]".  If there are multiple
+  allocations with the same tag, prints the allocation with the lowest
+  gaddr.  If there no allocations that match tag, prints "- 0".
+  Technically speaking, this always succeeds but logs any weirdness
+  detected.
+
 free wksp_gaddr
 - Free allocation pointed to by wksp cstr address wksp_gaddr.
   wksp_gaddr can point at any byte in the allocation.  Technically

--- a/src/util/wksp/fd_wksp_io.c
+++ b/src/util/wksp/fd_wksp_io.c
@@ -1,0 +1,472 @@
+#include "fd_wksp_private.h"
+
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+int
+fd_wksp_checkpt( fd_wksp_t *  wksp,
+                 char const * path,
+                 ulong        mode,
+                 int          style,
+                 char const * uinfo ) { /* TODO: CONSIDER ALLOWING SUBSET OF TAGS */
+
+  if( FD_UNLIKELY( !wksp ) ) {
+    FD_LOG_WARNING(( "NULL wksp" ));
+    return FD_WKSP_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( !path ) ) {
+    FD_LOG_WARNING(( "NULL path" ));
+    return FD_WKSP_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( mode!=(ulong)(mode_t)mode ) ) {
+    FD_LOG_WARNING(( "bad mode" ));
+    return FD_WKSP_ERR_INVAL;
+  }
+
+  style = fd_int_if( !!style, style, FD_WKSP_CHECKPT_STYLE_DEFAULT );
+
+  if( FD_UNLIKELY( !uinfo ) ) uinfo = "";
+
+  switch( style ) {
+
+  case FD_WKSP_CHECKPT_STYLE_RAW: {
+
+  //FD_LOG_INFO(( "Checkpt wksp \"%s\" to \"%s\" (mode 0%03lo), style %i, uinfo \"%s\"", wksp->name, path, mode, style, uinfo ));
+
+    mode_t old_mask = umask( (mode_t)0 );
+    int fd = open( path, O_CREAT|O_EXCL|O_WRONLY, (mode_t)mode );
+    umask( old_mask );
+    if( FD_UNLIKELY( fd==-1 ) ) {
+      FD_LOG_WARNING(( "open(\"%s\",O_CREAT|O_EXCL|O_WRONLY,0%03lo) failed (%i-%s)\n", path, mode, errno, strerror( errno ) ));
+      return FD_WKSP_ERR_FAIL;
+    }
+
+#   define WBUF_ALIGN     ( 4096UL)
+#   define WBUF_FOOTPRINT (65536UL)
+
+    uchar                    wbuf[ WBUF_FOOTPRINT ] __attribute__((aligned(WBUF_ALIGN)));
+    fd_io_buffered_ostream_t checkpt[ 1 ];
+    fd_io_buffered_ostream_init( checkpt, fd, wbuf, WBUF_FOOTPRINT );
+
+    int     err;
+    uchar * prep;
+
+    err = fd_wksp_private_lock( wksp ); if( FD_UNLIKELY( err ) ) goto fini; /* logs details */
+
+    /* Do basic wksp checks (TODO: CONSIDER RUNNING VERIFY ON WKSP
+       HERE AND ELIMINATING THIS CHECK AND THE CHECKS BELOW) */
+
+    ulong data_lo = wksp->gaddr_lo;
+    ulong data_hi = wksp->gaddr_hi;
+    if( FD_UNLIKELY( !((0UL<data_lo) & (data_lo<=data_hi)) ) ) goto corrupt_wksp;
+
+  //FD_LOG_INFO(( "Checkpt header and metadata" ));
+
+    prep = fd_wksp_private_checkpt_prepare( checkpt, WBUF_FOOTPRINT, &err ); if( FD_UNLIKELY( !prep ) ) goto io_err;
+    prep = fd_wksp_private_checkpt_ulong( prep, wksp->magic                                                          );
+    prep = fd_wksp_private_checkpt_ulong( prep, (ulong)(uint)style                                                   );
+    prep = fd_wksp_private_checkpt_ulong( prep, (ulong)wksp->seed                                                    );
+    prep = fd_wksp_private_checkpt_ulong( prep, wksp->part_max                                                       );
+    prep = fd_wksp_private_checkpt_ulong( prep, wksp->data_max                                                       );
+    prep = fd_wksp_private_checkpt_ulong( prep, (ulong)fd_log_wallclock()                                            );
+    prep = fd_wksp_private_checkpt_ulong( prep, fd_log_app_id()                                                      );
+    prep = fd_wksp_private_checkpt_ulong( prep, fd_log_thread_id()                                                   );
+    prep = fd_wksp_private_checkpt_ulong( prep, fd_log_host_id()                                                     );
+    prep = fd_wksp_private_checkpt_ulong( prep, fd_log_cpu_id()                                                      );
+    prep = fd_wksp_private_checkpt_ulong( prep, fd_log_group_id()                                                    );
+    prep = fd_wksp_private_checkpt_ulong( prep, fd_log_tid()                                                         );
+    prep = fd_wksp_private_checkpt_ulong( prep, fd_log_user_id()                                                     );
+    prep = fd_wksp_private_checkpt_buf  ( prep, wksp->name,        strlen( wksp->name      )                         );
+    prep = fd_wksp_private_checkpt_buf  ( prep, fd_log_app(),      strlen( fd_log_app()    )                         );
+    prep = fd_wksp_private_checkpt_buf  ( prep, fd_log_thread(),   strlen( fd_log_thread() )                         );
+    prep = fd_wksp_private_checkpt_buf  ( prep, fd_log_host(),     strlen( fd_log_host()   )                         );
+    prep = fd_wksp_private_checkpt_buf  ( prep, fd_log_cpu(),      strlen( fd_log_cpu()    )                         );
+    prep = fd_wksp_private_checkpt_buf  ( prep, fd_log_group(),    strlen( fd_log_group()  )                         );
+    prep = fd_wksp_private_checkpt_buf  ( prep, fd_log_user(),     strlen( fd_log_user()   )                         );
+    prep = fd_wksp_private_checkpt_buf  ( prep, fd_log_build_info, fd_ulong_min( fd_log_build_info_sz-1UL, 16383UL ) );
+    prep = fd_wksp_private_checkpt_buf  ( prep, uinfo,             fd_cstr_nlen( uinfo, 16383UL )                    );
+    fd_wksp_private_checkpt_publish( checkpt, prep );
+
+  //FD_LOG_INFO(( "Checkpt allocations" ));
+
+    ulong part_max = wksp->part_max;
+    fd_wksp_private_pinfo_t * pinfo = fd_wksp_private_pinfo( wksp );
+
+    ulong cycle_tag = wksp->cycle_tag++;
+
+    ulong gaddr_last = data_lo;
+
+    ulong i = fd_wksp_private_pinfo_idx( wksp->part_head_cidx );
+    while( !fd_wksp_private_pinfo_idx_is_null( i ) ) {
+      if( FD_UNLIKELY( i>=part_max ) || FD_UNLIKELY( pinfo[ i ].cycle_tag==cycle_tag ) ) goto corrupt_wksp;
+      pinfo[ i ].cycle_tag = cycle_tag; /* mark i as visited */
+
+      /* Do basic partition checks */
+
+      ulong gaddr_lo = pinfo[ i ].gaddr_lo;
+      ulong gaddr_hi = pinfo[ i ].gaddr_hi;
+      ulong tag      = pinfo[ i ].tag;
+
+      if( FD_UNLIKELY( !((gaddr_last==gaddr_lo) & (gaddr_lo<gaddr_hi) & (gaddr_hi<=data_hi)) ) ) goto corrupt_wksp;
+
+      gaddr_last = gaddr_hi;
+
+      /* If an allocated partition, checkpt it */
+
+      if( tag ) { /* ~50/50 */
+
+        ulong sz = gaddr_hi - gaddr_lo;
+
+        /* Checkpt partition header */
+
+        prep = fd_wksp_private_checkpt_prepare( checkpt, 3UL*9UL, &err ); if( FD_UNLIKELY( !prep ) ) goto io_err;
+        prep = fd_wksp_private_checkpt_ulong( prep, tag      );
+        prep = fd_wksp_private_checkpt_ulong( prep, gaddr_lo );
+        prep = fd_wksp_private_checkpt_ulong( prep, sz       );
+        fd_wksp_private_checkpt_publish( checkpt, prep );
+
+        /* Checkpt partition data */
+
+        void * laddr_lo = fd_wksp_laddr_fast( wksp, gaddr_lo );
+        err = fd_wksp_private_checkpt_write( checkpt, laddr_lo, sz ); if( FD_UNLIKELY( err ) ) goto io_err;
+      }
+
+      /* Advance to next partition */
+
+      i = fd_wksp_private_pinfo_idx( pinfo[ i ].next_cidx );
+    }
+
+  //FD_LOG_INFO(( "Checkpt footer" ));
+
+    prep = fd_wksp_private_checkpt_prepare( checkpt, 1UL*9UL, &err ); if( FD_UNLIKELY( !prep ) ) goto io_err;
+    prep = fd_wksp_private_checkpt_ulong( prep, 0UL ); /* tags are never 0 above */
+    fd_wksp_private_checkpt_publish( checkpt, prep );
+
+    err = fd_io_buffered_ostream_flush( checkpt ); if( FD_UNLIKELY( err ) ) goto io_err;
+
+    fd_wksp_private_unlock( wksp );
+
+  //FD_LOG_INFO(( "Checkpt successful" ));
+
+    /* note: err == 0 at this point */
+
+  fini: /* note: wksp unlocked at this point */
+    fd_io_buffered_ostream_fini( checkpt );
+    if( FD_UNLIKELY( err ) && FD_UNLIKELY( unlink( path ) ) )
+      FD_LOG_WARNING(( "unlink(\"%s\") failed (%i-%s); attempting to continue", path, errno, strerror( errno ) ));
+    if( FD_UNLIKELY( close( fd ) ) )
+      FD_LOG_WARNING(( "close(\"%s\") failed (%i-%s); attempting to continue", path, errno, strerror( errno ) ));
+    return err;
+
+  io_err: /* Failed due to I/O error ... clean up and log (note: wksp locked at this point) */
+    fd_wksp_private_unlock( wksp );
+    FD_LOG_WARNING(( "Checkpt wksp \"%s\" to \"%s\" failed due to I/O error (%i-%s)", wksp->name, path, err, strerror( err ) ));
+    err = FD_WKSP_ERR_FAIL;
+    goto fini;
+
+  corrupt_wksp: /* Failed due to wksp corruption ... clean up and log (note: wksp locked at this point) */
+    fd_wksp_private_unlock( wksp );
+    FD_LOG_WARNING(( "Checkpt wksp \"%s\" to \"%s\" failed due to wksp corruption", wksp->name, path ));
+    err = FD_WKSP_ERR_CORRUPT;
+    goto fini;
+
+#   undef WBUF_FOOTPRINT
+#   undef WBUF_ALIGN
+
+  } /* FD_WKSP_CHECKPT_STYLE_RAW */
+
+  default:
+    break;
+  }
+
+  FD_LOG_WARNING(( "unsupported style" ));
+  return FD_WKSP_ERR_INVAL;
+}
+
+/*********************************************************************/
+
+int
+fd_wksp_private_restore_ulong( fd_io_buffered_istream_t * in,
+                               ulong *                    _val ) {
+  ulong         csz;
+  uchar const * buf;
+  uchar         _buf[9UL];
+
+  /* Read the encoded val */
+
+  ulong peek_sz = fd_io_buffered_istream_peek_sz( in );
+
+  if( FD_LIKELY( peek_sz>=9UL ) ) { /* encoded val already prefetched */
+    buf = fd_io_buffered_istream_peek( in );
+    csz = fd_ulong_svw_dec_sz( buf );
+    fd_io_buffered_istream_seek( in, csz );
+  } else { /* encoded val not guaranteed prefetched (this will also implicitly prefetch for future restores) */
+    int err;
+    err = fd_io_buffered_istream_read( in, _buf,     1UL     ); if( FD_UNLIKELY( err ) ) { *_val = 0UL; return err; }
+    csz = fd_ulong_svw_dec_sz( _buf );
+    err = fd_io_buffered_istream_read( in, _buf+1UL, csz-1UL ); if( FD_UNLIKELY( err ) ) { *_val = 0UL; return err; }
+    buf = _buf;
+  }
+
+  /* Decode encoded val */
+
+  *_val = fd_ulong_svw_dec_fixed( buf, csz );
+  return 0;
+}
+
+int
+fd_wksp_private_restore_buf( fd_io_buffered_istream_t * in,
+                             void *                     buf,
+                             ulong                      buf_max,
+                             ulong *                    _buf_sz ) {
+
+  /* Restore buf_sz */
+
+  ulong buf_sz;
+  int   err = fd_wksp_private_restore_ulong( in, &buf_sz );
+  if( FD_UNLIKELY( (!!err) | (buf_sz>buf_max) ) ) { /* I/O error, unexpected EOF, or buf_max too small */
+    if( !!err ) err = EPROTO; /* cmov */
+    *_buf_sz = 0UL;
+    return err;
+  }
+
+  /* Restore buf */
+
+  err = fd_io_buffered_istream_read( in, buf, buf_sz );
+  *_buf_sz = fd_ulong_if( !err, buf_sz, 0UL );
+  return err;
+}
+
+/* TODO: CONSIDER ALLOWING RANGE OF TAGS?  CONSIDER OPS LIKE KEEPING
+   EXISTING PARTITIONS / REPLACE CONFLICTING / ETC? */
+
+int
+fd_wksp_restore( fd_wksp_t *  wksp,
+                 char const * path,
+                 uint         new_seed ) {
+
+  if( FD_UNLIKELY( !wksp ) ) {
+    FD_LOG_WARNING(( "NULL wksp" ));
+    return FD_WKSP_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( !path ) ) {
+    FD_LOG_WARNING(( "NULL path" ));
+    return FD_WKSP_ERR_INVAL;
+  }
+
+  FD_LOG_INFO(( "Restore checkpt \"%s\" into wksp \"%s\" (seed %u)", path, wksp->name, new_seed ));
+
+  int fd = open( path, O_RDONLY, (mode_t)0 );
+  if( FD_UNLIKELY( fd==-1 ) ) {
+    FD_LOG_WARNING(( "open(\"%s\",O_RDONLY,0) failed (%i-%s)\n", path, errno, strerror( errno ) ));
+    return FD_WKSP_ERR_FAIL;
+  }
+
+# define RBUF_ALIGN     (4096UL)
+# define RBUF_FOOTPRINT (65536UL)
+
+  uchar                    rbuf[ RBUF_FOOTPRINT ] __attribute__((aligned( RBUF_ALIGN )));
+  fd_io_buffered_istream_t restore[1];
+  fd_io_buffered_istream_init( restore, fd, rbuf, RBUF_FOOTPRINT );
+
+  int err;
+
+  err = fd_wksp_private_lock( wksp ); if( FD_UNLIKELY( err ) ) goto fini; /* logs details */
+
+  ulong                     wksp_part_max = wksp->part_max;
+  ulong                     wksp_data_max = wksp->data_max;
+  ulong                     wksp_data_lo  = wksp->gaddr_lo;
+  ulong                     wksp_data_hi  = wksp->gaddr_hi;
+  fd_wksp_private_pinfo_t * wksp_pinfo    = fd_wksp_private_pinfo( wksp );
+
+  char const * err_info;
+
+# define RESTORE_ULONG(v) do {                               \
+    err = fd_wksp_private_restore_ulong( restore, &v );      \
+    if( FD_UNLIKELY( err ) ) { err_info = #v; goto io_err; } \
+  } while(0)
+
+# define RESTORE_CSTR(v,max) do {                                         \
+    err = fd_wksp_private_restore_buf( restore, v, (max)-1UL, &v##_len ); \
+    if( FD_UNLIKELY( err ) ) { err_info = #v; goto io_err; }              \
+    v[v##_len] = '\0';                                                    \
+  } while(0)
+
+# define TEST(c) do { if( FD_UNLIKELY( !(c) ) ) { err_info = #c; goto stream_err; } } while(0)
+
+  FD_LOG_INFO(( "Restore header" ));
+
+  ulong magic;    RESTORE_ULONG( magic    );                                  TEST( magic   ==FD_WKSP_MAGIC      );
+  ulong style_ul; RESTORE_ULONG( style_ul ); int style = (int)(uint)style_ul; TEST( style_ul==(ulong)(uint)style );
+
+  FD_LOG_INFO(( "checkpt_magic  %016lx", magic ));
+  FD_LOG_INFO(( "checkpt_style  %i",     style ));
+
+  switch( style ) {
+
+  case FD_WKSP_CHECKPT_STYLE_RAW: {
+
+    FD_LOG_INFO(( "Restore metadata" ));
+
+    ulong seed_ul;   RESTORE_ULONG( seed_ul   ); uint seed = (uint)seed_ul; TEST( seed_ul==(ulong)seed                    );
+    ulong part_max;  RESTORE_ULONG( part_max  );
+    ulong data_max;  RESTORE_ULONG( data_max  );                            TEST( fd_wksp_footprint( part_max, data_max ) );
+
+    ulong ts_ul;     RESTORE_ULONG( ts_ul     ); long ts = (long)ts_ul;     TEST( ts_ul==(ulong)ts                        );
+    ulong app_id;    RESTORE_ULONG( app_id    );
+    ulong thread_id; RESTORE_ULONG( thread_id );
+    ulong host_id;   RESTORE_ULONG( host_id   );
+    ulong cpu_id;    RESTORE_ULONG( cpu_id    );
+    ulong group_id;  RESTORE_ULONG( group_id  );                            TEST( group_id>=2UL                           );
+    ulong tid;       RESTORE_ULONG( tid       );
+    ulong user_id;   RESTORE_ULONG( user_id   );
+
+    char name[ FD_SHMEM_NAME_MAX ]; ulong name_len; RESTORE_CSTR( name, FD_SHMEM_NAME_MAX );
+    TEST( fd_shmem_name_len( name )==name_len );
+
+    char app   [ FD_LOG_NAME_MAX ]; ulong app_len;    RESTORE_CSTR( app,    FD_LOG_NAME_MAX ); TEST( strlen( app    )==app_len    );
+    char thread[ FD_LOG_NAME_MAX ]; ulong thread_len; RESTORE_CSTR( thread, FD_LOG_NAME_MAX ); TEST( strlen( thread )==thread_len );
+    char host  [ FD_LOG_NAME_MAX ]; ulong host_len;   RESTORE_CSTR( host,   FD_LOG_NAME_MAX ); TEST( strlen( host   )==host_len   );
+    char cpu   [ FD_LOG_NAME_MAX ]; ulong cpu_len;    RESTORE_CSTR( cpu,    FD_LOG_NAME_MAX ); TEST( strlen( cpu    )==cpu_len    );
+    char group [ FD_LOG_NAME_MAX ]; ulong group_len;  RESTORE_CSTR( group,  FD_LOG_NAME_MAX ); TEST( strlen( group  )==group_len  );
+    char user  [ FD_LOG_NAME_MAX ]; ulong user_len;   RESTORE_CSTR( user,   FD_LOG_NAME_MAX ); TEST( strlen( user   )==user_len   );
+
+    char ts_cstr[ FD_LOG_WALLCLOCK_CSTR_BUF_SZ ]; fd_log_wallclock_cstr( ts, ts_cstr );
+
+    FD_LOG_INFO(( "checkpt_ts     %-20li \"%s\"", ts,        ts_cstr ));
+    FD_LOG_INFO(( "checkpt_app    %-20lu \"%s\"", app_id,    app     ));
+    FD_LOG_INFO(( "checkpt_thread %-20lu \"%s\"", thread_id, thread  ));
+    FD_LOG_INFO(( "checkpt_host   %-20lu \"%s\"", host_id,   host    ));
+    FD_LOG_INFO(( "checkpt_cpu    %-20lu \"%s\"", cpu_id,    cpu     ));
+    FD_LOG_INFO(( "checkpt_group  %-20lu \"%s\"", group_id,  group   ));
+    FD_LOG_INFO(( "checkpt_tid    %-20lu",        tid                ));
+    FD_LOG_INFO(( "checkpt_user   %-20lu \"%s\"", user_id,   user    ));
+
+    char buf[ 16384 ]; ulong buf_len;
+
+    RESTORE_CSTR( buf, 16384UL ); TEST( strlen( buf )==buf_len );
+    FD_LOG_INFO(( "checkpt_build\n\t%s", buf ) );
+
+    RESTORE_CSTR( buf, 16384UL ); TEST( strlen( buf )==buf_len );
+    FD_LOG_INFO(( "checkpt_info\n\t%s", buf ));
+
+    FD_LOG_INFO(( "shmem_name     \"%s\"", name ) );
+
+    ulong data_lo = fd_wksp_private_data_off( part_max );
+    ulong data_hi = data_lo + data_max;
+
+    FD_LOG_INFO(( "Restore allocations" ));
+
+    ulong wksp_part_cnt = 0UL;
+
+    for(;;) {
+
+      /* Restore the allocation header */
+
+      ulong tag;      RESTORE_ULONG( tag      ); if( FD_UNLIKELY( !tag ) ) break; /* Optimize for lots of partitions */
+      ulong gaddr_lo; RESTORE_ULONG( gaddr_lo );
+      ulong sz;       RESTORE_ULONG( sz       );
+
+      ulong gaddr_hi = gaddr_lo + sz;
+
+      TEST( (data_lo<=gaddr_lo) & (gaddr_lo<gaddr_hi) & (gaddr_hi<=data_hi) );
+
+      if( FD_UNLIKELY( wksp_part_cnt>=wksp_part_max ) ) {
+        FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed because too few wksp partitions "
+                         "(part_max checkpt %lu, wksp %lu); attempting to reset wksp and continue",
+                         path, wksp->name, part_max, wksp_part_max ));
+        goto corrupt_wksp; /* wksp might be dirty from previous iterations */
+      }
+
+      if( FD_UNLIKELY( !((wksp_data_lo<=gaddr_lo) & (gaddr_hi<=wksp_data_hi)) ) ) {
+        FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed because checkpt partition [0x%016lx,0x%016lx) tag %lu "
+                         "does not fit into wksp data region [0x%016lx,0x%016lx) (data_max checkpt %lu, wksp %lu); "
+                         "attempting to reset wksp and continue",
+                         path, wksp->name, gaddr_lo, gaddr_hi, tag, wksp_data_lo, wksp_data_hi, data_max, wksp_data_max ));
+        goto corrupt_wksp; /* wksp might be dirty from previous iterations */
+      }
+
+      /* Restore the allocation payload into the wksp (this will dirty the wksp) */
+
+      err = fd_io_buffered_istream_read( restore, fd_wksp_laddr_fast( wksp, gaddr_lo ), sz );
+      if( FD_UNLIKELY( err ) ) {
+        char const * msg = (err<0) ? "unexpected end of file" : strerror( err );
+        FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed because of I/O error (%i-%s); "
+                         "attempting to reset wksp and continue",
+                         path, wksp->name, err, msg ));
+        goto corrupt_wksp;
+      }
+
+      /* Record this allocation in the wksp (this will also dirty the wksp) */
+
+      wksp_pinfo[ wksp_part_cnt ].gaddr_lo = gaddr_lo;
+      wksp_pinfo[ wksp_part_cnt ].gaddr_hi = gaddr_hi;
+      wksp_pinfo[ wksp_part_cnt ].tag      = tag;
+      wksp_part_cnt++;
+    }
+
+    /* Remove all remaining old allocations (this will dirty the wksp) */
+
+    for( ulong i=wksp_part_cnt; i<wksp_part_max; i++ ) wksp_pinfo[ i ].tag = 0UL;
+
+    FD_LOG_INFO(( "Rebuilding wksp with restored allocations" ));
+
+    err = fd_wksp_rebuild( wksp, new_seed ); /* logs details */
+    if( FD_UNLIKELY( err ) ) { /* wksp dirty */
+      FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed because of rebuild error; attempting to reset wksp and continue",
+                       path, wksp->name ));
+      goto corrupt_wksp;
+    }
+
+    fd_wksp_private_unlock( wksp );
+    FD_LOG_INFO(( "Restore successful" ));
+    break;
+
+  } /* FD_WKSP_CHECKPT_STYLE_RAW */
+
+  default:
+    err_info = "unsupported style";
+    goto stream_err;
+  }
+
+  /* err = 0 at this point */
+
+fini: /* note: wksp unlocked at this point, wksp clean, details not logged */
+  fd_io_buffered_istream_fini( restore );
+  if( FD_UNLIKELY( close( fd ) ) )
+    FD_LOG_WARNING(( "close(\"%s\") failed (%i-%s); attempting to continue", path, errno, strerror( errno ) ));
+  return err;
+
+io_err: /* note: wksp locked at this point, wksp clean, details not logged */
+  fd_wksp_private_unlock( wksp );
+  char const * msg = (err<0) ? "unexpected end of file" : strerror( err );
+  FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed (%s) due to I/O error (%i-%s)", path, wksp->name, err_info, err, msg ));
+  err = FD_WKSP_ERR_FAIL;
+  goto fini;
+
+stream_err: /* note: wksp locked at this point, wksp clean, details not logged */
+  fd_wksp_private_unlock( wksp );
+  FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed (%s) due to checkpt format error", path, wksp->name, err_info ));
+  err = FD_WKSP_ERR_FAIL;
+  goto fini;
+
+corrupt_wksp: /* note: wksp locked at this point, wksp dirty, details already logged */
+  /* reset the wksp (if we can) to get it back to a clean state (TODO:
+     consider FD_LOG_CRIT here if rebuild fails though it shouldn't) */
+  for( ulong i=0UL; i<wksp_part_max; i++ ) wksp_pinfo[ i ].tag = 0UL;
+  fd_wksp_rebuild( wksp, new_seed ); /* logs details */
+  fd_wksp_private_unlock( wksp );
+  err = FD_WKSP_ERR_CORRUPT;
+  goto fini;
+
+# undef TEST
+# undef RESTORE_CSTR
+# undef RESTORE_ULONG
+# undef RBUF_FOOTPRINT
+# undef RBUF_ALIGN
+}

--- a/src/util/wksp/test_wksp_ctl
+++ b/src/util/wksp/test_wksp_ctl
@@ -93,6 +93,19 @@ GADDR1=$("$BIN"/fd_wksp_ctl tag 1234 alloc "$WKSP" 4096 4096 || fail alloc $?)
 GADDR2=$("$BIN"/fd_wksp_ctl tag 1234 alloc "$WKSP" 4096 4096 || fail alloc $?)
 GADDR3=$("$BIN"/fd_wksp_ctl tag 2345 alloc "$WKSP" 4096 4096 || fail alloc $?)
 
+echo Testing info
+
+"$BIN"/fd_wksp_ctl info         && fail info $?
+"$BIN"/fd_wksp_ctl info "$WKSP" && fail info $?
+"$BIN"/fd_wksp_ctl info bad     1234 \
+                   info "$WKSP"    0 \
+                   info "$WKSP" 4096 \
+                   info "$WKSP"    2 \
+                   info "$WKSP" 1234 \
+                   info "$WKSP" 2345 \
+                   info "$WKSP" 1234 \
+|| fail info $? # Yes ... a fail here is success from cmd exec POV (fail is logged)
+
 echo Testing memset
 
 "$BIN"/fd_wksp_ctl memset              && fail memset $?
@@ -193,4 +206,3 @@ echo Testing multi
 echo pass
 echo Log N/A
 exit 0
-

--- a/src/util/wksp/test_wksp_ctl
+++ b/src/util/wksp/test_wksp_ctl
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 fail() {
+  rm -fv "$CHECKPT"
   echo FAIL: "$1" unexpected exit code "$2"
   echo Log N/A
   exit 1
@@ -22,6 +23,10 @@ PAGE_SZ=gigantic
 CPU_IDX=0
 MODE=0600
 
+CHECKPT=test_fd_wksp_ctl.checkpt
+STYLE=0
+INFO="The quick brown fox jumps over the lazy dog"
+
 # Disable the permanent log
 
 FD_LOG_PATH=""
@@ -30,6 +35,7 @@ export FD_LOG_PATH
 # Try to clean up any leftovers from previous runs (including same name on multiple pages)
 
 "$BIN"/fd_wksp_ctl delete "$WKSP" delete "$WKSP" delete "$WKSP" > /dev/null 2>&1
+rm -fv "$CHECKPT"
 
 echo Testing no-op
 
@@ -92,6 +98,27 @@ GADDR=$("$BIN"/fd_wksp_ctl alloc "$WKSP" 4096 2097152 || fail alloc $?)
 GADDR1=$("$BIN"/fd_wksp_ctl tag 1234 alloc "$WKSP" 4096 4096 || fail alloc $?)
 GADDR2=$("$BIN"/fd_wksp_ctl tag 1234 alloc "$WKSP" 4096 4096 || fail alloc $?)
 GADDR3=$("$BIN"/fd_wksp_ctl tag 2345 alloc "$WKSP" 4096 4096 || fail alloc $?)
+
+echo Testing checkpt
+
+"$BIN"/fd_wksp_ctl checkpt                                              && fail checkpt $?
+"$BIN"/fd_wksp_ctl checkpt "$WKSP"                                      && fail checkpt $?
+"$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT"                          && fail checkpt $?
+"$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" "$MODE"                  && fail checkpt $?
+"$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" "$MODE" "$STYLE"         && fail checkpt $?
+"$BIN"/fd_wksp_ctl checkpt bad/name "$CHECKPT" "$MODE" "$STYLE" "$INFO" && fail checkpt $?
+"$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" -1      "$STYLE" "$INFO" && fail checkpt $?
+"$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" "$MODE" -1       "$INFO" && fail checkpt $?
+"$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" "$MODE" "$STYLE" "$INFO" || fail checkpt $?
+"$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" "$MODE" "$STYLE" "$INFO" && fail checkpt $?
+
+echo Testing checkpt-query
+
+"$BIN"/fd_wksp_ctl checkpt-query              && fail checkpt-query $?
+"$BIN"/fd_wksp_ctl checkpt-query "$CHECKPT"   && fail checkpt-query $?
+"$BIN"/fd_wksp_ctl checkpt-query "$CHECKPT" 0 \
+                   checkpt-query "$CHECKPT" 1 \
+                   checkpt-query "$CHECKPT" 2 || fail checkpt-query $?
 
 echo Testing info
 
@@ -186,6 +213,31 @@ echo Testing reset
 "$BIN"/fd_wksp_ctl reset bad/name && fail reset $?
 "$BIN"/fd_wksp_ctl reset "$WKSP"  || fail reset $?
 
+echo Testing restore
+
+"$BIN"/fd_wksp_ctl restore                         && fail restore $?
+"$BIN"/fd_wksp_ctl restore "$WKSP"                 && fail restore $?
+"$BIN"/fd_wksp_ctl restore "$WKSP"  "$CHECKPT"     && fail restore $?
+"$BIN"/fd_wksp_ctl restore bad/name "$CHECKPT"     && fail restore $?
+"$BIN"/fd_wksp_ctl restore "$WKSP"  "$CHECKPT" -   query "$WKSP" check "$WKSP" \
+                   restore "$WKSP"  "$CHECKPT" 123 query "$WKSP" check "$WKSP" \
+                   restore "$WKSP"  "$CHECKPT" 123 query "$WKSP" check "$WKSP" \
+                   restore "$WKSP"  "$CHECKPT" 234 query "$WKSP" check "$WKSP" \
+|| fail restore $?
+rm -fv "$CHECKPT"
+
+# Test checkpt empty wksp, query empty checkpt, restore empty to empty,
+# restore non-empty to empty
+
+"$BIN"/fd_wksp_ctl reset         "$WKSP"                                          \
+                   checkpt       "$WKSP" "$CHECKPT" "$MODE" "$STYLE" "$INFO"      \
+                   checkpt-query "$CHECKPT" 2                                     \
+                   restore       "$WKSP" "$CHECKPT" - query "$WKSP" check "$WKSP" \
+                   alloc         "$WKSP" 1 1          query "$WKSP" check "$WKSP" \
+                   restore       "$WKSP" "$CHECKPT" - query "$WKSP" check "$WKSP" \
+|| fail reset $?
+rm -fv "$CHECKPT"
+
 echo Testing delete
 
 "$BIN"/fd_wksp_ctl delete          && fail delete $?
@@ -194,14 +246,23 @@ echo Testing delete
 
 echo Testing multi
 
-"$BIN"/fd_wksp_ctl new  "$WKSP" "$PAGE_CNT" $PAGE_SZ $CPU_IDX $MODE check "$WKSP" \
-                 query  "$WKSP"                                     check "$WKSP" \
-                 alloc  "$WKSP" 4096 2097152                        check "$WKSP" \
-                 query  "$WKSP"                                     check "$WKSP" \
-                 reset  "$WKSP"                                     check "$WKSP" \
-                 query  "$WKSP"                                     check "$WKSP" \
-                 delete "$WKSP"                                                   \
+"$BIN"/fd_wksp_ctl new           "$WKSP" "$PAGE_CNT" $PAGE_SZ $CPU_IDX $MODE check "$WKSP" \
+                   query         "$WKSP"                                     check "$WKSP" \
+                   alloc         "$WKSP" 1 1                                 check "$WKSP" \
+                   alloc         "$WKSP" 2 2                                 check "$WKSP" \
+                   alloc         "$WKSP" 4 3                                 check "$WKSP" \
+                   query         "$WKSP"                                     check "$WKSP" \
+                   checkpt       "$WKSP" "$CHECKPT" "$MODE" "$STYLE" "$INFO" check "$WKSP" \
+                   checkpt-query "$CHECKPT" 2                                check "$WKSP" \
+                   reset         "$WKSP"                                     check "$WKSP" \
+                   alloc         "$WKSP" 8 8                                 check "$WKSP" \
+                   restore       "$WKSP" "$CHECKPT" -                        check "$WKSP" \
+                   query         "$WKSP"                                     check "$WKSP" \
+                   reset         "$WKSP"                                     check "$WKSP" \
+                   query         "$WKSP"                                     check "$WKSP" \
+                   delete        "$WKSP"                                                   \
 || fail multi $?
+rm -fv "$CHECKPT"
 
 echo pass
 echo Log N/A


### PR DESCRIPTION
To do this robustly, needed some lower level APIs and missing functionality filled out.  The most important ones:
- Generic buffered I/O APIs with implementation for POSIX systems.
- Build environment details programmatic exposed.
- Can lookup an wksp allocation by its tag to make various discovery processes at application startup cleaner.
