### PR TITLE
Remove Rust check from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "cargo" 
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    allow:
-      - dependency-type: "all"


### PR DESCRIPTION
This repo no longer contains Rust production code. Therefore it doesn't need Dependabot coverage.