### PR TITLE
util: basic aarch64 fence and tickcount

### DIFF
--- a/config/machine/native.mk
+++ b/config/machine/native.mk
@@ -60,8 +60,8 @@ $(call map-define,FD_HAS_X86, __x86_64__)
 $(call map-define,FD_HAS_SSE, __SSE4_2__)
 $(call map-define,FD_HAS_AVX, __AVX2__)
 $(call map-define,FD_HAS_GFNI, __GFNI__)
-$(call map-define,FD_IS_X86_64, __x86_64__)
 $(call map-define,FD_HAS_AESNI, __AES__)
+$(call map-define,FD_HAS_ARM, __aarch64__)
 
 # Older version of GCC (<10) don't fully support AVX512, so we disable
 # it in those cases. Older versions of Clang (<8) don't support it
@@ -82,7 +82,7 @@ ifdef FD_HAS_THREADS
 include config/extra/with-threads.mk
 endif
 
-ifdef FD_IS_X86_64
+ifdef FD_HAS_X86
 include config/extra/with-x86-64.mk
 $(info Using FD_HAS_SSE=$(FD_HAS_SSE))
 $(info Using FD_HAS_AVX=$(FD_HAS_AVX))

--- a/src/tango/test_frag_rx.c
+++ b/src/tango/test_frag_rx.c
@@ -194,7 +194,7 @@ main( int     argc,
     /* Already loaded into registers as part of the wait */
 
 #   elif WAIT_STYLE==0
- 
+
     ulong sig    = (ulong)meta->sig;
     ulong chunk  = (ulong)meta->chunk;
     ulong sz     = (ulong)meta->sz;

--- a/src/tango/test_meta_rx.c
+++ b/src/tango/test_meta_rx.c
@@ -1,6 +1,6 @@
 #include "fd_tango.h"
 
-#if FD_HAS_HOSTED && FD_HAS_AVX
+#if FD_HAS_HOSTED
 
 static uchar fseq_mem[ FD_FSEQ_FOOTPRINT ] __attribute__((aligned(FD_FSEQ_ALIGN)));
 
@@ -239,7 +239,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
-  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED and FD_HAS_AVX capabilities" ));
+  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED capability" ));
   fd_halt();
   return 0;
 }

--- a/src/tango/test_meta_tx.c
+++ b/src/tango/test_meta_tx.c
@@ -1,6 +1,6 @@
 #include "fd_tango.h"
 
-#if FD_HAS_HOSTED && FD_HAS_AVX
+#if FD_HAS_HOSTED
 
 #define RX_MAX (128UL) /* Max _reliable_ (arb unreliable) */
 
@@ -166,9 +166,9 @@ main( int     argc,
       now = fd_tickcount();
       continue;
     }
-    
+
     /* We are not backpressured, so send metadata with a test pattern */
-    
+
     ulong sig    =                seq;
     ulong chunk  = (ulong)(uint  )seq;
     ulong sz     = (ulong)(ushort)seq;
@@ -220,7 +220,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
-  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED and FD_HAS_AVX capabilities" ));
+  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED capability" ));
   fd_halt();
   return 0;
 }

--- a/src/util/test_util_base.c
+++ b/src/util/test_util_base.c
@@ -416,10 +416,12 @@ main( int     argc,
 
   /* Test fd_tickcount (FIXME: TEST MORE THAN MONOTONICITY?) */
 
-  long tic = fd_tickcount();
+  long  tic     = fd_tickcount();
+  ulong stutter = 0UL;
   for( ulong iter=0UL; iter<1000000UL; iter++ ) {
     long toc = fd_tickcount();
-    FD_TEST( (toc - tic) > 0L );
+    stutter = fd_ulong_if( toc==tic, stutter+1UL, 0UL );
+    FD_TEST( ( (toc - tic) >= 0L ) & ( stutter<16UL ) );
     tic = toc;
   }
 


### PR DESCRIPTION
- util: add FD_HAS_ARM
- util: add placeholder for FD_COMPILER_MFENCE using 'dmb ish'
- util: add placeholder for fd_tickcount using CNTVCT_EL0 MSR
- util: relax fd_tickcount() test to allow stutter (CNTVCT_EL0 increments slower than CPU can poll)
- tango: enable IPC meta test on non-x86
- config: detect FD_HAS_ARM

Closes https://github.com/firedancer-io/firedancer/issues/1176
Closes https://github.com/firedancer-io/firedancer/issues/1186
