### PR TITLE
util: don't zero entire wksp or dcache

### DIFF
--- a/src/tango/dcache/fd_dcache.c
+++ b/src/tango/dcache/fd_dcache.c
@@ -67,13 +67,15 @@ fd_dcache_new( void * shmem,
     return NULL;
   }
 
-  fd_memset( shmem, 0, footprint );
+  fd_memset( shmem, 0, sizeof(fd_dcache_private_hdr_t ) );
 
   fd_dcache_private_hdr_t * hdr = (fd_dcache_private_hdr_t *)shmem;
 
   hdr->data_sz = data_sz;
   hdr->app_sz  = app_sz;
   hdr->app_off = sizeof(fd_dcache_private_hdr_t) + fd_ulong_align_up( data_sz, FD_DCACHE_ALIGN );
+
+  fd_memset( (uchar*)shmem+hdr->app_off, 0, app_sz );
 
   FD_COMPILER_MFENCE();
   FD_VOLATILE( hdr->magic ) = FD_DCACHE_MAGIC;

--- a/src/util/wksp/fd_wksp_admin.c
+++ b/src/util/wksp/fd_wksp_admin.c
@@ -165,7 +165,7 @@ fd_wksp_new( void *       shmem,
     return NULL;
   }
 
-  fd_memset( wksp, 0, footprint );
+  fd_memset( wksp, 0, fd_wksp_footprint( part_max, 1UL ) );
 
   wksp->part_max       = part_max;
   wksp->data_max       = data_max;


### PR DESCRIPTION
With a large workspace or dcache, zeroing the entire space can take a long time.  This isn't strictly necessary, since the wksp and dcache implementations do not assume the data region is zeroed.

The underlying shared memory must be zeroed by the kernel when it is first grabbed, so the only way this is non-zero is if we are reusing space in the shared memory that we created previously.  It is OK to expose, but not use, the previous data in this case.

Related to #1391