### PR TITLE
sandbox: fix build on newer kernels

### DIFF
--- a/src/app/fdctl/run/run.c
+++ b/src/app/fdctl/run/run.c
@@ -406,8 +406,15 @@ run_firedancer( config_t * const config,
   fd_topo_print_log( 0, &config->topo );
 
 #if defined(__x86_64__)
+
+#ifndef SYS_landlock_create_ruleset
 #define SYS_landlock_create_ruleset 444
+#endif
+
+#ifndef LANDLOCK_CREATE_RULESET_VERSION
 #define LANDLOCK_CREATE_RULESET_VERSION (1U << 0)
+#endif
+
 #endif
   long abi = syscall( SYS_landlock_create_ruleset, NULL, 0, LANDLOCK_CREATE_RULESET_VERSION );
   if( -1L==abi && (errno==ENOSYS || errno==EOPNOTSUPP ) ) {

--- a/src/util/sandbox/fd_sandbox.c
+++ b/src/util/sandbox/fd_sandbox.c
@@ -28,8 +28,15 @@
 #if !defined(__x86_64__)
 #error "Target architecture is unsupported by seccomp."
 #else
+
+#ifndef SYS_landlock_create_ruleset
 #define SYS_landlock_create_ruleset 444
+#endif
+
+#ifndef SYS_landlock_restrict_self
 #define SYS_landlock_restrict_self 446
+#endif
+
 #endif
 
 extern char ** environ;

--- a/src/util/sandbox/test_sandbox.c
+++ b/src/util/sandbox/test_sandbox.c
@@ -415,7 +415,9 @@ test_resource_limits( void ) {
   TEST_FORK_EXIT_CODE( test_resource_limits_inner(), 0 );
 }
 
+#ifndef SYS_landlock_create_ruleset
 #define SYS_landlock_create_ruleset 444
+#endif
 
 struct landlock_ruleset_attr {
     __u64 handled_access_fs;


### PR DESCRIPTION
fd_sandbox always defines 'SYS_{...}' macros even when the current
kernel already defines them.  This patch adds ifndef guards to
unbreak Linux 6.8 builds.

Fixes #2086 
