### PR TITLE
fuzz, flamenco: Remove lamport overflow check in fuzz harness

### DIFF
--- a/src/flamenco/runtime/info/fd_instr_info.c
+++ b/src/flamenco/runtime/info/fd_instr_info.c
@@ -90,6 +90,10 @@ fd_instr_any_signed( fd_instr_info_t const * info,
   return is_signer;
 }
 
+/*
+  TODO: We should modify this function to handle overflows / other issues similar to Agave.
+  https://github.com/anza-xyz/agave/blob/9706a6464665f7ebd6ead47f0d12f853ccacbab9/sdk/src/transaction_context.rs#L407
+*/
 ulong
 fd_instr_info_sum_account_lamports( fd_instr_info_t const * instr ) {
   ulong total_lamports = 0;

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -668,31 +668,6 @@ fd_exec_instr_fixture_run( fd_exec_instr_test_runner_t *        runner,
   return !has_diff;
 }
 
-FD_FN_PURE static bool
-fd_instr_info_sum_account_lamports_no_crash( fd_instr_info_t const * instr ) {
-  ulong total_lamports = 0;
-
-  for( ulong i = 0; i < instr->acct_cnt; i++ ) {
-
-    if( instr->borrowed_accounts[i] == NULL ) {
-      continue;
-    }
-
-    if( ( instr->is_duplicate[i]                          ) |
-        ( instr->borrowed_accounts[i]->const_meta == NULL ) ) {
-      continue;
-    }
-
-    ulong acct_lamports = instr->borrowed_accounts[i]->const_meta->info.lamports;
-
-    if( FD_UNLIKELY( __builtin_uaddl_overflow( total_lamports, acct_lamports, &total_lamports ) ) ) {
-      FD_LOG_WARNING(("Sum of lamports exceeds UL MAX", total_lamports));
-      return false;
-    }
-  }
-  return true;
-}
-
 ulong
 fd_exec_instr_test_run( fd_exec_instr_test_runner_t *        runner,
                         fd_exec_test_instr_context_t const * input,
@@ -707,12 +682,6 @@ fd_exec_instr_test_run( fd_exec_instr_test_runner_t *        runner,
     return 0UL;
 
   fd_instr_info_t * instr = (fd_instr_info_t *) ctx->instr;
-
-  /* Check lamports beforehand to ensure we don't crash during test execution */
-  if (!fd_instr_info_sum_account_lamports_no_crash(instr)) {
-    _context_destroy( runner, ctx );
-    return 0UL;
-  }
 
   /* Execute the test */
   int exec_result = fd_execute_instr(ctx->txn_ctx, instr);


### PR DESCRIPTION
This check was added within the fuzz harness since we used to abort on a instruction account lamport sum overflow, but that is no longer the case, so this check is incorrect. 

We should be checking for overflows within the new lamport sum function, and returning an error as appropriate. 