### PR TITLE
flamenco: borrowed account scoping macro + fd_account api cleanup

### DIFF
--- a/contrib/test/instr-fixtures.list
+++ b/contrib/test/instr-fixtures.list
@@ -6229,3 +6229,4 @@ dump/test-vectors/instr/fixtures/vote/12ddcd6cb39895e0df6ff0130f574d23a238daeb.f
 dump/test-vectors/instr/fixtures/bpf-loader-v3-programs/4c3874406b6bc014434a6b08cfd7ce957005c299.fix
 dump/test-vectors/instr/fixtures/bpf-loader-v3-programs/crash-61560dca014f17632760e7915b271cfba4fdb121.fix
 dump/test-vectors/instr/fixtures/address-lookup-table/crash-1f3cff85b351a070fa572e17f61439fff44d4eda.fix
+dump/test-vectors/instr/fixtures/bpf-loader-v3/84b8ae94c85eccaf6504d8d247c18d4ad9276d8e.fix

--- a/src/flamenco/runtime/context/fd_exec_instr_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_instr_ctx.h
@@ -55,8 +55,9 @@ static inline int
 fd_instr_borrowed_account_view_idx( fd_exec_instr_ctx_t const * ctx,
                                     ulong                       idx,
                                     fd_borrowed_account_t **    account ) {
-  if( idx >= ctx->instr->acct_cnt )
+  if( FD_UNLIKELY( idx >= ctx->instr->acct_cnt ) ) {
     return FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT;
+  }
 
   fd_borrowed_account_t * instr_account = ctx->instr->borrowed_accounts[idx];
   FD_TEST( instr_account->const_meta != NULL );
@@ -68,6 +69,7 @@ int
 fd_instr_borrowed_account_view( fd_exec_instr_ctx_t *    ctx,
                                 fd_pubkey_t const *      pubkey,
                                 fd_borrowed_account_t ** account );
+
 int
 fd_instr_borrowed_account_modify_idx( fd_exec_instr_ctx_t const * ctx,
                                       ulong                       idx,

--- a/src/flamenco/runtime/fd_account.c
+++ b/src/flamenco/runtime/fd_account.c
@@ -1,82 +1,58 @@
 #include "fd_account.h"
 #include "context/fd_exec_instr_ctx.h"
 
-int
-fd_account_set_executable( fd_exec_instr_ctx_t const * ctx,
-                           ulong                       instr_acc_idx,
-                           int                         executable ) {
-
-  fd_instr_info_t const * instr = ctx->instr;
-
-  fd_borrowed_account_t * account = NULL;
-  do {
-    int err = fd_instr_borrowed_account_view_idx( ctx, (uchar)instr_acc_idx, &account );
-    if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "fd_instr_borrowed_account_view_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
-  } while(0);
-
-  fd_account_meta_t const * meta = account->const_meta;
-
-  fd_epoch_bank_t const * epoch_bank = fd_exec_epoch_ctx_epoch_bank_const( ctx->epoch_ctx );
-  fd_rent_t const * rent = &epoch_bank->rent;
-  if( FD_UNLIKELY( !fd_rent_exempt_minimum_balance2( rent, meta->dlen ) ) )
-    return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_ACCOUNT_NOT_RENT_EXEMPT;
-
-  if( !fd_account_is_owned_by_current_program( instr, meta ) )
-    return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_MODIFIED;
-  if( !fd_instr_acc_is_writable_idx( instr, instr_acc_idx ) )
-    return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_MODIFIED;
-  if( fd_account_is_executable( meta ) && !executable )
-    return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_MODIFIED;
-  if( fd_account_is_executable( meta ) == executable )
-    return FD_EXECUTOR_INSTR_SUCCESS;
-
-  do {
-    int err = fd_instr_borrowed_account_modify_idx( ctx, (uchar)instr_acc_idx, 0UL, &account );
-    if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "fd_instr_borrowed_account_modify_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
-  } while(0);
-
-  account->meta->info.executable = !!executable;
-  return FD_EXECUTOR_INSTR_SUCCESS;
-}
-
 /* https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L740-L767 */
+/* Assignes the owner of this account (transaction wide) */
 int
 fd_account_set_owner( fd_exec_instr_ctx_t const * ctx,
                       ulong                       instr_acc_idx,
                       fd_pubkey_t const *         owner ) {
 
   fd_instr_info_t const * instr = ctx->instr;
-
   fd_borrowed_account_t * account = NULL;
   do {
     int err = fd_instr_borrowed_account_view_idx( ctx, (uchar)instr_acc_idx, &account );
-    if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "fd_instr_borrowed_account_view_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    if( FD_UNLIKELY( err ) ) {
+      FD_LOG_ERR(( "fd_instr_borrowed_account_view_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    }
   } while(0);
 
   fd_account_meta_t const * meta = account->const_meta;
 
+  /* Only the owner can assign a new owner */
   if( !fd_account_is_owned_by_current_program( instr, meta ) ) {
     return FD_EXECUTOR_INSTR_ERR_MODIFIED_PROGRAM_ID;
   }
+  /* And only if the account is writable */
   if( !fd_instr_acc_is_writable_idx( instr, instr_acc_idx ) ) {
     return FD_EXECUTOR_INSTR_ERR_MODIFIED_PROGRAM_ID;
   }
+  /* And only if the account is not executable */
   if( fd_account_is_executable( meta ) ) {
     return FD_EXECUTOR_INSTR_ERR_MODIFIED_PROGRAM_ID;
   }
+  /* And only if the data is zero-initialized or empty */
   if( !fd_account_is_zeroed( meta ) ) {
     return FD_EXECUTOR_INSTR_ERR_MODIFIED_PROGRAM_ID;
+  }
+  /* Don't touch the account if the owner does not change */
+  if( !memcmp( account->const_meta->info.owner, owner, sizeof( fd_pubkey_t ) ) ) {
+    return FD_EXECUTOR_INSTR_SUCCESS;
   }
 
   do {
     int err = fd_instr_borrowed_account_modify_idx( ctx, (uchar)instr_acc_idx, 0UL, &account );
-    if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "fd_instr_borrowed_account_modify_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    if( FD_UNLIKELY( err ) ) {
+      FD_LOG_ERR(( "fd_instr_borrowed_account_modify_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    }
   } while(0);
 
   memcpy( account->meta->info.owner, owner, sizeof(fd_pubkey_t) );
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
 
+/* https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L774-L796 */
+/* Overwrites the number of lamports of this account (transaction wide) */
 int
 fd_account_set_lamports( fd_exec_instr_ctx_t const * ctx,
                          ulong                       instr_acc_idx,
@@ -85,28 +61,66 @@ fd_account_set_lamports( fd_exec_instr_ctx_t const * ctx,
   fd_borrowed_account_t * account = NULL;
   do {
     int err = fd_instr_borrowed_account_view_idx( ctx, (uchar)instr_acc_idx, &account );
-    if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "fd_instr_borrowed_account_view_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    if( FD_UNLIKELY( err ) ) { 
+      FD_LOG_ERR(( "fd_instr_borrowed_account_view_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    }
   } while(0);
-
-  if( FD_UNLIKELY( ( !fd_account_is_owned_by_current_program( ctx->instr, account->const_meta ) ) &
+  
+  /* An account not owned by the program cannot have its blanace decrease */
+  if( FD_UNLIKELY( ( !fd_account_is_owned_by_current_program( ctx->instr, account->const_meta ) ) &&
                    ( lamports < account->const_meta->info.lamports ) ) )
     return FD_EXECUTOR_INSTR_ERR_EXTERNAL_ACCOUNT_LAMPORT_SPEND;
 
+  /* The balance of read-only may not change */
   if( FD_UNLIKELY( !fd_instr_acc_is_writable_idx( ctx->instr, instr_acc_idx ) ) )
     return FD_EXECUTOR_INSTR_ERR_READONLY_LAMPORT_CHANGE;
 
+  /* The balance of executable accounts may not change */
   if( FD_UNLIKELY( fd_account_is_executable( account->const_meta ) ) )
     return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_LAMPORT_CHANGE;
 
-  if( lamports == account->const_meta->info.lamports ) return 0;
+  /* Don't touch the account if the lamports do not change */
+  if( lamports==account->const_meta->info.lamports ) {
+   return FD_EXECUTOR_INSTR_SUCCESS;
+  }
 
   do {
     int err = fd_instr_borrowed_account_modify_idx( ctx, (uchar)instr_acc_idx, 0UL, &account );
-    if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "fd_instr_borrowed_account_modify_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    if( FD_UNLIKELY( err ) ) { 
+      FD_LOG_ERR(( "fd_instr_borrowed_account_modify_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    }
   } while(0);
 
   account->meta->info.lamports = lamports;
-  return 0;
+  return FD_EXECUTOR_INSTR_SUCCESS;
+}
+
+int 
+fd_account_get_data_mut( fd_exec_instr_ctx_t const * ctx, 
+                         ulong                       instr_acc_idx,
+                         uchar * *                   data_out,
+                         ulong *                     dlen_out ) {
+  
+  int err;
+  if( FD_UNLIKELY( !fd_account_can_data_be_changed( ctx->instr, instr_acc_idx, &err ) ) ) {
+    return err;
+  }
+
+  fd_borrowed_account_t * account = NULL;
+  do {
+    int err = fd_instr_borrowed_account_view_idx( ctx, (uchar)instr_acc_idx, &account );
+    if( FD_UNLIKELY( err ) ) { 
+      FD_LOG_ERR(( "fd_instr_borrowed_account_modify_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    }
+  } while(0);
+
+  /* Equivalent of touch() */
+  account->meta->slot = ctx->slot_ctx->slot_bank.slot;
+
+  *data_out = account->data;
+  *dlen_out = account->meta->dlen;
+
+  return FD_EXECUTOR_INSTR_SUCCESS;
 }
 
 int
@@ -115,19 +129,23 @@ fd_account_set_data_from_slice( fd_exec_instr_ctx_t const * ctx,
                                 uchar const *               data,
                                 ulong                       data_sz ) {
 
-  int err = 0;
+  int err = FD_EXECUTOR_INSTR_SUCCESS;
 
   fd_borrowed_account_t * account = NULL;
   do {
     int err = fd_instr_borrowed_account_view_idx( ctx, (uchar)instr_acc_idx, &account );
-    if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "fd_instr_borrowed_account_view_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    if( FD_UNLIKELY( err ) ) {
+      FD_LOG_ERR(( "fd_instr_borrowed_account_view_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    }
   } while(0);
 
-  if( !fd_account_can_data_be_resized( ctx, account->const_meta, data_sz, &err ) )
+  if( !fd_account_can_data_be_resized( ctx, account->const_meta, data_sz, &err ) ) {
     return err;
+  }
 
-  if( !fd_account_can_data_be_changed( ctx->instr, instr_acc_idx, &err ) )
+  if( !fd_account_can_data_be_changed( ctx->instr, instr_acc_idx, &err ) ) {
     return err;
+  }
 
   if( !fd_account_update_accounts_resize_delta( ctx, instr_acc_idx, data_sz, &err ) ) {
     return err;
@@ -135,8 +153,12 @@ fd_account_set_data_from_slice( fd_exec_instr_ctx_t const * ctx,
 
   do {
     int err = fd_instr_borrowed_account_modify_idx( ctx, (uchar)instr_acc_idx, data_sz, &account );
-    if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "fd_instr_borrowed_account_modify_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    if( FD_UNLIKELY( err ) ) { 
+      FD_LOG_ERR(( "fd_instr_borrowed_account_modify_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    }
   } while(0);
+
+  account->meta->slot = ctx->slot_ctx->slot_bank.slot;
 
   assert( account->meta->dlen >= data_sz );
   fd_memcpy( account->data, data, data_sz );
@@ -146,42 +168,104 @@ fd_account_set_data_from_slice( fd_exec_instr_ctx_t const * ctx,
 int
 fd_account_set_data_length( fd_exec_instr_ctx_t const * ctx,
                             ulong                       instr_acc_idx,
-                            ulong                       new_len,
-                            int *                       err ) {
+                            ulong                       new_len ) {
 
   fd_borrowed_account_t * account = NULL;
   do {
     int err = fd_instr_borrowed_account_view_idx( ctx, (uchar)instr_acc_idx, &account );
-    if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "fd_instr_borrowed_account_view_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    if( FD_UNLIKELY( err ) ) {
+      FD_LOG_ERR(( "fd_instr_borrowed_account_view_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    }
   } while(0);
 
-  if( !fd_account_can_data_be_resized( ctx, account->const_meta, new_len, err ) )
-    return 0;
+  int err = FD_EXECUTOR_INSTR_SUCCESS;
+  if( !fd_account_can_data_be_resized( ctx, account->const_meta, new_len, &err ) ) {
+    return err;
+  }
 
-  if( !fd_account_can_data_be_changed( ctx->instr, instr_acc_idx, err ) )
-    return 0;
+  if( !fd_account_can_data_be_changed( ctx->instr, instr_acc_idx, &err ) ) {
+    return err;
+  }
 
   ulong old_len = account->const_meta->dlen;
 
-  if( old_len == new_len )
-    return 1;
+  /* Don't touch the account if the length does not change */
+  if( old_len==new_len ) {
+    return FD_EXECUTOR_INSTR_SUCCESS;
+  }
 
-  if( !fd_account_update_accounts_resize_delta( ctx, instr_acc_idx, new_len, err ) ) {
-    return 0;
+  if( !fd_account_update_accounts_resize_delta( ctx, instr_acc_idx, new_len, &err ) ) {
+    return err;
   }
 
   do {
     int err = fd_instr_borrowed_account_modify_idx( ctx, (uchar)instr_acc_idx, new_len, &account );
-    if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "fd_instr_borrowed_account_modify_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    if( FD_UNLIKELY( err ) ) {
+      FD_LOG_ERR(( "fd_instr_borrowed_account_modify_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    }
   } while(0);
 
-  if( new_len > old_len ) {
-    fd_memset( account->data + old_len, 0, new_len - old_len );
+  if( new_len>old_len ) {
+    fd_memset( account->data+old_len, 0, new_len-old_len );
   }
 
   account->meta->dlen = new_len;
+  return FD_EXECUTOR_INSTR_SUCCESS;
+}
 
-  return 1;
+int
+fd_account_set_executable( fd_exec_instr_ctx_t const * ctx,
+                           ulong                       instr_acc_idx,
+                           int                         is_executable ) {
+
+  fd_instr_info_t const * instr = ctx->instr;
+
+  fd_borrowed_account_t * account = NULL;
+  do {
+    int err = fd_instr_borrowed_account_view_idx( ctx, (uchar)instr_acc_idx, &account );
+    if( FD_UNLIKELY( err ) ) {
+      FD_LOG_ERR(( "fd_instr_borrowed_account_view_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    }
+  } while(0);
+
+  fd_account_meta_t const * meta = account->const_meta;
+
+  /* To become executable an account must be rent exempt */
+  fd_epoch_bank_t const * epoch_bank = fd_exec_epoch_ctx_epoch_bank_const( ctx->epoch_ctx );
+  fd_rent_t const * rent = &epoch_bank->rent;
+  if( FD_UNLIKELY( !fd_rent_exempt_minimum_balance2( rent, meta->dlen ) ) ) {
+    return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_ACCOUNT_NOT_RENT_EXEMPT;
+  }
+
+  /* Only the owner can set the exectuable flag */
+  if( FD_UNLIKELY( !fd_account_is_owned_by_current_program( instr, meta ) ) ) {
+    return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_MODIFIED;
+  }
+
+  /* And only if the account is writable */
+  if( FD_UNLIKELY( !fd_instr_acc_is_writable_idx( instr, instr_acc_idx ) ) ) {
+    return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_MODIFIED;
+  }
+
+  /* One can not clear the executable flag  */
+  if( FD_UNLIKELY( fd_account_is_executable( meta ) && !is_executable ) ) {
+    return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_MODIFIED;
+  }
+
+  /* Don't touch the account if the exectuable flag does not change */
+  if( fd_account_is_executable( meta ) == is_executable ) {
+    return FD_EXECUTOR_INSTR_SUCCESS;
+  }
+
+  do {
+    int err = fd_instr_borrowed_account_modify_idx( ctx, (uchar)instr_acc_idx, 0UL, &account );
+    if( FD_UNLIKELY( err ) ) { 
+      FD_LOG_ERR(( "fd_instr_borrowed_account_modify_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    }
+  } while(0);
+
+  account->meta->info.executable = !!is_executable;
+  return FD_EXECUTOR_INSTR_SUCCESS;
 }
 
 /* https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L1128-L1138 */

--- a/src/flamenco/runtime/fd_account.h
+++ b/src/flamenco/runtime/fd_account.h
@@ -40,30 +40,253 @@
 #include "fd_system_ids.h"
 #include "context/fd_exec_epoch_ctx.h"
 #include "context/fd_exec_txn_ctx.h"
+#include "program/fd_program_util.h"
+#include "sysvar/fd_sysvar_rent.h"
 #include <assert.h>  /* TODO remove */
 
 /* FD_ACC_SZ_MAX is the hardcoded size limit of a Solana account. */
 
-#define MAX_PERMITTED_DATA_LENGTH                               (10UL<<20) /* 10MiB */
+#define MAX_PERMITTED_DATA_LENGTH                 (10UL<<20) /* 10MiB */
 #define MAX_PERMITTED_ACCOUNT_DATA_ALLOCS_PER_TXN (10UL<<21) /* 20MiB */
 
 FD_PROTOTYPES_BEGIN
 
 /* Instruction account APIs *******************************************/
 
+/* Assert that enougha ccounts were supplied to this instruction. Returns 
+   FD_EXECUTOR_INSTR_SUCCESS if the number of accounts is as expected and 
+   FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS otherwise.
+   https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L492-L503 */
+static inline int
+fd_account_check_num_insn_accounts( fd_exec_instr_ctx_t * ctx,
+                                    uint                  expected_accounts ) {
+
+  if( FD_UNLIKELY( ctx->instr->acct_cnt<expected_accounts ) ) {
+    return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+  }
+  return FD_EXECUTOR_INSTR_SUCCESS;
+}
+
+/* fd_account_get_owner mirrors Anza function 
+   solana_sdk::transaction_context:Borrowed_account::get_owner.  Returns 0
+   iff the owner is retrieved successfully.
+   https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L734-L738 */
+static inline fd_pubkey_t const *
+fd_account_get_owner( fd_exec_instr_ctx_t const * ctx,
+                      ulong                       instr_acc_idx ) {
+  fd_borrowed_account_t * account = NULL;
+  do {
+    int err = fd_instr_borrowed_account_view_idx( ctx, (uchar)instr_acc_idx, &account );
+    if( FD_UNLIKELY( err ) ) {
+      FD_LOG_ERR(( "fd_instr_borrowed_account_view_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    }
+  } while(0);
+
+  return (fd_pubkey_t const *) account->const_meta->info.owner;
+}
+
+/* fd_account_set_owner mirrors Anza function 
+   solana_sdk::transaction_context:Borrowed_account::set_owner.  Returns 0
+   iff the owner is set successfully.  Acquires a writable handle. */
+int
+fd_account_set_owner( fd_exec_instr_ctx_t const * ctx,
+                      ulong                       instr_acc_idx,
+                      fd_pubkey_t const *         owner );
+
+/* fd_account_get_lamports mirrors Anza function
+   solana_sdk::transaction_context::BorrowedAccount::get_lamports.
+   Returns current number of lamports in account.  Well behaved if meta
+   is NULL. */
+
+static inline ulong
+fd_account_get_lamports( fd_account_meta_t const * meta ) {
+  if( FD_UNLIKELY( !meta ) ) return 0UL;  /* (!meta) considered an internal error */
+  return meta->info.lamports;
+}
+
+static inline ulong
+fd_account_get_lamports2( fd_exec_instr_ctx_t const * ctx,
+                          ulong                       instr_acc_idx ) {
+  fd_borrowed_account_t * account = NULL;
+  do {
+    int err = fd_instr_borrowed_account_view_idx( ctx, (uchar)instr_acc_idx, &account );
+    if( FD_UNLIKELY( err ) ) {
+      return 0UL;
+    }
+  } while(0);
+
+  return account->const_meta->info.lamports;
+}
+
+/* fd_account_set_lamports mirrors Anza function
+   solana_sdk::transaction_context::BorrowedAccount::set_lamports.
+   Runs through a sequence of permission checks, then sets the account
+   balance.  Does not update global capitalization.  On success, returns
+   0 and updates meta->lamports.  On failure, returns an
+   FD_EXECUTOR_INSTR_ERR_{...} code.  Acquires a writable handle. */
+
+int
+fd_account_set_lamports( fd_exec_instr_ctx_t const * ctx,
+                         ulong                       instr_acc_idx,
+                         ulong                       lamports );
+
+/* 
+  fd_account_checked_{add,sub}_lamports mirros Anza 
+   add/removes lamports to/from an
+   account.  Does not update global capitalization.  Returns 0 on
+   success or an FD_EXECUTOR_INSTR_ERR_{...} code on failure.
+   Gracefully handles underflow.  Acquires a writable handle. 
+   https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L798-L817 */
+
+static inline int
+fd_account_checked_add_lamports( fd_exec_instr_ctx_t const * ctx,
+                                 ulong                       instr_acc_idx,
+                                 ulong                       lamports ) {
+
+  fd_borrowed_account_t * account = NULL;
+  do {
+    int err = fd_instr_borrowed_account_modify_idx( ctx, (uchar)instr_acc_idx, 0UL, &account );
+    if( FD_UNLIKELY( err ) ) { 
+      FD_LOG_ERR(( "fd_instr_borrowed_account_modify_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    }
+  } while(0);
+
+  ulong balance_post = 0UL;
+  int err = fd_ulong_checked_add( account->const_meta->info.lamports, lamports, &balance_post );
+  if( FD_UNLIKELY( err ) ) {
+    return FD_EXECUTOR_INSTR_ERR_ARITHMETIC_OVERFLOW;
+  }
+
+  return fd_account_set_lamports( ctx, instr_acc_idx, balance_post );
+}
+
+static inline int
+fd_account_checked_sub_lamports( fd_exec_instr_ctx_t const * ctx,
+                                 ulong                       instr_acc_idx,
+                                 ulong                       lamports ) {
+
+  fd_borrowed_account_t * account = NULL;
+  do {
+    int err = fd_instr_borrowed_account_modify_idx( ctx, (uchar)instr_acc_idx, 0UL, &account );
+    if( FD_UNLIKELY( err ) ) { 
+      FD_LOG_ERR(( "fd_instr_borrowed_account_modify_idx failed (%d-%s)", err, fd_acc_mgr_strerror( err ) ));
+    }
+  } while(0);
+
+  ulong balance_post = 0UL;
+  int err = fd_ulong_checked_sub( account->const_meta->info.lamports, lamports, &balance_post );
+  if( FD_UNLIKELY( err ) ) {
+    return FD_EXECUTOR_INSTR_ERR_ARITHMETIC_OVERFLOW;
+  }
+
+  return fd_account_set_lamports( ctx, instr_acc_idx, balance_post );
+}
+
+/* fd_account_get_data_mut mirrors Anza function 
+   solana_sdk::transaction_context::BorrowedAccount::set_lamports. 
+   Returns a writable slice of the account data (transaction wide).
+   Acquires a writable handle. This function assumes that the relevant
+   borrowed has already acquired exclusive write access.
+   https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L824-L831 */
+int 
+fd_account_get_data_mut( fd_exec_instr_ctx_t const * ctx, 
+                         ulong                       instr_acc_idx,
+                         uchar * *                   data_out,
+                         ulong *                     dlen_out );
+              
+/* TODO: Implement fd_account_spare_data_capacity_mut which is used in direct mapping */
+
+/* fd_account_set_data_from_slice mirrors Anza function
+   solana_sdk::transaction_context::BorrowedAccount::set_data_from_slice.
+   In the firedancer client, it also mirrors the Anza function
+   solana_sdk::transaction_context::BorrowedAccount::set_data.
+   Assumes that destination account already has enough space to fit
+   data.  Acquires a writable handle.
+   https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L860-882 */
+
+int
+fd_account_set_data_from_slice( fd_exec_instr_ctx_t const * ctx,
+                                ulong                       instr_acc_idx,
+                                uchar const *               data,
+                                ulong                       data_sz );
+
+/* fd_account_set_data_length mirrors Anza function
+   solana_sdk::transaction_context::BorrowedAccount::set_data_length.
+   Acquires a writable handle. Returns 0 on success.
+   https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L994-L900 */
+
+int
+fd_account_set_data_length( fd_exec_instr_ctx_t const * ctx,
+                            ulong                       instr_acc_idx,
+                            ulong                       new_len );
+
+/* fd_account_is_rent_exempt_at_data_length mirrors Anza function
+   solana_sdk::transaction_context::BorrowedAccount::is_rent_exempt_at_data_length.
+   Returns 1 if an account is rent exempt at it's current data length.
+   https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L990-997 */
+
+static inline int
+fd_account_is_rent_exempt_at_data_length( fd_exec_instr_ctx_t const * ctx,
+                                          fd_account_meta_t   const * meta ) {
+  assert( meta != NULL );
+  fd_rent_t rent     = ctx->epoch_ctx->epoch_bank.rent;
+  ulong min_balanace = fd_rent_exempt_minimum_balance2( &rent, meta->dlen );
+  return meta->info.lamports >= min_balanace; 
+}
+
 /* fd_account_is_executable returns 1 if the given account has the
    executable flag set.  Otherwise, returns 0.  Mirrors Anza's
-   solana_sdk::transaction_context::BorrowedAccount::is_executable. */
+   solana_sdk::transaction_context::BorrowedAccount::is_executable.
+   https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L1001-1003 */
 
 FD_FN_PURE static inline int
 fd_account_is_executable( fd_account_meta_t const * meta ) {
   return !!meta->info.executable;
 }
 
+/* fd_account_set_executable mirrors Anza function
+   solana_sdk::transaction_context::BorrowedAccount::set_executable.
+   Returns FD_EXECUTOR_INSTR_SUCCESS if the set is successful.
+   https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L1007-1035 */
+
 int
 fd_account_set_executable( fd_exec_instr_ctx_t const * ctx,
                            ulong                       instr_acc_idx,
-                           int                         executable );
+                           int                         is_executable );
+
+/* fd_account_get_rent_epoch mirrors Anza function 
+   solana_sdk::transaction_context::BorrowedAccount::get_rent_epoch. 
+   https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L1040-1042 */
+
+static inline ulong
+fd_account_get_rent_epoch( fd_account_meta_t const * meta ) {
+  assert( meta != NULL );
+  return meta->info.rent_epoch;
+}
+
+/* fd_account_is_{signer,writable} mirror the Anza functions
+   solana_sdk::transaction_context::BorrowedAccount::is_{signer,writer}.
+   Returns 1 if the account is a signer or is writable and 0 otherwise.
+   https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L1044-1068 */
+
+static inline int
+fd_account_is_signer( fd_exec_instr_ctx_t const * ctx,
+                      ulong                       instr_acc_idx ) {
+  if( FD_UNLIKELY( instr_acc_idx >= ctx->instr->acct_cnt ) ) {
+    return 0;
+  }
+  return fd_instr_acc_is_signer_idx( ctx->instr, instr_acc_idx );
+}
+
+static inline int
+fd_account_is_writable( fd_exec_instr_ctx_t const * ctx,
+                        ulong                       instr_acc_idx ) {
+  if( FD_UNLIKELY( instr_acc_idx >= ctx->instr->acct_cnt ) ) {
+    return 0;
+  }
+
+  return fd_instr_acc_is_writable_idx( ctx->instr, instr_acc_idx );
+}
 
 /* fd_account_is_owned_by_current_program returns 1 if the given
    account is owned by the program invoked in the current instruction.
@@ -75,7 +298,41 @@ fd_account_is_owned_by_current_program( fd_instr_info_t const *   info,
                                         fd_account_meta_t const * acct ) {
   return 0==memcmp( info->program_id_pubkey.key, acct->info.owner, sizeof(fd_pubkey_t) );
 }
-/* https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L1096-L1119 */
+
+/* fd_account_can_data_be changed mirrors Anza function 
+   solana_sdk::transaction_context::BorrowedAccount::can_data_be_changed.
+   https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L1078-L1094 */
+static inline int
+fd_account_can_data_be_changed( fd_instr_info_t const * instr,
+                                ulong                   instr_acc_idx,
+                                int *                   err ) {
+
+  assert( instr_acc_idx < instr->acct_cnt );
+  fd_account_meta_t const * meta = instr->borrowed_accounts[ instr_acc_idx ]->const_meta;
+
+  if( FD_UNLIKELY( fd_account_is_executable( meta ) ) ) {
+    *err = FD_EXECUTOR_INSTR_ERR_EXECUTABLE_DATA_MODIFIED;
+    return 0;
+  }
+
+  if( FD_UNLIKELY( !fd_instr_acc_is_writable_idx( instr, instr_acc_idx ) ) ) {
+    *err = FD_EXECUTOR_INSTR_ERR_READONLY_DATA_MODIFIED;
+    return 0;
+  }
+
+  if( FD_UNLIKELY( !fd_account_is_owned_by_current_program( instr, meta ) ) ) {
+    *err = FD_EXECUTOR_INSTR_ERR_EXTERNAL_DATA_MODIFIED;
+    return 0;
+  }
+
+  err = FD_EXECUTOR_INSTR_SUCCESS;
+  return 1;
+}
+
+/* fd_account_can_data_be_resized mirrors Anza function 
+   solana_sdk::transaction_context::BorrowedAccount::can_data_be_resized 
+   https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L1096-L1119
+*/
 static inline int
 fd_account_can_data_be_resized( fd_exec_instr_ctx_t const * instr_ctx,
                                 fd_account_meta_t const *   acct,
@@ -106,132 +363,6 @@ fd_account_can_data_be_resized( fd_exec_instr_ctx_t const * instr_ctx,
   return 1;
 }
 
-static inline int
-fd_account_can_data_be_changed( fd_instr_info_t const * instr,
-                                ulong                   instr_acc_idx,
-                                int *                   err ) {
-
-  assert( instr_acc_idx < instr->acct_cnt );
-  fd_account_meta_t const * meta = instr->borrowed_accounts[ instr_acc_idx ]->const_meta;
-
-  if( FD_UNLIKELY( fd_account_is_executable( meta ) ) ) {
-    *err = FD_EXECUTOR_INSTR_ERR_EXECUTABLE_DATA_MODIFIED;
-    return 0;
-  }
-
-  if( FD_UNLIKELY( !fd_instr_acc_is_writable_idx( instr, instr_acc_idx ) ) ) {
-    *err = FD_EXECUTOR_INSTR_ERR_READONLY_DATA_MODIFIED;
-    return 0;
-  }
-
-  if( FD_UNLIKELY( !fd_account_is_owned_by_current_program( instr, meta ) ) ) {
-    *err = FD_EXECUTOR_INSTR_ERR_EXTERNAL_DATA_MODIFIED;
-    return 0;
-  }
-
-  err = FD_EXECUTOR_INSTR_SUCCESS;
-  return 1;
-}
-
-FD_FN_PURE static inline int
-fd_account_is_zeroed( fd_account_meta_t const * acct ) {
-  // TODO optimize this...
-  uchar const * data = ((uchar *) acct) + acct->hlen;
-  for( ulong i=0UL; i < acct->dlen; i++ )
-    if( data[i] != 0 )
-      return 0;
-  return 1;
-}
-
-int
-fd_account_set_owner( fd_exec_instr_ctx_t const * ctx,
-                      ulong                       instr_acc_idx,
-                      fd_pubkey_t const *         owner );
-
-/* fd_account_get_lamports mirrors Anza function
-   solana_sdk::transaction_context::BorrowedAccount::get_lamports.
-   Returns current number of lamports in account.  Well behaved if meta
-   is NULL. */
-
-static inline ulong
-fd_account_get_lamports( fd_account_meta_t const * meta ) {
-  if( FD_UNLIKELY( !meta ) ) return 0UL;  /* (!meta) considered an internal error */
-  return meta->info.lamports;
-}
-
-/* fd_account_set_lamports mirrors Anza function
-   solana_sdk::transaction_context::BorrowedAccount::set_lamports.
-   Runs through a sequence of permission checks, then sets the account
-   balance.  Does not update global capitalization.  On success, returns
-   0 and updates meta->lamports.  On failure, returns an
-   FD_EXECUTOR_INSTR_ERR_{...} code.  Acquires a writable handle. */
-
-int
-fd_account_set_lamports( fd_exec_instr_ctx_t const * ctx,
-                         ulong                       instr_acc_idx,
-                         ulong                       lamports );
-
-/* fd_account_checked_{add,sub}_lamports add/removes lamports to/from an
-   account.  Does not update global capitalization.  Returns 0 on
-   success or an FD_EXECUTOR_INSTR_ERR_{...} code on failure.
-   Gracefully handles underflow.  Acquires a writable handle. */
-
-static inline int
-fd_account_checked_add_lamports( fd_exec_instr_ctx_t const * ctx,
-                                 ulong                       instr_acc_idx,
-                                 ulong                       add_amount ) {
-
-  assert( instr_acc_idx < ctx->instr->acct_cnt );
-  fd_account_meta_t const * meta = ctx->instr->borrowed_accounts[ instr_acc_idx ]->const_meta;
-
-  ulong const balance_pre  = meta->info.lamports;
-  ulong const balance_post = balance_pre + add_amount;
-  if( FD_UNLIKELY( balance_post < balance_pre ) )
-    return FD_EXECUTOR_INSTR_ERR_ARITHMETIC_OVERFLOW;
-
-  return fd_account_set_lamports( ctx, instr_acc_idx, balance_post );
-}
-
-static inline int
-fd_account_checked_sub_lamports( fd_exec_instr_ctx_t const * ctx,
-                                 ulong                       instr_acc_idx,
-                                 ulong                       sub_amount ) {
-
-  assert( instr_acc_idx < ctx->instr->acct_cnt );
-  fd_account_meta_t const * meta = ctx->instr->borrowed_accounts[ instr_acc_idx ]->const_meta;
-
-  ulong const balance_pre  = meta->info.lamports;
-  ulong const balance_post = balance_pre - sub_amount;
-  if( FD_UNLIKELY( balance_post > balance_pre ) )
-    return FD_EXECUTOR_INSTR_ERR_ARITHMETIC_OVERFLOW;
-
-  return fd_account_set_lamports( ctx, instr_acc_idx, balance_post );
-}
-
-/* fd_account_set_data_from_slice mirrors Anza function
-   solana_sdk::transaction_context::BorrowedAccount::set_data_from_slice.
-   Assumes that destination account already has enough space to fit
-   data.  Acquires a writable handle.
-
-   https://github.com/solana-labs/solana/blob/v1.17.25/sdk/src/transaction_context.rs#L903-L923 */
-
-int
-fd_account_set_data_from_slice( fd_exec_instr_ctx_t const * ctx,
-                                ulong                       instr_acc_idx,
-                                uchar const *               data,
-                                ulong                       data_sz );
-
-/* fd_account_set_data_length mirrors Anza function
-   solana_sdk::transaction_context::BorrowedAccount::set_data_length.
-   Acquires a writable handle.
-   https://github.com/solana-labs/solana/blob/v1.17.25/sdk/src/transaction_context.rs#L925-L940 */
-
-int
-fd_account_set_data_length( fd_exec_instr_ctx_t const * ctx,
-                            ulong                       instr_acc_idx,
-                            ulong                       new_len,
-                            int *                       err );
-
 /* fd_account_update_acounts_resize_delta mirrors Anza function
    solana_sdk::transaction_context:BorrowedAccount::update_accounts_resize_delta. 
    https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/sdk/src/transaction_context.rs#L1128-L1138 */
@@ -241,6 +372,16 @@ fd_account_update_accounts_resize_delta( fd_exec_instr_ctx_t const * ctx,
                                          ulong                       instr_acc_idx,
                                          ulong                       new_len,
                                          int *                       err );
+
+FD_FN_PURE static inline int
+fd_account_is_zeroed( fd_account_meta_t const * acct ) {
+  // TODO: optimize this
+  uchar const * data = ((uchar *) acct) + acct->hlen;
+  for( ulong i=0UL; i < acct->dlen; i++ )
+    if( data[i] != 0 )
+      return 0;
+  return 1;
+}
 
 /* Transaction account APIs *******************************************/
 

--- a/src/flamenco/runtime/fd_account_old.h
+++ b/src/flamenco/runtime/fd_account_old.h
@@ -72,7 +72,9 @@ int fd_account_can_data_be_changed2(fd_exec_instr_ctx_t *ctx, fd_account_meta_t 
 
 static inline
 int fd_account_set_executable2( fd_exec_instr_ctx_t * ctx,
-                               fd_pubkey_t const * program_acc, fd_account_meta_t * metadata, char is_executable) {
+                                fd_pubkey_t const * program_acc, 
+                                fd_account_meta_t * metadata, 
+                                char is_executable ) {
   fd_rent_t rent;
   fd_rent_new( &rent );
   if( fd_sysvar_rent_read( &rent, ctx->slot_ctx ) ) {

--- a/src/flamenco/runtime/fd_borrowed_account.h
+++ b/src/flamenco/runtime/fd_borrowed_account.h
@@ -5,6 +5,9 @@
 #include "../types/fd_types.h"
 #include "../../funk/fd_funk_rec.h"
 
+#pragma GCC diagnostic ignored "-Wformat"
+#pragma GCC diagnostic ignored "-Wformat-extra-args"
+
 /* TODO This should be called fd_txn_acct. */
 
 struct __attribute__((aligned(8UL))) fd_borrowed_account {
@@ -42,6 +45,29 @@ typedef struct fd_borrowed_account fd_borrowed_account_t;
 #define FD_BORROWED_ACCOUNT_MAGIC     (0xF15EDF1C51F51AA1UL)
 
 #define FD_BORROWED_ACCOUNT_DECL(_x)  fd_borrowed_account_t _x[1]; fd_borrowed_account_init(_x);
+
+/* This macro provides the same scoping guarantees as the Agave client's 
+   borrowed account semantics. It allows for implict/explicit dropping of 
+   borrowed accounts' write locks. It's usage mirrors the use of
+   FD_SCRATCH_SCOPE_{BEGIN,END}. It is also safe to use the original
+   acquire/release api within the scoped macro in case you don't want
+   variables to go out of scope. An example of this is in the extend
+   instruction within the bpf loader.  */
+#define FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( _ctx, _idx, _account ) do {   \
+  fd_borrowed_account_t * _account = NULL;                                \
+  int _err = fd_instr_borrowed_account_view_idx( _ctx, _idx, &_account ); \
+  if( FD_UNLIKELY( _err != FD_ACC_MGR_SUCCESS ) ) {                       \
+    return FD_EXECUTOR_INSTR_ERR_MISSING_ACC;                             \
+  }                                                                       \
+  int _acquire_result = fd_borrowed_account_acquire_write(_account);      \
+  if( FD_UNLIKELY( !_acquire_result ) ) {                                 \
+    return FD_EXECUTOR_INSTR_ERR_ACC_BORROW_FAILED;                       \
+  }                                                                       \
+  fd_borrowed_account_t *  __fd_borrowed_lock_guard_ ## __LINE__          \
+    __attribute__((cleanup(fd_borrowed_account_release_write_private)))   \
+    __attribute__((unused)) = _account;                                   \
+  do  
+#define FD_BORROWED_ACCOUNT_DROP( _account_check ) while(0); (void)_account_check; } while(0)
 
 FD_PROTOTYPES_BEGIN
 
@@ -89,19 +115,30 @@ fd_borrowed_account_acquire_read_is_safe( fd_borrowed_account_t const * rw ) {
 
 static inline int
 fd_borrowed_account_acquire_write( fd_borrowed_account_t * rw ) {
-  if( FD_UNLIKELY( !fd_borrowed_account_acquire_write_is_safe( rw ) ) )
+  if( FD_UNLIKELY( !fd_borrowed_account_acquire_write_is_safe( rw ) ) ) {
     return 0;
+  }
   rw->refcnt_excl = (ushort)1;
   return 1;
 }
 
-/* fd_borrowed_account_release_write releases a write/exclusive access
-handle. */
+/* fd_borrowed_account_release_write{_private} releases a write/exclusive 
+   access handle. The private version should only be used by the try borrow
+   scoping macro. */
 
 static inline void
 fd_borrowed_account_release_write( fd_borrowed_account_t * rw ) {
   FD_TEST( rw->refcnt_excl==1U );
   rw->refcnt_excl = (ushort)0;
+}
+
+static inline void 
+fd_borrowed_account_release_write_private(fd_borrowed_account_t ** rw ) {
+  /* Only release if it is not yet released */
+  if( !fd_borrowed_account_acquire_write_is_safe( *rw ) ) {
+    fd_borrowed_account_release_write( *rw );
+  }
+  rw = NULL;
 }
 
 /* fd_borrowed_account_acquire_read acquires read/shared access.  Causes

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -772,7 +772,7 @@ fd_execute_instr( fd_exec_txn_ctx_t * txn_ctx,
       /* TODO where does Agave do this? */
       for( ulong j=0UL; j < txn_ctx->accounts_cnt; j++ ) {
         if( FD_UNLIKELY( txn_ctx->borrowed_accounts[j].refcnt_excl ) ) {
-          FD_LOG_ERR(( "Txn %64J: Program %32J didn't release lock (%u) on %32J", fd_txn_get_signatures( txn_ctx->txn_descriptor, txn_ctx->_txn_raw->raw )[0], instr->program_id_pubkey.uc, *(uint *)(instr->data), txn_ctx->borrowed_accounts[j].pubkey->uc ));
+          FD_LOG_ERR(( "Txn %64J: Program %32J didn't release lock (%u) on %32J with %u refcnt", fd_txn_get_signatures( txn_ctx->txn_descriptor, txn_ctx->_txn_raw->raw )[0], instr->program_id_pubkey.uc, *(uint *)(instr->data), txn_ctx->borrowed_accounts[j].pubkey->uc, txn_ctx->borrowed_accounts[j].refcnt_excl ));
         }
       }
     } else if( !txn_ctx->failed_instr ) {

--- a/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
@@ -188,7 +188,7 @@ deploy_program( fd_exec_instr_ctx_t * instr_ctx,
   }
 
   /* Validate the program */
-  fd_vm_t _vm[1];
+  fd_vm_t _vm[ 1UL ];
   fd_vm_t * vm = fd_vm_join( fd_vm_new( _vm ) );
 
   vm = fd_vm_init(
@@ -222,24 +222,36 @@ deploy_program( fd_exec_instr_ctx_t * instr_ctx,
 
 /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L195-L218 */
 int
-write_program_data( fd_borrowed_account_t * program,
+write_program_data( fd_exec_instr_ctx_t *   instr_ctx,
+                    ulong                   instr_acc_idx,
                     ulong                   program_data_offset,
                     uchar *                 bytes,
                     ulong                   bytes_len ) {
+  FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, instr_acc_idx, program ) {
+
   ulong write_offset = fd_ulong_sat_add( program_data_offset, bytes_len );
   if( FD_UNLIKELY( program->meta->dlen<write_offset ) ) {
     FD_LOG_WARNING(( "Write overflow %lu < %lu", program->meta->dlen, write_offset ));
     return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
   }
 
-  if( FD_UNLIKELY( program_data_offset>program->meta->dlen ) ) {
+  uchar * data = NULL;
+  ulong   dlen = 0UL;
+  int err = fd_account_get_data_mut( instr_ctx, instr_acc_idx, &data, &dlen );
+  if( FD_UNLIKELY( err ) ) {
+    return err;
+  }
+
+  if( FD_UNLIKELY( program_data_offset>dlen ) ) {
     FD_LOG_WARNING(( "Write offset out of bounds" ));
     return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
   }
 
   if( FD_LIKELY( bytes_len ) ) {
-    fd_memcpy( program->data+program_data_offset, bytes, bytes_len );
+    fd_memcpy( data+program_data_offset, bytes, bytes_len );
   }
+
+  } FD_BORROWED_ACCOUNT_DROP( program );
 
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
@@ -247,7 +259,7 @@ write_program_data( fd_borrowed_account_t * program,
 /* get_state() */
 /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/sdk/src/transaction_context.rs#L968-L972 */
 int
-fd_bpf_loader_v3_program_read_state( fd_exec_instr_ctx_t *               instr_ctx,
+fd_bpf_loader_v3_program_get_state( fd_exec_instr_ctx_t *               instr_ctx,
                                      fd_borrowed_account_t *             borrowed_acc,
                                      fd_bpf_upgradeable_loader_state_t * state ) {
     /* Check to see if the buffer account is already initialized */
@@ -267,26 +279,32 @@ fd_bpf_loader_v3_program_read_state( fd_exec_instr_ctx_t *               instr_c
 /* set_state() */
 /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/sdk/src/transaction_context.rs#L976-L985 */
 int
-fd_bpf_loader_v3_program_write_state( fd_exec_instr_ctx_t *               instr_ctx,
-                                      fd_borrowed_account_t *             borrowed_acc,
-                                      fd_bpf_upgradeable_loader_state_t * state ) {
+fd_bpf_loader_v3_program_set_state( fd_exec_instr_ctx_t *               instr_ctx,
+                                    ulong                               instr_acc_idx,
+                                    fd_bpf_upgradeable_loader_state_t * state ) {
   ulong state_size = fd_bpf_upgradeable_loader_state_size( state );
 
-  if( FD_UNLIKELY( state_size>borrowed_acc->meta->dlen ) ) {
+  uchar * data = NULL;
+  ulong   dlen = 0UL;
+  
+  int err = fd_account_get_data_mut( instr_ctx, instr_acc_idx, &data, &dlen );
+  if( FD_UNLIKELY( err ) ) {
+    return err;
+  }
+
+  if( FD_UNLIKELY( state_size>dlen ) ) {
     return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
   }
 
   fd_bincode_encode_ctx_t ctx = {
-    .data    = borrowed_acc->data,
-    .dataend = borrowed_acc->data + state_size
+    .data    = data,
+    .dataend = data + state_size
   };
 
-  int err = fd_bpf_upgradeable_loader_state_encode( state, &ctx );
+  err = fd_bpf_upgradeable_loader_state_encode( state, &ctx );
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
     return FD_EXECUTOR_INSTR_ERR_GENERIC_ERR;
   }
-
-  borrowed_acc->meta->slot = instr_ctx->slot_ctx->slot_bank.slot;
 
   return FD_BINCODE_SUCCESS;
 }
@@ -312,37 +330,29 @@ common_close_account( fd_pubkey_t * authority_address,
     return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
   }
 
-  fd_borrowed_account_t * close_account = NULL;
-  int err = fd_instr_borrowed_account_modify_idx( instr_ctx, 0UL, 0UL, &close_account );
-  if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-    FD_LOG_WARNING(( "Borrowed account lookup for close account failed" ));
-    return err;
-  }
-  fd_borrowed_account_t * recipient_account = NULL;
-  err = fd_instr_borrowed_account_modify_idx( instr_ctx, 1UL, 0UL, &recipient_account );
-  if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-    FD_LOG_WARNING(( "Borrowed account lookup for recipient account failed" ));
-    return err;
-  }
+  FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 0UL, close_account     ) {
+  FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 1UL, recipient_account ) {
 
-  ulong result = 0UL;
-  err = fd_ulong_checked_add( recipient_account->meta->info.lamports,
-                              close_account->meta->info.lamports,
-                              &result );
+  int err = fd_account_checked_add_lamports( instr_ctx, 1UL, close_account->meta->info.lamports );
   if( FD_UNLIKELY( err ) ) {
-    FD_LOG_WARNING(( "Failed checked add of recipient and close account balances" ));
     return err;
   }
-  recipient_account->meta->info.lamports = result;
-  close_account->meta->info.lamports     = 0UL;
+  err = fd_account_set_lamports( instr_ctx, 0UL, 0UL );
+  if( FD_UNLIKELY( err ) ) {
+    return err;
+  }
 
   state->discriminant = fd_bpf_upgradeable_loader_state_enum_uninitialized;
-  err = fd_bpf_loader_v3_program_write_state( instr_ctx, close_account, state );
+  err = fd_bpf_loader_v3_program_set_state( instr_ctx, 0UL, state );
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
     FD_LOG_WARNING(( "Bpf loader state write for close account failed" ));
     return err;
   }
+
   return FD_EXECUTOR_INSTR_SUCCESS;
+
+  } FD_BORROWED_ACCOUNT_DROP( recipient_account );
+  } FD_BORROWED_ACCOUNT_DROP( close_account     );
 }
 
 
@@ -477,975 +487,1088 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
   uchar const * instr_acc_idxs   = instr_ctx->instr->acct_txn_idxs;
   fd_pubkey_t const * txn_accs   = instr_ctx->txn_ctx->accounts;
   fd_pubkey_t const * program_id = &instr_ctx->instr->program_id_pubkey;
-
-  /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L476-L493 */
-  if( fd_bpf_upgradeable_loader_program_instruction_is_initialize_buffer( &instruction ) ) {
-    if( FD_UNLIKELY( instr_ctx->instr->acct_cnt<2U ) ) {
-      FD_LOG_WARNING(( "Not enough account keys for instruction" ));
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
-    }
-
-    fd_borrowed_account_t * buffer = NULL;
-    err = fd_instr_borrowed_account_modify_idx( instr_ctx, 0UL, 0UL, &buffer );
-    if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Borrowed account lookup for buffer account failed" ));
-      return err;
-    }
-
-    fd_bpf_upgradeable_loader_state_t buffer_state = {0};
-    err = fd_bpf_loader_v3_program_read_state( instr_ctx, buffer, &buffer_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bpf loader state read for buffer account failed" ));
-      return err;
-    }
-
-    if( FD_UNLIKELY( !fd_bpf_upgradeable_loader_state_is_uninitialized( &buffer_state ) ) ) {
-      FD_LOG_WARNING(( "Buffer account is already initialized" ));
-      return FD_EXECUTOR_INSTR_ERR_ACC_ALREADY_INITIALIZED;
-    }
-
-    fd_pubkey_t const * authority_key = &txn_accs[ instr_acc_idxs[ 1UL ] ];
-
-    buffer_state.discriminant                   = fd_bpf_upgradeable_loader_state_enum_buffer;
-    buffer_state.inner.buffer.authority_address = (fd_pubkey_t*)authority_key;
-
-    err = fd_bpf_loader_v3_program_write_state( instr_ctx, buffer, &buffer_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bpf loader state write for buffer account failed" ));
-      return err;
-    }
-  /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L494-L525 */
-  } else if ( fd_bpf_upgradeable_loader_program_instruction_is_write( &instruction ) ) {
-    if( FD_UNLIKELY( instr_ctx->instr->acct_cnt<2U ) ) {
-      FD_LOG_WARNING(( "Not enough account keys for instruction" ));
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
-    }
-    fd_borrowed_account_t * buffer = NULL;
-    err = fd_instr_borrowed_account_modify_idx( instr_ctx, 0UL, 0UL, &buffer );
-    if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Borrowed account lookup for buffer account failed" ));
-      return err;
-    }
-
-    fd_bpf_upgradeable_loader_state_t loader_state = {0};
-    err = fd_bpf_loader_v3_program_read_state( instr_ctx, buffer, &loader_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bpf loader state read for buffer account failed" ));
-      return err;
-    }
-
-    if( fd_bpf_upgradeable_loader_state_is_buffer( &loader_state ) ) {
-      if( FD_UNLIKELY( !loader_state.inner.buffer.authority_address ) ) {
-        FD_LOG_WARNING(( "Buffer is immutable" ));
-        return FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE;
+  switch( instruction.discriminant ) {
+    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L476-L493 */
+    case fd_bpf_upgradeable_loader_program_instruction_enum_initialize_buffer: {
+      if( FD_UNLIKELY( fd_account_check_num_insn_accounts( instr_ctx, 2U ) ) ) {
+        return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
       }
+
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 0UL, buffer ) {
+
+      fd_bpf_upgradeable_loader_state_t buffer_state = {0};
+      err = fd_bpf_loader_v3_program_get_state( instr_ctx, buffer, &buffer_state );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Bpf loader state read for buffer account failed" ));
+        return err;
+      }
+
+      if( FD_UNLIKELY( !fd_bpf_upgradeable_loader_state_is_uninitialized( &buffer_state ) ) ) {
+        FD_LOG_WARNING(( "Buffer account is already initialized" ));
+        return FD_EXECUTOR_INSTR_ERR_ACC_ALREADY_INITIALIZED;
+      }
+
       fd_pubkey_t const * authority_key = &txn_accs[ instr_acc_idxs[ 1UL ] ];
-      if( FD_UNLIKELY( memcmp( loader_state.inner.buffer.authority_address, authority_key, sizeof(fd_pubkey_t) ) ) ) {
-        FD_LOG_WARNING(( "Incorrect buffer authority provided" ));
-        return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
-      }
-      if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 1UL ) ) ) {
-        FD_LOG_WARNING(( "Buffer authority did not sign" ));
-        return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
-      }
-    } else {
-      FD_LOG_WARNING(( "Invalid Buffer account" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
-    }
 
-    ulong program_data_offset = fd_ulong_sat_add( BUFFER_METADATA_SIZE, instruction.inner.write.offset );
-    err = write_program_data( buffer,
-                              program_data_offset,
-                              instruction.inner.write.bytes,
-                              instruction.inner.write.bytes_len );
-    if( FD_UNLIKELY( err ) ) {
-      return err;
-    }
-  /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L526-L702 */
-  } else if( fd_bpf_upgradeable_loader_program_instruction_is_deploy_with_max_data_len( &instruction ) ) {
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L527-L541 */
-    if( instr_ctx->instr->acct_cnt<4U ) {
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
-    }
-    fd_pubkey_t const * payer_key       = &txn_accs[ instr_acc_idxs[ 0UL ] ];
-    fd_pubkey_t const * programdata_key = &txn_accs[ instr_acc_idxs[ 1UL ] ];
-    /* rent is accessed directly from the epoch bank and the clock from the
-       slot context. However, a check must be done to make sure that the
-       sysvars are correctly included in the set of transaction accounts. */
-    err = fd_check_sysvar_account( instr_ctx, 4UL, &fd_sysvar_rent_id );
-    if( FD_UNLIKELY( err ) ) {
-      return err;
-    }
-    err = fd_check_sysvar_account( instr_ctx, 5UL, &fd_sysvar_clock_id );
-    if( FD_UNLIKELY( err ) ) {
-      return err;
-    }
+      buffer_state.discriminant                   = fd_bpf_upgradeable_loader_state_enum_buffer;
+      buffer_state.inner.buffer.authority_address = (fd_pubkey_t*)authority_key;
 
-    fd_sol_sysvar_clock_t clock = {0};
-    if( FD_UNLIKELY( !fd_sysvar_clock_read( &clock, instr_ctx->slot_ctx ) ) ) {
-      return FD_EXECUTOR_INSTR_ERR_GENERIC_ERR;
-    }
-    if( FD_UNLIKELY( instr_ctx->instr->acct_cnt<8U ) ) {
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
-    }
-    fd_pubkey_t const * authority_key = &txn_accs[ instr_acc_idxs[ 7UL ] ];
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L542-L560 */
-    /* Verify Program account */
-
-    fd_borrowed_account_t * program = NULL;
-    err = fd_instr_borrowed_account_modify_idx( instr_ctx, 2UL, 0UL, &program );
-    if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Borrowed account lookup for program account failed" ));
-      return err;
-    }
-
-    fd_bpf_upgradeable_loader_state_t loader_state = {0};
-    err = fd_bpf_loader_v3_program_read_state( instr_ctx, program, &loader_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bpf state read for program account failed" ));
-      return err;
-    }
-    if( FD_UNLIKELY( !fd_bpf_upgradeable_loader_state_is_uninitialized( &loader_state ) ) ) {
-      FD_LOG_WARNING(( "Program account is already initialized" ));
-      return FD_EXECUTOR_INSTR_ERR_ACC_ALREADY_INITIALIZED;
-    }
-    if( FD_UNLIKELY( program->const_meta->dlen<SIZE_OF_PROGRAM ) ) {
-      FD_LOG_WARNING(( "Program account too small" ));
-      return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
-    }
-    if( FD_UNLIKELY( program->const_meta->info.lamports<fd_rent_exempt_minimum_balance( instr_ctx->slot_ctx,
-                                                                                        program->const_meta->dlen ) ) ) {
-      FD_LOG_WARNING(( "Program account not rent-exempt" ));
-      return FD_EXECUTOR_INSTR_ERR_ACC_NOT_RENT_EXEMPT;
-    }
-    fd_pubkey_t * new_program_id = program->pubkey;
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L561-L600 */
-    /* Verify Buffer account */
-
-    fd_borrowed_account_t * buffer = NULL;
-    err = fd_instr_borrowed_account_modify_idx( instr_ctx, 3UL, 0UL, &buffer );
-    if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Borrowed account lookup for buffer account failed" ));
-      return err;
-    }
-
-    fd_bpf_upgradeable_loader_state_t buffer_state = {0};
-    err = fd_bpf_loader_v3_program_read_state( instr_ctx, buffer, &buffer_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bincode decode failed for buffer account loader state" ));
-      return err;
-    }
-
-    if( fd_bpf_upgradeable_loader_state_is_buffer( &buffer_state ) ) {
-      if( FD_UNLIKELY( (authority_key==NULL) != (buffer_state.inner.buffer.authority_address == NULL) ||
-          (authority_key!=NULL && memcmp( buffer_state.inner.buffer.authority_address, authority_key, sizeof(fd_pubkey_t) ) ) ) ) {
-        FD_LOG_WARNING(( "Buffer and upgrade authority don't match" ));
-        return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
-      }
-      if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 7UL ) ) ) {
-        FD_LOG_WARNING(( "Upgrade authority did not sign" ));
-        return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
-      }
-    } else {
-      FD_LOG_WARNING(( "Invalid Buffer account" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
-    }
-    fd_pubkey_t * buffer_key      = buffer->pubkey;
-    ulong buffer_data_offset      = BUFFER_METADATA_SIZE;
-    ulong buffer_data_len         = fd_ulong_sat_sub( buffer->const_meta->dlen, buffer_data_offset );
-    /* UpgradeableLoaderState::size_of_program_data( max_data_len ) */
-    ulong programdata_len         = fd_ulong_sat_add( PROGRAMDATA_METADATA_SIZE,
-                                                      instruction.inner.deploy_with_max_data_len.max_data_len );
-    if( FD_UNLIKELY( buffer->const_meta->dlen<BUFFER_METADATA_SIZE || buffer->const_meta->dlen==0UL ) ) {
-      FD_LOG_WARNING(( "Buffer account too small" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
-    }
-    if( FD_UNLIKELY( instruction.inner.deploy_with_max_data_len.max_data_len<buffer_data_len ) ) {
-      FD_LOG_WARNING(( "Max data length is too small to hold Buffer data" ));
-      return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
-    }
-    if( FD_UNLIKELY( programdata_len>MAX_PERMITTED_DATA_LENGTH ) ) {
-      FD_LOG_WARNING(( "Max data length is too large" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
-    }
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L602-L608 */
-    /* Create ProgramData account */
-    fd_pubkey_t derived_address[ 1UL ];
-    uchar * seeds[ 1UL ];
-    seeds[ 0UL ] = (uchar *)new_program_id;
-    uchar bump_seed = 0;
-    err = fd_pubkey_try_find_program_address( program_id, 1UL, seeds, derived_address, &bump_seed );
-    if( FD_UNLIKELY( err ) ) {
-      FD_LOG_WARNING(( "Failed to derive program address" ));
-      return err;
-    }
-    if( FD_UNLIKELY( memcmp( derived_address, programdata_key, sizeof(fd_pubkey_t) ) ) ) {
-      FD_LOG_WARNING(( "ProgramData address is not derived" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
-    }
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L610-L627 */
-    /* Drain the Buffer account to payer before paying for programdata account */
-    fd_borrowed_account_t * payer = NULL;
-    err = fd_instr_borrowed_account_modify_idx( instr_ctx, 0UL, 0UL, &payer );
-    if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Borrowed account lookup for payer account failed" ));
-      return err;
-    }
-
-    ulong payer_lamports = 0UL;
-    err = fd_ulong_checked_add( payer->meta->info.lamports, buffer->meta->info.lamports, &payer_lamports );
-    if( FD_UNLIKELY( err ) ) {
-      FD_LOG_WARNING(( "Checked add on payer and buffer balances failed" ));
-      return err;
-    }
-    payer->meta->info.lamports  = payer_lamports;
-    buffer->meta->info.lamports = 0UL;
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L628-L642 */
-    /* Pass an extra account to avoid the overly strict unblanaced instruction error */
-    /* Invoke the system program to create the new account */
-    fd_system_program_instruction_create_account_t create_acct;
-    create_acct.lamports = fd_rent_exempt_minimum_balance( instr_ctx->slot_ctx, programdata_len );
-    if( !create_acct.lamports ) {
-      create_acct.lamports = 1UL;
-    }
-    create_acct.space    = programdata_len;
-    create_acct.owner    = instr_ctx->instr->program_id_pubkey;
-
-    fd_system_program_instruction_t instr = {0};
-    instr.discriminant         = fd_system_program_instruction_enum_create_account;
-    instr.inner.create_account = create_acct;
-
-    fd_vm_rust_account_meta_t * acct_metas = (fd_vm_rust_account_meta_t*)
-                                              fd_scratch_alloc( FD_VM_RUST_ACCOUNT_META_ALIGN,
-                                                                3UL * sizeof(fd_vm_rust_account_meta_t) );
-    fd_native_cpi_create_account_meta( payer_key,       1U, 1U, &acct_metas[ 0UL ] );
-    fd_native_cpi_create_account_meta( programdata_key, 1U, 1U, &acct_metas[ 1UL ] );
-    fd_native_cpi_create_account_meta( buffer_key,      0U, 1U, &acct_metas[ 2UL ] );
-
-    /* caller_program_id == program_id */
-    fd_pubkey_t signers[ 1UL ];
-    err = fd_pubkey_derive_pda( program_id, 1UL, seeds, &bump_seed, signers );
-    if( FD_UNLIKELY( err ) ) {
-      return err;
-    }
-
-    err = fd_native_cpi_execute_system_program_instruction( instr_ctx, &instr, acct_metas, 3UL, signers, 1UL );
-    if( FD_UNLIKELY( err ) ) {
-      return err;
-    }
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L644-L665 */
-    /* Load and verify the program bits */
-    if( FD_UNLIKELY( buffer_data_offset>buffer->meta->dlen ) ) {
-      FD_LOG_WARNING(( "Buffer data offset is out of bounds" ));
-      return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
-    }
-
-    uchar * buffer_data = buffer->data + buffer_data_offset;
-    err = deploy_program( instr_ctx, buffer_data, buffer_data_len );
-    if( FD_UNLIKELY( err ) ) {
-      FD_LOG_WARNING(( "Failed to deploy program" ));
-      return err;
-    }
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L667-L691 */
-    /* Update the ProgramData account and record the program bits */
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L669-L674 */
-    fd_borrowed_account_t * programdata = NULL;
-    err = fd_instr_borrowed_account_modify_idx( instr_ctx, 1UL, programdata_len, &programdata );
-    if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Borrowed account lookup for programdata account failed" ));
-      return err;
-    }
-
-    fd_bpf_upgradeable_loader_state_t programdata_loader_state = {
-      .discriminant = fd_bpf_upgradeable_loader_state_enum_program_data,
-      .inner.program_data = {
-        .slot                      = clock.slot,
-        .upgrade_authority_address = (fd_pubkey_t *)authority_key,
-      },
-    };
-    err = fd_bpf_loader_v3_program_write_state( instr_ctx, programdata, &programdata_loader_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bpf state write for programdata account failed" ));
-      return err;
-    }
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L675-L689 */
-    if( FD_UNLIKELY( PROGRAMDATA_METADATA_SIZE+buffer_data_len>programdata->meta->dlen ) ) {
-      uchar * sig = (uchar *)instr_ctx->txn_ctx->_txn_raw->raw + instr_ctx->txn_ctx->txn_descriptor->signature_off;
-      FD_LOG_WARNING(( "ProgramData account too small %32J %lu %lu", sig, buffer_data_len, programdata->meta->dlen ));
-      return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
-    }
-    if( FD_UNLIKELY( buffer_data_offset>buffer->meta->dlen ) ) {
-      FD_LOG_WARNING(( "Buffer account too small" ));
-      return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
-    }
-    uchar * dst_slice       = programdata->data + PROGRAMDATA_METADATA_SIZE;
-    ulong dst_slice_len     = buffer_data_len;
-    const uchar * src_slice = buffer->const_data + buffer_data_offset;
-    fd_memcpy( dst_slice, src_slice, dst_slice_len );
-
-    /* Update the programdata's metadata */
-    programdata->meta->dlen            = programdata_len;
-    programdata->meta->info.executable = 0U;
-    programdata->meta->info.lamports   = fd_rent_exempt_minimum_balance( instr_ctx->slot_ctx, programdata_len );
-    programdata->meta->info.rent_epoch = 0UL;
-    programdata->meta->slot            = clock.slot;
-    fd_memcpy( &programdata->meta->info.owner, fd_solana_bpf_loader_upgradeable_program_id.key, sizeof(fd_pubkey_t) );
-    buffer->meta->dlen = BUFFER_METADATA_SIZE;
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L692-L699 */
-    /* Update the Program account */
-    loader_state.discriminant = fd_bpf_upgradeable_loader_state_enum_program;
-    fd_memcpy( &loader_state.inner.program.programdata_address, programdata_key, sizeof(fd_pubkey_t) );
-    err = fd_bpf_loader_v3_program_write_state( instr_ctx, program, &loader_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bincode encode for program account failed" ));
-      return err;
-    }
-    err = fd_account_set_executable2( instr_ctx, program->pubkey, program->meta, 1 );
-    if( FD_UNLIKELY( err ) ) {
-      FD_LOG_WARNING(( "Couldn't set account to executable" ));
-      return err;
-    }
-  } else if( fd_bpf_upgradeable_loader_program_instruction_is_upgrade( &instruction ) ) {
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L704-L714 */
-    if( FD_UNLIKELY( instr_ctx->instr->acct_cnt<3U ) ) {
-      FD_LOG_WARNING(( "Not enough account keys for instruction" ));
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
-    }
-    fd_pubkey_t const * programdata_key = &txn_accs[ instr_acc_idxs[ 0UL ] ];
-
-    /* rent is accessed directly from the epoch bank and the clock from the
-       slot context. However, a check must be done to make sure that the
-       sysvars are correctly included in the set of transaction accounts. */
-    err = fd_check_sysvar_account( instr_ctx, 4UL, &fd_sysvar_rent_id );
-    if( FD_UNLIKELY( err ) ) {
-      return err;
-    }
-    err = fd_check_sysvar_account( instr_ctx, 5UL, &fd_sysvar_clock_id );
-    if( FD_UNLIKELY( err ) ) {
-      return err;
-    }
-
-    if( FD_UNLIKELY( instr_ctx->instr->acct_cnt<7U ) ) {
-      FD_LOG_WARNING(( "Not enough account keys for instruction" ));
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
-    }
-    fd_pubkey_t const * authority_key = &txn_accs[ instr_acc_idxs[ 6UL ] ];
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L716-L745 */
-    /* Verify Program account */
-
-    fd_borrowed_account_t * program = NULL;
-    err = fd_instr_borrowed_account_modify_idx( instr_ctx, 1UL, 0UL, &program );
-    if( FD_UNLIKELY( !program->meta->info.executable ) ) {
-      FD_LOG_WARNING(( "Program account not executable" ));
-      return FD_EXECUTOR_INSTR_ERR_ACC_NOT_EXECUTABLE;
-    }
-    if( FD_UNLIKELY( !fd_instr_acc_is_writable( instr_ctx->instr, program->pubkey ) ) ) {
-      FD_LOG_WARNING(( "Program account not writeable" ));
-    }
-    if( FD_UNLIKELY( memcmp( &program->meta->info.owner, program_id, sizeof(fd_pubkey_t) ) ) ) {
-      FD_LOG_WARNING(( "Program account not owned by loader" ));
-      return FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID;
-    }
-    fd_bpf_upgradeable_loader_state_t program_state = {0};
-    err = fd_bpf_loader_v3_program_read_state( instr_ctx, program, &program_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bincode decode for program account failed" ));
-      return err;
-    }
-    if( FD_UNLIKELY( fd_bpf_upgradeable_loader_state_is_program( &program_state ) ) ) {
-      if( FD_UNLIKELY( memcmp( &program_state.inner.program.programdata_address, programdata_key, sizeof(fd_pubkey_t) ) ) ) {
-        FD_LOG_WARNING(( "Program and ProgramData account mismatch" ));
-        return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
-      }
-    } else {
-      FD_LOG_WARNING(( "Invalid Program account" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
-    }
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L747-L773 */
-    /* Verify Buffer account */
-
-    fd_borrowed_account_t * buffer = NULL;
-    err = fd_instr_borrowed_account_modify_idx( instr_ctx, 2UL, 0UL, &buffer );
-    if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Borrowed account lookup for buffer account failed" ));
-      return err;
-    }
-    fd_bpf_upgradeable_loader_state_t buffer_state = {0};
-    err = fd_bpf_loader_v3_program_read_state( instr_ctx, buffer, &buffer_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bincode decode for buffer account failed" ));
-      return err;
-    }
-    if( fd_bpf_upgradeable_loader_state_is_buffer( &buffer_state ) ) {
-      if( FD_UNLIKELY( (authority_key==NULL) != (buffer_state.inner.buffer.authority_address == NULL) ||
-          (authority_key!=NULL && memcmp( buffer_state.inner.buffer.authority_address, authority_key, sizeof(fd_pubkey_t) ) ) ) ) {
-        FD_LOG_WARNING(( "Buffer and upgrade authority don't match" ));
-        return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
-      }
-      if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 6UL ) ) ) {
-        FD_LOG_WARNING(( "Upgrade authority did not sign" ));
-        return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
-      }
-    } else {
-      FD_LOG_WARNING(( "Invalid Buffer account" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
-    }
-    ulong buffer_lamports    = buffer->meta->info.lamports;
-    ulong buffer_data_offset = BUFFER_METADATA_SIZE;
-    ulong buffer_data_len    = fd_ulong_sat_sub( buffer->meta->dlen, buffer_data_offset );
-    if( FD_UNLIKELY( buffer->meta->dlen<BUFFER_METADATA_SIZE || buffer->meta->dlen==0UL ) ) {
-      FD_LOG_WARNING(( "Buffer account too small" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
-    }
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L775-L823 */
-    /* Verify ProgramData account */
-    fd_borrowed_account_t * programdata = NULL;
-    err = fd_instr_borrowed_account_modify_idx( instr_ctx, 0UL, 0UL, &programdata );
-    if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Borrowed account lookup for programdata account failed" ));
-      return err;
-    }
-    ulong programdata_data_offset      = PROGRAMDATA_METADATA_SIZE;
-    ulong programdata_balance_required = fd_rent_exempt_minimum_balance( instr_ctx->slot_ctx,
-                                                                         programdata->const_meta->dlen );
-    if( programdata_balance_required==0UL ) {
-      programdata_balance_required = 1UL;
-    }
-    if( FD_UNLIKELY( programdata->meta->dlen < fd_ulong_sat_add( PROGRAMDATA_METADATA_SIZE, buffer_data_len ) ) ) {
-      FD_LOG_WARNING(( "ProgramData account not large enough" ));
-      return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
-    }
-    if( FD_UNLIKELY( fd_ulong_sat_add( programdata->meta->info.lamports, buffer_lamports )<programdata_balance_required ) ) {
-      FD_LOG_WARNING(( "Buffer account balance too low to fund upgrade" ));
-      return FD_EXECUTOR_INSTR_ERR_INSUFFICIENT_FUNDS;
-    }
-    fd_bpf_upgradeable_loader_state_t programdata_state = {0};
-    err = fd_bpf_loader_v3_program_read_state( instr_ctx, programdata, &programdata_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bincode decode for programdata account failed" ));
-      return err;
-    }
-
-    fd_sol_sysvar_clock_t clock = {0};
-    if( FD_UNLIKELY( !fd_sysvar_clock_read( &clock, instr_ctx->slot_ctx ) ) ) {
-      return FD_EXECUTOR_INSTR_ERR_GENERIC_ERR;
-    }
-
-    if( fd_bpf_upgradeable_loader_state_is_program_data( &programdata_state ) ) {
-      if( FD_UNLIKELY( clock.slot==programdata_state.inner.program_data.slot ) ) {
-        FD_LOG_WARNING(( "Program was deployed in this block already" ));
-        return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
-      }
-      if( FD_UNLIKELY( !programdata_state.inner.program_data.upgrade_authority_address ) ) {
-        FD_LOG_WARNING(( "Prrogram not upgradeable" ));
-        return FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE;
-      }
-      if( FD_UNLIKELY( memcmp( programdata_state.inner.program_data.upgrade_authority_address, authority_key, sizeof(fd_pubkey_t) ) ) ) {
-        FD_LOG_WARNING(( "Incorrect upgrade authority provided" ));
-        return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
-      }
-      if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 6UL ) ) ) {
-        FD_LOG_WARNING(( "Upgrade authority did not sign" ));
-        return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
-      }
-    } else {
-      FD_LOG_WARNING(( "Invalid ProgramData account" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
-    }
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L825-L845 */
-    /* Load and verify the program bits */
-    if( FD_UNLIKELY( buffer_data_offset>buffer->meta->dlen ) ) {
-      FD_LOG_WARNING(( "Buffer data offset is out of bounds" ));
-      return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
-    }
-
-    uchar * buffer_data = buffer->data + buffer_data_offset;
-    err = deploy_program( instr_ctx, buffer_data, buffer_data_len );
-    if( FD_UNLIKELY( err ) ) {
-      FD_LOG_WARNING(( "Failed to deploy program" ));
-      return err;
-    }
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L846-L874 */
-    /* Update the ProgramData account, record the upgraded data, and zero the rest */
-    programdata_state.discriminant                                 = fd_bpf_upgradeable_loader_state_enum_program_data;
-    programdata_state.inner.program_data.slot                      = clock.slot;
-    programdata_state.inner.program_data.upgrade_authority_address = (fd_pubkey_t *)authority_key;
-    err = fd_bpf_loader_v3_program_write_state( instr_ctx, programdata, &programdata_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bpf state write for programdata account failed" ));
-      return err;
-    }
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L846-L875 */
-    /* We want to copy over the data and zero out the rest */
-    if( FD_UNLIKELY( programdata_data_offset+buffer_data_len>programdata->meta->dlen ) ) {
-      FD_LOG_WARNING(( "ProgramData account too small" ));
-      return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
-    }
-    if( FD_UNLIKELY( buffer_data_offset>buffer->meta->dlen ) ){
-      FD_LOG_WARNING(( "Buffer account too small" ));
-      return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
-    }
-    uchar * dst_slice     = programdata->data + programdata_data_offset;
-    ulong   dst_slice_len = buffer_data_len;
-    uchar * src_slice     = buffer->data + buffer_data_offset;
-    fd_memcpy( dst_slice, src_slice, dst_slice_len );
-    fd_memset( dst_slice + dst_slice_len, 0, programdata->meta->dlen - programdata_data_offset - dst_slice_len );
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L876-L891 */
-    /* Fund ProgramData to rent-exemption, spill the rest */
-    fd_borrowed_account_t * spill = NULL;
-    err = fd_instr_borrowed_account_modify_idx( instr_ctx, 3UL, 0UL, &spill );
-    if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Borrowed account lookup for spill account failed" ));
-      return err;
-    }
-    ulong spill_addend = fd_ulong_sat_sub( fd_ulong_sat_add( programdata->meta->info.lamports, buffer_lamports ),
-                                           programdata_balance_required );
-    ulong result = 0UL;
-    err = fd_ulong_checked_add( spill->meta->info.lamports, spill_addend, &result );
-    if( FD_UNLIKELY( err ) ) {
-      FD_LOG_WARNING(( "Failed checked add to update spill account balance" ));
-      return err;
-    }
-    spill->meta->info.lamports       = result;
-    buffer->meta->info.lamports      = 0UL;
-    programdata->meta->info.lamports = programdata_balance_required;
-    buffer->meta->dlen               = PROGRAMDATA_METADATA_SIZE; /* UpgradeableLoaderState::size_of_buffer(0) */
-  /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L893-L957 */
-  } else if( fd_bpf_upgradeable_loader_program_instruction_is_set_authority( &instruction ) ) {
-    if( FD_UNLIKELY( instr_ctx->instr->acct_cnt<2U ) ) {
-      FD_LOG_WARNING(( "Not enough account keys for instruction" ));
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
-    }
-    fd_borrowed_account_t * account = NULL;
-    err = fd_instr_borrowed_account_modify_idx( instr_ctx, 0UL, 0UL, &account );
-    if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Borrowed account lookup for account failed" ));
-      return err;
-    }
-    fd_pubkey_t const * present_authority_key = &txn_accs[ instr_acc_idxs[ 1UL ] ];
-    fd_pubkey_t * new_authority               = NULL;
-    if( FD_UNLIKELY( instr_ctx->instr->acct_cnt>=3UL ) ) {
-      new_authority = (fd_pubkey_t *)&txn_accs[ instr_acc_idxs[ 2UL ] ];
-    }
-
-    fd_bpf_upgradeable_loader_state_t account_state = {0};
-    err = fd_bpf_loader_v3_program_read_state( instr_ctx, account, &account_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bincode decode for account failed" ));
-      return err;
-    }
-
-    if( fd_bpf_upgradeable_loader_state_is_buffer( &account_state ) ) {
-      if( FD_UNLIKELY( !new_authority ) ) {
-        FD_LOG_WARNING(( "Buffer authority is not optional" ));
-        return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
-      }
-      if( FD_UNLIKELY( !account_state.inner.buffer.authority_address ) ) {
-        FD_LOG_WARNING(( "Buffer is immutable" ));
-        return FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE;
-      }
-      if( FD_UNLIKELY( memcmp( account_state.inner.buffer.authority_address, present_authority_key, sizeof(fd_pubkey_t) ) ) ) {
-        FD_LOG_WARNING(( "Incorrect buffer authority provided" ));
-        return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
-      }
-      if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 1UL ) ) ) {
-        FD_LOG_WARNING(( "Buffer authority did not sign" ));
-        return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
-      }
-      account_state.inner.buffer.authority_address = new_authority;
-      err = fd_bpf_loader_v3_program_write_state( instr_ctx, account, &account_state );
+      err = fd_bpf_loader_v3_program_set_state( instr_ctx, 0UL, &buffer_state );
       if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-        FD_LOG_WARNING(( "Bpf state write for account failed" ));
+        FD_LOG_WARNING(( "Bpf loader state write for buffer account failed" ));
         return err;
       }
-    } else if( fd_bpf_upgradeable_loader_state_is_program_data( &account_state ) ) {
-      if( FD_UNLIKELY( !account_state.inner.program_data.upgrade_authority_address ) ) {
-        FD_LOG_WARNING(( "Program not upgradeable" ));
-        return FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE;
-      }
-      if( FD_UNLIKELY( memcmp( account_state.inner.program_data.upgrade_authority_address, present_authority_key, sizeof(fd_pubkey_t) ) ) ) {
-        FD_LOG_WARNING(( "Incorrect program authority provided" ));
-        return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
-      }
-      if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 1UL ) ) ) {
-        FD_LOG_WARNING(( "Program authority did not sign" ));
-        return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
-      }
-      account_state.inner.program_data.upgrade_authority_address = new_authority;
-      err = fd_bpf_loader_v3_program_write_state( instr_ctx, account, &account_state );
-      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-        FD_LOG_WARNING(( "Bincode encode for program data account failed" ));
-        return err;
-      }
-    } else {
-      FD_LOG_WARNING(( "Account does not support authorities" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
-    }
-  /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L958-L1030 */
-  } else if( fd_bpf_upgradeable_loader_program_instruction_is_set_authority_checked( &instruction ) ) {
-    if( FD_UNLIKELY( instr_ctx->instr->acct_cnt<3U ) ) {
-      FD_LOG_WARNING(( "Not enough account keys for instruction" ));
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
-    }
-    fd_borrowed_account_t * account = NULL;
-    err = fd_instr_borrowed_account_modify_idx( instr_ctx, 0UL, 0UL, &account );
-    if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Borrowed account lookup for account failed" ));
-      return err;
-    }
-    fd_pubkey_t const * present_authority_key = &txn_accs[ instr_acc_idxs[ 1UL ] ];
-    fd_pubkey_t const * new_authority_key     = &txn_accs[ instr_acc_idxs[ 2UL ] ];
 
-    fd_bpf_upgradeable_loader_state_t account_state = {0};
-    err = fd_bpf_loader_v3_program_read_state( instr_ctx, account, &account_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bincode decode for account failed" ));
-      return err;
-    }
+      } FD_BORROWED_ACCOUNT_DROP( buffer );
 
-    if( fd_bpf_upgradeable_loader_state_is_buffer( &account_state ) ) {
-      if( FD_UNLIKELY( !account_state.inner.buffer.authority_address ) ) {
-        FD_LOG_WARNING(( "Buffer is immutable" ));
-        return FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE;
-      }
-      if( FD_UNLIKELY( memcmp( account_state.inner.buffer.authority_address, present_authority_key, sizeof(fd_pubkey_t) ) ) ) {
-        FD_LOG_WARNING(( "Incorrect buffer authority provided" ));
-        return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
-      }
-      if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 1UL ) ) ) {
-        FD_LOG_WARNING(( "Buffer authority did not sign" ));
-        return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
-      }
-      if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 2UL ) ) ) {
-        FD_LOG_WARNING(( "New authority did not sign" ));
-        return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
-      }
-      account_state.inner.buffer.authority_address = (fd_pubkey_t*)new_authority_key;
-      err = fd_bpf_loader_v3_program_write_state( instr_ctx, account, &account_state );
-      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-        FD_LOG_WARNING(( "Bincode encode for buffer account failed" ));
-        return err;
-      }
-    } else if( fd_bpf_upgradeable_loader_state_is_program_data( &account_state ) ) {
-      if( FD_UNLIKELY( !account_state.inner.program_data.upgrade_authority_address ) ) {
-        FD_LOG_WARNING(( "Program not upgradeable" ));
-        return FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE;
-      }
-      if( FD_UNLIKELY( memcmp( account_state.inner.program_data.upgrade_authority_address, present_authority_key, sizeof(fd_pubkey_t) ) ) ) {
-        FD_LOG_WARNING(( "Incorrect program authority provided" ));
-        return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
-      }
-      if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 1UL ) ) ) {
-        FD_LOG_WARNING(( "Program authority did not sign" ));
-        return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
-      }
-      if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 2UL ) ) ) {
-        FD_LOG_WARNING(( "New authority did not sign" ));
-        return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
-      }
-      account_state.inner.program_data.upgrade_authority_address = (fd_pubkey_t*)new_authority_key;
-      err = fd_bpf_loader_v3_program_write_state( instr_ctx, account, &account_state );
-      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-        FD_LOG_WARNING(( "Bpf state wr encode for program data account failed" ));
-        return err;
-      }
-    } else {
-      FD_LOG_WARNING(( "Account does not support authorities" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+      break;
     }
-  /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1031-L1134 */
-  } else if( fd_bpf_upgradeable_loader_program_instruction_is_close( &instruction ) ) {
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1032-L1046 */
-    if( FD_UNLIKELY( instr_ctx->instr->acct_cnt<2U ) ) {
-      FD_LOG_WARNING(( "Not enough account keys for instruction" ));
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
-    }
-    if( FD_UNLIKELY( instr_acc_idxs[ 0UL ]==instr_acc_idxs[ 1UL ] ) ) {
-      FD_LOG_WARNING(( "Recipient is the same as the account being closed" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
-    }
-    fd_borrowed_account_t * close_account = NULL;
-    err = fd_instr_borrowed_account_modify_idx( instr_ctx, 0UL, 0UL, &close_account );
-    if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Borrowed account lookup for close account failed" ));
-      return err;
-    }
-    fd_pubkey_t * close_key = close_account->pubkey;
-    fd_bpf_upgradeable_loader_state_t close_account_state = {0};
-    err = fd_bpf_loader_v3_program_read_state( instr_ctx, close_account, &close_account_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bpf state read for close account failed" ));
-      return err;
-    }
-    close_account->meta->dlen = SIZE_OF_UNINITIALIZED;
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1049-L1056 */
-    if( fd_bpf_upgradeable_loader_state_is_uninitialized( &close_account_state ) ) {
-      fd_borrowed_account_t * recipient_account = NULL;
-      err = fd_instr_borrowed_account_modify_idx( instr_ctx, 1UL, 0UL, &recipient_account );
-      if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-        FD_LOG_WARNING(( "Borrowed account lookup for recipient account failed" ));
-        return err;
-      }
-      ulong result = 0UL;
-      err = fd_ulong_checked_add( recipient_account->meta->info.lamports,
-                                  close_account->meta->info.lamports,
-                                  &result );
-      if( FD_UNLIKELY( err ) ) {
-        FD_LOG_WARNING(( "Checked add on recipient and close account balances failed" ));
-        return err;
-      }
-      recipient_account->meta->info.lamports = result;
-      close_account->meta->info.lamports     = 0UL;
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1057-L1068 */
-    } else if( fd_bpf_upgradeable_loader_state_is_buffer( &close_account_state ) ) {
-      if( FD_UNLIKELY( instr_ctx->instr->acct_cnt<3U ) ) {
-        FD_LOG_WARNING(( "Not enough account keys for instruction" ));
+    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L494-L525 */
+    case fd_bpf_upgradeable_loader_program_instruction_enum_write: {
+      if( FD_UNLIKELY( fd_account_check_num_insn_accounts( instr_ctx, 2U ) ) ) {
         return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
       }
-      err = common_close_account( close_account_state.inner.buffer.authority_address, instr_ctx, &close_account_state );
+
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 0UL, buffer ) {
+
+      fd_bpf_upgradeable_loader_state_t loader_state = {0};
+      err = fd_bpf_loader_v3_program_get_state( instr_ctx, buffer, &loader_state );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Bpf loader state read for buffer account failed" ));
+        return err;
+      }
+
+      if( fd_bpf_upgradeable_loader_state_is_buffer( &loader_state ) ) {
+        if( FD_UNLIKELY( !loader_state.inner.buffer.authority_address ) ) {
+          FD_LOG_WARNING(( "Buffer is immutable" ));
+          return FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE;
+        }
+        fd_pubkey_t const * authority_key = &txn_accs[ instr_acc_idxs[ 1UL ] ];
+        if( FD_UNLIKELY( memcmp( loader_state.inner.buffer.authority_address, authority_key, sizeof(fd_pubkey_t) ) ) ) {
+          FD_LOG_WARNING(( "Incorrect buffer authority provided" ));
+          return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
+        }
+        if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 1UL ) ) ) {
+          FD_LOG_WARNING(( "Buffer authority did not sign" ));
+          return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
+        }
+      } else {
+        FD_LOG_WARNING(( "Invalid Buffer account" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+      }
+
+      } FD_BORROWED_ACCOUNT_DROP( buffer );
+
+      ulong program_data_offset = fd_ulong_sat_add( BUFFER_METADATA_SIZE, instruction.inner.write.offset );
+      err = write_program_data( instr_ctx,
+                                0UL,
+                                program_data_offset,
+                                instruction.inner.write.bytes,
+                                instruction.inner.write.bytes_len );
       if( FD_UNLIKELY( err ) ) {
         return err;
       }
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1069-L1129 */
-    } else if( fd_bpf_upgradeable_loader_state_is_program_data( &close_account_state ) ) {
-      if( FD_UNLIKELY( instr_ctx->instr->acct_cnt<4U ) ) {
+
+      break;
+    }
+    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L526-L702 */
+    case fd_bpf_upgradeable_loader_program_instruction_enum_deploy_with_max_data_len: {
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L527-L541 */
+      if( FD_UNLIKELY( fd_account_check_num_insn_accounts( instr_ctx, 4U ) ) ) {
+        return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      }
+      fd_pubkey_t const * payer_key       = &txn_accs[ instr_acc_idxs[ 0UL ] ];
+      fd_pubkey_t const * programdata_key = &txn_accs[ instr_acc_idxs[ 1UL ] ];
+      /* rent is accessed directly from the epoch bank and the clock from the
+        slot context. However, a check must be done to make sure that the
+        sysvars are correctly included in the set of transaction accounts. */
+      err = fd_check_sysvar_account( instr_ctx, 4UL, &fd_sysvar_rent_id );
+      if( FD_UNLIKELY( err ) ) {
+        return err;
+      }
+      err = fd_check_sysvar_account( instr_ctx, 5UL, &fd_sysvar_clock_id );
+      if( FD_UNLIKELY( err ) ) {
+        return err;
+      }
+
+      fd_sol_sysvar_clock_t clock = {0};
+      if( FD_UNLIKELY( !fd_sysvar_clock_read( &clock, instr_ctx->slot_ctx ) ) ) {
+        return FD_EXECUTOR_INSTR_ERR_GENERIC_ERR;
+      }
+      if( fd_account_check_num_insn_accounts( instr_ctx, 8U ) ) {
+        return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      }
+      fd_pubkey_t const * authority_key = &txn_accs[ instr_acc_idxs[ 7UL ] ];
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L542-L560 */
+      /* Verify Program account */
+
+      fd_bpf_upgradeable_loader_state_t loader_state = {0};
+      fd_pubkey_t * new_program_id = NULL;
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 2UL, program ) {
+
+      err = fd_bpf_loader_v3_program_get_state( instr_ctx, program, &loader_state );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Bpf state read for program account failed" ));
+        return err;
+      }
+      if( FD_UNLIKELY( !fd_bpf_upgradeable_loader_state_is_uninitialized( &loader_state ) ) ) {
+        FD_LOG_WARNING(( "Program account is already initialized" ));
+        return FD_EXECUTOR_INSTR_ERR_ACC_ALREADY_INITIALIZED;
+      }
+      if( FD_UNLIKELY( program->const_meta->dlen<SIZE_OF_PROGRAM ) ) {
+        FD_LOG_WARNING(( "Program account too small" ));
+        return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
+      }
+      if( FD_UNLIKELY( program->const_meta->info.lamports<fd_rent_exempt_minimum_balance( instr_ctx->slot_ctx,
+                                                                                          program->const_meta->dlen ) ) ) {
+        FD_LOG_WARNING(( "Program account not rent-exempt" ));
+        return FD_EXECUTOR_INSTR_ERR_ACC_NOT_RENT_EXEMPT;
+      }
+      new_program_id = program->pubkey;
+
+      } FD_BORROWED_ACCOUNT_DROP( program );
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L561-L600 */
+      /* Verify Buffer account */
+
+      fd_borrowed_account_t * buffer = NULL;
+      err = fd_instr_borrowed_account_view_idx( instr_ctx, 3UL, &buffer );
+      if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Borrowed account lookup for buffer account failed" ));
+        return err;
+      }
+
+      fd_pubkey_t * buffer_key = NULL;
+      ulong buffer_data_offset = 0UL;
+      ulong buffer_data_len    = 0UL;
+      ulong programdata_len    = 0UL;
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 3UL, buffer ) {
+
+      fd_bpf_upgradeable_loader_state_t buffer_state = {0};
+      err = fd_bpf_loader_v3_program_get_state( instr_ctx, buffer, &buffer_state );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Bincode decode failed for buffer account loader state" ));
+        return err;
+      }
+
+      if( fd_bpf_upgradeable_loader_state_is_buffer( &buffer_state ) ) {
+        if( FD_UNLIKELY( (authority_key==NULL) != (buffer_state.inner.buffer.authority_address == NULL) ||
+            (authority_key!=NULL && memcmp( buffer_state.inner.buffer.authority_address, authority_key, sizeof(fd_pubkey_t) ) ) ) ) {
+          FD_LOG_WARNING(( "Buffer and upgrade authority don't match" ));
+          return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
+        }
+        if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 7UL ) ) ) {
+          FD_LOG_WARNING(( "Upgrade authority did not sign" ));
+          return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
+        }
+      } else {
+        FD_LOG_WARNING(( "Invalid Buffer account" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+      }
+      buffer_key         = buffer->pubkey;
+      buffer_data_offset = BUFFER_METADATA_SIZE;
+      buffer_data_len    = fd_ulong_sat_sub( buffer->const_meta->dlen, buffer_data_offset );
+      /* UpgradeableLoaderState::size_of_program_data( max_data_len ) */
+      programdata_len    = fd_ulong_sat_add( PROGRAMDATA_METADATA_SIZE,
+                                             instruction.inner.deploy_with_max_data_len.max_data_len );
+
+      if( FD_UNLIKELY( buffer->const_meta->dlen<BUFFER_METADATA_SIZE || buffer->const_meta->dlen==0UL ) ) {
+        FD_LOG_WARNING(( "Buffer account too small" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+      }
+    
+      if( FD_UNLIKELY( instruction.inner.deploy_with_max_data_len.max_data_len<buffer_data_len ) ) {
+        FD_LOG_WARNING(( "Max data length is too small to hold Buffer data" ));
+        return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
+      }
+
+      if( FD_UNLIKELY( programdata_len>MAX_PERMITTED_DATA_LENGTH ) ) {
+        FD_LOG_WARNING(( "Max data length is too large" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+      }
+
+      } FD_BORROWED_ACCOUNT_DROP( buffer );
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L602-L608 */
+      /* Create ProgramData account */
+
+      fd_pubkey_t derived_address[ 1UL ];
+      uchar * seeds[ 1UL ];
+      seeds[ 0UL ] = (uchar *)new_program_id;
+      uchar bump_seed = 0;
+      err = fd_pubkey_try_find_program_address( program_id, 1UL, seeds, derived_address, &bump_seed );
+      if( FD_UNLIKELY( err ) ) {
+        FD_LOG_WARNING(( "Failed to derive program address" ));
+        return err;
+      }
+      if( FD_UNLIKELY( memcmp( derived_address, programdata_key, sizeof(fd_pubkey_t) ) ) ) {
+        FD_LOG_WARNING(( "ProgramData address is not derived" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+      }
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L610-L627 */
+      /* Drain the Buffer account to payer before paying for programdata account */
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 0UL, payer  ) {
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 3UL, buffer ) {
+
+      err = fd_account_checked_add_lamports( instr_ctx, 0UL, buffer->meta->info.lamports );
+      if( FD_UNLIKELY( err ) ) {
+        return err;
+      }
+      err = fd_account_set_lamports( instr_ctx, 3UL, 0UL );
+      if( FD_UNLIKELY( err ) ) {
+        return err;
+      }
+
+      } FD_BORROWED_ACCOUNT_DROP( buffer );
+      } FD_BORROWED_ACCOUNT_DROP( payer  );
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L628-L642 */
+      /* Pass an extra account to avoid the overly strict unblanaced instruction error */
+      /* Invoke the system program to create the new account */
+      fd_system_program_instruction_create_account_t create_acct;
+      create_acct.lamports = fd_rent_exempt_minimum_balance( instr_ctx->slot_ctx, programdata_len );
+      if( !create_acct.lamports ) {
+        create_acct.lamports = 1UL;
+      }
+      create_acct.space = programdata_len;
+      create_acct.owner = instr_ctx->instr->program_id_pubkey;
+
+      fd_system_program_instruction_t instr = {0};
+      instr.discriminant         = fd_system_program_instruction_enum_create_account;
+      instr.inner.create_account = create_acct;
+
+      fd_vm_rust_account_meta_t * acct_metas = (fd_vm_rust_account_meta_t*)
+                                                fd_scratch_alloc( FD_VM_RUST_ACCOUNT_META_ALIGN,
+                                                                  3UL * sizeof(fd_vm_rust_account_meta_t) );
+      fd_native_cpi_create_account_meta( payer_key,       1U, 1U, &acct_metas[ 0UL ] );
+      fd_native_cpi_create_account_meta( programdata_key, 1U, 1U, &acct_metas[ 1UL ] );
+      fd_native_cpi_create_account_meta( buffer_key,      0U, 1U, &acct_metas[ 2UL ] );
+
+      /* caller_program_id == program_id */
+      fd_pubkey_t signers[ 1UL ];
+      err = fd_pubkey_derive_pda( program_id, 1UL, seeds, &bump_seed, signers );
+      if( FD_UNLIKELY( err ) ) {
+        return err;
+      }
+
+      err = fd_native_cpi_execute_system_program_instruction( instr_ctx, &instr, acct_metas, 3UL, signers, 1UL );
+      if( FD_UNLIKELY( err ) ) {
+        return err;
+      }
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L644-L665 */
+      /* Load and verify the program bits */
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 3UL, buffer ) {
+      if( FD_UNLIKELY( buffer_data_offset>buffer->meta->dlen ) ) {
+        FD_LOG_WARNING(( "Buffer data offset is out of bounds" ));
+        return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
+      }
+
+      uchar * buffer_data = buffer->data + buffer_data_offset;
+
+      err = deploy_program( instr_ctx, buffer_data, buffer_data_len );
+      if( FD_UNLIKELY( err ) ) {
+        FD_LOG_WARNING(( "Failed to deploy program" ));
+        return err;
+      }
+
+      } FD_BORROWED_ACCOUNT_DROP( buffer );
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L667-L691 */
+      /* Update the ProgramData account and record the program bits */
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L669-L674 */
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 1UL, programdata ) {
+
+      fd_bpf_upgradeable_loader_state_t programdata_loader_state = {
+        .discriminant = fd_bpf_upgradeable_loader_state_enum_program_data,
+        .inner.program_data = {
+          .slot                      = clock.slot,
+          .upgrade_authority_address = (fd_pubkey_t *)authority_key,
+        },
+      };
+      err = fd_bpf_loader_v3_program_set_state( instr_ctx, 1UL, &programdata_loader_state );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Bpf state write for programdata account failed" ));
+        return err;
+      }
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L675-L689 */
+      if( FD_UNLIKELY( PROGRAMDATA_METADATA_SIZE+buffer_data_len>programdata->meta->dlen ) ) {
+        uchar * sig = (uchar *)instr_ctx->txn_ctx->_txn_raw->raw + instr_ctx->txn_ctx->txn_descriptor->signature_off;
+        FD_LOG_WARNING(( "ProgramData account too small %32J %lu %lu", sig, buffer_data_len, programdata->meta->dlen ));
+        return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
+      }
+      if( FD_UNLIKELY( buffer_data_offset>buffer->meta->dlen ) ) {
+        FD_LOG_WARNING(( "Buffer account too small" ));
+        return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
+      }
+
+      uchar * programdata_data = NULL;
+      ulong   programdata_dlen = 0UL;
+      err = fd_account_get_data_mut( instr_ctx, 1UL, &programdata_data, &programdata_dlen );
+      if( FD_UNLIKELY( err ) ) {
+        return err;
+      }
+
+      uchar *   dst_slice = programdata_data + PROGRAMDATA_METADATA_SIZE;
+      ulong dst_slice_len = buffer_data_len;
+
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 3UL, buffer ) {
+
+      if( FD_UNLIKELY( buffer_data_offset>buffer->meta->dlen ) ) {
+        FD_LOG_WARNING(( "Buffer account too small" ));
+        return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
+      }
+      const uchar * src_slice = buffer->const_data + buffer_data_offset;
+      fd_memcpy( dst_slice, src_slice, dst_slice_len );
+      /* Update buffer data length.
+         BUFFER_METADATA_SIZE == UpgradeableLoaderState::size_of_buffer(0) */
+      err = fd_account_set_data_length( instr_ctx, 3UL, BUFFER_METADATA_SIZE );
+      if( FD_UNLIKELY( err ) ) {
+        return err;
+      }
+
+      } FD_BORROWED_ACCOUNT_DROP( buffer      );
+      } FD_BORROWED_ACCOUNT_DROP( programdata );
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L692-L699 */
+      /* Update the Program account */
+
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 2UL, program ) {
+
+      loader_state.discriminant = fd_bpf_upgradeable_loader_state_enum_program;
+      fd_memcpy( &loader_state.inner.program.programdata_address, programdata_key, sizeof(fd_pubkey_t) );
+      err = fd_bpf_loader_v3_program_set_state( instr_ctx, 2UL, &loader_state );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Bincode encode for program account failed" ));
+        return err;
+      }
+      err = fd_account_set_executable( instr_ctx, 2UL, 1 );
+      if( FD_UNLIKELY( err ) ) {
+        FD_LOG_WARNING(( "Couldn't set account to executable" ));
+        return err;
+      }
+
+      FD_LOG_INFO(( "Program deployed %32J", program->pubkey ));
+
+      } FD_BORROWED_ACCOUNT_DROP( program );
+
+      break;
+    }
+    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L703-L891 */
+    case fd_bpf_upgradeable_loader_program_instruction_enum_upgrade: {
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L704-L714 */
+      if( FD_UNLIKELY( fd_account_check_num_insn_accounts( instr_ctx, 3U ) ) ) {
         FD_LOG_WARNING(( "Not enough account keys for instruction" ));
         return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
       }
-      fd_borrowed_account_t * program_account = NULL;
-      err = fd_instr_borrowed_account_modify_idx( instr_ctx, 3UL, 0UL, &program_account );
-      if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-        FD_LOG_WARNING(( "Borrowed account lookup for program account failed" ));
+      fd_pubkey_t const * programdata_key = &txn_accs[ instr_acc_idxs[ 0UL ] ];
+
+      /* rent is accessed directly from the epoch bank and the clock from the
+        slot context. However, a check must be done to make sure that the
+        sysvars are correctly included in the set of transaction accounts. */
+      err = fd_check_sysvar_account( instr_ctx, 4UL, &fd_sysvar_rent_id );
+      if( FD_UNLIKELY( err ) ) {
         return err;
       }
-      fd_pubkey_t * program_key = program_account->pubkey;
-
-      if( FD_UNLIKELY( !fd_instr_acc_is_writable( instr_ctx->instr, program_key ) ) ) {
-        FD_LOG_WARNING(( "Program account is not writable" ));
-        return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+      err = fd_check_sysvar_account( instr_ctx, 5UL, &fd_sysvar_clock_id );
+      if( FD_UNLIKELY( err ) ) {
+        return err;
       }
-      if( FD_UNLIKELY( memcmp( program_account->const_meta->info.owner, program_id, sizeof(fd_pubkey_t) ) ) ) {
+
+      if( FD_UNLIKELY( fd_account_check_num_insn_accounts( instr_ctx, 7U ) ) ) {
+        FD_LOG_WARNING(( "Not enough account keys for instruction" ));
+        return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      }
+      fd_pubkey_t const * authority_key = &txn_accs[ instr_acc_idxs[ 6UL ] ];
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L716-L745 */
+      /* Verify Program account */
+      
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 1UL, program ) {
+
+      if( FD_UNLIKELY( !program->meta->info.executable ) ) {
+        FD_LOG_WARNING(( "Program account not executable" ));
+        return FD_EXECUTOR_INSTR_ERR_ACC_NOT_EXECUTABLE;
+      }
+      if( FD_UNLIKELY( !fd_instr_acc_is_writable( instr_ctx->instr, program->pubkey ) ) ) {
+        FD_LOG_WARNING(( "Program account not writeable" ));
+      }
+      if( FD_UNLIKELY( memcmp( &program->meta->info.owner, program_id, sizeof(fd_pubkey_t) ) ) ) {
         FD_LOG_WARNING(( "Program account not owned by loader" ));
         return FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID;
       }
-      fd_sol_sysvar_clock_t clock = {0};
+      fd_bpf_upgradeable_loader_state_t program_state = {0};
+      err = fd_bpf_loader_v3_program_get_state( instr_ctx, program, &program_state );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Bincode decode for program account failed" ));
+        return err;
+      }
+      if( FD_UNLIKELY( fd_bpf_upgradeable_loader_state_is_program( &program_state ) ) ) {
+        if( FD_UNLIKELY( memcmp( &program_state.inner.program.programdata_address, programdata_key, sizeof(fd_pubkey_t) ) ) ) {
+          FD_LOG_WARNING(( "Program and ProgramData account mismatch" ));
+          return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+        }
+      } else {
+        FD_LOG_WARNING(( "Invalid Program account" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+      }
+
+      } FD_BORROWED_ACCOUNT_DROP( program );
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L747-L773 */
+      /* Verify Buffer account */
+
+      ulong buffer_lamports    = 0UL;
+      ulong buffer_data_offset = 0UL;
+      ulong buffer_data_len    = 0UL;
+
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 2UL, buffer ) {
+
+      fd_bpf_upgradeable_loader_state_t buffer_state = {0};
+      err = fd_bpf_loader_v3_program_get_state( instr_ctx, buffer, &buffer_state );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Bincode decode for buffer account failed" ));
+        return err;
+      }
+      if( fd_bpf_upgradeable_loader_state_is_buffer( &buffer_state ) ) {
+        if( FD_UNLIKELY( (authority_key==NULL) != (buffer_state.inner.buffer.authority_address == NULL) ||
+            (authority_key!=NULL && memcmp( buffer_state.inner.buffer.authority_address, authority_key, sizeof(fd_pubkey_t) ) ) ) ) {
+          FD_LOG_WARNING(( "Buffer and upgrade authority don't match" ));
+          return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
+        }
+        if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 6UL ) ) ) {
+          FD_LOG_WARNING(( "Upgrade authority did not sign" ));
+          return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
+        }
+      } else {
+        FD_LOG_WARNING(( "Invalid Buffer account" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+      }
+      buffer_lamports    = buffer->meta->info.lamports;
+      buffer_data_offset = BUFFER_METADATA_SIZE;
+      buffer_data_len    = fd_ulong_sat_sub( buffer->meta->dlen, buffer_data_offset );
+      if( FD_UNLIKELY( buffer->meta->dlen<BUFFER_METADATA_SIZE || buffer->meta->dlen==0UL ) ) {
+        FD_LOG_WARNING(( "Buffer account too small" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+      }
+      
+      } FD_BORROWED_ACCOUNT_DROP( buffer );
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L775-L823 */
+      /* Verify ProgramData account */
+
+      ulong                             programdata_data_offset      = PROGRAMDATA_METADATA_SIZE;
+      fd_bpf_upgradeable_loader_state_t programdata_state            = {0};
+      fd_sol_sysvar_clock_t             clock                        = {0};
+      ulong                             programdata_balance_required = 0UL;
+
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 0UL, programdata ) {
+
+      programdata_balance_required = fd_ulong_max( 1UL, fd_rent_exempt_minimum_balance( instr_ctx->slot_ctx, programdata->const_meta->dlen ) );
+    
+      if( FD_UNLIKELY( programdata->meta->dlen<fd_ulong_sat_add( PROGRAMDATA_METADATA_SIZE, buffer_data_len ) ) ) {
+        FD_LOG_WARNING(( "ProgramData account not large enough" ));
+        return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
+      }
+      if( FD_UNLIKELY( fd_ulong_sat_add( programdata->meta->info.lamports, buffer_lamports )<programdata_balance_required ) ) {
+        FD_LOG_WARNING(( "Buffer account balance too low to fund upgrade" ));
+        return FD_EXECUTOR_INSTR_ERR_INSUFFICIENT_FUNDS;
+      }
+      err = fd_bpf_loader_v3_program_get_state( instr_ctx, programdata, &programdata_state );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Bincode decode for programdata account failed" ));
+        return err;
+      }
+
       if( FD_UNLIKELY( !fd_sysvar_clock_read( &clock, instr_ctx->slot_ctx ) ) ) {
-        FD_LOG_WARNING(( "Unable to read clock sysvar" ));
         return FD_EXECUTOR_INSTR_ERR_GENERIC_ERR;
       }
-      if( FD_UNLIKELY( clock.slot==close_account_state.inner.program_data.slot ) ) {
-        FD_LOG_WARNING(( "Program was deployed in this block already" ));
+
+      if( fd_bpf_upgradeable_loader_state_is_program_data( &programdata_state ) ) {
+        if( FD_UNLIKELY( clock.slot==programdata_state.inner.program_data.slot ) ) {
+          FD_LOG_WARNING(( "Program was deployed in this block already" ));
+          return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+        }
+        if( FD_UNLIKELY( !programdata_state.inner.program_data.upgrade_authority_address ) ) {
+          FD_LOG_WARNING(( "Prrogram not upgradeable" ));
+          return FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE;
+        }
+        if( FD_UNLIKELY( memcmp( programdata_state.inner.program_data.upgrade_authority_address, authority_key, sizeof(fd_pubkey_t) ) ) ) {
+          FD_LOG_WARNING(( "Incorrect upgrade authority provided" ));
+          return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
+        }
+        if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 6UL ) ) ) {
+          FD_LOG_WARNING(( "Upgrade authority did not sign" ));
+          return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
+        }
+      } else {
+        FD_LOG_WARNING(( "Invalid ProgramData account" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+      }
+
+      } FD_BORROWED_ACCOUNT_DROP( programdata );
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L825-L845 */
+      /* Load and verify the program bits */
+
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 2UL, buffer ) {
+
+      if( FD_UNLIKELY( buffer_data_offset>buffer->meta->dlen ) ) {
+        FD_LOG_WARNING(( "Buffer data offset is out of bounds" ));
+        return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
+      }
+
+      uchar * buffer_data = buffer->data + buffer_data_offset;
+      err = deploy_program( instr_ctx, buffer_data, buffer_data_len );
+      if( FD_UNLIKELY( err ) ) {
+        FD_LOG_WARNING(( "Failed to deploy program" ));
+        return err;
+      }
+
+      } FD_BORROWED_ACCOUNT_DROP( buffer );
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L846-L874 */
+      /* Update the ProgramData account, record the upgraded data, and zero the rest */
+
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 0UL, programdata ) {
+
+      programdata_state.discriminant                                 = fd_bpf_upgradeable_loader_state_enum_program_data;
+      programdata_state.inner.program_data.slot                      = clock.slot;
+      programdata_state.inner.program_data.upgrade_authority_address = (fd_pubkey_t *)authority_key;
+      err = fd_bpf_loader_v3_program_set_state( instr_ctx, 0UL, &programdata_state );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Bpf state write for programdata account failed" ));
+        return err;
+      }
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L846-L875 */
+      /* We want to copy over the data and zero out the rest */
+      if( FD_UNLIKELY( programdata_data_offset+buffer_data_len>programdata->meta->dlen ) ) {
+        FD_LOG_WARNING(( "ProgramData account too small" ));
+        return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
+      }
+
+      uchar * programdata_data = NULL;
+      ulong   programdata_dlen = 0UL;
+      err = fd_account_get_data_mut( instr_ctx, 0UL, &programdata_data, &programdata_dlen );
+      if( FD_UNLIKELY( err ) ) {
+        return err;
+      }
+      uchar * dst_slice     = programdata_data + programdata_data_offset;
+      ulong   dst_slice_len = buffer_data_len;
+
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 2UL, buffer ) {
+
+      if( FD_UNLIKELY( buffer_data_offset>buffer->meta->dlen ) ){
+        FD_LOG_WARNING(( "Buffer account too small" ));
+        return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
+      }
+
+      uchar * src_slice     = buffer->data + buffer_data_offset;
+      fd_memcpy( dst_slice, src_slice, dst_slice_len );
+      fd_memset( dst_slice + dst_slice_len, 0, programdata->meta->dlen - programdata_data_offset - dst_slice_len );
+
+      } FD_BORROWED_ACCOUNT_DROP( buffer );
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L876-L891 */
+      /* Fund ProgramData to rent-exemption, spill the rest */
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 2UL, buffer ) {
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 3UL, spill  ) {
+
+      ulong spill_addend = fd_ulong_sat_sub( fd_ulong_sat_add( programdata->meta->info.lamports, buffer_lamports ),
+                                             programdata_balance_required );
+      err = fd_account_checked_add_lamports( instr_ctx, 3UL, spill_addend );
+      if( FD_UNLIKELY( err ) ) {
+        return err;
+      }
+      err = fd_account_set_lamports( instr_ctx, 2UL, 0UL );
+      if( FD_UNLIKELY( err ) ) {
+        return err;
+      }
+      err = fd_account_set_lamports( instr_ctx, 0UL, programdata_balance_required );
+      if( FD_UNLIKELY( err ) ) {
+        return err;
+      }
+
+      programdata->meta->info.lamports = programdata_balance_required;
+      /* Buffer account set_data_length */
+      err = fd_account_set_data_length( instr_ctx, 2UL, PROGRAMDATA_METADATA_SIZE );
+      if( FD_UNLIKELY( err ) ) {
+        return err;
+      }
+
+      } FD_BORROWED_ACCOUNT_DROP( spill       );
+      } FD_BORROWED_ACCOUNT_DROP( buffer      );
+      } FD_BORROWED_ACCOUNT_DROP( programdata );
+
+      break;
+    }
+    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L893-L957 */
+    case fd_bpf_upgradeable_loader_program_instruction_enum_set_authority: {
+      if( FD_UNLIKELY( fd_account_check_num_insn_accounts( instr_ctx, 2U ) ) ) {
+        FD_LOG_WARNING(( "Not enough account keys for instruction" ));
+        return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      }
+
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 0UL, account ) {
+
+      fd_pubkey_t const * present_authority_key = &txn_accs[ instr_acc_idxs[ 1UL ] ];
+      fd_pubkey_t *       new_authority         = NULL;
+      if( FD_UNLIKELY( instr_ctx->instr->acct_cnt>=3UL ) ) {
+        new_authority = (fd_pubkey_t *)&txn_accs[ instr_acc_idxs[ 2UL ] ];
+      }
+
+      fd_bpf_upgradeable_loader_state_t account_state = {0};
+      err = fd_bpf_loader_v3_program_get_state( instr_ctx, account, &account_state );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Bincode decode for account failed" ));
+        return err;
+      }
+
+      if( fd_bpf_upgradeable_loader_state_is_buffer( &account_state ) ) {
+        if( FD_UNLIKELY( !new_authority ) ) {
+          FD_LOG_WARNING(( "Buffer authority is not optional" ));
+          return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
+        }
+        if( FD_UNLIKELY( !account_state.inner.buffer.authority_address ) ) {
+          FD_LOG_WARNING(( "Buffer is immutable" ));
+          return FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE;
+        }
+        if( FD_UNLIKELY( memcmp( account_state.inner.buffer.authority_address, present_authority_key, sizeof(fd_pubkey_t) ) ) ) {
+          FD_LOG_WARNING(( "Incorrect buffer authority provided" ));
+          return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
+        }
+        if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 1UL ) ) ) {
+          FD_LOG_WARNING(( "Buffer authority did not sign" ));
+          return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
+        }
+        account_state.inner.buffer.authority_address = new_authority;
+        err = fd_bpf_loader_v3_program_set_state( instr_ctx, 0UL, &account_state );
+        if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+          FD_LOG_WARNING(( "Bpf state write for account failed" ));
+          return err;
+        }
+      } else if( fd_bpf_upgradeable_loader_state_is_program_data( &account_state ) ) {
+        if( FD_UNLIKELY( !account_state.inner.program_data.upgrade_authority_address ) ) {
+          FD_LOG_WARNING(( "Program not upgradeable" ));
+          return FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE;
+        }
+        if( FD_UNLIKELY( memcmp( account_state.inner.program_data.upgrade_authority_address, present_authority_key, sizeof(fd_pubkey_t) ) ) ) {
+          FD_LOG_WARNING(( "Incorrect program authority provided" ));
+          return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
+        }
+        if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 1UL ) ) ) {
+          FD_LOG_WARNING(( "Program authority did not sign" ));
+          return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
+        }
+        account_state.inner.program_data.upgrade_authority_address = new_authority;
+        err = fd_bpf_loader_v3_program_set_state( instr_ctx, 0UL, &account_state );
+        if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+          FD_LOG_WARNING(( "Bincode encode for program data account failed" ));
+          return err;
+        }
+      } else {
+        FD_LOG_WARNING(( "Account does not support authorities" ));
         return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
       }
 
+      } FD_BORROWED_ACCOUNT_DROP( account );
+
+      break;
+    }
+    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L958-L1030 */
+    case fd_bpf_upgradeable_loader_program_instruction_enum_set_authority_checked: {
+      if( FD_UNLIKELY( fd_account_check_num_insn_accounts( instr_ctx, 3U ) ) ) {
+        FD_LOG_WARNING(( "Not enough account keys for instruction" ));
+        return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      }
+
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 0UL, account ) {
+
+      fd_pubkey_t const * present_authority_key = &txn_accs[ instr_acc_idxs[ 1UL ] ];
+      fd_pubkey_t const * new_authority_key     = &txn_accs[ instr_acc_idxs[ 2UL ] ];
+
+      fd_bpf_upgradeable_loader_state_t account_state = {0};
+      err = fd_bpf_loader_v3_program_get_state( instr_ctx, account, &account_state );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Bincode decode for account failed" ));
+        return err;
+      }
+
+      if( fd_bpf_upgradeable_loader_state_is_buffer( &account_state ) ) {
+        if( FD_UNLIKELY( !account_state.inner.buffer.authority_address ) ) {
+          FD_LOG_WARNING(( "Buffer is immutable" ));
+          return FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE;
+        }
+        if( FD_UNLIKELY( memcmp( account_state.inner.buffer.authority_address, present_authority_key, sizeof(fd_pubkey_t) ) ) ) {
+          FD_LOG_WARNING(( "Incorrect buffer authority provided" ));
+          return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
+        }
+        if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 1UL ) ) ) {
+          FD_LOG_WARNING(( "Buffer authority did not sign" ));
+          return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
+        }
+        if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 2UL ) ) ) {
+          FD_LOG_WARNING(( "New authority did not sign" ));
+          return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
+        }
+        account_state.inner.buffer.authority_address = (fd_pubkey_t*)new_authority_key;
+        err = fd_bpf_loader_v3_program_set_state( instr_ctx, 0UL, &account_state );
+        if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+          FD_LOG_WARNING(( "Bincode encode for buffer account failed" ));
+          return err;
+        }
+      } else if( fd_bpf_upgradeable_loader_state_is_program_data( &account_state ) ) {
+        if( FD_UNLIKELY( !account_state.inner.program_data.upgrade_authority_address ) ) {
+          FD_LOG_WARNING(( "Program not upgradeable" ));
+          return FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE;
+        }
+        if( FD_UNLIKELY( memcmp( account_state.inner.program_data.upgrade_authority_address, present_authority_key, sizeof(fd_pubkey_t) ) ) ) {
+          FD_LOG_WARNING(( "Incorrect program authority provided" ));
+          return FD_EXECUTOR_INSTR_ERR_INCORRECT_AUTHORITY;
+        }
+        if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 1UL ) ) ) {
+          FD_LOG_WARNING(( "Program authority did not sign" ));
+          return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
+        }
+        if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( instr_ctx->instr, 2UL ) ) ) {
+          FD_LOG_WARNING(( "New authority did not sign" ));
+          return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
+        }
+        account_state.inner.program_data.upgrade_authority_address = (fd_pubkey_t*)new_authority_key;
+        err = fd_bpf_loader_v3_program_set_state( instr_ctx, 0UL, &account_state );
+        if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+          FD_LOG_WARNING(( "Bpf state wr encode for program data account failed" ));
+          return err;
+        }
+      } else {
+        FD_LOG_WARNING(( "Account does not support authorities" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+      }
+
+      } FD_BORROWED_ACCOUNT_DROP( account );
+
+      break;
+    }
+    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1031-L1134 */
+    case fd_bpf_upgradeable_loader_program_instruction_enum_close: {
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1032-L1046 */
+      if( FD_UNLIKELY( fd_account_check_num_insn_accounts( instr_ctx, 2U ) ) ) {
+        FD_LOG_WARNING(( "Not enough account keys for instruction" ));
+        return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      }
+      if( FD_UNLIKELY( instr_acc_idxs[ 0UL ]==instr_acc_idxs[ 1UL ] ) ) {
+        FD_LOG_WARNING(( "Recipient is the same as the account being closed" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+      }
+
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 0UL, close_account ) {
+      
+      fd_pubkey_t * close_key = close_account->pubkey;
+      fd_bpf_upgradeable_loader_state_t close_account_state = {0};
+      err = fd_bpf_loader_v3_program_get_state( instr_ctx, close_account, &close_account_state );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Bpf state read for close account failed" ));
+        return err;
+      }
+      /* Close account set data length */
+      err = fd_account_set_data_length( instr_ctx, 0UL, SIZE_OF_UNINITIALIZED );
+      if( FD_UNLIKELY( err ) ) {
+        return err;
+      }
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1049-L1056 */
+      if( fd_bpf_upgradeable_loader_state_is_uninitialized( &close_account_state ) ) {
+
+        FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 1UL, recipient_account ) {
+
+        err = fd_account_checked_add_lamports( instr_ctx, 1UL, close_account->meta->info.lamports );
+        if( FD_UNLIKELY( err ) ) {
+          return err;
+        }
+        err = fd_account_set_lamports( instr_ctx, 0UL, 0UL );
+        if( FD_UNLIKELY( err ) ) {
+          return err;
+        }
+        FD_LOG_INFO(( "Closed Uninitialized %32J", close_key ));
+
+        } FD_BORROWED_ACCOUNT_DROP( recipient_account );
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1057-L1068 */
+      } else if( fd_bpf_upgradeable_loader_state_is_buffer( &close_account_state ) ) {
+
+        fd_borrowed_account_release_write( close_account );
+
+        if( FD_UNLIKELY( fd_account_check_num_insn_accounts( instr_ctx, 3U ) ) ) {
+          FD_LOG_WARNING(( "Not enough account keys for instruction" ));
+          return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+        }
+
+        err = common_close_account( close_account_state.inner.buffer.authority_address, instr_ctx, &close_account_state );
+        if( FD_UNLIKELY( err ) ) {
+          return err;
+        }
+        FD_LOG_INFO(( "Closed Buffer %32J", close_key ));
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1069-L1129 */
+      } else if( fd_bpf_upgradeable_loader_state_is_program_data( &close_account_state ) ) {
+        if( FD_UNLIKELY( fd_account_check_num_insn_accounts( instr_ctx, 4U ) ) ) {
+          FD_LOG_WARNING(( "Not enough account keys for instruction" ));
+          return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+        }
+
+        fd_borrowed_account_release_write( close_account );
+
+        FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 3UL, program_account ) {
+
+        fd_pubkey_t * program_key = program_account->pubkey;
+
+        if( FD_UNLIKELY( !fd_instr_acc_is_writable( instr_ctx->instr, program_key ) ) ) {
+          FD_LOG_WARNING(( "Program account is not writable" ));
+          return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+        }
+        if( FD_UNLIKELY( memcmp( program_account->const_meta->info.owner, program_id, sizeof(fd_pubkey_t) ) ) ) {
+          FD_LOG_WARNING(( "Program account not owned by loader" ));
+          return FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID;
+        }
+        fd_sol_sysvar_clock_t clock = {0};
+        if( FD_UNLIKELY( !fd_sysvar_clock_read( &clock, instr_ctx->slot_ctx ) ) ) {
+          FD_LOG_WARNING(( "Unable to read clock sysvar" ));
+          return FD_EXECUTOR_INSTR_ERR_GENERIC_ERR;
+        }
+        if( FD_UNLIKELY( clock.slot==close_account_state.inner.program_data.slot ) ) {
+          FD_LOG_WARNING(( "Program was deployed in this block already" ));
+          return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+        }
+
+        fd_bpf_upgradeable_loader_state_t program_state = {0};
+        err = fd_bpf_loader_v3_program_get_state( instr_ctx, program_account, &program_state );
+        if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+          FD_LOG_WARNING(( "Bpf state read for program account failed" ));
+          return err;
+        }
+        if( fd_bpf_upgradeable_loader_state_is_program( &program_state ) ) {
+          if( FD_UNLIKELY( memcmp( &program_state.inner.program.programdata_address, close_key, sizeof(fd_pubkey_t) ) ) ) {
+            FD_LOG_WARNING(( "Program account does not match ProgramData account" ));
+            return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+          }
+          fd_borrowed_account_release_write( program_account );
+
+          err = common_close_account( close_account_state.inner.program_data.upgrade_authority_address,
+                                      instr_ctx,
+                                      &close_account_state );
+          if( FD_UNLIKELY( err ) ) {
+            return err;
+          }
+
+          /* The Agave client updates the account state upon closing an account
+            in their loaded program cache. Checking for a program can be
+            checked by checking to see if the programdata account's loader state
+            is unitialized. The firedancer implementation also removes closed
+            accounts from the loaded program cache at the end of a slot. Closed
+            accounts currently get handled in the 
+            fd_bpf_loader_v3_is_executable check in fd_executor.c */
+
+        } else {
+          FD_LOG_WARNING(( "Invalid program account" ));
+          return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+        }
+
+        } FD_BORROWED_ACCOUNT_DROP( program_account );
+      } else {        
+        FD_LOG_WARNING(( "Account does not support closing" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+      }
+
+      } FD_BORROWED_ACCOUNT_DROP( close_account );
+
+      break;
+    }
+    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1136-L1294 */
+    case fd_bpf_upgradeable_loader_program_instruction_enum_extend_program: {
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1137-L1172 */
+      uint additional_bytes = instruction.inner.extend_program.additional_bytes;
+      if( FD_UNLIKELY( additional_bytes==0U ) ) {
+        FD_LOG_WARNING(( "Additional bytes must be greater than 0" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+      }
+
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 0UL, programdata_account ) {
+
+      fd_borrowed_account_t * programdata_account = NULL;
+      err = fd_instr_borrowed_account_modify_idx( instr_ctx, 0UL, 0UL, &programdata_account );
+      if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Borrowed account lookup for programdata account failed" ));
+        return err;
+      }
+      fd_pubkey_t * programdata_key = programdata_account->pubkey;
+
+      if( FD_UNLIKELY( memcmp( program_id, programdata_account->const_meta->info.owner, sizeof(fd_pubkey_t) ) ) ) {
+        FD_LOG_WARNING(( "ProgramData owner is invalid" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_OWNER;
+      }
+      if( FD_UNLIKELY( !fd_instr_acc_is_writable( instr_ctx->instr, programdata_key ) ) ) {
+        FD_LOG_WARNING(( "ProgramData is not writable" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+      }
+
+      FD_BORROWED_ACCOUNT_TRY_BORROW_IDX( instr_ctx, 1UL, program_account ) {
+
+      if( FD_UNLIKELY( !fd_instr_acc_is_writable( instr_ctx->instr, program_account->pubkey ) ) ) {
+        FD_LOG_WARNING(( "Program account is not writable" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+      }
+      if( FD_UNLIKELY( memcmp( program_id, program_account->const_meta->info.owner, sizeof(fd_pubkey_t) ) ) ) {
+        FD_LOG_WARNING(( "Program account not owned by loader" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_OWNER;
+      }
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1172-L1190 */
       fd_bpf_upgradeable_loader_state_t program_state = {0};
-      err = fd_bpf_loader_v3_program_read_state( instr_ctx, program_account, &program_state );
+      err = fd_bpf_loader_v3_program_get_state( instr_ctx, program_account, &program_state );
       if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
         FD_LOG_WARNING(( "Bpf state read for program account failed" ));
         return err;
       }
       if( fd_bpf_upgradeable_loader_state_is_program( &program_state ) ) {
-        if( FD_UNLIKELY( memcmp( &program_state.inner.program.programdata_address, close_key, sizeof(fd_pubkey_t) ) ) ) {
+        if( FD_UNLIKELY( memcmp( &program_state.inner.program.programdata_address, programdata_key, sizeof(fd_pubkey_t) ) ) ) {
           FD_LOG_WARNING(( "Program account does not match ProgramData account" ));
           return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
         }
-        err = common_close_account( close_account_state.inner.program_data.upgrade_authority_address,
-                                    instr_ctx,
-                                    &close_account_state );
+      } else {
+        FD_LOG_WARNING(( "Invalid program account" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+      }
+
+      } FD_BORROWED_ACCOUNT_DROP( program_account );
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1191-L1230 */
+      ulong old_len = programdata_account->const_meta->dlen;
+      ulong new_len = fd_ulong_sat_add( old_len, additional_bytes );
+      if( FD_UNLIKELY( new_len>MAX_PERMITTED_DATA_LENGTH ) ) {
+        FD_LOG_WARNING(( "Extended ProgramData length of %lu bytes exceeds max account data length of %lu bytes",
+                        new_len, MAX_PERMITTED_DATA_LENGTH ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_REALLOC;
+      }
+
+      fd_sol_sysvar_clock_t clock = {0};
+      if( FD_UNLIKELY( !fd_sysvar_clock_read( &clock, instr_ctx->slot_ctx ) ) ) {
+        FD_LOG_WARNING(( "Unable to read the slot sysvar" ));
+        return FD_EXECUTOR_INSTR_ERR_GENERIC_ERR;
+      }
+
+      fd_bpf_upgradeable_loader_state_t programdata_state = {0};
+      fd_pubkey_t * upgrade_authority_address = NULL;
+      err = fd_bpf_loader_v3_program_get_state( instr_ctx, programdata_account, &programdata_state );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Bpf state read for programdata account failed" ));
+        return err;
+      }
+      if( fd_bpf_upgradeable_loader_state_is_program_data( &programdata_state ) ) {
+        if( FD_UNLIKELY( clock.slot==programdata_state.inner.program_data.slot ) ) {
+          FD_LOG_WARNING(( "Program was extended in this block already" ));
+          return FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE;
+        }
+
+        if( FD_UNLIKELY( !programdata_state.inner.program_data.upgrade_authority_address ) ) {
+          FD_LOG_WARNING(( "Cannot extend ProgramData accounts that are not upgradeable" ));
+          return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+        }
+        upgrade_authority_address = programdata_state.inner.program_data.upgrade_authority_address;
+      } else {
+        FD_LOG_WARNING(( "ProgramData state is invalid" ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+      }
+
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1232-L1256 */
+      ulong balance          = programdata_account->const_meta->info.lamports;
+      ulong min_balance      = fd_ulong_max( fd_rent_exempt_minimum_balance( instr_ctx->slot_ctx, new_len ), 1UL );
+      ulong required_payment = fd_ulong_sat_sub( min_balance, balance );
+
+      /* Borrowed accounts need to be dropped before native invocations. Note:
+         the programdata account is manually released and acquired within the
+         extend instruction to preserve the local variable scoping to maintain
+         readability. The scoped macro still successfully handles the case of
+         freeing a write lock in case of an early termination. */
+      fd_borrowed_account_release_write( programdata_account );
+
+      if( FD_UNLIKELY( required_payment>0UL ) ) {
+        fd_pubkey_t const * payer_key = &txn_accs[ instr_acc_idxs[ 3UL ] ];
+
+        fd_system_program_instruction_t instr = {
+          .discriminant   = fd_system_program_instruction_enum_transfer,
+          .inner.transfer = required_payment
+        };
+
+        fd_vm_rust_account_meta_t * acct_metas = (fd_vm_rust_account_meta_t *)fd_scratch_alloc(
+                                                                                FD_VM_RUST_ACCOUNT_META_ALIGN,
+                                                                                2UL * sizeof(fd_vm_rust_account_meta_t) );
+        fd_native_cpi_create_account_meta( payer_key,       1UL, 1UL, &acct_metas[ 0UL ] );
+        fd_native_cpi_create_account_meta( programdata_key, 0UL, 1UL, &acct_metas[ 1UL ] );
+
+        err = fd_native_cpi_execute_system_program_instruction( instr_ctx, &instr, acct_metas, 2UL, NULL, 0UL );
         if( FD_UNLIKELY( err ) ) {
           return err;
         }
-
-        /* The Agave client updates the account state upon closing an account
-           in their loaded prograam cache. Checking for a program can be
-           checked by checking to see if the programdata account's loader state
-           is unitialized. */
-      } else {
-        FD_LOG_WARNING(( "Invalid program account" ));
-        return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
-      }
-    } else {
-      FD_LOG_WARNING(( "Account does not support closing" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
-    }
-  /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1136-L1294 */
-  } else if( fd_bpf_upgradeable_loader_program_instruction_is_extend_program( &instruction ) ) {
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1137-L1172 */
-    uint additional_bytes = instruction.inner.extend_program.additional_bytes;
-    if( FD_UNLIKELY( additional_bytes==0U ) ) {
-      FD_LOG_WARNING(( "Additional bytes must be greater than 0" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
-    }
-
-    fd_borrowed_account_t * programdata_account = NULL;
-    err = fd_instr_borrowed_account_modify_idx( instr_ctx, 0UL, 0UL, &programdata_account );
-    if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Borrowed account lookup for programdata account failed" ));
-      return err;
-    }
-    fd_pubkey_t * programdata_key = programdata_account->pubkey;
-
-    if( FD_UNLIKELY( memcmp( program_id, programdata_account->const_meta->info.owner, sizeof(fd_pubkey_t) ) ) ) {
-      FD_LOG_WARNING(( "ProgramData owner is invalid" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_OWNER;
-    }
-    if( FD_UNLIKELY( !fd_instr_acc_is_writable( instr_ctx->instr, programdata_key ) ) ) {
-      FD_LOG_WARNING(( "ProgramData is not writable" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
-    }
-
-    fd_borrowed_account_t * program_account = NULL;
-    err = fd_instr_borrowed_account_modify_idx( instr_ctx, 1UL, 0UL, &program_account );
-    if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Borrowed account lookup for program account failed" ));
-      return err;
-    }
-    if( FD_UNLIKELY( !fd_instr_acc_is_writable( instr_ctx->instr, program_account->pubkey ) ) ) {
-      FD_LOG_WARNING(( "Program account is not writable" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
-    }
-    if( FD_UNLIKELY( memcmp( program_id, program_account->const_meta->info.owner, sizeof(fd_pubkey_t) ) ) ) {
-      FD_LOG_WARNING(( "Program account not owned by loader" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_OWNER;
-    }
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1172-L1190 */
-    fd_bpf_upgradeable_loader_state_t program_state = {0};
-    err = fd_bpf_loader_v3_program_read_state( instr_ctx, program_account, &program_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bpf state read for program account failed" ));
-      return err;
-    }
-    if( fd_bpf_upgradeable_loader_state_is_program( &program_state ) ) {
-      if( FD_UNLIKELY( memcmp( &program_state.inner.program.programdata_address, programdata_key, sizeof(fd_pubkey_t) ) ) ) {
-        FD_LOG_WARNING(( "Program account does not match ProgramData account" ));
-        return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
-      }
-    } else {
-      FD_LOG_WARNING(( "Invalid program account" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
-    }
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1191-L1230 */
-    ulong old_len = programdata_account->const_meta->dlen;
-    ulong new_len = fd_ulong_sat_add( old_len, additional_bytes );
-    if( FD_UNLIKELY( new_len>MAX_PERMITTED_DATA_LENGTH ) ) {
-      FD_LOG_WARNING(( "Extended ProgramData length of %lu bytes exceeds max account data length of %lu bytes",
-                       new_len, MAX_PERMITTED_DATA_LENGTH ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_REALLOC;
-    }
-
-    fd_sol_sysvar_clock_t clock = {0};
-    if( FD_UNLIKELY( !fd_sysvar_clock_read( &clock, instr_ctx->slot_ctx ) ) ) {
-      FD_LOG_WARNING(( "Unable to read the slot sysvar" ));
-      return FD_EXECUTOR_INSTR_ERR_GENERIC_ERR;
-    }
-
-    fd_bpf_upgradeable_loader_state_t programdata_state = {0};
-    fd_pubkey_t * upgrade_authority_address = NULL;
-    err = fd_bpf_loader_v3_program_read_state( instr_ctx, programdata_account, &programdata_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bpf state read for programdata account failed" ));
-      return err;
-    }
-    if( fd_bpf_upgradeable_loader_state_is_program_data( &programdata_state ) ) {
-      if( FD_UNLIKELY( clock.slot==programdata_state.inner.program_data.slot ) ) {
-        FD_LOG_WARNING(( "Program was extended in this block already" ));
-        return FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE;
       }
 
-      if( FD_UNLIKELY( !programdata_state.inner.program_data.upgrade_authority_address ) ) {
-        FD_LOG_WARNING(( "Cannot extend ProgramData accounts that are not upgradeable" ));
-        return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+      /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1258-L1293 */
+      if( FD_UNLIKELY( !fd_borrowed_account_acquire_write( programdata_account ) ) ) {
+        return FD_EXECUTOR_INSTR_ERR_MISSING_ACC;
       }
-      upgrade_authority_address = programdata_state.inner.program_data.upgrade_authority_address;
-    } else {
-      FD_LOG_WARNING(( "ProgramData state is invalid" ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
-    }
 
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1232-L1256 */
-    ulong balance          = programdata_account->const_meta->info.lamports;
-    ulong min_balance      = fd_rent_exempt_minimum_balance( instr_ctx->slot_ctx, new_len );
-    min_balance            = fd_ulong_if( min_balance>0UL, min_balance, 1UL );
-    ulong required_payment = fd_ulong_sat_sub( min_balance, balance );
-
-    if( FD_UNLIKELY( required_payment>0UL ) ) {
-      fd_pubkey_t const * payer_key = &txn_accs[ instr_acc_idxs[ 3UL ] ];
-
-      fd_system_program_instruction_t instr = {
-        .discriminant   = fd_system_program_instruction_enum_transfer,
-        .inner.transfer = required_payment
-      };
-
-      fd_vm_rust_account_meta_t * acct_metas = (fd_vm_rust_account_meta_t *)fd_scratch_alloc(
-                                                                              FD_VM_RUST_ACCOUNT_META_ALIGN,
-                                                                              2UL * sizeof(fd_vm_rust_account_meta_t) );
-      fd_native_cpi_create_account_meta( payer_key,       1UL, 1UL, &acct_metas[ 0UL ] );
-      fd_native_cpi_create_account_meta( programdata_key, 0UL, 1UL, &acct_metas[ 1UL ] );
-
-      err = fd_native_cpi_execute_system_program_instruction( instr_ctx, &instr, acct_metas, 2UL, NULL, 0UL );
+      /* Programdata account set data length */
+      int err = fd_account_set_data_length( instr_ctx, 0UL, new_len );
       if( FD_UNLIKELY( err ) ) {
         return err;
       }
+
+      if( FD_UNLIKELY( PROGRAMDATA_METADATA_SIZE>programdata_account->meta->dlen ) ) {
+        return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
+      }
+
+      uchar * programdata_data = programdata_account->data + PROGRAMDATA_METADATA_SIZE;
+      ulong   programdata_size = new_len                   - PROGRAMDATA_METADATA_SIZE;
+
+      err = deploy_program( instr_ctx, programdata_data, programdata_size );
+      if( FD_UNLIKELY( err ) ) {
+        FD_LOG_WARNING(( "Failed to deploy program" ));
+        return err;
+      }
+
+      fd_borrowed_account_release_write( programdata_account );
+
+      /* Setting the discriminant and upgrade authority address here can likely
+         be a no-op because these values shouldn't change. These can probably be
+         removed, but can help to mirror against Agave client's implementation. 
+         The set_state function also contains an ownership check. */
+
+      if( FD_UNLIKELY( !fd_borrowed_account_acquire_write( programdata_account ) ) ) {
+        return FD_EXECUTOR_INSTR_ERR_MISSING_ACC;
+      }
+
+      programdata_state.discriminant                                 = fd_bpf_upgradeable_loader_state_enum_program_data;
+      programdata_state.inner.program_data.slot                      = clock.slot;
+      programdata_state.inner.program_data.upgrade_authority_address = upgrade_authority_address;
+
+      err = fd_bpf_loader_v3_program_set_state( instr_ctx, 0UL, &programdata_state );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
+        FD_LOG_WARNING(( "Bincode encode for programdata account failed" ));
+        return err;
+      }
+
+      } FD_BORROWED_ACCOUNT_DROP( programdata_account );
+
+      break;
     }
-
-    /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1258-L1293 */
-    err = fd_instr_borrowed_account_modify_idx( instr_ctx, 0UL, new_len, &programdata_account );
-    if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Borrowed account lookup for programdata account failed" ));
-      return err;
-    }
-
-    err = 0;
-    if( FD_UNLIKELY( !fd_account_set_data_length( instr_ctx, 0UL, new_len, &err ) ) ) {
-      return err;
-    }
-
-    if( FD_UNLIKELY( PROGRAMDATA_METADATA_SIZE>programdata_account->meta->dlen ) ) {
-      return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
-    }
-
-    uchar * programdata_data = programdata_account->data + PROGRAMDATA_METADATA_SIZE;
-    ulong   programdata_size = new_len                   - PROGRAMDATA_METADATA_SIZE;
-
-    err = deploy_program( instr_ctx, programdata_data, programdata_size );
-    if( FD_UNLIKELY( err ) ) {
-      FD_LOG_WARNING(( "Failed to deploy program" ));
-      return err;
-    }
-
-    /* Setting the discriminant and upgrade authority address here should
-       be a no-op because these values shouldn't change. These can probably be
-       removed, but can help to mirror against Agave client's implementation. */
-    programdata_state.discriminant                                 = fd_bpf_upgradeable_loader_state_enum_program_data;
-    programdata_state.inner.program_data.slot                      = clock.slot;
-    programdata_state.inner.program_data.upgrade_authority_address = upgrade_authority_address;
-
-    err = fd_bpf_loader_v3_program_write_state( instr_ctx, programdata_account, &programdata_state );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
-      FD_LOG_WARNING(( "Bincode encode for programdata account failed" ));
-      return err;
-    }
-  } else {
-    FD_LOG_WARNING(( "ProgramData state is invalid" ));
-    return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+    default: {
+      FD_LOG_WARNING(( "ProgramData state is invalid" ));
+      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+  }
   }
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
@@ -1533,7 +1656,7 @@ fd_bpf_loader_v3_program_execute( fd_exec_instr_ctx_t ctx ) {
       account's respective program data account is uninitialized. This should only
       happen when the account is closed. */
     fd_bpf_upgradeable_loader_state_t program_account_state = {0};
-    err = fd_bpf_loader_v3_program_read_state( &ctx, program_account, &program_account_state );
+    err = fd_bpf_loader_v3_program_get_state( &ctx, program_account, &program_account_state );
     if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
       FD_LOG_WARNING(( "Bpf state read for program account failed" ));
       return err;
@@ -1548,7 +1671,7 @@ fd_bpf_loader_v3_program_execute( fd_exec_instr_ctx_t ctx ) {
     }
 
     fd_bpf_upgradeable_loader_state_t program_data_account_state = {0};
-    err = fd_bpf_loader_v3_program_read_state( &ctx, program_data_account, &program_data_account_state );
+    err = fd_bpf_loader_v3_program_get_state( &ctx, program_data_account, &program_data_account_state );
     if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
       FD_LOG_WARNING(( "Bpf state read for program data account failed" ));
       return err;

--- a/src/flamenco/runtime/program/fd_system_program.c
+++ b/src/flamenco/runtime/program/fd_system_program.c
@@ -187,9 +187,10 @@ fd_system_program_allocate( fd_exec_instr_ctx_t * ctx,
   /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L108 */
 
   do {
-    int err = FD_EXECUTOR_INSTR_ERR_FATAL;  /* 'FATAL', in case set_data_length doesn't initialize this value */
-    int ok = fd_account_set_data_length( ctx, acct_idx, space, &err );
-    if( FD_UNLIKELY( !ok ) ) return err;
+    int err = fd_account_set_data_length( ctx, acct_idx, space );
+    if( FD_UNLIKELY( err ) ) {
+      return err;
+    }
   } while(0);
 
   return FD_EXECUTOR_INSTR_SUCCESS;

--- a/src/flamenco/runtime/program/fd_vote_program.c
+++ b/src/flamenco/runtime/program/fd_vote_program.c
@@ -779,11 +779,10 @@ set_vote_account_state( ulong                       vote_acct_idx,
 
     /* The resize operation itself is part of the horrible conditional,
        but behind a short-circuit operator. */
-    int resize_err;
     int resize_failed = 0;
     if( resize_needed && resize_rent_exempt ) {
       resize_failed =
-        !fd_account_set_data_length( ctx, vote_acct_idx, vsz, &resize_err );
+        fd_account_set_data_length( ctx, vote_acct_idx, vsz ) != FD_EXECUTOR_INSTR_SUCCESS;
     }
 
     if( FD_UNLIKELY( resize_needed && ( !resize_rent_exempt || resize_failed ) ) ) {


### PR DESCRIPTION
A follow up to this pr will be to replace the logic in the rest of the native programs with these updated APIs and a total tearout of fd_account_old

Also fixes: 
https://github.com/firedancer-io/auditor-internal/issues/107
https://github.com/firedancer-io/auditor-internal/issues/119