### PR TITLE
simd: only enable v{c,f,i,u,d,l,v}_gather on AVX2

### DIFF
--- a/src/util/simd/fd_sse_vc.h
+++ b/src/util/simd/fd_sse_vc.h
@@ -245,9 +245,11 @@ static inline vc_t vc_expand( vc_t c, int imm_hi ) {
    an "int const *".   User promises b[i(:)] values are already either 0
    or -1.  i here is a vi_t.  */
 
+#if defined(__AVX2__)
 #define vc_gather(b,i)      _mm_xor_si128( _mm_set1_epi32( -1 ), \
                                            _mm_cmpeq_epi32( _mm_i32gather_epi32( (b), (i), 4 ), _mm_setzero_si128() ) )
 #define vc_gather_fast(b,i) _mm_i32gather_epi32( (b), (i), 4 )
+#endif
 
 /* vc_transpose_4x4 transposes the 4x4 matrix stored in vc_t r0,r1,r2,r3
    and stores the result in 4x4 matrix vc_t c0,c1,c2,c3.  All

--- a/src/util/simd/fd_sse_vl.h
+++ b/src/util/simd/fd_sse_vl.h
@@ -290,9 +290,11 @@ vl_max_all( vl_t x ) { /* Returns vl_bcast( max( x ) ) */
    workaround clang sadness with passing a compile time constant into a
    static inline. */
 
+#if defined(__AVX2__)
 static inline vl_t _vl_gather( long const * b, vi_t i ) {
   return _mm_i32gather_epi64( (long long const *)b, i, 8 );
 }
+#endif
 
 #define vl_gather(b,i,imm_i0,imm_i1) _vl_gather( (b), _mm_shuffle_epi32( (i), _MM_SHUFFLE(3,2,(imm_i1),(imm_i0)) ) )
 

