### PR TITLE
vm, flamenco: removing extraneous signer assignment in CPI

### DIFF
--- a/src/flamenco/runtime/fd_rocksdb.c
+++ b/src/flamenco/runtime/fd_rocksdb.c
@@ -483,7 +483,7 @@ fd_rocksdb_copy_over_txn_status( fd_rocksdb_t * src,
     return;
   }
 
-  fd_rocksdb_insert_entry( dst, FD_ROCKSDB_CFIDX_TRANSACTION_STATUS, key, 80UL, res, sz );
+  fd_rocksdb_insert_entry( dst, FD_ROCKSDB_CFIDX_TRANSACTION_STATUS, key, 72UL, res, sz );
 }
 
 int

--- a/src/flamenco/runtime/program/fd_bpf_loader_v2_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v2_program.c
@@ -122,6 +122,8 @@ fd_bpf_loader_v2_user_execute( fd_exec_instr_ctx_t ctx ) {
   fd_vm_t _vm[1];
   fd_vm_t * vm = fd_vm_join( fd_vm_new( _vm ) );
 
+  ulong pre_insn_cus = ctx.txn_ctx->compute_meter;
+
   fd_vm_init(
       /* vm        */ vm,
       /* instr_ctx */ &ctx,
@@ -186,6 +188,8 @@ if( FD_UNLIKELY( vm->trace ) ) {
   fd_valloc_free( ctx.txn_ctx->valloc, fd_vm_trace_delete( fd_vm_trace_leave( vm->trace ) ) );
 }
 #endif
+
+  FD_LOG_DEBUG(("Program consumed %lu of %lu compute units", pre_insn_cus-vm->cu, pre_insn_cus ));
 
   ctx.txn_ctx->compute_meter = vm->cu;
 

--- a/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
@@ -383,6 +383,8 @@ execute( fd_exec_instr_ctx_t * instr_ctx, fd_sbpf_validated_program_t * prog ) {
   fd_vm_t _vm[1];
   fd_vm_t * vm = fd_vm_join( fd_vm_new( _vm ) );
 
+  ulong pre_insn_cus = instr_ctx->txn_ctx->compute_meter;
+
   /* TODO: (topointon): correctly set check_align and check_size in vm setup */
   vm = fd_vm_init(
     /* vm        */ vm,
@@ -449,7 +451,7 @@ execute( fd_exec_instr_ctx_t * instr_ctx, fd_sbpf_validated_program_t * prog ) {
     return FD_EXECUTOR_INSTR_ERR_GENERIC_ERR;
   }
 
-  /* TODO: Add log for "Program consumed {} of {} compute units "*/
+  FD_LOG_DEBUG(("Program consumed %lu of %lu compute units", pre_insn_cus-vm->cu, pre_insn_cus ));
 
   instr_ctx->txn_ctx->compute_meter = vm->cu;
 


### PR DESCRIPTION
We are not supposed to assign a callee instruction as a signer if it is a derived signer. This was causing CU mismatches