### PR TITLE
store: disable blockstore starting from a certain slot

### DIFF
--- a/book/guide/tuning.md
+++ b/book/guide/tuning.md
@@ -228,7 +228,7 @@ as part of Frankendancer.
 
 ```toml [bench-zen3-32core.toml]
 [development.bench]
-  disable_blockstore = true // [!code ++]
+  disable_blockstore_from_slot = 1 // [!code ++]
 ```
 
 :::

--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -668,8 +668,8 @@ fdctl_cfg_from_env( int *      pargc,
       FD_LOG_ERR(( "trying to join a live cluster, but configuration enables [development.bench.larger_max_cost_per_block] which is a development only feature" ));
     if( FD_UNLIKELY( config->development.bench.larger_shred_limits_per_block ) )
       FD_LOG_ERR(( "trying to join a live cluster, but configuration enables [development.bench.larger_shred_limits_per_block] which is a development only feature" ));
-    if( FD_UNLIKELY( config->development.bench.disable_blockstore ) )
-      FD_LOG_ERR(( "trying to join a live cluster, but configuration enables [development.bench.disable_blockstore] which is a development only feature" ));
+    if( FD_UNLIKELY( config->development.bench.disable_blockstore_from_slot ) )
+      FD_LOG_ERR(( "trying to join a live cluster, but configuration has a non-zero value for [development.bench.disable_blockstore_from_slot] which is a development only feature" ));
     if( FD_UNLIKELY( !config->development.bench.disable_status_cache ) )
       FD_LOG_ERR(( "trying to join a live cluster, but configuration enables [development.bench.disable_status_cache] which is a development only feature" ));
   }

--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -172,13 +172,13 @@ typedef struct {
     } genesis;
 
     struct {
-      uint benchg_tile_count;
-      uint benchs_tile_count;
-      char affinity[ AFFINITY_SZ ];
-      int  larger_max_cost_per_block;
-      int  larger_shred_limits_per_block;
-      int  disable_blockstore;
-      int  disable_status_cache;
+      uint  benchg_tile_count;
+      uint  benchs_tile_count;
+      char  affinity[ AFFINITY_SZ ];
+      int   larger_max_cost_per_block;
+      int   larger_shred_limits_per_block;
+      ulong disable_blockstore_from_slot;
+      int   disable_status_cache;
     } bench;
   } development;
 

--- a/src/app/fdctl/config/bench-icelake-80core.toml
+++ b/src/app/fdctl/config/bench-icelake-80core.toml
@@ -27,7 +27,7 @@ scratch_directory = "/dev/shm/fd1"
   affinity = "f1,0-26/2"
   larger_max_cost_per_block = true
   larger_shred_limits_per_block = true
-  disable_blockstore = true
+  disable_blockstore_from_slot = 1
 
 [rpc]
   transaction_history = false

--- a/src/app/fdctl/config/bench-zen3-32core.toml
+++ b/src/app/fdctl/config/bench-zen3-32core.toml
@@ -24,7 +24,7 @@
   affinity = "f1,0-13"
   larger_max_cost_per_block = true
   larger_shred_limits_per_block = true
-  disable_blockstore = true
+  disable_blockstore_from_slot = 1
 
 [rpc]
   transaction_history = false

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -1217,14 +1217,24 @@ dynamic_port_range = "8900-9000"
         # Frankendancer currently depends on the Agave blockstore
         # component for storing block data to disk.  This component can
         # frequently be a bottleneck when testing the throughput of the
-        # leader pipeline, so this option is provided to disable it.
+        # leader pipeline, so this option is provided to disable it
+        # starting from a certain slot.
         #
         # This option should not be used in a production network; it
         # causes the validator to not be able to serve repair requests,
         # snapshots, or participate in other consensus critical
         # operations.  It is only useful for benchmarking the leader
         # TPU performance in a single node cluster case.
