### PR TITLE
Use ONESHELL Make mode

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: ./.github/actions/deps
 
       - name: Build unit tests
-        run: make -j -Otarget unit-test
+        run: make -j unit-test
 
       - uses: ./.github/actions/hugepages
 
@@ -58,7 +58,7 @@ jobs:
       - name: Build Fuzz Tests
         env:
           MACHINE: linux_clang_x86_64_fuzz_asan
-        run: make -j -Otarget fuzz-test
+        run: make -j fuzz-test
 
       - name: Fetch Corpus, Generate Fuzzing Coverage
         run: ./.github/workflows/scripts/fuzzcov_generate.sh build/linux/clang/x86_64_fuzz_asan/fuzz-test/

--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: ./.github/actions/deps
 
       - name: Build everything
-        run: make -j -Otarget fddev unit-test
+        run: make -j fddev unit-test
 
       - name: Run functional tests
         run: |

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: ./.github/actions/deps
 
       - name: Build everything
-        run: make -j -Otarget all rust
+        run: make -j all rust
 
       - uses: ./.github/actions/hugepages
 

--- a/.github/workflows/make_daily.yml
+++ b/.github/workflows/make_daily.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: ./.github/actions/deps
 
       - name: Build unit tests
-        run: make -j -Otarget unit-test
+        run: make -j unit-test
 
       - uses: ./.github/actions/hugepages
 
@@ -59,7 +59,7 @@ jobs:
       - uses: ./.github/actions/deps
 
       - name: Build unit tests
-        run: make -j -Otarget unit-test
+        run: make -j unit-test
 
       - uses: ./.github/actions/hugepages
 
@@ -85,7 +85,7 @@ jobs:
       - uses: firedancer-io/fuzzbot-builder@main
         name: Build fuzz tests
         with:
-          command: make -j -Otarget fuzz-test
+          command: make -j fuzz-test
 
       - name: List Artifacts
         run: |
@@ -102,7 +102,7 @@ jobs:
           service-account-credentials: ${{ secrets.FUZZ_SERVICE_ACCT_JSON_BUNDLE }}
 
       - name: Run fuzz tests
-        run: make -k -j -Otarget run-fuzz-test
+        run: make -k -j run-fuzz-test
 
   # Build and analyze with CodeQL
   codeql:
@@ -137,7 +137,7 @@ jobs:
         languages: ${{ matrix.language }}
 
     - name: Build
-      run: make -j -Otarget all rust
+      run: make -j all rust
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/config/everything.mk
+++ b/config/everything.mk
@@ -4,6 +4,7 @@ MAKEFLAGS += --no-builtin-variables
 .PHONY: all info bin rust include lib unit-test fuzz-test run-unit-test help clean distclean asm ppp show-deps lint check-lint
 .SECONDARY:
 .SECONDEXPANSION:
+.ONESHELL:
 
 OBJDIR:=$(BASEDIR)/$(BUILDDIR)
 CORPUSDIR:=corpus

--- a/contrib/make-j
+++ b/contrib/make-j
@@ -6,7 +6,7 @@ if [ "$ISOLCPUS" = "" ]; then
 
         # No CPU isolation is setup ... just do a normal parallel make
 
-        make -j -Otarget "$@"
+        make -j "$@"
 
 else
 
@@ -32,7 +32,7 @@ else
 
         NP=$(nproc --all)
         NP_OS=$(nproc)
-        chrt -r 1 taskset -c "$ISOLCPUS" make -j$((NP-NP_OS)) -Otarget "$@"
+        chrt -r 1 taskset -c "$ISOLCPUS" make -j$((NP-NP_OS)) "$@"
 
 fi
 


### PR DESCRIPTION
Switches Firedancer's build system to [One Shell](https://www.gnu.org/software/make/manual/html_node/One-Shell.html).

This means that only one shell will be spawned per-target, as opposed to the default "one shell per line in target".

For instance, the following recipe will now only spawn one shell process instead of two:

```
.PHONY: echo
echo:
    echo A
    echo B
```

This improves Make performance (much less process spawns), but it also fixes line reordering, such that `--output-sync=target` is no longer necessary. 