### PR TITLE
poh: fix rare hang

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -696,12 +696,8 @@ topo_initialize( config_t * config ) {
      will never send more than one leader message until the pack tile
      must acknowledge it with a packing done frag, so there will be at
      most one in flight at any time. */
-  /**/                 fd_topob_tile_in(  topo, "pack",    0UL,          "metric_in", "poh_pack",     0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
-  /* These pack to bank links are reliable, but they are flow controlled
-     by the busy flag that sits between them.  We don't mark them
-     reliable here because it creates a reliable link loop (poh -> pack
-     -> bank) which leads to credit starvation. */
-  FOR(bank_tile_cnt)   fd_topob_tile_in(  topo, "bank",   i,             "metric_in", "pack_bank",    0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
+  /**/                 fd_topob_tile_in(  topo, "pack",   0UL,           "metric_in", "poh_pack",     0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
+  FOR(bank_tile_cnt)   fd_topob_tile_in(  topo, "bank",   i,             "metric_in", "pack_bank",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   FOR(bank_tile_cnt)   fd_topob_tile_in(  topo, "poh",    0UL,           "metric_in", "bank_poh",     i,            FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_in(  topo, "poh",    0UL,           "metric_in", "stake_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_in(  topo, "poh",    0UL,           "metric_in", "pack_bank",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );


### PR DESCRIPTION
When the pack->bank link is unreliable, banks will in rare cases get overrun on their next microblock, if they take too long between when they release the fseq account lock, and then poll for the next fragment.  This is not OK, both because the accounts in the next microblock will get locked indefinitely (and the bank will be locked forever), but also PoH will not see the transaction count it expected from pack and will hang forever.