### PR TITLE
quic: support loopback for QUIC connections

### DIFF
--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -6,7 +6,7 @@ on:
       - main
   workflow_dispatch:
 jobs:
-  single-transaction:
+  functional-tests:
     runs-on:
       group: github-v1
     env:
@@ -24,7 +24,10 @@ jobs:
       - uses: ./.github/actions/deps
 
       - name: Build everything
-        run: make -j -Otarget fddev unit-test
+        run: make -j -Otarget fddev
 
-      - name: Run functional tests
+      - name: Run single transaction
         run: ./src/test/single-transaction.sh
+
+      - name: Run single transfer
+        run: ./src/test/single-transfer.sh

--- a/book/guide/initializing.md
+++ b/book/guide/initializing.md
@@ -92,16 +92,18 @@ for best performance. The `sysctl` stage will check and configure these
 parameters. The stage will only increase values to meet the minimum, and
 will not decrease them if the minimum is already met.
 
-| Sysctl                            | Minimum     | Description
-| --------------------------------- | ----------- | -----------
-| /proc/sys/net/core/rmem_max       | 134217728   | Solana Labs network performance tuning.
-| /proc/sys/net/core/rmem_default   | 134217728   | Solana Labs network performance tuning.
-| /proc/sys/net/core/wmem_max       | 134217728   | Solana Labs network performance tuning.
-| /proc/sys/net/core/wmem_default   | 134217728   | Solana Labs network performance tuning.
-| /proc/sys/vm/max_map_count        | 1000000     | Solana Labs accounts database requires mapping many files.
-| /proc/sys/fs/file-max             | 1024000     | Solana Labs accounts database requires opening many files.
-| /proc/sys/fs/nr_open              | 1024000     | Solana Labs accounts database requires opening many files.
-| /proc/sys/net/core/bpf_jit_enable | 1           | Firedancer uses BPF for kernel bypass networking. BPF JIT makes this faster.
+| Sysctl                                  | Minimum     | Description
+|-----------------------------------------| ----------- | -----------
+| /proc/sys/net/core/rmem_max             | 134217728   | Solana Labs network performance tuning.
+| /proc/sys/net/core/rmem_default         | 134217728   | Solana Labs network performance tuning.
+| /proc/sys/net/core/wmem_max             | 134217728   | Solana Labs network performance tuning.
+| /proc/sys/net/core/wmem_default         | 134217728   | Solana Labs network performance tuning.
+| /proc/sys/vm/max_map_count              | 1000000     | Solana Labs accounts database requires mapping many files.
+| /proc/sys/fs/file-max                   | 1024000     | Solana Labs accounts database requires opening many files.
+| /proc/sys/fs/nr_open                    | 1024000     | Solana Labs accounts database requires opening many files.
+| /proc/sys/net/core/bpf_jit_enable       | 1           | Firedancer uses BPF for kernel bypass networking. BPF JIT makes this faster.
+| /proc/sys/net/ipv4/conf/lo/rp_filter    | 2           | Enable loose mode for reverse path filtering on the loopback interface. Loose mode is required for the XSK socket to successfully send packets to loopback.
+| /proc/sys/net/ipv4/conf/lo/accept_local | 1           | Accept packets with local source addresses on the loopback interface. This is required for the XSK socket to successfully send packets to loopback.
 
 The `init` mode requires either `root` privileges, or to be run with
 `CAP_SYS_ADMIN`. The `fini` mode does nothing and kernel parameters

--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -3,7 +3,7 @@ ifdef FD_HAS_ALLOCA
 ifdef FD_HAS_X86
 ifdef FD_HAS_DOUBLE
 
-.PHONY: fdctl cargo
+.PHONY: fdctl cargo rust solana
 
 $(call add-objs,main1 config caps utility topology keygen ready mem spy help run/run run/tiles/tiles run/run1 run/run_solana run/tiles/tiles run/tiles/fd_net run/tiles/fd_netmux run/tiles/fd_dedup run/tiles/fd_pack run/tiles/fd_quic run/tiles/fd_verify run/tiles/fd_bank run/tiles/fd_shred run/tiles/fd_store monitor/monitor monitor/helper configure/configure configure/large_pages configure/sysctl configure/shmem configure/xdp configure/xdp_leftover configure/ethtool configure/workspace_leftover configure/workspace,fd_fdctl)
 $(call make-bin-rust,fdctl,main,fd_fdctl fd_disco fd_flamenco fd_ip fd_reedsol fd_ballet fd_tango fd_util fd_quic solana_validator)
