### PR TITLE
flamenco, fuzz: fuzz `fd_vm_validate`

### DIFF
--- a/src/flamenco/runtime/tests/Local.mk
+++ b/src/flamenco/runtime/tests/Local.mk
@@ -3,8 +3,8 @@ $(call add-objs,generated/context.pb generated/elf.pb generated/invoke.pb genera
 
 ifdef FD_HAS_INT128
 ifdef FD_HAS_SECP256K1
-$(call add-hdrs,fd_exec_instr_test.h)
-$(call add-objs,fd_exec_instr_test,fd_flamenco)
+$(call add-hdrs,fd_exec_instr_test.h fd_vm_validate_test.h)
+$(call add-objs,fd_exec_instr_test fd_vm_validate_test,fd_flamenco)
 $(call add-objs,fd_exec_sol_compat,fd_flamenco)
 
 $(call make-unit-test,test_exec_instr,test_exec_instr,fd_flamenco fd_funk fd_ballet fd_util fd_disco,$(SECP256K1_LIBS))

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.h
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.h
@@ -98,6 +98,7 @@ fd_exec_vm_syscall_test_run( fd_exec_instr_test_runner_t *          runner,
                              void *                                 output_buf,
                              ulong                                  output_bufsz );
 
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_flamenco_runtime_tests_fd_exec_instr_test_h */

--- a/src/flamenco/runtime/tests/fd_exec_sol_compat.c
+++ b/src/flamenco/runtime/tests/fd_exec_sol_compat.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include "../../vm/fd_vm.h"
+#include "fd_vm_validate_test.h"
 
 /* This file defines stable APIs for compatibility testing.
 
@@ -47,6 +48,7 @@ static ulong supported_features[] =
     0x8a8eb9085ca2bb0b,  // commission_updates_only_allowed_in_first_half_of_epoch
     0x7bc99a080444c8d9,  // allow_votes_to_directly_update_vote_state
     0x2ca5833736ba5c69,  // compact_vote_state_updates
+    0x7e787d5c6d662d23,  // reject_callx_r10
   };
 
 static       uchar *     smem;
@@ -455,4 +457,41 @@ sol_compat_vm_syscall_execute_v1( uchar *       out,
   pb_release( &fd_exec_test_syscall_context_t_msg, input );
   sol_compat_cleanup_scratch_and_runner( runner );
   return ok;
+}
+
+int
+sol_compat_vm_validate_v1(  uchar *       out,
+                            ulong *       out_sz,
+                            uchar const * in,
+                            ulong         in_sz) {
+  // Setup
+  ulong fmem[ 64 ];
+  fd_exec_instr_test_runner_t * runner = sol_compat_setup_scratch_and_runner( fmem );
+
+  // Decode context
+  fd_exec_test_full_vm_context_t input[1] = {0};
+  void * res = sol_compat_decode( &input, in, in_sz, &fd_exec_test_full_vm_context_t_msg );
+  if ( res==NULL ) {
+    sol_compat_cleanup_scratch_and_runner( runner );
+    return 0;
+  }
+
+  // Execute
+  void * output = NULL;
+  sol_compat_execute_wrapper( runner, input, &output, (exec_test_run_fn_t *)fd_exec_vm_validate_test_run );
+
+  // Encode effects
+  int ok = 0;
+  if( output ) {
+    ok = !!sol_compat_encode( out, out_sz, output, &fd_exec_test_validate_vm_effects_t_msg );
+  }
+
+  // cleanup
+  pb_release( &fd_exec_test_full_vm_context_t_msg, input );
+  sol_compat_cleanup_scratch_and_runner( runner );
+  return ok;
+
+
+
+  
 }

--- a/src/flamenco/runtime/tests/fd_vm_validate_test.c
+++ b/src/flamenco/runtime/tests/fd_vm_validate_test.c
@@ -1,0 +1,88 @@
+#include "fd_vm_validate_test.h"
+#include "../context/fd_exec_epoch_ctx.h"
+#include "../context/fd_exec_slot_ctx.h"
+#include "../context/fd_exec_txn_ctx.h"
+#include "../../vm/test_vm_util.h"
+
+ulong
+fd_exec_vm_validate_test_run( fd_exec_instr_test_runner_t *         runner,
+                              fd_exec_test_full_vm_context_t const *input,
+                              fd_exec_test_validate_vm_effects_t ** output,
+                              void *                                output_buf,
+                              ulong                                 output_bufsz ) {
+  (void) runner; /* unused, for wrapper compat */
+  if( FD_UNLIKELY( !input->has_vm_ctx ) ) {
+    return 0UL;
+  }
+  
+  fd_exec_test_vm_context_t const * vm_ctx = &input->vm_ctx;
+  if( FD_UNLIKELY( !vm_ctx->rodata ) ) {
+    return 0UL;
+  }
+
+  int rej_callx_r10 = false;
+  if( input->has_features ) {
+    for( ulong i=0UL; i < input->features.features_count; i++ ) {
+      if( input->features.features[i] == TEST_VM_REJECT_CALLX_R10_FEATURE_PREFIX ) {
+        rej_callx_r10 = 1;
+        break;
+      }
+    }
+  }
+  fd_exec_instr_ctx_t * ctx = test_vm_minimal_exec_instr_ctx( fd_libc_alloc_virtual(), rej_callx_r10 );
+
+  FD_TEST( output_bufsz >= sizeof(fd_exec_test_validate_vm_effects_t) );
+
+  /* Capture outputs */
+  FD_SCRATCH_ALLOC_INIT( l, output_buf );
+
+  fd_exec_test_validate_vm_effects_t * effects =
+    FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_exec_test_validate_vm_effects_t),
+                                sizeof (fd_exec_test_validate_vm_effects_t) );
+  FD_SCRATCH_ALLOC_FINI( l, 1UL );
+
+  fd_valloc_t valloc = fd_scratch_virtual();
+  do{
+    uchar * rodata = vm_ctx->rodata->bytes;
+    ulong rodata_sz = vm_ctx->rodata->size;
+
+    ulong * text = (ulong *) (rodata + vm_ctx->rodata_text_section_offset);    
+    ulong text_cnt = vm_ctx->rodata_text_section_length / 8UL;
+
+    fd_vm_t * vm = fd_vm_join( fd_vm_new( fd_valloc_malloc( valloc, fd_vm_align(), fd_vm_footprint() ) ) );
+    FD_TEST( vm );
+
+    fd_vm_init(
+      vm,
+      ctx,
+      0, /* heap_max */
+      0, /* cu_avail */
+      rodata,
+      rodata_sz,
+      text,
+      text_cnt,
+      vm_ctx->rodata_text_section_offset,
+      vm_ctx->rodata_text_section_length,
+      0, /* entry_pc, not used in validate at the moment */
+      NULL, /* calldests */
+      NULL, /* syscalls */
+      NULL, /* input */
+      0, /* input_sz */
+      NULL, /* trace */
+      NULL /* sha */
+    );
+    effects->result = fd_vm_validate( vm );
+
+    fd_valloc_free( valloc, fd_vm_delete( fd_vm_leave( vm ) ) );
+
+  } while(0);
+  
+
+  /* Run vm validate and capture result */
+  
+  effects->success = (effects->result == FD_VM_SUCCESS);
+  *output = effects;
+  
+  test_vm_exec_instr_ctx_delete( ctx );
+  return sizeof (fd_exec_test_validate_vm_effects_t);
+}

