### PR TITLE
flamenco/tests: fix double normal classification

### DIFF
--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -97,7 +97,7 @@ static int
 fd_double_is_normal( double dbl ) {
   ulong x = fd_dblbits( dbl );
   int is_denorm =
-    ( fd_dblbits_bexp( x ) == 0 ) |
+    ( fd_dblbits_bexp( x ) == 0 ) &
     ( fd_dblbits_mant( x ) != 0 );
   int is_inf =
     ( fd_dblbits_bexp( x ) == 2047 ) &


### PR DESCRIPTION
Tested by differential fuzzing with C++'s `std::isnormal()`. Without the fix we would reject normal double such as `0x93da8e` that comes from the fuzzer (ie. lower coverage) whereas `std::normal()` would accept it. `-ffast-math` prevents us from using `std::isnormal()`.

Note: We are purposely not rejecting 0, because it is an interesting value from a fuzzing perspective. With @ripatel-fd we suggest to change the harnesses to accept 0 as a valid fuzzing value.

