### PR TITLE
High performance persistent shared scratch pads

### DIFF
--- a/src/util/fd_util.h
+++ b/src/util/fd_util.h
@@ -8,6 +8,7 @@
 //#include "wksp/fd_wksp.h"         /* includes sanitize/fd_asan.h */
 //#include "cstr/fd_cstr.h"         /* includes bits/fd_bits.h */
 //#include "io/fd_io.h"             /* includes bits/fd_bits.h */
+#include "spad/fd_spad.h"           /* includes bits/fd_bits.h */
 //#include "pod/fd_pod.h"           /* includes cstr/fd_cstr.h */
 //#include "env/fd_env.h"           /* includes cstr/fd_cstr.h */
 //#include "log/fd_log.h"           /* includes env/fd_env.h io/fd_io.h */

--- a/src/util/spad/Local.mk
+++ b/src/util/spad/Local.mk
@@ -1,0 +1,4 @@
+$(call add-hdrs,fd_spad.h)
+$(call add-objs,fd_spad,fd_util)
+$(call make-unit-test,test_spad,test_spad,fd_util)
+$(call run-unit-test,test_spad,)

--- a/src/util/spad/fd_spad.c
+++ b/src/util/spad/fd_spad.c
@@ -1,0 +1,112 @@
+#include "fd_spad.h"
+#include "../log/fd_log.h"
+
+int
+fd_spad_verify( fd_spad_t const * spad ) {
+
+# define TEST(c) do { if( FD_UNLIKELY( !(c) ) ) { FD_LOG_WARNING(( "FAIL: %s", #c )); return -1; } } while(0)
+
+  /* Test spad is a current local join */
+
+  TEST( spad!=NULL );
+  TEST( spad->magic==FD_SPAD_MAGIC );
+
+  /* Extract the metadata */
+
+  ulong frame_free = spad->frame_free; TEST( frame_free<=FD_SPAD_FRAME_MAX );
+  ulong mem_used   = spad->mem_used;   TEST( mem_used  <=spad->mem_max     );
+
+  /* If there are no frames, there should be no memory used.  Otherwise,
+     make sure the mem_used and frames are properly ordered starting
+     from 0. */
+
+  if( frame_free==FD_SPAD_FRAME_MAX ) FD_TEST( !mem_used );
+  else {
+    FD_TEST( mem_used >= spad->off[ frame_free ] );
+    for( ulong idx=frame_free; idx<FD_SPAD_FRAME_MAX-1UL; idx++ ) FD_TEST( spad->off[ idx ]>=spad->off[ idx+1UL ] );
+    FD_TEST( !spad->off[ FD_SPAD_FRAME_MAX-1UL] );
+  }
+
+# undef TEST
+
+  return 0;
+}
+
+ulong
+fd_spad_alloc_max_debug( fd_spad_t const * spad,
+                         ulong             align ) {
+  if( FD_UNLIKELY( !fd_spad_frame_used( spad )               ) ) FD_LOG_CRIT(( "not in a frame" ));
+  if( FD_UNLIKELY( (!!align) & (!fd_ulong_is_pow2( align ) ) ) ) FD_LOG_CRIT(( "bad align"      ));
+  return fd_spad_alloc_max( spad, align );
+}
+
+void *
+fd_spad_frame_lo_debug( fd_spad_t * spad ) {
+  if( FD_UNLIKELY( !fd_spad_frame_used( spad ) ) ) FD_LOG_CRIT(( "not in a frame" ));
+  return fd_spad_frame_lo( spad );
+}
+
+void *
+fd_spad_frame_hi_debug( fd_spad_t * spad ) {
+  if( FD_UNLIKELY( !fd_spad_frame_used( spad ) ) ) FD_LOG_CRIT(( "not in a frame" ));
+  return fd_spad_frame_hi( spad );
+}
+
+void
+fd_spad_push_debug( fd_spad_t * spad ) {
+  if( FD_UNLIKELY( !fd_spad_frame_free( spad ) ) ) FD_LOG_CRIT(( "too many frames" ));
+  fd_spad_push( spad );
+}
+
+void
+fd_spad_pop_debug( fd_spad_t * spad ) {
+  if( FD_UNLIKELY( !fd_spad_frame_used( spad ) ) ) FD_LOG_CRIT(( "not in a frame" ));
+  fd_spad_pop( spad );
+}
+
+void *
+fd_spad_alloc_debug( fd_spad_t * spad,
+                     ulong       align,
+                     ulong       sz ) {
+  if( FD_UNLIKELY( !fd_spad_frame_used( spad )               ) ) FD_LOG_CRIT(( "not in a frame"  ));
+  if( FD_UNLIKELY( (!!align) & (!fd_ulong_is_pow2( align ) ) ) ) FD_LOG_CRIT(( "bad align"       ));
+  if( FD_UNLIKELY( fd_spad_alloc_max( spad, align )<sz       ) ) FD_LOG_CRIT(( "bad sz"          ));
+  return fd_spad_alloc( spad, align, sz );
+}
+
+void
+fd_spad_trim_debug( fd_spad_t * spad,
+                    void *      hi ) {
+  if( FD_UNLIKELY( !fd_spad_frame_used( spad )                 ) ) FD_LOG_CRIT(( "not in a frame"    ));
+  if( FD_UNLIKELY( ((ulong)fd_spad_frame_lo( spad ))>(ulong)hi ) ) FD_LOG_CRIT(( "hi below frame_lo" ));
+  if( FD_UNLIKELY( ((ulong)fd_spad_frame_hi( spad ))<(ulong)hi ) ) FD_LOG_CRIT(( "hi above frame_hi" ));
+  fd_spad_trim( spad, hi );
+}
+
+void *
+fd_spad_prepare_debug( fd_spad_t * spad,
+                       ulong       align,
+                       ulong       max ) {
+  if( FD_UNLIKELY( !fd_spad_frame_used( spad )               ) ) FD_LOG_CRIT(( "not in a frame" ));
+  if( FD_UNLIKELY( (!!align) & (!fd_ulong_is_pow2( align ) ) ) ) FD_LOG_CRIT(( "bad align"      ));
+  if( FD_UNLIKELY( fd_spad_alloc_max( spad, align )<max      ) ) FD_LOG_CRIT(( "bad max"        ));
+  return fd_spad_prepare( spad, align, max );
+}
+
+void
+fd_spad_cancel_debug( fd_spad_t * spad ) {
+  if( FD_UNLIKELY( !fd_spad_frame_used( spad ) ) ) FD_LOG_CRIT(( "not in a frame" ));
+  /* FIXME: check if in prepare?  needs extra state and a lot of extra
+     tracking that state */
+  fd_spad_cancel( spad );
+}
+
+void
+fd_spad_publish_debug( fd_spad_t * spad,
+                       ulong       sz ) {
+  if( FD_UNLIKELY( !fd_spad_frame_used( spad )       ) ) FD_LOG_CRIT(( "not in a frame" ));
+  if( FD_UNLIKELY( fd_spad_alloc_max( spad, 1UL )<sz ) ) FD_LOG_CRIT(( "bad sz"         ));
+  /* FIXME: check if in prepare?  needs extra state and a lot of extra
+     tracking that state */
+  fd_spad_publish( spad, sz );
+}

