### PR TITLE
ci: unit tests for compiler versions

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -9,6 +9,18 @@ inputs:
     description: 'Path of deps-bundle.sh script'
     required: true
     default: './contrib/deps-bundle.sh'
+  compiler:
+    description: 'The compiler to use'
+    required: true
+    default: 'gcc'
+    type: choice
+    options:
+      - gcc
+      - clang
+  compiler-version:
+    description: 'The compiler version to use'
+    required: true
+    default: '12.4.0'
 outputs: {}
 runs:
   using: composite
@@ -35,7 +47,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: deps-bundle.tar.zst
-        key: ${{ runner.os }}-${{ runner.arch }}-deps-sh-${{ steps.deps-sh-hash.outputs.HASH }}
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-deps-sh-${{ steps.deps-sh-hash.outputs.HASH }}
 
     - name: Install system level dependencies
       shell: bash
@@ -49,6 +61,10 @@ runs:
     - name: Install dependencies from scratch
       shell: bash
       run: |
-        FD_AUTO_INSTALL_PACKAGES=1 '${{ inputs.deps-script-path }}' +dev fetch install
+        source /opt/${{ inputs.compiler }}/${{ inputs.compiler }}-${{ inputs.compiler-version }}/activate
+        CC='${{ inputs.compiler }}' \
+        CXX='${{ inputs.compiler == 'gcc' && 'g++' || 'clang++' }}' \
+        FD_AUTO_INSTALL_PACKAGES=1 \
+        '${{ inputs.deps-script-path }}' +dev fetch install
         '${{ inputs.deps-bundle-path }}'
       if: steps.deps-sh-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,48 +15,146 @@ jobs:
       # This matrix is a tradeoff between required resources and
       # test coverage.  You should probably only remove machine
       # targets from here, not add more.
+      fail-fast: true
       matrix:
-        machine:
-          - linux_gcc_noarch64    # least capable target
+        test-case:
+          - linux_gcc_noarch64-gcc-12
+          - linux_gcc_noarch64        # least capable target
           - linux_gcc_x86_64
-          - linux_gcc_icelake     #  most capable target
+          - linux_gcc_icelake         #  most capable target
           - linux_clang_x86_64
           - linux_clang_icelake
           - native
+          - fddev-no-solana
         # Attach additional params to machine types
         include:
-          - machine: linux_gcc_noarch64
+          - test-case: linux_gcc_noarch64-gcc-12 
+            machine: linux_gcc_noarch64
             label: X64
+            extras: rpath
             targets: "all"
-            notest: 1
-          - machine: linux_gcc_x86_64
+            compiler: gcc
+            compiler-version: 12.4.0
+            run-unit-tests: false
+            run-integration-tests: false
+          - test-case: linux_gcc_noarch64
+            machine: linux_gcc_noarch64
             label: X64
-          - machine: linux_gcc_icelake
+            extras: rpath
+            targets: "all"
+            compiler: gcc
+            compiler-version: 8.5.0
+            run-unit-tests: false
+            run-integration-tests: false
+          - test-case: linux_gcc_x86_64
+            machine: linux_gcc_x86_64
+            label: X64
+            extras: rpath
+            targets: "all integration-test fdctl"
+            compiler: gcc
+            compiler-version: 12.4.0
+            run-unit-tests: true
+            run-integration-tests: true
+          - test-case: linux_gcc_icelake
+            machine: linux_gcc_icelake
             label: icelake
-          - machine: linux_clang_x86_64
+            extras: rpath
+            targets: "all integration-test fdctl"
+            compiler: gcc
+            compiler-version: 12.4.0
+            run-unit-tests: true
+            run-integration-tests: true
+          - test-case: linux_clang_x86_64
+            machine: linux_clang_x86_64
             label: X64
-          - machine: native
-            env: CC=clang
+            extras: rpath
+            targets: "all integration-test fdctl"
+            compiler: clang
+            compiler-version: 15.0.6
+            run-unit-tests: true
+            run-integration-tests: true
+          - test-case: linux_clang_icelake
+            machine: linux_clang_icelake
+            label: icelake
+            extras: "asan ubsan rpath"
+            targets: "all integration-test fdctl"
+            compiler: clang
+            compiler-version: 15.0.6
+            run-unit-tests: true
+            run-integration-tests: false
+          - test-case: native
+            machine: native
             label: self-hosted
