### PR TITLE
Fix U.B. with pointer additions

### DIFF
--- a/src/util/tmpl/fd_map_chain.c
+++ b/src/util/tmpl/fd_map_chain.c
@@ -860,7 +860,7 @@ MAP_(ele_remove)( MAP_(t) *         join,
                   MAP_ELE_T *       sentinel,
                   MAP_ELE_T *       pool ) {
   ulong ele_idx = MAP_(idx_remove)( join, key, MAP_(private_idx_null)(), pool );
-  return fd_ptr_if( !MAP_(private_idx_is_null)( ele_idx ), pool + ele_idx, sentinel );
+  return fd_ptr_if( !MAP_(private_idx_is_null)( ele_idx ), (MAP_ELE_T       *)( (ulong)pool + (ele_idx * sizeof(MAP_ELE_T)) ), sentinel );
 }
 
 FD_FN_PURE static inline MAP_ELE_T *
@@ -869,7 +869,7 @@ MAP_(ele_query)( MAP_(t) *         join,
                  MAP_ELE_T *       sentinel,
                  MAP_ELE_T *       pool ) {
   ulong ele_idx = MAP_(idx_query)( join, key, MAP_(private_idx_null)(), pool );
-  return fd_ptr_if( !MAP_(private_idx_is_null)( ele_idx ), pool + ele_idx, sentinel );
+  return fd_ptr_if( !MAP_(private_idx_is_null)( ele_idx ), (MAP_ELE_T       *)( (ulong)pool + (ele_idx * sizeof(MAP_ELE_T)) ), sentinel );
 }
 
 FD_FN_PURE static inline MAP_ELE_T const *
@@ -878,7 +878,7 @@ MAP_(ele_query_const)( MAP_(t) const *   join,
                        MAP_ELE_T const * sentinel,
                        MAP_ELE_T const * pool ) {
   ulong ele_idx = MAP_(idx_query_const)( join, key, MAP_(private_idx_null)(), pool );
-  return fd_ptr_if( !MAP_(private_idx_is_null)( ele_idx ), pool + ele_idx, sentinel );
+  return fd_ptr_if( !MAP_(private_idx_is_null)( ele_idx ), (MAP_ELE_T const *)( (ulong)pool + (ele_idx * sizeof(MAP_ELE_T)) ), sentinel );
 }
 
 FD_PROTOTYPES_END

--- a/src/util/tmpl/fd_pool.c
+++ b/src/util/tmpl/fd_pool.c
@@ -334,7 +334,7 @@ POOL_(ele_test)( POOL_T const * join,
   ulong max = POOL_(private_meta_const)( join )->max;
   ulong idx = (ulong)(ele - join);
   FD_COMPILER_FORGET( idx ); /* prevent compiler from optimizing out alignment test */
-  return (!ele) | ((idx<max) & (ele==(join+idx))); /* last test checks alignment */
+  return (!ele) | ((idx<max) & ((ulong)ele==((ulong)join+(idx*sizeof(POOL_T))))); /* last test checks alignment */
 }
 
 FD_FN_CONST static inline ulong


### PR DESCRIPTION
Pointer arithmetic has some special assumptions.  For example,
adding a non-zero offset to a pointer value is assumed to never
result in a zero pointer.  (Or more generally, pointers cannot
overflow in C.)  Fixes instances of such U.B. by replacing them
with regular integer arithmetic.
