### PR TITLE
disco: move tile types header to disco

### DIFF
--- a/src/app/fdctl/monitor/monitor.c
+++ b/src/app/fdctl/monitor/monitor.c
@@ -3,7 +3,7 @@
 #include "generated/monitor_seccomp.h"
 #include "helper.h"
 #include "../run/run.h"
-#include "../run/tiles/tiles.h"
+#include "../../../disco/tiles.h"
 #include "../../../disco/fd_disco.h"
 
 #include <stdio.h>

--- a/src/app/fdctl/run/run.c
+++ b/src/app/fdctl/run/run.c
@@ -5,7 +5,7 @@
 #include "generated/main_seccomp.h"
 #include "generated/pidns_seccomp.h"
 
-#include "tiles/tiles.h"
+#include "../../../disco/tiles.h"
 #include "../configure/configure.h"
 
 #include <sched.h>

--- a/src/app/fdctl/run/run.h
+++ b/src/app/fdctl/run/run.h
@@ -2,7 +2,7 @@
 #define HEADER_fd_src_app_fdctl_run_h
 
 #include "../fdctl.h"
-#include "tiles/tiles.h"
+#include "../../../disco/tiles.h"
 #include "topos/topos.h"
 
 #include "../../../waltz/xdp/fd_xsk.h"

--- a/src/app/fdctl/run/tiles/fd_bank.c
+++ b/src/app/fdctl/run/tiles/fd_bank.c
@@ -1,4 +1,4 @@
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 #include "../../../../ballet/pack/fd_pack.h"
 #include "../../../../ballet/blake3/fd_blake3.h"

--- a/src/app/fdctl/run/tiles/fd_blackhole.c
+++ b/src/app/fdctl/run/tiles/fd_blackhole.c
@@ -1,4 +1,4 @@
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 /**
  * Tile used to filter out all packets when used as a consumer.

--- a/src/app/fdctl/run/tiles/fd_dedup.c
+++ b/src/app/fdctl/run/tiles/fd_dedup.c
@@ -1,4 +1,4 @@
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 #include "generated/dedup_seccomp.h"
 #include <linux/unistd.h>

--- a/src/app/fdctl/run/tiles/fd_gossip.c
+++ b/src/app/fdctl/run/tiles/fd_gossip.c
@@ -2,7 +2,7 @@
 
 #define _GNU_SOURCE 
 
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 #include <unistd.h>
 #include <arpa/inet.h>

--- a/src/app/fdctl/run/tiles/fd_metric.c
+++ b/src/app/fdctl/run/tiles/fd_metric.c
@@ -1,9 +1,10 @@
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 #include "generated/metric_seccomp.h"
 
 #include "../../../../ballet/http/picohttpparser.h"
 
+#include <errno.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/src/app/fdctl/run/tiles/fd_net.c
+++ b/src/app/fdctl/run/tiles/fd_net.c
@@ -1,4 +1,4 @@
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 #include <sys/socket.h> /* MSG_DONTWAIT needed before importing the net seccomp filter */
 #include "generated/net_seccomp.h"

--- a/src/app/fdctl/run/tiles/fd_netmux.c
+++ b/src/app/fdctl/run/tiles/fd_netmux.c
@@ -1,4 +1,4 @@
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 #include "generated/netmux_seccomp.h"
 #include <linux/unistd.h>

--- a/src/app/fdctl/run/tiles/fd_pack.c
+++ b/src/app/fdctl/run/tiles/fd_pack.c
@@ -1,4 +1,4 @@
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 #include "generated/pack_seccomp.h"
 

