### PR TITLE
rewards: eliminate unnecessary malloc

### DIFF
--- a/src/flamenco/rewards/fd_rewards_types.h
+++ b/src/flamenco/rewards/fd_rewards_types.h
@@ -73,7 +73,7 @@ typedef struct fd_validator_reward_calculation fd_validator_reward_calculation_t
 struct fd_partitioned_rewards_calculation {
     /* VoteRewardsAccount */
     fd_vote_reward_t_mapnode_t * vote_account_rewards;
-    fd_stake_rewards_vector_t * stake_rewards_by_partition;
+    fd_stake_rewards_vector_t stake_rewards_by_partition[1];
     ulong total_stake_rewards_lamports;
     ulong old_vote_balance_and_staked;
     ulong validator_rewards;
@@ -107,14 +107,14 @@ typedef struct fd_calculate_stake_points fd_calculate_stake_points_t;
 struct fd_calculate_rewards_and_distribute_vote_rewards_result {
   ulong total_rewards;
   ulong distributed_rewards;
-  fd_stake_rewards_vector_t * stake_rewards_by_partition;
+  fd_stake_rewards_vector_t stake_rewards_by_partition[1];
 };
 typedef struct fd_calculate_rewards_and_distribute_vote_rewards_result fd_calculate_rewards_and_distribute_vote_rewards_result_t;
 
 struct fd_epoch_reward_status {
   uint is_active;
   ulong start_block_height;
-  fd_stake_rewards_vector_t * stake_rewards_by_partition;
+  fd_stake_rewards_vector_t stake_rewards_by_partition[1];
 };
 typedef struct fd_epoch_reward_status fd_epoch_reward_status_t;
 

--- a/src/flamenco/runtime/context/fd_exec_slot_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_slot_ctx.c
@@ -263,7 +263,7 @@ fd_exec_slot_ctx_recover_( fd_exec_slot_ctx_t *   slot_ctx,
 
     fd_vote_accounts_pair_t_mapnode_t * pool = stakes1->stakes.vote_accounts.vote_accounts_pool;
     fd_vote_accounts_pair_t_mapnode_t * root = stakes1->stakes.vote_accounts.vote_accounts_root;
-    
+
     // Delete all nodes from existing
     fd_vote_accounts_pair_t_map_release_tree( epoch_bank->next_epoch_stakes.vote_accounts_pool, epoch_bank->next_epoch_stakes.vote_accounts_root );
 
@@ -315,9 +315,6 @@ fd_exec_slot_ctx_free( fd_exec_slot_ctx_t * slot_ctx ) {
 
   /* leader points to a caller-allocated leader schedule */
 
-  /* free vec in stake rewards*/
-  if( NULL != slot_ctx->epoch_reward_status.stake_rewards_by_partition )
-    fd_stake_rewards_vector_destroy( slot_ctx->epoch_reward_status.stake_rewards_by_partition );
-
+  fd_stake_rewards_vector_destroy( slot_ctx->epoch_reward_status.stake_rewards_by_partition );
   fd_exec_slot_ctx_delete( fd_exec_slot_ctx_leave( slot_ctx ) );
 }

--- a/src/flamenco/runtime/fd_vector.h
+++ b/src/flamenco/runtime/fd_vector.h
@@ -19,6 +19,7 @@ void VECT_(new)(struct VECT_NAME* self) {
 static inline
 void VECT_(destroy)(struct VECT_NAME* self) {
   free(self->elems);
+  self->elems = NULL;
 }
 
 static inline


### PR DESCRIPTION
The fd_vector structure is fixed-size. It is unnecessary to allocate it on the heap.