### PR TITLE
Improve fd_quic_transport_params test coverage

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -561,7 +561,7 @@ fd_quic_init( fd_quic_t * quic ) {
   FD_QUIC_TRANSPORT_PARAM_SET( tp, initial_max_streams_uni,             0                        );
   FD_QUIC_TRANSPORT_PARAM_SET( tp, ack_delay_exponent,                  0                        );
   FD_QUIC_TRANSPORT_PARAM_SET( tp, max_ack_delay,                       10                       );
-  FD_QUIC_TRANSPORT_PARAM_SET( tp, disable_active_migration,            1                        );
+  /*                         */tp->disable_active_migration_present =   1;
   FD_QUIC_TRANSPORT_PARAM_SET( tp, active_connection_id_limit,          FD_QUIC_MAX_CONN_ID_PER_CONN );
 
   /* Initialize next ephemeral udp port */

--- a/src/waltz/quic/templ/fd_quic_transport_params.c
+++ b/src/waltz/quic/templ/fd_quic_transport_params.c
@@ -39,7 +39,6 @@ fd_quic_dump_transport_param_desc( FILE * out ) {
   } while(0)
 
 #define FD_QUIC_PARSE_TP_ZERO_LENGTH(NAME) \
-  params->NAME = 1u;                       \
   params->NAME##_present = 1;
 
 #define FD_QUIC_PARSE_TP_TOKEN(NAME)                        \
@@ -117,7 +116,7 @@ fd_quic_decode_transport_params( fd_quic_transport_params_t * params,
     } \
   } while(0)
 #define FD_QUIC_DUMP_TP_ZERO_LENGTH(NAME) \
-  fprintf( out, "%u", (unsigned)params->NAME )
+  fprintf( out, "%u", (unsigned)params->NAME##_present )
 #define FD_QUIC_DUMP_TP_TOKEN(NAME) FD_QUIC_DUMP_TP_CONN_ID(NAME)
 #define FD_QUIC_DUMP_TP_PREFERRED_ADDRESS(NAME) FD_QUIC_DUMP_TP_CONN_ID(NAME)
 
@@ -156,7 +155,7 @@ fd_quic_dump_transport_params( fd_quic_transport_params_t const * params, FILE *
 
 #define FD_QUIC_ENCODE_TP_ZERO_LENGTH(NAME,ID)                         \
   do {                                                                 \
-    if( params->NAME ) {                                               \
+    if( params->NAME##_present ) {                                               \
       FD_QUIC_ENCODE_VARINT( buf, buf_sz, ID );                        \
       FD_QUIC_ENCODE_VARINT( buf, buf_sz, 0 );                         \
     }                                                                  \

--- a/src/waltz/quic/templ/fd_quic_transport_params.h
+++ b/src/waltz/quic/templ/fd_quic_transport_params.h
@@ -212,7 +212,6 @@ fd_quic_dump_transport_param_desc( FILE * out );
   uchar  NAME[20];                                    \
   uchar  NAME##_present;
 #define FD_QUIC_MBR_TYPE_ZERO_LENGTH(NAME,TYPE)       \
-  uchar  NAME;                                        \
   uchar  NAME##_present;
 #define FD_QUIC_MBR_TYPE_TOKEN(NAME,TYPE)             \
   uint   NAME##_len;                                  \

--- a/src/waltz/quic/templ/fd_quic_transport_params.h
+++ b/src/waltz/quic/templ/fd_quic_transport_params.h
@@ -238,8 +238,7 @@ typedef struct fd_quic_transport_params fd_quic_transport_params_t;
 /* parses the varint at *buf (capacity *buf_sz)
    advances the *buf and reduces *buf_sz by the number of bytes
    consumed */
-static inline
-ulong
+static inline ulong
 fd_quic_tp_parse_varint( uchar const ** buf,
                          ulong *        buf_sz ) {
 
@@ -258,22 +257,6 @@ fd_quic_tp_parse_varint( uchar const ** buf,
 
   return value;
 }
-
-/* parse a particular transport parameter into the corresponding
-   member(s) of params
-
-   args
-     params       the parameters to populate with parsed data
-     id           the id of the parameter to parse
-     buf          the start of the raw encoded transport parameter
-     sz           the size of the buffer
-
-   returns the number of bytes consumed or -1 upon failure to parse */
-int
-fd_quic_decode_transport_param( fd_quic_transport_params_t * params,
-                                uint                         id,
-                                uchar const *                buf,
-                                ulong                        sz );
 
 /* parse the entire buffer into the supplied transport parameters
 


### PR DESCRIPTION
- **quic: remove redundant variable for zero-length transport params**
- **quic: ensure unknown transport params are accepted**
