### PR TITLE
shred: batch microblocks up to one full FEC set

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -523,7 +523,7 @@ topo_initialize( config_t * config ) {
   LINK( 1,                                FD_TOPO_LINK_KIND_GOSSIP_TO_PACK,  FD_TOPO_WKSP_KIND_DEDUP_PACK,   config->tiles.verify.receive_buffer_size, FD_TPU_DCACHE_MTU,      1UL );
   LINK( 1,                                FD_TOPO_LINK_KIND_STAKE_TO_OUT,    FD_TOPO_WKSP_KIND_STAKE_OUT,    128UL,                                    32UL + 40200UL * 40UL,  1UL );
   LINK( 1,                                FD_TOPO_LINK_KIND_PACK_TO_BANK,    FD_TOPO_WKSP_KIND_PACK_BANK,    128UL,                                    USHORT_MAX,             1UL );
-  LINK( 1,                                FD_TOPO_LINK_KIND_POH_TO_SHRED,    FD_TOPO_WKSP_KIND_BANK_SHRED,   128UL,                                    USHORT_MAX,             1UL );
+  LINK( 1,                                FD_TOPO_LINK_KIND_POH_TO_SHRED,    FD_TOPO_WKSP_KIND_BANK_SHRED,   128UL,                                    FD_POH_SHRED_MTU,       1UL );
   LINK( 1,                                FD_TOPO_LINK_KIND_CRDS_TO_SHRED,   FD_TOPO_WKSP_KIND_BANK_SHRED,   128UL,                                    8UL  + 40200UL * 38UL,  1UL );
   /* See long comment in fd_shred_tile.c for an explanation about the size of this dcache. */
   LINK( 1,                                FD_TOPO_LINK_KIND_SHRED_TO_STORE,  FD_TOPO_WKSP_KIND_SHRED_STORE,  128UL,                                    4UL*FD_SHRED_STORE_MTU, 4UL+config->tiles.shred.max_pending_shred_sets );

--- a/src/app/fdctl/run/tiles/fd_pack.c
+++ b/src/app/fdctl/run/tiles/fd_pack.c
@@ -28,10 +28,18 @@
 /* About 1.5 kB on the stack */
 #define FD_PACK_PACK_MAX_OUT (16UL)
 
+/* in bytes.  Defined this way to use the size field of mcache.  This
+   only includes the transaction payload and the fd_txn_t portions of
+   the microblock, as all the other portions (hash, etc) are generated
+   by PoH later. */
+#define MAX_MICROBLOCK_SZ USHORT_MAX
+
 #define MAX_TXN_PER_MICROBLOCK (MAX_MICROBLOCK_SZ/sizeof(fd_txn_p_t))
 
-/* in bytes.  Defined this way to use the size field of mcache */
-#define MAX_MICROBLOCK_SZ USHORT_MAX
+/* In order not to couple things excessively, the definition for
+   POH_SHRED_MTU assumes this value is 31.  If it changes, update
+   POH_SHRED_MTU. */
+FD_STATIC_ASSERT( MAX_TXN_PER_MICROBLOCK==31UL, poh_shred_mtu );
 
 /* Each block is limited to 32k parity shreds.  At worst, a microblock
    batch contains 67 parity shreds.  Right now, we're using one

--- a/src/disco/fd_disco_base.h
+++ b/src/disco/fd_disco_base.h
@@ -22,6 +22,12 @@
    asserted in fd_shred_tile.c). */
 #define FD_SHRED_STORE_MTU (41792UL)
 
+/* FD_POH_SHRED_MTU is the size of the raw transaction portion of the
+   largest microblock the pack tile will produce, plus the 48B of
+   microblock header (hash and 2 ulongs) plus the fd_entry_batch_meta_t
+   metadata. */
+#define FD_POH_SHRED_MTU (40UL + 48UL + FD_TPU_MTU * 31UL)
+
 /* FD_TPU_DCACHE_MTU is the max size of a dcache entry */
 #define FD_TPU_DCACHE_MTU (FD_TPU_MTU + FD_TXN_MAX_SZ + 2UL)
 /* The literal value of FD_TPU_DCACHE_MTU is used in some of the Rust


### PR DESCRIPTION
Without batching, we produce many small FEC sets, which make inefficient use of our parity shred budget. This implements the simplest form of batching, where each batch is still limited to one FEC set.

This change enables relaxing some limits in pack. I'll make those changes in another PR.