### PR TITLE
flamenco, fuzz: CPI execution side-effects

### DIFF
--- a/contrib/tool/dump_cpi.patch
+++ b/contrib/tool/dump_cpi.patch
@@ -1,0 +1,43 @@
+diff --git a/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c b/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
+index 336b002c2..0403a4909 100644
+--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
++++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
+@@ -594,6 +594,10 @@ VM_SYSCALL_CPI_ENTRYPOINT( void *  _vm,
+ 
+   FD_VM_CU_UPDATE( vm, FD_VM_INVOKE_UNITS );
+ 
++  fd_exec_test_syscall_context_t sys_ctx = FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_DEFAULT;
++  dump_vm_cpi_state(vm, STRINGIFY(FD_EXPAND_THEN_CONCAT2(sol_invoke_signed_, VM_SYSCALL_CPI_ABI)),
++                    instruction_va, acct_infos_va, acct_info_cnt, signers_seeds_va, signers_seeds_cnt, &sys_ctx);
++
+   /* Pre-flight checks ************************************************/
+   int err = fd_vm_syscall_cpi_preflight_check( signers_seeds_cnt, acct_info_cnt, vm->instr_ctx->slot_ctx );
+   if( FD_UNLIKELY( err ) ) return err;
+@@ -732,18 +736,27 @@ VM_SYSCALL_CPI_ENTRYPOINT( void *  _vm,
+     }
+   }
+ 
++  sys_ctx.has_exec_effects = 1;
++  sys_ctx.exec_effects.modified_accounts_count = (pb_size_t) caller_accounts_to_update_len;
++  sys_ctx.exec_effects.modified_accounts = fd_scratch_alloc( 8UL, sizeof(fd_exec_test_acct_state_t) * caller_accounts_to_update_len );
++
+   /* Update the caller accounts with any changes made by the callee during CPI execution */
+   for( ulong i=0UL; i<caller_accounts_to_update_len; i++ ) {
+     /* https://github.com/firedancer-io/solana/blob/508f325e19c0fd8e16683ea047d7c1a85f127e74/programs/bpf_loader/src/syscalls/cpi.rs#L939-L943 */
+     /* We only want to update the writable accounts, because the non-writable 
+        caller accounts can't be changed during a CPI execution. */
+     if( fd_instr_acc_is_writable_idx( vm->instr_ctx->instr, callee_account_keys[i] ) ) {
++      dump_acct_to_state( vm->instr_ctx->instr, callee_account_keys[i], &sys_ctx.exec_effects.modified_accounts[i] );
+       fd_pubkey_t const * callee = &vm->instr_ctx->instr->acct_pubkeys[callee_account_keys[i]];
+       err = VM_SYSCALL_CPI_UPDATE_CALLER_ACC_FUNC(vm, &acc_infos[caller_accounts_to_update[i]], (uchar)callee_account_keys[i], callee);
+       if( FD_UNLIKELY( err ) ) return err;
+     }
+   }
+ 
++  char filename[256];
++  gen_cpi_state_filename( &vm->instr_ctx->instr->program_id_pubkey, VM_SYSCALL_CPI_INSTR_DATA_LEN( cpi_instruction ), filename );
++  dump_pb_to_file( &sys_ctx, filename, FD_EXEC_TEST_SYSCALL_CONTEXT_FIELDS );
++
+   caller_lamports_h = 0UL;
+   caller_lamports_l = 0UL;
+   err = fd_instr_info_sum_account_lamports( vm->instr_ctx->instr, &caller_lamports_h, &caller_lamports_l );

