### PR TITLE
Drop tiny TPU/UDP packets

### DIFF
--- a/src/app/fdctl/run/tiles/fd_quic.c
+++ b/src/app/fdctl/run/tiles/fd_quic.c
@@ -148,7 +148,7 @@ mux_ctx( void * scratch ) {
 static void
 legacy_stream_notify( fd_quic_ctx_t * ctx,
                       uchar *         packet,
-                      uint            packet_sz ) {
+                      ulong           packet_sz ) {
 
   fd_mux_context_t * mux = ctx->mux;
 
@@ -304,14 +304,21 @@ after_frag( void *             _ctx,
     fd_aio_send( ctx->quic_rx_aio, &pkt, 1, NULL, 1 );
   } else if( FD_LIKELY( proto==DST_PROTO_TPU_UDP ) ) {
     ulong network_hdr_sz = fd_disco_netmux_sig_hdr_sz( *opt_sig );
-    if( FD_UNLIKELY( *opt_sz<network_hdr_sz ) ) {
+    if( FD_UNLIKELY( *opt_sz<=network_hdr_sz ) ) {
       /* Transaction not valid if the packet isn't large enough for the network
          headers. */
       FD_MCNT_INC( QUIC_TILE, NON_QUIC_PACKET_TOO_SMALL, 1UL );
       return;
     }
 
-    if( FD_UNLIKELY( *opt_sz-network_hdr_sz>FD_TPU_MTU ) ) {
+    ulong data_sz = *opt_sz - network_hdr_sz;
+    if( FD_UNLIKELY( data_sz<FD_TXN_MIN_SERIALIZED_SZ ) ) {
+      /* Smaller than the smallest possible transaction */
+      FD_MCNT_INC( QUIC_TILE, NON_QUIC_PACKET_TOO_SMALL, 1UL );
+      return;
+    }
+
+    if( FD_UNLIKELY( data_sz>FD_TPU_MTU ) ) {
       /* Transaction couldn't possibly be valid if it's longer than transaction
          MTU so drop it. This is not required, as the txn will fail to parse,
          but it's a nice short circuit. */
@@ -319,7 +326,7 @@ after_frag( void *             _ctx,
       return;
     }
 
-    legacy_stream_notify( ctx, ctx->buffer+network_hdr_sz, (uint)(*opt_sz - network_hdr_sz) );
+    legacy_stream_notify( ctx, ctx->buffer+network_hdr_sz, data_sz );
   }
 }
 

--- a/src/app/fdctl/run/tiles/fd_shred.c
+++ b/src/app/fdctl/run/tiles/fd_shred.c
@@ -441,7 +441,7 @@ during_frag( void * _ctx,
       FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->net_in_chunk0, ctx->net_in_wmark ));
     uchar const * dcache_entry = fd_chunk_to_laddr_const( ctx->net_in_mem, chunk );
     ulong hdr_sz = fd_disco_netmux_sig_hdr_sz( sig );
-    FD_TEST( hdr_sz < sz ); /* Should be ensured by the net tile */
+    FD_TEST( hdr_sz <= sz ); /* Should be ensured by the net tile */
     fd_shred_t const * shred = fd_shred_parse( dcache_entry+hdr_sz, sz-hdr_sz );
     if( FD_UNLIKELY( !shred ) ) {
       *opt_filter = 1;


### PR DESCRIPTION
Ensure that incoming UDP packets can fit at least a minimum size transaction.
