### PR TITLE
base58: fix mismatching C header guard

### DIFF
--- a/src/ballet/base58/fd_base58.h
+++ b/src/ballet/base58/fd_base58.h
@@ -57,6 +57,6 @@ char * fd_base58_encode_64( uchar const * bytes, ulong * opt_len, char * out );
 uchar * fd_base58_decode_32( char const * encoded, uchar * out );
 uchar * fd_base58_decode_64( char const * encoded, uchar * out );
 
-FD_PROTOTYPES_BEGIN
+FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_ballet_base58_fd_base58_h */


### PR DESCRIPTION
Fix typo on closing prototype guard in base58, currently preventing inclusion in C++ projects.