### PR TITLE
flamenco, vm: correctly set check_align in vm

### DIFF
--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -429,7 +429,7 @@ execute( fd_exec_instr_ctx_t * instr_ctx, fd_sbpf_validated_program_t * prog, uc
   ulong pre_insn_cus = instr_ctx->txn_ctx->compute_meter;
   ulong heap_max = true ? instr_ctx->txn_ctx->heap_size : FD_VM_HEAP_DEFAULT; /* TODO:FIXME: fix this */
 
-  /* TODO: (topointon): correctly set check_align and check_size in vm setup */
+  /* TODO: (topointon): correctly set check_size in vm setup */
   vm = fd_vm_init(
     /* vm                    */ vm,
     /* instr_ctx             */ instr_ctx,

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -1755,7 +1755,7 @@ fd_exec_vm_syscall_test_run( fd_exec_instr_test_runner_t * runner,
     input_regions,
     input_regions_count,
     NULL,
-    (uchar)false );
+    input->vm_ctx.check_align );
 
   // Setup the vm state for execution
   if( fd_vm_setup_state_for_execution( vm ) != FD_VM_SUCCESS ) {
@@ -1776,9 +1776,6 @@ fd_exec_vm_syscall_test_run( fd_exec_instr_test_runner_t * runner,
   vm->reg[9] = input->vm_ctx.r9;
   vm->reg[10] = input->vm_ctx.r10;
   vm->reg[11] = input->vm_ctx.r11;
-
-  vm->check_align = input->vm_ctx.check_align;
-  vm->check_size = input->vm_ctx.check_size;
 
   // Override initial part of the heap, if specified the syscall fuzzer input
   if( input->syscall_invocation.heap_prefix ) {

--- a/src/flamenco/runtime/tests/fd_vm_test.c
+++ b/src/flamenco/runtime/tests/fd_vm_test.c
@@ -262,9 +262,6 @@ do{
     break;
   }
 
-  vm->check_align = input->vm_ctx.check_align;
-  vm->check_size  = input->vm_ctx.check_size;
-
   if( input->syscall_invocation.stack_prefix ) {
     uchar * stack    = input->syscall_invocation.stack_prefix->bytes;
     ulong   stack_sz = fd_ulong_min(input->syscall_invocation.stack_prefix->size, FD_VM_STACK_MAX);

--- a/src/flamenco/vm/fd_vm.h
+++ b/src/flamenco/vm/fd_vm.h
@@ -49,8 +49,6 @@ struct fd_vm {
      non-trivial use of instr_ctx). */
 
   fd_exec_instr_ctx_t * instr_ctx;   /* FIXME: DOCUMENT */
-  int                   check_align; /* If non-zero, the vm does alignment checks where necessary (syscalls) */
-  int                   check_size;  /* If non-zero, the vm does size checks where necessary (syscalls) */
 
   /* FIXME: frame_max should be run time configurable by compute budget.
      If there is no reasonable upper bound on this, shadow and stack
@@ -198,7 +196,7 @@ FD_PROTOTYPES_BEGIN
    integer power of 2.  FOOTPRINT is a multiple of align. 
    These are provided to facilitate compile time declarations. */
 #define FD_VM_ALIGN     (8UL     )
-#define FD_VM_FOOTPRINT (789416UL)
+#define FD_VM_FOOTPRINT (789408UL)
 
 /* fd_vm_{align,footprint} give the needed alignment and footprint
    of a memory region suitable to hold an fd_vm_t.
@@ -284,6 +282,20 @@ fd_vm_delete( void * shmem );
 
 FD_FN_PURE int
 fd_vm_validate( fd_vm_t const * vm );
+
+/* fd_vm_is_check_align_enabled returns 1 if the vm should check alignment
+   when doing memory translation. */
+FD_FN_PURE static inline int
+fd_vm_is_check_align_enabled( fd_vm_t const * vm ) {
+   return !vm->is_deprecated;
+}
+
+/* fd_vm_is_check_size_enabled returns 1 if the vm should check size
+   when doing memory translation. */
+FD_FN_PURE static inline int
+fd_vm_is_check_size_enabled( fd_vm_t const * vm ) {
+   return !vm->is_deprecated;
+}
 
 /* FIXME: make this trace-aware, and move into fd_vm_init
    This is a temporary hack to make the fuzz harness work. */

--- a/src/flamenco/vm/fd_vm_interp.c
+++ b/src/flamenco/vm/fd_vm_interp.c
@@ -13,7 +13,6 @@ fd_vm_exec_notrace( fd_vm_t * vm ) {
   if( FD_UNLIKELY( !vm ) ) return FD_VM_ERR_INVAL;
 
   /* Pull out variables needed for the fd_vm_interp_core template */
-  int   check_align = vm->check_align;
   ulong frame_max   = FD_VM_STACK_FRAME_MAX; /* FIXME: vm->frame_max to make this run-time configured */
 
   ulong const * FD_RESTRICT text          = vm->text;
@@ -49,7 +48,6 @@ fd_vm_exec_trace( fd_vm_t * vm ) {
   if( FD_UNLIKELY( !vm ) ) return FD_VM_ERR_INVAL;
 
   /* Pull out variables needed for the fd_vm_interp_core template */
-  int   check_align = vm->check_align;
   ulong frame_max   = FD_VM_STACK_FRAME_MAX; /* FIXME: vm->frame_max to make this run-time configured */
 
   ulong const * FD_RESTRICT text          = vm->text;

--- a/src/flamenco/vm/fd_vm_interp_core.c
+++ b/src/flamenco/vm/fd_vm_interp_core.c
@@ -358,8 +358,7 @@ interp_0x00: // FD_SBPF_OP_ADDL_IMM
     ulong vaddr           = reg_src + (ulong)(long)offset;
     ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(uint), region_haddr, region_ld_sz, 0, 0UL, &is_multi_region );
     int   sigsegv         = !haddr;
-    int   sigbus          = check_align & !fd_ulong_is_aligned( vaddr, sizeof(uint) );
-    if( FD_UNLIKELY( sigsegv | sigbus ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
+    if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
     reg[ dst ] = fd_vm_mem_ld_4( vm, vaddr, haddr, is_multi_region );
   }
   FD_VM_INTERP_INSTR_END;
@@ -369,8 +368,7 @@ interp_0x00: // FD_SBPF_OP_ADDL_IMM
     ulong vaddr           = reg_dst + (ulong)(long)offset;
     ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(uint), region_haddr, region_st_sz, 1, 0UL, &is_multi_region );
     int   sigsegv         = !haddr;
-    int   sigbus          = check_align & !fd_ulong_is_aligned( vaddr, sizeof(uint) );
-    if( FD_UNLIKELY( sigsegv | sigbus ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
+    if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
     fd_vm_mem_st_4( vm, vaddr, haddr, imm, is_multi_region );
   }
   FD_VM_INTERP_INSTR_END;
@@ -380,8 +378,7 @@ interp_0x00: // FD_SBPF_OP_ADDL_IMM
     ulong vaddr           = reg_dst + (ulong)(long)offset;
     ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(uint), region_haddr, region_st_sz, 1, 0UL, &is_multi_region );
     int   sigsegv         = !haddr;
-    int   sigbus          = check_align & !fd_ulong_is_aligned( vaddr, sizeof(uint) );
-    if( FD_UNLIKELY( sigsegv | sigbus ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus/rdonly */
+    if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus/rdonly */
     fd_vm_mem_st_4( vm, vaddr, haddr, (uint)reg_src, is_multi_region );
   }
   FD_VM_INTERP_INSTR_END;
@@ -403,8 +400,7 @@ interp_0x00: // FD_SBPF_OP_ADDL_IMM
     ulong vaddr           = reg_src + (ulong)(long)offset;
     ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(ushort), region_haddr, region_ld_sz, 0, 0UL, &is_multi_region );
     int   sigsegv         = !haddr;
-    int   sigbus          = check_align & !fd_ulong_is_aligned( vaddr, sizeof(ushort) );
-    if( FD_UNLIKELY( sigsegv | sigbus ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
+    if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
     reg[ dst ] = fd_vm_mem_ld_2( vm, vaddr, haddr, is_multi_region );
   }
   FD_VM_INTERP_INSTR_END;
@@ -414,8 +410,7 @@ interp_0x00: // FD_SBPF_OP_ADDL_IMM
     ulong vaddr           = reg_dst + (ulong)(long)offset;
     ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(ushort), region_haddr, region_st_sz, 1, 0UL, &is_multi_region );
     int   sigsegv         = !haddr;
-    int   sigbus          = check_align & !fd_ulong_is_aligned( vaddr, sizeof(ushort) );
-    if( FD_UNLIKELY( sigsegv | sigbus ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
+    if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
     fd_vm_mem_st_2( vm, vaddr, haddr, (ushort)imm, is_multi_region );
   }
   FD_VM_INTERP_INSTR_END;
@@ -425,8 +420,7 @@ interp_0x00: // FD_SBPF_OP_ADDL_IMM
     ulong vaddr           = reg_dst + (ulong)(long)offset;
     ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(ushort), region_haddr, region_st_sz, 1, 0UL, &is_multi_region );
     int   sigsegv         = !haddr;
-    int   sigbus          = check_align & !fd_ulong_is_aligned( vaddr, sizeof(ushort) );
-    if( FD_UNLIKELY( sigsegv | sigbus ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus/rdonly */
+    if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus/rdonly */
     fd_vm_mem_st_2( vm, vaddr, haddr, (ushort)reg_src, is_multi_region );
   }
   FD_VM_INTERP_INSTR_END;
@@ -489,8 +483,7 @@ interp_0x00: // FD_SBPF_OP_ADDL_IMM
     ulong vaddr           = reg_src + (ulong)(long)offset;
     ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(ulong), region_haddr, region_ld_sz, 0, 0UL, &is_multi_region );
     int   sigsegv         = !haddr;
-    int   sigbus          = check_align & !fd_ulong_is_aligned( vaddr, sizeof(ulong) );
-    if( FD_UNLIKELY( sigsegv | sigbus ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
+    if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
     reg[ dst ] = fd_vm_mem_ld_8( vm, vaddr, haddr, is_multi_region );
   }
   FD_VM_INTERP_INSTR_END;
@@ -500,8 +493,7 @@ interp_0x00: // FD_SBPF_OP_ADDL_IMM
     ulong vaddr           = reg_dst + (ulong)(long)offset;
     ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(ulong), region_haddr, region_st_sz, 1, 0UL, &is_multi_region );
     int   sigsegv         = !haddr;
-    int   sigbus          = check_align & !fd_ulong_is_aligned( vaddr, sizeof(ulong) );
-    if( FD_UNLIKELY( sigsegv | sigbus ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
+    if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
     fd_vm_mem_st_8( vm, vaddr, haddr, (ulong)imm, is_multi_region );
   }
   FD_VM_INTERP_INSTR_END;
@@ -511,8 +503,7 @@ interp_0x00: // FD_SBPF_OP_ADDL_IMM
     ulong vaddr           = reg_dst + (ulong)(long)offset;
     ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(ulong), region_haddr, region_st_sz, 1, 0UL, &is_multi_region );
     int   sigsegv         = !haddr;
-    int   sigbus          = check_align & !fd_ulong_is_aligned( vaddr, sizeof(ulong) );
-    if( FD_UNLIKELY( sigsegv | sigbus ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus/rdonly */
+    if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus/rdonly */
     fd_vm_mem_st_8( vm, vaddr, haddr, reg_src, is_multi_region );
   }
   FD_VM_INTERP_INSTR_END;

--- a/src/flamenco/vm/fd_vm_private.h
+++ b/src/flamenco/vm/fd_vm_private.h
@@ -43,13 +43,20 @@
       }
     ``` */
 
-#define FD_VM_ALIGN_RUST_U8           (1UL)
-#define FD_VM_ALIGN_RUST_U32          (4UL)
-#define FD_VM_ALIGN_RUST_U64          (8UL)
-#define FD_VM_ALIGN_RUST_U128        (16UL)
-#define FD_VM_ALIGN_RUST_SLICE_U8_REF (8UL)
-#define FD_VM_ALIGN_RUST_POD_U8_ARRAY (1UL)
-#define FD_VM_ALIGN_RUST_PUBKEY       (1UL)
+#define FD_VM_ALIGN_RUST_U8                       (1UL)
+#define FD_VM_ALIGN_RUST_U32                      (4UL)
+#define FD_VM_ALIGN_RUST_I32                      (4UL)
+#define FD_VM_ALIGN_RUST_U64                      (8UL)
+#define FD_VM_ALIGN_RUST_U128                     (16UL)
+#define FD_VM_ALIGN_RUST_SLICE_U8_REF             (8UL)
+#define FD_VM_ALIGN_RUST_POD_U8_ARRAY             (1UL)
+#define FD_VM_ALIGN_RUST_PUBKEY                   (1UL)
+#define FD_VM_ALIGN_RUST_SYSVAR_CLOCK             (8UL)
+#define FD_VM_ALIGN_RUST_SYSVAR_EPOCH_SCHEDULE    (8UL)
+#define FD_VM_ALIGN_RUST_SYSVAR_FEES              (8UL)
+#define FD_VM_ALIGN_RUST_SYSVAR_RENT              (8UL)
+#define FD_VM_ALIGN_RUST_SYSVAR_LAST_RESTART_SLOT (8UL)
+#define FD_VM_ALIGN_RUST_STABLE_INSTRUCTION       (8UL)
 
 /* fd_vm_vec_t is the in-memory representation of a vector descriptor.
    Equal in layout to the Rust slice header &[_] and various vector
@@ -499,7 +506,7 @@ static inline void fd_vm_mem_st_8( fd_vm_t const * vm,
     fd_vm_t const * _vm       = (vm);                                                                       \
     uchar           _is_multi = 0;                                                                          \
     ulong           _vaddr    = (vaddr);                                                                    \
-    int             _sigbus   = _vm->check_align & (!fd_ulong_is_aligned( _vaddr, (align) ));               \
+    int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _vaddr, (align) )); \
     ulong           _haddr    = fd_vm_mem_haddr( vm, _vaddr, (sz), _vm->region_haddr, _vm->region_ld_sz, 0, 0UL, &_is_multi ); \
     if( FD_UNLIKELY( (!_haddr) | _sigbus | _is_multi ) ) {                                                  \
       FD_VM_ERR_FOR_LOG_EBPF( _vm, FD_VM_ERR_EBPF_ACCESS_VIOLATION );                                       \
@@ -520,7 +527,7 @@ static inline void fd_vm_mem_st_8( fd_vm_t const * vm,
     fd_vm_t const * _vm       = (vm);                                                                       \
     uchar           _is_multi = 0;                                                                          \
     ulong           _vaddr    = (vaddr);                                                                    \
-    int             _sigbus   = _vm->check_align & (!fd_ulong_is_aligned( _vaddr, (align) ));               \
+    int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _vaddr, (align) )); \
     ulong           _haddr    = fd_vm_mem_haddr( vm, _vaddr, (sz), _vm->region_haddr, _vm->region_st_sz, 1, 0UL, &_is_multi ); \
     if( FD_UNLIKELY( (!_haddr) | _sigbus | _is_multi) ) {                                                   \
       FD_VM_ERR_FOR_LOG_EBPF( _vm, FD_VM_ERR_EBPF_ACCESS_VIOLATION );                                       \
@@ -533,7 +540,7 @@ static inline void fd_vm_mem_st_8( fd_vm_t const * vm,
     fd_vm_t const * _vm       = (vm);                                                                       \
     uchar           _is_multi = 0;                                                                          \
     ulong           _vaddr    = (vaddr);                                                                    \
-    int             _sigbus   = _vm->check_align & (!fd_ulong_is_aligned( _vaddr, (align) ));               \
+    int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _vaddr, (align) )); \
     ulong           _haddr    = fd_vm_mem_haddr( vm, _vaddr, (sz), _vm->region_haddr, _vm->region_ld_sz, 0, 0UL, &_is_multi ); \
     if( FD_UNLIKELY( (!_haddr) | _sigbus | _is_multi ) ) {                                                  \
       FD_VM_ERR_FOR_LOG_EBPF( _vm, FD_VM_ERR_EBPF_ACCESS_VIOLATION );                                       \

--- a/src/flamenco/vm/syscall/fd_vm_cpi.h
+++ b/src/flamenco/vm/syscall/fd_vm_cpi.h
@@ -121,7 +121,7 @@ struct __attribute__((packed)) fd_vm_rust_instruction {
 typedef struct fd_vm_rust_instruction fd_vm_rust_instruction_t;
 
 #define FD_VM_RUST_ACCOUNT_META_SIZE  (34UL)
-#define FD_VM_RUST_ACCOUNT_META_ALIGN (8UL)
+#define FD_VM_RUST_ACCOUNT_META_ALIGN (1UL)
 
 struct __attribute__((packed)) fd_vm_rust_account_meta {
   uchar pubkey[32];

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
@@ -504,14 +504,6 @@ fd_vm_syscall_cpi_check_authorized_program( fd_pubkey_t const * program_id,
             || fd_vm_syscall_cpi_is_precompile(program_id));
 }
 
-/*
-TODO: check_align is set wrong in the runtime, ensure that it is set correctly:
-https://github.com/solana-labs/solana/blob/dbf06e258ae418097049e845035d7d5502fe1327/program-runtime/src/invoke_context.rs#L869-L881.
-- Programs owned by the bpf_loader_deprecated should set this to false.
-- All other programs should set this to true.
-*/
-
-
 /**********************************************************************
   CROSS PROGRAM INVOCATION (C ABI)
  **********************************************************************/

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
@@ -171,8 +171,7 @@ VM_SYCALL_CPI_UPDATE_CALLEE_ACC_FUNC( fd_vm_t *                         vm,
     /* FIXME: double-check these permissions, especially the callee_acc_idx */
 
     /* Translate and get the account data */
-    uchar const * caller_acc_data = FD_VM_MEM_HADDR_LD( vm, caller_acc_data_vm_addr, 
-                                                        sizeof(ulong), caller_acc_data_len ); 
+    uchar const * caller_acc_data = FD_VM_MEM_HADDR_LD( vm, caller_acc_data_vm_addr, sizeof(uchar), caller_acc_data_len ); 
 
     if( fd_account_can_data_be_resized( vm->instr_ctx, callee_acc->meta, caller_acc_data_len, &err ) &&
         fd_account_can_data_be_changed( vm->instr_ctx->instr, instr_acc_idx, &err ) ) {
@@ -237,7 +236,7 @@ VM_SYCALL_CPI_UPDATE_CALLEE_ACC_FUNC( fd_vm_t *                         vm,
            smartly look up the right region and don't need to worry about 
            multiple region access.We just need to load in the bytes from 
            (original len, post_len]. */
-        uchar const * realloc_data = FD_VM_MEM_HADDR_LD( vm, caller_acc_data_vm_addr+original_len, alignof(ulong), realloc_bytes_used );
+        uchar const * realloc_data = FD_VM_MEM_HADDR_LD( vm, caller_acc_data_vm_addr+original_len, alignof(uchar), realloc_bytes_used );
 
         uchar * data = NULL;
         ulong   dlen = 0UL;
@@ -628,7 +627,7 @@ VM_SYSCALL_CPI_ENTRYPOINT( void *  _vm,
 
   uchar const * data = FD_VM_MEM_SLICE_HADDR_LD( 
     vm, VM_SYSCALL_CPI_INSTR_DATA_ADDR( cpi_instruction ),
-    alignof(uchar),
+    FD_VM_ALIGN_RUST_U8,
     VM_SYSCALL_CPI_INSTR_DATA_LEN( cpi_instruction ));
 
   /* Authorized program check *************************************************/

--- a/src/flamenco/vm/syscall/fd_vm_syscall_pda.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_pda.c
@@ -29,7 +29,7 @@ fd_vm_derive_pda( fd_vm_t *           vm,
                   uchar *             bump_seed,
                   fd_pubkey_t *       out ) {
 
-  fd_vm_vec_t const * seeds_haddr = FD_VM_MEM_SLICE_HADDR_LD( vm, seeds_vaddr, FD_VM_VEC_ALIGN,
+  fd_vm_vec_t const * seeds_haddr = FD_VM_MEM_SLICE_HADDR_LD( vm, seeds_vaddr, FD_VM_ALIGN_RUST_U8,
     fd_ulong_sat_mul( seeds_cnt, FD_VM_VEC_SIZE ) );
 
   if ( seeds_cnt>FD_VM_PDA_SEEDS_MAX ) {
@@ -113,7 +113,7 @@ fd_vm_syscall_sol_create_program_address( /**/            void *  _vm,
 
   /* https://github.com/anza-xyz/agave/blob/v2.0.8/programs/bpf_loader/src/syscalls/mod.rs#L723
      TODO: program_id is mapped *after* seeds. */
-  fd_pubkey_t const * program_id = FD_VM_MEM_HADDR_LD( vm, program_id_vaddr, FD_VM_ALIGN_RUST_PUBKEY, sizeof(fd_pubkey_t) );
+  fd_pubkey_t const * program_id = FD_VM_MEM_HADDR_LD( vm, program_id_vaddr, FD_VM_ALIGN_RUST_PUBKEY, FD_PUBKEY_FOOTPRINT );
 
   fd_pubkey_t derived[1];
   int err = fd_vm_derive_pda( vm, program_id, seeds_vaddr, seeds_cnt, bump_seed, derived );
@@ -124,8 +124,8 @@ fd_vm_syscall_sol_create_program_address( /**/            void *  _vm,
     return FD_VM_SUCCESS;
   }
 
-  fd_pubkey_t * out_haddr = FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_VM_ALIGN_RUST_PUBKEY, sizeof(fd_pubkey_t) );
-  memcpy( out_haddr, derived->uc, sizeof(fd_pubkey_t) );
+  fd_pubkey_t * out_haddr = FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_VM_ALIGN_RUST_U8, FD_PUBKEY_FOOTPRINT );
+  memcpy( out_haddr, derived->uc, FD_PUBKEY_FOOTPRINT );
 
   /* Success */
   *_ret = 0UL;
@@ -174,7 +174,7 @@ fd_vm_syscall_sol_try_find_program_address( void *  _vm,
     int err = fd_vm_derive_pda( vm, program_id, seeds_vaddr, seeds_cnt, bump_seed, derived );
     if ( FD_LIKELY( err == FD_VM_SUCCESS ) ) {
       /* Stop looking if we have found a valid PDA */
-      fd_pubkey_t * out_haddr = FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_VM_ALIGN_RUST_PUBKEY, sizeof(fd_pubkey_t) );
+      fd_pubkey_t * out_haddr = FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_VM_ALIGN_RUST_U8, sizeof(fd_pubkey_t) );
       uchar * out_bump_seed_haddr = FD_VM_MEM_HADDR_ST( vm, out_bump_seed_vaddr, FD_VM_ALIGN_RUST_U8, 1UL );
 
       /* Do the overlap check, which is only included for this syscall */

--- a/src/flamenco/vm/syscall/fd_vm_syscall_runtime.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_runtime.c
@@ -30,7 +30,7 @@ fd_vm_syscall_sol_get_clock_sysvar( /**/            void *  _vm,
 
   FD_VM_CU_UPDATE( vm, fd_ulong_sat_add( FD_VM_SYSVAR_BASE_COST, FD_SOL_SYSVAR_CLOCK_FOOTPRINT ) );
 
-  void * out = FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_SOL_SYSVAR_CLOCK_ALIGN, FD_SOL_SYSVAR_CLOCK_FOOTPRINT );
+  void * out = FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_VM_ALIGN_RUST_SYSVAR_CLOCK, FD_SOL_SYSVAR_CLOCK_FOOTPRINT );
 
   /* FIXME: is it possible to do the read in-place? */
   fd_sol_sysvar_clock_t clock[1];
@@ -66,7 +66,7 @@ fd_vm_syscall_sol_get_epoch_schedule_sysvar( /**/            void *  _vm,
 
   FD_VM_CU_UPDATE( vm, fd_ulong_sat_add( FD_VM_SYSVAR_BASE_COST, FD_EPOCH_SCHEDULE_FOOTPRINT ) );
 
-  void * out = FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_EPOCH_SCHEDULE_ALIGN, FD_EPOCH_SCHEDULE_FOOTPRINT );
+  void * out = FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_VM_ALIGN_RUST_SYSVAR_EPOCH_SCHEDULE, FD_EPOCH_SCHEDULE_FOOTPRINT );
 
   /* FIXME: is it possible to do the read in-place? */
   fd_epoch_schedule_t schedule[1];
@@ -102,7 +102,7 @@ fd_vm_syscall_sol_get_fees_sysvar( /**/            void *  _vm,
 
   FD_VM_CU_UPDATE( vm, fd_ulong_sat_add( FD_VM_SYSVAR_BASE_COST, FD_SYSVAR_FEES_FOOTPRINT ) );
 
-  void * out = FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_SYSVAR_FEES_ALIGN, FD_SYSVAR_FEES_FOOTPRINT );
+  void * out = FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_VM_ALIGN_RUST_SYSVAR_FEES, FD_SYSVAR_FEES_FOOTPRINT );
 
   /* FIXME: is it possible to do the read in-place? */
   fd_sysvar_fees_t fees[1];
@@ -138,7 +138,7 @@ fd_vm_syscall_sol_get_rent_sysvar( /**/            void *  _vm,
 
   FD_VM_CU_UPDATE( vm, fd_ulong_sat_add( FD_VM_SYSVAR_BASE_COST, FD_RENT_FOOTPRINT ) );
 
-  void * out = FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_RENT_ALIGN, FD_RENT_FOOTPRINT );
+  void * out = FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_VM_ALIGN_RUST_SYSVAR_RENT, FD_RENT_FOOTPRINT );
 
   /* FIXME: is it possible to do the read in-place? */
   fd_rent_t rent[1];
@@ -166,7 +166,7 @@ fd_vm_syscall_sol_get_last_restart_slot_sysvar( /**/            void *  _vm,
   FD_VM_CU_UPDATE( vm, fd_ulong_sat_add( FD_VM_SYSVAR_BASE_COST, FD_SOL_SYSVAR_LAST_RESTART_SLOT_FOOTPRINT ) );
 
   fd_sol_sysvar_last_restart_slot_t * out = 
-    FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_SOL_SYSVAR_LAST_RESTART_SLOT_ALIGN, FD_SOL_SYSVAR_LAST_RESTART_SLOT_FOOTPRINT );
+    FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_VM_ALIGN_RUST_SYSVAR_LAST_RESTART_SLOT, FD_SOL_SYSVAR_LAST_RESTART_SLOT_FOOTPRINT );
   if( FD_UNLIKELY( fd_sysvar_last_restart_slot_read( out, vm->instr_ctx->slot_ctx ) == NULL ) ) {
     return FD_VM_ERR_ABORT;
   }
@@ -409,7 +409,7 @@ fd_vm_syscall_sol_get_processed_sibling_instruction(
       fd_vm_rust_account_meta_t * result_accounts_haddr = FD_VM_MEM_SLICE_HADDR_ST(
         vm,
         result_accounts_vaddr,
-        FD_VM_RUST_ACCOUNT_META_ALIGN, //TODO: sync FD_VM_ALIGN_RUST_* and FD_VM_RUST_*
+        FD_VM_RUST_ACCOUNT_META_ALIGN,
         accounts_meta_total_size);
 
       /* Check for memory overlaps


### PR DESCRIPTION
Correctly set `check_align` in the vm based on if the deprecated loader is used.

Also correctly sets alignment values for all the memory address translations in the vm.