### PR TITLE
fuzz: fix sha fuzzers

### DIFF
--- a/src/ballet/sha256/fuzz_sha256.c
+++ b/src/ballet/sha256/fuzz_sha256.c
@@ -9,13 +9,48 @@
 #include "../../util/fd_util.h"
 #include "fd_sha256.h"
 
+#define BATCH_CNT 32UL /* must be at least 1UL */
+
+uchar * hash1, * hash2, *ref_hash;
+fd_sha256_batch_t * batch_sha;
+uchar * hash_mem;
+uchar **      hashes;
+const char ** messages;
+ulong *       msg_sizes;
+
+static void
+fuzz_exit( void ) {
+    free( ref_hash  );
+    free( msg_sizes );
+    free( messages  );
+    free( hashes    );
+    free( batch_sha );
+    free( hash1 );
+    free( hash2 );
+    free( hash_mem  );
+
+    fd_halt();
+}
+
 int
 LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
   fd_boot( argc, argv );
-  atexit( fd_halt );
+
+  assert( !posix_memalign( (void**) &batch_sha, FD_SHA256_BATCH_ALIGN, sizeof(fd_sha256_batch_t) ) );
+  assert( !posix_memalign( (void **) &hash1, FD_SHA256_ALIGN, FD_SHA256_HASH_SZ ) );
+  assert( !posix_memalign( (void **) &hash2, FD_SHA256_ALIGN, FD_SHA256_HASH_SZ ) );
+  assert( !posix_memalign( (void **) &ref_hash, FD_SHA256_ALIGN, FD_SHA256_HASH_SZ ) );
+
+  hash_mem  = malloc( FD_SHA256_HASH_SZ * BATCH_CNT );
+  hashes    = malloc( BATCH_CNT * sizeof(uchar *) );
+  messages  = malloc( BATCH_CNT * sizeof(const char *) );
+  msg_sizes = malloc( BATCH_CNT * sizeof(ulong) );
+  ref_hash  = malloc( FD_SHA256_HASH_SZ );
+
+  atexit( fuzz_exit );
   return 0;
 }
 
