### PR TITLE
Fuzzers for hashing algorithms in ballet

### DIFF
--- a/src/ballet/blake3/Local.mk
+++ b/src/ballet/blake3/Local.mk
@@ -5,3 +5,4 @@ $(call add-asms,blake3_avx2_x86-64,fd_ballet)
 endif
 
 $(call make-unit-test,test_blake3,test_blake3,fd_ballet fd_util)
+$(call fuzz-test,fuzz_blake3,fuzz_blake3,fd_ballet fd_util)

--- a/src/ballet/blake3/fuzz_blake3.c
+++ b/src/ballet/blake3/fuzz_blake3.c
@@ -1,0 +1,56 @@
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../util/fd_util.h"
+#include "fd_blake3.h"
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  /* Set up shell without signal handlers */
+  putenv( "FD_LOG_BACKTRACE=0" );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+  return 0;
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         size ) {
+  // hash single message
+  char const * msg = ( char const * ) data;
+
+  uchar hash1[ 32 ] __attribute__((aligned(32)));
+  uchar hash2[ 32 ] __attribute__((aligned(32)));
+
+  fd_blake3_t sha[1];
+  if( FD_UNLIKELY( fd_blake3_init( sha )!=sha ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( fd_blake3_append( sha, msg, size )!=sha ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( fd_blake3_fini( sha, hash1 )!=hash1 ) ) {
+    __builtin_trap();
+  }
+
+  if( FD_UNLIKELY( fd_blake3_init( sha )!=sha ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( fd_blake3_append( sha, msg, size )!=sha ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( fd_blake3_fini( sha, hash2 )!=hash2 ) ) {
+    __builtin_trap();
+  }
+
+  if( FD_UNLIKELY( memcmp( hash1, hash2, 32UL ) ) ) {
+    __builtin_trap();
+  }
+
+  return 0;
+}

--- a/src/ballet/hmac/Local.mk
+++ b/src/ballet/hmac/Local.mk
@@ -1,4 +1,5 @@
 $(call add-hdrs,fd_hmac.h)
 $(call add-objs,fd_hmac,fd_ballet)
 $(call make-unit-test,test_hmac,test_hmac,fd_ballet fd_util)
+$(call fuzz-test,fuzz_hmac,fuzz_hmac,fd_ballet fd_util)
 $(call run-unit=test,test_hmac)

--- a/src/ballet/hmac/fuzz_hmac.c
+++ b/src/ballet/hmac/fuzz_hmac.c
@@ -1,0 +1,79 @@
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../util/fd_util.h"
+#include "fd_hmac.h"
+#include "../sha256/fd_sha256.h"
+#include "../sha512/fd_sha512.h"
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  /* Set up shell without signal handlers */
+  putenv( "FD_LOG_BACKTRACE=0" );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+  return 0;
+}
+
+struct hmac_test {
+  ulong key_sz;
+  uchar key[ ];
+  /* uchar msg[ ]; */
+};
+typedef struct hmac_test hmac_test_t;
+
+#define KEY_MAX (256UL)
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         size ) {
+  if( FD_UNLIKELY( size<64UL ) ) return -1;
+  hmac_test_t * const test = ( hmac_test_t * const ) data;
+
+  ulong key_size = test->key_sz & (KEY_MAX-1UL);
+  if( FD_UNLIKELY( size<(64UL+key_size) ) ) return -1;
+  char const * key = key_size ? ( char const * ) test->key : NULL;
+
+  ulong msg_size = size-(64UL+key_size); 
+  char const * msg = msg_size ? ( char const * ) test->key + key_size : NULL;
+
+  uchar hash1[ 64 ] __attribute__((aligned(64)));
+  uchar hash2[ 64 ] __attribute__((aligned(64)));
+
+  if( FD_UNLIKELY( fd_hmac_sha256( msg, msg_size, key, key_size, hash1 )!=hash1 ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( fd_hmac_sha256( msg, msg_size, key, key_size, hash2 )!=hash2 ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( memcmp( hash1, hash2, FD_SHA256_HASH_SZ ) ) ) {
+    __builtin_trap();
+  }
+
+  if( FD_UNLIKELY( fd_hmac_sha384( msg, msg_size, key, key_size, hash1 )!=hash1 ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( fd_hmac_sha384( msg, msg_size, key, key_size, hash2 )!=hash2 ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( memcmp( hash1, hash2, FD_SHA384_HASH_SZ ) ) ) {
+    __builtin_trap();
+  }
+
+  if( FD_UNLIKELY( fd_hmac_sha512( msg, msg_size, key, key_size, hash1 )!=hash1 ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( fd_hmac_sha512( msg, msg_size, key, key_size, hash2 )!=hash2 ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( memcmp( hash1, hash2, FD_SHA512_HASH_SZ ) ) ) {
+    __builtin_trap();
+  }
+
+  return 0;
+}

--- a/src/ballet/keccak256/Local.mk
+++ b/src/ballet/keccak256/Local.mk
@@ -2,4 +2,5 @@ $(call add-hdrs,fd_keccak256.h)
 $(call add-objs,fd_keccak256,fd_ballet)
 
 $(call make-unit-test,test_keccak256,test_keccak256,fd_ballet fd_util)
+$(call fuzz-test,fuzz_keccak256,fuzz_keccak256,fd_ballet fd_util)
 $(call run-unit-test,test_keccak256)

--- a/src/ballet/keccak256/fuzz_keccak256.c
+++ b/src/ballet/keccak256/fuzz_keccak256.c
@@ -1,0 +1,50 @@
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../util/fd_util.h"
+#include "fd_keccak256.h"
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  /* Set up shell without signal handlers */
+  putenv( "FD_LOG_BACKTRACE=0" );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+  return 0;
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         size ) {
+  // hash single message
+  char const * msg = ( char const * ) data;
+
+  uchar hash1[ 32 ] __attribute__((aligned(32)));
+  uchar hash2[ 32 ] __attribute__((aligned(32)));
+
+  fd_keccak256_t sha[1];
+  if( FD_UNLIKELY( fd_keccak256_init( sha )!=sha ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( fd_keccak256_append( sha, msg, size )!=sha ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( fd_keccak256_fini( sha, hash1 )!=hash1 ) ) {
+    __builtin_trap();
+  }
+
+  if( FD_UNLIKELY( fd_keccak256_hash( data, size, hash2 )!=hash2 ) ) {
+    __builtin_trap();
+  }
+
+  if( FD_UNLIKELY( memcmp( hash1, hash2, 32UL ) ) ) {
+    __builtin_trap();
+  }
+
+  return 0;
+}

--- a/src/ballet/murmur3/Local.mk
+++ b/src/ballet/murmur3/Local.mk
@@ -1,3 +1,4 @@
 $(call add-hdrs,fd_murmur3.h)
 $(call add-objs,fd_murmur3,fd_ballet)
 $(call make-unit-test,test_murmur3,test_murmur3,fd_ballet fd_util)
+$(call fuzz-test,fuzz_murmur3,fuzz_murmur3,fd_ballet fd_util)

--- a/src/ballet/murmur3/fuzz_murmur3.c
+++ b/src/ballet/murmur3/fuzz_murmur3.c
@@ -1,0 +1,35 @@
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../util/fd_util.h"
+#include "fd_murmur3.h"
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  /* Set up shell without signal handlers */
+  putenv( "FD_LOG_BACKTRACE=0" );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+  return 0;
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         size ) {
+  // hash single message
+  char const * msg = ( char const * ) data;
+
+  uint hash1 = fd_murmur3_32( msg, size, 0 );
+  uint hash2 = fd_murmur3_32( msg, size, 0 );
+
+  if( FD_UNLIKELY( hash1!=hash2 ) ) {
+    __builtin_trap();
+  }
+
+  return 0;
+}

--- a/src/ballet/sha256/Local.mk
+++ b/src/ballet/sha256/Local.mk
@@ -11,4 +11,5 @@ $(call add-objs,fd_sha256_batch_avx512,fd_ballet)
 endif
 
 $(call make-unit-test,test_sha256,test_sha256,fd_ballet fd_util)
+$(call fuzz-test,fuzz_sha256,fuzz_sha256,fd_ballet fd_util)
 $(call run-unit-test,test_sha256)

--- a/src/ballet/sha256/fuzz_sha256.c
+++ b/src/ballet/sha256/fuzz_sha256.c
@@ -1,0 +1,86 @@
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../util/fd_util.h"
+#include "fd_sha256.h"
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  /* Set up shell without signal handlers */
+  putenv( "FD_LOG_BACKTRACE=0" );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+  return 0;
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         size ) {
+  // hash single message
+  char const * msg = ( char const * ) data;
+
+  uchar hash1[ 32 ] __attribute__((aligned(32)));
+  uchar hash2[ 32 ] __attribute__((aligned(32)));
+
+  fd_sha256_t sha[1];
+  if( FD_UNLIKELY( fd_sha256_init( sha )!=sha ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( fd_sha256_append( sha, msg, size )!=sha ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( fd_sha256_fini( sha, hash1 )!=hash1 ) ) {
+    __builtin_trap();
+  }
+
+  if( FD_UNLIKELY( fd_sha256_hash( data, size, hash2 )!=hash2 ) ) {
+    __builtin_trap();
+  }
+
+  if( FD_UNLIKELY( memcmp( hash1, hash2, 32UL ) ) ) {
+    __builtin_trap();
+  }
+
+  // batch hashing
+  #define BATCH_CNT 32UL /* must be at least 1UL */
+  if( size>=BATCH_CNT ) {
+    uchar hash_mem[ 32UL*BATCH_CNT ] __attribute__((aligned(32)));
+
+    fd_sha256_batch_t batch_sha[1];
+    if( FD_UNLIKELY( fd_sha256_batch_init( batch_sha )!=batch_sha ) ) {
+      __builtin_trap();
+    }
+
+    uchar *      hashes   [ BATCH_CNT ];
+    const char * messages [ BATCH_CNT ];
+    ulong        msg_sizes[ BATCH_CNT ];
+
+    ulong sz = size/BATCH_CNT;
+    for( ulong batch_idx=0UL; batch_idx<BATCH_CNT; batch_idx++ ) {
+      hashes   [ batch_idx ] = hash_mem + sz*batch_idx;
+      messages [ batch_idx ] = ( char const *) data + sz*batch_idx;
+      msg_sizes[ batch_idx ] = batch_idx<BATCH_CNT-1UL ? sz : sz+size%BATCH_CNT;
+      if( FD_UNLIKELY( fd_sha256_batch_add( batch_sha, messages[ batch_idx ], msg_sizes[ batch_idx ], hashes[ batch_idx ] )!=batch_sha ) ) {
+        __builtin_trap();
+      }
+    }
+
+    if( FD_UNLIKELY( fd_sha256_batch_fini( batch_sha )==batch_sha ) ) {
+      __builtin_trap();
+    }
+
+    for( ulong batch_idx=0UL; batch_idx<BATCH_CNT; batch_idx++ ) {
+      uchar ref_hash[ 32 ] __attribute__((aligned(32)));
+      if( FD_UNLIKELY( memcmp( fd_sha256_hash( messages[ batch_idx ], msg_sizes[ batch_idx ], ref_hash ), hashes[ batch_idx ], 32UL ) ) ) {
+        __builtin_trap();
+      }
+    }
+  }
+
+  return 0;
+}

--- a/src/ballet/sha512/Local.mk
+++ b/src/ballet/sha512/Local.mk
@@ -9,7 +9,9 @@ $(call add-objs,fd_sha512_batch_avx512,fd_ballet)
 endif
 
 $(call make-unit-test,test_sha512,test_sha512,fd_ballet fd_util)
+$(call fuzz-test,fuzz_sha512,fuzz_sha512,fd_ballet fd_util)
 $(call run-unit-test,test_sha512,)
 
 $(call make-unit-test,test_sha384,test_sha384,fd_ballet fd_util)
+$(call fuzz-test,fuzz_sha384,fuzz_sha384,fd_ballet fd_util)
 $(call run-unit-test,test_sha384)

--- a/src/ballet/sha512/fuzz_sha384.c
+++ b/src/ballet/sha512/fuzz_sha384.c
@@ -1,0 +1,50 @@
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../util/fd_util.h"
+#include "fd_sha512.h"
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  /* Set up shell without signal handlers */
+  putenv( "FD_LOG_BACKTRACE=0" );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+  return 0;
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         size ) {
+  // hash single message
+  char const * msg = ( char const * ) data;
+
+  uchar hash1[ 48 ] __attribute__((aligned(64)));
+  uchar hash2[ 48 ] __attribute__((aligned(64)));
+
+  fd_sha384_t sha[1];
+  if( FD_UNLIKELY( fd_sha384_init( sha )!=sha ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( fd_sha384_append( sha, msg, size )!=sha ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( fd_sha384_fini( sha, hash1 )!=hash1 ) ) {
+    __builtin_trap();
+  }
+
+  if( FD_UNLIKELY( fd_sha384_hash( data, size, hash2 )!=hash2 ) ) {
+    __builtin_trap();
+  }
+
+  if( FD_UNLIKELY( memcmp( hash1, hash2, 48UL ) ) ) {
+    __builtin_trap();
+  }
+
+  return 0;
+}

--- a/src/ballet/sha512/fuzz_sha512.c
+++ b/src/ballet/sha512/fuzz_sha512.c
@@ -1,0 +1,86 @@
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../util/fd_util.h"
+#include "fd_sha512.h"
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  /* Set up shell without signal handlers */
+  putenv( "FD_LOG_BACKTRACE=0" );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+  return 0;
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         size ) {
+  // hash single message
+  char const * msg = ( char const * ) data;
+
+  uchar hash1[ 64 ] __attribute__((aligned(64)));
+  uchar hash2[ 64 ] __attribute__((aligned(64)));
+
+  fd_sha512_t sha[1];
+  if( FD_UNLIKELY( fd_sha512_init( sha )!=sha ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( fd_sha512_append( sha, msg, size )!=sha ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( fd_sha512_fini( sha, hash1 )!=hash1 ) ) {
+    __builtin_trap();
+  }
+
+  if( FD_UNLIKELY( fd_sha512_hash( data, size, hash2 )!=hash2 ) ) {
+    __builtin_trap();
+  }
+
+  if( FD_UNLIKELY( memcmp( hash1, hash2, 64UL ) ) ) {
+    __builtin_trap();
+  }
+
+  // batch hashing
+  #define BATCH_CNT 32UL /* must be at least 1UL */
+  if( size>=BATCH_CNT ) {
+    uchar hash_mem[ 64UL*BATCH_CNT ] __attribute__((aligned(64)));
+
+    fd_sha512_batch_t batch_sha[1];     
+    if( FD_UNLIKELY( fd_sha512_batch_init( batch_sha )!=batch_sha ) ) {
+      __builtin_trap();
+    }
+
+    uchar *      hashes   [ BATCH_CNT ];
+    const char * messages [ BATCH_CNT ];
+    ulong        msg_sizes[ BATCH_CNT ];
+
+    ulong sz = size/BATCH_CNT;
+    for( ulong batch_idx=0UL; batch_idx<BATCH_CNT; batch_idx++ ) {
+      hashes   [ batch_idx ] = hash_mem + sz*batch_idx;
+      messages [ batch_idx ] = ( char const *) data + sz*batch_idx;
+      msg_sizes[ batch_idx ] = batch_idx<BATCH_CNT-1UL ? sz : sz+size%BATCH_CNT;
+      if( FD_UNLIKELY( fd_sha512_batch_add( batch_sha, messages[ batch_idx ], msg_sizes[ batch_idx ], hashes[ batch_idx ] )!=batch_sha ) ) {
+        __builtin_trap();
+      }
+    }
+
+    if( FD_UNLIKELY( fd_sha512_batch_fini( batch_sha )==batch_sha ) ) {
+      __builtin_trap();
+    }
+
+    for( ulong batch_idx=0UL; batch_idx<BATCH_CNT; batch_idx++ ) {
+      uchar ref_hash[ 64 ] __attribute__((aligned(64)));
+      if( FD_UNLIKELY( memcmp( fd_sha512_hash( messages[ batch_idx ], msg_sizes[ batch_idx ], ref_hash ), hashes[ batch_idx ], 64UL ) ) ) {
+        __builtin_trap();
+      }
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This PR adds fuzzers for the hashing algorithm implementations found in `ballet`:
- `sha256`
- `sha512` (and `sha384`)
- `keccak256`
- `blake3`
- `murmur3`
- `hmac`