### PR TITLE
quic: improve handling of self transport params

### DIFF
--- a/src/waltz/quic/tests/test_quic_tls_hs.c
+++ b/src/waltz/quic/tests/test_quic_tls_hs.c
@@ -97,12 +97,7 @@ main( int     argc,
 
   /* dump transport params */
   fd_quic_transport_params_t tmp_tp[1] = {0};
-  uchar const * transport_params      = test_tp;
-  ulong         transport_params_sz   = sizeof( test_tp ) - 1; /* test_tp has terminating NUL */
-  uchar const * tp_p  = transport_params;
-  ulong         tp_sz = transport_params_sz;
-
-  FD_TEST( fd_quic_decode_transport_params( tmp_tp, tp_p, tp_sz )>=0 );
+  FD_TEST( fd_quic_decode_transport_params( tmp_tp, test_tp, sizeof(test_tp)-1 )>=0 );
 
   fd_quic_dump_transport_params( tmp_tp, stdout );
   fflush( stdout );
@@ -126,8 +121,7 @@ main( int     argc,
                                                      tls_client,
                                                      0 /* is_server */,
                                                      "localhost",
-                                                     transport_params,
-                                                     transport_params_sz );
+                                                     tmp_tp );
   FD_TEST( hs_client );
 
   //uchar   svr_dst_conn_id[1] = {0};
@@ -136,8 +130,7 @@ main( int     argc,
                                                      tls_server,
                                                      1 /* is_server */,
                                                      "localhost",
-                                                     transport_params,
-                                                     transport_params_sz );
+                                                     tmp_tp );
   FD_TEST( hs_server );
 
   // generate initial secrets for client

--- a/src/waltz/quic/tls/fd_quic_tls.c
+++ b/src/waltz/quic/tls/fd_quic_tls.c
@@ -231,8 +231,7 @@ fd_quic_tls_hs_new( fd_quic_tls_t * quic_tls,
                     void *          context,
                     int             is_server,
                     char const *    hostname,
-                    uchar const *   transport_params_raw,
-                    ulong           transport_params_raw_sz ) {
+                    fd_quic_transport_params_t const * self_transport_params ) {
   // find a free handshake
   ulong hs_idx = 0;
   ulong hs_sz  = (ulong)quic_tls->max_concur_handshakes;
@@ -296,14 +295,7 @@ fd_quic_tls_hs_new( fd_quic_tls_t * quic_tls,
   (void)hostname;
 
   /* Set QUIC transport params */
-  if( transport_params_raw_sz > sizeof(self->self_transport_params) ) {
-    /* unreachable with well-behaved caller */
-    FD_LOG_WARNING(( "transport_params_raw_sz too large (got %lu, max %lu)",
-                     transport_params_raw_sz, sizeof(self->self_transport_params) ));
-    return NULL;
-  }
-  self->self_transport_params_sz = (uchar)transport_params_raw_sz;
-  fd_memcpy( self->self_transport_params, transport_params_raw, transport_params_raw_sz );
+  self->self_transport_params = *self_transport_params;
 
   /* Mark handshake as used */
   hs_used[hs_idx] = 1;
@@ -610,12 +602,13 @@ fd_quic_tls_tp_self( void *  const handshake,
                      ulong   const quic_tp_bufsz ) {
   fd_quic_tls_hs_t * hs = (fd_quic_tls_hs_t *)handshake;
 
-  /* Copy fd_quic_tls's transport params to fd_tls buffer */
-  ulong sz = fd_ulong_min( quic_tp_bufsz, hs->self_transport_params_sz );
-  fd_memcpy( quic_tp, hs->self_transport_params, sz );
+  ulong encoded_sz = fd_quic_encode_transport_params( quic_tp, quic_tp_bufsz, &hs->self_transport_params );
+  if( FD_UNLIKELY( encoded_sz==FD_QUIC_ENCODE_FAIL ) ) {
+    FD_LOG_WARNING(( "fd_quic_encode_transport_params failed" ));
+    return 0UL;
+  }
 
-  /* fd_tls will gracefully fail handshake if return value exceeds bufsz */
-  return hs->self_transport_params_sz;
+  return encoded_sz;
 }
 
 void

--- a/src/waltz/quic/tls/fd_quic_tls.h
+++ b/src/waltz/quic/tls/fd_quic_tls.h
@@ -6,6 +6,7 @@
 
 #include "../fd_quic_common.h"
 #include "../../tls/fd_tls.h"
+#include "../templ/fd_quic_transport_params.h"
 
 /* QUIC-TLS
 
@@ -197,9 +198,8 @@ struct fd_quic_tls_hs {
   /* TLS alert code */
   uint  alert;
 
-  /* buffer our own QUIC transport params.  This is even more annoying. */
-  uchar self_transport_params_sz;
-  uchar self_transport_params[ 255 ];
+  /* our own QUIC transport params */
+  fd_quic_transport_params_t self_transport_params;
 };
 
 ulong
@@ -229,8 +229,7 @@ fd_quic_tls_hs_new( fd_quic_tls_t * quic_tls,
                     void *          context,
                     int             is_server,
                     char const *    hostname,
-                    uchar const *   transport_params_raw,
-                    ulong           transport_params_raw_sz );
+                    fd_quic_transport_params_t const * self_transport_params );
 
 /* delete a handshake object and free resources */
 void


### PR DESCRIPTION
Fixes https://github.com/firedancer-io/firedancer/issues/2351 by storing self transport params in the decoded form.  Now encodes transport params on demand.

Depends on #2361  #2362