### PR TITLE
Build fixes for minimal config

### DIFF
--- a/src/ballet/pack/fd_est_tbl.h
+++ b/src/ballet/pack/fd_est_tbl.h
@@ -3,6 +3,7 @@
 
 #include "../fd_ballet_base.h"
 
+#if FD_HAS_DOUBLE
 
 /* This header defines a data structure for estimating the sliding-window mean
    and variance of tagged data.  It takes in real-valued input, with each value
@@ -182,5 +183,7 @@ fd_est_tbl_update( fd_est_tbl_t * tbl,
   bin->d  = 1.0         +   C*bin->d ; /* Can't go denormal */
   bin->d2 = 1.0         + C*C*bin->d2; /* Can't go denormal */
 }
+
+#endif /* FD_HAS_DOUBLE */
 
 #endif /* HEADER_fd_src_ballet_pack_fd_est_tbl_h */

--- a/src/ballet/x509/Local.mk
+++ b/src/ballet/x509/Local.mk
@@ -1,2 +1,4 @@
+ifdef FD_HAS_OPENSSL
 $(call add-hdrs,fd_x509.h)
 $(call add-objs,fd_x509,fd_ballet)
+endif

--- a/src/disco/mux/Local.mk
+++ b/src/disco/mux/Local.mk
@@ -1,3 +1,4 @@
+ifdef FD_HAS_SSE
 $(call add-hdrs,fd_mux.h)
 $(call add-objs,fd_mux,fd_disco)
 $(call make-unit-test,test_mux,test_mux,fd_disco fd_tango fd_util)
@@ -5,4 +6,4 @@ $(call make-unit-test,test_mux,test_mux,fd_disco fd_tango fd_util)
 # Order in add-test-script is important as it dictates the run order.
 $(call add-test-scripts,test_mux_ipc_init test_mux_ipc_meta test_mux_ipc_full test_mux_ipc_fini)
 $(call make-bin,fd_mux_tile,fd_mux_tile,fd_disco fd_tango fd_util)
-
+endif

--- a/src/disco/shred/Local.mk
+++ b/src/disco/shred/Local.mk
@@ -1,3 +1,4 @@
+ifdef FD_HAS_INT128
 $(call add-objs,fd_shred_dest,fd_disco)
 $(call add-objs,fd_shredder,fd_disco)
 $(call add-objs,fd_fec_resolver,fd_disco)
@@ -7,3 +8,4 @@ $(call make-unit-test,test_fec_resolver,test_fec_resolver,fd_ballet fd_util fd_t
 $(call run-unit-test,test_shred_dest,)
 $(call run-unit-test,test_shredder,)
 $(call run-unit-test,test_fec_resolver,)
+endif

--- a/src/flamenco/types/fd_bincode.h
+++ b/src/flamenco/types/fd_bincode.h
@@ -44,6 +44,8 @@ typedef struct fd_bincode_destroy_ctx fd_bincode_destroy_ctx_t;
 #define FD_BINCODE_ERR_SMALL_DEQUE -4 /* deque max size is too small */
 #define FD_BINCODE_ERR_ALLOC -5
 
+#if FD_HAS_INT128
+
 static inline int
 fd_bincode_uint128_decode(uint128 * self, fd_bincode_decode_ctx_t * ctx) {
   const uint128 * ptr = (const uint128 *) ctx->data;
@@ -67,6 +69,8 @@ fd_bincode_uint128_encode(uint128 const * self, fd_bincode_encode_ctx_t * ctx) {
 
   return FD_BINCODE_SUCCESS;
 }
+
+#endif /* FD_HAS_INT128 */
 
 static inline int
 fd_bincode_uint64_decode( ulong *                   self,


### PR DESCRIPTION
Many recent PRs have caused main to not compile with non-x86 build targets. (Such as linux_gcc_minimal).

Our current policy is preserve the ability to compile main on lesser featured targets, such as environments without 128-bit or floating point support. We do this by disabling code that uses features that the target machine does not support.