### PR TITLE
fd_pod: remove FD_FN_PURE from fd_pod_query_buf

### DIFF
--- a/src/util/pod/fd_pod.h
+++ b/src/util/pod/fd_pod.h
@@ -790,7 +790,7 @@ fd_pod_query_subpod( uchar const * FD_RESTRICT pod,
    untouched otherwise.  The return pointer's lifetime is the pod's
    local join lifetime or an invalidating operation is done on the pod. */
 
-FD_FN_PURE static inline void const *
+static inline void const *
 fd_pod_query_buf( uchar const * FD_RESTRICT pod,
                   char const  * FD_RESTRICT path,
                   ulong       * FD_RESTRICT opt_buf_sz ) {


### PR DESCRIPTION
`fd_pod_query_buf` writes to `opt_buf_sz` if it is non-NULL, and thus isn't a pure function according to the GCC manual