### PR TITLE
Misc changes to fix Clang AVX512 compilation

### DIFF
--- a/config/machine/linux_clang_icelake.mk
+++ b/config/machine/linux_clang_icelake.mk
@@ -21,7 +21,7 @@ include config/extra/with-zstd.mk
 
 CPPFLAGS+=-fomit-frame-pointer -march=icelake-server -mtune=icelake-server -mfpmath=sse \
 	  -DFD_HAS_INT128=1 -DFD_HAS_DOUBLE=1 -DFD_HAS_ALLOCA=1 -DFD_HAS_X86=1 -DFD_HAS_SSE=1 -DFD_HAS_AVX=1 \
-		-DFD_HAS_SHANI=1 -DFD_HAS_GFNI=1 -DFD_HAS_AESNI=1 -DFD_HAS_AESNI=1
+		-DFD_HAS_SHANI=1 -DFD_HAS_GFNI=1 -DFD_HAS_AESNI=1 -DFD_HAS_AESNI=1 -DFD_HAS_AVX512=1
 
 FD_HAS_INT128:=1
 FD_HAS_DOUBLE:=1
@@ -32,3 +32,4 @@ FD_HAS_AVX:=1
 FD_HAS_SHANI:=1
 FD_HAS_GFNI:=1
 FD_HAS_AESNI:=1
+FD_HAS_AVX512:=1

--- a/config/machine/linux_gcc_icelake.mk
+++ b/config/machine/linux_gcc_icelake.mk
@@ -12,9 +12,18 @@ include config/extra/with-ucontext.mk
 include config/extra/with-openssl.mk
 include config/extra/with-zstd.mk
 
+
 CPPFLAGS+=-march=icelake-server -mtune=icelake-server \
 	  -DFD_HAS_INT128=1 -DFD_HAS_DOUBLE=1 -DFD_HAS_ALLOCA=1 -DFD_HAS_X86=1 -DFD_HAS_SSE=1 -DFD_HAS_AVX=1 \
 		-DFD_HAS_SHANI=1 -DFD_HAS_GFNI=1 -DFD_HAS_AESNI=1
+
+FD_COMPILER_MAJOR_VERSION:=$(shell echo | $(CC) -march=native -E -dM - | grep __GNUC__ | awk '{print $$3}')
+ifeq ($(shell test $(FD_COMPILER_MAJOR_VERSION) -lt 10 && echo 1),1)
+	FD_HAS_AVX512:=
+else
+	CPPFLAGS+=-DFD_HAS_AVX512=1
+	FD_HAS_AVX512:=1
+endif
 
 FD_HAS_INT128:=1
 FD_HAS_DOUBLE:=1

--- a/src/app/fdctl/run/tiles/fd_poh.c
+++ b/src/app/fdctl/run/tiles/fd_poh.c
@@ -1097,15 +1097,9 @@ after_frag( void *             _ctx,
   }
 
   ulong txn_cnt = (*opt_sz-sizeof(fd_microblock_trailer_t))/sizeof(fd_txn_p_t);
+  fd_txn_p_t * txns = (fd_txn_p_t *)(ctx->_txns);
   ulong sanitized_txn_cnt = 0UL;
-  ulong executed_txn_cnt = 0UL;
-  for( ulong i=0; i<txn_cnt; i++ ) {
-    fd_txn_p_t * txn = (fd_txn_p_t *)(ctx->_txns + i*sizeof(fd_txn_p_t));
-    if( FD_UNLIKELY( !(txn->flags & FD_TXN_P_FLAGS_SANITIZE_SUCCESS) ) ) continue;
-    sanitized_txn_cnt++;
-    if( FD_UNLIKELY( !(txn->flags & FD_TXN_P_FLAGS_EXECUTE_SUCCESS) ) ) continue;
-    executed_txn_cnt++;
-  }
+  for( ulong i=0; i<txn_cnt; i++ ) { sanitized_txn_cnt += !!(txns[ i ].flags & FD_TXN_P_FLAGS_SANITIZE_SUCCESS); }
 
   uchar data[ 64 ];
   fd_memcpy( data, ctx->hash, 32UL );

--- a/src/ballet/ed25519/avx512/fd_r43x6_ge.c
+++ b/src/ballet/ed25519/avx512/fd_r43x6_ge.c
@@ -303,7 +303,7 @@ fd_r43x6_ge_smul_base_ref( wwl_t * _R03, wwl_t * _R14, wwl_t * _R25,
   FD_R43X6_QUAD_MOV( *_R, R );                    /* return R,          in u44|u44|u44|u44 */
 }
 
-FD_IMPORT( fd_r43x6_ge_smul_base_large_table, "src/ballet/ed25519/table/fd_r43x6_ge_smul_base_large_table", wwl_t, 128, "" );
+FD_IMPORT( fd_r43x6_ge_smul_base_large_table, "src/ballet/ed25519/table/fd_r43x6_ge_smul_base_large_table", wwl_t, 7, "" );
 /* 384 KiB */
 
 void