-        disable_blockstore = false
+        #
+        # A value of 0 means this option will not be used.  A value of 1
+        # disables the blockstore entirely.  A common use case for any
+        # other positive value is to create a snapshot before disabling
+        # the blockstore.  This is useful in cases when benchmarking an
+        # entire cluster.  The leader needs to create a first snapshot
+        # that the followers need to fetch in order to join the cluster.
+        # In such a case, it is useful to set this value to the same
+        # number as [snapshots.full_snapshot_interval_slots].
+        disable_blockstore_from_slot = 0
 
         # Frankendancer currently depends on the Agave status cache to
         # prevent double-spend attacks.  The data structure that backs

--- a/src/app/fdctl/config_parse.c
+++ b/src/app/fdctl/config_parse.c
@@ -333,7 +333,7 @@ fdctl_pod_to_cfg( config_t * config,
   CFG_POP      ( cstr,   development.bench.affinity                       );
   CFG_POP      ( bool,   development.bench.larger_max_cost_per_block      );
   CFG_POP      ( bool,   development.bench.larger_shred_limits_per_block  );
-  CFG_POP      ( bool,   development.bench.disable_blockstore             );
+  CFG_POP      ( ulong,  development.bench.disable_blockstore_from_slot   );
   CFG_POP      ( bool,   development.bench.disable_status_cache           );
 
   /* Firedancer-only configuration */

--- a/src/app/fdctl/run/tiles/fd_store.c
+++ b/src/app/fdctl/run/tiles/fd_store.c
@@ -9,7 +9,7 @@ typedef struct {
 typedef struct {
   uchar __attribute__((aligned(32UL))) mem[ FD_SHRED_STORE_MTU ];
 
-  int disable_blockstore;
+  ulong disable_blockstore_from_slot;
 
   fd_store_in_ctx_t in[ 32 ];
 } fd_store_ctx_t;
@@ -107,7 +107,7 @@ after_frag( void *             _ctx,
     FD_TEST( shred34->offset + shred34->stride*(shred34->shred_cnt - 1UL) + shred34->shred_sz <= *opt_sz);
   }
 
-  if( FD_UNLIKELY( ctx->disable_blockstore ) ) return;
+  if( FD_UNLIKELY( ctx->disable_blockstore_from_slot && ( ctx->disable_blockstore_from_slot <= shred34->pkts->shred.slot ) ) ) return;
 
   /* No error code because this cannot fail. */
   fd_ext_blockstore_insert_shreds( fd_ext_blockstore, shred34->shred_cnt, ctx->mem+shred34->offset, shred34->shred_sz, shred34->stride, !!*opt_sig );
@@ -130,7 +130,7 @@ unprivileged_init( fd_topo_t *      topo,
   FD_COMPILER_MFENCE();
   FD_LOG_INFO(( "Got blockstore" ));
 
-  ctx->disable_blockstore = tile->store.disable_blockstore;
+  ctx->disable_blockstore_from_slot = tile->store.disable_blockstore_from_slot;
 
   for( ulong i=0; i<tile->in_cnt; i++ ) {
     fd_topo_link_t * link = &topo->links[ tile->in_link_id[ i ] ];

--- a/src/app/fdctl/run/topos/fd_frankendancer.c
+++ b/src/app/fdctl/run/topos/fd_frankendancer.c
@@ -290,7 +290,7 @@ fd_topo_frankendancer( config_t * config ) {
       tile->shred.shred_listen_port      = config->tiles.shred.shred_listen_port;
 
     } else if( FD_UNLIKELY( !strcmp( tile->name, "store" ) ) ) {
-      tile->store.disable_blockstore =  config->development.bench.disable_blockstore;
+      tile->store.disable_blockstore_from_slot = config->development.bench.disable_blockstore_from_slot;
 
     } else if( FD_UNLIKELY( !strcmp( tile->name, "sign" ) ) ) {
       strncpy( tile->sign.identity_key_path, config->consensus.identity_path, sizeof(tile->sign.identity_key_path) );

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -193,7 +193,7 @@ typedef struct {
     } shred;
 
     struct {
-      int disable_blockstore;
+      ulong disable_blockstore_from_slot;
     } store;
 
     struct {


### PR DESCRIPTION
Note that there are no shreds for slot 0, so setting `disable_blockstore_from_slot = 1` has exactly the same effect as `disable_blockstore = true`.