### PR TITLE
fix --faucet-lamports parsing used in genesis creation

### DIFF
--- a/src/app/fddev/configure/genesis.c
+++ b/src/app/fddev/configure/genesis.c
@@ -26,10 +26,10 @@ init( config_t * const config ) {
   uint idx = 0;
   char * argv[ 128 ];
   uint bufidx = 0;
-  char buffer[ 32 ][ 16 ];
+  char buffer[ 32 ][ 24 ];
 #define ADD1( arg ) do { argv[ idx++ ] = arg; } while( 0 )
 #define ADD( arg, val ) do { argv[ idx++ ] = arg; argv[ idx++ ] = val; } while( 0 )
-#define ADDU( arg, val ) do { argv[ idx++ ] = arg; snprintf1( buffer[ bufidx ], 16, "%u", val ); argv[ idx++ ] = buffer[ bufidx++ ]; } while( 0 )
+#define ADDU( arg, val ) do { argv[ idx++ ] = arg; snprintf1( buffer[ bufidx ], 24, "%lu", val ); argv[ idx++ ] = buffer[ bufidx++ ]; } while( 0 )
 
   char faucet[ PATH_MAX ];
   snprintf1( faucet, PATH_MAX, "%s/faucet.json", config->scratch_directory );


### PR DESCRIPTION
```
llamb@emfr-ossdev-firedancer14> cat no-lu-buffer-too-small.c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

int main() {
	char buf[16];
	snprintf(buf, sizeof(buf), "%u", 500000000000000000UL);
	printf("%s\n", buf);
}
llamb@emfr-ossdev-firedancer14> gcc no-lu-buffer-too-small.c && ./a.out
3551657984
llamb@emfr-ossdev-firedancer14> cat buffer-too-small.c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

int main() {
	char buf[16];
	snprintf(buf, sizeof(buf), "%lu", 500000000000000000UL);
	printf("%s\n", buf);
}
llamb@emfr-ossdev-firedancer14> gcc buffer-too-small.c && ./a.out
500000000000000
llamb@emfr-ossdev-firedancer14> cat lu-and-buffer-big-enough.c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

int main() {
	char buf[24];
	snprintf(buf, sizeof(buf), "%lu", 500000000000000000UL);
	printf("%s\n", buf);
}
llamb@emfr-ossdev-firedancer14> gcc lu-and-buffer-big-enough.c && ./a.out
500000000000000000
```