### PR TITLE
fdctl: create genesis correctly

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -292,7 +292,7 @@ dynamic_port_range = "8000-10000"
     #
     # It is suggested to use all available CPU cores for Firedancer, so that the
     # Solana network can run as fast as possible.
-    affinity = "0-11"
+    affinity = "0-14"
 
     # How many verify tiles to run. Currently this also configures the number of
     # QUIC tiles to run. QUIC and verify tiles are connected 1:1.

--- a/src/app/fdctl/configure/configure.c
+++ b/src/app/fdctl/configure/configure.c
@@ -161,9 +161,20 @@ configure_cmd_fn( args_t *         args,
                   config_t * const config ) {
   int error = 0;
 
-  for( configure_stage_t ** stage = args->configure.stages; *stage; stage++ ) {
-    if( FD_UNLIKELY( configure_stage( *stage, (configure_cmd_t)args->configure.command, config ) ) ) error = 1;
+  if( FD_LIKELY( (configure_cmd_t)args->configure.command != CONFIGURE_CMD_FINI ) ) {
+    for( configure_stage_t ** stage = args->configure.stages; *stage; stage++ ) {
+      if( FD_UNLIKELY( configure_stage( *stage, (configure_cmd_t)args->configure.command, config ) ) ) error = 1;
+    }
+  } else {
+    ulong i;
+    for( i=0; args->configure.stages[ i ]; i++ ) ;
+    if( FD_LIKELY( i > 0 ) ) {
+      for( ulong j=0; j<i; j++ ) {
+        if( FD_UNLIKELY( configure_stage( args->configure.stages[ i-1-j ], (configure_cmd_t)args->configure.command, config ) ) ) error = 1;
+      }
+    }
   }
+
 
   if( FD_UNLIKELY( error ) ) FD_LOG_ERR(( "failed to configure some stages" ));
 }

--- a/src/app/fdctl/configure/configure.h
+++ b/src/app/fdctl/configure/configure.h
@@ -62,13 +62,11 @@ typedef struct configure_stage {
 extern configure_stage_t large_pages;
 extern configure_stage_t shmem;
 extern configure_stage_t sysctl;
-extern configure_stage_t netns;
 extern configure_stage_t xdp;
 extern configure_stage_t xdp_leftover;
 extern configure_stage_t ethtool;
 extern configure_stage_t workspace_leftover;
 extern configure_stage_t workspace;
-extern configure_stage_t cluster;
 
 extern configure_stage_t * STAGES[];
 

--- a/src/app/fdctl/configure/workspace.c
+++ b/src/app/fdctl/configure/workspace.c
@@ -331,8 +331,10 @@ fini( config_t * const config ) {
     if( FD_LIKELY( !result ) ) {
       char name[ FD_WKSP_CSTR_MAX ];
       workspace_name( config, wksp, name );
-      int err = fd_wksp_delete_named( name );
-      if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "fd_wksp_delete_named failed (%i-%s)", err, fd_wksp_strerror( err ) ));
+      if( FD_UNLIKELY( fd_wksp_delete_named( name ) ) ) {
+        if( FD_UNLIKELY( -1==unlink( path ) ) )
+          FD_LOG_ERR(( "unlink failed when trying to delete wksp `%s` (%i-%s)", path, errno, fd_io_strerror( errno ) ));
+      }
     }
     else if( FD_LIKELY( result && errno == ENOENT ) ) continue;
     else FD_LOG_ERR(( "stat failed when trying to delete wksp `%s` (%i-%s)", path, errno, fd_io_strerror( errno ) ));

--- a/src/app/fdctl/run.c
+++ b/src/app/fdctl/run.c
@@ -332,8 +332,27 @@ main_pid_namespace( void * args ) {
 
   ushort tile_to_cpu[ FD_TILE_MAX ];
   ulong  affinity_tile_cnt = fd_tile_private_cpus_parse( config->layout.affinity, tile_to_cpu );
-  /* TODO: Can we use something like config->shmem.workspaces_cnt = idx; here instead? */
-   ulong tile_cnt = 4UL + config->layout.verify_tile_count * 2;
+  ulong tile_cnt = 0;
+  for( ulong i=0; i<config->shmem.workspaces_cnt; i++ ) {
+    switch( config->shmem.workspaces[ i ].kind ) {
+      case wksp_tpu_txn_data:
+      case wksp_quic_verify:
+      case wksp_verify_dedup:
+      case wksp_dedup_pack:
+      case wksp_pack_bank:
+      case wksp_pack_forward:
+      case wksp_bank_shred:
+        break;
+      case wksp_quic:
+      case wksp_verify:
+      case wksp_dedup:
+      case wksp_pack:
+      case wksp_bank:
+      case wksp_forward:
+        tile_cnt++;
+        break;
+    }
+  }
   if( FD_UNLIKELY( affinity_tile_cnt<tile_cnt ) ) FD_LOG_ERR(( "at least %lu tiles required for this config", tile_cnt ));
   if( FD_UNLIKELY( affinity_tile_cnt>tile_cnt ) ) FD_LOG_WARNING(( "only %lu tiles required for this config", tile_cnt ));
 
@@ -428,7 +447,7 @@ static void
 parent_signal( int sig ) {
   (void)sig;
   if( pid_namespace ) kill( pid_namespace, SIGKILL );
-  fd_log_private_fprintf_0( STDERR_FILENO, "Log at \"%s\"", fd_log_private_path );
+  fd_log_private_fprintf_0( STDERR_FILENO, "Log at \"%s\"\n", fd_log_private_path );
   exit_group( 0 );
 }
 

--- a/src/app/fddev/Local.mk
+++ b/src/app/fddev/Local.mk
@@ -4,7 +4,7 @@ ifdef FD_HAS_X86
 ifdef FD_HAS_DOUBLE
 
 .PHONY: fddev
-$(call make-bin-rust,fddev,main dev dev1 configure/netns configure/cluster,fd_fdctl fd_frank fd_disco fd_ballet fd_tango fd_util fd_quic solana_validator_fd)
+$(call make-bin-rust,fddev,main dev dev1 configure/netns configure/genesis,fd_fdctl fd_frank fd_disco fd_ballet fd_tango fd_util fd_quic solana_validator_fd)
 
 ifeq (run,$(firstword $(MAKECMDGOALS)))
   RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))

