### PR TITLE
add 'Program log: ' prefix to sol_log to match agave

### DIFF
--- a/src/flamenco/vm/syscall/fd_vm_syscall_util.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_util.c
@@ -68,7 +68,11 @@ fd_vm_syscall_sol_log( /**/            void *  _vm,
      return success? */
 
   FD_VM_CU_UPDATE( vm, fd_ulong_max( msg_sz, FD_VM_SYSCALL_BASE_COST ) );
-  fd_vm_log_append( vm, FD_VM_MEM_SLICE_HADDR_LD( vm, msg_vaddr, 1UL, msg_sz ), msg_sz );
+
+  /* https://github.com/anza-xyz/agave/blob/ba9bf247c312a7f5e309650f921d1e0e8e741fde/programs/bpf_loader/src/syscalls/logging.rs#L21-L30 */
+  const void * msg_content = FD_VM_MEM_SLICE_HADDR_LD( vm, msg_vaddr, 1UL, msg_sz );
+  fd_vm_log_append( vm, "Program log: ", 13UL );
+  fd_vm_log_append( vm, msg_content, msg_sz );
 
   *_ret = 0UL;
   return FD_VM_SUCCESS;

--- a/src/flamenco/vm/syscall/test_vm_syscalls.c
+++ b/src/flamenco/vm/syscall/test_vm_syscalls.c
@@ -368,7 +368,7 @@ main( int     argc,
 
   FD_TEST( fd_vm_log_reset( vm )==vm ); expected_log_sz = 0UL;
 
-  APPEND( "hello world", 11UL );
+  APPEND( "Program log: hello world", 24UL );
   memcpy( &vm->heap[0], "hello world", 11 );
   // test for collecting logs at the heap region
   test_vm_syscall_sol_log( "test_vm_syscall_sol_log: log at the heap region",
@@ -380,6 +380,7 @@ main( int     argc,
                            expected_log, expected_log_sz );
 
   // test for collecting logs at the read only region
+  APPEND( "Program log: ", 13UL );
   APPEND( &vm->rodata[0], 100UL );
   test_vm_syscall_sol_log( "test_vm_syscall_sol_log: log at the read only region",
                            vm,
@@ -390,6 +391,7 @@ main( int     argc,
                            expected_log, expected_log_sz );
 
   // test for writing logs that exceed the remaining space
+  APPEND( "Program log: ", 13UL );
   APPEND( &vm->heap[0], FD_VM_LOG_MAX );
   test_vm_syscall_sol_log( "test_vm_syscall_sol_log: log that exceeds the limit",
                            vm,


### PR DESCRIPTION
To quote from an agave doc comment:
> any program-generated output is guaranteed to be prefixed by "Program log: "

https://github.com/firedancer-io/solana/blob/a5c7c999e2060971d9369bde13e05247c9ddd415/program-runtime/src/stable_log.rs#L41