### PR TITLE
flamenco: checkpoint on mismatch

### DIFF
--- a/src/disco/tvu/fd_tvu.c
+++ b/src/disco/tvu/fd_tvu.c
@@ -773,8 +773,7 @@ void capture_ctx_setup( fd_runtime_ctx_t * runtime_ctx, fd_runtime_args_t * args
   runtime_ctx->capture_file = NULL;
 
   int has_solcap           = args->capture_fpath && args->capture_fpath[0] != '\0';
-  int has_checkpt_dump     = args->checkpt_path && args->checkpt_path[0] != '\0' &&
-                             ( args->checkpt_slot != 0 || args->checkpt_freq != 0 );
+  int has_checkpt_dump     = args->checkpt_path && args->checkpt_path[0] != '\0';
   int has_prune            = args->pruned_funk != NULL;
   int has_dump_to_protobuf = args->dump_insn_to_pb;
 
@@ -787,7 +786,6 @@ void capture_ctx_setup( fd_runtime_ctx_t * runtime_ctx, fd_runtime_args_t * args
   fd_memset( capture_ctx_mem, 0, sizeof( fd_capture_ctx_t ) );
   runtime_ctx->capture_ctx = fd_capture_ctx_new( capture_ctx_mem );
 
-  runtime_ctx->capture_ctx->checkpt_slot = ULONG_MAX;
   runtime_ctx->capture_ctx->checkpt_freq = ULONG_MAX;
 
   if( has_solcap ) {
@@ -802,7 +800,6 @@ void capture_ctx_setup( fd_runtime_ctx_t * runtime_ctx, fd_runtime_args_t * args
   }
 
   if( has_checkpt_dump ) {
-    runtime_ctx->capture_ctx->checkpt_slot = args->checkpt_slot;
     runtime_ctx->capture_ctx->checkpt_path = args->checkpt_path;
     runtime_ctx->capture_ctx->checkpt_freq = args->checkpt_freq;
   }
@@ -1495,9 +1492,9 @@ fd_tvu_parse_args( fd_runtime_args_t * args, int argc, char ** argv ) {
   args->retrace       = fd_env_strip_cmdline_int( &argc, &argv, "--retrace", NULL, 0 );
   args->abort_on_mismatch =
       (uchar)fd_env_strip_cmdline_int( &argc, &argv, "--abort-on-mismatch", NULL, 0 );
-  args->checkpt_slot = fd_env_strip_cmdline_ulong( &argc, &argv, "--checkpt-slot", NULL, 0 );
-  args->checkpt_freq = fd_env_strip_cmdline_ulong( &argc, &argv, "--checkpt-freq", NULL, ULONG_MAX );
-  args->checkpt_path = fd_env_strip_cmdline_cstr( &argc, &argv, "--checkpt-path", NULL, NULL );
+  args->checkpt_freq     = fd_env_strip_cmdline_ulong( &argc, &argv, "--checkpt-freq", NULL, ULONG_MAX );
+  args->checkpt_path     = fd_env_strip_cmdline_cstr( &argc, &argv, "--checkpt-path", NULL, NULL );
+  args->checkpt_mismatch = fd_env_strip_cmdline_int ( &argc, &argv, "--checkpt-mismatch", NULL, 0 );
   args->dump_insn_to_pb = fd_env_strip_cmdline_int( &argc, &argv, "--dump-insn-to-pb", NULL, 0 );
   args->dump_insn_sig_filter = fd_env_strip_cmdline_cstr( &argc, &argv, "--dump-insn-sig-filter", NULL, NULL );
   args->dump_insn_output_dir = fd_env_strip_cmdline_cstr( &argc, &argv, "--dump-insn-output-dir", NULL, "protobuf_tests_from_executed_instr" );

--- a/src/flamenco/runtime/context/fd_capture_ctx.h
+++ b/src/flamenco/runtime/context/fd_capture_ctx.h
@@ -16,8 +16,7 @@ struct __attribute__((aligned(FD_CAPTURE_CTX_ALIGN))) fd_capture_ctx {
   int                      capture_txns; /* Capturing txns can add significant time */
 
   /* Checkpointing */
-  ulong                    checkpt_slot; /* Must be a rooted slot */
-  ulong                    checkpt_freq;
+  ulong                    checkpt_freq; /* Must be a rooted slot */
   char const *             checkpt_path;
 
   /* Prune */

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -2201,20 +2201,28 @@ void
 fd_runtime_checkpt( fd_capture_ctx_t * capture_ctx,
                     fd_exec_slot_ctx_t * slot_ctx,
                     ulong slot ) {
-  if( capture_ctx->checkpt_slot != slot && slot % capture_ctx->checkpt_freq != 0 ) {
+  int is_checkpt_freq = capture_ctx != NULL && slot % capture_ctx->checkpt_freq == 0;
+  int is_abort_slot   = slot == ULONG_MAX; 
+  if( !is_checkpt_freq && !is_abort_slot ) {
     return;
   }
-  FD_LOG_NOTICE(("checkpointing at slot=%lu", slot));
 
-  fd_funk_end_write( slot_ctx->acc_mgr->funk );
+  if( !is_abort_slot ) {
+    FD_LOG_NOTICE(( "checkpointing at slot=%lu to file=%s", slot, capture_ctx->checkpt_path ));
+    fd_funk_end_write( slot_ctx->acc_mgr->funk );
+  } else {
+    FD_LOG_NOTICE(( "checkpointing after mismatch to file=%s", capture_ctx->checkpt_path ));
+  }
 
   unlink( capture_ctx->checkpt_path );
   int err = fd_wksp_checkpt( fd_funk_wksp( slot_ctx->acc_mgr->funk ), capture_ctx->checkpt_path, 0666, 0, NULL );
   if ( err ) {
-    FD_LOG_ERR(("backup failed: error %d", err));
+    FD_LOG_ERR(( "backup failed: error %d", err ));
   }
 
-  fd_funk_start_write( slot_ctx->acc_mgr->funk );
+  if( !is_abort_slot ) {
+    fd_funk_start_write( slot_ctx->acc_mgr->funk );
+  }
 }
 
 int

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -112,9 +112,9 @@ struct fd_runtime_args {
   ulong        tcnt;
   ulong        txn_max;
   ushort       rpc_port;
-  ulong        checkpt_slot;
   ulong        checkpt_freq;
   char const * checkpt_path;
+  int          checkpt_mismatch;
   fd_funk_t *  pruned_funk;
   int          dump_insn_to_pb;
   char const * dump_insn_sig_filter;
@@ -344,6 +344,11 @@ void
 fd_runtime_read_genesis( fd_exec_slot_ctx_t * slot_ctx,
                          char const * genesis_filepath,
                          uchar is_snapshot );
+
+void
+fd_runtime_checkpt( fd_capture_ctx_t * capture_ctx,
+                    fd_exec_slot_ctx_t * slot_ctx,
+                    ulong slot );
 
 FD_PROTOTYPES_END
 


### PR DESCRIPTION
1. deprecating checkpt_slot option
2. adding cli option for checkpointing at last rooted slot upon mismatch