### PR TITLE
capture: add a stub implementation of fd_solcap_writer_t

### DIFF
--- a/src/flamenco/capture/Local.mk
+++ b/src/flamenco/capture/Local.mk
@@ -1,10 +1,12 @@
 $(call add-hdrs,fd_solcap_proto.h fd_solcap_writer.h fd_solcap_reader.h)
-ifdef FD_HAS_HOSTED
 ifdef FD_HAS_INT128
+ifdef FD_HAS_HOSTED
 $(call add-objs,fd_solcap_writer fd_solcap_reader fd_solcap.pb,fd_flamenco)
 $(call make-bin,fd_solcap_diff,fd_solcap_diff,fd_flamenco fd_ballet fd_util)
 $(call make-bin,fd_solcap_import,fd_solcap_import,fd_flamenco fd_cjson fd_ballet fd_util)
 $(call make-bin,fd_solcap_yaml,fd_solcap_yaml,fd_flamenco fd_ballet fd_util)
 $(call make-bin,fd_solcap_dump,fd_solcap_dump,fd_flamenco fd_ballet fd_util)
+else
+$(call add-objs,fd_solcap_writer_stub,fd_flamenco)
 endif
 endif

--- a/src/flamenco/capture/fd_solcap_writer.h
+++ b/src/flamenco/capture/fd_solcap_writer.h
@@ -5,8 +5,6 @@
 #include "fd_solcap.pb.h"
 #include "../types/fd_types.h"
 
-#if FD_HAS_HOSTED
-
 /* fd_solcap_writer_t is an opaque handle to a capture writer object.
    Currently, it implements writing SOLCAP_V1_BANK files.  See below
    on how to create and use this class. */
@@ -134,9 +132,5 @@ fd_solcap_write_bank_preimage2( fd_solcap_writer_t *     writer,
 int
 fd_solcap_write_transaction2( fd_solcap_writer_t *    writer,
                               fd_solcap_Transaction * txn );
-
-FD_PROTOTYPES_END
-
-#endif /* FD_HAS_HOSTED */
 
 #endif /* HEADER_fd_src_flamenco_capture_fd_solcap_writer_h */

--- a/src/flamenco/capture/fd_solcap_writer_stub.c
+++ b/src/flamenco/capture/fd_solcap_writer_stub.c
@@ -1,0 +1,84 @@
+#include "fd_solcap_writer.h"
+
+/* This file provides a stub implementation of fd_solcap_writer for
+   non-hosted targets. */
+
+struct fd_solcap_writer {
+  uchar dummy;
+};
+
+ulong
+fd_solcap_writer_align( void ) {
+  return alignof(fd_solcap_writer_t);
+}
+
+ulong
+fd_solcap_writer_footprint( void ) {
+  return sizeof(fd_solcap_writer_t);
+}
+
+fd_solcap_writer_t *
+fd_solcap_writer_new( void * mem ) {
+  return mem;
+}
+
+void *
+fd_solcap_writer_delete( fd_solcap_writer_t * mem ) {
+  return mem;
+}
+
+fd_solcap_writer_t *
+fd_solcap_writer_init( fd_solcap_writer_t * writer,
+                       void *               stream FD_PARAM_UNUSED ) {
+  return writer;
+}
+
+fd_solcap_writer_t *
+fd_solcap_writer_flush( fd_solcap_writer_t * writer ) {
+  return writer;
+}
+
+void
+fd_solcap_writer_set_slot( fd_solcap_writer_t * writer FD_PARAM_UNUSED,
+                           ulong                slot   FD_PARAM_UNUSED ) {} 
+
+int
+fd_solcap_write_account( fd_solcap_writer_t *             writer  FD_PARAM_UNUSED,
+                         void const *                     key     FD_PARAM_UNUSED,
+                         fd_solana_account_meta_t const * meta    FD_PARAM_UNUSED,
+                         void const *                     data    FD_PARAM_UNUSED,
+                         ulong                            data_sz FD_PARAM_UNUSED,
+                         void const *                     hash    FD_PARAM_UNUSED ) {
+  return 0;
+}
+
+int
+fd_solcap_write_account2( fd_solcap_writer_t *             writer  FD_PARAM_UNUSED,
+                          fd_solcap_account_tbl_t const *  tbl     FD_PARAM_UNUSED,
+                          fd_solcap_AccountMeta *          meta_pb FD_PARAM_UNUSED,
+                          void const *                     data    FD_PARAM_UNUSED,
+                          ulong                            data_sz FD_PARAM_UNUSED ) {
+  return 0;
+}
+
+int
+fd_solcap_write_bank_preimage( fd_solcap_writer_t * writer             FD_PARAM_UNUSED,
+                               void const *         bank_hash          FD_PARAM_UNUSED,
+                               void const *         prev_bank_hash     FD_PARAM_UNUSED,
+                               void const *         account_delta_hash FD_PARAM_UNUSED,
+                               void const *         poh_hash           FD_PARAM_UNUSED,
+                               ulong                signature_cnt      FD_PARAM_UNUSED ) {
+  return 0;
+}
+
+int
+fd_solcap_write_bank_preimage2( fd_solcap_writer_t *     writer FD_PARAM_UNUSED,
+                                fd_solcap_BankPreimage * preimg FD_PARAM_UNUSED ) {
+  return 0;
+}
+
+int
+fd_solcap_write_transaction2( fd_solcap_writer_t *    writer FD_PARAM_UNUSED,
+                              fd_solcap_Transaction * txn    FD_PARAM_UNUSED ) {
+  return 0;
+}


### PR DESCRIPTION
Allows executing Solana transactions on non-hosted targets.