@@ -55,6 +55,10 @@ $(OBJDIR)/bin/solana: solana/target/$(RUST_PROFILE)/solana
 	$(MKDIR) $(dir $@) && cp solana/target/$(RUST_PROFILE)/solana $@
 
 rust: $(OBJDIR)/bin/solana
+
+solana: $(OBJDIR)/bin/solana
+
+else
 
 endif
 endif

--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -3,9 +3,9 @@ ifdef FD_HAS_ALLOCA
 ifdef FD_HAS_X86
 ifdef FD_HAS_DOUBLE
 
-.PHONY: fdctl cargo rust solana
+.PHONY: fdctl cargo
 
-$(call add-objs,main1 config caps utility topology keygen ready mem spy help run/run run/tiles/tiles run/run1 run/run_solana run/tiles/tiles run/tiles/fd_net run/tiles/fd_netmux run/tiles/fd_dedup run/tiles/fd_pack run/tiles/fd_quic run/tiles/fd_verify run/tiles/fd_bank run/tiles/fd_shred run/tiles/fd_store monitor/monitor monitor/helper configure/configure configure/large_pages configure/sysctl configure/shmem configure/xdp configure/xdp_leftover configure/ethtool configure/workspace_leftover configure/workspace,fd_fdctl)
+$(call add-objs,main1 config caps utility topology keys ready mem spy help run/run run/tiles/tiles run/run1 run/run_solana run/tiles/tiles run/tiles/fd_net run/tiles/fd_netmux run/tiles/fd_dedup run/tiles/fd_pack run/tiles/fd_quic run/tiles/fd_verify run/tiles/fd_bank run/tiles/fd_shred run/tiles/fd_store monitor/monitor monitor/helper configure/configure configure/large_pages configure/sysctl configure/shmem configure/xdp configure/xdp_leftover configure/ethtool configure/workspace_leftover configure/workspace,fd_fdctl)
 $(call make-bin-rust,fdctl,main,fd_fdctl fd_disco fd_flamenco fd_ip fd_reedsol fd_ballet fd_tango fd_util fd_quic solana_validator)
 $(OBJDIR)/obj/app/fdctl/configure/xdp.o: src/tango/xdp/fd_xdp_redirect_prog.o
 $(OBJDIR)/obj/app/fdctl/config.o: src/app/fdctl/config/default.toml
@@ -52,13 +52,9 @@ $(OBJDIR)/lib/libsolana_validator.a: solana/target/$(RUST_PROFILE)/libsolana_val
 fdctl: $(OBJDIR)/bin/fdctl
 
 $(OBJDIR)/bin/solana: solana/target/$(RUST_PROFILE)/solana
-	$(MKDIR) $(dir $@) && cp solana/target/$(RUST_PROFILE)/solana $@
+	$(MKDIR) -p $(dir $@) && cp solana/target/$(RUST_PROFILE)/solana $@
 
 rust: $(OBJDIR)/bin/solana
-
-solana: $(OBJDIR)/bin/solana
-
-else
 
 endif
 endif

