### PR TITLE
refactor(ghost): init, node insert, slot key, publish, print, more tests

### DIFF
--- a/src/choreo/ghost/fd_ghost.h
+++ b/src/choreo/ghost/fd_ghost.h
@@ -1,36 +1,45 @@
 #ifndef HEADER_fd_src_choreo_ghost_fd_ghost_h
 #define HEADER_fd_src_choreo_ghost_fd_ghost_h
 
-/* fd_ghost ("greedy heaviest-observed subtree") implements Solana's LMD-GHOST fork choice rule.
+/* fd_ghost implements Solana's LMD-GHOST ("latest message-driven greedy
+   heaviest-observed subtree") fork choice rule.
 
    Protocol details:
 
-   - GHOST is an acronym for "greedy heaviest-observed subtree":
-     - greedy: pick the locally optimal subtree / fork based on our current view, which may not be globally optimal.
-     - heaviest: pick based on the highest stake weight.
-     - observed: this is the validator's local view, and other validators may have differing views.
-     - subtree: pick a subtree, not an individual node.
+   - LMD is an acronym for "latest message-driven". It denotes the
+     specific flavor of GHOST implementation, ie. only a
+     validator's latest vote counts.
 
-   - LMD is an acronym for "latest message-driven". It denotes the specific flavor of GHOST
-     implementation: in this case, only a validator's latest vote counts.
+   - GHOST is an acronym for "greedy heaviest-observed subtree":
+     - greedy:   pick the locally optimal subtree / fork based on our
+                 current view (which may not be globally optimal).
+     - heaviest: pick based on the highest stake weight.
+     - observed: this is the validator's local view, and other
+                 validators may have differing views.
+     - subtree:  pick a subtree, not an individual node.
 
    In-memory representation:
 
-   - fd_ghost_node_t implements a left-child right-sibling n-ary tree. Each node holds a pointer to
-     its left-most child (`child`), and a pointer to its right sibling (`sibling`).
+   - fd_ghost_node_t implements a left-child right-sibling n-ary tree.
+     Each node holds a pointer to its left-most child (`child`), and a
+     pointer to its right sibling (`sibling`).
 
-   - Each tree node is keyed by slot_hash, which is a tuple (slot, bank_hash).
+   - Each tree node is keyed by slot number.
 
-   - Each tree node tracks the amount of stake (`stake`) that has voted for that key, as well as the
-     recursive sum of stake for the subtree rooted at that node (`weight`).
+   - Each tree node tracks the amount of stake (`stake`) that has voted
+     for its slot, as well as the recursive sum of stake for the subtree
+     rooted at that node (`weight`).
 
-   - fd_ghost_t is the top-level structure that holds the root of the tree, as well as the memory
-     pools and maps for nodes and votes.
+   - fd_ghost_t is the top-level structure that holds the root of the
+     tree, as well as the memory pools and map structures for nodes and
+     votes.
 
-   - fd_ghost_vote_t represents a validator's vote. This includes a slot hash and the validator's pubkey
-     and stake.
+   - fd_ghost_vote_t represents a validator's vote.  This includes a
+     slot hash and the validator's pubkey and stake.
 
-   [1] Original GHOST paper: https://eprint.iacr.org/2013/881.pdf */
+   Link to original GHOST paper: https://eprint.iacr.org/2013/881.pdf.
+   This is simply a reference for those curious about the etymology, and
+   not prerequisite reading for understanding this implementation. */
 
 #include "../fd_choreo_base.h"
 
@@ -41,17 +50,18 @@
 #define FD_GHOST_USE_HANDHOLDING 1
 #endif
 
