### PR TITLE
tile: work around musl strict aliasing bug

### DIFF
--- a/src/util/tile/fd_tile_threads.cxx
+++ b/src/util/tile/fd_tile_threads.cxx
@@ -14,6 +14,19 @@
 #include "../sanitize/fd_sanitize.h"
 #include "fd_tile.h"
 
+/* Workarounds for less gifted stdlibs (musl).  musl depends on strict
+   aliasing volations for cpu_set_t. */
+
+#if !defined(__GLIBC__) && defined(__CPU_op_S)
+// Old:
+//   #define __CPU_op_S(i, size, set, op) ( (i)/8U >= (size) ? 0 :
+//   (((unsigned long *)(set))[(i)/8/sizeof(long)] op (1UL<<((i)%(8*sizeof(long))))) )
+// New:
+     #undef __CPU_op_S
+     #define __CPU_op_S(i, size, set, op) ( (i)/8U >= (size) ? 0 : \
+     (((set)->__bits)[(i)/8/sizeof(long)] op (1UL<<((i)%(8*sizeof(long))))) )
+#endif
+
 /* Operating system shims ********************************************/
 
 struct fd_tile_private_cpu_config {


### PR DESCRIPTION
musl's `CPU_SET` macro in `sched.h` has a bug where it casts a struct to a pointer of unsigned longs.

This is clearly a strict aliasing violation and has no place in a general-purpose libc, since it violates ISO C conventions.

This workaround redefines the internal macro causing the problem.

(We should probably drop support for musl because of conflicting philosophy that cause these recurring incompatibilities)