### PR TITLE
util: deepasan updates

### DIFF
--- a/src/util/alloc/fd_alloc.c
+++ b/src/util/alloc/fd_alloc.c
@@ -617,18 +617,19 @@ fd_alloc_malloc_at_least( fd_alloc_t * join,
 
   align = fd_ulong_if( !align, FD_ALLOC_MALLOC_ALIGN_DEFAULT, align );
 
-  #if FD_HAS_DEEPASAN
+# if FD_HAS_DEEPASAN
   /* The header is prepended and needs to be unpoisoned. Ensure that
      there is padding for the alloc_hdr to be properly aligned. We
      want to exit silently if the sz passed in is 0. The alignment must be
      at least 8. */
   ulong fd_alloc_hdr_footprint = fd_ulong_align_up( sizeof(fd_alloc_hdr_t), FD_ASAN_ALIGN );
-  if ( sz && sz < ULONG_MAX )
+  if( FD_LIKELY(sz && sz < ULONG_MAX) ) {
     sz = fd_ulong_align_up( sz, FD_ASAN_ALIGN );
+  }
   align = fd_ulong_if( align < FD_ASAN_ALIGN, FD_ASAN_ALIGN, align );
-  #else
+# else
   ulong fd_alloc_hdr_footprint = sizeof(fd_alloc_hdr_t);
-  #endif
+# endif
 
   ulong footprint = sz + fd_alloc_hdr_footprint + align - 1UL;
 
@@ -720,7 +721,7 @@ fd_alloc_malloc_at_least( fd_alloc_t * join,
         }
 
         superblock_gaddr = fd_ulong_align_up( wksp_gaddr + fd_alloc_hdr_footprint, FD_ALLOC_SUPERBLOCK_ALIGN );
-        #if FD_HAS_DEEPASAN
+#       if FD_HAS_DEEPASAN
         /* At this point, a new superblock is allocated from the wksp and the header
            is prepended. The alignment needs to be taken into account: the padding
            should also be unpoisoned.
@@ -735,7 +736,7 @@ fd_alloc_malloc_at_least( fd_alloc_t * join,
         void * unpoison_laddr = fd_wksp_laddr_fast( wksp, superblock_gaddr - fd_alloc_hdr_footprint );
         ulong aligned_superblock_footprint = fd_ulong_align_up( superblock_footprint, FD_ASAN_ALIGN );
         fd_asan_unpoison( unpoison_laddr, aligned_superblock_footprint + fd_alloc_hdr_footprint );
-        #endif
+#       endif
 
         superblock = (fd_alloc_superblock_t *)
           fd_alloc_hdr_store_large( fd_wksp_laddr_fast( wksp, superblock_gaddr ), 1 /* sb */ );
