### PR TITLE
wksp: clean up FD_WKSP_NO_LOCK_RECLAIM

### DIFF
--- a/config/base.mk
+++ b/config/base.mk
@@ -1,7 +1,7 @@
 BASEDIR?=build
 
 SHELL:=bash
-CPPFLAGS:=-isystem ./opt/include -DFD_LOG_UNCLEAN_EXIT=1 -DFD_WKSP_NO_LOCK_RECLAIM=1 -DFD_HAS_BACKTRACE=0 -DPB_SYSTEM_HEADER="\"pb_firedancer.h\""
+CPPFLAGS:=-isystem ./opt/include -DFD_LOG_UNCLEAN_EXIT=1 -DFD_HAS_BACKTRACE=0 -DPB_SYSTEM_HEADER="\"pb_firedancer.h\""
 CC:=gcc
 CFLAGS:=-std=c17
 CXX:=g++

--- a/src/util/wksp/fd_wksp_admin.c
+++ b/src/util/wksp/fd_wksp_admin.c
@@ -2,7 +2,7 @@
 
 int
 fd_wksp_private_lock( fd_wksp_t * wksp ) {
-# if !FD_WKSP_NO_LOCK_RECLAIM
+# if FD_WKSP_LOCK_RECLAIM
   int   warning = 0;
 #endif
   ulong me      = fd_log_group_id();
@@ -26,13 +26,7 @@ fd_wksp_private_lock( fd_wksp_t * wksp ) {
 
     if( FD_LIKELY( pid==ULONG_MAX ) ) return FD_WKSP_SUCCESS;
 
-    /* We support a FD_WKSP_NO_LOCK_RECLAIM mode which prevents us from
-       trying to recover the lock from dead processes.  This is useful,
-       for example, if we know that the lock will not get acquired by
-       another process, or that if another acquiring process dies that
-       all potential users will get exited.  It prevents a syscall on
-       various common workspace paths (eg, alloc). */
-# if !FD_WKSP_NO_LOCK_RECLAIM
+# if FD_WKSP_LOCK_RECLAIM
     int status = fd_log_group_id_query( pid );
     if( FD_UNLIKELY( status==FD_LOG_GROUP_ID_QUERY_DEAD ) ) { /* A process died while holding the lock, try to recover the lock */
 
@@ -89,7 +83,7 @@ fd_wksp_private_lock( fd_wksp_t * wksp ) {
     FD_YIELD();
 # else
 
-    /* If we are running with FD_WKSP_NO_LOCK_RECLAIM then it is assumed
+    /* If we are running without FD_WKSP_LOCK_RECLAIM then it is assumed
        that the contention is caused by a tile pinned to another core,
        and that this core is itself pinned so spin locking is best. */
     FD_SPIN_PAUSE();

--- a/src/util/wksp/fd_wksp_private.h
+++ b/src/util/wksp/fd_wksp_private.h
@@ -3,6 +3,16 @@
 
 #include "fd_wksp.h"
 
+/* If FD_WKSP_LOCK_RECLAIM==0, do not try to recover the lock from
+   dead processes.  This is useful, for example, if we know that the
+   lock will not get acquired by another process, or that if another
+   acquiring process dies that all potential users will get exited.  It
+   prevents a syscall on various common workspace paths (eg, alloc). */
+
+#ifndef FD_WKSP_LOCK_RECLAIM
+#define FD_WKSP_LOCK_RECLAIM 0
+#endif
+
 /* FD_WKSP_PRIVATE_PINFO_IDX_NULL is the pinfo index value used to
    indicate NULL */
 


### PR DESCRIPTION
fd_wksp_admin.c assumes that FD_WKSP_NO_LOCK_RECLAIM is always
defined via compile flags.  The current Make config defines this
macro then project-wide.  This commit cleans up the integration
by adding a sane default if the flag is not defined.
