### PR TITLE
reset key count when clearing dynamic map

### DIFF
--- a/src/util/tmpl/fd_map_dynamic.c
+++ b/src/util/tmpl/fd_map_dynamic.c
@@ -456,6 +456,7 @@ MAP_(remove)( MAP_T * map,
 static inline void
 MAP_(clear)( MAP_T * map ) {
   MAP_(private_t) * hdr = MAP_(private_from_slot)( map );
+  hdr->key_cnt = 0UL;
   ulong slot_cnt  = 1UL<<hdr->lg_slot_cnt;
   MAP_T * slot = hdr->slot;
   for( ulong slot_idx=0UL; slot_idx<slot_cnt; slot_idx++ )


### PR DESCRIPTION
Without this change [this code path](https://github.com/firedancer-io/firedancer/blob/main/src/util/tmpl/fd_map_dynamic.c#L380) would return `NULL` and [cause a segfault in pack](https://github.com/firedancer-io/firedancer/blob/main/src/ballet/pack/fd_pack.c#L617).