### PR TITLE
pack: various performance tuning improvments

### DIFF
--- a/src/app/fdctl/run/tiles/fd_pack.c
+++ b/src/app/fdctl/run/tiles/fd_pack.c
@@ -41,7 +41,7 @@ FD_STATIC_ASSERT( (ulong)LONG_MAX+TIME_OFFSET==ULONG_MAX, time_offset );
 
 
 /* Optionally allow a larger limit for benchmarking */
-#define LARGER_MAX_COST_PER_BLOCK (13UL*48000000UL)
+#define LARGER_MAX_COST_PER_BLOCK (18UL*48000000UL)
 
 /* 1.5 M cost units, enough for 1 max size transaction */
 const ulong CUS_PER_MICROBLOCK = 1500000UL;

--- a/src/app/fdctl/run/topos/fd_frankendancer.c
+++ b/src/app/fdctl/run/topos/fd_frankendancer.c
@@ -62,7 +62,7 @@ fd_topo_frankendancer( config_t * config ) {
   /**/                 fd_topob_link( topo, "gossip_dedup", "gossip_dedup", 0,        2048UL,                                   FD_TPU_DCACHE_MTU,      1UL );
   /* dedup_pack is large currently because pack can encounter stalls when running at very high throughput rates that would
      otherwise cause drops. */
-  /**/                 fd_topob_link( topo, "dedup_pack",   "dedup_pack",   0,        4*65536UL,                                FD_TPU_DCACHE_MTU,      1UL );
+  /**/                 fd_topob_link( topo, "dedup_pack",   "dedup_pack",   0,        65536UL,                                  FD_TPU_DCACHE_MTU,      1UL );
   /**/                 fd_topob_link( topo, "stake_out",    "stake_out",    0,        128UL,                                    40UL + 40200UL * 40UL,  1UL );
   /* pack_bank is shared across all banks, so if one bank stalls due to complex transactions, the buffer neeeds to be large so that
      other banks can keep proceeding. */

--- a/src/ballet/pack/fd_microblock.h
+++ b/src/ballet/pack/fd_microblock.h
@@ -48,7 +48,7 @@ struct fd_entry_batch_header {
 };
 typedef struct fd_entry_batch_header fd_entry_batch_header_t;
 
-struct fd_txn_p {
+struct __attribute__((aligned(64))) fd_txn_p {
   uchar payload[FD_TPU_MTU];
   ulong payload_sz;
   uint  requested_cus; /* Populated by pack. Bank does not read this. */

--- a/src/ballet/pack/fd_pack.c
+++ b/src/ballet/pack/fd_pack.c
@@ -8,6 +8,8 @@
 #include <stddef.h> /* for offsetof */
 #include "../../disco/metrics/fd_metrics.h"
 
+#define FD_PACK_USE_NON_TEMPORAL_MEMCPY 1
+
 /* Declare a bunch of helper structs used for pack-internal data
    structures. */
 
@@ -654,6 +656,7 @@ fd_pack_estimate_rewards_and_compute( fd_txn_p_t        * txnp,
   out->rewards            = (adtl_rewards < (UINT_MAX - sig_rewards)) ? (uint)(sig_rewards + adtl_rewards) : UINT_MAX;
   out->compute_est        = (uint)cost;
   out->txn->requested_cus = (uint)execution_cus;
+  out->txn->executed_cus  = 0U;
 
   out->root = (txnp->flags & FD_TXN_P_FLAGS_IS_SIMPLE_VOTE) ? FD_ORD_TXN_ROOT_PENDING_VOTE : FD_ORD_TXN_ROOT_PENDING;
 
@@ -1032,12 +1035,53 @@ fd_pack_schedule_impl( fd_pack_t          * pack,
     FD_PACK_BITSET_OR( bitset_rw_in_use, cur->rw_bitset );
     FD_PACK_BITSET_OR( bitset_w_in_use,  cur->w_bitset  );
 
-    fd_memcpy( out->payload, cur->txn->payload, cur->txn->payload_sz                                           );
-    fd_memcpy( TXN(out),     txn,               fd_txn_footprint( txn->instr_cnt, txn->addr_table_lookup_cnt ) );
-    out->payload_sz    = cur->txn->payload_sz;
-    out->requested_cus = cur->txn->requested_cus;
-    out->executed_cus  = 0U;
-    out->flags         = cur->txn->flags;
+    if(
+#if FD_HAS_AVX512 && FD_PACK_USE_NON_TEMPORAL_MEMCPY
+        FD_LIKELY( cur->txn->payload_sz>=1024UL )
+#else
+        0
+#endif
+      ) {
+#if FD_HAS_AVX512 && FD_PACK_USE_NON_TEMPORAL_MEMCPY
+      _mm512_stream_si512( (void*)(out->payload+   0UL), _mm512_load_epi64( cur->txn->payload+   0UL ) );
+      _mm512_stream_si512( (void*)(out->payload+  64UL), _mm512_load_epi64( cur->txn->payload+  64UL ) );
+      _mm512_stream_si512( (void*)(out->payload+ 128UL), _mm512_load_epi64( cur->txn->payload+ 128UL ) );
+      _mm512_stream_si512( (void*)(out->payload+ 192UL), _mm512_load_epi64( cur->txn->payload+ 192UL ) );
+      _mm512_stream_si512( (void*)(out->payload+ 256UL), _mm512_load_epi64( cur->txn->payload+ 256UL ) );
+      _mm512_stream_si512( (void*)(out->payload+ 320UL), _mm512_load_epi64( cur->txn->payload+ 320UL ) );
+      _mm512_stream_si512( (void*)(out->payload+ 384UL), _mm512_load_epi64( cur->txn->payload+ 384UL ) );
+      _mm512_stream_si512( (void*)(out->payload+ 448UL), _mm512_load_epi64( cur->txn->payload+ 448UL ) );
+      _mm512_stream_si512( (void*)(out->payload+ 512UL), _mm512_load_epi64( cur->txn->payload+ 512UL ) );
+      _mm512_stream_si512( (void*)(out->payload+ 576UL), _mm512_load_epi64( cur->txn->payload+ 576UL ) );
+      _mm512_stream_si512( (void*)(out->payload+ 640UL), _mm512_load_epi64( cur->txn->payload+ 640UL ) );
+      _mm512_stream_si512( (void*)(out->payload+ 704UL), _mm512_load_epi64( cur->txn->payload+ 704UL ) );
+      _mm512_stream_si512( (void*)(out->payload+ 768UL), _mm512_load_epi64( cur->txn->payload+ 768UL ) );
+      _mm512_stream_si512( (void*)(out->payload+ 832UL), _mm512_load_epi64( cur->txn->payload+ 832UL ) );
+      _mm512_stream_si512( (void*)(out->payload+ 896UL), _mm512_load_epi64( cur->txn->payload+ 896UL ) );
+      _mm512_stream_si512( (void*)(out->payload+ 960UL), _mm512_load_epi64( cur->txn->payload+ 960UL ) );
+      _mm512_stream_si512( (void*)(out->payload+1024UL), _mm512_load_epi64( cur->txn->payload+1024UL ) );
+      _mm512_stream_si512( (void*)(out->payload+1088UL), _mm512_load_epi64( cur->txn->payload+1088UL ) );
+      _mm512_stream_si512( (void*)(out->payload+1152UL), _mm512_load_epi64( cur->txn->payload+1152UL ) );
+      _mm512_stream_si512( (void*)(out->payload+1216UL), _mm512_load_epi64( cur->txn->payload+1216UL ) );
+      /* Copied out to 1280 bytes, which copies some other fields we needed to
+         copy anyway. */
+      FD_STATIC_ASSERT( offsetof(fd_txn_p_t, payload_sz   )+sizeof(((fd_txn_p_t*)NULL)->payload_sz   )<=1280UL, nt_memcpy );
+      FD_STATIC_ASSERT( offsetof(fd_txn_p_t, requested_cus)+sizeof(((fd_txn_p_t*)NULL)->requested_cus)<=1280UL, nt_memcpy );
+      FD_STATIC_ASSERT( offsetof(fd_txn_p_t, executed_cus )+sizeof(((fd_txn_p_t*)NULL)->executed_cus )<=1280UL, nt_memcpy );
+      FD_STATIC_ASSERT( offsetof(fd_txn_p_t, flags        )+sizeof(((fd_txn_p_t*)NULL)->flags        )<=1280UL, nt_memcpy );
+      FD_STATIC_ASSERT( offsetof(fd_txn_p_t, _            )                                           <=1280UL, nt_memcpy );
+      const ulong offset_into_txn = 1280UL - offsetof(fd_txn_p_t, _ );
+      fd_memcpy( offset_into_txn+(uchar *)TXN(out), offset_into_txn+(uchar const *)txn,
+          fd_ulong_max( offset_into_txn, fd_txn_footprint( txn->instr_cnt, txn->addr_table_lookup_cnt ) )-offset_into_txn );
+#endif
+    } else {
+      fd_memcpy( out->payload, cur->txn->payload, cur->txn->payload_sz                                           );
+      fd_memcpy( TXN(out),     txn,               fd_txn_footprint( txn->instr_cnt, txn->addr_table_lookup_cnt ) );
+      out->payload_sz    = cur->txn->payload_sz;
+      out->requested_cus = cur->txn->requested_cus;
+      out->executed_cus  = 0U;
+      out->flags         = cur->txn->flags;
+    }
     out++;
 
     for( fd_txn_acct_iter_t iter=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_WRITABLE & FD_TXN_ACCT_CAT_IMM );
@@ -1270,6 +1314,10 @@ fd_pack_schedule_next_microblock( fd_pack_t *  pack,
 
   fd_histf_sample( pack->txn_per_microblock,  scheduled              );
   fd_histf_sample( pack->vote_per_microblock, status1.txns_scheduled );
+
+#if FD_HAS_AVX512 && FD_PACK_USE_NON_TEMPORAL_MEMCPY
+  _mm_sfence();
+#endif
 
   return scheduled;
 }

--- a/src/ballet/pack/fd_pack.c
+++ b/src/ballet/pack/fd_pack.c
@@ -637,7 +637,7 @@ fd_pack_estimate_rewards_and_compute( fd_txn_p_t        * txnp,
   ulong execution_cus;
   ulong adtl_rewards;
   ulong precompile_sigs;
-  ulong cost = fd_pack_compute_cost( txnp, &txnp->flags, &execution_cus, &adtl_rewards, &precompile_sigs );
+  ulong cost = fd_pack_compute_cost( txn, txnp->payload, &txnp->flags, &execution_cus, &adtl_rewards, &precompile_sigs );
 
   if( FD_UNLIKELY( !cost ) ) return 0;
 

--- a/src/ballet/pack/fd_pack.c
+++ b/src/ballet/pack/fd_pack.c
@@ -317,6 +317,19 @@ static const fd_acct_addr_t null_addr = { 0 };
                              } while( 0 )
 #include "../../util/tmpl/fd_prq.c"
 
+/* fd_pack_smallest: We want to keep track of the smallest transaction
+   in each treap.  That way, if we know the amount of space left in the
+   block is less than the smallest transaction in the heap, we can just
+   skip the heap.  Since transactions can be deleted, etc. maintaining
+   this precisely is hard, but we can maintain a conservative value
+   fairly cheaply.  Since the CU limit or the byte limit can be the one
+   that matters, we keep track of the smallest by both. */
+struct fd_pack_smallest {
+  ulong cus;
+  ulong bytes;
+};
+typedef struct fd_pack_smallest fd_pack_smallest_t;
+
 /* Finally, we can now declare the main pack data structure */
 struct fd_pack_private {
   ulong      pack_depth;
@@ -358,6 +371,13 @@ struct fd_pack_private {
      pending simple votes separately. */
   treap_t pending[1];
   treap_t pending_votes[1];
+
+  /* pending{_votes}_smallest: keep a conservative estimate of the
+     smallest transaction (by cost units and by bytes) in each heap.
+     Both CUs and bytes should be set to ULONG_MAX is the treap is
+     empty. */
+  fd_pack_smallest_t pending_smallest[1];
+  fd_pack_smallest_t pending_votes_smallest[1];
 
   /* expiration_q: At the same time that a transaction is in exactly one
      of the above treaps, it is also in the expiration queue, sorted by
@@ -525,6 +545,11 @@ fd_pack_new( void                   * mem,
 
   treap_new( (void*)pack->pending,         pack_depth );
   treap_new( (void*)pack->pending_votes,   pack_depth );
+
+  pack->pending_smallest->cus         = ULONG_MAX;
+  pack->pending_smallest->bytes       = ULONG_MAX;
+  pack->pending_votes_smallest->cus   = ULONG_MAX;
+  pack->pending_votes_smallest->bytes = ULONG_MAX;
 
   expq_new( _expq, pack_depth+1UL );
 
@@ -823,7 +848,11 @@ fd_pack_insert_txn_fini( fd_pack_t  * pack,
   fd_pack_expq_t temp[ 1 ] = {{ .expires_at = expires_at, .txn = ord }};
   expq_insert( pack->expiration_q, temp );
 
-  if( FD_LIKELY( ord->root == FD_ORD_TXN_ROOT_PENDING_VOTE ) ) {
+  fd_pack_smallest_t * smallest = fd_ptr_if( is_vote, &pack->pending_votes_smallest[0], pack->pending_smallest );
+  smallest->cus   = fd_ulong_min( smallest->cus,   ord->compute_est );
+  smallest->bytes = fd_ulong_min( smallest->bytes, txnp->payload_sz );
+
+  if( FD_LIKELY( is_vote ) ) {
     treap_ele_insert( pack->pending_votes, ord, pack->pool );
     return replaces ? FD_PACK_INSERT_ACCEPT_VOTE_REPLACE : FD_PACK_INSERT_ACCEPT_VOTE_ADD;
   } else {
@@ -871,13 +900,14 @@ typedef struct {
 } sched_return_t;
 
 static inline sched_return_t
-fd_pack_schedule_impl( fd_pack_t  * pack,
-                       treap_t    * sched_from,
-                       ulong        cu_limit,
-                       ulong        txn_limit,
-                       ulong        byte_limit,
-                       ulong        bank_tile,
-                       fd_txn_p_t * out ) {
+fd_pack_schedule_impl( fd_pack_t          * pack,
+                       treap_t            * sched_from,
+                       ulong                cu_limit,
+                       ulong                txn_limit,
+                       ulong                byte_limit,
+                       ulong                bank_tile,
+                       fd_pack_smallest_t * smallest_in_treap,
+                       fd_txn_p_t         * out ) {
 
   fd_pack_ord_txn_t  * pool         = pack->pool;
   fd_pack_addr_use_t * acct_in_use  = pack->acct_in_use;
@@ -909,12 +939,15 @@ fd_pack_schedule_impl( fd_pack_t  * pack,
   ulong byte_limit_c  = 0UL;
   ulong write_limit_c = 0UL;
 
-  if( FD_UNLIKELY( (cu_limit<FD_PACK_MIN_TXN_COST) | (txn_limit==0UL) | (byte_limit<FD_TXN_MIN_SERIALIZED_SZ) ) ) {
+  ulong min_cus   = ULONG_MAX;
+  ulong min_bytes = ULONG_MAX;
+
+  if( FD_UNLIKELY( (cu_limit<smallest_in_treap->cus) | (txn_limit==0UL) | (byte_limit<smallest_in_treap->bytes) ) ) {
     sched_return_t to_return = { .cus_scheduled = 0UL, .txns_scheduled = 0UL, .bytes_scheduled = 0UL };
     return to_return;
   }
 
-  treap_rev_iter_t prev;
+  treap_rev_iter_t prev = treap_idx_null();
   for( treap_rev_iter_t _cur=treap_rev_iter_init( sched_from, pool ); !treap_rev_iter_done( _cur ); _cur=prev ) {
     /* Capture next so that we can delete while we iterate. */
     prev = treap_rev_iter_next( _cur, pool );
@@ -924,6 +957,9 @@ fd_pack_schedule_impl( fd_pack_t  * pack,
 #   endif
 
     fd_pack_ord_txn_t const * cur = treap_rev_iter_ele_const( _cur, pool );
+
+    min_cus   = fd_ulong_min( min_cus,   cur->compute_est     );
+    min_bytes = fd_ulong_min( min_bytes, cur->txn->payload_sz );
 
     ulong conflicts = 0UL;
 
@@ -1064,7 +1100,7 @@ fd_pack_schedule_impl( fd_pack_t  * pack,
     trp_pool_idx_release( pool, _cur );
     pack->pending_txn_cnt--;
 
-    if( FD_UNLIKELY( (cu_limit<FD_PACK_MIN_TXN_COST) | (txn_limit==0UL) | (byte_limit<FD_TXN_MIN_SERIALIZED_SZ) ) ) break;
+    if( FD_UNLIKELY( (cu_limit<smallest_in_treap->cus) | (txn_limit==0UL) | (byte_limit<smallest_in_treap->bytes) ) ) break;
   }
 
   FD_MCNT_INC( PACK, TRANSACTION_SCHEDULE_TAKEN,      txns_scheduled );
@@ -1077,6 +1113,13 @@ fd_pack_schedule_impl( fd_pack_t  * pack,
 #if DETAILED_LOGGING
   FD_LOG_NOTICE(( "cu_limit: %lu, fast_path: %lu, slow_path: %lu", cu_limit_c, fast_path, slow_path ));
 #endif
+
+  /* If we scanned the whole treap and didn't break early, we now have a
+     better estimate of the smallest. */
+  if( FD_UNLIKELY( treap_rev_iter_done( prev ) ) ) {
+    smallest_in_treap->cus   = min_cus;
+    smallest_in_treap->bytes = min_bytes;
+  }
 
   pack->use_by_bank_cnt[bank_tile] = use_by_bank_cnt;
   FD_PACK_BITSET_COPY( pack->bitset_rw_in_use, bitset_rw_in_use );
@@ -1188,7 +1231,7 @@ fd_pack_schedule_next_microblock( fd_pack_t *  pack,
   sched_return_t status, status1;
 
   /* Try to schedule non-vote transactions */
-  status = fd_pack_schedule_impl( pack, pack->pending,       cu_limit, txn_limit,          byte_limit, bank_tile, out+scheduled );
+  status = fd_pack_schedule_impl( pack, pack->pending,       cu_limit, txn_limit,          byte_limit, bank_tile, pack->pending_smallest,       out+scheduled );
 
   scheduled                   += status.txns_scheduled;            txn_limit  -= status.txns_scheduled;
   pack->cumulative_block_cost += status.cus_scheduled;             cu_limit   -= status.cus_scheduled;
@@ -1196,7 +1239,7 @@ fd_pack_schedule_next_microblock( fd_pack_t *  pack,
 
 
   /* Schedule vote transactions */
-  status1= fd_pack_schedule_impl( pack, pack->pending_votes, vote_cus, vote_reserved_txns, byte_limit, bank_tile, out+scheduled );
+  status1= fd_pack_schedule_impl( pack, pack->pending_votes, vote_cus, vote_reserved_txns, byte_limit, bank_tile, pack->pending_votes_smallest, out+scheduled );
 
   scheduled                   += status1.txns_scheduled;
   pack->cumulative_vote_cost  += status1.cus_scheduled;
@@ -1209,7 +1252,7 @@ fd_pack_schedule_next_microblock( fd_pack_t *  pack,
 
 
   /* Fill any remaining space with non-vote transactions */
-  status = fd_pack_schedule_impl( pack, pack->pending,       cu_limit, txn_limit,          byte_limit, bank_tile, out+scheduled );
+  status = fd_pack_schedule_impl( pack, pack->pending,       cu_limit, txn_limit,          byte_limit, bank_tile, pack->pending_smallest,       out+scheduled );
 
   scheduled                   += status.txns_scheduled;
   pack->cumulative_block_cost += status.cus_scheduled;
@@ -1395,6 +1438,11 @@ fd_pack_clear_all( fd_pack_t * pack ) {
   pack->cumulative_block_cost  = 0UL;
   pack->cumulative_vote_cost   = 0UL;
   pack->cumulative_rebated_cus = 0UL;
+
+  pack->pending_smallest->cus         = ULONG_MAX;
+  pack->pending_smallest->bytes       = ULONG_MAX;
+  pack->pending_votes_smallest->cus   = ULONG_MAX;
+  pack->pending_votes_smallest->bytes = ULONG_MAX;
 
   release_tree( pack->pending,         pack->pool );
   release_tree( pack->pending_votes,   pack->pool );

--- a/src/ballet/pack/fd_pack.h
+++ b/src/ballet/pack/fd_pack.h
@@ -45,8 +45,8 @@
    consider the data shreds limit. */
 #define FD_PACK_MAX_DATA_PER_BLOCK (((32UL*1024UL-17UL)/31UL)*25871UL + 48UL)
 
-/* Optionally allow up to 128k shreds per block for benchmarking. */
-#define LARGER_MAX_DATA_PER_BLOCK  (((4UL*32UL*1024UL-17UL)/31UL)*25871UL + 48UL)
+/* Optionally allow up to 1M shreds per block for benchmarking. */
+#define LARGER_MAX_DATA_PER_BLOCK  (((32UL*32UL*1024UL-17UL)/31UL)*25871UL + 48UL)
 
 /* ---- End consensus-critical constants */
 

--- a/src/ballet/pack/fd_pack.h
+++ b/src/ballet/pack/fd_pack.h
@@ -153,7 +153,13 @@ fd_pack_t * fd_pack_join( void * mem );
    scheduled yet. pack must be a valid local join.  The return value
    will be in [0, pack_depth). */
 
-FD_FN_PURE ulong fd_pack_avail_txn_cnt( fd_pack_t const * pack );
+/* For performance reasons, implement this here.  The offset is STATIC_ASSERTed
+   in fd_pack.c. */
+#define FD_PACK_PENDING_TXN_CNT_OFF 64
+FD_FN_PURE static inline ulong
+fd_pack_avail_txn_cnt( fd_pack_t const * pack ) {
+  return *((ulong const *)((uchar const *)pack + FD_PACK_PENDING_TXN_CNT_OFF));
+}
 
 /* fd_pack_bank_tile_cnt: returns the value of bank_tile_cnt provided in
    pack when the pack object was initialized with fd_pack_new.  pack

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -1139,7 +1139,7 @@ fd_execute_txn_prepare_phase3( fd_exec_slot_ctx_t * slot_ctx,
   /* TODO: These checks should be moved to phase2. */
 
   if (FD_FEATURE_ACTIVE( txn_ctx->slot_ctx, apply_cost_tracker_during_replay ) ) {
-    ulong est_cost = fd_pack_compute_cost( txn, &txn->flags, NULL, NULL, NULL );
+    ulong est_cost = fd_pack_compute_cost( TXN(txn), txn->payload, &txn->flags, NULL, NULL, NULL );
     if( slot_ctx->total_compute_units_requested + est_cost <= MAX_COMPUTE_UNITS_PER_BLOCK ) {
       slot_ctx->total_compute_units_requested += est_cost;
     } else {


### PR DESCRIPTION
Note that this changes the alignment of fd_txn_p_t to 64. This is necessary to use the non-temporal memcpy, which seems to make a big performance difference.