### PR TITLE
fd_shred: tighten parse constraints, other small changes

### DIFF
--- a/ffi/rust/firedancer-sys/src/ballet/shred.rs
+++ b/ffi/rust/firedancer-sys/src/ballet/shred.rs
@@ -3,7 +3,7 @@ pub use crate::generated::{
     fd_shred_t,
     FD_SHRED_CODE_HEADER_SZ,
     FD_SHRED_DATA_HEADER_SZ,
-    FD_SHRED_SZ,
+    FD_SHRED_MAX_SZ,
 };
 
 pub const FD_SHRED_TYPE_LEGACY_CODE: u8 = 0x5;

--- a/src/ballet/shred/Local.mk
+++ b/src/ballet/shred/Local.mk
@@ -1,4 +1,5 @@
 $(call add-hdrs,fd_shred.h)
 $(call add-objs,fd_shred,fd_ballet)
-$(call make-unit-test,test_shred,test_shred,fd_ballet fd_util fd_reedsol)
+$(call make-unit-test,test_shred,test_shred,fd_ballet fd_util)
+$(call fuzz-test,fuzz_shred_parse,fuzz_shred_parse,fd_ballet fd_util)
 $(call run-unit-test,test_shred,)

--- a/src/ballet/shred/fd_shred.c
+++ b/src/ballet/shred/fd_shred.c
@@ -1,15 +1,61 @@
 #include "fd_shred.h"
 
 fd_shred_t const *
