### PR TITLE
Fuzz: Generate reports

### DIFF
--- a/.github/workflows/make_daily.yml
+++ b/.github/workflows/make_daily.yml
@@ -6,6 +6,12 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   # Ensures that cron job is skipped if no commit was made on that day.
   check-date:
@@ -206,3 +212,54 @@ jobs:
       with:
         category: "/language:${{matrix.language}}"
         threads: 0
+
+  fuzz-coverage:
+    name: Fuzzer Coverage
+    runs-on:
+      group: github-v1
+    steps:
+      - name: Install Dependencies
+        run: sudo apt-get update && sudo apt-get install -y llvm lcov
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{ secrets.FUZZ_SERVICE_ACCT_JSON_BUNDLE }}
+
+      - uses: ./.github/actions/deps
+
+      # Not using fuzzbot-builder because llvm-cov must be ran in the same environment otherwise paths will not match
+      - name: Build Fuzz Tests
+        env:
+          CC: clang
+          MACHINE: linux_clang_x86_64_fuzz_asan
+          EXTRAS: llvm-cov
+        run: make -j -Otarget fuzz-test
+
+      - name: Fetch Corpus, Generate Fuzzing Coverage
+        run: ./.github/workflows/scripts/fuzzcov_generate.sh build/linux/clang/x86_64_fuzz_asan/fuzz-test/
+
+      - name: Publish Fuzzing Coverage to codecov.io
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: ./.github/workflows/scripts/fuzzcov_publish_codecov.sh
+
+      - name: Generate HTML Fuzzing Coverage Reports
+        run: ./.github/workflows/scripts/fuzzcov_genhtml.sh "${{ github.sha }}"
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          # Upload entire repository
+          path: './build/pages/'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/scripts/fuzzcov_generate.sh
+++ b/.github/workflows/scripts/fuzzcov_generate.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -uEexo pipefail
+
+mkdir -p build/fuzzcov/{profraw,profdata,lcov,corpus,corpus_unpacked}
+TARGET_DIR=$1
+
+# List all the corpus prefixes and save those to the `corpora` array
+readarray corpora < <(printf '%s' "$(gcloud storage ls gs://backup.isol-clusterfuzz.appspot.com/corpus/libFuzzer/)")
+
+# Get the latest corpus backups and unpack those in a directory named with the target's name
+for corpus in "${corpora[@]}"; do
+    BASE=$(basename ${corpus})
+    gcloud storage cp "$(echo $corpus | sed 's/ *$//g')latest.zip" "build/fuzzcov/corpus/${BASE}.zip"
+    unzip -q "build/fuzzcov/corpus/${BASE}.zip" -d build/fuzzcov/corpus_unpacked/${BASE} < <(yes)
+done
+
+# Run a fuzzing target against the entirety of its corpus
+for corpus in "${corpora[@]}"; do
+    BASE=$(basename ${corpus})
+    TARGET="${TARGET_DIR}/${BASE}/${BASE}"
+
+    # Run the fuzzing target
+    if [[ -f $TARGET ]]; then
+        export LLVM_PROFILE_FILE="build/profraw/${BASE}.profraw"
+        find build/fuzzcov/corpus_unpacked/${BASE}/ -type f -exec $TARGET {} +
+        llvm-profdata merge -sparse "${LLVM_PROFILE_FILE}" -o "build/fuzzcov/profdata/${BASE}.profdata"
+        CODECOV_FILE=${BASE}.lcov
+        llvm-cov export $TARGET -instr-profile="build/fuzzcov/profdata/${BASE}.profdata" -format=lcov > "build/fuzzcov/lcov/${BASE}.lcov"
+    else
+        echo "No such target '${TARGET}' but fuzzing corpus exists for it."
+    fi
+done

--- a/.github/workflows/scripts/fuzzcov_genhtml.sh
+++ b/.github/workflows/scripts/fuzzcov_genhtml.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -uEexo pipefail
+
+mkdir -p build/pages/fuzzcov/
+
+FUZZINDEX=build/pages/fuzzcov/index.html
+cat > $FUZZINDEX <<EOS
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>🔥💃 FuzzCov</title></head>
+<body>
+    <h1>🔥💃 Fuzzing Coverage</h1>
+EOS
+
+echo "<p>From rev: $1</p><ul>" >> $FUZZINDEX
+
+echo "<li><a href=\"./all\">all/</a></li>" >> $FUZZINDEX
+genhtml --output-directory "build/pages/fuzzcov/all" build/fuzzcov/lcov/*.lcov
+
+for f in build/fuzzcov/lcov/*.lcov
+do
+    BASE=$(basename "${f}")
+    echo "<li><a href=\"./${BASE}\">${BASE}/</a></li>" >> $FUZZINDEX
+    mkdir -p "build/pages/fuzzcov/${BASE}"
+    genhtml --output-directory "build/pages/fuzzcov/${BASE}" $f
+done
+
+cat >> $FUZZINDEX <<EOS
+</ul></body></html>
+EOS

--- a/.github/workflows/scripts/fuzzcov_publish_codecov.sh
+++ b/.github/workflows/scripts/fuzzcov_publish_codecov.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -uEexo pipefail
+
+mkdir -p build/codecovio-bin/
+
+CODECOV=build/codecovio-bin/codecov
+
+if [ ! -f $CODECOV ]
+then
+    curl -Lo $CODECOV https://uploader.codecov.io/latest/linux/codecov
+    chmod +x $CODECOV
+fi
+
+for f in build/fuzzcov/lcov/*.lcov
+do
+    BASE="$(basename $f)"
+    $CODECOV \
+        -f "${f}" \
+        -F "${BASE}"
+done


### PR DESCRIPTION
This PR upgrades the daily workflow so that it:

- for each fuzzing target:
  - pulls corpus from ClusterFuzz
  - runs the whole corpus through the target
  - compiles coverage
  - publishes coverage to https://app.codecov.io/github/firedancer-io/firedancer
  - generates lcov-genhtml reports to `build/pages/fuzzcov`

- generates an index for `fuzzcov/`
- publishes `build/pages` to https://firedancer-io.github.io/

https://vigilant-carnival-vrqv8pw.pages.github.io/fuzzcov/

