### PR TITLE
ci: update apt caches on deps run

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -13,6 +13,20 @@ outputs: {}
 runs:
   using: composite
   steps:
+    - name: Has apt-get?
+      shell: bash
+      run: |
+        if command -v apt-get > /dev/null 2>&1; then
+          echo "HAS_APT_GET=1" >> $GITHUB_ENV
+        else
+          echo "HAS_APT_GET=0" >> $GITHUB_ENV
+        fi
+
+    - name: apt-get update
+      shell: bash
+      run: sudo apt-get update
+      if: env.HAS_APT_GET == '1'
+
     - id: deps-sh-hash
       shell: bash
       run: sha256sum '${{ inputs.deps-script-path }}' | awk '{print "HASH=" $1}' >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
It does what it says on the tin.

Unblocks runs like those: https://github.com/firedancer-io/firedancer/actions/runs/7169937502/job/19521481236?pr=1042