### PR TITLE
fdctl: add ready and txn commands

### DIFF
--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -5,7 +5,7 @@ ifdef FD_HAS_DOUBLE
 
 .PHONY: fdctl run monitor cargo
 
-$(call add-objs,main1 config security utility run keygen monitor/monitor monitor/helper configure/configure configure/large_pages configure/sysctl configure/shmem configure/xdp configure/xdp_leftover configure/ethtool configure/workspace_leftover configure/workspace,fd_fdctl)
+$(call add-objs,main1 config security utility run keygen ready monitor/monitor monitor/helper configure/configure configure/large_pages configure/sysctl configure/shmem configure/xdp configure/xdp_leftover configure/ethtool configure/workspace_leftover configure/workspace,fd_fdctl)
 $(call make-bin-rust,fdctl,main,fd_fdctl fd_frank fd_disco fd_ballet fd_tango fd_util fd_quic solana_validator_fd)
 $(OBJDIR)/obj/app/fdctl/configure/xdp.o: src/tango/xdp/fd_xdp_redirect_prog.o
 $(OBJDIR)/obj/app/fdctl/config.o: src/app/fdctl/config/default.toml

--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -114,7 +114,6 @@ typedef struct {
 
   struct {
     int sandbox;
-    int sudo;
     struct {
       int  enabled;
       char interface0     [ 256 ];

--- a/src/app/fdctl/configure/configure.h
+++ b/src/app/fdctl/configure/configure.h
@@ -82,9 +82,12 @@ typedef struct {
 } configure_args_t;
 
 /* read_uint_file() reads a uint from the given path, or exits the
-   program with an error if any error was encountered. */
+   program with an error if any error was encountered.  If the path
+   cannot be opened due to ENOENT, the error message is prefixed
+   with the string provided in errmsg_enoent. */
 uint
-read_uint_file( const char * path );
+read_uint_file( const char * path,
+                const char * errmsg_enoent );
 
 /* write_uint_file() writes a uint to the given path, or exits the
    program with an error if any error was encountered. */

--- a/src/app/fdctl/configure/large_pages.c
+++ b/src/app/fdctl/configure/large_pages.c
@@ -10,12 +10,12 @@ init_perm( security_t *     security,
 }
 
 uint
-read_uint_file( const char * path ) {
+read_uint_file( const char * path, const char * errmsg_enoent ) {
   FILE * fp = fopen( path, "r" );
   if( FD_UNLIKELY( !fp ) ) {
     if( errno == ENOENT)
-      FD_LOG_ERR(( "please confirm your host is configured for gigantic pages! fopen failed `%s` (%i-%s)",
-                   path, errno, fd_io_strerror( errno ) ));
+      FD_LOG_ERR(( "%s fopen failed `%s` (%i-%s)",
+                   errmsg_enoent, path, errno, fd_io_strerror( errno ) ));
     else
       FD_LOG_ERR(( "fopen failed `%s` (%i-%s)", path, errno, fd_io_strerror( errno ) ));
   }
@@ -88,6 +88,8 @@ expected_pages( config_t * const config, uint out[2] ) {
   out[ 0 ] += ( num_tiles + 2 ) * 6;
 }
 
+static const char * ERR_MSG = "please confirm your host is configured for gigantic pages,";
+
 static void init( config_t * const config ) {
   char * paths[ 2 ] = {
     "/sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages",
@@ -97,7 +99,7 @@ static void init( config_t * const config ) {
   expected_pages( config, expected );
 
   for( int i=0; i<2; i++ ) {
-    uint actual = read_uint_file( paths[ i ] );
+    uint actual = read_uint_file( paths[ i ], ERR_MSG );
 
     try_defragment_memory();
     if( FD_UNLIKELY( actual < expected[ i ] ) )
@@ -114,7 +116,7 @@ static configure_result_t check( config_t * const config ) {
   expected_pages( config, expected );
 
   for( int i=0; i<2; i++ ) {
-    uint actual = read_uint_file( paths[i] );
+    uint actual = read_uint_file( paths[i], ERR_MSG );
     if( FD_UNLIKELY( actual < expected[i] ) )
       NOT_CONFIGURED( "expected at least %u %s pages, but there are %u",
                       expected[i],

--- a/src/app/fdctl/configure/sysctl.c
+++ b/src/app/fdctl/configure/sysctl.c
@@ -28,13 +28,16 @@ static uint limits[] = {
   1000000,
 };
 
+static const char * ERR_MSG = "system might not support configuring sysctl,";
+
+
 /* These sysctl limits are needed for the Solana Labs client, not Firedancer.
    We set them on their behalf to make configuration easier for users. */
 static void
 init( config_t * const config ) {
   (void)config;
   for( ulong i=0; i<sizeof( params ) / sizeof( params[ 0 ] ); i++ ) {
-    uint param = read_uint_file( params[ i ] );
+    uint param = read_uint_file( params[ i ], ERR_MSG );
     if( FD_UNLIKELY( param < limits[ i ] ) )
       write_uint_file( params[ i ], limits[ i ] );
   }
@@ -44,7 +47,7 @@ static configure_result_t
 check( config_t * const config ) {
   (void)config;
   for( ulong i=0; i<sizeof( params ) / sizeof( params[ 0 ] ); i++ ) {
-    uint param = read_uint_file( params[ i ] );
+    uint param = read_uint_file( params[ i ], ERR_MSG );
     if( FD_UNLIKELY( param < limits[ i ] ) )
       NOT_CONFIGURED( "kernel parameter `%s` is too low (%u < %lu)", params[ i ], param, limits[ i ] );
   }

--- a/src/app/fdctl/configure/xdp.c
+++ b/src/app/fdctl/configure/xdp.c
@@ -98,9 +98,6 @@ fini_perm( security_t *     security,
 
 static void
 fini( config_t * const config ) {
-  if( FD_UNLIKELY( config->development.netns.enabled ) )
-    enter_network_namespace( config->tiles.quic.interface );
-
   if( FD_UNLIKELY( fd_xdp_fini( config->name ) ) )
     FD_LOG_ERR(( "fd_xdp_fini failed" ));
 

--- a/src/app/fdctl/fdctl.h
+++ b/src/app/fdctl/fdctl.h
@@ -32,7 +32,14 @@ typedef union {
   } run1;
   struct {
     int monitor;
+    int no_configure;
   } dev;
+  struct {
+    const char * payload_base64;
+    ulong  count;
+    const char * dst_ip;
+    ushort dst_port;
+  } txn;
 } args_t;
 
 typedef struct security security_t;
@@ -44,7 +51,7 @@ typedef struct {
     void       (*fn  )( args_t * args, config_t * const config );
 } action_t;
 
-extern action_t ACTIONS[ 4 ];
+extern action_t ACTIONS[ 5 ];
 
 int
 main1( int     argc,
@@ -90,5 +97,9 @@ monitor_cmd_fn( args_t *         args,
 void
 keygen_cmd_fn( args_t *         args,
                config_t * const config );
+
+void
+ready_cmd_fn( args_t *         args,
+              config_t * const config );
 
 #endif /* HEADER_fd_src_app_fdctl_fdctl_h */

--- a/src/app/fdctl/main1.c
+++ b/src/app/fdctl/main1.c
@@ -1,10 +1,11 @@
 #include "fdctl.h"
 
-action_t ACTIONS[ 4 ] = {
+action_t ACTIONS[ 5 ] = {
   { .name = "run",       .args = NULL,               .fn = run_cmd_fn,       .perm = run_cmd_perm },
   { .name = "configure", .args = configure_cmd_args, .fn = configure_cmd_fn, .perm = configure_cmd_perm },
   { .name = "monitor",   .args = monitor_cmd_args,   .fn = monitor_cmd_fn,   .perm = monitor_cmd_perm },
   { .name = "keygen",    .args = NULL,               .fn = keygen_cmd_fn,    .perm = NULL },
+  { .name = "ready",     .args = NULL,               .fn = ready_cmd_fn,     .perm = NULL },
 };
 
 int

--- a/src/app/fdctl/ready.c
+++ b/src/app/fdctl/ready.c
@@ -1,0 +1,49 @@
+#include "fdctl.h"
+
+#include "run.h"
+
+#include "../../tango/fd_tango.h"
+
+void
+ready_cmd_fn( args_t *         args,
+              config_t * const config ) {
+  (void)args;
+
+  for( ulong i=0; i<config->shmem.workspaces_cnt; i++ ) {
+    workspace_config_t * wksp = &config->shmem.workspaces[i];
+    switch( wksp->kind ) {
+      case wksp_tpu_txn_data:
+      case wksp_quic_verify:
+      case wksp_verify_dedup:
+      case wksp_dedup_pack:
+      case wksp_pack_bank:
+      case wksp_pack_forward:
+      case wksp_bank_shred:
+      case wksp_bank:
+      case wksp_forward:
+        break;
+      case wksp_quic:
+      case wksp_verify:
+      case wksp_dedup:
+      case wksp_pack: {
+        const uchar * pod = workspace_pod_join( config->name, wksp->name, wksp->kind_idx );
+        fd_cnc_t * cnc = fd_cnc_join( fd_wksp_pod_map( pod, "cnc" ) );
+        int first_iter = 1;
+        do {
+          ulong signal = fd_cnc_signal_query( cnc );
+          char buf[ FD_CNC_SIGNAL_CSTR_BUF_MAX ];
+
+          if( FD_LIKELY( signal==FD_CNC_SIGNAL_RUN ) ) break;
+          else if( FD_UNLIKELY( signal!=FD_CNC_SIGNAL_BOOT ) )
+            FD_LOG_ERR(( "cnc for tile %s is in bad state %s", wksp->name, fd_cnc_signal_cstr( signal, buf ) ));
+
+          if( FD_UNLIKELY( first_iter ) )
+            FD_LOG_NOTICE(( "waiting for tile %s to be ready", wksp->name ));
+          first_iter = 0;
+        } while(1);
+      }
+    }
+  }
+
+  FD_LOG_NOTICE(( "all tiles ready" ));
+}

--- a/src/app/fdctl/run.c
+++ b/src/app/fdctl/run.c
@@ -102,9 +102,12 @@ tile_main( void * _args ) {
   fd_log_private_tid_set( args->idx );
   fd_log_thread_set( args->tile->name );
 
+  int pid = getpid1(); /* need to read /proc since we are in a PID namespace now */
+  FD_LOG_NOTICE(( "booting tile %s(%lu) pid(%d)", args->tile->name, args->tile_idx, pid ));
+
   install_tile_signals();
   fd_frank_args_t frank_args = {
-    .pid = getpid1(), /* need to read /proc since we are in a PID namespace now */
+    .pid = pid,
     .tile_idx = args->tile_idx,
     .idx = args->idx,
     .app_name = args->app_name,
@@ -168,8 +171,6 @@ clone_tile( tile_spawner_t * spawn, fd_frank_task_t * task, ulong idx ) {
 
   void * stack = fd_tile_private_stack_new( 1, cpu_idx );
   if( FD_UNLIKELY( !stack ) ) FD_LOG_ERR(( "unable to create a stack for tile process" ));
-
-  FD_LOG_NOTICE(( "booting tile %s(%lu)", task->name, idx ));
 
   tile_main_args_t args = {
     .app_name = spawn->app_name,

--- a/src/app/fddev/Local.mk
+++ b/src/app/fddev/Local.mk
@@ -4,7 +4,7 @@ ifdef FD_HAS_X86
 ifdef FD_HAS_DOUBLE
 
 .PHONY: fddev
-$(call make-bin-rust,fddev,main dev dev1 configure/netns configure/genesis,fd_fdctl fd_frank fd_disco fd_ballet fd_tango fd_util fd_quic solana_validator_fd)
+$(call make-bin-rust,fddev,main dev dev1 txn configure/netns configure/genesis,fd_fdctl fd_frank fd_disco fd_ballet fd_tango fd_util fd_quic solana_validator_fd)
 
 ifeq (run,$(firstword $(MAKECMDGOALS)))
   RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))

--- a/src/app/fddev/dev.c
+++ b/src/app/fddev/dev.c
@@ -15,20 +15,21 @@ dev_cmd_args( int *    pargc,
               char *** pargv,
               args_t * args ) {
   args->dev.monitor = fd_env_strip_cmdline_contains( pargc, pargv, "--monitor" );
+  args->dev.no_configure = fd_env_strip_cmdline_contains( pargc, pargv, "--no-configure" );
 }
 
 void
 dev_cmd_perm( args_t *         args,
               security_t *     security,
               config_t * const config ) {
-  (void)args;
-
-  args_t configure_args = {
-    .configure.command = CONFIGURE_CMD_INIT,
-  };
-  for( ulong i=0; i<CONFIGURE_STAGE_COUNT; i++ )
-    configure_args.configure.stages[ i ] = STAGES[ i ];
-  configure_cmd_perm( &configure_args, security, config );
+  if( FD_LIKELY( !args->dev.no_configure ) ) {
+    args_t configure_args = {
+      .configure.command = CONFIGURE_CMD_INIT,
+    };
+    for( ulong i=0; i<CONFIGURE_STAGE_COUNT; i++ )
+      configure_args.configure.stages[ i ] = STAGES[ i ];
+    configure_cmd_perm( &configure_args, security, config );
+  }
 
   run_cmd_perm( NULL, security, config );
 }
@@ -63,12 +64,14 @@ install_parent_signals( void ) {
 void
 dev_cmd_fn( args_t *         args,
             config_t * const config ) {
-  args_t configure_args = {
-    .configure.command = CONFIGURE_CMD_INIT,
-  };
-  for( ulong i=0; i<CONFIGURE_STAGE_COUNT; i++ )
-    configure_args.configure.stages[ i ] = STAGES[ i ];
-  configure_cmd_fn( &configure_args, config );
+  if( FD_LIKELY( !args->dev.no_configure ) ) {
+    args_t configure_args = {
+      .configure.command = CONFIGURE_CMD_INIT,
+    };
+    for( ulong i=0; i<CONFIGURE_STAGE_COUNT; i++ )
+      configure_args.configure.stages[ i ] = STAGES[ i ];
+    configure_cmd_fn( &configure_args, config );
+  }
 
   /* when starting from a new genesis block, this needs to be off else the
      validator will get stuck forever. */

--- a/src/app/fddev/fddev.h
+++ b/src/app/fddev/fddev.h
@@ -26,4 +26,18 @@ void
 dev1_cmd_fn( args_t *         args,
              config_t * const config );
 
+void
+txn_cmd_perm( args_t *         args,
+              security_t *     security,
+              config_t * const config );
+
+void
+txn_cmd_args( int *    pargc,
+              char *** pargv,
+              args_t * args);
+
+void
+txn_cmd_fn( args_t *         args,
+            config_t * const config );
+
 #endif /* HEADER_fd_src_app_fddev_fddev_h */

--- a/src/app/fddev/main.c
+++ b/src/app/fddev/main.c
@@ -29,6 +29,7 @@ configure_stage_t * STAGES[ CONFIGURE_STAGE_COUNT ] = {
 static action_t DEV_ACTIONS[] = {
   { .name = "dev",  .args = dev_cmd_args,  .fn = dev_cmd_fn,  .perm = dev_cmd_perm },
   { .name = "dev1", .args = dev1_cmd_args, .fn = dev1_cmd_fn, .perm = dev_cmd_perm },
+  { .name = "txn",  .args = txn_cmd_args,  .fn = txn_cmd_fn,  .perm = txn_cmd_perm },
 };
 
 #define MAX_ARGC 32

--- a/src/app/fddev/txn.c
+++ b/src/app/fddev/txn.c
@@ -1,0 +1,198 @@
+#include "fddev.h"
+
+#include "../fdctl/configure/configure.h"
+#include "../../ballet/base64/fd_base64.h"
+#include "../../tango/quic/fd_quic.h"
+#include "../../tango/quic/tests/fd_quic_test_helpers.h"
+
+#include <linux/capability.h>
+
+FD_IMPORT_BINARY(sample_transaction, "src/tango/quic/tests/quic_txn.bin");
+
+static int g_conn_hs_complete = 0;
+static int g_conn_final = 0;
+static int g_stream_notify = 0;
+
+#define MAX_TXN_COUNT 128
+
+void
+txn_cmd_perm( args_t *         args,
+              security_t *     security,
+              config_t * const config ) {
+  (void)args;
+
+  if( FD_UNLIKELY( config->development.netns.enabled ) )
+    check_cap( security, "txn", CAP_SYS_ADMIN, "enter a network namespace by calling `setns(2)`" );
+}
+
+void
+txn_cmd_args( int *    pargc,
+              char *** pargv,
+              args_t * args ) {
+  args->txn.payload_base64 = fd_env_strip_cmdline_cstr( pargc, pargv, "--payload-base64-encoded", NULL, NULL );
+  args->txn.count = fd_env_strip_cmdline_ulong( pargc, pargv, "--count", NULL, 1 );
+  if( FD_UNLIKELY( !args->txn.count || args->txn.count > MAX_TXN_COUNT ) )
+    FD_LOG_ERR(( "count must be between 1 and %d", MAX_TXN_COUNT ));
+
+  args->txn.dst_ip = fd_env_strip_cmdline_cstr( pargc, pargv, "--dst-ip", NULL, 0 );
+  args->txn.dst_port = fd_env_strip_cmdline_ushort( pargc, pargv, "--dst-port", NULL, 0 );
+}
+
+static ulong
+cb_now( void * context ) {
+  (void)context;
+  return (ulong)fd_log_wallclock();
+}
+
+static void
+cb_conn_hs_complete( fd_quic_conn_t * conn,
+                     void *           quic_ctx ) {
+  (void)conn;
+  (void)quic_ctx;
+  g_conn_hs_complete = 1;
+}
+
+static void
+cb_conn_final( fd_quic_conn_t * conn,
+               void *           quic_ctx ) {
+  (void)conn;
+  (void)quic_ctx;
+  g_conn_final = 1;
+}
+
+static void
+cb_stream_notify( fd_quic_stream_t * stream,
+                  void *             stream_ctx,
+                  int                notify_type ) {
+  (void)stream;
+  (void)stream_ctx;
+  (void)notify_type;
+  g_stream_notify = 1;
+}
+
+static void
+send_quic_transactions( fd_quic_t *         quic,
+                        fd_quic_udpsock_t * udpsock,
+                        ulong               count,
+                        uint                dst_ip,
+                        ushort              dst_port,
+                        fd_aio_pkt_info_t * pkt ) {
+  fd_quic_set_aio_net_tx( quic, udpsock->aio );
+  FD_TEST( fd_quic_init( quic ) );
+
+  quic->cb.now = cb_now;
+  quic->cb.conn_final = cb_conn_final;
+  quic->cb.conn_hs_complete = cb_conn_hs_complete;
+  quic->cb.stream_notify = cb_stream_notify;
+
+  fd_quic_conn_t * conn = fd_quic_connect( quic, dst_ip, dst_port, NULL );
+  while ( FD_LIKELY( !( g_conn_hs_complete || g_conn_final ) ) ) {
+    fd_quic_service( quic );
+    fd_quic_udpsock_service( udpsock );
+  }
+  FD_TEST( conn );
+  if( FD_UNLIKELY( conn->state != FD_QUIC_CONN_STATE_ACTIVE ) )
+    FD_LOG_ERR(( "unable to connect to QUIC endpoint at "FD_IP4_ADDR_FMT":%hu, is it running? state is %d", FD_IP4_ADDR_FMT_ARGS(dst_ip), dst_port, conn->state ));
+
+  fd_quic_stream_t * stream = fd_quic_conn_new_stream( conn, FD_QUIC_TYPE_UNIDIR );
+  FD_TEST( stream );
+
+  ulong sent = 0;
+  while( sent < count ) {
+    int res = fd_quic_stream_send( stream, pkt + sent, count - sent, 1 );
+    if( FD_UNLIKELY( res < 0 ) ) FD_LOG_ERR(( "fd_quic_stream_send failed (%d)", res ));
+    sent += (ulong)res;
+
+    fd_quic_service( quic );
+    fd_quic_udpsock_service( udpsock );
+  }
+
+  while ( FD_UNLIKELY( !( g_stream_notify || g_conn_final ) ) ) {
+    fd_quic_service( quic );
+    fd_quic_udpsock_service( udpsock );
+  }
+
+  fd_quic_conn_close( conn, 0 );
+  fd_quic_fini( quic );
+}
+
+void
+txn_cmd_fn( args_t *         args,
+            config_t * const config ) {
+  if( FD_UNLIKELY( config->development.netns.enabled ) )
+    enter_network_namespace( config->development.netns.interface1 );
+
+  /* wait until validator is ready to receive txns before sending */
+  ready_cmd_fn( args, config );
+
+  fd_quic_limits_t quic_limits = {
+    .conn_cnt         = 1UL,
+    .handshake_cnt    = 1UL,
+    .conn_id_cnt      = 4UL,
+    .conn_id_sparsity = 4.0,
+    .stream_cnt = { 0UL,   // FD_QUIC_STREAM_TYPE_BIDI_CLIENT
+                    0UL,   // FD_QUIC_STREAM_TYPE_BIDI_SERVER
+                    1UL,   // FD_QUIC_STREAM_TYPE_UNI_CLIENT
+                    0UL }, // FD_QUIC_STREAM_TYPE_UNI_SERVER
+    .stream_sparsity  = 4.0,
+    .inflight_pkt_cnt = 64UL,
+    .tx_buf_sz        = 1UL<<15UL
+  };
+  ulong quic_footprint = fd_quic_footprint( &quic_limits );
+  FD_TEST( quic_footprint );
+
+  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz("normal"),
+                                            1UL << 10,
+                                            fd_shmem_cpu_idx( 0 ),
+                                            "wksp",
+                                            0UL );
+  FD_TEST( wksp );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_quic_align(), quic_footprint, 1UL );
+  fd_quic_t * quic = fd_quic_new( mem, &quic_limits );
+  FD_TEST( quic );
+
+  fd_quic_udpsock_t _udpsock;
+  fd_quic_udpsock_t * udpsock = fd_quic_client_create_udpsock( &_udpsock, wksp, fd_quic_get_aio_net_rx( quic ), 0 );
+  FD_TEST( udpsock == &_udpsock );
+
+  fd_quic_config_t * client_cfg = &quic->config;
+  client_cfg->role = FD_QUIC_ROLE_CLIENT;
+  memcpy( client_cfg->alpns, "\xasolana-tpu", 11UL );
+  client_cfg->alpns_sz = 11U;
+  memcpy( client_cfg->link.dst_mac_addr, config->tiles.quic.mac_addr, 6UL );
+  client_cfg->net.ip_addr           = udpsock->listen_ip;
+  client_cfg->net.ephem_udp_port.lo = (ushort)udpsock->listen_port;
+  client_cfg->net.ephem_udp_port.hi = (ushort)(udpsock->listen_port + 1);
+  client_cfg->initial_rx_max_stream_data = 1<<15;
+  client_cfg->idle_timeout = 100UL * 1000UL * 1000UL; /* 100 millis */
+  client_cfg->initial_rx_max_stream_data = FD_QUIC_DEFAULT_INITIAL_RX_MAX_STREAM_DATA;
+
+  fd_aio_pkt_info_t pkt[ MAX_TXN_COUNT ];
+
+  if( FD_LIKELY( !args->txn.payload_base64 ) ) {
+    for( ulong i=0; i<args->txn.count; i++ ) {
+      pkt[ i ].buf    = (void * )sample_transaction;
+      pkt[ i ].buf_sz = (ushort )sample_transaction_sz;
+    }
+  } else {
+    uchar buf[1300];
+    int buf_sz = fd_base64_decode( args->txn.payload_base64, buf );
+    if( FD_UNLIKELY( buf_sz == -1 ) ) FD_LOG_ERR(( "bad payload input `%s`", args->txn.payload_base64 ));
+    for( ulong i=0; i<args->txn.count; i++ ) {
+      pkt[ i ].buf    = (void * )buf;
+      pkt[ i ].buf_sz = (ushort )buf_sz;
+    }
+  }
+
+  uint dst_ip = config->tiles.quic.ip_addr;
+  if( FD_UNLIKELY( args->txn.dst_ip ) )
+    if( FD_UNLIKELY( !fd_cstr_to_ip4_addr( args->txn.dst_ip, &dst_ip  ) ) ) FD_LOG_ERR(( "invalid --dst-ip" ));
+
+  ushort dst_port = config->tiles.quic.quic_transaction_listen_port;
+  if( FD_UNLIKELY( args->txn.dst_port ) ) dst_port = args->txn.dst_port;
+
+  FD_LOG_NOTICE(( "sending %lu transactions to "FD_IP4_ADDR_FMT":%hu", args->txn.count, FD_IP4_ADDR_FMT_ARGS(dst_ip), dst_port ));
+
+  send_quic_transactions( quic, udpsock, args->txn.count, dst_ip, dst_port, pkt );
+  exit_group( 0 );
+}

--- a/src/tango/xdp/fd_xdp_redirect_user.c
+++ b/src/tango/xdp/fd_xdp_redirect_user.c
@@ -439,12 +439,6 @@ fd_xdp_unhook_iface( char const * app_name,
     return -1;
   }
 
-  if( FD_UNLIKELY( 0!=unlinkat( dir_fd, "xdp_link2", 0 ) && errno != ENOENT ) ) {
-    FD_LOG_WARNING(( "unlinkat(\"%s\",\"xdp_link2\",0) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
-    close( dir_fd );
-    return -1;
-  }
-
   /* Clean up */
 
   close( dir_fd );

--- a/src/test/frank-single-transaction.sh
+++ b/src/test/frank-single-transaction.sh
@@ -1,37 +1,17 @@
 #!/bin/bash
 
 # bash strict mode
-set -euo pipefail
-IFS=$'\n\t'
+set -xeuo pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "${SCRIPT_DIR}/../../"
 
-# create test configuration for fddev
-TMPDIR=$(mktemp -d)
-cat > ${TMPDIR}/config.toml <<EOM
-[development]
-    sudo = true
-    sandbox = true
-    [development.netns]
-        enabled = true
-[tiles.quic]
-    interface = "veth_test_xdp_0"
-[layout]
-    affinity = "0-9"
-    verify_tile_count = 2
-    bank_tile_count = 2
-EOM
-export FIREDANCER_CONFIG_TOML=${TMPDIR}/config.toml
-
 # start fddev, send a single transaction, and if everything works return 0
 FDDEV=./build/native/gcc/bin/fddev
-TEST_QUIC_TXN=./build/native/gcc/unit-test/test_quic_txn
 # TODO: For some reason /tmp does not work on the github runner for --log-path
-timeout --preserve-status 15 $FDDEV configure init all --log-path ~/log
-timeout --preserve-status 15 $FDDEV --log-path ~/log &
+timeout --preserve-status 15 $FDDEV configure init all --netns --log-path ~/log
+timeout --preserve-status 15 $FDDEV --no-configure --netns --log-path ~/log &
 FDDEV_PID=$!
-sleep 4
-sudo nsenter --net=/var/run/netns/veth_test_xdp_1 ${TEST_QUIC_TXN}
+timeout --preserve-status 15 $FDDEV txn --netns --log-path ~/log2
 RETVAL=$?
 sudo kill $FDDEV_PID
 exit $RETVAL


### PR DESCRIPTION
`fdctl ready` waits until all tiles being booted by the systeme are ready to accept transactions.  Currently ignores the bank tile since it takes a while to start and will get backpressured so it doesn't really matter if it's booted anyway.

The `txn` command is stolen from `test_quic_txn.c` but integrates nicely with `fddev` so that it automatically targets the right endpoint and can be run easily.