### PR TITLE
sbpf: bounds check entry_pc against rodata_sz

### DIFF
--- a/src/ballet/sbpf/fd_sbpf_loader.c
+++ b/src/ballet/sbpf/fd_sbpf_loader.c
@@ -418,22 +418,23 @@ fd_sbpf_load_shdrs( fd_sbpf_elf_info_t *  info,
 
   /* Convert entrypoint offset to program counter */
 
+  info->rodata_sz        = (uint)segment_end;
+  info->rodata_footprint = (uint)elf_sz;
+
   ulong entry_off = fd_ulong_sat_sub( elf->ehdr.e_entry, shdr_text->sh_addr );
   ulong entry_pc = entry_off / 8UL;
   REQUIRE( fd_ulong_is_aligned( entry_off, 8UL ) );
+  REQUIRE( entry_pc < ( info->rodata_sz / 8UL ) );
   info->entry_pc = (uint)entry_pc;
 
   if( (info->shndx_dynstr)>=0 ) {
     fd_elf64_shdr const * shdr_dynstr = &shdr[ info->shndx_dynstr ];
     ulong sh_offset = shdr_dynstr->sh_offset;
     ulong sh_size   = shdr_dynstr->sh_size;
-    REQUIRE( (sh_offset+sh_size>=sh_offset) & (sh_offset+sh_size<=elf_sz) );
+    REQUIRE( (sh_offset+sh_size>=sh_offset) & (sh_offset+sh_size<=info->rodata_footprint) );
     info->dynstr_off = (uint)sh_offset;
     info->dynstr_sz  = (uint)sh_size;
   }
-
-  info->rodata_sz        = (uint)segment_end;
-  info->rodata_footprint = (uint)elf_sz;
 
   return 0;
 }


### PR DESCRIPTION
Addressing the crashes in https://github.com/firedancer-io/auditor-internal/issues/91

The check is basically a copy of https://github.com/firedancer-io/firedancer/blob/32b9530a2115b282b6bb8078b077b81c9cd9019e/src/ballet/sbpf/fd_sbpf_loader.c#L964