--- a/src/util/spad/fd_spad.h
+++ b/src/util/spad/fd_spad.h
@@ -1,0 +1,535 @@
+#ifndef HEADER_fd_src_util_spad_fd_spad_h
+#define HEADER_fd_src_util_spad_fd_spad_h
+
+/* APIs for high performance persistent inter-process shared scratch pad
+   memories.  A spad as a scratch pad that behaves very much like a
+   thread's stack:
+
+   - Spad allocations are very fast O(1) assembly.
+
+   - Spad allocations are grouped into a frames.
+
+   - Frames are nested.
+
+   - Pushing and popping frames are also very fast O(1) assembly.
+
+   - All allocations in a frame are automatically freed when the frame
+     is popped.
+
+   Unlike a thread's stack, the most recent allocation can be trimmed,
+   the most recent sequence of allocations be undone, operations on a
+   spad can by done more than one thread, threads can operate on
+   multiple spads and, if the spad is backed by a shared memory region
+   (e.g. wksp), spad allocations can be shared with different processes.
+   Also, it flexibly supports tight integration with real-time
+   streaming, custom allocation alignments, programmatic usage queries,
+   validation, and a large dynamic range of allocation sizes and
+   alignments.  Further, the API can be changed at compile time to
+   implementations with extra instrumentation for debugging and/or
+   sanitization. */
+
+#include "../bits/fd_bits.h"
+
+/* FD_SPAD_{ALIGN,FOOTPRINT} give the alignment and footprint of a
+   fd_spad_t.  ALIGN is an integer power of 2.  FOOTPRINT is a multiple
+   of ALIGN.  mem_max is assumed to be at most 2^63 such that the result
+   is guaranteed to never overflow a ulong.  These are provided to
+   facilitate compile time declarations a fd_spad_t.  128 is natural
+   alignment for x86 adjacent cache line prefetching and PCI-e device
+   interfacing like NICs and GPUs (e.g warp size).  Other possible
+   useful alignments here include 256 (recent x86 DRAM memory fetch),
+   512 (direct IO) and 4096 (x86 normal pages size).
+
+   FD_SPAD_LG_ALIGN is log2 FD_SPAD_ALIGN.  Note: FD_SPAD_ALIGN is
+   declared explicitly to to workaround legacy compiler issues. */
+
+#define FD_SPAD_LG_ALIGN (7)
+
+#define FD_SPAD_ALIGN (128)
+
+#define FD_SPAD_FOOTPRINT(mem_max)                                    \
+  FD_LAYOUT_FINI( FD_LAYOUT_APPEND( FD_LAYOUT_APPEND( FD_LAYOUT_INIT, \
+    FD_SPAD_ALIGN, sizeof(fd_spad_t) ), /* metadata */                \
+    FD_SPAD_ALIGN, (mem_max)         ), /* memory region */           \
+    FD_SPAD_ALIGN )
+
+/* A fd_spad_t * is an opaque handle of a scratch pad memory */
+
+struct fd_spad_private;
+typedef struct fd_spad_private fd_spad_t;
+
+/* FD_SPAD_FRAME_MAX gives the maximum number of frames in a spad. */
+
+#define FD_SPAD_FRAME_MAX (128UL)
+
+/* FD_SPAD_ALLOC_ALIGN_DEFAULT gives the default alignment for spad
+   allocations.  Must be an integer power of 2 in [1,FD_SPAD_ALIGN].  16
+   is uint128 and SSE natural alignment.  Other possible useful
+   alignments here include 8 (minimum on a 64-bit target malloc/free
+   conformanc), 32 (AVX2) and 64 (cache line and AVX-512). */
+
+#define FD_SPAD_ALLOC_ALIGN_DEFAULT (16UL)
+
+/* Internal use only *************************************************/
+
+/* Note: Details are exposed here to facilitate inlining of spad
+   operations as they are typically used in performance critical
+   contexts. */
+
+#define FD_SPAD_MAGIC (0xf17eda2ce759ad00UL) /* FIREDANCER SPAD version 0 */
+
+/* spad internals */
+
+struct __attribute__((aligned(FD_SPAD_ALIGN))) fd_spad_private {
+
+  /* This point is FD_SPAD_ALIGN aligned */
+
+  ulong magic; /* ==FD_SPAD_MAGIC */
+
+  /* off[i] for i in [0,FD_SPAD_FRAME_MAX) gives the byte offset into
+     the spad memory where allocations start for frame
+     FD_SPAD_FRAME_MAX-1-i.  That is, off array usage grows toward 0
+     such that off[i] for i in [0,frame_free) are not in use and
+     [frame_free,FD_SPAD_FRAME_MAX) descripe the locations of current
+     frames.  Typical bugs (e.g. pushing too many frames) here naturally
+     clobber FD_SPAD_MAGIC (invalidating the spad) and then will clobber
+     any guard region before the spad (invalidating the region) but will
+     not clobber metadata or spad allocations themselves. */
+
+  ulong off[ FD_SPAD_FRAME_MAX ];
+
+  ulong frame_free; /* number of frames free, in [0,FD_SPAD_FRAME_MAX] */
+  ulong mem_max;    /* byte size of the spad memory region */
+  ulong mem_used;   /* number of spad memory bytes used, in [0,mem_max] */
+
+  /* Padding to FD_SPAD_ALIGN here */
+
+  /* "uchar mem[ mem_max ];" spad memory here.  Grows toward +inf such
+     that bytes [0,mem_used) are currently allocated and bytes
+     [mem_used,mem_max) are free.  As such, typical bugs (e.g. writing
+     past the end of an allocation) naturally clobber any guard region
+     after the structure (invalidate the region) but will not clobber
+     the above metadata.  We are don't use a flexible array here due to
+     lack of C++ support (sigh). */
+
+  /* Padding to FD_SPAD_ALIGN here */
+
+};
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_spad_private_mem returns a pointer in the caller's local address
+   space to the first byte of the spad's memory region.  Assumes spad is
+   a current local join.  Lifetime of the returned pointer is the
+   lifetime of the join. */
+
+FD_FN_CONST static inline uchar *
+fd_spad_private_mem( fd_spad_t * spad ) {
+  return (uchar *)(spad+1UL);
+}
+
+FD_PROTOTYPES_END
+
+/* End internal use only *********************************************/
+
+FD_PROTOTYPES_BEGIN
+
+/* constructors */
+
+/* fd_spad_reset pops all frames in use.  Assumes spad is a current
+   local join.  On return, spad is not in a frame.  Fast O(1).  This
+   declared here to avoid forward use by fd_spad_new.  */
+
+static inline void
+fd_spad_reset( fd_spad_t * spad ) {
+  spad->frame_free = FD_SPAD_FRAME_MAX;
+  spad->mem_used   = 0UL;
+}
+
+/* fd_spad_mem_max_max returns the largest mem_max possible for a spad
+   that will fit into footprint bytes.  On success, returns the largest
+   mem_max such that:
+
+     fd_spad_footprint( mem_max ) == fd_ulong_align_dn( footprint, FD_SPAD_ALIGN )
+
+   On failure, returns 0.  Reasons for failure include the footprint is
+   too small, the resulting mem_max is too large or the actual mem_max
+   that can be support is actually 0 (which is arguably not an error).
+   This is provided for users that want to specify a spad in terms of
+   its footprint rather than mem_max.  FIXME: consider compile time
+   variant? */
+
+FD_FN_CONST static inline ulong
+fd_spad_mem_max_max( ulong footprint ) {
+  ulong mem_max = fd_ulong_max( fd_ulong_align_dn( footprint, FD_SPAD_ALIGN ), sizeof(fd_spad_t) ) - sizeof(fd_spad_t);
+  return fd_ulong_if( mem_max<=(1UL<<63), mem_max, 0UL );
+}
+
+/* fd_spad_{align,footprint} give the required alignment and footprint
+   for a spad that can support up mem_max bytes total of allocations.
+   fd_spad_align returns FD_SPAD_ALIGN.  fd_spad_footprint returns
+   non-zero on success and 0 on failure (silent).  Reasons for failure
+   include mem_max is too large. */
+
+FD_FN_CONST static inline ulong
+fd_spad_align( void ) {
+  return FD_SPAD_ALIGN;
+}
+
+FD_FN_CONST static inline ulong
+fd_spad_footprint( ulong mem_max ) {
+  return fd_ulong_if( mem_max<=(1UL<<63), FD_SPAD_FOOTPRINT( mem_max ), 0UL );
+}
+
+/* fd_spad_new formats an unused memory region with the appropriate
+   footprint and alignment into a spad.  shmem points in the caller's
+   address space to the first byte of the region.  Returns shmem on
+   success (silent) and NULL on failure.  Reasons for failure include
+   NULL spad, misaligned spad and too large mem_max.  The caller is
+   _not_ joined on return. */
+
+static inline void *
+fd_spad_new( void * shmem,
+             ulong  mem_max ) {
+  fd_spad_t * spad = (fd_spad_t *)shmem;
+
+  if( FD_UNLIKELY( !spad                                              ) ) return NULL;
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)spad, FD_SPAD_ALIGN ) ) ) return NULL;
+  if( FD_UNLIKELY( !fd_spad_footprint( mem_max )                      ) ) return NULL;
+
+  spad->mem_max = mem_max;
+
+  fd_spad_reset( spad);
+
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( spad->magic ) = FD_SPAD_MAGIC;
+  FD_COMPILER_MFENCE();
+
+  return spad;
+}
+
+/* fd_spad_join joins a spad.  shspad points in the caller's address
+   space to the first byte of the region containing the spad.  Returns a
+   local handle of the join on success (this is not necessarily a simple
+   cast of shspad) or NULL on failure (silent).  Reasons for failure
+   include NULL spad, misaligned spad and shspad obviously does not
+   contain an spad.  There is no practical limitation on the number of
+   concurrent joins in a thread, process or system wide.*/
+
+FD_FN_PURE static inline fd_spad_t *
+fd_spad_join( void * shspad ) {
+  fd_spad_t * spad = (fd_spad_t *)shspad;
+
+  if( FD_UNLIKELY( !spad                                              ) ) return NULL;
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)spad, FD_SPAD_ALIGN ) ) ) return NULL;
+  if( FD_UNLIKELY( spad->magic!=FD_SPAD_MAGIC                         ) ) return NULL;
+
+  return spad;
+}
+
+/* fd_spad_leave leaves a spad join.  Returns a pointer in the caller's
+   address space to the first byte of the region containing the spad on
+   success (this is not necessarily a simple cast of spad) and NULL on
+   failure (silent).  On success, the join is no longer current but the
+   spad will continue to exist.  Implicitly cancels any in-progress
+   prepare. */
+
+FD_FN_CONST static inline void *
+fd_spad_leave( fd_spad_t * spad ) {
+  return (void *)spad;
+}
+
+/* fd_spad_delete unformats a memory region used as a spad.  shspad
+   points in the caller's address space to the first byte of the region
+   containing the spad.  Returns the shspad on success and NULL on
+   failure (silent).  Reasons for failure include NULL shspad,
+   misaligned shspad and shspad obviously does not contain an spad.
+   Assumes there is nobody joined to the spad when it is deleted. */
+
+static inline void *
+fd_spad_delete( void * shspad ) {
+  fd_spad_t * spad = (fd_spad_t *)shspad;
+
+  if( FD_UNLIKELY( !spad                                              ) ) return NULL;
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)spad, FD_SPAD_ALIGN ) ) ) return NULL;
+  if( FD_UNLIKELY( spad->magic!=FD_SPAD_MAGIC                         ) ) return NULL;
+
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( spad->magic ) = 0UL;
+  FD_COMPILER_MFENCE();
+
+  return spad;
+}
+
+/* accessors */
+
+/* fd_spad_frame_{max,used,free} return the {max,used,free} number of
+   spad frames (used+free==max and max is always FD_SPAD_FRAME_MAX).
+   Assumes spad is a current local join. */
+
+FD_FN_CONST static inline ulong fd_spad_frame_max ( fd_spad_t const * spad ) { (void)spad; return FD_SPAD_FRAME_MAX;        }
+FD_FN_PURE  static inline ulong fd_spad_frame_used( fd_spad_t const * spad ) { return FD_SPAD_FRAME_MAX - spad->frame_free; }
+FD_FN_PURE  static inline ulong fd_spad_frame_free( fd_spad_t const * spad ) { return spad->frame_free;                     }
+
+/* fd_spad_mem_{max,used,free} return the {max,used,free} number of
+   bytes spad memory (used+free==max).  Assumes spad is a current local
+   join. */
+
+FD_FN_PURE static inline ulong fd_spad_mem_max ( fd_spad_t const * spad ) { return spad->mem_max;                  }
+FD_FN_PURE static inline ulong fd_spad_mem_used( fd_spad_t const * spad ) { return spad->mem_used;                 }
+FD_FN_PURE static inline ulong fd_spad_mem_free( fd_spad_t const * spad ) { return spad->mem_max - spad->mem_used; }
+
+/* fd_spad_in_frame returns 1 if the spad is in a frame and 0 otherwise.
+   Assumes spad is a current local join. */
+
+FD_FN_PURE static inline int fd_spad_in_frame( fd_spad_t const * spad ) { return spad->frame_free<FD_SPAD_FRAME_MAX; }
+
+/* fd_spad_alloc_max returns the maximum number of bytes with initial
+   byte alignment of align that can currently be allocated / prepared
+   (not including any in-progress prepare).  Assumes spad is a current
+   local join and in a frame and align is an integer power of 2 in
+   [1,FD_SPAD_ALIGN] or 0 (indicates to use
+   FD_SPAD_ALLOC_ALIGN_DEFAULT). */
+
+FD_FN_PURE static inline ulong
+fd_spad_alloc_max( fd_spad_t const * spad,
+                   ulong             align ) {
+  align = fd_ulong_if( align>0UL, align, FD_SPAD_ALLOC_ALIGN_DEFAULT ); /* typically compile time */
+  ulong off = fd_ulong_align_up( spad->mem_used, align );
+  return fd_ulong_max( spad->mem_max, off ) - off;
+}
+
+/* fd_spad_frame_{lo,hi} returns the range of spad memory covered by the
+   current frame (not including any in-progress prepare).  That is,
+   [lo,hi) is the range of bytes in the caller's address space for the
+   current frame.  Assumes spad is a current local join and in a frame.
+   FIXME: consider const correct versions? */
+
+FD_FN_PURE static inline void *
+fd_spad_frame_lo( fd_spad_t * spad ) {
+  return fd_spad_private_mem( spad ) + spad->off[ spad->frame_free ];
+}
+
+FD_FN_PURE static inline void *
+fd_spad_frame_hi( fd_spad_t * spad ) {
+  return fd_spad_private_mem( spad ) + spad->mem_used;
+}
+
+/* operations */
+
+/* fd_spad_push creates a new spad frame and makes it the current frame.
+   Assumes spad is a current local join with at least one frame free.
+   Implicitly cancels any in-progress prepare.  On return, spad will be
+   in a frame and not in a prepare.  Fast O(1). */
+
+static inline void
+fd_spad_push( fd_spad_t * spad ) {
+  spad->off[ --spad->frame_free ] = spad->mem_used;
+}
+
+/* fd_spad_pop destroys the current spad frame (which bulk frees all
+   allocations made in that frame and cancels any in progress prepare)
+   and (if applicable) makes the previous frame current.  Assumes spad
+   is a current local join (in a frame).  On return, spad will not be in
+   a prepare and, if there was a previous frame, spad will be in a frame
+   and not otherwise.  Fast O(1). */
+
+static inline void
+fd_spad_pop( fd_spad_t * spad ) {
+  spad->mem_used = spad->off[ spad->frame_free++ ];
+}
+
+/* The construct:
+
+     FD_SPAD_FRAME_BEGIN( spad )
+       ... code block ...
+     FD_SPAD_FRAME_END
+
+   is exactly equivalent linguistically to:
+
+     do
+       ... code block ...
+     while(0)
+
+   but fd_spad_{push,pop} is automatically called when the code block is
+   {entered,exited}.  This includes exiting via break or (ickily)
+   return.  Assumes spad has at least one frame free when the code block
+   is entered.  Fast O(1). */
+
+static inline void
+fd_spad_private_frame_end( fd_spad_t ** _spad ) { /* declared here to avoid a fd_spad_pop forward reference */
+  fd_spad_pop( *_spad );
+}
+
+#define FD_SPAD_FRAME_BEGIN(spad) do {                                            \
+  fd_spad_t * _spad __attribute__((cleanup(fd_spad_private_frame_end))) = (spad); \
+  fd_spad_push( _spad );                                                          \
+  do
+
+#define FD_SPAD_FRAME_END while(0); } while(0)
+
+/* fd_spad_alloc allocates sz bytes with alignment align from spad.
+   Returns a pointer in the caller's address space to the first byte of
+   the allocation (will be non-NULL with alignment align).  Assumes spad
+   is a current local join and in a frame, align is an integer power of
+   2 in [1,FD_SPAD_ALIGN] or 0 (indicates to use
+   FD_SPAD_ALLOC_ALIGN_DEFAULT) and sz is in [0,alloc_max].  Implicitly
+   cancels any in progress prepare.  On return, spad will be in a frame
+   and not in a prepare.  Fast O(1).
+
+   The lifetime of the returned region will be until the next pop or
+   delete and of the returned pointer until pop, delete or leave.  The
+   allocated region will be in the region backing the spad (e.g. if the
+   spad is backed by wksp memory, the returned value will be a laddr
+   that can be shared with threads in other processes using that wksp). */
+
+static inline void *
+fd_spad_alloc( fd_spad_t * spad,
+               ulong       align,
+               ulong       sz ) {
+  align = fd_ulong_if( align>0UL, align, FD_SPAD_ALLOC_ALIGN_DEFAULT ); /* typically compile time */
+  ulong   off = fd_ulong_align_up( spad->mem_used, align );
+  uchar * buf = fd_spad_private_mem( spad ) + off;
+  spad->mem_used = off + sz;
+  return buf;
+}
+
+/* fd_spad_trim trims trims frame_hi to end at hi where hi is given the
+   caller's local address space.  Assumes spad is a current local join
+   in a frame and hi is in [frame_lo,frame_hi] (FIXME: consider
+   supporting allowing trim to expand the frame to mem_hi?).  Implicitly
+   cancels any in-progress prepare.  On return, spad will be in a frame
+   with frame_hi==hi.  Fast O(1).
+
+   This is mostly useful for reducing the size of the most recent
+   fd_spad_alloc.  E.g. call fd_spad_alloc with an upper bound to the
+   final size, populate the region by bumping the returned pointer and
+   calling trim at the end to return whatever remains of the original
+   allocation to the spad.  Alternatively could use
+   prepare/publish/cancel semantics below.
+
+   Further note that the most recent sequence allocations in a frame can
+   be _completely_ undone (including alignment padding) by saving
+   frame_hi before the first alloc and then calling trim after the last
+   (and most recent) alloc with the saved value. */
+
+static inline void
+fd_spad_trim( fd_spad_t * spad,
+              void *      hi ) {
+  spad->mem_used = (ulong)hi - (ulong)fd_spad_private_mem( spad );
+}
+
+/* fd_spad_prepare starts preparing a spad allocation with alignment
+   align that can be up to max bytes in size.  Returns a pointer in the
+   caller's address space to the initial byte of the allocation (will be
+   non-NULL with alignment align).  Assumes spad is a current local join
+   in a frame, align is an integer power of 2 in [1,FD_SPAD_ALIGN] or 0
+   (indicates to use FD_SPAD_ALLOC_ALIGN_DEFAULT) and max is in
+   [0,alloc_max].  Implicitly cancels any in-progress prepare.  On
+   return, spad will be in a frame and in a prepare.  Fast O(1).
+
+   While in a prepare, the lifetime of the returned region and returned
+   pointer to it will be until prepare, cancel, alloc, trim, push, pop,
+   leave or delete.  The region will be in the region backing the spad
+   (e.g. if the spad is backed by a wksp, the returned value will be a
+   laddr for its lifetime that can be shared with threads in other
+   processes using that wksp).
+
+   On publication, the returned value will behave _exactly_ as if:
+
+     fd_spad_alloc( spad, align, sz )
+
+   was called here instead of prepare.  This is mostly useful for
+   optimizing allocations whose final size isn't known up front (e.g.
+   buffering of real time streaming data).  Alternatively, could use
+   alloc/trim semantics above.  FIXME: consider removing the
+   prepare/publish/cancel APIs as it simplifies this by eliminating the
+   concept of an in-progress prepare and it doesn't provide much benefit
+   over alloc/trim. */
+
+static inline void *
+fd_spad_prepare( fd_spad_t * spad,
+                 ulong       align,
+                 ulong       max ) {
+  (void)max;
+  align = fd_ulong_if( align>0UL, align, FD_SPAD_ALLOC_ALIGN_DEFAULT ); /* typically compile time */
+  ulong   off = fd_ulong_align_up( spad->mem_used, align );
+  uchar * buf = fd_spad_private_mem( spad ) + off;
+  spad->mem_used = off;
+  return buf;
+}
+
+/* fd_spad_cancel cancels the most recent prepare.  Assumes spad is a
+   current local join and in a prepare.  On return, spad will be in a
+   frame and not in a prepare.  Fast O(1).
+
+   IMPORTANT SAFETY TIP!  This is currently equivalent to
+   fd_spad_publish( spad, 0 ).  As such, any alignment padding done in
+   prepare will still be allocated on return.
+
+   FIXME: consider undoing prepare's align_up too?  This requires extra
+   state.  And, if a common alignment is being used, as is often the
+   case (e.g. FD_SPAD_ALLOC_ALIGN_DEFAULT), as is typically the case,
+   the amount of alignment padding will be typically 0.  And is usually
+   negligible in other cases.  And prepare/cancel/publish are not often
+   used anyway.  On top of that, it is already possible to undo the
+   align_up in a supported way via the frame_hi / trim mechanism
+   described above.  So this probably isn't worthwhile. */
+
+static inline void
+fd_spad_cancel( fd_spad_t * spad ) {
+  (void)spad;
+}
+
+/* fd_spad_publish finishes the allocation started in the most recent
+   prepare.  Assumes spad is a current local join and in a prepare and
+   sz is in [0,prepare's max].  On return, spad will be in a frame and
+   not in a prepare.  Fast O(1).  See publish for more details. */
+
+static inline void
+fd_spad_publish( fd_spad_t * spad,
+                 ulong       sz ) {
+  spad->mem_used += sz;
+}
+
+/* fd_spad_verify returns a negative integer error code if the spad is
+   obiviously corrupt if not (logs details) and 0 otherwise.  Reasons
+   for failure include spad is not a current local join and frame
+   metadata is corrupt (bad frames_used, bad mem_max, bad mem_used,
+   frames don't nest).  This can only be used if logging services are
+   available. */
+
+int
+fd_spad_verify( fd_spad_t const * spad );
+
+/* The debugging variants below do additional checking and will
+   FD_LOG_CRIT (dumping core) if their input requirements are not
+   satisfied (they all still assume spad is a current local join).  They
+   can only be used if logging services are available. */
+
+ulong  fd_spad_alloc_max_debug( fd_spad_t const * spad, ulong  align            );
+void * fd_spad_frame_lo_debug ( fd_spad_t       * spad                          );
+void * fd_spad_frame_hi_debug ( fd_spad_t       * spad                          );
+void   fd_spad_push_debug     ( fd_spad_t       * spad                          );
+void   fd_spad_pop_debug      ( fd_spad_t       * spad                          );
+void * fd_spad_alloc_debug    ( fd_spad_t       * spad, ulong  align, ulong sz  );
+void   fd_spad_trim_debug     ( fd_spad_t       * spad, void * hi               );
+void * fd_spad_prepare_debug  ( fd_spad_t       * spad, ulong  align, ulong max );
+void   fd_spad_cancel_debug   ( fd_spad_t       * spad                          );
+void   fd_spad_publish_debug  ( fd_spad_t       * spad, ulong  sz               );
+
+static inline void
+fd_spad_private_frame_end_debug( fd_spad_t ** _spad ) {
+  fd_spad_pop_debug( *_spad );
+}
+
+#define FD_SPAD_FRAME_BEGIN_DEBUG(spad) do {                                            \
+  fd_spad_t * _spad __attribute__((cleanup(fd_spad_private_frame_end_debug))) = (spad); \
+  fd_spad_push_debug( _spad );                                                          \
+  do
+
+#define FD_SPAD_FRAME_END_DEBUG while(0); } while(0)
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_util_spad_fd_spad_h */

