### PR TITLE
json: fix Clang 18 support

### DIFF
--- a/src/ballet/json/cJSON.c
+++ b/src/ballet/json/cJSON.c
@@ -22,6 +22,11 @@
 
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 
+/* Known bug: cJSON uses NaN/infinity but we use -ffast-math */
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wnan-infinity-disabled"
+
 /* cJSON */
 /* JSON parser in C. */
 


### PR DESCRIPTION
Clang 18 rightfully complains about our use of NaN in cJSON
which is incompatible with our compile flags.  This is an acceptable
bug for now -- suppress the warning to unbreak build.
