### PR TITLE
disco: replace SCRATCH_ALLOC macro

### DIFF
--- a/src/app/fdctl/run/tiles/fd_dedup.c
+++ b/src/app/fdctl/run/tiles/fd_dedup.c
@@ -47,10 +47,10 @@ scratch_align( void ) {
 FD_FN_PURE static inline ulong
 scratch_footprint( fd_topo_tile_t * tile ) {
   (void)tile;
-  ulong scratch_top = 0UL;
-  SCRATCH_ALLOC( alignof( fd_dedup_ctx_t ), sizeof( fd_dedup_ctx_t ) );
-  SCRATCH_ALLOC( fd_tcache_align(), fd_tcache_footprint( tile->dedup.tcache_depth, 0 ) );
-  return fd_ulong_align_up( scratch_top, scratch_align() );
+  ulong l = FD_LAYOUT_INIT;
+  l = FD_LAYOUT_APPEND( l, alignof( fd_dedup_ctx_t ), sizeof( fd_dedup_ctx_t ) );
+  l = FD_LAYOUT_APPEND( l, fd_tcache_align(), fd_tcache_footprint( tile->dedup.tcache_depth, 0 ) );
+  return FD_LAYOUT_FINI( l, scratch_align() );
 }
 
 FD_FN_CONST static inline void *
@@ -129,9 +129,9 @@ static void
 unprivileged_init( fd_topo_t *      topo,
                    fd_topo_tile_t * tile,
                    void *           scratch ) {
-  ulong scratch_top = (ulong)scratch;
-  fd_dedup_ctx_t * ctx = (fd_dedup_ctx_t*)SCRATCH_ALLOC( alignof( fd_dedup_ctx_t ), sizeof( fd_dedup_ctx_t ) );
-  fd_tcache_t * tcache = fd_tcache_join( fd_tcache_new( SCRATCH_ALLOC( FD_TCACHE_ALIGN, FD_TCACHE_FOOTPRINT( tile->dedup.tcache_depth, 0) ), tile->dedup.tcache_depth, 0 ) );
+  FD_SCRATCH_ALLOC_INIT( l, scratch );
+  fd_dedup_ctx_t * ctx = FD_SCRATCH_ALLOC_APPEND( l, alignof( fd_dedup_ctx_t ), sizeof( fd_dedup_ctx_t ) );
+  fd_tcache_t * tcache = fd_tcache_join( fd_tcache_new( FD_SCRATCH_ALLOC_APPEND( l, FD_TCACHE_ALIGN, FD_TCACHE_FOOTPRINT( tile->dedup.tcache_depth, 0) ), tile->dedup.tcache_depth, 0 ) );
   if( FD_UNLIKELY( !tcache ) ) FD_LOG_ERR(( "fd_tcache_new failed" ));
 
   ctx->tcache_depth   = fd_tcache_depth       ( tcache );
@@ -154,6 +154,7 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->out_wmark  = fd_dcache_compact_wmark ( ctx->out_mem, topo->links[ tile->out_link_id_primary ].dcache, topo->links[ tile->out_link_id_primary ].mtu );
   ctx->out_chunk  = ctx->out_chunk0;
 
+  ulong scratch_top = FD_SCRATCH_ALLOC_FINI( l, 1UL );
   if( FD_UNLIKELY( scratch_top > (ulong)scratch + scratch_footprint( tile ) ) )
     FD_LOG_ERR(( "scratch overflow %lu %lu %lu", scratch_top - (ulong)scratch - scratch_footprint( tile ), scratch_top, (ulong)scratch + scratch_footprint( tile ) ));
 }

--- a/src/app/fdctl/topology.c
+++ b/src/app/fdctl/topology.c
@@ -149,6 +149,13 @@ static void
 fd_topo_workspace_fill( fd_topo_t *      topo,
                         fd_topo_wksp_t * wksp,
                         ulong            mode ) {
+
+# define SCRATCH_ALLOC( a, s ) (__extension__({                   \
+    ulong _scratch_alloc = fd_ulong_align_up( scratch_top, (a) ); \
+    scratch_top = _scratch_alloc + (s);                           \
+    (void *)_scratch_alloc;                                       \
+  }))
+
   /* Our first (and only) allocation is always at gaddr_lo in the workspace. */
   ulong scratch_top = 0UL;
   if( FD_LIKELY( mode != FD_TOPO_FILL_MODE_FOOTPRINT ) )
