### PR TITLE
Low level fast parallel compressed checkpointing

### DIFF
--- a/config/extra/with-lz4.mk
+++ b/config/extra/with-lz4.mk
@@ -1,0 +1,7 @@
+ifneq (,$(wildcard /usr/include/lz4.h)) # FIXME: DEPS.SH INSTALL
+FD_HAS_LZ4:=1
+CFLAGS+=-DFD_HAS_LZ4=1
+LDFLAGS+=-llz4
+else
+$(warning "lz4 not installed, skipping")
+endif

--- a/config/extra/with-lz4.mk
+++ b/config/extra/with-lz4.mk
@@ -1,7 +1,7 @@
-ifneq (,$(wildcard /usr/include/lz4.h)) # FIXME: DEPS.SH INSTALL
+ifneq (,$(wildcard opt/lib/liblz4.a))
 FD_HAS_LZ4:=1
 CFLAGS+=-DFD_HAS_LZ4=1
-LDFLAGS+=-llz4
+LDFLAGS+=opt/lib/liblz4.a
 else
 $(warning "lz4 not installed, skipping")
 endif

--- a/config/extra/with-x86-64.mk
+++ b/config/extra/with-x86-64.mk
@@ -15,5 +15,6 @@ endif
 include config/extra/with-ucontext.mk
 include config/extra/with-secp256k1.mk
 include config/extra/with-zstd.mk
+include config/extra/with-lz4.mk
 include config/extra/with-openssl.mk
 include config/extra/with-rocksdb.mk

