### PR TITLE
QUIC - increase fuzz workspace size

### DIFF
--- a/src/tango/quic/tests/fuzz_quic.c
+++ b/src/tango/quic/tests/fuzz_quic.c
@@ -169,7 +169,7 @@ int LLVMFuzzerInitialize(int *argc, char ***argv) {
   char const *_page_sz =
       fd_env_strip_cmdline_cstr(argc, argv, "--page-sz", NULL, "normal");
   ulong page_cnt =
-      fd_env_strip_cmdline_ulong(argc, argv, "--page-cnt", NULL, 1024UL);
+      fd_env_strip_cmdline_ulong(argc, argv, "--page-cnt", NULL, 1500UL);
   ulong numa_idx = fd_env_strip_cmdline_ulong(argc, argv, "--numa-idx", NULL,
                                               fd_shmem_numa_idx(cpu_idx));
 


### PR DESCRIPTION
Quic fuzzer wasn't running due to increased memory requirements
This fixes