### PR TITLE
Fix stack memory UAF in fd_tower_to_tower_sync

### DIFF
--- a/src/choreo/tower/fd_tower.c
+++ b/src/choreo/tower/fd_tower.c
@@ -1031,11 +1031,12 @@ void
 fd_tower_to_tower_sync( fd_tower_t const *               tower,
                         fd_hash_t const *                bank_hash,
                         fd_compact_vote_state_update_t * tower_sync ) {
-  tower_sync->root         = tower->root;
-  long ts                  = fd_log_wallclock();
-  tower_sync->timestamp    = &ts;
-  tower_sync->lockouts_len = (ushort)fd_tower_votes_cnt( tower->votes );
-  tower_sync->lockouts     = (fd_lockout_offset_t *)
+  tower_sync->root          = tower->root;
+  long ts                   = fd_log_wallclock();
+  tower_sync->has_timestamp = 1;
+  tower_sync->timestamp     = ts;
+  tower_sync->lockouts_len  = (ushort)fd_tower_votes_cnt( tower->votes );
+  tower_sync->lockouts      = (fd_lockout_offset_t *)
       fd_scratch_alloc( alignof( fd_lockout_offset_t ),
                         tower_sync->lockouts_len * sizeof( fd_lockout_offset_t ) );
 

--- a/src/choreo/voter/test_voter.c
+++ b/src/choreo/voter/test_voter.c
@@ -59,10 +59,11 @@ main( int argc, char ** argv ) {
   /* create compact_vote_state_update with dummy values */
   fd_compact_vote_state_update_t compact_vote_update;
   memset( &compact_vote_update, 0, sizeof( fd_compact_vote_state_update_t ) );
-  compact_vote_update.root         = 100;
-  compact_vote_update.lockouts_len = 0;
-  static long now                  = 1715701506716580798L;
-  compact_vote_update.timestamp    = &now;
+  compact_vote_update.root          = 100;
+  compact_vote_update.lockouts_len  = 0;
+  static long now                   = 1715701506716580798L;
+  compact_vote_update.has_timestamp = 1;
+  compact_vote_update.timestamp     = now;
   FD_TEST( 32UL == getrandom( compact_vote_update.hash.key, 32UL, 0 ) );
 
   fd_hash_t recent_blockhash = { 0 };

--- a/src/flamenco/types/fd_types.c
+++ b/src/flamenco/types/fd_types.c
@@ -10443,11 +10443,10 @@ void fd_vote_state_update_decode_unsafe( fd_vote_state_update_t * self, fd_binco
   {
     uchar o;
     fd_bincode_bool_decode_unsafe( &o, ctx );
+    self->has_timestamp = !!o;
     if( o ) {
-      self->timestamp = fd_valloc_malloc( ctx->valloc, 8, sizeof(long) );
-      fd_bincode_int64_decode_unsafe( self->timestamp, ctx );
-    } else
-      self->timestamp = NULL;
+      fd_bincode_int64_decode_unsafe( &self->timestamp, ctx );
+    }
   }
 }
 int fd_vote_state_update_encode( fd_vote_state_update_t const * self, fd_bincode_encode_ctx_t * ctx ) {
@@ -10474,13 +10473,10 @@ int fd_vote_state_update_encode( fd_vote_state_update_t const * self, fd_bincode
   }
   err = fd_hash_encode( &self->hash, ctx );
   if( FD_UNLIKELY( err ) ) return err;
-  if( self->timestamp != NULL ) {
-    err = fd_bincode_bool_encode( 1, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    err = fd_bincode_int64_encode( self->timestamp[0], ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-  } else {
-    err = fd_bincode_bool_encode( 0, ctx );
+  err = fd_bincode_bool_encode( self->has_timestamp, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_timestamp ) {
+    err = fd_bincode_int64_encode( self->timestamp, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   return FD_BINCODE_SUCCESS;
@@ -10538,9 +10534,8 @@ void fd_vote_state_update_destroy( fd_vote_state_update_t * self, fd_bincode_des
     self->has_root = 0;
   }
   fd_hash_destroy( &self->hash, ctx );
-  if( self->timestamp ) {
-    fd_valloc_free( ctx->valloc, self->timestamp );
-    self->timestamp = NULL;
+  if( self->has_timestamp ) {
+    self->has_timestamp = 0;
   }
 }
 
@@ -10569,10 +10564,10 @@ void fd_vote_state_update_walk( void * w, fd_vote_state_update_t const * self, f
     fun( w, &self->root, "root", FD_FLAMENCO_TYPE_ULONG, "ulong", level );
   }
   fd_hash_walk( w, &self->hash, fun, "hash", level );
-  if( !self->timestamp ) {
+  if( !self->has_timestamp ) {
     fun( w, NULL, "timestamp", FD_FLAMENCO_TYPE_NULL, "long", level );
   } else {
-    fun( w, self->timestamp, "timestamp", FD_FLAMENCO_TYPE_SLONG, "long", level );
+    fun( w, &self->timestamp, "timestamp", FD_FLAMENCO_TYPE_SLONG, "long", level );
   }
   fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_vote_state_update", level-- );
 }
@@ -10593,7 +10588,7 @@ ulong fd_vote_state_update_size( fd_vote_state_update_t const * self ) {
   }
   size += fd_hash_size( &self->hash );
   size += sizeof(char);
-  if( NULL !=  self->timestamp ) {
+  if( self->has_timestamp ) {
     size += sizeof(long);
   }
   return size;
@@ -10651,11 +10646,10 @@ void fd_compact_vote_state_update_decode_unsafe( fd_compact_vote_state_update_t 
   {
     uchar o;
     fd_bincode_bool_decode_unsafe( &o, ctx );
+    self->has_timestamp = !!o;
     if( o ) {
-      self->timestamp = fd_valloc_malloc( ctx->valloc, 8, sizeof(long) );
-      fd_bincode_int64_decode_unsafe( self->timestamp, ctx );
-    } else
-      self->timestamp = NULL;
+      fd_bincode_int64_decode_unsafe( &self->timestamp, ctx );
+    }
   }
 }
 int fd_compact_vote_state_update_encode( fd_compact_vote_state_update_t const * self, fd_bincode_encode_ctx_t * ctx ) {
@@ -10672,13 +10666,10 @@ int fd_compact_vote_state_update_encode( fd_compact_vote_state_update_t const * 
   }
   err = fd_hash_encode( &self->hash, ctx );
   if( FD_UNLIKELY( err ) ) return err;
-  if( self->timestamp != NULL ) {
-    err = fd_bincode_bool_encode( 1, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    err = fd_bincode_int64_encode( self->timestamp[0], ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-  } else {
-    err = fd_bincode_bool_encode( 0, ctx );
+  err = fd_bincode_bool_encode( self->has_timestamp, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_timestamp ) {
+    err = fd_bincode_int64_encode( self->timestamp, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   return FD_BINCODE_SUCCESS;
@@ -10726,9 +10717,8 @@ void fd_compact_vote_state_update_destroy( fd_compact_vote_state_update_t * self
     self->lockouts = NULL;
   }
   fd_hash_destroy( &self->hash, ctx );
-  if( self->timestamp ) {
-    fd_valloc_free( ctx->valloc, self->timestamp );
-    self->timestamp = NULL;
+  if( self->has_timestamp ) {
+    self->has_timestamp = 0;
   }
 }
 
@@ -10745,10 +10735,10 @@ void fd_compact_vote_state_update_walk( void * w, fd_compact_vote_state_update_t
     fun( w, NULL, "lockouts", FD_FLAMENCO_TYPE_ARR_END, "array", level-- );
   }
   fd_hash_walk( w, &self->hash, fun, "hash", level );
-  if( !self->timestamp ) {
+  if( !self->has_timestamp ) {
     fun( w, NULL, "timestamp", FD_FLAMENCO_TYPE_NULL, "long", level );
   } else {
-    fun( w, self->timestamp, "timestamp", FD_FLAMENCO_TYPE_SLONG, "long", level );
+    fun( w, &self->timestamp, "timestamp", FD_FLAMENCO_TYPE_SLONG, "long", level );
   }
   fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_compact_vote_state_update", level-- );
 }
@@ -10763,7 +10753,7 @@ ulong fd_compact_vote_state_update_size( fd_compact_vote_state_update_t const * 
   } while(0);
   size += fd_hash_size( &self->hash );
   size += sizeof(char);
-  if( NULL !=  self->timestamp ) {
+  if( self->has_timestamp ) {
     size += sizeof(long);
   }
   return size;

--- a/src/flamenco/types/fd_types.h
+++ b/src/flamenco/types/fd_types.h
@@ -1840,7 +1840,8 @@ struct __attribute__((aligned(8UL))) fd_vote_state_update {
   ulong root;
   uchar has_root;
   fd_hash_t hash;
-  long* timestamp;
+  long timestamp;
+  uchar has_timestamp;
 };
 typedef struct fd_vote_state_update fd_vote_state_update_t;
 #define FD_VOTE_STATE_UPDATE_FOOTPRINT sizeof(fd_vote_state_update_t)
@@ -1862,7 +1863,8 @@ struct __attribute__((aligned(8UL))) fd_compact_vote_state_update {
   ushort lockouts_len;
   fd_lockout_offset_t * lockouts;
   fd_hash_t hash;
-  long* timestamp;
+  long timestamp;
+  uchar has_timestamp;
 };
 typedef struct fd_compact_vote_state_update fd_compact_vote_state_update_t;
 #define FD_COMPACT_VOTE_STATE_UPDATE_FOOTPRINT sizeof(fd_compact_vote_state_update_t)

--- a/src/flamenco/types/fd_types.json
+++ b/src/flamenco/types/fd_types.json
@@ -813,7 +813,7 @@
         { "name": "lockouts", "type": "deque", "element": "vote_lockout", "min": 32 },
         { "name": "root", "type": "option", "element": "ulong", "flat": true },
         { "name": "hash", "type": "hash" },
-        { "name": "timestamp", "type": "option", "element": "long" }
+        { "name": "timestamp", "type": "option", "element": "long", "flat": true }
       ],
       "comment": "https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L185"
     },
@@ -824,7 +824,7 @@
           { "name": "root", "type": "ulong" },
           { "name": "lockouts", "type": "vector", "element": "lockout_offset", "modifier": "compact" },
           { "name": "hash", "type": "hash" },
-          { "name": "timestamp", "type": "option", "element": "long" }
+          { "name": "timestamp", "type": "option", "element": "long", "flat": true }
       ]
     },
     {


### PR DESCRIPTION
Switch to flat representation for (compact_)vote_state_update->timestamp

Fixes https://github.com/firedancer-io/auditor-internal/issues/180
