### PR TITLE
introduce the `development.gossip.allow_private_addr` configuration item

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -249,6 +249,8 @@ static int parse_key_value( config_t *   config,
   ENTRY_STR   ( ., development.netns,   interface1_mac                                            );
   ENTRY_STR   ( ., development.netns,   interface1_addr                                           );
 
+  ENTRY_BOOL  ( ., development.gossip, allow_private_addr                                         );
+  
   /* We have encountered a token that is not recognized, return 0 to indicate failure. */
   return 0;
 }

--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -249,7 +249,7 @@ static int parse_key_value( config_t *   config,
   ENTRY_STR   ( ., development.netns,   interface1_mac                                            );
   ENTRY_STR   ( ., development.netns,   interface1_addr                                           );
 
-  ENTRY_BOOL  ( ., development.gossip, allow_private_addr                                         );
+  ENTRY_BOOL  ( ., development.gossip, allow_private_address                                      );
   
   /* We have encountered a token that is not recognized, return 0 to indicate failure. */
   return 0;

--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -143,7 +143,7 @@ typedef struct {
       char interface1_addr[ 32 ];
     } netns;
     struct {
-      int allow_private_addr;
+      int allow_private_address;
     } gossip;
   } development;
 

--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -142,6 +142,9 @@ typedef struct {
       char interface1_mac [ 32 ];
       char interface1_addr[ 32 ];
     } netns;
+    struct {
+      int allow_private_addr;
+    } gossip;
   } development;
 
   struct {

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -907,3 +907,7 @@ dynamic_port_range = "8900-9000"
         interface1_mac = "52:F1:7E:DA:2C:E1"
         # IP address of the second network namespace.
         interface1_addr = "198.18.0.2"
+    [development.gossip]
+        # Under normal operating conditions, a validator should always reach out to a host located on the public internet.
+        # This configuration item allows Firedancer to gossip with nodes located on a private internet (rfc1918).
+        allow_private_addr = false

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -910,4 +910,5 @@ dynamic_port_range = "8900-9000"
     [development.gossip]
         # Under normal operating conditions, a validator should always reach out to a host located on the public internet.
         # This configuration item allows Firedancer to gossip with nodes located on a private internet (rfc1918).
-        allow_private_addr = false
+        # This option is passed to the Solana Labs client with the `--allow-private-addr` flag.
+        allow_private_address = false

--- a/src/app/fdctl/run/run_solana.c
+++ b/src/app/fdctl/run/run_solana.c
@@ -193,6 +193,9 @@ solana_labs_boot( config_t * config ) {
     snprintf1( ip_addr, 16, FD_IP4_ADDR_FMT, FD_IP4_ADDR_FMT_ARGS(config->tiles.net.ip_addr) );
     ADD( "--gossip-host", ip_addr );
   }
+  if( config->development.gossip.allow_private_addr ) {
+    ADD1( "--allow-private-addr" );
+  }
 
   /* rpc */
   if( config->rpc.port ) ADDH( "--rpc-port", config->rpc.port );

--- a/src/app/fdctl/run/run_solana.c
+++ b/src/app/fdctl/run/run_solana.c
@@ -193,7 +193,7 @@ solana_labs_boot( config_t * config ) {
     snprintf1( ip_addr, 16, FD_IP4_ADDR_FMT, FD_IP4_ADDR_FMT_ARGS(config->tiles.net.ip_addr) );
     ADD( "--gossip-host", ip_addr );
   }
-  if( config->development.gossip.allow_private_addr ) {
+  if( config->development.gossip.allow_private_address ) {
     ADD1( "--allow-private-addr" );
   }
 


### PR DESCRIPTION
From the new documentation:
>  Under normal operating conditions, a validator should always reach out to a host located on the public internet.
> This configuration item allows Firedancer to gossip with nodes located on a private internet (rfc1918).