### PR TITLE
runtime: bug fixes from mainnet

### DIFF
--- a/src/flamenco/runtime/program/fd_config_program.c
+++ b/src/flamenco/runtime/program/fd_config_program.c
@@ -60,7 +60,7 @@ _process_config_instr( fd_exec_instr_ctx_t ctx ) {
 
   fd_bincode_decode_ctx_t config_acc_state_decode_context = {
     .valloc  = ctx.valloc,
-    .data    = config_acc_rec->orig_data,
+    .data    = config_acc_rec->const_data,
     .dataend = config_acc_rec->const_data + config_acc_rec->const_meta->dlen,
   };
   fd_config_keys_t current_data;

--- a/src/flamenco/runtime/program/fd_system_program_nonce.c
+++ b/src/flamenco/runtime/program/fd_system_program_nonce.c
@@ -76,7 +76,7 @@ most_recent_block_hash( fd_exec_instr_ctx_t * ctx,
     return FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR;
   }
 
-  *out = deq_fd_block_block_hash_entry_t_peek_tail_const( hashes )->blockhash;
+  *out = deq_fd_block_block_hash_entry_t_peek_head_const( hashes )->blockhash;
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
 
@@ -226,6 +226,11 @@ fd_system_program_advance_nonce_account( fd_exec_instr_ctx_t *   ctx,
       int err = fd_system_program_set_nonce_state( ctx, instr_acc_idx, &new_state );
       if( FD_UNLIKELY( err ) ) return err;
     } while(0);
+
+    /* Mark this as a nonce account usage.  This prevents the account
+       state from reverting in case the transaction fails. */
+
+    ctx->txn_ctx->nonce_accounts[ ctx->instr->acct_txn_idxs[ instr_acc_idx ] ] = 1;
 
     break;
   }


### PR DESCRIPTION
- Fix bug where config program uses orig_data ##hist
  The fuzzer didn't catch this because it sets const_data==orig_data.
  During actual replay, this obviously isn't the case.

- Fix account borrowing bugs in the stake program ##hist
  Several code paths didn't release exclusive locks on transaction
  accounts.  Currently, it is assumed that an instruction releases
  all such locks if it returns success.  This is currently not
  documented.  If violated, causes stray borrow failures in subsequent
  instructions.  The instruction fuzzer didn't catch this because it
  only executes one instruction at a time.  The suggested fix is to
  deliberately crash fuzz execution if a leftover exclusive lock is
  detected.  Interestingly, the release at line 1394 was unreachable
  code, but neither Clang nor GCC complained about it.

- Fix incorrect memcmp in stake program ##hist
  The 'delegate stake' instruction checked for the 'config' program ID
  instead of the 'stake config' sysvar ID.  Here, the fuzzer simply
  didn't reach far enough in existing fuzz runs.

- Fix incorrect nonce advance in system program ##hist
  The 'advance nonce' instruction is very special.  It is the only
  code path in instruction processing in the protocol where account
  changes are _not_ reverted if the transaction fails.  This is
  currently done by setting the 'nonce_account' flag to true in the
  transaction context.  I forgot to do this.  The instruction fuzzer
  did not catch this because it doesn't detect if an input is nonce
  related.

- Fix durable nonce derivation ##hist
  The system program read the _least_ recent entry in the blockhash
  queue.  The correct behavior is to use the most recent entry.
  It is unknown why the instruction fuzzer didn't catch this.
  Likely either because it (1) never generated a recent blockhash
  sysvar with more than one entry or (2) because the bootstrapping
  in the Agave target was also incorrect.
