### PR TITLE
quic: remove invalid frame handler prototypes

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -6253,32 +6253,6 @@ fd_quic_frame_handle_ack_frame(
 }
 
 static ulong
-fd_quic_frame_handle_ack_range_frag(
-    void * context,
-    fd_quic_ack_range_frag_t * data,
-    uchar const * p,
-    ulong p_sz) {
-  (void)context;
-  (void)data;
-  (void)p;
-  (void)p_sz;
-  return FD_QUIC_PARSE_FAIL;
-}
-
-static ulong
-fd_quic_frame_handle_ecn_counts_frag(
-    void * context,
-    fd_quic_ecn_counts_frag_t * data,
-    uchar const * p,
-    ulong p_sz) {
-  (void)context;
-  (void)data;
-  (void)p;
-  (void)p_sz;
-  return FD_QUIC_PARSE_FAIL;
-}
-
-static ulong
 fd_quic_frame_handle_reset_stream_frame(
     void * context,
     fd_quic_reset_stream_frame_t * data,
@@ -7009,21 +6983,6 @@ fd_quic_frame_handle_handshake_done_frame(
   conn->tls_hs = NULL;
 
   return 0;
-}
-
-static ulong
-fd_quic_frame_handle_common_frag(
-    void * context,
-    fd_quic_common_frag_t * data,
-    uchar const * p,
-    ulong p_sz) {
-  (void)context;
-  (void)data;
-  (void)p;
-  (void)p_sz;
-  /* this callback is completely unused */
-  /* TODO tag template to not generate code for this */
-  return FD_QUIC_PARSE_FAIL;
 }
 
 /* initiate the shutdown of a connection

--- a/src/waltz/quic/templ/fd_quic_frames_templ.h
+++ b/src/waltz/quic/templ/fd_quic_frames_templ.h
@@ -1,13 +1,3 @@
-/* frame common header
-
-   COMMON Frag {
-     Type (i)
-   } */
-FD_TEMPL_DEF_STRUCT_BEGIN(common_frag)
-  FD_TEMPL_MBR_ELEM_VARINT( type, ulong )
-FD_TEMPL_DEF_STRUCT_END(common_frag)
-
-
 /* Padding Frame
 
    PADDING Frame {
@@ -56,49 +46,6 @@ FD_TEMPL_DEF_STRUCT_BEGIN(ack_frame)
   /* N   ack_range_frag    (ack_range_count) */
   /* opt ecn_counts_frag   if type == 0x03 */
 FD_TEMPL_DEF_STRUCT_END(ack_frame)
-
-
-/* Acknowledgement Range Fragment
-
-   ACK Range {
-     Gap (i),
-     ACK Range Length (i),
-   }
-   Figure 26: ACK Ranges */
-
-FD_TEMPL_DEF_STRUCT_BEGIN(ack_range_frag)
-  FD_TEMPL_MBR_ELEM_VARINT( gap,    ulong )
-  FD_TEMPL_MBR_ELEM_VARINT( length, ulong )
-FD_TEMPL_DEF_STRUCT_END(ack_range_frag)
-
-
-/* ECN Counts Fragment
-
-   ECN Counts {
-     ECT0 Count (i),
-     ECT1 Count (i),
-     ECN-CE Count (i),
-   }
-   Figure 27: ECN Count Format
-   The ECN count fields are:
-
-   ECT0 Count:
-   A variable-length integer representing the total number of packets received with the
-     ECT(0) codepoint in the packet number space of the ACK frame.
-
-   ECT1 Count:
-   A variable-length integer representing the total number of packets received with the
-     ECT(1) codepoint in the packet number space of the ACK frame.
-
-   ECN-CE Count:
-   A variable-length integer representing the total number of packets received with the
-     ECN-CE codepoint in the packet number space of the ACK frame. */
-
-FD_TEMPL_DEF_STRUCT_BEGIN(ecn_counts_frag)
-  FD_TEMPL_MBR_ELEM_VARINT( ect0_count,   ulong )
-  FD_TEMPL_MBR_ELEM_VARINT( ect1_count,   ulong )
-  FD_TEMPL_MBR_ELEM_VARINT( ecn_ce_count, ulong )
-FD_TEMPL_DEF_STRUCT_END(ecn_counts_frag)
 
 
 /* Reset Stream Frame

--- a/src/waltz/quic/templ/fd_quic_templ.h
+++ b/src/waltz/quic/templ/fd_quic_templ.h
@@ -80,7 +80,7 @@ FD_TEMPL_DEF_STRUCT_END(version_neg)
      Packet Payload (8..),
    }
    Figure 15: Initial Packet
- 
+
    The first CRYPTO frame sent always begins at an offset of 0 */
 
 FD_TEMPL_DEF_STRUCT_BEGIN(initial)
@@ -229,7 +229,7 @@ FD_TEMPL_DEF_STRUCT_END(retry)
    }
    Figure 8: Retry Pseudo-Packet */
 FD_TEMPL_DEF_STRUCT_BEGIN(retry_pseudo)
