### PR TITLE
keyguard: fix support for multiple signing methods

### DIFF
--- a/src/app/fdctl/run/tiles/fd_gossip.c
+++ b/src/app/fdctl/run/tiles/fd_gossip.c
@@ -1,6 +1,6 @@
 /* Gossip tile runs the gossip networking protcol for a Firedancer node. */
 
-#define _GNU_SOURCE 
+#define _GNU_SOURCE
 
 #include "../../../../disco/tiles.h"
 
@@ -54,7 +54,7 @@ fd_pubkey_eq( fd_pubkey_t const * key1, fd_pubkey_t const * key2 ) {
 
 static ulong
 fd_pubkey_hash( fd_pubkey_t const * key, ulong seed ) {
-  return fd_hash( seed, key->key, sizeof(fd_pubkey_t) ); 
+  return fd_hash( seed, key->key, sizeof(fd_pubkey_t) );
 }
 
 static void
@@ -131,7 +131,7 @@ struct fd_gossip_tile_ctx {
   fd_gossip_peer_addr_t tpu_my_addr;
   fd_gossip_peer_addr_t tpu_vote_my_addr;
   ushort                gossip_listen_port;
-  
+
   fd_wksp_t *     net_in_mem;
   ulong           net_in_chunk;
   ulong           net_in_wmark;
@@ -216,9 +216,9 @@ send_packet( fd_gossip_tile_ctx_t * ctx,
   ulong packet_sz = payload_sz + sizeof(fd_net_hdrs_t);
   fd_memcpy( packet+sizeof(fd_net_hdrs_t), payload, payload_sz );
   hdr->udp->net_len   = fd_ushort_bswap( (ushort)(payload_sz + sizeof(fd_udp_hdr_t)) );
-  hdr->udp->check = fd_ip4_udp_check( *(uint *)FD_ADDRESS_OF_PACKED_MEMBER( hdr->ip4->saddr_c ), 
-                                      *(uint *)FD_ADDRESS_OF_PACKED_MEMBER( hdr->ip4->daddr_c ), 
-                                      (fd_udp_hdr_t const *)FD_ADDRESS_OF_PACKED_MEMBER( hdr->udp ), 
+  hdr->udp->check = fd_ip4_udp_check( *(uint *)FD_ADDRESS_OF_PACKED_MEMBER( hdr->ip4->saddr_c ),
+                                      *(uint *)FD_ADDRESS_OF_PACKED_MEMBER( hdr->ip4->daddr_c ),
+                                      (fd_udp_hdr_t const *)FD_ADDRESS_OF_PACKED_MEMBER( hdr->udp ),
                                       packet + sizeof(fd_net_hdrs_t) );
 
   ulong tspub = fd_frag_meta_ts_comp( fd_tickcount() );
@@ -227,10 +227,10 @@ send_packet( fd_gossip_tile_ctx_t * ctx,
   ctx->net_out_chunk = fd_dcache_compact_next( ctx->net_out_chunk, packet_sz, ctx->net_out_chunk0, ctx->net_out_wmark );
 }
 
-static void 
-gossip_send_packet( uchar const * msg, 
-                    size_t msglen, 
-                    fd_gossip_peer_addr_t const * addr, 
+static void
+gossip_send_packet( uchar const * msg,
+                    size_t msglen,
+                    fd_gossip_peer_addr_t const * addr,
                     void * arg ) {
 ulong tsorig = fd_frag_meta_ts_comp( fd_tickcount() );
   send_packet( arg, addr->addr, addr->port, msg, msglen, tsorig );
@@ -289,7 +289,7 @@ gossip_deliver_fun( fd_crds_data_t * data, void * arg ) {
     ulong vote_txn_sz    = gossip_vote->txn.raw_sz;
     memcpy( vote_txn_msg, gossip_vote->txn.raw, vote_txn_sz );
 
-    ulong sig = 1UL; 
+    ulong sig = 1UL;
     fd_mcache_publish( ctx->dedup_out_mcache, ctx->dedup_out_depth, ctx->dedup_out_seq, sig, ctx->dedup_out_chunk,
       vote_txn_sz, 0UL, 0, 0 );
     ctx->dedup_out_seq   = fd_seq_inc( ctx->dedup_out_seq, 1UL );
@@ -315,14 +315,15 @@ void
 gossip_signer( void *        signer_ctx,
                uchar         signature[ static 64 ],
                uchar const * buffer,
-               ulong         len ) {
+               ulong         len,
+               int           sign_type ) {
   fd_gossip_tile_ctx_t * ctx = (fd_gossip_tile_ctx_t *)signer_ctx;
-  fd_keyguard_client_sign( ctx->keyguard_client, signature, buffer, len );
+  fd_keyguard_client_sign( ctx->keyguard_client, signature, buffer, len, sign_type );
 }
 
 static void
 before_frag( void * _ctx        FD_PARAM_UNUSED,
-             ulong  in_idx      FD_PARAM_UNUSED, 
+             ulong  in_idx      FD_PARAM_UNUSED,
              ulong  seq         FD_PARAM_UNUSED,
              ulong  sig,
              int *  opt_filter ) {
@@ -624,7 +625,7 @@ unprivileged_init( fd_topo_t *      topo,
   /* Gossip set up */
   ctx->gossip = fd_gossip_join( fd_gossip_new( ctx->gossip, ctx->gossip_seed ) );
 
-  FD_LOG_NOTICE(( "gossip my addr - addr: " FD_IP4_ADDR_FMT ":%u", 
+  FD_LOG_NOTICE(( "gossip my addr - addr: " FD_IP4_ADDR_FMT ":%u",
     FD_IP4_ADDR_FMT_ARGS( ctx->gossip_my_addr.addr ), fd_ushort_bswap( ctx->gossip_my_addr.port ) ));
   ctx->gossip_config.my_addr       = ctx->gossip_my_addr;
   ctx->gossip_config.my_version = (fd_gossip_version_v2_t){
@@ -676,7 +677,7 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->net_in_mem    = topo->workspaces[ topo->objs[ netmux_link->dcache_obj_id ].wksp_id ].wksp;
   ctx->net_in_chunk  = fd_disco_compact_chunk0( ctx->net_in_mem );
   ctx->net_in_wmark  = fd_disco_compact_wmark( ctx->net_in_mem, netmux_link->mtu );
-  
+
   fd_topo_link_t * replay_in = &topo->links[ tile->in_link_id[ VOTER_IN_IDX ] ];
   ctx->replay_in_mem    = topo->workspaces[ topo->objs[ replay_in->dcache_obj_id ].wksp_id ].wksp;
   ctx->replay_in_chunk0 = fd_dcache_compact_chunk0( ctx->replay_in_mem, replay_in->dcache );

--- a/src/app/fdctl/run/tiles/fd_quic.c
+++ b/src/app/fdctl/run/tiles/fd_quic.c
@@ -3,6 +3,7 @@
 #include "generated/quic_seccomp.h"
 #include "../../../../disco/metrics/generated/fd_metrics_quic.h"
 #include "../../../../disco/keyguard/fd_keyload.h"
+#include "../../../../disco/keyguard/fd_keyguard.h"
 #include "../../../../waltz/quic/fd_quic.h"
 #include "../../../../waltz/xdp/fd_xsk_aio.h"
 #include "../../../../waltz/xdp/fd_xsk.h"
@@ -555,7 +556,7 @@ static void
 fd_quic_tls_cv_signer( void *        signer_ctx,
                        uchar         signature[ static 64 ],
                        uchar const   payload[ static 130] ) {
-  fd_keyguard_client_sign( signer_ctx, signature, payload, 130UL );
+  fd_keyguard_client_sign( signer_ctx, signature, payload, 130UL, FD_KEYGUARD_SIGN_TYPE_ED25519 );
 }
 
 static void

--- a/src/app/fdctl/run/tiles/fd_shred.c
+++ b/src/app/fdctl/run/tiles/fd_shred.c
@@ -6,6 +6,7 @@
 #include "../../../../disco/shred/fd_fec_resolver.h"
 #include "../../../../disco/shred/fd_stake_ci.h"
 #include "../../../../disco/keyguard/fd_keyload.h"
+#include "../../../../disco/keyguard/fd_keyguard.h"
 #include "../../../../flamenco/leaders/fd_leaders.h"
 #include "../../../../waltz/ip/fd_ip.h"
 #include "../../../../disco/fd_disco.h"
@@ -662,11 +663,11 @@ privileged_init( fd_topo_t *      topo,
   ctx->identity_key[ 0 ] = *(fd_pubkey_t const *)fd_type_pun_const( fd_keyload_load( tile->shred.identity_key_path, /* pubkey only: */ 1 ) );
 }
 
-void
+static void
 fd_shred_signer( void *        signer_ctx,
                  uchar         signature[ static 64 ],
                  uchar const   merkle_root[ static 32 ] ) {
-  fd_keyguard_client_sign( signer_ctx, signature, merkle_root, 32UL );
+  fd_keyguard_client_sign( signer_ctx, signature, merkle_root, 32UL, FD_KEYGUARD_SIGN_TYPE_ED25519 );
 }
 
 static void

--- a/src/disco/keyguard/Local.mk
+++ b/src/disco/keyguard/Local.mk
@@ -1,7 +1,13 @@
 ifdef FD_HAS_HOSTED
 ifdef FD_HAS_LINUX
-$(call add-hdrs,fd_keyguard.h fd_keyload.h fd_keyguard_client.h)
-$(call add-objs,fd_keyguard_match fd_keyguard_client fd_keyload,fd_disco)
+$(call add-hdrs,fd_keyguard.h)
+$(call add-objs,fd_keyguard_authorize fd_keyguard_match,fd_disco)
+
+$(call add-hdrs,fd_keyguard_client.h)
+$(call add-objs,fd_keyguard_client,fd_disco)
+
+$(call add-hdrs,fd_keyload.h)
+$(call add-objs,fd_keyload,fd_disco)
 $(call make-unit-test,test_keyload,test_keyload,fd_disco fd_util)
 endif
 endif

--- a/src/disco/keyguard/fd_keyguard_authorize.c
+++ b/src/disco/keyguard/fd_keyguard_authorize.c
@@ -1,0 +1,165 @@
+#include "fd_keyguard.h"
+#include "fd_keyguard_client.h"
+
+struct fd_keyguard_sign_req {
+  fd_keyguard_authority_t * authority;
+};
+
+typedef struct fd_keyguard_sign_req fd_keyguard_sign_req_t;
+
+static int
+fd_keyguard_authorize_vote_txn( fd_keyguard_authority_t const * authority,
+                                uchar const *                   data,
+                                ulong                           sz,
+                                int                             sign_type ) {
+  /* FIXME Add vote transaction authorization here */
+  (void)authority; (void)data; (void)sz; (void)sign_type;
+  return 1;
+}
+
+static int
+fd_keyguard_authorize_gossip( fd_keyguard_authority_t const * authority,
+                              uchar const *                   data,
+                              ulong                           sz,
+                              int                             sign_type ) {
+  /* FIXME Add gossip message authorization here */
+  (void)authority; (void)data; (void)sz; (void)sign_type;
+  return 1;
+}
+
+static int
+fd_keyguard_authorize_ping( fd_keyguard_authority_t const * authority,
+                            uchar const *                   data,
+                            ulong                           sz,
+                            int                             sign_type ) {
+  (void)authority;
+  if( sign_type != FD_KEYGUARD_SIGN_TYPE_SHA256_ED25519 ) return 0;
+  if( sz != 48 ) return 0;
+  if( 0!=memcmp( data, "SOLANA_PING_PONG", 16 ) ) return 0;
+  return 1;
+}
+
+static int
+fd_keyguard_authorize_gossip_prune( fd_keyguard_authority_t const * authority,
+                                    uchar const *                   data,
+                                    ulong                           sz,
+                                    int                             sign_type ) {
+  if( FD_UNLIKELY( sign_type != FD_KEYGUARD_SIGN_TYPE_ED25519 ) ) return 0;
+  /* Prune messages always begin with the node's pubkey */
+  if( sz<40UL ) return 0;
+  if( 0!=memcmp( authority->identity_pubkey, data, 32 ) ) return 0;
+  return 1;
+}
+
+static int
+fd_keyguard_authorize_repair( fd_keyguard_authority_t const * authority,
+                              uchar const *                   data,
+                              ulong                           sz,
+                              int                             sign_type ) {
+
+  if( sign_type != FD_KEYGUARD_SIGN_TYPE_ED25519 ) return 0;
+  if( sz<144 ) return 0;
+
+  uint          discriminant = fd_uint_load_4( data );
+  uchar const * sender       = data+4;
+
+  if( discriminant< 8 ) return 0; /* window_index is min ID */
+  if( discriminant>11 ) return 0; /* ancestor_hashes is max ID */
+
+  if( 0!=memcmp( authority->identity_pubkey, sender, 32 ) ) return 0;
+
+  return 1;
+}
+
+int
+fd_keyguard_payload_authorize( fd_keyguard_authority_t const * authority,
+                               uchar const *                   data,
+                               ulong                           sz,
+                               int                             role,
+                               int                             sign_type ) {
+
+  if( sz > FD_KEYGUARD_SIGN_REQ_MTU ) {
+    FD_LOG_WARNING(( "oversz signing request (role=%d sz=%lu)", role, sz ));
+    return 0;
+  }
+
+  /* Identify payload type */
+
+  ulong payload_mask = fd_keyguard_payload_match( data, sz, sign_type );
+  int   match_cnt    = fd_ulong_popcnt( payload_mask );
+  if( FD_UNLIKELY( payload_mask==0UL ) ) {
+    FD_LOG_WARNING(( "unrecognized payload type (role=%#x)", role ));
+  }
+
+  int is_ambiguous = match_cnt != 1;
+
+ /* We know that gossip, gossip prune, and repair messages are
+    ambiguous, so allow mismatches here. */
+  int is_gossip_repair =
+    0==( payload_mask &
+        (~( FD_KEYGUARD_PAYLOAD_GOSSIP |
+            FD_KEYGUARD_PAYLOAD_REPAIR |
+            FD_KEYGUARD_PAYLOAD_PRUNE  ) ) );
+
+  if( FD_UNLIKELY( is_ambiguous && !is_gossip_repair ) ) {
+    FD_LOG_WARNING(( "ambiguous payload type (role=%#x mask=%#lx)", role, payload_mask ));
+  }
+
+  /* Authorize each role */
+
+  switch( role ) {
+
+  case FD_KEYGUARD_ROLE_VOTER:
+    if( FD_UNLIKELY( payload_mask != FD_KEYGUARD_PAYLOAD_TXN ) ) {
+      FD_LOG_WARNING(( "unauthorized payload type for voter (mask=%#lx)", payload_mask ));
+      return 0;
+    }
+    return fd_keyguard_authorize_vote_txn( authority, data, sz, sign_type );
+
+  case FD_KEYGUARD_ROLE_GOSSIP: {
+    int ping_ok   = (!!( payload_mask & FD_KEYGUARD_PAYLOAD_PING )) &&
+                    fd_keyguard_authorize_ping( authority, data, sz, sign_type );
+    int prune_ok  = (!!( payload_mask & FD_KEYGUARD_PAYLOAD_PRUNE )) &&
+                    fd_keyguard_authorize_gossip_prune( authority, data, sz, sign_type );
+    int gossip_ok = (!!( payload_mask & FD_KEYGUARD_PAYLOAD_GOSSIP )) &&
+                    fd_keyguard_authorize_gossip( authority, data, sz, sign_type );
+    if( FD_UNLIKELY( !ping_ok && !prune_ok && !gossip_ok ) ) {
+      FD_LOG_WARNING(( "unauthorized payload type for gossip (mask=%#lx)", payload_mask ));
+      return 0;
+    }
+    return 1;
+  }
+
+  case FD_KEYGUARD_ROLE_REPAIR: {
+    int ping_ok   = (!!( payload_mask & FD_KEYGUARD_PAYLOAD_PING )) &&
+                    fd_keyguard_authorize_ping( authority, data, sz, sign_type );
+    int repair_ok = (!!( payload_mask & FD_KEYGUARD_PAYLOAD_REPAIR )) &&
+                    fd_keyguard_authorize_repair( authority, data, sz, sign_type );
+    if( FD_UNLIKELY( !ping_ok && !repair_ok ) ) {
+      FD_LOG_WARNING(( "unauthorized payload type for repair (mask=%#lx)", payload_mask ));
+      return 0;
+    }
+    return 1;
+  }
+
+  case FD_KEYGUARD_ROLE_LEADER:
+    if( FD_UNLIKELY( payload_mask != FD_KEYGUARD_PAYLOAD_SHRED ) ) {
+      FD_LOG_WARNING(( "unauthorized payload type for leader (mask=%#lx)", payload_mask ));
+      return 0;
+    }
+    /* no further restrictions on shred */
+    return 1;
+
+  case FD_KEYGUARD_ROLE_QUIC:
+    if( FD_UNLIKELY( payload_mask != FD_KEYGUARD_PAYLOAD_TLS_CV ) ) {
+      FD_LOG_WARNING(( "unauthorized payload type for quic (mask=%#lx)", payload_mask ));
+      return 0;
+    }
+    /* no further restrictions on TLS CertificateVerify */
+    return 1;
+
+  default:
+    FD_LOG_WARNING(( "unsupported role=%#x", role ));
+    return 0;
+  }
+}

--- a/src/disco/keyguard/fd_keyguard_client.c
+++ b/src/disco/keyguard/fd_keyguard_client.c
@@ -21,10 +21,13 @@ void
 fd_keyguard_client_sign( fd_keyguard_client_t * client,
                          uchar *                signature,
                          uchar const *          sign_data,
-                         ulong                  sign_data_len ) {
+                         ulong                  sign_data_len,
+                         int                    sign_type ) {
+
   fd_memcpy( client->request_data, sign_data, sign_data_len );
 
-  fd_mcache_publish( client->request, 128UL, client->request_seq, 0UL, 0UL, sign_data_len, 0UL, 0UL, 0UL );
+  ulong sig = (ulong)(uint)sign_type;
+  fd_mcache_publish( client->request, 128UL, client->request_seq, sig, 0UL, sign_data_len, 0UL, 0UL, 0UL );
   client->request_seq = fd_seq_inc( client->request_seq, 1UL );
 
   fd_frag_meta_t meta;

--- a/src/disco/keyguard/fd_keyguard_client.h
+++ b/src/disco/keyguard/fd_keyguard_client.h
@@ -6,7 +6,7 @@
 
    For maximum security, the caller should ensure a few things before
    using,
-   
+
     (a) The request mcache and data region are placed in a shared memory
         map that is accessible exclusively to the calling tile, and the
         keyguard tile.  The keyguard tile should map the memory as read
@@ -22,7 +22,7 @@
 
     (d) Each input/output mcache correspond to a single role, and the
         keyguard tile verifies that all incoming requests are
-        specifically formatted for that role. */        
+        specifically formatted for that role. */
 
 #include "../fd_disco_base.h"
 
@@ -60,27 +60,30 @@ fd_keyguard_client_delete( void * shclient ) { return shclient; }
 
 /* fd_keyguard_client_sign sends a remote signing request to the signing
     server, and blocks (spins) until the response is received.
-    
+
     Signing is treated as infallible, and there are no error codes or
     results. If the remote signer is stuck or not running, this function
     will not timeout and instead hangs forever waiting for a response.
     This is currently by design.
-    
+
     sign_data should be a pointer to a buffer, with length sign_data_len
     that will be signed.  The data should correspond to one of the
     roles described in fd_keyguard.h.  If the remote signing tile
     receives a malformed signing request, or one for a role that does
     not correspond to the role assigned to the receiving mcache, it
     will abort the whole program with a critical error.
-    
+
     The response, a 64 byte signature, will be written into the signature
-    buffer, which must be at least this size. */
+    buffer, which must be at least this size.
+
+    sign_type is in FD_KEYGUARD_SIGN_TYPE_{...}. */
 
 void
 fd_keyguard_client_sign( fd_keyguard_client_t * client,
                          uchar *                signature,
                          uchar const *          sign_data,
-                         ulong                  sign_data_len );
+                         ulong                  sign_data_len,
+                         int                    sign_type );
 
 FD_PROTOTYPES_END
 

--- a/src/disco/keyguard/fd_keyguard_match.c
+++ b/src/disco/keyguard/fd_keyguard_match.c
@@ -237,30 +237,15 @@ FD_FN_PURE int
 fd_keyguard_payload_matches_shred( uchar const * data,
                                    ulong         sz,
                                    int           sign_type ) {
+  (void)data;
 
-  if( sign_type != FD_KEYGUARD_SIGN_TYPE_ED25519 ) return 0;
+  /* Note: Legacy shreds no longer relevant (drop_legacy_shreds) */
 
-  switch( sz ) {
-
-  /* Merkle shreds signing payloads always 32 byte */
   /* FIXME: Sign Merkle shreds using SIGN_TYPE_SHA256_ED25519 (!!!) */
-  case   32UL:
-    return 1;
+  if( sign_type != FD_KEYGUARD_SIGN_TYPE_ED25519 ) return 0;
+  if( sz != 32 ) return 0;
 
-  /* Legacy shred signing payloads always 1228 (mtu) - 64 (sig sz) bytes */
-  case 1164UL: {
-    /* Verify shred type */
-    uint shred_type = data[ 0x00 ];
-    if( (shred_type==0x5a) | (shred_type==0xa5) )
-      return 1;
-    return 0;
-  }
-
-  default:
-  /* Not a known shred type */
-    return 0;
-
-  }
+  return 1;
 }
 
 FD_FN_PURE int

--- a/src/flamenco/gossip/fd_gossip.c
+++ b/src/flamenco/gossip/fd_gossip.c
@@ -3,6 +3,7 @@
 #include "../../ballet/sha256/fd_sha256.h"
 #include "../../ballet/ed25519/fd_ed25519.h"
 #include "../../ballet/base58/fd_base58.h"
+#include "../../disco/keyguard/fd_keyguard.h"
 #include "../../util/net/fd_eth.h"
 #include "../../util/rng/fd_rng.h"
 #include <string.h>
@@ -643,7 +644,7 @@ fd_gossip_make_ping( fd_gossip_t * glob, fd_pending_event_arg_t * arg ) {
 
   /* Sign it */
 
-  (*glob->sign_fun)(glob->sign_arg, ping->signature.uc, pre_image, FD_PING_PRE_IMAGE_SZ);
+  (*glob->sign_fun)( glob->sign_arg, ping->signature.uc, pre_image, FD_PING_PRE_IMAGE_SZ, FD_KEYGUARD_SIGN_TYPE_SHA256_ED25519 );
 
   fd_gossip_send( glob, key, &gmsg );
 }
@@ -679,7 +680,7 @@ fd_gossip_handle_ping( fd_gossip_t * glob, const fd_gossip_peer_addr_t * from, f
   fd_sha256_hash( pre_image, FD_PING_PRE_IMAGE_SZ, &pong->token );
 
   /* Sign it */
-  (*glob->sign_fun)(glob->sign_arg, pong->signature.uc, pre_image, FD_PING_PRE_IMAGE_SZ);
+  (*glob->sign_fun)( glob->sign_arg, pong->signature.uc, pre_image, FD_PING_PRE_IMAGE_SZ, FD_KEYGUARD_SIGN_TYPE_SHA256_ED25519 );
 
   fd_gossip_send(glob, from, &gmsg);
 }
@@ -752,7 +753,7 @@ fd_gossip_sign_crds_value( fd_gossip_t * glob, fd_crds_value_t * crd ) {
     return;
   }
 
-  (*glob->sign_fun)(glob->sign_arg, crd->signature.uc, buf, (ulong)((uchar*)ctx.data - buf));
+  (*glob->sign_fun)( glob->sign_arg, crd->signature.uc, buf, (ulong)((uchar*)ctx.data - buf), FD_KEYGUARD_SIGN_TYPE_ED25519 );
 }
 
 /* Convert a hash to a bloom filter bit position */
@@ -1753,7 +1754,7 @@ fd_gossip_make_prune( fd_gossip_t * glob, fd_pending_event_arg_t * arg ) {
       return;
     }
 
-    (*glob->sign_fun)(glob->sign_arg, prune_msg->data.signature.uc, buf, (ulong)((uchar*)ctx.data - buf));
+    (*glob->sign_fun)( glob->sign_arg, prune_msg->data.signature.uc, buf, (ulong)((uchar*)ctx.data - buf), FD_KEYGUARD_SIGN_TYPE_ED25519 );
 
     fd_gossip_send(glob, &peerval->key, &gmsg);
   }

--- a/src/flamenco/gossip/fd_gossip.h
+++ b/src/flamenco/gossip/fd_gossip.h
@@ -40,7 +40,7 @@ typedef void (*fd_gossip_data_deliver_fun)(fd_crds_data_t* data, void* arg);
 typedef void (*fd_gossip_send_packet_fun)( uchar const * msg, size_t msglen, fd_gossip_peer_addr_t const * addr, void * arg );
 
 /* Callback for signing */
-typedef void (*fd_gossip_sign_fun)( void * ctx, uchar * sig, uchar const * buffer, ulong len );
+typedef void (*fd_gossip_sign_fun)( void * ctx, uchar * sig, uchar const * buffer, ulong len, int sign_type );
 
 struct fd_gossip_config {
     fd_pubkey_t * public_key;

--- a/src/flamenco/repair/fd_repair.h
+++ b/src/flamenco/repair/fd_repair.h
@@ -40,7 +40,7 @@ typedef ulong (*fd_repair_serv_get_parent_fun)( ulong slot, void * arg );
 typedef void (*fd_repair_send_packet_fun)( uchar const * msg, size_t msglen, fd_repair_peer_addr_t const * addr, void * arg );
 
 /* Callback signing */
-typedef void (*fd_repair_sign_fun)( void * ctx, uchar * sig, uchar const * buffer, ulong len );
+typedef void (*fd_repair_sign_fun)( void * ctx, uchar * sig, uchar const * buffer, ulong len, int sign_type );
 
 /* Callback for when a request fails. Echoes back the request parameters. */
 typedef void (*fd_repair_shred_deliver_fail_fun)( fd_pubkey_t const * id, ulong slot, uint shred_index, void * arg, int reason );

--- a/verification/proofs/keyguard/authorize/Makefile
+++ b/verification/proofs/keyguard/authorize/Makefile
@@ -1,0 +1,13 @@
+HARNESS_ENTRY = harness
+HARNESS_FILE = fd_keyguard_authorize_proof
+PROOF_UID = fd_keyguard_authorize
+
+INCLUDES += -I$(SRCDIR)
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/disco/keyguard/fd_keyguard_authorize.c
+PROJECT_SOURCES += $(SRCDIR)/disco/keyguard/fd_keyguard_match.c
+
+UNWINDSET += memcmp.0:1024
+
+include ../../Makefile.common

--- a/verification/proofs/keyguard/authorize/fd_keyguard_authorize_proof.c
+++ b/verification/proofs/keyguard/authorize/fd_keyguard_authorize_proof.c
@@ -1,0 +1,56 @@
+#include <disco/keyguard/fd_keyguard.h>
+#include <stdlib.h>
+#include <assert.h>
+
+/* fd_keyguard_authorize_proof proves that the keyguard authorizer is
+   free of undefined behavior. */
+
+void
+fd_log_private_1( int          level,
+                  long         now,
+                  char const * file,
+                  int          line,
+                  char const * func,
+                  char const * msg ) {}
+
+
+void
+fd_log_private_2( int          level,
+                  long         now,
+                  char const * file,
+                  int          line,
+                  char const * func,
+                  char const * msg ) __attribute__((noreturn)) {
+  __CPROVER_assert( 0, "Error log used" );
+}
+
+long
+fd_log_wallclock( void ) {
+  long t;
+  return t;
+}
+
+char const *
+fd_log_private_0( char const * fmt, ... ) {
+  (void)fmt;
+  return "";
+}
+
+
+void
+harness( void ) {
+  ulong size;
+  uchar * buf = malloc( size );
+  if( !buf ) return;
+
+  int sign_type;
+  __CPROVER_assume( sign_type==FD_KEYGUARD_SIGN_TYPE_ED25519 ||
+                    sign_type==FD_KEYGUARD_SIGN_TYPE_SHA256_ED25519 );
+
+  int role;
+  __CPROVER_assume( role >= 0 && role < FD_KEYGUARD_ROLE_CNT );
+
+  fd_keyguard_authority_t authority;
+  int res = fd_keyguard_payload_authorize( &authority, buf, size, role, sign_type );
+  assert( res==0 || res==1 );
+}


### PR DESCRIPTION
Previously, support for ed25519_sign(sha256(x)) signing was
implemented ad-hoc in a way that broke ambiguity proofs.

This patch adds the signature scheme as an explicit param to the
signing request body.  Also removes various arbitrary hardcoded
parameters and edge cases from the sign tile.
