### PR TITLE
flamenco, runtime: remove support for RequestUnitsDeprecated instruction

### DIFF
--- a/src/flamenco/runtime/program/fd_compute_budget_program.c
+++ b/src/flamenco/runtime/program/fd_compute_budget_program.c
@@ -60,20 +60,6 @@ int fd_executor_compute_budget_program_execute_instructions( fd_exec_txn_ctx_t *
     }
 
     switch (instruction.discriminant) {
-      case fd_compute_budget_program_instruction_enum_request_units_deprecated: {
-        if( has_compute_units_limit_update | has_compute_units_price_update ) {
-          /* FIXME: RETURN TXN ERR DUPLICATE TXN! */
-          return 1;
-        }
-
-        has_compute_units_limit_update = 1;
-        has_compute_units_price_update = 1;
-        prioritization_fee_type = FD_COMPUTE_BUDGET_PRIORITIZATION_FEE_TYPE_DEPRECATED;
-        updated_compute_unit_limit =  instruction.inner.request_units_deprecated.units;
-        updated_compute_unit_price =  instruction.inner.request_units_deprecated.additional_fee;
-
-        break;
-      }
       case fd_compute_budget_program_instruction_enum_request_heap_frame: {
         if( has_requested_heap_size ) {
           /* FIXME: RETURN TXN ERR DUPLICATE TXN! */
@@ -125,7 +111,7 @@ int fd_executor_compute_budget_program_execute_instructions( fd_exec_txn_ctx_t *
           break;
       }
       default: {
-        FD_LOG_WARNING(( "unsupported compute budget program instruction: discriminant: %d", instruction.discriminant ));
+        return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
       }
     }
   }


### PR DESCRIPTION
This was feature gated by `remove_deprecated_request_unit_ix`, which has been activated on all networks.