### PR TITLE
flamenco, vm: implement disable_deploy_of_alloc_free_syscall

### DIFF
--- a/src/flamenco/runtime/program/fd_bpf_loader_v2_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v2_program.c
@@ -90,7 +90,7 @@ fd_bpf_loader_v2_user_execute( fd_exec_instr_ctx_t ctx ) {
   fd_sbpf_syscalls_t * syscalls = fd_sbpf_syscalls_new( fd_valloc_malloc( ctx.valloc, fd_sbpf_syscalls_align(), fd_sbpf_syscalls_footprint() ) );
   FD_TEST( syscalls );
 
-  fd_vm_syscall_register_all( syscalls );
+  fd_vm_syscall_register_all( syscalls, 0 );
   /* Load program */
 
   if(  0!=fd_sbpf_program_load( prog, program_data, program_data_len, syscalls, false ) ) {

--- a/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
@@ -158,7 +158,7 @@ deploy_program( fd_exec_instr_ctx_t * instr_ctx,
     FD_LOG_WARNING(( "Failed to register syscalls" ));
     return FD_EXECUTOR_INSTR_ERR_PROGRAM_ENVIRONMENT_SETUP_FAILURE;
   }
-  fd_vm_syscall_register_all( syscalls );
+  fd_vm_syscall_register_all( syscalls, 1 );
 
   /* Load executable */
   fd_sbpf_elf_info_t  _elf_info[ 1UL ];
@@ -357,7 +357,7 @@ execute( fd_exec_instr_ctx_t * instr_ctx, fd_sbpf_validated_program_t * prog ) {
                                                                           fd_sbpf_syscalls_footprint() ) );
   FD_TEST( syscalls );
 
-  fd_vm_syscall_register_all( syscalls );
+  fd_vm_syscall_register_all( syscalls, 0 );
 
   /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1362-L1368 */
   ulong input_sz = 0;

--- a/src/flamenco/runtime/program/fd_bpf_program_util.c
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.c
@@ -170,7 +170,7 @@ fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t * slot_ctx,
     fd_sbpf_syscalls_t * syscalls = fd_sbpf_syscalls_new( fd_scratch_alloc( fd_sbpf_syscalls_align(), fd_sbpf_syscalls_footprint() ) );
     FD_TEST( syscalls );
 
-    fd_vm_syscall_register_all( syscalls );
+    fd_vm_syscall_register_all( syscalls, 0 );
 
     /* Load program */
 

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -966,7 +966,7 @@ fd_sbpf_program_load_test_run( FD_PARAM_UNUSED fd_exec_instr_test_runner_t * run
     fd_sbpf_syscalls_t * syscalls = fd_sbpf_syscalls_new( fd_valloc_malloc( valloc, fd_sbpf_syscalls_align(), fd_sbpf_syscalls_footprint() ));
     FD_TEST( syscalls );
 
-    fd_vm_syscall_register_all( syscalls );
+    fd_vm_syscall_register_all( syscalls, 0 );
 
     int res = fd_sbpf_program_load( prog, _bin, elf_sz, syscalls, input->deploy_checks );
     if( FD_UNLIKELY( res ) ) {
@@ -1041,7 +1041,7 @@ fd_exec_vm_syscall_test_run( fd_exec_instr_test_runner_t *          runner,
   fd_sha256_t _sha[1];
   fd_sha256_t * sha = fd_sha256_join( fd_sha256_new( _sha ) );
   fd_sbpf_syscalls_t * syscalls = fd_sbpf_syscalls_new( fd_valloc_malloc( valloc, fd_sbpf_syscalls_align(), fd_sbpf_syscalls_footprint() ) );
-  fd_vm_syscall_register_all( syscalls );
+  fd_vm_syscall_register_all( syscalls, 0 );
 
   /* Pull out the memory regions */
   FD_TEST( input->has_vm_ctx );

--- a/src/flamenco/vm/fd_vm_base.h
+++ b/src/flamenco/vm/fd_vm_base.h
@@ -633,18 +633,23 @@ fd_vm_syscall_register( fd_sbpf_syscalls_t *   syscalls,
    will register all fd_vm syscall implementations (whether or not that
    makes sense ... may change between Firedancer versions without
    warning).  FIXME: probably better to pass the features for a slot
-   than pass the whole slot_ctx. */
+   than pass the whole slot_ctx.
+   
+   is_deploy should be 1 if the set of syscalls registered should be that
+   used to verify programs before they are deployed, and 0 if it
+   should be the set used to execute programs. */
 
 int
 fd_vm_syscall_register_slot( fd_sbpf_syscalls_t *       syscalls,
-                             fd_exec_slot_ctx_t const * slot_ctx );
+                             fd_exec_slot_ctx_t const * slot_ctx,
+                             uchar is_deploy );
 
 /* fd_vm_syscall_register_all is a shorthand for registering all
    syscalls (see register slot). */
 
 static inline int
-fd_vm_syscall_register_all( fd_sbpf_syscalls_t * syscalls ) {
-  return fd_vm_syscall_register_slot( syscalls, NULL );
+fd_vm_syscall_register_all( fd_sbpf_syscalls_t * syscalls, uchar is_deploy ) {
+  return fd_vm_syscall_register_slot( syscalls, NULL, is_deploy );
 }
 
 FD_PROTOTYPES_END

--- a/src/flamenco/vm/fd_vm_tool.c
+++ b/src/flamenco/vm/fd_vm_tool.c
@@ -63,7 +63,7 @@ fd_vm_tool_prog_create( fd_vm_tool_prog_t * tool_prog,
       aligned_alloc( fd_sbpf_syscalls_align(), fd_sbpf_syscalls_footprint() ) );
   FD_TEST( syscalls );
 
-  fd_vm_syscall_register_all( syscalls );
+  fd_vm_syscall_register_all( syscalls, 0 );
 
   /* Load program */
   if( FD_UNLIKELY( 0!=fd_sbpf_program_load( prog, bin_buf, bin_sz, syscalls, false ) ) )

--- a/src/flamenco/vm/syscall/fd_vm_syscall.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall.c
@@ -17,7 +17,8 @@ fd_vm_syscall_register( fd_sbpf_syscalls_t *   syscalls,
 
 int
 fd_vm_syscall_register_slot( fd_sbpf_syscalls_t *       syscalls,
-                             fd_exec_slot_ctx_t const * slot_ctx ) {
+                             fd_exec_slot_ctx_t const * slot_ctx,
+                             uchar is_deploy ) {
   if( FD_UNLIKELY( !syscalls ) ) return FD_VM_ERR_INVAL;
 
   int enable_secp256k1_recover_syscall     = 0;
@@ -64,7 +65,14 @@ fd_vm_syscall_register_slot( fd_sbpf_syscalls_t *       syscalls,
   REGISTER( "abort",                                 fd_vm_syscall_abort );
   REGISTER( "sol_panic_",                            fd_vm_syscall_sol_panic );
   REGISTER( "custom_panic",                          fd_vm_syscall_sol_panic ); /* FIXME: unsure if this is entirely correct */
-  REGISTER( "sol_alloc_free_",                       fd_vm_syscall_sol_alloc_free );
+
+  /* As of the activation of disable_deploy_of_alloc_free_syscall, which is activated on all networks,
+     programs can no longer be deployed which use the sol_alloc_free_ syscall.
+
+    https://github.com/anza-xyz/agave/blob/d6041c002bbcf1526de4e38bc18fa6e781c380e7/programs/bpf_loader/src/syscalls/mod.rs#L429 */
+  if ( FD_LIKELY( !is_deploy ) ) {
+    REGISTER( "sol_alloc_free_",                       fd_vm_syscall_sol_alloc_free );
+  }
 
   /* https://github.com/solana-labs/solana/blob/v1.18.1/sdk/program/src/syscalls/definitions.rs#L39 */
 


### PR DESCRIPTION
As of the activation of `disable_deploy_of_alloc_free_syscall`, which is activated on all networks, programs can no longer be deployed which use the `sol_alloc_free_` syscall.