### PR TITLE
QUIC - various fixes

### DIFF
--- a/src/waltz/quic/crypto/fd_quic_crypto_suites.h
+++ b/src/waltz/quic/crypto/fd_quic_crypto_suites.h
@@ -380,7 +380,8 @@ fd_quic_crypto_encrypt(
     ulong                          const pkt_sz,
     fd_quic_crypto_suite_t const * const suite,
     fd_quic_crypto_keys_t const *  const pkt_keys,
-    fd_quic_crypto_keys_t const *  const hp_keys );
+    fd_quic_crypto_keys_t const *  const hp_keys,
+    ulong                          const pkt_number );
 
 
 /* decrypt a quic protected packet

--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -61,6 +61,16 @@
  * which may only contain acks. */
 # define FD_QUIC_OPT_SEND_ALL_ACKS 0
 
+/* FD_QUIC_PING_ENABLE
+ *
+ * This compile time option specifies whether the server should use
+ * QUIC PING frames to keep connections alive
+ *
+ * Set to 1 to keep connections alive
+ * Set to 0 to allow connections to close on idle */
+# define FD_QUIC_PING_ENABLE 0
+
+
 
 /* Construction API ***************************************************/
 
@@ -2827,6 +2837,12 @@ fd_quic_process_packet( fd_quic_t * quic,
     return;
   }
 
+  /* verify ip4 packet isn't truncated
+   * AF_XDP can silently do this */
+  if( FD_UNLIKELY( pkt.ip4->net_tot_len > cur_sz ) ) {
+    return;
+  }
+
   /* update pointer + size */
   cur_ptr += rc;
   cur_sz  -= rc;
@@ -2837,9 +2853,14 @@ fd_quic_process_packet( fd_quic_t * quic,
     return;
   }
 
+  /* sanity check udp length */
+  if( FD_UNLIKELY( pkt.udp->net_len > cur_sz ) ) {
+    return;
+  }
+
   /* update pointer + size */
   cur_ptr += rc;
-  cur_sz  -= rc;
+  cur_sz   = pkt.udp->net_len - rc; /* replace with udp length */
 
   /* cur_ptr[0..cur_sz-1] should be payload */
 
@@ -3420,7 +3441,7 @@ fd_quic_service( fd_quic_t * quic ) {
           conn->state = FD_QUIC_CONN_STATE_DEAD;
           quic->metrics.conn_aborted_cnt++;
         }
-      } else {
+      } else if( FD_QUIC_PING_ENABLE ) {
         /* send PING */
         if( !( conn->flags & FD_QUIC_CONN_FLAGS_PING ) ) {
           conn->flags         |= FD_QUIC_CONN_FLAGS_PING;
@@ -4643,7 +4664,7 @@ fd_quic_conn_tx( fd_quic_t *      quic,
     pkt_meta->flags |= key_phase_flags;
 
     if( FD_UNLIKELY( fd_quic_crypto_encrypt( conn->tx_ptr, &cipher_text_sz, hdr, hdr_sz,
-          pay, pay_sz, suite, pkt_keys, hp_keys ) != FD_QUIC_SUCCESS ) ) {
+          pay, pay_sz, suite, pkt_keys, hp_keys, pkt_number ) != FD_QUIC_SUCCESS ) ) {
       FD_LOG_WARNING(( "fd_quic_crypto_encrypt failed" ));
 
       /* reschedule, since some data was unable to be sent */

--- a/src/waltz/quic/templ/fd_quic_encoders.h
+++ b/src/waltz/quic/templ/fd_quic_encoders.h
@@ -78,7 +78,8 @@
       return FD_QUIC_PARSE_FAIL;                                       \
     }                                                                  \
     frame->NAME##_pnoff = (unsigned)( buf - orig_buf );                \
-    if( fd_quic_encode_bits( buf, cur_bit, frame->NAME,                \
+    if( fd_quic_encode_bits( buf, cur_bit,                             \
+          frame->NAME & ( ( 1UL << frame->NAME##_bits ) - 1UL ),       \
           frame->NAME##_bits ) ) {                                     \
       return FD_QUIC_PARSE_FAIL;                                       \
     }                                                                  \

--- a/src/waltz/quic/tests/fuzz_quic_wire.c
+++ b/src/waltz/quic/tests/fuzz_quic_wire.c
@@ -356,6 +356,11 @@ encrypt_packet( uchar * const data,
   uchar const * hdr    = data;
   ulong         hdr_sz = pkt_num_pnoff + pkt_number_sz;
 
+  ulong pkt_number = 0UL;
+  for( ulong j = 0UL; j < pkt_number_sz; ++j ) {
+    pkt_number = ( pkt_number << 8UL ) + (ulong)( hdr[pkt_num_pnoff + j] );
+  }
+
   if( ( out_sz          < hdr_sz ) |
       ( out_sz - hdr_sz < FD_QUIC_CRYPTO_TAG_SZ ) )
     return size;
@@ -367,7 +372,8 @@ encrypt_packet( uchar * const data,
     fd_quic_crypto_encrypt( out, &out_sz,
                             hdr, hdr_sz,
                             pay, pay_sz,
-                            suite, keys, keys );
+                            suite, keys, keys,
+                            pkt_number );
   if( encrypt_res != FD_QUIC_SUCCESS )
     return size;
   assert( out_sz == total_len );

--- a/src/waltz/quic/tests/test_quic_crypto.c
+++ b/src/waltz/quic/tests/test_quic_crypto.c
@@ -234,6 +234,8 @@ main( int     argc,
   uchar const * hdr    = packet_header;
   ulong         hdr_sz = sizeof( packet_header );
 
+  ulong pkt_number = 2UL;
+
   FD_TEST( fd_quic_crypto_encrypt( cipher_text_,
                                    &cipher_text_sz,
                                    hdr,
@@ -242,7 +244,8 @@ main( int     argc,
                                    pkt_sz,
                                    suite,
                                    &client_keys,
-                                   &client_keys  )==FD_QUIC_SUCCESS );
+                                   &client_keys,
+                                   pkt_number )==FD_QUIC_SUCCESS );
 
   uchar const * cipher_text = cipher_text_;
 


### PR DESCRIPTION
Account for ethernet frames with padding
Disable PING keep alive
Encryption of short packet number. Not used, but helps testing of decryption of short packet numbers