### PR TITLE
Revert "flamenco: fd_bpf_loader_v3_program process_loader_upgradeable_instruction NULL checks"

### DIFF
--- a/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
@@ -412,10 +412,6 @@ execute( fd_exec_instr_ctx_t * instr_ctx, fd_sbpf_validated_program_t * prog ) {
 int
 process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
   uchar const * data = instr_ctx->instr->data;
-  if( FD_UNLIKELY( !instr_ctx || !instr_ctx->instr || !instr_ctx->instr->data ) ) {
-    FD_LOG_WARNING(( "instr_ctx %p instr_ctx->instr %p instr_ctx->instr->data %p", (void *)instr_ctx, (void *)instr_ctx->instr, (void *)instr_ctx->instr->data ));
-    return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
-  }
 
   fd_bpf_upgradeable_loader_program_instruction_t instruction = {0};
   fd_bincode_decode_ctx_t decode_ctx = {0};


### PR DESCRIPTION
Reverts firedancer-io/firedancer#2047

- instr and instr_ctx get accessed prematurely in line 414 
- instr and instr ctx should not be null at this point, that should be caught further up the call stack
- The check is unnecessary as null data gets rejected by the deserializer by design, and is not consistent with deserialization in other parts of the code 