### PR TITLE
log: don't lock the log after subprocess termination

### DIFF
--- a/src/app/fdctl/run/run.c
+++ b/src/app/fdctl/run/run.c
@@ -429,7 +429,7 @@ main_pid_namespace( void * args ) {
   int wstatus;
   pid_t exited_pid = wait4( -1, &wstatus, (int)__WCLONE, NULL );
   if( FD_UNLIKELY( exited_pid == -1 ) ) {
-    fd_log_private_fprintf_0( STDERR_FILENO, "wait4() failed (%i-%s)", errno, fd_io_strerror( errno ) );
+    fd_log_private_fprintf_nolock_0( STDERR_FILENO, "wait4() failed (%i-%s)", errno, fd_io_strerror( errno ) );
     exit_group( 1 );
   }
 
@@ -444,10 +444,10 @@ main_pid_namespace( void * args ) {
   }
 
   if( FD_UNLIKELY( !WIFEXITED( wstatus ) ) ) {
-    fd_log_private_fprintf_0( STDERR_FILENO, "tile %lu (%s) exited with signal %d (%s)\n", tile_idx, name, WTERMSIG( wstatus ), fd_io_strsignal( WTERMSIG( wstatus ) ) );
+    fd_log_private_fprintf_nolock_0( STDERR_FILENO, "tile %lu (%s) exited with signal %d (%s)\n", tile_idx, name, WTERMSIG( wstatus ), fd_io_strsignal( WTERMSIG( wstatus ) ) );
     exit_group( WTERMSIG( wstatus ) ? WTERMSIG( wstatus ) : 1 );
   }
-  fd_log_private_fprintf_0( STDERR_FILENO, "tile %lu (%s) exited with code %d\n", tile_idx, name, WEXITSTATUS( wstatus ) );
+  fd_log_private_fprintf_nolock_0( STDERR_FILENO, "tile %lu (%s) exited with code %d\n", tile_idx, name, WEXITSTATUS( wstatus ) );
   exit_group( WEXITSTATUS( wstatus ) ? WEXITSTATUS( wstatus ) : 1 );
   return 0;
 }
@@ -459,7 +459,7 @@ static void
 parent_signal( int sig ) {
   (void)sig;
   if( pid_namespace ) kill( pid_namespace, SIGKILL );
-  fd_log_private_fprintf_0( STDERR_FILENO, "Log at \"%s\"\n", fd_log_private_path );
+  fd_log_private_fprintf_nolock_0( STDERR_FILENO, "Log at \"%s\"\n", fd_log_private_path );
   exit_group( 0 );
 }
 
@@ -516,7 +516,7 @@ run_firedancer( config_t * const config ) {
   int wstatus;
   pid_t pid2 = wait4( pid_namespace, &wstatus, (int)__WCLONE, NULL );
   if( FD_UNLIKELY( pid2 == -1 ) ) {
-    fd_log_private_fprintf_0( STDERR_FILENO, "error waiting for child process to exit\nLog at \"%s\"\n", fd_log_private_path );
+    fd_log_private_fprintf_nolock_0( STDERR_FILENO, "error waiting for child process to exit\nLog at \"%s\"\n", fd_log_private_path );
     exit_group( 1 );
   }
   if( FD_UNLIKELY( WIFSIGNALED( wstatus ) ) ) exit_group( WTERMSIG( wstatus ) ? WTERMSIG( wstatus ) : 1 );

--- a/src/app/fddev/dev.c
+++ b/src/app/fddev/dev.c
@@ -45,7 +45,7 @@ parent_signal( int sig ) {
     if( kill( firedancer_pid, SIGINT ) ) err = 1;
   if( FD_LIKELY( monitor_pid ) )
     if( kill( monitor_pid, SIGKILL ) ) err = 1;
-  fd_log_private_fprintf_0( STDERR_FILENO, "Log at \"%s\"\n", fd_log_private_path );
+  fd_log_private_fprintf_nolock_0( STDERR_FILENO, "Log at \"%s\"\n", fd_log_private_path );
   exit_group( err );
 }
 
@@ -128,7 +128,7 @@ dev_cmd_fn( args_t *         args,
     int wstatus;
     pid_t exited_pid = wait4( -1, &wstatus, (int)__WALL, NULL );
     if( FD_UNLIKELY( exited_pid == -1 ) ) {
-      fd_log_private_fprintf_0( STDERR_FILENO, "wait4() failed (%i-%s)", errno, fd_io_strerror( errno ) );
+      fd_log_private_fprintf_nolock_0( STDERR_FILENO, "wait4() failed (%i-%s)", errno, fd_io_strerror( errno ) );
       exit_group( 1 );
     }
 

--- a/src/util/log/fd_log.h
+++ b/src/util/log/fd_log.h
@@ -578,6 +578,9 @@ void fd_log_level_core_set   ( int level );
 void
 fd_log_private_fprintf_0( int fd, char const * fmt, ... ) __attribute__((format(printf,2,3))); /* Type check the fmt string at compile time */
 
+void
+fd_log_private_fprintf_nolock_0( int fd, char const * fmt, ... ) __attribute__((format(printf,2,3))); /* Type check the fmt string at compile time */
+
 char const *
 fd_log_private_0( char const * fmt, ... ) __attribute__((format(printf,1,2))); /* Type check the fmt string at compile time */
 


### PR DESCRIPTION
If a child process is holding the lock for the log, and then the process tree is killed (due to Ctrl+C, or another process terminates), it will die holding the lock, and the process supervision infrastructure will hang trying to print some last diagnostics.