### PR TITLE
match sol_log_64 output

### DIFF
--- a/src/flamenco/vm/syscall/fd_vm_syscall_util.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_util.c
@@ -101,7 +101,8 @@ fd_vm_syscall_sol_log_64( void *  _vm,
   ulong  msg_max = fd_vm_log_prepare_max( vm );
   ulong  msg_len;
 
-  fd_cstr_printf( msg, msg_max, &msg_len, "Program log: %lx %lx %lx %lx %lx", r1, r2, r3, r4, r5 );
+  fd_cstr_printf( msg, msg_max, &msg_len, "Program log: 0x%lx, 0x%lx, 0x%lx, 0x%lx, 0x%lx",
+                  r1, r2, r3, r4, r5 );
 
   fd_vm_log_publish( vm, msg_len );
 

--- a/src/flamenco/vm/syscall/test_vm_syscalls.c
+++ b/src/flamenco/vm/syscall/test_vm_syscalls.c
@@ -416,7 +416,8 @@ main( int     argc,
   ulong r3 = fd_rng_ulong(rng);
   ulong r4 = fd_rng_ulong(rng);
   char  msg[1024];
-  ulong msg_len = (ulong)sprintf( msg, "Program log: %lx %lx %lx %lx %lx", r0, r1, r2, r3, r4 );
+  ulong msg_len = (ulong)sprintf( msg, "Program log: 0x%lx, 0x%lx, 0x%lx, 0x%lx, 0x%lx", r0, r1, r2, r3, r4 );
+
   APPEND( msg, msg_len );
   test_vm_syscall_sol_log_64( "test_vm_syscall_sol_log_64: log_64 at the heap region",
                               vm,


### PR DESCRIPTION
Currently, these are example logs from Firedancer and agave:

```
Program log: 5d724c44c0a108c8 ac246eae6b5f6c8a 7bd2aac7cd318b02 b8fb78d524538540 7a3034c712804303
Program log: 0x5d724c44c0a108c8, 0xac246eae6b5f6c8a, 0x7bd2aac7cd318b02, 0xb8fb78d524538540, 0x7a3034c712804303
```