### PR TITLE
config: fix clang ordering bug

### DIFF
--- a/config/extra/with-brutality.mk
+++ b/config/extra/with-brutality.mk
@@ -10,6 +10,8 @@ CPPFLAGS+=            \
 
 ifdef FD_USING_CLANG
 CPPFLAGS+=-Wimplicit-fallthrough
+# See with-clang.mk
+CPPFLAGS+=-Wno-address-of-packed-member -Wno-unused-command-line-argument -Wno-bitwise-instead-of-logical
 endif
 
 ifdef FD_USING_GCC

--- a/config/extra/with-clang.mk
+++ b/config/extra/with-clang.mk
@@ -30,7 +30,7 @@ LD:=clang++
 # there wasn't some subtle inconsistency created between them in the
 # process).
 
-CPPFLAGS+=-DFD_USING_CLANG=1 -Wno-address-of-packed-member -Wno-unused-command-line-argument -Wno-bitwise-instead-of-logical
+CPPFLAGS+=-DFD_USING_CLANG=1
 
 # Sigh ... clang doesn't understand some important command line
 # arguments (a couple of the more esoteric warnings in the brutality,
@@ -40,7 +40,3 @@ CPPFLAGS+=-DFD_USING_CLANG=1 -Wno-address-of-packed-member -Wno-unused-command-l
 # itself doesn't matter ... only that the variable is defined).
 
 FD_USING_CLANG:=1
-
-# Don't attempt to transform vsprtps into vrsqrtps (not IEEE-compliant)
-
-CPPFLAGS+=-Xclang -target-feature -Xclang +fast-vector-fsqrt

--- a/config/extra/with-x86-64.mk
+++ b/config/extra/with-x86-64.mk
@@ -4,6 +4,11 @@ ifdef FD_USING_GCC
 CPPFLAGS+=-mbranch-cost=5 -falign-jumps=32 -falign-labels=32 -falign-loops=32
 endif
 
+# Don't attempt to transform vsprtps into vrsqrtps (not IEEE-compliant)
+ifdef FD_USING_CLANG
+CPPFLAGS+=-Xclang -target-feature -Xclang +fast-vector-fsqrt
+endif
+
 # -falign-functions since Clang/LLVM 7
 # -falign-loops     since Clang/LLVM 13
 


### PR DESCRIPTION
Fixes a bug where Clang specific diagnostic flags are overwritten
by '-Wall'.
