### PR TITLE
ci: upgrade actions/cache to v4

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -32,7 +32,7 @@ runs:
       run: sha256sum '${{ inputs.deps-script-path }}' | awk '{print "HASH=" $1}' >> "$GITHUB_OUTPUT"
 
     - id: deps-sh-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: deps-bundle.tar.zst
         key: ${{ runner.os }}-deps-sh-${{ steps.deps-sh-hash.outputs.HASH }}


### PR DESCRIPTION
actions/cache@v3 is deprecated to due to old Node.js version.
