### PR TITLE
flamenco, vm: treat LDQ_ADDL_IMM as sigill 

### DIFF
--- a/src/flamenco/vm/fd_vm_interp_core.c
+++ b/src/flamenco/vm/fd_vm_interp_core.c
@@ -182,9 +182,8 @@ interp_exec:
   FD_VM_INTERP_INSTR_EXEC;
 
   /* 0x00 - 0x0f ******************************************************/
-
-/* FIXME: MORE THINKING AROUND LDQ HANDLING HERE (see below) */
-interp_0x00: // FD_SBPF_OP_ADDL_IMM
+  /* SKIP 0x00 (FD_SBPF_OP_ADDL_IMM). Agave treats this as an UnsupportedInstruction (sigill)
+     https://github.com/solana-labs/rbpf/blob/v0.8.5/src/jit.rs#L426 */
 
   FD_VM_INTERP_INSTR_BEGIN(0x04) /* FD_SBPF_OP_ADD_IMM */
     reg[ dst ] = (ulong)(long)( (int)reg_dst + (int)imm );

--- a/src/flamenco/vm/fd_vm_interp_jump_table.c
+++ b/src/flamenco/vm/fd_vm_interp_jump_table.c
@@ -6,7 +6,7 @@
 
 #   define OPCODE(opcode) interp_##opcode
 
-    /* 0x00 */ &&OPCODE(0x00), /* 0x01 */ &&sigill,       /* 0x02 */ &&sigill,       /* 0x03 */ &&sigill,
+    /* 0x00 */ &&sigill,       /* 0x01 */ &&sigill,       /* 0x02 */ &&sigill,       /* 0x03 */ &&sigill,
     /* 0x04 */ &&OPCODE(0x04), /* 0x05 */ &&OPCODE(0x05), /* 0x06 */ &&sigill,       /* 0x07 */ &&OPCODE(0x07),
     /* 0x08 */ &&sigill,       /* 0x09 */ &&sigill,       /* 0x0a */ &&sigill,       /* 0x0b */ &&sigill,
     /* 0x0c */ &&OPCODE(0x0c), /* 0x0d */ &&sigill,       /* 0x0e */ &&sigill,       /* 0x0f */ &&OPCODE(0x0f),


### PR DESCRIPTION
To follow Agave's handling of jumping-into-addl-imm case

TODO: 
- [ ] add fixture