### PR TITLE
deps.sh: use dnf install --skip-broken flag

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -129,9 +129,9 @@ check_fedora_pkgs () {
   fi
 
   if [[ -z "${SUDO}" ]]; then
-    PACKAGE_INSTALL_CMD=( dnf install -y ${MISSING_RPMS[*]} )
+    PACKAGE_INSTALL_CMD=( dnf install -y --skip-broken ${MISSING_RPMS[*]} )
   else
-    PACKAGE_INSTALL_CMD=( "${SUDO}" dnf install -y ${MISSING_RPMS[*]} )
+    PACKAGE_INSTALL_CMD=( "${SUDO}" dnf install -y --skip-broken ${MISSING_RPMS[*]} )
   fi
 }
 


### PR DESCRIPTION
Allows deps.sh to succeed even if a package was not found.

Fixes #2085
