### PR TITLE
fuzz: add rust fuzz targets to highend fuzz artifacts

### DIFF
--- a/.github/workflows/_publish_to_clusterfuzz.yml
+++ b/.github/workflows/_publish_to_clusterfuzz.yml
@@ -26,6 +26,12 @@ jobs:
         with:
           command: make -j -Otarget fuzz-test
 
+      - uses: firedancer-io/fuzzbot-builder@main
+        name: Build rust fuzz tests
+        with:
+          command: ./.github/workflows/scripts/build_rust_fuzz_highend.sh
+        if: ${{ matrix.feature_set == 'highend' }}
+
       - name: List Artifacts
         run: |
           ls build/linux/clang/combi/${{ matrix.feature_set }}/fuzz-test

--- a/.github/workflows/scripts/build_rust_fuzz_highend.sh
+++ b/.github/workflows/scripts/build_rust_fuzz_highend.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eux
+
+if [[ -d ffi/rust/firedancer-diff/fuzz ]]; then
+    # mix the fuzz targets with the highend fuzz
+    TARGET_DIR=./build/linux/clang/combi/highend/fuzz-test
+    RUST_FUZZ_OUT_DIR=./ffi/rust/firedancer-diff/fuzz/target/release
+    pushd ffi/rust/firedancer-diff/fuzz
+    cargo build --release
+    popd
+
+    ARTIFACTS=$(find ./ffi/rust/firedancer-diff/fuzz/target/release -maxdepth 1 -executable -type f)
+    for ARTIFACT in $ARTIFACTS; do
+        mkdir -p "${TARGET_DIR}/$(basename $ARTIFACT)"
+        cp $ARTIFACT "${TARGET_DIR}/$(basename $ARTIFACT)/"
+    done
+else
+    echo "ignoring rust fuzz since directory does not exist"
+fi


### PR DESCRIPTION
If the current fuzz build is `highend`, the `publish_to_clusterfuzz.yml` now builds the rust fuzz targets and places them next to the `highend` fuzz artifacts before the invocation to `firedancer-io/clusterfuzz-action`.