### PR TITLE
Fix underflowing in contains_slot when votes count is 0

### DIFF
--- a/src/flamenco/runtime/program/fd_vote_program.c
+++ b/src/flamenco/runtime/program/fd_vote_program.c
@@ -828,8 +828,14 @@ last_voted_slot( fd_vote_state_t * self ) {
 
 static int
 contains_slot( fd_vote_state_t * vote_state, ulong slot ) {
+  // Prevent underflowing of end boundary
+  ulong size = deq_fd_landed_vote_t_cnt( vote_state->votes );
+  if( FD_UNLIKELY( size == 0 ) ) {
+    return 0;
+  }
+
   ulong start = 0UL;
-  ulong end   = deq_fd_landed_vote_t_cnt( vote_state->votes ) - 1;
+  ulong end   = size - 1;
 
   while( start <= end ) {
     ulong mid      = start + ( end - start ) / 2;
@@ -839,7 +845,7 @@ contains_slot( fd_vote_state_t * vote_state, ulong slot ) {
     } else if( mid_slot < slot ) {
       start = mid + 1;
     } else {
-      if (mid == 0) {
+      if( mid == 0 ) {
         break;
       }
       end = mid - 1;


### PR DESCRIPTION
#1733 Fixed an issue with underflows during the binary search but also introduced an underflow issue when `deq_fd_landed_vote_t_cnt( vote_state->votes )` returns 0.

Closes [issue](https://github.com/firedancer-io/auditor-internal/issues/54).