### PR TITLE
quic - fixed bugs relating to stream pool assignments and MAX_STREAMS frames, changes to defaults.toml

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -823,11 +823,12 @@ dynamic_port_range = "8900-9000"
         # connections in the QUIC instance.  When a new connection is
         # established, QUIC attempts to allocate stream objects to it
         # for incoming peer-initiated streams.  Locally initiated
-        # streams are allocated explicitly.  One stream per connection is
-        # reserved, so every connection can be used.  This means that
+        # streams are allocated explicitly.  16 streams per connection
+        # are reserved, so every connection can be used.  This means that
         # this value must be at least as high as the value of
-        # `max_concurrent_connections` above.
-        stream_pool_cnt = 4096
+        # `max_concurrent_connections` above multiplied by 16, or else
+        # the validator will refuse to start.
+        stream_pool_cnt = 32768
 
         # Controls how much transactions coming in via TPU can be
         # reassembled at the same time.  Reassembly is required for user

--- a/src/waltz/quic/fd_quic_conn.c
+++ b/src/waltz/quic/fd_quic_conn.c
@@ -278,16 +278,24 @@ fd_quic_conn_update_weight( fd_quic_conn_t * conn, uint dirtype ) {
   uint type = peer + ( (uint)dirtype << 1u );
 
   /* get tgt_sup_stream_id, sup_stream_id */
-  ulong tgt_sup_stream_id = conn->tgt_sup_stream_id[type];
-  ulong sup_stream_id     = conn->sup_stream_id[type];
+  ulong tgt_sup_stream_id = conn->tgt_sup_stream_id[type] >> 2UL;
+  ulong sup_stream_id     = conn->sup_stream_id[type]     >> 2UL;
+  ulong cur_stream_cnt    = conn->cur_stream_cnt[type];
 
   /* update the cs_tree */
 
   /* determine the weight */
+  float assigned = (float)cur_stream_cnt;
+  float desired  = (float)fd_ulong_if( tgt_sup_stream_id > sup_stream_id,
+                                ( tgt_sup_stream_id - sup_stream_id ),
+                                0UL );
+  float tot      = assigned + desired;
 
-  ulong weight = fd_ulong_if( tgt_sup_stream_id > sup_stream_id,
-                              ( tgt_sup_stream_id - sup_stream_id ) >> 2UL,
-                              0UL );
+  float MAX_WEIGHT = (float)(1UL<<36UL);
+  float alpha      = logf( MAX_WEIGHT ) / tot;
+
+  /* weight is a function of desired vs assigned */
+  float weight = desired == 0.0f ? 0.0f : expf( alpha * desired );
 
   if( conn->state != FD_QUIC_CONN_STATE_ACTIVE &&
       conn->state != FD_QUIC_CONN_STATE_HANDSHAKE_COMPLETE ) {
@@ -297,7 +305,7 @@ fd_quic_conn_update_weight( fd_quic_conn_t * conn, uint dirtype ) {
   /* set the weight in the cs_tree */
   fd_quic_cs_tree_t * cs_tree = fd_quic_get_state( conn->quic )->cs_tree;
   ulong               idx     = ( conn->conn_idx << 1UL ) + dirtype;
-  fd_quic_cs_tree_update( cs_tree, idx, weight );
+  fd_quic_cs_tree_update( cs_tree, idx, (ulong)weight );
 
   /* don't assign streams here to avoid unwanted recursion */
 }

--- a/src/waltz/quic/fd_quic_conn.h
+++ b/src/waltz/quic/fd_quic_conn.h
@@ -10,6 +10,9 @@
 #include "fd_quic_pkt_meta.h"
 #include "templ/fd_quic_union.h"
 
+/* Minimum number of streams per connection */
+#define FD_QUIC_STREAM_MIN 16UL
+
 #define FD_QUIC_CONN_STATE_INVALID            0 /* dead object / freed */
 #define FD_QUIC_CONN_STATE_HANDSHAKE          1 /* currently doing handshaking with peer */
 #define FD_QUIC_CONN_STATE_HANDSHAKE_COMPLETE 2 /* handshake complete, confirming with peer */
@@ -236,6 +239,9 @@ struct fd_quic_conn {
              0x01 Server-Initiated, Bidirectional
              0x02 Client-Initiated, Unidirectional
              0x03 Server-Initiated, Unidirectional */
+
+  ulong rx_max_streams_unidir_ackd; /* value of MAX_STREAMS acked for UNIDIR */
+  ulong rx_max_streams_bidir_ackd;  /* value of MAX_STREAMS acked for BIDIR */
 
   fd_quic_stream_map_t *  stream_map;           /* map stream_id -> stream */
 

--- a/src/waltz/quic/tests/fd_quic_test_helpers.c
+++ b/src/waltz/quic/tests/fd_quic_test_helpers.c
@@ -197,7 +197,7 @@ fd_quic_new_anonymous_small( fd_wksp_t * wksp,
     .stream_sparsity    = 4.0,
     .inflight_pkt_cnt   = 64UL,
     .tx_buf_sz          = 1UL<<15UL,
-    .stream_pool_cnt    = 16
+    .stream_pool_cnt    = 1024
   };
 
   return fd_quic_new_anonymous( wksp, &quic_limits, role, rng );

--- a/src/waltz/quic/tests/fuzz_quic.c
+++ b/src/waltz/quic/tests/fuzz_quic.c
@@ -142,7 +142,7 @@ int LLVMFuzzerInitialize(int *argc, char ***argv) {
 
   /* Use unoptimized wksp memory */
 
-  ulong wksp_sz = 13107200UL;
+  ulong wksp_sz = 13107200UL * 2;
 
   uchar * mem = aligned_alloc( 4096UL, wksp_sz );
   assert( mem );
@@ -163,7 +163,7 @@ int LLVMFuzzerInitialize(int *argc, char ***argv) {
                                         .handshake_cnt = 10,
                                         .stream_cnt = {0, 0, 10, 0},
                                         .initial_stream_cnt = {0, 0, 10, 0 },
-                                        .stream_pool_cnt = 20,
+                                        .stream_pool_cnt = 640,
                                         .inflight_pkt_cnt = 1024,
                                         .tx_buf_sz = 1 << 14};
 

--- a/src/waltz/quic/tests/fuzz_quic_wire.c
+++ b/src/waltz/quic/tests/fuzz_quic_wire.c
@@ -122,7 +122,7 @@ LLVMFuzzerTestOneInput( uchar const * data,
     .stream_sparsity  = 1.0,
     .inflight_pkt_cnt = 8UL,
     .tx_buf_sz        = 4096UL,
-    .stream_pool_cnt  = 16
+    .stream_pool_cnt  = 1024
   };
 
   /* Enable features depending on the last few bits.  The last bits are


### PR DESCRIPTION
Added a fixed minimum of 16 streams per connection, and fixed the code
Changed the weighting scheme to use a power law, so connections with very few streams will be assigned some with priority
Changed packet metadata to track what value was used for MAX_STREAMS. This is important, or an update can get lost, and the server won't know the client still needs the update.
max_data in packet metadata wasn't being set. Not terribly relevant as we initialize it to an extreme value.
Set `default.toml` quic connections and streams to decent values which actually work with `fddev bench`

