### PR TITLE
tls: provide safe default for CSPRNG

### DIFF
--- a/src/waltz/quic/tls/fd_quic_tls.c
+++ b/src/waltz/quic/tls/fd_quic_tls.c
@@ -34,16 +34,6 @@ fd_quic_tls_secrets( void const * handshake,
                      void const * send_secret,
                      uint         encryption_level );
 
-/* fd_quic_tls_rand is the RNG provided to fd_tls.  Note: This is
-   a layering violation ... The user should pass the CSPRNG handle to
-   both fd_quic and fd_tls.  Currently, implemented via the getrandom()
-   syscall ... Inefficient! */
-
-void *
-fd_quic_tls_rand( void * ctx,
-                  void * buf,
-                  ulong  bufsz );
-
 /* fd_quic_tls_tp_self is called by fd_tls to retrieve fd_quic's QUIC
    transport parameters. */
 
@@ -164,10 +154,6 @@ fd_quic_tls_init( fd_tls_t *    tls,
   tls = fd_tls_new( tls );
   *tls = (fd_tls_t) {
     .quic = 1,
-    .rand = {
-      .ctx     = NULL,
-      .rand_fn = fd_quic_tls_rand
-    },
     .sign = signer,
     .secrets_fn = fd_quic_tls_secrets,
     .sendmsg_fn = fd_quic_tls_sendmsg,
@@ -589,14 +575,6 @@ fd_quic_tls_get_peer_transport_params( fd_quic_tls_hs_t * self,
   *transport_params_sz  = self->peer_transport_params_sz;
 }
 
-void *
-fd_quic_tls_rand( void * ctx,
-                  void * buf,
-                  ulong  bufsz ) {
-  (void)ctx;
-  FD_TEST( fd_rng_secure( buf, bufsz ) );
-  return buf;
-}
 
 ulong
 fd_quic_tls_tp_self( void *  const handshake,

--- a/src/waltz/tls/fd_tls.c
+++ b/src/waltz/tls/fd_tls.c
@@ -204,6 +204,23 @@ fd_tls_alert( fd_tls_estate_base_t * hs,
   return -(long)alert;
 }
 
+static void *
+fd_tls_rand_default( void * ctx,
+                     void * buf,
+                     ulong  bufsz ) {
+  (void)ctx;
+  return fd_rng_secure( buf, bufsz );
+}
+
+static void *
+fd_tls_rand( fd_tls_rand_t const * rand,
+             void *                buf,
+             ulong                 bufsz ) {
+  fd_tls_rand_fn_t rand_fn = rand->rand_fn;
+  if( !rand_fn ) rand_fn = fd_tls_rand_default;  /* cmov */
+  return rand_fn( rand->ctx, buf, bufsz );
+}
+
 /* fd_tls_send_cert_verify generates and sends a CertificateVerify
    message.  Returns 0L on success and negated TLS alert number on
    failure.  this is the local client or server object.  hs is the

--- a/src/waltz/tls/fd_tls.h
+++ b/src/waltz/tls/fd_tls.h
@@ -135,11 +135,7 @@ typedef void
    reasonable amount of data ahead of time.  NULL return value implies
    inability to keep up with demand for random values.  In this case,
    function should return NULL.  Function should minimize side effects
-   (notably, should not log).
-
-   TODO API considerations:
-   - read() style error codes?
-   - Buffering to reduce amount of virtual function calls? */
+   (notably, should not log). */
 
 typedef void *
 (* fd_tls_rand_fn_t)( void * ctx,
@@ -153,21 +149,14 @@ struct fd_tls_rand_vt {
 
 typedef struct fd_tls_rand_vt fd_tls_rand_t;
 
-static inline void *
-fd_tls_rand( fd_tls_rand_t const * rand,
-             void *                buf,
-             ulong                 bufsz ) {
-  return rand->rand_fn( rand->ctx, buf, bufsz );
-}
-
 /* fd_tls_sign_fn_t is called by by fd_tls to request signing of a
    TLS 1.3 certificate verify payload.
-   
+
    ctx is an arbitrary pointer that is provided as a callback argument.
    sig points to a 64 byte buffer where the implementor should store the
    ed25519 signature of the payload.  Payload will point to a 130 byte
    buffer containing the TLS 1.3 CertificateVerify payload.
-   
+
    This function must not fail.  Lifetime of the payload buffer ends at
    return. */
 
@@ -230,7 +219,7 @@ fd_tls_sign( fd_tls_sign_t const * sign,
    across multiple TLS handshakes. */
 
 struct fd_tls {
-  fd_tls_rand_t       rand;
+  fd_tls_rand_t       rand;  /* may be NULL */
   fd_tls_secrets_fn_t secrets_fn;
   fd_tls_sendmsg_fn_t sendmsg_fn;
 


### PR DESCRIPTION
- Fixes an unlikely crash in fd_quic when CSPRNG is starved
- Simplifies fd_tls public API by providing a safe default if the
  user doesn't provide an rng callback
