### PR TITLE
IP stack - ARP and routing table

### DIFF
--- a/src/tango/ip/Local.mk
+++ b/src/tango/ip/Local.mk
@@ -1,0 +1,4 @@
+$(call make-unit-test,test_netlink,test_netlink fd_netlink,fd_tango fd_util)
+$(call make-unit-test,test_ip,test_ip fd_ip fd_netlink,fd_tango fd_util)
+$(call make-unit-test,test_routing,test_routing fd_ip fd_netlink,fd_tango fd_util)
+$(call make-unit-test,test_arp,test_arp fd_ip fd_netlink,fd_tango fd_util)

--- a/src/tango/ip/fd_ip.c
+++ b/src/tango/ip/fd_ip.c
@@ -1,0 +1,392 @@
+#include "fd_ip.h"
+
+#include <arpa/inet.h>
+
+ulong
+fd_ip_align( void ) {
+  return FD_IP_ALIGN;
+}
+
+
+ulong
+fd_ip_footprint( ulong arp_entries,
+                 ulong route_entries ) {
+
+  ulong l;
+
+  l = FD_LAYOUT_INIT;
+  l = FD_LAYOUT_APPEND( l, FD_IP_ALIGN, sizeof(fd_ip_t)                             );
+  l = FD_LAYOUT_APPEND( l, FD_IP_ALIGN, sizeof(fd_nl_t)                             );
+  l = FD_LAYOUT_APPEND( l, FD_IP_ALIGN, arp_entries   * sizeof(fd_nl_arp_entry_t)   );
+  l = FD_LAYOUT_APPEND( l, FD_IP_ALIGN, route_entries * sizeof(fd_nl_route_entry_t) );
+
+  return FD_LAYOUT_FINI( l, FD_IP_ALIGN );
+}
+
+
+void *
+fd_ip_new( void * shmem,
+           ulong  arp_entries,
+           ulong  route_entries ) {
+  if( !fd_ulong_is_aligned( (ulong)shmem, FD_IP_ALIGN ) ) {
+    FD_LOG_ERR(( "Attempt to fd_ip_new with unaligned memory" ));
+    return NULL;
+  }
+
+  ulong l;
+  uchar * mem = (uchar*)shmem;
+
+  l = FD_LAYOUT_INIT;
+
+  fd_ip_t * ip = (fd_ip_t*)mem;
+  l = FD_LAYOUT_APPEND( l, FD_IP_ALIGN, sizeof(fd_ip_t)                             );
+
+  ulong ofs_netlink = l;
+  l = FD_LAYOUT_APPEND( l, FD_IP_ALIGN, sizeof(fd_nl_t)                             );
+
+  ulong ofs_arp_table   = FD_ULONG_ALIGN_UP( l, FD_IP_ALIGN );
+  l = FD_LAYOUT_APPEND( l, FD_IP_ALIGN, arp_entries   * sizeof(fd_nl_arp_entry_t)   );
+
+  ulong ofs_route_table = FD_ULONG_ALIGN_UP( l, FD_IP_ALIGN );
+  l = FD_LAYOUT_APPEND( l, FD_IP_ALIGN, route_entries * sizeof(fd_nl_route_entry_t) );
+
+  ulong mem_sz = FD_LAYOUT_FINI( l, FD_IP_ALIGN );
+
+  /* clear all to zero */
+  fd_memset( ip, 0, mem_sz );
+
+  /* set values in ip */
+  ip->num_arp_entries      = arp_entries;
+  ip->num_route_entries    = route_entries;
+  ip->ofs_netlink          = ofs_netlink;
+  ip->ofs_arp_table        = ofs_arp_table;
+  ip->ofs_route_table      = ofs_route_table;
+
+  /* set magic last, after a fence */
+  FD_COMPILER_MFENCE();
+  ip->magic                = FD_IP_MAGIC;
+
+  return (void*)ip;
+}
+
+
+fd_ip_t *
+fd_ip_join( void * mem ) {
+  if( !mem ) {
+    FD_LOG_ERR(( "Attempt to fd_ip_join a NULL" ));
+    return NULL;
+  }
+
+  if( !fd_ulong_is_aligned( (ulong)mem, FD_IP_ALIGN ) ) {
+    FD_LOG_ERR(( "Attempt to fd_ip_join with unaligned memory" ));
+    return NULL;
+  }
+
+  fd_ip_t * ip = (fd_ip_t*)mem;
+
+  if( ip->magic != FD_IP_MAGIC ) {
+    FD_LOG_ERR(( "Failed to fd_ip_join. Possibly memory corrupt" ));
+    return NULL;
+  }
+
+  /* initialize netlink */
+  fd_nl_t * netlink = fd_ip_netlink_get( ip );
+  if( fd_nl_init( netlink, 0 ) ) {
+    FD_LOG_ERR(( "Failed to initialize fd_netlink." ));
+    return NULL;
+  }
+
+  return ip;
+}
+
+
+void *
+fd_ip_leave( fd_ip_t * ip ) {
+  if( !ip ) {
+    FD_LOG_WARNING(( "fd_ip_leave a NULL fd_ip" ));
+    return NULL;
+  }
+
+  /* clear out the magic first */
+  ip->magic = 0;
+
+  /* then fence */
+  FD_COMPILER_MFENCE();
+
+  /* finalize the netlink */
+  fd_nl_t * netlink = fd_ip_netlink_get( ip );
+  fd_nl_fini( netlink );
+
+  fd_memset( ip, 0, sizeof( *ip ) );
+
+  return (void*)ip;
+}
+
+
+/* get pointer to fd_nl_t */
+fd_nl_t *
+fd_ip_netlink_get( fd_ip_t * ip ) {
+  ulong mem = (ulong)ip;
+
+  return (fd_nl_t*)( mem + ip->ofs_netlink );
+}
+
+
+/* get pointer to start of routing table */
+fd_ip_route_entry_t *
+fd_ip_route_table_get( fd_ip_t * ip ) {
+  ulong mem = (ulong)ip;
+
+  return (fd_ip_route_entry_t*)( mem + ip->ofs_route_table );
+}
+
+
+/* get pointer to start of arp table */
+fd_ip_arp_entry_t *
+fd_ip_arp_table_get( fd_ip_t * ip ) {
+  ulong mem = (ulong)ip;
+
+  return (fd_ip_arp_entry_t*)( mem + ip->ofs_arp_table );
+}
+
+
+void
+fd_ip_arp_fetch( fd_ip_t * ip ) {
+  fd_ip_arp_entry_t * arp_table     = fd_ip_arp_table_get( ip );
+  ulong               arp_table_cap = ip->num_arp_entries;
+  fd_nl_t *           netlink       = fd_ip_netlink_get( ip );
+
+  long num_entries = fd_nl_load_arp_table( netlink, arp_table, arp_table_cap );
+
+  if( num_entries < 0L ) {
+    return;
+  }
+
+  ip->cur_num_arp_entries = (ulong)num_entries;
+}
+
+
+/* query an arp entry
+
+   searches for an IP address in the table
+
+   if found, the resulting data is written into the destination and the function
+       returns 0
+
+   otherwise, the function returns 1 */
+
+int
+fd_ip_arp_query( fd_ip_t *            ip,
+                 fd_ip_arp_entry_t ** arp,
+                 uint                 ip_addr ) {
+  fd_ip_arp_entry_t * arp_table     = fd_ip_arp_table_get( ip );
+  ulong               arp_table_cap = ip->num_arp_entries;
+
+  fd_ip_arp_entry_t * entry = fd_nl_arp_query( arp_table, arp_table_cap, ip_addr );
+
+  if( FD_UNLIKELY( !entry ) ) return 1;
+
+  *arp = entry;
+
+  return 0;
+}
+
+
+/* generate a raw ARP packet
+
+   used for caller to generate an ARP packet to send in the event
+     we don't have an existing ARP entry
+
+   writes ARP packet into dest
+
+   if successful, returns 0
+
+   if unable to generate ARP, if the dest capacity (dest_cap) is not enough space
+     then the function returns 1 */
+
+int
+fd_ip_arp_gen_arp_probe( uchar *   buf,
+                         ulong     buf_cap,
+                         ulong *   arp_len,
+                         uint      dst_ip_addr,
+                         uint      src_ip_addr,
+                         uchar *   src_mac_addr ) {
+  if( buf_cap < sizeof( fd_ip_arp_t ) ) {
+    return 1;
+  }
+
+  /* convert ip_addr */
+  uint net_dst_ip_addr = htonl( dst_ip_addr );
+  uint net_src_ip_addr = htonl( src_ip_addr );
+
+  fd_ip_arp_t * arp = (fd_ip_arp_t*)buf;
+
+  fd_memset( arp->dst_mac_addr, 0xff, 6 );         /* set broadcast */
+  fd_memcpy( arp->src_mac_addr, src_mac_addr, 6 ); /* source mac address */
+
+  arp->ethtype        = htons( 0x0806 );       /* Ethertype - ARP is 0x0806 */
+  arp->hw_type        = htons( 1 );            /* Ethernet is 1 */
+  arp->proto_type     = htons( 0x0800 );       /* IP is 0x0800 */
+  arp->hw_addr_len    = 6;                     /* hardware address length - ethernet is 6 */
+  arp->proto_addr_len = 4;                     /* protocol address length - IPv4 is 4 */
+  arp->op             = htons( 1 );            /* operation - request is 1 */
+
+  fd_memcpy( arp->sender_hw_addr,    src_mac_addr,     6 ); /* sender hardware address */
+  fd_memcpy( arp->sender_proto_addr, &net_src_ip_addr, 4 ); /* sender protocol (IPv4) address */
+
+  fd_memset( arp->target_hw_addr,    0,                6 ); /* target hardware address - ignored for request */
+  fd_memcpy( arp->target_proto_addr, &net_dst_ip_addr, 4 ); /* target protocol (IPv4) address - ignored for request */
+
+  if( arp_len ) *arp_len = sizeof( *arp );
+
+  return 0;
+}
+
+
+/* fetch the routing table from the kernel
+
+   the routing table will be written into the workspace, completely replacing
+   any existing routing entries */
+
+void
+fd_ip_route_fetch( fd_ip_t * ip ) {
+  fd_ip_route_entry_t * route_table     = fd_ip_route_table_get( ip );
+  ulong                 route_table_cap = ip->num_route_entries;
+  fd_nl_t *             netlink         = fd_ip_netlink_get( ip );
+
+  long num_entries = fd_nl_load_route_table( netlink, route_table, route_table_cap );
+
+  if( num_entries < 0L ) {
+    return;
+  }
+
+  ip->cur_num_route_entries = (ulong)num_entries;
+}
+
+/* query the routing table
+
+   the provided IP address is looked up in the routing table
+
+   if an appropriate entry is found, the details are written into
+     the destination and 0 is returned
+
+   otherwise, 1 is returned */
+
+int
+fd_ip_route_query( fd_ip_t *              ip,
+                   fd_ip_route_entry_t ** route,
+                   uint                   ip_addr ) {
+  fd_ip_route_entry_t * route_table     = fd_ip_route_table_get( ip );
+  ulong                 route_table_cap = ip->num_route_entries;
+
+  fd_ip_route_entry_t * entry = fd_nl_route_query( route_table, route_table_cap, ip_addr );
+
+  if( FD_UNLIKELY( !entry ) ) return 1;
+
+  *route = entry;
+
+  return 0;
+}
+
+
+int
+fd_ip_route_ip_addr( uchar *   out_dst_mac,
+                     uint *    out_next_ip_addr,
+                     uint *    out_ifindex,
+                     fd_ip_t * ip,
+                     uint      ip_addr ) {
+  /* handle broadcasts and multicast */
+
+  /* multicast is 224.0.0.0/4 */
+  if( ( ip_addr & 0xf0000000 ) == 0xe0000000 ) {
+    /* multicast */
+
+    /* map to ethernet space */
+    out_dst_mac[0] = 0x01;
+    out_dst_mac[1] = 0x00;
+    out_dst_mac[2] = 0x5e;
+    out_dst_mac[3] = (uchar)( ( ip_addr >> 020 ) & 0x7fU );
+    out_dst_mac[4] = (uchar)( ( ip_addr >> 010 ) & 0xffU );
+    out_dst_mac[5] = (uchar)( ( ip_addr >> 000 ) & 0xffU );
+
+    return FD_IP_MULTICAST;
+  }
+
+  if( ip_addr == 0xffffffff ) {
+    /* broadcast */
+    out_dst_mac[0] = 0xffU;
+    out_dst_mac[1] = 0xffU;
+    out_dst_mac[2] = 0xffU;
+    out_dst_mac[3] = 0xffU;
+    out_dst_mac[4] = 0xffU;
+    out_dst_mac[5] = 0xffU;
+
+    return FD_IP_BROADCAST;
+  }
+
+  /* query routing table */
+  fd_ip_route_entry_t * route_entry = NULL;
+  int route_rtn = fd_ip_route_query( ip, &route_entry, ip_addr );
+  if( route_rtn ) {
+    return FD_IP_NO_ROUTE; /* no routing entry */
+  }
+
+  /* routing entry found */
+
+  uint next_ip_addr = ip_addr; /* assume local */
+
+  /* which ip address to use?
+       if the routing entry has a gateway, use that */
+  if( route_entry->nh_ip_addr ) {
+    next_ip_addr = route_entry->nh_ip_addr; /* use next hop */
+  } else {
+    uint host_mask = ~route_entry->dst_netmask;
+    if( ( ip_addr & host_mask ) == ( 0xffffffff & host_mask ) ) {
+      /* Local address, and subnet broadcast - send to ff:ff:ff:ff:ff:ff */
+
+      /* broadcast */
+      out_dst_mac[0] = 0xffU;
+      out_dst_mac[1] = 0xffU;
+      out_dst_mac[2] = 0xffU;
+      out_dst_mac[3] = 0xffU;
+      out_dst_mac[4] = 0xffU;
+      out_dst_mac[5] = 0xffU;
+
+      *out_ifindex = route_entry->oif;
+
+      return FD_IP_BROADCAST;
+    }
+
+    /* else local unicast */
+
+    next_ip_addr = ip_addr;
+  }
+
+  /* have a next IP address, so look up ARP table */
+
+  /* set out_next_ip_addr and out_ifindex */
+  *out_next_ip_addr = next_ip_addr;
+  *out_ifindex      = route_entry->oif;
+
+  /* query ARP table */
+  fd_ip_arp_entry_t * arp_entry = NULL;
+  int arp_rtn = fd_ip_arp_query( ip, &arp_entry, next_ip_addr );
+  if( arp_rtn ) {
+    return FD_IP_PROBE_RQD; /* send probe */
+  }
+
+  /* arp entry found - store mac addr in out_dst_mac */
+  fd_memcpy( out_dst_mac, arp_entry->mac_addr, 6 );
+
+  return FD_IP_SUCCESS;
+}
+
+
+int
+fd_ip_update_arp_table( fd_ip_t * ip,
+                        uint      ip_addr,
+                        uint      ifindex ) {
+  fd_nl_t * netlink = fd_ip_netlink_get( ip );
+
+  return fd_nl_update_arp_table( netlink, ip_addr, ifindex );
+}

