### PR TITLE
Remove direct mapping support for ABIv1

### DIFF
--- a/src/flamenco/vm/fd_vm.h
+++ b/src/flamenco/vm/fd_vm.h
@@ -18,9 +18,9 @@ typedef struct fd_vm fd_vm_t;
 struct fd_vm_shadow { ulong r6; ulong r7; ulong r8; ulong r9; ulong pc; };
 typedef struct fd_vm_shadow fd_vm_shadow_t;
 
-/* fd_vm_input_region_t holds information about fragmented memory regions 
+/* fd_vm_input_region_t holds information about fragmented memory regions
    within the larger input region. */
-   
+
 struct __attribute__((aligned(8UL))) fd_vm_input_region {
    ulong         vaddr_offset; /* Represents offset from the start of the input region. */
    ulong         haddr;        /* Host address corresponding to the start of the mem region. */
@@ -36,7 +36,7 @@ typedef struct fd_vm_input_region fd_vm_input_region_t;
 struct __attribute((aligned(8UL))) fd_vm_acc_region_meta {
    uint  region_idx;
    uchar has_data_region;
-   uchar has_resizing_region;        
+   uchar has_resizing_region;
 };
 typedef struct fd_vm_acc_region_meta fd_vm_acc_region_meta_t;
 
@@ -136,9 +136,9 @@ struct fd_vm {
      region_st_sz[1] is also zero such that requests to store data to
      any positive sz range in this region will fail, making region 1
      unwritable.
-     
+
      When the direct mapping feature is enabled, the input region will
-     no longer be a contigious buffer of host memory.  Instead 
+     no longer be a contigious buffer of host memory.  Instead
      it will compose of several fragmented regions of memory each with
      its own read/write privleges and size.  Address translation to the
      input region will now have to rely on a binary search lookup of the
@@ -161,7 +161,7 @@ struct fd_vm {
   fd_vm_input_region_t *    input_mem_regions;               /* An array of input mem regions represent the input region.
                                                                 The virtual addresses of each region are contigiuous and
                                                                 strictly increasing. */
-  uint                      input_mem_regions_cnt;          
+  uint                      input_mem_regions_cnt;
   fd_vm_acc_region_meta_t * acc_region_metas;                /* Represents a mapping from the instruction account indicies
                                                                 from the instruction context to the input memory region index
                                                                 of the account's data region in the input space. */
@@ -193,7 +193,7 @@ FD_PROTOTYPES_BEGIN
 
 /* FD_VM_{ALIGN,FOOTPRINT} describe the alignment and footprint needed
    for a memory region to hold a fd_vm_t.  ALIGN is a positive
-   integer power of 2.  FOOTPRINT is a multiple of align. 
+   integer power of 2.  FOOTPRINT is a multiple of align.
    These are provided to facilitate compile time declarations. */
 #define FD_VM_ALIGN     (8UL     )
 #define FD_VM_FOOTPRINT (789408UL)

--- a/src/flamenco/vm/fd_vm_interp_core.c
+++ b/src/flamenco/vm/fd_vm_interp_core.c
@@ -354,32 +354,29 @@ interp_0x00: // FD_SBPF_OP_ADDL_IMM
   /* FIXME: MEM TRACING DIAGNOSTICS GO IN HERE */
 
   FD_VM_INTERP_INSTR_BEGIN(0x61) { /* FD_SBPF_OP_LDXW */
-    uchar is_multi_region = 0;
     ulong vaddr           = reg_src + (ulong)(long)offset;
-    ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(uint), region_haddr, region_ld_sz, 0, 0UL, &is_multi_region );
+    ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(uint), region_haddr, region_ld_sz, 0, 0UL );
     int   sigsegv         = !haddr;
     if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
-    reg[ dst ] = fd_vm_mem_ld_4( vm, vaddr, haddr, is_multi_region );
+    reg[ dst ] = fd_vm_mem_ld_4( haddr );
   }
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0x62) { /* FD_SBPF_OP_STW */
-    uchar is_multi_region = 0;
     ulong vaddr           = reg_dst + (ulong)(long)offset;
-    ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(uint), region_haddr, region_st_sz, 1, 0UL, &is_multi_region );
+    ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(uint), region_haddr, region_st_sz, 1, 0UL );
     int   sigsegv         = !haddr;
     if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
-    fd_vm_mem_st_4( vm, vaddr, haddr, imm, is_multi_region );
+    fd_vm_mem_st_4( haddr, imm );
   }
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0x63) { /* FD_SBPF_OP_STXW */
-    uchar is_multi_region = 0;
     ulong vaddr           = reg_dst + (ulong)(long)offset;
-    ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(uint), region_haddr, region_st_sz, 1, 0UL, &is_multi_region );
+    ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(uint), region_haddr, region_st_sz, 1, 0UL );
     int   sigsegv         = !haddr;
     if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus/rdonly */
-    fd_vm_mem_st_4( vm, vaddr, haddr, (uint)reg_src, is_multi_region );
+    fd_vm_mem_st_4( haddr, (uint)reg_src );
   }
   FD_VM_INTERP_INSTR_END;
 
@@ -396,32 +393,29 @@ interp_0x00: // FD_SBPF_OP_ADDL_IMM
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0x69) { /* FD_SBPF_OP_LDXH */
-    uchar is_multi_region = 0;
-    ulong vaddr           = reg_src + (ulong)(long)offset;
-    ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(ushort), region_haddr, region_ld_sz, 0, 0UL, &is_multi_region );
-    int   sigsegv         = !haddr;
+    ulong vaddr   = reg_src + (ulong)(long)offset;
+    ulong haddr   = fd_vm_mem_haddr( vm, vaddr, sizeof(ushort), region_haddr, region_ld_sz, 0, 0UL );
+    int   sigsegv = !haddr;
     if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
-    reg[ dst ] = fd_vm_mem_ld_2( vm, vaddr, haddr, is_multi_region );
+    reg[ dst ] = fd_vm_mem_ld_2( haddr );
   }
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0x6a) { /* FD_SBPF_OP_STH */
-    uchar is_multi_region = 0;
-    ulong vaddr           = reg_dst + (ulong)(long)offset;
-    ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(ushort), region_haddr, region_st_sz, 1, 0UL, &is_multi_region );
-    int   sigsegv         = !haddr;
+    ulong vaddr   = reg_dst + (ulong)(long)offset;
+    ulong haddr   = fd_vm_mem_haddr( vm, vaddr, sizeof(ushort), region_haddr, region_st_sz, 1, 0UL );
+    int   sigsegv = !haddr;
     if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