--- a/src/app/fddev/main.c
+++ b/src/app/fddev/main.c
@@ -9,6 +9,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+extern configure_stage_t netns;
+extern configure_stage_t genesis;
+
 configure_stage_t * STAGES[ CONFIGURE_STAGE_COUNT ] = {
   &netns,
   &large_pages,
@@ -19,7 +22,7 @@ configure_stage_t * STAGES[ CONFIGURE_STAGE_COUNT ] = {
   &ethtool,
   &workspace_leftover,
   &workspace,
-  &cluster,
+  &genesis,
   NULL,
 };
 


### PR DESCRIPTION
When creating a genesis block, hashes per tick of "auto" was causing the genesis to not work correctly. Switching this to "sleep" like the Solana Labs run.sh command fixes the problem. Also fixed some other issues,

 * Fixed issue with affinity not matching number of tiles, due to new tiles not getting counted correctly.
 * Fixed problem where fini destructors were run in the wrong order (they should run in reverse).
 * Fixed issue where if workspace creation was killed while in-progress, the workspace would have "bad magic" and be undeleteable.
 * Renamed cluster stage to genesis to better reflect what it does.
 * Fixed problem where genesis creation spawned many threads into the Firedancer root process, causing sanboxing to fail later.
 * Fixed issue where genesis was not being re-created every time, since we were only deleting `genesis.bin` but `genesis.bin.bz2` would remain and get used.