### PR TITLE
Tidy up runtime dependency graph

### DIFF
--- a/src/app/ledger/Local.mk
+++ b/src/app/ledger/Local.mk
@@ -1,7 +1,11 @@
 ifdef FD_HAS_ROCKSDB
 
 ifdef FD_HAS_ZSTD
+ifdef FD_HAS_SECP256K1
 $(call make-bin,fd_ledger,main,fd_flamenco fd_ballet fd_reedsol fd_disco fd_funk fd_shred fd_tango fd_choreo fd_waltz fd_util,$(ROCKSDB_LIBS) $(SECP256K1_LIBS))
+else
+$(warning ledger tool build disabled due to lack of secp256k1)
+endif
 else
 $(warning ledger tool build disabled due to lack of zstd)
 endif

--- a/src/flamenco/rewards/fd_rewards.c
+++ b/src/flamenco/rewards/fd_rewards.c
@@ -1,7 +1,8 @@
 #include "fd_rewards.h"
 #include "fd_rewards_types.h"
-#include "math.h"
+#include <math.h>
 
+#include "../runtime/fd_executor_err.h"
 #include "../runtime/fd_system_ids.h"
 #include "../runtime/context/fd_exec_epoch_ctx.h"
 #include "../runtime/context/fd_exec_slot_ctx.h"

--- a/src/flamenco/runtime/Local.mk
+++ b/src/flamenco/runtime/Local.mk
@@ -25,8 +25,8 @@ $(call add-objs,fd_pubkey_utils,fd_flamenco)
 
 $(call add-hdrs,fd_rent_lists.h)
 
-$(call add-hdrs,fd_runtime.h fd_runtime_err.h)
-$(call add-objs,fd_runtime,fd_flamenco)
+$(call add-hdrs,fd_runtime.h fd_runtime_init.h fd_runtime_err.h)
+$(call add-objs,fd_runtime fd_runtime_init,fd_flamenco)
 endif
 
 $(call add-hdrs,fd_system_ids.h)

--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.c
@@ -1,7 +1,5 @@
 #include "fd_exec_txn_ctx.h"
-#include "fd_exec_slot_ctx.h"
-#include "../fd_acc_mgr.h"
-#include "../fd_executor.h"
+#include "../fd_executor_err.h"
 #include "../../vm/fd_vm_context.h"
 
 void *

--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.h
@@ -2,7 +2,6 @@
 #define HEADER_fd_src_flamenco_runtime_context_fd_exec_txn_ctx_h
 
 #include "fd_exec_instr_ctx.h"
-#include "../fd_executor.h"
 #include "../../../util/fd_util_base.h"
 
 #include "../fd_borrowed_account.h"
