### PR TITLE
fd_xsk, fdctl: make zero-copy mode configurable, disabled for skb mode

### DIFF
--- a/src/app/fdctl/run/tiles/fd_net.c
+++ b/src/app/fdctl/run/tiles/fd_net.c
@@ -426,7 +426,8 @@ privileged_init( fd_topo_t *      topo,
                            tile->net.xdp_rx_queue_size,
                            tile->net.xdp_rx_queue_size,
                            tile->net.xdp_tx_queue_size,
-                           tile->net.xdp_tx_queue_size );
+                           tile->net.xdp_tx_queue_size,
+                           tile->net.zero_copy );
   if( FD_UNLIKELY( !fd_xsk_bind( xsk, tile->net.app_name, tile->net.interface, (uint)tile->kind_id ) ) )
     FD_LOG_ERR(( "failed to bind xsk for net tile %lu", tile->kind_id ));
 
@@ -447,7 +448,8 @@ privileged_init( fd_topo_t *      topo,
                                 tile->net.xdp_rx_queue_size,
                                 tile->net.xdp_rx_queue_size,
                                 tile->net.xdp_tx_queue_size,
-                                tile->net.xdp_tx_queue_size );
+                                tile->net.xdp_tx_queue_size,
+                                0 /* Not zero-copy */ );
     if( FD_UNLIKELY( !fd_xsk_bind( lo_xsk, tile->net.app_name, "lo", (uint)tile->kind_id ) ) )
       FD_LOG_ERR(( "failed to bind lo_xsk for net tile %lu", tile->kind_id ));
 

