### PR TITLE
use offsetof to reduce UBSAN false positives

### DIFF
--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -148,7 +148,7 @@ _load_account( fd_borrowed_account_t *           acc,
                                /* min_data_sz */ size,
                                acc );
   assert( err==FD_ACC_MGR_SUCCESS );
-  fd_memcpy( acc->data, state->data->bytes, size );
+  if( state->data ) fd_memcpy( acc->data, state->data->bytes, size );
 
   data_wksp_ptrs[data_wksp_ptrs_idx++] = acc->data;
 

--- a/src/util/tmpl/fd_deque_dynamic.c
+++ b/src/util/tmpl/fd_deque_dynamic.c
@@ -89,6 +89,7 @@
    remove operation (remove_all is fine on an empty deque). */
 
 #include "../bits/fd_bits.h"
+#include <stddef.h>
 
 #ifndef DEQUE_NAME
 #error "Define DEQUE_NAME"
@@ -119,14 +120,14 @@ FD_PROTOTYPES_BEGIN
 
 FD_FN_CONST static inline DEQUE_(private_t) *
 DEQUE_(private_hdr_from_deque)( DEQUE_T * deque ) {
-  return (DEQUE_(private_t) *)( (ulong)deque - (ulong)&(((DEQUE_(private_t) *)NULL)->deque) );
+  return (DEQUE_(private_t) *)( (ulong)deque - offsetof(DEQUE_(private_t), deque) );
 }
 
 /* const-correct version of above */
 
 FD_FN_CONST static inline DEQUE_(private_t) const *
 DEQUE_(private_const_hdr_from_deque)( DEQUE_T const * deque ) {
-  return (DEQUE_(private_t) const *)( (ulong)deque - (ulong)&(((DEQUE_(private_t) *)NULL)->deque) );
+  return (DEQUE_(private_t) const *)( (ulong)deque - offsetof(DEQUE_(private_t), deque) );
 }
 
 /* These move i to the previous or next slot to i for given max.

--- a/src/util/tmpl/fd_queue.c
+++ b/src/util/tmpl/fd_queue.c
@@ -51,6 +51,7 @@
    remove operation (remove_all is fine on an empty queue). */
 
 #include "../bits/fd_bits.h"
+#include <stddef.h>
 
 #ifndef QUEUE_NAME
 #error "Define QUEUE_NAME"
@@ -107,14 +108,14 @@ FD_PROTOTYPES_BEGIN
 
 FD_FN_CONST static inline QUEUE_(private_t) *
 QUEUE_(private_hdr_from_queue)( QUEUE_T * queue ) {
-  return (QUEUE_(private_t) *)( (ulong)queue - (ulong)&(((QUEUE_(private_t) *)NULL)->queue) );
+  return (QUEUE_(private_t) *)( (ulong)queue - offsetof(QUEUE_(private_t), queue) );
 }
 
 /* const-correct version of above */
 
 FD_FN_CONST static inline QUEUE_(private_t) const *
 QUEUE_(private_const_hdr_from_queue)( QUEUE_T const * queue ) {
-  return (QUEUE_(private_t) const *)( (ulong)queue - (ulong)&(((QUEUE_(private_t) *)NULL)->queue) );
+  return (QUEUE_(private_t) const *)( (ulong)queue - offsetof(QUEUE_(private_t), queue) );
 }
 
 /* private_slot maps an index to a slot cnt.  The compiler should

--- a/src/util/tmpl/fd_queue_dynamic.c
+++ b/src/util/tmpl/fd_queue_dynamic.c
@@ -50,6 +50,7 @@
    remove operation (remove_all is fine on an empty queue). */
 
 #include "../bits/fd_bits.h"
+#include <stddef.h>
 
 #ifndef QUEUE_NAME
 #error "Define QUEUE_NAME"
