### PR TITLE
ci: write output command to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/make_daily.yml
+++ b/.github/workflows/make_daily.yml
@@ -18,7 +18,7 @@ jobs:
         continue-on-error: true
         name: check latest commit is less than a day
         if: ${{ github.event_name == 'schedule' }}
-        run: test -z $(git rev-list --after="24 hours" ${{ github.sha }}) && echo "::set-output name=should_run::false"
+        run: test -z $(git rev-list --after="24 hours" ${{ github.sha }}) && (echo "::set-output name=should_run::false" >> $GITHUB_OUTPUT)
     outputs:
       should_run: ${{ github.event_name != 'schedule' || steps.should_run.outputs.should_run }}
 


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/