--- a/src/flamenco/runtime/tests/fd_vm_validate_test.h
+++ b/src/flamenco/runtime/tests/fd_vm_validate_test.h
@@ -1,0 +1,29 @@
+#ifndef HEADER_fd_src_flamenco_runtime_tests_fd_exec_vm_test_h
+#define HEADER_fd_src_flamenco_runtime_tests_fd_exec_vm_test_h
+
+#include "fd_exec_instr_test.h" /* FIXME: extract common exec test API */
+#include "generated/vm.pb.h"
+#include "../../vm/fd_vm.h"
+
+/* fd_exec_vm_test.h provides APIs for running VM specific tests */
+
+/* FIXME: Migrate from fd_exec_instr_test, but need to expose _context_{create,destroy} */
+// FD_PROTOTYPES_BEGIN
+// ulong
+// fd_exec_vm_syscall_test_run( fd_exec_instr_test_runner_t *          runner,
+//                              fd_exec_test_syscall_context_t const * input,
+//                              fd_exec_test_syscall_effects_t **      output,
+//                              void *                                 output_buf,
+//                              ulong                                  output_bufsz );
+
+
+ulong
+fd_exec_vm_validate_test_run( fd_exec_instr_test_runner_t *         runner,
+                              fd_exec_test_full_vm_context_t const *input,
+                              fd_exec_test_validate_vm_effects_t ** output,
+                              void *                                output_buf,
+                              ulong                                 output_bufsz );
+
+FD_PROTOTYPES_END
+
+#endif

