### PR TITLE
Tune SHA-256 for Zen 2

### DIFF
--- a/src/ballet/sha256/fd_sha256.h
+++ b/src/ballet/sha256/fd_sha256.h
@@ -250,7 +250,7 @@ fd_sha256_batch_abort( fd_sha256_batch_t * batch );
 #ifndef FD_SHA256_BATCH_IMPL
 #if FD_HAS_AVX512
 #define FD_SHA256_BATCH_IMPL 2
-#elif FD_HAS_AVX
+#elif FD_HAS_AVX && !defined(__tune_znver2__)
 #define FD_SHA256_BATCH_IMPL 1
 #else
 #define FD_SHA256_BATCH_IMPL 0


### PR DESCRIPTION
The batch AVX backend is always slower than the SHA-NI backend on Zen 2.

Current main

```
Benchmarking batched
~ 7.005 Gbps throughput / core (batch_cnt  1 sz   55)
~ 7.093 Gbps throughput / core (batch_cnt  2 sz   55)
~ 7.159 Gbps throughput / core (batch_cnt  3 sz   55)
~ 7.156 Gbps throughput / core (batch_cnt  4 sz   55)
~ 7.190 Gbps throughput / core (batch_cnt  5 sz   55)
~ 4.576 Gbps throughput / core (batch_cnt  6 sz   55)
~ 5.339 Gbps throughput / core (batch_cnt  7 sz   55)
~ 5.994 Gbps throughput / core (batch_cnt  8 sz   55)
~ 6.097 Gbps throughput / core (batch_cnt  9 sz   55)
~ 6.142 Gbps throughput / core (batch_cnt 10 sz   55)
~ 6.300 Gbps throughput / core (batch_cnt 11 sz   55)
~ 6.345 Gbps throughput / core (batch_cnt 12 sz   55)
~ 6.356 Gbps throughput / core (batch_cnt 13 sz   55)
~ 5.327 Gbps throughput / core (batch_cnt 14 sz   55)
~ 5.667 Gbps throughput / core (batch_cnt 15 sz   55)
~ 6.025 Gbps throughput / core (batch_cnt 16 sz   55)
~ 6.038 Gbps throughput / core (batch_cnt 17 sz   55)
~ 6.123 Gbps throughput / core (batch_cnt 18 sz   55)
~ 6.166 Gbps throughput / core (batch_cnt 19 sz   55)
~ 6.154 Gbps throughput / core (batch_cnt 20 sz   55)
~ 6.257 Gbps throughput / core (batch_cnt 21 sz   55)
~ 5.580 Gbps throughput / core (batch_cnt 22 sz   55)
~ 5.806 Gbps throughput / core (batch_cnt 23 sz   55)
~ 5.984 Gbps throughput / core (batch_cnt 24 sz   55)
~ 6.056 Gbps throughput / core (batch_cnt 25 sz   55)
~ 6.075 Gbps throughput / core (batch_cnt 26 sz   55)
~ 6.133 Gbps throughput / core (batch_cnt 27 sz   55)
~ 6.162 Gbps throughput / core (batch_cnt 28 sz   55)
~ 6.217 Gbps throughput / core (batch_cnt 29 sz   55)
~ 5.689 Gbps throughput / core (batch_cnt 30 sz   55)
~ 5.864 Gbps throughput / core (batch_cnt 31 sz   55)
~ 6.039 Gbps throughput / core (batch_cnt 32 sz   55)
~ 6.032 Gbps throughput / core (batch_cnt 33 sz   55)
~ 6.093 Gbps throughput / core (batch_cnt 34 sz   55)
~ 6.101 Gbps throughput / core (batch_cnt 35 sz   55)
~ 6.130 Gbps throughput / core (batch_cnt 36 sz   55)
~ 6.195 Gbps throughput / core (batch_cnt 37 sz   55)
~ 5.738 Gbps throughput / core (batch_cnt 38 sz   55)
~ 5.869 Gbps throughput / core (batch_cnt 39 sz   55)
~ 6.014 Gbps throughput / core (batch_cnt 40 sz   55)
~ 6.068 Gbps throughput / core (batch_cnt 41 sz   55)
~ 6.071 Gbps throughput / core (batch_cnt 42 sz   55)
~ 6.088 Gbps throughput / core (batch_cnt 43 sz   55)
~ 6.130 Gbps throughput / core (batch_cnt 44 sz   55)
~ 6.129 Gbps throughput / core (batch_cnt 45 sz   55)
~ 5.804 Gbps throughput / core (batch_cnt 46 sz   55)
~ 5.921 Gbps throughput / core (batch_cnt 47 sz   55)
~ 6.050 Gbps throughput / core (batch_cnt 48 sz   55)
~10.857 Gbps throughput / core (batch_cnt  1 sz  119)
~10.932 Gbps throughput / core (batch_cnt  2 sz  119)
~10.881 Gbps throughput / core (batch_cnt  3 sz  119)
~10.680 Gbps throughput / core (batch_cnt  4 sz  119)
~10.971 Gbps throughput / core (batch_cnt  5 sz  119)
~ 5.357 Gbps throughput / core (batch_cnt  6 sz  119)
~ 6.208 Gbps throughput / core (batch_cnt  7 sz  119)
~ 7.081 Gbps throughput / core (batch_cnt  8 sz  119)
~ 7.257 Gbps throughput / core (batch_cnt  9 sz  119)
~ 7.494 Gbps throughput / core (batch_cnt 10 sz  119)
~ 7.772 Gbps throughput / core (batch_cnt 11 sz  119)
~ 7.947 Gbps throughput / core (batch_cnt 12 sz  119)
~ 8.129 Gbps throughput / core (batch_cnt 13 sz  119)
~ 6.272 Gbps throughput / core (batch_cnt 14 sz  119)
~ 6.659 Gbps throughput / core (batch_cnt 15 sz  119)
~ 7.037 Gbps throughput / core (batch_cnt 16 sz  119)
~ 7.159 Gbps throughput / core (batch_cnt 17 sz  119)
~ 7.322 Gbps throughput / core (batch_cnt 18 sz  119)
~ 7.474 Gbps throughput / core (batch_cnt 19 sz  119)
~ 7.554 Gbps throughput / core (batch_cnt 20 sz  119)
~ 7.693 Gbps throughput / core (batch_cnt 21 sz  119)
~ 6.526 Gbps throughput / core (batch_cnt 22 sz  119)
~ 6.792 Gbps throughput / core (batch_cnt 23 sz  119)
~ 7.082 Gbps throughput / core (batch_cnt 24 sz  119)
~ 7.158 Gbps throughput / core (batch_cnt 25 sz  119)
~ 7.267 Gbps throughput / core (batch_cnt 26 sz  119)
~ 7.341 Gbps throughput / core (batch_cnt 27 sz  119)
~ 7.417 Gbps throughput / core (batch_cnt 28 sz  119)
~ 7.500 Gbps throughput / core (batch_cnt 29 sz  119)
~ 6.676 Gbps throughput / core (batch_cnt 30 sz  119)
~ 6.861 Gbps throughput / core (batch_cnt 31 sz  119)
~ 7.100 Gbps throughput / core (batch_cnt 32 sz  119)
~ 7.162 Gbps throughput / core (batch_cnt 33 sz  119)
~ 7.225 Gbps throughput / core (batch_cnt 34 sz  119)
~ 7.255 Gbps throughput / core (batch_cnt 35 sz  119)
~ 7.351 Gbps throughput / core (batch_cnt 36 sz  119)
~ 7.406 Gbps throughput / core (batch_cnt 37 sz  119)
~ 6.779 Gbps throughput / core (batch_cnt 38 sz  119)
~ 6.917 Gbps throughput / core (batch_cnt 39 sz  119)
~ 7.092 Gbps throughput / core (batch_cnt 40 sz  119)
~ 7.137 Gbps throughput / core (batch_cnt 41 sz  119)
~ 7.190 Gbps throughput / core (batch_cnt 42 sz  119)
~ 7.210 Gbps throughput / core (batch_cnt 43 sz  119)
~ 7.248 Gbps throughput / core (batch_cnt 44 sz  119)
~ 7.354 Gbps throughput / core (batch_cnt 45 sz  119)
~ 6.835 Gbps throughput / core (batch_cnt 46 sz  119)
~ 6.978 Gbps throughput / core (batch_cnt 47 sz  119)
~ 7.120 Gbps throughput / core (batch_cnt 48 sz  119)
~12.050 Gbps throughput / core (batch_cnt  1 sz  247)
~11.976 Gbps throughput / core (batch_cnt  2 sz  247)
~11.785 Gbps throughput / core (batch_cnt  3 sz  247)
~11.770 Gbps throughput / core (batch_cnt  4 sz  247)
~11.922 Gbps throughput / core (batch_cnt  5 sz  247)
~ 5.800 Gbps throughput / core (batch_cnt  6 sz  247)
~ 6.776 Gbps throughput / core (batch_cnt  7 sz  247)
~ 7.683 Gbps throughput / core (batch_cnt  8 sz  247)
~ 7.967 Gbps throughput / core (batch_cnt  9 sz  247)
~ 8.243 Gbps throughput / core (batch_cnt 10 sz  247)
~ 8.463 Gbps throughput / core (batch_cnt 11 sz  247)
~ 8.677 Gbps throughput / core (batch_cnt 12 sz  247)
~ 8.868 Gbps throughput / core (batch_cnt 13 sz  247)
~ 6.741 Gbps throughput / core (batch_cnt 14 sz  247)
~ 7.212 Gbps throughput / core (batch_cnt 15 sz  247)
~ 7.705 Gbps throughput / core (batch_cnt 16 sz  247)
~ 7.842 Gbps throughput / core (batch_cnt 17 sz  247)
~ 7.997 Gbps throughput / core (batch_cnt 18 sz  247)
~ 8.139 Gbps throughput / core (batch_cnt 19 sz  247)
~ 8.246 Gbps throughput / core (batch_cnt 20 sz  247)
~ 8.372 Gbps throughput / core (batch_cnt 21 sz  247)
~ 7.091 Gbps throughput / core (batch_cnt 22 sz  247)
~ 7.397 Gbps throughput / core (batch_cnt 23 sz  247)
~ 7.714 Gbps throughput / core (batch_cnt 24 sz  247)
~ 7.809 Gbps throughput / core (batch_cnt 25 sz  247)
~ 7.909 Gbps throughput / core (batch_cnt 26 sz  247)
~ 8.016 Gbps throughput / core (batch_cnt 27 sz  247)
~ 8.103 Gbps throughput / core (batch_cnt 28 sz  247)
~ 8.209 Gbps throughput / core (batch_cnt 29 sz  247)
~ 7.235 Gbps throughput / core (batch_cnt 30 sz  247)
~ 7.464 Gbps throughput / core (batch_cnt 31 sz  247)
~ 7.715 Gbps throughput / core (batch_cnt 32 sz  247)
~ 7.786 Gbps throughput / core (batch_cnt 33 sz  247)
~ 7.860 Gbps throughput / core (batch_cnt 34 sz  247)
~ 7.936 Gbps throughput / core (batch_cnt 35 sz  247)
~ 8.012 Gbps throughput / core (batch_cnt 36 sz  247)
~ 8.084 Gbps throughput / core (batch_cnt 37 sz  247)
~ 7.346 Gbps throughput / core (batch_cnt 38 sz  247)
~ 7.529 Gbps throughput / core (batch_cnt 39 sz  247)
~ 7.711 Gbps throughput / core (batch_cnt 40 sz  247)
~ 7.776 Gbps throughput / core (batch_cnt 41 sz  247)
~ 7.840 Gbps throughput / core (batch_cnt 42 sz  247)
~ 7.898 Gbps throughput / core (batch_cnt 43 sz  247)
~ 7.956 Gbps throughput / core (batch_cnt 44 sz  247)
~ 8.025 Gbps throughput / core (batch_cnt 45 sz  247)
~ 7.406 Gbps throughput / core (batch_cnt 46 sz  247)
~ 7.561 Gbps throughput / core (batch_cnt 47 sz  247)
~ 7.714 Gbps throughput / core (batch_cnt 48 sz  247)
~12.587 Gbps throughput / core (batch_cnt  1 sz  503)
~12.389 Gbps throughput / core (batch_cnt  2 sz  503)
~12.439 Gbps throughput / core (batch_cnt  3 sz  503)
~12.524 Gbps throughput / core (batch_cnt  4 sz  503)
~12.454 Gbps throughput / core (batch_cnt  5 sz  503)
~ 6.043 Gbps throughput / core (batch_cnt  6 sz  503)
~ 7.047 Gbps throughput / core (batch_cnt  7 sz  503)
~ 8.023 Gbps throughput / core (batch_cnt  8 sz  503)
~ 8.315 Gbps throughput / core (batch_cnt  9 sz  503)
~ 8.616 Gbps throughput / core (batch_cnt 10 sz  503)
~ 8.882 Gbps throughput / core (batch_cnt 11 sz  503)
~ 9.066 Gbps throughput / core (batch_cnt 12 sz  503)
~ 9.286 Gbps throughput / core (batch_cnt 13 sz  503)
~ 7.032 Gbps throughput / core (batch_cnt 14 sz  503)
~ 7.541 Gbps throughput / core (batch_cnt 15 sz  503)
~ 8.038 Gbps throughput / core (batch_cnt 16 sz  503)
~ 8.194 Gbps throughput / core (batch_cnt 17 sz  503)
~ 8.365 Gbps throughput / core (batch_cnt 18 sz  503)
~ 8.508 Gbps throughput / core (batch_cnt 19 sz  503)
~ 8.646 Gbps throughput / core (batch_cnt 20 sz  503)
~ 8.775 Gbps throughput / core (batch_cnt 21 sz  503)
~ 7.373 Gbps throughput / core (batch_cnt 22 sz  503)
~ 7.710 Gbps throughput / core (batch_cnt 23 sz  503)
~ 8.041 Gbps throughput / core (batch_cnt 24 sz  503)
~ 8.148 Gbps throughput / core (batch_cnt 25 sz  503)
~ 8.256 Gbps throughput / core (batch_cnt 26 sz  503)
~ 8.362 Gbps throughput / core (batch_cnt 27 sz  503)
~ 8.463 Gbps throughput / core (batch_cnt 28 sz  503)
~ 8.559 Gbps throughput / core (batch_cnt 29 sz  503)
~ 7.542 Gbps throughput / core (batch_cnt 30 sz  503)
~ 7.796 Gbps throughput / core (batch_cnt 31 sz  503)
~ 8.043 Gbps throughput / core (batch_cnt 32 sz  503)
~ 8.122 Gbps throughput / core (batch_cnt 33 sz  503)
~ 8.206 Gbps throughput / core (batch_cnt 34 sz  503)
~ 8.285 Gbps throughput / core (batch_cnt 35 sz  503)
~ 8.370 Gbps throughput / core (batch_cnt 36 sz  503)
~ 8.441 Gbps throughput / core (batch_cnt 37 sz  503)
~ 7.646 Gbps throughput / core (batch_cnt 38 sz  503)
~ 7.844 Gbps throughput / core (batch_cnt 39 sz  503)
~ 8.038 Gbps throughput / core (batch_cnt 40 sz  503)
~ 8.108 Gbps throughput / core (batch_cnt 41 sz  503)
~ 8.177 Gbps throughput / core (batch_cnt 42 sz  503)
~ 8.239 Gbps throughput / core (batch_cnt 43 sz  503)
~ 8.307 Gbps throughput / core (batch_cnt 44 sz  503)
~ 8.367 Gbps throughput / core (batch_cnt 45 sz  503)
~ 7.698 Gbps throughput / core (batch_cnt 46 sz  503)
~ 7.879 Gbps throughput / core (batch_cnt 47 sz  503)
~ 8.040 Gbps throughput / core (batch_cnt 48 sz  503)
~12.899 Gbps throughput / core (batch_cnt  1 sz 1015)
~12.771 Gbps throughput / core (batch_cnt  2 sz 1015)
~12.890 Gbps throughput / core (batch_cnt  3 sz 1015)
~12.833 Gbps throughput / core (batch_cnt  4 sz 1015)
~12.869 Gbps throughput / core (batch_cnt  5 sz 1015)
~ 6.160 Gbps throughput / core (batch_cnt  6 sz 1015)
~ 7.182 Gbps throughput / core (batch_cnt  7 sz 1015)
~ 8.201 Gbps throughput / core (batch_cnt  8 sz 1015)
~ 8.520 Gbps throughput / core (batch_cnt  9 sz 1015)
~ 8.827 Gbps throughput / core (batch_cnt 10 sz 1015)
~ 9.087 Gbps throughput / core (batch_cnt 11 sz 1015)
~ 9.315 Gbps throughput / core (batch_cnt 12 sz 1015)
~ 9.525 Gbps throughput / core (batch_cnt 13 sz 1015)
~ 7.186 Gbps throughput / core (batch_cnt 14 sz 1015)
~ 7.698 Gbps throughput / core (batch_cnt 15 sz 1015)
~ 8.207 Gbps throughput / core (batch_cnt 16 sz 1015)
~ 8.383 Gbps throughput / core (batch_cnt 17 sz 1015)
~ 8.551 Gbps throughput / core (batch_cnt 18 sz 1015)
~ 8.694 Gbps throughput / core (batch_cnt 19 sz 1015)
~ 8.841 Gbps throughput / core (batch_cnt 20 sz 1015)
~ 8.977 Gbps throughput / core (batch_cnt 21 sz 1015)
~ 7.528 Gbps throughput / core (batch_cnt 22 sz 1015)
~ 7.865 Gbps throughput / core (batch_cnt 23 sz 1015)
~ 8.209 Gbps throughput / core (batch_cnt 24 sz 1015)
~ 8.328 Gbps throughput / core (batch_cnt 25 sz 1015)
~ 8.438 Gbps throughput / core (batch_cnt 26 sz 1015)
~ 8.545 Gbps throughput / core (batch_cnt 27 sz 1015)
~ 8.648 Gbps throughput / core (batch_cnt 28 sz 1015)
~ 8.746 Gbps throughput / core (batch_cnt 29 sz 1015)
~ 7.691 Gbps throughput / core (batch_cnt 30 sz 1015)
~ 7.952 Gbps throughput / core (batch_cnt 31 sz 1015)
~ 8.206 Gbps throughput / core (batch_cnt 32 sz 1015)
~ 8.294 Gbps throughput / core (batch_cnt 33 sz 1015)
~ 8.386 Gbps throughput / core (batch_cnt 34 sz 1015)
~ 8.469 Gbps throughput / core (batch_cnt 35 sz 1015)
~ 8.553 Gbps throughput / core (batch_cnt 36 sz 1015)
~ 8.629 Gbps throughput / core (batch_cnt 37 sz 1015)
~ 7.803 Gbps throughput / core (batch_cnt 38 sz 1015)
~ 8.009 Gbps throughput / core (batch_cnt 39 sz 1015)
~ 8.214 Gbps throughput / core (batch_cnt 40 sz 1015)
~ 8.285 Gbps throughput / core (batch_cnt 41 sz 1015)
~ 8.355 Gbps throughput / core (batch_cnt 42 sz 1015)
~ 8.420 Gbps throughput / core (batch_cnt 43 sz 1015)
~ 8.482 Gbps throughput / core (batch_cnt 44 sz 1015)
~ 8.551 Gbps throughput / core (batch_cnt 45 sz 1015)
~ 7.865 Gbps throughput / core (batch_cnt 46 sz 1015)
~ 8.038 Gbps throughput / core (batch_cnt 47 sz 1015)
~ 8.210 Gbps throughput / core (batch_cnt 48 sz 1015)
~12.984 Gbps throughput / core (batch_cnt  1 sz 2039)
~13.014 Gbps throughput / core (batch_cnt  2 sz 2039)
~13.056 Gbps throughput / core (batch_cnt  3 sz 2039)
~12.703 Gbps throughput / core (batch_cnt  4 sz 2039)
~12.848 Gbps throughput / core (batch_cnt  5 sz 2039)
~ 6.123 Gbps throughput / core (batch_cnt  6 sz 2039)
~ 7.187 Gbps throughput / core (batch_cnt  7 sz 2039)
~ 8.198 Gbps throughput / core (batch_cnt  8 sz 2039)
~ 8.564 Gbps throughput / core (batch_cnt  9 sz 2039)
~ 8.829 Gbps throughput / core (batch_cnt 10 sz 2039)
~ 9.097 Gbps throughput / core (batch_cnt 11 sz 2039)
~ 9.307 Gbps throughput / core (batch_cnt 12 sz 2039)
~ 9.548 Gbps throughput / core (batch_cnt 13 sz 2039)
~ 7.189 Gbps throughput / core (batch_cnt 14 sz 2039)
~ 7.723 Gbps throughput / core (batch_cnt 15 sz 2039)
~ 8.225 Gbps throughput / core (batch_cnt 16 sz 2039)
~ 8.408 Gbps throughput / core (batch_cnt 17 sz 2039)
~ 8.566 Gbps throughput / core (batch_cnt 18 sz 2039)
~ 8.722 Gbps throughput / core (batch_cnt 19 sz 2039)
~ 8.872 Gbps throughput / core (batch_cnt 20 sz 2039)
~ 9.010 Gbps throughput / core (batch_cnt 21 sz 2039)
~ 7.551 Gbps throughput / core (batch_cnt 22 sz 2039)
~ 7.870 Gbps throughput / core (batch_cnt 23 sz 2039)
~ 8.217 Gbps throughput / core (batch_cnt 24 sz 2039)
~ 8.348 Gbps throughput / core (batch_cnt 25 sz 2039)
~ 8.460 Gbps throughput / core (batch_cnt 26 sz 2039)
~ 8.577 Gbps throughput / core (batch_cnt 27 sz 2039)
~ 8.682 Gbps throughput / core (batch_cnt 28 sz 2039)
~ 8.780 Gbps throughput / core (batch_cnt 29 sz 2039)
~ 7.727 Gbps throughput / core (batch_cnt 30 sz 2039)
~ 7.974 Gbps throughput / core (batch_cnt 31 sz 2039)
~ 8.250 Gbps throughput / core (batch_cnt 32 sz 2039)
~ 8.328 Gbps throughput / core (batch_cnt 33 sz 2039)
~ 8.413 Gbps throughput / core (batch_cnt 34 sz 2039)
~ 8.419 Gbps throughput / core (batch_cnt 35 sz 2039)
~ 8.541 Gbps throughput / core (batch_cnt 36 sz 2039)
~ 8.599 Gbps throughput / core (batch_cnt 37 sz 2039)
~ 7.798 Gbps throughput / core (batch_cnt 38 sz 2039)
~ 7.998 Gbps throughput / core (batch_cnt 39 sz 2039)
~ 8.186 Gbps throughput / core (batch_cnt 40 sz 2039)
~ 8.260 Gbps throughput / core (batch_cnt 41 sz 2039)
~ 8.321 Gbps throughput / core (batch_cnt 42 sz 2039)
~ 8.411 Gbps throughput / core (batch_cnt 43 sz 2039)
~ 8.486 Gbps throughput / core (batch_cnt 44 sz 2039)
~ 8.532 Gbps throughput / core (batch_cnt 45 sz 2039)
~ 7.853 Gbps throughput / core (batch_cnt 46 sz 2039)
~ 8.093 Gbps throughput / core (batch_cnt 47 sz 2039)
~ 8.278 Gbps throughput / core (batch_cnt 48 sz 2039)
~13.085 Gbps throughput / core (batch_cnt  1 sz 4087)
~13.150 Gbps throughput / core (batch_cnt  2 sz 4087)
~13.032 Gbps throughput / core (batch_cnt  3 sz 4087)
~13.071 Gbps throughput / core (batch_cnt  4 sz 4087)
~13.114 Gbps throughput / core (batch_cnt  5 sz 4087)
~ 6.242 Gbps throughput / core (batch_cnt  6 sz 4087)
~ 7.283 Gbps throughput / core (batch_cnt  7 sz 4087)
~ 8.320 Gbps throughput / core (batch_cnt  8 sz 4087)
~ 8.667 Gbps throughput / core (batch_cnt  9 sz 4087)
~ 8.970 Gbps throughput / core (batch_cnt 10 sz 4087)
~ 9.241 Gbps throughput / core (batch_cnt 11 sz 4087)
~ 9.474 Gbps throughput / core (batch_cnt 12 sz 4087)
~ 9.684 Gbps throughput / core (batch_cnt 13 sz 4087)
~ 7.266 Gbps throughput / core (batch_cnt 14 sz 4087)
~ 7.805 Gbps throughput / core (batch_cnt 15 sz 4087)
~ 8.318 Gbps throughput / core (batch_cnt 16 sz 4087)
~ 8.496 Gbps throughput / core (batch_cnt 17 sz 4087)
~ 8.667 Gbps throughput / core (batch_cnt 18 sz 4087)
~ 8.827 Gbps throughput / core (batch_cnt 19 sz 4087)
~ 8.975 Gbps throughput / core (batch_cnt 20 sz 4087)
~ 9.111 Gbps throughput / core (batch_cnt 21 sz 4087)
~ 7.632 Gbps throughput / core (batch_cnt 22 sz 4087)
~ 7.967 Gbps throughput / core (batch_cnt 23 sz 4087)
~ 8.327 Gbps throughput / core (batch_cnt 24 sz 4087)
~ 8.449 Gbps throughput / core (batch_cnt 25 sz 4087)
~ 8.561 Gbps throughput / core (batch_cnt 26 sz 4087)
~ 8.673 Gbps throughput / core (batch_cnt 27 sz 4087)
~ 8.779 Gbps throughput / core (batch_cnt 28 sz 4087)
~ 8.879 Gbps throughput / core (batch_cnt 29 sz 4087)
~ 7.812 Gbps throughput / core (batch_cnt 30 sz 4087)
~ 8.054 Gbps throughput / core (batch_cnt 31 sz 4087)
~ 8.319 Gbps throughput / core (batch_cnt 32 sz 4087)
~ 8.423 Gbps throughput / core (batch_cnt 33 sz 4087)
~ 8.510 Gbps throughput / core (batch_cnt 34 sz 4087)
~ 8.594 Gbps throughput / core (batch_cnt 35 sz 4087)
~ 8.675 Gbps throughput / core (batch_cnt 36 sz 4087)
~ 8.752 Gbps throughput / core (batch_cnt 37 sz 4087)
~ 7.914 Gbps throughput / core (batch_cnt 38 sz 4087)
~ 8.119 Gbps throughput / core (batch_cnt 39 sz 4087)
~ 8.331 Gbps throughput / core (batch_cnt 40 sz 4087)
~ 8.406 Gbps throughput / core (batch_cnt 41 sz 4087)
~ 8.474 Gbps throughput / core (batch_cnt 42 sz 4087)
~ 8.541 Gbps throughput / core (batch_cnt 43 sz 4087)
~ 8.612 Gbps throughput / core (batch_cnt 44 sz 4087)
~ 8.670 Gbps throughput / core (batch_cnt 45 sz 4087)
~ 7.985 Gbps throughput / core (batch_cnt 46 sz 4087)
~ 8.154 Gbps throughput / core (batch_cnt 47 sz 4087)
~ 8.327 Gbps throughput / core (batch_cnt 48 sz 4087)
```

