### PR TITLE
fuzz: fix default slot hashes size

### DIFF
--- a/contrib/test/txn-fixtures/program-tests.list
+++ b/contrib/test/txn-fixtures/program-tests.list
@@ -15,7 +15,7 @@ dump/test-vectors/txn/fixtures/programs/crash-2a071a64139bf15f205d9284c323d2ed75
 dump/test-vectors/txn/fixtures/programs/crash-3267f556a7239eb9191fd5489db0341675fbbfd4.fix
 dump/test-vectors/txn/fixtures/programs/crash-3354ca5c9ba1c2ea78c33855ec5ced47dcf9f29e.fix
 dump/test-vectors/txn/fixtures/programs/crash-35325b58777ff62396ae18f13047a8fe2260d1b8.fix
-dump/test-vectors/txn/fixtures/programs/crash-38b53303426b0cb17570b27f89be658a890b867d-feature.fix
+dump/test-vectors/txn/fixtures/programs/crash-38b53303426b0cb17570b27f89be658a890b867d-add_new_reserved_account_keys.fix
 dump/test-vectors/txn/fixtures/programs/crash-38b53303426b0cb17570b27f89be658a890b867d.fix
 dump/test-vectors/txn/fixtures/programs/crash-3cdf49a1820462499f5b27e90cf0b0301ae7477c.fix
 dump/test-vectors/txn/fixtures/programs/crash-42295e53abb4382e2d579d46dcb1b20e63f030ea.fix
@@ -37,4 +37,5 @@ dump/test-vectors/txn/fixtures/programs/crash-ebdcdc6274bbf5f326439bf13868124500
 dump/test-vectors/txn/fixtures/programs/crash-f2a184eee1b1e6d5d455923d93825767843fcea6.fix
 dump/test-vectors/txn/fixtures/programs/d5e2332f53032ce4428b0b55e3a97c080c1db63e_1034518.fix
 dump/test-vectors/txn/fixtures/programs/deff84b60ea3c6284e621b4229f402c4274e4968_1446008.fix
+dump/test-vectors/txn/fixtures/programs/eaed07290ea8722cb900e1e648ca5209fa35ef6c_3861880.fix
 dump/test-vectors/txn/fixtures/programs/ed4565e33252bca4dc606bdce4aa48a650e75048_1366919.fix

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -698,7 +698,8 @@ _txn_context_create_and_exec( fd_exec_instr_test_runner_t *      runner,
   /* Provde default slot hashes of size 1 if not provided */
   if( !slot_ctx->sysvar_cache->has_slot_hashes ) {
     fd_slot_hash_t * slot_hashes = deq_fd_slot_hash_t_alloc( fd_scratch_virtual(), 1 );
-    memset( &slot_hashes[0], 0, sizeof(fd_slot_hash_t) );
+    fd_slot_hash_t * dummy_elem = deq_fd_slot_hash_t_push_tail_nocopy( slot_hashes );
+    memset( dummy_elem, 0, sizeof(fd_slot_hash_t) );
     fd_slot_hashes_t default_slot_hashes = { .hashes = slot_hashes };
     fd_sysvar_slot_hashes_init( slot_ctx, &default_slot_hashes );
   }


### PR DESCRIPTION
Slot hashes size was 0 by default