### PR TITLE
flamenco: dump CPI instruction effects to protobuf

### DIFF
--- a/contrib/tool/dump_cpi.patch
+++ b/contrib/tool/dump_cpi.patch
@@ -1,0 +1,43 @@
+diff --git a/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c b/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
+index 336b002c2..0403a4909 100644
+--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
++++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
+@@ -594,6 +594,10 @@ VM_SYSCALL_CPI_ENTRYPOINT( void *  _vm,
+ 
+   FD_VM_CU_UPDATE( vm, FD_VM_INVOKE_UNITS );
+ 
++  fd_exec_test_syscall_context_t sys_ctx = FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_DEFAULT;
++  dump_vm_cpi_state(vm, STRINGIFY(FD_EXPAND_THEN_CONCAT2(sol_invoke_signed_, VM_SYSCALL_CPI_ABI)),
++                    instruction_va, acct_infos_va, acct_info_cnt, signers_seeds_va, signers_seeds_cnt, &sys_ctx);
++
+   /* Pre-flight checks ************************************************/
+   int err = fd_vm_syscall_cpi_preflight_check( signers_seeds_cnt, acct_info_cnt, vm->instr_ctx->slot_ctx );
+   if( FD_UNLIKELY( err ) ) return err;
+@@ -732,18 +736,27 @@ VM_SYSCALL_CPI_ENTRYPOINT( void *  _vm,
+     }
+   }
+ 
++  sys_ctx.has_exec_effects = 1;
++  sys_ctx.exec_effects.modified_accounts_count = (pb_size_t) caller_accounts_to_update_len;
++  sys_ctx.exec_effects.modified_accounts = fd_scratch_alloc( 8UL, sizeof(fd_exec_test_acct_state_t) * caller_accounts_to_update_len );
++
+   /* Update the caller accounts with any changes made by the callee during CPI execution */
+   for( ulong i=0UL; i<caller_accounts_to_update_len; i++ ) {
+     /* https://github.com/firedancer-io/solana/blob/508f325e19c0fd8e16683ea047d7c1a85f127e74/programs/bpf_loader/src/syscalls/cpi.rs#L939-L943 */
+     /* We only want to update the writable accounts, because the non-writable 
+        caller accounts can't be changed during a CPI execution. */
+     if( fd_instr_acc_is_writable_idx( vm->instr_ctx->instr, callee_account_keys[i] ) ) {
++      dump_acct_to_state( vm->instr_ctx->instr, callee_account_keys[i], &sys_ctx.exec_effects.modified_accounts[i] );
+       fd_pubkey_t const * callee = &vm->instr_ctx->instr->acct_pubkeys[callee_account_keys[i]];
+       err = VM_SYSCALL_CPI_UPDATE_CALLER_ACC_FUNC(vm, &acc_infos[caller_accounts_to_update[i]], (uchar)callee_account_keys[i], callee);
+       if( FD_UNLIKELY( err ) ) return err;
+     }
+   }
+ 
++  char filename[256];
++  gen_cpi_state_filename( &vm->instr_ctx->instr->program_id_pubkey, VM_SYSCALL_CPI_INSTR_DATA_LEN( cpi_instruction ), filename );
++  dump_pb_to_file( &sys_ctx, filename, FD_EXEC_TEST_SYSCALL_CONTEXT_FIELDS );
++
+   caller_lamports_h = 0UL;
+   caller_lamports_l = 0UL;
+   err = fd_instr_info_sum_account_lamports( vm->instr_ctx->instr, &caller_lamports_h, &caller_lamports_l );

--- a/contrib/tool/dump_cpi_on_replay.sh
+++ b/contrib/tool/dump_cpi_on_replay.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+# This script is used to dump the a SyscallContext during CPIs executed on a ledger.
+# Run this from the root of the firedancer repository
+# Must have a "dump/vm_cpi_state" directory in the root of the firedancer repository
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+set -e
+
+# Apply the patch and build the project
+git apply $SCRIPT_DIR/dump_cpi.patch
+make -j  bin lib
+
+# Run the replay command 
+build/native/gcc/bin/fd_ledger --cmd replay --verify-acc-hash 1 --rocksdb dump/mainnet-265330432/rocksdb --index-max 5000000 --end-slot 265330433 --cluster-version 1190 --page-cnt 30 --funk-page-cnt 16 --snapshot dump/mainnet-265330432/snapshot-265330431-BMvcRhxNoRtkZ5KLEKhhXM6GiWdTgdkoGLMe86xY4rF.tar.zst --allocator wksp --tile-cpus 5-21
+
+# Revert the patch and clean the project
+git apply -R contrib/tool/dump_cpi.patch
+make -j  clean
+
+set +e

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
@@ -15,16 +15,86 @@
 #define STRINGIFY(x) TOSTRING(x)
 #define TOSTRING(x) #x
 