+#define FD_GHOST_PRINT_DEPTH_DEFAULT 8
+
 /* clang-format off */
 typedef struct fd_ghost_node fd_ghost_node_t;
 struct __attribute__((aligned(128UL))) fd_ghost_node {
-  fd_slot_hash_t    slot_hash;    /* (slot, bank_hash), also the ghost key */
+  ulong             slot;         /* both the ghost and map key */
   ulong             next;         /* reserved for internal use by fd_pool and fd_map_chain */
-  ulong             weight;       /* sum of stake for the subtree rooted at this slot hash */
-  ulong             stake;        /* vote stake for this slot hash (replay votes only) */
-  ulong             gossip_stake; /* vote stake from gossip (sans replay overlap) for this slot hash */
+  ulong             weight;       /* amount of stake that has voted for this slot hash or descendants */
+  ulong             stake;        /* amount of stake that has voted for this slot hash */
+  ulong             gossip_stake; /* amount of stake from gossip votes (sans replay overlap) */
+  ulong             rooted_stake; /* amount of stake that has rooted this slot */
   int               eqv;          /* flag for equivocation (multiple blocks) in this slot */
-  int               eqv_safe;     /* flag for equivocation safety (ie. 52% of stake has voted for this slot hash) */
-  int               opt_conf;     /* flag for optimistic confirmation (ie. 2/3 of stake has voted for this slot hash ) */
   fd_ghost_node_t * parent;       /* pointer to the parent */
   fd_ghost_node_t * child;        /* pointer to the left-most child */
   fd_ghost_node_t * sibling;      /* pointer to next sibling */
@@ -60,26 +70,19 @@ struct __attribute__((aligned(128UL))) fd_ghost_node {
 #define FD_GHOST_EQV_SAFE ( 0.52 )
 #define FD_GHOST_OPT_CONF ( 2.0 / 3.0 )
 
-/* fork a's weight > fork b's weight, with lower slot # as tie-break */
-#define FD_GHOST_NODE_MAX(a,b) (fd_ptr_if(fd_int_if(a->weight==b->weight, a->slot_hash.slot<b->slot_hash.slot, a->weight>b->weight),a,b))
-#define FD_GHOST_NODE_EQ(a,b)  (FD_SLOT_HASH_EQ(&a->slot_hash,&b->slot_hash))
-
 #define POOL_NAME fd_ghost_node_pool
 #define POOL_T    fd_ghost_node_t
 #include "../../util/tmpl/fd_pool.c"
 
 #define MAP_NAME               fd_ghost_node_map
 #define MAP_ELE_T              fd_ghost_node_t
-#define MAP_KEY                slot_hash
-#define MAP_KEY_T              fd_slot_hash_t
-#define MAP_KEY_EQ(k0,k1)      FD_SLOT_HASH_EQ(k0,k1)
-#define MAP_KEY_HASH(key,seed) (key->slot^seed)
+#define MAP_KEY                slot
 #include "../../util/tmpl/fd_map_chain.c"
 
 struct fd_ghost_vote {
-  fd_pubkey_t    pubkey;    /* validator's pubkey, also the map key */
+  fd_pubkey_t    pubkey;    /* validator identity, also the map key */
   ulong          next;      /* reserved for internal use by fd_pool and fd_map_chain */
-  fd_slot_hash_t slot_hash; /* slot hash being voted for */
+  ulong          slot;      /* slot being voted for */
   ulong          stake;     /* validator's stake */
 };
 typedef struct fd_ghost_vote fd_ghost_vote_t;
@@ -96,28 +99,22 @@ typedef struct fd_ghost_vote fd_ghost_vote_t;
 #define MAP_KEY_HASH(key,seed) (key->ui[0]^seed)
 #include "../../util/tmpl/fd_map_chain.c"
 
-#define DEQUE_NAME fd_ghost_prune_deque
-#define DEQUE_T    fd_ghost_node_t *
-#include "../../util/tmpl/fd_deque_dynamic.c"
-
 struct __attribute__((aligned(128UL))) fd_ghost {
   fd_ghost_node_t *     root;
-  ulong                 total_stake; /* total amount of stake */
-
   fd_ghost_node_t *     node_pool; /* memory pool of ghost nodes */
   fd_ghost_node_map_t * node_map;  /* map of slot_hash->fd_ghost_node_t */
   fd_ghost_vote_t *     vote_pool; /* memory pool of ghost votes */
   fd_ghost_vote_map_t * vote_map;  /* each node's latest vote. map of pubkey->fd_ghost_vote_t */
-
-  fd_ghost_node_t **    prune_deque;     /* deque reserved for BFS */
 };
 typedef struct fd_ghost fd_ghost_t;
+
 /* clang-format on */
 
 FD_PROTOTYPES_BEGIN
 
-/* fd_ghost_{align,footprint} return the required alignment and footprint of a memory region
-   suitable for use as ghost with up to node_max nodes and vote_max votes. */
+/* fd_ghost_{align,footprint} return the required alignment and
+   footprint of a memory region suitable for use as ghost with up to
+   node_max nodes and vote_max votes. */
 
 FD_FN_CONST static inline ulong
 fd_ghost_align( void ) {
@@ -133,123 +130,125 @@ fd_ghost_footprint( ulong node_max, ulong vote_max ) {
     FD_LAYOUT_APPEND(
     FD_LAYOUT_APPEND(
     FD_LAYOUT_APPEND(
-    FD_LAYOUT_APPEND(
     FD_LAYOUT_INIT,
-      alignof( fd_ghost_t ), sizeof( fd_ghost_t ) ),
+      alignof( fd_ghost_t ),      sizeof( fd_ghost_t ) ),
       fd_ghost_node_pool_align(), fd_ghost_node_pool_footprint( node_max ) ),
-      fd_ghost_node_map_align(), fd_ghost_node_map_footprint( node_max ) ),
+      fd_ghost_node_map_align(),  fd_ghost_node_map_footprint( node_max ) ),
       fd_ghost_vote_pool_align(), fd_ghost_vote_pool_footprint( vote_max ) ),
-      fd_ghost_vote_map_align(), fd_ghost_vote_map_footprint( vote_max ) ),
-      fd_ghost_prune_deque_align(), fd_ghost_prune_deque_footprint( node_max ) ),
+      fd_ghost_vote_map_align(),  fd_ghost_vote_map_footprint( vote_max ) ),
     alignof( fd_ghost_t ) );
 }
 /* clang-format on */
 
-/* fd_ghost_new formats an unused memory region for use as a ghost. mem is a non-NULL pointer to
-   this region in the local address space with the required footprint and alignment. */
+/* fd_ghost_new formats an unused memory region for use as a ghost.
+   mem is a non-NULL pointer to this region in the local address space
+   with the required footprint and alignment. */
 
 void *
 fd_ghost_new( void * mem, ulong node_max, ulong vote_max, ulong seed );
 
-/* fd_ghost_join joins the caller to the ghost. ghost points to the first byte of the memory region
-   backing the ghost in the caller's address space.
+/* fd_ghost_join joins the caller to the ghost.  ghost points to the
+   first byte of the memory region backing the ghost in the caller's
+   address space.
 
    Returns a pointer in the local address space to ghost on success. */
 
 fd_ghost_t *
 fd_ghost_join( void * ghost );
 
-/* fd_ghost_leave leaves a current local join. Returns a pointer to the underlying shared memory
-   region on success and NULL on failure (logs details). Reasons for failure include ghost is NULL.
+/* fd_ghost_leave leaves a current local join.  Returns a pointer to the
+   underlying shared memory region on success and NULL on failure (logs
+   details).  Reasons for failure include ghost is NULL.
  */
 
 void *
 fd_ghost_leave( fd_ghost_t const * ghost );
 
-/* fd_ghost_delete unformats a memory region used as a ghost. Assumes only the local process is
-   joined to the region. Returns a pointer to the underlying shared memory region or NULL if used
-   obviously in error (e.g. ghost is obviously not a ghost ... logs details). The ownership of the
-   memory region is transferred to the caller. */
+/* fd_ghost_delete unformats a memory region used as a ghost.
+   Assumes only the nobody is joined to the region.  Returns a
+   pointer to the underlying shared memory region or NULL if used
+   obviously in error (e.g. ghost is obviously not a ghost ... logs
+   details).  The ownership of the memory region is transferred to the
+   caller. */
 
 void *
 fd_ghost_delete( void * ghost );
 
-/* fd_ghost_head_query returns the head of the ghost. Ghost is always non-empty, ie. a root must exist. */
+/* fd_ghost_init initializes a ghost.  Assumes fd_ghost_new and 
+   fd_ghost_join and ghost is a valid local join root_slot_hash is the
+   initial root ghost will use.  This is the snapshot slot if booting
+   with a snapshot, genesis slot if not.
 
-static inline fd_ghost_node_t *
-fd_ghost_head_query( fd_ghost_t * ghost ) {
-  fd_ghost_node_t * head = ghost->root;
-  while( head->child ) {
-    fd_ghost_node_t * curr = head;
-    while( curr ) {
-      head = FD_GHOST_NODE_MAX( curr, head );
-      curr = curr->sibling;
-    }
-    head = head->child;
-  }
-  return head;
-}
+   This should generally not be called by anyone other than the owner of
+   ghost's memory (ie. same caller as fd_ghost_new.) */
+void
+fd_ghost_init( fd_ghost_t * ghost, ulong slot );
 
