### PR TITLE
hcache: avoid potential buffer overrun

### DIFF
--- a/src/ballet/http/fd_hcache.c
+++ b/src/ballet/http/fd_hcache.c
@@ -185,6 +185,7 @@ fd_hcache_printf( fd_hcache_t * hcache,
   va_end( ap );
 
   fd_hcache_reserve( hcache, printed_len );
+  if( FD_UNLIKELY( hcache->snap_err ) ) return;
 
   va_start( ap, fmt );
   vsnprintf( (char *)fd_hcache_private_data( hcache ) + hcache->snap_off + hcache->snap_len,


### PR DESCRIPTION
Check for reservation failure and abort.  Otherwise the ensuing print with a max length of INT_MAX could overrun buffer.