### PR TITLE
Add two fields to fd_topo_run_tile_t:

### DIFF
--- a/src/app/fddev/main1.c
+++ b/src/app/fddev/main1.c
@@ -51,6 +51,8 @@ extern fd_topo_run_tile_t fd_tile_bencho;
 extern fd_topo_run_tile_t fd_tile_benchg;
 extern fd_topo_run_tile_t fd_tile_benchs;
 
+fd_topo_run_tile_t fd_tile_tvu_thread = { .name = "thread", .for_tpool = 1 };
+
 fd_topo_run_tile_t * TILES[] = {
   &fd_tile_net,
   &fd_tile_netmux,

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -254,6 +254,7 @@ typedef struct {
   ulong                         mux_flags;
   ulong                         burst;
   ulong                         rlimit_file_cnt;
+  int                           for_tpool;
   void * (*mux_ctx           )( void * scratch );
 
   fd_mux_during_housekeeping_fn * mux_during_housekeeping;
@@ -272,6 +273,7 @@ typedef struct {
   ulong (*loose_footprint         )( fd_topo_tile_t const * tile );
   void  (*privileged_init         )( fd_topo_t * topo, fd_topo_tile_t * tile, void * scratch );
   void  (*unprivileged_init       )( fd_topo_t * topo, fd_topo_tile_t * tile, void * scratch );
+  int   (*main                    )( void );
 } fd_topo_run_tile_t;
 
 FD_PROTOTYPES_BEGIN


### PR DESCRIPTION
  `int for_tpool;`
      when set this a call to `run_tile_thread()` will not spawn a thread so the tpool can handle the thread spawning later
  `int   (*main                    )( void );`
      When not NULL this function is called instead of `fd_mux_tile()`.