### PR TITLE
flamenco, vm: check if callee program exists

### DIFF
--- a/contrib/test/syscall-fixtures/cpi.list
+++ b/contrib/test/syscall-fixtures/cpi.list
@@ -1,0 +1,1 @@
+dump/test-vectors/syscall/fixtures/cpi/cpi_callee_prog_in_txn_check.fix

--- a/src/flamenco/runtime/program/fd_native_cpi.c
+++ b/src/flamenco/runtime/program/fd_native_cpi.c
@@ -20,6 +20,10 @@ fd_native_cpi_execute_system_program_instruction( fd_exec_instr_ctx_t * ctx,
   fd_instruction_account_t instruction_accounts[256];
   ulong instruction_accounts_cnt;
 
+  /* fd_vm_prepare_instruction will handle missing/invalid account case */
+  instr_info->program_id_pubkey = fd_solana_system_program_id;
+  instr_info->program_id = UCHAR_MAX;
+
   for( ulong i = 0UL; i < ctx->txn_ctx->accounts_cnt; i++ ) {
     if( !memcmp( fd_solana_system_program_id.key, ctx->txn_ctx->accounts[i].key, sizeof(fd_pubkey_t) ) ) {
       instr_info->program_id = (uchar)i;
@@ -33,7 +37,6 @@ fd_native_cpi_execute_system_program_instruction( fd_exec_instr_ctx_t * ctx,
   uchar acc_idx_seen[256];
   memset( acc_idx_seen, 0, 256 );
 
-  instr_info->program_id_pubkey = fd_solana_system_program_id;
   instr_info->acct_cnt = (ushort)acct_metas_len;
   for ( ulong j = 0; j < acct_metas_len; j++ ) {
     fd_vm_rust_account_meta_t const * acct_meta = &acct_metas[j];

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
@@ -37,14 +37,15 @@ VM_SYSCALL_CPI_INSTRUCTION_TO_INSTR_FUNC( fd_vm_t * vm,
                             fd_pubkey_t const * program_id,
                             uchar const * cpi_instr_data,
                             fd_instr_info_t * out_instr ) {
+  /* fd_vm_prepare_instruction will handle the case where pubkey is missing */
+  out_instr->program_id_pubkey = *program_id;
+  out_instr->program_id = UCHAR_MAX;
 
   /* Find the index of the CPI instruction's program account in the transaction */
-  /* TODO: what if this is not present? */
   fd_pubkey_t * txn_accs = vm->instr_ctx->txn_ctx->accounts;
   for( ulong i=0UL; i < vm->instr_ctx->txn_ctx->accounts_cnt; i++ ) {
     if( !memcmp( program_id, &txn_accs[i], sizeof( fd_pubkey_t ) ) ) {
       out_instr->program_id = (uchar)i;
-      out_instr->program_id_pubkey = txn_accs[i];
       break;
     }
   }


### PR DESCRIPTION
Agave performs this check in `InvokeContext::prepare_instruction`

NOTE: this needs to be log collected, without which we cannot generate a (passing) fixture

# TODO
- [x] Add logs (match Agave)
- [x] Add fixture
- [x] Use logging idioms defined in this PR: https://github.com/firedancer-io/firedancer/pull/2827/