### PR TITLE
quic: simplify ACK generation

### DIFF
--- a/src/waltz/quic/fd_quic_conn.c
+++ b/src/waltz/quic/fd_quic_conn.c
@@ -21,7 +21,6 @@ struct fd_quic_conn_layout {
   int   stream_map_lg;
   ulong stream_map_off;
   ulong pkt_meta_off;
-  ulong ack_off;
   ulong token_len_off;
   ulong token_off;
 };
@@ -86,11 +85,6 @@ fd_quic_conn_footprint_ext( fd_quic_limits_t const * limits,
   off                   = fd_ulong_align_up( off, alignof(fd_quic_pkt_meta_t) );
   layout->pkt_meta_off  = off;
   off                  += inflight_pkt_cnt * sizeof(fd_quic_pkt_meta_t);
-
-  /* allocate space for ACKs */
-  off                   = fd_ulong_align_up( off, alignof(fd_quic_ack_t) );
-  layout->ack_off       = off;
-  off                  += inflight_pkt_cnt * sizeof(fd_quic_ack_t);
 
   /* align total footprint */
 
@@ -167,18 +161,9 @@ fd_quic_conn_new( void *                   mem,
   conn->pkt_meta_mem = pkt_meta;
   conn->num_pkt_meta = pkt_meta_cnt;
 
-  /* Initialize ACKs array */
-
-  ulong           ack_cnt = limits->inflight_pkt_cnt;
-  fd_quic_ack_t * acks    = (fd_quic_ack_t *)( (ulong)mem + layout.ack_off );
-  fd_memset( acks, 0, ack_cnt * sizeof(fd_quic_ack_t) );
-
-  /* initialize free list of acks metadata */
-  conn->acks_free = acks;
-  for( ulong j=0; j<ack_cnt; ++j ) {
-    ulong k = j + 1;
-    acks[j].next =  k < ack_cnt ? acks + k : NULL;
-  }
+  /* Initialize ACK queue */
+  conn->ack_queue_head = conn->ack_queue_tail = 0U;
+  memset( conn->ack_queue + (FD_QUIC_ACK_QUEUE_CNT-1), 0, sizeof(fd_quic_ack_t) );
 
   return conn;
 }

--- a/src/waltz/quic/fd_quic_pkt_meta.h
+++ b/src/waltz/quic/fd_quic_pkt_meta.h
@@ -93,7 +93,6 @@ struct fd_quic_pkt_meta {
        FD_QUIC_PKT_META_FLAGS_MAX_DATA            max_data frame
        FD_QUIC_PKT_META_FLAGS_MAX_STREAM_DATA     max_stream_data frame
        FD_QUIC_PKT_META_FLAGS_MAX_STREAMS_UNIDIR  max_streams frame (unidir)
-       FD_QUIC_PKT_META_FLAGS_ACK                 acknowledgement
        FD_QUIC_PKT_META_FLAGS_CLOSE               close frame
        FD_QUIC_PKT_META_FLAGS_KEY_UPDATE          indicates key update was in effect
        FD_QUIC_PKT_META_FLAGS_KEY_PHASE           set only if key_phase was set in the short-header
@@ -108,7 +107,6 @@ struct fd_quic_pkt_meta {
 # define          FD_QUIC_PKT_META_FLAGS_MAX_STREAM_DATA    (1u<<4u)
 # define          FD_QUIC_PKT_META_FLAGS_MAX_STREAMS_UNIDIR (1u<<5u)
 # define          FD_QUIC_PKT_META_FLAGS_MAX_STREAMS_BIDIR  (1u<<6u)
-# define          FD_QUIC_PKT_META_FLAGS_ACK                (1u<<7u)
 # define          FD_QUIC_PKT_META_FLAGS_CLOSE              (1u<<8u)
 # define          FD_QUIC_PKT_META_FLAGS_KEY_UPDATE         (1u<<9u)
 # define          FD_QUIC_PKT_META_FLAGS_KEY_PHASE          (1u<<10u)

--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -134,9 +134,8 @@ struct fd_quic_pkt {
   uint               datagram_sz; /* length of the original datagram */
   uint               ack_flag;    /* ORed together: 0-don't ack  1-ack  2-cancel ack */
   uint ping;
-# define ACK_FLAG_NOT_RQD 0
-# define ACK_FLAG_RQD     1
-# define ACK_FLAG_CANCEL  2
+# define ACK_FLAG_RQD     1 /* ack-eliciting */
+# define ACK_FLAG_CANCEL  2 /* do not send ACK to cause peer to retransmit */
 };
 
 FD_PROTOTYPES_BEGIN

--- a/src/waltz/quic/tests/test_quic_drops.c
+++ b/src/waltz/quic/tests/test_quic_drops.c
@@ -115,12 +115,12 @@ mitm_tx( void *                    ctx,
       }
       continue;
     }
-    
+
     /* send new packet */
     fd_aio_pkt_info_t batch_0[1] = { batch[j] };
     fd_aio_send( mitm_ctx->dst, batch_0, 1UL, NULL, 1 );
     PCAP(batch_0,1UL);
-      
+
     /* we aren't dropping or reordering, but we might have a prior reorder */
     if( mitm_ctx->reorder_sz > 0UL ) {
       fd_aio_pkt_info_t batch_1[1] = {{ .buf = mitm_ctx->reorder_buf, .buf_sz = (ushort)mitm_ctx->reorder_sz }};
@@ -168,7 +168,7 @@ static void
 my_tls_keylog( void *       quic_ctx,
                char const * line ) {
   (void)quic_ctx;
-  FD_LOG_WARNING(( "SECRET: %s", line ));
+  FD_LOG_DEBUG(( "SECRET: %s", line ));
   fd_pcapng_fwrite_tls_key_log( (uchar const *)line, (uint)strlen( line ), pcap_server_to_client.pcapng );
 }
 
@@ -200,7 +200,7 @@ my_stream_receive_cb( fd_quic_stream_t * stream,
   (void)stream;
   (void)fin;
 
-  FD_LOG_NOTICE(( "received data from peer.  stream_id: %lu  size: %lu offset: %lu\n",
+  FD_LOG_DEBUG(( "received data from peer.  stream_id: %lu  size: %lu offset: %lu",
                 (ulong)stream->stream_id, data_sz, offset ));
   FD_LOG_HEXDUMP_DEBUG(( "received data", data, data_sz ));
 

--- a/src/waltz/quic/tests/test_quic_hs.c
+++ b/src/waltz/quic/tests/test_quic_hs.c
@@ -17,7 +17,7 @@ my_stream_receive_cb( fd_quic_stream_t * stream,
   FD_LOG_DEBUG(( "server rx stream data stream=%lu size=%lu offset=%lu",
                  stream->stream_id, data_sz, offset ));
   FD_TEST( fd_ulong_is_aligned( offset, 512UL ) );
-  FD_LOG_HEXDUMP_DEBUG(( "received data", data, data_sz ));
+  //FD_LOG_HEXDUMP_DEBUG(( "received data", data, data_sz ));
 
   FD_TEST( data_sz==512UL );
   FD_TEST( !fin );


### PR DESCRIPTION
- Ignore peer ACKs of our ACKs
- Don't retransmit our ACKs if peer didn't ACK them
- Replace fd_quic_ack_t linked list with a simpler ring buffer
- Limit amount of disjoint ACK ranges generated in response to peer
  packets with gapped packet numbers
- Improve complexity of ACK generation algorithms