--- a/src/app/fdctl/run/tiles/fd_poh.c
+++ b/src/app/fdctl/run/tiles/fd_poh.c
@@ -1,4 +1,4 @@
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 /* Let's say there was a computer, the "leader" computer, that acted as
    a bank.  Users could send it messages saying they wanted to deposit

--- a/src/app/fdctl/run/tiles/fd_quic.c
+++ b/src/app/fdctl/run/tiles/fd_quic.c
@@ -1,4 +1,4 @@
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 #include "generated/quic_seccomp.h"
 #include "../../../../disco/metrics/generated/fd_metrics_quic.h"

--- a/src/app/fdctl/run/tiles/fd_repair.c
+++ b/src/app/fdctl/run/tiles/fd_repair.c
@@ -2,7 +2,7 @@
 
 #define _GNU_SOURCE
 
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 #include "generated/repair_seccomp.h"
 #include "../../../../flamenco/repair/fd_repair.h"

--- a/src/app/fdctl/run/tiles/fd_replay.c
+++ b/src/app/fdctl/run/tiles/fd_replay.c
@@ -1,6 +1,6 @@
 #define _GNU_SOURCE
 
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 #include "generated/replay_seccomp.h"
 #include "../../../../util/fd_util.h"
@@ -22,6 +22,7 @@
 #include "../../../../flamenco/fd_flamenco.h"
 #include "fd_replay_notif.h"
 
+#include <errno.h>
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <linux/unistd.h>

--- a/src/app/fdctl/run/tiles/fd_replay_thread.c
+++ b/src/app/fdctl/run/tiles/fd_replay_thread.c
@@ -1,3 +1,3 @@
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 fd_topo_run_tile_t fd_tile_replay_thread = { .name = "thread", .for_tpool = 1 };

--- a/src/app/fdctl/run/tiles/fd_shred.c
+++ b/src/app/fdctl/run/tiles/fd_shred.c
@@ -1,4 +1,4 @@
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 #include "generated/shred_seccomp.h"
 #include "../../../../disco/shred/fd_shredder.h"

--- a/src/app/fdctl/run/tiles/fd_sign.c
+++ b/src/app/fdctl/run/tiles/fd_sign.c
@@ -1,11 +1,12 @@
 #define _GNU_SOURCE
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 #include "generated/sign_seccomp.h"
 
 #include "../../../../disco/keyguard/fd_keyguard.h"
 #include "../../../../disco/keyguard/fd_keyload.h"
 
+#include <errno.h>
 #include <sys/mman.h>
 
 #define MAX_IN (32UL)

--- a/src/app/fdctl/run/tiles/fd_store.c
+++ b/src/app/fdctl/run/tiles/fd_store.c
@@ -1,4 +1,4 @@
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 typedef struct {
   fd_wksp_t * mem;

--- a/src/app/fdctl/run/tiles/fd_store_int.c
+++ b/src/app/fdctl/run/tiles/fd_store_int.c
@@ -2,7 +2,7 @@
 
 #define _GNU_SOURCE
 
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 #include "generated/store_int_seccomp.h"
 #include "../../../../flamenco/repair/fd_repair.h"

--- a/src/app/fdctl/run/tiles/fd_verify.c
+++ b/src/app/fdctl/run/tiles/fd_verify.c
@@ -1,4 +1,4 @@
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 #include "fd_verify.h"
 
 #include "generated/verify_seccomp.h"

--- a/src/app/fdctl/run/tiles/fd_verify.h
+++ b/src/app/fdctl/run/tiles/fd_verify.h
@@ -1,7 +1,7 @@
 #ifndef HEADER_fd_src_app_fdctl_run_tiles_verify_h
 #define HEADER_fd_src_app_fdctl_run_tiles_verify_h
 
-#include "tiles.h"
+#include "../../../../disco/tiles.h"
 
 #define VERIFY_TCACHE_DEPTH   16UL
 #define VERIFY_TCACHE_MAP_CNT 64UL

--- a/src/app/fdctl/run/topos/fd_firedancer.c
+++ b/src/app/fdctl/run/topos/fd_firedancer.c
@@ -1,7 +1,8 @@
 /* Firedancer topology used for testing the full validator.
    Associated test script: test_firedancer.sh */
 #include "topos.h"
-#include "../tiles/tiles.h"
+#include "../../../../disco/tiles.h"
+#include "../../fdctl.h"
 #include "../../config.h"
 #include "../../../../ballet/shred/fd_shred.h"
 #include "../../../../disco/topo/fd_topob.h"

