### PR TITLE
fdctl: fix config bugs

### DIFF
--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -72,7 +72,7 @@ $(call run-unit-test,test_tiles_verify)
 $(call make-unit-test,test_config_parse,test_config_parse,fd_fdctl fd_ballet fd_util)
 
 $(OBJDIR)/obj/app/fdctl/configure/xdp.o: src/waltz/xdp/fd_xdp_redirect_prog.o
-$(OBJDIR)/obj/app/fdctl/config.o: src/app/fdctl/config/default.toml
+$(OBJDIR)/obj/app/fdctl/config_parse.o: src/app/fdctl/config/default.toml
 
 $(OBJDIR)/obj/app/fdctl/run/run.o: src/app/fdctl/run/generated/main_seccomp.h src/app/fdctl/run/generated/pidns_seccomp.h
 $(OBJDIR)/obj/app/fdctl/run/tiles/fd_dedup.o: src/app/fdctl/run/tiles/generated/dedup_seccomp.h

--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -262,6 +262,8 @@ typedef struct {
   } tiles;
 } config_t;
 
+FD_PROTOTYPES_BEGIN
+
 /* memlock_max_bytes() returns, for the entire Firedancer application,
    what the maximum total amount of `mlock()`ed memory will be in any
    one process, aka. what the RLIMIT_MLOCK must be set to so that all
@@ -290,5 +292,7 @@ fdctl_cfg_from_env( int *      pargc,
 
 int
 fdctl_cfg_to_memfd( config_t * config );
+
+FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_app_fdctl_config_h */

--- a/src/app/fdctl/config_parse.h
+++ b/src/app/fdctl/config_parse.h
@@ -5,15 +5,25 @@
 
 FD_PROTOTYPES_BEGIN
 
+extern uchar const fdctl_default_config[];
+extern ulong const fdctl_default_config_sz;
+
 /* fdctl_pod_to_cfg extracts configuration from pod to the typed config
    struct.  Any recognized keys are removed from pod.  Logs errors to
-   warning log.  Returns config on success, NULL on error.
+   warning log.  Returns config on success, NULL on error.  Does not
+   zero initialize config fields.
 
    Not thread safe (uses global buffer).  */
 
 config_t *
 fdctl_pod_to_cfg( config_t * config,
                   uchar *    pod );
+
+/* fdctl_cfg_validate checks for missing config keys.  Exits with code 1
+   if anything is missing. */
+
+void
+fdctl_cfg_validate( config_t * config );
 
 FD_PROTOTYPES_END
 

--- a/src/app/fdctl/test_config_parse.c
+++ b/src/app/fdctl/test_config_parse.c
@@ -1,26 +1,60 @@
 #include "config_parse.h"
 #include "../../ballet/toml/fd_toml.h"
 
-static char const cfg_str[] =
+static char const cfg_str_1[] =
   "[tiles.gossip]\n"
   "  entrypoints = [\"208.91.106.45\"]";
+
+static char const cfg_str_2[] =
+  "wumbo = \"mini\"";
 
 int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
+  /* Parse a basic config string */
+
   static uchar pod_mem[ 1UL<<16 ];
   uchar * pod = fd_pod_join( fd_pod_new( pod_mem, sizeof(pod_mem) ) );
 
   static uchar scratch[ 4096 ];
-  FD_TEST( fd_toml_parse( cfg_str, sizeof(cfg_str)-1, pod, scratch, sizeof(scratch) ) == FD_TOML_SUCCESS );
+  FD_TEST( fd_toml_parse( cfg_str_1, sizeof(cfg_str_1)-1, pod, scratch, sizeof(scratch) ) == FD_TOML_SUCCESS );
 
   static config_t config[1];
-  fdctl_pod_to_cfg( config, pod );
+  FD_TEST( fdctl_pod_to_cfg( config, pod ) == config );
 
   FD_TEST( config->tiles.gossip.entrypoints_cnt == 1 );
   FD_TEST( 0==strcmp( config->tiles.gossip.entrypoints[0], "208.91.106.45" ) );
 
+  /* Reject unrecognized config keys */
+
+  memset( config, 0, sizeof(config_t) );
+  pod = fd_pod_join( fd_pod_new( pod_mem, sizeof(pod_mem) ) );
+  FD_TEST( fd_toml_parse( cfg_str_2, sizeof(cfg_str_2)-1, pod, scratch, sizeof(scratch) ) == FD_TOML_SUCCESS );
+  FD_TEST( !fdctl_pod_to_cfg( config, pod ) );
+
+  /* The default config must parse fine */
+
+  memset( config, 0, sizeof(config_t) );
+  pod = fd_pod_join( fd_pod_new( pod_mem, sizeof(pod_mem) ) );
+  FD_TEST( fd_toml_parse( fdctl_default_config, fdctl_default_config_sz, pod, scratch, sizeof(scratch) ) == FD_TOML_SUCCESS );
+  FD_TEST( fdctl_pod_to_cfg( config, pod ) == config );
+  fdctl_cfg_validate( config );  /* exits process with code 1 on failure */
+
+  /* Ensure we can selectively override a field */
+
+  config->tiles.gossip.gossip_listen_port = 9191;
+  config->tiles.gossip.entrypoints_cnt = 2;
+  strcpy( config->tiles.gossip.entrypoints[0], "foo" );
+  strcpy( config->tiles.gossip.entrypoints[1], "bar" );
+  pod = fd_pod_join( fd_pod_new( pod_mem, sizeof(pod_mem) ) );
+  FD_TEST( fd_toml_parse( cfg_str_1, sizeof(cfg_str_1)-1, pod, scratch, sizeof(scratch) ) == FD_TOML_SUCCESS );
+  FD_TEST( fdctl_pod_to_cfg( config, pod ) == config );
+  FD_TEST( config->tiles.gossip.entrypoints_cnt == 1 );
+  FD_TEST( 0==strcmp( config->tiles.gossip.entrypoints[0], "208.91.106.45" ) );
+  FD_TEST( config->tiles.gossip.gossip_listen_port == 9191 );  /* unchanged */
+
+  FD_LOG_NOTICE(( "pass" ));
   fd_halt();
 }


### PR DESCRIPTION
- Ensure fdctl_cfg_from_env zero-initializes config_t
- Fix incorrect return code in fdctl_pod_to_cfg
- Add unit test rejecting invalid config keys
- Add fdctl_cfg_validate API to validate fields from default.toml
- Add unit test asserting that parsing default.toml works
- Add unit test selectively overriding a field
