### PR TITLE
tls: use upstream OpenSSL

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -105,7 +105,7 @@ fetch () {
   #checkout_repo zlib      https://github.com/madler/zlib            "v1.2.13"
   #checkout_repo bzip2     https://sourceware.org/git/bzip2.git      "bzip2-1.0.8"
   checkout_repo zstd      https://github.com/facebook/zstd          "v1.5.5"
-  checkout_repo openssl   https://github.com/quictls/openssl        "openssl-3.1.2-quic1"
+  checkout_repo openssl   https://github.com/openssl/openssl        "openssl-3.2.1"
   #checkout_repo rocksdb   https://github.com/facebook/rocksdb       "v7.10.2"
   #checkout_repo secp256k1 https://github.com/bitcoin-core/secp256k1 "v0.3.2"
   #checkout_repo libff     https://github.com/firedancer-io/libff.git "develop"
@@ -319,7 +319,6 @@ install_openssl () {
     -fPIC \
     --prefix="$PREFIX" \
     --libdir=lib \
-    enable-quic \
     no-engine \
     no-static-engine \
     no-weak-ssl-ciphers \
@@ -338,6 +337,7 @@ install_openssl () {
     no-sctp \
     no-ssl3 \
     no-aria \
+    no-argon2 \
     no-bf \
     no-blake2 \
     no-camellia \

--- a/src/tango/tls/Local.mk
+++ b/src/tango/tls/Local.mk
@@ -5,7 +5,10 @@ $(call make-unit-test,test_tls,test_tls,fd_tls fd_ballet fd_util)
 $(call run-unit-test,test_tls)
 $(call make-fuzz-test,fuzz_tls,fuzz_tls,fd_tls fd_ballet fd_util)
 $(call make-fuzz-test,fuzz_tls_msg_parser,fuzz_tls_msg_parser,fd_tls fd_ballet fd_util)
-ifdef FD_HAS_OPENSSL
-$(call make-unit-test,test_tls_openssl,test_tls_openssl,fd_quic fd_tls fd_ballet fd_util)
-$(call run-unit-test,test_tls_openssl)
-endif
+
+# Uncomment this to test against quictls.  Upstream OpenSSL does not
+# support this test.
+#ifdef FD_HAS_OPENSSL
+#$(call make-unit-test,test_tls_openssl,test_tls_openssl,fd_quic fd_tls fd_ballet fd_util)
+#$(call run-unit-test,test_tls_openssl)
+#endif


### PR DESCRIPTION
We no longer depend on the QUIC-specific functionality of OpenSSL thanks to fd_tls.

We can therefore switch to upstream OpenSSL. This allows us to bring OpenSSL bug fixes to Firedancer faster. 