### PR TITLE
quic: polish RNG handling

### DIFF
--- a/src/waltz/quic/crypto/fd_quic_crypto_suites.c
+++ b/src/waltz/quic/crypto/fd_quic_crypto_suites.c
@@ -598,15 +598,6 @@ fd_quic_crypto_lookup_suite( uchar major,
                              uchar minor );
 
 int
-fd_quic_crypto_rand( uchar * buf,
-                     ulong   buf_sz ) {
-  /* TODO buffer */
-  if( FD_UNLIKELY( fd_rng_secure( buf, buf_sz ) ) )
-    return FD_QUIC_FAILED;
-  return FD_QUIC_SUCCESS;
-}
-
-int
 fd_quic_retry_token_encrypt(
     uchar const         retry_secret[static FD_QUIC_RETRY_SECRET_SZ],
     fd_quic_conn_id_t const * orig_dst_conn_id,
@@ -623,8 +614,7 @@ fd_quic_retry_token_encrypt(
 
   /* Generate pseudorandom bytes to use as the key for the AEAD HKDF. Note these bytes form the
      beginning of the retry token. */
-  int rc = fd_quic_crypto_rand( retry_token, FD_QUIC_RETRY_TOKEN_HKDF_KEY_SZ );
-  if ( FD_UNLIKELY( rc == FD_QUIC_FAILED ) ) {
+  if( FD_UNLIKELY( !fd_rng_secure( retry_token, FD_QUIC_RETRY_TOKEN_HKDF_KEY_SZ ) ) ) {
     return FD_QUIC_FAILED;
   }
 

--- a/src/waltz/quic/crypto/fd_quic_crypto_suites.h
+++ b/src/waltz/quic/crypto/fd_quic_crypto_suites.h
@@ -200,18 +200,6 @@ struct fd_quic_crypto_secrets {
   uchar new_secret_sz[2];
 };
 
-/* fd_quic_crypto_rand retrieves cryptographic quality random bytes
-   into given memory region.  buf points to first byte of buffer in
-   local address space.  buf_sz is the number of bytes to fill.  Current
-   backend is getrandom(2) (>=256-bit security level on Linux).
-   Return value in FD_QUIC_{SUCCESS,FAILURE}.  Reasons for failure
-   include lack of entropy, in which case caller should wait and retry.
-   buf_sz in [1,INT_MAX] but should be reasonably small (max KiB-ish) */
-
-int
-fd_quic_crypto_rand( uchar * buf,
-                     ulong   buf_sz );
-
 /* fd_quic_crypto_ctx_init initializes the given QUIC crypto context
    using the TLS provider library.  Should be considered an expensive
    operation and thus used sparingly.  On failure, logs error and

--- a/src/waltz/quic/fd_quic_conn_id.h
+++ b/src/waltz/quic/fd_quic_conn_id.h
@@ -2,6 +2,7 @@
 #define HEADER_fd_src_waltz_quic_fd_quic_conn_id_h
 
 #include "../../util/fd_util_base.h"
+#include "../../util/rng/fd_rng.h"
 #include <string.h>
 
 /* use a global seed initialized at runtime
@@ -43,6 +44,27 @@ fd_quic_conn_id_new( void const * conn_id,
   fd_quic_conn_id_t id = { .sz = (uchar)sz };
   fd_memcpy( id.conn_id, conn_id, sz );
   return id;
+}
+
+/* fd_quic_conn_id_rand creates a new random 8 byte conn ID.  Returns
+   conn_id on success.  In the rare case that the platform RNG fails
+   returns NULL. */
+
+__attribute__((warn_unused_result))
+static inline fd_quic_conn_id_t *
+fd_quic_conn_id_rand( fd_quic_conn_id_t * conn_id ) {
+
+  /* from rfc9000:
+     Each endpoint selects connection IDs using an implementation-specific (and
+       perhaps deployment-specific) method that will allow packets with that
+       connection ID to be routed back to the endpoint and to be identified by
+       the endpoint upon receipt. */
+  /* this means we can generate a connection id with the property that it can
+     be delivered to the same endpoint by flow control */
+  /* TODO load balancing / flow steering */
+
+  conn_id->sz = 8;
+  return fd_rng_secure( conn_id->conn_id, 8u ) ? conn_id : NULL;
 }
 
 FD_PROTOTYPES_END

--- a/verification/stubs/fd_quic_crypto.c
+++ b/verification/stubs/fd_quic_crypto.c
@@ -8,13 +8,13 @@ mock_crypto_suite = {
   .hash_sz = 32UL,
 };
 
-int
-fd_quic_crypto_rand( uchar * buf,
-                     ulong   buf_sz ) {
+FD_FN_SENSITIVE void *
+fd_rng_secure( void * buf,
+               ulong  buf_sz ) {
   __CPROVER_havoc_slice( buf, buf_sz );
 
-  int res;
-  __CPROVER_assume( res==FD_QUIC_SUCCESS || res==FD_QUIC_FAILED );
+  void * res;
+  __CPROVER_assume( res==buf || res==NULL );
   return res;
 }
 


### PR DESCRIPTION
- Unifies all cryptographically secure RNG through fd_rng_secure.
- Adds fd_conn_id_rand helper function
- Fixes missing error handling on RNG failure
