### PR TITLE
flamenco: implement load_transaction_accounts runtime checks

### DIFF
--- a/contrib/test/txn-fixtures/program-tests.list
+++ b/contrib/test/txn-fixtures/program-tests.list
@@ -27,3 +27,4 @@ dump/test-vectors/txn/fixtures/programs/d5e2332f53032ce4428b0b55e3a97c080c1db63e
 dump/test-vectors/txn/fixtures/programs/deff84b60ea3c6284e621b4229f402c4274e4968_1446008.fix
 dump/test-vectors/txn/fixtures/programs/ed4565e33252bca4dc606bdce4aa48a650e75048_1366919.fix
 dump/test-vectors/txn/fixtures/programs/crash-3354ca5c9ba1c2ea78c33855ec5ced47dcf9f29e.fix
+dump/test-vectors/txn/fixtures/programs/crash-6ac1f183ec533a9ef01c6b19ac8938ade3b12354.fix

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -145,7 +145,7 @@ FD_FN_CONST char const *
 fd_executor_instr_strerror( int err );
 
 int
-fd_executor_check_txn_data_sz( fd_exec_txn_ctx_t * txn_ctx );
+fd_executor_check_txn_program_accounts_and_data_sz( fd_exec_txn_ctx_t * txn_ctx );
 
 int
 fd_executor_check_replenish_program_cache( fd_exec_txn_ctx_t * txn_ctx );

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -819,8 +819,9 @@ fd_runtime_prepare_txns_start( fd_exec_slot_ctx_t *         slot_ctx,
    validating the fee payer and collecting the fee. This is mirrored in
    firedancer with fd_executor_compute_budget_program_execute_instructions()
    and fd_executor_collect_fees(). load_and_execute_sanitized_transactions()
-   also checks the total data size of the accounts in load_accounts(), this
-   is paralled by fd_executor_check_txn_data_sz(). */
+   also checks the total data size of the accounts in load_accounts() and
+   validates the program accounts in load_transaction_accounts(). This
+   is paralled by fd_executor_check_txn_program_accounts_and_data_sz(). */
 
 static void FD_FN_UNUSED
 fd_txn_sigverify_task( void *tpool,
@@ -930,7 +931,7 @@ fd_runtime_pre_execute_check( fd_execute_txn_task_info_t * task_info ) {
   }
 
   /* https://github.com/anza-xyz/agave/blob/16de8b75ebcd57022409b422de557dd37b1de8db/svm/src/account_loader.rs#L278-L284 */
-  err = fd_executor_check_txn_data_sz( txn_ctx );
+  err = fd_executor_check_txn_program_accounts_and_data_sz( txn_ctx );
   if( FD_UNLIKELY( err!=FD_RUNTIME_EXECUTE_SUCCESS ) ) {
     task_info->txn->flags = 0U;
     task_info->exec_res   = err;


### PR DESCRIPTION
Agave implements several checks for program accounts that we were missing