### PR TITLE
bpf loader v3 limited deserialize

### DIFF
--- a/contrib/test/instr-fixtures/bpf-loader-v3.list
+++ b/contrib/test/instr-fixtures/bpf-loader-v3.list
@@ -5,3 +5,4 @@ dump/test-vectors/instr/fixtures/bpf-loader-v3/c572b4b462cff3193528a0d2caff33a2b
 dump/test-vectors/instr/fixtures/bpf-loader-v3/crash-16024ef412d62b56856d9ce608805519d74852af.fix
 dump/test-vectors/instr/fixtures/bpf-loader-v3/crash-61ea95e45c86d739e83f5ad2b765956427990794.fix
 dump/test-vectors/instr/fixtures/bpf-loader-v3/b12ffbfaddfbe2b91bc773e602e6332f11d6c2ba_1386074.fix
+dump/test-vectors/instr/fixtures/bpf-loader-v3/990563ae7eb4ef56bf61683e23ae4a2bd0606bdb_1579578.fix

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -537,7 +537,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
   fd_bpf_upgradeable_loader_program_instruction_t instruction = {0};
   fd_bincode_decode_ctx_t decode_ctx = {0};
   decode_ctx.data    = data;
-  decode_ctx.dataend = &data[ instr_ctx->instr->data_sz ];
+  decode_ctx.dataend = &data[ instr_ctx->instr->data_sz > 1232UL ? 1232UL : instr_ctx->instr->data_sz ];
   decode_ctx.valloc  = instr_ctx->valloc;
 
   int err = fd_bpf_upgradeable_loader_program_instruction_decode( &instruction, &decode_ctx );


### PR DESCRIPTION

Bpf loader was not correctly limited the input data size to 1232 bytes