### PR TITLE
ci: do not provide extra_cppflags from job

### DIFF
--- a/.github/workflows/publish_fuzz_targets.yml
+++ b/.github/workflows/publish_fuzz_targets.yml
@@ -12,7 +12,6 @@ jobs:
       group: github-v1
     env:
       MACHINE: linux_clang_x86_64_fuzz_asan
-      EXTRA_CPPFLAGS: -isystem /root/include
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
The value is instead provided by the Docker image which is aware of which packages provides the headers.