### PR TITLE
Initial metrics tile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ deps-bundle.tar.zst
 
 # Logs
 *.log
+
+# JetBrains
+.idea

--- a/deps.sh
+++ b/deps.sh
@@ -314,8 +314,6 @@ install_openssl () {
     no-tls1-method \
     no-tls1_1 \
     no-tls1_1-method \
-    no-tls1_2 \
-    no-tls1_2-method \
     enable-tls1_3 \
     no-shared \
     no-legacy \
@@ -360,7 +358,6 @@ install_openssl () {
     no-sm4 \
     no-srp \
     no-srtp \
-    no-sock \
     no-ts \
     no-whirlpool
   echo "[+] Configured OpenSSL"

--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -5,7 +5,7 @@ ifdef FD_HAS_DOUBLE
 
 .PHONY: fdctl run monitor cargo
 
-$(call add-objs,main1 config security utility run/run run/tiles/tiles run/tiles/net run/tiles/netmux run/tiles/dedup run/tiles/pack run/tiles/quic run/tiles/verify run/tiles/bank keygen ready monitor/monitor monitor/helper configure/configure configure/large_pages configure/sysctl configure/shmem configure/xdp configure/xdp_leftover configure/ethtool configure/workspace_leftover configure/workspace,fd_fdctl)
+$(call add-objs,main1 config security utility run/run run/tiles/tiles run/tiles/net run/tiles/netmux run/tiles/metrics run/tiles/dedup run/tiles/pack run/tiles/quic run/tiles/verify run/tiles/bank keygen ready monitor/monitor monitor/helper configure/configure configure/large_pages configure/sysctl configure/shmem configure/xdp configure/xdp_leftover configure/ethtool configure/workspace_leftover configure/workspace,fd_fdctl)
 $(call make-bin-rust,fdctl,main,fd_fdctl fd_disco fd_ballet fd_tango fd_util fd_quic solana_validator_fd)
 $(OBJDIR)/obj/app/fdctl/configure/xdp.o: src/tango/xdp/fd_xdp_redirect_prog.o
 $(OBJDIR)/obj/app/fdctl/config.o: src/app/fdctl/config/default.toml

--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -31,6 +31,12 @@ workspace_kind_str( workspace_kind_t kind ) {
     case wksp_dedup: return "dedup";
     case wksp_pack: return "pack";
     case wksp_bank: return "bank";
+    case wksp_metrics: return "metrics";
+    case wksp_metrics_quic: return "metrics_quic";
+    case wksp_metrics_verify: return "metrics_verify";
+    case wksp_metrics_dedup: return "metrics_dedup";
+    case wksp_metrics_pack: return "metrics_pack";
+    case wksp_metrics_bank: return "metrics_bank";
   }
   return NULL;
 }
@@ -69,6 +75,11 @@ memlock_max_bytes( config_t * const config ) {
       case wksp_dedup_pack:
       case wksp_pack_bank:
       case wksp_bank_shred:
+      case wksp_metrics_quic:
+      case wksp_metrics_verify:
+      case wksp_metrics_dedup:
+      case wksp_metrics_pack:
+      case wksp_metrics_bank:
         break;
       case wksp_net:
         TILE_MAX( net );
@@ -90,6 +101,9 @@ memlock_max_bytes( config_t * const config ) {
         break;
       case wksp_bank:
         TILE_MAX( bank );
+        break;
+      case wksp_metrics:
+        TILE_MAX( metrics );
         break;
     }
   }
@@ -308,6 +322,13 @@ static void parse_key_value( config_t *   config,
   ENTRY_UINT  ( ., tiles.pack,          max_pending_transactions                                  );
 
   ENTRY_UINT  ( ., tiles.bank,          receive_buffer_size                                       );
+
+  ENTRY_UINT  ( ., tiles.metrics,       depth                                                     );
+  ENTRY_UINT  ( ., tiles.metrics,       buffer_size                                               );
+  ENTRY_STR   ( ., tiles.metrics,       server                                                    );
+  ENTRY_STR   ( ., tiles.metrics,       user_pass                                                 );
+  ENTRY_STR   ( ., tiles.metrics,       db                                                        );
+  ENTRY_UINT  ( ., tiles.metrics,       post_interval_ms                                          );
 
   ENTRY_UINT  ( ., tiles.dedup,         signature_cache_size                                      );
 }
@@ -560,6 +581,42 @@ init_workspaces( config_t * config ) {
 
   config->shmem.workspaces[ idx ].kind      = wksp_bank;
   config->shmem.workspaces[ idx ].name      = "bank";
+  config->shmem.workspaces[ idx ].page_size = FD_SHMEM_HUGE_PAGE_SZ;
+  config->shmem.workspaces[ idx ].num_pages = 1;
+  idx++;
+
+  config->shmem.workspaces[ idx ].kind      = wksp_metrics;
+  config->shmem.workspaces[ idx ].name      = "metrics";
+  config->shmem.workspaces[ idx ].page_size = FD_SHMEM_GIGANTIC_PAGE_SZ;
+  config->shmem.workspaces[ idx ].num_pages = 1;
+  idx++;
+
+  config->shmem.workspaces[ idx ].kind      = wksp_metrics_quic;
+  config->shmem.workspaces[ idx ].name      = "metrics_quic";
+  config->shmem.workspaces[ idx ].page_size = FD_SHMEM_HUGE_PAGE_SZ;
+  config->shmem.workspaces[ idx ].num_pages = 1;
+  idx++;
+
+  config->shmem.workspaces[ idx ].kind      = wksp_metrics_verify;
+  config->shmem.workspaces[ idx ].name      = "metrics_verify";
+  config->shmem.workspaces[ idx ].page_size = FD_SHMEM_HUGE_PAGE_SZ;
+  config->shmem.workspaces[ idx ].num_pages = 1;
+  idx++;
+
+  config->shmem.workspaces[ idx ].kind      = wksp_metrics_dedup;
+  config->shmem.workspaces[ idx ].name      = "metrics_dedup";
+  config->shmem.workspaces[ idx ].page_size = FD_SHMEM_HUGE_PAGE_SZ;
+  config->shmem.workspaces[ idx ].num_pages = 1;
+  idx++;
+
+  config->shmem.workspaces[ idx ].kind      = wksp_metrics_pack;
+  config->shmem.workspaces[ idx ].name      = "metrics_pack";
+  config->shmem.workspaces[ idx ].page_size = FD_SHMEM_HUGE_PAGE_SZ;
+  config->shmem.workspaces[ idx ].num_pages = 1;
+  idx++;
+
+  config->shmem.workspaces[ idx ].kind      = wksp_metrics_bank;
+  config->shmem.workspaces[ idx ].name      = "metrics_bank";
   config->shmem.workspaces[ idx ].page_size = FD_SHMEM_HUGE_PAGE_SZ;
   config->shmem.workspaces[ idx ].num_pages = 1;
   idx++;

--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -26,6 +26,12 @@ typedef enum {
   wksp_dedup,
   wksp_pack,
   wksp_bank,
+  wksp_metrics,
+  wksp_metrics_quic,
+  wksp_metrics_verify,
+  wksp_metrics_dedup,
+  wksp_metrics_pack,
+  wksp_metrics_bank,
 } workspace_kind_t;
 
 FD_FN_CONST char *
@@ -171,6 +177,16 @@ typedef struct {
     struct {
       uint receive_buffer_size;
     } bank;
+
+    struct {
+      uint   depth;
+      uint   buffer_size;
+      char   server[ PATH_MAX ];
+      ushort port;
+      char   user_pass[ PATH_MAX ];
+      char   db[ PATH_MAX ];
+      uint   post_interval_ms;
+    } metrics;
 
     struct {
       uint signature_cache_size;

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -307,7 +307,7 @@ dynamic_port_range = "8000-10000"
     #
     # It is suggested to use all available CPU cores for Firedancer, so that the
     # Solana network can run as fast as possible.
-    affinity = "0-14"
+    affinity = "0-15"
 
     # How many net tiles to run.  Each networking tile will service exactly one
     # queue from a network device being listened to.  If there are less net
@@ -534,6 +534,29 @@ dynamic_port_range = "8000-10000"
     # state as a result of any operations performed by the transactions.
     [tiles.bank]
         receive_buffer_size = 128
+
+    # The metrics tile is responsible for collecting metrics from the other tiles
+    # and forwarding them to metrics.solana.com which uses InfluxDB.
+    [tiles.metrics]
+        # This is the size of the mcache which is used to buffer metrics before
+        # the metrics tile processes them. There each tile has its own mcache.
+        depth = 128
+        # This is the internal buffer size of the metrics tile. It is used to
+        # store the body of the metrics post in InfluxDB line protocol before it
+        # is sent to the server.
+        buffer_size = 16777216
+        # This is the IP and port for InfluxDB at metrics.solana.com. We use an IP
+        # for now instead of a DNS name because we don't want to support DNS right
+        # now due to sandbox concerns.
+        server = "35.206.116.166:8086"
+        # This is the username and password for the InfluxDB server. They are public
+        # credentials.
+        user_pass = "scratch_writer:topsecret"
+        # The solana cluster name. This is a database in InfluxDB.
+        db = "devnet"
+        # How long to wait between posting metrics to the server. For now this needs to be
+        # set above
+        post_interval_ms = 5000
 
     # All transactions entering into the validator are deduplicated after their
     # signature is verified, to ensure the same transaction is not repeated

--- a/src/app/fdctl/configure/large_pages.c
+++ b/src/app/fdctl/configure/large_pages.c
@@ -58,6 +58,11 @@ expected_pages( config_t * const config, uint out[2] ) {
       case wksp_dedup_pack:
       case wksp_pack_bank:
       case wksp_bank_shred:
+      case wksp_metrics_quic:
+      case wksp_metrics_verify:
+      case wksp_metrics_dedup:
+      case wksp_metrics_pack:
+      case wksp_metrics_bank:
         break;
       case wksp_net:
       case wksp_netmux:
@@ -66,6 +71,7 @@ expected_pages( config_t * const config, uint out[2] ) {
       case wksp_dedup:
       case wksp_pack:
       case wksp_bank:
+      case wksp_metrics:
         num_tiles++;
         break;
     }

--- a/src/app/fdctl/configure/workspace.c
+++ b/src/app/fdctl/configure/workspace.c
@@ -350,6 +350,37 @@ init( config_t * const config ) {
           cnc   ( pod, "cnc%lu", i );
         }
         break;
+      case wksp_metrics:
+        cnc   ( pod, "cnc" );
+        ulong1( pod, "quic_count", config->layout.verify_tile_count );
+        ulong1( pod, "verify_count", config->layout.verify_tile_count );
+        ulong1( pod, "bank_count", config->layout.bank_tile_count );
+        ulong1( pod, "depth", config->tiles.metrics.depth );
+        ulong1( pod, "buffer_size", config->tiles.metrics.buffer_size );
+        fd_pod_insert_cstr( pod, "server",    config->tiles.metrics.server );
+        ushort1(            pod, "port", config->tiles.metrics.port, 0 );
+        fd_pod_insert_cstr( pod, "user_pass", config->tiles.metrics.user_pass );
+        fd_pod_insert_cstr( pod, "db", config->tiles.metrics.db );
+        ulong1(             pod, "post_interval_ms", config->tiles.metrics.post_interval_ms );
+        break;
+      case wksp_metrics_quic:
+      case wksp_metrics_verify:
+        for( ulong i=0; i<config->layout.verify_tile_count; i++ ) {
+          mcache( pod, "mcache%lu", config->tiles.metrics.depth, i );
+          dcache( pod, "dcache%lu", sizeof(Datapoint), (ulong)config->tiles.metrics.depth, 0 , i );
+        }
+        break;
+      case wksp_metrics_dedup:
+      case wksp_metrics_pack:
+        mcache( pod, "mcache0", config->tiles.metrics.depth );
+        dcache( pod, "dcache0", sizeof(Datapoint), (ulong)config->tiles.metrics.depth, 0 );
+        break;
+      case wksp_metrics_bank:
+        for( ulong i=0; i<config->layout.bank_tile_count; i++ ) {
+          mcache( pod, "mcache%lu", config->tiles.metrics.depth, i );
+          dcache( pod, "dcache%lu", sizeof(Datapoint), (ulong)config->tiles.metrics.depth, 0, i );
+        }
+        break;
     }
 
     WKSP_END();

--- a/src/app/fdctl/monitor/monitor.c
+++ b/src/app/fdctl/monitor/monitor.c
@@ -205,6 +205,11 @@ run_monitor( config_t * const config,
       case wksp_dedup_pack:
       case wksp_pack_bank:
       case wksp_bank_shred:
+      case wksp_metrics_quic:
+      case wksp_metrics_verify:
+      case wksp_metrics_dedup:
+      case wksp_metrics_pack:
+      case wksp_metrics_bank:
         break;
       case wksp_net:
         tile_cnt += config->layout.net_tile_count;
@@ -221,6 +226,8 @@ run_monitor( config_t * const config,
         break;
       case wksp_pack:
         tile_cnt += 1;
+        break;
+      case wksp_metrics:
         break;
       case wksp_bank:
         tile_cnt += config->layout.bank_tile_count;
@@ -388,6 +395,13 @@ run_monitor( config_t * const config,
           if( FD_UNLIKELY( fd_cnc_app_sz( tiles[ tile_idx ].cnc )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
           tile_idx++;
         }
+        break;
+      case wksp_metrics:
+      case wksp_metrics_quic:
+      case wksp_metrics_verify:
+      case wksp_metrics_dedup:
+      case wksp_metrics_pack:
+      case wksp_metrics_bank:
         break;
     }
   }
@@ -577,7 +591,7 @@ monitor_cmd_fn( args_t *         args,
   ushort allow_syscalls_cnt = args->monitor.drain_output_fd >= 0 ? num_syscalls : (ushort)(num_syscalls - 1);
 
   if( FD_UNLIKELY( close( 0 ) ) ) FD_LOG_ERR(( "close(0) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
-  fd_sandbox( config->development.sandbox,
+  fd_sandbox( config->development.sandbox ? SANDBOX_MODE_FULL : SANDBOX_MODE_NONE,
               config->uid,
               config->gid,
               allow_fds_sz,

--- a/src/app/fdctl/ready.c
+++ b/src/app/fdctl/ready.c
@@ -39,6 +39,11 @@ ready_cmd_fn( args_t *         args,
       case wksp_pack_bank:
       case wksp_bank_shred:
       case wksp_bank:
+      case wksp_metrics_quic:
+      case wksp_metrics_verify:
+      case wksp_metrics_dedup:
+      case wksp_metrics_pack:
+      case wksp_metrics_bank:
         break;
       case wksp_net:
         for( ulong i=0; i<config->layout.net_tile_count; i++ ) {
@@ -58,6 +63,7 @@ ready_cmd_fn( args_t *         args,
       }
       case wksp_netmux:
       case wksp_dedup:
+      case wksp_metrics:
       case wksp_pack: {
         wait_for( config->name, wksp->name, "cnc" );
         break;

--- a/src/app/fdctl/run/run.h
+++ b/src/app/fdctl/run/run.h
@@ -4,6 +4,7 @@
 #include "../fdctl.h"
 
 #include "../../../tango/xdp/fd_xsk.h"
+#include "../../../util/sandbox/fd_sandbox.h"
 
 typedef struct {
    int                pid;
@@ -22,10 +23,10 @@ typedef struct {
    workspace_kind_t * allow_workspaces;
    ushort             allow_syscalls_cnt;
    long *             allow_syscalls;
-
    ulong (*allow_fds)( fd_tile_args_t * args, ulong out_fds_sz, int * out_fds );
    void  (*init)( fd_tile_args_t * args );
    void  (*run )( fd_tile_args_t * args );
+   sandbox_mode_t sandbox_mode;
 } fd_tile_config_t;
 
 extern fd_tile_config_t net;
@@ -34,6 +35,7 @@ extern fd_tile_config_t quic;
 extern fd_tile_config_t verify;
 extern fd_tile_config_t dedup;
 extern fd_tile_config_t pack;
+extern fd_tile_config_t metrics;
 extern fd_tile_config_t bank;
 
 typedef struct {

--- a/src/app/fdctl/run/tiles/dedup.c
+++ b/src/app/fdctl/run/tiles/dedup.c
@@ -17,9 +17,11 @@ init( fd_tile_args_t * args ) {
 
 static void
 run( fd_tile_args_t * args ) {
-  const uchar * tile_pod = args->wksp_pod[ 0 ];
-  const uchar * in_pod   = args->wksp_pod[ 1 ];
-  const uchar * out_pod  = args->wksp_pod[ 2 ];
+  const uchar * tile_pod     = args->wksp_pod[ 0 ];
+  const uchar * in_pod       = args->wksp_pod[ 1 ];
+  const uchar * out_pod      = args->wksp_pod[ 2 ];
+  const uchar * metrics_pod  = args->wksp_pod[ 3 ];
+  fd_metrics_boot( metrics_pod, metrics_dedup, args->tile_idx );
 
   ulong in_cnt = fd_pod_query_ulong( in_pod, "cnt", 0UL );
   if( FD_UNLIKELY( !in_cnt ) ) FD_LOG_ERR(( "in_cnt not set" ));
@@ -65,6 +67,7 @@ static workspace_kind_t allow_workspaces[] = {
   wksp_dedup,        /* the tile itself */
   wksp_verify_dedup, /* receive path */
   wksp_dedup_pack,   /* send path */
+  wksp_metrics_dedup /* metrics */
 };
 
 static ulong

--- a/src/app/fdctl/run/tiles/metrics.c
+++ b/src/app/fdctl/run/tiles/metrics.c
@@ -1,0 +1,367 @@
+#include "../../fdctl.h"
+#include "../run.h"
+
+#include "../../../../disco/fd_disco.h"
+#include "../../../../disco/metrics/fd_ssl.h"
+#include "../../../../disco/metrics/fd_metrics_impl.h"
+
+#include <linux/unistd.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
+#define METRICS_TAG 0x8bf72a57ca2947b7UL
+
+/* ssl_init must be called in init() because it must execute outside the sandbox */
+static void
+ssl_init( void ) {
+  /* none of the below functions return a useful value */
+  SSL_library_init();
+  OpenSSL_add_all_algorithms();
+  SSL_load_error_strings();
+  ERR_load_BIO_strings();
+  ERR_load_crypto_strings();
+}
+
+#define SSL_STATE_SZ 2
+/* double buffer because we are not servicing more than two connections at a time */
+ssl_service_state_t ssl_state[SSL_STATE_SZ];
+
+/* append_datapoints converts datapoints into InfluxDB line protocol lines which get appended to append_buffer for
+ * later posting to metrics.solana.com.  It returns the remaining capacity of append_buffer. tile_name and idx are
+ * used to tag the measurement */
+static ulong
+append_datapoints( char *       append_buffer,
+                   ulong        append_buffer_capacity,
+                   char * const tile_name,
+                   ulong        idx,
+                   Datapoint *  datapoints,
+                   ulong        datapoints_sz ) {
+  metrics_kv_t tags[] = {
+      { .key   = "host_id",
+         .value = "" },     /* strncpy below from fd_log_host() */
+      { .key   = "tile",
+          .value = "" },    /* snprintf below */
+      { .key   = "index",
+          .value = "" },    /* snprintf below */
+  };
+  strncpy(  tags[ 0 ].value, fd_log_host(), sizeof( tags[ 0 ].value ) - 1 );
+  strncpy(  tags[ 1 ].value, tile_name,     sizeof( tags[ 1 ].value ) - 1 );
+  snprintf( tags[ 2 ].value, sizeof( tags[ 2 ].value ), "%ld", idx );
+
+  long ts = fd_log_wallclock();
+  for( ulong i=0; i<datapoints_sz; i++ ) {
+    char data[ 4096 ];
+    int ret = fd_metrics_format( data, sizeof( data ), tile_name, tags, sizeof( tags )/sizeof( tags[0] ), &datapoints[i], 1, ts++ );
+    if( FD_UNLIKELY( ret<0 || ret>=(int)sizeof( data ) ) ) {
+      FD_LOG_WARNING(( "snprintf error %d", ret ));
+      return 0;
+    }
+    ulong line_sz = strlen( data ) + 1;
+    if( FD_UNLIKELY( append_buffer_capacity <= line_sz ) ) {
+      FD_LOG_WARNING(( "append_buffer_capacity %lu <= %lu", append_buffer_capacity, strlen( data ) + 1 ));
+      return 0;
+    }
+    strncat( append_buffer, data, append_buffer_capacity - 1 );
+    append_buffer_capacity -= line_sz;
+  }
+  return append_buffer_capacity;
+}
+
+/* metrics_ctx_t is required because the contents of the strcut are used in the run function but need to be initialized
+   in the init function */
+typedef struct {
+  ulong  depth;
+  ulong  quic_count;
+  ulong  bank_count;
+  ulong  verify_count;
+  ulong  buffer_size;
+  ulong  data_buffer_sz;
+  char * data_buffer;
+  ulong  post_buffer_sz;
+  char * post_buffer;
+  const char * server;
+  const char * user_pass;
+  const char * db;
+  ulong post_interval_ms;
+  ulong in_cnt;
+  metrics_t * metrics;
+} metrics_ctx_t;
+
+/* metrics_init must be called in init() because it must execute outside the sandbox.
+   workspace_pod_join must be executed outside the sandbox. */
+void
+metrics_init( fd_tile_args_t const * args, metrics_ctx_t * ctx ) {
+  const uchar * tile_pod   = args->wksp_pod[ 0 ];
+  const uchar * quic_pod   = args->wksp_pod[ 1 ];
+  const uchar * verify_pod = args->wksp_pod[ 2 ];
+  const uchar * dedup_pod  = args->wksp_pod[ 3 ];
+  const uchar * pack_pod   = args->wksp_pod[ 4 ];
+  const uchar * bank_pod   = args->wksp_pod[ 5 ];
+
+  ctx->depth = fd_pod_query_ulong( tile_pod, "depth", 0UL );
+  if( FD_UNLIKELY( !ctx->depth ) ) FD_LOG_ERR(( "depth must be set" ));
+
+  ctx->quic_count = fd_pod_query_ulong( tile_pod, "quic_count", 0UL );
+  if( FD_UNLIKELY( !ctx->quic_count ) ) FD_LOG_ERR(( "quic_count must be set" ));
+
+  ctx->bank_count = fd_pod_query_ulong( tile_pod, "bank_count", 0UL );
+  if( FD_UNLIKELY( !ctx->bank_count ) ) FD_LOG_ERR(( "bank_count must be set" ));
+
+  ctx->verify_count = fd_pod_query_ulong( tile_pod, "verify_count", 0UL );
+  if( FD_UNLIKELY( !ctx->verify_count ) ) FD_LOG_ERR(( "verify_count must be set" ));
+
+  ctx->buffer_size = fd_pod_query_ulong( tile_pod, "buffer_size", 0UL );
+  if( FD_UNLIKELY( !ctx->buffer_size ) ) FD_LOG_ERR(( "buffer_size must be set" ));
+
+  for( ulong i=0; i<SSL_STATE_SZ; i++ ) {
+    ulong  data_buf_sz = ctx->buffer_size;
+    char * data_buf = fd_wksp_alloc_laddr( fd_wksp_containing( tile_pod ), 1, data_buf_sz, METRICS_TAG );
+    if( FD_UNLIKELY( !data_buf ) ) FD_LOG_ERR(( "data_buf must be set" ));
+
+    /* The post buffer is larger than the data buffer to allow for the HTTP headers */
+    ulong  tx_buf_sz = ctx->buffer_size + 1000;
+    char * tx_buf = fd_wksp_alloc_laddr( fd_wksp_containing( tile_pod ), 1, tx_buf_sz, METRICS_TAG );
+    if( FD_UNLIKELY( !tx_buf_sz ) ) FD_LOG_ERR(( "tx_buf_sz must be set" ));
+
+    ssl_service_init( &ssl_state[i], data_buf, data_buf_sz, tx_buf, tx_buf_sz );
+  }
+
+  ctx->server = fd_pod_query_cstr( tile_pod, "server", NULL );
+  if( FD_UNLIKELY( !ctx->server ) ) FD_LOG_ERR(( "server must be set" ));
+
+  ctx->user_pass = fd_pod_query_cstr( tile_pod, "user_pass", NULL );
+  if( FD_UNLIKELY( !ctx->user_pass ) ) FD_LOG_ERR(( "user_pass must be set" ));
+
+  ctx->db = fd_pod_query_cstr( tile_pod, "db", NULL );
+  if( FD_UNLIKELY( !ctx->db ) ) FD_LOG_ERR(( "db must be set" ));
+
+  ctx->post_interval_ms = fd_pod_query_ulong( tile_pod, "post_interval_ms", 0UL );
+  if( FD_UNLIKELY( !ctx->post_interval_ms ) ) FD_LOG_ERR(( "post_interval_ms must be set" ));
+
+  ctx->in_cnt = ctx->bank_count + ctx->quic_count + ctx->verify_count + 2; /* +2 for dedup and pack */
+
+  ctx->metrics = fd_wksp_alloc_laddr( fd_wksp_containing( tile_pod ), alignof( metrics_ctx_t ), ctx->in_cnt * sizeof( metrics_ctx_t ), METRICS_TAG );
+  if( FD_UNLIKELY( !ctx->metrics ) ) FD_LOG_ERR(( "metrics must be set %lu", ctx->in_cnt ));
+  ulong idx = 0;
+
+  /* quic */
+  for( ulong i = 0; i < ctx->quic_count; i++ ) {
+    metrics_boot_unmanaged( quic_pod, metrics_quic, i, &ctx->metrics[ idx++ ] );
+  }
+
+  /* verify */
+  for( ulong i = 0; i < ctx->verify_count; i++ ) {
+    metrics_boot_unmanaged( verify_pod, metrics_verify, i, &ctx->metrics[ idx++ ] );
+  }
+
+  /* dedup */
+  metrics_boot_unmanaged( dedup_pod, metrics_dedup, 0, &ctx->metrics[ idx++ ] );
+
+  /* pack */
+  metrics_boot_unmanaged( pack_pod, metrics_pack,   0, &ctx->metrics[ idx++ ] );
+
+  /* bank */
+  for( ulong i = 0; i < ctx->bank_count; i++ ) {
+    metrics_boot_unmanaged( bank_pod, metrics_bank, i, &ctx->metrics[ idx++ ] );
+  }
+}
+
+/* metrics_ctx_t is required because the contents of the strcut are used in the run function but need to be initialized
+   in the init function */
+metrics_ctx_t ctx;
+
+static void
+init( fd_tile_args_t * args ) {
+  (void)args;
+  /* calling fd_tempo_tick_per_ns requires nanosleep, it is cached with
+     a FD_ONCE */
+  fd_tempo_tick_per_ns( NULL );
+
+  ssl_init();
+  metrics_init( args, &ctx );
+}
+
+static void
+run( fd_tile_args_t * args ) {
+  const uchar * tile_pod   = args->wksp_pod[ 0 ];
+
+  SSL_CTX * ssl_ctx = SSL_CTX_new(TLS_client_method());
+  /* this should never happen, if it does the tile is unhealthy and unable to operate so exit */
+  if( FD_UNLIKELY( ssl_ctx == NULL ) ) {
+    FD_LOG_WARNING(( "SSL_CTX_new failed" ));
+  }
+
+  /* Join the IPC objects needed this tile instance */
+  FD_LOG_INFO(( "joining cnc" ));
+  fd_cnc_t * cnc = fd_cnc_join( fd_wksp_pod_map( tile_pod, "cnc" ) );
+  if( FD_UNLIKELY( !cnc ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
+  if( FD_UNLIKELY( fd_cnc_signal_query( cnc ) != FD_CNC_SIGNAL_BOOT ) ) FD_LOG_ERR(( "cnc not in boot state" ));
+
+  ulong * cnc_diag = ( ulong * ) fd_cnc_app_laddr( cnc );
+  cnc_diag[ FD_APP_CNC_DIAG_PID ] = ( ulong ) args->pid;
+
+  /* Setup local objects used by this tile */
+  long lazy = fd_pod_query_long( tile_pod, "lazy", 0L );
+  FD_LOG_INFO(( "configuring flow control (lazy %li)", lazy ));
+  if( FD_UNLIKELY( lazy <= 0L ) ) lazy = fd_tempo_lazy_default( ctx.depth );
+  FD_LOG_INFO(( "using lazy %li ns", lazy ));
+  ulong async_min = fd_tempo_async_min( lazy, 1UL /*event_cnt*/, ( float ) fd_tempo_tick_per_ns( NULL ) );
+  if( FD_UNLIKELY( !async_min ) ) FD_LOG_ERR(( "bad lazy" ));
+
+  uint seed = ( uint ) fd_tile_id(); /* TODO: LML is this a good seed? */
+  FD_LOG_INFO(( "creating rng (seed %u)", seed ));
+  fd_rng_t _rng[1];
+  fd_rng_t *rng = fd_rng_join( fd_rng_new( _rng, seed, 0UL ) );
+  if( FD_UNLIKELY( !rng )) FD_LOG_ERR(( "fd_rng_join failed" ));
+
+  FD_LOG_INFO(( "metrics run" ));
+  fd_cnc_signal( cnc, FD_CNC_SIGNAL_RUN );
+  long cnc_service_deadline = fd_tickcount();
+  long metrics_service_deadline = fd_tickcount();
+
+  ulong     metrics_idx = 0;
+  ulong     ssl_idx = 0;
+  ulong     num_datapoints = 0;
+  Datapoint datapoints[ctx.depth];
+  for( ;; ) {
+    long now = fd_tickcount();
+    metrics_t * metric = &ctx.metrics[ metrics_idx ];
+
+    /* Service the SSL connections */
+    for( ulong i=0; i<SSL_STATE_SZ; i++ ) {
+      do {
+        /* If the connection is active service it */
+        if( FD_LIKELY( ssl_state[ i ].conn.ssl_bio ) ) {
+          ssl_service( &ssl_state[ i ] );
+        }
+        /* If the connection is done, reinitialize it */
+        if( FD_UNLIKELY( ssl_state[ i ].rx_done ) ) {
+          ssl_service_reinit( &ssl_state[ i ] );
+        }
+      } while( ssl_state[ i ].conn.ssl_bio && !ssl_state[ i ].rx_done);
+    }
+
+    /* Periodically post metrics */
+    if( FD_UNLIKELY( metrics_service_deadline <= now ) ) {
+      if( FD_LIKELY( strlen( ssl_state[ssl_idx].data_buf ) ) ) {
+        fd_ssl_send_data( ctx.server, ctx.user_pass, ctx.db, ssl_ctx, &ssl_state[ssl_idx] );
+      }
+      ssl_idx++;
+      ssl_idx %= SSL_STATE_SZ;
+      metrics_service_deadline = now + (long)ctx.post_interval_ms*1000000 + (long)fd_tempo_async_reload( rng, async_min );
+    }
+
+    /* Read available datapoints from the tile then queue up the next one */
+    for( ulong i = 0; i < ctx.depth; i++ ) {
+      uint tag;
+      ulong value;
+      metrics_status_t status = metrics_pop_unmanaged( metric, &tag, &value );
+      switch( status ) {
+        case METRICS_STATUS_OK:
+          fd_metrics_tag_value_to_datapoint( tag, value, &datapoints[ num_datapoints ] );
+          num_datapoints++;
+          break;
+        case METRICS_STATUS_EMPTY:
+          goto loop_break;
+        case METRICS_STATUS_OVERRUN:
+          FD_LOG_WARNING(( "metrics overrun %s", metrics_tile_names[ metric->tile ] ));
+          break;
+        case METRICS_STATUS_UNINITIALIZED:
+          FD_LOG_WARNING(( "metrics uninitialized %s", metrics_tile_names[ metric->tile ] ));
+          goto loop_break;
+      }
+    }
+    loop_break:
+
+    /* If we have new datapoints append them now */
+    if( FD_LIKELY( num_datapoints ) ) {
+      ssl_state[ssl_idx].data_buf_capacity = append_datapoints( ssl_state[ssl_idx].data_buf,
+                                                                ssl_state[ssl_idx].data_buf_capacity,
+                                                                metrics_tile_names[ metric->tile ],
+                                                                metric->idx,
+                                                                datapoints,
+                                                                num_datapoints );
+      num_datapoints = 0;
+
+      /* The buffer is filled, post metrics on the next iteration */
+      if( FD_UNLIKELY( !ssl_state[ssl_idx].data_buf_capacity ) ) {
+        metrics_service_deadline = now;
+      }
+    }
+
+    /* Advance to the next tile */
+    metrics_idx++;
+    metrics_idx %= ctx.in_cnt;
+
+    /* Check for CNC signals */
+    if( FD_UNLIKELY( cnc_service_deadline <= now )) {
+      fd_cnc_heartbeat( cnc, now );
+      ulong s = fd_cnc_signal_query( cnc );
+      if( FD_UNLIKELY( s != FD_CNC_SIGNAL_RUN )) {
+        if( FD_LIKELY( s == FD_CNC_SIGNAL_HALT )) break;
+        if( FD_UNLIKELY( s != FD_MUX_CNC_SIGNAL_ACK )) {
+          char buf[FD_CNC_SIGNAL_CSTR_BUF_MAX];
+          FD_LOG_WARNING(( "Unexpected signal %s (%lu) received; trying to resume", fd_cnc_signal_cstr( s, buf ), s ));
+        }
+        fd_cnc_signal( cnc, FD_CNC_SIGNAL_RUN);
+      }
+      cnc_service_deadline = now + ( long ) fd_tempo_async_reload( rng, async_min );
+    }
+  }
+}
+
+/* These are all required for openssl, many due to nonblocking mode */
+static long allow_syscalls[] = {
+  __NR_bind,
+  __NR_close,
+  __NR_connect,
+  __NR_fstat,
+  __NR_fsync,
+  __NR_getpid,
+  __NR_getrandom,
+  __NR_getsockname,
+  __NR_getsockopt,
+  __NR_ioctl,
+  __NR_openat,
+  __NR_poll,
+  __NR_read,
+  __NR_recvmsg,
+  __NR_select,
+  __NR_sendto,
+  __NR_setsockopt,
+  __NR_shutdown,
+  __NR_socket,
+  __NR_write,
+};
+
+static ulong
+allow_fds( fd_tile_args_t * args,
+           ulong out_fds_sz,
+           int * out_fds ) {
+  (void)args;
+  if( FD_UNLIKELY( out_fds_sz < 2 ) ) FD_LOG_ERR(( "out_fds_sz %lu", out_fds_sz ));
+  out_fds[ 0 ] = 2; /* stderr */
+  out_fds[ 1 ] = 3; /* logfile */
+  return 2;
+}
+
+static workspace_kind_t allow_workspaces[] = {
+    wksp_metrics,
+    wksp_metrics_quic,
+    wksp_metrics_verify,
+    wksp_metrics_dedup,
+    wksp_metrics_pack,
+    wksp_metrics_bank,
+};
+
+fd_tile_config_t metrics = {
+    .name              = "metrics",
+    .allow_workspaces_cnt = sizeof(allow_workspaces)/sizeof(allow_workspaces[ 0 ]),
+    .allow_workspaces     = allow_workspaces,
+    .allow_syscalls_cnt   = sizeof(allow_syscalls)/sizeof(allow_syscalls[ 0 ]),
+    .allow_syscalls    = allow_syscalls,
+    .allow_fds         = allow_fds,
+    .init              = init,
+    .run               = run,
+    .sandbox_mode      = SANDBOX_MODE_METRICS,
+};

--- a/src/app/fdctl/run/tiles/pack.c
+++ b/src/app/fdctl/run/tiles/pack.c
@@ -19,9 +19,11 @@ init( fd_tile_args_t * args ) {
 
 static void
 run( fd_tile_args_t * args ) {
-  const uchar * tile_pod = args->wksp_pod[ 0 ];
-  const uchar * in_pod   = args->wksp_pod[ 1 ];
-  const uchar * out_pod  = args->wksp_pod[ 2 ];
+  const uchar * tile_pod     = args->wksp_pod[ 0 ];
+  const uchar * in_pod       = args->wksp_pod[ 1 ];
+  const uchar * out_pod      = args->wksp_pod[ 2 ];
+  const uchar * metrics_pod  = args->wksp_pod[ 3 ];
+  fd_metrics_boot( metrics_pod, metrics_pack, args->tile_idx );
 
   ulong out_cnt = fd_pod_query_ulong( out_pod, "cnt", 0UL );
   if( FD_UNLIKELY( !out_cnt ) ) FD_LOG_ERR(( "num_tiles unset or set to zero" ));
@@ -84,9 +86,10 @@ static long allow_syscalls[] = {
 };
 
 static workspace_kind_t allow_workspaces[] = {
-  wksp_pack,       /* the tile itself */
-  wksp_dedup_pack, /* receive path */
-  wksp_pack_bank,  /* send path */
+  wksp_pack,        /* the tile itself */
+  wksp_dedup_pack,  /* receive path */
+  wksp_pack_bank,   /* send path */
+  wksp_metrics_pack /* metrics */
 };
 
 static ulong

--- a/src/app/fdctl/run/tiles/quic.c
+++ b/src/app/fdctl/run/tiles/quic.c
@@ -66,9 +66,11 @@ initialize_quic( fd_quic_config_t * config,
 
 static void
 run( fd_tile_args_t * args ) {
-  const uchar * tile_pod = args->wksp_pod[ 0 ];
-  const uchar * mux_pod  = args->wksp_pod[ 1 ];
-  const uchar * out_pod  = args->wksp_pod[ 2 ];
+  const uchar * tile_pod     = args->wksp_pod[ 0 ];
+  const uchar * mux_pod      = args->wksp_pod[ 1 ];
+  const uchar * out_pod      = args->wksp_pod[ 2 ];
+  const uchar * metrics_pod  = args->wksp_pod[ 3 ];
+  fd_metrics_boot( metrics_pod, metrics_quic, args->tile_idx );
 
   fd_quic_t * quic = fd_quic_join( fd_wksp_pod_map1( tile_pod, "quic%lu", args->tile_idx ) );
   if( FD_UNLIKELY( !quic ) ) FD_LOG_ERR(( "fd_quic_join failed" ));
@@ -114,6 +116,7 @@ static workspace_kind_t allow_workspaces[] = {
   wksp_quic,         /* the tile itself */
   wksp_netmux_inout, /* sending / receiving packets from network */
   wksp_quic_verify,  /* send path for transactions */
+  wksp_metrics_quic  /* metrics */
 };
 
 static ulong

--- a/src/app/fdctl/run/tiles/verify.c
+++ b/src/app/fdctl/run/tiles/verify.c
@@ -17,9 +17,11 @@ init( fd_tile_args_t * args ) {
 
 static void
 run( fd_tile_args_t * args ) {
-  const uchar * tile_pod = args->wksp_pod[ 0 ];
-  const uchar * in_pod   = args->wksp_pod[ 1 ];
-  const uchar * out_pod  = args->wksp_pod[ 2 ];
+  const uchar * tile_pod     = args->wksp_pod[ 0 ];
+  const uchar * in_pod       = args->wksp_pod[ 1 ];
+  const uchar * out_pod      = args->wksp_pod[ 2 ];
+  const uchar * metrics_pod  = args->wksp_pod[ 3 ];
+  fd_metrics_boot( metrics_pod, metrics_verify, args->tile_idx );
 
   char mcache[32], fseq[32], dcache[32];
   snprintf( mcache, sizeof(mcache), "mcache%lu", args->tile_idx );
@@ -52,9 +54,10 @@ static long allow_syscalls[] = {
 };
 
 static workspace_kind_t allow_workspaces[] = {
-  wksp_verify,       /* the tile itself */
-  wksp_quic_verify,  /* receive path  */
-  wksp_verify_dedup, /* send path */
+  wksp_verify,        /* the tile itself */
+  wksp_quic_verify,   /* receive path  */
+  wksp_verify_dedup,  /* send path */
+  wksp_metrics_verify /* metrics */
 };
 
 static ulong

--- a/src/app/fddev/dev1.c
+++ b/src/app/fddev/dev1.c
@@ -15,6 +15,7 @@ typedef enum {
   DEV1_VERIFY,
   DEV1_QUIC,
   DEV1_BANK,
+  DEV1_METRICS,
   DEV1_SOLANA,
 } tile_t;
 
@@ -30,6 +31,7 @@ dev1_cmd_args( int *    pargc,
   else if( FD_LIKELY( !strcmp( *pargv[ 0 ], "verify" ) ) )      args->run1.tile = DEV1_VERIFY;
   else if( FD_LIKELY( !strcmp( *pargv[ 0 ], "quic" ) ) )        args->run1.tile = DEV1_QUIC;
   else if( FD_LIKELY( !strcmp( *pargv[ 0 ], "bank" ) ) )        args->run1.tile = DEV1_BANK;
+  else if( FD_LIKELY( !strcmp( *pargv[ 0 ], "metrics" ) ) )     args->run1.tile = DEV1_METRICS;
   else if( FD_LIKELY( !strcmp( *pargv[ 0 ], "labs" ) ) )        args->run1.tile = DEV1_SOLANA;
   else if( FD_LIKELY( !strcmp( *pargv[ 0 ], "solana" ) ) )      args->run1.tile = DEV1_SOLANA;
   else if( FD_LIKELY( !strcmp( *pargv[ 0 ], "solana-labs" ) ) ) args->run1.tile = DEV1_SOLANA;
@@ -74,6 +76,7 @@ dev1_cmd_fn( args_t *         args,
     case DEV1_DEDUP:   tile_args.tile = &dedup; break;
     case DEV1_VERIFY:  tile_args.tile = &verify; break;
     case DEV1_QUIC:    tile_args.tile = &quic; break;
+    case DEV1_METRICS: tile_args.tile = &metrics; break;
     case DEV1_SOLANA: break;
     default: FD_LOG_ERR(( "unknown tile %d", args->run1.tile ));
   }

--- a/src/disco/fd_disco.h
+++ b/src/disco/fd_disco.h
@@ -9,6 +9,7 @@
 #include "pack/fd_pack.h"     /* includes fd_disco_base.h */
 #include "mux/fd_mux.h"       /* includes fd_disco_base.h */
 #include "replay/fd_replay.h" /* includes fd_disco_base.h */
+#include "metrics/fd_metrics.h" /* includes fd_disco_base.h */
 
 #endif /* HEADER_fd_src_disco_fd_disco_base_h */
 

--- a/src/disco/metrics/Local.mk
+++ b/src/disco/metrics/Local.mk
@@ -1,0 +1,2 @@
+$(call add-hdrs,fd_metrics.h fd_ssl.h)
+$(call add-objs,fd_metrics fd_ssl,fd_disco)

--- a/src/disco/metrics/fd_metrics.c
+++ b/src/disco/metrics/fd_metrics.c
@@ -1,0 +1,210 @@
+#include "fd_metrics.h"
+#include "fd_metrics_impl.h"
+#include <stdio.h>
+#include <stdbool.h>
+
+/* metrics_definition is used to define the metrics which are
+ * available for ALL tiles. This is used by the fd_metrics_pop
+ * function to convert the tag into a string name and ulong value
+ * into the correct InfluxDB wire protocol type.
+ */
+Measurement metrics_definition[] = {
+    {
+        .name = "__test_seq",
+        .type = METRICS_DATATYPE_INT,
+    },
+};
+
+const int metrics_definition_sz = sizeof( metrics_definition )/sizeof( metrics_definition[ 0 ] );
+
+FD_TLS metrics_t metrics_tls;
+FD_TLS bool      metrics_initialized    = false;
+FD_TLS bool      metrics_warning_issued = false;
+
+/* Used in conjunction with metrics_tile_t */
+char * metrics_tile_names[] = { "quic", "verify", "dedup", "pack", "bank" };
+
+/* metrics_boot_unmanaged is used to initialize the metrics_t struct
+ * for a given tile and index. This is used by the fd_metrics_boot function
+ * to initialize the TLS metrics_t struct.
+ */
+void
+metrics_boot_unmanaged( uchar const * pod, const metrics_tile_t tile, const ulong idx, metrics_t * m ) {
+  char path[ 32 ];
+
+  snprintf( path, 32, "mcache%lu", idx );
+  FD_LOG_INFO(( "joining %s", path ));
+  m->mcache = fd_mcache_join( fd_wksp_pod_map( pod, path ) );
+  if( FD_UNLIKELY( !m->mcache ) ) FD_LOG_ERR(( "fd_mcache_join failed" ));
+
+  m->tile         = tile;
+  m->idx          = idx;
+  m->sync         = fd_mcache_seq_laddr( m->mcache );
+  m->seq          = fd_mcache_seq_query( m->sync );
+  m->seq_consumer = fd_mcache_seq_query( m->sync );
+  m->depth        = fd_mcache_depth( m->mcache );
+
+  metrics_initialized = true;
+}
+
+/* fd_metrics_boot is used to initialize the TLS metrics_t struct
+ * for a given tile and index. This function is called by any
+ * tile which needs to push metrics.
+ */
+void
+fd_metrics_boot( uchar const * pod, const metrics_tile_t tile, const ulong idx ) {
+  metrics_boot_unmanaged( pod, tile, idx, &metrics_tls );
+}
+
+metrics_status_t
+metrics_pop_unmanaged( metrics_t * m, uint * tag, ulong * value ) {
+  if( FD_UNLIKELY( !metrics_initialized ) ) {
+    if( FD_UNLIKELY( !metrics_warning_issued )) {
+      FD_LOG_WARNING(( "metrics not initialized" ));
+      metrics_warning_issued = true;
+    }
+    return METRICS_STATUS_UNINITIALIZED;
+  }
+
+  fd_frag_meta_t const * mline = m->mcache + fd_mcache_line_idx( m->seq_consumer, m->depth );
+
+  ulong seq_found = fd_frag_meta_seq_query( mline );
+  long  diff      = fd_seq_diff( seq_found, m->seq_consumer );
+  if( FD_UNLIKELY( diff ) ) { /* caught up or overrun, optimize for expected sequence number ready */
+    if( FD_LIKELY( diff<0L ) ) { /* caught up */
+      return METRICS_STATUS_EMPTY;
+    } else {
+      m->seq_consumer = fd_mcache_seq_query( m->sync );
+      FD_LOG_NOTICE(( "overrun1 %s: seq=%lu seq_found=%lu diff=%ld", metrics_tile_names[ m->tile ], m->seq_consumer, seq_found, diff ));
+      return METRICS_STATUS_OVERRUN;
+    }
+  }
+
+  *tag   = mline->chunk;
+  *value = mline->seq;
+
+  seq_found = fd_frag_meta_seq_query( mline );
+  if( FD_UNLIKELY( fd_seq_ne( seq_found, m->seq_consumer ) ) ) {
+    m->seq_consumer = seq_found;
+    FD_LOG_NOTICE(( "overrun2" ));
+    return METRICS_STATUS_OVERRUN;
+  }
+
+  /* a successful read of the data, move to the next */
+  m->seq_consumer++;
+  return METRICS_STATUS_OK;
+}
+
+int
+fd_metrics_format( char          * buf,
+                   ulong           buf_sz,
+                   char          * tile_name,
+                   metrics_kv_t  * tags,
+                   ulong           tags_sz,
+                   Datapoint     * datapoints,
+                   ulong           datapoints_sz,
+                   long            ts ) {
+  char * offset = buf;
+  ulong capacity_remaining = buf_sz;
+
+  int ret = snprintf( offset, capacity_remaining, "%s", tile_name );
+  offset += ret;
+  capacity_remaining -= (ulong) ret;
+
+  /* Write tags */
+  for( ulong i=0; i<tags_sz; i++ ) {
+    ret = snprintf( offset, capacity_remaining, ",%s=%s", tags[ i ].key, tags[ i ].value );
+    if( FD_UNLIKELY( ret<0 || ret>=(long)capacity_remaining ) ) {
+      FD_LOG_WARNING(( "snprintf error %d", ret ));
+      return -1;
+    }
+    offset += ret;
+    capacity_remaining -= (ulong) ret;
+  }
+
+  /* Write datapoints */
+  for( ulong i=0; i<datapoints_sz; i++ ) {
+    switch( datapoints[i].measurement.type ) {
+      case METRICS_DATATYPE_FLOAT:
+        ret = snprintf( offset, capacity_remaining, " %s=%f",  datapoints[ i ].measurement.name, datapoints[ i ].value.f );
+        break;
+      case METRICS_DATATYPE_INT:
+        ret = snprintf( offset, capacity_remaining, " %s=%ld", datapoints[ i ].measurement.name, datapoints[ i ].value.i );
+        break;
+      case METRICS_DATATYPE_STRING:
+        ret = snprintf( offset, capacity_remaining, " %s=\"%s\"",  datapoints[ i ].measurement.name, datapoints[ i ].value.s );
+        break;
+      case METRICS_DATATYPE_BOOL:
+        if( datapoints[ i ].value.b ) {
+          ret = snprintf( offset, capacity_remaining, " %s=t", datapoints[ i ].measurement.name );
+        } else {
+          ret = snprintf( offset, capacity_remaining, " %s=f", datapoints[ i ].measurement.name );
+        }
+        break;
+    }
+    if( FD_UNLIKELY( ret<0 || ret>=(long)capacity_remaining ) ) {
+      FD_LOG_WARNING(( "snprintf error %d", ret ));
+      return -1;
+    }
+    offset += ret;
+    capacity_remaining -= (ulong) ret;
+  }
+
+  /* Write timestamp */
+  ret = snprintf( offset, capacity_remaining, " %ld\n", ts );
+  if( FD_UNLIKELY( ret<0 || ret>=(long)capacity_remaining ) ) {
+    FD_LOG_WARNING(( "snprintf error %d", ret ));
+    return -1;
+  }
+  capacity_remaining -= (ulong) ret;
+
+  return (int)( buf_sz - capacity_remaining );
+}
+
+void
+fd_metrics_push( uint tag, ulong value ) {
+  metrics_push_unmanaged( &metrics_tls, tag, value );
+}
+
+void
+metrics_push_unmanaged( metrics_t * m, uint tag, ulong value ) {
+  if( FD_UNLIKELY( !metrics_initialized ) ) {
+    if( FD_UNLIKELY( !metrics_warning_issued ) ) {
+      FD_LOG_WARNING(( "metrics not initialized" ));
+      metrics_warning_issued = true;
+    }
+    return;
+  }
+
+  ulong tspub  = (ulong)fd_frag_meta_ts_comp( fd_tickcount() );
+  ulong ctl    = fd_frag_meta_ctl( m->idx, 1, 1, 0 );
+  /* we put the tag in the chunk field, and the value in the seq field */
+  fd_mcache_publish( m->mcache, m->depth, m->seq, value, tag, sizeof( Datapoint ), ctl, 0UL, tspub );
+  m->seq++;
+  fd_mcache_seq_update( m->sync, m->seq );
+}
+
+void
+fd_metrics_tag_value_to_datapoint( uint tag, ulong val, Datapoint * d ) {
+  if( FD_UNLIKELY( tag >= (uint)metrics_definition_sz ) ) {
+    FD_LOG_WARNING(( "tag %u out of range", tag ));
+    return;
+  }
+
+  d->measurement = metrics_definition[ tag ];
+
+  switch( d->measurement.type ) {
+    case METRICS_DATATYPE_FLOAT:
+      d->value.f = (double)val;
+      break;
+    case METRICS_DATATYPE_INT:
+      d->value.i = (long)val;
+      break;
+    case METRICS_DATATYPE_STRING:
+      // TODO: unsupported for now
+      break;
+    case METRICS_DATATYPE_BOOL:
+      d->value.b = (bool)val;
+      break;
+  }
+}

--- a/src/disco/metrics/fd_metrics.h
+++ b/src/disco/metrics/fd_metrics.h
@@ -1,0 +1,88 @@
+#ifndef HEADER_fd_src_util_metrics_fd_metrics_h
+#define HEADER_fd_src_util_metrics_fd_metrics_h
+
+#include "../fd_disco_base.h"
+#include "../../tango/mcache/fd_mcache.h"
+#include "../../tango/tempo/fd_tempo.h"
+#include <stdbool.h>
+
+/* metrics_tags_t is used to define the tags which are available
+ * for ALL tiles.
+ *
+ * Used in conjunction with metrics_definition
+ */
+typedef enum {
+  METRIC_MUX_TEST_TAG,
+} metrics_tags_t;
+
+typedef enum {
+  METRICS_DATATYPE_FLOAT,
+  METRICS_DATATYPE_INT,
+  METRICS_DATATYPE_STRING,
+  METRICS_DATATYPE_BOOL,
+} metrics_datatype_t;
+
+#define METRICS_NAME_SZ 40
+
+typedef struct {
+  metrics_datatype_t  type;
+  char                name[METRICS_NAME_SZ];
+} Measurement;
+
+/* metrics_definition is used to define the metrics which are
+ * available for ALL tiles. This is used by the fd_metrics_pop
+ * function to convert the tag into a string name and ulong value
+ * into the correct InfluxDB wire protocol type.
+ *
+ * * Used in conjunction with metrics_tags_t
+ */
+extern Measurement metrics_definition[];
+
+/* metrics_t is an opaque type which is used to track the
+ * metrics for a given tile.
+ *
+ * Used in conjunction with metrics_tile_t
+ */
+struct metrics_t;
+typedef struct metrics_t metrics_t;
+
+/* metrics_tile_t is used to identify the type of tile when calling fd_metrics_boot */
+typedef enum {
+  metrics_quic,
+  metrics_verify,
+  metrics_dedup,
+  metrics_pack,
+  metrics_bank,
+} metrics_tile_t;
+
+/* Used in conjunction with metrics_tile_t to turn the enum into a string */
+extern char * metrics_tile_names[];
+
+/* A union of the types of metrics values we support */
+#define METRICS_VALUE_STRING_SZ 128
+typedef struct {
+  long   i;
+  double f;
+  bool   b;
+  char   s[METRICS_VALUE_STRING_SZ];
+} metrics_value;
+
+/* Datapoint is used to store a single value for a measurement. In practice this translates to a single line
+ * in a POST to metrics.solana.com */
+typedef struct {
+  Measurement   measurement;
+  metrics_value value;
+} Datapoint;
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_metrics_boot is used to initialize the metrics for a given tile. This should be called once per tile
+ * at startup. */
+void fd_metrics_boot( uchar const * pod, const metrics_tile_t tile, const ulong idx );
+
+/* fd_metrics_push is used to push a single metric value into the mcache. */
+void fd_metrics_push( uint tag, ulong value );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_util_metrics_fd_metrics_h */

--- a/src/disco/metrics/fd_metrics_impl.h
+++ b/src/disco/metrics/fd_metrics_impl.h
@@ -1,0 +1,60 @@
+#ifndef HEADER_fd_src_util_metrics_fd_metrics_impl_h
+#define HEADER_fd_src_util_metrics_fd_metrics_impl_h
+
+#include "fd_metrics.h"
+
+/* Per tile struct that allows the metrics tile to know where the metrics are coming from
+ * and for tracking mcache */
+struct metrics_t {
+  metrics_tile_t tile;
+  ulong   idx;
+  fd_frag_meta_t * mcache;
+  ulong * sync;
+  ulong   seq;
+  ulong   seq_consumer;
+  ulong   depth;
+};
+
+typedef struct metrics_tag {
+  char key[ METRICS_VALUE_STRING_SZ ];
+  char value[ METRICS_VALUE_STRING_SZ ];
+} metrics_kv_t;
+
+/* Takes a datapoint with associated tags and formats it into a string
+ * suitable for sending to InfluxDB */
+int
+fd_metrics_format( char         * buf,
+                   ulong          buf_sz,
+                   char         * tile_name,
+                   metrics_kv_t * tags,
+                   ulong          tags_sz,
+                   Datapoint *    datapoints,
+                   ulong          datapoints_sz,
+                   long           ts );
+
+/* Converts a tag and value into a Datapoint
+ * Used in conjunction with metrics_tags_t and metrics_definition */
+void
+fd_metrics_tag_value_to_datapoint( uint tag, ulong val, Datapoint * d );
+
+/* Underlying functions for metrics_boot */
+void
+metrics_boot_unmanaged( uchar const * pod, const metrics_tile_t tile, const ulong idx, metrics_t * m );
+
+/* Underlying functions for metrics_push */
+void
+metrics_push_unmanaged( metrics_t * m, uint tag, ulong value );
+
+/* Potential return values of metrics_pop family functions */
+typedef enum {
+  METRICS_STATUS_OK,
+  METRICS_STATUS_EMPTY,
+  METRICS_STATUS_OVERRUN,
+  METRICS_STATUS_UNINITIALIZED
+} metrics_status_t;
+
+/* Pop a tag and value from metrics_t * m */
+metrics_status_t
+metrics_pop_unmanaged( metrics_t * m, uint * tag, ulong * value );
+
+#endif /* HEADER_fd_src_util_metrics_fd_metrics_impl_h */

--- a/src/disco/metrics/fd_ssl.c
+++ b/src/disco/metrics/fd_ssl.c
@@ -1,0 +1,267 @@
+#include "fd_ssl.h"
+#include <sys/poll.h>
+
+/*
+ * The application wants to know a fd it can poll on to determine when the
+ * SSL state machine needs to be pumped.
+ */
+static int
+get_conn_fd( conn_t *conn ) {
+  return (int) BIO_get_fd(conn->ssl_bio, NULL);
+}
+
+/*
+ * These functions returns zero or more of:
+ *
+ *   POLLIN:    The SSL state machine is interested in socket readability events.
+ *
+ *   POLLOUT:   The SSL state machine is interested in socket writeability events.
+ *
+ *   POLLERR:   The SSL state machine is interested in socket error events.
+ *
+ * get_conn_pending_tx returns events which may cause SSL_write to make
+ * progress and get_conn_pending_rx returns events which may cause SSL_read
+ * to make progress.
+ */
+static int
+get_conn_pending_tx( conn_t *conn ) {
+  return (conn->tx_need_rx ? POLLIN : 0) | POLLOUT | POLLERR;
+}
+
+static int
+get_conn_pending_rx( conn_t *conn ) {
+  return (conn->rx_need_tx ? POLLOUT : 0) | POLLIN | POLLERR;
+}
+
+/*
+ * Close the connection and free bookkeeping structures.
+ */
+static void
+ssl_teardown( conn_t *conn ) {
+  BIO_free_all( conn->ssl_bio );
+  conn->ssl_bio = NULL;
+}
+
+/* Reinitialize the state machine. */
+void
+ssl_service_reinit( ssl_service_state_t * state ) {
+  if( FD_LIKELY( state->conn.ssl_bio ) ) {
+    ssl_teardown( &state->conn );
+  }
+  state->data_buf_capacity = state->data_buf_sz;
+  state->tx_ptr = state->tx_msg;
+  state->tx_len =  0;
+  state->tx_done = 0;
+  state->tx_tick = 0;
+  state->rx_ptr = state->rx_msg;
+  state->rx_len = SSL_SERVICE_RX_BUF_SZ;
+  state->rx_done = 0;
+  fd_memset( state->data_buf, 0, state->data_buf_sz );
+  fd_memset( state->tx_msg,   0, state->tx_msg_sz );
+}
+
+/* Initialize the state machine. */
+void
+ssl_service_init( ssl_service_state_t * state,
+                  char *                data_buf,
+                  ulong                 data_buf_sz,
+                  char *                tx_buf,
+                  ulong                 tx_buf_sz ) {
+  state->data_buf    = data_buf;
+  state->data_buf_sz = data_buf_sz;
+  state->tx_msg      = tx_buf;
+  state->tx_msg_sz   = tx_buf_sz;
+  ssl_service_reinit( state );
+}
+
+/* Format and setup staet machine to send the contents of state->data_buf to the server.
+ * Requires subsequent calls to ssl_service */
+void
+fd_ssl_send_data( const char * server_port,
+                  const char * user_pass,
+                  const char * db,
+                  SSL_CTX    * ctx,
+                  ssl_service_state_t * state ) {
+
+  if( FD_UNLIKELY( !ssl_conn_init( ctx, server_port, &state->conn ) ) ) {
+    return;
+  }
+
+  int ret = snprintf( state->tx_msg, state->tx_msg_sz,
+                      "POST /write?db=%s HTTP/1.1\r\n"
+                      "Host: %s\r\n"
+                      "Authorization: Basic %s\r\n"
+                      "Content-Length: %zu\r\n"
+                      "Connection: close\r\n"
+                      "Content-Type: application/x-www-form-urlencoded\r\n\r\n"
+                      "%s", db, server_port, user_pass, strlen(state->data_buf), state->data_buf );
+  if( FD_UNLIKELY( ret<0 || ret>=(int)state->tx_msg_sz ) ) {
+    FD_LOG_WARNING(( "snprintf error %d", ret ));
+    return;
+  }
+
+  state->tx_len = (int)strlen( state->tx_msg );
+}
+
+/*
+ * The application wants to create a new outgoing connection using a given
+ * SSL_CTX.
+ *
+ * hostname is a string like "openssl.org:443" or "[::1]:443".
+ */
+int ssl_conn_init( SSL_CTX * ctx, const char * hostname, conn_t * conn ) {
+  BIO * out = BIO_new_ssl_connect(ctx);
+  if( FD_UNLIKELY( out == NULL ) ) {
+    return 0;
+  }
+
+  SSL * ssl;
+  if( FD_UNLIKELY( BIO_get_ssl( out, &ssl ) ) == 0 ) {
+    BIO_free_all( out );
+    return 0;
+  }
+
+  BIO * buf = BIO_new(BIO_f_buffer());
+  if( FD_UNLIKELY( buf == NULL ) ) {
+    BIO_free_all(out);
+    return 0;
+  }
+
+  BIO_push(out, buf);
+
+  if( FD_UNLIKELY( BIO_set_conn_hostname( out, hostname ) == 0 ) ) {
+    BIO_free_all( out );
+    return 0;
+  }
+
+  /* Tell the SSL object the hostname to check certificates against. */
+  if( FD_UNLIKELY( SSL_set1_host( ssl, "metrics.solana.com" ) <= 0 ) ) {
+    BIO_free_all( out );
+    return 0;
+  }
+
+  /* Make the BIO nonblocking. */
+  BIO_set_nbio( out, 1 );
+
+  conn->ssl_bio = out;
+  return 1;
+}
+
+/*
+ * Non-blocking transmission.
+ *
+ * Returns -1 on error. Returns -2 if the function would block (corresponds to
+ * EWOULDBLOCK).
+ */
+static int
+tx( conn_t *conn, const void *buf, int buf_len ) {
+  conn->tx_need_rx = 0;
+  int l = BIO_write( conn->ssl_bio, buf, buf_len );
+  if( FD_LIKELY( l <= 0 ) ) {
+    if( FD_LIKELY( BIO_should_retry( conn->ssl_bio ) ) ) {
+      conn->tx_need_rx = BIO_should_read( conn->ssl_bio );
+      return -2;
+    } else {
+      int reason = BIO_get_retry_reason( BIO_get_retry_BIO( conn->ssl_bio, NULL ) );
+      FD_LOG_NOTICE(( "tx failure reason %d", reason ));
+      return -1;
+    }
+  }
+
+  return l;
+}
+
+/*
+ * Non-blocking reception.
+ *
+ * Returns -1 on error. Returns -2 if the function would block (corresponds to
+ * EWOULDBLOCK).
+ */
+static int
+rx( conn_t * conn, void * buf, int buf_len ) {
+  int l;
+  conn->rx_need_tx = 0;
+  l = BIO_read( conn->ssl_bio, buf, buf_len );
+  if( FD_LIKELY( l <= 0 ) ) {
+    if( FD_LIKELY( BIO_should_retry( conn->ssl_bio ) ) ) {
+      conn->rx_need_tx = BIO_should_write( conn->ssl_bio );
+      return -2;
+    } else {
+      return -1;
+    }
+  }
+  return l;
+}
+
+/* Log the HTTP response if the status code is not 204 */
+static void
+parse_http_status_code( const char * http_response ) {
+  if( FD_LIKELY( strnlen( http_response, 12 ) == 12 && strncmp( http_response, "HTTP/1.1 ", 9 ) == 0 ) ) {
+    int response_code = fd_cstr_to_int( &http_response[9] );
+    if( FD_UNLIKELY( response_code != 204 ) ) {
+      FD_LOG_WARNING(( "bad http response code %d %s", response_code, http_response ));
+    }
+  } else {
+    FD_LOG_NOTICE(( "bad http response %s", http_response ));
+  }
+}
+
+/* Pump the SSL state machine. This function requires a preceeding invocation of fd_ssl_send_data which connects to
+ * the server and sets state->tx_msg and state->tx_len. It pumps the state machine until either the message is
+ * successfully transmitted or an error occurs (l = -1). Either way, tx_done is set and then we attempt to read a
+ * response. If the response is not an HTTP status code of 204 we log it.
+ *
+ * ssl_service DOES expect state to be initialized. */
+void
+ssl_service( ssl_service_state_t * state ) {
+  /* TX */
+  if( FD_UNLIKELY( !state->tx_done && state->tx_len != 0 ) ) {
+    int l = tx( &state->conn, state->tx_ptr, (int)state->tx_len );
+    if( FD_UNLIKELY( l > 0 ) ) {
+      state->tx_ptr += l;
+      state->tx_len -= l;
+      if( FD_UNLIKELY( state->tx_len == 0 )) {
+        state->tx_done = 1;
+        state->tx_tick = fd_tickcount();
+        FD_LOG_WARNING(( "tx capacity hit" ));
+      }
+    } else if( FD_UNLIKELY( l == -1 ) ) {
+      FD_LOG_WARNING(( "tx error %d", state->tx_len ));
+      state->tx_done = 1;
+    } else if( FD_LIKELY( l == -2 ) ) {
+      struct pollfd pfd = {0};
+      pfd.fd = get_conn_fd( &state->conn );
+      pfd.events = (short) get_conn_pending_tx( &state->conn );
+      poll(&pfd, 1, 0 );
+    }
+  }
+
+  /* RX */
+  if( FD_LIKELY( state->tx_done ) ) {
+    /* We do not check for a response until 150 milliseconds have passed because
+     * the call to poll will block for about a microsecond even when given a timeout parameter of zero */
+    long now = fd_tickcount();
+    double delta_ns = (double)(now - state->tx_tick) / fd_tempo_tick_per_ns( NULL );
+    if( FD_LIKELY( delta_ns < 150000000UL )) {
+      return;
+    }
+    int l = rx( &state->conn, state->rx_ptr, (int)state->rx_len );
+    if( FD_UNLIKELY( l > 0 ) ) {
+      state->rx_ptr += l;
+      state->rx_len -= l;
+      if( FD_UNLIKELY( state->rx_len == 0 ) ) {
+        state->rx_done = 1;
+        parse_http_status_code( state->rx_msg );
+        FD_LOG_WARNING(( "rx capacity hit" ));
+      }
+    } else if( FD_UNLIKELY( l == -1 ) ) {
+      state->rx_done = 1;
+      parse_http_status_code( state->rx_msg );
+    } else if( FD_LIKELY( l == -2 ) ) {
+      struct pollfd pfd = {0};
+      pfd.fd = get_conn_fd( &state->conn );
+      pfd.events = ( short ) get_conn_pending_rx( &state->conn );
+      poll(&pfd, 1, 0 );
+    }
+  }
+}

--- a/src/disco/metrics/fd_ssl.h
+++ b/src/disco/metrics/fd_ssl.h
@@ -1,0 +1,80 @@
+#ifndef HEADER_fd_src_disco_metrics_fd_ssl_h
+#define HEADER_fd_src_disco_metrics_fd_ssl_h
+
+#include "../fd_disco_base.h"
+
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
+/* This struct contains state required by OpenSSL
+ * See https://github.com/openssl/openssl/blob/master/doc/designs/ddd/ddd-02-conn-nonblocking.c */
+typedef struct {
+  SSL *ssl;
+  BIO *ssl_bio;
+  int rx_need_tx;
+  int tx_need_rx;
+} conn_t;
+
+#define SSL_SERVICE_RX_BUF_SZ 8192
+typedef struct {
+  conn_t conn;
+  char * data_buf;
+  ulong  data_buf_sz;
+  ulong  data_buf_capacity;
+
+  char * tx_msg;
+  ulong  tx_msg_sz;
+
+  char * tx_ptr;
+  int    tx_len;
+
+  int    tx_done;
+  long   tx_tick;
+
+  char   rx_msg[ SSL_SERVICE_RX_BUF_SZ ];
+  char * rx_ptr;
+  int    rx_len;
+  int    rx_done;
+} ssl_service_state_t;
+
+FD_PROTOTYPES_BEGIN
+
+/*
+ * The application wants to create a new outgoing connection using a given
+ * SSL_CTX.
+ *
+ * hostname is a string like "openssl.org:443" or "[::1]:443".
+ */
+int ssl_conn_init( SSL_CTX * ctx, const char * hostname, conn_t * conn );
+
+/* Format and setup staet machine to send the contents of state->data_buf to the server.
+ * Requires subsequent calls to ssl_service */
+void
+fd_ssl_send_data( const char * server_port,
+                  const char * user_pass,
+                  const char * db,
+                  SSL_CTX    * ctx,
+                  ssl_service_state_t * state );
+
+/* Initialize the state machine. */
+void
+ssl_service_init( ssl_service_state_t * state,
+                  char *                data_buf,
+                  ulong                 data_buf_sz,
+                  char *                tx_buf,
+                  ulong                 tx_buf_sz );
+
+void
+ssl_service_reinit( ssl_service_state_t * state );
+
+/* Pump the SSL state machine. This function requires a preceeding invocation of fd_ssl_send_data which connects to
+ * the server and sets state->tx_msg and state->tx_len. It pumps the state machine until either the message is
+ * successfully transmitted or an error occurs (l = -1). Either way, tx_done is set and then we attempt to read a
+ * response. If the response is not an HTTP status code of 204 we log it.
+ *
+ * ssl_service DOES expect state to be initialized. */
+void ssl_service( ssl_service_state_t * state );
+
+FD_PROTOTYPES_END
+
+#endif

--- a/src/disco/mux/fd_mux.c
+++ b/src/disco/mux/fd_mux.c
@@ -1,4 +1,5 @@
 #include "fd_mux.h"
+#include "../metrics/fd_metrics.h"
 
 /* A fd_mux_tile_in has all the state needed for muxing frags from an
    in.  It fits on exactly one cache line. */
@@ -642,6 +643,7 @@ fd_mux_publish( fd_mux_context_t * ctx,
   fd_mcache_publish( ctx->mcache, ctx->depth, *ctx->seq, sig, chunk, sz, ctl, tsorig, tspub );
   (*ctx->cr_avail)--;
   *ctx->seq = fd_seq_inc( *ctx->seq, 1UL );
+  fd_metrics_push( METRIC_MUX_TEST_TAG, *ctx->seq );
 }
 
 #undef SCRATCH_ALLOC

--- a/src/test/single-transaction.sh
+++ b/src/test/single-transaction.sh
@@ -8,10 +8,10 @@ cd "${SCRIPT_DIR}/../../"
 # start fddev, send a single transaction, and if everything works return 0
 FDDEV=./build/native/gcc/bin/fddev
 # TODO: For some reason /tmp does not work on the github runner for --log-path
-timeout --preserve-status 15 $FDDEV configure init all --netns --log-path ~/log
-timeout --preserve-status 15 $FDDEV --no-configure --netns --log-path ~/log &
+timeout --preserve-status --kill-after=20 15 $FDDEV configure init all --netns --log-path ~/log
+timeout --preserve-status --kill-after=20 15 $FDDEV --no-configure --netns --log-path ~/log &
 FDDEV_PID=$!
-timeout --preserve-status 15 $FDDEV txn --netns --log-path ~/log2
+timeout --preserve-status --kill-after=20 15 $FDDEV txn --netns --log-path ~/log2
 RETVAL=$?
 sudo kill $FDDEV_PID
 exit $RETVAL

--- a/src/util/metrics/Local.mk
+++ b/src/util/metrics/Local.mk
@@ -1,0 +1,2 @@
+#$(call add-hdrs,fd_metrics.h)
+#$(call add-objs,fd_metrics,fd_util)

--- a/src/util/sandbox/fd_sandbox.h
+++ b/src/util/sandbox/fd_sandbox.h
@@ -64,15 +64,21 @@
       We have the luxury of disallowing all of the syscalls that might
       have received less scrutiny. */
 
+typedef enum {
+  SANDBOX_MODE_FULL    = 0,
+  SANDBOX_MODE_NONE    = 1,
+  SANDBOX_MODE_METRICS = 2,
+} sandbox_mode_t;
+
 /* fd_sandbox sandboxes the current process, performing both privileged and
    private steps. */
 void
-fd_sandbox( int    full_sandbox,
-            uint   uid,
-            uint   gid,
-            ulong  allow_fds_sz,
-            int *  allow_fds,
-            ushort allow_syscalls_cnt,
-            long * allow_syscalls );
+fd_sandbox( sandbox_mode_t sandbox_mode,
+            uint           uid,
+            uint           gid,
+            ulong          allow_fds_sz,
+            int *          allow_fds,
+            ushort         allow_syscalls_cnt,
+            long *         allow_syscalls );
 
 #endif /* HEADER_fd_src_util_sandbox_fd_sandbox_h */


### PR DESCRIPTION
This PR adds a new metrics tile which aggregates measurements from other tiles and publishes them to https://metrics.solana.com. There is a single metrics being published in this PR, `__test_seq`, in `src/disco/mux/fd_mux.c`.

This functionality can be viewed at https://metrics.solana.com:3000/d/b74ee3d7-cc7e-467d-95f0-c7f1c07a1ea0/new-dashboard?orgId=1&from=1695851580220&to=1695884020369. Credentials to log in and view the dashboard are in the Firedancer/IT shared 1password vault.

We publish using [InfluxDB line protocol](https://docs.influxdata.com/influxdb/v2/reference/syntax/line-protocol/).

Highlights / Interesting Points:
- Metrics uses OpenSSL because `metrics.solana.com` requires `https`. The OpenSSL configuration had to be changed in `deps.sh` to give us required functionality.
- The sandbox had to be relaxed for the metrics tile since it opens and closes sockets, uses OpenSSL, and requires DNS. The sandbox for the metrics tile allows files to be opened, does not use a network namespace, and does not use `setup_mountns()`. In a future PR we will handle DNS ourselves by crafting requests and parsing responses which will allow us to use `setup_mountns()` and greatly reduce the number of syscalls which are whitelisted.
- A basic metrics api available in `src/util/metrics/fd_metrics.h` with a more advanced option available in `src/util/metrics/fd_metrics_impl.h`.
- A minor bug was addressed in `src/app/fddev/txn.c` so the flag `--payload-base64-encoded` works now.

Follow on work:
- Additional metrics and reworking the metrics API depending on how it's used.
- Metrics testing in CI. Will likely involve spinning up a simple HTTPS server locally with Python