### PR TITLE
VM: updating is writable check in CPI

### DIFF
--- a/src/flamenco/runtime/tests/run_ledger_tests_all.txt
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.txt
@@ -27,3 +27,4 @@ src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-266134813 -s snapshot-
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-266545736 -s snapshot-266545735-6FUAw2xdpPSw166xyWYpnXNqXogNkb1yPANZZiUqakK2.tar.zst -p 16 -y 16 -m 5000000 -e 266545737
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-267059180 -s snapshot-267059179-93LQKWDQZRKdw44JLy1BwwwSh4gTp26zUkAfGdPRBRjJ.tar.zst -p 16 -y 16 -m 5000000 -e 267059181
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-267580466 -s snapshot-267580465-EWeMRpeNFC9ue4qD6EFS6SkFrVJwmKnrSrwDHKLRr73h.tar.zst -p 16 -y 16 -m 5000000 -e 267580467
+src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-268196194 -s snapshot-268196193-57VFX99qvEzdE6aQ5GYMsa4ZdMJFawM657seKjWs7oMe.tar.zst -p 16 -y 16 -m 5000000 -e 268196195

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
@@ -160,15 +160,13 @@ fd_vm_prepare_instruction( fd_instr_info_t const *  caller_instr,
     fd_pubkey_t const * pubkey = &caller_instr->acct_pubkeys[instruction_account->index_in_caller];
 
     /* Check that the account is not read-only in the caller but writable in the callee */
-    if ( FD_UNLIKELY( instruction_account->is_writable && !fd_instr_acc_is_writable(instr_ctx->instr, pubkey) ) ) {
-      /* TODO: return InstructionError::PrivilegeEscalation */
-      return 1;
+    if( FD_UNLIKELY( instruction_account->is_writable && !fd_instr_acc_is_writable( instr_ctx->instr, pubkey ) ) ) {
+      return FD_EXECUTOR_INSTR_ERR_PRIVILEGE_ESCALATION;
     }
 
     /* If the account is signed in the callee, it must be signed by the caller or the program */
-    if ( FD_UNLIKELY( instruction_account->is_signer && !(fd_instr_acc_is_signer(instr_ctx->instr, pubkey) || fd_vm_syscall_cpi_is_signer(pubkey, signers, signers_cnt)) ) ) {
-      /* TODO: return InstructionError::PrivilegeEscalation */
-      return 1;
+    if ( FD_UNLIKELY( instruction_account->is_signer && !( fd_instr_acc_is_signer( instr_ctx->instr, pubkey ) || fd_vm_syscall_cpi_is_signer( pubkey, signers, signers_cnt) ) ) ) {
+      return FD_EXECUTOR_INSTR_ERR_PRIVILEGE_ESCALATION;
     }
   }
 

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
@@ -63,11 +63,11 @@ VM_SYSCALL_CPI_INSTRUCTION_TO_INSTR_FUNC( fd_vm_t * vm,
       if( !memcmp( pubkey, &txn_accs[j], sizeof( fd_pubkey_t ) ) ) {
         /* TODO: error if not found, if flags are wrong */
         memcpy( out_instr->acct_pubkeys[i].uc, pubkey, sizeof( fd_pubkey_t ) );
-        out_instr->acct_txn_idxs[i] = (uchar)j;
-        out_instr->acct_flags[i] = 0;
+        out_instr->acct_txn_idxs[i]     = (uchar)j;
+        out_instr->acct_flags[i]        = 0;
         out_instr->borrowed_accounts[i] = &vm->instr_ctx->txn_ctx->borrowed_accounts[j];
+        out_instr->is_duplicate[i]      = acc_idx_seen[j];
 
-        out_instr->is_duplicate[i] = acc_idx_seen[j];
         if( FD_LIKELY( !acc_idx_seen[j] ) ) {
           /* This is the first time seeing this account */
           acc_idx_seen[j] = 1;
@@ -80,12 +80,11 @@ VM_SYSCALL_CPI_INSTRUCTION_TO_INSTR_FUNC( fd_vm_t * vm,
           }
         }
 
-        /* TODO: should check the parent has writable flag set */
-        if( VM_SYSCALL_CPI_ACC_META_IS_WRITABLE( cpi_acct_meta ) && fd_instr_acc_is_writable( vm->instr_ctx->instr, (fd_pubkey_t*)pubkey) ) {
+        /* The parent flag(s) for is writable/signer is checked in fd_vm_prepare_instruction */
+        if( VM_SYSCALL_CPI_ACC_META_IS_WRITABLE( cpi_acct_meta ) ) {
           out_instr->acct_flags[i] |= FD_INSTR_ACCT_FLAGS_IS_WRITABLE;
         }
 
-        /* TODO: should check the parent has signer flag set */
         if( VM_SYSCALL_CPI_ACC_META_IS_SIGNER( cpi_acct_meta ) ) {
           out_instr->acct_flags[i] |= FD_INSTR_ACCT_FLAGS_IS_SIGNER;
         } else {
@@ -466,7 +465,7 @@ VM_SYSCALL_CPI_ENTRYPOINT( void *  _vm,
      before we can pass an instruction to the executor. */
   fd_instruction_account_t instruction_accounts[256];
   ulong instruction_accounts_cnt;
-  err = fd_vm_prepare_instruction(vm->instr_ctx->instr, &instruction_to_execute, vm->instr_ctx, instruction_accounts, &instruction_accounts_cnt, signers, signers_seeds_cnt );
+  err = fd_vm_prepare_instruction( vm->instr_ctx->instr, &instruction_to_execute, vm->instr_ctx, instruction_accounts, &instruction_accounts_cnt, signers, signers_seeds_cnt );
   if( FD_UNLIKELY( err ) ) return err;
 
   /* Update the callee accounts with any changes made by the caller prior to this CPI execution */


### PR DESCRIPTION
When we set the writable flag for an account during a CPI setup, we previously checked the caller account before we set the flag. Instead we need to set the flag without checking the caller and error out after the fact during the vm prepare