### PR TITLE
types: fix ele sz calc in treap ##fuzz

### DIFF
--- a/src/flamenco/types/fd_types.c
+++ b/src/flamenco/types/fd_types.c
@@ -1075,10 +1075,6 @@ ulong fd_stake_history_entry_size(fd_stake_history_entry_t const * self) {
   size += sizeof(ulong);
   size += sizeof(ulong);
   size += sizeof(ulong);
-  size += sizeof(ulong);
-  size += sizeof(ulong);
-  size += sizeof(ulong);
-  size += sizeof(ulong);
   return size;
 }
 
@@ -5143,10 +5139,6 @@ ulong fd_vote_authorized_voter_size(fd_vote_authorized_voter_t const * self) {
   ulong size = 0;
   size += sizeof(ulong);
   size += fd_pubkey_size(&self->pubkey);
-  size += sizeof(ulong);
-  size += sizeof(ulong);
-  size += sizeof(ulong);
-  size += sizeof(ulong);
   return size;
 }
 

--- a/src/flamenco/types/gen_stubs.py
+++ b/src/flamenco/types/gen_stubs.py
@@ -219,7 +219,8 @@ class PrimitiveMember:
     }
 
     def emitSize(self, inner):
-        PrimitiveMember.emitSizeMap[self.type](self.name, self.varint);
+        if self.encode:
+            PrimitiveMember.emitSizeMap[self.type](self.name, self.varint);
 
     emitWalkMap = {
         "char" :      lambda n, inner: print(f'  fun( w, &self->{inner}{n}, "{n}", FD_FLAMENCO_TYPE_SCHAR,   "char",      level );', file=body),


### PR DESCRIPTION
The size function did not skip element members that are skipped during encoding.
