### PR TITLE
flamenco, fuzz: Fuzz VM CPI syscalls

### DIFF
--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -489,7 +489,7 @@ dump_sorted_features( const fd_features_t * features, fd_exec_test_feature_set_t
 }
 
 static void
-dump_account_state( fd_borrowed_account_t * borrowed_account,
+dump_account_state( fd_borrowed_account_t const * borrowed_account,
                       fd_exec_test_acct_state_t * output_account ) {
     // Address
     fd_memcpy(output_account->address, borrowed_account->pubkey, sizeof(fd_pubkey_t));
@@ -515,10 +515,10 @@ dump_account_state( fd_borrowed_account_t * borrowed_account,
     output_account->has_seed_addr = false;
 }
 
-static void
-create_instr_context_protobuf_from_instructions( fd_exec_test_instr_context_t * instr_context,
-                                                 fd_exec_txn_ctx_t *txn_ctx,
-                                                 fd_instr_info_t *instr ) {
+void
+fd_create_instr_context_protobuf_from_instructions( fd_exec_test_instr_context_t * instr_context,
+                                                 fd_exec_txn_ctx_t const *txn_ctx,
+                                                 fd_instr_info_t const *instr ) {
   /*
   NOTE: Calling this function requires the caller to have a scratch frame ready (see dump_instr_to_protobuf)
   */
@@ -546,7 +546,7 @@ create_instr_context_protobuf_from_instructions( fd_exec_test_instr_context_t * 
   instr_context->accounts = fd_scratch_alloc(alignof(fd_exec_test_acct_state_t), (instr_context->accounts_count + num_sysvar_entries + txn_ctx->executable_cnt) * sizeof(fd_exec_test_acct_state_t));
   for( ulong i = 0; i < txn_ctx->accounts_cnt; i++ ) {
     // Copy account information over
-    fd_borrowed_account_t * borrowed_account = &txn_ctx->borrowed_accounts[i];
+    fd_borrowed_account_t const * borrowed_account = &txn_ctx->borrowed_accounts[i];
     fd_exec_test_acct_state_t * output_account = &instr_context->accounts[i];
     dump_account_state( borrowed_account, output_account );
   }
@@ -670,7 +670,7 @@ dump_instr_to_protobuf( fd_exec_txn_ctx_t *txn_ctx,
     }
 
     fd_exec_test_instr_context_t instr_context = FD_EXEC_TEST_INSTR_CONTEXT_INIT_DEFAULT;
-    create_instr_context_protobuf_from_instructions( &instr_context, txn_ctx, instr );
+    fd_create_instr_context_protobuf_from_instructions( &instr_context, txn_ctx, instr );
 
     /* Output to file */
     ulong out_buf_size = 100 * 1024 * 1024;

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -13,6 +13,16 @@
 
 FD_PROTOTYPES_BEGIN
 
+/* Create an InstrContext protobuf struct from a given 
+   transaction context and instr info. 
+
+   NOTE: Calling this function requires the caller to have a scratch 
+   frame ready and pushed (see dump_instr_to_protobuf) */
+void
+fd_create_instr_context_protobuf_from_instructions( fd_exec_test_instr_context_t       * instr_context,
+                                                    fd_exec_txn_ctx_t            const * txn_ctx,
+                                                    fd_instr_info_t              const * instr );
+
 /* fd_exec_instr_fn_t processes an instruction.  Returns an error code
    in FD_EXECUTOR_INSTR_{ERR_{...},SUCCESS}. */
 

--- a/src/flamenco/runtime/tests/test_exec_sol_compat.c
+++ b/src/flamenco/runtime/tests/test_exec_sol_compat.c
@@ -64,10 +64,7 @@ main( int     argc,
     // Init runner
     fd_exec_instr_test_runner_t * runner = sol_compat_setup_scratch_and_runner( fmem );
 
-    FD_TEST( fd_scratch_frame_used()==0UL );
-    fd_scratch_push();
     fail_cnt += !run_test( runner, argv[j] );
-    fd_scratch_pop();
  
     // Free runner
     sol_compat_cleanup_scratch_and_runner( runner );

--- a/src/flamenco/vm/fd_vm_base.h
+++ b/src/flamenco/vm/fd_vm_base.h
@@ -79,6 +79,16 @@
 #define FD_VM_SH_OVERFLOW           (-37) /* detected a shift overflow, equivalent to VeriferError::ShiftWithOverflow */
 #define FD_VM_TEXT_SZ_UNALIGNED     (-38) /* detected a text section that is not a multiple of 8 */
 
+/* Error codes related to CPI syscall.
+   FIXME: Should this be in fd_executor_err.h instead?
+          Or a separate file for syscall errors? */
+
+#define FD_VM_CPI_ERR_TOO_MANY_SIGNERS       (-39) /* detected too many signers */
+#define FD_VM_CPI_ERR_TOO_MANY_ACC_INFOS     (-40) /* detected too many account infos */
+#define FD_VM_CPI_ERR_INSTR_TOO_LARGE        (-41) /* detected too many account infos meta */
+#define FD_VM_CPI_ERR_INSTR_DATA_TOO_LARGE   (-42) /* detected instruction data too large */
+#define FD_VM_CPI_ERR_TOO_MANY_ACC_METAS     (-43) /* detected too many account metas */
+
 FD_PROTOTYPES_BEGIN
 
 /* fd_vm_strerror converts an FD_VM_SUCCESS / FD_VM_ERR_* code into

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
@@ -4,6 +4,130 @@
 #include "../../runtime/fd_account.h"
 #include "../../runtime/fd_executor.h"
 #include "../../runtime/fd_account_old.h" /* FIXME: remove this and update to use new APIs */
+#include <stdio.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <errno.h>
+#include "../../nanopb/pb_encode.h"
+#include "../../runtime/tests/generated/vm.pb.h"
+#include "../../runtime/tests/fd_exec_instr_test.h"
+
+#define STRINGIFY(x) TOSTRING(x)
+#define TOSTRING(x) #x
+
+/* Captures the state of the VM (including the instruction context).
+   Meant to be invoked at the start of the VM_SYSCALL_CPI_ENTRYPOINT like so:
+   
+  ```
+   dump_vm_cpi_state(vm, STRINGIFY(FD_EXPAND_THEN_CONCAT2(sol_invoke_signed_, VM_SYSCALL_CPI_ABI)), 
+                     instruction_va, acct_infos_va, acct_info_cnt, signers_seeds_va, signers_seeds_cnt);
+  ```
+
+  Assumes that a `vm_cp_state` directory exists in the current working directory. Generates a
+  unique dump for combination of (tile_id, caller_pubkey, instr_sz). */
+
+static FD_FN_UNUSED void
+dump_vm_cpi_state(fd_vm_t *vm,
+                  char const * fn_name,
+                  ulong   instruction_va,
+                  ulong   acct_infos_va,
+                  ulong   acct_info_cnt,
+                  ulong   signers_seeds_va,
+                  ulong   signers_seeds_cnt ) {
+  char filename[100];
+  fd_instr_info_t const *instr = vm->instr_ctx->instr;
+  sprintf(filename, "vm_cpi_state/%lu_%lu%lu_%lu.sysctx", fd_tile_id(), instr->program_id_pubkey.ul[0], instr->program_id_pubkey.ul[1], instr->data_sz);
+
+  // Check if file exists
+  if( access (filename, F_OK) != -1 ) {
+    return;
+  }
+
+  fd_exec_test_syscall_context_t sys_ctx = FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_ZERO;
+  sys_ctx.has_instr_ctx = true;
+  sys_ctx.has_vm_ctx = true;
+  sys_ctx.has_syscall_invocation = true;
+
+  // Copy function name
+  sys_ctx.syscall_invocation.function_name.size = fd_uint_min( (uint) strlen(fn_name), sizeof(sys_ctx.syscall_invocation.function_name.bytes) );
+  fd_memcpy( sys_ctx.syscall_invocation.function_name.bytes,
+             fn_name,
+             sys_ctx.syscall_invocation.function_name.size );
+
+  // VM Ctx integral fields
+  sys_ctx.vm_ctx.r1 = instruction_va;
+  sys_ctx.vm_ctx.r2 = acct_infos_va;
+  sys_ctx.vm_ctx.r3 = acct_info_cnt;
+  sys_ctx.vm_ctx.r4 = signers_seeds_va;
+  sys_ctx.vm_ctx.r5 = signers_seeds_cnt;
+
+  sys_ctx.vm_ctx.rodata_text_section_length = vm->text_sz;
+  sys_ctx.vm_ctx.rodata_text_section_offset = vm->text_off;
+
+  sys_ctx.vm_ctx.heap_max = vm->heap_max; /* should be equiv. to txn_ctx->heap_sz */
+
+  FD_SCRATCH_SCOPE_BEGIN{
+    sys_ctx.vm_ctx.rodata = fd_scratch_alloc( 8UL, PB_BYTES_ARRAY_T_ALLOCSIZE(vm->rodata_sz) );
+    sys_ctx.vm_ctx.rodata->size = (pb_size_t) vm->rodata_sz;
+    fd_memcpy( sys_ctx.vm_ctx.rodata->bytes, vm->rodata, vm->rodata_sz );
+
+    pb_size_t stack_sz = (pb_size_t) ( (vm->frame_cnt + 1)*FD_VM_STACK_GUARD_SZ*2 );
+    sys_ctx.syscall_invocation.stack_prefix = fd_scratch_alloc( 8UL, PB_BYTES_ARRAY_T_ALLOCSIZE(stack_sz) );
+    sys_ctx.syscall_invocation.stack_prefix->size = stack_sz;
+    fd_memcpy( sys_ctx.syscall_invocation.stack_prefix->bytes, vm->stack, stack_sz );
+    
+    sys_ctx.syscall_invocation.heap_prefix = fd_scratch_alloc( 8UL, PB_BYTES_ARRAY_T_ALLOCSIZE(vm->heap_max) );
+    sys_ctx.syscall_invocation.heap_prefix->size = (pb_size_t) vm->instr_ctx->txn_ctx->heap_size;
+    fd_memcpy( sys_ctx.syscall_invocation.heap_prefix->bytes, vm->heap, vm->instr_ctx->txn_ctx->heap_size );
+
+    sys_ctx.vm_ctx.input_data_regions_count = vm->input_mem_regions_cnt;
+    sys_ctx.vm_ctx.input_data_regions = fd_scratch_alloc( 8UL, sizeof(fd_exec_test_input_data_region_t) * vm->input_mem_regions_cnt );
+    for( ulong i=0UL; i<vm->input_mem_regions_cnt; i++ ) {
+      sys_ctx.vm_ctx.input_data_regions[i].content = fd_scratch_alloc( 8UL, PB_BYTES_ARRAY_T_ALLOCSIZE(vm->input_mem_regions[i].region_sz) );
+      sys_ctx.vm_ctx.input_data_regions[i].content->size = (pb_size_t) vm->input_mem_regions[i].region_sz;
+      fd_memcpy( sys_ctx.vm_ctx.input_data_regions[i].content->bytes, (uchar *) vm->input_mem_regions[i].haddr, vm->input_mem_regions[i].region_sz );
+      sys_ctx.vm_ctx.input_data_regions[i].offset = vm->input_mem_regions[i].vaddr_offset;
+      sys_ctx.vm_ctx.input_data_regions[i].is_writable = vm->input_mem_regions[i].is_writable;
+    }
+  
+    fd_create_instr_context_protobuf_from_instructions( &sys_ctx.instr_ctx, 
+                                                        vm->instr_ctx->txn_ctx,
+                                                        vm->instr_ctx->instr );
+
+    // Serialize the protobuf to file (using mmap)
+    size_t pb_alloc_size = 100 * 1024 * 1024; // 100MB (largest so far is 19MB)
+    FILE *f = fopen(filename, "wb+");
+    if( ftruncate(fileno(f), (off_t) pb_alloc_size) != 0 ) {
+      FD_LOG_WARNING(("Failed to resize file %s", filename));
+      fclose(f);
+      return;
+    }
+
+    uchar *pb_alloc = mmap( NULL, 
+                            pb_alloc_size, 
+                            PROT_READ | PROT_WRITE, 
+                            MAP_SHARED, 
+                            fileno(f), 
+                            0 /* offset */);
+    if( pb_alloc == MAP_FAILED ) {
+      FD_LOG_WARNING(( "Failed to mmap file %d", errno ));
+      fclose(f);
+      return;
+    }
+
+    pb_ostream_t stream = pb_ostream_from_buffer(pb_alloc, pb_alloc_size);
+    if( !pb_encode( &stream, FD_EXEC_TEST_SYSCALL_CONTEXT_FIELDS, &sys_ctx ) ) {
+      FD_LOG_WARNING(( "Failed to encode instruction context" ));
+    }
+    // resize file to actual size
+    if( ftruncate( fileno(f), (off_t) stream.bytes_written ) != 0 ) {
+      FD_LOG_WARNING(( "Failed to resize file %s", filename ));
+    }
+
+    fclose(f);
+
+  } FD_SCRATCH_SCOPE_END;
+}
 
 /* FIXME: ALGO EFFICIENCY */
 static inline int
@@ -266,7 +390,7 @@ fd_vm_syscall_cpi_preflight_check( ulong signers_seeds_cnt,
   if( FD_UNLIKELY( signers_seeds_cnt > FD_CPI_MAX_SIGNER_CNT ) ) {
     // TODO: return SyscallError::TooManySigners
     FD_LOG_WARNING(("TODO: return too many signers" ));
-    return FD_VM_ERR_INVAL;
+    return FD_VM_CPI_ERR_TOO_MANY_SIGNERS;
   }
 
   /* https://github.com/solana-labs/solana/blob/eb35a5ac1e7b6abe81947e22417f34508f89f091/programs/bpf_loader/src/syscalls/cpi.rs#L996-L997 */
@@ -274,7 +398,7 @@ fd_vm_syscall_cpi_preflight_check( ulong signers_seeds_cnt,
     if( FD_UNLIKELY( acct_info_cnt > FD_CPI_MAX_ACCOUNT_INFOS  ) ) {
       // TODO: return SyscallError::MaxInstructionAccountInfosExceeded
       FD_LOG_WARNING(( "TODO: return max instruction account infos exceeded" ));
-      return FD_VM_ERR_INVAL;
+      return FD_VM_CPI_ERR_TOO_MANY_ACC_INFOS;
     }
   } else {
     ulong adjusted_len = fd_ulong_sat_mul( acct_info_cnt, sizeof( fd_pubkey_t ) );
@@ -282,7 +406,8 @@ fd_vm_syscall_cpi_preflight_check( ulong signers_seeds_cnt,
       /* Cap the number of account_infos a caller can pass to approximate
          maximum that accounts that could be passed in an instruction
          TODO: return SyscallError::TooManyAccounts */
-      return FD_VM_ERR_INVAL;
+      FD_LOG_WARNING(( "TODO: return max instruction account infos exceeded" ));
+      return FD_VM_CPI_ERR_TOO_MANY_ACC_INFOS;
     }
   }
 
@@ -302,12 +427,12 @@ fd_vm_syscall_cpi_check_instruction( fd_vm_t const * vm,
     if( FD_UNLIKELY( data_sz > FD_CPI_MAX_INSTRUCTION_DATA_LEN ) ) {
       FD_LOG_WARNING(( "cpi: data too long (%#lx)", data_sz ));
       // SyscallError::MaxInstructionDataLenExceeded
-      return FD_VM_ERR_INVAL;
+      return FD_VM_CPI_ERR_INSTR_DATA_TOO_LARGE;
     }
     if( FD_UNLIKELY( acct_cnt > FD_CPI_MAX_INSTRUCTION_ACCOUNTS ) ) {
       FD_LOG_WARNING(( "cpi: too many accounts (%#lx)", acct_cnt ));
       // SyscallError::MaxInstructionAccountsExceeded
-      return FD_VM_ERR_INVAL;
+      return FD_VM_CPI_ERR_TOO_MANY_ACC_METAS;
     }
   } else {
     // https://github.com/solana-labs/solana/blob/dbf06e258ae418097049e845035d7d5502fe1327/programs/bpf_loader/src/syscalls/cpi.rs#L1114
@@ -315,7 +440,7 @@ fd_vm_syscall_cpi_check_instruction( fd_vm_t const * vm,
     if ( FD_UNLIKELY( tot_sz > FD_VM_MAX_CPI_INSTRUCTION_SIZE ) ) {
       FD_LOG_WARNING(( "cpi: instruction too long (%#lx)", tot_sz ));
       // SyscallError::InstructionTooLarge
-      return FD_VM_ERR_INVAL;
+      return FD_VM_CPI_ERR_INSTR_TOO_LARGE;
     }
   }
 


### PR DESCRIPTION
~~Introduces a "stubbed" version of `libfd_exec_sol_compat` that wraps around `fd_execute_instr` for CPI syscall fuzzing.~~

Supporting CPI syscalls implements the following:
- Performing a full `_instr_context_create` (i.e, `is_syscall = false`) specifically for CPI calls 
- Summing up account lamports during `_instr_context_create`
- Capturing of data from input_data_regions into SyscallEffects
- Tool to dump `SyscallContext` at CPI entrypoint

Further cleanup:
- Fixed scratch frame mismanagement, particularly use-after-free when writing to output buffer
