### PR TITLE
Fix pcapng timestamp resolution

### DIFF
--- a/src/util/net/fd_pcapng.c
+++ b/src/util/net/fd_pcapng.c
@@ -632,6 +632,9 @@ fd_pcapng_fwrite_idb( uint                         link_type,
                                and payload. (meta is variable length) */
   };
 
+  uchar tsresol = FD_PCAPNG_TSRESOL_NS;
+  FD_PCAPNG_FWRITE_OPT( FD_PCAPNG_IDB_OPT_TSRESOL, 1UL, &tsresol );
+
   if( opt ) {
 
     if( opt->name[0] )
@@ -640,8 +643,6 @@ fd_pcapng_fwrite_idb( uint                         link_type,
       FD_PCAPNG_FWRITE_OPT( FD_PCAPNG_IDB_OPT_IPV4_ADDR, 4UL,                                 opt->ip4_addr );
     if( fd_ulong_load_6( opt->mac_addr ) )
       FD_PCAPNG_FWRITE_OPT( FD_PCAPNG_IDB_OPT_MAC_ADDR,  6UL,                                 opt->mac_addr );
-
-  /**/FD_PCAPNG_FWRITE_OPT( FD_PCAPNG_IDB_OPT_TSRESOL,   1UL,                                 &opt->tsresol );
 
     if( opt->hardware[0] )
       FD_PCAPNG_FWRITE_OPT( FD_PCAPNG_IDB_OPT_HARDWARE,  fd_cstr_nlen( opt->hardware, 64UL ), opt->hardware );

--- a/src/util/net/fd_pcapng.h
+++ b/src/util/net/fd_pcapng.h
@@ -187,7 +187,8 @@ fd_pcapng_idb_defaults( fd_pcapng_idb_opts_t * opt,
 /* fd_pcapng_fwrite_idb writes an IDB (Interface Description Block) to
    the stream pointed to by file.  Usually a successor of an SHB.  Refer
    to fd_pcapng_fwrite_shb for use of opt, file args. link_type is one
-   of FD_PCAPNG_LINKTYPE_*. */
+   of FD_PCAPNG_LINKTYPE_*.  opt->tsresol is ignored.  fd_pcapng always
+   writes TSRESOL==9 (nanoseconds). */
 
 /* FD_PCAPNG_LINKTYPE_*: Link types (currently only Ethernet supported) */
 
@@ -201,10 +202,8 @@ fd_pcapng_fwrite_idb( uint                         link_type,
 /* fd_pcapng_fwrite_pkt writes an EPB (Enhanced Packet Block) containing
    an ethernet frame at time ts (in nanos). Same semantics as fwrite
    (returns the number of packets written, which should be 1 on success
-   and 0 on failure). Current section's IDB tsresol==
-   FD_PCAPNG_TSRESOL_NS (initialized accordingly by
-   fd_pcapng_idb_defaults).  queue is the RX queue index on which this
-   packet was received on (-1 if unknown). */
+   and 0 on failure).  queue is the RX queue index on which this packet
+   was received on (-1 if unknown). */
 
 ulong
 fd_pcapng_fwrite_pkt( long         ts,

--- a/src/util/net/test_pcapng.c
+++ b/src/util/net/test_pcapng.c
@@ -74,7 +74,6 @@ test_pcapng_fwrite_idb( void ) {
     .name     = "eth0",
     .ip4_addr = {10, 0, 0, 1},
     .mac_addr = {0x06, 0x00, 0xde, 0xad, 0xbe, 0xef},
-    .tsresol  = FD_PCAPNG_TSRESOL_NS,
     .hardware = "A fake NIC"
   };
   FD_TEST( 1UL==fd_pcapng_fwrite_idb( FD_PCAPNG_LINKTYPE_ETHERNET, &opts, pcap ) );
@@ -148,7 +147,6 @@ test_pcapng_dogfood( void ) {
     .name     = "eth0",
     .ip4_addr = {10, 0, 0, 1},
     .mac_addr = {0x06, 0x00, 0xde, 0xad, 0xbe, 0xef},
-    .tsresol  = FD_PCAPNG_TSRESOL_NS,
     .hardware = "A fake NIC"
   };
   FD_TEST( 1UL==fd_pcapng_fwrite_idb( FD_PCAPNG_LINKTYPE_ETHERNET, &idb_opts, pcap ) );


### PR DESCRIPTION
fd_aio_pcapng was generating captures with invalid timestamps.

Defaults fd_pcapng_fwrite APIs to always use nanosecond precision,
removing the user's ability/responsibility to set tsresol.
