### PR TITLE
flamenco: adding heap cu consume before bpf execution

### DIFF
--- a/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
@@ -106,6 +106,28 @@ read_bpf_upgradeable_loader_state_for_program( fd_exec_txn_ctx_t *              
   return rec->const_meta;
 }
 
+/* https://github.com/anza-xyz/agave/blob/9b22f28104ec5fd606e4bb39442a7600b38bb671/programs/bpf_loader/src/lib.rs#L216-L229 */
+ulong
+calculate_heap_cost( ulong heap_size, ulong heap_cost, int round_up_heap_size, int * err ) {
+  #define KIBIBYTE_MUL_PAGES       (1024UL * 32UL)
+  #define KIBIBYTE_MUL_PAGES_SUB_1 (KIBIBYTE_MUL_PAGES - 1UL)
+
+  if( round_up_heap_size ) {
+    heap_size = fd_ulong_sat_add( heap_size, KIBIBYTE_MUL_PAGES_SUB_1 );
+  }
+
+  if( FD_UNLIKELY( heap_size==0UL ) ) {
+    *err = FD_EXECUTOR_INSTR_ERR_GENERIC_ERR;
+    return 0UL;
+  }
+
+  heap_size = fd_ulong_sat_mul( fd_ulong_sat_sub( heap_size / KIBIBYTE_MUL_PAGES, 1UL ), heap_cost );
+  return heap_size;
+
+  #undef KIBIBYTE_MUL_PAGES
+  #undef KIBIBYTE_MUL_PAGES_SUB_1
+}
+
 /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L105-L171 */
 int
 deploy_program( fd_exec_instr_ctx_t * instr_ctx,
@@ -339,6 +361,20 @@ execute( fd_exec_instr_ctx_t * instr_ctx, fd_sbpf_validated_program_t * prog ) {
     .previous_instruction_meter = instr_ctx->txn_ctx->compute_meter,
     .alloc               = { .offset = 0UL }
   };
+
+  /* https://github.com/anza-xyz/agave/blob/9b22f28104ec5fd606e4bb39442a7600b38bb671/programs/bpf_loader/src/lib.rs#L288-L298 */
+  ulong heap_size = instr_ctx->txn_ctx->heap_size;
+  ulong heap_cost = vm_compute_budget.heap_cost;
+  int round_up_heap_size = FD_FEATURE_ACTIVE( instr_ctx->slot_ctx, round_up_heap_size );
+  int heap_err = 0;
+  ulong heap_cost_result = calculate_heap_cost( heap_size, heap_cost, round_up_heap_size, &heap_err );
+  if( FD_UNLIKELY( heap_err ) ) {
+    return FD_EXECUTOR_INSTR_ERR_GENERIC_ERR;
+  }
+  if( FD_UNLIKELY( heap_cost_result>vm_ctx.compute_meter ) ) {
+    return FD_EXECUTOR_INSTR_ERR_COMPUTE_BUDGET_EXCEEDED;
+  }
+  vm_ctx.compute_meter -= heap_cost_result;
 
   memset( vm_ctx.register_file, 0, sizeof(vm_ctx.register_file) );
   vm_ctx.register_file[1] = FD_VM_MEM_MAP_INPUT_REGION_START;

--- a/src/flamenco/runtime/tests/run_ledger_tests_all.txt
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.txt
@@ -26,4 +26,5 @@ src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-267651942 -s snapshot-
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-267081197 -s snapshot-267081196-9qwnybW2TVKfpMKJXKwFwfeW81qX2voqJYxd4qEaHPQu.tar.zst -p 16 -y 16 -m 5000000 -e 267081198
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-267085604 -s snapshot-267085603-6JYpKrZVkmvsNvr83xTB63UsYDspCLUgsSAZLgJJZ3we.tar.zst -p 16 -y 16 -m 5000000 -e 267085605
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-265688706 -s snapshot-265688705-Hz56JjQuN4yfXGohYWMsYe2QJiTejQgGNLUaviVN16qP.tar.zst -p 16 -y 16 -m 5000000 -e 265688707
-src/flamenco/runtime/tests/run_ledger_tests.sh -l v18multi-deployclose -s snapshot-400-4u5FU6ucpVAGaNgerGXs93vKtuS3tkmH2cAGwjQA9QcR.tar.zst -p 16 -y 16 -m 5000000 -e 600
+src/flamenco/runtime/tests/run_ledger_tests.sh -l v18multi-deployclose -s snapshot-400-4u5FU6ucpVAGaNgerGXs93vKtuS3tkmH2cAGwjQA9QcR.tar.zst    -p 16 -y 16 -m 5000000 -e 600
+src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-265330432 -s snapshot-265330431-BMvcRhxNoRtkZ5KLEKhhXM6GiWdTgdkoGLMe86xY4rF.tar.zst  -p 16 -y 16 -m 5000000 -e 265330433


### PR DESCRIPTION
Missing CU consume for heap size before entry into VM. Porting over change into belt sanding and adding a ledger test