### PR TITLE
standardized container build based on rhel8.5

### DIFF
--- a/contrib/container-build/Dockerfile
+++ b/contrib/container-build/Dockerfile
@@ -1,0 +1,13 @@
+FROM docker.io/redhat/ubi8@sha256:56c374376a42da40f3aec753c4eab029b5ea162d70cb5f0cda24758780c31d81
+
+ENV RUST_VERSION=1.73.0
+
+RUN INSTALL_PKGS="git perl autoconf gettext-devel automake flex bison cmake clang protobuf-compiler llvm-toolset lcov hostname patch" && \
+    dnf install -y --setopt=tsflags=nodoc https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    dnf clean all -y
+
+RUN curl "https://sh.rustup.rs" -sfo /tmp/rustup.sh && \
+    sh /tmp/rustup.sh -y --default-toolchain ${RUST_VERSION} && \
+    source $HOME/.cargo/env && \
+    rustup show

--- a/contrib/container-build/README.md
+++ b/contrib/container-build/README.md
@@ -1,0 +1,11 @@
+# Container build
+
+Creates a build container with all build dependencies that will be used for subsequent builds. First build takes slightly longer as it creates the build container.
+
+`fdctl` and `solana` binaries will be generated and exported to `~/build/out`
+
+## Execution
+
+Just run `./buildit.sh`
+
+Can optionally pass a tag, branch, or release to buildit.sh as `./buildit.sh somebranch`

--- a/contrib/container-build/README.md
+++ b/contrib/container-build/README.md
@@ -2,10 +2,11 @@
 
 Creates a build container with all build dependencies that will be used for subsequent builds. First build takes slightly longer as it creates the build container.
 
-`fdctl` and `solana` binaries will be generated and exported to `~/build/out`
+`fdctl` and `solana` binaries will be generated and exported to `~/build`
 
 ## Execution
 
-Just run `./buildit.sh`
+Just run `./buildit.sh` to build with default options
 
-Can optionally pass a tag, branch, or release to buildit.sh as `./buildit.sh somebranch`
+Supports options for choosing a tag|release|branch and machine type. See `./buildit.sh --help` for usage.
+

--- a/contrib/container-build/buildit.sh
+++ b/contrib/container-build/buildit.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+OUTDIR=~/build/out
+SCRIPTSDIR=$PWD/scripts
+
+chmod +x "$SCRIPTSDIR/*.sh"
+mkdir -p $OUTDIR
+
+if which podman >/dev/null 2>&1
+  then DOCKER=podman
+elif which docker >/dev/null 2>&1
+  then DOCKER=docker
+else echo "Please install docker or podman"
+  exit 1
+fi
+
+$DOCKER image exists fdbuilder:latest || $DOCKER build -t fdbuilder:latest .
+
+$DOCKER run --rm \
+        --volume "$OUTDIR:/build/out:Z" \
+        --volume "$SCRIPTSDIR:/build/scripts:ro,Z" \
+        fdbuilder:latest \
+        /build/scripts/fdbuild.sh

--- a/contrib/container-build/buildit.sh
+++ b/contrib/container-build/buildit.sh
@@ -4,6 +4,9 @@ OUTDIR=~/build
 SCRIPTDIR=${PWD}/scripts
 MACHINE=linux_gcc_x86_64
 
+#Bump this any time there's a change to the Dockerfile
+IMAGETAG=0.5
+
 GETOPT=$(getopt -o :t:m:h -l tag:,machine:,help -n $0 -- "$@")
 eval set -- "$GETOPT"
 
@@ -46,7 +49,7 @@ fi
 
 
 
-$DOCKER image exists fdbuilder:latest || $DOCKER build -t fdbuilder:latest .
+$DOCKER image exists fdbuilder:$IMAGETAG || $DOCKER build -t fdbuilder:$IMAGETAG -t fdbuilder:latest .
 
 $DOCKER run --rm \
         --volume "$OUTDIR:/build/out:Z" \

--- a/contrib/container-build/buildit.sh
+++ b/contrib/container-build/buildit.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
 OUTDIR=~/build/out
-SCRIPTSDIR=$PWD/scripts
+SCRIPTDIR=$PWD/scripts
 
 # Allow for a tag, release, or branch
 [ -n "$1" ] && TAG="$1"
 
-chmod +x "$SCRIPTSDIR/*.sh"
-mkdir -p $OUTDIR
+chmod +x "$SCRIPTDIR/fdbuild.sh"
+mkdir -p "$OUTDIR"
 
 if which podman >/dev/null 2>&1
   then DOCKER=podman
@@ -23,6 +23,6 @@ $DOCKER image exists fdbuilder:latest || $DOCKER build -t fdbuilder:latest .
 
 $DOCKER run --rm \
         --volume "$OUTDIR:/build/out:Z" \
-        --volume "$SCRIPTSDIR:/build/scripts:ro,Z" \
+        --volume "$SCRIPTDIR:/build/scripts:ro,Z" \
         fdbuilder:latest \
-        /build/scripts/fdbuild.sh $TAG
+        /build/scripts/fdbuild.sh "$TAG"

--- a/contrib/container-build/buildit.sh
+++ b/contrib/container-build/buildit.sh
@@ -1,10 +1,37 @@
 #!/bin/sh
 
-OUTDIR=~/build/out
-SCRIPTDIR=$PWD/scripts
+OUTDIR=~/build
+SCRIPTDIR=${PWD}/scripts
+MACHINE=linux_gcc_x86_64
 
