### PR TITLE
quic - fixed default.toml - stream_pool was too small to function proerly

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -817,7 +817,7 @@ dynamic_port_range = "8900-9000"
         # underlying link bandwidth.  Supporting more streams per
         # connection currently has a memory footprint cost on the order
         # of kilobytes per stream, per connection.
-        max_concurrent_streams_per_connection = 2048
+        max_concurrent_streams_per_connection = 64
 
         # QUIC uses a fixed-size pool of streams to use for all the
         # connections in the QUIC instance.  When a new connection is
@@ -827,7 +827,7 @@ dynamic_port_range = "8900-9000"
         # reserved, so every connection can be used.  This means that
         # this value must be at least as high as the value of
         # `max_concurrent_connections` above.
-        stream_pool_cnt = 4096
+        stream_pool_cnt = 16384
 
         # Controls how much transactions coming in via TPU can be
         # reassembled at the same time.  Reassembly is required for user


### PR DESCRIPTION
stream pool was so small that all the available streams were allocated to unused connections, and remain there