### PR TITLE
pack: fix typo that prevented transactions from ever expiring

### DIFF
--- a/src/app/fdctl/run/tiles/fd_pack.c
+++ b/src/app/fdctl/run/tiles/fd_pack.c
@@ -386,7 +386,7 @@ after_credit( void *             _ctx,
        helps with account locality. */
     fd_pack_microblock_complete( ctx->pack, (ulong)i );
 
-    ulong exp_cnt = fd_pack_expire_before( ctx->pack, fd_ulong_min( (ulong)now+TIME_OFFSET, ctx->transaction_lifetime_ticks )-ctx->transaction_lifetime_ticks );
+    ulong exp_cnt = fd_pack_expire_before( ctx->pack, fd_ulong_max( (ulong)now+TIME_OFFSET, ctx->transaction_lifetime_ticks )-ctx->transaction_lifetime_ticks );
     FD_MCNT_INC( PACK, TRANSACTION_EXPIRED, exp_cnt );
 
     void * microblock_dst = fd_chunk_to_laddr( ctx->out_mem, ctx->out_chunk );
@@ -531,7 +531,7 @@ during_frag( void * _ctx,
     FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
 
   long now = fd_tickcount();
-  ulong exp_cnt = fd_pack_expire_before( ctx->pack, fd_ulong_min( (ulong)now+TIME_OFFSET, ctx->transaction_lifetime_ticks )-ctx->transaction_lifetime_ticks );
+  ulong exp_cnt = fd_pack_expire_before( ctx->pack, fd_ulong_max( (ulong)now+TIME_OFFSET, ctx->transaction_lifetime_ticks )-ctx->transaction_lifetime_ticks );
   FD_MCNT_INC( PACK, TRANSACTION_EXPIRED, exp_cnt );
 
   if( FD_LIKELY( ctx->leader_slot!=ULONG_MAX || fd_pack_avail_txn_cnt( ctx->pack )<ctx->max_pending_transactions ) ) {


### PR DESCRIPTION
Assuming `now` is in `[LONG_MIN, LONG_MAX]` but never wraps around, then `x = (ulong)now+TIME_OFFSET` is in `[0, ULONG_MAX]`. We want to compute `x-transaction_lifetime_ticks`, but saturating at 0 instead of underflowing.  The right way to do that is `max(x, transaction_lifetime_ticks) - transaction_lifetime_ticks`, which is in `[0, ULONG_MAX-transaction_lifetime_ticks]`.