### PR TITLE
txn: remove allow_zero_signatures flag

### DIFF
--- a/src/ballet/txn/fd_txn.h
+++ b/src/ballet/txn/fd_txn.h
@@ -651,26 +651,20 @@ static inline ulong              FD_FN_CONST fd_txn_acct_iter_idx( fd_txn_acct_i
 
    payload_sz_opt, if supplied, gets filled with the total bytes this txn
    uses (allowing for walking of an entry/microblock). If it is not supplied, the
-   parse will return an error if the payload_sz does not exactly match.
-
-   allow_zero_signatures tells the parser we are ok with txn that have zero signatures.
-   This is only used by the test engine to pass invalid transactions into the
-   native programs.
-*/
+   parse will return an error if the payload_sz does not exactly match. */
 
 ulong
 fd_txn_parse_core( uchar const             * payload,
                    ulong                     payload_sz,
                    void                    * out_buf,
                    fd_txn_parse_counters_t * counters_opt,
-                   ulong *                   payload_sz_opt,
-                   int                       allow_zero_signatures );
+                   ulong *                   payload_sz_opt );
 
 
 /* fd_txn_parse: Convenient wrapper around fd_txn_parse_core that eliminates some optional arguments */
 static inline ulong
 fd_txn_parse( uchar const * payload, ulong payload_sz, void * out_buf, fd_txn_parse_counters_t * counters_opt ) {
-  return fd_txn_parse_core(payload, payload_sz, out_buf, counters_opt, NULL, 0);
+  return fd_txn_parse_core( payload, payload_sz, out_buf, counters_opt, NULL );
 }
 
 /* fd_txn_is_writable: Is the account at the supplied index writable

--- a/src/ballet/txn/fd_txn_parse.c
+++ b/src/ballet/txn/fd_txn_parse.c
@@ -8,8 +8,7 @@ fd_txn_parse_core( uchar const             * payload,
                    ulong                     payload_sz,
                    void                    * out_buf,
                    fd_txn_parse_counters_t * counters_opt,
-                   ulong *                   payload_sz_opt,
-                   int                       allow_zero_signatures ) {
+                   ulong *                   payload_sz_opt ) {
   ulong i = 0UL;
   /* This code does non-trivial parsing of untrusted user input, which
      is a potentially dangerous thing.  The main invariants we need to
@@ -86,7 +85,7 @@ fd_txn_parse_core( uchar const             * payload,
      represented the same way. */
   CHECK_LEFT( 1UL                               );   uchar signature_cnt  = payload[ i ];     i++;
   /* Must have at least one signer for the fee payer */
-  CHECK( allow_zero_signatures | ((1UL<=signature_cnt) & (signature_cnt<=FD_TXN_SIG_MAX)) );
+  CHECK( (1UL<=signature_cnt) & (signature_cnt<=FD_TXN_SIG_MAX) );
   CHECK_LEFT( FD_TXN_SIGNATURE_SZ*signature_cnt );   ulong signature_off  =          i  ;     i+=FD_TXN_SIGNATURE_SZ*signature_cnt;
 
   /* Not actually parsing anything, just store. */   ulong message_off    =          i  ;
@@ -105,7 +104,7 @@ fd_txn_parse_core( uchar const             * payload,
   }
   CHECK_LEFT( 1UL                               );   uchar ro_signed_cnt  = payload[ i ];     i++;
   /* Must have at least one writable signer for the fee payer */
-  CHECK( allow_zero_signatures | (ro_signed_cnt<signature_cnt ) );
+  CHECK( ro_signed_cnt<signature_cnt );
 
   CHECK_LEFT( 1UL                               );   uchar ro_unsigned_cnt= payload[ i ];     i++;
 
