### PR TITLE
quic: don't retransmit ACKs

### DIFF
--- a/src/waltz/quic/fd_quic_pkt_meta.h
+++ b/src/waltz/quic/fd_quic_pkt_meta.h
@@ -90,7 +90,6 @@ struct fd_quic_pkt_meta {
        FD_QUIC_PKT_META_FLAGS_HS_DONE             handshake-done frame
        FD_QUIC_PKT_META_FLAGS_MAX_DATA            max_data frame
        FD_QUIC_PKT_META_FLAGS_MAX_STREAMS_UNIDIR  max_streams frame (unidir)
-       FD_QUIC_PKT_META_FLAGS_ACK                 acknowledgement
        FD_QUIC_PKT_META_FLAGS_CLOSE               close frame
        FD_QUIC_PKT_META_FLAGS_KEY_UPDATE          indicates key update was in effect
        FD_QUIC_PKT_META_FLAGS_KEY_PHASE           set only if key_phase was set in the short-header
@@ -103,7 +102,6 @@ struct fd_quic_pkt_meta {
 # define          FD_QUIC_PKT_META_FLAGS_HS_DONE            (1u<<2u)
 # define          FD_QUIC_PKT_META_FLAGS_MAX_DATA           (1u<<3u)
 # define          FD_QUIC_PKT_META_FLAGS_MAX_STREAMS_UNIDIR (1u<<5u)
-# define          FD_QUIC_PKT_META_FLAGS_ACK                (1u<<7u)
 # define          FD_QUIC_PKT_META_FLAGS_CLOSE              (1u<<8u)
 # define          FD_QUIC_PKT_META_FLAGS_KEY_UPDATE         (1u<<9u)
 # define          FD_QUIC_PKT_META_FLAGS_KEY_PHASE          (1u<<10u)

--- a/src/waltz/quic/tests/test_quic_drops.c
+++ b/src/waltz/quic/tests/test_quic_drops.c
@@ -115,12 +115,12 @@ mitm_tx( void *                    ctx,
       }
       continue;
     }
-    
+
     /* send new packet */
     fd_aio_pkt_info_t batch_0[1] = { batch[j] };
     fd_aio_send( mitm_ctx->dst, batch_0, 1UL, NULL, 1 );
     PCAP(batch_0,1UL);
-      
+
     /* we aren't dropping or reordering, but we might have a prior reorder */
     if( mitm_ctx->reorder_sz > 0UL ) {
       fd_aio_pkt_info_t batch_1[1] = {{ .buf = mitm_ctx->reorder_buf, .buf_sz = (ushort)mitm_ctx->reorder_sz }};
@@ -200,7 +200,7 @@ my_stream_receive_cb( fd_quic_stream_t * stream,
   (void)stream;
   (void)fin;
 
-  FD_LOG_NOTICE(( "received data from peer.  stream_id: %lu  size: %lu offset: %lu\n",
+  FD_LOG_NOTICE(( "received data from peer.  stream_id: %lu  size: %lu offset: %lu",
                 (ulong)stream->stream_id, data_sz, offset ));
   FD_LOG_HEXDUMP_DEBUG(( "received data", data, data_sz ));
 


### PR DESCRIPTION
Instead of storing sent ACKs in pkt_meta, now immediately reclaims
ack objects in conn_tx.  This reduces pressure on the ack pool for
fd_quic tiles.
