### PR TITLE
make it simple to add extra cppflags

### DIFF
--- a/config/everything.mk
+++ b/config/everything.mk
@@ -9,6 +9,7 @@ OBJDIR:=$(BASEDIR)/$(BUILDDIR)
 CORPUSDIR:=corpus
 
 CPPFLAGS+=-DFD_BUILD_INFO=\"$(OBJDIR)/info\"
+CPPFLAGS+=$(EXTRA_CPPFLAGS)
 
 # Auxiliarily rules that should not set up depenencies
 AUX_RULES:=clean distclean help show-deps lint check-lint run-unit-test
@@ -17,29 +18,30 @@ all: info bin include lib unit-test
 
 help:
 	# Configuration
-	# MACHINE   = $(MACHINE)
-	# EXTRAS    = $(EXTRAS)
-	# SHELL     = $(SHELL)
-	# BASEDIR   = $(BASEDIR)
-	# OBJDIR    = $(OBJDIR)
-	# CPPFLAGS  = $(CPPFLAGS)
-	# CC        = $(CC)
-	# CFLAGS    = $(CFLAGS)
-	# CXX       = $(CXX)
-	# CXXFLAGS  = $(CXXFLAGS)
-	# LD        = $(LD)
-	# LDFLAGS   = $(LDFLAGS)
-	# AR        = $(AR)
-	# ARFLAGS   = $(ARFLAGS)
-	# RANLIB    = $(RANLIB)
-	# CP        = $(CP)
-	# RM        = $(RM)
-	# MKDIR     = $(MKDIR)
-	# RMDIR     = $(RMDIR)
-	# SED       = $(SED)
-	# FIND      = $(FIND)
-	# SCRUB     = $(SCRUB)
-	# FUZZFLAGS = $(FUZZFLAGS)
+	# MACHINE         = $(MACHINE)
+	# EXTRAS          = $(EXTRAS)
+	# SHELL           = $(SHELL)
+	# BASEDIR         = $(BASEDIR)
+	# OBJDIR          = $(OBJDIR)
+	# CPPFLAGS        = $(CPPFLAGS)
+	# CC              = $(CC)
+	# CFLAGS          = $(CFLAGS)
+	# CXX             = $(CXX)
+	# CXXFLAGS        = $(CXXFLAGS)
+	# LD              = $(LD)
+	# LDFLAGS         = $(LDFLAGS)
+	# AR              = $(AR)
+	# ARFLAGS         = $(ARFLAGS)
+	# RANLIB          = $(RANLIB)
+	# CP              = $(CP)
+	# RM              = $(RM)
+	# MKDIR           = $(MKDIR)
+	# RMDIR           = $(RMDIR)
+	# SED             = $(SED)
+	# FIND            = $(FIND)
+	# SCRUB           = $(SCRUB)
+	# FUZZFLAGS       = $(FUZZFLAGS)
+	# EXTRAS_CPPFLAGS = $(EXTRA_CPPFLAGS)
 	# Explicit goals are: all bin include lib unit-test help clean distclean asm ppp
 	# "make all" is equivalent to "make bin include lib unit-test"
 	# "make info" makes build info $(OBJDIR)/info for the current platform (if not already made)


### PR DESCRIPTION
```
~/src/firedancer (main*) » make EXTRA_CPPFLAGS="LOOKHERE"
gcc -isystem ./opt/include -DFD_LOG_UNCLEAN_EXIT=1 -march=native -mtune=native -Werror -Wall -Wextra -Wpedantic -Wstrict-aliasing=2 -Wconversion -Wdouble-promotion -Wformat-security -Wimplicit-fallthrough -Wimplicit-fallthrough=2 -O3 -ffast-math -fno-associative-math -fno-reciprocal-math -DFD_HAS_OPTIMIZATION=1 -g -DFD_HAS_INT128=1 -DFD_HAS_DOUBLE=1 -DFD_HAS_ALLOCA=1 -DFD_HAS_THREADS=1 -DFD_HAS_OPENSSL=1 -DFD_HAS_X86=1 -DFD_HAS_SSE=1 -DFD_HAS_AVX=1 -DFD_IS_X86_64=1 -D_XOPEN_SOURCE=700 -DFD_HAS_HOSTED=1 -pthread -DFD_HAS_THREADS=1 -DFD_HAS_ATOMIC=1 -DFD_HAS_OPENSSL=1 -DOPENSSL_API_COMPAT=0x10100000L -DOPENSSL_SUPPRESS_DEPRECATED -fomit-frame-pointer -mfpmath=sse -falign-functions=32 -falign-jumps=32 -falign-labels=32 -falign-loops=32 -mbranch-cost=5 -DFD_BUILD_INFO=\"build/native/gcc/info\" LOOKHERE -std=c17 -c src/tango/xdp/fd_xdp_ctl.c -o build/native/gcc/obj/tango/xdp/fd_xdp_ctl.o
gcc: error: LOOKHERE: No such file or directory
make: *** [config/everything.mk:289: build/native/gcc/obj/tango/xdp/fd_xdp_ctl.o] Error 1
```