### PR TITLE
fd_dedup: prevent potential future memory corruption issue

### DIFF
--- a/src/app/fdctl/run/tiles/fd_dedup.c
+++ b/src/app/fdctl/run/tiles/fd_dedup.c
@@ -137,7 +137,7 @@ unprivileged_init( fd_topo_t *      topo,
                    void *           scratch ) {
   FD_SCRATCH_ALLOC_INIT( l, scratch );
   fd_dedup_ctx_t * ctx = FD_SCRATCH_ALLOC_APPEND( l, alignof( fd_dedup_ctx_t ), sizeof( fd_dedup_ctx_t ) );
-  fd_tcache_t * tcache = fd_tcache_join( fd_tcache_new( FD_SCRATCH_ALLOC_APPEND( l, FD_TCACHE_ALIGN, FD_TCACHE_FOOTPRINT( tile->dedup.tcache_depth, 0) ), tile->dedup.tcache_depth, 0 ) );
+  fd_tcache_t * tcache = fd_tcache_join( fd_tcache_new( FD_SCRATCH_ALLOC_APPEND( l, FD_TCACHE_ALIGN, fd_tcache_footprint( tile->dedup.tcache_depth, 0) ), tile->dedup.tcache_depth, 0 ) );
   if( FD_UNLIKELY( !tcache ) ) FD_LOG_ERR(( "fd_tcache_new failed" ));
 
   ctx->tcache_depth   = fd_tcache_depth       ( tcache );


### PR DESCRIPTION
`FD_TCACHE_FOOTPRINT` (the macro version) does not return the right value when `depth` (the second argument) is 0.  This is not an actual issue because the footprint calculation for the tile uses `fd_tcache_footprint`, but it could cause a problem if someone adds another object to the scratch space without noticing.