### PR TITLE
ledger: increase parallelism and specify directory

### DIFF
--- a/.github/workflows/ledgers.yml
+++ b/.github/workflows/ledgers.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: ./.github/actions/deps
       - uses: ./.github/actions/hugepages
         with:
-          count_gigantic: 300
+          count_gigantic: 310
           count_huge: 1000 # TODO: this is required until we can handle anonymouse workspaces and loose huge pages in fddev
 
       - name: build
@@ -43,7 +43,7 @@ jobs:
         run: |
           sudo prlimit --pid=$$ --nofile=1048576
           sudo prlimit --pid=$$ --memlock=unlimited
-          make run-runtime-test
+          DUMP_DIR=../dump make run-runtime-test
 
       - name: Merge coverage reports
         if: ${{ inputs.coverage }}

--- a/src/flamenco/runtime/tests/run_ledger_tests_all.py
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.py
@@ -4,7 +4,7 @@ import multiprocessing
 from multiprocessing import Queue, Value, Event
 
 
-def group_cpus(batch_size=16):
+def group_cpus_by_batch_size(batch_size=8):
     import os
     # Get the number of available CPUs
     num_cpus = os.cpu_count()
@@ -14,6 +14,21 @@ def group_cpus(batch_size=16):
     batches = [list(range(i, min(i + batch_size, num_cpus))) for i in range(0, num_cpus, batch_size)]
     return batches
 
+def group_cpus_by_num_batches(num_batches=4):
+    import os
+    # Get the number of available CPUs
+    num_cpus = os.cpu_count()
+    print(f"Total CPUs available: {num_cpus}")
+    batch_size = num_cpus//num_batches
+    print(f"Batch size: {batch_size}")
+
+    # Create batches of CPUs
+    batches = [list(range(i, min(i + batch_size, num_cpus))) for i in range(0, num_cpus, batch_size)]
+    # if we had some extras, add them to the last batch
+    if num_cpus%batch_size != 0:
+        batches[-2].extend(batches[-1])
+        batches.pop()
+    return batches
 
 def worker(command_queue, available_params, error_occurred, error_event):
     while not error_event.is_set():
@@ -39,7 +54,7 @@ def worker(command_queue, available_params, error_occurred, error_event):
 
 
 def main(file_path):
-    cpu_batches = group_cpus()
+    cpu_batches = group_cpus_by_num_batches(num_batches=4)
     print("CPU Batches:", cpu_batches)
     # Define parameter ranges
     parameter_ranges = [ f'--tile-cpus {b[0]}-{b[-1]}' for b in cpu_batches ]


### PR DESCRIPTION
* The max pages that can be used for a test (given the current list in `run_ledger_tests_all.txt`) is 45+32=77 and if we run 4 of them in parallel, we need a total page count of 308, hence bumped the limit in the action
* If we add a high core count box with the same memory, it would try to schedule many parallel runs and might fail to allocate memory, hence introduced the function to set the number of batches getting executed and defaulted to 4
* Set the dump dir outside the repository directory in CI so that we can save a minute by not having to re-download the ledgers