### PR TITLE
flamenco: adding error checks to bpf deserialize

### DIFF
--- a/src/flamenco/runtime/fd_account_old.h
+++ b/src/flamenco/runtime/fd_account_old.h
@@ -20,14 +20,11 @@ fd_account_get_data(fd_account_meta_t * m) {
   return ((char *) m) + m->hlen;
 }
 
-//    /// Returns true if the owner of this account is the current `InstructionContext`s last program (instruction wide)
+// TODO: Confirm if the program id pubkey actually corresponds to the 
+// Returns true if the owner of this account is the current `InstructionContext`s last program (instruction wide)
 static inline
-int fd_account_is_owned_by_current_program2(const FD_FN_UNUSED fd_exec_instr_ctx_t *ctx, const FD_FN_UNUSED fd_account_meta_t * acct, FD_FN_UNUSED  int *err) {
-//        self.instruction_context
-//            .get_last_program_key(self.transaction_context)
-//            .map(|key| key == self.get_owner())
-//            .unwrap_or_default()
-  return 1;
+int fd_account_is_owned_by_current_program2(const fd_exec_instr_ctx_t *ctx, const fd_account_meta_t * acct, FD_FN_UNUSED int *err) {
+  return memcmp( &ctx->instr->program_id_pubkey, acct->info.owner, sizeof(fd_pubkey_t) ) == 0;
 }
 
 static inline

--- a/src/flamenco/runtime/program/fd_bpf_loader_v2_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v2_program.c
@@ -170,10 +170,18 @@ if( FD_UNLIKELY( vm->trace ) ) {
     return -1;
   }
 
-  if (FD_UNLIKELY(memcmp(metadata->info.owner, fd_solana_bpf_loader_deprecated_program_id.key, sizeof(fd_pubkey_t)) == 0)) {
-    fd_bpf_loader_input_deserialize_unaligned(ctx, pre_lens, input, input_sz);
+  if( FD_UNLIKELY( memcmp( metadata->info.owner, fd_solana_bpf_loader_deprecated_program_id.key, sizeof(fd_pubkey_t) ) == 0 ) ) {
+    int err = fd_bpf_loader_input_deserialize_unaligned( ctx, pre_lens, input, input_sz );
+    fd_valloc_free( ctx.valloc, input );
+    if( FD_UNLIKELY( err ) ) {
+      return err;
+    }
   } else {
-    fd_bpf_loader_input_deserialize_aligned(ctx, pre_lens, input, input_sz);
+    int err = fd_bpf_loader_input_deserialize_aligned(ctx, pre_lens, input, input_sz);
+    fd_valloc_free( ctx.valloc, input );
+    if( FD_UNLIKELY( err ) ) {
+      return err;
+    }
   }
 
   return 0;

--- a/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
@@ -389,8 +389,10 @@ execute( fd_exec_instr_ctx_t * instr_ctx, fd_sbpf_validated_program_t * prog ) {
     return FD_EXECUTOR_INSTR_ERR_GENERIC_ERR;;
   }
 
-  if( FD_UNLIKELY( fd_bpf_loader_input_deserialize_aligned( *instr_ctx, pre_lens, input, input_sz )!=0 ) ) {
-    return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+  int err = fd_bpf_loader_input_deserialize_aligned( *instr_ctx, pre_lens, input, input_sz );
+  fd_valloc_free( instr_ctx->valloc, input );
+  if( FD_UNLIKELY( err ) ) {
+    return err;
   }
 
   return FD_EXECUTOR_INSTR_SUCCESS;

--- a/src/flamenco/runtime/tests/run_ledger_tests_all.txt
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.txt
@@ -30,3 +30,4 @@ src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-266545736 -s snapshot-
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-267059180 -s snapshot-267059179-93LQKWDQZRKdw44JLy1BwwwSh4gTp26zUkAfGdPRBRjJ.tar.zst -p 16 -y 16 -m 5000000 -e 267059181
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-267580466 -s snapshot-267580465-EWeMRpeNFC9ue4qD6EFS6SkFrVJwmKnrSrwDHKLRr73h.tar.zst -p 16 -y 16 -m 5000000 -e 267580467
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-268196194 -s snapshot-268196193-57VFX99qvEzdE6aQ5GYMsa4ZdMJFawM657seKjWs7oMe.tar.zst -p 16 -y 16 -m 5000000 -e 268196195
+src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-267085604 -s snapshot-267085603-6JYpKrZVkmvsNvr83xTB63UsYDspCLUgsSAZLgJJZ3we.tar.zst -p 16 -y 16 -m 5000000 -e 267085605


### PR DESCRIPTION
There was no check for an ownership in the deserialize which was causing a hash mismatch. Added other error checks as well