### PR TITLE
config: only link librt on hosted builds

### DIFF
--- a/config/base.mk
+++ b/config/base.mk
@@ -8,7 +8,7 @@ CFLAGS:=-std=c17
 CXX:=g++
 CXXFLAGS:=-std=c++17
 LD:=g++
-LDFLAGS:=-lm -lrt -ldl -L./opt/lib
+LDFLAGS:=-lm -ldl -L./opt/lib
 AR:=ar
 ARFLAGS:=rv
 RANLIB:=ranlib

--- a/config/extra/with-hosted.mk
+++ b/config/extra/with-hosted.mk
@@ -1,5 +1,5 @@
 CPPFLAGS+=-D_XOPEN_SOURCE=700 -DFD_HAS_HOSTED=1
-LDFLAGS+=-z noexecstack
+LDFLAGS+=-z noexecstack -lrt
 
 FD_HAS_HOSTED:=1
 

--- a/config/machine/macos_clang_m1.mk
+++ b/config/machine/macos_clang_m1.mk
@@ -3,7 +3,6 @@ BUILDDIR:=macos/clang/m1
 include config/base.mk
 include config/extra/with-clang.mk
 include config/extra/with-debug.mk
-include config/extra/with-brutality.mk
 include config/extra/with-optimization.mk
 
 # brew install llvm
@@ -14,7 +13,7 @@ include config/extra/with-optimization.mk
 CPPFLAGS+=-DFD_HAS_INT128=1 -DFD_HAS_DOUBLE=1 -DFD_HAS_ALLOCA=1
 
 # Remove this when we support FD_HAS_HOSTED for macOS
-CPPFLAGS+=-D_XOPEN_SOURCE=700 -DFD_ENV_STYLE=0 -DFD_IO_STYLE=0 -DFD_LOG_STYLE=0
+CPPFLAGS+=-DFD_ENV_STYLE=0 -DFD_IO_STYLE=0 -DFD_LOG_STYLE=0
 
 # Remove this when we support FD_HAS_THREADS for macOS
 CPPFLAGS+=-DFD_HAS_ATOMIC=1


### PR DESCRIPTION
librt provides shm, mq, timer, aio utils which are only available
on hosted targets.  To improve portability, remove them from the
base build configuration.
