### PR TITLE
fdctl: separate workspace for transaction pipeline

### DIFF
--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -14,6 +14,7 @@
 
 typedef struct {
   enum {
+    wksp_tpu_txn_data,
     wksp_quic_verify,
     wksp_verify_dedup,
     wksp_dedup_pack,

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -112,13 +112,13 @@ dynamic_port_range = "8000-10000"
     # If nonzero, enable JSON RPC on this port, and use the next port for the
     # RPC websocket. If zero, disable JSON RPC. This option is passed to the
     # Solana Labs client with the `--rpc-port` argument.
-    port = 0
+    port = 8899
 
     # If true, all RPC operations are enabled on this validator, including
     # non-default RPC methods for querying chain state and transaction history.
     # This option is passed to the Solana Labs client with the `--full-rpc-api`
     # argument.
-    full_api = false
+    full_api = true
 
     # If the RPC is private, the valdiator's open RPC port is not published in
     # the `solana gossip` command for use by others. This option is passed to
@@ -129,7 +129,7 @@ dynamic_port_range = "8000-10000"
     # `getConfirmedBlock` API. This will cause an increase in disk usage and
     # IOPS. This option is passed to the Solana Labs client with the
     # `--enable-rpc-transaction-history` argument.
-    transaction_history = false
+    transaction_history = true
 
     # If enabled, include CPI inner instructions, logs, and return data in the
     # historical transaction info stored. This option is passed to the Solana

--- a/src/app/fdctl/configure/workspace.c
+++ b/src/app/fdctl/configure/workspace.c
@@ -216,10 +216,14 @@ init( config_t * const config ) {
     WKSP_BEGIN( config, wksp1, 0 );
 
     switch( wksp1->kind ) {
+      case wksp_tpu_txn_data:
+        for( ulong i=0; i<config->layout.verify_tile_count; i++ ) {
+          dcache( pod, "dcache%lu", config->tiles.verify.mtu, config->tiles.verify.receive_buffer_size, config->tiles.verify.receive_buffer_size * 32, i );
+        }
+        break;
       case wksp_quic_verify:
         for( ulong i=0; i<config->layout.verify_tile_count; i++ ) {
           mcache( pod, "mcache%lu", config->tiles.verify.receive_buffer_size, i );
-          dcache( pod, "dcache%lu", config->tiles.verify.mtu, config->tiles.verify.receive_buffer_size, config->tiles.verify.receive_buffer_size * 32, i );
           fseq  ( pod, "fseq%lu", i );
         }
         break;
@@ -227,7 +231,6 @@ init( config_t * const config ) {
         ulong1( pod, "cnt", config->layout.verify_tile_count );
         for( ulong i=0; i<config->layout.verify_tile_count; i++ ) {
           mcache( pod, "mcache%lu", config->tiles.verify.receive_buffer_size, i );
-          dcache( pod, "dcache%lu", config->tiles.verify.mtu, config->tiles.verify.receive_buffer_size, 0, i );
           fseq  ( pod, "fseq%lu",   i );
         }
         break;
@@ -241,6 +244,8 @@ init( config_t * const config ) {
           mcache( pod, "mcache%lu", config->tiles.bank.receive_buffer_size, i );
           dcache( pod, "dcache%lu", USHORT_MAX, config->layout.bank_tile_count * (ulong)config->tiles.bank.receive_buffer_size, 0, i );
           fseq  ( pod, "fseq%lu", i );
+          mcache( pod, "mcache-back%lu", config->tiles.bank.receive_buffer_size, i );
+          fseq  ( pod, "fseq-back%lu", i );
         }
         break;
       case wksp_bank_shred:

--- a/src/app/fdctl/run.c
+++ b/src/app/fdctl/run.c
@@ -111,6 +111,7 @@ tile_main( void * _args ) {
     .tile_name = args->tile->name,
     .in_pod = NULL,
     .out_pod = NULL,
+    .extra_pod = NULL,
     .tick_per_ns = args->tick_per_ns,
   };
 
@@ -119,6 +120,8 @@ tile_main( void * _args ) {
     frank_args.in_pod = workspace_pod_join( args->app_name, args->tile->in_wksp, 0 );
   if( FD_LIKELY( args->tile->out_wksp ) )
     frank_args.out_pod = workspace_pod_join( args->app_name, args->tile->out_wksp, 0 );
+  if( FD_LIKELY( args->tile->extra_wksp ) )
+    frank_args.extra_pod = workspace_pod_join( args->app_name, args->tile->extra_wksp, 0 );
 
   if( FD_UNLIKELY( args->tile->init ) ) args->tile->init( &frank_args );
 

--- a/src/app/fddev/configure/cluster.c
+++ b/src/app/fddev/configure/cluster.c
@@ -53,6 +53,7 @@ init( config_t * const config ) {
   ADD( "--bootstrap-validator", config->consensus.identity_path );
   ADD1( vote );
   ADD1( stake );
+  ADD( "--bootstrap-stake-authorized-pubkey", config->consensus.identity_path );
 
   ADD( "--ledger", config->ledger.path );
   ADD( "--faucet-pubkey", faucet );
@@ -153,7 +154,7 @@ check( config_t * const config ) {
 
 configure_stage_t cluster = {
   .name            = NAME,
-  .always_recreate = 0,
+  .always_recreate = 1,
   .enabled         = enabled,
   .init_perm       = NULL,
   .fini_perm       = NULL,

--- a/src/app/fddev/dev.c
+++ b/src/app/fddev/dev.c
@@ -74,6 +74,15 @@ dev_cmd_fn( args_t *         args,
      validator will get stuck forever. */
   config->consensus.wait_for_vote_to_start_leader = 0;
 
+  config->consensus.genesis_fetch = 0;
+  config->consensus.snapshot_fetch = 0;
+
+  if( FD_LIKELY( !strcmp( config->consensus.vote_account_path, "" ) ) )
+    snprintf1( config->consensus.vote_account_path,
+               sizeof( config->consensus.vote_account_path ),
+               "%s/vote-account.json",
+               config->scratch_directory );
+
   if( FD_UNLIKELY( config->development.netns.enabled ) ) {
     /* if we entered a network namespace during configuration, leave it
        so that `run_firedancer` starts from a clean namespace */

--- a/src/app/frank/fd_frank.h
+++ b/src/app/frank/fd_frank.h
@@ -35,6 +35,7 @@ typedef struct {
    uchar const * tile_pod;
    uchar const * in_pod;
    uchar const * out_pod;
+   uchar const * extra_pod;
    fd_xsk_t    * xsk;
    double        tick_per_ns;
 } fd_frank_args_t;
@@ -43,6 +44,7 @@ typedef struct {
    char *  name;
    char *  in_wksp;
    char *  out_wksp;
+   char *  extra_wksp;
    ushort  allow_syscalls_sz;
    long *  allow_syscalls;
    ulong (*allow_fds)( fd_frank_args_t * args, ulong out_fds_sz, int * out_fds );

--- a/src/app/frank/fd_frank_dedup.c
+++ b/src/app/frank/fd_frank_dedup.c
@@ -101,6 +101,7 @@ fd_frank_task_t frank_dedup = {
   .name              = "dedup",
   .in_wksp           = "verify_dedup",
   .out_wksp          = "dedup_pack",
+  .extra_wksp        = NULL,
   .allow_syscalls_sz = sizeof(allow_syscalls)/sizeof(allow_syscalls[ 0 ]),
   .allow_syscalls    = allow_syscalls,
   .allow_fds         = allow_fds,

--- a/src/app/frank/fd_frank_quic.c
+++ b/src/app/frank/fd_frank_quic.c
@@ -53,7 +53,7 @@ run( fd_frank_args_t * args ) {
 
   FD_LOG_INFO(( "joining dcache" ));
   snprintf( path, sizeof(path), "dcache%lu", args->tile_idx );
-  uchar * dcache = fd_dcache_join( fd_wksp_pod_map( args->out_pod, path ) );
+  uchar * dcache = fd_dcache_join( fd_wksp_pod_map( args->extra_pod, path ) );
   if( FD_UNLIKELY( !dcache ) ) FD_LOG_ERR(( "fd_dcache_join failed" ));
 
   FD_LOG_INFO(( "loading quic" ));
@@ -154,6 +154,7 @@ fd_frank_task_t frank_quic = {
   .name              = "quic",
   .in_wksp           = NULL,
   .out_wksp          = "quic_verify",
+  .extra_wksp        = "tpu_txn_data",
   .allow_syscalls_sz = sizeof(allow_syscalls)/sizeof(allow_syscalls[ 0 ]),
   .allow_syscalls    = allow_syscalls,
   .allow_fds         = allow_fds,


### PR DESCRIPTION
A shared workspace is added for the QUIC, verify, dedup, and pack tiles so that they can share dcache entries and not copy transactions back and forth.