### PR TITLE
simd: use AVX-512 native rotate

### DIFF
--- a/src/ballet/chacha20/fd_chacha20_sse.c
+++ b/src/ballet/chacha20/fd_chacha20_sse.c
@@ -40,13 +40,8 @@ fd_chacha20_block( void *       _block,
      so this makes a difference. */
 #define ROTATE_LEFT_16( x ) _mm_shuffle_epi8( (x), vb( 2,3,0,1, 6,7,4,5, 10,11,8,9,  14,15,12,13 ) )
 #define ROTATE_LEFT_08( x ) _mm_shuffle_epi8( (x), vb( 3,0,1,2, 7,4,5,6, 11,8,9,10,  15,12,13,14 ) )
-#if FD_HAS_AVX512
-# define ROTATE_LEFT_12( x ) _mm_rol_epi32( (x), 12 )
-# define ROTATE_LEFT_07( x ) _mm_rol_epi32( (x),  7 )
-#else
-# define ROTATE_LEFT_12( x ) vu_rol( (x), 12 )
-# define ROTATE_LEFT_07( x ) vu_rol( (x),  7 )
-#endif
+#define ROTATE_LEFT_12( x ) vu_rol( (x), 12 )
+#define ROTATE_LEFT_07( x ) vu_rol( (x),  7 )
 
   /* Run the ChaCha round function 20 times.
      (Each iteration does a column round and a diagonal round.) */

--- a/src/util/simd/fd_avx512_wwi.h
+++ b/src/util/simd/fd_avx512_wwi.h
@@ -87,8 +87,17 @@ static inline void  wwi_stu( void * m, wwi_t x ) { _mm512_storeu_epi32( m, x ); 
    wwi_rol_vector(x,y) returns wwi( rotate_left (x0,y0), rotate_left (x1,y1), ... )
    wwi_ror_vector(x,y) returns wwi( rotate_right(x0,y0), rotate_right(x1,y1), ... ) */
 
-static inline wwi_t wwi_rol( wwi_t a, int n ) { return wwi_or( wwi_shl ( a, n & 31 ), wwi_shru( a, (-n) & 31 ) ); }
-static inline wwi_t wwi_ror( wwi_t a, int n ) { return wwi_or( wwi_shru( a, n & 31 ), wwi_shl ( a, (-n) & 31 ) ); }
+static inline wwi_t wwi_rol( wwi_t a, int n ) {
+  return __builtin_constant_p(n) ?
+         _mm512_rol_epi32( (a), (n)&31 ) :
+         wwi_or( wwi_shl ( a, n & 31 ), wwi_shru( a, (-n) & 31 ) );
+}
+
+static inline wwi_t wwi_ror( wwi_t a, int n ) {
+  return __builtin_constant_p(n) ?
+         _mm512_ror_epi32( (a), (n)&31 ) :
+         wwi_or( wwi_shru( a, n & 31 ), wwi_shl ( a, (-n) & 31 ) );
+}
 
 static inline wwi_t wwi_rol_vector( wwi_t a, wwi_t b ) {
   wwi_t m = wwi_bcast( 31 );

--- a/src/util/simd/fd_avx512_wwl.h
+++ b/src/util/simd/fd_avx512_wwl.h
@@ -86,8 +86,17 @@ static inline void  wwl_stu( void * m, wwl_t x ) { _mm512_storeu_epi64( m, x ); 
    wwl_rol_vector(x,y) returns wwl( rotate_left (x0,y0), rotate_left (x1,y1), ... )
    wwl_ror_vector(x,y) returns wwl( rotate_right(x0,y0), rotate_right(x1,y1), ... ) */
 
-static inline wwl_t wwl_rol( wwl_t a, long n ) { return wwl_or( wwl_shl ( a, n & 63L ), wwl_shru( a, (-n) & 63L ) ); }
-static inline wwl_t wwl_ror( wwl_t a, long n ) { return wwl_or( wwl_shru( a, n & 63L ), wwl_shl ( a, (-n) & 63L ) ); }
+static inline wwl_t wwl_rol( wwl_t a, long n ) {
+  return __builtin_constant_p(n) ?
+         _mm512_rol_epi64( (a), (n)&63 ) :
+         wwl_or( wwl_shl ( a, n & 63L ), wwl_shru( a, (-n) & 63L ) );
+}
+
+static inline wwl_t wwl_ror( wwl_t a, long n ) {
+  return __builtin_constant_p(n) ?
+         _mm512_ror_epi64( (a), (n)&63 ) :
+         wwl_or( wwl_shru( a, n & 63L ), wwl_shl ( a, (-n) & 63L ) );
+}
 
 static inline wwl_t wwl_rol_vector( wwl_t a, wwl_t b ) {
   wwl_t m = wwl_bcast( 63L );

--- a/src/util/simd/fd_avx512_wwu.h
+++ b/src/util/simd/fd_avx512_wwu.h
@@ -88,8 +88,17 @@ static inline void  wwu_stu( void * m, wwu_t x ) { _mm512_storeu_epi32( m, x ); 
    wwu_rol_vector(x,y) returns wwu( rotate_left (x0,y0), rotate_left (x1,y1), ... )
    wwu_ror_vector(x,y) returns wwu( rotate_right(x0,y0), rotate_right(x1,y1), ... ) */
 
-static inline wwu_t wwu_rol( wwu_t a, uint n ) { return wwu_or( wwu_shl( a, n & 31U ), wwu_shr( a, (-n) & 31U ) ); }
-static inline wwu_t wwu_ror( wwu_t a, uint n ) { return wwu_or( wwu_shr( a, n & 31U ), wwu_shl( a, (-n) & 31U ) ); }
+static inline wwu_t wwu_rol( wwu_t a, uint n ) {
+  return __builtin_constant_p(n) ?
+         _mm512_rol_epi32( (a), (n)&31U ) :
+         wwu_or( wwu_shl( a, n & 31U ), wwu_shr( a, (-n) & 31U ) );
+}
+
+static inline wwu_t wwu_ror( wwu_t a, uint n ) {
+  return __builtin_constant_p(n) ?
+         _mm512_ror_epi32( (a), (n)&31U ) :
+         wwu_or( wwu_shr( a, n & 31U ), wwu_shl( a, (-n) & 31U ) );
+}
 
 static inline wwu_t wwu_rol_vector( wwu_t a, wwu_t b ) {
   wwu_t m = wwu_bcast( 31U );

--- a/src/util/simd/fd_avx512_wwv.h
+++ b/src/util/simd/fd_avx512_wwv.h
@@ -87,8 +87,17 @@ static inline void  wwv_stu( void * m, wwv_t x ) { _mm512_storeu_epi64( m, x ); 
    wwv_rol_vector(x,y) returns wwv( rotate_left (x0,y0), rotate_left (x1,y1), ... )
    wwv_ror_vector(x,y) returns wwv( rotate_right(x0,y0), rotate_right(x1,y1), ... ) */
 
-static inline wwv_t wwv_rol( wwv_t a, ulong n ) { return wwv_or( wwv_shl( a, n & 63UL ), wwv_shr( a, (-n) & 63UL ) ); }
-static inline wwv_t wwv_ror( wwv_t a, ulong n ) { return wwv_or( wwv_shr( a, n & 63UL ), wwv_shl( a, (-n) & 63UL ) ); }
+static inline wwv_t wwv_rol( wwv_t a, ulong n ) {
+  return __builtin_constant_p(n) ?
+         _mm512_rol_epi64( (a), (n)&63 ) :
+         wwv_or( wwv_shl( a, n & 63UL ), wwv_shr( a, (-n) & 63UL ) );
+}
+
+static inline wwv_t wwv_ror( wwv_t a, ulong n ) {
+  return __builtin_constant_p(n) ?
+         _mm512_ror_epi64( (a), (n)&63 ) :
+         wwv_or( wwv_shr( a, n & 63UL ), wwv_shl( a, (-n) & 63UL ) );
+}
 
 static inline wwv_t wwv_rol_vector( wwv_t a, wwv_t b ) {
   wwv_t m = wwv_bcast( 63UL );

--- a/src/util/simd/fd_avx_wi.h
+++ b/src/util/simd/fd_avx_wi.h
@@ -164,8 +164,16 @@ wi_insert_variable( wi_t a, int n, int v ) {
 #define wi_or(a,b)     _mm256_or_si256(     (a), (b) ) /* [   a0 |b0    a1 |b1 ...   a7 |b7 ] */
 #define wi_xor(a,b)    _mm256_xor_si256(    (a), (b) ) /* [   a0 ^b0    a1 ^b1 ...   a7 ^b7 ] */
 
+/* wi_rol(x,n) returns wi( rotate_left (x0,n), rotate_left (x1,n), ... )
+   wi_ror(x,n) returns wi( rotate_right(x0,n), rotate_right(x1,n), ... ) */
+
+#if FD_HAS_AVX512
+#define wi_rol(a,imm)  _mm256_rol_epi32( (a), (imm) )
+#define wi_ror(a,imm)  _mm256_ror_epi32( (a), (imm) )
+#else
 static inline wi_t wi_rol( wi_t a, int imm ) { return wi_or( wi_shl(  a, imm & 31 ), wi_shru( a, (-imm) & 31 ) ); }
 static inline wi_t wi_ror( wi_t a, int imm ) { return wi_or( wi_shru( a, imm & 31 ), wi_shl(  a, (-imm) & 31 ) ); }
+#endif
 
 static inline wi_t wi_rol_variable( wi_t a, int n ) { return wi_or( wi_shl_variable(  a, n&31 ), wi_shru_variable( a, (-n)&31 ) ); }
 static inline wi_t wi_ror_variable( wi_t a, int n ) { return wi_or( wi_shru_variable( a, n&31 ), wi_shl_variable(  a, (-n)&31 ) ); }

--- a/src/util/simd/fd_avx_wl.h
+++ b/src/util/simd/fd_avx_wl.h
@@ -162,8 +162,16 @@ wl_insert_variable( wl_t a, int n, long v ) {
 #define wl_or(a,b)     _mm256_or_si256(     (a), (b) ) /* [   a0 |b0    a1 |b1 ...   a3 |b3 ] */
 #define wl_xor(a,b)    _mm256_xor_si256(    (a), (b) ) /* [   a0 ^b0    a1 ^b1 ...   a3 ^b3 ] */
 
+/* wl_rol(x,n) returns wl( rotate_left (x0,n), rotate_left (x1,n), ... )
+   wl_ror(x,n) returns wl( rotate_right(x0,n), rotate_right(x1,n), ... ) */
+
+#if FD_HAS_AVX512
+#define wl_rol(a,imm)  _mm256_rol_epi64( (a), (imm) )
+#define wl_ror(a,imm)  _mm256_ror_epi64( (a), (imm) )
+#else
 static inline wl_t wl_rol( wl_t a, int imm ) { return wl_or( wl_shl(  a, imm & 63 ), wl_shru( a, (-imm) & 63 ) ); }
 static inline wl_t wl_ror( wl_t a, int imm ) { return wl_or( wl_shru( a, imm & 63 ), wl_shl(  a, (-imm) & 63 ) ); }
+#endif
 
 static inline wl_t wl_rol_variable( wl_t a, int n ) { return wl_or( wl_shl_variable(  a, n&63 ), wl_shru_variable( a, (-n)&63 ) ); }
 static inline wl_t wl_ror_variable( wl_t a, int n ) { return wl_or( wl_shru_variable( a, n&63 ), wl_shl_variable(  a, (-n)&63 ) ); }

--- a/src/util/simd/fd_avx_wu.h
+++ b/src/util/simd/fd_avx_wu.h
@@ -165,8 +165,16 @@ wu_insert_variable( wu_t a, int n, uint v ) {
 #define wu_or(a,b)     _mm256_or_si256(     (a), (b) ) /* [   a0 |b0    a1 |b1 ...   a7 |b7 ] */
 #define wu_xor(a,b)    _mm256_xor_si256(    (a), (b) ) /* [   a0 ^b0    a1 ^b1 ...   a7 ^b7 ] */
 
+/* wu_rol(x,n) returns wu( rotate_left (x0,n), rotate_left (x1,n), ... )
+   wu_ror(x,n) returns wu( rotate_right(x0,n), rotate_right(x1,n), ... ) */
+
+#if FD_HAS_AVX512
+#define wu_rol(a,imm)  _mm256_rol_epi32( (a), (imm) )
+#define wu_ror(a,imm)  _mm256_ror_epi32( (a), (imm) )
+#else
 static inline wu_t wu_rol( wu_t a, int imm ) { return wu_or( wu_shl( a, imm & 31 ), wu_shr( a, (-imm) & 31 ) ); }
 static inline wu_t wu_ror( wu_t a, int imm ) { return wu_or( wu_shr( a, imm & 31 ), wu_shl( a, (-imm) & 31 ) ); }
+#endif
 
 static inline wu_t wu_rol_variable( wu_t a, int n ) { return wu_or( wu_shl_variable( a, n&31 ), wu_shr_variable( a, (-n)&31 ) ); }
 static inline wu_t wu_ror_variable( wu_t a, int n ) { return wu_or( wu_shr_variable( a, n&31 ), wu_shl_variable( a, (-n)&31 ) ); }

--- a/src/util/simd/fd_avx_wv.h
+++ b/src/util/simd/fd_avx_wv.h
@@ -159,8 +159,16 @@ wv_insert_variable( wv_t a, int n, ulong v ) {
 #define wv_or(a,b)     _mm256_or_si256(     (a), (b) ) /* [   a0 |b0    a1 |b1 ...   a3 |b3 ] */
 #define wv_xor(a,b)    _mm256_xor_si256(    (a), (b) ) /* [   a0 ^b0    a1 ^b1 ...   a3 ^b3 ] */
 
+/* wv_rol(x,n) returns wv( rotate_left (x0,n), rotate_left (x1,n), ... )
+   wv_ror(x,n) returns wv( rotate_right(x0,n), rotate_right(x1,n), ... ) */
+
+#if FD_HAS_AVX512
+#define wv_rol(a,imm)  _mm256_rol_epi64( (a), (imm) )
+#define wv_ror(a,imm)  _mm256_ror_epi64( (a), (imm) )
+#else
 static inline wv_t wv_rol( wv_t a, int imm ) { return wv_or( wv_shl( a, imm & 63 ), wv_shr( a, (-imm) & 63 ) ); }
 static inline wv_t wv_ror( wv_t a, int imm ) { return wv_or( wv_shr( a, imm & 63 ), wv_shl( a, (-imm) & 63 ) ); }
+#endif
 
 static inline wv_t wv_rol_variable( wv_t a, int n ) { return wv_or( wv_shl_variable( a, n&63 ), wv_shr_variable( a, (-n)&63 ) ); }
 static inline wv_t wv_ror_variable( wv_t a, int n ) { return wv_or( wv_shr_variable( a, n&63 ), wv_shl_variable( a, (-n)&63 ) ); }

--- a/src/util/simd/fd_sse_vi.h
+++ b/src/util/simd/fd_sse_vi.h
@@ -136,8 +136,16 @@ vi_insert_variable( vi_t a, int n, int v ) {
 #define vi_or(a,b)     _mm_or_si128(     (a), (b) ) /* [   a0 |b0    a1 |b1 ...   a3 |b3 ] */
 #define vi_xor(a,b)    _mm_xor_si128(    (a), (b) ) /* [   a0 ^b0    a1 ^b1 ...   a3 ^b3 ] */
 
+/* vi_rol(x,n) returns vi( rotate_left (x0,n), rotate_left (x1,n), ... )
+   vi_ror(x,n) returns vi( rotate_right(x0,n), rotate_right(x1,n), ... ) */
+
+#if FD_HAS_AVX512
+#define vi_rol(a,imm)  _mm_rol_epi32( (a), (imm) )
+#define vi_ror(a,imm)  _mm_ror_epi32( (a), (imm) )
+#else
 static inline vi_t vi_rol( vi_t a, int imm ) { return vi_or( vi_shl(  a, imm & 31 ), vi_shru( a, (-imm) & 31 ) ); }
 static inline vi_t vi_ror( vi_t a, int imm ) { return vi_or( vi_shru( a, imm & 31 ), vi_shl(  a, (-imm) & 31 ) ); }
+#endif
 
 static inline vi_t vi_rol_variable( vi_t a, int n ) { return vi_or( vi_shl_variable(  a, n&31 ), vi_shru_variable( a, (-n)&31 ) ); }
 static inline vi_t vi_ror_variable( vi_t a, int n ) { return vi_or( vi_shru_variable( a, n&31 ), vi_shl_variable(  a, (-n)&31 ) ); }

--- a/src/util/simd/fd_sse_vl.h
+++ b/src/util/simd/fd_sse_vl.h
@@ -135,8 +135,16 @@ vl_insert_variable( vl_t a, int n, long v ) {
 #define vl_or(a,b)     _mm_or_si128(     (a), (b) ) /* [   a0 |b0    a1 |b1 ] */
 #define vl_xor(a,b)    _mm_xor_si128(    (a), (b) ) /* [   a0 ^b0    a1 ^b1 ] */
 
+/* vl_rol(x,n) returns vl( rotate_left (x0,n), rotate_left (x1,n), ... )
+   vl_ror(x,n) returns vl( rotate_right(x0,n), rotate_right(x1,n), ... ) */
+
+#if FD_HAS_AVX512
+#define vl_rol(a,imm)  _mm_rol_epi64( (a), (imm) )
+#define vl_ror(a,imm)  _mm_ror_epi64( (a), (imm) )
+#else
 static inline vl_t vl_rol( vl_t a, int imm ) { return vl_or( vl_shl(  a, imm & 63 ), vl_shru( a, (-imm) & 63 ) ); }
 static inline vl_t vl_ror( vl_t a, int imm ) { return vl_or( vl_shru( a, imm & 63 ), vl_shl(  a, (-imm) & 63 ) ); }
+#endif
 
 static inline vl_t vl_rol_variable( vl_t a, int n ) { return vl_or( vl_shl_variable(  a, n&63 ), vl_shru_variable( a, (-n)&63 ) ); }
 static inline vl_t vl_ror_variable( vl_t a, int n ) { return vl_or( vl_shru_variable( a, n&63 ), vl_shl_variable(  a, (-n)&63 ) ); }

--- a/src/util/simd/fd_sse_vu.h
+++ b/src/util/simd/fd_sse_vu.h
@@ -135,8 +135,16 @@ vu_insert_variable( vu_t a, int n, uint v ) {
 #define vu_or(a,b)     _mm_or_si128(     (a), (b) ) /* [   a0 |b0    a1 |b1 ...   a3 |b3 ] */
 #define vu_xor(a,b)    _mm_xor_si128(    (a), (b) ) /* [   a0 ^b0    a1 ^b1 ...   a3 ^b3 ] */
 
+/* vu_rol(x,n) returns vu( rotate_left (x0,n), rotate_left (x1,n), ... )
+   vu_ror(x,n) returns vu( rotate_right(x0,n), rotate_right(x1,n), ... ) */
+
+#if FD_HAS_AVX512
+#define vu_rol(a,imm)  _mm_rol_epi32( (a), (imm) )
+#define vu_ror(a,imm)  _mm_ror_epi32( (a), (imm) )
+#else
 static inline vu_t vu_rol( vu_t a, int imm ) { return vu_or( vu_shl( a, imm & 31 ), vu_shr( a, (-imm) & 31 ) ); }
 static inline vu_t vu_ror( vu_t a, int imm ) { return vu_or( vu_shr( a, imm & 31 ), vu_shl( a, (-imm) & 31 ) ); }
+#endif
 
 static inline vu_t vu_rol_variable( vu_t a, int n ) { return vu_or( vu_shl_variable( a, n&31 ), vu_shr_variable( a, (-n)&31 ) ); }
 static inline vu_t vu_ror_variable( vu_t a, int n ) { return vu_or( vu_shr_variable( a, n&31 ), vu_shl_variable( a, (-n)&31 ) ); }

--- a/src/util/simd/fd_sse_vv.h
+++ b/src/util/simd/fd_sse_vv.h
@@ -131,8 +131,16 @@ vv_insert_variable( vv_t a, int n, ulong v ) {
 #define vv_or(a,b)     _mm_or_si128(     (a), (b) ) /* [   a0 |b0    a1 |b1 ] */
 #define vv_xor(a,b)    _mm_xor_si128(    (a), (b) ) /* [   a0 ^b0    a1 ^b1 ] */
 
+/* vv_rol(x,n) returns vv( rotate_left (x0,n), rotate_left (x1,n), ... )
+   vv_ror(x,n) returns vv( rotate_right(x0,n), rotate_right(x1,n), ... ) */
+
+#if FD_HAS_AVX512
+#define vv_rol(a,imm)  _mm_rol_epi64( (a), (imm) )
+#define vv_ror(a,imm)  _mm_ror_epi64( (a), (imm) )
+#else
 static inline vv_t vv_rol( vv_t a, int imm ) { return vv_or( vv_shl( a, imm & 63 ), vv_shr( a, (-imm) & 63 ) ); }
 static inline vv_t vv_ror( vv_t a, int imm ) { return vv_or( vv_shr( a, imm & 63 ), vv_shl( a, (-imm) & 63 ) ); }
+#endif
 
 static inline vv_t vv_rol_variable( vv_t a, int n ) { return vv_or( vv_shl_variable( a, n&63 ), vv_shr_variable( a, (-n)&63 ) ); }
 static inline vv_t vv_ror_variable( vv_t a, int n ) { return vv_or( vv_shr_variable( a, n&63 ), vv_shl_variable( a, (-n)&63 ) ); }


### PR DESCRIPTION
AVX-512F comes with native rotate instructions which are slightly
faster than the existing emulated rotate.

Improves SHA-256 batch throughput by 0.6% on Sapphire Rapids.
