### PR TITLE
added quic support to fddev bench. Numerous QUIC fixes.

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -693,7 +693,7 @@ dynamic_port_range = "8900-9000"
         # underlying link bandwidth.  Supporting more streams per
         # connection currently has a memory footprint cost on the order
         # of kilobytes per stream, per connection.
-        max_concurrent_streams_per_connection = 32
+        max_concurrent_streams_per_connection = 2048
 
         # QUIC uses a fixed-size pool of streams to use for all the
         # connections in the QUIC instance.  When a new connection is
@@ -741,7 +741,7 @@ dynamic_port_range = "8900-9000"
         # rather than the underlying link bandwidth.  If you have a lot
         # of memory available and are constrained by this, it can make
         # sense to increase.
-        max_inflight_quic_packets = 2048
+        max_inflight_quic_packets = 2500
 
         # TODO: This should be removed.  We never transmit stream data
         # so this should be unused.

--- a/src/app/fdctl/fdctl.h
+++ b/src/app/fdctl/fdctl.h
@@ -80,6 +80,7 @@ typedef union {
     ulong   connections;
     ulong   benchg;
     ulong   benchs;
+    int     no_quic;
   } spammer;
 } args_t;
 

--- a/src/app/fddev/bench.c
+++ b/src/app/fddev/bench.c
@@ -46,6 +46,7 @@ bench_cmd_args( int *    pargc,
   (void)pargc;
   (void)pargv;
   (void)args;
+  args->spammer.no_quic = fd_env_strip_cmdline_contains( pargc, pargv, "--no-quic" );
 }
 
 static void *
