### PR TITLE
QUIC ack and resend fixes

### DIFF
--- a/src/tango/quic/fd_quic.c
+++ b/src/tango/quic/fd_quic.c
@@ -6533,7 +6533,7 @@ fd_quic_frame_handle_stream_frame(
       fd_quic_stream_retry( conn->quic, conn, stream_id );
     } else if( offset == exp_offset && data->length == 0 && data->fin_opt ) {
       /* fin stream in zero-length packet */
-      if( ~( stream->state & FD_QUIC_STREAM_STATE_RX_FIN ) ) {
+      if( !( stream->state & FD_QUIC_STREAM_STATE_RX_FIN ) ) {
         stream->state |= FD_QUIC_STREAM_STATE_RX_FIN;
         if( stream->state & FD_QUIC_STREAM_STATE_TX_FIN ||
             stream->stream_id & ( FD_QUIC_TYPE_UNIDIR << 1u ) ) {

--- a/src/tango/quic/fd_quic_pkt_meta.h
+++ b/src/tango/quic/fd_quic_pkt_meta.h
@@ -30,21 +30,29 @@ struct fd_quic_range {
  */
 union fd_quic_pkt_meta_key {
   union {
-    ulong stream_id:62;
+    ulong stream_id;
     struct {
       ulong flags:62;
       ulong type:2;
-#define FD_QUIC_PKT_META_TYPE_OTHER           0
-#define FD_QUIC_PKT_META_TYPE_STREAM_DATA     1
-#define FD_QUIC_PKT_META_TYPE_MAX_STREAM_DATA 2
+#define FD_QUIC_PKT_META_TYPE_OTHER           0UL
+#define FD_QUIC_PKT_META_TYPE_STREAM_DATA     1UL
+#define FD_QUIC_PKT_META_TYPE_MAX_STREAM_DATA 2UL
     };
+#define FD_QUIC_PKT_META_KEY( TYPE, FLAGS, STREAM_ID ) \
+    ((fd_quic_pkt_meta_key_t)                          \
+     { .stream_id = ( ( (ulong)(STREAM_ID) )    |      \
+                      ( (ulong)(TYPE) << 62UL ) |      \
+                      ( (ulong)(FLAGS) ) ) } )
   };
 };
 typedef union fd_quic_pkt_meta_key fd_quic_pkt_meta_key_t;
 
 struct fd_quic_pkt_meta_var {
   fd_quic_pkt_meta_key_t key;
-  ulong                  value;
+  union {
+    ulong                value;
+    fd_quic_range_t      range;
+  };
 };
 typedef struct fd_quic_pkt_meta_var fd_quic_pkt_meta_var_t;
 
@@ -123,7 +131,6 @@ struct fd_quic_pkt_meta_pool {
 
   /* one of each of these for each enc_level */
   fd_quic_pkt_meta_list_t sent[4]; /* sent pkt_meta */
-  fd_quic_pkt_meta_list_t pend[4]; /* pending pkt_meta */
 };
 
 

--- a/src/tango/quic/fd_quic_stream.h
+++ b/src/tango/quic/fd_quic_stream.h
@@ -40,7 +40,7 @@ struct fd_quic_stream {
 
   fd_quic_buffer_t tx_buf;     /* transmit buffer */
   uchar *          tx_ack;     /* ack - 1 bit per byte of tx_buf */
-  ulong            tx_sent;    /* first unsent byte of tx_buf */
+  ulong            tx_sent;    /* stream offset of first unsent byte of tx_buf */
 
   uint stream_flags;   /* flags representing elements that require action */
 # define FD_QUIC_STREAM_FLAGS_TX_FIN          (1u<<0u)
@@ -85,6 +85,8 @@ struct fd_quic_stream {
 
   ulong  rx_max_stream_data; /* the limit on the number of bytes we allow the peer to
                                   send to us */
+  ulong  rx_max_stream_data_ackd;
+                             /* the largest acked value of rx_max_stream_data */
   ulong  rx_tot_data;        /* the total number of bytes received on this stream */
 
   /* last tx packet num with max_stream_data frame referring to this stream


### PR DESCRIPTION
Stream flow control accounting was incorrect, resulting in double counting
Ack handling didn't clear acks when moving tx_tail, resulting in bytes appearing acked when they weren't
max_stream_data frames had a race condition with peer
handshake_done could be sent unnecessarily (after being acked)