### PR TITLE
caps: log the particular resource limit if one is too low

### DIFF
--- a/src/app/fdctl/caps.c
+++ b/src/app/fdctl/caps.c
@@ -105,17 +105,24 @@ fd_caps_check_capability( fd_caps_ctx_t * ctx,
 FD_FN_CONST static char *
 fd_caps_resource_str( fd_rlimit_res_t resource ) {
   switch( resource ) {
-    case RLIMIT_CPU:     return "RLIMIT_CPU";
-    case RLIMIT_FSIZE:   return "RLIMIT_FSIZE";
-    case RLIMIT_DATA:    return "RLIMIT_DATA";
-    case RLIMIT_STACK:   return "RLIMIT_STACK";
-    case RLIMIT_CORE:    return "RLIMIT_CORE";
-    case RLIMIT_RSS:     return "RLIMIT_RSS";
-    case RLIMIT_NOFILE:  return "RLIMIT_NOFILE";
-    case RLIMIT_AS:      return "RLIMIT_AS";
-    case RLIMIT_NPROC:   return "RLIMIT_NPROC";
-    case RLIMIT_MEMLOCK: return "RLIMIT_MEMLOCK";
-    default:             return "UNKNOWN";
+    case RLIMIT_CPU:        return "RLIMIT_CPU";
+    case RLIMIT_FSIZE:      return "RLIMIT_FSIZE";
+    case RLIMIT_DATA:       return "RLIMIT_DATA";
+    case RLIMIT_STACK:      return "RLIMIT_STACK";
+    case RLIMIT_CORE:       return "RLIMIT_CORE";
+    case RLIMIT_RSS:        return "RLIMIT_RSS";
+    case RLIMIT_NOFILE:     return "RLIMIT_NOFILE";
+    case RLIMIT_AS:         return "RLIMIT_AS";
+    case RLIMIT_NPROC:      return "RLIMIT_NPROC";
+    case RLIMIT_MEMLOCK:    return "RLIMIT_MEMLOCK";
+    case RLIMIT_LOCKS:      return "RLIMIT_LOCKS";
+    case RLIMIT_SIGPENDING: return "RLIMIT_SIGPENDING";
+    case RLIMIT_MSGQUEUE:   return "RLIMIT_MSGQUEUE";
+    case RLIMIT_NICE:       return "RLIMIT_NICE";
+    case RLIMIT_RTPRIO:     return "RLIMIT_RTPRIO";
+    case RLIMIT_RTTIME:     return "RLIMIT_RTTIME";
+    case RLIMIT_NLIMITS:    return "RLIMIT_NLIMITS";
+    default:                return "UNKNOWN";
   }
 }
 

--- a/src/app/fdctl/caps.c
+++ b/src/app/fdctl/caps.c
@@ -102,6 +102,23 @@ fd_caps_check_capability( fd_caps_ctx_t * ctx,
   fd_caps_private_add_error( ctx, "%s ... process requires capability `%s` to %s", name, fd_caps_str( capability ), reason );
 }
 
+FD_FN_CONST static char *
+fd_caps_resource_str( fd_rlimit_res_t resource ) {
+  switch( resource ) {
+    case RLIMIT_CPU:     return "RLIMIT_CPU";
+    case RLIMIT_FSIZE:   return "RLIMIT_FSIZE";
+    case RLIMIT_DATA:    return "RLIMIT_DATA";
+    case RLIMIT_STACK:   return "RLIMIT_STACK";
+    case RLIMIT_CORE:    return "RLIMIT_CORE";
+    case RLIMIT_RSS:     return "RLIMIT_RSS";
+    case RLIMIT_NOFILE:  return "RLIMIT_NOFILE";
+    case RLIMIT_AS:      return "RLIMIT_AS";
+    case RLIMIT_NPROC:   return "RLIMIT_NPROC";
+    case RLIMIT_MEMLOCK: return "RLIMIT_MEMLOCK";
+    default:             return "UNKNOWN";
+  }
+}
+
 void
 fd_caps_check_resource( fd_caps_ctx_t * ctx,
                         char const *    name,
@@ -137,6 +154,6 @@ fd_caps_check_resource( fd_caps_ctx_t * ctx,
     rlim.rlim_cur = limit;
     rlim.rlim_max = limit;
     if( FD_UNLIKELY( setrlimit( resource, &rlim ) ) )
-      FD_LOG_ERR(( "setrlimit failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+      FD_LOG_ERR(( "setrlimit failed (%i-%s) for resource %s", errno, fd_io_strerror( errno ), fd_caps_resource_str( resource ) ));
   }
 }


### PR DESCRIPTION
Hello frens. Was setting up my firedancer test node and a resource limit was missing but didn't know which one. Modified the ERR log to log which one is too low.

Example log: `ERR     10-30 19:09:18.536913 76797  f0   main src/app/fdctl/caps.c(158): setrlimit failed (1-EPERM-operation not permitted) for resource RLIMIT_NOFILE`

happy to modify if any of these are irrelevant / if I missed any that we might need