### PR TITLE
fdctl: fix monitor reporting of slow cnt

### DIFF
--- a/src/disco/mux/fd_mux.c
+++ b/src/disco/mux/fd_mux.c
@@ -469,7 +469,7 @@ fd_mux_tile( fd_cnc_t *              cnc,
           /* See notes above about use of quasi-atomic diagnostic accum */
           if( FD_LIKELY( slowest_out!=ULONG_MAX ) ) {
             FD_COMPILER_MFENCE();
-            (*out_slow[ slowest_out ])++;
+            (*out_slow[ slowest_out ]) += metric_in_backp;
             FD_COMPILER_MFENCE();
           }
 


### PR DESCRIPTION
Additionally, this changes slow_cnt to only increment when backpressured. In the normal course of events, with `n` identical consumers, each consumer will be the slowest around 1/n of the time. That's expected and not an issue. Slow is most useful as a way to blame backpressure on a consumer.