### PR TITLE
ci: fix clusterfuzz publish script

### DIFF
--- a/.github/workflows/clusterfuzz.yml
+++ b/.github/workflows/clusterfuzz.yml
@@ -26,6 +26,8 @@ jobs:
       EXTRAS: fuzz asan ubsan
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: ./.github/actions/hugepages
       - uses: ./.github/actions/deps

--- a/.github/workflows/coverage_report_clusterfuzz.yml
+++ b/.github/workflows/coverage_report_clusterfuzz.yml
@@ -15,6 +15,8 @@ jobs:
       EXTRAS: llvm-cov
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: ./.github/actions/deps
 


### PR DESCRIPTION
Submodules need to be fetched so that fdctl's version.h [generator script](https://github.com/firedancer-io/firedancer/blob/7541b4bb0645a311922132f60959f03e30aa0bf7/src/app/fdctl/with-version.mk#L15) can correctly determine FIREDANCER_VERSION_PATCH

This fixes the clusterfuzz ci scripts

