### PR TITLE
tpu_reasm: don't use frag_meta sigs

### DIFF
--- a/src/app/fdctl/topology.c
+++ b/src/app/fdctl/topology.c
@@ -208,9 +208,7 @@ fd_topo_workspace_fill( fd_topo_t *      topo,
       FD_TEST( !link->mtu );
       void * reasm = SCRATCH_ALLOC( fd_tpu_reasm_align(), fd_tpu_reasm_footprint( link->depth, link->burst ) );
       if( FD_LIKELY( mode==FD_TOPO_FILL_MODE_NEW ) ) {
-        fd_frag_meta_t * joined_mcache = fd_mcache_join( mcache );
-        FD_TEST( fd_tpu_reasm_new( reasm, link->depth, link->burst, 0UL, joined_mcache ) );
-        fd_mcache_leave( joined_mcache );
+        FD_TEST( fd_tpu_reasm_new( reasm, link->depth, link->burst, 0UL ) );
       } else if( FD_LIKELY( mode==FD_TOPO_FILL_MODE_JOIN ) ) {
         link->dcache = fd_tpu_reasm_join( reasm );
         if( FD_UNLIKELY( !link->dcache ) ) FD_LOG_ERR(( "fd_tpu_reasm_join failed" ));

--- a/src/disco/quic/fd_tpu_reasm_private.h
+++ b/src/disco/quic/fd_tpu_reasm_private.h
@@ -8,12 +8,37 @@
 #define FD_TPU_REASM_MAGIC (0xb4ef0d5ea766713cUL) /* random */
 
 /* fd_tpu_reasm_reset initializes all reassembly slots to their initial
-   state.  Also sets the 'sig' field of every mcache line. mcache is
-   assumed to be of depth reasm->depth. */
+   state.  Corrupts messages currently visible in mcache ring. */
 
 void
-fd_tpu_reasm_reset( fd_tpu_reasm_t * reasm,
-                    fd_frag_meta_t * mcache );
+fd_tpu_reasm_reset( fd_tpu_reasm_t * reasm );
+
+/* Accessors **********************************************************/
+
+static inline FD_FN_PURE fd_tpu_reasm_slot_t *
+fd_tpu_reasm_slots_laddr( fd_tpu_reasm_t * reasm ) {
+  return (fd_tpu_reasm_slot_t *)( (ulong)reasm + reasm->slots_off );
+}
+
+static inline FD_FN_PURE fd_tpu_reasm_slot_t const *
+fd_tpu_reasm_slots_laddr_const( fd_tpu_reasm_t const * reasm ) {
+  return (fd_tpu_reasm_slot_t const *)( (ulong)reasm + reasm->slots_off );
+}
+
+static inline FD_FN_PURE uint *
+fd_tpu_reasm_pub_slots_laddr( fd_tpu_reasm_t * reasm ) {
+  return (uint *)( (ulong)reasm + reasm->pub_slots_off );
+}
+
+static inline FD_FN_PURE uchar *
+fd_tpu_reasm_chunks_laddr( fd_tpu_reasm_t * reasm ) {
+  return (uchar *)( (ulong)reasm + reasm->chunks_off );
+}
+
+static inline FD_FN_PURE uchar const *
+fd_tpu_reasm_chunks_laddr_const( fd_tpu_reasm_t const * reasm ) {
+  return (uchar const *)( (ulong)reasm + reasm->chunks_off );
+}
 
 /* Slot class methods *************************************************/
 


### PR DESCRIPTION
Previously, fd_tpu_reasm used the fd_frag_meta_t sig field to store internal state metadata.  This was incompatible with the abstractions defined by fdctl.  In particular, initialization of a fd_tpu_reasm caused side effects on its assigned mcache (updating all sig fields). fdctl expects that tile objects and IPC objects are initialized separately.

With the new patch, this internal metadata is moved back to the fd_tpu_reasm.  This probably caused a slight performance regressions. However, the 'sig' field is now left empty so it can be repurposed for filtering at some later point.

Continuation of https://github.com/firedancer-io/firedancer/pull/1280