--- a/src/app/fdctl/run/topos/fd_frankendancer.c
+++ b/src/app/fdctl/run/topos/fd_frankendancer.c
@@ -1,4 +1,5 @@
-#include "../tiles/tiles.h"
+#include "../../../../disco/tiles.h"
+#include "../../fdctl.h"
 #include "../../config.h"
 #include "../../../../ballet/shred/fd_shred.h"
 #include "../../../../disco/topo/fd_topob.h"

--- a/src/app/fddev/configure/blockstore.c
+++ b/src/app/fddev/configure/blockstore.c
@@ -4,7 +4,7 @@
 #include "../../../ballet/shred/fd_shred.h"
 #include "../../../disco/shred/fd_shredder.h"
 #include "../../../ballet/poh/fd_poh.h"
-#include "../../fdctl/run/tiles/tiles.h"
+#include "../../../disco/tiles.h"
 #include "../genesis_hash.h"
 
 #include <sys/stat.h>

--- a/src/app/fddev/tiles/fd_benchg.c
+++ b/src/app/fddev/tiles/fd_benchg.c
@@ -1,4 +1,4 @@
-#include "../../fdctl/run/tiles/tiles.h"
+#include "../../../disco/tiles.h"
 
 #include "../../../flamenco/types/fd_types_custom.h"
 #include "../../../flamenco/runtime/fd_system_ids_pp.h"

--- a/src/app/fddev/tiles/fd_bencho.c
+++ b/src/app/fddev/tiles/fd_bencho.c
@@ -1,4 +1,4 @@
-#include "../../fdctl/run/tiles/tiles.h"
+#include "../../../disco/tiles.h"
 
 #include "../rpc_client/fd_rpc_client.h"
 #include "../rpc_client/fd_rpc_client_private.h"

--- a/src/app/fddev/tiles/fd_benchs.c
+++ b/src/app/fddev/tiles/fd_benchs.c
@@ -1,11 +1,12 @@
 /* _GNU_SOURCE for recvmmsg and sendmmsg */
 #define _GNU_SOURCE
 
-#include "../../fdctl/run/tiles/tiles.h"
+#include "../../../disco/tiles.h"
 #include "../../../waltz/xdp/fd_xsk_aio.h"
 #include "../../../waltz/quic/fd_quic.h"
 #include "../../../waltz/tls/test_tls_helper.h"
 
+#include <errno.h>
 #include <linux/unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/src/disco/tiles.h
+++ b/src/disco/tiles.h
@@ -1,12 +1,11 @@
 #ifndef HEADER_fd_src_app_fdctl_run_tiles_h
 #define HEADER_fd_src_app_fdctl_run_tiles_h
 
-#include "../../fdctl.h"
-
-#include "../../../../disco/mux/fd_mux.h"
-#include "../../../../disco/shred/fd_shredder.h"
-#include "../../../../ballet/shred/fd_shred.h"
-#include "../../../../ballet/pack/fd_pack.h"
+#include "mux/fd_mux.h"
+#include "shred/fd_shredder.h"
+#include "../ballet/shred/fd_shred.h"
+#include "../ballet/pack/fd_pack.h"
+#include "topo/fd_topo.h"
 
 #include <linux/filter.h>
 
@@ -94,5 +93,13 @@ struct fd_microblock_bank_trailer {
   void const * bank;
 };
 typedef struct fd_microblock_bank_trailer fd_microblock_bank_trailer_t;
+
+typedef struct __attribute__((packed)) {
+  double hashcnt_duration_ns;
+  ulong  hashcnt_per_tick;
+  ulong  ticks_per_slot;
+  ulong  tick_height;
+  uchar  last_entry_hash[32];
+} fd_poh_init_msg_t;
 
 #endif /* HEADER_fd_src_app_fdctl_run_tiles_h */


### PR DESCRIPTION
We are moving some shared tile functionality to the disco folder. The types therefore need to move.


- disco: move tiles types to disco
- chore: move over to new tiles hdr