--- a/src/flamenco/runtime/tests/generated/vm.pb.c
+++ b/src/flamenco/runtime/tests/generated/vm.pb.c
@@ -24,6 +24,9 @@ PB_BIND(FD_EXEC_TEST_SYSCALL_EFFECTS, fd_exec_test_syscall_effects_t, AUTO)
 PB_BIND(FD_EXEC_TEST_SYSCALL_FIXTURE, fd_exec_test_syscall_fixture_t, 2)
 
 
+PB_BIND(FD_EXEC_TEST_FULL_VM_CONTEXT, fd_exec_test_full_vm_context_t, AUTO)
+
+
 PB_BIND(FD_EXEC_TEST_VALIDATE_VM_EFFECTS, fd_exec_test_validate_vm_effects_t, AUTO)
 
 

--- a/src/flamenco/runtime/tests/generated/vm.pb.h
+++ b/src/flamenco/runtime/tests/generated/vm.pb.h
@@ -6,6 +6,7 @@
 
 #include "../../../nanopb/pb_firedancer.h"
 #include "invoke.pb.h"
+#include "context.pb.h"
 
 #if PB_PROTO_HEADER_VERSION != 40
 #error Regenerate this file with the current version of nanopb generator.
@@ -101,6 +102,15 @@ typedef struct fd_exec_test_syscall_fixture {
     fd_exec_test_syscall_effects_t output;
 } fd_exec_test_syscall_fixture_t;
 
