### PR TITLE
flamenco: slot check against program deploy/upgrades

### DIFF
--- a/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
@@ -175,6 +175,42 @@ fd_bpf_loader_v3_user_execute( fd_exec_instr_ctx_t ctx ) {
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
   }
 
+  /* Lookup account and its programdata account, error out if program data slot
+    is same as the current slot */
+  FD_BORROWED_ACCOUNT_DECL( program_account );
+  const fd_pubkey_t * program_id_pubkey = &ctx.instr->program_id_pubkey;
+  int err = fd_acc_mgr_view( ctx.txn_ctx->acc_mgr, ctx.txn_ctx->funk_txn, program_id_pubkey, program_account );
+  if( err ) {
+    return FD_EXECUTOR_INSTR_ERR_GENERIC_ERR;
+  }
+  fd_bpf_upgradeable_loader_state_t program_account_state = {0};
+  fd_bincode_decode_ctx_t program_acc_ctx = {
+    .data    = program_account->const_data,
+    .dataend = program_account->const_data + program_account->const_meta->dlen,
+    .valloc  = ctx.valloc,
+  };
+  fd_bpf_upgradeable_loader_state_decode( &program_account_state, &program_acc_ctx );
+
+  /* lookup program_data_account */
+  FD_BORROWED_ACCOUNT_DECL( program_data_account );
+  fd_pubkey_t * programdata_pubkey = (fd_pubkey_t *)&program_account_state.inner.program.programdata_address;
+  err = fd_acc_mgr_view( ctx.txn_ctx->acc_mgr, ctx.txn_ctx->funk_txn, programdata_pubkey, program_data_account );
+  if( err ) {
+    return FD_EXECUTOR_INSTR_ERR_GENERIC_ERR;
+  }
+  fd_bpf_upgradeable_loader_state_t program_data_account_state = {0};
+  fd_bincode_decode_ctx_t program_data_account_ctx = {
+    .data    = program_data_account->const_data,
+    .dataend = program_data_account->const_data + program_data_account->const_meta->dlen,
+    .valloc  = ctx.valloc,
+  };
+  fd_bpf_upgradeable_loader_state_decode( &program_data_account_state, &program_data_account_ctx );
+
+  ulong program_data_slot = program_data_account_state.inner.program_data.slot;
+  if( program_data_slot >= ctx.slot_ctx->slot_bank.slot ) {
+    return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+  }
+
   // FD_LOG_DEBUG(("Starting CUs %lu", ctx.txn_ctx->compute_meter));
   fd_vm_exec_context_t vm_ctx = {
     .entrypoint          = (long)prog->entry_pc,

--- a/src/flamenco/runtime/tests/run_ledger_tests_all.txt
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.txt
@@ -22,4 +22,5 @@ src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-257059815 -s snapshot-
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-257061172 -s snapshot-257061172-8e6cUSMUx2VZZBDzwXjEY6bGkzPgnUmqrDyr4uErG8BF.tar.zst -p 16 -y 16 -m 5000000 -e 257061175 --zst
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-257222682 -s snapshot-257222682-Dudsosehu5xdHbqzG5sy72qEu6KyS9FmHnW7oV8pRoNn.tar.zst -p 16 -y 16 -m 5000000 -e 257222688 --zst
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-264890264 -s snapshot-264890263-G9sNBh5CPSU9A1nXtC6QE87o1NPkwyMPh7XVKG5mw1Ka.tar.zst -p 32 -y 16 -m 5000000 -e 264890265 --zst
-src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-257229353 -s snapshot-257229353-9wETKbJxKf7ceWxtLFJN8VffLQJ2xQVXLUgrXtp6UMx.tar.zst  -p 16 -y 16 -m 5000000 -e 257229353 --zst                              
+src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-257229353 -s snapshot-257229353-9wETKbJxKf7ceWxtLFJN8VffLQJ2xQVXLUgrXtp6UMx.tar.zst  -p 16 -y 16 -m 5000000 -e 257229353 --zst
+src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-257257983 -s snapshot-257257983-2BUVWgqWECejK8jk8XzJhYpYdMuJk2cnAshMcQZmN2Tz.tar.zst -p 16 -y 32 -m 5000000 -e 257257986 --zst


### PR DESCRIPTION
programs can't be executed on the same slot that they are deployed or upgraded. Adding ledger test to CI as well