### PR TITLE
waltz: fd_aio build fixes

### DIFF
--- a/src/waltz/aio/Local.mk
+++ b/src/waltz/aio/Local.mk
@@ -1,4 +1,4 @@
 $(call add-hdrs,fd_aio.h fd_aio_pcapng.h)
-$(call add-objs,fd_aio fd_aio_pcapng,fd_util)
+$(call add-objs,fd_aio fd_aio_pcapng,fd_waltz)
 $(call make-unit-test,test_aio,test_aio,fd_waltz fd_util)
 $(call run-unit-test,test_aio)

--- a/src/waltz/quic/tests/Local.mk
+++ b/src/waltz/quic/tests/Local.mk
@@ -3,13 +3,13 @@ $(call add-hdrs,fd_quic_sandbox.h)
 $(call add-objs,fd_quic_stream_spam fd_quic_sandbox fd_quic_test_helpers,fd_quic)
 
 # fd_quic unit tests
-$(call make-unit-test,test_quic_hs,         test_quic_hs,         fd_quic fd_tls fd_aio fd_ballet fd_waltz fd_util)
-$(call make-unit-test,test_quic_streams,    test_quic_streams,    fd_quic fd_tls fd_aio fd_ballet fd_waltz fd_util)
-$(call make-unit-test,test_quic_conn,       test_quic_conn,       fd_quic fd_tls fd_aio fd_ballet fd_waltz fd_util)
-$(call make-unit-test,test_quic_drops,      test_quic_drops,      fd_quic fd_tls fd_aio fd_ballet fd_waltz fd_util fd_fibre)
-$(call make-unit-test,test_quic_bw,         test_quic_bw,         fd_quic fd_tls fd_aio fd_ballet fd_waltz fd_util)
+$(call make-unit-test,test_quic_hs,         test_quic_hs,         fd_quic fd_tls fd_ballet fd_waltz fd_util)
+$(call make-unit-test,test_quic_streams,    test_quic_streams,    fd_quic fd_tls fd_ballet fd_waltz fd_util)
+$(call make-unit-test,test_quic_conn,       test_quic_conn,       fd_quic fd_tls fd_ballet fd_waltz fd_util)
+$(call make-unit-test,test_quic_drops,      test_quic_drops,      fd_quic fd_tls fd_ballet fd_waltz fd_util fd_fibre)
+$(call make-unit-test,test_quic_bw,         test_quic_bw,         fd_quic fd_tls fd_ballet fd_waltz fd_util)
 $(call make-unit-test,test_quic_layout,     test_quic_layout,                                              fd_util)
-$(call make-unit-test,test_quic_conformance,test_quic_conformance,fd_quic fd_tls fd_aio fd_tango fd_ballet fd_waltz fd_util)
+$(call make-unit-test,test_quic_conformance,test_quic_conformance,fd_quic fd_tls fd_tango fd_ballet fd_waltz fd_util)
 # $(call run-unit-test,test_quic_hs)
 $(call run-unit-test,test_quic_streams)
 #$(call run-unit-test,test_quic_conn) -- broken because of fd_ip
@@ -17,7 +17,7 @@ $(call run-unit-test,test_quic_streams)
 $(call run-unit-test,test_quic_layout)
 
 # fd_quic_tls unit tests
-$(call make-unit-test,test_quic_tls_hs,test_quic_tls_hs,fd_quic fd_aio fd_tls fd_ballet fd_util)
+$(call make-unit-test,test_quic_tls_hs,test_quic_tls_hs,fd_quic fd_tls fd_ballet fd_util)
 $(call run-unit-test,test_quic_tls_hs)
 
 # fd_quic_crypto unit tests
@@ -25,20 +25,20 @@ $(call make-unit-test,test_quic_crypto,test_quic_crypto,fd_quic fd_tls fd_ballet
 $(call run-unit-test,test_quic_crypto)
 
 # Manual test programs
-$(call make-unit-test,test_quic_client_flood,test_quic_client_flood,fd_quic fd_tls fd_aio fd_ballet fd_waltz fd_util)
-$(call make-unit-test,test_quic_server,test_quic_server,            fd_quic fd_tls fd_aio fd_ballet fd_waltz fd_util)
-$(call make-unit-test,test_quic_txns,  test_quic_txns,              fd_quic fd_tls fd_aio fd_ballet fd_waltz fd_util)
+$(call make-unit-test,test_quic_client_flood,test_quic_client_flood,fd_quic fd_tls fd_ballet fd_waltz fd_util)
+$(call make-unit-test,test_quic_server,test_quic_server,            fd_quic fd_tls fd_ballet fd_waltz fd_util)
+$(call make-unit-test,test_quic_txns,  test_quic_txns,              fd_quic fd_tls fd_ballet fd_waltz fd_util)
 
 $(call make-unit-test,test_quic_frames,test_frames,fd_quic fd_util)
-# $(call make-unit-test,test_quic_flow_control,test_quic_flow_control,fd_aio fd_quic fd_ballet fd_waltz fd_util)
-$(call make-unit-test,test_quic_retry_unit,test_quic_retry_unit,fd_aio fd_quic fd_ballet fd_waltz fd_util)
-$(call make-unit-test,test_quic_retry_integration,test_quic_retry_integration,fd_aio fd_quic fd_tls fd_ballet fd_waltz fd_util)
-$(call make-unit-test,test_quic_arp_server,arp/test_quic_arp_server,fd_aio fd_quic fd_tls fd_ballet fd_waltz fd_util)
-$(call make-unit-test,test_quic_arp_client,arp/test_quic_arp_client,fd_aio fd_quic fd_tls fd_ballet fd_waltz fd_util fd_fibre)
+# $(call make-unit-test,test_quic_flow_control,test_quic_flow_control,fd_quic fd_ballet fd_waltz fd_util)
+$(call make-unit-test,test_quic_retry_unit,test_quic_retry_unit,fd_quic fd_ballet fd_waltz fd_util)
+$(call make-unit-test,test_quic_retry_integration,test_quic_retry_integration,fd_quic fd_tls fd_ballet fd_waltz fd_util)
+$(call make-unit-test,test_quic_arp_server,arp/test_quic_arp_server,fd_quic fd_tls fd_ballet fd_waltz fd_util)
+$(call make-unit-test,test_quic_arp_client,arp/test_quic_arp_client,fd_quic fd_tls fd_ballet fd_waltz fd_util fd_fibre)
 
 ifdef FD_HAS_HOSTED
-$(call make-fuzz-test,fuzz_quic,fuzz_quic,fd_aio fd_quic fd_tls fd_ballet fd_waltz fd_util)
-$(call make-fuzz-test,fuzz_quic_wire,fuzz_quic_wire,fd_aio fd_quic fd_tls fd_ballet fd_waltz fd_util)
+$(call make-fuzz-test,fuzz_quic,fuzz_quic,fd_quic fd_tls fd_ballet fd_waltz fd_util)
+$(call make-fuzz-test,fuzz_quic_wire,fuzz_quic_wire,fd_quic fd_tls fd_ballet fd_waltz fd_util)
 endif
 
 $(call run-unit-test,test_quic_frames)


### PR DESCRIPTION
- Removes mentions of non-existent fd_aio API from fd_quic build rules
- Fix typo that included fd_aio.o in fd_util instead of fd_waltz
