### PR TITLE
x509: add CBMC proof for parser

### DIFF
--- a/src/ballet/x509/fd_x509_mock.c
+++ b/src/ballet/x509/fd_x509_mock.c
@@ -139,7 +139,7 @@ fd_x509_mock_pubkey_v1( uchar const * cert,
   uchar const * match = memmem( cert, cert_sz, fd_x509_mock_v1_prefix, sizeof(fd_x509_mock_v1_prefix) );
   if( !match ) return NULL;
   uchar const * pubkey = match + sizeof(fd_x509_mock_v1_prefix);
-  if( FD_UNLIKELY( pubkey + 32 > end ) ) return NULL;
+  if( FD_UNLIKELY( (ulong)pubkey+32UL > (ulong)end ) ) return NULL;
   return pubkey;
 }
 

--- a/verification/proofs/x509_mock/Makefile
+++ b/verification/proofs/x509_mock/Makefile
@@ -1,0 +1,15 @@
+HARNESS_ENTRY = harness
+HARNESS_FILE = fd_x509_mock_harness
+PROOF_UID = fd_x509_mock
+
+INCLUDES += -I$(SRCDIR)
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES = $(SRCDIR)/ballet/x509/fd_x509_mock.c
+
+CBMC_OBJECT_BITS = 16
+UNWINDSET += memcmp.0:1024
+
+CBMC_FLAG_UNSIGNED_OVERFLOW_CHECK =
+
+include ../Makefile.common

--- a/verification/proofs/x509_mock/cbmc-viewer.json
+++ b/verification/proofs/x509_mock/cbmc-viewer.json
@@ -1,0 +1,5 @@
+{
+  "expected-missing-functions": [],
+  "proof-name": "fd_tls_client_hs_harness",
+  "proof-root": "verification/proofs"
+}

--- a/verification/proofs/x509_mock/fd_x509_mock_harness.c
+++ b/verification/proofs/x509_mock/fd_x509_mock_harness.c
@@ -1,0 +1,30 @@
+#include <ballet/x509/fd_x509_mock.h>
+#include <assert.h>
+
+void *
+memmem( void const * haystack,
+        ulong        haystack_sz,
+        void const * needle,
+        ulong        needle_sz ) {
+  if( !haystack_sz ) return NULL;
+  if( !needle_sz   ) return NULL;
+  if( needle_sz > haystack_sz ) return NULL;
+  void * rc;
+  __CPROVER_assume(
+    rc==NULL ||
+    ( (ulong)rc             >= (ulong)haystack &&
+      (ulong)rc + needle_sz <= (ulong)haystack+haystack_sz ) );
+  return rc;
+}
+
+void
+harness( void ) {
+  ulong sz;
+  __CPROVER_assume( sz<=UINT_MAX );
+  uchar buf[sz];
+  uchar const * pubkey = fd_x509_mock_pubkey( buf, sz );
+  assert(
+    pubkey==NULL ||
+    ( (ulong)pubkey >= (ulong)buf &&
+      (ulong)pubkey <  (ulong)(buf+sz) ) );
+}


### PR DESCRIPTION
Proves that the fd_x509_mock parser is free of U.B. using CBMC.