### PR TITLE
flamenco: fix epoch rewards "active" type (+ other Agave bool types)

### DIFF
--- a/contrib/test/instr-fixtures.list
+++ b/contrib/test/instr-fixtures.list
@@ -720,6 +720,7 @@ dump/test-vectors/instr/fixtures/stake/crash-da3d467a4ee38bde652d3ae0a449fc4cb80
 dump/test-vectors/instr/fixtures/stake/crash-db00b687b4a3bee38d27d95c242154938919dbeb.fix
 dump/test-vectors/instr/fixtures/stake/crash-db86181f95cfd87ca25923e27536dfae2079694c.fix
 dump/test-vectors/instr/fixtures/stake/crash-dd736eae7fe5506cb301b7b586a1da4311fc6587.fix
+dump/test-vectors/instr/fixtures/stake/crash-e7a4ec1de85439a91e088ffeea1898d419a16228.fix
 dump/test-vectors/instr/fixtures/stake/crash-e7cd66be85a9d8772b2155d514e2391f63ba6141.fix
 dump/test-vectors/instr/fixtures/stake/crash-e88ff1216b853bb40a7e15297de9c4a24fd8c1c4.fix
 dump/test-vectors/instr/fixtures/stake/crash-e8c57a673dcc06f5ce33641fab0e07db58b7fd88.fix

