### PR TITLE
book: fix ethtool-gro.ansi

### DIFF
--- a/book/snippets/ethtool-gro.ansi
+++ b/book/snippets/ethtool-gro.ansi
@@ -4,4 +4,4 @@ $ sudo fdctl configure init ethtool-gro
 [32mNOTICE [0m ethtool-gro ... RUN: `ethtool --offload ens3f0 generic-receive-offload off`
 
 $ ethtool --show-offload ens3f0 | grep generic-receive-offload
-[01;31m[Kgeneric-receive-offload[m[K: off
+generic-receive-offload: off


### PR DESCRIPTION
The embedded ansi codes were causing `bun run build` to hang