### PR TITLE
bmtree: relax alignment requirements

### DIFF
--- a/src/ballet/bmtree/fd_bmtree.c
+++ b/src/ballet/bmtree/fd_bmtree.c
@@ -8,7 +8,7 @@
 
    will declare in the current compile unit a header only library
    with the following APIs:
-   
+
      // Public node API
 
      struct __attribute__((aligned(32))) bmt_node {
@@ -116,9 +116,9 @@ fd_bmtree_private_merge( fd_bmtree_node_t       * node,
 
 # if FD_HAS_AVX
 
-  __m256i avx_pre = _mm256_load_si256( (__m256i const *)fd_bmtree_node_prefix );
-  __m256i avx_a   = _mm256_load_si256( (__m256i const *)a           );
-  __m256i avx_b   = _mm256_load_si256( (__m256i const *)b           );
+  __m256i avx_pre = _mm256_load_si256 ( (__m256i const *)fd_bmtree_node_prefix );
+  __m256i avx_a   = _mm256_loadu_si256( (__m256i const *)a           );
+  __m256i avx_b   = _mm256_loadu_si256( (__m256i const *)b           );
 
   uchar mem[96] __attribute__((aligned(32)));
 
@@ -147,7 +147,7 @@ FD_FN_CONST ulong
 fd_bmtree_depth( ulong leaf_cnt ) {
   return fd_ulong_if(
     /* if */   leaf_cnt<=1UL,
-    /* then */ leaf_cnt, 
+    /* then */ leaf_cnt,
     /* else */ (ulong)fd_ulong_find_msb_w_default( leaf_cnt-1UL, -1 /*irrelevant*/ ) + 2UL
   );
 }
@@ -176,7 +176,7 @@ fd_bmtree_node_cnt( ulong leaf_cnt ) {
 
 /* bmtree_commit_{footprint,align} return the alignment and footprint
    required for a memory region to be used as a bmtree_commit_t. */
-FD_FN_CONST ulong fd_bmtree_commit_align    ( void ) { return alignof(fd_bmtree_commit_t); }
+FD_FN_CONST ulong fd_bmtree_commit_align    ( void ) { return FD_BMTREE_COMMIT_ALIGN; }
 
 FD_FN_CONST ulong
 fd_bmtree_commit_footprint( ulong inclusion_proof_layer_cnt ) {
@@ -325,7 +325,7 @@ fd_bmtree_get_proof( fd_bmtree_commit_t * state,
 
   ulong leaf_cnt = state->leaf_cnt;
   ulong hash_sz  = state->hash_sz;
-  
+
   if( FD_UNLIKELY( leaf_idx >= leaf_cnt ) ) return 0UL;
 
   ulong inc_idx   = leaf_idx * 2UL;

--- a/src/ballet/bmtree/fd_bmtree.h
+++ b/src/ballet/bmtree/fd_bmtree.h
@@ -146,7 +146,7 @@ static uchar const fd_bmtree_node_prefix[32UL] __attribute__((aligned(32))) = "\
    for a 20 / 32 byte node size).  We declare it this way to make the
    structure very AVX friendly and to allow SHA256 to write directly
    into the hash even if BMTREE_HASH_SZ isn't 32. */
-struct __attribute__((aligned(32))) fd_bmtree_node {
+struct __attribute__((packed)) fd_bmtree_node {
   uchar hash[ 32 ]; /* Last bytes may not be meaningful */
 };
 


### PR DESCRIPTION
fuzz_bmtree was misusing the fd_bmtree API leading to segfaults
due to misaligned AVX accesses.  Relaxes alignment assumptions in
the fd_bmtree public API.

No visible performance loss reported by test_bmtree.
