### PR TITLE
fdctl: fix misleading TOML error message

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -64,11 +64,11 @@ fdctl_cfg_load_buf( config_t *   out,
   uchar scratch[ 4096 ];
   long toml_err = fd_toml_parse( buf, sz, pod, scratch, sizeof(scratch) );
   if( FD_UNLIKELY( toml_err!=FD_TOML_SUCCESS ) ) {
-    FD_LOG_ERR(( "Invalid config (%s) at line %lu", path, toml_err ));
+    FD_LOG_ERR(( "Invalid config (%s)", path ));
   }
 
   if( FD_UNLIKELY( !fdctl_pod_to_cfg( out, pod ) ) ) {
-    FD_LOG_ERR(( "Invalid config" ));
+    FD_LOG_ERR(( "Invalid config (%s)", path ));
   }
 
   fd_pod_delete( fd_pod_leave( pod ) );


### PR DESCRIPTION
fd_toml_parse can return negative numbers.  Thus we shouldn't
print 'Invalid config at line -2'.

Error details are logged to warning log anyways.
