### PR TITLE
flamenco, vm: skip pubkeys which span multiple regions

### DIFF
--- a/contrib/test/test-vectors-fixtures/cpi-fixtures/cpi.list
+++ b/contrib/test/test-vectors-fixtures/cpi-fixtures/cpi.list
@@ -53,3 +53,4 @@ dump/test-vectors/cpi/fixtures/f6c8cf465b4edc04fbad54c3d55c78f39cd67059_3168608.
 dump/test-vectors/cpi/fixtures/fc3571eee4259ca8587c388c4f2a71df4ec5ca02_3165792.fix
 dump/test-vectors/cpi/fixtures/ff6c6c34d1e3065cb0573fa26a478d6497b70664_3165041.fix
 dump/test-vectors/cpi/fixtures/fb2e44bd7ced7d783a7645207a9789510347ad74_3574993.fix
+dump/test-vectors/cpi/fixtures/cpi_segfault_on_bad_pubkey_input_region.fix


### PR DESCRIPTION
User-provided pubkeys should never span multiple regions, these should ~~be skipped.~~ error out