@@ -325,6 +332,8 @@ fd_topo_workspace_fill( fd_topo_t *      topo,
     wksp->page_sz = page_sz;
     wksp->page_cnt = wksp_aligned_footprint / page_sz;
   }
+
+# undef SCRATCH_ALLOC
 }
 
 void

--- a/src/disco/fd_disco_base.h
+++ b/src/disco/fd_disco_base.h
@@ -29,12 +29,6 @@
    in the Rust code. */
 FD_STATIC_ASSERT( FD_TPU_DCACHE_MTU==2094UL, tpu_dcache_mtu_check );
 
-#define SCRATCH_ALLOC( a, s ) (__extension__({                    \
-    ulong _scratch_alloc = fd_ulong_align_up( scratch_top, (a) ); \
-    scratch_top = _scratch_alloc + (s);                           \
-    (void *)_scratch_alloc;                                       \
-  }))
-
 /* FD_APP_CNC_DIAG_* are FD_CNC_DIAG_* style diagnostics and thus the
    same considerations apply.  Further they are harmonized with the
    standard FD_CNC_DIAG_*.  Specifically:

--- a/src/disco/mux/fd_mux.c
+++ b/src/disco/mux/fd_mux.c
@@ -76,13 +76,13 @@ fd_mux_tile_scratch_footprint( ulong in_cnt,
                                ulong out_cnt ) {
   if( FD_UNLIKELY( in_cnt >FD_MUX_TILE_IN_MAX  ) ) return 0UL;
   if( FD_UNLIKELY( out_cnt>FD_MUX_TILE_OUT_MAX ) ) return 0UL;
-  ulong scratch_top = 0UL;
-  SCRATCH_ALLOC( alignof(fd_mux_tile_in_t), in_cnt*sizeof(fd_mux_tile_in_t)     ); /* in */
-  SCRATCH_ALLOC( alignof(ulong const *),    out_cnt*sizeof(ulong const *)       ); /* out_fseq */
-  SCRATCH_ALLOC( alignof(ulong *),          out_cnt*sizeof(ulong *)             ); /* out_slow */
-  SCRATCH_ALLOC( alignof(ulong),            out_cnt*sizeof(ulong)               ); /* out_seq */
-  SCRATCH_ALLOC( alignof(ushort),           (in_cnt+out_cnt+1UL)*sizeof(ushort) ); /* event_map */
-  return fd_ulong_align_up( scratch_top, fd_mux_tile_scratch_align() );
+  ulong l = FD_LAYOUT_INIT;
+  l = FD_LAYOUT_APPEND( l, alignof(fd_mux_tile_in_t), in_cnt*sizeof(fd_mux_tile_in_t)     ); /* in */
+  l = FD_LAYOUT_APPEND( l, alignof(ulong const *),    out_cnt*sizeof(ulong const *)       ); /* out_fseq */
+  l = FD_LAYOUT_APPEND( l, alignof(ulong *),          out_cnt*sizeof(ulong *)             ); /* out_slow */
+  l = FD_LAYOUT_APPEND( l, alignof(ulong),            out_cnt*sizeof(ulong)               ); /* out_seq */
+  l = FD_LAYOUT_APPEND( l, alignof(ushort),           (in_cnt+out_cnt+1UL)*sizeof(ushort) ); /* event_map */
+  return FD_LAYOUT_FINI( l, fd_mux_tile_scratch_align() );
 }
 
 int
