### PR TITLE
test-vectors: fix asan/ubsan complains

### DIFF
--- a/contrib/test/run_test_vectors.sh
+++ b/contrib/test/run_test_vectors.sh
@@ -31,16 +31,16 @@ LOG=$LOG_PATH/test_exec_syscall
 cat contrib/test/syscall-fixtures.list | xargs ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG
 
 LOG=$LOG_PATH/test_exec_precompiles
-cat contrib/test/precompile-fixtures.list | xargs  ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG
+cat contrib/test/precompile-fixtures.list | xargs ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG
 
 zstd -df dump/test-vectors/elf_loader/fixtures/*.zst
 LOG=$LOG_PATH/test_elf_loader
 cat contrib/test/elf-loader-fixtures.list | xargs ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG
 
 LOG=$LOG_PATH/test_exec_instr
-cat contrib/test/instr-fixtures.list | xargs ./$OBJDIR/unit-test/test_exec_instr --log-path $LOG --log-level-stderr 4
+cat contrib/test/instr-fixtures.list | xargs ./$OBJDIR/unit-test/test_exec_instr --log-path $LOG
 
 LOG=$LOG_PATH/test_vm_validate
-xargs -a contrib/test/vm_validate-fixtures.list ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG --log-level-stderr 4
+xargs -a contrib/test/vm_validate-fixtures.list ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG
 
 echo Test vectors success

--- a/src/ballet/ed25519/avx512/fd_f25519.h
+++ b/src/ballet/ed25519/avx512/fd_f25519.h
@@ -100,10 +100,10 @@ fd_f25519_mul_121666( fd_f25519_t * r,
 FD_25519_INLINE fd_f25519_t *
 fd_f25519_frombytes( fd_f25519_t * r,
                      uchar const   buf[ 32 ] ) {
-  ulong y0 = ((ulong *)buf)[0];                      /* Bits   0- 63 */
-  ulong y1 = ((ulong *)buf)[1];                      /* Bits  64-127 */
-  ulong y2 = ((ulong *)buf)[2];                      /* Bits 128-191 */
-  ulong y3 = ((ulong *)buf)[3] & 0x7fffffffffffffff; /* Bits 192-254 */
+  ulong y0 = fd_ulong_load_8_fast( buf );                         /* Bits   0- 63 */
+  ulong y1 = fd_ulong_load_8_fast( buf+8 );                       /* Bits  64-127 */
+  ulong y2 = fd_ulong_load_8_fast( buf+16 );                      /* Bits 128-191 */
+  ulong y3 = fd_ulong_load_8_fast( buf+24 ) & 0x7fffffffffffffff; /* Bits 192-254 */
   r->el = fd_r43x6_unpack( wv( y0, y1, y2, y3 ) );
   return r;
 }

