### PR TITLE
config: static link deps

### DIFF
--- a/config/extra/with-gcc.mk
+++ b/config/extra/with-gcc.mk
@@ -6,6 +6,7 @@ LD:=g++
 # FD_USING_CLANG should not be both set simultaneously
 
 CPPFLAGS+=-DFD_USING_GCC=1
+LDFLAGS+=-static-libgcc
 
 FD_USING_GCC:=1
 

--- a/config/extra/with-openssl.mk
+++ b/config/extra/with-openssl.mk
@@ -1,4 +1,4 @@
-LDFLAGS+=-Wl,--push-state,-Bstatic -lssl -lcrypto -Wl,--pop-state
+LDFLAGS+=opt/lib/libssl.a opt/lib/libcrypto.a
 
 FD_HAS_OPENSSL:=1
 CPPFLAGS+=-DFD_HAS_OPENSSL=1

--- a/config/extra/with-zstd.mk
+++ b/config/extra/with-zstd.mk
@@ -1,3 +1,3 @@
 FD_HAS_ZSTD:=1
 CFLAGS+=-DFD_HAS_ZSTD=1
-LDFLAGS+=-lzstd
+LDFLAGS+=opt/lib/libzstd.a


### PR DESCRIPTION
Fixes an issue of our binaries having dynamic dependencies on libzstd and libssl.