--- a/src/tango/ip/fd_ip.h
+++ b/src/tango/ip/fd_ip.h
@@ -1,0 +1,295 @@
+#ifndef HEADER_fd_src_tango_ip_fd_ip_h
+#define HEADER_fd_src_tango_ip_fd_ip_h
+
+#include "fd_netlink.h"
+#include "../../util/fd_util.h"
+
+/* implements a number of IP protocol functions required by XDP, since we're bypassing
+   parts of the kernel */
+
+
+/* ARP
+
+   We use netlink to retrieve the ARP table
+
+   Whenever an IP we're trying to resolve is not in the ARP table, we'll simply send an
+   ARP request. The Kernel should see the responses and update its ARP table
+
+   */
+
+/* Routing
+
+   We use netlink to obtain the routing table
+
+   In particular we need to choose which next hop IP is required
+
+   */
+
+#define FD_IP_NO_ROUTE -1
+#define FD_IP_SUCCESS   0
+#define FD_IP_PROBE_RQD 1
+#define FD_IP_MULTICAST 2
+#define FD_IP_BROADCAST 3
+
+/* magic */
+#define FD_IP_MAGIC (0x37ad94a6ec098fc1UL)
+
+/* alias fd_ip_route_entry_t to fd_nl_route_entry_t
+   and   fd_ip_arp_entry_t   to fd_nl_arp_entry_t */
+typedef fd_nl_route_entry_t fd_ip_route_entry_t;
+typedef fd_nl_arp_entry_t   fd_ip_arp_entry_t;
+
+
+struct fd_ip {
+  ulong magic;
+
+  /* capacity */
+  ulong num_arp_entries;
+  ulong num_route_entries;
+
+  /* current state */
+  ulong cur_num_arp_entries;
+  ulong cur_num_route_entries;
+
+  ulong ofs_netlink;
+  ulong ofs_arp_table;
+  ulong ofs_route_table;
+};
+typedef struct fd_ip fd_ip_t;
+
+
+struct fd_ip_arp {
+  /* Ethernet header */
+  uchar  dst_mac_addr[6];        /* broadcast address */
+  uchar  src_mac_addr[6];        /* source mac address */
+  ushort ethtype;                /* Ethertype - ARP is 0x0806 */
+
+  /* ARP */
+  ushort hw_type;                /* Ethernet is 1 */
+  ushort proto_type;             /* IP is 0x0800 */
+  uchar  hw_addr_len;            /* hardware address length - ethernet is 6 */
+  uchar  proto_addr_len;         /* protocol address length - IPv4 is 4 */
+  ushort op;                     /* operation - request is 1 */
+  uchar  sender_hw_addr[6];      /* sender hardware address */
+  uchar  sender_proto_addr[4];   /* sender protocol (IPv4) address */
+  uchar  target_hw_addr[6];      /* target hardware address - ignored for request */
+  uchar  target_proto_addr[4];   /* target protocol (IPv4) address - ignored for request */
+
+};
+typedef struct fd_ip_arp fd_ip_arp_t;
+
+
+FD_PROTOTYPES_BEGIN
+
+/* footprint and align
+
+   obtain the required footprint and alignment */
+
+#define FD_IP_ALIGN (64UL)
+
+FD_FN_CONST ulong fd_ip_footprint( ulong arp_entries, ulong routing_entries );
+FD_FN_CONST ulong fd_ip_align( void );
+
+
+/* new IP
+
+   create IP stack in the workspace
+
+   arp_entries        the maximum number of arp entries allowed
+   routing_entries    the maximum number ot routing entries allowed
+
+   returns
+     a void pointer to the value required by fd_ip_join */
+
+void *
+fd_ip_new( void * shmem, ulong arp_entries, ulong routing_entries  );
+
+
+/* join existing IP stack
+
+   joins the IP stack that already exists in the workspace
+
+   returns pointer to the fd_ip_t instance or NULL in a failure
+
+   only one join to each fd_ip_t per process is allowed
+   each join creates a netlink file descriptor
+
+   args
+     mem           the return value from fd_ip_new
+
+   returns
+     pointer to the fd_ip_t joined for use, or NULL if an error occurred */
+
+
+fd_ip_t *
+fd_ip_join( void * mem );
+
+
+/* leave the fd_ip
+
+   cleans up local resources
+   the supplied ip pointer should not be used after
+
+   args
+     ip            the fd_ip to leave */
+void *
+fd_ip_leave( fd_ip_t * ip );
+
+
+/* get pointer to netlink
+   this is used internally */
+fd_nl_t *
+fd_ip_netlink_get( fd_ip_t * ip );
+
+
+/* get pointer to start of routing table
+   this is used internally
+   probably best not to modify the data */
+fd_ip_route_entry_t *
+fd_ip_route_table_get( fd_ip_t * ip );
+
+
+/* get pointer to start of arp table
+   this is used internally
+   probably best not to modify the data */
+fd_ip_arp_entry_t *
+fd_ip_arp_table_get( fd_ip_t * ip );
+
+
+/* fetch the ARP table from the kernel
+
+   The table is written into the workspace
+
+   use fd_ip_arp_query to access the data */
+
+void
+fd_ip_arp_fetch( fd_ip_t * ip );
+
+
+/* query an arp entry
+
+   searches for an IP address in the table
+
+   if found, *arp is set to point to the entry and the function
+       returns 0
+
+   otherwise, the function returns 1 */
+
+int
+fd_ip_arp_query( fd_ip_t * ip, fd_ip_arp_entry_t ** arp, uint ip_addr );
+
+
+/* generate a raw ARP probe (request) packet
+
+   used for caller to generate an ARP packet to send in the event
+     we don't have an existing ARP entry
+
+   writes ARP packet into buf
+
+   if successful, returns 0
+
+   if unable to generate ARP, if the dest capacity (dest_cap) is not enough space
+     then the function returns 1
+
+   args
+     buf          the buffer used to accept the raw ethernet packet
+     buf_cap      the capacity in bytes of buf
+     arp_len      *arp_len is set to the length in bytes of the generated ARP packet
+     ip_addr      the IPv4 address of the target to be probed
+     src_mac_addr the MAC address of the source (caller)
+
+   returns
+     0 on success
+     1 on failure (buf_cap not large enough) */
+
+int
+fd_ip_arp_gen_arp_probe( uchar *   buf,
+                         ulong     buf_cap,
+                         ulong *   arp_len,
+                         uint      dst_ip_addr,
+                         uint      src_ip_addr,
+                         uchar *   src_mac_addr );
+
+
+/* fetch the routing table from the kernel
+
+   the routing table will be written into the workspace, completely replacing
+   any existing routing entries */
+
+void
+fd_ip_route_fetch( fd_ip_t * ip );
+
+
+/* query the routing table
+
+   the provided IP address is looked up in the routing table
+
+   if an appropriate entry is found, *route is set to point to it
+     and 0 is returned
+
+   otherwise, 1 is returned */
+
+int
+fd_ip_route_query( fd_ip_t *              ip,
+                   fd_ip_route_entry_t ** route,
+                   uint                   ip_addr );
+
+
+/* Do routing for an ip_addr
+
+   Handles unicast, broadcast and multicast
+       broadcast:
+         ff.ff.ff.ff -> mac: ff:ff:ff:ff:ff:ff
+       subnet broadcast:
+         a.ff.ff.ff/8
+         a.b.ff.ff/16
+         a.b.c.ff/24 -> if local, ff:ff:ff:ff:ff:ff
+                        else normal routing
+       multicast:
+         224+a,b,c,d -> 01:00:5e:B:c:d (B = b & 0x7f)
+
+   Queries the routing table
+     If no match return -1 error
+     If match,
+       Determines which ip_addr to use
+         If local, uses dst_ip_addr
+         Else, uses the gateway/next hop ip addr
+    Queries the arp table
+      If no match returns 1 - send probe
+      If match, sets mac and ifindex and returns 0
+
+    returns
+      FD_IP_NO_ROUTE  -1  No route to destination
+      FD_IP_SUCCESS    0  Route (and arp if necessary) found. out_* have been set
+      FD_IP_PROBE_RQD  1  Route, but we need to send an ARP probe to resolve the MAC address
+                            Resolve the supplied out_next_ip_addr by sending a probe packet
+      FD_IP_MULTICAST  2  Multicast
+      FD_IP_BROADCAST  3  Local broadcast */
+int
+fd_ip_route_ip_addr( uchar *   out_dst_mac,
+                     uint *    out_next_ip_addr,
+                     uint *    out_ifindex,
+                     fd_ip_t * ip,
+                     uint      ip_addr );
+
+
+/* Prepares the ARP cache for recieving a new ARP entry
+
+   Should be called prior to sending an ARP request
+
+   The kernel ignores unsolicited ARP responses, so this function
+   allows our ARP requests to update the kernel ARP table
+
+   It only adds an entry in the case one does not already exist
+   The entry added is in state "INCOMPLETE", and gets updated to a
+   resolved address when the matching response arrives
+   */
+int
+fd_ip_update_arp_table( fd_ip_t * ip,
+                        uint      ip_addr,
+                        uint      ifindex );
+
+
+FD_PROTOTYPES_END
+
+#endif

