### PR TITLE
ballet, elf: cleanup `err_on_syscall_bpf_func_collision` feature gate + collision checks

### DIFF
--- a/src/flamenco/features/fd_features_generated.c
+++ b/src/flamenco/features/fd_features_generated.c
@@ -478,7 +478,7 @@ fd_feature_id_t const ids[] = {
     .id         = {"\x68\x0b\x04\x8f\x62\x8e\xa5\x3c\x7f\xfa\x04\x93\xa4\xd2\x90\xa0\xba\xc9\xbe\xa5\x4a\x03\xa8\x63\x01\xd7\xea\x4f\xa7\x0c\x9e\xdc"},
                   /* 8199Q2gMD2kwgfopK5qqVWuDbegLgpuFUFHCcUJQDN8b */
     .name       = "error_on_syscall_bpf_function_hash_collisions",
-    .cleaned_up = {UINT_MAX, UINT_MAX, UINT_MAX} },
+    .cleaned_up = {2, 0, 11} },
 
   { .index      = offsetof(fd_features_t, reject_callx_r10)>>3,
     .id         = {"\x23\x2d\x66\x6d\x5c\x7d\x78\x7e\xf9\x05\x90\x7b\x5c\x5b\xfe\x99\xd2\x8a\x96\xc4\x37\xaa\x40\x2a\x06\x26\x72\x4e\xdd\x3c\x7a\x10"},

--- a/src/flamenco/features/feature_map.json
+++ b/src/flamenco/features/feature_map.json
@@ -77,7 +77,7 @@
   {"name":"check_slice_translation_size","pubkey": "GmC19j9qLn2RFk5NduX6QXaDhVpGncVVBzyM8e9WMz2F","cleaned_up":[1,18,0]},
   {"name":"stake_split_uses_rent_sysvar","pubkey": "FQnc7U4koHqWgRvFaBJjZnV8VPg6L6wWK33yJeDp4yvV","cleaned_up":[1,18,0]},
   {"name":"add_get_minimum_delegation_instruction_to_stake_program","pubkey": "St8k9dVXP97xT6faW24YmRSYConLbhsMJA4TJTBLmMT","cleaned_up":[1,18,0]},
-  {"name":"error_on_syscall_bpf_function_hash_collisions","pubkey": "8199Q2gMD2kwgfopK5qqVWuDbegLgpuFUFHCcUJQDN8b"},
+  {"name":"error_on_syscall_bpf_function_hash_collisions","pubkey": "8199Q2gMD2kwgfopK5qqVWuDbegLgpuFUFHCcUJQDN8b","cleaned_up":[2,0,11]},
   {"name":"reject_callx_r10","pubkey": "3NKRSwpySNwD3TvP5pHnRmkAQRsdkXWRr1WaQh8p4PWX","cleaned_up":[2,0,10]},
   {"name":"drop_redundant_turbine_path","pubkey": "4Di3y24QFLt5QEUPZtbnjyfQKfm6ZMTfa6Dw1psfoMKU","cleaned_up":[1,18,0]},
   {"name":"executables_incur_cpi_data_cost","pubkey": "7GUcYgq4tVtaqNCKT3dho9r4665Qp5TxCZ27Qgjx3829","cleaned_up":[1,18,0]},


### PR DESCRIPTION
Feature gate cleaned up here: https://github.com/anza-xyz/agave/pull/3000

Also noticed we were checking for syscall <> bpf function collisions on the wrong key (raw target pc instead of pc_hash) in 32b relocations and missing the check entirely in `fd_sbpf_hash_calls`