@@ -147,7 +147,7 @@ fd_mux_tile( fd_cnc_t *              cnc,
       return 1;
     }
 
-    ulong scratch_top = (ulong)scratch;
+    FD_SCRATCH_ALLOC_INIT( l, scratch );
 
     /* cnc state init */
 
@@ -166,7 +166,7 @@ fd_mux_tile( fd_cnc_t *              cnc,
     /* in frag stream init */
 
     in_seq = 0UL; /* First in to poll */
-    in = (fd_mux_tile_in_t *)SCRATCH_ALLOC( alignof(fd_mux_tile_in_t), in_cnt*sizeof(fd_mux_tile_in_t) );
+    in = (fd_mux_tile_in_t *)FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_mux_tile_in_t), in_cnt*sizeof(fd_mux_tile_in_t) );
 
     ulong min_in_depth = (ulong)LONG_MAX;
 
@@ -315,9 +315,9 @@ fd_mux_tile( fd_cnc_t *              cnc,
     cr_avail = 0UL; /* Will be initialized by run loop */
     cr_filt  = 0UL;
 
-    out_fseq = (ulong const **)SCRATCH_ALLOC( alignof(ulong const *), out_cnt*sizeof(ulong const *) );
-    out_slow = (ulong **)      SCRATCH_ALLOC( alignof(ulong *),       out_cnt*sizeof(ulong *)       );
-    out_seq  = (ulong *)       SCRATCH_ALLOC( alignof(ulong),         out_cnt*sizeof(ulong)         );
+    out_fseq = (ulong const **)FD_SCRATCH_ALLOC_APPEND( l, alignof(ulong const *), out_cnt*sizeof(ulong const *) );
+    out_slow = (ulong **)      FD_SCRATCH_ALLOC_APPEND( l, alignof(ulong *),       out_cnt*sizeof(ulong *)       );
+    out_seq  = (ulong *)       FD_SCRATCH_ALLOC_APPEND( l, alignof(ulong),         out_cnt*sizeof(ulong)         );
 
     if( FD_UNLIKELY( !!out_cnt && !_out_fseq ) ) { FD_LOG_WARNING(( "NULL out_fseq" )); return 1; }
     for( ulong out_idx=0UL; out_idx<out_cnt; out_idx++ ) {
@@ -337,7 +337,7 @@ fd_mux_tile( fd_cnc_t *              cnc,
        ins accordingly. */
 
     event_cnt = in_cnt + 1UL + out_cnt;
-    event_map = (ushort *)SCRATCH_ALLOC( alignof(ushort), event_cnt*sizeof(ushort) );
+    event_map = (ushort *)FD_SCRATCH_ALLOC_APPEND( l, alignof(ushort), event_cnt*sizeof(ushort) );
     event_seq = 0UL;                                     event_map[ event_seq++ ] = (ushort)out_cnt;
     for( ulong  in_idx=0UL;  in_idx< in_cnt;  in_idx++ ) event_map[ event_seq++ ] = (ushort)(in_idx+out_cnt+1UL);
     for( ulong out_idx=0UL; out_idx<out_cnt; out_idx++ ) event_map[ event_seq++ ] = (ushort)out_idx;
@@ -631,6 +631,3 @@ fd_mux_tile( fd_cnc_t *              cnc,
 
   return 0;
 }
-
-#undef SCRATCH_ALLOC
-

--- a/src/wiredancer/test/fd_replay_loop.c
+++ b/src/wiredancer/test/fd_replay_loop.c
@@ -7,12 +7,6 @@
 #include <errno.h>
 #include <unistd.h> /* FIXME remove when ready */
 
-#define SCRATCH_ALLOC( a, s ) (__extension__({                    \
-    ulong _scratch_alloc = fd_ulong_align_up( scratch_top, (a) ); \
-    scratch_top = _scratch_alloc + (s);                           \
-    (void *)_scratch_alloc;                                       \
-  }))
-
 FD_STATIC_ASSERT( FD_FCTL_ALIGN<=FD_REPLAY_TILE_SCRATCH_ALIGN, packing );
 
 ulong
