### PR TITLE
quic - fix alignment issues

### DIFF
--- a/src/tango/quic/fd_quic.c
+++ b/src/tango/quic/fd_quic.c
@@ -3269,8 +3269,7 @@ fd_quic_tx_buffered_raw(
   memcpy( pkt.eth->src, quic->config.link.src_mac_addr, 6 );
   pkt.eth->net_type = FD_ETH_HDR_TYPE_IP;
 
-  pkt.ip4->version      = 4;
-  pkt.ip4->ihl          = 5;
+  pkt.ip4->verihl       = FD_IP4_VERIHL(4,5);
   pkt.ip4->tos          = (uchar)(config->net.dscp << 2); /* could make this per-connection or per-stream */
   pkt.ip4->net_tot_len  = (ushort)( 20 + 8 + payload_sz );
   pkt.ip4->net_id       = *ipv4_id++;
@@ -3278,10 +3277,10 @@ fd_quic_tx_buffered_raw(
   pkt.ip4->ttl          = 64; /* TODO make configurable */
   pkt.ip4->protocol     = FD_IP4_HDR_PROTOCOL_UDP;
   pkt.ip4->check        = 0;
-  pkt.udp->net_sport = src_udp_port;
-  pkt.udp->net_dport = dst_udp_port;
-  pkt.udp->net_len   = (ushort)( 8 + payload_sz );
-  pkt.udp->check     = 0x0000;
+  pkt.udp->net_sport    = src_udp_port;
+  pkt.udp->net_dport    = dst_udp_port;
+  pkt.udp->net_len      = (ushort)( 8 + payload_sz );
+  pkt.udp->check        = 0x0000;
 
   /* TODO saddr could be zero -- should use the kernel routing table to
      determine an appropriate source address */

--- a/src/tango/quic/fd_quic_proto.h
+++ b/src/tango/quic/fd_quic_proto.h
@@ -82,8 +82,9 @@ fd_quic_decode_ip4( fd_ip4_hdr_t * FD_RESTRICT out,
 
   /* FIXME unaligned accesses */
   fd_ip4_hdr_t const * peek = (fd_ip4_hdr_t const *)fd_type_pun_const( buf );
-  ulong hdr_len = peek->ihl * 4UL;
-  if( FD_UNLIKELY( (peek->version!=4) | (hdr_len<20UL) | (sz<hdr_len) ) ) {
+  ulong hdr_len = FD_IP4_GET_LEN(*peek);
+  ulong version = FD_IP4_GET_VERSION(*peek);
+  if( FD_UNLIKELY( (version!=4) | (hdr_len<20UL) | (sz<hdr_len) ) ) {
     return FD_QUIC_PARSE_FAIL;
   }
 

--- a/src/tango/quic/tests/fuzz_quic.c
+++ b/src/tango/quic/tests/fuzz_quic.c
@@ -72,8 +72,7 @@ uint send_packet(uchar const *payload, size_t payload_sz) {
   memcpy(pkt.eth->src, "\x52\xF1\x7E\xDA\x2C\xE0", 6);
   pkt.eth->net_type = FD_ETH_HDR_TYPE_IP;
 
-  pkt.ip4->version = 4;
-  pkt.ip4->ihl = 5;
+  pkt.ip4->verihl = FD_IP4_VERIHL(4,5);
   pkt.ip4->tos = 0;
   pkt.ip4->net_tot_len = (ushort)(20 + 8 + payload_sz);
   pkt.ip4->net_id = 0;

--- a/src/tango/udpsock/fd_udpsock.c
+++ b/src/tango/udpsock/fd_udpsock.c
@@ -286,8 +286,7 @@ fd_udpsock_service( fd_udpsock_t * sock ) {
 
     fd_ip4_hdr_t * ip4 = (fd_ip4_hdr_t *)((ulong)eth + sizeof(fd_eth_hdr_t));
     *ip4 = (fd_ip4_hdr_t) {
-      .ihl          = 5,
-      .version      = 4,
+      .verihl       = FD_IP4_VERIHL(4,5),
       .tos          = 0,
       .net_tot_len  = (ushort)( sock->rx_msg[i].msg_len
                       + sizeof(fd_ip4_hdr_t)
@@ -348,7 +347,7 @@ fd_udpsock_send( void *                    ctx,
       fd_ip4_hdr_bswap( ip4 );  /* convert to host byte order */
       uint daddr = 0;
       memcpy( &daddr, ip4->daddr_c, 4 );
-      fd_udp_hdr_t * udp = (fd_udp_hdr_t *)( (ulong)ip4 + (ulong)ip4->ihl*4 );
+      fd_udp_hdr_t * udp = (fd_udp_hdr_t *)( (ulong)ip4 + (ulong)FD_IP4_GET_LEN(*ip4) );
       fd_udp_hdr_bswap( udp );  /* convert to host byte order */
       ushort dport = udp->net_dport;
 

--- a/src/tango/udpsock/test_udpsock_echo.c
+++ b/src/tango/udpsock/test_udpsock_echo.c
@@ -22,13 +22,16 @@ echo_aio_recv( void *                    ctx,
   for( ulong i=0UL; i<batch_cnt; i++ ) {
     fd_eth_hdr_t * eth_hdr = (fd_eth_hdr_t *)batch[i].buf;
     fd_ip4_hdr_t * ip4_hdr = (fd_ip4_hdr_t *)(eth_hdr+1);
-    fd_udp_hdr_t * udp_hdr = (fd_udp_hdr_t *)((ulong)ip4_hdr+((ulong)ip4_hdr->ihl<<2));
-    uint           ip4_src = ip4_hdr->saddr;
-    uint           ip4_dst = ip4_hdr->daddr;
+    fd_udp_hdr_t * udp_hdr = (fd_udp_hdr_t *)((ulong)ip4_hdr+((ulong)FD_IP4_GET_LEN(*ip4_hdr)));
+    uint           ip4_src;
+    uint           ip4_dst;
+    memcpy( &ip4_src, ip4_hdr->saddr_c, 4U );
+    memcpy( &ip4_dst, ip4_hdr->daddr_c, 4U );
     ushort         udp_src = udp_hdr->net_sport;
     ushort         udp_dst = udp_hdr->net_dport;
-    ip4_hdr->saddr     = ip4_dst;
-    ip4_hdr->daddr     = ip4_src;
+    /* switch source and destination */
+    memcpy( &ip4_dst, ip4_hdr->saddr_c, 4U );
+    memcpy( &ip4_src, ip4_hdr->daddr_c, 4U );
     ip4_hdr->ttl--;
     udp_hdr->net_sport = udp_dst;
     udp_hdr->net_dport = udp_src;

--- a/src/util/net/fd_igmp.h
+++ b/src/util/net/fd_igmp.h
@@ -1,6 +1,8 @@
 #ifndef HEADER_fd_src_util_net_fd_igmp_h
 #define HEADER_fd_src_util_net_fd_igmp_h
 
+#include <string.h>
+
 #include "fd_ip4.h"
 
 /* FIXME: IGMP CRASH COURSE HERE */
@@ -81,8 +83,7 @@ fd_ip4_igmp( void * _msg,
              uint   igmp_group ) {
   fd_ip4_igmp_t * msg = (fd_ip4_igmp_t *)_msg;
 
-  msg->ip4->ihl          = 6U;
-  msg->ip4->version      = 4U;
+  msg->ip4->verihl       = FD_IP4_VERIHL(6U,4U);
   msg->ip4->tos          = FD_IP4_HDR_TOS_PREC_INTERNETCONTROL;
   msg->ip4->net_tot_len  = fd_ushort_bswap( (ushort)32 );
   msg->ip4->net_id       = (ushort)0;
@@ -90,8 +91,9 @@ fd_ip4_igmp( void * _msg,
   msg->ip4->ttl          = (uchar)1;
   msg->ip4->protocol     = FD_IP4_HDR_PROTOCOL_IGMP;
   msg->ip4->check        = (ushort)0; /* Computation completed below */
-  msg->ip4->saddr        = ip4_saddr;
-  msg->ip4->daddr        = ip4_daddr;
+
+  memcpy( msg->ip4->saddr_c, &ip4_saddr, 4U );
+  memcpy( msg->ip4->daddr_c, &ip4_daddr, 4U );
 
   msg->opt[0]            = FD_IP4_OPT_RA;
   msg->opt[1]            = (uchar)4;

--- a/src/util/net/fd_ip4.h
+++ b/src/util/net/fd_ip4.h
@@ -23,8 +23,8 @@
 
 union fd_ip4_hdr {
   struct {
-    uint   ihl     : 4;  /* Header length in words (>=5) */
-    uint   version : 4;  /* IP version (==4), assumes little endian */
+    uchar  ihl     : 4;  /* Header length in words (>=5) */
+    uchar  version : 4;  /* IP version (==4), assumes little endian */
     uchar  tos;          /* Type of service */
     ushort net_tot_len;  /* Frag size in bytes, incl ip hdr, net order */
     ushort net_id;       /* Frag id, unique from sender for long enough, net order */
@@ -32,8 +32,8 @@ union fd_ip4_hdr {
     uchar  ttl;          /* Frag time to live */
     uchar  protocol;     /* Type of payload */
     ushort check;        /* Header checksum ("invariant" order) */
-    uint   saddr;        /* Address of sender, technically net order but all APIs below work with this directly */
-    uint   daddr;        /* Address of destination, tecnically net order but all APIs below work with this directly */
+    uchar  saddr_c[4];   /* Address of sender, technically net order but all APIs below work with this directly */
+    uchar  daddr_c[4];   /* Address of destination, tecnically net order but all APIs below work with this directly */
     /* Up to 40 bytes of options here */
   };
   uint u[5]; /* Actually ihl long, used for checksum calcs */

--- a/src/util/net/fd_ip4.h
+++ b/src/util/net/fd_ip4.h
@@ -23,8 +23,8 @@
 
 union fd_ip4_hdr {
   struct {
-    uchar  ihl     : 4;  /* Header length in words (>=5) */
-    uchar  version : 4;  /* IP version (==4), assumes little endian */
+    uchar  verihl;       /* 4 lsb: IP version (==4), assumes little endian */
+                         /* 4 msb: Header length in words (>=5) */
     uchar  tos;          /* Type of service */
     ushort net_tot_len;  /* Frag size in bytes, incl ip hdr, net order */
     ushort net_id;       /* Frag id, unique from sender for long enough, net order */
@@ -36,10 +36,36 @@ union fd_ip4_hdr {
     uchar  daddr_c[4];   /* Address of destination, tecnically net order but all APIs below work with this directly */
     /* Up to 40 bytes of options here */
   };
-  uint u[5]; /* Actually ihl long, used for checksum calcs */
 };
 
 typedef union fd_ip4_hdr fd_ip4_hdr_t;
+
+/* FD_IP4_GET_VERSION obtains the version from the supplied fd_ip4_hdr */
+
+#define FD_IP4_GET_VERSION(ip4) ((uchar)( ( (uint)(ip4).verihl >> 4u ) & 0x0fu ))
+
+/* FD_IP4_SET_VERSION sets the version in the supplied fd_ip4_hdr */
+
+#define FD_IP4_SET_VERSION(ip4,value) (ip4).verihl = ((uchar)( \
+      ( (uint)(ip4).verihl & 0x0fu ) | ( ( (uint)(value) & 0x0fu ) << 4u ) ))
+
+/* FD_IP4_GET_IHL retrieves the IHL field from the supplied fd_ip4_hdr */
+
+#define FD_IP4_GET_IHL(ip4) ((uchar)( (uint)(ip4).verihl & 0x0fu ))
+
+/* FD_IP4_GET_LEN retrieves and adjusts the IHL field from the supplied fd_ip4_hdr */
+
+#define FD_IP4_GET_LEN(ip4) ( FD_IP4_GET_IHL(ip4) * 4u )
+
+/* FD_IP4_SET_IHL sets the IHL field in the supplied fd_ip4_hdr */
+
+#define FD_IP4_SET_IHL(ip4,value) ((uchar)( \
+      ( (uint)(ip4).verihl & 0xf0u ) | ( (uint)(value) & 0x0fu ) ))
+
+/* FD_IP4_VERIHL combines the suplied IHL and VERISION into a single verihl fields */
+
+#define FD_IP4_VERIHL(version,ihl) ((uchar)( ( ((uint)(version) & 0x0fu) << 4u ) | \
+                                               ((uint)(ihl)     & 0x0fu) ))
 
 /* FD_IP4_ADDR constructs an IP4 address from the 4-tuple x.y.z.w.
    Assumes x,y,z,w are all integers in [0,255]. */
@@ -85,17 +111,30 @@ fd_ip4_hdr_net_frag_off_is_unfragmented( ushort net_frag_off ) { /* net order */
    the packet doesn't do various checksum offload computations. */
 
 FD_FN_PURE static inline ushort
-fd_ip4_hdr_check( fd_ip4_hdr_t const * hdr ) {
-  uint const * u = hdr->u;
+fd_ip4_hdr_check( void const * vp_hdr ) {
+  uchar * cp = (uchar*)vp_hdr;
+
+  uint n = ( (*cp) & 0x0fu );
+
+  /* optimizes the first 5 by unrolling */
+  if( n < 5 ) __builtin_unreachable();
+
   ulong        c = 0UL;
-  uint         n = hdr->ihl; /*FD_COMPILER_FORGET( n );*/
-  for( uint i=0U; i<n; i++ ) c += (ulong)u[i];
+  for( uint i=0U; i<n; i++ ) {
+    uint u;
+
+    /* the compiler elides the copy in practice */
+    memcpy( &u, cp + i*4, 4 );
+    c += (ulong)u;
+  }
+
   c  = ( c>>32            ) +
        ((c>>16) & 0xffffUL) +
        ( c      & 0xffffUL);
   c  = ( c>>16            ) +
        ( c      & 0xffffUL);
   c += ( c>>16            );
+
   return (ushort)~c;
 }
 
@@ -103,15 +142,31 @@ fd_ip4_hdr_check( fd_ip4_hdr_t const * hdr ) {
    header has no options (i.e. ihl==5) */
 
 FD_FN_PURE static inline ushort
-fd_ip4_hdr_check_fast( fd_ip4_hdr_t const * hdr ) {
-  uint const * u = hdr->u;
-  ulong        c = (ulong)u[0] + (ulong)u[1] + (ulong)u[2] + (ulong)u[3] + (ulong)u[4];
+fd_ip4_hdr_check_fast( void const * vp_hdr ) {
+  uchar * cp = (uchar*)vp_hdr;
+
+  uint n = ( (*cp) & 0x0fu );
+
+  /* branches aren't taken don't use branch table entries */
+  if( FD_UNLIKELY( n != 5 ) ) return fd_ip4_hdr_check(vp_hdr);
+
+  /* the compiler knows n here and completely unrolls the loop */
+  ulong c = 0UL;
+  for( uint i=0U; i<n; i++ ) {
+    uint u;
+
+    /* the compiler elides the copy in practice */
+    memcpy( &u, cp + i*4, 4 );
+    c += (ulong)u;
+  }
+
   c  = ( c>>32            ) +
        ((c>>16) & 0xffffUL) +
        ( c      & 0xffffUL);
   c  = ( c>>16            ) +
        ( c      & 0xffffUL);
   c += ( c>>16            );
+
   return (ushort)~c;
 }
 

--- a/src/util/net/fd_pcap.c
+++ b/src/util/net/fd_pcap.c
@@ -283,8 +283,9 @@ fd_pcap_iter_next_split( fd_pcap_iter_t * iter,
       return 0;
     }
 
-    ulong options_len = sizeof(uint)*(((fd_ip4_hdr_t *)_hdr_buf)->ihl - 5U);
-    uchar protocol   = ((fd_ip4_hdr_t *)_hdr_buf)->protocol;
+    fd_ip4_hdr_t * ip4 = (fd_ip4_hdr_t *)_hdr_buf;
+    ulong options_len  = 4u * ( FD_IP4_GET_IHL(*ip4) - 5u );
+    uchar protocol     = ip4->protocol;
 
     _hdr_buf += sizeof(fd_ip4_hdr_t);
     hdr_rem  -= sizeof(fd_ip4_hdr_t);

--- a/src/util/net/test_ip4.c
+++ b/src/util/net/test_ip4.c
@@ -50,9 +50,8 @@ main( int     argc,
   FD_TEST( (ulong)( &(((fd_ip4_hdr_t *)NULL)->ttl         ) )== 8UL );
   FD_TEST( (ulong)( &(((fd_ip4_hdr_t *)NULL)->protocol    ) )== 9UL );
   FD_TEST( (ulong)( &(((fd_ip4_hdr_t *)NULL)->check       ) )==10UL );
-  FD_TEST( (ulong)( &(((fd_ip4_hdr_t *)NULL)->saddr       ) )==12UL );
-  FD_TEST( (ulong)( &(((fd_ip4_hdr_t *)NULL)->daddr       ) )==16UL );
-  FD_TEST( (ulong)(  (((fd_ip4_hdr_t *)NULL)->u           ) )== 0UL );
+  FD_TEST( (ulong)( &(((fd_ip4_hdr_t *)NULL)->saddr_c     ) )==12UL );
+  FD_TEST( (ulong)( &(((fd_ip4_hdr_t *)NULL)->daddr_c     ) )==16UL );
 
   uint ip4_addr_ucast = FD_IP4_ADDR(  1,  2,  3,  4); FD_TEST( ip4_addr_ucast==0x04030201U );
   uint ip4_addr_mcast = FD_IP4_ADDR(239, 17, 34, 51); FD_TEST( ip4_addr_mcast==0x332211efU );


### PR DESCRIPTION
UBSAN kicked out a lot of unaligned access UB cases. In preference for keeping the warnings/errors/UB to a minimum/zero I have "fixed" a number of them. In some key areas I ensured that the output of several versions of gcc and clang produce good output, particularly in eliding the memcpys.
Note: using fd_memcpy would prevent the compiler from eliding them.