### PR TITLE
Create executable binary for executing Protobuf instructions

### DIFF
--- a/src/app/fdtestsuite/Local.mk
+++ b/src/app/fdtestsuite/Local.mk
@@ -1,0 +1,1 @@
+$(call make-bin,fdtestsuite,main,fd_flamenco fd_funk fd_ballet fd_util)

--- a/src/app/fdtestsuite/main.c
+++ b/src/app/fdtestsuite/main.c
@@ -1,0 +1,47 @@
+#include "../../flamenco/runtime/tests/fd_exec_sol_compat.h"
+#include <stdio.h>
+
+int main(int argc, char ** argv) {
+    printf("Executing!\n");
+    for (int i = 1; i < argc; i++) {
+        // Open the Protobuf file
+        char * file_name = argv[i];
+        FILE * file = fopen(file_name, "rb");
+        assert(file);
+
+        // Get the file size
+        fseek(file, 0, SEEK_END);
+        ulong in_sz = (ulong) ftell(file);
+        fseek(file, 0, SEEK_SET);
+
+        // Allocate memory to read in the file
+        uchar * in = malloc(in_sz);
+        assert(in);
+
+        // Read in the file
+        ulong bytes_read = fread(in, 1, in_sz, file);
+        if (bytes_read != in_sz) {
+            printf("Failed to read file.\n");
+            return 1;
+        }
+        fclose(file);
+
+        uchar out[32 * 1024];
+        ulong out_sz = sizeof(out);
+
+        sol_compat_init();
+
+        int result = sol_compat_instr_execute_v1(out, &out_sz, in, in_sz);
+        if (result) {
+            printf("Execution successful.\n");
+        } else {
+            printf("Execution failed.\n");
+        }
+
+        sol_compat_fini();
+    }
+
+    printf("Done!\n");
+
+    return 0;
+}

--- a/src/flamenco/runtime/tests/Local.mk
+++ b/src/flamenco/runtime/tests/Local.mk
@@ -5,6 +5,8 @@ ifdef FD_HAS_INT128
 $(call add-hdrs,fd_exec_instr_test.h)
 $(call add-objs,fd_exec_instr_test,fd_flamenco)
 
+$(call add-objs,fd_exec_sol_compat,fd_flamenco)
+
 $(call make-unit-test,test_exec_instr,test_exec_instr,fd_flamenco fd_funk fd_ballet fd_util)
 $(call make-shared,libfd_exec_sol_compat.so,fd_exec_sol_compat,fd_flamenco fd_funk fd_ballet fd_util)
 endif

--- a/src/flamenco/runtime/tests/fd_exec_sol_compat.c
+++ b/src/flamenco/runtime/tests/fd_exec_sol_compat.c
@@ -1,16 +1,4 @@
-#include "fd_exec_instr_test.h"
-#include "../../nanopb/pb_decode.h"
-#include "../../nanopb/pb_encode.h"
-#include <assert.h>
-#include <stdlib.h>
-
-typedef struct {
-  ulong   struct_size;
-  ulong * hardcoded_features;
-  ulong   hardcoded_feature_cnt;
-  ulong * supported_features;
-  ulong   supported_feature_cnt;
-} sol_compat_features_t;
+#include "fd_exec_sol_compat.h"
 
 static sol_compat_features_t features;
 static ulong hardcoded_features[] =

--- a/src/flamenco/runtime/tests/fd_exec_sol_compat.h
+++ b/src/flamenco/runtime/tests/fd_exec_sol_compat.h
@@ -1,0 +1,36 @@
+#ifndef HEADER_fd_src_flamenco_runtime_tests_fd_exec_sol_compat_h
+#define HEADER_fd_src_flamenco_runtime_tests_fd_exec_sol_compat_h
+
+#include "fd_exec_instr_test.h"
+#include "../../nanopb/pb_decode.h"
+#include "../../nanopb/pb_encode.h"
+#include <assert.h>
+#include <stdlib.h>
+#include "../../../funk/fd_funk.h"
+
+typedef struct {
+  ulong struct_size;
+  ulong *hardcoded_features;
+  ulong hardcoded_feature_cnt;
+  ulong *supported_features;
+  ulong supported_feature_cnt;
+} sol_compat_features_t;
+
+FD_PROTOTYPES_BEGIN
+
+void
+sol_compat_init( void );
+
+void
+sol_compat_fini( void );
+
+int
+sol_compat_instr_execute_v1( uchar *       out,
+                             ulong *       out_sz,
+                             uchar const * in,
+                             ulong         in_sz );
+
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_flamenco_runtime_tests_fd_exec_sol_compat_h */


### PR DESCRIPTION
Creates binary that accepts Protobuf message files and executes them through Firedancer. Useful for being able to step through and debug individual instructions through testing suites.