### PR TITLE
flamenco, vm: implement last restart slot syscall

### DIFF
--- a/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.c
@@ -34,7 +34,7 @@ fd_sysvar_last_restart_slot_init( fd_exec_slot_ctx_t * slot_ctx ) {
                  0UL );
 }
 
-static fd_sol_sysvar_last_restart_slot_t *
+fd_sol_sysvar_last_restart_slot_t *
 fd_sysvar_last_restart_slot_read( fd_sol_sysvar_last_restart_slot_t * result,
                                   fd_exec_slot_ctx_t const *          slot_ctx ) {
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.h
@@ -19,6 +19,14 @@ fd_sysvar_last_restart_slot_init( fd_exec_slot_ctx_t * slot_ctx );
 void
 fd_sysvar_last_restart_slot_update( fd_exec_slot_ctx_t * slot_ctx );
 
+/* fd_sysvar_last_restart_slot queries the last restart slot sysvar from the given slot
+   context.  The sysvar is written into *result (may be uninitialized).
+   Returns result on success, NULL otherwise. */
+
+fd_sol_sysvar_last_restart_slot_t *
+fd_sysvar_last_restart_slot_read( fd_sol_sysvar_last_restart_slot_t * result,
+                                  fd_exec_slot_ctx_t const *          slot_ctx );
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_flamenco_runtime_fd_sysvar_last_restart_slot_h */

--- a/src/flamenco/vm/syscall/fd_vm_syscall.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall.c
@@ -26,6 +26,7 @@ fd_vm_syscall_register_slot( fd_sbpf_syscalls_t *       syscalls,
   int enable_curve25519_syscall            = 0;
   int enable_poseidon_syscall              = 0;
   int enable_alt_bn128_compression_syscall = 0;
+  int enable_last_restart_slot_syscall     = 0;
 
   int disable_fees_sysvar                  = 0;
 
@@ -36,6 +37,7 @@ fd_vm_syscall_register_slot( fd_sbpf_syscalls_t *       syscalls,
     enable_curve25519_syscall            = FD_FEATURE_ACTIVE( slot_ctx, curve25519_syscall_enabled );
     enable_poseidon_syscall              = FD_FEATURE_ACTIVE( slot_ctx, enable_poseidon_syscall );
     enable_alt_bn128_compression_syscall = FD_FEATURE_ACTIVE( slot_ctx, enable_alt_bn128_compression_syscall );
+    enable_last_restart_slot_syscall     = FD_FEATURE_ACTIVE( slot_ctx, last_restart_slot_sysvar );
 
     disable_fees_sysvar                  = !FD_FEATURE_ACTIVE( slot_ctx, disable_fees_sysvar );
 
@@ -46,6 +48,7 @@ fd_vm_syscall_register_slot( fd_sbpf_syscalls_t *       syscalls,
     enable_curve25519_syscall            = 1;
     enable_poseidon_syscall              = 1;
     enable_alt_bn128_compression_syscall = 1;
+    enable_last_restart_slot_syscall     = 1;
 
   }
 
@@ -98,7 +101,11 @@ fd_vm_syscall_register_slot( fd_sbpf_syscalls_t *       syscalls,
     REGISTER( "sol_get_fees_sysvar",                 fd_vm_syscall_sol_get_fees_sysvar );
 
   REGISTER( "sol_get_rent_sysvar",                   fd_vm_syscall_sol_get_rent_sysvar );
-//REGISTER( "sol_get_last_restart_slot",             fd_vm_syscall_sol_get_last_restart_slot );
+
+  if( FD_LIKELY( enable_last_restart_slot_syscall ) ) {
+    REGISTER( "sol_get_last_restart_slot",             fd_vm_syscall_sol_get_last_restart_slot_sysvar );
+  }
+  
   REGISTER( "sol_memcpy_",                           fd_vm_syscall_sol_memcpy );
   REGISTER( "sol_memmove_",                          fd_vm_syscall_sol_memmove );
   REGISTER( "sol_memcmp_",                           fd_vm_syscall_sol_memcmp );

--- a/src/flamenco/vm/syscall/fd_vm_syscall.h
+++ b/src/flamenco/vm/syscall/fd_vm_syscall.h
@@ -402,11 +402,12 @@ FD_VM_SYSCALL_DECL( sol_memmove );
    syscall(FIXME) "sol_get_epoch_schedule_sysvar"
    syscall(FIXME) "sol_get_fees_sysvar"
    syscall(FIXME) "sol_get_rent_sysvar"
+   syscall(FIXME) "sol_get_last_restart_slot_sysvar"
    Get various sysvar values
 
    Inputs:
 
-     r1 - out, {clock,schedule,fees,rent} VM pointer
+     r1 - out, {clock,schedule,fees,rent,last_restart_slot} VM pointer
      r2 - ignored
      r3 - ignored
      r4 - ignored
@@ -422,20 +423,22 @@ FD_VM_SYSCALL_DECL( sol_memmove );
 
      FD_VM_ERR_SIGSEGV: bad address range.  *_ret unchanged.  vm->cu
      decremented and vm->cu>0.  out should have:
-                | align | sz
-       clock    |     8 | 40
-       schedule |     1 | 40 ... FIXME: CHECK THIS IS CORRECT!
-       fees     |     8 |  8
-       rent     |     8 | 24
+                          | align | sz
+       clock              |     8 | 40
+       schedule           |     1 | 40 ... FIXME: CHECK THIS IS CORRECT!
+       fees               |     8 |  8
+       rent               |     8 | 24
+       last restart slot  |     8 | 8
      Strict alignment is only required when the VM has check_align set.
 
      FD_VM_SUCCESS: success.  *_ret=0.  vm->cu decremented and vm->cu>0.
      On return, *out will hold the value of the appropriate sysvar. */
 
-FD_VM_SYSCALL_DECL( sol_get_clock_sysvar          );
-FD_VM_SYSCALL_DECL( sol_get_epoch_schedule_sysvar );
-FD_VM_SYSCALL_DECL( sol_get_fees_sysvar           );
-FD_VM_SYSCALL_DECL( sol_get_rent_sysvar           );
+FD_VM_SYSCALL_DECL( sol_get_clock_sysvar             );
+FD_VM_SYSCALL_DECL( sol_get_epoch_schedule_sysvar    );
+FD_VM_SYSCALL_DECL( sol_get_fees_sysvar              );
+FD_VM_SYSCALL_DECL( sol_get_rent_sysvar              );
+FD_VM_SYSCALL_DECL( sol_get_last_restart_slot_sysvar );
 
 /* syscall(FIXME) "sol_get_stack_height"
 


### PR DESCRIPTION
We've implemented the sysvar but not the syscall. This will be activated on mainnet in the next epoch.