### PR TITLE
fd_store: pass is_trusted==false for shreds that come from the network

### DIFF
--- a/src/app/fdctl/external_functions.c
+++ b/src/app/fdctl/external_functions.c
@@ -20,7 +20,8 @@ fd_ext_blockstore_insert_shreds( void const *  blockstore FD_PARAM_UNUSED,
                                  ulong         shred_cnt FD_PARAM_UNUSED,
                                  uchar const * shred_bytes FD_PARAM_UNUSED,
                                  ulong         shred_sz FD_PARAM_UNUSED,
-                                 ulong         stride FD_PARAM_UNUSED ) { return 0; }
+                                 ulong         stride FD_PARAM_UNUSED,
+                                 int           is_trusted FD_PARAM_UNUSED ) { return 0; }
 
 extern int
 fd_ext_bank_sanitized_txn_load_addresess( void const * bank FD_PARAM_UNUSED,

--- a/src/app/fdctl/run/tiles/fd_shred.c
+++ b/src/app/fdctl/run/tiles/fd_shred.c
@@ -603,7 +603,7 @@ after_frag( void *             _ctx,
   s34[ fd_ulong_if( s34[ 3 ].shred_cnt>0UL, 3, 2 ) ].est_txn_cnt += ctx->shredded_txn_cnt - txn_per_s34*s34_cnt;
 
   /* Send to the blockstore, skipping any empty shred34_t s. */
-  ulong sig = 0UL;
+  ulong sig = in_idx!=NET_IN_IDX; /* sig==0 means the store tile will do extra checks */
   ulong tspub = fd_frag_meta_ts_comp( fd_tickcount() );
   fd_mux_publish( mux, sig, fd_laddr_to_chunk( ctx->store_out_mem, s34+0UL ), sizeof(fd_shred34_t), 0UL, ctx->tsorig, tspub );
   if( FD_UNLIKELY( s34[ 1 ].shred_cnt ) )

--- a/src/app/fdctl/run/tiles/fd_store.c
+++ b/src/app/fdctl/run/tiles/fd_store.c
@@ -73,7 +73,8 @@ fd_ext_blockstore_insert_shreds( void const *  blockstore,
                                  ulong         shred_cnt,
                                  uchar const * shred_bytes,
                                  ulong         shred_sz,
-                                 ulong         stride );
+                                 ulong         stride,
+                                 int           is_trusted );
 
 static inline void
 after_frag( void *             _ctx,
@@ -87,7 +88,6 @@ after_frag( void *             _ctx,
             fd_mux_context_t * mux ) {
   (void)in_idx;
   (void)seq;
-  (void)opt_sig;
   (void)opt_chunk;
   (void)opt_tsorig;
   (void)opt_filter;
@@ -105,7 +105,7 @@ after_frag( void *             _ctx,
   }
 
   /* No error code because this cannot fail. */
-  fd_ext_blockstore_insert_shreds( fd_ext_blockstore, shred34->shred_cnt, ctx->mem+shred34->offset, shred34->shred_sz, shred34->stride );
+  fd_ext_blockstore_insert_shreds( fd_ext_blockstore, shred34->shred_cnt, ctx->mem+shred34->offset, shred34->shred_sz, shred34->stride, !!*opt_sig );
 
   FD_MCNT_INC( STORE_TILE, TRANSACTIONS_INSERTED, shred34->est_txn_cnt );
 }


### PR DESCRIPTION
The shred tile does some of the `is_trusted` checks, but importantly does not do any of the duplicate shred checks, so we need to do these. Because we don't handle repair yet, it's not possible to move all the checks to the shred tile yet.