### PR TITLE
flamenco: decrement instr stack on fd_execute_instr error case

### DIFF
--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -764,7 +764,8 @@ fd_execute_instr( fd_exec_txn_ctx_t * txn_ctx,
       ulong ending_lamports_h = 0UL;
       ulong ending_lamports_l = 0UL;
       err = fd_instr_info_sum_account_lamports( instr, &ending_lamports_h, &ending_lamports_l );
-      if( err ) {
+      if( FD_UNLIKELY( err ) ) {
+        txn_ctx->instr_stack_sz--;
         return err;
       }
 

--- a/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
@@ -103,7 +103,7 @@ read_bpf_upgradeable_loader_state_for_program( fd_exec_txn_ctx_t *              
     return NULL;
   }
 
-  return rec->const_meta;  /* UGLY!!!!! */
+  return rec->const_meta;
 }
 
 /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L105-L171 */


### PR DESCRIPTION
the commit for "flamenco: add uwide support for lamport calculations" added an error path to fd_execute_instr that forgets to decrement txn_ctx->instr_stack_sz. Not 100% sure if that error condition is triggerable in practice, but if it is then this would probably break stuff (buffer overflow on txn_ctx->instr_stack)

^ from slack