### PR TITLE
Fix fd_snapshot_loader_delete uninitialized read

### DIFF
--- a/src/flamenco/snapshot/fd_snapshot_http.c
+++ b/src/flamenco/snapshot/fd_snapshot_http.c
@@ -100,6 +100,7 @@ fd_snapshot_http_new( void *               mem,
 
 void *
 fd_snapshot_http_delete( fd_snapshot_http_t * this ) {
+  if( FD_UNLIKELY( !this ) ) return NULL;
   if( this->socket_fd>=0 ) {
     close( this->socket_fd );
     this->socket_fd = -1;


### PR DESCRIPTION
fd_snapshot_loader_new doesn't zero initialize, but
fd_snapshot_loader_delete unconditionally calls fd_snapshot_http_delete,
which is U.B. in some cases.

Adds zero initialization and moves fd_snapshot_loader_t->http to
the class dynamic region for performance.
