### PR TITLE
rng: add fd_rng_secure API

### DIFF
--- a/src/util/rng/Local.mk
+++ b/src/util/rng/Local.mk
@@ -1,5 +1,5 @@
 $(call add-hdrs,fd_rng.h)
-$(call add-objs,fd_rng,fd_util)
+$(call add-objs,fd_rng fd_rng_secure,fd_util)
 $(call make-unit-test,test_rng,test_rng,fd_util)
 $(call run-unit-test,test_rng,)
 

--- a/src/util/rng/fd_rng.h
+++ b/src/util/rng/fd_rng.h
@@ -449,6 +449,25 @@ double fd_rng_double_norm  ( fd_rng_t * rng );
    FOR SET, ATOMIC_INC OF INDEX FOR THE RETURN TYPES, CAS STATE UPDATES,
    ETC) */
 
+/* fd_rng_secure reads random bytes from a cryptographically secure
+   source provided by the platform.  Features /dev/urandom like entropy.  
+
+   On success, returns d and guarantees that [d,d+sz) is filled with 
+   unguessable random bytes.  On failure, returns NULL and prints reason
+   for failure to warning log.
+
+   (!!!) This operation may fail if no secure RNG is available or the
+         RNG failed for some reason.  Always check the return code.
+   
+   Currently available on Linux, FreeBSD, and macOS.
+   On Linux and FreeBSD uses getrandom(2).
+   On macOS uses CommonCrypto's CommonRandom. */
+
+FD_FN_SENSITIVE __attribute__((warn_unused_result))
+void *
+fd_rng_secure( void * d,
+               ulong  sz );
+
 FD_PROTOTYPES_END
 
 #if FD_HAS_X86
@@ -486,6 +505,8 @@ FD_PROTOTYPES_END
      random number generator hardware can supply them. This will lead to
      the RDRAND instruction returning no data transitorily. */
 
+FD_PROTOTYPES_BEGIN
+
 __attribute__((warn_unused_result)) static inline int
 fd_rdrand( uchar * dst,
            ulong   sz ) {
@@ -510,6 +531,8 @@ fd_rdrand( uchar * dst,
 
   return 1;
 }
+
+FD_PROTOTYPES_END
 
 #endif /* FD_HAS_X86 */
 

--- a/src/util/rng/fd_rng_secure.c
+++ b/src/util/rng/fd_rng_secure.c
@@ -1,0 +1,57 @@
+#include "fd_rng.h"
+#include "../log/fd_log.h"
+
+/* Choose best fd_rng_secure based on platform */
+
+#if defined(__linux__) || defined(__FreeBSD__)
+
+#include <assert.h>
+#include <errno.h>
+#include <sys/random.h>
+
+FD_FN_SENSITIVE __attribute__((warn_unused_result))
+void *
+fd_rng_secure( void * d,
+               ulong  sz ) {
+  uchar * out = d;
+  while( sz ) {
+    long res = getrandom( out, sz, 0 );
+    if( FD_UNLIKELY( res<0 ) ) {
+      FD_LOG_WARNING(( "getrandom(sz=%lu) failed (%d-%s)", sz, errno, fd_io_strerror( errno ) ));
+      return NULL;
+    }
+    assert( (ulong)res <= sz );
+    sz -= (ulong)res;
+  }
+  return d;
+} 
+
+#elif defined(__APPLE__)
+
+#include <CommonCrypto/CommonRandom.h>
+
+FD_FN_SENSITIVE __attribute__((warn_unused_result))
+void *
+fd_rng_secure( void * d,
+               ulong  sz ) {
+
+  int status = CCRandomGenerateBytes( d, sz );
+  if( FD_UNLIKELY( status!=kCCSuccess ) ) {
+    FD_LOG_WARNING(( "CCRandomGenerateBytes(sz=%lu) failed (%d)", sz, status ));
+    return NULL;
+  }
+
+  return d;
+}
+
+#else
+
+FD_FN_SENSITIVE __attribute__((warn_unused_result))
+void *
+fd_rng_secure( void * d,
+               ulong  sz ) {
+  FD_LOG_WARNING(( "fd_rng_secure failed (not supported by this build)" ));
+  return NULL;
+} 
+
+#endif


### PR DESCRIPTION
Adds secure RNG for Linux, FreeBSD, and macOS.
