### PR TITLE
quic: free server-side tls_hs when peer ACKs handshake_done

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -4241,11 +4241,8 @@ fd_quic_conn_tx( fd_quic_t *      quic,
       /* are we at application level of encryption? */
       if( enc_level == fd_quic_enc_level_appdata_id ) {
         if( conn->handshake_done_send ) {
-          if( FD_UNLIKELY( conn->handshake_done_ackd ) ) {
-            /* already acked? then ignore it
-             * just clear the send flag */
-            conn->handshake_done_send = 0;
-          } else {
+          conn->handshake_done_send = 0;
+          if( FD_LIKELY( !conn->handshake_done_ackd ) ) {
             /* send handshake done frame */
             frame_sz = 1;
             pkt_meta->flags |= FD_QUIC_PKT_META_FLAGS_HS_DONE;
@@ -4810,8 +4807,6 @@ fd_quic_conn_service( fd_quic_t * quic, fd_quic_conn_t * conn, ulong now ) {
               fd_quic_tls_pop_hs_data( conn->tls_hs, enc_level );
               hs_data = fd_quic_tls_get_hs_data( conn->tls_hs, enc_level );
             }
-
-            /* TODO we should be able to free the TLS object now */
           }
 
           /* if we're the client, fd_quic_conn_tx will flush the hs
@@ -4962,10 +4957,8 @@ fd_quic_conn_free( fd_quic_t *      quic,
   fd_memset( conn->keys, 0, sizeof(conn->keys) );
 
   /* free tls-hs */
-  if( conn->tls_hs ) {
-    fd_quic_tls_hs_delete( conn->tls_hs );
-    conn->tls_hs = NULL;
-  }
+  fd_quic_tls_hs_delete( conn->tls_hs );
+  conn->tls_hs = NULL;
 
   /* put connection back in free list */
   conn->next   = state->conns;
@@ -5339,10 +5332,6 @@ fd_quic_conn_create( fd_quic_t *               quic,
   /* return connection */
   return conn;
 }
-
-extern inline FD_FN_PURE
-int
-fd_quic_handshake_complete( fd_quic_conn_t * conn );
 
 ulong
 fd_quic_get_next_wakeup( fd_quic_t * quic ) {
@@ -5727,6 +5716,7 @@ fd_quic_reclaim_pkt_meta( fd_quic_conn_t *     conn,
   }
 
   if( flags & FD_QUIC_PKT_META_FLAGS_HS_DATA ) {
+    /* Note that tls_hs could already be freed */
     /* is this ack'ing the next consecutive bytes?
        if so, we can increase the ack'd bytes
        if not, we retransmit the bytes expected to be ack'd
@@ -5761,7 +5751,12 @@ fd_quic_reclaim_pkt_meta( fd_quic_conn_t *     conn,
       hs_data = fd_quic_tls_get_hs_data( conn->tls_hs, enc_level );
     }
 
-    /* TODO we should be able to free the TLS object now */
+    conn->handshake_done_ackd = 1;
+    conn->handshake_done_send = 0;
+    conn->hs_data_empty       = 1;
+
+    fd_quic_tls_hs_delete( conn->tls_hs );
+    conn->tls_hs = NULL;
   }
 
   if( flags & FD_QUIC_PKT_META_FLAGS_MAX_DATA ) {

--- a/src/waltz/quic/fd_quic_conn.h
+++ b/src/waltz/quic/fd_quic_conn.h
@@ -126,10 +126,10 @@ struct fd_quic_conn {
   uint               tx_max_datagram_sz;  /* size of maximum datagram allowed by peer */
 
   /* handshake members */
-  int                handshake_complete;  /* have we completed a successful handshake? */
-  int                handshake_done_send; /* do we need to send handshake-done to peer? */
-  int                handshake_done_ackd; /* was handshake_done ack'ed? */
-  int                hs_data_empty;       /* has all hs_data been consumed? */
+  uint               handshake_complete  : 1; /* have we completed a successful handshake? */
+  uint               handshake_done_send : 1; /* do we need to send handshake-done to peer? */
+  uint               handshake_done_ackd : 1; /* was handshake_done ack'ed? */
+  uint               hs_data_empty       : 1; /* has all hs_data been consumed? */
   fd_quic_tls_hs_t * tls_hs;
 
   /* expected handshake data offset - one per encryption level
@@ -360,16 +360,6 @@ fd_quic_conn_set_context( fd_quic_conn_t * conn, void * context );
 /* get the user-defined context value from a connection */
 void *
 fd_quic_conn_get_context( fd_quic_conn_t * conn );
-
-/* fd_quic_handshake_complete checks whether the initial conn handshake
-   is complete for the given conn.  Returns 1 if a handshake has been
-   completed, 0 otherwise.  Will return 1 even if the conn has died
-   since handshake. */
-
-FD_QUIC_API FD_FN_PURE inline int
-fd_quic_handshake_complete( fd_quic_conn_t * conn ) {
-  return conn->handshake_complete;
-}
 
 
 /* set the max concurrent streams value for the specified type

--- a/src/waltz/quic/tls/fd_quic_tls.h
+++ b/src/waltz/quic/tls/fd_quic_tls.h
@@ -231,9 +231,10 @@ fd_quic_tls_hs_new( fd_quic_tls_t * quic_tls,
                     char const *    hostname,
                     fd_quic_transport_params_t const * self_transport_params );
 
-/* delete a handshake object and free resources */
+/* fd_quic_tls_hs_delete frees a handshake object and its resources.
+   Fine if hs is NULL. */
 void
-fd_quic_tls_hs_delete( fd_quic_tls_hs_t * self );
+fd_quic_tls_hs_delete( fd_quic_tls_hs_t * hs );
 
 /* fd_quic_tls_provide_data forwards an incoming QUIC CRYPTO frame
    containing TLS handshake message data to the underlying TLS
@@ -272,7 +273,7 @@ fd_quic_tls_provide_data( fd_quic_tls_hs_t * self,
      fd_quic_tls_hs_delete
 
    args
-     self        the handshake in question
+     self        the handshake in question (fine if NULL)
      enc_level   a pointer for receiving the encryption level
      data        a pointer for receiving the pointer to the data buffer
      data_sz     a pointer for receiving the data size */


### PR DESCRIPTION
Previously, an fd_quic server retained the tls_hs object for the
lifetime of a connection.  The fd_quic client freed it as soon as
it saw a 'handshake_done' frame.

With this patch, the server now frees the tls_hs object as soon as
the client ACKs the 'handshake_done' frame sent by the server.
Technically, the server can free it as soon as it sends it.  This
can be optimized in a future patch.

Changes:
- Move 'handshake_{complete,done_send,done_ackd},hs_data_empty'
  into a bit field
- Set 'conn->handshake_done_ackd' when a handshake_done frame is
  ACKed by the client (previously, this flag was always 0)
- Document APIs that accept a NULL tls_hs object
- Remove unused function 'fd_quic_handshake_complete'
