### PR TITLE
cli: allowing configure to make use of gossip.host

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -796,11 +796,26 @@ config_parse( int *      pargc,
     if( FD_UNLIKELY( !if_nametoindex( config->tiles.net.interface ) ) )
       FD_LOG_ERR(( "configuration specifies network interface `%s` which does not exist", config->tiles.net.interface ));
     uint iface_ip = listen_address( config->tiles.net.interface );
-    if ( FD_UNLIKELY( !fd_ip4_addr_is_public ( iface_ip ) && config->is_live_cluster ) )
+    if( FD_UNLIKELY( strcmp( config->gossip.host, "" ) ) ) {
+      uint gossip_ip_addr;
+      if( FD_UNLIKELY( !fd_cstr_to_ip4_addr( config->gossip.host, &gossip_ip_addr ) && strlen( config->gossip.host )<=15UL ) )
+        FD_LOG_ERR(( "configuration specifies invalid gossip host IP address `%s`", config->gossip.host ));
+      if ( FD_UNLIKELY( !fd_ip4_addr_is_public ( gossip_ip_addr ) && config->is_live_cluster ) )
+        FD_LOG_ERR(( "Trying to use gossip host " FD_IP4_ADDR_FMT " for listening to incoming transactions, "
+                     "which is not a publicly routable IP address, "
+                     "and will not be routable for other Solana network nodes.", 
+                     FD_IP4_ADDR_FMT_ARGS( gossip_ip_addr ) ));
+    }
+    else if ( FD_UNLIKELY( !fd_ip4_addr_is_public ( iface_ip ) && config->is_live_cluster ) ) {
       FD_LOG_ERR(( "Trying to use network interface `%s` for listening to incoming transactions, "
-                   "but it has IPv4 address " FD_IP4_ADDR_FMT " "
-                   "which is part of a private network and will not be routable for other Solana network nodes.",
+                   "but it has IPv4 address " FD_IP4_ADDR_FMT " which is part of a private network "
+                   "and will not be routable for other Solana network nodes. If you are running "
+                   "behind a NAT and this interface is publicly reachable, you can continue by "
+                   "manually specifying the IP address to advertise in your configuration under "
+                   "[gossip.host].",
                    config->tiles.net.interface, FD_IP4_ADDR_FMT_ARGS( iface_ip ) ));
+    } 
+
 
     config->tiles.net.ip_addr = iface_ip;
     mac_address( config->tiles.net.interface, config->tiles.net.mac_addr );

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -227,7 +227,8 @@ dynamic_port_range = "8900-9000"
     # none is provided, the default is to ask the first entrypoint which
     # replies to the port check described above what our IP address is.
     # If no entrypoints are specified, then this will be defaulted to
-    # 127.0.0.1.
+    # 127.0.0.1.  If connecting to a public cluster like mainnet or
+    # testnet, make sure this is an externally resolvable IP address.
     #
     # This option is passed to the Solana Labs client with the
     # `--gossip-host` argument.


### PR DESCRIPTION
A few (admittedly unideal) machines for firedancer don't have network interfaces on them with a public IP. Think of a machine here with 1 network interface `eth0` where `eth0` only has a private IP. These machines are NAT'd further up the stack (switch / router layer).

It's still possible for a node like this though to gossip and participate in network consensus by manually setting the gossip host, however the `configure` command currently doesn't check if `gossip.host` is set and will error out. This commit fixes that