### PR TITLE
last_restart_slot_errs: fix error checking

### DIFF
--- a/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.c
@@ -34,30 +34,35 @@ fd_sysvar_last_restart_slot_init( fd_exec_slot_ctx_t * slot_ctx ) {
                  0UL );
 }
 
-fd_sol_sysvar_last_restart_slot_t *
+static int
 fd_sysvar_last_restart_slot_read( fd_sol_sysvar_last_restart_slot_t * result,
                                   fd_exec_slot_ctx_t const *          slot_ctx ) {
 
   FD_BORROWED_ACCOUNT_DECL(acc);
   int err = fd_acc_mgr_view(slot_ctx->acc_mgr, slot_ctx->funk_txn, &fd_sysvar_last_restart_slot_id, acc);
-  if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) )
-    return NULL;
+  if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
+    return 1;
+  }
 
   fd_bincode_decode_ctx_t decode =
     { .data    = acc->const_data,
       .dataend = acc->const_data + acc->const_meta->dlen,
       .valloc  = {0}  /* valloc not required */ };
 
-  if( FD_UNLIKELY( fd_sol_sysvar_last_restart_slot_decode( result, &decode )!=FD_BINCODE_SUCCESS ) )
-    return NULL;
-  return FD_ACC_MGR_SUCCESS;
+  if( FD_UNLIKELY( fd_sol_sysvar_last_restart_slot_decode( result, &decode )!=FD_BINCODE_SUCCESS ) ) {
+    return 1;
+  }
+  return 0;
 }
 
 void
 fd_sysvar_last_restart_slot_update( fd_exec_slot_ctx_t * slot_ctx ) {
   if( !FD_FEATURE_ACTIVE( slot_ctx, last_restart_slot_sysvar ) ) return;
+
   fd_sol_sysvar_last_restart_slot_t result;
-  fd_sysvar_last_restart_slot_read( &result, slot_ctx );
+  if (fd_sysvar_last_restart_slot_read( &result, slot_ctx ))
+    return;
+
   if ( result.slot == slot_ctx->slot_bank.last_restart_slot.slot ) return;
 
   /* Set this every slot? */

--- a/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.h
@@ -13,19 +13,6 @@ FD_PROTOTYPES_BEGIN
 void
 fd_sysvar_last_restart_slot_init( fd_exec_slot_ctx_t * slot_ctx );
 
-/* fd_sysvar_last_restart_slot_read queries the sysvar cache (?) for the
-   slot number at which the last hard fork occurred.  This matches the
-   highest slot number in the bank's "hard forks" list that is not in
-   the future.  On success, returns 0 and writes *result.  On failure,
-   returns an FD_ACC_MGR error code.  Reasons for error include that the
-   "last restart slot sysvar" feature is not yet activated
-   (FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT), or that there is a critical runtime
-   error. */
-
-fd_sol_sysvar_last_restart_slot_t *
-fd_sysvar_last_restart_slot_read( fd_sol_sysvar_last_restart_slot_t * result,
-                                  fd_exec_slot_ctx_t const *          slot_ctx );
-
 /* fd_sysvar_last_restart_slot_update performs a sysvar update before
    transaction processing.  TODO not completely implemented. */
 
@@ -35,4 +22,3 @@ fd_sysvar_last_restart_slot_update( fd_exec_slot_ctx_t * slot_ctx );
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_flamenco_runtime_fd_sysvar_last_restart_slot_h */
-


### PR DESCRIPTION
fd_sysvar_last_restart_slot_read needs to cleanly log a error and exit