### PR TITLE
flamenco: add instruction tracing

### DIFF
--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.c
@@ -216,6 +216,13 @@ fd_exec_txn_ctx_setup( fd_exec_txn_ctx_t * txn_ctx,
   txn_ctx->failed_instr    = NULL;
   txn_ctx->instr_err_idx   = INT_MAX;
   txn_ctx->capture_ctx     = NULL;
+
+  txn_ctx->instr_info_pool = fd_instr_info_pool_join( fd_instr_info_pool_new( 
+    fd_valloc_malloc( txn_ctx->valloc, fd_instr_info_pool_align( ), fd_instr_info_pool_footprint( FD_MAX_INSTRUCTION_TRACE_LENGTH ) ),
+    FD_MAX_INSTRUCTION_TRACE_LENGTH
+  ) );
+
+  txn_ctx->instr_trace_length      = 0;
 }
 
 void

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -118,7 +118,11 @@ fd_executor_lookup_native_program(  fd_pubkey_t const * program_id );
 
 /* fd_execute_instr creates a new fd_exec_instr_ctx_t and performs
    instruction processing.  Does fd_scratch allocations.  Returns an
-   error code in FD_EXECUTOR_INSTR_{ERR_{...},SUCCESS}. */
+   error code in FD_EXECUTOR_INSTR_{ERR_{...},SUCCESS}.
+   
+   IMPORTANT: instr_info must have the same lifetime as txn_ctx. This can
+   be achieved by using fd_executor_acquire_instr_info_elem( txn_ctx ) to
+   acquire an fd_instr_info_t element with the same lifetime as the txn_ctx */
 
 int
 fd_execute_instr( fd_exec_txn_ctx_t * txn_ctx,
@@ -153,6 +157,15 @@ fd_execute_txn_finalize( fd_exec_slot_ctx_t * slot_ctx,
   Makes changes to the Funk accounts DB. */
 int
 fd_execute_txn( fd_exec_txn_ctx_t * txn_ctx );
+
+/* Returns a new fd_instr_info_t element, which will have the same lifetime as the given txn_ctx.
+
+   Returns NULL if we failed to acquire a new fd_instr_info_t element from the pool, which has 
+   FD_MAX_INSTRUCTION_TRACE_LENGTH capacity. The appropiate response to this is usually 
+   failing with FD_EXECUTOR_INSTR_ERR_MAX_INSN_TRACE_LENS_EXCEEDED.
+ */
+fd_instr_info_t *
+fd_executor_acquire_instr_info_elem( fd_exec_txn_ctx_t * txn_ctx );
 
 uint
 fd_executor_txn_uses_sysvar_instructions( fd_exec_txn_ctx_t const * txn_ctx );

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -1305,6 +1305,7 @@ fd_runtime_finalize_txns_tpool( fd_exec_slot_ctx_t * slot_ctx,
 
     for (ulong txn_idx = 0; txn_idx < txn_cnt; txn_idx++) {
       fd_exec_txn_ctx_t * txn_ctx = task_info[txn_idx].txn_ctx;
+      fd_valloc_free( txn_ctx->valloc, fd_instr_info_pool_delete( fd_instr_info_pool_leave( txn_ctx->instr_info_pool ) ) );
       fd_valloc_free( slot_ctx->valloc, txn_ctx );
     }
 

--- a/src/flamenco/runtime/program/fd_native_cpi.c
+++ b/src/flamenco/runtime/program/fd_native_cpi.c
@@ -10,7 +10,11 @@ fd_native_cpi_execute_system_program_instruction( fd_exec_instr_ctx_t * ctx,
                                                   ulong acct_metas_len,
                                                   fd_pubkey_t const * signers,
                                                   ulong signers_cnt ) {
-  fd_instr_info_t instr_info[1];
+  fd_instr_info_t * instr_info = fd_executor_acquire_instr_info_elem( ctx->txn_ctx );
+  if ( FD_UNLIKELY( instr_info == NULL ) ) {
+    return FD_EXECUTOR_INSTR_ERR_MAX_INSN_TRACE_LENS_EXCEEDED;
+  }
+
   fd_instruction_account_t instruction_accounts[256];
   ulong instruction_accounts_cnt;
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_instructions.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_instructions.c
@@ -5,15 +5,15 @@
 #include "../fd_system_ids.h"
 
 static ulong
-instructions_serialized_size( fd_instr_info_t const *  instrs,
-                              ushort              instrs_cnt ) {
+instructions_serialized_size( fd_instr_info_t const **  instrs,
+                              ushort                    instrs_cnt ) {
   ulong serialized_size = 0;
 
   serialized_size += sizeof(ushort)       // num_instructions
     + (sizeof(ushort) * instrs_cnt);      // instruction offsets
 
   for ( ushort i = 0; i < instrs_cnt; ++i ) {
-    fd_instr_info_t const * instr = &instrs[i];
+    fd_instr_info_t const * instr = instrs[i];
 
     serialized_size += sizeof(ushort); // num_accounts;
 
@@ -34,9 +34,9 @@ instructions_serialized_size( fd_instr_info_t const *  instrs,
 }
 
 int
-fd_sysvar_instructions_serialize_account( fd_exec_txn_ctx_t *     txn_ctx,
-                                          fd_instr_info_t const * instrs,
-                                          ushort                  instrs_cnt ) {
+fd_sysvar_instructions_serialize_account( fd_exec_txn_ctx_t *      txn_ctx,
+                                          fd_instr_info_t const ** instrs,
+                                          ushort                   instrs_cnt ) {
   ulong serialized_sz = instructions_serialized_size( instrs, instrs_cnt );
 
   fd_borrowed_account_t * rec = NULL;
@@ -74,7 +74,7 @@ fd_sysvar_instructions_serialize_account( fd_exec_txn_ctx_t *     txn_ctx,
     FD_STORE( ushort, serialized_instruction_offsets, (ushort) offset );
     serialized_instruction_offsets += sizeof(ushort);
 
-    fd_instr_info_t const * instr = &instrs[i];
+    fd_instr_info_t const * instr = instrs[i];
 
     // num_accounts
     FD_STORE( ushort, serialized_instructions + offset, instr->acct_cnt );

--- a/src/flamenco/runtime/sysvar/fd_sysvar_instructions.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_instructions.h
@@ -9,9 +9,9 @@
 FD_PROTOTYPES_BEGIN
 
 int
-fd_sysvar_instructions_serialize_account( fd_exec_txn_ctx_t *     txn_ctx,
-                                          fd_instr_info_t const * instrs,
-                                          ushort                  instrs_cnt );
+fd_sysvar_instructions_serialize_account( fd_exec_txn_ctx_t *      txn_ctx,
+                                          fd_instr_info_t const ** instrs,
+                                          ushort                   instrs_cnt );
 
 int
 fd_sysvar_instructions_cleanup_account( fd_exec_txn_ctx_t *  txn_ctx );

--- a/src/flamenco/vm/fd_vm_syscalls.c
+++ b/src/flamenco/vm/fd_vm_syscalls.c
@@ -1602,10 +1602,14 @@ fd_vm_syscall_cpi_c(
 
   fd_instruction_account_t instruction_accounts[256];
   ulong instruction_accounts_cnt;
-  fd_instr_info_t cpi_instr;
+  fd_instr_info_t * cpi_instr = fd_executor_acquire_instr_info_elem( ctx->instr_ctx->txn_ctx );
+  if ( FD_UNLIKELY( cpi_instr == NULL ) ) {
+    FD_LOG_WARNING(( "failed to acquire cpi_instr" ));
+    return FD_VM_SYSCALL_ERR_INSTR_ERR;
+  }
 
-  fd_vm_syscall_cpi_c_instruction_to_instr( ctx, instruction, accounts, signers, signers_seeds_cnt, data, &cpi_instr );
-  err = fd_vm_prepare_instruction(ctx->instr_ctx->instr, &cpi_instr, ctx->instr_ctx, instruction_accounts, &instruction_accounts_cnt, signers, signers_seeds_cnt );
+  fd_vm_syscall_cpi_c_instruction_to_instr( ctx, instruction, accounts, signers, signers_seeds_cnt, data, cpi_instr );
+  err = fd_vm_prepare_instruction(ctx->instr_ctx->instr, cpi_instr, ctx->instr_ctx, instruction_accounts, &instruction_accounts_cnt, signers, signers_seeds_cnt );
   if( err != 0 ) {
     FD_LOG_WARNING(("vm preparation failed"));
     return err;
@@ -1635,7 +1639,7 @@ fd_vm_syscall_cpi_c(
   }
 
   ctx->instr_ctx->txn_ctx->compute_meter = ctx->compute_meter;
-  err_exec = fd_execute_instr( ctx->instr_ctx->txn_ctx, &cpi_instr );
+  err_exec = fd_execute_instr( ctx->instr_ctx->txn_ctx, cpi_instr );
   ulong instr_exec_res = (ulong)err_exec;
   // uchar * sig = (uchar *)ctx->instr_ctx->txn_ctx->_txn_raw->raw + ctx->instr_ctx->txn_ctx->txn_descriptor->signature_off;
   // FD_LOG_WARNING(( "CPI CUs CONSUMED: %lu %lu %lu %64J", ctx->compute_meter, ctx->instr_ctx->txn_ctx->compute_meter, ctx->compute_meter - ctx->instr_ctx->txn_ctx->compute_meter, sig));
@@ -1772,10 +1776,14 @@ fd_vm_syscall_cpi_rust(
 
   fd_instruction_account_t instruction_accounts[256];
   ulong instruction_accounts_cnt;
-  fd_instr_info_t cpi_instr;
+  fd_instr_info_t * cpi_instr = fd_executor_acquire_instr_info_elem( ctx->instr_ctx->txn_ctx );
+  if ( FD_UNLIKELY( cpi_instr == NULL ) ) {
+    FD_LOG_WARNING(( "failed to acquire cpi_instr" ));
+    return FD_VM_SYSCALL_ERR_INSTR_ERR;
+  }
 
-  fd_vm_syscall_cpi_rust_instruction_to_instr( ctx, instruction, accounts, signers, signers_seeds_cnt, data, &cpi_instr );
-  err = fd_vm_prepare_instruction(ctx->instr_ctx->instr, &cpi_instr, ctx->instr_ctx, instruction_accounts, &instruction_accounts_cnt, signers, signers_seeds_cnt );
+  fd_vm_syscall_cpi_rust_instruction_to_instr( ctx, instruction, accounts, signers, signers_seeds_cnt, data, cpi_instr );
+  err = fd_vm_prepare_instruction(ctx->instr_ctx->instr, cpi_instr, ctx->instr_ctx, instruction_accounts, &instruction_accounts_cnt, signers, signers_seeds_cnt );
   if( err != 0 ) {
     FD_LOG_WARNING(("vm prepare failed"));
     return err;
@@ -1805,7 +1813,7 @@ fd_vm_syscall_cpi_rust(
   }
   
   ctx->instr_ctx->txn_ctx->compute_meter = ctx->compute_meter;
-  err_exec = fd_execute_instr( ctx->instr_ctx->txn_ctx, &cpi_instr );
+  err_exec = fd_execute_instr( ctx->instr_ctx->txn_ctx, cpi_instr );
   ulong instr_exec_res = (ulong)err_exec;
   #ifdef VLOG
   uchar * sig = (uchar *)ctx->instr_ctx->txn_ctx->_txn_raw->raw + ctx->instr_ctx->txn_ctx->txn_descriptor->signature_off;


### PR DESCRIPTION
This PR adds transaction instruction tracing, in the same way that Agave does. We keep a list of all instructions that were executed in the current trace.

We need to do this for `sol_get_processed_sibling_instruction`, which requires the full instruction trace.

In cases where we create an instruction info object on the fly, such as CPIs, we now need to ensure this has the same lifetime as the transaction. To do this, we allocate all instruction info objects out of a memory pool, which is owned by the transaction. This also avoids an expensive memcpy when saving traces.