### PR TITLE
deps: install CMake system package

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -136,7 +136,7 @@ check_fedora_pkgs () {
 }
 
 check_debian_pkgs () {
-  local REQUIRED_DEBS=( perl autoconf gettext automake autopoint flex bison build-essential gcc-multilib protobuf-compiler llvm lcov libgmp-dev )
+  local REQUIRED_DEBS=( perl autoconf gettext automake autopoint flex bison build-essential gcc-multilib protobuf-compiler llvm lcov libgmp-dev cmake )
 
   echo "[~] Checking for required DEB packages"
 


### PR DESCRIPTION
We require CMake to build some dependencies, so it should be
installed by deps.sh.
