### PR TITLE
flamenco: fix account resize delta double add

### DIFF
--- a/contrib/test/txn-fixtures/program-tests.list
+++ b/contrib/test/txn-fixtures/program-tests.list
@@ -26,3 +26,4 @@ dump/test-vectors/txn/fixtures/programs/crash-ebdcdc6274bbf5f326439bf13868124500
 dump/test-vectors/txn/fixtures/programs/d5e2332f53032ce4428b0b55e3a97c080c1db63e_1034518.fix
 dump/test-vectors/txn/fixtures/programs/deff84b60ea3c6284e621b4229f402c4274e4968_1446008.fix
 dump/test-vectors/txn/fixtures/programs/ed4565e33252bca4dc606bdce4aa48a650e75048_1366919.fix
+dump/test-vectors/txn/fixtures/programs/crash-3354ca5c9ba1c2ea78c33855ec5ced47dcf9f29e.fix

--- a/src/flamenco/runtime/fd_account.h
+++ b/src/flamenco/runtime/fd_account.h
@@ -351,10 +351,11 @@ fd_account_can_data_be_resized( fd_exec_instr_ctx_t const * instr_ctx,
     return 0;
   }
 
-  /* The resize can not exceed the per-transaction maximum */
+  /* The resize can not exceed the per-transaction maximum
+     https://github.com/firedancer-io/agave/blob/1e460f466da60a63c7308e267c053eec41dc1b1c/sdk/src/transaction_context.rs#L1107-L1111 */
   ulong length_delta = fd_ulong_sat_sub( new_length, acct->dlen );
-  instr_ctx->txn_ctx->accounts_resize_delta = fd_ulong_sat_add( instr_ctx->txn_ctx->accounts_resize_delta, length_delta );
-  if( FD_UNLIKELY( instr_ctx->txn_ctx->accounts_resize_delta>MAX_PERMITTED_ACCOUNT_DATA_ALLOCS_PER_TXN ) ) {
+  ulong new_accounts_resize_delta = fd_ulong_sat_add( instr_ctx->txn_ctx->accounts_resize_delta, length_delta );
+  if( FD_UNLIKELY( new_accounts_resize_delta>MAX_PERMITTED_ACCOUNT_DATA_ALLOCS_PER_TXN ) ) {
     *err = FD_EXECUTOR_INSTR_ERR_MAX_ACCS_DATA_ALLOCS_EXCEEDED;
     return 0;
   }


### PR DESCRIPTION
Agave modifies a copy of the variable here, and then increments the actual variable later. We mistakenly perform a double add and incorrectly throw an error