### PR TITLE
fuzz, flamenco: load default sysvars properly in FD harness

### DIFF
--- a/contrib/test/txn-fixtures/program-tests.list
+++ b/contrib/test/txn-fixtures/program-tests.list
@@ -28,3 +28,4 @@ dump/test-vectors/txn/fixtures/programs/deff84b60ea3c6284e621b4229f402c4274e4968
 dump/test-vectors/txn/fixtures/programs/ed4565e33252bca4dc606bdce4aa48a650e75048_1366919.fix
 dump/test-vectors/txn/fixtures/programs/crash-3354ca5c9ba1c2ea78c33855ec5ced47dcf9f29e.fix
 dump/test-vectors/txn/fixtures/programs/crash-6ac1f183ec533a9ef01c6b19ac8938ade3b12354.fix
+dump/test-vectors/txn/fixtures/programs/crash-10c291c5d8f688fa03b3007887e577e636d2ea79.fix

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -14,7 +14,9 @@
 #include "../context/fd_exec_slot_ctx.h"
 #include "../context/fd_exec_txn_ctx.h"
 #include "../sysvar/fd_sysvar_recent_hashes.h"
+#include "../sysvar/fd_sysvar_last_restart_slot.h"
 #include "../sysvar/fd_sysvar_slot_hashes.h"
+#include "../sysvar/fd_sysvar_stake_history.h"
 #include "../sysvar/fd_sysvar_epoch_rewards.h"
 #include "../../../funk/fd_funk.h"
 #include "../../../util/bits/fd_float.h"
@@ -699,6 +701,16 @@ _txn_context_create_and_exec( fd_exec_instr_test_runner_t *      runner,
     memset( &slot_hashes[0], 0, sizeof(fd_slot_hash_t) );
     fd_slot_hashes_t default_slot_hashes = { .hashes = slot_hashes };
     fd_sysvar_slot_hashes_init( slot_ctx, &default_slot_hashes );
+  }
+
+  /* Provide default stake history if not provided */
+  if( !slot_ctx->sysvar_cache->has_stake_history ) {
+    fd_sysvar_stake_history_init( slot_ctx );
+  }
+
+  /* Provide default last restart slot sysvar if not provided */
+  if( !slot_ctx->sysvar_cache->has_last_restart_slot ) {
+    fd_sysvar_last_restart_slot_init( slot_ctx );
   }
 
   /* Provide a default clock if not present */


### PR DESCRIPTION
Load default sysvars in txn harness similar to how bank does it in Agave.