### PR TITLE
AVX-512 accelerated batch SHA256 implementation, related features and minor cleanups

### DIFF
--- a/src/ballet/ed25519/fd_ed25519_user.c
+++ b/src/ballet/ed25519/fd_ed25519_user.c
@@ -477,12 +477,10 @@ fd_ed25519_public_from_private( void *        A,
   /* WARNING!  Some implementations do a mod L here (including the go
      implementation but not OpenSSL).  The standard doesn't indicate to
      do this here but it does indicate to do it in the sign operation.
-     It is also highly suggestive there should be a mod L in the verify
-     operation ( see "as an integer S, in the range 0 <= s < L" in 5.1.7
-     (page 14) and "S is a member of the set {0, 1, ..., L-1}." in 3.4
-     (page 8) ) and OpenSSL does it there.  However, the standard is
-     quite sloppy here.  Commenting out for now to match the standard
-     and OpenSSL behavior. */
+     The standard does not explicitly indicate to do it in the verify
+     operation but it can be inferred following the sign operation,
+     and OpenSSL does it there. The standard is quite sloppy here.
+     Commenting out for now to match the standard and OpenSSL behavior. */
 
 //fd_ed25519_sc_reduce( h, h ); /* TODO: AVX-512 VERSION (THIS IS MOD _L_, NOT MOD P) */
 
@@ -680,9 +678,8 @@ fd_ed25519_verify( void const *  M,
                   r, 32UL ), A, 32UL ), M, sz ), k );
 
   /* Note: the spec does not explicitly indicate whether k should be reduced
-     mod l here.  However, it does implicitly mention that:
-        "... as an integer S, in the range 0 <= s < L" in 5.1.7 (page 14)
-        "... S is a member of the set {0, 1, ..., L-1}." in 3.4 (page  8)
+     mod l here.  However, it does indicate so when signing (Section 5.1.6
+     step 5, page 14): "... For efficiency, again reduce k modulo L first."
      This matches OpenSSL and sign implementation above. */
 
   fd_ed25519_sc_reduce( k, k ); /* TODO: make AVX-512 accelerated version */

--- a/src/ballet/sha256/Local.mk
+++ b/src/ballet/sha256/Local.mk
@@ -6,6 +6,9 @@ endif
 ifdef FD_HAS_AVX
 $(call add-objs,fd_sha256_batch_avx,fd_ballet)
 endif
+ifdef FD_HAS_AVX512
+$(call add-objs,fd_sha256_batch_avx512,fd_ballet)
+endif
 
 $(call make-unit-test,test_sha256,test_sha256,fd_ballet fd_util)
 $(call run-unit-test,test_sha256)

--- a/src/ballet/sha256/fd_sha256.h
+++ b/src/ballet/sha256/fd_sha256.h
@@ -157,6 +157,12 @@ FD_PROTOTYPES_END
 #define FD_SHA256_BATCH_ALIGN     ...
 #define FD_SHA256_BATCH_FOOTPRINT ...
 
+/* FD_SHA256_BATCH_MAX returns the batch size used under the hood.
+   Will be positive.  Users should not normally need use this for
+   anything. */
+
+#define FD_SHA256_BATCH_MAX       ...
+
 /* A fd_sha256_batch_t is an opaque handle for a set of SHA-256
    calculations. */
 
@@ -241,83 +247,21 @@ fd_sha256_batch_abort( fd_sha256_batch_t * batch );
 
 #endif
 
-#if FD_HAS_AVX /* AVX accelerated batching implementation */
+#ifndef FD_SHA256_BATCH_IMPL
+#if FD_HAS_AVX512
+#define FD_SHA256_BATCH_IMPL 2
+#elif FD_HAS_AVX
+#define FD_SHA256_BATCH_IMPL 1
+#else
+#define FD_SHA256_BATCH_IMPL 0
+#endif
+#endif
 
-#define FD_SHA256_BATCH_ALIGN     (128UL)
-#define FD_SHA256_BATCH_FOOTPRINT (256UL)
-
-/* This is exposed here to facilitate inlining various operations */
-
-#define FD_SHA256_PRIVATE_BATCH_MAX (8UL)
-
-struct __attribute__((aligned(FD_SHA256_BATCH_ALIGN))) fd_sha256_private_batch {
-  void const * data[ FD_SHA256_PRIVATE_BATCH_MAX ]; /* AVX aligned */
-  ulong        sz  [ FD_SHA256_PRIVATE_BATCH_MAX ]; /* AVX aligned */
-  void *       hash[ FD_SHA256_PRIVATE_BATCH_MAX ]; /* AVX aligned */
-  ulong        cnt;
-};
-
-typedef struct fd_sha256_private_batch fd_sha256_batch_t;
-
-FD_PROTOTYPES_BEGIN
-
-/* Internal use only */
-
-void
-fd_sha256_private_batch_avx( ulong          batch_cnt,    /* In [1,FD_SHA256_PRIVATE_BATCH_MAX] */
-                             void const *   batch_data,   /* Indexed [0,FD_SHA256_PRIVATE_BATCH_MAX), aligned 32,
-                                                             only [0,batch_cnt) used, essentially a msg_t const * const * */
-                             ulong const *  batch_sz,     /* Indexed [0,FD_SHA256_PRIVATE_BATCH_MAX), aligned 32,
-                                                             only [0,batch_cnt) used */
-                             void * const * batch_hash ); /* Indexed [0,FD_SHA256_PRIVATE_BATCH_MAX), aligned 32,
-                                                             only [0,batch_cnt) used */
-
-FD_FN_CONST static inline ulong fd_sha256_batch_align    ( void ) { return alignof(fd_sha256_batch_t); }
-FD_FN_CONST static inline ulong fd_sha256_batch_footprint( void ) { return sizeof (fd_sha256_batch_t); }
-
-static inline fd_sha256_batch_t *
-fd_sha256_batch_init( void * mem ) {
-  fd_sha256_batch_t * batch = (fd_sha256_batch_t *)mem;
-  batch->cnt = 0UL;
-  return batch;
-}
-
-static inline fd_sha256_batch_t *
-fd_sha256_batch_add( fd_sha256_batch_t * batch,
-                     void const *        data,
-                     ulong               sz,
-                     void *              hash ) {
-  ulong batch_cnt = batch->cnt;
-  batch->data[ batch_cnt ] = data;
-  batch->sz  [ batch_cnt ] = sz;
-  batch->hash[ batch_cnt ] = hash;
-  batch_cnt++;
-  if( FD_UNLIKELY( batch_cnt==FD_SHA256_PRIVATE_BATCH_MAX ) ) {
-    fd_sha256_private_batch_avx( batch_cnt, batch->data, batch->sz, batch->hash );
-    batch_cnt = 0UL;
-  }
-  batch->cnt = batch_cnt;
-  return batch;
-}
-
-static inline void *
-fd_sha256_batch_fini( fd_sha256_batch_t * batch ) {
-  ulong batch_cnt = batch->cnt;
-  if( FD_LIKELY( batch_cnt ) ) fd_sha256_private_batch_avx( batch_cnt, batch->data, batch->sz, batch->hash );
-  return (void *)batch;
-}
-
-static inline void *
-fd_sha256_batch_abort( fd_sha256_batch_t * batch ) {
-  return (void *)batch;
-}
-
-FD_PROTOTYPES_END
-
-#else /* Reference batching implementation */
+#if FD_SHA256_BATCH_IMPL==0 /* Reference batching implementation */
 
 #define FD_SHA256_BATCH_ALIGN     (1UL)
 #define FD_SHA256_BATCH_FOOTPRINT (1UL)
+#define FD_SHA256_BATCH_MAX       (1UL)
 
 typedef uchar fd_sha256_batch_t;
 
