### PR TITLE
runtime: vote program hardening, support 'tower sync'

### DIFF
--- a/src/flamenco/genesis/fd_genesis_create.c
+++ b/src/flamenco/genesis/fd_genesis_create.c
@@ -123,8 +123,8 @@ genesis_create( void *                       buf,
     vs->node_pubkey             = options->identity_pubkey;
     vs->authorized_withdrawer   = options->identity_pubkey;
     vs->commission              = 100;
-    vs->authorized_voters.pool  = fd_vote_authorized_voters_pool_alloc ( fd_scratch_virtual() );
-    vs->authorized_voters.treap = fd_vote_authorized_voters_treap_alloc( fd_scratch_virtual() );
+    vs->authorized_voters.pool  = fd_vote_authorized_voters_pool_alloc ( fd_scratch_virtual(), 1UL );
+    vs->authorized_voters.treap = fd_vote_authorized_voters_treap_alloc( fd_scratch_virtual(), 1UL );
 
     fd_vote_authorized_voter_t * ele =
       fd_vote_authorized_voters_pool_ele_acquire( vs->authorized_voters.pool );

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -5,6 +5,7 @@
 #include "sysvar/fd_sysvar_cache.h"
 #include "sysvar/fd_sysvar_clock.h"
 #include "sysvar/fd_sysvar_epoch_schedule.h"
+#include "sysvar/fd_sysvar_recent_hashes.h"
 #include "sysvar/fd_sysvar_stake_history.h"
 #include "sysvar/fd_sysvar.h"
 #include "../../ballet/base58/fd_base58.h"
@@ -89,7 +90,7 @@ fd_runtime_init_bank_from_genesis( fd_exec_slot_ctx_t *  slot_ctx,
   slot_ctx->slot_bank.block_height = 0UL;
 
   fd_block_block_hash_entry_t *hashes = slot_ctx->slot_bank.recent_block_hashes.hashes =
-      deq_fd_block_block_hash_entry_t_alloc(slot_ctx->valloc);
+      deq_fd_block_block_hash_entry_t_alloc( slot_ctx->valloc, FD_SYSVAR_RECENT_HASHES_CAP );
   fd_block_block_hash_entry_t *elem = deq_fd_block_block_hash_entry_t_push_head_nocopy(hashes);
   fd_block_block_hash_entry_new(elem);
   fd_memcpy(elem->blockhash.hash, genesis_hash, FD_SHA256_HASH_SZ);
@@ -1183,7 +1184,7 @@ fd_runtime_finalize_txns_tpool( fd_exec_slot_ctx_t * slot_ctx,
             for ( deq_fd_block_block_hash_entry_t_iter_t iter = deq_fd_block_block_hash_entry_t_iter_init( hashes_deque );
                   !deq_fd_block_block_hash_entry_t_iter_done( hashes_deque, iter );
                   iter = deq_fd_block_block_hash_entry_t_iter_next( hashes_deque, iter ) ) {
-              /* If the block hash entry matches the transactions recent block hash, we skip thje hash */
+              /* If the block hash entry matches the transactions recent block hash, we skip the hash */
               fd_block_block_hash_entry_t * entry = deq_fd_block_block_hash_entry_t_iter_ele( hashes_deque, iter );
               if ( memcmp( entry->blockhash.hash, recent_blockhash->hash, sizeof(fd_hash_t) ) == 0 ) {
                 skip_hash = 1;
@@ -3796,7 +3797,7 @@ fd_runtime_replay( fd_runtime_ctx_t * state, fd_runtime_args_t * args ) {
     prev_slot = slot;
   }
 
-  if( state->tpool ) { 
+  if( state->tpool ) {
     fd_tpool_fini( state->tpool );
   }
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_recent_hashes.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_recent_hashes.h
@@ -2,7 +2,16 @@
 #define HEADER_fd_src_flamenco_runtime_sysvar_fd_recent_hashes_h
 
 #include "../../fd_flamenco_base.h"
-#include "../fd_executor.h"
+
+/* FD_SYSVAR_RECENT_HASHES_CAP is the max number of block hash entries
+   the recent blockhashes sysvar will include.
+   
+   https://github.com/anza-xyz/agave/blob/6398ddf6ab8a8f81017bf675ab315a70067f0bf0/sdk/program/src/sysvar/recent_blockhashes.rs#L32
+*/
+
+#define FD_SYSVAR_RECENT_HASHES_CAP (150UL)
+
+FD_PROTOTYPES_BEGIN
 
 /* The recent hashes sysvar */
 
@@ -13,6 +22,8 @@ fd_sysvar_recent_hashes_init( fd_exec_slot_ctx_t * slot_ctx );
 /* Update the recent hashes sysvar account. This should be called at the start of every slot, before execution commences. */
 void
 fd_sysvar_recent_hashes_update( fd_exec_slot_ctx_t * slot_ctx );
+
+FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_flamenco_runtime_sysvar_fd_recent_hashes_h */
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
@@ -31,12 +31,13 @@ void write_slot_hashes( fd_exec_slot_ctx_t * slot_ctx, fd_slot_hashes_t* slot_ha
 //}
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/slot_hashes.rs#L34 */
-void fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx ) {
+void
+fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx ) {
   FD_SCRATCH_SCOPE_BEGIN {
 
     fd_slot_hashes_t slot_hashes;
     if( !fd_sysvar_slot_hashes_read( &slot_hashes, slot_ctx ) ) {
-      slot_hashes.hashes = deq_fd_slot_hash_t_alloc( slot_ctx->valloc );
+      slot_hashes.hashes = deq_fd_slot_hash_t_alloc( slot_ctx->valloc, FD_SYSVAR_SLOT_HASHES_CAP );
       FD_TEST( slot_hashes.hashes );
     }
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.h
@@ -7,11 +7,21 @@
 
 /* The slot hashes sysvar contains the most recent hashes of the slot's parent bank hashes. */
 
+/* FD_SYSVAR_SLOT_HASHES_CAP is the max number of entries that the
+   "slot hashes" sysvar will include.
+   
+   https://github.com/anza-xyz/agave/blob/6398ddf6ab8a8f81017bf675ab315a70067f0bf0/sdk/program/src/slot_hashes.rs#L19 */
+
+#define FD_SYSVAR_SLOT_HASHES_CAP (512UL)
+
+FD_PROTOTYPES_BEGIN
+
 /* Initialize the slot hashes sysvar account. */
 // void fd_sysvar_slot_hashes_init( fd_exec_slot_ctx_t* global );
 
 /* Update the slot hashes sysvar account. This should be called at the end of every slot, before execution commences. */
-void fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx);
+void
+fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx);
 
 /* fd_sysvar_slot_hashes_read reads the slot hashes sysvar from the
    accounts manager.  On success, returns 0 and writes deserialized
@@ -20,6 +30,8 @@ void fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx);
 fd_slot_hashes_t *
 fd_sysvar_slot_hashes_read( fd_slot_hashes_t *   result,
                             fd_exec_slot_ctx_t * slot_ctx );
+
+FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_flamenco_runtime_sysvar_fd_slot_hashes_h */
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.c
@@ -4,6 +4,10 @@
 #include "../fd_system_ids.h"
 #include "../context/fd_exec_slot_ctx.h"
 
+/* Ensure that the size declared by our header matches the minimum size
+   of the corresponding fd_types entry. */
+FD_STATIC_ASSERT( FD_SYSVAR_STAKE_HISTORY_CAP == FD_STAKE_HISTORY_MIN, types );
+
 void
 write_stake_history( fd_exec_slot_ctx_t * slot_ctx,
                      fd_stake_history_t * stake_history ) {
@@ -43,8 +47,8 @@ fd_sysvar_stake_history_read( fd_stake_history_t * result,
 void
 fd_sysvar_stake_history_init( fd_exec_slot_ctx_t * slot_ctx ) {
   fd_stake_history_t stake_history = {
-    .pool = fd_stake_history_pool_alloc( slot_ctx->valloc ),
-    .treap = fd_stake_history_treap_alloc( slot_ctx->valloc )
+    .pool  = fd_stake_history_pool_alloc ( slot_ctx->valloc, FD_SYSVAR_STAKE_HISTORY_CAP ),
+    .treap = fd_stake_history_treap_alloc( slot_ctx->valloc, FD_SYSVAR_STAKE_HISTORY_CAP )
   };
   write_stake_history( slot_ctx, &stake_history );
 }

--- a/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.h
@@ -4,6 +4,13 @@
 #include "../../fd_flamenco_base.h"
 #include "../fd_executor.h"
 
+/* FD_SYSVAR_STAKE_HISTORY_CAP is the max number of entries that the
+   "stake history" sysvar will include.
+   
+   https://github.com/anza-xyz/agave/blob/6398ddf6ab8a8f81017bf675ab315a70067f0bf0/sdk/program/src/stake_history.rs#L12 */
+
+#define FD_SYSVAR_STAKE_HISTORY_CAP (512UL)
+
 FD_PROTOTYPES_BEGIN
 
 /* The stake history sysvar contains the history of cluster-wide activations and de-activations per-epoch. Updated at the start of each epoch. */

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -10,6 +10,7 @@
 #include "../context/fd_exec_epoch_ctx.h"
 #include "../context/fd_exec_slot_ctx.h"
 #include "../context/fd_exec_txn_ctx.h"
+#include "../sysvar/fd_sysvar_recent_hashes.h"
 #include "../../../funk/fd_funk.h"
 #include "../../../util/bits/fd_float.h"
 #include <assert.h>
@@ -222,7 +223,7 @@ _context_create( fd_exec_instr_test_runner_t *        runner,
   /* TODO: Restore slot_bank */
 
   fd_slot_bank_new( &slot_ctx->slot_bank );
-  fd_block_block_hash_entry_t * recent_block_hashes = deq_fd_block_block_hash_entry_t_alloc( slot_ctx->valloc );
+  fd_block_block_hash_entry_t * recent_block_hashes = deq_fd_block_block_hash_entry_t_alloc( slot_ctx->valloc, FD_SYSVAR_RECENT_HASHES_CAP );
   slot_ctx->slot_bank.recent_block_hashes.hashes = recent_block_hashes;
   fd_block_block_hash_entry_t * recent_block_hash = deq_fd_block_block_hash_entry_t_push_tail_nocopy( recent_block_hashes );
   fd_memset( recent_block_hash, 0, sizeof(fd_block_block_hash_entry_t) );

--- a/src/flamenco/types/fd_bincode.h
+++ b/src/flamenco/types/fd_bincode.h
@@ -51,7 +51,6 @@ typedef struct fd_bincode_destroy_ctx fd_bincode_destroy_ctx_t;
 #define FD_BINCODE_ERR_UNDERFLOW   (-1001) /* Attempted to read past end of buffer */
 #define FD_BINCODE_ERR_OVERFLOW    (-1002) /* Attempted to write past end of buffer */
 #define FD_BINCODE_ERR_ENCODING    (-1003) /* Invalid encoding */
-#define FD_BINCODE_ERR_SMALL_DEQUE (-1004) /* deque max size is too small */
 
 #define FD_BINCODE_PRIMITIVE_STUBS( name, type ) \
   static inline int \

--- a/src/flamenco/types/fd_types.json
+++ b/src/flamenco/types/fd_types.json
@@ -190,7 +190,7 @@
       "name": "stake_history",
       "type": "struct",
       "fields": [
-        { "name": "fd_stake_history", "type": "treap", "treap_t": "fd_stake_history_entry_t", "treap_query_t": "ulong", "treap_cmp": "((q == (e)->epoch) ? 0 : ((q < (e)->epoch) ? -1 : 1 ) )", "treap_lt": "((e0)->epoch<(e1)->epoch)", "max": 512, "rev": true }
+        { "name": "fd_stake_history", "type": "treap", "treap_t": "fd_stake_history_entry_t", "treap_query_t": "ulong", "treap_cmp": "((q == (e)->epoch) ? 0 : ((q < (e)->epoch) ? -1 : 1 ) )", "treap_lt": "((e0)->epoch<(e1)->epoch)", "min": 512, "rev": true }
       ],
       "comment": "https://github.com/firedancer-io/solana/blob/v1.17/sdk/program/src/stake_history.rs#L12-L75"
     },
@@ -738,9 +738,9 @@
           { "name": "prior_voters", "type": "vote_prior_voters_0_23_5" },
           { "name": "authorized_withdrawer", "type": "pubkey" },
           { "name": "commission", "type": "uchar" },
-          { "name": "votes", "type": "deque", "element": "vote_lockout", "max":1228 },
+          { "name": "votes", "type": "deque", "element": "vote_lockout", "min": 32 },
           { "name": "root_slot", "type": "option", "element": "ulong", "flat": true },
-          { "name": "epoch_credits", "type": "deque", "element": "vote_epoch_credits", "max":100 },
+          { "name": "epoch_credits", "type": "deque", "element": "vote_epoch_credits", "min": 64 },
           { "name": "last_timestamp", "type": "vote_block_timestamp" }
       ],
       "comment": "https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/vote_state_0_23_5.rs#L6"
@@ -749,7 +749,7 @@
       "name": "vote_authorized_voters",
       "type": "struct",
       "fields": [
-          { "name": "fd_vote_authorized_voters", "type": "treap", "treap_t": "fd_vote_authorized_voter_t", "treap_query_t": "ulong", "treap_cmp": "( (q == (e)->epoch) ? 0 : ( (q < (e)->epoch) ? -1 : 1 ) )", "treap_lt": "((e0)->epoch<(e1)->epoch)", "max": 64, "upsert": true }
+          { "name": "fd_vote_authorized_voters", "type": "treap", "treap_t": "fd_vote_authorized_voter_t", "treap_query_t": "ulong", "treap_cmp": "( (q == (e)->epoch) ? 0 : ( (q < (e)->epoch) ? -1 : 1 ) )", "treap_lt": "((e0)->epoch<(e1)->epoch)", "min": 64, "upsert": true }
       ],
       "comment": "https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L310"
     },
@@ -760,11 +760,11 @@
           { "name": "node_pubkey", "type": "pubkey" },
           { "name": "authorized_withdrawer", "type": "pubkey" },
           { "name": "commission", "type": "uchar" },
-          { "name": "votes", "type": "deque", "element": "vote_lockout", "max":1228 },
+          { "name": "votes", "type": "deque", "element": "vote_lockout", "min": 32 },
           { "name": "root_slot", "type": "option", "element": "ulong", "flat": true },
           { "name": "authorized_voters", "type": "vote_authorized_voters" },
           { "name": "prior_voters", "type": "vote_prior_voters" },
-          { "name": "epoch_credits", "type": "deque", "element": "vote_epoch_credits", "max":64 },
+          { "name": "epoch_credits", "type": "deque", "element": "vote_epoch_credits", "min": 64 },
           { "name": "last_timestamp", "type": "vote_block_timestamp" }
       ],
       "comment": "https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L310"
@@ -776,11 +776,11 @@
           { "name": "node_pubkey", "type": "pubkey" },
           { "name": "authorized_withdrawer", "type": "pubkey" },
           { "name": "commission", "type": "uchar" },
-          { "name": "votes", "type": "deque", "element": "landed_vote", "max":35 },
+          { "name": "votes", "type": "deque", "element": "landed_vote", "min": 32 },
           { "name": "root_slot", "type": "option", "element": "ulong", "flat": true },
           { "name": "authorized_voters", "type": "vote_authorized_voters" },
           { "name": "prior_voters", "type": "vote_prior_voters" },
-          { "name": "epoch_credits", "type": "deque", "element": "vote_epoch_credits", "max":100 },
+          { "name": "epoch_credits", "type": "deque", "element": "vote_epoch_credits", "min": 64 },
           { "name": "last_timestamp", "type": "vote_block_timestamp" }
       ],
       "comment": "https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L310"
@@ -800,7 +800,7 @@
       "name": "vote_state_update",
       "type": "struct",
       "fields": [
-        { "name": "lockouts", "type": "deque", "element": "vote_lockout", "max": 1228 },
+        { "name": "lockouts", "type": "deque", "element": "vote_lockout", "min": 32 },
         { "name": "root", "type": "option", "element": "ulong", "flat": true },
         { "name": "hash", "type": "hash" },
         { "name": "timestamp", "type": "option", "element": "ulong" }
@@ -830,7 +830,7 @@
       "name": "tower_sync",
       "type": "struct",
       "fields": [
-        { "name": "lockouts", "type": "array", "element": "vote_lockout", "length": 32 },
+        { "name": "lockouts", "type": "deque", "element": "vote_lockout" },
         { "name": "lockouts_cnt", "type": "ulong" },
         { "name": "root", "type": "option", "element": "ulong", "flat": true },
         { "name": "hash", "type": "hash" },
@@ -885,7 +885,7 @@
       "name": "slot_hashes",
       "type": "struct",
       "fields": [
-          { "name": "hashes", "type": "deque", "element": "slot_hash", "max":512 }
+          { "name": "hashes", "type": "deque", "element": "slot_hash", "min": 512 }
       ],
       "comment": "https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/slot_hashes.rs#L31"
     },
@@ -901,7 +901,7 @@
       "name": "recent_block_hashes",
       "type": "struct",
       "fields": [
-          { "name": "hashes", "type": "deque", "element": "block_block_hash_entry", "max":350 }
+          { "name": "hashes", "type": "deque", "element": "block_block_hash_entry", "min": 151 }
       ]
     },
     {
@@ -1077,7 +1077,7 @@
       "name": "vote",
       "type": "struct",
       "fields": [
-        { "name": "slots", "type": "deque", "element": "ulong", "max":35 },
+        { "name": "slots", "type": "deque", "element": "ulong" },
         { "name": "hash", "type": "hash" },
         { "name": "timestamp", "type": "option", "element": "ulong" }
       ],
@@ -1492,7 +1492,7 @@
       "name": "config_keys",
       "type": "struct",
       "fields": [
-        { "name": "keys", "type": "vector", "element": "config_keys_pair", "modifier": "compact", "max":35 }
+        { "name": "keys", "type": "vector", "element": "config_keys_pair", "modifier": "compact" }
       ],
       "comment": "https://github.com/solana-labs/solana/blob/a03ae63daff987912c48ee286eb8ee7e8a84bf01/programs/config/src/lib.rs#L32"
     },


### PR DESCRIPTION
- types: fd_treap and fd_deque alloc helper to accept custom max
- sysvar: define max element count for 'slot hashes', 'recent block hashes', and 'stake history'
- types: change collection 'max' to 'min', update deserializer to always allocate enough capacity for collections
- types: remove 'SMALL_DEQUE' error
- program: support vote program 'tower sync' instructions

A note on hardening:

Previously, Firedancer used Agave's size limits for various dynamically sized bincode data structures, such as the lockouts deque of the vote instruction and vote state.

A malicious user could provide a oversize structure in instruction data though.  Similarly, a fuzzer could provide a corrupted vote state, though this is assumed to not be possible on a real network.

We did not handle this case correctly and would instead fail to deserialize the input (potentially leading to a different execution result).

The real item count limit of dynamically sized structures in native programs is derived from size limitations:  instruction data size is ~1.2kB max, account size is 10MiB max.

This patch updates fd_types to consider the previous 'max' item count limits as minimums instead.  If any larger structure is provided, the deserializer will allocate as much as needed.  (Provably bounded as the deserializer always advances when it makes an allocation, and verifies that the serialization is valid before allocating)

This handles all cases correctly.  If the user provides 0 vote lockouts, we allocate 31 (the minimum), which is enough space to correctly execute native program business logic, which might append more entries to the structure.  If the user provides 100 vote lockouts, we allocate 100, as that exceeds the minimum.

However, we do still need to ensure that the native program never attempts to add more items to a collection in the oversize case. This is out of scope for this PR.