--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -922,7 +922,7 @@ config_parse( int *      pargc,
         tile->net.xdp_aio_depth = config->tiles.net.xdp_aio_depth;
         tile->net.xdp_rx_queue_size = config->tiles.net.xdp_rx_queue_size;
         tile->net.xdp_tx_queue_size = config->tiles.net.xdp_tx_queue_size;
-        tile->net.src_ip_addr = result.tiles.net.ip_addr;
+        tile->net.src_ip_addr      = config->tiles.net.ip_addr;
         tile->net.allow_ports[ 0 ] = config->tiles.quic.regular_transaction_listen_port;
         tile->net.allow_ports[ 1 ] = config->tiles.quic.quic_transaction_listen_port;
         tile->net.allow_ports[ 2 ] = config->tiles.shred.shred_listen_port;

--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -922,6 +922,7 @@ config_parse( int *      pargc,
         tile->net.xdp_aio_depth = config->tiles.net.xdp_aio_depth;
         tile->net.xdp_rx_queue_size = config->tiles.net.xdp_rx_queue_size;
         tile->net.xdp_tx_queue_size = config->tiles.net.xdp_tx_queue_size;
+        tile->net.src_ip_addr = result.tiles.net.ip_addr;
         tile->net.allow_ports[ 0 ] = config->tiles.quic.regular_transaction_listen_port;
         tile->net.allow_ports[ 1 ] = config->tiles.quic.quic_transaction_listen_port;
         tile->net.allow_ports[ 2 ] = config->tiles.shred.shred_listen_port;

--- a/src/app/fdctl/configure/sysctl.c
+++ b/src/app/fdctl/configure/sysctl.c
@@ -21,6 +21,8 @@ static const char * params[] = {
   "/proc/sys/net/core/bpf_jit_enable",
   "/proc/sys/fs/file-max",
   "/proc/sys/fs/nr_open",
+  "/proc/sys/net/ipv4/conf/lo/rp_filter",
+  "/proc/sys/net/ipv4/conf/lo/accept_local",
 };
 
 static uint limits[] = {
@@ -32,6 +34,8 @@ static uint limits[] = {
   1,
   CONFIGURE_NR_OPEN_FILES,
   CONFIGURE_NR_OPEN_FILES,
+  2,
+  1,
 };
 
 static const char * ERR_MSG = "system might not support configuring sysctl,";

--- a/src/app/fdctl/fdctl.h
+++ b/src/app/fdctl/fdctl.h
@@ -45,8 +45,9 @@ typedef union {
   } dev1;
 
   struct {
-    ulong key_type;
-  } keygen;
+    ulong cmd;
+    char  file_path[ 256 ];
+  } keys;
 
   struct {
     const char * payload_base64;
@@ -129,13 +130,13 @@ monitor_cmd_fn( args_t *         args,
                 config_t * const config );
 
 void
-keygen_cmd_args( int *    pargc,
-                 char *** pargv,
-                 args_t * args );
+keys_cmd_args( int *    pargc,
+               char *** pargv,
+               args_t * args );
 
 void
-keygen_cmd_fn( args_t *         args,
-               config_t * const config );
+keys_cmd_fn( args_t *         args,
+             config_t * const config );
 
 void
 ready_cmd_fn( args_t *         args,

--- a/src/app/fdctl/main1.c
+++ b/src/app/fdctl/main1.c
@@ -13,7 +13,7 @@ action_t ACTIONS[ ACTIONS_CNT ] = {
   { .name = "run-solana", .args = NULL,               .fn = run_solana_cmd_fn, .perm = NULL,                .description = "Start up the Solana Labs side of a Firedancer validator" },
   { .name = "configure",  .args = configure_cmd_args, .fn = configure_cmd_fn,  .perm = configure_cmd_perm,  .description = "Configure the local host so it can run Firedancer correctly" },
   { .name = "monitor",    .args = monitor_cmd_args,   .fn = monitor_cmd_fn,    .perm = monitor_cmd_perm,    .description = "Monitor a locally running Firedancer instance with a terminal GUI" },
-  { .name = "keygen",     .args = keygen_cmd_args,    .fn = keygen_cmd_fn,     .perm = NULL,                .description = "Generate new keypairs for use with the validator" },
+  { .name = "keys",       .args = keys_cmd_args,      .fn = keys_cmd_fn,       .perm = NULL,                .description = "Generate new keypairs for use with the validator or print a public key" },
   { .name = "ready",      .args = NULL,               .fn = ready_cmd_fn,      .perm = NULL,                .description = "Wait for all tiles to be running" },
   { .name = "mem",        .args = NULL,               .fn = mem_cmd_fn,        .perm = NULL,                .description = "Print workspace memory and tile topology information" },
   { .name = "spy",        .args = NULL,               .fn = spy_cmd_fn,        .perm = NULL,                .description = "Spy on and print out gossip traffic" },

--- a/src/app/fdctl/run/tiles/fd_net.c
+++ b/src/app/fdctl/run/tiles/fd_net.c
@@ -5,10 +5,7 @@
 #include "../../../../tango/quic/fd_quic.h"
 #include "../../../../tango/xdp/fd_xdp.h"
 #include "../../../../tango/xdp/fd_xsk_private.h"
-
-#include "../../../../util/net/fd_eth.h"
 #include "../../../../util/net/fd_ip4.h"
-#include "../../../../util/net/fd_udp.h"
 
 #include <linux/unistd.h>
 
@@ -184,7 +181,7 @@ before_frag( void * _ctx,
 
   /* Round robin by sequence number for now, QUIC should be modified to
      echo the net tile index back so we can transmit on the same queue.
-     
+
      127.0.0.1 packets for localhost must go out on net tile 0 which
      owns the loopback interface XSK, which only has 1 queue. */
   int handled_packet = 0;
@@ -219,12 +216,6 @@ during_frag( void * _ctx,
   fd_memcpy( ctx->frame, src, sz ); // TODO: Change xsk_aio interface to eliminate this copy
 }
 
-typedef struct __attribute__((packed)) {
-  fd_eth_hdr_t eth[1];
-  fd_ip4_hdr_t ip4[1];
-  fd_udp_hdr_t udp[1];
-} eth_ip_udp_t;
-
 static void
 after_frag( void *             _ctx,
             ulong              in_idx,
@@ -243,29 +234,6 @@ after_frag( void *             _ctx,
 
   fd_aio_pkt_info_t aio_buf = { .buf = ctx->frame, .buf_sz = (ushort)*opt_sz };
   if( FD_UNLIKELY( route_loopback( ctx->src_ip_addr, *opt_sig ) ) ) {
-    /* Because we are skipping part of the kernel networking stack, we
-       need to reformat the packet so it will get accepted onto the
-       loopback device.  A few things are needed,
-       
-        (1) The src and dst ip addresses both need to be zero. Not
-            entirely sure why, but the kernel will silently discard
-            packets that arrive onto lo without this, probably it
-            sets them to zero as part of a sanity check in the code
-            that runs before the XDP splice point.
-            
-        (2) The src mac address can be anything, but the dst mac
-            address must be zero.  Similar story to the above, not
-            entirely sure why. */
-    eth_ip_udp_t * hdr = (eth_ip_udp_t *)ctx->frame;
-    if( FD_UNLIKELY( *opt_sz < sizeof( eth_ip_udp_t ) ) )
-      FD_LOG_ERR(( "loopback packet too small %lu", *opt_sz ));
-
-    fd_memset( hdr->eth->dst, 0, 6UL );
-    fd_memset( hdr->ip4->daddr_c, 0, 4UL );
-    fd_memset( hdr->ip4->saddr_c, 0, 4UL );
-    hdr->ip4->check = 0U;
-    /* TODO: Do we need to update check here? */
-    hdr->ip4->check = fd_ip4_hdr_check( ( fd_ip4_hdr_t const *) FD_ADDRESS_OF_PACKED_MEMBER( hdr->ip4 ) );
     ctx->lo_tx->send_func( ctx->xsk_aio[ 1 ], &aio_buf, 1, NULL, 1 );
   } else {
     ctx->tx->send_func( ctx->xsk_aio[ 0 ], &aio_buf, 1, NULL, 1 );
@@ -349,7 +317,7 @@ unprivileged_init( fd_topo_t *      topo,
     ctx->lo_tx = fd_xsk_aio_get_tx( init_ctx->lo_xsk_aio );
     ctx->xsk_aio_cnt = 2;
   }
-  
+
   ctx->src_ip_addr = tile->net.src_ip_addr;
 
   for( ulong i=0UL; i<FD_NET_PORT_ALLOW_CNT; i++ ) {

--- a/src/app/fdctl/run/tiles/fd_net.c
+++ b/src/app/fdctl/run/tiles/fd_net.c
@@ -6,6 +6,10 @@
 #include "../../../../tango/xdp/fd_xdp.h"
 #include "../../../../tango/xdp/fd_xsk_private.h"
 
+#include "../../../../util/net/fd_eth.h"
+#include "../../../../util/net/fd_ip4.h"
+#include "../../../../util/net/fd_udp.h"
+
 #include <linux/unistd.h>
 
 #define FD_NET_PORT_ALLOW_CNT (sizeof(((fd_topo_tile_t*)0)->net.allow_ports)/sizeof(((fd_topo_tile_t*)0)->net.allow_ports[ 0 ]))
@@ -18,11 +22,13 @@ typedef struct {
   ulong round_robin_id;
 
   const fd_aio_t * tx;
+  const fd_aio_t * lo_tx;
 
   uchar frame[ FD_NET_MTU ];
 
   fd_mux_context_t * mux;
 
+  uint   src_ip_addr;
   ushort allow_ports[ FD_NET_PORT_ALLOW_CNT ];
 
   fd_wksp_t * in_mem;
@@ -157,6 +163,13 @@ before_credit( void * _ctx,
   }
 }
 
+FD_FN_PURE static int
+route_loopback( uint  tile_ip_addr,
+                ulong sig ) {
+  return fd_disco_netmux_sig_ip_addr( sig )==FD_IP4_ADDR(127,0,0,1) ||
+    fd_disco_netmux_sig_ip_addr( sig )==tile_ip_addr;
+}
+
 static void
 before_frag( void * _ctx,
              ulong  in_idx,
@@ -169,10 +182,19 @@ before_frag( void * _ctx,
 
   ushort src_tile = fd_disco_netmux_sig_src_tile( sig );
 
-  /* round robin by sequence number for now, quic should be modified to
-     echo the net tile index back so we can transmit on the same queue */
-  int handled_packet = (seq % ctx->round_robin_cnt) == ctx->round_robin_id;
-  if( FD_UNLIKELY( src_tile == SRC_TILE_NET || !handled_packet ) ) {
+  /* Round robin by sequence number for now, QUIC should be modified to
+     echo the net tile index back so we can transmit on the same queue.
+     
+     127.0.0.1 packets for localhost must go out on net tile 0 which
+     owns the loopback interface XSK, which only has 1 queue. */
+  int handled_packet = 0;
+  if( FD_UNLIKELY( route_loopback( ctx->src_ip_addr, sig ) ) ) {
+    handled_packet = ctx->round_robin_id == 0;
+  } else {
+    handled_packet = (seq % ctx->round_robin_cnt) == ctx->round_robin_id;
+  }
+
+  if( FD_UNLIKELY( src_tile==SRC_TILE_NET || !handled_packet ) ) {
     *opt_filter = 1;
   }
 }
@@ -197,6 +219,12 @@ during_frag( void * _ctx,
   fd_memcpy( ctx->frame, src, sz ); // TODO: Change xsk_aio interface to eliminate this copy
 }
 
+typedef struct __attribute__((packed)) {
+  fd_eth_hdr_t eth[1];
+  fd_ip4_hdr_t ip4[1];
+  fd_udp_hdr_t udp[1];
+} eth_ip_udp_t;
+
 static void
 after_frag( void *             _ctx,
             ulong              in_idx,
@@ -214,7 +242,34 @@ after_frag( void *             _ctx,
   fd_net_ctx_t * ctx = (fd_net_ctx_t *)_ctx;
 
   fd_aio_pkt_info_t aio_buf = { .buf = ctx->frame, .buf_sz = (ushort)*opt_sz };
-  ctx->tx->send_func( ctx->xsk_aio[ 0 ], &aio_buf, 1, NULL, 1 );
+  if( FD_UNLIKELY( route_loopback( ctx->src_ip_addr, *opt_sig ) ) ) {
+    /* Because we are skipping part of the kernel networking stack, we
+       need to reformat the packet so it will get accepted onto the
+       loopback device.  A few things are needed,
+       
+        (1) The src and dst ip addresses both need to be zero. Not
+            entirely sure why, but the kernel will silently discard
+            packets that arrive onto lo without this, probably it
+            sets them to zero as part of a sanity check in the code
+            that runs before the XDP splice point.
+            
+        (2) The src mac address can be anything, but the dst mac
+            address must be zero.  Similar story to the above, not
+            entirely sure why. */
+    eth_ip_udp_t * hdr = (eth_ip_udp_t *)ctx->frame;
+    if( FD_UNLIKELY( *opt_sz < sizeof( eth_ip_udp_t ) ) )
+      FD_LOG_ERR(( "loopback packet too small %lu", *opt_sz ));
+
+    fd_memset( hdr->eth->dst, 0, 6UL );
+    fd_memset( hdr->ip4->daddr_c, 0, 4UL );
+    fd_memset( hdr->ip4->saddr_c, 0, 4UL );
+    hdr->ip4->check = 0U;
+    /* TODO: Do we need to update check here? */
+    hdr->ip4->check = fd_ip4_hdr_check( ( fd_ip4_hdr_t const *) FD_ADDRESS_OF_PACKED_MEMBER( hdr->ip4 ) );
+    ctx->lo_tx->send_func( ctx->xsk_aio[ 1 ], &aio_buf, 1, NULL, 1 );
+  } else {
+    ctx->tx->send_func( ctx->xsk_aio[ 0 ], &aio_buf, 1, NULL, 1 );
+  }
 
   *opt_filter = 1;
 }
@@ -286,13 +341,16 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->xsk_aio[ 0 ] = fd_xsk_aio_join( init_ctx->xsk_aio, init_ctx->xsk );
   if( FD_UNLIKELY( !ctx->xsk_aio[ 0 ] ) ) FD_LOG_ERR(( "fd_xsk_aio_join failed" ));
   fd_xsk_aio_set_rx( ctx->xsk_aio[ 0 ], net_rx_aio );
+  ctx->tx = fd_xsk_aio_get_tx( init_ctx->xsk_aio );
   if( FD_UNLIKELY( init_ctx->lo_xsk ) ) {
     ctx->xsk_aio[ 1 ] = fd_xsk_aio_join( init_ctx->lo_xsk_aio, init_ctx->lo_xsk );
     if( FD_UNLIKELY( !ctx->xsk_aio[ 1 ] ) ) FD_LOG_ERR(( "fd_xsk_aio_join failed" ));
     fd_xsk_aio_set_rx( ctx->xsk_aio[ 1 ], net_rx_aio );
+    ctx->lo_tx = fd_xsk_aio_get_tx( init_ctx->lo_xsk_aio );
     ctx->xsk_aio_cnt = 2;
   }
-  ctx->tx = fd_xsk_aio_get_tx( init_ctx->xsk_aio );
+  
+  ctx->src_ip_addr = tile->net.src_ip_addr;
 
   for( ulong i=0UL; i<FD_NET_PORT_ALLOW_CNT; i++ ) {
     if( FD_UNLIKELY( !tile->net.allow_ports[ i ] ) ) FD_LOG_ERR(( "net tile listen port %lu was 0", i ));

--- a/src/app/fdctl/run/tiles/fd_quic.c
+++ b/src/app/fdctl/run/tiles/fd_quic.c
@@ -559,7 +559,7 @@ quic_tx_aio_send( void *                    _ctx,
     uchar const * iphdr = packet + 14U;
 
     uint test_ethip = ( (uint)packet[12] << 16u ) | ( (uint)packet[13] << 8u ) | (uint)packet[23];
-    uint ip_dstaddr = 0;
+    uint   ip_dstaddr  = 0;
     ushort udp_dstport = 0;
     if( FD_LIKELY( test_ethip==0x080011 ) ) {
       /* IPv4 is variable-length, so lookup IHL to find start of UDP */
@@ -570,7 +570,7 @@ quic_tx_aio_send( void *                    _ctx,
       if( FD_UNLIKELY( udp+8U > packet_end ) ) continue;
 
       /* Extract IP dest addr and UDP dest port */
-      ip_dstaddr    =                  *(uint   *)( iphdr+16UL );
+      ip_dstaddr  =                  *(uint   *)( iphdr+16UL );
       udp_dstport = fd_ushort_bswap( *(ushort *)( udp+2UL    ) );
     }
 

--- a/src/app/fdctl/topology.h
+++ b/src/app/fdctl/topology.h
@@ -187,6 +187,7 @@ typedef struct {
     ulong  xdp_rx_queue_size;
     ulong  xdp_tx_queue_size;
     ulong  xdp_aio_depth;
+    uint   src_ip_addr;
     ushort allow_ports[ 3 ];
   } net;
 

--- a/src/app/fdctl/utility.c
+++ b/src/app/fdctl/utility.c
@@ -87,7 +87,7 @@ read_key( char const * key_path,
           "keyfile at `%s` but there is no such file. Either update the "
           "configuration file to point to your validator identity "
           "keypair, or generate a new validator identity key by running "
-          "`fdctl keygen`", key_path ));
+          "`fdctl keys new identity`", key_path ));
     } else
       FD_LOG_ERR(( "Opening key file (%s) failed (%i-%s)", key_path,  errno, fd_io_strerror( errno ) ));
   }

--- a/src/app/fddev/Local.mk
+++ b/src/app/fddev/Local.mk
@@ -4,7 +4,7 @@ ifdef FD_HAS_X86
 ifdef FD_HAS_DOUBLE
 
 .PHONY: fddev run monitor
-$(call make-bin-rust,fddev,main dev dev1 txn configure/netns configure/keygen configure/genesis,fd_fdctl fd_disco fd_flamenco fd_reedsol fd_ballet fd_tango fd_util fd_quic solana_validator solana_genesis)
+$(call make-bin-rust,fddev,main dev dev1 txn configure/netns configure/keys configure/genesis,fd_fdctl fd_disco fd_flamenco fd_reedsol fd_ballet fd_tango fd_util fd_quic solana_validator solana_genesis)
 
 solana/target/$(RUST_PROFILE)/libsolana_genesis.a: cargo
 

--- a/src/app/fddev/configure/keys.c
+++ b/src/app/fddev/configure/keys.c
@@ -2,7 +2,7 @@
 
 #include <sys/stat.h>
 
-#define NAME "keygen"
+#define NAME "keys"
 
 
 static void
@@ -64,7 +64,7 @@ check( config_t * const config ) {
   CONFIGURE_OK();
 }
 
-configure_stage_t keygen = {
+configure_stage_t keys = {
   .name            = NAME,
   .always_recreate = 0,
   .enabled         = NULL,

--- a/src/app/fddev/main.c
+++ b/src/app/fddev/main.c
@@ -11,7 +11,7 @@
 
 extern configure_stage_t netns;
 extern configure_stage_t genesis;
-extern configure_stage_t keygen;
+extern configure_stage_t keys;
 
 configure_stage_t * STAGES[ CONFIGURE_STAGE_COUNT ] = {
   &netns,
@@ -21,7 +21,7 @@ configure_stage_t * STAGES[ CONFIGURE_STAGE_COUNT ] = {
   &xdp,
   &xdp_leftover,
   &ethtool,
-  &keygen,
+  &keys,
   &workspace_leftover,
   &workspace,
   &genesis,

--- a/src/disco/fd_disco_base.h
+++ b/src/disco/fd_disco_base.h
@@ -58,7 +58,7 @@ fd_disco_netmux_sig( ulong  ip_addr,
   return (((ulong)ip_addr)<<32UL) | (((ulong)port)<<16UL) | ((src_tile&0xFUL)<<12UL) | ((hdr_sz_i&0xFUL)<<4UL) | (dst_idx&0xFUL);
 }
 
-FD_FN_CONST static inline ulong  fd_disco_netmux_sig_ip_addr ( ulong sig ) { return (sig>>32UL) & 0xFFFFUL; }
+FD_FN_CONST static inline uint   fd_disco_netmux_sig_ip_addr ( ulong sig ) { return (uint)((sig>>32UL) & 0xFFFFFFFFUL); }
 FD_FN_CONST static inline ushort fd_disco_netmux_sig_port    ( ulong sig ) { return (sig>>16UL) & 0xFFFFUL; }
 FD_FN_CONST static inline ushort fd_disco_netmux_sig_src_tile( ulong sig ) { return (sig>>12UL) & 0xFUL; }
 FD_FN_CONST static inline ushort fd_disco_netmux_sig_dst_idx ( ulong sig ) { return (sig>> 0UL) & 0xFUL; }

--- a/src/test/single-transfer.sh
+++ b/src/test/single-transfer.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# bash strict mode
+set -xeuo pipefail
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "${SCRIPT_DIR}/../../"
+
+cleanup() {
+    # TODO: We grep instead of using 'sudo ausearch -c fddev' because ausearch returns 'no matches'
+    # when it should not.
+    sudo grep -n fddev /var/log/audit/audit.log
+}
+trap cleanup EXIT INT TERM
+
+# start fddev, send a single transfer to the locally running RPC endpoint, and if everything works return 0
+FDDEV=./build/native/gcc/bin/fddev
+
+# TODO: For some reason /tmp does not work on the github runner for --log-path
+timeout --preserve-status --kill-after=20 15 $FDDEV configure init all --log-path ./log
+timeout --preserve-status --kill-after=20 15 $FDDEV --no-configure --log-path ./log &
+FDDEV_PID=$!
+sleep 2
+timeout --preserve-status --kill-after=20 15 ./solana/target/release/solana transfer -u http://127.0.0.1:8899 -k /home/$USER/.firedancer/fd1/faucet.json $($FDDEV keys pubkey /home/$USER/.firedancer/fd1/faucet.json)  0.01
+RETVAL=$?
+sudo kill $FDDEV_PID
+exit $RETVAL


### PR DESCRIPTION
We are trying to send outgoing packets for 127.0.0.1 to the external facing NIC rather than on the loopback device, which won't work.

This is mostly to support development and testing, although it's conceivable someone would send transactions via. loopback in production as well.