-# Allow for a tag, release, or branch
-[ -n "$1" ] && TAG="$1"
+GETOPT=$(getopt -o :t:m:h -l tag:,machine:,help -n $0 -- "$@")
+eval set -- "$GETOPT"
+
+usage () {
+echo -e "\nUsage: $0 [ -t|--tag release|tag|branchname ] [ -m|--machine machinetype ]
+\nWhere machinetype is one of the targets in ../../config and defaults to
+linux_gcc_x86_64 if not specified\n"
+}
+
+while : ; do
+  case "${1}" in
+    -t | --tag )  TAG="$2" ; shift 2
+      ;;
+    -m | --machine )
+        if [ -f ../../config/${2}.mk ]
+          then MACHINE="$2" ; shift 2
+        else echo "$2 does not appear to be a valid machine type, please review types in ../../config"
+          exit 1
+        fi
+      ;;
+    -h | --help ) usage ; exit 1
+      ;;
+    -- ) shift ; break
+      ;;
+    * ) usage ; exit 1
+      ;;
+  esac
+done
 
 chmod +x "$SCRIPTDIR/fdbuild.sh"
 mkdir -p "$OUTDIR"
@@ -25,4 +52,4 @@ $DOCKER run --rm \
         --volume "$OUTDIR:/build/out:Z" \
         --volume "$SCRIPTDIR:/build/scripts:ro,Z" \
         fdbuilder:latest \
-        /build/scripts/fdbuild.sh "$TAG"
+        /build/scripts/fdbuild.sh "$MACHINE" "$TAG"

--- a/contrib/container-build/buildit.sh
+++ b/contrib/container-build/buildit.sh
@@ -3,6 +3,9 @@
 OUTDIR=~/build/out
 SCRIPTSDIR=$PWD/scripts
 
+# Allow for a tag, release, or branch
+[ -n "$1" ] && TAG="$1"
+
 chmod +x "$SCRIPTSDIR/*.sh"
 mkdir -p $OUTDIR
 
@@ -14,10 +17,12 @@ else echo "Please install docker or podman"
   exit 1
 fi
 
+
+
 $DOCKER image exists fdbuilder:latest || $DOCKER build -t fdbuilder:latest .
 
 $DOCKER run --rm \
         --volume "$OUTDIR:/build/out:Z" \
         --volume "$SCRIPTSDIR:/build/scripts:ro,Z" \
         fdbuilder:latest \
-        /build/scripts/fdbuild.sh
+        /build/scripts/fdbuild.sh $TAG

--- a/contrib/container-build/scripts/fdbuild.sh
+++ b/contrib/container-build/scripts/fdbuild.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -xeo pipefail
+
+GITDIR=/build/src
+source "$HOME/.cargo/env"
+
+git clone --recurse-submodules https://github.com/firedancer-io/firedancer.git $GITDIR
+cd "$GITDIR"
+
+# Currently needed to build and install openssl build libs that support QUIC
+./deps.sh install
+
+# Do the thing
+MACHINE=linux_gcc_x86_64 make -j fdctl solana
+
+cp -v build/linux/gcc/x86_64/bin/* /build/out
+echo "You can find build output in $HOME/build/out"

--- a/contrib/container-build/scripts/fdbuild.sh
+++ b/contrib/container-build/scripts/fdbuild.sh
@@ -7,6 +7,9 @@ source "$HOME/.cargo/env"
 git clone --recurse-submodules https://github.com/firedancer-io/firedancer.git $GITDIR
 cd "$GITDIR"
 
+# Allow for a tag, release, or branch
+[ -n "$1" ] && git checkout "$1"
+
 # Currently needed to build and install openssl build libs that support QUIC
 ./deps.sh install
 

--- a/contrib/container-build/scripts/fdbuild.sh
+++ b/contrib/container-build/scripts/fdbuild.sh
@@ -8,13 +8,18 @@ git clone --recurse-submodules https://github.com/firedancer-io/firedancer.git $
 cd "$GITDIR"
 
 # Allow for a tag, release, or branch
-[ -n "$1" ] && git checkout "$1"
+[ -n "$2" ] && git checkout "$2"
 
 # Currently needed to build and install openssl build libs that support QUIC
 ./deps.sh install
 
 # Do the thing
-MACHINE=linux_gcc_x86_64 make -j fdctl solana
+MACHINE=$1 make -j fdctl solana
 
-cp -v build/linux/gcc/x86_64/bin/* /build/out
-echo "You can find build output in $HOME/build/out"
+cd build
+for dir in $(find . -name bin -type d)
+  do mkdir -p /build/out/$dir
+    cp $dir/* /build/out/$dir/
+done
+
+echo "You can find build output in ~/build"

--- a/contrib/container-build/scripts/fdbuild.sh
+++ b/contrib/container-build/scripts/fdbuild.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -xeo pipefail
+set -eo pipefail
 
 GITDIR=/build/src
 source "$HOME/.cargo/env"


### PR DESCRIPTION
- creates a build container with all build dependencies that will be used for subsequent builds. First build takes slightly longer as it creates the container.
- spits out fdctl and solana bins to `~/build/machinetype`
- can optionally pass a tag, branch, or release to buildit.sh as `./buildit.sh --tag somebranch`
- optionally specify a machine type with `./buildit.sh --machine machinetype` but defaults to linux_gcc_x86_64
