### PR TITLE
solfuzz-publish without ubsan

### DIFF
--- a/.github/workflows/clusterfuzz.yml
+++ b/.github/workflows/clusterfuzz.yml
@@ -54,10 +54,35 @@ jobs:
           qualifier: ${{ matrix.qualifier }}
           service-account-credentials: ${{ secrets.FUZZ_SERVICE_ACCT_JSON_BUNDLE }}
 
+  solfuzz-publish:
+    runs-on:
+      group: github-v1
+    env:
+      MACHINE: linux_clang_haswell
+      EXTRAS: fuzz asan
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/hugepages
+      - uses: ./.github/actions/deps
+
+      - run: sudo apt update && sudo apt install -y zip
+
+      - uses: asymmetric-research/clusterfuzz-fuzzbot-builder@main
+        name: Build fuzz tests
+        with:
+          command: make -j -Otarget fuzz-test lib
+
+      - name: List Artifacts
+        run: |
+          ls ${{ env.MACHINE }}/fuzz-test
+          ls ${{ env.MACHINE }}/lib
+
       - name: upload lib artifact
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.machine == 'linux_clang_haswell' }}
         with:
-          path: ${{ matrix.artifact_dir }}/lib/libfd_exec_sol_compat.so
+          path: ${{ env.MACHINE }}/lib/libfd_exec_sol_compat.so
           name: libfd_exec_sol_compat
           retention-days: 14


### PR DESCRIPTION
This change splits the builds for clusterfuzz and solfuzz.

The solfuzz build should not use ubsan.

The builds are not sequentially dependent.