@@ -23,9 +17,9 @@ fd_replay_tile_scratch_align( void ) {
 ulong
 fd_replay_tile_scratch_footprint( ulong out_cnt ) {
   if( FD_UNLIKELY( out_cnt>FD_REPLAY_TILE_OUT_MAX ) ) return 0UL;
-  ulong scratch_top = 0UL;
-  SCRATCH_ALLOC( fd_fctl_align(), fd_fctl_footprint( out_cnt ) ); /* fctl */
-  return fd_ulong_align_up( scratch_top, fd_replay_tile_scratch_align() );
+  ulong l = FD_LAYOUT_INIT;
+  l = FD_LAYOUT_APPEND( l, fd_fctl_align(), fd_fctl_footprint( out_cnt ) ); /* fctl */
+  return FD_LAYOUT_FINI( l, fd_replay_tile_scratch_align() );
 }
 
 int
@@ -88,7 +82,7 @@ fd_replay_tile( fd_cnc_t *       cnc,
       return 1;
     }
 
-    ulong scratch_top = (ulong)scratch;
+    FD_SCRATCH_ALLOC_INIT( l, scratch );
 
     /* cnc state init */
 
@@ -151,7 +145,7 @@ fd_replay_tile( fd_cnc_t *       cnc,
 
     if( FD_UNLIKELY( !!out_cnt && !out_fseq ) ) { FD_LOG_WARNING(( "NULL out_fseq" )); return 1; }
 
-    fctl = fd_fctl_join( fd_fctl_new( SCRATCH_ALLOC( fd_fctl_align(), fd_fctl_footprint( out_cnt ) ), out_cnt ) );
+    fctl = fd_fctl_join( fd_fctl_new( FD_SCRATCH_ALLOC_APPEND( l, fd_fctl_align(), fd_fctl_footprint( out_cnt ) ), out_cnt ) );
     if( FD_UNLIKELY( !fctl ) ) { FD_LOG_WARNING(( "join failed" )); return 1; }
 
     for( ulong out_idx=0UL; out_idx<out_cnt; out_idx++ ) {
@@ -388,7 +382,7 @@ fd_replay_tile_loop(  fd_cnc_t *       cnc,
       return 1;
     }
 
-    ulong scratch_top = (ulong)scratch;
+    FD_SCRATCH_ALLOC_INIT( l, scratch );
 
     /* cnc state init */
 
@@ -451,7 +445,7 @@ fd_replay_tile_loop(  fd_cnc_t *       cnc,
 
     if( FD_UNLIKELY( !!out_cnt && !out_fseq ) ) { FD_LOG_WARNING(( "NULL out_fseq" )); return 1; }
 
-    fctl = fd_fctl_join( fd_fctl_new( SCRATCH_ALLOC( fd_fctl_align(), fd_fctl_footprint( out_cnt ) ), out_cnt ) );
+    fctl = fd_fctl_join( fd_fctl_new( FD_SCRATCH_ALLOC_APPEND( l, fd_fctl_align(), fd_fctl_footprint( out_cnt ) ), out_cnt ) );
     if( FD_UNLIKELY( !fctl ) ) { FD_LOG_WARNING(( "join failed" )); return 1; }
 
     for( ulong out_idx=0UL; out_idx<out_cnt; out_idx++ ) {
@@ -637,8 +631,5 @@ fd_replay_tile_loop(  fd_cnc_t *       cnc,
 
   return 0;
 }
-
-
-#undef SCRATCH_ALLOC
 
 #endif


### PR DESCRIPTION
Code cleanup replacing uses of the deprecated `SCRATCH_ALLOC` macro.