### PR TITLE
ballet: add Rust-compatible UTF-8 validator

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -399,3 +399,13 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=======================================================================
+
+The UTF-8 validator in src/ballet/fd_utf8.c is derived from the Rust
+standard library taken ca 2023-May.
+
+Source: https://github.com/rust-lang/rust/blob/master/library/core/src/str/validations.rs
+
+See https://github.com/rust-lang/rust/blob/master/LICENSE-APACHE for
+license information.  SPDX-License-Identifier: MIT or Apache-2.0

--- a/src/ballet/utf8/Local.mk
+++ b/src/ballet/utf8/Local.mk
@@ -1,0 +1,4 @@
+$(call add-hdrs,fd_utf8.h)
+$(call add-objs,fd_utf8,fd_ballet)
+$(call make-unit-test,test_utf8,test_utf8,fd_ballet fd_util)
+$(call run-unit-test,test_utf8)

--- a/src/ballet/utf8/fd_utf8.c
+++ b/src/ballet/utf8/fd_utf8.c
@@ -1,0 +1,80 @@
+#include "fd_utf8.h"
+
+/* Basic UTF-8 validator imported from Rust's core/src/str/validations.rs */
+
+/* FIXME: Add high-performance AVX version */
+
+static uchar const fd_utf8_char_width[ 256 ] = {
+  // 1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 1
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 2
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 3
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 4
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 5
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 6
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 7
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 8
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 9
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // A
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // B
+  0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // C
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // D
+  3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, // E
+  4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // F
+};
+
+FD_FN_PURE int
+fd_utf8_verify( char const * str,
+                ulong        sz ) {
+
+  char const *       cur = str;
+  char const * const end = cur+sz;
+
+  while( cur<end ) {
+    uint c0 = (uchar)*cur;
+    if( c0>=0x80U ) {
+      cur++;
+      ulong width = fd_utf8_char_width[ c0 ];
+      switch( width ) {
+      case 2: {
+        schar c1 = (schar)( *cur++ );
+        if( FD_UNLIKELY( (c1>=-64) ) )
+          return 0;
+        break;
+      }
+      case 3: {
+        uchar c1 = (uchar)( *cur++ );
+        schar c2 = (schar)( *cur++ );
+        if( FD_UNLIKELY(
+            !(   ( (c0==0xe0)&           (c1>=0xa0)&(c1<=0xbf) )
+               | ( (c0>=0xe1)&(c0<=0xec)&(c1>=0x80)&(c1<=0xbf) )
+               | ( (c0==0xed)&           (c1>=0x80)&(c1<=0x9f) )
+               | ( (c0>=0xee)&(c0<=0xef)&(c1>=0x80)&(c1<=0xbf) ) )
+            | (c2>=-64) ) )
+          return 0;
+        break;
+      }
+      case 4: {
+        uchar c1 = (uchar)( *cur++ );
+        schar c2 = (schar)( *cur++ );
+        schar c3 = (schar)( *cur++ );
+        if( FD_UNLIKELY(
+            !(   ( (c0==0xf0)&           (c1>=0x90)&(c1<=0xbf) )
+               | ( (c0>=0xf1)&(c0<=0xf3)&(c1>=0x80)&(c1<=0xbf) )
+               | ( (c0==0xf4)&           (c1>=0x80)&(c1<=0x8f) ) )
+            | (c2>=-64)
+            | (c3>=-64) ) )
+          return 0;
+        break;
+      }
+      default:
+        return 0;
+      }
+    } else {
+      cur++;
+    }
+  }
+
+  return 1;
+}

