### PR TITLE
ci: only run trailing whitespace check on PRs

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -14,6 +14,3 @@ jobs:
   tests-fddev:
     uses: ./.github/workflows/tests_fddev.yml
     secrets: inherit
-
-  whitespace-check:
-    uses: ./.github/workflows/trailing_whitespace.yml

--- a/.github/workflows/trailing_whitespace.yml
+++ b/.github/workflows/trailing_whitespace.yml
@@ -1,6 +1,6 @@
 name: Trailing Whitespace
 on:
-  workflow_call:
+  pull_request:
 jobs:
   check:
     name: trailing-whitespace


### PR DESCRIPTION
This check produces different results on main vs on PRs.