### PR TITLE
fddev/dump: new features for fddev dump

### DIFF
--- a/src/app/fdctl/fdctl.h
+++ b/src/app/fdctl/fdctl.h
@@ -65,7 +65,7 @@ typedef union {
   } txn;
 
   struct {
-    char link_name[ 13UL ];
+    char link_name[ 64UL ];
     char pcap_path[ 256UL ];
   } dump;
 


### PR DESCRIPTION
- Properly dump links that are not a tile's primary out
- Allow a few comma separated link names on command line
- Print number of frags dumped from each link