### PR TITLE
Add missing FD_HAS_HOSTED checks

### DIFF
--- a/src/app/fddev/rpc_client/Local.mk
+++ b/src/app/fddev/rpc_client/Local.mk
@@ -1,5 +1,7 @@
+ifdef FD_HAS_HOSTED
 $(call add-hdrs,fd_rpc_client.h)
 $(call add-objs,fd_rpc_client,fd_fddev)
 $(call make-unit-test,test_rpc_client,test_rpc_client,fd_fddev fd_util fd_ballet)
 $(call make-unit-test,dump_rpc_client,dump_rpc_client,fd_fddev fd_util fd_ballet)
 $(call run-unit-test,test_rpc_client,)
+endif

--- a/src/ballet/pack/Local.mk
+++ b/src/ballet/pack/Local.mk
@@ -3,13 +3,13 @@ $(call add-hdrs,fd_pack.h fd_est_tbl.h fd_compute_budget_program.h fd_microblock
 $(call add-objs,fd_pack,fd_ballet)
 $(call make-unit-test,test_compute_budget_program,test_compute_budget_program,fd_ballet fd_util)
 $(call make-unit-test,test_est_tbl,test_est_tbl,fd_ballet fd_util)
-$(call make-unit-test,test_pack,test_pack,fd_disco fd_ballet fd_util)
 $(call make-unit-test,test_pack_bitset,test_pack_bitset,fd_ballet fd_util)
 $(call run-unit-test,test_compute_budget_program,)
 $(call run-unit-test,test_est_tbl,)
-$(call run-unit-test,test_pack,)
 $(call run-unit-test,test_pack_bitset,)
 ifdef FD_HAS_HOSTED
 $(call make-fuzz-test,fuzz_compute_budget_program_parse,fuzz_compute_budget_program_parse,fd_ballet fd_util)
+$(call make-unit-test,test_pack,test_pack,fd_disco fd_ballet fd_util)
+$(call run-unit-test,test_pack,)
 endif
 endif

--- a/src/choreo/ghost/Local.mk
+++ b/src/choreo/ghost/Local.mk
@@ -1,5 +1,7 @@
 ifdef FD_HAS_INT128
 $(call add-hdrs,fd_ghost.h)
 $(call add-objs,fd_ghost,fd_choreo)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_ghost,test_ghost,fd_choreo fd_flamenco fd_ballet fd_util)
+endif
 endif

--- a/src/choreo/tower/fd_tower.c
+++ b/src/choreo/tower/fd_tower.c
@@ -129,14 +129,18 @@ fd_tower_fork_update( fd_tower_t * tower, fd_fork_t * fork ) {
     if( FD_UNLIKELY( rc != FD_ACC_MGR_SUCCESS ) ) {
       FD_LOG_WARNING(
           ( "fd_acc_mgr_view failed on vote account %32J. error: %d", vote_account_address, rc ) );
+#     if defined(__x86_64__)
       __asm__( "int $3" );
+#     endif
     }
 
     rc = fd_vote_get_state( vote_account, valloc, &vote_state_versioned );
     if( FD_UNLIKELY( rc != FD_ACC_MGR_SUCCESS ) ) {
       FD_LOG_WARNING( (
           "fd_vote_get_state failed on vote account %32J. error: %d", vote_account_address, rc ) );
+#     if defined(__x86_64__)
       __asm__( "int $3" );
+#     endif
     }
 
     fd_vote_convert_to_current( &vote_state_versioned, valloc );

--- a/src/choreo/voter/Local.mk
+++ b/src/choreo/voter/Local.mk
@@ -1,5 +1,7 @@
 ifdef FD_HAS_INT128
 $(call add-hdrs,fd_voter.h)
 $(call add-objs,fd_voter,fd_choreo)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_choreo_voter,test_choreo_voter,fd_disco fd_choreo fd_flamenco fd_funk fd_tango fd_util fd_ballet fd_reedsol fd_waltz,$(SECP256K1_LIBS))
+endif
 endif

--- a/src/disco/bank/Local.mk
+++ b/src/disco/bank/Local.mk
@@ -1,7 +1,9 @@
 ifdef FD_HAS_ATOMIC
 $(call add-hdrs,fd_bank_abi.h fd_txncache.h fd_rwlock.h)
 $(call add-objs,fd_bank_abi fd_txncache,fd_disco)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_txncache,test_txncache,fd_disco fd_util)
 # TODO: Reenable after fixing purge reprobing bug
 # $(call run-unit-test,test_txncache,)
