### PR TITLE
config: auto-enable RocksDB for native target

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,6 @@ jobs:
           - linux_gcc_noarch64    # least capable target
           - linux_gcc_icelake     # most capable target
           - linux_clang_x86_64
-          - linux_clang_haswell
           - linux_clang_icelake
         # Attach additional params to machine types
         include:
@@ -25,7 +24,8 @@ jobs:
           - machine: linux_gcc_icelake
             group: rhel85-icelake
           - machine: linux_clang_x86_64
-          - machine: linux_clang_haswell
+          - machine: native
+            env: CC=clang
           - machine: linux_clang_icelake
             group: rhel85-icelake
             extras: asan ubsan
@@ -46,4 +46,5 @@ jobs:
           MACHINES=${{ matrix.machine }} \
           EXTRAS="${{ matrix.extras || '' }}" \
           NOTEST=${{ matrix.notest || '' }} \
+          ${{ matrix.env || '' }} \
           contrib/test/ci_tests.sh

--- a/config/machine/native.mk
+++ b/config/machine/native.mk
@@ -99,3 +99,10 @@ endif
 
 include config/extra/with-secp256k1.mk
 include config/extra/with-zstd.mk
+
+# Detect if RocksDB dependency is installed
+ifneq (,$(wildcard opt/lib/librocksdb.a))
+ifneq (,$(wildcard opt/lib/libsnappy.a))
+include config/extra/with-rocksdb.mk
+endif
+endif


### PR DESCRIPTION
This is a compromise between the 1.5 team, who wants fast builds. And the component 2 team, who currently needs an Agave-RocksDB integration to source blocks. If RocksDB was installed with deps.sh, links in RocksDB into builds. Switches CI to the native target so we exercise this functionality.

- config: auto-enable RocksDB for native target 
- ci: replace linux_clang_haswell with native/clang
