### PR TITLE
ci: enable carryforward for clusterfuzz codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,3 +3,7 @@ coverage:
     project: off
     patch: off
 comment: false
+flags:
+  clusterfuzz:
+    # We only report ClusterFuzz coverage nightly
+    carryforward: true


### PR DESCRIPTION
Fixes flickering of the clusterfuzz code coverage reports by making
them sticky across multiple commits.
