### PR TITLE
bank: rewrite status cache

### DIFF
--- a/src/disco/bank/Local.mk
+++ b/src/disco/bank/Local.mk
@@ -1,2 +1,5 @@
-$(call add-hdrs,fd_bank_abi.h)
-$(call add-objs,fd_bank_abi,fd_disco)
+$(call add-hdrs,fd_bank_abi.h fd_txncache.h fd_rwlock.h)
+$(call add-objs,fd_bank_abi fd_txncache,fd_disco)
+$(call make-unit-test,test_txncache,test_txncache,fd_disco fd_util)
+# TODO: Reenable after fixing purge reprobing bug
+# $(call run-unit-test,test_txncache,)

--- a/src/disco/bank/fd_rwlock.h
+++ b/src/disco/bank/fd_rwlock.h
@@ -1,0 +1,57 @@
+#ifndef HEADER_fd_src_disco_bank_rwlock_h
+#define HEADER_fd_src_disco_bank_rwlock_h
+
+/* A very simple read-write spin lock. */
+
+#include "../fd_disco_base.h"
+#include "../../util/fd_util_base.h"
+
+struct fd_rwlock {
+  ushort value; /* Bits 0..16 are
+
+                    0: Unlocked
+                    1..=0xFFFE: Locked by N readers
+                    0xFFFF: Write locked */
+};
+
+typedef struct fd_rwlock fd_rwlock_t;
+
+static inline void
+fd_rwlock_write( fd_rwlock_t * lock ) {
+  for(;;) {
+    ushort value = lock->value;
+    if( FD_LIKELY( !value ) ) {
+      if( FD_LIKELY( !FD_ATOMIC_CAS( &lock->value, 0, 0xFFFF ) ) ) return;
+    }
+    FD_SPIN_PAUSE();
+  }
+  FD_COMPILER_MFENCE();
+}
+
+static inline void
+fd_rwlock_unwrite( fd_rwlock_t * lock ) {
+  FD_COMPILER_MFENCE();
+  lock->value = 0;
+}
+
+static inline void
+fd_rwlock_read( fd_rwlock_t * lock ) {
+  for(;;) {
+    ushort value = lock->value;
+    if( FD_UNLIKELY( value!=0xFFFE ) ) {
+      if( FD_LIKELY( FD_ATOMIC_CAS( &lock->value, value, value+1 )==value ) ) {
+        return;
+      }
+    }
+    FD_SPIN_PAUSE();
+  }
+  FD_COMPILER_MFENCE();
+}
+
+static inline void
+fd_rwlock_unread( fd_rwlock_t * lock ) {
+  FD_COMPILER_MFENCE();
+  FD_ATOMIC_FETCH_AND_SUB( &lock->value, 1 );
+}
+
+#endif /* HEADER_fd_src_disco_bank_rwlock_h */

