### PR TITLE
fix(quic): missing NULL check in fd_quic_conn_close

### DIFF
--- a/src/tango/quic/fd_quic.c
+++ b/src/tango/quic/fd_quic.c
@@ -1862,7 +1862,9 @@ ulong fd_quic_handle_v1_retry(
 ) {
   (void)pkt;
   if ( FD_UNLIKELY ( quic->config.role == FD_QUIC_ROLE_SERVER ) ) {
-    fd_quic_conn_close( conn, FD_QUIC_CONN_REASON_PROTOCOL_VIOLATION );
+    if ( FD_UNLIKELY( conn ) ) { /* likely a misbehaving client w/o a conn */
+      fd_quic_conn_close( conn, FD_QUIC_CONN_REASON_PROTOCOL_VIOLATION );
+    }
     return FD_QUIC_PARSE_FAIL;
   }
   fd_quic_retry_t retry_pkt;


### PR DESCRIPTION
fix firedancer-io/auditor-internal#5