@@ -126,7 +125,7 @@ fd_txn_parse_core( uchar const             * payload,
   CHECK_LEFT( MIN_INSTR_SZ*instr_cnt            );
   /* If it has >0 instructions, it must have at least one other account
      address (the program id) that can't be the fee payer */
-  CHECK( allow_zero_signatures | ((ulong)acct_addr_cnt>(!!instr_cnt)) );
+  CHECK( (ulong)acct_addr_cnt>(!!instr_cnt) );
 
   fd_txn_t * parsed = (fd_txn_t *)out_buf;
 
@@ -165,7 +164,7 @@ fd_txn_parse_core( uchar const             * payload,
        system program is not permitted to own any executable account.
        As of https://github.com/solana-labs/solana/issues/25034, the
        program ID can't come from a table. */
-    CHECK( allow_zero_signatures | ((0UL < (ulong)program_id) & ((ulong)program_id < (ulong)acct_addr_cnt) ) );
+    CHECK( (0UL < (ulong)program_id) & ((ulong)program_id < (ulong)acct_addr_cnt) );
 
     if( parsed ){
       parsed->instr[ j ].program_id          = program_id;

--- a/src/flamenco/runtime/fd_blockstore.c
+++ b/src/flamenco/runtime/fd_blockstore.c
@@ -397,8 +397,7 @@ fd_blockstore_scan_block( fd_blockstore_t * blockstore, ulong slot, fd_block_t *
                                           fd_ulong_min( sz - blockoff, FD_TXN_MTU ),
                                           txn_out,
                                           NULL,
-                                          &pay_sz,
-                                          0 );
+                                          &pay_sz );
         if( txn_sz == 0 || txn_sz > FD_TXN_MTU ) {
           FD_LOG_ERR( ( "failed to parse transaction %lu in microblock %lu in slot %lu. txn size: %lu",
                         txn_idx,
@@ -734,7 +733,7 @@ fd_blockstore_deshred( fd_blockstore_t * blockstore, ulong slot ) {
   switch( deshredder.result ) {
   case FD_SHRED_ESLOT:
     fd_blockstore_scan_block( blockstore, slot, block );
-    
+
     /* Do this last when it's safe */
     FD_COMPILER_MFENCE();
     block_map_entry->block_gaddr     = fd_wksp_gaddr_fast( wksp, block );
@@ -1265,7 +1264,7 @@ fd_blockstore_init( fd_blockstore_t * blockstore, fd_slot_bank_t const * slot_ba
   block_map_entry->bank_hash = slot_bank->banks_hash;
   /* clang-format off */
   block_map_entry->flags     = fd_uchar_set_bit(
-                               fd_uchar_set_bit( 
+                               fd_uchar_set_bit(
                                fd_uchar_set_bit( block_map_entry->flags,
                                  FD_BLOCK_FLAG_PROCESSED ),
                                  FD_BLOCK_FLAG_CONFIRMED ),

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -383,7 +383,7 @@ int fd_runtime_parse_microblock_txns( void const * buf,
 
   for (ulong i = 0; i < microblock_hdr->txn_cnt; i++) {
     ulong payload_sz = 0;
-    ulong txn_sz = fd_txn_parse_core((uchar const *)buf + buf_off, fd_ulong_min( buf_sz-buf_off, FD_TXN_MTU), TXN(&out_txns[i]), NULL, &payload_sz, 0);
+    ulong txn_sz = fd_txn_parse_core( (uchar const *)buf + buf_off, fd_ulong_min( buf_sz-buf_off, FD_TXN_MTU), TXN(&out_txns[i]), NULL, &payload_sz );
     if (txn_sz == 0 || txn_sz > FD_TXN_MTU) {
       return -1;
     }

--- a/src/flamenco/types/fd_types_custom.c
+++ b/src/flamenco/types/fd_types_custom.c
@@ -11,7 +11,7 @@ fd_flamenco_txn_decode( fd_flamenco_txn_t *       self,
   static FD_TL fd_txn_parse_counters_t counters[1];
   ulong bufsz = (ulong)ctx->dataend - (ulong)ctx->data;
   ulong sz;
-  ulong res = fd_txn_parse_core( ctx->data, bufsz, self->txn, counters, &sz, 0 );
+  ulong res = fd_txn_parse_core( ctx->data, bufsz, self->txn, counters, &sz );
   if( FD_UNLIKELY( !res ) ) {
     /* TODO: Remove this debug print in prod */
     FD_LOG_DEBUG(( "Failed to decode txn (fd_txn.c:%lu)",
@@ -29,7 +29,7 @@ fd_flamenco_txn_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
   ulong bufsz = (ulong)ctx->dataend - (ulong)ctx->data;
   fd_flamenco_txn_t self;
   ulong sz;
-  ulong res = fd_txn_parse_core( ctx->data, bufsz, self.txn, NULL, &sz, 0 );
+  ulong res = fd_txn_parse_core( ctx->data, bufsz, self.txn, NULL, &sz );
   if( FD_UNLIKELY( !res ) ) {
     return -1000001;
   }
@@ -43,7 +43,7 @@ fd_flamenco_txn_decode_unsafe( fd_flamenco_txn_t *       self,
   static FD_TL fd_txn_parse_counters_t counters[1];
   ulong bufsz = (ulong)ctx->dataend - (ulong)ctx->data;
   ulong sz;
-  ulong res = fd_txn_parse_core( ctx->data, bufsz, self->txn, counters, &sz, 0 );
+  ulong res = fd_txn_parse_core( ctx->data, bufsz, self->txn, counters, &sz );
   if( FD_UNLIKELY( !res ) ) {
     FD_LOG_ERR(( "Failed to decode txn (fd_txn.c:%lu)",
                  counters->failure_ring[ counters->failure_cnt % FD_TXN_PARSE_COUNTERS_RING_SZ ] ));


### PR DESCRIPTION
allow_zero_signatures was an ugly hack added by the runtime team,
only used for testing.  We have since moved on to better testing
so we can remove this hack.
