### PR TITLE
fd_stake_ci: fix size computation for AVX512 and non-AVX platforms

### DIFF
--- a/src/disco/shred/fd_fec_resolver.c
+++ b/src/disco/shred/fd_fec_resolver.c
@@ -38,7 +38,7 @@ typedef struct set_ctx set_ctx_t;
 #define DEQUE_T    void *
 #include "../../util/tmpl/fd_deque_dynamic.c"
 
-static const wrapped_sig_t null_signature = {0};
+static const wrapped_sig_t null_signature = {{0}};
 
 #define MAP_KEY               sig
 #define MAP_KEY_T             wrapped_sig_t

--- a/src/disco/shred/fd_shred_dest.c
+++ b/src/disco/shred/fd_shred_dest.c
@@ -6,7 +6,7 @@ struct pubkey_to_idx {
 };
 typedef struct pubkey_to_idx pubkey_to_idx_t;
 
-const fd_pubkey_t null_pubkey = { 0 };
+const fd_pubkey_t null_pubkey = {{ 0 }};
 
 #define MAP_NAME              pubkey_to_idx
 #define MAP_T                 pubkey_to_idx_t

--- a/src/disco/shred/fd_stake_ci.h
+++ b/src/disco/shred/fd_stake_ci.h
@@ -15,9 +15,13 @@
 #include "fd_shred_dest.h"
 #include "../../flamenco/leaders/fd_leaders.h"
 
-#define MAX_SHRED_DESTS             40200UL
-#define MAX_SLOTS_PER_EPOCH        432000UL
-#define MAX_SHRED_DEST_FOOTPRINT 10067968UL /* == fd_shred_dest_footprint( MAX_SHRED_DESTS ), runtime asserted in new */
+#define MAX_SHRED_DESTS              40200UL
+#define MAX_SLOTS_PER_EPOCH         432000UL
+/* MAX_SHRED_DEST_FOOTPRINT==fd_shred_dest_footprint( MAX_SHRED_DESTS),
+   runtime asserted in new.  The size of fd_shred_dest_t, varies
+   based on FD_SHA256_BATCH_FOOTPRINT, which depends on the compiler
+   settings. */
+#define MAX_SHRED_DEST_FOOTPRINT (10067072UL + sizeof(fd_shred_dest_t))
 
 #define FD_STAKE_CI_STAKE_MSG_SZ (32UL + MAX_SHRED_DESTS * 40UL)
 


### PR DESCRIPTION
The size of an `fd_shred_dest` depends on `FD_SHA256_BATCH_FOOTPRINT` which varies based on the target (no-AVX, AVX, AVX512). The code was using the hardcoded value for AVX, which caused failures. Unfortunately, they were runtime failures because not all the structs expose compile-time footprint calculations.