### PR TITLE
flamenco: bpf loader null memcpy guard

### DIFF
--- a/contrib/test/instr-fixtures.list
+++ b/contrib/test/instr-fixtures.list
@@ -6216,3 +6216,4 @@ dump/test-vectors/instr/fixtures/vote/fe8df142a90fadf7ebfec8e72be3f9b35b11966e.f
 dump/test-vectors/instr/fixtures/vote/feed79286bb39c48daef4fcc4e4330d776072206.fix
 dump/test-vectors/instr/fixtures/bpf-loader-v3-programs/4c3874406b6bc014434a6b08cfd7ce957005c299.fix
 dump/test-vectors/instr/fixtures/bpf-loader-v3-programs/crash-61560dca014f17632760e7915b271cfba4fdb121.fix
+dump/test-vectors/instr/fixtures/bpf-loader-v3/84b8ae94c85eccaf6504d8d247c18d4ad9276d8e.fix

--- a/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
@@ -218,7 +218,10 @@ write_program_data( fd_borrowed_account_t * program,
     return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
   }
 
-  fd_memcpy( program->data+program_data_offset, bytes, bytes_len );
+  if( FD_LIKELY( bytes_len ) ) {
+    fd_memcpy( program->data+program_data_offset, bytes, bytes_len );
+  }
+
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
 


### PR DESCRIPTION
https://github.com/firedancer-io/auditor-internal/issues/119
Ubsan throws an error if we try to memcpy null pointer with zero length