--- a/src/ballet/ed25519/fd_curve25519_scalar.h
+++ b/src/ballet/ed25519/fd_curve25519_scalar.h
@@ -56,10 +56,10 @@ fd_curve25519_scalar_reduce( uchar       out[ 32 ],
 
 static inline uchar const *
 fd_curve25519_scalar_validate( uchar const s[ 32 ] ) {
-  ulong s0 = *(ulong *)(&s[  0 ]);
-  ulong s1 = *(ulong *)(&s[  8 ]);
-  ulong s2 = *(ulong *)(&s[ 16 ]);
-  ulong s3 = *(ulong *)(&s[ 24 ]);
+  ulong s0 = fd_ulong_load_8_fast( s      );
+  ulong s1 = fd_ulong_load_8_fast( s +  8 );
+  ulong s2 = fd_ulong_load_8_fast( s + 16 );
+  ulong s3 = fd_ulong_load_8_fast( s + 24 );
   ulong l0 = *(ulong *)(&fd_curve25519_scalar_minus_one[  0 ]);
   ulong l1 = *(ulong *)(&fd_curve25519_scalar_minus_one[  8 ]);
   ulong l2 = *(ulong *)(&fd_curve25519_scalar_minus_one[ 16 ]);

--- a/src/ballet/sha256/fd_sha256.c
+++ b/src/ballet/sha256/fd_sha256.c
@@ -349,16 +349,15 @@ fd_sha256_fini( fd_sha256_t * sha,
 
   /* Unpack the result into md (annoying bswaps here) */
 
-  uint * hash = (uint *)_hash;
-  hash[0] = fd_uint_bswap( state[0] );
-  hash[1] = fd_uint_bswap( state[1] );
-  hash[2] = fd_uint_bswap( state[2] );
-  hash[3] = fd_uint_bswap( state[3] );
-  hash[4] = fd_uint_bswap( state[4] );
-  hash[5] = fd_uint_bswap( state[5] );
-  hash[6] = fd_uint_bswap( state[6] );
-  hash[7] = fd_uint_bswap( state[7] );
-  return _hash;
+  state[0] = fd_uint_bswap( state[0] );
+  state[1] = fd_uint_bswap( state[1] );
+  state[2] = fd_uint_bswap( state[2] );
+  state[3] = fd_uint_bswap( state[3] );
+  state[4] = fd_uint_bswap( state[4] );
+  state[5] = fd_uint_bswap( state[5] );
+  state[6] = fd_uint_bswap( state[6] );
+  state[7] = fd_uint_bswap( state[7] );
+  return memcpy( _hash, state, 32 );
 }
 
 void *
@@ -401,16 +400,15 @@ fd_sha256_hash( void const * _data,
   FD_STORE( ulong, buf+FD_SHA256_PRIVATE_BUF_MAX-8UL, fd_ulong_bswap( bit_cnt ) );
   fd_sha256_core( state, buf, 1UL );
 
-  uint * hash = (uint *)_hash;
-  hash[0] = fd_uint_bswap( state[0] );
-  hash[1] = fd_uint_bswap( state[1] );
-  hash[2] = fd_uint_bswap( state[2] );
-  hash[3] = fd_uint_bswap( state[3] );
-  hash[4] = fd_uint_bswap( state[4] );
-  hash[5] = fd_uint_bswap( state[5] );
-  hash[6] = fd_uint_bswap( state[6] );
-  hash[7] = fd_uint_bswap( state[7] );
-  return _hash;
+  state[0] = fd_uint_bswap( state[0] );
+  state[1] = fd_uint_bswap( state[1] );
+  state[2] = fd_uint_bswap( state[2] );
+  state[3] = fd_uint_bswap( state[3] );
+  state[4] = fd_uint_bswap( state[4] );
+  state[5] = fd_uint_bswap( state[5] );
+  state[6] = fd_uint_bswap( state[6] );
+  state[7] = fd_uint_bswap( state[7] );
+  return memcpy( _hash, state, 32 );
 }
 
 void *
@@ -454,16 +452,15 @@ fd_sha256_hash_32( void const * _data,
   FD_STORE( ulong, buf+FD_SHA256_PRIVATE_BUF_MAX-8UL, fd_ulong_bswap( bit_cnt ) );
   fd_sha256_core( state, buf, 1UL );
 
-  uint * hash = (uint *)_hash;
-  hash[0] = fd_uint_bswap( state[0] );
-  hash[1] = fd_uint_bswap( state[1] );
-  hash[2] = fd_uint_bswap( state[2] );
-  hash[3] = fd_uint_bswap( state[3] );
-  hash[4] = fd_uint_bswap( state[4] );
-  hash[5] = fd_uint_bswap( state[5] );
-  hash[6] = fd_uint_bswap( state[6] );
-  hash[7] = fd_uint_bswap( state[7] );
-  return _hash;
+  state[0] = fd_uint_bswap( state[0] );
+  state[1] = fd_uint_bswap( state[1] );
+  state[2] = fd_uint_bswap( state[2] );
+  state[3] = fd_uint_bswap( state[3] );
+  state[4] = fd_uint_bswap( state[4] );
+  state[5] = fd_uint_bswap( state[5] );
+  state[6] = fd_uint_bswap( state[6] );
+  state[7] = fd_uint_bswap( state[7] );
+  return memcpy( _hash, state, 32 );
 }
 
 #undef fd_sha256_core

--- a/src/ballet/utf8/fd_utf8.c
+++ b/src/ballet/utf8/fd_utf8.c
@@ -29,6 +29,10 @@ fd_utf8_verify( char const * str,
                 ulong        sz ) {
 
   uchar const *       cur = (uchar const *)str;
+  if( FD_UNLIKELY( cur==NULL ) ) {
+    return 1;
+  }
+
   uchar const * const end = cur+sz;
 
   while( cur<end ) {

--- a/src/flamenco/runtime/fd_acc_mgr.c
+++ b/src/flamenco/runtime/fd_acc_mgr.c
@@ -176,9 +176,6 @@ fd_acc_mgr_modify_raw( fd_acc_mgr_t *        acc_mgr,
 
   fd_funk_rec_key_t id   = fd_acc_funk_key( pubkey );
 
-  if (((pubkey->ul[0] == 0) & (pubkey->ul[1] == 0) & (pubkey->ul[2] == 0) & (pubkey->ul[3] == 0)))
-    FD_LOG_WARNING(( "null pubkey (system program?) is being modified" ));
-
 //#ifdef VLOG
 //  ulong rec_cnt = 0;
 //  for( fd_funk_rec_t const * rec = fd_funk_txn_first_rec( funk, txn );

--- a/src/flamenco/runtime/program/fd_address_lookup_table_program.c
+++ b/src/flamenco/runtime/program/fd_address_lookup_table_program.c
@@ -1050,6 +1050,9 @@ fd_address_lookup_table_program_execute( fd_exec_instr_ctx_t _ctx ) {
   fd_exec_instr_ctx_t * ctx = &_ctx;
   uchar const * instr_data    = ctx->instr->data;
   ulong         instr_data_sz = ctx->instr->data_sz;
+  if( FD_UNLIKELY( instr_data==NULL ) ) {
+    return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+  }
 
   FD_SCRATCH_SCOPE_BEGIN {
 

--- a/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
@@ -66,7 +66,6 @@ fd_bpf_loader_v3_is_executable( fd_exec_slot_ctx_t * slot_ctx,
 
   fd_bpf_upgradeable_loader_state_t loader_state = {0};
   if( FD_UNLIKELY( fd_bpf_upgradeable_loader_state_decode( &loader_state, &ctx ) ) ) {
-    FD_LOG_WARNING(( "fd_bpf_upgradeable_loader_state_decode failed" ));
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
   }
 
@@ -105,7 +104,6 @@ read_bpf_upgradeable_loader_state_for_program( fd_exec_txn_ctx_t *              
   };
 
   if( FD_UNLIKELY( fd_bpf_upgradeable_loader_state_decode( result, &ctx ) ) ) {
-    FD_LOG_WARNING(( "fd_bpf_upgradeable_loader_state_decode failed" ));
     *opt_err = FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
     return NULL;
   }
@@ -1652,7 +1650,6 @@ fd_bpf_loader_v3_program_execute( fd_exec_instr_ctx_t ctx ) {
 
     fd_sbpf_validated_program_t * prog = NULL;
     if( FD_UNLIKELY( fd_bpf_load_cache_entry( ctx.slot_ctx, &ctx.instr->program_id_pubkey, &prog ) ) ) {
-      FD_LOG_WARNING(( "Program cache load for program failed" ));
       return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
     }
 

--- a/src/flamenco/runtime/program/fd_bpf_program_util.c
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.c
@@ -99,7 +99,6 @@ fd_bpf_get_executable_program_content_for_upgradeable_loader( fd_exec_slot_ctx_t
     }
 
     if( FD_UNLIKELY( programdata_rec->const_meta->dlen < PROGRAMDATA_METADATA_SIZE ) ) {
-      FD_LOG_WARNING(( "programdata_rec->const_meta->dlen < PROGRAMDATA_METADATA_SIZE (%lu<%lu)", programdata_rec->const_meta->dlen, PROGRAMDATA_METADATA_SIZE ));
       return -1;
     }
 

--- a/src/flamenco/runtime/program/fd_config_program.c
+++ b/src/flamenco/runtime/program/fd_config_program.c
@@ -19,6 +19,9 @@ _process_config_instr( fd_exec_instr_ctx_t ctx ) {
 
   /* Deserialize the Config Program instruction data, which consists only of the ConfigKeys
      https://github.com/solana-labs/solana/blob/v1.17.17/programs/config/src/config_processor.rs#L21 */
+  if( FD_UNLIKELY( ctx.instr->data==NULL ) ) {
+    return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+  }
 
   fd_bincode_decode_ctx_t decode =
     { .valloc  = fd_scratch_virtual(),

--- a/src/flamenco/runtime/program/fd_stake_program.c
+++ b/src/flamenco/runtime/program/fd_stake_program.c
@@ -2466,6 +2466,9 @@ fd_stake_program_execute( fd_exec_instr_ctx_t ctx ) {
   fd_instr_get_signers( ctx.instr, signers );
 
   /* https://github.com/solana-labs/solana/blob/v1.18.9/programs/stake/src/stake_instruction.rs#L72 */
+  if( FD_UNLIKELY( ctx.instr->data==NULL ) ) {
+    return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+  }
 
   fd_valloc_t valloc = fd_scratch_virtual();
   fd_bincode_decode_ctx_t decode =

--- a/src/flamenco/runtime/program/fd_system_program.c
+++ b/src/flamenco/runtime/program/fd_system_program.c
@@ -653,6 +653,9 @@ fd_system_program_execute( fd_exec_instr_ctx_t ctx ) {
 
   /* Deserialize the SystemInstruction enum */
   uchar * data = ctx.instr->data;
+  if( FD_UNLIKELY( data==NULL ) ) {
+    return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+  }
 
   fd_system_program_instruction_t instruction;
   fd_bincode_decode_ctx_t decode =

--- a/src/flamenco/runtime/program/fd_vote_program.c
+++ b/src/flamenco/runtime/program/fd_vote_program.c
@@ -2369,6 +2369,9 @@ fd_vote_program_execute( fd_exec_instr_ctx_t ctx ) {
   fd_instr_get_signers( ctx.instr, signers );
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L70
+  if( FD_UNLIKELY( ctx.instr->data==NULL ) ) {
+    return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+  }
   fd_vote_instruction_t   instruction;
   fd_bincode_decode_ctx_t decode = {
       .data    = ctx.instr->data,

--- a/src/flamenco/runtime/program/fd_zk_elgamal_proof_program.h
+++ b/src/flamenco/runtime/program/fd_zk_elgamal_proof_program.h
@@ -17,7 +17,6 @@
   } while(0);
 
 #define FD_RUNTIME_LOG_APPEND( ctx, log ) do { \
-  FD_LOG_NOTICE(( log ));                      \
   } while(0);
 
 /* FD_ZKSDK_INSTR_{...} identify ZK ElGamal Proof Program instructions.

--- a/src/flamenco/runtime/program/zksdk/fd_zksdk.c
+++ b/src/flamenco/runtime/program/zksdk/fd_zksdk.c
@@ -170,7 +170,7 @@ fd_zksdk_process_verify_proof( fd_exec_instr_ctx_t ctx ) {
 
       /* https://github.com/anza-xyz/agave/blob/v2.0.1/programs/zk-elgamal-proof/src/lib.rs#L50-L61
          Note: it doesn't look like the ref code can throw any error. */
-      uint proof_data_offset = *((uint *)(&instr_data[1]));
+      uint proof_data_offset = fd_uint_load_4_fast(&instr_data[1]);
 
       /* https://github.com/anza-xyz/agave/blob/v2.0.1/programs/zk-elgamal-proof/src/lib.rs#L62-L65 */
       if( proof_data_offset+proof_data_sz > proof_data_acc->meta->dlen ) {

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -1265,11 +1265,13 @@ fd_exec_instr_fixture_run( fd_exec_instr_test_runner_t *        runner,
 }
 
 ulong
-fd_exec_instr_test_run( fd_exec_instr_test_runner_t *        runner,
-                        fd_exec_test_instr_context_t const * input,
-                        fd_exec_test_instr_effects_t **      output,
-                        void *                               output_buf,
-                        ulong                                output_bufsz ) {
+fd_exec_instr_test_run( fd_exec_instr_test_runner_t * runner,
+                        void const *                  input_,
+                        void **                       output_,
+                        void *                        output_buf,
+                        ulong                         output_bufsz ) {
+  fd_exec_test_instr_context_t const * input  = fd_type_pun_const( input_ );
+  fd_exec_test_instr_effects_t **      output = fd_type_pun( output_ );
   fd_wksp_t *  wksp  = fd_wksp_attach( "wksp" );
   fd_alloc_t * alloc = fd_alloc_join( fd_alloc_new( fd_wksp_alloc_laddr( wksp, fd_alloc_align(), fd_alloc_footprint(), 2 ), 2 ), 0 );
 
@@ -1375,11 +1377,14 @@ fd_exec_instr_test_run( fd_exec_instr_test_runner_t *        runner,
 }
 
 ulong
-fd_exec_txn_test_run( fd_exec_instr_test_runner_t *        runner, // Runner only contains funk instance, so we can borrow instr test runner
-                      fd_exec_test_txn_context_t const *   input,
-                      fd_exec_test_txn_result_t **         output,
-                      void *                               output_buf,
-                      ulong                                output_bufsz ) {
+fd_exec_txn_test_run( fd_exec_instr_test_runner_t * runner, // Runner only contains funk instance, so we can borrow instr test runner
+                      void const *                  input_,
+                      void **                       output_,
+                      void *                        output_buf,
+                      ulong                         output_bufsz ) {
+  fd_exec_test_txn_context_t const * input  = fd_type_pun_const( input_ );
+  fd_exec_test_txn_result_t **       output = fd_type_pun( output_ );
+
   FD_SCRATCH_SCOPE_BEGIN {
     /* Initialize memory */
     fd_wksp_t *           wksp          = fd_wksp_attach( "wksp" );
@@ -1494,10 +1499,13 @@ fd_exec_txn_test_run( fd_exec_instr_test_runner_t *        runner, // Runner onl
 
 ulong
 fd_sbpf_program_load_test_run( FD_PARAM_UNUSED fd_exec_instr_test_runner_t * runner,
-                               fd_exec_test_elf_loader_ctx_t const * input,
-                               fd_exec_test_elf_loader_effects_t **  output,
-                               void *                                output_buf,
-                               ulong                                 output_bufsz ){
+                               void const *                  input_,
+                               void **                       output_,
+                               void *                        output_buf,
+                               ulong                         output_bufsz ) {
+  fd_exec_test_elf_loader_ctx_t const * input  = fd_type_pun_const( input_ );
+  fd_exec_test_elf_loader_effects_t **  output = fd_type_pun( output_ );
+
   fd_sbpf_elf_info_t info;
   fd_valloc_t valloc = fd_scratch_virtual();
 
@@ -1606,11 +1614,13 @@ fd_sbpf_program_load_test_run( FD_PARAM_UNUSED fd_exec_instr_test_runner_t * run
 }
 
 ulong
-fd_exec_vm_syscall_test_run( fd_exec_instr_test_runner_t *          runner,
-                             fd_exec_test_syscall_context_t const * input,
-                             fd_exec_test_syscall_effects_t **      output,
-                             void *                                 output_buf,
-                             ulong                                  output_bufsz ) {
+fd_exec_vm_syscall_test_run( fd_exec_instr_test_runner_t * runner,
+                             void const *                  input_,
+                             void **                       output_,
+                             void *                        output_buf,
+                             ulong                         output_bufsz ) {
+  fd_exec_test_syscall_context_t const * input =  fd_type_pun_const( input_ );
+  fd_exec_test_syscall_effects_t **      output = fd_type_pun( output_ );
   fd_wksp_t *  wksp  = fd_wksp_attach( "wksp" );
   fd_alloc_t * alloc = fd_alloc_join( fd_alloc_new( fd_wksp_alloc_laddr( wksp, fd_alloc_align(), fd_alloc_footprint(), 2 ), 2 ), 0 );
 
@@ -1756,18 +1766,18 @@ fd_exec_vm_syscall_test_run( fd_exec_instr_test_runner_t *          runner,
   effects->cu_avail = (ulong)vm->cu;
 
   effects->heap = FD_SCRATCH_ALLOC_APPEND(
-    l, alignof(uchar), PB_BYTES_ARRAY_T_ALLOCSIZE( vm->heap_max ) );
+    l, alignof(uint), PB_BYTES_ARRAY_T_ALLOCSIZE( vm->heap_max ) );
   effects->heap->size = (uint)vm->heap_max;
   fd_memcpy( effects->heap->bytes, vm->heap, vm->heap_max );
 
   effects->stack = FD_SCRATCH_ALLOC_APPEND(
-    l, alignof(uchar), PB_BYTES_ARRAY_T_ALLOCSIZE( FD_VM_STACK_MAX ) );
+    l, alignof(uint), PB_BYTES_ARRAY_T_ALLOCSIZE( FD_VM_STACK_MAX ) );
   effects->stack->size = (uint)FD_VM_STACK_MAX;
   fd_memcpy( effects->stack->bytes, vm->stack, FD_VM_STACK_MAX );
 
   // if( input_data_sz ) {
   //   effects->inputdata = FD_SCRATCH_ALLOC_APPEND(
-  //     l, alignof(uchar), PB_BYTES_ARRAY_T_ALLOCSIZE( input_data_sz ) );
+  //     l, alignof(uint), PB_BYTES_ARRAY_T_ALLOCSIZE( input_data_sz ) );
   //   effects->inputdata->size = (uint)input_data_sz;
   //   fd_memcpy( effects->inputdata->bytes, vm->input, input_data_sz );
   // } else {

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.h
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.h
@@ -70,21 +70,21 @@ fd_exec_instr_fixture_run( fd_exec_instr_test_runner_t *        runner,
    for failure.  Reasons for failure include insufficient output_bufsz. */
 
 ulong
-fd_exec_instr_test_run( fd_exec_instr_test_runner_t *        runner,
-                        fd_exec_test_instr_context_t const * input,
-                        fd_exec_test_instr_effects_t **      output,
-                        void *                               output_buf,
-                        ulong                                output_bufsz );
+fd_exec_instr_test_run( fd_exec_instr_test_runner_t * runner,
+                        void const *                  input_,
+                        void **                       output_,
+                        void *                        output_buf,
+                        ulong                         output_bufsz );
 
 /*
    Similar to above, but executes a txn given txn context (input)
 */
 ulong
-fd_exec_txn_test_run( fd_exec_instr_test_runner_t *        runner, // Runner only contains funk instance, so we can borrow instr test runner
-                      fd_exec_test_txn_context_t const *   input,
-                      fd_exec_test_txn_result_t **         output,
-                      void *                               output_buf,
-                      ulong                                output_bufsz );
+fd_exec_txn_test_run( fd_exec_instr_test_runner_t * runner, // Runner only contains funk instance, so we can borrow instr test runner
+                      void const *                  input_,
+                      void **                       output_,
+                      void *                        output_buf,
+                      ulong                         output_bufsz );
 
 /* Loads an ELF binary (in input->elf.data()). 
    output_buf points to a memory region of output_bufsz bytes where the
@@ -96,18 +96,18 @@ fd_exec_txn_test_run( fd_exec_instr_test_runner_t *        runner, // Runner onl
    but output is incomplete/undefined.
    */
 ulong
-fd_sbpf_program_load_test_run( fd_exec_instr_test_runner_t *         runner,
-                               fd_exec_test_elf_loader_ctx_t const * input,
-                               fd_exec_test_elf_loader_effects_t **  output,
-                               void *                                output_buf,
-                               ulong                                 output_bufsz );
+fd_sbpf_program_load_test_run( fd_exec_instr_test_runner_t * runner,
+                               void const *                  input_,
+                               void **                       output_,
+                               void *                        output_buf,
+                               ulong                         output_bufsz );
 
 ulong
-fd_exec_vm_syscall_test_run( fd_exec_instr_test_runner_t *          runner,
-                             fd_exec_test_syscall_context_t const * input,
-                             fd_exec_test_syscall_effects_t **      output,
-                             void *                                 output_buf,
-                             ulong                                  output_bufsz );
+fd_exec_vm_syscall_test_run( fd_exec_instr_test_runner_t * runner,
+                             void const *                  input_,
+                             void **                       output_,
+                             void *                        output_buf,
+                             ulong                         output_bufsz );
 
 
 FD_PROTOTYPES_END

--- a/src/flamenco/runtime/tests/fd_exec_sol_compat.c
+++ b/src/flamenco/runtime/tests/fd_exec_sol_compat.c
@@ -266,7 +266,7 @@ sol_compat_instr_fixture( fd_exec_instr_test_runner_t * runner,
 
   // Execute
   void * output = NULL;
-  sol_compat_execute_wrapper( runner, &fixture->input, &output, (exec_test_run_fn_t *)fd_exec_instr_test_run );
+  sol_compat_execute_wrapper( runner, &fixture->input, &output, fd_exec_instr_test_run );
 
   // Compare effects
   int ok = sol_compat_cmp_binary_strict( output, &fixture->output, &fd_exec_test_instr_effects_t_msg );
@@ -290,7 +290,7 @@ sol_compat_precompile_fixture( fd_exec_instr_test_runner_t * runner,
 
   // Execute
   void * output = NULL;
-  sol_compat_execute_wrapper( runner, &fixture->input, &output, (exec_test_run_fn_t *)fd_exec_instr_test_run );
+  sol_compat_execute_wrapper( runner, &fixture->input, &output, fd_exec_instr_test_run );
 
   // Compare effects
   int ok = sol_compat_cmp_success_fail_only( output, &fixture->output );
@@ -314,7 +314,7 @@ sol_compat_elf_loader_fixture( fd_exec_instr_test_runner_t * runner,
 
   // Execute
   void * output = NULL;
-  sol_compat_execute_wrapper( runner, &fixture->input, &output, (exec_test_run_fn_t *)fd_sbpf_program_load_test_run );
+  sol_compat_execute_wrapper( runner, &fixture->input, &output, fd_sbpf_program_load_test_run );
 
   // Compare effects
   int ok = sol_compat_cmp_binary_strict( output, &fixture->output, &fd_exec_test_elf_loader_effects_t_msg );
@@ -337,7 +337,7 @@ sol_compat_syscall_fixture( fd_exec_instr_test_runner_t * runner,
 
   // Execute
   void * output = NULL;
-  sol_compat_execute_wrapper( runner, &fixture->input, &output, (exec_test_run_fn_t *)fd_exec_vm_syscall_test_run );
+  sol_compat_execute_wrapper( runner, &fixture->input, &output, fd_exec_vm_syscall_test_run );
 
   // Compare effects
   int ok = sol_compat_cmp_binary_strict( output, &fixture->output, &fd_exec_test_syscall_effects_t_msg );
@@ -360,10 +360,8 @@ sol_compat_validate_vm_fixture( fd_exec_instr_test_runner_t * runner,
 
   // Execute
   void * output = NULL;
-  sol_compat_execute_wrapper( runner,
-                              &fixture->input,
-                              &output, 
-                              (exec_test_run_fn_t *)fd_exec_vm_validate_test_run );
+  sol_compat_execute_wrapper( runner, &fixture->input, &output, fd_exec_vm_validate_test_run );
+
   // Compare effects
   int ok = sol_compat_cmp_binary_strict( output, &fixture->output, &fd_exec_test_validate_vm_effects_t_msg );
 
@@ -395,7 +393,7 @@ sol_compat_instr_execute_v1( uchar *       out,
 
   // Execute
   void * output = NULL;
-  sol_compat_execute_wrapper( runner, input, &output, (exec_test_run_fn_t *)fd_exec_instr_test_run );
+  sol_compat_execute_wrapper( runner, input, &output, fd_exec_instr_test_run );
 
   // Encode effects
   int ok = 0;
@@ -432,7 +430,7 @@ sol_compat_txn_execute_v1( uchar *       out,
 
   // Execute
   void * output = NULL;
-  sol_compat_execute_wrapper( runner, input, &output, (exec_test_run_fn_t *)fd_exec_txn_test_run );
+  sol_compat_execute_wrapper( runner, input, &output, fd_exec_txn_test_run );
 
   // Encode effects
   int ok = 0;
@@ -472,7 +470,7 @@ sol_compat_elf_loader_v1( uchar *       out,
     void * out0 = fd_scratch_prepare( 1UL );
     assert( out_bufsz < fd_scratch_free() );
     fd_scratch_publish( (void *)( (ulong)out0 + out_bufsz ) );
-    ulong out_used = fd_sbpf_program_load_test_run( NULL, input, &output, out0, out_bufsz );
+    ulong out_used = fd_sbpf_program_load_test_run( NULL, fd_type_pun_const( input ), fd_type_pun( &output ), out0, out_bufsz );
     if( FD_UNLIKELY( !out_used ) ) {
       output = NULL;
       break;
@@ -524,7 +522,7 @@ sol_compat_vm_syscall_execute_v1( uchar *       out,
 
   // Execute
   void * output = NULL;
-  sol_compat_execute_wrapper( runner, input, &output, (exec_test_run_fn_t *)fd_exec_vm_syscall_test_run );
+  sol_compat_execute_wrapper( runner, input, &output, fd_exec_vm_syscall_test_run );
 
   // Encode effects
   int ok = 0;
@@ -561,7 +559,7 @@ sol_compat_vm_validate_v1(  uchar *       out,
 
   // Execute
   void * output = NULL;
-  sol_compat_execute_wrapper( runner, input, &output, (exec_test_run_fn_t *)fd_exec_vm_validate_test_run );
+  sol_compat_execute_wrapper( runner, input, &output, fd_exec_vm_validate_test_run );
 
   // Encode effects
   int ok = 0;

--- a/src/flamenco/runtime/tests/fd_vm_validate_test.c
+++ b/src/flamenco/runtime/tests/fd_vm_validate_test.c
@@ -5,12 +5,15 @@
 #include "../../vm/test_vm_util.h"
 
 ulong
-fd_exec_vm_validate_test_run( fd_exec_instr_test_runner_t *         runner,
-                              fd_exec_test_full_vm_context_t const *input,
-                              fd_exec_test_validate_vm_effects_t ** output,
-                              void *                                output_buf,
-                              ulong                                 output_bufsz ) {
+fd_exec_vm_validate_test_run( fd_exec_instr_test_runner_t * runner,
+                              void const *                  input_,
+                              void **                       output_,
+                              void *                        output_buf,
+                              ulong                         output_bufsz ) {
   (void) runner; /* unused, for wrapper compat */
+  fd_exec_test_full_vm_context_t const * input  = fd_type_pun_const( input_ );
+  fd_exec_test_validate_vm_effects_t **  output = fd_type_pun( output_ );
+
   if( FD_UNLIKELY( !input->has_vm_ctx ) ) {
     return 0UL;
   }

--- a/src/flamenco/runtime/tests/fd_vm_validate_test.h
+++ b/src/flamenco/runtime/tests/fd_vm_validate_test.h
@@ -18,11 +18,11 @@
 
 
 ulong
-fd_exec_vm_validate_test_run( fd_exec_instr_test_runner_t *         runner,
-                              fd_exec_test_full_vm_context_t const *input,
-                              fd_exec_test_validate_vm_effects_t ** output,
-                              void *                                output_buf,
-                              ulong                                 output_bufsz );
+fd_exec_vm_validate_test_run( fd_exec_instr_test_runner_t * runner,
+                              void const *                  input_,
+                              void **                       output_,
+                              void *                        output_buf,
+                              ulong                         output_bufsz );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/tests/test_exec_instr.c
+++ b/src/flamenco/runtime/tests/test_exec_instr.c
@@ -63,11 +63,11 @@ main( int     argc,
   /* TODO switch to leap API and set up a thread pool once available */
   ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
   if( cpu_idx>=fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( FD_SHMEM_GIGANTIC_PAGE_SZ, 4UL, fd_shmem_cpu_idx( fd_shmem_numa_idx( cpu_idx ) ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous( FD_SHMEM_NORMAL_PAGE_SZ, 65536, fd_shmem_cpu_idx( fd_shmem_numa_idx( cpu_idx ) ), "wksp", 0UL );
 
   ulong   scratch_fmem[ 64UL ] __attribute((aligned(FD_SCRATCH_FMEM_ALIGN)));
   uchar * scratch_smem = malloc( 1 << 30 ); // 1 GB
-  fd_scratch_attach( scratch_smem, scratch_fmem, 1UL<<31, 64UL );
+  fd_scratch_attach( scratch_smem, scratch_fmem, 1UL<<30, 64UL );
 
   // Setup usage tracking
   fd_wksp_usage_t usage[1];

--- a/src/flamenco/types/fd_bincode.h
+++ b/src/flamenco/types/fd_bincode.h
@@ -206,6 +206,9 @@ static inline int
 fd_bincode_compact_u16_decode( ushort *                  self,
                                fd_bincode_decode_ctx_t * ctx ) {
   const uchar * ptr = (const uchar*) ctx->data;
+  if( FD_UNLIKELY( ptr==NULL ) ) {
+    return FD_BINCODE_ERR_UNDERFLOW;
+  }
 
   if( FD_LIKELY( (void *) (ptr + 1) <= ctx->dataend && !(0x80U & ptr[0]) ) ) {
     *self = (ushort)ptr[0];

--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -1005,9 +1005,9 @@ static inline void *
 fd_memcpy( void       * FD_RESTRICT d,
            void const * FD_RESTRICT s,
            ulong                    sz ) {
-# ifdef CBMC
+#if defined(CBMC) || FD_HAS_ASAN
   if( FD_UNLIKELY( !sz ) ) return d; /* Standard says sz 0 is UB, uncomment if target is insane and doesn't treat sz 0 as a nop */
-# endif
+#endif
   return memcpy( d, s, sz );
 }
 

--- a/src/util/wksp/fd_wksp_user.c
+++ b/src/util/wksp/fd_wksp_user.c
@@ -363,7 +363,9 @@ fd_wksp_free( fd_wksp_t * wksp,
 
   fd_wksp_private_unlock( wksp );
 
-  if( FD_UNLIKELY( i>=part_max ) ) FD_LOG_WARNING(( "gaddr does not appear to be a current wksp allocation" ));
+  if( FD_UNLIKELY( i>=part_max && i!=FD_WKSP_PRIVATE_PINFO_IDX_NULL ) ) {
+    FD_LOG_WARNING(( "gaddr does not appear to be a current wksp allocation" ));
+  }
 }
 
 ulong


### PR DESCRIPTION
- [x] enable warn logs for all tests
- [x] remove unnecessary warn logs (cluttering output / hiding real issues)
- [x] curve25519: fix ulong load alignment
- [x] sha256: fix uint bswap alignment
- [x] utf8: handle null pointer
- [x] programs: handle null instr->data
- [x] zk-sdk: fix uint load alignment
- [x] bincode: handle null pointer
- [x] sol_compat: fix asan complaints with fn interface
- [x] test_exec_instr: fix page size and boundaries