-    fd_vm_mem_st_2( vm, vaddr, haddr, (ushort)imm, is_multi_region );
+    fd_vm_mem_st_2( haddr, (ushort)imm );
   }
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0x6b) { /* FD_SBPF_OP_STXH */
-    uchar is_multi_region = 0;
-    ulong vaddr           = reg_dst + (ulong)(long)offset;
-    ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(ushort), region_haddr, region_st_sz, 1, 0UL, &is_multi_region );
-    int   sigsegv         = !haddr;
+    ulong vaddr   = reg_dst + (ulong)(long)offset;
+    ulong haddr   = fd_vm_mem_haddr( vm, vaddr, sizeof(ushort), region_haddr, region_st_sz, 1, 0UL );
+    int   sigsegv = !haddr;
     if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus/rdonly */
-    fd_vm_mem_st_2( vm, vaddr, haddr, (ushort)reg_src, is_multi_region );
+    fd_vm_mem_st_2( haddr, (ushort)reg_src );
   }
   FD_VM_INTERP_INSTR_END;
 
@@ -440,27 +434,24 @@ interp_0x00: // FD_SBPF_OP_ADDL_IMM
   /* 0x70 - 0x7f ******************************************************/
 
   FD_VM_INTERP_INSTR_BEGIN(0x71) { /* FD_SBPF_OP_LDXB */
-    uchar is_multi_region = 0;
-    ulong vaddr           = reg_src + (ulong)(long)offset;
-    ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(uchar), region_haddr, region_ld_sz, 0, 0UL, &is_multi_region );
+    ulong vaddr = reg_src + (ulong)(long)offset;
+    ulong haddr = fd_vm_mem_haddr( vm, vaddr, sizeof(uchar), region_haddr, region_ld_sz, 0, 0UL );
     if( FD_UNLIKELY( !haddr ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */
     reg[ dst ] = fd_vm_mem_ld_1( haddr );
   }
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0x72) { /* FD_SBPF_OP_STB */
-    uchar is_multi_region = 0;
-    ulong vaddr           = reg_dst + (ulong)(long)offset;
-    ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(uchar), region_haddr, region_st_sz, 1, 0UL, &is_multi_region );
+    ulong vaddr = reg_dst + (ulong)(long)offset;
+    ulong haddr = fd_vm_mem_haddr( vm, vaddr, sizeof(uchar), region_haddr, region_st_sz, 1, 0UL );
     if( FD_UNLIKELY( !haddr ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */
     fd_vm_mem_st_1( haddr, (uchar)imm );
   }
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0x73) { /* FD_SBPF_OP_STXB */
-    uchar is_multi_region = 0;
-    ulong vaddr           = reg_dst + (ulong)(long)offset;
-    ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(uchar), region_haddr, region_st_sz, 1, 0UL, &is_multi_region );
+    ulong vaddr = reg_dst + (ulong)(long)offset;
+    ulong haddr = fd_vm_mem_haddr( vm, vaddr, sizeof(uchar), region_haddr, region_st_sz, 1, 0UL );
     if( FD_UNLIKELY( !haddr ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigrdonly */
     fd_vm_mem_st_1( haddr, (uchar)reg_src );
   }
@@ -479,32 +470,29 @@ interp_0x00: // FD_SBPF_OP_ADDL_IMM
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0x79) { /* FD_SBPF_OP_LDXQ */
-    uchar is_multi_region = 0;
-    ulong vaddr           = reg_src + (ulong)(long)offset;
-    ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(ulong), region_haddr, region_ld_sz, 0, 0UL, &is_multi_region );
-    int   sigsegv         = !haddr;
+    ulong vaddr   = reg_src + (ulong)(long)offset;
+    ulong haddr   = fd_vm_mem_haddr( vm, vaddr, sizeof(ulong), region_haddr, region_ld_sz, 0, 0UL );
+    int   sigsegv = !haddr;
     if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
-    reg[ dst ] = fd_vm_mem_ld_8( vm, vaddr, haddr, is_multi_region );
+    reg[ dst ] = fd_vm_mem_ld_8( haddr );
   }
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0x7a) { /* FD_SBPF_OP_STQ */
-    uchar is_multi_region = 0;
-    ulong vaddr           = reg_dst + (ulong)(long)offset;
-    ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(ulong), region_haddr, region_st_sz, 1, 0UL, &is_multi_region );
-    int   sigsegv         = !haddr;
+    ulong vaddr   = reg_dst + (ulong)(long)offset;
+    ulong haddr   = fd_vm_mem_haddr( vm, vaddr, sizeof(ulong), region_haddr, region_st_sz, 1, 0UL );
+    int   sigsegv = !haddr;
     if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
-    fd_vm_mem_st_8( vm, vaddr, haddr, (ulong)imm, is_multi_region );
+    fd_vm_mem_st_8( haddr, (ulong)imm );
   }
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0x7b) { /* FD_SBPF_OP_STXQ */
-    uchar is_multi_region = 0;
     ulong vaddr           = reg_dst + (ulong)(long)offset;
-    ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(ulong), region_haddr, region_st_sz, 1, 0UL, &is_multi_region );
+    ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(ulong), region_haddr, region_st_sz, 1, 0UL );
     int   sigsegv         = !haddr;
     if( FD_UNLIKELY( sigsegv ) ) goto sigsegv; /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus/rdonly */
-    fd_vm_mem_st_8( vm, vaddr, haddr, reg_src, is_multi_region );
+    fd_vm_mem_st_8( haddr, reg_src );
   }
   FD_VM_INTERP_INSTR_END;
 

