### PR TITLE
precompiles: simplify return err code

### DIFF
--- a/src/flamenco/runtime/fd_executor_err.h
+++ b/src/flamenco/runtime/fd_executor_err.h
@@ -80,13 +80,12 @@
    the order they decided to write their code.
    These are all fatal errors, so the specific errors doesn't matter for
    consensus.
-   We cover a number of them, but to reduce complexity we just summarize
-   them in 2 codes: error verifying signature, error retrieving data. */
+   To simplify our fuzzers, we return the same error code for all errors. */
 #define FD_EXECUTOR_PRECOMPILE_ERR_PUBLIC_KEY                    ( -1 )
-#define FD_EXECUTOR_PRECOMPILE_ERR_RECOVERY_ID                   ( -2 )
-#define FD_EXECUTOR_PRECOMPILE_ERR_SIGNATURE                     ( -3 )
-#define FD_EXECUTOR_PRECOMPILE_ERR_DATA_OFFSET                   ( -4 )
-#define FD_EXECUTOR_PRECOMPILE_ERR_INSTR_DATA_SIZE               ( -5 )
+#define FD_EXECUTOR_PRECOMPILE_ERR_RECOVERY_ID                   ( -1 )
+#define FD_EXECUTOR_PRECOMPILE_ERR_SIGNATURE                     ( -1 )
+#define FD_EXECUTOR_PRECOMPILE_ERR_DATA_OFFSET                   ( -1 )
+#define FD_EXECUTOR_PRECOMPILE_ERR_INSTR_DATA_SIZE               ( -1 )
 
 #define FD_COMPUTE_BUDGET_PRIORITIZATION_FEE_TYPE_COMPUTE_UNIT_PRICE (0)
 #define FD_COMPUTE_BUDGET_PRIORITIZATION_FEE_TYPE_DEPRECATED         (1)


### PR DESCRIPTION
So far we had to handle special logic to check precompiles result, as the error code is different in firedancer than agave.
With this change (and corresponding change in solfuzz-agave), we no longer need special comparisons.
All precompiles only return success/fail, one single error code.