### PR TITLE
bench: make bench transactions succeed

### DIFF
--- a/src/app/fddev/tiles/fd_benchg.c
+++ b/src/app/fddev/tiles/fd_benchg.c
@@ -60,14 +60,24 @@ typedef struct __attribute__((packed)) {
   uchar fee_payer[32];
   uchar compute_budget_program[32]; /* = {COMPUTE_BUDGET_PROG_ID} */
   uchar recent_blockhash[32];
-  uchar instr_cnt; /* = 1 */
+  uchar instr_cnt; /* = 2 */
   /* Start of instruction */
-  uchar prog_id; /* = 1 */
-  uchar acct_cnt; /* = 0 */
-  uchar data_sz; /* = 9 */
-  uchar set_cu_price; /* = 3 */
-  ulong micro_lamports_per_cu; /* Can be any value, doesn't affect the transaction price */
-} transfer_t;
+  struct __attribute__((packed)) {
+    uchar prog_id; /* = 1 */
+    uchar acct_cnt; /* = 0 */
+    uchar data_sz; /* = 9 */
+    uchar set_cu_price; /* = 3 */
+    ulong micro_lamports_per_cu; /* Prefereably less than 10k or so */
+  } _1;
+  /* Start of second instruction */
+  struct __attribute__((packed)) {
+    uchar prog_id; /* = 1 */
+    uchar acct_cnt; /* = 0 */
+    uchar data_sz; /* = 5 */
+    uchar set_cu_limit; /* = 2 */
+    uint cus; /* = 300 */
+  } _2;
+} bench_transaction_t;
 
 static inline void
 after_credit( void *             _ctx,
@@ -79,8 +89,8 @@ after_credit( void *             _ctx,
 
   if( FD_UNLIKELY( !ctx->has_recent_blockhash ) ) return;
 
-  transfer_t * transfer = (transfer_t *)fd_chunk_to_laddr( ctx->mem, ctx->out_chunk );
-  *transfer = (transfer_t){
+  bench_transaction_t * txn = (bench_transaction_t *)fd_chunk_to_laddr( ctx->mem, ctx->out_chunk );
+  *txn = (bench_transaction_t){
     /* Fixed values */
     .sig_cnt         = 1,
     ._sig_cnt        = 1,
@@ -88,28 +98,33 @@ after_credit( void *             _ctx,
     .ro_unsigned_cnt = 1,
     .acct_addr_cnt   = 2,
     .compute_budget_program  = {COMPUTE_BUDGET_PROG_ID},
-    .instr_cnt       = 1,
-    .prog_id         = 1,
-    .acct_cnt        = 0,
-    .data_sz         = 9,
-    .set_cu_price    = 3,
+    .instr_cnt       = 2,
+    ._1.prog_id      = 1,
+    ._1.acct_cnt     = 0,
+    ._1.data_sz      = 9,
+    ._1.set_cu_price = 3,
+    ._2.prog_id      = 1,
+    ._2.acct_cnt     = 0,
+    ._2.data_sz      = 5,
+    ._2.set_cu_limit = 2,
+    ._2.cus          = 300,
 
     /* Variable */
-    .micro_lamports_per_cu = ctx->lamport_idx, /* Unique per transaction so they aren't duplicates */
+    ._1.micro_lamports_per_cu = ctx->lamport_idx, /* Unique per transaction so they aren't duplicates */
   };
 
-  fd_memcpy( transfer->fee_payer, ctx->acct_public_keys[ ctx->sender_idx ].uc, 32UL );
-  fd_memcpy( transfer->recent_blockhash, ctx->recent_blockhash, 32UL );
+  fd_memcpy( txn->fee_payer, ctx->acct_public_keys[ ctx->sender_idx ].uc, 32UL );
+  fd_memcpy( txn->recent_blockhash, ctx->recent_blockhash, 32UL );
 
-  fd_ed25519_sign( transfer->signature,
-                   &(transfer->_sig_cnt),
-                   sizeof(*transfer)-65UL,
+  fd_ed25519_sign( txn->signature,
+                   &(txn->_sig_cnt),
+                   sizeof(bench_transaction_t)-65UL,
                    ctx->acct_public_keys[ ctx->sender_idx ].uc,
                    ctx->acct_private_keys[ ctx->sender_idx ].uc,
                    ctx->sha );
 
-  fd_mux_publish( mux, 0UL, ctx->out_chunk, sizeof(*transfer), 0UL, 0UL, 0UL );
-  ctx->out_chunk = fd_dcache_compact_next( ctx->out_chunk, sizeof(*transfer), ctx->out_chunk0, ctx->out_wmark );
+  fd_mux_publish( mux, 0UL, ctx->out_chunk, sizeof(bench_transaction_t), 0UL, 0UL, 0UL );
+  ctx->out_chunk = fd_dcache_compact_next( ctx->out_chunk, sizeof(bench_transaction_t), ctx->out_chunk0, ctx->out_wmark );
 
   ctx->sender_idx = (ctx->sender_idx + 1UL) % ctx->acct_cnt;
   if( FD_UNLIKELY( !ctx->sender_idx ) ) {


### PR DESCRIPTION
Previously, transactions contained a single compute budget `set_cu_price` instruction. For some reason, the VM set the transaction's CU limit to 0. (Strangely different behavior from how transaction cost is estimated). "Executing" the compute budget program instruction costs 150 CUs, so the transaction was failing with `ComputationalBudgetExceeded`. 