### PR TITLE
flamenco: make rent epoch logic conformant with Agave

### DIFF
--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -1097,7 +1097,7 @@ fd_executor_setup_borrowed_accounts_for_txn( fd_exec_txn_ctx_t * txn_ctx ) {
 
     fd_account_meta_t const * meta = borrowed_account->const_meta ? borrowed_account->const_meta : borrowed_account->meta;
     if( meta==NULL ) {
-      static const fd_account_meta_t sentinel = { .magic = FD_ACCOUNT_META_MAGIC };
+      static const fd_account_meta_t sentinel = { .magic = FD_ACCOUNT_META_MAGIC, .info = { .rent_epoch = ULONG_MAX } };
       borrowed_account->const_meta        = &sentinel;
       borrowed_account->starting_lamports = 0UL;
       borrowed_account->starting_dlen     = 0UL;

--- a/src/flamenco/runtime/tests/fd_exec_sol_compat.c
+++ b/src/flamenco/runtime/tests/fd_exec_sol_compat.c
@@ -259,12 +259,11 @@ _diff_txn_acct( fd_exec_test_acct_state_t * expected,
     return 0;
   }
 
-  /* AcctState -> rent_epoch 
-     TODO: Add this check back in once rent epoch is more stable */
-  // if( expected->rent_epoch != actual->rent_epoch ) {
-  //   FD_LOG_WARNING(( "Rent epoch mismatch: expected=%lu actual=%lu", expected->rent_epoch, actual->rent_epoch ));
-  //   return 0;
-  // }
+  /* AcctState -> rent_epoch */
+  if( expected->rent_epoch != actual->rent_epoch ) {
+    FD_LOG_WARNING(( "Rent epoch mismatch: expected=%lu actual=%lu", expected->rent_epoch, actual->rent_epoch ));
+    return 0;
+  }
 
   /* AcctState -> owner */
   if( !fd_memeq( expected->owner, actual->owner, sizeof(fd_pubkey_t) ) ) {


### PR DESCRIPTION
Rent epoch setting logic is now conformant with Agave's logic, with hyperlinks included. 