### PR TITLE
runtime: remove "touch" verbiage

### DIFF
--- a/src/flamenco/runtime/fd_account.c
+++ b/src/flamenco/runtime/fd_account.c
@@ -35,7 +35,7 @@ fd_account_set_owner( fd_exec_instr_ctx_t const * ctx,
   if( !fd_account_is_zeroed( meta ) ) {
     return FD_EXECUTOR_INSTR_ERR_MODIFIED_PROGRAM_ID;
   }
-  /* Don't touch the account if the owner does not change */
+  /* Don't copy the account if the owner does not change */
   if( !memcmp( account->const_meta->info.owner, owner, sizeof( fd_pubkey_t ) ) ) {
     return FD_EXECUTOR_INSTR_SUCCESS;
   }
@@ -47,8 +47,8 @@ fd_account_set_owner( fd_exec_instr_ctx_t const * ctx,
     }
   } while(0);
 
-  /* self.touch()? */
-  account->meta->slot = ctx->slot_ctx->slot_bank.slot;
+  /* Agave self.touch() is a no-op */
+
   memcpy( account->meta->info.owner, owner, sizeof(fd_pubkey_t) );
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
@@ -84,7 +84,7 @@ fd_account_set_lamports( fd_exec_instr_ctx_t const * ctx,
     return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_LAMPORT_CHANGE;
   }
 
-  /* Don't touch the account if the lamports do not change */
+  /* Don't copy the account if the lamports do not change */
   if( lamports==account->const_meta->info.lamports ) {
    return FD_EXECUTOR_INSTR_SUCCESS;
   }
@@ -96,8 +96,7 @@ fd_account_set_lamports( fd_exec_instr_ctx_t const * ctx,
     }
   } while(0);
 
-  /* self.touch()? */
-  account->meta->slot = ctx->slot_ctx->slot_bank.slot;
+  /* Agave self.touch() is a no-op */
 
   account->meta->info.lamports = lamports;
   return FD_EXECUTOR_INSTR_SUCCESS;
@@ -122,8 +121,7 @@ fd_account_get_data_mut( fd_exec_instr_ctx_t const * ctx,
     }
   } while(0);
 
-  /* self.touch() */
-  account->meta->slot = ctx->slot_ctx->slot_bank.slot;
+  /* Agave self.touch() is a no-op */
 
   if (NULL != data_out)
     *data_out = account->data;
@@ -156,8 +154,7 @@ fd_account_set_data_from_slice( fd_exec_instr_ctx_t const * ctx,
     return err;
   }
 
-  /* touch() */
-  account->meta->slot = ctx->slot_ctx->slot_bank.slot;
+  /* Agave self.touch() is a no-op */
 
   if( FD_UNLIKELY( !fd_account_update_accounts_resize_delta( ctx, instr_acc_idx, data_sz, &err ) ) ) {
     return err;
@@ -201,13 +198,12 @@ fd_account_set_data_length( fd_exec_instr_ctx_t const * ctx,
 
   ulong old_len = account->const_meta->dlen;
 
-  /* Don't touch the account if the length does not change */
+  /* Don't copy the account if the length does not change */
   if( old_len==new_len ) {
     return FD_EXECUTOR_INSTR_SUCCESS;
   }
 
-  /* self.touch() */
-  account->meta->slot = ctx->slot_ctx->slot_bank.slot;
+  /* Agave self.touch() is a no-op */
 
   if( !fd_account_update_accounts_resize_delta( ctx, instr_acc_idx, new_len, &err ) ) {
     return err;
@@ -267,7 +263,7 @@ fd_account_set_executable( fd_exec_instr_ctx_t const * ctx,
     return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_MODIFIED;
   }
 
-  /* Don't touch the account if the exectuable flag does not change */
+  /* Don't copy the account if the exectuable flag does not change */
   if( fd_account_is_executable( meta ) == is_executable ) {
     return FD_EXECUTOR_INSTR_SUCCESS;
   }
@@ -279,8 +275,7 @@ fd_account_set_executable( fd_exec_instr_ctx_t const * ctx,
     }
   } while(0);
 
-  /* self.touch()? */
-  account->meta->slot = ctx->slot_ctx->slot_bank.slot;
+  /* Agave self.touch() is a no-op */
 
   account->meta->info.executable = !!is_executable;
 

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -1057,14 +1057,10 @@ fd_txn_reclaim_accounts( fd_exec_txn_ctx_t * txn_ctx ) {
   for( ulong i = 0; i < txn_ctx->accounts_cnt; i++ ) {
     fd_borrowed_account_t * acc_rec = &txn_ctx->borrowed_accounts[i];
 
-    /* An account writable iff it is writable AND it is not being demoted.
-        If this criteria is not met, the account should not be marked as touched
-        via updating its most recent slot. */
+    /* An account is writable if it is writable AND it is not being demoted. */
     if( !fd_txn_account_is_writable_idx( txn_ctx, (int)i ) ) {
       continue;
     }
-
-    acc_rec->meta->slot = txn_ctx->slot_ctx->slot_bank.slot;
 
     if( acc_rec->meta->info.lamports == 0 ) {
       acc_rec->meta->dlen = 0;

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -1147,7 +1147,7 @@ fd_runtime_copy_accounts_to_pruned_funk( fd_funk_t * pruned_funk,
                                          fd_exec_slot_ctx_t * slot_ctx,
                                          fd_exec_txn_ctx_t * txn_ctx ) {
   /* This function is only responsible for copying over the account ids that are
-     touched. The account data is copied over after execution is complete. */
+     modified. The account data is copied over after execution is complete. */
 
   /* Copy over ALUTs */
   fd_txn_acct_addr_lut_t * addr_luts = fd_txn_get_address_tables( (fd_txn_t *) txn_ctx->txn_descriptor );


### PR DESCRIPTION
BorrowedAccount::touch() is a no-op in recent Agave versions.
Update Firedancer code to be less confusing about the behavior of
touch by updating comments and removing redundant statements.