-fd_shred_parse( uchar const * buf ) {
+fd_shred_parse( uchar const * const buf,
+                ulong         const sz ) {
+  ulong total_shred_sz = sz;
+  /* Initial bounds check */
+  if( FD_UNLIKELY( total_shred_sz<fd_ulong_min( FD_SHRED_DATA_HEADER_SZ, FD_SHRED_CODE_HEADER_SZ ) ) ) return NULL;
+
   fd_shred_t const * shred = (fd_shred_t *)buf;
-  /* Validate shred type */
-  uchar shred_type = fd_shred_type( shred->variant );
-  if( FD_UNLIKELY( shred_type!=FD_SHRED_TYPE_MERKLE_DATA &&
-                   shred_type!=FD_SHRED_TYPE_MERKLE_CODE &&
-                   shred->variant!=0xa5 /*FD_SHRED_TYPE_LEGACY_DATA*/ &&
-                   shred->variant!=0x5a /*FD_SHRED_TYPE_LEGACY_CODE*/ ) ) {
+
+  /* Validate shred type.
+     Safe to access because `variant` ends at 0x41, which is <= 0x58 */
+  uchar variant = shred->variant;
+  uchar type = fd_shred_type( variant );
+  if( FD_UNLIKELY( (type!=FD_SHRED_TYPE_MERKLE_DATA) &
+                   (type!=FD_SHRED_TYPE_MERKLE_CODE) &
+                   (variant!=0xa5 /*FD_SHRED_TYPE_LEGACY_DATA*/ ) &
+                   (variant!=0x5a /*FD_SHRED_TYPE_LEGACY_CODE*/ ) ) )
     return NULL;
+
+  /* There are four sections of a shred that can contribute to the size:
+     header, payload, zero-padding, and Merkle proof.  Some of these may
+     have 0 size in certain cases.  sz is the sum of all 4, while for
+     data shreds, shred->data.size == header+payload. */
+  ulong header_sz       = fd_shred_header_sz( variant ); /* between 88 and 89 bytes */
+  ulong merkle_proof_sz = fd_shred_merkle_sz( shred->variant ); /* between 0 and 300 bytes */
+  ulong zero_padding_sz;
+  ulong payload_sz;
+
+  if( FD_LIKELY( type & (FD_SHRED_TYPE_LEGACY_DATA|FD_SHRED_TYPE_MERKLE_DATA) ) ) {
+    if( FD_UNLIKELY( shred->data.size<header_sz ) ) return NULL;
+    payload_sz = (ulong)shred->data.size - header_sz; /* between 0 and USHORT_MAX */
+    if( FD_UNLIKELY( (variant!=FD_SHRED_TYPE_LEGACY_DATA) & (sz<FD_SHRED_MIN_SZ) ) ) return NULL;
+
+    /* legacy data shreds might be shorter than the normal
+       FD_SHRED_MIN_SZ, but they don't have Merkle proofs, so everything
+       after the payload is zero-padding/ignored.  On the other hand,
+       Merkle data shreds might have some zero-padding, but anything
+       between [FD_SHRED_MIN_SZ, sz) is extra bytes after the shred
+       (which we don't care about the contents of but also tolerate).
+       The Merkle proof is not in bytes [sz-merkle_proof_sz, sz) but in
+       [FD_SHRED_MIN_SZ-merkle_proof_sz, FD_SHRED_MIN_SZ).  From above,
+       we know sz >= FD_SHRED_MIN_SZ in this case. */
+    ulong effective_sz = fd_ulong_if( type==FD_SHRED_TYPE_MERKLE_DATA, FD_SHRED_MIN_SZ, sz );
+    if( FD_UNLIKELY( effective_sz < header_sz+merkle_proof_sz+payload_sz ) ) return NULL;
+    zero_padding_sz = effective_sz - header_sz - merkle_proof_sz - payload_sz;
   }
+  else if( FD_LIKELY( type & (FD_SHRED_TYPE_LEGACY_CODE|FD_SHRED_TYPE_MERKLE_CODE) ) ) {
+    zero_padding_sz = 0UL;
+    /* Payload size is not specified directly, but the whole shred must
+       be FD_SHRED_MAX_SZ. */
+    if( FD_UNLIKELY( header_sz+merkle_proof_sz+zero_padding_sz > FD_SHRED_MAX_SZ ) ) return NULL;
+    payload_sz      = FD_SHRED_MAX_SZ - header_sz - merkle_proof_sz - zero_padding_sz;
+  }
+  else return NULL;
+
+  if( FD_UNLIKELY( sz < header_sz + payload_sz + zero_padding_sz + merkle_proof_sz ) ) return NULL;
+
   return shred;
 }

--- a/src/ballet/shred/fuzz_shred_parse.c
+++ b/src/ballet/shred/fuzz_shred_parse.c
@@ -1,0 +1,46 @@
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../util/fd_util.h"
+#include "fd_shred.h"
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  /* Set up shell without signal handlers */
+  putenv( "FD_LOG_BACKTRACE=0" );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+  return 0;
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         size ) {
+
+  fd_shred_t const * shred = fd_shred_parse( data, size );
+  if( shred==NULL ) return 0;
+
+  if( fd_shred_merkle_cnt( shred->variant ) ) {
+    if( (ulong)(fd_shred_merkle_nodes( shred )+fd_shred_merkle_cnt( shred->variant )) > (ulong)(data+size) ) __builtin_trap();
+  }
+  switch( fd_shred_type( shred->variant ) ) {
+    case FD_SHRED_TYPE_LEGACY_CODE:
+    case FD_SHRED_TYPE_MERKLE_CODE:
+      if( fd_shred_code_payload( shred )+fd_shred_payload_sz( shred ) > data+size ) __builtin_trap();
+      break;
+    case FD_SHRED_TYPE_LEGACY_DATA:
+    case FD_SHRED_TYPE_MERKLE_DATA:
+      if( fd_shred_data_payload( shred )+fd_shred_payload_sz( shred ) > data+size ) __builtin_trap();
+      break;
+    default:
+      __builtin_trap();
+      break;
+  }
+
+  return 0;
+}

--- a/src/ballet/shred/test_shred.c
+++ b/src/ballet/shred/test_shred.c
@@ -1,22 +1,21 @@
 #include "fd_shred.h"
-#include <stddef.h>
 
-FD_STATIC_ASSERT( offsetof( fd_shred_t, signature       )==0x00, unit_test );
-FD_STATIC_ASSERT( offsetof( fd_shred_t, variant         )==0x40, unit_test );
-FD_STATIC_ASSERT( offsetof( fd_shred_t, slot            )==0x41, unit_test );
-FD_STATIC_ASSERT( offsetof( fd_shred_t, idx             )==0x49, unit_test );
-FD_STATIC_ASSERT( offsetof( fd_shred_t, version         )==0x4d, unit_test );
-FD_STATIC_ASSERT( offsetof( fd_shred_t, fec_set_idx     )==0x4f, unit_test );
+FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, signature       )==0x00, unit_test );
+FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, variant         )==0x40, unit_test );
+FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, slot            )==0x41, unit_test );
+FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, idx             )==0x49, unit_test );
+FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, version         )==0x4d, unit_test );
+FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, fec_set_idx     )==0x4f, unit_test );
 
