### PR TITLE
Added config for QUIC RETRY

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -223,6 +223,7 @@ static int parse_key_value( config_t *   config,
   ENTRY_UINT  ( ., tiles.quic,          max_inflight_quic_packets                                 );
   ENTRY_UINT  ( ., tiles.quic,          tx_buf_size                                               );
   ENTRY_UINT  ( ., tiles.quic,          idle_timeout_millis                                       );
+  ENTRY_BOOL  ( ., tiles.quic,          retry                                                     );
 
   ENTRY_UINT  ( ., tiles.verify,        receive_buffer_size                                       );
   ENTRY_UINT  ( ., tiles.verify,        mtu                                                       );
@@ -1023,6 +1024,7 @@ config_parse( int *      pargc,
         tile->quic.legacy_transaction_listen_port = config->tiles.quic.regular_transaction_listen_port;
         tile->quic.idle_timeout_millis = config->tiles.quic.idle_timeout_millis;
         strncpy( tile->quic.identity_key_path, config->consensus.identity_path, sizeof(tile->quic.identity_key_path) );
+        tile->quic.retry = config->tiles.quic.retry;
         break;
       case FD_TOPO_TILE_KIND_VERIFY:
         break;

--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -171,6 +171,7 @@ typedef struct {
       uint max_inflight_quic_packets;
       uint tx_buf_size;
       uint idle_timeout_millis;
+      int  retry;
 
     } quic;
 

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -721,6 +721,12 @@ dynamic_port_range = "8900-9000"
         # milliseconds
         idle_timeout_millis = 10000
 
+        # Whether QUIC RETRY is enabled
+        # QUIC RETRY is a feature to combat New Connection Request spamming
+        #
+        # This is a boolean
+        retry = true
+
     # Verify tiles perform signature verification of incoming
     # transactions, making sure that the data is well-formed, and that
     # it is signed by the appropriate private key.

--- a/src/app/fdctl/run/tiles/fd_quic.c
+++ b/src/app/fdctl/run/tiles/fd_quic.c
@@ -616,6 +616,7 @@ unprivileged_init( fd_topo_t *      topo,
   quic->config.net.listen_udp_port        = tile->quic.quic_transaction_listen_port;
   quic->config.idle_timeout               = tile->quic.idle_timeout_millis * 1000000UL;
   quic->config.initial_rx_max_stream_data = 1<<15;
+  quic->config.retry                      = tile->quic.retry;
   fd_memcpy( quic->config.link.src_mac_addr, tile->quic.src_mac_addr, 6 );
 
   quic->config.sign         = fd_quic_tls_cv_signer;

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -225,7 +225,8 @@ typedef struct {
       ushort quic_transaction_listen_port;
       ushort legacy_transaction_listen_port;
       ulong  idle_timeout_millis;
-      char  identity_key_path[ PATH_MAX ];
+      char   identity_key_path[ PATH_MAX ];
+      int    retry;
     } quic;
 
     struct {


### PR DESCRIPTION
RETRY functionality couldn't be accessed thru fddev or fdctl