### PR TITLE
flamenco: better rent epoch handling

### DIFF
--- a/src/app/ledger/main.c
+++ b/src/app/ledger/main.c
@@ -418,6 +418,7 @@ fd_ledger_main_setup( fd_ledger_args_t * args ) {
   fd_calculate_epoch_accounts_hash_values( args->slot_ctx );
   fd_bpf_scan_and_create_bpf_program_cache_entry( args->slot_ctx, args->slot_ctx->funk_txn );
   fd_funk_end_write( funk );
+
 }
 
 void

--- a/src/flamenco/features/fd_features_generated.c
+++ b/src/flamenco/features/fd_features_generated.c
@@ -688,7 +688,8 @@ fd_feature_id_t const ids[] = {
   { .index      = offsetof(fd_features_t, set_exempt_rent_epoch_max)>>3,
     .id         = {"\x49\x4e\x98\x21\x34\x4b\x72\xe0\x04\xd2\x66\xa2\x2e\xf9\xfb\x20\xbd\xba\x5a\xad\xec\xe7\xf6\xbc\x0a\x93\xe4\xd1\x83\xe0\xfd\x8f"},
                   /* 5wAGiy15X1Jb2hkHnPDCM8oB9V42VNA9ftNVFK84dEgv */
-    .name       = "set_exempt_rent_epoch_max" },
+    .name       = "set_exempt_rent_epoch_max",
+    .cleaned_up = 1180 },
 
   { .index      = offsetof(fd_features_t, relax_authority_signer_check_for_lookup_table_creation)>>3,
     .id         = {"\xd4\xaa\xef\x53\x4b\x5a\xa1\xad\x90\xf8\x49\xb9\x13\x45\x25\x3c\x4c\x39\x46\x28\xb4\xb6\xb4\xfa\x41\x0d\xb5\x1e\xa1\x4f\xa8\xf5"},

--- a/src/flamenco/features/feature_map.json
+++ b/src/flamenco/features/feature_map.json
@@ -116,7 +116,7 @@
   {"name":"disable_cpi_setting_executable_and_rent_epoch","pubkey": "B9cdB55u4jQsDNsdTK525yE9dmSc5Ga7YBaBrDFvEhM9","cleaned_up":1180},
   {"name":"on_load_preserve_rent_epoch_for_rent_exempt_accounts","pubkey": "CpkdQmspsaZZ8FVAouQTtTWZkc8eeQ7V3uj7dWz543rZ","cleaned_up":1180},
   {"name":"account_hash_ignore_slot","pubkey": "SVn36yVApPLYsa8koK3qUcy14zXDnqkNYWyUh1f4oK1","cleaned_up":1180},
-  {"name":"set_exempt_rent_epoch_max","pubkey": "5wAGiy15X1Jb2hkHnPDCM8oB9V42VNA9ftNVFK84dEgv"},
+  {"name":"set_exempt_rent_epoch_max","pubkey": "5wAGiy15X1Jb2hkHnPDCM8oB9V42VNA9ftNVFK84dEgv","cleaned_up":1180},
   {"name":"relax_authority_signer_check_for_lookup_table_creation","pubkey": "FKAcEvNgSY79RpqsPNUV5gDyumopH4cEHqUxyfm8b8Ap"},
   {"name":"stop_sibling_instruction_search_at_parent","pubkey": "EYVpEP7uzH1CoXzbD6PubGhYmnxRXPeq3PPsm1ba3gpo","cleaned_up":1180},
   {"name":"vote_state_update_root_fix","pubkey": "G74BkWBzmsByZ1kxHy44H3wjwp5hp7JbrGRuDpco22tY","cleaned_up":1180},

--- a/src/flamenco/runtime/fd_acc_mgr.c
+++ b/src/flamenco/runtime/fd_acc_mgr.c
@@ -217,8 +217,9 @@ fd_acc_mgr_modify_raw( fd_acc_mgr_t *        acc_mgr,
 
   fd_account_meta_t * ret = fd_funk_val( rec, fd_funk_wksp( funk ) );
 
-  if( do_create && ret->magic == 0 )
-    fd_account_meta_init(ret);
+  if( do_create && ret->magic==0UL ) {
+    fd_account_meta_init( ret );
+  }
 
   if( ret->magic != FD_ACCOUNT_META_MAGIC )
     FD_LOG_ERR(( "bad magic" ));

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -52,12 +52,10 @@ fd_execute_txn_prepare_phase3( fd_exec_slot_ctx_t *  slot_ctx,
                                fd_txn_p_t * txn );
 
 int
-fd_execute_txn_prepare_phase4( fd_exec_slot_ctx_t * slot_ctx,
-                               fd_exec_txn_ctx_t * txn_ctx );
+fd_execute_txn_prepare_phase4( fd_exec_txn_ctx_t * txn_ctx );
 
 int
-fd_execute_txn_finalize( fd_exec_slot_ctx_t * slot_ctx,
-                         fd_exec_txn_ctx_t * txn_ctx,
+fd_execute_txn_finalize( fd_exec_txn_ctx_t * txn_ctx,
                          int exec_txn_err );
 
 /*

--- a/src/flamenco/runtime/program/fd_bpf_loader_serialization.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_serialization.c
@@ -119,9 +119,7 @@ fd_bpf_loader_input_serialize_aligned( fd_exec_instr_ctx_t ctx,
           + sizeof(ulong)                         // data_len
           + 0                                     // data
           + MAX_PERMITTED_DATA_INCREASE;
-        if (FD_FEATURE_ACTIVE( ctx.slot_ctx, set_exempt_rent_epoch_max)) {
-          FD_STORE( ulong, serialized_params, ULONG_MAX );
-        }
+        FD_STORE( ulong, serialized_params, ULONG_MAX );
         serialized_params += sizeof(ulong); // rent_epoch
         pre_lens[i] = 0;
         continue;

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -135,11 +135,8 @@ _txn_collect_rent( fd_exec_txn_ctx_t * txn_ctx ) {
       continue;
     }
 
-    /* Filter accounts that we've already visited */
-    if (acc->const_meta->info.rent_epoch <= epoch || FD_FEATURE_ACTIVE(slot_ctx, set_exempt_rent_epoch_max)) {
-      /* Actually invoke rent collection */
-      fd_runtime_collect_rent_account(slot_ctx, acc->meta, acc->pubkey, epoch);
-    }
+    /* Actually invoke rent collection */
+    fd_runtime_collect_rent_account( slot_ctx, acc->meta, acc->pubkey, epoch );
   }
 }
 
@@ -892,7 +889,7 @@ _txn_context_create( fd_exec_instr_test_runner_t *      runner,
     return 0;
   }
 
-  res = fd_execute_txn_prepare_phase4( slot_ctx, txn_ctx );
+  res = fd_execute_txn_prepare_phase4( txn_ctx );
   if (res != 0) {
     FD_LOG_WARNING(("could not prepare txn (phase 4 failed)"));
     return 0;

--- a/src/flamenco/runtime/tests/run_ledger_tests_all.txt
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.txt
@@ -1,6 +1,5 @@
 src/flamenco/runtime/tests/run_ledger_test.sh -l v201-small -p 30 -y 16 -m 500000 -e 120
 src/flamenco/runtime/tests/run_ledger_test.sh -t 105 -l v18multi-inverted -s snapshot-100-FpGocyQzYgnzjnvazuiDHPLkVPZt3vRvGvSNX1GBUMGT.tar.zst -p 30 -y 16 -m 5000000 -e 110 -c 1186
-src/flamenco/runtime/tests/run_ledger_test.sh -l v118-multi -c 1185
 src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-519       -s snapshot-255311992-Fju7xb3XaTY6SBxkGcsKko15EGAqnvdfkXBd1o6agPDq.tar.zst -p 45 -y 32 -m 1000000 -e 255312007 -c 1190
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-251418170 -s snapshot-251418170-8sAkojR9PYTZvqiQZ1VWu27ewX5tXeVdC97wMXAtgHnT.tar.zst -p 45 -y 32 -m 2000000 -e 251418233 -c 1190
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257066033 -s snapshot-257066033-AD2nFFTCtZVmo5nXLVsQMV1hiQDjzoEBXibRicBJc5Vw.tar.zst -p 30 -y 16 -m 5000000 -e 257066038 -c 1190 --zst
@@ -27,7 +26,6 @@ src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267651942 -s snapshot-2
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267081197 -s snapshot-267081196-9qwnybW2TVKfpMKJXKwFwfeW81qX2voqJYxd4qEaHPQu.tar.zst -p 30 -y 16 -m 5000000 -e 267081198 -c 1190
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267085604 -s snapshot-267085603-6JYpKrZVkmvsNvr83xTB63UsYDspCLUgsSAZLgJJZ3we.tar.zst -p 30 -y 16 -m 5000000 -e 267085605 -c 1190
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-265688706 -s snapshot-265688705-Hz56JjQuN4yfXGohYWMsYe2QJiTejQgGNLUaviVN16qP.tar.zst -p 30 -y 16 -m 5000000 -e 265688707 -c 1190
-src/flamenco/runtime/tests/run_ledger_test.sh -l v18multi-deployclose -s snapshot-400-4u5FU6ucpVAGaNgerGXs93vKtuS3tkmH2cAGwjQA9QcR.tar.zst    -p 30 -y 16 -m 5000000 -e 600 -c 1190
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-265330432 -s snapshot-265330431-BMvcRhxNoRtkZ5KLEKhhXM6GiWdTgdkoGLMe86xY4rF.tar.zst  -p 30 -y 16 -m 5000000 -e 265330433 -c 1190
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-268575190 -s snapshot-268575189-ABBpiGpcqgMs9SMNM4GTcpRPdwidgK6Vi1ZdRdQ4mpmA.tar.zst -p 30 -y 16 -m 5000000 -e 268575191 -c 1190
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-268129380 -s snapshot-268129379-Gr7yXEFt4jyfzSdWytELypb3CNeiYESJWFU6ioAKLJJC.tar.zst -p 30 -y 16 -m 5000000 -e 268129380 -c 1190
@@ -40,7 +38,6 @@ src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267059180 -s snapshot-2
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267580466 -s snapshot-267580465-EWeMRpeNFC9ue4qD6EFS6SkFrVJwmKnrSrwDHKLRr73h.tar.zst -p 30 -y 16 -m 5000000 -e 267580467 -c 1190
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-268196194 -s snapshot-268196193-57VFX99qvEzdE6aQ5GYMsa4ZdMJFawM657seKjWs7oMe.tar.zst -p 30 -y 16 -m 5000000 -e 268196195 -c 1190
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267766641 -s snapshot-267766640-36YeYWmcfiPXXXLMKuAohjM3SxzvXKDJSrG747zGB72B.tar.zst -p 30 -y 16 -m 5000000 -e 267766642 -c 1190
-src/flamenco/runtime/tests/run_ledger_test.sh -l v18multi-bpf-loader -s snapshot-60-E46cuqnBKdkC2qsgR7tzG5x1C8koiTHX58QcabEDJs2F.tar.zst      -p 30 -y 16 -m 5000000 -e 120 -c 1186
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-269648145 -s snapshot-269648144-7zWxbqhi4UFRNXxZBxAr8CsKt8MvnXJKwWiakAF4q5wu.tar.zst -p 30 -y 16 -m 5000000 -e 269648146 -c 1190
 src/flamenco/runtime/tests/run_ledger_test.sh -l v201-small -s snapshot-100-38CM8ita1fT5SmSLUEeqQZffn2xsy9vKz3WJmsFSnhrJ.tar.zst -p 30 -y 16 -m 500000 -e 120
 src/flamenco/runtime/tests/run_ledger_test.sh -l v20-harcoded-features -s snapshot-100-4EmZxoqF6P2fJJEKgvznd2BkfTvYzsFSup3gyDdV2mY1.tar.zst -p 30 -y 16 -m 500000 -e 700 -c 2000


### PR DESCRIPTION
1. Fixing handling for lookup table accounts, we previously didn't iterate over them
2. Setting rent epoch for accounts that don't exist, instead of defaulting to 0
3. removing set_exempt_rent_epoch_max feature flag guard