+endif
 endif

--- a/src/disco/shred/Local.mk
+++ b/src/disco/shred/Local.mk
@@ -5,11 +5,13 @@ $(call add-objs,fd_shred_cap,fd_disco,fd_flamenco)
 $(call add-objs,fd_fec_resolver,fd_disco)
 $(call add-objs,fd_stake_ci,fd_disco)
 $(call make-unit-test,test_shred_dest,test_shred_dest,fd_disco fd_flamenco fd_ballet fd_util)
-$(call make-unit-test,test_shredder,test_shredder,fd_disco fd_flamenco fd_ballet fd_util fd_reedsol)
 $(call make-unit-test,test_fec_resolver,test_fec_resolver,fd_flamenco fd_disco fd_ballet fd_util fd_tango fd_reedsol)
 $(call make-unit-test,test_stake_ci,test_stake_ci,fd_disco fd_flamenco fd_ballet fd_util fd_tango fd_reedsol)
 $(call run-unit-test,test_shred_dest,)
-$(call run-unit-test,test_shredder,)
 $(call run-unit-test,test_fec_resolver,)
 $(call run-unit-test,test_stake_ci,)
+ifdef FD_HAS_HOSTED
+$(call make-unit-test,test_shredder,test_shredder,fd_disco fd_flamenco fd_ballet fd_util fd_reedsol)
+$(call run-unit-test,test_shredder,)
+endif
 endif

--- a/src/disco/tvu/Local.mk
+++ b/src/disco/tvu/Local.mk
@@ -1,4 +1,6 @@
+ifdef FD_HAS_HOSTED
 ifdef FD_HAS_INT128
 $(call add-hdrs,fd_replay.h fd_tvu.h fd_store.h fd_pending_slots.h)
 $(call add-objs,fd_replay fd_tvu fd_store fd_pending_slots,fd_disco)
+endif
 endif

--- a/src/flamenco/genesis/Local.mk
+++ b/src/flamenco/genesis/Local.mk
@@ -1,6 +1,8 @@
 ifdef FD_HAS_INT128
 $(call add-hdrs,fd_genesis_create.h)
 $(call add-objs,fd_genesis_create,fd_flamenco)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_genesis_create,test_genesis_create,fd_flamenco fd_funk fd_ballet fd_util)
 $(call run-unit-test,test_genesis_create)
+endif
 endif

--- a/src/flamenco/gossip/Local.mk
+++ b/src/flamenco/gossip/Local.mk
@@ -1,5 +1,7 @@
+ifdef FD_HAS_HOSTED
 ifdef FD_HAS_INT128
 $(call add-hdrs,fd_gossip.h)
 $(call add-objs,fd_gossip,fd_flamenco)
 $(call make-bin,fd_gossip_spy,fd_gossip_spy,fd_flamenco fd_ballet fd_funk fd_util)
+endif
 endif

--- a/src/flamenco/repair/Local.mk
+++ b/src/flamenco/repair/Local.mk
@@ -1,5 +1,7 @@
 ifdef FD_HAS_INT128
 $(call add-hdrs,fd_repair.h)
 $(call add-objs,fd_repair,fd_flamenco)
+ifdef FD_HAS_HOSTED
 $(call make-bin,fd_repair_tool,fd_repair_tool,fd_flamenco fd_ballet fd_funk fd_util)
+endif
 endif

--- a/src/flamenco/runtime/sysvar/Local.mk
+++ b/src/flamenco/runtime/sysvar/Local.mk
@@ -13,8 +13,10 @@ $(call add-objs,fd_sysvar_epoch_rewards,fd_flamenco)
 
 $(call add-hdrs,fd_sysvar_epoch_schedule.h)
 $(call add-objs,fd_sysvar_epoch_schedule,fd_flamenco)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_sysvar_epoch_schedule,test_sysvar_epoch_schedule,fd_flamenco fd_funk fd_ballet fd_util)
 $(call run-unit-test,test_sysvar_epoch_schedule)
+endif
 
 $(call add-hdrs,fd_sysvar_fees.h)
 $(call add-objs,fd_sysvar_fees,fd_flamenco)
@@ -30,8 +32,10 @@ $(call add-objs,fd_sysvar_recent_hashes,fd_flamenco)
 
 $(call add-hdrs,fd_sysvar_rent.h)
 $(call add-objs,fd_sysvar_rent,fd_flamenco)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_sysvar_rent,test_sysvar_rent,fd_flamenco fd_funk fd_ballet fd_util)
 $(call run-unit-test,test_sysvar_rent)