--- a/src/tango/ip/fd_netlink.c
+++ b/src/tango/ip/fd_netlink.c
@@ -1,0 +1,773 @@
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <linux/neighbour.h>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include "fd_netlink.h"
+
+
+#define FD_NL_DATATYPE(X,...) \
+  X( FD_NL_IGN   , 1 , ignore , __VA_ARGS__ ) \
+  X( FD_NL_CHAR  , 0 , int    , __VA_ARGS__ ) \
+  X( FD_NL_SHORT , 0 , int    , __VA_ARGS__ ) \
+  X( FD_NL_INT   , 0 , int    , __VA_ARGS__ ) \
+  X( FD_NL_ADDR  , 0 , addr   , __VA_ARGS__ )
+
+#define FD_NL_RTA_TYPE(X,...) \
+  X( RTA_UNSPEC      , FD_NL_IGN   , "ignored"                            , __VA_ARGS__ ) \
+  X( RTA_DST         , FD_NL_ADDR  , "Route destination address"          , __VA_ARGS__ ) \
+  X( RTA_SRC         , FD_NL_ADDR  , "Route source address"               , __VA_ARGS__ ) \
+  X( RTA_IIF         , FD_NL_INT   , "Input interface index"              , __VA_ARGS__ ) \
+  X( RTA_OIF         , FD_NL_INT   , "Output interface index"             , __VA_ARGS__ ) \
+  X( RTA_GATEWAY     , FD_NL_ADDR  , "The gateway of the route"           , __VA_ARGS__ ) \
+  X( RTA_PRIORITY    , FD_NL_INT   , "Priority of route"                  , __VA_ARGS__ ) \
+  X( RTA_PREFSRC     , FD_NL_ADDR  , "Preferred source address"           , __VA_ARGS__ ) \
+  X( RTA_METRICS     , FD_NL_INT   , "Route metric"                       , __VA_ARGS__ ) \
+  X( RTA_MULTIPATH   , FD_NL_IGN   , "Multipath nexthop data br"          , __VA_ARGS__ ) \
+  X( RTA_PROTOINFO   , FD_NL_IGN   , "RTA_PROTOINFO No longer used"       , __VA_ARGS__ ) \
+  X( RTA_FLOW        , FD_NL_INT   , "Route realm"                        , __VA_ARGS__ ) \
+  X( RTA_CACHEINFO   , FD_NL_IGN   , "Cache info"                         , __VA_ARGS__ ) \
+  X( RTA_SESSION     , FD_NL_IGN   , "RTA_SESSION No longer used"         , __VA_ARGS__ ) \
+  X( RTA_MP_ALGO     , FD_NL_IGN   , "RTA_MP_ALGO No longer used"         , __VA_ARGS__ ) \
+  X( RTA_TABLE       , FD_NL_INT   , "Routing table ID; if set,"          , __VA_ARGS__ ) \
+  X( RTA_MARK        , FD_NL_INT   , "RTA_MARK"                           , __VA_ARGS__ ) \
+  X( RTA_MFC_STATS   , FD_NL_IGN   , "RTA_MFC_STATS"                      , __VA_ARGS__ ) \
+  X( RTA_VIA         , FD_NL_IGN   , "Gateway in different AF"            , __VA_ARGS__ ) \
+  X( RTA_NEWDST      , FD_NL_ADDR  , "Change packet destination"          , __VA_ARGS__ ) \
+  X( RTA_PREF        , FD_NL_CHAR  , "RFC4191 IPv6 router"                , __VA_ARGS__ ) \
+  X( RTA_ENCAP_TYPE  , FD_NL_SHORT , "Encapsulation type"                 , __VA_ARGS__ ) \
+  X( RTA_ENCAP       , FD_NL_IGN   , "Defined by RTA_ENCAP_TYPE"          , __VA_ARGS__ ) \
+  X( RTA_EXPIRES     , FD_NL_INT   , "Expire time for IPv6"               , __VA_ARGS__ )
+
+char const *
+fd_rta_type_to_label( uint rta_type ) {
+# define FD_RTA_MATCH( LABEL, CLASS, DESC, ... ) \
+  if( rta_type == LABEL ) return #LABEL;
+  FD_NL_RTA_TYPE(FD_RTA_MATCH,x)
+  return "RTA_UNKNOWN";
+# undef FD_RTA_MATCH
+}
+
+char const *
+fd_rta_type_to_class( uint rta_type ) {
+# define FD_RTA_MATCH( LABEL, CLASS, DESC, ... ) \
+  if( rta_type == LABEL ) return #CLASS;
+  FD_NL_RTA_TYPE(FD_RTA_MATCH,x)
+  return "RTA_UNKNOWN";
+# undef FD_RTA_MATCH
+}
+
+#define FD_NL_RTM_TYPE(X,...) \
+  X( RTN_UNSPEC        , "unknown route"                                   , __VA_ARGS__ ) \
+  X( RTN_UNICAST       , "a gateway or direct route"                       , __VA_ARGS__ ) \
+  X( RTN_LOCAL         , "a local interface route"                         , __VA_ARGS__ ) \
+  X( RTN_BROADCAST     , "a local broadcast route (sent as a broadcast)"   , __VA_ARGS__ ) \
+  X( RTN_ANYCAST       , "a local broadcast route (sent as a unicast)"     , __VA_ARGS__ ) \
+  X( RTN_MULTICAST     , "a multicast route"                               , __VA_ARGS__ ) \
+  X( RTN_BLACKHOLE     , "a packet dropping route"                         , __VA_ARGS__ ) \
+  X( RTN_UNREACHABLE   , "an unreachable destination"                      , __VA_ARGS__ ) \
+  X( RTN_PROHIBIT      , "a packet rejection route"                        , __VA_ARGS__ ) \
+  X( RTN_THROW         , "continue routing lookup in another table"        , __VA_ARGS__ ) \
+  X( RTN_NAT           , "a network address translation rule"              , __VA_ARGS__ ) \
+  X( RTN_XRESOLVE      , "refer to an external resolver (not implemented)" , __VA_ARGS__ )
+
+char const *
+fd_rtm_type_to_label( uint rtm_type ) {
+# define FD_RTN_MATCH( LABEL, ... ) \
+  if( rtm_type == LABEL ) return #LABEL;
+  FD_NL_RTM_TYPE(FD_RTN_MATCH,y)
+  return "RTN_UNKNOWN";
+# undef FD_RTN_MATCH
+}
+
+#define FD_NL_NDA_TYPE(X,...) \
+  X( NDA_UNSPEC             , __VA_ARGS__ ) \
+  X( NDA_DST                , __VA_ARGS__ ) \
+  X( NDA_LLADDR             , __VA_ARGS__ ) \
+  X( NDA_CACHEINFO          , __VA_ARGS__ ) \
+  X( NDA_PROBES             , __VA_ARGS__ ) \
+  X( NDA_VLAN               , __VA_ARGS__ ) \
+  X( NDA_PORT               , __VA_ARGS__ ) \
+  X( NDA_VNI                , __VA_ARGS__ ) \
+  X( NDA_IFINDEX            , __VA_ARGS__ ) \
+  X( NDA_MASTER             , __VA_ARGS__ ) \
+  X( NDA_LINK_NETNSID       , __VA_ARGS__ ) \
+  X( NDA_SRC_VNI            , __VA_ARGS__ ) \
+  X( NDA_PROTOCOL           , __VA_ARGS__ ) \
+  X( NDA_FDB_EXT_ATTRS      , __VA_ARGS__ )
+
+char const *
+fd_nda_type_to_label( uint nda_type ) {
+# define FD_NDA_MATCH( LABEL, ... ) \
+  if( nda_type == LABEL ) return #LABEL;
+  FD_NL_NDA_TYPE(FD_NDA_MATCH,)
+  return "NDA_UNKNOWN";
+# undef FD_NDA_MATCH
+}
+
+
+int
+fd_nl_create_socket( ) {
+  int fd = socket( AF_NETLINK, SOCK_RAW | SOCK_NONBLOCK, NETLINK_ROUTE );
+
+  if( fd < 0 ) {
+    FD_LOG_WARNING(( "Unable to create netlink socket. Error: %d %s", errno,
+          strerror( errno ) ));
+    return -1;
+  }
+
+  struct sockaddr_nl sa;
+  fd_memset( &sa, 0, sizeof(sa) );
+  sa.nl_family = AF_NETLINK;
+  if( bind( fd, (void*)&sa, sizeof(sa) ) < 0 ) {
+    FD_LOG_WARNING(( "Unable to bind netlink socket. Error: %d %s",
+          errno, strerror( errno ) ));
+    close( fd );
+    return -1;
+  }
+
+  return fd;
+}
+
+
+void
+fd_nl_close_socket( int fd ) {
+  if( fd >= 0 ) {
+    close( fd );
+  }
+}
+
+long
+fd_nl_read_socket( int fd, uchar * buf, ulong buf_sz ) {
+  /* netlink is datagram based
+     once a recv succeeds, any un-received bytes are lost
+     and the next datagram will be properly aligned in the buffer */
+  long len = -1;
+  do {
+    len = recv( fd, buf, buf_sz, 0 );
+  } while( len <= 0 && errno == EINTR );
+
+  if( len < 0 ) {
+    if( errno == EAGAIN ) {
+      /* EAGAIN means no data. We can simply try again later */
+      return -1;
+    }
+
+    FD_LOG_WARNING(( "netlink recv failed with %d %s", errno, strerror( errno ) ));
+    return -1;
+  }
+
+  return len;
+}
+
+int
+fd_nl_init( fd_nl_t * nl, uint seq ) {
+  nl->seq = seq;
+  nl->fd  = fd_nl_create_socket();
+
+  /* returns 1 for failure, 0 for success */
+  return nl->fd < 0 ? 1 : 0;
+}
+
+void
+fd_nl_fini( fd_nl_t * nl ) {
+  fd_nl_close_socket( nl->fd );
+}
+
+
+long
+fd_nl_load_route_table( fd_nl_t *             nl,
+                        fd_nl_route_entry_t * route_table,
+                        ulong                 route_table_cap ) {
+  int fd = nl->fd;
+  if( fd < 0 ) {
+    FD_LOG_ERR(( "fd_nl_load_route_table called without valid file descriptor" ));
+    return -1;
+  }
+
+  /* format the request */
+
+  /* Request struct */
+  struct {
+    struct nlmsghdr nlh;  /* Netlink header */
+    struct rtmsg    rtm;  /* Payload - route message */
+  } nl_request;
+
+  fd_memset( &nl_request, 0, sizeof( nl_request ) );
+
+  uint seq = nl->seq++;
+
+  nl_request.nlh.nlmsg_type  = RTM_GETROUTE;  /* We wish to get routes */
+#if 0
+  /* CAP_NET_ADMIN required for NLM_F_ATOMIC */
+  nl_request.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ROOT | NLM_F_ATOMIC;
+#else
+  nl_request.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ROOT;
+#endif
+  nl_request.nlh.nlmsg_len   = sizeof(nl_request);
+  nl_request.nlh.nlmsg_pid   = 0;
+  nl_request.nlh.nlmsg_seq   = seq;
+
+  /* request only IPv4 routes */
+  nl_request.rtm.rtm_family  = AF_INET;
+
+  ulong send_sz = sizeof(nl_request);
+  long  sent    = send( fd, &nl_request, send_sz, 0 );
+  if( sent == -1 ) {
+    FD_LOG_WARNING(( "Unable to make netlink request. Error: %d %s", errno, strerror( errno ) ));
+    return -1;
+  }
+
+  if( sent != (long)send_sz ) {
+    FD_LOG_WARNING(( "netlink send returned unexpected size: %lu expected: %lu", sent, send_sz ));
+    return -1;
+  }
+
+  /* receiving */
+  long len;
+
+  /* set alignment such that the returned data is aligned */
+  uchar __attribute__(( aligned(16) )) ibuf[FD_NL_BUF_SZ] = {0};
+
+  /* Pointer to the messages head */
+  struct nlmsghdr *h = (struct nlmsghdr *)ibuf;
+
+  while(1) {
+    len = fd_nl_read_socket( fd, ibuf, sizeof(ibuf) );
+    if( len <= 0 ) {
+      return -1;
+    }
+
+    if( h->nlmsg_seq == seq ) break;
+  }
+
+  /* index into route_entries */
+  long route_entry_idx = 0L;
+
+  /* interpret the response */
+
+  long msglen = len;
+
+  /* Iterate through all messages in buffer */
+
+  while( NLMSG_OK(h, msglen) ) {
+    /* are we still within the bounds of the table? */
+    if( route_entry_idx >= (long)route_table_cap ) {
+      /* we filled the table */
+      FD_LOG_ERR(( "fd_nl_load_route_table, but table larger than reserved storage" ));
+      return -1; /* return failure */
+    }
+
+    /* current route entry */
+    fd_nl_route_entry_t * entry = route_table + route_entry_idx;
+
+    /* clear current entry */
+    fd_memset( entry, 0, sizeof( *entry ) );
+
+    if( h->nlmsg_flags & NLM_F_DUMP_INTR ) {
+      /* function was interrupted */
+
+      return -1; /* return failure */
+    }
+
+    if( h->nlmsg_type == NLMSG_ERROR ) {
+      struct nlmsgerr * err = NLMSG_DATA(h);
+
+      FD_LOG_WARNING(( "netlink returned data with error: %d %s", -err->error, strerror( -err->error) ));
+
+      /* error occurred */
+
+      return -1; /* return failure */
+    }
+
+    struct rtmsg *  msg       = NLMSG_DATA( h );
+    struct rtattr * rat       = RTM_RTA(msg);
+    long            ratmsglen = (long)RTM_PAYLOAD(h);
+
+    /* only care about RTN_UNICAST */
+    if( msg->rtm_type == RTN_UNICAST ) {
+
+      while( RTA_OK( rat, ratmsglen ) ) {
+        uchar * rta_data    = RTA_DATA( rat );
+        ulong   rta_data_sz = RTA_PAYLOAD( rat );
+
+        switch( rat->rta_type ) {
+          case RTA_GATEWAY:
+            if( rta_data_sz != 4 ) {
+              FD_LOG_WARNING(( "Routing entry has gateway address with other than"
+                    " 4 byte address" ));
+            } else {
+              uint nh_ip_addr;
+              memcpy( &nh_ip_addr, rta_data, 4 );
+
+              entry->nh_ip_addr     = ntohl( nh_ip_addr );
+
+              entry->flags |= FD_NL_RT_FLAGS_NH_IP_ADDR;
+            }
+            break;
+
+          case RTA_DST:
+            if( rta_data_sz != 4 ) {
+              FD_LOG_WARNING(( "Routing entry has destination address with other than"
+                    " 4 byte destination address" ));
+            } else {
+              uint nh_ip_addr;
+              memcpy( &nh_ip_addr, rta_data, 4 );
+
+              entry->dst_netmask    = (uint)( 0xffffffff00000000LU >> (ulong)msg->rtm_dst_len );
+              entry->dst_netmask_sz = (uint)msg->rtm_dst_len;
+              entry->dst_ip_addr    = ntohl( nh_ip_addr ) & entry->dst_netmask;
+
+              entry->flags |= FD_NL_RT_FLAGS_DST_IP_ADDR | FD_NL_RT_FLAGS_DST_NETMASK;
+            }
+            break;
+
+          case RTA_OIF:
+            if( rta_data_sz != 4 ) {
+              FD_LOG_WARNING(( "Routing entry has output interface with other than"
+                    " 4 byte index" ));
+            } else {
+              memcpy( &entry->oif, rta_data, 4 );
+
+              entry->flags |= FD_NL_RT_FLAGS_OIF;
+            }
+            break;
+
+          case RTA_PREFSRC:
+            if( rta_data_sz != 4 ) {
+              FD_LOG_WARNING(( "Routing entry has destination address with other than"
+                    " 4 byte destination address" ));
+            } else {
+              uint src_ip_addr;
+              memcpy( &src_ip_addr, rta_data, 4 );
+
+              entry->src_ip_addr = ntohl( src_ip_addr );
+
+              entry->flags |= FD_NL_RT_FLAGS_SRC_IP_ADDR;
+            }
+            break;
+
+          case RTA_MULTIPATH:
+          case RTA_VIA:
+            /* not currently supported */
+            FD_LOG_WARNING(( "Routing entry contains an unsupported feature: %s",
+                  fd_rta_type_to_label( rat->rta_type ) ));
+            entry->flags |= FD_NL_RT_FLAGS_UNSUPPORTED;
+            break;
+        }
+
+        if( entry->flags & FD_NL_RT_FLAGS_UNSUPPORTED ) {
+          break;
+        }
+
+        rat = RTA_NEXT( rat, ratmsglen );
+      }
+    }
+
+    /* the FD_NL_RT_FLAGS_UNSUPPORTED flags must not be present */
+    if( ( entry->flags & FD_NL_RT_FLAGS_UNSUPPORTED ) == 0 ) {
+      /* supported combinations of flags */
+      uint rqd0 = FD_NL_RT_FLAGS_DST_IP_ADDR |
+                  FD_NL_RT_FLAGS_DST_NETMASK |
+                  FD_NL_RT_FLAGS_OIF;
+      uint rqd1 = FD_NL_RT_FLAGS_NH_IP_ADDR  |
+                  FD_NL_RT_FLAGS_OIF;
+      uint rqd_mask = rqd0 | rqd1;
+      uint flags = entry->flags & rqd_mask;
+      if( flags == rqd0 || flags == rqd1 ) {
+        entry->flags |= FD_NL_RT_FLAGS_USED;
+        route_entry_idx++;
+      }
+    }
+
+    h = NLMSG_NEXT( h, msglen );
+  }
+
+  /* clear remaining entries */
+  for( long j = route_entry_idx; j < (long)route_table_cap; ++j ) {
+    fd_memset( route_table + j, 0, sizeof( route_table[0] ) );
+  }
+
+  return route_entry_idx;
+}
+
+
+fd_nl_route_entry_t *
+fd_nl_route_query( fd_nl_route_entry_t * route_table, ulong route_table_sz, uint ip_addr ) {
+  long best_idx   = -1;
+  uint best_class = -1U;
+
+  for( long j = 0L; j < (long)route_table_sz; ++j ) {
+    fd_nl_route_entry_t * entry = route_table + j;
+
+    /* the used entries are always contiguous */
+    if( ( entry->flags & FD_NL_RT_FLAGS_USED ) == 0 ) break;
+
+    uint netmask = entry->dst_netmask;
+    uint clazz   = entry->dst_netmask_sz;
+    uint nh_net  = entry->dst_ip_addr;
+    uint dst_net = ip_addr & netmask;
+
+    if( nh_net == dst_net && ( best_idx == -1 || clazz > best_class ) ) {
+      best_idx   = j;
+      best_class = clazz;
+    }
+  }
+
+  if( best_idx < 0L ) {
+    return NULL;
+  } else {
+    return route_table + best_idx;
+  }
+}
+
+
+long
+fd_nl_load_arp_table( fd_nl_t *           nl,
+                      fd_nl_arp_entry_t * arp_table,
+                      ulong               arp_table_cap ) {
+  int fd = nl->fd;
+  if( fd < 0 ) return -1;
+
+  /* format the request */
+
+  /* Request struct */
+  struct {
+    struct nlmsghdr nlh;  /* Netlink header */
+    struct ndmsg    ndm;  /* Payload - neighbor message */
+  } nl_request;
+
+  fd_memset( &nl_request, 0, sizeof( nl_request ) );
+
+  uint seq = nl->seq++;
+
+  nl_request.nlh.nlmsg_type  = RTM_GETNEIGH;  /* We wish to get neighbors */
+  nl_request.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+  nl_request.nlh.nlmsg_len   = NLMSG_LENGTH(sizeof(struct rtmsg));
+  nl_request.nlh.nlmsg_pid   = 0;
+  nl_request.nlh.nlmsg_seq   = seq;
+
+  /* request IPv4 entries */
+  nl_request.ndm.ndm_family  = AF_INET;
+
+  ulong send_sz = sizeof(nl_request);
+  long  sent    = send( fd, &nl_request, send_sz, 0 );
+  if( sent == -1 ) {
+    FD_LOG_WARNING(( "Unable to make netlink request. Error: %d %s", errno, strerror( errno ) ));
+    return -1;
+  }
+
+  if( sent != (long)send_sz ) {
+    FD_LOG_WARNING(( "netlink send returned unexpected size: %lu expected: %lu", sent, send_sz ));
+    return -1;
+  }
+
+  /* receiving */
+  long len;
+
+  /* set alignment such that the returned data is aligned */
+  uchar __attribute__(( aligned(16) )) ibuf[FD_NL_BUF_SZ] = {0};
+
+  /* Pointer to the messages head */
+  struct nlmsghdr *h = (struct nlmsghdr *)ibuf;
+
+  while(1) {
+    len = fd_nl_read_socket( fd, ibuf, sizeof(ibuf) );
+    if( len <= 0 ) {
+      return -1;
+    }
+
+    if( h->nlmsg_seq == seq ) break;
+  }
+
+  /* index into arp_table */
+  long arp_entry_idx = 0L;
+
+  /* interpret the response */
+
+  long msglen = len;
+
+  /* Iterate through all messages in buffer */
+
+  while( NLMSG_OK(h, msglen) ) {
+    /* are we still within the bounds of the table? */
+    if( arp_entry_idx >= (long)arp_table_cap ) {
+      /* we filled the table */
+      FD_LOG_ERR(( "fd_nl_load_arp_table, but table larger than reserved storage" ));
+      return -1; /* return failure */
+    }
+
+    /* current arp entry */
+    fd_nl_arp_entry_t * entry = arp_table + arp_entry_idx;
+
+    /* clear current entry */
+    fd_memset( entry, 0, sizeof( *entry ) );
+
+    if( h->nlmsg_flags & NLM_F_DUMP_INTR ) {
+      /* function was interrupted - don't switch to new routing table */
+
+      return -1; /* return failure */
+    }
+
+    if( h->nlmsg_type == NLMSG_ERROR ) {
+      struct nlmsgerr * err = NLMSG_DATA(h);
+
+      FD_LOG_WARNING(( "netlink returned data with error: %d %s", -err->error, strerror( -err->error) ));
+
+      /* error occurred - don't switch to new routing table */
+
+      return -1; /* return failure */
+    }
+
+    struct ndmsg *  msg       = NLMSG_DATA( h );
+    struct rtattr * rat       = RTM_RTA(msg);
+    long            ratmsglen = (long)RTM_PAYLOAD( h );
+
+    /* store the interface */
+    entry->ifindex = (uint)msg->ndm_ifindex;
+    entry->flags  |= FD_NL_ARP_FLAGS_IFINDEX;
+
+    /* we want to skip some entries based on state
+       here are the states:
+           NUD_INCOMPLETE   a currently resolving cache entry
+           NUD_REACHABLE    a confirmed working cache entry
+           NUD_STALE        an expired cache entry
+           NUD_DELAY        an entry waiting for a timer
+           NUD_PROBE        a cache entry that is currently reprobed
+           NUD_FAILED       an invalid cache entry
+           NUD_NOARP        a device with no destination cache
+           NUD_PERMANENT    a static entry
+
+       Keeping:
+           NUD_REACHABLE    valid, so use it
+           NUD_STALE        probably better to use the existing address
+           than wait or discard packet
+           NUD_PROBE        being reprobed, so it's probably valid
+           NUD_PERMANENT    a static entry, so use it */
+
+    int skip = 0;
+    switch( msg->ndm_state ) {
+      case NUD_INCOMPLETE:
+      case NUD_DELAY:
+      case NUD_FAILED:
+      case NUD_NOARP:
+        skip = 1;
+    }
+
+    if( !skip ) {
+      /* only care about RTN_UNICAST */
+      while( RTA_OK( rat, ratmsglen ) ) {
+        uchar * rta_data    = RTA_DATA( rat );
+        ulong   rta_data_sz = RTA_PAYLOAD( rat );
+
+        switch( rat->rta_type ) {
+          case NDA_DST:
+            if( rta_data_sz != 4 ) {
+              FD_LOG_WARNING(( "Neighbor entry has IP address with other than"
+                    " 4 byte address" ));
+            } else {
+              uint dst_ip_addr;
+              memcpy( &dst_ip_addr, rta_data, 4 );
+              entry->dst_ip_addr = ntohl( dst_ip_addr );
+
+              entry->flags |= FD_NL_ARP_FLAGS_IP_ADDR;
+            }
+            break;
+
+          case NDA_LLADDR:
+            if( rta_data_sz != 6 ) {
+              FD_LOG_WARNING(( "Neighbor entry has LL address with other than"
+                    " 6 byte MAC address" ));
+            } else {
+              memcpy( &entry->mac_addr[0], rta_data, 6 );
+
+              entry->flags |= FD_NL_ARP_FLAGS_MAC_ADDR;
+            }
+            break;
+
+        }
+
+        if( entry->flags & FD_NL_RT_FLAGS_UNSUPPORTED ) {
+          break;
+        }
+
+        rat = RTA_NEXT( rat, ratmsglen );
+      }
+
+      /* at present, each entry must have at least the following:
+             FD_NL_ARP_FLAGS_IP_ADDR
+             FD_NL_ARP_FLAGS_MAC_ADDR
+             FD_NL_ARP_FLAGS_IFINDEX
+
+         the FD_NL_ARP_FLAGS_UNSUPPORTED flags must not be present */
+      if( ( entry->flags & FD_NL_ARP_FLAGS_UNSUPPORTED ) == 0 ) {
+        uint rqd = FD_NL_ARP_FLAGS_IP_ADDR   |
+          FD_NL_ARP_FLAGS_MAC_ADDR  |
+          FD_NL_ARP_FLAGS_IFINDEX;
+        if( ( entry->flags & rqd ) == rqd ) {
+          entry->flags |= FD_NL_ARP_FLAGS_USED;
+          arp_entry_idx++;
+        }
+      }
+    }
+
+    h = NLMSG_NEXT( h, msglen );
+  }
+
+  /* clear remaining entries */
+  for( long j = arp_entry_idx; j < (long)arp_table_cap; ++j ) {
+    fd_memset( arp_table + j, 0, sizeof( arp_table[0] ) );
+  }
+
+  return arp_entry_idx;
+}
+
+
+fd_nl_arp_entry_t *
+fd_nl_arp_query( fd_nl_arp_entry_t * arp_table,
+                 ulong               arp_table_sz,
+                 uint                ip_addr ) {
+  for( long j = 0L; j < (long)arp_table_sz; ++j ) {
+    fd_nl_arp_entry_t * entry = arp_table + j;
+    if( ( entry->flags & FD_NL_ARP_FLAGS_USED ) == 0 ) break;
+
+    if( entry->dst_ip_addr == ip_addr ) {
+      return entry;
+    }
+  }
+
+  return NULL;
+}
+
+
+int
+fd_nl_update_arp_table( fd_nl_t * nl,
+                        uint      ip_addr,
+                        uint      ifindex ) {
+  int fd = nl->fd;
+  if( fd < 0 ) {
+    FD_LOG_ERR(( "fd_nl_update_arp_table called with invalid file descriptor" ));
+    return -1;
+  }
+
+  uint net_ip_addr = htonl( ip_addr );
+
+  /* format the request */
+
+# define IP_ADDR_LEN 4
+# define NLMSG_LEN   NLMSG_LENGTH( sizeof(struct rtmsg) )
+# define TOT_SZ      ( NLMSG_LEN + RTA_LENGTH(IP_ADDR_LEN) )
+# define BUF_OFFS    ( sizeof( struct nlmsghdr ) + sizeof( struct ndmsg ) )
+# define BUF_SZ      ( TOT_SZ - BUF_OFFS )
+
+  /* Request struct */
+  struct {
+    struct nlmsghdr nlh;         /* Netlink header */
+    struct ndmsg    ndm;         /* Payload - neighbor message */
+    uchar           buf[BUF_SZ]; /* sized to match the request exactly */
+  } nl_request;
+
+  fd_memset( &nl_request, 0, sizeof( nl_request ) );
+
+  uint seq = nl->seq++;
+
+  nl_request.nlh.nlmsg_type  = RTM_NEWNEIGH;  /* We wish to get neighbors */
+  nl_request.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_CREATE | NLM_F_EXCL;
+  nl_request.nlh.nlmsg_len   = (uint)NLMSG_LEN;
+  nl_request.nlh.nlmsg_pid   = 0;
+  nl_request.nlh.nlmsg_seq   = seq;
+
+  /* request IPv4 entries */
+  nl_request.ndm.ndm_family  = AF_INET;
+  nl_request.ndm.ndm_ifindex = (int)ifindex;
+  nl_request.ndm.ndm_state   = NUD_INCOMPLETE;
+  nl_request.ndm.ndm_flags   = 0;
+  nl_request.ndm.ndm_type    = RTN_UNICAST;
+
+  /* not necessarily defined! */
+#ifndef NLMSG_TAIL
+#define NLMSG_TAIL(nmsg) ((struct rtattr *)(((uchar *)(nmsg)) + NLMSG_ALIGN((nmsg)->nlmsg_len)))
+#endif
+
+  /* write required attributes */
+  struct rtattr * rqs_rat = NLMSG_TAIL(&nl_request.nlh);
+
+  rqs_rat->rta_type = NDA_DST;
+  rqs_rat->rta_len =  RTA_LENGTH(4);
+
+  memcpy( RTA_DATA(rqs_rat), &net_ip_addr, 4 );
+  nl_request.nlh.nlmsg_len += sizeof(struct rtattr) + 4;
+
+  ulong nl_request_sz = (ulong)nl_request.nlh.nlmsg_len;
+
+  if( nl_request_sz != TOT_SZ ) {
+    FD_LOG_ERR(( "request size does not match expected size" ));
+    return -1;
+  }
+
+  ulong send_sz = nl_request_sz;
+  long  sent    = send( fd, &nl_request, send_sz, 0 );
+  if( sent == -1 ) {
+    FD_LOG_WARNING(( "Unable to make netlink request. Error: %d %s", errno, strerror( errno ) ));
+    return -1;
+  }
+
+  if( sent != (long)send_sz ) {
+    FD_LOG_WARNING(( "netlink send returned unexpected size: %lu expected: %lu", sent, send_sz ));
+    return -1;
+  }
+
+  /* receiving */
+  long len;
+
+  /* set alignment such that the returned data is aligned */
+  uchar __attribute__(( aligned(16) )) ibuf[FD_NL_BUF_SZ] = {0};
+
+  /* Pointer to the messages head */
+  struct nlmsghdr *h = (struct nlmsghdr *)ibuf;
+
+  /* iterate thru until no more messages looking for error */
+  while(1) {
+    len = fd_nl_read_socket( fd, ibuf, sizeof(ibuf) );
+    if( len <= 0 ) {
+      return -1;
+    }
+
+    if( h->nlmsg_seq == seq ) break;
+  }
+
+  /* interpret the response */
+
+  long msglen = len;
+
+  /* check for errors */
+
+  while( NLMSG_OK(h, msglen) ) {
+    if( h->nlmsg_type == NLMSG_ERROR ) {
+      struct nlmsgerr * err = NLMSG_DATA(h);
+
+      /* we are expecting the ARP entry to sometimes exist
+         so simply return SUCCESS here */
+      if( err->error == -EEXIST ) {
+        return 0;
+      }
+
+      /* all other errors are reported */
+
+      FD_LOG_WARNING(( "netlink returned data with error: %d %s", -err->error, strerror( -err->error ) ));
+
+      /* error occurred - don't switch to new routing table */
+
+      return -1; /* return failure */
+    }
+
+    h = NLMSG_NEXT( h, msglen );
+  }
+
+  return 0;
+}