@@ -141,19 +140,6 @@ fd_exec_txn_ctx_from_exec_slot_ctx( fd_exec_slot_ctx_t * slot_ctx,
 
 void
 fd_exec_txn_ctx_teardown( fd_exec_txn_ctx_t * txn_ctx );
-
-static inline int
-fd_exec_consume_cus( fd_exec_txn_ctx_t * txn_ctx,
-                     ulong               cus ) {
-  ulong new_cus   =  txn_ctx->compute_meter - cus;
-  int   underflow = (txn_ctx->compute_meter < cus);
-  if( FD_UNLIKELY( underflow ) ) {
-    txn_ctx->compute_meter = 0UL;
-    return FD_EXECUTOR_INSTR_ERR_COMPUTE_BUDGET_EXCEEDED;
-  }
-  txn_ctx->compute_meter = new_cus;
-  return FD_EXECUTOR_INSTR_SUCCESS;
-}
 
 int
 fd_txn_borrowed_account_view_idx( fd_exec_txn_ctx_t * ctx,

--- a/src/flamenco/runtime/fd_account.c
+++ b/src/flamenco/runtime/fd_account.c
@@ -1,10 +1,5 @@
 #include "fd_account.h"
 #include "context/fd_exec_instr_ctx.h"
-#include "fd_acc_mgr.h"
-#include "fd_borrowed_account.h"
-#include "fd_executor.h"
-#include "info/fd_instr_info.h"
-#include "sysvar/fd_sysvar_rent.h"
 
 int
 fd_account_set_executable( fd_exec_instr_ctx_t const * ctx,

--- a/src/flamenco/runtime/fd_account.h
+++ b/src/flamenco/runtime/fd_account.h
@@ -36,15 +36,10 @@
    See fd_acc_exists and the below helper functions for safe use in
    native programs. */
 
-#include "../../ballet/txn/fd_txn.h"
-#include "fd_executor.h"
-#include "info/fd_instr_info.h"
+#include "fd_executor_err.h"
 #include "fd_system_ids.h"
-#include "fd_runtime.h"
 #include "context/fd_exec_epoch_ctx.h"
-#include "context/fd_exec_slot_ctx.h"
 #include "context/fd_exec_txn_ctx.h"
-#include "context/fd_exec_instr_ctx.h"
 #include <assert.h>  /* TODO remove */
 
 /* FD_ACC_SZ_MAX is the hardcoded size limit of a Solana account. */

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -1,101 +1,13 @@
 #ifndef HEADER_fd_src_flamenco_runtime_fd_executor_h
 #define HEADER_fd_src_flamenco_runtime_fd_executor_h
 
+#include "fd_executor_err.h"
+#include "context/fd_exec_txn_ctx.h"
 #include "context/fd_exec_instr_ctx.h"
 #include "../../ballet/block/fd_microblock.h"
 #include "../../ballet/pack/fd_microblock.h"
 #include "../../ballet/poh/fd_poh.h"
 #include "tests/fd_exec_test.pb.h"
-
-/* Instruction error codes */
-
-/* TODO make sure these are serialized consistently with solana_program::InstructionError */
-/* TODO FD_EXECUTOR_INSTR_SUCCESS is used like Ok(()) in Rust. But this is both overloaded and a
-        misnomer, because the instruction hasn't necessarily been executed succesfully yet */
-
-#define FD_EXECUTOR_INSTR_ERR_FATAL                              ( INT_MIN ) /* Unrecoverable error */
-#define FD_EXECUTOR_INSTR_SUCCESS                                (   0 ) /* Instruction executed successfully */
-#define FD_EXECUTOR_INSTR_ERR_GENERIC_ERR                        (  -1 ) /* The program instruction returned an error */
-#define FD_EXECUTOR_INSTR_ERR_INVALID_ARG                        (  -2 ) /* The arguments provided to a program were invalid */
-#define FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA                 (  -3 ) /* An instruction's data contents were invalid */
-#define FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA                   (  -4 ) /* An account's data contents was invalid */
-#define FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL                 (  -5 ) /* An account's data was too small */
-#define FD_EXECUTOR_INSTR_ERR_INSUFFICIENT_FUNDS                 (  -6 ) /* An account's balance was too small to complete the instruction */
-#define FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID               (  -7 ) /* The account did not have the expected program id */
-#define FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE         (  -8 ) /* A signature was required but not found */
-#define FD_EXECUTOR_INSTR_ERR_ACC_ALREADY_INITIALIZED            (  -9 ) /* An initialize instruction was sent to an account that has already been initialized. */
-#define FD_EXECUTOR_INSTR_ERR_UNINITIALIZED_ACCOUNT              ( -10 ) /* An attempt to operate on an account that hasn't been initialized. */
-#define FD_EXECUTOR_INSTR_ERR_UNBALANCED_INSTR                   ( -11 ) /* Program's instruction lamport balance does not equal the balance after the instruction */
-#define FD_EXECUTOR_INSTR_ERR_MODIFIED_PROGRAM_ID                ( -12 ) /* Program illegally modified an account's program id */
-#define FD_EXECUTOR_INSTR_ERR_EXTERNAL_ACCOUNT_LAMPORT_SPEND     ( -13 ) /* Program spent the lamports of an account that doesn't belong to it */
-#define FD_EXECUTOR_INSTR_ERR_EXTERNAL_DATA_MODIFIED             ( -14 ) /* Program modified the data of an account that doesn't belong to it */
-#define FD_EXECUTOR_INSTR_ERR_READONLY_LAMPORT_CHANGE            ( -15 ) /* Read-only account's lamports modified */
-#define FD_EXECUTOR_INSTR_ERR_READONLY_DATA_MODIFIED             ( -16 ) /* Read-only account's data was modified */
-#define FD_EXECUTOR_INSTR_ERR_DUPLICATE_ACCOUNT_IDX              ( -17 ) /* An account was referenced more than once in a single instruction. Deprecated. */
-#define FD_EXECUTOR_INSTR_ERR_EXECUTABLE_MODIFIED                ( -18 ) /* Executable bit on account changed, but shouldn't have */
-#define FD_EXECUTOR_INSTR_ERR_RENT_EPOCH_MODIFIED                ( -19 ) /* Rent_epoch account changed, but shouldn't have */
-#define FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS                ( -20 ) /* The instruction expected additional account keys */
-#define FD_EXECUTOR_INSTR_ERR_ACC_DATA_SIZE_CHANGED              ( -21 ) /* Program other than the account's owner changed the size of the account data */
-#define FD_EXECUTOR_INSTR_ERR_ACC_NOT_EXECUTABLE                 ( -22 ) /* The instruction expected an executable account */
-#define FD_EXECUTOR_INSTR_ERR_ACC_BORROW_FAILED                  ( -23 ) /* Failed to borrow a reference to account data, already borrowed */
-#define FD_EXECUTOR_INSTR_ERR_ACC_BORROW_OUTSTANDING             ( -24 ) /* Account data has an outstanding reference after a program's execution */
-#define FD_EXECUTOR_INSTR_ERR_DUPLICATE_ACCOUNT_OUT_OF_SYNC      ( -25 ) /* The same account was multiply passed to an on-chain program's entrypoint, but the program modified them differently. */
-#define FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR                         ( -26 ) /* Allows on-chain programs to implement program-specific error types and see them returned by the runtime. */
-#define FD_EXECUTOR_INSTR_ERR_INVALID_ERR                        ( -27 ) /* The return value from the program was invalid.  */
-#define FD_EXECUTOR_INSTR_ERR_EXECUTABLE_DATA_MODIFIED           ( -28 ) /* Executable account's data was modified */
-#define FD_EXECUTOR_INSTR_ERR_EXECUTABLE_LAMPORT_CHANGE          ( -29 ) /* Executable account's lamports modified */
-#define FD_EXECUTOR_INSTR_ERR_EXECUTABLE_ACCOUNT_NOT_RENT_EXEMPT ( -30 ) /* Executable accounts must be rent exempt */
-#define FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID             ( -31 ) /* Unsupported program id */
-#define FD_EXECUTOR_INSTR_ERR_CALL_DEPTH                         ( -32 ) /* Cross-program invocation call depth too deep */
-#define FD_EXECUTOR_INSTR_ERR_MISSING_ACC                        ( -33 ) /* An account required by the instruction is missing */
-#define FD_EXECUTOR_INSTR_ERR_REENTRANCY_NOT_ALLOWED             ( -34 ) /* Cross-program invocation reentrancy not allowed for this instruction */
-#define FD_EXECUTOR_INSTR_ERR_MAX_SEED_LENGTH_EXCEEDED           ( -35 ) /* Length of the seed is too long for address generation */
-#define FD_EXECUTOR_INSTR_ERR_INVALID_SEEDS                      ( -36 ) /* Provided seeds do not result in a valid address */
-#define FD_EXECUTOR_INSTR_ERR_INVALID_REALLOC                    ( -37 ) /* Failed to reallocate account data of this length */
-#define FD_EXECUTOR_INSTR_ERR_COMPUTE_BUDGET_EXCEEDED            ( -38 ) /* Computational budget exceeded */
-#define FD_EXECUTOR_INSTR_ERR_PRIVILEGE_ESCALATION               ( -39 ) /* Cross-program invocation with unauthorized signer or writable account */
-#define FD_EXECUTOR_INSTR_ERR_PROGRAM_ENVIRONMENT_SETUP_FAILURE  ( -40 ) /* Failed to create program execution environment */
-#define FD_EXECUTOR_INSTR_ERR_PROGRAM_FAILED_TO_COMPLETE         ( -41 ) /* Program failed to complete */
-#define FD_EXECUTOR_INSTR_ERR_PROGRAM_FAILED_TO_COMPILE          ( -42 ) /* Program failed to compile */
-#define FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE                      ( -43 ) /* Account is immutable */
-#define FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY                ( -44 ) /* Incorrect authority provided */
-#define FD_EXECUTOR_INSTR_ERR_BORSH_IO_ERROR                     ( -45 ) /* Failed to serialize or deserialize account data */
-#define FD_EXECUTOR_INSTR_ERR_ACC_NOT_RENT_EXEMPT                ( -46 ) /* An account does not have enough lamports to be rent-exempt */
-#define FD_EXECUTOR_INSTR_ERR_INVALID_ACC_OWNER                  ( -47 ) /* Invalid account owner */
-#define FD_EXECUTOR_INSTR_ERR_ARITHMETIC_OVERFLOW                ( -48 ) /* Program arithmetic overflowed */
-#define FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR                 ( -49 ) /* Unsupported sysvar */
-#define FD_EXECUTOR_INSTR_ERR_ILLEGAL_OWNER                      ( -50 ) /* Provided owner is not allowed */
-#define FD_EXECUTOR_INSTR_ERR_MAX_ACCS_DATA_ALLOCS_EXCEEDED      ( -51 ) /* Account data allocation exceeded the maximum accounts data size limit */
-#define FD_EXECUTOR_INSTR_ERR_MAX_ACCS_EXCEEDED                  ( -52 ) /* Max accounts exceeded */
-#define FD_EXECUTOR_INSTR_ERR_MAX_INSN_TRACE_LENS_EXCEEDED       ( -53 ) /* Max instruction trace length exceeded */
-#define FD_EXECUTOR_INSTR_ERR_BUILTINS_MUST_CONSUME_CUS          ( -54 ) /* Builtin programs must consume compute units */
-
-#define FD_EXECUTOR_SYSTEM_ERR_ACCOUNT_ALREADY_IN_USE            ( -1 ) /* an account with the same address already exists */
-#define FD_EXECUTOR_SYSTEM_ERR_RESULTS_WITH_NEGATIVE_LAMPORTS    ( -2 ) /* account does not have enough SOL to perform the operation */
-#define FD_EXECUTOR_SYSTEM_ERR_INVALID_PROGRAM_ID                ( -3 ) /* cannot assign account to this program id */
-#define FD_EXECUTOR_SYSTEM_ERR_INVALID_ACCOUNT_DATA_LENGTH       ( -4 ) /* cannot allocate account data of this length */
-#define FD_EXECUTOR_SYSTEM_ERR_MAX_SEED_LENGTH_EXCEEDED          ( -5 ) /* length of requested seed is too long */
-#define FD_EXECUTOR_SYSTEM_ERR_ADDRESS_WITH_SEED_MISMATCH        ( -6 ) /* provided address does not match addressed derived from seed */
-#define FD_EXECUTOR_SYSTEM_ERR_NONCE_NO_RECENT_BLOCKHASHES       ( -7 ) /* advancing stored nonce requires a populated RecentBlockhashes sysvar */
-#define FD_EXECUTOR_SYSTEM_ERR_NONCE_BLOCKHASH_NOT_EXPIRED       ( -8 ) /* stored nonce is still in recent_blockhashes */
-#define FD_EXECUTOR_SYSTEM_ERR_NONCE_UNEXPECTED_BLOCKHASH_VALUE  ( -9 ) /* specified nonce does not match stored nonce */
-
-/* PrecompileError
-   https://github.com/anza-xyz/agave/blob/v1.18.12/sdk/src/precompiles.rs#L16
-   Agave distinguishes between 5 errors and the returned one depends on
-   the order they decided to write their code.
-   These are all fatal errors, so the specific errors doesn't matter for
-   consensus.
-   We cover a number of them, but to reduce complexity we just summarize
-   them in 2 codes: error verifying signature, error retrieving data. */
-#define FD_EXECUTOR_PRECOMPILE_ERR_PUBLIC_KEY                    ( -1 )
-#define FD_EXECUTOR_PRECOMPILE_ERR_RECOVERY_ID                   ( -2 )
-#define FD_EXECUTOR_PRECOMPILE_ERR_SIGNATURE                     ( -3 )
-#define FD_EXECUTOR_PRECOMPILE_ERR_DATA_OFFSET                   ( -4 )
-#define FD_EXECUTOR_PRECOMPILE_ERR_INSTR_DATA_SIZE               ( -5 )
-
-#define FD_COMPUTE_BUDGET_PRIORITIZATION_FEE_TYPE_COMPUTE_UNIT_PRICE (0)
-#define FD_COMPUTE_BUDGET_PRIORITIZATION_FEE_TYPE_DEPRECATED         (1)
 
 FD_PROTOTYPES_BEGIN
 
@@ -206,6 +118,19 @@ fd_executor_instr_strerror( int err );
 
 int
 fd_executor_check_txn_accounts( fd_exec_txn_ctx_t * txn_ctx );
+
+static inline int
+fd_exec_consume_cus( fd_exec_txn_ctx_t * txn_ctx,
+                     ulong               cus ) {
+  ulong new_cus   =  txn_ctx->compute_meter - cus;
+  int   underflow = (txn_ctx->compute_meter < cus);
+  if( FD_UNLIKELY( underflow ) ) {
+    txn_ctx->compute_meter = 0UL;
+    return FD_EXECUTOR_INSTR_ERR_COMPUTE_BUDGET_EXCEEDED;
+  }
+  txn_ctx->compute_meter = new_cus;
+  return FD_EXECUTOR_INSTR_SUCCESS;
+}
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/fd_executor_err.h
+++ b/src/flamenco/runtime/fd_executor_err.h
@@ -1,0 +1,94 @@
+#ifndef HEADER_fd_src_flamenco_runtime_fd_executor_err_h
+#define HEADER_fd_src_flamenco_runtime_fd_executor_err_h
+
+/* Instruction error codes */
+
+/* TODO make sure these are serialized consistently with solana_program::InstructionError */
+/* TODO FD_EXECUTOR_INSTR_SUCCESS is used like Ok(()) in Rust. But this is both overloaded and a
+        misnomer, because the instruction hasn't necessarily been executed succesfully yet */
+
+#define FD_EXECUTOR_INSTR_ERR_FATAL                              ( INT_MIN ) /* Unrecoverable error */
+#define FD_EXECUTOR_INSTR_SUCCESS                                (   0 ) /* Instruction executed successfully */
+#define FD_EXECUTOR_INSTR_ERR_GENERIC_ERR                        (  -1 ) /* The program instruction returned an error */
+#define FD_EXECUTOR_INSTR_ERR_INVALID_ARG                        (  -2 ) /* The arguments provided to a program were invalid */
+#define FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA                 (  -3 ) /* An instruction's data contents were invalid */
+#define FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA                   (  -4 ) /* An account's data contents was invalid */
+#define FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL                 (  -5 ) /* An account's data was too small */
+#define FD_EXECUTOR_INSTR_ERR_INSUFFICIENT_FUNDS                 (  -6 ) /* An account's balance was too small to complete the instruction */
+#define FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID               (  -7 ) /* The account did not have the expected program id */
+#define FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE         (  -8 ) /* A signature was required but not found */
+#define FD_EXECUTOR_INSTR_ERR_ACC_ALREADY_INITIALIZED            (  -9 ) /* An initialize instruction was sent to an account that has already been initialized. */
+#define FD_EXECUTOR_INSTR_ERR_UNINITIALIZED_ACCOUNT              ( -10 ) /* An attempt to operate on an account that hasn't been initialized. */
+#define FD_EXECUTOR_INSTR_ERR_UNBALANCED_INSTR                   ( -11 ) /* Program's instruction lamport balance does not equal the balance after the instruction */
+#define FD_EXECUTOR_INSTR_ERR_MODIFIED_PROGRAM_ID                ( -12 ) /* Program illegally modified an account's program id */
+#define FD_EXECUTOR_INSTR_ERR_EXTERNAL_ACCOUNT_LAMPORT_SPEND     ( -13 ) /* Program spent the lamports of an account that doesn't belong to it */
+#define FD_EXECUTOR_INSTR_ERR_EXTERNAL_DATA_MODIFIED             ( -14 ) /* Program modified the data of an account that doesn't belong to it */
+#define FD_EXECUTOR_INSTR_ERR_READONLY_LAMPORT_CHANGE            ( -15 ) /* Read-only account's lamports modified */
+#define FD_EXECUTOR_INSTR_ERR_READONLY_DATA_MODIFIED             ( -16 ) /* Read-only account's data was modified */
+#define FD_EXECUTOR_INSTR_ERR_DUPLICATE_ACCOUNT_IDX              ( -17 ) /* An account was referenced more than once in a single instruction. Deprecated. */
+#define FD_EXECUTOR_INSTR_ERR_EXECUTABLE_MODIFIED                ( -18 ) /* Executable bit on account changed, but shouldn't have */
+#define FD_EXECUTOR_INSTR_ERR_RENT_EPOCH_MODIFIED                ( -19 ) /* Rent_epoch account changed, but shouldn't have */
+#define FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS                ( -20 ) /* The instruction expected additional account keys */
+#define FD_EXECUTOR_INSTR_ERR_ACC_DATA_SIZE_CHANGED              ( -21 ) /* Program other than the account's owner changed the size of the account data */
+#define FD_EXECUTOR_INSTR_ERR_ACC_NOT_EXECUTABLE                 ( -22 ) /* The instruction expected an executable account */
+#define FD_EXECUTOR_INSTR_ERR_ACC_BORROW_FAILED                  ( -23 ) /* Failed to borrow a reference to account data, already borrowed */
+#define FD_EXECUTOR_INSTR_ERR_ACC_BORROW_OUTSTANDING             ( -24 ) /* Account data has an outstanding reference after a program's execution */
+#define FD_EXECUTOR_INSTR_ERR_DUPLICATE_ACCOUNT_OUT_OF_SYNC      ( -25 ) /* The same account was multiply passed to an on-chain program's entrypoint, but the program modified them differently. */
+#define FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR                         ( -26 ) /* Allows on-chain programs to implement program-specific error types and see them returned by the runtime. */
+#define FD_EXECUTOR_INSTR_ERR_INVALID_ERR                        ( -27 ) /* The return value from the program was invalid.  */
+#define FD_EXECUTOR_INSTR_ERR_EXECUTABLE_DATA_MODIFIED           ( -28 ) /* Executable account's data was modified */
+#define FD_EXECUTOR_INSTR_ERR_EXECUTABLE_LAMPORT_CHANGE          ( -29 ) /* Executable account's lamports modified */
+#define FD_EXECUTOR_INSTR_ERR_EXECUTABLE_ACCOUNT_NOT_RENT_EXEMPT ( -30 ) /* Executable accounts must be rent exempt */
+#define FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID             ( -31 ) /* Unsupported program id */
+#define FD_EXECUTOR_INSTR_ERR_CALL_DEPTH                         ( -32 ) /* Cross-program invocation call depth too deep */
+#define FD_EXECUTOR_INSTR_ERR_MISSING_ACC                        ( -33 ) /* An account required by the instruction is missing */
+#define FD_EXECUTOR_INSTR_ERR_REENTRANCY_NOT_ALLOWED             ( -34 ) /* Cross-program invocation reentrancy not allowed for this instruction */
+#define FD_EXECUTOR_INSTR_ERR_MAX_SEED_LENGTH_EXCEEDED           ( -35 ) /* Length of the seed is too long for address generation */
+#define FD_EXECUTOR_INSTR_ERR_INVALID_SEEDS                      ( -36 ) /* Provided seeds do not result in a valid address */
+#define FD_EXECUTOR_INSTR_ERR_INVALID_REALLOC                    ( -37 ) /* Failed to reallocate account data of this length */
+#define FD_EXECUTOR_INSTR_ERR_COMPUTE_BUDGET_EXCEEDED            ( -38 ) /* Computational budget exceeded */
+#define FD_EXECUTOR_INSTR_ERR_PRIVILEGE_ESCALATION               ( -39 ) /* Cross-program invocation with unauthorized signer or writable account */
+#define FD_EXECUTOR_INSTR_ERR_PROGRAM_ENVIRONMENT_SETUP_FAILURE  ( -40 ) /* Failed to create program execution environment */
+#define FD_EXECUTOR_INSTR_ERR_PROGRAM_FAILED_TO_COMPLETE         ( -41 ) /* Program failed to complete */
+#define FD_EXECUTOR_INSTR_ERR_PROGRAM_FAILED_TO_COMPILE          ( -42 ) /* Program failed to compile */
+#define FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE                      ( -43 ) /* Account is immutable */
+#define FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY                ( -44 ) /* Incorrect authority provided */
+#define FD_EXECUTOR_INSTR_ERR_BORSH_IO_ERROR                     ( -45 ) /* Failed to serialize or deserialize account data */
+#define FD_EXECUTOR_INSTR_ERR_ACC_NOT_RENT_EXEMPT                ( -46 ) /* An account does not have enough lamports to be rent-exempt */
+#define FD_EXECUTOR_INSTR_ERR_INVALID_ACC_OWNER                  ( -47 ) /* Invalid account owner */
+#define FD_EXECUTOR_INSTR_ERR_ARITHMETIC_OVERFLOW                ( -48 ) /* Program arithmetic overflowed */
+#define FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR                 ( -49 ) /* Unsupported sysvar */
+#define FD_EXECUTOR_INSTR_ERR_ILLEGAL_OWNER                      ( -50 ) /* Provided owner is not allowed */
+#define FD_EXECUTOR_INSTR_ERR_MAX_ACCS_DATA_ALLOCS_EXCEEDED      ( -51 ) /* Account data allocation exceeded the maximum accounts data size limit */
+#define FD_EXECUTOR_INSTR_ERR_MAX_ACCS_EXCEEDED                  ( -52 ) /* Max accounts exceeded */
+#define FD_EXECUTOR_INSTR_ERR_MAX_INSN_TRACE_LENS_EXCEEDED       ( -53 ) /* Max instruction trace length exceeded */
+#define FD_EXECUTOR_INSTR_ERR_BUILTINS_MUST_CONSUME_CUS          ( -54 ) /* Builtin programs must consume compute units */
+
+#define FD_EXECUTOR_SYSTEM_ERR_ACCOUNT_ALREADY_IN_USE            ( -1 ) /* an account with the same address already exists */
+#define FD_EXECUTOR_SYSTEM_ERR_RESULTS_WITH_NEGATIVE_LAMPORTS    ( -2 ) /* account does not have enough SOL to perform the operation */
+#define FD_EXECUTOR_SYSTEM_ERR_INVALID_PROGRAM_ID                ( -3 ) /* cannot assign account to this program id */
+#define FD_EXECUTOR_SYSTEM_ERR_INVALID_ACCOUNT_DATA_LENGTH       ( -4 ) /* cannot allocate account data of this length */
+#define FD_EXECUTOR_SYSTEM_ERR_MAX_SEED_LENGTH_EXCEEDED          ( -5 ) /* length of requested seed is too long */
+#define FD_EXECUTOR_SYSTEM_ERR_ADDRESS_WITH_SEED_MISMATCH        ( -6 ) /* provided address does not match addressed derived from seed */
+#define FD_EXECUTOR_SYSTEM_ERR_NONCE_NO_RECENT_BLOCKHASHES       ( -7 ) /* advancing stored nonce requires a populated RecentBlockhashes sysvar */
+#define FD_EXECUTOR_SYSTEM_ERR_NONCE_BLOCKHASH_NOT_EXPIRED       ( -8 ) /* stored nonce is still in recent_blockhashes */
+#define FD_EXECUTOR_SYSTEM_ERR_NONCE_UNEXPECTED_BLOCKHASH_VALUE  ( -9 ) /* specified nonce does not match stored nonce */
+
+/* PrecompileError
+   https://github.com/anza-xyz/agave/blob/v1.18.12/sdk/src/precompiles.rs#L16
+   Agave distinguishes between 5 errors and the returned one depends on
+   the order they decided to write their code.
+   These are all fatal errors, so the specific errors doesn't matter for
+   consensus.
+   We cover a number of them, but to reduce complexity we just summarize
+   them in 2 codes: error verifying signature, error retrieving data. */
+#define FD_EXECUTOR_PRECOMPILE_ERR_PUBLIC_KEY                    ( -1 )
+#define FD_EXECUTOR_PRECOMPILE_ERR_RECOVERY_ID                   ( -2 )
+#define FD_EXECUTOR_PRECOMPILE_ERR_SIGNATURE                     ( -3 )
+#define FD_EXECUTOR_PRECOMPILE_ERR_DATA_OFFSET                   ( -4 )
+#define FD_EXECUTOR_PRECOMPILE_ERR_INSTR_DATA_SIZE               ( -5 )
+
+#define FD_COMPUTE_BUDGET_PRIORITIZATION_FEE_TYPE_COMPUTE_UNIT_PRICE (0)
+#define FD_COMPUTE_BUDGET_PRIORITIZATION_FEE_TYPE_DEPRECATED         (1)
+
+#endif /* HEADER_fd_src_flamenco_runtime_fd_executor_err_h */

--- a/src/flamenco/runtime/fd_pubkey_utils.c
+++ b/src/flamenco/runtime/fd_pubkey_utils.c
@@ -1,4 +1,5 @@
 #include "fd_pubkey_utils.h"
+#include "fd_executor_err.h"
 #include "../vm/fd_vm_syscalls.h"
 #include "../../ballet/ed25519/fd_curve25519.h"
 

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -1,5 +1,7 @@
-#include "fd_acc_mgr.h"
 #include "fd_runtime.h"
+#include "fd_runtime_init.h"
+
+#include "fd_executor.h"
 #include "fd_account.h"
 #include "fd_hashes.h"
 #include "sysvar/fd_sysvar_cache.h"
@@ -16,10 +18,8 @@
 #include "../stakes/fd_stakes.h"
 #include "../rewards/fd_rewards.h"
 
-#include "context/fd_exec_epoch_ctx.h"
 #include "context/fd_exec_txn_ctx.h"
 #include "context/fd_exec_instr_ctx.h"
-#include "info/fd_block_info.h"
 #include "info/fd_microblock_batch_info.h"
 #include "info/fd_microblock_info.h"
 
@@ -3230,151 +3230,6 @@ fd_runtime_freeze( fd_exec_slot_ctx_t * slot_ctx ) {
   slot_ctx->slot_bank.collected_rent = 0;
 }
 
-fd_funk_rec_key_t
-fd_runtime_firedancer_bank_key( void ) {
-  fd_funk_rec_key_t id;
-  fd_memset(&id, 1, sizeof(id));
-  id.c[FD_FUNK_REC_KEY_FOOTPRINT - 1] = FD_BLOCK_BANKS_TYPE;
-
-  return id;
-}
-
-fd_funk_rec_key_t
-fd_runtime_epoch_bank_key( void ) {
-  fd_funk_rec_key_t id;
-  fd_memset(&id, 1, sizeof(id));
-  id.c[FD_FUNK_REC_KEY_FOOTPRINT - 1] = FD_BLOCK_EPOCH_BANK_TYPE;
-
-  return id;
-}
-
-fd_funk_rec_key_t
-fd_runtime_slot_bank_key( void ) {
-  fd_funk_rec_key_t id;
-  fd_memset(&id, 1, sizeof(id));
-  id.c[FD_FUNK_REC_KEY_FOOTPRINT - 1] = FD_BLOCK_SLOT_BANK_TYPE;
-
-  return id;
-}
-
-int
-fd_runtime_save_epoch_bank( fd_exec_slot_ctx_t * slot_ctx ) {
-  fd_epoch_bank_t * epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
-  ulong sz = fd_epoch_bank_size(epoch_bank);
-  fd_funk_rec_key_t id = fd_runtime_epoch_bank_key();
-  int opt_err = 0;
-  fd_funk_rec_t *rec = fd_funk_rec_write_prepare(slot_ctx->acc_mgr->funk, slot_ctx->funk_txn, &id, sz, 1, NULL, &opt_err);
-  if (NULL == rec)
-  {
-    FD_LOG_WARNING(("fd_runtime_save_banks failed: %s", fd_funk_strerror(opt_err)));
-    return opt_err;
-  }
-
-  uchar *buf = fd_funk_val(rec, fd_funk_wksp(slot_ctx->acc_mgr->funk));
-  fd_bincode_encode_ctx_t ctx = {
-      .data = buf,
-      .dataend = buf + sz,
-  };
-
-  if (FD_UNLIKELY(fd_epoch_bank_encode(epoch_bank, &ctx) != FD_BINCODE_SUCCESS))
-  {
-    FD_LOG_WARNING(("fd_runtime_save_banks: fd_firedancer_banks_encode failed"));
-    return -1;
-  }
-
-  FD_LOG_DEBUG(("epoch frozen, slot=%d bank_hash=%32J poh_hash=%32J", slot_ctx->slot_bank.slot, slot_ctx->slot_bank.banks_hash.hash, slot_ctx->slot_bank.poh.hash));
-
-  return FD_RUNTIME_EXECUTE_SUCCESS;
-}
-
-int fd_runtime_save_slot_bank(fd_exec_slot_ctx_t *slot_ctx)
-{
-  ulong sz = fd_slot_bank_size(&slot_ctx->slot_bank);
-
-  fd_funk_rec_key_t id = fd_runtime_slot_bank_key();
-  int opt_err = 0;
-  fd_funk_rec_t *rec = fd_funk_rec_write_prepare(slot_ctx->acc_mgr->funk, slot_ctx->funk_txn, &id, sz, 1, NULL, &opt_err);
-  if (NULL == rec)
-  {
-    FD_LOG_WARNING(("fd_runtime_save_banks failed: %s", fd_funk_strerror(opt_err)));
-    return opt_err;
-  }
-
-  uchar *buf = fd_funk_val(rec, fd_funk_wksp(slot_ctx->acc_mgr->funk));
-  fd_bincode_encode_ctx_t ctx = {
-      .data = buf,
-      .dataend = buf + sz,
-  };
-  if (FD_UNLIKELY(fd_slot_bank_encode(&slot_ctx->slot_bank, &ctx) != FD_BINCODE_SUCCESS))
-  {
-    FD_LOG_WARNING(("fd_runtime_save_banks: fd_firedancer_banks_encode failed"));
-    return -1;
-  }
-
-  // FD_LOG_DEBUG(("slot frozen, slot=%d bank_hash=%32J poh_hash=%32J", slot_ctx->slot_bank.slot, slot_ctx->slot_bank.banks_hash.hash, slot_ctx->slot_bank.poh.hash));
-  slot_ctx->slot_bank.block_height += 1UL;
-
-  // Update blockstore
-  if ( slot_ctx->blockstore != NULL ) {
-    fd_blockstore_block_height_set(
-        slot_ctx->blockstore, slot_ctx->slot_bank.slot, slot_ctx->slot_bank.block_height );
-  } else {
-    FD_LOG_WARNING(( "NULL blockstore in slot_ctx" ));
-  }
-
-  return FD_RUNTIME_EXECUTE_SUCCESS;
-}
-
-/* fd_feature_restore loads a feature from the accounts database and
-   updates the bank's feature activation state, given a feature account
-   address. */
-
-static void
-fd_feature_restore( fd_exec_slot_ctx_t * slot_ctx,
-                    fd_feature_id_t const * id,
-                    uchar const       acct[ static 32 ] ) {
-
-  FD_BORROWED_ACCOUNT_DECL(acct_rec);
-  int err = fd_acc_mgr_view(slot_ctx->acc_mgr, slot_ctx->funk_txn, (fd_pubkey_t *)acct, acct_rec);
-  if (FD_UNLIKELY(err != FD_ACC_MGR_SUCCESS))
-    return;
-
-  fd_feature_t feature[1];
-
-  FD_SCRATCH_SCOPE_BEGIN
-  {
-
-    fd_bincode_decode_ctx_t ctx = {
-        .data = acct_rec->const_data,
-        .dataend = acct_rec->const_data + acct_rec->const_meta->dlen,
-        .valloc = fd_scratch_virtual(),
-    };
-    int decode_err = fd_feature_decode(feature, &ctx);
-    if (FD_UNLIKELY(decode_err != FD_BINCODE_SUCCESS))
-    {
-      FD_LOG_ERR(("Failed to decode feature account %32J (%d)", acct, decode_err));
-      return;
-    }
-
-    if( feature->has_activated_at ) {
-      FD_LOG_INFO(( "Feature %32J activated at %lu", acct, feature->activated_at ));
-      fd_features_set(&slot_ctx->epoch_ctx->features, id, feature->activated_at);
-    } else {
-      FD_LOG_DEBUG(( "Feature %32J not activated at %lu", acct, feature->activated_at ));
-    }
-    /* No need to call destroy, since we are using fd_scratch allocator. */
-  } FD_SCRATCH_SCOPE_END;
-}
-
-void
-fd_features_restore( fd_exec_slot_ctx_t * slot_ctx ) {
-  for( fd_feature_id_t const * id = fd_feature_iter_init();
-                                   !fd_feature_iter_done( id );
-                               id = fd_feature_iter_next( id ) ) {
-    fd_feature_restore( slot_ctx, id, id->id.key );
-  }
-}
-
 static void
 fd_feature_activate( fd_exec_slot_ctx_t * slot_ctx,
                     fd_feature_id_t const * id,
@@ -3703,70 +3558,6 @@ void fd_process_new_epoch(
 
   fd_runtime_update_leaders(slot_ctx, slot_ctx->slot_bank.slot);
   FD_LOG_WARNING(("Updated leader %32J", slot_ctx->leader->uc));
-}
-
-void
-fd_runtime_recover_banks( fd_exec_slot_ctx_t * slot_ctx, int delete_first ) {
-  fd_funk_t *           funk        = slot_ctx->acc_mgr->funk;
-  fd_funk_txn_t *       txn         = slot_ctx->funk_txn;
-  fd_exec_epoch_ctx_t * epoch_ctx   = slot_ctx->epoch_ctx;
-  fd_epoch_bank_t *     epoch_bank  = fd_exec_epoch_ctx_epoch_bank( epoch_ctx );
-  fd_valloc_t           epoch_valloc = fd_scratch_virtual();
-  {
-    fd_funk_rec_key_t id = fd_runtime_epoch_bank_key();
-    fd_funk_rec_t const * rec = fd_funk_rec_query_global(funk, txn, &id);
-    if ( rec == NULL )
-      FD_LOG_ERR(("failed to read banks record"));
-    void * val = fd_funk_val( rec, fd_funk_wksp(funk) );
-
-    fd_exec_epoch_ctx_bank_mem_clear( epoch_ctx );
-    fd_bincode_decode_ctx_t ctx;
-    ctx.data = val;
-    ctx.dataend = (uchar*)val + fd_funk_val_sz( rec );
-    ctx.valloc  = epoch_valloc;
-    FD_TEST( fd_epoch_bank_decode_no_malloc( epoch_bank, &ctx, epoch_ctx )==FD_BINCODE_SUCCESS );
-
-    FD_LOG_NOTICE(( "recovered epoch_bank" ));
-  }
-
-  {
-    if ( delete_first ) {
-      fd_bincode_destroy_ctx_t ctx;
-      ctx.valloc  = slot_ctx->valloc;
-      fd_slot_bank_destroy(&slot_ctx->slot_bank, &ctx);
-    }
-    fd_funk_rec_key_t id = fd_runtime_slot_bank_key();
-    fd_funk_rec_t const * rec = fd_funk_rec_query_global(funk, txn, &id);
-    if ( rec == NULL )
-      FD_LOG_ERR(("failed to read banks record"));
-    void * val = fd_funk_val( rec, fd_funk_wksp(funk) );
-    fd_bincode_decode_ctx_t ctx;
-    ctx.data = val;
-    ctx.dataend = (uchar*)val + fd_funk_val_sz( rec );
-    ctx.valloc  = slot_ctx->valloc;
-    FD_TEST( fd_slot_bank_decode(&slot_ctx->slot_bank, &ctx )==FD_BINCODE_SUCCESS );
-
-    FD_LOG_NOTICE(( "recovered slot_bank for slot=%ld banks_hash=%32J poh_hash %32J lthash %32J",
-                    (long)slot_ctx->slot_bank.slot,
-                    slot_ctx->slot_bank.banks_hash.hash,
-                    slot_ctx->slot_bank.poh.hash,
-                    slot_ctx->slot_bank.lthash ));
-
-    slot_ctx->slot_bank.collected_fees = 0;
-    slot_ctx->slot_bank.collected_rent = 0;
-  }
-
-}
-
-void
-fd_runtime_delete_banks( fd_exec_slot_ctx_t * slot_ctx ) {
-
-  /* As the collection pointers are not owned by fd_alloc, zero them
-     out to prevent invalid frees by the destroy function. */
-
-  fd_bincode_destroy_ctx_t ctx = { .valloc = slot_ctx->valloc };
-  fd_exec_epoch_ctx_epoch_bank_delete( slot_ctx->epoch_ctx );
-  fd_slot_bank_destroy( &slot_ctx->slot_bank, &ctx );
 }
 
 ulong

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -3,6 +3,7 @@
 
 #include "../fd_flamenco_base.h"
 #include "fd_runtime_err.h"
+#include "fd_runtime_init.h"
 #include "fd_rocksdb.h"
 #include "fd_acc_mgr.h"
 #include "../features/fd_features.h"
@@ -219,31 +220,9 @@ ulong
 fd_runtime_lamports_per_signature_for_blockhash( fd_exec_slot_ctx_t const * slot_ctx,
                                                  fd_hash_t const * blockhash );
 
-fd_funk_rec_key_t
-fd_runtime_firedancer_bank_key( void );
-
-fd_funk_rec_key_t
-fd_runtime_epoch_bank_key( void );
-
-fd_funk_rec_key_t
-fd_runtime_slot_bank_key( void );
-
-int
-fd_runtime_save_slot_bank( fd_exec_slot_ctx_t * slot_ctx );
-
-int
-fd_runtime_save_epoch_bank( fd_exec_slot_ctx_t * slot_ctx );
-
 // int
 // fd_global_import_solana_manifest( fd_exec_slot_ctx_t * slot_ctx,
 //                                   fd_solana_manifest_t * manifest);
-
-/* fd_features_restore loads all known feature accounts from the
-   accounts database.  This is used when initializing bank from a
-   snapshot. */
-
-void
-fd_features_restore( fd_exec_slot_ctx_t * slot_ctx );
 
 static inline ulong
 fd_rent_exempt( fd_rent_t const * rent,
@@ -261,17 +240,6 @@ fd_runtime_update_leaders( fd_exec_slot_ctx_t * slot_ctx, ulong slot );
 /* rollback runtime to the state where the given slot just FINISHED executing */
 int
 fd_runtime_rollback_to( fd_exec_slot_ctx_t * slot_ctx, ulong slot );
-
-/* Recover slot_bank and epoch_bnck from funky */
-void
-fd_runtime_recover_banks( fd_exec_slot_ctx_t * slot_ctx, int delete_first );
-
-void
-fd_runtime_delete_banks( fd_exec_slot_ctx_t * slot_ctx );
-
-/* Recover slot_ctx from funky */
-void
-fd_runtime_recover_slot_ctx( fd_exec_slot_ctx_t * slot_ctx );
 
 /* fd_runtime_ctx_{align,footprint} return FD_REPLAY_STATE_{ALIGN,FOOTPRINT}. */
 

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -34,15 +34,6 @@
 
 #define FD_FEATURE_ACTIVE(_slot_ctx, _feature_name)  (_slot_ctx->slot_bank.slot >= _slot_ctx->epoch_ctx->features. _feature_name)
 
-/* FD_BLOCK_BANKS_TYPE stores fd_firedancer_banks_t bincode encoded (obsolete)*/
-#define FD_BLOCK_BANKS_TYPE ((uchar)3)
-
-/* FD_BLOCK_SLOT_BANK_TYPE stores fd_slot_bank_t bincode encoded */
-#define FD_BLOCK_SLOT_BANK_TYPE ((uchar)6)
-
-/* FD_BLOCK_EPOCH_BANK_TYPE stores fd_epoch_bank_t bincode encoded */
-#define FD_BLOCK_EPOCH_BANK_TYPE ((uchar)7)
-
 #define FD_BLOCKHASH_QUEUE_MAX_ENTRIES       (300UL)
 #define FD_RECENT_BLOCKHASHES_MAX_ENTRIES    (150UL)
 

--- a/src/flamenco/runtime/fd_runtime_init.c
+++ b/src/flamenco/runtime/fd_runtime_init.c
@@ -1,0 +1,216 @@
+#include "fd_runtime.h"
+
+#pragma GCC diagnostic ignored "-Wformat"
+#pragma GCC diagnostic ignored "-Wformat-extra-args"
+
+/* This file must not depend on fd_executor.h */
+
+fd_funk_rec_key_t
+fd_runtime_firedancer_bank_key( void ) {
+  fd_funk_rec_key_t id;
+  fd_memset(&id, 1, sizeof(id));
+  id.c[FD_FUNK_REC_KEY_FOOTPRINT - 1] = FD_BLOCK_BANKS_TYPE;
+
+  return id;
+}
+
+fd_funk_rec_key_t
+fd_runtime_epoch_bank_key( void ) {
+  fd_funk_rec_key_t id;
+  fd_memset(&id, 1, sizeof(id));
+  id.c[FD_FUNK_REC_KEY_FOOTPRINT - 1] = FD_BLOCK_EPOCH_BANK_TYPE;
+
+  return id;
+}
+
+fd_funk_rec_key_t
+fd_runtime_slot_bank_key( void ) {
+  fd_funk_rec_key_t id;
+  fd_memset(&id, 1, sizeof(id));
+  id.c[FD_FUNK_REC_KEY_FOOTPRINT - 1] = FD_BLOCK_SLOT_BANK_TYPE;
+
+  return id;
+}
+
+int
+fd_runtime_save_epoch_bank( fd_exec_slot_ctx_t * slot_ctx ) {
+  fd_epoch_bank_t * epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
+  ulong sz = fd_epoch_bank_size(epoch_bank);
+  fd_funk_rec_key_t id = fd_runtime_epoch_bank_key();
+  int opt_err = 0;
+  fd_funk_rec_t *rec = fd_funk_rec_write_prepare(slot_ctx->acc_mgr->funk, slot_ctx->funk_txn, &id, sz, 1, NULL, &opt_err);
+  if (NULL == rec)
+  {
+    FD_LOG_WARNING(("fd_runtime_save_banks failed: %s", fd_funk_strerror(opt_err)));
+    return opt_err;
+  }
+
+  uchar *buf = fd_funk_val(rec, fd_funk_wksp(slot_ctx->acc_mgr->funk));
+  fd_bincode_encode_ctx_t ctx = {
+      .data = buf,
+      .dataend = buf + sz,
+  };
+
+  if (FD_UNLIKELY(fd_epoch_bank_encode(epoch_bank, &ctx) != FD_BINCODE_SUCCESS))
+  {
+    FD_LOG_WARNING(("fd_runtime_save_banks: fd_firedancer_banks_encode failed"));
+    return -1;
+  }
+
+  FD_LOG_DEBUG(("epoch frozen, slot=%d bank_hash=%32J poh_hash=%32J", slot_ctx->slot_bank.slot, slot_ctx->slot_bank.banks_hash.hash, slot_ctx->slot_bank.poh.hash));
+
+  return FD_RUNTIME_EXECUTE_SUCCESS;
+}
+
+int fd_runtime_save_slot_bank(fd_exec_slot_ctx_t *slot_ctx)
+{
+  ulong sz = fd_slot_bank_size(&slot_ctx->slot_bank);
+
+  fd_funk_rec_key_t id = fd_runtime_slot_bank_key();
+  int opt_err = 0;
+  fd_funk_rec_t *rec = fd_funk_rec_write_prepare(slot_ctx->acc_mgr->funk, slot_ctx->funk_txn, &id, sz, 1, NULL, &opt_err);
+  if (NULL == rec)
+  {
+    FD_LOG_WARNING(("fd_runtime_save_banks failed: %s", fd_funk_strerror(opt_err)));
+    return opt_err;
+  }
+
+  uchar *buf = fd_funk_val(rec, fd_funk_wksp(slot_ctx->acc_mgr->funk));
+  fd_bincode_encode_ctx_t ctx = {
+      .data = buf,
+      .dataend = buf + sz,
+  };
+  if (FD_UNLIKELY(fd_slot_bank_encode(&slot_ctx->slot_bank, &ctx) != FD_BINCODE_SUCCESS))
+  {
+    FD_LOG_WARNING(("fd_runtime_save_banks: fd_firedancer_banks_encode failed"));
+    return -1;
+  }
+
+  // FD_LOG_DEBUG(("slot frozen, slot=%d bank_hash=%32J poh_hash=%32J", slot_ctx->slot_bank.slot, slot_ctx->slot_bank.banks_hash.hash, slot_ctx->slot_bank.poh.hash));
+  slot_ctx->slot_bank.block_height += 1UL;
+
+  // Update blockstore
+  if ( slot_ctx->blockstore != NULL ) {
+    fd_blockstore_block_height_set(
+        slot_ctx->blockstore, slot_ctx->slot_bank.slot, slot_ctx->slot_bank.block_height );
+  } else {
+    FD_LOG_WARNING(( "NULL blockstore in slot_ctx" ));
+  }
+
+  return FD_RUNTIME_EXECUTE_SUCCESS;
+}
+
+void
+fd_runtime_recover_banks( fd_exec_slot_ctx_t * slot_ctx, int delete_first ) {
+  fd_funk_t *           funk        = slot_ctx->acc_mgr->funk;
+  fd_funk_txn_t *       txn         = slot_ctx->funk_txn;
+  fd_exec_epoch_ctx_t * epoch_ctx   = slot_ctx->epoch_ctx;
+  fd_epoch_bank_t *     epoch_bank  = fd_exec_epoch_ctx_epoch_bank( epoch_ctx );
+  fd_valloc_t           epoch_valloc = fd_scratch_virtual();
+  {
+    fd_funk_rec_key_t id = fd_runtime_epoch_bank_key();
+    fd_funk_rec_t const * rec = fd_funk_rec_query_global(funk, txn, &id);
+    if ( rec == NULL )
+      FD_LOG_ERR(("failed to read banks record"));
+    void * val = fd_funk_val( rec, fd_funk_wksp(funk) );
+
+    fd_exec_epoch_ctx_bank_mem_clear( epoch_ctx );
+    fd_bincode_decode_ctx_t ctx;
+    ctx.data = val;
+    ctx.dataend = (uchar*)val + fd_funk_val_sz( rec );
+    ctx.valloc  = epoch_valloc;
+    FD_TEST( fd_epoch_bank_decode_no_malloc( epoch_bank, &ctx, epoch_ctx )==FD_BINCODE_SUCCESS );
+
+    FD_LOG_NOTICE(( "recovered epoch_bank" ));
+  }
+
+  {
+    if ( delete_first ) {
+      fd_bincode_destroy_ctx_t ctx;
+      ctx.valloc  = slot_ctx->valloc;
+      fd_slot_bank_destroy(&slot_ctx->slot_bank, &ctx);
+    }
+    fd_funk_rec_key_t id = fd_runtime_slot_bank_key();
+    fd_funk_rec_t const * rec = fd_funk_rec_query_global(funk, txn, &id);
+    if ( rec == NULL )
+      FD_LOG_ERR(("failed to read banks record"));
+    void * val = fd_funk_val( rec, fd_funk_wksp(funk) );
+    fd_bincode_decode_ctx_t ctx;
+    ctx.data = val;
+    ctx.dataend = (uchar*)val + fd_funk_val_sz( rec );
+    ctx.valloc  = slot_ctx->valloc;
+    FD_TEST( fd_slot_bank_decode(&slot_ctx->slot_bank, &ctx )==FD_BINCODE_SUCCESS );
+
+    FD_LOG_NOTICE(( "recovered slot_bank for slot=%ld banks_hash=%32J poh_hash %32J lthash %32J",
+                    (long)slot_ctx->slot_bank.slot,
+                    slot_ctx->slot_bank.banks_hash.hash,
+                    slot_ctx->slot_bank.poh.hash,
+                    slot_ctx->slot_bank.lthash ));
+
+    slot_ctx->slot_bank.collected_fees = 0;
+    slot_ctx->slot_bank.collected_rent = 0;
+  }
+
+}
+
+void
+fd_runtime_delete_banks( fd_exec_slot_ctx_t * slot_ctx ) {
+
+  /* As the collection pointers are not owned by fd_alloc, zero them
+     out to prevent invalid frees by the destroy function. */
+
+  fd_bincode_destroy_ctx_t ctx = { .valloc = slot_ctx->valloc };
+  fd_exec_epoch_ctx_epoch_bank_delete( slot_ctx->epoch_ctx );
+  fd_slot_bank_destroy( &slot_ctx->slot_bank, &ctx );
+}
+
+
+/* fd_feature_restore loads a feature from the accounts database and
+   updates the bank's feature activation state, given a feature account
+   address. */
+
+static void
+fd_feature_restore( fd_exec_slot_ctx_t * slot_ctx,
+                    fd_feature_id_t const * id,
+                    uchar const       acct[ static 32 ] ) {
+
+  FD_BORROWED_ACCOUNT_DECL(acct_rec);
+  int err = fd_acc_mgr_view(slot_ctx->acc_mgr, slot_ctx->funk_txn, (fd_pubkey_t *)acct, acct_rec);
+  if (FD_UNLIKELY(err != FD_ACC_MGR_SUCCESS))
+    return;
+
+  fd_feature_t feature[1];
+
+  FD_SCRATCH_SCOPE_BEGIN
+  {
+
+    fd_bincode_decode_ctx_t ctx = {
+        .data = acct_rec->const_data,
+        .dataend = acct_rec->const_data + acct_rec->const_meta->dlen,
+        .valloc = fd_scratch_virtual(),
+    };
+    int decode_err = fd_feature_decode(feature, &ctx);
+    if (FD_UNLIKELY(decode_err != FD_BINCODE_SUCCESS))
+    {
+      FD_LOG_ERR(("Failed to decode feature account %32J (%d)", acct, decode_err));
+      return;
+    }
+
+    if( feature->has_activated_at ) {
+      FD_LOG_INFO(( "Feature %32J activated at %lu", acct, feature->activated_at ));
+      fd_features_set(&slot_ctx->epoch_ctx->features, id, feature->activated_at);
+    } else {
+      FD_LOG_DEBUG(( "Feature %32J not activated at %lu", acct, feature->activated_at ));
+    }
+    /* No need to call destroy, since we are using fd_scratch allocator. */
+  } FD_SCRATCH_SCOPE_END;
+}
+
+void
+fd_features_restore( fd_exec_slot_ctx_t * slot_ctx ) {
+  for( fd_feature_id_t const * id = fd_feature_iter_init();
+                                   !fd_feature_iter_done( id );
+                               id = fd_feature_iter_next( id ) ) {
+    fd_feature_restore( slot_ctx, id, id->id.key );
+  }
+}

--- a/src/flamenco/runtime/fd_runtime_init.c
+++ b/src/flamenco/runtime/fd_runtime_init.c
@@ -1,4 +1,8 @@
-#include "fd_runtime.h"
+#include "fd_runtime_init.h"
+#include "fd_runtime_err.h"
+#include "../types/fd_types.h"
+#include "context/fd_exec_epoch_ctx.h"
+#include "context/fd_exec_slot_ctx.h"
 
 #pragma GCC diagnostic ignored "-Wformat"
 #pragma GCC diagnostic ignored "-Wformat-extra-args"

--- a/src/flamenco/runtime/fd_runtime_init.h
+++ b/src/flamenco/runtime/fd_runtime_init.h
@@ -1,0 +1,43 @@
+#ifndef HEADER_fd_src_flamenco_runtime_fd_runtime_init_h
+#define HEADER_fd_src_flamenco_runtime_fd_runtime_init_h
+
+/* fd_runtime_init.h provides APIs for backing up and restoring a Solana
+   runtime environment.  This file must not include on fd_executor.h. */
+
+#include "../fd_flamenco_base.h"
+#include "../../funk/fd_funk_rec.h"
+
+FD_PROTOTYPES_BEGIN
+
+fd_funk_rec_key_t
+fd_runtime_firedancer_bank_key( void );
+
+fd_funk_rec_key_t
+fd_runtime_epoch_bank_key( void );
+
+fd_funk_rec_key_t
+fd_runtime_slot_bank_key( void );
+
+int
+fd_runtime_save_slot_bank( fd_exec_slot_ctx_t * slot_ctx );
+
+int
+fd_runtime_save_epoch_bank( fd_exec_slot_ctx_t * slot_ctx );
+
+/* fd_features_restore loads all known feature accounts from the
+   accounts database.  This is used when initializing bank from a
+   snapshot. */
+
+void
+fd_features_restore( fd_exec_slot_ctx_t * slot_ctx );
+
+/* Recover slot_bank and epoch_bnck from funky */
+void
+fd_runtime_recover_banks( fd_exec_slot_ctx_t * slot_ctx, int delete_first );
+
+void
+fd_runtime_delete_banks( fd_exec_slot_ctx_t * slot_ctx );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_flamenco_runtime_fd_runtime_init_h */

--- a/src/flamenco/runtime/fd_runtime_init.h
+++ b/src/flamenco/runtime/fd_runtime_init.h
@@ -2,10 +2,19 @@
 #define HEADER_fd_src_flamenco_runtime_fd_runtime_init_h
 
 /* fd_runtime_init.h provides APIs for backing up and restoring a Solana
-   runtime environment.  This file must not include on fd_executor.h. */
+   runtime environment.  This file must not depend on fd_executor.h. */
 
 #include "../fd_flamenco_base.h"
 #include "../../funk/fd_funk_rec.h"
+
+/* FD_BLOCK_BANKS_TYPE stores fd_firedancer_banks_t bincode encoded (obsolete)*/
+#define FD_BLOCK_BANKS_TYPE ((uchar)3)
+
+/* FD_BLOCK_SLOT_BANK_TYPE stores fd_slot_bank_t bincode encoded */
+#define FD_BLOCK_SLOT_BANK_TYPE ((uchar)6)
+
+/* FD_BLOCK_EPOCH_BANK_TYPE stores fd_epoch_bank_t bincode encoded */
+#define FD_BLOCK_EPOCH_BANK_TYPE ((uchar)7)
 
 FD_PROTOTYPES_BEGIN
 

--- a/src/flamenco/runtime/program/fd_bpf_loader_serialization.h
+++ b/src/flamenco/runtime/program/fd_bpf_loader_serialization.h
@@ -2,8 +2,6 @@
 #define HEADER_fd_src_flamenco_runtime_program_fd_bpf_loader_serialization_h
 
 #include "../../fd_flamenco_base.h"
-#include "../fd_executor.h"
-#include "../fd_runtime.h"
 
 #define MAX_PERMITTED_DATA_INCREASE (10 * 1024)
 

--- a/src/flamenco/runtime/program/fd_bpf_loader_v1_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v1_program.c
@@ -1,5 +1,5 @@
 #include "fd_bpf_loader_v1_program.h"
-#include "../context/fd_exec_txn_ctx.h"
+#include "../fd_executor.h"
 
 int
 fd_bpf_loader_v1_program_execute( fd_exec_instr_ctx_t ctx ) {

--- a/src/flamenco/runtime/program/fd_bpf_loader_v1_program.h
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v1_program.h
@@ -8,8 +8,7 @@
    Address: BPFLoader1111111111111111111111111111111111 */
 
 #include "../../fd_flamenco_base.h"
-#include "../fd_executor.h"
-#include "../fd_runtime.h"
+#include "../context/fd_exec_instr_ctx.h"
 
 FD_PROTOTYPES_BEGIN
 

--- a/src/flamenco/runtime/program/fd_bpf_loader_v2_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v2_program.c
@@ -1,15 +1,13 @@
 #include "fd_bpf_loader_v2_program.h"
 
 #include "../fd_account.h"
-#include "../../../ballet/base58/fd_base58.h"
+#include "../fd_executor.h"
 #include "../sysvar/fd_sysvar_rent.h"
 #include "../../../ballet/sbpf/fd_sbpf_loader.h"
 #include "../../vm/fd_vm_syscalls.h"
 #include "../../vm/fd_vm_interp.h"
 #include "../../vm/fd_vm_disasm.h"
 #include "fd_bpf_loader_serialization.h"
-#include "../context/fd_exec_txn_ctx.h"
-#include "../context/fd_exec_instr_ctx.h"
 
 #include <stdio.h>
 

--- a/src/flamenco/runtime/program/fd_bpf_loader_v2_program.h
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v2_program.h
@@ -10,8 +10,7 @@
    Address: BPFLoader2111111111111111111111111111111111 */
 
 #include "../../fd_flamenco_base.h"
-#include "../fd_executor.h"
-#include "../fd_runtime.h"
+#include "../context/fd_exec_instr_ctx.h"
 
 FD_PROTOTYPES_BEGIN
 

--- a/src/flamenco/runtime/program/fd_bpf_program_util.h
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.h
@@ -1,10 +1,9 @@
 #ifndef HEADER_fd_src_flamenco_runtime_program_fd_bpf_program_util_h
 #define HEADER_fd_src_flamenco_runtime_program_fd_bpf_program_util_h
 
-#include "../../../ballet/sbpf/fd_sbpf_loader.h"
 #include "../../fd_flamenco_base.h"
-#include "../fd_executor.h"
-#include "../fd_runtime.h"
+#include "../../../ballet/sbpf/fd_sbpf_loader.h"
+#include "../../../funk/fd_funk_txn.h"
 
 struct fd_sbpf_validated_program {
   ulong magic;

--- a/src/flamenco/runtime/program/fd_builtin_programs.h
+++ b/src/flamenco/runtime/program/fd_builtin_programs.h
@@ -2,8 +2,6 @@
 #define HEADER_fd_src_flamenco_runtime_program_fd_buildin_programs_h
 
 #include "../../fd_flamenco_base.h"
-#include "../fd_executor.h"
-#include "../fd_runtime.h"
 
 FD_PROTOTYPES_BEGIN
 

--- a/src/flamenco/runtime/program/fd_compute_budget_program.c
+++ b/src/flamenco/runtime/program/fd_compute_budget_program.c
@@ -1,6 +1,7 @@
 #include "fd_compute_budget_program.h"
 
 #include "../fd_system_ids.h"
+#include "../fd_executor.h"
 #include "../context/fd_exec_instr_ctx.h"
 #include "../context/fd_exec_txn_ctx.h"
 #include "../context/fd_exec_slot_ctx.h"

--- a/src/flamenco/runtime/program/fd_compute_budget_program.h
+++ b/src/flamenco/runtime/program/fd_compute_budget_program.h
@@ -2,8 +2,7 @@
 #define HEADER_fd_src_flamenco_runtime_program_fd_compute_budget_program_h
 
 #include "../../fd_flamenco_base.h"
-#include "../fd_executor.h"
-#include "../fd_runtime.h"
+#include "../context/fd_exec_instr_ctx.h"
 
 /* FIXME: put these elsewhere */
 #define FD_MIN_HEAP_FRAME_BYTES (32 * 1024)     /* Min heap size */

--- a/src/flamenco/runtime/program/fd_config_program.c
+++ b/src/flamenco/runtime/program/fd_config_program.c
@@ -2,7 +2,6 @@
 #include "../fd_account.h"
 #include "../fd_acc_mgr.h"
 #include "../fd_executor.h"
-#include "../fd_runtime.h"
 #include "../fd_system_ids.h"
 #include "../context/fd_exec_epoch_ctx.h"
 #include "../context/fd_exec_slot_ctx.h"

--- a/src/flamenco/runtime/program/fd_config_program.h
+++ b/src/flamenco/runtime/program/fd_config_program.h
@@ -9,7 +9,8 @@
 
    Address: Config1111111111111111111111111111111111111 */
 
-#include "../fd_runtime.h"
+#include "../../fd_flamenco_base.h"
+#include "../context/fd_exec_instr_ctx.h"
 
 FD_PROTOTYPES_BEGIN
 

--- a/src/flamenco/runtime/program/fd_native_cpi.c
+++ b/src/flamenco/runtime/program/fd_native_cpi.c
@@ -1,4 +1,6 @@
+#include "fd_native_cpi.h"
 #include "../fd_account.h"
+#include "../fd_executor.h"
 #include "../../vm/fd_vm_syscalls.h"
 #include "../../vm/fd_vm_interp.h"
 #include "../../../util/bits/fd_uwide.h"

--- a/src/flamenco/runtime/program/fd_native_cpi.h
+++ b/src/flamenco/runtime/program/fd_native_cpi.h
@@ -2,8 +2,8 @@
 #define HEADER_fd_src_flamenco_runtime_program_fd_native_program_cpi_h
 
 #include "../../fd_flamenco_base.h"
-#include "../fd_executor.h"
-#include "../fd_runtime.h"
+#include "../../types/fd_types.h"
+#include "../../vm/fd_vm_cpi.h"
 
 FD_PROTOTYPES_BEGIN
 

--- a/src/flamenco/runtime/program/fd_precompiles.c
+++ b/src/flamenco/runtime/program/fd_precompiles.c
@@ -1,4 +1,5 @@
 #include "./fd_precompiles.h"
+#include "../fd_executor_err.h"
 #include "../../../ballet/keccak256/fd_keccak256.h"
 #include "../../../ballet/ed25519/fd_ed25519.h"
 #include "../../../ballet/secp256k1/fd_secp256k1.h"

--- a/src/flamenco/runtime/program/fd_precompiles.c
+++ b/src/flamenco/runtime/program/fd_precompiles.c
@@ -1,4 +1,4 @@
-#include "./fd_precompiles.h"
+#include "fd_precompiles.h"
 #include "../fd_executor_err.h"
 #include "../../../ballet/keccak256/fd_keccak256.h"
 #include "../../../ballet/ed25519/fd_ed25519.h"

--- a/src/flamenco/runtime/program/fd_program_util.h
+++ b/src/flamenco/runtime/program/fd_program_util.h
@@ -2,7 +2,8 @@
 #define HEADER_fd_src_flamenco_runtime_native_program_util_h
 
 #include "../../fd_flamenco_base.h"
-#include "../fd_executor.h"
+#include "../fd_executor_err.h"
+#include "../fd_borrowed_account.h"
 
 #define FD_DEBUG_MODE 0
 

--- a/src/flamenco/runtime/program/fd_stake_program.c
+++ b/src/flamenco/runtime/program/fd_stake_program.c
@@ -5,6 +5,7 @@
 #include "../../../util/bits/fd_uwide.h"
 #include "../../../ballet/utf8/fd_utf8.h"
 #include "../fd_account.h"
+#include "../fd_executor.h"
 #include "../fd_pubkey_utils.h"
 #include "../fd_system_ids.h"
 

--- a/src/flamenco/runtime/program/fd_system_program.c
+++ b/src/flamenco/runtime/program/fd_system_program.c
@@ -1,7 +1,6 @@
 #include "../fd_executor.h"
 #include "fd_system_program.h"
 #include "../fd_acc_mgr.h"
-#include "../fd_runtime.h"
 #include "../fd_account.h"
 #include "../fd_system_ids.h"
 #include "../fd_pubkey_utils.h"

--- a/src/flamenco/runtime/program/fd_system_program.h
+++ b/src/flamenco/runtime/program/fd_system_program.h
@@ -2,7 +2,7 @@
 #define HEADER_fd_src_flamenco_runtime_program_fd_system_program_h
 
 #include "../../fd_flamenco_base.h"
-#include "../fd_executor.h"
+#include "../../types/fd_types.h"
 
 /* Custom error types */
 

--- a/src/flamenco/runtime/program/fd_vote_program.c
+++ b/src/flamenco/runtime/program/fd_vote_program.c
@@ -3,7 +3,6 @@
 #include "../../types/fd_types_yaml.h"
 #include "../fd_account.h"
 #include "../fd_executor.h"
-#include "../fd_runtime.h"
 #include "../fd_pubkey_utils.h"
 #include "../sysvar/fd_sysvar_epoch_schedule.h"
 #include "../sysvar/fd_sysvar_rent.h"

--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.c
@@ -1,7 +1,9 @@
 #include "fd_sysvar_epoch_rewards.h"
-#include "../../../flamenco/types/fd_types.h"
 #include "fd_sysvar.h"
+#include "../fd_acc_mgr.h"
+#include "../fd_borrowed_account.h"
 #include "../fd_system_ids.h"
+#include "../context/fd_exec_slot_ctx.h"
 
 // THIS IS ALL WRONG... the partitioned epoch rewards code paths have not been finalized with agave
 // so these changes are here to support getting the fuzz tests to pass and not actual ledger correctness.
@@ -27,9 +29,9 @@ fd_sysvar_epoch_rewards_burn_and_purge(
 
 static void
 write_epoch_rewards( fd_exec_slot_ctx_t * slot_ctx, fd_sysvar_epoch_rewards_t * epoch_rewards, fd_acc_lamports_t acc_lamports) {
-  ulong          sz = fd_sysvar_epoch_rewards_size( epoch_rewards );
-  unsigned char *enc = fd_alloca( 1, sz );
-  memset( enc, 0, sz );
+  ulong sz = fd_sysvar_epoch_rewards_size( epoch_rewards );
+  uchar enc[sz];
+  fd_memset( enc, 0, sz );
   fd_bincode_encode_ctx_t ctx;
   ctx.data = enc;
   ctx.dataend = enc + sz;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.h
@@ -2,8 +2,7 @@
 #define HEADER_fd_src_flamenco_runtime_sysvar_epoch_rewards_h
 
 #include "../../fd_flamenco_base.h"
-#include "../fd_executor.h"
-#include "../context/fd_exec_slot_ctx.h"
+#include "../../types/fd_types.h"
 
 FD_PROTOTYPES_BEGIN
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_fees.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_fees.h
@@ -1,7 +1,8 @@
 #ifndef HEADER_fd_src_flamenco_runtime_fd_sysvar_fees_h
 #define HEADER_fd_src_flamenco_runtime_fd_sysvar_fees_h
 
-#include "../fd_executor.h"
+#include "../../fd_flamenco_base.h"
+#include "../../types/fd_types.h"
 
 /* The fees sysvar contains the fee calculator for the current slot. */
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_instructions.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_instructions.c
@@ -1,7 +1,5 @@
 #include "fd_sysvar_instructions.h"
-#include "../fd_acc_mgr.h"
 #include "../fd_account.h"
-#include "../fd_runtime.h"
 #include "../fd_system_ids.h"
 
 static ulong

--- a/src/flamenco/runtime/sysvar/fd_sysvar_instructions.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_instructions.h
@@ -2,8 +2,7 @@
 #define HEADER_fd_src_flamenco_runtime_sysvar_instructions_h
 
 #include "../../fd_flamenco_base.h"
-#include "../fd_executor.h"
-#include "../fd_runtime.h"
+#include "../../types/fd_types.h"
 #include "../info/fd_instr_info.h"
 
 FD_PROTOTYPES_BEGIN

--- a/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.h
@@ -1,7 +1,8 @@
 #ifndef HEADER_fd_src_flamenco_runtime_fd_sysvar_last_restart_slot_h
 #define HEADER_fd_src_flamenco_runtime_fd_sysvar_last_restart_slot_h
 
-#include "../fd_executor.h"
+#include "../../fd_flamenco_base.h"
+#include "../../types/fd_types.h"
 
 FD_PROTOTYPES_BEGIN
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
@@ -1,7 +1,9 @@
 #include "fd_sysvar_slot_hashes.h"
-#include "../../../flamenco/types/fd_types.h"
 #include "fd_sysvar.h"
+#include "../fd_acc_mgr.h"
+#include "../fd_borrowed_account.h"
 #include "../fd_system_ids.h"
+#include "../context/fd_exec_slot_ctx.h"
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/slot_hashes.rs#L11 */
 const ulong slot_hashes_max_entries = 512;
@@ -13,8 +15,8 @@ void write_slot_hashes( fd_exec_slot_ctx_t * slot_ctx, fd_slot_hashes_t* slot_ha
   ulong sz = fd_slot_hashes_size( slot_hashes );
   if (sz < slot_hashes_min_account_size)
     sz = slot_hashes_min_account_size;
-  unsigned char *enc = fd_alloca( 1, sz );
-  memset( enc, 0, sz );
+  uchar enc[sz];
+  fd_memset( enc, 0, sz );
   fd_bincode_encode_ctx_t ctx;
   ctx.data = enc;
   ctx.dataend = enc + sz;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.h
@@ -2,8 +2,7 @@
 #define HEADER_fd_src_flamenco_runtime_sysvar_fd_slot_hashes_h
 
 #include "../../fd_flamenco_base.h"
-#include "../fd_executor.h"
-#include "../context/fd_exec_slot_ctx.h"
+#include "../../types/fd_types.h"
 
 /* The slot hashes sysvar contains the most recent hashes of the slot's parent bank hashes. */
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
@@ -1,10 +1,9 @@
 #include "fd_sysvar_slot_history.h"
-#include "../../types/fd_types.h"
 #include "fd_sysvar.h"
 #include "fd_sysvar_rent.h"
+#include "../fd_executor_err.h"
 #include "../fd_system_ids.h"
 #include "../context/fd_exec_epoch_ctx.h"
-#include "../context/fd_exec_slot_ctx.h"
 
 const ulong slot_history_min_account_size = 131097;
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.h
@@ -2,7 +2,7 @@
 #define HEADER_fd_src_flamenco_runtime_sysvar_fd_slot_history_h
 
 #include "../../fd_flamenco_base.h"
-#include "../fd_executor.h"
+#include "../../types/fd_types.h"
 
 /* The slot history sysvar contains a bit-vector indicating which slots have been processed in the current epoch. */
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.h
@@ -2,7 +2,7 @@
 #define HEADER_fd_src_flamenco_runtime_fd_sysvar_stake_history_h
 
 #include "../../fd_flamenco_base.h"
-#include "../fd_executor.h"
+#include "../../types/fd_types.h"
 
 /* FD_SYSVAR_STAKE_HISTORY_CAP is the max number of entries that the
    "stake history" sysvar will include.

--- a/src/flamenco/snapshot/fd_snapshot.c
+++ b/src/flamenco/snapshot/fd_snapshot.c
@@ -3,7 +3,7 @@
 #include "fd_snapshot_restore.h"
 #include "../runtime/fd_acc_mgr.h"
 #include "../runtime/fd_hashes.h"
-#include "../runtime/fd_runtime.h"
+#include "../runtime/fd_runtime_init.h"
 #include "../runtime/fd_system_ids.h"
 #include "../runtime/context/fd_exec_epoch_ctx.h"
 #include "../runtime/context/fd_exec_slot_ctx.h"

--- a/src/flamenco/vm/fd_vm_syscalls.c
+++ b/src/flamenco/vm/fd_vm_syscalls.c
@@ -12,6 +12,7 @@
 #include "../runtime/sysvar/fd_sysvar_epoch_schedule.h"
 #include "../runtime/sysvar/fd_sysvar_fees.h"
 #include "../runtime/fd_account.h"
+#include "../runtime/fd_executor.h"
 #include "../runtime/context/fd_exec_txn_ctx.h"
 #include "../runtime/context/fd_exec_instr_ctx.h"
 #include "../../ballet/ed25519/fd_curve25519.h"


### PR DESCRIPTION
- **runtime: split parts of fd_runtime.c into fd_runtime_init.c**
- **runtime: split executor error codes into fd_executor_err.h**
- **runtime: Optimize imports**
