### PR TITLE
fuzz: set higher cap for raw txn alloc

### DIFF
--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -745,7 +745,7 @@ _txn_context_create( fd_exec_instr_test_runner_t *      runner,
   }
 
   /* Create the raw txn (https://solana.com/docs/core/transactions#transaction-size) */
-  uchar * txn_raw_begin = fd_scratch_alloc( alignof(uchar), FD_TXN_MTU );
+  uchar * txn_raw_begin = fd_scratch_alloc( alignof(uchar), 10000 ); // max txn size is 1232 but we allocate extra for safety
   uchar * txn_raw_cur_ptr = txn_raw_begin;
 
   /* Compact array of signatures (https://solana.com/docs/core/transactions#transaction)


### PR DESCRIPTION
The txn fuzzer may generate larger-than-expected raw transactions