### PR TITLE
ci: build fdctl

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,16 +17,15 @@ jobs:
       # targets from here, not add more.
       matrix:
         machine:
-          - linux_gcc_noarch64    # least capable target
-          - linux_gcc_icelake     # most capable target
+          - linux_gcc_x86_64      # least capable target
+          - linux_gcc_icelake     #  most capable target
           - linux_clang_x86_64
           - linux_clang_icelake
           - native
         # Attach additional params to machine types
         include:
-          - machine: linux_gcc_noarch64
-            notest: true
-            label: self-hosted
+          - machine: linux_gcc_x86_64
+            label: X64
           - machine: linux_gcc_icelake
             label: icelake
           - machine: linux_clang_x86_64

--- a/contrib/test/ci_tests.sh
+++ b/contrib/test/ci_tests.sh
@@ -29,7 +29,7 @@ for MACHINE in ${MACHINES[*]}; do
   OBJDIR="$(make help | grep OBJDIR | awk '{print $4}')"
   OBJDIRS+=( "${OBJDIR}" )
   make clean --silent >/dev/null
-  contrib/make-j all integration-test
+  contrib/make-j all integration-test fdctl
   if [[ "$NOTEST" != 1 ]]; then
     make run-unit-test
     if [[ "$EXTRAS" != *"ubsan"* && "$EXTRAS" != *"asan"* ]]; then

--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -1,6 +1,8 @@
 ifdef FD_HAS_HOSTED
 ifdef FD_HAS_ALLOCA
 ifdef FD_HAS_DOUBLE
+ifdef FD_HAS_INT128
+ifdef FD_HAS_SSE
 
 include src/app/fdctl/with-version.mk
 $(info Using FIREDANCER_VERSION=$(FIREDANCER_VERSION_MAJOR).$(FIREDANCER_VERSION_MINOR).$(FIREDANCER_VERSION_PATCH))
@@ -128,6 +130,8 @@ $(OBJDIR)/bin/solana: solana/target/$(RUST_PROFILE)/solana
 
 solana: $(OBJDIR)/bin/solana $(OBJDIR)/bin/solana
 
+endif
+endif
 endif
 endif
 endif

--- a/src/app/fdctl/run/topos/fd_firedancer.c
+++ b/src/app/fdctl/run/topos/fd_firedancer.c
@@ -1,5 +1,5 @@
 /* Firedancer topology used for testing the full validator.
-   Associated test script: test-firedancer.sh */
+   Associated test script: test_firedancer.sh */
 #include "topos.h"
 #include "../tiles/tiles.h"
 #include "../../config.h"

--- a/src/disco/consensus/Local.mk
+++ b/src/disco/consensus/Local.mk
@@ -1,4 +1,6 @@
 ifdef FD_HAS_INT128
+ifdef FD_HAS_SECP256K1
 $(call make-unit-test,test_consensus,test_consensus,fd_disco fd_choreo fd_flamenco fd_funk fd_tango fd_util fd_ballet fd_reedsol fd_waltz,$(SECP256K1_LIBS))
 $(call make-unit-test,test_gossip_echo_vote,test_gossip_echo_vote,fd_disco fd_choreo fd_flamenco fd_funk fd_tango fd_util fd_ballet fd_reedsol fd_waltz,$(SECP256K1_LIBS))
+endif
 endif

--- a/src/flamenco/fd_flamenco.c
+++ b/src/flamenco/fd_flamenco.c
@@ -45,7 +45,7 @@ fd_printf_specifier_base58_arginfo( struct printf_info const * info __attribute_
   return 1;
 }
 
-# if FD_HAS_INT128
+#if FD_HAS_INT128
 
 static int
 fd_printf_specifier_uint128( FILE *                     stream,

--- a/src/flamenco/runtime/tests/Local.mk
+++ b/src/flamenco/runtime/tests/Local.mk
@@ -2,11 +2,13 @@ $(call add-hdrs,fd_exec_test.pb.h)
 $(call add-objs,fd_exec_test.pb,fd_flamenco)
 
 ifdef FD_HAS_INT128
+ifdef FD_HAS_SECP256K1
 $(call add-hdrs,fd_exec_instr_test.h)
 $(call add-objs,fd_exec_instr_test,fd_flamenco)
 
 $(call make-unit-test,test_exec_instr,test_exec_instr,fd_flamenco fd_funk fd_ballet fd_util,$(SECP256K1_LIBS))
 $(call make-shared,libfd_exec_sol_compat.so,fd_exec_sol_compat,fd_flamenco fd_funk fd_ballet fd_util,$(SECP256K1_LIBS))
+endif
 endif
 
 run-runtime-test: $(OBJDIR)/bin/fd_ledger

--- a/src/flamenco/vm/Local.mk
+++ b/src/flamenco/vm/Local.mk
@@ -3,7 +3,9 @@ $(call add-hdrs,fd_vm_context.h fd_vm_disasm.h fd_vm_interp.h fd_vm_log_collecto
 $(call add-objs,fd_vm_context fd_vm_disasm fd_vm_interp fd_vm_log_collector fd_vm_stack fd_vm_syscalls fd_vm_trace,fd_flamenco)
 
 ifdef FD_HAS_HOSTED
+ifdef FD_HAS_SECP256K1
 $(call make-bin,fd_vm_tool,fd_vm_tool,fd_flamenco fd_funk fd_ballet fd_util,$(SECP256K1_LIBS))
+endif
 endif
 
 $(call make-unit-test,test_vm_cpi,test_vm_cpi,fd_util)


### PR DESCRIPTION
* We should build `fdctl` during our CI runs
* Based on requirements, we cannot build `fdctl` on `minimal`, `noarch64` or `noarch128`, hence the minimal capable build is updated to `linux_gcc_x86_64`
* We currently don't require secp256k so, added build conditions wherever that library is called during `all` target