### PR TITLE
config: enable security profile for native target

### DIFF
--- a/config/native.mk
+++ b/config/native.mk
@@ -44,6 +44,7 @@ CPPFLAGS+=-march=native -mtune=native
 include config/with-brutality.mk
 include config/with-optimization.mk
 include config/with-debug.mk
+include config/with-security.mk
 
 $(call map-define,FD_HAS_SHANI, __SHA__)
 $(call map-define,FD_HAS_INT128, __SIZEOF_INT128__)


### PR DESCRIPTION
All configs except native include `with-security.mk`. This is presumably an oversight from when the security team first added this profile.