### PR TITLE
map read side of workspaces as readonly

### DIFF
--- a/src/app/fdctl/monitor/monitor.c
+++ b/src/app/fdctl/monitor/monitor.c
@@ -428,9 +428,11 @@ monitor_cmd_fn( args_t *         args,
   if( FD_UNLIKELY( args->monitor.drain_output_fd!=-1 ) )
     allow_fds[ allow_fds_cnt++ ] = args->monitor.drain_output_fd; /* maybe we are interposing firedancer log output with the monitor */
 
-  /* join all workspaces needed by the topology before sandboxing, so
-     we can access them later */
-  fd_topo_join_workspaces( config->name, &config->topo, FD_SHMEM_JOIN_MODE_READ_ONLY );
+  /* Join just the metrics workspace readonly, which should have
+     everything the monitor needs. */
+  ulong wksp_id = fd_topo_find_wksp( &config->topo, FD_TOPO_WKSP_KIND_METRIC_IN );
+  FD_TEST( wksp_id!=ULONG_MAX );
+  fd_topo_join_workspace( config->name, &config->topo.workspaces[ wksp_id ], FD_SHMEM_JOIN_MODE_READ_ONLY );
 
   struct sock_filter seccomp_filter[ 128UL ];
   uint drain_output_fd = args->monitor.drain_output_fd >= 0 ? (uint)args->monitor.drain_output_fd : (uint)-1;

--- a/src/app/fdctl/ready.c
+++ b/src/app/fdctl/ready.c
@@ -16,8 +16,8 @@ ready_cmd_fn( args_t *         args,
   for( ulong i=0; i<config->topo.tile_cnt; i++) {
     fd_topo_tile_t * tile = &config->topo.tiles[i];
 
-    /* don't wait for bank tiles yet, not a real firedancer tile */
-    if( tile->kind == FD_TOPO_TILE_KIND_BANK ) continue;
+    /* don't wait for solana labs hosted tiles yet, they will take a long time */
+    if( FD_UNLIKELY( fd_topo_tile_kind_is_labs( tile->kind ) ) ) continue;
     
     int first_iter = 1;
     do {

--- a/src/app/fdctl/ready.c
+++ b/src/app/fdctl/ready.c
@@ -9,14 +9,18 @@ ready_cmd_fn( args_t *         args,
               config_t * const config ) {
   (void)args;
 
-  fd_topo_join_workspaces( config->name, &config->topo, FD_SHMEM_JOIN_MODE_READ_ONLY );
-  fd_topo_fill( &config->topo, FD_TOPO_FILL_MODE_FOOTPRINT );
+  ulong wksp_id = fd_topo_find_wksp( &config->topo, FD_TOPO_WKSP_KIND_METRIC_IN );
+  FD_TEST( wksp_id!=ULONG_MAX );
+
+  fd_topo_join_workspace( config->name, &config->topo.workspaces[ wksp_id ], FD_SHMEM_JOIN_MODE_READ_ONLY );
   fd_topo_fill( &config->topo, FD_TOPO_FILL_MODE_JOIN );
 
   for( ulong i=0; i<config->topo.tile_cnt; i++) {
     fd_topo_tile_t * tile = &config->topo.tiles[i];
 
-    /* don't wait for solana labs hosted tiles yet, they will take a long time */
+    /* Don't wait for solana labs hosted tiles yet, they will take a
+       long time, and aren't needed to start sending transactions
+       anyway. */
     if( FD_UNLIKELY( fd_topo_tile_kind_is_labs( tile->kind ) ) ) continue;
     
     int first_iter = 1;

--- a/src/app/fdctl/run/run.c
+++ b/src/app/fdctl/run/run.c
@@ -178,10 +178,10 @@ main_pid_namespace( void * _args ) {
       FD_LOG_ERR(( "prctl(PR_SET_CHILD_SUBREAPER) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
   }
 
-  /* Bank and store tiles are not real tiles yet. */
-  ulong tile_cnt = config->topo.tile_cnt
-    - fd_topo_tile_kind_cnt( &config->topo, FD_TOPO_TILE_KIND_BANK )
-    - fd_topo_tile_kind_cnt( &config->topo, FD_TOPO_TILE_KIND_STORE );
+  ulong tile_cnt = config->topo.tile_cnt;
+  for( ulong i=0; i<config->topo.tile_cnt; i++ ) {
+    if( FD_UNLIKELY( fd_topo_tile_kind_is_labs( config->topo.tiles[ i ].kind ) ) ) tile_cnt--;
+  }
 
   ushort tile_to_cpu[ FD_TILE_MAX ];
   ulong  affinity_tile_cnt = fd_tile_private_cpus_parse( config->layout.affinity, tile_to_cpu );
@@ -227,7 +227,7 @@ main_pid_namespace( void * _args ) {
 
   for( ulong i=0; i<config->topo.tile_cnt; i++ ) {
     fd_topo_tile_t * tile = &config->topo.tiles[ i ];
-    if( FD_UNLIKELY( tile->kind == FD_TOPO_TILE_KIND_BANK || tile->kind == FD_TOPO_TILE_KIND_STORE ) ) continue;
+    if( FD_UNLIKELY( fd_topo_tile_kind_is_labs( tile->kind ) ) ) continue;
 
     int pipefd[ 2 ];
     if( FD_UNLIKELY( pipe2( pipefd, O_CLOEXEC ) ) ) FD_LOG_ERR(( "pipe2() failed (%i-%s)", errno, fd_io_strerror( errno ) ));

--- a/src/app/fdctl/topology.h
+++ b/src/app/fdctl/topology.h
@@ -373,6 +373,12 @@ fd_topo_link_kind_str( ulong kind ) {
   }
 }
 
+FD_FN_CONST static inline int
+fd_topo_tile_kind_is_labs( ulong kind ) {
+  return kind==FD_TOPO_TILE_KIND_BANK ||
+    kind==FD_TOPO_TILE_KIND_STORE;
+}
+
 /* Given a tile kind, one of FD_TOPO_TILE_KIND_*, produce a human
    readable string describing it.  This string does not uniquely
    identify a tile, since there can be multiple of each tile kind

--- a/src/app/fdctl/topology.h
+++ b/src/app/fdctl/topology.h
@@ -458,6 +458,16 @@ fd_topo_join_tile_workspaces( char * const     app_name,
                               fd_topo_t *      topo,
                               fd_topo_tile_t * tile );
 
+/* Join (map into the process) the shared memory (huge/gigantic pages)
+   for the given workspace.  Mode is one of
+   FD_SHMEM_JOIN_MODE_READ_WRITE or FD_SHMEM_JOIN_MODE_READ_ONLY and
+   determines the prot argument that will be passed to mmap when mapping
+   the pages in (PROT_WRITE or PROT_READ respectively). */
+void
+fd_topo_join_workspace( char * const     app_name,
+                        fd_topo_wksp_t * wksp,
+                        int              mode );
+
 /* Join (map into the process) all shared memory (huge/gigantic pages)
    needed by all tiles in the topology.  Mode is one of
    FD_SHMEM_JOIN_MODE_READ_WRITE or FD_SHMEM_JOIN_MODE_READ_ONLY and


### PR DESCRIPTION
The return fseq objects are placed into the metrics workspace, so that we can map link workspaces as readonly on the consumer side. Cnc objects are also moved to the metrics workspace so that monitoring applications can monitor firedancer just by mapping the one workspace as readonly.