### PR TITLE
fuzz_siphash13: fix usage of posix_memalign

### DIFF
--- a/src/ballet/siphash13/fuzz_siphash13.c
+++ b/src/ballet/siphash13/fuzz_siphash13.c
@@ -25,8 +25,8 @@ LLVMFuzzerInitialize( int  *   argc,
   putenv( "FD_LOG_BACKTRACE=0" );
   fd_boot( argc, argv );
 
-  assert( !posix_memalign( (void **) &sip, sizeof(fd_siphash13_t), alignof(fd_siphash13_t) ) );
-  assert( !posix_memalign( (void **) &sip_fast, sizeof(fd_siphash13_t), alignof(fd_siphash13_t) ) );
+  assert( !posix_memalign( (void **) &sip,      alignof(fd_siphash13_t), sizeof(fd_siphash13_t) ) );
+  assert( !posix_memalign( (void **) &sip_fast, alignof(fd_siphash13_t), sizeof(fd_siphash13_t) ) );
 
   atexit( fuzz_exit );
   return 0;


### PR DESCRIPTION
Arg 2 and 3 to `posix_memalign` are flipped. This changes fixes this.

It's been working before because `sizeof(fd_siphash13_t)` and `alignof(fd_siphash13_t)` are both 128.