--- a/deps.sh
+++ b/deps.sh
@@ -101,6 +101,7 @@ fetch () {
   mkdir -pv ./opt/git
 
   checkout_repo zstd      https://github.com/facebook/zstd          "v1.5.5"
+  checkout_repo lz4       https://github.com/lz4/lz4                "v1.9.4"
   checkout_repo secp256k1 https://github.com/bitcoin-core/secp256k1 "v0.5.0"
   #checkout_repo openssl   https://github.com/openssl/openssl        "openssl-3.3.0"
   if [[ $DEVMODE == 1 ]]; then
@@ -265,6 +266,14 @@ install_zstd () {
   echo "[+] Successfully installed zstd"
 }
 
+install_lz4 () {
+  cd ./opt/git/lz4/lib
+  
+  echo "[+] Installing lz4 to $PREFIX"
+  "${MAKE[@]}" PREFIX="$PREFIX" BUILD_SHARED=no install
+  echo "[+] Successfully installed lz4"
+}
+
 install_secp256k1 () {
   cd ./opt/git/secp256k1
 
@@ -386,7 +395,6 @@ install_rocksdb () {
   ROCKSDB_DISABLE_NUMA=1 \
   ROCKSDB_DISABLE_ZLIB=1 \
   ROCKSDB_DISABLE_BZIP=1 \
-  ROCKSDB_DISABLE_LZ4=1 \
   ROCKSDB_DISABLE_GFLAGS=1 \
   PORTABLE=haswell \
   CFLAGS="-isystem $(pwd)/../../include -g0 -DSNAPPY -DZSTD" \
@@ -458,6 +466,7 @@ install () {
   mkdir -p ./opt/{include,lib}
 
   ( install_zstd      )
+  ( install_lz4       )
   ( install_secp256k1 )
   #( install_openssl   )
   if [[ $DEVMODE == 1 ]]; then

--- a/deps.sh
+++ b/deps.sh
@@ -270,7 +270,7 @@ install_lz4 () {
   cd ./opt/git/lz4/lib
   
   echo "[+] Installing lz4 to $PREFIX"
-  "${MAKE[@]}" PREFIX="$PREFIX" BUILD_SHARED=no install
+  "${MAKE[@]}" PREFIX="$PREFIX" BUILD_SHARED=no MOREFLAGS="-fPIC" install
   echo "[+] Successfully installed lz4"
 }
 

--- a/src/flamenco/snapshot/fd_snapshot_istream.h
+++ b/src/flamenco/snapshot/fd_snapshot_istream.h
@@ -57,7 +57,7 @@ FD_PROTOTYPES_END
 
 /* fd_io_istream_zstd_t implements fd_io_istream_vt_t. ****************/
 
-#ifdef FD_HAS_ZSTD
+#if FD_HAS_ZSTD
 
 struct fd_io_istream_zstd {
   fd_zstd_dstream_t * dstream;  /* borrowed for lifetime of self */

--- a/src/util/checkpt/Local.mk
+++ b/src/util/checkpt/Local.mk
@@ -1,0 +1,6 @@
+$(call add-hdrs,fd_checkpt.h)
+$(call add-objs,fd_checkpt,fd_util)
+$(call make-unit-test,test_checkpt_mmio,test_checkpt_mmio,fd_util)
+$(call make-unit-test,test_checkpt_stream,test_checkpt_stream,fd_util)
+$(call run-unit-test,test_checkpt_mmio,)
+$(call run-unit-test,test_checkpt_stream,)

--- a/src/util/checkpt/Local.mk
+++ b/src/util/checkpt/Local.mk
@@ -1,5 +1,5 @@
 $(call add-hdrs,fd_checkpt.h)
-$(call add-objs,fd_checkpt,fd_util)
+$(call add-objs,fd_checkpt fd_restore,fd_util)
 $(call make-unit-test,test_checkpt_mmio,test_checkpt_mmio,fd_util)
 $(call make-unit-test,test_checkpt_stream,test_checkpt_stream,fd_util)
 $(call run-unit-test,test_checkpt_mmio,)

--- a/src/util/checkpt/fd_checkpt.c
+++ b/src/util/checkpt/fd_checkpt.c
@@ -1,0 +1,911 @@
+#include "fd_checkpt.h"
+
+#if FD_HAS_LZ4
+#include <lz4.h>
+#endif
+
+fd_checkpt_t *
+fd_checkpt_init_stream( void * mem,
+                        int    fd,
+                        void * wbuf,
+                        ulong  wbuf_sz ) {
+
+  /* Check input args */
+
+  if( FD_UNLIKELY( !mem ) ) {
+    FD_LOG_WARNING(( "NULL mem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)mem, FD_CHECKPT_ALIGN ) ) ) {
+    FD_LOG_WARNING(( "misaligned mem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( fd<0 ) ) {
+    FD_LOG_WARNING(( "bad fd" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !wbuf ) ) {
+    FD_LOG_WARNING(( "NULL wbuf" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( wbuf_sz<FD_CHECKPT_WBUF_MIN ) ) {
+    FD_LOG_WARNING(( "wbuf_sz too small" ));
+    return NULL;
+  }
+
+  /* Create the compressor */
+
+# if FD_HAS_LZ4
+  LZ4_stream_t * lz4 = LZ4_createStream();
+  if( FD_UNLIKELY( !lz4 ) ) {
+    FD_LOG_WARNING(( "lz4 error" ));
+    return NULL;
+  }
+# else
+  void * lz4 = NULL;
+# endif
+
+  /* Init the checkpt */
+
+  fd_checkpt_t * checkpt = (fd_checkpt_t *)mem;
+
+  checkpt->fd          = fd; /* streaming mode */
+  checkpt->frame_style = 0;  /* not in frame */
+  checkpt->lz4         = lz4;
+  checkpt->off         = 0UL;
+  checkpt->wbuf.mem    = (char *)wbuf;
+  checkpt->wbuf.sz     = wbuf_sz;
+  checkpt->wbuf.used   = 0UL;
+
+  return checkpt;
+}
+
+fd_checkpt_t *
+fd_checkpt_init_mmio( void * mem,
+                      void * mmio,
+                      ulong  mmio_sz ) {
+
+  /* Check input args */
+
+  if( FD_UNLIKELY( !mem ) ) {
+    FD_LOG_WARNING(( "NULL mem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)mem, FD_CHECKPT_ALIGN ) ) ) {
+    FD_LOG_WARNING(( "misaligned mem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( (!mmio) & (!!mmio_sz) ) ) {
+    FD_LOG_WARNING(( "NULL mmio" ));
+    return NULL;
+  }
+
+  /* Create the compressor */
+
+# if FD_HAS_LZ4
+  LZ4_stream_t * lz4 = LZ4_createStream();
+  if( FD_UNLIKELY( !lz4 ) ) {
+    FD_LOG_WARNING(( "lz4 error" ));
+    return NULL;
+  }
+# else
+  void * lz4 = NULL;
+# endif
+
+  /* Init the checkpt */
+
+  fd_checkpt_t * checkpt = (fd_checkpt_t *)mem;
+
+  checkpt->fd          = -1; /* mmio mode */
+  checkpt->frame_style = 0;  /* not in frame */
+  checkpt->lz4         = lz4;
+  checkpt->off         = 0UL;
+  checkpt->mmio.mem    = (char *)mmio;
+  checkpt->mmio.sz     = mmio_sz;
+
+  return checkpt;
+}
+
+void *
+fd_checkpt_fini( fd_checkpt_t * checkpt ) {
+
+  if( FD_UNLIKELY( !checkpt ) ) {
+    FD_LOG_WARNING(( "NULL checkpt" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( fd_checkpt_private_in_frame( checkpt ) ) ) {
+    FD_LOG_WARNING(( "in a frame" ));
+    checkpt->frame_style = -1; /* failed */
+    return NULL;
+  }
+
+# if FD_HAS_LZ4
+
+  /* Note: Though this this doesn't seem to be officially documented,
+     the LZ4-1.9.4 source code (lz4/lib/lz4.c:1575) suggests that this
+     always returns 0.  That is, 0 is success and non-zero is failure. */
+
+  if( FD_UNLIKELY( LZ4_freeStream( (LZ4_stream_t *)checkpt->lz4 ) ) )
+    FD_LOG_WARNING(( "LZ4 freeStream error, attempting to continue" ));
+
+# endif
+
+  return (void *)checkpt;
+}
+
+int
+fd_checkpt_frame_open_advanced( fd_checkpt_t * checkpt,
+                                int            frame_style,
+                                ulong *        _off ) {
+
+  if( FD_UNLIKELY( !checkpt ) ) {
+    FD_LOG_WARNING(( "NULL checkpt" ));
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( fd_checkpt_private_in_frame( checkpt ) ) ) {
+    FD_LOG_WARNING(( "in a frame" ));
+    checkpt->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( !_off ) ) {
+    FD_LOG_WARNING(( "NULL _off" ));
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  frame_style = fd_int_if( !!frame_style, frame_style, FD_CHECKPT_FRAME_STYLE_DEFAULT );
+
+  switch( frame_style ) {
+
+  case FD_CHECKPT_FRAME_STYLE_RAW: {
+    break;
+  }
+
+# if FD_HAS_LZ4
+  case FD_CHECKPT_FRAME_STYLE_LZ4: {
+    LZ4_resetStream( (LZ4_stream_t *)checkpt->lz4 ); /* Note: no error code for this API */
+    break;
+  }
+# endif
+
+  default: {
+    FD_LOG_WARNING(( "unsupported frame_style" ));
+    checkpt->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_UNSUP;
+  }
+
+  }
+
+  checkpt->frame_style = frame_style;
+
+  *_off = checkpt->off;
+  return FD_CHECKPT_SUCCESS;
+}
+
+int
+fd_checkpt_frame_close_advanced( fd_checkpt_t * checkpt,
+                                 ulong *        _off ) {
+
+  if( FD_UNLIKELY( !checkpt ) ) {
+    FD_LOG_WARNING(( "NULL checkpt" ));
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( !fd_checkpt_private_in_frame( checkpt ) ) ) {
+    FD_LOG_WARNING(( "not in a frame" ));
+    checkpt->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( !_off ) ) {
+    FD_LOG_WARNING(( "NULL _off" ));
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  ulong off = checkpt->off;
+
+  if( fd_checkpt_private_is_mmio( checkpt ) ) { /* mmio mode (app dependent branch prob) */
+
+    /* Nothing to do */
+
+  } else { /* streaming mode */
+
+    /* Flush out all pending bytes for this frame */
+
+    ulong wbuf_used = checkpt->wbuf.used;
+
+    if( FD_LIKELY( wbuf_used ) ) {
+
+      ulong wsz;
+      int   err = fd_io_write( checkpt->fd, checkpt->wbuf.mem, wbuf_used, wbuf_used, &wsz );
+      if( FD_UNLIKELY( err ) ) {
+        FD_LOG_WARNING(( "fd_io_write failed (%i-%s)", err, fd_io_strerror( err ) ));
+        checkpt->frame_style = -1; /* failed */
+        return FD_CHECKPT_ERR_IO;
+      }
+
+      off += wsz;
+      if( FD_UNLIKELY( off<wsz ) ) {
+        FD_LOG_WARNING(( "checkpt sz overflow" ));
+        checkpt->frame_style = -1; /* failed */
+        return FD_CHECKPT_ERR_IO;
+      }
+
+    }
+
+    checkpt->wbuf.used = 0UL;
+
+  }
+
+  checkpt->off         = off;
+  checkpt->frame_style = 0;   /* not in frame */
+
+  *_off = off;
+  return FD_CHECKPT_SUCCESS;
+}
+
+int
+fd_checkpt_buf( fd_checkpt_t * checkpt,
+                void const *   buf,
+                ulong          sz ) {
+
+  if( FD_UNLIKELY( !checkpt ) ) {
+    FD_LOG_WARNING(( "NULL checkpt" ));
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( !fd_checkpt_private_in_frame( checkpt ) ) ) {
+    FD_LOG_WARNING(( "not in a frame" ));
+    checkpt->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( !sz ) ) return FD_CHECKPT_SUCCESS; /* nothing to do */
+
+  if( FD_UNLIKELY( !buf ) ) {
+    FD_LOG_WARNING(( "NULL buf with non-zero sz" ));
+    checkpt->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  ulong off = checkpt->off;
+
+  switch( checkpt->frame_style ) {
+
+  case FD_CHECKPT_FRAME_STYLE_RAW: {
+
+    if( fd_checkpt_private_is_mmio( checkpt ) ) { /* mmio mode (app dependent branch prob) */
+
+      if( FD_UNLIKELY( sz > (checkpt->mmio.sz-off) ) ) {
+        FD_LOG_WARNING(( "mmio_sz too small" ));
+        checkpt->frame_style = -1; /* failed */
+        return FD_CHECKPT_ERR_IO;
+      }
+
+      memcpy( checkpt->mmio.mem + off, buf, sz );
+      off += sz;
+
+    } else { /* streaming mode */
+
+      ulong wbuf_used = checkpt->wbuf.used;
+
+      ulong wsz_max = wbuf_used + sz;
+      if( FD_UNLIKELY( wsz_max<sz ) ) {
+        FD_LOG_WARNING(( "sz overflow" ));
+        checkpt->frame_style = -1; /* failed */
+        return FD_CHECKPT_ERR_IO;
+      }
+
+      int err = fd_io_buffered_write( checkpt->fd, buf, sz, checkpt->wbuf.mem, checkpt->wbuf.sz, &wbuf_used );
+      if( FD_UNLIKELY( err ) ) {
+        FD_LOG_WARNING(( "fd_io_buffered_write failed (%i-%s)", err, fd_io_strerror( err ) ));
+        checkpt->frame_style = -1; /* failed */
+        return FD_CHECKPT_ERR_IO;
+      }
+
+      if( FD_UNLIKELY( wsz_max<wbuf_used ) ) {
+        FD_LOG_WARNING(( "unexpected buffered write size" ));
+        checkpt->frame_style = -1; /* failed */
+        return FD_CHECKPT_ERR_IO;
+      }
+
+      ulong wsz = wsz_max - wbuf_used;
+
+      off += wsz;
+      if( FD_UNLIKELY( off<wsz ) ) {
+        FD_LOG_WARNING(( "checkpt sz overflow" ));
+        checkpt->frame_style = -1; /* failed */
+        return FD_CHECKPT_ERR_IO;
+      }
+
+      checkpt->wbuf.used = wbuf_used;
+
+    }
+
+    break;
+  }
+
+# if FD_HAS_LZ4
+  case FD_CHECKPT_FRAME_STYLE_LZ4: {
+    LZ4_stream_t * lz4 = (LZ4_stream_t *)checkpt->lz4;
+
+    if( fd_checkpt_private_is_mmio( checkpt ) ) { /* mmio mode, app dependent branch prob */
+      char * mmio      = checkpt->mmio.mem;
+      ulong  mmio_sz   = checkpt->mmio.sz;
+
+      char const * chunk = (char const *)buf;
+      do {
+        ulong mmio_rem = mmio_sz - off;
+        if( FD_UNLIKELY( !mmio_rem ) ) {
+          FD_LOG_WARNING(( "mmio_sz too small" ));
+          checkpt->frame_style = -1; /* failed */
+          return FD_CHECKPT_ERR_IO;
+        }
+
+        ulong chunk_usz     = fd_ulong_min( sz, FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX );
+        ulong chunk_csz_max = fd_ulong_min( FD_CHECKPT_PRIVATE_CSZ_MAX( chunk_usz ), mmio_rem );
+
+        /* At this point, chunk_usz is in [1,CHUNK_USZ_MAX] and
+           chunk_csz_max is in [1,CSZ_MAX( USZ_MAX )].  chunk_csz_max is
+           also at most the amount of space remaining in the mmio
+           region.
+
+           FIXME: DOES CHUNK_CSZ_MAX (DSTCAPACITY) AFFECT HOW LZ4 DOES
+           ITS COMPRESSION/DECOMPRESSION?  THE APIS SUGGEST NO AND THIS
+           ASSUMES IT DOESNT.  IF IT DOES, THIS CALL AND VARIOUS CALLS
+           BELOW MIGHT NEED TO BE ADJUST TO PROVIDE IDENTICAL VALUES FOR
+           DST_CAPACITY BETWEEN STREAMING AND MMIO AND BETWEEN CHECKPT
+           AND RESTORE. */
+
+        /* Note: 1 is default LZ4 acceleration */
+        int _chunk_csz = LZ4_compress_fast_continue( lz4, chunk, mmio + off, (int)chunk_usz, (int)chunk_csz_max, 1 );
+        if( FD_UNLIKELY( _chunk_csz<=0 ) ) {
+          FD_LOG_WARNING(( "LZ4_compress_fast_continue error (%i), mmio_sz probably too small", _chunk_csz ));
+          checkpt->frame_style = -1; /* failed */
+          return FD_CHECKPT_ERR_COMP;
+        }
+
+        ulong chunk_csz = (ulong)_chunk_csz;
+        if( FD_UNLIKELY( chunk_csz>chunk_csz_max ) ) {
+          FD_LOG_WARNING(( "unexpected chunk_csz" ));
+          checkpt->frame_style = -1; /* failed */
+          return FD_CHECKPT_ERR_COMP;
+        }
+
+        off += chunk_csz;
+
+        chunk += chunk_usz;
+        sz    -= chunk_usz;
+      } while( sz );
+
+    } else { /* streaming mode */
+
+      int    fd        = checkpt->fd;
+      char * wbuf      = checkpt->wbuf.mem;
+      ulong  wbuf_sz   = checkpt->wbuf.sz;
+      ulong  wbuf_used = checkpt->wbuf.used;
+
+      char const * chunk = (char const *)buf;
+      do {
+        ulong chunk_usz     = fd_ulong_min( sz, FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX );
+        ulong chunk_csz_max = FD_CHECKPT_PRIVATE_CSZ_MAX( chunk_usz );
+
+        /* At this point, chunk_usz is in [1,CHUNK_USZ_MAX] and
+           chunk_csz_max is in [1,CSZ_MAX(CHUNK_USZ_MAX)].  If we don't
+           have enough room in the write buffer, flush it to make room. */
+
+        ulong wbuf_free = wbuf_sz - wbuf_used; /* In [0,wbuf_sz] */
+        if( FD_UNLIKELY( chunk_csz_max > wbuf_free ) ) {
+
+          ulong wsz;
+          int   err = fd_io_write( fd, wbuf, wbuf_used, wbuf_used, &wsz );
+          if( FD_UNLIKELY( err ) ) {
+            FD_LOG_WARNING(( "fd_io_write failed (%i-%s)", err, fd_io_strerror( err ) ));
+            checkpt->frame_style = -1; /* failed */
+            return FD_CHECKPT_ERR_IO;
+          }
+
+          off += wsz;
+          if( FD_UNLIKELY( off<wsz ) ) {
+            FD_LOG_WARNING(( "checkpt sz overflow" ));
+            checkpt->frame_style = -1; /* failed */
+            return FD_CHECKPT_ERR_IO;
+          }
+
+          wbuf_used = 0UL;
+          wbuf_free = wbuf_sz; /* >= WBUF_MIN >= CSZ_MAX( CHUNK_USZ_MAX ) >= CSZ_MAX( chunk_usz ) */
+
+        }
+
+        /* At this point, wbuf_free >= CSZ_MAX(chunk_usz) such that
+           LZ4_compressed_fast_continue cannot fail (at least, according
+           to its documentation).  We use the default acceleration.
+           ALSO SEE FIXME IN CHECKPT_BUF MMIO */
+
+        /* Note: 1 is default LZ4 acceleration */
+        int _chunk_csz = LZ4_compress_fast_continue( lz4, chunk, wbuf + wbuf_used, (int)chunk_usz, (int)wbuf_free, 1 );
+        if( FD_UNLIKELY( _chunk_csz<=0 ) ) {
+          FD_LOG_WARNING(( "lz4 error" ));
+          checkpt->frame_style = -1; /* failed */
+          return FD_CHECKPT_ERR_COMP;
+        }
+
+        ulong chunk_csz = (ulong)_chunk_csz;
+        if( FD_UNLIKELY( chunk_csz>chunk_csz_max ) ) {
+          FD_LOG_WARNING(( "unexpected chunk_csz" ));
+          checkpt->frame_style = -1; /* failed */
+          return FD_CHECKPT_ERR_COMP;
+        }
+
+        wbuf_used += chunk_csz;
+
+        chunk += chunk_usz;
+        sz    -= chunk_usz;
+
+      } while( sz );
+
+      checkpt->wbuf.used = wbuf_used;
+
+    }
+
+    break;
+  }
+# endif
+
+  default: { /* never get here */
+    FD_LOG_WARNING(( "unsupported frame style" ));
+    checkpt->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_UNSUP;
+  }
+
+  }
+
+  checkpt->off = off;
+  return FD_CHECKPT_SUCCESS;
+}
+
+fd_restore_t *
+fd_restore_init_stream( void * mem,
+                        int    fd,
+                        void * rbuf,
+                        ulong  rbuf_sz ) {
+
+  /* Check input args */
+
+  if( FD_UNLIKELY( !mem ) ) {
+    FD_LOG_WARNING(( "NULL mem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)mem, FD_RESTORE_ALIGN ) ) ) {
+    FD_LOG_WARNING(( "misaligned mem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( fd<0 ) ) {
+    FD_LOG_WARNING(( "bad fd" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !rbuf ) ) {
+    FD_LOG_WARNING(( "NULL rbuf" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( rbuf_sz<FD_RESTORE_RBUF_MIN ) ) {
+    FD_LOG_WARNING(( "rbuf_sz too small" ));
+    return NULL;
+  }
+
+  /* Create decompressor */
+
+# if FD_HAS_LZ4
+  LZ4_streamDecode_t * lz4 = LZ4_createStreamDecode();
+  if( FD_UNLIKELY( !lz4 ) ) {
+    FD_LOG_WARNING(( "lz4 error" ));
+    return NULL;
+  }
+# else
+  void * lz4 = NULL;
+# endif
+
+  /* Init restore */
+
+  fd_restore_t * restore = (fd_restore_t *)mem;
+
+  restore->fd          = fd; /* streaming mode */
+  restore->frame_style = 0;  /* not in frame */
+  restore->lz4         = lz4;
+  restore->rbuf.mem    = rbuf;
+  restore->rbuf.sz     = rbuf_sz;
+  restore->rbuf.lo     = 0UL;
+  restore->rbuf.ready  = 0UL;
+
+  return restore;
+}
+
+fd_restore_t *
+fd_restore_init_mmio( void *       mem,
+                      void const * mmio,
+                      ulong        mmio_sz ) {
+
+  /* Check input args */
+
+  if( FD_UNLIKELY( !mem ) ) {
+    FD_LOG_WARNING(( "NULL mem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)mem, FD_RESTORE_ALIGN ) ) ) {
+    FD_LOG_WARNING(( "misaligned mem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( (!mmio) & (!!mmio_sz) ) ) {
+    FD_LOG_WARNING(( "NULL mmio with non-zero mmio_sz" ));
+    return NULL;
+  }
+
+  /* Create decompressor */
+
+# if FD_HAS_LZ4
+  LZ4_streamDecode_t * lz4 = LZ4_createStreamDecode();
+  if( FD_UNLIKELY( !lz4 ) ) {
+    FD_LOG_WARNING(( "lz4 error" ));
+    return NULL;
+  }
+# else
+  void * lz4 = NULL;
+# endif
+
+  /* Init restore */
+
+  fd_restore_t * restore = (fd_restore_t *)mem;
+
+  restore->fd          = -1; /* mmio mode */
+  restore->frame_style = 0;  /* not in frame */
+  restore->lz4         = lz4;
+  restore->mmio.mem    = (char const *)mmio;
+  restore->mmio.sz     = mmio_sz;
+  restore->mmio.off    = 0UL;
+
+  return restore;
+}
+
+void *
+fd_restore_fini( fd_restore_t * restore ) {
+
+  if( FD_UNLIKELY( !restore ) ) {
+    FD_LOG_WARNING(( "NULL restore" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( fd_restore_private_in_frame( restore ) ) ) {
+    FD_LOG_WARNING(( "in a frame" ));
+    restore->frame_style = -1; /* failed */
+    return NULL;
+  }
+
+# if FD_HAS_LZ4
+
+  /* Note: Though this this doesn't seem to be officially documented,
+     the LZ4-1.9.4 source code (lz4/lib/lz4.c:2575) suggests that this
+     always returns 0.  That is, 0 is success and non-zero is failure. */
+
+  if( FD_UNLIKELY( LZ4_freeStreamDecode( (LZ4_streamDecode_t *)restore->lz4 ) ) )
+    FD_LOG_WARNING(( "LZ4 freeStreamDecode error, attempting to continue" ));
+
+# endif
+
+  return restore;
+}
+
+int
+fd_restore_frame_open( fd_restore_t * restore,
+                       int            frame_style ) {
+
+  if( FD_UNLIKELY( !restore ) ) {
+    FD_LOG_WARNING(( "NULL restore" ));
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( fd_restore_private_in_frame( restore ) ) ) {
+    FD_LOG_WARNING(( "in a frame" ));
+    restore->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  frame_style = fd_int_if( !!frame_style, frame_style, FD_CHECKPT_FRAME_STYLE_DEFAULT );
+
+  switch( frame_style ) {
+
+  case FD_CHECKPT_FRAME_STYLE_RAW: {
+    break;
+  }
+
+# if FD_HAS_LZ4
+  case FD_CHECKPT_FRAME_STYLE_LZ4: {
+    if( FD_UNLIKELY( !LZ4_setStreamDecode( (LZ4_streamDecode_t *)restore->lz4, NULL, 0 ) ) ) {
+      FD_LOG_WARNING(( "LZ4_setStreamDecode failed" ));
+      restore->frame_style = -1; /* failed */
+      return FD_CHECKPT_ERR_COMP;
+    }
+    break;
+  }
+# endif
+
+  default: {
+    FD_LOG_WARNING(( "unsupported frame_style" ));
+    restore->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_UNSUP;
+  }
+
+  }
+
+  restore->frame_style = frame_style;
+  return FD_CHECKPT_SUCCESS;
+}
+
+int
+fd_restore_frame_close( fd_restore_t * restore ) {
+
+  if( FD_UNLIKELY( !restore ) ) {
+    FD_LOG_WARNING(( "NULL restore" ));
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( !fd_restore_private_in_frame( restore ) ) ) {
+    FD_LOG_WARNING(( "not in a frame" ));
+    restore->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  restore->frame_style = 0;
+  return FD_CHECKPT_SUCCESS;
+}
+
+int
+fd_restore_buf( fd_restore_t * restore,
+                void *         buf,
+                ulong          sz ) {
+
+  if( FD_UNLIKELY( !restore ) ) {
+    FD_LOG_WARNING(( "NULL restore" ));
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( !fd_restore_private_in_frame( restore ) ) ) {
+    FD_LOG_WARNING(( "not in a frame" ));
+    restore->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( !sz ) ) return FD_CHECKPT_SUCCESS; /* nothing to do */
+
+  if( FD_UNLIKELY( !buf ) ) {
+    FD_LOG_WARNING(( "NULL buf with non-zero sz" ));
+    restore->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  switch( restore->frame_style ) {
+
+  case FD_CHECKPT_FRAME_STYLE_RAW: {
+
+    if( fd_restore_private_is_mmio( restore ) ) { /* mmio mode, app dependent branch prob */
+
+      ulong mmio_sz  = restore->mmio.sz;
+      ulong mmio_off = restore->mmio.off;
+
+      if( FD_UNLIKELY( sz > (mmio_sz-mmio_off) ) ) {
+        FD_LOG_WARNING(( "sz overflow" ));
+        restore->frame_style = -1; /* failed */
+        return FD_CHECKPT_ERR_IO;
+      }
+
+      memcpy( buf, restore->mmio.mem + mmio_off, sz );
+
+      restore->mmio.off = mmio_off + sz;
+
+    } else { /* streaming mode */
+
+      int err = fd_io_buffered_read( restore->fd, buf, sz, restore->rbuf.mem, restore->rbuf.sz,
+                                     &restore->rbuf.lo, &restore->rbuf.ready );
+
+      if( FD_UNLIKELY( err ) ) {
+        FD_LOG_WARNING(( "fd_io_buffered_read failed (%i-%s)", err, fd_io_strerror( err ) ));
+        restore->frame_style = -1; /* failed */
+        return FD_CHECKPT_ERR_IO;
+      }
+
+    }
+
+    break;
+  }
+
+# if FD_HAS_LZ4
+  case FD_CHECKPT_FRAME_STYLE_LZ4: {
+
+    LZ4_streamDecode_t * lz4 = (LZ4_streamDecode_t *)restore->lz4;
+
+    if( fd_restore_private_is_mmio( restore ) ) { /* mmio mode */
+
+      char const * mmio     = restore->mmio.mem;
+      ulong        mmio_sz  = restore->mmio.sz;
+      ulong        mmio_off = restore->mmio.off;
+
+      char * chunk = (char *)buf;
+      do {
+        ulong mmio_rem = mmio_sz - mmio_off;
+        if( FD_UNLIKELY( !mmio_rem ) ) {
+          FD_LOG_WARNING(( "sz error" ));
+          restore->frame_style = -1; /* failed */
+          return FD_CHECKPT_ERR_IO;
+        }
+
+        ulong chunk_usz     = fd_ulong_min( sz, FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX );
+        ulong chunk_csz_max = FD_CHECKPT_PRIVATE_CSZ_MAX( chunk_usz );
+
+        /* At this point, chunk_usz is in [1,CHUNK_USZ_MAX] and
+           chunk_csz_max is in [0,CSZ_MAX( USZ_MAX )].  chunk_csz_max is
+           also at most the amount of space remaining in the mmio
+           region.
+
+           Note: The LZ4 header doesn't thoroughly document these APIs
+           so we make some guesses.  If we assume no checkpoint
+           corruption or truncation, the fast variant should "just
+           work".  If we don't, when mmio_rem<chunk_csz_max, it looks
+           like the fast variant could read up to chunk_csz_max-mmio_rem
+           bytes past the end of the mmio region.  Though this is
+           reasonably bounded, it is not easy or natural to append a
+           tail reading guard to the end of a memory mapped fail.  So,
+           we fall back the safe variant when we are too close for
+           comfort.  ALSO SEE FIXME IN CHECKPT_BUF MMIO. */
+
+        int _chunk_csz = FD_LIKELY( (chunk_csz_max<=mmio_rem) )
+          ? LZ4_decompress_fast_continue( lz4, mmio + mmio_off, chunk,                (int)chunk_usz )
+          : LZ4_decompress_safe_continue( lz4, mmio + mmio_off, chunk, (int)mmio_rem, (int)chunk_usz );
+        if( FD_UNLIKELY( _chunk_csz<=0 ) ) {
+          FD_LOG_WARNING(( "LZ4_decompress_fast/safe_continue error (%i)", _chunk_csz ));
+          restore->frame_style = -1; /* failed */
+          return FD_CHECKPT_ERR_COMP;
+        }
+
+        ulong chunk_csz = (ulong)_chunk_csz;
+        if( FD_UNLIKELY( chunk_csz>fd_ulong_min( chunk_csz_max, mmio_rem ) ) ) {
+          FD_LOG_WARNING(( "unexpected chunk_csz" ));
+          restore->frame_style = -1; /* failed */
+          return FD_CHECKPT_ERR_COMP;
+        }
+
+        mmio_off += chunk_csz;
+
+        chunk += chunk_usz;
+        sz    -= chunk_usz;
+      } while( sz );
+
+      restore->mmio.off = mmio_off;
+
+    } else { /* streaming mode */
+
+      int    fd         = restore->fd;
+      char * rbuf       = restore->rbuf.mem;
+      ulong  rbuf_sz    = restore->rbuf.sz;
+      ulong  rbuf_lo    = restore->rbuf.lo;
+      ulong  rbuf_ready = restore->rbuf.ready;
+
+      char * chunk = (char *)buf;
+      do {
+        ulong chunk_usz     = fd_ulong_min( sz, FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX );
+        ulong chunk_csz_max = FD_CHECKPT_PRIVATE_CSZ_MAX( chunk_usz );
+
+        /* At this point, chunk_usz is in [1,CHUNK_USZ_MAX] and
+           chunk_csz_max is in [1,CSZ_MAX(CHUNK_USZ_MAX)].  If we don't
+           have enough bytes buffered from the file to guarantee
+           successful decompression, read more from the file. */
+
+        if( FD_UNLIKELY( rbuf_ready < chunk_csz_max ) ) {
+
+          /* Move the unprocessed bytes to the beginning of the buffer */
+
+          memmove( rbuf, rbuf+rbuf_lo, rbuf_ready );
+
+          /* Try to read at least enough bytes to get to chunk_csz_max
+             unprocessed bytes into rbuf and at most enough bytes to
+             fill up the read buffer. */
+
+          ulong rsz;
+          int   err = fd_io_read( fd, rbuf+rbuf_ready, chunk_csz_max-rbuf_ready, rbuf_sz-rbuf_ready, &rsz );
+          if( FD_UNLIKELY( err>0 ) ) {
+            FD_LOG_WARNING(( "fd_io_read failed (%i-%s)", err, fd_io_strerror( err ) ));
+            restore->frame_style = -1; /* failed */
+            return FD_CHECKPT_ERR_IO;
+          }
+          rbuf_ready += rsz;
+
+          rbuf_lo = 0UL;
+
+          /* At this point, if we didn't hit eof (err==0), we have at
+             least chunk_csz_max unprocessed bytes in rbuf.
+
+             If we hit eof (err<0) before getting to at least
+             chunk_csz_max unprocessed bytes in rbuf, rbuf_ready should
+             be still enough to decompress this block if there was no
+             file corruption.
+
+             If we hit eof prematurely due to file corruption though,
+             decompression should not crash (the decompressor will not
+             touch more than chunk_csz_max and rbuf has a size of
+             rbuf_sz >= RBUF_MIN >= CSZ_MAX( CHUNK_CSZ_MAX ) >=
+             chunk_csz_max).  The decompressed result will almost
+             certainly be corrupt (and potentially previous restores in
+             this frame were too as we don't know when the corruption
+             occurred).  We can detect this adjusting chunk_csz_max to
+             the number of bytes available to eof.
+
+             ALSO SEE FIXME IN CHECKPT_BUF MMIO. */
+
+          chunk_csz_max = fd_ulong_min( chunk_csz_max, rbuf_ready );
+        }
+
+        int _chunk_csz = LZ4_decompress_fast_continue( lz4, rbuf + rbuf_lo, chunk, (int)chunk_usz );
+        if( FD_UNLIKELY( _chunk_csz<=0 ) ) {
+          FD_LOG_WARNING(( "LZ4 decompress_fast_continue failed (%i)", _chunk_csz ));
+          restore->frame_style = -1; /* failed */
+          return FD_CHECKPT_ERR_COMP;
+        }
+
+        ulong chunk_csz = (ulong)_chunk_csz;
+        if( FD_UNLIKELY( chunk_csz>chunk_csz_max ) ) {
+          FD_LOG_WARNING(( "unexpected chunk_csz" ));
+          restore->frame_style = -1; /* failed */
+          return FD_CHECKPT_ERR_COMP;
+        }
+
+        rbuf_lo    += chunk_csz;
+        rbuf_ready -= chunk_csz;
+
+        chunk += chunk_usz;
+        sz    -= chunk_usz;
+      } while( sz );
+
+      restore->rbuf.lo    = rbuf_lo;
+      restore->rbuf.ready = rbuf_ready;
+
+    }
+
+    break;
+  }
+# endif
+
+  default: { /* never get here */
+    FD_LOG_WARNING(( "unsupported frame style" ));
+    restore->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_UNSUP;
+  }
+
+  }
+
+  return FD_CHECKPT_SUCCESS;
+}
+
+char const *
+fd_checkpt_strerror( int err ) {
+  switch( err ) {
+  case FD_CHECKPT_SUCCESS:   return "success";
+  case FD_CHECKPT_ERR_INVAL: return "bad input args";
+  case FD_CHECKPT_ERR_UNSUP: return "unsupported on this target";
+  case FD_CHECKPT_ERR_IO:    return "io error";
+  case FD_CHECKPT_ERR_COMP:  return "compression error";
+  default: break;
+  }
+  return "unknown";
+}

--- a/src/util/checkpt/fd_checkpt.c
+++ b/src/util/checkpt/fd_checkpt.c
@@ -1,7 +1,158 @@
 #include "fd_checkpt.h"
 
+char const *
+fd_checkpt_strerror( int err ) {
+  switch( err ) {
+  case FD_CHECKPT_SUCCESS:   return "success";
+  case FD_CHECKPT_ERR_INVAL: return "bad input args";
+  case FD_CHECKPT_ERR_UNSUP: return "unsupported on this target";
+  case FD_CHECKPT_ERR_IO:    return "io error";
+  case FD_CHECKPT_ERR_COMP:  return "compression error";
+  default: break;
+  }
+  return "unknown";
+}
+
 #if FD_HAS_LZ4
 #include <lz4.h>
+
+/* fd_checkpt_private_lz4 compresses the ubuf_usz byte size memory
+   region pointed to by ubuf into the cbuf_max memory region pointed to
+   by cbuf using the given lz4 compressor.  Assumes lz4, ubuf and cbuf
+   are valid.  On success, returns the compressed size (will be in
+   [4,cbuf_max]).  The ubuf passed to this should not be modified
+   until the given lz4 stream is reset / closed or there has been an
+   additional 64 KiB passed to the stream.  On failure, returns 0 and
+   retains no interest in ubuf.  In, either case, this retains no
+   interest in cbuf on return.
+
+   _gbuf, gbuf_sz, gbuf_thresh, _gbuf_cursor specify the small buf
+   gather ring state.  It is detailed below. */
+
+static ulong
+fd_checkpt_private_lz4( LZ4_stream_t * lz4,
+                        void const *   _ubuf,
+                        ulong          ubuf_usz,
+                        void *         _cbuf,
+                        ulong          cbuf_max,
+                        void *         _gbuf,
+                        ulong          gbuf_sz,
+                        ulong          gbuf_thresh,
+                        ulong *        _gbuf_cursor ) {
+  char *       cbuf = (char *)      _cbuf;
+  char const * ubuf = (char const *)_ubuf;
+
+  /* Verify ubuf_usz is in [1,LZ4_MAX_INPUT_SIZE] and cbuf_max is large
+     enough to store a header and a non-trivial compressed body. */
+
+  if( FD_UNLIKELY( !((1UL<=ubuf_usz) & (ubuf_usz<=(ulong)LZ4_MAX_INPUT_SIZE)) ) ) {
+    FD_LOG_WARNING(( "bad ubuf_usz" ));
+    return 0UL;
+  }
+
+  if( FD_UNLIKELY( cbuf_max<4UL ) ) {
+    FD_LOG_WARNING(( "not enough room to compress" ));
+    return 0UL;
+  }
+
+  /* Small ubuf gather optimization.  Though the LZ4 streaming API looks
+     like it is designed for scatter/gather operation, the
+     implementation under the hood is heavily optimized for the case the
+     incoming data buffers are stored in a ring buffer (basically, the
+     compression dictionary has a size of the most recent 64 KiB of
+     _contiguous_ _in_ _memory_ buffers passed to it ... see
+     lz4-1.9.4@lz4/lib/lz4.c:2636-2665 for an example).
+
+     When a buffer >> 64 KiB is checkpointed, it will be compressed as
+     CHUNK_USZ sequential chunks contiguous in memory.  So outside of
+     minor startup effects (where the initial dictionary might not be as
+     large as it could have been), this case is optimal.
+
+     But when lots of disjoint tiny buffers << 64 KiB are checkpointed,
+     LZ4 is constantly reseting its dictionary to only use the most
+     recently previously compressed (tiny) buffer.  This case is
+     suboptimal.
+
+     At the same time, we don't want to use a ring buffer because that
+     would imply an extra copy when compressing large data.  This is a
+     complete waste because that case was already optimal.  And this is
+     the most important case for high performance.
+
+     Below, if the incoming buffer to compress is large enough
+     (>=thresh), we compress it in place as it will be optimal as
+     before.
+
+     If not, we first copy it into a gather buffer and have LZ4 compress
+     out of the gather buffer location.  Then, when compressing lots of
+     tiny buffer disjoint buffers, it will appear to LZ4 as though they
+     were contiguous in memory and LZ4 will handle that optimally too.
+
+     Then our dictionary size is optimal in both asymptotic regimes and
+     we are still zero copy in the important case of compressing large
+     data.  The dictionary will also be reasonable when toggling
+     frequently between the asymptotic regimes, as often happens in
+     checkpointing (small metadata checkpts/large checkpt/small metadata
+     checkpts/large data checkpt/...).
+
+     The lz4 API streaming API requires up to the most recent 64 KiB of
+     uncompressed bytes to be unmodified when called.  Suppose we have
+     only been compressing small buffers and we are trying to compress a
+     thresh-1 byte buffer when only thresh-2 bytes of gather buffer
+     space remains.  Since we wrap at buffer granularity, we will need
+     to put the thresh-1 bytes at the head of the buffer.  To ensure
+     this doesn't clobber any of the 64 KiB previously compressed, we
+     need a gather buffer at least:
+
+       thresh-1 + 64KiB + thresh-2 = 2 thresh + 64 KiB - 3
+
+     in size.  Larger is fine.  Smaller will break compression.
+
+     We do the corresponding in the restore and the restore
+     configuration must match our checkpt configuration exactly in order
+     to keep the dictionaries on both sides synchronized.
+
+     TL;DR  We store small buffers into a gather ring at buffer
+     granularity for better compression and compress large buffers in
+     place for extra performance due to the details of how LZ4 stream
+     APIs are implemented. */
+
+  int is_small = ubuf_usz<gbuf_thresh;
+  if( is_small ) { /* app dependent branch prob */
+    ulong gbuf_cursor = *_gbuf_cursor;
+    if( (gbuf_sz-gbuf_cursor)<ubuf_usz ) gbuf_cursor = 0UL; /* cmov */
+    ubuf = (char *)_gbuf + gbuf_cursor;
+    *_gbuf_cursor = gbuf_cursor + ubuf_usz;
+    memcpy( (char *)ubuf, _ubuf, ubuf_usz );
+  }
+
+  /* Compress ubuf into cbuf, leaving space for the header.  Compression
+     will fail if there is no room to the resulting compressed size into
+     the header as we clamp the capacity to 2^24-1. */
+
+  ulong ubuf_csz_max = fd_ulong_min( cbuf_max-3UL, (1UL<<24)-1UL ); /* In [1,2^24) */
+
+  int _ubuf_csz = LZ4_compress_fast_continue( lz4, ubuf, cbuf+3UL, (int)ubuf_usz, (int)ubuf_csz_max, 1 /* default */ );
+  if( FD_UNLIKELY( _ubuf_csz<=0 ) ) {
+    FD_LOG_WARNING(( "LZ4_compress_fast_continue error (%i)", _ubuf_csz ));
+    return 0UL;
+  }
+
+  ulong ubuf_csz = (ulong)_ubuf_csz;
+  if( FD_UNLIKELY( ubuf_csz>ubuf_csz_max ) ) {
+    FD_LOG_WARNING(( "unexpected compressed size" ));
+    return 0UL;
+  }
+
+  /* Write compressed size we obtained into the header as a 24-bit
+     little endian unsigned integer.  This need to do this is a
+     limitation of how the recent LZ4 APIs (>=1.9) work. */
+
+  cbuf[0] = (char)( ubuf_csz      & 255UL);
+  cbuf[1] = (char)((ubuf_csz>> 8) & 255UL);
+  cbuf[2] = (char)((ubuf_csz>>16) & 255UL);
+
+  return ubuf_csz + 3UL;
+}
 #endif
 
 fd_checkpt_t *
@@ -55,9 +206,9 @@ fd_checkpt_init_stream( void * mem,
 
   checkpt->fd          = fd; /* streaming mode */
   checkpt->frame_style = 0;  /* not in frame */
-  checkpt->lz4         = lz4;
+  checkpt->lz4         = (void *)lz4;
   checkpt->off         = 0UL;
-  checkpt->wbuf.mem    = (char *)wbuf;
+  checkpt->wbuf.mem    = (uchar *)wbuf;
   checkpt->wbuf.sz     = wbuf_sz;
   checkpt->wbuf.used   = 0UL;
 
@@ -104,9 +255,10 @@ fd_checkpt_init_mmio( void * mem,
 
   checkpt->fd          = -1; /* mmio mode */
   checkpt->frame_style = 0;  /* not in frame */
-  checkpt->lz4         = lz4;
+  checkpt->lz4         = (void *)lz4;
+  checkpt->gbuf_cursor = 0UL;
   checkpt->off         = 0UL;
-  checkpt->mmio.mem    = (char *)mmio;
+  checkpt->mmio.mem    = (uchar *)mmio;
   checkpt->mmio.sz     = mmio_sz;
 
   return checkpt;
@@ -129,8 +281,8 @@ fd_checkpt_fini( fd_checkpt_t * checkpt ) {
 # if FD_HAS_LZ4
 
   /* Note: Though this this doesn't seem to be officially documented,
-     the LZ4-1.9.4 source code (lz4/lib/lz4.c:1575) suggests that this
-     always returns 0.  That is, 0 is success and non-zero is failure. */
+     the lz4-1.9.4@lz4/lib/lz4.c:1575) suggests that this always returns
+     0.  That is, 0 is success and non-zero is failure. */
 
   if( FD_UNLIKELY( LZ4_freeStream( (LZ4_stream_t *)checkpt->lz4 ) ) )
     FD_LOG_WARNING(( "LZ4 freeStream error, attempting to continue" ));
@@ -150,14 +302,15 @@ fd_checkpt_frame_open_advanced( fd_checkpt_t * checkpt,
     return FD_CHECKPT_ERR_INVAL;
   }
 
-  if( FD_UNLIKELY( fd_checkpt_private_in_frame( checkpt ) ) ) {
-    FD_LOG_WARNING(( "in a frame" ));
+  if( FD_UNLIKELY( !fd_checkpt_private_can_open( checkpt ) ) ) {
+    FD_LOG_WARNING(( "in a frame or failed" ));
     checkpt->frame_style = -1; /* failed */
     return FD_CHECKPT_ERR_INVAL;
   }
 
   if( FD_UNLIKELY( !_off ) ) {
     FD_LOG_WARNING(( "NULL _off" ));
+    checkpt->frame_style = -1; /* failed */
     return FD_CHECKPT_ERR_INVAL;
   }
 
@@ -171,7 +324,8 @@ fd_checkpt_frame_open_advanced( fd_checkpt_t * checkpt,
 
 # if FD_HAS_LZ4
   case FD_CHECKPT_FRAME_STYLE_LZ4: {
-    LZ4_resetStream( (LZ4_stream_t *)checkpt->lz4 ); /* Note: no error code for this API */
+    LZ4_resetStream_fast( (LZ4_stream_t *)checkpt->lz4 ); /* Note: no error code for this API */
+    checkpt->gbuf_cursor = 0UL;
     break;
   }
 # endif
@@ -207,6 +361,7 @@ fd_checkpt_frame_close_advanced( fd_checkpt_t * checkpt,
 
   if( FD_UNLIKELY( !_off ) ) {
     FD_LOG_WARNING(( "NULL _off" ));
+    checkpt->frame_style = -1; /* failed */
     return FD_CHECKPT_ERR_INVAL;
   }
 
@@ -291,7 +446,8 @@ fd_checkpt_buf( fd_checkpt_t * checkpt,
       }
 
       memcpy( checkpt->mmio.mem + off, buf, sz );
-      off += sz;
+
+      off += sz; /* at most mmio.sz */
 
     } else { /* streaming mode */
 
@@ -338,49 +494,23 @@ fd_checkpt_buf( fd_checkpt_t * checkpt,
     LZ4_stream_t * lz4 = (LZ4_stream_t *)checkpt->lz4;
 
     if( fd_checkpt_private_is_mmio( checkpt ) ) { /* mmio mode, app dependent branch prob */
-      char * mmio      = checkpt->mmio.mem;
-      ulong  mmio_sz   = checkpt->mmio.sz;
 
-      char const * chunk = (char const *)buf;
+      uchar * mmio    = checkpt->mmio.mem;
+      ulong   mmio_sz = checkpt->mmio.sz;
+
+      uchar const * chunk = (uchar const *)buf;
       do {
-        ulong mmio_rem = mmio_sz - off;
-        if( FD_UNLIKELY( !mmio_rem ) ) {
-          FD_LOG_WARNING(( "mmio_sz too small" ));
-          checkpt->frame_style = -1; /* failed */
-          return FD_CHECKPT_ERR_IO;
-        }
+        ulong chunk_usz = fd_ulong_min( sz, FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX );
 
-        ulong chunk_usz     = fd_ulong_min( sz, FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX );
-        ulong chunk_csz_max = fd_ulong_min( FD_CHECKPT_PRIVATE_CSZ_MAX( chunk_usz ), mmio_rem );
-
-        /* At this point, chunk_usz is in [1,CHUNK_USZ_MAX] and
-           chunk_csz_max is in [1,CSZ_MAX( USZ_MAX )].  chunk_csz_max is
-           also at most the amount of space remaining in the mmio
-           region.
-
-           FIXME: DOES CHUNK_CSZ_MAX (DSTCAPACITY) AFFECT HOW LZ4 DOES
-           ITS COMPRESSION/DECOMPRESSION?  THE APIS SUGGEST NO AND THIS
-           ASSUMES IT DOESNT.  IF IT DOES, THIS CALL AND VARIOUS CALLS
-           BELOW MIGHT NEED TO BE ADJUST TO PROVIDE IDENTICAL VALUES FOR
-           DST_CAPACITY BETWEEN STREAMING AND MMIO AND BETWEEN CHECKPT
-           AND RESTORE. */
-
-        /* Note: 1 is default LZ4 acceleration */
-        int _chunk_csz = LZ4_compress_fast_continue( lz4, chunk, mmio + off, (int)chunk_usz, (int)chunk_csz_max, 1 );
-        if( FD_UNLIKELY( _chunk_csz<=0 ) ) {
-          FD_LOG_WARNING(( "LZ4_compress_fast_continue error (%i), mmio_sz probably too small", _chunk_csz ));
+        ulong chunk_csz = fd_checkpt_private_lz4( lz4, chunk, chunk_usz, mmio + off, mmio_sz - off,
+                                                  checkpt->gbuf, FD_CHECKPT_PRIVATE_GBUF_SZ, FD_CHECKPT_PRIVATE_GBUF_THRESH,
+                                                  &checkpt->gbuf_cursor ); /* logs details */
+        if( FD_UNLIKELY( !chunk_csz ) ) {
           checkpt->frame_style = -1; /* failed */
           return FD_CHECKPT_ERR_COMP;
         }
 
-        ulong chunk_csz = (ulong)_chunk_csz;
-        if( FD_UNLIKELY( chunk_csz>chunk_csz_max ) ) {
-          FD_LOG_WARNING(( "unexpected chunk_csz" ));
-          checkpt->frame_style = -1; /* failed */
-          return FD_CHECKPT_ERR_COMP;
-        }
-
-        off += chunk_csz;
+        off += chunk_csz; /* at most mmio_sz */
 
         chunk += chunk_usz;
         sz    -= chunk_usz;
@@ -388,21 +518,20 @@ fd_checkpt_buf( fd_checkpt_t * checkpt,
 
     } else { /* streaming mode */
 
-      int    fd        = checkpt->fd;
-      char * wbuf      = checkpt->wbuf.mem;
-      ulong  wbuf_sz   = checkpt->wbuf.sz;
-      ulong  wbuf_used = checkpt->wbuf.used;
+      int     fd        = checkpt->fd;
+      uchar * wbuf      = checkpt->wbuf.mem;
+      ulong   wbuf_sz   = checkpt->wbuf.sz;
+      ulong   wbuf_used = checkpt->wbuf.used;
 
-      char const * chunk = (char const *)buf;
+      uchar const * chunk = (uchar const *)buf;
       do {
-        ulong chunk_usz     = fd_ulong_min( sz, FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX );
+        ulong chunk_usz = fd_ulong_min( sz, FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX );
+
+        /* If we are not guaranteed to have enough room in the write
+           buffer to hold the compressed chunk, flush it to make room. */
+
         ulong chunk_csz_max = FD_CHECKPT_PRIVATE_CSZ_MAX( chunk_usz );
-
-        /* At this point, chunk_usz is in [1,CHUNK_USZ_MAX] and
-           chunk_csz_max is in [1,CSZ_MAX(CHUNK_USZ_MAX)].  If we don't
-           have enough room in the write buffer, flush it to make room. */
-
-        ulong wbuf_free = wbuf_sz - wbuf_used; /* In [0,wbuf_sz] */
+        ulong wbuf_free     = wbuf_sz - wbuf_used;
         if( FD_UNLIKELY( chunk_csz_max > wbuf_free ) ) {
 
           ulong wsz;
@@ -425,22 +554,12 @@ fd_checkpt_buf( fd_checkpt_t * checkpt,
 
         }
 
-        /* At this point, wbuf_free >= CSZ_MAX(chunk_usz) such that
-           LZ4_compressed_fast_continue cannot fail (at least, according
-           to its documentation).  We use the default acceleration.
-           ALSO SEE FIXME IN CHECKPT_BUF MMIO */
+        /* At this point, wbuf_free >= chunk_csz_max */
 
-        /* Note: 1 is default LZ4 acceleration */
-        int _chunk_csz = LZ4_compress_fast_continue( lz4, chunk, wbuf + wbuf_used, (int)chunk_usz, (int)wbuf_free, 1 );
-        if( FD_UNLIKELY( _chunk_csz<=0 ) ) {
-          FD_LOG_WARNING(( "lz4 error" ));
-          checkpt->frame_style = -1; /* failed */
-          return FD_CHECKPT_ERR_COMP;
-        }
-
-        ulong chunk_csz = (ulong)_chunk_csz;
-        if( FD_UNLIKELY( chunk_csz>chunk_csz_max ) ) {
-          FD_LOG_WARNING(( "unexpected chunk_csz" ));
+        ulong chunk_csz = fd_checkpt_private_lz4( lz4, chunk, chunk_usz, wbuf + wbuf_used, wbuf_free,
+                                                  checkpt->gbuf, FD_CHECKPT_PRIVATE_GBUF_SZ, FD_CHECKPT_PRIVATE_GBUF_THRESH,
+                                                  &checkpt->gbuf_cursor ); /* logs details */
+        if( FD_UNLIKELY( !chunk_csz ) ) {
           checkpt->frame_style = -1; /* failed */
           return FD_CHECKPT_ERR_COMP;
         }
@@ -470,442 +589,4 @@ fd_checkpt_buf( fd_checkpt_t * checkpt,
 
   checkpt->off = off;
   return FD_CHECKPT_SUCCESS;
-}
-
-fd_restore_t *
-fd_restore_init_stream( void * mem,
-                        int    fd,
-                        void * rbuf,
-                        ulong  rbuf_sz ) {
-
-  /* Check input args */
-
-  if( FD_UNLIKELY( !mem ) ) {
-    FD_LOG_WARNING(( "NULL mem" ));
-    return NULL;
-  }
-
-  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)mem, FD_RESTORE_ALIGN ) ) ) {
-    FD_LOG_WARNING(( "misaligned mem" ));
-    return NULL;
-  }
-
-  if( FD_UNLIKELY( fd<0 ) ) {
-    FD_LOG_WARNING(( "bad fd" ));
-    return NULL;
-  }
-
-  if( FD_UNLIKELY( !rbuf ) ) {
-    FD_LOG_WARNING(( "NULL rbuf" ));
-    return NULL;
-  }
-
-  if( FD_UNLIKELY( rbuf_sz<FD_RESTORE_RBUF_MIN ) ) {
-    FD_LOG_WARNING(( "rbuf_sz too small" ));
-    return NULL;
-  }
-
-  /* Create decompressor */
-
-# if FD_HAS_LZ4
-  LZ4_streamDecode_t * lz4 = LZ4_createStreamDecode();
-  if( FD_UNLIKELY( !lz4 ) ) {
-    FD_LOG_WARNING(( "lz4 error" ));
-    return NULL;
-  }
-# else
-  void * lz4 = NULL;
-# endif
-
-  /* Init restore */
-
-  fd_restore_t * restore = (fd_restore_t *)mem;
-
-  restore->fd          = fd; /* streaming mode */
-  restore->frame_style = 0;  /* not in frame */
-  restore->lz4         = lz4;
-  restore->rbuf.mem    = rbuf;
-  restore->rbuf.sz     = rbuf_sz;
-  restore->rbuf.lo     = 0UL;
-  restore->rbuf.ready  = 0UL;
-
-  return restore;
-}
-
-fd_restore_t *
-fd_restore_init_mmio( void *       mem,
-                      void const * mmio,
-                      ulong        mmio_sz ) {
-
-  /* Check input args */
-
-  if( FD_UNLIKELY( !mem ) ) {
-    FD_LOG_WARNING(( "NULL mem" ));
-    return NULL;
-  }
-
-  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)mem, FD_RESTORE_ALIGN ) ) ) {
-    FD_LOG_WARNING(( "misaligned mem" ));
-    return NULL;
-  }
-
-  if( FD_UNLIKELY( (!mmio) & (!!mmio_sz) ) ) {
-    FD_LOG_WARNING(( "NULL mmio with non-zero mmio_sz" ));
-    return NULL;
-  }
-
-  /* Create decompressor */
-
-# if FD_HAS_LZ4
-  LZ4_streamDecode_t * lz4 = LZ4_createStreamDecode();
-  if( FD_UNLIKELY( !lz4 ) ) {
-    FD_LOG_WARNING(( "lz4 error" ));
-    return NULL;
-  }
-# else
-  void * lz4 = NULL;
-# endif
-
-  /* Init restore */
-
-  fd_restore_t * restore = (fd_restore_t *)mem;
-
-  restore->fd          = -1; /* mmio mode */
-  restore->frame_style = 0;  /* not in frame */
-  restore->lz4         = lz4;
-  restore->mmio.mem    = (char const *)mmio;
-  restore->mmio.sz     = mmio_sz;
-  restore->mmio.off    = 0UL;
-
-  return restore;
-}
-
-void *
-fd_restore_fini( fd_restore_t * restore ) {
-
-  if( FD_UNLIKELY( !restore ) ) {
-    FD_LOG_WARNING(( "NULL restore" ));
-    return NULL;
-  }
-
-  if( FD_UNLIKELY( fd_restore_private_in_frame( restore ) ) ) {
-    FD_LOG_WARNING(( "in a frame" ));
-    restore->frame_style = -1; /* failed */
-    return NULL;
-  }
-
-# if FD_HAS_LZ4
-
-  /* Note: Though this this doesn't seem to be officially documented,
-     the LZ4-1.9.4 source code (lz4/lib/lz4.c:2575) suggests that this
-     always returns 0.  That is, 0 is success and non-zero is failure. */
-
-  if( FD_UNLIKELY( LZ4_freeStreamDecode( (LZ4_streamDecode_t *)restore->lz4 ) ) )
-    FD_LOG_WARNING(( "LZ4 freeStreamDecode error, attempting to continue" ));
-
-# endif
-
-  return restore;
-}
-
-int
-fd_restore_frame_open( fd_restore_t * restore,
-                       int            frame_style ) {
-
-  if( FD_UNLIKELY( !restore ) ) {
-    FD_LOG_WARNING(( "NULL restore" ));
-    return FD_CHECKPT_ERR_INVAL;
-  }
-
-  if( FD_UNLIKELY( fd_restore_private_in_frame( restore ) ) ) {
-    FD_LOG_WARNING(( "in a frame" ));
-    restore->frame_style = -1; /* failed */
-    return FD_CHECKPT_ERR_INVAL;
-  }
-
-  frame_style = fd_int_if( !!frame_style, frame_style, FD_CHECKPT_FRAME_STYLE_DEFAULT );
-
-  switch( frame_style ) {
-
-  case FD_CHECKPT_FRAME_STYLE_RAW: {
-    break;
-  }
-
-# if FD_HAS_LZ4
-  case FD_CHECKPT_FRAME_STYLE_LZ4: {
-    if( FD_UNLIKELY( !LZ4_setStreamDecode( (LZ4_streamDecode_t *)restore->lz4, NULL, 0 ) ) ) {
-      FD_LOG_WARNING(( "LZ4_setStreamDecode failed" ));
-      restore->frame_style = -1; /* failed */
-      return FD_CHECKPT_ERR_COMP;
-    }
-    break;
-  }
-# endif
-
-  default: {
-    FD_LOG_WARNING(( "unsupported frame_style" ));
-    restore->frame_style = -1; /* failed */
-    return FD_CHECKPT_ERR_UNSUP;
-  }
-
-  }
-
-  restore->frame_style = frame_style;
-  return FD_CHECKPT_SUCCESS;
-}
-
-int
-fd_restore_frame_close( fd_restore_t * restore ) {
-
-  if( FD_UNLIKELY( !restore ) ) {
-    FD_LOG_WARNING(( "NULL restore" ));
-    return FD_CHECKPT_ERR_INVAL;
-  }
-
-  if( FD_UNLIKELY( !fd_restore_private_in_frame( restore ) ) ) {
-    FD_LOG_WARNING(( "not in a frame" ));
-    restore->frame_style = -1; /* failed */
-    return FD_CHECKPT_ERR_INVAL;
-  }
-
-  restore->frame_style = 0;
-  return FD_CHECKPT_SUCCESS;
-}
-
-int
-fd_restore_buf( fd_restore_t * restore,
-                void *         buf,
-                ulong          sz ) {
-
-  if( FD_UNLIKELY( !restore ) ) {
-    FD_LOG_WARNING(( "NULL restore" ));
-    return FD_CHECKPT_ERR_INVAL;
-  }
-
-  if( FD_UNLIKELY( !fd_restore_private_in_frame( restore ) ) ) {
-    FD_LOG_WARNING(( "not in a frame" ));
-    restore->frame_style = -1; /* failed */
-    return FD_CHECKPT_ERR_INVAL;
-  }
-
-  if( FD_UNLIKELY( !sz ) ) return FD_CHECKPT_SUCCESS; /* nothing to do */
-
-  if( FD_UNLIKELY( !buf ) ) {
-    FD_LOG_WARNING(( "NULL buf with non-zero sz" ));
-    restore->frame_style = -1; /* failed */
-    return FD_CHECKPT_ERR_INVAL;
-  }
-
-  switch( restore->frame_style ) {
-
-  case FD_CHECKPT_FRAME_STYLE_RAW: {
-
-    if( fd_restore_private_is_mmio( restore ) ) { /* mmio mode, app dependent branch prob */
-
-      ulong mmio_sz  = restore->mmio.sz;
-      ulong mmio_off = restore->mmio.off;
-
-      if( FD_UNLIKELY( sz > (mmio_sz-mmio_off) ) ) {
-        FD_LOG_WARNING(( "sz overflow" ));
-        restore->frame_style = -1; /* failed */
-        return FD_CHECKPT_ERR_IO;
-      }
-
-      memcpy( buf, restore->mmio.mem + mmio_off, sz );
-
-      restore->mmio.off = mmio_off + sz;
-
-    } else { /* streaming mode */
-
-      int err = fd_io_buffered_read( restore->fd, buf, sz, restore->rbuf.mem, restore->rbuf.sz,
-                                     &restore->rbuf.lo, &restore->rbuf.ready );
-
-      if( FD_UNLIKELY( err ) ) {
-        FD_LOG_WARNING(( "fd_io_buffered_read failed (%i-%s)", err, fd_io_strerror( err ) ));
-        restore->frame_style = -1; /* failed */
-        return FD_CHECKPT_ERR_IO;
-      }
-
-    }
-
-    break;
-  }
-
-# if FD_HAS_LZ4
-  case FD_CHECKPT_FRAME_STYLE_LZ4: {
-
-    LZ4_streamDecode_t * lz4 = (LZ4_streamDecode_t *)restore->lz4;
-
-    if( fd_restore_private_is_mmio( restore ) ) { /* mmio mode */
-
-      char const * mmio     = restore->mmio.mem;
-      ulong        mmio_sz  = restore->mmio.sz;
-      ulong        mmio_off = restore->mmio.off;
-
-      char * chunk = (char *)buf;
-      do {
-        ulong mmio_rem = mmio_sz - mmio_off;
-        if( FD_UNLIKELY( !mmio_rem ) ) {
-          FD_LOG_WARNING(( "sz error" ));
-          restore->frame_style = -1; /* failed */
-          return FD_CHECKPT_ERR_IO;
-        }
-
-        ulong chunk_usz     = fd_ulong_min( sz, FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX );
-        ulong chunk_csz_max = FD_CHECKPT_PRIVATE_CSZ_MAX( chunk_usz );
-
-        /* At this point, chunk_usz is in [1,CHUNK_USZ_MAX] and
-           chunk_csz_max is in [0,CSZ_MAX( USZ_MAX )].  chunk_csz_max is
-           also at most the amount of space remaining in the mmio
-           region.
-
-           Note: The LZ4 header doesn't thoroughly document these APIs
-           so we make some guesses.  If we assume no checkpoint
-           corruption or truncation, the fast variant should "just
-           work".  If we don't, when mmio_rem<chunk_csz_max, it looks
-           like the fast variant could read up to chunk_csz_max-mmio_rem
-           bytes past the end of the mmio region.  Though this is
-           reasonably bounded, it is not easy or natural to append a
-           tail reading guard to the end of a memory mapped fail.  So,
-           we fall back the safe variant when we are too close for
-           comfort.  ALSO SEE FIXME IN CHECKPT_BUF MMIO. */
-
-        int _chunk_csz = FD_LIKELY( (chunk_csz_max<=mmio_rem) )
-          ? LZ4_decompress_fast_continue( lz4, mmio + mmio_off, chunk,                (int)chunk_usz )
-          : LZ4_decompress_safe_continue( lz4, mmio + mmio_off, chunk, (int)mmio_rem, (int)chunk_usz );
-        if( FD_UNLIKELY( _chunk_csz<=0 ) ) {
-          FD_LOG_WARNING(( "LZ4_decompress_fast/safe_continue error (%i)", _chunk_csz ));
-          restore->frame_style = -1; /* failed */
-          return FD_CHECKPT_ERR_COMP;
-        }
-
-        ulong chunk_csz = (ulong)_chunk_csz;
-        if( FD_UNLIKELY( chunk_csz>fd_ulong_min( chunk_csz_max, mmio_rem ) ) ) {
-          FD_LOG_WARNING(( "unexpected chunk_csz" ));
-          restore->frame_style = -1; /* failed */
-          return FD_CHECKPT_ERR_COMP;
-        }
-
-        mmio_off += chunk_csz;
-
-        chunk += chunk_usz;
-        sz    -= chunk_usz;
-      } while( sz );
-
-      restore->mmio.off = mmio_off;
-
-    } else { /* streaming mode */
-
-      int    fd         = restore->fd;
-      char * rbuf       = restore->rbuf.mem;
-      ulong  rbuf_sz    = restore->rbuf.sz;
-      ulong  rbuf_lo    = restore->rbuf.lo;
-      ulong  rbuf_ready = restore->rbuf.ready;
-
-      char * chunk = (char *)buf;
-      do {
-        ulong chunk_usz     = fd_ulong_min( sz, FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX );
-        ulong chunk_csz_max = FD_CHECKPT_PRIVATE_CSZ_MAX( chunk_usz );
-
-        /* At this point, chunk_usz is in [1,CHUNK_USZ_MAX] and
-           chunk_csz_max is in [1,CSZ_MAX(CHUNK_USZ_MAX)].  If we don't
-           have enough bytes buffered from the file to guarantee
-           successful decompression, read more from the file. */
-
-        if( FD_UNLIKELY( rbuf_ready < chunk_csz_max ) ) {
-
-          /* Move the unprocessed bytes to the beginning of the buffer */
-
-          memmove( rbuf, rbuf+rbuf_lo, rbuf_ready );
-
-          /* Try to read at least enough bytes to get to chunk_csz_max
-             unprocessed bytes into rbuf and at most enough bytes to
-             fill up the read buffer. */
-
-          ulong rsz;
-          int   err = fd_io_read( fd, rbuf+rbuf_ready, chunk_csz_max-rbuf_ready, rbuf_sz-rbuf_ready, &rsz );
-          if( FD_UNLIKELY( err>0 ) ) {
-            FD_LOG_WARNING(( "fd_io_read failed (%i-%s)", err, fd_io_strerror( err ) ));
-            restore->frame_style = -1; /* failed */
-            return FD_CHECKPT_ERR_IO;
-          }
-          rbuf_ready += rsz;
-
-          rbuf_lo = 0UL;
-
-          /* At this point, if we didn't hit eof (err==0), we have at
-             least chunk_csz_max unprocessed bytes in rbuf.
-
-             If we hit eof (err<0) before getting to at least
-             chunk_csz_max unprocessed bytes in rbuf, rbuf_ready should
-             be still enough to decompress this block if there was no
-             file corruption.
-
-             If we hit eof prematurely due to file corruption though,
-             decompression should not crash (the decompressor will not
-             touch more than chunk_csz_max and rbuf has a size of
-             rbuf_sz >= RBUF_MIN >= CSZ_MAX( CHUNK_CSZ_MAX ) >=
-             chunk_csz_max).  The decompressed result will almost
-             certainly be corrupt (and potentially previous restores in
-             this frame were too as we don't know when the corruption
-             occurred).  We can detect this adjusting chunk_csz_max to
-             the number of bytes available to eof.
-
-             ALSO SEE FIXME IN CHECKPT_BUF MMIO. */
-
-          chunk_csz_max = fd_ulong_min( chunk_csz_max, rbuf_ready );
-        }
-
-        int _chunk_csz = LZ4_decompress_fast_continue( lz4, rbuf + rbuf_lo, chunk, (int)chunk_usz );
-        if( FD_UNLIKELY( _chunk_csz<=0 ) ) {
-          FD_LOG_WARNING(( "LZ4 decompress_fast_continue failed (%i)", _chunk_csz ));
-          restore->frame_style = -1; /* failed */
-          return FD_CHECKPT_ERR_COMP;
-        }
-
-        ulong chunk_csz = (ulong)_chunk_csz;
-        if( FD_UNLIKELY( chunk_csz>chunk_csz_max ) ) {
-          FD_LOG_WARNING(( "unexpected chunk_csz" ));
-          restore->frame_style = -1; /* failed */
-          return FD_CHECKPT_ERR_COMP;
-        }
-
-        rbuf_lo    += chunk_csz;
-        rbuf_ready -= chunk_csz;
-
-        chunk += chunk_usz;
-        sz    -= chunk_usz;
-      } while( sz );
-
-      restore->rbuf.lo    = rbuf_lo;
-      restore->rbuf.ready = rbuf_ready;
-
-    }
-
-    break;
-  }
-# endif
-
-  default: { /* never get here */
-    FD_LOG_WARNING(( "unsupported frame style" ));
-    restore->frame_style = -1; /* failed */
-    return FD_CHECKPT_ERR_UNSUP;
-  }
-
-  }
-
-  return FD_CHECKPT_SUCCESS;
-}
-
-char const *
-fd_checkpt_strerror( int err ) {
-  switch( err ) {
-  case FD_CHECKPT_SUCCESS:   return "success";
-  case FD_CHECKPT_ERR_INVAL: return "bad input args";
-  case FD_CHECKPT_ERR_UNSUP: return "unsupported on this target";
-  case FD_CHECKPT_ERR_IO:    return "io error";
-  case FD_CHECKPT_ERR_COMP:  return "compression error";
-  default: break;
-  }
-  return "unknown";
 }

--- a/src/util/checkpt/fd_checkpt.h
+++ b/src/util/checkpt/fd_checkpt.h
@@ -1,0 +1,507 @@
+#ifndef HEADER_fd_src_util_checkpt_fd_checkpt_h
+#define HEADER_fd_src_util_checkpt_fd_checkpt_h
+
+/* APIs for fast parallel compressed checkpoint and restore.  Concepts:
+
+   - A checkpoint contains of zero or more frames.
+
+   - Each frame resides in a disjoint contiguous sequence of bytes in
+     the checkpoint and contains a sequence of zero of more data
+     buffers.
+
+   - Data buffers can have (up to physical limitation) arbitrary
+     variable byte size.
+
+   - A frame can have a style of either RAW or LZ4.
+   
+   - Buffers in a RAW frame are stored verbatim with no gaps.  As such,
+     the space needed for a raw frame and the location of buffers in a
+     raw frame can computed exactly up front.
+
+   - Buffers in a LZ4 frame are stored via LZ4 streaming compression.  A
+     worst case upper bound for the space needed for a LZ4 can be
+     computed up front, roughly:
+
+       (256/255) total_sz_all_buffers + 16 buffer_count.
+
+     The location of buffers in LZ4 frame is not practically computable
+     in advance and decompression of a buffer in a frame depends on
+     previous buffers in that frame.
+
+   - Checkpoints can be read and written in a streaming IO mode or in a
+     memory IO mode with the exact same APIs (i.e. no changes to the
+     calling code outside of specifying the mode when starting a
+     checkpoint or a restore).  The checkpoint and restore processes
+     will produce bit-level identical results regardless of mode.
+     
+   - Frames are independent such that different frames can be generated
+     in parallel.  Each frame generated will be bit-level identical
+     regardless how generation is distributed over threads.
+
+   - Similarly, frames can restored in parallel.  The restored results
+     will be bit-level identical regardles how restoration is
+     distributed over threads.
+
+   - As such, arbitrary streaming / mmio serial/parallel operation is
+     fine (e.g. have a single thread write checkpoint file in streaming
+     I/O and then use multiple threads to restore from that checkpoint
+     file in memory mapped I/O). */
+
+#include "../log/fd_log.h"
+
+/* FD_CHECKPT_SUCCESS / FD_CHECKPT_ERR_* are return values from various
+   fd_checkpt APIs.  SUCCESS is zero and ERR_* are negative integers. */
+
+#define FD_CHECKPT_SUCCESS   (0)  /* operation was successful */
+#define FD_CHECKPT_ERR_INVAL (-1) /* operation failed because bad input arguments */
+#define FD_CHECKPT_ERR_UNSUP (-2) /* operation failed because it is unsupported on this target */
+#define FD_CHECKPT_ERR_IO    (-3) /* operation failed because an I/O error occurred */
+#define FD_CHECKPT_ERR_COMP  (-4) /* operation failed because a compressor/decompressor error occurred */
+
+/* FD_CHECKPT_FRAME_STYLE_* specify a checkpoint frame style.  These are
+   positive integers. */
+
+#define FD_CHECKPT_FRAME_STYLE_RAW (1) /* uncompressed   frame */
+#define FD_CHECKPT_FRAME_STYLE_LZ4 (2) /* lz4 compressed frame */
+
+#define FD_CHECKPT_FRAME_STYLE_DEFAULT FD_CHECKPT_FRAME_STYLE_RAW
+
+/* FD_CHECKPT_WBUF_MIN is the minimum write buffer size needed by a
+   fd_checkpt_t in streaming mode.  Must be at least 65810 ~
+     FD_CHECKPT_PRIVATE_CSZ_MAX( FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX ) */
+
+#define FD_CHECKPT_WBUF_MIN (69632UL) /* 68 KiB */
+
+/* FD_CHECKPT_{ALIGN,FOOTPRINT} give the required {alignment,footprint}
+   of a memory region suitable for use as a fd_checkpt_t. */
+
+#define FD_CHECKPT_ALIGN     alignof( fd_checkpt_t )
+#define FD_CHECKPT_FOOTPRINT sizeof(  fd_checkpt_t )
+
+/* A fd_checkpt_t a semi-opaque handle of an in-progress checkpoint (a
+   stack or global declaration of an fd_checkpt_t is sufficient to get
+   the correct alignment and footprint). */
+
+struct fd_checkpt_private;
+typedef struct fd_checkpt_private fd_checkpt_t;
+
+/* FD_RESTORE_RBUF_MIN is the minimum read buffer size needed by a
+   fd_restore_t in streaming mode.  Must be at least
+   FD_CHECKPT_WBUF_MIN. */
+
+#define FD_RESTORE_RBUF_MIN FD_CHECKPT_WBUF_MIN
+
+/* FD_RESTORE_{ALIGN,FOOTPRINT} give the required {alignment,footprint}
+   of a memory region suitable for use as a fd_restore_t. */
+
+#define FD_RESTORE_ALIGN     alignof( fd_restore_t )
+#define FD_RESTORE_FOOTPRINT sizeof(  fd_restore_t )
+
+/* A fd_restore_t a semi-opaque handle of an in-progress restore (a
+   stack or global declaration of an fd_restore_t is sufficient to get
+   the correct alignment and footprint). */
+
+struct fd_restore_private;
+typedef struct fd_restore_private fd_restore_t;
+
+/* Internal use only **************************************************/
+
+/* These are exposed to facilitate things like stack declaration */
+
+/* FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX is the maximum amount of checkpt
+   data fed into the underlying compressor at a time.  Should be much
+   less than LZ4_MAX_INPUT_SIZE . */
+
+#define FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX (65536UL)
+
+/* FD_CHECKPT_PRIVATE_CSZ_MAX returns an reasonably tight upper bound to
+   the number of compressed output bytes given usz uncompressed input
+   bytes.  Assumes usz <= FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX and usz is
+   safe against multiple evaluation.  (This is the same as
+   LZ4_COMPRESSBOUND but with ulong typing and usz assumption.) */
+
+#define FD_CHECKPT_PRIVATE_CSZ_MAX(usz) ((usz) + ((usz)/255UL) + 16UL)
+
+FD_STATIC_ASSERT( FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX <= (1<<30), adjust_comp_limits );
+FD_STATIC_ASSERT( FD_CHECKPT_WBUF_MIN >= FD_CHECKPT_PRIVATE_CSZ_MAX( FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX ), adjust_buf_limits );
+FD_STATIC_ASSERT( FD_RESTORE_RBUF_MIN >= FD_CHECKPT_WBUF_MIN, adjust_buf_limits );
+
+/* fd_checkpt_t internals */
+
+struct fd_checkpt_private_wbuf { /* very similar to fd_io_buffered_ostream */
+  char * mem;  /* Buffer of compressed bytes not yet written to fd, byte indexed [0,wbuf_sz) */
+  ulong  sz;   /* Buffer size in bytes, >=FD_CHECKPT_WBUF_MIN */
+  ulong  used; /* Buffer bytes [0,wbuf_used) are not yet written to fd,
+                  buffer bytes [wbuf_used,wbuf_sz) are free */
+};
+
+typedef struct fd_checkpt_private_wbuf fd_checkpt_private_wbuf_t;
+
+struct fd_checkpt_private_mmio { /* very similar to fd_io_buffered_ostream */
+  char * mem;  /* Buffer of compressed bytes not yet written to fd, byte indexed [0,wbuf_sz) */
+  ulong  sz;   /* Buffer size in bytes, >=FD_CHECKPT_WBUF_MIN */
+  ulong  used; /* Buffer bytes [0,wbuf_used) are not yet written to fd,
+                  buffer bytes [wbuf_used,wbuf_sz) are free */
+};
+
+typedef struct fd_checkpt_private_mmio fd_checkpt_private_mmio_t;
+
+struct fd_checkpt_private {
+  int    fd;          /* (stream) File descriptor for the checkpt (>=0), (mmio) -1 */
+  int    frame_style; /* FD_CHECKPT_FRAME_STYLE_* (>0), 0: not in frame (valid), -1: not in frame (failed) */
+  void * lz4;         /* Handle of the underlying compressor */
+  ulong  off;         /* Offset of the next byte to write (relative to the checkpoint first byte), in [0,mmio_sz) in mmio mode */
+  union {
+    fd_checkpt_private_wbuf_t wbuf; /* used in streaming mode */
+    fd_checkpt_private_mmio_t mmio; /* used in mmio mode */
+  };
+};
+
+/* fd_restore_t internals */
+
+struct fd_restore_private_rbuf { /* very similar to fd_io_buffered_istream */
+  char * mem;   /* Buffer of compressed bytes read from fd, byte indexed [0,rbuf_sz) */
+  ulong  sz;    /* Buffer size in bytes, >=FD_RESTORE_RBUF_MIN */
+  ulong  lo;    /* Buffer bytes [0,rbuf_lo) have been read and restored */
+  ulong  ready; /* Number of compressed bytes that haven't been processed, 0<=rbuf_lo<=(rbuf_lo+rbuf_ready)<=rbuf_sz */
+};
+
+typedef struct fd_restore_private_rbuf fd_restore_private_rbuf_t;
+
+struct fd_restore_private_mmio { /* very similar to fd_io_buffered_istream */
+  char const * mem; /* Checkpoint memory region */
+  ulong        sz;  /* Checkpoint memory region size in bytes */
+  ulong        off; /* Offset of next byte to process relative to mmio, in [0,mmio_sz) */
+};
+
+typedef struct fd_restore_private_mmio fd_restore_private_mmio_t;
+
+struct fd_restore_private {
+  int    fd;          /* (stream) File descriptor for the restore (>=0), (mmio) -1 */
+  int    frame_style; /* FD_CHECKPT_FRAME_STYLE_* (>0), 0: not in frame (valid), -1: not in frame (failed) */
+  void * lz4;         /* Handle of the underlying decompressor used */
+  union {
+    fd_restore_private_rbuf_t rbuf; /* used in streaming mode */
+    fd_restore_private_mmio_t mmio; /* used in mmio mode */
+  };
+};
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_{checkpt,restore}_private_is_mmio returns 0/1 if in streaming/mmio
+   mode.  Assumes {checkpt,restore} is valid. */
+
+FD_FN_PURE static inline int fd_checkpt_private_is_mmio( fd_checkpt_t const * checkpt ) { return checkpt->fd<0; }
+FD_FN_PURE static inline int fd_restore_private_is_mmio( fd_restore_t const * restore ) { return restore->fd<0; }
+
+/* fd_{checkpt,restore}_private_in_frame returns 0/1 if is not/is in a
+   frame.  Assumes {checkpt,restore} is valid. */
+
+FD_FN_PURE static inline int fd_checkpt_private_in_frame( fd_checkpt_t const * checkpt ) { return checkpt->frame_style>0; }
+FD_FN_PURE static inline int fd_restore_private_in_frame( fd_restore_t const * restore ) { return restore->frame_style>0; }
+
+FD_PROTOTYPES_END
+
+/* End internal use only **********************************************/
+
+FD_PROTOTYPES_BEGIN
+
+/* Checkpt APIs *******************************************************/
+
+/* fd_checkpt_init_stream formats a memory region, mem, with suitable
+   alignment and footprint into a fd_checkpt_t (a pointer to a stack
+   declared fd_checkpt_t is fine).  fd is an open normal-ish file
+   descriptor to which the checkpoint should be streamed.  wbuf points
+   to the first byte in the caller's address space to an unused wbuf_sz
+   byte size memory region to use for write buffering.  wbuf_sz should
+   be at least FD_CHECKPT_WBUF_MIN.
+
+   On success, returns mem formatted as a fd_checkpt_t in streaming
+   mode.  On return, the fd_checkpt_t will be valid, not in a frame and
+   will have ownership of mem, fd, and wbuf.
+
+   On failure, returns NULL (logs details).  No ownership changed. */
+
+fd_checkpt_t *
+fd_checkpt_init_stream( void * mem,
+                        int    fd,
+                        void * wbuf,
+                        ulong  wbuf_sz );
+
+/* fd_checkpt_init_mmio is the same as fd_checkpt_init_stream but
+   checkpoints frames into a mmio_sz byte sized memory region whose
+   first byte in the caller the local address space is pointed to by
+   mmio. */
+
+fd_checkpt_t *
+fd_checkpt_init_mmio( void * mem,
+                      void * mmio,
+                      ulong  mmio_sz );
+
+/* fd_checkpt_fini finishes a checkpoint.  checkpt should be valid and
+   not in a frame.
+
+   On success, returns mem.  On return, checkpt is no longer valid and
+   the caller will have ownership of mem, fd and wbuf (streaming mode)
+   or mem and mmio (mmio mode).
+
+   On failure, returns NULL (logs details).  Reasons for failure include
+   NULL checkpt and checkpt in a frame.  The checkpt (and underlying fd
+   in streaming mode) should be considered failed (i.e. checkpt no
+   longer has any interest in checkpointed data and the user should only
+   fini checkpt, close fd in streaming mode and discard the failed
+   checkpoint). */
+
+void *
+fd_checkpt_fini( fd_checkpt_t * checkpt );
+
+/* fd_checkpt_frame_open_advanced opens a new frame.  Different frames
+   in a checkpoint can be restored in parallel.  frame_style is a
+   FD_CHECKPT_FRAME_STYLE_* that specifies the style of frame to output
+   (0 indicates to use FD_CHECKPT_FRAME_STYLE_DEFAULT).  checkpt should
+   be valid and not currently in a frame.
+   
+   On success, returns FD_CHECKPT_SUCCESS (0).  On return, *_off will
+   contain the offset of this frame from the beginning of the
+   checkpoint.  This is to allow parallel restore threads to jump to
+   frames they are assigned to restore.  Retains no interest in
+   _off.
+
+   On failure, logs details and returns a FD_CHECKPT_ERR (negative).
+   *_off will be untouched.  Retains no interest in _off.  Reasons for
+   failure include INVAL (NULL checkpt, in a frame) and UNSUP
+   (unsupported frame style on this target).  The checkpt (and
+   underlying fd in streaming mode) should be considered failed (i.e.
+   the checkpt no longer has any interest in checkpointed data and the
+   user should only fini checkpt, close fd in streaming mode and discard
+   the failed checkpoint).
+
+   IMPORTANT SAFETY TIP!  The returned offset is relative to the start
+   of the _checkpoint_, _not_ the start of the _file_.  These are often
+   the same but do not have to be (e.g. writing a checkpoint to an
+   unseekable file descriptor like stdout, the caller has already
+   written other data to the file descriptor before starting the
+   checkpoint, etc).
+
+   IMPORTANT SAFETY TIP!  Compression ratios for compressed frames can
+   optimized by putting similar items into the same frame.
+   
+   fd_checkpt_frame_open is a convenience for when the frame offset
+   isn't needed. */
+
+int
+fd_checkpt_frame_open_advanced( fd_checkpt_t * checkpt,
+                                int            frame_style,
+                                ulong *        _off );
+
+static inline int
+fd_checkpt_frame_open( fd_checkpt_t * checkpt,
+                       int            frame_style ) {
+  ulong off;
+  return fd_checkpt_frame_open_advanced( checkpt,frame_style, &off );
+}
+
+/* fd_checkpt_frame_close_advanced closes the current frame.  checkpt
+   should be valid and in a frame.
+
+   On success, returns FD_CHECKPT_SUCCESS (0).  On return, *_off will
+   contain the offset of one past the last byte of the just closed
+   frame.  That is, [off_open,off_close) specify the range bytes
+   relative to the start of the checkpoint used by this frame and
+   off_close-off_open is the frame byte count.  This is to faciliate
+   parallel checkpoint writing and then concatentating results from
+   different threads into compact checkpoint.  checkpt will no longer
+   have any interest in checkpointed data or in _off.
+
+   On failure, logs details and returns a FD_CHECKPT_ERR (negative).  On
+   return, *_off will be untouched and checkpoint will have no inteest
+   in opt_off.  Reasons for failure include INVAL (NULL checkpt, not in
+   a frame) and IO (write failed, too many bytes written).  The checkpt
+   (and underlying fd in streaming mode) should be considered failed
+   (i.e.  the checkpt no longer has any interest in checkpointed data
+   and the user should only fini checkpt, close fd in streaming mode and
+   discard the failed checkpoint).
+
+   fd_checkpt_frame_close is a convenience for when the frame offset
+   isn't needed. */
+
+int
+fd_checkpt_frame_close_advanced( fd_checkpt_t * checkpt,
+                                 ulong *        _off );
+
+static inline int
+fd_checkpt_frame_close( fd_checkpt_t * checkpt ) {
+  ulong off;
+  return fd_checkpt_frame_close_advanced( checkpt, &off );
+}
+
+/* fd_checkpt_buf checkpoints the sz byte memory region whose first byte
+   in the caller's local address space is pointed to by buf.  checkpt
+   should be valid and in a frame.  sz==0 is fine (and buf==NULL if
+   sz==0 is also fine).
+
+   On success, returns FD_CHECKPT_SUCCESS (0).  IMPORTANT SAFETY TIP!
+   checkpt retains an interest in buf until the frame is closed (e.g.
+   buf should continue to exist unchanged until the frame is closed).
+   AMONG OTHER THINGS, THIS MEANS IT IS UNSAFE TO GATHER DATA INTO A
+   TEMP BUFFER, CHECKPT THE TEMP BUFFER AND THEN FREE / REUSE THAT TEMP
+   BUFFER BEFORE THE FRAME IS CLOSED!
+
+   On failure, logs details and returns a FD_CHECKPT_ERR (negative).
+   Reasons for failure include INVAL (NULL checkpt, not in a frame, NULL
+   buf with a non-zero sz), IO (write failed, too many bytes written)
+   and COMP (compressor error).  The checkpt (and underlying fd in
+   streaming mode) should be considered failed (i.e. should only fini
+   checkpt, close fd in streaming mode and discard the failed
+   checkpoint). */
+
+int
+fd_checkpt_buf( fd_checkpt_t * checkpt,
+                void const *   buf,
+                ulong          sz );
+
+/* Restore APIs *******************************************************/
+
+/* fd_restore_init_stream formats a memory region, mem, with suitable
+   alignment and footprint into a fd_restore_t in streaming mode (a
+   pointer to a stack declared fd_restore_t is fine).  fd is an open
+   normal-ish file descriptor positioned at the start of the first
+   checkpoint frame to read.  rbuf points to the first byte in the
+   caller's address space to an unused rbuf_sz byte size memory region
+   to use for read buffering.  rbuf_sz should be at least
+   FD_RESTORE_RBUF_MIN (it does _not_ need to match the wbuf_sz used to
+   make the checkpoint).
+
+   On success, returns mem formatted as a fd_restore_t.  On return, the
+   fd_restore_t will be valid, not in a frame and will have ownership of
+   mem, fd, and rbuf.
+
+   On failure, returns NULL (logs details).  No ownership changed. */
+
+fd_restore_t *
+fd_restore_init_stream( void * mem,
+                        int    fd,
+                        void * rbuf,
+                        ulong  rbuf_sz );
+
+/* fd_restore_init_mmio is the same as fd_restore_init_stream but the
+   frames to restore have been memory mapped into the mmio_sz byte
+   memory region whose first byte in the caller the local address space
+   is pointed to by mmio. */
+
+fd_restore_t *
+fd_restore_init_mmio( void *       mem,
+                      void const * mmio,
+                      ulong        mmio_sz );
+
+/* fd_restore_fini finishes restoring from a checkpoint.  restore should
+   be valid and not in a frame.
+
+   On success, returns mem.  On return, restore is no longer valid and
+   the caller will have ownership of mem, fd and rbuf (streaming mode)
+   or mem and mmio (mmio mode).
+   
+   On failure, returns NULL (logs details).  Reasons for failure include
+   NULL restore and restore in a frame.  The restore (and underlying fd
+   in streaming mode) should be considered failed (i.e. the restore no
+   longer has any interest in restored data and the user should only
+   fini restore and close fd in streaming mode). */
+
+void *
+fd_restore_fini( fd_restore_t * restore );
+
+/* fd_restore_frame_open opens a new checkpoint frame.  Different frames
+   in a checkpoint can be restored in parallel.  frame_style is a
+   FD_CHECKPT_FRAME_STYLE_* that specifies the style of frame to read
+   (0 indicates to use FD_CHECKPT_FRAME_STYLE_DEFAULT).  restore should
+   be valid and not currently in a frame.
+   
+   On success, returns FD_CHECKPT_SUCCESS (0).
+
+   On failure, logs details and returns a FD_CHECKPT_ERR (negative).
+   Reasons for failure include INVAL (NULL restore, in a frame), UNSUP
+   (unsupported frame style on this target) and COMP (decompressor
+   error).  The restore (and underlying fd in streaming mode) should be
+   considered failed (i.e.  the restore no longer has any interest in
+   restored data and the user should only fini restore and close fd in
+   streaming mode).
+
+   IMPORTANT SAFETY TIP!  frame_style should match the frame_style used
+   to when the checkpoint was written.
+
+   IMPORTANT SAFETY TIP!  The sequence of restore_frame_open /
+   restore_buf / restore_frame_close calls should _exactly_ match the
+   sequence of checkpt_frame_open / checkpt_buf / checkpt_frame_close
+   used when the frame was written. */
+
+int
+fd_restore_frame_open( fd_restore_t * restore,
+                       int            frame_style );
+
+/* fd_restore_frame_close closes the current frame.  restore should be
+   valid and in a frame.
+
+   On success, returns FD_CHECKPT_SUCCESS (0).  The restore will no
+   longer have any interest in restored data.
+
+   On failure, logs details and returns a FD_CHECKPT_ERR (negative).
+   Reasons for failure include INVAL (NULL restore, not in a frame).
+   The restore (and underlying fd in streaming mode) should be
+   considered failed (i.e. the restore no longer has any interest in
+   restored data and the user should only fini restore and close fd in
+   streaming mode).
+
+   IMPORTANT SAFETY TIP!  The sequence of restore_frame_open /
+   restore_buf / restore_frame_close calls should _exactly_ match the
+   sequence of checkpt_frame_open / checkpt_buf / checkpt_frame_close
+   used when the frame was created. */
+
+int
+fd_restore_frame_close( fd_restore_t * restore );
+
+/* fd_restore_buf restores sz bytes to the memory region whose first
+   byte in the caller's local address space is pointed to by buf.
+   restore should be valid and in a frame.  sz==0 is fine (and buf==NULL
+   if sz==0 is also fine).
+
+   On success, returns FD_CHECKPT_SUCCESS (0).  On return, buf will
+   contain the restored data (FIXME: consider not guaranteeing
+   availability of the restored buf until the frame is closed).
+   IMPORTANT SAFETY TIP!  restore retains an interest in buf until the
+   frame is closed (e.g. buf should continue to exist unchanged until
+   the frame is closed).  AMONG OTHER THINGS, THIS IMPLIES RESTORE
+   MEMORY REGIONS SHOULD NOT OVERLAP AND THAT IT IS UNSAFE TO RESTORE TO
+   A TEMP BUFFER, SCATTER DATA FROM THE TEMP BUFFER AND THEN FREE /
+   REUSE THAT TEMP BUFFER BEFORE THE FRAME IS CLOSED!
+
+   On failure, logs details and returns a FD_CHECKPT_ERR (negative).
+   Reasons for failure include INVAL (NULL restore, not in a frame, NULL
+   buf with a non-zero sz), IO (read failed, too many bytes read) and
+   COMP (decompressor error).  The restore (and underlying fd in
+   streaming mode) should be considered failed (i.e. the restore no
+   longer has any interest in restored data and the user should only
+   fini restore and close fd in streaming mode).
+
+   IMPORTANT SAFETY TIP!  The sequence of restore_frame_open /
+   restore_buf / restore_frame_close calls should _exactly_ match the
+   sequence of checkpt_frame_open / checkpt_buf / checkpt_frame_close
+   used when the frame was created. */
+
+int
+fd_restore_buf( fd_restore_t * restore,
+                void *         buf,
+                ulong          sz );
+
+/* Misc APIs **********************************************************/
+
+/* fd_checkpt_strerror converts an FD_CHECKPT_SUCCESS / FD_CHECKPT_ERR_*
+   code into a human readable cstr.  The lifetime of the returned
+   pointer is infinite.  The returned pointer is always to a non-NULL
+   cstr. */
+
+char const *
+fd_checkpt_strerror( int err );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_util_checkpt_fd_checkpt_h */

--- a/src/util/checkpt/fd_restore.c
+++ b/src/util/checkpt/fd_restore.c
@@ -1,0 +1,506 @@
+#include "fd_checkpt.h"
+
+#if FD_HAS_LZ4
+#include <lz4.h>
+
+/* fd_restore_private_lz4 decompresses the cbuf_max memory region
+   pointed to by cbuf into the ubuf_usz memory region pointed to by ubuf
+   using the given lz4 decompressor.  Assumes lz4, ubuf and cbuf are
+   valid and assumes ubuf_usz matches the corresponding
+   fd_checkpt_private_lz4 call and cbuf is valid.  On success, returns
+   the number of leading bytes cbuf bytes that were used for the
+   decompression (will be in [4,cbuf_max]) and the ubuf should not
+   be modified until the stream is reset, closed or an additional 64 KiB
+   has been decompressed.  On failure, returns 0 and retains no interest
+   in ubuf.  In either case, this retains no interest in cbuf on return.
+
+   _sbuf, sbuf_sz, sbuf_thresh, _sbuf_cursor specify the small buf
+   scatter ring state.  See fd_checkpt_private_lz4 for more details. */
+
+static ulong
+fd_restore_private_lz4( LZ4_streamDecode_t * lz4,
+                        void *               _ubuf,
+                        ulong                ubuf_usz,
+                        void const *         _cbuf,
+                        ulong                cbuf_max,
+                        void *               _sbuf,
+                        ulong                sbuf_sz,
+                        ulong                sbuf_thresh,
+                        ulong *              _sbuf_cursor ) {
+  char *       ubuf = (char *)      _ubuf;
+  char const * cbuf = (char const *)_cbuf;
+
+  /* Verify ubuf_usz is in [1,LZ4_MAX_INPUT_SIZE] and cbuf_max is large
+     enough to store a header and a non-trivial compressed body. */
+
+  if( FD_UNLIKELY( !((1UL<=ubuf_usz) & (ubuf_usz<=(ulong)LZ4_MAX_INPUT_SIZE)) ) ) {
+    FD_LOG_WARNING(( "bad ubuf_usz" ));
+    return 0UL;
+  }
+
+  if( FD_UNLIKELY( cbuf_max<4UL ) ) {
+    FD_LOG_WARNING(( "not enough room to compress" ));
+    return 0UL;
+  }
+
+  /* Restore and validate header */
+
+  if( FD_UNLIKELY( cbuf_max<4UL ) ) { /* 3 bytes for header, 1 byte minimum for body */
+    FD_LOG_WARNING(( "truncated header" ));
+    return 0UL;
+  }
+
+  ulong ubuf_csz = (((ulong)(uchar)cbuf[0])      )
+                 | (((ulong)(uchar)cbuf[1]) <<  8)
+                 | (((ulong)(uchar)cbuf[2]) << 16); /* In [1,2^24) */
+
+  ulong cbuf_sz  = ubuf_csz + 3UL;
+  if( FD_UNLIKELY( !((4UL<=cbuf_sz) | (cbuf_sz<=FD_CHECKPT_PRIVATE_CSZ_MAX( ubuf_usz ))) ) ) {
+    FD_LOG_WARNING(( "corrupt header" ));
+    return 0UL;
+  }
+
+  if( FD_UNLIKELY( cbuf_sz>cbuf_max ) ) {
+    FD_LOG_WARNING(( "truncated checkpt" ));
+    return 0UL;
+  }
+
+  /* Small ubuf scatter optimization.  See note in
+     fd_checkpt_private_lz4 for details. */
+
+  int is_small = ubuf_usz<sbuf_thresh;
+  if( is_small ) { /* app dependent branch prob */
+    ulong sbuf_cursor = *_sbuf_cursor;
+    if( (sbuf_sz-sbuf_cursor)<ubuf_usz ) sbuf_cursor = 0UL; /* cmov */
+    ubuf = (char *)_sbuf + sbuf_cursor;
+    *_sbuf_cursor = sbuf_cursor + ubuf_usz;
+  }
+
+  /* Restore the buffer */
+
+  int res = LZ4_decompress_safe_continue( lz4, cbuf+3UL, ubuf, (int)ubuf_csz, (int)ubuf_usz );
+  if( FD_UNLIKELY( res<=0 ) ) {
+    FD_LOG_WARNING(( "LZ4_decompress_safe_continue error (%i)", res ));
+    return 0UL;
+  }
+
+  /* Small ubuf scatter optimization */
+
+  if( is_small ) memcpy( _ubuf, ubuf, ubuf_usz ); /* app dependent branch prob */
+
+  return cbuf_sz;
+}
+#endif
+
+fd_restore_t *
+fd_restore_init_stream( void * mem,
+                        int    fd,
+                        void * rbuf,
+                        ulong  rbuf_sz ) {
+
+  /* Check input args */
+
+  if( FD_UNLIKELY( !mem ) ) {
+    FD_LOG_WARNING(( "NULL mem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)mem, FD_RESTORE_ALIGN ) ) ) {
+    FD_LOG_WARNING(( "misaligned mem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( fd<0 ) ) {
+    FD_LOG_WARNING(( "bad fd" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !rbuf ) ) {
+    FD_LOG_WARNING(( "NULL rbuf" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( rbuf_sz<FD_RESTORE_RBUF_MIN ) ) {
+    FD_LOG_WARNING(( "rbuf_sz too small" ));
+    return NULL;
+  }
+
+  /* Create decompressor */
+
+# if FD_HAS_LZ4
+  LZ4_streamDecode_t * lz4 = LZ4_createStreamDecode();
+  if( FD_UNLIKELY( !lz4 ) ) {
+    FD_LOG_WARNING(( "lz4 error" ));
+    return NULL;
+  }
+# else
+  void * lz4 = NULL;
+# endif
+
+  /* Init restore */
+
+  fd_restore_t * restore = (fd_restore_t *)mem;
+
+  restore->fd          = fd; /* streaming mode */
+  restore->frame_style = 0;  /* not in frame */
+  restore->lz4         = (void *)lz4;
+  restore->sbuf_cursor = 0UL;
+  restore->rbuf.mem    = (uchar *)rbuf;
+  restore->rbuf.sz     = rbuf_sz;
+  restore->rbuf.lo     = 0UL;
+  restore->rbuf.ready  = 0UL;
+
+  return restore;
+}
+
+fd_restore_t *
+fd_restore_init_mmio( void *       mem,
+                      void const * mmio,
+                      ulong        mmio_sz ) {
+
+  /* Check input args */
+
+  if( FD_UNLIKELY( !mem ) ) {
+    FD_LOG_WARNING(( "NULL mem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)mem, FD_RESTORE_ALIGN ) ) ) {
+    FD_LOG_WARNING(( "misaligned mem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( (!mmio) & (!!mmio_sz) ) ) {
+    FD_LOG_WARNING(( "NULL mmio with non-zero mmio_sz" ));
+    return NULL;
+  }
+
+  /* Create decompressor */
+
+# if FD_HAS_LZ4
+  LZ4_streamDecode_t * lz4 = LZ4_createStreamDecode();
+  if( FD_UNLIKELY( !lz4 ) ) {
+    FD_LOG_WARNING(( "lz4 error" ));
+    return NULL;
+  }
+# else
+  void * lz4 = NULL;
+# endif
+
+  /* Init restore */
+
+  fd_restore_t * restore = (fd_restore_t *)mem;
+
+  restore->fd          = -1; /* mmio mode */
+  restore->frame_style = 0;  /* not in frame */
+  restore->lz4         = (void *)lz4;
+  restore->mmio.mem    = (uchar const *)mmio;
+  restore->mmio.sz     = mmio_sz;
+  restore->mmio.off    = 0UL;
+
+  return restore;
+}
+
+void *
+fd_restore_fini( fd_restore_t * restore ) {
+
+  if( FD_UNLIKELY( !restore ) ) {
+    FD_LOG_WARNING(( "NULL restore" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( fd_restore_private_in_frame( restore ) ) ) {
+    FD_LOG_WARNING(( "in a frame" ));
+    restore->frame_style = -1; /* failed */
+    return NULL;
+  }
+
+# if FD_HAS_LZ4
+
+  /* Note: Though this this doesn't seem to be officially documented,
+     the lz4-1.9.4@lz4/lib/lz4.c:2575 suggests that this always returns
+     0.  That is, 0 is success and non-zero is failure. */
+
+  if( FD_UNLIKELY( LZ4_freeStreamDecode( (LZ4_streamDecode_t *)restore->lz4 ) ) )
+    FD_LOG_WARNING(( "LZ4 freeStreamDecode error, attempting to continue" ));
+
+# endif
+
+  return restore;
+}
+
+int
+fd_restore_frame_open( fd_restore_t * restore,
+                       int            frame_style ) {
+
+  if( FD_UNLIKELY( !restore ) ) {
+    FD_LOG_WARNING(( "NULL restore" ));
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( !fd_restore_private_can_open( restore ) ) ) {
+    FD_LOG_WARNING(( "in a frame or failed" ));
+    restore->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  frame_style = fd_int_if( !!frame_style, frame_style, FD_CHECKPT_FRAME_STYLE_DEFAULT );
+
+  switch( frame_style ) {
+
+  case FD_CHECKPT_FRAME_STYLE_RAW: {
+    break;
+  }
+
+# if FD_HAS_LZ4
+  case FD_CHECKPT_FRAME_STYLE_LZ4: {
+    if( FD_UNLIKELY( !LZ4_setStreamDecode( (LZ4_streamDecode_t *)restore->lz4, NULL, 0 ) ) ) {
+      FD_LOG_WARNING(( "LZ4_setStreamDecode failed" ));
+      restore->frame_style = -1; /* failed */
+      return FD_CHECKPT_ERR_COMP;
+    }
+    restore->sbuf_cursor = 0UL;
+    break;
+  }
+# endif
+
+  default: {
+    FD_LOG_WARNING(( "unsupported frame_style" ));
+    restore->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_UNSUP;
+  }
+
+  }
+
+  restore->frame_style = frame_style;
+  return FD_CHECKPT_SUCCESS;
+}
+
+int
+fd_restore_frame_close( fd_restore_t * restore ) {
+
+  if( FD_UNLIKELY( !restore ) ) {
+    FD_LOG_WARNING(( "NULL restore" ));
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( !fd_restore_private_in_frame( restore ) ) ) {
+    FD_LOG_WARNING(( "not in a frame" ));
+    restore->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  restore->frame_style = 0;
+  return FD_CHECKPT_SUCCESS;
+}
+
+int
+fd_restore_buf( fd_restore_t * restore,
+                void *         buf,
+                ulong          sz ) {
+
+  if( FD_UNLIKELY( !restore ) ) {
+    FD_LOG_WARNING(( "NULL restore" ));
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( !fd_restore_private_in_frame( restore ) ) ) {
+    FD_LOG_WARNING(( "not in a frame" ));
+    restore->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  if( FD_UNLIKELY( !sz ) ) return FD_CHECKPT_SUCCESS; /* nothing to do */
+
+  if( FD_UNLIKELY( !buf ) ) {
+    FD_LOG_WARNING(( "NULL buf with non-zero sz" ));
+    restore->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_INVAL;
+  }
+
+  switch( restore->frame_style ) {
+
+  case FD_CHECKPT_FRAME_STYLE_RAW: {
+
+    if( fd_restore_private_is_mmio( restore ) ) { /* mmio mode, app dependent branch prob */
+
+      ulong mmio_sz  = restore->mmio.sz;
+      ulong mmio_off = restore->mmio.off;
+
+      if( FD_UNLIKELY( sz > (mmio_sz-mmio_off) ) ) {
+        FD_LOG_WARNING(( "sz overflow" ));
+        restore->frame_style = -1; /* failed */
+        return FD_CHECKPT_ERR_IO;
+      }
+
+      memcpy( buf, restore->mmio.mem + mmio_off, sz );
+
+      restore->mmio.off = mmio_off + sz; /* at most mmio.sz */
+
+    } else { /* streaming mode */
+
+      int err = fd_io_buffered_read( restore->fd, buf, sz, restore->rbuf.mem, restore->rbuf.sz,
+                                     &restore->rbuf.lo, &restore->rbuf.ready );
+
+      if( FD_UNLIKELY( err ) ) {
+        FD_LOG_WARNING(( "fd_io_buffered_read failed (%i-%s)", err, fd_io_strerror( err ) ));
+        restore->frame_style = -1; /* failed */
+        return FD_CHECKPT_ERR_IO;
+      }
+
+    }
+
+    break;
+  }
+
+# if FD_HAS_LZ4
+  case FD_CHECKPT_FRAME_STYLE_LZ4: {
+
+    LZ4_streamDecode_t * lz4 = (LZ4_streamDecode_t *)restore->lz4;
+
+    if( fd_restore_private_is_mmio( restore ) ) { /* mmio mode */
+
+      uchar const * mmio    = restore->mmio.mem;
+      ulong         mmio_sz = restore->mmio.sz;
+      ulong         off     = restore->mmio.off;
+
+      uchar * chunk = (uchar *)buf;
+      do {
+        ulong chunk_usz = fd_ulong_min( sz, FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX );
+
+        ulong chunk_csz = fd_restore_private_lz4( lz4, chunk, chunk_usz, mmio + off, mmio_sz - off,
+                                                  restore->sbuf, FD_RESTORE_PRIVATE_SBUF_SZ, FD_RESTORE_PRIVATE_SBUF_THRESH,
+                                                  &restore->sbuf_cursor ); /* logs details */
+        if( FD_UNLIKELY( !chunk_csz ) ) {
+          restore->frame_style = -1; /* failed */
+          return FD_CHECKPT_ERR_COMP;
+        }
+
+        off += chunk_csz; /* at most mmio_sz */
+
+        chunk += chunk_usz;
+        sz    -= chunk_usz;
+      } while( sz );
+
+      restore->mmio.off = off;
+
+    } else { /* streaming mode */
+
+      int     fd         = restore->fd;
+      uchar * rbuf       = restore->rbuf.mem;
+      ulong   rbuf_sz    = restore->rbuf.sz;
+      ulong   rbuf_lo    = restore->rbuf.lo;
+      ulong   rbuf_ready = restore->rbuf.ready;
+
+      uchar * chunk = (uchar *)buf;
+      do {
+        ulong chunk_usz = fd_ulong_min( sz, FD_CHECKPT_PRIVATE_CHUNK_USZ_MAX );
+
+        /* Pre-buffer the header and the first body byte to figure out
+           how large the compressed chunk actually is.
+
+           Note: This can buffer bytes past the end of the checkpoint in
+           the uncommon case of there being data past the end of the
+           checkpoint (e.g. is a stream like stdin without an EOF or the
+           checkpoint is embedded in a larger file).  We could have
+           fd_io_read below use min_sz-rbuf_ready for the min and max sz
+           arguments to not overread (but then there isn't much point to
+           using buffered reads).  We could also make an unbuffered
+           streaming a restore option (but it probably much slower if
+           there are lots of tiny buffers).  Regardless, overreading in
+           such scenarios is an unavoidable possibility if the incoming
+           file is corrupt anyway and the caller will usually be able to
+           seek such streams.  So we currently just allow it to get the
+           benefits of buffering. */
+
+#       define BUFFER(min_ready)                                                                         \
+        if( FD_UNLIKELY( rbuf_ready<min_ready ) ) { /* If not enough bytes buffered */                   \
+                                                                                                         \
+          /* Move the unprocessed bytes to the beginning of the buffer */                                \
+                                                                                                         \
+          if( FD_LIKELY( (rbuf_lo>0UL) & (rbuf_ready>0UL) ) ) memmove( rbuf, rbuf+rbuf_lo, rbuf_ready ); \
+                                                                                                         \
+          /* Read at least enough bytes to make progress and at most */                                  \
+          /* enough bytes to fill the rbuf.  If we hit EOF or another */                                 \
+          /* error, the restore failed. */                                                               \
+                                                                                                         \
+          ulong rsz;                                                                                     \
+          int   err = fd_io_read( fd, rbuf+rbuf_ready, min_ready-rbuf_ready, rbuf_sz-rbuf_ready, &rsz ); \
+          if( FD_UNLIKELY( err ) ) {                                                                     \
+            FD_LOG_WARNING(( "fd_io_read failed (%i-%s)", err, fd_io_strerror( err ) ));                 \
+            restore->frame_style = -1; /* failed */                                                      \
+            return FD_CHECKPT_ERR_IO;                                                                    \
+          }                                                                                              \
+                                                                                                         \
+          rbuf_ready += rsz; /* in [min_ready,rbuf_sz] */                                                \
+          rbuf_lo     = 0UL;                                                                             \
+        }
+
+        BUFFER( 4UL )
+
+        ulong chunk_csz = 3UL + ( ((ulong)rbuf[ rbuf_lo     ]      )
+                                | ((ulong)rbuf[ rbuf_lo+1UL ] <<  8)
+                                | ((ulong)rbuf[ rbuf_lo+2UL ] << 16) );
+
+        if( FD_UNLIKELY( !((4UL<=chunk_csz) & (chunk_csz<=FD_CHECKPT_PRIVATE_CSZ_MAX( chunk_usz ))) ) ) {
+          FD_LOG_WARNING(( "corrupt header" ));
+          restore->frame_style = -1; /* failed */
+          return FD_CHECKPT_ERR_COMP;
+        }
+
+        /* Buffer the compressed chunk.  If the fd doesn't have
+           chunk_csz bytes available (e.g. we hit EOF unexpectedly or
+           other I/O error), this will fail the restore.  Note that we
+           haven't advanced rbuf_lo yet so we invoke buffer with the
+           entire chunk_csz.  Also note that at this point:
+
+             rbuf_sz >= RBUF_MIN >= CSZ_MAX( USZ_MAX ) >= CSZ_MAX( chunk_usz ) >= chunk_csz
+
+           such that we always can buffer chunk_csz bytes into rbuf. */
+
+        BUFFER( chunk_csz );
+
+        /* Decompress the compressed chunk in rbuf */
+
+        ulong res = fd_restore_private_lz4( lz4, chunk, chunk_usz, rbuf + rbuf_lo, rbuf_ready,
+                                            restore->sbuf, FD_RESTORE_PRIVATE_SBUF_SZ, FD_RESTORE_PRIVATE_SBUF_THRESH,
+                                            &restore->sbuf_cursor ); /* logs details */
+        if( FD_UNLIKELY( !res ) ) {
+          restore->frame_style = -1; /* failed */
+          return FD_CHECKPT_ERR_COMP;
+        }
+
+        if( FD_UNLIKELY( res!=chunk_csz ) ) {
+          FD_LOG_WARNING(( "corrupt body" ));
+          restore->frame_style = -1; /* failed */
+          return FD_CHECKPT_ERR_COMP;
+        }
+
+#       undef BUFFER
+
+        rbuf_lo    += chunk_csz;
+        rbuf_ready -= chunk_csz;
+
+        chunk += chunk_usz;
+        sz    -= chunk_usz;
+      } while( sz );
+
+      restore->rbuf.lo    = rbuf_lo;
+      restore->rbuf.ready = rbuf_ready;
+
+    }
+
+    break;
+  }
+# endif
+
+  default: { /* never get here */
+    FD_LOG_WARNING(( "unsupported frame style" ));
+    restore->frame_style = -1; /* failed */
+    return FD_CHECKPT_ERR_UNSUP;
+  }
+
+  }
+
+  return FD_CHECKPT_SUCCESS;
+}

--- a/src/util/checkpt/test_checkpt_mmio.c
+++ b/src/util/checkpt/test_checkpt_mmio.c
@@ -1,0 +1,483 @@
+#include "../fd_util.h"
+
+FD_STATIC_ASSERT( FD_CHECKPT_SUCCESS  == 0, unit_test );
+FD_STATIC_ASSERT( FD_CHECKPT_ERR_INVAL==-1, unit_test );
+FD_STATIC_ASSERT( FD_CHECKPT_ERR_UNSUP==-2, unit_test );
+FD_STATIC_ASSERT( FD_CHECKPT_ERR_IO   ==-3, unit_test );
+FD_STATIC_ASSERT( FD_CHECKPT_ERR_COMP ==-4, unit_test );
+
+FD_STATIC_ASSERT( FD_CHECKPT_FRAME_STYLE_RAW==1, unit_test );
+FD_STATIC_ASSERT( FD_CHECKPT_FRAME_STYLE_LZ4==2, unit_test );
+
+FD_STATIC_ASSERT( FD_CHECKPT_FRAME_STYLE_DEFAULT==1, unit_test );
+
+FD_STATIC_ASSERT( FD_CHECKPT_WBUF_MIN==69632UL, unit_test );
+
+FD_STATIC_ASSERT( FD_CHECKPT_ALIGN    == 8UL, unit_test );
+FD_STATIC_ASSERT( FD_CHECKPT_FOOTPRINT==48UL, unit_test );
+
+FD_STATIC_ASSERT( FD_RESTORE_RBUF_MIN ==69632UL, unit_test );
+
+FD_STATIC_ASSERT( FD_RESTORE_ALIGN    == 8UL, unit_test );
+FD_STATIC_ASSERT( FD_RESTORE_FOOTPRINT==48UL, unit_test );
+
+#define BUF_MAX (1048576UL)
+static uchar in  [ BUF_MAX ];
+static uchar out [ BUF_MAX ];
+static uchar mmio[ BUF_MAX ];
+
+int
+main( int argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  if( !FD_HAS_LZ4 ) FD_LOG_WARNING(( "target does not have lz4 support; lz4 style frames will not be tested" ));
+
+  ulong data_sz = fd_env_strip_cmdline_ulong( &argc, &argv, "--data-sz", NULL, BUF_MAX );
+  ulong mmio_sz = fd_env_strip_cmdline_ulong( &argc, &argv, "--mmio-sz", NULL, BUF_MAX );
+
+  FD_LOG_NOTICE(( "Using --data-sz %lu --mmio-sz %lu", data_sz, mmio_sz ));
+
+  if( FD_UNLIKELY( data_sz>BUF_MAX ) ) FD_LOG_ERR(( "--data-sz too large for BUF_MAX" ));
+  if( FD_UNLIKELY( mmio_sz>BUF_MAX ) ) FD_LOG_ERR(( "--mmio-sz too large for BUF_MAX" ));
+
+  fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
+
+  int style_raw = FD_CHECKPT_FRAME_STYLE_RAW;
+  int style_lz4 = FD_HAS_LZ4 ? FD_CHECKPT_FRAME_STYLE_LZ4 : FD_CHECKPT_FRAME_STYLE_RAW;
+
+  FD_LOG_NOTICE(( "Creating test data" ));
+
+  uchar val = (uchar)(fd_rng_ulong( rng ) & 255UL);
+  for( ulong in_idx=0UL; in_idx<data_sz; in_idx++ ) {
+    ulong r = fd_rng_ulong( rng );
+    val = fd_uchar_if( r & 255UL, val, (uchar)(r>>8) );
+    in[ in_idx ] = val;
+  }
+
+  FD_LOG_NOTICE(( "Testing fd_checkpt_strerror" ));
+
+  FD_TEST( !strcmp( fd_checkpt_strerror( FD_CHECKPT_SUCCESS   ), "success"                    ) );
+  FD_TEST( !strcmp( fd_checkpt_strerror( FD_CHECKPT_ERR_INVAL ), "bad input args"             ) );
+  FD_TEST( !strcmp( fd_checkpt_strerror( FD_CHECKPT_ERR_UNSUP ), "unsupported on this target" ) );
+  FD_TEST( !strcmp( fd_checkpt_strerror( FD_CHECKPT_ERR_IO    ), "io error"                   ) );
+  FD_TEST( !strcmp( fd_checkpt_strerror( FD_CHECKPT_ERR_COMP  ), "compression error"          ) );
+  FD_TEST( !strcmp( fd_checkpt_strerror( 1                    ), "unknown"                    ) );
+
+  fd_checkpt_t _checkpt[1];
+  fd_restore_t _restore[1];
+
+  FD_LOG_NOTICE(( "Testing fd_checkpt_init_mmio" ));
+
+  FD_TEST( !fd_checkpt_init_mmio( NULL,        mmio, mmio_sz ) ); /* NULL mem */
+  FD_TEST( !fd_checkpt_init_mmio( (void *)1UL, mmio, mmio_sz ) ); /* misaligned mem */
+  FD_TEST( !fd_checkpt_init_mmio( _checkpt,    NULL, mmio_sz ) ); /* NULL mmio with non-zero sz */
+  fd_checkpt_t * checkpt = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+
+  FD_LOG_NOTICE(( "Testing fd_checkpt_fini" ));
+
+  FD_TEST( !fd_checkpt_fini( NULL ) );                      /* NULL checkpt */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt ); /* fini (normal) */
+
+  checkpt = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_frame_open( checkpt, 0 ) );          /* open default (raw) frame */
+  FD_TEST( !fd_checkpt_fini( checkpt ) );                   /* fini (in frame) */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt ); /* fini (failed) */
+
+  FD_LOG_NOTICE(( "Testing fd_checkpt_frame_open" ));
+
+  FD_TEST(  fd_checkpt_frame_open( NULL, 0 )==FD_CHECKPT_ERR_INVAL ); /* NULL checkpt */
+
+  checkpt = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_frame_open( checkpt, style_raw ) );                       /* open raw frame */
+  FD_TEST(  fd_checkpt_frame_open( checkpt, style_raw )==FD_CHECKPT_ERR_INVAL ); /* in frame */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );                      /* fini (failed) */
+
+  checkpt = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_frame_open( checkpt, style_lz4 ) );  /* open lz4 frame (if target supports, raw if not) */
+  FD_TEST( !fd_checkpt_fini( checkpt ) );                   /* fini (in frame) */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt ); /* fini (failed) */
+
+  checkpt = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST(  fd_checkpt_frame_open( checkpt, -1 )==FD_CHECKPT_ERR_UNSUP ); /* unsupported frame */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );               /* fini (failed) */
+
+  FD_LOG_NOTICE(( "Testing fd_checkpt_frame_close" ));
+
+  FD_TEST( fd_checkpt_frame_close( NULL )==FD_CHECKPT_ERR_INVAL ); /* NULL checkpt */
+
+  checkpt = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST(  fd_checkpt_frame_close( checkpt )==FD_CHECKPT_ERR_INVAL ); /* close (not in frame) */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );            /* fini (failed) */
+
+  checkpt = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_frame_open( checkpt, style_raw ) );  /* open raw frame */
+  FD_TEST( !fd_checkpt_frame_close( checkpt ) );            /* close (in frame) */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt ); /* fini (normal) */
+
+  FD_LOG_NOTICE(( "Testing fd_checkpt_buf" ));
+
+  FD_TEST(  fd_checkpt_buf( NULL, in, data_sz )==FD_CHECKPT_ERR_INVAL ); /* NULL checkpt */
+
+  checkpt = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST(  fd_checkpt_buf( checkpt, in, 1UL )==FD_CHECKPT_ERR_INVAL ); /* not in frame */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );             /* fini (normal) */
+
+  checkpt = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST(  fd_checkpt_buf( checkpt, in, 0UL )==FD_CHECKPT_ERR_INVAL ); /* zero sz (not in frame) */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );             /* fini (normal) */
+
+  checkpt = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST(  fd_checkpt_buf( checkpt, NULL, 0UL )==FD_CHECKPT_ERR_INVAL ); /* NULL with zero sz (not in frame) */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );               /* fini (normal) */
+
+  checkpt = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_frame_open( checkpt, style_raw ) );  /* open raw frame */
+  FD_TEST( !fd_checkpt_buf( checkpt, in,   0UL ) );         /* zero sz */
+  FD_TEST( !fd_checkpt_buf( checkpt, NULL, 0UL ) );         /* NULL with zero sz */
+  FD_TEST( !fd_checkpt_frame_close( checkpt ) );            /* close (in frame) */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt ); /* fini (normal) */
+
+  FD_LOG_NOTICE(( "Testing fd_restore_init_mmio" ));
+
+  FD_TEST( !fd_restore_init_mmio( NULL,        mmio, mmio_sz ) ); /* NULL mem */
+  FD_TEST( !fd_restore_init_mmio( (void *)1UL, mmio, mmio_sz ) ); /* misaligned mem */
+  FD_TEST( !fd_restore_init_mmio( _restore,    NULL, mmio_sz ) ); /* NULL mmio with non-zero sz */
+  fd_restore_t * restore = fd_restore_init_mmio( _restore, mmio, mmio_sz ); FD_TEST( restore==_restore );
+
+  FD_LOG_NOTICE(( "Testing fd_restore_fini" ));
+
+  FD_TEST( !fd_restore_fini( NULL ) );                      /* NULL restore */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore ); /* fini (normal) */
+
+  restore = fd_restore_init_mmio( _restore, mmio, mmio_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_frame_open( restore, 0 ) );          /* open default (raw) frame */
+  FD_TEST( !fd_restore_fini( restore ) );                   /* fini (in frame) */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore ); /* fini (failed) */
+
+  FD_LOG_NOTICE(( "Testing fd_restore_frame_open" ));
+
+  FD_TEST(  fd_restore_frame_open( NULL, 0 )==FD_CHECKPT_ERR_INVAL ); /* NULL restore */
+
+  restore = fd_restore_init_mmio( _restore, mmio, mmio_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_frame_open( restore, style_raw )                       ); /* open raw frame */
+  FD_TEST(  fd_restore_frame_open( restore, style_raw )==FD_CHECKPT_ERR_INVAL ); /* in frame */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );                      /* fini (failed) */
+
+  restore = fd_restore_init_mmio( _restore, mmio, mmio_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_frame_open( restore, style_lz4 ) );  /* open lz4 frame (if target supports, raw if not) */
+  FD_TEST( !fd_restore_fini( restore ) );                   /* fini (in frame) */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore ); /* fini (failed) */
+
+  restore = fd_restore_init_mmio( _restore, mmio, mmio_sz ); FD_TEST( restore==_restore );
+  FD_TEST(  fd_restore_frame_open( restore, -1 )==FD_CHECKPT_ERR_UNSUP ); /* unsupported frame */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );               /* fini (failed) */
+
+  FD_LOG_NOTICE(( "Testing fd_restore_frame_close" ));
+
+  FD_TEST( fd_restore_frame_close( NULL )==FD_CHECKPT_ERR_INVAL ); /* NULL restore */
+
+  restore = fd_restore_init_mmio( _restore, mmio, mmio_sz ); FD_TEST( restore==_restore );
+  FD_TEST(  fd_restore_frame_close( restore )==FD_CHECKPT_ERR_INVAL ); /* close (not in frame) */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );            /* fini (failed) */
+
+  restore = fd_restore_init_mmio( _restore, mmio, mmio_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_frame_open( restore, style_raw ) );  /* open raw frame */
+  FD_TEST( !fd_restore_frame_close( restore           ) );  /* close (in frame) */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore ); /* fini (normal) */
+
+  FD_LOG_NOTICE(( "Testing fd_restore_buf" ));
+
+  FD_TEST(  fd_restore_buf( NULL, in, data_sz )==FD_CHECKPT_ERR_INVAL ); /* NULL restore */
+
+  restore = fd_restore_init_mmio( _restore, mmio, mmio_sz ); FD_TEST( restore==_restore );
+  FD_TEST(  fd_restore_buf( restore, in, 1UL )==FD_CHECKPT_ERR_INVAL ); /* not in frame */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );             /* fini (normal) */
+
+  restore = fd_restore_init_mmio( _restore, mmio, mmio_sz ); FD_TEST( restore==_restore );
+  FD_TEST(  fd_restore_buf( restore, in, 0UL )==FD_CHECKPT_ERR_INVAL ); /* zero sz (not in frame) */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );             /* fini (normal) */
+
+  restore = fd_restore_init_mmio( _restore, mmio, mmio_sz ); FD_TEST( restore==_restore );
+  FD_TEST(  fd_restore_buf( restore, NULL, 0UL )==FD_CHECKPT_ERR_INVAL ); /* NULL with zero sz (not in frame) */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );               /* fini (normal) */
+
+  restore = fd_restore_init_mmio( _restore, mmio, mmio_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_frame_open( restore, style_raw ) );  /* open raw frame */
+  FD_TEST( !fd_restore_buf( restore, in,   0UL ) );         /* zero sz */
+  FD_TEST( !fd_restore_buf( restore, NULL, 0UL ) );         /* NULL with zero sz */
+  FD_TEST( !fd_restore_frame_close( restore ) );            /* close (in frame) */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore ); /* fini (normal) */
+
+  FD_LOG_NOTICE(( "Testing end-to-end" ));
+
+  ulong off_open;
+  ulong off_close;
+  int   style;
+
+  for( ulong iter=0UL; iter<1000UL; iter++ ) {
+    style = fd_int_if( !(iter & 1UL), style_raw, style_lz4 );
+
+    uchar const * ibuf;
+    uchar       * obuf;
+    ulong         rem;
+    uint          rng_seq;
+    ulong         rng_idx;
+    ulong         frame_sz;
+
+    /* checkpt/restore a single buffer in a single frame */
+
+    memset( mmio, 0, mmio_sz );
+    memset( out,  0, data_sz );
+
+    checkpt = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+    FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+    FD_TEST( !fd_checkpt_buf( checkpt, in, data_sz ) );
+    FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+    FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
+
+    if( style==style_raw ) {
+      FD_TEST( (off_close-off_open)==data_sz );
+      FD_TEST( !memcmp( in, mmio, data_sz ) );
+    }
+
+    restore = fd_restore_init_mmio( _restore, mmio, mmio_sz ); FD_TEST( restore==_restore );
+    FD_TEST( !fd_restore_frame_open( restore, style ) );
+    FD_TEST( !fd_restore_buf( restore, out, data_sz ) );
+    FD_TEST( !fd_restore_frame_close( restore ) );
+    FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
+
+    FD_TEST( !memcmp( in, out, data_sz ) );
+
+    /* checkpt/restore with mixed sized buffers (including zero sized)
+       in a single frame */
+
+    rng_seq = fd_rng_seq( rng ); rng_idx = fd_rng_idx( rng ); /* save rng for restore */
+
+    memset( mmio, 0, mmio_sz );
+
+    checkpt = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+    FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+    ibuf = in;
+    rem  = data_sz;
+    while( rem ) {
+      ulong r      = fd_rng_ulong( rng );
+      ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+      ulong buf_sz = fd_ulong_min( rem, r & mask ); /* In [0,128KiB) biased toward small */
+      FD_TEST( !fd_checkpt_buf( checkpt, ibuf, buf_sz ) );
+      ibuf += buf_sz;
+      rem  -= buf_sz;
+    }
+    FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+    FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
+
+    if( style==style_raw ) {
+      FD_TEST( (off_close-off_open)==data_sz );
+      FD_TEST( !memcmp( in, mmio, data_sz ) );
+    }
+
+    fd_rng_seq_set( rng, rng_seq ); fd_rng_idx_set( rng, rng_idx ); /* Restore to recreate same checkpt open/buf/close */
+
+    memset( out, 0, data_sz );
+
+    restore = fd_restore_init_mmio( _restore, mmio, mmio_sz ); FD_TEST( restore==_restore );
+    FD_TEST( !fd_restore_frame_open( restore, style ) );
+    obuf = out;
+    rem  = data_sz;
+    while( rem ) {
+      ulong r      = fd_rng_ulong( rng );
+      ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+      ulong buf_sz = fd_ulong_min( rem, r & mask ); /* In [0,128KiB) biased toward small */
+      FD_TEST( !fd_restore_buf( restore, obuf, buf_sz ) );
+      if( FD_LIKELY( buf_sz ) ) FD_TEST( !memcmp( in+(data_sz-rem), obuf, buf_sz ) ); /* Test immedate avail */
+      obuf += buf_sz;
+      rem  -= buf_sz;
+    }
+    FD_TEST( !fd_restore_frame_close( restore ) );
+    FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
+
+    FD_TEST( !memcmp( in, out, data_sz ) );
+
+    /* checkpt/restore with mixed sized buffers (including 0 sized)
+       distributed over multiple homegeneous frames (including empty
+       frames) */
+
+    rng_seq = fd_rng_seq( rng ); rng_idx = fd_rng_idx( rng ); /* save rng for restore */
+
+    memset( mmio, 0, mmio_sz );
+
+    checkpt  = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+    frame_sz = 0UL;
+    FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+    ibuf     = in;
+    rem      = data_sz;
+    while( rem ) {
+      ulong r      = fd_rng_ulong( rng );
+      ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+      ulong buf_sz = fd_ulong_min( rem, r & mask ); r >>= 18; /* In [0,128KiB) biased toward small */
+      for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
+        if( FD_LIKELY( r & 7UL ) ) break;
+        r >>= 3;
+        FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+        if( style==style_raw ) FD_TEST( (off_close-off_open)==frame_sz );
+        frame_sz = 0UL;
+        FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+      }
+      FD_TEST( !fd_checkpt_buf( checkpt, ibuf, buf_sz ) );
+      ibuf     += buf_sz;
+      rem      -= buf_sz;
+      frame_sz += buf_sz;
+    }
+    FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+    FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
+
+    if( style==style_raw ) {
+      FD_TEST( (off_close-off_open)==frame_sz );
+      FD_TEST( !memcmp( in, mmio, data_sz ) );
+    }
+
+    fd_rng_seq_set( rng, rng_seq ); fd_rng_idx_set( rng, rng_idx ); /* Restore to recreate same checkpt open/buf/close */
+
+    memset( out, 0, data_sz );
+
+    restore = fd_restore_init_mmio( _restore, mmio, mmio_sz ); FD_TEST( restore==_restore );
+    FD_TEST( !fd_restore_frame_open( restore, style ) );
+    obuf = out;
+    rem  = data_sz;
+    while( rem ) {
+      ulong r      = fd_rng_ulong( rng );
+      ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+      ulong buf_sz = fd_ulong_min( rem, r & mask ); r >>= 18; /* In [0,128KiB) biased toward small */
+      for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
+        if( FD_LIKELY( r & 7UL ) ) break;
+        r >>= 3;
+        FD_TEST( !fd_restore_frame_close( restore ) );
+        FD_TEST( !fd_restore_frame_open( restore, style ) );
+      }
+      FD_TEST( !fd_restore_buf( restore, obuf, buf_sz ) );
+      if( FD_LIKELY( buf_sz ) ) FD_TEST( !memcmp( in+(data_sz-rem), obuf, buf_sz ) ); /* Test immedate avail */
+      obuf += buf_sz;
+      rem  -= buf_sz;
+    }
+    FD_TEST( !fd_restore_frame_close( restore ) );
+    FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
+
+    FD_TEST( !memcmp( in, out, data_sz ) );
+
+    /* checkpt/restore with mixed sized buffers (including 0 sized)
+       distributed over multiple mixed style frames (including empty
+       frames) */
+
+    rng_seq = fd_rng_seq( rng ); rng_idx = fd_rng_idx( rng ); /* save rng for restore */
+
+    memset( mmio, 0, mmio_sz );
+
+    checkpt  = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+    style    = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
+    frame_sz = 0UL;
+    FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+    ibuf     = in;
+    rem      = data_sz;
+    while( rem ) {
+      ulong r      = fd_rng_ulong( rng );
+      ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+      ulong buf_sz = fd_ulong_min( rem, r & mask ); r >>= 18; /* In [0,128KiB) biased toward small */
+      for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
+        if( FD_LIKELY( r & 7UL ) ) break;
+        r >>= 3;
+        FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+        if( style==style_raw ) FD_TEST( (off_close-off_open)==frame_sz );
+        /* FIXME: consider comparing frame bytes when raw? */
+        style    = fd_int_if( !(r & 1UL), style_raw, style_lz4 ); r >>= 1;
+        frame_sz = 0UL;
+        FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+      }
+      FD_TEST( !fd_checkpt_buf( checkpt, ibuf, buf_sz ) );
+      ibuf     += buf_sz;
+      rem      -= buf_sz;
+      frame_sz += buf_sz;
+    }
+    FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+    FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
+
+    fd_rng_seq_set( rng, rng_seq ); fd_rng_idx_set( rng, rng_idx ); /* Restore to recreate same checkpt open/buf/close */
+
+    memset( out, 0, data_sz );
+
+    restore = fd_restore_init_mmio( _restore, mmio, mmio_sz ); FD_TEST( restore==_restore );
+    style   = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
+    FD_TEST( !fd_restore_frame_open( restore, style ) );
+    obuf = out;
+    rem  = data_sz;
+    while( rem ) {
+      ulong r      = fd_rng_ulong( rng );
+      ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+      ulong buf_sz = fd_ulong_min( rem, r & mask ); r >>= 18; /* In [0,128KiB) biased toward small */
+      for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
+        if( FD_LIKELY( r & 7UL ) ) break;
+        r >>= 3;
+        FD_TEST( !fd_restore_frame_close( restore ) );
+        style = fd_int_if( !(r & 1UL), style_raw, style_lz4 ); r >>= 1;
+        FD_TEST( !fd_restore_frame_open( restore, style ) );
+      }
+      FD_TEST( !fd_restore_buf( restore, obuf, buf_sz ) );
+      if( FD_LIKELY( buf_sz ) ) FD_TEST( !memcmp( in+(data_sz-rem), obuf, buf_sz ) ); /* Test immedate avail */
+      obuf += buf_sz;
+      rem  -= buf_sz;
+    }
+    FD_TEST( !fd_restore_frame_close( restore ) );
+    FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
+
+    FD_TEST( !memcmp( in, out, data_sz ) );
+  }
+
+  FD_LOG_NOTICE(( "Testing checkpt too small (raw)" ));
+
+  memset( mmio, 0, mmio_sz );
+
+  checkpt = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style_raw, &off_open ) );
+  ulong rem;
+  for( rem=mmio_sz; rem>=data_sz; rem-=data_sz ) FD_TEST( !fd_checkpt_buf( checkpt, in, data_sz ) );
+  FD_TEST(  fd_checkpt_buf( checkpt, in, rem+1UL )==FD_CHECKPT_ERR_IO );
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
+
+  FD_LOG_NOTICE(( "Testing checkpt too small (lz4)" ));
+
+  memset( mmio, 0, mmio_sz );
+
+  checkpt = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style_lz4, &off_open ) );
+  while( !fd_checkpt_buf( checkpt, in, data_sz ) ) /**/;
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
+
+  FD_LOG_NOTICE(( "Testing checkpt too small (mixed)" ));
+
+  memset( mmio, 0, mmio_sz );
+
+  checkpt  = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+  style    = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
+  FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+  for(;;) {
+    ulong r      = fd_rng_ulong( rng );
+    ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+    ulong buf_sz = r & mask; r >>= 18; /* In [0,128KiB) biased toward small */
+    for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
+      if( FD_LIKELY( r & 7UL ) ) break;
+      r >>= 3;
+      if( fd_checkpt_frame_close_advanced( checkpt, &off_close ) ) goto err;
+      style = fd_int_if( !(r & 1UL), style_raw, style_lz4 ); r >>= 1;
+      if( fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) ) goto err;
+    }
+    if( fd_checkpt_buf( checkpt, in, buf_sz ) ) goto err;
+  }
+err:
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
+
+  fd_rng_delete( fd_rng_leave( rng ) );
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}
+

--- a/src/util/checkpt/test_checkpt_mmio.c
+++ b/src/util/checkpt/test_checkpt_mmio.c
@@ -11,20 +11,21 @@ FD_STATIC_ASSERT( FD_CHECKPT_FRAME_STYLE_LZ4==2, unit_test );
 
 FD_STATIC_ASSERT( FD_CHECKPT_FRAME_STYLE_DEFAULT==1, unit_test );
 
-FD_STATIC_ASSERT( FD_CHECKPT_WBUF_MIN==69632UL, unit_test );
+FD_STATIC_ASSERT( FD_CHECKPT_WBUF_MIN == 69632UL, unit_test );
+FD_STATIC_ASSERT( FD_CHECKPT_ALIGN    ==     8UL, unit_test );
+FD_STATIC_ASSERT( FD_CHECKPT_FOOTPRINT==196664UL, unit_test );
 
-FD_STATIC_ASSERT( FD_CHECKPT_ALIGN    == 8UL, unit_test );
-FD_STATIC_ASSERT( FD_CHECKPT_FOOTPRINT==48UL, unit_test );
-
-FD_STATIC_ASSERT( FD_RESTORE_RBUF_MIN ==69632UL, unit_test );
-
-FD_STATIC_ASSERT( FD_RESTORE_ALIGN    == 8UL, unit_test );
-FD_STATIC_ASSERT( FD_RESTORE_FOOTPRINT==48UL, unit_test );
+FD_STATIC_ASSERT( FD_RESTORE_RBUF_MIN == 69632UL, unit_test );
+FD_STATIC_ASSERT( FD_RESTORE_ALIGN    ==     8UL, unit_test );
+FD_STATIC_ASSERT( FD_RESTORE_FOOTPRINT==196664UL, unit_test );
 
 #define BUF_MAX (1048576UL)
 static uchar in  [ BUF_MAX ];
 static uchar out [ BUF_MAX ];
 static uchar mmio[ BUF_MAX ];
+
+static fd_checkpt_t _checkpt[1];
+static fd_restore_t _restore[1];
 
 int
 main( int argc,
@@ -63,9 +64,6 @@ main( int argc,
   FD_TEST( !strcmp( fd_checkpt_strerror( FD_CHECKPT_ERR_IO    ), "io error"                   ) );
   FD_TEST( !strcmp( fd_checkpt_strerror( FD_CHECKPT_ERR_COMP  ), "compression error"          ) );
   FD_TEST( !strcmp( fd_checkpt_strerror( 1                    ), "unknown"                    ) );
-
-  fd_checkpt_t _checkpt[1];
-  fd_restore_t _restore[1];
 
   FD_LOG_NOTICE(( "Testing fd_checkpt_init_mmio" ));
 
@@ -480,4 +478,3 @@ err:
   fd_halt();
   return 0;
 }
-

--- a/src/util/checkpt/test_checkpt_stream.c
+++ b/src/util/checkpt/test_checkpt_stream.c
@@ -1,0 +1,624 @@
+#include "../fd_util.h"
+
+#include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+/* Note: macros tested in mmio */
+
+#define BUF_MAX (1048576UL)
+
+static uchar in  [ BUF_MAX ];
+static uchar out [ BUF_MAX ];
+static uchar mmio[ BUF_MAX ];
+static uchar rbuf[ BUF_MAX ];
+static uchar wbuf[ BUF_MAX ];
+
+int
+main( int argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  if( !FD_HAS_LZ4 ) FD_LOG_WARNING(( "target does not have lz4 support; lz4 style frames will not be tested" ));
+
+  char const * path    = fd_env_strip_cmdline_cstr ( &argc, &argv, "--path",    NULL, NULL                );
+  char const * _mode   = fd_env_strip_cmdline_cstr ( &argc, &argv, "--mode",    NULL, "0600"              );
+  int          keep    = fd_env_strip_cmdline_int  ( &argc, &argv, "--keep",    NULL, 0                   );
+  ulong        data_sz = fd_env_strip_cmdline_ulong( &argc, &argv, "--data-sz", NULL, BUF_MAX             );
+  ulong        mmio_sz = fd_env_strip_cmdline_ulong( &argc, &argv, "--mmio-sz", NULL, BUF_MAX             );
+  ulong        wbuf_sz = fd_env_strip_cmdline_ulong( &argc, &argv, "--wbuf-sz", NULL, FD_CHECKPT_WBUF_MIN );
+  ulong        rbuf_sz = fd_env_strip_cmdline_ulong( &argc, &argv, "--rbuf-sz", NULL, FD_RESTORE_RBUF_MIN );
+
+  FD_LOG_NOTICE(( "Using --data-sz %lu --wbuf-sz %lu --rbuf-sz %lu", data_sz, wbuf_sz, rbuf_sz ));
+
+  if( FD_UNLIKELY( data_sz>BUF_MAX ) ) FD_LOG_ERR(( "--data-sz too large for BUF_MAX" ));
+  if( FD_UNLIKELY( mmio_sz>BUF_MAX ) ) FD_LOG_ERR(( "--mmio-sz too large for BUF_MAX" ));
+  if( FD_UNLIKELY( wbuf_sz>BUF_MAX ) ) FD_LOG_ERR(( "--wbuf-sz too large for BUF_MAX" ));
+  if( FD_UNLIKELY( rbuf_sz>BUF_MAX ) ) FD_LOG_ERR(( "--rbuf-sz too large for BUF_MAX" ));
+
+  fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
+
+  int style_raw = FD_CHECKPT_FRAME_STYLE_RAW;
+  int style_lz4 = FD_HAS_LZ4 ? FD_CHECKPT_FRAME_STYLE_LZ4 : FD_CHECKPT_FRAME_STYLE_RAW;
+
+  FD_LOG_NOTICE(( "Creating test data" ));
+
+  uchar val = (uchar)(fd_rng_ulong( rng ) & 255UL);
+  for( ulong in_idx=0UL; in_idx<data_sz; in_idx++ ) {
+    ulong r = fd_rng_ulong( rng );
+    val = fd_uchar_if( r & 255UL, val, (uchar)(r>>8) );
+    in[ in_idx ] = val;
+  }
+
+  FD_LOG_NOTICE(( "Creating test stream" ));
+
+  int fd;
+
+  char tmp_path[] = "/tmp/test_checkpt.XXXXXX";
+  if( path ) {
+
+    ulong mode = fd_cstr_to_ulong_octal( _mode );
+    FD_LOG_NOTICE(( "Using --path %s (--mode 0%03lo --keep %i)", path, mode, keep ));
+    mode_t old_mask = umask( (mode_t)0 );
+    fd = open( path, O_CREAT | O_EXCL | O_RDWR, (mode_t)mode );
+    umask( old_mask );
+    if( FD_UNLIKELY( fd==-1 ) ) FD_LOG_ERR(( "open(O_CREATE | O_EXCL | O_RDWR) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+
+  } else {
+
+    FD_LOG_NOTICE(( "--path not specified; using tmp file (--mode ignored --keep %i)", keep ));
+    fd = mkstemp( tmp_path );
+    if( FD_UNLIKELY( fd==-1 ) ) FD_LOG_ERR(( "mkstemp(\"%s\")failed (%i-%s)", tmp_path, errno, fd_io_strerror( errno ) ));
+    path = tmp_path;
+    FD_LOG_NOTICE(( "tmp file at %s", path ));
+
+  }
+
+  /* If keep is not set, we unlink the created file so it gets
+     automagically cleaned up at program termination (normal or not).
+     That is, as per usual UNIX semantics, the underlying file will
+     still exist it has any open file descriptors. */
+
+  if( FD_UNLIKELY( !keep && unlink( path ) ) )
+    FD_LOG_ERR(( "unlink( \"%s\" ) failed (%i-%s)", path,  errno, fd_io_strerror( errno ) ));
+
+  /* Note: strerror tested in mmio */
+
+# define RESET(fd) do {                                                       \
+    if( FD_UNLIKELY( lseek( (fd), (off_t)0, SEEK_SET ) ) )                    \
+      FD_LOG_ERR(( "lseek failed (%i-%s)", errno, fd_io_strerror( errno ) )); \
+  } while(0)
+
+  fd_checkpt_t _checkpt[1];
+  fd_restore_t _restore[1];
+
+  FD_LOG_NOTICE(( "Testing fd_checkpt_init_stream" ));
+
+  FD_TEST( !fd_checkpt_init_stream( NULL,        fd, wbuf, wbuf_sz                 ) ); /* NULL mem */
+  FD_TEST( !fd_checkpt_init_stream( (void *)1UL, fd, wbuf, wbuf_sz                 ) ); /* misaligned mem */
+  FD_TEST( !fd_checkpt_init_stream( _checkpt,    -1, wbuf, wbuf_sz                 ) ); /* bad fd */
+  FD_TEST( !fd_checkpt_init_stream( _checkpt,    fd, NULL, wbuf_sz                 ) ); /* NULL wbuf */
+  FD_TEST( !fd_checkpt_init_stream( _checkpt,    fd, wbuf, FD_CHECKPT_WBUF_MIN-1UL ) ); /* wbuf_sz too small */
+
+  fd_checkpt_t * checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+
+  FD_LOG_NOTICE(( "Testing fd_checkpt_fini" ));
+
+  FD_TEST( !fd_checkpt_fini( NULL ) );                      /* NULL checkpt */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt ); /* fini (normal) */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_frame_open( checkpt, 0 ) );          /* open default (raw) frame */
+  FD_TEST( !fd_checkpt_fini( checkpt ) );                   /* fini (in frame) */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt ); /* fini (failed) */
+
+  FD_LOG_NOTICE(( "Testing fd_checkpt_frame_open" ));
+
+  FD_TEST(  fd_checkpt_frame_open( NULL, 0 )==FD_CHECKPT_ERR_INVAL ); /* NULL checkpt */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_frame_open( checkpt, style_raw ) );                       /* open raw frame */
+  FD_TEST(  fd_checkpt_frame_open( checkpt, style_raw )==FD_CHECKPT_ERR_INVAL ); /* in frame */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );                      /* fini (failed) */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_frame_open( checkpt, style_lz4 ) );  /* open lz4 frame (if target supports, raw if not) */
+  FD_TEST( !fd_checkpt_fini( checkpt ) );                   /* fini (in frame) */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt ); /* fini (failed) */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST(  fd_checkpt_frame_open( checkpt, -1 )==FD_CHECKPT_ERR_UNSUP ); /* unsupported frame */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );               /* fini (failed) */
+
+  FD_LOG_NOTICE(( "Testing fd_checkpt_frame_close" ));
+
+  FD_TEST( fd_checkpt_frame_close( NULL )==FD_CHECKPT_ERR_INVAL ); /* NULL checkpt */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST(  fd_checkpt_frame_close( checkpt )==FD_CHECKPT_ERR_INVAL ); /* close (not in frame) */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );            /* fini (failed) */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_frame_open( checkpt, style_raw ) );  /* open raw frame */
+  FD_TEST( !fd_checkpt_frame_close( checkpt ) );            /* close (in frame) */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt ); /* fini (normal) */
+
+  FD_LOG_NOTICE(( "Testing fd_checkpt_buf" ));
+
+  FD_TEST(  fd_checkpt_buf( NULL, in, data_sz )==FD_CHECKPT_ERR_INVAL ); /* NULL checkpt */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST(  fd_checkpt_buf( checkpt, in, 1UL )==FD_CHECKPT_ERR_INVAL ); /* not in frame */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );             /* fini (normal) */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST(  fd_checkpt_buf( checkpt, in, 0UL )==FD_CHECKPT_ERR_INVAL ); /* zero sz (not in frame) */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );             /* fini (normal) */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST(  fd_checkpt_buf( checkpt, NULL, 0UL )==FD_CHECKPT_ERR_INVAL ); /* NULL with zero sz (not in frame) */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );               /* fini (normal) */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_frame_open( checkpt, style_raw ) );  /* open raw frame */
+  FD_TEST( !fd_checkpt_buf( checkpt, in,   0UL ) );         /* zero sz */
+  FD_TEST( !fd_checkpt_buf( checkpt, NULL, 0UL ) );         /* NULL with zero sz */
+  FD_TEST( !fd_checkpt_frame_close( checkpt ) );            /* close (in frame) */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt ); /* fini (normal) */
+
+  FD_LOG_NOTICE(( "Testing fd_restore_init_stream" ));
+
+  FD_TEST( !fd_restore_init_stream( NULL,        fd, rbuf, rbuf_sz                 ) ); /* NULL mem */
+  FD_TEST( !fd_restore_init_stream( (void *)1UL, fd, rbuf, rbuf_sz                 ) ); /* misaligned mem */
+  FD_TEST( !fd_restore_init_stream( _restore,    -1, rbuf, rbuf_sz                 ) ); /* bad fd */
+  FD_TEST( !fd_restore_init_stream( _restore,    fd, NULL, rbuf_sz                 ) ); /* NULL rbuf */
+  FD_TEST( !fd_restore_init_stream( _restore,    fd, rbuf, FD_RESTORE_RBUF_MIN-1UL ) ); /* too small rbuf */
+  fd_restore_t * restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+
+  FD_LOG_NOTICE(( "Testing fd_restore_fini" ));
+
+  FD_TEST( !fd_restore_fini( NULL ) );                      /* NULL restore */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore ); /* fini (normal) */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_frame_open( restore, 0 ) );          /* open default (raw) frame */
+  FD_TEST( !fd_restore_fini( restore ) );                   /* fini (in frame) */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore ); /* fini (failed) */
+
+  FD_LOG_NOTICE(( "Testing fd_restore_frame_open" ));
+
+  FD_TEST(  fd_restore_frame_open( NULL, 0 )==FD_CHECKPT_ERR_INVAL ); /* NULL restore */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_frame_open( restore, style_raw )                       ); /* open raw frame */
+  FD_TEST(  fd_restore_frame_open( restore, style_raw )==FD_CHECKPT_ERR_INVAL ); /* in frame */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );                      /* fini (failed) */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_frame_open( restore, style_lz4 ) );  /* open lz4 frame (if target supports, raw if not) */
+  FD_TEST( !fd_restore_fini( restore ) );                   /* fini (in frame) */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore ); /* fini (failed) */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST(  fd_restore_frame_open( restore, -1 )==FD_CHECKPT_ERR_UNSUP ); /* unsupported frame */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );               /* fini (failed) */
+
+  FD_LOG_NOTICE(( "Testing fd_restore_frame_close" ));
+
+  FD_TEST( fd_restore_frame_close( NULL )==FD_CHECKPT_ERR_INVAL ); /* NULL restore */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST(  fd_restore_frame_close( restore )==FD_CHECKPT_ERR_INVAL ); /* close (not in frame) */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );            /* fini (failed) */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_frame_open( restore, style_raw ) );  /* open raw frame */
+  FD_TEST( !fd_restore_frame_close( restore           ) );  /* close (in frame) */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore ); /* fini (normal) */
+
+  FD_LOG_NOTICE(( "Testing fd_restore_buf" ));
+
+  FD_TEST(  fd_restore_buf( NULL, in, data_sz )==FD_CHECKPT_ERR_INVAL ); /* NULL restore */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST(  fd_restore_buf( restore, in, 1UL )==FD_CHECKPT_ERR_INVAL ); /* not in frame */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );             /* fini (normal) */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST(  fd_restore_buf( restore, in, 0UL )==FD_CHECKPT_ERR_INVAL ); /* zero sz (not in frame) */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );             /* fini (normal) */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST(  fd_restore_buf( restore, NULL, 0UL )==FD_CHECKPT_ERR_INVAL ); /* NULL with zero sz (not in frame) */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );               /* fini (normal) */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_frame_open( restore, style_raw ) );  /* open raw frame */
+  FD_TEST( !fd_restore_buf( restore, in,   0UL ) );         /* zero sz */
+  FD_TEST( !fd_restore_buf( restore, NULL, 0UL ) );         /* NULL with zero sz */
+  FD_TEST( !fd_restore_frame_close( restore ) );            /* open raw frame */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore ); /* fini (normal) */
+
+  FD_LOG_NOTICE(( "Testing end-to-end" ));
+
+  ulong off_open;
+  ulong off_close;
+  int   style;
+
+  for( ulong iter=0UL; iter<1000UL; iter++ ) {
+    style = fd_int_if( !(iter & 1UL), style_raw, style_lz4 );
+
+    uchar const * ibuf;
+    uchar       * obuf;
+    ulong         rem;
+    uint          rng_seq;
+    ulong         rng_idx;
+    ulong         frame_sz;
+
+    /* checkpt/restore a single buffer in a single frame */
+
+    RESET( fd );
+    checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+    FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+    FD_TEST( !fd_checkpt_buf( checkpt, in, data_sz ) );
+    FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+    FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
+
+    if( style==style_raw ) FD_TEST( (off_close-off_open)==data_sz );
+
+    memset( out, 0, data_sz );
+    RESET( fd );
+    restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+    FD_TEST( !fd_restore_frame_open( restore, style ) );
+    FD_TEST( !fd_restore_buf( restore, out, data_sz ) );
+    FD_TEST( !fd_restore_frame_close( restore ) );
+    FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
+
+    FD_TEST( !memcmp( in, out, data_sz ) );
+
+    /* checkpt/restore with mixed sized buffers (including zero sized)
+       in a single frame */
+
+    rng_seq = fd_rng_seq( rng ); rng_idx = fd_rng_idx( rng ); /* save rng for restore */
+
+    RESET( fd );
+    checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+    FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+    ibuf = in;
+    rem  = data_sz;
+    while( rem ) {
+      ulong r      = fd_rng_ulong( rng );
+      ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+      ulong buf_sz = fd_ulong_min( rem, r & mask ); /* In [0,128KiB) biased toward small */
+      FD_TEST( !fd_checkpt_buf( checkpt, ibuf, buf_sz ) );
+      ibuf += buf_sz;
+      rem  -= buf_sz;
+    }
+    FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+    FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
+
+    if( style==style_raw ) FD_TEST( (off_close-off_open)==data_sz );
+
+    fd_rng_seq_set( rng, rng_seq ); fd_rng_idx_set( rng, rng_idx ); /* Restore to recreate same checkpt open/buf/close */
+
+    memset( out, 0, data_sz );
+    RESET( fd );
+    restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+    FD_TEST( !fd_restore_frame_open( restore, style ) );
+    obuf = out;
+    rem  = data_sz;
+    while( rem ) {
+      ulong r      = fd_rng_ulong( rng );
+      ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+      ulong buf_sz = fd_ulong_min( rem, r & mask ); /* In [0,128KiB) biased toward small */
+      FD_TEST( !fd_restore_buf( restore, obuf, buf_sz ) );
+      obuf += buf_sz;
+      rem  -= buf_sz;
+    }
+    FD_TEST( !fd_restore_frame_close( restore ) );
+    FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
+
+    FD_TEST( !memcmp( in, out, data_sz ) );
+
+    /* checkpt/restore with mixed sized buffers (including 0 sized)
+       distributed over multiple homegeneous frames (including empty
+       frames) */
+
+    rng_seq = fd_rng_seq( rng ); rng_idx = fd_rng_idx( rng ); /* save rng for restore */
+
+    memset( out, 0, data_sz );
+
+    RESET( fd );
+    checkpt  = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+    frame_sz = 0UL;
+    FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+    ibuf     = in;
+    rem      = data_sz;
+    while( rem ) {
+      ulong r      = fd_rng_ulong( rng );
+      ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+      ulong buf_sz = fd_ulong_min( rem, r & mask ); r >>= 18; /* In [0,128KiB) biased toward small */
+      for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
+        if( FD_LIKELY( r & 7UL ) ) break;
+        r >>= 3;
+        FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+        if( style==style_raw ) FD_TEST( (off_close-off_open)==frame_sz );
+        frame_sz = 0UL;
+        FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+      }
+      FD_TEST( !fd_checkpt_buf( checkpt, ibuf, buf_sz ) );
+      ibuf     += buf_sz;
+      rem      -= buf_sz;
+      frame_sz += buf_sz;
+    }
+    FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+    FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
+
+    if( style==style_raw ) FD_TEST( (off_close-off_open)==frame_sz );
+
+    fd_rng_seq_set( rng, rng_seq ); fd_rng_idx_set( rng, rng_idx ); /* Restore to recreate same checkpt open/buf/close */
+
+    RESET( fd );
+    restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+    FD_TEST( !fd_restore_frame_open( restore, style ) );
+    obuf = out;
+    rem  = data_sz;
+    while( rem ) {
+      ulong r      = fd_rng_ulong( rng );
+      ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+      ulong buf_sz = fd_ulong_min( rem, r & mask ); r >>= 18; /* In [0,128KiB) biased toward small */
+      for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
+        if( FD_LIKELY( r & 7UL ) ) break;
+        r >>= 3;
+        FD_TEST( !fd_restore_frame_close( restore ) );
+        FD_TEST( !fd_restore_frame_open( restore, style ) );
+      }
+      FD_TEST( !fd_restore_buf( restore, obuf, buf_sz ) );
+      if( FD_LIKELY( buf_sz ) ) FD_TEST( !memcmp( in+(data_sz-rem), obuf, buf_sz ) ); /* Test immedate avail */
+      obuf += buf_sz;
+      rem  -= buf_sz;
+    }
+    FD_TEST( !fd_restore_frame_close( restore ) );
+    FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
+
+    FD_TEST( !memcmp( in, out, data_sz ) );
+
+    /* checkpt/restore with mixed sized buffers (including 0 sized)
+       distributed over multiple mixed style frames (including empty
+       frames) */
+
+    rng_seq = fd_rng_seq( rng ); rng_idx = fd_rng_idx( rng ); /* save rng for restore */
+
+    RESET( fd );
+    checkpt  = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+    style    = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
+    frame_sz = 0UL;
+    FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+    ibuf     = in;
+    rem      = data_sz;
+    while( rem ) {
+      ulong r      = fd_rng_ulong( rng );
+      ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+      ulong buf_sz = fd_ulong_min( rem, r & mask ); r >>= 18; /* In [0,128KiB) biased toward small */
+      for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
+        if( FD_LIKELY( r & 7UL ) ) break;
+        r >>= 3;
+        FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+        if( style==style_raw ) FD_TEST( (off_close-off_open)==frame_sz );
+        /* FIXME: consider comparing frame bytes when raw? */
+        style    = fd_int_if( !(r & 1UL), style_raw, style_lz4 ); r >>= 1;
+        frame_sz = 0UL;
+        FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+      }
+      FD_TEST( !fd_checkpt_buf( checkpt, ibuf, buf_sz ) );
+      ibuf     += buf_sz;
+      rem      -= buf_sz;
+      frame_sz += buf_sz;
+    }
+    FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+    FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
+
+    fd_rng_seq_set( rng, rng_seq ); fd_rng_idx_set( rng, rng_idx ); /* Restore to recreate same checkpt open/buf/close */
+
+    memset( out, 0, data_sz );
+
+    RESET( fd );
+    restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+    style   = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
+    FD_TEST( !fd_restore_frame_open( restore, style ) );
+    obuf = out;
+    rem  = data_sz;
+    while( rem ) {
+      ulong r      = fd_rng_ulong( rng );
+      ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+      ulong buf_sz = fd_ulong_min( rem, r & mask ); r >>= 18; /* In [0,128KiB) biased toward small */
+      for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
+        if( FD_LIKELY( r & 7UL ) ) break;
+        r >>= 3;
+        FD_TEST( !fd_restore_frame_close( restore ) );
+        style = fd_int_if( !(r & 1UL), style_raw, style_lz4 ); r >>= 1;
+        FD_TEST( !fd_restore_frame_open( restore, style ) );
+      }
+      FD_TEST( !fd_restore_buf( restore, obuf, buf_sz ) );
+      if( FD_LIKELY( buf_sz ) ) FD_TEST( !memcmp( in+(data_sz-rem), obuf, buf_sz ) ); /* Test immedate avail */
+      obuf += buf_sz;
+      rem  -= buf_sz;
+    }
+    FD_TEST( !fd_restore_frame_close( restore ) );
+    FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
+
+    FD_TEST( !memcmp( in, out, data_sz ) );
+
+    /* checkpt(mmio)/restore(stream) with mixed sized buffers (including
+       0 sized) distributed over multiple mixed style frames (including
+       empty frames) */
+
+    rng_seq = fd_rng_seq( rng ); rng_idx = fd_rng_idx( rng ); /* save rng for restore */
+
+    memset( out, 0, mmio_sz );
+
+    checkpt  = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
+    style    = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
+    frame_sz = 0UL;
+    FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+    ibuf     = in;
+    rem      = data_sz;
+    while( rem ) {
+      ulong r      = fd_rng_ulong( rng );
+      ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+      ulong buf_sz = fd_ulong_min( rem, r & mask ); r >>= 18; /* In [0,128KiB) biased toward small */
+      for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
+        if( FD_LIKELY( r & 7UL ) ) break;
+        r >>= 3;
+        FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+        if( style==style_raw ) FD_TEST( (off_close-off_open)==frame_sz );
+        /* FIXME: consider comparing frame bytes when raw? */
+        style    = fd_int_if( !(r & 1UL), style_raw, style_lz4 ); r >>= 1;
+        frame_sz = 0UL;
+        FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+      }
+      FD_TEST( !fd_checkpt_buf( checkpt, ibuf, buf_sz ) );
+      ibuf     += buf_sz;
+      rem      -= buf_sz;
+      frame_sz += buf_sz;
+    }
+    FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+    FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
+
+    RESET( fd );
+    ulong wsz;
+    FD_TEST( !fd_io_write( fd, mmio, mmio_sz, mmio_sz, &wsz ) );
+
+    fd_rng_seq_set( rng, rng_seq ); fd_rng_idx_set( rng, rng_idx ); /* Restore to recreate same checkpt open/buf/close */
+
+    memset( out, 0, data_sz );
+
+    RESET( fd );
+    restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+    style   = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
+    FD_TEST( !fd_restore_frame_open( restore, style ) );
+    obuf = out;
+    rem  = data_sz;
+    while( rem ) {
+      ulong r      = fd_rng_ulong( rng );
+      ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+      ulong buf_sz = fd_ulong_min( rem, r & mask ); r >>= 18; /* In [0,128KiB) biased toward small */
+      for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
+        if( FD_LIKELY( r & 7UL ) ) break;
+        r >>= 3;
+        FD_TEST( !fd_restore_frame_close( restore ) );
+        style = fd_int_if( !(r & 1UL), style_raw, style_lz4 ); r >>= 1;
+        FD_TEST( !fd_restore_frame_open( restore, style ) );
+      }
+      FD_TEST( !fd_restore_buf( restore, obuf, buf_sz ) );
+      if( FD_LIKELY( buf_sz ) ) FD_TEST( !memcmp( in+(data_sz-rem), obuf, buf_sz ) ); /* Test immedate avail */
+      obuf += buf_sz;
+      rem  -= buf_sz;
+    }
+    FD_TEST( !fd_restore_frame_close( restore ) );
+    FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
+
+    FD_TEST( !memcmp( in, out, data_sz ) );
+
+    /* checkpt(stream)/restore(mmio) with mixed sized buffers (including
+       0 sized) distributed over multiple mixed style frames (including
+       empty frames) */
+
+    rng_seq = fd_rng_seq( rng ); rng_idx = fd_rng_idx( rng ); /* save rng for restore */
+
+    RESET( fd );
+    checkpt  = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+    style    = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
+    frame_sz = 0UL;
+    FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+    ibuf     = in;
+    rem      = data_sz;
+    while( rem ) {
+      ulong r      = fd_rng_ulong( rng );
+      ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+      ulong buf_sz = fd_ulong_min( rem, r & mask ); r >>= 18; /* In [0,128KiB) biased toward small */
+      for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
+        if( FD_LIKELY( r & 7UL ) ) break;
+        r >>= 3;
+        FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+        if( style==style_raw ) FD_TEST( (off_close-off_open)==frame_sz );
+        /* FIXME: consider comparing frame bytes when raw? */
+        style    = fd_int_if( !(r & 1UL), style_raw, style_lz4 ); r >>= 1;
+        frame_sz = 0UL;
+        FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+      }
+      FD_TEST( !fd_checkpt_buf( checkpt, ibuf, buf_sz ) );
+      ibuf     += buf_sz;
+      rem      -= buf_sz;
+      frame_sz += buf_sz;
+    }
+    FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+    FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
+
+    fd_rng_seq_set( rng, rng_seq ); fd_rng_idx_set( rng, rng_idx ); /* Restore to recreate same checkpt open/buf/close */
+
+    memset( out, 0, data_sz );
+
+    RESET( fd );
+    ulong rsz;
+    FD_TEST( !fd_io_read( fd, mmio, 1UL, mmio_sz, &rsz ) );
+
+    restore = fd_restore_init_mmio( _restore, mmio, rsz ); FD_TEST( restore==_restore );
+    style   = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
+    FD_TEST( !fd_restore_frame_open( restore, style ) );
+    obuf = out;
+    rem  = data_sz;
+    while( rem ) {
+      ulong r      = fd_rng_ulong( rng );
+      ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
+      ulong buf_sz = fd_ulong_min( rem, r & mask ); r >>= 18; /* In [0,128KiB) biased toward small */
+      for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
+        if( FD_LIKELY( r & 7UL ) ) break;
+        r >>= 3;
+        FD_TEST( !fd_restore_frame_close( restore ) );
+        style = fd_int_if( !(r & 1UL), style_raw, style_lz4 ); r >>= 1;
+        FD_TEST( !fd_restore_frame_open( restore, style ) );
+      }
+      FD_TEST( !fd_restore_buf( restore, obuf, buf_sz ) );
+      if( FD_LIKELY( buf_sz ) ) FD_TEST( !memcmp( in+(data_sz-rem), obuf, buf_sz ) ); /* Test immedate avail */
+      obuf += buf_sz;
+      rem  -= buf_sz;
+    }
+    FD_TEST( !fd_restore_frame_close( restore ) );
+    FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
+
+    FD_TEST( !memcmp( in, out, data_sz ) );
+
+    /* Note: mmio/mmio tested in test_checkpt_mmio */
+  }
+
+# undef RESET
+
+  fd_rng_delete( fd_rng_leave( rng ) );
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}