+/* Everything needed to setup a fd_vm_t */
+typedef struct fd_exec_test_full_vm_context {
+    bool has_vm_ctx;
+    fd_exec_test_vm_context_t vm_ctx;
+    /* InstrContext instr_ctx = 2; */
+    bool has_features;
+    fd_exec_test_feature_set_t features;
+} fd_exec_test_full_vm_context_t;
+
 /* Effects of fd_vm_validate */
 typedef struct fd_exec_test_validate_vm_effects {
     int32_t result;
@@ -120,6 +130,7 @@ extern "C" {
 #define FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_DEFAULT {false, FD_EXEC_TEST_VM_CONTEXT_INIT_DEFAULT, false, FD_EXEC_TEST_INSTR_CONTEXT_INIT_DEFAULT, false, FD_EXEC_TEST_SYSCALL_INVOCATION_INIT_DEFAULT}
 #define FD_EXEC_TEST_SYSCALL_EFFECTS_INIT_DEFAULT {0, 0, 0, NULL, NULL, NULL, 0, NULL}
 #define FD_EXEC_TEST_SYSCALL_FIXTURE_INIT_DEFAULT {false, FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_DEFAULT, false, FD_EXEC_TEST_SYSCALL_EFFECTS_INIT_DEFAULT}
+#define FD_EXEC_TEST_FULL_VM_CONTEXT_INIT_DEFAULT {false, FD_EXEC_TEST_VM_CONTEXT_INIT_DEFAULT, false, FD_EXEC_TEST_FEATURE_SET_INIT_DEFAULT}
 #define FD_EXEC_TEST_VALIDATE_VM_EFFECTS_INIT_DEFAULT {0, 0}
 #define FD_EXEC_TEST_INPUT_DATA_REGION_INIT_ZERO {0, NULL, 0}
 #define FD_EXEC_TEST_VM_CONTEXT_INIT_ZERO        {0, NULL, 0, 0, 0, NULL, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
@@ -127,6 +138,7 @@ extern "C" {
 #define FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_ZERO   {false, FD_EXEC_TEST_VM_CONTEXT_INIT_ZERO, false, FD_EXEC_TEST_INSTR_CONTEXT_INIT_ZERO, false, FD_EXEC_TEST_SYSCALL_INVOCATION_INIT_ZERO}
 #define FD_EXEC_TEST_SYSCALL_EFFECTS_INIT_ZERO   {0, 0, 0, NULL, NULL, NULL, 0, NULL}
 #define FD_EXEC_TEST_SYSCALL_FIXTURE_INIT_ZERO   {false, FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_ZERO, false, FD_EXEC_TEST_SYSCALL_EFFECTS_INIT_ZERO}
+#define FD_EXEC_TEST_FULL_VM_CONTEXT_INIT_ZERO   {false, FD_EXEC_TEST_VM_CONTEXT_INIT_ZERO, false, FD_EXEC_TEST_FEATURE_SET_INIT_ZERO}
 #define FD_EXEC_TEST_VALIDATE_VM_EFFECTS_INIT_ZERO {0, 0}
 
 /* Field tags (for use in manual encoding/decoding) */
@@ -165,6 +177,8 @@ extern "C" {
 #define FD_EXEC_TEST_SYSCALL_EFFECTS_LOG_TAG     8
 #define FD_EXEC_TEST_SYSCALL_FIXTURE_INPUT_TAG   1
 #define FD_EXEC_TEST_SYSCALL_FIXTURE_OUTPUT_TAG  2
+#define FD_EXEC_TEST_FULL_VM_CONTEXT_VM_CTX_TAG  1
+#define FD_EXEC_TEST_FULL_VM_CONTEXT_FEATURES_TAG 3
 #define FD_EXEC_TEST_VALIDATE_VM_EFFECTS_RESULT_TAG 1
 #define FD_EXEC_TEST_VALIDATE_VM_EFFECTS_SUCCESS_TAG 2
 
@@ -234,6 +248,14 @@ X(a, STATIC,   OPTIONAL, MESSAGE,  output,            2)
 #define fd_exec_test_syscall_fixture_t_input_MSGTYPE fd_exec_test_syscall_context_t
 #define fd_exec_test_syscall_fixture_t_output_MSGTYPE fd_exec_test_syscall_effects_t
 
+#define FD_EXEC_TEST_FULL_VM_CONTEXT_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  vm_ctx,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  features,          3)
+#define FD_EXEC_TEST_FULL_VM_CONTEXT_CALLBACK NULL
+#define FD_EXEC_TEST_FULL_VM_CONTEXT_DEFAULT NULL
+#define fd_exec_test_full_vm_context_t_vm_ctx_MSGTYPE fd_exec_test_vm_context_t
+#define fd_exec_test_full_vm_context_t_features_MSGTYPE fd_exec_test_feature_set_t
+
 #define FD_EXEC_TEST_VALIDATE_VM_EFFECTS_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, INT32,    result,            1) \
 X(a, STATIC,   SINGULAR, BOOL,     success,           2)
@@ -246,6 +268,7 @@ extern const pb_msgdesc_t fd_exec_test_syscall_invocation_t_msg;
 extern const pb_msgdesc_t fd_exec_test_syscall_context_t_msg;
 extern const pb_msgdesc_t fd_exec_test_syscall_effects_t_msg;
 extern const pb_msgdesc_t fd_exec_test_syscall_fixture_t_msg;
+extern const pb_msgdesc_t fd_exec_test_full_vm_context_t_msg;
 extern const pb_msgdesc_t fd_exec_test_validate_vm_effects_t_msg;
 
 /* Defines for backwards compatibility with code written before nanopb-0.4.0 */
@@ -255,6 +278,7 @@ extern const pb_msgdesc_t fd_exec_test_validate_vm_effects_t_msg;
 #define FD_EXEC_TEST_SYSCALL_CONTEXT_FIELDS &fd_exec_test_syscall_context_t_msg
 #define FD_EXEC_TEST_SYSCALL_EFFECTS_FIELDS &fd_exec_test_syscall_effects_t_msg
 #define FD_EXEC_TEST_SYSCALL_FIXTURE_FIELDS &fd_exec_test_syscall_fixture_t_msg
+#define FD_EXEC_TEST_FULL_VM_CONTEXT_FIELDS &fd_exec_test_full_vm_context_t_msg
 #define FD_EXEC_TEST_VALIDATE_VM_EFFECTS_FIELDS &fd_exec_test_validate_vm_effects_t_msg
 
 /* Maximum encoded size of messages (where known) */
@@ -264,6 +288,7 @@ extern const pb_msgdesc_t fd_exec_test_validate_vm_effects_t_msg;
 /* fd_exec_test_SyscallContext_size depends on runtime parameters */
 /* fd_exec_test_SyscallEffects_size depends on runtime parameters */
 /* fd_exec_test_SyscallFixture_size depends on runtime parameters */
+/* fd_exec_test_FullVmContext_size depends on runtime parameters */
 #define FD_EXEC_TEST_VALIDATE_VM_EFFECTS_SIZE    13
 #define ORG_SOLANA_SEALEVEL_V1_VM_PB_H_MAX_SIZE  FD_EXEC_TEST_VALIDATE_VM_EFFECTS_SIZE
 
@@ -274,6 +299,7 @@ extern const pb_msgdesc_t fd_exec_test_validate_vm_effects_t_msg;
 #define org_solana_sealevel_v1_SyscallContext fd_exec_test_SyscallContext
 #define org_solana_sealevel_v1_SyscallEffects fd_exec_test_SyscallEffects
 #define org_solana_sealevel_v1_SyscallFixture fd_exec_test_SyscallFixture
+#define org_solana_sealevel_v1_FullVmContext fd_exec_test_FullVmContext
 #define org_solana_sealevel_v1_ValidateVmEffects fd_exec_test_ValidateVmEffects
 #define ORG_SOLANA_SEALEVEL_V1_INPUT_DATA_REGION_INIT_DEFAULT FD_EXEC_TEST_INPUT_DATA_REGION_INIT_DEFAULT
 #define ORG_SOLANA_SEALEVEL_V1_VM_CONTEXT_INIT_DEFAULT FD_EXEC_TEST_VM_CONTEXT_INIT_DEFAULT
@@ -281,6 +307,7 @@ extern const pb_msgdesc_t fd_exec_test_validate_vm_effects_t_msg;
 #define ORG_SOLANA_SEALEVEL_V1_SYSCALL_CONTEXT_INIT_DEFAULT FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_DEFAULT
 #define ORG_SOLANA_SEALEVEL_V1_SYSCALL_EFFECTS_INIT_DEFAULT FD_EXEC_TEST_SYSCALL_EFFECTS_INIT_DEFAULT
 #define ORG_SOLANA_SEALEVEL_V1_SYSCALL_FIXTURE_INIT_DEFAULT FD_EXEC_TEST_SYSCALL_FIXTURE_INIT_DEFAULT
+#define ORG_SOLANA_SEALEVEL_V1_FULL_VM_CONTEXT_INIT_DEFAULT FD_EXEC_TEST_FULL_VM_CONTEXT_INIT_DEFAULT
 #define ORG_SOLANA_SEALEVEL_V1_VALIDATE_VM_EFFECTS_INIT_DEFAULT FD_EXEC_TEST_VALIDATE_VM_EFFECTS_INIT_DEFAULT
 #define ORG_SOLANA_SEALEVEL_V1_INPUT_DATA_REGION_INIT_ZERO FD_EXEC_TEST_INPUT_DATA_REGION_INIT_ZERO
 #define ORG_SOLANA_SEALEVEL_V1_VM_CONTEXT_INIT_ZERO FD_EXEC_TEST_VM_CONTEXT_INIT_ZERO
@@ -288,6 +315,7 @@ extern const pb_msgdesc_t fd_exec_test_validate_vm_effects_t_msg;
 #define ORG_SOLANA_SEALEVEL_V1_SYSCALL_CONTEXT_INIT_ZERO FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_ZERO
 #define ORG_SOLANA_SEALEVEL_V1_SYSCALL_EFFECTS_INIT_ZERO FD_EXEC_TEST_SYSCALL_EFFECTS_INIT_ZERO
 #define ORG_SOLANA_SEALEVEL_V1_SYSCALL_FIXTURE_INIT_ZERO FD_EXEC_TEST_SYSCALL_FIXTURE_INIT_ZERO
+#define ORG_SOLANA_SEALEVEL_V1_FULL_VM_CONTEXT_INIT_ZERO FD_EXEC_TEST_FULL_VM_CONTEXT_INIT_ZERO
 #define ORG_SOLANA_SEALEVEL_V1_VALIDATE_VM_EFFECTS_INIT_ZERO FD_EXEC_TEST_VALIDATE_VM_EFFECTS_INIT_ZERO
 
 #ifdef __cplusplus

--- a/src/flamenco/vm/fd_vm_base.h
+++ b/src/flamenco/vm/fd_vm_base.h
@@ -75,6 +75,9 @@
 #define FD_VM_ERR_LDQ_NO_ADDL_IMM   (-33) /* detected a ldq without an addl imm following it */
 #define FD_VM_ERR_NO_SUCH_EXT_CALL  (-34) /* detected a call imm with no function was registered for that immediate */
 #define FD_VM_ERR_INVALID_REG       (-35) /* detected an invalid register */
+#define FD_VM_ERR_BAD_TEXT          (-36) /* detected a bad text section (overflow, outside rodata boundary, etc.,)*/
+#define FD_VM_SH_OVERFLOW           (-37) /* detected a shift overflow, equivalent to VeriferError::ShiftWithOverflow */
+#define FD_VM_TEXT_SZ_UNALIGNED     (-38) /* detected a text section that is not a multiple of 8 */
 
 FD_PROTOTYPES_BEGIN
 


### PR DESCRIPTION
- Adds fuzzing harness for `fd_vm_validate`
- Some changes to the validate function:
  - Shift overflow checks for `BPF_ARSH` (0xc4) and ` BPF_ARSH64` (0xc7)
    - New error code for shift overflow (`FD_VM_SH_OVERFLOW`)
  - Boundary checks
    - New error code (`FD_VM_ERR_BAD_TEXT`)
  - Text size alignment checks
    - New error code (`FD_VM_TEXT_SZ_UNALIGNED`) 
  - Empty `text_cnt` checks
  - Additional immediate checks for LDQ (0x18) instructions