### PR TITLE
Fix GCC 14 build

### DIFF
--- a/src/ballet/ed25519/fd_curve25519.h
+++ b/src/ballet/ed25519/fd_curve25519.h
@@ -141,7 +141,7 @@ fd_ed25519_scalar_mul( fd_ed25519_point_t *       r,
 /* fd_ed25519_scalar_mul_base_const_time computes r = n * P, and returns r.
    n is a scalar. P is the base point.
    Note: const time implementation, safe to use with n secret. */
-fd_ed25519_point_t *
+fd_ed25519_point_t * FD_FN_SENSITIVE
 fd_ed25519_scalar_mul_base_const_time( fd_ed25519_point_t * r,
                                        uchar const          n[ 32 ] ); /* can be a secret */
 


### PR DESCRIPTION
GCC 14 considers the FD_FN_SENSITIVE attribute as part of the
function signature.  We were declaring functions with the attribute
and then assigning them to function pointers without it.

Since the attribute is only available on GCC 14 but we've been
using older versions, we've never noticed that the build is broken.

Fixes #2087