@@ -80,14 +81,14 @@ FD_PROTOTYPES_BEGIN
 
 FD_FN_CONST static inline QUEUE_(private_t) *
 QUEUE_(private_hdr_from_queue)( QUEUE_T * queue ) {
-  return (QUEUE_(private_t) *)( (ulong)queue - (ulong)&(((QUEUE_(private_t) *)NULL)->queue) );
+  return (QUEUE_(private_t) *)( (ulong)queue - offsetof(QUEUE_(private_t), queue) );
 }
 
 /* const-correct version of above */
 
 FD_FN_CONST static inline QUEUE_(private_t) const *
 QUEUE_(private_const_hdr_from_queue)( QUEUE_T const * queue ) {
-  return (QUEUE_(private_t) const *)( (ulong)queue - (ulong)&(((QUEUE_(private_t) *)NULL)->queue) );
+  return (QUEUE_(private_t) const *)( (ulong)queue - offsetof(QUEUE_(private_t), queue) );
 }
 
 /* These move i to the previous or next slot to i for given max.

--- a/src/util/tmpl/fd_set_dynamic.c
+++ b/src/util/tmpl/fd_set_dynamic.c
@@ -162,6 +162,7 @@
    unless otherwise explicitly noted. */
 
 #include "../bits/fd_bits.h"
+#include <stddef.h>
 
 #ifndef SET_NAME
 #error "Define SET_NAME"
@@ -208,12 +209,12 @@ SET_(private_full_last_word)( ulong max ) {
 
 FD_FN_CONST static inline SET_(private_t) *
 SET_(private_hdr_from_set)( SET_(t) * set ) {
-  return (SET_(private_t) *)( (ulong)set - (ulong)&(((SET_(private_t) *)NULL)->set) );
+  return (SET_(private_t) *)( (ulong)set - offsetof(SET_(private_t), set) );
 }
 
 FD_FN_CONST static inline SET_(private_t) const *
 SET_(private_hdr_from_set_const)( SET_(t) const * set ) {
-  return (SET_(private_t) const *)( (ulong)set - (ulong)&(((SET_(private_t) *)NULL)->set) );
+  return (SET_(private_t) const *)( (ulong)set - offsetof(SET_(private_t), set) );
 }
 
 /* Public APIs ********************************************************/

--- a/src/util/tmpl/fd_stack.c
+++ b/src/util/tmpl/fd_stack.c
@@ -48,6 +48,7 @@
    remove operation (remove_all is fine on an empty stack). */
 
 #include "../bits/fd_bits.h"
+#include <stddef.h>
 
 #ifndef STACK_NAME
 #error "Define STACK_NAME"
@@ -83,14 +84,14 @@ FD_PROTOTYPES_BEGIN
 
 FD_FN_CONST static inline STACK_(private_t) *
 STACK_(private_hdr_from_stack)( STACK_T * stack ) {
-  return (STACK_(private_t) *)( (ulong)stack - (ulong)&(((STACK_(private_t) *)NULL)->stack) );
+  return (STACK_(private_t) *)( (ulong)stack - offsetof(STACK_(private_t), stack) );
 }
 
 /* const-correct version of above */
 
 FD_FN_CONST static inline STACK_(private_t) const *
 STACK_(private_const_hdr_from_stack)( STACK_T const * stack ) {
-  return (STACK_(private_t) const *)( (ulong)stack - (ulong)&(((STACK_(private_t) *)NULL)->stack) );
+  return (STACK_(private_t) const *)( (ulong)stack - offsetof(STACK_(private_t), stack) );
 }
 
 FD_FN_CONST static inline ulong STACK_(align)( void ) { return alignof(STACK_(private_t)); }


### PR DESCRIPTION
UBSAN gets confused on our use of code like 

`(ulong)&(((DEQUE_(private_t) *)NULL)->deque)` 

which equivalent to 

`offsetof(DEQUE_(private_t), deque)`

This PR changes all of those in `util/tmpl` which removes a large number of UBSAN false positives.