--- a/src/flamenco/vm/fd_vm_interp_core.c
+++ b/src/flamenco/vm/fd_vm_interp_core.c
@@ -867,39 +867,39 @@ interp_halt:
 /*   Agave/JIT CU model analysis (and why we are conformant!):
 
      The Agave JIT employs a similar strategy of accumulating instructions
-     in a linear run and processing them at the start of a new linear 
-     run/branch (side note: the JIT treats the LDQ instruction as a "branch" 
-     that jumps pc + 2). 
-     
-     In what is assumed to be an act of register conservation, the JIT 
+     in a linear run and processing them at the start of a new linear
+     run/branch (side note: the JIT treats the LDQ instruction as a "branch"
+     that jumps pc + 2).
+
+     In what is assumed to be an act of register conservation, the JIT
      uses a catch-all "instruction meter" (IM) register (REGISTER_INSTRUCTION_METER)
      that represents two different interpretations of the question
      "how many instructions can I execute?".
 
      The IM, depending on where we are in the execution, either represents:
-        1. IM => The number of instructions remaining before exhausting CU 
+        1. IM => The number of instructions remaining before exhausting CU
         budget. This is analagous to vm->cu in our interpreter.
         2. IM' => The last pc you can execute in the current linear run before
         exhausting CU budget.  Mathematically, IM' = IM + pc0
         where pc0, just like our definition, is the start of the linear run.
-        
-        Note: IM' can go past the actual basic block/segment. In-fact, 
+
+        Note: IM' can go past the actual basic block/segment. In-fact,
         it typically does, and implies we can execute the full block without
         exhausting CU budget (reminder that LDQ is treated as a branch).
-      
+
       By default, the IM' form is used during execution. The IM form is used:
-        - (transiently) during the processing of a branch instruction 
+        - (transiently) during the processing of a branch instruction
         - in post-VM cleanup (updates EbpfVm::previous_instruction_meter).
 
       When a branch instruction is encountered, the JIT checks
       for CU exhaustion with pc > IM', and throws an exception if so. This is valid,
       because as described above, IM' is the largest PC you can reach.
-      
+
       If we haven't exhausted our CU limit, it updates IM':
-        1. IM = IM' - (pc + 1)  # Note that IM' at this point is IM + pc0', 
+        1. IM = IM' - (pc + 1)  # Note that IM' at this point is IM + pc0',
                                 # where pc0' is the start of the current linear run.
         2. IM' = IM + pc0       # pc0 is the start of the new linear run (typically the target pc)
-      
+
       Code (that does the above in one ALU instruction):
        https://github.com/solana-labs/rbpf/blob/v0.8.5/src/jit.rs#L891
 
@@ -919,17 +919,17 @@ interp_halt:
       linear run. This is the same as our ic_correction(*) in FD_VM_INTERP_BRANCH_BEGIN.
 
       If we replace IM with cu, this effectively becomes the
-           cu -= ic_correction 
+           cu -= ic_correction
       line in FD_VM_INTERP_BRANCH_BEGIN.
 
-      (*) Note: ic_correction (also) takes two forms. It is either the instruction 
-      accumulator or the number of instructions executed in the current linear run. 
-      It (transiently) takes the latter form during FD_VM_INTERP_BRANCH_BEGIN and 
+      (*) Note: ic_correction (also) takes two forms. It is either the instruction
+      accumulator or the number of instructions executed in the current linear run.
+      It (transiently) takes the latter form during FD_VM_INTERP_BRANCH_BEGIN and
       FD_VM_INTERP_FAULT, and the former form otherwise.
 */
 
 /* (WIP) Precise faulting and the Agave JIT:
-   
+
    Since the cost model is a part of consensus, we need to conform with the Agave/JIT
    cost model 1:1. To achieve that, our faulting model also needs to match precisely. This
    section covers the various faults that the respective VMs implement and how they match.
@@ -966,7 +966,7 @@ interp_halt:
     IM < ic_correction
 
     This is analagous to the ic_correction>cu check in VM_INTERP_BRANCH_BEGIN.
-   
+
    # (TODO) Text Overrun (sigtext/sigsplit):
 
 */

