### PR TITLE
QUIC - fix to ensure RETRY tokens include a per-instance secret so clients cannot spoof the token

### DIFF
--- a/src/waltz/quic/crypto/fd_quic_crypto_suites.h
+++ b/src/waltz/quic/crypto/fd_quic_crypto_suites.h
@@ -159,6 +159,10 @@ extern uchar FD_QUIC_CRYPTO_V1_INITIAL_SALT[ 20UL ];
 #define FD_QUIC_RETRY_TOKEN_HKDF_KEY_SZ 32
 /* retry token = prepended random bytes + encrypted ciphertext + appended authentication tag */
 #define FD_QUIC_RETRY_TOKEN_SZ (FD_QUIC_RETRY_TOKEN_HKDF_KEY_SZ + FD_QUIC_RETRY_TOKEN_PLAINTEXT_SZ + FD_QUIC_CRYPTO_TAG_SZ)
+/* RETRY secret size in bytes */
+#define FD_QUIC_RETRY_SECRET_SZ 32
+/* RETRY iv size in bytes */
+#define FD_QUIC_RETRY_IV_SZ 12
 /* 256-bit output from HKDF */
 #define FD_QUIC_RETRY_TOKEN_AEAD_KEY_SZ 32
 /* HKFD application-specific context (similar to a salt) */
@@ -504,22 +508,26 @@ fd_quic_crypto_lookup_suite( uchar major,
     original Solana validator client), though a similar HKDF + AEAD scheme is used in other
     implementations as well (quic-go, msquic). The differences are mainly what metadata is passed
     to AEAD as plaintext vs. as associated data. */
-int fd_quic_retry_token_encrypt(
+int
+fd_quic_retry_token_encrypt(
+    uchar const               retry_secret[static FD_QUIC_RETRY_SECRET_SZ],
     /* plaintext (timestamp calculated in function) */
     fd_quic_conn_id_t const * orig_dst_conn_id,
-    ulong               now,
+    ulong                     now,
     /* aad */
     fd_quic_conn_id_t const * retry_src_conn_id,
-    uint                ip_addr,
-    ushort              udp_port,
+    uint                      ip_addr,
+    ushort                    udp_port,
     /* ciphertext */
-    uchar retry_token[static FD_QUIC_RETRY_TOKEN_SZ]
+    uchar                     retry_token[static FD_QUIC_RETRY_TOKEN_SZ]
 );
 
 /* Decrypt a retry token, and checks it for validity (see `fd_quic_retry_token_encrypt`). */
-int fd_quic_retry_token_decrypt(
+int
+fd_quic_retry_token_decrypt(
+    uchar const         retry_secret[static FD_QUIC_RETRY_SECRET_SZ],
     /* ciphertext */
-    uchar * retry_token,
+    uchar               retry_token[static FD_QUIC_RETRY_TOKEN_SZ],
     /* aad */
     fd_quic_conn_id_t * retry_src_conn_id,
     uint                ip_addr,

--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -503,6 +503,13 @@ fd_quic_init( fd_quic_t * quic ) {
 
   fd_rng_new( state->_rng, 0UL, 0UL );
 
+  /* use rng to generate secret bytes for future RETRY token generation */
+  fd_rng_t * rng = fd_rng_join( state->_rng );
+  for( ulong j = 0; j < FD_QUIC_RETRY_SECRET_SZ; ++j ) {
+    state->retry_secret[j] = fd_rng_uchar( rng );
+  }
+  fd_rng_leave( rng );
+
   /* Initialize crypto */
 
   fd_quic_crypto_ctx_init( state->crypto_ctx );
@@ -1195,9 +1202,12 @@ fd_quic_send_retry( fd_quic_t *                  quic,
   uint saddr = 0;
   memcpy( &saddr, pkt->ip4->saddr_c, 4 );
 
+  fd_quic_state_t * state = fd_quic_get_state( quic );
+
   /* Retry token */
   ulong now = fd_quic_get_state( quic )->now;
   int   rc  = fd_quic_retry_token_encrypt(
+      state->retry_secret,
       orig_dst_conn_id,
       now,
       new_conn_id,
@@ -1491,7 +1501,8 @@ fd_quic_handle_v1_initial( fd_quic_t *               quic,
 
         fd_quic_conn_id_t orig_dst_conn_id;
         ulong issued = 0UL;
-        if( FD_UNLIKELY( fd_quic_retry_token_decrypt( (uchar*)initial->token,
+        if( FD_UNLIKELY( fd_quic_retry_token_decrypt( state->retry_secret,
+                                                      (uchar*)initial->token,
                                                       retry_src_conn_id,
                                                       dst_ip_addr,
                                                       dst_udp_port,

--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -112,6 +112,9 @@ struct __attribute__((aligned(16UL))) fd_quic_state_private {
   /* last arp/routing tables update */
   ulong ip_table_upd;
 
+  /* secret for generating RETRY tokens */
+  uchar retry_secret[FD_QUIC_RETRY_SECRET_SZ];
+
   /* Scratch space for packet protection */
   uchar                   crypt_scratch[FD_QUIC_MTU];
 };


### PR DESCRIPTION
Added a random server secret to the quic `state`
This secret is xor'ed with the random nonce and the result used to generate the keys. This way the client should not be able to determine the secret, nor generate the keys. 
Also, the IV initialization vector used to launch the GCM counter sequence has been initialized with a hash of some of the entropy. This is simply to avoid using the same sequence every time. A constant IV is strongly discouraged.

Probably we should look at simplifying this RETRY logic.