### PR TITLE
0-set txn context to fix memory issues

### DIFF
--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -230,14 +230,30 @@ _context_create( fd_exec_instr_test_runner_t *        runner,
 
   /* Set up txn context */
 
-  txn_ctx->epoch_ctx = epoch_ctx;
-  txn_ctx->slot_ctx  = slot_ctx;
-  txn_ctx->funk_txn  = funk_txn;
-  txn_ctx->acc_mgr   = acc_mgr;
-  txn_ctx->valloc    = fd_scratch_virtual();
+  txn_ctx->epoch_ctx               = epoch_ctx;
+  txn_ctx->slot_ctx                = slot_ctx;
+  txn_ctx->funk_txn                = funk_txn;
+  txn_ctx->acc_mgr                 = acc_mgr;
+  txn_ctx->valloc                  = fd_scratch_virtual();
+  txn_ctx->compute_unit_limit      = test_ctx->cu_avail;
+  txn_ctx->compute_unit_price      = 0;
+  txn_ctx->compute_meter           = test_ctx->cu_avail;
+  txn_ctx->prioritization_fee_type = FD_COMPUTE_BUDGET_PRIORITIZATION_FEE_TYPE_DEPRECATED;
+  txn_ctx->custom_err              = UINT_MAX;
+  txn_ctx->instr_stack_sz          = 0;
+  txn_ctx->executable_cnt          = 0;
+  txn_ctx->paid_fees               = 0;
+  txn_ctx->num_instructions        = 0;
+  txn_ctx->dirty_vote_acc          = 0;
+  txn_ctx->dirty_stake_acc         = 0;
+  txn_ctx->failed_instr            = NULL;
+  txn_ctx->capture_ctx             = NULL;
+  txn_ctx->vote_accounts_pool      = NULL;
 
-  txn_ctx->compute_meter      = test_ctx->cu_avail;
-  txn_ctx->compute_unit_limit = test_ctx->cu_avail;
+  memset( txn_ctx->_txn_raw, 0, sizeof(fd_rawtxn_b_t) );
+  memset( txn_ctx->return_data.program_id.key, 0, sizeof(fd_pubkey_t) );
+  txn_ctx->return_data.len         = 0;
+
 
   /* Set up instruction context */
 

--- a/src/flamenco/runtime/tests/fd_exec_sol_compat.c
+++ b/src/flamenco/runtime/tests/fd_exec_sol_compat.c
@@ -89,18 +89,6 @@ sol_compat_instr_execute_v1( uchar *       out,
                              ulong         in_sz ) {
 
   ulong fmem[ 64 ];
-  /*
-  FIXME: Previously, there were issues with getting different execution results from this
-  function within different execution contexts. By setting the shared memory to 0 before every
-  execution, we can at least ensure that the context remains the same between executions. 
-  
-  Is this a permanent fix? No. But it allows us to continue testing, fuzzing, and then reproducing 
-  issues in an isolated context. The root cause is probably some out-of-bounds access
-  within execution that should be detectable with (deep)asan.
-
-  This will also slow down execution until the root cause is fixed, then the memset can be removed.
-  */
-  memset( smem, 0, smax );
   fd_scratch_attach( smem, fmem, smax, 64UL );
   fd_scratch_push();
 


### PR DESCRIPTION
* Manually set `txn_ctx` fields to default values when creating context to avoid phantom reads from prior executions
* Remove smem 0-setting introduced in [this PR](https://github.com/firedancer-io/firedancer/pull/1784)