### PR TITLE
fdctl: fix two small bugs

### DIFF
--- a/src/app/fdctl/run/tiles/fd_pack.c
+++ b/src/app/fdctl/run/tiles/fd_pack.c
@@ -413,6 +413,7 @@ after_credit( void *             _ctx,
       fd_txn_t   const * insert_txn = TXN(insert);
       fd_memcpy( spot->payload, insert->payload, insert->payload_sz                                                           );
       fd_memcpy( TXN(spot),     insert_txn,      fd_txn_footprint( insert_txn->instr_cnt, insert_txn->addr_table_lookup_cnt ) );
+      spot->payload_sz = insert->payload_sz;
       extra_txn_deq_remove_head( ctx->extra_txn_deq );
 
 


### PR DESCRIPTION
When inserting to pack from the extra storage, we forgot to set payload_sz which would occasionally lead to producing bad blocks under heavy load.

Also, fix the computation for `max_remaining_ticks_or_microblocks` which was sometimes running out of hashcnt for the final tick.