### PR TITLE
flamenco: use correct lamports value for updating sysvar accounts

### DIFF
--- a/src/flamenco/runtime/sysvar/fd_sysvar.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar.c
@@ -10,8 +10,7 @@ fd_sysvar_set( fd_exec_slot_ctx_t * slot_ctx,
                fd_pubkey_t const *  pubkey,
                void const *         data,
                ulong                sz,
-               ulong                slot,
-               ulong                lamports ) {
+               ulong                slot ) {
 
   fd_acc_mgr_t *  acc_mgr  = slot_ctx->acc_mgr;
   fd_funk_txn_t * funk_txn = slot_ctx->funk_txn;
@@ -27,7 +26,10 @@ fd_sysvar_set( fd_exec_slot_ctx_t * slot_ctx,
   /* https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/runtime/src/bank.rs#L1825 */
   fd_acc_lamports_t lamports_before = rec->meta->info.lamports;
   fd_epoch_bank_t * epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
-  fd_acc_lamports_t lamports_after = fd_ulong_max( lamports, fd_rent_exempt_minimum_balance2( &epoch_bank->rent, sz ) );
+  /* https://github.com/anza-xyz/agave/blob/ae18213c19ea5335dfc75e6b6116def0f0910aff/runtime/src/bank.rs#L6184
+     The account passed in via the updater is always the current sysvar account, so we take the max of the
+     current account lamports and the minimum rent exempt balance needed. */
+  fd_acc_lamports_t lamports_after = fd_ulong_max( lamports_before, fd_rent_exempt_minimum_balance2( &epoch_bank->rent, sz ) );
   rec->meta->info.lamports = lamports_after;
 
   /* https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/runtime/src/bank.rs#L1826 */

--- a/src/flamenco/runtime/sysvar/fd_sysvar.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar.h
@@ -14,7 +14,6 @@ fd_sysvar_set( fd_exec_slot_ctx_t * state,
                fd_pubkey_t const *  pubkey,
                void const *         data,
                ulong                sz,
-               ulong                slot,
-               ulong                lamports );
+               ulong                slot );
 
 #endif /* HEADER_fd_src_flamenco_runtime_fd_sysvar_h */

--- a/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
@@ -42,7 +42,7 @@ write_clock( fd_exec_slot_ctx_t *    slot_ctx,
   if( fd_sol_sysvar_clock_encode( clock, &ctx ) )
     FD_LOG_ERR(("fd_sol_sysvar_clock_encode failed"));
 
-  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, (fd_pubkey_t *) &fd_sysvar_clock_id, enc, sz, slot_ctx->slot_bank.slot, 0UL );
+  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, (fd_pubkey_t *) &fd_sysvar_clock_id, enc, sz, slot_ctx->slot_bank.slot );
 }
 
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.c
@@ -18,7 +18,7 @@ write_epoch_rewards( fd_exec_slot_ctx_t * slot_ctx, fd_sysvar_epoch_rewards_t * 
     FD_LOG_ERR(("fd_sysvar_epoch_rewards_encode failed"));
   }
 
-  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_epoch_rewards_id, enc, sz, slot_ctx->slot_bank.slot, 0UL );
+  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_epoch_rewards_id, enc, sz, slot_ctx->slot_bank.slot );
 }
 
 fd_sysvar_epoch_rewards_t *

--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.c
@@ -46,7 +46,7 @@ write_epoch_schedule( fd_exec_slot_ctx_t  * slot_ctx,
   if ( fd_epoch_schedule_encode( epoch_schedule, &ctx ) )
     FD_LOG_ERR(("fd_epoch_schedule_encode failed"));
 
-  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_epoch_schedule_id, enc, sz, slot_ctx->slot_bank.slot, 0UL );
+  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_epoch_schedule_id, enc, sz, slot_ctx->slot_bank.slot );
 }
 
 fd_epoch_schedule_t *

--- a/src/flamenco/runtime/sysvar/fd_sysvar_fees.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_fees.c
@@ -15,7 +15,7 @@ write_fees( fd_exec_slot_ctx_t* slot_ctx, fd_sysvar_fees_t* fees ) {
   if ( fd_sysvar_fees_encode( fees, &ctx ) )
     FD_LOG_ERR(("fd_sysvar_fees_encode failed"));
 
-  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_fees_id, enc, sz, slot_ctx->slot_bank.slot, 0UL );
+  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_fees_id, enc, sz, slot_ctx->slot_bank.slot );
 }
 
 fd_sysvar_fees_t *

