### PR TITLE
Fuzzers for base58/base64/hex encoders/decoders in ballet

### DIFF
--- a/src/ballet/base58/Local.mk
+++ b/src/ballet/base58/Local.mk
@@ -1,3 +1,4 @@
 $(call add-hdrs,fd_base58.h)
 $(call add-objs,fd_base58,fd_ballet)
 $(call make-unit-test,test_base58,test_base58,fd_ballet fd_util)
+$(call fuzz-test,fuzz_base58,fuzz_base58,fd_ballet fd_util)

--- a/src/ballet/base58/fuzz_base58.c
+++ b/src/ballet/base58/fuzz_base58.c
@@ -1,0 +1,58 @@
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../util/fd_util.h"
+#include "fd_base58.h"
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  /* Set up shell without signal handlers */
+  putenv( "FD_LOG_BACKTRACE=0" );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+  return 0;
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         size ) {
+  if( FD_UNLIKELY( size < 64UL ) ) return -1;
+
+  #define MAKE_FUZZ_TEST(n)                                                                 \
+  ulong len##n;                                                                             \
+  char  enc##n        [ FD_BASE58_ENCODED_##n##_SZ ];                                       \
+  char  enc##n##_nolen[ FD_BASE58_ENCODED_##n##_SZ ];                                       \
+  uchar dec##n        [ n ];                                                                \
+  if( FD_UNLIKELY( fd_base58_encode_##n( data, &len##n, enc##n )!=enc##n ) ) {              \
+    __builtin_trap();                                                                       \
+  }                                                                                         \
+  if( FD_UNLIKELY( strlen( enc##n )!=len##n ) ) {                                           \
+    __builtin_trap();                                                                       \
+  }                                                                                         \
+  if( FD_UNLIKELY( len##n<n##UL || len##n>FD_BASE58_ENCODED_##n##_LEN ) ) {                 \
+    __builtin_trap();                                                                       \
+  }                                                                                         \
+  if( FD_UNLIKELY( fd_base58_decode_##n( enc##n, dec##n )!=dec##n ) ) {                     \
+    __builtin_trap();                                                                       \
+  }                                                                                         \
+  if( FD_UNLIKELY( memcmp( dec##n, data, n##UL ) ) ) {                                      \
+    __builtin_trap();                                                                       \
+  }                                                                                         \
+  if( FD_UNLIKELY( fd_base58_encode_##n( data, NULL, enc##n##_nolen )!=enc##n##_nolen ) ) { \
+    __builtin_trap();                                                                       \
+  }                                                                                         \
+  if( FD_UNLIKELY( strcmp( enc##n##_nolen, enc##n ) ) ) {                                   \
+    __builtin_trap();                                                                       \
+  }
+
+  MAKE_FUZZ_TEST(32)
+  MAKE_FUZZ_TEST(64)
+  #undef MAKE_FUZZ_TEST
+
+  return 0;
+}

--- a/src/ballet/base64/Local.mk
+++ b/src/ballet/base64/Local.mk
@@ -1,3 +1,4 @@
 $(call add-hdrs,fd_base64.h)
 $(call add-objs,fd_base64,fd_ballet)
 $(call make-unit-test,test_base64,test_base64,fd_ballet fd_util)
+$(call fuzz-test,fuzz_base64,fuzz_base64,fd_ballet fd_util)

--- a/src/ballet/base64/fuzz_base64.c
+++ b/src/ballet/base64/fuzz_base64.c
@@ -1,0 +1,49 @@
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../util/fd_util.h"
+#include "fd_base64.h"
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  /* Set up shell without signal handlers */
+  putenv( "FD_LOG_BACKTRACE=0" );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+  return 0;
+}
+
+#define get_encoded_len(bytes) ( ( ( ( bytes*4UL + 2UL) / 3UL ) + 3UL ) & ~3UL )
+#define MAX_DATA_SZ 4096UL
+#define MAX_ENCODED_SZ ( get_encoded_len( MAX_DATA_SZ )+1UL )
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         size ) {
+  if( FD_UNLIKELY( size > MAX_DATA_SZ ) ) return -1;
+
+  char encoded[ MAX_ENCODED_SZ ];
+  ulong encoded_len = fd_base64_encode( data, (int) size, encoded );
+  if( FD_UNLIKELY( encoded_len!=get_encoded_len(size) ) ) {
+    __builtin_trap();
+  }
+
+  uchar decoded[ MAX_DATA_SZ ];
+  int decoded_sz = fd_base64_decode( encoded, decoded );
+  if( FD_UNLIKELY( decoded_sz<0 ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( ( ( ulong ) decoded_sz )!=size ) ) {
+    __builtin_trap();
+  }
+  if( FD_UNLIKELY( memcmp( decoded, data, size ) ) ) {
+    __builtin_trap();
+  }
+
+  return 0;
+}

--- a/src/ballet/hex/Local.mk
+++ b/src/ballet/hex/Local.mk
@@ -1,2 +1,3 @@
 $(call add-hdrs,fd_hex.h)
 $(call add-objs,fd_hex,fd_ballet)
+$(call fuzz-test,fuzz_hex,fuzz_hex,fd_ballet fd_util)

--- a/src/ballet/hex/fuzz_hex.c
+++ b/src/ballet/hex/fuzz_hex.c
@@ -1,0 +1,55 @@
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../util/fd_util.h"
+#include "fd_hex.h"
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  /* Set up shell without signal handlers */
+  putenv( "FD_LOG_BACKTRACE=0" );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+  return 0;
+}
+
+// checks if given encoding of sz chars is valid, sz must be even
+// returns sz on success, index of first invalid char on failure
+static inline ulong
+check_hex_encoding( char const * enc, ulong sz  ) {
+  ulong i;
+  for( i=0; i<sz; i++ ) {
+    char c = enc[i];
+    if( c>='0' && c<='9' ) continue;
+    if( c>='a' && c<='f' ) continue;
+    if( c>='A' && c<='F' ) continue;
+    return i;
+  }
+  return sz;
+}
+
+#define MAX_DATA_SZ 4096UL
+#define MAX_DECODED_SZ ( MAX_DATA_SZ / 2UL )
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         size ) {
+  if( FD_UNLIKELY( size > MAX_DATA_SZ ) ) return -1;
+  char const * encoded = ( char  const * ) data;
+
+  size = size & ~1UL; // ignore last char of encoding if size is odd
+
+  uchar decoded[ MAX_DECODED_SZ ];
+  ulong decoded_sz = fd_hex_decode( decoded, encoded, size/2UL );
+
+  if( FD_UNLIKELY( decoded_sz!=( check_hex_encoding( encoded, size )/2UL ) ) ) {
+    __builtin_trap();
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This PR adds fuzzers for the encoders/decoders found in `ballet`:
- `base58`
- `base64`
- `hex`