### PR TITLE
flamenco: update fee calculator to use parent signature count

### DIFF
--- a/src/flamenco/runtime/context/fd_exec_slot_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_slot_ctx.h
@@ -71,6 +71,7 @@ struct __attribute__((aligned(8UL))) fd_exec_slot_ctx {
   ulong                    signature_cnt;
   fd_hash_t                account_delta_hash;
   fd_hash_t                prev_banks_hash;
+  ulong                    parent_signature_cnt;
 
   fd_sysvar_cache_t *      sysvar_cache;
   fd_account_compute_elem_t * account_compute_table;

--- a/src/flamenco/runtime/fd_hashes.c
+++ b/src/flamenco/runtime/fd_hashes.c
@@ -280,6 +280,7 @@ fd_hash_bank( fd_exec_slot_ctx_t * slot_ctx,
               fd_pubkey_hash_pair_t * dirty_keys,
               ulong dirty_key_cnt ) {
   slot_ctx->prev_banks_hash = slot_ctx->slot_bank.banks_hash;
+  slot_ctx->parent_signature_cnt = slot_ctx->signature_cnt;
 
   fd_hash_account_deltas( dirty_keys, dirty_key_cnt, &slot_ctx->account_delta_hash, slot_ctx );
 

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -1696,7 +1696,7 @@ fd_runtime_block_sysvar_update_pre_execute( fd_exec_slot_ctx_t * slot_ctx ) {
   //     FeeRateGovernor::new_derived(&parent.fee_rate_governor, parent.signature_count())
   // );
   /* https://github.com/firedancer-io/solana/blob/dab3da8e7b667d7527565bddbdbecf7ec1fb868e/runtime/src/bank.rs#L1312-L1314 */
-  fd_sysvar_fees_new_derived(slot_ctx, slot_ctx->slot_bank.fee_rate_governor, slot_ctx->signature_cnt);
+  fd_sysvar_fees_new_derived(slot_ctx, slot_ctx->slot_bank.fee_rate_governor, slot_ctx->parent_signature_cnt);
 
   // TODO: move all these out to a fd_sysvar_update() call...
   long clock_update_time = -fd_log_wallclock();


### PR DESCRIPTION
```
[Replay]
slot:             281357641
bank hash:        Fpyqu9KBdZ755yaT3a6cMWWR5xr1rBJ6Q1HRJuDBGA2w
parent bank hash: 3L2Zim8wh1Z27jT8Xg3Y6xYgQ8euqNDx9i95bVLpj5Sv
accounts_delta:   AEUc5ZixZ8MpR5kt2DGmRmKckBZLoXb78QDtsuKiHrQY
signature_count:  12395
last_blockhash:   9Kh3zRE4frzcnoDKCQBymSawt8wcm8u5ipNtkzZgN2cZ

NOTICE  07-15 17:27:22.731496 256445 5    0    src/app/ledger/main.c(318): replay completed - slots: 31, elapsed: 28.419037 s, txns: 107324, tps: 3776.482597, sec/slot: 0.916743
```

Agave uses parent slot signature count to determine fees. We were incorrectly passing in the signature count of the current slot which would be default to 0 at the current point in time