### PR TITLE
Remove unnecessary code

### DIFF
--- a/src/app/fdctl/run/topos/fd_firedancer.c
+++ b/src/app/fdctl/run/topos/fd_firedancer.c
@@ -578,6 +578,4 @@ fd_topo_firedancer( config_t * _config ) {
     ulong footprint = fd_wksp_footprint( part_max, data_max );
     wksp->page_cnt = footprint / page_sz;
   }
-
-  config->topo = *topo;
 }

--- a/src/app/fdctl/run/topos/fd_frankendancer.c
+++ b/src/app/fdctl/run/topos/fd_frankendancer.c
@@ -302,5 +302,4 @@ fd_topo_frankendancer( config_t * config ) {
   }
 
   fd_topob_finish( topo, fdctl_obj_align, fdctl_obj_footprint, fdctl_obj_loose );
-  config->topo = *topo;
 }


### PR DESCRIPTION
1. Move the call to fcntl( pipefd, F_SETFD, 0 ) into the child process; the parent process will be not impacted, the call to fcntl( pipefd, F_SETFD, FD_CLOEXEC ) can be removed.
2. Remove the while loop around the system call poll. poll only returns 0 if we set a non-negative timeout and expires before any watched file descriptor becomes available. Since we use -1 as a timeout, this would never happen. The option WNOHANG and spurious wakeup logic are also removed because once the poll returns a value other than -1, we are guaranteed that there must be at least one process exit.
3. Remove statement config->topo = *topo. Both the 2 pointers point to the same object and the topo is a big-size struct; assigning it to itself is unnecessary and might be wasteful.