### PR TITLE
book: fix incorrect deps.sh docs

### DIFF
--- a/book/guide/getting-started.md
+++ b/book/guide/getting-started.md
@@ -55,7 +55,7 @@ package manager on your system, while library dependencies will be
 compiled and output placed under `./opt`.
 
 ```sh [bash]
-$ FD_AUTO_INSTALL_PACKAGES=1 ./deps.sh check install
+$ ./deps.sh
 ```
 
 ## Building


### PR DESCRIPTION
Addresses some confusion reported by the community.

The deps.sh instructions in the book were incorrect because they
instructed users to install deps without fetching them first (which
results in an error).

Also removes the auto installation of system deps, reverting to
prompting the user.  This avoids potentially destructive actions
by the package manager.
