### PR TITLE
remove FD_HAS_FFI

### DIFF
--- a/src/ballet/bn254/Local.mk
+++ b/src/ballet/bn254/Local.mk
@@ -1,12 +1,10 @@
 ifneq ($(FD_HAS_LIBFF),)
-ifndef FD_HAS_FFI
 
 $(call add-hdrs,fd_bn254.h fd_poseidon.h)
 $(call add-objs,fd_bn254 fd_poseidon_params fd_poseidon,fd_ballet)
 $(call make-unit-test,test_bn254,test_bn254,fd_ballet fd_util)
 $(call make-unit-test,test_poseidon,test_poseidon,fd_ballet fd_util)
 
-endif
 else
 
 $(info bn254 disabled due to lack of libff)

--- a/src/util/sandbox/Local.mk
+++ b/src/util/sandbox/Local.mk
@@ -1,5 +1,3 @@
-ifndef FD_HAS_FFI
 $(call add-hdrs,fd_sandbox.h)
 $(call add-objs,fd_sandbox,fd_util)
 $(call make-unit-test,test_sandbox,test_sandbox,fd_util)
-endif

--- a/src/util/sandbox/fd_sandbox.h
+++ b/src/util/sandbox/fd_sandbox.h
@@ -1,7 +1,6 @@
 #ifndef HEADER_fd_src_util_sandbox_fd_sandbox_h
 #define HEADER_fd_src_util_sandbox_fd_sandbox_h
 
-#ifndef FD_HAS_FFI
 #ifdef FD_HAS_HOSTED
 
 #include "../fd_util_base.h"
@@ -170,6 +169,5 @@ ulong
 fd_sandbox_gettid( void );
 
 #endif /* FD_HAS_HOSTED */
-#endif /* FD_HAS_FFI */
 
 #endif /* HEADER_fd_src_util_sandbox_fd_sandbox_h */


### PR DESCRIPTION
Removes a defunct config variable that's a relict of the past.
