### PR TITLE
disco/pack: Only pack when leader, and pack for a specific slot

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -507,7 +507,7 @@ topo_initialize( config_t * config ) {
   LINK( 1,                                FD_TOPO_LINK_KIND_DEDUP_TO_PACK,   FD_TOPO_WKSP_KIND_DEDUP_PACK,   config->tiles.verify.receive_buffer_size, FD_TPU_DCACHE_MTU,      1UL );
   /* FD_TOPO_LINK_KIND_GOSSIP_TO_PACK could be FD_TPU_MTU for now, since txns are not parsed, but better to just share one size for all the ins of pack */
   LINK( 1,                                FD_TOPO_LINK_KIND_GOSSIP_TO_PACK,  FD_TOPO_WKSP_KIND_DEDUP_PACK,   config->tiles.verify.receive_buffer_size, FD_TPU_DCACHE_MTU,      1UL );
-  LINK( 1,                                FD_TOPO_LINK_KIND_LSCHED_TO_PACK,  FD_TOPO_WKSP_KIND_DEDUP_PACK,   128UL,                                    16UL + 432000UL * 32UL, 1UL );
+  LINK( 1,                                FD_TOPO_LINK_KIND_LSCHED_TO_PACK,  FD_TOPO_WKSP_KIND_DEDUP_PACK,   128UL,                                    24UL + 432000UL * 32UL, 1UL );
   LINK( 1,                                FD_TOPO_LINK_KIND_PACK_TO_BANK,    FD_TOPO_WKSP_KIND_PACK_BANK,    128UL,                                    USHORT_MAX,             1UL );
   LINK( 1,                                FD_TOPO_LINK_KIND_POH_TO_SHRED,    FD_TOPO_WKSP_KIND_BANK_SHRED,   128UL,                                    USHORT_MAX,             1UL );
   /* See long comment in fd_shred_tile.c for an explanation about the size of this dcache. */
@@ -827,6 +827,7 @@ config_parse( int *    pargc,
       case FD_TOPO_TILE_KIND_PACK:
         tile->pack.max_pending_transactions = result.tiles.pack.max_pending_transactions;
         tile->pack.bank_tile_count = result.layout.bank_tile_count;
+        strncpy( tile->pack.identity_key_path, result.consensus.identity_path, sizeof(tile->pack.identity_key_path) );
         break;
       case FD_TOPO_TILE_KIND_BANK:
         break;

--- a/src/app/fdctl/run/tiles/fd_dedup.c
+++ b/src/app/fdctl/run/tiles/fd_dedup.c
@@ -103,11 +103,13 @@ during_frag( void * _ctx,
 
 static inline void
 after_frag( void *             _ctx,
+            ulong              in_idx,
             ulong *            opt_sig,
             ulong *            opt_chunk,
             ulong *            opt_sz,
             int   *            opt_filter,
             fd_mux_context_t * mux ) {
+  (void)in_idx;
   (void)mux;
 
   fd_dedup_ctx_t * ctx = (fd_dedup_ctx_t *)_ctx;

--- a/src/app/fdctl/run/tiles/fd_net.c
+++ b/src/app/fdctl/run/tiles/fd_net.c
@@ -197,11 +197,13 @@ during_frag( void * _ctx,
 
 static void
 after_frag( void *             _ctx,
+            ulong              in_idx,
             ulong *            opt_sig,
             ulong *            opt_chunk,
             ulong *            opt_sz,
             int *              opt_filter,
             fd_mux_context_t * mux ) {
+  (void)in_idx;
   (void)opt_sig;
   (void)opt_chunk;
   (void)opt_filter;

--- a/src/app/fdctl/run/tiles/fd_pack.c
+++ b/src/app/fdctl/run/tiles/fd_pack.c
@@ -10,6 +10,15 @@
    multiple microblocks can execute in parallel, if they don't
    write to the same accounts. */
 
+#define LSCHED_IN_IDX (2UL)
+
+#define MAX_SLOTS_PER_EPOCH          432000UL
+#define NUM_CONSECUTIVE_LEADER_SLOTS 4UL
+
+#define SET_NAME lsched_bitset
+#define SET_MAX ((MAX_SLOTS_PER_EPOCH)/(NUM_CONSECUTIVE_LEADER_SLOTS))
+#include "../../../../util/tmpl/fd_set.c"
+
 #define BLOCK_DURATION_NS (400UL*1000UL*1000UL)
 
 /* About 1.5 kB on the stack */
@@ -25,6 +34,14 @@ const ulong CUS_PER_MICROBLOCK = 1500000UL;
 
 const float VOTE_FRACTION = 0.75;
 
+struct bit_lsched {
+  ulong epoch;
+  ulong start_slot;
+  ulong slot_cnt;
+  lsched_bitset_t lsched[ lsched_bitset_word_cnt ];
+};
+typedef struct bit_lsched bit_lsched_t;
+
 typedef struct {
   fd_wksp_t * mem;
   ulong       chunk0;
@@ -33,10 +50,32 @@ typedef struct {
 
 typedef struct {
   fd_pack_t *  pack;
-  fd_txn_p_t * cur_slot;
+  fd_txn_p_t * cur_spot;
 
   long block_duration_ticks;
   long block_end;
+
+  fd_acct_addr_t identity_pubkey __attribute__((aligned(32UL)));
+
+  /* These point to memory, each which is written atomically by the PoH recorder */
+  ulong * _poh_slot;
+  ulong * _poh_reset_slot;
+  /* And these are our local copies, updated in the housekeeping loop to
+     limit cache ping-ponging. */
+  ulong poh_slot;
+  ulong poh_reset_slot;
+  int   poh_slots_updated;
+
+  ulong packing_for; /* The slot for which we are producing microblocks, or ULONG_MAX if we aren't leader. */
+
+  /* Keep two leader schedules around for the transition between epochs,
+     and a third for speculative processing.  The following three
+     pointers jump around between the three elements of _lsched as the
+     epochs progress. */
+  bit_lsched_t * even_epoch_lsched;
+  bit_lsched_t * odd_epoch_lsched;
+  bit_lsched_t * spare_lsched;
+  bit_lsched_t   _lsched[ 3 ];
 
   fd_pack_in_ctx_t in[ 32 ];
 
@@ -72,33 +111,134 @@ mux_ctx( void * scratch ) {
 }
 
 static inline void
+during_housekeeping( void * _ctx ) {
+  fd_pack_ctx_t * ctx = (fd_pack_ctx_t *)_ctx;
+
+  ulong new_poh_slot   = FD_VOLATILE_CONST( *(ctx->_poh_slot      ) );
+  ulong new_reset_slot = FD_VOLATILE_CONST( *(ctx->_poh_reset_slot) );
+  if( FD_UNLIKELY( (new_poh_slot!=ctx->poh_slot) | (new_reset_slot!=ctx->poh_reset_slot) ) ) {
+    ctx->poh_slot          = new_poh_slot;
+    ctx->poh_reset_slot    = new_reset_slot;
+    ctx->poh_slots_updated  = 1; /* Handle all the state transitions in before_credit below */
+  }
+}
+
+static inline int
+am_i_leader( fd_pack_ctx_t * ctx,
+             ulong           slot ) {
+  bit_lsched_t const * even = ctx->even_epoch_lsched;
+  bit_lsched_t const * odd  = ctx->odd_epoch_lsched;
+
+  int is_even = (even->start_slot <= slot) & (slot-even->start_slot < even->slot_cnt);
+  int is_odd  = (odd->start_slot  <= slot) & (slot-odd->start_slot  < odd->slot_cnt);
+
+  if( FD_UNLIKELY( !(is_even | is_odd) ) ) {
+    FD_LOG_WARNING(( "Tried to query the leader for slot %lu, but we only knew about epochs: "
+          "%lu slots [%lu, %lu), and %lu slots [%lu, %lu)",
+          slot, even->epoch, even->start_slot, even->start_slot + even->slot_cnt,
+          odd->epoch, odd->start_slot, odd->start_slot + odd->slot_cnt ));
+    return 0;
+  }
+
+  ulong offset = (slot - fd_ulong_if( is_even, even->start_slot, odd->start_slot )) / NUM_CONSECUTIVE_LEADER_SLOTS;
+
+  return lsched_bitset_test( fd_ptr_if( is_even, even, odd )->lsched, offset );
+}
+
+static inline int
+should_pack( fd_pack_ctx_t * ctx,
+             ulong           current_slot,
+             ulong           reset_slot    ) {
+  /* Optimize for the case that we are becoming leader even though it's
+     statistically infrequent. */
+  if( FD_LIKELY( am_i_leader( ctx, current_slot ) ) ) {
+    /* If reset_slot and current_slot are the same, that means the
+       banking stage has received and fully processed the last tick in
+       the previous leader's block, so there's no need to continue
+       waiting grace ticks.
+
+       If it has been more than 4 slots since the last block, then
+       probably the previous leader just didn't produce anything, so we
+       don't wait grace ticks either.
+
+       If I'm leader for slot 0, grace ticks don't make any sense, so
+       just start packing now.
+
+       If I was leader in the previous slot (which we know exists since
+       it's not slot 0), then either I was packing in the previous slot,
+       or I've already waited a full slot worth of grace ticks.  Either
+       way, now I can start packing.  Solana Labs's code seems to try to
+       give two slots of grace ticks, but actually ends up only giving
+       one, so we also only give one. */
+    if( FD_LIKELY  ( current_slot==reset_slot            ) ) return 1;
+    if( FD_UNLIKELY( current_slot>=reset_slot + 4UL      ) ) return 1;
+    if( FD_UNLIKELY( current_slot==0UL                   ) ) return 1;
+    if( FD_LIKELY  ( am_i_leader( ctx, current_slot-1UL )) ) return 1;
+  }
+  /* Either I'm not the leader for this slot or I need to give the
+     previous leader grace ticks. */
+  return 0;
+}
+
+static inline void
 before_credit( void * _ctx,
                fd_mux_context_t * mux ) {
   (void)mux;
 
   fd_pack_ctx_t * ctx = (fd_pack_ctx_t *)_ctx;
 
-  if( FD_UNLIKELY( ctx->cur_slot ) ) {
-    /* If we were overrun while processing a frag from an in, then cur_slot
+  if( FD_UNLIKELY( ctx->cur_spot ) ) {
+    /* If we were overrun while processing a frag from an in, then cur_spot
        is left dangling and not cleaned up, so clean it up here (by returning
        the slot to the pool of free slots). */
-    fd_pack_insert_txn_cancel( ctx->pack, ctx->cur_slot );
-    ctx->cur_slot = NULL;
+    fd_pack_insert_txn_cancel( ctx->pack, ctx->cur_spot );
+    ctx->cur_spot = NULL;
   }
 
-  /* Are we ready to end the block? */
+  /* There are two things that can cause a transition in our leader
+     state machine: observing a poh_slot/poh_reset_slot update, and the
+     block timeout expiring. */
 
+  /* Block timeout.  When we're not leader, block_end is LONG_MAX, so
+     this will never be true. */
   long now = fd_tickcount();
+  ulong initial_packing_for = ctx->packing_for;
+
   if( FD_UNLIKELY( (now-ctx->block_end)>=0L ) ) {
-    fd_pack_end_block( ctx->pack );
-    ctx->block_end += ctx->block_duration_ticks;
+    /* Temporarily pause packing until we observe PoH advance */
+    ctx->block_end   = LONG_MAX;
+    ctx->packing_for = ULONG_MAX;
   }
+  /* Slot update */
+  if( FD_UNLIKELY( ctx->poh_slots_updated ) ) {
+    ctx->poh_slots_updated = 0;
+
+    /* Optimize for the non-leader -> leader transition */
+    if( FD_LIKELY( should_pack( ctx, ctx->poh_slot, ctx->poh_reset_slot ) ) ) {
+      if( FD_UNLIKELY( (ctx->packing_for==ULONG_MAX) | (ctx->poh_slot>ctx->packing_for) ) ) {
+        /* Handle transition from non-leader to leader or transition
+           from leader to the next leader slot that happened after the
+           timeout triggered. */
+        ctx->packing_for = ctx->poh_slot;
+        ctx->block_end   = fd_tickcount() + ctx->block_duration_ticks;
+      }
+    } else {
+      /* I'm no longer leader */
+      ctx->block_end   = LONG_MAX;
+      ctx->packing_for = ULONG_MAX;
+    }
+  }
+
+  if( FD_UNLIKELY( ctx->packing_for != initial_packing_for ) ) fd_pack_end_block( ctx->pack );
 }
 
 static inline void
 after_credit( void *             _ctx,
               fd_mux_context_t * mux ) {
   fd_pack_ctx_t * ctx = (fd_pack_ctx_t *)_ctx;
+
+  /* Am I leader? If not, nothing to do. */
+  if( FD_UNLIKELY( ctx->packing_for == ULONG_MAX ) ) return;
 
   /* Is it time to schedule the next microblock? For each banking
      thread, if it's not busy... */
@@ -113,8 +253,13 @@ after_credit( void *             _ctx,
         ulong chunk  = ctx->out_chunk;
         ulong msg_sz = schedule_cnt*sizeof(fd_txn_p_t);
 
-        /* publish with sig=i, banks will filter to only handle frags with their own sig idx */
-        fd_mux_publish( mux, i, chunk, msg_sz, 0, 0UL, tspub );
+        /* The low byte of the signature field is the bank idx.  Banks
+           will filter to only handle frags with their own idx.  The
+           higher 7 bytes are the slot number.  Technically, the slot
+           number is a ulong, but it won't hit 256^7 for about 10^9
+           years at the current rate. */
+        ulong sig = (ctx->packing_for << 8) | (i & 0xFFUL);
+        fd_mux_publish( mux, sig, chunk, msg_sz, 0, 0UL, tspub );
 
         ctx->out_chunk = fd_dcache_compact_next( ctx->out_chunk, msg_sz, ctx->out_chunk0, ctx->out_wmark );
       }
@@ -137,9 +282,27 @@ during_frag( void * _ctx,
   if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark || sz > FD_TPU_DCACHE_MTU ) )
     FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
 
-  ctx->cur_slot              = fd_pack_insert_txn_init( ctx->pack );
-
   uchar const * dcache_entry = fd_chunk_to_laddr_const( ctx->in[in_idx].mem, chunk );
+
+  if( FD_UNLIKELY( in_idx == LSCHED_IN_IDX ) ) {
+    bit_lsched_t * new_lsched = ctx->spare_lsched;
+    lsched_bitset_t * bit = lsched_bitset_join( lsched_bitset_new( new_lsched->lsched ) );
+
+    ulong * hdr = (ulong *)dcache_entry;
+    new_lsched->epoch      = hdr[ 0 ];
+    new_lsched->start_slot = hdr[ 1 ];
+    new_lsched->slot_cnt   = hdr[ 2 ] - hdr[ 1 ];
+
+    ulong offset = 3UL*sizeof(ulong);
+    for( ulong i=0UL; i<new_lsched->slot_cnt; i+=NUM_CONSECUTIVE_LEADER_SLOTS ) {
+      lsched_bitset_insert_if( bit, !memcmp( dcache_entry+offset, ctx->identity_pubkey.b, 32UL ), i/NUM_CONSECUTIVE_LEADER_SLOTS );
+      offset += NUM_CONSECUTIVE_LEADER_SLOTS * 32UL;
+    }
+
+    return;
+  }
+
+  ctx->cur_spot              = fd_pack_insert_txn_init( ctx->pack );
 
   ulong payload_sz;
   /* There are two senders, one (dedup tile) which has already parsed the
@@ -159,22 +322,22 @@ during_frag( void * _ctx,
     payload_sz = *(ushort*)(dcache_entry + sz - sizeof(ushort));
     uchar    const * payload = dcache_entry;
     fd_txn_t const * txn     = (fd_txn_t const *)( dcache_entry + fd_ulong_align_up( payload_sz, 2UL ) );
-    fd_memcpy( ctx->cur_slot->payload, payload, payload_sz                                                     );
-    fd_memcpy( TXN(ctx->cur_slot),     txn,     fd_txn_footprint( txn->instr_cnt, txn->addr_table_lookup_cnt ) );
-    ctx->cur_slot->payload_sz = payload_sz;
+    fd_memcpy( ctx->cur_spot->payload, payload, payload_sz                                                     );
+    fd_memcpy( TXN(ctx->cur_spot),     txn,     fd_txn_footprint( txn->instr_cnt, txn->addr_table_lookup_cnt ) );
+    ctx->cur_spot->payload_sz = payload_sz;
   } else {
     /* Here there is just a transaction payload, so it needs to be
        parsed.  We can parse right out into the pack structure. */
     payload_sz = sz;
-    fd_memcpy( ctx->cur_slot->payload, dcache_entry, sz );
-    ulong txn_t_sz = fd_txn_parse( ctx->cur_slot->payload, sz, TXN(ctx->cur_slot), NULL );
+    fd_memcpy( ctx->cur_spot->payload, dcache_entry, sz );
+    ulong txn_t_sz = fd_txn_parse( ctx->cur_spot->payload, sz, TXN(ctx->cur_spot), NULL );
     if( FD_UNLIKELY( !txn_t_sz ) ) {
       FD_LOG_WARNING(( "fd_txn_parse failed for gossiped vote" ));
-      fd_pack_insert_txn_cancel( ctx->pack, ctx->cur_slot );
+      fd_pack_insert_txn_cancel( ctx->pack, ctx->cur_spot );
       *opt_filter = 1;
       return;
     }
-    ctx->cur_slot->payload_sz = payload_sz;
+    ctx->cur_spot->payload_sz = payload_sz;
   }
 
 #if DETAILED_LOGGING
@@ -185,11 +348,11 @@ during_frag( void * _ctx,
 }
 
 /* After the transaction has been fully received, and we know we were
-   not overrun while reading it, check if it's a duplicate of a prior
-   transaction. */
+   not overrun while reading it, insert it into pack. */
 
 static inline void
 after_frag( void *             _ctx,
+            ulong              in_idx,
             ulong *            opt_sig,
             ulong *            opt_chunk,
             ulong *            opt_sz,
@@ -203,8 +366,65 @@ after_frag( void *             _ctx,
 
   fd_pack_ctx_t * ctx = (fd_pack_ctx_t *)_ctx;
 
-  fd_pack_insert_txn_fini( ctx->pack, ctx->cur_slot );
-  ctx->cur_slot = NULL;
+  if( FD_UNLIKELY( in_idx == LSCHED_IN_IDX ) ) {
+    /* Swap the spare leader schedule we just populated into the spot
+       where it belongs. */
+    bit_lsched_t * temp;
+    ulong new_epoch = ctx->spare_lsched->epoch;
+    if( ctx->spare_lsched->epoch & 1 ) {
+      temp = ctx->odd_epoch_lsched;
+      ctx->odd_epoch_lsched = ctx->spare_lsched;
+    } else {
+      temp = ctx->even_epoch_lsched;
+      ctx->even_epoch_lsched = ctx->spare_lsched;
+    }
+    ctx->spare_lsched = temp;
+    lsched_bitset_delete( lsched_bitset_leave( temp->lsched ) );
+
+    /* The leader schedule for the first two epochs is always the
+       singular bootstrap validator chosen at genesis, so we fabricate
+       the leader schedule for epoch 0 from epoch 1. */
+    if( FD_UNLIKELY( new_epoch==1UL ) ) {
+      bit_lsched_t * new_lsched = temp;
+      lsched_bitset_t * bit = lsched_bitset_join( lsched_bitset_new( new_lsched->lsched ) );
+
+      new_lsched->epoch      = 0UL;
+      new_lsched->start_slot = 0UL;
+      new_lsched->slot_cnt   = ctx->odd_epoch_lsched->start_slot; /* must be epoch 1 */
+
+      /* Fill epoch 0 with the bit from the first slot of epoch 1. */
+      lsched_bitset_full_if( bit, lsched_bitset_test( ctx->odd_epoch_lsched->lsched, 0UL ) );
+
+      temp = ctx->even_epoch_lsched;
+      ctx->even_epoch_lsched = new_lsched;
+      ctx->spare_lsched = temp;
+      lsched_bitset_delete( lsched_bitset_leave( temp->lsched ) );
+    }
+
+  } else {
+    /* Normal transaction case */
+    fd_pack_insert_txn_fini( ctx->pack, ctx->cur_spot );
+    ctx->cur_spot = NULL;
+  }
+}
+
+static void
+privileged_init( fd_topo_t *      topo,
+                 fd_topo_tile_t * tile,
+                 void *           scratch ) {
+  (void)topo;
+
+  ulong scratch_top = (ulong)scratch;
+  fd_pack_ctx_t * ctx = SCRATCH_ALLOC( alignof( fd_pack_ctx_t ), sizeof( fd_pack_ctx_t ) );
+
+  if( FD_UNLIKELY( !strcmp( tile->pack.identity_key_path, "" ) ) )
+    FD_LOG_ERR(( "identity_key_path not set" ));
+
+  /* This seems like overkill for just the public key, but it's not
+     really easy to load just the public key without also getting the
+     private key. */
+  void const * identity_pubkey = load_key_into_protected_memory( tile->pack.identity_key_path, 1 /* public_key_only */ );
+  ctx->identity_pubkey = *(fd_acct_addr_t const *)identity_pubkey;
 }
 
 static void
@@ -227,11 +447,25 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->pack = fd_pack_join( fd_pack_new( SCRATCH_ALLOC( fd_pack_align(), pack_footprint ), tile->pack.max_pending_transactions, out_cnt, MAX_TXN_PER_MICROBLOCK, rng ) );
   if( FD_UNLIKELY( !ctx->pack ) ) FD_LOG_ERR(( "fd_pack_new failed" ));
 
-  ctx->cur_slot = NULL;
+  ctx->cur_spot = NULL;
   ctx->block_duration_ticks = (long)(fd_tempo_tick_per_ns( NULL ) * (double)BLOCK_DURATION_NS);
-  ctx->block_end = fd_tickcount() + ctx->block_duration_ticks;
-  ctx->out_cnt  = out_cnt;
+  ctx->block_end = LONG_MAX;
 
+  if( FD_UNLIKELY( (!tile->extra[0]) | (!tile->extra[1]) ) ) FD_LOG_ERR(( "poh_slot and/or poh_reset_slot not configured" ));
+  ctx->_poh_slot       = tile->extra[0];
+  ctx->_poh_reset_slot = tile->extra[1];
+  ctx->poh_slot          = 0UL;
+  ctx->poh_reset_slot    = 0UL;
+  ctx->poh_slots_updated = 0;
+
+  ctx->packing_for = ULONG_MAX;
+  ctx->even_epoch_lsched = ctx->_lsched + 0;
+  ctx->odd_epoch_lsched  = ctx->_lsched + 1;
+  ctx->spare_lsched      = ctx->_lsched + 2;
+  ctx->even_epoch_lsched->slot_cnt = 0UL;
+  ctx->odd_epoch_lsched->slot_cnt  = 0UL;
+
+  ctx->out_cnt  = out_cnt;
   for( ulong i=0; i<out_cnt; i++ ) {
     ctx->out_busy[ i ] = tile->extra[ i ];
     if( FD_UNLIKELY( !ctx->out_busy[ i ] ) ) FD_LOG_ERR(( "banking tile %lu has no busy flag", i ));
@@ -274,18 +508,19 @@ allow_fds( void * scratch,
 }
 
 fd_tile_config_t fd_tile_pack = {
-  .mux_flags           = FD_MUX_FLAG_MANUAL_PUBLISH | FD_MUX_FLAG_COPY,
+  .mux_flags               = FD_MUX_FLAG_MANUAL_PUBLISH | FD_MUX_FLAG_COPY,
   .burst                   = 1UL,
-  .mux_ctx             = mux_ctx,
-  .mux_before_credit   = before_credit,
-  .mux_after_credit    = after_credit,
-  .mux_during_frag     = during_frag,
-  .mux_after_frag      = after_frag,
-  .allow_syscalls_cnt  = sizeof(allow_syscalls)/sizeof(allow_syscalls[ 0 ]),
-  .allow_syscalls      = allow_syscalls,
-  .allow_fds           = allow_fds,
-  .scratch_align       = scratch_align,
-  .scratch_footprint   = scratch_footprint,
-  .privileged_init     = NULL,
-  .unprivileged_init   = unprivileged_init,
+  .mux_ctx                 = mux_ctx,
+  .mux_during_housekeeping = during_housekeeping,
+  .mux_before_credit       = before_credit,
+  .mux_after_credit        = after_credit,
+  .mux_during_frag         = during_frag,
+  .mux_after_frag          = after_frag,
+  .allow_syscalls_cnt      = sizeof(allow_syscalls)/sizeof(allow_syscalls[ 0 ]),
+  .allow_syscalls          = allow_syscalls,
+  .allow_fds               = allow_fds,
+  .scratch_align           = scratch_align,
+  .scratch_footprint       = scratch_footprint,
+  .privileged_init         = privileged_init,
+  .unprivileged_init       = unprivileged_init,
 };

--- a/src/app/fdctl/run/tiles/fd_quic.c
+++ b/src/app/fdctl/run/tiles/fd_quic.c
@@ -428,11 +428,13 @@ during_frag( void * _ctx,
 
 static void
 after_frag( void *             _ctx,
+            ulong              in_idx,
             ulong *            opt_sig,
             ulong *            opt_chunk,
             ulong *            opt_sz,
             int *              opt_filter,
             fd_mux_context_t * mux ) {
+  (void)in_idx;
   (void)opt_chunk;
   (void)opt_filter;
   (void)mux;

--- a/src/app/fdctl/run/tiles/fd_shred.c
+++ b/src/app/fdctl/run/tiles/fd_shred.c
@@ -440,11 +440,13 @@ send_shred( fd_shred_ctx_t *      ctx,
 
 static void
 after_frag( void *             _ctx,
+            ulong              in_idx,
             ulong *            opt_sig,
             ulong *            opt_chunk,
             ulong *            opt_sz,
             int *              opt_filter,
             fd_mux_context_t * mux ) {
+  (void)in_idx;
   (void)opt_sig;
   (void)opt_chunk;
   (void)opt_sz;
@@ -609,7 +611,7 @@ privileged_init( fd_topo_t *      topo,
   if( FD_UNLIKELY( !strcmp( tile->shred.identity_key_path, "" ) ) )
     FD_LOG_ERR(( "identity_key_path not set" ));
 
-  ctx->shred_signing_key = load_key_into_protected_memory( tile->shred.identity_key_path );
+  ctx->shred_signing_key = load_key_into_protected_memory( tile->shred.identity_key_path, /* pubkey only: */ 0 );
 }
 
 static void

--- a/src/app/fdctl/run/tiles/fd_verify.c
+++ b/src/app/fdctl/run/tiles/fd_verify.c
@@ -86,11 +86,13 @@ during_frag( void * _ctx,
 
 static inline void
 after_frag( void *             _ctx,
+            ulong              in_idx,
             ulong *            opt_sig,
             ulong *            opt_chunk,
             ulong *            opt_sz,
             int *              opt_filter,
             fd_mux_context_t * mux ) {
+  (void)in_idx;
   (void)opt_sig;
   (void)mux;
 

--- a/src/app/fdctl/topology.c
+++ b/src/app/fdctl/topology.c
@@ -235,10 +235,13 @@ fd_topo_workspace_fill( fd_topo_t *      topo,
     switch( tile->kind ) {
       case FD_TOPO_TILE_KIND_PACK: {
         void * poh_slot = SCRATCH_ALLOC( 8UL, 8UL );
-        void * poh_parent_slot = SCRATCH_ALLOC( 8UL, 8UL );
+        void * poh_reset_slot = SCRATCH_ALLOC( 8UL, 8UL );
         if( FD_LIKELY( mode==FD_TOPO_FILL_MODE_NEW ) ) {
           INSERT_POD( "poh_slot", poh_slot );
-          INSERT_POD( "poh_parent_slot", poh_parent_slot );
+          INSERT_POD( "poh_reset_slot", poh_reset_slot );
+        } else if( FD_LIKELY( mode==FD_TOPO_FILL_MODE_JOIN ) ) {
+          tile->extra[ 0 ] = poh_slot;
+          tile->extra[ 1 ] = poh_reset_slot;
         }
         break;
       }

--- a/src/app/fdctl/topology.h
+++ b/src/app/fdctl/topology.h
@@ -205,6 +205,7 @@ typedef struct {
   struct {
     ulong max_pending_transactions;
     ulong bank_tile_count;
+    char  identity_key_path[ PATH_MAX ];
   } pack;
 
   struct {

--- a/src/app/fdctl/utility.h
+++ b/src/app/fdctl/utility.h
@@ -46,11 +46,15 @@ snprintf1( char * s,
    key_path must point to the first letter in a nul-terminated cstr that
    is the path on disk of the key file.  The key file must exist, be
    readable, and have the form of a Solana keypair (64 element JSON
-   array of bytes).  Returns a pointer to the first byte of the key in
-   binary format.  Terminates the process with FD_LOG_ERR on any error,
-   so from the perspective of the caller, it cannot fail. */
+   array of bytes).  If public_key_only is non-zero, zeros out the
+   private part of the key and returns a pointer to the first byte (of
+   32) of the public part of the key in binary format.  If
+   public_key_only is zero, returns a pointer to the first byte (of 64)
+   of the key in binary format.  Terminates the process by calling
+   FD_LOG_ERR with details on any error, so from the perspective of the
+   caller, it cannot fail. */
 uchar const *
-load_key_into_protected_memory( char const * key_path );
+load_key_into_protected_memory( char const * key_path, int public_key_only );
 
 /* self_exe() retrieves the full path of the current executable
    into the path. Path should be a buffer with at least PATH_MAX

--- a/src/ballet/pack/fd_pack.c
+++ b/src/ballet/pack/fd_pack.c
@@ -465,11 +465,6 @@ fd_pack_insert_txn_fini( fd_pack_t  * pack,
     trp_pool_ele_release( pack->pool, ord );
     return;
   }
-  /* Throw out transactions ... */
-  /*           ... that are unfunded */
-  if( FD_UNLIKELY( !fd_pack_can_fee_payer_afford( accts, ord->rewards ) ) ) { trp_pool_ele_release( pack->pool, ord ); return; }
-  /*           ... that are so big they'll never run */
-  if( FD_UNLIKELY( ord->compute_est >= FD_PACK_MAX_COST_PER_BLOCK       ) ) { trp_pool_ele_release( pack->pool, ord ); return; }
 
   fd_txn_acct_iter_t ctrl[1];
   int writes_to_sysvar = 0;
@@ -477,8 +472,18 @@ fd_pack_insert_txn_fini( fd_pack_t  * pack,
       i=fd_txn_acct_iter_next( i, ctrl ) ) {
     writes_to_sysvar |= fd_pack_unwritable_contains( accts+i );
   }
-  /*           ... try to write to a sysvar */
-  if( FD_UNLIKELY( writes_to_sysvar )                                     ) { trp_pool_ele_release( pack->pool, ord ); return; }
+
+  fd_ed25519_sig_t const * sig = fd_txn_get_signatures( txn, payload );
+
+  /* Throw out transactions ... */
+  /*           ... that are unfunded */
+  if( FD_UNLIKELY( !fd_pack_can_fee_payer_afford( accts, ord->rewards ) ) ) { trp_pool_ele_release( pack->pool, ord ); return; }
+  /*           ... that are so big they'll never run */
+  if( FD_UNLIKELY( ord->compute_est >= FD_PACK_MAX_COST_PER_BLOCK       ) ) { trp_pool_ele_release( pack->pool, ord ); return; }
+  /*           ... that try to write to a sysvar */
+  if( FD_UNLIKELY( writes_to_sysvar                                     ) ) { trp_pool_ele_release( pack->pool, ord ); return; }
+  /*           ... that we already know about */
+  if( FD_UNLIKELY( sig2txn_query( pack->signature_map, sig, NULL )      ) ) { trp_pool_ele_release( pack->pool, ord ); return; }
 
   /* TODO: Add recent blockhash based expiry here */
 

--- a/src/disco/mux/fd_mux.c
+++ b/src/disco/mux/fd_mux.c
@@ -583,7 +583,7 @@ fd_mux_tile( fd_cnc_t *              cnc,
       /* We have successfully loaded the metadata.  Decide whether it
           is interesting downstream and publish or filter accordingly. */
 
-      if( FD_LIKELY( callbacks->after_frag ) ) callbacks->after_frag( ctx, &sig, &chunk, &sz, &filter, &mux );
+      if( FD_LIKELY( callbacks->after_frag ) ) callbacks->after_frag( ctx, (ulong)this_in->idx, &sig, &chunk, &sz, &filter, &mux );
     }
 
     now = fd_tickcount();

--- a/src/disco/mux/fd_mux.h
+++ b/src/disco/mux/fd_mux.h
@@ -221,7 +221,8 @@ typedef void (fd_mux_during_frag_fn)( void * ctx,
    is not invoked if the mux is backpressured, as it would not read a
    frag in the first place.  It is also not invoked if
    fd_mux_during_frag sets opt_filter to non-zero, indicating to filter
-   the frag.
+   the frag. in_idx will be the index of the in that the frag was
+   received from.
 
    You should not read the frag data directly here, as it might still
    get overrun, instead it should be copied out of the frag during the
@@ -243,6 +244,7 @@ typedef void (fd_mux_during_frag_fn)( void * ctx,
    be trusted. */
 
 typedef void (fd_mux_after_frag_fn)( void *             ctx,
+                                     ulong              in_idx,
                                      ulong *            opt_sig,
                                      ulong *            opt_chunk,
                                      ulong *            opt_sz,


### PR DESCRIPTION
The logic for keeping the pack tile and the bank tile in sync is a bit tricky. Because pack keeps track of per-block limits, it needs to make sure the transactions it packs land in the block it expects them to. A prerequisite for getting this to work is for the pack tile to know if it's actually leader or not.

While we're at it, have pack filter transactions it already knows about. This can happen when we get the same vote transaction over the normal TPU pipeline and over gossip, or if the dedup tcache is too small.