### PR TITLE
chacha20: SSE fixes

### DIFF
--- a/src/ballet/chacha20/Local.mk
+++ b/src/ballet/chacha20/Local.mk
@@ -1,6 +1,6 @@
 $(call add-hdrs,fd_chacha20.h fd_chacha20rng.h)
-ifdef FD_HAS_AVX
-$(call add-objs,fd_chacha20_avx fd_chacha20rng,fd_ballet)
+ifdef FD_HAS_SSE
+$(call add-objs,fd_chacha20_sse fd_chacha20rng,fd_ballet)
 else
 $(call add-objs,fd_chacha20 fd_chacha20rng,fd_ballet)
 endif

--- a/src/ballet/chacha20/fd_chacha20.c
+++ b/src/ballet/chacha20/fd_chacha20.c
@@ -19,8 +19,11 @@ fd_chacha20_quarter_round( uint * a,
 void *
 fd_chacha20_block( void *       _block,
                    void const * _key,
-                   uint         idx,
-                   void const * _nonce ) {
+                   void const * _idx_nonce ) {
+
+  uint *       block     = __builtin_assume_aligned( _block,     64UL );
+  uint const * key       = __builtin_assume_aligned( _key,       32UL );
+  uint const * idx_nonce = __builtin_assume_aligned( _idx_nonce, 16UL );
 
   /* Construct the input ChaCha20 block state as the following
      matrix of little endian uint entries:
@@ -36,18 +39,13 @@ fd_chacha20_block( void *       _block,
        b is the block index
        n is the nonce */
 
-  uint * block = (uint *)_block;
   block[ 0 ] = 0x61707865U;
   block[ 1 ] = 0x3320646eU;
   block[ 2 ] = 0x79622d32U;
   block[ 3 ] = 0x6b206574U;
 
-  uint const * key = (uint const *)_key;
-  memcpy( block+ 4, key, 8*sizeof(uint) );
-
-  block[ 12 ] = idx;
-  uint const * nonce = (uint const *)_nonce;
-  memcpy( block+13, nonce, 3*sizeof(uint) );
+  memcpy( block+ 4, key,       8*sizeof(uint) );
+  memcpy( block+12, idx_nonce, 4*sizeof(uint) );
 
   /* Remember the input state for later use */
 

--- a/src/ballet/chacha20/fd_chacha20.h
+++ b/src/ballet/chacha20/fd_chacha20.h
@@ -15,20 +15,18 @@ FD_PROTOTYPES_BEGIN
 
 /* fd_chacha20_block is the ChaCha20 block function.
 
-   - block points to the first byte of the output block of 64 bytes size
-     and 64 bytes alignment
-   - key points to the first byte of the encryption key of 32 bytes size
-   - idx is the block index
-   - nonce points to the first byte of the block nonce of 24 bytes size
-     and 4 bytes alignment
+   - block points to the output block (64 byte size, 32 byte align)
+   - key points to the encryption key (32 byte size, 32 byte align)
+   - idx_nonce points to the block index and block nonce
+     (first byte is 32-bit index, rest is 96-bit nonce)
+     (16 byte size, 16 byte align)
 
    FIXME this should probably do multiple blocks */
 
 void *
 fd_chacha20_block( void *       block,
                    void const * key,
-                   uint         idx,
-                   void const * nonce );
+                   void const * idx_nonce );
 
 /* Encryption/decryption functions not implemented for now
    as they are not yet required. */

--- a/src/ballet/chacha20/fd_chacha20rng.c
+++ b/src/ballet/chacha20/fd_chacha20rng.c
@@ -64,7 +64,7 @@ fd_chacha20rng_init( fd_chacha20rng_t * rng,
   memcpy( rng->key, key, FD_CHACHA20_KEY_SZ );
   rng->buf_off  = 0UL;
   rng->buf_fill = 0UL;
-  rng->idx      = 0U ;
+  memset( rng->idx_nonce, 0, 16UL );
   fd_chacha20rng_private_refill( rng );
   return rng;
 }
@@ -72,15 +72,14 @@ fd_chacha20rng_init( fd_chacha20rng_t * rng,
 void
 fd_chacha20rng_private_refill( fd_chacha20rng_t * rng ) {
   ulong fill_target = FD_CHACHA20RNG_BUFSZ - FD_CHACHA20_BLOCK_SZ;
-  uint nonce[ 3 ]={0};
 
   ulong buf_avail;
   while( (buf_avail=(rng->buf_fill - rng->buf_off))<fill_target ) {
     fd_chacha20_block( rng->buf + (rng->buf_fill % FD_CHACHA20RNG_BUFSZ),
                        rng->key,
-                       rng->idx++,
-                       &nonce );
+                       rng->idx_nonce );
     rng->buf_fill += (uint)FD_CHACHA20_BLOCK_SZ;
+    rng->idx_nonce[0]++;
   }
 }
 

--- a/src/ballet/chacha20/fd_chacha20rng.h
+++ b/src/ballet/chacha20/fd_chacha20rng.h
@@ -41,7 +41,7 @@ struct __attribute__((aligned(32UL))) fd_chacha20rng_private {
   int mode;
 
   /* ChaCha20 block index */
-  uint idx;
+  uint idx_nonce[ 4UL ] __attribute__((aligned(16UL)));
 };
 typedef struct fd_chacha20rng_private fd_chacha20rng_t;
 
@@ -178,7 +178,7 @@ fd_chacha20rng_ulong_roll( fd_chacha20rng_t * rng,
                      = 2^64-1 - (2^64-n)%n, since n<2^64
                      = 2^64-1 - ((2^64-1)-n+1)%n
      Which is back to having a mod... But at least if n is a
-     compile-time constant than the whole zone computation becomes a
+     compile-time constant then the whole zone computation becomes a
      compile-time constant.
 
      When MODE_SHIFT is set, we use uses almost the largest possible


### PR DESCRIPTION
- Rename fd_chacha20_avx to fd_chacha20_sse
- Fix 4 byte OOB access when loading nonce field
- Merge block index and nonce into a 16 byte region
- Tune alignment and use aligned memory accesses
