### PR TITLE
fd_ip - added diagnostics for unusual LL ADDR length

### DIFF
--- a/src/tango/ip/fd_netlink.c
+++ b/src/tango/ip/fd_netlink.c
@@ -200,7 +200,7 @@ fd_nl_dump_rat( struct rtattr * rat, long ratmsglen ) {
     rat = RTA_NEXT( rat, ratmsglen );
   }
 
-  FD_LOG_WARNING(( "%s", buf ));
+  FD_LOG_NOTICE(( "%s", buf ));
 }
 
 


### PR DESCRIPTION
Getting an warning reported from a user.
This adds the needed info from netlink to diagnose the issue.