@@ -506,7 +506,7 @@ fd_r43x6_ge_smul_base_large( wwl_t * _R03, wwl_t * _R14, wwl_t * _R25,
   FD_R43X6_QUAD_MOV( *_R, R );                                        /* return R, in u44|u44|u44|u44 */
 }
 
-FD_IMPORT( fd_r43x6_ge_smul_base_small_table, "src/ballet/ed25519/table/fd_r43x6_ge_smul_base_small_table", wwl_t, 128, "" );
+FD_IMPORT( fd_r43x6_ge_smul_base_small_table, "src/ballet/ed25519/table/fd_r43x6_ge_smul_base_small_table", wwl_t, 7, "" );
 /* 48 KiB */
 
 void
@@ -850,7 +850,7 @@ fd_r43x6_ge_dmul_ref( wwl_t * _R03, wwl_t * _R14, wwl_t * _R25,
   FD_R43X6_QUAD_MOV( *_R, R );                                 /* return R,                  in u44|u44|u44|u44 */
 }
 
-FD_IMPORT( fd_r43x6_ge_dmul_sparse_table, "src/ballet/ed25519/table/fd_r43x6_ge_dmul_sparse_table", wwl_t, 128, "" ); /* 384 KiB */
+FD_IMPORT( fd_r43x6_ge_dmul_sparse_table, "src/ballet/ed25519/table/fd_r43x6_ge_dmul_sparse_table", wwl_t, 7, "" ); /* 384 KiB */
 
 void
 fd_r43x6_ge_dmul_sparse( wwl_t * _R03, wwl_t * _R14, wwl_t * _R25,

--- a/src/util/simd/fd_avx512_wwi.h
+++ b/src/util/simd/fd_avx512_wwi.h
@@ -82,22 +82,22 @@ static inline void  wwi_stu( void * m, wwi_t x ) { _mm512_storeu_epi32( m, x ); 
 #define wwi_or(x,y)          _mm512_or_epi32    ( (x), (y) )       /* wwi( x0|y0,  x1|y1,  ... xf|yf  ) */
 #define wwi_xor(x,y)         _mm512_xor_epi32   ( (x), (y) )       /* wwi( x0^y0,  x1^y1,  ... xf^yf  ) */
 
-/* wwi_rol(x,n)        returns wwi( rotate_left (x0,n ), rotate_left (x1,n ), ... )
-   wwi_ror(x,n)        returns wwi( rotate_right(x0,n ), rotate_right(x1,n ), ... )
-   wwi_rol_vector(x,y) returns wwi( rotate_left (x0,y0), rotate_left (x1,y1), ... )
-   wwi_ror_vector(x,y) returns wwi( rotate_right(x0,y0), rotate_right(x1,y1), ... ) */
+/* wwi_rol(x,n)          returns wwi( rotate_left (x0,n ), rotate_left (x1,n ), ... )
+   wwi_ror(x,n)          returns wwi( rotate_right(x0,n ), rotate_right(x1,n ), ... )
+   wwi_rol_variable(x,n) returns wwi( rotate_left (x0,n ), rotate_left (x1,n ), ... )
+   wwi_ror_variable(x,n) returns wwi( rotate_right(x0,n ), rotate_right(x1,n ), ... )
+   wwi_rol_vector(x,y)   returns wwi( rotate_left (x0,y0), rotate_left (x1,y1), ... )
+   wwi_ror_vector(x,y)   returns wwi( rotate_right(x0,y0), rotate_right(x1,y1), ... )
 
-static inline wwi_t wwi_rol( wwi_t a, int n ) {
-  return __builtin_constant_p(n) ?
-         _mm512_rol_epi32( (a), (n)&31 ) :
-         wwi_or( wwi_shl ( a, n & 31 ), wwi_shru( a, (-n) & 31 ) );
-}
+   The variable variants are slower but do not require the shift amount
+   to be known at compile time. */
 
-static inline wwi_t wwi_ror( wwi_t a, int n ) {
-  return __builtin_constant_p(n) ?
-         _mm512_ror_epi32( (a), (n)&31 ) :
-         wwi_or( wwi_shru( a, n & 31 ), wwi_shl ( a, (-n) & 31 ) );
-}
+#define wwi_rol(a,imm)       _mm512_rol_epi32( (a), (imm)&31 )
+#define wwi_ror(a,imm)       _mm512_ror_epi32( (a), (imm)&31 )
+
+static inline wwi_t wwi_rol_variable( wwi_t a, int n ) { return wwi_or( wwi_shl ( a, n & 31 ), wwi_shru( a, (-n) & 31 ) ); }
+static inline wwi_t wwi_ror_variable( wwi_t a, int n ) { return wwi_or( wwi_shru( a, n & 31 ), wwi_shl ( a, (-n) & 31 ) ); }
+
 
 static inline wwi_t wwi_rol_vector( wwi_t a, wwi_t b ) {
   wwi_t m = wwi_bcast( 31 );

--- a/src/util/simd/fd_avx512_wwl.h
+++ b/src/util/simd/fd_avx512_wwl.h
@@ -81,22 +81,21 @@ static inline void  wwl_stu( void * m, wwl_t x ) { _mm512_storeu_epi64( m, x ); 
 #define wwl_or(x,y)          _mm512_or_epi64    ( (x), (y)       ) /* wwl( x0|y0,  x1|y1,  ... x7|y7  ) */
 #define wwl_xor(x,y)         _mm512_xor_epi64   ( (x), (y)       ) /* wwl( x0^y0,  x1^y1,  ... x7^y7  ) */
 
-/* wwl_rol(x,n)        returns wwl( rotate_left (x0,n ), rotate_left (x1,n ), ... )
-   wwl_ror(x,n)        returns wwl( rotate_right(x0,n ), rotate_right(x1,n ), ... )
-   wwl_rol_vector(x,y) returns wwl( rotate_left (x0,y0), rotate_left (x1,y1), ... )
-   wwl_ror_vector(x,y) returns wwl( rotate_right(x0,y0), rotate_right(x1,y1), ... ) */
+/* wwl_rol(x,n)          returns wwl( rotate_left (x0,n ), rotate_left (x1,n ), ... )
+   wwl_ror(x,n)          returns wwl( rotate_right(x0,n ), rotate_right(x1,n ), ... )
+   wwl_rol_variable(x,n) returns wwl( rotate_left (x0,n ), rotate_left (x1,n ), ... )
+   wwl_ror_variable(x,n) returns wwl( rotate_right(x0,n ), rotate_right(x1,n ), ... )
+   wwl_rol_vector(x,y)   returns wwl( rotate_left (x0,y0), rotate_left (x1,y1), ... )
+   wwl_ror_vector(x,y)   returns wwl( rotate_right(x0,y0), rotate_right(x1,y1), ... )
 
-static inline wwl_t wwl_rol( wwl_t a, long n ) {
-  return __builtin_constant_p(n) ?
-         _mm512_rol_epi64( (a), (n)&63 ) :
-         wwl_or( wwl_shl ( a, n & 63L ), wwl_shru( a, (-n) & 63L ) );
-}
+   The variable variants are slower but do not require the shift amount
+   to be known at compile time. */
 
-static inline wwl_t wwl_ror( wwl_t a, long n ) {
-  return __builtin_constant_p(n) ?
-         _mm512_ror_epi64( (a), (n)&63 ) :
-         wwl_or( wwl_shru( a, n & 63L ), wwl_shl ( a, (-n) & 63L ) );
-}
+#define wwl_rol(a,imm)       _mm512_rol_epi64( (a), (imm)&63L )
+#define wwl_ror(a,imm)       _mm512_ror_epi64( (a), (imm)&63L )
+
+static inline wwl_t wwl_rol_variable( wwl_t a, long n ) { return wwl_or( wwl_shl ( a, n & 63L ), wwl_shru( a, (-n) & 63L ) ); }
+static inline wwl_t wwl_ror_variable( wwl_t a, long n ) { return wwl_or( wwl_shru( a, n & 63L ), wwl_shl ( a, (-n) & 63L ) ); }
 
 static inline wwl_t wwl_rol_vector( wwl_t a, wwl_t b ) {
   wwl_t m = wwl_bcast( 63L );

--- a/src/util/simd/fd_avx512_wwu.h
+++ b/src/util/simd/fd_avx512_wwu.h
@@ -83,22 +83,21 @@ static inline void  wwu_stu( void * m, wwu_t x ) { _mm512_storeu_epi32( m, x ); 
 #define wwu_or(x,y)          _mm512_or_epi32    ( (x), (y)       ) /* wwu( x0|y0,  x1|y1,  ... xf|yf  ) */
 #define wwu_xor(x,y)         _mm512_xor_epi32   ( (x), (y)       ) /* wwu( x0^y0,  x1^y1,  ... xf^yf  ) */
 
-/* wwu_rol(x,n)        returns wwu( rotate_left (x0,n ), rotate_left (x1,n ), ... )
-   wwu_ror(x,n)        returns wwu( rotate_right(x0,n ), rotate_right(x1,n ), ... )
-   wwu_rol_vector(x,y) returns wwu( rotate_left (x0,y0), rotate_left (x1,y1), ... )
-   wwu_ror_vector(x,y) returns wwu( rotate_right(x0,y0), rotate_right(x1,y1), ... ) */
+/* wwu_rol(x,n)          returns wwu( rotate_left (x0,n ), rotate_left (x1,n ), ... )
+   wwu_ror(x,n)          returns wwu( rotate_right(x0,n ), rotate_right(x1,n ), ... )
+   wwu_rol_variable(x,n) returns wwu( rotate_left (x0,n ), rotate_left (x1,n ), ... )
+   wwu_ror_variable(x,n) returns wwu( rotate_right(x0,n ), rotate_right(x1,n ), ... )
+   wwu_rol_vector(x,y)   returns wwu( rotate_left (x0,y0), rotate_left (x1,y1), ... )
+   wwu_ror_vector(x,y)   returns wwu( rotate_right(x0,y0), rotate_right(x1,y1), ... )
 
-static inline wwu_t wwu_rol( wwu_t a, uint n ) {
-  return __builtin_constant_p(n) ?
-         _mm512_rol_epi32( (a), (n)&31U ) :
-         wwu_or( wwu_shl( a, n & 31U ), wwu_shr( a, (-n) & 31U ) );
-}
+   The variable variants are slower but do not require the shift amount
+   to be known at compile time. */
 
-static inline wwu_t wwu_ror( wwu_t a, uint n ) {
-  return __builtin_constant_p(n) ?
-         _mm512_ror_epi32( (a), (n)&31U ) :
-         wwu_or( wwu_shr( a, n & 31U ), wwu_shl( a, (-n) & 31U ) );
-}
+#define wwu_rol(a,imm)       _mm512_rol_epi32( (a), (imm)&31U )
+#define wwu_ror(a,imm)       _mm512_ror_epi32( (a), (imm)&31U )
+
+static inline wwu_t wwu_rol_variable( wwu_t a, uint n ) { return wwu_or( wwu_shl( a, n & 31U ), wwu_shr( a, (-n) & 31U ) ); }
+static inline wwu_t wwu_ror_variable( wwu_t a, uint n ) { return wwu_or( wwu_shr( a, n & 31U ), wwu_shl( a, (-n) & 31U ) ); }
 
 static inline wwu_t wwu_rol_vector( wwu_t a, wwu_t b ) {
   wwu_t m = wwu_bcast( 31U );

--- a/src/util/simd/fd_avx512_wwv.h
+++ b/src/util/simd/fd_avx512_wwv.h
@@ -82,22 +82,21 @@ static inline void  wwv_stu( void * m, wwv_t x ) { _mm512_storeu_epi64( m, x ); 
 #define wwv_or(x,y)          _mm512_or_epi64    ( (x), (y)       ) /* wwv( x0|y0,  x1|y1,  ... x7|y7  ) */
 #define wwv_xor(x,y)         _mm512_xor_epi64   ( (x), (y)       ) /* wwv( x0^y0,  x1^y1,  ... x7^y7  ) */
 
-/* wwv_rol(x,n)        returns wwv( rotate_left (x0,n ), rotate_left (x1,n ), ... )
-   wwv_ror(x,n)        returns wwv( rotate_right(x0,n ), rotate_right(x1,n ), ... )
-   wwv_rol_vector(x,y) returns wwv( rotate_left (x0,y0), rotate_left (x1,y1), ... )
-   wwv_ror_vector(x,y) returns wwv( rotate_right(x0,y0), rotate_right(x1,y1), ... ) */
+/* wwv_rol(x,n)          returns wwv( rotate_left (x0,n ), rotate_left (x1,n ), ... )
+   wwv_ror(x,n)          returns wwv( rotate_right(x0,n ), rotate_right(x1,n ), ... )
+   wwv_rol_variable(x,n) returns wwv( rotate_left (x0,n ), rotate_left (x1,n ), ... )
+   wwv_ror_variable(x,n) returns wwv( rotate_right(x0,n ), rotate_right(x1,n ), ... )
+   wwv_rol_vector(x,y)   returns wwv( rotate_left (x0,y0), rotate_left (x1,y1), ... )
+   wwv_ror_vector(x,y)   returns wwv( rotate_right(x0,y0), rotate_right(x1,y1), ... )
 
-static inline wwv_t wwv_rol( wwv_t a, ulong n ) {
-  return __builtin_constant_p(n) ?
-         _mm512_rol_epi64( (a), (n)&63 ) :
-         wwv_or( wwv_shl( a, n & 63UL ), wwv_shr( a, (-n) & 63UL ) );
-}
+   The variable variants are slower but do not require the shift amount
+   to be known at compile time. */
 
-static inline wwv_t wwv_ror( wwv_t a, ulong n ) {
-  return __builtin_constant_p(n) ?
-         _mm512_ror_epi64( (a), (n)&63 ) :
-         wwv_or( wwv_shr( a, n & 63UL ), wwv_shl( a, (-n) & 63UL ) );
-}
+#define wwv_rol(a,imm)  _mm512_rol_epi64( (a), (imm)&63 )
+#define wwv_ror(a,imm)  _mm512_ror_epi64( (a), (imm)&63 )
+
+static inline wwv_t wwv_rol_variable( wwv_t a, ulong n ) { return wwv_or( wwv_shl( a, n & 63UL ), wwv_shr( a, (-n) & 63UL ) ); }
+static inline wwv_t wwv_ror_variable( wwv_t a, ulong n ) { return wwv_or( wwv_shr( a, n & 63UL ), wwv_shl( a, (-n) & 63UL ) ); }
 
 static inline wwv_t wwv_rol_vector( wwv_t a, wwv_t b ) {
   wwv_t m = wwv_bcast( 63UL );

--- a/src/util/simd/test_avx512.h
+++ b/src/util/simd/test_avx512.h
@@ -86,4 +86,29 @@ FD_STATIC_ASSERT( WW_LG_ALIGN    == 6, unit_test );
                      _u[0], _u[1], _u[2], _u[3], _u[4], _u[5], _u[6], _u[7] ));                                          \
   } while(0)
 
+
+/* Some utility macros for testing functions that need compile time
+   values.
+   EXPAND_n( F, j ) expands F n times with j, j+1, ..., j+n-1 as the
+   argument (not a literal, but a compile time constant).
+
+   COMPARE_n( C, p, fn1, fn2, j ) uses comparator function C to test the
+   result of fn1(p, j) against fn2(p0, j), fn2(p1, j), ... fn3(p{n-1},
+   j), where the counters for p, the prefix, are in hex.  C must take
+   n+1 arguments. */
+
+#define EXPAND_4( F, j) F(j)              F((j)+1)             F((j)+2)             F((j)+3)
+#define EXPAND_16(F, j) EXPAND_4( F, (j)) EXPAND_4( F, (j)+ 4) EXPAND_4( F, (j)+ 8) EXPAND_4( F, (j)+12)
+#define EXPAND_32(F, j) EXPAND_16(F, (j))                      EXPAND_16(F, (j)+16)
+#define EXPAND_64(F, j) EXPAND_32(F, (j))                      EXPAND_32(F, (j)+32)
+
+#define COMPARE8( C, p, fn1, fn2, j)  C( fn1(p, j), fn2( p##0, j ), fn2( p##1, j ), fn2( p##2, j ), fn2( p##3, j ), \
+                                                    fn2( p##4, j ), fn2( p##5, j ), fn2( p##6, j ), fn2( p##7, j ) )
+
+#define COMPARE16(C, p, fn1, fn2, j)  C( fn1(p, j), fn2( p##0, j ), fn2( p##1, j ), fn2( p##2, j ), fn2( p##3, j ), \
+                                                    fn2( p##4, j ), fn2( p##5, j ), fn2( p##6, j ), fn2( p##7, j ), \
+                                                    fn2( p##8, j ), fn2( p##9, j ), fn2( p##a, j ), fn2( p##b, j ), \
+                                                    fn2( p##c, j ), fn2( p##d, j ), fn2( p##e, j ), fn2( p##f, j ) )
+
+
 #endif /* HEADER_fd_src_util_simd_test_avx512_h */

--- a/src/util/simd/test_avx512_16x32.c
+++ b/src/util/simd/test_avx512_16x32.c
@@ -146,22 +146,28 @@ main( int     argc,
 
 #   define ROL(x,y) fd_int_rotate_left ( (x), (y) )
 #   define ROR(x,y) fd_int_rotate_right( (x), (y) )
-    WWI_TEST( wwi_rol( x, y0 ),       ROL( x0, y0 ), ROL( x1, y0 ), ROL( x2, y0 ), ROL( x3, y0 ),
-                                      ROL( x4, y0 ), ROL( x5, y0 ), ROL( x6, y0 ), ROL( x7, y0 ),
-                                      ROL( x8, y0 ), ROL( x9, y0 ), ROL( xa, y0 ), ROL( xb, y0 ),
-                                      ROL( xc, y0 ), ROL( xd, y0 ), ROL( xe, y0 ), ROL( xf, y0 ) );
-    WWI_TEST( wwi_ror( x, y0 ),       ROR( x0, y0 ), ROR( x1, y0 ), ROR( x2, y0 ), ROR( x3, y0 ),
-                                      ROR( x4, y0 ), ROR( x5, y0 ), ROR( x6, y0 ), ROR( x7, y0 ),
-                                      ROR( x8, y0 ), ROR( x9, y0 ), ROR( xa, y0 ), ROR( xb, y0 ),
-                                      ROR( xc, y0 ), ROR( xd, y0 ), ROR( xe, y0 ), ROR( xf, y0 ) );
-    WWI_TEST( wwi_rol_vector( x, y ), ROL( x0, y0 ), ROL( x1, y1 ), ROL( x2, y2 ), ROL( x3, y3 ),
-                                      ROL( x4, y4 ), ROL( x5, y5 ), ROL( x6, y6 ), ROL( x7, y7 ),
-                                      ROL( x8, y8 ), ROL( x9, y9 ), ROL( xa, ya ), ROL( xb, yb ),
-                                      ROL( xc, yc ), ROL( xd, yd ), ROL( xe, ye ), ROL( xf, yf ) );
-    WWI_TEST( wwi_ror_vector( x, y ), ROR( x0, y0 ), ROR( x1, y1 ), ROR( x2, y2 ), ROR( x3, y3 ),
-                                      ROR( x4, y4 ), ROR( x5, y5 ), ROR( x6, y6 ), ROR( x7, y7 ),
-                                      ROR( x8, y8 ), ROR( x9, y9 ), ROR( xa, ya ), ROR( xb, yb ),
-                                      ROR( xc, yc ), ROR( xd, yd ), ROR( xe, ye ), ROR( xf, yf ) );
+    WWI_TEST( wwi_rol_variable( x, y0 ), ROL( x0, y0 ), ROL( x1, y0 ), ROL( x2, y0 ), ROL( x3, y0 ),
+                                         ROL( x4, y0 ), ROL( x5, y0 ), ROL( x6, y0 ), ROL( x7, y0 ),
+                                         ROL( x8, y0 ), ROL( x9, y0 ), ROL( xa, y0 ), ROL( xb, y0 ),
+                                         ROL( xc, y0 ), ROL( xd, y0 ), ROL( xe, y0 ), ROL( xf, y0 ) );
+    WWI_TEST( wwi_ror_variable( x, y0 ), ROR( x0, y0 ), ROR( x1, y0 ), ROR( x2, y0 ), ROR( x3, y0 ),
+                                         ROR( x4, y0 ), ROR( x5, y0 ), ROR( x6, y0 ), ROR( x7, y0 ),
+                                         ROR( x8, y0 ), ROR( x9, y0 ), ROR( xa, y0 ), ROR( xb, y0 ),
+                                         ROR( xc, y0 ), ROR( xd, y0 ), ROR( xe, y0 ), ROR( xf, y0 ) );
+    WWI_TEST( wwi_rol_vector( x, y ),    ROL( x0, y0 ), ROL( x1, y1 ), ROL( x2, y2 ), ROL( x3, y3 ),
+                                         ROL( x4, y4 ), ROL( x5, y5 ), ROL( x6, y6 ), ROL( x7, y7 ),
+                                         ROL( x8, y8 ), ROL( x9, y9 ), ROL( xa, ya ), ROL( xb, yb ),
+                                         ROL( xc, yc ), ROL( xd, yd ), ROL( xe, ye ), ROL( xf, yf ) );
+    WWI_TEST( wwi_ror_vector( x, y ),    ROR( x0, y0 ), ROR( x1, y1 ), ROR( x2, y2 ), ROR( x3, y3 ),
+                                         ROR( x4, y4 ), ROR( x5, y5 ), ROR( x6, y6 ), ROR( x7, y7 ),
+                                         ROR( x8, y8 ), ROR( x9, y9 ), ROR( xa, ya ), ROR( xb, yb ),
+                                         ROR( xc, yc ), ROR( xd, yd ), ROR( xe, ye ), ROR( xf, yf ) );
+#   define COMPARE_WWI_ROL( j ) COMPARE16( WWI_TEST, x, wwi_rol, ROL, j );
+#   define COMPARE_WWI_ROR( j ) COMPARE16( WWI_TEST, x, wwi_ror, ROR, j );
+    EXPAND_32(COMPARE_WWI_ROL, 0)
+    EXPAND_32(COMPARE_WWI_ROR, 0)
+#   undef COMPARE_WWI_ROR
+#   undef COMPARE_WWI_ROL
 #   undef ROR
 #   undef ROL
 
@@ -397,22 +403,28 @@ main( int     argc,
 
 #   define ROL(x,y) fd_uint_rotate_left ( (x), (int)(uint)(y) )
 #   define ROR(x,y) fd_uint_rotate_right( (x), (int)(uint)(y) )
-    WWU_TEST( wwu_rol( x, y0 ),       ROL( x0, y0 ), ROL( x1, y0 ), ROL( x2, y0 ), ROL( x3, y0 ),
-                                      ROL( x4, y0 ), ROL( x5, y0 ), ROL( x6, y0 ), ROL( x7, y0 ),
-                                      ROL( x8, y0 ), ROL( x9, y0 ), ROL( xa, y0 ), ROL( xb, y0 ),
-                                      ROL( xc, y0 ), ROL( xd, y0 ), ROL( xe, y0 ), ROL( xf, y0 ) );
-    WWU_TEST( wwu_ror( x, y0 ),       ROR( x0, y0 ), ROR( x1, y0 ), ROR( x2, y0 ), ROR( x3, y0 ),
-                                      ROR( x4, y0 ), ROR( x5, y0 ), ROR( x6, y0 ), ROR( x7, y0 ),
-                                      ROR( x8, y0 ), ROR( x9, y0 ), ROR( xa, y0 ), ROR( xb, y0 ),
-                                      ROR( xc, y0 ), ROR( xd, y0 ), ROR( xe, y0 ), ROR( xf, y0 ) );
-    WWU_TEST( wwu_rol_vector( x, y ), ROL( x0, y0 ), ROL( x1, y1 ), ROL( x2, y2 ), ROL( x3, y3 ),
-                                      ROL( x4, y4 ), ROL( x5, y5 ), ROL( x6, y6 ), ROL( x7, y7 ),
-                                      ROL( x8, y8 ), ROL( x9, y9 ), ROL( xa, ya ), ROL( xb, yb ),
-                                      ROL( xc, yc ), ROL( xd, yd ), ROL( xe, ye ), ROL( xf, yf ) );
-    WWU_TEST( wwu_ror_vector( x, y ), ROR( x0, y0 ), ROR( x1, y1 ), ROR( x2, y2 ), ROR( x3, y3 ),
-                                      ROR( x4, y4 ), ROR( x5, y5 ), ROR( x6, y6 ), ROR( x7, y7 ),
-                                      ROR( x8, y8 ), ROR( x9, y9 ), ROR( xa, ya ), ROR( xb, yb ),
-                                      ROR( xc, yc ), ROR( xd, yd ), ROR( xe, ye ), ROR( xf, yf ) );
+    WWU_TEST( wwu_rol_variable( x, y0 ), ROL( x0, y0 ), ROL( x1, y0 ), ROL( x2, y0 ), ROL( x3, y0 ),
+                                         ROL( x4, y0 ), ROL( x5, y0 ), ROL( x6, y0 ), ROL( x7, y0 ),
+                                         ROL( x8, y0 ), ROL( x9, y0 ), ROL( xa, y0 ), ROL( xb, y0 ),
+                                         ROL( xc, y0 ), ROL( xd, y0 ), ROL( xe, y0 ), ROL( xf, y0 ) );
+    WWU_TEST( wwu_ror_variable( x, y0 ), ROR( x0, y0 ), ROR( x1, y0 ), ROR( x2, y0 ), ROR( x3, y0 ),
+                                         ROR( x4, y0 ), ROR( x5, y0 ), ROR( x6, y0 ), ROR( x7, y0 ),
+                                         ROR( x8, y0 ), ROR( x9, y0 ), ROR( xa, y0 ), ROR( xb, y0 ),
+                                         ROR( xc, y0 ), ROR( xd, y0 ), ROR( xe, y0 ), ROR( xf, y0 ) );
+    WWU_TEST( wwu_rol_vector( x, y ),    ROL( x0, y0 ), ROL( x1, y1 ), ROL( x2, y2 ), ROL( x3, y3 ),
+                                         ROL( x4, y4 ), ROL( x5, y5 ), ROL( x6, y6 ), ROL( x7, y7 ),
+                                         ROL( x8, y8 ), ROL( x9, y9 ), ROL( xa, ya ), ROL( xb, yb ),
+                                         ROL( xc, yc ), ROL( xd, yd ), ROL( xe, ye ), ROL( xf, yf ) );
+    WWU_TEST( wwu_ror_vector( x, y ),    ROR( x0, y0 ), ROR( x1, y1 ), ROR( x2, y2 ), ROR( x3, y3 ),
+                                         ROR( x4, y4 ), ROR( x5, y5 ), ROR( x6, y6 ), ROR( x7, y7 ),
+                                         ROR( x8, y8 ), ROR( x9, y9 ), ROR( xa, ya ), ROR( xb, yb ),
+                                         ROR( xc, yc ), ROR( xd, yd ), ROR( xe, ye ), ROR( xf, yf ) );
+#   define COMPARE_WWU_ROL( j ) COMPARE16( WWU_TEST, x, wwu_rol, ROL, j );
+#   define COMPARE_WWU_ROR( j ) COMPARE16( WWU_TEST, x, wwu_ror, ROR, j );
+    EXPAND_32(COMPARE_WWU_ROL, 0)
+    EXPAND_32(COMPARE_WWU_ROR, 0)
+#   undef COMPARE_WWU_ROR
+#   undef COMPARE_WWU_ROL
 #   undef ROR
 #   undef ROL
 

--- a/src/util/simd/test_avx512_8x64.c
+++ b/src/util/simd/test_avx512_8x64.c
@@ -111,14 +111,20 @@ main( int     argc,
 
 #   define ROL(x,y) (long)fd_ulong_rotate_left ( (ulong)(x), (int)(uint)(y) )
 #   define ROR(x,y) (long)fd_ulong_rotate_right( (ulong)(x), (int)(uint)(y) )
-    WWL_TEST( wwl_rol( x, y0 ),       ROL( x0, y0 ), ROL( x1, y0 ), ROL( x2, y0 ), ROL( x3, y0 ),
-                                      ROL( x4, y0 ), ROL( x5, y0 ), ROL( x6, y0 ), ROL( x7, y0 ) );
-    WWL_TEST( wwl_ror( x, y0 ),       ROR( x0, y0 ), ROR( x1, y0 ), ROR( x2, y0 ), ROR( x3, y0 ),
-                                      ROR( x4, y0 ), ROR( x5, y0 ), ROR( x6, y0 ), ROR( x7, y0 ) );
-    WWL_TEST( wwl_rol_vector( x, y ), ROL( x0, y0 ), ROL( x1, y1 ), ROL( x2, y2 ), ROL( x3, y3 ),
-                                      ROL( x4, y4 ), ROL( x5, y5 ), ROL( x6, y6 ), ROL( x7, y7 ) );
-    WWL_TEST( wwl_ror_vector( x, y ), ROR( x0, y0 ), ROR( x1, y1 ), ROR( x2, y2 ), ROR( x3, y3 ),
-                                      ROR( x4, y4 ), ROR( x5, y5 ), ROR( x6, y6 ), ROR( x7, y7 ) );
+    WWL_TEST( wwl_rol_variable( x, y0 ), ROL( x0, y0 ), ROL( x1, y0 ), ROL( x2, y0 ), ROL( x3, y0 ),
+                                         ROL( x4, y0 ), ROL( x5, y0 ), ROL( x6, y0 ), ROL( x7, y0 ) );
+    WWL_TEST( wwl_ror_variable( x, y0 ), ROR( x0, y0 ), ROR( x1, y0 ), ROR( x2, y0 ), ROR( x3, y0 ),
+                                         ROR( x4, y0 ), ROR( x5, y0 ), ROR( x6, y0 ), ROR( x7, y0 ) );
+    WWL_TEST( wwl_rol_vector( x, y ),    ROL( x0, y0 ), ROL( x1, y1 ), ROL( x2, y2 ), ROL( x3, y3 ),
+                                         ROL( x4, y4 ), ROL( x5, y5 ), ROL( x6, y6 ), ROL( x7, y7 ) );
+    WWL_TEST( wwl_ror_vector( x, y ),    ROR( x0, y0 ), ROR( x1, y1 ), ROR( x2, y2 ), ROR( x3, y3 ),
+                                         ROR( x4, y4 ), ROR( x5, y5 ), ROR( x6, y6 ), ROR( x7, y7 ) );
+#   define COMPARE_WWL_ROL( j ) COMPARE8( WWL_TEST, x, wwl_rol, ROL, j );
+#   define COMPARE_WWL_ROR( j ) COMPARE8( WWL_TEST, x, wwl_ror, ROR, j );
+    EXPAND_64(COMPARE_WWL_ROL, 0)
+    EXPAND_64(COMPARE_WWL_ROR, 0)
+#   undef COMPARE_WWL_ROR
+#   undef COMPARE_WWL_ROL
 #   undef ROR
 #   undef ROL
 
@@ -310,14 +316,20 @@ main( int     argc,
 
 #   define ROL(x,y) fd_ulong_rotate_left ( (x), (int)(uint)(y) )
 #   define ROR(x,y) fd_ulong_rotate_right( (x), (int)(uint)(y) )
-    WWV_TEST( wwv_rol( x, y0 ),       ROL( x0, y0 ), ROL( x1, y0 ), ROL( x2, y0 ), ROL( x3, y0 ),
-                                      ROL( x4, y0 ), ROL( x5, y0 ), ROL( x6, y0 ), ROL( x7, y0 ) );
-    WWV_TEST( wwv_ror( x, y0 ),       ROR( x0, y0 ), ROR( x1, y0 ), ROR( x2, y0 ), ROR( x3, y0 ),
-                                      ROR( x4, y0 ), ROR( x5, y0 ), ROR( x6, y0 ), ROR( x7, y0 ) );
-    WWV_TEST( wwv_rol_vector( x, y ), ROL( x0, y0 ), ROL( x1, y1 ), ROL( x2, y2 ), ROL( x3, y3 ),
-                                      ROL( x4, y4 ), ROL( x5, y5 ), ROL( x6, y6 ), ROL( x7, y7 ) );
-    WWV_TEST( wwv_ror_vector( x, y ), ROR( x0, y0 ), ROR( x1, y1 ), ROR( x2, y2 ), ROR( x3, y3 ),
-                                      ROR( x4, y4 ), ROR( x5, y5 ), ROR( x6, y6 ), ROR( x7, y7 ) );
+    WWV_TEST( wwv_rol_variable( x, y0 ), ROL( x0, y0 ), ROL( x1, y0 ), ROL( x2, y0 ), ROL( x3, y0 ),
+                                         ROL( x4, y0 ), ROL( x5, y0 ), ROL( x6, y0 ), ROL( x7, y0 ) );
+    WWV_TEST( wwv_ror_variable( x, y0 ), ROR( x0, y0 ), ROR( x1, y0 ), ROR( x2, y0 ), ROR( x3, y0 ),
+                                         ROR( x4, y0 ), ROR( x5, y0 ), ROR( x6, y0 ), ROR( x7, y0 ) );
+    WWV_TEST( wwv_rol_vector( x, y ),    ROL( x0, y0 ), ROL( x1, y1 ), ROL( x2, y2 ), ROL( x3, y3 ),
+                                         ROL( x4, y4 ), ROL( x5, y5 ), ROL( x6, y6 ), ROL( x7, y7 ) );
+    WWV_TEST( wwv_ror_vector( x, y ),    ROR( x0, y0 ), ROR( x1, y1 ), ROR( x2, y2 ), ROR( x3, y3 ),
+                                         ROR( x4, y4 ), ROR( x5, y5 ), ROR( x6, y6 ), ROR( x7, y7 ) );
+#   define COMPARE_WWV_ROL( j ) COMPARE8( WWV_TEST, x, wwv_rol, ROL, j );
+#   define COMPARE_WWV_ROR( j ) COMPARE8( WWV_TEST, x, wwv_ror, ROR, j );
+    EXPAND_64(COMPARE_WWV_ROL, 0)
+    EXPAND_64(COMPARE_WWV_ROR, 0)
+#   undef COMPARE_WWV_ROR
+#   undef COMPARE_WWV_ROL
 #   undef ROR
 #   undef ROL
 


### PR DESCRIPTION
Clang and GCC are pickier about `_mm512_rol_epi32` having a compile-time constant argument.  Richie's fix using `__builtin_constant_p` works fine with GCC but not with Clang. The best way to address it is to split into e.g. `wwi_rol` and `wwi_rol_variable`. I modified the tests correspondingly.

There was also an unused variable Clang did not like in the PoH tile, and an incorrect alignment argument in `fd_r43x6_ge.c`.

The reason all these issues have gone undetected is that CI was not building with `FD_HAS_AVX512`, so I've fixed that as well.

Fixes #1188.