### PR TITLE
flamenco: add uwide support for lamport calculation

### DIFF
--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -704,8 +704,15 @@ fd_execute_instr( fd_exec_txn_ctx_t * txn_ctx,
     }
     txn_ctx->num_instructions++;
     fd_pubkey_t const * txn_accs = txn_ctx->accounts;
-    ulong starting_lamports = fd_instr_info_sum_account_lamports( instr );
-    instr->starting_lamports = starting_lamports;
+
+    ulong starting_lamports_h = 0;
+    ulong starting_lamports_l = 0;
+    int err = fd_instr_info_sum_account_lamports( instr, &starting_lamports_h, &starting_lamports_l );
+    if( err ) {
+      return err;
+    }
+    instr->starting_lamports_h = starting_lamports_h;
+    instr->starting_lamports_l = starting_lamports_l;
 
     fd_exec_instr_ctx_t * parent = NULL;
     if( txn_ctx->instr_stack_sz )
@@ -754,11 +761,14 @@ fd_execute_instr( fd_exec_txn_ctx_t * txn_ctx,
     // FD_LOG_NOTICE(("COMPUTE METER END %lu %lu %lu %64J", before_instr_cus - txn_ctx->compute_meter, txn_ctx->compute_meter, txn_ctx->compute_unit_limit, sig ));
 
     if( exec_result == FD_EXECUTOR_INSTR_SUCCESS ) {
-      ulong ending_lamports = fd_instr_info_sum_account_lamports( instr );
-      // FD_LOG_WARNING(("check lamports %lu %lu %lu", starting_lamports, instr->starting_lamports, ending_lamports ));
+      ulong ending_lamports_h = 0UL;
+      ulong ending_lamports_l = 0UL;
+      err = fd_instr_info_sum_account_lamports( instr, &ending_lamports_h, &ending_lamports_l );
+      if( err ) {
+        return err;
+      }
 
-      if( starting_lamports != ending_lamports ) {
-        FD_LOG_WARNING(("starting lamports mismatched %lu %lu %lu", starting_lamports, instr->starting_lamports, ending_lamports ));
+      if( ending_lamports_l != starting_lamports_l || ending_lamports_h != starting_lamports_h ) {
         exec_result = FD_EXECUTOR_INSTR_ERR_UNBALANCED_INSTR;
       }
 

--- a/src/flamenco/runtime/info/fd_instr_info.c
+++ b/src/flamenco/runtime/info/fd_instr_info.c
@@ -1,6 +1,7 @@
 #include "fd_instr_info.h"
 
 #include "../fd_account.h"
+#include "../../../util/bits/fd_uwide.h"
 
 /* demote_program_id() in https://github.com/solana-labs/solana/blob/061bed0a8ca80afb97f4438155e8a6b47bbf7f6d/sdk/program/src/message/versions/v0/loaded.rs#L150 */
 int
@@ -35,12 +36,15 @@ fd_convert_txn_instr_to_instr( fd_exec_txn_ctx_t *     txn_ctx,
   fd_rawtxn_b_t const * txn_raw = txn_ctx->_txn_raw;
   const fd_pubkey_t *   accounts = txn_ctx->accounts;
 
-  ulong starting_lamports = 0;
-  instr->program_id = txn_instr->program_id;
+  /* TODO: Lamport check may be redundant */
+  ulong starting_lamports_h = 0;
+  ulong starting_lamports_l = 0;
+
+  instr->program_id        = txn_instr->program_id;
   instr->program_id_pubkey = accounts[txn_instr->program_id];
-  instr->acct_cnt = txn_instr->acct_cnt;
-  instr->data_sz = txn_instr->data_sz;
-  instr->data =  (uchar *)txn_raw->raw + txn_instr->data_off;
+  instr->acct_cnt          = txn_instr->acct_cnt;
+  instr->data_sz           = txn_instr->data_sz;
+  instr->data              = (uchar *)txn_raw->raw + txn_instr->data_off;
 
   uchar acc_idx_seen[256];
   memset(acc_idx_seen, 0, 256);
@@ -57,10 +61,12 @@ fd_convert_txn_instr_to_instr( fd_exec_txn_ctx_t *     txn_ctx,
     instr->is_duplicate[i] = acc_idx_seen[acc_idx];
     if( FD_LIKELY( !acc_idx_seen[acc_idx] ) ) {
       /* This is the first time seeing this account */
-      acc_idx_seen[acc_idx] = 1;
       if( instr->borrowed_accounts[i] != NULL && instr->borrowed_accounts[i]->const_meta != NULL ) {
-        starting_lamports += instr->borrowed_accounts[i]->const_meta->info.lamports;
+        fd_uwide_inc( &starting_lamports_h, &starting_lamports_l, 
+                      starting_lamports_h, starting_lamports_l,
+                      instr->borrowed_accounts[i]->const_meta->info.lamports );
       }
+      acc_idx_seen[acc_idx] = 1;
     }
 
     instr->acct_txn_idxs[i] = acc_idx;
@@ -76,10 +82,12 @@ fd_convert_txn_instr_to_instr( fd_exec_txn_ctx_t *     txn_ctx,
     }
   }
 
-  instr->starting_lamports = starting_lamports;
+  instr->starting_lamports_h = starting_lamports_h;
+  instr->starting_lamports_l = starting_lamports_l;
+
 }
 
-FD_FN_PURE int
+int
 fd_instr_any_signed( fd_instr_info_t const * info,
                      fd_pubkey_t const *     pubkey ) {
   int is_signer = 0;
@@ -90,20 +98,34 @@ fd_instr_any_signed( fd_instr_info_t const * info,
   return is_signer;
 }
 
-/*
-  TODO: We should modify this function to handle overflows / other issues similar to Agave.
-  https://github.com/anza-xyz/agave/blob/9706a6464665f7ebd6ead47f0d12f853ccacbab9/sdk/src/transaction_context.rs#L407
-*/
-ulong
-fd_instr_info_sum_account_lamports( fd_instr_info_t const * instr ) {
-  ulong total_lamports = 0;
-  for( ulong i = 0; i < instr->acct_cnt; i++ ) {
-    if( instr->borrowed_accounts[i] != NULL && !instr->is_duplicate[i] && instr->borrowed_accounts[i]->const_meta != NULL ) {
-      // FD_LOG_WARNING(("SUM INSTR INFO LAMPS: %32J %lu", instr->acct_pubkeys[i].key, instr->borrowed_accounts[i]->const_meta->info.lamports ));
-      total_lamports += instr->borrowed_accounts[i]->const_meta->info.lamports;
+/* https://github.com/anza-xyz/agave/blob/9706a6464665f7ebd6ead47f0d12f853ccacbab9/sdk/src/transaction_context.rs#L40 */
+int
+fd_instr_info_sum_account_lamports( fd_instr_info_t const * instr, 
+                                    ulong *                 total_lamports_h, 
+                                    ulong *                 total_lamports_l ) {
+  *total_lamports_h = 0UL;
+  *total_lamports_l = 0UL;
+  for( ulong i=0UL; i<instr->acct_cnt; ++i ) {
+    if( instr->borrowed_accounts[i] == NULL || 
+        instr->is_duplicate[i]              || 
+        instr->borrowed_accounts[i]->const_meta == NULL ) {
+      continue;
     }
-  }
-  // FD_LOG_WARNING(("SUM: %lu", total_lamports));
 
-  return total_lamports;
+    /* Perform a checked add on a fd_uwide */
+    ulong tmp_total_lamports_h = 0UL;
+    ulong tmp_total_lamports_l = 0UL;
+
+    fd_uwide_inc( &tmp_total_lamports_h, &tmp_total_lamports_l, *total_lamports_h, *total_lamports_l,
+                  instr->borrowed_accounts[i]->const_meta->info.lamports );
+    
+    if( tmp_total_lamports_h < *total_lamports_h ) {
+      return FD_EXECUTOR_INSTR_ERR_ARITHMETIC_OVERFLOW;
+    }
+
+    *total_lamports_h = tmp_total_lamports_h;
+    *total_lamports_l = tmp_total_lamports_l;
+  }
+
+  return FD_EXECUTOR_INSTR_SUCCESS;
 }

--- a/src/flamenco/runtime/info/fd_instr_info.h
+++ b/src/flamenco/runtime/info/fd_instr_info.h
@@ -12,21 +12,23 @@
 #define FD_INSTR_ACCT_MAX (256)
 
 struct fd_instr_info {
-  uchar                 program_id;
-  ushort                data_sz;
-  ushort                acct_cnt;
+  uchar                   program_id;
+  ushort                  data_sz;
+  ushort                  acct_cnt;
 
-  uchar *               data;
-  fd_pubkey_t           program_id_pubkey;
+  uchar *                 data;
+  fd_pubkey_t             program_id_pubkey;
 
-  uchar                 acct_txn_idxs[FD_INSTR_ACCT_MAX];
-  uchar                 acct_flags[FD_INSTR_ACCT_MAX];
-  fd_pubkey_t           acct_pubkeys[FD_INSTR_ACCT_MAX];
-  uchar                 is_duplicate[FD_INSTR_ACCT_MAX];
+  uchar                   acct_txn_idxs[FD_INSTR_ACCT_MAX];
+  uchar                   acct_flags[FD_INSTR_ACCT_MAX];
+  fd_pubkey_t             acct_pubkeys[FD_INSTR_ACCT_MAX];
+  uchar                   is_duplicate[FD_INSTR_ACCT_MAX];
 
   fd_borrowed_account_t * borrowed_accounts[FD_INSTR_ACCT_MAX];
 
-  ulong starting_lamports;
+  /* fd_uwide representation of uint_128 */
+  ulong                   starting_lamports_h;
+  ulong                   starting_lamports_l;
 };
 
 typedef struct fd_instr_info fd_instr_info_t;
@@ -96,8 +98,10 @@ fd_instr_any_signed( fd_instr_info_t const * info,
 
    Aborts on integer overflow. */
 
-FD_FN_PURE ulong
-fd_instr_info_sum_account_lamports( fd_instr_info_t const * instr );
+int
+fd_instr_info_sum_account_lamports( fd_instr_info_t const * instr, 
+                                    ulong *                 total_lamports_h, 
+                                    ulong *                 total_lamports_l );
 
 static inline void
 fd_instr_get_signers( fd_instr_info_t const * self,

--- a/src/flamenco/runtime/program/fd_stake_program.c
+++ b/src/flamenco/runtime/program/fd_stake_program.c
@@ -905,15 +905,14 @@ stake_weighted_credits_observed( fd_stake_t const * stake,
                                  ulong              absorbed_lamports,
                                  ulong              absorbed_credits_observed,
                                  ulong *            out ) {
-  // FIXME: FD_LIKELY
-  if( stake->credits_observed == absorbed_credits_observed ) {
+  if( FD_LIKELY( stake->credits_observed == absorbed_credits_observed ) ) {
     *out = stake->credits_observed;
     return 1;
   } else {
     /* total_stake = stake->delegation.stake + absorbed_lamports */
-    ulong total_stake_h = 0;
-    ulong total_stake_l = 0;
-    fd_uwide_inc( &total_stake_h, &total_stake_l, 0, stake->delegation.stake,
+    ulong total_stake_h = 0UL;
+    ulong total_stake_l = 0UL;
+    fd_uwide_inc( &total_stake_h, &total_stake_l, 0UL, stake->delegation.stake,
                   absorbed_lamports );
 
     /* stake_weighted_credits = stake->credits_observed + stake->delegation.stake */
@@ -933,26 +932,26 @@ stake_weighted_credits_observed( fd_stake_t const * stake,
     ulong total_weighted_credits_partial_one_l;
     fd_uwide_add( &total_weighted_credits_partial_one_h, &total_weighted_credits_partial_one_l,
                   stake_weighted_credits_h, stake_weighted_credits_l,
-                  absorbed_weighted_credits_h, absorbed_weighted_credits_l, 0 );
+                  absorbed_weighted_credits_h, absorbed_weighted_credits_l, 0UL );
 
     ulong total_weighted_credits_partial_two_h;
     ulong total_weighted_credits_partial_two_l;
     fd_uwide_add( &total_weighted_credits_partial_two_h, &total_weighted_credits_partial_two_l,
                   total_weighted_credits_partial_one_h, total_weighted_credits_partial_one_l,
-                  total_stake_h, total_stake_l, 0 );
+                  total_stake_h, total_stake_l, 0UL );
 
     ulong total_weighted_credits_h;
     ulong total_weighted_credits_l;
     fd_uwide_dec( &total_weighted_credits_h, &total_weighted_credits_l,
-                  total_weighted_credits_partial_two_h, total_weighted_credits_partial_two_l, 1 );
+                  total_weighted_credits_partial_two_h, total_weighted_credits_partial_two_l, 1UL );
 
     /* FIXME: fd_uwide_div doesn't support denominator that is an fd_uwide */
     /* res = totalWeighted_credits / total_stake */
     ulong res_h;
     ulong res_l;
-    FD_TEST(( total_stake_h == 0 ));
+    FD_TEST( total_stake_h == 0UL );
     fd_uwide_div( &res_h, &res_l, total_weighted_credits_h, total_weighted_credits_l, total_stake_l );
-    FD_TEST(( res_h == 0 ));
+    FD_TEST( res_h == 0UL );
     //*out = total_weighted_credits / total_stake;
     *out = res_l;
     return 1;

--- a/src/flamenco/runtime/tests/run_ledger_tests.sh
+++ b/src/flamenco/runtime/tests/run_ledger_tests.sh
@@ -276,9 +276,6 @@ if [[ $ON_DEMAND = 1 ]]; then
     $TILE_CPUS >& $LOG
 
   status=$?
-  if [ $status -ne 0 ]; then
-    echo_error "on demand 1 $LOG"
-  fi
   { set +x; } &> /dev/null
   echo_notice "Finished on-demand ingest and replay\n"
 fi

--- a/src/flamenco/runtime/tests/run_ledger_tests_all.txt
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.txt
@@ -22,3 +22,4 @@ src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-257059815 -s snapshot-
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-257061172 -s snapshot-257061172-8e6cUSMUx2VZZBDzwXjEY6bGkzPgnUmqrDyr4uErG8BF.tar.zst -p 16 -y 16 -m 5000000 -e 257061175 --zst
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-257222682 -s snapshot-257222682-Dudsosehu5xdHbqzG5sy72qEu6KyS9FmHnW7oV8pRoNn.tar.zst -p 16 -y 16 -m 5000000 -e 257222688 --zst
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-264890264 -s snapshot-264890263-G9sNBh5CPSU9A1nXtC6QE87o1NPkwyMPh7XVKG5mw1Ka.tar.zst -p 32 -y 16 -m 5000000 -e 264890265 --zst
+src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-257229353 -s snapshot-257229353-9wETKbJxKf7ceWxtLFJN8VffLQJ2xQVXLUgrXtp6UMx.tar.zst  -p 16 -y 16 -m 5000000 -e 257229353 --zst                              


### PR DESCRIPTION
Solana represents total lamports as a u128 but we did as a ulong and it resulted in overflow. This replaces the lamport summation with a fd_uwide which represents a u128 as two ulongs