### PR TITLE
shmem: always compile cstr utils

### DIFF
--- a/src/util/shmem/fd_shmem_admin.c
+++ b/src/util/shmem/fd_shmem_admin.c
@@ -4,6 +4,62 @@
 
 #include "fd_shmem_private.h"
 
+/* Portable APIs */
+
+int
+fd_cstr_to_shmem_lg_page_sz( char const * cstr ) {
+  if( !cstr ) return FD_SHMEM_UNKNOWN_LG_PAGE_SZ;
+
+  if( !fd_cstr_casecmp( cstr, "normal"   ) ) return FD_SHMEM_NORMAL_LG_PAGE_SZ;
+  if( !fd_cstr_casecmp( cstr, "huge"     ) ) return FD_SHMEM_HUGE_LG_PAGE_SZ;
+  if( !fd_cstr_casecmp( cstr, "gigantic" ) ) return FD_SHMEM_GIGANTIC_LG_PAGE_SZ;
+
+  int i = fd_cstr_to_int( cstr );
+  if( i==FD_SHMEM_NORMAL_LG_PAGE_SZ   ) return FD_SHMEM_NORMAL_LG_PAGE_SZ;
+  if( i==FD_SHMEM_HUGE_LG_PAGE_SZ     ) return FD_SHMEM_HUGE_LG_PAGE_SZ;
+  if( i==FD_SHMEM_GIGANTIC_LG_PAGE_SZ ) return FD_SHMEM_GIGANTIC_LG_PAGE_SZ;
+
+  return FD_SHMEM_UNKNOWN_LG_PAGE_SZ;
+}
+
+char const *
+fd_shmem_lg_page_sz_to_cstr( int lg_page_sz ) {
+  switch( lg_page_sz ) {
+  case FD_SHMEM_NORMAL_LG_PAGE_SZ:   return "normal";
+  case FD_SHMEM_HUGE_LG_PAGE_SZ:     return "huge";
+  case FD_SHMEM_GIGANTIC_LG_PAGE_SZ: return "gigantic";
+  default:                           break;
+  }
+  return "unknown";
+}
+
+ulong
+fd_cstr_to_shmem_page_sz( char const * cstr ) {
+  if( !cstr ) return FD_SHMEM_UNKNOWN_PAGE_SZ;
+
+  if( !fd_cstr_casecmp( cstr, "normal"   ) ) return FD_SHMEM_NORMAL_PAGE_SZ;
+  if( !fd_cstr_casecmp( cstr, "huge"     ) ) return FD_SHMEM_HUGE_PAGE_SZ;
+  if( !fd_cstr_casecmp( cstr, "gigantic" ) ) return FD_SHMEM_GIGANTIC_PAGE_SZ;
+
+  ulong u = fd_cstr_to_ulong( cstr );
+  if( u==FD_SHMEM_NORMAL_PAGE_SZ   ) return FD_SHMEM_NORMAL_PAGE_SZ;
+  if( u==FD_SHMEM_HUGE_PAGE_SZ     ) return FD_SHMEM_HUGE_PAGE_SZ;
+  if( u==FD_SHMEM_GIGANTIC_PAGE_SZ ) return FD_SHMEM_GIGANTIC_PAGE_SZ;
+
+  return FD_SHMEM_UNKNOWN_PAGE_SZ;
+}
+
+char const *
+fd_shmem_page_sz_to_cstr( ulong page_sz ) {
+  switch( page_sz ) {
+  case FD_SHMEM_NORMAL_PAGE_SZ:   return "normal";
+  case FD_SHMEM_HUGE_PAGE_SZ:     return "huge";
+  case FD_SHMEM_GIGANTIC_PAGE_SZ: return "gigantic";
+  default:                        break;
+  }
+  return "unknown";
+}
+
 #if FD_HAS_HOSTED
 
 #include <ctype.h>
