### PR TITLE
flamenco: cast safely with fd_rust_cast_double_to_ulong

### DIFF
--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -2691,7 +2691,9 @@ fd_rent_due(fd_account_meta_t *acc,
   }
 
   ulong lamports_per_year = rent->lamports_per_uint8_year * (acc->dlen + 128UL);
-  return (long)(ulong)(years_elapsed * (double)lamports_per_year);
+  /* https://github.com/anza-xyz/agave/blob/d2124a995f89e33c54f41da76bfd5b0bd5820898/sdk/src/rent_collector.rs#L108 */
+  /* https://github.com/anza-xyz/agave/blob/d2124a995f89e33c54f41da76bfd5b0bd5820898/sdk/program/src/rent.rs#L95 */
+  return (long)fd_rust_cast_double_to_ulong(years_elapsed * (double)lamports_per_year);
 }
 
 /* fd_runtime_collect_rent_account performs rent collection duties.

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -215,11 +215,6 @@ fd_runtime_lamports_per_signature_for_blockhash( fd_exec_slot_ctx_t const * slot
 // fd_global_import_solana_manifest( fd_exec_slot_ctx_t * slot_ctx,
 //                                   fd_solana_manifest_t * manifest);
 
-static inline ulong
-fd_rent_exempt( fd_rent_t const * rent,
-                ulong             sz ) {
-  return (sz + 128) * ((ulong) ((double)rent->lamports_per_uint8_year * rent->exemption_threshold));
-}
 
 void
 fd_process_new_epoch( fd_exec_slot_ctx_t * slot_ctx,

--- a/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
@@ -1,5 +1,6 @@
 #include "fd_sysvar_clock.h"
 #include "fd_sysvar_epoch_schedule.h"
+#include "fd_sysvar_rent.h"
 #include "fd_sysvar.h"
 #include "../fd_executor.h"
 #include "../fd_acc_mgr.h"
@@ -427,7 +428,7 @@ fd_sysvar_clock_update( fd_exec_slot_ctx_t * slot_ctx ) {
   if( fd_sol_sysvar_clock_encode( &clock, &e_ctx ) )
     return FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR;
 
-  ulong lamps = (sz + 128) * ((ulong) ((double)epoch_bank->rent.lamports_per_uint8_year * epoch_bank->rent.exemption_threshold));
+  ulong lamps = fd_rent_exempt_minimum_balance2( &epoch_bank->rent, sz );
   if( acc->meta->info.lamports < lamps )
     acc->meta->info.lamports = lamps;
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
@@ -64,8 +64,8 @@ fd_sysvar_rent_init( fd_exec_slot_ctx_t * slot_ctx ) {
 ulong
 fd_rent_exempt_minimum_balance2( fd_rent_t const * rent,
                                  ulong             data_len ) {
-  /* https://github.com/solana-labs/solana/blob/792fafe0c25ac06868e3ac80a2b13f1a5b4a1ef8/sdk/program/src/rent.rs#L72 */
-  return (ulong)( (double)((data_len + ACCOUNT_STORAGE_OVERHEAD) * rent->lamports_per_uint8_year) * (double)rent->exemption_threshold );
+  /* https://github.com/anza-xyz/agave/blob/d2124a995f89e33c54f41da76bfd5b0bd5820898/sdk/program/src/rent.rs#L74 */
+  return fd_rust_cast_double_to_ulong( (double)((data_len + ACCOUNT_STORAGE_OVERHEAD) * rent->lamports_per_uint8_year) * rent->exemption_threshold );
 }
 
 ulong


### PR DESCRIPTION
https://github.com/firedancer-io/auditor-internal/issues/105

also remove `fd_rent_exempt` since it doesn't appear to be used anywhere