### PR TITLE
config: don't link OpenSSL unless requested

### DIFF
--- a/config/extra/with-openssl.mk
+++ b/config/extra/with-openssl.mk
@@ -1,4 +1,4 @@
-LDFLAGS+=opt/lib/libssl.a opt/lib/libcrypto.a
+OPENSSL_LIBS=opt/lib/libssl.a opt/lib/libcrypto.a
 
 FD_HAS_OPENSSL:=1
 CPPFLAGS+=-DFD_HAS_OPENSSL=1


### PR DESCRIPTION
Removes OpenSSL from the default link flags. Currently, we have no dependencies on OpenSSL.