### PR TITLE
feat(choreo): vote counting and equivocation handling for fork choice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ deps-bundle.tar.zst
 /book/.vitepress/cache
 /book/.vitepress/dist
 /book/node_modules
+
+# TVU
+testnet.toml

--- a/src/choreo/bft/fd_bft.h
+++ b/src/choreo/bft/fd_bft.h
@@ -27,7 +27,7 @@ struct fd_bft {
   ulong      epoch_stake; /* total amount of stake in the current epoch */
   fd_tower_t tower;       /* our local vote tower */
 
-  /* external joins */
+  /* external joins, pointer don't need updating */
 
   fd_acc_mgr_t *    acc_mgr;
   fd_blockstore_t * blockstore;

--- a/src/choreo/ghost/test_ghost.c
+++ b/src/choreo/ghost/test_ghost.c
@@ -41,12 +41,12 @@ test_ghost_simple( fd_ghost_t * ghost ) {
 
   fd_pubkey_t    pk1 = { .key = { 1 } };
   fd_slot_hash_t sh2 = { .slot = 2, .hash = pubkey_null };
-  fd_ghost_latest_vote_upsert( ghost, &sh2, &pk1, 1 );
+  fd_ghost_replay_vote_upsert( ghost, &sh2, &pk1, 1 );
 
   fd_ghost_print( ghost );
 
   fd_slot_hash_t sh3 = { .slot = 3, .hash = pubkey_null };
-  fd_ghost_latest_vote_upsert( ghost, &sh3, &pk1, 1 );
+  fd_ghost_replay_vote_upsert( ghost, &sh3, &pk1, 1 );
 
   fd_ghost_print( ghost );
 }


### PR DESCRIPTION
This PR updates the vote counting and equivocation handling in fd_bft and fd_ghost. Blocks get marked as equivocating if we have a different bank hash from what is being voted on for a given slot. Also added and cleaned up error checks when running with handholding.