### PR TITLE
quic: do not clear on join

### DIFF
--- a/src/tango/quic/fd_quic.c
+++ b/src/tango/quic/fd_quic.c
@@ -308,13 +308,6 @@ fd_quic_join( void * shquic ) {
     return NULL;
   }
 
-  /* Clear join-lifetime memory regions */
-
-  quic->cert_object     = NULL;
-  quic->cert_key_object = NULL;
-
-  memset( &quic->cb, 0, sizeof( fd_quic_callbacks_t  ) );
-
   return quic;
 }
 


### PR DESCRIPTION
As additional tiles might join a QUIC object (e.g. to read metrics), the join function should not clear memory.