--- a/src/disco/bank/fd_txncache.c
+++ b/src/disco/bank/fd_txncache.c
@@ -1,0 +1,744 @@
+#include "fd_txncache.h"
+
+#define SORT_NAME        sort_slot_ascend
+#define SORT_KEY_T       ulong
+#define SORT_BEFORE(a,b) (a)<(b)
+#include "../../util/tmpl/fd_sort.c"
+
+/* The number of transactions in each page.  This needs to be high
+   enough to amoritze the cost of caller code reserving pages from,
+   and returning pages to the pool, but not so high that the memory
+   wasted from blockhashes with only one transaction is significant. */
+
+#define FD_TXNCACHE_TXNS_PER_PAGE (16384UL)
+
+/* The number of unique entries in the hash lookup table for each
+   blockhash.  A higher value here uses more memory but enables faster
+   lookups. */
+
+#define FD_TXNCACHE_BLOCKCACHE_MAP_CNT (524288UL)
+
+/* The number of unique entries in the hash lookup table for each
+   (slot, blockhash).  This prevents all the entries needing to be in
+   one slotcache list, so insertions can happen concurrently. */
+
+#define FD_TXNCACHE_SLOTCACHE_MAP_CNT (1024UL)
+
+struct fd_txncache_private_txn {
+  uint  blockcache_next; /* Pointer to the next element in the blockcache hash chain containing this entry from the pool. */
+  uint  slotblockcache_next;  /* Pointer to the next element in the slotcache hash chain containing this entry from the pool. */
+
+  ulong slot;            /* Slot that the transaction was executed.  A transaction might be in the cache
+                            multiple times if it was executed in a different slot on different forks.  The
+                            same slot will not appear multiple times however. */
+  uchar txnhash[ 20 ];   /* The transaction hash, truncated to 20 bytes.  The hash is not always the first 20
+                            bytes, but is 20 bytes starting at some arbitrary offset given by the key_offset value
+                            of the containing by_blockhash entry. */
+  uchar result[ 40 ];    /* The result of executing the transaction. */
+};
+
+typedef struct fd_txncache_private_txn fd_txncache_private_txn_t;
+
+struct fd_txncache_private_txnpage {
+  ushort                    free; /* The number of free txn entries in this page. */
+  fd_txncache_private_txn_t txns[ FD_TXNCACHE_TXNS_PER_PAGE][ 1 ]; /* The transactions in the page. */
+};
+
+typedef struct fd_txncache_private_txnpage fd_txncache_private_txnpage_t;
+
+struct fd_txncache_private_blockcache {
+  uchar blockhash[ 32 ]; /* The actual blockhash of these transactions. */
+  ulong lowest_slot;     /* The lowest slot we have seen that contains a transaction referencing this blockhash.
+                            The blockhash entry will not be purged until the lowest rooted slot is at least 150
+                            slots higher than this. */
+  ulong txnhash_offset;  /* To save memory, the Agave validator decided to truncate the hash of transactions stored in
+                            this memory to 20 bytes rather than 32 bytes.  The bytes used are not the first 20 as you
+                            might expect, but instead the first 20 starting at some random offset into the transaction
+                            hash (starting between 0 and len(hash)-20, a/k/a 44 for signatures, and 12 for hashes).
+
+                            In an unfortunate turn, the offset is also propogated to peers via. snapshot responses,
+                            which only communicate the offset and the respective 20 bytes.  To make sure we are
+                            deduplicating incoming transactions correctly, we must replicate this system even though
+                            it would be easier to just always take the first 20 bytes.  For transactions that we
+                            insert into the cache ourselves, we do just always use a key_offset of zero, so this is
+                            only nonzero when constructed form a peer snapshot. */
+
+  uint  heads[ FD_TXNCACHE_BLOCKCACHE_MAP_CNT ]; /* The hash table for the blockhash.  Each entry is a pointer to the head of a
+                                                    linked list of transactions that reference this blockhash.  As we add
+                                                    transactions to the bucket, the head pointer is updated to the new item, and
+                                                    the new item is pointed to the previous head. */
+
+  ushort pages_cnt;      /* The number of txnpages currently in use to store the transactions in this blockcache. */
+  uint * pages;          /* A list of the txnpages containing the transactions for this blockcache. */
+};
+
+typedef struct fd_txncache_private_blockcache fd_txncache_private_blockcache_t;
+
+struct fd_txncache_private_slotblockcache {
+  uchar blockhash[ 32 ]; /* The actual blockhash of these transactions. */
+  ulong txnhash_offset;  /* As described above. */
+  uint  heads[ FD_TXNCACHE_SLOTCACHE_MAP_CNT ]; /* A map of the head of a linked list of tansactions in this slot and blockhash */
+};
+
+typedef struct fd_txncache_private_slotblockcache fd_txncache_private_slotblockcache_t;
+
+struct fd_txncache_private_slotcache {
+  ulong                                slot; /* The slot that this slotcache is for. */
+  fd_txncache_private_slotblockcache_t blockcache[ 300UL ];
+};
+
+typedef struct fd_txncache_private_slotcache fd_txncache_private_slotcache_t;
+
+struct __attribute__((aligned(FD_TXNCACHE_ALIGN))) fd_txncache_private {
+  fd_rwlock_t lock[ 1 ]; /* The txncache is a concurrent structure and will be accessed by multiple threads
+                            concurrently.  Insertion and querying only take a read lock as they can be done
+                            lockless but all other operations will take a write lock internally. */
+
+  ulong  root_slots_max;
+  ulong  live_slots_max;
+  ushort txnpages_per_blockhash_max;
+
+  ulong   root_slots_cnt; /* The number of root slots being tracked in the below array. */
+  ulong * root_slots; /* The highest N slots that have been rooted.  These slots are
+                         used to determine which transactions should be kept around to
+                         be queried and served to snapshot requests.  The actual
+                         footprint for this data (and other data below) are declared
+                         immediately following the struct.  I.e. these pointers point to
+                         memory not far after the struct. */
+
+  fd_txncache_private_blockcache_t * blockcache; /* The actual cache of transactions.  This is a linear probed hash
+                                                    table that maps blockhashes to the transactions that reference them.
+                                                    The depth of the hash table is live_slots_max, since this is the
+                                                    maximum number of blockhashes that can be alive.  The loading factor
+                                                    if they were all alive would be 1.0, but this is rare because we
+                                                    will almost never fork repeatedly to hit this limit.  These
+                                                    blockcaches are just pointers to pages from the txnpages below, so
+                                                    they don't take up much memory. */
+
+  ulong * slotcache_slots; /* The slots that are being tracked in the below slotcache array.  Each slot occupies 300
+                              consecutive spaces in the slotcache. */
+  fd_txncache_private_slotcache_t * slotcache; /* The cache of transactions by slot instead of by blockhash, so we
+                                                  can quickly serialize the slot deltas for the root slots which are
+                                                  served to peers in snapshots.  Similar to the above, it uses the
+                                                  same underlying transaction storage, but different lookup tables. */
+
+  ushort   txnpages_free_cnt; /* The number of pages in the txnpages that are not currently in use. */
+  ushort * txnpages_free;     /* The index in the txnpages array that is free, for each of the free pages. */
+  fd_txncache_private_txnpage_t * txnpages; /* The actual storage for the transactions.  The blockcache points to these
+                                               pages when storing transactions.  Transaction are grouped into pages of
+                                               size 16384 to make certain allocation and deallocation operations faster
+                                               (just the pages are acquired/released, rather than each txn). */
+
+  ulong magic; /* ==FD_TXNCACHE_MAGIC */
+};
+
+FD_FN_CONST static ushort
+fd_txncache_max_txnpages_per_blockhash( ulong max_txn_per_slot ) {
+  /* The maximum number of transaction pages we might need to store all
+     the transactions that could be seen in a blockhash.
+
+     In the worst case, every transaction in every slot refers to
+     the same blockhash for as long as it is possible (150 slots
+     following the slot where the blockhash is produced).  So there
+     could be up to
+
+        524,288 * 150 = 78,643,200
+
+     Note that the blockcaches store txns for forks, and the same txn
+     might appear multiple times in one block, but if there's a fork,
+     the fork has to have skipped slots (had 0 txns in them), so it
+     cannot cause this limit to go higher.
+
+     Transactions referenced by a particular blockhash.
+     Transactions are stored in pages of 16,384, so we might need up
+     to 4,800 of these pages to store all the transactions in a
+     slot. */
+
+  ulong result = 1UL+(max_txn_per_slot*150UL-1UL)/FD_TXNCACHE_TXNS_PER_PAGE;
+  if( FD_UNLIKELY( result>USHORT_MAX ) ) return 0;
+  return (ushort)result;
+}
+
+FD_FN_CONST static ushort
+fd_txncache_max_txnpages( ulong max_live_slots,
+                          ulong max_txn_per_slot ) {
+  /* We need to be able to store potentially every slot that is live
+     being completely full of transactions.  This would be
+
+       max_live_slots*max_txn_per_slot
+
+     transactions, except that we are counting pages here, not
+     transactions.  It's not enough to divide by the page size, because
+     pages might be wasted.  The maximum page wastage occurs when all
+     the blockhashes except one have one transaction in them, and the
+     remaining blockhash has all other transactions.  In that case, the
+     full blockhash needs
+
+       (max_live_slots*max_txn_per_slot)/FD_TXNCACHE_TXNS_PER_PAGE
+
+     pages, and the other blockhashes need 1 page each. */
+
+  ulong result = max_live_slots-1UL+max_live_slots*(1UL+(max_txn_per_slot-1UL)/FD_TXNCACHE_TXNS_PER_PAGE);
+  if( FD_UNLIKELY( result>USHORT_MAX ) ) return 0;
+  return (ushort)result;
+}
+
+FD_FN_CONST ulong
+fd_txncache_align( void ) {
+  return FD_TXNCACHE_ALIGN;
+}
+
+FD_FN_CONST ulong
+fd_txncache_footprint( ulong max_rooted_slots,
+                       ulong max_live_slots,
+                       ulong max_txn_per_slot ) {
+  if( FD_UNLIKELY( max_rooted_slots<1UL || max_live_slots<1UL ) ) return 0UL;
+  if( FD_UNLIKELY( max_live_slots<max_rooted_slots ) ) return 0UL;
+  if( FD_UNLIKELY( max_txn_per_slot<1UL ) ) return 0UL;
+  if( FD_UNLIKELY( !fd_ulong_is_pow2( max_live_slots || !fd_ulong_is_pow2( max_txn_per_slot ) ) ) ) return 0UL;
+
+  /* To save memory, txnpages are referenced as ushort which is enough
+     to support mainnet parameters without overflow. */
+  ushort max_txnpages = fd_txncache_max_txnpages( max_live_slots, max_txn_per_slot );
+  if( FD_UNLIKELY( !max_txnpages ) ) return 0UL;
+
+  ulong max_txnpages_per_blockhash = fd_txncache_max_txnpages_per_blockhash( max_txn_per_slot );
+  if( FD_UNLIKELY( !max_txnpages_per_blockhash ) ) return 0UL;
+
+  ulong l;
+  l = FD_LAYOUT_INIT;
+  l = FD_LAYOUT_APPEND( l, FD_TXNCACHE_ALIGN,                         sizeof(fd_txncache_t)                                   );
+  l = FD_LAYOUT_APPEND( l, alignof(ulong),                            max_rooted_slots*sizeof(ulong)                          ); /* root_slots */
+  l = FD_LAYOUT_APPEND( l, alignof(fd_txncache_private_blockcache_t), max_live_slots*sizeof(fd_txncache_private_blockcache_t) ); /* blockcache */
+  l = FD_LAYOUT_APPEND( l, alignof(uint),                             max_live_slots*max_txnpages_per_blockhash*sizeof(uint)  ); /* blockcache->pages */
+  l = FD_LAYOUT_APPEND( l, alignof(ulong),                            max_live_slots                                          ); /* slotcache_slots */
+  l = FD_LAYOUT_APPEND( l, alignof(fd_txncache_private_slotcache_t),  max_live_slots*sizeof(fd_txncache_private_slotcache_t ) ); /* slotcache */
+  l = FD_LAYOUT_APPEND( l, alignof(ushort),                           max_txnpages                                            ); /* txnpages_free */
+  l = FD_LAYOUT_APPEND( l, alignof(fd_txncache_private_txnpage_t),    max_txnpages*sizeof(fd_txncache_private_txnpage_t)      ); /* txnpages */
+  return FD_LAYOUT_FINI( l, FD_TXNCACHE_ALIGN );
+}
+
+void *
+fd_txncache_new( void * shmem,
+                 ulong  max_rooted_slots,
+                 ulong  max_live_slots,
+                 ulong  max_txn_per_slot ) {
+  fd_txncache_t * tc = (fd_txncache_t *)shmem;
+
+  if( FD_UNLIKELY( !shmem ) ) {
+    FD_LOG_WARNING(( "NULL shmem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, fd_txncache_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned shmem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !max_rooted_slots ) ) return NULL;
+  if( FD_UNLIKELY( !max_live_slots ) ) return NULL;
+  if( FD_UNLIKELY( max_live_slots<max_rooted_slots ) ) return NULL;
+  if( FD_UNLIKELY( !max_txn_per_slot ) ) return NULL;
+  if( FD_UNLIKELY( !fd_ulong_is_pow2( max_live_slots ) || !fd_ulong_is_pow2( max_txn_per_slot ) ) ) return NULL;
+
+  ushort max_txnpages               = fd_txncache_max_txnpages( max_live_slots, max_txn_per_slot );
+  ushort max_txnpages_per_blockhash = fd_txncache_max_txnpages_per_blockhash( max_txn_per_slot );
+
+  if( FD_UNLIKELY( !max_txnpages ) ) return NULL;
+  if( FD_UNLIKELY( !max_txnpages_per_blockhash ) ) return NULL;
+
+  FD_SCRATCH_ALLOC_INIT( l, shmem );
+  fd_txncache_t * txncache = FD_SCRATCH_ALLOC_APPEND( l,  FD_TXNCACHE_ALIGN,                        sizeof(fd_txncache_t)                                   );
+  void * _root_slots       = FD_SCRATCH_ALLOC_APPEND( l, alignof(ulong),                            max_rooted_slots*sizeof(ulong)                          );
+  void * _blockcache       = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_private_blockcache_t), max_live_slots*sizeof(fd_txncache_private_blockcache_t) );
+  void * _blockcache_pages = FD_SCRATCH_ALLOC_APPEND( l, alignof(uint),                             max_live_slots*max_txnpages_per_blockhash*sizeof(uint)  );
+  void * _slotcache        = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_private_slotcache_t),  max_live_slots*sizeof(fd_txncache_private_slotcache_t ) );
+  void * _txnpages_free    = FD_SCRATCH_ALLOC_APPEND( l, alignof(ushort),                           max_txnpages                                            );
+  void * _txnpages         = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_private_txnpage_t),    max_txnpages*sizeof(fd_txncache_private_txnpage_t)      );
+
+  txncache->root_slots      = _root_slots;
+  txncache->blockcache      = _blockcache;
+  txncache->slotcache       = _slotcache;
+  txncache->txnpages_free   = _txnpages_free;
+  txncache->txnpages        = _txnpages;
+
+  tc->lock->value = 0;
+  tc->root_slots_cnt = 0UL;
+
+  tc->root_slots_max             = max_rooted_slots;
+  tc->live_slots_max             = max_live_slots;
+  tc->txnpages_per_blockhash_max = max_txnpages_per_blockhash;
+
+  memset( tc->root_slots, 0xFF, max_rooted_slots*sizeof(ulong) );
+
+  for( ulong i=0UL; i<max_live_slots; i++ ) {
+    tc->blockcache[ i ].lowest_slot = ULONG_MAX;
+    tc->blockcache[ i ].pages       = (uint *)_blockcache_pages + i*max_txnpages_per_blockhash;
+    tc->slotcache[ i ].slot         = ULONG_MAX;
+  }
+
+  tc->txnpages_free_cnt = max_txnpages;
+  for( ushort i=0; i<max_txnpages; i++ ) tc->txnpages_free[ i ] = i;
+
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( tc->magic ) = FD_TXNCACHE_MAGIC;
+  FD_COMPILER_MFENCE();
+
+  return (void *)tc;
+}
+
+fd_txncache_t *
+fd_txncache_join( void * shtc ) {
+  if( FD_UNLIKELY( !shtc ) ) {
+    FD_LOG_WARNING(( "NULL shtc" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shtc, fd_txncache_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned shtc" ));
+    return NULL;
+  }
+
+  fd_txncache_t * tc = (fd_txncache_t *)shtc;
+
+  if( FD_UNLIKELY( tc->magic!=FD_TXNCACHE_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+    return NULL;
+  }
+
+  return tc;
+}
+
+void *
+fd_txncache_leave( fd_txncache_t * tc ) {
+  if( FD_UNLIKELY( !tc ) ) {
+    FD_LOG_WARNING(( "NULL tc" ));
+    return NULL;
+  }
+
+  return (void *)tc;
+}
+
+void *
+fd_txncache_delete( void * shtc ) {
+  if( FD_UNLIKELY( !shtc ) ) {
+    FD_LOG_WARNING(( "NULL shtc" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shtc, fd_txncache_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned shtc" ));
+    return NULL;
+  }
+
+  fd_txncache_t * tc = (fd_txncache_t *)shtc;
+
+  if( FD_UNLIKELY( tc->magic!=FD_TXNCACHE_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+    return NULL;
+  }
+
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( tc->magic ) = 0UL;
+  FD_COMPILER_MFENCE();
+
+  return (void *)tc;
+}
+
+static void
+fd_txncache_purge_slot( fd_txncache_t * tc,
+                        ulong           slot ) {
+  for( ulong i=0UL; i<tc->live_slots_max; i++ ) {
+    if( FD_LIKELY( tc->blockcache[ i ].lowest_slot==ULONG_MAX || (tc->blockcache[ i ].lowest_slot+150UL)>slot ) ) continue;
+    tc->blockcache[ i ].lowest_slot = ULONG_MAX;
+    memcpy( tc->txnpages_free+tc->txnpages_free_cnt, tc->blockcache[ i ].pages, tc->blockcache[ i ].pages_cnt*sizeof(ushort) );
+
+    /* TODO: Hash was removed, so any map entries that could have been
+       here but were probed later in the list need to be moved to this
+       empty slot now as well. */
+  }
+
+  for( ulong i=0UL; i<tc->live_slots_max; i++ ) {
+    if( FD_LIKELY( tc->slotcache[ i ].slot==ULONG_MAX || tc->slotcache[ i ].slot>slot ) ) continue;
+    tc->slotcache[ i ].slot = ULONG_MAX;
+
+    /* TODO: Hash was removed, so any map entries that could have been
+       here but were probed later in the list need to be moved to this
+       empty slot now as well. */
+  }
+}
+
+void
+fd_txncache_register_root_slot( fd_txncache_t * tc,
+                                ulong           slot ) {
+  fd_rwlock_write( tc->lock );
+
+  ulong idx;
+  for( idx=0UL; idx<tc->root_slots_cnt; idx++ ) {
+    if( FD_UNLIKELY( tc->root_slots[ idx ]==slot ) ) goto unlock;
+    if( FD_UNLIKELY( tc->root_slots[ idx ]>slot ) ) break;
+  }
+
+  if( FD_UNLIKELY( tc->root_slots_cnt>=tc->root_slots_max ) ) {
+    if( FD_LIKELY( idx ) ) {
+      fd_txncache_purge_slot( tc, tc->root_slots[ 0 ] );
+      memmove( tc->root_slots, tc->root_slots+1UL, (idx-1UL)*sizeof(ulong) );
+      tc->root_slots[ (idx-1UL) ] = slot;
+    } else {
+      fd_txncache_purge_slot( tc, slot );
+    }
+  } else {
+    if( FD_UNLIKELY( idx<tc->root_slots_cnt ) ) {
+      memmove( tc->root_slots+idx+1UL, tc->root_slots+idx, (tc->root_slots_cnt-idx)*sizeof(ulong) );
+    }
+    tc->root_slots[ idx ] = slot;
+    tc->root_slots_cnt++;
+  }
+
+unlock:
+  fd_rwlock_unwrite( tc->lock );
+}
+
+void
+fd_txncache_root_slots( fd_txncache_t * tc,
+                        ulong *         out_slots ) {
+  fd_rwlock_write( tc->lock );
+  memcpy( out_slots, tc->root_slots, tc->root_slots_max*sizeof(ulong) );
+  fd_rwlock_unwrite( tc->lock );
+}
+
+#define FD_TXNCACHE_FIND_FOUND      (0)
+#define FD_TXNCACHE_FIND_FOUNDEMPTY (1)
+#define FD_TXNCACHE_FIND_FULL       (2)
+
+static int
+fd_txncache_find_blockhash( fd_txncache_t const *               tc,
+                            uchar const                         blockhash[ static 32 ],
+                            fd_txncache_private_blockcache_t ** out_blockcache ) {
+  ulong hash = FD_LOAD( ulong, blockhash );
+  for( ulong i=0UL; i<tc->live_slots_max; i++ ) {
+    ulong blockcache_idx = (hash+i)%tc->live_slots_max;
+    fd_txncache_private_blockcache_t * blockcache = &tc->blockcache[ blockcache_idx ];
+    if( FD_UNLIKELY( blockcache->lowest_slot==ULONG_MAX ) ) {
+      *out_blockcache = blockcache;
+      return FD_TXNCACHE_FIND_FOUNDEMPTY;
+    }
+    while( FD_UNLIKELY( blockcache->lowest_slot==ULONG_MAX-1UL ) ) {
+      FD_SPIN_PAUSE();
+    }
+    FD_COMPILER_MFENCE(); /* Prevent reordering of the blockhash read to before the atomic lock
+                             (highest_slot) has been fully released by the writer. */
+    if( FD_LIKELY( !memcmp( blockcache->blockhash, blockhash, 32UL ) ) ) {
+      *out_blockcache = blockcache;
+      return FD_TXNCACHE_FIND_FOUND;
+    }
+  }
+  return FD_TXNCACHE_FIND_FULL;
+}
+
+static int
+fd_txncache_find_slot( fd_txncache_t const *              tc,
+                       ulong                              slot,
+                       fd_txncache_private_slotcache_t ** out_slotcache ) {
+  for( ulong i=0UL; i<tc->live_slots_max; i++ ) {
+    ulong slotcache_idx = (slot+i)%tc->live_slots_max;
+    fd_txncache_private_slotcache_t * slotcache = &tc->slotcache[ slotcache_idx ];
+    if( FD_UNLIKELY( slotcache->slot==ULONG_MAX ) ) {
+      *out_slotcache = slotcache;
+      return FD_TXNCACHE_FIND_FOUNDEMPTY;
+    }
+    while( FD_UNLIKELY( slotcache->slot==ULONG_MAX-1UL ) ) {
+      FD_SPIN_PAUSE();
+    }
+    FD_COMPILER_MFENCE(); /* Prevent reordering of the slot read to before the atomic lock
+                             (slot) has been fully released by the writer. */
+    if( FD_LIKELY( slotcache->slot==slot ) ) {
+      *out_slotcache = slotcache;
+      return FD_TXNCACHE_FIND_FOUND;
+    }
+  }
+  return FD_TXNCACHE_FIND_FULL;
+}
+
+static int
+fd_txncache_find_slot_blockhash( fd_txncache_private_slotcache_t *       slotcache,
+                                 uchar const                             blockhash[ static 32 ],
+                                 fd_txncache_private_slotblockcache_t ** out_slotblockcache ) {
+  ulong hash = FD_LOAD( ulong, blockhash );
+  for( ulong i=0UL; i<300UL; i++ ) {
+    ulong slotblockcache_idx = (hash+i)%300UL;
+    fd_txncache_private_slotblockcache_t * slotblockcache = &slotcache->blockcache[ slotblockcache_idx ];
+    if( FD_UNLIKELY( slotblockcache->txnhash_offset==ULONG_MAX ) ) {
+      *out_slotblockcache = slotblockcache;
+      return FD_TXNCACHE_FIND_FOUNDEMPTY;
+    }
+    while( FD_UNLIKELY( slotblockcache->txnhash_offset==ULONG_MAX-1UL ) ) {
+      FD_SPIN_PAUSE();
+    }
+    FD_COMPILER_MFENCE(); /* Prevent reordering of the blockhash read to before the atomic lock
+                             (txnhash_offset) has been fully released by the writer. */
+    if( FD_LIKELY( !memcmp( slotblockcache->blockhash, blockhash, 32UL ) ) ) {
+      *out_slotblockcache = slotblockcache;
+      return FD_TXNCACHE_FIND_FOUND;
+    }
+  }
+  return FD_TXNCACHE_FIND_FULL;
+}
+
+static int
+fd_txncache_ensure_blockcache( fd_txncache_t *                     tc,
+                               uchar const                         blockhash[ static 32 ],
+                               fd_txncache_private_blockcache_t ** out_blockcache ) {
+  for(;;) {
+    int blockcache_find = fd_txncache_find_blockhash( tc, blockhash, out_blockcache );
+    if( FD_LIKELY( blockcache_find==FD_TXNCACHE_FIND_FOUND ) ) return 1;
+    else if( FD_UNLIKELY( blockcache_find==FD_TXNCACHE_FIND_FULL ) ) return 0;
+
+    if( FD_LIKELY( FD_ATOMIC_CAS( &(*out_blockcache)->lowest_slot, ULONG_MAX, ULONG_MAX-1UL ) ) ) {
+      memcpy( (*out_blockcache)->blockhash, blockhash, 32UL );
+      memset( (*out_blockcache)->heads, 0xFF, FD_TXNCACHE_BLOCKCACHE_MAP_CNT*sizeof(uint) );
+      (*out_blockcache)->pages_cnt      = 0;
+      (*out_blockcache)->txnhash_offset = 0UL;
+      memset( (*out_blockcache)->pages, 0xFF, tc->txnpages_per_blockhash_max*sizeof(uint) );
+      FD_COMPILER_MFENCE();
+      (*out_blockcache)->lowest_slot    = ULONG_MAX-2UL;
+      return 1;
+    }
+    FD_SPIN_PAUSE();
+  }
+}
+
+static int
+fd_txncache_ensure_slotcache( fd_txncache_t *                    tc,
+                              ulong                              slot,
+                              fd_txncache_private_slotcache_t ** out_slotcache ) {
+  for(;;) {
+    int slotcache_find = fd_txncache_find_slot( tc, slot, out_slotcache );
+    if( FD_LIKELY( slotcache_find==FD_TXNCACHE_FIND_FOUND ) ) return 1;
+    else if( FD_UNLIKELY( slotcache_find==FD_TXNCACHE_FIND_FULL ) ) return 0;
+
+    if( FD_LIKELY( FD_ATOMIC_CAS( &(*out_slotcache)->slot, ULONG_MAX, ULONG_MAX-1UL ) ) ) {
+      for( ulong i=0UL; i<300UL; i++ ) {
+        (*out_slotcache)->blockcache[ i ].txnhash_offset = ULONG_MAX;
+      }
+      FD_COMPILER_MFENCE();
+      (*out_slotcache)->slot = slot;
+      return 1;
+    }
+    FD_SPIN_PAUSE();
+  }
+}
+
+static int
+fd_txncache_ensure_slotblockcache( fd_txncache_private_slotcache_t *       slotcache,
+                                   uchar const                             blockhash[ static 32 ],
+                                   fd_txncache_private_slotblockcache_t ** out_slotblockcache ) {
+  for(;;) {
+    int slotblockcache_find = fd_txncache_find_slot_blockhash( slotcache, blockhash, out_slotblockcache );
+    if( FD_LIKELY( slotblockcache_find==FD_TXNCACHE_FIND_FOUND ) ) return 1;
+    else if( FD_UNLIKELY( slotblockcache_find==FD_TXNCACHE_FIND_FULL ) ) return 0;
+
+    if( FD_LIKELY( FD_ATOMIC_CAS( &(*out_slotblockcache)->txnhash_offset, ULONG_MAX, ULONG_MAX-1UL ) ) ) {
+      memcpy( (*out_slotblockcache)->blockhash, blockhash, 32UL );
+      memset( (*out_slotblockcache)->heads, 0xFF, FD_TXNCACHE_SLOTCACHE_MAP_CNT*sizeof(uint) );
+      FD_COMPILER_MFENCE();
+      (*out_slotblockcache)->txnhash_offset = 0UL;
+      return 1;
+    }
+    FD_SPIN_PAUSE();
+  }
+}
+
+static fd_txncache_private_txnpage_t *
+fd_txncache_ensure_txnpage( fd_txncache_t *                    tc,
+                            fd_txncache_private_blockcache_t * blockcache ) {
+  ushort page_cnt = blockcache->pages_cnt;
+  if( FD_UNLIKELY( page_cnt>tc->txnpages_per_blockhash_max ) ) return NULL;
+
+  if( FD_LIKELY( page_cnt ) ) {
+    uint txnpage_idx = blockcache->pages[ page_cnt-1 ];
+    ushort txnpage_free = tc->txnpages[ txnpage_idx ].free;
+    if( FD_LIKELY( txnpage_free ) ) return &tc->txnpages[ txnpage_idx ];
+  }
+
+  if( FD_UNLIKELY( page_cnt==tc->txnpages_per_blockhash_max ) ) return NULL;
+  if( FD_LIKELY( FD_ATOMIC_CAS( &blockcache->pages[ page_cnt ], UINT_MAX, UINT_MAX-1UL )==UINT_MAX ) ) {
+    ulong txnpages_free_cnt = tc->txnpages_free_cnt;
+    for(;;) {
+      if( FD_UNLIKELY( !txnpages_free_cnt ) ) return NULL;
+      ulong old_txnpages_free_cnt = FD_ATOMIC_CAS( &tc->txnpages_free_cnt, (ushort)txnpages_free_cnt, (ushort)(txnpages_free_cnt-1UL) );
+      if( FD_LIKELY( old_txnpages_free_cnt==txnpages_free_cnt ) ) break;
+      txnpages_free_cnt = old_txnpages_free_cnt;
+      FD_SPIN_PAUSE();
+    }
+
+    ushort txnpage_idx = tc->txnpages_free[ txnpages_free_cnt-1UL ];
+    fd_txncache_private_txnpage_t * txnpage = &tc->txnpages[ txnpage_idx ];
+    txnpage->free = FD_TXNCACHE_TXNS_PER_PAGE;
+    FD_COMPILER_MFENCE();
+    blockcache->pages[ page_cnt ] = txnpage_idx;
+    FD_COMPILER_MFENCE();
+    blockcache->pages_cnt = (ushort)(page_cnt+1);
+    return txnpage;
+  } else {
+    uint txnpage_idx = blockcache->pages[ page_cnt ];
+    while( FD_UNLIKELY( txnpage_idx>=UINT_MAX-1UL ) ) {
+      txnpage_idx = blockcache->pages[ page_cnt ];
+      FD_SPIN_PAUSE();
+    }
+    return &tc->txnpages[ txnpage_idx ];
+  }
+}
+
+static int
+fd_txncache_insert_txn( fd_txncache_t *                        tc,
+                        fd_txncache_private_blockcache_t *     blockcache,
+                        fd_txncache_private_slotblockcache_t * slotblockcache,
+                        fd_txncache_private_txnpage_t *        txnpage,
+                        fd_txncache_insert_t const *           txn ) {
+  ulong txnpage_idx = (ulong)(txnpage - tc->txnpages);
+
+  for(;;) {
+    ushort txnpage_free = txnpage->free;
+    if( FD_UNLIKELY( !txnpage_free ) ) return 0;
+    if( FD_UNLIKELY( FD_ATOMIC_CAS( &txnpage->free, txnpage_free, txnpage_free-1UL )!=txnpage_free ) ) continue;
+  
+    ulong txn_idx = FD_TXNCACHE_TXNS_PER_PAGE-txnpage_free;
+    ulong txnhash_offset = blockcache->txnhash_offset;
+    ulong txnhash = FD_LOAD( ulong, txn->txnhash+txnhash_offset );
+    memcpy( txnpage->txns[ txn_idx ]->txnhash, txn->txnhash+txnhash_offset, 20UL );
+    memcpy( txnpage->txns[ txn_idx ]->result,  txn->result,                 40UL );
+    txnpage->txns[ txn_idx ]->slot = txn->slot;
+    FD_COMPILER_MFENCE();
+
+    for(;;) {
+      ulong txn_bucket = txnhash%FD_TXNCACHE_BLOCKCACHE_MAP_CNT;
+      uint head = blockcache->heads[ txn_bucket ];
+      txnpage->txns[ txn_idx ]->blockcache_next = head;
+      FD_COMPILER_MFENCE();
+      if( FD_LIKELY( FD_ATOMIC_CAS( &blockcache->heads[ txn_bucket ], head, (uint)(FD_TXNCACHE_TXNS_PER_PAGE*txnpage_idx+txn_idx) )==head ) ) break;
+      FD_SPIN_PAUSE();
+    }
+
+    for(;;) {
+      ulong txn_bucket = txnhash%FD_TXNCACHE_SLOTCACHE_MAP_CNT;
+      uint head = slotblockcache->heads[ txn_bucket ];
+      txnpage->txns[ txn_idx ]->slotblockcache_next = head;
+      FD_COMPILER_MFENCE();
+      if( FD_LIKELY( FD_ATOMIC_CAS( &slotblockcache->heads[ txn_bucket ], head, (uint)(FD_TXNCACHE_TXNS_PER_PAGE*txnpage_idx+txn_idx) )==head ) ) break;
+      FD_SPIN_PAUSE();
+    }
+
+    for(;;) {
+      ulong lowest_slot = blockcache->lowest_slot;
+      if( FD_UNLIKELY( txn->slot>=lowest_slot ) ) break;
+      if( FD_LIKELY( FD_ATOMIC_CAS( &blockcache->lowest_slot, lowest_slot, txn->slot )==lowest_slot ) ) break;
+      FD_SPIN_PAUSE();
+    }
+    return 1;
+  }
+}
+
+int
+fd_txncache_insert_batch( fd_txncache_t *              tc,
+                          fd_txncache_insert_t const * txns,
+                          ulong                        txns_cnt ) {
+  fd_rwlock_read( tc->lock );
+
+  for( ulong i=0UL; i<txns_cnt; i++ ) {
+    fd_txncache_private_blockcache_t * blockcache;
+    if( FD_UNLIKELY( !fd_txncache_ensure_blockcache( tc, txns[ i ].blockhash, &blockcache ) ) ) goto unlock_fail;
+
+    // TODO: We should turn this on to prevent corruption
+    // if( FD_UNLIKELY( txns[ i ].slot>=blockcache->lowest_slot+150UL ) ) goto unlock_fail;
+
+    fd_txncache_private_slotcache_t * slotcache;
+    if( FD_UNLIKELY( !fd_txncache_ensure_slotcache( tc, txns[ i ].slot, &slotcache ) ) ) goto unlock_fail;
+
+    fd_txncache_private_slotblockcache_t * slotblockcache;
+    if( FD_UNLIKELY( !fd_txncache_ensure_slotblockcache( slotcache, txns[ i ].blockhash, &slotblockcache ) ) ) goto unlock_fail;
+
+    for(;;) {
+      fd_txncache_private_txnpage_t * txnpage = fd_txncache_ensure_txnpage( tc, blockcache );
+      if( FD_UNLIKELY( !txnpage ) ) goto unlock_fail;
+
+      int success = fd_txncache_insert_txn( tc, blockcache, slotblockcache, txnpage, &txns[ i ] );
+      if( FD_LIKELY( success ) ) break;
+      FD_SPIN_PAUSE();
+    }
+  }
+
+  fd_rwlock_unread( tc->lock );
+  return 1;
+
+unlock_fail:
+  fd_rwlock_unread( tc->lock );
+  return 0;
+}
+
+void
+fd_txncache_query_batch( fd_txncache_t *             tc,
+                         fd_txncache_query_t const * queries,
+                         ulong                       queries_cnt,
+                         void *                      query_func_ctx,
+                         int ( * query_func )( ulong slot, void * ctx ),
+                         int *                       out_results ) {
+  fd_rwlock_read( tc->lock );
+
+  for( ulong i=0UL; i<queries_cnt; i++ ) {
+    out_results[ i ] = 0;
+
+    fd_txncache_query_t const * query = &queries[ i ];
+    fd_txncache_private_blockcache_t * blockcache;
+    int result = fd_txncache_find_blockhash( tc, query->blockhash, &blockcache );
+    if( FD_UNLIKELY( result!=FD_TXNCACHE_FIND_FOUND ) ) {
+      continue;
+    }
+
+    ulong txnhash_offset = blockcache->txnhash_offset;
+    ulong head_hash = FD_LOAD( ulong, query->txnhash+txnhash_offset ) % FD_TXNCACHE_BLOCKCACHE_MAP_CNT;
+    for( uint head=blockcache->heads[ head_hash ]; head!=UINT_MAX; head=tc->txnpages[ head/FD_TXNCACHE_TXNS_PER_PAGE ].txns[ head%FD_TXNCACHE_TXNS_PER_PAGE ]->blockcache_next ) {
+      fd_txncache_private_txn_t * txn = tc->txnpages[ head/FD_TXNCACHE_TXNS_PER_PAGE ].txns[ head%FD_TXNCACHE_TXNS_PER_PAGE ];
+      if( FD_LIKELY( !memcmp( query->txnhash+txnhash_offset, txn->txnhash, 20UL ) ) ) {
+        if( FD_LIKELY( !query_func || query_func( txn->slot, query_func_ctx ) ) ) {
+          out_results[ i ] = 1;
+          break;
+        }
+      }
+    }
+  }
+
+  fd_rwlock_unread( tc->lock );
+}
+
+int
+fd_txncache_snapshot( fd_txncache_t * tc,
+                      void *          ctx,
+                      int ( * write )( uchar const * data, ulong data_sz, void * ctx ) ) {
+  fd_rwlock_read( tc->lock );
+
+  for( ulong i=0UL; i<tc->root_slots_cnt; i++ ) {
+    ulong slot = tc->root_slots[ i ];
+
+    fd_txncache_private_slotcache_t * slotcache;
+    if( FD_UNLIKELY( FD_TXNCACHE_FIND_FOUND!=fd_txncache_find_slot( tc, slot, &slotcache ) ) ) continue;
+
+    for( ulong j=0UL; j<300UL; j++ ) {
+      fd_txncache_private_slotblockcache_t * slotblockcache = &slotcache->blockcache[ j ];
+      if( FD_UNLIKELY( slotblockcache->txnhash_offset>=ULONG_MAX-1UL ) ) continue;
+
+      for( ulong k=0UL; k<FD_TXNCACHE_SLOTCACHE_MAP_CNT; k++ ) {
+        uint head = slotblockcache->heads[ k ];
+        for( ; head!=UINT_MAX; head=tc->txnpages[ head/FD_TXNCACHE_TXNS_PER_PAGE ].txns[ head%FD_TXNCACHE_TXNS_PER_PAGE ]->slotblockcache_next ) {
+          fd_txncache_private_txn_t * txn = tc->txnpages[ head/FD_TXNCACHE_TXNS_PER_PAGE ].txns[ head%FD_TXNCACHE_TXNS_PER_PAGE ];
+          (void)txn; /* TODO: Actually write the transactions out here. */
+          (void)write;
+          (void)ctx;
+        }
+      }
+    }
+  }
+
+  fd_rwlock_unread( tc->lock );
+  return 0;
+}

--- a/src/disco/bank/fd_txncache.h
+++ b/src/disco/bank/fd_txncache.h
@@ -1,0 +1,373 @@
+#ifndef HEADER_fd_src_disco_bank_txncache_h
+#define HEADER_fd_src_disco_bank_txncache_h
+
+/* A txn cache is a concurrent map for saving the result (status) of
+   transactions that have executed.  In addition to supporting fast
+   concurrent insertion and query of transaction results, the txn
+   cache supports serialization of its state into a standard bincode
+   format for serving the state to other nodes via. snapshot responses,
+   and then restoring snapshots produced by other nodes.
+
+   The txn cache is designed to do two operations fast,
+
+     (a) Insertion.  Insertion is done by both the leader pipeline and
+         the replay stage, with an insertion for every transaction that
+         is executed, potentially over 1M per second.
+
+     (b) Query.  The leader pipeline queries the status of transactions
+         before executing them to ensure that it does not execute
+         anything twice.
+
+   Both of these operations are concurrent and lockless, assuming there
+   are no other (non-insert/query) operations occuring on the txn cache.
+   Most other operations lock the entire structure and will prevent both
+   insertion and query from proceeding.
+
+   The txn cache is both CPU and memory sensitive.  A transaction result
+   is 40 bytes, and the stored transaction hashes are 20 bytes, so
+   without any overhead just storing 150 slots of transactions in a flat
+   array would require
+
+      524,288 * 150 * 60 ~ 5GiB
+
+   Of memory.  But, we can't query, insert, and remove quickly from a
+   flat array.  We make a few trade-offs to achieve good performance
+   without bloating memory completely.  In particular:
+
+     - The transactions to be queried are stored in a structure that
+       looks like a
+       
+         hash_map<blockhash, hash_map<txnhash, vec<(slot, status)>>>
+
+       The top level hash_map is a probed hash map, and the txnhash map
+       is a chained hash map, where the items come from a pool of pages
+       of transactions.  We use pages of transactions to support fast
+       removal of a blockhash from the top level map, we need to return
+       at most 4,800 pages back to the pool rather than 78,643,200
+       individual transactions.
+
+       This adds additional memory overhead, a blockhash with only one
+       transaction in it will still consume a full page (16,384) of
+       transactions of memory.  Allocating a new transaction page to a
+       chained map is rare (once every 16,384 inserts) so the cost
+       amortizes to zero.  Creating a blockhash happens once per
+       blockhash, so also amortizes to zero, the only operation we care
+       about is then the simple insert case with an unfull transaction
+       page into an existing blockhash.  This can be done with two
+       compare-and-swaps,
+
+         // 1. Find the blockhash in the probed hash map.
+
+            let by_blockhash = hash_map[ blockhash ];
+
+         // 2. Request space for the transaction from the current page
+
+            let page = by_blockhash.pages.back();
+            let idx = page.used.compare_and_swap( current, current+1 );
+
+         // 3. Write the transaction into the page and the map
+
+            page.txns[ idx ] = txn;
+            page.txns[ idx ].next = by_blockhash.txns[ txnhash ].idx;
+            by_blockhash.txns[ txnhash ].head.compare_and_swap( current, idx );
+
+       Removal of a blockhash from this structure is simple because it
+       does not need to be concurrent (the caller will only remove
+       between executing slots, so there's no contention and it can take
+       a full write lock).  We take a write lock, restore the pages in
+       the blockhash to the pool, and then mark the space in the
+       hash_map as empty.  This is fast since there are at most 4,800
+       pages to restore and restoration is a simple memcpy.
+      
+     - Another structure is required to support serialization of
+       snapshots from the cache.  Serialization must produce a binary
+       structure that encodes essentially:
+
+         hash_map<slot, hash_map<blockhash, vec<(txnhash, txn_result)>>>
+
+       For each slot that is rooted.  Observe that we can't reuse the
+       structure used for queries, since it's not grouped by slot, we
+       would have to iterate all of the transactions to do this grouping
+       which is not feasible.
+
+       We can't add the slot to that index, since then query would not
+       be fast.  Queries are just against (blockhash, txnhash) pairs,
+       they don't know which slot might have included it.
+
+       So we need a second index for this information.  The index is
+       going to line up with what we described above, the root hash map
+       will be probed, and the nested hash map will be chained.  The
+       vector of results will also use a pool of pages.
+
+       In this case the page pool is for a different reason: we know a
+       sensible upper bound for the number of transactions that could be
+       alive in the entire cache at any point in time, but we don't know
+       quite how to bound it for a single slot or blockhash.  Well, we
+       do: the bound is 524,288 per (slot, blockhash) pair but we would
+       need to allocate all that memory up front.  Instead, we bound the
+       total number of slots and transactions per slot, assume the
+       transactions must be distributed somehow within the blockhashes,
+       and then give some overhead for unoccupied page entries.
+
+       The insertion process for this structure is similar to the one
+       above, except the vector is not a chained map but just a regular
+       vector.
+
+         // 1. Find the (slot, blockhash) in the probed hash map.
+
+            let by_slot_blockhash = hash_map[ slot ][ blockhash ];
+
+         // 2. Request space for the transaction from the current page
+
+            let page = by_slot_blockhash.pages.back();
+            let idx = page.used.fetch_add( 1 );
+
+         // 3. Write the transaction into the page and the map
+
+            page.txns[ idx ] = txn;
+            by_slot_blockhash.txn_count += 1;
+
+       The final increment is OK even with concurrent inserts because
+       no reader will try to observe the txn_count until the slot is
+       rooted, at which point nothing could be being inserted into it
+       and the txn_count will be finalized. */
+
+#include "fd_rwlock.h"
+#include "../fd_disco_base.h"
+
+#define FD_TXNCACHE_ALIGN (128UL)
+
+#define FD_TXNCACHE_MAGIC (0xF17EDA2CE5CAC4E0) /* FIREDANCE SCACHE V0 */
+
+/* The duration of history to keep around in the txn cache before aging
+   it out.  This must be at least 150, otherwise we could forget about
+   transactions for blockhashes that are still valid to use, and let
+   duplicate transactions make it into a produced block.
+   
+   Beyond 150, any value is valid.  The value used here, 300 comes from
+   Agave, and corresponds to roughly 2 minutes of history assuming there
+   are no forks, with an extra 12.8 seconds of history for slots that
+   are in progress but have not rooted yet.  On a production validator
+   without RPC support, the value should probably be configurable and
+   always set to strictly 150. */
+
+#define FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS (300UL)
+
+/* A note on live slots ...
+
+   The maximum number of live slots is the sum of the rooted and
+   unrooted slots.  The rooted slots are explicitly capped at 300 for
+   this structure (implying we keep around 2 minutes of history
+   around for queries and snapshots).
+
+   For the unrooted slots, we must root at least one slot in an epoch
+   for an epoch transition to occur successfully to the next one, so
+   assuming every slot is unconfirmed for some reason, and the prior
+   epoch was rooted at the first slot in the epoch, and the next epoch
+   is rooted at the last slot, there could be 
+
+      432,000 + 432,000 - 31 = 863,969
+
+   Live slots on the validator.  This is clearly impractical as each
+   bank consumes a lof of memory to store slot state, so the
+   validator would crash long before this.
+
+   For now we just pick a number: 1024, and hope for the best.  This
+   would represent the network failing to root a new slot for almost
+   five minutes.
+
+   TODO: Hmm... need to figure out what's reasonable here. */
+
+#define FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS (1024UL)
+
+/* The Solana consensus protocol has an implied restriction on the number
+   transactions in a slot.  A slot might have at most 48,000,000 CUs,
+   but a transaction requires at least around 1500 CUs, so there could
+   be at most 32,000 transactions in a slot.
+
+   For Firedancer, we respect this limit when running in production, but
+   for development and preformance tuning this limit is removed, and
+   instead we will produce and accept at most 524,288 transactions per
+   slot.  This is chosen arbitrarily and works out to around ~1.3M TPS,
+   however such a value does not exist in the consensus protocol. */
+
+#define FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT (524288UL)
+
+struct fd_txncache_insert {
+  uchar const * blockhash;
+  uchar const * txnhash;
+  ulong         slot;
+  uchar const * result;
+};
+
+typedef struct fd_txncache_insert fd_txncache_insert_t;
+
+struct fd_txncache_query {
+  uchar const * blockhash;
+  uchar const * txnhash;
+};
+
+typedef struct fd_txncache_query fd_txncache_query_t;
+
+/* Forward declare opaque handle */
+struct fd_txncache_private;
+typedef struct fd_txncache_private fd_txncache_t;
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_txncache_{align,footprint} give the needed alignment and
+   footprint of a memory region suitable to hold a txn cache.
+   fd_txncache_{align,footprint} return the same value as
+   FD_TXNCACHE_{ALIGN,FOOTPRINT}.
+
+   fd_txncache_new formats memory region with suitable alignment and
+   footprint suitable for holding a txn cache.  Assumes shmem points
+   on the caller to the first byte of the memory region owned by the
+   caller to use.  Returns shmem on success and NULL on failure (logs
+   details).  The memory region will be owned by the state on successful
+   return.  The caller is not joined on return.
+
+   fd_txncache_join joins the caller to a txn cache. Assumes shtc points
+   to the first byte of the memory region holding the state.  Returns a
+   local handle to the join on success (this is not necessarily a simple
+   cast of the address) and NULL on failure (logs details).
+
+   fd_txncache_leave leaves the caller's current local join to a txn
+   cache.  Returns a pointer to the memory region holding the state on
+   success (this is not necessarily a simple cast of the address) and
+   NULL on failure (logs details).  The caller is not joined on
+   successful return.
+
+   fd_txncache_delete unformats a memory region that holds a txn cache.
+   Assumes shtc points on the caller to the first byte of the memory
+   region holding the state and that nobody is joined.  Returns a
+   pointer to the memory region on success and NULL on failure (logs
+   details).  The caller has ownership of the memory region on
+   successful return. */
+
+FD_FN_CONST ulong
+fd_txncache_align( void );
+
+FD_FN_CONST ulong
+fd_txncache_footprint( ulong max_rooted_slots,
+                       ulong max_live_slots,
+                       ulong max_txn_per_slot );
+
+void *
+fd_txncache_new( void * shmem,
+                 ulong  max_rooted_slots,
+                 ulong  max_live_slots,
+                 ulong  max_txn_per_slot );
+
+fd_txncache_t *
+fd_txncache_join( void * shtc );
+
+void *
+fd_txncache_leave( fd_txncache_t * tc );
+
+void *
+fd_txncache_delete( void * shtc );
+
+/* fd_txncache_register_root registers a root slot in a txn cache.  Only
+   the provided limit of roots (typically 300) can exist in the txn
+   cache at once, after which the oldest roots will be purged.
+
+   Purging a root means it cannot be served in a snapshot response,
+   although transactions in the root may or may not still be present.
+   Transaction status is removed once all roots referencing the
+   blockhash of the transaction are removed from the txn cache.
+   
+   This is neither cheap or expensive, it will pause all insertion and
+   query operations but only momentarily until any old slots can be
+   purged from the cache. */
+
+void
+fd_txncache_register_root_slot( fd_txncache_t * tc,
+                                ulong           slot );
+
+/* fd_txncache_root_slots returns the list of live slots currently
+   tracked by the txn cache.  There will be at most max_root_slots
+   slots, which will be written into the provided out_slots.  It is
+   assumed tc points to a txn cache and out_slots has space for at least
+   max_root_slots results.  If there are less than max_root_slots slots
+   in the cache, the front part of out_slots will be filled in, and all
+   the remaining slots will be set to ULONG_MAX.
+   
+   This is a fast operation, but it will lock the whole structure and
+   cause a temporary pause in insert and query operations. */
+
+void
+fd_txncache_root_slots( fd_txncache_t * tc,
+                        ulong *         out_slots );
+
+/* fd_txncache_snapshot writes the current state of a txn cache into a
+   binary format suitable for serving to other nodes via. snapshot
+   responses.  The write function is called in a streaming fashion with
+   the binary data, the size of the data, and the ctx pointer provided
+   to this function.  The write function should return 0 on success and
+   -1 on failure, this function will propgate a failure to write back to
+   the caller immediately, so this function also returns 0 on success
+   and -1 on failure.
+
+   IMPORTANT!  THIS ASSUMES THERE ARE NO CONCURRENT INSERTS OCCURING ON
+   THE TXN CACHE AT THE ROOT SLOTS DURING SNAPSHOTTING.  OTHERWISE THE
+   SNAPSHOT MIGHT BE NOT CONTAIN ALL OF THE DATA, ALTHOUGH IT WILL NOT
+   CAUSE CORRUPTION.  THIS IS ASSUMED OK BECAUSE YOU CANNOT MODIFY A
+   ROOTED SLOT.
+
+   This is a cheap operation and will not cause any pause in insertion
+   or query operations. */
+
+int
+fd_txncache_snapshot( fd_txncache_t * tc,
+                      void *          ctx,
+                      int ( * write )( uchar const * data, ulong data_sz, void * ctx ) );
+
+/* fd_txncache_insert_batch inserts a batch of transaction results into
+   a txn cache.  Assumes tc points to a txn cache, txns is a list of
+   transaction results to be inserted, and txns_cnt is the count of the
+   results list.  The insert copies data from the results and does not
+   have any lifetime interest in the results memory provided once this
+   call returns.
+
+   Returns 1 on success and 0 on failure.  The only reason insertion can
+   fail is because the txn cache is full, which should never happen in
+   practice if the caller sizes the bounds correctly.  This is mostly
+   here to support testing and fuzzing.
+
+   This is a cheap, high performance, concurrent operation and can occur
+   at the same time as queries and arbitrary other insertions. */
+
+int
+fd_txncache_insert_batch( fd_txncache_t *              tc,
+                          fd_txncache_insert_t const * txns,
+                          ulong                        txns_cnt );
+
+/* fd_txncache_query_batch queries a batch of transactions to determine
+   if they exist in the txn cache or not.  The queries have an ambiguous
+   slot, but must match both the blockhash and txnhash.  In addition, if
+   the query_func is not NULL, the query_func will be called with the
+   slot of the txn and the query_func_ctx that was provided, and the
+   transaction will be considered present only if the query_func also
+   returns 1.
+
+   Assumes tc points to a txn cache, queries is a list of queries to be
+   executed, and queries_cnt is the count of the queries list.
+   out_results must be at least as large as queries_cnt and will be
+   filled with 0 or 1 if the transaction is not present or present
+   respectively.
+
+   This is a cheap, high performance, concurrent operation and can occur
+   at the same time as queries and arbitrary other insertions. */
+
+void
+fd_txncache_query_batch( fd_txncache_t *             tc,
+                         fd_txncache_query_t const * queries,
+                         ulong                       queries_cnt,
+                         void *                      query_func_ctx,
+                         int ( * query_func )( ulong slot, void * ctx ),
+                         int *                       out_results );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_disco_bank_txncache_h */

--- a/src/disco/bank/test_txncache.c
+++ b/src/disco/bank/test_txncache.c
@@ -1,0 +1,625 @@
+#include "fd_txncache.h"
+
+#include <pthread.h>
+
+#define SORT_NAME        sort_slot_ascend
+#define SORT_KEY_T       ulong
+#define SORT_BEFORE(a,b) (a)<(b)
+#include "../../util/tmpl/fd_sort.c"
+
+FD_STATIC_ASSERT( FD_TXNCACHE_ALIGN    ==128UL,                  unit_test );
+
+ulong txncache_scratch_sz;
+uchar * txncache_scratch;
+
+static fd_txncache_t *
+init_all( ulong max_rooted_slots,
+          ulong max_live_slots,
+          ulong max_transactions_per_slot ) {
+  ulong footprint = fd_txncache_footprint( max_rooted_slots,
+                                           max_live_slots,
+                                           max_transactions_per_slot );
+  FD_TEST( footprint );
+
+  if( FD_UNLIKELY( footprint>txncache_scratch_sz ) ) FD_LOG_ERR(( "Test required %lu bytes, but scratch was only %lu", footprint, txncache_scratch_sz ));
+  fd_txncache_t * tc = fd_txncache_join( fd_txncache_new( txncache_scratch,
+                                                          max_rooted_slots,
+                                                          max_live_slots,
+                                                          max_transactions_per_slot ) );
+  FD_TEST( tc );
+  return tc;
+}
+
+static void
+insert( ulong _blockhash,
+        ulong _txnhash,
+        ulong slot ) {
+  uchar blockhash[ 32 ] = {0};
+  uchar txnhash[ 32 ] = {0};
+  uchar result[ 40 ] = {0};
+  FD_STORE( ulong, blockhash, _blockhash );
+  FD_STORE( ulong, txnhash,   _txnhash );
+
+  fd_txncache_insert_t insert = {
+    .blockhash = blockhash,
+    .txnhash   = txnhash,
+    .slot      = slot,
+    .result    = result,
+  };
+  if( FD_UNLIKELY( !fd_txncache_insert_batch( (fd_txncache_t*)txncache_scratch, &insert, 1 ) ) )
+    FD_LOG_ERR(( "fd_txncache_insert_batch() failed %lu %lu %lu", _blockhash, _txnhash, slot ));
+}
+
+static void
+no_insert( ulong _blockhash,
+           ulong _txnhash,
+           ulong slot ) {
+  uchar blockhash[ 32 ] = {0};
+  uchar txnhash[ 32 ] = {0};
+  uchar result[ 40 ] = {0};
+  FD_STORE( ulong, blockhash, _blockhash );
+  FD_STORE( ulong, txnhash,   _txnhash );
+
+  fd_txncache_insert_t insert = {
+    .blockhash = blockhash,
+    .txnhash   = txnhash,
+    .slot      = slot,
+    .result    = result,
+  };
+  FD_TEST( !fd_txncache_insert_batch( (fd_txncache_t*)txncache_scratch, &insert, 1 ) );
+}
+
+static int
+query_fn( ulong slot,
+          void * ctx ) {
+  return slot==*(ulong *)ctx;
+}
+
+static void
+contains( ulong _blockhash,
+          ulong _txnhash,
+          ulong slot ) {
+  uchar blockhash[ 32 ] = {0};
+  uchar txnhash[ 32 ] = {0};
+  FD_STORE( ulong, blockhash, _blockhash );
+  FD_STORE( ulong, txnhash,   _txnhash );
+
+  fd_txncache_query_t query = {
+    .blockhash = blockhash,
+    .txnhash   = txnhash,
+  };
+
+  int results[1];
+  fd_txncache_query_batch( (fd_txncache_t*)txncache_scratch, &query, 1UL, &slot, query_fn, results );
+  if( FD_UNLIKELY( !results[0] ) )
+    FD_LOG_ERR(( "expected contains %lu %lu %lu", _blockhash, _txnhash, slot ));
+}
+
+static void
+no_contains( ulong _blockhash,
+             ulong _txnhash,
+             ulong slot ) {
+  uchar blockhash[ 32 ] = {0};
+  uchar txnhash[ 32 ] = {0};
+  FD_STORE( ulong, blockhash, _blockhash );
+  FD_STORE( ulong, txnhash,   _txnhash );
+
+  fd_txncache_query_t query = {
+    .blockhash = blockhash,
+    .txnhash   = txnhash,
+  };
+
+  int results[1];
+  fd_txncache_query_batch( (fd_txncache_t*)txncache_scratch, &query, 1UL, &slot, query_fn, results );
+  if( FD_UNLIKELY( results[0] ) )
+    FD_LOG_ERR(( "expected no contains %lu %lu %lu", _blockhash, _txnhash, slot ));
+}
+
+void
+test0( void ) {
+  FD_LOG_NOTICE(( "TEST 0" ));
+
+  init_all( 2, 4, 4 );
+  insert( 0, 0, 0 );
+  contains( 0, 0, 0 );
+  no_contains( 0, 0, 1 );
+  no_contains( 0, 1, 0 );
+  no_contains( 1, 0, 0 );
+  no_contains( 1, 1, 1 );
+}
+
+void
+test_new_join_leave_delete( void ) {
+  FD_LOG_NOTICE(( "TEST NEW JOIN LEAVE DELETE" ));
+
+  FD_TEST( fd_txncache_new( NULL, 1UL, 1UL, 1UL )==NULL );             /* null shmem         */
+  FD_TEST( fd_txncache_new( (void *)0x1UL, 1UL, 1UL, 1UL )==NULL );    /* misaligned shmem   */
+  FD_TEST( fd_txncache_new( txncache_scratch, 0UL, 1UL, 1UL )==NULL ); /* 0 max_rooted_slots */
+  FD_TEST( fd_txncache_new( txncache_scratch, 2UL, 1UL, 1UL )==NULL ); /* 0 max_live_slots<max_rooted_slots */
+  FD_TEST( fd_txncache_new( txncache_scratch, 2UL, 2UL, 0UL )==NULL ); /* 0 max_txn_per_slot */
+
+  FD_TEST( fd_txncache_new( txncache_scratch, 1UL, 1UL, 1UL ) );
+  FD_TEST( fd_txncache_new( txncache_scratch, 2UL, 2UL, 2UL ) );
+  FD_TEST( fd_txncache_new( txncache_scratch, 2UL, 2UL, 2UL ) );
+  FD_TEST( fd_txncache_new( txncache_scratch, FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS,
+                                              FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS,
+                                              FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT ) );
+  FD_TEST( fd_txncache_new( txncache_scratch, FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS,
+                                              512UL,
+                                              FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT ) );
+  FD_TEST( fd_txncache_new( txncache_scratch, FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS,
+                                              FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS,
+                                              1UL ) );
+  void * obj = fd_txncache_new( txncache_scratch, 1UL,
+                                                  FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS,
+                                                  FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT );
+  FD_TEST( obj );
+
+  FD_LOG_NOTICE(( "TEST JOIN" ));
+
+  FD_TEST( fd_txncache_join( NULL )==NULL );          /* null shtc       */
+  FD_TEST( fd_txncache_join( (void *)0x1UL )==NULL ); /* misaligned shtc */
+
+  fd_txncache_t * tc = fd_txncache_join( txncache_scratch ); FD_TEST( tc );
+  FD_TEST( fd_txncache_leave( NULL )==NULL ); /* null tc */
+  FD_TEST( fd_txncache_leave( tc  )==txncache_scratch ); /* ok */
+
+  FD_TEST( fd_txncache_leave( NULL )==NULL ); /* null tc */
+  FD_TEST( fd_txncache_leave( tc  )==obj  );  /* ok */
+
+  FD_TEST( fd_txncache_delete( NULL          )==NULL ); /* null shtc       */
+  FD_TEST( fd_txncache_delete( (void *)0x1UL )==NULL ); /* misaligned shtx */
+  FD_TEST( fd_txncache_delete( obj           )==txncache_scratch  ); /* ok */
+}
+
+void
+test_register_root_slot_simple( void ) {
+  FD_LOG_NOTICE(( "TEST REGISTER ROOT SLOT SIMPLE" ));
+
+  fd_txncache_t * tc = init_all( 6,
+                                 FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS,
+                                 FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT );
+
+  ulong slots[ 6 ];
+  fd_txncache_root_slots( tc, slots );
+  for( ulong i=0UL; i<6UL; i++ ) FD_TEST( slots[ i ]==ULONG_MAX );
+
+  fd_txncache_register_root_slot( tc, 15UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 0 ]==15UL );
+  for( ulong i=1UL; i<6UL; i++ ) FD_TEST( slots[ i ]==ULONG_MAX );
+
+  fd_txncache_register_root_slot( tc, 9UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 0 ]==9UL );
+  FD_TEST( slots[ 1 ]==15UL );
+  for( ulong i=2UL; i<6UL; i++ ) FD_TEST( slots[ i ]==ULONG_MAX );
+
+  fd_txncache_register_root_slot( tc, 20UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 0 ]==9UL );
+  FD_TEST( slots[ 1 ]==15UL );
+  FD_TEST( slots[ 2 ]==20UL );
+  for( ulong i=3UL; i<6UL; i++ ) FD_TEST( slots[ i ]==ULONG_MAX );
+
+  fd_txncache_register_root_slot( tc, 9UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 0 ]==9UL );
+  FD_TEST( slots[ 1 ]==15UL );
+  FD_TEST( slots[ 2 ]==20UL );
+  for( ulong i=3UL; i<6UL; i++ ) FD_TEST( slots[ i ]==ULONG_MAX );
+
+  fd_txncache_register_root_slot( tc, 15UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 0 ]==9UL );
+  FD_TEST( slots[ 1 ]==15UL );
+  FD_TEST( slots[ 2 ]==20UL );
+  for( ulong i=3UL; i<6UL; i++ ) FD_TEST( slots[ i ]==ULONG_MAX );
+
+  fd_txncache_register_root_slot( tc, 20UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 0 ]==9UL );
+  FD_TEST( slots[ 1 ]==15UL );
+  FD_TEST( slots[ 2 ]==20UL );
+  for( ulong i=3UL; i<6UL; i++ ) FD_TEST( slots[ i ]==ULONG_MAX );
+
+  fd_txncache_register_root_slot( tc, 1UL );
+  fd_txncache_register_root_slot( tc, 2UL );
+  fd_txncache_register_root_slot( tc, 30UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 0 ]==1UL );
+  FD_TEST( slots[ 1 ]==2UL );
+  FD_TEST( slots[ 2 ]==9UL );
+  FD_TEST( slots[ 3 ]==15UL );
+  FD_TEST( slots[ 4 ]==20UL );
+  FD_TEST( slots[ 5 ]==30UL );
+
+  fd_txncache_register_root_slot( tc, 0UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 0 ]==1UL );
+  FD_TEST( slots[ 1 ]==2UL );
+  FD_TEST( slots[ 2 ]==9UL );
+  FD_TEST( slots[ 3 ]==15UL );
+  FD_TEST( slots[ 4 ]==20UL );
+  FD_TEST( slots[ 5 ]==30UL );
+
+  fd_txncache_register_root_slot( tc, 3UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 0 ]==2UL );
+  FD_TEST( slots[ 1 ]==3UL );
+  FD_TEST( slots[ 2 ]==9UL );
+  FD_TEST( slots[ 3 ]==15UL );
+  FD_TEST( slots[ 4 ]==20UL );
+  FD_TEST( slots[ 5 ]==30UL );
+
+  fd_txncache_register_root_slot( tc, 27UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 0 ]==3UL );
+  FD_TEST( slots[ 1 ]==9UL );
+  FD_TEST( slots[ 2 ]==15UL );
+  FD_TEST( slots[ 3 ]==20UL );
+  FD_TEST( slots[ 4  ]==27UL );
+  FD_TEST( slots[ 5 ]==30UL );
+}
+
+void
+test_register_root_slot( void ) {
+  FD_LOG_NOTICE(( "TEST REGISTER ROOT SLOT" ));
+  
+  fd_txncache_t * tc = init_all( FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS,
+                                 FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS,
+                                 FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT );
+
+  FD_TEST( fd_txncache_new( tc,
+                            FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS,
+                            FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS,
+                            FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT ) );
+
+  ulong slots[ 300 ];
+  fd_txncache_root_slots( tc, slots );
+  for( ulong i=0UL; i<300UL; i++ ) FD_TEST( slots[ i ]==ULONG_MAX );
+
+  fd_txncache_register_root_slot( tc, 0UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 0 ]==0UL );
+  for( ulong i=1UL; i<300UL; i++ ) FD_TEST( slots[ i ]==ULONG_MAX );
+
+  fd_txncache_register_root_slot( tc, 0UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 0 ]==0UL );
+  for( ulong i=1UL; i<300UL; i++ ) FD_TEST( slots[ i ]==ULONG_MAX );
+
+  fd_txncache_register_root_slot( tc, 2UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 0 ]==0UL );
+  FD_TEST( slots[ 1 ]==2UL );
+  for( ulong i=2UL; i<300UL; i++ ) FD_TEST( slots[ i ]==ULONG_MAX );
+
+  fd_txncache_register_root_slot( tc, 999UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 0 ]==0UL );
+  FD_TEST( slots[ 1 ]==2UL );
+  FD_TEST( slots[ 2 ]==999UL );
+  for( ulong i=3UL; i<300UL; i++ ) FD_TEST( slots[ i ]==ULONG_MAX );
+
+  fd_txncache_register_root_slot( tc, 500UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 0 ]==0UL );
+  FD_TEST( slots[ 1 ]==2UL );
+  FD_TEST( slots[ 2 ]==500UL );
+  FD_TEST( slots[ 3 ]==999UL );
+  for( ulong i=4UL; i<300UL; i++ ) FD_TEST( slots[ i ]==ULONG_MAX );
+
+  fd_txncache_register_root_slot( tc, 1UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 0 ]==0UL );
+  FD_TEST( slots[ 1 ]==1UL );
+  FD_TEST( slots[ 2 ]==2UL );
+  FD_TEST( slots[ 3 ]==500UL );
+  FD_TEST( slots[ 4 ]==999UL );
+  for( ulong i=5UL; i<300UL; i++ ) FD_TEST( slots[ i ]==ULONG_MAX );
+
+  FD_TEST( fd_txncache_new( tc,
+                            FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS,
+                            FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS,
+                            FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT ) );
+  for( ulong i=0UL; i<300UL; i++ ) fd_txncache_register_root_slot( tc, 600UL-2UL*i );
+  fd_txncache_root_slots( tc, slots );
+  for( ulong i=0UL; i<300UL; i++ ) FD_TEST( slots[ i ]==2UL+2UL*i );
+
+  fd_txncache_register_root_slot( tc, 16UL );
+  fd_txncache_register_root_slot( tc, 96UL );
+  fd_txncache_register_root_slot( tc, 128UL );
+  fd_txncache_root_slots( tc, slots );
+  for( ulong i=0UL; i<300UL; i++ ) FD_TEST( slots[ i ]==2UL+2UL*i );
+
+  fd_txncache_register_root_slot( tc, 0UL );
+  for( ulong i=0UL; i<300UL; i++ ) FD_TEST( slots[ i ]==2UL+2UL*i );
+
+  fd_txncache_register_root_slot( tc, 1UL );
+  for( ulong i=0UL; i<300UL; i++ ) FD_TEST( slots[ i ]==2UL+2UL*i );
+
+  fd_txncache_register_root_slot( tc, 3UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[0]==3UL );
+  for( ulong i=1UL; i<300UL; i++ ) FD_TEST( slots[ i ]==2UL+2UL*i );
+
+  fd_txncache_register_root_slot( tc, 1000UL );
+  fd_txncache_root_slots( tc, slots );
+  FD_TEST( slots[ 299 ]==1000UL );
+  for( ulong i=0UL; i<299UL; i++ ) FD_TEST( slots[ i ]==4UL+2UL*i );
+}
+
+
+void
+test_register_root_slot_random( void ) {
+  FD_LOG_NOTICE(( "TEST REGISTER ROOT SLOT RANDOM" ));
+
+  fd_txncache_t * tc = init_all( FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS,
+                                 FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS,
+                                 FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT );
+
+  ulong slots[ 300 ];
+
+  ulong slots_self_cnt = 0UL;
+  ulong slots_self[ 301 ];
+  memset( slots_self, 0xFF, 301*sizeof(ulong) );
+
+  fd_rng_t rng[1];
+  FD_TEST( fd_rng_join( fd_rng_new( rng, 1U, 10UL ) ) );
+
+  for( ulong i=0UL; i<262144; i++ ) {
+    ulong next = fd_rng_ulong( rng );
+    fd_txncache_register_root_slot( tc, next );
+
+    int contains = 0;
+    for( ulong j=0UL; j<slots_self_cnt; j++ ) {
+      if( slots_self[ j ]==next ) {
+        contains = 1;
+        break;
+      }
+    }
+
+    if( FD_LIKELY( !contains ) ) {
+      slots_self[ slots_self_cnt++ ] = next;
+      sort_slot_ascend_inplace( slots_self, slots_self_cnt );
+      if( FD_LIKELY( slots_self_cnt>300UL ) ) {
+        memmove( slots_self, slots_self+1, 300UL*sizeof(ulong) );
+        slots_self_cnt--;
+      }
+    }
+
+    fd_txncache_root_slots( tc, slots );
+    for( ulong j=0UL; j<300UL; j++ ) {
+      FD_TEST( slots_self[ j ]==slots[ j ] );
+    }
+  }
+}
+
+
+void
+test_full_blockhash( void ) {
+  FD_LOG_NOTICE(( "TEST FULL BLOCKHASH" ));
+
+  init_all( FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS,
+            FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS,
+            FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT );
+
+  for( ulong i=0UL; i<150UL*524288UL; i++ ) {
+    insert( 0UL, i, 0UL );
+
+    if( i==0UL ) {
+      for( ulong j=0UL; j<150UL*524288UL; j++ ) {
+        if( j<=i ) contains   ( 0UL, j, 0UL );
+        else       no_contains( 0UL, j, 0UL );
+      }
+    } else if( i==150UL*524288UL-1UL ) {
+      for( ulong j=150UL*524288UL-4096UL; j<150UL*524288UL; j++ ) {
+        if( j<=i ) contains   ( 0UL, j, 0UL );
+        else       no_contains( 0UL, j, 0UL );
+      }
+    } else if( i==31UL+150UL*524288UL/2UL ) {
+      for( ulong j=i-4069UL; j<i+4096UL; j++ ) {
+        if( j<=i ) contains   ( 0UL, j, 0UL );
+        else       no_contains( 0UL, j, 0UL );
+      }
+    }
+  }
+
+  no_insert( 0UL, 0UL, 0UL );
+  no_insert( 0UL, 524288UL, 0UL );
+  insert( 1UL, 0UL, 0UL );
+  insert( 2UL, 0UL, 0UL );
+}
+
+
+void
+test_insert_forks( void ) {
+  FD_LOG_NOTICE(( "TEST INSERT FORKS" ));
+
+  fd_txncache_t * tc = init_all( FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS,
+                                 FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS,
+                                 FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT );
+
+  for( ulong i=0UL; i<1024UL; i++ ) insert( i, 0UL, i );
+  for( ulong i=0UL; i<1024UL; i++ ) contains( i, 0UL, i );
+  for( ulong i=0UL; i<450UL; i++ ) fd_txncache_register_root_slot( tc, i );
+  for( ulong i=0UL; i<1024UL; i++ ) contains( i, 0UL, i );
+
+  fd_txncache_register_root_slot( tc, 450 );
+  no_contains( 0UL, 0UL, 0UL );
+  for( ulong i=1UL; i<1024UL; i++ ) contains( i, 0UL, i );
+
+  fd_txncache_register_root_slot( tc, 451 );
+  no_contains( 0UL, 0UL, 0UL );
+  no_contains( 1UL, 0UL, 1UL );
+  for( ulong i=2UL; i<1024UL; i++ ) contains( i, 0UL, i );
+}
+
+void
+test_purge_gap( void ) {
+  FD_LOG_NOTICE(( "TEST PURGE GAP" ));
+
+  fd_txncache_t * tc = init_all( FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS,
+                                 FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS,
+                                 FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT );
+
+  insert( 0, 0, 1000 );
+  insert( 1, 0, 0 );
+  insert( 1025, 0, 1001 );
+
+  contains( 0, 0, 1000 );
+  contains( 1, 0, 0 );
+  contains( 1025, 0, 1001 );
+
+  for( ulong i=0UL; i<1000UL; i++) fd_txncache_register_root_slot( tc, i );
+  contains( 0, 0, 1000 );
+  no_contains( 1, 0, 0 );
+  contains( 1025, 0, 1001 );
+}
+
+void
+test_many_blockhashes( void ) {
+  FD_LOG_NOTICE(( "TEST MANY BLOCKHASHES" ));
+
+  fd_txncache_t * tc = init_all( FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS,
+                                 FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS,
+                                 FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT );
+
+  for( ulong i=0UL; i<1024UL; i++ ) {
+    insert( i, 0UL, i );
+    contains( i, 0UL, i );
+  }
+
+  no_insert( 1024UL, 0UL, 0UL );
+  for( ulong i=0UL; i<301UL; i++ ) {
+    fd_txncache_register_root_slot( tc, 1024UL-1UL-i );
+  }
+
+  for( ulong i=0UL; i<574UL; i++ ) {
+    no_contains( i, 0UL, i );
+  }
+  for( ulong i=574UL; i<1024UL; i++ ) {
+    contains( i, 0UL, i );
+  }
+}
+
+void *
+full_blockhash_concurrent_fn( void * arg ) {
+  ulong i = (ulong)arg;
+  for( ulong j=i; j<150UL*524288UL; j+=30UL ) insert( 0UL, j, 0UL );
+  return NULL;
+}
+
+void *
+full_blockhash_concurrent_query_fn( void * arg ) {
+  ulong x = (ulong)arg;
+  fd_rng_t rng[1];
+  FD_TEST( fd_rng_join( fd_rng_new( rng, (uint)x, x+10UL ) ) );
+
+  for( ulong i=0UL; i<1000UL; i++ ) {
+    contains( 0UL, fd_rng_ulong( rng ) % (150UL*524288UL), 0UL );
+    no_contains( 1UL, fd_rng_ulong( rng ) % (150UL*524288UL), 0UL );
+    no_contains( 0UL, fd_rng_ulong( rng ) % (150UL*524288UL), 1UL );
+  }
+  return NULL;
+}
+
+void
+test_full_blockhash_concurrent( void ) {
+  FD_LOG_NOTICE(( "TEST FULL BLOCKHASH CONCURRENT" ));
+
+  init_all( FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS,
+            FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS,
+            FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT );
+
+  pthread_t threads[ 30 ];
+  for( ulong i=0UL; i<30UL; i++ ) {
+    FD_TEST( !pthread_create( threads+i, NULL, full_blockhash_concurrent_fn, (void *)i ) );
+  }
+
+  for( ulong i=0UL; i<30UL; i++ ) {
+    FD_TEST( !pthread_join( threads[i], NULL ) );
+  }
+
+  pthread_t threads2[ 1024 ];
+  for( ulong i=0UL; i<1024UL; i++ ) {
+    FD_TEST( !pthread_create( threads2+i, NULL, full_blockhash_concurrent_query_fn, (void *)i ) );
+  }
+
+  for( ulong i=0UL; i<1024UL; i++ ) {
+    FD_TEST( !pthread_join( threads2[i], NULL ) );
+  }
+
+  no_insert( 0UL, 0UL, 0UL );
+  no_insert( 0UL, 524288UL, 0UL );
+  insert( 1UL, 0UL, 0UL );
+  insert( 2UL, 0UL, 0UL );
+}
+
+static volatile int go;
+
+void *
+full_blockhash_concurrent_insert_fn2( void * arg ) {
+  while( !go );
+
+  ulong x = (ulong)arg;
+  for( ulong i=x; i<1024UL; i+=30UL ) insert( i, 0UL, 0UL );
+  return NULL;
+}
+
+void
+test_many_blockhashes_concurrent( void ) {
+  FD_LOG_NOTICE(( "TEST MANY BLOCKHASHES CONCURRENT" ));
+
+  init_all( FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS,
+            FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS,
+            FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT );
+
+  pthread_t threads[ 30 ];
+  for( ulong i=0UL; i<30UL; i++ ) {
+    FD_TEST( !pthread_create( threads+i, NULL, full_blockhash_concurrent_insert_fn2, (void *)i ) );
+  }
+
+  go = 1;
+
+  for( ulong i=0UL; i<30UL; i++ ) {
+    FD_TEST( !pthread_join( threads[i], NULL ) );
+  }
+
+  no_insert( 1024UL, 0UL, 0UL );
+  for( ulong i=0UL; i<1024UL; i++ ) {
+    contains( i, 0UL, 0UL );
+  }
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  ulong max_footprint = fd_txncache_footprint( FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS,
+                                               FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS,
+                                               FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT );
+  txncache_scratch = fd_shmem_acquire( 4096UL, 1UL+(max_footprint/4096UL), 0UL );
+  txncache_scratch_sz = 4096UL * (1UL+(max_footprint/4096UL));
+  FD_TEST( txncache_scratch );
+
+  FD_TEST( fd_txncache_align()==FD_TXNCACHE_ALIGN );
+
+  test0();
+  test_new_join_leave_delete();
+  test_register_root_slot_simple();
+  test_register_root_slot();
+  test_register_root_slot_random();
+  test_full_blockhash();
+  test_insert_forks();
+  test_purge_gap();
+  test_many_blockhashes();
+  test_full_blockhash_concurrent();
+  test_many_blockhashes_concurrent();
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
The status cache has two main issues,

 (1) It's not particularly concurrent, and causes slowdowns when running
     with highly parallel bank execution.

 (2) It has unbounded memory consumption, and can cause out of memory
     conditions when it needs to store large numbers of transactions.

It is rewritten in Firedancer for performance.  The general design is there are two operations which need to be highly concurrent, insert and query, and everything else is rare and happens between slots and can largely just lock the whole thing.

The base case for insert is optimized to two always-uncontended, and one very lightly contended compare and swap.  Query is fully lockless.

The transaction result storage is combined between the snapshot service cache, and the query lookup cache, which more than halves the memory usage and the memory use is fixed up front.

Related to #1770 