### PR TITLE
Support for offline rpc service

### DIFF
--- a/src/app/ledger/main.c
+++ b/src/app/ledger/main.c
@@ -862,10 +862,14 @@ ingest( fd_ledger_args_t * args ) {
 
   /* At this point the account state has been ingested into funk. Intake rocksdb */
   if( args->start_slot == 0 ) {
-    args->start_slot = slot_ctx->slot_bank.slot;
+    args->start_slot = slot_ctx->slot_bank.slot + 1;
+  }
+  fd_blockstore_t * blockstore = args->blockstore;
+  if( blockstore ) {
+    blockstore->min = blockstore->max = blockstore->lps =
+      blockstore->hcs = blockstore->smr = slot_ctx->slot_bank.slot;
   }
 
-  fd_blockstore_t * blockstore = args->blockstore;
   if( args->funk_only ) {
     FD_LOG_NOTICE(( "using funk only, skipping blockstore ingest" ));
   } else if( args->shredcap ) {

--- a/src/app/rpcserver/fd_rpc_service.h
+++ b/src/app/rpcserver/fd_rpc_service.h
@@ -12,6 +12,7 @@
 #include <netinet/in.h>
 
 struct fd_rpcserver_args {
+  int               offline;
   fd_funk_t *       funk;
   fd_blockstore_t * blockstore;
   fd_wksp_t *       rep_notify_wksp;

--- a/src/flamenco/runtime/fd_rocksdb.c
+++ b/src/flamenco/runtime/fd_rocksdb.c
@@ -580,7 +580,7 @@ fd_rocksdb_import_block_blockstore( fd_rocksdb_t *    db,
 
   rocksdb_iter_destroy(iter);
 
-  fd_wksp_t * wksp = fd_wksp_containing( blockstore );
+  fd_wksp_t * wksp = fd_blockstore_wksp( blockstore );
   fd_block_map_t * block_map_entry = fd_blockstore_block_map_query( blockstore, slot );
   if( FD_LIKELY( block_map_entry && block_map_entry->block_gaddr ) ) {
     size_t vallen = 0;
@@ -718,6 +718,13 @@ fd_rocksdb_import_block_blockstore( fd_rocksdb_t *    db,
     }
 
     FD_TEST( blk->txns_meta_gaddr + blk->txns_meta_sz == fd_wksp_gaddr_fast( wksp, cur_laddr ) );
+  }
+
+  if( slot > blockstore->max ) {
+    blockstore->max = blockstore->hcs = slot;
+  }
+  if( FD_LIKELY( block_map_entry ) ) {
+    block_map_entry->flags = fd_uchar_set_bit( block_map_entry->flags, FD_BLOCK_FLAG_COMPLETED );
   }
 
   fd_blockstore_end_write(blockstore);


### PR DESCRIPTION
sample commands:

build/native/gcc/bin/fd_ledger --cmd ingest --rocksdb /data/asiegel/firedancer/dump/testnet-281688085/rocksdb --index-max 5000000 --end-slot 281688085 --page-cnt 30 --funk-page-cnt 16 --snapshot /data/asiegel/firedancer/dump/testnet-281688085/snapshot-281688080-6NHAVEju9WSsz7LQ3sLS9Yn2Tk9J7QByHRFEQLvXKqHG.tar.zst --checkpt /data/asiegel/test-bstore.wksp --checkpt-funk /data/asiegel/test-funk.wksp --copy-txn-status 1

build/native/gcc/bin/fd_rpcserver --offline 1 --port 8123 --restore-funk /data/asiegel/test-funk.wksp --restore-blockstore /data/asiegel/test-bstore.wksp
