### PR TITLE
ballet/txn: small changes to improve parse performance

### DIFF
--- a/src/ballet/txn/test_txn_parse.c
+++ b/src/ballet/txn/test_txn_parse.c
@@ -223,7 +223,7 @@ void test_mutate( uchar const * payload,
 
 void test_performance( uchar const * payload,
                        ulong sz ) {
-  const ulong test_count = 1000000;
+  const ulong test_count = 10000000UL;
   long start = fd_log_wallclock( );
   for( ulong i = 0; i < test_count; i++ ) {
     FD_TEST( fd_txn_parse( payload, sz, out_buf, NULL ) );


### PR DESCRIPTION
I found that (on our two test transactions) a substantial fraction of parse time was spent checking that no account index exceeded the number of accounts in the transaction. I changed the check, and moved it, and that seems to have improved performance substantially: 

- Transaction 1: `80.8ns` to `50.8ns` (-37%)
- Transaction 2: `42.6ns` to `37.9ns` (-11%)

Note: These are pretty lousy benchmarks, because the branch predictor will predict everything exactly. Regardless, this change eliminates some branches, so it should still be a win.

This PR does change the behavior slightly. In particular, previously this account index check was omitted when `out_buf==NULL`. That seems like a mistake. Secondly, previously, transactions with 0 instructions and 0 accounts were accepted when `allow_zero_signatures==true`. Now such transactions will be rejected.
 
While I was at it, I also rewrapped and clarified some of the comments.