### PR TITLE
fix some port traffic related issues

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -686,6 +686,13 @@ validate_ports( config_t * result ) {
                  "This must be outside the dynamic port range `%s`",
                  result->tiles.quic.quic_transaction_listen_port,
                  result->dynamic_port_range ));
+
+  if( FD_UNLIKELY( result->tiles.shred.shred_listen_port >= solana_port_min &&
+                   result->tiles.shred.shred_listen_port < solana_port_max ) )
+    FD_LOG_ERR(( "configuration specifies invalid [tiles.shred.shred_listen_port] `%hu`. "
+                 "This must be outside the dynamic port range `%s`",
+                 result->tiles.shred.shred_listen_port,
+                 result->dynamic_port_range ));
 }
 
 config_t

--- a/src/app/fdctl/configure/workspace.c
+++ b/src/app/fdctl/configure/workspace.c
@@ -344,6 +344,9 @@ init( config_t * const config ) {
             fd_wksp_unmap( lo_shmem );
           }
         }
+        ushort1( pod, "transaction_listen_port",      config->tiles.quic.regular_transaction_listen_port, 0 );
+        ushort1( pod, "quic_transaction_listen_port", config->tiles.quic.quic_transaction_listen_port,    0 );
+        ushort1( pod, "shred_listen_port",            config->tiles.shred.shred_listen_port,              0 );
         break;
       case wksp_netmux:
         cnc   ( pod, "cnc" );