--- a/src/tango/ip/fd_netlink.h
+++ b/src/tango/ip/fd_netlink.h
@@ -1,0 +1,177 @@
+#ifndef HEADER_fd_src_tango_fd_netlink_h
+#define HEADER_fd_src_tango_fd_netlink_h
+
+#include "../../util/fd_util.h"
+
+
+/* Defined the buffer space used in netlink calls
+   We are not expecting many routing entries or ARP cache entries */
+#define FD_NL_BUF_SZ 4096UL
+
+struct fd_nl {
+  int   fd;  /* netlink socket */
+  uint  seq; /* netlink sequence number */
+};
+typedef struct fd_nl fd_nl_t;
+
+
+struct fd_nl_route_entry {
+  uint dst_ip_addr;    /* destination subnet */
+  uint dst_netmask;    /* destination netmask  */
+  uint dst_netmask_sz; /* size of netmask in bits */
+
+  uint nh_ip_addr;     /* next hop ip address - AKA gateway */
+                       /* zero if no next hop */
+
+  /* IPv4 address - source ip addr */
+  uint src_ip_addr;
+
+  /* output interface index */
+  uint oif;
+
+  /* flags
+     FD_NL_RT_FLAGS_USED        Entry contains data
+     FD_NL_RT_FLAGS_DST_IP_ADDR Entry contains an ip address
+     FD_NL_RT_FLAGS_DST_NETMASK Entry contains a netmask
+     FD_NL_RT_FLAGS_NH_IP_ADDR  Entry contains an ip address
+     FD_NL_RT_FLAGS_SRC_IP_ADDR Entry contains a (perferred) source ip address
+     FD_NL_RT_FLAGS_OIF         Entry contains an output interface index
+     FD_NL_RT_FLAGS_UNSUPPORTED Entry contains an unsupported feature */
+  uint flags;
+# define  FD_NL_RT_FLAGS_USED        (1U << 0U)
+# define  FD_NL_RT_FLAGS_UNSUPPORTED (1U << 1U)
+# define  FD_NL_RT_FLAGS_DST_IP_ADDR (1U << 2U)
+# define  FD_NL_RT_FLAGS_DST_NETMASK (1U << 3U)
+# define  FD_NL_RT_FLAGS_NH_IP_ADDR  (1U << 4U)
+# define  FD_NL_RT_FLAGS_SRC_IP_ADDR (1U << 5U)
+# define  FD_NL_RT_FLAGS_OIF         (1U << 6U)
+};
+typedef struct fd_nl_route_entry fd_nl_route_entry_t;
+
+
+/* ARP entries for IPv4 and Ethernet */
+struct fd_nl_arp_entry {
+  uint  dst_ip_addr;
+  uchar mac_addr[6];
+  uint  ifindex;
+
+  /* Flags
+     FD_NL_ARP_FLAGS_USED        Entry contains data
+     FD_NL_ARP_FLAGS_IP_ADDR     Entry contains an ip address
+     FD_NL_ARP_FLAGS_MAC_ADDR    Entry contains a MAC address
+     FD_NL_ARP_FLAGS_IFINDEX     Entry contains a interface index
+     FD_NL_ARP_FLAGS_UNSUPPORTED Entry contains an unsupported feature */
+  uint flags;
+# define  FD_NL_ARP_FLAGS_USED        (1U << 0U)
+# define  FD_NL_ARP_FLAGS_UNSUPPORTED (1U << 1U)
+# define  FD_NL_ARP_FLAGS_IP_ADDR     (1U << 2U)
+# define  FD_NL_ARP_FLAGS_MAC_ADDR    (1U << 3U)
+# define  FD_NL_ARP_FLAGS_IFINDEX     (1U << 4U)
+};
+typedef struct fd_nl_arp_entry fd_nl_arp_entry_t;
+
+
+FD_PROTOTYPES_BEGIN
+
+
+/* Creates and configures a socket for netlink
+
+   used by fd_nl_init */
+int
+fd_nl_create_socket( void );
+
+
+/* Closes a netlink socket */
+void
+fd_nl_close_socket( int fd );
+
+
+/* Initializes fd_nl_t
+
+   seq should be set to some reasonably random value */
+int
+fd_nl_init( fd_nl_t * nl, uint seq );
+
+
+/* finilizes fd_nl_t, closes socket */
+void
+fd_nl_fini( fd_nl_t * nl );
+
+
+/* Loads the routing table referred to as route_table
+   from the kernel using the netlink socket definted in
+   nl
+   Unused entries are zeroed out
+
+   Args
+     nl               The netlink instance
+     route_table      A pointer to the array of fd_nl_route_entry_t objects
+                        to load with data
+     route_table_cap  The number of entries in the route_table array
+
+   Return
+     -1               If a transient error occorred
+     count            The number of entries filled with data */
+long
+fd_nl_load_route_table( fd_nl_t *             nl,
+                        fd_nl_route_entry_t * route_table,
+                        ulong                 route_table_cap );
+
+
+/* Queries the routing table for a suitable routing entry
+   for the given ip_addr
+
+   Returns a pointer to the entry, or NULL if none is found */
+fd_nl_route_entry_t *
+fd_nl_route_query( fd_nl_route_entry_t * route_table, ulong route_table_sz, uint ip_addr );
+
+
+/* loads the specified arp_table with entries from the kernel
+   using the netlink socket defined in nl
+   Unused entries are zeroed out
+
+   Args
+     nl               The netlink instance
+     arp_table        A pointer to the array of fd_nl_arp_entry_t objects
+                        to load with data
+     arp_table_cap    The number of entries in the arp_table array
+
+   Return
+     -1               If a transient error occorred
+     count            The number of entries filled with data */
+long
+fd_nl_load_arp_table( fd_nl_t *           nl,
+                      fd_nl_arp_entry_t * arp_table,
+                      ulong               arp_table_cap );
+
+
+/* Queries the specified arp_table for an entry matching ip_addr
+
+   NOTE This is currently O(N), which is fine for small tables
+   but we might want to use a hashmap for larger tables */
+fd_nl_arp_entry_t *
+fd_nl_arp_query( fd_nl_arp_entry_t * arp_table,
+                 ulong               arp_table_sz,
+                 uint                ip_addr );
+
+
+/* Prepares the ARP cache for recieving a new ARP entry
+
+   Should be called prior to sending an ARP request
+
+   The kernel ignores unsolicited ARP responses, so this function
+   allows our ARP requests to update the kernel ARP table
+
+   It only adds an entry in the case one does not already exist
+   The entry added is in state "INCOMPLETE", and gets updated to a
+   resolved address when the matching response arrives
+   */
+int
+fd_nl_update_arp_table( fd_nl_t * nl,
+                        uint      ip_addr,
+                        uint      ifindex );
+
+
+FD_PROTOTYPES_END
+
+#endif

