### PR TITLE
flamenco: disabling speed load

### DIFF
--- a/src/flamenco/snapshot/fd_snapshot.c
+++ b/src/flamenco/snapshot/fd_snapshot.c
@@ -131,7 +131,8 @@ fd_snapshot_load( const char *         snapshotfile,
     break;
   }
 
-  fd_funk_speed_load_mode( slot_ctx->acc_mgr->funk, 1 );
+  /* TODO: re-enable speed load after leak is resolved */
+  fd_funk_speed_load_mode( slot_ctx->acc_mgr->funk, 0 );
   fd_funk_start_write( slot_ctx->acc_mgr->funk );
 
   fd_funk_txn_t * child_txn = slot_ctx->funk_txn;


### PR DESCRIPTION
Speed loading snapshots currently causes a leak in the funk wksp. This is a temporary fix to prevent leaks