--- a/src/flamenco/vm/fd_vm_private.h
+++ b/src/flamenco/vm/fd_vm_private.h
@@ -184,12 +184,12 @@ fd_vm_mem_cfg( fd_vm_t * vm ) {
   if( FD_FEATURE_ACTIVE( vm->instr_ctx->slot_ctx, bpf_account_data_direct_mapping ) || !vm->input_mem_regions_cnt ) {
     /* When direct mapping is enabled, we don't use these fields because
        the load and stores are fragmented. */
-    vm->region_haddr[4] = 0UL; 
-    vm->region_ld_sz[4] = 0U; 
+    vm->region_haddr[4] = 0UL;
+    vm->region_ld_sz[4] = 0U;
     vm->region_st_sz[4] = 0U;
   } else {
-    vm->region_haddr[4] = vm->input_mem_regions[0].haddr;  
-    vm->region_ld_sz[4] = vm->input_mem_regions[0].region_sz;    
+    vm->region_haddr[4] = vm->input_mem_regions[0].haddr;
+    vm->region_ld_sz[4] = vm->input_mem_regions[0].region_sz;
     vm->region_st_sz[4] = vm->input_mem_regions[0].region_sz;
   }
   return vm;
@@ -223,7 +223,7 @@ fd_vm_mem_cfg( fd_vm_t * vm ) {
 
    fd_vm_mem_haddr_fast is when the vaddr is for use when it is already
    known that the vaddr region has a valid mapping.
-   
+
    These assumptions don't hold if direct mapping is enabled since input
    region lookups become O(log(n)). */
 
@@ -251,15 +251,15 @@ fd_vm_get_input_mem_region_idx( fd_vm_t const * vm, ulong offset ) {
 }
 
 /* fd_vm_find_input_mem_region returns the translated haddr for a given
-   offset into the input region.  If an offset/sz is invalid or if an 
+   offset into the input region.  If an offset/sz is invalid or if an
    illegal write is performed, the sentinel value is returned. If the offset
    provided is too large, it will choose the upper-most region as the
    region_idx. However, it will get caught for being too large of an access
    in the multi-region checks. */
 static inline ulong
-fd_vm_find_input_mem_region( fd_vm_t const * vm, 
+fd_vm_find_input_mem_region( fd_vm_t const * vm,
                              ulong           offset,
-                             ulong           sz, 
+                             ulong           sz,
                              uchar           write,
                              ulong           sentinel,
                              uchar *         is_multi_region ) {
@@ -296,7 +296,7 @@ fd_vm_find_input_mem_region( fd_vm_t const * vm,
   }
 
   ulong adjusted_haddr = vm->input_mem_regions[ start_region_idx ].haddr + offset - vm->input_mem_regions[ start_region_idx ].vaddr_offset;
-  return adjusted_haddr; 
+  return adjusted_haddr;
 }
 
 
@@ -325,7 +325,7 @@ fd_vm_mem_haddr( fd_vm_t const *    vm,
   if( region==4UL ) {
     return fd_vm_find_input_mem_region( vm, offset, sz, write, sentinel, is_multi_region );
   }
-  
+
 # ifdef FD_VM_INTERP_MEM_TRACING_ENABLED
   if ( FD_LIKELY( sz<=sz_max ) ) {
     fd_vm_trace_event_mem( vm->trace, write, vaddr, sz, vm_region_haddr[ region ] + offset );
@@ -335,7 +335,7 @@ fd_vm_mem_haddr( fd_vm_t const *    vm,
 }
 
 FD_FN_PURE static inline ulong
-fd_vm_mem_haddr_fast( fd_vm_t const * vm, 
+fd_vm_mem_haddr_fast( fd_vm_t const * vm,
                       ulong           vaddr,
                       ulong   const * vm_region_haddr ) { /* indexed [0,6) */
   uchar is_multi = 0;
@@ -349,7 +349,7 @@ fd_vm_mem_haddr_fast( fd_vm_t const * vm,
 
 /* fd_vm_mem_ld_N loads N bytes from the host address location haddr,
    zero extends it to a ulong and returns the ulong.  haddr need not be
-   aligned.  fd_vm_mem_ld_multi handles the case where the load spans 
+   aligned.  fd_vm_mem_ld_multi handles the case where the load spans
    multiple input memory regions. */
 
 static inline void fd_vm_mem_ld_multi( fd_vm_t const * vm, uint sz, ulong vaddr, ulong haddr, uchar * dst ) {
@@ -372,14 +372,14 @@ static inline void fd_vm_mem_ld_multi( fd_vm_t const * vm, uint sz, ulong vaddr,
   }
 }
 
-FD_FN_PURE static inline ulong fd_vm_mem_ld_1( ulong haddr ) { 
-  return (ulong)*(uchar const *)haddr; 
+FD_FN_PURE static inline ulong fd_vm_mem_ld_1( ulong haddr ) {
+  return (ulong)*(uchar const *)haddr;
 }
 
-FD_FN_PURE static inline ulong fd_vm_mem_ld_2( fd_vm_t const * vm, ulong vaddr, ulong haddr, uint is_multi_region ) { 
-  ushort t; 
+FD_FN_PURE static inline ulong fd_vm_mem_ld_2( fd_vm_t const * vm, ulong vaddr, ulong haddr, uint is_multi_region ) {
+  ushort t;
   if( FD_LIKELY( !is_multi_region ) ) {
-    memcpy( &t, (void const *)haddr, sizeof(ushort) ); 
+    memcpy( &t, (void const *)haddr, sizeof(ushort) );
   } else {
     fd_vm_mem_ld_multi( vm, 2U, vaddr, haddr, (uchar *)&t );
   }
@@ -387,9 +387,9 @@ FD_FN_PURE static inline ulong fd_vm_mem_ld_2( fd_vm_t const * vm, ulong vaddr, 
 }
 
 FD_FN_PURE static inline ulong fd_vm_mem_ld_4( fd_vm_t const * vm, ulong vaddr, ulong haddr, uint is_multi_region ) {
-  uint t; 
+  uint t;
   if( FD_LIKELY( !is_multi_region ) ) {
-    memcpy( &t, (void const *)haddr, sizeof(uint) ); 
+    memcpy( &t, (void const *)haddr, sizeof(uint) );
   } else {
     fd_vm_mem_ld_multi( vm, 4U, vaddr, haddr, (uchar *)&t );
   }
@@ -397,9 +397,9 @@ FD_FN_PURE static inline ulong fd_vm_mem_ld_4( fd_vm_t const * vm, ulong vaddr, 
 }
 
 FD_FN_PURE static inline ulong fd_vm_mem_ld_8( fd_vm_t const * vm, ulong vaddr, ulong haddr, uint is_multi_region ) {
-  ulong t; 
+  ulong t;
   if( FD_LIKELY( !is_multi_region ) ) {
-    memcpy( &t, (void const *)haddr, sizeof(ulong) ); 
+    memcpy( &t, (void const *)haddr, sizeof(ulong) );
   } else {
     fd_vm_mem_ld_multi( vm, 8U, vaddr, haddr, (uchar *)&t );
   }
@@ -430,17 +430,17 @@ static inline void fd_vm_mem_st_multi( fd_vm_t const * vm, uint sz, ulong vaddr,
   }
 }
 
-static inline void fd_vm_mem_st_1( ulong haddr, uchar val ) { 
+static inline void fd_vm_mem_st_1( ulong haddr, uchar val ) {
   *(uchar *)haddr = val;
 }
 
 static inline void fd_vm_mem_st_2( fd_vm_t const * vm,
                                    ulong           vaddr,
-                                   ulong           haddr, 
-                                   ushort          val, 
-                                   uint            is_multi_region ) { 
+                                   ulong           haddr,
+                                   ushort          val,
+                                   uint            is_multi_region ) {
   if( FD_LIKELY( !is_multi_region ) ) {
-    memcpy( (void *)haddr, &val, sizeof(ushort) ); 
+    memcpy( (void *)haddr, &val, sizeof(ushort) );
   } else {
     fd_vm_mem_st_multi( vm, 2U, vaddr, haddr, (uchar *)&val );
   }
@@ -448,11 +448,11 @@ static inline void fd_vm_mem_st_2( fd_vm_t const * vm,
 
 static inline void fd_vm_mem_st_4( fd_vm_t const * vm,
                                    ulong           vaddr,
-                                   ulong           haddr, 
-                                   uint            val, 
-                                   uint            is_multi_region ) { 
+                                   ulong           haddr,
+                                   uint            val,
+                                   uint            is_multi_region ) {
   if( FD_LIKELY( !is_multi_region ) ) {
-    memcpy( (void *)haddr, &val, sizeof(uint)   ); 
+    memcpy( (void *)haddr, &val, sizeof(uint)   );
   } else {
     fd_vm_mem_st_multi( vm, 4U, vaddr, haddr, (uchar *)&val );
   }
@@ -462,9 +462,9 @@ static inline void fd_vm_mem_st_8( fd_vm_t const * vm,
                                    ulong           vaddr,
                                    ulong           haddr,
                                    ulong           val,
-                                   uint            is_multi_region ) { 
+                                   uint            is_multi_region ) {
   if( FD_LIKELY( !is_multi_region ) ) {
-    memcpy( (void *)haddr, &val, sizeof(ulong)  ); 
+    memcpy( (void *)haddr, &val, sizeof(ulong)  );
   } else {
     fd_vm_mem_st_multi( vm, 8U, vaddr, haddr, (uchar *)&val );
   }
@@ -494,12 +494,12 @@ static inline void fd_vm_mem_st_8( fd_vm_t const * vm,
 
    These macros intentionally don't support multi region loads/stores.
    The load/store macros are used by vm syscalls and mirror the use
-   of translate_slice{_mut}. However, this check does not allow for 
+   of translate_slice{_mut}. However, this check does not allow for
    multi region accesses. So if there is an attempt at a multi region
-   translation, an error will be returned. 
-   
-   FD_VM_MEM_HADDR_ST_UNCHECKED has all of the checks of a load or a 
-   store, but intentionally omits the is_writable checks for the 
+   translation, an error will be returned.
+
+   FD_VM_MEM_HADDR_ST_UNCHECKED has all of the checks of a load or a
+   store, but intentionally omits the is_writable checks for the
    input region that are done during memory translation. */
 
 #define FD_VM_MEM_HADDR_LD( vm, vaddr, align, sz ) (__extension__({                                         \
@@ -555,9 +555,9 @@ static inline void fd_vm_mem_st_8( fd_vm_t const * vm,
 
 /* FD_VM_MEM_SLICE_HADDR_[LD, ST] macros return an arbitrary value if sz == 0. This is because
    Agave's translate_slice function returns an empty array if the sz == 0.
-   
+
    Users of this macro should be aware that they should never access the returned value if sz==0.
-   
+
    https://github.com/solana-labs/solana/blob/767d24e5c10123c079e656cdcf9aeb8a5dae17db/programs/bpf_loader/src/syscalls/mod.rs#L560  */
 #define FD_VM_MEM_SLICE_HADDR_LD( vm, vaddr, align, sz ) (__extension__({                                       \
     void const * haddr = 0UL;                                                                                   \

--- a/src/flamenco/vm/syscall/fd_vm_syscall_util.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_util.c
@@ -370,108 +370,13 @@ fd_vm_syscall_sol_memcpy( /**/            void *  _vm,
     return FD_VM_SUCCESS;
   }
 
-  if( !FD_FEATURE_ACTIVE( vm->instr_ctx->slot_ctx, bpf_account_data_direct_mapping ) ) {
-    void *       dst = FD_VM_MEM_HADDR_ST( vm, dst_vaddr, FD_VM_ALIGN_RUST_U8, sz );
-    void const * src = FD_VM_MEM_HADDR_LD( vm, src_vaddr, FD_VM_ALIGN_RUST_U8, sz );
+  void *       dst = FD_VM_MEM_HADDR_ST( vm, dst_vaddr, FD_VM_ALIGN_RUST_U8, sz );
+  void const * src = FD_VM_MEM_HADDR_LD( vm, src_vaddr, FD_VM_ALIGN_RUST_U8, sz );
 
-    fd_memcpy( dst, src, sz );
+  fd_memcpy( dst, src, sz );
 
-    *_ret = 0;
-    return FD_VM_SUCCESS;
-  } else {
-
-    /* Lookup host address chunks.  Try to do a standard memcpy if the regions
-       do not cross memory regions. */
-    ulong   dst_region              = dst_vaddr >> 32;
-    ulong   dst_offset              = dst_vaddr & 0xffffffffUL;
-    ulong   dst_region_idx          = 0UL;
-    ulong   dst_bytes_in_cur_region = sz;
-    uchar * dst_haddr               = NULL;
-    if( dst_region==4UL ) {
-      dst_region_idx          = fd_vm_get_input_mem_region_idx( vm, dst_offset );
-      dst_haddr               = (uchar*)(vm->input_mem_regions[ dst_region_idx ].haddr + dst_offset - vm->input_mem_regions[ dst_region_idx ].vaddr_offset);
-      dst_bytes_in_cur_region = fd_ulong_min( sz, fd_ulong_sat_sub( vm->input_mem_regions[ dst_region_idx ].region_sz,
-                                                                    ((ulong)dst_haddr - vm->input_mem_regions[ dst_region_idx ].haddr) ) );
-      if( FD_UNLIKELY( !vm->input_mem_regions[ dst_region_idx ].is_writable ) ) {
-        *_ret = 1;
-        return FD_VM_ERR_ABORT;
-      }
-      if( FD_UNLIKELY( dst_region_idx+1UL==vm->input_mem_regions_cnt && dst_bytes_in_cur_region<sz ) ) {
-        *_ret = 1;
-        return FD_VM_ERR_ABORT;
-      }
-
-    } else {
-      dst_haddr = (uchar *)FD_VM_MEM_SLICE_HADDR_ST( vm, dst_vaddr, FD_VM_ALIGN_RUST_U8, sz );
-    }
-
-    ulong src_region              = src_vaddr >> 32;
-    ulong src_offset              = src_vaddr & 0xffffffffUL;
-    ulong src_region_idx          = 0UL;
-    ulong src_bytes_in_cur_region = sz;
-    uchar * src_haddr             = NULL;
-    if( src_region==4UL ) {
-      src_region_idx          = fd_vm_get_input_mem_region_idx( vm, src_offset );
-      src_haddr               = (uchar*)(vm->input_mem_regions[ src_region_idx ].haddr + src_offset - vm->input_mem_regions[ src_region_idx ].vaddr_offset);
-      src_bytes_in_cur_region = fd_ulong_min( sz, fd_ulong_sat_sub( vm->input_mem_regions[ src_region_idx ].region_sz,
-                                                                    ((ulong)src_haddr - vm->input_mem_regions[ src_region_idx ].haddr) ) );
-      if( FD_UNLIKELY( src_region_idx+1UL==vm->input_mem_regions_cnt && src_bytes_in_cur_region<sz ) ) {
-        *_ret = 1;
-        return FD_VM_ERR_ABORT;
-      }
-
-    } else {
-      src_haddr           = (uchar *)FD_VM_MEM_SLICE_HADDR_LD( vm, src_vaddr, FD_VM_ALIGN_RUST_U8, sz );
-    }
-
-    /* Do a normal memcpy if regions do not overlap */
-    if( FD_LIKELY( src_bytes_in_cur_region==dst_bytes_in_cur_region && src_bytes_in_cur_region==sz ) ) {
-      fd_memcpy( dst_haddr, src_haddr, sz );
-      *_ret = 0;
-      return FD_VM_SUCCESS;
-    }
-
-    /* Case where the operation spans multiple regions. Copy over the bytes
-       from each region while iterating to the next one. */
-    /* TODO: An optimization would be to memcpy chunks at once */
-    ulong dst_idx = 0UL;
-    ulong src_idx = 0UL;
-    for( ulong i=0UL; i<sz; i++ ) {
-      if( FD_UNLIKELY( !dst_bytes_in_cur_region ) ) {
-        /* Go to next one */
-        if( FD_UNLIKELY( ++dst_region_idx>=vm->input_mem_regions_cnt ) ) {
-          *_ret = 1;
-          return FD_VM_ERR_ABORT;
-        }
-        if( FD_UNLIKELY( !vm->input_mem_regions[ dst_region_idx ].is_writable ) ) {
-          *_ret = 1;
-          return FD_VM_ERR_ABORT;
-        }
-        dst_haddr               = (uchar*)vm->input_mem_regions[ dst_region_idx ].haddr;
-        dst_bytes_in_cur_region = vm->input_mem_regions[ dst_region_idx ].region_sz;
-        dst_idx                 = 0UL;
-      }
-      if( FD_UNLIKELY( !src_bytes_in_cur_region ) ) {
-        /* Go to next one */
-        if( FD_UNLIKELY( ++src_region_idx>=vm->input_mem_regions_cnt ) ) {
-          *_ret = 1;
-          return FD_VM_ERR_ABORT;
-        }
-        src_haddr               = (uchar*)vm->input_mem_regions[ src_region_idx ].haddr;
-        src_bytes_in_cur_region = vm->input_mem_regions[ src_region_idx ].region_sz;
-        src_idx                 = 0UL;
-      }
-
-      dst_haddr[ dst_idx ] = src_haddr[ src_idx ];
-
-      dst_bytes_in_cur_region--;
-      src_bytes_in_cur_region--;
-      dst_idx++;
-      src_idx++;
-    }
-    *_ret = 0;
-    return FD_VM_SUCCESS;
-  }
+  *_ret = 0;
+  return FD_VM_SUCCESS;
 }
 
 int
@@ -493,115 +398,29 @@ fd_vm_syscall_sol_memcmp( /**/            void *  _vm,
      doesn't provide strong enough guarantees about the return value (it
      only promises the sign). */
 
-  if( !FD_FEATURE_ACTIVE( vm->instr_ctx->slot_ctx, bpf_account_data_direct_mapping ) ) {
-    uchar const * m0 = (uchar const *)FD_VM_MEM_SLICE_HADDR_LD( vm, m0_vaddr, FD_VM_ALIGN_RUST_U8, sz );
-    uchar const * m1 = (uchar const *)FD_VM_MEM_SLICE_HADDR_LD( vm, m1_vaddr, FD_VM_ALIGN_RUST_U8, sz );
+  uchar const * m0 = (uchar const *)FD_VM_MEM_SLICE_HADDR_LD( vm, m0_vaddr, FD_VM_ALIGN_RUST_U8, sz );
+  uchar const * m1 = (uchar const *)FD_VM_MEM_SLICE_HADDR_LD( vm, m1_vaddr, FD_VM_ALIGN_RUST_U8, sz );
 
-    /* Silly that this doesn't use r0 to return ... slower, more edge
-      case, different from libc style memcmp, harder to callers to use,
-      etc ... probably too late to do anything about it now ... sigh */
+  /* Silly that this doesn't use r0 to return ... slower, more edge
+    case, different from libc style memcmp, harder to callers to use,
+    etc ... probably too late to do anything about it now ... sigh */
 
-    void * _out = FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_VM_ALIGN_RUST_I32, 4UL );
+  void * _out = FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_VM_ALIGN_RUST_I32, 4UL );
 
-    int out = 0;
-    for( ulong i=0UL; i<sz; i++ ) {
-      int i0 = (int)m0[i];
-      int i1 = (int)m1[i];
-      if( i0!=i1 ) {
-        out = i0 - i1;
-        break;
-      }
+  int out = 0;
+  for( ulong i=0UL; i<sz; i++ ) {
+    int i0 = (int)m0[i];
+    int i1 = (int)m1[i];
+    if( i0!=i1 ) {
+      out = i0 - i1;
+      break;
     }
-
-    fd_memcpy( _out, &out, 4UL ); /* Sigh ... see note above (and might be unaligned ... double sigh) */
-
-    *_ret = 0;
-    return FD_VM_SUCCESS;
-  } else {
-    void * _out = FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_VM_ALIGN_RUST_I32, 4UL );
-
-    int    out  = 0;
-    /* Lookup host address chunks.  Try to do a standard memcpy if the regions
-       do not cross memory regions. */
-    ulong   m0_region              = m0_vaddr >> 32;
-    ulong   m0_offset              = m0_vaddr & 0xffffffffUL;
-    ulong   m0_region_idx          = 0UL;
-    ulong   m0_bytes_in_cur_region = sz;
-    uchar * m0_haddr               = NULL;
-    if( m0_region==4UL ) {
-      m0_region_idx          = fd_vm_get_input_mem_region_idx( vm, m0_offset );
-      m0_haddr               = (uchar*)(vm->input_mem_regions[ m0_region_idx ].haddr + m0_offset - vm->input_mem_regions[ m0_region_idx ].vaddr_offset);
-      m0_bytes_in_cur_region = fd_ulong_min( sz, fd_ulong_sat_sub( vm->input_mem_regions[ m0_region_idx ].region_sz,
-                                                                   ((ulong)m0_haddr - vm->input_mem_regions[ m0_region_idx ].haddr) ) );
-      if( FD_UNLIKELY( m0_region_idx+1UL==vm->input_mem_regions_cnt && m0_bytes_in_cur_region<sz ) ) {
-        *_ret = 1;
-        return FD_VM_ERR_ABORT;
-      }
-    } else {
-      m0_haddr = (uchar *)FD_VM_MEM_SLICE_HADDR_LD( vm, m0_vaddr, FD_VM_ALIGN_RUST_U8, sz );
-    }
-
-    ulong   m1_region              = m1_vaddr >> 32;
-    ulong   m1_offset              = m1_vaddr & 0xffffffffUL;
-    ulong   m1_region_idx          = 0UL;
-    ulong   m1_bytes_in_cur_region = sz;
-    uchar * m1_haddr               = NULL;
-    if( m1_region==4UL ) {
-      m1_region_idx          = fd_vm_get_input_mem_region_idx( vm, m1_offset );
-      m1_haddr               = (uchar*)(vm->input_mem_regions[ m1_region_idx ].haddr + m1_offset - vm->input_mem_regions[ m1_region_idx ].vaddr_offset);
-      m1_bytes_in_cur_region = fd_ulong_min( sz, fd_ulong_sat_sub( vm->input_mem_regions[ m1_region_idx ].region_sz,
-                                                                   ((ulong)m1_haddr - vm->input_mem_regions[ m1_region_idx ].haddr) ) );
-      if( FD_UNLIKELY( m1_region_idx+1UL==vm->input_mem_regions_cnt && m1_bytes_in_cur_region<sz ) ) {
-        *_ret = 1;
-        return FD_VM_ERR_ABORT;
-      }
-    } else {
-      m1_haddr = (uchar *)FD_VM_MEM_SLICE_HADDR_LD( vm, m1_vaddr, FD_VM_ALIGN_RUST_U8, sz );
-    }
-
-    /* Case where the operation spans multiple regions. Copy over the bytes
-       from each region while iterating to the next one. */
-    /* TODO: An optimization would be to memcmp chunks at once */
-    ulong m0_idx = 0UL;
-    ulong m1_idx = 0UL;
-    for( ulong i=0UL; i<sz; i++ ) {
-      if( FD_UNLIKELY( !m0_bytes_in_cur_region ) ) {
-        /* Go to next one */
-        if( FD_UNLIKELY( ++m0_region_idx>=vm->input_mem_regions_cnt ) ) {
-          *_ret = 1;
-          return FD_VM_ERR_ABORT;
-        }
-        m0_haddr = (uchar*)vm->input_mem_regions[ m0_region_idx ].haddr;
-        m0_idx = 0UL;
-        m0_bytes_in_cur_region = vm->input_mem_regions[ m0_region_idx ].region_sz;
-      }
-      if( FD_UNLIKELY( !m1_bytes_in_cur_region ) ) {
-        /* Go to next one */
-        if( FD_UNLIKELY( ++m1_region_idx>=vm->input_mem_regions_cnt ) ) {
-          *_ret = 1;
-          return FD_VM_ERR_ABORT;
-        }
-        m1_haddr = (uchar*)vm->input_mem_regions[ m1_region_idx ].haddr;
-        m1_idx = 0UL;
-        m1_bytes_in_cur_region = vm->input_mem_regions[ m1_region_idx ].region_sz;
-      }
-
-      int i0 = (int)m0_haddr[ m0_idx ];
-      int i1 = (int)m1_haddr[ m1_idx ];
-      if( i0!=i1 ) {
-        out = i0 - i1;
-        break;
-      }
-
-      m0_bytes_in_cur_region--;
-      m1_bytes_in_cur_region--;
-      m0_idx++;
-      m1_idx++;
-    }
-    fd_memcpy( _out, &out, 4UL ); /* Sigh ... see note above (and might be unaligned ... double sigh) */
-    *_ret = 0;
-    return FD_VM_SUCCESS;
   }
+
+  fd_memcpy( _out, &out, 4UL ); /* Sigh ... see note above (and might be unaligned ... double sigh) */
+
+  *_ret = 0;
+  return FD_VM_SUCCESS;
 }
 
 int
@@ -621,46 +440,8 @@ fd_vm_syscall_sol_memset( /**/            void *  _vm,
   ulong FD_FN_UNUSED dst_region = dst_vaddr >> 32;
   int b = (int)(c & 255UL);
 
-  if( dst_region!=4UL || !FD_FEATURE_ACTIVE( vm->instr_ctx->slot_ctx, bpf_account_data_direct_mapping ) ) {
-    void * dst = FD_VM_MEM_SLICE_HADDR_ST( vm, dst_vaddr, 1UL, sz );
-    fd_memset( dst, b, sz );
-  } else {
-    /* Syscall manages the pointer accesses directly and will report in the
-       case of bad memory accesses. */
-    ulong sz_left              = sz;
-    ulong dst_offset           = dst_vaddr & 0xffffffffUL;
-    ulong region_idx           = fd_vm_get_input_mem_region_idx( vm, dst_offset );
-    ulong region_offset        = dst_offset - vm->input_mem_regions[region_idx].vaddr_offset;
-    ulong bytes_left_in_region = fd_ulong_sat_sub(vm->input_mem_regions[region_idx].region_sz, region_offset);
-    uchar * haddr              = (uchar*)(vm->input_mem_regions[region_idx].haddr + region_offset);
-
-    if( FD_UNLIKELY( !bytes_left_in_region ) ) {
-      *_ret = 1UL;
-      return FD_VM_ERR_INVAL;
-    }
-
-    while( sz_left ) {
-      if( FD_UNLIKELY( region_idx>=vm->input_mem_regions_cnt ) ) {
-        *_ret = 1UL;
-        return FD_VM_ERR_INVAL;
-      }
-      if( FD_UNLIKELY( !vm->input_mem_regions[region_idx].is_writable ) ) {
-        *_ret = 1UL;
-        return FD_VM_ERR_INVAL;
-      }
-
-      ulong bytes_to_write = fd_ulong_min( sz_left, bytes_left_in_region );
-      memset( haddr, b, bytes_to_write );
-
-      sz_left = fd_ulong_sat_sub( sz_left, bytes_to_write );
-      region_idx++;
-
-      if( region_idx!=vm->input_mem_regions_cnt ) {
-        haddr                = (uchar*)vm->input_mem_regions[region_idx].haddr;
-        bytes_left_in_region = vm->input_mem_regions[region_idx].region_sz;
-      }
-    }
-  }
+  void * dst = FD_VM_MEM_SLICE_HADDR_ST( vm, dst_vaddr, 1UL, sz );
+  fd_memset( dst, b, sz );
 
   *_ret = 0;
   return FD_VM_SUCCESS;
@@ -679,102 +460,10 @@ fd_vm_syscall_sol_memmove( /**/            void *  _vm,
 
   FD_VM_CU_MEM_OP_UPDATE( vm, sz );
 
-  if( !FD_FEATURE_ACTIVE( vm->instr_ctx->slot_ctx, bpf_account_data_direct_mapping ) ) {
-    void *       dst = FD_VM_MEM_SLICE_HADDR_ST( vm, dst_vaddr, FD_VM_ALIGN_RUST_U8, sz );
-    void const * src = FD_VM_MEM_SLICE_HADDR_LD( vm, src_vaddr, FD_VM_ALIGN_RUST_U8, sz );
-    if( FD_LIKELY( sz > 0 ) ) {
-      memmove( dst, src, sz );
-    }
-  } else {
-    /* Lookup host address chunks.  Try to do a standard memcpy if the regions
-       do not cross memory regions. */
-    ulong   dst_region              = dst_vaddr >> 32;
-    ulong   dst_offset              = dst_vaddr & 0xffffffffUL;
-    ulong   dst_region_idx          = 0UL;
-    ulong   dst_bytes_in_cur_region = sz;
-    uchar * dst_haddr               = NULL;
-    if( dst_region==4UL ) {
-      dst_region_idx          = fd_vm_get_input_mem_region_idx( vm, dst_offset );
-      dst_haddr               = (uchar*)(vm->input_mem_regions[ dst_region_idx ].haddr + dst_offset - vm->input_mem_regions[ dst_region_idx ].vaddr_offset);
-      dst_bytes_in_cur_region = fd_ulong_min( sz, fd_ulong_sat_sub( vm->input_mem_regions[ dst_region_idx ].region_sz,
-                                                                    ((ulong)dst_haddr - vm->input_mem_regions[ dst_region_idx ].haddr) ) );
-      if( FD_UNLIKELY( !vm->input_mem_regions[ dst_region_idx ].is_writable ) ) {
-        *_ret = 1;
-        return FD_VM_ERR_ABORT;
-      }
-      if( FD_UNLIKELY( dst_region_idx+1UL==vm->input_mem_regions_cnt && dst_bytes_in_cur_region<sz ) ) {
-        *_ret = 1;
-        return FD_VM_ERR_ABORT;
-      }
-
-    } else {
-      dst_haddr = (uchar *)FD_VM_MEM_SLICE_HADDR_ST( vm, dst_vaddr, 1UL, sz );
-    }
-
-    ulong src_region              = src_vaddr >> 32;
-    ulong src_offset              = src_vaddr & 0xffffffffUL;
-    ulong src_region_idx          = 0UL;
-    ulong src_bytes_in_cur_region = sz;
-    uchar * src_haddr             = NULL;
-    if( src_region==4UL ) {
-      src_region_idx          = fd_vm_get_input_mem_region_idx( vm, src_offset );
-      src_haddr               = (uchar*)(vm->input_mem_regions[ src_region_idx ].haddr + src_offset - vm->input_mem_regions[ src_region_idx ].vaddr_offset);
-      src_bytes_in_cur_region = fd_ulong_min( sz, fd_ulong_sat_sub( vm->input_mem_regions[ src_region_idx ].region_sz,
-                                                                    ((ulong)src_haddr - vm->input_mem_regions[ src_region_idx ].haddr) ) );
-
-      if( FD_UNLIKELY( src_region_idx+1UL==vm->input_mem_regions_cnt && src_bytes_in_cur_region<sz ) ) {
-        *_ret = 1;
-        return FD_VM_ERR_ABORT;
-      }
-    } else {
-      src_haddr = (uchar *)FD_VM_MEM_SLICE_HADDR_LD( vm, src_vaddr, 1UL, sz );
-    }
-
-    /* Do a normal memcpy if regions do not overlap */
-    if( FD_LIKELY( src_bytes_in_cur_region==dst_bytes_in_cur_region && src_bytes_in_cur_region==sz ) ) {
-      memmove( dst_haddr, src_haddr, sz );
-      *_ret = 0;
-      return FD_VM_SUCCESS;
-    }
-
-    /* Case where the operation spans multiple regions. Copy over the bytes
-       from each region while iterating to the next one. */
-    /* TODO: An optimization would be to memcpy chunks at once */
-    ulong dst_idx = 0UL;
-    ulong src_idx = 0UL;
-    for( ulong i=0UL; i<sz; i++ ) {
-      if( FD_UNLIKELY( !dst_bytes_in_cur_region ) ) {
-        /* Go to next one */
-        if( FD_UNLIKELY( ++dst_region_idx>=vm->input_mem_regions_cnt ) ) {
-          *_ret = 1;
-          return FD_VM_ERR_ABORT;
-        }
-        if( FD_UNLIKELY( !vm->input_mem_regions[ dst_region_idx ].is_writable ) ) {
-          *_ret = 1;
-          return FD_VM_ERR_ABORT;
-        }
-        dst_haddr               = (uchar*)vm->input_mem_regions[ dst_region_idx ].haddr;
-        dst_bytes_in_cur_region = vm->input_mem_regions[ dst_region_idx ].region_sz;
-        dst_idx                 = 0UL;
-      }
-      if( FD_UNLIKELY( !src_bytes_in_cur_region ) ) {
-        /* Go to next one */
-        if( FD_UNLIKELY( ++src_region_idx>=vm->input_mem_regions_cnt ) ) {
-          *_ret = 1;
-          return FD_VM_ERR_ABORT;
-        }
-        src_haddr               = (uchar*)vm->input_mem_regions[ src_region_idx ].haddr;
-        src_bytes_in_cur_region = vm->input_mem_regions[ src_region_idx ].region_sz;
-        src_idx                 = 0UL;
-      }
-
-      dst_haddr[ dst_idx ] = src_haddr[ src_idx ];
-
-      dst_bytes_in_cur_region--;
-      src_bytes_in_cur_region--;
-      dst_idx++;
-      src_idx++;
-    }
+  void *       dst = FD_VM_MEM_SLICE_HADDR_ST( vm, dst_vaddr, FD_VM_ALIGN_RUST_U8, sz );
+  void const * src = FD_VM_MEM_SLICE_HADDR_LD( vm, src_vaddr, FD_VM_ALIGN_RUST_U8, sz );
+  if( FD_LIKELY( sz > 0 ) ) {
+    memmove( dst, src, sz );
   }
 
   *_ret = 0;

--- a/src/flamenco/vm/syscall/fd_vm_syscall_util.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_util.c
@@ -390,7 +390,7 @@ fd_vm_syscall_sol_memcpy( /**/            void *  _vm,
     if( dst_region==4UL ) {
       dst_region_idx          = fd_vm_get_input_mem_region_idx( vm, dst_offset );
       dst_haddr               = (uchar*)(vm->input_mem_regions[ dst_region_idx ].haddr + dst_offset - vm->input_mem_regions[ dst_region_idx ].vaddr_offset);
-      dst_bytes_in_cur_region = fd_ulong_min( sz, fd_ulong_sat_sub( vm->input_mem_regions[ dst_region_idx ].region_sz, 
+      dst_bytes_in_cur_region = fd_ulong_min( sz, fd_ulong_sat_sub( vm->input_mem_regions[ dst_region_idx ].region_sz,
                                                                     ((ulong)dst_haddr - vm->input_mem_regions[ dst_region_idx ].haddr) ) );
       if( FD_UNLIKELY( !vm->input_mem_regions[ dst_region_idx ].is_writable ) ) {
         *_ret = 1;
@@ -413,7 +413,7 @@ fd_vm_syscall_sol_memcpy( /**/            void *  _vm,
     if( src_region==4UL ) {
       src_region_idx          = fd_vm_get_input_mem_region_idx( vm, src_offset );
       src_haddr               = (uchar*)(vm->input_mem_regions[ src_region_idx ].haddr + src_offset - vm->input_mem_regions[ src_region_idx ].vaddr_offset);
-      src_bytes_in_cur_region = fd_ulong_min( sz, fd_ulong_sat_sub( vm->input_mem_regions[ src_region_idx ].region_sz, 
+      src_bytes_in_cur_region = fd_ulong_min( sz, fd_ulong_sat_sub( vm->input_mem_regions[ src_region_idx ].region_sz,
                                                                     ((ulong)src_haddr - vm->input_mem_regions[ src_region_idx ].haddr) ) );
       if( FD_UNLIKELY( src_region_idx+1UL==vm->input_mem_regions_cnt && src_bytes_in_cur_region<sz ) ) {
         *_ret = 1;
@@ -430,7 +430,7 @@ fd_vm_syscall_sol_memcpy( /**/            void *  _vm,
       *_ret = 0;
       return FD_VM_SUCCESS;
     }
-  
+
     /* Case where the operation spans multiple regions. Copy over the bytes
        from each region while iterating to the next one. */
     /* TODO: An optimization would be to memcpy chunks at once */
@@ -625,7 +625,7 @@ fd_vm_syscall_sol_memset( /**/            void *  _vm,
     void * dst = FD_VM_MEM_SLICE_HADDR_ST( vm, dst_vaddr, 1UL, sz );
     fd_memset( dst, b, sz );
   } else {
-    /* Syscall manages the pointer accesses directly and will report in the 
+    /* Syscall manages the pointer accesses directly and will report in the
        case of bad memory accesses. */
     ulong sz_left              = sz;
     ulong dst_offset           = dst_vaddr & 0xffffffffUL;
@@ -736,7 +736,7 @@ fd_vm_syscall_sol_memmove( /**/            void *  _vm,
       *_ret = 0;
       return FD_VM_SUCCESS;
     }
-  
+
     /* Case where the operation spans multiple regions. Copy over the bytes
        from each region while iterating to the next one. */
     /* TODO: An optimization would be to memcpy chunks at once */


### PR DESCRIPTION
This PR removes parts of the "direct mapping" implementation that are specific to ABIv1. 

Leaves intact the CPI and serialization routines because those might be reused for ABIv2 when it is ready.

Not yet ready for merge.
This should be merged only after testnet disables the direct mapping feature. 