### PR TITLE
towerSync: hand written deserializer for compact form

### DIFF
--- a/src/flamenco/types/fd_type_names.c
+++ b/src/flamenco/types/fd_type_names.c
@@ -1,5 +1,5 @@
 // This is an auto-generated file. To add entries, edit fd_types.json
-#define FD_TYPE_NAME_COUNT 199
+#define FD_TYPE_NAME_COUNT 200
 static char const * fd_type_names[FD_TYPE_NAME_COUNT] = {
  "fd_hash",
  "fd_pubkey",
@@ -79,6 +79,7 @@ static char const * fd_type_names[FD_TYPE_NAME_COUNT] = {
  "fd_vote_state_update",
  "fd_compact_vote_state_update",
  "fd_compact_vote_state_update_switch",
+ "fd_compact_tower_sync",
  "fd_tower_sync",
  "fd_tower_sync_switch",
  "fd_slot_history_inner",

--- a/src/flamenco/types/fd_types.c
+++ b/src/flamenco/types/fd_types.c
@@ -8639,34 +8639,25 @@ int fd_compact_vote_state_update_switch_encode( fd_compact_vote_state_update_swi
   return FD_BINCODE_SUCCESS;
 }
 
-int fd_tower_sync_decode( fd_tower_sync_t * self, fd_bincode_decode_ctx_t * ctx ) {
+int fd_compact_tower_sync_decode( fd_compact_tower_sync_t * self, fd_bincode_decode_ctx_t * ctx ) {
   void const * data = ctx->data;
-  int err = fd_tower_sync_decode_preflight( ctx );
+  int err = fd_compact_tower_sync_decode_preflight( ctx );
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
   ctx->data = data;
-  fd_tower_sync_new( self );
-  fd_tower_sync_decode_unsafe( self, ctx );
+  fd_compact_tower_sync_new( self );
+  fd_compact_tower_sync_decode_unsafe( self, ctx );
   return FD_BINCODE_SUCCESS;
 }
-int fd_tower_sync_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
+int fd_compact_tower_sync_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
   int err;
-  ulong lockouts_len;
-  err = fd_bincode_uint64_decode( &lockouts_len, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  ulong lockouts_sz;
-  if( FD_UNLIKELY( __builtin_umull_overflow( lockouts_len, 12, &lockouts_sz ) ) ) return FD_BINCODE_ERR_UNDERFLOW;
-  err = fd_bincode_bytes_decode_preflight( lockouts_sz, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
   err = fd_bincode_uint64_decode_preflight( ctx );
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
-  {
-    uchar o;
-    err = fd_bincode_bool_decode( &o, ctx );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
-    if( o ) {
-      err = fd_bincode_uint64_decode_preflight( ctx );
-      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
-    }
+  ushort lockout_offsets_len;
+  err = fd_bincode_compact_u16_decode( &lockout_offsets_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  for( ulong i = 0; i < lockout_offsets_len; ++i ) {
+    err = fd_lockout_offset_decode_preflight( ctx );
+    if( FD_UNLIKELY( err ) ) return err;
   }
   err = fd_hash_decode_preflight( ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -8683,23 +8674,16 @@ int fd_tower_sync_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
-void fd_tower_sync_decode_unsafe( fd_tower_sync_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  ulong lockouts_len;
-  fd_bincode_uint64_decode_unsafe( &lockouts_len, ctx );
-  self->lockouts = deq_fd_vote_lockout_t_alloc( ctx->valloc, lockouts_len );
-  for( ulong i=0; i < lockouts_len; i++ ) {
-    fd_vote_lockout_t * elem = deq_fd_vote_lockout_t_push_tail_nocopy( self->lockouts );
-    fd_vote_lockout_new( elem );
-    fd_vote_lockout_decode_unsafe( elem, ctx );
-  }
-  fd_bincode_uint64_decode_unsafe( &self->lockouts_cnt, ctx );
-  {
-    uchar o;
-    fd_bincode_bool_decode_unsafe( &o, ctx );
-    self->has_root = !!o;
-    if( o ) {
-      fd_bincode_uint64_decode_unsafe( &self->root, ctx );
-    }
+void fd_compact_tower_sync_decode_unsafe( fd_compact_tower_sync_t * self, fd_bincode_decode_ctx_t * ctx ) {
+  fd_bincode_uint64_decode_unsafe( &self->root, ctx );
+  ushort lockout_offsets_len;
+  fd_bincode_compact_u16_decode_unsafe( &lockout_offsets_len, ctx );
+  ulong lockout_offsets_max = fd_ulong_max( lockout_offsets_len, 32 );
+  self->lockout_offsets = deq_fd_lockout_offset_t_alloc( ctx->valloc, lockout_offsets_max );
+  for( ulong i=0; i < lockout_offsets_len; i++ ) {
+    fd_lockout_offset_t * elem = deq_fd_lockout_offset_t_push_tail_nocopy( self->lockout_offsets );
+    fd_lockout_offset_new( elem );
+    fd_lockout_offset_decode_unsafe( elem, ctx );
   }
   fd_hash_decode_unsafe( &self->hash, ctx );
   {
@@ -8712,29 +8696,19 @@ void fd_tower_sync_decode_unsafe( fd_tower_sync_t * self, fd_bincode_decode_ctx_
   }
   fd_hash_decode_unsafe( &self->block_id, ctx );
 }
-int fd_tower_sync_decode_offsets( fd_tower_sync_off_t * self, fd_bincode_decode_ctx_t * ctx ) {
+int fd_compact_tower_sync_decode_offsets( fd_compact_tower_sync_off_t * self, fd_bincode_decode_ctx_t * ctx ) {
   uchar const * data = ctx->data;
   int err;
-  self->lockouts_off = (uint)( (ulong)ctx->data - (ulong)data );
-  ulong lockouts_len;
-  err = fd_bincode_uint64_decode( &lockouts_len, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  ulong lockouts_sz;
-  if( FD_UNLIKELY( __builtin_umull_overflow( lockouts_len, 12, &lockouts_sz ) ) ) return FD_BINCODE_ERR_UNDERFLOW;
-  err = fd_bincode_bytes_decode_preflight( lockouts_sz, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->lockouts_cnt_off = (uint)( (ulong)ctx->data - (ulong)data );
+  self->root_off = (uint)( (ulong)ctx->data - (ulong)data );
   err = fd_bincode_uint64_decode_preflight( ctx );
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
-  self->root_off = (uint)( (ulong)ctx->data - (ulong)data );
-  {
-    uchar o;
-    err = fd_bincode_bool_decode( &o, ctx );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
-    if( o ) {
-      err = fd_bincode_uint64_decode_preflight( ctx );
-      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
-    }
+  self->lockout_offsets_off = (uint)( (ulong)ctx->data - (ulong)data );
+  ushort lockout_offsets_len;
+  err = fd_bincode_compact_u16_decode( &lockout_offsets_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  for( ulong i = 0; i < lockout_offsets_len; ++i ) {
+    err = fd_lockout_offset_decode_preflight( ctx );
+    if( FD_UNLIKELY( err ) ) return err;
   }
   self->hash_off = (uint)( (ulong)ctx->data - (ulong)data );
   err = fd_hash_decode_preflight( ctx );
@@ -8754,6 +8728,109 @@ int fd_tower_sync_decode_offsets( fd_tower_sync_off_t * self, fd_bincode_decode_
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
+void fd_compact_tower_sync_new(fd_compact_tower_sync_t * self) {
+  fd_memset( self, 0, sizeof(fd_compact_tower_sync_t) );
+  fd_hash_new( &self->hash );
+  fd_hash_new( &self->block_id );
+}
+void fd_compact_tower_sync_destroy( fd_compact_tower_sync_t * self, fd_bincode_destroy_ctx_t * ctx ) {
+  if( self->lockout_offsets ) {
+    for( deq_fd_lockout_offset_t_iter_t iter = deq_fd_lockout_offset_t_iter_init( self->lockout_offsets ); !deq_fd_lockout_offset_t_iter_done( self->lockout_offsets, iter ); iter = deq_fd_lockout_offset_t_iter_next( self->lockout_offsets, iter ) ) {
+      fd_lockout_offset_t * ele = deq_fd_lockout_offset_t_iter_ele( self->lockout_offsets, iter );
+      fd_lockout_offset_destroy( ele, ctx );
+    }
+    fd_valloc_free( ctx->valloc, deq_fd_lockout_offset_t_delete( deq_fd_lockout_offset_t_leave( self->lockout_offsets) ) );
+    self->lockout_offsets = NULL;
+  }
+  fd_hash_destroy( &self->hash, ctx );
+  if( self->has_timestamp ) {
+    self->has_timestamp = 0;
+  }
+  fd_hash_destroy( &self->block_id, ctx );
+}
+
+ulong fd_compact_tower_sync_footprint( void ){ return FD_COMPACT_TOWER_SYNC_FOOTPRINT; }
+ulong fd_compact_tower_sync_align( void ){ return FD_COMPACT_TOWER_SYNC_ALIGN; }
+
+void fd_compact_tower_sync_walk( void * w, fd_compact_tower_sync_t const * self, fd_types_walk_fn_t fun, const char *name, uint level ) {
+  fun( w, self, name, FD_FLAMENCO_TYPE_MAP, "fd_compact_tower_sync", level++ );
+  fun( w, &self->root, "root", FD_FLAMENCO_TYPE_ULONG, "ulong", level );
+
+  /* Walk deque */
+  fun( w, self->lockout_offsets, "lockout_offsets", FD_FLAMENCO_TYPE_ARR, "lockout_offsets", level++ );
+  if( self->lockout_offsets ) {
+    for( deq_fd_lockout_offset_t_iter_t iter = deq_fd_lockout_offset_t_iter_init( self->lockout_offsets );
+         !deq_fd_lockout_offset_t_iter_done( self->lockout_offsets, iter );
+         iter = deq_fd_lockout_offset_t_iter_next( self->lockout_offsets, iter ) ) {
+      fd_lockout_offset_t * ele = deq_fd_lockout_offset_t_iter_ele( self->lockout_offsets, iter );
+      fd_lockout_offset_walk(w, ele, fun, "lockout_offsets", level );
+    }
+  }
+  fun( w, self->lockout_offsets, "lockout_offsets", FD_FLAMENCO_TYPE_ARR_END, "lockout_offsets", level-- );
+  /* Done walking deque */
+
+  fd_hash_walk( w, &self->hash, fun, "hash", level );
+  if( !self->has_timestamp ) {
+    fun( w, NULL, "timestamp", FD_FLAMENCO_TYPE_NULL, "ulong", level );
+  } else {
+    fun( w, &self->timestamp, "timestamp", FD_FLAMENCO_TYPE_ULONG, "ulong", level );
+  }
+  fd_hash_walk( w, &self->block_id, fun, "block_id", level );
+  fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_compact_tower_sync", level-- );
+}
+ulong fd_compact_tower_sync_size( fd_compact_tower_sync_t const * self ) {
+  ulong size = 0;
+  size += sizeof(ulong);
+  if( self->lockout_offsets ) {
+    ushort lockout_offsets_len = (ushort)deq_fd_lockout_offset_t_cnt( self->lockout_offsets );
+    size += fd_bincode_compact_u16_size( &lockout_offsets_len );
+    for( deq_fd_lockout_offset_t_iter_t iter = deq_fd_lockout_offset_t_iter_init( self->lockout_offsets ); !deq_fd_lockout_offset_t_iter_done( self->lockout_offsets, iter ); iter = deq_fd_lockout_offset_t_iter_next( self->lockout_offsets, iter ) ) {
+      fd_lockout_offset_t * ele = deq_fd_lockout_offset_t_iter_ele( self->lockout_offsets, iter );
+      size += fd_lockout_offset_size( ele );
+    }
+  } else {
+    size += 1;
+  }
+  size += fd_hash_size( &self->hash );
+  size += sizeof(char);
+  if( self->has_timestamp ) {
+    size += sizeof(ulong);
+  }
+  size += fd_hash_size( &self->block_id );
+  return size;
+}
+
+int fd_compact_tower_sync_encode( fd_compact_tower_sync_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->root, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->lockout_offsets ) {
+    ushort lockout_offsets_len = (ushort)deq_fd_lockout_offset_t_cnt( self->lockout_offsets );
+    err = fd_bincode_compact_u16_encode( &lockout_offsets_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( deq_fd_lockout_offset_t_iter_t iter = deq_fd_lockout_offset_t_iter_init( self->lockout_offsets ); !deq_fd_lockout_offset_t_iter_done( self->lockout_offsets, iter ); iter = deq_fd_lockout_offset_t_iter_next( self->lockout_offsets, iter ) ) {
+      fd_lockout_offset_t const * ele = deq_fd_lockout_offset_t_iter_ele_const( self->lockout_offsets, iter );
+      err = fd_lockout_offset_encode( ele, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ushort lockout_offsets_len = 0;
+    err = fd_bincode_compact_u16_encode( &lockout_offsets_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_hash_encode( &self->hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_bool_encode( self->has_timestamp, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_timestamp ) {
+    err = fd_bincode_uint64_encode( self->timestamp, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_hash_encode( &self->block_id, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+
 void fd_tower_sync_new(fd_tower_sync_t * self) {
   fd_memset( self, 0, sizeof(fd_tower_sync_t) );
   fd_hash_new( &self->hash );
@@ -8837,42 +8914,6 @@ ulong fd_tower_sync_size( fd_tower_sync_t const * self ) {
   return size;
 }
 
-int fd_tower_sync_encode( fd_tower_sync_t const * self, fd_bincode_encode_ctx_t * ctx ) {
-  int err;
-  if( self->lockouts ) {
-    ulong lockouts_len = deq_fd_vote_lockout_t_cnt( self->lockouts );
-    err = fd_bincode_uint64_encode( lockouts_len, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    for( deq_fd_vote_lockout_t_iter_t iter = deq_fd_vote_lockout_t_iter_init( self->lockouts ); !deq_fd_vote_lockout_t_iter_done( self->lockouts, iter ); iter = deq_fd_vote_lockout_t_iter_next( self->lockouts, iter ) ) {
-      fd_vote_lockout_t const * ele = deq_fd_vote_lockout_t_iter_ele_const( self->lockouts, iter );
-      err = fd_vote_lockout_encode( ele, ctx );
-      if( FD_UNLIKELY( err ) ) return err;
-    }
-  } else {
-    ulong lockouts_len = 0;
-    err = fd_bincode_uint64_encode( lockouts_len, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-  }
-  err = fd_bincode_uint64_encode( self->lockouts_cnt, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_bincode_bool_encode( self->has_root, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  if( self->has_root ) {
-    err = fd_bincode_uint64_encode( self->root, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-  }
-  err = fd_hash_encode( &self->hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_bincode_bool_encode( self->has_timestamp, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  if( self->has_timestamp ) {
-    err = fd_bincode_uint64_encode( self->timestamp, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-  }
-  err = fd_hash_encode( &self->block_id, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 
 int fd_tower_sync_switch_decode( fd_tower_sync_switch_t * self, fd_bincode_decode_ctx_t * ctx ) {
   void const * data = ctx->data;

--- a/src/flamenco/types/fd_types.h
+++ b/src/flamenco/types/fd_types.h
@@ -141,6 +141,7 @@ struct fd_hash_hash_age_pair_t_mapnode {
 };
 static inline fd_hash_hash_age_pair_t_mapnode_t *
 fd_hash_hash_age_pair_t_map_alloc( fd_valloc_t valloc, ulong len ) {
+  if( FD_UNLIKELY( 0 == len ) ) len = 1; // prevent underflow
   void * mem = fd_valloc_malloc( valloc, fd_hash_hash_age_pair_t_map_align(), fd_hash_hash_age_pair_t_map_footprint(len));
   return fd_hash_hash_age_pair_t_map_join(fd_hash_hash_age_pair_t_map_new(mem, len));
 }
@@ -530,6 +531,7 @@ struct fd_vote_accounts_pair_t_mapnode {
 };
 static inline fd_vote_accounts_pair_t_mapnode_t *
 fd_vote_accounts_pair_t_map_alloc( fd_valloc_t valloc, ulong len ) {
+  if( FD_UNLIKELY( 0 == len ) ) len = 1; // prevent underflow
   void * mem = fd_valloc_malloc( valloc, fd_vote_accounts_pair_t_map_align(), fd_vote_accounts_pair_t_map_footprint(len));
   return fd_vote_accounts_pair_t_map_join(fd_vote_accounts_pair_t_map_new(mem, len));
 }
@@ -582,6 +584,7 @@ struct fd_stake_accounts_pair_t_mapnode {
 };
 static inline fd_stake_accounts_pair_t_mapnode_t *
 fd_stake_accounts_pair_t_map_alloc( fd_valloc_t valloc, ulong len ) {
+  if( FD_UNLIKELY( 0 == len ) ) len = 1; // prevent underflow
   void * mem = fd_valloc_malloc( valloc, fd_stake_accounts_pair_t_map_align(), fd_stake_accounts_pair_t_map_footprint(len));
   return fd_stake_accounts_pair_t_map_join(fd_stake_accounts_pair_t_map_new(mem, len));
 }
@@ -635,6 +638,7 @@ struct fd_stake_weight_t_mapnode {
 };
 static inline fd_stake_weight_t_mapnode_t *
 fd_stake_weight_t_map_alloc( fd_valloc_t valloc, ulong len ) {
+  if( FD_UNLIKELY( 0 == len ) ) len = 1; // prevent underflow
   void * mem = fd_valloc_malloc( valloc, fd_stake_weight_t_map_align(), fd_stake_weight_t_map_footprint(len));
   return fd_stake_weight_t_map_join(fd_stake_weight_t_map_new(mem, len));
 }
@@ -711,6 +715,7 @@ struct fd_delegation_pair_t_mapnode {
 };
 static inline fd_delegation_pair_t_mapnode_t *
 fd_delegation_pair_t_map_alloc( fd_valloc_t valloc, ulong len ) {
+  if( FD_UNLIKELY( 0 == len ) ) len = 1; // prevent underflow
   void * mem = fd_valloc_malloc( valloc, fd_delegation_pair_t_map_align(), fd_delegation_pair_t_map_footprint(len));
   return fd_delegation_pair_t_map_join(fd_delegation_pair_t_map_new(mem, len));
 }
@@ -1394,7 +1399,7 @@ typedef struct fd_vote_lockout_off fd_vote_lockout_off_t;
 #define FD_VOTE_LOCKOUT_OFF_FOOTPRINT sizeof(fd_vote_lockout_off_t)
 #define FD_VOTE_LOCKOUT_OFF_ALIGN (8UL)
 
-/* Encoded Size: Fixed (9 bytes) */
+/* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_lockout_offset {
   ulong offset;
   uchar confirmation_count;
@@ -1577,6 +1582,7 @@ typedef struct fd_landed_vote_off fd_landed_vote_off_t;
 #undef DEQUE_MAX
 static inline fd_vote_lockout_t *
 deq_fd_vote_lockout_t_alloc( fd_valloc_t valloc, ulong max ) {
+  if( FD_UNLIKELY( 0 == max ) ) max = 1; // prevent underflow
   void * mem = fd_valloc_malloc( valloc, deq_fd_vote_lockout_t_align(), deq_fd_vote_lockout_t_footprint( max ) );
   return deq_fd_vote_lockout_t_join( deq_fd_vote_lockout_t_new( mem, max ) );
 }
@@ -1588,6 +1594,7 @@ deq_fd_vote_lockout_t_alloc( fd_valloc_t valloc, ulong max ) {
 #undef DEQUE_MAX
 static inline fd_vote_epoch_credits_t *
 deq_fd_vote_epoch_credits_t_alloc( fd_valloc_t valloc, ulong max ) {
+  if( FD_UNLIKELY( 0 == max ) ) max = 1; // prevent underflow
   void * mem = fd_valloc_malloc( valloc, deq_fd_vote_epoch_credits_t_align(), deq_fd_vote_epoch_credits_t_footprint( max ) );
   return deq_fd_vote_epoch_credits_t_join( deq_fd_vote_epoch_credits_t_new( mem, max ) );
 }
@@ -1711,6 +1718,7 @@ typedef struct fd_vote_state_1_14_11_off fd_vote_state_1_14_11_off_t;
 #undef DEQUE_MAX
 static inline fd_landed_vote_t *
 deq_fd_landed_vote_t_alloc( fd_valloc_t valloc, ulong max ) {
+  if( FD_UNLIKELY( 0 == max ) ) max = 1; // prevent underflow
   void * mem = fd_valloc_malloc( valloc, deq_fd_landed_vote_t_align(), deq_fd_landed_vote_t_footprint( max ) );
   return deq_fd_landed_vote_t_join( deq_fd_landed_vote_t_new( mem, max ) );
 }
@@ -1842,6 +1850,43 @@ typedef struct fd_compact_vote_state_update_switch_off fd_compact_vote_state_upd
 #define FD_COMPACT_VOTE_STATE_UPDATE_SWITCH_OFF_FOOTPRINT sizeof(fd_compact_vote_state_update_switch_off_t)
 #define FD_COMPACT_VOTE_STATE_UPDATE_SWITCH_OFF_ALIGN (8UL)
 
+#define DEQUE_NAME deq_fd_lockout_offset_t
+#define DEQUE_T fd_lockout_offset_t
+#include "../../util/tmpl/fd_deque_dynamic.c"
+#undef DEQUE_NAME
+#undef DEQUE_T
+#undef DEQUE_MAX
+static inline fd_lockout_offset_t *
+deq_fd_lockout_offset_t_alloc( fd_valloc_t valloc, ulong max ) {
+  if( FD_UNLIKELY( 0 == max ) ) max = 1; // prevent underflow
+  void * mem = fd_valloc_malloc( valloc, deq_fd_lockout_offset_t_align(), deq_fd_lockout_offset_t_footprint( max ) );
+  return deq_fd_lockout_offset_t_join( deq_fd_lockout_offset_t_new( mem, max ) );
+}
+/* https://github.com/anza-xyz/agave/blob/20ee70cd1829cd414d09040460defecf9792a370/sdk/program/src/vote/state/mod.rs#L990 */
+/* Encoded Size: Dynamic */
+struct __attribute__((aligned(8UL))) fd_compact_tower_sync {
+  ulong root;
+  fd_lockout_offset_t * lockout_offsets; /* fd_deque_dynamic (min cnt 32) */
+  fd_hash_t hash;
+  ulong timestamp;
+  uchar has_timestamp;
+  fd_hash_t block_id;
+};
+typedef struct fd_compact_tower_sync fd_compact_tower_sync_t;
+#define FD_COMPACT_TOWER_SYNC_FOOTPRINT sizeof(fd_compact_tower_sync_t)
+#define FD_COMPACT_TOWER_SYNC_ALIGN (8UL)
+
+struct __attribute__((aligned(8UL))) fd_compact_tower_sync_off {
+  uint root_off;
+  uint lockout_offsets_off;
+  uint hash_off;
+  uint timestamp_off;
+  uint block_id_off;
+};
+typedef struct fd_compact_tower_sync_off fd_compact_tower_sync_off_t;
+#define FD_COMPACT_TOWER_SYNC_OFF_FOOTPRINT sizeof(fd_compact_tower_sync_off_t)
+#define FD_COMPACT_TOWER_SYNC_OFF_ALIGN (8UL)
+
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L185 */
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_tower_sync {
@@ -1965,6 +2010,7 @@ typedef struct fd_slot_hash_off fd_slot_hash_off_t;
 #undef DEQUE_MAX
 static inline fd_slot_hash_t *
 deq_fd_slot_hash_t_alloc( fd_valloc_t valloc, ulong max ) {
+  if( FD_UNLIKELY( 0 == max ) ) max = 1; // prevent underflow
   void * mem = fd_valloc_malloc( valloc, deq_fd_slot_hash_t_align(), deq_fd_slot_hash_t_footprint( max ) );
   return deq_fd_slot_hash_t_join( deq_fd_slot_hash_t_new( mem, max ) );
 }
@@ -2009,6 +2055,7 @@ typedef struct fd_block_block_hash_entry_off fd_block_block_hash_entry_off_t;
 #undef DEQUE_MAX
 static inline fd_block_block_hash_entry_t *
 deq_fd_block_block_hash_entry_t_alloc( fd_valloc_t valloc, ulong max ) {
+  if( FD_UNLIKELY( 0 == max ) ) max = 1; // prevent underflow
   void * mem = fd_valloc_malloc( valloc, deq_fd_block_block_hash_entry_t_align(), deq_fd_block_block_hash_entry_t_footprint( max ) );
   return deq_fd_block_block_hash_entry_t_join( deq_fd_block_block_hash_entry_t_new( mem, max ) );
 }
@@ -2096,6 +2143,7 @@ struct fd_clock_timestamp_vote_t_mapnode {
 };
 static inline fd_clock_timestamp_vote_t_mapnode_t *
 fd_clock_timestamp_vote_t_map_alloc( fd_valloc_t valloc, ulong len ) {
+  if( FD_UNLIKELY( 0 == len ) ) len = 1; // prevent underflow
   void * mem = fd_valloc_malloc( valloc, fd_clock_timestamp_vote_t_map_align(), fd_clock_timestamp_vote_t_map_footprint(len));
   return fd_clock_timestamp_vote_t_map_join(fd_clock_timestamp_vote_t_map_new(mem, len));
 }
@@ -2395,6 +2443,7 @@ typedef struct fd_prev_epoch_inflation_rewards_off fd_prev_epoch_inflation_rewar
 #undef DEQUE_MAX
 static inline ulong *
 deq_ulong_alloc( fd_valloc_t valloc, ulong max ) {
+  if( FD_UNLIKELY( 0 == max ) ) max = 1; // prevent underflow
   void * mem = fd_valloc_malloc( valloc, deq_ulong_align(), deq_ulong_footprint( max ) );
   return deq_ulong_join( deq_ulong_new( mem, max ) );
 }
@@ -3837,7 +3886,7 @@ typedef struct fd_gossip_version_v2_off fd_gossip_version_v2_off_t;
 #define FD_GOSSIP_VERSION_V2_OFF_FOOTPRINT sizeof(fd_gossip_version_v2_off_t)
 #define FD_GOSSIP_VERSION_V2_OFF_ALIGN (8UL)
 
-/* Encoded Size: Fixed (16 bytes) */
+/* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_version_v3 {
   ushort major;
   ushort minor;
@@ -3937,7 +3986,7 @@ typedef struct fd_gossip_incremental_snapshot_hashes_off fd_gossip_incremental_s
 #define FD_GOSSIP_INCREMENTAL_SNAPSHOT_HASHES_OFF_FOOTPRINT sizeof(fd_gossip_incremental_snapshot_hashes_off_t)
 #define FD_GOSSIP_INCREMENTAL_SNAPSHOT_HASHES_OFF_ALIGN (8UL)
 
-/* Encoded Size: Fixed (4 bytes) */
+/* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_socket_entry {
   uchar key;
   uchar index;
@@ -5277,6 +5326,18 @@ void fd_compact_vote_state_update_switch_walk( void * w, fd_compact_vote_state_u
 ulong fd_compact_vote_state_update_switch_size( fd_compact_vote_state_update_switch_t const * self );
 ulong fd_compact_vote_state_update_switch_footprint( void );
 ulong fd_compact_vote_state_update_switch_align( void );
+
+void fd_compact_tower_sync_new( fd_compact_tower_sync_t * self );
+int fd_compact_tower_sync_decode( fd_compact_tower_sync_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_compact_tower_sync_decode_preflight( fd_bincode_decode_ctx_t * ctx );
+void fd_compact_tower_sync_decode_unsafe( fd_compact_tower_sync_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_compact_tower_sync_decode_offsets( fd_compact_tower_sync_off_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_compact_tower_sync_encode( fd_compact_tower_sync_t const * self, fd_bincode_encode_ctx_t * ctx );
+void fd_compact_tower_sync_destroy( fd_compact_tower_sync_t * self, fd_bincode_destroy_ctx_t * ctx );
+void fd_compact_tower_sync_walk( void * w, fd_compact_tower_sync_t const * self, fd_types_walk_fn_t fun, const char *name, uint level );
+ulong fd_compact_tower_sync_size( fd_compact_tower_sync_t const * self );
+ulong fd_compact_tower_sync_footprint( void );
+ulong fd_compact_tower_sync_align( void );
 
 void fd_tower_sync_new( fd_tower_sync_t * self );
 int fd_tower_sync_decode( fd_tower_sync_t * self, fd_bincode_decode_ctx_t * ctx );

--- a/src/flamenco/types/fd_types.json
+++ b/src/flamenco/types/fd_types.json
@@ -827,8 +827,21 @@
       "comment": "https://github.com/solana-labs/solana/blob/252438e28fbfb2c695fe1215171b83456e4b761c/programs/vote/src/vote_instruction.rs#L143"
     },
     {
+      "name": "compact_tower_sync",
+      "type": "struct",
+      "fields": [
+        { "name": "root", "type": "ulong" },
+        { "name": "lockout_offsets", "type": "deque", "element": "lockout_offset", "modifier": "compact" , "min": 32, "max": 100, "comment": "100 is the max packet length / sizeof(vote_lockout)" },
+        { "name": "hash", "type": "hash" },
+        { "name": "timestamp", "type": "option", "element": "ulong", "flat": true },
+        { "name": "block_id", "type": "hash" }
+      ],
+      "comment": "https://github.com/anza-xyz/agave/blob/20ee70cd1829cd414d09040460defecf9792a370/sdk/program/src/vote/state/mod.rs#L990"
+    },
+    {
       "name": "tower_sync",
       "type": "struct",
+      "encoders": false,
       "fields": [
         { "name": "lockouts", "type": "deque", "element": "vote_lockout" },
         { "name": "lockouts_cnt", "type": "ulong" },

--- a/src/flamenco/types/fd_types_custom.c
+++ b/src/flamenco/types/fd_types_custom.c
@@ -79,3 +79,57 @@ fd_gossip_ip6_addr_walk( void *                       w,
            FD_LOG_HEX16_FMT_ARGS( self->us ) );
   fun( w, buf, name, FD_FLAMENCO_TYPE_CSTR, "ip6_addr", level );
 }
+
+int fd_tower_sync_decode( fd_tower_sync_t * self, fd_bincode_decode_ctx_t * ctx ) {
+  void const * data = ctx->data;
+  int err = fd_tower_sync_decode_preflight( ctx );
+  if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
+  ctx->data = data;
+  fd_tower_sync_new( self );
+  fd_tower_sync_decode_unsafe( self, ctx );
+  return FD_BINCODE_SUCCESS;
+}
+
+int fd_tower_sync_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
+  return fd_compact_tower_sync_decode_preflight( ctx );
+}
+
+void fd_tower_sync_decode_unsafe( fd_tower_sync_t * self, fd_bincode_decode_ctx_t * ctx ) {
+  self->has_root = 1;
+  fd_bincode_uint64_decode_unsafe( &self->root, ctx );
+  self->has_root = self->root != ULONG_MAX;
+
+  ushort lockout_offsets_len;
+  fd_bincode_compact_u16_decode_unsafe( &lockout_offsets_len, ctx );
+  ulong lockout_offsets_max = fd_ulong_max( lockout_offsets_len, 32 );
+  self->lockouts = deq_fd_vote_lockout_t_alloc( ctx->valloc, lockout_offsets_max );
+
+  for( ulong i=0; i < lockout_offsets_len; i++ ) {
+    fd_vote_lockout_t * elem = deq_fd_vote_lockout_t_push_tail_nocopy( self->lockouts );
+
+    fd_lockout_offset_t o;
+    fd_lockout_offset_decode_unsafe( &o, ctx );
+
+    elem->slot = ((self->root == ULONG_MAX) ? 0 : self->root)  + o.offset;
+    elem->confirmation_count = o.confirmation_count;
+  }
+
+  fd_hash_decode_unsafe( &self->hash, ctx );
+  {
+    uchar o;
+    fd_bincode_bool_decode_unsafe( &o, ctx );
+    self->has_timestamp = !!o;
+    if( o ) {
+      fd_bincode_uint64_decode_unsafe( &self->timestamp, ctx );
+    }
+  }
+  fd_hash_decode_unsafe( &self->block_id, ctx );
+}
+
+int fd_tower_sync_decode_offsets( fd_tower_sync_off_t * self, fd_bincode_decode_ctx_t * ctx ) {
+  FD_LOG_ERR(( "todo"));
+}
+
+int fd_tower_sync_encode( fd_tower_sync_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  FD_LOG_ERR(( "todo"));
+}


### PR DESCRIPTION

1) fixed a underflow issue with dequeue initialization of empty arrays
2) fixed variable sized objects to handle varints in primitives
3) handwrote a compactTowerSync deserializer 
4) Fixed some UINT_MAX checks which have the same "effect" as the optional root