### PR TITLE
Stop relying on snapshot file name for slot number

### DIFF
--- a/src/app/fdctl/run/tiles/fd_replay.c
+++ b/src/app/fdctl/run/tiles/fd_replay.c
@@ -369,6 +369,7 @@ init_after_snapshot( fd_replay_tile_ctx_t * ctx ) {
   ulong snapshot_slot = ctx->slot_ctx->slot_bank.slot;
   if( snapshot_slot != ctx->curr_slot ) {
     /* The initial snapshot_slot was wrong or unspecified. Fix everything. */
+    FD_LOG_NOTICE(( "detected snapshot slot %lu, prev_slot %lu", snapshot_slot, ctx->slot_ctx->slot_bank.prev_slot ));
     fd_fork_t * ele = fd_fork_frontier_ele_remove( ctx->replay->forks->frontier, &ctx->curr_slot, NULL, ctx->replay->forks->pool );
     ele->slot                = snapshot_slot;
     fd_fork_frontier_ele_insert( ctx->replay->forks->frontier, ele, ctx->replay->forks->pool );

--- a/src/app/fdctl/run/tiles/fd_store_int.c
+++ b/src/app/fdctl/run/tiles/fd_store_int.c
@@ -263,8 +263,8 @@ fd_store_tile_slot_prepare( fd_store_tile_ctx_t * ctx,
   switch( store_slot_prepare_mode ) {
     case FD_STORE_SLOT_PREPARE_CONTINUE: {
       if( slot > 64UL ) {
-        ctx->store->smr = fd_ulong_max( ctx->store->smr, slot - 64UL );
-        fd_pending_slots_set_lo_wmark( ctx->store->pending_slots, ctx->store->smr );
+        ctx->blockstore->smr = fd_ulong_max( ctx->blockstore->smr, slot - 64UL );
+        fd_pending_slots_set_lo_wmark( ctx->store->pending_slots, ctx->blockstore->smr );
       }
       ctx->store->now = fd_log_wallclock();
       break;

--- a/src/app/fdctl/run/topos/fd_firedancer.c
+++ b/src/app/fdctl/run/topos/fd_firedancer.c
@@ -1,4 +1,4 @@
-/* Firedancer topology used for testing the full validator. 
+/* Firedancer topology used for testing the full validator.
    Associated test script: test-firedancer.sh */
 #include "topos.h"
 #include "../tiles/tiles.h"
@@ -11,26 +11,8 @@
 #include "../../../../util/tile/fd_tile_private.h"
 #include <sys/sysinfo.h>
 
-static ulong
-parse_snapshot_slot( char const * snapshot, char const * incremental ) {
-  char const * str = strlen( incremental ) > 0 ? incremental : snapshot;
-  ulong str_len = strlen( str );
-  char const * end_ptr = &str[str_len - 1];
-
-  while( end_ptr > str && *end_ptr != '-') end_ptr--;
-
-  if( end_ptr == str ) FD_LOG_ERR(("Could not parse snapshot slot out of snapshot file %s", str));
-
-  char const * start_ptr = (end_ptr - 1);
-  while( start_ptr > str && *start_ptr != '-') start_ptr--;
-
-  if( start_ptr++ == str ) FD_LOG_ERR(("Could not parse snapshot slot out of snapshot file %s", str));
-  char *eptr;
-  return strtoul(start_ptr, &eptr, 10);
-}
-
 void
-fd_topo_firedancer( config_t * _config ) { 
+fd_topo_firedancer( config_t * _config ) {
   config_t * config = (config_t *)_config;
   ulong net_tile_cnt    = config->layout.net_tile_count;
   ulong shred_tile_cnt  = config->layout.shred_tile_count;
@@ -52,7 +34,7 @@ fd_topo_firedancer( config_t * _config ) {
 
   fd_topob_wksp( topo, "shred_sign" );
   fd_topob_wksp( topo, "sign_shred" );
-  
+
   fd_topob_wksp( topo, "gossip_sign" );
   fd_topob_wksp( topo, "sign_gossip" );
 
@@ -185,11 +167,11 @@ fd_topo_firedancer( config_t * _config ) {
   FOR(shred_tile_cnt)  fd_topob_tile_in(  topo, "shred",  i,             "metric_in", "crds_shred",    0UL,          FD_TOPOB_RELIABLE,     FD_TOPOB_POLLED );
   FOR(shred_tile_cnt)  fd_topob_tile_out( topo, "shred",  i,                          "shred_net",     i                                                  );
   FOR(shred_tile_cnt)  fd_topob_tile_in(  topo, "storei",  0UL,          "metric_in", "shred_storei",  i,            FD_TOPOB_RELIABLE,     FD_TOPOB_POLLED );
-  
+
   /**/                 fd_topob_tile_in(  topo, "storei",  0UL,          "metric_in", "repair_store",  0UL,          FD_TOPOB_UNRELIABLE,   FD_TOPOB_POLLED );
-  /**/                 fd_topob_tile_out( topo, "repair",  0UL,                        "repair_net",   0UL                                                  );  
-  /**/                 fd_topob_tile_out( topo, "storei",  0UL,                       "store_repair",  0UL                                                  );  
-  /**/                 fd_topob_tile_out( topo, "storei",  0UL,                       "store_replay",  0UL                                                  );  
+  /**/                 fd_topob_tile_out( topo, "repair",  0UL,                        "repair_net",   0UL                                                  );
+  /**/                 fd_topob_tile_out( topo, "storei",  0UL,                       "store_repair",  0UL                                                  );
+  /**/                 fd_topob_tile_out( topo, "storei",  0UL,                       "store_replay",  0UL                                                  );
   /**/                 fd_topob_tile_in(  topo, "storei",  0UL,          "metric_in", "stake_out",     0UL,          FD_TOPOB_UNRELIABLE,   FD_TOPOB_POLLED );
 
 
@@ -205,7 +187,7 @@ fd_topo_firedancer( config_t * _config ) {
     /**/               fd_topob_tile_in(  topo, "shred",  i,             "metric_in", "sign_shred",    i,            FD_TOPOB_UNRELIABLE, FD_TOPOB_UNPOLLED );
     /**/               fd_topob_tile_out( topo, "sign",   0UL,                        "sign_shred",    i                                                    );
   }
-  
+
   FOR(net_tile_cnt)    fd_topob_tile_out( topo, "net",      i,                         "net_gossip",   i                                                    );
   FOR(net_tile_cnt)    fd_topob_tile_in(  topo, "gossip",   0UL,          "metric_in", "net_gossip",   i,            FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED   ); /* No reliable consumers of networking fragments, may be dropped or overrun */
   /**/                 fd_topob_tile_out( topo, "gossip",   0UL,                       "crds_shred",   0UL                                                  );
@@ -221,7 +203,7 @@ fd_topo_firedancer( config_t * _config ) {
   /**/                 fd_topob_tile_in(  topo, "repair",  0UL,          "metric_in", "gossip_repai",  0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED   );
   /**/                 fd_topob_tile_in(  topo, "repair",  0UL,          "metric_in", "stake_out",     0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED   );
   /**/                 fd_topob_tile_in(  topo, "repair",  0UL,          "metric_in", "store_repair",  0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED   );
-  
+
   /**/                 fd_topob_tile_in(  topo, "replay",  0UL,          "metric_in", "store_replay",  0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED   );
   /**/                 fd_topob_tile_out( topo, "replay",  0UL,                        "replay_poh",   0UL                                                  );
 
@@ -264,7 +246,7 @@ fd_topo_firedancer( config_t * _config ) {
 
     } else if( FD_UNLIKELY( !strcmp( tile->name, "storei" ) ) ) {
       strncpy( tile->store_int.identity_key_path, config->consensus.identity_path, sizeof(tile->store_int.identity_key_path) );
-      tile->store_int.snapshot_slot = parse_snapshot_slot( config->tiles.replay.snapshot, config->tiles.replay.incremental );
+      tile->store_int.snapshot_slot = ULONG_MAX; /* Determine when we load the snapshot */
     } else if( FD_UNLIKELY( !strcmp( tile->name, "gossip" ) ) ) {
       tile->gossip.ip_addr = config->tiles.net.ip_addr;
       memcpy( tile->gossip.src_mac_addr, config->tiles.net.mac_addr, 6UL );
@@ -273,7 +255,7 @@ fd_topo_firedancer( config_t * _config ) {
       tile->gossip.tvu_port = config->tiles.shred.shred_listen_port;
       tile->gossip.tvu_fwd_port = config->tiles.shred.shred_listen_port;
       tile->gossip.expected_shred_version = config->consensus.expected_shred_version;
-      
+
       FD_TEST( config->tiles.gossip.entrypoints_cnt == config->tiles.gossip.peer_ports_cnt );
       tile->gossip.entrypoints_cnt = config->tiles.gossip.entrypoints_cnt;
       for (ulong i=0UL; i<config->tiles.gossip.entrypoints_cnt; i++) {
@@ -294,13 +276,13 @@ fd_topo_firedancer( config_t * _config ) {
     } else if( FD_UNLIKELY( !strcmp( tile->name, "replay" ) )) {
       strncpy( tile->replay.snapshot, config->tiles.replay.snapshot, sizeof(tile->replay.snapshot) );
       strncpy( tile->replay.incremental, config->tiles.replay.incremental, sizeof(tile->replay.incremental) );
-      tile->replay.snapshot_slot = parse_snapshot_slot( config->tiles.replay.snapshot, config->tiles.replay.incremental );
+      tile->replay.snapshot_slot = ULONG_MAX; /* Determine when we load the snapshot */
       tile->replay.tpool_thread_count =  config->tiles.replay.tpool_thread_count;
 
       tile->replay.pages     = config->tiles.replay.funk_sz_gb;
       tile->replay.txn_max   = config->tiles.replay.funk_txn_max;
       tile->replay.index_max = config->tiles.replay.funk_rec_max;
-      
+
       if( FD_UNLIKELY( tile->replay.tpool_thread_count == 0 || tile->replay.tpool_thread_count>FD_TILE_MAX ) )
         FD_LOG_ERR(( "bad tpool_thread_count %lu", tile->replay.tpool_thread_count ));
     } else if( FD_UNLIKELY( !strcmp( tile->name, "bhole" ) ) ) {

--- a/src/app/fdctl/run/topos/fd_firedancer.c
+++ b/src/app/fdctl/run/topos/fd_firedancer.c
@@ -246,7 +246,6 @@ fd_topo_firedancer( config_t * _config ) {
 
     } else if( FD_UNLIKELY( !strcmp( tile->name, "storei" ) ) ) {
       strncpy( tile->store_int.identity_key_path, config->consensus.identity_path, sizeof(tile->store_int.identity_key_path) );
-      tile->store_int.snapshot_slot = ULONG_MAX; /* Determine when we load the snapshot */
     } else if( FD_UNLIKELY( !strcmp( tile->name, "gossip" ) ) ) {
       tile->gossip.ip_addr = config->tiles.net.ip_addr;
       memcpy( tile->gossip.src_mac_addr, config->tiles.net.mac_addr, 6UL );

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -124,7 +124,7 @@ typedef struct {
        may point to the link, if there are multiple consumers.  An fseq
        can be uniquely identified via (link_id, tile_id), or (link_kind,
        link_kind_id, tile_kind, tile_kind_id) */
-    ulong *    in_link_fseq[ FD_TOPO_MAX_TILE_IN_LINKS ]; 
+    ulong *    in_link_fseq[ FD_TOPO_MAX_TILE_IN_LINKS ];
   };
 
   /* Configuration fields.  These are required to be known by the topology so it can determine the
@@ -256,7 +256,6 @@ typedef struct {
     } gossip;
 
     struct {
-      ulong snapshot_slot;
       char  identity_key_path[ PATH_MAX ];
     } store_int;
   };
@@ -469,7 +468,7 @@ fd_topo_join_workspaces( fd_topo_t *  topo,
 
 /* Leave (unmap from the process) the shared memory needed for the
    given workspace in the topology, if it was previously mapped.
-   
+
    topo and wksp are assumed non-NULL.  It is OK if the workspace
    has not been previously joined, in which case this is a no-op. */
 
@@ -494,7 +493,7 @@ fd_topo_leave_workspaces( fd_topo_t * topo );
    Returns 0 on success and -1 on failure, with errno set to the error.
    The only reason for failure currently that will be returned is
    ENOMEM, as other unexpected errors will cause the program to exit.
-   
+
    If update_existing is 1, the workspace will not be created from
    scratch but it will be assumed that it already exists from a prior
    run and needs to be maybe resized and then have the header
@@ -537,12 +536,12 @@ fd_topo_fill( fd_topo_t * topo );
 /* fd_topo_tile_stack_new creates a new huge page optimized stack for
    provided tile.  The stack is placed in a workspace in the hugetlbfs
    mount.
-   
+
    If optimize is 1, fd_topo_tile_stack_new creates a new huge page
    optimized stack for the provided tile.  The stack will be placed
    in a workspace in the hugetlbfs, with a name determined by the
    provided app_name, tile_name, and tile_kind_id arguments.
-   
+
    If optimize is 0, fd_topo_tile_stack_new creates a new regular
    page backed stack, which is not placed in the hugetlbfs.  In
    this case cpu_idx and the other arguments are ignored. */
@@ -573,7 +572,7 @@ fd_topo_tile_stack_new( int          optimize,
    production Firedancer process runs.  For production, each tile is run
    in its own address space with a separate process and full security
    sandbox.
-   
+
    The solana_labs argument determines which tiles are started.  If the
    argument is 0 or 1, only non-labs (or only labs) tiles are started.
    If the argument is any other value, all tiles in the topology are
@@ -591,7 +590,7 @@ fd_topo_run_single_process( fd_topo_t * topo,
    process (and thread).  The function will never return, as tiles are
    expected to run forever.  An error is logged and the application will
    exit if the tile exits.
-   
+
    The sandbox argument determines if the current process will be
    sandboxed fully before starting the tile.  The thread will switch to
    the UID and GID provided before starting the tile, even if the thread
@@ -599,14 +598,14 @@ fd_topo_run_single_process( fd_topo_t * topo,
    a process must share a UID and GID, this is not the case on Linux.
    The thread will switch to the provided UID and GID without switching
    the other threads in the process.
-   
+
    The allow_fd argument is only used if sandbox is true, and is a file
    descriptor which will be allowed to exist in the process.  Normally
    the sandbox code rejects and aborts if there is an unexpected file
    descriptor present on boot.  This is helpful to allow a parent
    process to be notified on termination of the tile by waiting for a
    pipe file descriptor to get closed.
-   
+
    wait and debugger are both used in debugging.  If wait is non-NULL,
    the runner will wait until the value pointed to by wait is non-zero
    before launching the tile.  Likewise, if debugger is non-NULL, the

--- a/src/disco/tvu/fd_store.h
+++ b/src/disco/tvu/fd_store.h
@@ -20,7 +20,6 @@ struct __attribute__((aligned(128UL))) fd_store {
   long now;            /* Current time */
 
   /* metadata */
-  ulong smr;           /* super-majority root */
   ulong snapshot_slot; /* the snapshot slot */
   ulong first_turbine_slot;  /* the first turbine slot we received on startup */
   ulong curr_turbine_slot;
@@ -50,7 +49,7 @@ fd_store_footprint( void ) {
 void *
 fd_store_new( void * mem, ulong lo_wmark_slot );
 
-fd_store_t * 
+fd_store_t *
 fd_store_join( void * store );
 
 void *

--- a/src/disco/tvu/fd_tvu.c
+++ b/src/disco/tvu/fd_tvu.c
@@ -811,7 +811,7 @@ void capture_ctx_setup( fd_runtime_ctx_t * runtime_ctx, fd_runtime_args_t * args
     runtime_ctx->capture_ctx->dump_insn_sig_filter = args->dump_insn_sig_filter;
     runtime_ctx->capture_ctx->dump_insn_output_dir = args->dump_insn_output_dir;
   }
-                      
+
 }
 
 typedef struct {
@@ -1289,7 +1289,6 @@ fd_tvu_main_setup( fd_runtime_ctx_t *    runtime_ctx,
     void *        store_mem = fd_valloc_malloc( valloc, fd_store_align(), fd_store_footprint() );
     fd_store_t * store     = fd_store_join( fd_store_new( store_mem, snapshot_slot ) );
     store->blockstore = blockstore_setup_out.blockstore;
-    store->smr = snapshot_slot;
     store->snapshot_slot = snapshot_slot;
     store->valloc = valloc;
 

--- a/src/flamenco/gossip/fd_gossip.c
+++ b/src/flamenco/gossip/fd_gossip.c
@@ -1986,6 +1986,7 @@ fd_gossip_set_entrypoints( fd_gossip_t * gossip,
 
 uint
 fd_gossip_is_allowed_entrypoint( fd_gossip_t * gossip, fd_gossip_peer_addr_t * addr ) {
+  return 1;
   addr->port = fd_ushort_bswap( addr->port );
   for( ulong i = 0UL; i<gossip->entrypoints_cnt; i++) {
     if (fd_gossip_peer_addr_eq( addr, &gossip->entrypoints[i]) ) return 1;

--- a/src/flamenco/gossip/fd_gossip.c
+++ b/src/flamenco/gossip/fd_gossip.c
@@ -1986,7 +1986,6 @@ fd_gossip_set_entrypoints( fd_gossip_t * gossip,
 
 uint
 fd_gossip_is_allowed_entrypoint( fd_gossip_t * gossip, fd_gossip_peer_addr_t * addr ) {
-  return 1;
   addr->port = fd_ushort_bswap( addr->port );
   for( ulong i = 0UL; i<gossip->entrypoints_cnt; i++) {
     if (fd_gossip_peer_addr_eq( addr, &gossip->entrypoints[i]) ) return 1;


### PR DESCRIPTION
When we start using funk checkpoints or urls, the snapshot name will no longer have the number