### PR TITLE
util: Added APIs for deque wrapping push_head / push_tail

### DIFF
--- a/src/util/tmpl/fd_deque_dynamic.c
+++ b/src/util/tmpl/fd_deque_dynamic.c
@@ -8,6 +8,16 @@
 
    This creates the following API for use in the local compilation unit:
 
+     // Constructors
+
+     // IMPORTANT SAFETY TIP!  max==0 is fine for this API.  Calling
+     // most APIs on such a deque will be a violation of the API
+     // pre-requisites (e.g. push_head and pop_tail are not valid
+     // because a max==0 deque is simultaneously full and empty).  The
+     // accessors (max==0, cnt==0, avail==0, empty==true, full==true),
+     // remove_all (no-op) and iterators (will indicate nothing to
+     // iterator over) are still valid to use.
+
      ulong      my_deque_align    ( void               ); // required byte alignment of a deque
      ulong      my_deque_footprint( ulong      max     ); // required byte footprint of a deque with max capacity
      void     * my_deque_new      ( void     * shmem,     // format memory region into a my_deque, my_deque will be empty
@@ -27,10 +37,22 @@
 
      // Simple API
 
-     my_ele_t * my_deque_push_head( my_ele_t * deque, my_ele_t ele ); // push ele at the deque head, returns deque
-     my_ele_t * my_deque_push_tail( my_ele_t * deque, my_ele_t ele ); // push ele at the deque tail, returns deque
-     my_ele_t   my_deque_pop_head ( my_ele_t * deque               ); // pops ele from the head of the deque, returns ele
-     my_ele_t   my_deque_pop_tail ( my_ele_t * deque               ); // pops ele from the tail of the deque, returns ele
+     // IMPORTANT SAFETY TIP!  The wrap APIs discard the value popped on
+     // wrapping.  Thus, these should not be used when a my_ele_t might
+     // contain the only reference to a resource (memory, file
+     // descriptors, etc) that might need to be released after popping
+     // (e.g. use these only if my_ele_t is plain-old-data).
+
+     // IMPORTANT SAFETY TIP!  The pop_idx APIs have an O(cnt) worst
+     // case.
+
+     my_ele_t * my_deque_push_head     ( my_ele_t * deque, my_ele_t ele ); // push ele at the deque head, returns deque
+     my_ele_t * my_deque_push_tail     ( my_ele_t * deque, my_ele_t ele ); // push ele at the deque tail, returns deque
+     my_ele_t   my_deque_pop_head      ( my_ele_t * deque               ); // pops ele from the head of the deque, returns ele
+     my_ele_t   my_deque_pop_tail      ( my_ele_t * deque               ); // pops ele from the tail of the deque, returns ele
+     my_ele_t * my_deque_push_head_wrap( my_ele_t * deque, my_ele_t ele ); // push ele at the deque head (pops tail first if deque full), returns deque, assumes deque has a positive max
+     my_ele_t * my_deque_push_tail_wrap( my_ele_t * deque, my_ele_t ele ); // push ele at the deque tail (pops head first if deque full), returns deque, assumes deque has a positive max
+     my_ele_t   my_deque_pop_idx_tail  ( my_ele_t * deque, ulong    idx ); // pops ele at idx, returns ele. idx in [0,cnt). shifts head <= tail
 
      // Advanced API for zero-copy usage
 
@@ -147,7 +169,7 @@ static inline void *
 DEQUE_(new)( void * shmem,
              ulong  max ) {
   DEQUE_(private_t) * hdr = (DEQUE_(private_t) *)shmem;
-  hdr->max1  = max-1UL;
+  hdr->max1  = max-1UL; /* Note: will wrap to ULONG_MAX if max==0 (and ULONG_MAX+1 will wrap back to 0) */
   hdr->cnt   = 0UL;
   hdr->start = 0UL;
   hdr->end   = 0UL;
@@ -246,6 +268,90 @@ DEQUE_(pop_tail)( DEQUE_T * deque ) {
   return ele;
 }
 
+static inline DEQUE_T *
+DEQUE_(push_head_wrap)( DEQUE_T * deque,
+                        DEQUE_T   ele ) {
+  DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
+  ulong max1  = hdr->max1;
+  ulong cnt   = hdr->cnt;
+  ulong start = hdr->start;
+  ulong end   = hdr->end;
+
+# if 0 /* handholding check */
+  if( FD_UNLIKELY( max1==ULONG_MAX ) ) FD_LOG_CRIT(( "cannot push_head_wrap when max is zero" ));
+# endif
+
+  /* If the deque is full, pop and discard the tail. */
+
+  int is_full = (cnt>max1);
+  end  = fd_ulong_if( !is_full, end, DEQUE_(private_prev)( end, max1 ) );
+  cnt -= (ulong)is_full;
+
+  /* Push the head */
+
+  start = DEQUE_(private_prev)( start, max1 );
+  hdr->deque[ start ] = ele;
+
+  hdr->cnt   = cnt + 1UL;
+  hdr->start = start;
+  hdr->end   = end;
+  return deque;
+}
+
+static inline DEQUE_T *
+DEQUE_(push_tail_wrap)( DEQUE_T * deque,
+                        DEQUE_T   ele ) {
+  DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
+  ulong max1  = hdr->max1;
+  ulong cnt   = hdr->cnt;
+  ulong start = hdr->start;
+  ulong end   = hdr->end;
+
+# if 0 /* handholding check */
+  if( FD_UNLIKELY( max1==ULONG_MAX ) ) FD_LOG_CRIT(( "cannot push_tail_wrap when max is zero" ));
+# endif
+
+  /* If the deque is full, pop and discard the head. */
+
+  int is_full = (cnt>max1);
+  start  = fd_ulong_if( !is_full, start, DEQUE_(private_next)( start, max1 ) );
+  cnt   -= (ulong)is_full;
+
+  /* Push the head */
+
+  hdr->deque[ end ] = ele;
+  end = DEQUE_(private_next)( end, max1 );
+
+  hdr->cnt   = cnt + 1UL;
+  hdr->start = start;
+  hdr->end   = end;
+  return deque;
+}
+
+static inline DEQUE_T
+DEQUE_(pop_idx_tail)( DEQUE_T * deque, ulong idx ) {
+  DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
+
+  ulong max1 = hdr->max1;
+
+  ulong slot = hdr->start + idx;
+        slot = fd_ulong_if( slot <= max1, slot, slot - max1 - 1UL );
+  ulong cnt  = --hdr->cnt;
+  ulong rem  = cnt - idx;
+
+  hdr->end   = DEQUE_(private_prev)( hdr->end, max1 );
+
+  DEQUE_T * cur = &deque[ slot ];
+  DEQUE_T   ele = *cur;
+  while( rem-- ) {
+    slot = DEQUE_(private_next)( slot, max1 );
+    DEQUE_T * next = &deque[ slot ];
+    *cur = *next;
+     cur =  next;
+  }
+  return ele;
+}
+
 FD_FN_PURE static inline DEQUE_T *
 DEQUE_(peek_head)( DEQUE_T * deque ) {
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
@@ -328,30 +434,6 @@ DEQUE_(remove_tail)( DEQUE_T * deque ) {
   hdr->cnt   = cnt - 1UL;
   hdr->end   = DEQUE_(private_prev)( end, max1 );
   return deque;
-}
-
-static inline DEQUE_T
-DEQUE_(pop_idx_tail)( DEQUE_T * deque, ulong idx ) {
-  DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
-
-  ulong max1 = hdr->max1;
-
-  ulong slot = hdr->start + idx;
-        slot = fd_ulong_if( slot <= max1, slot, slot - max1 - 1UL );
-  ulong cnt  = --hdr->cnt;
-  ulong rem  = cnt - idx;
-
-  hdr->end   = DEQUE_(private_prev)( hdr->end, max1 );
-
-  DEQUE_T * cur = &deque[ slot ];
-  DEQUE_T   ele = *cur;
-  while( rem-- ) {
-    slot = DEQUE_(private_next)( slot, max1 );
-    DEQUE_T * next = &deque[ slot ];
-    *cur = *next;
-     cur =  next;
-  }
-  return ele;
 }
 
 static inline DEQUE_T *

--- a/src/util/tmpl/test_deque.c
+++ b/src/util/tmpl/test_deque.c
@@ -94,10 +94,10 @@ main( int     argc,
 
     /* Randomly pick an operation to do */
 
-    ulong r = fd_rng_ulong( rng );
-    int   op    = (int)(r & 0xfUL); r >>= 4;
-    int   val   = (int)(uint)r;   r >>= 32;
-    int   reset = !(r & 65535UL); r >>= 16;
+    int   op    = fd_rng_int_roll( rng, 17 ); /* in [0,17) */
+    ulong r     = fd_rng_ulong( rng );
+    int   val   = (int)(uint)r;      r >>= 32;
+    int   reset = !(r & 65535UL);    r >>= 16;
 
     if( FD_UNLIKELY( reset ) ) {
       buf_start = 0UL;
@@ -207,11 +207,25 @@ main( int     argc,
       break;
     }
 
-    case 15: { /* pop index (shift tail to head) */
+    case 14: { /* pop index (shift tail to head) */
       if( FD_UNLIKELY( !buf_cnt ) ) break; /* skip when empty */
       ulong idx = fd_rng_uint_roll( rng, (uint)buf_cnt );
       val = buf_pop_idx( idx );
       FD_TEST( test_deque_pop_idx_tail( deque, idx )==val );
+      break;
+    }
+
+    case 15: { /* push_head_wrap */
+      if( FD_UNLIKELY( buf_cnt>=TEST_DEQUE_MAX ) ) (void)buf_pop_tail(); /* pop when full */
+      buf_push_head( val );
+      FD_TEST( test_deque_push_head_wrap( deque, val )==deque );
+      break;
+    }
+
+    case 16: { /* push_tail_wrap */
+      if( FD_UNLIKELY( buf_cnt>=TEST_DEQUE_MAX ) ) (void)buf_pop_head(); /* pop when full */
+      buf_push_tail( val );
+      FD_TEST( test_deque_push_tail_wrap( deque, val )==deque );
       break;
     }
 

--- a/src/util/tmpl/test_deque_dynamic.c
+++ b/src/util/tmpl/test_deque_dynamic.c
@@ -99,10 +99,10 @@ main( int     argc,
 
     /* Randomly pick an operation to do */
 
-    ulong r = fd_rng_ulong( rng );
-    int   op    = (int)(r & 0xfUL); r >>= 4;
-    int   val   = (int)(uint)r;     r >>= 32;
-    int   reset = !(r & 65535UL);   r >>= 16;
+    int   op    = fd_rng_int_roll( rng, 17 ); /* in [0,17) */
+    ulong r     = fd_rng_ulong( rng );
+    int   val   = (int)(uint)r;      r >>= 32;
+    int   reset = !(r & 65535UL);    r >>= 16;
 
     if( FD_UNLIKELY( reset ) ) {
       buf_start = 0UL;
@@ -217,11 +217,27 @@ main( int     argc,
       break;
     }
 
-    case 15: { /* pop index (shift tail to head) */
+    case 14: { /* pop index (shift tail to head) */
       if( FD_UNLIKELY( !buf_cnt ) ) break; /* skip when empty */
       ulong idx = fd_rng_uint_roll( rng, (uint)buf_cnt );
       val = buf_pop_idx( idx );
       FD_TEST( test_deque_pop_idx_tail( deque, idx )==val );
+      break;
+    }
+
+    case 15: { /* push_head_wrap */
+      if( FD_UNLIKELY( !max ) ) break; /* not valid on max 0 */
+      if( FD_UNLIKELY( buf_cnt>=max ) ) (void)buf_pop_tail(); /* pop when full */
+      buf_push_head( val );
+      FD_TEST( test_deque_push_head_wrap( deque, val )==deque );
+      break;
+    }
+
+    case 16: { /* push_tail_wrap */
+      if( FD_UNLIKELY( !max ) ) break; /* not valid on max 0 */
+      if( FD_UNLIKELY( buf_cnt>=max ) ) (void)buf_pop_head(); /* pop when full */
+      buf_push_tail( val );
+      FD_TEST( test_deque_push_tail_wrap( deque, val )==deque );
       break;
     }
 
@@ -234,6 +250,34 @@ main( int     argc,
     FD_TEST( test_deque_avail( deque )==(max-buf_cnt)  );
     FD_TEST( test_deque_empty( deque )==(!buf_cnt)     );
     FD_TEST( test_deque_full ( deque )==(buf_cnt==max) );
+  }
+
+  FD_TEST( test_deque_leave ( deque   )==shdeque         );
+  FD_TEST( test_deque_delete( shdeque )==(void *)scratch );
+
+  FD_LOG_NOTICE(( "Testing max==0 deque" ));
+
+  shdeque = test_deque_new ( scratch, 0UL ); FD_TEST( shdeque );
+  deque   = test_deque_join( shdeque      ); FD_TEST( deque   );
+
+  FD_TEST( test_deque_max  ( deque )==0UL );
+  FD_TEST( test_deque_cnt  ( deque )==0UL );
+  FD_TEST( test_deque_avail( deque )==0UL );
+  FD_TEST( test_deque_empty( deque )==1   );
+  FD_TEST( test_deque_full ( deque )==1   );
+
+  for( test_deque_iter_t iter=test_deque_iter_init( deque );
+       !test_deque_iter_done( deque, iter );
+       iter = test_deque_iter_next( deque, iter ) ) {
+    int never_get_here = 1;
+    FD_TEST( never_get_here );
+  }
+
+  for( test_deque_iter_t iter=test_deque_iter_init_rev( deque );
+       !test_deque_iter_done_rev( deque, iter );
+       iter = test_deque_iter_prev( deque, iter ) ) {
+    int never_get_here = 1;
+    FD_TEST( never_get_here );
   }
 
   FD_TEST( test_deque_leave ( deque   )==shdeque         );


### PR DESCRIPTION
Adding by popular demand (hat tip to Josh and the folks at Asymmetric Research).  This mimics some implicitly specified behaviors in the Rust equivalent APIs and simplifies replicating that behavior in C/C++. Specifically, push_head_wrap will implicitly deque the tail element first if the deque is full (and vice vice for push_tail_wrap).

Additionally, made it clearer that max==0 run-time sized deques are supported (including unit test coverage so it doesn't get accidentally broken in the future) and stubbed out the handholding checks for the new API to help AR with various testing tasks.