### PR TITLE
Output audit.log in CI to help with debugging bad syscalls

### DIFF
--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -12,6 +12,9 @@ jobs:
     env:
       CC: gcc
     steps:
+      - name: Install ausearch for debugging seccomp/bad syscalls
+        run: sudo apt update && sudo apt install -y auditd
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -24,5 +27,4 @@ jobs:
         run: make -j -Otarget fddev unit-test
 
       - name: Run functional tests
-        run: |
-          ./src/test/single-transaction.sh
+        run: ./src/test/single-transaction.sh

--- a/src/test/single-transaction.sh
+++ b/src/test/single-transaction.sh
@@ -5,13 +5,21 @@ set -xeuo pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "${SCRIPT_DIR}/../../"
 
+cleanup() {
+    # TODO: We grep instead of using 'sudo ausearch -c fddev' because ausearch returns 'no matches'
+    # when it should not.
+    sudo grep -n fddev /var/log/audit/audit.log
+}
+trap cleanup EXIT INT TERM
+
 # start fddev, send a single transaction, and if everything works return 0
 FDDEV=./build/native/gcc/bin/fddev
+
 # TODO: For some reason /tmp does not work on the github runner for --log-path
-timeout --preserve-status 15 $FDDEV configure init all --netns --log-path ~/log
-timeout --preserve-status 15 $FDDEV --no-configure --netns --log-path ~/log &
+timeout --preserve-status --kill-after=20 15 $FDDEV configure init all --netns --log-path ./log
+timeout --preserve-status --kill-after=20 15 $FDDEV --no-configure --netns --log-path ./log &
 FDDEV_PID=$!
-timeout --preserve-status 15 $FDDEV txn --netns --log-path ~/log2
+timeout --preserve-status --kill-after=20 15 $FDDEV txn --netns --log-path ./log2
 RETVAL=$?
 sudo kill $FDDEV_PID
 exit $RETVAL


### PR DESCRIPTION
An example of a failed pipeline due to a bad syscall https://github.com/firedancer-io/firedancer/actions/runs/6501223757/job/17658136990?pr=766#step:7:779
```
52:type=SECCOMP msg=audit(1697147265.298:78): auid=4294967295 uid=1000 gid=1000 ses=4294967295 subj=unconfined pid=53620 comm="fddev" exe="/home/runner/work/firedancer/firedancer/build/native/gcc/bin/fddev" sig=31 arch=c000003e syscall=1 compat=0 ip=0x7fad80314a37 code=0x80000000AUID="unset" UID="runner" GID="runner" ARCH=x86_64 SYSCALL=write
```

A bad syscall to `write`.