### PR TITLE
fd_reedsol: support CPUs with GFNI but no AVX512

### DIFF
--- a/src/ballet/reedsol/fd_reedsol.c
+++ b/src/ballet/reedsol/fd_reedsol.c
@@ -13,7 +13,7 @@ FD_IMPORT_BINARY( fd_reedsol_arith_consts_gfni_mul, "src/ballet/reedsol/constant
 void
 fd_reedsol_encode_fini( fd_reedsol_t * rs ) {
 
-# if FD_REEDSOL_ARITH_IMPL==2
+# if FD_REEDSOL_ARITH_IMPL==3
   if( FD_LIKELY( (rs->data_shred_cnt==32UL) & (rs->parity_shred_cnt==32UL ) ) )
     fd_reedsol_private_encode_32_32( rs->shred_sz, rs->encode.data_shred, rs->encode.parity_shred, rs->scratch );
   else

--- a/src/ballet/reedsol/fd_reedsol_private.h
+++ b/src/ballet/reedsol/fd_reedsol_private.h
@@ -12,10 +12,13 @@
 
      0 - unaccelerated
      1 - AVX accelerated
-     2 - GFNI accelerated */
+     2 - GFNI accelerated with AVX2
+     3 - GFNI accelerated with AVX512 */
 
 #ifndef FD_REEDSOL_ARITH_IMPL
-#if FD_HAS_GFNI
+#if FD_HAS_GFNI && FD_HAS_AVX512
+#define FD_REEDSOL_ARITH_IMPL 3
+#elif FD_HAS_GFNI
 #define FD_REEDSOL_ARITH_IMPL 2
 #elif FD_HAS_AVX
 #define FD_REEDSOL_ARITH_IMPL 1
@@ -28,7 +31,7 @@
 #include "fd_reedsol_arith_none.h"
 #elif FD_REEDSOL_ARITH_IMPL==1
 #include "fd_reedsol_arith_avx2.h"
-#elif FD_REEDSOL_ARITH_IMPL==2
+#elif FD_REEDSOL_ARITH_IMPL==2 || FD_REEDSOL_ARITH_IMPL==3
 #include "fd_reedsol_arith_gfni.h"
 #else
 #error "Unsupported FD_REEDSOL_ARITH_IMPL"


### PR DESCRIPTION
Although `fd_reedsol_private_encode_32_32` only uses 256-bit registers, it assumes the CPU has `ymm16-31`, which is only true for systems with AVX512. I didn't realize there were chips with GFNI but no AVX512, but we've seen it on some consumer hardware. In that case, still use the GFNI arithmetic, but avoid the hand-optimized version. The compiler will have to do more work to rename registers, but it'll compile it just fine for 16 vector registers.