--- a/src/ballet/utf8/fd_utf8.h
+++ b/src/ballet/utf8/fd_utf8.h
@@ -1,0 +1,41 @@
+#ifndef HEADER_fd_src_ballet_utf8_fd_utf8_h
+#define HEADER_fd_src_ballet_utf8_fd_utf8_h
+
+#include "../fd_ballet_base.h"
+
+/* fd_utf8_verify checks whether a byte array contains valid UTF-8.
+
+   This function matches the validation rules of Rust's
+   std::str::from_utf8.
+   https://doc.rust-lang.org/std/str/fn.from_utf8.html
+
+   The validation rules are:
+
+     1. Each code point must be one to four bytes long.
+     1.1. 1-byte code points must be in [U+0000,U+0080) (US-ASCII)
+          The zero byte is not considered a code point.
+     1.2. 2-byte code points must be in [U+0080,U+0800)
+     1.3. 3-byte code points must be in [U+0800,U+10000)
+           excluding UTF-16 surrogates [U+D800,U+D900)
+     1.4. 4-byte code points must be in [U+10000,U+110000)
+
+     2. Zero bytes are treated as a one byte code point (notably, zero
+        bytes do not fail validation, nor do they terminate the string)
+
+     3. Each encoded code point starts with a control char and is
+        followed by zero or more continuation chars.  The number of
+        continuation chars is indicated by the control char;  Out-of-
+        place continuation chars are treated as an error.
+
+     4. It is not checked whether code points are valid Unicode
+        characters.
+
+   str points to the first byte of the UTF-8 string (not a C string).
+   sz is the number of bytes in the string.  Assumes that str+sz does
+   not overflow.  str is ignored if sz==0UL. */
+
+FD_FN_PURE int
+fd_utf8_verify( char const * str,
+                ulong        sz );
+
+#endif /* HEADER_fd_src_ballet_utf8_fd_utf8_h */

--- a/src/ballet/utf8/test_utf8.c
+++ b/src/ballet/utf8/test_utf8.c
@@ -1,0 +1,80 @@
+#include "fd_utf8.h"
+#include <assert.h>
+
+struct fd_utf8_test_vector {
+  char const * input;
+  uint         sz;
+  int          result;
+};
+
+typedef struct fd_utf8_test_vector fd_utf8_test_vector_t;
+
+/* Test vectors imported from
+   https://github.com/rust-lang/rust/blob/master/library/alloc/tests/str.rs */
+
+static fd_utf8_test_vector_t const _single_glyph_vec[] = {
+  { NULL,               0UL, 1 },
+  { "\xc0\x80",         2UL, 0 },
+  { "\xc0\xae",         2UL, 0 },
+  { "\xe0\x80\x80",     3UL, 0 },
+  { "\xe0\x80\xaf",     3UL, 0 },
+  { "\xe0\x81\x81",     3UL, 0 },
+  { "\xf0\x82\x82\xac", 4UL, 0 },
+  { "\xf4\x90\x80\x80", 4UL, 0 },
+  { "\xED\xA0\x80",     3UL, 0 },
+  { "\xED\xBF\xBF",     3UL, 0 },
+  { "\xC2\x80",         2UL, 1 },
+  { "\xDF\xBF",         2UL, 1 },
+  { "\xE0\xA0\x80",     3UL, 1 },
+  { "\xED\x9F\xBF",     3UL, 1 },
+  { "\xEE\x80\x80",     3UL, 1 },
+  { "\xEF\xBF\xBF",     3UL, 1 },
+  { "\xF0\x90\x80\x80", 4UL, 1 },
+  { "\xF4\x8F\xBF\xBF", 4UL, 1 },
+  {0}
+};
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  /* Check single glyphs */
+
+  for( fd_utf8_test_vector_t const * vec = _single_glyph_vec; vec->input; vec++ ) {
+    FD_TEST( fd_utf8_verify( vec->input, vec->sz ) == vec->result );
+
+    for( ulong sz=1UL; sz < vec->sz; sz++ ) {
+      /* Smaller size */
+      FD_TEST( fd_utf8_verify( vec->input, sz ) == -1 );
+      /* Insert null byte */
+      char input[ 8 ];
+      fd_memcpy( input, vec->input, vec->sz );
+      input[ sz-1UL ] = '\0';
+      FD_TEST( fd_utf8_verify( input, vec->sz ) == -1 );
+    }
+  }
+
+  /* Check any combination of (single glyph, single glyph) -- O(n^2) */
+
+  for( fd_utf8_test_vector_t const * vec0 = _single_glyph_vec; vec0->input; vec0++ ) {
+    for( fd_utf8_test_vector_t const * vec1 = _single_glyph_vec; vec1->input; vec1++ ) {
+      char  input[8];
+      ulong input_sz = 0UL;
+
+      assert( vec0->sz + vec1->sz <= sizeof(input) );
+
+      fd_memcpy( input, vec0->input, vec0->sz );
+      input_sz += vec0->sz;
+      fd_memcpy( input+input_sz, vec1->input, vec1->sz );
+      input_sz += vec1->sz;
+
+      FD_TEST( fd_utf8_verify( input, input_sz ) == (vec0->result & vec1->result) );
+    }
+  }
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}
+


### PR DESCRIPTION
Partially reverts commit 8a8c95a3798ec1b17054e698bdc4cdae34855447, which removed the UTF-8 validator last year.
