### PR TITLE
flamenco, capture: fix solcap at epoch boundary

### DIFF
--- a/src/flamenco/capture/fd_solcap_proto.h
+++ b/src/flamenco/capture/fd_solcap_proto.h
@@ -144,7 +144,7 @@ typedef struct fd_solcap_account_tbl fd_solcap_account_tbl_t;
 /* FD_SOLCAP_ACC_TBL_CNT is the number of entries that fit in the in-
    memory buffer for the account table. */
 
-#define FD_SOLCAP_ACC_TBL_CNT (8192U)
+#define FD_SOLCAP_ACC_TBL_CNT (2097152U)
 
 /* FD_SOLCAP_FILE_META_FOOTPRINT is the max size of the FileMeta
    Protobuf struct. */

--- a/src/flamenco/capture/fd_solcap_writer.c
+++ b/src/flamenco/capture/fd_solcap_writer.c
@@ -196,11 +196,8 @@ fd_solcap_writer_init( fd_solcap_writer_t * writer,
   }
 
   /* Init writer */
-
-  *writer = (fd_solcap_writer_t) {
-    .file        = (FILE *)file,
-    .stream_goff = (ulong)stream_goff
-  };
+  writer->file        = file;
+  writer->stream_goff = stream_goff;
 
   return writer;
 }
@@ -285,6 +282,7 @@ fd_solcap_flush_account_table( fd_solcap_writer_t * writer ) {
 
   /* FIXME: This breaks account recording for epoch boundaries and needs to be fixed */
   if( writer->account_idx >= FD_SOLCAP_ACC_TBL_CNT ) {
+    FD_LOG_WARNING(( "too many records in solcap accounts table" ));
     writer->account_idx = 0UL;
     return 0;
   }


### PR DESCRIPTION
This is a short-term fix for solcap at mainnet epoch boundaries, where the size of the accounts table needs to be quite large (~1000000). We size it to be the smallest power of 2 greater than the required capacity. We also change the initialization of the writer to avoid smashing the stack.

Note that this is a short-term fix. A better long-term solution would be to dynamically size the table as the size of this account table varies dramatically between epoch boundary slots and non-epoch boundary slots.