--- a/src/app/fdctl/run/tiles/net.c
+++ b/src/app/fdctl/run/tiles/net.c
@@ -45,6 +45,12 @@ run( fd_tile_args_t * args ) {
   ulong cnt = fd_pod_query_ulong( mux_pod, "net-cnt", 0UL );
   if( FD_UNLIKELY( !cnt ) ) FD_LOG_ERR(( "net-cnt not set" ));
 
+  ushort allow_ports[ FD_NET_ALLOW_PORT_CNT ] = {
+    fd_pod_query_ushort( tile_pod, "transaction_listen_port",      0 ),
+    fd_pod_query_ushort( tile_pod, "quic_transaction_listen_port", 0 ),
+    fd_pod_query_ushort( tile_pod, "shred_listen_port",            0 )
+  };
+
   fd_rng_t _rng[ 1 ];
   fd_net_tile( fd_cnc_join( fd_wksp_pod_map1( tile_pod, "cnc%lu", args->tile_idx ) ),
                (ulong)args->pid,
@@ -59,6 +65,7 @@ run( fd_tile_args_t * args ) {
                fd_dcache_join( fd_wksp_pod_map1( mux_pod, "net-out-dcache%lu", args->tile_idx ) ),
                0,
                0,
+               allow_ports,
                fd_rng_join( fd_rng_new( _rng, 0, 0UL ) ),
                fd_alloca( FD_NET_TILE_SCRATCH_ALIGN, FD_NET_TILE_SCRATCH_FOOTPRINT( 1, 0 ) ) );
 }

--- a/src/app/fdctl/run/tiles/shred.c
+++ b/src/app/fdctl/run/tiles/shred.c
@@ -112,7 +112,7 @@ run( fd_tile_args_t * tile_args ) {
   fd_wksp_t * net_shred_wksp = fd_wksp_containing( net_shred_pod );
   if( FD_UNLIKELY( !net_shred_wksp ) ) FD_LOG_ERR(( "fd_wksp_containing( net_shred_pod ) failed." ));
   args.from_net_chunk0 = fd_disco_compact_chunk0( net_shred_wksp );
-  args.from_net_wmark  = fd_disco_compact_chunk0( net_shred_wksp );
+  args.from_net_wmark  = fd_disco_compact_wmark( net_shred_wksp, FD_NET_MTU );
 
   args.bank_shred_wksp = bank_shred_wksp;
 

--- a/src/disco/net/fd_net.c
+++ b/src/disco/net/fd_net.c
@@ -15,6 +15,8 @@ typedef struct {
 
   fd_mux_context_t * mux;
 
+  ushort allow_ports[ FD_NET_ALLOW_PORT_CNT ];
+
   void * in_wksp;
   ulong  in_chunk0;
   ulong  in_wmark;
@@ -71,13 +73,21 @@ net_rx_aio_send( void *                    _ctx,
     if( FD_UNLIKELY( udp+8U > packet_end ) ) continue;
 
     /* Extract IP dest addr and UDP dest port */
-    uint ip_srcaddr    = *(uint   *)( iphdr+12UL );
-    ushort udp_dstport = *(ushort *)( udp+2UL    );
+    uint ip_srcaddr    =                  *(uint   *)( iphdr+12UL );
+    ushort udp_dstport = fd_ushort_bswap( *(ushort *)( udp+2UL    ) );
+
+    int allow_port = 0;
+    for( ulong i=0UL; i<FD_NET_ALLOW_PORT_CNT; i++ ) allow_port |= udp_dstport==ctx->allow_ports[ i ];
+    if( FD_UNLIKELY( !allow_port ) )
+      FD_LOG_ERR(( "Firedancer received a UDP packet on port %hu which was not expected. "
+                   "Only ports %hu, %hu, and %hu should be configured to forward packets. Do "
+                   "you need to reload the XDP program?",
+                 udp_dstport, ctx->allow_ports[ 0 ], ctx->allow_ports[ 1 ], ctx->allow_ports[ 2 ] ));
 
     fd_memcpy( fd_chunk_to_laddr( ctx->out_wksp, ctx->out_chunk ), packet, batch[i].buf_sz );
 
     /* tile can decide how to partition based on src ip addr and port */
-    ulong sig = fd_disco_netmux_sig( ip_srcaddr, fd_ushort_bswap( udp_dstport ), 14UL+8UL+iplen, SRC_TILE_NET, 0 );
+    ulong sig = fd_disco_netmux_sig( ip_srcaddr, udp_dstport, 14UL+8UL+iplen, SRC_TILE_NET, 0 );
 
     ulong tspub  = (ulong)fd_frag_meta_ts_comp( fd_tickcount() );
     fd_mux_publish( ctx->mux, sig, ctx->out_chunk, batch[i].buf_sz, 0, 0, tspub );
@@ -178,6 +188,7 @@ fd_net_tile( fd_cnc_t *              cnc,
              uchar *                 dcache,
              ulong                   cr_max,
              long                    lazy,
+             ushort                  allow_ports[ static FD_NET_ALLOW_PORT_CNT ], /* indexed [0, allow_port_cnt) */
              fd_rng_t *              rng,
              void *                  scratch ) {
   fd_net_ctx_t ctx[1];
@@ -209,6 +220,11 @@ fd_net_tile( fd_cnc_t *              cnc,
     if( FD_UNLIKELY( round_robin_id >= round_robin_cnt ) ) { FD_LOG_WARNING(( "round_robin_id is too large" )); return 1; }
     ctx->round_robin_cnt = round_robin_cnt;
     ctx->round_robin_id  = round_robin_id;
+
+    for( ulong i=0UL; i<FD_NET_ALLOW_PORT_CNT; i++ ) {
+      if( FD_UNLIKELY( !allow_ports[ i ] ) ) FD_LOG_ERR(( "net tile listen port %lu was 0", i ));
+      ctx->allow_ports[ i ] = allow_ports[ i ];
+    }
 
     ctx->xsk_aio_cnt = xsk_aio_cnt;
     ctx->xsk_aio = xsk_aio;

--- a/src/disco/net/fd_net.h
+++ b/src/disco/net/fd_net.h
@@ -15,6 +15,11 @@
     FD_MUX_TILE_SCRATCH_ALIGN,   FD_MUX_TILE_SCRATCH_FOOTPRINT( in_cnt, out_cnt ) ),    \
     FD_VERIFY_TILE_SCRATCH_ALIGN )
 
+/* FD_NET_ALLOW_PORT_CNT specifies the number of UDP ports the net tile
+   recognizes.  If you update this, you also need to update the error
+   message if the related check fails. */
+#define FD_NET_ALLOW_PORT_CNT 3UL
+
 FD_PROTOTYPES_BEGIN
 
 int
@@ -31,6 +36,7 @@ fd_net_tile( fd_cnc_t *              cnc,                     /* Local join to t
              uchar *                 dcache,                  /* Local join to the quic's frag stream output dcache */
              ulong                   cr_max,                  /* Maximum number of flow control credits, 0 means use a reasonable default */
              long                    lazy,                    /* Lazyiness, <=0 means use a reasonable default */
+             ushort                  allow_ports[ static FD_NET_ALLOW_PORT_CNT ], /* The UDP ports to allow */
              fd_rng_t *              rng,                     /* Local join to the rng this quic should use */
              void *                  scratch );               /* Tile scratch memory */
 

--- a/src/disco/quic/fd_quic.c
+++ b/src/disco/quic/fd_quic.c
@@ -306,11 +306,10 @@ before_frag( void * _ctx,
   int handled_port = dst_port == ctx->legacy_transaction_port ||
                      dst_port == ctx->quic->config.net.listen_udp_port;
 
+  /* Ignore traffic e.g. for shred tile */
   if( FD_UNLIKELY( !handled_port ) ) {
-    FD_LOG_ERR(( "Firedancer received a UDP packet on port %hu which was not expected. "
-                 "Only ports %hu and %hu should be configured to forward packets. Do "
-                 "you need to reload the XDP program?",
-                 dst_port, ctx->quic->config.net.listen_udp_port, ctx->legacy_transaction_port ));
+    *opt_filter = 1;
+    return;
   }
 
   int handled_ip_address = (src_ip_addr % ctx->round_robin_cnt) == ctx->round_robin_id;


### PR DESCRIPTION
Range end was not getting set correctly resulting in:
```
ERR     10-19 20:15:38.662281 16     f0   shred src/disco/shred/fd_shred_tile.c(331): chunk 823780 1245 corrupt, not in range [16370,16370]
```

If some port, for e.g. shred port is set to 8003 and it is not in the range of handled_port, we were erroring out:
```
ERR     10-19 20:15:38.656524 6      f0   quic src/disco/quic/fd_quic.c(313): Firedancer received a UDP packet on port 8003 which was not expected. Only ports 9007 and 9001 should be configured to forward packets. Do you need to reload the XDP program?
```