### PR TITLE
Revert codecov/codecov-action back to version 3

### DIFF
--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -44,7 +44,7 @@ jobs:
           gcloud storage cp -r ./build/cov/html/* ${{ vars.COVERAGE_BUCKET }}/
 
       - name: Upload coverage report to CodeCov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         timeout-minutes: 5
         with:
           files: build/cov/cov.lcov


### PR DESCRIPTION
Reverts firedancer-io/firedancer#1236

Unfortunately, version 4 is broken.
https://github.com/codecov/codecov-action/issues/1277