### PR TITLE
coverage: publish to gcloud

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,17 +9,12 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   all-coverage:
     name: All Coverage
     runs-on:
       group: rhel85-icelake
-    environment:
-      name: github-pages
-      url: ${{ steps.pages-deploy.outputs.page_url }}
     env:
       CC: clang
       EXTRAS: llvm-cov
@@ -36,18 +31,20 @@ jobs:
         with:
           credentials_json: ${{ secrets.FUZZ_SERVICE_ACCT_JSON_BUNDLE }}
 
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+
       - name: Generate all coverage
         run: ./.github/workflows/scripts/cov_all.sh
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
-        with:
-          # Upload entire repository
-          path: './build/pages/'
+        run: gcloud storage cp -r ./build/pages/* ${{ vars.COVERAGE_BUCKET }}${{ github.sha }}/
 
-      # - name: Deploy to GitHub Pages
-      #   id: deployment
-      #   uses: actions/deploy-pages@v2
+      - name: Refresh top index
+        run: |
+          echo '<html><head>
+          <meta http-equiv="refresh" content="3; url=${{ github.sha }}/index.html"/>
+          <meta http-equiv="pragma" content="no-cache" />
+          <meta http-equiv="cache-control" content="no-cache" /></head>
+          <body>Redirecting to latest coverage... (${{ github.sha }})</body></html>' > ./build/index.html
+          gcloud storage cp -r ./build/index.html ${{ vars.COVERAGE_BUCKET }}/

--- a/.github/workflows/scripts/testcov_gen_index.sh
+++ b/.github/workflows/scripts/testcov_gen_index.sh
@@ -11,31 +11,32 @@ TEST_TARGETS=$(ls -1 build/pages/cov/test/)
 for TARGET in $FEATURE_SETS_BUILT; do
   DIRS=$(echo build/pages/cov/fuzz/$TARGET/)
   PAGE="build/pages/cov/fuzz/$TARGET/index.html"
-  echo "<h1>Fuzz / $TARGET</h1>" > $PAGE
+  echo "<!DOCTYPE html><html><head><meta charset="UTF-8"/></head><body><h1>Fuzz / $TARGET</h1>" > $PAGE
   echo '<ul>' >> $PAGE
   for FT in $(ls -1 $DIRS); do
-    echo "<li><a href=\"./${FT}\">${FT}</a></li>" >> $PAGE
+    echo "<li><a href=\"./${FT}/index.html\">${FT}</a></li>" >> $PAGE
   done
 
   echo '</ul>' >> $PAGE
 done
+echo '</body></html>' >> $PAGE
 
 
 PAGE="build/pages/cov/fuzz/index.html"
-echo "<h1>Fuzz /</h1>" > $PAGE
+echo "<!DOCTYPE html><html><head><meta charset="UTF-8"/></head><body><h1>Fuzz /</h1>" > $PAGE
 echo '<ul>' >> $PAGE
 for TARGET in $FUZZ_TARGETS; do
-  echo "<li><a href=\"./${TARGET}\">${TARGET}</a></li>" >> $PAGE
+  echo "<li><a href=\"./${TARGET}/index.html\">${TARGET}</a></li>" >> $PAGE
 done
-echo '</ul>' >> $PAGE
+echo '</body></html>' >> $PAGE
 
 PAGE="build/pages/cov/test/index.html"
-echo "<h1>Test /</h1>" > $PAGE
+echo "<!DOCTYPE html><html><head><meta charset="UTF-8"/></head><body><h1>Test /</h1>" > $PAGE
 echo '<ul>' >> $PAGE
 for TARGET in $TEST_TARGETS; do
-  echo "<li><a href=\"./${TARGET}\">${TARGET}</a></li>" >> $PAGE
+  echo "<li><a href=\"./${TARGET}/index.html\">${TARGET}</a></li>" >> $PAGE
 done
-echo '</ul>' >> $PAGE
+echo '</body></html>' >> $PAGE
 
 
 # Generate cov index
@@ -43,6 +44,7 @@ cat <<EOS > build/pages/cov/index.html
 <!DOCTYPE html>
 <html>
 <head>
+<meta charset="UTF-8"/>
 <title>🔥💃 Coverage</title>
 </head>
 
@@ -50,8 +52,8 @@ cat <<EOS > build/pages/cov/index.html
 <h1>🔥💃 Coverage</h1>
 <h2>Links 🔗</h2>
 <ul>
-<li><a href="./test/">Test Coverage</li>
-<li><a href="./fuzz/">Fuzzing Coverage</li>
+<li><a href="./test/index.html">Test Coverage</li>
+<li><a href="./fuzz/index.html">Fuzzing Coverage</li>
 </ul>
 </body>
 
@@ -63,6 +65,7 @@ cat <<EOS > build/pages/index.html
 <!DOCTYPE html>
 <html>
 <head>
+<meta charset="UTF-8">
 <title>🔥💃 Pages</title>
 </head>
 
@@ -71,7 +74,7 @@ cat <<EOS > build/pages/index.html
 <p>From rev: $(git rev-parse HEAD)</p>
 <h2>Links 🔗</h2>
 <ul>
-<li><a href="./cov/">Coverage</li>
+<li><a href="./cov/index.html">Coverage</li>
 </ul>
 </body>
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ join this cluster with other validators, you can define
 `[rpc.entrypoints]` in the configuration file to point at your first
 validator and run `fddev dev` again.
 
+### Code Coverage
+Test and fuzzing coverage are available [here](https://storage.googleapis.com/firedancer-ci-artifacts-public/index.html).
+
 ## License
 Firedancer is available under the [Apache 2
 license](https://www.apache.org/licenses/LICENSE-2.0). Firedancer also


### PR DESCRIPTION
This change publishes testing and fuzzing coverage to a Google Cloud Storage bucket.

The [index](https://storage.googleapis.com/firedancer-ci-artifacts-public/index.html) gets rewritten to redirect to the latest revision.