### PR TITLE
fd_verify: explicitly set unused variable to avoid compiler complaints

### DIFF
--- a/src/app/fdctl/run/tiles/fd_verify.c
+++ b/src/app/fdctl/run/tiles/fd_verify.c
@@ -137,7 +137,7 @@ after_frag( void *             _ctx,
      quick dedup of ha traffic. */
 
   int ha_dup;
-  ulong tcache_map_idx = 0; /* ignored */
+  FD_FN_UNUSED ulong tcache_map_idx = 0; /* ignored */
   FD_TCACHE_QUERY( ha_dup, tcache_map_idx, ctx->tcache_map, ctx->tcache_map_cnt, *(ulong *)local_sig );
   if( FD_UNLIKELY( ha_dup ) ) {
     *opt_filter = 1;


### PR DESCRIPTION
Not sure if anyone has a better solution to fix this?
https://github.com/firedancer-io/firedancer/actions/runs/7263228554/job/19788066039#step:6:3779