### PR TITLE
flamenco: add fd_rust_cast_double_to_ulong to flamenco/types/fd_cast.h

### DIFF
--- a/src/flamenco/fd_flamenco_base.h
+++ b/src/flamenco/fd_flamenco_base.h
@@ -5,6 +5,7 @@
 #include "../ballet/base58/fd_base58.h"
 #include "../ballet/sha256/fd_sha256.h"
 #include "types/fd_types_custom.h"
+#include "types/fd_cast.h"
 
 #define FD_DEFAULT_SLOTS_PER_EPOCH   ( 432000UL )
 #define FD_DEFAULT_SHREDS_PER_EPOCH  ( ( 1 << 15UL ) * FD_DEFAULT_SLOTS_PER_EPOCH )

--- a/src/flamenco/types/Local.mk
+++ b/src/flamenco/types/Local.mk
@@ -1,9 +1,10 @@
 ifdef FD_HAS_INT128
-$(call add-hdrs,fd_bincode.h fd_types.h fd_types_custom.h fd_types_meta.h fd_types_yaml.h)
+$(call add-hdrs,fd_bincode.h fd_types.h fd_types_custom.h fd_types_meta.h fd_types_yaml.h fd_cast.h)
 $(call add-objs,fd_types fd_types_yaml,fd_flamenco)
 $(call make-unit-test,test_types_meta,test_types_meta,fd_flamenco fd_ballet fd_util)
 $(call make-unit-test,test_types_yaml,test_types_yaml,fd_flamenco fd_ballet fd_util)
 $(call make-unit-test,test_types_fixtures,test_types_fixtures,fd_flamenco fd_ballet fd_util)
+$(call make-unit-test,test_cast,test_cast,fd_flamenco fd_ballet fd_util)
 endif
 
 # "ConfirmedBlock" Protobuf definitions

--- a/src/flamenco/types/fd_cast.h
+++ b/src/flamenco/types/fd_cast.h
@@ -1,0 +1,48 @@
+#ifndef HEADER_fd_src_flamenco_types_fd_cast_h
+#define HEADER_fd_src_flamenco_types_fd_cast_h
+
+#include "../../util/bits/fd_float.h"
+
+/* From https://doc.rust-lang.org/rust-by-example/types/cast.html
+
+   Since Rust 1.45, the `as` keyword performs a *saturating cast*
+   when casting from float to int. If the floating point value exceeds
+   the upper bound or is less than the lower bound, the returned value
+   will be equal to the bound crossed. */
+
+FD_PROTOTYPES_BEGIN
+
+/* Cast a double to unsigned long the same way as rust by suturating.
+   Saturate to 0 if the value is negative or NaN.
+   Saturate to ULONG_MAX if the value is greater than ULONG_MAX. */
+FD_FN_CONST static inline ulong
+fd_rust_cast_double_to_ulong( double f ) {
+  ulong u = fd_dblbits( f );
+  /* Check if the exponent is all 1s (infinity or NaN )*/
+  if( fd_dblbits_bexp( u ) == 0x7FFUL ) {
+    /* Check if the mantissa is 0 (infinity) */
+    if( fd_dblbits_mant( u ) == 0 ) {
+      return ULONG_MAX;
+    } else {
+      /* NaN case */
+      return 0;
+    }
+  }
+
+  /* If the value is negative saturate to 0 */
+  if( fd_dblbits_sign( u ) == 1 ) {
+    return 0;
+  }
+
+  /* Saturate to max unsigned long value */
+  if( f > (double)ULONG_MAX ) {
+    return ULONG_MAX;
+  }
+
+  /* Normal value, cast to unsigned long */
+  return (ulong)f;
+}
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_flamenco_types_fd_cast_h */

--- a/src/flamenco/types/test_cast.c
+++ b/src/flamenco/types/test_cast.c
@@ -1,0 +1,26 @@
+#include "../fd_flamenco.h"
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+  fd_flamenco_boot( &argc, &argv );
+
+  double inf  = fd_double( fd_dblbits_pack( 0UL, 0x7FFUL, 0UL ) );
+  double ninf = fd_double( fd_dblbits_pack( 1UL, 0x7FFUL, 0UL ) );
+  double nan  = fd_double( fd_dblbits_pack( 1UL, 0x7FFUL, 1UL ) );
+  double neg  = -1.0;
+  double pos  = 42.0;
+  double max  = (double)ULONG_MAX+1;
+
+  FD_TEST( fd_rust_cast_double_to_ulong( inf  ) == ULONG_MAX );
+  FD_TEST( fd_rust_cast_double_to_ulong( ninf ) == ULONG_MAX );
+  FD_TEST( fd_rust_cast_double_to_ulong( nan  ) == 0  );
+  FD_TEST( fd_rust_cast_double_to_ulong( neg  ) == 0  );
+  FD_TEST( fd_rust_cast_double_to_ulong( pos  ) == 42 );
+  FD_TEST( fd_rust_cast_double_to_ulong( max  ) == ULONG_MAX );
+
+  fd_flamenco_halt();
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
This adds `fd_rust_cast_double_to_ulong ` for casting from double to unsigned long the same way as rust.

https://doc.rust-lang.org/rust-by-example/types/cast.html

https://github.com/firedancer-io/auditor-internal/issues/104
https://github.com/firedancer-io/auditor-internal/issues/105