### PR TITLE
Update Cargo.toml

### DIFF
--- a/ffi/rust/Cargo.toml
+++ b/ffi/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["ffi/rust/firedancer-sys", "ffi/rust/firedancer-diff"]
+members = ["firedancer-sys", "firedancer-diff"]
 resolver = "2"
 
 [profile.dev]


### PR DESCRIPTION
corrected toml now that it's moved into `ffi/rust`