### PR TITLE
config: fix combined coverage reports

### DIFF
--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -51,3 +51,4 @@ jobs:
           name: dist-cov-report
           fail_ci_if_error: false
           functionalities: search
+          flags: ci

--- a/config/base.mk
+++ b/config/base.mk
@@ -31,6 +31,7 @@ LLVM_PROFDATA?=llvm-profdata
 RUST_PROFILE=debug
 
 # lcov
+LCOV=lcov
 GENHTML=genhtml
 # newer versions of genhtml will require '-ignore-errors unmapped'
 

--- a/contrib/test/ci_tests.sh
+++ b/contrib/test/ci_tests.sh
@@ -35,7 +35,7 @@ for MACHINE in ${MACHINES[*]}; do
     make run-fuzz-test
     make run-script-test
     if [[ "$HAS_LLVM_COV" == 1 ]]; then
-      make "${OBJDIR}/cov/cov.profdata"
+      make "${OBJDIR}/cov/cov.lcov"
     fi
   fi
   export -n MACHINE


### PR DESCRIPTION
Using llvm-profdata to merge index profile data across different
builds is a bad idea.  It doesn't actually aggregate coverage
across builds, but rather selects a random object for each target
for reporting.  This resulted in underreporting of our AVX512 code.

This commit does merging via lcov instead.

Also updates CodeCov to give the base report the 'ci' flag.
