### PR TITLE
Fix underflow error in binary search

### DIFF
--- a/src/flamenco/runtime/program/fd_vote_program.c
+++ b/src/flamenco/runtime/program/fd_vote_program.c
@@ -829,7 +829,7 @@ last_voted_slot( fd_vote_state_t * self ) {
 static int
 contains_slot( fd_vote_state_t * vote_state, ulong slot ) {
   ulong start = 0UL;
-  ulong end   = deq_fd_landed_vote_t_cnt( vote_state->votes );
+  ulong end   = deq_fd_landed_vote_t_cnt( vote_state->votes ) - 1;
 
   while( start <= end ) {
     ulong mid      = start + ( end - start ) / 2;
@@ -839,6 +839,9 @@ contains_slot( fd_vote_state_t * vote_state, ulong slot ) {
     } else if( mid_slot < slot ) {
       start = mid + 1;
     } else {
+      if (mid == 0) {
+        break;
+      }
       end = mid - 1;
     }
   }


### PR DESCRIPTION
Case if `start = 0, end = 1`, and `slot` is lower than all values in the deque. When mid = 0, `end = mid - 1` which causes an underflow and thus a segfault / infinite loop.

Similarly, if `slot` is greater than all deque values, we may try to access a value at `vote_state->votes[len]` which would cause an out of bounds memory access.