### PR TITLE
quic: fix MSan false positives

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -1239,7 +1239,7 @@ fd_quic_handle_v1_initial( fd_quic_t *               quic,
 
   /* Parse initial packet */
 
-  fd_quic_initial_t initial[1];
+  fd_quic_initial_t initial[1] = {0};
   ulong rc = fd_quic_decode_initial( initial, cur_ptr, cur_sz );
   if( FD_UNLIKELY( rc == FD_QUIC_PARSE_FAIL ) ) {
     FD_DEBUG( FD_LOG_DEBUG(( "fd_quic_decode_initial failed" )) );
@@ -3561,7 +3561,7 @@ fd_quic_conn_tx( fd_quic_t *      quic,
   /* TODO probably should be called tx_max_udp_payload_sz */
   ulong tx_max_datagram_sz = conn->tx_max_datagram_sz;
 
-  fd_quic_pkt_hdr_t pkt_hdr;
+  fd_quic_pkt_hdr_t pkt_hdr = {0};
 
   fd_quic_pkt_meta_t * pkt_meta         = NULL;
   ulong                pkt_meta_var_idx = 0UL;


### PR DESCRIPTION
QUIC conn IDs are variable size (in range [0,20] bytes).
If the conn ID size is less than 20, high bytes are usually left
uninitialized (e.g. stack memory).

Some code always copies all 20 bytes as an optimization, including
uninitialized bytes.  This avoids a variable-sz memcpy.

The resulting logic is "copy of uninitialized bytes to a place that
also contains uninitialized bytes".  While this isn't a security
issue, it will trigger tools like MSan that see an explicit read of
uninitialized memory.

Updates local declarations of fd_quic_initial_t to be zero-inited.
(Now writes about 700 bytes of zeros)

Thanks to ImmuneFi User gln for reporting this bug.
