### PR TITLE
config: flatten fuzz-test dir

### DIFF
--- a/.github/workflows/clusterfuzz.yml
+++ b/.github/workflows/clusterfuzz.yml
@@ -40,16 +40,18 @@ jobs:
         with:
           command: make -j -Otarget fuzz-test lib
 
-      - name: List Artifacts
+      - name: ClusterFuzz directory structure
         run: |
           ls ${{ matrix.artifact_dir }}/fuzz-test
           ls ${{ matrix.artifact_dir }}/lib
+          mkdir cf-dist
+          find build/clang-fuzz/fuzz-test -maxdepth 1 -executable -print | while read -r BIN_PATH; do TARGET=$(basename "$BIN_PATH"); mkdir cf-dist/$TARGET && mv $BIN_PATH cf-dist/$TARGET/$TARGET; done
 
       - uses: asymmetric-research/firedancer-clusterfuzz-action@main
         name: Upload fuzz targets to ClusterFuzz
         with:
           bucket-name: firedancer-builds.isol-clusterfuzz.appspot.com
-          artifact-dir: ${{ matrix.artifact_dir }}/fuzz-test
+          artifact-dir: cf-dist
           object-prefix: main/libfuzzer/${{ matrix.qualifier }}/firedancer
           project-id: isol-clusterfuzz
           qualifier: ${{ matrix.qualifier }}

--- a/config/everything.mk
+++ b/config/everything.mk
@@ -238,9 +238,9 @@ endif
 
 define _fuzz-test
 
-$(eval $(call _make-exe,$(1)/$(1),$(2),$(3),fuzz-test,fuzz-test,$(LDFLAGS_FUZZ) $(FUZZ_EXTRA)))
+$(eval $(call _make-exe,$(1),$(2),$(3),fuzz-test,fuzz-test,$(LDFLAGS_FUZZ) $(FUZZ_EXTRA)))
 
-$(OBJDIR)/fuzz-test/$(1)/$(1): $(FUZZ_EXTRA)
+$(OBJDIR)/fuzz-test/$(1): $(FUZZ_EXTRA)
 
 .PHONY: $(1)_unit
 $(1)_unit:
@@ -248,7 +248,7 @@ $(1)_unit:
 $(MKDIR) -p "$(OBJDIR)/cov/raw" && \
 FD_LOG_PATH="" \
 LLVM_PROFILE_FILE="$(OBJDIR)/cov/raw/$(1)_unit.profraw" \
-$(FIND) corpus/$(1) -type f -exec $(OBJDIR)/fuzz-test/$(1)/$(1) $(FUZZFLAGS) {} +
+$(FIND) corpus/$(1) -type f -exec $(OBJDIR)/fuzz-test/$(1) $(FUZZFLAGS) {} +
 
 .PHONY: $(1)_run
 $(1)_run:
@@ -256,7 +256,7 @@ $(1)_run:
 $(MKDIR) -p "$(OBJDIR)/cov/raw" && \
 FD_LOG_PATH="" \
 LLVM_PROFILE_FILE="$(OBJDIR)/cov/raw/$(1)_run.profraw" \
-$(OBJDIR)/fuzz-test/$(1)/$(1) -artifact_prefix=corpus/$(1)/ $(FUZZFLAGS) corpus/$(1)/explore corpus/$(1)
+$(OBJDIR)/fuzz-test/$(1) -artifact_prefix=corpus/$(1)/ $(FUZZFLAGS) corpus/$(1)/explore corpus/$(1)
 
 run-fuzz-test: $(1)_unit
 


### PR DESCRIPTION
Fixes unnecessary nesting of executables in the fuzz-test dir.

Previously: OBJDIR/fuzz-test/fuzz_example/fuzz_example
Now:        OBJDIR/fuzz-test/fuzz_example
