### PR TITLE
ci: don't share deps cache across OS

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -29,13 +29,13 @@ runs:
 
     - id: deps-sh-hash
       shell: bash
-      run: sha256sum '${{ inputs.deps-script-path }}' | awk '{print "HASH=" $1}' >> "$GITHUB_OUTPUT"
+      run: cat /etc/os-release '${{ inputs.deps-script-path }}' | sha256sum | awk '{print "HASH=" $1}' >> "$GITHUB_OUTPUT"
 
     - id: deps-sh-cache
       uses: actions/cache@v4
       with:
         path: deps-bundle.tar.zst
-        key: ${{ runner.os }}-deps-sh-${{ steps.deps-sh-hash.outputs.HASH }}
+        key: ${{ runner.os }}-${{ runner.arch }}-deps-sh-${{ steps.deps-sh-hash.outputs.HASH }}
 
     - name: Install system level dependencies
       shell: bash


### PR DESCRIPTION
Improves binary compatibility of GitHub CI deps cache across different Linux distros

Required for RocksDB enabled builds