### PR TITLE
xdp: also listen on loopback by default

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -278,7 +278,8 @@ static void parse_key_value( config_t *   config,
   ENTRY_STR   ( ., development.netns,   interface1_addr                                           );
 
   ENTRY_STR   ( ., tiles.quic,          interface                                                 );
-  ENTRY_USHORT( ., tiles.quic,          listen_port                                               );
+  ENTRY_USHORT( ., tiles.quic,          transaction_listen_port                                   );
+  ENTRY_USHORT( ., tiles.quic,          quic_transaction_listen_port                              );
   ENTRY_UINT  ( ., tiles.quic,          max_concurrent_connections                                );
   ENTRY_UINT  ( ., tiles.quic,          max_concurrent_connection_ids_per_connection              );
   ENTRY_UINT  ( ., tiles.quic,          max_concurrent_streams_per_connection                     );
@@ -729,6 +730,12 @@ config_parse( int *    pargc,
     if( FD_UNLIKELY( result.development.netns.enabled ) )
       FD_LOG_ERR(( "trying to join a live cluster, but configuration enables [development.netns] which is a development only feature" ));
   }
+
+  if( FD_UNLIKELY( result.tiles.quic.quic_transaction_listen_port != result.tiles.quic.transaction_listen_port + 6 ) )
+    FD_LOG_ERR(( "configuration specifies invalid [tiles.quic.quic_transaction_listen_port] `%hu`. "
+                 "This must be 6 more than [tiles.quic.transaction_listen_port] `%hu`",
+                 result.tiles.quic.quic_transaction_listen_port,
+                 result.tiles.quic.transaction_listen_port ));
 
   init_workspaces( &result );
 

--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -131,7 +131,8 @@ typedef struct {
       char   interface[ IF_NAMESIZE ];
       uint   ip_addr;
       uchar  mac_addr[6];
-      ushort listen_port;
+      ushort transaction_listen_port;
+      ushort quic_transaction_listen_port;
       char   xdp_mode[ 8 ];
 
       uint max_concurrent_connections;

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -370,8 +370,13 @@ dynamic_port_range = "8000-10000"
         # you can check what this is with `ip route get 8.8.8.8`
         interface = ""
 
-        # Which port to listen on.
-        listen_port = 9001
+        # Which port to listen on for incoming transactions. This could be votes,
+        # user transactions, or transactions forwarded from another validator.
+        transaction_listen_port = 9001
+
+        # Which port to listen on for incoming quic transactions. Currently
+        # this must be exactly 6 more than the transaction_listen_port.
+        quic_transaction_listen_port = 9007
 
         # Maximum number of simultaneous QUIC connections which can be open. New
         # connections which would exceed this limit will not be accepted.

--- a/src/app/fdctl/run.c
+++ b/src/app/fdctl/run.c
@@ -242,7 +242,12 @@ solana_labs_main( void * args ) {
   ADD1( "fdctl" );
   ADD( "--log", "-" );
 
-  ADD( "--dynamic-port-range", config->dynamic_port_range );
+  if( FD_UNLIKELY( strcmp( config->dynamic_port_range, "" ) ) )
+    ADD( "--dynamic-port-range", config->dynamic_port_range );
+
+  char ip_addr[16];
+  snprintf1( ip_addr, 16, FD_IP4_ADDR_FMT, FD_IP4_ADDR_FMT_ARGS(config->tiles.quic.ip_addr) );
+  ADD( "--gossip-host", ip_addr );
 
   /* consensus */
   ADD( "--identity", identity_path );

--- a/src/app/frank/fd_frank.h
+++ b/src/app/frank/fd_frank.h
@@ -37,6 +37,7 @@ typedef struct {
    uchar const * out_pod;
    uchar const * extra_pod;
    fd_xsk_t    * xsk;
+   fd_xsk_t    * lo_xsk;
    double        tick_per_ns;
 } fd_frank_args_t;
 

--- a/src/disco/quic/fd_quic.h
+++ b/src/disco/quic/fd_quic.h
@@ -121,6 +121,7 @@ int
 fd_quic_tile( fd_cnc_t *         cnc,           /* Local join to the tile's command-and-control */
               fd_quic_t *        quic,          /* QUIC without active join */
               fd_xsk_aio_t *     xsk_aio,       /* Local join to QUIC XSK aio */
+              fd_xsk_aio_t *     lo_xsk_aio,    /* Local join to QUIC XSK aio for loopback interface */
               fd_frag_meta_t *   mcache,        /* Local join to the tile's txn output mcache */
               uchar *            dcache,        /* Local join to the tile's txn output dcache */
               long               lazy,          /* Laziness, <=0 means use a reasonable default */

--- a/src/disco/quic/fd_quic_tile.c
+++ b/src/disco/quic/fd_quic_tile.c
@@ -104,6 +104,29 @@ fd_tpu_conn_destroy( fd_quic_conn_t * conn,
   ctx->cnc_diag_tpu_conn_live_cnt--;
 }
 
+static void
+fd_tpu_dummy_dcache( fd_quic_tpu_ctx_t * ctx ) {
+  /* By default the dcache only has headroom for one in-flight fragment, but
+     QUIC might have many. If we exceed the headroom, we publish a dummy
+     mcache entry to evict the reader from this fragment we want to use so we
+     can start using it.
+
+     This is not ideal because if the reader is already done with the fragment
+     we are writing a useless mcache entry, so we try and do it only when
+     needed.
+
+     The QUIC receive path might typically execute stream_create,
+     stream_receive, and stream_notice serially, so it is often the case that
+     even if we are handling multiple new connections in one receive batch,
+     the in-flight count remains zero or one. */
+  if( ctx->inflight_streams > 0 ) {
+    ulong ctl   = fd_frag_meta_ctl( 0, 1 /* som */, 1 /* eom */, 0 /* err */ );
+    ulong tsnow = fd_frag_meta_ts_comp( fd_tickcount() );
+    fd_mcache_publish( ctx->mcache, ctx->depth, *ctx->seq, 1, 0, 0, ctl, tsnow, tsnow );
+    *ctx->seq = fd_seq_inc( *ctx->seq, 1UL );
+  }
+}
+
 /* fd_tpu_stream_create implements fd_quic_cb_stream_new_t */
 static void
 fd_tpu_stream_create( fd_quic_stream_t * stream,
@@ -143,25 +166,7 @@ fd_tpu_stream_create( fd_quic_stream_t * stream,
   msg_ctx->sz        = 0U;
   msg_ctx->tsorig    = (uint)fd_frag_meta_ts_comp( fd_tickcount() );
 
-  /* By default the dcache only has headroom for one in-flight fragment, but
-     QUIC might have many. If we exceed the headroom, we publish a dummy
-     mcache entry to evict the reader from this fragment we want to use so we
-     can start using it.
-     
-     This is not ideal because if the reader is already done with the fragment
-     we are writing a useless mcache entry, so we try and do it only when
-     needed.
-     
-     The QUIC receive path might typically execute stream_create,
-     stream_receive, and stream_notice serially, so it is often the case that
-     even if we are handling multiple new connections in one receive batch,
-     the in-flight count remains zero or one. */
-  if( ctx->inflight_streams > 0 ) {
-    ulong ctl   = fd_frag_meta_ctl( 0, 1 /* som */, 1 /* eom */, 0 /* err */ );
-    ulong tsnow = fd_frag_meta_ts_comp( fd_tickcount() );
-    fd_mcache_publish( ctx->mcache, ctx->depth, *ctx->seq, 1, 0, 0, ctl, tsnow, tsnow );
-    *ctx->seq = fd_seq_inc( *ctx->seq, 1UL );
-  }
+  fd_tpu_dummy_dcache( ctx );
 
   ctx->inflight_streams += 1;
 
@@ -169,6 +174,43 @@ fd_tpu_stream_create( fd_quic_stream_t * stream,
 
   ctx->chunk      = chunk;    /* Update dcache chunk index */
   stream->context = msg_ctx;  /* Update stream dcache entry */
+}
+
+void
+fd_quic_transaction_receive( fd_quic_t *         _ctx,
+                             uchar const *       packet,
+                             uint                packet_sz ) {
+  fd_quic_tpu_ctx_t * ctx = _ctx->cb.quic_ctx;
+
+  /* Load dcache info */
+  uchar * const base       = ctx->base;
+  uchar * const dcache_app = ctx->dcache_app;
+  ulong   const chunk0     = ctx->chunk0;
+  ulong   const wmark      = ctx->wmark;
+  ulong         chunk      = ctx->chunk;
+
+  /* Allocate new dcache entry */
+  chunk = fd_dcache_compact_next( chunk, FD_TPU_DCACHE_MTU, chunk0, wmark );
+
+  fd_quic_tpu_msg_ctx_t * msg_ctx = fd_quic_dcache_msg_ctx( dcache_app, chunk0, chunk );
+  msg_ctx->conn_id   = ULONG_MAX;
+  msg_ctx->stream_id = ULONG_MAX;
+  msg_ctx->data      = fd_chunk_to_laddr( base, chunk );
+  msg_ctx->sz        = packet_sz;
+  msg_ctx->tsorig    = (uint)fd_frag_meta_ts_comp( fd_tickcount() );
+
+  fd_tpu_dummy_dcache( ctx );
+
+  /* Add to local publish queue */
+  if( FD_UNLIKELY( pubq_full( ctx->pubq ) ) ) {
+    FD_LOG_WARNING(( "pubq full, dropping" ));
+    return;
+  }
+
+  fd_memcpy( msg_ctx->data, packet, packet_sz );
+  pubq_push( ctx->pubq, msg_ctx );
+
+  ctx->chunk      = chunk;    /* Update dcache chunk index */
 }
 
 /* fd_tpu_stream_receive implements fd_quic_cb_stream_receive_t */
@@ -259,6 +301,7 @@ int
 fd_quic_tile( fd_cnc_t *         cnc,
               fd_quic_t *        quic,
               fd_xsk_aio_t *     xsk_aio,
+              fd_xsk_aio_t *     lo_xsk_aio,
               fd_frag_meta_t *   mcache,
               uchar *            dcache,
               long               lazy,
@@ -448,6 +491,7 @@ fd_quic_tile( fd_cnc_t *         cnc,
 
     /* Poll network backend */
     fd_xsk_aio_service( xsk_aio );
+    if( FD_UNLIKELY( lo_xsk_aio ) ) fd_xsk_aio_service( lo_xsk_aio );
 
     /* Service QUIC clients */
     fd_quic_service( quic );

--- a/src/disco/quic/test_quic_tile.c
+++ b/src/disco/quic/test_quic_tile.c
@@ -188,6 +188,7 @@ tx_tile_main( int     argc,
       cfg->tx_cnc,
       cfg->tx_quic,
       cfg->xsk_aio,
+      NULL,
       cfg->tx_mcache,
       cfg->tx_dcache,
       cfg->tx_lazy,
@@ -225,7 +226,7 @@ int main( int     argc,
   char const * iface        =       fd_env_strip_cmdline_cstr  ( &argc, &argv, "--iface",          NULL, NULL                         );
   uint         ifqueue      =       fd_env_strip_cmdline_uint  ( &argc, &argv, "--ifqueue",        NULL, 0U                           );
   char const * _listen_addr =       fd_env_strip_cmdline_cstr  ( &argc, &argv, "--listen",         NULL, NULL                         );
-  uint         udp_port     =       fd_env_strip_cmdline_uint  ( &argc, &argv, "--port",           NULL, 8080U                        );
+  ushort       udp_port     =       fd_env_strip_cmdline_ushort( &argc, &argv, "--port",           NULL, 8080U                        );
   char const * _hwaddr      =       fd_env_strip_cmdline_cstr  ( &argc, &argv, "--hwaddr",         NULL, NULL                         );
   char const * bpf_dir      =       fd_env_strip_cmdline_cstr  ( &argc, &argv, "--bpf-dir",        NULL, "test_quic"                  );
 
@@ -245,7 +246,7 @@ int main( int     argc,
   if( FD_UNLIKELY( !fd_cstr_to_ip4_addr( _listen_addr, &listen_addr ) ) )
     FD_LOG_ERR(( "invalid IPv4 address \"%s\"", _listen_addr ));
 
-  if( FD_UNLIKELY( udp_port<=0 || udp_port>USHORT_MAX ) )
+  if( FD_UNLIKELY( udp_port<=0 ) )
     FD_LOG_ERR(( "invalid UDP port %d", udp_port ));
 
   if( FD_UNLIKELY( !_hwaddr  ) ) FD_LOG_ERR(( "missing --hwaddr" ));
@@ -314,7 +315,7 @@ int main( int     argc,
 
   FD_LOG_NOTICE(( "Listening on " FD_IP4_ADDR_FMT ":%u",
                   FD_IP4_ADDR_FMT_ARGS( listen_addr ), udp_port ));
-  FD_TEST( 0==fd_xdp_listen_udp_port( bpf_dir, listen_addr, udp_port, 0U ) );
+  FD_TEST( 0==fd_xdp_listen_udp_ports( bpf_dir, listen_addr, 1, &udp_port, 0U ) );
 
   FD_LOG_NOTICE(( "Joining xsk" ));
   cfg->xsk = fd_xsk_join( shxsk );

--- a/src/tango/quic/tests/fd_quic_test_helpers.c
+++ b/src/tango/quic/tests/fd_quic_test_helpers.c
@@ -380,7 +380,7 @@ fd_quic_udpsock_create( void *           _sock,
 
     FD_LOG_NOTICE(( "Adding UDP listener (" FD_IP4_ADDR_FMT ":%u)",
                     FD_IP4_ADDR_FMT_ARGS( quic_sock->listen_ip ), quic_sock->listen_port ));
-    if( FD_UNLIKELY( 0!=fd_xdp_listen_udp_port( xdp_app_name, quic_sock->listen_ip, quic_sock->listen_port, 0 ) ) ) {
+    if( FD_UNLIKELY( 0!=fd_xdp_listen_udp_ports( xdp_app_name, quic_sock->listen_ip, 1, &quic_sock->listen_port, 0 ) ) ) {
       FD_LOG_WARNING(( "failed to add UDP listener" ));
       fd_xsk_aio_leave( xsk_aio );
       fd_xsk_leave( xsk );

--- a/src/tango/quic/tests/test_quic_txn.c
+++ b/src/tango/quic/tests/test_quic_txn.c
@@ -82,7 +82,7 @@ run_quic_client( fd_quic_t *         quic,
                  fd_aio_pkt_info_t * pkt ) {
   uint dst_ip;
   if( FD_UNLIKELY( !fd_cstr_to_ip4_addr( "198.18.0.1", &dst_ip  ) ) ) FD_LOG_ERR(( "invalid --dst-ip" ));
-  ushort dst_port = 9001;
+  ushort dst_port = 9007;
 
 
   #define MSG_SZ_MIN (1UL)

--- a/src/tango/xdp/fd_xdp_ctl.c
+++ b/src/tango/xdp/fd_xdp_ctl.c
@@ -144,8 +144,9 @@ main( int     argc,
       (void)_proto;
       uint proto = 1UL;
 
-      if( FD_UNLIKELY( 0!=fd_xdp_listen_udp_port( _wksp, ip_addr, (uint)udp_port, proto ) ) )
-        FD_LOG_ERR(( "%i: %s: fd_xdp_listen_udp_port(%s,%s,%lu,%s) failed\n\tDo %s help for help",
+      ushort port = (ushort)udp_port;
+      if( FD_UNLIKELY( 0!=fd_xdp_listen_udp_ports( _wksp, ip_addr, 1, &port, proto ) ) )
+        FD_LOG_ERR(( "%i: %s: fd_xdp_listen_udp_ports(%s,%s,%lu,%s) failed\n\tDo %s help for help",
                      cnt, cmd, _wksp, _ip_addr, udp_port, _proto, bin ));
 
       FD_LOG_NOTICE(( "%i: %s %s %s %lu %s: success", cnt, cmd, _wksp, _ip_addr, udp_port, _proto ));

--- a/src/tango/xdp/fd_xdp_redirect_user.h
+++ b/src/tango/xdp/fd_xdp_redirect_user.h
@@ -33,7 +33,7 @@
        - fd_xsk_bind()
        - fd_xsk_join()
    - For each UDP/IP destination to listen on
-     - fd_xdp_listen_udp_port()
+     - fd_xdp_listen_udp_ports()
    - ... Application run ... */
 
 /* TODO: Support NUMA-aware eBPF maps */
@@ -135,8 +135,8 @@ fd_xdp_udp_dst_key( uint ip4_addr,
   return ( (ulong)( ip4_addr )<<16 ) | fd_ushort_bswap( (ushort)udp_port );
 }
 
-/* fd_xdp_listen_udp_port installs a listener for protocol proto on IPv4
-   destination addr ip4_dst_addr and UDP destination port udp_dst_port.
+/* fd_xdp_listen_udp_ports installs a listener for protocol proto on IPv4
+   destination addr ip4_dst_addr and UDP destination ports udp_dst_ports.
    Installation lifetime is until a matching call to
    fd_xdp_release_udp_port() or until the system is shut down.
    On interfaces running the XDP redirect program, causes matching
@@ -145,13 +145,14 @@ fd_xdp_udp_dst_key( uint ip4_addr,
    or if no redirect program installation was found, and -1 on error.
    Reasons for error are logged to FD_LOG_WARNING. */
 int
-fd_xdp_listen_udp_port( char const * app_name,
-                        uint         ip4_dst_addr,
-                        uint         udp_dst_port,
-                        uint         proto );
+fd_xdp_listen_udp_ports( char const * app_name,
+                         uint         ip4_dst_addr,
+                         ulong        udp_dst_ports_sz,
+                         ushort *     udp_dst_ports,
+                         uint         proto );
 
 /* fd_xdp_release_udp_port uninstalls a listener that was previously
-   installed with fd_xdp_listen_udp_port().  Restores processing of
+   installed with fd_xdp_listen_udp_ports().  Restores processing of
    matching traffic in the Linux networking stack.  Returns 0 on success
    or if no redirect program installation was found, and -1 on error.
    Reasons for error are logged to FD_LOG_WARNING. */
@@ -161,7 +162,7 @@ fd_xdp_release_udp_port( char const * app_name,
                          uint         udp_dst_port );
 
 /* fd_xdp_clear_listeners uninstalls all listeners previously installed
-   via fd_xdp_listen_udp_port(). */
+   via fd_xdp_listen_udp_ports(). */
 
 int
 fd_xdp_clear_listeners( char const * app_name );

--- a/src/test/frank-single-transaction.sh
+++ b/src/test/frank-single-transaction.sh
@@ -33,5 +33,5 @@ FDDEV_PID=$!
 sleep 4
 sudo nsenter --net=/var/run/netns/veth_test_xdp_1 ${TEST_QUIC_TXN}
 RETVAL=$?
-sudo kill -9 $FDDEV_PID
+sudo kill $FDDEV_PID
 exit $RETVAL


### PR DESCRIPTION
The Linux kernel does some short circuiting optimizations when sending packets to an IP address that's owned by the same host. The optimization is basically to route them over to the loopback interface directly, bypassing the network hardware.

This redirection to the loopback interface happens before XDP programs are executed, so local traffic destined for our listen addresses will not get ingested correctly.

There are two reasons we send traffic locally,

* For testing and development.
* The Solana Labs code sends local traffic to itself to as part of routine operation (eg, when it's the leader it sends votes to its own TPU socket).

So for now we need to also bind to loopback. This is a small performance hit for other traffic, but we only redirect packets destined for our target IP and port so it will not otherwise interfere.

Hopefully we can remove this for production use cases soon once we change how the validator communicates with itself.