### PR TITLE
topo: add concrete sized, aligned, topology objs

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -535,10 +535,10 @@ fd_topo_tile_to_config( fd_topo_tile_t const * tile ) {
 ulong
 fdctl_obj_align( fd_topo_t const *     topo,
                  fd_topo_obj_t const * obj ) {
-  #define VAL(name) (__extension__({                                                               \
-    ulong __x = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "obj.%lu.%s", obj->id, name );      \
-    if( FD_UNLIKELY( __x==ULONG_MAX ) ) FD_LOG_ERR(( "obj.%lu.%s was not set", obj->id, name )); \
-    __x; }))
+  ulong align = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "obj.%lu.%s", obj->id, "align" );
+  if( align!=ULONG_MAX ) {
+    return align;
+  }
 
   if( FD_UNLIKELY( !strcmp( obj->name, "tile" ) ) ) {
     fd_topo_tile_t const * tile = NULL;
@@ -564,10 +564,9 @@ fdctl_obj_align( fd_topo_t const *     topo,
   } else if( FD_UNLIKELY( !strcmp( obj->name, "metrics" ) ) ) {
     return FD_METRICS_ALIGN;
   } else {
-    ulong align = VAL("align");
-    return align;
+    FD_LOG_ERR(( "unknown object `%s`", obj->name ));
+    return 0UL;
   }
-#undef VAL
 }
 
 ulong
@@ -578,6 +577,11 @@ fdctl_obj_footprint( fd_topo_t const *     topo,
       if( FD_UNLIKELY( __x==ULONG_MAX ) ) FD_LOG_ERR(( "obj.%lu.%s was not set", obj->id, name )); \
       __x; }))
   
+  ulong sz = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "obj.%lu.%s", obj->id, "sz" );
+  if( sz!=ULONG_MAX ) {
+    return sz;
+  }
+
   if( FD_UNLIKELY( !strcmp( obj->name, "tile" ) ) ) {
     fd_topo_tile_t const * tile = NULL;
     for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
@@ -602,8 +606,8 @@ fdctl_obj_footprint( fd_topo_t const *     topo,
   } else if( FD_UNLIKELY( !strcmp( obj->name, "metrics" ) ) ) {
     return FD_METRICS_FOOTPRINT( VAL("in_cnt"), VAL("out_cnt") );
   } else {
-    ulong sz = VAL("sz");
-    return sz;
+    FD_LOG_ERR(( "unknown object `%s`", obj->name ));
+    return 0UL;
   }
 #undef VAL
 }
@@ -611,6 +615,11 @@ fdctl_obj_footprint( fd_topo_t const *     topo,
 ulong
 fdctl_obj_loose( fd_topo_t const *     topo,
                  fd_topo_obj_t const * obj ) {
+  ulong loose = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "obj.%lu.%s", obj->id, "loose" );
+  if( loose!=ULONG_MAX ) {
+    return loose;
+  }
+
   if( FD_UNLIKELY( !strcmp( obj->name, "tile" ) ) ) {
     fd_topo_tile_t const * tile = NULL;
     for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
@@ -621,11 +630,6 @@ fdctl_obj_loose( fd_topo_t const *     topo,
     }
     fd_topo_run_tile_t * config = fd_topo_tile_to_config( tile );
     if( FD_LIKELY( config->loose_footprint ) ) return config->loose_footprint( tile );
-  } else {
-    ulong loose_sz = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "obj.%lu.%s", obj->id, "loose" );
-    if( loose_sz!=ULONG_MAX ) {
-      return loose_sz;
-    }
   }
   return 0UL;
 }

--- a/src/app/fdctl/configure/workspace.c
+++ b/src/app/fdctl/configure/workspace.c
@@ -31,6 +31,18 @@ fdctl_obj_new( fd_topo_t const *     topo,
       if( FD_UNLIKELY( __x==ULONG_MAX ) ) FD_LOG_ERR(( "obj.%lu.%s was not set", obj->id, name )); \
       __x; }))
 