-/* fd_ghost_leaf_insert inserts a new leaf node with key into the ghost, with parent_slot_hash
-   optionally specified. The caller promises the key is not currently in the map and that the
-   parent_slot_hash, if specified, is in the map.
-
-   There are three cases to consider:
-      1. there is no parent, implying key is the root and the fork head.
-      2. key is the only child of parent, implying key is the new fork head.
-      2. key has siblings. Then, key is compared in stake (>), slot (<) priority
-         respectively with its siblings, and the fork head is updated if the key has the
-         highest priority.
-*/
+/* fd_ghost_head_query returns the head of the ghost.  Ghost is always
+   non-empty, ie. a root must exist. */
 
 fd_ghost_node_t *
-fd_ghost_node_insert( fd_ghost_t *           ghost,
-                      fd_slot_hash_t const * slot_hash,
-                      fd_slot_hash_t const * parent_slot_hash_opt );
+fd_ghost_head_query( fd_ghost_t * ghost );
 
-/* fd_ghost_node_query finds the node corresponding to key. */
+/* fd_ghost_leaf_insert inserts a new leaf node with key into the ghost,
+   with parent_slot_hash optionally specified.  The caller promises
+   slot_hash is not currently in the map and parent_slot_hash is. */
 
 fd_ghost_node_t *
-fd_ghost_node_query( fd_ghost_t * ghost, fd_slot_hash_t const * slot_hash );
+fd_ghost_node_insert( fd_ghost_t * ghost, ulong slot, ulong parent_slot );
 
-/* fd_ghost_replay_vote_insert inserts a replay vote into ghost.
+/* fd_ghost_node_query queries and returns the node keyed by slot_hash.
+   Returns NULL if not found. */
 
-   The stake associated with pubkey is added to the ancestry chain beginning at slot hash
-   ("insert"). If pubkey has previously voted, the previous vote's stake is removed from the
-   previous vote slot hash's ancestry chain ("update").
+fd_ghost_node_t *
+fd_ghost_node_query( fd_ghost_t * ghost, ulong slot );
 
-   TODO the implementation can be made more efficient by short-circuiting and doing fewer
-   traversals, but as it exists this is bounded to O(h), where h is the height of ghost.
+/* fd_ghost_replay_vote_upsert inserts a replay vote into ghost.
 
-   Note it is specific to the replay vote case that stake is propagated up the ancestry
-   chain.
-*/
+   The stake associated with pubkey is added to the ancestry chain
+   beginning at slot hash ("insert").  If pubkey has previously voted,
+   the previous vote's stake is removed from the previous vote slot
+   hash's ancestry chain ("update").
 
-void
-fd_ghost_replay_vote_insert( fd_ghost_t *           ghost,
-                             fd_slot_hash_t const * slot_hash,
-                             fd_pubkey_t const *    pubkey,
-                             ulong                  stake );
-
-/* fd_ghost_gossip_vote_insert inserts a gossip vote into ghost.
-
-   Unlike fd_ghost_replay_vote_upsert, the stake associated with pubkey is not propagated. It is
-   only counted towards the individual slot hash voted for.
-*/
+   TODO the implementation can be made more efficient by
+   short-circuiting and doing fewer traversals, but as it exists this is
+   bounded to O(h), where h is the height of ghost. */
 
 void
-fd_ghost_gossip_vote_insert( fd_ghost_t *           ghost,
-                             fd_slot_hash_t const * slot_hash,
-                             fd_pubkey_t const *    pubkey,
-                             ulong                  stake );
+fd_ghost_replay_vote_upsert( fd_ghost_t * ghost, ulong slot, fd_pubkey_t const * pubkey, ulong stake );
+
+/* fd_ghost_gossip_vote_upsert inserts a gossip vote into ghost.
+
+   Unlike fd_ghost_replay_vote_upsert, the stake associated with pubkey
+   is not propagated to ancestors of slot_hash.  It is only counted
+   towards slot_hash itself. */
 
 void
-fd_ghost_prune( fd_ghost_t * ghost, fd_ghost_node_t const * root );
+fd_ghost_gossip_vote_upsert( fd_ghost_t * ghost, ulong slot, fd_pubkey_t const * pubkey, ulong stake );
 
-/* fd_ghost_print calls printf to generate a pretty-printed ghost. */
+/* fd_ghost_publish publishes the subtree at root as the new ghost tree,
+   pruning all nodes prior to root. */
+void
+fd_ghost_publish( fd_ghost_t * ghost, fd_ghost_node_t * root );
+
+/* fd_ghost_print pretty-prints a formatted ghost tree.  start controls
+   which node to begin printing from.  depth controls how many
+   additional ancestors to walk back from start to begin printing from.
+   total_stake controls how much total stake is active to enable
+   percentage calculations.
+
+   FD_SLOT_NULL, 0 and 0 are valid defaults for the above, respectively.
+   In that case, ghost would begin printing from the root without
+   percentages (not recommended because the output will be difficult
+   to read).
+   
+   Typical usage is to pass in the most recently executed slot hash for
+   start, so that start is always in a leaf position, and pick an
+   appropriate depth for visualization (FD_GHOST_PRINT_DEPTH_DEFAULT
+   is the recommended default). */
 
 void
-fd_ghost_print( fd_ghost_t const * ghost, fd_ghost_node_t const * root );
+fd_ghost_print( fd_ghost_t * ghost, ulong start, ulong depth, ulong total_stake );
 
 FD_PROTOTYPES_END
 

--- a/src/choreo/ghost/test_ghost.c
+++ b/src/choreo/ghost/test_ghost.c
@@ -1,16 +1,14 @@
 #include "fd_ghost.h"
 #include <stdlib.h>
 
