### PR TITLE
flamenco: fixing index shifting for lockout deque in vote program

### DIFF
--- a/src/flamenco/runtime/tests/run_ledger_tests_all.txt
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.txt
@@ -28,3 +28,4 @@ src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-267085604 -s snapshot-
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-265688706 -s snapshot-265688705-Hz56JjQuN4yfXGohYWMsYe2QJiTejQgGNLUaviVN16qP.tar.zst -p 16 -y 16 -m 5000000 -e 265688707
 src/flamenco/runtime/tests/run_ledger_tests.sh -l v18multi-deployclose -s snapshot-400-4u5FU6ucpVAGaNgerGXs93vKtuS3tkmH2cAGwjQA9QcR.tar.zst    -p 16 -y 16 -m 5000000 -e 600
 src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-265330432 -s snapshot-265330431-BMvcRhxNoRtkZ5KLEKhhXM6GiWdTgdkoGLMe86xY4rF.tar.zst  -p 16 -y 16 -m 5000000 -e 265330433
+src/flamenco/runtime/tests/run_ledger_tests.sh -l mainnet-268575190 -s snapshot-268575189-ABBpiGpcqgMs9SMNM4GTcpRPdwidgK6Vi1ZdRdQ4mpmA.tar.zst -p 16 -y 16 -m 5000000 -e 268575191


### PR DESCRIPTION
Previously on filtering votes, we were forward iterating through an increasing array and removing each value as an index from a deque. This can lead to the index being shifted leading to incorrect behavior. 

There is a ledger test that demonstrates this case on transaction sig: 5dAiW3rhfkm2gpWnnNigUDURNwwQx2usJJQaSsuDdarBJZjVEwKsq3MNCLFGmeMXtPPCqarPmKEbPb7m99xKPotF.

Fixing nits + adding comments/perma links in relevant function as well