### PR TITLE
fdctl: add help message and vote keygen

### DIFF
--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -5,7 +5,7 @@ ifdef FD_HAS_DOUBLE
 
 .PHONY: fdctl cargo
 
-$(call add-objs,main1 config caps utility topology keygen ready info run/run run/tiles/tiles run/tiles/fd_net run/tiles/fd_netmux run/tiles/fd_dedup run/tiles/fd_pack run/tiles/fd_quic run/tiles/fd_verify run/tiles/fd_bank run/tiles/fd_shred run/tiles/fd_store monitor/monitor monitor/helper configure/configure configure/large_pages configure/sysctl configure/shmem configure/xdp configure/xdp_leftover configure/ethtool configure/workspace_leftover configure/workspace,fd_fdctl)
+$(call add-objs,main1 config caps utility topology keygen ready mem help run/run run/tiles/tiles run/tiles/fd_net run/tiles/fd_netmux run/tiles/fd_dedup run/tiles/fd_pack run/tiles/fd_quic run/tiles/fd_verify run/tiles/fd_bank run/tiles/fd_shred run/tiles/fd_store monitor/monitor monitor/helper configure/configure configure/large_pages configure/sysctl configure/shmem configure/xdp configure/xdp_leftover configure/ethtool configure/workspace_leftover configure/workspace,fd_fdctl)
 $(call make-bin-rust,fdctl,main,fd_fdctl fd_disco fd_flamenco fd_ip fd_reedsol fd_ballet fd_tango fd_util fd_quic solana_validator)
 $(OBJDIR)/obj/app/fdctl/configure/xdp.o: src/tango/xdp/fd_xdp_redirect_prog.o
 $(OBJDIR)/obj/app/fdctl/config.o: src/app/fdctl/config/default.toml

