### PR TITLE
fd_txn: improve performance of iterating over accounts

### DIFF
--- a/src/ballet/pack/test_pack.c
+++ b/src/ballet/pack/test_pack.c
@@ -227,17 +227,18 @@ schedule_validate_microblock( fd_pack_t * pack,
     total_rewards += rewards;
 
     fd_acct_addr_t const * acct = fd_txn_get_acct_addrs( txn, txnp->payload );
-    fd_txn_acct_iter_t ctrl[1];
-    for( ulong j=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_WRITABLE_NONSIGNER_IMM, ctrl ); j<fd_txn_acct_iter_end();
-        j = fd_txn_acct_iter_next( j, ctrl ) ) {
+    for( fd_txn_acct_iter_t iter=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_WRITABLE_NONSIGNER_IMM );
+        iter!=fd_txn_acct_iter_end(); iter=fd_txn_acct_iter_next( iter ) ) {
+      ulong j=fd_txn_acct_iter_idx( iter );
       uchar b0 = acct[j].b[0]; uchar b1 = acct[j].b[1];
       if( (0x30UL<=b0) & (b0<0x70UL) & (b0==b1) ) {
         FD_TEST( !aset_test( write_accts, (ulong)b0-0x30 ) );
         write_accts = aset_insert( write_accts, (ulong)b0-0x30UL );
       }
     }