--- a/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.c
@@ -30,8 +30,7 @@ fd_sysvar_last_restart_slot_init( fd_exec_slot_ctx_t * slot_ctx ) {
                  fd_sysvar_owner_id.key,
                  &fd_sysvar_last_restart_slot_id,
                  enc, sz,
-                 slot_ctx->slot_bank.slot,
-                 0UL );
+                 slot_ctx->slot_bank.slot );
 }
 
 fd_sol_sysvar_last_restart_slot_t *
@@ -82,7 +81,6 @@ fd_sysvar_last_restart_slot_update( fd_exec_slot_ctx_t * slot_ctx ) {
         slot_ctx, fd_sysvar_owner_id.key,
         &fd_sysvar_last_restart_slot_id,
         &last_restart_slot, sizeof(ulong),
-        slot_ctx->slot_bank.slot,
-        0UL );
+        slot_ctx->slot_bank.slot );
   }
 }

--- a/src/flamenco/runtime/sysvar/fd_sysvar_recent_hashes.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_recent_hashes.c
@@ -36,7 +36,7 @@ void fd_sysvar_recent_hashes_init( fd_exec_slot_ctx_t* slot_ctx ) {
   if ( fd_recent_block_hashes_encode(&slot_ctx->slot_bank.recent_block_hashes, &ctx) )
     FD_LOG_ERR(("fd_recent_block_hashes_encode failed"));
 
-  fd_sysvar_set(slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_recent_block_hashes_id, enc, sz, slot_ctx->slot_bank.slot, 0UL );
+  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_recent_block_hashes_id, enc, sz, slot_ctx->slot_bank.slot );
 }
 
 // https://github.com/anza-xyz/agave/blob/e8750ba574d9ac7b72e944bc1227dc7372e3a490/accounts-db/src/blockhash_queue.rs#L113
@@ -99,7 +99,7 @@ void fd_sysvar_recent_hashes_update( fd_exec_slot_ctx_t* slot_ctx ) {
   if ( fd_recent_block_hashes_encode(&slot_ctx->slot_bank.recent_block_hashes, &ctx) )
     FD_LOG_ERR(("fd_recent_block_hashes_encode failed"));
 
-  fd_sysvar_set(slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_recent_block_hashes_id, enc, sz, slot_ctx->slot_bank.slot, 0UL);
+  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_recent_block_hashes_id, enc, sz, slot_ctx->slot_bank.slot );
 
   register_blockhash( slot_ctx, &slot_ctx->slot_bank.poh );
 }

--- a/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
@@ -50,7 +50,7 @@ write_rent( fd_exec_slot_ctx_t * slot_ctx,
   if( fd_rent_encode( rent, &ctx ) )
     FD_LOG_ERR(("fd_rent_encode failed"));
 
-  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_rent_id, enc, sz, slot_ctx->slot_bank.slot, 0UL );
+  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_rent_id, enc, sz, slot_ctx->slot_bank.slot );
 }
 
 void

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
@@ -23,7 +23,7 @@ void write_slot_hashes( fd_exec_slot_ctx_t * slot_ctx, fd_slot_hashes_t* slot_ha
   if ( fd_slot_hashes_encode( slot_hashes, &ctx ) )
     FD_LOG_ERR(("fd_slot_hashes_encode failed"));
 
-  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_slot_hashes_id, enc, sz, slot_ctx->slot_bank.slot, 0UL );
+  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_slot_hashes_id, enc, sz, slot_ctx->slot_bank.slot );
 }
 
 //void fd_sysvar_slot_hashes_init( fd_slot_ctx_ctx_t* slot_ctx ) {

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
@@ -44,7 +44,7 @@ int fd_sysvar_slot_history_write_history( fd_exec_slot_ctx_t * slot_ctx,
   int err = fd_slot_history_encode( history, &ctx );
   if (0 != err)
     return err;
-  return fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_slot_history_id, enc, sz, slot_ctx->slot_bank.slot, 0UL );
+  return fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_slot_history_id, enc, sz, slot_ctx->slot_bank.slot );
 }
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/slot_history.rs#L16 */

--- a/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.c
@@ -19,7 +19,7 @@ write_stake_history( fd_exec_slot_ctx_t * slot_ctx,
   if( FD_UNLIKELY( fd_stake_history_encode( stake_history, &encode )!=FD_BINCODE_SUCCESS ) )
     FD_LOG_ERR(("fd_stake_history_encode failed"));
 
-  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_stake_history_id, enc, sizeof(enc), slot_ctx->slot_bank.slot, 0UL );
+  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_stake_history_id, enc, sizeof(enc), slot_ctx->slot_bank.slot );
 }
 
 fd_stake_history_t *


### PR DESCRIPTION
The updater used in Agave for updating sysvar account balance retains the initial lamport balance to calculate the new balance.
Closes [#195](https://github.com/firedancer-io/auditor-internal/issues/195)