### PR TITLE
flamenco: Update ic in CALL_IMM instruction

### DIFF
--- a/src/flamenco/vm/fd_vm_interp_dispatch_tab.c
+++ b/src/flamenco/vm/fd_vm_interp_dispatch_tab.c
@@ -342,7 +342,8 @@ BRANCH_PRE_CODE
 
   /* tally the current basic block */
 
-  due_insn_cnt  += (ulong)insns - skipped_insns;
+  due_insn_cnt   += (ulong)insns - skipped_insns;
+  ic             += (ulong)insns - skipped_insns;
   insns          = 0UL;
   skipped_insns  = 0UL;
   start_pc       = pc;


### PR DESCRIPTION
Because we flush the intermediate CU accounting state in CALL_IMM, we need to also update the ic. Before this change, ic was getting reset to 0 in every CALL_IMM.