### PR TITLE
flamenco, vm: adding memory gap checks for address host translation

### DIFF
--- a/src/app/ledger/main.c
+++ b/src/app/ledger/main.c
@@ -858,6 +858,10 @@ replay( fd_ledger_args_t * args ) {
   fd_replay_t * replay = NULL;
   fd_tvu_main_setup( &state, &replay, NULL, NULL, 0, wksp, &runtime_args, NULL );
 
+  if( !args->on_demand_block_ingest ) {
+    ingest_rocksdb( args->alloc, args->rocksdb_dir, args->start_slot, args->end_slot, args->blockstore, 0, args->trash_hash );
+  }
+
   FD_LOG_WARNING(( "tvu main setup done" ));
 
   int ret = runtime_replay( &state, &runtime_args );

--- a/src/flamenco/runtime/tests/run_ledger_tests_all.txt
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.txt
@@ -26,3 +26,4 @@ src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-267728520 -s snapshot-
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-267651942 -s snapshot-267651941-7u1sT9iRtd26nJdk3CqywGmo857ufb715PSTmfrBxYiS.tar.zst -p 16 -y 16 -m 5000000 -e 267651943
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-267081197 -s snapshot-267081196-9qwnybW2TVKfpMKJXKwFwfeW81qX2voqJYxd4qEaHPQu.tar.zst -p 16 -y 16 -m 5000000 -e 267081198
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-267085604 -s snapshot-267085603-6JYpKrZVkmvsNvr83xTB63UsYDspCLUgsSAZLgJJZ3we.tar.zst -p 16 -y 16 -m 5000000 -e 267085605
+src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-265688706 -s snapshot-265688705-Hz56JjQuN4yfXGohYWMsYe2QJiTejQgGNLUaviVN16qP.tar.zst -p 16 -y 16 -m 5000000 -e 265688707

--- a/src/flamenco/vm/fd_vm_context.c
+++ b/src/flamenco/vm/fd_vm_context.c
@@ -172,9 +172,30 @@ fd_vm_translate_vm_to_host_private( fd_vm_exec_context_t *  ctx,
   ulong end_addr = start_addr + sz;
 
   ulong host_addr = 0UL;
+
+  /* https://github.com/solana-labs/rbpf/blob/b503a1867a9cfa13f93b4d99679a17fe219831de/src/memory_region.rs#L123-L133 */
+  /* https://github.com/firedancer-io/solana/blob/4546f4db6129e9c05601cf4782f5e7c404762b75/programs/bpf_loader/src/lib.rs#L350-L381 */
+  /* */
+  /* Note: vm gap shift is calculated when a memory region is created. However,
+     it is always == 63 unless the memory region is writable and gapped. This is
+     onlt the case for the stack region in memory which has a calculated value
+     of 12 for the vm_gap_shift. We know that it will always be 12 because the 
+     stack will always be the same size (4096) */
+  /* TODO: Currently the specific BPF error is not returned when there is a 
+     memory access violation. */
+  ulong vm_gap_shift = 0UL;
+  int is_in_gap = 0;
   switch( mem_region ) {
     case FD_VM_MEM_MAP_PROGRAM_REGION_START:
       /* Read-only program binary blob memory region */
+
+      /* TODO: This should be a checked shift for all gap checks */
+      vm_gap_shift = 63UL;
+      is_in_gap = ((start_addr>>vm_gap_shift)&1UL) == 1;
+      if( FD_UNLIKELY( is_in_gap ) ) {
+        return 0UL;
+      }
+
       if( FD_UNLIKELY( ( write                        )
                      | ( end_addr > ctx->read_only_sz ) ) ) {
         return 0UL;
@@ -184,6 +205,13 @@ fd_vm_translate_vm_to_host_private( fd_vm_exec_context_t *  ctx,
       break;
     case FD_VM_MEM_MAP_STACK_REGION_START:
       /* Stack memory region */
+
+      vm_gap_shift = 12UL;
+      is_in_gap = ((start_addr>>vm_gap_shift)&1UL) == 1;
+      if( FD_UNLIKELY( is_in_gap ) ) {
+        return 0UL;
+      }
+
       /* TODO: needs more of the runtime to actually implement */
       /* FIXME: check that we are in the current or previous stack frame! */
       if( FD_UNLIKELY( end_addr > (FD_VM_STACK_MAX_DEPTH * FD_VM_STACK_FRAME_WITH_GUARD_SZ ) ) ) {
@@ -193,6 +221,13 @@ fd_vm_translate_vm_to_host_private( fd_vm_exec_context_t *  ctx,
       break;
     case FD_VM_MEM_MAP_HEAP_REGION_START:
       /* Heap memory region */
+
+      vm_gap_shift = 63UL;
+      is_in_gap = ((start_addr>>vm_gap_shift)&1UL) == 1;
+      if( FD_UNLIKELY( is_in_gap ) ) {
+        return 0UL;
+      }
+
       if( FD_UNLIKELY( end_addr > ctx->heap_sz ) ) {
         return 0UL;
       }
@@ -200,6 +235,13 @@ fd_vm_translate_vm_to_host_private( fd_vm_exec_context_t *  ctx,
       break;
     case FD_VM_MEM_MAP_INPUT_REGION_START:
       /* Program input memory region */
+
+      vm_gap_shift = 63UL;
+      is_in_gap = ((start_addr>>vm_gap_shift)&1UL) == 1;
+      if( FD_UNLIKELY( is_in_gap ) ) {
+        return 0UL;
+      }
+
       if( FD_UNLIKELY( end_addr > ctx->input_sz ) ) {
         return 0UL;
       }


### PR DESCRIPTION
In the address to host translation, we currently don't check against if we are in a gapped region in memory. This adds the check along with a ledger test that tests this case. It is a temporary holdover before moving over and implementing this check in vm-belt-sanding