### PR TITLE
flamenco: Rent epoch logic optimizations

### DIFF
--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.h
@@ -81,7 +81,6 @@ struct __attribute__((aligned(8UL))) fd_exec_txn_ctx {
   ulong                 executable_cnt;                  /* Number of BPF upgradeable loader accounts. */
   fd_borrowed_account_t executable_accounts[128];        /* Array of BPF upgradeable loader program data accounts */
   fd_borrowed_account_t borrowed_accounts[128];          /* Array of borrowed accounts accessed by this transaction. */
-  uchar                 unknown_accounts[128];           /* Array of boolean values to denote if an account is unknown */
   uchar                 nonce_accounts[128];             /* Nonce accounts in the txn to be saved */
   uint                  num_instructions;                /* Counter for number of instructions in txn */
   fd_txn_return_data_t  return_data;                     /* Data returned from `return_data` syscalls */

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -84,9 +84,6 @@ fd_execute_txn_prepare_phase3( fd_exec_slot_ctx_t *  slot_ctx,
                                fd_txn_p_t * txn );
 
 int
-fd_execute_txn_prepare_finish( fd_exec_txn_ctx_t * txn_ctx );
-
-int
 fd_execute_txn_finalize( fd_exec_txn_ctx_t * txn_ctx,
                          int exec_txn_err );
 
@@ -119,10 +116,6 @@ fd_executor_txn_check( fd_exec_slot_ctx_t * slot_ctx,  fd_exec_txn_ctx_t *txn );
 int
 fd_should_set_exempt_rent_epoch_max( fd_rent_t const *       rent,
                                      fd_borrowed_account_t * rec );
-
-void
-fd_txn_set_exempt_rent_epoch_max( fd_exec_txn_ctx_t * txn_ctx,
-                                  void const *        addr );
 
 int
 fd_executor_collect_fee( fd_borrowed_account_t const * rec,

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -925,11 +925,6 @@ _txn_context_create_and_exec( fd_exec_instr_test_runner_t *      runner,
   fd_runtime_pre_execute_check( task_info );
 
   if( !task_info->exec_res ) {
-    int res = fd_execute_txn_prepare_finish( task_info->txn_ctx );
-    if( FD_UNLIKELY( res ) ) {
-      FD_LOG_ERR(("could not prepare txn"));
-    }
-
     task_info->txn->flags |= FD_TXN_P_FLAGS_EXECUTE_SUCCESS;
     task_info->exec_res    = fd_execute_txn( task_info->txn_ctx );
   }


### PR DESCRIPTION
Rent epochs for unknown accounts should be set at the txn level