@@ -342,6 +286,152 @@ static inline void * fd_sha256_batch_abort( fd_sha256_batch_t * batch ) { return
 
 FD_PROTOTYPES_END
 
+#elif FD_SHA256_BATCH_IMPL==1 /* AVX accelerated batching implementation */
+
+#define FD_SHA256_BATCH_ALIGN     (128UL)
+#define FD_SHA256_BATCH_FOOTPRINT (256UL)
+#define FD_SHA256_BATCH_MAX       (8UL)
+
+/* This is exposed here to facilitate inlining various operations */
+
+struct __attribute__((aligned(FD_SHA256_BATCH_ALIGN))) fd_sha256_private_batch {
+  void const * data[ FD_SHA256_BATCH_MAX ]; /* AVX aligned */
+  ulong        sz  [ FD_SHA256_BATCH_MAX ]; /* AVX aligned */
+  void *       hash[ FD_SHA256_BATCH_MAX ]; /* AVX aligned */
+  ulong        cnt;
+};
+
+typedef struct fd_sha256_private_batch fd_sha256_batch_t;
+
+FD_PROTOTYPES_BEGIN
+
+/* Internal use only */
+
+void
+fd_sha256_private_batch_avx( ulong          batch_cnt,    /* In [1,FD_SHA256_BATCH_MAX] */
+                             void const *   batch_data,   /* Indexed [0,FD_SHA256_BATCH_MAX), aligned 32,
+                                                             only [0,batch_cnt) used, essentially a msg_t const * const * */
+                             ulong const *  batch_sz,     /* Indexed [0,FD_SHA256_BATCH_MAX), aligned 32,
+                                                             only [0,batch_cnt) used */
+                             void * const * batch_hash ); /* Indexed [0,FD_SHA256_BATCH_MAX), aligned 32,
+                                                             only [0,batch_cnt) used */
+
+FD_FN_CONST static inline ulong fd_sha256_batch_align    ( void ) { return alignof(fd_sha256_batch_t); }
+FD_FN_CONST static inline ulong fd_sha256_batch_footprint( void ) { return sizeof (fd_sha256_batch_t); }
+
+static inline fd_sha256_batch_t *
+fd_sha256_batch_init( void * mem ) {
+  fd_sha256_batch_t * batch = (fd_sha256_batch_t *)mem;
+  batch->cnt = 0UL;
+  return batch;
+}
+
+static inline fd_sha256_batch_t *
+fd_sha256_batch_add( fd_sha256_batch_t * batch,
+                     void const *        data,
+                     ulong               sz,
+                     void *              hash ) {
+  ulong batch_cnt = batch->cnt;
+  batch->data[ batch_cnt ] = data;
+  batch->sz  [ batch_cnt ] = sz;
+  batch->hash[ batch_cnt ] = hash;
+  batch_cnt++;
+  if( FD_UNLIKELY( batch_cnt==FD_SHA256_BATCH_MAX ) ) {
+    fd_sha256_private_batch_avx( batch_cnt, batch->data, batch->sz, batch->hash );
+    batch_cnt = 0UL;
+  }
+  batch->cnt = batch_cnt;
+  return batch;
+}
+
+static inline void *
+fd_sha256_batch_fini( fd_sha256_batch_t * batch ) {
+  ulong batch_cnt = batch->cnt;
+  if( FD_LIKELY( batch_cnt ) ) fd_sha256_private_batch_avx( batch_cnt, batch->data, batch->sz, batch->hash );
+  return (void *)batch;
+}
+
+static inline void *
+fd_sha256_batch_abort( fd_sha256_batch_t * batch ) {
+  return (void *)batch;
+}
+
+FD_PROTOTYPES_END
+
+#elif FD_SHA256_BATCH_IMPL==2 /* AVX-512 accelerated batching implementation */
+
+#define FD_SHA256_BATCH_ALIGN     (128UL)
+#define FD_SHA256_BATCH_FOOTPRINT (512UL)
+#define FD_SHA256_BATCH_MAX       (16UL)
+
+/* This is exposed here to facilitate inlining various operations */
+
+struct __attribute__((aligned(FD_SHA256_BATCH_ALIGN))) fd_sha256_private_batch {
+  void const * data[ FD_SHA256_BATCH_MAX ]; /* AVX aligned */
+  ulong        sz  [ FD_SHA256_BATCH_MAX ]; /* AVX aligned */
+  void *       hash[ FD_SHA256_BATCH_MAX ]; /* AVX aligned */
+  ulong        cnt;
+};
+
+typedef struct fd_sha256_private_batch fd_sha256_batch_t;
+
+FD_PROTOTYPES_BEGIN
+
+/* Internal use only */
+
+void
+fd_sha256_private_batch_avx512( ulong          batch_cnt,    /* In [1,FD_SHA256_BATCH_MAX] */
+                                void const *   batch_data,   /* Indexed [0,FD_SHA256_BATCH_MAX), aligned 32,
+                                                                only [0,batch_cnt) used, essentially a msg_t const * const * */
+                                ulong const *  batch_sz,     /* Indexed [0,FD_SHA256_BATCH_MAX), aligned 32,
+                                                                only [0,batch_cnt) used */
+                                void * const * batch_hash ); /* Indexed [0,FD_SHA256_BATCH_MAX), aligned 32,
+                                                                only [0,batch_cnt) used */
+
+FD_FN_CONST static inline ulong fd_sha256_batch_align    ( void ) { return alignof(fd_sha256_batch_t); }
+FD_FN_CONST static inline ulong fd_sha256_batch_footprint( void ) { return sizeof (fd_sha256_batch_t); }
+
+static inline fd_sha256_batch_t *
+fd_sha256_batch_init( void * mem ) {
+  fd_sha256_batch_t * batch = (fd_sha256_batch_t *)mem;
+  batch->cnt = 0UL;
+  return batch;
+}
+
+static inline fd_sha256_batch_t *
+fd_sha256_batch_add( fd_sha256_batch_t * batch,
+                     void const *        data,
+                     ulong               sz,
+                     void *              hash ) {
+  ulong batch_cnt = batch->cnt;
+  batch->data[ batch_cnt ] = data;
+  batch->sz  [ batch_cnt ] = sz;
+  batch->hash[ batch_cnt ] = hash;
+  batch_cnt++;
+  if( FD_UNLIKELY( batch_cnt==FD_SHA256_BATCH_MAX ) ) {
+    fd_sha256_private_batch_avx512( batch_cnt, batch->data, batch->sz, batch->hash );
+    batch_cnt = 0UL;
+  }
+  batch->cnt = batch_cnt;
+  return batch;
+}
+
+static inline void *
+fd_sha256_batch_fini( fd_sha256_batch_t * batch ) {
+  ulong batch_cnt = batch->cnt;
+  if( FD_LIKELY( batch_cnt ) ) fd_sha256_private_batch_avx512( batch_cnt, batch->data, batch->sz, batch->hash );
+  return (void *)batch;
+}
+
+static inline void *
+fd_sha256_batch_abort( fd_sha256_batch_t * batch ) {
+  return (void *)batch;
+}
+
+FD_PROTOTYPES_END
+
+#else
+#error "Unsupported FD_SHA256_BATCH_IMPL"
 #endif
 
 #endif /* HEADER_fd_src_ballet_sha256_fd_sha256_h */

--- a/src/ballet/sha256/fd_sha256_batch_avx512.c
+++ b/src/ballet/sha256/fd_sha256_batch_avx512.c
@@ -99,11 +99,11 @@ fd_sha256_private_batch_avx512( ulong          batch_cnt,
       ulong src = data + tail_data_off;
       ulong dst = tail_data;
       ulong rem = tail_data_sz;
-      while( rem>=64UL ) { wwv_st( (ulong *)dst, wwv_ldu( (ulong const *)src ) ); dst += 64UL; src += 64UL; rem -= 64UL; }
-      while( rem>= 8UL ) { *(ulong  *)dst = FD_LOAD( ulong,  src );               dst +=  8UL; src +=  8UL; rem -=  8UL; }
-      if   ( rem>= 4UL ) { *(uint   *)dst = FD_LOAD( uint,   src );               dst +=  4UL; src +=  4UL; rem -=  4UL; }
-      if   ( rem>= 2UL ) { *(ushort *)dst = FD_LOAD( ushort, src );               dst +=  2UL; src +=  2UL; rem -=  2UL; }
-      if   ( rem       ) { *(uchar  *)dst = FD_LOAD( uchar,  src );               dst++;                                 }
+      while( rem>=32UL ) { wv_st( (ulong *)dst, wv_ldu( (ulong const *)src ) ); dst += 32UL; src += 32UL; rem -= 32UL; }
+      while( rem>= 8UL ) { *(ulong  *)dst = FD_LOAD( ulong,  src );             dst +=  8UL; src +=  8UL; rem -=  8UL; }
+      if   ( rem>= 4UL ) { *(uint   *)dst = FD_LOAD( uint,   src );             dst +=  4UL; src +=  4UL; rem -=  4UL; }
+      if   ( rem>= 2UL ) { *(ushort *)dst = FD_LOAD( ushort, src );             dst +=  2UL; src +=  2UL; rem -=  2UL; }
+      if   ( rem       ) { *(uchar  *)dst = FD_LOAD( uchar,  src );             dst++;                                 }
       *(uchar *)dst = (uchar)0x80;
 #     else
       fd_memcpy( (void *)tail_data, (void const *)(data + tail_data_off), tail_data_sz );

--- a/src/ballet/sha256/fd_sha256_batch_avx512.c
+++ b/src/ballet/sha256/fd_sha256_batch_avx512.c
@@ -1,0 +1,320 @@
+#define FD_SHA256_BATCH_IMPL 2
+
+#include "fd_sha256.h"
+#include "../../util/simd/fd_avx512.h"
+#include "../../util/simd/fd_avx.h"
+
+FD_STATIC_ASSERT( FD_SHA256_BATCH_MAX==16UL, compat );
+
+void
+fd_sha256_private_batch_avx( ulong          batch_cnt,
+                             void const *   batch_data,
+                             ulong const *  batch_sz,
+                             void * const * batch_hash );
+
+void
+fd_sha256_private_batch_avx512( ulong          batch_cnt,
+                                void const *   _batch_data,
+                                ulong const *  batch_sz,
+                                void * const * _batch_hash ) {
+
+  /* If the batch is small enough, it is more efficient to use the
+     narrow batched implementations.  The threshold for fallback depends
+     on whether that itself narrower batched implementation is using
+     SHA-NI acceleration for really small batches. */
+
+# if FD_HAS_SHANI
+# define MIN_BATCH_CNT (5UL)
+# else
+# define MIN_BATCH_CNT (2UL)
+# endif
+
+  if( FD_UNLIKELY( batch_cnt<MIN_BATCH_CNT ) ) {
+    fd_sha256_private_batch_avx( batch_cnt, _batch_data, batch_sz, _batch_hash );
+    return;
+  }
+
+# undef MIN_BATCH_CNT
+
+  /* SHA appends to the end of each message 9 bytes of additional data
+     (a messaging terminator byte and the big endian ulong with the
+     message size in bits) and enough zero padding to make the message
+     an integer number of blocks long.  We compute the 1 or 2 tail
+     blocks of each message here.  We then process complete blocks of
+     the original messages in place, switching to processing these tail
+     blocks in the same pass toward the end.  TODO: This code could
+     probably be SIMD optimized slightly more (this is where all the
+     really performance suboptimally designed parts of SHA live so it is
+     just inherently gross).  The main optimization would probably be to
+     allow tail reading to use a faster memcpy and then maybe some
+     vectorization of the bswap. */
+
+  ulong const * batch_data = (ulong const *)_batch_data;
+
+  ulong batch_tail_data[ FD_SHA256_BATCH_MAX ] __attribute__((aligned(64)));
+  ulong batch_tail_rem [ FD_SHA256_BATCH_MAX ] __attribute__((aligned(64)));
+
+  uchar scratch[ FD_SHA256_BATCH_MAX*2UL*FD_SHA256_PRIVATE_BUF_MAX ] __attribute__((aligned(128)));
+  do {
+    ulong scratch_free = (ulong)scratch;
+
+    wwv_t zero = wwv_zero();
+
+    for( ulong batch_idx=0UL; batch_idx<batch_cnt; batch_idx++ ) {
+
+      /* Allocate the tail blocks for this message */
+
+      ulong data = batch_data[ batch_idx ];
+      ulong sz   = batch_sz  [ batch_idx ];
+
+      ulong tail_data     = scratch_free;
+      ulong tail_data_sz  = sz & (FD_SHA256_PRIVATE_BUF_MAX-1UL);
+      ulong tail_data_off = fd_ulong_align_dn( sz,               FD_SHA256_PRIVATE_BUF_MAX );
+      ulong tail_sz       = fd_ulong_align_up( tail_data_sz+9UL, FD_SHA256_PRIVATE_BUF_MAX );
+
+      batch_tail_data[ batch_idx ] = tail_data;
+      batch_tail_rem [ batch_idx ] = tail_sz >> FD_SHA256_PRIVATE_LG_BUF_MAX;
+
+      scratch_free += tail_sz;
+
+      /* Populate the tail blocks.  We first clear the blocks (note that
+         it is okay to clobber bytes 64:127 if tail_sz only 64, saving a
+         nasty branch).  Then we copy any straggler data bytes into the
+         tail, terminate the message, and finally record the size of the
+         message in bits at the end as a big endian ulong.  */
+
+      wwv_st( (ulong *) tail_data,     zero );
+      wwv_st( (ulong *)(tail_data+64), zero );
+
+#     if 1
+      /* Quick experiments found that, once again, straight memcpy is
+         much slower than a fd_memcpy is slightly slower than a
+         site-optimized handrolled memcpy (fd_memcpy would be less L1I
+         cache footprint though).  They also found that doing the below
+         in a branchless way is slightly worse and an ILP optimized
+         version of the conditional calculation is about the same.  They
+         also found that vectorizing the overall loop and/or Duffing the
+         vectorized loop did not provide noticeable performance
+         improvements under various styles of memcpy. */
+      ulong src = data + tail_data_off;
+      ulong dst = tail_data;
+      ulong rem = tail_data_sz;
+      while( rem>=64UL ) { wwv_st( (ulong *)dst, wwv_ldu( (ulong const *)src ) ); dst += 64UL; src += 64UL; rem -= 64UL; }
+      while( rem>= 8UL ) { *(ulong  *)dst = FD_LOAD( ulong,  src );               dst +=  8UL; src +=  8UL; rem -=  8UL; }
+      if   ( rem>= 4UL ) { *(uint   *)dst = FD_LOAD( uint,   src );               dst +=  4UL; src +=  4UL; rem -=  4UL; }
+      if   ( rem>= 2UL ) { *(ushort *)dst = FD_LOAD( ushort, src );               dst +=  2UL; src +=  2UL; rem -=  2UL; }
+      if   ( rem       ) { *(uchar  *)dst = FD_LOAD( uchar,  src );               dst++;                                 }
+      *(uchar *)dst = (uchar)0x80;
+#     else
+      fd_memcpy( (void *)tail_data, (void const *)(data + tail_data_off), tail_data_sz );
+      *((uchar *)(tail_data+tail_data_sz)) = (uchar)0x80;
+#     endif
+
+      *((ulong *)(tail_data+tail_sz-8UL )) = fd_ulong_bswap( sz<<3 );
+    }
+  } while(0);
+
+  wwu_t s0 = wwu_bcast( 0x6a09e667U );
+  wwu_t s1 = wwu_bcast( 0xbb67ae85U );
+  wwu_t s2 = wwu_bcast( 0x3c6ef372U );
+  wwu_t s3 = wwu_bcast( 0xa54ff53aU );
+  wwu_t s4 = wwu_bcast( 0x510e527fU );
+  wwu_t s5 = wwu_bcast( 0x9b05688cU );
+  wwu_t s6 = wwu_bcast( 0x1f83d9abU );
+  wwu_t s7 = wwu_bcast( 0x5be0cd19U );
+
+  wwv_t zero       = wwv_zero();
+  wwv_t one        = wwv_one();
+  wwv_t wwv_64     = wwv_bcast( FD_SHA256_PRIVATE_BUF_MAX );
+  wwv_t W_sentinel = wwv_bcast( (ulong)scratch );
+
+  wwv_t tail_lo      = wwv_ld( batch_tail_data   ); wwv_t tail_hi      = wwv_ld( batch_tail_data+8 );
+  wwv_t tail_rem_lo  = wwv_ld( batch_tail_rem    ); wwv_t tail_rem_hi  = wwv_ld( batch_tail_rem +8 );
+  wwv_t W_lo         = wwv_ld( batch_data        ); wwv_t W_hi         = wwv_ld( batch_data     +8 );
+
+  wwv_t block_rem_lo = wwv_if( ((1<<batch_cnt)-1) & 0xff,
+                               wwv_add( wwv_shr( wwv_ld( batch_sz   ), FD_SHA256_PRIVATE_LG_BUF_MAX ), tail_rem_lo ), zero );
+  wwv_t block_rem_hi = wwv_if( ((1<<batch_cnt)-1) >> 8,
+                               wwv_add( wwv_shr( wwv_ld( batch_sz+8 ), FD_SHA256_PRIVATE_LG_BUF_MAX ), tail_rem_hi ), zero );
+
+  for(;;) {
+    int active_lane_lo = wwv_ne( block_rem_lo, zero );
+    int active_lane_hi = wwv_ne( block_rem_hi, zero );
+    if( FD_UNLIKELY( !(active_lane_lo | active_lane_hi) ) ) break;
+
+    /* Switch lanes that have hit the end of their in-place bulk
+       processing to their out-of-place scratch tail regions as
+       necessary. */
+
+    W_lo = wwv_if( wwv_eq( block_rem_lo, tail_rem_lo ), tail_lo, W_lo );
+    W_hi = wwv_if( wwv_eq( block_rem_hi, tail_rem_hi ), tail_hi, W_hi );
+
+    /* At this point, we have at least 1 block in this message segment
+       pass that has not been processed.  Load the next 64 bytes of
+       each unprocessed block.  Inactive lanes (e.g. message segments
+       in this pass for which we've already processed all the blocks)
+       will load garbage from a sentinel location (and the result of
+       the state computations for the inactive lane will be ignored). */
+
+    ulong _W0; ulong _W1; ulong _W2; ulong _W3; ulong _W4; ulong _W5; ulong _W6; ulong _W7;
+    ulong _W8; ulong _W9; ulong _Wa; ulong _Wb; ulong _Wc; ulong _Wd; ulong _We; ulong _Wf;
+    wwv_unpack( wwv_if( active_lane_lo, W_lo, W_sentinel ), _W0, _W1, _W2, _W3, _W4, _W5, _W6, _W7 );
+    wwv_unpack( wwv_if( active_lane_hi, W_hi, W_sentinel ), _W8, _W9, _Wa, _Wb, _Wc, _Wd, _We, _Wf );
+    uchar const * W0 = (uchar const *)_W0; uchar const * W1 = (uchar const *)_W1;
+    uchar const * W2 = (uchar const *)_W2; uchar const * W3 = (uchar const *)_W3;
+    uchar const * W4 = (uchar const *)_W4; uchar const * W5 = (uchar const *)_W5;
+    uchar const * W6 = (uchar const *)_W6; uchar const * W7 = (uchar const *)_W7;
+    uchar const * W8 = (uchar const *)_W8; uchar const * W9 = (uchar const *)_W9;
+    uchar const * Wa = (uchar const *)_Wa; uchar const * Wb = (uchar const *)_Wb;
+    uchar const * Wc = (uchar const *)_Wc; uchar const * Wd = (uchar const *)_Wd;
+    uchar const * We = (uchar const *)_We; uchar const * Wf = (uchar const *)_Wf;
+
+    wwu_t x0; wwu_t x1; wwu_t x2; wwu_t x3; wwu_t x4; wwu_t x5; wwu_t x6; wwu_t x7;
+    wwu_t x8; wwu_t x9; wwu_t xa; wwu_t xb; wwu_t xc; wwu_t xd; wwu_t xe; wwu_t xf;
+    wwu_transpose_16x16( wwu_bswap( wwu_ldu( W0 ) ), wwu_bswap( wwu_ldu( W1 ) ),
+                         wwu_bswap( wwu_ldu( W2 ) ), wwu_bswap( wwu_ldu( W3 ) ),
+                         wwu_bswap( wwu_ldu( W4 ) ), wwu_bswap( wwu_ldu( W5 ) ),
+                         wwu_bswap( wwu_ldu( W6 ) ), wwu_bswap( wwu_ldu( W7 ) ),
+                         wwu_bswap( wwu_ldu( W8 ) ), wwu_bswap( wwu_ldu( W9 ) ),
+                         wwu_bswap( wwu_ldu( Wa ) ), wwu_bswap( wwu_ldu( Wb ) ),
+                         wwu_bswap( wwu_ldu( Wc ) ), wwu_bswap( wwu_ldu( Wd ) ),
+                         wwu_bswap( wwu_ldu( We ) ), wwu_bswap( wwu_ldu( Wf ) ),
+                         x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf );
+
+    /* Compute the SHA-256 state updates */
+
+    wwu_t a = s0; wwu_t b = s1; wwu_t c = s2; wwu_t d = s3; wwu_t e = s4; wwu_t f = s5; wwu_t g = s6; wwu_t h = s7;
+
+    static uint const K[64] = { /* FIXME: Reuse with other functions */
+      0x428a2f98U, 0x71374491U, 0xb5c0fbcfU, 0xe9b5dba5U, 0x3956c25bU, 0x59f111f1U, 0x923f82a4U, 0xab1c5ed5U,
+      0xd807aa98U, 0x12835b01U, 0x243185beU, 0x550c7dc3U, 0x72be5d74U, 0x80deb1feU, 0x9bdc06a7U, 0xc19bf174U,
+      0xe49b69c1U, 0xefbe4786U, 0x0fc19dc6U, 0x240ca1ccU, 0x2de92c6fU, 0x4a7484aaU, 0x5cb0a9dcU, 0x76f988daU,
+      0x983e5152U, 0xa831c66dU, 0xb00327c8U, 0xbf597fc7U, 0xc6e00bf3U, 0xd5a79147U, 0x06ca6351U, 0x14292967U,
+      0x27b70a85U, 0x2e1b2138U, 0x4d2c6dfcU, 0x53380d13U, 0x650a7354U, 0x766a0abbU, 0x81c2c92eU, 0x92722c85U,
+      0xa2bfe8a1U, 0xa81a664bU, 0xc24b8b70U, 0xc76c51a3U, 0xd192e819U, 0xd6990624U, 0xf40e3585U, 0x106aa070U,
+      0x19a4c116U, 0x1e376c08U, 0x2748774cU, 0x34b0bcb5U, 0x391c0cb3U, 0x4ed8aa4aU, 0x5b9cca4fU, 0x682e6ff3U,
+      0x748f82eeU, 0x78a5636fU, 0x84c87814U, 0x8cc70208U, 0x90befffaU, 0xa4506cebU, 0xbef9a3f7U, 0xc67178f2U,
+    };
+
+#   define Sigma0(x)  wwu_xor( wwu_rol(x,30), wwu_xor( wwu_rol(x,19), wwu_rol(x,10) ) )
+#   define Sigma1(x)  wwu_xor( wwu_rol(x,26), wwu_xor( wwu_rol(x,21), wwu_rol(x, 7) ) )
+#   define sigma0(x)  wwu_xor( wwu_rol(x,25), wwu_xor( wwu_rol(x,14), wwu_shr(x, 3) ) )
+#   define sigma1(x)  wwu_xor( wwu_rol(x,15), wwu_xor( wwu_rol(x,13), wwu_shr(x,10) ) )
+#   define Ch(x,y,z)  wwu_xor( wwu_and(x,y), wwu_andnot(x,z) )
+#   define Maj(x,y,z) wwu_xor( wwu_and(x,y), wwu_xor( wwu_and(x,z), wwu_and(y,z) ) )
+#   define SHA_CORE(xi,ki)                                                           \
+    T1 = wwu_add( wwu_add(xi,ki), wwu_add( wwu_add( h, Sigma1(e) ), Ch(e, f, g) ) ); \
+    T2 = wwu_add( Sigma0(a), Maj(a, b, c) );                                         \
+    h = g;                                                                           \
+    g = f;                                                                           \
+    f = e;                                                                           \
+    e = wwu_add( d, T1 );                                                            \
+    d = c;                                                                           \
+    c = b;                                                                           \
+    b = a;                                                                           \
+    a = wwu_add( T1, T2 )
+
+    wwu_t T1;
+    wwu_t T2;
+
+    SHA_CORE( x0, wwu_bcast( K[ 0] ) );
+    SHA_CORE( x1, wwu_bcast( K[ 1] ) );
+    SHA_CORE( x2, wwu_bcast( K[ 2] ) );
+    SHA_CORE( x3, wwu_bcast( K[ 3] ) );
+    SHA_CORE( x4, wwu_bcast( K[ 4] ) );
+    SHA_CORE( x5, wwu_bcast( K[ 5] ) );
+    SHA_CORE( x6, wwu_bcast( K[ 6] ) );
+    SHA_CORE( x7, wwu_bcast( K[ 7] ) );
+    SHA_CORE( x8, wwu_bcast( K[ 8] ) );
+    SHA_CORE( x9, wwu_bcast( K[ 9] ) );
+    SHA_CORE( xa, wwu_bcast( K[10] ) );
+    SHA_CORE( xb, wwu_bcast( K[11] ) );
+    SHA_CORE( xc, wwu_bcast( K[12] ) );
+    SHA_CORE( xd, wwu_bcast( K[13] ) );
+    SHA_CORE( xe, wwu_bcast( K[14] ) );
+    SHA_CORE( xf, wwu_bcast( K[15] ) );
+    for( ulong i=16UL; i<64UL; i+=16UL ) {
+      x0 = wwu_add( wwu_add( x0, sigma0(x1) ), wwu_add( sigma1(xe), x9 ) ); SHA_CORE( x0, wwu_bcast( K[i     ] ) );
+      x1 = wwu_add( wwu_add( x1, sigma0(x2) ), wwu_add( sigma1(xf), xa ) ); SHA_CORE( x1, wwu_bcast( K[i+ 1UL] ) );
+      x2 = wwu_add( wwu_add( x2, sigma0(x3) ), wwu_add( sigma1(x0), xb ) ); SHA_CORE( x2, wwu_bcast( K[i+ 2UL] ) );
+      x3 = wwu_add( wwu_add( x3, sigma0(x4) ), wwu_add( sigma1(x1), xc ) ); SHA_CORE( x3, wwu_bcast( K[i+ 3UL] ) );
+      x4 = wwu_add( wwu_add( x4, sigma0(x5) ), wwu_add( sigma1(x2), xd ) ); SHA_CORE( x4, wwu_bcast( K[i+ 4UL] ) );
+      x5 = wwu_add( wwu_add( x5, sigma0(x6) ), wwu_add( sigma1(x3), xe ) ); SHA_CORE( x5, wwu_bcast( K[i+ 5UL] ) );
+      x6 = wwu_add( wwu_add( x6, sigma0(x7) ), wwu_add( sigma1(x4), xf ) ); SHA_CORE( x6, wwu_bcast( K[i+ 6UL] ) );
+      x7 = wwu_add( wwu_add( x7, sigma0(x8) ), wwu_add( sigma1(x5), x0 ) ); SHA_CORE( x7, wwu_bcast( K[i+ 7UL] ) );
+      x8 = wwu_add( wwu_add( x8, sigma0(x9) ), wwu_add( sigma1(x6), x1 ) ); SHA_CORE( x8, wwu_bcast( K[i+ 8UL] ) );
+      x9 = wwu_add( wwu_add( x9, sigma0(xa) ), wwu_add( sigma1(x7), x2 ) ); SHA_CORE( x9, wwu_bcast( K[i+ 9UL] ) );
+      xa = wwu_add( wwu_add( xa, sigma0(xb) ), wwu_add( sigma1(x8), x3 ) ); SHA_CORE( xa, wwu_bcast( K[i+10UL] ) );
+      xb = wwu_add( wwu_add( xb, sigma0(xc) ), wwu_add( sigma1(x9), x4 ) ); SHA_CORE( xb, wwu_bcast( K[i+11UL] ) );
+      xc = wwu_add( wwu_add( xc, sigma0(xd) ), wwu_add( sigma1(xa), x5 ) ); SHA_CORE( xc, wwu_bcast( K[i+12UL] ) );
+      xd = wwu_add( wwu_add( xd, sigma0(xe) ), wwu_add( sigma1(xb), x6 ) ); SHA_CORE( xd, wwu_bcast( K[i+13UL] ) );
+      xe = wwu_add( wwu_add( xe, sigma0(xf) ), wwu_add( sigma1(xc), x7 ) ); SHA_CORE( xe, wwu_bcast( K[i+14UL] ) );
+      xf = wwu_add( wwu_add( xf, sigma0(x0) ), wwu_add( sigma1(xd), x8 ) ); SHA_CORE( xf, wwu_bcast( K[i+15UL] ) );
+    }
+
+#   undef SHA_CORE
+#   undef Sigma0
+#   undef Sigma1
+#   undef sigma0
+#   undef sigma1
+#   undef Ch
+#   undef Maj
+
+    /* Apply the state updates to the active lanes */
+
+    int active_lane = active_lane_lo | (active_lane_hi<<8);
+
+    s0 = wwu_add_if( active_lane, s0, a, s0 );
+    s1 = wwu_add_if( active_lane, s1, b, s1 );
+    s2 = wwu_add_if( active_lane, s2, c, s2 );
+    s3 = wwu_add_if( active_lane, s3, d, s3 );
+    s4 = wwu_add_if( active_lane, s4, e, s4 );
+    s5 = wwu_add_if( active_lane, s5, f, s5 );
+    s6 = wwu_add_if( active_lane, s6, g, s6 );
+    s7 = wwu_add_if( active_lane, s7, h, s7 );
+
+    /* Advance to the next message segment blocks.  In pseudo code,
+       the below is:
+
+         W += 64; if( block_rem ) block_rem--;
+
+       Since we do not load anything at W(lane) above unless
+       block_rem(lane) is non-zero, we can omit vector conditional
+       operations for W(lane) below. */
+
+    W_lo = wwv_add( W_lo, wwv_64 );
+    W_hi = wwv_add( W_hi, wwv_64 );
+
+    block_rem_lo = wwv_sub_if( active_lane_lo, block_rem_lo, one, block_rem_lo );
+    block_rem_hi = wwv_sub_if( active_lane_hi, block_rem_hi, one, block_rem_hi );
+  }
+
+  /* Store the results.  FIXME: Probably could optimize the transpose
+     further by taking into account needed stores (and then maybe go
+     direct into memory ... would need a family of such transposed
+     stores). */
+
+  wwu_transpose_2x8x8( wwu_bswap(s0), wwu_bswap(s1), wwu_bswap(s2), wwu_bswap(s3),
+                       wwu_bswap(s4), wwu_bswap(s5), wwu_bswap(s6), wwu_bswap(s7), s0,s1,s2,s3,s4,s5,s6,s7 );
+
+  uint * const * batch_hash = (uint * const *)_batch_hash;
+  switch( batch_cnt ) { /* application dependent prob */
+  case 16UL: wu_stu( batch_hash[15], _mm512_extracti32x8_epi32( s7, 1 ) ); __attribute__((fallthrough));
+  case 15UL: wu_stu( batch_hash[14], _mm512_extracti32x8_epi32( s6, 1 ) ); __attribute__((fallthrough));
+  case 14UL: wu_stu( batch_hash[13], _mm512_extracti32x8_epi32( s5, 1 ) ); __attribute__((fallthrough));
+  case 13UL: wu_stu( batch_hash[12], _mm512_extracti32x8_epi32( s4, 1 ) ); __attribute__((fallthrough));
+  case 12UL: wu_stu( batch_hash[11], _mm512_extracti32x8_epi32( s3, 1 ) ); __attribute__((fallthrough));
+  case 11UL: wu_stu( batch_hash[10], _mm512_extracti32x8_epi32( s2, 1 ) ); __attribute__((fallthrough));
+  case 10UL: wu_stu( batch_hash[ 9], _mm512_extracti32x8_epi32( s1, 1 ) ); __attribute__((fallthrough));
+  case  9UL: wu_stu( batch_hash[ 8], _mm512_extracti32x8_epi32( s0, 1 ) ); __attribute__((fallthrough));
+  case  8UL: wu_stu( batch_hash[ 7], _mm512_extracti32x8_epi32( s7, 0 ) ); __attribute__((fallthrough));
+  case  7UL: wu_stu( batch_hash[ 6], _mm512_extracti32x8_epi32( s6, 0 ) ); __attribute__((fallthrough));
+  case  6UL: wu_stu( batch_hash[ 5], _mm512_extracti32x8_epi32( s5, 0 ) ); __attribute__((fallthrough));
+  case  5UL: wu_stu( batch_hash[ 4], _mm512_extracti32x8_epi32( s4, 0 ) ); __attribute__((fallthrough));
+  case  4UL: wu_stu( batch_hash[ 3], _mm512_extracti32x8_epi32( s3, 0 ) ); __attribute__((fallthrough));
+  case  3UL: wu_stu( batch_hash[ 2], _mm512_extracti32x8_epi32( s2, 0 ) ); __attribute__((fallthrough));
+  case  2UL: wu_stu( batch_hash[ 1], _mm512_extracti32x8_epi32( s1, 0 ) ); __attribute__((fallthrough));
+  case  1UL: wu_stu( batch_hash[ 0], _mm512_extracti32x8_epi32( s0, 0 ) ); __attribute__((fallthrough));
+  default: break;
+  }
+}

--- a/src/ballet/sha256/test_sha256.c
+++ b/src/ballet/sha256/test_sha256.c
@@ -147,10 +147,10 @@ main( int     argc,
   FD_LOG_NOTICE(( "Benchmarking incremental (best case)" ));
   for( ulong idx=0U; idx<2UL; idx++ ) {
     ulong sz = bench_sz[ idx ];
-  
+
     /* warmup */
     for( ulong rem=10UL; rem; rem-- ) fd_sha256_fini( fd_sha256_append( fd_sha256_init( sha ), buf, sz ), hash );
-  
+
     /* for real */
     ulong iter = 100000UL;
     long  dt   = -fd_log_wallclock();
@@ -179,7 +179,7 @@ main( int     argc,
   FD_LOG_NOTICE(( "Benchmarking batched" ));
   for( ulong idx=0U; idx<2UL; idx++ ) {
     ulong sz = bench_sz[ idx ];
-    for( ulong batch_cnt=1UL; batch_cnt<32UL; batch_cnt++ ) {
+    for( ulong batch_cnt=1UL; batch_cnt<=48UL; batch_cnt++ ) {
 
       /* warmup */
       for( ulong rem=10UL; rem; rem-- ) {
@@ -239,4 +239,3 @@ main( int     argc,
   fd_halt();
   return 0;
 }
-

--- a/src/ballet/sha512/fd_sha512_batch_avx.c
+++ b/src/ballet/sha512/fd_sha512_batch_avx.c
@@ -126,25 +126,25 @@ fd_sha512_private_batch_avx( ulong          batch_cnt,
        the state computations for the inactive lane will be ignored). */
 
     wv_t W03 = wv_if( active_lane, W, W_sentinel );
-    ulong const * W0 = (ulong const *)wv_extract( W03, 0 );
-    ulong const * W1 = (ulong const *)wv_extract( W03, 1 );
-    ulong const * W2 = (ulong const *)wv_extract( W03, 2 );
-    ulong const * W3 = (ulong const *)wv_extract( W03, 3 );
+    uchar const * W0 = (uchar const *)wv_extract( W03, 0 );
+    uchar const * W1 = (uchar const *)wv_extract( W03, 1 );
+    uchar const * W2 = (uchar const *)wv_extract( W03, 2 );
+    uchar const * W3 = (uchar const *)wv_extract( W03, 3 );
 
     wv_t x0; wv_t x1; wv_t x2; wv_t x3;
     wv_transpose_4x4( wv_bswap( wv_ldu(W0   ) ), wv_bswap( wv_ldu(W1   ) ), wv_bswap( wv_ldu(W2   ) ), wv_bswap( wv_ldu(W3   ) ),
                       x0, x1, x2, x3 );
 
     wv_t x4; wv_t x5; wv_t x6; wv_t x7;
-    wv_transpose_4x4( wv_bswap( wv_ldu(W0+ 4) ), wv_bswap( wv_ldu(W1+ 4) ), wv_bswap( wv_ldu(W2+ 4) ), wv_bswap( wv_ldu(W3+ 4) ),
+    wv_transpose_4x4( wv_bswap( wv_ldu(W0+32) ), wv_bswap( wv_ldu(W1+32) ), wv_bswap( wv_ldu(W2+32) ), wv_bswap( wv_ldu(W3+32) ),
                       x4, x5, x6, x7 );
 
     wv_t x8; wv_t x9; wv_t xa; wv_t xb;
-    wv_transpose_4x4( wv_bswap( wv_ldu(W0+ 8) ), wv_bswap( wv_ldu(W1+ 8) ), wv_bswap( wv_ldu(W2+ 8) ), wv_bswap( wv_ldu(W3+ 8) ),
+    wv_transpose_4x4( wv_bswap( wv_ldu(W0+64) ), wv_bswap( wv_ldu(W1+64) ), wv_bswap( wv_ldu(W2+64) ), wv_bswap( wv_ldu(W3+64) ),
                       x8, x9, xa, xb );
 
     wv_t xc; wv_t xd; wv_t xe; wv_t xf;
-    wv_transpose_4x4( wv_bswap( wv_ldu(W0+12) ), wv_bswap( wv_ldu(W1+12) ), wv_bswap( wv_ldu(W2+12) ), wv_bswap( wv_ldu(W3+12) ),
+    wv_transpose_4x4( wv_bswap( wv_ldu(W0+96) ), wv_bswap( wv_ldu(W1+96) ), wv_bswap( wv_ldu(W2+96) ), wv_bswap( wv_ldu(W3+96) ),
                       xc, xd, xe, xf );
 
     /* Compute the SHA-512 state updates */

--- a/src/ballet/sha512/fd_sha512_batch_avx512.c
+++ b/src/ballet/sha512/fd_sha512_batch_avx512.c
@@ -3,23 +3,6 @@
 #include "fd_sha512.h"
 #include "../../util/simd/fd_avx512.h"
 
-/* TODO: consider adding this to fd_avx512_wwv (and its equivalent to
-   fd_avx512_wwl) */
-
-#define wwv_unpack( x, x0,x1,x2,x3,x4,x5,x6,x7 ) do {                       \
-    __m512i _wwv_unpack_x  = (x);                                           \
-    __m256i _wwv_unpack_xl = _mm512_extracti64x4_epi64( _wwv_unpack_x, 0 ); \
-    __m256i _wwv_unpack_xh = _mm512_extracti64x4_epi64( _wwv_unpack_x, 1 ); \
-    (x0) = (ulong)_mm256_extract_epi64( _wwv_unpack_xl, 0 );                \
-    (x1) = (ulong)_mm256_extract_epi64( _wwv_unpack_xl, 1 );                \
-    (x2) = (ulong)_mm256_extract_epi64( _wwv_unpack_xl, 2 );                \
-    (x3) = (ulong)_mm256_extract_epi64( _wwv_unpack_xl, 3 );                \
-    (x4) = (ulong)_mm256_extract_epi64( _wwv_unpack_xh, 0 );                \
-    (x5) = (ulong)_mm256_extract_epi64( _wwv_unpack_xh, 1 );                \
-    (x6) = (ulong)_mm256_extract_epi64( _wwv_unpack_xh, 2 );                \
-    (x7) = (ulong)_mm256_extract_epi64( _wwv_unpack_xh, 3 );                \
-  } while(0)
-
 FD_STATIC_ASSERT( FD_SHA512_BATCH_MAX==8UL, compat );
 
 void
@@ -149,10 +132,10 @@ fd_sha512_private_batch_avx512( ulong          batch_cnt,
 
     ulong _W0; ulong _W1; ulong _W2; ulong _W3; ulong _W4; ulong _W5; ulong _W6; ulong _W7;
     wwv_unpack( wwv_if( active_lane, W, W_sentinel ), _W0,_W1,_W2,_W3,_W4,_W5,_W6,_W7 );
-    ulong const * W0 = (ulong const *)_W0; ulong const * W1 = (ulong const *)_W1;
-    ulong const * W2 = (ulong const *)_W2; ulong const * W3 = (ulong const *)_W3;
-    ulong const * W4 = (ulong const *)_W4; ulong const * W5 = (ulong const *)_W5;
-    ulong const * W6 = (ulong const *)_W6; ulong const * W7 = (ulong const *)_W7;
+    uchar const * W0 = (uchar const *)_W0; uchar const * W1 = (uchar const *)_W1;
+    uchar const * W2 = (uchar const *)_W2; uchar const * W3 = (uchar const *)_W3;
+    uchar const * W4 = (uchar const *)_W4; uchar const * W5 = (uchar const *)_W5;
+    uchar const * W6 = (uchar const *)_W6; uchar const * W7 = (uchar const *)_W7;
 
     wwv_t x0; wwv_t x1; wwv_t x2; wwv_t x3; wwv_t x4; wwv_t x5; wwv_t x6; wwv_t x7;
     wwv_transpose_8x8( wwv_bswap( wwv_ldu( W0   ) ), wwv_bswap( wwv_ldu( W1   ) ),
@@ -161,10 +144,10 @@ fd_sha512_private_batch_avx512( ulong          batch_cnt,
                        wwv_bswap( wwv_ldu( W6   ) ), wwv_bswap( wwv_ldu( W7   ) ), x0, x1, x2, x3, x4, x5, x6, x7 );
 
     wwv_t x8; wwv_t x9; wwv_t xa; wwv_t xb; wwv_t xc; wwv_t xd; wwv_t xe; wwv_t xf;
-    wwv_transpose_8x8( wwv_bswap( wwv_ldu( W0+8 ) ), wwv_bswap( wwv_ldu( W1+8 ) ),
-                       wwv_bswap( wwv_ldu( W2+8 ) ), wwv_bswap( wwv_ldu( W3+8 ) ),
-                       wwv_bswap( wwv_ldu( W4+8 ) ), wwv_bswap( wwv_ldu( W5+8 ) ),
-                       wwv_bswap( wwv_ldu( W6+8 ) ), wwv_bswap( wwv_ldu( W7+8 ) ), x8, x9, xa, xb, xc, xd, xe, xf );
+    wwv_transpose_8x8( wwv_bswap( wwv_ldu( W0+64 ) ), wwv_bswap( wwv_ldu( W1+64 ) ),
+                       wwv_bswap( wwv_ldu( W2+64 ) ), wwv_bswap( wwv_ldu( W3+64 ) ),
+                       wwv_bswap( wwv_ldu( W4+64 ) ), wwv_bswap( wwv_ldu( W5+64 ) ),
+                       wwv_bswap( wwv_ldu( W6+64 ) ), wwv_bswap( wwv_ldu( W7+64 ) ), x8, x9, xa, xb, xc, xd, xe, xf );
 
     /* Compute the SHA-512 state updates */
 

--- a/src/ballet/shred/fd_shred.h
+++ b/src/ballet/shred/fd_shred.h
@@ -62,7 +62,6 @@
 
 #include "../fd_ballet.h"
 
-
 /* FD_SHRED_MAX_SZ: The max byte size of a shred.
    This limit derives from the IPv6 MTU of 1280 bytes, minus 48 bytes
    for the UDP/IPv6 headers and another 4 bytes for good measure.  Most
@@ -216,7 +215,7 @@ fd_shred_variant( uchar type,
   return (uchar)(type | merkle_cnt);
 }
 
-FD_FN_CONST static inline ulong
+FD_FN_PURE static inline ulong
 fd_shred_sz( fd_shred_t const * shred ) {
   return fd_ulong_if( shred->variant & FD_SHRED_TYPEMASK_CODE, FD_SHRED_MAX_SZ,
          fd_ulong_if( fd_shred_type( shred->variant )==FD_SHRED_TYPE_MERKLE_DATA, FD_SHRED_MIN_SZ,
@@ -270,7 +269,7 @@ fd_shred_payload_sz( fd_shred_t const * shred ) {
 /* fd_shred_merkle_off: Returns the byte offset of the merkle inclusion proof of a shred.
 
    The provided shred must have passed validation in fd_shred_parse(). */
-FD_FN_CONST static inline ulong
+FD_FN_PURE static inline ulong
 fd_shred_merkle_off( fd_shred_t const * shred ) {
   return fd_shred_sz( shred ) - fd_shred_merkle_sz( shred->variant );
 }

--- a/src/disco/shred/fd_shred_dest.h
+++ b/src/disco/shred/fd_shred_dest.h
@@ -44,6 +44,7 @@ struct pubkey_to_idx;
 typedef struct pubkey_to_idx pubkey_to_idx_t;
 
 #define FD_SHRED_DEST_ALIGN (128UL)
+FD_STATIC_ASSERT( FD_SHRED_DEST_ALIGN>=FD_SHA256_BATCH_ALIGN, fd_shred_dest_private_align );
 
 struct __attribute__((aligned(FD_SHRED_DEST_ALIGN))) fd_shred_dest_private {
   uchar      _sha256_batch[ FD_SHA256_BATCH_FOOTPRINT ]  __attribute__((aligned(FD_SHA256_BATCH_ALIGN)));

--- a/src/disco/shred/fd_shredder.h
+++ b/src/disco/shred/fd_shredder.h
@@ -15,7 +15,9 @@
 #define FD_FEC_SET_MAX_BMTREE_DEPTH (9UL) /* ceil(log2(DATA_SHREDS_MAX + PARITY_SHREDS_MAX)) */
 
 #define FD_SHREDDER_ALIGN     (  128UL)
-#define FD_SHREDDER_FOOTPRINT (25984UL) /* == sizeof(fd_shredder_t) */
+/* FD_SHREDDER_FOOTPRINT is not provided because it depends on the footprint
+   of fd_sha256_batch_t, which is not invariant (the latter depends on the
+   underlying implementation). Instead, a static inline function is provided. */
 
 #define FD_SHREDDER_MAGIC (0xF17EDA2547EDDE70UL) /* FIREDAN SHREDDER V0 */
 
@@ -40,9 +42,9 @@ struct __attribute__((aligned(FD_SHREDDER_ALIGN))) fd_shredder_private {
   ulong  magic;
   ushort shred_version;
 
+  fd_sha256_batch_t sha256 [ 1 ];
   fd_sha512_t       sha512 [ 1 ]; /* Needed for signing */
   fd_reedsol_t      reedsol[ 1 ];
-  fd_sha256_batch_t sha256 [ 1 ];
   union __attribute__((aligned(FD_BMTREE_COMMIT_ALIGN))) {
     fd_bmtree_commit_t bmtree;
     uchar _bmtree_footprint[ FD_BMTREE_COMMIT_FOOTPRINT( FD_FEC_SET_MAX_BMTREE_DEPTH ) ];
@@ -63,7 +65,7 @@ struct __attribute__((aligned(FD_SHREDDER_ALIGN))) fd_shredder_private {
 typedef struct fd_shredder_private fd_shredder_t;
 
 FD_FN_CONST static inline ulong fd_shredder_align    ( void ) { return FD_SHREDDER_ALIGN;     }
-FD_FN_CONST static inline ulong fd_shredder_footprint( void ) { return FD_SHREDDER_FOOTPRINT; }
+FD_FN_CONST static inline ulong fd_shredder_footprint( void ) { return sizeof(fd_shredder_t); }
 
 /* fd_shredder_new formats a region of memory as a shredder object.
    pubkey must point to the first byte of 32 bytes containing the public

--- a/src/disco/shred/test_shredder.c
+++ b/src/disco/shred/test_shredder.c
@@ -231,9 +231,9 @@ main( int     argc,
 
   FD_TEST( FD_FEC_SET_MAX_BMTREE_DEPTH == fd_bmtree_depth( FD_REEDSOL_DATA_SHREDS_MAX + FD_REEDSOL_PARITY_SHREDS_MAX ) );
 
-  if( sizeof(fd_shredder_t) != FD_SHREDDER_FOOTPRINT )
-    FD_LOG_WARNING(( "sizeof() %lu, footprint: %lu", sizeof(fd_shredder_t), FD_SHREDDER_FOOTPRINT ));
-  FD_TEST( sizeof(fd_shredder_t) == FD_SHREDDER_FOOTPRINT );
+  if( sizeof(fd_shredder_t) != fd_shredder_footprint() )
+    FD_LOG_WARNING(( "sizeof() %lu, footprint: %lu", sizeof(fd_shredder_t), fd_shredder_footprint() ));
+  FD_TEST( sizeof(fd_shredder_t) == fd_shredder_footprint() );
 
 
   test_shredder_count();

--- a/src/tango/quic/fd_quic.c
+++ b/src/tango/quic/fd_quic.c
@@ -5117,7 +5117,7 @@ fd_quic_conn_create( fd_quic_t *               quic,
   return conn;
 }
 
-extern inline FD_FN_CONST
+extern inline FD_FN_PURE
 int
 fd_quic_handshake_complete( fd_quic_conn_t * conn );
 

--- a/src/tango/quic/fd_quic_conn.h
+++ b/src/tango/quic/fd_quic_conn.h
@@ -54,7 +54,6 @@ typedef struct fd_quic_ack        fd_quic_ack_t;
        all preceding acks. ack ids are only increasing
    enc_level of acks is implied by the list it's in */
 
-
 struct fd_quic_ack {
   /* stores data about what was ack'ed */
   ulong           tx_pkt_number; /* the packet number this ack range was or will be transmitted in */
@@ -68,7 +67,6 @@ struct fd_quic_ack {
 # define FD_QUIC_ACK_FLAGS_SENT      (1u<<0u)
 # define FD_QUIC_ACK_FLAGS_MANDATORY (1u<<1u)
 };
-
 
 struct fd_quic_conn {
   fd_quic_t *        quic;
@@ -182,7 +180,6 @@ struct fd_quic_conn {
   uint state;
   uint reason;     /* quic reason for closing. see FD_QUIC_CONN_REASON_* */
   uint app_reason; /* application reason for closing */
-
 
   /* sent packet metadata */
   /* TODO */
@@ -298,7 +295,6 @@ fd_quic_conn_align( void );
 FD_FN_PURE ulong
 fd_quic_conn_footprint( fd_quic_limits_t const * );
 
-
 /* called by fd_quic_new to initialize the connection objects
    used by fd_quic */
 fd_quic_conn_t *
@@ -306,11 +302,9 @@ fd_quic_conn_new( void *                   mem,
                   fd_quic_t *              quic,
                   fd_quic_limits_t const * limits );
 
-
 /* set the user-defined context value on the connection */
 void
 fd_quic_conn_set_context( fd_quic_conn_t * conn, void * context );
-
 
 /* get the user-defined context value from a connection */
 void *
@@ -321,7 +315,7 @@ fd_quic_conn_get_context( fd_quic_conn_t * conn );
    completed, 0 otherwise.  Will return 1 even if the conn has died
    since handshake. */
 
-FD_QUIC_API FD_FN_CONST inline int
+FD_QUIC_API FD_FN_PURE inline int
 fd_quic_handshake_complete( fd_quic_conn_t * conn ) {
   return conn->handshake_complete;
 }

--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -512,7 +512,41 @@ fd_type_pun_const( void const * p ) {
 /* FD_FN_PURE hints to the optimizer that the function, roughly
    speaking, does not have side effects.  As such, the compiler can
    replace a call to the function with the result of an earlier call to
-   that function provide the inputs and memory used hasn't changed. */
+   that function provide the inputs and memory used hasn't changed.
+
+   IMPORTANT SAFETY TIP!  Recent compilers seem to take an undocumented
+   and debatable stance that pure functions do no writes to memory.
+   This is a sufficient condition for the above but not a necessary one.
+
+   Consider, for example, the real world case of an otherwise pure
+   function that uses pass-by-reference to return more than one value
+   (an unpleasant practice that is sadly often necessary because C/C++,
+   compilers and underlying platform ABIs are very bad at helping
+   developers simply and clearly express their intent to return multiple
+   values and then generate good assembly for such).
+
+   If called multiple times sequentially, all but the first call to such
+   a "pure" function could be optimized away because the non-volatile
+   memory writes done in the all but the 1st call for the
+   pass-by-reference-returns write the same value to normal memory that
+   was written on the 1st call.  That is, these calls return the same
+   value for their direct return and do writes that do not have any
+   visible effect.
+
+   Thus, while it is safe for the compiler to eliminate all but the
+   first call via techniques like common subexpression elimination, it
+   is not safe for the compiler to infer that the first call did no
+   writes.
+
+   But recent compilers seem to do exactly that.
+
+   Sigh ... we can't use FD_FN_PURE on such functions because of all the
+   above linguistic, compiler, documentation and ABI infinite sadness.
+
+   TL;DR To be safe against the above vagaries, recommend using
+   FD_FN_PURE to annotate functions that do no memory writes (including
+   trivial memory writes) and try to design HPC APIs to avoid returning
+   multiple values as much as possible. */
 
 #define FD_FN_PURE __attribute__((pure))
 

--- a/src/util/simd/Local.mk
+++ b/src/util/simd/Local.mk
@@ -18,8 +18,10 @@ $(call run-unit-test,test_avx_4x64,)
 $(call run-unit-test,test_avx_32x8,)
 endif
 
-$(call add-hdrs,fd_avx512.h fd_avx512_wwl.h)
+$(call add-hdrs,fd_avx512.h fd_avx512_wwi.h fd_avx512_wwu.h fd_avx512_wwl.h fd_avx512_wwv.h)
 ifdef FD_HAS_AVX512
-$(call make-unit-test,test_avx512_8x64,test_avx512_8x64 test_avx_common,fd_util)
+$(call make-unit-test,test_avx512_16x32,test_avx512_16x32,fd_util)
+$(call make-unit-test,test_avx512_8x64,test_avx512_8x64,fd_util)
+$(call run-unit-test,test_avx512_16x32,)
 $(call run-unit-test,test_avx512_8x64,)
 endif

--- a/src/util/simd/fd_avx512.h
+++ b/src/util/simd/fd_avx512.h
@@ -57,10 +57,9 @@
 /* Include all the APIs */
 
 /* TODO: ADD EXTRA APIS AS NECESSARY */
-//#include "fd_avx512_wwc.h" /* Vector conditional support */
 //#include "fd_avx512_wwf.h" /* Vector float support */
-//#include "fd_avx512_wwi.h" /* Vector int support */
-//#include "fd_avx512_wwu.h" /* Vector uint support */
+#include "fd_avx512_wwi.h" /* Vector int support */
+#include "fd_avx512_wwu.h" /* Vector uint support */
 //#include "fd_avx512_wwd.h" /* Vector double support */
 #include "fd_avx512_wwl.h" /* Vector long support */
 #include "fd_avx512_wwv.h" /* Vector ulong support */

--- a/src/util/simd/fd_avx512_wwi.h
+++ b/src/util/simd/fd_avx512_wwi.h
@@ -1,0 +1,319 @@
+#ifndef HEADER_fd_src_util_simd_fd_avx512_h
+#error "Do not include this directly; use fd_avx512.h"
+#endif
+
+/* TODO: REDUCE, EXTRACT, ADDITIONAL LANE OPS, ... */
+
+/* Vector int API ****************************************************/
+
+/* A wwi_t is a vector where each 32-bit wide lane holds an signed twos
+   complement 32-bit integer (an "int").
+
+   These mirror the other APIs as much as possible.  Macros are
+   preferred over static inlines when it is possible to do it robustly
+   to reduce the risk of the compiler mucking it up. */
+
+#define wwi_t __m512i
+
+/* Constructors */
+
+/* wwi(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf)
+   returns the wwi_t [x0 x1 ... xf] where x* are ints */
+
+#define wwi(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf) \
+  _mm512_setr_epi32( (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7), (x8), (x9), (xa), (xb), (xc), (xd), (xe), (xf) )
+
+#define wwi_bcast(x)         _mm512_set1_epi32( (x) ) /* wwi(x, x, ... x) */
+
+/* wwi_permute(p,x) returns:
+     wwi( x(p(0)), x(p(1)), ... x(p(15)) ).
+   As such p(*) should be ints in [0,15]. */
+
+#define wwi_permute(p,x)     _mm512_permutexvar_epi32( (p), (x) )
+
+/* wwi_select(s,x,y) concatenates the wwi_t's x and y into
+     z = [ x0 x1 ... xf y0 y1 ... yf ]
+   and then returns:
+     wwi( z(p(0)), z(p(1)), ... z(p(15)) ).
+   As such p(*) should be ints in [0,31]. */
+
+#define wwi_select(p,x,y)    _mm512_permutex2var_epi32( (x), (p), (y) )
+
+/* Predefined constants */
+
+#define wwi_zero()           _mm512_setzero_si512()  /* wwi(0, 0, ... 0) */
+#define wwi_one()            _mm512_set1_epi32( 1 )  /* wwi(1, 1, ... 1) */
+
+/* Memory operations */
+/* Note: wwi_{ld,st} assume m is 64-byte aligned while wwi_{ldu,stu}
+   allow m to have arbitrary alignment */
+
+static inline wwi_t wwi_ld( int const * m ) { return _mm512_load_epi32( m ); }  /* wwi( m[0], m[1], ... m[15] ) */
+static inline void  wwi_st( int * m, wwi_t x ) { _mm512_store_epi32( m, x ); }  /* does m[0] = x0, m[1] = x1, ... m[15] = xf */
+
+static inline wwi_t wwi_ldu( void const * m ) { return _mm512_loadu_epi32( m ); } /* wwi( m[0], m[1], ... m[15]) */
+static inline void  wwi_stu( void * m, wwi_t x ) { _mm512_storeu_epi32( m, x ); } /* does m[0] = x0, m[1] = x1, ... m[15] = xf */
+
+/* Arithmetic operations */
+
+#define wwi_neg(x)           _mm512_sub_epi32( _mm512_setzero_si512(), (x) ) /* wwi( -x0, -x1, ... -xf ) */
+#define wwi_abs(x)           (x)                                             /* wwi(  x0,  x1, ...  xf ) */
+
+#define wwi_min(x,y)         _mm512_min_epi32  ( (x), (y) ) /* wwi( min(x0,y0), min(x1,y1), ... min(xf,yf) ) */
+#define wwi_max(x,y)         _mm512_max_epi32  ( (x), (y) ) /* wwi( max(x0,y0), max(x1,y1), ... max(xf,yf) ) */
+#define wwi_add(x,y)         _mm512_add_epi32  ( (x), (y) ) /* wwi( x0+y0,      x1+y1,      ... xf+yf      ) */
+#define wwi_sub(x,y)         _mm512_sub_epi32  ( (x), (y) ) /* wwi( x0-y0,      x1-y1,      ... xf-yf      ) */
+#define wwi_mul(x,y)         _mm512_mullo_epi32( (x), (y) ) /* wwi( x0*y0,      x1*y1,      ... xf*yf      ) */
+
+/* Binary operations */
+/* Note: shifts assumes n and or y* in [0,31].  Rotates work for
+   arbitrary values */
+
+#define wwi_not(x)           _mm512_xor_epi32( _mm512_set1_epi32( -1 ), (x) )
+
+#define wwi_shl(x,n)         _mm512_slli_epi32  ( (x), (uint)(n) ) /* wwi( x0<<n,  x1<<n,  ... xf<<n  ) */
+#define wwi_shr(x,n)         _mm512_srai_epi32  ( (x), (uint)(n) ) /* wwi( x0>>n,  x1>>n,  ... xf>>n  ) */
+#define wwi_shru(x,n)        _mm512_srli_epi32  ( (x), (uint)(n) ) /* wwi( x0>>n,  x1>>n,  ... xf>>n  ) (unsigned right shift) */
+#define wwi_shl_vector(x,y)  _mm512_sllv_epi32  ( (x), (y) )       /* wwi( x0<<y0, x1<<y1, ... xf<<yf ) */
+#define wwi_shr_vector(x,y)  _mm512_srav_epi32  ( (x), (y) )       /* wwi( x0>>y0, x1>>y1, ... xf>>yf ) */
+#define wwi_shru_vector(x,y) _mm512_srlv_epi32  ( (x), (y) )       /* wwi( x0>>y0, x1>>y1, ... xf>>yf ) (unsigned right shift) */
+#define wwi_and(x,y)         _mm512_and_epi32   ( (x), (y) )       /* wwi( x0&y0,  x1&y1,  ... xf&yf  ) */
+#define wwi_andnot(x,y)      _mm512_andnot_epi32( (x), (y) )       /* wwi( ~x0&y0, ~x1&y1, ... ~xf&yf ) */
+#define wwi_or(x,y)          _mm512_or_epi32    ( (x), (y) )       /* wwi( x0|y0,  x1|y1,  ... xf|yf  ) */
+#define wwi_xor(x,y)         _mm512_xor_epi32   ( (x), (y) )       /* wwi( x0^y0,  x1^y1,  ... xf^yf  ) */
+
+/* wwi_rol(x,n)        returns wwi( rotate_left (x0,n ), rotate_left (x1,n ), ... )
+   wwi_ror(x,n)        returns wwi( rotate_right(x0,n ), rotate_right(x1,n ), ... )
+   wwi_rol_vector(x,y) returns wwi( rotate_left (x0,y0), rotate_left (x1,y1), ... )
+   wwi_ror_vector(x,y) returns wwi( rotate_right(x0,y0), rotate_right(x1,y1), ... ) */
+
+static inline wwi_t wwi_rol( wwi_t a, int n ) { return wwi_or( wwi_shl ( a, n & 31 ), wwi_shru( a, (-n) & 31 ) ); }
+static inline wwi_t wwi_ror( wwi_t a, int n ) { return wwi_or( wwi_shru( a, n & 31 ), wwi_shl ( a, (-n) & 31 ) ); }
+
+static inline wwi_t wwi_rol_vector( wwi_t a, wwi_t b ) {
+  wwi_t m = wwi_bcast( 31 );
+  return wwi_or( wwi_shl_vector ( a, wwi_and( b, m ) ), wwi_shru_vector( a, wwi_and( wwi_neg( b ), m ) ) );
+}
+
+static inline wwi_t wwi_ror_vector( wwi_t a, wwi_t b ) {
+  wwi_t m = wwi_bcast( 31 );
+  return wwi_or( wwi_shru_vector( a, wwi_and( b, m ) ), wwi_shl_vector ( a, wwi_and( wwi_neg( b ), m ) ) );
+}
+
+/* Comparison operations */
+/* mask(c0,c1,...) means (((int)c0)<<0) | (((int)c1)<<1) | ... */
+
+#define wwi_eq(x,y) ((int)_mm512_cmpeq_epi32_mask(  (x), (y) )) /* mask( x0==y0, x1==y1, ... ) */
+#define wwi_gt(x,y) ((int)_mm512_cmpgt_epi32_mask(  (x), (y) )) /* mask( x0> y0, x1> y1, ... ) */
+#define wwi_lt(x,y) ((int)_mm512_cmplt_epi32_mask(  (x), (y) )) /* mask( x0< y0, x1< y1, ... ) */
+#define wwi_ne(x,y) ((int)_mm512_cmpneq_epi32_mask( (x), (y) )) /* mask( x0!=y0, x1!=y1, ... ) */
+#define wwi_ge(x,y) ((int)_mm512_cmpge_epi32_mask(  (x), (y) )) /* mask( x0>=y0, x1>=y1, ... ) */
+#define wwi_le(x,y) ((int)_mm512_cmple_epi32_mask(  (x), (y) )) /* mask( x0<=y0, x1<=y1, ... ) */
+
+#define wwi_lnot(x)    wwi_eq( (x), wwi_zero() )                /* mask(  !x0,  !x1, ... ) */
+#define wwi_lnotnot(x) wwi_ne( (x), wwi_zero() )                /* mask( !!x0, !!x1, ... ) */
+
+/* Conditional operations */
+/* cn means bit n of c */
+
+#define wwi_if(c,x,y)       _mm512_mask_blend_epi32( (__mmask16)(c), (y), (x) )    /* wwi( c0? x0    :y0, ... ) */
+#define wwi_add_if(c,x,y,z) _mm512_mask_add_epi32( (z), (__mmask16)(c), (x), (y) ) /* wwi( c0?(x0+y0):z0, ... ) */
+#define wwi_sub_if(c,x,y,z) _mm512_mask_sub_epi32( (z), (__mmask16)(c), (x), (y) ) /* wwi( c0?(x0-y0):z0, ... ) */
+
+/* Conversions */
+
+/* wwi_to_wwu( x )    returns wwi(  (uint)x0,  (uint)x1, ...  (uint)x15 )
+
+   wwi_to_wwl( x, 0 ) returns wwl(  (long)x0,  (long)x2, ...  (long)x14 )
+   wwi_to_wwl( x, 1 ) returns wwl(  (long)x1,  (long)x3, ...  (long)x15 )
+
+   wwi_to_wwv( x, 0 ) returns wwv( (ulong)x0, (ulong)x2, ... (ulong)x14 )
+   wwi_to_wwv( x, 1 ) returns wwv( (ulong)x1, (ulong)x3, ... (ulong)x15 )
+
+   TODO: consider _mm512_cvtepi32_* intrinsics? */
+
+#define wwi_to_wwu( x ) (x)
+#define wwi_to_wwl( x, odd ) /* trinary should be compile time */ \
+  (__extension__({ wwl_t _wwi_to_wwl_tmp = (x); wwl_shr( (odd) ? _wwi_to_wwl_tmp : wwl_shl( _wwi_to_wwl_tmp, 32 ), 32 ); }))
+#define wwi_to_wwv( x, odd ) /* trinary should be compile time (yes, wwl_shr) */ \
+  (__extension__({ wwv_t _wwi_to_wwv_tmp = (x); wwl_shr( (odd) ? _wwi_to_wwv_tmp : wwv_shl( _wwi_to_wwv_tmp, 32 ), 32 ); }))
+
+#define wwi_to_wwu_raw(x) (x)
+#define wwi_to_wwl_raw(x) (x)
+#define wwi_to_wwv_raw(x) (x)
+
+/* Misc operations */
+
+/* wwi_pack_halves(x,imm0,y,imm1) packs half of x and half of y into a
+   wwi.  imm0/imm1 select which half of x and y to pack.  imm0 / imm1
+   should be in [0,1].  That is, this returns:
+
+     [ if( imm0, x(8:15), x(0:7) ) if( imm1, y(8:15), y(0:7) ) ]
+
+   wwi_pack_h0_h1(x,y) does the wwi_pack_halves(x,0,y,1) case faster.
+   Hat tip to Philip Taffet for pointing this out. */
+
+#define wwi_pack_halves(x,imm0,y,imm1) _mm512_shuffle_i32x4( (x), (y), 68+10*(imm0)+160*(imm1) )
+#define wwi_pack_h0_h1(x,y)            _mm512_mask_blend_epi32( (__mmask16)0xFF00, (x), (y) )
+
+/* wwi_slide(x,y,imm) treats as a x FIFO with the oldest / newest
+   element at lane 0 / 15.  Returns the result of dequeing x imm times
+   and enqueing the values y0 ... y{imm-1} in that order.  imm should be
+   in [0,15].  For example, with imm==5 case, returns:
+     [ x5 x6 ... xf y0 y1 y2 y3 y4 ]. */
+
+#define wwi_slide(x,y,imm) _mm512_alignr_epi32( (y), (x), (imm) )
+
+/* wwv_unpack unpacks the wwv x into its int components x0,x1,...xf. */
+
+#define wwi_unpack( x, x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf ) do { \
+    __m512i _wwi_unpack_x  = (x);                                             \
+    __m256i _wwi_unpack_xl = _mm512_extracti32x8_epi32( _wwi_unpack_x, 0 );   \
+    __m256i _wwi_unpack_xh = _mm512_extracti32x8_epi32( _wwi_unpack_x, 1 );   \
+    (x0) = _mm256_extract_epi32( _wwi_unpack_xl, 0 );                         \
+    (x1) = _mm256_extract_epi32( _wwi_unpack_xl, 1 );                         \
+    (x2) = _mm256_extract_epi32( _wwi_unpack_xl, 2 );                         \
+    (x3) = _mm256_extract_epi32( _wwi_unpack_xl, 3 );                         \
+    (x4) = _mm256_extract_epi32( _wwi_unpack_xl, 4 );                         \
+    (x5) = _mm256_extract_epi32( _wwi_unpack_xl, 5 );                         \
+    (x6) = _mm256_extract_epi32( _wwi_unpack_xl, 6 );                         \
+    (x7) = _mm256_extract_epi32( _wwi_unpack_xl, 7 );                         \
+    (x8) = _mm256_extract_epi32( _wwi_unpack_xh, 0 );                         \
+    (x9) = _mm256_extract_epi32( _wwi_unpack_xh, 1 );                         \
+    (xa) = _mm256_extract_epi32( _wwi_unpack_xh, 2 );                         \
+    (xb) = _mm256_extract_epi32( _wwi_unpack_xh, 3 );                         \
+    (xc) = _mm256_extract_epi32( _wwi_unpack_xh, 4 );                         \
+    (xd) = _mm256_extract_epi32( _wwi_unpack_xh, 5 );                         \
+    (xe) = _mm256_extract_epi32( _wwi_unpack_xh, 6 );                         \
+    (xf) = _mm256_extract_epi32( _wwi_unpack_xh, 7 );                         \
+  } while(0)
+
+/* wwi_transpose_16x16 sets wwi_t's c0,c1,...cf to the columns of a
+   16x16 int matrix given the rows of the matrix in wwi_t's r0,r1,...rf.
+   In-place operation fine. */
+
+#define wwi_transpose_16x16( r0,r1,r2,r3,r4,r5,r6,r7,r8,r9,ra,rb,rc,rd,re,rf,                      \
+                             c0,c1,c2,c3,c4,c5,c6,c7,c8,c9,ca,cb,cc,cd,ce,cf ) do {                \
+    wwi_t _wwi_transpose_r0 = (r0); wwi_t _wwi_transpose_r1 = (r1);                                \
+    wwi_t _wwi_transpose_r2 = (r2); wwi_t _wwi_transpose_r3 = (r3);                                \
+    wwi_t _wwi_transpose_r4 = (r4); wwi_t _wwi_transpose_r5 = (r5);                                \
+    wwi_t _wwi_transpose_r6 = (r6); wwi_t _wwi_transpose_r7 = (r7);                                \
+    wwi_t _wwi_transpose_r8 = (r8); wwi_t _wwi_transpose_r9 = (r9);                                \
+    wwi_t _wwi_transpose_ra = (ra); wwi_t _wwi_transpose_rb = (rb);                                \
+    wwi_t _wwi_transpose_rc = (rc); wwi_t _wwi_transpose_rd = (rd);                                \
+    wwi_t _wwi_transpose_re = (re); wwi_t _wwi_transpose_rf = (rf);                                \
+                                                                                                   \
+    /* Outer 4x4 transpose of 4x4 blocks */                                                        \
+    wwi_t _wwi_transpose_t0  = _mm512_shuffle_i32x4( _wwi_transpose_r0, _wwi_transpose_r4, 0x88 ); \
+    wwi_t _wwi_transpose_t1  = _mm512_shuffle_i32x4( _wwi_transpose_r1, _wwi_transpose_r5, 0x88 ); \
+    wwi_t _wwi_transpose_t2  = _mm512_shuffle_i32x4( _wwi_transpose_r2, _wwi_transpose_r6, 0x88 ); \
+    wwi_t _wwi_transpose_t3  = _mm512_shuffle_i32x4( _wwi_transpose_r3, _wwi_transpose_r7, 0x88 ); \
+    wwi_t _wwi_transpose_t4  = _mm512_shuffle_i32x4( _wwi_transpose_r0, _wwi_transpose_r4, 0xdd ); \
+    wwi_t _wwi_transpose_t5  = _mm512_shuffle_i32x4( _wwi_transpose_r1, _wwi_transpose_r5, 0xdd ); \
+    wwi_t _wwi_transpose_t6  = _mm512_shuffle_i32x4( _wwi_transpose_r2, _wwi_transpose_r6, 0xdd ); \
+    wwi_t _wwi_transpose_t7  = _mm512_shuffle_i32x4( _wwi_transpose_r3, _wwi_transpose_r7, 0xdd ); \
+    wwi_t _wwi_transpose_t8  = _mm512_shuffle_i32x4( _wwi_transpose_r8, _wwi_transpose_rc, 0x88 ); \
+    wwi_t _wwi_transpose_t9  = _mm512_shuffle_i32x4( _wwi_transpose_r9, _wwi_transpose_rd, 0x88 ); \
+    wwi_t _wwi_transpose_ta  = _mm512_shuffle_i32x4( _wwi_transpose_ra, _wwi_transpose_re, 0x88 ); \
+    wwi_t _wwi_transpose_tb  = _mm512_shuffle_i32x4( _wwi_transpose_rb, _wwi_transpose_rf, 0x88 ); \
+    wwi_t _wwi_transpose_tc  = _mm512_shuffle_i32x4( _wwi_transpose_r8, _wwi_transpose_rc, 0xdd ); \
+    wwi_t _wwi_transpose_td  = _mm512_shuffle_i32x4( _wwi_transpose_r9, _wwi_transpose_rd, 0xdd ); \
+    wwi_t _wwi_transpose_te  = _mm512_shuffle_i32x4( _wwi_transpose_ra, _wwi_transpose_re, 0xdd ); \
+    wwi_t _wwi_transpose_tf  = _mm512_shuffle_i32x4( _wwi_transpose_rb, _wwi_transpose_rf, 0xdd ); \
+                                                                                                   \
+    /**/  _wwi_transpose_r0  = _mm512_shuffle_i32x4( _wwi_transpose_t0, _wwi_transpose_t8, 0x88 ); \
+    /**/  _wwi_transpose_r1  = _mm512_shuffle_i32x4( _wwi_transpose_t1, _wwi_transpose_t9, 0x88 ); \
+    /**/  _wwi_transpose_r2  = _mm512_shuffle_i32x4( _wwi_transpose_t2, _wwi_transpose_ta, 0x88 ); \
+    /**/  _wwi_transpose_r3  = _mm512_shuffle_i32x4( _wwi_transpose_t3, _wwi_transpose_tb, 0x88 ); \
+    /**/  _wwi_transpose_r4  = _mm512_shuffle_i32x4( _wwi_transpose_t4, _wwi_transpose_tc, 0x88 ); \
+    /**/  _wwi_transpose_r5  = _mm512_shuffle_i32x4( _wwi_transpose_t5, _wwi_transpose_td, 0x88 ); \
+    /**/  _wwi_transpose_r6  = _mm512_shuffle_i32x4( _wwi_transpose_t6, _wwi_transpose_te, 0x88 ); \
+    /**/  _wwi_transpose_r7  = _mm512_shuffle_i32x4( _wwi_transpose_t7, _wwi_transpose_tf, 0x88 ); \
+    /**/  _wwi_transpose_r8  = _mm512_shuffle_i32x4( _wwi_transpose_t0, _wwi_transpose_t8, 0xdd ); \
+    /**/  _wwi_transpose_r9  = _mm512_shuffle_i32x4( _wwi_transpose_t1, _wwi_transpose_t9, 0xdd ); \
+    /**/  _wwi_transpose_ra  = _mm512_shuffle_i32x4( _wwi_transpose_t2, _wwi_transpose_ta, 0xdd ); \
+    /**/  _wwi_transpose_rb  = _mm512_shuffle_i32x4( _wwi_transpose_t3, _wwi_transpose_tb, 0xdd ); \
+    /**/  _wwi_transpose_rc  = _mm512_shuffle_i32x4( _wwi_transpose_t4, _wwi_transpose_tc, 0xdd ); \
+    /**/  _wwi_transpose_rd  = _mm512_shuffle_i32x4( _wwi_transpose_t5, _wwi_transpose_td, 0xdd ); \
+    /**/  _wwi_transpose_re  = _mm512_shuffle_i32x4( _wwi_transpose_t6, _wwi_transpose_te, 0xdd ); \
+    /**/  _wwi_transpose_rf  = _mm512_shuffle_i32x4( _wwi_transpose_t7, _wwi_transpose_tf, 0xdd ); \
+                                                                                                   \
+    /* Inner 4x4 transpose of 1x1 blocks */                                                        \
+    /**/  _wwi_transpose_t0  = _mm512_unpacklo_epi32( _wwi_transpose_r0, _wwi_transpose_r2 );      \
+    /**/  _wwi_transpose_t1  = _mm512_unpacklo_epi32( _wwi_transpose_r1, _wwi_transpose_r3 );      \
+    /**/  _wwi_transpose_t2  = _mm512_unpackhi_epi32( _wwi_transpose_r0, _wwi_transpose_r2 );      \
+    /**/  _wwi_transpose_t3  = _mm512_unpackhi_epi32( _wwi_transpose_r1, _wwi_transpose_r3 );      \
+    /**/  _wwi_transpose_t4  = _mm512_unpacklo_epi32( _wwi_transpose_r4, _wwi_transpose_r6 );      \
+    /**/  _wwi_transpose_t5  = _mm512_unpacklo_epi32( _wwi_transpose_r5, _wwi_transpose_r7 );      \
+    /**/  _wwi_transpose_t6  = _mm512_unpackhi_epi32( _wwi_transpose_r4, _wwi_transpose_r6 );      \
+    /**/  _wwi_transpose_t7  = _mm512_unpackhi_epi32( _wwi_transpose_r5, _wwi_transpose_r7 );      \
+    /**/  _wwi_transpose_t8  = _mm512_unpacklo_epi32( _wwi_transpose_r8, _wwi_transpose_ra );      \
+    /**/  _wwi_transpose_t9  = _mm512_unpacklo_epi32( _wwi_transpose_r9, _wwi_transpose_rb );      \
+    /**/  _wwi_transpose_ta  = _mm512_unpackhi_epi32( _wwi_transpose_r8, _wwi_transpose_ra );      \
+    /**/  _wwi_transpose_tb  = _mm512_unpackhi_epi32( _wwi_transpose_r9, _wwi_transpose_rb );      \
+    /**/  _wwi_transpose_tc  = _mm512_unpacklo_epi32( _wwi_transpose_rc, _wwi_transpose_re );      \
+    /**/  _wwi_transpose_td  = _mm512_unpacklo_epi32( _wwi_transpose_rd, _wwi_transpose_rf );      \
+    /**/  _wwi_transpose_te  = _mm512_unpackhi_epi32( _wwi_transpose_rc, _wwi_transpose_re );      \
+    /**/  _wwi_transpose_tf  = _mm512_unpackhi_epi32( _wwi_transpose_rd, _wwi_transpose_rf );      \
+                                                                                                   \
+    /**/  (c0)               = _mm512_unpacklo_epi32( _wwi_transpose_t0, _wwi_transpose_t1 );      \
+    /**/  (c1)               = _mm512_unpackhi_epi32( _wwi_transpose_t0, _wwi_transpose_t1 );      \
+    /**/  (c2)               = _mm512_unpacklo_epi32( _wwi_transpose_t2, _wwi_transpose_t3 );      \
+    /**/  (c3)               = _mm512_unpackhi_epi32( _wwi_transpose_t2, _wwi_transpose_t3 );      \
+    /**/  (c4)               = _mm512_unpacklo_epi32( _wwi_transpose_t4, _wwi_transpose_t5 );      \
+    /**/  (c5)               = _mm512_unpackhi_epi32( _wwi_transpose_t4, _wwi_transpose_t5 );      \
+    /**/  (c6)               = _mm512_unpacklo_epi32( _wwi_transpose_t6, _wwi_transpose_t7 );      \
+    /**/  (c7)               = _mm512_unpackhi_epi32( _wwi_transpose_t6, _wwi_transpose_t7 );      \
+    /**/  (c8)               = _mm512_unpacklo_epi32( _wwi_transpose_t8, _wwi_transpose_t9 );      \
+    /**/  (c9)               = _mm512_unpackhi_epi32( _wwi_transpose_t8, _wwi_transpose_t9 );      \
+    /**/  (ca)               = _mm512_unpacklo_epi32( _wwi_transpose_ta, _wwi_transpose_tb );      \
+    /**/  (cb)               = _mm512_unpackhi_epi32( _wwi_transpose_ta, _wwi_transpose_tb );      \
+    /**/  (cc)               = _mm512_unpacklo_epi32( _wwi_transpose_tc, _wwi_transpose_td );      \
+    /**/  (cd)               = _mm512_unpackhi_epi32( _wwi_transpose_tc, _wwi_transpose_td );      \
+    /**/  (ce)               = _mm512_unpacklo_epi32( _wwi_transpose_te, _wwi_transpose_tf );      \
+    /**/  (cf)               = _mm512_unpackhi_epi32( _wwi_transpose_te, _wwi_transpose_tf );      \
+  } while(0)
+
+/* wwi_transpose_2x8x8 transposes the 2 8x8 matrices whos rows are in
+   held in the lower and upper halves of wwi_t's r0,r1...r7 and
+   stores the result in c0,c1...c7.  In-place operation fine. */
+
+#define wwi_transpose_2x8x8( r0,r1,r2,r3,r4,r5,r6,r7,                                                \
+                             c0,c1,c2,c3,c4,c5,c6,c7 ) {                                             \
+    wwi_t _wwi_transpose_r0 = (r0); wwi_t _wwi_transpose_r1 = (r1);                                  \
+    wwi_t _wwi_transpose_r2 = (r2); wwi_t _wwi_transpose_r3 = (r3);                                  \
+    wwi_t _wwi_transpose_r4 = (r4); wwi_t _wwi_transpose_r5 = (r5);                                  \
+    wwi_t _wwi_transpose_r6 = (r6); wwi_t _wwi_transpose_r7 = (r7);                                  \
+                                                                                                     \
+    /* Outer 2x2 transpose of 4x4 blocks */                                                          \
+    /* No _mm256_permute2f128_si128 equiv? sigh ... probably a better method possible here */        \
+    wwi_t _wwi_transpose_p   = wwi( 0, 1, 2, 3,16,17,18,19, 8, 9,10,11,24,25,26,27);                 \
+    wwi_t _wwi_transpose_q   = wwi( 4, 5, 6, 7,20,21,22,23,12,13,14,15,28,29,30,31);                 \
+    wwi_t _wwi_transpose_t0  = wwi_select( _wwi_transpose_p, _wwi_transpose_r0, _wwi_transpose_r4 ); \
+    wwi_t _wwi_transpose_t1  = wwi_select( _wwi_transpose_p, _wwi_transpose_r1, _wwi_transpose_r5 ); \
+    wwi_t _wwi_transpose_t2  = wwi_select( _wwi_transpose_p, _wwi_transpose_r2, _wwi_transpose_r6 ); \
+    wwi_t _wwi_transpose_t3  = wwi_select( _wwi_transpose_p, _wwi_transpose_r3, _wwi_transpose_r7 ); \
+    wwi_t _wwi_transpose_t4  = wwi_select( _wwi_transpose_q, _wwi_transpose_r0, _wwi_transpose_r4 ); \
+    wwi_t _wwi_transpose_t5  = wwi_select( _wwi_transpose_q, _wwi_transpose_r1, _wwi_transpose_r5 ); \
+    wwi_t _wwi_transpose_t6  = wwi_select( _wwi_transpose_q, _wwi_transpose_r2, _wwi_transpose_r6 ); \
+    wwi_t _wwi_transpose_t7  = wwi_select( _wwi_transpose_q, _wwi_transpose_r3, _wwi_transpose_r7 ); \
+                                                                                                     \
+    /* Inner 4x4 transpose of 1x1 blocks */                                                          \
+    /**/  _wwi_transpose_r0  = _mm512_unpacklo_epi32( _wwi_transpose_t0, _wwi_transpose_t2 );        \
+    /**/  _wwi_transpose_r1  = _mm512_unpacklo_epi32( _wwi_transpose_t1, _wwi_transpose_t3 );        \
+    /**/  _wwi_transpose_r2  = _mm512_unpackhi_epi32( _wwi_transpose_t0, _wwi_transpose_t2 );        \
+    /**/  _wwi_transpose_r3  = _mm512_unpackhi_epi32( _wwi_transpose_t1, _wwi_transpose_t3 );        \
+    /**/  _wwi_transpose_r4  = _mm512_unpacklo_epi32( _wwi_transpose_t4, _wwi_transpose_t6 );        \
+    /**/  _wwi_transpose_r5  = _mm512_unpacklo_epi32( _wwi_transpose_t5, _wwi_transpose_t7 );        \
+    /**/  _wwi_transpose_r6  = _mm512_unpackhi_epi32( _wwi_transpose_t4, _wwi_transpose_t6 );        \
+    /**/  _wwi_transpose_r7  = _mm512_unpackhi_epi32( _wwi_transpose_t5, _wwi_transpose_t7 );        \
+                                                                                                     \
+    /**/  (c0)               = _mm512_unpacklo_epi32( _wwi_transpose_r0, _wwi_transpose_r1 );        \
+    /**/  (c1)               = _mm512_unpackhi_epi32( _wwi_transpose_r0, _wwi_transpose_r1 );        \
+    /**/  (c2)               = _mm512_unpacklo_epi32( _wwi_transpose_r2, _wwi_transpose_r3 );        \
+    /**/  (c3)               = _mm512_unpackhi_epi32( _wwi_transpose_r2, _wwi_transpose_r3 );        \
+    /**/  (c4)               = _mm512_unpacklo_epi32( _wwi_transpose_r4, _wwi_transpose_r5 );        \
+    /**/  (c5)               = _mm512_unpackhi_epi32( _wwi_transpose_r4, _wwi_transpose_r5 );        \
+    /**/  (c6)               = _mm512_unpacklo_epi32( _wwi_transpose_r6, _wwi_transpose_r7 );        \
+    /**/  (c7)               = _mm512_unpackhi_epi32( _wwi_transpose_r6, _wwi_transpose_r7 );        \
+  } while(0)

--- a/src/util/simd/fd_avx512_wwi.h
+++ b/src/util/simd/fd_avx512_wwi.h
@@ -274,7 +274,7 @@ static inline wwi_t wwi_ror_vector( wwi_t a, wwi_t b ) {
     /**/  (cf)               = _mm512_unpackhi_epi32( _wwi_transpose_te, _wwi_transpose_tf );      \
   } while(0)
 
-/* wwi_transpose_2x8x8 transposes the 2 8x8 matrices whos rows are in
+/* wwi_transpose_2x8x8 transposes the 2 8x8 matrices whose rows are
    held in the lower and upper halves of wwi_t's r0,r1...r7 and
    stores the result in c0,c1...c7.  In-place operation fine. */
 

--- a/src/util/simd/fd_avx512_wwu.h
+++ b/src/util/simd/fd_avx512_wwu.h
@@ -1,0 +1,327 @@
+#ifndef HEADER_fd_src_util_simd_fd_avx512_h
+#error "Do not include this directly; use fd_avx512.h"
+#endif
+
+/* TODO: REDUCE, EXTRACT, ADDITIONAL LANE OPS, ... */
+/* TODO: USE INT FOR THS SCALAR N ROL/ROR (AND IN OTHER ROL/ROR)? */
+/* TODO: BACKPORT UNPACKS TO AVX AND SSE? */
+
+/* Vector uint API ***************************************************/
+
+/* A wwu_t is a vector where each 32-bit wide lane holds an unsigned
+   32-bit integer (a "uint").
+
+   These mirror the other APIs as much as possible.  Macros are
+   preferred over static inlines when it is possible to do it robustly
+   to reduce the risk of the compiler mucking it up. */
+
+#define wwu_t __m512i
+
+/* Constructors */
+
+/* wwu(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf)
+   returns the wwu_t [x0 x1 ... xf] where x* are uints */
+
+#define wwu(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf)                                                 \
+  _mm512_setr_epi32( (int)(x0), (int)(x1), (int)(x2), (int)(x3), (int)(x4), (int)(x5), (int)(x6), (int)(x7), \
+                     (int)(x8), (int)(x9), (int)(xa), (int)(xb), (int)(xc), (int)(xd), (int)(xe), (int)(xf) )
+
+#define wwu_bcast(x)         _mm512_set1_epi32( (int)(x) ) /* wwu(x, x, ... x) */
+
+/* wwu_permute(p,x) returns:
+     wwu( x(p(0)), x(p(1)), ... x(p(15)) ).
+   As such p(*) should be uints in [0,15]. */
+
+#define wwu_permute(p,x)     _mm512_permutexvar_epi32( (p), (x) )
+
+/* wwu_select(s,x,y) concatenates the wwu_t's x and y into
+     z = [ x0 x1 ... xf y0 y1 ... yf ]
+   and then returns:
+     wwu( z(p(0)), z(p(1)), ... z(p(15)) ).
+   As such p(*) should be uints in [0,31]. */
+
+#define wwu_select(p,x,y)    _mm512_permutex2var_epi32( (x), (p), (y) )
+
+/* Predefined constants */
+
+#define wwu_zero()           _mm512_setzero_si512()  /* wwu(0, 0, ... 0) */
+#define wwu_one()            _mm512_set1_epi32( 1 )  /* wwu(1, 1, ... 1) */
+
+/* Memory operations */
+/* Note: wwu_{ld,st} assume m is 64-byte aligned while wwu_{ldu,stu}
+   allow m to have arbitrary alignment */
+
+static inline wwu_t wwu_ld( uint const * m ) { return _mm512_load_epi32( m ); }  /* wwu( m[0], m[1], ... m[15] ) */
+static inline void  wwu_st( uint * m, wwu_t x ) { _mm512_store_epi32( m, x ); }  /* does m[0] = x0, m[1] = x1, ... m[15] = xf */
+
+static inline wwu_t wwu_ldu( void const * m ) { return _mm512_loadu_epi32( m ); } /* wwu( m[0], m[1], ... m[15]) */
+static inline void  wwu_stu( void * m, wwu_t x ) { _mm512_storeu_epi32( m, x ); } /* does m[0] = x0, m[1] = x1, ... m[15] = xf */
+
+/* Arithmetic operations */
+
+#define wwu_neg(x)           _mm512_sub_epi32( _mm512_setzero_si512(), (x) ) /* wwu( -x0, -x1, ... -xf ) */
+#define wwu_abs(x)           (x)                                             /* wwu(  x0,  x1, ...  xf ) */
+
+#define wwu_min(x,y)         _mm512_min_epu32  ( (x), (y) ) /* wwu( min(x0,y0), min(x1,y1), ... min(xf,yf) ) */
+#define wwu_max(x,y)         _mm512_max_epu32  ( (x), (y) ) /* wwu( max(x0,y0), max(x1,y1), ... max(xf,yf) ) */
+#define wwu_add(x,y)         _mm512_add_epi32  ( (x), (y) ) /* wwu( x0+y0,      x1+y1,      ... xf+yf      ) */
+#define wwu_sub(x,y)         _mm512_sub_epi32  ( (x), (y) ) /* wwu( x0-y0,      x1-y1,      ... xf-yf      ) */
+#define wwu_mul(x,y)         _mm512_mullo_epi32( (x), (y) ) /* wwu( x0*y0,      x1*y1,      ... xf*yf      ) */
+
+/* Binary operations */
+/* Note: shifts assumes n and or y* in [0,31].  Rotates work for
+   arbitrary values */
+
+#define wwu_not(x)           _mm512_xor_epi32( _mm512_set1_epi32( -1 ), (x) )
+
+#define wwu_shl(x,n)         _mm512_slli_epi32  ( (x), (uint)(n) ) /* wwu( x0<<n,  x1<<n,  ... xf<<n  ) */
+#define wwu_shr(x,n)         _mm512_srli_epi32  ( (x), (uint)(n) ) /* wwu( x0>>n,  x1>>n,  ... xf>>n  ) */
+#define wwu_shl_vector(x,y)  _mm512_sllv_epi32  ( (x), (y)       ) /* wwu( x0<<y0, x1<<y1, ... xf<<yf ) */
+#define wwu_shr_vector(x,y)  _mm512_srlv_epi32  ( (x), (y)       ) /* wwu( x0>>y0, x1>>y1, ... xf>>yf ) */
+#define wwu_and(x,y)         _mm512_and_epi32   ( (x), (y)       ) /* wwu( x0&y0,  x1&y1,  ... xf&yf  ) */
+#define wwu_andnot(x,y)      _mm512_andnot_epi32( (x), (y)       ) /* wwu( ~x0&y0, ~x1&y1, ... ~xf&yf ) */
+#define wwu_or(x,y)          _mm512_or_epi32    ( (x), (y)       ) /* wwu( x0|y0,  x1|y1,  ... xf|yf  ) */
+#define wwu_xor(x,y)         _mm512_xor_epi32   ( (x), (y)       ) /* wwu( x0^y0,  x1^y1,  ... xf^yf  ) */
+
+/* wwu_rol(x,n)        returns wwu( rotate_left (x0,n ), rotate_left (x1,n ), ... )
+   wwu_ror(x,n)        returns wwu( rotate_right(x0,n ), rotate_right(x1,n ), ... )
+   wwu_rol_vector(x,y) returns wwu( rotate_left (x0,y0), rotate_left (x1,y1), ... )
+   wwu_ror_vector(x,y) returns wwu( rotate_right(x0,y0), rotate_right(x1,y1), ... ) */
+
+static inline wwu_t wwu_rol( wwu_t a, uint n ) { return wwu_or( wwu_shl( a, n & 31U ), wwu_shr( a, (-n) & 31U ) ); }
+static inline wwu_t wwu_ror( wwu_t a, uint n ) { return wwu_or( wwu_shr( a, n & 31U ), wwu_shl( a, (-n) & 31U ) ); }
+
+static inline wwu_t wwu_rol_vector( wwu_t a, wwu_t b ) {
+  wwu_t m = wwu_bcast( 31U );
+  return wwu_or( wwu_shl_vector( a, wwu_and( b, m ) ), wwu_shr_vector( a, wwu_and( wwu_neg( b ), m ) ) );
+}
+
+static inline wwu_t wwu_ror_vector( wwu_t a, wwu_t b ) {
+  wwu_t m = wwu_bcast( 31U );
+  return wwu_or( wwu_shr_vector( a, wwu_and( b, m ) ), wwu_shl_vector( a, wwu_and( wwu_neg( b ), m ) ) );
+}
+
+/* wwu_bswap(x) returns wwu( bswap(x0), bswap(x1), ... ) */
+
+#define wwu_bswap( x ) _mm512_shuffle_epi8( (x), _mm512_set_epi8( 12,13,14,15, 8, 9,10,11, 4, 5, 6, 7, 0, 1, 2, 3, \
+                                                                  12,13,14,15, 8, 9,10,11, 4, 5, 6, 7, 0, 1, 2, 3, \
+                                                                  12,13,14,15, 8, 9,10,11, 4, 5, 6, 7, 0, 1, 2, 3, \
+                                                                  12,13,14,15, 8, 9,10,11, 4, 5, 6, 7, 0, 1, 2, 3 ) )
+
+/* Comparison operations */
+/* mask(c0,c1,...) means (((int)c0)<<0) | (((int)c1)<<1) | ... */
+
+#define wwu_eq(x,y) ((int)_mm512_cmpeq_epu32_mask(  (x), (y) )) /* mask( x0==y0, x1==y1, ... ) */
+#define wwu_gt(x,y) ((int)_mm512_cmpgt_epu32_mask(  (x), (y) )) /* mask( x0> y0, x1> y1, ... ) */
+#define wwu_lt(x,y) ((int)_mm512_cmplt_epu32_mask(  (x), (y) )) /* mask( x0< y0, x1< y1, ... ) */
+#define wwu_ne(x,y) ((int)_mm512_cmpneq_epu32_mask( (x), (y) )) /* mask( x0!=y0, x1!=y1, ... ) */
+#define wwu_ge(x,y) ((int)_mm512_cmpge_epu32_mask(  (x), (y) )) /* mask( x0>=y0, x1>=y1, ... ) */
+#define wwu_le(x,y) ((int)_mm512_cmple_epu32_mask(  (x), (y) )) /* mask( x0<=y0, x1<=y1, ... ) */
+
+#define wwu_lnot(x)    wwu_eq( (x), wwu_zero() )                /* mask(  !x0,  !x1, ... ) */
+#define wwu_lnotnot(x) wwu_ne( (x), wwu_zero() )                /* mask( !!x0, !!x1, ... ) */
+
+/* Conditional operations */
+/* cn means bit n of c */
+
+#define wwu_if(c,x,y)       _mm512_mask_blend_epi32( (__mmask16)(c), (y), (x) )    /* wwu( c0? x0    :y0, ... ) */
+#define wwu_add_if(c,x,y,z) _mm512_mask_add_epi32( (z), (__mmask16)(c), (x), (y) ) /* wwu( c0?(x0+y0):z0, ... ) */
+#define wwu_sub_if(c,x,y,z) _mm512_mask_sub_epi32( (z), (__mmask16)(c), (x), (y) ) /* wwu( c0?(x0-y0):z0, ... ) */
+
+/* Conversions */
+
+/* wwu_to_wwi( x )    returns wwi(   (int)x0,   (int)x1, ...   (int)x15 )
+
+   wwu_to_wwl( x, 0 ) returns wwl(  (long)x0,  (long)x2, ...  (long)x14 )
+   wwu_to_wwl( x, 1 ) returns wwl(  (long)x1,  (long)x3, ...  (long)x15 )
+
+   wwu_to_wwv( x, 0 ) returns wwv( (ulong)x0, (ulong)x2, ... (ulong)x14 )
+   wwu_to_wwv( x, 1 ) returns wwv( (ulong)x1, (ulong)x3, ... (ulong)x15 )
+
+   TODO: consider _mm512_cvtepu32_* intrinsics? */
+
+#define wwu_to_wwi( x ) (x)
+#define wwu_to_wwl( x, odd ) /* trinary should be compile time */ \
+  (__extension__({ wwl_t _wwu_to_wwl_tmp = (x); wwl_shru( (odd) ? _wwu_to_wwl_tmp : wwl_shl( _wwu_to_wwl_tmp, 32 ), 32 ); }))
+#define wwu_to_wwv( x, odd ) /* trinary should be compile time */ \
+  (__extension__({ wwv_t _wwu_to_wwv_tmp = (x); wwv_shr ( (odd) ? _wwu_to_wwv_tmp : wwv_shl( _wwu_to_wwv_tmp, 32 ), 32 ); }))
+
+#define wwu_to_wwi_raw(x) (x)
+#define wwu_to_wwl_raw(x) (x)
+#define wwu_to_wwv_raw(x) (x)
+
+/* Misc operations */
+
+/* wwu_pack_halves(x,imm0,y,imm1) packs half of x and half of y into a
+   wwu.  imm0/imm1 select which half of x and y to pack.  imm0 / imm1
+   should be in [0,1].  That is, this returns:
+
+     [ if( imm0, x(8:15), x(0:7) ) if( imm1, y(8:15), y(0:7) ) ]
+
+   wwu_pack_h0_h1(x,y) does the wwu_pack_halves(x,0,y,1) case faster.
+   Hat tip to Philip Taffet for pointing this out. */
+
+#define wwu_pack_halves(x,imm0,y,imm1) _mm512_shuffle_i32x4( (x), (y), 68+10*(imm0)+160*(imm1) )
+#define wwu_pack_h0_h1(x,y)            _mm512_mask_blend_epi32( (__mmask16)0xFF00, (x), (y) )
+
+/* wwu_slide(x,y,imm) treats as a x FIFO with the oldest / newest
+   element at lane 0 / 15.  Returns the result of dequeing x imm times
+   and enqueing the values y0 ... y{imm-1} in that order.  imm should be
+   in [0,15].  For example, with imm==5 case, returns:
+     [ x5 x6 ... xf y0 y1 y2 y3 y4 ]. */
+
+#define wwu_slide(x,y,imm) _mm512_alignr_epi32( (y), (x), (imm) )
+
+/* wwv_unpack unpacks the wwv x into its uint components x0,x1,...xf. */
+
+#define wwu_unpack( x, x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf ) do { \
+    __m512i _wwu_unpack_x  = (x);                                             \
+    __m256i _wwu_unpack_xl = _mm512_extracti32x8_epi32( _wwu_unpack_x, 0 );   \
+    __m256i _wwu_unpack_xh = _mm512_extracti32x8_epi32( _wwu_unpack_x, 1 );   \
+    (x0) = (uint)_mm256_extract_epi32( _wwu_unpack_xl, 0 );                   \
+    (x1) = (uint)_mm256_extract_epi32( _wwu_unpack_xl, 1 );                   \
+    (x2) = (uint)_mm256_extract_epi32( _wwu_unpack_xl, 2 );                   \
+    (x3) = (uint)_mm256_extract_epi32( _wwu_unpack_xl, 3 );                   \
+    (x4) = (uint)_mm256_extract_epi32( _wwu_unpack_xl, 4 );                   \
+    (x5) = (uint)_mm256_extract_epi32( _wwu_unpack_xl, 5 );                   \
+    (x6) = (uint)_mm256_extract_epi32( _wwu_unpack_xl, 6 );                   \
+    (x7) = (uint)_mm256_extract_epi32( _wwu_unpack_xl, 7 );                   \
+    (x8) = (uint)_mm256_extract_epi32( _wwu_unpack_xh, 0 );                   \
+    (x9) = (uint)_mm256_extract_epi32( _wwu_unpack_xh, 1 );                   \
+    (xa) = (uint)_mm256_extract_epi32( _wwu_unpack_xh, 2 );                   \
+    (xb) = (uint)_mm256_extract_epi32( _wwu_unpack_xh, 3 );                   \
+    (xc) = (uint)_mm256_extract_epi32( _wwu_unpack_xh, 4 );                   \
+    (xd) = (uint)_mm256_extract_epi32( _wwu_unpack_xh, 5 );                   \
+    (xe) = (uint)_mm256_extract_epi32( _wwu_unpack_xh, 6 );                   \
+    (xf) = (uint)_mm256_extract_epi32( _wwu_unpack_xh, 7 );                   \
+  } while(0)
+
+/* wwu_transpose_16x16 sets wwu_t's c0,c1,...cf to the columns of a
+   16x16 uint matrix given the rows of the matrix in wwu_t's
+   r0,r1,...rf.  In-place operation fine. */
+
+#define wwu_transpose_16x16( r0,r1,r2,r3,r4,r5,r6,r7,r8,r9,ra,rb,rc,rd,re,rf,                      \
+                             c0,c1,c2,c3,c4,c5,c6,c7,c8,c9,ca,cb,cc,cd,ce,cf ) do {                \
+    wwu_t _wwu_transpose_r0 = (r0); wwu_t _wwu_transpose_r1 = (r1);                                \
+    wwu_t _wwu_transpose_r2 = (r2); wwu_t _wwu_transpose_r3 = (r3);                                \
+    wwu_t _wwu_transpose_r4 = (r4); wwu_t _wwu_transpose_r5 = (r5);                                \
+    wwu_t _wwu_transpose_r6 = (r6); wwu_t _wwu_transpose_r7 = (r7);                                \
+    wwu_t _wwu_transpose_r8 = (r8); wwu_t _wwu_transpose_r9 = (r9);                                \
+    wwu_t _wwu_transpose_ra = (ra); wwu_t _wwu_transpose_rb = (rb);                                \
+    wwu_t _wwu_transpose_rc = (rc); wwu_t _wwu_transpose_rd = (rd);                                \
+    wwu_t _wwu_transpose_re = (re); wwu_t _wwu_transpose_rf = (rf);                                \
+                                                                                                   \
+    /* Outer 4x4 transpose of 4x4 blocks */                                                        \
+    wwu_t _wwu_transpose_t0  = _mm512_shuffle_i32x4( _wwu_transpose_r0, _wwu_transpose_r4, 0x88 ); \
+    wwu_t _wwu_transpose_t1  = _mm512_shuffle_i32x4( _wwu_transpose_r1, _wwu_transpose_r5, 0x88 ); \
+    wwu_t _wwu_transpose_t2  = _mm512_shuffle_i32x4( _wwu_transpose_r2, _wwu_transpose_r6, 0x88 ); \
+    wwu_t _wwu_transpose_t3  = _mm512_shuffle_i32x4( _wwu_transpose_r3, _wwu_transpose_r7, 0x88 ); \
+    wwu_t _wwu_transpose_t4  = _mm512_shuffle_i32x4( _wwu_transpose_r0, _wwu_transpose_r4, 0xdd ); \
+    wwu_t _wwu_transpose_t5  = _mm512_shuffle_i32x4( _wwu_transpose_r1, _wwu_transpose_r5, 0xdd ); \
+    wwu_t _wwu_transpose_t6  = _mm512_shuffle_i32x4( _wwu_transpose_r2, _wwu_transpose_r6, 0xdd ); \
+    wwu_t _wwu_transpose_t7  = _mm512_shuffle_i32x4( _wwu_transpose_r3, _wwu_transpose_r7, 0xdd ); \
+    wwu_t _wwu_transpose_t8  = _mm512_shuffle_i32x4( _wwu_transpose_r8, _wwu_transpose_rc, 0x88 ); \
+    wwu_t _wwu_transpose_t9  = _mm512_shuffle_i32x4( _wwu_transpose_r9, _wwu_transpose_rd, 0x88 ); \
+    wwu_t _wwu_transpose_ta  = _mm512_shuffle_i32x4( _wwu_transpose_ra, _wwu_transpose_re, 0x88 ); \
+    wwu_t _wwu_transpose_tb  = _mm512_shuffle_i32x4( _wwu_transpose_rb, _wwu_transpose_rf, 0x88 ); \
+    wwu_t _wwu_transpose_tc  = _mm512_shuffle_i32x4( _wwu_transpose_r8, _wwu_transpose_rc, 0xdd ); \
+    wwu_t _wwu_transpose_td  = _mm512_shuffle_i32x4( _wwu_transpose_r9, _wwu_transpose_rd, 0xdd ); \
+    wwu_t _wwu_transpose_te  = _mm512_shuffle_i32x4( _wwu_transpose_ra, _wwu_transpose_re, 0xdd ); \
+    wwu_t _wwu_transpose_tf  = _mm512_shuffle_i32x4( _wwu_transpose_rb, _wwu_transpose_rf, 0xdd ); \
+                                                                                                   \
+    /**/  _wwu_transpose_r0  = _mm512_shuffle_i32x4( _wwu_transpose_t0, _wwu_transpose_t8, 0x88 ); \
+    /**/  _wwu_transpose_r1  = _mm512_shuffle_i32x4( _wwu_transpose_t1, _wwu_transpose_t9, 0x88 ); \
+    /**/  _wwu_transpose_r2  = _mm512_shuffle_i32x4( _wwu_transpose_t2, _wwu_transpose_ta, 0x88 ); \
+    /**/  _wwu_transpose_r3  = _mm512_shuffle_i32x4( _wwu_transpose_t3, _wwu_transpose_tb, 0x88 ); \
+    /**/  _wwu_transpose_r4  = _mm512_shuffle_i32x4( _wwu_transpose_t4, _wwu_transpose_tc, 0x88 ); \
+    /**/  _wwu_transpose_r5  = _mm512_shuffle_i32x4( _wwu_transpose_t5, _wwu_transpose_td, 0x88 ); \
+    /**/  _wwu_transpose_r6  = _mm512_shuffle_i32x4( _wwu_transpose_t6, _wwu_transpose_te, 0x88 ); \
+    /**/  _wwu_transpose_r7  = _mm512_shuffle_i32x4( _wwu_transpose_t7, _wwu_transpose_tf, 0x88 ); \
+    /**/  _wwu_transpose_r8  = _mm512_shuffle_i32x4( _wwu_transpose_t0, _wwu_transpose_t8, 0xdd ); \
+    /**/  _wwu_transpose_r9  = _mm512_shuffle_i32x4( _wwu_transpose_t1, _wwu_transpose_t9, 0xdd ); \
+    /**/  _wwu_transpose_ra  = _mm512_shuffle_i32x4( _wwu_transpose_t2, _wwu_transpose_ta, 0xdd ); \
+    /**/  _wwu_transpose_rb  = _mm512_shuffle_i32x4( _wwu_transpose_t3, _wwu_transpose_tb, 0xdd ); \
+    /**/  _wwu_transpose_rc  = _mm512_shuffle_i32x4( _wwu_transpose_t4, _wwu_transpose_tc, 0xdd ); \
+    /**/  _wwu_transpose_rd  = _mm512_shuffle_i32x4( _wwu_transpose_t5, _wwu_transpose_td, 0xdd ); \
+    /**/  _wwu_transpose_re  = _mm512_shuffle_i32x4( _wwu_transpose_t6, _wwu_transpose_te, 0xdd ); \
+    /**/  _wwu_transpose_rf  = _mm512_shuffle_i32x4( _wwu_transpose_t7, _wwu_transpose_tf, 0xdd ); \
+                                                                                                   \
+    /* Inner 4x4 transpose of 1x1 blocks */                                                        \
+    /**/  _wwu_transpose_t0  = _mm512_unpacklo_epi32( _wwu_transpose_r0, _wwu_transpose_r2 );      \
+    /**/  _wwu_transpose_t1  = _mm512_unpacklo_epi32( _wwu_transpose_r1, _wwu_transpose_r3 );      \
+    /**/  _wwu_transpose_t2  = _mm512_unpackhi_epi32( _wwu_transpose_r0, _wwu_transpose_r2 );      \
+    /**/  _wwu_transpose_t3  = _mm512_unpackhi_epi32( _wwu_transpose_r1, _wwu_transpose_r3 );      \
+    /**/  _wwu_transpose_t4  = _mm512_unpacklo_epi32( _wwu_transpose_r4, _wwu_transpose_r6 );      \
+    /**/  _wwu_transpose_t5  = _mm512_unpacklo_epi32( _wwu_transpose_r5, _wwu_transpose_r7 );      \
+    /**/  _wwu_transpose_t6  = _mm512_unpackhi_epi32( _wwu_transpose_r4, _wwu_transpose_r6 );      \
+    /**/  _wwu_transpose_t7  = _mm512_unpackhi_epi32( _wwu_transpose_r5, _wwu_transpose_r7 );      \
+    /**/  _wwu_transpose_t8  = _mm512_unpacklo_epi32( _wwu_transpose_r8, _wwu_transpose_ra );      \
+    /**/  _wwu_transpose_t9  = _mm512_unpacklo_epi32( _wwu_transpose_r9, _wwu_transpose_rb );      \
+    /**/  _wwu_transpose_ta  = _mm512_unpackhi_epi32( _wwu_transpose_r8, _wwu_transpose_ra );      \
+    /**/  _wwu_transpose_tb  = _mm512_unpackhi_epi32( _wwu_transpose_r9, _wwu_transpose_rb );      \
+    /**/  _wwu_transpose_tc  = _mm512_unpacklo_epi32( _wwu_transpose_rc, _wwu_transpose_re );      \
+    /**/  _wwu_transpose_td  = _mm512_unpacklo_epi32( _wwu_transpose_rd, _wwu_transpose_rf );      \
+    /**/  _wwu_transpose_te  = _mm512_unpackhi_epi32( _wwu_transpose_rc, _wwu_transpose_re );      \
+    /**/  _wwu_transpose_tf  = _mm512_unpackhi_epi32( _wwu_transpose_rd, _wwu_transpose_rf );      \
+                                                                                                   \
+    /**/  (c0)               = _mm512_unpacklo_epi32( _wwu_transpose_t0, _wwu_transpose_t1 );      \
+    /**/  (c1)               = _mm512_unpackhi_epi32( _wwu_transpose_t0, _wwu_transpose_t1 );      \
+    /**/  (c2)               = _mm512_unpacklo_epi32( _wwu_transpose_t2, _wwu_transpose_t3 );      \
+    /**/  (c3)               = _mm512_unpackhi_epi32( _wwu_transpose_t2, _wwu_transpose_t3 );      \
+    /**/  (c4)               = _mm512_unpacklo_epi32( _wwu_transpose_t4, _wwu_transpose_t5 );      \
+    /**/  (c5)               = _mm512_unpackhi_epi32( _wwu_transpose_t4, _wwu_transpose_t5 );      \
+    /**/  (c6)               = _mm512_unpacklo_epi32( _wwu_transpose_t6, _wwu_transpose_t7 );      \
+    /**/  (c7)               = _mm512_unpackhi_epi32( _wwu_transpose_t6, _wwu_transpose_t7 );      \
+    /**/  (c8)               = _mm512_unpacklo_epi32( _wwu_transpose_t8, _wwu_transpose_t9 );      \
+    /**/  (c9)               = _mm512_unpackhi_epi32( _wwu_transpose_t8, _wwu_transpose_t9 );      \
+    /**/  (ca)               = _mm512_unpacklo_epi32( _wwu_transpose_ta, _wwu_transpose_tb );      \
+    /**/  (cb)               = _mm512_unpackhi_epi32( _wwu_transpose_ta, _wwu_transpose_tb );      \
+    /**/  (cc)               = _mm512_unpacklo_epi32( _wwu_transpose_tc, _wwu_transpose_td );      \
+    /**/  (cd)               = _mm512_unpackhi_epi32( _wwu_transpose_tc, _wwu_transpose_td );      \
+    /**/  (ce)               = _mm512_unpacklo_epi32( _wwu_transpose_te, _wwu_transpose_tf );      \
+    /**/  (cf)               = _mm512_unpackhi_epi32( _wwu_transpose_te, _wwu_transpose_tf );      \
+  } while(0)
+
+/* wwu_transpose_2x8x8 transposes the 2 8x8 matrices whos rows are in
+   held in the lower and upper halves of wwu_t's r0,r1...r7 and
+   stores the result in c0,c1...c7.  In-place operation fine. */
+
+#define wwu_transpose_2x8x8( r0,r1,r2,r3,r4,r5,r6,r7,                                                \
+                             c0,c1,c2,c3,c4,c5,c6,c7 ) {                                             \
+    wwu_t _wwu_transpose_r0 = (r0); wwu_t _wwu_transpose_r1 = (r1);                                  \
+    wwu_t _wwu_transpose_r2 = (r2); wwu_t _wwu_transpose_r3 = (r3);                                  \
+    wwu_t _wwu_transpose_r4 = (r4); wwu_t _wwu_transpose_r5 = (r5);                                  \
+    wwu_t _wwu_transpose_r6 = (r6); wwu_t _wwu_transpose_r7 = (r7);                                  \
+                                                                                                     \
+    /* Outer 2x2 transpose of 4x4 blocks */                                                          \
+    /* No _mm256_permute2f128_si128 equiv? sigh ... probably a better method possible here */        \
+    wwu_t _wwu_transpose_p   = wwu( 0U, 1U, 2U, 3U,16U,17U,18U,19U, 8U, 9U,10U,11U,24U,25U,26U,27U); \
+    wwu_t _wwu_transpose_q   = wwu( 4U, 5U, 6U, 7U,20U,21U,22U,23U,12U,13U,14U,15U,28U,29U,30U,31U); \
+    wwu_t _wwu_transpose_t0  = wwu_select( _wwu_transpose_p, _wwu_transpose_r0, _wwu_transpose_r4 ); \
+    wwu_t _wwu_transpose_t1  = wwu_select( _wwu_transpose_p, _wwu_transpose_r1, _wwu_transpose_r5 ); \
+    wwu_t _wwu_transpose_t2  = wwu_select( _wwu_transpose_p, _wwu_transpose_r2, _wwu_transpose_r6 ); \
+    wwu_t _wwu_transpose_t3  = wwu_select( _wwu_transpose_p, _wwu_transpose_r3, _wwu_transpose_r7 ); \
+    wwu_t _wwu_transpose_t4  = wwu_select( _wwu_transpose_q, _wwu_transpose_r0, _wwu_transpose_r4 ); \
+    wwu_t _wwu_transpose_t5  = wwu_select( _wwu_transpose_q, _wwu_transpose_r1, _wwu_transpose_r5 ); \
+    wwu_t _wwu_transpose_t6  = wwu_select( _wwu_transpose_q, _wwu_transpose_r2, _wwu_transpose_r6 ); \
+    wwu_t _wwu_transpose_t7  = wwu_select( _wwu_transpose_q, _wwu_transpose_r3, _wwu_transpose_r7 ); \
+                                                                                                     \
+    /* Inner 4x4 transpose of 1x1 blocks */                                                          \
+    /**/  _wwu_transpose_r0  = _mm512_unpacklo_epi32( _wwu_transpose_t0, _wwu_transpose_t2 );        \
+    /**/  _wwu_transpose_r1  = _mm512_unpacklo_epi32( _wwu_transpose_t1, _wwu_transpose_t3 );        \
+    /**/  _wwu_transpose_r2  = _mm512_unpackhi_epi32( _wwu_transpose_t0, _wwu_transpose_t2 );        \
+    /**/  _wwu_transpose_r3  = _mm512_unpackhi_epi32( _wwu_transpose_t1, _wwu_transpose_t3 );        \
+    /**/  _wwu_transpose_r4  = _mm512_unpacklo_epi32( _wwu_transpose_t4, _wwu_transpose_t6 );        \
+    /**/  _wwu_transpose_r5  = _mm512_unpacklo_epi32( _wwu_transpose_t5, _wwu_transpose_t7 );        \
+    /**/  _wwu_transpose_r6  = _mm512_unpackhi_epi32( _wwu_transpose_t4, _wwu_transpose_t6 );        \
+    /**/  _wwu_transpose_r7  = _mm512_unpackhi_epi32( _wwu_transpose_t5, _wwu_transpose_t7 );        \
+                                                                                                     \
+    /**/  (c0)               = _mm512_unpacklo_epi32( _wwu_transpose_r0, _wwu_transpose_r1 );        \
+    /**/  (c1)               = _mm512_unpackhi_epi32( _wwu_transpose_r0, _wwu_transpose_r1 );        \
+    /**/  (c2)               = _mm512_unpacklo_epi32( _wwu_transpose_r2, _wwu_transpose_r3 );        \
+    /**/  (c3)               = _mm512_unpackhi_epi32( _wwu_transpose_r2, _wwu_transpose_r3 );        \
+    /**/  (c4)               = _mm512_unpacklo_epi32( _wwu_transpose_r4, _wwu_transpose_r5 );        \
+    /**/  (c5)               = _mm512_unpackhi_epi32( _wwu_transpose_r4, _wwu_transpose_r5 );        \
+    /**/  (c6)               = _mm512_unpacklo_epi32( _wwu_transpose_r6, _wwu_transpose_r7 );        \
+    /**/  (c7)               = _mm512_unpackhi_epi32( _wwu_transpose_r6, _wwu_transpose_r7 );        \
+  } while(0)

--- a/src/util/simd/fd_avx512_wwu.h
+++ b/src/util/simd/fd_avx512_wwu.h
@@ -282,7 +282,7 @@ static inline wwu_t wwu_ror_vector( wwu_t a, wwu_t b ) {
     /**/  (cf)               = _mm512_unpackhi_epi32( _wwu_transpose_te, _wwu_transpose_tf );      \
   } while(0)
 
-/* wwu_transpose_2x8x8 transposes the 2 8x8 matrices whos rows are in
+/* wwu_transpose_2x8x8 transposes the 2 8x8 matrices whose rows are
    held in the lower and upper halves of wwu_t's r0,r1...r7 and
    stores the result in c0,c1...c7.  In-place operation fine. */
 

--- a/src/util/simd/fd_avx512_wwv.h
+++ b/src/util/simd/fd_avx512_wwv.h
@@ -129,8 +129,17 @@ static inline wwv_t wwv_ror_vector( wwv_t a, wwv_t b ) {
 
 /* Conversions */
 
-#define wwv_to_wwl(x)     (x) /* wwl( (long)x0, (long)x1, ... (long)x7 ) */
-#define wwv_to_wwl_raw(x) (x) /* reinterp raw bits as a wwl */
+/* wwv_to_wwi(x) returns [  (int)x0,0,  (int)x1,0, ...  (int)x7,0 ]
+   wwv_to_wwu(x) returns [ (uint)x0,0, (uint)x1,0, ... (uint)x7,0 ]
+   wwv_to_wwv(x) returns [ (ulong)x0,  (ulong)x1,  ... (ulong)x7  ] */
+
+#define wwv_to_wwi(x) wwv_and( (x), wwv_bcast( (ulong)UINT_MAX ) )
+#define wwv_to_wwu(x) wwv_and( (x), wwv_bcast( (ulong)UINT_MAX ) )
+#define wwv_to_wwv(x) (x)
+
+#define wwv_to_wwi_raw(x) (x)
+#define wwv_to_wwu_raw(x) (x)
+#define wwv_to_wwv_raw(x) (x)
 
 /* Misc operations */
 
@@ -160,33 +169,58 @@ static inline wwv_t wwv_ror_vector( wwv_t a, wwv_t b ) {
 
 #define wwv_slide(x,y,imm) _mm512_alignr_epi64( (y), (x), (imm) )
 
+/* wwv_unpack unpacks the wwv x into its ulong components x0,x1,...x7. */
+
+#define wwv_unpack( x, x0,x1,x2,x3,x4,x5,x6,x7 ) do {                       \
+    __m512i _wwv_unpack_x  = (x);                                           \
+    __m256i _wwv_unpack_xl = _mm512_extracti64x4_epi64( _wwv_unpack_x, 0 ); \
+    __m256i _wwv_unpack_xh = _mm512_extracti64x4_epi64( _wwv_unpack_x, 1 ); \
+    (x0) = (ulong)_mm256_extract_epi64( _wwv_unpack_xl, 0 );                \
+    (x1) = (ulong)_mm256_extract_epi64( _wwv_unpack_xl, 1 );                \
+    (x2) = (ulong)_mm256_extract_epi64( _wwv_unpack_xl, 2 );                \
+    (x3) = (ulong)_mm256_extract_epi64( _wwv_unpack_xl, 3 );                \
+    (x4) = (ulong)_mm256_extract_epi64( _wwv_unpack_xh, 0 );                \
+    (x5) = (ulong)_mm256_extract_epi64( _wwv_unpack_xh, 1 );                \
+    (x6) = (ulong)_mm256_extract_epi64( _wwv_unpack_xh, 2 );                \
+    (x7) = (ulong)_mm256_extract_epi64( _wwv_unpack_xh, 3 );                \
+  } while(0)
+
 /* wwv_transpose_8x8 sets wwv_t's c0,c1,...c7 to the columns of an 8x8
    ulong matrix given the rows of the matrix in wwv_t's r0,r1,...r7.
    In-place operation fine. */
 
-#define wwv_transpose_8x8( r0,r1,r2,r3,r4,r5,r6,r7, c0,c1,c2,c3,c4,c5,c6,c7 ) do {            \
-    wwv_t _r0 = (r0);                            wwv_t _r1 = (r1);                            \
-    wwv_t _r2 = (r2);                            wwv_t _r3 = (r3);                            \
-    wwv_t _r4 = (r4);                            wwv_t _r5 = (r5);                            \
-    wwv_t _r6 = (r6);                            wwv_t _r7 = (r7);                            \
-                                                                                              \
-    /* Transpose 4x4 blocks */                                                                \
-    wwv_t _t0 = wwv_pack_halves( _r0,0, _r4,0 ); wwv_t _t4 = wwv_pack_halves( _r0,1, _r4,1 ); \
-    wwv_t _t1 = wwv_pack_halves( _r1,0, _r5,0 ); wwv_t _t5 = wwv_pack_halves( _r1,1, _r5,1 ); \
-    wwv_t _t2 = wwv_pack_halves( _r2,0, _r6,0 ); wwv_t _t6 = wwv_pack_halves( _r2,1, _r6,1 ); \
-    wwv_t _t3 = wwv_pack_halves( _r3,0, _r7,0 ); wwv_t _t7 = wwv_pack_halves( _r3,1, _r7,1 ); \
-                                                                                              \
-    /* Transpose 2x2 blocks */                                                                \
-    wwv_t const _pa = wwv(0UL,1UL, 8UL, 9UL,4UL,5UL,12UL,13UL);                               \
-    wwv_t const _pb = wwv(2UL,3UL,10UL,11UL,6UL,7UL,14UL,15UL);                               \
-    _r0 = wwv_select( _pa, _t0, _t2 );           _r2 = wwv_select( _pb, _t0, _t2 );           \
-    _r1 = wwv_select( _pa, _t1, _t3 );           _r3 = wwv_select( _pb, _t1, _t3 );           \
-    _r4 = wwv_select( _pa, _t4, _t6 );           _r6 = wwv_select( _pb, _t4, _t6 );           \
-    _r5 = wwv_select( _pa, _t5, _t7 );           _r7 = wwv_select( _pb, _t5, _t7 );           \
-                                                                                              \
-    /* Transpose 1x1 blocks */                                                                \
-    (c0) = _mm512_unpacklo_epi64( _r0, _r1 );    (c1) = _mm512_unpackhi_epi64( _r0, _r1 );    \
-    (c2) = _mm512_unpacklo_epi64( _r2, _r3 );    (c3) = _mm512_unpackhi_epi64( _r2, _r3 );    \
-    (c4) = _mm512_unpacklo_epi64( _r4, _r5 );    (c5) = _mm512_unpackhi_epi64( _r4, _r5 );    \
-    (c6) = _mm512_unpacklo_epi64( _r6, _r7 );    (c7) = _mm512_unpackhi_epi64( _r6, _r7 );    \
+#define wwv_transpose_8x8( r0,r1,r2,r3,r4,r5,r6,r7, c0,c1,c2,c3,c4,c5,c6,c7 ) do {                \
+    wwv_t _wwv_transpose_r0 = (r0); wwv_t _wwv_transpose_r1 = (r1);                               \
+    wwv_t _wwv_transpose_r2 = (r2); wwv_t _wwv_transpose_r3 = (r3);                               \
+    wwv_t _wwv_transpose_r4 = (r4); wwv_t _wwv_transpose_r5 = (r5);                               \
+    wwv_t _wwv_transpose_r6 = (r6); wwv_t _wwv_transpose_r7 = (r7);                               \
+                                                                                                  \
+    /* Outer 4x4 transpose of 2x2 blocks */                                                       \
+    wwv_t _wwv_transpose_t0 = _mm512_shuffle_i64x2( _wwv_transpose_r0, _wwv_transpose_r2, 0x88 ); \
+    wwv_t _wwv_transpose_t1 = _mm512_shuffle_i64x2( _wwv_transpose_r1, _wwv_transpose_r3, 0x88 ); \
+    wwv_t _wwv_transpose_t2 = _mm512_shuffle_i64x2( _wwv_transpose_r0, _wwv_transpose_r2, 0xdd ); \
+    wwv_t _wwv_transpose_t3 = _mm512_shuffle_i64x2( _wwv_transpose_r1, _wwv_transpose_r3, 0xdd ); \
+    wwv_t _wwv_transpose_t4 = _mm512_shuffle_i64x2( _wwv_transpose_r4, _wwv_transpose_r6, 0x88 ); \
+    wwv_t _wwv_transpose_t5 = _mm512_shuffle_i64x2( _wwv_transpose_r5, _wwv_transpose_r7, 0x88 ); \
+    wwv_t _wwv_transpose_t6 = _mm512_shuffle_i64x2( _wwv_transpose_r4, _wwv_transpose_r6, 0xdd ); \
+    wwv_t _wwv_transpose_t7 = _mm512_shuffle_i64x2( _wwv_transpose_r5, _wwv_transpose_r7, 0xdd ); \
+                                                                                                  \
+    /**/  _wwv_transpose_r0 = _mm512_shuffle_i64x2( _wwv_transpose_t0, _wwv_transpose_t4, 0x88 ); \
+    /**/  _wwv_transpose_r1 = _mm512_shuffle_i64x2( _wwv_transpose_t1, _wwv_transpose_t5, 0x88 ); \
+    /**/  _wwv_transpose_r2 = _mm512_shuffle_i64x2( _wwv_transpose_t2, _wwv_transpose_t6, 0x88 ); \
+    /**/  _wwv_transpose_r3 = _mm512_shuffle_i64x2( _wwv_transpose_t3, _wwv_transpose_t7, 0x88 ); \
+    /**/  _wwv_transpose_r4 = _mm512_shuffle_i64x2( _wwv_transpose_t0, _wwv_transpose_t4, 0xdd ); \
+    /**/  _wwv_transpose_r5 = _mm512_shuffle_i64x2( _wwv_transpose_t1, _wwv_transpose_t5, 0xdd ); \
+    /**/  _wwv_transpose_r6 = _mm512_shuffle_i64x2( _wwv_transpose_t2, _wwv_transpose_t6, 0xdd ); \
+    /**/  _wwv_transpose_r7 = _mm512_shuffle_i64x2( _wwv_transpose_t3, _wwv_transpose_t7, 0xdd ); \
+                                                                                                  \
+    /* Inner 2x2 transpose of 1x1 blocks */                                                       \
+    /**/  (c0)              = _mm512_unpacklo_epi64( _wwv_transpose_r0, _wwv_transpose_r1 );      \
+    /**/  (c1)              = _mm512_unpackhi_epi64( _wwv_transpose_r0, _wwv_transpose_r1 );      \
+    /**/  (c2)              = _mm512_unpacklo_epi64( _wwv_transpose_r2, _wwv_transpose_r3 );      \
+    /**/  (c3)              = _mm512_unpackhi_epi64( _wwv_transpose_r2, _wwv_transpose_r3 );      \
+    /**/  (c4)              = _mm512_unpacklo_epi64( _wwv_transpose_r4, _wwv_transpose_r5 );      \
+    /**/  (c5)              = _mm512_unpackhi_epi64( _wwv_transpose_r4, _wwv_transpose_r5 );      \
+    /**/  (c6)              = _mm512_unpacklo_epi64( _wwv_transpose_r6, _wwv_transpose_r7 );      \
+    /**/  (c7)              = _mm512_unpackhi_epi64( _wwv_transpose_r6, _wwv_transpose_r7 );      \
   } while(0)

--- a/src/util/simd/fd_avx512_wwv.h
+++ b/src/util/simd/fd_avx512_wwv.h
@@ -135,11 +135,11 @@ static inline wwv_t wwv_ror_vector( wwv_t a, wwv_t b ) {
 
 #define wwv_to_wwi(x) wwv_and( (x), wwv_bcast( (ulong)UINT_MAX ) )
 #define wwv_to_wwu(x) wwv_and( (x), wwv_bcast( (ulong)UINT_MAX ) )
-#define wwv_to_wwv(x) (x)
+#define wwv_to_wwl(x) (x)
 
 #define wwv_to_wwi_raw(x) (x)
 #define wwv_to_wwu_raw(x) (x)
-#define wwv_to_wwv_raw(x) (x)
+#define wwv_to_wwl_raw(x) (x)
 
 /* Misc operations */
 

--- a/src/util/simd/test_avx512.h
+++ b/src/util/simd/test_avx512.h
@@ -1,0 +1,89 @@
+#ifndef HEADER_fd_src_util_simd_test_avx512_h
+#define HEADER_fd_src_util_simd_test_avx512_h
+
+/* This header provides common functionality for the various AVX-512
+   unit tests */
+
+#include "../fd_util.h"
+#include "fd_avx512.h"
+
+FD_STATIC_ASSERT( WW_WIDTH       ==16, unit_test );
+FD_STATIC_ASSERT( WW_FOOTPRINT   ==64, unit_test );
+FD_STATIC_ASSERT( WW_ALIGN       ==64, unit_test );
+FD_STATIC_ASSERT( WW_LG_WIDTH    == 4, unit_test );
+FD_STATIC_ASSERT( WW_LG_FOOTPRINT== 6, unit_test );
+FD_STATIC_ASSERT( WW_LG_ALIGN    == 6, unit_test );
+
+#define WWI_TEST( x, x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf ) do {                                                 \
+    int _t[16] WW_ATTR;                                                                                                     \
+    int _u[16] WW_ATTR;                                                                                                     \
+    wwi_st( _t, (x) );                                                                                                      \
+    _u[ 0] = (x0); _u[ 1] = (x1); _u[ 2] = (x2); _u[ 3] = (x3); _u[ 4] = (x4); _u[ 5] = (x5); _u[ 6] = (x6); _u[ 7] = (x7); \
+    _u[ 8] = (x8); _u[ 9] = (x9); _u[10] = (xa); _u[11] = (xb); _u[12] = (xc); _u[13] = (xd); _u[14] = (xe); _u[15] = (xf); \
+    for( int _lane=0; _lane<16; _lane++ )                                                                                   \
+      if( FD_UNLIKELY( _t[_lane]!=_u[_lane] ) )                                                                             \
+        FD_LOG_ERR(( "FAIL: %s @ lane %i\n\t"                                                                               \
+                     "  got 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x "                                       \
+                           "0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x\n\t"                                    \
+                     "  exp 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x "                                       \
+                           "0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x",                                       \
+                     #x, _lane,                                                                                             \
+                     _t[ 0], _t[ 1], _t[ 2], _t[ 3], _t[ 4], _t[ 5], _t[ 6], _t[ 7],                                        \
+                     _t[ 8], _t[ 9], _t[10], _t[11], _t[12], _t[13], _t[14], _t[15],                                        \
+                     _u[ 0], _u[ 1], _u[ 2], _u[ 3], _u[ 4], _u[ 5], _u[ 6], _u[ 7],                                        \
+                     _u[ 8], _u[ 9], _u[10], _u[11], _u[12], _u[13], _u[14], _u[15] ));                                     \
+  } while(0)
+
+#define WWU_TEST( x, x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf ) do {                                                 \
+    uint _t[16] WW_ATTR;                                                                                                    \
+    uint _u[16] WW_ATTR;                                                                                                    \
+    wwu_st( _t, (x) );                                                                                                      \
+    _u[ 0] = (x0); _u[ 1] = (x1); _u[ 2] = (x2); _u[ 3] = (x3); _u[ 4] = (x4); _u[ 5] = (x5); _u[ 6] = (x6); _u[ 7] = (x7); \
+    _u[ 8] = (x8); _u[ 9] = (x9); _u[10] = (xa); _u[11] = (xb); _u[12] = (xc); _u[13] = (xd); _u[14] = (xe); _u[15] = (xf); \
+    for( int _lane=0; _lane<16; _lane++ )                                                                                   \
+      if( FD_UNLIKELY( _t[_lane]!=_u[_lane] ) )                                                                             \
+        FD_LOG_ERR(( "FAIL: %s @ lane %i\n\t"                                                                               \
+                     "  got 0x%08xU 0x%08xU 0x%08xU 0x%08xU 0x%08xU 0x%08xU 0x%08xU 0x%08xU "                               \
+                           "0x%08xU 0x%08xU 0x%08xU 0x%08xU 0x%08xU 0x%08xU 0x%08xU 0x%08xU\n\t"                            \
+                     "  exp 0x%08xU 0x%08xU 0x%08xU 0x%08xU 0x%08xU 0x%08xU 0x%08xU 0x%08xU "                               \
+                           "0x%08xU 0x%08xU 0x%08xU 0x%08xU 0x%08xU 0x%08xU 0x%08xU 0x%08xU",                               \
+                     #x, _lane,                                                                                             \
+                     _t[ 0], _t[ 1], _t[ 2], _t[ 3], _t[ 4], _t[ 5], _t[ 6], _t[ 7],                                        \
+                     _t[ 8], _t[ 9], _t[10], _t[11], _t[12], _t[13], _t[14], _t[15],                                        \
+                     _u[ 0], _u[ 1], _u[ 2], _u[ 3], _u[ 4], _u[ 5], _u[ 6], _u[ 7],                                        \
+                     _u[ 8], _u[ 9], _u[10], _u[11], _u[12], _u[13], _u[14], _u[15] ));                                     \
+  } while(0)
+
+#define WWL_TEST( x, x0,x1,x2,x3,x4,x5,x6,x7 ) do {                                                                 \
+    long _t[8] WW_ATTR;                                                                                             \
+    long _u[8] WW_ATTR;                                                                                             \
+    wwl_st( _t, (x) );                                                                                              \
+    _u[0] = (x0); _u[1] = (x1); _u[2] = (x2); _u[3] = (x3); _u[4] = (x4); _u[5] = (x5); _u[6] = (x6); _u[7] = (x7); \
+    for( int _lane=0; _lane<8; _lane++ )                                                                            \
+      if( FD_UNLIKELY( _t[_lane]!=_u[_lane] ) )                                                                     \
+        FD_LOG_ERR(( "FAIL: %s @ lane %i\n\t"                                                                       \
+                     "  got 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL\n\t"    \
+                     "  exp 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL",       \
+                     #x, _lane,                                                                                     \
+                     (ulong)_t[0], (ulong)_t[1], (ulong)_t[2], (ulong)_t[3],                                        \
+                     (ulong)_t[4], (ulong)_t[5], (ulong)_t[6], (ulong)_t[7],                                        \
+                     (ulong)_u[0], (ulong)_u[1], (ulong)_u[2], (ulong)_u[3],                                        \
+                     (ulong)_u[4], (ulong)_u[5], (ulong)_u[6], (ulong)_u[7] ));                                     \
+  } while(0)
+
+#define WWV_TEST( x, x0,x1,x2,x3,x4,x5,x6,x7 ) do {                                                                      \
+    ulong _t[8] WW_ATTR;                                                                                                 \
+    ulong _u[8] WW_ATTR;                                                                                                 \
+    wwv_st( _t, (x) );                                                                                                   \
+    _u[0] = (x0); _u[1] = (x1); _u[2] = (x2); _u[3] = (x3); _u[4] = (x4); _u[5] = (x5); _u[6] = (x6); _u[7] = (x7);      \
+    for( int _lane=0; _lane<8; _lane++ )                                                                                 \
+      if( FD_UNLIKELY( _t[_lane]!=_u[_lane] ) )                                                                          \
+        FD_LOG_ERR(( "FAIL: %s @ lane %i\n\t"                                                                            \
+                     "  got 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL\n\t" \
+                     "  exp 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL",    \
+                     #x, _lane,                                                                                          \
+                     _t[0], _t[1], _t[2], _t[3], _t[4], _t[5], _t[6], _t[7],                                             \
+                     _u[0], _u[1], _u[2], _u[3], _u[4], _u[5], _u[6], _u[7] ));                                          \
+  } while(0)
+
+#endif /* HEADER_fd_src_util_simd_test_avx512_h */

--- a/src/util/simd/test_avx512_16x32.c
+++ b/src/util/simd/test_avx512_16x32.c
@@ -1,0 +1,545 @@
+#include "test_avx512.h"
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
+
+  FD_LOG_NOTICE(( "Testing wwi_t" ));
+
+  for( ulong rem=1000000UL; rem; rem-- ) {
+
+    /* Test construct */
+
+    int x0 = (int)fd_rng_uint( rng ); int x1 = (int)fd_rng_uint( rng );
+    int x2 = (int)fd_rng_uint( rng ); int x3 = (int)fd_rng_uint( rng );
+    int x4 = (int)fd_rng_uint( rng ); int x5 = (int)fd_rng_uint( rng );
+    int x6 = (int)fd_rng_uint( rng ); int x7 = (int)fd_rng_uint( rng );
+    int x8 = (int)fd_rng_uint( rng ); int x9 = (int)fd_rng_uint( rng );
+    int xa = (int)fd_rng_uint( rng ); int xb = (int)fd_rng_uint( rng );
+    int xc = (int)fd_rng_uint( rng ); int xd = (int)fd_rng_uint( rng );
+    int xe = (int)fd_rng_uint( rng ); int xf = (int)fd_rng_uint( rng );
+    wwi_t x = wwi( x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf );
+    WWI_TEST( x, x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf );
+
+    int y0 = (int)fd_rng_uint( rng ); int y1 = (int)fd_rng_uint( rng );
+    int y2 = (int)fd_rng_uint( rng ); int y3 = (int)fd_rng_uint( rng );
+    int y4 = (int)fd_rng_uint( rng ); int y5 = (int)fd_rng_uint( rng );
+    int y6 = (int)fd_rng_uint( rng ); int y7 = (int)fd_rng_uint( rng );
+    int y8 = (int)fd_rng_uint( rng ); int y9 = (int)fd_rng_uint( rng );
+    int ya = (int)fd_rng_uint( rng ); int yb = (int)fd_rng_uint( rng );
+    int yc = (int)fd_rng_uint( rng ); int yd = (int)fd_rng_uint( rng );
+    int ye = (int)fd_rng_uint( rng ); int yf = (int)fd_rng_uint( rng );
+    wwi_t y = wwi( y0, y1, y2, y3, y4, y5, y6, y7, y8, y9, ya, yb, yc, yd, ye, yf );
+    WWI_TEST( y, y0, y1, y2, y3, y4, y5, y6, y7, y8, y9, ya, yb, yc, yd, ye, yf );
+
+    int z0 = (int)fd_rng_uint( rng ); int z1 = (int)fd_rng_uint( rng );
+    int z2 = (int)fd_rng_uint( rng ); int z3 = (int)fd_rng_uint( rng );
+    int z4 = (int)fd_rng_uint( rng ); int z5 = (int)fd_rng_uint( rng );
+    int z6 = (int)fd_rng_uint( rng ); int z7 = (int)fd_rng_uint( rng );
+    int z8 = (int)fd_rng_uint( rng ); int z9 = (int)fd_rng_uint( rng );
+    int za = (int)fd_rng_uint( rng ); int zb = (int)fd_rng_uint( rng );
+    int zc = (int)fd_rng_uint( rng ); int zd = (int)fd_rng_uint( rng );
+    int ze = (int)fd_rng_uint( rng ); int zf = (int)fd_rng_uint( rng );
+    wwi_t z = wwi( z0, z1, z2, z3, z4, z5, z6, z7, z8, z9, za, zb, zc, zd, ze, zf );
+    WWI_TEST( z, z0, z1, z2, z3, z4, z5, z6, z7, z8, z9, za, zb, zc, zd, ze, zf );
+
+    int u0; int u1; int u2; int u3; int u4; int u5; int u6; int u7;
+    int u8; int u9; int ua; int ub; int uc; int ud; int ue; int uf;
+    wwi_t u;
+
+    int _b[32] WW_ATTR;
+
+    /* Test permute/select */
+
+    wwi_st( _b, y ); wwi_st( _b+16, z );
+
+    u0 = x0 & 15; u1 = x1 & 15; u2 = x2 & 15; u3 = x3 & 15; u4 = x4 & 15; u5 = x5 & 15; u6 = x6 & 15; u7 = x7 & 15;
+    u8 = x8 & 15; u9 = x9 & 15; ua = xa & 15; ub = xb & 15; uc = xc & 15; ud = xd & 15; ue = xe & 15; uf = xf & 15;
+    u = wwi( u0, u1, u2, u3, u4, u5, u6, u7, u8, u9, ua, ub, uc, ud, ue, uf );
+    WWI_TEST( wwi_permute( u, y ), _b[ u0 ], _b[ u1 ], _b[ u2 ], _b[ u3 ], _b[ u4 ], _b[ u5 ], _b[ u6 ], _b[ u7 ],
+                                   _b[ u8 ], _b[ u9 ], _b[ ua ], _b[ ub ], _b[ uc ], _b[ ud ], _b[ ue ], _b[ uf ] );
+
+    u0 = x0 & 31; u1 = x1 & 31; u2 = x2 & 31; u3 = x3 & 31; u4 = x4 & 31; u5 = x5 & 31; u6 = x6 & 31; u7 = x7 & 31;
+    u8 = x8 & 31; u9 = x9 & 31; ua = xa & 31; ub = xb & 31; uc = xc & 31; ud = xd & 31; ue = xe & 31; uf = xf & 31;
+    u = wwi( u0, u1, u2, u3, u4, u5, u6, u7, u8, u9, ua, ub, uc, ud, ue, uf );
+    WWI_TEST( wwi_select( u, y, z ), _b[ u0 ], _b[ u1 ], _b[ u2 ], _b[ u3 ], _b[ u4 ], _b[ u5 ], _b[ u6 ], _b[ u7 ],
+                                     _b[ u8 ], _b[ u9 ], _b[ ua ], _b[ ub ], _b[ uc ], _b[ ud ], _b[ ue ], _b[ uf ] );
+
+    /* Test bcast/zero/one */
+
+    WWI_TEST( wwi_bcast(x0), x0, x0, x0, x0, x0, x0, x0, x0, x0, x0, x0, x0, x0, x0, x0, x0 );
+    WWI_TEST( wwi_zero(),    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  );
+    WWI_TEST( wwi_one(),     1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1  );
+
+    /* Test ld/st/ldu/stu */
+
+    wwi_st( _b, x );
+    WWI_TEST( wwi_ld( _b ), x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf );
+
+    uchar _m[128] WW_ATTR;
+    u0 = x0 & 63;
+    wwi_stu( _m+u0, y );
+    WWI_TEST( wwi_ldu( _m+u0 ), y0, y1, y2, y3, y4, y5, y6, y7, y8, y9, ya, yb, yc, yd, ye, yf );
+
+    /* Test arithmetic ops */
+
+    WWI_TEST( wwi_neg(x), -x0, -x1, -x2, -x3, -x4, -x5, -x6, -x7, -x8, -x9, -xa, -xb, -xc, -xd, -xe, -xf );
+    WWI_TEST( wwi_abs(x),  x0,  x1,  x2,  x3,  x4,  x5,  x6,  x7,  x8,  x9,  xa,  xb,  xc,  xd,  xe,  xf );
+
+    WWI_TEST( wwi_min(x,y), fd_int_min(x0,y0), fd_int_min(x1,y1), fd_int_min(x2,y2), fd_int_min(x3,y3),
+                            fd_int_min(x4,y4), fd_int_min(x5,y5), fd_int_min(x6,y6), fd_int_min(x7,y7),
+                            fd_int_min(x8,y8), fd_int_min(x9,y9), fd_int_min(xa,ya), fd_int_min(xb,yb),
+                            fd_int_min(xc,yc), fd_int_min(xd,yd), fd_int_min(xe,ye), fd_int_min(xf,yf) );
+    WWI_TEST( wwi_max(x,y), fd_int_max(x0,y0), fd_int_max(x1,y1), fd_int_max(x2,y2), fd_int_max(x3,y3),
+                            fd_int_max(x4,y4), fd_int_max(x5,y5), fd_int_max(x6,y6), fd_int_max(x7,y7),
+                            fd_int_max(x8,y8), fd_int_max(x9,y9), fd_int_max(xa,ya), fd_int_max(xb,yb),
+                            fd_int_max(xc,yc), fd_int_max(xd,yd), fd_int_max(xe,ye), fd_int_max(xf,yf) );
+    WWI_TEST( wwi_add(x,y), x0+y0, x1+y1, x2+y2, x3+y3, x4+y4, x5+y5, x6+y6, x7+y7,
+                            x8+y8, x9+y9, xa+ya, xb+yb, xc+yc, xd+yd, xe+ye, xf+yf );
+    WWI_TEST( wwi_sub(x,y), x0-y0, x1-y1, x2-y2, x3-y3, x4-y4, x5-y5, x6-y6, x7-y7,
+                            x8-y8, x9-y9, xa-ya, xb-yb, xc-yc, xd-yd, xe-ye, xf-yf );
+    WWI_TEST( wwi_mul(x,y), x0*y0, x1*y1, x2*y2, x3*y3, x4*y4, x5*y5, x6*y6, x7*y7,
+                            x8*y8, x9*y9, xa*ya, xb*yb, xc*yc, xd*yd, xe*ye, xf*yf );
+
+    /* Test bit ops */
+
+    u0 = y0 & 31; u1 = y1 & 31; u2 = y2 & 31; u3 = y3 & 31; u4 = y4 & 31; u5 = y5 & 31; u6 = y6 & 31; u7 = y7 & 31;
+    u8 = y8 & 31; u9 = y9 & 31; ua = ya & 31; ub = yb & 31; uc = yc & 31; ud = yd & 31; ue = ye & 31; uf = yf & 31;
+    u = wwi( u0, u1, u2, u3, u4, u5, u6, u7, u8, u9, ua, ub, uc, ud, ue, uf );
+
+    WWI_TEST( wwi_not(x), ~x0, ~x1, ~x2, ~x3, ~x4, ~x5, ~x6, ~x7, ~x8, ~x9, ~xa, ~xb, ~xc, ~xd, ~xe, ~xf );
+
+    WWI_TEST( wwi_shl ( x, u0 ), x0<<u0, x1<<u0, x2<<u0, x3<<u0, x4<<u0, x5<<u0, x6<<u0, x7<<u0,
+                                 x8<<u0, x9<<u0, xa<<u0, xb<<u0, xc<<u0, xd<<u0, xe<<u0, xf<<u0 );
+    WWI_TEST( wwi_shr ( x, u0 ), x0>>u0, x1>>u0, x2>>u0, x3>>u0, x4>>u0, x5>>u0, x6>>u0, x7>>u0,
+                                 x8>>u0, x9>>u0, xa>>u0, xb>>u0, xc>>u0, xd>>u0, xe>>u0, xf>>u0 );
+    WWI_TEST( wwi_shru( x, u0 ),
+      (int)(((uint)x0)>>u0), (int)(((uint)x1)>>u0), (int)(((uint)x2)>>u0), (int)(((uint)x3)>>u0),
+      (int)(((uint)x4)>>u0), (int)(((uint)x5)>>u0), (int)(((uint)x6)>>u0), (int)(((uint)x7)>>u0),
+      (int)(((uint)x8)>>u0), (int)(((uint)x9)>>u0), (int)(((uint)xa)>>u0), (int)(((uint)xb)>>u0),
+      (int)(((uint)xc)>>u0), (int)(((uint)xd)>>u0), (int)(((uint)xe)>>u0), (int)(((uint)xf)>>u0) );
+
+    WWI_TEST( wwi_shl_vector ( x, u ), x0<<u0, x1<<u1, x2<<u2, x3<<u3, x4<<u4, x5<<u5, x6<<u6, x7<<u7,
+                                       x8<<u8, x9<<u9, xa<<ua, xb<<ub, xc<<uc, xd<<ud, xe<<ue, xf<<uf );
+    WWI_TEST( wwi_shr_vector ( x, u ), x0>>u0, x1>>u1, x2>>u2, x3>>u3, x4>>u4, x5>>u5, x6>>u6, x7>>u7,
+                                       x8>>u8, x9>>u9, xa>>ua, xb>>ub, xc>>uc, xd>>ud, xe>>ue, xf>>uf );
+    WWI_TEST( wwi_shru_vector( x, u ),
+      (int)(((uint)x0)>>u0), (int)(((uint)x1)>>u1), (int)(((uint)x2)>>u2), (int)(((uint)x3)>>u3),
+      (int)(((uint)x4)>>u4), (int)(((uint)x5)>>u5), (int)(((uint)x6)>>u6), (int)(((uint)x7)>>u7),
+      (int)(((uint)x8)>>u8), (int)(((uint)x9)>>u9), (int)(((uint)xa)>>ua), (int)(((uint)xb)>>ub),
+      (int)(((uint)xc)>>uc), (int)(((uint)xd)>>ud), (int)(((uint)xe)>>ue), (int)(((uint)xf)>>uf) );
+
+    WWI_TEST( wwi_and   (x,y),   x0  & y0,   x1  & y1,   x2  & y2,   x3  & y3,   x4  & y4,   x5  & y5,   x6  & y6,   x7  & y7,
+                                 x8  & y8,   x9  & y9,   xa  & ya,   xb  & yb,   xc  & yc,   xd  & yd,   xe  & ye,   xf  & yf );
+    WWI_TEST( wwi_andnot(x,y), (~x0) & y0, (~x1) & y1, (~x2) & y2, (~x3) & y3, (~x4) & y4, (~x5) & y5, (~x6) & y6, (~x7) & y7,
+                               (~x8) & y8, (~x9) & y9, (~xa) & ya, (~xb) & yb, (~xc) & yc, (~xd) & yd, (~xe) & ye, (~xf) & yf );
+    WWI_TEST( wwi_or    (x,y),   x0  | y0,   x1  | y1,   x2  | y2,   x3  | y3,   x4  | y4,   x5  | y5,   x6  | y6,   x7  | y7,
+                                 x8  | y8,   x9  | y9,   xa  | ya,   xb  | yb,   xc  | yc,   xd  | yd,   xe  | ye,   xf  | yf );
+    WWI_TEST( wwi_xor   (x,y),   x0  ^ y0,   x1  ^ y1,   x2  ^ y2,   x3  ^ y3,   x4  ^ y4,   x5  ^ y5,   x6  ^ y6,   x7  ^ y7,
+                                 x8  ^ y8,   x9  ^ y9,   xa  ^ ya,   xb  ^ yb,   xc  ^ yc,   xd  ^ yd,   xe  ^ ye,   xf  ^ yf );
+
+#   define ROL(x,y) fd_int_rotate_left ( (x), (y) )
+#   define ROR(x,y) fd_int_rotate_right( (x), (y) )
+    WWI_TEST( wwi_rol( x, y0 ),       ROL( x0, y0 ), ROL( x1, y0 ), ROL( x2, y0 ), ROL( x3, y0 ),
+                                      ROL( x4, y0 ), ROL( x5, y0 ), ROL( x6, y0 ), ROL( x7, y0 ),
+                                      ROL( x8, y0 ), ROL( x9, y0 ), ROL( xa, y0 ), ROL( xb, y0 ),
+                                      ROL( xc, y0 ), ROL( xd, y0 ), ROL( xe, y0 ), ROL( xf, y0 ) );
+    WWI_TEST( wwi_ror( x, y0 ),       ROR( x0, y0 ), ROR( x1, y0 ), ROR( x2, y0 ), ROR( x3, y0 ),
+                                      ROR( x4, y0 ), ROR( x5, y0 ), ROR( x6, y0 ), ROR( x7, y0 ),
+                                      ROR( x8, y0 ), ROR( x9, y0 ), ROR( xa, y0 ), ROR( xb, y0 ),
+                                      ROR( xc, y0 ), ROR( xd, y0 ), ROR( xe, y0 ), ROR( xf, y0 ) );
+    WWI_TEST( wwi_rol_vector( x, y ), ROL( x0, y0 ), ROL( x1, y1 ), ROL( x2, y2 ), ROL( x3, y3 ),
+                                      ROL( x4, y4 ), ROL( x5, y5 ), ROL( x6, y6 ), ROL( x7, y7 ),
+                                      ROL( x8, y8 ), ROL( x9, y9 ), ROL( xa, ya ), ROL( xb, yb ),
+                                      ROL( xc, yc ), ROL( xd, yd ), ROL( xe, ye ), ROL( xf, yf ) );
+    WWI_TEST( wwi_ror_vector( x, y ), ROR( x0, y0 ), ROR( x1, y1 ), ROR( x2, y2 ), ROR( x3, y3 ),
+                                      ROR( x4, y4 ), ROR( x5, y5 ), ROR( x6, y6 ), ROR( x7, y7 ),
+                                      ROR( x8, y8 ), ROR( x9, y9 ), ROR( xa, ya ), ROR( xb, yb ),
+                                      ROR( xc, yc ), ROR( xd, yd ), ROR( xe, ye ), ROR( xf, yf ) );
+#   undef ROR
+#   undef ROL
+
+    /* Test comparison */
+
+    int c = (int)(fd_rng_uint( rng ) & 65535U);
+    wwi_t t = wwi_if( c, x, y );
+    wwi_st( _b, t );
+    int t0 = _b[ 0]; int t1 = _b[ 1]; int t2 = _b[ 2]; int t3 = _b[ 3];
+    int t4 = _b[ 4]; int t5 = _b[ 5]; int t6 = _b[ 6]; int t7 = _b[ 7];
+    int t8 = _b[ 8]; int t9 = _b[ 9]; int ta = _b[10]; int tb = _b[11];
+    int tc = _b[12]; int td = _b[13]; int te = _b[14]; int tf = _b[15];
+
+#   define TEST_CMP(fn,op)                                                                                          \
+    FD_TEST( fn(x,t)==( ((x##0 op t##0)<< 0) | ((x##1 op t##1)<< 1) | ((x##2 op t##2)<< 2) | ((x##3 op t##3)<< 3) | \
+                        ((x##4 op t##4)<< 4) | ((x##5 op t##5)<< 5) | ((x##6 op t##6)<< 6) | ((x##7 op t##7)<< 7) | \
+                        ((x##8 op t##8)<< 8) | ((x##9 op t##9)<< 9) | ((x##a op t##a)<<10) | ((x##b op t##b)<<11) | \
+                        ((x##c op t##c)<<12) | ((x##d op t##d)<<13) | ((x##e op t##e)<<14) | ((x##f op t##f)<<15) ) );
+
+    TEST_CMP( wwi_eq, == );
+    TEST_CMP( wwi_gt, >  );
+    TEST_CMP( wwi_lt, <  );
+
+    TEST_CMP( wwi_ne, != );
+    TEST_CMP( wwi_ge, >= );
+    TEST_CMP( wwi_le, <= );
+
+    wwi_t tt = wwi_if( c, wwi_or( x, wwi_one() ), wwi_zero() );
+    FD_TEST( wwi_lnot   ( tt )==wwi_eq( tt, wwi_zero() ) );
+    FD_TEST( wwi_lnotnot( tt )==wwi_ne( tt, wwi_zero() ) );
+
+#   undef TEST_CMP
+
+    /* Test lane ops */
+
+    WWI_TEST( wwi_if( c, y, z ),
+              ((c>> 0)&1) ? y0 : z0, ((c>> 1)&1) ? y1 : z1, ((c>> 2)&1) ? y2 : z2, ((c>> 3)&1) ? y3 : z3,
+              ((c>> 4)&1) ? y4 : z4, ((c>> 5)&1) ? y5 : z5, ((c>> 6)&1) ? y6 : z6, ((c>> 7)&1) ? y7 : z7,
+              ((c>> 8)&1) ? y8 : z8, ((c>> 9)&1) ? y9 : z9, ((c>>10)&1) ? ya : za, ((c>>11)&1) ? yb : zb,
+              ((c>>12)&1) ? yc : zc, ((c>>13)&1) ? yd : zd, ((c>>14)&1) ? ye : ze, ((c>>15)&1) ? yf : zf );
+    WWI_TEST( wwi_add_if( c, x, y, z ),
+              ((c>> 0)&1) ? (x0+y0) : z0, ((c>> 1)&1) ? (x1+y1) : z1, ((c>> 2)&1) ? (x2+y2) : z2, ((c>> 3)&1) ? (x3+y3) : z3,
+              ((c>> 4)&1) ? (x4+y4) : z4, ((c>> 5)&1) ? (x5+y5) : z5, ((c>> 6)&1) ? (x6+y6) : z6, ((c>> 7)&1) ? (x7+y7) : z7,
+              ((c>> 8)&1) ? (x8+y8) : z8, ((c>> 9)&1) ? (x9+y9) : z9, ((c>>10)&1) ? (xa+ya) : za, ((c>>11)&1) ? (xb+yb) : zb,
+              ((c>>12)&1) ? (xc+yc) : zc, ((c>>13)&1) ? (xd+yd) : zd, ((c>>14)&1) ? (xe+ye) : ze, ((c>>15)&1) ? (xf+yf) : zf );
+    WWI_TEST( wwi_sub_if( c, x, y, z ),
+              ((c>> 0)&1) ? (x0-y0) : z0, ((c>> 1)&1) ? (x1-y1) : z1, ((c>> 2)&1) ? (x2-y2) : z2, ((c>> 3)&1) ? (x3-y3) : z3,
+              ((c>> 4)&1) ? (x4-y4) : z4, ((c>> 5)&1) ? (x5-y5) : z5, ((c>> 6)&1) ? (x6-y6) : z6, ((c>> 7)&1) ? (x7-y7) : z7,
+              ((c>> 8)&1) ? (x8-y8) : z8, ((c>> 9)&1) ? (x9-y9) : z9, ((c>>10)&1) ? (xa-ya) : za, ((c>>11)&1) ? (xb-yb) : zb,
+              ((c>>12)&1) ? (xc-yc) : zc, ((c>>13)&1) ? (xd-yd) : zd, ((c>>14)&1) ? (xe-ye) : ze, ((c>>15)&1) ? (xf-yf) : zf );
+
+    /* Test conversions */
+
+    WWU_TEST( wwi_to_wwu( x ),     (uint)x0,  (uint)x1,  (uint)x2,  (uint)x3,  (uint)x4,  (uint)x5,  (uint)x6,  (uint)x7,
+                                   (uint)x8,  (uint)x9,  (uint)xa,  (uint)xb,  (uint)xc,  (uint)xd,  (uint)xe,  (uint)xf );
+    WWL_TEST( wwi_to_wwl( x, 0 ),  (long)x0,  (long)x2,  (long)x4,  (long)x6,  (long)x8,  (long)xa,  (long)xc,  (long)xe );
+    WWL_TEST( wwi_to_wwl( x, 1 ),  (long)x1,  (long)x3,  (long)x5,  (long)x7,  (long)x9,  (long)xb,  (long)xd,  (long)xf );
+    WWV_TEST( wwi_to_wwv( x, 0 ), (ulong)x0, (ulong)x2, (ulong)x4, (ulong)x6, (ulong)x8, (ulong)xa, (ulong)xc, (ulong)xe );
+    WWV_TEST( wwi_to_wwv( x, 1 ), (ulong)x1, (ulong)x3, (ulong)x5, (ulong)x7, (ulong)x9, (ulong)xb, (ulong)xd, (ulong)xf );
+
+    /* Test misc operations */
+
+    WWI_TEST( wwi_pack_halves( y,0, z,0 ), y0,y1,y2,y3,y4,y5,y6,y7, z0,z1,z2,z3,z4,z5,z6,z7 );
+    WWI_TEST( wwi_pack_halves( y,1, z,0 ), y8,y9,ya,yb,yc,yd,ye,yf, z0,z1,z2,z3,z4,z5,z6,z7 );
+    WWI_TEST( wwi_pack_halves( y,0, z,1 ), y0,y1,y2,y3,y4,y5,y6,y7, z8,z9,za,zb,zc,zd,ze,zf );
+    WWI_TEST( wwi_pack_halves( y,1, z,1 ), y8,y9,ya,yb,yc,yd,ye,yf, z8,z9,za,zb,zc,zd,ze,zf );
+    WWI_TEST( wwi_pack_h0_h1 ( y,   z   ), y0,y1,y2,y3,y4,y5,y6,y7, z8,z9,za,zb,zc,zd,ze,zf );
+
+    WWI_TEST( wwi_slide( x, y,  0 ), x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf );
+    WWI_TEST( wwi_slide( x, y,  1 ), x1,x2,x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf,y0 );
+    WWI_TEST( wwi_slide( x, y,  2 ), x2,x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf,y0,y1 );
+    WWI_TEST( wwi_slide( x, y,  3 ), x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf,y0,y1,y2 );
+    WWI_TEST( wwi_slide( x, y,  4 ), x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf,y0,y1,y2,y3 );
+    WWI_TEST( wwi_slide( x, y,  5 ), x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf,y0,y1,y2,y3,y4 );
+    WWI_TEST( wwi_slide( x, y,  6 ), x6,x7,x8,x9,xa,xb,xc,xd,xe,xf,y0,y1,y2,y3,y4,y5 );
+    WWI_TEST( wwi_slide( x, y,  7 ), x7,x8,x9,xa,xb,xc,xd,xe,xf,y0,y1,y2,y3,y4,y5,y6 );
+    WWI_TEST( wwi_slide( x, y,  8 ), x8,x9,xa,xb,xc,xd,xe,xf,y0,y1,y2,y3,y4,y5,y6,y7 );
+    WWI_TEST( wwi_slide( x, y,  9 ), x9,xa,xb,xc,xd,xe,xf,y0,y1,y2,y3,y4,y5,y6,y7,y8 );
+    WWI_TEST( wwi_slide( x, y, 10 ), xa,xb,xc,xd,xe,xf,y0,y1,y2,y3,y4,y5,y6,y7,y8,y9 );
+    WWI_TEST( wwi_slide( x, y, 11 ), xb,xc,xd,xe,xf,y0,y1,y2,y3,y4,y5,y6,y7,y8,y9,ya );
+    WWI_TEST( wwi_slide( x, y, 12 ), xc,xd,xe,xf,y0,y1,y2,y3,y4,y5,y6,y7,y8,y9,ya,yb );
+    WWI_TEST( wwi_slide( x, y, 13 ), xd,xe,xf,y0,y1,y2,y3,y4,y5,y6,y7,y8,y9,ya,yb,yc );
+    WWI_TEST( wwi_slide( x, y, 14 ), xe,xf,y0,y1,y2,y3,y4,y5,y6,y7,y8,y9,ya,yb,yc,yd );
+    WWI_TEST( wwi_slide( x, y, 15 ), xf,y0,y1,y2,y3,y4,y5,y6,y7,y8,y9,ya,yb,yc,yd,ye );
+
+    wwi_unpack( x, t0,t1,t2,t3,t4,t5,t6,t7,t8,t9,ta,tb,tc,td,te,tf );
+    WWI_TEST( wwi( t0,t1,t2,t3,t4,t5,t6,t7,t8,t9,ta,tb,tc,td,te,tf ), x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf );
+
+    wwi_t r0 = x;               wwi_t r1 = y;               wwi_t r2 = z;               wwi_t r3 = t;
+    wwi_t r4 = wwi_not( x );    wwi_t r5 = wwi_not( y );    wwi_t r6 = wwi_not( z );    wwi_t r7 = wwi_not( t );
+    wwi_t r8 = wwi_ror( x, 8 ); wwi_t r9 = wwi_ror( y, 8 ); wwi_t ra = wwi_ror( z, 8 ); wwi_t rb = wwi_ror( t, 8 );
+    wwi_t rc = wwi_rol( x, 8 ); wwi_t rd = wwi_rol( y, 8 ); wwi_t re = wwi_rol( z, 8 ); wwi_t rf = wwi_rol( t, 8 );
+
+    int A [256] WW_ATTR;
+    int AT[256] WW_ATTR;
+
+    wwi_st( A,     r0 ); wwi_st( A+ 16, r1 ); wwi_st( A+ 32, r2 ); wwi_st( A+ 48, r3 );
+    wwi_st( A+ 64, r4 ); wwi_st( A+ 80, r5 ); wwi_st( A+ 96, r6 ); wwi_st( A+112, r7 );
+    wwi_st( A+128, r8 ); wwi_st( A+144, r9 ); wwi_st( A+160, ra ); wwi_st( A+176, rb );
+    wwi_st( A+192, rc ); wwi_st( A+208, rd ); wwi_st( A+224, re ); wwi_st( A+240, rf );
+
+    wwi_t c0; wwi_t c1; wwi_t c2; wwi_t c3; wwi_t c4; wwi_t c5; wwi_t c6; wwi_t c7;
+    wwi_t c8; wwi_t c9; wwi_t ca; wwi_t cb; wwi_t cc; wwi_t cd; wwi_t ce; wwi_t cf;
+
+    wwi_transpose_16x16( r0,r1,r2,r3,r4,r5,r6,r7,r8,r9,ra,rb,rc,rd,re,rf, c0,c1,c2,c3,c4,c5,c6,c7,c8,c9,ca,cb,cc,cd,ce,cf );
+
+    wwi_st( AT,     c0 ); wwi_st( AT+ 16, c1 ); wwi_st( AT+ 32, c2 ); wwi_st( AT+ 48, c3 );
+    wwi_st( AT+ 64, c4 ); wwi_st( AT+ 80, c5 ); wwi_st( AT+ 96, c6 ); wwi_st( AT+112, c7 );
+    wwi_st( AT+128, c8 ); wwi_st( AT+144, c9 ); wwi_st( AT+160, ca ); wwi_st( AT+176, cb );
+    wwi_st( AT+192, cc ); wwi_st( AT+208, cd ); wwi_st( AT+224, ce ); wwi_st( AT+240, cf );
+
+    for( int ii=0; ii<16; ii++ ) for( int jj=0; jj<16; jj++ ) FD_TEST( A[ii+16*jj]==AT[jj+16*ii] );
+
+    wwi_transpose_2x8x8( r0,r1,r2,r3,r4,r5,r6,r7, c0,c1,c2,c3,c4,c5,c6,c7 );
+
+    wwi_st( AT,     c0 ); wwi_st( AT+ 16, c1 ); wwi_st( AT+ 32, c2 ); wwi_st( AT+ 48, c3 );
+    wwi_st( AT+ 64, c4 ); wwi_st( AT+ 80, c5 ); wwi_st( AT+ 96, c6 ); wwi_st( AT+112, c7 );
+    for( int kk=0; kk<2; kk++ )
+      for( int ii=0; ii<8; ii++ )
+        for( int jj=0; jj<8; jj++ ) FD_TEST( A[8*kk+ii+16*jj]==AT[8*kk+jj+16*ii] );
+  }
+
+  FD_LOG_NOTICE(( "Testing wwu_t" ));
+
+  for( ulong rem=1000000UL; rem; rem-- ) {
+
+    /* Test construct */
+
+    uint x0 = fd_rng_uint( rng ); uint x1 = fd_rng_uint( rng ); uint x2 = fd_rng_uint( rng ); uint x3 = fd_rng_uint( rng );
+    uint x4 = fd_rng_uint( rng ); uint x5 = fd_rng_uint( rng ); uint x6 = fd_rng_uint( rng ); uint x7 = fd_rng_uint( rng );
+    uint x8 = fd_rng_uint( rng ); uint x9 = fd_rng_uint( rng ); uint xa = fd_rng_uint( rng ); uint xb = fd_rng_uint( rng );
+    uint xc = fd_rng_uint( rng ); uint xd = fd_rng_uint( rng ); uint xe = fd_rng_uint( rng ); uint xf = fd_rng_uint( rng );
+    wwu_t x = wwu( x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf );
+    WWU_TEST( x, x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf );
+
+    uint y0 = fd_rng_uint( rng ); uint y1 = fd_rng_uint( rng ); uint y2 = fd_rng_uint( rng ); uint y3 = fd_rng_uint( rng );
+    uint y4 = fd_rng_uint( rng ); uint y5 = fd_rng_uint( rng ); uint y6 = fd_rng_uint( rng ); uint y7 = fd_rng_uint( rng );
+    uint y8 = fd_rng_uint( rng ); uint y9 = fd_rng_uint( rng ); uint ya = fd_rng_uint( rng ); uint yb = fd_rng_uint( rng );
+    uint yc = fd_rng_uint( rng ); uint yd = fd_rng_uint( rng ); uint ye = fd_rng_uint( rng ); uint yf = fd_rng_uint( rng );
+    wwu_t y = wwu( y0, y1, y2, y3, y4, y5, y6, y7, y8, y9, ya, yb, yc, yd, ye, yf );
+    WWU_TEST( y, y0, y1, y2, y3, y4, y5, y6, y7, y8, y9, ya, yb, yc, yd, ye, yf );
+
+    uint z0 = fd_rng_uint( rng ); uint z1 = fd_rng_uint( rng ); uint z2 = fd_rng_uint( rng ); uint z3 = fd_rng_uint( rng );
+    uint z4 = fd_rng_uint( rng ); uint z5 = fd_rng_uint( rng ); uint z6 = fd_rng_uint( rng ); uint z7 = fd_rng_uint( rng );
+    uint z8 = fd_rng_uint( rng ); uint z9 = fd_rng_uint( rng ); uint za = fd_rng_uint( rng ); uint zb = fd_rng_uint( rng );
+    uint zc = fd_rng_uint( rng ); uint zd = fd_rng_uint( rng ); uint ze = fd_rng_uint( rng ); uint zf = fd_rng_uint( rng );
+    wwu_t z = wwu( z0, z1, z2, z3, z4, z5, z6, z7, z8, z9, za, zb, zc, zd, ze, zf );
+    WWU_TEST( z, z0, z1, z2, z3, z4, z5, z6, z7, z8, z9, za, zb, zc, zd, ze, zf );
+
+    uint u0; uint u1; uint u2; uint u3; uint u4; uint u5; uint u6; uint u7;
+    uint u8; uint u9; uint ua; uint ub; uint uc; uint ud; uint ue; uint uf;
+    wwu_t u;
+
+    uint _b[32] WW_ATTR;
+
+    /* Test permute/select */
+
+    wwu_st( _b, y ); wwu_st( _b+16, z );
+
+    u0 = x0 & 15U; u1 = x1 & 15U; u2 = x2 & 15U; u3 = x3 & 15U; u4 = x4 & 15U; u5 = x5 & 15U; u6 = x6 & 15U; u7 = x7 & 15U;
+    u8 = x8 & 15U; u9 = x9 & 15U; ua = xa & 15U; ub = xb & 15U; uc = xc & 15U; ud = xd & 15U; ue = xe & 15U; uf = xf & 15U;
+    u = wwu( u0, u1, u2, u3, u4, u5, u6, u7, u8, u9, ua, ub, uc, ud, ue, uf );
+    WWU_TEST( wwu_permute( u, y ), _b[ u0 ], _b[ u1 ], _b[ u2 ], _b[ u3 ], _b[ u4 ], _b[ u5 ], _b[ u6 ], _b[ u7 ],
+                                   _b[ u8 ], _b[ u9 ], _b[ ua ], _b[ ub ], _b[ uc ], _b[ ud ], _b[ ue ], _b[ uf ] );
+
+    u0 = x0 & 31U; u1 = x1 & 31U; u2 = x2 & 31U; u3 = x3 & 31U; u4 = x4 & 31U; u5 = x5 & 31U; u6 = x6 & 31U; u7 = x7 & 31U;
+    u8 = x8 & 31U; u9 = x9 & 31U; ua = xa & 31U; ub = xb & 31U; uc = xc & 31U; ud = xd & 31U; ue = xe & 31U; uf = xf & 31U;
+    u = wwu( u0, u1, u2, u3, u4, u5, u6, u7, u8, u9, ua, ub, uc, ud, ue, uf );
+    WWU_TEST( wwu_select( u, y, z ), _b[ u0 ], _b[ u1 ], _b[ u2 ], _b[ u3 ], _b[ u4 ], _b[ u5 ], _b[ u6 ], _b[ u7 ],
+                                     _b[ u8 ], _b[ u9 ], _b[ ua ], _b[ ub ], _b[ uc ], _b[ ud ], _b[ ue ], _b[ uf ] );
+
+    /* Test bcast/zero/one */
+
+    WWU_TEST( wwu_bcast(x0), x0, x0, x0, x0, x0, x0, x0, x0, x0, x0, x0, x0, x0, x0, x0, x0 );
+    WWU_TEST( wwu_zero(),    0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U );
+    WWU_TEST( wwu_one(),     1U, 1U, 1U, 1U, 1U, 1U, 1U, 1U, 1U, 1U, 1U, 1U, 1U, 1U, 1U, 1U );
+
+    /* Test ld/st/ldu/stu */
+
+    wwu_st( _b, x );
+    WWU_TEST( wwu_ld( _b ), x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf );
+
+    uchar _m[128] WW_ATTR;
+    u0 = x0 & 63U;
+    wwu_stu( _m+u0, y );
+    WWU_TEST( wwu_ldu( _m+u0 ), y0, y1, y2, y3, y4, y5, y6, y7, y8, y9, ya, yb, yc, yd, ye, yf );
+
+    /* Test arithmetic ops */
+
+    WWU_TEST( wwu_neg(x), -x0, -x1, -x2, -x3, -x4, -x5, -x6, -x7, -x8, -x9, -xa, -xb, -xc, -xd, -xe, -xf );
+    WWU_TEST( wwu_abs(x),  x0,  x1,  x2,  x3,  x4,  x5,  x6,  x7,  x8,  x9,  xa,  xb,  xc,  xd,  xe,  xf );
+
+    WWU_TEST( wwu_min(x,y), fd_uint_min(x0,y0), fd_uint_min(x1,y1), fd_uint_min(x2,y2), fd_uint_min(x3,y3),
+                            fd_uint_min(x4,y4), fd_uint_min(x5,y5), fd_uint_min(x6,y6), fd_uint_min(x7,y7),
+                            fd_uint_min(x8,y8), fd_uint_min(x9,y9), fd_uint_min(xa,ya), fd_uint_min(xb,yb),
+                            fd_uint_min(xc,yc), fd_uint_min(xd,yd), fd_uint_min(xe,ye), fd_uint_min(xf,yf) );
+    WWU_TEST( wwu_max(x,y), fd_uint_max(x0,y0), fd_uint_max(x1,y1), fd_uint_max(x2,y2), fd_uint_max(x3,y3),
+                            fd_uint_max(x4,y4), fd_uint_max(x5,y5), fd_uint_max(x6,y6), fd_uint_max(x7,y7),
+                            fd_uint_max(x8,y8), fd_uint_max(x9,y9), fd_uint_max(xa,ya), fd_uint_max(xb,yb),
+                            fd_uint_max(xc,yc), fd_uint_max(xd,yd), fd_uint_max(xe,ye), fd_uint_max(xf,yf) );
+    WWU_TEST( wwu_add(x,y), x0+y0, x1+y1, x2+y2, x3+y3, x4+y4, x5+y5, x6+y6, x7+y7,
+                            x8+y8, x9+y9, xa+ya, xb+yb, xc+yc, xd+yd, xe+ye, xf+yf );
+    WWU_TEST( wwu_sub(x,y), x0-y0, x1-y1, x2-y2, x3-y3, x4-y4, x5-y5, x6-y6, x7-y7,
+                            x8-y8, x9-y9, xa-ya, xb-yb, xc-yc, xd-yd, xe-ye, xf-yf );
+    WWU_TEST( wwu_mul(x,y), x0*y0, x1*y1, x2*y2, x3*y3, x4*y4, x5*y5, x6*y6, x7*y7,
+                            x8*y8, x9*y9, xa*ya, xb*yb, xc*yc, xd*yd, xe*ye, xf*yf );
+
+    /* Test bit ops */
+
+    u0 = y0 & 31U; u1 = y1 & 31U; u2 = y2 & 31U; u3 = y3 & 31U; u4 = y4 & 31U; u5 = y5 & 31U; u6 = y6 & 31U; u7 = y7 & 31U;
+    u8 = y8 & 31U; u9 = y9 & 31U; ua = ya & 31U; ub = yb & 31U; uc = yc & 31U; ud = yd & 31U; ue = ye & 31U; uf = yf & 31U;
+    u = wwu( u0, u1, u2, u3, u4, u5, u6, u7, u8, u9, ua, ub, uc, ud, ue, uf );
+
+    WWU_TEST( wwu_not(x), ~x0, ~x1, ~x2, ~x3, ~x4, ~x5, ~x6, ~x7, ~x8, ~x9, ~xa, ~xb, ~xc, ~xd, ~xe, ~xf );
+
+    WWU_TEST( wwu_shl       ( x, u0 ), x0<<u0, x1<<u0, x2<<u0, x3<<u0, x4<<u0, x5<<u0, x6<<u0, x7<<u0,
+                                       x8<<u0, x9<<u0, xa<<u0, xb<<u0, xc<<u0, xd<<u0, xe<<u0, xf<<u0 );
+    WWU_TEST( wwu_shr       ( x, u0 ), x0>>u0, x1>>u0, x2>>u0, x3>>u0, x4>>u0, x5>>u0, x6>>u0, x7>>u0,
+                                       x8>>u0, x9>>u0, xa>>u0, xb>>u0, xc>>u0, xd>>u0, xe>>u0, xf>>u0 );
+    WWU_TEST( wwu_shl_vector( x, u  ), x0<<u0, x1<<u1, x2<<u2, x3<<u3, x4<<u4, x5<<u5, x6<<u6, x7<<u7,
+                                       x8<<u8, x9<<u9, xa<<ua, xb<<ub, xc<<uc, xd<<ud, xe<<ue, xf<<uf );
+    WWU_TEST( wwu_shr_vector( x, u  ), x0>>u0, x1>>u1, x2>>u2, x3>>u3, x4>>u4, x5>>u5, x6>>u6, x7>>u7,
+                                       x8>>u8, x9>>u9, xa>>ua, xb>>ub, xc>>uc, xd>>ud, xe>>ue, xf>>uf );
+
+    WWU_TEST( wwu_and   (x,y),   x0  & y0,   x1  & y1,   x2  & y2,   x3  & y3,   x4  & y4,   x5  & y5,   x6  & y6,   x7  & y7,
+                                 x8  & y8,   x9  & y9,   xa  & ya,   xb  & yb,   xc  & yc,   xd  & yd,   xe  & ye,   xf  & yf );
+    WWU_TEST( wwu_andnot(x,y), (~x0) & y0, (~x1) & y1, (~x2) & y2, (~x3) & y3, (~x4) & y4, (~x5) & y5, (~x6) & y6, (~x7) & y7,
+                               (~x8) & y8, (~x9) & y9, (~xa) & ya, (~xb) & yb, (~xc) & yc, (~xd) & yd, (~xe) & ye, (~xf) & yf );
+    WWU_TEST( wwu_or    (x,y),   x0  | y0,   x1  | y1,   x2  | y2,   x3  | y3,   x4  | y4,   x5  | y5,   x6  | y6,   x7  | y7,
+                                 x8  | y8,   x9  | y9,   xa  | ya,   xb  | yb,   xc  | yc,   xd  | yd,   xe  | ye,   xf  | yf );
+    WWU_TEST( wwu_xor   (x,y),   x0  ^ y0,   x1  ^ y1,   x2  ^ y2,   x3  ^ y3,   x4  ^ y4,   x5  ^ y5,   x6  ^ y6,   x7  ^ y7,
+                                 x8  ^ y8,   x9  ^ y9,   xa  ^ ya,   xb  ^ yb,   xc  ^ yc,   xd  ^ yd,   xe  ^ ye,   xf  ^ yf );
+
+#   define ROL(x,y) fd_uint_rotate_left ( (x), (int)(uint)(y) )
+#   define ROR(x,y) fd_uint_rotate_right( (x), (int)(uint)(y) )
+    WWU_TEST( wwu_rol( x, y0 ),       ROL( x0, y0 ), ROL( x1, y0 ), ROL( x2, y0 ), ROL( x3, y0 ),
+                                      ROL( x4, y0 ), ROL( x5, y0 ), ROL( x6, y0 ), ROL( x7, y0 ),
+                                      ROL( x8, y0 ), ROL( x9, y0 ), ROL( xa, y0 ), ROL( xb, y0 ),
+                                      ROL( xc, y0 ), ROL( xd, y0 ), ROL( xe, y0 ), ROL( xf, y0 ) );
+    WWU_TEST( wwu_ror( x, y0 ),       ROR( x0, y0 ), ROR( x1, y0 ), ROR( x2, y0 ), ROR( x3, y0 ),
+                                      ROR( x4, y0 ), ROR( x5, y0 ), ROR( x6, y0 ), ROR( x7, y0 ),
+                                      ROR( x8, y0 ), ROR( x9, y0 ), ROR( xa, y0 ), ROR( xb, y0 ),
+                                      ROR( xc, y0 ), ROR( xd, y0 ), ROR( xe, y0 ), ROR( xf, y0 ) );
+    WWU_TEST( wwu_rol_vector( x, y ), ROL( x0, y0 ), ROL( x1, y1 ), ROL( x2, y2 ), ROL( x3, y3 ),
+                                      ROL( x4, y4 ), ROL( x5, y5 ), ROL( x6, y6 ), ROL( x7, y7 ),
+                                      ROL( x8, y8 ), ROL( x9, y9 ), ROL( xa, ya ), ROL( xb, yb ),
+                                      ROL( xc, yc ), ROL( xd, yd ), ROL( xe, ye ), ROL( xf, yf ) );
+    WWU_TEST( wwu_ror_vector( x, y ), ROR( x0, y0 ), ROR( x1, y1 ), ROR( x2, y2 ), ROR( x3, y3 ),
+                                      ROR( x4, y4 ), ROR( x5, y5 ), ROR( x6, y6 ), ROR( x7, y7 ),
+                                      ROR( x8, y8 ), ROR( x9, y9 ), ROR( xa, ya ), ROR( xb, yb ),
+                                      ROR( xc, yc ), ROR( xd, yd ), ROR( xe, ye ), ROR( xf, yf ) );
+#   undef ROR
+#   undef ROL
+
+    WWU_TEST( wwu_bswap(x), fd_uint_bswap(x0), fd_uint_bswap(x1), fd_uint_bswap(x2), fd_uint_bswap(x3),
+                            fd_uint_bswap(x4), fd_uint_bswap(x5), fd_uint_bswap(x6), fd_uint_bswap(x7),
+                            fd_uint_bswap(x8), fd_uint_bswap(x9), fd_uint_bswap(xa), fd_uint_bswap(xb),
+                            fd_uint_bswap(xc), fd_uint_bswap(xd), fd_uint_bswap(xe), fd_uint_bswap(xf) );
+
+    /* Test comparison */
+
+    int c = (int)(fd_rng_uint( rng ) & 65535U);
+    wwu_t t = wwu_if( c, x, y );
+    wwu_st( _b, t );
+    uint t0 = _b[ 0]; uint t1 = _b[ 1]; uint t2 = _b[ 2]; uint t3 = _b[ 3];
+    uint t4 = _b[ 4]; uint t5 = _b[ 5]; uint t6 = _b[ 6]; uint t7 = _b[ 7];
+    uint t8 = _b[ 8]; uint t9 = _b[ 9]; uint ta = _b[10]; uint tb = _b[11];
+    uint tc = _b[12]; uint td = _b[13]; uint te = _b[14]; uint tf = _b[15];
+
+#   define TEST_CMP(fn,op)                                                                                          \
+    FD_TEST( fn(x,t)==( ((x##0 op t##0)<< 0) | ((x##1 op t##1)<< 1) | ((x##2 op t##2)<< 2) | ((x##3 op t##3)<< 3) | \
+                        ((x##4 op t##4)<< 4) | ((x##5 op t##5)<< 5) | ((x##6 op t##6)<< 6) | ((x##7 op t##7)<< 7) | \
+                        ((x##8 op t##8)<< 8) | ((x##9 op t##9)<< 9) | ((x##a op t##a)<<10) | ((x##b op t##b)<<11) | \
+                        ((x##c op t##c)<<12) | ((x##d op t##d)<<13) | ((x##e op t##e)<<14) | ((x##f op t##f)<<15) ) );
+
+    TEST_CMP( wwu_eq, == );
+    TEST_CMP( wwu_gt, >  );
+    TEST_CMP( wwu_lt, <  );
+
+    TEST_CMP( wwu_ne, != );
+    TEST_CMP( wwu_ge, >= );
+    TEST_CMP( wwu_le, <= );
+
+    wwu_t tt = wwu_if( c, wwu_or( x, wwu_one() ), wwu_zero() );
+    FD_TEST( wwu_lnot   ( tt )==wwu_eq( tt, wwu_zero() ) );
+    FD_TEST( wwu_lnotnot( tt )==wwu_ne( tt, wwu_zero() ) );
+
+#   undef TEST_CMP
+
+    /* Test lane ops */
+
+    WWU_TEST( wwu_if( c, y, z ),
+              ((c>> 0)&1) ? y0 : z0, ((c>> 1)&1) ? y1 : z1, ((c>> 2)&1) ? y2 : z2, ((c>> 3)&1) ? y3 : z3,
+              ((c>> 4)&1) ? y4 : z4, ((c>> 5)&1) ? y5 : z5, ((c>> 6)&1) ? y6 : z6, ((c>> 7)&1) ? y7 : z7,
+              ((c>> 8)&1) ? y8 : z8, ((c>> 9)&1) ? y9 : z9, ((c>>10)&1) ? ya : za, ((c>>11)&1) ? yb : zb,
+              ((c>>12)&1) ? yc : zc, ((c>>13)&1) ? yd : zd, ((c>>14)&1) ? ye : ze, ((c>>15)&1) ? yf : zf );
+    WWU_TEST( wwu_add_if( c, x, y, z ),
+              ((c>> 0)&1) ? (x0+y0) : z0, ((c>> 1)&1) ? (x1+y1) : z1, ((c>> 2)&1) ? (x2+y2) : z2, ((c>> 3)&1) ? (x3+y3) : z3,
+              ((c>> 4)&1) ? (x4+y4) : z4, ((c>> 5)&1) ? (x5+y5) : z5, ((c>> 6)&1) ? (x6+y6) : z6, ((c>> 7)&1) ? (x7+y7) : z7,
+              ((c>> 8)&1) ? (x8+y8) : z8, ((c>> 9)&1) ? (x9+y9) : z9, ((c>>10)&1) ? (xa+ya) : za, ((c>>11)&1) ? (xb+yb) : zb,
+              ((c>>12)&1) ? (xc+yc) : zc, ((c>>13)&1) ? (xd+yd) : zd, ((c>>14)&1) ? (xe+ye) : ze, ((c>>15)&1) ? (xf+yf) : zf );
+    WWU_TEST( wwu_sub_if( c, x, y, z ),
+              ((c>> 0)&1) ? (x0-y0) : z0, ((c>> 1)&1) ? (x1-y1) : z1, ((c>> 2)&1) ? (x2-y2) : z2, ((c>> 3)&1) ? (x3-y3) : z3,
+              ((c>> 4)&1) ? (x4-y4) : z4, ((c>> 5)&1) ? (x5-y5) : z5, ((c>> 6)&1) ? (x6-y6) : z6, ((c>> 7)&1) ? (x7-y7) : z7,
+              ((c>> 8)&1) ? (x8-y8) : z8, ((c>> 9)&1) ? (x9-y9) : z9, ((c>>10)&1) ? (xa-ya) : za, ((c>>11)&1) ? (xb-yb) : zb,
+              ((c>>12)&1) ? (xc-yc) : zc, ((c>>13)&1) ? (xd-yd) : zd, ((c>>14)&1) ? (xe-ye) : ze, ((c>>15)&1) ? (xf-yf) : zf );
+
+    /* Test conversions */
+
+    WWI_TEST( wwu_to_wwi( x ),      (int)x0,   (int)x1,   (int)x2,   (int)x3,   (int)x4,   (int)x5,   (int)x6,   (int)x7,
+                                    (int)x8,   (int)x9,   (int)xa,   (int)xb,   (int)xc,   (int)xd,   (int)xe,   (int)xf );
+    WWL_TEST( wwu_to_wwl( x, 0 ),  (long)x0,  (long)x2,  (long)x4,  (long)x6,  (long)x8,  (long)xa,  (long)xc,  (long)xe );
+    WWL_TEST( wwu_to_wwl( x, 1 ),  (long)x1,  (long)x3,  (long)x5,  (long)x7,  (long)x9,  (long)xb,  (long)xd,  (long)xf );
+    WWV_TEST( wwu_to_wwv( x, 0 ), (ulong)x0, (ulong)x2, (ulong)x4, (ulong)x6, (ulong)x8, (ulong)xa, (ulong)xc, (ulong)xe );
+    WWV_TEST( wwu_to_wwv( x, 1 ), (ulong)x1, (ulong)x3, (ulong)x5, (ulong)x7, (ulong)x9, (ulong)xb, (ulong)xd, (ulong)xf );
+
+    /* Test misc operations */
+
+    WWU_TEST( wwu_pack_halves( y,0, z,0 ), y0,y1,y2,y3,y4,y5,y6,y7, z0,z1,z2,z3,z4,z5,z6,z7 );
+    WWU_TEST( wwu_pack_halves( y,1, z,0 ), y8,y9,ya,yb,yc,yd,ye,yf, z0,z1,z2,z3,z4,z5,z6,z7 );
+    WWU_TEST( wwu_pack_halves( y,0, z,1 ), y0,y1,y2,y3,y4,y5,y6,y7, z8,z9,za,zb,zc,zd,ze,zf );
+    WWU_TEST( wwu_pack_halves( y,1, z,1 ), y8,y9,ya,yb,yc,yd,ye,yf, z8,z9,za,zb,zc,zd,ze,zf );
+    WWU_TEST( wwu_pack_h0_h1 ( y,   z   ), y0,y1,y2,y3,y4,y5,y6,y7, z8,z9,za,zb,zc,zd,ze,zf );
+
+    WWU_TEST( wwu_slide( x, y,  0 ), x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf );
+    WWU_TEST( wwu_slide( x, y,  1 ), x1,x2,x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf,y0 );
+    WWU_TEST( wwu_slide( x, y,  2 ), x2,x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf,y0,y1 );
+    WWU_TEST( wwu_slide( x, y,  3 ), x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf,y0,y1,y2 );
+    WWU_TEST( wwu_slide( x, y,  4 ), x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf,y0,y1,y2,y3 );
+    WWU_TEST( wwu_slide( x, y,  5 ), x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf,y0,y1,y2,y3,y4 );
+    WWU_TEST( wwu_slide( x, y,  6 ), x6,x7,x8,x9,xa,xb,xc,xd,xe,xf,y0,y1,y2,y3,y4,y5 );
+    WWU_TEST( wwu_slide( x, y,  7 ), x7,x8,x9,xa,xb,xc,xd,xe,xf,y0,y1,y2,y3,y4,y5,y6 );
+    WWU_TEST( wwu_slide( x, y,  8 ), x8,x9,xa,xb,xc,xd,xe,xf,y0,y1,y2,y3,y4,y5,y6,y7 );
+    WWU_TEST( wwu_slide( x, y,  9 ), x9,xa,xb,xc,xd,xe,xf,y0,y1,y2,y3,y4,y5,y6,y7,y8 );
+    WWU_TEST( wwu_slide( x, y, 10 ), xa,xb,xc,xd,xe,xf,y0,y1,y2,y3,y4,y5,y6,y7,y8,y9 );
+    WWU_TEST( wwu_slide( x, y, 11 ), xb,xc,xd,xe,xf,y0,y1,y2,y3,y4,y5,y6,y7,y8,y9,ya );
+    WWU_TEST( wwu_slide( x, y, 12 ), xc,xd,xe,xf,y0,y1,y2,y3,y4,y5,y6,y7,y8,y9,ya,yb );
+    WWU_TEST( wwu_slide( x, y, 13 ), xd,xe,xf,y0,y1,y2,y3,y4,y5,y6,y7,y8,y9,ya,yb,yc );
+    WWU_TEST( wwu_slide( x, y, 14 ), xe,xf,y0,y1,y2,y3,y4,y5,y6,y7,y8,y9,ya,yb,yc,yd );
+    WWU_TEST( wwu_slide( x, y, 15 ), xf,y0,y1,y2,y3,y4,y5,y6,y7,y8,y9,ya,yb,yc,yd,ye );
+
+    wwu_unpack( x, t0,t1,t2,t3,t4,t5,t6,t7,t8,t9,ta,tb,tc,td,te,tf );
+    WWU_TEST( wwu( t0,t1,t2,t3,t4,t5,t6,t7,t8,t9,ta,tb,tc,td,te,tf ), x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,xa,xb,xc,xd,xe,xf );
+
+    wwu_t r0 = x;               wwu_t r1 = y;               wwu_t r2 = z;               wwu_t r3 = t;
+    wwu_t r4 = wwu_not( x );    wwu_t r5 = wwu_not( y );    wwu_t r6 = wwu_not( z );    wwu_t r7 = wwu_not( t );
+    wwu_t r8 = wwu_ror( x, 8 ); wwu_t r9 = wwu_ror( y, 8 ); wwu_t ra = wwu_ror( z, 8 ); wwu_t rb = wwu_ror( t, 8 );
+    wwu_t rc = wwu_rol( x, 8 ); wwu_t rd = wwu_rol( y, 8 ); wwu_t re = wwu_rol( z, 8 ); wwu_t rf = wwu_rol( t, 8 );
+
+    uint A [256] WW_ATTR;
+    uint AT[256] WW_ATTR;
+
+    wwu_st( A,     r0 ); wwu_st( A+ 16, r1 ); wwu_st( A+ 32, r2 ); wwu_st( A+ 48, r3 );
+    wwu_st( A+ 64, r4 ); wwu_st( A+ 80, r5 ); wwu_st( A+ 96, r6 ); wwu_st( A+112, r7 );
+    wwu_st( A+128, r8 ); wwu_st( A+144, r9 ); wwu_st( A+160, ra ); wwu_st( A+176, rb );
+    wwu_st( A+192, rc ); wwu_st( A+208, rd ); wwu_st( A+224, re ); wwu_st( A+240, rf );
+
+    wwu_t c0; wwu_t c1; wwu_t c2; wwu_t c3; wwu_t c4; wwu_t c5; wwu_t c6; wwu_t c7;
+    wwu_t c8; wwu_t c9; wwu_t ca; wwu_t cb; wwu_t cc; wwu_t cd; wwu_t ce; wwu_t cf;
+
+    wwu_transpose_16x16( r0,r1,r2,r3,r4,r5,r6,r7,r8,r9,ra,rb,rc,rd,re,rf, c0,c1,c2,c3,c4,c5,c6,c7,c8,c9,ca,cb,cc,cd,ce,cf );
+
+    wwu_st( AT,     c0 ); wwu_st( AT+ 16, c1 ); wwu_st( AT+ 32, c2 ); wwu_st( AT+ 48, c3 );
+    wwu_st( AT+ 64, c4 ); wwu_st( AT+ 80, c5 ); wwu_st( AT+ 96, c6 ); wwu_st( AT+112, c7 );
+    wwu_st( AT+128, c8 ); wwu_st( AT+144, c9 ); wwu_st( AT+160, ca ); wwu_st( AT+176, cb );
+    wwu_st( AT+192, cc ); wwu_st( AT+208, cd ); wwu_st( AT+224, ce ); wwu_st( AT+240, cf );
+
+    for( int ii=0; ii<16; ii++ ) for( int jj=0; jj<16; jj++ ) FD_TEST( A[ii+16*jj]==AT[jj+16*ii] );
+
+    wwu_transpose_2x8x8( r0,r1,r2,r3,r4,r5,r6,r7, c0,c1,c2,c3,c4,c5,c6,c7 );
+
+    wwu_st( AT,     c0 ); wwu_st( AT+ 16, c1 ); wwu_st( AT+ 32, c2 ); wwu_st( AT+ 48, c3 );
+    wwu_st( AT+ 64, c4 ); wwu_st( AT+ 80, c5 ); wwu_st( AT+ 96, c6 ); wwu_st( AT+112, c7 );
+    for( int kk=0; kk<2; kk++ )
+      for( int ii=0; ii<8; ii++ )
+        for( int jj=0; jj<8; jj++ ) FD_TEST( A[8*kk+ii+16*jj]==AT[8*kk+jj+16*ii] );
+  }
+
+  fd_rng_delete( fd_rng_leave( rng ) );
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}

--- a/src/util/simd/test_avx512_8x64.c
+++ b/src/util/simd/test_avx512_8x64.c
@@ -1,44 +1,4 @@
-#include "../fd_util.h"
-#include "fd_avx512.h"
-
-FD_STATIC_ASSERT( WW_WIDTH       ==16, unit_test );
-FD_STATIC_ASSERT( WW_FOOTPRINT   ==64, unit_test );
-FD_STATIC_ASSERT( WW_ALIGN       ==64, unit_test );
-FD_STATIC_ASSERT( WW_LG_WIDTH    == 4, unit_test );
-FD_STATIC_ASSERT( WW_LG_FOOTPRINT== 6, unit_test );
-FD_STATIC_ASSERT( WW_LG_ALIGN    == 6, unit_test );
-
-#define WWL_TEST( x, x0,x1,x2,x3,x4,x5,x6,x7 ) do {                                                                 \
-    long _t[8] WW_ATTR;                                                                                             \
-    long _u[8] WW_ATTR;                                                                                             \
-    wwl_st( _t, (x) );                                                                                              \
-    _u[0] = (x0); _u[1] = (x1); _u[2] = (x2); _u[3] = (x3); _u[4] = (x4); _u[5] = (x5); _u[6] = (x6); _u[7] = (x7); \
-    for( int _lane=0; _lane<8; _lane++ )                                                                            \
-      if( FD_UNLIKELY( _t[_lane]!=_u[_lane] ) )                                                                     \
-        FD_LOG_ERR(( "FAIL: %s @ lane %i\n\t"                                                                       \
-                     "  got 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL\n\t"    \
-                     "  exp 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL 0x%016lxL",       \
-                     #x, _lane,                                                                                     \
-                     (ulong)_t[0], (ulong)_t[1], (ulong)_t[2], (ulong)_t[3],                                        \
-                     (ulong)_t[4], (ulong)_t[5], (ulong)_t[6], (ulong)_t[7],                                        \
-                     (ulong)_u[0], (ulong)_u[1], (ulong)_u[2], (ulong)_u[3],                                        \
-                     (ulong)_u[4], (ulong)_u[5], (ulong)_u[6], (ulong)_u[7] ));                                     \
-  } while(0)
-
-#define WWV_TEST( x, x0,x1,x2,x3,x4,x5,x6,x7 ) do {                                                                      \
-    ulong _t[8] WW_ATTR;                                                                                                 \
-    ulong _u[8] WW_ATTR;                                                                                                 \
-    wwv_st( _t, (x) );                                                                                                   \
-    _u[0] = (x0); _u[1] = (x1); _u[2] = (x2); _u[3] = (x3); _u[4] = (x4); _u[5] = (x5); _u[6] = (x6); _u[7] = (x7);      \
-    for( int _lane=0; _lane<8; _lane++ )                                                                                 \
-      if( FD_UNLIKELY( _t[_lane]!=_u[_lane] ) )                                                                          \
-        FD_LOG_ERR(( "FAIL: %s @ lane %i\n\t"                                                                            \
-                     "  got 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL\n\t" \
-                     "  exp 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL 0x%016lxUL",    \
-                     #x, _lane,                                                                                          \
-                     _t[0], _t[1], _t[2], _t[3], _t[4], _t[5], _t[6], _t[7],                                             \
-                     _u[0], _u[1], _u[2], _u[3], _u[4], _u[5], _u[6], _u[7] ));                                          \
-  } while(0)
+#include "test_avx512.h"
 
 int
 main( int     argc,
@@ -107,7 +67,7 @@ main( int     argc,
     wwl_stu( _m+i0, y );
     WWL_TEST( wwl_ldu( _m+i0 ), y0, y1, y2, y3, y4, y5, y6, y7 );
 
-    /* Test unary ops */
+    /* Test arithmetic ops */
 
     WWL_TEST( wwl_neg(x), -x0, -x1, -x2, -x3, -x4, -x5, -x6, -x7 );
     WWL_TEST( wwl_abs(x), (long)fd_long_abs(x0), (long)fd_long_abs(x1), (long)fd_long_abs(x2), (long)fd_long_abs(x3),
@@ -125,7 +85,7 @@ main( int     argc,
                                ((long)(int)x4)*((long)(int)y4), ((long)(int)x5)*((long)(int)y5),
                                ((long)(int)x6)*((long)(int)y6), ((long)(int)x7)*((long)(int)y7) );
 
-    /* Test binary ops */
+    /* Test bit ops */
 
     i0 = y0 & 63L; i1 = y1 & 63L; i2 = y2 & 63L; i3 = y3 & 63L; i4 = y4 & 63L; i5 = y5 & 63L; i6 = y6 & 63L; i7 = y7 & 63L;
     i = wwl( i0, i1, i2, i3, i4, i5, i6, i7 );
@@ -202,7 +162,9 @@ main( int     argc,
 
     /* Test conversions */
 
-    WWV_TEST( wwl_to_wwv(x), (ulong)x0, (ulong)x1, (ulong)x2, (ulong)x3, (ulong)x4, (ulong)x5, (ulong)x6, (ulong)x7 );
+    WWI_TEST( wwl_to_wwi(x),  (int)x0,0,  (int)x1,0,  (int)x2,0,  (int)x3,0,  (int)x4,0,  (int)x5,0,  (int)x6,0,  (int)x7,0 );
+    WWU_TEST( wwl_to_wwu(x), (uint)x0,0, (uint)x1,0, (uint)x2,0, (uint)x3,0, (uint)x4,0, (uint)x5,0, (uint)x6,0, (uint)x7,0 );
+    WWV_TEST( wwl_to_wwv(x), (ulong)x0,  (ulong)x1,  (ulong)x2,  (ulong)x3,  (ulong)x4,  (ulong)x5,  (ulong)x6,  (ulong)x7  );
 
     /* Test misc operations */
 
@@ -231,6 +193,9 @@ main( int     argc,
     WWL_TEST( wwl_slide( x, y, 5 ), x5,x6,x7,y0,y1,y2,y3,y4 );
     WWL_TEST( wwl_slide( x, y, 6 ), x6,x7,y0,y1,y2,y3,y4,y5 );
     WWL_TEST( wwl_slide( x, y, 7 ), x7,y0,y1,y2,y3,y4,y5,y6 );
+
+    wwl_unpack( x, t0,t1,t2,t3,t4,t5,t6,t7 );
+    WWL_TEST( wwl( t0,t1,t2,t3,t4,t5,t6,t7 ), x0,x1,x2,x3,x4,x5,x6,x7 );
 
     wwl_t r0 = x;            wwl_t r1 = y;            wwl_t r2 = z;            wwl_t r3 = t;
     wwl_t r4 = wwl_not( x ); wwl_t r5 = wwl_not( y ); wwl_t r6 = wwl_not( z ); wwl_t r7 = wwl_not( t );
@@ -309,7 +274,7 @@ main( int     argc,
     wwv_stu( _m+i0, y );
     WWV_TEST( wwv_ldu( _m+i0 ), y0, y1, y2, y3, y4, y5, y6, y7 );
 
-    /* Test unary ops */
+    /* Test arithmetic ops */
 
     WWV_TEST( wwv_neg(x), -x0, -x1, -x2, -x3, -x4, -x5, -x6, -x7 );
     WWV_TEST( wwv_abs(x),  x0,  x1,  x2,  x3,  x4,  x5,  x6,  x7 );
@@ -326,7 +291,7 @@ main( int     argc,
                                ((ulong)(uint)x4)*((ulong)(uint)y4), ((ulong)(uint)x5)*((ulong)(uint)y5),
                                ((ulong)(uint)x6)*((ulong)(uint)y6), ((ulong)(uint)x7)*((ulong)(uint)y7) );
 
-    /* Test binary ops */
+    /* Test bit ops */
 
     i0 = y0 & 63UL; i1 = y1 & 63UL; i2 = y2 & 63UL; i3 = y3 & 63UL; i4 = y4 & 63UL; i5 = y5 & 63UL; i6 = y6 & 63UL; i7 = y7 & 63UL;
     i = wwv( i0, i1, i2, i3, i4, i5, i6, i7 );
@@ -399,7 +364,9 @@ main( int     argc,
 
     /* Test conversions */
 
-    WWL_TEST( wwv_to_wwl(x), (long)x0, (long)x1, (long)x2, (long)x3, (long)x4, (long)x5, (long)x6, (long)x7 );
+    WWI_TEST( wwl_to_wwi(x),  (int)x0,0,  (int)x1,0,  (int)x2,0,  (int)x3,0,  (int)x4,0,  (int)x5,0,  (int)x6,0,  (int)x7,0 );
+    WWU_TEST( wwl_to_wwu(x), (uint)x0,0, (uint)x1,0, (uint)x2,0, (uint)x3,0, (uint)x4,0, (uint)x5,0, (uint)x6,0, (uint)x7,0 );
+    WWV_TEST( wwl_to_wwv(x), (ulong)x0,  (ulong)x1,  (ulong)x2,  (ulong)x3,  (ulong)x4,  (ulong)x5,  (ulong)x6,  (ulong)x7  );
 
     /* Test misc operations */
 
@@ -428,6 +395,9 @@ main( int     argc,
     WWV_TEST( wwv_slide( x, y, 5 ), x5,x6,x7,y0,y1,y2,y3,y4 );
     WWV_TEST( wwv_slide( x, y, 6 ), x6,x7,y0,y1,y2,y3,y4,y5 );
     WWV_TEST( wwv_slide( x, y, 7 ), x7,y0,y1,y2,y3,y4,y5,y6 );
+
+    wwv_unpack( x, t0,t1,t2,t3,t4,t5,t6,t7 );
+    WWV_TEST( wwv( t0,t1,t2,t3,t4,t5,t6,t7 ), x0,x1,x2,x3,x4,x5,x6,x7 );
 
     wwv_t r0 = x;            wwv_t r1 = y;            wwv_t r2 = z;            wwv_t r3 = t;
     wwv_t r4 = wwv_not( x ); wwv_t r5 = wwv_not( y ); wwv_t r6 = wwv_not( z ); wwv_t r7 = wwv_not( t );

--- a/src/util/simd/test_avx512_8x64.c
+++ b/src/util/simd/test_avx512_8x64.c
@@ -364,9 +364,9 @@ main( int     argc,
 
     /* Test conversions */
 
-    WWI_TEST( wwl_to_wwi(x),  (int)x0,0,  (int)x1,0,  (int)x2,0,  (int)x3,0,  (int)x4,0,  (int)x5,0,  (int)x6,0,  (int)x7,0 );
-    WWU_TEST( wwl_to_wwu(x), (uint)x0,0, (uint)x1,0, (uint)x2,0, (uint)x3,0, (uint)x4,0, (uint)x5,0, (uint)x6,0, (uint)x7,0 );
-    WWV_TEST( wwl_to_wwv(x), (ulong)x0,  (ulong)x1,  (ulong)x2,  (ulong)x3,  (ulong)x4,  (ulong)x5,  (ulong)x6,  (ulong)x7  );
+    WWI_TEST( wwv_to_wwi(x),  (int)x0,0,  (int)x1,0,  (int)x2,0,  (int)x3,0,  (int)x4,0,  (int)x5,0,  (int)x6,0,  (int)x7,0 );
+    WWU_TEST( wwv_to_wwu(x), (uint)x0,0, (uint)x1,0, (uint)x2,0, (uint)x3,0, (uint)x4,0, (uint)x5,0, (uint)x6,0, (uint)x7,0 );
+    WWL_TEST( wwv_to_wwl(x), (long)x0,   (long)x1,   (long)x2,   (long)x3,   (long)x4,   (long)x5,   (long)x6,   (long)x7   );
 
     /* Test misc operations */
 

--- a/src/util/tmpl/fd_map_dynamic.c
+++ b/src/util/tmpl/fd_map_dynamic.c
@@ -76,8 +76,8 @@
     ulong mymap_slot_idx( mymap_t const * map, mymap_t const * slot );
 
     // Returns the "null" key, which is the canonical key that will
-    // never be inserted (typically zero). 
-    
+    // never be inserted (typically zero).
+
     ulong mymap_key_null( void ); // == MAP_KEY_NULL
 
     // Return the 1/0 if key is a key that will never/might be inserted.
@@ -90,9 +90,9 @@
 
     // Return the hash of key used by the map.  Should ideally be a
     // random mapping from MAP_KEY_T -> MAP_HASH_T.
-    
+
     uint mymap_key_hash( ulong key );
-    
+
     // Insert key into the map, fast O(1).  Returns a pointer to the map
     // entry with key on success and NULL on failure (i.e. key is
     // already in the map or there are too many keys in the map to
@@ -140,7 +140,7 @@
     mymap_t * slot = mymap_insert( map, cxx_key );
     if( FD_UNLIKELY( !slot ) ) ... handle failure (cxx_key was not moved)
     else {
-      ... mymap_insert did a MAP_KEY_MOVE of cxx_key into slot->key 
+      ... mymap_insert did a MAP_KEY_MOVE of cxx_key into slot->key
       ... clean cxx_key's shell here as necessary here
       ... initialize other slot fields as necessary
     }
@@ -337,7 +337,7 @@ MAP_(new)( void *  shmem,
 
   MAP_T * slot = map->slot; FD_COMPILER_FORGET( slot );
 
-  for( ulong slot_idx=0UL; slot_idx<slot_cnt; slot_idx++ ) 
+  for( ulong slot_idx=0UL; slot_idx<slot_cnt; slot_idx++ )
     slot[ slot_idx ].MAP_KEY = (MAP_KEY_NULL);
 
   return map;
@@ -353,10 +353,10 @@ MAP_(join)( void * shmap ) {
 static inline void * MAP_(leave) ( MAP_T * slot  ) { return (void *)MAP_(private_from_slot)( slot ); }
 static inline void * MAP_(delete)( void *  shmap ) { return shmap; }
 
-FD_FN_PURE  static inline ulong MAP_(key_cnt)    ( MAP_T const * slot ) { return MAP_(private_from_slot_const)( slot )->key_cnt;       }
-FD_FN_CONST static inline ulong MAP_(key_max)    ( MAP_T const * slot ) { return MAP_(private_from_slot_const)( slot )->slot_mask;     }
-FD_FN_CONST static inline int   MAP_(lg_slot_cnt)( MAP_T const * slot ) { return MAP_(private_from_slot_const)( slot )->lg_slot_cnt;   }
-FD_FN_CONST static inline ulong MAP_(slot_cnt)   ( MAP_T const * slot ) { return MAP_(private_from_slot_const)( slot )->slot_mask+1UL; }
+FD_FN_PURE static inline ulong MAP_(key_cnt)    ( MAP_T const * slot ) { return MAP_(private_from_slot_const)( slot )->key_cnt;       }
+FD_FN_PURE static inline ulong MAP_(key_max)    ( MAP_T const * slot ) { return MAP_(private_from_slot_const)( slot )->slot_mask;     }
+FD_FN_PURE static inline int   MAP_(lg_slot_cnt)( MAP_T const * slot ) { return MAP_(private_from_slot_const)( slot )->lg_slot_cnt;   }
+FD_FN_PURE static inline ulong MAP_(slot_cnt)   ( MAP_T const * slot ) { return MAP_(private_from_slot_const)( slot )->slot_mask+1UL; }
 
 FD_FN_CONST static inline ulong MAP_(slot_idx)( MAP_T const * map, MAP_T const * entry ) { return (ulong)(entry - map); }
 
@@ -458,7 +458,7 @@ MAP_(clear)( MAP_T * map ) {
   MAP_(private_t) * hdr = MAP_(private_from_slot)( map );
   ulong slot_cnt  = 1UL<<hdr->lg_slot_cnt;
   MAP_T * slot = hdr->slot;
-  for( ulong slot_idx=0UL; slot_idx<slot_cnt; slot_idx++ ) 
+  for( ulong slot_idx=0UL; slot_idx<slot_cnt; slot_idx++ )
     slot[ slot_idx ].MAP_KEY = (MAP_KEY_NULL);
 }
 
@@ -525,4 +525,3 @@ FD_PROTOTYPES_END
 #undef MAP_HASH_T
 #undef MAP_T
 #undef MAP_NAME
-

--- a/src/util/tmpl/fd_map_giant.c
+++ b/src/util/tmpl/fd_map_giant.c
@@ -109,7 +109,7 @@
     //
     // Critically, as this is used in high performance contexts where
     // the application already knows this, THE CALLER PROMISES THE KEY
-    // IS NOT IN THE MAP AND THAT THE MAP HAS SPACE FOR KEY. 
+    // IS NOT IN THE MAP AND THAT THE MAP HAS SPACE FOR KEY.
     //
     // This always succeeds (with the above requirements) and returns
     // non NULL.
@@ -190,7 +190,7 @@
 
     // mymap_verify returns 0 if the mymap is not obviously corrupt or a
     // -1 (i.e. ERR_INVAL) if it is obviously corrupt (logs details).
-    // join is the handle of a current local join to mymap.  
+    // join is the handle of a current local join to mymap.
 
     int mymap_verify( mymap_t const * join );
 
@@ -348,12 +348,12 @@ MAP_(private_const)( MAP_T const * join ) {
    address space of the map lists and elements.  The _const variants are
    for const correctness.  Assumes map is valid. */
 
-FD_FN_CONST static inline ulong *
+FD_FN_PURE static inline ulong *
 MAP_(private_list)( MAP_(private_t) * map ) {
   return ((ulong *)map) - map->list_cnt;
 }
 
-FD_FN_CONST static inline ulong const *
+FD_FN_PURE static inline ulong const *
 MAP_(private_list_const)( MAP_(private_t) const * map ) {
   return ((ulong const *)map) - map->list_cnt;
 }
@@ -527,7 +527,7 @@ MAP_(footprint)( ulong key_max ) {
   /* memory layout is:
 
        2 ulong | pad | list_cnt ulong | map_private_t | key_max map_t | pad
-       <------ meta_footprint, align multiple ------> 
+       <------ meta_footprint, align multiple ------>
        <------------------ footprint, align multiple -------------------->
 
      Noting that list_cnt is in [key_max/2,key_max], footprint is
@@ -581,7 +581,7 @@ MAP_(new)( void * shmem,
   map->seed     = seed;
   map->list_cnt = list_cnt;
   map->key_cnt  = 0UL;
-  
+
   /* Init the free stack */
 
   if( FD_UNLIKELY( !key_max ) ) map->free_stack = MAP_(private_box_next)( MAP_IDX_NULL, 1 );
@@ -709,7 +709,7 @@ MAP_(remove)( MAP_T *           join,
       *cur = ele->MAP_NEXT; /* already tagged empty */
       ele->MAP_NEXT = map->free_stack; /* already tagged free */
       map->free_stack = MAP_(private_box_next)( ele_idx, 1 );
-      map->key_cnt--; 
+      map->key_cnt--;
       return ele;
     }
     cur = &ele->MAP_NEXT; /* Retain the pointer to next so we can rewrite it later. */
@@ -868,4 +868,3 @@ MAP_(verify)( MAP_T const * join ) {
 #undef MAP_KEY_T
 #undef MAP_T
 #undef MAP_NAME
-

--- a/src/util/tmpl/fd_pool.c
+++ b/src/util/tmpl/fd_pool.c
@@ -152,7 +152,7 @@
 
 #ifndef POOL_SENTINEL
 #define POOL_SENTINEL 0
-#endif  
+#endif
 
 /* POOL_MAGIC is the magic number that should be used to identify
    pools of this type in shared memory.  Should be non-zero. */
@@ -321,14 +321,14 @@ FD_FN_CONST static inline POOL_T const * POOL_(ele_sentinel_const)( POOL_T const
 
 /* Address space conversion */
 
-FD_FN_CONST static inline int
+FD_FN_PURE static inline int
 POOL_(idx_test)( POOL_T const * join,
                  ulong          idx ) {
   ulong max = POOL_(private_meta_const)( join )->max;
   return (idx<max) | (idx==POOL_IDX_NULL);
 }
 
-FD_FN_CONST static inline int
+FD_FN_PURE static inline int
 POOL_(ele_test)( POOL_T const * join,
                  POOL_T const * ele ) {
   ulong max = POOL_(private_meta_const)( join )->max;
@@ -410,4 +410,3 @@ FD_PROTOTYPES_END
 #undef POOL_NEXT
 #undef POOL_T
 #undef POOL_NAME
-


### PR DESCRIPTION
As mentioned in PR #760, here is the accelerated SHA-256 version.  On a 2.3 GHz Icelake server core with turbo disabled (same one mentioned previously for AVX-512 accelerated SHA-512 and ED25519), quick and dirty benchmarks saw a large batch asymptotic Ethernet equivalent bandwidth processing rate of:
```
impl      | small msg | large msg
----------+-----------+----------
portable  |  1.8 Gbps |  1.4 Gbps
shani     |  6.4 Gbps |  7.0 Gbps
avx       |  9.4 Gbps |  8.7 Gbps * same asymptotic w shani
avx512    | 18.9 Gbps | 18.4 Gbps * same asymptotic w shani
```
As before, the small message size was 14 bytes (i.e. a maximum UDP payload of a minimal Ethernet frame holding a UDP/IP4/VLAN/Ethernet packet) and the large message size was 1472 bytes (i.e. a maximum UDP payload of a non-Jumbo 1500 byte MTU Ethernet frame holding a UDP/IP4/VLAN/Ethernet packet).  

This is based on and extends the AVX-512 support added recently for faster SHA-512 hashing and ED25519 signature verification.  Included here are lower level APIs necessary (e.g. 16-wide vector uint support) and some minor cleanups that ended up easier to include here than separate out into additional PRs (most notably, a function attribute linting pass).  At this point, there is very good coverage for accelerated 16-wide vector int / uint and 8-wide vector long / ulong operations.

This implementation is a turn-the-crank widened version of the existing AVX implementation with some additional streamlining to take advantage of AVX-512 support for vector lane masks and the SHA-256 header was also tweaked to make it easier to switch implementations at compile time and/or in individual translation units without needing to change build targets.

As per the "same asymptotic comment" above, for small enough batches, this will fall back on the serial SHA-NI implementation when available and faster.

That is, the batch implementations (i.e. GPU style data parallel using generic vector operations) are _much_ _faster_ asymptotically than the SHA-NI based implementation (i.e. take silicon away that could have been used for more cores and use it to try to overcome the "never met a sequential dependency I didn't like" design philosophy pervasive in crypto protocols).

While this might seem surprising, it's usually much easier to do N independent tasks that each take time T in parallel than it is to do one of the tasks in time T/N, even when you throw custom hardware at it.  This is a real world example the that compute-constrained serial mindset taught in schools and reinforced by languages and tooling is completely misaligned with our massively-parallel speed-of-light constrained reality.  (Better still would be to stop designing cryptographic protocols as though computers are just fast Turing tape machines and instead design them for machines buildable in a universe with a finite speed of light ... but we make do with what we have.)

TL;DR

AVX-512 accelerated batch SHA-256 is ~11x-12x faster than the existing portable implementation, ~2.6x-3.0x faster than the existing SHA-NI accelerated implementation and ~2.0x faster than the existing AVX accelerated batch implementation per core for large numbers of similar sized messages.  YMMV.