### PR TITLE
add fd_tile_private_map_boot() to fd_tile.h for later tpool use in fddev

### DIFF
--- a/src/util/tile/fd_tile.h
+++ b/src/util/tile/fd_tile.h
@@ -165,6 +165,10 @@ fd_tile_private_boot( int *    pargc,
                       char *** pargv );
 
 void
+fd_tile_private_map_boot( ushort * tile_to_cpu,
+                          ulong    tile_cnt );
+
+void
 fd_tile_private_halt( void );
 
 FD_PROTOTYPES_END

--- a/src/util/tile/fd_tile_threads.cxx
+++ b/src/util/tile/fd_tile_threads.cxx
@@ -526,24 +526,8 @@ fd_tile_private_cpus_parse( char const * cstr,
 static fd_tile_private_cpu_config_t fd_tile_private_cpu_config_save[1];
 
 void
-fd_tile_private_boot( int *    pargc,
-                      char *** pargv ) {
-  FD_LOG_INFO(( "fd_tile: boot" ));
-
-  /* Extract the tile configuration from the command line */
-
-  char const * cpus = fd_env_strip_cmdline_cstr( pargc, pargv, "--tile-cpus", "FD_TILE_CPUS", NULL );
-  if( !cpus ) FD_LOG_INFO(( "fd_tile: --tile-cpus not specified" ));
-  else        FD_LOG_INFO(( "fd_tile: --tile-cpus \"%s\"", cpus ));
-  ushort tile_to_cpu[ FD_TILE_MAX ];
-  ulong  tile_cnt = fd_tile_private_cpus_parse( cpus, tile_to_cpu );
-
-  if( FD_UNLIKELY( !tile_cnt ) ) {
-    FD_LOG_INFO(( "fd_tile: no cpus specified; treating thread group as single tile running on O/S assigned cpu(s)" ));
-    tile_to_cpu[0] = (ushort)65535;
-    tile_cnt       = 1UL;
-  }
-
+fd_tile_private_map_boot( ushort * tile_to_cpu,
+                          ulong    tile_cnt ) {
   fd_tile_private_id0 = fd_log_thread_id();
   fd_tile_private_id1 = fd_tile_private_id0 + tile_cnt;
   fd_tile_private_cnt = tile_cnt;
@@ -743,6 +727,33 @@ fd_tile_private_boot( int *    pargc,
   fd_memcpy( fd_tile_private_cpu_id, tile_to_cpu, fd_tile_private_cnt*sizeof(ushort) );
 
   FD_LOG_INFO(( "fd_tile: boot success" ));
+}
+
+void
+fd_tile_private_boot_str( char const * cpus ) {
+  ushort tile_to_cpu[ FD_TILE_MAX ];
+  ulong  tile_cnt = fd_tile_private_cpus_parse( cpus, tile_to_cpu );
+
+  if( FD_UNLIKELY( !tile_cnt ) ) {
+    FD_LOG_INFO(( "fd_tile: no cpus specified; treating thread group as single tile running on O/S assigned cpu(s)" ));
+    tile_to_cpu[0] = (ushort)65535;
+    tile_cnt       = 1UL;
+  }
+
+  fd_tile_private_map_boot( tile_to_cpu, tile_cnt );
+}
+
+void
+fd_tile_private_boot( int *    pargc,
+                      char *** pargv ) {
+  /* Extract the tile configuration from the command line */
+
+  char const * cpus = fd_env_strip_cmdline_cstr( pargc, pargv, "--tile-cpus", "FD_TILE_CPUS", NULL );
+
+  if( !cpus ) FD_LOG_INFO(( "fd_tile: --tile-cpus not specified" ));
+  else        FD_LOG_INFO(( "fd_tile: --tile-cpus \"%s\"", cpus ));
+
+  fd_tile_private_boot_str( cpus );
 }
 
 void


### PR DESCRIPTION
`fd_tile_private_map_boot` will allow a tile to boot a tpool on the CPUs specified by `tile_to_cpu`. These CPUs have tiles running on them with `for_tpool = 1` from https://github.com/firedancer-io/firedancer/pull/1742.