### PR TITLE
fuzz, runtime, flamenco: fix fd_map_giant bad magic and change fuzz harness to use libc alloc

### DIFF
--- a/src/flamenco/runtime/context/fd_exec_slot_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_slot_ctx.c
@@ -91,7 +91,7 @@ fd_exec_slot_ctx_delete( void * mem ) {
 
   fd_valloc_free( hdr->valloc, fd_sysvar_cache_delete( hdr->sysvar_cache ) );
   hdr->sysvar_cache = NULL;
-  fd_valloc_free( hdr->valloc, fd_account_compute_table_delete( hdr->account_compute_table ) );
+  fd_valloc_free( hdr->valloc, fd_account_compute_table_delete( fd_account_compute_table_leave( hdr->account_compute_table ) ) );
   hdr->account_compute_table = NULL;
 
   FD_COMPILER_MFENCE();

--- a/src/flamenco/runtime/tests/fd_exec_sol_compat.c
+++ b/src/flamenco/runtime/tests/fd_exec_sol_compat.c
@@ -54,7 +54,7 @@ sol_compat_init( void ) {
 
   ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
   if( cpu_idx>=fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-  wksp = fd_wksp_new_anonymous( FD_SHMEM_GIGANTIC_PAGE_SZ, 4, fd_shmem_cpu_idx( fd_shmem_numa_idx( cpu_idx ) ), "wksp", 0UL );
+  wksp = fd_wksp_new_anonymous( FD_SHMEM_NORMAL_PAGE_SZ, 65536, fd_shmem_cpu_idx( fd_shmem_numa_idx( cpu_idx ) ), "wksp", 0UL );
   assert( wksp );
 
   smem = malloc( smax );  /* 1 GiB */


### PR DESCRIPTION
* Fix bad magic / memory leaks caused by incorrect free operations in slot context
* Change fuzz harness to use libc allocators
* Reduce workspace page requirements