### PR TITLE
fd_pack: limit the number of microblocks we produce in a block

### DIFF
--- a/src/ballet/pack/fd_pack.h
+++ b/src/ballet/pack/fd_pack.h
@@ -75,15 +75,16 @@ fd_pack_footprint( ulong pack_depth,
    pack object.  mem is a non-NULL pointer to a region of memory in the
    local address space with the required alignment and footprint.
    pack_depth, bank_tile_cnt, and max_txn_per_microblock are as above.
-   rng is a local join to a random number generator used to perturb
-   estimates.
+   The pack object will produce at most max_microblocks_per_block
+   non-empty microblocks in a block.  rng is a local join to a random
+   number generator used to perturb estimates.
 
    Returns `mem` (which will be properly formatted as a pack object) on
    success and NULL on failure.  Logs details on failure.  The caller
    will not be joined to the pack object when this function returns. */
 void * fd_pack_new( void * mem,
     ulong pack_depth, ulong bank_tile_cnt, ulong max_txn_per_microblock,
-    fd_rng_t * rng );
+    ulong max_microblocks_per_block, fd_rng_t * rng );
 
 /* fd_pack_join joins the caller to the pack object.  Every successful
    join should have a matching leave.  Returns mem. */

--- a/src/ballet/pack/test_pack.c
+++ b/src/ballet/pack/test_pack.c
@@ -50,7 +50,7 @@ init_all( ulong pack_depth,
   else                         FD_LOG_NOTICE(( "Test required %lu bytes of %lu available bytes",    footprint, PACK_SCRATCH_SZ ));
 #endif
 
-  fd_pack_t * pack = fd_pack_join( fd_pack_new( pack_scratch, pack_depth, gap, max_txn_per_microblock, rng ) );
+  fd_pack_t * pack = fd_pack_join( fd_pack_new( pack_scratch, pack_depth, gap, max_txn_per_microblock, MAX_TEST_TXNS, rng ) );
 #define MAX_BANKING_THREADS 64
 
   outcome->microblock_cnt = 0UL;


### PR DESCRIPTION
Long term, we probably want a better solution than this (e.g. shred tile doing better batching), but for now this is safe.