### PR TITLE
flamenco: various BPF loader v3 mismatch fixes

### DIFF
--- a/contrib/test/instr-fixtures.list
+++ b/contrib/test/instr-fixtures.list
@@ -15292,3 +15292,6 @@ dump/test-vectors/instr/fixtures/address-lookup-table/ffcaacd28181455e05bbd94ca9
 dump/test-vectors/instr/fixtures/bpf-loader-v3/asan-91901b5e0f48e1e59d1e4f620354f01fb6cefa3f.fix
 dump/test-vectors/instr/fixtures/bpf-loader-v3/84b8ae94c85eccaf6504d8d247c18d4ad9276d8e.fix
 dump/test-vectors/instr/fixtures/bpf-loader-v3/8e4c4ee5587139615ce74a674b881f06ff284dc5_3220910.fix   
+dump/test-vectors/instr/fixtures/bpf-loader-v3/c572b4b462cff3193528a0d2caff33a2b1d87e82_3252903.fix
+dump/test-vectors/instr/fixtures/bpf-loader-v3/crash-16024ef412d62b56856d9ce608805519d74852af.fix
+dump/test-vectors/instr/fixtures/bpf-loader-v3/crash-61ea95e45c86d739e83f5ad2b765956427990794.fix

--- a/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_v3_program.c
@@ -691,7 +691,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
       programdata_len    = fd_ulong_sat_add( PROGRAMDATA_METADATA_SIZE,
                                              instruction.inner.deploy_with_max_data_len.max_data_len );
 
-      if( FD_UNLIKELY( buffer->const_meta->dlen<BUFFER_METADATA_SIZE || buffer->const_meta->dlen==0UL ) ) {
+      if( FD_UNLIKELY( buffer->const_meta->dlen<BUFFER_METADATA_SIZE || buffer_data_len==0UL ) ) {
         FD_LOG_WARNING(( "Buffer account too small" ));
         return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
       }
@@ -970,7 +970,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
       buffer_lamports    = buffer->const_meta->info.lamports;
       buffer_data_offset = BUFFER_METADATA_SIZE;
       buffer_data_len    = fd_ulong_sat_sub( buffer->const_meta->dlen, buffer_data_offset );
-      if( FD_UNLIKELY( buffer->const_meta->dlen<BUFFER_METADATA_SIZE || buffer->const_meta->dlen==0UL ) ) {
+      if( FD_UNLIKELY( buffer->const_meta->dlen<BUFFER_METADATA_SIZE || buffer_data_len==0UL ) ) {
         FD_LOG_WARNING(( "Buffer account too small" ));
         return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
       }

--- a/src/flamenco/runtime/program/fd_native_cpi.c
+++ b/src/flamenco/runtime/program/fd_native_cpi.c
@@ -55,15 +55,8 @@ fd_native_cpi_execute_system_program_instruction( fd_exec_instr_ctx_t * ctx,
         if( acct_meta->is_writable ) {
           instr_info.acct_flags[j] |= FD_INSTR_ACCT_FLAGS_IS_WRITABLE;
         }
-        if( acct_meta->is_signer && fd_instr_acc_is_signer_idx( ctx->instr, k ) ) {
+        if( acct_meta->is_signer ) {
           instr_info.acct_flags[j] |= FD_INSTR_ACCT_FLAGS_IS_SIGNER;
-        } else {
-          for( ulong k = 0; k < signers_cnt; k++ ) {
-            if( memcmp( &signers[k], &acct_meta->pubkey, sizeof( fd_pubkey_t ) ) == 0 ) {
-              instr_info.acct_flags[j] |= FD_INSTR_ACCT_FLAGS_IS_SIGNER;
-              break;
-            }
-          }
         }
         break;
       }


### PR DESCRIPTION
* Using correct buffer data len
* Modifying inherited signer and writable status in native program CPI calls