### PR TITLE
tiles: add net and netmux tiles

### DIFF
--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -5,7 +5,7 @@ ifdef FD_HAS_DOUBLE
 
 .PHONY: fdctl run monitor cargo
 
-$(call add-objs,main1 config security utility run/run run/tiles/dedup run/tiles/pack run/tiles/quic run/tiles/verify keygen ready monitor/monitor monitor/helper configure/configure configure/large_pages configure/sysctl configure/shmem configure/xdp configure/xdp_leftover configure/ethtool configure/workspace_leftover configure/workspace,fd_fdctl)
+$(call add-objs,main1 config security utility run/run run/tiles/tiles run/tiles/net run/tiles/netmux run/tiles/dedup run/tiles/pack run/tiles/quic run/tiles/verify run/tiles/bank keygen ready monitor/monitor monitor/helper configure/configure configure/large_pages configure/sysctl configure/shmem configure/xdp configure/xdp_leftover configure/ethtool configure/workspace_leftover configure/workspace,fd_fdctl)
 $(call make-bin-rust,fdctl,main,fd_fdctl fd_disco fd_ballet fd_tango fd_util fd_quic solana_validator_fd)
 $(OBJDIR)/obj/app/fdctl/configure/xdp.o: src/tango/xdp/fd_xdp_redirect_prog.o
 $(OBJDIR)/obj/app/fdctl/config.o: src/app/fdctl/config/default.toml

--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -12,21 +12,28 @@
 /* Maximum size of the string describing the CPU affinity of Firedancer */
 #define AFFINITY_SZ 256
 
+typedef enum {
+  wksp_netmux_inout,
+  wksp_quic_verify,
+  wksp_verify_dedup,
+  wksp_dedup_pack,
+  wksp_pack_bank,
+  wksp_bank_shred,
+  wksp_net,
+  wksp_netmux,
+  wksp_quic,
+  wksp_verify,
+  wksp_dedup,
+  wksp_pack,
+  wksp_bank,
+} workspace_kind_t;
+
+FD_FN_CONST char *
+workspace_kind_str( workspace_kind_t kind );
+
 typedef struct {
-  enum {
-    wksp_quic_verify,
-    wksp_verify_dedup,
-    wksp_dedup_pack,
-    wksp_pack_bank,
-    wksp_bank_shred,
-    wksp_quic,
-    wksp_verify,
-    wksp_dedup,
-    wksp_pack,
-    wksp_bank,
-  } kind;
+  workspace_kind_t kind;
   char * name;
-  ulong kind_idx;
   ulong page_size;
   ulong num_pages;
 } workspace_config_t;