+endif
 
 $(call add-hdrs,fd_sysvar_slot_hashes.h)
 $(call add-objs,fd_sysvar_slot_hashes,fd_flamenco)

--- a/src/flamenco/snapshot/Local.mk
+++ b/src/flamenco/snapshot/Local.mk
@@ -1,9 +1,9 @@
 ifdef FD_HAS_INT128
+ifdef FD_HAS_HOSTED
 $(call add-hdrs,fd_snapshot_http.h)
 $(call add-objs,fd_snapshot_http,fd_flamenco)
 $(call make-unit-test,test_snapshot_http,test_snapshot_http,fd_flamenco fd_funk fd_ballet fd_util)
 $(call run-unit-test,test_snapshot_http)
-ifdef FD_HAS_HOSTED
 $(call make-fuzz-test,fuzz_snapshot_http,fuzz_snapshot_http,fd_flamenco fd_funk fd_ballet fd_util)
 endif
 
@@ -12,8 +12,10 @@ $(call add-objs,fd_snapshot_istream,fd_flamenco)
 
 $(call add-hdrs,fd_snapshot_restore.h)
 $(call add-objs,fd_snapshot_restore,fd_flamenco)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_snapshot_restore,test_snapshot_restore,fd_flamenco fd_funk fd_ballet fd_util)
 $(call run-unit-test,test_snapshot_restore)
+endif
 
 ifdef FD_HAS_ZSTD
 $(call add-hdrs,fd_snapshot.h)

--- a/src/flamenco/stakes/Local.mk
+++ b/src/flamenco/stakes/Local.mk
@@ -2,5 +2,7 @@ ifdef FD_HAS_INT128
 $(call add-hdrs,fd_stakes.h)
 $(call add-objs,fd_stakes,fd_flamenco)
 # TODO this should not depend on fd_funk
+ifdef FD_HAS_HOSTED
 $(call make-bin,fd_stakes_from_snapshot,fd_stakes_from_snapshot,fd_flamenco fd_funk fd_ballet fd_util)
+endif
 endif

--- a/src/funk/Local.mk
+++ b/src/funk/Local.mk
@@ -5,8 +5,10 @@ $(call make-unit-test,test_funk_base,test_funk_base,fd_funk fd_util)
 $(call run-unit-test,test_funk_base)
 $(call make-unit-test,test_funk_txn,test_funk_txn,fd_funk fd_util)
 $(call run-unit-test,test_funk_txn)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_funk_txn2,test_funk_txn2,fd_funk fd_util)
 $(call run-unit-test,test_funk_txn2)
+endif
 $(call make-unit-test,test_funk_rec,test_funk_rec test_funk_common,fd_funk fd_util)
 $(call run-unit-test,test_funk_rec)
 $(call make-unit-test,test_funk_val,test_funk_val test_funk_common,fd_funk fd_util)
@@ -15,4 +17,6 @@ $(call make-unit-test,test_funk_part,test_funk_part test_funk_common,fd_funk fd_
 $(call run-unit-test,test_funk_part)
 $(call make-unit-test,test_funk,test_funk,fd_funk fd_util)
 $(call run-unit-test,test_funk)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_funk_concur,test_funk_concur,fd_funk fd_util)
+endif

--- a/src/util/fibre/Local.mk
+++ b/src/util/fibre/Local.mk
@@ -1,4 +1,8 @@
+ifdef FD_HAS_HOSTED
+ifdef FD_HAS_LINUX
 $(call make-lib,fd_fibre)
 $(call add-objs,fd_fibre,fd_fibre)
 $(call make-unit-test,test_fibre,test_fibre,fd_fibre fd_util)
 $(call run-unit-test,test_fibre)
+endif
+endif

--- a/src/waltz/udpsock/Local.mk
+++ b/src/waltz/udpsock/Local.mk
@@ -1,3 +1,5 @@
+ifdef FD_HAS_HOSTED
 $(call add-hdrs,fd_udpsock.h)
 $(call add-objs,fd_udpsock,fd_waltz)
 $(call make-unit-test,test_udpsock_echo,test_udpsock_echo,fd_waltz fd_util)
+endif


### PR DESCRIPTION
We have lots of code that assumes a hosted environment (i.e.
workspaces, file system, etc.).  This code shouldn't try to compile
on non-hosted targets.
