### PR TITLE
ballet: fix fd_uint256.h build on noarch128

### DIFF
--- a/src/ballet/bigint/Local.mk
+++ b/src/ballet/bigint/Local.mk
@@ -1,0 +1,3 @@
+$(call add-hdr,fd_uint256.h fd_uint256_mul.h)
+$(call make-unit-test,test_uint256,test_uint256,fd_util)
+$(call run-unit-test,test_uint256)

--- a/src/ballet/bigint/test_uint256.c
+++ b/src/ballet/bigint/test_uint256.c
@@ -1,0 +1,26 @@
+#include "fd_uint256.h"
+
+static void
+test_ulong_sub_borrow( void ) {
+  ulong r;
+  int   b;
+
+  fd_ulong_sub_borrow( &r, &b, 0UL,       0UL, 0 );  FD_TEST( r==0UL       && b==0 );
+  fd_ulong_sub_borrow( &r, &b, ULONG_MAX, 0UL, 0 );  FD_TEST( r==ULONG_MAX && b==0 );
+  fd_ulong_sub_borrow( &r, &b, 0UL,       1UL, 0 );  FD_TEST( r==ULONG_MAX && b==1 );
+  fd_ulong_sub_borrow( &r, &b, 4UL,       2UL, 1 );  FD_TEST( r==1UL       && b==0 );
+  fd_ulong_sub_borrow( &r, &b, 2UL,       2UL, 1 );  FD_TEST( r==ULONG_MAX && b==1 );
+}
+
+int
+main( int    argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  test_ulong_sub_borrow();
+  /* TODO more checks here */
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}

--- a/src/flamenco/vm/syscall/Local.mk
+++ b/src/flamenco/vm/syscall/Local.mk
@@ -1,5 +1,6 @@
 ifdef FD_HAS_INT128
 ifdef FD_HAS_HOSTED
+ifdef FD_HAS_SECP256K1
 $(call add-hdrs,fd_vm_syscall.h fd_vm_cpi.h)
 $(call add-objs,fd_vm_syscall fd_vm_syscall_cpi fd_vm_syscall_hash fd_vm_syscall_crypto fd_vm_syscall_curve fd_vm_syscall_pda fd_vm_syscall_runtime fd_vm_syscall_util,fd_flamenco)
 
@@ -10,5 +11,6 @@ $(call make-unit-test,test_vm_syscalls,test_vm_syscalls,fd_flamenco fd_funk fd_b
 $(call run-unit-test,test_vm_syscalls)
 $(call run-unit-test,test_vm_syscall_cpi)
 $(call run-unit-test,test_vm_syscall_curve)
+endif
 endif
 endif


### PR DESCRIPTION
Turns out __builtin_subcll is not widely supported.
Replaces this compiler builtin with ISO C code.

Adds a minimal unit test for fd_ulong_sub_borrow.

Fixes a build issue in vm/syscall.
