### PR TITLE
sbpf: undo rodata footprint optimization

### DIFF
--- a/src/ballet/sbpf/fd_sbpf_loader.h
+++ b/src/ballet/sbpf/fd_sbpf_loader.h
@@ -52,7 +52,7 @@ struct fd_sbpf_elf_info {
   uint dynstr_sz;   /* Dynstr char count */
 
   uint rodata_sz;         /* size of rodata segment */
-  uint rodata_footprint;  /* rodata_sz + FD_SBPF_RODATA_GUARD */
+  uint rodata_footprint;  /* size of ELF binary */
 
   /* Known section indices
      In [-1,USHORT_MAX) where -1 means "not found" */
@@ -77,8 +77,8 @@ typedef struct fd_sbpf_elf_info fd_sbpf_elf_info_t;
 
    [rodata,rodata+rodata_sz) is an externally allocated buffer holding
    the read-only segment to be loaded into the VM.  WARNING: The rodata
-   area required doing load (rodata_footprint) is slightly larger than
-   the area mapped into the VM (rodata_sz).  See FD_SBPF_RODATA_GUARD.
+   area required doing load (rodata_footprint) is larger than the area
+   mapped into the VM (rodata_sz).
 
    [text,text+8*text_cnt) is a sub-region of the read-only segment
    containing executable code. */


### PR DESCRIPTION
This commit increases the ELF loader's rodata_footprint to be equal
to the ELF file size.  This increases memory usage by 5-10% for most
contracts.

The ELF loader made an incorrect assumption that relocations outside
of the rodata segment are invisible to the virtual machine.  The
loader therefore reduced the rodata segment size and skipped those
relocations.

This is problematic for two reasons:

  1) R_BPF_64_32 can read ~15 bytes past the end of the rodata region
     and conditionally fails loading depending on the content that was
     read.
  2) Some relocations move information from high bits to low bits
     within a 64-bit value. Chaining those relocations thus allows
     moving information from outside the rodata segment into the
     rodata segment.

fd_sbpf_loader would have the wrong execution result in both cases.