--- a/src/util/simd/fd_sse_vu.h
+++ b/src/util/simd/fd_sse_vu.h
@@ -297,9 +297,11 @@ vu_max_all( vu_t x ) { /* Returns vu_bcast( max( x ) ) */
    of a define to keep strict type checking while working around yet
    another Intel intrinsic type mismatch issue. */
 
+#if defined(__AVX2__)
 static inline vu_t vu_gather( uint const * b, vi_t i ) {
   return _mm_i32gather_epi32( (int const *)b, (i), 4 );
 }
+#endif /* defined(__AVX2__) */
 
 /* vu_transpose_4x4 transposes the 4x4 matrix stored in vu_t r0,r1,r2,r3
    and stores the result in 4x4 matrix vu_t c0,c1,c2,c3.  All

--- a/src/util/simd/test_sse_common.c
+++ b/src/util/simd/test_sse_common.c
@@ -35,7 +35,9 @@ int vc_test( vc_t c, int c0, int c1, int c2, int c3 ) {
   d = vc_ldu_fast( m+14 ); if( vc_any( vc_ne( c, d ) ) ) return 0;
   d = vc_ldu_fast( m+19 ); if( vc_any( vc_ne( c, d ) ) ) return 0;
 
+# if defined(__AVX2__)
   d = vc_gather_fast( m, vi(9,20,6,17) ); if( vc_any( vc_ne( c, d ) ) ) return 0;
+# endif
 
   for( int i=0; i<23; i++ ) m[i] *= (i+1);
 
@@ -45,7 +47,9 @@ int vc_test( vc_t c, int c0, int c1, int c2, int c3 ) {
   d = vc_ldu( m+14 ); if( !vc_all( vc_eq( c, d ) ) ) return 0;
   d = vc_ldu( m+19 ); if( !vc_all( vc_eq( c, d ) ) ) return 0;
 
+# if defined(__AVX2__)
   d = vc_gather( m, vi(19,5,16,12) ); if( !vc_all( vc_eq( c, d ) ) ) return 0;
+# endif
 
   d = vc_insert( vc_false(),0, c0 );
   d = vc_insert( d,         1, c1 );
@@ -87,7 +91,9 @@ int vf_test( vf_t f, float f0, float f1, float f2, float f3 ) {
   g = vf_ldu( m+14 ); if( vc_pack( vf_eq( f, g ) )!=15 ) return 0;
   g = vf_ldu( m+19 ); if( vc_pack( vf_eq( f, g ) )!=15 ) return 0;
 
+# if defined(__AVX2__)
   g = vf_gather( m, vi(14,5,21,12) ); if( !vc_all( vf_eq( f, g ) ) ) return 0;
+# endif
 
   g = vf_insert( vf_zero(),0, f0 );
   g = vf_insert( g,        1, f1 );
@@ -129,7 +135,9 @@ int vi_test( vi_t i, int i0, int i1, int i2, int i3 ) {
   j = vi_ldu( m+14 ); if( vc_pack( vi_eq( i, j ) )!=15 ) return 0;
   j = vi_ldu( m+19 ); if( vc_pack( vi_eq( i, j ) )!=15 ) return 0;
 
+# if defined(__AVX2__)
   j = vi_gather( m, vi(9,5,21,17) ); if( !vc_all( vi_eq( i, j ) ) ) return 0;
+# endif
 
   j = vi_insert( vi_zero(),0, i0 );
   j = vi_insert( j,        1, i1 );
@@ -171,7 +179,9 @@ int vu_test( vu_t u, uint u0, uint u1, uint u2, uint u3 ) {
   v = vu_ldu( m+14 ); if( vc_pack( vu_eq( u, v ) )!=15 ) return 0;
   v = vu_ldu( m+19 ); if( vc_pack( vu_eq( u, v ) )!=15 ) return 0;
 
+# if defined(__AVX2__)
   v = vu_gather( m, vu(9,5,21,17) ); if( !vc_all( vu_eq( u, v ) ) ) return 0;
+# endif
 
   v = vu_insert( vu_zero(),0, u0 );
   v = vu_insert( v,        1, u1 );
@@ -205,10 +215,12 @@ int vd_test( vd_t d, double d0, double d1 ) {
   e = vd_ldu( m+2 ); if( vc_pack( vd_eq( d, e ) )!=15 ) return 0;
   e = vd_ldu( m+5 ); if( vc_pack( vd_eq( d, e ) )!=15 ) return 0;
 
+# if defined(__AVX2__)
   e = vd_gather( m, vi( 2, 6, 5, 3 ), 0,1 ); if( !vc_all( vd_eq( d, e ) ) ) return 0;
   e = vd_gather( m, vi( 2, 6, 5, 3 ), 0,3 ); if( !vc_all( vd_eq( d, e ) ) ) return 0;
   e = vd_gather( m, vi( 2, 6, 5, 3 ), 2,1 ); if( !vc_all( vd_eq( d, e ) ) ) return 0;
   e = vd_gather( m, vi( 2, 6, 5, 3 ), 2,3 ); if( !vc_all( vd_eq( d, e ) ) ) return 0;
+# endif
 
   e = vd_insert( vd_zero(),0, d0 );
   e = vd_insert( e,        1, d1 ); if( vc_any( vd_ne( d, e ) ) ) return 0;
@@ -238,10 +250,12 @@ int vl_test( vl_t l, long l0, long l1 ) {
   k = vl_ldu( m+2  ); if( vc_pack( vl_eq( l, k ) )!=15 ) return 0;
   k = vl_ldu( m+5  ); if( vc_pack( vl_eq( l, k ) )!=15 ) return 0;
 
+# if defined(__AVX2__)
   k = vl_gather( m, vi( 2, 6, 5, 3 ), 0,1 ); if( !vc_all( vl_eq( l, k ) ) ) return 0;
   k = vl_gather( m, vi( 2, 6, 5, 3 ), 0,3 ); if( !vc_all( vl_eq( l, k ) ) ) return 0;
   k = vl_gather( m, vi( 2, 6, 5, 3 ), 2,1 ); if( !vc_all( vl_eq( l, k ) ) ) return 0;
   k = vl_gather( m, vi( 2, 6, 5, 3 ), 2,3 ); if( !vc_all( vl_eq( l, k ) ) ) return 0;
+# endif
 
   k = vl_insert( vl_zero(),0, l0 );
   k = vl_insert( k,        1, l1 ); if( vc_any( vl_ne( l, k ) ) ) return 0;
@@ -271,10 +285,12 @@ int vv_test( vv_t v, ulong v0, ulong v1 ) {
   w = vv_ldu( m+2  ); if( vc_pack( vv_eq( v, w ) )!=15 ) return 0;
   w = vv_ldu( m+5  ); if( vc_pack( vv_eq( v, w ) )!=15 ) return 0;
 
+# if defined(__AVX2__)
   w = vv_gather( m, vi( 2, 6, 5, 3 ), 0,1 ); if( !vc_all( vv_eq( v, w ) ) ) return 0;
   w = vv_gather( m, vi( 2, 6, 5, 3 ), 0,3 ); if( !vc_all( vv_eq( v, w ) ) ) return 0;
   w = vv_gather( m, vi( 2, 6, 5, 3 ), 2,1 ); if( !vc_all( vv_eq( v, w ) ) ) return 0;
   w = vv_gather( m, vi( 2, 6, 5, 3 ), 2,3 ); if( !vc_all( vv_eq( v, w ) ) ) return 0;
+# endif
 
   w = vv_insert( vv_zero(),0, v0 );
   w = vv_insert( w,        1, v1 ); if( vc_any( vv_ne( v, w ) ) ) return 0;


### PR DESCRIPTION
vc_gather and co are defined in fd_sse but require AVX2.
This patch adds compile guards to fix builds on targets without AVX.
