### PR TITLE
quic: remove dead code

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -24,13 +24,8 @@
 #include <fcntl.h>   /* for keylog open(2)  */
 #include <unistd.h>  /* for keylog close(2) */
 
-#include <sys/random.h>
 #include "../../ballet/x509/fd_x509_mock.h"
 #include "../../ballet/hex/fd_hex.h"
-
-#define CONN_FMT "%02x%02x%02x%02x%02x%02x%02x%02x"
-#define CONN_ID(CONN_ID) (CONN_ID)->conn_id[0], (CONN_ID)->conn_id[1], (CONN_ID)->conn_id[2], (CONN_ID)->conn_id[3],  \
-                         (CONN_ID)->conn_id[4], (CONN_ID)->conn_id[5], (CONN_ID)->conn_id[6], (CONN_ID)->conn_id[7]
 
 /* Declare priority queue for time based processing */
 #define PRQ_NAME      service_queue
@@ -5043,7 +5038,6 @@ fd_quic_conn_create( fd_quic_t *               quic,
   /* transport params */
   fd_quic_transport_params_t * our_tp  = &state->transport_params;
   conn->rx_max_data                    = our_tp->initial_max_data;
-  conn->rx_initial_max_stream_data_uni = our_tp->initial_max_stream_data_uni;
 
   /* update metrics */
   quic->metrics.conn_active_cnt++;

--- a/src/waltz/quic/fd_quic.h
+++ b/src/waltz/quic/fd_quic.h
@@ -583,10 +583,6 @@ fd_quic_stream_send( fd_quic_stream_t *  stream,
 FD_QUIC_API void
 fd_quic_stream_fin( fd_quic_stream_t * stream );
 
-/* TODO: fd_quic_stream_close */
-//void
-//fd_quic_stream_close( fd_quic_stream_t * stream, int direction_flags );
-
 FD_QUIC_API void
 fd_quic_process_packet( fd_quic_t * quic,
                         uchar *     data,

--- a/src/waltz/quic/fd_quic_conn.c
+++ b/src/waltz/quic/fd_quic_conn.c
@@ -246,19 +246,6 @@ fd_quic_conn_set_max_streams( fd_quic_conn_t * conn, uint dirtype, ulong stream_
   fd_quic_assign_streams( conn->quic );
 }
 
-
-/* get the current value for the concurrent streams for the specified type
-
-   type is one of:
-     FD_QUIC_TYPE_UNIDIR
-     FD_QUIC_TYPE_BIDIR */
-FD_QUIC_API ulong
-fd_quic_conn_get_max_streams( fd_quic_conn_t * conn, uint dirtype ) {
-  uint peer = (uint)!conn->server;
-  uint type = peer + ( (uint)dirtype << 1u );
-  return conn->max_concur_streams[type];
-}
-
 /* update the tree weight
    called whenever weight may have changed */
 void

--- a/src/waltz/quic/fd_quic_conn.h
+++ b/src/waltz/quic/fd_quic_conn.h
@@ -141,8 +141,6 @@ struct fd_quic_conn {
        duplicate packets should already have been dropped
      data received higher than this would be a gap
        ignore at present, assuming will be resent in order */
-  ulong tx_crypto_offset[4]; /* next handshake data (crypto) offset
-                                   one per encryption level */
   ulong rx_crypto_offset[4]; /* expected handshake data (crypto) offset
                                    one per encryption level */
 
@@ -313,7 +311,6 @@ struct fd_quic_conn {
 
   /* max stream data per stream type */
   ulong                tx_initial_max_stream_data_uni;
-  ulong                rx_initial_max_stream_data_uni;
 
   /* last tx packet num with max_data frame referring to this stream
      set to next_pkt_number to indicate a new max_data frame should be sent
@@ -321,7 +318,7 @@ struct fd_quic_conn {
        and update this value */
   ulong                upd_pkt_number;
 
-  /* current round-trip-time */
+  /* current round-trip-time (FIXME this never updates) */
   ulong                rtt;
 
   /* highest peer encryption level */
@@ -371,15 +368,6 @@ fd_quic_conn_get_context( fd_quic_conn_t * conn );
      FD_QUIC_CONN_MAX_STREAM_TYPE_BIDIR */
 FD_QUIC_API void
 fd_quic_conn_set_max_streams( fd_quic_conn_t * conn, uint type, ulong stream_cnt );
-
-
-/* get the current value for the concurrent streams for the specified type
-
-   type is one of:
-     FD_QUIC_CONN_MAX_STREAM_TYPE_UNIDIR
-     FD_QUIC_CONN_MAX_STREAM_TYPE_BIDIR */
-FD_QUIC_API ulong
-fd_quic_conn_get_max_streams( fd_quic_conn_t * conn, uint type );
 
 
 /* update the tree weight

--- a/src/waltz/quic/fd_quic_pkt_meta.c
+++ b/src/waltz/quic/fd_quic_pkt_meta.c
@@ -1,17 +1,5 @@
 #include "fd_quic_pkt_meta.h"
 
-ulong
-fd_quic_get_pkt_meta_free_count( fd_quic_pkt_meta_pool_t * pool ) {
-  fd_quic_pkt_meta_t * pkt_meta = pool->free.head;
-  ulong cnt = 0;
-  while( pkt_meta ) {
-    cnt++;
-    pkt_meta = pkt_meta->next;
-  }
-  return cnt;
-}
-
-
 /* initialize pool with existing array of pkt_meta */
 void
 fd_quic_pkt_meta_pool_init( fd_quic_pkt_meta_pool_t * pool,

--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -24,8 +24,6 @@
 enum {
   FD_QUIC_TYPE_INGRESS = 1 << 0,
   FD_QUIC_TYPE_EGRESS  = 1 << 1,
-
-  FD_QUIC_TRANSPORT_PARAMS_RAW_SZ = 1200,
 };
 
 #define FD_QUIC_PKT_NUM_UNUSED  (~0ul)
@@ -134,7 +132,6 @@ struct fd_quic_pkt {
   uint               datagram_sz; /* length of the original datagram */
   uint               ack_flag;    /* ORed together: 0-don't ack  1-ack  2-cancel ack */
   uint ping;
-# define ACK_FLAG_NOT_RQD 0
 # define ACK_FLAG_RQD     1
 # define ACK_FLAG_CANCEL  2
 };

--- a/src/waltz/quic/fd_quic_stream.c
+++ b/src/waltz/quic/fd_quic_stream.c
@@ -192,14 +192,3 @@ void *
 fd_quic_stream_get_context( fd_quic_stream_t * stream ) {
   return stream->context;
 }
-
-
-/* set stream connection
-
-   args
-     stream      the stream to change
-     conn        the connection to set on the stream or NULL to remove the connection */
-void
-fd_quic_stream_set_conn( fd_quic_stream_t * stream, fd_quic_conn_t * conn ) {
-  stream->conn = conn;
-}

--- a/src/waltz/quic/fd_quic_stream.h
+++ b/src/waltz/quic/fd_quic_stream.h
@@ -233,15 +233,6 @@ void *
 fd_quic_stream_get_context( fd_quic_stream_t * stream );
 
 
-/* set stream connection
-
-   args
-     stream      the stream to change
-     conn        the connection to set on the stream or NULL to remove the connection */
-void
-fd_quic_stream_set_conn( fd_quic_stream_t * stream, fd_quic_conn_t * conn );
-
-
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_waltz_quic_fd_quic_stream_h */

--- a/src/waltz/quic/tests/fd_quic_sandbox.c
+++ b/src/waltz/quic/tests/fd_quic_sandbox.c
@@ -329,8 +329,7 @@ fd_quic_sandbox_new_conn_established( fd_quic_sandbox_t * sandbox,
   conn->rx_max_data      = 0UL;
   conn->rx_tot_data      = 0UL;
   conn->rx_max_data_ackd = 0UL;
-  conn->tx_initial_max_stream_data_uni         = 0UL;
-  conn->rx_initial_max_stream_data_uni         = 0UL;
+  conn->tx_initial_max_stream_data_uni = 0UL;
 
   /* TODO set a realistic packet number */
 

--- a/src/waltz/quic/tests/fuzz_quic_wire.c
+++ b/src/waltz/quic/tests/fuzz_quic_wire.c
@@ -160,7 +160,6 @@ LLVMFuzzerTestOneInput( uchar const * data,
   conn->tx_max_data                            =       512UL;
   conn->tx_initial_max_stream_data_uni         =        64UL;
   conn->rx_max_data                            =       512UL;
-  conn->rx_initial_max_stream_data_uni         =        64UL;
   conn->tx_max_datagram_sz                     = FD_QUIC_MTU;
   fd_quic_conn_set_max_streams( conn, 0, 1 );
   fd_quic_conn_set_max_streams( conn, 1, 1 );

--- a/src/waltz/quic/tls/fd_quic_tls.c
+++ b/src/waltz/quic/tls/fd_quic_tls.c
@@ -185,7 +185,7 @@ fd_quic_tls_init( fd_tls_t *    tls,
 
   /* Generate X25519 key */
   if( FD_UNLIKELY( !fd_rng_secure( tls->kex_private_key, 32UL ) ) )
-    FD_LOG_ERR(( "getrandom failed: %s", fd_io_strerror( errno ) ));
+    FD_LOG_ERR(( "fd_rng_secure failed: %s", fd_io_strerror( errno ) ));
   fd_x25519_public( tls->kex_public_key, tls->kex_private_key );
 
   /* Set up Ed25519 key */


### PR DESCRIPTION
Removes identifiers, parameters, and functions that are not used.
