### PR TITLE
flamenco: adding system program CPI to extend instruction

### DIFF
--- a/src/flamenco/runtime/program/fd_native_cpi.c
+++ b/src/flamenco/runtime/program/fd_native_cpi.c
@@ -67,17 +67,17 @@ fd_native_cpi_execute_system_program_instruction( fd_exec_instr_ctx_t * ctx,
   }
 
   fd_bincode_encode_ctx_t ctx2;
-  uchar buf[4096UL];
+  uchar buf[4096UL]; // Size that is large enough for the instruction
   ctx2.data = buf;
-  ctx2.dataend = (uchar*)ctx2.data + 4096UL;
+  ctx2.dataend = (uchar*)ctx2.data + sizeof(buf);
   int err = fd_system_program_instruction_encode( instr, &ctx2 );
-  if (err != FD_EXECUTOR_INSTR_SUCCESS) {
-    FD_LOG_WARNING(("Encode failed"));
-    return err;
+  if( err ) {
+    FD_LOG_WARNING(( "Encode failed" ));
+    return FD_EXECUTOR_INSTR_ERR_FATAL;
   }
 
   instr_info->data = buf;
-  instr_info->data_sz = 4096UL;
+  instr_info->data_sz = sizeof(buf);
   ulong exec_err = fd_vm_prepare_instruction( ctx->instr, instr_info, ctx, instruction_accounts,
                                               &instruction_accounts_cnt, signers, signers_cnt );
   if( exec_err != FD_EXECUTOR_INSTR_SUCCESS ) {

--- a/src/flamenco/runtime/tests/Local.mk
+++ b/src/flamenco/runtime/tests/Local.mk
@@ -27,6 +27,7 @@ run-runtime-test-1: $(OBJDIR)/unit-test/test_runtime $(OBJDIR)/bin/fd_frank_ledg
 	OBJDIR=$(OBJDIR) src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-251418170 -s snapshot-251418170-8sAkojR9PYTZvqiQZ1VWu27ewX5tXeVdC97wMXAtgHnT.tar.zst -p 64 -m 2000000 -e 251418233
 	OBJDIR=$(OBJDIR) src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-257066033 -s snapshot-257066033-AD2nFFTCtZVmo5nXLVsQMV1hiQDjzoEBXibRicBJc5Vw.tar.zst -p 16 -m 5000000 -e 257066038 --zst
 	OBJDIR=$(OBJDIR) src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-257066844 -s snapshot-257066844-B5JpRYzvMa4iyQeR8w9co4y7oEayphgbXVeQHXLDoWvV.tar.zst -p 16 -m 5000000 -e 257066849 --zst
+	OBJDIR=$(OBJDIR) src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-257067457 -s snapshot-257067457-DxbpHefwdjLkPecZG2jLuqyQp8me9dFZQMQ8hZMyfhsw.tar.zst -p 16 -m 5000000 -e 257067461 --zst
 
 #	src/flamenco/runtime/run_bpf_tests.sh
 


### PR DESCRIPTION
1. Adding system program transfer CPI for extend instruction in bpf program
2. Native program CPI cleanup
3. Adding ledger test