### PR TITLE
tango: add multi version concurrency control (mvcc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ highly restrictive sandbox and almost no system calls.
 diversity to the Solana network and helps it stay resilient to supply
 chain attacks in build tooling or dependencies.
 
-## Frankendancer
+## Frankendancer 👹💃
 
 Firedancer is a new Solana validator with a new codebase, but it is
 being developed incrementally. To enable testing and deployment before

--- a/ffi/rust/firedancer-sys/src/tango/mod.rs
+++ b/ffi/rust/firedancer-sys/src/tango/mod.rs
@@ -3,6 +3,7 @@ mod dcache;
 mod fctl;
 mod fseq;
 mod mcache;
+mod mvcc;
 mod tcache;
 mod xdp;
 
@@ -11,6 +12,7 @@ pub use dcache::*;
 pub use fctl::*;
 pub use fseq::*;
 pub use mcache::*;
+pub use mvcc::*;
 pub use tcache::*;
 pub use xdp::*;
 

--- a/ffi/rust/firedancer-sys/src/tango/mvcc.rs
+++ b/ffi/rust/firedancer-sys/src/tango/mvcc.rs
@@ -1,0 +1,15 @@
+pub use crate::generated::{
+    fd_mvcc_align,
+    fd_mvcc_app_laddr,
+    fd_mvcc_app_laddr_const,
+    fd_mvcc_app_sz,
+    fd_mvcc_begin_write,
+    fd_mvcc_delete,
+    fd_mvcc_end_write,
+    fd_mvcc_footprint,
+    fd_mvcc_join,
+    fd_mvcc_leave,
+    fd_mvcc_new,
+    fd_mvcc_t,
+    fd_mvcc_version_query,
+};

--- a/src/tango/fd_tango.h
+++ b/src/tango/fd_tango.h
@@ -10,6 +10,6 @@
 #include "dcache/fd_dcache.h" /* Includes fd_tango_base.h */
 #include "tcache/fd_tcache.h" /* Includes fd_tango_base.h */
 #include "aio/fd_aio.h"       /* Includes fd_tango_base.h */
+#include "mvcc/fd_mvcc.h"     /* Includes fd_tango_base.h */
 
 #endif /* HEADER_fd_src_tango_fd_tango_h */
-

--- a/src/tango/mvcc/Local.mk
+++ b/src/tango/mvcc/Local.mk
@@ -1,0 +1,4 @@
+$(call add-hdrs,fd_mvcc.h)
+$(call add-objs,fd_mvcc,fd_tango)
+$(call make-unit-test,test_mvcc,test_mvcc,fd_tango fd_util)
+$(call run-unit-test,test_mvcc,)

--- a/src/tango/mvcc/fd_mvcc.c
+++ b/src/tango/mvcc/fd_mvcc.c
@@ -1,0 +1,106 @@
+#include "fd_mvcc.h"
+
+ulong
+fd_mvcc_align( void ) {
+  return FD_MVCC_ALIGN;
+}
+
+ulong
+fd_mvcc_footprint( ulong app_sz ) {
+  if( FD_UNLIKELY( app_sz > (ULONG_MAX-191UL) ) ) return 0UL; /* overflow */
+  return FD_MVCC_FOOTPRINT( app_sz );
+}
+
+void *
+fd_mvcc_new( void * shmem,
+             ulong  app_sz ) {
+  fd_mvcc_t * mvcc = (fd_mvcc_t *)shmem;
+
+  if( FD_UNLIKELY( !shmem ) ) {
+    FD_LOG_WARNING(( "NULL shmem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, fd_mvcc_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned shmem" ));
+    return NULL;
+  }
+
+  ulong footprint = fd_mvcc_footprint( app_sz );
+  if( FD_UNLIKELY( !footprint ) ) {
+    FD_LOG_WARNING(( "bad app_sz (%lu)", app_sz ));
+    return NULL;
+  }
+
+  fd_memset( mvcc, 0, footprint );
+
+  mvcc->app_sz     = app_sz;
+  mvcc->version    = 0UL;
+
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( mvcc->magic ) = FD_MVCC_MAGIC;
+  FD_COMPILER_MFENCE();
+
+  return (void *)mvcc;
+}
+
+fd_mvcc_t *
+fd_mvcc_join( void * shmvcc ) {
+
+  if( FD_UNLIKELY( !shmvcc ) ) {
+    FD_LOG_WARNING(( "NULL shmvcc" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmvcc, fd_mvcc_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned shmvcc" ));
+    return NULL;
+  }
+
+  fd_mvcc_t * mvcc = (fd_mvcc_t *)shmvcc;
+
+  if( FD_UNLIKELY( mvcc->magic!=FD_MVCC_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+    return NULL;
+  }
+
+  return mvcc;
+}
+
+void *
+fd_mvcc_leave( fd_mvcc_t const * mvcc ) {
+
+  if( FD_UNLIKELY( !mvcc ) ) {
+    FD_LOG_WARNING(( "NULL mvcc" ));
+    return NULL;
+  }
+
+  return (void *)mvcc; /* Kinda ugly const cast */
+}
+
+void *
+fd_mvcc_delete( void * shmvcc ) {
+
+  if( FD_UNLIKELY( !shmvcc ) ) {
+    FD_LOG_WARNING(( "NULL shmvcc" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmvcc, fd_mvcc_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned shmvcc" ));
+    return NULL;
+  }
+
+  fd_mvcc_t * mvcc = (fd_mvcc_t *)shmvcc;
+
+  if( FD_UNLIKELY( mvcc->magic!=FD_MVCC_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+    return NULL;
+  }
+
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( mvcc->magic ) = 0UL;
+  FD_COMPILER_MFENCE();
+
+  return (void *)mvcc;
+}

--- a/src/tango/mvcc/fd_mvcc.h
+++ b/src/tango/mvcc/fd_mvcc.h
@@ -1,0 +1,179 @@
+#ifndef HEADER_fd_src_tango_mvcc_fd_mvcc_h
+#define HEADER_fd_src_tango_mvcc_fd_mvcc_h
+
+#include "../../util/fd_util.h"
+
+/* A fd_mvcc_t provides functionality for lock-free synchronization of
+   single producer multiple consumer data. It is strictly less general
+   than the MVCC used in various DBMS
+   [https://dl.acm.org/doi/pdf/10.1145/356842.356846], but it is
+   conceptually similar in that it uses a version number to detect
+   conflicts.
+
+   Write steps,
+
+    1. Writer increments version number
+    2. Writer updates data
+    3. Writer increments version number
+
+  If the version number is odd, a write is in progress.  When reading,
+
+    1. Reader reads version number
+    2. Reader reads data
+    3. Reader reads version number again
+
+  If the version numbers retrieved in steps 1 and 3 are different, the
+  read is invalid as a partial write was in progress.  Typically, the
+  reader should simply retry the read.
+
+  A mvcc has an application defined app region where the versioned data
+  structure can be stored, although it does not need to be, the
+  producer and consumers should agree on what is being synchronized.
+
+  Note this is similar to how producers / consumers synchronize across
+  mcache / dcache.
+
+  TODO: Hardware fencing */
+
+/* FD_MVCC_{ALIGN,FOOTPRINT} describe the alignment and footprint of a
+   fd_mvcc_t.  ALIGN is a positive integer power of 2.  FOOTPRINT is a
+   multiple of ALIGN.  ALIGN is recommended to be at least double cache
+   line to mitigate various kinds of false sharing.  app_sz is assumed
+   to be valid (e.g. will not require a footprint larger than
+   ULONG_MAX).  These are provided to facilitate compile time
+   declarations. */
+
+#define FD_MVCC_ALIGN (128UL)
+#define FD_MVCC_FOOTPRINT( app_sz )                                   \
+  FD_LAYOUT_FINI( FD_LAYOUT_APPEND( FD_LAYOUT_APPEND( FD_LAYOUT_INIT, \
+    FD_MVCC_ALIGN,     64UL     ),                                    \
+    FD_MVCC_APP_ALIGN, (app_sz) ),                                    \
+    FD_MVCC_ALIGN )
+
+/* FD_MVCC_APP_ALIGN describes the alignment and footprint of a
+   fd_mvcc_t's application region.  This is a power of 2 of the minimal
+   malloc alignment (typically 8) and at most FD_MVCC_ALIGN. */
+
+#define FD_MVCC_APP_ALIGN (64UL)
+
+#define FD_MVCC_MAGIC (0xf17eda2c37ecc000UL) /* firedancer mvc ver 0 */
+
+struct __attribute__((aligned(FD_MVCC_ALIGN))) fd_mvcc {
+  ulong magic;     /* ==FD_MVCC_MAGIC */
+  ulong app_sz;
+  ulong version;
+  /* Padding to FD_MVCC_APP_ALIGN here */
+  /* app_sz bytes here */
+  /* Padding to FD_MVCC_ALIGN here */
+};
+
+typedef struct fd_mvcc fd_mvcc_t;
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_mvcc_{align,footprint} return the required alignment and footprint
+   of a memory region suitable for use as a mvcc.  fd_mvcc_align returns
+   FD_MVCC_ALIGN.  If footprint is larger than ULONG_MAX, footprint will
+   silently return 0 (and thus can be used by the caller to validate the
+   mvcc configuration parameters). */
+
+FD_FN_CONST ulong
+fd_mvcc_align( void );
+
+FD_FN_CONST ulong
+fd_mvcc_footprint( ulong app_sz );
+
+/* fd_mvcc_new formats an unused memory region for use as a mvcc.
+   Assumes shmem is a non-NULL pointer to this region in the local
+   address space with the required footprint and alignment.  The mvcc
+   application region will be initialized to zero.  Returns shmem (and
+   the memory region it points to will be formatted as a mvcc, caller is
+   not joined) and NULL on failure (logs details).  Reasons for failure
+   include an obviously bad shmem region or app_sz. */
+
+void *
+fd_mvcc_new( void * shmem,
+             ulong  app_sz );
+
+/* fd_mvcc_join joins the caller to the mvcc.  shmvcc points to the
+   first byte of the memory region backing the mvcc in the caller's
+   address space.  Returns a pointer in the local address space to the
+   mvcc on success (this should not be assumed to be just a cast of
+   shmvcc) or NULL on failure (logs details).  Reasons for failure
+   include the shmvcc is obviously not a local pointer to a memory
+   region holding a mvcc.  Every successful join should have a matching
+   leave.  The lifetime of the join is until the matching leave or
+   caller's thread group is terminated. */
+
+fd_mvcc_t *
+fd_mvcc_join( void * shmvcc );
+
+/* fd_mvcc_leave leaves a current local join.  Returns a pointer to the
+   underlying shared memory region on success (this should not be
+   assumed to be just a cast of mvcc) and NULL on failure (logs
+   details). Reasons for failure include mvcc is NULL. */
+
+void *
+fd_mvcc_leave( fd_mvcc_t const * mvcc );
+
+/* fd_mvcc_delete unformats a memory region used as a mvcc.  Assumes
+   nobody is joined to the region.  Returns a pointer to the underlying
+   shared memory region or NULL if used obviously in error (e.g. shmvcc
+   obviously does not point to a mvcc ... logs details).  The ownership
+   of the memory region is transferred to the caller on success. */
+
+void *
+fd_mvcc_delete( void * shmvcc );
+
+/* fd_mvcc_app_sz returns the size of a the mvcc's application region.
+   Assumes mvcc is a current local join. */
+
+FD_FN_PURE static inline ulong fd_mvcc_app_sz( fd_mvcc_t const * mvcc ) { return mvcc->app_sz; }
+
+/* fd_mvcc_app_laddr returns local address of the mvcc's application
+   region.  This will have FD_MVCC_APP_ALIGN alignment and room for at
+   least fd_mvcc_app_sz( mvcc ) bytes.  Assumes mvcc is a current local
+   join.  fd_mvcc_app_laddr_const is for const correctness.  The return
+   values are valid for the lifetime of the local join. */
+
+FD_FN_CONST static inline void *       fd_mvcc_app_laddr      ( fd_mvcc_t *       mvcc ) { return (void *      )(((ulong)mvcc)+64UL); }
+FD_FN_CONST static inline void const * fd_mvcc_app_laddr_const( fd_mvcc_t const * mvcc ) { return (void const *)(((ulong)mvcc)+64UL); }
+
+/* fd_mvcc_version_query returns the value of the mvcc's version as of
+   some point in time between when this was called and when this
+   returned.  Assumes mvcc is a current local join.  This acts as a
+   compiler memory fence.  Any reads from the mvcc must consist of a
+   pair of version queries, one before and one after the reads are
+   performed.  If the version numbers do not match, the read was not
+   successful and should be retried. */
+
+static inline ulong
+fd_mvcc_version_query( fd_mvcc_t const * mvcc ) {
+  FD_COMPILER_MFENCE();
+  ulong version = FD_VOLATILE_CONST( mvcc->version );
+  FD_COMPILER_MFENCE();
+  return version;
+}
+
+/* fd_mvcc_{begin,end}_write increment the version number of the mvcc to
+   mark that a write is in progress or has completed respectively.  If a
+   write is in progress, any reads during that time are invalid. Assumes
+   mvcc is a local join.  This acts a compiler memory fence. Any writes
+   to data being versioned must occur between a pair of {begin,end}
+   calls. These calls should not be interleaved, or made across threads,
+   or within a thread because of an async signal handler. */
+static inline void
+fd_mvcc_begin_write( fd_mvcc_t * mvcc ) {
+  FD_ATOMIC_FETCH_AND_ADD( &mvcc->version, 1 );
+  FD_COMPILER_MFENCE();
+}
+
+static inline void
+fd_mvcc_end_write( fd_mvcc_t * mvcc ) {
+  FD_COMPILER_MFENCE();
+  FD_ATOMIC_FETCH_AND_ADD( &mvcc->version, 1 );
+}
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_tango_mvcc_fd_mvcc_h */

--- a/src/tango/mvcc/test_mvcc.c
+++ b/src/tango/mvcc/test_mvcc.c
@@ -1,0 +1,58 @@
+#include "../../util/fd_util.h"
+#include "fd_mvcc.h"
+
+FD_STATIC_ASSERT( FD_MVCC_ALIGN          ==128UL, unit_test );
+FD_STATIC_ASSERT( FD_MVCC_FOOTPRINT( 0UL)==128UL, unit_test );
+FD_STATIC_ASSERT( FD_MVCC_FOOTPRINT(64UL)==128UL, unit_test );
+FD_STATIC_ASSERT( FD_MVCC_FOOTPRINT(65UL)==256UL, unit_test );
+
+FD_STATIC_ASSERT( FD_MVCC_APP_ALIGN==64UL, unit_test );
+
+#define APP_MIN (32UL)
+#define APP_MAX (192UL)
+uchar __attribute__((aligned(FD_MVCC_ALIGN))) shmem[ FD_MVCC_FOOTPRINT( APP_MAX ) ];
+
+int
+main( int argc, char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  ulong app_sz = fd_env_strip_cmdline_ulong( &argc, &argv, "--app-sz", NULL,  192UL );
+
+  if( FD_UNLIKELY( app_sz<APP_MIN     ) ) FD_LOG_ERR(( "app_sz should be at least %lu for this unit test", APP_MIN ));
+  if( FD_UNLIKELY( app_sz>APP_MAX     ) ) FD_LOG_ERR(( "increase APP_MAX for this app_sz"  ));
+
+  FD_TEST( !fd_mvcc_footprint( ULONG_MAX ) );
+
+  FD_TEST( fd_mvcc_align()            ==FD_MVCC_ALIGN               );
+  FD_TEST( fd_mvcc_footprint( app_sz )==FD_MVCC_FOOTPRINT( app_sz ) );
+
+  void * shmvcc = fd_mvcc_new( shmem, app_sz); FD_TEST( shmvcc );
+  fd_mvcc_t * mvcc = fd_mvcc_join( shmvcc );   FD_TEST( mvcc );
+
+  FD_TEST( fd_mvcc_app_sz( mvcc )==app_sz );
+  uchar *       app       = (uchar       *)fd_mvcc_app_laddr( mvcc );
+  uchar const * app_const = (uchar const *)fd_mvcc_app_laddr_const( mvcc );
+  FD_TEST( (ulong)app==(ulong)app_const );
+  FD_TEST( fd_ulong_is_aligned( (ulong)app, FD_MVCC_APP_ALIGN ) );
+
+  FD_TEST( fd_mvcc_version_query( mvcc ) == 0 );
+  FD_TEST( fd_mvcc_version_query( mvcc ) == 0 );
+
+  fd_mvcc_begin_write( mvcc );
+  FD_TEST( fd_mvcc_version_query( mvcc ) == 1 );
+  FD_TEST( fd_mvcc_version_query( mvcc ) == 1 );
+  fd_mvcc_end_write( mvcc );
+
+  FD_TEST( fd_mvcc_version_query( mvcc ) == 2 );
+  fd_mvcc_begin_write( mvcc );
+  FD_TEST( fd_mvcc_version_query( mvcc ) == 3 );
+  fd_mvcc_end_write( mvcc );
+  FD_TEST( fd_mvcc_version_query( mvcc ) == 4 );
+
+  FD_TEST( fd_mvcc_leave( mvcc )==shmvcc );
+  FD_TEST( fd_mvcc_delete( shmvcc )==shmem );
+
+  FD_LOG_NOTICE( ( "pass" ) );
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
A primitive is added for versioning data for single-producer multi-consumer contexts.  This is designed for use between Solana Labs and Firedancer for passing information like stake weights and the leader schedule which Firedancer cannot yet derive independently.