--- a/src/tango/ip/test_arp
+++ b/src/tango/ip/test_arp
@@ -1,0 +1,96 @@
+#!/bin/bash -x
+
+: "${IFACE0:=veth_test_arp_0}"
+: "${IFACE1:=veth_test_arp_1}"
+
+NETNS0=/var/run/netns/"$IFACE0"
+NETNS1=/var/run/netns/"$IFACE1"
+
+: "${IFACE0_MAC:=40:00:00:80:00:f0}"
+: "${IFACE1_MAC:=40:00:00:80:00:f1}"
+
+: "${IP_CLASS:=24}"
+: "${IFACE0_ADDR:=192.168.42.10}"
+: "${IFACE1_ADDR:=192.168.42.11}"
+
+CONF=tmp/test_arp.conf
+
+########################################################################
+
+if [ $# -ne 1 ]; then
+  echo ""
+  echo "        build directory not specified"
+  echo ""
+  echo "        Usage: $0 [BUILD_DIRECTORY]"
+  echo ""
+  echo "        Creates two network namespaces with a network config in each"
+  echo "        Runs ARP tests between them"
+  echo ""
+  exit 1
+fi
+
+UNIT_TEST=$1/unit-test
+
+# Disable permanant log for all the controls we are going to run in here
+
+FD_LOG_PATH=""
+export FD_LOG_PATH
+
+# Delete any existing netns and interface
+ip netns delete "$IFACE0" &> /dev/null
+ip netns delete "$IFACE1" &> /dev/null
+
+ip link del dev "$IFACE0" &> /dev/null # Destroys IFACE1 too. Okay if this fails
+ip link del dev "$IFACE1" &> /dev/null # Just in case
+
+# (Re-)create veth virtual network devices
+
+# create namespaces
+ip netns add "$IFACE0" || exit $?
+ip netns add "$IFACE1" || exit $?
+
+# create pair of connected interfaces
+ip link add dev "$IFACE0"       \
+            type veth           \
+            peer name "$IFACE1" \
+  || exit $?
+
+# add MAC addresses
+ip link set dev "$IFACE0" address "$IFACE0_MAC" || exit $?
+ip link set dev "$IFACE1" address "$IFACE1_MAC" || exit $?
+
+# attach interfaces to namespaces
+ip link set "$IFACE0" netns "$IFACE0" || exit $?
+ip link set "$IFACE1" netns "$IFACE1" || exit $?
+
+# add IP addresses
+ip netns exec "$IFACE0" ip address add "$IFACE0_ADDR/$IP_CLASS" dev "$IFACE0" || exit $?
+ip netns exec "$IFACE1" ip address add "$IFACE1_ADDR/$IP_CLASS" dev "$IFACE1" || exit $?
+
+# raise interfaces
+ip netns exec "$IFACE0" ip link set dev "$IFACE0" up || exit $?
+ip netns exec "$IFACE1" ip link set dev "$IFACE1" up || exit $?
+
+# run test in namespace "$IFACE0"
+ip netns exec "$IFACE0" $UNIT_TEST/test_arp "$IFACE0" "$IFACE1_ADDR" || exit $?
+
+# there is a race here, so wait for reply to update kernel ARP table
+# this should not take long!
+sleep "0.1s"
+
+# check arp table after
+# verify the ip address and mac address are listed together
+ip netns exec "$IFACE0" arp | fgrep "$IFACE1_ADDR" | fgrep "$IFACE1_MAC" || exit $?
+
+# Clean up
+
+# delete namespaces
+ip netns delete "$IFACE0" &> /dev/null
+ip netns delete "$IFACE1" &> /dev/null
+
+# delete interfaces
+ip link del dev "$IFACE0" &> /dev/null
+ip link del dev "$IFACE1" &> /dev/null
+
+echo pass
+exit 0

--- a/src/tango/ip/test_arp.c
+++ b/src/tango/ip/test_arp.c
@@ -1,0 +1,166 @@
+#include "fd_ip.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <linux/if_packet.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <linux/if.h>
+#include <unistd.h>
+
+#define PGM_NAME "test_arp"
+
+
+/* to test ARP run this in a network namespace
+   and verify the arp cache after */
+
+
+/* get interface index from interface name */
+uint
+get_ifindex( char const * intf, int fd ) {
+  struct ifreq if_idx = {0};
+  memset( &if_idx, 0, sizeof(struct ifreq) );
+  strncpy( if_idx.ifr_name, intf, IFNAMSIZ-1 );
+  if( ioctl( fd, SIOCGIFINDEX, &if_idx ) < 0 ) {
+    FD_LOG_ERR(( " Error from ioctl( fd, SIOCGIFINDEX, ... ). Error: %d %s", errno, strerror( errno ) ));
+    exit(1);
+  }
+
+  return (uint)if_idx.ifr_ifindex;
+}
+
+
+/* get interface mac address from interface name */
+void
+get_mac_addr( uchar * out_mac_addr, char const * intf, int fd )
+{
+  struct ifreq if_mac = {0};
+  memset( &if_mac, 0, sizeof(struct ifreq) );
+  strncpy( if_mac.ifr_name, intf, IFNAMSIZ-1 );
+  if( ioctl( fd, SIOCGIFHWADDR, &if_mac ) < 0 ) {
+    FD_LOG_ERR(( " Error from ioctl( fd, SIOCGIFHWADDR, ... ). Error: %d %s", errno, strerror( errno ) ));
+    exit(1);
+  }
+
+  memcpy( out_mac_addr, &if_mac.ifr_hwaddr.sa_data, 6 );
+}
+
+
+/* get interface ip address from interace name */
+uint
+get_ip_addr( char const * intf, int fd ) {
+  struct ifreq ifr = {0};
+  ifr.ifr_addr.sa_family = AF_INET;
+  strncpy( ifr.ifr_name, intf, IFNAMSIZ-1 );
+
+  if( ioctl( fd, SIOCGIFADDR, &ifr ) < 0 ) {
+    FD_LOG_ERR(( " Error from ioctl( fd, SIOCGIFADDR, ... ). Error: %d %s", errno, strerror( errno ) ));
+    exit(1);
+  }
+
+  void * v_ifr = (void*)&ifr.ifr_addr;
+
+  return ntohl( ((struct sockaddr_in *)v_ifr)->sin_addr.s_addr );
+}
+
+
+void
+print_help() {
+  printf(
+      "NAME\n"
+      "\t"  "test_arp - test ARP API in Firedancer\n"
+      "\n"
+      "SYNOPSIS\n"
+      "\t"  "test_arp INTERFACE_NAME DST_IP_ADDR\n"
+      "\n"
+      "INTERFACE_NAME\n"
+      "\t"  "Specifies the name of the interface used to send the ARP\n"
+      "\n"
+      "DST_IP_ADDR\n"
+      "\t"  "Specifies the name of the destination V4 IP address\n"
+      "\n"
+      "DESCRIPTION\n"
+      "\t"  "Sends an ARP with the target IP address specified.\n"
+      "\n"
+      "EXPECTED RESULT\n"
+      "\t"  "Should update the kernel ARP\n"
+      );
+}
+
+
+uint
+str_to_ip_addr( char const * in ) {
+  uint a = 0;
+  uint b = 0;
+  uint c = 0;
+  uint d = 0;
+  if( sscanf( in, "%u.%u.%u.%u", &a, &b, &c, &d ) != 4 ) {
+    fprintf( stderr, "IP address not understood\n\n" );
+    print_help();
+
+    exit(1);
+  }
+
+  return ( a << 030 ) | ( b << 020 ) | ( c << 010 ) | d;
+}
+
+
+int
+main( int argc, char **argv ) {
+  fd_boot( &argc, &argv );
+
+  if( argc < 3 ) {
+    print_help();
+    exit(0);
+  }
+
+  int fd = socket( AF_PACKET, SOCK_RAW, IPPROTO_RAW );
+  if( fd == -1 ) {
+    FD_LOG_NOTICE(( "error: %d %s", errno, strerror( errno ) ));
+  }
+
+  char const * intf             = argv[1];
+  uint         ifindex          = get_ifindex( intf, fd );
+  uint         dst_ip_addr      = str_to_ip_addr( argv[2] );
+  uint         src_ip_addr      = get_ip_addr( intf, fd );
+  uchar        src_mac_addr[6]  = {0};
+
+  get_mac_addr( src_mac_addr, intf, fd );
+
+  fd_nl_t nl;
+  fd_nl_init( &nl, 312 );
+
+  /* attempt to update kernel ARP table with an unresolved entry */
+  if( fd_nl_update_arp_table( &nl, dst_ip_addr, ifindex ) ) {
+    FD_LOG_WARNING(( "fd_nl_update_arp_table returned error" ));
+    return 1;
+  }
+
+  uchar buf[2048];
+  ulong buf_sz  = sizeof( buf );
+  ulong arp_len = 0;
+
+  /* format an ARP probe message */
+  fd_ip_arp_gen_arp_probe( buf, buf_sz, &arp_len, dst_ip_addr, src_ip_addr, src_mac_addr );
+
+  struct sockaddr_ll dst_nic = {0};
+
+  dst_nic.sll_ifindex = (int)ifindex;
+  memcpy( &dst_nic.sll_addr, src_mac_addr, 6 );
+
+  /* send the ARP probe via the given local interface */
+  if( sendto( fd, buf, arp_len, 0, (void*)&dst_nic, sizeof( dst_nic ) ) == -1 ) {
+    FD_LOG_NOTICE(( "sendto failed with: %d %s", errno, strerror( errno ) ));
+  }
+
+  close( fd );
+
+  fd_halt();
+
+  return 0;
+}

--- a/src/tango/ip/test_ip
+++ b/src/tango/ip/test_ip
@@ -1,0 +1,104 @@
+#!/bin/bash -x
+
+: "${IFACE0:=veth_test_arp_0}"
+: "${IFACE1:=veth_test_arp_1}"
+
+NETNS0=/var/run/netns/"$IFACE0"
+NETNS1=/var/run/netns/"$IFACE1"
+
+: "${IFACE0_MAC:=40:00:00:80:00:f0}"
+: "${IFACE1_MAC:=40:00:00:80:00:f1}"
+
+: "${IP_CLASS:=24}"
+: "${IFACE0_ADDR:=192.168.42.10}"
+: "${IFACE1_ADDR:=192.168.42.11}"
+
+CONF=tmp/test_arp.conf
+
+########################################################################
+
+if [ $# -ne 1 ]; then
+  echo ""
+  echo "        build directory not specified"
+  echo ""
+  echo "        Usage: $0 [BUILD_DIRECTORY]"
+  echo ""
+  echo "        Creates two network namespaces with a network config in each"
+  echo "        Runs ARP tests between them"
+  echo ""
+  exit 1
+fi
+
+UNIT_TEST=$1/unit-test
+
+# Disable permanant log for all the controls we are going to run in here
+
+FD_LOG_PATH=""
+export FD_LOG_PATH
+
+# Delete any existing netns and interface
+ip netns delete "$IFACE0" &> /dev/null
+ip netns delete "$IFACE1" &> /dev/null
+
+ip link del dev "$IFACE0" &> /dev/null # Destroys IFACE1 too. Okay if this fails
+ip link del dev "$IFACE1" &> /dev/null # Just in case
+
+# (Re-)create veth virtual network devices
+
+# create namespaces
+ip netns add "$IFACE0" || exit $?
+ip netns add "$IFACE1" || exit $?
+
+# create pair of connected interfaces
+ip link add dev "$IFACE0"       \
+            type veth           \
+            peer name "$IFACE1" \
+  || exit $?
+
+# add MAC addresses
+ip link set dev "$IFACE0" address "$IFACE0_MAC" || exit $?
+ip link set dev "$IFACE1" address "$IFACE1_MAC" || exit $?
+
+# attach interfaces to namespaces
+ip link set "$IFACE0" netns "$IFACE0" || exit $?
+ip link set "$IFACE1" netns "$IFACE1" || exit $?
+
+# add IP addresses
+ip netns exec "$IFACE0" ip address add "$IFACE0_ADDR/$IP_CLASS" dev "$IFACE0" || exit $?
+ip netns exec "$IFACE1" ip address add "$IFACE1_ADDR/$IP_CLASS" dev "$IFACE1" || exit $?
+
+# raise interfaces
+ip netns exec "$IFACE0" ip link set dev "$IFACE0" up || exit $?
+ip netns exec "$IFACE1" ip link set dev "$IFACE1" up || exit $?
+
+# add routes
+ip netns exec "$IFACE0" ip route add unicast 192.168.36.0/24 dev "$IFACE0"
+ip netns exec "$IFACE0" ip route add unicast default via 192.168.42.11 dev "$IFACE0"
+
+# dump routes
+echo dump route:
+ip netns exec "$IFACE0" ip route
+echo done
+
+# ping to get ARP entry
+ip netns exec "$IFACE0" ping -c1 "${IFACE1_ADDR}"
+sleep "0.15s"
+
+# run test in namespace "$IFACE0"
+ip netns exec "$IFACE0" $UNIT_TEST/test_ip || exit $?
+
+# TODO verify output of previous command, or possibly
+#      change it to do verification internally
+
+# Clean up
+
+# delete namespaces
+ip netns delete "$IFACE0" &> /dev/null
+ip netns delete "$IFACE1" &> /dev/null
+
+# delete interfaces
+ip link del dev "$IFACE0" &> /dev/null
+ip link del dev "$IFACE1" &> /dev/null
+
+echo pass
+exit 0

--- a/src/tango/ip/test_ip.c
+++ b/src/tango/ip/test_ip.c
@@ -1,0 +1,88 @@
+#include "fd_ip.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+int
+main( int argc, char **argv ) {
+  fd_boot( &argc, &argv );
+
+  ulong num_arp_entries   = 32;
+  ulong num_route_entries = 32;
+
+  ulong ip_footprint = fd_ip_footprint( num_arp_entries, num_route_entries );
+  FD_LOG_NOTICE(( "ip_footprint: %lu", ip_footprint ));
+
+  ulong ip_align = fd_ip_align();
+  FD_LOG_NOTICE(( "ip_align: %lu", ip_align ));
+
+  void * base_mem = aligned_alloc( ip_align, ip_footprint );
+  FD_TEST( base_mem );
+
+  void * mem = fd_ip_new( base_mem, num_arp_entries, num_route_entries );
+  FD_TEST( mem );
+
+  fd_ip_t * ip = fd_ip_join( mem );
+  FD_TEST( ip );
+
+  /* fetch the arp table */
+  fd_ip_arp_fetch( ip );
+
+  fd_ip_arp_entry_t * arp_table     = fd_ip_arp_table_get( ip );
+  ulong               arp_table_sz  = ip->cur_num_arp_entries;
+
+  FD_LOG_NOTICE(( "ARP table:" ));
+  for( ulong j = 0L; j < arp_table_sz; ++j ) {
+    fd_ip_arp_entry_t * arp_entry = arp_table + j;
+
+    if( arp_entry->flags == 0 ) break;
+
+#define IP_FMT          "%3u.%3u.%3u.%3u"
+#define IP_VAR(IP) (((IP)>>030) & 0xffU), \
+                   (((IP)>>020) & 0xffU), \
+                   (((IP)>>010) & 0xffU), \
+                   (((IP)>>000) & 0xffU)
+
+    FD_LOG_NOTICE(( "  " IP_FMT "  %02x:%02x:%02x:%02x:%02x:%02x  %2u  %x",
+          IP_VAR(arp_table[j].dst_ip_addr),
+          arp_table[j].mac_addr[0],
+          arp_table[j].mac_addr[1],
+          arp_table[j].mac_addr[2],
+          arp_table[j].mac_addr[3],
+          arp_table[j].mac_addr[4],
+          arp_table[j].mac_addr[5],
+          arp_table[j].ifindex,
+          arp_table[j].flags ));
+  }
+
+  /* fetch the route table */
+  fd_ip_route_fetch( ip );
+
+  fd_ip_route_entry_t * route_table     = fd_ip_route_table_get( ip );
+  ulong                 route_table_sz  = ip->cur_num_route_entries;
+
+  FD_LOG_NOTICE(( "Routing table:" ));
+  for( ulong j = 0L; j < route_table_sz; ++j ) {
+    fd_ip_route_entry_t * route_entry = route_table + j;
+
+    if( route_entry->flags == 0 ) break;
+
+    FD_LOG_NOTICE(( "  " IP_FMT "  " IP_FMT "  " IP_FMT "  %2u  " IP_FMT "  %2u  %x",
+          IP_VAR(route_table[j].nh_ip_addr),
+          IP_VAR(route_table[j].dst_ip_addr),
+          IP_VAR(route_table[j].dst_netmask),
+          route_table[j].dst_netmask_sz,
+          IP_VAR(route_table[j].src_ip_addr),
+          route_table[j].oif,
+          route_table[j].flags ));
+  }
+
+  fd_ip_leave( ip );
+
+  free( base_mem );
+
+  fd_halt();
+
+  return 0;
+}
+

--- a/src/tango/ip/test_netlink.c
+++ b/src/tango/ip/test_netlink.c
@@ -1,0 +1,203 @@
+#include "fd_netlink.h"
+
+#include <stdlib.h>
+
+
+#define TEST_IP( a, b, c, d ) ( ( (uint)(a) << 24U ) | ( (uint)(b) << 16U ) | \
+                                ( (uint)(c) <<  8U ) | ( (uint)(d) <<  0U ) )
+
+void
+test_route_query( fd_nl_route_entry_t * test_table,
+                  ulong                 test_table_sz,
+                  uint                  ip_addr,
+                  long                  expected_idx ) {
+  fd_nl_route_entry_t * result = fd_nl_route_query( test_table, test_table_sz, ip_addr );
+
+  long idx = result == NULL ? -1 : (long)( result - test_table ); 
+
+  FD_LOG_NOTICE(( "route test %08x matched idx %ld  %s", ip_addr, idx,
+        idx == expected_idx ? "PASSED" : "FAILED" ));
+}
+
+void
+test_arp_query( fd_nl_arp_entry_t * arp_table,
+                ulong               arp_table_sz,
+                uint                ip_addr,
+                long                expected_idx ) {
+  fd_nl_arp_entry_t * result = fd_nl_arp_query( arp_table, arp_table_sz, ip_addr );
+
+  long idx = result == NULL ? -1 : (long)( result - arp_table );
+
+  FD_LOG_NOTICE(( "arp test %08x matched idx %ld  %s", ip_addr, idx,
+        idx == expected_idx ? "PASSED" : "FAILED" ));
+}
+
+
+void
+test_routes() {
+  /* construct a table and test the entries directly */
+                                
+  uint flags = FD_NL_RT_FLAGS_USED;
+
+  fd_nl_route_entry_t test_table[] = {
+    { .nh_ip_addr = TEST_IP(  10,   1,   2, 2 ), .dst_netmask_sz = 31, .oif =  0, .flags = flags },
+    { .nh_ip_addr = TEST_IP(  10,   1,   2, 1 ), .dst_netmask_sz = 24, .oif =  1, .flags = flags },
+    { .nh_ip_addr = TEST_IP(  10,   1,   3, 1 ), .dst_netmask_sz = 24, .oif =  2, .flags = flags },
+    { .nh_ip_addr = TEST_IP(  10,   1, 128, 1 ), .dst_netmask_sz = 24, .oif =  3, .flags = flags },
+    { .nh_ip_addr = TEST_IP(  10,   1,   1, 1 ), .dst_netmask_sz = 16, .oif =  4, .flags = flags },
+    { .nh_ip_addr = TEST_IP(  10,   2,   2, 2 ), .dst_netmask_sz = 16, .oif =  5, .flags = flags },
+    { .nh_ip_addr = TEST_IP(  10, 128,   8, 3 ), .dst_netmask_sz = 16, .oif =  6, .flags = flags },
+    { .nh_ip_addr = TEST_IP(  10,   1,   1, 5 ), .dst_netmask_sz =  8, .oif =  7, .flags = flags },
+    { .nh_ip_addr = TEST_IP(  15,   1,   2, 2 ), .dst_netmask_sz =  8, .oif =  8, .flags = flags },
+    { .nh_ip_addr = TEST_IP( 128,   1,   8, 3 ), .dst_netmask_sz =  8, .oif =  9, .flags = flags },
+    { .nh_ip_addr = TEST_IP( 191,   1,   8, 3 ), .dst_netmask_sz =  0, .oif = 10, .flags = flags },
+  };
+
+  /* number of entries in the test table */
+  ulong test_table_sz = sizeof( test_table ) / sizeof( test_table[0] );
+
+  /* netmasks and dest net ip addrs are calculated from nh_netmask_sz */
+  for( long j = 0L; j < (long)test_table_sz; ++j ) {
+    fd_nl_route_entry_t * entry = test_table + j;
+    entry->dst_netmask = (uint)( 0xffffffff00000000LU >> (ulong)entry->dst_netmask_sz );
+    entry->dst_ip_addr = entry->nh_ip_addr & entry->dst_netmask;
+  }
+
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   1,   2,   2 ),  0 );
+  test_route_query( test_table, test_table_sz,   TEST_IP( 192, 168,   1,   2 ), 10 );
+  test_route_query( test_table, test_table_sz-1, TEST_IP( 192, 168,   1,   2 ), -1 );
+
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   1,   2,   2 ),  0 );
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   1,   2,   3 ),  0 );
+
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   1,   2,   4 ),  1 );
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   1,   2,   5 ),  1 );
+
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   1,   3,   1 ),  2 );
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   1,   3,   2 ),  2 );
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   1,   3,   3 ),  2 );
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   1,   3, 127 ),  2 );
+
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   1,   3, 129 ),  2 );
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   1,   3, 130 ),  2 );
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   1,   3, 131 ),  2 );
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   1,   3, 255 ),  2 );
+
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   1, 127,   1 ),  4 );
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   1, 128,   1 ),  3 );
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   1, 129,   1 ),  4 );
+
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   2,   1,   1 ),  5 );
+
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10,   3,   1,   1 ),  7 );
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10, 254,   1,   1 ),  7 );
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10, 255,   1,   1 ),  7 );
+
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10, 127,   1,   1 ),  7 );
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10, 128,   1,   1 ),  6 );
+  test_route_query( test_table, test_table_sz,   TEST_IP(  10, 129,   1,   1 ),  7 );
+
+  test_route_query( test_table, test_table_sz,   TEST_IP(  14,   1,   1,  91 ), 10 );
+  test_route_query( test_table, test_table_sz,   TEST_IP(  15,   1,   1,  91 ),  8 );
+  test_route_query( test_table, test_table_sz,   TEST_IP(  16,   1,   1,  91 ), 10 );
+
+}
+
+void
+test_arp_queries() {
+  /* construct a table and test the entries directly */
+                                
+  uint flags = FD_NL_ARP_FLAGS_USED;
+
+  fd_nl_arp_entry_t test_table[] = {
+    { .dst_ip_addr = TEST_IP(  10,   1,   2, 2 ), .mac_addr = {0}, .ifindex =  0, .flags = flags },
+    { .dst_ip_addr = TEST_IP(  10,   1,   2, 1 ), .mac_addr = {0}, .ifindex =  1, .flags = flags },
+    { .dst_ip_addr = TEST_IP(  10,   1,   3, 1 ), .mac_addr = {0}, .ifindex =  2, .flags = flags },
+    { .dst_ip_addr = TEST_IP(  10,   1, 128, 1 ), .mac_addr = {0}, .ifindex =  3, .flags = flags },
+    { .dst_ip_addr = TEST_IP(  10,   1,   1, 1 ), .mac_addr = {0}, .ifindex =  4, .flags = flags },
+    { .dst_ip_addr = TEST_IP(  10,   2,   2, 2 ), .mac_addr = {0}, .ifindex =  5, .flags = flags },
+    { .dst_ip_addr = TEST_IP(  10, 128,   8, 3 ), .mac_addr = {0}, .ifindex =  6, .flags = flags },
+    { .dst_ip_addr = TEST_IP(  10,   1,   1, 5 ), .mac_addr = {0}, .ifindex =  7, .flags = flags },
+    { .dst_ip_addr = TEST_IP(  15,   1,   2, 2 ), .mac_addr = {0}, .ifindex =  8, .flags = flags },
+    { .dst_ip_addr = TEST_IP( 128,   1,   8, 3 ), .mac_addr = {0}, .ifindex =  9, .flags = flags },
+    { .dst_ip_addr = TEST_IP( 191,   1,   8, 3 ), .mac_addr = {0}, .ifindex = 10, .flags = flags },
+  };
+
+  /* number of entries in the test table */
+  ulong test_table_sz = sizeof( test_table ) / sizeof( test_table[0] );
+
+  test_arp_query( test_table, test_table_sz,   TEST_IP(  10,   1,   2,   2 ),  0 );
+  test_arp_query( test_table, test_table_sz,   TEST_IP(  10,   1,   2,   1 ),  1 );
+  test_arp_query( test_table, test_table_sz,   TEST_IP(  10,   1,   3,   1 ),  2 );
+  test_arp_query( test_table, test_table_sz,   TEST_IP(  10,   1, 128,   1 ),  3 );
+
+  test_arp_query( test_table, test_table_sz,   TEST_IP( 192, 168,   1,   1 ), -1 );
+  test_arp_query( test_table, test_table_sz,   TEST_IP( 192, 168,   1,   2 ), -1 );
+  test_arp_query( test_table, test_table_sz,   TEST_IP( 192, 168,   1,   2 ), -1 );
+  test_arp_query( test_table, test_table_sz,   TEST_IP( 192, 168,   2,   2 ), -1 );
+}
+
+
+
+int
+main( int argc, char **argv ) {
+  fd_boot( &argc, &argv );
+
+  fd_nl_t nl[1];
+
+  if( fd_nl_init( nl, 1234U ) ) {
+    FD_LOG_ERR(( "Unable to initialize netlink fd_nl_init" ));
+    exit(1);
+  }
+
+#define ROUTE_TABLE_CAP 32
+  fd_nl_route_entry_t route_table[ROUTE_TABLE_CAP];
+  ulong               route_table_cap = ROUTE_TABLE_CAP;
+
+  if( 1 ) {
+    long route_num_entries = fd_nl_load_route_table( nl, route_table, route_table_cap );
+
+    FD_LOG_NOTICE(( "number of routing entries: %ld", route_num_entries ));
+
+    for( long j = 0L; j < route_num_entries; ++j ) {
+      FD_LOG_NOTICE(( "  route entry: %08x  %08x  %08x  %2u  %08x %u",
+            route_table[j].nh_ip_addr,
+            route_table[j].dst_ip_addr,
+            route_table[j].dst_netmask,
+            route_table[j].dst_netmask_sz,
+            route_table[j].src_ip_addr,
+            route_table[j].oif ));
+    }
+  }
+
+
+#define ARP_TABLE_CAP 32
+  fd_nl_arp_entry_t arp_table[ARP_TABLE_CAP];
+  ulong             arp_table_cap = ARP_TABLE_CAP;
+
+  long arp_num_entries = fd_nl_load_arp_table( nl, arp_table, arp_table_cap );
+
+  FD_LOG_NOTICE(( "number of arp entries: %ld", arp_num_entries ));
+
+  for( long j = 0L; j < arp_num_entries; ++j ) {
+    FD_LOG_NOTICE(( "  arp entry: %08x  %02x:%02x:%02x:%02x:%02x:%02x  %u",
+          arp_table[j].dst_ip_addr,
+          arp_table[j].mac_addr[0],
+          arp_table[j].mac_addr[1],
+          arp_table[j].mac_addr[2],
+          arp_table[j].mac_addr[3],
+          arp_table[j].mac_addr[4],
+          arp_table[j].mac_addr[5],
+          arp_table[j].ifindex ));
+  }
+
+
+  test_routes();
+
+  test_arp_queries();
+
+  fd_halt();
+
+  return 0;
+}
+