-FD_STATIC_ASSERT( offsetof( fd_shred_t, code.data_cnt   )==0x53, unit_test );
-FD_STATIC_ASSERT( offsetof( fd_shred_t, code.code_cnt   )==0x55, unit_test );
-FD_STATIC_ASSERT( offsetof( fd_shred_t, code.idx        )==0x57, unit_test );
+FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, code.data_cnt   )==0x53, unit_test );
+FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, code.code_cnt   )==0x55, unit_test );
+FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, code.idx        )==0x57, unit_test );
 
-FD_STATIC_ASSERT( offsetof( fd_shred_t, data.parent_off )==0x53, unit_test );
-FD_STATIC_ASSERT( offsetof( fd_shred_t, data.flags      )==0x55, unit_test );
-FD_STATIC_ASSERT( offsetof( fd_shred_t, data.size       )==0x56, unit_test );
+FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, data.parent_off )==0x53, unit_test );
+FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, data.flags      )==0x55, unit_test );
+FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, data.size       )==0x56, unit_test );
 
-static uchar const fixture_legacy_coding_shred[FD_SHRED_SZ] = {
+static uchar const fixture_legacy_coding_shred[FD_SHRED_MAX_SZ] = {
   0x12,0x5f,0x43,0x31,0xbe,0x64,0x52,0x07,0x88,0xc8,0x2b,0x22,0x71,0x4a,0xb9,0x2c,
   0xa9,0x46,0xfb,0x2f,0xc6,0x50,0xc6,0xf8,0x30,0x23,0x4e,0x1e,0x96,0x76,0xf3,0xab,
   0x6f,0xf1,0x7c,0x41,0x2e,0xe7,0x39,0x37,0x6b,0x37,0x94,0x60,0x14,0x92,0x65,0x4e,
@@ -31,7 +30,7 @@ static uchar const fixture_legacy_coding_shred[FD_SHRED_SZ] = {
   0xf5,0xa2,0xeb,0xda,0xee,0x9d,0xb3,
 };
 
-static uchar const fixture_legacy_data_shred[FD_SHRED_SZ] = {
+static uchar const fixture_legacy_data_shred[FD_SHRED_MAX_SZ] = {
   0xfb,0x2b,0x54,0xe1,0xe8,0x81,0x25,0xb2,0xde,0xe1,0x9a,0xd4,0x94,0x41,0x1c,0x31,
   0xeb,0xc2,0x3a,0xc4,0x85,0xfa,0x1b,0x8c,0x22,0x69,0x18,0xcb,0xf6,0x6d,0xac,0x25,
   0x73,0xd0,0x1c,0x76,0x14,0xfa,0x1f,0x2c,0x94,0xd2,0xa2,0x13,0x42,0xee,0x8f,0x33,
@@ -46,7 +45,7 @@ static uchar const fixture_legacy_data_shred[FD_SHRED_SZ] = {
   0x6b,0x51,0x6a,0x54,0x9b,0xcf,0x39,
 };
 
-static uchar const fixture_legacy_data_shred_empty[FD_SHRED_SZ] = {
+static uchar const fixture_legacy_data_shred_empty[FD_SHRED_MAX_SZ] = {
   0x61,0x57,0xad,0x27,0x31,0xa7,0xf6,0x15,0x29,0xd2,0x29,0x6a,0x88,0xad,0xd9,0x81,
   0x84,0xb7,0xdf,0x1c,0x7f,0x92,0x45,0x12,0x0f,0x42,0x31,0x14,0xcf,0xaa,0xe1,0x6d,
   0x89,0xd0,0x12,0x0e,0x70,0x57,0xc0,0xad,0x65,0x27,0xc3,0x68,0x44,0x10,0x0f,0x90,
@@ -65,12 +64,12 @@ main( int     argc,
   /* Test shred parsing rules. */
   for( uint i = 0; i < 0x100U; i++ ) {
     /* Create fake shred */
-    uchar buf[FD_SHRED_SZ] = {0};
+    uchar buf[FD_SHRED_MAX_SZ] = {0};
     buf[0x40] = (uchar)i;
 
     /* Make sure our buffer is larger than the smallest size of the largest shred variant. */
-    _Static_assert( sizeof(buf) > sizeof(fd_shred_t)+(((1<<4)-1))*FD_SHRED_MERKLE_NODE_SZ,
-                    "buffer is too small to fit coding shred with 15 merkle nodes" );
+    FD_STATIC_ASSERT( sizeof(buf) > sizeof(fd_shred_t)+(((1<<4)-1))*FD_SHRED_MERKLE_NODE_SZ,
+                      "buffer must be large enough to fit shred with 15 merkle nodes" );
 
     /* Test type detection */
     int is_legacy =  i      ==0x5a ||  i      ==0xa5;
@@ -79,42 +78,47 @@ main( int     argc,
     int is_code   =  i      ==0x5a || (i&0xf0)==0x40;
     int is_valid  = (is_legacy^is_merkle) && (is_data^is_code);
 
-    /* Test merkle node count */
-    uint merkle_cnt = fd_shred_merkle_cnt( (uchar)i );
-    FD_TEST( (is_merkle || merkle_cnt==0) && merkle_cnt<=16 );
+    /* Find sizes for shred type */
+    ulong header_sz = 0;
+    if( FD_LIKELY( is_data   ) ) header_sz = 0x58;
+    if( FD_LIKELY( is_code   ) ) header_sz = 0x59;
+    ulong merkle_sz = 0;
+    if( FD_LIKELY( is_merkle ) ) merkle_sz = (i&0x0f)*FD_SHRED_MERKLE_NODE_SZ;
+    ulong payload_sz = ((is_merkle&is_data) ? FD_SHRED_MIN_SZ : FD_SHRED_MAX_SZ) - header_sz - merkle_sz;
+
+    if( is_data )
+      *(ushort*)(buf+0x56) = (ushort)(payload_sz + header_sz); /* write data.size */
 
     /* Test type-specific bounds checks */
     if( FD_LIKELY( is_valid )) {
-      /* Find sizes for shred type */
-      ulong header_sz = 0;
-      if( FD_LIKELY( is_data   ) ) header_sz = 0x58;
-      if( FD_LIKELY( is_code   ) ) header_sz = 0x59;
-      ulong merkle_sz = 0;
-      if( FD_LIKELY( is_merkle ) ) merkle_sz = ((i&0x0f)+1)*FD_SHRED_MERKLE_NODE_SZ;
-      ulong payload_sz = sizeof(buf) - header_sz - merkle_sz;
+      /* Test merkle node count */
+      uint merkle_cnt = fd_shred_merkle_cnt( (uchar)i );
+      FD_TEST( (is_merkle || merkle_cnt==0) && merkle_cnt<=16 );
 
       FD_TEST( header_sz > 0 );
-      FD_TEST( !!merkle_sz==is_merkle );
+      FD_TEST( !merkle_sz || is_merkle ); /* !is_merkle implies merkle_sz == 0 */
 
       FD_LOG_NOTICE(( "shred variant 0x%02x: type=%s header_sz=0x%lx merkle_sz=0x%lx payload_sz=0x%lx",
                       i, is_data ? "data" : "code", header_sz, merkle_sz, payload_sz ));
 
       /* Test with min buffer size */
       fd_shred_t const * shred;
-      FD_TEST( (shred = fd_shred_parse( buf ))!=NULL );
+      FD_TEST( (shred = fd_shred_parse( buf, sizeof(buf) ))!=NULL );
       FD_TEST( i==fd_shred_variant( fd_shred_type( shred->variant ), (uchar)fd_shred_merkle_cnt( shred->variant ) ) );
       FD_TEST( fd_shred_header_sz ( shred->variant )==header_sz  );
-      FD_TEST( fd_shred_payload_sz( shred->variant )==payload_sz );
+      FD_TEST( fd_shred_payload_sz( shred          )==payload_sz );
       FD_TEST( fd_shred_merkle_sz ( shred->variant )==merkle_sz  );
     } else {
       FD_LOG_NOTICE(( "shred type 0x%02x: invalid", i ));
       /* Invalid shred types should always be rejected irrespective of buffer size */
-      FD_TEST( fd_shred_parse( buf )==NULL );
+      FD_TEST( fd_shred_parse( buf, sizeof(buf) )==NULL );
     }
   }
 
+# define PARSE(x) fd_shred_parse( x, sizeof(x) )
+
   /* Parse legacy data shred. */
-  shred = fd_shred_parse( fixture_legacy_data_shred );
+  shred = PARSE( fixture_legacy_data_shred );
   FD_TEST( shred != NULL );
   FD_TEST( !memcmp( shred->signature, fixture_legacy_data_shred, sizeof(shred->signature) ) );
   FD_TEST( fd_shred_type      ( shred->variant )==FD_SHRED_TYPE_LEGACY_DATA );
@@ -127,7 +131,7 @@ main( int     argc,
   FD_TEST( shred->data.flags     ==     0xe5 );
 
   /* Parse empty legacy data shred. */
-  shred = fd_shred_parse( fixture_legacy_data_shred_empty );
+  shred = PARSE( fixture_legacy_data_shred_empty );
   FD_TEST( shred != NULL );
   FD_TEST( !memcmp( shred->signature, fixture_legacy_data_shred_empty, sizeof(shred->signature) ) );
   FD_TEST( fd_shred_type      ( shred->variant )==FD_SHRED_TYPE_LEGACY_DATA );
@@ -141,7 +145,7 @@ main( int     argc,
   FD_TEST( shred->data.size      ==     0x58 );
 
   /* Parse legacy coding shred. */
-  shred = fd_shred_parse( fixture_legacy_coding_shred );
+  shred = PARSE( fixture_legacy_coding_shred );
   FD_TEST( shred != NULL );
   FD_TEST( !memcmp( shred->signature, fixture_legacy_coding_shred, sizeof(shred->signature) ) );
   FD_TEST( fd_shred_type      ( shred->variant )==FD_SHRED_TYPE_LEGACY_CODE );
@@ -153,6 +157,8 @@ main( int     argc,
   FD_TEST( shred->code.data_cnt==        32 );
   FD_TEST( shred->code.code_cnt==        58 );
   FD_TEST( shred->code.idx     ==        43 );
+
+# undef PARSE
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();


### PR DESCRIPTION
Basically rewrote the parsing function, added a fuzzer. 

Other assorted small changes, mostly changes that Richie made, plus a few fixes, many of which Josh also made

Note: Way back when, Tom suggested some changes on #123 that we never made, but it's nothing critical.