### PR TITLE
fuzz: crash file destination

### DIFF
--- a/config/everything.mk
+++ b/config/everything.mk
@@ -213,7 +213,7 @@ $(1)_unit:
 .PHONY: $(1)_run
 $(1)_run:
 	$(MKDIR) "$(CORPUSDIR)/$(1)/explore"
-	$(OBJDIR)/fuzz-test/$(1)/$(1) $(FUZZFLAGS) $(CORPUSDIR)/$(1)/explore $(CORPUSDIR)/$(1)
+	$(OBJDIR)/fuzz-test/$(1)/$(1) -artifact_prefix=$(CORPUSDIR)/$(1)/ $(FUZZFLAGS) $(CORPUSDIR)/$(1)/explore $(CORPUSDIR)/$(1)
 
 run-fuzz-test: $(1)_unit
 


### PR DESCRIPTION
As requested by @lheeger-jump, it writes finding in the appropriate corpus directory.