### PR TITLE
add fd_wksp_mprotect api

### DIFF
--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -1019,7 +1019,7 @@ fd_wksp_restore( fd_wksp_t *  wksp,
    a seg fault. */
 
 void
-fd_wksp_set_readonly( fd_wksp_t * wksp, int flag );
+fd_wksp_mprotect( fd_wksp_t * wksp, int flag );
 
 FD_PROTOTYPES_END
 

--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -1014,6 +1014,13 @@ fd_wksp_restore( fd_wksp_t *  wksp,
                  char const * path,
                  uint         seed );
 
+/* fd_wksp_readonly marks all the memory in a workspace as read-only
+   (flag==1) or read-write (flag==0). Accessing read-only memory produces
+   a seg fault. */
+
+void
+fd_wksp_set_readonly( fd_wksp_t * wksp, int flag );
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_util_wksp_fd_wksp_h */

--- a/src/util/wksp/fd_wksp_admin.c
+++ b/src/util/wksp/fd_wksp_admin.c
@@ -785,7 +785,7 @@ fd_wksp_rebuild( fd_wksp_t * wksp,
 }
 
 void
-fd_wksp_set_readonly( fd_wksp_t * wksp, int flag ) {
+fd_wksp_mprotect( fd_wksp_t * wksp, int flag ) {
   if( FD_UNLIKELY( !wksp ) ) {
     FD_LOG_WARNING(( "NULL wksp" ));
     return;


### PR DESCRIPTION
This api provides a way to set a workspace to be read-only. This is useful for security and debugging.