+static FD_FN_UNUSED long
+dump_pb_to_file( void *pb_struct, 
+                 char const *filename,
+                 pb_msgdesc_t const *fields ) {
+  static const size_t pb_alloc_size = 100 * 1024 * 1024; // 100MB (largest so far is 19MB)
+
+  // Check if file exists
+  if( access (filename, F_OK) != -1 ) {
+    return 0L;
+  }
+
+  FILE *f = fopen(filename, "wb+");
+  if( ftruncate(fileno(f), (off_t) pb_alloc_size) != 0 ) {
+    FD_LOG_WARNING(("Failed to resize file %s", filename));
+    fclose(f);
+    return -1L;
+  }
+
+  uchar *pb_alloc = mmap( NULL,
+                          pb_alloc_size,
+                          PROT_READ | PROT_WRITE,
+                          MAP_SHARED,
+                          fileno(f),
+                          0 /* offset */);
+  
+  if( pb_alloc == MAP_FAILED ) {
+    FD_LOG_WARNING(( "Failed to mmap file %d", errno ));
+    fclose(f);
+    return -1L;
+  }
+
+  pb_ostream_t stream = pb_ostream_from_buffer( pb_alloc, pb_alloc_size );
+  if( !pb_encode( &stream, fields, pb_struct ) ) {
+    FD_LOG_WARNING(("Failed to encode protobuf to file %s", filename));
+    fclose(f);
+    return -1L;
+  }
+
+  // resize file to actual size
+  if( ftruncate( fileno(f), (off_t) stream.bytes_written ) != 0 ) {
+    FD_LOG_WARNING(( "Failed to resize file %s", filename ));
+  }
+
+  fclose(f);
+  return (long)stream.bytes_written;
+}
+
+static inline FD_FN_UNUSED void
+gen_cpi_state_filename( fd_pubkey_t const *caller_pubkey,
+                        ulong instr_sz,
+                        char *filename ) {
+  sprintf(filename, "dump/vm_cpi_state/%lu_%lu%lu_%hu.sysctx", fd_tile_id(), caller_pubkey->ul[0], caller_pubkey->ul[1], instr_sz);
+}
+
 /* Captures the state of the VM (including the instruction context).
+   Use contrib/tools/dump_cpi_on_replay.sh 
+
    Meant to be invoked at the start of the VM_SYSCALL_CPI_ENTRYPOINT like so:
-
   ```
-   dump_vm_cpi_state(vm, STRINGIFY(FD_EXPAND_THEN_CONCAT2(sol_invoke_signed_, VM_SYSCALL_CPI_ABI)),
-                     instruction_va, acct_infos_va, acct_info_cnt, signers_seeds_va, signers_seeds_cnt);
+    fd_exec_test_syscall_context_t sys_ctx = FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_DEFAULT;
+    dump_vm_cpi_state(vm, STRINGIFY(FD_EXPAND_THEN_CONCAT2(sol_invoke_signed_, VM_SYSCALL_CPI_ABI)),
+                      instruction_va, acct_infos_va, acct_info_cnt, signers_seeds_va, signers_seeds_cnt, &sys_ctx);
+
+    // ... rest of the function till fd_execute_instr
+
+    sys_ctx.has_exec_effects = 1;
+    sys_ctx.exec_effects.modified_accounts_count = caller_accounts_to_update_len;
+    sys_ctx.exec_effects.modified_accounts = fd_scratch_alloc( 8UL, sizeof(fd_exec_test_acct_state_t) * caller_accounts_to_update_len );
+    for( ulong i=0UL; i<caller_accounts_to_update_len; i++ ){
+      dump_acct_to_state( &vm->instr_ctx->instr, callee_account_keys[i], &sys_ctx.exec_effects.modified_accounts[i] );
+      // ... rest of loop
+    }
+
+    char filename[256];
+    gen_cpi_state_filename( &vm->instr_ctx->instr->program_id_pubkey, VM_SYSCALL_CPI_INSTR_DATA_LEN( cpi_instruction ), filename );
+    long bytes_written = dump_pb_to_file( &sys_ctx, filename, fd_exec_test_syscall_context_fields );
   ```
 
-  Assumes that a `vm_cp_state` directory exists in the current working directory. Generates a
-  unique dump for combination of (tile_id, caller_pubkey, instr_sz). */
+  Assumes that a `dump/vm_cpi_state` directory exists in the current working directory. Generates a
+  (sufficiently) unique dump for combination of (tile_id, caller_pubkey, instr_sz). */
 
 static FD_FN_UNUSED void
 dump_vm_cpi_state(fd_vm_t *vm,
@@ -33,100 +103,83 @@ dump_vm_cpi_state(fd_vm_t *vm,
                   ulong   acct_infos_va,
                   ulong   acct_info_cnt,
                   ulong   signers_seeds_va,
-                  ulong   signers_seeds_cnt ) {
-  char filename[100];
-  fd_instr_info_t const *instr = vm->instr_ctx->instr;
-  sprintf(filename, "vm_cpi_state/%lu_%lu%lu_%hu.sysctx", fd_tile_id(), instr->program_id_pubkey.ul[0], instr->program_id_pubkey.ul[1], instr->data_sz);
+                  ulong   signers_seeds_cnt,
+                  fd_exec_test_syscall_context_t * sys_ctx ) {
 
-  // Check if file exists
-  if( access (filename, F_OK) != -1 ) {
+  sys_ctx->has_instr_ctx = 1;
+  sys_ctx->has_vm_ctx = 1;
+  sys_ctx->has_syscall_invocation = 1;
+
+  // Copy function name
+  sys_ctx->syscall_invocation.function_name.size = fd_uint_min( (uint) strlen(fn_name), sizeof(sys_ctx->syscall_invocation.function_name.bytes) );
+  fd_memcpy( sys_ctx->syscall_invocation.function_name.bytes,
+             fn_name,
+             sys_ctx->syscall_invocation.function_name.size );
+
+  // VM Ctx integral fields
+  sys_ctx->vm_ctx.r1 = instruction_va;
+  sys_ctx->vm_ctx.r2 = acct_infos_va;
+  sys_ctx->vm_ctx.r3 = acct_info_cnt;
+  sys_ctx->vm_ctx.r4 = signers_seeds_va;
+  sys_ctx->vm_ctx.r5 = signers_seeds_cnt;
+
+  sys_ctx->vm_ctx.rodata_text_section_length = vm->text_sz;
+  sys_ctx->vm_ctx.rodata_text_section_offset = vm->text_off;
+
+  sys_ctx->vm_ctx.heap_max = vm->heap_max; /* should be equiv. to txn_ctx->heap_sz */
+
+  sys_ctx->vm_ctx.rodata = fd_scratch_alloc( 8UL, PB_BYTES_ARRAY_T_ALLOCSIZE(vm->rodata_sz) );
+  sys_ctx->vm_ctx.rodata->size = (pb_size_t) vm->rodata_sz;
+  fd_memcpy( sys_ctx->vm_ctx.rodata->bytes, vm->rodata, vm->rodata_sz );
+
+  pb_size_t stack_sz = (pb_size_t) ( (vm->frame_cnt + 1)*FD_VM_STACK_GUARD_SZ*2 );
+  sys_ctx->syscall_invocation.stack_prefix = fd_scratch_alloc( 8UL, PB_BYTES_ARRAY_T_ALLOCSIZE(stack_sz) );
+  sys_ctx->syscall_invocation.stack_prefix->size = stack_sz;
+  fd_memcpy( sys_ctx->syscall_invocation.stack_prefix->bytes, vm->stack, stack_sz );
+
+  sys_ctx->syscall_invocation.heap_prefix = fd_scratch_alloc( 8UL, PB_BYTES_ARRAY_T_ALLOCSIZE(vm->heap_max) );
+  sys_ctx->syscall_invocation.heap_prefix->size = (pb_size_t) vm->instr_ctx->txn_ctx->heap_size;
+  fd_memcpy( sys_ctx->syscall_invocation.heap_prefix->bytes, vm->heap, vm->instr_ctx->txn_ctx->heap_size );
+
+  sys_ctx->vm_ctx.input_data_regions_count = vm->input_mem_regions_cnt;
+  sys_ctx->vm_ctx.input_data_regions = fd_scratch_alloc( 8UL, sizeof(fd_exec_test_input_data_region_t) * vm->input_mem_regions_cnt );
+  for( ulong i=0UL; i<vm->input_mem_regions_cnt; i++ ) {
+    sys_ctx->vm_ctx.input_data_regions[i].content = fd_scratch_alloc( 8UL, PB_BYTES_ARRAY_T_ALLOCSIZE(vm->input_mem_regions[i].region_sz) );
+    sys_ctx->vm_ctx.input_data_regions[i].content->size = (pb_size_t) vm->input_mem_regions[i].region_sz;
+    fd_memcpy( sys_ctx->vm_ctx.input_data_regions[i].content->bytes, (uchar *) vm->input_mem_regions[i].haddr, vm->input_mem_regions[i].region_sz );
+    sys_ctx->vm_ctx.input_data_regions[i].offset = vm->input_mem_regions[i].vaddr_offset;
+    sys_ctx->vm_ctx.input_data_regions[i].is_writable = vm->input_mem_regions[i].is_writable;
+  }
+
+  fd_create_instr_context_protobuf_from_instructions( &sys_ctx->instr_ctx,
+                                                      vm->instr_ctx->txn_ctx,
+                                                      vm->instr_ctx->instr );
+
+}
+
+static inline FD_FN_UNUSED void
+dump_acct_to_state( fd_instr_info_t const * instr, /* Caller instr_info */
+                    ulong idx_in_instr,
+                    fd_exec_test_acct_state_t * out_acct_st ) {
+  *out_acct_st = (fd_exec_test_acct_state_t) FD_EXEC_TEST_ACCT_STATE_INIT_ZERO;
+  fd_borrowed_account_t * acc = instr->borrowed_accounts[idx_in_instr];
+  if( FD_UNLIKELY( !acc || !fd_acc_exists( acc->const_meta ) ) ){
     return;
   }
 
-  fd_exec_test_syscall_context_t sys_ctx = FD_EXEC_TEST_SYSCALL_CONTEXT_INIT_ZERO;
-  sys_ctx.has_instr_ctx = 1;
-  sys_ctx.has_vm_ctx = 1;
-  sys_ctx.has_syscall_invocation = 1;
+  out_acct_st->lamports = acc->const_meta->info.lamports;
+  out_acct_st->rent_epoch = acc->const_meta->info.rent_epoch;
+  out_acct_st->executable = acc->const_meta->info.executable;
+  memcpy( out_acct_st->owner, acc->const_meta->info.owner, sizeof(fd_pubkey_t) );
+  memcpy( out_acct_st->address, acc->pubkey, sizeof(fd_pubkey_t) );
 
-  // Copy function name
-  sys_ctx.syscall_invocation.function_name.size = fd_uint_min( (uint) strlen(fn_name), sizeof(sys_ctx.syscall_invocation.function_name.bytes) );
-  fd_memcpy( sys_ctx.syscall_invocation.function_name.bytes,
-             fn_name,
-             sys_ctx.syscall_invocation.function_name.size );
+  if( acc->const_meta->dlen > 0 ) {
+    out_acct_st->data = fd_scratch_alloc( 8UL, PB_BYTES_ARRAY_T_ALLOCSIZE(acc->const_meta->dlen) );
+    out_acct_st->data->size = (pb_size_t) acc->const_meta->dlen;
+    fd_memcpy( out_acct_st->data->bytes, acc->const_data, acc->const_meta->dlen );
+  }
 
-  // VM Ctx integral fields
-  sys_ctx.vm_ctx.r1 = instruction_va;
-  sys_ctx.vm_ctx.r2 = acct_infos_va;
-  sys_ctx.vm_ctx.r3 = acct_info_cnt;
-  sys_ctx.vm_ctx.r4 = signers_seeds_va;
-  sys_ctx.vm_ctx.r5 = signers_seeds_cnt;
-
-  sys_ctx.vm_ctx.rodata_text_section_length = vm->text_sz;
-  sys_ctx.vm_ctx.rodata_text_section_offset = vm->text_off;
-
-  sys_ctx.vm_ctx.heap_max = vm->heap_max; /* should be equiv. to txn_ctx->heap_sz */
-
-  FD_SCRATCH_SCOPE_BEGIN{
-    sys_ctx.vm_ctx.rodata = fd_scratch_alloc( 8UL, PB_BYTES_ARRAY_T_ALLOCSIZE(vm->rodata_sz) );
-    sys_ctx.vm_ctx.rodata->size = (pb_size_t) vm->rodata_sz;
-    fd_memcpy( sys_ctx.vm_ctx.rodata->bytes, vm->rodata, vm->rodata_sz );
-
-    pb_size_t stack_sz = (pb_size_t) ( (vm->frame_cnt + 1)*FD_VM_STACK_GUARD_SZ*2 );
-    sys_ctx.syscall_invocation.stack_prefix = fd_scratch_alloc( 8UL, PB_BYTES_ARRAY_T_ALLOCSIZE(stack_sz) );
-    sys_ctx.syscall_invocation.stack_prefix->size = stack_sz;
-    fd_memcpy( sys_ctx.syscall_invocation.stack_prefix->bytes, vm->stack, stack_sz );
-
-    sys_ctx.syscall_invocation.heap_prefix = fd_scratch_alloc( 8UL, PB_BYTES_ARRAY_T_ALLOCSIZE(vm->heap_max) );
-    sys_ctx.syscall_invocation.heap_prefix->size = (pb_size_t) vm->instr_ctx->txn_ctx->heap_size;
-    fd_memcpy( sys_ctx.syscall_invocation.heap_prefix->bytes, vm->heap, vm->instr_ctx->txn_ctx->heap_size );
-
-    sys_ctx.vm_ctx.input_data_regions_count = vm->input_mem_regions_cnt;
-    sys_ctx.vm_ctx.input_data_regions = fd_scratch_alloc( 8UL, sizeof(fd_exec_test_input_data_region_t) * vm->input_mem_regions_cnt );
-    for( ulong i=0UL; i<vm->input_mem_regions_cnt; i++ ) {
-      sys_ctx.vm_ctx.input_data_regions[i].content = fd_scratch_alloc( 8UL, PB_BYTES_ARRAY_T_ALLOCSIZE(vm->input_mem_regions[i].region_sz) );
-      sys_ctx.vm_ctx.input_data_regions[i].content->size = (pb_size_t) vm->input_mem_regions[i].region_sz;
-      fd_memcpy( sys_ctx.vm_ctx.input_data_regions[i].content->bytes, (uchar *) vm->input_mem_regions[i].haddr, vm->input_mem_regions[i].region_sz );
-      sys_ctx.vm_ctx.input_data_regions[i].offset = vm->input_mem_regions[i].vaddr_offset;
-      sys_ctx.vm_ctx.input_data_regions[i].is_writable = vm->input_mem_regions[i].is_writable;
-    }
-
-    fd_create_instr_context_protobuf_from_instructions( &sys_ctx.instr_ctx,
-                                                        vm->instr_ctx->txn_ctx,
-                                                        vm->instr_ctx->instr );
-
-    // Serialize the protobuf to file (using mmap)
-    size_t pb_alloc_size = 100 * 1024 * 1024; // 100MB (largest so far is 19MB)
-    FILE *f = fopen(filename, "wb+");
-    if( ftruncate(fileno(f), (off_t) pb_alloc_size) != 0 ) {
-      FD_LOG_WARNING(("Failed to resize file %s", filename));
-      fclose(f);
-      return;
-    }
-
-    uchar *pb_alloc = mmap( NULL,
-                            pb_alloc_size,
-                            PROT_READ | PROT_WRITE,
-                            MAP_SHARED,
-                            fileno(f),
-                            0 /* offset */);
-    if( pb_alloc == MAP_FAILED ) {
-      FD_LOG_WARNING(( "Failed to mmap file %d", errno ));
-      fclose(f);
-      return;
-    }
-
-    pb_ostream_t stream = pb_ostream_from_buffer(pb_alloc, pb_alloc_size);
-    if( !pb_encode( &stream, FD_EXEC_TEST_SYSCALL_CONTEXT_FIELDS, &sys_ctx ) ) {
-      FD_LOG_WARNING(( "Failed to encode instruction context" ));
-    }
-    // resize file to actual size
-    if( ftruncate( fileno(f), (off_t) stream.bytes_written ) != 0 ) {
-      FD_LOG_WARNING(( "Failed to resize file %s", filename ));
-    }
-
-    fclose(f);
-
-  } FD_SCRATCH_SCOPE_END;
+  return;
 }
 
 /* FIXME: ALGO EFFICIENCY */


### PR DESCRIPTION
# Dumping account state in CPI calls
To generate seed corpus with execution effects, the CPI dump tool was modified to capture post-CPI instruction account data.

Also added a script that temporarily applies a patch file that dumps CPI state during CPI syscall.

Relevant fuzz PR: https://github.com/firedancer-io/firedancer/pull/2824