### PR TITLE
topo: fd_topob_new uses caller-owned address

### DIFF
--- a/src/app/fdctl/run/topos/fd_frankendancer.c
+++ b/src/app/fdctl/run/topos/fd_frankendancer.c
@@ -15,7 +15,7 @@ fd_topo_frankendancer( config_t * config ) {
   ulong bank_tile_cnt   = config->layout.bank_tile_count;
   ulong shred_tile_cnt  = config->layout.shred_tile_count;
 
-  fd_topo_t topo[1] = { fd_topob_new( config->name ) };
+  fd_topo_t * topo = { fd_topob_new( &config->topo, config->name ) };
 
   /*             topo, name */
   fd_topob_wksp( topo, "net_quic" );

--- a/src/app/fddev/spammer.c
+++ b/src/app/fddev/spammer.c
@@ -96,7 +96,7 @@ spammer_cmd_fn( args_t *         args,
   if( FD_UNLIKELY( !args->spammer.connections ) )
     args->spammer.connections = config->layout.quic_tile_count;
 
-  fd_topo_t topo[ 1 ] = { fd_topob_new( config->name ) };
+  fd_topo_t * topo = { fd_topob_new( &config->topo, config->name ) };
   add_bench_topo( topo,
                   args->spammer.affinity,
                   args->spammer.benchg,

--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -2,15 +2,29 @@
 
 #include "fd_pod_format.h"
 
-fd_topo_t
-fd_topob_new( char const * app_name ) {
-  fd_topo_t topo[1] = {0};
+fd_topo_t *
+fd_topob_new( void * mem,
+              char const * app_name ) {
+  fd_topo_t * topo = (fd_topo_t *)mem;
+
+  if( FD_UNLIKELY( !topo ) ) {
+    FD_LOG_WARNING( ( "NULL topo" ) );
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)topo, alignof(fd_topo_t) ) ) ) {
+    FD_LOG_WARNING( ( "misaligned topo" ) );
+    return NULL;
+  }
+
+  fd_memset( topo, 0, sizeof(fd_topo_t) );
+
   FD_TEST( fd_pod_new( topo->props, sizeof(topo->props) ) );
 
   if( FD_UNLIKELY( strlen( app_name )>=sizeof(topo->app_name) ) ) FD_LOG_ERR(( "app_name too long: %s", app_name ));
   strncpy( topo->app_name, app_name, sizeof(topo->app_name) );
 
-  return *topo;
+  return topo;
 }
 
 void

--- a/src/disco/topo/fd_topob.h
+++ b/src/disco/topo/fd_topob.h
@@ -24,11 +24,13 @@
 
 FD_PROTOTYPES_BEGIN
 
-/* Initialize a new fd_topo_t with the given app name, the topology will
-   be empty with no tiles, objects, links. */
+/* Initialize a new fd_topo_t with the given app name and at the memory address
+   provided.  Returns the topology at given address.  The topology will be empty
+   with no tiles, objects, links. */
 
-fd_topo_t
-fd_topob_new( char const * app_name );
+fd_topo_t *
+fd_topob_new( void * mem, 
+              char const * app_name );
 
 /* Add a workspace with the given name to the topology.  Workspace names
    must be unique and adding the same workspace twice will produce an


### PR DESCRIPTION
The `fd_topo_t` type is getting a bit big to put on the stack. This addresses the major case were that was causing issues.
