### PR TITLE
quic: reduce fd_quic_tls_hs buffer size

### DIFF
--- a/src/waltz/quic/tls/fd_quic_tls.h
+++ b/src/waltz/quic/tls/fd_quic_tls.h
@@ -60,7 +60,7 @@
 
 /* number of bytes allocated for queued handshake data
    must be a multiple of FD_QUIC_TLS_HS_DATA_ALIGN */
-#define FD_QUIC_TLS_HS_DATA_SZ  (1u<<14u)
+#define FD_QUIC_TLS_HS_DATA_SZ  (2048UL)
 
 /* callback function prototypes */
 


### PR DESCRIPTION
Reduces the size of fd_quic_tls_hs_t from 17.7kB to 3.4kB.
This allows an approx ~5x greater max concurrent handshake setting
with the same amount of memory.

The new TLS buffer size is now 2048 bytes. This is plenty even for
large QUIC transport parameters.
