### PR TITLE
Native program mismatch fixes

### DIFF
--- a/src/flamenco/runtime/program/fd_address_lookup_table_program.c
+++ b/src/flamenco/runtime/program/fd_address_lookup_table_program.c
@@ -908,6 +908,10 @@ close_lookup_table( fd_exec_instr_ctx_t * ctx ) {
 
 int
 fd_address_lookup_table_program_execute( fd_exec_instr_ctx_t _ctx ) {
+  do {
+    int err = fd_exec_consume_cus( _ctx.txn_ctx, 750UL );
+    if( FD_UNLIKELY( err ) ) return err;
+  } while(0);
 
   fd_exec_instr_ctx_t * ctx = &_ctx;
   uchar const * instr_data    = ctx->instr->data;


### PR DESCRIPTION
* Add extra check in address lookup table program for compute units (was causing mismatch with Agave)
* Add error code output for unsupported programs