-    for( ulong j=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_READONLY_NONSIGNER_IMM, ctrl ); j<fd_txn_acct_iter_end();
-        j = fd_txn_acct_iter_next( j, ctrl ) ) {
+    for( fd_txn_acct_iter_t iter=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_READONLY_NONSIGNER_IMM );
+        iter!=fd_txn_acct_iter_end(); iter=fd_txn_acct_iter_next( iter ) ) {
+      ulong j=fd_txn_acct_iter_idx( iter );
       uchar b0 = acct[j].b[0]; uchar b1 = acct[j].b[1];
       if( (0x30UL<=b0) & (b0<0x70UL) & (b0==b1) )
         read_accts = aset_insert( read_accts, (ulong)b0-0x30UL );

--- a/src/ballet/txn/test_txn.c
+++ b/src/ballet/txn/test_txn.c
@@ -106,101 +106,101 @@ test_iter( fd_txn_t * txn,
            ulong      wa,
            ulong      ra ) {
 
-  ulong expected[128];
+  ulong expected[128] = { 0 };
   ulong expected_cnt = 0UL;
 
-  fd_txn_acct_iter_t ctrl;
-  ulong i;
+  fd_txn_acct_iter_t i;
 
-  ulong j, _j;
+  ulong j=0UL, _j=0UL;
 #define RESET() j=0UL; _j=0UL; expected_cnt=0UL
 #define INCLUDE(cnt) for( ulong i=0UL; i<(cnt); i++ ) { expected[ expected_cnt++ ]=_j+i; } _j += (cnt)
 #define SKIP(cnt)    _j+=(cnt)
 
-  i=fd_txn_acct_iter_init( txn, 0, &ctrl );
+  i=fd_txn_acct_iter_init( txn, 0 );
   RESET(); SKIP(ws); SKIP(rs); SKIP(wi); SKIP(ri); SKIP(wa); SKIP(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
 
-  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_WRITABLE_SIGNER, &ctrl );
+  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_WRITABLE_SIGNER );
   RESET(); INCLUDE(ws); SKIP(rs); SKIP(wi); SKIP(ri); SKIP(wa); SKIP(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
 
-  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_READONLY_SIGNER, &ctrl );
+  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_READONLY_SIGNER );
   RESET(); SKIP(ws); INCLUDE(rs); SKIP(wi); SKIP(ri); SKIP(wa); SKIP(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
 
-  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_WRITABLE_NONSIGNER_IMM, &ctrl );
+  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_WRITABLE_NONSIGNER_IMM );
   RESET(); SKIP(ws); SKIP(rs); INCLUDE(wi); SKIP(ri); SKIP(wa); SKIP(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
 
-  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_READONLY_NONSIGNER_IMM, &ctrl );
+  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_READONLY_NONSIGNER_IMM );
   RESET(); SKIP(ws); SKIP(rs); SKIP(wi); INCLUDE(ri); SKIP(wa); SKIP(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
 
-  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_WRITABLE_ALT, &ctrl );
+  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_WRITABLE_ALT );
   RESET(); SKIP(ws); SKIP(rs); SKIP(wi); SKIP(ri); INCLUDE(wa); SKIP(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
 
-  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_READONLY_ALT, &ctrl );
+  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_READONLY_ALT );
   RESET(); SKIP(ws); SKIP(rs); SKIP(wi); SKIP(ri); SKIP(wa); INCLUDE(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
 
-  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_IMM, &ctrl );
+  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_IMM );
   RESET(); INCLUDE(ws); INCLUDE(rs); INCLUDE(wi); INCLUDE(ri); SKIP(wa); SKIP(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
 
-  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_SIGNER, &ctrl );
+  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_SIGNER );
   RESET(); INCLUDE(ws); INCLUDE(rs); SKIP(wi); SKIP(ri); SKIP(wa); SKIP(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
 
-  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_NONSIGNER, &ctrl );
+  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_NONSIGNER );
   RESET(); SKIP(ws); SKIP(rs); INCLUDE(wi); INCLUDE(ri); INCLUDE(wa); INCLUDE(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
 
-  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_WRITABLE & FD_TXN_ACCT_CAT_IMM, &ctrl );
+  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_WRITABLE & FD_TXN_ACCT_CAT_IMM );
   RESET(); INCLUDE(ws); SKIP(rs); INCLUDE(wi); SKIP(ri); SKIP(wa); SKIP(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
 
-  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_READONLY & FD_TXN_ACCT_CAT_IMM, &ctrl );
+  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_READONLY & FD_TXN_ACCT_CAT_IMM );
   RESET(); SKIP(ws); INCLUDE(rs); SKIP(wi); INCLUDE(ri); SKIP(wa); SKIP(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
 
-  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_WRITABLE, &ctrl );
+  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_WRITABLE );
   RESET(); INCLUDE(ws); SKIP(rs); INCLUDE(wi); SKIP(ri); INCLUDE(wa); SKIP(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
 
-  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_READONLY, &ctrl );
+  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_READONLY );
   RESET(); SKIP(ws); INCLUDE(rs); SKIP(wi); INCLUDE(ri); SKIP(wa); INCLUDE(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
 
-  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_ALT, &ctrl );
+  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_ALT );
   RESET(); SKIP(ws); SKIP(rs); SKIP(wi); SKIP(ri); INCLUDE(wa); INCLUDE(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
 
-  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_NONE, &ctrl );
+  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_NONE );
   RESET(); SKIP(ws); SKIP(rs); SKIP(wi); SKIP(ri); SKIP(wa); SKIP(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
 
-  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_ALL, &ctrl );
+  i=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_ALL );
   RESET(); INCLUDE(ws); INCLUDE(rs); INCLUDE(wi); INCLUDE(ri); INCLUDE(wa); INCLUDE(ra);
-  for( ; i<fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i, &ctrl ) ) { FD_TEST( expected[ j++ ]==i ); }
+  for( ; i!=fd_txn_acct_iter_end(); i=fd_txn_acct_iter_next( i ) ) { FD_TEST( expected[ j++ ]==fd_txn_acct_iter_idx( i ) ); }
   FD_TEST( j==expected_cnt );
+
 }
 
 


### PR DESCRIPTION
After considering many approaches, I decided to stick with something close to the original design.  Switching to requiring a (very cheap) `fd_txn_acct_iter_idx` means that I no longer need the grossness of the separate control word that is passed by reference.