### PR TITLE
snapshot: fix destructor ordering

### DIFF
--- a/src/ballet/zstd/fd_zstd.h
+++ b/src/ballet/zstd/fd_zstd.h
@@ -90,10 +90,10 @@ fd_zstd_peek( fd_zstd_peek_t * peek,
    memory region backing a fd_zstd_dstream_t.  max_window_sz is the
    largest window size that this object is able to handle. */
 
-ulong
+FD_FN_CONST ulong
 fd_zstd_dstream_align( void );
 
-ulong
+FD_FN_CONST ulong
 fd_zstd_dstream_footprint( ulong max_window_sz );
 
 /* fd_zstd_dstream_new creates a new dstream object backed by the memory


### PR DESCRIPTION
- Fixes a bug where AccountVec fields are deleted before read
  (not a UAF, but a logic bug)
- Improves error message if AppendVecs appear before snapshot
  manifest
