### PR TITLE
FD_TEMPL_MBR_ELEM_{VAR,ARRAY} encoding lacks a boundary check #4. Also made zero_rtt return FD_QUIC_PARSE_FAIL instead of zero to avoid looping.

### DIFF
--- a/src/tango/quic/fd_quic.c
+++ b/src/tango/quic/fd_quic.c
@@ -1952,7 +1952,8 @@ fd_quic_handle_v1_zero_rtt( fd_quic_t * quic, fd_quic_conn_t * conn, fd_quic_pkt
   (void)cur_ptr;
   (void)cur_sz;
   FD_DEBUG( FD_LOG_DEBUG(( "stub" )) );
-  return 0;
+  /* since we do not support zero-rtt, simply fail the packet */
+  return FD_QUIC_PARSE_FAIL;
 }
 
 ulong
@@ -2556,6 +2557,11 @@ fd_quic_process_quic_packet_v1( fd_quic_t *     quic,
 
     rc = fd_quic_handle_v1_one_rtt( quic, conn, pkt, cur_ptr, cur_sz );
     if( rc == FD_QUIC_PARSE_FAIL ) return FD_QUIC_PARSE_FAIL;
+  }
+
+  if( rc == 0UL ) {
+    /* this is an error because it causes infinite looping */
+    return FD_QUIC_PARSE_FAIL;
   }
 
   /* if we get here we parsed all the frames, so ack the packet */

--- a/src/tango/quic/templ/fd_quic_encoders.h
+++ b/src/tango/quic/templ/fd_quic_encoders.h
@@ -93,7 +93,7 @@
    remaining bits are all data bits
    checks for capacity before writing */
 #define FD_TEMPL_MBR_ELEM_VARINT(NAME,TYPE)                            \
-    do{                                                                \
+    do {                                                               \
       buf += (cur_bit != 0);                                           \
       cur_bit = 0;                                                     \
       tmp_len = FD_QUIC_ENCODE_VARINT_LEN(frame->NAME);                \
@@ -138,6 +138,9 @@
             (ulong)( tmp_len * 8 ) ));                                 \
       return FD_QUIC_PARSE_FAIL;                                       \
     }                                                                  \
+    if( FD_UNLIKELY( (ulong)buf + tmp_len > (ulong)buf_end ) ) {       \
+      return FD_QUIC_PARSE_FAIL;                                       \
+    }                                                                  \
     fd_memcpy( buf, frame->NAME, tmp_len );                            \
     buf += tmp_len;
 
@@ -158,6 +161,9 @@
             (ulong)BITS_MAX,                                           \
             (ulong)frame->LEN_NAME,                                    \
             (ulong)( tmp_len * 8 ) ));                                 \
+      return FD_QUIC_PARSE_FAIL;                                       \
+    }                                                                  \
+    if( FD_UNLIKELY( (ulong)buf + tmp_len > (ulong)buf_end ) ) {       \
       return FD_QUIC_PARSE_FAIL;                                       \
     }                                                                  \
     fd_memcpy( buf, frame->NAME, tmp_len );                            \


### PR DESCRIPTION
https://github.com/firedancer-io/auditor-internal/issues/4