### PR TITLE
quic - set min timeout per connection to 1s

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -2078,7 +2078,7 @@ fd_quic_schedule_conn( fd_quic_conn_t * conn ) {
    is sufficient */
 ulong
 fd_quic_get_service_interval( fd_quic_t * quic ) {
-  ulong min_service_interval = (ulong)1e5;
+  ulong min_service_interval = (ulong)1e9;
   ulong service_interval = quic->config.service_interval;
   if( FD_UNLIKELY( service_interval < min_service_interval ) ) {
     service_interval = quic->config.service_interval = min_service_interval;


### PR DESCRIPTION
quic tile was spending far too much time servicing idle connections. This was due to service_interval in config not being set, and defaulting to the minimum, which is far too low.
This change replaces the minimum with a more reasonable value