### PR TITLE
fdctl: preserve ticks_per_ns accross processes

### DIFF
--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -23,6 +23,9 @@ typedef struct {
   char user[ 256 ];
   char hostname[ FD_LOG_NAME_MAX ];
 
+  double tick_per_ns_mu;
+  double tick_per_ns_sigma;
+
   fd_topo_t topo;
 
   int is_live_cluster;

--- a/src/app/fdctl/main1.c
+++ b/src/app/fdctl/main1.c
@@ -91,8 +91,12 @@ fdctl_boot( int *        pargc,
   char * thread = "";
   if( FD_UNLIKELY( config_fd >= 0 ) ) {
     copy_config_from_fd( config_fd, &config );
+    /* tick_per_ns needs to be synchronized across procesess so that they
+       can coordinate on metrics measurement. */
+    fd_tempo_set_tick_per_ns( config.tick_per_ns_mu, config.tick_per_ns_sigma );
   } else {
     config_parse( pargc, pargv, &config );
+    config.tick_per_ns_mu = fd_tempo_tick_per_ns( &config.tick_per_ns_sigma );
     config.log.lock_fd = init_log_memfd();
     config.log.log_fd  = -1;
     thread = "main";

--- a/src/app/fdctl/run/tiles/fd_verify.c
+++ b/src/app/fdctl/run/tiles/fd_verify.c
@@ -68,6 +68,8 @@ during_frag( void * _ctx,
              ulong sz,
              int * opt_filter ) {
   (void)sig;
+  (void)opt_filter;
+
   fd_verify_ctx_t * ctx = (fd_verify_ctx_t *)_ctx;
 
   if( FD_UNLIKELY( chunk<ctx->in[in_idx].chunk0 || chunk>ctx->in[in_idx].wmark || sz > FD_TPU_DCACHE_MTU ) )

--- a/src/tango/tempo/fd_tempo.h
+++ b/src/tango/tempo/fd_tempo.h
@@ -30,6 +30,18 @@ fd_tempo_wallclock_model( double * opt_tau );
 double
 fd_tempo_tickcount_model( double * opt_tau );
 
+/* fd_tempo_set_tick_per_ns explicitly sets the return values of
+   fd_tempo_tick_per_ns below, subsequent calls to that function will
+   return the values given here.
+   
+   These should not be arbitrarily provided, and this function is here
+   primarily to enable different processes to synchronize their
+   tick_per_ns value. */
+
+void
+fd_tempo_set_tick_per_ns( double _mu,
+                          double _sigma );
+
 /* fd_tempo_tick_per_ns is the same as the above but gives an estimate
    of the rate fd_tickcount() ticks relative to fd_log_wallclock() (this
    is in Ghz).  The returned value is the observed rate when


### PR DESCRIPTION
Now that processes are restarted with execve() to get randomized address layout, they lose the fd_tempo_tick_per_ns value.  This isn't much of a problem normally, they will be similar and just used for things like randomizing wait times.

But duration histograms for metrics are an exception.  These histograms have buckets defined in wallclock time (eg, 0-1s, 1s-2s, 2s+).  But they are measured on the tile in ticks (eg, 0-1s/ticks_per_sec, 1s-2s/ticks_per_sec,, 2s/ticks_per_sec+), to enable faster collection without scaling.  The metrics tile that reports to external viewers will rescale to wallclock time.

So the tiles doing collection and the tile doing reporting need to agree on the ticks_per_ns value so they can create the same histogram buckets.  We achieve this by just passing it through and restoring from the config object.