-#define INSERT( c, p )                                                           \
-  slot_hashes[i] = ( fd_slot_hash_t ){ .slot = c, .hash = pubkey_null };          \
-  if( p < ULONG_MAX ) {                                                          \
-    parent_slot_hashes[i] = ( fd_slot_hash_t ){ .slot = p, .hash = pubkey_null }; \
-    fd_ghost_node_insert( ghost, &slot_hashes[i], &parent_slot_hashes[i] );        \
-  } else {                                                                       \
-    parent_slot_hashes[i] = ( fd_slot_hash_t ){ .slot = p, .hash = pubkey_null }; \
-    fd_ghost_node_insert( ghost, &slot_hashes[i], NULL );                         \
-  }                                                                              \
-  i++;
+#define INSERT( c, p )                                                                                                                     \
+  slots[i]        = c;                                                                                                                     \
+  parent_slots[i] = p;                                                                                                                     \
+  if( p < ULONG_MAX ) {                                                                                                                    \
+    fd_ghost_node_insert( ghost, slots[i], parent_slots[i] );                                                                              \
+  } else {                                                                                                                                 \
+    fd_ghost_init( ghost, slots[i] );                                                                                                      \
+  }
 
 /*
          slot 0
@@ -25,10 +23,16 @@
             slot 6
 */
 void
