### PR TITLE
config: enable -z relro

### DIFF
--- a/config/extra/with-security.mk
+++ b/config/extra/with-security.mk
@@ -1,6 +1,13 @@
-ifeq ($(FD_DISABLE_OPTIMIZATION),)
-CPPFLAGS+=-D_FORTIFY_SOURCE=2 -fPIC -Wl,-z,now -fstack-protector-strong
-else
-CPPFLAGS+=-fPIC -Wl,-z,now -fstack-protector-strong
-endif
+CPPFLAGS+=-fPIC
 LDFLAGS+=-fPIC
+
+CPPFLAGS+=-Wl,-z,relro,-z,now
+LDFLAGS+=-Wl,-z,relro,-z,now
+
+CPPFLAGS+=-fstack-protector-strong
+LDFLAGS+=-fstack-protector-strong
+
+# _FORTIFY_SOURCE only works when optimization is enabled
+ifeq ($(FD_DISABLE_OPTIMIZATION),)
+CPPFLAGS+=-D_FORTIFY_SOURCE=2
+endif


### PR DESCRIPTION
The relro link flag protects more memory regions as read-only post
startup.  Makes binary sizes and startup times slightly worse.

Also fixes some instances of link flags not being set correctly.

Closes https://github.com/firedancer-io/auditor-runtimeverification/issues/54