--- a/src/app/fdctl/fdctl.h
+++ b/src/app/fdctl/fdctl.h
@@ -34,8 +34,12 @@ typedef union {
 
   struct {
     char tile_name[ 32 ];
-    int no_configure;
+    int  no_configure;
   } dev1;
+
+  struct {
+    ulong key_type;
+  } keygen;
 
   struct {
     const char * payload_base64;
@@ -48,13 +52,15 @@ typedef union {
 typedef struct fd_caps_ctx fd_caps_ctx_t;
 
 typedef struct {
-    const char * name;
-    void       (*args)( int * pargc, char *** pargv, args_t * args );
-    void       (*perm)( args_t * args, fd_caps_ctx_t * caps, config_t * const config );
-    void       (*fn  )( args_t * args, config_t * const config );
+  const char * name;
+  const char * description;
+
+  void       (*args)( int * pargc, char *** pargv, args_t * args );
+  void       (*perm)( args_t * args, fd_caps_ctx_t * caps, config_t * const config );
+  void       (*fn  )( args_t * args, config_t * const config );
 } action_t;
 
-#define ACTIONS_CNT (8UL)
+#define ACTIONS_CNT (7UL)
 extern action_t ACTIONS[ ACTIONS_CNT ];
 
 int
@@ -99,6 +105,11 @@ monitor_cmd_fn( args_t *         args,
                 config_t * const config );
 
 void
+keygen_cmd_args( int *    pargc,
+                 char *** pargv,
+                 args_t * args );
+
+void
 keygen_cmd_fn( args_t *         args,
                config_t * const config );
 
@@ -107,7 +118,11 @@ ready_cmd_fn( args_t *         args,
               config_t * const config );
 
 void
-info_cmd_fn( args_t *         args,
+mem_cmd_fn( args_t *         args,
+            config_t * const config );
+
+void
+help_cmd_fn( args_t *         args,
              config_t * const config );
 
 #endif /* HEADER_fd_src_app_fdctl_fdctl_h */

--- a/src/app/fdctl/help.c
+++ b/src/app/fdctl/help.c
@@ -1,0 +1,36 @@
+#include "fdctl.h"
+
+#include <stdio.h>
+
+#define MAX_LENGTH 4096
+
+#define PRINT_HELP( ... ) do {                                                \
+    int n = snprintf( cur, rem, __VA_ARGS__ );                                \
+    if( FD_UNLIKELY( n < 0 ) ) FD_LOG_ERR(( "snprintf failed" ));             \
+    if( FD_UNLIKELY( (ulong)n >= rem ) ) FD_LOG_ERR(( "snprintf overflow" )); \
+    rem -= (ulong)n;                                                          \
+    cur += n;                                                                 \
+  } while( 0 )
+
+void
+help_cmd_fn( args_t *         args,
+             config_t * const config ) {
+  (void)args;
+  (void)config;
+
+  char help[ MAX_LENGTH ] = {0};
+  char * cur = help;
+  ulong rem = MAX_LENGTH-1; /* Leave one character to NUL terminate string */
+
+  PRINT_HELP( "Firedancer control binary\n\n" );
+  PRINT_HELP( "Usage: fdctl [OPTIONS] <SUBCOMMAND>\n\n" );
+  PRINT_HELP( "\nOPTIONS:\n" );
+  /* fdctl does not have many flag arguments so we hard-code the
+     --config parameter. */
+  PRINT_HELP( "        --config <PATH>    Path to config TOML file\n\n" );
+  PRINT_HELP( "SUBCOMMANDS:\n" );
+  for( ulong i=0; i<ACTIONS_CNT ; i++ ) {
+    PRINT_HELP( "    %9s    %s\n", ACTIONS[ i ].name, ACTIONS[ i ].description );
+  }
+  fd_log_private_fprintf_0( STDOUT_FILENO, "%s", help );
+}

--- a/src/app/fdctl/keygen.c
+++ b/src/app/fdctl/keygen.c
@@ -5,16 +5,39 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <sys/stat.h>
+#include <sys/random.h>
+
+#define KEYGEN_KEY_IDENTITY     (0UL)
+#define KEYGEN_KEY_VOTE_ACCOUNT (1UL)
+
+void
+keygen_cmd_args( int *    pargc,
+                 char *** pargv,
+                 args_t * args) {
+  char * usage = "usage: keygen <identity|vote>";
+  if( FD_UNLIKELY( *pargc < 1 ) ) FD_LOG_ERR(( "%s", usage ));
+
+  if( FD_LIKELY( !strcmp( *pargv[ 0 ], "identity" ) ) ) args->keygen.key_type = KEYGEN_KEY_IDENTITY;
+  else if( FD_LIKELY( !strcmp( *pargv[ 0 ], "vote"  ) ) ) args->keygen.key_type = KEYGEN_KEY_VOTE_ACCOUNT;
+  else FD_LOG_ERR(( "unrecognized subcommand `%s`, %s", *pargv[0], usage ));
+
+  (*pargc)--;
+  (*pargv)++;
+
+  return;
+}
 
 void
 generate_keypair( const char * keyfile,
                   config_t * const config ) {
   uchar keys[ 64 ];
 
-  FILE * fp = fopen( "/dev/urandom", "r" );
-  if( FD_UNLIKELY( !fp ) ) FD_LOG_ERR(( "could not create keypair, fopen(/dev/urandom) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
-  if( FD_UNLIKELY( fread( keys, 1, 32, fp ) != 32 ) ) FD_LOG_ERR(( "could not create keypair, fread(/dev/urandom) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
-  if( FD_UNLIKELY( fclose( fp ) ) ) FD_LOG_ERR(( "could not create keypair, fclose(/dev/urandom) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  long bytes_produced = 0L;
+  while( FD_LIKELY( bytes_produced<32 ) ) {
+    long n = getrandom( keys+bytes_produced, (ulong)(32-bytes_produced), GRND_RANDOM );
+    if( FD_UNLIKELY( -1==n ) ) FD_LOG_ERR(( "could not create keypair, getrandom() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    bytes_produced += n;
+  }
 
   fd_sha512_t _sha[1];
   fd_sha512_t * sha = fd_sha512_join( fd_sha512_new( _sha ) );
@@ -31,7 +54,7 @@ generate_keypair( const char * keyfile,
 
   mode_t previous = umask( S_IRWXO | S_IRWXG | S_IXUSR );
 
-  fp = fopen( keyfile, "wx" );
+  FILE * fp = fopen( keyfile, "wx" );
   if( FD_UNLIKELY( !fp ) ) {
     if( FD_LIKELY( errno == EEXIST ) )
       FD_LOG_ERR(( "could not create keypair as the keyfile `%s` already exists", keyfile ));
@@ -64,7 +87,15 @@ generate_keypair( const char * keyfile,
 void
 keygen_cmd_fn( args_t *         args,
                config_t * const config ) {
-  (void)args;
+  if( FD_LIKELY( args->keygen.key_type == KEYGEN_KEY_IDENTITY ) ) {
+    generate_keypair( config->consensus.identity_path, config );
+  } else if( FD_LIKELY( args->keygen.key_type == KEYGEN_KEY_VOTE_ACCOUNT ) ) {
+    if( FD_UNLIKELY( !strcmp( config->consensus.vote_account_path, "" ) ) )
+      FD_LOG_ERR(( "Cannot create a vote account keypair because your validator is not configured "
+                   "to vote. Please set [consensus.vote_account_path] in your configuration file." ));
 
-  generate_keypair( config->consensus.identity_path, config );
+    generate_keypair( config->consensus.vote_account_path, config );
+  } else {
+    FD_LOG_ERR(( "unknown key type `%lu`", args->keygen.key_type ));
+  }
 }

--- a/src/app/fdctl/mem.c
+++ b/src/app/fdctl/mem.c
@@ -1,8 +1,8 @@
 #include "fdctl.h"
 
 void
-info_cmd_fn( args_t *         args,
-             config_t * const config ) {
+mem_cmd_fn( args_t *         args,
+            config_t * const config ) {
   (void)args;
 
   fd_topo_fill( &config->topo, FD_TOPO_FILL_MODE_FOOTPRINT );

--- a/src/app/fdctl/topology.c
+++ b/src/app/fdctl/topology.c
@@ -729,7 +729,7 @@ fd_topo_print_log( fd_topo_t * topo ) {
 
     char size[ 24 ];
     fd_topo_mem_sz_string( wksp->page_sz * wksp->page_cnt, size );
-    PRINT( "  %2lu (%6s): %12s  page_cnt=%lu  page_sz=%-8s  footprint=%-10lu  loose=%lu\n", i, size, fd_topo_wksp_kind_str( wksp->kind ), wksp->page_cnt, fd_shmem_page_sz_to_cstr( wksp->page_sz ), wksp->known_footprint, wksp->total_footprint - wksp->known_footprint );
+    PRINT( "  %2lu (%7s): %12s  page_cnt=%lu  page_sz=%-8s  footprint=%-10lu  loose=%lu\n", i, size, fd_topo_wksp_kind_str( wksp->kind ), wksp->page_cnt, fd_shmem_page_sz_to_cstr( wksp->page_sz ), wksp->known_footprint, wksp->total_footprint - wksp->known_footprint );
   }
 
   PRINT( "\nLINKS\n" );
@@ -738,7 +738,7 @@ fd_topo_print_log( fd_topo_t * topo ) {
 
     char size[ 24 ];
     fd_topo_mem_sz_string( fd_dcache_req_data_sz( link->mtu, link->depth, link->burst, 1 ), size );
-    PRINT( "  %2lu (%6s): %12s  kind_id=%-2lu  wksp_id=%-2lu  depth=%-5lu  mtu=%-9lu  burst=%lu\n", i, size, fd_topo_link_kind_str( link->kind ), link->kind_id, link->wksp_id, link->depth, link->mtu, link->burst );
+    PRINT( "  %2lu (%7s): %12s  kind_id=%-2lu  wksp_id=%-2lu  depth=%-5lu  mtu=%-9lu  burst=%lu\n", i, size, fd_topo_link_kind_str( link->kind ), link->kind_id, link->wksp_id, link->depth, link->mtu, link->burst );
   }
 
 #define PRINTIN( ... ) do {                                                            \
@@ -785,7 +785,7 @@ fd_topo_print_log( fd_topo_t * topo ) {
       snprintf1( out_link_id, 24, "%lu", tile->out_link_id_primary );
     char size[ 24 ];
     fd_topo_mem_sz_string( fd_topo_mlock_max_tile1( topo, tile ), size );
-    PRINT( "  %2lu (%6s): %12s  kind_id=%-2lu  wksp_id=%-2lu  out_link=%-2s  in=[%s]  out=[%s]", i, size, fd_topo_tile_kind_str( tile->kind ), tile->kind_id, tile->wksp_id, out_link_id, in, out );
+    PRINT( "  %2lu (%7s): %12s  kind_id=%-2lu  wksp_id=%-2lu  out_link=%-2s  in=[%s]  out=[%s]", i, size, fd_topo_tile_kind_str( tile->kind ), tile->kind_id, tile->wksp_id, out_link_id, in, out );
     if( FD_LIKELY( i != topo->tile_cnt-1 ) ) PRINT( "\n" );
   }
 


### PR DESCRIPTION
```
$ build/native/gcc/bin/fdctl help
NOTICE  10-27 15:48:56.962811 2095364 f0   main src/app/fdctl/help.c(56): 
fdctl: Firedancer control binary

usage: fdctl [OPTIONS] <SUBCOMMAND>

Sub Commands:
             run        Start up a firedancer validator
       configure        Setup the environment needed to start firedancer
         monitor        Monitor a locally running firedancer validator
          keygen        Generate identity and voting keypairs
           ready        Detect if all CNC pieces are ready
             mem        Print workspace memory and topology information [ aliases: info, topo ]
            help        Print this help message

Options:
        --config <PATH>
                Path to config TOML file
```