-test_ghost_simple( fd_ghost_t * ghost ) {
-  fd_slot_hash_t slot_hashes[fd_ghost_node_pool_max( ghost->node_pool )];
-  fd_slot_hash_t parent_slot_hashes[fd_ghost_node_pool_max( ghost->node_pool )];
-  ulong          i = 0;
+test_ghost_simple( fd_wksp_t * wksp ) {
+  ulong  node_max = 8;
+  ulong  vote_max = 8;
+  void * mem      = fd_wksp_alloc_laddr( wksp, fd_ghost_align(), fd_ghost_footprint( node_max, vote_max ), 1UL );
+  FD_TEST( mem );
+  fd_ghost_t * ghost = fd_ghost_join( fd_ghost_new( mem, node_max, vote_max, 0UL ) );
+
+  ulong slots[fd_ghost_node_pool_max( ghost->node_pool )];
+  ulong parent_slots[fd_ghost_node_pool_max( ghost->node_pool )];
+  ulong i = 0;
 
   INSERT( 0, ULONG_MAX );
   INSERT( 1, 0 );
@@ -38,53 +42,175 @@ test_ghost_simple( fd_ghost_t * ghost ) {
   INSERT( 5, 3 );
   INSERT( 6, 5 );
 
-  fd_ghost_print( ghost, ghost->root );
+  fd_ghost_print( ghost, FD_SLOT_NULL, 0, 0 );
 
-  fd_pubkey_t    pk1 = { .key = { 1 } };
-  fd_slot_hash_t sh2 = { .slot = 2, .hash = pubkey_null };
-  fd_ghost_replay_vote_insert( ghost, &sh2, &pk1, 1 );
+  fd_pubkey_t pk1  = { .key = { 1 } };
+  ulong       key2 = 2;
+  fd_ghost_replay_vote_upsert( ghost, key2, &pk1, 1 );
 
-  fd_ghost_print( ghost, ghost->root );
+  fd_ghost_print( ghost, FD_SLOT_NULL, 0, 0 );
 
-  fd_slot_hash_t sh3 = { .slot = 3, .hash = pubkey_null };
-  fd_ghost_replay_vote_insert( ghost, &sh3, &pk1, 1 );
+  ulong key3 = 3;
+  fd_ghost_replay_vote_upsert( ghost, key3, &pk1, 1 );
 
-  ghost->total_stake = 1;
-  fd_ghost_print( ghost, ghost->root );
+  fd_ghost_print( ghost, FD_SLOT_NULL, 0, 0 );
+
+  fd_wksp_free_laddr( mem );
+}
+
+/*
+         slot 0
+           |
+         slot 1
+         /    \
+    slot 2    |
+       |    slot 3
+    slot 4    |
+            slot 5
+              |
+            slot 6
+
+          ...
+
+         slot 2
+           |
+         slot 4
+*/
+void
+test_ghost_publish_left( fd_wksp_t * wksp ) {
+  ulong  node_max = 8;
+  ulong  vote_max = 8;
+  void * mem      = fd_wksp_alloc_laddr( wksp, fd_ghost_align(), fd_ghost_footprint( node_max, vote_max ), 1UL );
+  FD_TEST( mem );
+  fd_ghost_t * ghost = fd_ghost_join( fd_ghost_new( mem, node_max, vote_max, 0UL ) );
+
+  ulong slots[node_max];
+  ulong parent_slots[node_max];
+  ulong i = 0;
+
+  INSERT( 0, ULONG_MAX );
+  INSERT( 1, 0 );
+  INSERT( 2, 1 );
+  INSERT( 3, 1 );
+  INSERT( 4, 2 );
+  INSERT( 5, 3 );
+  INSERT( 6, 5 );
+
+  fd_pubkey_t pk1  = { .key = { 1 } };
+  ulong       key2 = 2;
+  fd_ghost_replay_vote_upsert( ghost, key2, &pk1, 1 );
+
+  ulong key3 = 3;
+  fd_ghost_replay_vote_upsert( ghost, key3, &pk1, 1 );
+  fd_ghost_node_t * node2 = fd_ghost_node_query( ghost, key2 );
+  FD_TEST( node2 );
+
+  fd_ghost_print( ghost, FD_SLOT_NULL, 0, 0 );
+  fd_ghost_publish( ghost, node2 );
+  FD_TEST( ghost->root->slot == 2 );
+  FD_TEST( ghost->root->child->slot == 4 );
+  FD_TEST( fd_ghost_node_pool_free( ghost->node_pool ) == node_max - 2 );
+  fd_ghost_print( ghost, FD_SLOT_NULL, 0, 0 );
+
+  fd_wksp_free_laddr( mem );
+}
+
+/*
+         slot 0
+           |
+         slot 1
+         /    \
+    slot 2    |
+       |    slot 3
+    slot 4    |
+            slot 5
+              |
+            slot 6
+
+          ...
+
+         slot 3
+           |
+         slot 5
+           |
+         slot 6
+*/
+void
+test_ghost_publish_right( fd_wksp_t * wksp ) {
+  ulong  node_max = 8;
+  ulong  vote_max = 8;
+  void * mem      = fd_wksp_alloc_laddr( wksp, fd_ghost_align(), fd_ghost_footprint( node_max, vote_max ), 1UL );
+  FD_TEST( mem );
+  fd_ghost_t * ghost = fd_ghost_join( fd_ghost_new( mem, node_max, vote_max, 0UL ) );
+
+  ulong slots[node_max];
+  ulong parent_slots[node_max];
+  ulong i = 0;
+
+  INSERT( 0, ULONG_MAX );
+  INSERT( 1, 0 );
+  INSERT( 2, 1 );
+  INSERT( 3, 1 );
+  INSERT( 4, 2 );
+  INSERT( 5, 3 );
+  INSERT( 6, 5 );
+
+  fd_pubkey_t pk1  = { .key = { 1 } };
+  ulong       key2 = 2;
+  fd_ghost_replay_vote_upsert( ghost, key2, &pk1, 1 );
+
+  ulong key3 = 3;
+  fd_ghost_replay_vote_upsert( ghost, key3, &pk1, 1 );
+  fd_ghost_node_t * node3 = fd_ghost_node_query( ghost, key3 );
+  FD_TEST( node3 );
+
+  fd_ghost_print( ghost, FD_SLOT_NULL, 0, 0 );
+  fd_ghost_publish( ghost, node3 );
+  FD_TEST( ghost->root->slot == 3 );
+  FD_TEST( ghost->root->child->slot == 5 );
+  FD_TEST( ghost->root->child->child->slot == 6 );
+  FD_TEST( fd_ghost_node_pool_free( ghost->node_pool ) == node_max - 3 );
+  fd_ghost_print( ghost, FD_SLOT_NULL, 0, 0 );
+
+  fd_wksp_free_laddr( mem );
 }
 
 void
-test_ghost_print( fd_ghost_t * ghost ) {
-  fd_slot_hash_t slot_hashes[fd_ghost_node_pool_max( ghost->node_pool )];
-  fd_slot_hash_t parent_slot_hashes[fd_ghost_node_pool_max( ghost->node_pool )];
-  ulong          i = 0;
+test_ghost_print( fd_wksp_t * wksp ) {
+  ulong  node_max = 16;
+  ulong  vote_max = 16;
+  void * mem      = fd_wksp_alloc_laddr( wksp, fd_ghost_align(), fd_ghost_footprint( node_max, vote_max ), 1UL );
+  FD_TEST( mem );
+  fd_ghost_t * ghost = fd_ghost_join( fd_ghost_new( mem, node_max, vote_max, 0UL ) );
+
+  ulong slots[node_max];
+  ulong parent_slots[node_max];
+  ulong i = 0;
 
   INSERT( 268538758, ULONG_MAX );
   INSERT( 268538759, 268538758 );
   INSERT( 268538760, 268538759 );
   INSERT( 268538761, 268538758 );
 
-  fd_slot_hash_t query = {
-    .slot = 268538758,
-    .hash = pubkey_null
-  };
-  fd_ghost_node_t * node = fd_ghost_node_query( ghost, &query );
-  node->weight = 32;
+  ulong             query = 268538758;
+  fd_ghost_node_t * node  = fd_ghost_node_query( ghost, query );
+  node->weight            = 32;
 
-  query.slot = 268538759;
-  node = fd_ghost_node_query( ghost, &query );
+  query        = 268538759;
+  node         = fd_ghost_node_query( ghost, query );
   node->weight = 8;
 
-  query.slot = 268538760;
-  node = fd_ghost_node_query( ghost, &query );
+  query        = 268538760;
+  node         = fd_ghost_node_query( ghost, query );
   node->weight = 9;
 
-  query.slot = 268538761;
-  node = fd_ghost_node_query( ghost, &query );
+  query        = 268538761;
+  node         = fd_ghost_node_query( ghost, query );
   node->weight = 10;
 
-  ghost->total_stake = 100;
-  fd_ghost_print( ghost, ghost->root );
+  fd_ghost_print( ghost, query, FD_GHOST_PRINT_DEPTH_DEFAULT, 100 );
+
+  fd_wksp_free_laddr( mem );
 }
 
 int
@@ -94,29 +220,14 @@ main( int argc, char ** argv ) {
   ulong  page_cnt = 1;
   char * _page_sz = "gigantic";
   ulong  numa_idx = fd_shmem_numa_idx( 0 );
-  FD_LOG_NOTICE( ( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)",
-                   page_cnt,
-                   _page_sz,
-                   numa_idx ) );
-  fd_wksp_t * wksp = fd_wksp_new_anonymous(
-      fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  FD_LOG_NOTICE( ( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ) );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
-  ulong  node_max = 16;
-  ulong  vote_max = 16;
-  void * mem =
-      fd_wksp_alloc_laddr( wksp, fd_ghost_align(), fd_ghost_footprint( node_max, vote_max ), 1UL );
-  FD_TEST( mem );
-  fd_ghost_t * ghost = fd_ghost_join( fd_ghost_new( mem, node_max, vote_max, 0UL ) );
-  FD_TEST( ghost );
-  FD_TEST( !ghost->root );
-  FD_TEST( ghost->node_pool );
-  FD_TEST( ghost->node_map );
-  FD_TEST( ghost->vote_pool );
-  FD_TEST( ghost->vote_map );
-
-  test_ghost_print(ghost);
-  test_ghost_simple( ghost );
+  test_ghost_print( wksp );
+  test_ghost_simple( wksp );
+  test_ghost_publish_left( wksp );
+  test_ghost_publish_right( wksp );
 
   fd_halt();
   return 0;

--- a/src/choreo/tower/fd_tower.c
+++ b/src/choreo/tower/fd_tower.c
@@ -75,13 +75,15 @@ void
 fd_tower_epoch_update( fd_tower_t * tower, fd_exec_epoch_ctx_t * epoch_ctx ) {
   ulong                               total_stake = 0;
   fd_epoch_bank_t *                   epoch_bank  = fd_exec_epoch_ctx_epoch_bank( epoch_ctx );
-  fd_vote_accounts_pair_t_mapnode_t * pool        = epoch_bank->stakes.vote_accounts.vote_accounts_pool;
-  fd_vote_accounts_pair_t_mapnode_t * root        = epoch_bank->stakes.vote_accounts.vote_accounts_root;
-  for( fd_vote_accounts_pair_t_mapnode_t * node = fd_vote_accounts_pair_t_map_minimum( pool, root ); node;
-       node                                     = fd_vote_accounts_pair_t_map_successor( pool, node ) ) {
+  fd_vote_accounts_pair_t_mapnode_t * pool = epoch_bank->stakes.vote_accounts.vote_accounts_pool;
+  fd_vote_accounts_pair_t_mapnode_t * root = epoch_bank->stakes.vote_accounts.vote_accounts_root;
+  for( fd_vote_accounts_pair_t_mapnode_t * node = fd_vote_accounts_pair_t_map_minimum( pool, root );
+       node;
+       node = fd_vote_accounts_pair_t_map_successor( pool, node ) ) {
     total_stake += node->elem.stake;
   }
   tower->total_stake = total_stake;
+  FD_LOG_NOTICE(("total stake is %lu", tower->total_stake));
 }
 
 void
@@ -92,56 +94,48 @@ fd_tower_fork_update( fd_tower_t * tower, fd_fork_t * fork ) {
   fd_ghost_t *      ghost      = tower->ghost;
   fd_valloc_t       valloc     = tower->valloc;
 
-  /* Get the slot hash of the just-executed slot. */
-
-  fd_slot_hash_t slot_hash = {
-      .slot = fork->slot,
-      .hash = fork->slot_ctx.slot_bank.banks_hash,
-  };
-
   /* Get the parent key. Every slot except the root must have a parent. */
 
   fd_blockstore_start_read( blockstore );
-  ulong             parent_slot      = fd_blockstore_parent_slot_query( blockstore, fork->slot );
-  fd_hash_t const * parent_bank_hash = fd_blockstore_bank_hash_query( blockstore, parent_slot );
+  ulong parent_slot = fd_blockstore_parent_slot_query( blockstore, fork->slot );
 #if FD_TOWER_USE_HANDHOLDING
   /* we must have a parent slot and bank hash, given we just executed
      its child. if not, likely a bug in blockstore pruning. */
   if( FD_UNLIKELY( parent_slot == FD_SLOT_NULL ) ) {
     FD_LOG_ERR( ( "missing parent slot for curr slot %lu", fork->slot ) );
   };
-  if( FD_UNLIKELY( !parent_bank_hash ) ) {
-    FD_LOG_ERR( ( "missing parent bank hash for parent slot %lu", parent_slot ) );
-  };
 #endif
-  fd_slot_hash_t parent_slot_hash = { .slot = parent_slot, .hash = *parent_bank_hash };
   fd_blockstore_end_read( blockstore );
 
-  /* Insert this the fork head into ghost. */
+  /* Insert the new fork head into ghost. */
 
-  fork->ghost_node = fd_ghost_node_insert( ghost, &slot_hash, &parent_slot_hash );
+  fork->ghost_node = fd_ghost_node_insert( ghost, fork->slot, parent_slot );
 
-  fd_vote_accounts_pair_t_mapnode_t * root = fork->slot_ctx.slot_bank.epoch_stakes.vote_accounts_root;
-  fd_vote_accounts_pair_t_mapnode_t * pool = fork->slot_ctx.slot_bank.epoch_stakes.vote_accounts_pool;
-  for( fd_vote_accounts_pair_t_mapnode_t * curr = fd_vote_accounts_pair_t_map_minimum( pool, root ); curr;
-       curr                                     = fd_vote_accounts_pair_t_map_successor( pool, curr ) ) {
-    if( FD_UNLIKELY( curr->elem.stake == 0UL ) ) {
-      continue;
-    }
+  fd_vote_accounts_pair_t_mapnode_t * root =
+      fork->slot_ctx.slot_bank.epoch_stakes.vote_accounts_root;
+  fd_vote_accounts_pair_t_mapnode_t * pool =
+      fork->slot_ctx.slot_bank.epoch_stakes.vote_accounts_pool;
+  for( fd_vote_accounts_pair_t_mapnode_t * curr = fd_vote_accounts_pair_t_map_minimum( pool, root );
+       curr;
+       curr = fd_vote_accounts_pair_t_map_successor( pool, curr ) ) {
+    if( FD_UNLIKELY( curr->elem.stake == 0UL ) ) continue;
 
     fd_pubkey_t const * vote_account_address = &curr->elem.key;
     FD_BORROWED_ACCOUNT_DECL( vote_account );
     fd_vote_state_versioned_t vote_state_versioned = { 0 };
 
-    rc = fd_acc_mgr_view( tower->acc_mgr, fork->slot_ctx.funk_txn, vote_account_address, vote_account );
+    rc = fd_acc_mgr_view(
+        tower->acc_mgr, fork->slot_ctx.funk_txn, vote_account_address, vote_account );
     if( FD_UNLIKELY( rc != FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING( ( "fd_acc_mgr_view failed on vote account %32J. error: %d", vote_account_address, rc ) );
+      FD_LOG_WARNING(
+          ( "fd_acc_mgr_view failed on vote account %32J. error: %d", vote_account_address, rc ) );
       __asm__( "int $3" );
     }
 
     rc = fd_vote_get_state( vote_account, valloc, &vote_state_versioned );
     if( FD_UNLIKELY( rc != FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING( ( "fd_vote_get_state failed on vote account %32J. error: %d", vote_account_address, rc ) );
+      FD_LOG_WARNING( (
+          "fd_vote_get_state failed on vote account %32J. error: %d", vote_account_address, rc ) );
       __asm__( "int $3" );
     }
 
@@ -149,66 +143,32 @@ fd_tower_fork_update( fd_tower_t * tower, fd_fork_t * fork ) {
     fd_vote_state_t *  vote_state   = &vote_state_versioned.inner.current;
     fd_landed_vote_t * landed_votes = vote_state->votes;
 
-    if( FD_UNLIKELY( deq_fd_landed_vote_t_empty( landed_votes ) ) ) {
-      continue;
-    }
+    if( FD_UNLIKELY( deq_fd_landed_vote_t_empty( landed_votes ) ) ) { continue; }
 
     ulong vote_slot = deq_fd_landed_vote_t_peek_tail_const( landed_votes )->lockout.slot;
 
     /* Ignore votes for slots < root. */
 
-    if( FD_UNLIKELY( vote_slot < tower->root ) ) {
-      continue;
-    }
+    if( FD_UNLIKELY( vote_slot < tower->root ) ) { continue; }
 
-    /* Look up _our_ bank hash for this vote. It is invariant that our
-       bank hash matches the voter's hash, because this was checked
-       earlier by the vote program during slot execution. */
+    /* Look up the ghost node.
 
-    fd_blockstore_start_read( blockstore );
-    fd_hash_t const * vote_hash = fd_blockstore_bank_hash_query( blockstore, vote_slot );
-#if FD_TOWER_USE_HANDHOLDING
-    /* Somehow we're missing this bank hash. Likely a bug in blockstore
-       pruning logic. */
-    if( FD_UNLIKELY( !vote_hash ) ) {
-      FD_LOG_WARNING( ( "unexpected missing bank hash for slot %lu", vote_slot ) );
-      continue;
-    };
-#endif
-    fd_slot_hash_t vote_slot_hash = { .slot = vote_slot, .hash = *vote_hash };
-    fd_blockstore_end_read( blockstore );
+       It is invariant that our bank hash matches the voter's hash,
+       because this was checked earlier by the vote program during slot
+       execution. */
 
-    /* Look up the ghost node. */
-
-    fd_ghost_node_t * ghost_node = fd_ghost_node_query( ghost, &vote_slot_hash );
+    fd_ghost_node_t * ghost_node = fd_ghost_node_query( ghost, fork->slot );
 
 #if FD_TOWER_USE_HANDHOLDING
-    /* The vote hash must match our bank hash, so we must have inserted
-       this slot hash into ghost previously.
-       
-       FIXME vote for slot # > root but got pruned off different fork before root? */
+    /* FIXME vote for slot # > root but got pruned off different fork before root? */
     if( FD_UNLIKELY( !ghost_node ) ) {
-      FD_LOG_ERR( ( "missing ghost key %lu %32J", vote_slot_hash.slot, vote_slot_hash.hash.hash ) );
+      FD_LOG_ERR( ( "ghost is missing vote slot %lu", vote_slot ) );
     };
 #endif
 
     /* Upsert the vote into ghost. */
 
-    fd_ghost_replay_vote_insert( ghost, &vote_slot_hash, &vote_state->node_pubkey, curr->elem.stake );
-
-    /* Check this slot's stake pct in ghost, and mark stake threshold accordingly if reached. */
-
-    double pct = (double)ghost_node->stake / (double)tower->total_stake;
-
-    if( FD_UNLIKELY( !ghost_node->eqv_safe && pct > FD_TOWER_EQV_SAFE ) ) {
-      ghost_node->eqv_safe = 1;
-      // FD_LOG_NOTICE(( "[tower] eqv safe (%lf): (%lu, %32J)", pct, slot_hash.slot, slot_hash.hash.hash ) );
-    }
-
-    if( FD_UNLIKELY( !ghost_node->opt_conf && pct > FD_TOWER_OPT_CONF ) ) {
-      ghost_node->opt_conf = 1;
-      // FD_LOG_NOTICE( ( "[tower] opt conf (%lf): (%lu, %32J)", pct, slot_hash.slot, slot_hash.hash.hash ) );
-    }
+    fd_ghost_replay_vote_upsert( ghost, vote_slot, &vote_state->node_pubkey, curr->elem.stake );
   }
 }
 
@@ -221,13 +181,11 @@ is_same_fork( fd_tower_t * tower, fd_fork_t * fork ) {
   /* Look for prev_vote_slot in fork's ancestry.
 
      It is invariant that the prev_vote_slot either appears in the
-     ancestry, or ancestor->slot_hash.slot < prev_vote_slot. This is
+     ancestry, or ancestor->slot < prev_vote_slot. This is
      because we only root when we reach max lockout in our tower. */
 
-  while( FD_LIKELY( ancestor->slot_hash.slot >= prev_vote_slot ) ) {
-    if( FD_LIKELY( ancestor->slot_hash.slot == prev_vote_slot ) ) {
-      return 1;
-    }
+  while( FD_LIKELY( ancestor->slot >= prev_vote_slot ) ) {
+    if( FD_LIKELY( ancestor->slot == prev_vote_slot ) ) { return 1; }
 
     ancestor = ancestor->parent;
   }
@@ -241,13 +199,13 @@ fd_tower_best_fork_select( fd_tower_t * tower ) {
 
   /* search for the fork head in the frontier. */
 
-  fd_fork_t * best = fd_fork_frontier_ele_query( tower->forks->frontier, &head->slot_hash.slot, NULL, tower->forks->pool );
+  fd_fork_t * best =
+      fd_fork_frontier_ele_query( tower->forks->frontier, &head->slot, NULL, tower->forks->pool );
 
 #if FD_TOWER_USE_HANDHOLDING
-  /* if the ghost head is not in the frontier, it means we must have pruned it and that means we're in a bad state.  */
-  if( FD_UNLIKELY( !best ) ) {
-    FD_LOG_ERR( ( "missing ghost head (%lu, %32J) in frontier", head->slot_hash.slot, &head->slot_hash.hash ) );
-  }
+  /* if the ghost head is not in the frontier, so we must have pruned
+     it and we're in a bad state. */
+  if( FD_UNLIKELY( !best ) ) FD_LOG_ERR( ( "missing ghost head %lu in frontier", head->slot ) );
 #endif
 
   return best;
@@ -263,18 +221,18 @@ fd_tower_reset_fork_select( fd_tower_t * tower ) {
   fd_fork_frontier_t * frontier = tower->forks->frontier;
   fd_fork_t *          pool     = tower->forks->pool;
 
-  for( fd_fork_frontier_iter_t iter = fd_fork_frontier_iter_init( frontier, pool ); !fd_fork_frontier_iter_done( iter, frontier, pool );
-       iter                         = fd_fork_frontier_iter_next( iter, frontier, pool ) ) {
+  for( fd_fork_frontier_iter_t iter = fd_fork_frontier_iter_init( frontier, pool );
+       !fd_fork_frontier_iter_done( iter, frontier, pool );
+       iter = fd_fork_frontier_iter_next( iter, frontier, pool ) ) {
     fd_fork_t * fork = fd_fork_frontier_iter_ele( iter, frontier, pool );
-    if( FD_LIKELY( is_same_fork( tower, fork ) ) ) {
-      return fork;
-    }
+    if( FD_LIKELY( is_same_fork( tower, fork ) ) ) { return fork; }
   }
 
   /* TODO This can happen if we throw away an equivocating block
      (unimplemented), but otherwise should never happen. */
 
-  FD_LOG_ERR( ( "Our prev_vote_slot was not compatible with any of the frontier forks. Halting." ) );
+  FD_LOG_ERR(
+      ( "Our prev_vote_slot was not compatible with any of the frontier forks. Halting." ) );
 }
 
 fd_fork_t *
@@ -288,17 +246,15 @@ fd_tower_vote_fork_select( fd_tower_t * tower ) {
     /* The best fork is the same fork as our last vote, so we can vote
        for the fork's head, if we pass the threshold check. */
 
-    if( FD_LIKELY( fd_tower_threshold_check( tower ) ) ) {
-
-      vote_fork = best;
-    }
+    if( FD_LIKELY( fd_tower_threshold_check( tower ) ) ) { vote_fork = best; }
 
   } else {
 
     /* The best fork is on a different fork, so try to switch if we pass
        lockout and switch threshold. */
 
-    if( FD_UNLIKELY( fd_tower_lockout_check( tower, best ) && fd_tower_switch_check( tower, best ) ) ) {
+    if( FD_UNLIKELY( fd_tower_lockout_check( tower, best ) &&
+                     fd_tower_switch_check( tower, best ) ) ) {
       vote_fork = best;
     }
   }
@@ -346,9 +302,7 @@ fd_tower_vote_fork_select( fd_tower_t * tower ) {
 
 int
 fd_tower_lockout_check( fd_tower_t * tower, fd_fork_t * fork ) {
-  if( FD_UNLIKELY( !tower->vote_slot_cnt ) ) {
-    return 1;
-  }
+  if( FD_UNLIKELY( !tower->vote_slot_cnt ) ) { return 1; }
   ulong prev_vote_slot          = tower->vote_slots[tower->vote_slot_cnt - 1];
   ulong lockout_expiration_slot = prev_vote_slot + ( 1UL << tower->vote_slot_cnt );
   return fork->slot > lockout_expiration_slot;
@@ -361,9 +315,7 @@ fd_tower_switch_check( fd_tower_t * tower, fd_fork_t * fork ) {
   while( FD_LIKELY( ancestor ) ) {
     fd_ghost_node_t * curr = ancestor;
     while( FD_LIKELY( curr ) ) {
-      if( FD_LIKELY( curr != fork->ghost_node ) ) {
-        switch_stake += curr->weight;
-      }
+      if( FD_LIKELY( curr != fork->ghost_node ) ) switch_stake += curr->weight;
       curr = curr->sibling;
     }
   }
@@ -372,37 +324,20 @@ fd_tower_switch_check( fd_tower_t * tower, fd_fork_t * fork ) {
 
 int
 fd_tower_threshold_check( fd_tower_t * tower ) {
-  fd_blockstore_t * blockstore = tower->blockstore;
-
-  if( FD_UNLIKELY( tower->vote_slot_cnt < THRESHOLD_DEPTH ) ) {
-    return 1;
-  }
+  if( FD_UNLIKELY( tower->vote_slot_cnt < THRESHOLD_DEPTH ) ) { return 1; }
 
   ulong threshold_slot = tower->vote_slots[tower->vote_slot_cnt - THRESHOLD_DEPTH];
-  fd_blockstore_start_read( blockstore );
-  fd_hash_t const * threshold_bank_hash = fd_blockstore_bank_hash_query( blockstore, threshold_slot );
-#if FD_TOWER_USE_HANDHOLDING
-  if( FD_UNLIKELY( !threshold_bank_hash ) ) {
-    /* the threshold bank hash must be in the blockstore,
-       because if it's in our tower we voted on it. */
-    /* TODO think about the case where we dump a bank hash */
-    FD_LOG_ERR( ( "missing threshold_bank_hash for slot %lu", threshold_slot ) );
-  }
-#endif
-  fd_slot_hash_t threshold_slot_hash = { .slot = threshold_slot, .hash = *threshold_bank_hash };
-  fd_blockstore_end_read( blockstore );
 
   /* FIXME needs to use more complicated voted_stakes logic vs. ghost weight */
 
-  fd_ghost_node_t const * threshold_ghost_node = fd_ghost_node_query( tower->ghost, &threshold_slot_hash );
+  fd_ghost_node_t const * threshold_ghost_node =
+      fd_ghost_node_query( tower->ghost, threshold_slot );
 
 #if FD_TOWER_USE_HANDHOLDING
   /* the threshold slot hash must be in ghost,
      because we voted on it thus must have inserted it into ghost. */
   if( FD_UNLIKELY( !threshold_ghost_node ) ) {
-    FD_LOG_ERR( ( "missing threshold_ghost_node (%lu, %32J) in ghost",
-                  threshold_ghost_node->slot_hash.slot,
-                  &threshold_ghost_node->slot_hash.hash ) );
+    FD_LOG_ERR( ( "missing threshold_slot %lu in ghost", threshold_ghost_node->slot ) );
   }
 #endif
 

--- a/src/disco/tvu/fd_tvu.c
+++ b/src/disco/tvu/fd_tvu.c
@@ -1028,8 +1028,8 @@ snapshot_insert( fd_fork_t *        fork,
 
   /* Add snapshot slot to ghost. */
 
-  fd_slot_hash_t slot_hash = { .slot = snapshot_slot, .hash = fork->slot_ctx.slot_bank.banks_hash };
-  fd_ghost_node_insert( replay->bft->ghost, &slot_hash, NULL );
+  // fd_slot_hash_t slot_hash = { .slot = snapshot_slot, .hash = fork->slot_ctx.slot_bank.banks_hash };
+  // fd_ghost_node_insert( replay->bft->ghost, &slot_hash, NULL );
 
   /* Add snapshot slot to bft. */
 


### PR DESCRIPTION
- Introduce fd_ghost_init to the API for initializing a ghost.
- Make parent a required argument for node_insert
given init will handle the special case of initializing the root.
- Change the key to use slot instead of slot_hash. This leverages the
invariant that a vote will only be upserted after successful execution
by the vote program, so the bank hash is implied to be our own.
- Reimplement publish (renamed from prune) to not use an additional buffer
as well as provide a generally cleaner and better commented impl.
- Rework the pretty-print API to support functionality like in the demo
directly (vs. having to be done in the caller).
- Add more tests relating to all the above.