--- a/src/util/checkpt/test_checkpt_stream.c
+++ b/src/util/checkpt/test_checkpt_stream.c
@@ -16,6 +16,9 @@ static uchar mmio[ BUF_MAX ];
 static uchar rbuf[ BUF_MAX ];
 static uchar wbuf[ BUF_MAX ];
 
+static fd_checkpt_t _checkpt[1];
+static fd_restore_t _restore[1];
+
 int
 main( int argc,
       char ** argv ) {
@@ -90,9 +93,6 @@ main( int argc,
     if( FD_UNLIKELY( lseek( (fd), (off_t)0, SEEK_SET ) ) )                    \
       FD_LOG_ERR(( "lseek failed (%i-%s)", errno, fd_io_strerror( errno ) )); \
   } while(0)
-
-  fd_checkpt_t _checkpt[1];
-  fd_restore_t _restore[1];
 
   FD_LOG_NOTICE(( "Testing fd_checkpt_init_stream" ));
 

--- a/src/util/fd_util.h
+++ b/src/util/fd_util.h
@@ -12,6 +12,7 @@
 //#include "env/fd_env.h"           /* includes cstr/fd_cstr.h */
 //#include "log/fd_log.h"           /* includes env/fd_env.h io/fd_io.h */
 //#include "shmem/fd_shmem.h"       /* includes log/fd_log.h */
+#include "checkpt/fd_checkpt.h"     /* includes log/fd_log.h */
 //#include "tile/fd_tile.h"         /* includes shmem/fd_shmem.h */
 //#include "wksp/fd_wksp.h"         /* includes shmem/fd_shmem.h pod/fd_pod.h */
 //#include "valloc/fd_valloc.h"     /* includes fd_util_base.h */

--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -190,6 +190,20 @@
 #define FD_HAS_AESNI 0
 #endif
 
+/* FD_HAS_LZ4 indicates that the target supports LZ4 compression.
+   Roughly, does "#include <lz4.h>" and the APIs therein work? */
+
+#ifndef FD_HAS_LZ4
+#define FD_HAS_LZ4 0
+#endif
+
+/* FD_HAS_ZSTD indicates that the target supports ZSTD compression.
+   Roughly, does "#include <zstd.h>" and the APIs therein work? */
+
+#ifndef FD_HAS_ZSTD
+#define FD_HAS_ZSTD 0
+#endif
+
 /* FD_HAS_COVERAGE indicates that the build target is built with coverage instrumentation. */
 
 #ifndef FD_HAS_COVERAGE


### PR DESCRIPTION
This implements low level APIs installed to facilitate high performance workspace checkpointing and fast snapshots.

- Currently needs proper updating of deps.sh to include the appropriate lz4 library (will work without it though ... compressed frames will not be supported).

- Also added a missing FD_HAS_ZSTD default to fd_util_base.h to match FD_HAS_LZ4 and fixed an #if / #ifdef confusion in fd_snapshot_istream.h.