### PR TITLE
global tile specific flag to get things to cleanly shut down

### DIFF
--- a/src/util/tile/fd_tile.c
+++ b/src/util/tile/fd_tile.c
@@ -3,6 +3,8 @@
 
 #include "fd_tile_private.h"
 
+volatile int fd_tile_shutdown_flag = 0;
+
 int
 fd_cpuset_getaffinity( ulong         pid,
                        fd_cpuset_t * mask ) {

--- a/src/util/tile/fd_tile.h
+++ b/src/util/tile/fd_tile.h
@@ -167,6 +167,8 @@ fd_tile_private_boot( int *    pargc,
 void
 fd_tile_private_halt( void );
 
+extern volatile int fd_tile_shutdown_flag;
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_util_tile_fd_tile_h */

--- a/src/util/tpool/fd_tpool.h
+++ b/src/util/tpool/fd_tpool.h
@@ -795,7 +795,7 @@ fd_tpool_wait( fd_tpool_t const * tpool,
                ulong              worker_idx ) {
   int volatile * vstate = (int volatile *)&(fd_tpool_private_worker( tpool )[ worker_idx ]->state);
   int            state;
-  for(;;) {
+  while( FD_LIKELY( !fd_tile_shutdown_flag ) ) {
     state = *vstate;
     if( FD_LIKELY( state!=FD_TPOOL_WORKER_STATE_EXEC ) ) break;
     FD_SPIN_PAUSE();


### PR DESCRIPTION

This is a process specific shutdown for tiles/threads.  This should be integrated with other shutdown standards with the goal of cleanly shutting down the entire system