### PR TITLE
quic-arp - disable broadcast ips

### DIFF
--- a/src/tango/ip/fd_ip.c
+++ b/src/tango/ip/fd_ip.c
@@ -337,22 +337,22 @@ fd_ip_route_ip_addr( uchar *   out_dst_mac,
   if( route_entry->nh_ip_addr ) {
     next_ip_addr = route_entry->nh_ip_addr; /* use next hop */
   } else {
-    uint host_mask = ~route_entry->dst_netmask;
-    if( ( ip_addr & host_mask ) == ( 0xffffffff & host_mask ) ) {
-      /* Local address, and subnet broadcast - send to ff:ff:ff:ff:ff:ff */
+    //uint host_mask = ~route_entry->dst_netmask;
+    //if( ( ip_addr & host_mask ) == ( 0xffffffff & host_mask ) ) {
+    //  /* Local address, and subnet broadcast - send to ff:ff:ff:ff:ff:ff */
 
-      /* broadcast */
-      out_dst_mac[0] = 0xffU;
-      out_dst_mac[1] = 0xffU;
-      out_dst_mac[2] = 0xffU;
-      out_dst_mac[3] = 0xffU;
-      out_dst_mac[4] = 0xffU;
-      out_dst_mac[5] = 0xffU;
+    //  /* broadcast */
+    //  out_dst_mac[0] = 0xffU;
+    //  out_dst_mac[1] = 0xffU;
+    //  out_dst_mac[2] = 0xffU;
+    //  out_dst_mac[3] = 0xffU;
+    //  out_dst_mac[4] = 0xffU;
+    //  out_dst_mac[5] = 0xffU;
 
-      *out_ifindex = route_entry->oif;
+    //  *out_ifindex = route_entry->oif;
 
-      return FD_IP_BROADCAST;
-    }
+    //  return FD_IP_BROADCAST;
+    //}
 
     /* else local unicast */
 

--- a/src/tango/ip/test_routing.c
+++ b/src/tango/ip/test_routing.c
@@ -259,7 +259,7 @@ test_routes_1( fd_ip_t * ip ) {
 
 #define TEST_MAC( a, b, c, d, e, f ) ((uchar[]){a,b,c,d,e,f})
   /* local subnet broadcast ip */
-  test_route( ip, TEST_IP( 192, 168, 200, 255 ), FD_IP_BROADCAST, TEST_IP(   0,   0,   0,   0 ), 100, TEST_MAC( 0xff, 0xff, 0xff, 0xff, 0xff, 0xff ) );
+  //test_route( ip, TEST_IP( 192, 168, 200, 255 ), FD_IP_BROADCAST, TEST_IP(   0,   0,   0,   0 ), 100, TEST_MAC( 0xff, 0xff, 0xff, 0xff, 0xff, 0xff ) );
 
   /* routable subnet broadcast ip addresses */
   test_route( ip, TEST_IP( 192, 168, 255, 255 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 101 ), 101, TEST_MAC( 0x42, 0x42, 200,   1,   1, 101 ) );
@@ -337,7 +337,7 @@ test_routes_3( fd_ip_t * ip ) {
 
 #define TEST_MAC( a, b, c, d, e, f ) ((uchar[]){a,b,c,d,e,f})
   /* local subnet broadcast ip */
-  test_route( ip, TEST_IP( 192, 168, 200, 255 ), FD_IP_BROADCAST, TEST_IP(   0,   0,   0,   0 ), 100, TEST_MAC( 0xff, 0xff, 0xff, 0xff, 0xff, 0xff ) );
+  //test_route( ip, TEST_IP( 192, 168, 200, 255 ), FD_IP_BROADCAST, TEST_IP(   0,   0,   0,   0 ), 100, TEST_MAC( 0xff, 0xff, 0xff, 0xff, 0xff, 0xff ) );
 
   /* routable subnet broadcast ip addresses */
   test_route( ip, TEST_IP( 192, 168, 255, 255 ), FD_IP_SUCCESS,   TEST_IP( 200,   1,   1, 101 ), 101, TEST_MAC( 0x42, 0x42, 200,   1,   1, 101 ) );


### PR DESCRIPTION
This code misbehaved. It's unneeded for now, so disable for now.