### PR TITLE
quic: remove support for bidirectional streams

### DIFF
--- a/src/app/fdctl/run/tiles/fd_quic.c
+++ b/src/app/fdctl/run/tiles/fd_quic.c
@@ -358,9 +358,7 @@ quic_conn_new( fd_quic_conn_t * conn,
 
 static void
 quic_stream_new( fd_quic_stream_t * stream,
-                 void *             _ctx,
-                 int                type ) {
-  (void)type; /* TODO reject bidi streams? */
+                 void *             _ctx ) {
 
   /* Load QUIC state */
 

--- a/src/app/fddev/tiles/fd_benchs.c
+++ b/src/app/fddev/tiles/fd_benchs.c
@@ -222,12 +222,10 @@ handshake_complete( fd_quic_conn_t * conn,
 
 static void
 quic_stream_new( fd_quic_stream_t * stream,
-                 void *             _ctx,
-                 int                type ) {
+                 void *             _ctx ) {
   /* we don't expect the server to initiate streams */
   (void)stream;
   (void)_ctx;
-  (void)type;
 }
 
 /* quic_stream_receive is called back by the QUIC engine when any stream

--- a/src/waltz/quic/fd_quic.h
+++ b/src/waltz/quic/fd_quic.h
@@ -238,12 +238,10 @@ typedef void
 /* fd_quic_cb_stream_new_t is called when the peer creates a new stream.
    Callback should set "context" within the supplied stream object but
    may not change any other stream fields. quic_ctx is the user-provided
-   QUIC context.  Note that this differs from the stream context.
-   stream_type is one of FD_QUIC_TYPE_{UNI,BI}DIR. */
+   QUIC context.  Note that this differs from the stream context. */
 typedef void
 (* fd_quic_cb_stream_new_t)( fd_quic_stream_t * stream,
-                             void *             quic_ctx,
-                             int                stream_type );
+                             void *             quic_ctx );
 
 /* fd_quic_cb_stream_notify_t signals a notable stream event.
    stream_ctx object is the user-provided stream context set in the new

--- a/src/waltz/quic/fd_quic_conn.h
+++ b/src/waltz/quic/fd_quic_conn.h
@@ -241,7 +241,6 @@ struct fd_quic_conn {
              0x03 Server-Initiated, Unidirectional */
 
   ulong rx_max_streams_unidir_ackd; /* value of MAX_STREAMS acked for UNIDIR */
-  ulong rx_max_streams_bidir_ackd;  /* value of MAX_STREAMS acked for BIDIR */
 
   fd_quic_stream_map_t *  stream_map;           /* map stream_id -> stream */
 
@@ -307,7 +306,6 @@ struct fd_quic_conn {
 # define FD_QUIC_CONN_FLAGS_MAX_DATA           (1u<<0u)
 # define FD_QUIC_CONN_FLAGS_CLOSE_SENT         (1u<<1u)
 # define FD_QUIC_CONN_FLAGS_MAX_STREAMS_UNIDIR (1u<<2u)
-# define FD_QUIC_CONN_FLAGS_MAX_STREAMS_BIDIR  (1u<<3u)
 # define FD_QUIC_CONN_FLAGS_PING               (1u<<4u)
 # define FD_QUIC_CONN_FLAGS_PING_SENT          (1u<<5u)
 
@@ -315,11 +313,7 @@ struct fd_quic_conn {
 
   /* max stream data per stream type */
   ulong                tx_initial_max_stream_data_uni;
-  ulong                tx_initial_max_stream_data_bidi_local;
-  ulong                tx_initial_max_stream_data_bidi_remote;
   ulong                rx_initial_max_stream_data_uni;
-  ulong                rx_initial_max_stream_data_bidi_local;
-  ulong                rx_initial_max_stream_data_bidi_remote;
 
   /* last tx packet num with max_data frame referring to this stream
      set to next_pkt_number to indicate a new max_data frame should be sent

--- a/src/waltz/quic/fd_quic_pkt_meta.h
+++ b/src/waltz/quic/fd_quic_pkt_meta.h
@@ -93,7 +93,6 @@ struct fd_quic_pkt_meta {
        FD_QUIC_PKT_META_FLAGS_MAX_DATA            max_data frame
        FD_QUIC_PKT_META_FLAGS_MAX_STREAM_DATA     max_stream_data frame
        FD_QUIC_PKT_META_FLAGS_MAX_STREAMS_UNIDIR  max_streams frame (unidir)
-       FD_QUIC_PKT_META_FLAGS_MAX_STREAMS_BIDIR   max_streams frame (bidir)
        FD_QUIC_PKT_META_FLAGS_ACK                 acknowledgement
        FD_QUIC_PKT_META_FLAGS_CLOSE               close frame
        FD_QUIC_PKT_META_FLAGS_KEY_UPDATE          indicates key update was in effect

--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -281,10 +281,9 @@ fd_quic_cb_conn_final( fd_quic_t *      quic,
 
 static inline void
 fd_quic_cb_stream_new( fd_quic_t *        quic,
-                       fd_quic_stream_t * stream,
-                       int                stream_type ) {
+                       fd_quic_stream_t * stream ) {
   if( FD_UNLIKELY( !quic->cb.stream_new ) ) return;
-  quic->cb.stream_new( stream, quic->cb.quic_ctx, stream_type );
+  quic->cb.stream_new( stream, quic->cb.quic_ctx );
 
   /* update metrics */
   ulong stream_id = stream->stream_id;

--- a/src/waltz/quic/tests/fd_quic_sandbox.c
+++ b/src/waltz/quic/tests/fd_quic_sandbox.c
@@ -330,11 +330,7 @@ fd_quic_sandbox_new_conn_established( fd_quic_sandbox_t * sandbox,
   conn->rx_tot_data      = 0UL;
   conn->rx_max_data_ackd = 0UL;
   conn->tx_initial_max_stream_data_uni         = 0UL;
-  conn->tx_initial_max_stream_data_bidi_local  = 0UL;
-  conn->tx_initial_max_stream_data_bidi_remote = 0UL;
   conn->rx_initial_max_stream_data_uni         = 0UL;
-  conn->rx_initial_max_stream_data_bidi_local  = 0UL;
-  conn->rx_initial_max_stream_data_bidi_remote = 0UL;
 
   /* TODO set a realistic packet number */
 

--- a/src/waltz/quic/tests/fd_quic_test_helpers.c
+++ b/src/waltz/quic/tests/fd_quic_test_helpers.c
@@ -48,10 +48,9 @@ fd_quic_test_cb_conn_final( fd_quic_conn_t * conn,
 
 static void
 fd_quic_test_cb_stream_new( fd_quic_stream_t * stream,
-                            void *             quic_ctx,
-                            int                stream_type ) {
-  FD_LOG_DEBUG(( "cb_stream_new(stream=%lu, quic_ctx=%p, stream_type=%#x)",
-                 stream->stream_id, (void *)quic_ctx, stream_type ));
+                            void *             quic_ctx ) {
+  FD_LOG_DEBUG(( "cb_stream_new(stream=%lu, quic_ctx=%p)",
+                 stream->stream_id, (void *)quic_ctx ));
 }
 
 static void

--- a/src/waltz/quic/tests/fuzz_quic_wire.c
+++ b/src/waltz/quic/tests/fuzz_quic_wire.c
@@ -167,12 +167,8 @@ LLVMFuzzerTestOneInput( uchar const * data,
 
   conn->tx_max_data                            =       512UL;
   conn->tx_initial_max_stream_data_uni         =        64UL;
-  conn->tx_initial_max_stream_data_bidi_local  =        64UL;
-  conn->tx_initial_max_stream_data_bidi_remote =        64UL;
   conn->rx_max_data                            =       512UL;
   conn->rx_initial_max_stream_data_uni         =        64UL;
-  conn->rx_initial_max_stream_data_bidi_local  =        64UL;
-  conn->rx_initial_max_stream_data_bidi_remote =        64UL;
   conn->tx_max_datagram_sz                     = FD_QUIC_MTU;
   fd_quic_conn_set_max_streams( conn, 0, 1 );
   fd_quic_conn_set_max_streams( conn, 1, 1 );

--- a/src/waltz/quic/tests/test_quic_txns.c
+++ b/src/waltz/quic/tests/test_quic_txns.c
@@ -50,11 +50,9 @@ cb_conn_final( fd_quic_conn_t * conn,
 
 void
 cb_stream_new( fd_quic_stream_t * stream,
-               void *             quic_ctx,
-               int stream_type ) {
+               void *             quic_ctx ) {
   (void)stream;
   (void)quic_ctx;
-  (void)stream_type;
   FD_LOG_NOTICE(( "cb_stream_new" ));
 }
 


### PR DESCRIPTION
Not required for Solana TPU protocol.
No plans to implement the 'repair over QUIC' protocol.
