### PR TITLE
util: add valloc

### DIFF
--- a/src/util/valloc/Local.mk
+++ b/src/util/valloc/Local.mk
@@ -1,0 +1,2 @@
+$(call add-hdrs,fd_valloc.h)
+$(call add-objs,fd_valloc,fd_util)

--- a/src/util/valloc/fd_valloc.c
+++ b/src/util/valloc/fd_valloc.c
@@ -1,0 +1,22 @@
+#include "fd_valloc.h"
+#include "../bits/fd_bits.h"
+#include <stdlib.h>
+
+static void *
+fd_libc_malloc_virtual( void * _self __attribute__((unused)),
+                        ulong  align,
+                        ulong  sz ) {
+  return aligned_alloc( align, fd_ulong_align_up( sz, align ) );
+}
+
+static void
+fd_libc_free_virtual( void * _self __attribute__((unused)),
+                      void * _addr ) {
+  free( _addr );
+}
+
+const fd_valloc_vtable_t
+fd_libc_vtable = {
+  .malloc = fd_libc_malloc_virtual,
+  .free   = fd_libc_free_virtual
+};

--- a/src/util/valloc/fd_valloc.h
+++ b/src/util/valloc/fd_valloc.h
@@ -1,0 +1,50 @@
+#ifndef HEADER_fd_src_util_valloc_fd_valloc_h
+#define HEADER_fd_src_util_valloc_fd_valloc_h
+
+#include "../fd_util_base.h"
+
+/* APIs to abstract memory allocators. */
+
+typedef void * (* fd_valloc_malloc_fn_t)( void * allocator, ulong align, ulong sz );
+typedef void   (* fd_valloc_free_fn_t  )( void * allocator, void * ptr );
+
+struct fd_valloc_vtable {
+  fd_valloc_malloc_fn_t malloc;
+  fd_valloc_free_fn_t   free;
+};
+
+typedef struct fd_valloc_vtable fd_valloc_vtable_t;
+
+struct fd_valloc {
+  void *                     self;
+  fd_valloc_vtable_t const * vt;
+};
+
+typedef struct fd_valloc fd_valloc_t;
+
+FD_PROTOTYPES_BEGIN
+
+extern const fd_valloc_vtable_t fd_libc_vtable;
+
+static inline FD_FN_CONST fd_valloc_t
+fd_libc_alloc_virtual( void ) {
+  fd_valloc_t valloc = { NULL, &fd_libc_vtable };
+  return valloc;
+}
+
+static inline void *
+fd_valloc_malloc( fd_valloc_t valloc,
+                  ulong       align,
+                  ulong       sz ) {
+  return valloc.vt->malloc( valloc.self, align, sz );
+}
+
+static inline void
+fd_valloc_free( fd_valloc_t valloc,
+                void *      ptr ) {
+  valloc.vt->free( valloc.self, ptr );
+}
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_util_valloc_fd_valloc_h */


### PR DESCRIPTION
Backports valloc from the Firedancer runtime branch. 

fd_valloc is an abstract class providing a minimal allocation API.
Heavily used in Firedancer runtime code, such as the types generator.

Also used to swap out fd_alloc for libc malloc for debugging, such as when running with AddressSanitizer.