### PR TITLE
ubsan complains that log_buf_ptr is null if it is assigned after the …

### DIFF
--- a/src/util/log/fd_log.c
+++ b/src/util/log/fd_log.c
@@ -626,8 +626,8 @@ fd_log_private_hexdump_msg( char const * descr,
 # define FD_LOG_HEXDUMP_BLOB_DESCRIPTION_MAX_LEN (32UL)
 # define FD_LOG_HEXDUMP_MAX_INPUT_BLOB_SZ        (1664UL) /* multiple of 128 >= 1542 */
 
-# define FD_LOG_HEXDUMP_ADD_TO_LOG_BUF(...)  do { log_buf_ptr += fd_int_max( sprintf( log_buf_ptr, __VA_ARGS__ ), 0 ); } while(0)
   char * log_buf_ptr = fd_log_private_log_msg; /* used by FD_LOG_HEXDUMP_ADD_TO_LOG_BUF macro */
+# define FD_LOG_HEXDUMP_ADD_TO_LOG_BUF(...)  do { log_buf_ptr += fd_int_max( sprintf( log_buf_ptr, __VA_ARGS__ ), 0 ); } while(0)
 
   /* Print the hexdump header */
   /* FIXME: consider additional sanitization of descr or using compiler


### PR DESCRIPTION
…macro definition