### PR TITLE
quic: internal polishing

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -5,6 +5,10 @@
 #include "fd_quic_conn_map.h"
 #include "fd_quic_proto.h"
 
+#include "templ/fd_quic_frame_handler_decl.h"
+#include "templ/fd_quic_frames_templ.h"
+#include "templ/fd_quic_undefs.h"
+
 #include "crypto/fd_quic_crypto_suites.h"
 #include "templ/fd_quic_transport_params.h"
 #include "templ/fd_quic_parse_util.h"
@@ -5264,7 +5268,6 @@ fd_quic_conn_create( fd_quic_t *               quic,
   conn->flags                = 0;
   conn->spin_bit             = 0;
   conn->upd_pkt_number       = 0;
-  conn->base_timeout         = 0;
 
   /* initialize connection members */
   ulong our_conn_id_idx = 0;

--- a/src/waltz/quic/fd_quic_common.h
+++ b/src/waltz/quic/fd_quic_common.h
@@ -19,6 +19,7 @@ typedef struct fd_quic_tls         fd_quic_tls_t;
 typedef struct fd_quic_tls_hs      fd_quic_tls_hs_t;
 typedef struct fd_quic_tls_secret  fd_quic_tls_secret_t;
 typedef struct fd_quic_tls_hs_data fd_quic_tls_hs_data_t;
+typedef struct fd_quic_pkt         fd_quic_pkt_t;
 
 #endif /* HEADER_fd_src_waltz_quic_fd_quic_common_h */
 

--- a/src/waltz/quic/fd_quic_conn.c
+++ b/src/waltz/quic/fd_quic_conn.c
@@ -145,9 +145,8 @@ fd_quic_conn_new( void *                   mem,
   fd_quic_conn_t * conn = (fd_quic_conn_t *)mem;
   fd_memset( conn, 0, sizeof(fd_quic_conn_t) );
 
-  conn->quic             = quic;
-  conn->stream_tx_buf_sz = limits->tx_buf_sz;
-  conn->state            = FD_QUIC_CONN_STATE_INVALID;
+  conn->quic  = quic;
+  conn->state = FD_QUIC_CONN_STATE_INVALID;
 
   /* Initialize streams */
 

--- a/src/waltz/quic/fd_quic_conn.h
+++ b/src/waltz/quic/fd_quic_conn.h
@@ -260,8 +260,6 @@ struct fd_quic_conn {
   uchar * tx_ptr; /* ptr to free space in tx_scratch */
   ulong   tx_sz;  /* sz remaining at ptr */
 
-  ulong   stream_tx_buf_sz; /* size of per-stream tx buffer */
-
   uint state;
   uint reason;     /* quic reason for closing. see FD_QUIC_CONN_REASON_* */
   uint app_reason; /* application reason for closing */
@@ -320,10 +318,6 @@ struct fd_quic_conn {
      if we time out this packet (or possibly a later packet) we resend the frame
        and update this value */
   ulong                upd_pkt_number;
-
-  /* for timing out data and resending
-     should be at least the smoothed round-trip-time */
-  ulong                base_timeout;
 
   /* current round-trip-time */
   ulong                rtt;

--- a/src/waltz/quic/fd_quic_proto.h
+++ b/src/waltz/quic/fd_quic_proto.h
@@ -26,10 +26,6 @@
 #include "templ/fd_quic_frames_templ.h"
 #include "templ/fd_quic_undefs.h"
 
-#include "templ/fd_quic_frame_handler_decl.h"
-#include "templ/fd_quic_frames_templ.h"
-#include "templ/fd_quic_undefs.h"
-
 #include "../../util/net/fd_eth.h"
 #include "../../util/net/fd_ip4.h"
 #include "../../util/net/fd_udp.h"

--- a/src/waltz/quic/templ/fd_quic_encoders_decl.h
+++ b/src/waltz/quic/templ/fd_quic_encoders_decl.h
@@ -1,9 +1,9 @@
 /* QUIC encoders + footprints */
 
-#define FD_TEMPL_DEF_STRUCT_BEGIN(NAME)                                    \
-  ulong fd_quic_encode_##NAME( uchar *                          buf,      \
-                                ulong                           sz ,      \
-                                fd_quic_##NAME##_t *             frame );  \
+#define FD_TEMPL_DEF_STRUCT_BEGIN(NAME)                       \
+  ulong fd_quic_encode_##NAME( uchar *              buf,      \
+                               ulong                sz ,      \
+                               fd_quic_##NAME##_t * frame );  \
   ulong fd_quic_encode_footprint_##NAME( fd_quic_##NAME##_t * frame );
 
 #include "fd_quic_dft.h"

--- a/src/waltz/quic/templ/fd_quic_frame_handler_decl.h
+++ b/src/waltz/quic/templ/fd_quic_frame_handler_decl.h
@@ -5,8 +5,7 @@
                     void *                    context,     \
                     fd_quic_##NAME##_t *      data,        \
                     uchar const *             p,           \
-                    ulong                     p_sz )       \
-          __attribute__(( used ));
+                    ulong                     p_sz );
 
 #include "fd_quic_dft.h"
 

--- a/src/waltz/quic/templ/fd_quic_parse_frame.h
+++ b/src/waltz/quic/templ/fd_quic_parse_frame.h
@@ -1,4 +1,6 @@
-/* QUIC frame parser */
+/* fd_quic_parse_frame.h generates a switch table that parses and then
+   immediately handles an incoming encoded frame.  This code is used as
+   part of fd_quic_handle_v1_frame. */
 
 /* this is defines the body of the frame parsing logic
    there should be a set up prior to including this, and a tear down after

--- a/src/waltz/quic/tests/test_frames.c
+++ b/src/waltz/quic/tests/test_frames.c
@@ -5,21 +5,6 @@
 #include "../fd_quic_types.h"
 #include "../fd_quic_proto.h"
 
-/* define empty functions for handlers */
-#define FD_TEMPL_DEF_STRUCT_BEGIN(NAME)                     \
-          static ulong                                      \
-          fd_quic_frame_handle_##NAME(                      \
-                    void *                    context,      \
-                    fd_quic_##NAME##_t *      data,         \
-                    uchar const *             p,            \
-                    ulong                     p_sz ) {      \
-            (void)context; (void)data; (void)p; (void)p_sz; \
-            return 0u;                                      \
-          }
-#include "../templ/fd_quic_dft.h"
-#include "../templ/fd_quic_frames_templ.h"
-#include "../templ/fd_quic_undefs.h"
-
 uchar raw_crypto_frame[] =
 "\x06\x00\x41\x79\x01\x00\x01\x75\x03\x03\x6f\x2d\xa1\x28\xdd\x7e"
 "\xff\xa9\x8c\x1c\xe4\x84\x55\x04\xa2\xcc\xc6\x35\x46\xfa\xfa\xfa"

--- a/src/waltz/quic/tests/test_quic_layout.c
+++ b/src/waltz/quic/tests/test_quic_layout.c
@@ -3,21 +3,6 @@
 #include "../templ/fd_quic_union.h"
 #include "../templ/fd_quic_parse_util.h"
 
-/* define empty functions for handlers */
-#define FD_TEMPL_DEF_STRUCT_BEGIN(NAME)                     \
-          static ulong                                      \
-          fd_quic_frame_handle_##NAME(                      \
-                    void *                    context,      \
-                    fd_quic_##NAME##_t *      data,         \
-                    uchar const *             p,            \
-                    ulong                     p_sz ) {      \
-            (void)context; (void)data; (void)p; (void)p_sz; \
-            return 0u;                                      \
-          }
-#include "../templ/fd_quic_dft.h"
-#include "../templ/fd_quic_frames_templ.h"
-#include "../templ/fd_quic_undefs.h"
-
 int
 main( int argc, char ** argv ) {
   (void)argc;

--- a/src/waltz/quic/tests/test_quic_server.c
+++ b/src/waltz/quic/tests/test_quic_server.c
@@ -75,18 +75,6 @@ main( int argc, char ** argv ) {
   quic_config->net.ip_addr         = udpsock->listen_ip;
   quic_config->net.listen_udp_port = udpsock->listen_port;
   fd_quic_set_aio_net_tx( quic, udpsock->aio );
-  uchar pkey[32]        = {
-      137, 115, 254, 55, 116, 55, 118, 19,  151, 66,  229, 24, 188, 62,  99,  209,
-      162, 16,  6,   7,  24,  81, 152, 128, 139, 234, 170, 93, 88,  204, 245, 205,
-  };
-  uchar pubkey[32]      = { 44, 174, 25,  39, 43, 255, 200, 81, 55, 73, 10,  113, 174, 91, 223, 80,
-                            50, 51,  102, 25, 63, 110, 36,  28, 51, 11, 174, 179, 110, 8,  25,  152 };
-  FD_LOG_HEXDUMP_NOTICE(( "Solana private key", pkey, 32 ));  /* TODO use base-58 format specifier */
-  FD_LOG_HEXDUMP_NOTICE(( "Solana public key", pubkey, 32 ));  /* TODO use base-58 format specifier */
-
-  fd_tls_test_sign_ctx_t * ctx = quic_config->sign_ctx;
-  fd_memcpy( ctx->private_key, pkey, 32UL );
-  fd_memcpy( ctx->public_key, pubkey, 32UL );
 
   FD_LOG_NOTICE(( "Initializing QUIC" ));
   FD_TEST( fd_quic_init( quic ) );

--- a/src/waltz/quic/tls/fd_quic_tls.c
+++ b/src/waltz/quic/tls/fd_quic_tls.c
@@ -344,7 +344,6 @@ fd_quic_tls_provide_data( fd_quic_tls_hs_t * self,
     if( FD_UNLIKELY( res<0L ) ) {
       int alert = (int)-res;
       self->alert = (uint)alert;
-      FD_LOG_NOTICE(( "state %u reason %s", self->hs.base.state, fd_tls_reason_cstr( self->hs.base.reason ) ));
       self->quic_tls->alert_cb( self, self->context, alert );
       return FD_QUIC_TLS_FAILED;
     }


### PR DESCRIPTION
Some code cleanup and internal API restructuring in preparation for the
QUIC conformance testing suite.

- Remove unused stream_tx_buf_sz and base_timeout vars from fd_quic_conn_t.
- Forward declare fd_quic_pkt_t type
- Remove static function declarations (fd_quic_frame_handler_decl.h)
  from fd_quic_proto.h, which keep causing annoying "static function
  declared but not defined/used" issues.
- Remove now useless template includes from unit tests
- Remove redundant identity config in test_quic_server (already done
  by fd_quic_new_anonymous)
- Remove FD_LOG_NOTICE function call from remotely reachable code path
  (security issue)