With this PR

```
Benchmarking batched
~ 7.320 Gbps throughput / core (batch_cnt  1 sz   55)
~ 7.285 Gbps throughput / core (batch_cnt  2 sz   55)
~ 7.334 Gbps throughput / core (batch_cnt  3 sz   55)
~ 7.292 Gbps throughput / core (batch_cnt  4 sz   55)
~ 7.333 Gbps throughput / core (batch_cnt  5 sz   55)
~ 7.151 Gbps throughput / core (batch_cnt  6 sz   55)
~ 7.172 Gbps throughput / core (batch_cnt  7 sz   55)
~ 7.325 Gbps throughput / core (batch_cnt  8 sz   55)
~ 7.218 Gbps throughput / core (batch_cnt  9 sz   55)
~ 7.212 Gbps throughput / core (batch_cnt 10 sz   55)
~ 7.238 Gbps throughput / core (batch_cnt 11 sz   55)
~ 7.266 Gbps throughput / core (batch_cnt 12 sz   55)
~ 7.212 Gbps throughput / core (batch_cnt 13 sz   55)
~ 7.299 Gbps throughput / core (batch_cnt 14 sz   55)
~ 7.134 Gbps throughput / core (batch_cnt 15 sz   55)
~ 7.294 Gbps throughput / core (batch_cnt 16 sz   55)
~ 7.196 Gbps throughput / core (batch_cnt 17 sz   55)
~ 7.277 Gbps throughput / core (batch_cnt 18 sz   55)
~ 7.297 Gbps throughput / core (batch_cnt 19 sz   55)
~ 7.247 Gbps throughput / core (batch_cnt 20 sz   55)
~ 7.273 Gbps throughput / core (batch_cnt 21 sz   55)
~ 7.234 Gbps throughput / core (batch_cnt 22 sz   55)
~ 7.206 Gbps throughput / core (batch_cnt 23 sz   55)
~ 7.320 Gbps throughput / core (batch_cnt 24 sz   55)
~ 7.319 Gbps throughput / core (batch_cnt 25 sz   55)
~ 7.222 Gbps throughput / core (batch_cnt 26 sz   55)
~ 7.205 Gbps throughput / core (batch_cnt 27 sz   55)
~ 7.212 Gbps throughput / core (batch_cnt 28 sz   55)
~ 7.199 Gbps throughput / core (batch_cnt 29 sz   55)
~ 7.265 Gbps throughput / core (batch_cnt 30 sz   55)
~ 7.188 Gbps throughput / core (batch_cnt 31 sz   55)
~ 7.254 Gbps throughput / core (batch_cnt 32 sz   55)
~ 7.168 Gbps throughput / core (batch_cnt 33 sz   55)
~ 7.284 Gbps throughput / core (batch_cnt 34 sz   55)
~ 7.194 Gbps throughput / core (batch_cnt 35 sz   55)
~ 7.281 Gbps throughput / core (batch_cnt 36 sz   55)
~ 7.244 Gbps throughput / core (batch_cnt 37 sz   55)
~ 7.243 Gbps throughput / core (batch_cnt 38 sz   55)
~ 7.185 Gbps throughput / core (batch_cnt 39 sz   55)
~ 7.245 Gbps throughput / core (batch_cnt 40 sz   55)
~ 7.174 Gbps throughput / core (batch_cnt 41 sz   55)
~ 7.239 Gbps throughput / core (batch_cnt 42 sz   55)
~ 7.213 Gbps throughput / core (batch_cnt 43 sz   55)
~ 7.221 Gbps throughput / core (batch_cnt 44 sz   55)
~ 7.249 Gbps throughput / core (batch_cnt 45 sz   55)
~ 7.219 Gbps throughput / core (batch_cnt 46 sz   55)
~ 7.250 Gbps throughput / core (batch_cnt 47 sz   55)
~ 7.215 Gbps throughput / core (batch_cnt 48 sz   55)
~10.668 Gbps throughput / core (batch_cnt  1 sz  119)
~10.869 Gbps throughput / core (batch_cnt  2 sz  119)
~10.561 Gbps throughput / core (batch_cnt  3 sz  119)
~10.451 Gbps throughput / core (batch_cnt  4 sz  119)
~10.713 Gbps throughput / core (batch_cnt  5 sz  119)
~10.544 Gbps throughput / core (batch_cnt  6 sz  119)
~10.700 Gbps throughput / core (batch_cnt  7 sz  119)
~10.530 Gbps throughput / core (batch_cnt  8 sz  119)
~10.698 Gbps throughput / core (batch_cnt  9 sz  119)
~10.744 Gbps throughput / core (batch_cnt 10 sz  119)
~10.724 Gbps throughput / core (batch_cnt 11 sz  119)
~10.758 Gbps throughput / core (batch_cnt 12 sz  119)
~10.768 Gbps throughput / core (batch_cnt 13 sz  119)
~10.902 Gbps throughput / core (batch_cnt 14 sz  119)
~10.886 Gbps throughput / core (batch_cnt 15 sz  119)
~10.960 Gbps throughput / core (batch_cnt 16 sz  119)
~10.952 Gbps throughput / core (batch_cnt 17 sz  119)
~11.024 Gbps throughput / core (batch_cnt 18 sz  119)
~11.007 Gbps throughput / core (batch_cnt 19 sz  119)
~10.977 Gbps throughput / core (batch_cnt 20 sz  119)
~10.925 Gbps throughput / core (batch_cnt 21 sz  119)
~10.904 Gbps throughput / core (batch_cnt 22 sz  119)
~10.897 Gbps throughput / core (batch_cnt 23 sz  119)
~10.761 Gbps throughput / core (batch_cnt 24 sz  119)
~10.802 Gbps throughput / core (batch_cnt 25 sz  119)
~10.805 Gbps throughput / core (batch_cnt 26 sz  119)
~10.772 Gbps throughput / core (batch_cnt 27 sz  119)
~10.796 Gbps throughput / core (batch_cnt 28 sz  119)
~10.759 Gbps throughput / core (batch_cnt 29 sz  119)
~10.657 Gbps throughput / core (batch_cnt 30 sz  119)
~10.890 Gbps throughput / core (batch_cnt 31 sz  119)
~10.767 Gbps throughput / core (batch_cnt 32 sz  119)
~10.791 Gbps throughput / core (batch_cnt 33 sz  119)
~10.837 Gbps throughput / core (batch_cnt 34 sz  119)
~10.771 Gbps throughput / core (batch_cnt 35 sz  119)
~10.787 Gbps throughput / core (batch_cnt 36 sz  119)
~10.853 Gbps throughput / core (batch_cnt 37 sz  119)
~10.875 Gbps throughput / core (batch_cnt 38 sz  119)
~10.903 Gbps throughput / core (batch_cnt 39 sz  119)
~10.938 Gbps throughput / core (batch_cnt 40 sz  119)
~10.882 Gbps throughput / core (batch_cnt 41 sz  119)
~10.848 Gbps throughput / core (batch_cnt 42 sz  119)
~10.750 Gbps throughput / core (batch_cnt 43 sz  119)
~10.884 Gbps throughput / core (batch_cnt 44 sz  119)
~10.878 Gbps throughput / core (batch_cnt 45 sz  119)
~10.898 Gbps throughput / core (batch_cnt 46 sz  119)
~10.800 Gbps throughput / core (batch_cnt 47 sz  119)
~10.909 Gbps throughput / core (batch_cnt 48 sz  119)
~11.697 Gbps throughput / core (batch_cnt  1 sz  247)
~11.835 Gbps throughput / core (batch_cnt  2 sz  247)
~11.707 Gbps throughput / core (batch_cnt  3 sz  247)
~11.849 Gbps throughput / core (batch_cnt  4 sz  247)
~11.846 Gbps throughput / core (batch_cnt  5 sz  247)
~11.787 Gbps throughput / core (batch_cnt  6 sz  247)
~11.761 Gbps throughput / core (batch_cnt  7 sz  247)
~11.767 Gbps throughput / core (batch_cnt  8 sz  247)
~11.891 Gbps throughput / core (batch_cnt  9 sz  247)
~11.824 Gbps throughput / core (batch_cnt 10 sz  247)
~11.864 Gbps throughput / core (batch_cnt 11 sz  247)
~11.852 Gbps throughput / core (batch_cnt 12 sz  247)
~11.858 Gbps throughput / core (batch_cnt 13 sz  247)
~11.848 Gbps throughput / core (batch_cnt 14 sz  247)
~11.823 Gbps throughput / core (batch_cnt 15 sz  247)
~11.857 Gbps throughput / core (batch_cnt 16 sz  247)
~11.873 Gbps throughput / core (batch_cnt 17 sz  247)
~11.882 Gbps throughput / core (batch_cnt 18 sz  247)
~11.812 Gbps throughput / core (batch_cnt 19 sz  247)
~11.808 Gbps throughput / core (batch_cnt 20 sz  247)
~11.841 Gbps throughput / core (batch_cnt 21 sz  247)
~11.813 Gbps throughput / core (batch_cnt 22 sz  247)
~11.734 Gbps throughput / core (batch_cnt 23 sz  247)
~11.848 Gbps throughput / core (batch_cnt 24 sz  247)
~11.835 Gbps throughput / core (batch_cnt 25 sz  247)
~11.821 Gbps throughput / core (batch_cnt 26 sz  247)
~11.837 Gbps throughput / core (batch_cnt 27 sz  247)
~11.725 Gbps throughput / core (batch_cnt 28 sz  247)
~11.857 Gbps throughput / core (batch_cnt 29 sz  247)
~11.800 Gbps throughput / core (batch_cnt 30 sz  247)
~11.791 Gbps throughput / core (batch_cnt 31 sz  247)
~11.783 Gbps throughput / core (batch_cnt 32 sz  247)
~11.876 Gbps throughput / core (batch_cnt 33 sz  247)
~11.784 Gbps throughput / core (batch_cnt 34 sz  247)
~11.800 Gbps throughput / core (batch_cnt 35 sz  247)
~11.742 Gbps throughput / core (batch_cnt 36 sz  247)
~11.810 Gbps throughput / core (batch_cnt 37 sz  247)
~11.849 Gbps throughput / core (batch_cnt 38 sz  247)
~11.836 Gbps throughput / core (batch_cnt 39 sz  247)
~11.843 Gbps throughput / core (batch_cnt 40 sz  247)
~11.934 Gbps throughput / core (batch_cnt 41 sz  247)
~11.957 Gbps throughput / core (batch_cnt 42 sz  247)
~11.872 Gbps throughput / core (batch_cnt 43 sz  247)
~11.920 Gbps throughput / core (batch_cnt 44 sz  247)
~11.874 Gbps throughput / core (batch_cnt 45 sz  247)
~11.859 Gbps throughput / core (batch_cnt 46 sz  247)
~11.903 Gbps throughput / core (batch_cnt 47 sz  247)
~11.860 Gbps throughput / core (batch_cnt 48 sz  247)
~12.407 Gbps throughput / core (batch_cnt  1 sz  503)
~12.384 Gbps throughput / core (batch_cnt  2 sz  503)
~12.457 Gbps throughput / core (batch_cnt  3 sz  503)
~12.376 Gbps throughput / core (batch_cnt  4 sz  503)
~12.358 Gbps throughput / core (batch_cnt  5 sz  503)
~12.438 Gbps throughput / core (batch_cnt  6 sz  503)
~12.477 Gbps throughput / core (batch_cnt  7 sz  503)
~12.319 Gbps throughput / core (batch_cnt  8 sz  503)
~12.466 Gbps throughput / core (batch_cnt  9 sz  503)
~12.414 Gbps throughput / core (batch_cnt 10 sz  503)
~12.491 Gbps throughput / core (batch_cnt 11 sz  503)
~12.487 Gbps throughput / core (batch_cnt 12 sz  503)
~12.488 Gbps throughput / core (batch_cnt 13 sz  503)
~12.384 Gbps throughput / core (batch_cnt 14 sz  503)
~12.362 Gbps throughput / core (batch_cnt 15 sz  503)
~12.512 Gbps throughput / core (batch_cnt 16 sz  503)
~12.461 Gbps throughput / core (batch_cnt 17 sz  503)
~12.466 Gbps throughput / core (batch_cnt 18 sz  503)
~12.481 Gbps throughput / core (batch_cnt 19 sz  503)
~12.428 Gbps throughput / core (batch_cnt 20 sz  503)
~12.458 Gbps throughput / core (batch_cnt 21 sz  503)
~12.421 Gbps throughput / core (batch_cnt 22 sz  503)
~12.400 Gbps throughput / core (batch_cnt 23 sz  503)
~12.425 Gbps throughput / core (batch_cnt 24 sz  503)
~12.479 Gbps throughput / core (batch_cnt 25 sz  503)
~12.474 Gbps throughput / core (batch_cnt 26 sz  503)
~12.453 Gbps throughput / core (batch_cnt 27 sz  503)
~12.486 Gbps throughput / core (batch_cnt 28 sz  503)
~12.458 Gbps throughput / core (batch_cnt 29 sz  503)
~12.470 Gbps throughput / core (batch_cnt 30 sz  503)
~12.476 Gbps throughput / core (batch_cnt 31 sz  503)
~12.443 Gbps throughput / core (batch_cnt 32 sz  503)
~12.481 Gbps throughput / core (batch_cnt 33 sz  503)
~12.462 Gbps throughput / core (batch_cnt 34 sz  503)
~12.521 Gbps throughput / core (batch_cnt 35 sz  503)
~12.494 Gbps throughput / core (batch_cnt 36 sz  503)
~12.472 Gbps throughput / core (batch_cnt 37 sz  503)
~12.481 Gbps throughput / core (batch_cnt 38 sz  503)
~12.474 Gbps throughput / core (batch_cnt 39 sz  503)
~12.466 Gbps throughput / core (batch_cnt 40 sz  503)
~12.456 Gbps throughput / core (batch_cnt 41 sz  503)
~12.451 Gbps throughput / core (batch_cnt 42 sz  503)
~12.486 Gbps throughput / core (batch_cnt 43 sz  503)
~12.448 Gbps throughput / core (batch_cnt 44 sz  503)
~12.491 Gbps throughput / core (batch_cnt 45 sz  503)
~12.445 Gbps throughput / core (batch_cnt 46 sz  503)
~12.424 Gbps throughput / core (batch_cnt 47 sz  503)
~12.407 Gbps throughput / core (batch_cnt 48 sz  503)
~12.568 Gbps throughput / core (batch_cnt  1 sz 1015)
~12.716 Gbps throughput / core (batch_cnt  2 sz 1015)
~12.710 Gbps throughput / core (batch_cnt  3 sz 1015)
~12.628 Gbps throughput / core (batch_cnt  4 sz 1015)
~12.667 Gbps throughput / core (batch_cnt  5 sz 1015)
~12.751 Gbps throughput / core (batch_cnt  6 sz 1015)
~12.702 Gbps throughput / core (batch_cnt  7 sz 1015)
~12.660 Gbps throughput / core (batch_cnt  8 sz 1015)
~12.730 Gbps throughput / core (batch_cnt  9 sz 1015)
~12.650 Gbps throughput / core (batch_cnt 10 sz 1015)
~12.783 Gbps throughput / core (batch_cnt 11 sz 1015)
~12.767 Gbps throughput / core (batch_cnt 12 sz 1015)
~12.709 Gbps throughput / core (batch_cnt 13 sz 1015)
~12.804 Gbps throughput / core (batch_cnt 14 sz 1015)
~12.787 Gbps throughput / core (batch_cnt 15 sz 1015)
~12.717 Gbps throughput / core (batch_cnt 16 sz 1015)
~12.792 Gbps throughput / core (batch_cnt 17 sz 1015)
~12.722 Gbps throughput / core (batch_cnt 18 sz 1015)
~12.682 Gbps throughput / core (batch_cnt 19 sz 1015)
~12.726 Gbps throughput / core (batch_cnt 20 sz 1015)
~12.804 Gbps throughput / core (batch_cnt 21 sz 1015)
~12.768 Gbps throughput / core (batch_cnt 22 sz 1015)
~12.776 Gbps throughput / core (batch_cnt 23 sz 1015)
~12.804 Gbps throughput / core (batch_cnt 24 sz 1015)
~12.722 Gbps throughput / core (batch_cnt 25 sz 1015)
~12.762 Gbps throughput / core (batch_cnt 26 sz 1015)
~12.797 Gbps throughput / core (batch_cnt 27 sz 1015)
~12.790 Gbps throughput / core (batch_cnt 28 sz 1015)
~12.758 Gbps throughput / core (batch_cnt 29 sz 1015)
~12.827 Gbps throughput / core (batch_cnt 30 sz 1015)
~12.790 Gbps throughput / core (batch_cnt 31 sz 1015)
~12.793 Gbps throughput / core (batch_cnt 32 sz 1015)
~12.816 Gbps throughput / core (batch_cnt 33 sz 1015)
~12.819 Gbps throughput / core (batch_cnt 34 sz 1015)
~12.801 Gbps throughput / core (batch_cnt 35 sz 1015)
~12.814 Gbps throughput / core (batch_cnt 36 sz 1015)
~12.817 Gbps throughput / core (batch_cnt 37 sz 1015)
~12.779 Gbps throughput / core (batch_cnt 38 sz 1015)
~12.800 Gbps throughput / core (batch_cnt 39 sz 1015)
~12.837 Gbps throughput / core (batch_cnt 40 sz 1015)
~12.801 Gbps throughput / core (batch_cnt 41 sz 1015)
~12.808 Gbps throughput / core (batch_cnt 42 sz 1015)
~12.798 Gbps throughput / core (batch_cnt 43 sz 1015)
~12.807 Gbps throughput / core (batch_cnt 44 sz 1015)
~12.817 Gbps throughput / core (batch_cnt 45 sz 1015)
~12.816 Gbps throughput / core (batch_cnt 46 sz 1015)
~12.751 Gbps throughput / core (batch_cnt 47 sz 1015)
~12.725 Gbps throughput / core (batch_cnt 48 sz 1015)
~13.028 Gbps throughput / core (batch_cnt  1 sz 2039)
~12.740 Gbps throughput / core (batch_cnt  2 sz 2039)
~12.920 Gbps throughput / core (batch_cnt  3 sz 2039)
~12.864 Gbps throughput / core (batch_cnt  4 sz 2039)
~12.901 Gbps throughput / core (batch_cnt  5 sz 2039)
~12.928 Gbps throughput / core (batch_cnt  6 sz 2039)
~12.948 Gbps throughput / core (batch_cnt  7 sz 2039)
~12.947 Gbps throughput / core (batch_cnt  8 sz 2039)
~12.945 Gbps throughput / core (batch_cnt  9 sz 2039)
~12.918 Gbps throughput / core (batch_cnt 10 sz 2039)
~12.947 Gbps throughput / core (batch_cnt 11 sz 2039)
~12.900 Gbps throughput / core (batch_cnt 12 sz 2039)
~12.891 Gbps throughput / core (batch_cnt 13 sz 2039)
~12.955 Gbps throughput / core (batch_cnt 14 sz 2039)
~12.950 Gbps throughput / core (batch_cnt 15 sz 2039)
~12.966 Gbps throughput / core (batch_cnt 16 sz 2039)
~12.951 Gbps throughput / core (batch_cnt 17 sz 2039)
~12.946 Gbps throughput / core (batch_cnt 18 sz 2039)
~12.898 Gbps throughput / core (batch_cnt 19 sz 2039)
~12.957 Gbps throughput / core (batch_cnt 20 sz 2039)
~12.955 Gbps throughput / core (batch_cnt 21 sz 2039)
~12.994 Gbps throughput / core (batch_cnt 22 sz 2039)
~12.953 Gbps throughput / core (batch_cnt 23 sz 2039)
~12.960 Gbps throughput / core (batch_cnt 24 sz 2039)
~12.967 Gbps throughput / core (batch_cnt 25 sz 2039)
~12.975 Gbps throughput / core (batch_cnt 26 sz 2039)
~12.966 Gbps throughput / core (batch_cnt 27 sz 2039)
~12.927 Gbps throughput / core (batch_cnt 28 sz 2039)
~12.988 Gbps throughput / core (batch_cnt 29 sz 2039)
~12.975 Gbps throughput / core (batch_cnt 30 sz 2039)
~12.971 Gbps throughput / core (batch_cnt 31 sz 2039)
~12.986 Gbps throughput / core (batch_cnt 32 sz 2039)
~12.948 Gbps throughput / core (batch_cnt 33 sz 2039)
~12.966 Gbps throughput / core (batch_cnt 34 sz 2039)
~12.985 Gbps throughput / core (batch_cnt 35 sz 2039)
~12.966 Gbps throughput / core (batch_cnt 36 sz 2039)
~12.970 Gbps throughput / core (batch_cnt 37 sz 2039)
~12.961 Gbps throughput / core (batch_cnt 38 sz 2039)
~12.966 Gbps throughput / core (batch_cnt 39 sz 2039)
~12.997 Gbps throughput / core (batch_cnt 40 sz 2039)
~12.999 Gbps throughput / core (batch_cnt 41 sz 2039)
~12.993 Gbps throughput / core (batch_cnt 42 sz 2039)
~13.009 Gbps throughput / core (batch_cnt 43 sz 2039)
~12.981 Gbps throughput / core (batch_cnt 44 sz 2039)
~12.980 Gbps throughput / core (batch_cnt 45 sz 2039)
~12.967 Gbps throughput / core (batch_cnt 46 sz 2039)
~12.987 Gbps throughput / core (batch_cnt 47 sz 2039)
~12.963 Gbps throughput / core (batch_cnt 48 sz 2039)
~13.009 Gbps throughput / core (batch_cnt  1 sz 4087)
~12.974 Gbps throughput / core (batch_cnt  2 sz 4087)
~12.961 Gbps throughput / core (batch_cnt  3 sz 4087)
~13.026 Gbps throughput / core (batch_cnt  4 sz 4087)
~13.041 Gbps throughput / core (batch_cnt  5 sz 4087)
~13.057 Gbps throughput / core (batch_cnt  6 sz 4087)
~13.067 Gbps throughput / core (batch_cnt  7 sz 4087)
~13.053 Gbps throughput / core (batch_cnt  8 sz 4087)
~13.054 Gbps throughput / core (batch_cnt  9 sz 4087)
~13.063 Gbps throughput / core (batch_cnt 10 sz 4087)
~13.048 Gbps throughput / core (batch_cnt 11 sz 4087)
~13.068 Gbps throughput / core (batch_cnt 12 sz 4087)
~13.061 Gbps throughput / core (batch_cnt 13 sz 4087)
~13.054 Gbps throughput / core (batch_cnt 14 sz 4087)
~13.069 Gbps throughput / core (batch_cnt 15 sz 4087)
~13.076 Gbps throughput / core (batch_cnt 16 sz 4087)
~13.076 Gbps throughput / core (batch_cnt 17 sz 4087)
~13.076 Gbps throughput / core (batch_cnt 18 sz 4087)
~13.059 Gbps throughput / core (batch_cnt 19 sz 4087)
~13.058 Gbps throughput / core (batch_cnt 20 sz 4087)
~13.066 Gbps throughput / core (batch_cnt 21 sz 4087)
~13.007 Gbps throughput / core (batch_cnt 22 sz 4087)
~13.054 Gbps throughput / core (batch_cnt 23 sz 4087)
~13.031 Gbps throughput / core (batch_cnt 24 sz 4087)
~13.067 Gbps throughput / core (batch_cnt 25 sz 4087)
~13.035 Gbps throughput / core (batch_cnt 26 sz 4087)
~13.039 Gbps throughput / core (batch_cnt 27 sz 4087)
~13.015 Gbps throughput / core (batch_cnt 28 sz 4087)
~13.045 Gbps throughput / core (batch_cnt 29 sz 4087)
~13.059 Gbps throughput / core (batch_cnt 30 sz 4087)
~13.069 Gbps throughput / core (batch_cnt 31 sz 4087)
~13.081 Gbps throughput / core (batch_cnt 32 sz 4087)
~13.020 Gbps throughput / core (batch_cnt 33 sz 4087)
~13.054 Gbps throughput / core (batch_cnt 34 sz 4087)
~13.080 Gbps throughput / core (batch_cnt 35 sz 4087)
~13.046 Gbps throughput / core (batch_cnt 36 sz 4087)
~13.061 Gbps throughput / core (batch_cnt 37 sz 4087)
~13.057 Gbps throughput / core (batch_cnt 38 sz 4087)
~13.030 Gbps throughput / core (batch_cnt 39 sz 4087)
~13.057 Gbps throughput / core (batch_cnt 40 sz 4087)
~13.031 Gbps throughput / core (batch_cnt 41 sz 4087)
~13.060 Gbps throughput / core (batch_cnt 42 sz 4087)
~13.038 Gbps throughput / core (batch_cnt 43 sz 4087)
~13.069 Gbps throughput / core (batch_cnt 44 sz 4087)
~13.077 Gbps throughput / core (batch_cnt 45 sz 4087)
~13.066 Gbps throughput / core (batch_cnt 46 sz 4087)
~13.047 Gbps throughput / core (batch_cnt 47 sz 4087)
~13.076 Gbps throughput / core (batch_cnt 48 sz 4087)
```