--- a/src/util/spad/test_spad.c
+++ b/src/util/spad/test_spad.c
@@ -1,0 +1,291 @@
+#include "../fd_util.h"
+
+/* Use the debug variant for extra code coverage and test strictness */
+
+#if 1
+#define fd_spad_alloc_max fd_spad_alloc_max_debug
+#define fd_spad_frame_lo  fd_spad_frame_lo_debug
+#define fd_spad_frame_hi  fd_spad_frame_hi_debug
+#define fd_spad_push      fd_spad_push_debug
+#define fd_spad_pop       fd_spad_pop_debug
+#define fd_spad_alloc     fd_spad_alloc_debug
+#define fd_spad_trim      fd_spad_trim_debug
+#define fd_spad_prepare   fd_spad_prepare_debug
+#define fd_spad_cancel    fd_spad_cancel_debug
+#define fd_spad_publish   fd_spad_publish_debug
+
+#undef  FD_SPAD_FRAME_BEGIN
+#undef  FD_SPAD_FRAME_END
+
+#define FD_SPAD_FRAME_BEGIN FD_SPAD_FRAME_BEGIN_DEBUG
+#define FD_SPAD_FRAME_END   FD_SPAD_FRAME_END_DEBUG
+#endif
+
+FD_STATIC_ASSERT( FD_SPAD_LG_ALIGN      ==7,                       unit_test );
+FD_STATIC_ASSERT( FD_SPAD_ALIGN         ==(1UL<<FD_SPAD_LG_ALIGN), unit_test );
+FD_STATIC_ASSERT( FD_SPAD_FOOTPRINT(0UL)==1152UL,                  unit_test );
+
+FD_STATIC_ASSERT( FD_SPAD_FRAME_MAX          ==128UL, unit_test );
+FD_STATIC_ASSERT( FD_SPAD_ALLOC_ALIGN_DEFAULT== 16UL, unit_test );
+
+#define FOOTPRINT_MAX 1048576UL
+static uchar mem[ FOOTPRINT_MAX ] __attribute__((aligned(FD_SPAD_ALIGN)));
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  ulong mem_max = fd_env_strip_cmdline_ulong( &argc, &argv, "--mem-max", NULL, 524288UL );
+
+  FD_LOG_NOTICE(( "Testing with --mem-max %lu", mem_max ));
+
+  fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
+
+  /* Test mem_max, align, footprint */
+
+  for( ulong iter=0UL; iter<1000000UL; iter++ ) {
+    ulong mem_max = fd_rng_ulong( rng ) >> ((int)(fd_rng_uint( rng ) & 63UL));
+
+    ulong align     = fd_spad_align();
+    ulong footprint = fd_spad_footprint( mem_max );
+
+    FD_TEST( align==FD_SPAD_ALIGN );
+
+    if( FD_UNLIKELY( mem_max>(1UL<<63) ) ) FD_TEST( !footprint );
+    else {
+      FD_TEST( footprint==fd_ulong_align_up( sizeof(fd_spad_t) + mem_max, FD_SPAD_ALIGN ) );
+      FD_TEST( footprint==FD_SPAD_FOOTPRINT( mem_max ) );
+    }
+
+    footprint = mem_max;
+    mem_max   = fd_spad_mem_max_max( footprint );
+
+    ulong footprint_dn = fd_ulong_align_dn( footprint, FD_SPAD_ALIGN );
+    if( FD_UNLIKELY( (footprint_dn<sizeof(fd_spad_t)) | ((footprint_dn-sizeof(fd_spad_t))>(1UL<<63)) ) )
+      FD_TEST( !mem_max );
+    else
+      FD_TEST( fd_spad_footprint( mem_max )==footprint_dn );
+  }
+
+  /* Test constructors */
+
+  ulong footprint = fd_spad_footprint( mem_max );
+  if( FD_UNLIKELY( !footprint              ) ) FD_LOG_ERR(( "too large --mem-max" ));
+  if( FD_UNLIKELY( footprint>FOOTPRINT_MAX ) ) FD_LOG_ERR(( "increase FOOTPRINT_MAX to test with this large --mem-max" ));
+
+  FD_TEST( !fd_spad_new( NULL,  mem_max       ) ); /* NULL shmem */
+  FD_TEST( !fd_spad_new( mem+1, mem_max       ) ); /* misaligned shmem */
+  FD_TEST( !fd_spad_new( mem,   (1UL<<63)+1UL ) ); /* too large mem_max */
+
+  FD_TEST( fd_spad_new( mem, mem_max )==(void *)mem );
+
+  FD_TEST( !fd_spad_join( NULL  ) ); /* NULL shmem */
+  FD_TEST( !fd_spad_join( mem+1 ) ); /* misaligned shmem */
+  /* bad magic tested below */
+
+  fd_spad_t * spad = fd_spad_join( mem ); FD_TEST( spad );
+
+  /* Test accessors */
+
+  FD_TEST( fd_spad_frame_max ( spad )==FD_SPAD_FRAME_MAX );
+  FD_TEST( fd_spad_frame_used( spad )==0UL               );
+  FD_TEST( fd_spad_frame_free( spad )==FD_SPAD_FRAME_MAX );
+
+  FD_TEST( fd_spad_mem_max ( spad )==mem_max );
+  FD_TEST( fd_spad_mem_used( spad )==0UL     );
+  FD_TEST( fd_spad_mem_free( spad )==mem_max );
+
+  uchar * alloc;
+
+  FD_TEST( !fd_spad_in_frame( spad ) );
+
+  fd_spad_push( spad );
+
+  FD_TEST( fd_spad_frame_max ( spad )==FD_SPAD_FRAME_MAX     );
+  FD_TEST( fd_spad_frame_used( spad )==1UL                   );
+  FD_TEST( fd_spad_frame_free( spad )==FD_SPAD_FRAME_MAX-1UL );
+
+  FD_TEST( fd_spad_in_frame ( spad ) );
+  FD_TEST( fd_spad_alloc_max( spad, 1UL )==mem_max );
+
+  FD_TEST( (ulong)mem                     < (ulong)fd_spad_frame_lo( spad ) );
+  FD_TEST( (ulong)fd_spad_frame_lo( spad )==(ulong)fd_spad_frame_hi( spad ) );
+
+  /* sz==0 behavior */
+  for( ulong align=FD_SPAD_ALIGN; align; align>>=1 ) {
+    alloc = (uchar *)fd_spad_alloc( spad, align, 0UL );
+    FD_TEST( alloc ); FD_TEST( fd_ulong_is_aligned( (ulong)alloc, align ) );
+  }
+
+  alloc = (uchar *)fd_spad_alloc( spad, 0UL, 0UL );
+  FD_TEST( alloc ); FD_TEST( fd_ulong_is_aligned( (ulong)alloc, FD_SPAD_ALLOC_ALIGN_DEFAULT ) );
+
+  /* non-multiple size behavior */
+  for( ulong align=FD_SPAD_ALIGN; align; align>>=1 ) {
+    alloc = (uchar *)fd_spad_alloc( spad, align, 1UL );
+    FD_TEST( alloc ); FD_TEST( fd_ulong_is_aligned( (ulong)alloc, align ) );
+  }
+
+  alloc = (uchar *)fd_spad_alloc( spad, 0UL, 1UL );
+  FD_TEST( alloc ); FD_TEST( fd_ulong_is_aligned( (ulong)alloc, FD_SPAD_ALLOC_ALIGN_DEFAULT ) );
+
+  fd_spad_pop( spad );
+  FD_TEST( fd_spad_frame_max ( spad )==FD_SPAD_FRAME_MAX );
+  FD_TEST( fd_spad_frame_used( spad )==0UL               );
+  FD_TEST( fd_spad_frame_free( spad )==FD_SPAD_FRAME_MAX );
+
+  FD_TEST( fd_spad_frame_max ( spad )==FD_SPAD_FRAME_MAX );
+  FD_TEST( fd_spad_frame_used( spad )==0UL               );
+  FD_TEST( fd_spad_frame_free( spad )==FD_SPAD_FRAME_MAX );
+
+  ulong m0   [ 1024UL ];
+  ulong m1   [ 1024UL ];            ulong alloc_cnt = 0UL;
+  ulong frame[ FD_SPAD_FRAME_MAX ]; ulong frame_cnt = 0UL;
+
+  for( ulong iter=0UL; iter<1000000UL; iter++ ) {
+    ulong bits = fd_rng_ulong(rng);
+
+    int do_verify = (!(bits & 15UL)); bits >>= 4;
+    if( do_verify ) FD_TEST( !fd_spad_verify( spad ) );
+
+    int do_reset = (!(bits & 4095UL)); bits >>= 12;
+    if( do_reset ) {
+      fd_spad_reset( spad );
+      FD_TEST( fd_spad_frame_max ( spad )==FD_SPAD_FRAME_MAX );
+      FD_TEST( fd_spad_frame_used( spad )==0UL               );
+      FD_TEST( fd_spad_frame_free( spad )==FD_SPAD_FRAME_MAX );
+      alloc_cnt = 0UL;
+      frame_cnt = 0UL;
+      continue;
+    }
+
+    int do_push = (!(bits & 63UL)) & (fd_spad_frame_free( spad )>0UL); bits >>= 6;
+    if( do_push ) {
+      frame[ frame_cnt++ ] = alloc_cnt;
+      fd_spad_push( spad );
+      FD_TEST( fd_spad_frame_max ( spad )==FD_SPAD_FRAME_MAX           );
+      FD_TEST( fd_spad_frame_used( spad )==frame_cnt                   );
+      FD_TEST( fd_spad_frame_free( spad )==FD_SPAD_FRAME_MAX-frame_cnt );
+      continue;
+    }
+
+    int do_pop = (!(bits & 63UL)) & (fd_spad_frame_used( spad )>0UL); bits >>= 6;
+    if( do_pop ) {
+      alloc_cnt = frame[ --frame_cnt ];
+      fd_spad_pop( spad );
+      FD_TEST( fd_spad_frame_max ( spad )==FD_SPAD_FRAME_MAX           );
+      FD_TEST( fd_spad_frame_used( spad )==frame_cnt                   );
+      FD_TEST( fd_spad_frame_free( spad )==FD_SPAD_FRAME_MAX-frame_cnt );
+      continue;
+    }
+
+    /* Do an alloc randomly via the usual mechanism or via prepare /
+       cancel / publish */
+
+    if( !fd_spad_frame_used( spad ) ) continue;
+
+    int lg_align = fd_rng_int_roll( rng, FD_SPAD_LG_ALIGN+2UL ); /* in [0,FD_SPAD_LG_ALIGN+1], FD_SPAD_LG_ALIGN+1 means use 0 */
+
+    ulong align = ((ulong)(lg_align<=FD_SPAD_LG_ALIGN)) << lg_align;
+    ulong sz    = (ulong)fd_rng_uint( rng ) & 2047U;
+    ulong max   = fd_spad_alloc_max( spad, align );
+    if( !( (alloc_cnt<1024UL) & (max>=sz) & (fd_spad_frame_used( spad )>0UL) ) ) continue;
+
+    if( fd_rng_uint( rng ) & 1U ) alloc = (uchar *)fd_spad_alloc( spad, align, sz );
+    else {
+      ulong pmax = sz + fd_rng_ulong_roll( rng, max-sz+1UL ); /* in [sz,max] */
+      alloc = (uchar *)fd_spad_prepare( spad, align, pmax );
+      if( fd_rng_uint( rng ) & 1U ) {
+        fd_spad_cancel( spad );
+        alloc = (uchar *)fd_spad_prepare( spad, align, pmax ); /* note: will not bump mem_used as previous aligned */
+      }
+      fd_spad_publish( spad, sz );
+    }
+
+    ulong a = fd_ulong_if( !!align, align, FD_SPAD_ALLOC_ALIGN_DEFAULT );
+
+    /* Validate the allocation */
+
+    FD_TEST( alloc );
+    FD_TEST( fd_ulong_is_aligned( (ulong)alloc, a ) );
+    if( FD_LIKELY( sz ) ) {
+      alloc[ 0UL    ] = (uchar)1;
+      alloc[ sz/2UL ] = (uchar)1;
+      alloc[ sz-1UL ] = (uchar)1;
+    }
+
+    ulong new_m0 = (ulong)alloc;
+    ulong new_m1 = new_m0 + sz;
+    FD_TEST( (((ulong)mem)<=new_m0) & (new_m0<=new_m1) & (new_m1<=(ulong)(mem+footprint)) );     /* in backing memory */
+    for( ulong idx=0UL; idx<alloc_cnt; idx++ ) FD_TEST( (m1[idx]<=new_m0) | (new_m1<=m0[idx]) ); /* with no overlap */
+
+    /* Trim the allocation */
+
+    sz = fd_rng_ulong_roll( rng, sz+1UL );
+    fd_spad_trim( spad, alloc + sz );
+    new_m1 = new_m0 + sz;
+
+    /* Validate the trimmed allocation */
+
+    FD_TEST( (((ulong)mem)<=new_m0) & (new_m0<=new_m1) & (new_m1<=(ulong)(mem+footprint)) );     /* in backing memory */
+    for( ulong idx=0UL; idx<alloc_cnt; idx++ ) FD_TEST( (m1[idx]<=new_m0) | (new_m1<=m0[idx]) ); /* with no overlap */
+
+    m0[ alloc_cnt ] = new_m0;
+    m1[ alloc_cnt ] = new_m1;
+    alloc_cnt++;
+  }
+
+  /* Test FD_SPAD_FRAME_{BEGIN,END} */
+
+  fd_spad_reset( spad );
+
+  for( ulong i=0UL; i<1024UL; i++ ) {
+
+    FD_TEST( fd_spad_frame_used( spad )==0UL );
+    FD_SPAD_FRAME_BEGIN( spad ) {
+      FD_TEST( fd_spad_frame_used( spad )==1UL );
+
+      ulong inner_cnt = fd_rng_ulong( rng ) & 1023UL;
+      for( ulong j=0UL; j<inner_cnt; j++ ) {
+        int volatile dummy[1];
+
+        FD_TEST( fd_spad_frame_used( spad )==1UL );
+        FD_SPAD_FRAME_BEGIN( spad ) {
+          FD_TEST( fd_spad_frame_used( spad )==2UL );
+
+          if( fd_rng_uint( rng ) & 1U ) break;
+          dummy[0]++;
+
+          FD_TEST( fd_spad_frame_used( spad )==2UL );
+        } FD_SPAD_FRAME_END;
+        FD_TEST( fd_spad_frame_used( spad )==1UL );
+
+      }
+
+      FD_TEST( fd_spad_frame_used( spad )==1UL );
+    } FD_SPAD_FRAME_END;
+    FD_TEST( fd_spad_frame_used( spad )==0UL );
+
+  }
+
+  /* Test destructors */
+
+  FD_TEST( !fd_spad_leave( NULL ) ); /* NULL spad */
+
+  FD_TEST( fd_spad_leave( spad )==spad );
+
+  FD_TEST( !fd_spad_delete( NULL  ) ); /* NULL shmem */
+  FD_TEST( !fd_spad_delete( mem+1 ) ); /* misaligned shmem */
+  /* bad magic tested below */
+  FD_TEST( fd_spad_delete( mem )==(void *)mem );
+
+  FD_TEST( !fd_spad_join  ( mem ) ); /* bad magic */
+  FD_TEST( !fd_spad_delete( mem ) ); /* bad magic */
+
+  fd_rng_delete( fd_rng_leave( rng ) );
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
By popular demand, this is a more general implementation of the non-alloca parts of util/scratch (and it probably makes sense at some point to convert the util/scratch equivalents to use this under the hood).

From the documentation, a spad is a scratch pad that behaves very much like a thread's stack:

- Spad allocations are very fast O(1) assembly.

- Spad allocations are grouped into a frames.

- Frames are nested.

- Pushing and popping frames are also very fast O(1) assembly.

- All allocations in a frame are automatically freed when the frame is popped.

Unlike a thread's stack, the most recent allocation can be trimmed, the most recent sequence of allocations be undone, operations on a spad can by done more than one thread, threads can operate on multiple spads and, if the spad is backed by a shared memory region (e.g. wksp), spad allocations can be shared with different processes. Also, it flexibly supports tight integration with real-time streaming, custom allocation alignments, programmatic usage queries, validation, and a large dynamic range of allocation sizes and alignments.  Further, the API can be changed at compile time to implementations with extra instrumentation for debugging and/or sanitization.