@@ -861,7 +862,7 @@ fd_alloc_malloc_at_least( fd_alloc_t * join,
   ulong block_laddr     = (ulong)superblock + sizeof(fd_alloc_superblock_t) + block_idx*block_footprint;
   ulong alloc_laddr     = fd_ulong_align_up( block_laddr + fd_alloc_hdr_footprint, align );
 
-  #if FD_HAS_DEEPASAN
+# if FD_HAS_DEEPASAN
   /* The block and the header must be unpoisoned to accomodate the block
      footprint. The block footprint is determined by the sizeclass which
      provides the minimum size that accomodates the footprint which is the
@@ -872,12 +873,12 @@ fd_alloc_malloc_at_least( fd_alloc_t * join,
      in the block can be safely rounded down.
   */
 
-  void* laddr = (void*) ( alloc_laddr - fd_alloc_hdr_footprint );
+  void* laddr = (void*)(alloc_laddr - fd_alloc_hdr_footprint);
 
   ulong block_hi_addr = block_laddr + block_footprint;
   ulong block_unpoison_sz = fd_ulong_align_dn( block_hi_addr - alloc_laddr, FD_ASAN_ALIGN );
   fd_asan_unpoison( laddr, block_unpoison_sz + fd_alloc_hdr_footprint );
-  #endif
+# endif
 
   *max = block_footprint - (alloc_laddr - block_laddr);
 
@@ -917,7 +918,7 @@ fd_alloc_free( fd_alloc_t * join,
   fd_alloc_block_set_t    free_blocks = fd_alloc_block_set_add( &superblock->free_blocks, block );
 
 
-  #if FD_HAS_DEEPASAN
+# if FD_HAS_DEEPASAN
   /* The portion of the block which is used for the header and the allocation
      should get poisoned. The alloc's laddr is already at least 8 byte aligned.
      The 8 bytes prior to the start of the laddr are used by the fd_alloc_hdr_t.
@@ -931,8 +932,8 @@ fd_alloc_free( fd_alloc_t * join,
   ulong fd_alloc_hdr_footprint = fd_ulong_align_up( sizeof(fd_alloc_hdr_t), FD_ASAN_ALIGN );
   ulong fd_alloc_hdr_laddr     = (ulong)laddr - fd_alloc_hdr_footprint;
   ulong sz                     = block_hi_addr - (ulong)laddr + fd_alloc_hdr_footprint;
-  fd_asan_poison( (void*) fd_alloc_hdr_laddr, sz );
-  #endif
+  fd_asan_poison( (void*)fd_alloc_hdr_laddr, sz );
+# endif
 
   /* At this point, free_blocks is the set of free blocks just before
      the free. */

--- a/src/util/alloc/test_alloc.c
+++ b/src/util/alloc/test_alloc.c
@@ -62,7 +62,7 @@ test_main( int     argc,
 
   for( ulong i=0UL; i<2UL*alloc_cnt; i++ ) {
 
-    #if !FD_HAS_DEEPASAN
+#   if !FD_HAS_DEEPASAN
     if( (i & print_mask)==print_interval )  {
       char * info    = NULL;
       ulong  info_sz = 0UL;
@@ -75,7 +75,7 @@ test_main( int     argc,
       FD_LOG_DEBUG(( "fd_alloc_fprintf said:\n%*s", (int)(info_sz&INT_MAX), info ));
       free( info );
     }
-    #endif
+#   endif
 
     /* Determine if we should alloc or free this iteration.  If j==0,
        there are no outstanding allocs to free so we must alloc.  If
@@ -96,21 +96,22 @@ test_main( int     argc,
       ulong align    = fd_ulong_if( lg_align==lg_align_max+1, 0UL, 1UL<<lg_align );
 
       sz[j] = fd_rng_ulong_roll( rng, sz_max+1UL );
-      #if FD_HAS_DEEPASAN
+#     if FD_HAS_DEEPASAN
       /* Enforce 8 byte alignment requirements */
       align = fd_ulong_if( align < FD_ASAN_ALIGN, FD_ASAN_ALIGN, align );
       sz[j] = fd_ulong_if( sz[j] < FD_ASAN_ALIGN, FD_ASAN_ALIGN, sz[j] ); 
-      #endif
+#     endif
 
       /* Allocate it */
 
       ulong max;
       mem[j] = (uchar *)fd_alloc_malloc_at_least( alloc, align, sz[j], &max );
 
-      #if FD_HAS_DEEPASAN
-      if ( mem[j] && sz[j] )
+#     if FD_HAS_DEEPASAN
+      if( mem[j] && sz[j] ) {
         FD_TEST( fd_asan_query( mem[j], sz[j] ) == NULL );
-      #endif
+      }
+#     endif
 
       /* Check if the value is sane */
 
@@ -154,10 +155,11 @@ test_main( int     argc,
 
       fd_alloc_free( alloc, mem[k] );
 
-      #if FD_HAS_DEEPASAN
-      if ( mem[k] && sz[k] )
+#     if FD_HAS_DEEPASAN
+      if( mem[k] && sz[k] ) {
         FD_TEST( fd_asan_query( mem[k], sz[k] ) != NULL );
-      #endif
+      }
+#     endif
 
       /* Remove from outstanding allocations */
 

--- a/src/util/scratch/fd_scratch.h
+++ b/src/util/scratch/fd_scratch.h
@@ -179,10 +179,11 @@ fd_scratch_attach( void * smem,
   fd_scratch_private_frame_max = depth;
 
 # if FD_HAS_DEEPASAN
-  /* Poison the entire smem region and populate with junk bytes for debugging.
-     Alignment should be hanmdled by the caller */
-  fd_memset( smem, 'A', smax );
-  fd_asan_poison( smem, smax );
+  /* Poison the entire smem region. Underpoison the boundaries to respect 
+     alignment requirements. */
+  ulong aligned_start = fd_ulong_align_up( fd_scratch_private_start, FD_ASAN_ALIGN );
+  ulong aligned_end   = fd_ulong_align_dn( fd_scratch_private_stop, FD_ASAN_ALIGN );
+  fd_asan_poison( (void*)aligned_start, aligned_end - aligned_start );
 # endif
 }
 
@@ -208,10 +209,11 @@ fd_scratch_detach( void ** _opt_fmem ) {
 # endif
 
 # if FD_HAS_DEEPASAN
-  /* Unpoison the entire scratch space and fill with junk bytes. We have a guarantee
-     about the alignment region already. */
-  fd_asan_unpoison( (void *)fd_scratch_private_start, fd_scratch_private_stop - fd_scratch_private_start );
-  fd_memset( (void *)fd_scratch_private_start, 'B', fd_scratch_private_stop - fd_scratch_private_start );
+  /* Unpoison the entire scratch space. There should now be an underlying
+     allocation which has not been poisoned. */
+  ulong aligned_start = fd_ulong_align_up( fd_scratch_private_start, FD_ASAN_ALIGN );
+  ulong aligned_stop  = fd_ulong_align_dn( fd_scratch_private_stop, FD_ASAN_ALIGN );
+  fd_asan_unpoison( (void*)aligned_start, aligned_stop - aligned_start );
 # endif
 
   void * smem = (void *)fd_scratch_private_start;
@@ -272,7 +274,9 @@ fd_scratch_reset( void ) {
 
 # if FD_HAS_DEEPASAN
   /* Poison entire scratch space again. */
-  fd_asan_poison( (void *)fd_scratch_private_start, fd_scratch_private_stop - fd_scratch_private_start );
+  ulong aligned_start = fd_ulong_align_up( fd_scratch_private_start, FD_ASAN_ALIGN );
+  ulong aligned_stop  = fd_ulong_align_dn( fd_scratch_private_stop, FD_ASAN_ALIGN );
+  fd_asan_poison( (void*)aligned_start, aligned_stop - aligned_start );
 # endif
 }
 
@@ -293,6 +297,14 @@ fd_scratch_push( void ) {
   fd_scratch_in_prepare = 0;
 # endif
   fd_scratch_private_frame[ fd_scratch_private_frame_cnt++ ] = fd_scratch_private_free;
+
+# if FD_HAS_DEEPASAN
+  /* Poison to end of scratch region to account for case of in-prep allocation
+     getting implictly cancelled. */
+  ulong aligned_start = fd_ulong_align_up( fd_scratch_private_free, FD_ASAN_ALIGN );
+  ulong aligned_stop  = fd_ulong_align_dn( fd_scratch_private_stop, FD_ASAN_ALIGN );
+  fd_asan_poison( (void*)aligned_start, aligned_stop - aligned_start );
+# endif 
 }
 
 /* fd_scratch_pop frees all allocations in the current scratch frame,
@@ -317,14 +329,10 @@ fd_scratch_pop( void ) {
 # if FD_HAS_DEEPASAN
   /* On a pop() operation, the entire range from fd_scratch_private_free to the
      end of the scratch space can be safely poisoned. The region must be aligned
-     to accomodate asan manual poisoning requirements. The region from the new
-     fd_scratch_private_free to the poisoned region is populated with junk bytes
-     for debugging. If the junk bytes are accessed before a frame is pushed and
-     is populated with allocations, then it is a bad memory access.*/
-  ulong aligned_free = fd_ulong_align_up( fd_scratch_private_free, FD_ASAN_ALIGN );
-  ulong poison_range = fd_scratch_private_stop - aligned_free;
-  fd_asan_poison( (void *)aligned_free, poison_range );
-  fd_memset( (void *)fd_scratch_private_free, 'C', aligned_free - fd_scratch_private_free );
+     to accomodate asan manual poisoning requirements. */
+  ulong aligned_start = fd_ulong_align_up( fd_scratch_private_free, FD_ASAN_ALIGN );
+  ulong aligned_stop  = fd_ulong_align_dn( fd_scratch_private_stop, FD_ASAN_ALIGN );
+  fd_asan_poison( (void*)aligned_start, aligned_stop - aligned_start );
 # endif
 }
 
@@ -384,11 +392,11 @@ fd_scratch_prepare( ulong align ) {
   if( FD_UNLIKELY( !fd_scratch_private_align_is_valid( align ) ) ) FD_LOG_ERR(( "bad align (%lu)", align ));
 # endif
 
-  ulong true_align = fd_scratch_private_true_align( align );
 # if FD_HAS_DEEPASAN
-  /* Need 8 byte alignment */
-  align            = fd_ulong_if( align < FD_ASAN_ALIGN, FD_ASAN_ALIGN, align );
+  /* Need 8 byte alignment. */
+  align            = fd_ulong_align_up( align, FD_ASAN_ALIGN );
 # endif
+  ulong true_align = fd_scratch_private_true_align( align );
   ulong smem       = fd_ulong_align_up( fd_scratch_private_free, true_align );
 
 # if FD_SCRATCH_USE_HANDHOLDING
@@ -397,6 +405,13 @@ fd_scratch_prepare( ulong align ) {
                                                                    align, smem - fd_scratch_private_stop ));
   fd_scratch_in_prepare = 1;
 # endif
+
+# if FD_HAS_DEEPASAN
+  /* At this point the user is able to clobber any bytes in the region. smem is
+     always going to be at least 8 byte aligned. */
+  ulong aligned_sz = fd_ulong_align_up( fd_scratch_private_stop - smem, FD_ASAN_ALIGN );
+  fd_asan_unpoison( (void*)smem, aligned_sz );
+# endif 
 
   fd_scratch_private_free = smem;
   return (void *)smem;
@@ -415,19 +430,11 @@ fd_scratch_publish( void * _end ) {
 # endif
 
 # if FD_HAS_DEEPASAN
-  /* Unpoison the range from the previous fd_scratch_private_free to the end
-     address specified by the caller. The start address is aligned down because
-     the start of the scratch space is aligned and any prior bytes should be
-     unpoisoned already. The size is aligned up to accomodate 8 byte alignment
-     for asan manual poisoning. This is also acceptable because future allocations
-     will be aligned up. For debugging purposes the range from end_ to the end of
-     the unpoisoned region will be filled with junk bytes because these bytes
-     should not ever be accessed (until the frame is popped, pushed, and the
-     region is allocated again).  */
-  ulong aligned_addr = fd_ulong_align_dn( fd_scratch_private_free, FD_ASAN_ALIGN );
-  ulong aligned_sz = fd_ulong_align_up( end - aligned_addr, FD_ASAN_ALIGN );
-  fd_asan_unpoison( (void *) aligned_addr, aligned_sz );
-  fd_memset( _end, 'D', aligned_addr + aligned_sz - end );
+  /* Poison everything that is trimmed off. Conservatively poison potentially
+     less than the region that is trimmed to respect alignment requirements. */
+  ulong aligned_end  = fd_ulong_align_up( end, FD_ASAN_ALIGN );
+  ulong aligned_stop = fd_ulong_align_dn( fd_scratch_private_stop, FD_ASAN_ALIGN ); 
+  fd_asan_poison( (void*)aligned_end, aligned_stop - aligned_end );
 # endif
 
   fd_scratch_private_free = end;
@@ -533,12 +540,10 @@ fd_scratch_trim( void * _end ) {
 
 # if FD_HAS_DEEPASAN
   /* The region to poison should be from _end to the end of the scratch's region.
-     The same alignment considerations need to be taken into account. The region
-     that is trimmed but not poisoned will be populated with junk bytes. */
-  ulong aligned_free = fd_ulong_align_up( end, FD_ASAN_ALIGN );
-  ulong poison_range = fd_scratch_private_stop - aligned_free;
-  fd_asan_poison( (void*)aligned_free, poison_range );
-  fd_memset( (void*)end, 'E', aligned_free - end );
+     The same alignment considerations need to be taken into account. */
+  ulong aligned_end  = fd_ulong_align_up( end, FD_ASAN_ALIGN );
+  ulong aligned_stop = fd_ulong_align_dn( fd_scratch_private_stop, FD_ASAN_ALIGN );
+  fd_asan_poison( (void*)aligned_end, aligned_stop - aligned_end );
 # endif
 
   fd_scratch_private_free = end;

--- a/src/util/scratch/test_scratch.c
+++ b/src/util/scratch/test_scratch.c
@@ -162,7 +162,6 @@ main( int     argc,
       FD_TEST( fd_asan_query( mem, sz) == NULL );
       FD_TEST( fd_asan_test( mem ) == 0 );
       FD_TEST( fd_asan_test( mem + sz - 1 ) == 0 );
-      FD_TEST( fd_asan_test( mem + sz ) || mem[sz] == 'D' );
       FD_TEST( fd_asan_test( mem + sz + FD_ASAN_ALIGN ) == 1 );
       # endif
     }
@@ -181,16 +180,13 @@ main( int     argc,
     fd_scratch_trim( mem + sz );
 
     /* Try to safely access memory around freshly poisoned region. Check past the
-       boundary to make sure that it is poisoned, check the boundary itself to
-       see if it either is poisoned or has a junk byte, and check the oriignal memory
-       itself. Note: 187 maps to the char 0xBB which is populated. */
+       boundary to make sure that it is poisoned. */
     #if FD_HAS_DEEPASAN
     if ( sz ) {
       FD_TEST( fd_asan_test( mem ) == 0 );
       FD_TEST( fd_asan_test( mem + sz - 1 ) == 0 );
     }
     FD_TEST( fd_asan_test( mem + sz + FD_ASAN_ALIGN ) != 0 );
-    FD_TEST( fd_asan_test( mem + sz ) || mem[sz] == 'E' );
     #endif
 
     new_m1 = new_m0 + sz;

--- a/src/util/wksp/fd_wksp_admin.c
+++ b/src/util/wksp/fd_wksp_admin.c
@@ -207,8 +207,13 @@ fd_wksp_new( void *       shmem,
   }
 
   #if FD_HAS_DEEPASAN
-  void * laddr_lo = fd_wksp_laddr_fast( wksp, wksp->gaddr_lo + sizeof(fd_wksp_t) );
-  fd_asan_poison( laddr_lo, footprint - sizeof(fd_wksp_t) );
+  /* Poison entire workspace except wksp header and the pinfo array. */
+  void * wksp_data = (void*)((ulong)wksp + fd_wksp_private_pinfo_off());
+  fd_asan_poison( wksp_data, footprint - fd_wksp_private_pinfo_off() );
+  fd_wksp_private_pinfo_t * pinfo = fd_wksp_private_pinfo( wksp );
+  for( ulong i=0; i<part_max; i++ ) { 
+    fd_asan_unpoison( &pinfo[ i ], FD_WKSP_PRIVATE_PINFO_FOOTPRINT );
+  }
   #endif
 
   fd_wksp_private_unlock( wksp );
@@ -273,13 +278,12 @@ fd_wksp_delete( void * shwksp ) {
   FD_VOLATILE( wksp->magic ) = 0UL;
   FD_COMPILER_MFENCE();
 
-  #if FD_HAS_DEEPASAN
-  /* Unpoison everything in case region of memory is reallocated at some point.
-     Fill wksp bytes with human readable junk for debugging. */
-  ulong wksp_footprint = fd_wksp_footprint( wksp->part_max, wksp->data_max );
-  fd_asan_unpoison( wksp, wksp_footprint );
-  fd_memset( (void*)wksp, 'B', wksp_footprint );
-  #endif
+# if FD_HAS_DEEPASAN
+  /* Unpoison entire wksp region. */
+  ulong footprint = fd_wksp_footprint( wksp->part_max, wksp->data_max );
+  void * wksp_data = (void*)((ulong)wksp + fd_wksp_private_pinfo_off());
+  fd_asan_unpoison( wksp_data, footprint - fd_wksp_private_pinfo_off());
+# endif
 
   return wksp;
 }

--- a/src/util/wksp/fd_wksp_io.c
+++ b/src/util/wksp/fd_wksp_io.c
@@ -122,12 +122,6 @@ fd_wksp_checkpt( fd_wksp_t *  wksp,
         ulong sz = gaddr_hi - gaddr_lo;
         void * laddr_lo = fd_wksp_laddr_fast( wksp, gaddr_lo );
 
-        #if FD_HAS_DEEPASAN
-        /* Copy the entire wksp over. This includes regions that may have been
-           poisoned at one point. */
-        fd_asan_unpoison( laddr_lo, sz );
-        #endif
-
         /* Checkpt partition header */
 
         prep = fd_wksp_private_checkpt_prepare( checkpt, 3UL*9UL, &err ); if( FD_UNLIKELY( !prep ) ) goto io_err;
@@ -406,7 +400,16 @@ fd_wksp_restore( fd_wksp_t *  wksp,
       wksp_dirty = 1;
 
       #if FD_HAS_DEEPASAN
-      fd_asan_unpoison( fd_wksp_laddr_fast( wksp, gaddr_lo ), sz );
+      /* Poison the restored allocations. Potentially under poison to respect
+         manual poisoning alignment requirements. Don't poison if the allocation
+         is smaller than FD_ASAN_ALIGN. */
+      ulong laddr_lo = (ulong)fd_wksp_laddr_fast( wksp, gaddr_lo );
+      ulong laddr_hi = laddr_lo + sz;
+      ulong aligned_laddr_lo = fd_ulong_align_up( laddr_lo, FD_ASAN_ALIGN );
+      ulong aligned_laddr_hi = fd_ulong_align_dn( laddr_hi, FD_ASAN_ALIGN );
+      if( aligned_laddr_lo < aligned_laddr_hi ) {
+        fd_asan_poison( (void*)aligned_laddr_lo, aligned_laddr_hi - aligned_laddr_lo );
+      }
       #endif
 
       err = fd_io_buffered_istream_read( restore, fd_wksp_laddr_fast( wksp, gaddr_lo ), sz );

--- a/src/util/wksp/fd_wksp_private.h
+++ b/src/util/wksp/fd_wksp_private.h
@@ -262,6 +262,9 @@ static inline ulong                                                 /* Assumes i
 fd_wksp_private_idle_stack_pop( fd_wksp_t *               wksp,     /* Assumes current local join */
                                 fd_wksp_private_pinfo_t * pinfo ) { /* == fd_wksp_private_pinfo( wksp ) */
   ulong i = fd_wksp_private_pinfo_idx( wksp->idle_top_cidx );
+# if FD_HAS_DEEPASAN
+  fd_asan_unpoison( &pinfo[ i ], FD_WKSP_PRIVATE_PINFO_FOOTPRINT );
+# endif
   wksp->idle_top_cidx = pinfo[ i ].parent_cidx;
   pinfo[ i ].parent_cidx = fd_wksp_private_pinfo_cidx( FD_WKSP_PRIVATE_PINFO_IDX_NULL );
   return i;
@@ -286,6 +289,10 @@ fd_wksp_private_idle_stack_push( ulong                     i,        /* Assumes 
   pinfo[ i ].same_cidx   = fd_wksp_private_pinfo_cidx( FD_WKSP_PRIVATE_PINFO_IDX_NULL );
   pinfo[ i ].parent_cidx = wksp->idle_top_cidx;
   wksp->idle_top_cidx = fd_wksp_private_pinfo_cidx( i );
+
+# if FD_HAS_DEEPASAN
+  fd_asan_poison( &pinfo[ i ], FD_WKSP_PRIVATE_PINFO_FOOTPRINT );
+# endif
 }
 
 /* pinfo used treap APIs **********************************************/

--- a/src/util/wksp/fd_wksp_user.c
+++ b/src/util/wksp/fd_wksp_user.c
@@ -177,6 +177,11 @@ fd_wksp_private_free( ulong                     i,        /* Partition to free, 
     FD_LOG_WARNING(( "corrupt wksp detected" ));
     return;
   }
+
+# if FD_HAS_DEEPASAN
+  /* Poison the data region of the now freed allocation. */
+  fd_asan_poison( fd_wksp_laddr_fast( wksp, pinfo[ i ].gaddr_lo ), pinfo[ i ].gaddr_hi - pinfo[ i ].gaddr_lo );
+# endif
 }
 
 /* user APIs **********************************************************/
@@ -229,14 +234,16 @@ fd_wksp_alloc_at_least( fd_wksp_t * wksp,
   if( FD_UNLIKELY( !fd_ulong_is_pow2( align ) ) ) { FD_LOG_WARNING(( "bad align"   )); goto fail; }
   if( FD_UNLIKELY( !tag                       ) ) { FD_LOG_WARNING(( "bad tag"     )); goto fail; }
 
-  #if FD_HAS_DEEPASAN
-    /* ASan requires 8 byte alignment for poisoning because memory is mapped in
-       8 byte intervals to ASan shadow bytes. */
-    align = fd_ulong_if( align < FD_ASAN_ALIGN, FD_ASAN_ALIGN, align );
-    if ( sz && sz < ULONG_MAX )
-      sz = fd_ulong_align_up( sz, FD_ASAN_ALIGN );
-    footprint = sz + align - 1UL;
-  #endif
+# if FD_HAS_DEEPASAN
+  /* ASan requires 8 byte alignment for poisoning because memory is mapped in
+     8 byte intervals to ASan shadow bytes. Update alignment, sz, and footprint
+     to meet manual poisoning requirements. */
+  align = fd_ulong_if( align < FD_ASAN_ALIGN, FD_ASAN_ALIGN, align );
+  if( sz && sz < ULONG_MAX ) {
+    sz = fd_ulong_align_up( sz, FD_ASAN_ALIGN );
+  }
+  footprint = sz + align - 1UL;
+# endif
 
   if( FD_UNLIKELY( footprint < sz             ) ) { FD_LOG_WARNING(( "sz overflow" )); goto fail; }
 
@@ -323,9 +330,10 @@ trimmed:
   FD_VOLATILE( pinfo[ i ].tag ) = tag;
   FD_COMPILER_MFENCE();
 
-  #if FD_HAS_DEEPASAN
+# if FD_HAS_DEEPASAN
+  /* Unpoison the data region of the allocation */
   fd_asan_unpoison( fd_wksp_laddr_fast( wksp, lo ), hi - lo );
-  #endif
+# endif
 
   fd_wksp_private_unlock( wksp );
   *_lo = lo;
@@ -356,11 +364,6 @@ fd_wksp_free( fd_wksp_t * wksp,
   fd_wksp_private_unlock( wksp );
 
   if( FD_UNLIKELY( i>=part_max ) ) FD_LOG_WARNING(( "gaddr does not appear to be a current wksp allocation" ));
-  else {
-    #if FD_HAS_DEEPASAN
-    fd_asan_poison( fd_wksp_laddr_fast( wksp, pinfo[ i ].gaddr_lo ), pinfo[ i ].gaddr_hi - pinfo[ i ].gaddr_lo );
-    #endif
-  }
 }
 
 ulong
@@ -513,6 +516,17 @@ void
 fd_wksp_reset( fd_wksp_t * wksp,
                uint        seed ) {
   if( FD_UNLIKELY( !wksp ) ) { FD_LOG_WARNING(( "NULL wksp" )); return; }
+
+# if FD_HAS_DEEPASAN
+  /* Poison entire workspace except wksp header and the pinfo array. */
+  ulong footprint = fd_wksp_footprint( wksp->part_max, wksp->data_max );
+  void * wksp_data = (void*)((ulong)wksp + fd_wksp_private_pinfo_off());
+  fd_asan_poison( wksp_data, footprint - fd_wksp_private_pinfo_off() );
+  fd_wksp_private_pinfo_t * pinfo_arr = fd_wksp_private_pinfo( wksp );
+  for( ulong i=0; i<wksp->part_max; i++ ) { 
+    fd_asan_unpoison( &pinfo_arr[ i ], FD_WKSP_PRIVATE_PINFO_FOOTPRINT );
+  }
+# endif
 
   ulong                     part_max = wksp->part_max;
   fd_wksp_private_pinfo_t * pinfo    = fd_wksp_private_pinfo( wksp );

--- a/src/util/wksp/test_wksp_user.c
+++ b/src/util/wksp/test_wksp_user.c
@@ -208,9 +208,9 @@ main( int     argc,
     fd_wksp_free( wksp, g );
 
     FD_TEST( !fd_wksp_tag( wksp, g ) );
-    #if !FD_HAS_DEEPASAN
+#   if !FD_HAS_DEEPASAN
     fd_wksp_free  ( wksp, g      ); /* double free */
-    #endif
+#   endif
     fd_wksp_memset( wksp, g, 255 ); /* memset unallocated */
     FD_TEST( !fd_wksp_tag( wksp, g ) );
   }


### PR DESCRIPTION
1. Style fixes across deep asan uses (scratch, alloc, wksp)
2. Adding unpoisoning on scratch_prepare
3. Removing junk byte memsetting in scratch
4. wksp: poisoning/unpoisoning pinfo on idle stack push/pop
5. updating poisoning/unpoisoining on allocations and frees (poisoning data region + unpoisoning pinfo array)