### PR TITLE
fdctl: pass accounts_path onto labs client

### DIFF
--- a/src/app/fdctl/run/run_solana.c
+++ b/src/app/fdctl/run/run_solana.c
@@ -85,6 +85,7 @@ solana_labs_main( void * args ) {
 
   /* ledger */
   ADD( "--ledger", config->ledger.path );
+  if( strcmp( "", config->ledger.accounts_path ) ) ADD( "--accounts", config->ledger.accounts_path );
   ADDU( "--limit-ledger-size", config->ledger.limit_size );
   if( config->ledger.bigtable_storage ) ADD1( "--enable-rpc-bigtable-ledger-storage" );
   for( ulong i=0; i<config->ledger.account_indexes_cnt; i++ )


### PR DESCRIPTION
Despite `[ledger.accounts_path]` being a valid configuration option, the path never gets passed onto the labs client. This causes both accounts and ledger to be written to the same disk, which can be painful on nodes with smaller disks for operators. 