### PR TITLE
Avoid unnecessary acks, enforce frame type restrictions

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -4061,6 +4061,7 @@ fd_quic_conn_tx( fd_quic_t *      quic,
               /* attributes on ack */
               ack_head->tx_pkt_number = pkt_number;
               ack_head->flags        |= FD_QUIC_ACK_FLAGS_SENT;
+              ack_head->tx_time       = now; /* ensure ack isn't sent again unnecessarily */
 
               /* attributes on pkt_meta */
               pkt_meta->flags        |= FD_QUIC_PKT_META_FLAGS_ACK;

--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -8,6 +8,7 @@
 #include "templ/fd_quic_frame_handler_decl.h"
 #include "templ/fd_quic_frames_templ.h"
 #include "templ/fd_quic_undefs.h"
+#include "templ/fd_quic_frame_types_templ.h"
 
 #include "crypto/fd_quic_crypto_suites.h"
 #include "templ/fd_quic_transport_params.h"
@@ -754,6 +755,7 @@ ulong
 fd_quic_handle_v1_frame( fd_quic_t *       quic,
                          fd_quic_conn_t *  conn,
                          fd_quic_pkt_t *   pkt,
+                         uint              pkt_type,
                          uchar const *     buf,
                          ulong             buf_sz,
                          fd_quic_frame_u * frame_union ) {
@@ -773,13 +775,20 @@ fd_quic_handle_v1_frame( fd_quic_t *       quic,
   uchar id_lo = 255; /* allow for fragments to work */
   uchar id_hi = 0;
 
+  /* check whether packet type, frame type combo is allowed */
+  if( FD_UNLIKELY( !fd_quic_frame_type_allowed( pkt_type, id ) ) ) {
+    fd_quic_conn_error( conn, FD_QUIC_CONN_REASON_PROTOCOL_VIOLATION, __LINE__ );
+    return FD_QUIC_PARSE_FAIL;
+  }
+
 #include "templ/fd_quic_parse_frame.h"
 #include "templ/fd_quic_frames_templ.h"
 #include "templ/fd_quic_undefs.h"
 
+  /* unknown frame types are PROTOCOL_VIOLATION errors */
   FD_DEBUG( FD_LOG_DEBUG(( "unexpected frame type: %d  at offset: %ld", (int)*p, (long)( p - buf ) )); )
+  fd_quic_conn_error( conn, FD_QUIC_CONN_REASON_PROTOCOL_VIOLATION, __LINE__ );
 
-  // if we get here we didn't understand "frame type"
   return FD_QUIC_PARSE_FAIL;
 }
 
@@ -1736,7 +1745,13 @@ fd_quic_handle_v1_initial( fd_quic_t *               quic,
   uchar const * frame_ptr   = cur_ptr + payload_off;
   ulong         frame_sz    = body_sz - pkt_number_sz - FD_QUIC_CRYPTO_TAG_SZ; /* total size of all frames in packet */
   while( frame_sz != 0UL ) {
-    rc = fd_quic_handle_v1_frame( quic, conn, pkt, frame_ptr, frame_sz, &conn->frame_union );
+    rc = fd_quic_handle_v1_frame( quic,
+                                  conn,
+                                  pkt,
+                                  FD_QUIC_PKT_TYPE_INITIAL,
+                                  frame_ptr,
+                                  frame_sz,
+                                  &conn->frame_union );
     if( FD_UNLIKELY( rc == FD_QUIC_PARSE_FAIL ) ) {
       return FD_QUIC_PARSE_FAIL;
     }
@@ -1896,7 +1911,13 @@ fd_quic_handle_v1_handshake(
   uchar const * frame_ptr   = cur_ptr + payload_off;
   ulong         frame_sz    = body_sz - pkt_number_sz - FD_QUIC_CRYPTO_TAG_SZ; /* total size of all frames in packet */
   while( frame_sz != 0UL ) {
-    rc = fd_quic_handle_v1_frame( quic, conn, pkt, frame_ptr, frame_sz, &conn->frame_union );
+    rc = fd_quic_handle_v1_frame( quic,
+                                  conn,
+                                  pkt,
+                                  FD_QUIC_PKT_TYPE_HANDSHAKE,
+                                  frame_ptr,
+                                  frame_sz,
+                                  &conn->frame_union );
     if( FD_UNLIKELY( rc == FD_QUIC_PARSE_FAIL ) ) {
       return FD_QUIC_PARSE_FAIL;
     }
@@ -2221,7 +2242,13 @@ fd_quic_handle_v1_one_rtt( fd_quic_t *           quic,
   uchar const * frame_ptr   = cur_ptr + payload_off;
   ulong         frame_sz    = cur_sz - pn_offset - pkt_number_sz - FD_QUIC_CRYPTO_TAG_SZ; /* total size of all frames in packet */
   while( frame_sz != 0UL ) {
-    rc = fd_quic_handle_v1_frame( quic, conn, pkt, frame_ptr, frame_sz, &conn->frame_union );
+    rc = fd_quic_handle_v1_frame( quic,
+                                  conn,
+                                  pkt,
+                                  FD_QUIC_PKT_TYPE_ONE_RTT,
+                                  frame_ptr,
+                                  frame_sz,
+                                  &conn->frame_union );
     if( FD_UNLIKELY( rc == FD_QUIC_PARSE_FAIL ) ) {
       FD_DEBUG( FD_LOG_DEBUG(( "frame failed to parse" )) );
       return FD_QUIC_PARSE_FAIL;
@@ -4063,7 +4090,6 @@ fd_quic_conn_tx( fd_quic_t *      quic,
               ack_head->flags        |= FD_QUIC_ACK_FLAGS_SENT;
               ack_head->tx_time       = now; /* ensure ack isn't sent again unnecessarily */
 
-              /* attributes on pkt_meta */
               pkt_meta->flags        |= FD_QUIC_PKT_META_FLAGS_ACK;
 
               /* ack frames don't really expire, but we still want to reclaim the pkt_meta */

--- a/src/waltz/quic/fd_quic_enum.h
+++ b/src/waltz/quic/fd_quic_enum.h
@@ -85,6 +85,12 @@
 #define FD_QUIC_NOTIFY_RESET (101)
 #define FD_QUIC_NOTIFY_ABORT (102)
 
+/* defines the packet types */
+#define FD_QUIC_PKT_TYPE_INITIAL   0
+#define FD_QUIC_PKT_TYPE_HANDSHAKE 1
+#define FD_QUIC_PKT_TYPE_ZERO_RTT  2
+#define FD_QUIC_PKT_TYPE_ONE_RTT   3
+
 
 #endif
 

--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -370,6 +370,7 @@ ulong
 fd_quic_handle_v1_frame( fd_quic_t *       quic,
                          fd_quic_conn_t *  conn,
                          fd_quic_pkt_t *   pkt,
+                         uint              pkt_type,
                          uchar const *     frame_ptr,
                          ulong             frame_sz,
                          fd_quic_frame_u * frame_scratch );

--- a/src/waltz/quic/templ/fd_quic_frame_types_templ.h
+++ b/src/waltz/quic/templ/fd_quic_frame_types_templ.h
@@ -1,0 +1,102 @@
+#ifndef HEADER_fd_src_waltz_quic_templ_fd_quic_frame_types_templ_h
+#define HEADER_fd_src_waltz_quic_templ_fd_quic_frame_types_templ_h
+
+#include "../fd_quic_enum.h"
+
+/* describes the frame types and their attributes */
+
+/*  Type  Sub   Frame Type Name       Definition        Pkts          Spec */
+
+#define FD_QUIC_FRAME_TYPES(X,...)                                           \
+  X(0x00, 0x00, PADDING,              "Section 19.1 ",  I, H, 0, 1,   N, P, __VA_ARGS__) \
+  X(0x01, 0x00, PING,                 "Section 19.2 ",  I, H, 0, 1,    ,  , __VA_ARGS__) \
+  X(0x02, 0x00, ACK,                  "Section 19.3 ",  I, H, _, 1,   N, C, __VA_ARGS__) \
+  X(0x02, 0x01, ACK,                  "Section 19.3 ",  I, H, _, 1,   N, C, __VA_ARGS__) \
+  X(0x04, 0x00, RESET_STREAM,         "Section 19.4 ",  _, _, 0, 1,    ,  , __VA_ARGS__) \
+  X(0x05, 0x00, STOP_SENDING,         "Section 19.5 ",  _, _, 0, 1,    ,  , __VA_ARGS__) \
+  X(0x06, 0x00, CRYPTO,               "Section 19.6 ",  I, H, _, 1,    ,  , __VA_ARGS__) \
+  X(0x07, 0x00, NEW_TOKEN,            "Section 19.7 ",  _, _, _, 1,    ,  , __VA_ARGS__) \
+  X(0x08, 0x00, STREAM,               "Section 19.8 ",  _, _, 0, 1,   F,  , __VA_ARGS__) \
+  X(0x08, 0x01, STREAM,               "Section 19.8 ",  _, _, 0, 1,   F,  , __VA_ARGS__) \
+  X(0x08, 0x02, STREAM,               "Section 19.8 ",  _, _, 0, 1,   F,  , __VA_ARGS__) \
+  X(0x08, 0x03, STREAM,               "Section 19.8 ",  _, _, 0, 1,   F,  , __VA_ARGS__) \
+  X(0x08, 0x04, STREAM,               "Section 19.8 ",  _, _, 0, 1,   F,  , __VA_ARGS__) \
+  X(0x08, 0x05, STREAM,               "Section 19.8 ",  _, _, 0, 1,   F,  , __VA_ARGS__) \
+  X(0x08, 0x06, STREAM,               "Section 19.8 ",  _, _, 0, 1,   F,  , __VA_ARGS__) \
+  X(0x08, 0x07, STREAM,               "Section 19.8 ",  _, _, 0, 1,   F,  , __VA_ARGS__) \
+  X(0x10, 0x00, MAX_DATA,             "Section 19.9 ",  _, _, 0, 1,    ,  , __VA_ARGS__) \
+  X(0x11, 0x00, MAX_STREAM_DATA,      "Section 19.10",  _, _, 0, 1,    ,  , __VA_ARGS__) \
+  X(0x12, 0x00, MAX_STREAMS,          "Section 19.11",  _, _, 0, 1,    ,  , __VA_ARGS__) \
+  X(0x12, 0x01, MAX_STREAMS,          "Section 19.11",  _, _, 0, 1,    ,  , __VA_ARGS__) \
+  X(0x14, 0x00, DATA_BLOCKED,         "Section 19.12",  _, _, 0, 1,    ,  , __VA_ARGS__) \
+  X(0x15, 0x00, STREAM_DATA_BLOCKED,  "Section 19.13",  _, _, 0, 1,    ,  , __VA_ARGS__) \
+  X(0x16, 0x00, STREAMS_BLOCKED,      "Section 19.14",  _, _, 0, 1,    ,  , __VA_ARGS__) \
+  X(0x16, 0x01, STREAMS_BLOCKED,      "Section 19.14",  _, _, 0, 1,    ,  , __VA_ARGS__) \
+  X(0x18, 0x00, NEW_CONNECTION_ID,    "Section 19.15",  _, _, 0, 1,   P,  , __VA_ARGS__) \
+  X(0x19, 0x00, RETIRE_CONNECTION_ID, "Section 19.16",  _, _, 0, 1,    ,  , __VA_ARGS__) \
+  X(0x1a, 0x00, PATH_CHALLENGE,       "Section 19.17",  _, _, 0, 1,   P,  , __VA_ARGS__) \
+  X(0x1b, 0x00, PATH_RESPONSE,        "Section 19.18",  _, _, _, 1,   P,  , __VA_ARGS__) \
+  X(0x1c, 0x00, CONNECTION_CLOSE,     "Section 19.19",  I, H, 0, 1,   N,  , __VA_ARGS__) \
+  X(0x1c, 0x01, CONNECTION_CLOSE,     "Section 19.19",  _, _, 0, 1,   N,  , __VA_ARGS__) \
+  X(0x1e, 0x00, HANDSHAKE_DONE,       "Section 19.20",  _, _, _, 1,    ,  , __VA_ARGS__)
+
+
+/* packets
+ * defines the flag for each packet type
+ *   _ placeholder
+ *   I INITIAL packet
+ *   H HANDSHAKE packet
+ *   0 ZERO RTT packet
+ *   1 ONE RTT packet */
+#define PKT_FLAG__ 0u
+#define PKT_FLAG_I (1u<<FD_QUIC_PKT_TYPE_INITIAL)
+#define PKT_FLAG_H (1u<<FD_QUIC_PKT_TYPE_HANDSHAKE)
+#define PKT_FLAG_0 (1u<<FD_QUIC_PKT_TYPE_ZERO_RTT)
+#define PKT_FLAG_1 (1u<<FD_QUIC_PKT_TYPE_ONE_RTT)
+
+
+/* fd_quic_frame_type_allowed
+ *
+ * Returns an int representing whether the given combination of
+ * packet type and frame type is allowed.
+ *
+ * args
+ *  pkt_type    the type of packet:
+ *                FD_QUIC_PKT_TYPE_INITIAL
+ *                FD_QUIC_PKT_TYPE_HANDSHAKE
+ *                FD_QUIC_PKT_TYPE_ZERO_RTT
+ *                FD_QUIC_PKT_TYPE_ONE_RTT
+ *  frame_type  the type of frame (0x00-0x1e)
+ *
+ *  returns
+ *    1   If the frame type is allowed in the given packet type
+ *    0   Otherwise */
+FD_FN_PURE static inline
+int
+fd_quic_frame_type_allowed( uint pkt_type, uint frame_type ) {
+  if( FD_UNLIKELY( pkt_type > 3u ) ) FD_LOG_ERR(( "Packet type not valid: %x", pkt_type ));
+
+  /* macro used to initialize the lookup table */
+# define INIT(T,S,NAME,_0,F0,F1,F2,F3,...) \
+      [T+S] = PKT_FLAG_##F0 + PKT_FLAG_##F1 + PKT_FLAG_##F2 + PKT_FLAG_##F3,
+
+  /* construct table from the frame types */
+  /* this results in a handfull of compile time constants */
+  uchar tbl[] = {
+    FD_QUIC_FRAME_TYPES(INIT,a)
+  };
+
+# undef INIT
+
+  if( FD_UNLIKELY( frame_type > sizeof(tbl) / sizeof(tbl[0]) ) ) return 0;
+
+  return !!(tbl[frame_type] & (1u<<pkt_type));
+}
+
+#undef PKT_FLAG__
+#undef PKT_FLAG_I
+#undef PKT_FLAG_H
+#undef PKT_FLAG_0
+#undef PKT_FLAG_1
+
+#endif

--- a/src/waltz/quic/tests/fd_quic_sandbox.c
+++ b/src/waltz/quic/tests/fd_quic_sandbox.c
@@ -353,9 +353,13 @@ fd_quic_sandbox_send_frame( fd_quic_sandbox_t * sandbox,
 
   fd_quic_t * quic = sandbox->quic;
 
+  /* set pkt_type to FD_QUIC_PKT_TYPE_ONE_RTT as it allows all
+   * frame types */
+  uint pkt_type = FD_QUIC_PKT_TYPE_ONE_RTT;
+
   /* Scratch space to deserialize frame data into */
   fd_quic_frame_u frame[1];
-  ulong rc = fd_quic_handle_v1_frame( quic, conn, pkt_meta, frame_ptr, frame_sz, frame );
+  ulong rc = fd_quic_handle_v1_frame( quic, conn, pkt_meta, pkt_type, frame_ptr, frame_sz, frame );
   if( FD_UNLIKELY( rc==FD_QUIC_PARSE_FAIL ) ) return;
   if( FD_UNLIKELY( rc==0UL || rc>frame_sz ) ) {
     fd_quic_conn_error( conn, FD_QUIC_CONN_REASON_PROTOCOL_VIOLATION, __LINE__ );


### PR DESCRIPTION
ack->tx_time should have been updated upon acking. This PR fixes that
We were not enforcing the frame type rules. This PR fixes that also