### PR TITLE
quic - fix NULL pointer dereference

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -2427,6 +2427,9 @@ fd_quic_ack_merge( fd_quic_conn_t * conn, uint enc_level ) {
 
       /* list has changed, so reestablish pri_ack and cur_ack */
       cur_ack = pri_ack->next;
+
+      /* cur_ack could be NULL here */
+      if( FD_UNLIKELY( !cur_ack ) ) break;
     }
 
     pri_ack = cur_ack;


### PR DESCRIPTION
https://github.com/firedancer-io/firedancer/pull/2078 introduced a NULL pointer dereference.
This fixes that.