### PR TITLE
deploy_mode flag in ELF Loader

### DIFF
--- a/src/ballet/sbpf/fd_sbpf_loader.h
+++ b/src/ballet/sbpf/fd_sbpf_loader.h
@@ -11,6 +11,7 @@
 
 #include "../../util/fd_util_base.h"
 #include "../elf/fd_elf64.h"
+#include <stdbool.h>
 
 /* Error types ********************************************************/
 
@@ -128,12 +129,18 @@ FD_PROTOTYPES_BEGIN
 
 /* fd_sbpf_elf_peek partially parses the given ELF file in memory region
    [bin,bin+bin_sz)  Populates `info`.  Returns `info` on success.  On
-   failure, returns NULL. */
+   failure, returns NULL. 
+   
+   elf_deploy_checks: The Agave ELF loader introduced additional checks 
+   that would fail on (certain) existing mainnet programs. Since it is
+   impossible to retroactively enforce these checks on already deployed programs,
+   a guard flag is used to enable these checks only when deploying programs. */
 
 fd_sbpf_elf_info_t *
 fd_sbpf_elf_peek( fd_sbpf_elf_info_t * info,
                   void const *         bin,
-                  ulong                bin_sz );
+                  ulong                bin_sz,
+                  bool                 elf_deploy_checks );
 
 /* fd_sbpf_program_{align,footprint} return the alignment and size
    requirements of the memory region backing the fd_sbpf_program_t
@@ -180,7 +187,7 @@ fd_sbpf_program_new( void *                     prog_mem,
 
      new_elf_parser:     true
      enable_elf_vaddr:   false
-     reject_broken_elfs: true
+     reject_broken_elfs: elf_deploy_checks
 
    For documentation on these config params, see:
    https://github.com/solana-labs/rbpf/blob/v0.3.0/src/vm.rs#L198 */
@@ -189,7 +196,8 @@ int
 fd_sbpf_program_load( fd_sbpf_program_t *  prog,
                       void const *         bin,
                       ulong                bin_sz,
-                      fd_sbpf_syscalls_t * syscalls );
+                      fd_sbpf_syscalls_t * syscalls,
+                      bool                 elf_deploy_checks );
 
 /* fd_sbpf_program_delete destroys the program object and unformats the
    memory regions holding it. */