@@ -100,6 +107,7 @@ typedef struct {
 
   struct {
     char affinity[ AFFINITY_SZ ];
+    uint net_tile_count;
     uint verify_tile_count;
     uint bank_tile_count;
   } layout;
@@ -111,13 +119,6 @@ typedef struct {
     ulong workspaces_cnt;
     workspace_config_t workspaces[ 256 ];
   } shmem;
-
-  struct {
-    char   interface[ IF_NAMESIZE ];
-    uint   ip_addr;
-    uchar  mac_addr[6];
-    char   xdp_mode[ 8 ];
-  } net;
 
   struct {
     int sandbox;
@@ -134,6 +135,19 @@ typedef struct {
 
   struct {
     struct {
+      char   interface[ IF_NAMESIZE ];
+      uint   ip_addr;
+      uchar  mac_addr[6];
+      char   xdp_mode[ 8 ];
+
+      uint xdp_rx_queue_size;
+      uint xdp_tx_queue_size;
+      uint xdp_aio_depth;
+
+      uint send_buffer_size;
+    } net;
+
+    struct {
       ushort transaction_listen_port;
       ushort quic_transaction_listen_port;
 
@@ -142,9 +156,7 @@ typedef struct {
       uint max_concurrent_handshakes;
       uint max_inflight_quic_packets;
       uint tx_buf_size;
-      uint xdp_rx_queue_size;
-      uint xdp_tx_queue_size;
-      uint xdp_aio_depth;
+
     } quic;
 
     struct {

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -257,7 +257,8 @@ dynamic_port_range = "8000-10000"
 #
 # Consider a validator node needing to do six essential pieces of work:
 #
-#  1. quic      Receive client transactions on a network device
+#  1. quic      Parse received QUIC packets into transactions, and respond
+#               to the client appropriately
 #  2. verify    Verify the signature of the transaction, dropping invalid ones
 #  3. dedup     Drop duplicated or repeatedly sent transactions
 #  4. pack      Decide which transactions to execute, ordering them by
@@ -306,7 +307,16 @@ dynamic_port_range = "8000-10000"
     #
     # It is suggested to use all available CPU cores for Firedancer, so that the
     # Solana network can run as fast as possible.
-    affinity = "0-13"
+    affinity = "0-14"
+
+    # How many net tiles to run.  Each networking tile will service exactly one
+    # queue from a network device being listened to.  If there are less net
+    # tiles than queues, some queues will not get drained and packets will be
+    # lost, and if there are more tiles than queues, some tiles will spin a CPU
+    # core doing nothing since no packets will ever arrive.
+    #
+    # See the comments for the [tiles.net] section below for more information.
+    net_tile_count = 4
 
     # How many verify tiles to run. Currently this also configures the number of
     # QUIC tiles to run. QUIC and verify tiles are connected 1:1.
@@ -366,29 +376,61 @@ dynamic_port_range = "8000-10000"
     # programs. Same as above.
     min_kernel_huge_pages = 512
 
-
-[net]
-    # Which interface to bind to for QUIC and Turbine traffic. If
-    # developing under a network namespace with [netns] enabled, this
-    # should be the same as [development.netns.interface0].
-    #
-    # If this is empty, the default is interface used to route to 8.8.8.8,
-    # you can check what this is with `ip route get 8.8.8.8`
-    interface = ""
-
-    # Firedancer uses XDP for fast packet processing. XDP supports two
-    # modes, XDP_SKB and XDP_DRV. XDP_DRV is preferred as it is faster,
-    # but is not supported by all drivers.
-    xdp_mode = "skb"
-
-
-
-
 # Tiles are described in detail in the layout section above. While the layout
 # configuration determines how many of each tile to place on which CPU core to
 # create a functioning system, below is the individual settings that can change
 # behavior of the tiles.
 [tiles]
+    # A networking tile is responsible for sending and receiving packets on the
+    # the network.  Each networking tile is bound to a specific queue on a
+    # network device.  For example, if you have one network device with four
+    # queues, you must run four net tiles.
+    #
+    # Net tiles will multiplex in both directions, fanning out packets to
+    # multiple parts of Firedancer that can receive and handled them, like QUIC
+    # tiles and the Turbine retransmission engine.  Then also fanning in from
+    # these various network senders to transmit on the queues we have available.
+    [tiles.net]
+        # Which interface to bind to for network traffic. Currently only one
+        # interface is supported for networking.  If this is empty, the default
+        # is interface used to route to 8.8.8.8, you can check what this is with
+        # `ip route get 8.8.8.8`
+        #
+        # If developing under a network namespace with [netns] enabled, this
+        # should be the same as [development.netns.interface0].
+        interface = ""
+
+        # Firedancer uses XDP for fast packet processing. XDP supports two
+        # modes, XDP_SKB and XDP_DRV. XDP_DRV is preferred as it is faster,
+        # but is not supported by all drivers.
+        xdp_mode = "skb"
+
+        # XDP has a metadata queue with memory defined by the driver or kernel
+        # that is specially mapped into userspace. With XDP mode XDP_DRV this
+        # could be MMIO to a PCIE device, but in SKB it's kernel memory made
+        # available to userspace that is copied in and out of the device.
+        #
+        # This setting defines the size of these metadata queues. A larger value
+        # is probably better if supported by the hardware, as we will drop less
+        # packets when bursting in high bandwidth scenarios.
+        #
+        # TODO: This probably shouldn't be configurable, we should just use the
+        # maximum available to the hardware?
+        xdp_rx_queue_size = 4096
+        xdp_tx_queue_size = 4096
+
+        # When writing multiple queue entries to XDP, we may wish to batch them
+        # together if it's expensive to do them one at a time. This might be the
+        # case for example if the writes go directly to the network device. A
+        # large batch size may not be ideal either, as it adds latency and
+        # jitter to packet handling.
+        xdp_aio_depth = 256
+
+        # The maximum number of messages in-flight between a net tile and
+        # downstream consumers, after which additional messages begin being
+        # dropped. TODO: ... Should this really be configurable?
+        send_buffer_size = 8192
+
     # QUIC tiles are responsible for implementing the QUIC protocol, including
     # binding and listening to network devices on the system to receive
     # transactions from clients, and forwarding well formed (but not necessarily
@@ -450,27 +492,6 @@ dynamic_port_range = "8000-10000"
         # TODO: This should be removed. We never transmit stream data so this
         # should be unused.
         tx_buf_size = 4096
-
-        # XDP has a metadata queue with memory defined by the driver or kernel
-        # that is specially mapped into userspace. With XDP mode XDP_DRV this
-        # could be MMIO to a PCIE device, but in SKB it's kernel memory made
-        # available to userspace that is copied in and out of the device.
-        #
-        # This setting defines the size of these metadata queues. A larger value
-        # is probably better if supported by the hardware, as we will drop less
-        # packets when bursting in high bandwidth scenarios.
-        #
-        # TODO: This probably shouldn't be configurable, we should just use the
-        # maximum available to the hardware?
-        xdp_rx_queue_size = 4096
-        xdp_tx_queue_size = 4096
-
-        # When writing multiple queue entries to XDP, we may wish to batch them
-        # together if it's expensive to do them one at a time. This might be the
-        # case for example if the writes go directly to the network device. A
-        # large batch size may not be ideal either, as it adds latency and
-        # jitter to packet handling.
-        xdp_aio_depth = 256
 
     # Verify tiles perform initial verification of incoming transactions, making
     # sure that they have a valid signature.

--- a/src/app/fdctl/configure/ethtool.c
+++ b/src/app/fdctl/configure/ethtool.c
@@ -92,17 +92,17 @@ static void
 init( config_t * const config ) {
   /* we need one channel for both TX and RX on the NIC for each QUIC
      tile, but the interface probably defaults to one channel total */
-  if( FD_UNLIKELY( device_is_bonded( config->net.interface ) ) ) {
+  if( FD_UNLIKELY( device_is_bonded( config->tiles.net.interface ) ) ) {
     /* if using a bonded device, we need to set channels on the
        underlying devices. */
     char line[ 4096 ];
-    device_read_slaves( config->net.interface, line );
+    device_read_slaves( config->tiles.net.interface, line );
     char * saveptr;
     for( char * token=strtok_r( line , " \t", &saveptr ); token!=NULL; token=strtok_r( NULL, " \t", &saveptr ) ) {
       init_device( token, config->layout.verify_tile_count );
     }
   } else {
-    init_device( config->net.interface, config->layout.verify_tile_count );
+    init_device( config->tiles.net.interface, config->layout.verify_tile_count );
   }
 }
 
@@ -146,11 +146,11 @@ check_device( const char * device,
   if( FD_UNLIKELY( current_channels != expected_channel_count ) ) {
     if( FD_UNLIKELY( !supports_channels ) )
       FD_LOG_ERR(( "Network device `%s` does not support setting number of channels, "
-                   "but you are running with more than one QUIC tile (expected {%u}), "
+                   "but you are running with more than one net tile (expected {%u}), "
                    "and there must be one channel per tile. You can either use a NIC "
                    "that supports multiple channels, or run Firedancer with only one "
-                   "QUIC tile. You can configure Firedancer to run with only one QUIC "
-                   "tile by setting `layout.verify_tile_count` to 1 in your "
+                   "net tile. You can configure Firedancer to run with only one QUIC "
+                   "tile by setting `layout.net_tile_count` to 1 in your "
                    "configuration file. It is not recommended to do this in production "
                    "as it will limit network performance.",
                    device, expected_channel_count ));
@@ -165,15 +165,15 @@ check_device( const char * device,
 
 static configure_result_t
 check( config_t * const config ) {
-  if( FD_UNLIKELY( device_is_bonded( config->net.interface ) ) ) {
+  if( FD_UNLIKELY( device_is_bonded( config->tiles.net.interface ) ) ) {
     char line[ 4096 ];
-    device_read_slaves( config->net.interface, line );
+    device_read_slaves( config->tiles.net.interface, line );
     char * saveptr;
     for( char * token=strtok_r( line, " \t", &saveptr ); token!=NULL; token=strtok_r( NULL, " \t", &saveptr ) ) {
-      CHECK( check_device( token, config->layout.verify_tile_count ) );
+      CHECK( check_device( token, config->layout.net_tile_count ) );
     }
   } else {
-    CHECK( check_device( config->net.interface, config->layout.verify_tile_count ) );
+    CHECK( check_device( config->tiles.net.interface, config->layout.net_tile_count ) );
   }
 
   CONFIGURE_OK();

--- a/src/app/fdctl/configure/large_pages.c
+++ b/src/app/fdctl/configure/large_pages.c
@@ -52,12 +52,15 @@ expected_pages( config_t * const config, uint out[2] ) {
 
   for( ulong i=0; i<config->shmem.workspaces_cnt; i++ ) {
     switch( config->shmem.workspaces[ i ].kind ) {
+      case wksp_netmux_inout:
       case wksp_quic_verify:
       case wksp_verify_dedup:
       case wksp_dedup_pack:
       case wksp_pack_bank:
       case wksp_bank_shred:
         break;
+      case wksp_net:
+      case wksp_netmux:
       case wksp_quic:
       case wksp_verify:
       case wksp_dedup:

--- a/src/app/fdctl/configure/xdp.c
+++ b/src/app/fdctl/configure/xdp.c
@@ -28,13 +28,13 @@ FD_IMPORT_BINARY( fd_xdp_redirect_prog, "src/tango/xdp/fd_xdp_redirect_prog.o" )
 static void
 init( config_t * const config ) {
   if( FD_UNLIKELY( config->development.netns.enabled ) )
-    enter_network_namespace( config->net.interface );
+    enter_network_namespace( config->tiles.net.interface );
 
   uint mode = 0;
-  if(      FD_LIKELY( !strcmp( config->net.xdp_mode, "skb" ) ) ) mode = XDP_FLAGS_SKB_MODE;
-  else if( FD_LIKELY( !strcmp( config->net.xdp_mode, "drv" ) ) ) mode = XDP_FLAGS_DRV_MODE;
-  else if( FD_LIKELY( !strcmp( config->net.xdp_mode, "hw"  ) ) ) mode = XDP_FLAGS_HW_MODE;
-  else FD_LOG_ERR(( "unknown XDP mode `%s`", config->net.xdp_mode ));
+  if(      FD_LIKELY( !strcmp( config->tiles.net.xdp_mode, "skb" ) ) ) mode = XDP_FLAGS_SKB_MODE;
+  else if( FD_LIKELY( !strcmp( config->tiles.net.xdp_mode, "drv" ) ) ) mode = XDP_FLAGS_DRV_MODE;
+  else if( FD_LIKELY( !strcmp( config->tiles.net.xdp_mode, "hw"  ) ) ) mode = XDP_FLAGS_HW_MODE;
+  else FD_LOG_ERR(( "unknown XDP mode `%s`", config->tiles.net.xdp_mode ));
 
   if( FD_UNLIKELY( fd_xdp_init( config->name,
                                 0750,
@@ -43,7 +43,7 @@ init( config_t * const config ) {
     FD_LOG_ERR(( "fd_xdp_init failed" ));
 
   if( FD_UNLIKELY( fd_xdp_hook_iface( config->name,
-                                      config->net.interface,
+                                      config->tiles.net.interface,
                                       mode,
                                       fd_xdp_redirect_prog,
                                       fd_xdp_redirect_prog_sz ) ) )
@@ -70,7 +70,7 @@ init( config_t * const config ) {
      small performance hit for other traffic, but we only
      redirect packets destined for our target IP and port so
      it will not otherwise interfere. */
-  if( FD_LIKELY( strcmp( config->net.interface, "lo" ) ) ) {
+  if( FD_LIKELY( strcmp( config->tiles.net.interface, "lo" ) ) ) {
     if( FD_UNLIKELY( fd_xdp_hook_iface( config->name,
                                         "lo",
                                         mode,
@@ -82,7 +82,7 @@ init( config_t * const config ) {
 
   ushort udp_ports[] = { config->tiles.quic.transaction_listen_port, config->tiles.quic.quic_transaction_listen_port };
   if( FD_UNLIKELY( fd_xdp_listen_udp_ports( config->name,
-                                            config->net.ip_addr,
+                                            config->tiles.net.ip_addr,
                                             2,
                                             udp_ports,
                                             1 ) ) )
@@ -106,7 +106,7 @@ fini( config_t * const config ) {
   nanosleep1( 1, 0 );
 
   char path[ PATH_MAX ];
-  snprintf1( path, PATH_MAX, "/sys/fs/bpf/%s/%s", config->name, config->net.interface );
+  snprintf1( path, PATH_MAX, "/sys/fs/bpf/%s/%s", config->name, config->tiles.net.interface );
   if( FD_UNLIKELY( rmdir( path ) && errno != ENOENT ) ) FD_LOG_ERR(( "rmdir failed (%i-%s)", errno, fd_io_strerror( errno ) ));
   snprintf1( path, PATH_MAX, "/sys/fs/bpf/%s/lo", config->name );
   if( FD_UNLIKELY( rmdir( path ) && errno != ENOENT ) ) FD_LOG_ERR(( "rmdir failed (%i-%s)", errno, fd_io_strerror( errno ) ));
@@ -130,8 +130,8 @@ check( config_t * const config ) {
   snprintf1( xdp_path, PATH_MAX, "/sys/fs/bpf/%s/udp_dsts", config->name );
   CHECK( check_file( xdp_path,      config->uid, config->uid, S_IFREG | S_IRUSR | S_IWUSR | S_IRGRP ) );
 
-  char * interfaces[] = { config->net.interface, "lo" };
-  ulong interfaces_sz = !strcmp( config->net.interface, "lo" ) ? 1 : 2;
+  char * interfaces[] = { config->tiles.net.interface, "lo" };
+  ulong interfaces_sz = !strcmp( config->tiles.net.interface, "lo" ) ? 1 : 2;
   for( ulong i=0; i<interfaces_sz; i++ ) {
     snprintf1( xdp_path, PATH_MAX, "/sys/fs/bpf/%s/%s/xdp_link", config->name, interfaces[i] );
     CHECK( check_file( xdp_path,      config->uid, config->uid, S_IFREG | S_IRUSR | S_IWUSR | S_IRGRP ) );

--- a/src/app/fdctl/monitor/monitor.c
+++ b/src/app/fdctl/monitor/monitor.c
@@ -2,6 +2,7 @@
 
 #include "helper.h"
 #include "../run/run.h"
+#include "../run/tiles/tiles.h"
 #include "../../../disco/fd_disco.h"
 
 #include <stdio.h>
@@ -146,7 +147,7 @@ static void write_stdout( char * buf, ulong buf_sz ) {
 
 static int stop1 = 0;
 
-#define FD_MONITOR_TEXT_BUF_SZ 16384
+#define FD_MONITOR_TEXT_BUF_SZ 32768
 char buffer[ FD_MONITOR_TEXT_BUF_SZ ];
 char buffer2[ FD_MONITOR_TEXT_BUF_SZ ];
 
@@ -198,27 +199,44 @@ run_monitor( config_t * const config,
   ulong tile_cnt = 0;
   for( ulong i=0; i<config->shmem.workspaces_cnt; i++ ) {
     switch( config->shmem.workspaces[ i ].kind ) {
+      case wksp_netmux_inout:
       case wksp_quic_verify:
       case wksp_verify_dedup:
       case wksp_dedup_pack:
       case wksp_pack_bank:
       case wksp_bank_shred:
         break;
+      case wksp_net:
+        tile_cnt += config->layout.net_tile_count;
+        break;
+      case wksp_netmux:
+        tile_cnt += 1;
+        break;
       case wksp_quic:
       case wksp_verify:
+        tile_cnt += config->layout.verify_tile_count;
+        break;
       case wksp_dedup:
+        tile_cnt += 1;
+        break;
       case wksp_pack:
+        tile_cnt += 1;
+        break;
       case wksp_bank:
-        tile_cnt++;
+        tile_cnt += config->layout.bank_tile_count;
         break;
     }
   }
 
   ulong link_cnt =
-    config->layout.verify_tile_count + // quic <-> verify
-    config->layout.verify_tile_count + // verify <-> dedup
-    1 +                                // dedup <-> pack
-    config->layout.bank_tile_count;    // pack <-> bank
+    config->layout.net_tile_count +    // net -> netmux
+    config->layout.net_tile_count +    // netmux -> net
+    config->layout.verify_tile_count + // quic -> netmux
+    config->layout.verify_tile_count + // netmux -> quic
+    config->layout.verify_tile_count + // quic -> verify
+    config->layout.verify_tile_count + // verify -> dedup
+    1 +                                // dedup -> pack
+    config->layout.bank_tile_count;    // pack -> bank
 
   tile_t * tiles = fd_alloca( alignof(tile_t *), sizeof(tile_t)*tile_cnt );
   link_t * links = fd_alloca( alignof(link_t *), sizeof(link_t)*link_cnt );
@@ -228,10 +246,48 @@ run_monitor( config_t * const config,
   ulong link_idx = 0;
   for( ulong j=0; j<config->shmem.workspaces_cnt; j++ ) {
     workspace_config_t * wksp = &config->shmem.workspaces[ j ];
-    const uchar * pod = workspace_pod_join( config->name, wksp->name, wksp->kind_idx );
+    const uchar * pod = workspace_pod_join( config->name, wksp->name );
 
     char buf[ 64 ];
     switch( wksp->kind ) {
+      case wksp_netmux_inout:
+        for( ulong i=0; i<config->layout.net_tile_count; i++ ) {
+          links[ link_idx ].src_name = "net";
+          links[ link_idx ].dst_name = "netmux";
+          links[ link_idx ].mcache = fd_mcache_join( fd_wksp_pod_map( pods[ j ], snprintf1( buf, 64, "net-out-mcache%lu", i ) ) );
+          if( FD_UNLIKELY( !links[ link_idx ].mcache ) ) FD_LOG_ERR(( "fd_mcache_join failed" ));
+          links[ link_idx ].fseq = fd_fseq_join( fd_wksp_pod_map( pods[ j ], snprintf1( buf, 64, "net-out-fseq%lu", i ) ) );
+          if( FD_UNLIKELY( !links[ link_idx ].fseq ) ) FD_LOG_ERR(( "fd_fseq_join failed" ));
+          link_idx++;
+        }
+        for( ulong i=0; i<config->layout.verify_tile_count; i++ ) {
+          links[ link_idx ].src_name = "quic";
+          links[ link_idx ].dst_name = "netmux";
+          links[ link_idx ].mcache = fd_mcache_join( fd_wksp_pod_map( pods[ j ], snprintf1( buf, 64, "quic-out-mcache%lu", i ) ) );
+          if( FD_UNLIKELY( !links[ link_idx ].mcache ) ) FD_LOG_ERR(( "fd_mcache_join failed" ));
+          links[ link_idx ].fseq = fd_fseq_join( fd_wksp_pod_map( pods[ j ], snprintf1( buf, 64, "quic-out-fseq%lu", i ) ) );
+          if( FD_UNLIKELY( !links[ link_idx ].fseq ) ) FD_LOG_ERR(( "fd_fseq_join failed" ));
+          link_idx++;
+        }
+        for( ulong i=0; i<config->layout.net_tile_count; i++ ) {
+          links[ link_idx ].src_name = "netmux";
+          links[ link_idx ].dst_name = "net";
+          links[ link_idx ].mcache = fd_mcache_join( fd_wksp_pod_map( pods[ j ], "mcache" ) );
+          if( FD_UNLIKELY( !links[ link_idx ].mcache ) ) FD_LOG_ERR(( "fd_mcache_join failed" ));
+          links[ link_idx ].fseq = fd_fseq_join( fd_wksp_pod_map( pods[ j ], snprintf1( buf, 64, "net-in-fseq%lu", i ) ) );
+          if( FD_UNLIKELY( !links[ link_idx ].fseq ) ) FD_LOG_ERR(( "fd_fseq_join failed" ));
+          link_idx++;
+        }
+        for( ulong i=0; i<config->layout.verify_tile_count; i++ ) {
+          links[ link_idx ].src_name = "netmux";
+          links[ link_idx ].dst_name = "quic";
+          links[ link_idx ].mcache = fd_mcache_join( fd_wksp_pod_map( pods[ j ], "mcache" ) );
+          if( FD_UNLIKELY( !links[ link_idx ].mcache ) ) FD_LOG_ERR(( "fd_mcache_join failed" ));
+          links[ link_idx ].fseq = fd_fseq_join( fd_wksp_pod_map( pods[ j ], snprintf1( buf, 64, "quic-in-fseq%lu", i ) ) );
+          if( FD_UNLIKELY( !links[ link_idx ].fseq ) ) FD_LOG_ERR(( "fd_fseq_join failed" ));
+          link_idx++;
+        }
+        break;
       case wksp_quic_verify:
         for( ulong i=0; i<config->layout.verify_tile_count; i++ ) {
           links[ link_idx ].src_name = "quic";
@@ -276,19 +332,39 @@ run_monitor( config_t * const config,
         break;
       case wksp_bank_shred:
         break;
-      case wksp_quic:
-        tiles[ tile_idx ].name = "quic";
+      case wksp_net:
+        for( ulong i=0; i<config->layout.net_tile_count; i++ ) {
+          tiles[ tile_idx ].name = "net";
+          tiles[ tile_idx ].cnc = fd_cnc_join( fd_wksp_pod_map1( pod, "cnc%lu", i ) );
+          if( FD_UNLIKELY( !tiles[ tile_idx ].cnc ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
+          if( FD_UNLIKELY( fd_cnc_app_sz( tiles[ tile_idx ].cnc )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
+          tile_idx++;
+        }
+        break;
+      case wksp_netmux:
+        tiles[ tile_idx ].name = "netmux";
         tiles[ tile_idx ].cnc = fd_cnc_join( fd_wksp_pod_map( pod, "cnc" ) );
         if( FD_UNLIKELY( !tiles[ tile_idx ].cnc ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
         if( FD_UNLIKELY( fd_cnc_app_sz( tiles[ tile_idx ].cnc )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
         tile_idx++;
         break;
+      case wksp_quic:
+        for( ulong i=0; i<config->layout.verify_tile_count; i++ ) {
+          tiles[ tile_idx ].name = "quic";
+          tiles[ tile_idx ].cnc = fd_cnc_join( fd_wksp_pod_map1( pod, "cnc%lu", i ) );
+          if( FD_UNLIKELY( !tiles[ tile_idx ].cnc ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
+          if( FD_UNLIKELY( fd_cnc_app_sz( tiles[ tile_idx ].cnc )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
+          tile_idx++;
+        }
+        break;
       case wksp_verify:
-        tiles[ tile_idx ].name = "verify";
-        tiles[ tile_idx ].cnc = fd_cnc_join( fd_wksp_pod_map( pod, "cnc" ) );
-        if( FD_UNLIKELY( !tiles[tile_idx].cnc ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
-        if( FD_UNLIKELY( fd_cnc_app_sz( tiles[ tile_idx ].cnc )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
-        tile_idx++;
+        for( ulong i=0; i<config->layout.verify_tile_count; i++ ) {
+          tiles[ tile_idx ].name = "verify";
+          tiles[ tile_idx ].cnc = fd_cnc_join( fd_wksp_pod_map1( pod, "cnc%lu", i ) );
+          if( FD_UNLIKELY( !tiles[tile_idx].cnc ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
+          if( FD_UNLIKELY( fd_cnc_app_sz( tiles[ tile_idx ].cnc )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
+          tile_idx++;
+        }
         break;
       case wksp_dedup:
         tiles[ tile_idx ].name = "dedup";
@@ -305,11 +381,13 @@ run_monitor( config_t * const config,
         tile_idx++;
         break;
       case wksp_bank:
-        tiles[ tile_idx ].name = "bank";
-        tiles[ tile_idx ].cnc = fd_cnc_join( fd_wksp_pod_map( pod, "cnc" ) );
-        if( FD_UNLIKELY( !tiles[ tile_idx ].cnc ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
-        if( FD_UNLIKELY( fd_cnc_app_sz( tiles[ tile_idx ].cnc )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
-        tile_idx++;
+        for( ulong i=0; i<config->layout.verify_tile_count; i++ ) {
+          tiles[ tile_idx ].name = "bank";
+          tiles[ tile_idx ].cnc = fd_cnc_join( fd_wksp_pod_map1( pod, "cnc%lu", i ) );
+          if( FD_UNLIKELY( !tiles[ tile_idx ].cnc ) ) FD_LOG_ERR(( "fd_cnc_join failed" ));
+          if( FD_UNLIKELY( fd_cnc_app_sz( tiles[ tile_idx ].cnc )<64UL ) ) FD_LOG_ERR(( "cnc app sz should be at least 64 bytes" ));
+          tile_idx++;
+        }
         break;
     }
   }
@@ -464,7 +542,7 @@ monitor_cmd_fn( args_t *         args,
   const uchar * pods[ 256 ] = { 0 };
   for( ulong i=0; i<config->shmem.workspaces_cnt; i++ ) {
     workspace_config_t * wksp = &config->shmem.workspaces[ i ];
-    pods[ pods_cnt++ ] = workspace_pod_join( config->name, wksp->name, wksp->kind_idx );
+    pods[ pods_cnt++ ] = workspace_pod_join( config->name, wksp->name );
   }
 
   struct sigaction sa = {
@@ -496,7 +574,7 @@ monitor_cmd_fn( args_t *         args,
   ushort num_syscalls = sizeof(allow_syscalls)/sizeof(allow_syscalls[0]);
 
   ulong allow_fds_sz = args->monitor.drain_output_fd >= 0 ? num_fds : num_fds - 1;
-  ushort allow_syscalls_sz = args->monitor.drain_output_fd >= 0 ? num_syscalls : (ushort)(num_syscalls - 1);
+  ushort allow_syscalls_cnt = args->monitor.drain_output_fd >= 0 ? num_syscalls : (ushort)(num_syscalls - 1);
 
   if( FD_UNLIKELY( close( 0 ) ) ) FD_LOG_ERR(( "close(0) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
   fd_sandbox( config->development.sandbox,
@@ -504,7 +582,7 @@ monitor_cmd_fn( args_t *         args,
               config->gid,
               allow_fds_sz,
               allow_fds,
-              allow_syscalls_sz,
+              allow_syscalls_cnt,
               allow_syscalls );
 
   run_monitor( config,

--- a/src/app/fdctl/ready.c
+++ b/src/app/fdctl/ready.c
@@ -4,6 +4,26 @@
 
 #include "../../tango/fd_tango.h"
 
+static void wait_for( char * app_name,
+                      char * workspace_name,
+                      char * cnc_name ) {
+  const uchar * pod = workspace_pod_join( app_name, workspace_name );
+  fd_cnc_t * cnc = fd_cnc_join( fd_wksp_pod_map( pod, cnc_name ) );
+  int first_iter = 1;
+  do {
+    ulong signal = fd_cnc_signal_query( cnc );
+    char buf[ FD_CNC_SIGNAL_CSTR_BUF_MAX ];
+
+    if( FD_LIKELY( signal==FD_CNC_SIGNAL_RUN ) ) break;
+    else if( FD_UNLIKELY( signal!=FD_CNC_SIGNAL_BOOT ) )
+      FD_LOG_ERR(( "cnc for tile %s is in bad state %s", workspace_name, fd_cnc_signal_cstr( signal, buf ) ));
+
+    if( FD_UNLIKELY( first_iter ) )
+      FD_LOG_NOTICE(( "waiting for tile %s to be ready", workspace_name ));
+    first_iter = 0;
+  } while(1);
+}
+
 void
 ready_cmd_fn( args_t *         args,
               config_t * const config ) {
@@ -12,6 +32,7 @@ ready_cmd_fn( args_t *         args,
   for( ulong i=0; i<config->shmem.workspaces_cnt; i++ ) {
     workspace_config_t * wksp = &config->shmem.workspaces[i];
     switch( wksp->kind ) {
+      case wksp_netmux_inout:
       case wksp_quic_verify:
       case wksp_verify_dedup:
       case wksp_dedup_pack:
@@ -19,25 +40,27 @@ ready_cmd_fn( args_t *         args,
       case wksp_bank_shred:
       case wksp_bank:
         break;
+      case wksp_net:
+        for( ulong i=0; i<config->layout.net_tile_count; i++ ) {
+          char cnc[32];
+          snprintf1( cnc, 32, "cnc%lu", i );
+          wait_for( config->name, wksp->name, cnc );
+        }
+        break;
       case wksp_quic:
-      case wksp_verify:
+      case wksp_verify: {
+        for( ulong i=0; i<config->layout.verify_tile_count; i++ ) {
+          char cnc[32];
+          snprintf1( cnc, 32, "cnc%lu", i );
+          wait_for( config->name, wksp->name, cnc );
+        }
+        break;
+      }
+      case wksp_netmux:
       case wksp_dedup:
       case wksp_pack: {
-        const uchar * pod = workspace_pod_join( config->name, wksp->name, wksp->kind_idx );
-        fd_cnc_t * cnc = fd_cnc_join( fd_wksp_pod_map( pod, "cnc" ) );
-        int first_iter = 1;
-        do {
-          ulong signal = fd_cnc_signal_query( cnc );
-          char buf[ FD_CNC_SIGNAL_CSTR_BUF_MAX ];
-
-          if( FD_LIKELY( signal==FD_CNC_SIGNAL_RUN ) ) break;
-          else if( FD_UNLIKELY( signal!=FD_CNC_SIGNAL_BOOT ) )
-            FD_LOG_ERR(( "cnc for tile %s is in bad state %s", wksp->name, fd_cnc_signal_cstr( signal, buf ) ));
-
-          if( FD_UNLIKELY( first_iter ) )
-            FD_LOG_NOTICE(( "waiting for tile %s to be ready", wksp->name ));
-          first_iter = 0;
-        } while(1);
+        wait_for( config->name, wksp->name, "cnc" );
+        break;
       }
     }
   }

--- a/src/app/fdctl/run/run.h
+++ b/src/app/fdctl/run/run.h
@@ -6,33 +6,35 @@
 #include "../../../tango/xdp/fd_xsk.h"
 
 typedef struct {
-   int           pid;
-   char *        app_name;
-   char *        tile_name;
-   ulong         tile_idx;
-   ulong         idx;
-   uchar const * tile_pod;
-   uchar const * in_pod;
-   uchar const * out_pod;
-   fd_xsk_t    * xsk;
-   fd_xsk_t    * lo_xsk;
+   int                pid;
+   char *             app_name;
+   char *             tile_name;
+   ulong              tile_idx;
+   ulong              idx;
+   const uchar *      wksp_pod[ 16 ];
+   fd_xsk_t *         xsk;
+   fd_xsk_t *         lo_xsk;
 } fd_tile_args_t;
 
 typedef struct {
-   char *  name;
-   char *  in_wksp;
-   char *  out_wksp;
-   ushort  allow_syscalls_sz;
-   long *  allow_syscalls;
+   char *             name;
+   ushort             allow_workspaces_cnt;
+   workspace_kind_t * allow_workspaces;
+   ushort             allow_syscalls_cnt;
+   long *             allow_syscalls;
+
    ulong (*allow_fds)( fd_tile_args_t * args, ulong out_fds_sz, int * out_fds );
    void  (*init)( fd_tile_args_t * args );
    void  (*run )( fd_tile_args_t * args );
 } fd_tile_config_t;
 
+extern fd_tile_config_t net;
+extern fd_tile_config_t netmux;
+extern fd_tile_config_t quic;
 extern fd_tile_config_t verify;
 extern fd_tile_config_t dedup;
-extern fd_tile_config_t quic;
 extern fd_tile_config_t pack;
+extern fd_tile_config_t bank;
 
 typedef struct {
   fd_tile_config_t * tile;
@@ -46,8 +48,7 @@ typedef struct {
 
 const uchar *
 workspace_pod_join( char * app_name,
-                    char * tile_name,
-                    ulong tile_idx );
+                    char * workspace_name );
 
 int
 solana_labs_main( void * args );

--- a/src/app/fdctl/run/tiles/bank.c
+++ b/src/app/fdctl/run/tiles/bank.c
@@ -1,0 +1,20 @@
+#include "tiles.h"
+#include "../run.h"
+
+/* dummy bank definition for use by some config macros */
+
+static workspace_kind_t allow_workspaces[] = {
+  wksp_pack_bank,  /* receive path */
+  wksp_bank_shred, /* send path */
+};
+
+fd_tile_config_t bank = {
+  .name                 = "bank",
+  .allow_workspaces_cnt = sizeof(allow_workspaces)/sizeof(allow_workspaces[ 0 ]),
+  .allow_workspaces     = allow_workspaces,
+  .allow_syscalls_cnt   = 0,
+  .allow_syscalls       = NULL,
+  .allow_fds            = NULL,
+  .init                 = NULL,
+  .run                  = NULL,
+};

--- a/src/app/fdctl/run/tiles/net.c
+++ b/src/app/fdctl/run/tiles/net.c
@@ -1,0 +1,98 @@
+#include "tiles.h"
+#include "../../fdctl.h"
+#include "../run.h"
+
+#include "../../../../disco/fd_disco.h"
+#include "../../../../tango/xdp/fd_xsk_private.h"
+
+#include <linux/unistd.h>
+
+
+static void
+init( fd_tile_args_t * args ) {
+  const uchar * tile_pod = args->wksp_pod[ 0 ];
+
+  FD_LOG_INFO(( "loading %s", "xsk" ));
+  args->xsk = fd_xsk_join( fd_wksp_pod_map1( tile_pod, "xsk%lu", args->tile_idx ) );
+  if( FD_UNLIKELY( !args->xsk ) ) FD_LOG_ERR(( "fd_xsk_join failed" ));
+
+  char lo_xsk_name[32];
+  snprintf1( lo_xsk_name, 32, "lo_xsk%lu", args->tile_idx );
+  args->lo_xsk = NULL;
+  if( FD_UNLIKELY( fd_pod_query_cstr( tile_pod, lo_xsk_name, NULL ) ) ) {
+    FD_LOG_INFO(( "loading %s", lo_xsk_name ));
+    args->lo_xsk = fd_xsk_join( fd_wksp_pod_map( tile_pod, lo_xsk_name ) );
+    if( FD_UNLIKELY( !args->lo_xsk ) ) FD_LOG_ERR(( "fd_xsk_join (lo) failed" ));
+  }
+
+  /* calling fd_tempo_tick_per_ns requires nanosleep, it is cached with
+     a FD_ONCE */
+  fd_tempo_tick_per_ns( NULL );
+}
+
+static void
+run( fd_tile_args_t * args ) {
+  const uchar * tile_pod = args->wksp_pod[ 0 ];
+  const uchar * mux_pod  = args->wksp_pod[ 1 ];
+
+  ulong xsk_aio_cnt = 1;
+  fd_xsk_aio_t * xsk_aio[2] = { fd_xsk_aio_join( fd_wksp_pod_map1( tile_pod, "xsk_aio%lu", args->tile_idx ), args->xsk ), NULL };
+  if( FD_UNLIKELY( args->lo_xsk ) ) {
+    xsk_aio[1] = fd_xsk_aio_join( fd_wksp_pod_map1( tile_pod, "lo_xsk_aio%lu", args->tile_idx ), args->lo_xsk );
+    xsk_aio_cnt += 1;
+  }
+
+  ulong cnt = fd_pod_query_ulong( mux_pod, "net-cnt", 0UL );
+  if( FD_UNLIKELY( !cnt ) ) FD_LOG_ERR(( "net-cnt not set" ));
+
+  fd_rng_t _rng[ 1 ];
+  fd_net_tile( fd_cnc_join( fd_wksp_pod_map1( tile_pod, "cnc%lu", args->tile_idx ) ),
+               (ulong)args->pid,
+               1,
+               (const fd_frag_meta_t **)&(fd_frag_meta_t*){ fd_mcache_join( fd_wksp_pod_map( mux_pod, "mcache" ) ) },
+               &(ulong*){ fd_fseq_join( fd_wksp_pod_map1( mux_pod, "net-in-fseq%lu", args->tile_idx ) ) },
+               cnt,
+               args->tile_idx,
+               xsk_aio_cnt,
+               xsk_aio,
+               fd_mcache_join( fd_wksp_pod_map1( mux_pod, "net-out-mcache%lu", args->tile_idx ) ),
+               fd_dcache_join( fd_wksp_pod_map1( mux_pod, "net-out-dcache%lu", args->tile_idx ) ),
+               0,
+               0,
+               fd_rng_join( fd_rng_new( _rng, 0, 0UL ) ),
+               fd_alloca( FD_NET_TILE_SCRATCH_ALIGN, FD_NET_TILE_SCRATCH_FOOTPRINT( 1, 0 ) ) );
+}
+
+static long allow_syscalls[] = {
+  __NR_write,  /* logging */
+  __NR_fsync,  /* logging, WARNING and above fsync immediately */
+  __NR_sendto, /* performance optimization for send/recv path, should be investigated */
+};
+
+static workspace_kind_t allow_workspaces[] = {
+  wksp_net,          /* the tile itself */
+  wksp_netmux_inout, /* receive from mux, send to mux */
+};
+
+static ulong
+allow_fds( fd_tile_args_t * args,
+           ulong            out_fds_sz,
+           int *            out_fds ) {
+  if( FD_UNLIKELY( out_fds_sz < 4 ) ) FD_LOG_ERR(( "out_fds_sz %lu", out_fds_sz ));
+  out_fds[ 0 ] = 2; /* stderr */
+  out_fds[ 1 ] = 3; /* logfile */
+  out_fds[ 2 ] = args->xsk->xsk_fd;
+  out_fds[ 3 ] = args->lo_xsk ? args->lo_xsk->xsk_fd : -1;
+  return args->lo_xsk ? 4 : 3;
+}
+
+fd_tile_config_t net = {
+  .name                 = "net",
+  .allow_workspaces_cnt = sizeof(allow_workspaces)/sizeof(allow_workspaces[ 0 ]),
+  .allow_workspaces     = allow_workspaces,
+  .allow_syscalls_cnt   = sizeof(allow_syscalls)/sizeof(allow_syscalls[ 0 ]),
+  .allow_syscalls       = allow_syscalls,
+  .allow_fds            = allow_fds,
+  .init                 = init,
+  .run                  = run,
+};

--- a/src/app/fdctl/run/tiles/netmux.c
+++ b/src/app/fdctl/run/tiles/netmux.c
@@ -1,0 +1,91 @@
+#include "tiles.h"
+#include "../../fdctl.h"
+#include "../run.h"
+
+#include "../../../../disco/fd_disco.h"
+
+#include <linux/unistd.h>
+
+static void
+init( fd_tile_args_t * args ) {
+  (void)args;
+
+  /* calling fd_tempo_tick_per_ns requires nanosleep, it is cached with
+     a FD_ONCE */
+  fd_tempo_tick_per_ns( NULL );
+}
+
+static void
+run( fd_tile_args_t * args ) {
+  const uchar * tile_pod = args->wksp_pod[ 0 ];
+  const uchar * mux_pod  = args->wksp_pod[ 1 ];
+
+  ulong net_tile_cnt = fd_pod_query_ulong( mux_pod, "net-cnt", 0UL );
+  if( FD_UNLIKELY( !net_tile_cnt ) ) FD_LOG_ERR(( "net_tile_cnt not set" ));
+  ulong quic_tile_cnt = fd_pod_query_ulong( mux_pod, "quic-cnt", 0UL );
+  if( FD_UNLIKELY( !quic_tile_cnt ) ) FD_LOG_ERR(( "quic_tile_cnt not set" ));
+
+  ulong in_cnt = net_tile_cnt + quic_tile_cnt;
+  fd_frag_meta_t const ** in_mcache = (fd_frag_meta_t const **)fd_alloca( alignof(fd_frag_meta_t const *), sizeof(fd_frag_meta_t const *)*in_cnt );
+  ulong ** in_fseq = (ulong **)fd_alloca( alignof(ulong *), sizeof(ulong *)*in_cnt );
+  FD_TEST( in_mcache && in_fseq );
+
+  for( ulong i=0; i<net_tile_cnt; i++ ) {
+    in_mcache[ i ] = fd_mcache_join( fd_wksp_pod_map1( mux_pod, "net-out-mcache%lu", i ) );
+    in_fseq[ i ] = fd_fseq_join( fd_wksp_pod_map1( mux_pod, "net-out-fseq%lu", i ) );
+  }
+  for( ulong i=0; i<quic_tile_cnt; i++ ) {
+    in_mcache[ net_tile_cnt + i ] = fd_mcache_join( fd_wksp_pod_map1( mux_pod, "quic-out-mcache%lu", i ) );
+    in_fseq[ net_tile_cnt + i ] = fd_fseq_join( fd_wksp_pod_map1( mux_pod, "quic-out-fseq%lu", i ) );
+  }
+
+  fd_mux_callbacks_t callbacks[1] = { 0 };
+  fd_rng_t _rng[ 1 ];
+  fd_mux_tile( fd_cnc_join( fd_wksp_pod_map( tile_pod, "cnc" ) ),
+               (ulong)args->pid,
+               FD_MUX_FLAG_DEFAULT,
+               in_cnt,
+               in_mcache,
+               in_fseq,
+               fd_mcache_join( fd_wksp_pod_map( mux_pod, "mcache" ) ),
+               0, /* no reliable consumers, consumers are unreliable */
+               NULL,
+               0,
+               0,
+               fd_rng_join( fd_rng_new( _rng, 0, 0UL ) ),
+               fd_alloca( FD_MUX_TILE_SCRATCH_ALIGN, FD_MUX_TILE_SCRATCH_FOOTPRINT( in_cnt, 0 ) ),
+               NULL,
+               callbacks );
+}
+
+static long allow_syscalls[] = {
+  __NR_write, /* logging */
+  __NR_fsync, /* logging, WARNING and above fsync immediately */
+};
+
+static workspace_kind_t allow_workspaces[] = {
+  wksp_netmux,       /* the tile itself */
+  wksp_netmux_inout, /* receive from producers, send to consumers */
+};
+
+static ulong
+allow_fds( fd_tile_args_t * args,
+           ulong            out_fds_sz,
+           int *            out_fds ) {
+  (void)args;
+  if( FD_UNLIKELY( out_fds_sz < 2 ) ) FD_LOG_ERR(( "out_fds_sz %lu", out_fds_sz ));
+  out_fds[ 0 ] = 2; /* stderr */
+  out_fds[ 1 ] = 3; /* logfile */
+  return 2;
+}
+
+fd_tile_config_t netmux = {
+  .name                 = "netmux",
+  .allow_workspaces_cnt = sizeof(allow_workspaces)/sizeof(allow_workspaces[ 0 ]),
+  .allow_workspaces     = allow_workspaces,
+  .allow_syscalls_cnt   = sizeof(allow_syscalls)/sizeof(allow_syscalls[ 0 ]),
+  .allow_syscalls       = allow_syscalls,
+  .allow_fds            = allow_fds,
+  .init                 = init,
+  .run                  = run,
+};

--- a/src/app/fdctl/run/tiles/tiles.c
+++ b/src/app/fdctl/run/tiles/tiles.c
@@ -1,0 +1,22 @@
+#include "tiles.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+
+void *
+fd_wksp_pod_map1( uchar const * pod,
+                  char const *  format,
+                  ... ) {
+  char s[ 256 ];
+
+  va_list args;
+  va_start( args, format );
+  int len = vsnprintf( s, sizeof(s), format, args );
+  va_end( args );
+  if( FD_UNLIKELY( len < 0 ) )
+    FD_LOG_ERR(( "vsnprintf failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  if( FD_UNLIKELY( (ulong)len >= sizeof(s) ) )
+    FD_LOG_ERR(( "vsnprintf truncated output (maxlen=%lu)", sizeof(s) ));
+
+  return fd_wksp_pod_map( pod, s );
+}

--- a/src/app/fdctl/run/tiles/tiles.h
+++ b/src/app/fdctl/run/tiles/tiles.h
@@ -1,0 +1,13 @@
+#ifndef HEADER_fd_src_app_fdctl_run_tiles_h
+#define HEADER_fd_src_app_fdctl_run_tiles_h
+
+#include "../../fdctl.h"
+
+#include <stdlib.h>
+
+void *
+fd_wksp_pod_map1( uchar const * pod,
+                  char const *  format,
+                  ... );
+
+#endif /* HEADER_fd_src_app_fdctl_run_tiles_h */

--- a/src/app/fddev/txn.c
+++ b/src/app/fddev/txn.c
@@ -80,10 +80,10 @@ send_quic_transactions( fd_quic_t *         quic,
   fd_quic_set_aio_net_tx( quic, udpsock->aio );
   FD_TEST( fd_quic_init( quic ) );
 
-  quic->cb.now = cb_now;
-  quic->cb.conn_final = cb_conn_final;
+  quic->cb.now              = cb_now;
+  quic->cb.conn_final       = cb_conn_final;
   quic->cb.conn_hs_complete = cb_conn_hs_complete;
-  quic->cb.stream_notify = cb_stream_notify;
+  quic->cb.stream_notify    = cb_stream_notify;
 
   fd_quic_conn_t * conn = fd_quic_connect( quic, dst_ip, dst_port, NULL );
   while ( FD_LIKELY( !( g_conn_hs_complete || g_conn_final ) ) ) {
@@ -159,7 +159,7 @@ txn_cmd_fn( args_t *         args,
   client_cfg->role = FD_QUIC_ROLE_CLIENT;
   memcpy( client_cfg->alpns, "\xasolana-tpu", 11UL );
   client_cfg->alpns_sz = 11U;
-  memcpy( client_cfg->link.dst_mac_addr, config->net.mac_addr, 6UL );
+  memcpy( client_cfg->link.dst_mac_addr, config->tiles.net.mac_addr, 6UL );
   client_cfg->net.ip_addr           = udpsock->listen_ip;
   client_cfg->net.ephem_udp_port.lo = (ushort)udpsock->listen_port;
   client_cfg->net.ephem_udp_port.hi = (ushort)(udpsock->listen_port + 1);
@@ -184,7 +184,7 @@ txn_cmd_fn( args_t *         args,
     }
   }
 
-  uint dst_ip = config->net.ip_addr;
+  uint dst_ip = config->tiles.net.ip_addr;
   if( FD_UNLIKELY( args->txn.dst_ip ) )
     if( FD_UNLIKELY( !fd_cstr_to_ip4_addr( args->txn.dst_ip, &dst_ip  ) ) ) FD_LOG_ERR(( "invalid --dst-ip" ));
 

--- a/src/disco/fd_disco.h
+++ b/src/disco/fd_disco.h
@@ -2,6 +2,7 @@
 #define HEADER_fd_src_disco_fd_disco_h
 
 //#include "fd_disco_base.h"  /* includes ../tango/fd_tango.h */
+#include "net/fd_net.h"       /* includes fd_disco_base.h */
 #include "dedup/fd_dedup.h"   /* includes fd_disco_base.h */
 #include "verify/fd_verify.h" /* includes fd_disco_base.h */
 #include "quic/fd_quic.h"     /* includes fd_disco_base.h */

--- a/src/disco/net/Local.mk
+++ b/src/disco/net/Local.mk
@@ -1,0 +1,2 @@
+$(call add-hdrs,fd_net.h)
+$(call add-objs,fd_net,fd_disco)

--- a/src/disco/net/fd_net.c
+++ b/src/disco/net/fd_net.c
@@ -1,0 +1,243 @@
+#include "fd_net.h"
+
+#include "../mux/fd_mux.h"
+
+typedef struct {
+  ulong xsk_aio_cnt;
+  fd_xsk_aio_t ** xsk_aio;
+
+  ulong round_robin_cnt;
+  ulong round_robin_id;
+
+  const fd_aio_t * tx;
+
+  uchar frame[ FD_NET_MTU ];
+
+  fd_mux_context_t * mux;
+
+  void * in_wksp;
+  ulong  in_chunk0;
+  ulong  in_wmark;
+
+  void  * out_wksp;
+  ulong   out_chunk0;
+  ulong   out_wmark;
+  ulong   out_chunk;
+} fd_net_ctx_t;
+
+/* net_rx_aio_send is a callback invoked by aio when new data is
+   received on an incoming xsk.  The xsk might be bound to any interface
+   or ports, so the purpose of this callback is to determine if the
+   packet might be a valid transaction, and whether it is QUIC or
+   non-QUIC (raw UDP) before forwarding to the appropriate handler.
+
+   This callback is supposed to return the number of packets in the
+   batch which were successfully processed, but we always return
+   batch_cnt since there is no logic in place to backpressure this far
+   up the stack there is no sane way to "not handle" an incoming packet.
+   */
+static int
+net_rx_aio_send( void *                    _ctx,
+                 fd_aio_pkt_info_t const * batch,
+                 ulong                     batch_cnt,
+                 ulong *                   opt_batch_idx,
+                 int                       flush ) {
+  (void)flush;
+
+  fd_net_ctx_t * ctx = (fd_net_ctx_t *)_ctx;
+
+  for( ulong i=0; i<batch_cnt; i++ ) {
+    uchar const * packet = batch[i].buf;
+    uchar const * packet_end = packet + batch[i].buf_sz;
+
+    if( FD_UNLIKELY( batch[i].buf_sz > FD_NET_MTU ) )
+      FD_LOG_ERR(( "received a UDP packet with a too large payload (%u)", batch[i].buf_sz ));
+
+    uchar const * iphdr = packet + 14U;
+
+    /* Filter for UDP/IPv4 packets. Test for ethtype and ipproto in 1
+       branch */
+    uint test_ethip = ( (uint)packet[12] << 16u ) | ( (uint)packet[13] << 8u ) | (uint)packet[23];
+    if( FD_UNLIKELY( test_ethip!=0x080011 ) )
+      FD_LOG_ERR(( "Firedancer received a packet from the XDP program that was either "
+                   "not an IPv4 packet, or not a UDP packet. It is likely your XDP program "
+                   "is not configured correctly." ));
+
+    /* IPv4 is variable-length, so lookup IHL to find start of UDP */
+    uint iplen = ( ( (uint)iphdr[0] ) & 0x0FU ) * 4U;
+    uchar const * udp = iphdr + iplen;
+
+    /* Ignore if UDP header is too short */
+    if( FD_UNLIKELY( udp+4U > packet_end ) ) continue;
+
+    /* Extract IP dest addr and UDP dest port */
+    uint ip_srcaddr    = *(uint   *)( iphdr+12UL );
+    ushort udp_dstport = *(ushort *)( udp+2UL    );
+
+    fd_memcpy( fd_chunk_to_laddr( ctx->out_wksp, ctx->out_chunk ), packet, batch[i].buf_sz );
+
+    /* tile can decide how to partition based on src ip addr and port */
+    ulong sig = fd_disco_netmux_sig( ip_srcaddr, fd_ushort_bswap( udp_dstport ), SRC_TILE_NET, 0 );
+
+    ulong tspub  = (ulong)fd_frag_meta_ts_comp( fd_tickcount() );
+    fd_mux_publish( ctx->mux, sig, ctx->out_chunk, batch[i].buf_sz, 0, 0, tspub );
+
+    ctx->out_chunk = fd_dcache_compact_next( ctx->out_chunk, FD_NET_MTU, ctx->out_chunk0, ctx->out_wmark );
+  }
+
+  if( FD_LIKELY( opt_batch_idx ) ) {
+    *opt_batch_idx = batch_cnt;
+  }
+
+  return FD_AIO_SUCCESS;
+}
+
+static void
+before_credit( void * _ctx,
+               fd_mux_context_t * mux ) {
+  fd_net_ctx_t * ctx = (fd_net_ctx_t *)_ctx;
+
+  ctx->mux = mux;
+
+  for( ulong i=0; i<ctx->xsk_aio_cnt; i++ ) {
+    fd_xsk_aio_service( ctx->xsk_aio[i] );
+  }
+}
+
+static void
+before_frag( void * _ctx,
+             ulong  in_idx,
+             ulong  seq,
+             ulong  sig,
+             int *  opt_filter ) {
+  (void)in_idx;
+
+  fd_net_ctx_t * ctx = (fd_net_ctx_t *)_ctx;
+
+  ushort src_tile = fd_disco_netmux_sig_src_tile( sig );
+
+  /* round robin by sequence number for now, quic should be modified to
+     echo the net tile index back so we can transmit on the same queue */
+  int handled_packet = (seq % ctx->round_robin_cnt) == ctx->round_robin_id;
+  if( FD_UNLIKELY( src_tile == SRC_TILE_NET || !handled_packet ) ) {
+    *opt_filter = 1;
+  }
+}
+
+static void
+during_frag( void * _ctx,
+             ulong in_idx,
+             ulong sig,
+             ulong chunk,
+             ulong sz,
+             int * opt_filter ) {
+  (void)in_idx;
+  (void)sig;
+  (void)opt_filter;
+
+  fd_net_ctx_t * ctx = (fd_net_ctx_t *)_ctx;
+
+  if( FD_UNLIKELY( chunk<ctx->in_chunk0 || chunk>=ctx->in_wmark || sz > FD_NET_MTU ) )
+    FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu)", chunk, sz, ctx->in_chunk0, ctx->in_wmark ));
+
+  uchar * src = (uchar *)fd_chunk_to_laddr( ctx->in_wksp, chunk );
+  fd_memcpy( ctx->frame, src, sz ); // TODO: Change xsk_aio interface to eliminate this copy
+}
+
+static void
+after_frag( void *  _ctx,
+            ulong * opt_sig,
+            ulong * opt_chunk,
+            ulong * opt_sz,
+            int *   opt_filter ) {
+  (void)opt_sig;
+  (void)opt_chunk;
+  (void)opt_filter;
+
+  fd_net_ctx_t * ctx = (fd_net_ctx_t *)_ctx;
+
+  fd_aio_pkt_info_t aio_buf = { .buf = ctx->frame, .buf_sz = (ushort)*opt_sz };
+  ctx->tx->send_func( ctx->xsk_aio[ 0 ], &aio_buf, 1, NULL, 1 );
+
+  *opt_filter = 1;
+}
+
+int
+fd_net_tile( fd_cnc_t *              cnc,
+             ulong                   pid,
+             ulong                   in_cnt,
+             const fd_frag_meta_t ** in_mcache,
+             ulong **                in_fseq,
+             ulong                   round_robin_cnt,
+             ulong                   round_robin_id,
+             ulong                   xsk_aio_cnt,
+             fd_xsk_aio_t **         xsk_aio,
+             fd_frag_meta_t *        mcache,
+             uchar *                 dcache,
+             ulong                   cr_max,
+             long                    lazy,
+             fd_rng_t *              rng,
+             void *                  scratch ) {
+  fd_net_ctx_t ctx[1];
+
+  fd_mux_callbacks_t callbacks[1] = { 0 };
+
+  callbacks->before_credit = before_credit;
+  callbacks->before_frag   = before_frag;
+  callbacks->during_frag   = during_frag;
+  callbacks->after_frag    = after_frag;
+
+  ulong scratch_top = (ulong)scratch;
+
+  do {
+    if( FD_UNLIKELY( !dcache ) ) { FD_LOG_WARNING(( "NULL dcache" )); return 1; }
+
+    ulong depth = fd_mcache_depth( mcache );
+    if( FD_UNLIKELY( !fd_dcache_compact_is_safe( fd_wksp_containing( dcache ), dcache, FD_NET_MTU, depth  ) ) ) {
+      FD_LOG_WARNING(( "dcache not compatible with wksp base and mcache depth" ));
+      return 1;
+    }
+
+    if( FD_UNLIKELY( !xsk_aio_cnt ) ) { FD_LOG_WARNING(( "no xsk_aio" )); return 1; }
+
+    fd_aio_t * net_rx_aio = fd_aio_join( fd_aio_new( SCRATCH_ALLOC( fd_aio_align(), fd_aio_footprint() ), ctx, net_rx_aio_send ) );
+    for( ulong i=0; i<xsk_aio_cnt; i++ ) fd_xsk_aio_set_rx( xsk_aio[i], net_rx_aio );
+
+    if( FD_UNLIKELY( !round_robin_cnt ) ) { FD_LOG_WARNING(( "round_robin_cnt is zero" )); return 1; }
+    if( FD_UNLIKELY( round_robin_id >= round_robin_cnt ) ) { FD_LOG_WARNING(( "round_robin_id is too large" )); return 1; }
+    ctx->round_robin_cnt = round_robin_cnt;
+    ctx->round_robin_id  = round_robin_id;
+
+    ctx->xsk_aio_cnt = xsk_aio_cnt;
+    ctx->xsk_aio = xsk_aio;
+    ctx->tx = fd_xsk_aio_get_tx( xsk_aio[ 0 ] );
+
+    ctx->in_wksp = fd_wksp_containing( mcache );
+
+    /* Put a bound on chunks we read from the input, to make sure they
+       are within in the data region of the workspace. */
+    ctx->in_chunk0 = fd_disco_compact_chunk0( ctx->in_wksp );
+    ctx->in_wmark  = fd_disco_compact_wmark ( ctx->in_wksp, FD_NET_MTU );
+
+    ctx->out_wksp   = fd_wksp_containing( dcache );
+    ctx->out_chunk0 = fd_dcache_compact_chunk0( ctx->out_wksp, dcache );
+    ctx->out_wmark  = fd_dcache_compact_wmark ( ctx->out_wksp, dcache, FD_NET_MTU );
+    ctx->out_chunk  = ctx->out_chunk0;
+  } while(0);
+
+  return fd_mux_tile( cnc,
+                      pid,
+                      FD_MUX_FLAG_MANUAL_PUBLISH | FD_MUX_FLAG_COPY,
+                      in_cnt,
+                      in_mcache,
+                      in_fseq,
+                      mcache,
+                      0, /* no reliable consumers, downstream tiles may be overrun */
+                      NULL,
+                      cr_max,
+                      lazy,
+                      rng,
+                      (void*)fd_ulong_align_up( scratch_top, FD_MUX_TILE_SCRATCH_ALIGN ),
+                      ctx,
+                      callbacks );
+}

--- a/src/disco/net/fd_net.h
+++ b/src/disco/net/fd_net.h
@@ -1,0 +1,39 @@
+#ifndef HEADER_fd_src_disco_net_fd_net_h
+#define HEADER_fd_src_disco_net_fd_net_h
+
+#include "../fd_disco_base.h"
+
+#include "../fd_disco_base.h"
+#include "../../tango/quic/fd_quic.h"
+#include "../../tango/xdp/fd_xdp.h"
+
+#define FD_NET_TILE_SCRATCH_ALIGN (128UL)
+#define FD_NET_TILE_SCRATCH_FOOTPRINT( in_cnt, out_cnt )                                \
+  FD_LAYOUT_FINI( FD_LAYOUT_APPEND( FD_LAYOUT_APPEND( FD_LAYOUT_APPEND( FD_LAYOUT_INIT, \
+    FD_AIO_ALIGN,                FD_AIO_FOOTPRINT ),                                    \
+    alignof(fd_verify_in_ctx_t), (in_cnt)*sizeof(fd_verify_in_ctx_t) ),                 \
+    FD_MUX_TILE_SCRATCH_ALIGN,   FD_MUX_TILE_SCRATCH_FOOTPRINT( in_cnt, out_cnt ) ),    \
+    FD_VERIFY_TILE_SCRATCH_ALIGN )
+
+FD_PROTOTYPES_BEGIN
+
+int
+fd_net_tile( fd_cnc_t *              cnc,                     /* Local join to the quic's command-and-control */
+             ulong                   pid,                     /* Tile PID for diagnostic purposes */
+             ulong                   in_cnt,
+             const fd_frag_meta_t ** in_mcache,
+             ulong **                in_fseq,
+             ulong                   round_robin_cnt,
+             ulong                   round_robin_id,
+             ulong                   xsk_aio_cnt,             /* Number of xsk_aio producers to poll, indexed [0,xsk_aio_cnt)] */
+             fd_xsk_aio_t **         xsk_aio,                 /* xsk_aio[xsk_aio_idx] is the local join to xsk_aio producer */
+             fd_frag_meta_t *        mcache,                  /* Local join to the quic's frag stream output mcache */
+             uchar *                 dcache,                  /* Local join to the quic's frag stream output dcache */
+             ulong                   cr_max,                  /* Maximum number of flow control credits, 0 means use a reasonable default */
+             long                    lazy,                    /* Lazyiness, <=0 means use a reasonable default */
+             fd_rng_t *              rng,                     /* Local join to the rng this quic should use */
+             void *                  scratch );               /* Tile scratch memory */
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_disco_net_fd_net_h */

--- a/src/disco/pack/fd_pack.c
+++ b/src/disco/pack/fd_pack.c
@@ -63,7 +63,6 @@ after_credit( void *             _ctx,
      thread, if it's not busy... */
   for( ulong i=0UL; i<ctx->out_cnt; i++ ) {
     if( FD_LIKELY( fd_fseq_query( ctx->out_busy[i] ) == *mux->seq ) ) { /* optimize for the case we send a microblock */
-      FD_LOG_WARNING(( "out_busy[%lu] is %lu, expected %lu", i, fd_fseq_query( ctx->out_busy[i] ), *mux->seq ));
       fd_pack_microblock_complete( ctx->pack, i );
 
       void * microblock_dst = fd_chunk_to_laddr( ctx->out_wksp, ctx->out_chunk );
@@ -78,8 +77,6 @@ after_credit( void *             _ctx,
 
         ctx->out_chunk = fd_dcache_compact_next( ctx->out_chunk, msg_sz, ctx->out_chunk0, ctx->out_wmark );
       }
-    } else {
-      FD_LOG_WARNING(( "out_busy[%lu] is %lu, expected %lu", i, fd_fseq_query( ctx->out_busy[i] ), *mux->seq ));
     }
   }
 }

--- a/src/disco/quic/fd_quic.h
+++ b/src/disco/quic/fd_quic.h
@@ -51,8 +51,8 @@
    startup (as such that they can be accumulated over multiple runs).
    Clearing is up to monitoring scripts. */
 
-#define FD_QUIC_CNC_DIAG_TPU_CONN_LIVE_CNT (6UL) /* ", frequently */
-#define FD_QUIC_CNC_DIAG_TPU_CONN_SEQ      (7UL) /* ", frequently */
+#define FD_QUIC_CNC_DIAG_TPU_CONN_LIVE_CNT (6UL)
+#define FD_QUIC_CNC_DIAG_TPU_CONN_SEQ      (7UL)
 
 #define FD_QUIC_TILE_SCRATCH_ALIGN (128UL)
 
@@ -70,18 +70,23 @@ fd_quic_tile_scratch_footprint( ulong depth,
                                 ulong out_cnt );
 
 int
-fd_quic_tile( fd_cnc_t *       cnc,                     /* Local join to the quic's command-and-control */
-              ulong            pid,                     /* Tile PID for diagnostic purposes */
-              fd_quic_t *      quic,                    /* Local join to the quic's quic context */
-              ushort           legacy_transaction_port, /* Port to "listen" on for non-QUIC (raw UDP) transactions */
-              ulong            xsk_aio_cnt,             /* Number of xsk_aio producers to poll, indexed [0,xsk_aio_cnt)] */
-              fd_xsk_aio_t **  xsk_aio,                 /* xsk_aio[xsk_aio_idx] is the local join to xsk_aio producer */
-              fd_frag_meta_t * mcache,                  /* Local join to the quic's frag stream output mcache */
-              uchar *          dcache,                  /* Local join to the quic's frag stream output dcache */
-              ulong            cr_max,                  /* Maximum number of flow control credits, 0 means use a reasonable default */
-              long             lazy,                    /* Lazyiness, <=0 means use a reasonable default */
-              fd_rng_t *       rng,                     /* Local join to the rng this quic should use */
-              void *           scratch );               /* Tile scratch memory */
+fd_quic_tile( fd_cnc_t *              cnc,                     /* Local join to the quic's command-and-control */
+              ulong                   pid,                     /* Tile PID for diagnostic purposes */
+              ulong                   in_cnt,
+              const fd_frag_meta_t ** in_mcache,
+              ulong **                in_fseq,
+              ulong                   round_robin_cnt,
+              ulong                   round_robin_id,
+              fd_frag_meta_t *        net_mcache,
+              uchar *                 net_dcache,
+              fd_quic_t *             quic,                    /* Local join to the quic's quic context */
+              ushort                  legacy_transaction_port, /* Port to "listen" on for non-QUIC (raw UDP) transactions */
+              fd_frag_meta_t *        mcache,                  /* Local join to the quic's frag stream output mcache */
+              uchar *                 dcache,                  /* Local join to the quic's frag stream output dcache */
+              ulong                   cr_max,                  /* Maximum number of flow control credits, 0 means use a reasonable default */
+              long                    lazy,                    /* Lazyiness, <=0 means use a reasonable default */
+              fd_rng_t *              rng,                     /* Local join to the rng this quic should use */
+              void *                  scratch );               /* Tile scratch memory */
 
 FD_PROTOTYPES_END
 

--- a/src/tango/aio/fd_aio.c
+++ b/src/tango/aio/fd_aio.c
@@ -5,12 +5,12 @@
 
 ulong
 fd_aio_align( void ) {
-  return alignof(fd_aio_t);
+  return FD_AIO_ALIGN;
 }
 
 ulong
 fd_aio_footprint( void ) {
-  return sizeof(fd_aio_t);
+  return FD_AIO_FOOTPRINT;
 }
 
 void *

--- a/src/tango/aio/fd_aio.h
+++ b/src/tango/aio/fd_aio.h
@@ -209,6 +209,9 @@ struct fd_aio_private {
 
 typedef struct fd_aio_private fd_aio_t;
 
+#define FD_AIO_ALIGN (alignof(fd_aio_t))
+#define FD_AIO_FOOTPRINT (sizeof(fd_aio_t))
+
 FD_PROTOTYPES_BEGIN
 
 /* FIXME: document these.  Also fd_aio_{align,footprint,new} are

--- a/src/util/sandbox/fd_sandbox.h
+++ b/src/util/sandbox/fd_sandbox.h
@@ -72,7 +72,7 @@ fd_sandbox( int    full_sandbox,
             uint   gid,
             ulong  allow_fds_sz,
             int *  allow_fds,
-            ushort allow_syscalls_sz,
+            ushort allow_syscalls_cnt,
             long * allow_syscalls );
 
 #endif /* HEADER_fd_src_util_sandbox_fd_sandbox_h */


### PR DESCRIPTION
A networking tile is addded to decouple packet receipt from the various consumers that may wish to handle packets, in the near term the QUIC and shred tiles.  The number of net tiles should exactly match the number of network queues being serviced.

A netmux tile is also added, which zero-copy muxes fragments from all the networking tiles to the interested consumers, and then back in the other direction for the tx path.