@@ -25,37 +60,22 @@ LLVMFuzzerTestOneInput( uchar const * fuzz_data,
   // hash single message
   char const * msg = ( char const * ) fuzz_data;
 
-  uchar hash1[ FD_SHA256_HASH_SZ ] __attribute__((aligned(32)));
-  uchar hash2[ FD_SHA256_HASH_SZ ] __attribute__((aligned(32)));
-
   fd_sha256_t sha[1];
   assert( fd_sha256_init( sha ) == sha );
   assert( fd_sha256_append( sha, msg, fuzz_sz ) == sha );
-
   assert( fd_sha256_fini( sha, hash1 ) == hash1 );
-
   assert( fd_sha256_hash( fuzz_data, fuzz_sz, hash2 ) == hash2 );
-
   assert( !memcmp( hash1, hash2, FD_SHA256_HASH_SZ ) );
 
   // batch hashing
-  #define BATCH_CNT 32UL /* must be at least 1UL */
   if( fuzz_sz>=BATCH_CNT ) {
-    uchar * hash_mem = malloc( FD_SHA256_HASH_SZ * BATCH_CNT );
-
-    fd_sha256_batch_t * batch_sha; //= malloc( sizeof(fd_sha256_batch_t) );
-    assert(!posix_memalign( (void**) &batch_sha, 128UL, sizeof(fd_sha256_batch_t) ) );
 
     assert( fd_sha256_batch_init( batch_sha ) == batch_sha );
 
-    uchar **      hashes    = malloc( BATCH_CNT * sizeof(uchar *) );
-    const char ** messages  = malloc( BATCH_CNT * sizeof(const char *) );
-    ulong *       msg_sizes = malloc( BATCH_CNT * sizeof(ulong) );
-
     ulong entry_sz = fuzz_sz/BATCH_CNT;
     for( ulong batch_idx=0UL; batch_idx<BATCH_CNT; batch_idx++ ) {
-      hashes   [ batch_idx ] = hash_mem + BATCH_CNT*batch_idx;
-      messages [ batch_idx ] = ( char const *) fuzz_data + entry_sz*batch_idx;
+      hashes   [ batch_idx ] = hash_mem + FD_SHA256_HASH_SZ*batch_idx;
+      messages [ batch_idx ] = (char const *) fuzz_data + entry_sz*batch_idx;
       msg_sizes[ batch_idx ] = batch_idx<BATCH_CNT-1UL ? entry_sz : entry_sz+fuzz_sz%BATCH_CNT;
       assert( fd_sha256_batch_add( batch_sha, messages[ batch_idx ], msg_sizes[ batch_idx ], hashes[ batch_idx ] ) == batch_sha );
     }
@@ -63,15 +83,8 @@ LLVMFuzzerTestOneInput( uchar const * fuzz_data,
     assert( fd_sha256_batch_fini( batch_sha ) == batch_sha );
 
     for( ulong batch_idx=0UL; batch_idx<BATCH_CNT; batch_idx++ ) {
-      uchar * ref_hash = malloc( FD_SHA256_HASH_SZ );
       assert( !memcmp( fd_sha256_hash( messages[ batch_idx ], msg_sizes[ batch_idx ], ref_hash ), hashes[ batch_idx ], FD_SHA256_HASH_SZ ) );
-      free( ref_hash );
     }
-    free(msg_sizes);
-    free(messages);
-    free(hashes);
-    free(batch_sha);
-    free(hash_mem);
   }
 
   return 0;

--- a/src/ballet/sha512/fuzz_sha512.c
+++ b/src/ballet/sha512/fuzz_sha512.c
@@ -2,11 +2,35 @@
 #error "This target requires FD_HAS_HOSTED"
 #endif
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 
 #include "../../util/fd_util.h"
 #include "fd_sha512.h"
+
+#define BATCH_CNT 32UL /* must be at least 1UL */
+
+uchar * hash1, * hash2, *ref_hash;
+fd_sha512_batch_t * batch_sha;
+uchar * hash_mem;
+uchar **      hashes;
+const char ** messages;
+ulong *       msg_sizes;
+
+static void
+fuzz_exit( void ) {
+    free( ref_hash  );
+    free( msg_sizes );
+    free( messages  );
+    free( hashes    );
+    free( batch_sha );
+    free( hash1 );
+    free( hash2 );
+    free( hash_mem  );
+
+    fd_halt();
+}
 
 int
 LLVMFuzzerInitialize( int  *   argc,
@@ -14,71 +38,52 @@ LLVMFuzzerInitialize( int  *   argc,
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
   fd_boot( argc, argv );
-  atexit( fd_halt );
+
+  assert( !posix_memalign( (void**) &batch_sha, FD_SHA512_BATCH_ALIGN, sizeof(fd_sha512_batch_t) ) );
+  assert( !posix_memalign( (void **) &hash1, FD_SHA512_ALIGN, FD_SHA512_HASH_SZ ) );
+  assert( !posix_memalign( (void **) &hash2, FD_SHA512_ALIGN, FD_SHA512_HASH_SZ ) );
+  assert( !posix_memalign( (void **) &ref_hash, FD_SHA512_ALIGN, FD_SHA512_HASH_SZ ) );
+
+  hash_mem  = malloc( FD_SHA512_HASH_SZ * BATCH_CNT );
+  hashes    = malloc( BATCH_CNT * sizeof(uchar *) );
+  messages  = malloc( BATCH_CNT * sizeof(const char *) );
+  msg_sizes = malloc( BATCH_CNT * sizeof(ulong) );
+  ref_hash  = malloc( FD_SHA512_HASH_SZ );
+
+  atexit( fuzz_exit );
   return 0;
 }
 
 int
-LLVMFuzzerTestOneInput( uchar const * data,
-                        ulong         size ) {
+LLVMFuzzerTestOneInput( uchar const * fuzz_data,
+                        ulong         fuzz_sz ) {
   // hash single message
-  char const * msg = ( char const * ) data;
-
-  uchar hash1[ 64 ] __attribute__((aligned(64)));
-  uchar hash2[ 64 ] __attribute__((aligned(64)));
+  char const * msg = ( char const * ) fuzz_data;
 
   fd_sha512_t sha[1];
-  if( FD_UNLIKELY( fd_sha512_init( sha )!=sha ) ) {
-    __builtin_trap();
-  }
-  if( FD_UNLIKELY( fd_sha512_append( sha, msg, size )!=sha ) ) {
-    __builtin_trap();
-  }
-  if( FD_UNLIKELY( fd_sha512_fini( sha, hash1 )!=hash1 ) ) {
-    __builtin_trap();
-  }
-
-  if( FD_UNLIKELY( fd_sha512_hash( data, size, hash2 )!=hash2 ) ) {
-    __builtin_trap();
-  }
-
-  if( FD_UNLIKELY( memcmp( hash1, hash2, 64UL ) ) ) {
-    __builtin_trap();
-  }
+  assert( fd_sha512_init( sha ) == sha );
+  assert( fd_sha512_append( sha, msg, fuzz_sz ) == sha );
+  assert( fd_sha512_fini( sha, hash1 ) == hash1 );
+  assert( fd_sha512_hash( fuzz_data, fuzz_sz, hash2 ) == hash2 );
+  assert( !memcmp( hash1, hash2, FD_SHA512_HASH_SZ ) );
 
   // batch hashing
-  #define BATCH_CNT 32UL /* must be at least 1UL */
-  if( size>=BATCH_CNT ) {
-    uchar hash_mem[ 64UL*BATCH_CNT ] __attribute__((aligned(64)));
+  if( fuzz_sz>=BATCH_CNT ) {
 
-    fd_sha512_batch_t batch_sha[1];     
-    if( FD_UNLIKELY( fd_sha512_batch_init( batch_sha )!=batch_sha ) ) {
-      __builtin_trap();
-    }
+    assert( fd_sha512_batch_init( batch_sha ) == batch_sha );
 
-    uchar *      hashes   [ BATCH_CNT ];
-    const char * messages [ BATCH_CNT ];
-    ulong        msg_sizes[ BATCH_CNT ];
-
-    ulong sz = size/BATCH_CNT;
+    ulong entry_sz = fuzz_sz/BATCH_CNT;
     for( ulong batch_idx=0UL; batch_idx<BATCH_CNT; batch_idx++ ) {
-      hashes   [ batch_idx ] = hash_mem + sz*batch_idx;
-      messages [ batch_idx ] = ( char const *) data + sz*batch_idx;
-      msg_sizes[ batch_idx ] = batch_idx<BATCH_CNT-1UL ? sz : sz+size%BATCH_CNT;
-      if( FD_UNLIKELY( fd_sha512_batch_add( batch_sha, messages[ batch_idx ], msg_sizes[ batch_idx ], hashes[ batch_idx ] )!=batch_sha ) ) {
-        __builtin_trap();
-      }
+      hashes   [ batch_idx ] = hash_mem + FD_SHA512_HASH_SZ*batch_idx;
+      messages [ batch_idx ] = (char const *) fuzz_data + entry_sz*batch_idx;
+      msg_sizes[ batch_idx ] = batch_idx<BATCH_CNT-1UL ? entry_sz : entry_sz+fuzz_sz%BATCH_CNT;
+      assert( fd_sha512_batch_add( batch_sha, messages[ batch_idx ], msg_sizes[ batch_idx ], hashes[ batch_idx ] ) == batch_sha );
     }
 
-    if( FD_UNLIKELY( fd_sha512_batch_fini( batch_sha )==batch_sha ) ) {
-      __builtin_trap();
-    }
+    assert( fd_sha512_batch_fini( batch_sha ) == batch_sha );
 
     for( ulong batch_idx=0UL; batch_idx<BATCH_CNT; batch_idx++ ) {
-      uchar ref_hash[ 64 ] __attribute__((aligned(64)));
-      if( FD_UNLIKELY( memcmp( fd_sha512_hash( messages[ batch_idx ], msg_sizes[ batch_idx ], ref_hash ), hashes[ batch_idx ], 64UL ) ) ) {
-        __builtin_trap();
-      }
+      assert( !memcmp( fd_sha512_hash( messages[ batch_idx ], msg_sizes[ batch_idx ], ref_hash ), hashes[ batch_idx ], FD_SHA512_HASH_SZ ) );
     }
   }
 


### PR DESCRIPTION
The SHA512 fuzzer was broken.
Both SHA256 and SHA512 now share the same code.