### PR TITLE
flamenco: only memcmp authority_key and authority_address when they are not NULL

### DIFF
--- a/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
@@ -590,7 +590,8 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
     }
 
     if( fd_bpf_upgradeable_loader_state_is_buffer( &buffer_state ) ) {
-      if( FD_UNLIKELY( memcmp( buffer_state.inner.buffer.authority_address, authority_key, sizeof(fd_pubkey_t) ) ) ) {
+      if( FD_UNLIKELY( (authority_key==NULL) != (buffer_state.inner.buffer.authority_address == NULL) ||
+          (authority_key!=NULL && memcmp( buffer_state.inner.buffer.authority_address, authority_key, sizeof(fd_pubkey_t) ) ) ) ) {
         FD_LOG_WARNING(( "Buffer and upgrade authority don't match" ));
         return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
       }


### PR DESCRIPTION
https://github.com/firedancer-io/auditor-internal/issues/95

https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L566
authority_key and authority_address are both `Option<Pubkey>`, so they can be equivalent when they're the same `Some` or when they're both `None`.