--- a/src/flamenco/types/fd_types.c
+++ b/src/flamenco/types/fd_types.c
@@ -12650,7 +12650,7 @@ int fd_sysvar_epoch_rewards_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
   err = fd_bincode_uint64_decode_preflight( ctx );
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
-  err = fd_bincode_uint8_decode_preflight( ctx );
+  err = fd_bincode_bool_decode_preflight( ctx );
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
@@ -12661,7 +12661,7 @@ void fd_sysvar_epoch_rewards_decode_unsafe( fd_sysvar_epoch_rewards_t * self, fd
   fd_bincode_uint128_decode_unsafe( &self->total_points, ctx );
   fd_bincode_uint64_decode_unsafe( &self->total_rewards, ctx );
   fd_bincode_uint64_decode_unsafe( &self->distributed_rewards, ctx );
-  fd_bincode_uint8_decode_unsafe( &self->active, ctx );
+  fd_bincode_bool_decode_unsafe( &self->active, ctx );
 }
 int fd_sysvar_epoch_rewards_encode( fd_sysvar_epoch_rewards_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
@@ -12677,7 +12677,7 @@ int fd_sysvar_epoch_rewards_encode( fd_sysvar_epoch_rewards_t const * self, fd_b
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_bincode_uint64_encode( self->distributed_rewards, ctx );
   if( FD_UNLIKELY( err ) ) return err;
-  err = fd_bincode_uint8_encode( (uchar)(self->active), ctx );
+  err = fd_bincode_bool_encode( (uchar)(self->active), ctx );
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
@@ -12703,7 +12703,7 @@ int fd_sysvar_epoch_rewards_decode_offsets( fd_sysvar_epoch_rewards_off_t * self
   err = fd_bincode_uint64_decode_preflight( ctx );
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
   self->active_off = (uint)( (ulong)ctx->data - (ulong)data );
-  err = fd_bincode_uint8_decode_preflight( ctx );
+  err = fd_bincode_bool_decode_preflight( ctx );
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
@@ -12726,7 +12726,7 @@ void fd_sysvar_epoch_rewards_walk( void * w, fd_sysvar_epoch_rewards_t const * s
   fun( w, &self->total_points, "total_points", FD_FLAMENCO_TYPE_UINT128, "uint128", level );
   fun( w, &self->total_rewards, "total_rewards", FD_FLAMENCO_TYPE_ULONG, "ulong", level );
   fun( w, &self->distributed_rewards, "distributed_rewards", FD_FLAMENCO_TYPE_ULONG, "ulong", level );
-  fun( w, &self->active, "active", FD_FLAMENCO_TYPE_UCHAR, "uchar", level );
+  fun( w, &self->active, "active", FD_FLAMENCO_TYPE_BOOL, "bool", level );
   fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_sysvar_epoch_rewards", level-- );
 }
 ulong fd_sysvar_epoch_rewards_size( fd_sysvar_epoch_rewards_t const * self ) {

--- a/src/flamenco/types/fd_types.c
+++ b/src/flamenco/types/fd_types.c
@@ -2695,7 +2695,7 @@ int fd_solana_account_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
   }
   err = fd_bincode_bytes_decode_preflight( 32, ctx );
   if( FD_UNLIKELY( err ) ) return err;
-  err = fd_bincode_uint8_decode_preflight( ctx );
+  err = fd_bincode_bool_decode_preflight( ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_bincode_uint64_decode_preflight( ctx );
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
@@ -2710,7 +2710,7 @@ void fd_solana_account_decode_unsafe( fd_solana_account_t * self, fd_bincode_dec
   } else
     self->data = NULL;
   fd_pubkey_decode_unsafe( &self->owner, ctx );
-  fd_bincode_uint8_decode_unsafe( &self->executable, ctx );
+  fd_bincode_bool_decode_unsafe( &self->executable, ctx );
   fd_bincode_uint64_decode_unsafe( &self->rent_epoch, ctx );
 }
 int fd_solana_account_encode( fd_solana_account_t const * self, fd_bincode_encode_ctx_t * ctx ) {
@@ -2725,7 +2725,7 @@ int fd_solana_account_encode( fd_solana_account_t const * self, fd_bincode_encod
   }
   err = fd_pubkey_encode( &self->owner, ctx );
   if( FD_UNLIKELY( err ) ) return err;
-  err = fd_bincode_uint8_encode( (uchar)(self->executable), ctx );
+  err = fd_bincode_bool_encode( (uchar)(self->executable), ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_bincode_uint64_encode( self->rent_epoch, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -2749,7 +2749,7 @@ int fd_solana_account_decode_offsets( fd_solana_account_off_t * self, fd_bincode
   err = fd_bincode_bytes_decode_preflight( 32, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   self->executable_off = (uint)( (ulong)ctx->data - (ulong)data );
-  err = fd_bincode_uint8_decode_preflight( ctx );
+  err = fd_bincode_bool_decode_preflight( ctx );
   if( FD_UNLIKELY( err ) ) return err;
   self->rent_epoch_off = (uint)( (ulong)ctx->data - (ulong)data );
   err = fd_bincode_uint64_decode_preflight( ctx );
@@ -2776,7 +2776,7 @@ void fd_solana_account_walk( void * w, fd_solana_account_t const * self, fd_type
   fun( w, &self->lamports, "lamports", FD_FLAMENCO_TYPE_ULONG, "ulong", level );
   fun(w, self->data, "data", FD_FLAMENCO_TYPE_UCHAR, "uchar", level );
   fd_pubkey_walk( w, &self->owner, fun, "owner", level );
-  fun( w, &self->executable, "executable", FD_FLAMENCO_TYPE_UCHAR, "uchar", level );
+  fun( w, &self->executable, "executable", FD_FLAMENCO_TYPE_BOOL, "bool", level );
   fun( w, &self->rent_epoch, "rent_epoch", FD_FLAMENCO_TYPE_ULONG, "ulong", level );
   fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_solana_account", level-- );
 }

--- a/src/flamenco/types/fd_types.json
+++ b/src/flamenco/types/fd_types.json
@@ -978,7 +978,7 @@
         { "name": "total_points", "type": "uint128" },
         { "name": "total_rewards", "type": "ulong" },
         { "name": "distributed_rewards", "type": "ulong" },
-        { "name": "active", "type": "uchar" }
+        { "name": "active", "type": "bool" }
       ],
       "comment": "https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/sdk/program/src/epoch_rewards.rs#L14"
     },

--- a/src/flamenco/types/fd_types.json
+++ b/src/flamenco/types/fd_types.json
@@ -188,7 +188,7 @@
         { "name": "lamports", "type": "ulong" },
         { "name": "data", "type": "vector", "element": "uchar" },
         { "name": "owner", "type": "pubkey" },
-        { "name": "executable", "type": "uchar" },
+        { "name": "executable", "type": "bool" },
         { "name": "rent_epoch", "type": "ulong" }
       ],
       "comment": "https://github.com/anza-xyz/agave/blob/6ac4fe32e28d8ceb4085072b61fa0c6cb09baac1/sdk/src/account.rs#L37"


### PR DESCRIPTION
Booleans are decoded differently than uchars - if the byte value is not 0 or 1, the decoding fails.