### PR TITLE
Selective ubsan

### DIFF
--- a/config/extra/with-ubsan.mk
+++ b/config/extra/with-ubsan.mk
@@ -19,6 +19,7 @@ CPPFLAGS+=-fsanitize=undefined \
           -fsanitize=null \
           -fsanitize=return \
           -fsanitize=signed-integer-overflow \
+          -fsanitize=unsigned-integer-overflow \
           -fsanitize=bounds \
           -fsanitize=alignment \
           -fsanitize=object-size \

--- a/src/flamenco/runtime/tests/Local.mk
+++ b/src/flamenco/runtime/tests/Local.mk
@@ -5,6 +5,8 @@ ifdef FD_HAS_INT128
 $(call add-hdrs,fd_exec_instr_test.h)
 $(call add-objs,fd_exec_instr_test,fd_flamenco)
 
+CFLAGS+=-fno-sanitize=undefined
+
 $(call make-unit-test,test_exec_instr,test_exec_instr,fd_flamenco fd_funk fd_ballet fd_util,$(SECP256K1_LIBS))
 $(call make-shared,libfd_exec_sol_compat.so,fd_exec_sol_compat,fd_flamenco fd_funk fd_ballet fd_util,$(SECP256K1_LIBS))
 endif

--- a/src/flamenco/runtime/tests/Local.mk
+++ b/src/flamenco/runtime/tests/Local.mk
@@ -5,7 +5,9 @@ ifdef FD_HAS_INT128
 $(call add-hdrs,fd_exec_instr_test.h)
 $(call add-objs,fd_exec_instr_test,fd_flamenco)
 
+ifdef FD_HAS_UBSAN
 CFLAGS+=-fno-sanitize=undefined
+endif
 
 $(call make-unit-test,test_exec_instr,test_exec_instr,fd_flamenco fd_funk fd_ballet fd_util,$(SECP256K1_LIBS))
 $(call make-shared,libfd_exec_sol_compat.so,fd_exec_sol_compat,fd_flamenco fd_funk fd_ballet fd_util,$(SECP256K1_LIBS))

--- a/src/util/bits/fd_bits.h
+++ b/src/util/bits/fd_bits.h
@@ -443,7 +443,11 @@ static inline void fd_char_store_if( int c, char * p, char v ) { char _[ 1 ]; *(
    tests of randomness when used as a PRNG. */
 
 FD_FN_CONST static inline uint
+#ifndef FD_HAS_UBSAN
+fd_uint_hash( uint x )
+#else
 fd_uint_hash( uint x ) __attribute__((no_sanitize("unsigned-integer-overflow"))) {
+#endif
   x ^= x >> 16;
   x *= 0x85ebca6bU;
   x ^= x >> 13;
@@ -453,7 +457,11 @@ fd_uint_hash( uint x ) __attribute__((no_sanitize("unsigned-integer-overflow")))
 }
 
 FD_FN_CONST static inline ulong
+#ifndef FD_HAS_UBSAN
+fd_ulong_hash( ulong x )
+#else
 fd_ulong_hash( ulong x ) __attribute__((no_sanitize("unsigned-integer-overflow"))) {
+#endif
   x ^= x >> 33;
   x *= 0xff51afd7ed558ccdUL;
   x ^= x >> 33;

--- a/src/util/bits/fd_bits.h
+++ b/src/util/bits/fd_bits.h
@@ -443,7 +443,7 @@ static inline void fd_char_store_if( int c, char * p, char v ) { char _[ 1 ]; *(
    tests of randomness when used as a PRNG. */
 
 FD_FN_CONST static inline uint
-fd_uint_hash( uint x ) {
+fd_uint_hash( uint x ) __attribute__((no_sanitize("unsigned-integer-overflow"))) {
   x ^= x >> 16;
   x *= 0x85ebca6bU;
   x ^= x >> 13;
@@ -453,7 +453,7 @@ fd_uint_hash( uint x ) {
 }
 
 FD_FN_CONST static inline ulong
-fd_ulong_hash( ulong x ) {
+fd_ulong_hash( ulong x ) __attribute__((no_sanitize("unsigned-integer-overflow"))) {
   x ^= x >> 33;
   x *= 0xff51afd7ed558ccdUL;
   x ^= x >> 33;

--- a/src/util/fd_hash.c
+++ b/src/util/fd_hash.c
@@ -12,7 +12,7 @@
 ulong
 fd_hash( ulong        seed,
          void const * buf,
-         ulong        sz ) {
+         ulong        sz ) __attribute__((no_sanitize("unsigned-integer-overflow"))) {
   uchar const * p    = ((uchar const *)buf);
   uchar const * stop = p + sz;
 

--- a/src/util/shmem/fd_shmem_user.c
+++ b/src/util/shmem/fd_shmem_user.c
@@ -66,7 +66,11 @@ static inline fd_shmem_join_info_t *
 fd_shmem_private_map_query_by_addr( fd_shmem_join_info_t * map,
                                     ulong                  a0,
                                     ulong                  a1,      /* Assumes a1>=a0 */
+#ifndef FD_HAS_UBSAN
+                                    fd_shmem_join_info_t * def ) {
+#else
                                     fd_shmem_join_info_t * def ) __attribute__((no_sanitize("unsigned-integer-overflow"))) {
+#endif
   for( ulong slot_idx=0UL; slot_idx<FD_SHMEM_PRIVATE_MAP_SLOT_CNT; slot_idx++ ) {
     ulong j0 = (ulong)map[slot_idx].shmem;
     ulong j1 = j0 + map[slot_idx].page_sz*map[slot_idx].page_cnt - 1UL;

--- a/src/util/shmem/fd_shmem_user.c
+++ b/src/util/shmem/fd_shmem_user.c
@@ -66,7 +66,7 @@ static inline fd_shmem_join_info_t *
 fd_shmem_private_map_query_by_addr( fd_shmem_join_info_t * map,
                                     ulong                  a0,
                                     ulong                  a1,      /* Assumes a1>=a0 */
-                                    fd_shmem_join_info_t * def ) {
+                                    fd_shmem_join_info_t * def ) __attribute__((no_sanitize("unsigned-integer-overflow"))) {
   for( ulong slot_idx=0UL; slot_idx<FD_SHMEM_PRIVATE_MAP_SLOT_CNT; slot_idx++ ) {
     ulong j0 = (ulong)map[slot_idx].shmem;
     ulong j1 = j0 + map[slot_idx].page_sz*map[slot_idx].page_cnt - 1UL;


### PR DESCRIPTION
Set of patches intended to make UBSAN work when fuzzing M2. Currently UBSAN is showing reports that do not appear to be security related during initialization. This allows the fuzzing session to halt on UBSAN reports and be cleaner. I have encountered 2 integer overflows issues in the native programs and think UBSAN would be beneficial for those running the Fuzzers.

The patches are for the Clang build. IIRC when testing, GCC's UBSAN had more false positives (that appeared during compilation) than Clang and was not supporting all sanitize flags of UBSAN (ie. less stable). 

I also added unsigned-overflow checks to `with-ubsan.mk`, as this is targeted for fuzzing.

Note: `fd_exec_instr_test.c` is an exception that requires modifying CFLAGS for -fno-sanitize=undefined (I did not manage to make it work with `__attribute__((no_sanitize("undefined")))` nor  `__attribute__((no_sanitize("nullability")))` ). This does not prevent dependencies such as native programs to be compiled in with UBSAN.

