### PR TITLE
quic: benchmark retry handling

### DIFF
--- a/src/waltz/quic/Local.mk
+++ b/src/waltz/quic/Local.mk
@@ -18,6 +18,8 @@ $(call add-objs,fd_quic_pkt_meta,fd_quic)
 $(call add-hdrs,fd_quic_proto.h fd_quic_proto_structs.h fd_quic_types.h)
 $(call add-objs,fd_quic_proto,fd_quic)
 
+$(call add-hdrs,fd_quic_retry.h)
+
 $(call add-hdrs,fd_quic_stream_pool.h)
 $(call add-objs,fd_quic_stream_pool,fd_quic)
 

--- a/src/waltz/quic/crypto/fd_quic_crypto_suites.c
+++ b/src/waltz/quic/crypto/fd_quic_crypto_suites.c
@@ -764,24 +764,25 @@ int fd_quic_retry_token_decrypt(
   return FD_QUIC_SUCCESS;
 }
 
-int fd_quic_retry_integrity_tag_encrypt(
+void
+fd_quic_retry_integrity_tag_encrypt(
     uchar * retry_pseudo_pkt,
-    int     retry_pseudo_pkt_len,
+    ulong   retry_pseudo_pkt_len,
     uchar   retry_integrity_tag[static FD_QUIC_RETRY_INTEGRITY_TAG_SZ]
 ) {
   fd_aes_gcm_t gcm[1];
   fd_aes_128_gcm_init( gcm, FD_QUIC_RETRY_INTEGRITY_TAG_KEY, FD_QUIC_RETRY_INTEGRITY_TAG_NONCE );
-  fd_aes_gcm_aead_encrypt( gcm, NULL, NULL, 0UL, retry_pseudo_pkt, (ulong)retry_pseudo_pkt_len, retry_integrity_tag );
-  return FD_QUIC_SUCCESS;
+  fd_aes_gcm_aead_encrypt( gcm, NULL, NULL, 0UL, retry_pseudo_pkt, retry_pseudo_pkt_len, retry_integrity_tag );
 }
 
-int fd_quic_retry_integrity_tag_decrypt(
-    uchar * retry_pseudo_pkt,
-    int     retry_pseudo_pkt_len,
-    uchar   retry_integrity_tag[static FD_QUIC_RETRY_INTEGRITY_TAG_SZ]
+int
+fd_quic_retry_integrity_tag_decrypt(
+    uchar *     retry_pseudo_pkt,
+    ulong       retry_pseudo_pkt_len,
+    uchar const retry_integrity_tag[static FD_QUIC_RETRY_INTEGRITY_TAG_SZ]
 ) {
   fd_aes_gcm_t gcm[1];
   fd_aes_128_gcm_init( gcm, FD_QUIC_RETRY_INTEGRITY_TAG_KEY, FD_QUIC_RETRY_INTEGRITY_TAG_NONCE );
-  int ok = fd_aes_gcm_aead_decrypt( gcm, NULL, NULL, 0UL, retry_pseudo_pkt, (ulong)retry_pseudo_pkt_len, retry_integrity_tag );
+  int ok = fd_aes_gcm_aead_decrypt( gcm, NULL, NULL, 0UL, retry_pseudo_pkt, retry_pseudo_pkt_len, retry_integrity_tag );
   return ok ? FD_QUIC_SUCCESS : FD_QUIC_FAILED;
 }

--- a/src/waltz/quic/crypto/fd_quic_crypto_suites.h
+++ b/src/waltz/quic/crypto/fd_quic_crypto_suites.h
@@ -526,16 +526,4 @@ fd_quic_retry_token_decrypt(
     ulong *             now
 );
 
-int fd_quic_retry_integrity_tag_encrypt(
-    uchar * retry_pseudo_pkt,
-    int     retry_pseudo_pkt_len,
-    uchar   retry_integrity_tag[static FD_QUIC_RETRY_INTEGRITY_TAG_SZ]
-);
-
-int fd_quic_retry_integrity_tag_decrypt(
-    uchar * retry_pseudo_pkt,
-    int     retry_pseudo_pkt_len,
-    uchar   retry_integrity_tag[static FD_QUIC_RETRY_INTEGRITY_TAG_SZ]
-);
-
 #endif /* HEADER_fd_src_waltz_quic_crypto_fd_quic_crypto_suites_h */

--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -5,6 +5,7 @@
 #include "fd_quic_conn.h"
 #include "fd_quic_conn_map.h"
 #include "fd_quic_proto.h"
+#include "fd_quic_retry.h"
 
 #include "templ/fd_quic_frame_handler_decl.h"
 #include "templ/fd_quic_frames_templ.h"
@@ -1273,7 +1274,7 @@ fd_quic_send_retry( fd_quic_t *                  quic,
     return FD_QUIC_PARSE_FAIL;
   }
   fd_quic_encode_retry_pseudo( retry_pseudo_buf, retry_pseudo_footprint, &retry_pseudo_pkt );
-  fd_quic_retry_integrity_tag_encrypt( retry_pseudo_buf, (int) retry_pseudo_footprint, retry_pkt.retry_integrity_tag );
+  fd_quic_retry_integrity_tag_encrypt( retry_pseudo_buf, retry_pseudo_footprint, retry_pkt.retry_integrity_tag );
 
   ulong tx_buf_sz = fd_quic_encode_footprint_retry( &retry_pkt );
   uchar tx_buf[tx_buf_sz];
@@ -2014,7 +2015,7 @@ fd_quic_handle_v1_retry(
      corrupted by the network, and only an entity that observes an Initial packet can send a valid
      Retry packet.*/
   int rc = fd_quic_retry_integrity_tag_decrypt(
-      retry_pseudo_buf, (int)retry_pseudo_footprint, retry_pkt.retry_integrity_tag
+      retry_pseudo_buf, retry_pseudo_footprint, retry_pkt.retry_integrity_tag
   );
 
   /* Clients MUST discard Retry packets that have a Retry Integrity Tag that

--- a/src/waltz/quic/fd_quic_retry.h
+++ b/src/waltz/quic/fd_quic_retry.h
@@ -1,0 +1,50 @@
+#ifndef HEADER_fd_src_waltz_quic_fd_quic_retry_h
+#define HEADER_fd_src_waltz_quic_fd_quic_retry_h
+
+#include "crypto/fd_quic_crypto_suites.h"
+
+/* fd_quic_retry.h contains APIs for
+   - the QUIC-TLS v1 Retry Integrity Tag (RFC 9001) */
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_quic_retry_integrity_tag_{encrypt,decrypt} implement the RFC 9001
+   "Retry Integrity Tag" AEAD scheme.
+
+   This is a standard and mandatory step in the QUIC retry proces, both
+   on the server (encrypt) and client side.  Confusingly, all inputs to
+   these functions are either public constants (e.g. the hardcoded
+   encryption key) or sent in plain text over the wire.  Thus, the
+   "retry_integrity_tag" is more like a hash function than a MAC and the
+   retry_pseudo_pkt is just obfuscated, but not securely encrypted.
+
+   Failure to generate a correct integrity tag as part of the retry
+   handshake is considered a protocol error that typically results in
+   connection termination.
+
+   The fd_quic_retry_integrity_tag_encrypt function "encrypts" the byte
+   range at retry_pseudo_pkt_sz and sets retry_integrity_tag.  It is
+   infallible.
+
+   The fd_quic_retry_integrity_tag_decrypt attempts to "decrypt" the
+   byte range at retry_pseudo_pkt_sz.  It returns FD_QUIC_SUCCESS if the
+   integrity tag seemed correct, and FD_QUIC_FAILURE otherwise.  On
+   failure, the contents of retry_pseudo_pkt are undefined. */
+
+void
+fd_quic_retry_integrity_tag_encrypt(
+    uchar * retry_pseudo_pkt,
+    ulong   retry_pseudo_pkt_sz,
+    uchar   retry_integrity_tag[static FD_QUIC_RETRY_INTEGRITY_TAG_SZ]
+);
+
+int
+fd_quic_retry_integrity_tag_decrypt(
+    uchar *     retry_pseudo_pkt,
+    ulong       retry_pseudo_pkt_sz,
+    uchar const retry_integrity_tag[static FD_QUIC_RETRY_INTEGRITY_TAG_SZ]
+);
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_waltz_quic_fd_quic_retry_h */


### PR DESCRIPTION
- Clean up and document fd_quic_retry_integrity_tag_{encrypt,decrypt}
- Add a simple benchmark
