### PR TITLE
stream pool implementation. fd_quic_conn_set_max_stream flow control

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -248,6 +248,7 @@ static int parse_key_value( config_t *   config,
   ENTRY_UINT  ( ., tiles.quic,          txn_reassembly_count                                      );
   ENTRY_UINT  ( ., tiles.quic,          max_concurrent_connections                                );
   ENTRY_UINT  ( ., tiles.quic,          max_concurrent_streams_per_connection                     );
+  ENTRY_UINT  ( ., tiles.quic,          stream_pool_cnt                                           );
   ENTRY_UINT  ( ., tiles.quic,          max_concurrent_handshakes                                 );
   ENTRY_UINT  ( ., tiles.quic,          max_inflight_quic_packets                                 );
   ENTRY_UINT  ( ., tiles.quic,          tx_buf_size                                               );

--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -827,6 +827,7 @@ topo_initialize( config_t * config ) {
       tile->quic.idle_timeout_millis            = config->tiles.quic.idle_timeout_millis;
       tile->quic.retry                          = config->tiles.quic.retry;
       tile->quic.max_concurrent_streams_per_connection = config->tiles.quic.max_concurrent_streams_per_connection;
+      tile->quic.stream_pool_cnt                = config->tiles.quic.stream_pool_cnt;
 
     } else if( FD_UNLIKELY( !strcmp( tile->name, "verify" ) ) ) {
 

--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -185,6 +185,7 @@ typedef struct {
       uint txn_reassembly_count;
       uint max_concurrent_connections;
       uint max_concurrent_streams_per_connection;
+      uint stream_pool_cnt;
       uint max_concurrent_handshakes;
       uint max_inflight_quic_packets;
       uint tx_buf_size;

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -496,7 +496,7 @@ dynamic_port_range = "8900-9000"
     #
     # It is suggested to use all available CPU cores for Firedancer, so
     # that the Solana network can run as fast as possible.
-    affinity = "0-21"
+    affinity = "1-22"
 
     # In addition to the Firedancer tiles which use a core each, the
     # current version of Firedancer hosts a Solana Labs (Agave)
@@ -689,7 +689,7 @@ dynamic_port_range = "8900-9000"
         # underlying link bandwidth.  Supporting more streams per
         # connection currently has a memory footprint cost on the order
         # of kilobytes per stream, per connection.
-        max_concurrent_streams_per_connection = 16
+        max_concurrent_streams_per_connection = 32
 
         # QUIC uses a fixed-size pool of streams to use for all the
         # connections in the QUIC instance.  When a new connection is
@@ -699,7 +699,7 @@ dynamic_port_range = "8900-9000"
         # every connection can be used.  This means that this value MUST
         # be at least as high as max_concurrent_connections.
         # The size of the pool is defined here:
-        stream_pool_cnt = 8192
+        stream_pool_cnt = 65536
 
         # Controls how much transactions coming in via TPU can be
         # reassembled at the same time.  Reassembly is required for user
@@ -724,7 +724,7 @@ dynamic_port_range = "8900-9000"
         # above.
         #
         # TODO: This should be removed.
-        max_concurrent_handshakes = 32
+        max_concurrent_handshakes = 2048
 
         # QUIC has a concept of a "QUIC packet", there can be multiple
         # of these inside a UDP packet.  Each QUIC packet we send to the
@@ -737,7 +737,7 @@ dynamic_port_range = "8900-9000"
         # rather than the underlying link bandwidth.  If you have a lot
         # of memory available and are constrained by this, it can make
         # sense to increase.
-        max_inflight_quic_packets = 4096
+        max_inflight_quic_packets = 65536
 
         # TODO: This should be removed.  We never transmit stream data
         # so this should be unused.
@@ -755,7 +755,7 @@ dynamic_port_range = "8900-9000"
         # QUIC retry is a feature to combat new connection request
         # spamming.  See rfc9000 8.1.2 for more details.  This flag
         # determines whether the feature is enabled in the validator.
-        retry = true
+        retry = false
 
     # Verify tiles perform signature verification of incoming
     # transactions, making sure that the data is well-formed, and that

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -691,6 +691,16 @@ dynamic_port_range = "8900-9000"
         # of kilobytes per stream, per connection.
         max_concurrent_streams_per_connection = 16
 
+        # QUIC uses a fixed-size pool of streams to use for all the
+        # connections in the QUIC instance.  When a new connection is
+        # established, QUIC attempts to allocate stream objects to it for
+        # incoming peer-initiated streams. Locally-initiated streams are
+        # allocated explicitly.  One stream per connection is reserved, so
+        # every connection can be used.  This means that this value MUST
+        # be at least as high as max_concurrent_connections.
+        # The size of the pool is defined here:
+        stream_pool_cnt = 8192
+
         # Controls how much transactions coming in via TPU can be
         # reassembled at the same time.  Reassembly is required for user
         # transactions larger than ca ~1200 bytes, as these arrive

--- a/src/app/fdctl/run/tiles/fd_quic.c
+++ b/src/app/fdctl/run/tiles/fd_quic.c
@@ -103,11 +103,16 @@ quic_limits( fd_topo_tile_t const * tile ) {
     .conn_id_sparsity                              = 0.0,
     .inflight_pkt_cnt                              = tile->quic.max_inflight_quic_packets,
     .tx_buf_sz                                     = tile->quic.tx_buf_size,
-    .stream_cnt[ FD_QUIC_STREAM_TYPE_BIDI_CLIENT ] = 0,
-    .stream_cnt[ FD_QUIC_STREAM_TYPE_BIDI_SERVER ] = 0,
+    .stream_cnt[ FD_QUIC_STREAM_TYPE_BIDI_CLIENT ] = 2,
+    .stream_cnt[ FD_QUIC_STREAM_TYPE_BIDI_SERVER ] = 3,
     .stream_cnt[ FD_QUIC_STREAM_TYPE_UNI_CLIENT  ] = tile->quic.max_concurrent_streams_per_connection,
-    .stream_cnt[ FD_QUIC_STREAM_TYPE_UNI_SERVER  ] = 0,
+    .stream_cnt[ FD_QUIC_STREAM_TYPE_UNI_SERVER  ] = 4,
+    .initial_stream_cnt[ FD_QUIC_STREAM_TYPE_BIDI_CLIENT ] = 2,
+    .initial_stream_cnt[ FD_QUIC_STREAM_TYPE_BIDI_SERVER ] = 3,
+    .initial_stream_cnt[ FD_QUIC_STREAM_TYPE_UNI_CLIENT  ] = tile->quic.max_concurrent_streams_per_connection,
+    .initial_stream_cnt[ FD_QUIC_STREAM_TYPE_UNI_SERVER  ] = 4,
     .stream_sparsity                               = 0.0,
+    .stream_pool_cnt                               = tile->quic.stream_pool_cnt,
   };
   return limits;
 }

--- a/src/app/fddev/txn.c
+++ b/src/app/fddev/txn.c
@@ -145,9 +145,14 @@ txn_cmd_fn( args_t *         args,
                     0UL,   // FD_QUIC_STREAM_TYPE_BIDI_SERVER
                     1UL,   // FD_QUIC_STREAM_TYPE_UNI_CLIENT
                     0UL }, // FD_QUIC_STREAM_TYPE_UNI_SERVER
+    .initial_stream_cnt = { 0UL,   // FD_QUIC_STREAM_TYPE_BIDI_CLIENT
+                            0UL,   // FD_QUIC_STREAM_TYPE_BIDI_SERVER
+                            1UL,   // FD_QUIC_STREAM_TYPE_UNI_CLIENT
+                            0UL }, // FD_QUIC_STREAM_TYPE_UNI_SERVER
     .stream_sparsity  = 4.0,
     .inflight_pkt_cnt = 64UL,
-    .tx_buf_sz        = 1UL<<15UL
+    .tx_buf_sz        = 1UL<<15UL,
+    .stream_pool_cnt  = 16
   };
   ulong quic_footprint = fd_quic_footprint( &quic_limits );
   FD_TEST( quic_footprint );

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -150,6 +150,7 @@ typedef struct {
       ulong  max_inflight_quic_packets;
       ulong  tx_buf_size;
       ulong  max_concurrent_streams_per_connection;
+      ulong  stream_pool_cnt;
       uint   ip_addr;
       uchar  src_mac_addr[ 6 ];
       ushort quic_transaction_listen_port;

--- a/src/waltz/quic/Local.mk
+++ b/src/waltz/quic/Local.mk
@@ -1,6 +1,6 @@
 $(call make-lib,fd_quic)
 $(call add-objs,fd_quic fd_quic_conn fd_quic_conn_id fd_quic_conn_map fd_quic_proto \
-  fd_quic_stream tls/fd_quic_tls crypto/fd_quic_crypto_suites templ/fd_quic_transport_params \
+ fd_quic_stream_pool   fd_quic_stream tls/fd_quic_tls crypto/fd_quic_crypto_suites templ/fd_quic_transport_params \
   templ/fd_quic_parse_util fd_quic_pkt_meta,fd_quic)
 $(call make-bin,fd_quic_ctl,fd_quic_ctl,fd_quic fd_tls fd_ballet fd_waltz fd_util)
 $(call add-test-scripts,test_quic_ctl)

--- a/src/waltz/quic/crypto/fd_quic_crypto_suites.c
+++ b/src/waltz/quic/crypto/fd_quic_crypto_suites.c
@@ -25,14 +25,15 @@ void
 fd_quic_crypto_ctx_init( fd_quic_crypto_ctx_t * ctx ) {
 
   /* initialize suites map */
-#define EACH( ID, SUITE, MAJ, MIN, PKT, HP, HASHFN, KEY_SZ, IV_SZ, ... ) \
+#define EACH( ID, SUITE, MAJ, MIN, PKT, HP, HASHFN, KEY_SZ, IV_SZ, PKT_LIMIT, ... ) \
   ctx->suites[ ID ].id         = ID;                       \
   ctx->suites[ ID ].major      = MAJ;                      \
   ctx->suites[ ID ].minor      = MIN;                      \
   ctx->suites[ ID ].key_sz     = KEY_SZ;                   \
   ctx->suites[ ID ].iv_sz      = IV_SZ;                    \
   ctx->suites[ ID ].hmac_fn    = fd_hmac_##HASHFN;         \
-  ctx->suites[ ID ].hash_sz    = FD_QUIC_HASH_SZ_##HASHFN;
+  ctx->suites[ ID ].hash_sz    = FD_QUIC_HASH_SZ_##HASHFN; \
+  ctx->suites[ ID ].pkt_limit  = PKT_LIMIT;
   FD_QUIC_CRYPTO_SUITE_LIST( EACH, )
 #undef EACH
 }

--- a/src/waltz/quic/crypto/fd_quic_crypto_suites.h
+++ b/src/waltz/quic/crypto/fd_quic_crypto_suites.h
@@ -31,9 +31,9 @@
 
 /* TLS suites
 
-    id,  suite name,                   major, minor, pkt cipher,        hp cipher,   hash,   key sz, iv sz */
+    id,  suite name,                   major, minor, pkt cipher,        hp cipher,   hash,   key sz, iv sz, packet limit */
 #define FD_QUIC_CRYPTO_SUITE_LIST( X, ... ) \
-  X( 0, TLS_AES_128_GCM_SHA256,        0x13,  0x01,  AES_128_GCM,       AES_128_ECB, sha256, 16,     12, __VA_ARGS__ )
+  X( 0, TLS_AES_128_GCM_SHA256,        0x13,  0x01,  AES_128_GCM,       AES_128_ECB, sha256, 16,     12,    1UL<<23, __VA_ARGS__ )
 
 
 #define FD_QUIC_ENC_LEVEL_LIST( X, ... ) \
@@ -65,6 +65,7 @@ struct fd_quic_crypto_suite {
   int   minor;
   ulong key_sz;
   ulong iv_sz;
+  ulong pkt_limit;
 
   fd_hmac_fn_t       hmac_fn;     /* not owned */
   ulong              hash_sz;

--- a/src/waltz/quic/fd_quic.h
+++ b/src/waltz/quic/fd_quic.h
@@ -614,7 +614,7 @@ uint fd_quic_tx_buffered_raw( fd_quic_t      * quic,
 
 /* FD_DEBUG_MODE: set to enable debug-only code
    TODO move to util? */
-#ifndef FD_DEBUG_MODE
+#ifdef FD_DEBUG_MODE
 #define FD_DEBUG(...) __VA_ARGS__
 #else
 #define FD_DEBUG(...)

--- a/src/waltz/quic/fd_quic.h
+++ b/src/waltz/quic/fd_quic.h
@@ -81,90 +81,15 @@
 
 /* TODO provide fd_quic on non-hosted targets */
 
+#include "fd_quic_enum.h"
+
 #include "../aio/fd_aio.h"
 #include "../tls/fd_tls.h"
 #include "../../util/fd_util.h"
+#include "../../util/rng/fd_rng.h"
 
 /* FD_QUIC_API marks public API declarations.  No-op for now. */
 #define FD_QUIC_API
-
-/* FD_QUIC_{SUCCESS,FAILED} are used for error return codes. */
-#define FD_QUIC_SUCCESS (0)
-#define FD_QUIC_FAILED  (1)
-
-/* FD_QUIC_TYPE_{UNI,BI}DIR indicate stream type. */
-#define FD_QUIC_TYPE_BIDIR  (0)
-#define FD_QUIC_TYPE_UNIDIR (1)
-
-/* FD_QUIC_ALIGN specifies the alignment needed for an fd_quic_t.
-   This is provided to facilitate compile-time QUIC declarations.
-   Also see fd_quic_align() */
-#define FD_QUIC_ALIGN (4096UL)  /* 4KiB */
-
-/* FD_QUIC_MTU is the assumed network link MTU in bytes, including L2
-   and L3 headers. */
-#define FD_QUIC_MTU (1500)
-
-/* FD_QUIC_INITIAL_PAYLOAD_SZ_MIN is the min byte size of the UDP payload
-   of Initial-type packets.  Mandated for both clients and servers as a
-   form of MTU discovery and to mitigate amplification attacks.  See
-   RFC 9000 Section 14.1:
-   https://datatracker.ietf.org/doc/html/rfc9000#name-initial-datagram-size */
-#define FD_QUIC_INITIAL_PAYLOAD_SZ_MIN (1200)
-#define FD_QUIC_INITIAL_PAYLOAD_SZ_MAX (FD_QUIC_INITIAL_PAYLOAD_SZ_MIN)
-
-/* Tokens (both RETRY and NEW_TOKEN) are specified by varints. We bound it to
-   77 bytes. Both our and quinn's RETRY tokens are 77 bytes, but our client
-   needs to be able to handle other server impl's of RETRY too.
-
-   FIXME change this bound (requires variable-length encoding). */
-#define FD_QUIC_TOKEN_SZ_MAX (77)
-/* Retry packets don't carry a token length field, so we infer it from the
-   footprint of a packet with a zero-length token and zero-length conn ids. */
-#define FD_QUIC_EMPTY_RETRY_PKT_SZ (23)
-
-/* FD_QUIC_MAX_PAYLOAD_SZ is the max byte size of the UDP payload of any
-   QUIC packets.  Derived from FD_QUIC_MTU by subtracting the typical
-   IPv4 header (no options) and UDP header sizes. */
-#define FD_QUIC_MAX_PAYLOAD_SZ (FD_QUIC_MTU - 20 - 8)
-
-/* FD_QUIC_ROLE_{CLIENT,SERVER} identify the fd_quic_t's role as a
-   client or server. */
-#define FD_QUIC_ROLE_CLIENT 1
-#define FD_QUIC_ROLE_SERVER 2
-
-/* FD_QUIC_SEND_ERR_* are negative int error codes indicating a stream
-   send failure.
-   ...INVAL_STREAM: Not allowed to send for stream ID (e.g. not open)
-   ...INVAL_CONN:   Connection not in valid state for sending
-   ...FIN:          Not allowed to send, stream finished */
-#define FD_QUIC_SEND_ERR_INVAL_STREAM (-1)
-#define FD_QUIC_SEND_ERR_INVAL_CONN   (-2)
-#define FD_QUIC_SEND_ERR_STREAM_FIN   (-3)
-
-/* FD_QUIC_MIN_CONN_ID_CNT: min permitted conn ID count per conn */
-#define FD_QUIC_MIN_CONN_ID_CNT (4UL)
-
-/* FD_QUIC_DEFAULT_SPARSITY: default fd_quic_limits_t->conn_id_sparsity */
-#define FD_QUIC_DEFAULT_SPARSITY (2.5)
-
-/* FD_QUIC_STREAM_TYPE_* indicate stream type (two least significant
-   bits of a stream ID).  These values are persisted to logs.  Entries
-   should not be renumbered and numeric values should never be reused. */
-#define FD_QUIC_STREAM_TYPE_BIDI_CLIENT 0
-#define FD_QUIC_STREAM_TYPE_BIDI_SERVER 1
-#define FD_QUIC_STREAM_TYPE_UNI_CLIENT  2
-#define FD_QUIC_STREAM_TYPE_UNI_SERVER  3
-
-/* FD_QUIC_NOTIFY_* indicate stream notification types.
-   ...END:   Stream lifetime has ended, no more callbacks will be
-             generated for it.  Stream will be freed after event
-             delivery.
-   ...RESET: Peer has reset the stream (will not send)
-   ...ABORT: Peer has aborted the stream (will not receive) */
-#define FD_QUIC_NOTIFY_END   (100)
-#define FD_QUIC_NOTIFY_RESET (101)
-#define FD_QUIC_NOTIFY_ABORT (102)
 
 /* Forward declarations */
 
@@ -182,19 +107,22 @@ typedef struct fd_quic_state_private fd_quic_state_t;
    (i.e. outlasts joins, until fd_quic_delete) */
 
 struct __attribute__((aligned(16UL))) fd_quic_limits {
-  ulong  conn_cnt;         /* instance-wide, max concurrent conn count      */
-  ulong  handshake_cnt;    /* instance-wide, max concurrent handshake count */
+  ulong  conn_cnt;              /* instance-wide, max concurrent conn count              */
+  ulong  handshake_cnt;         /* instance-wide, max concurrent handshake count         */
 
-  ulong  conn_id_cnt;      /* per-conn, max conn ID count (min 4UL) */
-  double conn_id_sparsity; /* per-conn, conn ID hashmap sparsity    */
+  ulong  conn_id_cnt;           /* per-conn, max conn ID count (min 4UL)                 */
+  double conn_id_sparsity;      /* per-conn, conn ID hashmap sparsity                    */
 
-  ulong  stream_cnt[4];    /* per-conn, max concurrent stream count */
-  double stream_sparsity;  /* per-conn, stream hashmap sparsity     */
+  ulong  stream_cnt[4];         /* per-conn, max concurrent stream count                 */
+  ulong  initial_stream_cnt[4]; /* per-conn, initial target max concurrent stream count  */
+  double stream_sparsity;       /* per-conn, stream hashmap sparsity                     */
 
-  ulong  inflight_pkt_cnt; /* per-conn, max inflight packet count   */
+  ulong  inflight_pkt_cnt;      /* per-conn, max inflight packet count                   */
 
-  ulong  tx_buf_sz;        /* per-stream, tx buf sz in bytes          */
+  ulong  tx_buf_sz;             /* per-stream, tx buf sz in bytes                        */
   /* the user consumes rx directly from the network buffer */
+
+  ulong  stream_pool_cnt;  /* instance-wide, number of streams in stream pool */
 };
 typedef struct fd_quic_limits fd_quic_limits_t;
 

--- a/src/waltz/quic/fd_quic_conn.c
+++ b/src/waltz/quic/fd_quic_conn.c
@@ -2,6 +2,7 @@
 #include "fd_quic_common.h"
 #include "../../util/fd_util.h"
 #include "fd_quic_pkt_meta.h"
+#include "fd_quic_private.h"
 
 /* define a map for stream_id -> stream* */
 #define MAP_NAME              fd_quic_stream_map
@@ -17,7 +18,6 @@ struct fd_quic_conn_layout {
   ulong stream_cnt;
   ulong stream_ptr_off;
   ulong stream_footprint;
-  ulong stream_off;
   int   stream_map_lg;
   ulong stream_map_off;
   ulong pkt_meta_off;
@@ -60,27 +60,20 @@ fd_quic_conn_footprint_ext( fd_quic_limits_t const * limits,
     stream_sparsity = FD_QUIC_DEFAULT_SPARSITY;
   }
 
+  /* initial stream count not allowed to be larger than max stream count limit */
+  if( FD_UNLIKELY( limits->initial_stream_cnt[0] > limits->stream_cnt[0] ) ) return 0UL;
+  if( FD_UNLIKELY( limits->initial_stream_cnt[1] > limits->stream_cnt[1] ) ) return 0UL;
+  if( FD_UNLIKELY( limits->initial_stream_cnt[2] > limits->stream_cnt[2] ) ) return 0UL;
+  if( FD_UNLIKELY( limits->initial_stream_cnt[3] > limits->stream_cnt[3] ) ) return 0UL;
+
   ulong off  = 0;
 
   off += sizeof( fd_quic_conn_t );
 
-  /* allocate space for stream pointers
-     FIXME: for now assuming stream cnt is same for each 4 types of streams */
-  off                     = fd_ulong_align_up( off, alignof(void *) );
-  layout->stream_ptr_off  = off;
-  off                    += stream_cnt * sizeof(void *);
-
-  /* allocate space for stream instances */
-  ulong   stream_footprint = fd_quic_stream_footprint( tx_buf_sz );
-  layout->stream_footprint = stream_footprint;
-
-  off                 = fd_ulong_align_up( off, fd_quic_stream_align() );
-  layout->stream_off  = off;
-  off                += stream_cnt*stream_footprint;
-
   /* allocate space for stream hash map */
+  /* about a million seems like a decent bound, with expected values up to 20,000 */
   ulong lg = 0;
-  while( lg < 40 && (1ul<<lg) < (ulong)((double)stream_cnt*stream_sparsity) ) {
+  while( lg < 20 && (1ul<<lg) < (ulong)((double)stream_cnt*stream_sparsity) ) {
     lg++;
   }
   layout->stream_map_lg = (int)lg;
@@ -152,38 +145,16 @@ fd_quic_conn_new( void *                   mem,
 
   conn->quic             = quic;
   conn->stream_tx_buf_sz = limits->tx_buf_sz;
-  conn->tot_num_streams  = layout.stream_cnt;
   conn->state            = FD_QUIC_CONN_STATE_INVALID;
-
-  /* Initialize stream pointers */
-
-  conn->streams = (fd_quic_stream_t **)( (ulong)mem + layout.stream_ptr_off );
 
   /* Initialize streams */
 
   FD_QUIC_STREAM_LIST_SENTINEL( conn->send_streams );
-  FD_QUIC_STREAM_LIST_SENTINEL( conn->unused_streams );
-
-  fd_quic_stream_t * unused_streams = conn->unused_streams;
-
-  ulong stream_laddr = (ulong)mem + layout.stream_off;
-  for( ulong j=0; j < layout.stream_cnt; j++ ) {
-    fd_quic_stream_t * stream = fd_quic_stream_new(
-        (void *)stream_laddr, conn, limits->tx_buf_sz );
-    if( FD_UNLIKELY( !stream ) ) return NULL;
-
-    conn->streams[j] = stream;
-
-    /* insert into unused list */
-    FD_QUIC_STREAM_LIST_INSERT_BEFORE( unused_streams, stream );
-
-    stream_laddr += layout.stream_footprint;
-  }
+  FD_QUIC_STREAM_LIST_SENTINEL( conn->used_streams );
 
   /* Initialize stream hash map */
 
   ulong stream_map_laddr = (ulong)mem + layout.stream_map_off;
-  FD_TEST( stream_laddr <= stream_map_laddr );
   conn->stream_map = fd_quic_stream_map_join( fd_quic_stream_map_new( (void *)stream_map_laddr, layout.stream_map_lg ) );
   if( FD_UNLIKELY( !conn->stream_map ) ) return NULL;
 
@@ -224,4 +195,105 @@ fd_quic_conn_set_context( fd_quic_conn_t * conn, void * context ) {
 void *
 fd_quic_conn_get_context( fd_quic_conn_t * conn ) {
   return conn->context;
+}
+
+
+/* set the max concurrent streams value for the specified type
+   This is used to flow control the peer.
+
+   type is one of:
+     FD_QUIC_TYPE_UNIDIR
+     FD_QUIC_TYPE_BIDIR */
+FD_QUIC_API void
+fd_quic_conn_set_max_streams( fd_quic_conn_t * conn, uint dirtype, ulong stream_cnt ) {
+  if( FD_UNLIKELY( dirtype != FD_QUIC_TYPE_UNIDIR
+                && dirtype != FD_QUIC_TYPE_BIDIR ) ) {
+    FD_LOG_ERR(( "fd_quic_conn_set_max_stream called with invalid type" ));
+    return;
+  }
+
+  fd_quic_t *       quic  = conn->quic;
+
+  /* TODO align usage of "type" and "dirtype"
+     perhaps:
+       dir        - direction: bidir or unidir
+       role       - client or server
+       type       - dir | role */
+  uint peer = (uint)!conn->server;
+  uint type = peer + ( (uint)dirtype << 1u );
+
+  /* check the limit on stream_cnt */
+  if( FD_UNLIKELY( stream_cnt > quic->limits.stream_cnt[type] ) ) {
+    return;
+  }
+
+  /* store the desired value */
+  ulong max_concur_streams = conn->max_concur_streams[type] = stream_cnt;
+  ulong cur_stream_cnt     = conn->cur_stream_cnt[type];
+
+  /* how many remain */
+  ulong rem = fd_ulong_if( max_concur_streams > cur_stream_cnt,
+                           max_concur_streams - cur_stream_cnt,
+                           0UL );
+
+  /* set tgt_sup_stream_id */
+  conn->tgt_sup_stream_id[type] = conn->sup_stream_id[type] + ( rem << 2UL );
+
+  /* update the weight */
+
+  fd_quic_conn_update_weight( conn, dirtype );
+
+  /* reassign the streams */
+  fd_quic_assign_streams( conn->quic );
+}
+
+
+/* get the current value for the concurrent streams for the specified type
+
+   type is one of:
+     FD_QUIC_TYPE_UNIDIR
+     FD_QUIC_TYPE_BIDIR */
+FD_QUIC_API ulong
+fd_quic_conn_get_max_streams( fd_quic_conn_t * conn, uint dirtype ) {
+  uint peer = (uint)!conn->server;
+  uint type = peer + ( (uint)dirtype << 1u );
+  return conn->max_concur_streams[type];
+}
+
+/* update the tree weight
+   called whenever weight may have changed */
+void
+fd_quic_conn_update_weight( fd_quic_conn_t * conn, uint dirtype ) {
+  if( FD_UNLIKELY( dirtype != FD_QUIC_TYPE_UNIDIR
+                && dirtype != FD_QUIC_TYPE_BIDIR ) ) {
+    FD_LOG_ERR(( "fd_quic_conn_update_weight called with invalid type" ));
+    return;
+  }
+
+  /* TODO align usage of "type" and "dirtype"
+     perhaps:
+       dir        - direction: bidir or unidir
+       role       - client or server
+       type       - dir | role */
+  uint peer = (uint)!conn->server;
+  uint type = peer + ( (uint)dirtype << 1u );
+
+  /* get tgt_sup_stream_id, sup_stream_id */
+  ulong tgt_sup_stream_id = conn->tgt_sup_stream_id[type];
+  ulong sup_stream_id     = conn->sup_stream_id[type];
+
+  /* update the cs_tree */
+
+  /* determine the weight */
+
+  ulong weight = fd_ulong_if( tgt_sup_stream_id > sup_stream_id,
+                              ( tgt_sup_stream_id - sup_stream_id ) >> 2UL,
+                              0UL );
+
+  /* set the weight in the cs_tree */
+  fd_quic_cs_tree_t * cs_tree = fd_quic_get_state( conn->quic )->cs_tree;
+  ulong               idx     = ( conn->conn_idx << 1UL ) + dirtype;
+  fd_quic_cs_tree_update( cs_tree, idx, weight );
+
+  /* don't assign streams here to avoid unwanted recursion */
 }

--- a/src/waltz/quic/fd_quic_conn.c
+++ b/src/waltz/quic/fd_quic_conn.c
@@ -290,6 +290,11 @@ fd_quic_conn_update_weight( fd_quic_conn_t * conn, uint dirtype ) {
                               ( tgt_sup_stream_id - sup_stream_id ) >> 2UL,
                               0UL );
 
+  if( conn->state != FD_QUIC_CONN_STATE_ACTIVE &&
+      conn->state != FD_QUIC_CONN_STATE_HANDSHAKE_COMPLETE ) {
+    weight = 0;
+  }
+
   /* set the weight in the cs_tree */
   fd_quic_cs_tree_t * cs_tree = fd_quic_get_state( conn->quic )->cs_tree;
   ulong               idx     = ( conn->conn_idx << 1UL ) + dirtype;

--- a/src/waltz/quic/fd_quic_conn.h
+++ b/src/waltz/quic/fd_quic_conn.h
@@ -240,6 +240,7 @@ struct fd_quic_conn {
   ulong exp_pkt_number[3]; /* different packet number spaces:
                                  INITIAL, HANDSHAKE and APPLICATION */
   ulong pkt_number[3];     /* tx packet number by pn space */
+  ulong last_pkt_number[3]; /* last (highest) packet numer seen */
 
   ushort ipv4_id;           /* ipv4 id field */
 
@@ -301,6 +302,8 @@ struct fd_quic_conn {
 # define FD_QUIC_CONN_FLAGS_CLOSE_SENT         (1u<<1u)
 # define FD_QUIC_CONN_FLAGS_MAX_STREAMS_UNIDIR (1u<<2u)
 # define FD_QUIC_CONN_FLAGS_MAX_STREAMS_BIDIR  (1u<<3u)
+# define FD_QUIC_CONN_FLAGS_PING               (1u<<4u)
+# define FD_QUIC_CONN_FLAGS_PING_SENT          (1u<<5u)
 
   uchar                spin_bit;                   /* spin bit used for latency measurements */
 

--- a/src/waltz/quic/fd_quic_conn_id.h
+++ b/src/waltz/quic/fd_quic_conn_id.h
@@ -13,7 +13,9 @@ extern ulong fd_quic_conn_id_hash_seed;
 #define FD_QUIC_MAX_CONN_ID_SZ 20
 
 /* max number of connection ids per connection */
-#define FD_QUIC_MAX_CONN_ID_PER_CONN 4
+/* NOTE QUINN seems to ignore our active_connection_id_limit transport parameter */
+/*      So setting this to 16 */
+#define FD_QUIC_MAX_CONN_ID_PER_CONN 16
 
 /* Firedancer connection ids will sized thus */
 #define FD_QUIC_CONN_ID_SZ 8

--- a/src/waltz/quic/fd_quic_enum.h
+++ b/src/waltz/quic/fd_quic_enum.h
@@ -1,0 +1,86 @@
+#ifndef HEADER_fd_src_tango_quic_fd_quic_enum_h
+#define HEADER_fd_src_tango_quic_fd_quic_enum_h
+
+
+/* FD_QUIC_STREAM_TYPE_* indicate stream type (two least significant
+   bits of a stream ID) */
+#define FD_QUIC_STREAM_TYPE_BIDI_CLIENT 0
+#define FD_QUIC_STREAM_TYPE_BIDI_SERVER 1
+#define FD_QUIC_STREAM_TYPE_UNI_CLIENT  2
+#define FD_QUIC_STREAM_TYPE_UNI_SERVER  3
+
+/* FD_QUIC_{SUCCESS,FAILED} are used for error return codes. */
+#define FD_QUIC_SUCCESS (0)
+#define FD_QUIC_FAILED  (1)
+
+/* FD_QUIC_TYPE_{UNI,BI}DIR indicate stream type. */
+#define FD_QUIC_TYPE_BIDIR  (0)
+#define FD_QUIC_TYPE_UNIDIR (1)
+
+/* FD_QUIC_ALIGN specifies the alignment needed for an fd_quic_t.
+   This is provided to facilitate compile-time QUIC declarations.
+   Also see fd_quic_align() */
+#define FD_QUIC_ALIGN (4096UL)  /* 4KiB */
+
+/* FD_QUIC_MTU is the assumed network link MTU in bytes, including L2
+   and L3 headers. */
+#define FD_QUIC_MTU (1500)
+
+/* FD_QUIC_INITIAL_PAYLOAD_SZ_MIN is the min byte size of the UDP payload
+   of Initial-type packets.  Mandated for both clients and servers as a
+   form of MTU discovery and to mitigate amplification attacks.  See
+   RFC 9000 Section 14.1:
+   https://datatracker.ietf.org/doc/html/rfc9000#name-initial-datagram-size */
+#define FD_QUIC_INITIAL_PAYLOAD_SZ_MIN (1200)
+#define FD_QUIC_INITIAL_PAYLOAD_SZ_MAX (FD_QUIC_INITIAL_PAYLOAD_SZ_MIN)
+
+/* Tokens (both RETRY and NEW_TOKEN) are specified by varints. We bound it to
+   77 bytes. Both our and quinn's RETRY tokens are 77 bytes, but our client
+   needs to be able to handle other server impl's of RETRY too.
+
+   FIXME change this bound (requires variable-length encoding). */
+#define FD_QUIC_TOKEN_SZ_MAX (77)
+/* Retry packets don't carry a token length field, so we infer it from the
+   footprint of a packet with a zero-length token and zero-length conn ids. */
+#define FD_QUIC_EMPTY_RETRY_PKT_SZ (23)
+
+/* FD_QUIC_MAX_PAYLOAD_SZ is the max byte size of the UDP payload of any
+   QUIC packets.  Derived from FD_QUIC_MTU by subtracting the typical
+   IPv4 header (no options) and UDP header sizes. */
+#define FD_QUIC_MAX_PAYLOAD_SZ (FD_QUIC_MTU - 20 - 8)
+
+/* FD_QUIC_ROLE_{CLIENT,SERVER} identify the fd_quic_t's role as a
+   client or server. */
+#define FD_QUIC_ROLE_CLIENT 1
+#define FD_QUIC_ROLE_SERVER 2
+
+/* FD_QUIC_SEND_ERR_* are negative int error codes indicating a stream
+   send failure.
+   ...INVAL_STREAM: Not allowed to send for stream ID (e.g. not open)
+   ...INVAL_CONN:   Connection not in valid state for sending
+   ...FIN:          Not allowed to send, stream finished
+   ...STREAM_STATE: Stream is not (yet) in valid state to send */
+#define FD_QUIC_SEND_ERR_INVAL_STREAM (-1)
+#define FD_QUIC_SEND_ERR_INVAL_CONN   (-2)
+#define FD_QUIC_SEND_ERR_STREAM_FIN   (-3)
+#define FD_QUIC_SEND_ERR_STREAM_STATE (-3)
+
+/* FD_QUIC_MIN_CONN_ID_CNT: min permitted conn ID count per conn */
+#define FD_QUIC_MIN_CONN_ID_CNT (4UL)
+
+/* FD_QUIC_DEFAULT_SPARSITY: default fd_quic_limits_t->conn_id_sparsity */
+#define FD_QUIC_DEFAULT_SPARSITY (2.5)
+
+/* FD_QUIC_NOTIFY_* indicate stream notification types.
+   ...END:   Stream lifetime has ended, no more callbacks will be
+             generated for it.  Stream will be freed after event
+             delivery.
+   ...RESET: Peer has reset the stream (will not send)
+   ...ABORT: Peer has aborted the stream (will not receive) */
+#define FD_QUIC_NOTIFY_END   (100)
+#define FD_QUIC_NOTIFY_RESET (101)
+#define FD_QUIC_NOTIFY_ABORT (102)
+
+
+#endif
+

--- a/src/waltz/quic/fd_quic_pkt_meta.h
+++ b/src/waltz/quic/fd_quic_pkt_meta.h
@@ -91,6 +91,7 @@ struct fd_quic_pkt_meta {
        FD_QUIC_PKT_META_FLAGS_CLOSE               close frame
        FD_QUIC_PKT_META_FLAGS_KEY_UPDATE          indicates key update was in effect
        FD_QUIC_PKT_META_FLAGS_KEY_PHASE           set only if key_phase was set in the short-header
+       FD_QUIC_PKT_META_FLAGS_PING                set to send a PING frame
 
      some of these flags are mutually exclusive */
   uint                   flags;       /* flags */
@@ -105,6 +106,7 @@ struct fd_quic_pkt_meta {
 # define          FD_QUIC_PKT_META_FLAGS_CLOSE              (1u<<8u)
 # define          FD_QUIC_PKT_META_FLAGS_KEY_UPDATE         (1u<<9u)
 # define          FD_QUIC_PKT_META_FLAGS_KEY_PHASE          (1u<<10u)
+# define          FD_QUIC_PKT_META_FLAGS_PING               (1u<<11u)
   fd_quic_range_t        range;       /* range of bytes referred to by this meta */
                                       /* stream data or crypto data */
                                       /* we currently do not put both in the same packet */

--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -60,6 +60,8 @@ struct __attribute__((aligned(16UL))) fd_quic_state_private {
   ulong flags;
 # define FD_QUIC_FLAGS_ASSIGN_STREAMS (1ul<<1ul)
 
+  ulong now; /* the time we entered into fd_quic_service, or fd_quic_aio_cb_receive */
+
   /* Pointer to TLS state (part of quic memory region) */
 
   fd_quic_tls_t * tls;
@@ -383,8 +385,11 @@ fd_quic_choose_weighted_index( fd_quic_cs_tree_t * cs_tree, fd_rng_t * rng );
 
 /* fd_quic_cs_tree_total returns the total value across all the leaves in */
 /* the supplied cs_tree                                                   */
-ulong
-fd_quic_cs_tree_total( fd_quic_cs_tree_t * cs_tree );
+static inline ulong
+fd_quic_cs_tree_total( fd_quic_cs_tree_t * cs_tree ) {
+  /* total is the value at node_idx = 1 (which is the root) */
+  return cs_tree->values[1UL];
+}
 
 /* fd_quic_cs_tree_footprint returns the amount of memory required for a  */
 /* cs_tree over cnt elements                                              */

--- a/src/waltz/quic/fd_quic_stream.c
+++ b/src/waltz/quic/fd_quic_stream.c
@@ -152,6 +152,9 @@ fd_quic_stream_new( void * mem, fd_quic_conn_t * conn, ulong tx_buf_sz ) {
   stream->conn      = conn;
   stream->stream_id = FD_QUIC_STREAM_ID_UNUSED;
 
+  /* stream pointing to itself is not a member of any list */
+  stream->next = stream->prev = stream;
+
   return stream;
 }
 
@@ -161,8 +164,9 @@ fd_quic_stream_new( void * mem, fd_quic_conn_t * conn, ulong tx_buf_sz ) {
      stream       the stream to free */
 void
 fd_quic_stream_delete( fd_quic_stream_t * stream ) {
-  /* nothing to do */
-  (void)stream;
+  /* stream pointing to itself is not a member of any list */
+  stream->next = stream->prev = stream;
+  stream->list_memb = FD_QUIC_STREAM_LIST_MEMB_NONE;
 }
 
 
@@ -187,4 +191,15 @@ fd_quic_stream_set_context( fd_quic_stream_t * stream, void * context ) {
 void *
 fd_quic_stream_get_context( fd_quic_stream_t * stream ) {
   return stream->context;
+}
+
+
+/* set stream connection
+
+   args
+     stream      the stream to change
+     conn        the connection to set on the stream or NULL to remove the connection */
+void
+fd_quic_stream_set_conn( fd_quic_stream_t * stream, fd_quic_conn_t * conn ) {
+  stream->conn = conn;
 }

--- a/src/waltz/quic/fd_quic_stream.h
+++ b/src/waltz/quic/fd_quic_stream.h
@@ -61,18 +61,26 @@ struct fd_quic_stream {
 
   uint sentinel; /* does this stream represent a sentinel? */
 
-  /* send and receive state
+  /* stream state
      mask made up of the following:
+       FD_QUIC_STREAM_STATE_UNUSED      Stream is not yet used
        FD_QUIC_STREAM_STATE_TX_FIN      TX is finished (no more TX)
        FD_QUIC_STREAM_STATE_RX_FIN      RX is finished (no more RX)
        FD_QUIC_STREAM_STATE_DEAD        stream is dead and waiting to be
-	                                  reclaimed */
+	                                reclaimed, or is in stream_pool */
   uint state;
+# define FD_QUIC_STREAM_STATE_DEAD   0u
 # define FD_QUIC_STREAM_STATE_TX_FIN (1u<<0u)
 # define FD_QUIC_STREAM_STATE_RX_FIN (1u<<1u)
-# define FD_QUIC_STREAM_STATE_DEAD   (1u<<2u)
+# define FD_QUIC_STREAM_STATE_UNUSED (1u<<2u)
 
 # define FD_QUIC_DEFAULT_INITIAL_RX_MAX_STREAM_DATA 1280  // IPv6 minimum MTU
+
+  uint list_memb; /* list membership */
+# define FD_QUIC_STREAM_LIST_MEMB_NONE   0
+# define FD_QUIC_STREAM_LIST_MEMB_UNUSED 1
+# define FD_QUIC_STREAM_LIST_MEMB_USED   2
+# define FD_QUIC_STREAM_LIST_MEMB_SEND   3
 
   /* flow control */
   ulong  tx_max_stream_data; /* the limit on the number of bytes we are allowed to send
@@ -114,6 +122,15 @@ struct fd_quic_stream {
   do {                                                         \
     FD_QUIC_STREAM_LIST_LINK( stream, stream );                \
     stream->sentinel = 1;                                      \
+    stream->stream_id = ~(0UL);                                \
+  } while(0)
+
+/* initialize non-sentinel stream
+   stream just points to itself, at first */
+#define FD_QUIC_STREAM_LIST_INIT_STREAM( stream )              \
+  do {                                                         \
+    FD_QUIC_STREAM_LIST_LINK( stream, stream );                \
+    stream->sentinel = 0;                                      \
   } while(0)
 
 /* insert new_stream after stream in list */
@@ -132,7 +149,9 @@ struct fd_quic_stream {
     FD_QUIC_STREAM_LIST_LINK( stream_prev, new_stream );        \
   } while(0)
 
-/* remove stream from list */
+/* remove stream from list
+
+   a stream pointing to itself is not in a list */
 #define FD_QUIC_STREAM_LIST_REMOVE( stream )                    \
   do {                                                          \
     fd_quic_stream_t * stream_prev = (stream)->prev;            \
@@ -218,8 +237,25 @@ fd_quic_stream_set_context( fd_quic_stream_t * stream, void * context );
 void *
 fd_quic_stream_get_context( fd_quic_stream_t * stream );
 
+/* set rx max stream data
+
+   This allows the peer to send more data on this stream
+
+   args
+     stream               the stream to change
+     rx_max_stream_data   the new max_stream_data to set on the stream */
 void
 fd_quic_stream_set_rx_max_stream_data( fd_quic_stream_t * stream, ulong rx_max_stream_data );
+
+
+/* set stream connection
+
+   args
+     stream      the stream to change
+     conn        the connection to set on the stream or NULL to remove the connection */
+void
+fd_quic_stream_set_conn( fd_quic_stream_t * stream, fd_quic_conn_t * conn );
+
 
 FD_PROTOTYPES_END
 

--- a/src/waltz/quic/fd_quic_stream_pool.c
+++ b/src/waltz/quic/fd_quic_stream_pool.c
@@ -1,0 +1,112 @@
+#include "fd_quic_stream_pool.h"
+
+#include "../../util/fd_util.h"
+
+/* returns the required footprint of fd_quic_stream_pool_t
+
+   args
+     count        the number of streams the pool will manage
+     tx_buf_sz    the size of the tx buffer
+                  should be 0 for RX only streams */
+FD_FN_CONST
+ulong
+fd_quic_stream_pool_footprint( ulong count, ulong tx_buf_sz ) {
+  ulong foot =  fd_ulong_align_up( sizeof( fd_quic_stream_pool_t ),
+      FD_QUIC_STREAM_POOL_ALIGN );
+
+  ulong stream_foot = fd_quic_stream_footprint( tx_buf_sz );
+
+  return foot + stream_foot * count;
+}
+
+/* returns a newly initialized stream pool
+
+   args
+     mem          the memory aligned to fd_quic_stream_pool_align, and at least fd_quic_stream_pool_footprint
+                    bytes
+     count        the number of streams the pool will manage
+     type         the stream type used for the streams managed by this pool */
+fd_quic_stream_pool_t *
+fd_quic_stream_pool_new( void * mem, ulong count, ulong tx_buf_sz ) {
+  ulong offs   = 0;
+  ulong ul_mem = (ulong)mem;
+
+  fd_quic_stream_pool_t * pool = (fd_quic_stream_pool_t*)ul_mem;
+  memset( pool, 0, sizeof( fd_quic_stream_pool_t ) );
+
+  pool->cap     = count;
+  pool->cur_cnt = 0UL;
+
+  offs += fd_ulong_align_up( sizeof( fd_quic_stream_pool_t ), FD_QUIC_STREAM_POOL_ALIGN );
+
+  ulong stream_foot = fd_quic_stream_footprint( tx_buf_sz );
+
+  FD_QUIC_STREAM_LIST_SENTINEL( pool->head );
+
+  /* allocate count streams */
+  for( ulong j = 0; j < count; ++j ) {
+    fd_quic_stream_t * stream = fd_quic_stream_new( (void*)( ul_mem + offs ), NULL, tx_buf_sz );
+
+    FD_QUIC_STREAM_LIST_INIT_STREAM( stream );
+    FD_QUIC_STREAM_LIST_INSERT_BEFORE( pool->head, stream );
+    pool->cur_cnt++;
+
+    offs += stream_foot;
+
+  }
+
+  return pool;
+}
+
+
+/* delete a stream pool
+
+   this will also delete all the associated streams
+
+   All streams should be freed back to the pool before this function is called
+
+   args
+     stream_pool  the stream pool to free */
+void
+fd_quic_stream_pool_delete( fd_quic_stream_pool_t * stream_pool ) {
+  (void)stream_pool;
+}
+
+
+/* allocates a stream from the pool 
+
+   args
+     stream_pool  the pool from which to obtain the stream
+
+   returns
+     the newly allocated stream, or NULL if no streams are available */
+fd_quic_stream_t *
+fd_quic_stream_pool_alloc( fd_quic_stream_pool_t * pool ) {
+  fd_quic_stream_t * stream_sentinel = pool->head;
+  fd_quic_stream_t * stream          = stream_sentinel->next;
+
+  if( FD_UNLIKELY( stream == stream_sentinel ) ) {
+    /* no streams left in free list, return NULL */
+    return NULL;
+  }
+
+  /* remove from free list */
+  FD_QUIC_STREAM_LIST_REMOVE( stream );
+  pool->cur_cnt--;
+
+  return stream;
+}
+
+/* free a stream to the specified pool
+
+   args
+     stream_pool  the pool to return the stream to
+     stream       the stream to return */
+void
+fd_quic_stream_pool_free( fd_quic_stream_pool_t * pool,
+                          fd_quic_stream_t *      stream ) {
+  FD_QUIC_STREAM_LIST_INSERT_BEFORE( pool->head, stream );
+  pool->cur_cnt++;
+}
+
+

--- a/src/waltz/quic/fd_quic_stream_pool.c
+++ b/src/waltz/quic/fd_quic_stream_pool.c
@@ -1,4 +1,5 @@
 #include "fd_quic_stream_pool.h"
+#include "fd_quic_private.h"
 
 #include "../../util/fd_util.h"
 
@@ -109,4 +110,9 @@ fd_quic_stream_pool_free( fd_quic_stream_pool_t * pool,
   pool->cur_cnt++;
 }
 
-
+void
+fd_quic_stream_pool_free_batch( void ) {
+  /* TODO
+   * stream pool and used/send lists are both doubly linked lists
+   * so this can be achieved in O(1) */
+}

--- a/src/waltz/quic/fd_quic_stream_pool.h
+++ b/src/waltz/quic/fd_quic_stream_pool.h
@@ -1,0 +1,82 @@
+#ifndef HEADER_fd_src_tango_quic_fd_quic_stream_pool_h
+#define HEADER_fd_src_tango_quic_fd_quic_stream_pool_h
+
+#include "fd_quic_stream.h"
+
+/* stream pool alignment */
+#define FD_QUIC_STREAM_POOL_ALIGN 128ul
+
+struct fd_quic_stream_pool {
+  ulong              cap;     /* the capacity of the pool */
+  ulong              cur_cnt; /* the current number of streams in the pool */
+  fd_quic_stream_t   head[1]; /* the head of the linked list of free streams, or NULL if none */
+};
+
+typedef struct fd_quic_stream_pool fd_quic_stream_pool_t;
+
+FD_PROTOTYPES_BEGIN
+
+/* returns the alignment of the fd_quic_stream_pool_t */
+FD_FN_CONST inline
+ulong
+fd_quic_stream_pool_align( void ) {
+  return FD_QUIC_STREAM_POOL_ALIGN;
+}
+
+/* returns the required footprint of fd_quic_stream_pool_t
+
+   args
+     count        the number of streams the pool will manage */
+FD_FN_CONST
+ulong
+fd_quic_stream_pool_footprint( ulong count, ulong tx_buf_sz );
+
+/* returns a newly initialized stream pool
+
+   args
+     mem          the memory aligned to fd_quic_stream_pool_align, and at least fd_quic_stream_pool_footprint
+                    bytes
+     count        the number of streams the pool will manage
+     type         the stream type used for the streams managed by this pool */
+fd_quic_stream_pool_t *
+fd_quic_stream_pool_new( void * mem, ulong count, ulong tx_buf_sz );
+
+/* delete a stream pool
+
+   this will also delete all the associated streams
+
+   All streams should be freed back to the pool before this function is called
+
+   args
+     stream_pool  the stream pool to free */
+void
+fd_quic_stream_pool_delete( fd_quic_stream_pool_t * stream_pool );
+
+/* allocates a stream from the pool 
+
+   args
+     stream_pool  the pool from which to obtain the stream
+
+   returns
+     the newly allocated stream, or NULL if no streams are available */
+fd_quic_stream_t *
+fd_quic_stream_pool_alloc( fd_quic_stream_pool_t * pool );
+
+/* free a stream to the specified pool
+
+   args
+     stream_pool  the pool to return the stream to
+     stream       the stream to return */
+void
+fd_quic_stream_pool_free( fd_quic_stream_pool_t * pool, fd_quic_stream_t * stream );
+
+/* returns the number of streams available in the pool */
+static inline
+ulong
+fd_quic_stream_pool_avail( fd_quic_stream_pool_t * pool ) {
+  return pool->cur_cnt;
+}
+
+FD_PROTOTYPES_END
+
+#endif

--- a/src/waltz/quic/templ/fd_quic_transport_params.h
+++ b/src/waltz/quic/templ/fd_quic_transport_params.h
@@ -168,7 +168,7 @@ X( preferred_address,                                                           
 X( active_connection_id_limit,                                                         \
   0x0e,                                                                                \
   VARINT,                                                                              \
-  DFT_UNKNOWN,                                                                         \
+  2,                                                                                   \
   "This is an integer value specifying the maximum number of connection IDs from "     \
   "the peer that an endpoint is willing to store. This value includes the "            \
   "connection ID received during the handshake, that received in the "                 \

--- a/src/waltz/quic/tests/arp/test_quic_arp_client.c
+++ b/src/waltz/quic/tests/arp/test_quic_arp_client.c
@@ -241,13 +241,15 @@ main( int argc, char ** argv ) {
   fd_quic_limits_from_env( &argc, &argv, &quic_limits);
 #else
   fd_quic_limits_t const quic_limits = {
-    .conn_cnt         = 10,
-    .conn_id_cnt      = 10,
-    .conn_id_sparsity = 4.0,
-    .handshake_cnt    = 10,
-    .stream_cnt       = { 2, 2, 2, 2 },
-    .inflight_pkt_cnt = 1024,
-    .tx_buf_sz        = 1<<14,
+    .conn_cnt           = 10,
+    .conn_id_cnt        = 10,
+    .conn_id_sparsity   = 4.0,
+    .handshake_cnt      = 10,
+    .stream_cnt         = { 2, 2, 2, 2 },
+    .initial_stream_cnt = { 2, 2, 2, 2 },
+    .stream_pool_cnt    = 100,
+    .inflight_pkt_cnt   = 1024,
+    .tx_buf_sz          = 1<<14,
   };
 #endif
 

--- a/src/waltz/quic/tests/arp/test_quic_arp_server.c
+++ b/src/waltz/quic/tests/arp/test_quic_arp_server.c
@@ -123,13 +123,15 @@ main( int argc, char ** argv ) {
   fd_quic_limits_from_env( &argc, &argv, &quic_limits);
 #else
   fd_quic_limits_t const quic_limits = {
-    .conn_cnt         = 10,
-    .conn_id_cnt      = 10,
-    .conn_id_sparsity = 4.0,
-    .handshake_cnt    = 10,
-    .stream_cnt       = { 2, 2, 2, 2 },
-    .inflight_pkt_cnt = 1024,
-    .tx_buf_sz        = 1<<14,
+    .conn_cnt           = 10,
+    .conn_id_cnt        = 10,
+    .conn_id_sparsity   = 4.0,
+    .handshake_cnt      = 10,
+    .stream_cnt         = { 2, 2, 2, 2 },
+    .initial_stream_cnt = { 2, 2, 2, 2 },
+    .stream_pool_cnt    = 100,
+    .inflight_pkt_cnt   = 1024,
+    .tx_buf_sz          = 1<<14,
   };
 #endif
 

--- a/src/waltz/quic/tests/fd_quic_stream_spam.c
+++ b/src/waltz/quic/tests/fd_quic_stream_spam.c
@@ -111,6 +111,7 @@ fd_quic_stream_spam_service( fd_quic_conn_t *        conn,
 
   /* Create new streams
      Stop when QUIC quota runs out or stack limit reached */
+   ulong streams = 0;
 
   for( ulong avail=spam_pending_avail( pending ); avail>0; avail-- ) {
     fd_quic_stream_t * stream = fd_quic_conn_new_stream( conn, FD_QUIC_TYPE_UNIDIR );
@@ -119,6 +120,7 @@ fd_quic_stream_spam_service( fd_quic_conn_t *        conn,
     /* Insert stream into stack, set back reference */
     spam_pending_push( pending, stream );
     stream->context = &pending[ spam_pending_cnt( pending )-1UL ];
+    streams++;
   }
 
   /* Send streams */
@@ -166,8 +168,6 @@ fd_quic_stream_spam_notify( fd_quic_stream_t * stream,
 
   (void)stream;
   (void)notify_type;
-
-  //FD_LOG_DEBUG(( "client notify stream=%lu notify_type=%d", stream->stream_id, notify_type ));
 
   /* Nothing to do for completed streams */
   if( FD_LIKELY( !stream_ctx ) ) return;

--- a/src/waltz/quic/tests/fd_quic_stream_spam.c
+++ b/src/waltz/quic/tests/fd_quic_stream_spam.c
@@ -111,7 +111,6 @@ fd_quic_stream_spam_service( fd_quic_conn_t *        conn,
 
   /* Create new streams
      Stop when QUIC quota runs out or stack limit reached */
-   ulong streams = 0;
 
   for( ulong avail=spam_pending_avail( pending ); avail>0; avail-- ) {
     fd_quic_stream_t * stream = fd_quic_conn_new_stream( conn, FD_QUIC_TYPE_UNIDIR );
@@ -120,7 +119,6 @@ fd_quic_stream_spam_service( fd_quic_conn_t *        conn,
     /* Insert stream into stack, set back reference */
     spam_pending_push( pending, stream );
     stream->context = &pending[ spam_pending_cnt( pending )-1UL ];
-    streams++;
   }
 
   /* Send streams */

--- a/src/waltz/quic/tests/fuzz_quic.c
+++ b/src/waltz/quic/tests/fuzz_quic.c
@@ -163,7 +163,7 @@ int LLVMFuzzerInitialize(int *argc, char ***argv) {
                                         .handshake_cnt = 10,
                                         .stream_cnt = {0, 0, 10, 0},
                                         .initial_stream_cnt = {0, 0, 10, 0 },
-                                        .stream_pool_cnt = 200,
+                                        .stream_pool_cnt = 20,
                                         .inflight_pkt_cnt = 1024,
                                         .tx_buf_sz = 1 << 14};
 

--- a/src/waltz/quic/tests/fuzz_quic.c
+++ b/src/waltz/quic/tests/fuzz_quic.c
@@ -162,6 +162,8 @@ int LLVMFuzzerInitialize(int *argc, char ***argv) {
                                         .conn_id_sparsity = 4.0,
                                         .handshake_cnt = 10,
                                         .stream_cnt = {0, 0, 10, 0},
+                                        .initial_stream_cnt = {0, 0, 10, 0 },
+                                        .stream_pool_cnt = 200,
                                         .inflight_pkt_cnt = 1024,
                                         .tx_buf_sz = 1 << 14};
 

--- a/src/waltz/quic/tests/test_quic_bw.c
+++ b/src/waltz/quic/tests/test_quic_bw.c
@@ -80,13 +80,15 @@ main( int     argc,
   FD_TEST( wksp );
 
   fd_quic_limits_t const quic_limits = {
-    .conn_cnt         = 10,
-    .conn_id_cnt      = 10,
-    .conn_id_sparsity = 4.0,
-    .handshake_cnt    = 10,
-    .stream_cnt       = { 0, 0, 10, 0 },
-    .inflight_pkt_cnt = 100,
-    .tx_buf_sz        = 1<<20
+    .conn_cnt           = 10,
+    .conn_id_cnt        = 10,
+    .conn_id_sparsity   = 4.0,
+    .handshake_cnt      = 10,
+    .stream_cnt         = { 0, 0, 10, 0 },
+    .initial_stream_cnt = { 0, 0, 10, 0 },
+    .stream_pool_cnt    = 200,
+    .inflight_pkt_cnt   = 100,
+    .tx_buf_sz          = 1<<20
   };
 
   ulong quic_footprint = fd_quic_footprint( &quic_limits );

--- a/src/waltz/quic/tests/test_quic_conn.c
+++ b/src/waltz/quic/tests/test_quic_conn.c
@@ -193,6 +193,7 @@ my_stream_notify_cb( fd_quic_stream_t * stream, void * ctx, int type ) {
   }
 }
 
+ulong recv = 0;
 void
 my_stream_receive_cb( fd_quic_stream_t * stream,
                       void *             ctx,
@@ -206,7 +207,7 @@ my_stream_receive_cb( fd_quic_stream_t * stream,
 
   ulong expected_data_sz = 512ul;
 
-  FD_LOG_INFO(( "received data from peer. size: %lu offset: %lu\n",
+  FD_LOG_INFO(( "received data from peer. size: %lu offset: %lu",
                 data_sz, offset ));
   FD_LOG_HEXDUMP_DEBUG(( "received data", data, data_sz ));
 
@@ -224,6 +225,8 @@ my_stream_receive_cb( fd_quic_stream_t * stream,
   }
 
   FD_LOG_DEBUG(( "recv ok" ));
+
+  recv++;
 }
 
 
@@ -307,13 +310,15 @@ main( int argc, char ** argv ) {
   FD_TEST( wksp );
 
   fd_quic_limits_t const quic_limits = {
-    .conn_cnt         = 10,
-    .conn_id_cnt      = 10,
-    .conn_id_sparsity = 4.0,
-    .handshake_cnt    = 10,
-    .stream_cnt       = { 0, 0, 10, 0 },
-    .inflight_pkt_cnt = 1024,
-    .tx_buf_sz        = 1<<14
+    .conn_cnt           = 10,
+    .conn_id_cnt        = 10,
+    .conn_id_sparsity   = 4.0,
+    .handshake_cnt      = 10,
+    .stream_cnt         = { 0, 0, 10, 0 },
+    .initial_stream_cnt = { 0, 0, 10, 0 },
+    .stream_pool_cnt    = 400,
+    .inflight_pkt_cnt   = 1024,
+    .tx_buf_sz          = 1<<14
   };
 
   ulong quic_footprint = fd_quic_footprint( &quic_limits );
@@ -330,6 +335,7 @@ main( int argc, char ** argv ) {
 
   fd_quic_config_t * client_config = &client_quic->config;
   client_config->idle_timeout = 5e6;
+  client_config->service_interval = 1e6;
 
   client_quic->cb.conn_hs_complete = my_handshake_complete;
   client_quic->cb.stream_receive   = my_stream_receive_cb;
@@ -341,6 +347,7 @@ main( int argc, char ** argv ) {
 
   fd_quic_config_t * server_config = &server_quic->config;
   server_config->idle_timeout = 5e6;
+  server_config->service_interval = 1e6;
 
   server_quic->cb.conn_new       = my_connection_new;
   server_quic->cb.stream_receive = my_stream_receive_cb;
@@ -380,11 +387,13 @@ main( int argc, char ** argv ) {
     my_stream_meta_t * meta = NULL;
     now += 50000;
 
-    fd_quic_service( client_quic );
+    ulong client_wakeup = fd_quic_get_next_wakeup( client_quic );
+    ulong server_wakeup = fd_quic_get_next_wakeup( server_quic );
+    ulong earliest_wakeup = fd_ulong_min( client_wakeup, server_wakeup );
+    if( earliest_wakeup > now && earliest_wakeup != (ulong)(-1) ) now = earliest_wakeup;
 
-    if( (j%1)==0 ) {
-      fd_quic_service( server_quic );
-    }
+    fd_quic_service( client_quic );
+    fd_quic_service( server_quic );
 
     buf[12] = ' ';
     buf[15] = (char)( ( k / 10 ) + '0' );
@@ -472,6 +481,11 @@ main( int argc, char ** argv ) {
     }
 
   }
+
+  FD_LOG_NOTICE(( "Done sending. Received: %lu", recv ));
+
+  if( client_conn ) fd_quic_conn_close( client_conn, 0 );
+  if( server_conn ) fd_quic_conn_close( server_conn, 0 );
 
   FD_LOG_INFO(( "client_conn: %p", (void*)client_conn ));
   FD_LOG_INFO(( "server_conn: %p", (void*)server_conn ));

--- a/src/waltz/quic/tests/test_quic_conn.c
+++ b/src/waltz/quic/tests/test_quic_conn.c
@@ -193,7 +193,7 @@ my_stream_notify_cb( fd_quic_stream_t * stream, void * ctx, int type ) {
   }
 }
 
-ulong recv = 0;
+static ulong _recv = 0;
 void
 my_stream_receive_cb( fd_quic_stream_t * stream,
                       void *             ctx,
@@ -226,7 +226,7 @@ my_stream_receive_cb( fd_quic_stream_t * stream,
 
   FD_LOG_DEBUG(( "recv ok" ));
 
-  recv++;
+  _recv++;
 }
 
 
@@ -479,7 +479,7 @@ main( int argc, char ** argv ) {
 
   }
 
-  FD_LOG_NOTICE(( "Done sending. Received: %lu", recv ));
+  FD_LOG_NOTICE(( "Done sending. Received: %lu", _recv ));
 
   if( client_conn ) fd_quic_conn_close( client_conn, 0 );
   if( server_conn ) fd_quic_conn_close( server_conn, 0 );

--- a/src/waltz/quic/tests/test_quic_conn.c
+++ b/src/waltz/quic/tests/test_quic_conn.c
@@ -380,10 +380,7 @@ main( int argc, char ** argv ) {
 
   state = 1;
 
-  ulong j = 0;
   while( k < 4000 && !done ) {
-    j++;
-
     my_stream_meta_t * meta = NULL;
     now += 50000;
 

--- a/src/waltz/quic/tests/test_quic_drops.c
+++ b/src/waltz/quic/tests/test_quic_drops.c
@@ -473,13 +473,15 @@ main( int argc, char ** argv ) {
   FD_TEST( wksp );
 
   fd_quic_limits_t const quic_limits = {
-    .conn_cnt         = 10,
-    .conn_id_cnt      = 10,
-    .conn_id_sparsity = 4.0,
-    .handshake_cnt    = 10,
-    .stream_cnt       = { 0, 0, 10, 0 },
-    .inflight_pkt_cnt = 1024,
-    .tx_buf_sz        = 1<<14
+    .conn_cnt           = 10,
+    .conn_id_cnt        = 10,
+    .conn_id_sparsity   = 4.0,
+    .handshake_cnt      = 10,
+    .stream_cnt         = { 0, 0, 10, 0 },
+    .initial_stream_cnt = { 0, 0, 10, 0 },
+    .stream_pool_cnt    = 512,
+    .inflight_pkt_cnt   = 1024,
+    .tx_buf_sz          = 1<<14
   };
 
   ulong quic_footprint = fd_quic_footprint( &quic_limits );
@@ -496,6 +498,7 @@ main( int argc, char ** argv ) {
 
   fd_quic_config_t * client_config = &client_quic->config;
   client_config->idle_timeout = 5e9;
+  client_config->service_interval = 1e6;
 
   client_quic->cb.conn_hs_complete = my_handshake_complete;
   client_quic->cb.stream_receive   = my_stream_receive_cb;
@@ -509,6 +512,7 @@ main( int argc, char ** argv ) {
 
   fd_quic_config_t * server_config = &server_quic->config;
   server_config->idle_timeout = 5e9;
+  server_config->service_interval = 1e6;
 
   server_quic->cb.conn_new       = my_connection_new;
   server_quic->cb.stream_receive = my_stream_receive_cb;

--- a/src/waltz/quic/tests/test_quic_flow_control.c
+++ b/src/waltz/quic/tests/test_quic_flow_control.c
@@ -98,13 +98,15 @@ main( int argc, char ** argv ) {
   FD_TEST( wksp );
 
   fd_quic_limits_t const quic_limits = {
-    .conn_cnt         = 2,
-    .conn_id_cnt      = 4,
-    .conn_id_sparsity = 4.0,
-    .handshake_cnt    = 10,
-    .stream_cnt       = {0, 0, 2, 0},
-    .inflight_pkt_cnt = 100,
-    .tx_buf_sz        = 1<<16
+    .conn_cnt           = 10,
+    .conn_id_cnt        = 10,
+    .conn_id_sparsity   = 4.0,
+    .handshake_cnt      = 10,
+    .stream_cnt         = { 0, 0, 10, 0 },
+    .initial_stream_cnt = { 0, 0, 10, 0 },
+    .stream_pool_cnt    = 400,
+    .inflight_pkt_cnt   = 1024,
+    .tx_buf_sz          = 1<<14
   };
 
   ulong quic_footprint = fd_quic_footprint( &quic_limits );

--- a/src/waltz/quic/tests/test_quic_hs.c
+++ b/src/waltz/quic/tests/test_quic_hs.c
@@ -83,13 +83,15 @@ main( int argc, char ** argv ) {
   FD_TEST( wksp );
 
   fd_quic_limits_t const quic_limits = {
-    .conn_cnt         = 2,
-    .conn_id_cnt      = 4,
-    .conn_id_sparsity = 4.0,
-    .handshake_cnt    = 10,
-    .stream_cnt       = {0, 0, 2, 0},
-    .inflight_pkt_cnt = 100,
-    .tx_buf_sz        = 1<<16
+    .conn_cnt           = 10,
+    .conn_id_cnt        = 10,
+    .conn_id_sparsity   = 4.0,
+    .handshake_cnt      = 10,
+    .stream_cnt         = { 0, 0, 10, 0 },
+    .initial_stream_cnt = { 0, 0, 10, 0 },
+    .stream_pool_cnt    = 400,
+    .inflight_pkt_cnt   = 1024,
+    .tx_buf_sz          = 1<<14
   };
 
   ulong quic_footprint = fd_quic_footprint( &quic_limits );

--- a/src/waltz/quic/tests/test_quic_retry_integration.c
+++ b/src/waltz/quic/tests/test_quic_retry_integration.c
@@ -82,13 +82,15 @@ main( int argc, char ** argv ) {
   FD_TEST( wksp );
 
   fd_quic_limits_t const quic_limits = {
-    .conn_cnt         = 2,
-    .conn_id_cnt      = 4,
-    .conn_id_sparsity = 4.0,
-    .handshake_cnt    = 10,
-    .stream_cnt       = {0, 0, 2, 0},
-    .inflight_pkt_cnt = 100,
-    .tx_buf_sz        = 1<<16
+    .conn_cnt           = 10,
+    .conn_id_cnt        = 10,
+    .conn_id_sparsity   = 4.0,
+    .handshake_cnt      = 10,
+    .stream_cnt         = { 0, 0, 10, 0 },
+    .initial_stream_cnt = { 0, 0, 10, 0 },
+    .stream_pool_cnt    = 400,
+    .inflight_pkt_cnt   = 1024,
+    .tx_buf_sz          = 1<<14
   };
 
   ulong quic_footprint = fd_quic_footprint( &quic_limits );

--- a/src/waltz/quic/tests/test_quic_txn.c
+++ b/src/waltz/quic/tests/test_quic_txn.c
@@ -183,17 +183,22 @@ main( int argc,
   FD_TEST( wksp );
 
   fd_quic_limits_t quic_limits = {
-     .conn_cnt         = 1024UL,
-     .handshake_cnt    = 256UL,
-     .conn_id_cnt      = 16UL,
-     .conn_id_sparsity = 4.0,
-     .stream_cnt = { 0UL,   // FD_QUIC_STREAM_TYPE_BIDI_CLIENT
-                     0UL,   // FD_QUIC_STREAM_TYPE_BIDI_SERVER
-                     2UL,   // FD_QUIC_STREAM_TYPE_UNI_CLIENT
-                     0UL }, // FD_QUIC_STREAM_TYPE_UNI_SERVER
-     .stream_sparsity  = 4.0,
-     .inflight_pkt_cnt = 64UL,
-     .tx_buf_sz        = 1UL<<15UL
+     .conn_cnt           = 1024UL,
+     .handshake_cnt      = 256UL,
+     .conn_id_cnt        = 16UL,
+     .conn_id_sparsity   = 4.0,
+     .stream_cnt         = { 0UL,   // FD_QUIC_STREAM_TYPE_BIDI_CLIENT
+                             0UL,   // FD_QUIC_STREAM_TYPE_BIDI_SERVER
+                             2UL,   // FD_QUIC_STREAM_TYPE_UNI_CLIENT
+                             0UL }, // FD_QUIC_STREAM_TYPE_UNI_SERVER
+     .initial_stream_cnt = { 0UL,   // FD_QUIC_STREAM_TYPE_BIDI_CLIENT
+                             0UL,   // FD_QUIC_STREAM_TYPE_BIDI_SERVER
+                             2UL,   // FD_QUIC_STREAM_TYPE_UNI_CLIENT
+                             0UL }, // FD_QUIC_STREAM_TYPE_UNI_SERVER
+     .stream_pool_cnt    = 2048UL,
+     .stream_sparsity    = 4.0,
+     .inflight_pkt_cnt   = 64UL,
+     .tx_buf_sz          = 1UL<<15UL
   };
   ulong quic_footprint = fd_quic_footprint( &quic_limits );
   FD_TEST( quic_footprint );

--- a/src/waltz/quic/tests/test_quic_txns.c
+++ b/src/waltz/quic/tests/test_quic_txns.c
@@ -261,17 +261,22 @@ main( int argc,
   FD_TEST( wksp );
 
   fd_quic_limits_t quic_limits = {
-     .conn_cnt         = 1024UL,
-     .handshake_cnt    = 256UL,
-     .conn_id_cnt      = 16UL,
-     .conn_id_sparsity = 4.0,
-     .stream_cnt = { 0UL,   // FD_QUIC_STREAM_TYPE_BIDI_CLIENT
-                     0UL,   // FD_QUIC_STREAM_TYPE_BIDI_SERVER
-                     2UL,   // FD_QUIC_STREAM_TYPE_UNI_CLIENT
-                     0UL }, // FD_QUIC_STREAM_TYPE_UNI_SERVER
-     .stream_sparsity  = 4.0,
-     .inflight_pkt_cnt = 64UL,
-     .tx_buf_sz        = 1UL<<15UL
+     .conn_cnt           = 1024UL,
+     .handshake_cnt      = 256UL,
+     .conn_id_cnt        = 16UL,
+     .conn_id_sparsity   = 4.0,
+     .stream_cnt         = { 0UL,   // FD_QUIC_STREAM_TYPE_BIDI_CLIENT
+                             0UL,   // FD_QUIC_STREAM_TYPE_BIDI_SERVER
+                             2UL,   // FD_QUIC_STREAM_TYPE_UNI_CLIENT
+                             0UL }, // FD_QUIC_STREAM_TYPE_UNI_SERVER
+     .initial_stream_cnt = { 0UL,   // FD_QUIC_STREAM_TYPE_BIDI_CLIENT
+                             0UL,   // FD_QUIC_STREAM_TYPE_BIDI_SERVER
+                             2UL,   // FD_QUIC_STREAM_TYPE_UNI_CLIENT
+                             0UL }, // FD_QUIC_STREAM_TYPE_UNI_SERVER
+     .stream_pool_cnt    = 2048UL,
+     .stream_sparsity    = 4.0,
+     .inflight_pkt_cnt   = 64UL,
+     .tx_buf_sz          = 1UL<<15UL
   };
   ulong quic_footprint = fd_quic_footprint( &quic_limits );
   FD_TEST( quic_footprint );


### PR DESCRIPTION
Connections currently preallocate a fixed number of streams. This PR replaces that functionality with a pool of streams such that different connections may be allocated different numbers of streams. 