### PR TITLE
fdctl: map some workspaces as readonly if possible

### DIFF
--- a/src/app/fdctl/configure/workspace.c
+++ b/src/app/fdctl/configure/workspace.c
@@ -43,7 +43,7 @@ init( config_t * const config ) {
 
   fd_topo_fill( &config->topo, FD_TOPO_FILL_MODE_FOOTPRINT );
   fd_topo_create_workspaces( config->name, &config->topo );
-  fd_topo_join_workspaces( config->name, &config->topo );
+  fd_topo_join_workspaces( config->name, &config->topo, FD_SHMEM_JOIN_MODE_READ_WRITE );
   fd_topo_fill( &config->topo, FD_TOPO_FILL_MODE_NEW );
   fd_topo_leave_workspaces( &config->topo );
 

--- a/src/app/fdctl/monitor/monitor.c
+++ b/src/app/fdctl/monitor/monitor.c
@@ -369,7 +369,7 @@ monitor_cmd_fn( args_t *         args,
 
   /* join all workspaces needed by the toplogy before sandboxing, so
      we can access them later */
-  fd_topo_join_workspaces( config->name, &config->topo );
+  fd_topo_join_workspaces( config->name, &config->topo, FD_SHMEM_JOIN_MODE_READ_ONLY );
 
   if( FD_UNLIKELY( close( 0 ) ) ) FD_LOG_ERR(( "close(0) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
   fd_sandbox( config->development.sandbox,

--- a/src/app/fdctl/ready.c
+++ b/src/app/fdctl/ready.c
@@ -9,7 +9,7 @@ ready_cmd_fn( args_t *         args,
               config_t * const config ) {
   (void)args;
 
-  fd_topo_join_workspaces( config->name, &config->topo );
+  fd_topo_join_workspaces( config->name, &config->topo, FD_SHMEM_JOIN_MODE_READ_ONLY );
   fd_topo_fill( &config->topo, FD_TOPO_FILL_MODE_JOIN );
 
   for( ulong i=0; i<config->topo.tile_cnt; i++) {

--- a/src/app/fdctl/run/tiles/fd_dedup.c
+++ b/src/app/fdctl/run/tiles/fd_dedup.c
@@ -122,7 +122,6 @@ after_frag( void *             _ctx,
     *opt_sig       = 0; /* indicate this txn is coming from dedup, and has already been parsed */
     ctx->out_chunk = fd_dcache_compact_next( ctx->out_chunk, *opt_sz, ctx->out_chunk0, ctx->out_wmark );
   }
-  FD_LOG_NOTICE(( "sending packet %lu %lu", *opt_sz, *opt_sig ));
 }
 
 static void

--- a/src/app/fdctl/topology.h
+++ b/src/app/fdctl/topology.h
@@ -410,10 +410,14 @@ fd_topo_join_tile_workspaces( char * const     app_name,
                               fd_topo_tile_t * tile );
 
 /* Join (map into the process) all shared memory (huge/gigantic pages)
-   needed by all tiles in the topology. */
+   needed by all tiles in the topology.  Mode is one of
+   FD_SHMEM_JOIN_MODE_READ_WRITE or FD_SHMEM_JOIN_MODE_READ_ONLY and
+   determines the prot argument that will be passed to mmap when
+   mapping the pages in (PROT_WRITE or PROT_READ respectively). */
 void
 fd_topo_join_workspaces( char * const app_name,
-                         fd_topo_t *  topo );
+                         fd_topo_t *  topo,
+                         int          mode );
 
 /* Leave (unmap from the process) all shared memory needed by all
    tiles in the toplogy, if each of them was mapped. */


### PR DESCRIPTION
We want to map shared memory as PROT_READ only for added security if a tile does not write to the associated workspace.  We automatically determine if this is possible from the topology.