### PR TITLE
deps: adding clang as a dependency for debian based machines

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -136,7 +136,7 @@ check_fedora_pkgs () {
 }
 
 check_debian_pkgs () {
-  local REQUIRED_DEBS=( perl autoconf gettext automake autopoint flex bison build-essential gcc-multilib protobuf-compiler llvm lcov )
+  local REQUIRED_DEBS=( perl autoconf gettext automake autopoint flex bison clang build-essential gcc-multilib protobuf-compiler llvm lcov )
 
 
   echo "[~] Checking for required DEB packages"


### PR DESCRIPTION
Compiling on debian based machines results in errors right now without manual intervention if a machine doesn't have `clang` installed by default. You get the error below:

```
error: failed to run custom build command for `firedancer-sys v0.3.0 (/home/max/Documents/firedancer/ffi/rust/firedancer-sys)`

Caused by:
  process didn't exit successfully: `/home/max/Documents/firedancer/solana/target/release/build/firedancer-sys-0712ccd48b712ce2/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=wrapper_util.h
  cargo:rerun-if-changed=../../../src/util
  cargo:rerun-if-changed=wrapper_ballet.h
  cargo:rerun-if-changed=../../../src/ballet
  cargo:rerun-if-changed=wrapper_tango.h
  cargo:rerun-if-changed=../../../src/tango

  --- stderr
  thread 'main' panicked at /home/max/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bindgen-0.66.1/lib.rs:604:31:
  Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...

```

It's listed as a required dependency in [Fedora](https://github.com/firedancer-io/firedancer/blob/main/deps.sh#L115) based distros right now, but not debian based distros (or alpine FWIW). Right now, I'm working on a debian based machine, so just in the spirit of keeping the PR small and as someone new to the code base, I'm only fixing debian for right now. Let me know if you'd rather do anything different