--- a/src/tango/ip/test_routing.c
+++ b/src/tango/ip/test_routing.c
@@ -1,0 +1,454 @@
+#include "fd_ip.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+
+#define TEST_IP( a, b, c, d ) ( ( (uint)(a) << 24U ) | ( (uint)(b) << 16U ) | \
+                                ( (uint)(c) <<  8U ) | ( (uint)(d) <<  0U ) )
+#define IP_FMT          "%3u.%3u.%3u.%3u"
+#define IP_VAR(IP) (((IP)>>030) & 0xffU), \
+                   (((IP)>>020) & 0xffU), \
+                   (((IP)>>010) & 0xffU), \
+                   (((IP)>>000) & 0xffU)
+#define MAC_FMT    "%02x:%02x:%02x:%02x:%02x:%02x"
+#define MAC_VAR(X) (X)[0], (X)[1], (X)[2], (X)[3], (X)[4], (X)[5]
+
+/* set netmasks on routing entries */
+void
+route_table_complete( fd_ip_route_entry_t * test_table, ulong test_table_sz ) {
+  /* netmasks and dest net ip addrs are calculated from nh_netmask_sz */
+  for( long j = 0L; j < (long)test_table_sz; ++j ) {
+    fd_nl_route_entry_t * entry = test_table + j;
+    entry->dst_netmask = (uint)( 0xffffffff00000000LU >> (ulong)entry->dst_netmask_sz );
+  }
+}
+
+
+/* build custom route table */
+ulong
+build_route_table( fd_ip_route_entry_t * output, ulong output_cap ) {
+  /* clear original table */
+
+  fd_memset( output, 0, output_cap * sizeof( output[0] ) );
+
+  /* construct a table */
+
+  uint flags = FD_NL_RT_FLAGS_USED;
+
+  fd_nl_route_entry_t test_table[] = {
+    { .dst_ip_addr = TEST_IP( 192, 168, 200,   0 ), .nh_ip_addr = TEST_IP(   0,   0,   0,   0 ), .dst_netmask_sz = 24, .oif = 100, .flags = flags },
+    { .dst_ip_addr = TEST_IP( 192, 168,   0,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 101 ), .dst_netmask_sz = 16, .oif = 101, .flags = flags },
+    { .dst_ip_addr = TEST_IP(  10,   0,   0,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 102 ), .dst_netmask_sz =  8, .oif = 102, .flags = flags },
+    { .dst_ip_addr = TEST_IP(   0,   0,   0,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 103 ), .dst_netmask_sz =  0, .oif = 103, .flags = flags },
+  };
+
+  /* number of entries in the test table */
+  ulong test_table_sz = sizeof( test_table ) / sizeof( test_table[0] );
+
+  FD_TEST( test_table_sz < output_cap );
+
+  route_table_complete( test_table, test_table_sz );
+
+  /* copy the table into the output */
+  for( long j = 0L; j < (long)test_table_sz; ++j ) {
+    fd_memcpy( output + j, test_table + j, sizeof( test_table[0] ) );
+  }
+
+  return test_table_sz;
+}
+
+
+/* build custom route table */
+ulong
+build_route_table_1( fd_ip_route_entry_t * output, ulong output_cap ) {
+  /* clear original table */
+
+  fd_memset( output, 0, output_cap * sizeof( output[0] ) );
+
+  /* construct a table */
+
+  uint flags = FD_NL_RT_FLAGS_USED;
+
+  fd_nl_route_entry_t test_table[] = {
+    { .dst_ip_addr = TEST_IP( 192, 168, 200,   0 ), .nh_ip_addr = TEST_IP(   0,   0,   0,   0 ), .dst_netmask_sz = 24, .oif = 100, .flags = flags },
+    { .dst_ip_addr = TEST_IP( 192, 168,   0,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 101 ), .dst_netmask_sz = 16, .oif = 101, .flags = flags },
+    { .dst_ip_addr = TEST_IP(  10,   0,   0,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 102 ), .dst_netmask_sz =  8, .oif = 102, .flags = flags },
+  };
+
+  /* number of entries in the test table */
+  ulong test_table_sz = sizeof( test_table ) / sizeof( test_table[0] );
+
+  FD_TEST( test_table_sz < output_cap );
+
+  route_table_complete( test_table, test_table_sz );
+
+  /* copy the table into the output */
+  for( long j = 0L; j < (long)test_table_sz; ++j ) {
+    fd_memcpy( output + j, test_table + j, sizeof( test_table[0] ) );
+  }
+
+  return test_table_sz;
+}
+
+ulong
+build_arp_table( fd_ip_arp_entry_t * output, ulong output_cap ) {
+  /* construct a table */
+
+  uint flags = FD_NL_ARP_FLAGS_USED;
+
+  /* define all the gateways */
+  fd_nl_arp_entry_t test_table[] = {
+    { .dst_ip_addr = TEST_IP( 200,   1,   1, 100 ), .mac_addr = {0}, .ifindex =  0, .flags = flags },
+    { .dst_ip_addr = TEST_IP( 200,   1,   1, 101 ), .mac_addr = {0}, .ifindex =  1, .flags = flags },
+    { .dst_ip_addr = TEST_IP( 200,   1,   1, 102 ), .mac_addr = {0}, .ifindex =  2, .flags = flags },
+    { .dst_ip_addr = TEST_IP( 200,   1,   1, 103 ), .mac_addr = {0}, .ifindex =  3, .flags = flags },
+
+    { .dst_ip_addr = TEST_IP( 192, 168, 200,   1 ), .mac_addr = {0}, .ifindex =  4, .flags = flags },
+    { .dst_ip_addr = TEST_IP( 192, 168, 200,   2 ), .mac_addr = {0}, .ifindex =  5, .flags = flags },
+    { .dst_ip_addr = TEST_IP( 192, 168, 200,   3 ), .mac_addr = {0}, .ifindex =  6, .flags = flags },
+  };
+
+  /* number of entries in the test table */
+  ulong test_table_sz = sizeof( test_table ) / sizeof( test_table[0] );
+
+  FD_TEST( test_table_sz < output_cap );
+
+  /* set some mac addresses */
+  for( long j = 0L; j < (long)test_table_sz; ++j ) {
+    fd_memcpy( output + j, test_table + j, sizeof( test_table[0] ) );
+    test_table[j].mac_addr[0] = 0x42;
+    test_table[j].mac_addr[1] = 0x42;
+    test_table[j].mac_addr[2] = (uchar)( ( test_table[j].dst_ip_addr >> 030 ) & 0xffU );
+    test_table[j].mac_addr[3] = (uchar)( ( test_table[j].dst_ip_addr >> 020 ) & 0xffU );
+    test_table[j].mac_addr[4] = (uchar)( ( test_table[j].dst_ip_addr >> 010 ) & 0xffU );
+    test_table[j].mac_addr[5] = (uchar)( ( test_table[j].dst_ip_addr >> 000 ) & 0xffU );
+  }
+
+  /* copy the table into the output */
+  for( long j = 0L; j < (long)test_table_sz; ++j ) {
+    fd_memcpy( output + j, test_table + j, sizeof( test_table[0] ) );
+  }
+
+  return test_table_sz;
+}
+
+
+#if 0
+void
+test_route( fd_ip_t * ip,
+            uint      ip_addr,
+            int       exp_rtn,
+            uint      exp_next_ip_addr,
+            uint      exp_ifindex,
+            uchar *   exp_dst_mac ) {
+  uchar dst_mac[6]      = {0};
+  uint  next_ip_addr[1] = {0};
+  uint  ifindex[1]      = {0};
+
+  int rtn = fd_ip_route_ip_addr( dst_mac, next_ip_addr, ifindex, ip, ip_addr );
+
+  FD_LOG_NOTICE(( "rtn:              " "%d",    rtn                      ));
+  FD_LOG_NOTICE(( "dst_mac:          " MAC_FMT, MAC_VAR(dst_mac)         ));
+  FD_LOG_NOTICE(( "next_ip_addr:     " IP_FMT,  IP_VAR(next_ip_addr[0])  ));
+  FD_LOG_NOTICE(( "ifindex:          " "%u",    ifindex[0]               ));
+
+  FD_LOG_NOTICE(( "exp_rtn:          " "%d",    exp_rtn                  ));
+  FD_LOG_NOTICE(( "exp_dst_mac:      " MAC_FMT, MAC_VAR(exp_dst_mac)     ));
+  FD_LOG_NOTICE(( "exp_next_ip_addr: " IP_FMT,  IP_VAR(exp_next_ip_addr) ));
+  FD_LOG_NOTICE(( "exp_ifindex:      " "%u",    exp_ifindex              ));
+
+  FD_TEST( rtn             == exp_rtn             );
+  FD_TEST( memcmp( dst_mac, exp_dst_mac, 6 ) == 0 );
+  FD_TEST( next_ip_addr[0] == exp_next_ip_addr    );
+  FD_TEST( ifindex[0]      == exp_ifindex         );
+}
+#else
+/* making this a macro helps the error reporting in the failure case */
+#define \
+test_route( /* fd_ip_t * */ ip,                                                        \
+            /* uint      */ ip_addr,                                                   \
+            /* int       */ exp_rtn,                                                   \
+            /* uint      */ exp_next_ip_addr,                                          \
+            /* uint      */ exp_ifindex,                                               \
+            /* uchar *   */ exp_dst_mac ) do {                                         \
+  uchar dst_mac[6]      = {0};                                                         \
+  uint  next_ip_addr[1] = {0};                                                         \
+  uint  ifindex[1]      = {0};                                                         \
+                                                                                       \
+  int rtn = fd_ip_route_ip_addr( dst_mac, next_ip_addr, ifindex, ip, ip_addr );              \
+                                                                                       \
+  FD_LOG_NOTICE(( "rtn:              " "%d",    rtn                      ));           \
+  FD_LOG_NOTICE(( "dst_mac:          " MAC_FMT, MAC_VAR(dst_mac)         ));           \
+  FD_LOG_NOTICE(( "next_ip_addr:     " IP_FMT,  IP_VAR(next_ip_addr[0])  ));           \
+  FD_LOG_NOTICE(( "ifindex:          " "%u",    ifindex[0]               ));           \
+                                                                                       \
+  FD_LOG_NOTICE(( "exp_rtn:          " "%d",    exp_rtn                  ));           \
+  FD_LOG_NOTICE(( "exp_dst_mac:      " MAC_FMT, MAC_VAR(exp_dst_mac)     ));           \
+  FD_LOG_NOTICE(( "exp_next_ip_addr: " IP_FMT,  IP_VAR(exp_next_ip_addr) ));           \
+  FD_LOG_NOTICE(( "exp_ifindex:      " "%u",    exp_ifindex              ));           \
+                                                                                       \
+  FD_TEST( rtn             == exp_rtn             );                                   \
+  FD_TEST( memcmp( dst_mac, exp_dst_mac, 6 ) == 0 );                                   \
+  FD_TEST( next_ip_addr[0] == exp_next_ip_addr    );                                   \
+  FD_TEST( ifindex[0]      == exp_ifindex         );                                   \
+} while(0)
+#endif
+
+
+void
+test_routes_0( fd_ip_t * ip ) {
+  /*
+  { .dst_ip_addr = TEST_IP( 192, 168, 200,   0 ), .nh_ip_addr = TEST_IP(   0,   0,   0,   0 ), .dst_netmask_sz = 24, .oif = 100, .flags = flags },
+  { .dst_ip_addr = TEST_IP( 192, 168,   1,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 101 ), .dst_netmask_sz = 16, .oif = 101, .flags = flags },
+  { .dst_ip_addr = TEST_IP(  10,   1,   1,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 102 ), .dst_netmask_sz =  8, .oif = 102, .flags = flags },
+  { .dst_ip_addr = TEST_IP(   0,   0,   0,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 103 ), .dst_netmask_sz =  0, .oif = 103, .flags = flags },
+
+  { .dst_ip_addr = TEST_IP( 200,   1,   1, 100 ), .mac_addr = {0}, .ifindex =  0, .flags = flags },
+  { .dst_ip_addr = TEST_IP( 200,   1,   1, 101 ), .mac_addr = {0}, .ifindex =  1, .flags = flags },
+  { .dst_ip_addr = TEST_IP( 200,   1,   1, 102 ), .mac_addr = {0}, .ifindex =  2, .flags = flags },
+  { .dst_ip_addr = TEST_IP( 200,   1,   1, 103 ), .mac_addr = {0}, .ifindex =  3, .flags = flags },
+  */
+
+#define TEST_MAC( a, b, c, d, e, f ) ((uchar[]){a,b,c,d,e,f})
+  /* local ip addresses */
+  test_route( ip, TEST_IP( 192, 168, 200,   1 ), FD_IP_SUCCESS,   TEST_IP( 192, 168, 200,   1 ), 100, TEST_MAC( 0x42, 0x42, 192, 168, 200,   1 ) );
+  test_route( ip, TEST_IP( 192, 168, 200,   2 ), FD_IP_SUCCESS,   TEST_IP( 192, 168, 200,   2 ), 100, TEST_MAC( 0x42, 0x42, 192, 168, 200,   2 ) );
+  test_route( ip, TEST_IP( 192, 168, 200,   3 ), FD_IP_SUCCESS,   TEST_IP( 192, 168, 200,   3 ), 100, TEST_MAC( 0x42, 0x42, 192, 168, 200,   3 ) );
+
+  /* local ip addresses - need probe */
+  test_route( ip, TEST_IP( 192, 168, 200, 101 ), FD_IP_PROBE_RQD, TEST_IP( 192, 168, 200, 101 ), 100, TEST_MAC(    0,    0,   0,   0,   0,   0 ) );
+  test_route( ip, TEST_IP( 192, 168, 200, 102 ), FD_IP_PROBE_RQD, TEST_IP( 192, 168, 200, 102 ), 100, TEST_MAC(    0,    0,   0,   0,   0,   0 ) );
+  test_route( ip, TEST_IP( 192, 168, 200, 103 ), FD_IP_PROBE_RQD, TEST_IP( 192, 168, 200, 103 ), 100, TEST_MAC(    0,    0,   0,   0,   0,   0 ) );
+
+  /* routable ip addresses */
+  test_route( ip, TEST_IP( 192, 168,   1,   1 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 101 ), 101, TEST_MAC( 0x42, 0x42, 200,   1,   1, 101 ) );
+  test_route( ip, TEST_IP( 192, 168,   1,   2 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 101 ), 101, TEST_MAC( 0x42, 0x42, 200,   1,   1, 101 ) );
+  test_route( ip, TEST_IP( 192, 168,   1,   3 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 101 ), 101, TEST_MAC( 0x42, 0x42, 200,   1,   1, 101 ) );
+
+  test_route( ip, TEST_IP( 192, 168,   2,   1 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 101 ), 101, TEST_MAC( 0x42, 0x42, 200,   1,   1, 101 ) );
+  test_route( ip, TEST_IP( 192, 168,   2,   2 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 101 ), 101, TEST_MAC( 0x42, 0x42, 200,   1,   1, 101 ) );
+  test_route( ip, TEST_IP( 192, 168,   2,   3 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 101 ), 101, TEST_MAC( 0x42, 0x42, 200,   1,   1, 101 ) );
+
+  /* .169 doesn't match any of the specific rules */
+  test_route( ip, TEST_IP( 192, 169,   2,   1 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 103 ), 103, TEST_MAC( 0x42, 0x42, 200,   1,   1, 103 ) );
+  test_route( ip, TEST_IP( 192, 169,   2,   2 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 103 ), 103, TEST_MAC( 0x42, 0x42, 200,   1,   1, 103 ) );
+  test_route( ip, TEST_IP( 192, 169,   2,   3 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 103 ), 103, TEST_MAC( 0x42, 0x42, 200,   1,   1, 103 ) );
+
+  test_route( ip, TEST_IP(  10,   1,   1,   1 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 102 ), 102, TEST_MAC( 0x42, 0x42, 200,   1,   1, 102 ) );
+  test_route( ip, TEST_IP(  10,   1,   1,   2 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 102 ), 102, TEST_MAC( 0x42, 0x42, 200,   1,   1, 102 ) );
+  test_route( ip, TEST_IP(  10,   1,   1,   3 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 102 ), 102, TEST_MAC( 0x42, 0x42, 200,   1,   1, 102 ) );
+
+}
+
+
+/* test multicast and broadcast routes */
+void
+test_routes_1( fd_ip_t * ip ) {
+  /*
+  { .dst_ip_addr = TEST_IP( 192, 168, 200,   0 ), .nh_ip_addr = TEST_IP(   0,   0,   0,   0 ), .dst_netmask_sz = 24, .oif = 100, .flags = flags },
+  { .dst_ip_addr = TEST_IP( 192, 168,   1,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 101 ), .dst_netmask_sz = 16, .oif = 101, .flags = flags },
+  { .dst_ip_addr = TEST_IP(  10,   1,   1,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 102 ), .dst_netmask_sz =  8, .oif = 102, .flags = flags },
+  { .dst_ip_addr = TEST_IP(   0,   0,   0,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 103 ), .dst_netmask_sz =  0, .oif = 103, .flags = flags },
+
+  { .dst_ip_addr = TEST_IP( 200,   1,   1, 100 ), .mac_addr = {0}, .ifindex =  0, .flags = flags },
+  { .dst_ip_addr = TEST_IP( 200,   1,   1, 101 ), .mac_addr = {0}, .ifindex =  1, .flags = flags },
+  { .dst_ip_addr = TEST_IP( 200,   1,   1, 102 ), .mac_addr = {0}, .ifindex =  2, .flags = flags },
+  { .dst_ip_addr = TEST_IP( 200,   1,   1, 103 ), .mac_addr = {0}, .ifindex =  3, .flags = flags },
+  */
+
+#define TEST_MAC( a, b, c, d, e, f ) ((uchar[]){a,b,c,d,e,f})
+  /* local subnet broadcast ip */
+  test_route( ip, TEST_IP( 192, 168, 200, 255 ), FD_IP_BROADCAST, TEST_IP(   0,   0,   0,   0 ), 100, TEST_MAC( 0xff, 0xff, 0xff, 0xff, 0xff, 0xff ) );
+
+  /* routable subnet broadcast ip addresses */
+  test_route( ip, TEST_IP( 192, 168, 255, 255 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 101 ), 101, TEST_MAC( 0x42, 0x42, 200,   1,   1, 101 ) );
+
+  /* .169 doesn't match any of the specific rules */
+  test_route( ip, TEST_IP( 192, 169, 255, 255 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 103 ), 103, TEST_MAC( 0x42, 0x42, 200,   1,   1, 103 ) );
+
+  /* /24 subnet broadcast */
+  test_route( ip, TEST_IP(  10, 255, 255, 255 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 102 ), 102, TEST_MAC( 0x42, 0x42, 200,   1,   1, 102 ) );
+
+  /* multicast */
+  test_route( ip, TEST_IP( 239,   1,   2,   3 ), FD_IP_MULTICAST, TEST_IP(   0,   0,   0,   0 ),   0, TEST_MAC( 0x01, 0x00, 0x5e,  1,   2,   3 ) );
+}
+
+
+void
+test_routes_2( fd_ip_t * ip ) {
+  /*
+  { .dst_ip_addr = TEST_IP( 192, 168, 200,   0 ), .nh_ip_addr = TEST_IP(   0,   0,   0,   0 ), .dst_netmask_sz = 24, .oif = 100, .flags = flags },
+  { .dst_ip_addr = TEST_IP( 192, 168,   1,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 101 ), .dst_netmask_sz = 16, .oif = 101, .flags = flags },
+  { .dst_ip_addr = TEST_IP(  10,   1,   1,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 102 ), .dst_netmask_sz =  8, .oif = 102, .flags = flags },
+  { .dst_ip_addr = TEST_IP(   0,   0,   0,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 103 ), .dst_netmask_sz =  0, .oif = 103, .flags = flags },
+
+  { .dst_ip_addr = TEST_IP( 200,   1,   1, 100 ), .mac_addr = {0}, .ifindex =  0, .flags = flags },
+  { .dst_ip_addr = TEST_IP( 200,   1,   1, 101 ), .mac_addr = {0}, .ifindex =  1, .flags = flags },
+  { .dst_ip_addr = TEST_IP( 200,   1,   1, 102 ), .mac_addr = {0}, .ifindex =  2, .flags = flags },
+  { .dst_ip_addr = TEST_IP( 200,   1,   1, 103 ), .mac_addr = {0}, .ifindex =  3, .flags = flags },
+  */
+
+  /* local ip addresses */
+  test_route( ip, TEST_IP( 192, 168, 200,   1 ), FD_IP_SUCCESS,   TEST_IP( 192, 168, 200,   1 ), 100, TEST_MAC( 0x42, 0x42, 192, 168, 200,   1 ) );
+  test_route( ip, TEST_IP( 192, 168, 200,   2 ), FD_IP_SUCCESS,   TEST_IP( 192, 168, 200,   2 ), 100, TEST_MAC( 0x42, 0x42, 192, 168, 200,   2 ) );
+  test_route( ip, TEST_IP( 192, 168, 200,   3 ), FD_IP_SUCCESS,   TEST_IP( 192, 168, 200,   3 ), 100, TEST_MAC( 0x42, 0x42, 192, 168, 200,   3 ) );
+
+  /* local ip addresses - need probe */
+  test_route( ip, TEST_IP( 192, 168, 200, 101 ), FD_IP_PROBE_RQD, TEST_IP( 192, 168, 200, 101 ), 100, TEST_MAC(    0,    0,   0,   0,   0,   0 ) );
+  test_route( ip, TEST_IP( 192, 168, 200, 102 ), FD_IP_PROBE_RQD, TEST_IP( 192, 168, 200, 102 ), 100, TEST_MAC(    0,    0,   0,   0,   0,   0 ) );
+  test_route( ip, TEST_IP( 192, 168, 200, 103 ), FD_IP_PROBE_RQD, TEST_IP( 192, 168, 200, 103 ), 100, TEST_MAC(    0,    0,   0,   0,   0,   0 ) );
+
+  /* routable ip addresses */
+  test_route( ip, TEST_IP( 192, 168,   1,   1 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 101 ), 101, TEST_MAC( 0x42, 0x42, 200,   1,   1, 101 ) );
+  test_route( ip, TEST_IP( 192, 168,   1,   2 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 101 ), 101, TEST_MAC( 0x42, 0x42, 200,   1,   1, 101 ) );
+  test_route( ip, TEST_IP( 192, 168,   1,   3 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 101 ), 101, TEST_MAC( 0x42, 0x42, 200,   1,   1, 101 ) );
+
+  test_route( ip, TEST_IP( 192, 168,   2,   1 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 101 ), 101, TEST_MAC( 0x42, 0x42, 200,   1,   1, 101 ) );
+  test_route( ip, TEST_IP( 192, 168,   2,   2 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 101 ), 101, TEST_MAC( 0x42, 0x42, 200,   1,   1, 101 ) );
+  test_route( ip, TEST_IP( 192, 168,   2,   3 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 101 ), 101, TEST_MAC( 0x42, 0x42, 200,   1,   1, 101 ) );
+
+  /* .169 doesn't match any of the specific rules, and now we don't have a default entry */
+  test_route( ip, TEST_IP( 192, 169,   2,   1 ), FD_IP_NO_ROUTE,  TEST_IP(   0,   0,   0,   0 ),   0, TEST_MAC(    0,   0,   0,   0,   0,   0 ) );
+  test_route( ip, TEST_IP( 192, 169,   2,   2 ), FD_IP_NO_ROUTE,  TEST_IP(   0,   0,   0,   0 ),   0, TEST_MAC(    0,   0,   0,   0,   0,   0 ) );
+  test_route( ip, TEST_IP( 192, 169,   2,   3 ), FD_IP_NO_ROUTE,  TEST_IP(   0,   0,   0,   0 ),   0, TEST_MAC(    0,   0,   0,   0,   0,   0 ) );
+
+  test_route( ip, TEST_IP(  10,   1,   1,   1 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 102 ), 102, TEST_MAC( 0x42, 0x42, 200,   1,   1, 102 ) );
+  test_route( ip, TEST_IP(  10,   1,   1,   2 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 102 ), 102, TEST_MAC( 0x42, 0x42, 200,   1,   1, 102 ) );
+  test_route( ip, TEST_IP(  10,   1,   1,   3 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 102 ), 102, TEST_MAC( 0x42, 0x42, 200,   1,   1, 102 ) );
+
+}
+
+
+/* test multicast and broadcast routes */
+void
+test_routes_3( fd_ip_t * ip ) {
+  /*
+  { .dst_ip_addr = TEST_IP( 192, 168, 200,   0 ), .nh_ip_addr = TEST_IP(   0,   0,   0,   0 ), .dst_netmask_sz = 24, .oif = 100, .flags = flags },
+  { .dst_ip_addr = TEST_IP( 192, 168,   1,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 101 ), .dst_netmask_sz = 16, .oif = 101, .flags = flags },
+  { .dst_ip_addr = TEST_IP(  10,   1,   1,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 102 ), .dst_netmask_sz =  8, .oif = 102, .flags = flags },
+  { .dst_ip_addr = TEST_IP(   0,   0,   0,   0 ), .nh_ip_addr = TEST_IP( 200,   1,   1, 103 ), .dst_netmask_sz =  0, .oif = 103, .flags = flags },
+
+  { .dst_ip_addr = TEST_IP( 200,   1,   1, 100 ), .mac_addr = {0}, .ifindex =  0, .flags = flags },
+  { .dst_ip_addr = TEST_IP( 200,   1,   1, 101 ), .mac_addr = {0}, .ifindex =  1, .flags = flags },
+  { .dst_ip_addr = TEST_IP( 200,   1,   1, 102 ), .mac_addr = {0}, .ifindex =  2, .flags = flags },
+  { .dst_ip_addr = TEST_IP( 200,   1,   1, 103 ), .mac_addr = {0}, .ifindex =  3, .flags = flags },
+  */
+
+#define TEST_MAC( a, b, c, d, e, f ) ((uchar[]){a,b,c,d,e,f})
+  /* local subnet broadcast ip */
+  test_route( ip, TEST_IP( 192, 168, 200, 255 ), FD_IP_BROADCAST, TEST_IP(   0,   0,   0,   0 ), 100, TEST_MAC( 0xff, 0xff, 0xff, 0xff, 0xff, 0xff ) );
+
+  /* routable subnet broadcast ip addresses */
+  test_route( ip, TEST_IP( 192, 168, 255, 255 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 101 ), 101, TEST_MAC( 0x42, 0x42, 200,   1,   1, 101 ) );
+
+  /* .169 doesn't match any of the specific rules */
+  test_route( ip, TEST_IP( 192, 169, 255, 255 ), FD_IP_NO_ROUTE,  TEST_IP(   0,   0,   0,   0 ),   0, TEST_MAC(    0,    0,   0,   0,   0,   0 ) );
+
+  /* /24 subnet broadcast */
+  test_route( ip, TEST_IP(  10, 255, 255, 255 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 102 ), 102, TEST_MAC( 0x42, 0x42, 200,   1,   1, 102 ) );
+
+  /* multicast */
+  test_route( ip, TEST_IP( 239,   1,   2,   3 ), FD_IP_MULTICAST, TEST_IP(   0,   0,   0,   0 ),   0, TEST_MAC( 0x01, 0x00, 0x5e,  1,   2,   3 ) );
+}
+
+
+int
+main( int argc, char **argv ) {
+  fd_boot( &argc, &argv );
+
+  ulong num_arp_entries   = 32;
+  ulong num_route_entries = 32;
+
+  ulong ip_footprint = fd_ip_footprint( num_arp_entries, num_route_entries );
+  FD_LOG_NOTICE(( "ip_footprint: %lu", ip_footprint ));
+
+  ulong ip_align = fd_ip_align();
+  FD_LOG_NOTICE(( "ip_align: %lu", ip_align ));
+
+  void * base_mem = aligned_alloc( ip_align, ip_footprint );
+  FD_TEST( base_mem );
+
+  void * mem = fd_ip_new( base_mem, num_arp_entries, num_route_entries );
+  FD_TEST( mem );
+
+  fd_ip_t * ip = fd_ip_join( mem );
+  FD_TEST( ip );
+
+  fd_ip_arp_entry_t * arp_table = fd_ip_arp_table_get( ip );
+
+  /* construct a custom table */
+  ulong arp_table_sz = ip->cur_num_arp_entries = build_arp_table( arp_table, num_arp_entries );
+
+  FD_LOG_NOTICE(( "ARP table:" ));
+  for( ulong j = 0L; j < arp_table_sz; ++j ) {
+    fd_ip_arp_entry_t * arp_entry = arp_table + j;
+
+    if( arp_entry->flags == 0 ) break;
+
+#define IP_FMT          "%3u.%3u.%3u.%3u"
+#define IP_VAR(IP) (((IP)>>030) & 0xffU), \
+                   (((IP)>>020) & 0xffU), \
+                   (((IP)>>010) & 0xffU), \
+                   (((IP)>>000) & 0xffU)
+
+    FD_LOG_NOTICE(( "  " IP_FMT "  %02x:%02x:%02x:%02x:%02x:%02x  %2u  %x",
+          IP_VAR(arp_table[j].dst_ip_addr),
+          arp_table[j].mac_addr[0],
+          arp_table[j].mac_addr[1],
+          arp_table[j].mac_addr[2],
+          arp_table[j].mac_addr[3],
+          arp_table[j].mac_addr[4],
+          arp_table[j].mac_addr[5],
+          arp_table[j].ifindex,
+          arp_table[j].flags ));
+  }
+
+  /* route table */
+
+  fd_ip_route_entry_t * route_table = fd_ip_route_table_get( ip );
+
+  /* construct a custom table */
+  ulong route_table_sz = ip->cur_num_route_entries
+                       = build_route_table( route_table, num_route_entries );
+
+  FD_LOG_NOTICE(( "Routing table:" ));
+  for( ulong j = 0L; j < route_table_sz; ++j ) {
+    fd_ip_route_entry_t * route_entry = route_table + j;
+
+    if( route_entry->flags == 0 ) break;
+
+    FD_LOG_NOTICE(( "  " IP_FMT "  " IP_FMT "  " IP_FMT "  %2u  " IP_FMT "  %2u  %x",
+          IP_VAR(route_table[j].nh_ip_addr),
+          IP_VAR(route_table[j].dst_ip_addr),
+          IP_VAR(route_table[j].dst_netmask),
+          route_table[j].dst_netmask_sz,
+          IP_VAR(route_table[j].src_ip_addr),
+          route_table[j].oif,
+          route_table[j].flags ));
+  }
+
+  /* test some routing */
+
+  test_routes_0( ip );
+  test_routes_1( ip );
+
+  /* construct another routing table */
+
+  route_table_sz = build_route_table_1( route_table, route_table_sz );
+
+  /* test the new routing */
+
+  test_routes_2( ip );
+  test_routes_3( ip );
+
+  /* clean up */
+
+  fd_ip_leave( ip );
+
+  free( base_mem );
+
+  fd_halt();
+
+  return 0;
+}


### PR DESCRIPTION
This PR adds functionality to do the following, needed for XDP kernel bypass:
  Fetch ARP and Routing tables from the kernel via Netlink
  Run a routing algo for an IP address
  generate an ARP request
  prime the kernel ARP table to accept an ARP response for a specific IP address
It is only intended to support Ethernet and IPv4
