### PR TITLE
flamenco, runtime: fix loading incremental snapshots

### DIFF
--- a/src/flamenco/snapshot/fd_snapshot.c
+++ b/src/flamenco/snapshot/fd_snapshot.c
@@ -81,6 +81,7 @@ load_one_snapshot( fd_exec_slot_ctx_t * slot_ctx,
     name_out->slot = slot_ctx->slot_bank.slot;
     return;
   }
+  fd_exec_epoch_ctx_bank_mem_clear( slot_ctx->epoch_ctx );
 
   fd_valloc_t     valloc   = slot_ctx->valloc;
   fd_acc_mgr_t *  acc_mgr  = slot_ctx->acc_mgr;


### PR DESCRIPTION
We need to clear the epoch bank every time, otherwise the incremental snapshot will try and populate a data structure which is already full.