@@ -617,60 +673,6 @@ fd_shmem_name_len( char const * name ) {
   if( FD_UNLIKELY( !len                   ) ) return 0UL; /* Name too short (empty string) */
   if( FD_UNLIKELY( len>=FD_SHMEM_NAME_MAX ) ) return 0UL; /* Name too long */
   return len;
-}
-
-int
-fd_cstr_to_shmem_lg_page_sz( char const * cstr ) {
-  if( !cstr ) return FD_SHMEM_UNKNOWN_LG_PAGE_SZ;
-
-  if( !fd_cstr_casecmp( cstr, "normal"   ) ) return FD_SHMEM_NORMAL_LG_PAGE_SZ;
-  if( !fd_cstr_casecmp( cstr, "huge"     ) ) return FD_SHMEM_HUGE_LG_PAGE_SZ;
-  if( !fd_cstr_casecmp( cstr, "gigantic" ) ) return FD_SHMEM_GIGANTIC_LG_PAGE_SZ;
-
-  int i = fd_cstr_to_int( cstr );
-  if( i==FD_SHMEM_NORMAL_LG_PAGE_SZ   ) return FD_SHMEM_NORMAL_LG_PAGE_SZ;
-  if( i==FD_SHMEM_HUGE_LG_PAGE_SZ     ) return FD_SHMEM_HUGE_LG_PAGE_SZ;
-  if( i==FD_SHMEM_GIGANTIC_LG_PAGE_SZ ) return FD_SHMEM_GIGANTIC_LG_PAGE_SZ;
-
-  return FD_SHMEM_UNKNOWN_LG_PAGE_SZ;
-}
-
-char const *
-fd_shmem_lg_page_sz_to_cstr( int lg_page_sz ) {
-  switch( lg_page_sz ) {
-  case FD_SHMEM_NORMAL_LG_PAGE_SZ:   return "normal";
-  case FD_SHMEM_HUGE_LG_PAGE_SZ:     return "huge";
-  case FD_SHMEM_GIGANTIC_LG_PAGE_SZ: return "gigantic";
-  default:                           break;
-  }
-  return "unknown";
-}
-
-ulong
-fd_cstr_to_shmem_page_sz( char const * cstr ) {
-  if( !cstr ) return FD_SHMEM_UNKNOWN_PAGE_SZ;
-
-  if( !fd_cstr_casecmp( cstr, "normal"   ) ) return FD_SHMEM_NORMAL_PAGE_SZ;
-  if( !fd_cstr_casecmp( cstr, "huge"     ) ) return FD_SHMEM_HUGE_PAGE_SZ;
-  if( !fd_cstr_casecmp( cstr, "gigantic" ) ) return FD_SHMEM_GIGANTIC_PAGE_SZ;
-
-  ulong u = fd_cstr_to_ulong( cstr );
-  if( u==FD_SHMEM_NORMAL_PAGE_SZ   ) return FD_SHMEM_NORMAL_PAGE_SZ;
-  if( u==FD_SHMEM_HUGE_PAGE_SZ     ) return FD_SHMEM_HUGE_PAGE_SZ;
-  if( u==FD_SHMEM_GIGANTIC_PAGE_SZ ) return FD_SHMEM_GIGANTIC_PAGE_SZ;
-
-  return FD_SHMEM_UNKNOWN_PAGE_SZ;
-}
-
-char const *
-fd_shmem_page_sz_to_cstr( ulong page_sz ) {
-  switch( page_sz ) {
-  case FD_SHMEM_NORMAL_PAGE_SZ:   return "normal";
-  case FD_SHMEM_HUGE_PAGE_SZ:     return "huge";
-  case FD_SHMEM_GIGANTIC_PAGE_SZ: return "gigantic";
-  default:                        break;
-  }
-  return "unknown";
 }
 
 /* BOOT/HALT APIs *****************************************************/


### PR DESCRIPTION
Always compile shmem's cstr helpers, not just on hosted platforms.
