### PR TITLE
util: fix map_dynamic MSan false positive

### DIFF
--- a/src/util/tmpl/fd_map_dynamic.c
+++ b/src/util/tmpl/fd_map_dynamic.c
@@ -337,8 +337,16 @@ MAP_(new)( void *  shmem,
 
   MAP_T * slot = map->slot; FD_COMPILER_FORGET( slot );
 
-  for( ulong slot_idx=0UL; slot_idx<slot_cnt; slot_idx++ )
+  for( ulong slot_idx=0UL; slot_idx<slot_cnt; slot_idx++ ) {
     slot[ slot_idx ].MAP_KEY = (MAP_KEY_NULL);
+
+  # if MAP_MEMOIZE && MAP_KEY_EQUAL_IS_SLOW
+    /* Allow speculative reads of uninitialized MAP_HASH value. */
+    fd_msan_unpoison( &slot[ slot_idx ].MAP_HASH, sizeof(MAP_HASH_T) );
+    slot[ slot_idx ].MAP_HASH = 0;
+  # endif
+
+  }
 
   return map;
 }

--- a/src/util/tmpl/test_map_dynamic.c
+++ b/src/util/tmpl/test_map_dynamic.c
@@ -66,6 +66,7 @@ main( int     argc,
   FD_TEST( fd_ulong_is_pow2   ( align            ) );
   FD_TEST( fd_ulong_is_aligned( footprint, align ) );
 
+  fd_msan_poison( mem, sizeof(mem) );
   void   * shmap = map_new ( mem, LG_SLOT_CNT ); FD_TEST( shmap );
   pair_t * map   = map_join( shmap );            FD_TEST( map   );
 


### PR DESCRIPTION
map_dynamic with large keys, memoize==1, key_equal_is_slow==1
relies on speculative reads of the MAP_HASH, which can be
uninitialized in some cases.
