### PR TITLE
quic: validate Retry Integrity tags client-side

### DIFF
--- a/src/waltz/quic/crypto/fd_quic_crypto_suites.c
+++ b/src/waltz/quic/crypto/fd_quic_crypto_suites.c
@@ -782,6 +782,6 @@ int fd_quic_retry_integrity_tag_decrypt(
 ) {
   fd_aes_gcm_t gcm[1];
   fd_aes_128_gcm_init( gcm, FD_QUIC_RETRY_INTEGRITY_TAG_KEY, FD_QUIC_RETRY_INTEGRITY_TAG_NONCE );
-  fd_aes_gcm_aead_decrypt( gcm, NULL, NULL, 0UL, retry_pseudo_pkt, (ulong)retry_pseudo_pkt_len, retry_integrity_tag );
-  return FD_QUIC_SUCCESS;
+  int ok = fd_aes_gcm_aead_decrypt( gcm, NULL, NULL, 0UL, retry_pseudo_pkt, (ulong)retry_pseudo_pkt_len, retry_integrity_tag );
+  return ok ? FD_QUIC_SUCCESS : FD_QUIC_FAILED;
 }

--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -2020,8 +2020,8 @@ fd_quic_handle_v1_retry(
   /* Clients MUST discard Retry packets that have a Retry Integrity Tag that
      cannot be validated */
 
-  if ( FD_UNLIKELY( rc == FD_QUIC_FAILED ) ) {
-    return cur_sz;  // FIXME hack to drop packet
+  if( FD_UNLIKELY( rc == FD_QUIC_FAILED ) ) {
+    return FD_QUIC_PARSE_FAIL;
   }
 
   /* Update the peer using the retry src conn id */


### PR DESCRIPTION
The fd_quic client does all the necessary computatations to verify
a QUIC Retry Integrity Tag (RFC 9001).  But it ignores the result.
This was probably not a problem, but this patch updates the retry
handling logic to validate tags as recommended by the spec.  This
improves resiliency against connection tampering attempts by
unauthenticated attackers.
