### PR TITLE
tiles: sign tile supports asan

### DIFF
--- a/src/app/fdctl/run/tiles/fd_sign.c
+++ b/src/app/fdctl/run/tiles/fd_sign.c
@@ -171,12 +171,23 @@ privileged_init( fd_topo_t *      topo,
   ctx->private_key = identity_key;
   ctx->public_key  = identity_key + 32UL;
 
+  /* The stack can be taken over and reorganized by under AddressSanitizer, 
+     which causes this code to fail.  */
+#if FD_HAS_ASAN
+  FD_LOG_WARNING(( "!!! SECURITY WARNING !!! YOU ARE RUNNING THE SIGNING TILE "
+                   "WITH ADDRESS SANITIZER ENABLED. THIS CAN LEAK SENSITIVE " 
+                   "DATA INCLUDING YOUR PRIVATE KEYS INTO CORE DUMPS IF THIS "
+                   "PROCESS ABORTS. IT IS HIGHLY ADVISED TO NOT TO RUN IN THIS "
+                   "MODE IN PRODUCTION!" ));
+#else
   /* Prevent the stack from showing up in core dumps just in case the
      private key somehow ends up in there. */
   FD_TEST( fd_tile_stack0() );
   FD_TEST( fd_tile_stack_sz() );
   if( FD_UNLIKELY( madvise( (void*)fd_tile_stack0(), fd_tile_stack_sz(), MADV_DONTDUMP ) ) )
     FD_LOG_ERR(( "madvise failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+#endif
+  
 }
 
 static void FD_FN_SENSITIVE


### PR DESCRIPTION
Under ASan, sign tile freaks out when ASan changes the stack configuration. This fixes that.