@@ -68,7 +69,8 @@ add_bench_topo( fd_topo_t  * topo,
                 ushort       send_to_port,
                 uint         send_to_ip_addr,
                 ushort       rpc_port,
-                uint         rpc_ip_addr ) {
+                uint         rpc_ip_addr,
+                int          no_quic ) {
 
   fd_topob_wksp( topo, "bench" );
   fd_topob_link( topo, "bencho_out", "bench", 0, 128UL, 64UL, 1UL );
@@ -95,6 +97,7 @@ add_bench_topo( fd_topo_t  * topo,
     benchs->benchs.send_to_ip_addr = send_to_ip_addr;
     benchs->benchs.send_to_port    = send_to_port;
     benchs->benchs.conn_cnt        = conn_cnt;
+    benchs->benchs.no_quic         = no_quic;
   }
 
   for( ulong i=0UL; i<benchg_tile_cnt; i++ ) fd_topob_tile_in( topo, "benchg", i, "bench", "bencho_out", 0, 1, 1 );
@@ -114,16 +117,21 @@ bench_cmd_fn( args_t *         args,
               config_t * const config ) {
   (void)args;
 
+  ushort dest_port = fd_ushort_if( args->spammer.no_quic,
+                                   config->tiles.quic.regular_transaction_listen_port,
+                                   config->tiles.quic.quic_transaction_listen_port );
+
   add_bench_topo( &config->topo,
                   config->development.bench.affinity,
                   config->development.bench.benchg_tile_count,
                   config->development.bench.benchs_tile_count,
                   config->development.genesis.fund_initial_accounts,
                   config->layout.quic_tile_count,
-                  config->tiles.quic.regular_transaction_listen_port,
+                  dest_port,
                   config->tiles.net.ip_addr,
                   config->rpc.port,
-                  config->tiles.net.ip_addr );
+                  config->tiles.net.ip_addr,
+                  args->spammer.no_quic );
 
   if( FD_LIKELY( !args->dev.no_configure ) ) {
     args_t configure_args = {

--- a/src/app/fddev/fddev.h
+++ b/src/app/fddev/fddev.h
@@ -19,7 +19,8 @@ add_bench_topo( fd_topo_t  * topo,
                 ushort       send_to_port,
                 uint         send_to_ip_addr,
                 ushort       rpc_port,
-                uint         rpc_ip_addr );
+                uint         rpc_ip_addr,
+                int          no_quic );
 
 void
 dev_cmd_args( int *    pargc,

--- a/src/app/fddev/spammer.c
+++ b/src/app/fddev/spammer.c
@@ -60,6 +60,8 @@ spammer_cmd_args( int *    pargc,
       FD_LOG_ERR(( "invalid --rpc-ip" ));
   }
 
+  args->spammer.no_quic = fd_env_strip_cmdline_contains( pargc, pargv, "--no-quic" );
+
 }
 
 void
@@ -104,7 +106,8 @@ spammer_cmd_fn( args_t *         args,
                   args->spammer.tpu_port,
                   args->spammer.tpu_ip,
                   args->spammer.rpc_port,
-                  args->spammer.rpc_ip );
+                  args->spammer.rpc_ip,
+                  args->spammer.no_quic );
   config->topo = *topo;
 
   args_t configure_args = {

--- a/src/app/fddev/tiles/fd_benchs.c
+++ b/src/app/fddev/tiles/fd_benchs.c
@@ -1,9 +1,72 @@
+/* _GNU_SOURCE for recvmmsg and sendmmsg */
+#define _GNU_SOURCE
+
 #include "../../fdctl/run/tiles/tiles.h"
+#include "../../../waltz/xdp/fd_xsk_aio.h"
+#include "../../../waltz/quic/fd_quic.h"
+#include "../../../waltz/tls/test_tls_helper.h"
 
 #include <linux/unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <string.h>
+#include <unistd.h>
+#include <poll.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <time.h>
+
+/* max number of buffers batched for receive */
+#define IO_VEC_CNT 128
+
+
+struct signer_ctx {
+  fd_sha512_t sha512[ 1 ];
+
+  uchar public_key[ 32UL ];
+  uchar private_key[ 32UL ];
+};
+typedef struct signer_ctx signer_ctx_t;
+
+
+static void
+signer( void *        _ctx,
+        uchar         signature[ static 64 ],
+        uchar const   payload[ static 130 ] ) {
+  fd_tls_test_sign_ctx_t * ctx = (fd_tls_test_sign_ctx_t *)_ctx;
+  fd_ed25519_sign( signature, payload, 130UL, ctx->public_key, ctx->private_key, ctx->sha512 );
+}
+
+static FD_FN_UNUSED
+signer_ctx_t
+signer_ctx( fd_rng_t * rng ) {
+  signer_ctx_t ctx[1];
+  FD_TEST( fd_sha512_join( fd_sha512_new( ctx->sha512 ) ) );
+  for( ulong b=0; b<32UL; b++ ) ctx->private_key[b] = fd_rng_uchar( rng );
+  fd_ed25519_public_from_private( ctx->public_key, ctx->private_key, ctx->sha512 );
+
+  return *ctx;
+}
+
+static int
+quic_tx_aio_send( void *                    _ctx,
+                  fd_aio_pkt_info_t const * batch,
+                  ulong                     batch_cnt,
+                  ulong *                   opt_batch_idx,
+                  int                       flush );
+
+
+/* quic_now is called by the QUIC engine to get the current timestamp in
+   UNIX time.  */
+
+static ulong
+quic_now( void * ctx ) {
+  (void)ctx;
+  return (ulong)fd_log_wallclock();
+}
 
 typedef struct {
   ulong round_robin_cnt;
@@ -11,15 +74,244 @@ typedef struct {
 
   ulong packet_cnt;
 
-  ulong conn_cnt;
-  int conn_fd[ 128UL ];
+  ulong         conn_cnt;
+  int           conn_fd[ 128UL ];
+  struct pollfd poll_fd[ 128UL ];
+
+  signer_ctx_t     signer_ctx;
+  int              no_quic;
+  fd_quic_t *      quic;
+  ushort           quic_port;
+  fd_quic_conn_t * quic_conn;
+  const fd_aio_t * quic_rx_aio;
+  ulong            no_stream;
+
+  // vector receive members
+  struct mmsghdr rx_msgs[IO_VEC_CNT];
+  struct mmsghdr tx_msgs[IO_VEC_CNT];
+  struct iovec   rx_iovecs[IO_VEC_CNT];
+  struct iovec   tx_iovecs[IO_VEC_CNT];
+  char           rx_bufs[IO_VEC_CNT][2048];
+  char           tx_bufs[IO_VEC_CNT][2048];
+
+  ulong tx_idx;
+
+  fd_quic_stream_t * stream;
 
   fd_wksp_t * mem;
 } fd_benchs_ctx_t;
 
+void
+service_quic( fd_benchs_ctx_t * ctx ) {
+
+  if( !ctx->no_quic ) {
+    /* Publishes to mcache via callbacks */
+    fd_quic_service( ctx->quic );
+
+    /* receive from socket, and pass to quic */
+    int poll_rc = poll( ctx->poll_fd, ctx->conn_cnt, 0 );
+    if( FD_LIKELY( poll_rc == 0 ) ) {
+      return;
+    } if( FD_UNLIKELY( poll_rc == -1 ) ) {
+      if( FD_UNLIKELY( errno == EINTR ) ) return; /* will try later */
+      FD_LOG_ERR(( "Error occurred during poll: %d %s", errno,
+            strerror( errno ) ));
+    }
+
+    for( ulong j = 0; j < ctx->conn_cnt; ++j ) {
+      int revents = ctx->poll_fd[j].revents;
+      if( FD_LIKELY( revents & POLLIN ) ) {
+        /* data available - receive up to IO_VEC_CNT buffers */
+        struct timespec timeout = {0};
+        int retval = recvmmsg( ctx->poll_fd[j].fd, ctx->rx_msgs, IO_VEC_CNT, 0, &timeout );
+        if( FD_UNLIKELY( retval < 0 ) ) {
+          FD_LOG_ERR(( "Error occurred on recvmmsg: %d %s", errno, strerror( errno ) ));
+        } else {
+          /* pass buffers to QUIC */
+          fd_aio_pkt_info_t pkt[IO_VEC_CNT];
+          ulong hdr_sz = 14 + 20 + 8;
+          for( ulong j = 0; j < (ulong)retval; ++j ) {
+            pkt[j].buf    = ctx->rx_bufs[j];
+            pkt[j].buf_sz = (ushort)( ctx->rx_msgs[j].msg_len + hdr_sz );
+
+            /* set some required values */
+            uint payload_len = ctx->rx_msgs[j].msg_len;
+            uint udp_len     = payload_len + 8;
+            uint ip_len      = udp_len + 20;
+
+            uchar * buf = (uchar*)pkt[j].buf;
+
+            /* set ethtype */
+            buf[12 + 0] = 0x08;
+            buf[12 + 1] = 0x00;
+
+            /* set ver and len */
+            buf[14] = 0x45;
+
+            /* set protocol */
+            buf[14 + 9] = 17;
+
+            /* set udp length */
+            buf[14 + 20 + 4] = (uchar)( udp_len >> 8 );
+            buf[14 + 20 + 5] = (uchar)( udp_len      );
+
+            /* set ip length */
+            buf[14 + 2] = (uchar)( ip_len >> 8 );
+            buf[14 + 3] = (uchar)( ip_len      );
+          }
+          fd_aio_send( ctx->quic_rx_aio, pkt, (ulong)retval, NULL, 1 );
+        }
+      } else if( FD_UNLIKELY( revents & POLLERR ) ) {
+        int error = 0;
+        socklen_t errlen = sizeof(error);
+
+        if( getsockopt( ctx->poll_fd[j].fd, SOL_SOCKET, SO_ERROR, (void *)&error, &errlen ) == -1 ) {
+          FD_LOG_ERR(( "Unknown error on socket" ));
+        } else {
+          FD_LOG_ERR(( "Error on socket: %d %s", error, strerror( error ) ));
+        }
+      }
+    }
+  }
+}
+
+static void
+quic_stream_notify( fd_quic_stream_t * stream,
+                    void *             stream_ctx,
+                    int                type ) {
+  (void)stream;
+  (void)stream_ctx;
+  (void)type;
+
+  fd_benchs_ctx_t * ctx = (fd_benchs_ctx_t*)stream_ctx;
+  if( FD_LIKELY( ctx ) ) {
+    if( FD_LIKELY( ctx->stream == stream ) ) {
+      ctx->stream = NULL;
+    }
+  } else {
+    FD_LOG_ERR(( "quic_stream_notify - no context" ));
+  }
+}
+
+/* quic_conn_new is invoked by the QUIC engine whenever a new connection
+   is being established. */
+static void
+quic_conn_new( fd_quic_conn_t * conn,
+               void *           _ctx ) {
+  (void)conn;
+  (void)_ctx;
+}
+
+
+void
+handshake_complete( fd_quic_conn_t * conn,
+                    void *           _ctx ) {
+  (void)conn;
+  (void)_ctx;
+  FD_LOG_NOTICE(( "client handshake complete" ));
+}
+
+
+/* quic_stream_new is called back by the QUIC engine whenever an open
+   connection creates a new stream, at the time this is called, both the
+   client and server must have agreed to open the stream.  In case the
+   client has opened this stream, it is assumed that the QUIC
+   implementation has verified that the client has the necessary stream
+   quota to do so. */
+
+static void
+quic_stream_new( fd_quic_stream_t * stream,
+                 void *             _ctx,
+                 int                type ) {
+  /* we don't expect the server to initiate streams */
+  (void)stream;
+  (void)_ctx;
+  (void)type;
+}
+
+/* quic_stream_receive is called back by the QUIC engine when any stream
+   in any connection being serviced receives new data.  Currently we
+   simply copy received data out of the xsk (network device memory) into
+   a local dcache. */
+
+static void
+quic_stream_receive( fd_quic_stream_t * stream,
+                     void *             stream_ctx,
+                     uchar const *      data,
+                     ulong              data_sz,
+                     ulong              offset,
+                     int                fin ) {
+  /* we're not expecting to receive anything */
+  (void)stream;
+  (void)stream_ctx;
+  (void)data;
+  (void)data_sz;
+  (void)offset;
+  (void)fin;
+}
+
+
+static void
+quic_stream_notify( fd_quic_stream_t * stream,
+                    void *             stream_ctx,
+                    int                type );
+
+static void
+conn_final( fd_quic_conn_t * conn,
+            void *           _ctx ) {
+  (void)conn;
+
+  fd_benchs_ctx_t * ctx = (fd_benchs_ctx_t *)_ctx;
+
+  if( ctx ) {
+    ctx->quic_conn = NULL;
+  }
+}
+
+
+
 FD_FN_CONST static inline ulong
 scratch_align( void ) {
-  return alignof( fd_benchs_ctx_t );
+  return fd_ulong_max( fd_quic_align(), alignof( fd_benchs_ctx_t ) );
+}
+
+void
+populate_quic_limits( fd_quic_limits_t * limits ) {
+  //int    argc = 0;
+  //char * args[] = { NULL };
+  //char ** argv = args;
+  //fd_quic_limits_from_env( &argc, &argv, limits );
+  limits->stream_cnt[0] = 0;
+  limits->stream_cnt[1] = 0;
+  limits->stream_cnt[2] = 1500;
+  limits->stream_cnt[3] = 0;
+  limits->initial_stream_cnt[0] = 0;
+  limits->initial_stream_cnt[1] = 0;
+  limits->initial_stream_cnt[2] = 1500;
+  limits->initial_stream_cnt[3] = 0;
+
+  limits->conn_cnt = 2;
+  limits->handshake_cnt = limits->conn_cnt;
+  limits->conn_id_cnt = 16;
+  limits->conn_id_sparsity = 4.0;
+  limits->stream_sparsity = 2.0;
+  limits->inflight_pkt_cnt = 1500;
+  limits->tx_buf_sz = 1<<12;
+  limits->stream_pool_cnt = 1<<16;
+}
+
+void
+populate_quic_config( fd_quic_config_t * config ) {
+  config->role = FD_QUIC_ROLE_CLIENT;
+  config->service_interval = (ulong)1e6;
+  config->ping_interval = (ulong)1e6;
+  config->retry = 0;
+  config->initial_rx_max_stream_data = 1<<12;
+
+  config->net.ephem_udp_port.lo = 12000;
+  config->net.ephem_udp_port.hi = 12100;
+
+  config->net.dscp = 0;
 }
 
 FD_FN_PURE static inline ulong
@@ -27,6 +319,13 @@ scratch_footprint( fd_topo_tile_t const * tile ) {
   (void)tile;
   ulong l = FD_LAYOUT_INIT;
   l = FD_LAYOUT_APPEND( l, alignof( fd_benchs_ctx_t ), sizeof( fd_benchs_ctx_t ) );
+  if( !tile->benchs.no_quic ) {
+    fd_quic_limits_t quic_limits = {0};
+    populate_quic_limits( &quic_limits );
+    ulong quic_fp = fd_quic_footprint( &quic_limits );
+    l = FD_LAYOUT_APPEND( l, fd_quic_align(),          quic_fp );
+    l = FD_LAYOUT_APPEND( l, fd_aio_align(),           fd_aio_footprint() );
+  }
   return FD_LAYOUT_FINI( l, scratch_align() );
 }
 
@@ -46,10 +345,7 @@ before_frag( void * _ctx,
 
   fd_benchs_ctx_t * ctx = (fd_benchs_ctx_t *)_ctx;
 
-  if( FD_UNLIKELY( (seq%ctx->round_robin_cnt)!=ctx->round_robin_id ) ) {
-    *opt_filter = 1;
-    return;
-  }
+  *opt_filter = (int)( (seq%ctx->round_robin_cnt)!=ctx->round_robin_id );
 }
 
 static inline void
@@ -67,10 +363,77 @@ during_frag( void * _ctx,
 
   fd_benchs_ctx_t * ctx = (fd_benchs_ctx_t *)_ctx;
 
-  if( FD_UNLIKELY( -1==send( ctx->conn_fd[ ctx->packet_cnt % ctx->conn_cnt ], fd_chunk_to_laddr( ctx->mem, chunk ), sz, 0 ) ) )
-    FD_LOG_ERR(( "send() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  if( ctx->no_quic ) {
 
-  ctx->packet_cnt++;
+    if( FD_UNLIKELY( -1==send( ctx->conn_fd[ ctx->packet_cnt % ctx->conn_cnt ], fd_chunk_to_laddr( ctx->mem, chunk ), sz, 0 ) ) )
+      FD_LOG_ERR(( "send() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+
+    ctx->packet_cnt++;
+  } else {
+    service_quic( ctx );
+
+    if( FD_UNLIKELY( !ctx->quic_conn ) ) {
+      ctx->no_stream = 0;
+
+      /* try to connect */
+      uint   dest_ip   = 0;
+      ushort dest_port = fd_ushort_bswap( ctx->quic_port );
+
+      ctx->quic_conn = fd_quic_connect( ctx->quic, dest_ip, dest_port, "client" );
+
+      /* failed? try later */
+      if( FD_UNLIKELY( !ctx->quic_conn ) ) {
+        FD_LOG_NOTICE(( "no connection available" ));
+        return;
+      }
+
+      FD_LOG_NOTICE(( "connection created on port %d", (int)dest_port ));
+
+      /* set the context to point to the location
+         of the quic_conn pointer
+         this allows the notification to NULL the value when
+         a connection dies */
+      fd_quic_conn_set_context( ctx->quic_conn, ctx );
+
+      return;
+    }
+
+    fd_quic_stream_t * stream = ctx->stream;
+    if( FD_UNLIKELY( !stream ) ) {
+      ctx->stream = stream = fd_quic_conn_new_stream( ctx->quic_conn, FD_QUIC_TYPE_UNIDIR );
+      if( FD_LIKELY( stream ) ) {
+        fd_quic_stream_set_context( stream, ctx );
+      }
+    }
+
+    if( FD_UNLIKELY( !stream ) ) {
+      ctx->no_stream++;
+    } else {
+      int fin = 1;
+      fd_aio_pkt_info_t   batch[1]  = { { .buf    = fd_chunk_to_laddr( ctx->mem, chunk ),
+                                          .buf_sz = (ushort)sz } };
+      ulong               batch_cnt = 1;
+      int rtn = fd_quic_stream_send( stream, batch, batch_cnt, fin );
+      ctx->packet_cnt++;
+
+      if( FD_LIKELY( rtn == 1UL ) ) {
+        /* after using, fetch a new stream */
+        ctx->stream = stream = fd_quic_conn_new_stream( ctx->quic_conn, FD_QUIC_TYPE_UNIDIR );
+        if( FD_LIKELY( stream ) ) {
+          fd_quic_stream_set_context( stream, ctx );
+        }
+      } else if( FD_UNLIKELY( rtn == 0 ) ) {
+        FD_LOG_NOTICE(( "fd_quic_stream_send returned zero" ));
+      } else {
+        /* this can happen dring handshaking */
+        if( rtn != FD_QUIC_SEND_ERR_INVAL_CONN ) {
+          FD_LOG_ERR(( "fd_quic_stream_send failed with: %d", rtn ));
+        }
+      }
+    }
+
+    fd_quic_service( ctx->quic );
+  }
 }
 
 static void
@@ -84,13 +447,62 @@ privileged_init( fd_topo_t *      topo,
   FD_SCRATCH_ALLOC_INIT( l, scratch );
   fd_benchs_ctx_t * ctx = FD_SCRATCH_ALLOC_APPEND( l, alignof( fd_benchs_ctx_t ), sizeof( fd_benchs_ctx_t ) );
 
+  int no_quic = ctx->no_quic = tile->benchs.no_quic;
+
+  if( !no_quic ) {
+    fd_quic_limits_t quic_limits = {0};
+    populate_quic_limits( &quic_limits );
+    ulong quic_fp = fd_quic_footprint( &quic_limits );
+    void * quic_mem = FD_SCRATCH_ALLOC_APPEND( l, fd_quic_align(), quic_fp );
+    fd_quic_t * quic = fd_quic_join( fd_quic_new( quic_mem, &quic_limits ) );
+
+    populate_quic_config( &quic->config );
+
+    /* Signer */
+    fd_rng_t   _rng[1];
+    uint       seed = 4242424242;
+    fd_rng_t * rng  = fd_rng_join( fd_rng_new( _rng, seed, 0UL ) );
+
+    ctx->signer_ctx = signer_ctx( rng );
+
+    quic->config.sign_ctx = &ctx->signer_ctx;
+    quic->config.sign     = signer;
+
+    fd_memcpy( quic->config.identity_public_key, ctx->signer_ctx.public_key, 32UL );
+
+    /* store the pointer to quic and quic_rx_aio for later use */
+    ctx->quic        = quic;
+    ctx->quic_rx_aio = fd_quic_get_aio_net_rx( quic );
+
+    ctx->tx_idx = 0UL;
+    ctx->stream = NULL;
+
+    /* call wallclock so glibc loads VDSO, which requires calling mmap while
+       privileged */
+    fd_log_wallclock();
+  }
+
   ushort port = 12000;
 
   ctx->conn_cnt = tile->benchs.conn_cnt;
+  if( !no_quic ) ctx->conn_cnt = 1;
   FD_TEST( ctx->conn_cnt <=sizeof(ctx->conn_fd)/sizeof(*ctx->conn_fd) );
+  ctx->quic_port = tile->benchs.send_to_port;
   for( ulong i=0UL; i<ctx->conn_cnt ; i++ ) {
     int conn_fd = socket( AF_INET, SOCK_DGRAM, 0 );
     if( FD_UNLIKELY( -1==conn_fd ) ) FD_LOG_ERR(( "socket() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+
+    int recvbuff = 8<<20;
+
+    // Set the buffer size
+    if( setsockopt( conn_fd, SOL_SOCKET, SO_RCVBUF, &recvbuff, sizeof(recvbuff) ) < 0 ) {
+	FD_LOG_ERR(( "Error setting receive buffer size. Error: %d %s", errno, strerror( errno ) ));
+    }
+
+    int sendbuff = 8<<20;
+    if( setsockopt( conn_fd, SOL_SOCKET, SO_SNDBUF, &sendbuff, sizeof(sendbuff) ) < 0 ) {
+	FD_LOG_ERR(( "Error setting transmit buffer size. Error: %d %s", errno, strerror( errno ) ));
+    }
 
     ushort found_port = 0;
     for( ulong j=0UL; j<10UL; j++ ) {
@@ -115,7 +527,11 @@ privileged_init( fd_topo_t *      topo,
     };
     if( FD_UNLIKELY( -1==connect( conn_fd, fd_type_pun( &addr ), sizeof(addr) ) ) ) FD_LOG_ERR(( "connect() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
 
-    ctx->conn_fd[ i ] = conn_fd;
+    ctx->conn_fd[ i ]      = conn_fd;
+    if( !no_quic ) {
+      ctx->poll_fd[i].fd     = conn_fd;
+      ctx->poll_fd[i].events = POLLIN;
+    }
     port++;
   }
 }
@@ -134,9 +550,143 @@ unprivileged_init( fd_topo_t *      topo,
 
   ctx->mem = topo->workspaces[ topo->objs[ topo->links[ tile->in_link_id[ 0UL ] ].dcache_obj_id ].wksp_id ].wksp;
 
+  void * aio_mem  = NULL;
+
+  if( !ctx->no_quic ) {
+    fd_quic_limits_t quic_limits = {0};
+    populate_quic_limits( &quic_limits );
+    ulong quic_fp = fd_quic_footprint( &quic_limits );
+    FD_SCRATCH_ALLOC_APPEND( l, fd_quic_align(), quic_fp );
+
+    fd_quic_t * quic = ctx->quic;
+    aio_mem = FD_SCRATCH_ALLOC_APPEND( l, fd_aio_align(), fd_aio_footprint() );
+    fd_aio_t * quic_tx_aio = fd_aio_join( fd_aio_new( aio_mem, ctx, quic_tx_aio_send ) );
+
+    if( FD_UNLIKELY( !quic_tx_aio ) ) FD_LOG_ERR(( "fd_aio_join failed" ));
+
+    uint  quic_ip_addr             = 0;     /* TODO fetch the quic destination ip addr */
+    ulong quic_idle_timeout_millis = 10000;  /* idle timeout in milliseconds */
+    uchar quic_src_mac_addr[6]     = {0};   /* source MAC address */
+    quic->config.role                       = FD_QUIC_ROLE_CLIENT;
+    quic->config.net.ip_addr                = quic_ip_addr;
+    quic->config.net.listen_udp_port        = 42424; /* should be unused */
+    quic->config.idle_timeout               = quic_idle_timeout_millis * 1000000UL;
+    quic->config.initial_rx_max_stream_data = 1<<15;
+    quic->config.retry                      = 0; /* unused on clients */
+    fd_memcpy( quic->config.link.src_mac_addr, quic_src_mac_addr, 6 );
+
+    quic->cb.conn_new         = quic_conn_new;
+    quic->cb.conn_hs_complete = handshake_complete;
+    quic->cb.conn_final       = conn_final;
+    quic->cb.stream_new       = quic_stream_new;
+    quic->cb.stream_receive   = quic_stream_receive;
+    quic->cb.stream_notify    = quic_stream_notify;
+    quic->cb.now              = quic_now;
+    quic->cb.now_ctx          = NULL;
+    quic->cb.quic_ctx         = ctx;
+
+    fd_quic_set_aio_net_tx( quic, quic_tx_aio );
+    if( FD_UNLIKELY( !fd_quic_init( quic ) ) ) FD_LOG_ERR(( "fd_quic_init failed" ));
+
+    ulong hdr_sz = 14 + 20 + 8;
+    for( ulong i = 0; i < IO_VEC_CNT; i++ ) {
+      /* leave space for headers */
+      ctx->rx_iovecs[i].iov_base         = ctx->rx_bufs[i]         + hdr_sz;
+      ctx->rx_iovecs[i].iov_len          = sizeof(ctx->rx_bufs[i]) - hdr_sz;
+      ctx->rx_msgs[i].msg_hdr.msg_iov    = &ctx->rx_iovecs[i];
+      ctx->rx_msgs[i].msg_hdr.msg_iovlen = 1;
+    }
+  }
+
   ulong scratch_top = FD_SCRATCH_ALLOC_FINI( l, 1UL );
   if( FD_UNLIKELY( scratch_top > (ulong)scratch + scratch_footprint( tile ) ) )
     FD_LOG_ERR(( "scratch overflow %lu %lu %lu", scratch_top - (ulong)scratch - scratch_footprint( tile ), scratch_top, (ulong)scratch + scratch_footprint( tile ) ));
+
+}
+
+static void
+quic_tx_aio_send_flush( fd_benchs_ctx_t * ctx ) {
+  if( FD_LIKELY( ctx->tx_idx ) ) {
+    int flags = MSG_DONTWAIT;
+    int rtn = sendmmsg( ctx->conn_fd[0], ctx->tx_msgs, (uint)ctx->tx_idx, flags );
+    if( FD_UNLIKELY( rtn < 0 ) ) {
+      FD_LOG_NOTICE(( "Error occurred in sendmmsg. Error: %d %s",
+          errno, strerror( errno ) ));
+    }
+    ctx->tx_idx = 0;
+  }
+}
+
+static int
+quic_tx_aio_send( void *                    _ctx,
+                  fd_aio_pkt_info_t const * batch,
+                  ulong                     batch_cnt,
+                  ulong *                   opt_batch_idx,
+                  int                       flush ) {
+  (void)_ctx;
+  (void)batch;
+  (void)batch_cnt;
+  (void)opt_batch_idx;
+  (void)flush;
+
+  fd_benchs_ctx_t * ctx = (fd_benchs_ctx_t *)_ctx;
+
+  /* quic adds eth, ip and udp headers which we don't need */
+  /* assume 14 + 20 + 8 for those */
+  ulong hdr_sz = 14+20+8;
+
+  if( FD_LIKELY( batch_cnt ) ) {
+    /* do we have space? */
+    ulong remain = IO_VEC_CNT - ctx->tx_idx;
+    if( FD_UNLIKELY( remain > batch_cnt ) ) {
+      quic_tx_aio_send_flush( ctx );
+
+      /* tx_idx may have changed */
+      remain = IO_VEC_CNT - ctx->tx_idx;
+    }
+
+    ulong cnt = fd_ulong_min( remain, batch_cnt );
+    ulong tx_idx = ctx->tx_idx;
+    for( ulong j = 0; j < cnt; ++j ) {
+      if( FD_UNLIKELY( batch[j].buf_sz < hdr_sz ) ) continue;
+
+      char * tx_buf = ctx->tx_bufs[tx_idx];
+
+      /* copy, stripping the header */
+      fd_memcpy( tx_buf, (uchar*)batch[j].buf + hdr_sz, batch[j].buf_sz - hdr_sz );
+
+      ctx->tx_iovecs[tx_idx].iov_base         = tx_buf;
+      ctx->tx_iovecs[tx_idx].iov_len          = batch[j].buf_sz - hdr_sz;
+      ctx->tx_msgs[tx_idx].msg_hdr.msg_iov    = &ctx->tx_iovecs[tx_idx];
+      ctx->tx_msgs[tx_idx].msg_hdr.msg_iovlen = 1;
+
+      tx_idx++;
+    }
+
+    /* write back */
+    ctx->tx_idx = tx_idx;
+
+    // TODO count drops?
+    // ctx->dropped += batch_cnt - remain;
+  }
+
+  if( FD_UNLIKELY( ctx->tx_idx == IO_VEC_CNT || flush ) ) {
+    quic_tx_aio_send_flush( ctx );
+  }
+
+  if( FD_LIKELY( opt_batch_idx ) ) *opt_batch_idx = batch_cnt;
+
+  return 0;
+}
+
+static void
+before_credit( void * _ctx,
+               fd_mux_context_t * mux ) {
+  (void)mux;
+
+  fd_benchs_ctx_t * ctx = (fd_benchs_ctx_t*)_ctx;
+
+  service_quic( ctx );
 }
 
 fd_topo_run_tile_t fd_tile_benchs = {
@@ -144,6 +694,7 @@ fd_topo_run_tile_t fd_tile_benchs = {
   .mux_flags                = FD_MUX_FLAG_MANUAL_PUBLISH | FD_MUX_FLAG_COPY,
   .burst                    = 1UL,
   .mux_ctx                  = mux_ctx,
+  .mux_before_credit        = before_credit,
   .mux_before_frag          = before_frag,
   .mux_during_frag          = during_frag,
   .scratch_align            = scratch_align,

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -200,6 +200,7 @@ typedef struct {
       ushort send_to_port;
       uint   send_to_ip_addr;
       ulong  conn_cnt;
+      int    no_quic;
     } benchs;
 
     struct {

--- a/src/waltz/quic/fd_quic_conn.c
+++ b/src/waltz/quic/fd_quic_conn.c
@@ -66,6 +66,8 @@ fd_quic_conn_footprint_ext( fd_quic_limits_t const * limits,
   if( FD_UNLIKELY( limits->initial_stream_cnt[2] > limits->stream_cnt[2] ) ) return 0UL;
   if( FD_UNLIKELY( limits->initial_stream_cnt[3] > limits->stream_cnt[3] ) ) return 0UL;
 
+  stream_cnt = layout->stream_cnt = limits->stream_pool_cnt;
+
   ulong off  = 0;
 
   off += sizeof( fd_quic_conn_t );

--- a/src/waltz/quic/fd_quic_conn.h
+++ b/src/waltz/quic/fd_quic_conn.h
@@ -123,6 +123,7 @@ struct fd_quic_conn {
   int                handshake_complete;  /* have we completed a successful handshake? */
   int                handshake_done_send; /* do we need to send handshake-done to peer? */
   int                handshake_done_ackd; /* was handshake_done ack'ed? */
+  int                hs_data_empty;       /* has all hs_data been consumed? */
   fd_quic_tls_hs_t * tls_hs;
 
   /* expected handshake data offset - one per encryption level
@@ -259,6 +260,7 @@ struct fd_quic_conn {
   uint state;
   uint reason;     /* quic reason for closing. see FD_QUIC_CONN_REASON_* */
   uint app_reason; /* application reason for closing */
+  uint int_reason; /* internal reason */
 
 
   /* TODO find better name than pool */

--- a/src/waltz/quic/fd_quic_pkt_meta.h
+++ b/src/waltz/quic/fd_quic_pkt_meta.h
@@ -132,7 +132,7 @@ struct fd_quic_pkt_meta_pool {
   fd_quic_pkt_meta_list_t free;    /* free pkt_meta */
 
   /* one of each of these for each enc_level */
-  fd_quic_pkt_meta_list_t sent[4]; /* sent pkt_meta */
+  fd_quic_pkt_meta_list_t sent_pkt_meta[4]; /* sent pkt_meta */
 };
 
 
@@ -154,7 +154,6 @@ fd_quic_pkt_meta_pop_front( fd_quic_pkt_meta_list_t * list );
 void
 fd_quic_pkt_meta_push_front( fd_quic_pkt_meta_list_t * list,
                              fd_quic_pkt_meta_t *      pkt_meta );
-
 
 /* push onto back of list */
 void

--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -319,7 +319,8 @@ fd_quic_cb_stream_notify( fd_quic_t *        quic,
 void
 fd_quic_pkt_meta_retry( fd_quic_t *          quic,
                         fd_quic_conn_t *     conn,
-                        int                  force );
+                        int                  force,
+                        uint                 arg_enc_level );
 
 /* reclaim resources associated with packet metadata
    this is called in response to received acks */

--- a/src/waltz/quic/templ/fd_quic_transport_params.h
+++ b/src/waltz/quic/templ/fd_quic_transport_params.h
@@ -126,13 +126,13 @@ X( ack_delay_exponent,                                                          
 X( max_ack_delay,                                                                      \
   0x0b,                                                                                \
   VARINT,                                                                              \
-  DFT_UNKNOWN,                                                                         \
+  25,                                                                                  \
   "The maximum acknowledgment delay is an integer value indicating the maximum "       \
   "amount of time in milliseconds by which the endpoint will delay sending "           \
   "acknowledgments. This value SHOULD include the receiver's expected delays in "      \
   "alarms firing. For example, if a receiver sets a timer for 5ms and alarms "         \
   "commonly fire up to 1ms late, then it should send a max_ack_delay of 6ms. If "      \
-  "this value is absent, a default of 25 milliseconds is assumed. Values of 214 or "   \
+  "this value is absent, a default of 25 milliseconds is assumed. Values of 2^14 or "  \
   "greater are invalid.",                                                              \
   __VA_ARGS__ )                                                                        \
 X( disable_active_migration,                                                           \


### PR DESCRIPTION
bench code needs the following, but putting these into another PR:
  quic_enable - hard coded flag to use quic rather than udp: should be configurable
  only supports one connection. Each benchs should have a connection for each fd_quic tile

This PR should help us move forward with the demo