--- a/src/ballet/sbpf/fuzz_sbpf_loader.c
+++ b/src/ballet/sbpf/fuzz_sbpf_loader.c
@@ -34,7 +34,7 @@ LLVMFuzzerTestOneInput( uchar const * data,
                         ulong         size ) {
 
   fd_sbpf_elf_info_t info;
-  if( FD_UNLIKELY( !fd_sbpf_elf_peek( &info, data, size ) ) )
+  if( FD_UNLIKELY( !fd_sbpf_elf_peek( &info, data, size, true ) ) )
     return -1;
 
   /* Allocate objects */
@@ -52,7 +52,7 @@ LLVMFuzzerTestOneInput( uchar const * data,
     fd_sbpf_syscalls_insert( syscalls, *x );
 
   /* Load program */
-  int res = fd_sbpf_program_load( prog, data, size, syscalls );
+  int res = fd_sbpf_program_load( prog, data, size, syscalls, true );
 
   /* Should be able to load at least one program and not load at least one program */
   if ( FD_UNLIKELY( !res ) ) {

--- a/src/ballet/sbpf/test_sbpf_load_prog.c
+++ b/src/ballet/sbpf/test_sbpf_load_prog.c
@@ -63,7 +63,7 @@ main( int     argc,
   /* Extract ELF info */
 
   fd_sbpf_elf_info_t elf_info;
-  if( FD_UNLIKELY( !fd_sbpf_elf_peek( &elf_info, bin_buf, bin_sz ) ) )
+  if( FD_UNLIKELY( !fd_sbpf_elf_peek( &elf_info, bin_buf, bin_sz, true ) ) )
     FD_LOG_ERR(( "FAIL: %s", fd_sbpf_strerror() ));
 
   /* Allocate rodata segment */
@@ -91,7 +91,7 @@ main( int     argc,
   for( uint const * x = _syscalls; *x; x++ )
     fd_sbpf_syscalls_insert( syscalls, *x );
 
-  int load_err = fd_sbpf_program_load( prog, bin_buf, bin_sz, syscalls );
+  int load_err = fd_sbpf_program_load( prog, bin_buf, bin_sz, syscalls, true );
 
   FD_LOG_HEXDUMP_NOTICE(( "Output rodata segment", prog->rodata, prog->rodata_sz ));
 

--- a/src/ballet/sbpf/test_sbpf_loader.c
+++ b/src/ballet/sbpf/test_sbpf_loader.c
@@ -39,7 +39,7 @@ void test_duplicate_entrypoint_entry( void ) {
   fd_valloc_t valloc = fd_scratch_virtual();
   fd_sbpf_elf_info_t info;
 
-  fd_sbpf_elf_peek( &info, duplicate_entrypoint_entry_elf, duplicate_entrypoint_entry_elf_sz );
+  fd_sbpf_elf_peek( &info, duplicate_entrypoint_entry_elf, duplicate_entrypoint_entry_elf_sz, true );
 
   void* rodata = fd_valloc_malloc( valloc, 8UL, info.rodata_footprint );
   FD_TEST( rodata );
@@ -52,7 +52,7 @@ void test_duplicate_entrypoint_entry( void ) {
   for( uint const * x = _syscalls; *x; x++ )
       fd_sbpf_syscalls_insert( syscalls, *x );
   
-  int res = fd_sbpf_program_load( prog, duplicate_entrypoint_entry_elf, duplicate_entrypoint_entry_elf_sz, syscalls );
+  int res = fd_sbpf_program_load( prog, duplicate_entrypoint_entry_elf, duplicate_entrypoint_entry_elf_sz, syscalls, true);
   FD_TEST( res == 0 );
 
   // end of boilerplate

--- a/src/flamenco/runtime/program/fd_bpf_loader_v2_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v2_program.c
@@ -59,7 +59,7 @@ fd_bpf_loader_v2_user_execute( fd_exec_instr_ctx_t ctx ) {
 
   long dt = -fd_log_wallclock();
   fd_sbpf_elf_info_t elf_info;
-  if (fd_sbpf_elf_peek( &elf_info, program_data, program_data_len ) == NULL) {
+  if (fd_sbpf_elf_peek( &elf_info, program_data, program_data_len, false ) == NULL) {
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
   }
 
@@ -83,7 +83,7 @@ fd_bpf_loader_v2_user_execute( fd_exec_instr_ctx_t ctx ) {
   fd_vm_syscall_register_all( syscalls );
   /* Load program */
 
-  if(  0!=fd_sbpf_program_load( prog, program_data, program_data_len, syscalls ) ) {
+  if(  0!=fd_sbpf_program_load( prog, program_data, program_data_len, syscalls, false ) ) {
     FD_LOG_ERR(( "fd_sbpf_program_load() failed: %s", fd_sbpf_strerror() ));
   }
   dt += fd_log_wallclock();

--- a/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
@@ -111,6 +111,7 @@ int
 deploy_program( fd_exec_instr_ctx_t * instr_ctx,
                 uchar * const         programdata,
                 ulong                 programdata_size ) {   
+  bool deploy_mode = true;
   fd_sbpf_syscalls_t * syscalls = fd_sbpf_syscalls_new( fd_scratch_alloc( fd_sbpf_syscalls_align(),
                                                                           fd_sbpf_syscalls_footprint() ) );
   if( FD_UNLIKELY( !syscalls ) ) {
@@ -121,7 +122,7 @@ deploy_program( fd_exec_instr_ctx_t * instr_ctx,
 
   /* Load executable */
   fd_sbpf_elf_info_t  _elf_info[ 1UL ];
-  fd_sbpf_elf_info_t * elf_info = fd_sbpf_elf_peek( _elf_info, programdata, programdata_size );
+  fd_sbpf_elf_info_t * elf_info = fd_sbpf_elf_peek( _elf_info, programdata, programdata_size, deploy_mode );
   if( FD_UNLIKELY( !elf_info ) ) {
     FD_LOG_WARNING(( "Elf info failing" ));
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
@@ -142,7 +143,7 @@ deploy_program( fd_exec_instr_ctx_t * instr_ctx,
   } 
 
   /* Load program */
-  if( FD_UNLIKELY( fd_sbpf_program_load( prog, programdata, programdata_size, syscalls ) ) ) {
+  if( FD_UNLIKELY( fd_sbpf_program_load( prog, programdata, programdata_size, syscalls, deploy_mode ) ) ) {
     FD_LOG_ERR(( "fd_sbpf_program_load() failed: %s", fd_sbpf_strerror() ));
   }
 

--- a/src/flamenco/runtime/program/fd_bpf_program_util.c
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.c
@@ -135,7 +135,7 @@ fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t * slot_ctx,
     }
 
     fd_sbpf_elf_info_t elf_info;
-    if( fd_sbpf_elf_peek( &elf_info, program_data, program_data_len ) == NULL ) {
+    if( fd_sbpf_elf_peek( &elf_info, program_data, program_data_len, false ) == NULL ) {
       FD_LOG_WARNING(( "fd_sbpf_elf_peek() failed: %s", fd_sbpf_strerror() ));
       return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
     }
@@ -165,7 +165,7 @@ fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t * slot_ctx,
 
     /* Load program */
 
-    if( 0!=fd_sbpf_program_load( prog, program_data, program_data_len, syscalls ) ) {
+    if( 0!=fd_sbpf_program_load( prog, program_data, program_data_len, syscalls, false ) ) {
       FD_LOG_DEBUG(( "fd_sbpf_program_load() failed: %s", fd_sbpf_strerror() ));
       return -1;
     }

--- a/src/flamenco/vm/fd_vm_tool.c
+++ b/src/flamenco/vm/fd_vm_tool.c
@@ -49,7 +49,7 @@ fd_vm_tool_prog_create( fd_vm_tool_prog_t * tool_prog,
   /* Extract ELF info */
 
   fd_sbpf_elf_info_t elf_info;
-  FD_TEST( fd_sbpf_elf_peek( &elf_info, bin_buf, bin_sz ) );
+  FD_TEST( fd_sbpf_elf_peek( &elf_info, bin_buf, bin_sz, false ) );
 
   /* Allocate rodata segment */
 
@@ -71,7 +71,7 @@ fd_vm_tool_prog_create( fd_vm_tool_prog_t * tool_prog,
   fd_vm_syscall_register_all( syscalls );
 
   /* Load program */
-  if( FD_UNLIKELY( 0!=fd_sbpf_program_load( prog, bin_buf, bin_sz, syscalls ) ) )
+  if( FD_UNLIKELY( 0!=fd_sbpf_program_load( prog, bin_buf, bin_sz, syscalls, false ) ) )
     FD_LOG_ERR(( "fd_sbpf_program_load() failed: %s", fd_sbpf_strerror() ));
 
   tool_prog->bin_buf  = bin_buf;


### PR DESCRIPTION
The Agave ELF loader introduced additional checks that would fail on (certain) existing mainnet programs. Since it is impossible to retroactively enforce these checks on already deployed programs, a guard flag is used to enable these checks only when deploying programs. This PR implements the equivalent for FD.