### PR TITLE
flamenco, runtime: correctly handle features getting activated at epoch boundary

### DIFF
--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -3518,8 +3518,8 @@ void fd_process_new_epoch(
   (void)epoch;
 
   // activate feature flags
-  fd_features_restore( slot_ctx );
   fd_features_activate( slot_ctx );
+  fd_features_restore( slot_ctx );
 
   // Change the speed of the poh clock
   if (FD_FEATURE_ACTIVE(slot_ctx, update_hashes_per_tick6))


### PR DESCRIPTION
At the epoch boundary, we need to first update the feature account and then update the in-memory map, not the other way around.