### PR TITLE
config: enable -maes for linux_clang_haswell

### DIFF
--- a/config/machine/linux_clang_haswell.mk
+++ b/config/machine/linux_clang_haswell.mk
@@ -9,7 +9,7 @@ include config/extra/with-brutality.mk
 include config/extra/with-optimization.mk
 include config/extra/with-threads.mk
 
-CPPFLAGS+=-march=haswell -mtune=haswell
+CPPFLAGS+=-march=haswell -mtune=haswell -maes
 
 CPPFLAGS+=\
   -DFD_HAS_INT128=1 \


### PR DESCRIPTION
Fixes build failure on main. Some low end Haswell CPUs don't support hardware AES.