+  ulong align = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "obj.%lu.align", obj->id );
+  ulong sz    = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "obj.%lu.sz", obj->id );
+  ulong loose = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "obj.%lu.loose", obj->id );
+  
+  if( align!=ULONG_MAX && sz!=ULONG_MAX && loose!=ULONG_MAX ) {
+    /* If the object specified the properities necessary to be concrete then
+       we should not call any sort of `new` function on it. The user is
+       responsible for initializing the data structure properly after topology
+       init time. */
+    return;
+  }
+
   void * laddr = fd_topo_obj_laddr( topo, obj->id );
 
   if( FD_UNLIKELY( !strcmp( obj->name, "tile" ) ) ) {
@@ -48,14 +60,7 @@ fdctl_obj_new( fd_topo_t const *     topo,
   } else if( FD_UNLIKELY( !strcmp( obj->name, "metrics" ) ) ) {
     fd_metrics_new( laddr, VAL("in_cnt"), VAL("out_cnt") );
   } else {
-    /* if the object specified the properities necessary to be concrete */
-    ulong align = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "obj.%lu.align", obj->id );
-    ulong sz    = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "obj.%lu.sz", obj->id );
-    ulong loose = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "obj.%lu.loose", obj->id );
-
-    if( align==ULONG_MAX || sz==ULONG_MAX || loose==ULONG_MAX ) {
-      FD_LOG_ERR(( "unknown object `%s` or either `align`, `sz` or `loose` are missing", obj->name ));
-    }
+    FD_LOG_ERR(( "unknown object `%s`", obj->name ));
   }
 #undef VAL
 }

--- a/src/app/fdctl/configure/workspace.c
+++ b/src/app/fdctl/configure/workspace.c
@@ -48,7 +48,14 @@ fdctl_obj_new( fd_topo_t const *     topo,
   } else if( FD_UNLIKELY( !strcmp( obj->name, "metrics" ) ) ) {
     fd_metrics_new( laddr, VAL("in_cnt"), VAL("out_cnt") );
   } else {
-    FD_LOG_ERR(( "unknown object `%s`", obj->name ));
+    /* if the object specified the properities necessary to be concrete */
+    ulong align = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "obj.%lu.align", obj->id );
+    ulong sz    = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "obj.%lu.sz", obj->id );
+    ulong loose = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "obj.%lu.loose", obj->id );
+
+    if( align==ULONG_MAX || sz==ULONG_MAX || loose==ULONG_MAX ) {
+      FD_LOG_ERR(( "unknown object `%s` or either `align`, `sz` or `loose` are missing", obj->name ));
+    }
   }
 #undef VAL
 }

--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -46,6 +46,22 @@ fd_topob_obj( fd_topo_t *  topo,
   return obj;
 }
 
+fd_topo_obj_t *
+fd_topob_obj_concrete( fd_topo_t *  topo,
+                       char const * obj_name,
+                       char const * wksp_name,
+                       ulong align,
+                       ulong sz,
+                       ulong loose ) {
+  fd_topo_obj_t * obj = fd_topob_obj( topo, obj_name, wksp_name );
+
+  FD_TEST( fd_pod_insertf_ulong( topo->props, align, "obj.%lu.align", obj->id ) );
+  FD_TEST( fd_pod_insertf_ulong( topo->props, sz,    "obj.%lu.sz",    obj->id ) );
+  FD_TEST( fd_pod_insertf_ulong( topo->props, loose, "obj.%lu.loose", obj->id ) );
+
+  return obj;
+}
+
 void
 fd_topob_link( fd_topo_t *  topo,
                char const * link_name,

--- a/src/disco/topo/fd_topob.h
+++ b/src/disco/topo/fd_topob.h
@@ -51,6 +51,24 @@ fd_topob_obj( fd_topo_t *  topo,
               char const * obj_name,
               char const * wksp_name );
 
+/* Add an object with the given name, size and alignment to the toplogy.  An
+   object is something that takes up space in memory, in a workspace.  The
+   `align`, `sz` and `loose` parameters denote the alignment, maximum memory
+   and loose space to be assigned to the object.
+
+   The workspace must exist and have been added to the topology.
+   Adding an object will cause it to occupt space in memory, but not
+   be mapped into any tiles.  If you wish the object to be readable or
+   writable by a tile, you need to add a fd_topob_tile_uses relationship. */
+
+fd_topo_obj_t *
+fd_topob_obj_concrete( fd_topo_t *  topo,
+                       char const * obj_name,
+                       char const * wksp_name,
+                       ulong align,
+                       ulong sz,
+                       ulong loose );
+
 /* Add a relationship saying that a certain tile uses a given object.
    This has the effect that when memory mapping required workspaces
    for a tile, it will map the workspace required for this object in


### PR DESCRIPTION
Adds an explicit function for adding sized and aligned object to topology. This allows us to add objects like blockstore and funk to a topology without special case logic for every single object in a topology.
