### PR TITLE
ffi: fix fuzz-asan

### DIFF
--- a/config/native_fuzz_asan.mk
+++ b/config/native_fuzz_asan.mk
@@ -1,0 +1,8 @@
+CC:=clang
+BUILDDIR:=native/fuzz_asan
+include config/native.mk
+include config/with-ffi.mk
+
+FD_HAS_MAIN:=0
+CPPFLAGS+=-fsanitize=fuzzer-no-link
+LDFLAGS+=-fsanitize=fuzzer

--- a/ffi/rust/firedancer-sys/build.rs
+++ b/ffi/rust/firedancer-sys/build.rs
@@ -12,8 +12,8 @@ fn main() {
 
     let (machine, build_dir) = if cfg!(feature = "fuzz-asan") {
         (
-            "linux_clang_x86_64_fuzz_asan",
-            out_dir.join("build/linux/clang/fuzz_asan"),
+            "native_fuzz_asan",
+            out_dir.join("build/native/fuzz_asan"),
         )
     } else {
         ("native_ffi", out_dir.join("build/linux/gcc/x86_64_ffi"))
@@ -175,7 +175,6 @@ fn main() {
             .arg(format!("{}/lib/libfd_{lib}.a", build_dir.display()))
             .current_dir(&dir.join(prefix))
             .env("MACHINE", machine)
-            .env("CC", "gcc") // Always use GCC for building FFI
             .env("BASEDIR", out_dir.join("build"));
 
         let key = format!("{}_STATIC_EXTERN_OBJECT", lib.to_uppercase());


### PR DESCRIPTION
Introduces a new native_fuzz_asan target.
Updates build.rs to repair the fuzz-asan functionality.
This required undoing a recent change that forced GCC for Firedancer FFI library builds.
