### PR TITLE
quic - changed fd_quic_conn_id_rand to clear whole structure

### DIFF
--- a/src/waltz/quic/fd_quic_conn_id.h
+++ b/src/waltz/quic/fd_quic_conn_id.h
@@ -63,7 +63,8 @@ fd_quic_conn_id_rand( fd_quic_conn_id_t * conn_id ) {
      be delivered to the same endpoint by flow control */
   /* TODO load balancing / flow steering */
 
-  conn_id->sz = 8;
+  /* padding must be set to zero also */
+  *conn_id = (fd_quic_conn_id_t){ .sz = 8u, .conn_id = {0u}, .pad = {0u} };
   return fd_rng_secure( conn_id->conn_id, 8u ) ? conn_id : NULL;
 }
 


### PR DESCRIPTION
Padding is included in the hash. In the past the padding had been forced to zero. This allows a multiple of 8 to be used for all the operations.

A change introduced code that did not clear the pad, resulting in hash mismatches.

This fix clears the whole structure, including the padding