### PR TITLE
Revert "ci: enable merge queue"

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -1,7 +1,8 @@
 name: On Pull Request
 on:
+  push:
+    branches: [main]
   pull_request:
-  merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Reverts firedancer-io/firedancer#1164

There appears to be an issue with merge queue where checks are not being run.
Might be due to a race condition with `workflow_call`.