-  FD_TEMPL_MBR_ELEM          ( odcid_len,           uchar                  ) 
+  FD_TEMPL_MBR_ELEM          ( odcid_len,           uchar                  )
   FD_TEMPL_MBR_ELEM_VAR      ( odcid,               0,160, odcid_len       )
 
   FD_TEMPL_MBR_ELEM_BITS     ( hdr_form,            uchar, 1               )
@@ -300,3 +300,56 @@ FD_TEMPL_DEF_STRUCT_BEGIN(transport_param_entry)
   FD_TEMPL_MBR_ELEM_VARINT ( param_len, ulong             )
   FD_TEMPL_MBR_ELEM_VAR_RAW( param_val, 0,8192, param_len )
 FD_TEMPL_DEF_STRUCT_END(transport_param_entry)
+
+
+/* 19. Frame common header
+
+   COMMON Frag {
+     Type (i)
+   } */
+FD_TEMPL_DEF_STRUCT_BEGIN(common_frag)
+  FD_TEMPL_MBR_ELEM_VARINT( type, ulong )
+FD_TEMPL_DEF_STRUCT_END(common_frag)
+
+
+/* 19.3.1. ACK Ranges (part of ACK frame)
+
+   ACK Range {
+     Gap (i),
+     ACK Range Length (i),
+   }
+   Figure 26: ACK Ranges */
+
+FD_TEMPL_DEF_STRUCT_BEGIN(ack_range_frag)
+  FD_TEMPL_MBR_ELEM_VARINT( gap,    ulong )
+  FD_TEMPL_MBR_ELEM_VARINT( length, ulong )
+FD_TEMPL_DEF_STRUCT_END(ack_range_frag)
+
+
+/* 19.3.2. ECN Counts (part of ACK frame)
+
+   ECN Counts {
+     ECT0 Count (i),
+     ECT1 Count (i),
+     ECN-CE Count (i),
+   }
+   Figure 27: ECN Count Format
+   The ECN count fields are:
+
+   ECT0 Count:
+   A variable-length integer representing the total number of packets received with the
+     ECT(0) codepoint in the packet number space of the ACK frame.
+
+   ECT1 Count:
+   A variable-length integer representing the total number of packets received with the
+     ECT(1) codepoint in the packet number space of the ACK frame.
+
+   ECN-CE Count:
+   A variable-length integer representing the total number of packets received with the
+     ECN-CE codepoint in the packet number space of the ACK frame. */
+
+FD_TEMPL_DEF_STRUCT_BEGIN(ecn_counts_frag)
+  FD_TEMPL_MBR_ELEM_VARINT( ect0_count,   ulong )
+  FD_TEMPL_MBR_ELEM_VARINT( ect1_count,   ulong )
+  FD_TEMPL_MBR_ELEM_VARINT( ecn_ce_count, ulong )
+FD_TEMPL_DEF_STRUCT_END(ecn_counts_frag)


### PR DESCRIPTION
The quic/templ plumbing generates a 'handle_frame' prototype for
each structure that appears in fd_quic_frames_templ.h.  There are
some structs in this file that aren't frames, and we have to define
dummy frame handlers for these.

This commit moves these structs into 'fd_quic_templ.h' and removes
the dummy frame handler functions.
