### PR TITLE
Fix QUIC RX stream size limits

### DIFF
--- a/src/app/fdctl/run/tiles/fd_quic.c
+++ b/src/app/fdctl/run/tiles/fd_quic.c
@@ -604,7 +604,7 @@ unprivileged_init( fd_topo_t *      topo,
   quic->config.net.ip_addr                = tile->quic.ip_addr;
   quic->config.net.listen_udp_port        = tile->quic.quic_transaction_listen_port;
   quic->config.idle_timeout               = tile->quic.idle_timeout_millis * 1000000UL;
-  quic->config.initial_rx_max_stream_data = 1<<15;
+  quic->config.initial_rx_max_stream_data = FD_TXN_MTU;
   quic->config.retry                      = tile->quic.retry;
   fd_memcpy( quic->config.link.src_mac_addr, tile->quic.src_mac_addr, 6 );
   fd_memcpy( quic->config.identity_public_key, ctx->identity_public_key, 32UL );

--- a/src/app/fddev/tiles/fd_benchs.c
+++ b/src/app/fddev/tiles/fd_benchs.c
@@ -308,7 +308,7 @@ populate_quic_config( fd_quic_config_t * config ) {
   config->service_interval = (ulong)1e6;
   config->ping_interval = (ulong)1e6;
   config->retry = 0;
-  config->initial_rx_max_stream_data = 1<<12;
+  config->initial_rx_max_stream_data = 0; /* we don't expect the server to initiate streams */
 
   config->net.ephem_udp_port.lo = 12000;
   config->net.ephem_udp_port.hi = 12100;
@@ -590,7 +590,7 @@ unprivileged_init( fd_topo_t *      topo,
     quic->config.net.ip_addr                = quic_ip_addr;
     quic->config.net.listen_udp_port        = 42424; /* should be unused */
     quic->config.idle_timeout               = quic_idle_timeout_millis * 1000000UL;
-    quic->config.initial_rx_max_stream_data = 1<<15;
+    quic->config.initial_rx_max_stream_data = 0;
     quic->config.retry                      = 0; /* unused on clients */
     fd_memcpy( quic->config.link.src_mac_addr, quic_src_mac_addr, 6 );
 

--- a/src/app/fddev/txn.c
+++ b/src/app/fddev/txn.c
@@ -186,9 +186,8 @@ txn_cmd_fn( args_t *         args,
   client_cfg->net.ip_addr           = udpsock->listen_ip;
   client_cfg->net.ephem_udp_port.lo = (ushort)udpsock->listen_port;
   client_cfg->net.ephem_udp_port.hi = (ushort)(udpsock->listen_port + 1);
-  client_cfg->initial_rx_max_stream_data = 1<<15;
   client_cfg->idle_timeout = 200UL * 1000UL * 1000UL; /* 5000 millis */
-  client_cfg->initial_rx_max_stream_data = FD_QUIC_DEFAULT_INITIAL_RX_MAX_STREAM_DATA;
+  client_cfg->initial_rx_max_stream_data = 0; /* doesn't receive */
 
   fd_aio_pkt_info_t pkt[ MAX_TXN_COUNT ];
 

--- a/src/waltz/quic/tests/fd_quic_test_helpers.c
+++ b/src/waltz/quic/tests/fd_quic_test_helpers.c
@@ -8,6 +8,7 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include "../../../ballet/ed25519/fd_ed25519.h"
+#include "../../../ballet/txn/fd_txn.h" /* FD_TXN_MTU */
 #include "../../../util/net/fd_eth.h"
 #include "../../../util/net/fd_ip4.h"
 
@@ -137,6 +138,7 @@ fd_quic_config_anonymous( fd_quic_t * quic,
   /* Default settings */
   config->idle_timeout     = (ulong)200e6; /* 200ms */
   config->service_interval = (ulong) 10e6; /*  10ms */
+  config->initial_rx_max_stream_data = FD_TXN_MTU;
   strcpy( config->sni, "local" );
 
   /* Default callbacks */


### PR DESCRIPTION
- Reduce TPU/QUIC stream limit to FD_TXN_MTU
- Fixes empty stream size limit in anonymous QUIC test instances
- Set RX stream limit to 0 for 'fddev txn' and 'benchs'
  (These tiles only send)

Closes https://github.com/firedancer-io/firedancer/issues/2456