--- a/contrib/tool/dump_cpi_on_replay.sh
+++ b/contrib/tool/dump_cpi_on_replay.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+# This script is used to dump the a SyscallContext during CPIs executed on a ledger.
+# Run this from the root of the firedancer repository
+# Must have a "dump/vm_cpi_state" directory in the root of the firedancer repository
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+set -e
+
+# Apply the patch and build the project
+git apply $SCRIPT_DIR/dump_cpi.patch
+make -j  bin lib
+
+# Run the replay command 
+build/native/gcc/bin/fd_ledger --cmd replay --verify-acc-hash 1 --rocksdb dump/mainnet-265330432/rocksdb --index-max 5000000 --end-slot 265330433 --cluster-version 1190 --page-cnt 30 --funk-page-cnt 16 --snapshot dump/mainnet-265330432/snapshot-265330431-BMvcRhxNoRtkZ5KLEKhhXM6GiWdTgdkoGLMe86xY4rF.tar.zst --allocator wksp --tile-cpus 5-21
+
+# Revert the patch and clean the project
+git apply -R contrib/tool/dump_cpi.patch
+make -j  clean
+
+set +e

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -1797,7 +1797,10 @@ fd_exec_vm_syscall_test_run( fd_exec_instr_test_runner_t * runner,
   int syscall_err = syscall->func( vm, vm->reg[1], vm->reg[2], vm->reg[3], vm->reg[4], vm->reg[5], &vm->reg[0] );
 
   /* Capture the effects */
-  effects->error = -syscall_err;
+
+  /* Ignore Lamport mismatches since Agave performs this check outside of the CPI */
+  effects->error = syscall_err == FD_VM_CPI_ERR_LAMPORTS_MISMATCH ? 0 : -syscall_err;
+
   effects->r0 = syscall_err ? 0 : vm->reg[0]; // Save only on success
   effects->cu_avail = (ulong)vm->cu;
 

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -1718,7 +1718,7 @@ fd_exec_vm_syscall_test_run( fd_exec_instr_test_runner_t * runner,
     input_regions_count = setup_vm_input_regions( input_regions, input->vm_ctx.input_data_regions, input->vm_ctx.input_data_regions_count );
   }
 
-  if (input->vm_ctx.heap_max > FD_VM_HEAP_DEFAULT) {
+  if (input->vm_ctx.heap_max > FD_VM_HEAP_MAX) {
     goto error;
   }
 

--- a/src/flamenco/runtime/tests/generated/vm.pb.h
+++ b/src/flamenco/runtime/tests/generated/vm.pb.h
@@ -85,6 +85,9 @@ typedef struct fd_exec_test_syscall_context {
     fd_exec_test_instr_context_t instr_ctx;
     bool has_syscall_invocation;
     fd_exec_test_syscall_invocation_t syscall_invocation;
+    /* For CPI, we want to control the effects of a program invocation */
+    bool has_exec_effects;
+    fd_exec_test_instr_effects_t exec_effects;
 } fd_exec_test_syscall_context_t;
 
 /* The effects of executing a SyscallContext. */
@@ -151,7 +154,7 @@ extern "C" {
 #define FD_EXEC_TEST_INPUT_DATA_REGION_INIT_DEFAULT {0, NULL, 0}
 #define FD_EXEC_TEST_VM_CONTEXT_INIT_DEFAULT     {0, NULL, 0, 0, 0, NULL, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, NULL, 0}
 #define FD_EXEC_TEST_SYSCALL_INVOCATION_INIT_DEFAULT {{0, {0}}, NULL, NULL}
-#define FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_DEFAULT {false, FD_EXEC_TEST_VM_CONTEXT_INIT_DEFAULT, false, FD_EXEC_TEST_INSTR_CONTEXT_INIT_DEFAULT, false, FD_EXEC_TEST_SYSCALL_INVOCATION_INIT_DEFAULT}
+#define FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_DEFAULT {false, FD_EXEC_TEST_VM_CONTEXT_INIT_DEFAULT, false, FD_EXEC_TEST_INSTR_CONTEXT_INIT_DEFAULT, false, FD_EXEC_TEST_SYSCALL_INVOCATION_INIT_DEFAULT, false, FD_EXEC_TEST_INSTR_EFFECTS_INIT_DEFAULT}
 #define FD_EXEC_TEST_SYSCALL_EFFECTS_INIT_DEFAULT {0, 0, 0, NULL, NULL, NULL, 0, NULL, NULL, 0, 0, NULL}
 #define FD_EXEC_TEST_SYSCALL_FIXTURE_INIT_DEFAULT {false, FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_DEFAULT, false, FD_EXEC_TEST_SYSCALL_EFFECTS_INIT_DEFAULT}
 #define FD_EXEC_TEST_FULL_VM_CONTEXT_INIT_DEFAULT {false, FD_EXEC_TEST_VM_CONTEXT_INIT_DEFAULT, false, FD_EXEC_TEST_FEATURE_SET_INIT_DEFAULT}
@@ -160,7 +163,7 @@ extern "C" {
 #define FD_EXEC_TEST_INPUT_DATA_REGION_INIT_ZERO {0, NULL, 0}
 #define FD_EXEC_TEST_VM_CONTEXT_INIT_ZERO        {0, NULL, 0, 0, 0, NULL, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, NULL, 0}
 #define FD_EXEC_TEST_SYSCALL_INVOCATION_INIT_ZERO {{0, {0}}, NULL, NULL}
-#define FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_ZERO   {false, FD_EXEC_TEST_VM_CONTEXT_INIT_ZERO, false, FD_EXEC_TEST_INSTR_CONTEXT_INIT_ZERO, false, FD_EXEC_TEST_SYSCALL_INVOCATION_INIT_ZERO}
+#define FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_ZERO   {false, FD_EXEC_TEST_VM_CONTEXT_INIT_ZERO, false, FD_EXEC_TEST_INSTR_CONTEXT_INIT_ZERO, false, FD_EXEC_TEST_SYSCALL_INVOCATION_INIT_ZERO, false, FD_EXEC_TEST_INSTR_EFFECTS_INIT_ZERO}
 #define FD_EXEC_TEST_SYSCALL_EFFECTS_INIT_ZERO   {0, 0, 0, NULL, NULL, NULL, 0, NULL, NULL, 0, 0, NULL}
 #define FD_EXEC_TEST_SYSCALL_FIXTURE_INIT_ZERO   {false, FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_ZERO, false, FD_EXEC_TEST_SYSCALL_EFFECTS_INIT_ZERO}
 #define FD_EXEC_TEST_FULL_VM_CONTEXT_INIT_ZERO   {false, FD_EXEC_TEST_VM_CONTEXT_INIT_ZERO, false, FD_EXEC_TEST_FEATURE_SET_INIT_ZERO}
@@ -199,6 +202,7 @@ extern "C" {
 #define FD_EXEC_TEST_SYSCALL_CONTEXT_VM_CTX_TAG  1
 #define FD_EXEC_TEST_SYSCALL_CONTEXT_INSTR_CTX_TAG 2
 #define FD_EXEC_TEST_SYSCALL_CONTEXT_SYSCALL_INVOCATION_TAG 3
+#define FD_EXEC_TEST_SYSCALL_CONTEXT_EXEC_EFFECTS_TAG 4
 #define FD_EXEC_TEST_SYSCALL_EFFECTS_ERROR_TAG   1
 #define FD_EXEC_TEST_SYSCALL_EFFECTS_R0_TAG      2
 #define FD_EXEC_TEST_SYSCALL_EFFECTS_CU_AVAIL_TAG 3
@@ -264,12 +268,14 @@ X(a, POINTER,  SINGULAR, BYTES,    stack_prefix,      3)
 #define FD_EXEC_TEST_SYSCALL_CONTEXT_FIELDLIST(X, a) \
 X(a, STATIC,   OPTIONAL, MESSAGE,  vm_ctx,            1) \
 X(a, STATIC,   OPTIONAL, MESSAGE,  instr_ctx,         2) \
-X(a, STATIC,   OPTIONAL, MESSAGE,  syscall_invocation,   3)
+X(a, STATIC,   OPTIONAL, MESSAGE,  syscall_invocation,   3) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  exec_effects,      4)
 #define FD_EXEC_TEST_SYSCALL_CONTEXT_CALLBACK NULL
 #define FD_EXEC_TEST_SYSCALL_CONTEXT_DEFAULT NULL
 #define fd_exec_test_syscall_context_t_vm_ctx_MSGTYPE fd_exec_test_vm_context_t
 #define fd_exec_test_syscall_context_t_instr_ctx_MSGTYPE fd_exec_test_instr_context_t
 #define fd_exec_test_syscall_context_t_syscall_invocation_MSGTYPE fd_exec_test_syscall_invocation_t
+#define fd_exec_test_syscall_context_t_exec_effects_MSGTYPE fd_exec_test_instr_effects_t
 
 #define FD_EXEC_TEST_SYSCALL_EFFECTS_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, INT64,    error,             1) \

--- a/src/flamenco/vm/fd_vm_base.h
+++ b/src/flamenco/vm/fd_vm_base.h
@@ -88,6 +88,7 @@
 #define FD_VM_CPI_ERR_INSTR_TOO_LARGE        (-41) /* detected too many account infos meta */
 #define FD_VM_CPI_ERR_INSTR_DATA_TOO_LARGE   (-42) /* detected instruction data too large */
 #define FD_VM_CPI_ERR_TOO_MANY_ACC_METAS     (-43) /* detected too many account metas */
+#define FD_VM_CPI_ERR_LAMPORTS_MISMATCH      (-44) /* detected lamports mismatch */
 
 FD_PROTOTYPES_BEGIN
 

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
@@ -70,8 +70,9 @@ gen_cpi_state_filename( fd_pubkey_t const *caller_pubkey,
 }
 
 /* Captures the state of the VM (including the instruction context).
-   Meant to be invoked at the start of the VM_SYSCALL_CPI_ENTRYPOINT like so:
+   Use contrib/tools/dump_cpi_on_replay.sh 
 
+   Meant to be invoked at the start of the VM_SYSCALL_CPI_ENTRYPOINT like so:
   ```
     fd_exec_test_syscall_context_t sys_ctx = FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_DEFAULT;
     dump_vm_cpi_state(vm, STRINGIFY(FD_EXPAND_THEN_CONCAT2(sol_invoke_signed_, VM_SYSCALL_CPI_ABI)),
@@ -93,7 +94,7 @@ gen_cpi_state_filename( fd_pubkey_t const *caller_pubkey,
   ```
 
   Assumes that a `dump/vm_cpi_state` directory exists in the current working directory. Generates a
-  unique dump for combination of (tile_id, caller_pubkey, instr_sz). */
+  (sufficiently) unique dump for combination of (tile_id, caller_pubkey, instr_sz). */
 
 static FD_FN_UNUSED void
 dump_vm_cpi_state(fd_vm_t *vm,

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
@@ -680,11 +680,11 @@ VM_SYSCALL_CPI_ENTRYPOINT( void *  _vm,
   ulong caller_lamports_l = 0UL;
 
   err = fd_instr_info_sum_account_lamports( vm->instr_ctx->instr, &caller_lamports_h, &caller_lamports_l );
-  if ( FD_UNLIKELY( err ) ) return FD_VM_ERR_INSTR_ERR;
+  if ( FD_UNLIKELY( err ) ) return err;
 
   if( caller_lamports_h != vm->instr_ctx->instr->starting_lamports_h || 
       caller_lamports_l != vm->instr_ctx->instr->starting_lamports_l ) {
-    return FD_VM_ERR_INSTR_ERR;
+    return FD_VM_CPI_ERR_LAMPORTS_MISMATCH;
   }
   
   /* Set the transaction compute meter to be the same as the VM's compute meter,
@@ -747,11 +747,11 @@ VM_SYSCALL_CPI_ENTRYPOINT( void *  _vm,
   caller_lamports_h = 0UL;
   caller_lamports_l = 0UL;
   err = fd_instr_info_sum_account_lamports( vm->instr_ctx->instr, &caller_lamports_h, &caller_lamports_l );
-  if ( FD_UNLIKELY( err ) ) return FD_VM_ERR_INSTR_ERR;
+  if ( FD_UNLIKELY( err ) ) return err;
 
   if( caller_lamports_h != vm->instr_ctx->instr->starting_lamports_h || 
       caller_lamports_l != vm->instr_ctx->instr->starting_lamports_l ) {
-    return FD_VM_ERR_INSTR_ERR;
+    return FD_VM_CPI_ERR_LAMPORTS_MISMATCH;
   }
 
   return FD_VM_SUCCESS;


### PR DESCRIPTION
This PR does two tangential things:

## 1. Mock CPI execution
With `__wrap_fd_execute`, we can simulate the execution of a CPI by modifying account states with a provided `InstrEffects` message. 


## 2. Dumping account state in CPI calls
To generate seed corpus with execution effects, the CPI dump tool was modified to capture post-CPI instruction account data. 

Also added a script that temporarily applies a patch file that dumps CPI state during CPI syscall. 
