### PR TITLE
x509: update cert template

### DIFF
--- a/src/ballet/x509/Local.mk
+++ b/src/ballet/x509/Local.mk
@@ -6,5 +6,6 @@ $(call make-fuzz-test,fuzz_x509_cert_parser,fuzz_x509_cert_parser,fd_ballet fd_u
 # X.509 mock cert generator
 $(call add-hdrs,fd_x509_mock.h)
 $(call add-objs,fd_x509_mock,fd_ballet)
-$(call make-unit-test,test_x509_mock,test_x509_mock,fd_ballet fd_util)
-$(call run-unit-test,test_x509_mock)
+
+$(call make-unit-test,test_x509,test_x509,fd_ballet fd_util)
+$(call run-unit-test,test_x509)

--- a/src/ballet/x509/fd_x509_mock.c
+++ b/src/ballet/x509/fd_x509_mock.c
@@ -1,17 +1,12 @@
 #include "fd_x509_mock.h"
 
-#include "../ed25519/fd_ed25519.h"
-
-
 static uchar const
 fd_x509_mock_tpl[ FD_X509_MOCK_CERT_SZ ] = {
   /* Certificate SEQUENCE (3 elem) */
-  0x30, 0x81, 0xf1,
+  0x30, 0x81, 0xf6,
 
     /* tbsCertificate TBSCertificate SEQUENCE (8 elem) */
-    #define FD_X509_MOCK_TBS_OFF (0x03)
-    #define FD_X509_MOCK_TBS_SZ  (0xa7)
-    0x30, 0x81, 0xa4,
+    0x30, 0x81, 0xa9,
 
       /* version [0] (1 elem)  */
       0xa0, 0x03,
@@ -28,15 +23,15 @@ fd_x509_mock_tpl[ FD_X509_MOCK_CERT_SZ ] = {
         0x06, 0x03, 0x2b, 0x65, 0x70,
 
       /* issuer Name SEQUENCE (1 elem) */
-      0x30, 0x11,
+      0x30, 0x16,
         /* RelativeDistinguishedName SET (1 elem) */
-        0x31, 0x0f,
+        0x31, 0x14,
           /* AttributeTypeAndValue SEQUENCE (2 elem) */
-          0x30, 0x0d,
+          0x30, 0x12,
             /* type AttributeType OBJECT IDENTIFIER 2.5.4.3 commonName (X.520 DN component) */
             0x06, 0x03, 0x55, 0x04, 0x03,
-            /* value AttributeValue [?] UTF8String Solana */
-            0x0c, 0x06, 0x53, 0x6f, 0x6c, 0x61, 0x6e, 0x61,
+            /* value AttributeValue [?] UTF8String Solana node */
+            0x0c, 0x0b, 0x53, 0x6f, 0x6c, 0x61, 0x6e, 0x61, 0x20, 0x6e, 0x6f, 0x64, 0x65,
 
       /* validity Validity SEQUENCE (2 elem) */
       0x30, 0x20,
@@ -56,7 +51,7 @@ fd_x509_mock_tpl[ FD_X509_MOCK_CERT_SZ ] = {
           0x06, 0x03, 0x2b, 0x65, 0x70,
         /* subjectPublicKey BIT STRING (256 bit) */
         0x03, 0x21, 0x00,
-        #define FD_X509_MOCK_PUBKEY_OFF (0x5f)
+        #define FD_X509_MOCK_PUBKEY_OFF (0x64)
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -107,16 +102,9 @@ fd_x509_mock_tpl[ FD_X509_MOCK_CERT_SZ ] = {
       0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
 };
 
-
-#if defined(__linux__)
-#include <sys/random.h>
-#include <errno.h>
-#endif
-
 void
-fd_x509_mock_cert( uchar         buf[ static FD_X509_MOCK_CERT_SZ ],
-                   uchar         public_key[ static 32 ] ) {
+fd_x509_mock_cert( uchar buf[ static FD_X509_MOCK_CERT_SZ ],
+                   uchar public_key[ static 32 ] ) {
   fd_memcpy( buf, fd_x509_mock_tpl, FD_X509_MOCK_CERT_SZ );
   fd_memcpy( buf+FD_X509_MOCK_PUBKEY_OFF, public_key, 32UL );
 }
-

--- a/src/ballet/x509/fd_x509_mock.h
+++ b/src/ballet/x509/fd_x509_mock.h
@@ -1,21 +1,20 @@
 #ifndef HEADER_fd_src_ballet_x509_fd_x509_gen_h
 #define HEADER_fd_src_ballet_x509_fd_x509_gen_h
 
-/* fd_x509_gen.h generates mock X.509 certificates for QUIC peer-to-peer
-   use.  These certificates are deliberately crafted to pass as valid
-   when connecting to a rustls peer.  They are however semantically
-   invalid (e.g. hardcoded to subject 'localhost').  The use of X.509 is
-   a mistake in the first place, and should be fixed via RFC 7250 raw
-   public keys.  As soon as raw public keys are implemented network
-   wide, this code should be deleted. */
+/* fd_x509_mock.h generates mock X.509 certificates for QUIC
+   peer-to-peer use.  These certificates are deliberately crafted to
+   pass as valid when connecting to a rustls peer.  They are however
+   semantically invalid (e.g. hardcoded to subject 'localhost').  The
+   use of X.509 is a mistake in the first place, and should be fixed via
+   RFC 7250 raw public keys.  As soon as raw public keys are implemented
+   network wide, this code should be deleted. */
 
 #include "../../util/fd_util_base.h"
-#include "../sha512/fd_sha512.h"
 
 /* FD_X509_MOCK_CERT_SZ is the byte size of the DER serialization of a
    mock X.509 certificate */
 
-#define FD_X509_MOCK_CERT_SZ (0xf4)
+#define FD_X509_MOCK_CERT_SZ (0xf9)
 
 /* fd_x509_mock_cert generates a dummy X.509 certificate given an
    Ed25519 public key.  Resulting cert will contain an invalid
@@ -23,7 +22,7 @@
    copied out to buf. */
 
 void
-fd_x509_mock_cert( uchar         buf[ static FD_X509_MOCK_CERT_SZ ],
-                   uchar         public_key[ static 32 ] );
+fd_x509_mock_cert( uchar buf[ static FD_X509_MOCK_CERT_SZ ],
+                   uchar public_key[ static 32 ] );
 
 #endif /* HEADER_fd_src_ballet_x509_fd_x509_gen_h */

--- a/src/ballet/x509/test_x509.c
+++ b/src/ballet/x509/test_x509.c
@@ -52,7 +52,7 @@ main( int     argc,
   FD_TEST( 0==parse_x509_cert( parsed, cert, FD_X509_MOCK_CERT_SZ ) );
 
   FD_TEST( parsed->tbs_start                       ==0x03U );
-  FD_TEST( parsed->tbs_len                         ==0xa7U );
+  FD_TEST( parsed->tbs_len                         ==0xacU );
   FD_TEST( parsed->version                         ==0x02U );
   FD_TEST( parsed->serial_start                    ==0x0dU );
   FD_TEST( parsed->serial_len                      ==0x08U );
@@ -62,22 +62,25 @@ main( int     argc,
   FD_TEST( parsed->tbs_sig_alg_oid_len             ==0x05U );
   FD_TEST( parsed->tbs_sig_alg_oid_params_len      ==0x00U );
   FD_TEST( parsed->issuer_start                    ==0x1cU );
-  FD_TEST( parsed->issuer_len                      ==0x13U );
+  FD_TEST( parsed->issuer_len                      ==0x18U );
   FD_TEST( parsed->not_before         ==2166042218463232UL );
   FD_TEST( parsed->not_after          ==4503603939115008UL );
-  FD_TEST( parsed->subject_start                   ==0x51U );
+  FD_TEST( parsed->subject_start                   ==0x56U );
   FD_TEST( parsed->subject_len                     ==0x02U );
-  FD_TEST( parsed->sig_start                       ==0xb1U );
+  FD_TEST( parsed->sig_start                       ==0xb6U );
   FD_TEST( parsed->sig_len                         ==0x43U );
-  FD_TEST( parsed->sig_alg_params.ed25519.r_raw_off==0xb4U );
+  FD_TEST( parsed->sig_alg_params.ed25519.r_raw_off==0xb9U );
   FD_TEST( parsed->sig_alg_params.ed25519.r_raw_len==0x20U );
-  FD_TEST( parsed->sig_alg_params.ed25519.s_raw_off==0xd4U );
+  FD_TEST( parsed->sig_alg_params.ed25519.s_raw_off==0xd9U );
   FD_TEST( parsed->sig_alg_params.ed25519.s_raw_len==0x20U );
   FD_TEST( !!parsed->empty_subject             );
   FD_TEST(  !parsed->subject_issuer_identical  );
   FD_TEST( parsed->spki_alg ==SPKI_ALG_ED25519 );
   FD_TEST( parsed->sig_alg  ==SIG_ALG_ED25519  );
   FD_TEST( parsed->hash_alg ==HASH_ALG_SHA512  );
+
+  FD_TEST( 0==memcmp( cert + parsed->spki_alg_params.ed25519.ed25519_raw_pub_off,
+                      public_key, 32 ) );
 
   /* Parse certificate captured from Solana Labs client */
 


### PR DESCRIPTION
In https://github.com/solana-labs/solana/pull/34896,
Solana Labs chose a slightly different mock cert layout.

This PR updates Firedancer and Solana Labs to use the same.
