### PR TITLE
flamenco, fuzz: stub out fd_execute_instr with --wrap

### DIFF
--- a/.github/workflows/clusterfuzz.yml
+++ b/.github/workflows/clusterfuzz.yml
@@ -85,9 +85,16 @@ jobs:
           ls ${{ env.OBJ_DIR }}/fuzz-test
           ls ${{ env.OBJ_DIR }}/lib
 
-      - name: upload lib artifact
+      - name: upload so artifact
         uses: actions/upload-artifact@v4
         with:
           path: ${{ env.OBJ_DIR }}/lib/libfd_exec_sol_compat.so
           name: libfd_exec_sol_compat
+          retention-days: 14
+      
+      - name: upload stubbed so artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: ${{ env.OBJ_DIR }}/lib/libfd_exec_sol_compat_stubbed.so
+          name: libfd_exec_sol_compat_stubbed
           retention-days: 14

--- a/src/flamenco/runtime/tests/Local.mk
+++ b/src/flamenco/runtime/tests/Local.mk
@@ -10,6 +10,15 @@ $(call add-objs,fd_exec_sol_compat,fd_flamenco)
 $(call make-unit-test,test_exec_instr,test_exec_instr,fd_flamenco fd_funk fd_ballet fd_util fd_disco,$(SECP256K1_LIBS))
 $(call make-unit-test,test_exec_sol_compat,test_exec_sol_compat,fd_flamenco fd_funk fd_ballet fd_util fd_disco,$(SECP256K1_LIBS))
 $(call make-shared,libfd_exec_sol_compat.so,fd_exec_sol_compat,fd_flamenco fd_funk fd_ballet fd_util fd_disco,$(SECP256K1_LIBS))
+
+ifdef FD_HAS_FUZZ
+# The --wrap flag stubs out a function so that we can replace it with our own implementation in the fuzz harness(es)
+# See __wrap_fd_execute_instr in  fd_exec_instr_test.c for example
+# We guard this with FD_HAS_FUZZ because the --wrap flag may not be portable across linkers
+WRAP_FLAGS += -Xlinker --wrap=fd_execute_instr
+$(call make-shared,libfd_exec_sol_compat_stubbed.so,fd_exec_sol_compat,fd_flamenco fd_funk fd_ballet fd_util fd_disco,$(SECP256K1_LIBS) $(WRAP_FLAGS))
+endif
+
 endif
 endif
 

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -1807,3 +1807,15 @@ error:
   _instr_context_destroy( runner, ctx, wksp, alloc );
   return 0;
 }
+
+/* Stubs fd_execute_instr for binaries compiled with 
+   `-Xlinker --wrap=fd_execute_instr` */
+int
+__wrap_fd_execute_instr( fd_exec_txn_ctx_t * txn_ctx,
+                         fd_instr_info_t *   instr_info )
+{
+    (void)(txn_ctx);
+    (void)(instr_info);
+    FD_LOG_WARNING(( "fd_execute_instr is disabled" ));
+    return FD_EXECUTOR_INSTR_SUCCESS;
+}


### PR DESCRIPTION
For certain fuzz harnesses (namely, the CPI syscall), we want to control the scope of the fuzzer (which is coverage-guided) by stubbing out certain functions. This PR uses ld's `--wrap` functionality to stub out `fd_execute_instr`. 

This is currently a simple stub, but the plan is to simulate the effects of an `fd_execute_instr` call so that the CPI clean up stage isn't effectively a NO-OP. Wrap allows us to redefine functions in a separate translation unit, which would give the fuzz harnesses more control over what it can do (particularly, access to static variables within TUs).