### PR TITLE
Temporarily disable functional-tests

### DIFF
--- a/contrib/test/run_integration_tests.sh
+++ b/contrib/test/run_integration_tests.sh
@@ -8,6 +8,10 @@ export LLVM_PROFILE_FILE
 set -xeuo pipefail
 
 cd "$(dirname "$0")/../.."
-src/app/fddev/tests/test_single_transfer.sh
-# This test appears to be broken
+
+# TODO add fddev integration tests here
+
+# Broken because genesis creation is unreliable
+#src/app/fddev/tests/test_single_transfer.sh
+# Broken because 'fddev txn' is unreliable
 #src/app/fddev/tests/test_single_txn.sh


### PR DESCRIPTION
Functional tests have been showing false positives for over a month.
Let's disable them until they are fixed.
