### PR TITLE
simd: mask vf_fma if target doesn't support FMA

### DIFF
--- a/src/util/simd/fd_sse_vf.h
+++ b/src/util/simd/fd_sse_vf.h
@@ -177,9 +177,11 @@ vf_insert_variable( vf_t a, int n, float v ) {
 #define vf_copysign(a,b) _mm_or_ps( _mm_andnot_ps( _mm_set1_ps( -0.f ), (a) ), _mm_and_ps( _mm_set1_ps( -0.f ), (b) ) )
 #define vf_flipsign(a,b) _mm_xor_ps( (a), _mm_and_ps( _mm_set1_ps( -0.f ), (b) ) )
 
+#if defined(__FMA__)
 #define vf_fma(a,b,c)    _mm_fmadd_ps(  (a), (b), (c) )
 #define vf_fms(a,b,c)    _mm_fmsub_ps(  (a), (b), (c) )
 #define vf_fnma(a,b,c)   _mm_fnmadd_ps( (a), (b), (c) )
+#endif
 
 /* Binary operations */
 

--- a/src/util/simd/test_sse_2x64.c
+++ b/src/util/simd/test_sse_2x64.c
@@ -80,9 +80,13 @@ main( int     argc,
     FD_TEST( vd_test( vd_copysign( x, y ), copysign(x0,y0), copysign(x1,y1) ) );
     FD_TEST( vd_test( vd_flipsign( x, y ), y0<0.?-x0:x0, y1<0.?-x1:x1 ) );
 
+#   if defined(__FMA__)
     FD_TEST( vd_test( vd_fma(  x, y, z ),  x0*y0+z0,  x1*y1+z1 ) );
     FD_TEST( vd_test( vd_fms(  x, y, z ),  x0*y0-z0,  x1*y1-z1 ) );
     FD_TEST( vd_test( vd_fnma( x, y, z ), -x0*y0+z0, -x1*y1+z1 ) );
+#   else
+    (void)z;
+#   endif
 
     /* Logical operations */
 

--- a/src/util/simd/test_sse_4x32.c
+++ b/src/util/simd/test_sse_4x32.c
@@ -184,9 +184,13 @@ main( int     argc,
     FD_TEST( vf_test( vf_copysign( x, y ), copysignf(x0,y0), copysignf(x1,y1), copysignf(x2,y2), copysignf(x3,y3) ) );
     FD_TEST( vf_test( vf_flipsign( x, y ), y0<0.f?-x0:x0, y1<0.f?-x1:x1, y2<0.f?-x2:x2, y3<0.f?-x3:x3 ) );
 
+#   if defined(__FMA__)
     FD_TEST( vf_test( vf_fma(  x, y, z ),  x0*y0+z0,  x1*y1+z1,  x2*y2+z2,  x3*y3+z3 ) );
     FD_TEST( vf_test( vf_fms(  x, y, z ),  x0*y0-z0,  x1*y1-z1,  x2*y2-z2,  x3*y3-z3 ) );
     FD_TEST( vf_test( vf_fnma( x, y, z ), -x0*y0+z0, -x1*y1+z1, -x2*y2+z2, -x3*y3+z3 ) );
+#   else
+    (void)z;
+#   endif
 
     /* Logical operations */
 


### PR DESCRIPTION
Fixes compatibility with Ivy Bridge CPUs, which have SSE, but not
FMA.