-          - machine: linux_clang_icelake
-            label: icelake
-            extras: asan ubsan rpath
+            extras: rpath
+            targets: "all integration-test fdctl"
+            compiler: clang
+            compiler-version: 15.0.6
+            run-unit-tests: true
+            run-integration-tests: true
+          - test-case: fddev-no-solana
+            machine: linux_gcc_x86_64
+            label: self-hosted
+            extras: "no-solana rpath"
+            targets: "fddev"
+            compiler: gcc
+            compiler-version: 12.4.0
+            run-unit-tests: false
+            run-integration-tests: false
     runs-on: ${{ matrix.label }}
+    env:
+      MACHINE: ${{ matrix.machine }}
+      EXTRAS: ${{ matrix.extras || '' }}
+      CC: ${{ matrix.compiler }}
+      CXX: ${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - uses: ./.github/actions/deps
+        with:
+          compiler: ${{ matrix.compiler }}
+          compiler-version: ${{ matrix.compiler-version }}
       - uses: ./.github/actions/hugepages
       - uses: dtolnay/rust-toolchain@1.73.0
 
-      - name: Run tests
+      - name: build targets
+        run: |
+          source /opt/${{ matrix.compiler }}/${{ matrix.compiler }}-${{ matrix.compiler-version }}/activate
+          make clean --silent >/dev/null
+          ./contrib/make-j ${{ matrix.targets }}
+      
+      - name: run unit tests
+        if: ${{ matrix.run-unit-tests }}
         run: |
           sudo prlimit --pid $$ --memlock=-1:-1
-          MACHINES=${{ matrix.machine }} \
-          EXTRAS="${{ matrix.extras || 'rpath' }}" \
-          NOTEST=${{ matrix.notest || '' }} \
-          TARGETS="${{ matrix.targets || '' }}" \
-          ${{ matrix.env || '' }} \
-          contrib/test/ci_tests.sh
+          source /opt/${{ matrix.compiler }}/${{ matrix.compiler }}-${{ matrix.compiler-version }}/activate
+          make run-unit-test
+
+      - name: run script tests
+        if: ${{ matrix.run-unit-tests }}
+        run: |
+          sudo prlimit --pid $$ --memlock=-1:-1
+          source /opt/${{ matrix.compiler }}/${{ matrix.compiler }}-${{ matrix.compiler-version }}/activate
+          make run-script-test
+
+      - name: run fuzz tests
+        if: ${{ matrix.run-unit-tests }}
+        run: |
+          sudo prlimit --pid $$ --memlock=-1:-1
+          source /opt/${{ matrix.compiler }}/${{ matrix.compiler }}-${{ matrix.compiler-version }}/activate
+          make run-fuzz-test
+
+      - name: run test-vector tests
+        if: ${{ matrix.run-unit-tests }}
+        run: |
+          sudo prlimit --pid $$ --memlock=-1:-1
+          source /opt/${{ matrix.compiler }}/${{ matrix.compiler }}-${{ matrix.compiler-version }}/activate
+          make run-test-vectors
+
+      - name: run integration tests
+        if: ${{ matrix.run-integration-tests }}
+        run: |
+          sudo prlimit --pid $$ --memlock=-1:-1
+          source /opt/${{ matrix.compiler }}/${{ matrix.compiler }}-${{ matrix.compiler-version }}/activate
+          make run-integration-test

--- a/deps.sh
+++ b/deps.sh
@@ -420,7 +420,7 @@ install_rocksdb () {
   ROCKSDB_DISABLE_ZLIB=1 \
   ROCKSDB_DISABLE_BZIP=1 \
   ROCKSDB_DISABLE_GFLAGS=1 \
-  CFLAGS="-isystem $(pwd)/../../include -g0 -DSNAPPY -DZSTD -Wno-uninitialized -Wno-array-bounds -Wno-stringop-overread" \
+  CFLAGS="-isystem $(pwd)/../../include -g0 -DSNAPPY -DZSTD -Wno-unknown-warning-option -Wno-uninitialized -Wno-array-bounds -Wno-stringop-overread" \
   make -j $NJOBS \
     LITE=1 \
     V=1 \


### PR DESCRIPTION
Adds multiple compiler support to CI. You can configure different compiler versions for tests. Also will make sure deps are build with the same compiler, or a compiler of your request.