--- a/src/app/fdctl/run/topos/fd_firedancer.c
+++ b/src/app/fdctl/run/topos/fd_firedancer.c
@@ -230,6 +230,8 @@ fd_topo_firedancer( config_t * _config ) {
       tile->net.xdp_rx_queue_size              = config->tiles.net.xdp_rx_queue_size;
       tile->net.xdp_tx_queue_size              = config->tiles.net.xdp_tx_queue_size;
       tile->net.src_ip_addr                    = config->tiles.net.ip_addr;
+      tile->net.zero_copy                      = !!strcmp( config->tiles.net.xdp_mode, "skb" ); /* disable zc for skb */
+
       tile->net.shred_listen_port              = config->tiles.shred.shred_listen_port;
       tile->net.quic_transaction_listen_port   = config->tiles.quic.quic_transaction_listen_port;
       tile->net.legacy_transaction_listen_port = config->tiles.quic.regular_transaction_listen_port;

--- a/src/app/fdctl/run/topos/fd_frankendancer.c
+++ b/src/app/fdctl/run/topos/fd_frankendancer.c
@@ -219,7 +219,9 @@ fd_topo_frankendancer( config_t * config ) {
       tile->net.xdp_rx_queue_size = config->tiles.net.xdp_rx_queue_size;
       tile->net.xdp_tx_queue_size = config->tiles.net.xdp_tx_queue_size;
       tile->net.src_ip_addr       = config->tiles.net.ip_addr;
-      tile->net.shred_listen_port = config->tiles.shred.shred_listen_port;
+      tile->net.zero_copy         = !!strcmp( config->tiles.net.xdp_mode, "skb" ); /* disable zc for skb */
+
+      tile->net.shred_listen_port              = config->tiles.shred.shred_listen_port;
       tile->net.quic_transaction_listen_port   = config->tiles.quic.quic_transaction_listen_port;
       tile->net.legacy_transaction_listen_port = config->tiles.quic.regular_transaction_listen_port;
 

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -136,6 +136,7 @@ typedef struct {
       ulong  xdp_rx_queue_size;
       ulong  xdp_tx_queue_size;
       ulong  xdp_aio_depth;
+      int    zero_copy;
       uint   src_ip_addr;
       uchar  src_mac_addr[6];
 

--- a/src/waltz/quic/tests/fd_quic_test_helpers.c
+++ b/src/waltz/quic/tests/fd_quic_test_helpers.c
@@ -359,7 +359,7 @@ fd_quic_udpsock_create( void *           _sock,
 
     FD_LOG_NOTICE(( "Creating XSK" ));
     void * xsk_mem = fd_wksp_alloc_laddr( wksp, fd_xsk_align(), xsk_sz, 1UL );
-    if( FD_UNLIKELY( !fd_xsk_new( xsk_mem, mtu, rx_depth, rx_depth, tx_depth, tx_depth ) ) ) {
+    if( FD_UNLIKELY( !fd_xsk_new( xsk_mem, mtu, rx_depth, rx_depth, tx_depth, tx_depth, 0 ) ) ) {
       FD_LOG_WARNING(( "failed to create XSK" ));
       return NULL;
     }

--- a/src/waltz/xdp/fd_xdp_ctl.c
+++ b/src/waltz/xdp/fd_xdp_ctl.c
@@ -180,10 +180,11 @@ main( int     argc,
 
       if( FD_UNLIKELY( argc<4 ) ) FD_LOG_ERR(( "%i: %s: too few arguments\n\tDo %s help for help", cnt, cmd, bin ));
 
-      char const * _wksp    =                   argv[0];
-      ulong        frame_sz = fd_cstr_to_ulong( argv[1] );
-      ulong        rx_depth = fd_cstr_to_ulong( argv[2] );
-      ulong        tx_depth = fd_cstr_to_ulong( argv[3] );
+      char const * _wksp     =                   argv[0];
+      ulong        frame_sz  = fd_cstr_to_ulong( argv[1] );
+      ulong        rx_depth  = fd_cstr_to_ulong( argv[2] );
+      ulong        tx_depth  = fd_cstr_to_ulong( argv[3] );
+      int          zero_copy = fd_cstr_to_int  ( argv[4] );
       /* For now, have fill/completion ring depth match rx/tx rings */
       ulong        fr_depth = rx_depth;
       ulong        cr_depth = tx_depth;
@@ -212,7 +213,7 @@ main( int     argc,
         FD_LOG_ERR(( "%i: %s: fd_wksp_laddr( \"%s\", %lu ) failed\n\tDo %s help for help", cnt, cmd, _wksp, gaddr, bin ));
       }
 
-      void * shxsk = fd_xsk_new( shmem, frame_sz, fr_depth, rx_depth, tx_depth, cr_depth );
+      void * shxsk = fd_xsk_new( shmem, frame_sz, fr_depth, rx_depth, tx_depth, cr_depth, zero_copy );
       if( FD_UNLIKELY( !shxsk ) ) {
         fd_wksp_free( wksp, gaddr );
         fd_wksp_detach( wksp );
@@ -226,7 +227,7 @@ main( int     argc,
       fd_wksp_detach( wksp );
 
       FD_LOG_NOTICE(( "%i: %s %s %lu %lu %lu: success", cnt, cmd, _wksp, frame_sz, rx_depth, tx_depth ));
-      SHIFT( 4 );
+      SHIFT( 5 );
 
     } else if( 0==strcmp( cmd, "bind-xsk" ) ) {
 

--- a/src/waltz/xdp/fd_xdp_ctl_help
+++ b/src/waltz/xdp/fd_xdp_ctl_help
@@ -75,10 +75,13 @@ release-udp-port [BPF_DIR] [IP_ADDR] [UDP_PORT]
   to receive packets again.
 - Requires CAP_SYS_ADMIN, see capabilities(7).
 
-new-xsk [WKSP] [FRAME_SZ] [RX_DEPTH] [TX_DEPTH]
+new-xsk [WKSP] [FRAME_SZ] [RX_DEPTH] [TX_DEPTH] [ZERO_COPY]
 - Create a new XSK buffer in [WKSP] with the given frame size
   [FRAME_SZ], RX/Fill queue depth [RX_DEPTH], and TX/Completion
   queue depth [TX_DEPTH].
+- If [ZERO_COPY] is non-zero, the xsk will use zero copy mode.
+  Zero copy mode may not not supported if the xdp program is
+  installed in skb mode.
 - The value of [FRAME_SZ] is restricted by the Linux kernel.
   As of Linux 4.18, valid values include 2048 and 4096.
 - Prints the wksp gaddr of the xdp to stdout.

--- a/src/waltz/xdp/fd_xsk.c
+++ b/src/waltz/xdp/fd_xsk.c
@@ -183,7 +183,8 @@ fd_xsk_new( void *       shmem,
             ulong        fr_depth,
             ulong        rx_depth,
             ulong        tx_depth,
-            ulong        cr_depth ) {
+            ulong        cr_depth,
+            int          zero_copy ) {
   /* Validate arguments */
 
   if( FD_UNLIKELY( !shmem ) ) {
@@ -219,6 +220,7 @@ fd_xsk_new( void *       shmem,
   xsk->params.rx_depth = rx_depth;
   xsk->params.tx_depth = tx_depth;
   xsk->params.cr_depth = cr_depth;
+  xsk->params.zerocopy = zero_copy ? XDP_ZEROCOPY : XDP_COPY;
 
   /* Derive offsets (TODO overflow check) */
 

--- a/src/waltz/xdp/fd_xsk.h
+++ b/src/waltz/xdp/fd_xsk.h
@@ -178,8 +178,9 @@ fd_xsk_footprint( ulong frame_sz,
    fd_xsk_footprint().  frame_sz controls the frame size used in the
    UMEM ring buffers and should be either 2048 or 4096.
    {fr,rx,tx,cr}_depth control the number of frames allocated for the
-   Fill, RX, TX, Completion rings respectively.  Returns handle suitable
-   for fd_xsk_join() on success. */
+   Fill, RX, TX, Completion rings respectively.  If zero_copy is
+   non-zero, the xsk will be created in zero-copy mode.  Returns handle
+   suitable for fd_xsk_join() on success. */
 
 void *
 fd_xsk_new( void * shmem,
@@ -187,7 +188,8 @@ fd_xsk_new( void * shmem,
             ulong  fr_depth,
             ulong  rx_depth,
             ulong  tx_depth,
-            ulong  cr_depth);
+            ulong  cr_depth,
+            int    zero_copy );
 
 /* fd_xsk_bind assigns an XSK buffer to the network device with name
    ifname and RX queue index ifqueue.  fd_xsk_unbind unassigns an XSK

--- a/src/waltz/xdp/fd_xsk_private.h
+++ b/src/waltz/xdp/fd_xsk_private.h
@@ -80,17 +80,6 @@ struct __attribute__((aligned(FD_XSK_ALIGN))) fd_xsk_private {
 
   fd_xsk_params_t params;
 
-  /* xdp_mode: XDP processing mode.  Defined by <linux/if_link.h>
-
-     Valid values:
-
-       0                   kernel default mode
-       XDP_FLAGS_SKB_MODE  sk_buff generic mode (hardware-agnostic)
-       XDP_FLAGS_DRV_MODE  driver XDP (requires driver support)
-       XDP_FLAGS_HW_MODE   hardware-accelerated XDP
-                           (requires NIC and driver support) */
-  ulong xdp_mode;
-
   /* Per-join thread-group-local objects ******************************/
 
   /* Kernel descriptor of UMEM in local address space */

--- a/src/waltz/xdp/test_xsk.c
+++ b/src/waltz/xdp/test_xsk.c
@@ -112,21 +112,21 @@ test_xsk( void ) {
 
   /* Invalid new params */
 
-  FD_TEST( NULL==fd_xsk_new( NULL,               2048UL, 1UL, 1UL, 1UL, 1UL ) ); /* NULL shmem     */
-  FD_TEST( NULL==fd_xsk_new( (void *)(_xsk+1UL), 2048UL, 1UL, 1UL, 1UL, 1UL ) ); /* unalign shmem  */
-  FD_TEST( NULL==fd_xsk_new( _xsk,               0UL,    1UL, 1UL, 1UL, 1UL ) ); /* zero frame_sz  */
-  FD_TEST( NULL==fd_xsk_new( _xsk,               1UL,    1UL, 1UL, 1UL, 1UL ) ); /* inval frame_sz */
-  FD_TEST( NULL==fd_xsk_new( _xsk,               8192UL, 1UL, 1UL, 1UL, 1UL ) ); /* inval frame_sz */
-  FD_TEST( NULL==fd_xsk_new( _xsk,               2048UL, 0UL, 1UL, 1UL, 1UL ) ); /* zero fr_depth  */
-  FD_TEST( NULL==fd_xsk_new( _xsk,               2048UL, 1UL, 0UL, 1UL, 1UL ) ); /* zero fr_depth  */
-  FD_TEST( NULL==fd_xsk_new( _xsk,               2048UL, 1UL, 1UL, 0UL, 1UL ) ); /* zero fr_depth  */
-  FD_TEST( NULL==fd_xsk_new( _xsk,               2048UL, 1UL, 1UL, 1UL, 0UL ) ); /* zero fr_depth  */
+  FD_TEST( NULL==fd_xsk_new( NULL,               2048UL, 1UL, 1UL, 1UL, 1UL, 0 ) ); /* NULL shmem     */
+  FD_TEST( NULL==fd_xsk_new( (void *)(_xsk+1UL), 2048UL, 1UL, 1UL, 1UL, 1UL, 0 ) ); /* unalign shmem  */
+  FD_TEST( NULL==fd_xsk_new( _xsk,               0UL,    1UL, 1UL, 1UL, 1UL, 0 ) ); /* zero frame_sz  */
+  FD_TEST( NULL==fd_xsk_new( _xsk,               1UL,    1UL, 1UL, 1UL, 1UL, 0 ) ); /* inval frame_sz */
+  FD_TEST( NULL==fd_xsk_new( _xsk,               8192UL, 1UL, 1UL, 1UL, 1UL, 0 ) ); /* inval frame_sz */
+  FD_TEST( NULL==fd_xsk_new( _xsk,               2048UL, 0UL, 1UL, 1UL, 1UL, 0 ) ); /* zero fr_depth  */
+  FD_TEST( NULL==fd_xsk_new( _xsk,               2048UL, 1UL, 0UL, 1UL, 1UL, 0 ) ); /* zero fr_depth  */
+  FD_TEST( NULL==fd_xsk_new( _xsk,               2048UL, 1UL, 1UL, 0UL, 1UL, 0 ) ); /* zero fr_depth  */
+  FD_TEST( NULL==fd_xsk_new( _xsk,               2048UL, 1UL, 1UL, 1UL, 0UL, 0 ) ); /* zero fr_depth  */
 
   /* Create new XSK */
 
   FD_TEST( fd_xsk_footprint( 2048UL, 8UL, 8UL, 8UL, 8UL )==69632UL );
 
-  void * shxsk = fd_xsk_new( _xsk, 2048UL, 8UL, 8UL, 8UL, 8UL );
+  void * shxsk = fd_xsk_new( _xsk, 2048UL, 8UL, 8UL, 8UL, 8UL, 0 );
   FD_TEST( shxsk );
 
   /* Invalid magic */
@@ -495,7 +495,7 @@ test_xsk_aio( void ) {
   /* Mock XSK */
 
   FD_TEST( fd_xsk_footprint( 2048UL, 8UL, 8UL, 8UL, 8UL )<=sizeof(_xsk) );
-  void * shxsk = fd_xsk_new( _xsk, 2048UL, 8UL, 8UL, 8UL, 8UL );
+  void * shxsk = fd_xsk_new( _xsk, 2048UL, 8UL, 8UL, 8UL, 8UL, 1 );
   FD_TEST( shxsk );
 
   fd_xsk_t * xsk = (fd_xsk_t *)shxsk;


### PR DESCRIPTION
Now the only way to get the error on the boxes with the strange driver is to initialize xdp with skb mode, then manually change the mode to drv mode before running, which is fine.