### PR TITLE
Revert "update openssl dependency tag from openssl-3.1.2-quic1 to ope…

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -105,7 +105,7 @@ fetch () {
   #checkout_repo zlib      https://github.com/madler/zlib            "v1.2.13"
   #checkout_repo bzip2     https://sourceware.org/git/bzip2.git      "bzip2-1.0.8"
   #checkout_repo zstd      https://github.com/facebook/zstd          "v1.5.4"
-  checkout_repo openssl   https://github.com/quictls/openssl        "openssl-3.1.2+quic"
+  checkout_repo openssl   https://github.com/quictls/openssl        "openssl-3.1.2-quic1"
   #checkout_repo rocksdb   https://github.com/facebook/rocksdb       "v7.10.2"
   #checkout_repo secp256k1 https://github.com/bitcoin-core/secp256k1 "v0.3.2"
 }


### PR DESCRIPTION
This reverts commit a58d342b632c42bf2fb8576e872d06e5759302ba.