### PR TITLE
Fix broken build on platforms without threads

### DIFF
--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -1,4 +1,5 @@
 ifdef FD_HAS_HOSTED
+ifdef FD_HAS_THREADS
 ifdef FD_HAS_ALLOCA
 ifdef FD_HAS_DOUBLE
 ifdef FD_HAS_INT128
@@ -151,6 +152,7 @@ $(OBJDIR)/bin/solana: solana/target/$(RUST_PROFILE)/solana
 
 solana: $(OBJDIR)/bin/solana $(OBJDIR)/bin/solana
 
+endif
 endif
 endif
 endif

--- a/src/disco/topo/Local.mk
+++ b/src/disco/topo/Local.mk
@@ -1,6 +1,8 @@
 ifdef FD_HAS_HOSTED
+ifdef FD_HAS_THREADS
 ifdef FD_HAS_LINUX
 $(call add-hdrs,fd_topo.h fd_pod_format.h)
 $(call add-objs,fd_topo fd_topob fd_topo_run,fd_disco)
+endif
 endif
 endif

--- a/src/disco/tvu/fd_replay.c
+++ b/src/disco/tvu/fd_replay.c
@@ -102,10 +102,14 @@ fd_replay_delete( void * replay ) {
 
 static void
 fd_replay_pending_lock( fd_replay_t * replay ) {
+# if FD_HAS_THREADS
   for( ;; ) {
     if( FD_LIKELY( !FD_ATOMIC_CAS( &replay->pending_lock, 0UL, 1UL ) ) ) break;
     FD_SPIN_PAUSE();
   }
+# else
+  replay->pending_lock = 1;
+# endif
   FD_COMPILER_MFENCE();
 }
 

--- a/src/flamenco/gossip/fd_gossip.c
+++ b/src/flamenco/gossip/fd_gossip.c
@@ -401,10 +401,14 @@ fd_gossip_delete ( void * shmap ) {
 
 static void
 fd_gossip_lock( fd_gossip_t * gossip ) {
+# if FD_HAS_THREADS
   for(;;) {
     if( FD_LIKELY( !FD_ATOMIC_CAS( &gossip->lock, 0UL, 1UL) ) ) break;
     FD_SPIN_PAUSE();
   }
+# else
+  gossip->lock = 1;
+# endif
   FD_COMPILER_MFENCE();
 }
 
@@ -511,7 +515,7 @@ fd_gossip_update_tvu_addr( fd_gossip_t * glob, const fd_gossip_peer_addr_t * tvu
 }
 
 int
-fd_gossip_update_tpu_addr( fd_gossip_t * glob, 
+fd_gossip_update_tpu_addr( fd_gossip_t * glob,
                            fd_gossip_peer_addr_t const * tpu,
                            fd_gossip_peer_addr_t const * tpu_fwd ) {
   char tmp[100];

--- a/src/flamenco/runtime/fd_bank_hash_cmp.c
+++ b/src/flamenco/runtime/fd_bank_hash_cmp.c
@@ -85,10 +85,14 @@ fd_bank_hash_cmp_delete( void * bank_hash_cmp ) {
 void
 fd_bank_hash_cmp_lock( fd_bank_hash_cmp_t * bank_hash_cmp ) {
   volatile int * lock = &bank_hash_cmp->lock;
+# if FD_HAS_THREADS
   for( ;; ) {
     if( FD_LIKELY( !FD_ATOMIC_CAS( lock, 0UL, 1UL ) ) ) break;
     FD_SPIN_PAUSE();
   }
+# else
+  *lock = 1;
+# endif
   FD_COMPILER_MFENCE();
 }
 

--- a/src/flamenco/snapshot/Local.mk
+++ b/src/flamenco/snapshot/Local.mk
@@ -7,7 +7,9 @@ $(call add-hdrs,fd_snapshot_http.h)
 $(call add-objs,fd_snapshot_http,fd_flamenco)
 $(call make-unit-test,test_snapshot_http,test_snapshot_http,fd_flamenco fd_disco fd_funk fd_ballet fd_util)
 $(call run-unit-test,test_snapshot_http)
+ifdef FD_HAS_THREADS
 $(call make-fuzz-test,fuzz_snapshot_http,fuzz_snapshot_http,fd_flamenco fd_disco fd_funk fd_ballet fd_util)
+endif
 endif
 
 $(call add-hdrs,fd_snapshot_istream.h)


### PR DESCRIPTION
Closes #2178

Unfortunately, excessive use of tpool breaks basic functionality like fd_vm on targets without threads. Fixing that is a larger change that is out of scope for this PR.