### PR TITLE
Fix nshredcap_hdr read size check

### DIFF
--- a/src/disco/shred/fd_shred_cap.c
+++ b/src/disco/shred/fd_shred_cap.c
@@ -48,7 +48,7 @@ fd_shred_cap_replay( const char *      shred_cap_fpath,
   for( ;; ) {
     fd_shred_cap_hdr_t header;
     ulong nshredcap_hdr = fread( &header, sizeof( fd_shred_cap_hdr_t ), 1, shred_cap );
-    FD_TEST( nshredcap_hdr = 1 );
+    FD_TEST( nshredcap_hdr == 1 );
     ulong n          = header.size;
 
     uchar buffer[FD_SHRED_MAX_SZ];


### PR DESCRIPTION
Previously, an assignment was confused for an equality check