### PR TITLE
mux: temporary fix for clang strangeness breaking fddev

### DIFF
--- a/src/app/fdctl/configure/ethtool.c
+++ b/src/app/fdctl/configure/ethtool.c
@@ -119,7 +119,7 @@ check_device( const char * device,
   struct ethtool_channels channels = {0};
   channels.cmd = ETHTOOL_GCHANNELS;
 
-  struct ifreq ifr;
+  struct ifreq ifr = {0};
   strncpy( ifr.ifr_name, device, IF_NAMESIZE );
   ifr.ifr_name[ IF_NAMESIZE - 1 ] = '\0'; // silence linter, not needed for correctness
   ifr.ifr_data = (void *)&channels;

--- a/src/app/fdctl/run/tiles/fd_bank.c
+++ b/src/app/fdctl/run/tiles/fd_bank.c
@@ -139,10 +139,12 @@ during_frag( void * _ctx,
   fd_bank_ctx_t * ctx = (fd_bank_ctx_t *)_ctx;
 
   if( FD_UNLIKELY( in_idx==POH_IN_IDX ) ) {
-    if( FD_UNLIKELY( chunk<ctx->poh_in_chunk0 || chunk>ctx->poh_in_wmark || sz!=sizeof(fd_became_leader_t) ) )
-      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->pack_in_chunk0, ctx->pack_in_wmark ));
+    if( FD_UNLIKELY( chunk<ctx->poh_in_chunk0 || chunk>ctx->poh_in_wmark || sz!=sizeof(fd_became_leader_t) ) ) {
+      FD_LOG_WARNING(( "seq=%lu sig=%lx. pkt_type=%lu", seq, sig, fd_disco_poh_sig_pkt_type( sig ) ));
+      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->poh_in_chunk0, ctx->poh_in_wmark ));
+    }
 
-    fd_memcpy( &ctx->leader_frag, fd_chunk_to_laddr( ctx->poh_in_mem, chunk ), 16UL );
+    fd_memcpy( &ctx->leader_frag, fd_chunk_to_laddr( ctx->poh_in_mem, chunk ), sizeof(fd_became_leader_t) );
   } else {
     uchar * src = (uchar *)fd_chunk_to_laddr( ctx->pack_in_mem, chunk );
     uchar * dst = (uchar *)fd_chunk_to_laddr( ctx->out_mem, ctx->out_chunk );

--- a/src/app/fdctl/run/tiles/fd_poh.c
+++ b/src/app/fdctl/run/tiles/fd_poh.c
@@ -812,12 +812,13 @@ publish_tick( fd_poh_ctx_t *     ctx,
   ctx->last_hashcnt = ctx->hashcnt;
 
   dst += sizeof(fd_entry_batch_meta_t);
-  *(ulong*)dst = hash_delta;
-  fd_memcpy( dst+8UL, ctx->hash, 32UL );
-  *(ulong*)(dst+40UL) = 0;
+  fd_entry_batch_header_t * tick = (fd_entry_batch_header_t *)dst;
+  tick->hashcnt_delta = hash_delta;
+  fd_memcpy( tick->hash, ctx->hash, 32UL );
+  tick->txn_cnt = 0UL;
 
   ulong tspub = (ulong)fd_frag_meta_ts_comp( fd_tickcount() );
-  ulong sz = sizeof(fd_entry_batch_meta_t)+48UL;
+  ulong sz = sizeof(fd_entry_batch_meta_t)+sizeof(fd_entry_batch_header_t);
   ulong sig = fd_disco_poh_sig( slot, POH_PKT_TYPE_MICROBLOCK, 0UL );
   fd_mux_publish( mux, sig, ctx->out_chunk, sz, 0UL, 0UL, tspub );
   ctx->out_chunk = fd_dcache_compact_next( ctx->out_chunk, sz, ctx->out_chunk0, ctx->out_wmark );


### PR DESCRIPTION
Some cleanup, plus:

> Clang optimizes extremely aggressively which breaks the
>        atomicity expected by seq_sig_query.  In particular, it replaces
>        the sequence query with a second load (immediately following
>        vector load).  The signature query a few lines down is still an
>        extract from the vector which then means that effectively the
>        signature is loaded before the sequence number.
>        Adding this clobbers of the vector prevents this optimization by
>        forcing the seq query to be an extract, but we probably want a
>        better long term solution.