### PR TITLE
flamenco: make ALUT decode errors conformant + prevent OOB memory accesses

### DIFF
--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -91,7 +91,7 @@ fd_execute_txn( fd_exec_txn_ctx_t * txn_ctx );
 uint
 fd_executor_txn_uses_sysvar_instructions( fd_exec_txn_ctx_t const * txn_ctx );
 
-void
+int
 fd_executor_setup_accessed_accounts_for_txn( fd_exec_txn_ctx_t * txn_ctx );
 
 void

--- a/src/flamenco/runtime/program/fd_address_lookup_table_program.h
+++ b/src/flamenco/runtime/program/fd_address_lookup_table_program.h
@@ -7,6 +7,9 @@
 #define FD_ADDRLUT_STATUS_DEACTIVATING (1)
 #define FD_ADDRLUT_STATUS_DEACTIVATED  (2)
 
+/* https://github.com/firedancer-io/agave/blob/368ea563c423b0a85cc317891187e15c9a321521/sdk/program/src/address_lookup_table/state.rs#L19 */
+#define FD_LOOKUP_TABLE_META_SIZE      (56)
+
 FD_PROTOTYPES_BEGIN
 
 int


### PR DESCRIPTION
Also properly propagate errors from `fd_execute_txn_prepare_start` 