### PR TITLE
netmux: copy packets to avoid corruption

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -659,7 +659,7 @@ topo_initialize( config_t * config ) {
 
   /*                                  topo, link_name,      wksp_name,      is_reasm, depth,                                    mtu,                    burst */
   FOR(net_tile_cnt)    fd_topob_link( topo, "net_netmux",   "netmux_inout", 0,        config->tiles.net.send_buffer_size,       FD_NET_MTU,             1UL );
-  /**/                 fd_topob_link( topo, "netmux_out",   "netmux_inout", 0,        config->tiles.net.send_buffer_size,       0UL,                    1UL );
+  /**/                 fd_topob_link( topo, "netmux_out",   "netmux_inout", 0,        config->tiles.net.send_buffer_size,       FD_NET_MTU,             1UL );
   FOR(quic_tile_cnt)   fd_topob_link( topo, "quic_netmux",  "netmux_inout", 0,        config->tiles.net.send_buffer_size,       FD_NET_MTU,             1UL );
   /**/                 fd_topob_link( topo, "shred_netmux", "netmux_inout", 0,        config->tiles.net.send_buffer_size,       FD_NET_MTU,             1UL );
   FOR(quic_tile_cnt)   fd_topob_link( topo, "quic_verify",  "quic_verify",  1,        config->tiles.verify.receive_buffer_size, 0UL,                    config->tiles.quic.txn_reassembly_count );

--- a/src/app/fdctl/run/tiles/fd_netmux.c
+++ b/src/app/fdctl/run/tiles/fd_netmux.c
@@ -3,6 +3,114 @@
 #include "generated/netmux_seccomp.h"
 #include <linux/unistd.h>
 
+#define MAX_IN_CNT (32UL)
+
+typedef struct {
+  fd_wksp_t * mem;
+  ulong       chunk0;
+  ulong       wmark;
+} fd_netmux_in_ctx_t;
+
+typedef struct {
+  fd_netmux_in_ctx_t in[ MAX_IN_CNT ];
+
+  fd_wksp_t * out_mem;
+  ulong       out_chunk0;
+  ulong       out_wmark;
+  ulong       out_chunk;
+} fd_netmux_ctx_t;
+
+FD_FN_CONST static inline ulong
+scratch_align( void ) {
+  return alignof( fd_netmux_ctx_t );
+}
+
+FD_FN_PURE static inline ulong
+scratch_footprint( fd_topo_tile_t const * tile ) {
+  (void)tile;
+  ulong l = FD_LAYOUT_INIT;
+  l = FD_LAYOUT_APPEND( l, alignof( fd_netmux_ctx_t ), sizeof( fd_netmux_ctx_t ) );
+  return FD_LAYOUT_FINI( l, scratch_align() );
+}
+
+FD_FN_CONST static inline void *
+mux_ctx( void * scratch ) {
+  return (void*)fd_ulong_align_up( (ulong)scratch, alignof( fd_netmux_ctx_t ) );
+}
+
+static inline void
+during_frag( void * _ctx,
+             ulong  in_idx,
+             ulong  seq,
+             ulong  sig,
+             ulong  chunk,
+             ulong  sz,
+             int *  opt_filter ) {
+  (void)seq;
+  (void)sig;
+  (void)opt_filter;
+
+  fd_netmux_ctx_t * ctx = (fd_netmux_ctx_t *)_ctx;
+
+  if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark || sz > FD_NET_MTU ) )
+    FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
+
+  uchar * src = (uchar *)fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk );
+  uchar * dst = (uchar *)fd_chunk_to_laddr( ctx->out_mem, ctx->out_chunk );
+
+  fd_memcpy( dst, src, sz );
+}
+
+static inline void
+after_frag( void *             _ctx,
+            ulong              in_idx,
+            ulong              seq,
+            ulong *            opt_sig,
+            ulong *            opt_chunk,
+            ulong *            opt_sz,
+            ulong *            opt_tsorig,
+            int   *            opt_filter,
+            fd_mux_context_t * mux ) {
+  (void)in_idx;
+  (void)seq;
+  (void)opt_tsorig;
+  (void)opt_chunk;
+  (void)opt_filter;
+
+  fd_netmux_ctx_t * ctx = (fd_netmux_ctx_t *)_ctx;
+
+  ulong tspub  = (ulong)fd_frag_meta_ts_comp( fd_tickcount() );
+  fd_mux_publish( mux, *opt_sig, ctx->out_chunk, *opt_sz, 0, *opt_tsorig, tspub );
+  ctx->out_chunk = fd_dcache_compact_next( ctx->out_chunk, *opt_sz, ctx->out_chunk0, ctx->out_wmark );
+}
+
+static void
+unprivileged_init( fd_topo_t *      topo,
+                   fd_topo_tile_t * tile,
+                   void *           scratch ) {
+  FD_SCRATCH_ALLOC_INIT( l, scratch );
+  fd_netmux_ctx_t * ctx = FD_SCRATCH_ALLOC_APPEND( l, alignof( fd_netmux_ctx_t ), sizeof( fd_netmux_ctx_t ) );
+
+  FD_TEST( tile->in_cnt<=MAX_IN_CNT );
+  for( ulong i=0; i<tile->in_cnt; i++ ) {
+    fd_topo_link_t * link = &topo->links[ tile->in_link_id[ i ] ];
+    fd_topo_wksp_t * link_wksp = &topo->workspaces[ topo->objs[ link->dcache_obj_id ].wksp_id ];
+
+    ctx->in[ i ].mem    = link_wksp->wksp;
+    ctx->in[ i ].chunk0 = fd_dcache_compact_chunk0( ctx->in[ i ].mem, link->dcache );
+    ctx->in[ i ].wmark  = fd_dcache_compact_wmark ( ctx->in[ i ].mem, link->dcache, link->mtu );
+  }
+
+  ctx->out_mem    = topo->workspaces[ topo->objs[ topo->links[ tile->out_link_id_primary ].dcache_obj_id ].wksp_id ].wksp;
+  ctx->out_chunk0 = fd_dcache_compact_chunk0( ctx->out_mem, topo->links[ tile->out_link_id_primary ].dcache );
+  ctx->out_wmark  = fd_dcache_compact_wmark ( ctx->out_mem, topo->links[ tile->out_link_id_primary ].dcache, topo->links[ tile->out_link_id_primary ].mtu );
+  ctx->out_chunk  = ctx->out_chunk0;
+
+  ulong scratch_top = FD_SCRATCH_ALLOC_FINI( l, 1UL );
+  if( FD_UNLIKELY( scratch_top > (ulong)scratch + scratch_footprint( tile ) ) )
+    FD_LOG_ERR(( "scratch overflow %lu %lu %lu", scratch_top - (ulong)scratch - scratch_footprint( tile ), scratch_top, (ulong)scratch + scratch_footprint( tile ) ));
+}
+
 static ulong
 populate_allowed_seccomp( void *               scratch,
                           ulong                out_cnt,
@@ -28,13 +136,15 @@ populate_allowed_fds( void * scratch,
 
 fd_topo_run_tile_t fd_tile_netmux = {
   .name                     = "netmux",
-  .mux_flags                = FD_MUX_FLAG_DEFAULT,
+  .mux_flags                = FD_MUX_FLAG_MANUAL_PUBLISH | FD_MUX_FLAG_COPY,
   .burst                    = 1UL,
-  .mux_ctx                  = NULL,
+  .mux_ctx                  = mux_ctx,
+  .mux_during_frag          = during_frag,
+  .mux_after_frag           = after_frag,
   .populate_allowed_seccomp = populate_allowed_seccomp,
   .populate_allowed_fds     = populate_allowed_fds,
-  .scratch_align            = NULL,
-  .scratch_footprint        = NULL,
+  .scratch_align            = scratch_align,
+  .scratch_footprint        = scratch_footprint,
   .privileged_init          = NULL,
-  .unprivileged_init        = NULL,
+  .unprivileged_init        = unprivileged_init,
 };


### PR DESCRIPTION
Fixes #1358

A muxer that doesn't copy packets has a problem, where the mux tile itself might get overrun, but the downstream consumer won't realize because the sequence number that the consumer checks after reading the fragment gets incremented against the mcache, which is different for the consumer and the producer.

There's a few ways to fix this:

 * You can keep two sequence numbers, and have the consumer check both of them.
 * You can write the sequence number check into the dcache itself (before and at the end of) the packet.
 * You can copy the fragments.

For now we do the 3rd option, as it's the easiest to implement.