### PR TITLE
solcap: fix format string specifier

### DIFF
--- a/src/flamenco/capture/fd_solcap_yaml.c
+++ b/src/flamenco/capture/fd_solcap_yaml.c
@@ -449,7 +449,7 @@ if ( verbose < 3 )
 
   if ( meta.solana_txn_err != ULONG_MAX || meta.solana_cus_used != ULONG_MAX ) {
     printf(
-      "      solana_txn_err:  %d\n"
+      "      solana_txn_err:  %lu\n"
       "      solana_cus_used: %lu\n",
       meta.solana_txn_err,
       meta.solana_cus_used );


### PR DESCRIPTION
`meta.solana_txn_err` is of type `uint64_t`