### PR TITLE
util: fix test_sort on Clang 18

### DIFF
--- a/src/util/tmpl/test_sort.c
+++ b/src/util/tmpl/test_sort.c
@@ -203,12 +203,12 @@ main( int     argc,
     FD_TEST( sort_up_search_geq( NULL, 0UL, 3.0f )==0UL );
     float sorted[1024];
     for( ulong j=0UL; j<1024UL; j++ ) sorted[j] = (float)j;
-    FD_TEST( sort_up_search_geq( sorted, 1024UL, -INFINITY )==0UL );
+    FD_TEST( sort_up_search_geq( sorted, 1024.0f, -9999.0f )==0UL );
     for( ulong j=0UL; j<2048UL; j++ ) {
       float query = sorted[j/2] + (((float)(j&1UL))/2.0f);
-      FD_TEST( sort_up_search_geq( sorted, 1024UL, query )==j/2 );
+      FD_TEST( sort_up_search_geq( sorted, 1024.0f, query )==j/2 );
     }
-    FD_TEST( sort_up_search_geq( sorted, 1024UL, INFINITY )==1023UL );
+    FD_TEST( sort_up_search_geq( sorted, 1024.0f, 9999.0f )==1023UL );
   } while(0);
 
   fd_rng_delete( fd_rng_leave( rng ) );


### PR DESCRIPTION
test_sort.c had some type confusion issues where ulong literals
were used in place of floats.  Also used INFINITY which is U.B.
in the Firedancer programming model.

Fixes #2089 
