### PR TITLE
alut_error_mask: Fix alut error mask bug

### DIFF
--- a/src/flamenco/runtime/program/fd_address_lookup_table_program.c
+++ b/src/flamenco/runtime/program/fd_address_lookup_table_program.c
@@ -342,7 +342,7 @@ create_lookup_table( fd_exec_instr_ctx_t *       ctx,
         signers_cnt
       );
       if ( err != 0 ) {
-        return FD_EXECUTOR_INSTR_ERR_GENERIC_ERR;
+        return err;
       }
     } FD_SCRATCH_SCOPE_END;
   }


### PR DESCRIPTION

address lookup table was masking out the returned error code