### PR TITLE
flamenco: checkpoint on mismatch

### DIFF
--- a/src/app/ledger/main.c
+++ b/src/app/ledger/main.c
@@ -264,6 +264,7 @@ runtime_replay( fd_runtime_ctx_t * state, fd_runtime_args_t * args ) {
                         expected->hash,
                         state->slot_ctx->slot_bank.poh.hash ));
       if( state->abort_on_mismatch ) {
+        fd_runtime_checkpt( state->capture_ctx, state->slot_ctx, ULONG_MAX );
         fd_blockstore_end_read( blockstore );
         return 1;
       }
@@ -280,6 +281,7 @@ runtime_replay( fd_runtime_ctx_t * state, fd_runtime_args_t * args ) {
                         expected->hash,
                         state->slot_ctx->slot_bank.banks_hash.hash ));
       if( state->abort_on_mismatch ) {
+        fd_runtime_checkpt( state->capture_ctx, state->slot_ctx, ULONG_MAX );
         fd_blockstore_end_read( blockstore );
         return 1;
       }

--- a/src/app/ledger/main.c
+++ b/src/app/ledger/main.c
@@ -71,7 +71,6 @@ static void usage( char const * progname ) {
   fprintf( stderr, " --capture-solcap <capture file>            capture solcap\n" ); /* Capture context tool for solcaps*/
   fprintf( stderr, " --capture-txns <int>                       capture transactions\n" );
   fprintf( stderr, " --checkpt-path <checkpoint path>           path to checkpoint\n" ); /* Capture context tool for runtime checkpoints */
-  fprintf( stderr, " --checkpt-slot <ulong>                     checkpoint slot\n" );
   fprintf( stderr, " --checkpt-freq <ulong>                     checkpoint frequency\n" );
   fprintf( stderr, " --allocator <allocator>                    allocator to use\n" );
   fprintf( stderr, " --dump-insn-to-pb <int>                    dump instructions to pb\n" ); /* Capture ctx tool for insn dumping*/
@@ -113,7 +112,6 @@ struct fd_ledger_args {
   char const *      capture_fpath; /* solcap */
   int               capture_txns;
   char const *      checkpt_path; /* runtime checkpoints */
-  ulong             checkpt_slot;
   ulong             checkpt_freq;
   ulong             on_demand_block_history;
   int               dump_insn_to_pb;
@@ -833,7 +831,6 @@ replay( fd_ledger_args_t * args ) {
   runtime_args.capture_fpath           = args->capture_fpath;
   runtime_args.capture_txns            = args->capture_txns;
   runtime_args.checkpt_path            = args->checkpt_path;
-  runtime_args.checkpt_slot            = args->checkpt_slot;
   runtime_args.checkpt_freq            = args->checkpt_freq;
   runtime_args.copy_txn_status         = args->copy_txn_status;
   runtime_args.on_demand_block_ingest  = args->on_demand_block_ingest;
@@ -865,7 +862,7 @@ prune( fd_ledger_args_t * args ) {
     /* Replay all slots before prune slot and checkpoint at prune_start_slot */
     args->start_slot = 0;
     args->end_slot = prune_start_slot + FD_RUNTIME_NUM_ROOT_BLOCKS;
-    args->checkpt_slot = prune_start_slot;
+    args->checkpt_freq = prune_start_slot;
     args->checkpt_path = args->checkpt_funk == NULL ? args->checkpt : args->checkpt_funk;
 
     int err = replay( args );
@@ -1222,7 +1219,6 @@ initial_setup( int argc, char ** argv, fd_ledger_args_t * args ) {
   char const * capture_fpath           = fd_env_strip_cmdline_cstr ( &argc, &argv, "--capture-solcap",          NULL, NULL      );
   int          capture_txns            = fd_env_strip_cmdline_int  ( &argc, &argv, "--capture-txns",            NULL, 1         );
   char const * checkpt_path            = fd_env_strip_cmdline_cstr ( &argc, &argv, "--checkpt-path",            NULL, NULL      );
-  ulong        checkpt_slot            = fd_env_strip_cmdline_ulong( &argc, &argv, "--checkpt-slot",            NULL, 0         );
   ulong        checkpt_freq            = fd_env_strip_cmdline_ulong( &argc, &argv, "--checkpt-freq",            NULL, ULONG_MAX );
   char const * allocator               = fd_env_strip_cmdline_cstr ( &argc, &argv, "--allocator",               NULL, "wksp"    );
   int          abort_on_mismatch       = fd_env_strip_cmdline_int  ( &argc, &argv, "--abort-on-mismatch",       NULL, 1         );
@@ -1325,7 +1321,6 @@ initial_setup( int argc, char ** argv, fd_ledger_args_t * args ) {
   args->capture_fpath           = capture_fpath;
   args->capture_txns            = capture_txns;
   args->checkpt_path            = checkpt_path;
-  args->checkpt_slot            = checkpt_slot;
   args->checkpt_freq            = checkpt_freq;
   args->allocator               = allocator;
   args->abort_on_mismatch       = abort_on_mismatch;

--- a/src/disco/tvu/fd_tvu.c
+++ b/src/disco/tvu/fd_tvu.c
@@ -773,7 +773,7 @@ void capture_ctx_setup( fd_runtime_ctx_t * runtime_ctx, fd_runtime_args_t * args
   runtime_ctx->capture_file = NULL;
 
   int has_solcap           = args->capture_fpath && args->capture_fpath[0] != '\0';
-  int has_checkpt_dump     = args->checkpt_path && args->checkpt_path[0] != '\0' && args->checkpt_freq != 0;
+  int has_checkpt_dump     = args->checkpt_path && args->checkpt_path[0] != '\0';
   int has_prune            = args->pruned_funk != NULL;
   int has_dump_to_protobuf = args->dump_insn_to_pb;
 
@@ -1492,8 +1492,8 @@ fd_tvu_parse_args( fd_runtime_args_t * args, int argc, char ** argv ) {
   args->retrace       = fd_env_strip_cmdline_int( &argc, &argv, "--retrace", NULL, 0 );
   args->abort_on_mismatch =
       (uchar)fd_env_strip_cmdline_int( &argc, &argv, "--abort-on-mismatch", NULL, 0 );
-  args->checkpt_freq = fd_env_strip_cmdline_ulong( &argc, &argv, "--checkpt-freq", NULL, ULONG_MAX );
-  args->checkpt_path = fd_env_strip_cmdline_cstr( &argc, &argv, "--checkpt-path", NULL, NULL );
+  args->checkpt_freq     = fd_env_strip_cmdline_ulong( &argc, &argv, "--checkpt-freq", NULL, ULONG_MAX );
+  args->checkpt_path     = fd_env_strip_cmdline_cstr( &argc, &argv, "--checkpt-path", NULL, NULL );
   args->dump_insn_to_pb = fd_env_strip_cmdline_int( &argc, &argv, "--dump-insn-to-pb", NULL, 0 );
   args->dump_insn_sig_filter = fd_env_strip_cmdline_cstr( &argc, &argv, "--dump-insn-sig-filter", NULL, NULL );
   args->dump_insn_output_dir = fd_env_strip_cmdline_cstr( &argc, &argv, "--dump-insn-output-dir", NULL, "protobuf_tests_from_executed_instr" );

--- a/src/disco/tvu/fd_tvu.c
+++ b/src/disco/tvu/fd_tvu.c
@@ -773,8 +773,7 @@ void capture_ctx_setup( fd_runtime_ctx_t * runtime_ctx, fd_runtime_args_t * args
   runtime_ctx->capture_file = NULL;
 
   int has_solcap           = args->capture_fpath && args->capture_fpath[0] != '\0';
-  int has_checkpt_dump     = args->checkpt_path && args->checkpt_path[0] != '\0' &&
-                             ( args->checkpt_slot != 0 || args->checkpt_freq != 0 );
+  int has_checkpt_dump     = args->checkpt_path && args->checkpt_path[0] != '\0' && args->checkpt_freq != 0;
   int has_prune            = args->pruned_funk != NULL;
   int has_dump_to_protobuf = args->dump_insn_to_pb;
 
@@ -787,7 +786,6 @@ void capture_ctx_setup( fd_runtime_ctx_t * runtime_ctx, fd_runtime_args_t * args
   fd_memset( capture_ctx_mem, 0, sizeof( fd_capture_ctx_t ) );
   runtime_ctx->capture_ctx = fd_capture_ctx_new( capture_ctx_mem );
 
-  runtime_ctx->capture_ctx->checkpt_slot = ULONG_MAX;
   runtime_ctx->capture_ctx->checkpt_freq = ULONG_MAX;
 
   if( has_solcap ) {
@@ -802,7 +800,6 @@ void capture_ctx_setup( fd_runtime_ctx_t * runtime_ctx, fd_runtime_args_t * args
   }
 
   if( has_checkpt_dump ) {
-    runtime_ctx->capture_ctx->checkpt_slot = args->checkpt_slot;
     runtime_ctx->capture_ctx->checkpt_path = args->checkpt_path;
     runtime_ctx->capture_ctx->checkpt_freq = args->checkpt_freq;
   }
@@ -1495,7 +1492,6 @@ fd_tvu_parse_args( fd_runtime_args_t * args, int argc, char ** argv ) {
   args->retrace       = fd_env_strip_cmdline_int( &argc, &argv, "--retrace", NULL, 0 );
   args->abort_on_mismatch =
       (uchar)fd_env_strip_cmdline_int( &argc, &argv, "--abort-on-mismatch", NULL, 0 );
-  args->checkpt_slot = fd_env_strip_cmdline_ulong( &argc, &argv, "--checkpt-slot", NULL, 0 );
   args->checkpt_freq = fd_env_strip_cmdline_ulong( &argc, &argv, "--checkpt-freq", NULL, ULONG_MAX );
   args->checkpt_path = fd_env_strip_cmdline_cstr( &argc, &argv, "--checkpt-path", NULL, NULL );
   args->dump_insn_to_pb = fd_env_strip_cmdline_int( &argc, &argv, "--dump-insn-to-pb", NULL, 0 );

--- a/src/flamenco/runtime/context/fd_capture_ctx.h
+++ b/src/flamenco/runtime/context/fd_capture_ctx.h
@@ -16,8 +16,7 @@ struct __attribute__((aligned(FD_CAPTURE_CTX_ALIGN))) fd_capture_ctx {
   int                      capture_txns; /* Capturing txns can add significant time */
 
   /* Checkpointing */
-  ulong                    checkpt_slot; /* Must be a rooted slot */
-  ulong                    checkpt_freq;
+  ulong                    checkpt_freq; /* Must be a rooted slot*/
   char const *             checkpt_path;
 
   /* Prune */

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -1115,9 +1115,9 @@ fd_execute_txn( fd_exec_txn_ctx_t * txn_ctx ) {
       }
 
       int exec_result = fd_execute_instr( txn_ctx, &instrs[i] );
-      if ( 254462504 == txn_ctx->slot_ctx->slot_bank.slot ) {
-        exec_result = -1;
-      }
+      //if ( 254462504 == txn_ctx->slot_ctx->slot_bank.slot ) {
+      //  exec_result = -1;
+      //}
 
       if( exec_result != FD_EXECUTOR_INSTR_SUCCESS ) {
   #ifdef VLOG

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -1115,6 +1115,10 @@ fd_execute_txn( fd_exec_txn_ctx_t * txn_ctx ) {
       }
 
       int exec_result = fd_execute_instr( txn_ctx, &instrs[i] );
+      if ( 254462504 == txn_ctx->slot_ctx->slot_bank.slot ) {
+        exec_result = -1;
+      }
+
       if( exec_result != FD_EXECUTOR_INSTR_SUCCESS ) {
   #ifdef VLOG
         if ( 257037453 == txn_ctx->slot_ctx->slot_bank.slot ) {

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -2201,7 +2201,7 @@ void
 fd_runtime_checkpt( fd_capture_ctx_t * capture_ctx,
                     fd_exec_slot_ctx_t * slot_ctx,
                     ulong slot ) {
-  if( capture_ctx->checkpt_slot != slot && slot % capture_ctx->checkpt_freq != 0 ) {
+  if( slot % capture_ctx->checkpt_freq != 0 ) {
     return;
   }
   FD_LOG_NOTICE(("checkpointing at slot=%lu", slot));

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -2206,19 +2206,21 @@ fd_runtime_checkpt( fd_capture_ctx_t * capture_ctx,
   if( !is_checkpt_freq && !is_abort_slot ) {
     return;
   }
-  FD_LOG_NOTICE(("checkpointing at slot=%lu", slot));
 
-  if( is_checkpt_freq ) {
+  if( !is_abort_slot ) {
+    FD_LOG_NOTICE(( "checkpointing at slot=%lu", slot ));
     fd_funk_end_write( slot_ctx->acc_mgr->funk );
+  } else {
+    FD_LOG_NOTICE(( "checkpointing after mismatch" ));
   }
 
   unlink( capture_ctx->checkpt_path );
   int err = fd_wksp_checkpt( fd_funk_wksp( slot_ctx->acc_mgr->funk ), capture_ctx->checkpt_path, 0666, 0, NULL );
   if ( err ) {
-    FD_LOG_ERR(("backup failed: error %d", err));
+    FD_LOG_ERR(( "backup failed: error %d", err ));
   }
 
-  if( is_checkpt_freq ) {
+  if( !is_abort_slot ) {
     fd_funk_start_write( slot_ctx->acc_mgr->funk );
   }
 }

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -344,6 +344,11 @@ fd_runtime_read_genesis( fd_exec_slot_ctx_t * slot_ctx,
                          char const * genesis_filepath,
                          uchar is_snapshot );
 
+void
+fd_runtime_checkpt( fd_capture_ctx_t * capture_ctx,
+                    fd_exec_slot_ctx_t * slot_ctx,
+                    ulong slot );
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_flamenco_runtime_fd_runtime_h */

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -112,7 +112,6 @@ struct fd_runtime_args {
   ulong        tcnt;
   ulong        txn_max;
   ushort       rpc_port;
-  ulong        checkpt_slot;
   ulong        checkpt_freq;
   char const * checkpt_path;
   fd_funk_t *  pruned_funk;

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -114,6 +114,7 @@ struct fd_runtime_args {
   ushort       rpc_port;
   ulong        checkpt_freq;
   char const * checkpt_path;
+  int          checkpt_mismatch;
   fd_funk_t *  pruned_funk;
   int          dump_insn_to_pb;
   char const * dump_insn_sig_filter;


### PR DESCRIPTION
1. deprecating checkpt_slot in favor of checkpt_freq
2. adding option to checkpoint at last rooted slot when a mismatch occurs