### PR TITLE
Fix system program mismatch (remove system transfer zero check)

### DIFF
--- a/src/flamenco/runtime/program/fd_system_program.c
+++ b/src/flamenco/runtime/program/fd_system_program.c
@@ -128,13 +128,6 @@ fd_system_program_transfer( fd_exec_instr_ctx_t * ctx,
                             ulong                 from_acct_idx,
                             ulong                 to_acct_idx ) {
 
-  /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L223-L229 */
-
-  if( !FD_FEATURE_ACTIVE( ctx->slot_ctx, system_transfer_zero_check )
-      && transfer_amount == 0UL ) {
-    return FD_EXECUTOR_INSTR_SUCCESS;
-  }
-
   /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L231-L241 */
 
   if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( ctx->instr, from_acct_idx ) ) ) {
@@ -602,12 +595,6 @@ fd_system_program_exec_transfer_with_seed( fd_exec_instr_ctx_t *                
   ulong const from_idx      = 0UL;
   ulong const from_base_idx = 1UL;
   ulong const to_idx        = 2UL;
-
-  /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L264-L270 */
-
-  if( FD_UNLIKELY( ( !FD_FEATURE_ACTIVE( ctx->slot_ctx, system_transfer_zero_check ) ) ) &
-                   ( args->lamports == 0UL ) )
-    return 0;
 
   /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L272-L282 */
 


### PR DESCRIPTION
Solana removed system transfer zero checks [here](https://github.com/solana-labs/solana/pull/34076).