### PR TITLE
wksp: add compile time option to avoid lock reclamation

### DIFF
--- a/config/base.mk
+++ b/config/base.mk
@@ -1,7 +1,7 @@
 BASEDIR?=build
 
 SHELL:=bash
-CPPFLAGS:=-isystem ./opt/include -DFD_LOG_UNCLEAN_EXIT=1
+CPPFLAGS:=-isystem ./opt/include -DFD_LOG_UNCLEAN_EXIT=1 -DFD_WKSP_NO_LOCK_RECLAIM=1
 CC:=gcc
 CFLAGS:=-std=c17
 CXX:=g++


### PR DESCRIPTION
This doesn't make sense within the sandbox, we cannot see or check if another process is alive, and all processes have a PID of 0 anyway since they are within their own PID namespace. The operating model of Firedancer will bring all processes down together if one of them crashes so it's OK to just not run this logic.