### PR TITLE
redo plumbing of stake weights, contact info into pack, shred tiles

### DIFF
--- a/src/app/fdctl/monitor/monitor.c
+++ b/src/app/fdctl/monitor/monitor.c
@@ -288,12 +288,16 @@ run_monitor( config_t * const config,
             producer = "poh";
             break;
           }
-          case FD_TOPO_LINK_KIND_LSCHED_TO_PACK: {
-            producer = "lsched";
+          case FD_TOPO_LINK_KIND_STAKE_TO_OUT: {
+            producer = "stakes";
             break;
           }
           case FD_TOPO_LINK_KIND_GOSSIP_TO_PACK: {
             producer = "gossip";
+            break;
+          }
+          case FD_TOPO_LINK_KIND_CRDS_TO_SHRED: {
+            producer = "crds";
             break;
           }
           default: {

--- a/src/app/fdctl/topology.c
+++ b/src/app/fdctl/topology.c
@@ -633,12 +633,13 @@ fd_topo_validate( fd_topo_t * topo ) {
 
   /* Each link has exactly one producer */
   for( ulong i=0UL; i<topo->link_cnt; i++ ) {
-    /* gossip/lsched to pack is sent by solana, and not hosted in a tile for now */
+    /* gossip to pack is sent by solana, and not hosted in a tile for
+       now, nor are the stakes to pack and shred tile link, the contact
+       info to shred link, or the poh to shred link. */
     if( FD_UNLIKELY( topo->links[ i ].kind == FD_TOPO_LINK_KIND_GOSSIP_TO_PACK ) ) continue;
-    if( FD_UNLIKELY( topo->links[ i ].kind == FD_TOPO_LINK_KIND_LSCHED_TO_PACK ) ) continue;
-
-    /* poh to shred is sent by solana, and not hosted in a tile for now */
-    if( FD_UNLIKELY( topo->links[ i ].kind == FD_TOPO_LINK_KIND_POH_TO_SHRED ) ) continue;
+    if( FD_UNLIKELY( topo->links[ i ].kind == FD_TOPO_LINK_KIND_STAKE_TO_OUT   ) ) continue;
+    if( FD_UNLIKELY( topo->links[ i ].kind == FD_TOPO_LINK_KIND_CRDS_TO_SHRED  ) ) continue;
+    if( FD_UNLIKELY( topo->links[ i ].kind == FD_TOPO_LINK_KIND_POH_TO_SHRED   ) ) continue;
 
     ulong producer_cnt = 0;
     for( ulong j=0UL; j<topo->tile_cnt; j++ ) {

--- a/src/app/fdctl/topology.h
+++ b/src/app/fdctl/topology.h
@@ -34,15 +34,16 @@
 #define FD_TOPO_WKSP_KIND_PACK_BANK    ( 4UL)
 #define FD_TOPO_WKSP_KIND_BANK_SHRED   ( 5UL)
 #define FD_TOPO_WKSP_KIND_SHRED_STORE  ( 6UL)
-#define FD_TOPO_WKSP_KIND_NET          ( 7UL)
-#define FD_TOPO_WKSP_KIND_NETMUX       ( 8UL)
-#define FD_TOPO_WKSP_KIND_QUIC         ( 9UL)
-#define FD_TOPO_WKSP_KIND_VERIFY       (10UL)
-#define FD_TOPO_WKSP_KIND_DEDUP        (11UL)
-#define FD_TOPO_WKSP_KIND_PACK         (12UL)
-#define FD_TOPO_WKSP_KIND_BANK         (13UL)
-#define FD_TOPO_WKSP_KIND_SHRED        (14UL)
-#define FD_TOPO_WKSP_KIND_STORE        (15UL)
+#define FD_TOPO_WKSP_KIND_STAKE_OUT    ( 7UL)
+#define FD_TOPO_WKSP_KIND_NET          ( 8UL)
+#define FD_TOPO_WKSP_KIND_NETMUX       ( 9UL)
+#define FD_TOPO_WKSP_KIND_QUIC         (10UL)
+#define FD_TOPO_WKSP_KIND_VERIFY       (11UL)
+#define FD_TOPO_WKSP_KIND_DEDUP        (12UL)
+#define FD_TOPO_WKSP_KIND_PACK         (13UL)
+#define FD_TOPO_WKSP_KIND_BANK         (14UL)
+#define FD_TOPO_WKSP_KIND_SHRED        (15UL)
+#define FD_TOPO_WKSP_KIND_STORE        (16UL)
 #define FD_TOPO_WKSP_KIND_MAX          ( FD_TOPO_WKSP_KIND_STORE+1 ) /* Keep updated with maximum tile IDX */
 
 /* FD_TOPO_LINK_KIND_* is an identifier for a particular kind of link. A
@@ -64,11 +65,12 @@
 #define FD_TOPO_LINK_KIND_VERIFY_TO_DEDUP ( 4UL)
 #define FD_TOPO_LINK_KIND_DEDUP_TO_PACK   ( 5UL)
 #define FD_TOPO_LINK_KIND_GOSSIP_TO_PACK  ( 6UL)
-#define FD_TOPO_LINK_KIND_LSCHED_TO_PACK  ( 7UL)
+#define FD_TOPO_LINK_KIND_STAKE_TO_OUT    ( 7UL)
 #define FD_TOPO_LINK_KIND_PACK_TO_BANK    ( 8UL)
 #define FD_TOPO_LINK_KIND_POH_TO_SHRED    ( 9UL)
 #define FD_TOPO_LINK_KIND_SHRED_TO_NETMUX (10UL)
 #define FD_TOPO_LINK_KIND_SHRED_TO_STORE  (11UL)
+#define FD_TOPO_LINK_KIND_CRDS_TO_SHRED   (12UL)
 
 /* FD_TOPO_TILE_KIND_* is an identifier for a particular kind of tile.
    There may be multiple or in some cases zero of a particular tile
@@ -323,6 +325,7 @@ fd_topo_wksp_kind_str( ulong kind ) {
     case FD_TOPO_WKSP_KIND_PACK_BANK:    return "pack_bank";
     case FD_TOPO_WKSP_KIND_BANK_SHRED:   return "bank_shred";
     case FD_TOPO_WKSP_KIND_SHRED_STORE:  return "shred_store";
+    case FD_TOPO_WKSP_KIND_STAKE_OUT:    return "stake_out";
     case FD_TOPO_WKSP_KIND_NET:          return "net";
     case FD_TOPO_WKSP_KIND_NETMUX:       return "netmux";
     case FD_TOPO_WKSP_KIND_QUIC:         return "quic";
@@ -350,11 +353,12 @@ fd_topo_link_kind_str( ulong kind ) {
     case FD_TOPO_LINK_KIND_VERIFY_TO_DEDUP: return "verify_dedup";
     case FD_TOPO_LINK_KIND_DEDUP_TO_PACK:   return "dedup_pack";
     case FD_TOPO_LINK_KIND_GOSSIP_TO_PACK:  return "gossip_pack";
-    case FD_TOPO_LINK_KIND_LSCHED_TO_PACK:  return "lsched_pack";
+    case FD_TOPO_LINK_KIND_STAKE_TO_OUT:    return "stake_out";
     case FD_TOPO_LINK_KIND_PACK_TO_BANK:    return "pack_bank";
     case FD_TOPO_LINK_KIND_POH_TO_SHRED:    return "poh_shred";
     case FD_TOPO_LINK_KIND_SHRED_TO_NETMUX: return "shred_netmux";
     case FD_TOPO_LINK_KIND_SHRED_TO_STORE:  return "shred_store";
+    case FD_TOPO_LINK_KIND_CRDS_TO_SHRED:   return "crds_shred";
     default: FD_LOG_ERR(( "unknown workspace kind %lu", kind )); return NULL;
   }
 }

--- a/src/disco/shred/Local.mk
+++ b/src/disco/shred/Local.mk
@@ -2,6 +2,7 @@ ifdef FD_HAS_INT128
 $(call add-objs,fd_shred_dest,fd_disco)
 $(call add-objs,fd_shredder,fd_disco)
 $(call add-objs,fd_fec_resolver,fd_disco)
+$(call add-objs,fd_stake_ci,fd_disco)
 $(call make-unit-test,test_shred_dest,test_shred_dest,fd_ballet fd_util fd_flamenco fd_disco)
 $(call make-unit-test,test_shredder,test_shredder,fd_ballet fd_util fd_flamenco fd_disco fd_reedsol)
 $(call make-unit-test,test_fec_resolver,test_fec_resolver,fd_ballet fd_util fd_tango fd_flamenco fd_disco fd_reedsol)

--- a/src/disco/shred/fd_shred_dest.c
+++ b/src/disco/shred/fd_shred_dest.c
@@ -92,6 +92,8 @@ fd_shred_dest_new( void                           * mem,
 
   fd_chacha20rng_t * rng = fd_chacha20rng_join( fd_chacha20rng_new( sdest->rng, FD_CHACHA20RNG_MODE_SHIFT ) );
 
+  /* We reserved enough space in _wsample for both the staked and
+     unstaked info */
   void  *  _staked   = fd_wsample_new_init( _wsample,  rng, staked_cnt,   1, FD_WSAMPLE_HINT_POWERLAW_REMOVE );
   ulong * unstaked = (ulong *)fd_ulong_align_up( ((ulong)_wsample + fd_wsample_footprint( staked_cnt, 1 )), alignof(ulong) );
 
@@ -421,3 +423,15 @@ fd_shred_dest_compute_children( fd_shred_dest_t          * sdest,
   fd_ulong_store_if( !!opt_max_dest_cnt, opt_max_dest_cnt, max_dest_cnt );
   return out;
 }
+
+fd_shred_dest_idx_t
+fd_shred_dest_pubkey_to_idx( fd_shred_dest_t   * sdest,
+                             fd_pubkey_t const * pubkey     ) {
+  if( FD_UNLIKELY( !memcmp( pubkey, null_pubkey.uc, 32UL ) ) ) return FD_SHRED_DEST_NO_DEST;
+
+  pubkey_to_idx_t default_res[ 1 ] = {{ .idx = FD_SHRED_DEST_NO_DEST }};
+  pubkey_to_idx_t * query = pubkey_to_idx_query( sdest->pubkey_to_idx_map, *pubkey, default_res );
+
+  return (fd_shred_dest_idx_t)query->idx;
+}
+

--- a/src/disco/shred/fd_shred_dest.h
+++ b/src/disco/shred/fd_shred_dest.h
@@ -120,6 +120,16 @@ fd_shred_dest_t * fd_shred_dest_join( void * mem );
 void * fd_shred_dest_leave( fd_shred_dest_t * sdest );
 void * fd_shred_dest_delete( void * mem );
 
+/* fd_shred_dest_cnt_{staked, unstaked, all} returns the number of known
+   destination that are staked, unstaked, or either, respectively.  The
+   staked destinations have index [0, fd_shred_dest_cnt_staked()) and
+   the unstaked destinations have index [fd_shred_dest_cnt_staked(),
+   fd_shred_dest_cnt_all() ).  fd_shred_dest_cnt_all() ==
+   fd_shred_dest_cnt_staked() + fd_shred_dest_cnt_unstaked(). */
+static inline ulong fd_shred_dest_cnt_staked  ( fd_shred_dest_t * sdest ) { return sdest->staked_cnt                      ; }
+static inline ulong fd_shred_dest_cnt_unstaked( fd_shred_dest_t * sdest ) { return                     sdest->unstaked_cnt; }
+static inline ulong fd_shred_dest_cnt_all     ( fd_shred_dest_t * sdest ) { return sdest->staked_cnt + sdest->unstaked_cnt; }
+
 /* fd_shred_dest_compute_first computes the root of the Turbine tree for
    each of the provided shreds.  All the provided shreds must come from
    the same slot (and thus have the same leader).  This should only be
@@ -197,5 +207,10 @@ static inline fd_shred_dest_weighted_t *
 fd_shred_dest_idx_to_dest( fd_shred_dest_t * sdest, fd_shred_dest_idx_t idx ) {
   return fd_ptr_if( idx!=FD_SHRED_DEST_NO_DEST, sdest->all_destinations + idx, sdest->null_dest );
 }
+
+/* fd_shred_dest_idx_t maps a pubkey to a destination index, if the
+   pubkey is known as a destination.  If the pubkey is not know, returns
+   FD_SHRED_DEST_NO_DEST. */
+fd_shred_dest_idx_t fd_shred_dest_pubkey_to_idx( fd_shred_dest_t * sdest, fd_pubkey_t const * pubkey );
 
 #endif /* HEADER_fd_src_disco_shred_fd_shred_dest_h */

--- a/src/disco/shred/fd_stake_ci.c
+++ b/src/disco/shred/fd_stake_ci.c
@@ -1,0 +1,253 @@
+#include "fd_stake_ci.h"
+#include "../../util/net/fd_ip4.h" /* Just for debug */
+
+#define SORT_NAME sort_pubkey
+#define SORT_KEY_T fd_shred_dest_weighted_t
+#define SORT_BEFORE(a,b) memcmp( (a).pubkey.uc, (b).pubkey.uc, 32UL )
+#include "../../util/tmpl/fd_sort.c"
+
+void *
+fd_stake_ci_new( void             * mem,
+                fd_pubkey_t const * identity_key ) {
+  fd_stake_ci_t * info = (fd_stake_ci_t *)mem;
+
+  if( FD_UNLIKELY( MAX_SHRED_DEST_FOOTPRINT != fd_shred_dest_footprint( MAX_SHRED_DESTS ) ) )
+    FD_LOG_ERR(( "MAX_SHRED_DEST_FOOTPRINT should be set to %lu", fd_shred_dest_footprint( MAX_SHRED_DESTS ) ));
+
+
+  fd_stake_weight_t dummy_stakes[ 1 ] = {{ .key = {{0}}, .stake = 1UL }};
+  fd_shred_dest_weighted_t dummy_dests[ 1 ] = {{ .pubkey = *identity_key }};
+
+  /* Initialize first 2 to satisfy invariants */
+  info->stake_weight[ 0 ] = dummy_stakes[ 0 ];
+  info->shred_dest  [ 0 ] = dummy_dests [ 0 ];
+  for( ulong i=0UL; i<2UL; i++ ) {
+    fd_per_epoch_info_t * ei = info->epoch_info + i;
+    ei->epoch      = i;
+    ei->start_slot = 0UL;
+    ei->slot_cnt   = 0UL;
+
+    ei->lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( ei->_lsched, 0UL, 0UL, 1UL, 1UL,    info->stake_weight       ) );
+    ei->sdest  = fd_shred_dest_join   ( fd_shred_dest_new   ( ei->_sdest,  info->shred_dest, 1UL, ei->lsched, identity_key ) );
+  }
+  info->identity_key[ 0 ] = *identity_key;
+
+  return (void *)info;
+}
+
+fd_stake_ci_t * fd_stake_ci_join( void * mem ) { return (fd_stake_ci_t *)mem; }
+
+void * fd_stake_ci_leave ( fd_stake_ci_t * info ) { return (void *)info; }
+void * fd_stake_ci_delete( void          * mem  ) { return mem;          }
+
+
+void
+fd_stake_ci_stake_msg_init( fd_stake_ci_t * info,
+                            uchar const   * new_message ) {
+  ulong const * hdr = fd_type_pun_const( new_message );
+
+  ulong epoch               = hdr[ 0 ];
+  ulong staked_cnt          = hdr[ 1 ];
+  ulong start_slot          = hdr[ 2 ];
+  ulong slot_cnt            = hdr[ 3 ];
+
+  if( FD_UNLIKELY( staked_cnt > MAX_SHRED_DESTS ) )
+    FD_LOG_ERR(( "The stakes -> Firedancer splice sent a malformed update with %lu stakes in it,"
+                 " but the maximum allowed is %lu", staked_cnt, MAX_SHRED_DESTS ));
+
+  info->scratch->epoch      = epoch;
+  info->scratch->start_slot = start_slot;
+  info->scratch->slot_cnt   = slot_cnt;
+  info->scratch->staked_cnt = staked_cnt;
+
+  fd_memcpy( info->stake_weight, hdr+4UL, sizeof(fd_stake_weight_t)*staked_cnt );
+}
+
+static inline void
+log_summary( char const * msg, fd_stake_ci_t * info ) {
+  fd_per_epoch_info_t const * ei = info->epoch_info;
+  FD_LOG_NOTICE(( "Dumping stake contact information because %s", msg ));
+  for( ulong i=0UL; i<2UL; i++ ) {
+    FD_LOG_NOTICE(( "  Dumping shred destination details for epoch %lu, slots [%lu, %lu)", ei[i].epoch, ei[i].start_slot, ei[i].start_slot+ei[i].slot_cnt ));
+    fd_shred_dest_t * sdest = ei[i].sdest;
+    for( fd_shred_dest_idx_t j=0; j<(fd_shred_dest_idx_t)fd_shred_dest_cnt_all( sdest ); j++ ) {
+      fd_shred_dest_weighted_t * dest = fd_shred_dest_idx_to_dest( sdest, j );
+      FD_LOG_NOTICE(( "    %16lx  %20lu " FD_IP4_ADDR_FMT " %hu ", *(ulong *)dest->pubkey.uc, dest->stake_lamports, FD_IP4_ADDR_FMT_ARGS( dest->ip4 ), dest->port ));
+    }
+  }
+}
+
+void
+fd_stake_ci_stake_msg_fini( fd_stake_ci_t * info ) {
+  /* The grossness here is a sign our abstractions are wrong and need to
+     be fixed instead of just patched.  We need to generate weighted
+     shred destinations using a combination of the new stake information
+     and whatever contact info we previously knew. */
+  ulong epoch                  = info->scratch->epoch;
+  ulong staked_cnt             = info->scratch->staked_cnt;
+
+  /* Just take the first one arbitrarily because they both have the same
+     contact info. */
+  fd_shred_dest_t * existing_sdest        = info->epoch_info->sdest;
+  ulong             existing_staked_cnt   = fd_shred_dest_cnt_staked( existing_sdest );
+  ulong             existing_unstaked_cnt = fd_shred_dest_cnt_unstaked( existing_sdest );
+
+  for( ulong i=0UL; i<staked_cnt; i++ ) {
+    fd_shred_dest_idx_t old_idx = fd_shred_dest_pubkey_to_idx( existing_sdest, &(info->stake_weight[ i ].key) );
+    fd_shred_dest_weighted_t * in_prev = fd_shred_dest_idx_to_dest( existing_sdest, old_idx );
+    info->shred_dest[ i ] = *in_prev;
+    if( FD_UNLIKELY( old_idx==FD_SHRED_DEST_NO_DEST ) ) {
+      /* We got the generic empty entry, so fixup the pubkey */
+      info->shred_dest[ i ].pubkey = info->stake_weight[ i ].key;
+    } else if( FD_UNLIKELY( old_idx >= existing_staked_cnt ) ) {
+      /* This was known and unstaked in the existing epoch, but is now
+         staked.  We have to be careful not to add it to the unstaked
+         list for this epoch.  Temporarily mark it so that we know to
+         skip it and unmark it later. */
+      in_prev->stake_lamports = 1UL;
+    }
+    info->shred_dest[ i ].stake_lamports = info->stake_weight[ i ].stake;
+  }
+  /* Now we have to copy over all the unstaked nodes */
+
+  ulong j = staked_cnt;
+  for( ulong unstaked_idx=0UL; unstaked_idx<existing_unstaked_cnt; unstaked_idx++ ) {
+    fd_shred_dest_weighted_t * in_prev = fd_shred_dest_idx_to_dest( existing_sdest, (fd_shred_dest_idx_t)(existing_staked_cnt + unstaked_idx) );
+    if( FD_UNLIKELY( in_prev->stake_lamports ) ) {
+      in_prev->stake_lamports = 0UL;
+    } else if( FD_LIKELY( j<MAX_SHRED_DESTS ) ) {
+      info->shred_dest[ j++ ] = *in_prev;
+    } /* don't break because we need to finish unmarking any */
+  }
+
+  /* Now we have a plausible shred_dest list. */
+
+  /* Clear the existing info */
+  fd_per_epoch_info_t * new_ei = info->epoch_info + (epoch % 2UL);
+  fd_shred_dest_delete   ( fd_shred_dest_leave   ( new_ei->sdest  ) );
+  fd_epoch_leaders_delete( fd_epoch_leaders_leave( new_ei->lsched ) );
+
+  /* And create the new one */
+  new_ei->epoch      = epoch;
+  new_ei->start_slot = info->scratch->start_slot;
+  new_ei->slot_cnt   = info->scratch->slot_cnt;
+
+  new_ei->lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( new_ei->_lsched, epoch, new_ei->start_slot, new_ei->slot_cnt,
+                                                                staked_cnt, info->stake_weight ) );
+  new_ei->sdest  = fd_shred_dest_join   ( fd_shred_dest_new   ( new_ei->_sdest, info->shred_dest, j,
+                                                                new_ei->lsched, info->identity_key ) );
+  log_summary( "stake update", info );
+}
+
+fd_shred_dest_weighted_t * fd_stake_ci_dest_add_init( fd_stake_ci_t * info ) { return info->shred_dest; }
+
+static inline void
+fd_stake_ci_dest_add_fini_impl( fd_stake_ci_t       * info,
+                                ulong                 cnt,
+                                fd_per_epoch_info_t * ei ) {
+  /* Initially we start with one list containing S+U staked and unstaked
+     destinations jumbled together.  In order to update sdest, we need
+     to convert the list to S' staked destinations (taken from the
+     existing sdest, though possibly updated) followed by U unstaked
+     destinations.
+
+     It's possible to do this in place, but at a cost of additional
+     complexity (similar to memcpy vs memmove).  Rather than do that, we
+     build the combined list in shred_dest_temp. */
+
+  ulong found_unstaked_cnt = 0UL;
+  int   any_new_unstaked   = 0;
+
+  ulong const staked_cnt = fd_shred_dest_cnt_staked( ei->sdest );
+  ulong j = staked_cnt;
+
+  for( ulong i=0UL; i<cnt; i++ ) {
+    fd_shred_dest_idx_t idx = fd_shred_dest_pubkey_to_idx( ei->sdest, &(info->shred_dest[ i ].pubkey) );
+    fd_shred_dest_weighted_t * dest = fd_shred_dest_idx_to_dest( ei->sdest, idx );
+    if( FD_UNLIKELY( dest->stake_lamports==0UL ) ) {
+      /* Copy this destination to the unstaked part of the new list */
+      info->shred_dest_temp[ j ] = info->shred_dest[ i ];
+      info->shred_dest_temp[ j ].stake_lamports = 0UL;
+      j++;
+    }
+
+    if( FD_LIKELY( idx!=FD_SHRED_DEST_NO_DEST ) ) {
+      dest->ip4  = info->shred_dest[ i ].ip4;
+      dest->port = info->shred_dest[ i ].port;
+      memcpy( dest->mac_addr, info->shred_dest[ i ].mac_addr, 6UL );
+    }
+
+    any_new_unstaked   |= (idx==FD_SHRED_DEST_NO_DEST);
+    found_unstaked_cnt += (ulong)((idx!=FD_SHRED_DEST_NO_DEST) & (dest->stake_lamports==0UL));
+  }
+
+  if( FD_LIKELY( !any_new_unstaked && found_unstaked_cnt==fd_shred_dest_cnt_unstaked( ei->sdest ) ) ) {
+    /* Because any_new_unstaked==0, the set of unstaked nodes in this
+       update is fully contained in the set of unstaked nodes in the
+       sdest.  Then additionally, because the sets are the same size,
+       they must actually be equal.  In this case, we've already updated
+       the existing shred_dest_weighted with the newest contact info we
+       have, so there's nothing else to do. */
+    return;
+  }
+
+  /* Otherwise something more significant changed and we need to
+     regenerate the sdest.  At this point, elements [staked_cnt, j) now
+     contain all the current unstaked destinations. */
+
+  /* Copy staked nodes to [0, staked_cnt). We've already applied the
+     updated contact info to these. */
+  for( ulong i=0UL; i<staked_cnt; i++ )
+    info->shred_dest_temp[ i ] = *fd_shred_dest_idx_to_dest( ei->sdest, (fd_shred_dest_idx_t)i );
+
+  /* The staked nodes are sorted properly because we use the index from
+     sdest.  We need to sort the unstaked nodes by pubkey though. */
+  sort_pubkey_inplace( info->shred_dest + staked_cnt, j - staked_cnt );
+
+  fd_shred_dest_delete( fd_shred_dest_leave( ei->sdest ) );
+
+  ei->sdest  = fd_shred_dest_join( fd_shred_dest_new( ei->_sdest, info->shred_dest_temp, j, ei->lsched, info->identity_key ) );
+}
+
+
+void
+fd_stake_ci_dest_add_fini( fd_stake_ci_t * info,
+                           ulong           cnt ) {
+  /* The Rust side uses tvu_peers which excludes the local validator.
+     Add the local validator back. */
+  FD_TEST( cnt<MAX_SHRED_DESTS );
+  fd_shred_dest_weighted_t self_dests[ 1 ] = {{ .pubkey = info->identity_key[ 0 ] }};
+  info->shred_dest[ cnt++ ] = self_dests[ 0 ];
+
+  /* Update both of them */
+  fd_stake_ci_dest_add_fini_impl( info, cnt, info->epoch_info + 0UL );
+  fd_stake_ci_dest_add_fini_impl( info, cnt, info->epoch_info + 1UL );
+
+  log_summary( "dest update", info );
+}
+
+
+/* Returns a value in [0, 2) if found, and ULONG_MAX if not */
+static inline ulong
+fd_stake_ci_get_idx_for_slot( fd_stake_ci_t const * info,
+                              ulong                 slot ) {
+  fd_per_epoch_info_t const * ei = info->epoch_info;
+  ulong idx = ULONG_MAX;
+  for( ulong i=0UL; i<2UL; i++ ) idx = fd_ulong_if( (ei[i].start_slot<=slot) & (slot-ei[i].start_slot<ei[i].slot_cnt), i, idx );
+  return idx;
+}
+
+
+fd_shred_dest_t *
+fd_stake_ci_get_sdest_for_slot( fd_stake_ci_t const * info,
+                                ulong                 slot ) {
+  ulong idx = fd_stake_ci_get_idx_for_slot( info, slot );
+  return idx!=ULONG_MAX ? info->epoch_info[ idx ].sdest : NULL;
+}
+
+fd_epoch_leaders_t *
+fd_stake_ci_get_lsched_for_slot( fd_stake_ci_t const * info,
+                                 ulong                 slot ) {
+  ulong idx = fd_stake_ci_get_idx_for_slot( info, slot );
+  return idx!=ULONG_MAX ? info->epoch_info[ idx ].lsched : NULL;
+}

--- a/src/disco/shred/fd_stake_ci.h
+++ b/src/disco/shred/fd_stake_ci.h
@@ -1,0 +1,154 @@
+#ifndef HEADER_fd_src_app_fdctl_run_tiles_fd_stake_ci_h
+#define HEADER_fd_src_app_fdctl_run_tiles_fd_stake_ci_h
+
+/* fd_stake_ci handles the thorny problem of keeping track of leader
+   schedules and shred destinations, which are epoch specific.  Around
+   epoch boundaries, we may need to query information from the epoch on
+   either side of the boundary.
+
+   When you make a stake delegation change during epoch N, it becomes
+   active at the start of the first slot of epoch N+1, but it doesn't
+   affect the leader schedule or the shred destinations until epoch N+2.
+   These methods take care all that complexity, so the caller does not
+   need to do any adjustment. */
+
+#include "fd_shred_dest.h"
+#include "../../flamenco/leaders/fd_leaders.h"
+
+#define MAX_SHRED_DESTS             40200UL
+#define MAX_SLOTS_PER_EPOCH        432000UL
+#define MAX_SHRED_DEST_FOOTPRINT 10067968UL /* == fd_shred_dest_footprint( MAX_SHRED_DESTS ), runtime asserted in new */
+
+#define FD_STAKE_CI_STAKE_MSG_SZ (32UL + MAX_SHRED_DESTS * 40UL)
+
+struct fd_per_epoch_info_private {
+  /* Epoch, and [start_slot, start_slot+slot_cnt) refer to the time
+     period for which lsched and sdest are valid. I.e. if you're
+     interested in the leader or computing a shred destination for a
+     slot s, this struct has the right data when s is in [start_slot,
+     start_slot+slot_cnt). */
+  ulong epoch;
+  ulong start_slot;
+  ulong slot_cnt;
+
+  /* Invariant: These are always joined and use the memory below for
+     their footprint. */
+  fd_epoch_leaders_t * lsched;
+  fd_shred_dest_t    * sdest;
+
+  uchar __attribute__((aligned(FD_EPOCH_LEADERS_ALIGN))) _lsched[ FD_EPOCH_LEADERS_FOOTPRINT(MAX_SHRED_DESTS, MAX_SLOTS_PER_EPOCH) ];
+  uchar __attribute__((aligned(FD_SHRED_DEST_ALIGN   ))) _sdest [ MAX_SHRED_DEST_FOOTPRINT ];
+};
+typedef struct fd_per_epoch_info_private fd_per_epoch_info_t;
+
+struct fd_stake_ci {
+  fd_pubkey_t identity_key[ 1 ];
+
+  /* scratch and stake_weight are only relevant between stake_msg_init
+     and stake_msg_fini.  shred_dest is only relevant between
+     dest_add_init and dest_add_fini. */
+  struct {
+    ulong epoch;
+    ulong start_slot;
+    ulong slot_cnt;
+    ulong staked_cnt;
+  } scratch[1];
+
+  fd_stake_weight_t        stake_weight   [ MAX_SHRED_DESTS ];
+  fd_shred_dest_weighted_t shred_dest     [ MAX_SHRED_DESTS ];
+
+  fd_shred_dest_weighted_t shred_dest_temp[ MAX_SHRED_DESTS ];
+
+  /* The information to be used for epoch i can be found at
+     epoch_info[ i%2 ] if it is known. */
+  fd_per_epoch_info_t epoch_info[ 2 ];
+};
+typedef struct fd_stake_ci fd_stake_ci_t;
+
+/* fd_stake_ci_{footprint, align} return the footprint and alignment
+   required of a region of memory to be used as an fd_stake_ci_t.
+   fd_stake_ci_t is statically sized, so it can just be declared
+   outright if needed, but it's pretty large (~30 MB!), so you probably
+   don't want it on the stack. */
+
+static inline ulong fd_stake_ci_footprint( void ) { return sizeof (fd_stake_ci_t); }
+static inline ulong fd_stake_ci_align    ( void ) { return alignof(fd_stake_ci_t); }
+
+/* fd_stake_ci_new formats a piece of memory as a valid stake contact
+   information store.  `identity_key` is a pointer to the public key of
+   the identity keypair of the local validator.  This is used by
+   fd_shred_dest to know where in the Turbine tree it belongs.
+   Does NOT retain a read interest in identity_key after the function
+   returns. */
+void          * fd_stake_ci_new ( void * mem, fd_pubkey_t const * identity_key );
+fd_stake_ci_t * fd_stake_ci_join( void * mem );
+
+void * fd_stake_ci_leave ( fd_stake_ci_t * info );
+void * fd_stake_ci_delete( void          * mem  );
+
+/* fd_stake_ci_stake_msg_{init, fini} are used to handle messages
+   containing stake weight updates from the Rust side of the splice, and
+   fd_stake_ci_dest_add_{init, fini} are used to handle messages
+   containing contact info (potential shred destinations) updates from
+   the Rust side of the splice.
+
+   These are very specific to the current splices, but rather than parse
+   the message in the pack and shred tiles, we parse it here.  Since
+   these messages arrive on a dcache and can get overrun, both expose a
+   init/fini model.
+
+   Upon returning from a call to fd_stake_ci_{stake_msg, dest_add}_init,
+   the stake contact info object will be in a stake-msg-pending or
+   dest-add-pending mode, respectively, regardless of what mode it was
+   in before.  In either of these modes, calls to the query functions
+   (get_*_for slot) are okay and will return the same values they
+   returned prior to the _init call.
+
+   In order to call fd_stake_ci_{stake_msg, dest_add}_fini, the stake
+   contact info must be in stake-msg-pending / dest-add-pending mode,
+   respectively.  This means, for example, you cannot call
+   fd_stake_ci_stake_msg_init followed by fd_stake_ci_dest_add_fini
+   without an intervening call to fd_stake_ci_dest_add_init.  There's no
+   need to cancel an operation that begun but didn't finish.  Calling
+   init multiple times without calling fini will not leak any resources.
+
+   new_message should be a pointer to the first byte of the dcache entry
+   containing the stakes update.  new_message will be accessed
+   new_message[i] for i in [0, FD_STAKE_CI_STAKE_MSG_SZ).
+
+   fd_stake_ci_dest_add_init behaves slightly differently and returns a
+   pointer to the first element of an array of size MAX_SHRED_DESTS-1 to
+   be populated.  This allows the caller to add augment the information
+   in the message from Rust with additional information (i.e. mac
+   addresses).  The `cnt` argument to _dest_add_fini specifies the
+   number of elements of the array returned by _init that were
+   populated. 0<=cnt<MAX_SHRED_DESTS.  _fini will only read the first
+   `cnt` elements of the array.  The identity pubkey provided at
+   initialization must not be one of the cnt values in the array.  The
+   caller should not retain a read or write interest in the pointer
+   returned by _init after fini has been called, or after the caller has
+   determined that fini will not be called for that update, e.g. because
+   the update was overrun.  Calls to _fini may clobber the array.  */
+void                       fd_stake_ci_stake_msg_init( fd_stake_ci_t * info, uchar const * new_message );
+void                       fd_stake_ci_stake_msg_fini( fd_stake_ci_t * info                            );
+fd_shred_dest_weighted_t * fd_stake_ci_dest_add_init ( fd_stake_ci_t * info                            );
+void                       fd_stake_ci_dest_add_fini ( fd_stake_ci_t * info, ulong cnt                 );
+
+
+/* fd_stake_ci_get_{sdest, lsched}_for_slot respectively return a
+   pointer to the fd_shred_dest_t and fd_epoch_leaders_t containin
+   information about the specified slot, if it is available.  These
+   functions are the primary query functions for fd_stake_ci.  They
+   return NULL if we don't have information for that slot.
+
+   The fact these take a slot perhaps makes it more clear, but, it's
+   worth mentioning again there's nothing like the adjustment performed
+   by Solana's get_leader_schedule_epoch going on here.  If you want to
+   know the leader in slot X, just pass slot X.  The returned leader
+   schedule will not be based on the stake weights active during slot X,
+   but rather the stake weights offset in time by an appropriate amount
+   so they apply to slot X. */
+fd_shred_dest_t *    fd_stake_ci_get_sdest_for_slot ( fd_stake_ci_t const * info, ulong slot );
+fd_epoch_leaders_t * fd_stake_ci_get_lsched_for_slot( fd_stake_ci_t const * info, ulong slot );
+
+#endif /* HEADER_fd_src_app_fdctl_run_tiles_fd_stake_ci_h */


### PR DESCRIPTION
Rather than sending the full leader schedule, we now send the stake weights. These are usable by the pack tile and the shred tile. Also changed the splice point for contact info.

Around epoch boundaries, this can get a little tricky (especially in the shred tile case), so we keep around an even epoch and an odd epoch, which is normally the current epoch and the next epoch. We get the next epoch as soon as the current one is rooted.