### PR TITLE
runtime: dump hex diff of syscall memory mismatch

### DIFF
--- a/contrib/test/run_test_vectors.sh
+++ b/contrib/test/run_test_vectors.sh
@@ -28,7 +28,7 @@ else
 fi
 
 LOG=$LOG_PATH/test_exec_syscall
-cat contrib/test/syscall-fixtures.list | xargs ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG
+xargs -a contrib/test/syscall-fixtures.list ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG
 
 LOG=$LOG_PATH/test_exec_precompiles
 cat contrib/test/precompile-fixtures.list | xargs ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG


### PR DESCRIPTION
Print a condensed hex diff of the expected and actual memory contents
after a mismatching syscall.
