### PR TITLE
remove custom format string specifiers

### DIFF
--- a/src/app/fdctl/run/tiles/fd_poh_int.c
+++ b/src/app/fdctl/run/tiles/fd_poh_int.c
@@ -12,9 +12,6 @@
 #include "../../../../flamenco/leaders/fd_leaders.h"
 #include "../../../../flamenco/fd_flamenco.h"
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 /* The PoH recorder is implemented in Firedancer but for now needs to
    work with Agave, so we have a locking scheme for them to
    co-operate.

--- a/src/app/fdctl/run/tiles/fd_replay.c
+++ b/src/app/fdctl/run/tiles/fd_replay.c
@@ -405,7 +405,7 @@ during_frag( void * _ctx,
     */
     ctx->curr_slot = fd_disco_poh_sig_slot( sig );
     if( FD_UNLIKELY( ctx->curr_slot < ctx->tower->root ) ) {
-      FD_LOG_WARNING(( "pack sent slot %lu before our root.", ctx->curr_slot, ctx->tower->root ));
+      FD_LOG_WARNING(( "pack sent slot %lu before our root %lu.", ctx->curr_slot, ctx->tower->root ));
     }
     if( fd_disco_poh_sig_pkt_type( sig )==POH_PKT_TYPE_MICROBLOCK ) {
       ulong bank_idx = fd_disco_poh_sig_bank_tile( sig );
@@ -570,7 +570,7 @@ suppress_notify( const fd_pubkey_t * prog ) {
 }
 
 static void
-publish_account_notifications( fd_replay_tile_ctx_t * ctx, 
+publish_account_notifications( fd_replay_tile_ctx_t * ctx,
                                fd_fork_t *            fork,
                                ulong                  curr_slot,
                                fd_txn_p_t const *     txns,
@@ -627,7 +627,7 @@ publish_account_notifications( fd_replay_tile_ctx_t * ctx,
 }
 
 static void
-publish_slot_notifications( fd_replay_tile_ctx_t * ctx, 
+publish_slot_notifications( fd_replay_tile_ctx_t * ctx,
                             fd_fork_t *            fork,
                             fd_block_map_t const * block_map_entry,
                             ulong                  curr_slot ) {
@@ -801,14 +801,14 @@ prepare_new_block_execution( fd_replay_tile_ctx_t * ctx,
     FD_LOG_ERR(( "slot history read failed" ));
   }
 
-  FD_LOG_NOTICE(("Current leader: %32J", fork->slot_ctx.leader->uc));
+  FD_LOG_NOTICE(("Current leader: %s", FD_BASE58_ENC_32_ALLOCA( fork->slot_ctx.leader->uc ) ));
   if( is_new_epoch_in_new_block ) {
     publish_stake_weights( ctx, mux, &fork->slot_ctx );
   }
 
   prepare_time_ns += fd_log_wallclock();
   FD_LOG_DEBUG(("TIMING: prepare_time - slot: %lu, elapsed: %6.6f ms", curr_slot, (double)prepare_time_ns * 1e-6));
-  
+
   return fork;
 }
 
@@ -1240,7 +1240,7 @@ init_after_snapshot( fd_replay_tile_ctx_t * ctx ) {
   ulong snapshot_slot = ctx->slot_ctx->slot_bank.slot;
   if( FD_UNLIKELY( !snapshot_slot ) ) {
     fd_runtime_update_leaders(ctx->slot_ctx, ctx->slot_ctx->slot_bank.slot);
-    FD_LOG_WARNING(("Updated leader %32J", ctx->slot_ctx->leader->uc));
+    FD_LOG_WARNING(( "Updated leader %s", FD_BASE58_ENC_32_ALLOCA( ctx->slot_ctx->leader->uc) ));
 
     ctx->slot_ctx->slot_bank.prev_slot = 0UL;
     ctx->slot_ctx->slot_bank.slot = 1UL;

--- a/src/app/fdctl/run/tiles/fd_sender.c
+++ b/src/app/fdctl/run/tiles/fd_sender.c
@@ -35,9 +35,6 @@
 
 #include "../../../../util/net/fd_net_headers.h"
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 #define SCRATCH_MAX    (4UL /*KiB*/ << 10)
 #define SCRATCH_DEPTH  (4UL) /* 4 scratch frames */
 

--- a/src/app/fdctl/run/tiles/fd_store_int.c
+++ b/src/app/fdctl/run/tiles/fd_store_int.c
@@ -35,9 +35,6 @@
 #include "../../../../disco/metrics/fd_metrics.h"
 #include "../../../../disco/metrics/generated/fd_metrics_replay.h"
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 #define STAKE_IN_IDX    0
 #define REPAIR_IN_IDX   1
 
@@ -413,12 +410,12 @@ fd_store_tile_slot_prepare( fd_store_tile_ctx_t * ctx,
       if( FD_UNLIKELY( fd_trusted_slots_find( ctx->trusted_slots, slot ) ) ) {
         /* if is caught up and is leader */
         replay_sig = fd_disco_replay_sig( slot, REPLAY_FLAG_FINISHED_BLOCK );
-        FD_LOG_INFO(( "packed block prepared - slot: %lu, mblks: %lu, blockhash: %32J, txn_cnt: %lu, shred_cnt: %lu, data_sz: %lu", slot, block->micros_cnt, block_hash->uc, block->txns_cnt, block->shreds_cnt, block->data_sz ));
+        FD_LOG_INFO(( "packed block prepared - slot: %lu, mblks: %lu, blockhash: %s, txn_cnt: %lu, shred_cnt: %lu, data_sz: %lu", slot, block->micros_cnt, FD_BASE58_ENC_32_ALLOCA( block_hash->uc ), block->txns_cnt, block->shreds_cnt, block->data_sz ));
       } else {
-        
+
         fd_txn_p_t * txns = fd_type_pun( out_buf );
         FD_LOG_DEBUG(( "first turbine: %lu, current received turbine: %lu, behind: %lu current "
-                        "executed: %lu, caught up: %d",
+                        "executed: %lu, caught up: %lu",
                         ctx->store->first_turbine_slot,
                         ctx->store->curr_turbine_slot,
                         behind,
@@ -454,7 +451,7 @@ fd_store_tile_slot_prepare( fd_store_tile_ctx_t * ctx,
           FD_LOG_WARNING(("FINISHED BLOCK %lu", slot ));
           replay_sig = fd_disco_replay_sig( slot, REPLAY_FLAG_FINISHED_BLOCK | REPLAY_FLAG_MICROBLOCK | caught_up_flag );
         }
-        FD_LOG_INFO(( "block prepared - slot: %lu, mblks: %lu, blockhash: %32J, txn_cnt: %lu, shred_cnt: %lu", slot, block->micros_cnt, block_hash->uc, txn_cnt, block->shreds_cnt ));
+        FD_LOG_INFO(( "block prepared - slot: %lu, mblks: %lu, blockhash: %s, txn_cnt: %lu, shred_cnt: %lu", slot, block->micros_cnt, FD_BASE58_ENC_32_ALLOCA( block_hash->uc ), txn_cnt, block->shreds_cnt ));
       }
 
       out_buf += sizeof(ulong);

--- a/src/choreo/forks/fd_forks.c
+++ b/src/choreo/forks/fd_forks.c
@@ -6,9 +6,6 @@
 #include "../../flamenco/runtime/program/fd_program_util.h"
 #include "../../flamenco/runtime/program/fd_vote_program.h"
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 void *
 fd_forks_new( void * shmem, ulong max, ulong seed ) {
 
@@ -254,10 +251,10 @@ slot_ctx_restore( ulong                 slot,
   // signature_cnt, account_delta_hash, prev_banks_hash are used for the banks
   // hash calculation and not needed when restoring parent
 
-  FD_LOG_NOTICE(( "recovered slot_bank for slot=%lu banks_hash=%32J poh_hash %32J",
+  FD_LOG_NOTICE(( "recovered slot_bank for slot=%lu banks_hash=%s poh_hash %s",
                    slot_ctx_out->slot_bank.slot,
-                   slot_ctx_out->slot_bank.banks_hash.hash,
-                   slot_ctx_out->slot_bank.poh.hash ));
+                   FD_BASE58_ENC_32_ALLOCA( slot_ctx_out->slot_bank.banks_hash.hash ),
+                   FD_BASE58_ENC_32_ALLOCA( slot_ctx_out->slot_bank.poh.hash ) ));
 
   /* Prepare bank for next slot */
   slot_ctx_out->slot_bank.slot                     = slot;

--- a/src/choreo/ghost/fd_ghost.c
+++ b/src/choreo/ghost/fd_ghost.c
@@ -2,9 +2,6 @@
 #include "stdio.h"
 #include <string.h>
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 /* clang-format off */
 
 void *
@@ -279,7 +276,7 @@ fd_ghost_head( fd_ghost_t const * ghost ) {
 
 fd_ghost_node_t const *
 fd_ghost_replay_vote( fd_ghost_t * ghost, ulong slot, fd_pubkey_t const * pubkey, ulong stake ) {
-  FD_LOG_DEBUG(( "[%s] slot %lu, pubkey %32J, stake %lu", __func__, slot, pubkey, stake ));
+  FD_LOG_DEBUG(( "[%s] slot %lu, pubkey %s, stake %lu", __func__, slot, FD_BASE58_ENC_32_ALLOCA( pubkey ), stake ));
 
 #if FD_GHOST_USE_HANDHOLDING
   if( FD_UNLIKELY( slot < ghost->root->slot ) ) {
@@ -333,16 +330,16 @@ fd_ghost_replay_vote( fd_ghost_t * ghost, ulong slot, fd_pubkey_t const * pubkey
 
     if( FD_UNLIKELY( !node ) ) {
 
-      FD_LOG_NOTICE(( "[ghost] %32J's latest vote slot %lu was too old and already pruned.",
-                      pubkey,
+      FD_LOG_NOTICE(( "[ghost] %s's latest vote slot %lu was too old and already pruned.",
+                      FD_BASE58_ENC_32_ALLOCA( pubkey ),
                       latest_vote->slot ));
 
     } else {
 
       /* Subtract pubkey's stake from the prev voted slot hash and propagate. */
 
-      FD_LOG_DEBUG(( "[ghost] removing (%32J, %lu, %lu)",
-                      pubkey,
+      FD_LOG_DEBUG(( "[ghost] removing (%s, %lu, %lu)",
+                      FD_BASE58_ENC_32_ALLOCA( pubkey ),
                       latest_vote->stake,
                       latest_vote->slot ));
 
@@ -394,7 +391,7 @@ fd_ghost_replay_vote( fd_ghost_t * ghost, ulong slot, fd_pubkey_t const * pubkey
   /* Propagate the vote stake up the ancestry, including updating the
      head. */
 
-  FD_LOG_DEBUG(( "[ghost] adding (%32J, %lu, %lu)", pubkey, stake, latest_vote->slot ));
+  FD_LOG_DEBUG(( "[ghost] adding (%s, %lu, %lu)", FD_BASE58_ENC_32_ALLOCA( pubkey ), stake, latest_vote->slot ));
   int cf = __builtin_uaddl_overflow( node->stake, latest_vote->stake, &node->stake );
   if( FD_UNLIKELY( cf ) ) {
     FD_LOG_ERR(( "[%s] add overflow. node->stake %lu latest_vote->stake %lu",
@@ -440,7 +437,7 @@ fd_ghost_gossip_vote( FD_PARAM_UNUSED fd_ghost_t *        ghost,
 
 fd_ghost_node_t const *
 fd_ghost_rooted_vote( fd_ghost_t * ghost, ulong root, fd_pubkey_t const * pubkey, ulong stake ) {
-  FD_LOG_DEBUG(( "[%s] root %lu, pubkey %32J, stake %lu", __func__, root, pubkey, stake ));
+  FD_LOG_DEBUG(( "[%s] root %lu, pubkey %s, stake %lu", __func__, root, FD_BASE58_ENC_32_ALLOCA( pubkey ), stake ));
 
 #if FD_GHOST_USE_HANDHOLDING
   if( FD_UNLIKELY( root < ghost->root->slot ) ) {
@@ -462,7 +459,7 @@ fd_ghost_rooted_vote( fd_ghost_t * ghost, ulong root, fd_pubkey_t const * pubkey
 
 #if FD_GHOST_USE_HANDHOLDING
   if( FD_UNLIKELY( !node ) ) {
-    FD_LOG_ERR(( "[%s] invariant violation. missing voter %32J's root %lu.", __func__, pubkey, root ));
+    FD_LOG_ERR(( "[%s] invariant violation. missing voter %s's root %lu.", __func__, FD_BASE58_ENC_32_ALLOCA( pubkey ), root ));
   }
 #endif
 

--- a/src/choreo/tower/fd_tower.c
+++ b/src/choreo/tower/fd_tower.c
@@ -219,11 +219,11 @@ fd_tower_init( fd_tower_t *                tower,
                                                               &vote_state_versioned );
     if( FD_LIKELY( vote_state ) ) {
       fd_tower_from_vote_state( tower, vote_state );
-      FD_LOG_NOTICE(( "[%s] loading vote state for vote acc: %32J", __func__, vote_acc_addr ));
+      FD_LOG_NOTICE(( "[%s] loading vote state for vote acc: %s", __func__, FD_BASE58_ENC_32_ALLOCA( vote_acc_addr ) ));
     } else {
-      FD_LOG_WARNING(( "[%s] didn't find existing vote state for vote acc: %32J",
+      FD_LOG_WARNING(( "[%s] didn't find existing vote state for vote acc: %s",
                        __func__,
-                       vote_acc_addr ));
+                       FD_BASE58_ENC_32_ALLOCA( vote_acc_addr ) ));
     }
   }
   FD_SCRATCH_SCOPE_END;
@@ -235,8 +235,6 @@ fd_tower_init( fd_tower_t *                tower,
   /* Init the smr. */
 
   tower->smr = smr;
-
-  return;
 }
 
 int
@@ -384,9 +382,9 @@ fd_tower_threshold_check( fd_tower_t const * tower,
                                                                 fd_scratch_virtual(),
                                                                 &vote_state_versioned );
       if( FD_UNLIKELY( !vote_state ) ) {
-        FD_LOG_WARNING(( "[%s] failed to load vote acc addr %32J. skipping.",
+        FD_LOG_WARNING(( "[%s] failed to load vote acc addr %s. skipping.",
                          __func__,
-                         vote_acc->addr ));
+                         FD_BASE58_ENC_32_ALLOCA( vote_acc->addr ) ));
         continue;
       }
 
@@ -724,9 +722,9 @@ fd_tower_fork_update( fd_tower_t const * tower,
                                                                 fd_scratch_virtual(),
                                                                 &vote_state_versioned );
       if( FD_UNLIKELY( !vote_state ) ) {
-        FD_LOG_WARNING(( "[%s] failed to load vote acc addr %32J. skipping.",
+        FD_LOG_WARNING(( "[%s] failed to load vote acc addr %s. skipping.",
                          __func__,
-                         vote_acc->addr ));
+                         FD_BASE58_ENC_32_ALLOCA( vote_acc->addr ) ));
         continue;
       }
 
@@ -927,23 +925,23 @@ fd_tower_vote_state_query( FD_PARAM_UNUSED fd_tower_t const * tower,
   FD_BORROWED_ACCOUNT_DECL( vote_acc );
   rc = fd_acc_mgr_view( acc_mgr, fork->slot_ctx.funk_txn, vote_acc_addr, vote_acc );
   if( FD_UNLIKELY( rc == FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT ) ) {
-    FD_LOG_WARNING(( "[%s] fd_acc_mgr_view could not find vote account %32J. error: %d",
+    FD_LOG_WARNING(( "[%s] fd_acc_mgr_view could not find vote account %s. error: %d",
                      __func__,
-                     vote_acc_addr,
+                     FD_BASE58_ENC_32_ALLOCA( vote_acc_addr ),
                      rc ));
     return NULL;
   } else if( FD_UNLIKELY( rc != FD_ACC_MGR_SUCCESS ) ) {
-    FD_LOG_ERR(( "[%s] fd_acc_mgr_view failed on vote account %32J. error: %d",
+    FD_LOG_ERR(( "[%s] fd_acc_mgr_view failed on vote account %s. error: %d",
                  __func__,
-                 vote_acc_addr,
+                 FD_BASE58_ENC_32_ALLOCA( vote_acc_addr ),
                  rc ));
   }
 
   rc = fd_vote_get_state( vote_acc, valloc, versioned );
   if( FD_UNLIKELY( rc != FD_ACC_MGR_SUCCESS ) ) {
-    FD_LOG_ERR(( "[%s] fd_vote_get_state failed on vote account %32J. error: %d",
+    FD_LOG_ERR(( "[%s] fd_vote_get_state failed on vote account %s. error: %d",
                  __func__,
-                 vote_acc_addr,
+                 FD_BASE58_ENC_32_ALLOCA( vote_acc_addr ),
                  rc ));
   }
 

--- a/src/choreo/tower/fd_tower.h
+++ b/src/choreo/tower/fd_tower.h
@@ -334,7 +334,7 @@
 
      2. We have a latest vote slot that is older than the SMR, meaning
         the cluster has rooted past our latest vote.  This can happen
-        when we don't vote for a while (eg. this validator was not
+        when we don't vote for a while (e.g. this validator was not
         running or we were stuck waiting for lockouts.)
    */
 
@@ -342,9 +342,6 @@
 #include "../fd_choreo_base.h"
 #include "../forks/fd_forks.h"
 #include "../ghost/fd_ghost.h"
-
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
 
 #define FD_TOWER_EQV_SAFE ( 0.52 )
 #define FD_TOWER_OPT_CONF ( 2.0 / 3.0 )

--- a/src/choreo/voter/fd_voter.c
+++ b/src/choreo/voter/fd_voter.c
@@ -2,9 +2,6 @@
 
 #include <string.h>
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 void *
 fd_voter_new( void * shmem ) {
   if( FD_UNLIKELY( !shmem ) ) {
@@ -75,7 +72,7 @@ fd_voter_txn_generate( fd_voter_t const *                     voter,
                        fd_hash_t const *                      recent_blockhash,
                        uchar                                  txn_meta_out[static FD_TXN_MAX_SZ],
                        uchar                                  txn_out[static FD_TXN_MTU] ) {
-  FD_LOG_NOTICE( ( "[%s]: vote acc addr %32J", __func__, &voter->vote_acc_addr ) );
+  FD_LOG_NOTICE(( "[%s]: vote acc addr %s", __func__, FD_BASE58_ENC_32_ALLOCA( &voter->vote_acc_addr ) ));
 
   int same_addr = !memcmp( &voter->validator_identity,
                            &voter->vote_authority,
@@ -181,9 +178,9 @@ fd_voter_txn_generate( fd_voter_t const *                     voter,
 //   if( FD_UNLIKELY( memcmp( program_account_addr,
 //                            fd_solana_vote_program_id.key,
 //                            sizeof( fd_pubkey_t ) ) ) ) {
-//     FD_LOG_WARNING( ( "[fd_voter_txn_parse] txn program %32J was not vote program id %32J",
-//                       program_account_addr,
-//                       fd_solana_vote_program_id.key ) );
+//     FD_LOG_WARNING(( "[fd_voter_txn_parse] txn program %s was not vote program id %s",
+//                      FD_BASE58_ENC_32_ALLOCA( program_account_addr ),
+//                      FD_BASE58_ENC_32_ALLOCA( fd_solana_vote_program_id.key ) ));
 //     return -1;
 //   }
 

--- a/src/choreo/voter/test_voter.c
+++ b/src/choreo/voter/test_voter.c
@@ -6,9 +6,6 @@
 #include "../../util/fd_util.h"
 #include <sys/random.h>
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 #define TEST_VOTE_TXN_MAGIC ( 0x7e58UL )
 
 void
@@ -57,11 +54,10 @@ main( int argc, char ** argv ) {
   FD_PARAM_UNUSED fd_valloc_t  valloc        = fd_alloc_virtual( alloc );
 
   /* create compact_vote_state_update with dummy values */
-  fd_compact_vote_state_update_t compact_vote_update;
-  memset( &compact_vote_update, 0, sizeof( fd_compact_vote_state_update_t ) );
-  compact_vote_update.root          = 100;
-  compact_vote_update.lockouts_len  = 0;
-  static long now                   = 1715701506716580798L;
+  fd_compact_vote_state_update_t compact_vote_update = {0};
+  compact_vote_update.root         = 100;
+  compact_vote_update.lockouts_len = 0;
+  static long now                  = 1715701506716580798L;
   compact_vote_update.has_timestamp = 1;
   compact_vote_update.timestamp     = now;
   FD_TEST( 32UL == getrandom( compact_vote_update.hash.key, 32UL, 0 ) );
@@ -92,14 +88,14 @@ main( int argc, char ** argv ) {
   //                                            valloc,
   //                                            &parsed_recent_blockhash_off,
   //                                            &parsed_vote_update ) );
-  // FD_LOG_NOTICE( ( "recent blockhash: %32J == %32J",
-  //                  recent_blockhash,
-  //                  txn_buf + parsed_recent_blockhash_off ) );
-  // FD_LOG_NOTICE( ( "root: %ld == %ld", compact_vote_update.root, parsed_vote_update.root ) );
-  // FD_LOG_NOTICE( ( "timestamp: %lu == %lu",
-  //                  *compact_vote_update.timestamp,
-  //                  *parsed_vote_update.timestamp ) );
-  // FD_LOG_NOTICE( ( "hash: %32J == %32J",
-  //                  compact_vote_update.hash.key,
-  //                  parsed_vote_update.hash.key ) );
+  // FD_LOG_NOTICE(( "recent blockhash: %s == %s",
+  //                 FD_BASE58_ENC_32_ALLOCA( recent_blockhash ),
+  //                 FD_BASE58_ENC_32_ALLOCA( txn_buf + parsed_recent_blockhash_off ) ));
+  // FD_LOG_NOTICE(( "root: %ld == %ld", compact_vote_update.root, parsed_vote_update.root ) );
+  // FD_LOG_NOTICE(( "timestamp: %lu == %lu",
+  //                 *compact_vote_update.timestamp,
+  //                 *parsed_vote_update.timestamp ) );
+  // FD_LOG_NOTICE(( "hash: %s == %s",
+  //                 FD_BASE58_ENC_32_ALLOCA( compact_vote_update.hash.key ),
+  //                 FD_BASE58_ENC_32_ALLOCA( parsed_vote_update.hash.key ) ));
 }

--- a/src/disco/consensus/test_consensus.c
+++ b/src/disco/consensus/test_consensus.c
@@ -30,9 +30,6 @@
 // #include "../../util/fd_util.h"
 // #include "../../util/net/fd_eth.h"
 
-// #pragma GCC diagnostic ignored "-Wformat"
-// #pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 // #define MAX_ADDR_STRLEN      128
 // #define TEST_CONSENSUS_MAGIC ( 0x7e57UL ) /* test */
 
@@ -171,8 +168,8 @@
 //                          void *              arg,
 //                          int                 reason ) {
 //   (void)arg;
-//   FD_LOG_WARNING( ( "repair_deliver_fail_fun - shred: %32J, slot: %lu, idx: %u, reason: %d",
-//                     id,
+//   FD_LOG_WARNING( ( "repair_deliver_fail_fun - shred: %s, slot: %lu, idx: %u, reason: %d",
+//                     FD_BASE58_ENC_32_ALLOCA( id ),
 //                     slot,
 //                     shred_index,
 //                     reason ) );

--- a/src/disco/poh/fd_poh_tile.c
+++ b/src/disco/poh/fd_poh_tile.c
@@ -1,8 +1,5 @@
 #include "fd_poh_tile.h"
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 ulong
 fd_poh_tile_align( void ) {
   return 128UL;

--- a/src/flamenco/capture/fd_solcap_yaml.c
+++ b/src/flamenco/capture/fd_solcap_yaml.c
@@ -8,9 +8,6 @@
 #include <errno.h>
 #include <stdio.h>
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 static int
 usage( void ) {
   fprintf( stderr,
@@ -94,13 +91,13 @@ process_account( FILE * file,
   } while(0);
 
   printf(
-    "      owner:      '%32J'\n"
+    "      owner:      '%s'\n"
     "      lamports:   %lu\n"
     "      slot:       %lu\n"
     "      rent_epoch: %lu\n"
     "      executable: %s\n"
     "      data_sz:    %lu\n",
-    meta->owner,
+    FD_BASE58_ENC_32_ALLOCA( meta->owner ),
     meta->lamports,
     meta->slot,
     meta->rent_epoch,
@@ -262,13 +259,13 @@ process_account_table( FILE * file,
     /* Write to YAML */
 
     printf(
-      "    - pubkey:   '%32J'\n"
-      "      hash:     '%32J'\n"
-      "      explorer: 'https://explorer.solana.com/block/%lu?accountFilter=%32J&filter=all'\n",
-      entry->key,
-      entry->hash,
+      "    - pubkey:   '%s'\n"
+      "      hash:     '%s'\n"
+      "      explorer: 'https://explorer.solana.com/block/%lu?accountFilter=%s&filter=all'\n",
+      FD_BASE58_ENC_32_ALLOCA( entry->key ),
+      FD_BASE58_ENC_32_ALLOCA( entry->hash ),
       slot,
-      entry->key );
+      FD_BASE58_ENC_32_ALLOCA( entry->key ) );
 
     /* Fetch account details */
 
@@ -307,7 +304,7 @@ process_bank( fd_solcap_chunk_t const * chunk,
 
 # define FD_SOLCAP_BANK_PREIMAGE_FOOTPRINT (512UL)
   if( FD_UNLIKELY( chunk->meta_sz > FD_SOLCAP_BANK_PREIMAGE_FOOTPRINT ) ) {
-    FD_LOG_ERR(( "invalid bank preimage meta size (%lu)", chunk->meta_sz ));
+    FD_LOG_ERR(( "invalid bank preimage meta size (%u)", chunk->meta_sz ));
     return ENOMEM;
   }
 
@@ -343,18 +340,18 @@ process_bank( fd_solcap_chunk_t const * chunk,
     printf( "- slot: %lu\n", meta.slot );
 
   printf(
-      "  - bank_hash:          '%32J'\n",
-      meta.bank_hash );
+      "  - bank_hash:          '%s'\n",
+      FD_BASE58_ENC_32_ALLOCA( meta.bank_hash ) );
 
   if( verbose>=1 ) {
     printf(
-      "  - prev_bank_hash:     '%32J'\n"
-      "  - account_delta_hash: '%32J'\n"
-      "  - poh_hash:           '%32J'\n"
+      "  - prev_bank_hash:     '%s'\n"
+      "  - account_delta_hash: '%s'\n"
+      "  - poh_hash:           '%s'\n"
       "  - signature_cnt:      %lu\n",
-      meta.prev_bank_hash,
-      meta.account_delta_hash,
-      meta.poh_hash,
+      FD_BASE58_ENC_32_ALLOCA( meta.prev_bank_hash ),
+      FD_BASE58_ENC_32_ALLOCA( meta.account_delta_hash ),
+      FD_BASE58_ENC_32_ALLOCA( meta.poh_hash ),
       meta.signature_cnt );
   }
 
@@ -394,7 +391,7 @@ if ( verbose < 3 )
 
 # define FD_SOLCAP_TRANSACTION_FOOTPRINT (128UL)
   if( FD_UNLIKELY( chunk->meta_sz > FD_SOLCAP_TRANSACTION_FOOTPRINT ) ) {
-    FD_LOG_ERR(( "invalid transaction meta size (%lu)", chunk->meta_sz ));
+    FD_LOG_ERR(( "invalid transaction meta size (%u)", chunk->meta_sz ));
   }
 
   /* Read transaction meta */
@@ -434,7 +431,7 @@ if ( verbose < 3 )
     "      txn_err:         %d\n"
     "      cus_used:        %lu\n"
     "      instr_err_idx:   %d\n",
-    FD_BASE58_ENCODE_64( meta.txn_sig ),
+    FD_BASE58_ENC_64_ALLOCA( meta.txn_sig ),
     meta.fd_txn_err,
     meta.fd_cus_used,
     meta.instr_err_idx);
@@ -459,9 +456,9 @@ if ( verbose < 3 )
     "      explorer:       'https://explorer.solana.com/tx/%s'\n"
     "      solscan:        'https://solscan.io/tx/%s'\n"
     "      solanafm:       'https://solana.fm/tx/%s'\n",
-    FD_BASE58_ENCODE_64( meta.txn_sig ),
-    FD_BASE58_ENCODE_64( meta.txn_sig ),
-    FD_BASE58_ENCODE_64( meta.txn_sig ) );
+    FD_BASE58_ENC_64_ALLOCA( meta.txn_sig ),
+    FD_BASE58_ENC_64_ALLOCA( meta.txn_sig ),
+    FD_BASE58_ENC_64_ALLOCA( meta.txn_sig ) );
 
   return meta.slot;
 }

--- a/src/flamenco/fd_flamenco.c
+++ b/src/flamenco/fd_flamenco.c
@@ -1,92 +1,12 @@
 #include "fd_flamenco_base.h"
-#include <stdio.h>
-#include <string.h>
-
-/* glibc specific *****************************************************/
-
-#if defined(__GLIBC__)
-
-#include <printf.h>
-#include "../ballet/base58/fd_base58.h"
-
-/* Deprecated, use FD_BASE58_ENCODE_{32,64} instead */
-FD_FN_NO_MSAN static int
-fd_printf_specifier_base58( FILE *                     stream,
-                            struct printf_info const * info,
-                            void const * const *       args ) {
-
-  void const * mem = *((void const * const *)args[0]);
-  char out[ FD_BASE58_ENCODED_64_SZ ];
-
-  if( FD_UNLIKELY( !mem ) )
-    return fprintf( stream, "<NULL>" );
-
-  switch( info->width ) {
-  case 32:
-    fd_base58_encode_32( mem, NULL, out );
-    break;
-  case 64:
-    fd_base58_encode_64( mem, NULL, out );
-    break;
-  default:
-    return fprintf( stream, "<unsupported Base58 width>" );
-  }
-  return fprintf( stream, "%s", out );
-}
-
-static int
-fd_printf_specifier_base58_arginfo( struct printf_info const * info __attribute__((unused)),
-                                    ulong                      n,
-                                    int *                      argtypes,
-                                    int *                      size ) {
-  if( FD_LIKELY( n>=1UL ) ) {
-    argtypes[ 0 ] = PA_POINTER;
-    size    [ 0 ] = sizeof(void *);
-  }
-  return 1;
-}
-
-#if FD_HAS_INT128
-
-static int
-fd_printf_specifier_uint128( FILE *                     stream,
-                            struct printf_info const * info FD_PARAM_UNUSED,
-                            void const * const *       args ) {
-
-  uint128 const * num = *((uint128 const * const *)args[0]);
-  char out[40];
-
-  fd_cstr_append_uint128_as_text( out, ' ', '\0', *num, 40 );
-
-  return fprintf( stream, "%s", out );
-}
-
-static int
-fd_printf_specifier_uint128_arginfo( struct printf_info const * info __attribute__((unused)),
-                                    ulong                      n,
-                                    int *                      argtypes,
-                                    int *                      size ) {
-  if( FD_LIKELY( n>=1UL ) ) {
-    argtypes[ 0 ] = PA_POINTER;
-    size    [ 0 ] = sizeof(void *);
-  }
-  return 1;
-}
-
-#endif
-
-#endif
 
 void
 fd_flamenco_boot( int *    pargc __attribute__((unused)),
                   char *** pargv __attribute__((unused)) ) {
-  #if defined(__GLIBC__)
-  FD_TEST( 0==register_printf_specifier( 'J', fd_printf_specifier_base58, fd_printf_specifier_base58_arginfo ) );
-  # if FD_HAS_INT128
-  FD_TEST( 0==register_printf_specifier( 'K', fd_printf_specifier_uint128, fd_printf_specifier_uint128_arginfo ) );
-  #endif
-  #endif
-  /* TODO implement printf specifiers for non-glibc */
+  /* Since the removal of custom format string specifiers there is no
+     technical need for boot/halt anymore.  However, if such a need arises in
+     the future it is good to have the functions and calls to it in place.
+     Until then these are no-ops. */
 }
 
 void

--- a/src/flamenco/fd_flamenco_base.h
+++ b/src/flamenco/fd_flamenco_base.h
@@ -24,25 +24,38 @@
 #define FD_DEFAULT_AGAVE_CLUSTER_VERSION_MINOR 0
 #define FD_DEFAULT_AGAVE_CLUSTER_VERSION_PATCH 0
 
-/* FD_BASE58_ENCODE_{32,64} is a shorthand for fd_base58_encode_{32,64},
-   including defining a temp buffer.  Useful for printf-like functions.
+/* FD_BASE58_ENC_{32,64}_ALLOCA is a shorthand for fd_base58_encode_{32,64},
+   including defining a temp buffer.  With additional support for passing
+   NULL.  Useful for printf-like functions.
    Example:
 
     fd_pubkey_t pk = ... ;
-    printf("%s", FD_BASE58_ENCODE_32( pk ) );
+    printf("%s", FD_BASE58_ENC_32_ALLOCA( pk ) );
 
    The temp buffer is allocated on the stack and therefore invalidated
-   when the function this is used in returns. */
-#define FD_BASE58_ENCODE_32( x ) __extension__({           \
-  char *_out = (char *)alloca( FD_BASE58_ENCODED_32_SZ );  \
-  fd_base58_encode_32( (uchar const *)(x), NULL, _out );   \
+   when the function this is used in returns.  NULL will result in
+   "<NULL>".
+   Do NOT use this marco in a long loop or a recursive function.
+   */
+#define FD_BASE58_ENC_32_ALLOCA( x ) __extension__({                     \
+  char *_out = (char *)fd_alloca_check( 1UL, FD_BASE58_ENCODED_32_SZ );  \
+  if( FD_UNLIKELY( x == NULL ) ) {                                       \
+    strcpy(_out, "<NULL>");                                              \
+  } else {                                                               \
+    fd_base58_encode_32( (uchar const *)(x), NULL, _out );               \
+  }                                                                      \
+  _out;                                                                  \
 })
 
-#define FD_BASE58_ENCODE_64( x ) __extension__({           \
-  char *_out = (char *)alloca( FD_BASE58_ENCODED_64_SZ );  \
-  fd_base58_encode_64( (uchar const *)(x), NULL, _out );   \
+#define FD_BASE58_ENC_64_ALLOCA( x ) __extension__({                    \
+  char *_out = (char *)fd_alloca_check( 1UL, FD_BASE58_ENCODED_64_SZ ); \
+  if( FD_UNLIKELY( x == NULL ) ) {                                      \
+    strcpy(_out, "<NULL>");                                             \
+  } else {                                                              \
+    fd_base58_encode_64( (uchar const *)(x), NULL, _out );              \
+  }                                                                     \
+  _out;                                                                 \
 })
-
 
 /* Forward declarations */
 

--- a/src/flamenco/repair/fd_repair.c
+++ b/src/flamenco/repair/fd_repair.c
@@ -14,9 +14,6 @@
 
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 /* Max number of validators that can be actively queried */
 #define FD_ACTIVE_KEY_MAX (1<<12)
 /* Max number of pending shred requests */
@@ -386,7 +383,7 @@ fd_repair_add_active_peer( fd_repair_t * glob, fd_repair_peer_addr_t const * add
     val->first_request_time = 0;
     val->permanent = 0;
     val->stake = 0UL;
-    FD_LOG_DEBUG( ( "adding repair peer %32J", val->key.uc ) );
+    FD_LOG_DEBUG(( "adding repair peer %s", FD_BASE58_ENC_32_ALLOCA( val->key.uc ) ));
   }
   fd_repair_unlock( glob );
   return 0;
@@ -946,12 +943,12 @@ print_stats( fd_active_elem_t * val ) {
   fd_pubkey_t const * id = &val->key;
   if( FD_UNLIKELY( NULL == val ) ) return;
   if( val->avg_reqs == 0 )
-    FD_LOG_DEBUG(( "repair peer %32J: no requests sent, stake=%lu", id, val->stake / (ulong)1e9 ));
+    FD_LOG_DEBUG(( "repair peer %s: no requests sent, stake=%lu", FD_BASE58_ENC_32_ALLOCA( id ), val->stake / (ulong)1e9 ));
   else if( val->avg_reps == 0 )
-    FD_LOG_DEBUG(( "repair peer %32J: avg_requests=%lu, no responses received, stake=%lu", id, val->avg_reqs, val->stake / (ulong)1e9 ));
+    FD_LOG_DEBUG(( "repair peer %s: avg_requests=%lu, no responses received, stake=%lu", FD_BASE58_ENC_32_ALLOCA( id ), val->avg_reqs, val->stake / (ulong)1e9 ));
   else
-    FD_LOG_DEBUG(( "repair peer %32J: avg_requests=%lu, response_rate=%f, latency=%f, stake=%lu",
-                    id,
+    FD_LOG_DEBUG(( "repair peer %s: avg_requests=%lu, response_rate=%f, latency=%f, stake=%lu",
+                    FD_BASE58_ENC_32_ALLOCA( id ),
                     val->avg_reqs,
                     ((double)val->avg_reps)/((double)val->avg_reqs),
                     1.0e-9*((double)val->avg_lat)/((double)val->avg_reps),
@@ -1106,7 +1103,7 @@ fd_repair_recv_serv_packet(fd_repair_t * glob, uchar const * msg, ulong msglen, 
     }
 
     if( !fd_hash_eq( &header->recipient, glob->public_key ) ) {
-      FD_LOG_WARNING(( "received repair request with wrong recipient, %32J instead of %32J", header->recipient.uc, glob->public_key ));
+      FD_LOG_WARNING(( "received repair request with wrong recipient, %s instead of %s", FD_BASE58_ENC_32_ALLOCA( header->recipient.uc ), FD_BASE58_ENC_32_ALLOCA( glob->public_key ) ));
       return 0;
     }
 

--- a/src/flamenco/repair/fd_repair_tool.c
+++ b/src/flamenco/repair/fd_repair_tool.c
@@ -26,9 +26,6 @@
 #include <netdb.h>
 #include <stdlib.h>
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 // SIGINT signal handler
 volatile int stopflag = 0;
 static void stop(int sig) { (void)sig; stopflag = 1; }
@@ -252,11 +249,11 @@ deliver_fail_fun( fd_pubkey_t const * id,
                          void *              arg,
                          int                 reason ) {
   (void)arg;
-  FD_LOG_WARNING( ( "repair_deliver_fail_fun - shred: %32J, slot: %lu, idx: %u, reason: %d",
-                    id,
+  FD_LOG_WARNING(( "repair_deliver_fail_fun - shred: %s, slot: %lu, idx: %u, reason: %d",
+                    FD_BASE58_ENC_32_ALLOCA( id ),
                     slot,
                     shred_index,
-                    reason ) );
+                    reason ));
 }
 
 int main(int argc, char **argv) {

--- a/src/flamenco/rewards/fd_rewards.c
+++ b/src/flamenco/rewards/fd_rewards.c
@@ -8,9 +8,6 @@
 #include "../../ballet/siphash13/fd_siphash13.h"
 #include "../runtime/program/fd_program_util.h"
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 /* https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/sdk/program/src/native_token.rs#L6 */
 #define LAMPORTS_PER_SOL   ( 1000000000UL )
 
@@ -360,11 +357,11 @@ calculate_reward_points_partitioned(
                 continue;
             }
             if ( err == FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT ) {
-                FD_LOG_DEBUG(( "stake account not found %32J", stake_acc->uc ));
+                FD_LOG_DEBUG(( "stake account not found %s", FD_BASE58_ENC_32_ALLOCA( stake_acc->uc ) ));
                 continue;
             }
             if ( stake_acc_rec->const_meta->info.lamports == 0 ) {
-                FD_LOG_DEBUG(( "stake acc with zero lamports %32J", stake_acc->uc));
+                FD_LOG_DEBUG(( "stake acc with zero lamports %s", FD_BASE58_ENC_32_ALLOCA( stake_acc->uc ) ));
                 continue;
             }
 
@@ -444,11 +441,11 @@ calculate_reward_points_partitioned(
                 continue;
             }
             if ( err == FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT ) {
-                FD_LOG_DEBUG(( "stake account not found %32J", stake_acc->uc ));
+                FD_LOG_DEBUG(( "stake account not found %s", FD_BASE58_ENC_32_ALLOCA( stake_acc->uc ) ));
                 continue;
             }
             if ( stake_acc_rec->const_meta->info.lamports == 0 ) {
-                FD_LOG_DEBUG(( "stake acc with zero lamports %32J", stake_acc->uc));
+                FD_LOG_DEBUG(( "stake acc with zero lamports %s", FD_BASE58_ENC_32_ALLOCA( stake_acc->uc ) ));
                 continue;
             }
 
@@ -533,13 +530,13 @@ calculate_stake_vote_rewards_account(
 
         FD_BORROWED_ACCOUNT_DECL( stake_acc_rec );
         if( fd_acc_mgr_view( slot_ctx->acc_mgr, slot_ctx->funk_txn, stake_acc, stake_acc_rec) != 0 ) {
-            FD_LOG_DEBUG(( "Stake acc not found %32J", stake_acc->uc ));
+            FD_LOG_DEBUG(( "Stake acc not found %s", FD_BASE58_ENC_32_ALLOCA( stake_acc->uc ) ));
             return;
         }
 
         fd_stake_state_v2_t stake_state[1] = {0};
         if ( fd_stake_get_state( stake_acc_rec, &slot_ctx->valloc, stake_state ) != 0 ) {
-            FD_LOG_DEBUG(( "Failed to read stake state from stake account %32J", stake_acc ));
+            FD_LOG_DEBUG(( "Failed to read stake state from stake account %s", FD_BASE58_ENC_32_ALLOCA( stake_acc ) ));
             return;
         }
         if ( !fd_stake_state_v2_is_stake( stake_state ) ) {
@@ -583,7 +580,7 @@ calculate_stake_vote_rewards_account(
         fd_calculated_stake_rewards_t calculated_stake_rewards[1] = {0};
         int err = redeem_rewards( stake_history, stake_state, vote_state_versioned, rewarded_epoch, point_value, calculated_stake_rewards );
         if ( err != 0) {
-            FD_LOG_DEBUG(( "redeem_rewards failed for %32J with error %d", stake_acc->key, err ));
+            FD_LOG_DEBUG(( "redeem_rewards failed for %s with error %d", FD_BASE58_ENC_32_ALLOCA( stake_acc->key ), err ));
             return;
         }
 
@@ -932,7 +929,7 @@ distribute_epoch_reward_to_stake_acc(
 
     fd_stake_state_v2_t stake_state[1] = {0};
     if ( fd_stake_get_state(stake_acc_rec, &slot_ctx->valloc, stake_state) != 0 ) {
-        FD_LOG_DEBUG(( "failed to read stake state for %32J", stake_pubkey ));
+        FD_LOG_DEBUG(( "failed to read stake state for %s", FD_BASE58_ENC_32_ALLOCA( stake_pubkey ) ));
         return 1;
     }
 

--- a/src/flamenco/runtime/context/fd_exec_instr_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_instr_ctx.c
@@ -2,9 +2,6 @@
 #include "fd_exec_txn_ctx.h"
 #include "../fd_acc_mgr.h"
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 void *
 fd_exec_instr_ctx_new( void * mem ) {
   if( FD_UNLIKELY( !mem ) ) {
@@ -143,7 +140,7 @@ fd_instr_borrowed_account_modify( fd_exec_instr_ctx_t * ctx,
       // TODO: check if writable???
       if( FD_UNLIKELY( !fd_instr_acc_is_writable_idx( ctx->instr, (uchar)i ) ) ) {
         // FIXME: we should just handle the try_borrow_account semantics correctly
-        FD_LOG_DEBUG(( "unwritable account passed to fd_instr_borrowed_account_modify_idx (idx=%lu, account=%32J)", i, pubkey ));
+        FD_LOG_DEBUG(( "unwritable account passed to fd_instr_borrowed_account_modify_idx (idx=%lu, account=%s)", i, FD_BASE58_ENC_32_ALLOCA( pubkey ) ));
       }
       fd_borrowed_account_t * instr_account = ctx->instr->borrowed_accounts[i];
       if( min_data_sz > instr_account->const_meta->dlen ) {

--- a/src/flamenco/runtime/fd_acc_mgr.c
+++ b/src/flamenco/runtime/fd_acc_mgr.c
@@ -8,9 +8,6 @@
 #include "fd_system_ids.h"
 #include <assert.h>
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 fd_acc_mgr_t *
 fd_acc_mgr_new( void *      mem,
                 fd_funk_t * funk ) {
@@ -148,7 +145,7 @@ fd_acc_mgr_view( fd_acc_mgr_t *          acc_mgr,
   }
 
   if( FD_BORROWED_ACCOUNT_MAGIC != account->magic ) {
-    FD_LOG_ERR(( "bad magic for borrowed account - acc: %32J, expected: %016lx, got: %016lx", pubkey->uc, FD_BORROWED_ACCOUNT_MAGIC, account->magic ));
+    FD_LOG_ERR(( "bad magic for borrowed account - acc: %s, expected: %016lx, got: %016lx", FD_BASE58_ENC_32_ALLOCA( pubkey->uc ), FD_BORROWED_ACCOUNT_MAGIC, account->magic ));
   }
 
   fd_memcpy(account->pubkey, pubkey, sizeof(fd_pubkey_t));
@@ -191,12 +188,12 @@ fd_acc_mgr_modify_raw( fd_acc_mgr_t *        acc_mgr,
 //
 //    if( !fd_funk_key_is_acc( rec->pair.key  ) ) continue;
 //
-//    FD_LOG_DEBUG(( "fd_acc_mgr_modify_raw: %32J create: %s  rec_cnt: %d", rec->pair.key->uc, do_create ? "true" : "false", rec_cnt));
+//    FD_LOG_DEBUG(( "fd_acc_mgr_modify_raw: %s create: %s  rec_cnt: %d", FD_BASE58_ENC_32_ALLOCA( rec->pair.key->uc ), do_create ? "true" : "false", rec_cnt));
 //
 //    rec_cnt++;
 //  }
 //
-//  FD_LOG_DEBUG(( "fd_acc_mgr_modify_raw: %32J create: %s", pubkey->uc, do_create ? "true" : "false"));
+//  FD_LOG_DEBUG(( "fd_acc_mgr_modify_raw: %s create: %s", FD_BASE58_ENC_32_ALLOCA( pubkey->uc ), do_create ? "true" : "false"));
 //#endif
 
   int funk_err = FD_FUNK_SUCCESS;
@@ -208,7 +205,7 @@ fd_acc_mgr_modify_raw( fd_acc_mgr_t *        acc_mgr,
       return NULL;
     }
     /* Irrecoverable funky internal error [[noreturn]] */
-    FD_LOG_ERR(( "fd_funk_rec_write_prepare(%32J) failed (%i-%s)", pubkey->key, funk_err, fd_funk_strerror( funk_err ) ));
+    FD_LOG_ERR(( "fd_funk_rec_write_prepare(%s) failed (%i-%s)", FD_BASE58_ENC_32_ALLOCA( pubkey->key ), funk_err, fd_funk_strerror( funk_err ) ));
   }
 
   if (NULL != opt_out_rec)
@@ -251,8 +248,13 @@ fd_acc_mgr_modify( fd_acc_mgr_t *          acc_mgr,
     return FD_ACC_MGR_ERR_WRONG_MAGIC;
 
 #ifdef VLOG
-  FD_LOG_DEBUG(( "fd_acc_mgr_modify: %32J create: %s  lamports: %ld  owner: %32J  executable: %s,  rent_epoch: %ld, data_len: %ld",
-      pubkey->uc, do_create ? "true" : "false", meta->info.lamports, meta->info.owner, meta->info.executable ? "true" : "false", meta->info.rent_epoch, meta->dlen ));
+  FD_LOG_DEBUG(( "fd_acc_mgr_modify: %s create: %s  lamports: %ld  owner: %s  executable: %s,  rent_epoch: %ld, data_len: %ld",
+                 FD_BASE58_ENC_32_ALLOCA( pubkey->uc ),
+                 do_create ? "true" : "false",
+                 meta->info.lamports,
+                 FD_BASE58_ENC_32_ALLOCA( meta->info.owner ),
+                 meta->info.executable ? "true" : "false",
+                 meta->info.rent_epoch, meta->dlen ));
 #endif
 
   account->orig_rec  = account->const_rec  = account->rec;
@@ -291,7 +293,7 @@ fd_acc_mgr_save( fd_acc_mgr_t *          acc_mgr,
                  fd_borrowed_account_t * account ) {
   if( account->meta == NULL || account->rec == NULL ) {
     // The meta is NULL so the account is not writable.
-    FD_LOG_DEBUG(( "fd_acc_mgr_save: account is not writable: %32J", account->pubkey ));
+    FD_LOG_DEBUG(( "fd_acc_mgr_save: account is not writable: %s", FD_BASE58_ENC_32_ALLOCA( account->pubkey ) ));
     return FD_ACC_MGR_SUCCESS;
   }
 

--- a/src/flamenco/runtime/fd_bank_hash_cmp.c
+++ b/src/flamenco/runtime/fd_bank_hash_cmp.c
@@ -1,9 +1,6 @@
 #include "fd_bank_hash_cmp.h"
 #include <unistd.h>
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 void *
 fd_bank_hash_cmp_new( void * mem ) {
 
@@ -148,11 +145,11 @@ fd_bank_hash_cmp_insert( fd_bank_hash_cmp_t * bank_hash_cmp,
   ulong max = sizeof( cmp->stakes ) / sizeof( ulong );
   if( FD_UNLIKELY( cmp->cnt == max ) ) {
     if( !cmp->overflow ) {
-      FD_LOG_WARNING( ( "[Bank Hash Comparison] more than %lu equivocating hashes for slot %lu. "
-                        "new hash: %32J. ignoring.",
-                        max,
-                        slot,
-                        hash ) );
+      FD_LOG_WARNING(( "[Bank Hash Comparison] more than %lu equivocating hashes for slot %lu. "
+                       "new hash: %s. ignoring.",
+                       max,
+                       slot,
+                       FD_BASE58_ENC_32_ALLOCA( hash ) ));
       cmp->overflow = 1;
     }
     return;
@@ -162,11 +159,11 @@ fd_bank_hash_cmp_insert( fd_bank_hash_cmp_t * bank_hash_cmp,
   cmp->stakes[cmp->cnt - 1] = stake;
   if( FD_UNLIKELY( cmp->cnt > 1 ) ) {
     for( ulong i = 0; i < cmp->cnt; i++ ) {
-      FD_LOG_WARNING( ( "slot: %lu. equivocating hash (#%lu): %32J. stake: %lu",
+      FD_LOG_WARNING(( "slot: %lu. equivocating hash (#%lu): %s. stake: %lu",
                         cmp->slot,
                         i,
-                        cmp->theirs[i].hash,
-                        cmp->stakes[i] ) );
+                        FD_BASE58_ENC_32_ALLOCA( cmp->theirs[i].hash ),
+                        cmp->stakes[i] ));
     }
   }
 }
@@ -194,37 +191,37 @@ fd_bank_hash_cmp_check( fd_bank_hash_cmp_t * bank_hash_cmp, ulong slot ) {
   double pct = (double)stake / (double)bank_hash_cmp->total_stake;
   if( FD_LIKELY( pct > 0.52 ) ) {
     if( FD_UNLIKELY( 0 != memcmp( &cmp->ours, theirs, sizeof( fd_hash_t ) ) ) ) {
-      FD_LOG_WARNING( ( "\n\n[Bank Hash Comparison]\n"
+      FD_LOG_WARNING(( "\n\n[Bank Hash Comparison]\n"
                         "slot:   %lu\n"
-                        "ours:   %32J\n"
-                        "theirs: %32J\n"
+                        "ours:   %s\n"
+                        "theirs: %s\n"
                         "stake:  %.0lf%%\n"
                         "result: mismatch!\n",
                         cmp->slot,
-                        cmp->ours.hash,
-                        theirs->hash,
-                        pct * 100 ) );
+                        FD_BASE58_ENC_32_ALLOCA( cmp->ours.hash ),
+                        FD_BASE58_ENC_32_ALLOCA( theirs->hash ),
+                        pct * 100 ));
       if( FD_UNLIKELY( cmp->cnt > 1 ) ) {
         for( ulong i = 0; i < cmp->cnt; i++ ) {
-          FD_LOG_WARNING( ( "slot: %lu. hash (#%lu): %32J. stake: %lu",
-                            cmp->slot,
-                            i,
-                            cmp->theirs[i].hash,
-                            cmp->stakes[i] ) );
+          FD_LOG_WARNING(( "slot: %lu. hash (#%lu): %s. stake: %lu",
+                           cmp->slot,
+                           i,
+                           FD_BASE58_ENC_32_ALLOCA( cmp->theirs[i].hash ),
+                           cmp->stakes[i] ));
         }
       }
       return -1;
     } else {
-      FD_LOG_NOTICE( ( "\n\n[Bank Hash Comparison]\n"
-                       "slot:   %lu\n"
-                       "ours:   %32J\n"
-                       "theirs: %32J\n"
-                       "stake:  %.0lf%%\n"
-                       "result: match!\n",
-                       cmp->slot,
-                       cmp->ours.hash,
-                       theirs->hash,
-                       pct * 100 ) );
+      FD_LOG_NOTICE(( "\n\n[Bank Hash Comparison]\n"
+                      "slot:   %lu\n"
+                      "ours:   %s\n"
+                      "theirs: %s\n"
+                      "stake:  %.0lf%%\n"
+                      "result: match!\n",
+                      cmp->slot,
+                      FD_BASE58_ENC_32_ALLOCA( cmp->ours.hash ),
+                      FD_BASE58_ENC_32_ALLOCA( theirs->hash ),
+                      pct * 100 ));
     }
     fd_bank_hash_cmp_map_remove( bank_hash_cmp->map, cmp );
     bank_hash_cmp->cnt--;

--- a/src/flamenco/runtime/fd_borrowed_account.h
+++ b/src/flamenco/runtime/fd_borrowed_account.h
@@ -5,9 +5,6 @@
 #include "../types/fd_types.h"
 #include "../../funk/fd_funk_rec.h"
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 /* TODO This should be called fd_txn_acct. */
 
 struct __attribute__((aligned(8UL))) fd_borrowed_account {

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -318,12 +318,12 @@ fd_executor_load_transaction_accounts( fd_exec_txn_ctx_t * txn_ctx ) {
   requested_loaded_accounts_data_size = txn_ctx->loaded_accounts_data_size_limit;
 
   ulong accumulated_account_size = 0UL;
-  
+
   /* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/account_loader.rs#L217-L296 */
   /* In the agave client, this loop is responsible for loading in all of the
      accounts in the transaction. This contains a LOT of special casing as their
-     accounts database is handled very differently than the FD client. 
-      
+     accounts database is handled very differently than the FD client.
+
      The logic is as follows:
      1. If the account is the instructions sysvar, then load in the compiled
         instructions from the transactions into the sysvar's data.
@@ -334,14 +334,14 @@ fd_executor_load_transaction_accounts( fd_exec_txn_ctx_t * txn_ctx ) {
         in the loaded program cache, then load in a dummy account with the
         correct owner and the executable flag set to true.
      5. Otherwise load in the account from the accounts DB. If the account is
-        writable try to collect rent from the account. 
-        
+        writable try to collect rent from the account.
+
      After the account is loaded accumulate the data size to make sure the
      transaction doesn't violate the transaction loading limit.
 
      In the firedancer client only some of these steps are necessary because
      all of the accounts are loaded in from the accounts db into borrowed
-     accounts already. The instruction sysvar gets loaded in later in 
+     accounts already. The instruction sysvar gets loaded in later in
      fd_execute_txn
      1. If the account is writable, try to collect fees on the account. Unlike
         the agave client, this is also done on the fee payer account. The agave
@@ -349,7 +349,7 @@ fd_executor_load_transaction_accounts( fd_exec_txn_ctx_t * txn_ctx ) {
         collected in validate_fees().
      2. If the account is not writable and it is not an instruction account
         and would be in the loaded program cache, then it should be replaced
-        with a dummy value. 
+        with a dummy value.
      */
 
   fd_epoch_schedule_t const * schedule = fd_sysvar_cache_epoch_schedule( txn_ctx->slot_ctx->sysvar_cache );
@@ -357,13 +357,13 @@ fd_executor_load_transaction_accounts( fd_exec_txn_ctx_t * txn_ctx ) {
 
   for( ulong i=0UL; i<txn_ctx->accounts_cnt; i++ ) {
     fd_borrowed_account_t * acct = NULL;
-  
+
     int   err      = fd_txn_borrowed_account_view_idx( txn_ctx, (uchar)i, &acct );
     ulong acc_size = err==FD_ACC_MGR_SUCCESS ? acct->const_meta->dlen : 0UL;
 
     /* Try to collect rent on all writable accounts. If rent is collected
        successfully, update the starting lamports accordingly to avoid
-       unbalanced lamports issues during instruction execution. 
+       unbalanced lamports issues during instruction execution.
        TODO: the rent epoch check in the conditional should probably be moved
        to inside fd_runtime_collect_rent_account. */
     if( fd_txn_account_is_writable_idx( txn_ctx, (int)i ) && acct->const_meta->info.rent_epoch<=epoch ) {
@@ -382,7 +382,7 @@ fd_executor_load_transaction_accounts( fd_exec_txn_ctx_t * txn_ctx ) {
 
   ushort      instr_cnt = txn_ctx->txn_descriptor->instr_cnt;
   fd_pubkey_t program_owners[instr_cnt];
-  ushort      program_owners_cnt = 0;  
+  ushort      program_owners_cnt = 0;
 
   /* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/account_loader.rs#L297-L358 */
   for( ushort i=0; i<instr_cnt; i++ ) {
@@ -459,8 +459,8 @@ fd_executor_load_transaction_accounts( fd_exec_txn_ctx_t * txn_ctx ) {
     /* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/account_loader.rs#L342-347 */
     /* Count the owner's data in the loaded account size for program accounts.
        However, it is important to not double count repeated owners. */
-    err = accumulate_and_check_loaded_account_data_size( owner_account->const_meta->dlen, 
-                                                         requested_loaded_accounts_data_size, 
+    err = accumulate_and_check_loaded_account_data_size( owner_account->const_meta->dlen,
+                                                         requested_loaded_accounts_data_size,
                                                          &accumulated_account_size );
     if( FD_UNLIKELY( err!=FD_RUNTIME_EXECUTE_SUCCESS ) ) {
       return err;
@@ -927,7 +927,7 @@ dump_instr_to_protobuf( fd_exec_txn_ctx_t *txn_ctx,
 static inline int
 fd_txn_ctx_push( fd_exec_txn_ctx_t * txn_ctx,
                  fd_instr_info_t *   instr ) {
-  /* Earlier checks in the permalink are redundant since Agave maintains instr stack and trace accounts separately 
+  /* Earlier checks in the permalink are redundant since Agave maintains instr stack and trace accounts separately
      https://github.com/anza-xyz/agave/blob/c4b42ab045860d7b13b3912eafb30e6d2f4e593f/sdk/src/transaction_context.rs#L327-L328 */
   ulong starting_lamports_h = 0UL;
   ulong starting_lamports_l = 0UL;
@@ -1105,9 +1105,9 @@ fd_execute_instr( fd_exec_txn_ctx_t * txn_ctx,
 
 #ifdef VLOG
   if ( FD_UNLIKELY( exec_result != FD_EXECUTOR_INSTR_SUCCESS ) ) {
-    FD_LOG_WARNING(( "instruction executed unsuccessfully: error code %d, custom err: %d, program id: %32J", exec_result, txn_ctx->custom_err, instr->program_id_pubkey.uc ));
+    FD_LOG_WARNING(( "instruction executed unsuccessfully: error code %d, custom err: %d, program id: %s", exec_result, txn_ctx->custom_err, FD_BASE58_ENC_32_ALLOCA( instr->program_id_pubkey.uc ));
   } else {
-    FD_LOG_WARNING(( "instruction executed successfully: error code %d, custom err: %d, program id: %32J", exec_result, txn_ctx->custom_err, instr->program_id_pubkey.uc ));
+    FD_LOG_WARNING(( "instruction executed successfully: error code %d, custom err: %d, program id: %s", exec_result, txn_ctx->custom_err, FD_BASE58_ENC_32_ALLOCA( instr->program_id_pubkey.uc ));
   }
 #endif
 
@@ -1146,14 +1146,14 @@ fd_executor_is_blockhash_valid_for_age( fd_block_hash_queue_t const * block_hash
   fd_hash_hash_age_pair_t_mapnode_t * hash_age = fd_hash_hash_age_pair_t_map_find( block_hash_queue->ages_pool, block_hash_queue->ages_root, &key );
   if( hash_age==NULL ) {
     #ifdef VLOG
-    FD_LOG_WARNING(( "txn with missing recent blockhash - blockhash: %32J", blockhash->uc ));
+    FD_LOG_WARNING(( "txn with missing recent blockhash - blockhash: %s", FD_BASE58_ENC_32_ALLOCA( blockhash->uc ) ));
     #endif
     return 0;
   }
   ulong age = block_hash_queue->last_hash_index-hash_age->elem.val.hash_index;
 #ifdef VLOG
   if( age>max_age ) {
-    FD_LOG_WARNING(( "txn with old blockhash - age: %lu, blockhash: %32J", age, hash_age->elem.key.uc ));
+    FD_LOG_WARNING(( "txn with old blockhash - age: %lu, blockhash: %s", age, FD_BASE58_ENC_32_ALLOCA( hash_age->elem.key.uc ) ));
   }
 #endif
   return ( age<=max_age );
@@ -1765,7 +1765,7 @@ fd_execute_txn( fd_exec_txn_ctx_t * txn_ctx ) {
 
     for ( ushort i = 0; i < txn_ctx->txn_descriptor->instr_cnt; i++ ) {
 #ifdef VLOG
-      FD_LOG_WARNING(( "Start of transaction for %d for %s", i, FD_BASE58_ENCODE_64( sig ) ));
+      FD_LOG_WARNING(( "Start of transaction for %d for %s", i, FD_BASE58_ENC_64_ALLOCA( sig ) ));
 #endif
 
       if ( FD_UNLIKELY( use_sysvar_instructions ) ) {
@@ -1784,7 +1784,7 @@ fd_execute_txn( fd_exec_txn_ctx_t * txn_ctx ) {
 
       int exec_result = fd_execute_instr( txn_ctx, &txn_ctx->instr_infos[i] );
 #ifdef VLOG
-      FD_LOG_WARNING(( "fd_execute_instr result (%d) for %s", exec_result, FD_BASE58_ENCODE_64( sig ) ));
+      FD_LOG_WARNING(( "fd_execute_instr result (%d) for %s", exec_result, FD_BASE58_ENC_64_ALLOCA( sig ) ));
 #endif
       if( exec_result != FD_EXECUTOR_INSTR_SUCCESS ) {
         if ( txn_ctx->instr_err_idx == INT_MAX )
@@ -1799,14 +1799,14 @@ fd_execute_txn( fd_exec_txn_ctx_t * txn_ctx ) {
             FD_LOG_WARNING(( "fd_execute_instr failed (%d:%d) for %s",
                              exec_result,
                              txn_ctx->custom_err,
-                             FD_BASE58_ENCODE_64( sig ) ));
+                             FD_BASE58_ENC_64_ALLOCA( sig ) ));
   #endif
           } else {
   #ifdef VLOG
             FD_LOG_WARNING(( "fd_execute_instr failed (%d) index %u for %s",
               exec_result,
               i,
-              FD_BASE58_ENCODE_64( sig ) ));
+              FD_BASE58_ENC_64_ALLOCA( sig ) ));
   #endif
           }
   #ifdef VLOG
@@ -1883,14 +1883,28 @@ int fd_executor_txn_check( fd_exec_slot_ctx_t * slot_ctx,  fd_exec_txn_ctx_t *tx
 
           /* https://github.com/anza-xyz/agave/blob/b2c388d6cbff9b765d574bbb83a4378a1fc8af32/svm/src/account_rent_state.rs#L50 */
           if( before_uninitialized || before_rent_exempt ) {
-            FD_LOG_DEBUG(( "Rent exempt error for %32J Curr len %lu Starting len %lu Curr lamports %lu Starting lamports %lu Curr exempt %lu Starting exempt %lu", b->pubkey->uc, b->meta->dlen, b->starting_dlen, b->meta->info.lamports, b->starting_lamports, fd_rent_exempt_minimum_balance2( rent, b->meta->dlen ), fd_rent_exempt_minimum_balance2( rent, b->starting_dlen ) ));
+            FD_LOG_DEBUG(( "Rent exempt error for %s Curr len %lu Starting len %lu Curr lamports %lu Starting lamports %lu Curr exempt %lu Starting exempt %lu",
+                           FD_BASE58_ENC_32_ALLOCA( b->pubkey->uc ),
+                           b->meta->dlen,
+                           b->starting_dlen,
+                           b->meta->info.lamports,
+                           b->starting_lamports,
+                           fd_rent_exempt_minimum_balance2( rent, b->meta->dlen ),
+                           fd_rent_exempt_minimum_balance2( rent, b->starting_dlen ) ));
             /* https://github.com/anza-xyz/agave/blob/b2c388d6cbff9b765d574bbb83a4378a1fc8af32/svm/src/account_rent_state.rs#L104 */
             return FD_RUNTIME_TXN_ERR_INSUFFICIENT_FUNDS_FOR_RENT;
           /* https://github.com/anza-xyz/agave/blob/b2c388d6cbff9b765d574bbb83a4378a1fc8af32/svm/src/account_rent_state.rs#L56 */
           } else if( (b->meta->dlen == b->starting_dlen) && b->meta->info.lamports <= b->starting_lamports ) {
             // no-op
           } else {
-            FD_LOG_DEBUG(( "Rent exempt error for %32J Curr len %lu Starting len %lu Curr lamports %lu Starting lamports %lu Curr exempt %lu Starting exempt %lu", b->pubkey->uc, b->meta->dlen, b->starting_dlen, b->meta->info.lamports, b->starting_lamports, fd_rent_exempt_minimum_balance2( rent, b->meta->dlen ), fd_rent_exempt_minimum_balance2( rent, b->starting_dlen ) ));
+            FD_LOG_DEBUG(( "Rent exempt error for %s Curr len %lu Starting len %lu Curr lamports %lu Starting lamports %lu Curr exempt %lu Starting exempt %lu",
+                           FD_BASE58_ENC_32_ALLOCA( b->pubkey->uc ),
+                           b->meta->dlen,
+                           b->starting_dlen,
+                           b->meta->info.lamports,
+                           b->starting_lamports,
+                           fd_rent_exempt_minimum_balance2( rent, b->meta->dlen ),
+                           fd_rent_exempt_minimum_balance2( rent, b->starting_dlen ) ));
             /* https://github.com/anza-xyz/agave/blob/b2c388d6cbff9b765d574bbb83a4378a1fc8af32/svm/src/account_rent_state.rs#L104 */
             return FD_RUNTIME_TXN_ERR_INSUFFICIENT_FUNDS_FOR_RENT;
           }
@@ -1902,14 +1916,13 @@ int fd_executor_txn_check( fd_exec_slot_ctx_t * slot_ctx,  fd_exec_txn_ctx_t *tx
       if (b->starting_dlen != ULONG_MAX)
         starting_dlen += b->starting_dlen;
     } else if (NULL != b->const_meta) {
-      // FD_LOG_DEBUG(("Const rec mismatch %32J starting %lu %lu ending %lu %lu", b->pubkey->uc, b->starting_dlen, b->starting_lamports, b->const_meta->dlen, b->const_meta->info.lamports));
       // Should these just kill the client?  They are impossible...
       if (b->starting_lamports != b->const_meta->info.lamports) {
-        FD_LOG_DEBUG(("Const rec mismatch %32J starting %lu %lu ending %lu %lu", b->pubkey->uc, b->starting_dlen, b->starting_lamports, b->const_meta->dlen, b->const_meta->info.lamports));
+        FD_LOG_DEBUG(("Const rec mismatch %s starting %lu %lu ending %lu %lu", FD_BASE58_ENC_32_ALLOCA( b->pubkey->uc ), b->starting_dlen, b->starting_lamports, b->const_meta->dlen, b->const_meta->info.lamports));
         return FD_EXECUTOR_INSTR_ERR_UNBALANCED_INSTR;
       }
       if (b->starting_dlen != b->const_meta->dlen) {
-        FD_LOG_DEBUG(("Const rec mismatch %32J starting %lu %lu ending %lu %lu", b->pubkey->uc, b->starting_dlen, b->starting_lamports, b->const_meta->dlen, b->const_meta->info.lamports));
+        FD_LOG_DEBUG(("Const rec mismatch %s starting %lu %lu ending %lu %lu", FD_BASE58_ENC_32_ALLOCA( b->pubkey->uc ), b->starting_dlen, b->starting_lamports, b->const_meta->dlen, b->const_meta->info.lamports));
         return FD_EXECUTOR_INSTR_ERR_UNBALANCED_INSTR;
       }
     }

--- a/src/flamenco/runtime/fd_runtime_init.c
+++ b/src/flamenco/runtime/fd_runtime_init.c
@@ -4,9 +4,6 @@
 #include "context/fd_exec_epoch_ctx.h"
 #include "context/fd_exec_slot_ctx.h"
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 /* This file must not depend on fd_executor.h */
 
 fd_funk_rec_key_t
@@ -54,7 +51,7 @@ fd_runtime_save_epoch_bank( fd_exec_slot_ctx_t * slot_ctx ) {
   }
   FD_TEST(ctx.data == ctx.dataend);
 
-  FD_LOG_DEBUG(("epoch frozen, slot=%d bank_hash=%32J poh_hash=%32J", slot_ctx->slot_bank.slot, slot_ctx->slot_bank.banks_hash.hash, slot_ctx->slot_bank.poh.hash));
+  FD_LOG_DEBUG(( "epoch frozen, slot=%lu bank_hash=%s poh_hash=%s", slot_ctx->slot_bank.slot, FD_BASE58_ENC_32_ALLOCA( slot_ctx->slot_bank.banks_hash.hash ), FD_BASE58_ENC_32_ALLOCA( slot_ctx->slot_bank.poh.hash ) ));
 
   return FD_RUNTIME_EXECUTE_SUCCESS;
 }
@@ -116,7 +113,10 @@ int fd_runtime_save_slot_bank(fd_exec_slot_ctx_t *slot_ctx)
   }
   FD_TEST(ctx.data == ctx.dataend);
 
-  // FD_LOG_DEBUG(("slot frozen, slot=%d bank_hash=%32J poh_hash=%32J", slot_ctx->slot_bank.slot, slot_ctx->slot_bank.banks_hash.hash, slot_ctx->slot_bank.poh.hash));
+  FD_LOG_DEBUG(( "slot frozen, slot=%lu bank_hash=%s poh_hash=%s",
+                 slot_ctx->slot_bank.slot,
+                 FD_BASE58_ENC_32_ALLOCA( slot_ctx->slot_bank.banks_hash.hash ),
+                 FD_BASE58_ENC_32_ALLOCA( slot_ctx->slot_bank.poh.hash ) ));
 
   return FD_RUNTIME_EXECUTE_SUCCESS;
 }
@@ -218,11 +218,11 @@ fd_runtime_recover_banks( fd_exec_slot_ctx_t * slot_ctx, int delete_first, int c
       FD_LOG_ERR(("failed to read banks record: invalid magic number"));
     }
 
-    FD_LOG_NOTICE(( "recovered slot_bank for slot=%ld banks_hash=%32J poh_hash %32J lthash %32J",
+    FD_LOG_NOTICE(( "recovered slot_bank for slot=%ld banks_hash=%s poh_hash %s lthash %s",
                     (long)slot_ctx->slot_bank.slot,
-                    slot_ctx->slot_bank.banks_hash.hash,
-                    slot_ctx->slot_bank.poh.hash,
-                    slot_ctx->slot_bank.lthash ));
+                    FD_BASE58_ENC_32_ALLOCA( slot_ctx->slot_bank.banks_hash.hash ),
+                    FD_BASE58_ENC_32_ALLOCA( slot_ctx->slot_bank.poh.hash ),
+                    FD_BASE58_ENC_32_ALLOCA( slot_ctx->slot_bank.lthash ) ));
 
     slot_ctx->slot_bank.collected_execution_fees = 0;
     slot_ctx->slot_bank.collected_priority_fees = 0;
@@ -270,15 +270,15 @@ fd_feature_restore( fd_exec_slot_ctx_t * slot_ctx,
     int decode_err = fd_feature_decode(feature, &ctx);
     if (FD_UNLIKELY(decode_err != FD_BINCODE_SUCCESS))
     {
-      FD_LOG_ERR(("Failed to decode feature account %32J (%d)", acct, decode_err));
+      FD_LOG_ERR(("Failed to decode feature account %s (%d)", FD_BASE58_ENC_32_ALLOCA( acct ), decode_err));
       return;
     }
 
     if( feature->has_activated_at ) {
-      FD_LOG_INFO(( "Feature %32J activated at %lu", acct, feature->activated_at ));
+      FD_LOG_INFO(( "Feature %s activated at %lu", FD_BASE58_ENC_32_ALLOCA( acct ), feature->activated_at ));
       fd_features_set(&slot_ctx->epoch_ctx->features, id, feature->activated_at);
     } else {
-      FD_LOG_DEBUG(( "Feature %32J not activated at %lu", acct, feature->activated_at ));
+      FD_LOG_DEBUG(( "Feature %s not activated at %lu", FD_BASE58_ENC_32_ALLOCA( acct ), feature->activated_at ));
     }
     /* No need to call destroy, since we are using fd_scratch allocator. */
   } FD_SCRATCH_SCOPE_END;

--- a/src/flamenco/runtime/program/fd_address_lookup_table_program.c
+++ b/src/flamenco/runtime/program/fd_address_lookup_table_program.c
@@ -270,7 +270,7 @@ create_lookup_table( fd_exec_instr_ctx_t *       ctx,
   if( FD_UNLIKELY( 0!=memcmp( lut_key->key, derived_tbl_key->key, sizeof(fd_pubkey_t) ) ) ) {
     /* Max msg_sz: 44 - 2 + 45 = 87 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Table address must match derived address: %s", FD_BASE58_ENCODE_32( derived_tbl_key ) );
+      "Table address must match derived address: %s", FD_BASE58_ENC_32_ALLOCA( derived_tbl_key ) );
     return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
   }
 

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -15,9 +15,6 @@
 #include "fd_bpf_program_util.h"
 #include "fd_native_cpi.h"
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 #include <stdlib.h>
 
 static char * trace_buf;
@@ -895,7 +892,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
       } FD_BORROWED_ACCOUNT_DROP( programdata );
 
       /* Max msg_sz: 19 - 2 + 45 = 62 < 127 => we can use printf */
-      fd_log_collector_printf_dangerous_max_127( instr_ctx, "Deployed program %s", FD_BASE58_ENCODE_32( program_id ) );
+      fd_log_collector_printf_dangerous_max_127( instr_ctx, "Deployed program %s", FD_BASE58_ENC_32_ALLOCA( program_id ) );
 
       /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L692-L699 */
       /* Update the Program account */
@@ -915,7 +912,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
         return err;
       }
 
-      FD_LOG_INFO(( "Program deployed %s", FD_BASE58_ENCODE_32( program->pubkey ) ));
+      FD_LOG_INFO(( "Program deployed %s", FD_BASE58_ENC_32_ALLOCA( program->pubkey ) ));
 
       } FD_BORROWED_ACCOUNT_DROP( program );
 
@@ -1165,7 +1162,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
 
       /* Max msg_sz: 19 - 2 + 45 = 62 < 127 => we can use printf */
       //TODO: this is likely the incorrect program_id, do we have new_program_id?
-      fd_log_collector_printf_dangerous_max_127( instr_ctx, "Upgraded program %s", FD_BASE58_ENCODE_32( program_id ) );
+      fd_log_collector_printf_dangerous_max_127( instr_ctx, "Upgraded program %s", FD_BASE58_ENC_32_ALLOCA( program_id ) );
 
       break;
     }
@@ -1238,7 +1235,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
       }
 
       /* Max msg_sz: 16 - 2 + 45 = 59 < 127 => we can use printf */
-      fd_log_collector_printf_dangerous_max_127( instr_ctx, "New authority %s", FD_BASE58_ENCODE_32( new_authority ) );
+      fd_log_collector_printf_dangerous_max_127( instr_ctx, "New authority %s", FD_BASE58_ENC_32_ALLOCA( new_authority ) );
 
       } FD_BORROWED_ACCOUNT_DROP( account );
 
@@ -1318,7 +1315,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
       }
 
       /* Max msg_sz: 16 - 2 + 45 = 59 < 127 => we can use printf */
-      fd_log_collector_printf_dangerous_max_127( instr_ctx, "New authority %s", FD_BASE58_ENCODE_32( new_authority_key ) );
+      fd_log_collector_printf_dangerous_max_127( instr_ctx, "New authority %s", FD_BASE58_ENC_32_ALLOCA( new_authority_key ) );
 
       } FD_BORROWED_ACCOUNT_DROP( account );
 
@@ -1366,7 +1363,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
         }
         /* Max msg_sz: 23 - 2 + 45 = 66 < 127 => we can use printf */
         fd_log_collector_printf_dangerous_max_127( instr_ctx,
-          "Closed Uninitialized %s", FD_BASE58_ENCODE_32( close_key ) );
+          "Closed Uninitialized %s", FD_BASE58_ENC_32_ALLOCA( close_key ) );
 
         } FD_BORROWED_ACCOUNT_DROP( recipient_account );
 
@@ -1385,7 +1382,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
         }
         /* Max msg_sz: 16 - 2 + 45 = 63 < 127 => we can use printf */
         fd_log_collector_printf_dangerous_max_127( instr_ctx,
-          "Closed Buffer %s", FD_BASE58_ENCODE_32( close_key ) );
+          "Closed Buffer %s", FD_BASE58_ENC_32_ALLOCA( close_key ) );
 
       /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1069-L1129 */
       } else if( fd_bpf_upgradeable_loader_state_is_program_data( &close_account_state ) ) {
@@ -1451,7 +1448,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
 
         /* Max msg_sz: 17 - 2 + 45 = 60 < 127 => we can use printf */
         fd_log_collector_printf_dangerous_max_127( instr_ctx,
-          "Closed Program %s", FD_BASE58_ENCODE_32( close_key ) );
+          "Closed Program %s", FD_BASE58_ENC_32_ALLOCA( close_key ) );
 
         } FD_BORROWED_ACCOUNT_DROP( program_account );
       } else {

--- a/src/flamenco/runtime/program/fd_bpf_loader_serialization.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_serialization.c
@@ -1,9 +1,6 @@
 #include "fd_bpf_loader_serialization.h"
 #include "../fd_account.h"
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 /* As a general note, copy_account_data implies that direct mapping is not being
    used/is inactive. This file is responsible for serializing and deserializing
    the input region of the BPF virtual machine. The input region contains
@@ -592,7 +589,7 @@ fd_bpf_loader_input_serialize_unaligned( fd_exec_instr_ctx_t       ctx,
 
         continue;
       } else if ( FD_UNLIKELY( read_result != FD_ACC_MGR_SUCCESS ) ) {
-        FD_LOG_DEBUG(( "failed to read account data - pubkey: %32J, err: %d", acc, read_result ));
+        FD_LOG_DEBUG(( "failed to read account data - pubkey: %s, err: %d", FD_BASE58_ENC_32_ALLOCA( acc ), read_result ));
         return NULL;
       }
       fd_account_meta_t const * metadata = view_acc->const_meta;

--- a/src/flamenco/runtime/program/fd_bpf_program_util.c
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.c
@@ -7,9 +7,6 @@
 #include <assert.h>
 
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 fd_sbpf_validated_program_t *
 fd_sbpf_validated_program_new( void * mem ) {
   return (fd_sbpf_validated_program_t *)mem;

--- a/src/flamenco/runtime/program/fd_config_program.c
+++ b/src/flamenco/runtime/program/fd_config_program.c
@@ -122,13 +122,13 @@ _process_config_instr( fd_exec_instr_ctx_t * ctx ) {
       if( FD_UNLIKELY( borrow_err!=FD_ACC_MGR_SUCCESS ) ) {
         /* Max msg_sz: 33 - 2 + 45 = 76 < 127 => we can use printf */
         fd_log_collector_printf_dangerous_max_127( ctx,
-          "account %s is not in account list", FD_BASE58_ENCODE_32( signer ) );
+          "account %s is not in account list", FD_BASE58_ENC_32_ALLOCA( signer ) );
         return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
       }
       if( FD_UNLIKELY( !fd_borrowed_account_acquire_read( signer_account ) ) ) {
         /* Max msg_sz: 33 - 2 + 45 = 76 < 127 => we can use printf */
         fd_log_collector_printf_dangerous_max_127( ctx,
-          "account %s is not in account list", FD_BASE58_ENCODE_32( signer ) );
+          "account %s is not in account list", FD_BASE58_ENC_32_ALLOCA( signer ) );
         return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;  /* seems to be deliberately not ACC_BORROW_FAILED? */
       }
 
@@ -137,7 +137,7 @@ _process_config_instr( fd_exec_instr_ctx_t * ctx ) {
       if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( ctx->instr, (uchar)counter ) ) ) {
         /* Max msg_sz: 33 - 2 + 45 = 76 < 127 => we can use printf */
         fd_log_collector_printf_dangerous_max_127( ctx,
-          "account %s signer_key().is_none()", FD_BASE58_ENCODE_32( signer ) );
+          "account %s signer_key().is_none()", FD_BASE58_ENC_32_ALLOCA( signer ) );
         return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
       }
 
@@ -165,7 +165,7 @@ _process_config_instr( fd_exec_instr_ctx_t * ctx ) {
         if( FD_UNLIKELY( !is_signer ) ) {
           /* Max msg_sz: 39 - 2 + 45 = 82 < 127 => we can use printf */
           fd_log_collector_printf_dangerous_max_127( ctx,
-            "account %s is not in stored signer list", FD_BASE58_ENCODE_32( signer ) );
+            "account %s is not in stored signer list", FD_BASE58_ENC_32_ALLOCA( signer ) );
           return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
         }
       }

--- a/src/flamenco/runtime/program/fd_system_program.c
+++ b/src/flamenco/runtime/program/fd_system_program.c
@@ -40,8 +40,8 @@ verify_seed_address( fd_exec_instr_ctx_t * ctx,
     /* Log msg_sz can be more or less than 127 bytes */
     fd_log_collector_printf_inefficient_max_512( ctx,
       "Create: address %s does not match derived address %s",
-      FD_BASE58_ENCODE_32( expected ),
-      FD_BASE58_ENCODE_32( actual ) );
+      FD_BASE58_ENC_32_ALLOCA( expected ),
+      FD_BASE58_ENC_32_ALLOCA( actual ) );
     ctx->txn_ctx->custom_err = FD_SYSTEM_PROGRAM_ERR_ADDR_WITH_SEED_MISMATCH;
     return FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR;
   }
@@ -123,7 +123,7 @@ fd_system_program_transfer( fd_exec_instr_ctx_t * ctx,
   if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( ctx->instr, from_acct_idx ) ) ) {
     /* Max msg_sz: 37 - 2 + 45 = 80 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Transfer: `from` account %s must sign", FD_BASE58_ENCODE_32( &ctx->instr->acct_pubkeys[ from_acct_idx ] ) );
+      "Transfer: `from` account %s must sign", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ from_acct_idx ] ) );
     return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
   }
 
@@ -152,7 +152,7 @@ fd_system_program_allocate( fd_exec_instr_ctx_t * ctx,
   if( FD_UNLIKELY( !fd_instr_any_signed( ctx->instr, authority ) ) ) {
     /* Max msg_sz: 35 - 2 + 45 = 78 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Allocate: 'to' account %s must sign", FD_BASE58_ENCODE_32( authority ) );
+      "Allocate: 'to' account %s must sign", FD_BASE58_ENC_32_ALLOCA( authority ) );
     return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
   }
 
@@ -162,7 +162,7 @@ fd_system_program_allocate( fd_exec_instr_ctx_t * ctx,
                    ( 0!=memcmp( account->const_meta->info.owner, fd_solana_system_program_id.uc, 32UL ) ) ) ) {
     /* Max msg_sz: 35 - 2 + 45 = 78 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Allocate: account %s already in use", FD_BASE58_ENCODE_32( account->pubkey ) );
+      "Allocate: account %s already in use", FD_BASE58_ENC_32_ALLOCA( account->pubkey ) );
     ctx->txn_ctx->custom_err = FD_SYSTEM_PROGRAM_ERR_ACCT_ALREADY_IN_USE;
     return FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR;
   }
@@ -214,7 +214,7 @@ fd_system_program_assign( fd_exec_instr_ctx_t * ctx,
   if( FD_UNLIKELY( !fd_instr_any_signed( ctx->instr, authority ) ) ) {
     /* Max msg_sz: 28 - 2 + 45 = 71 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Assign: account %s must sign", FD_BASE58_ENCODE_32( authority ) );
+      "Assign: account %s must sign", FD_BASE58_ENC_32_ALLOCA( authority ) );
     return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
   }
 
@@ -269,7 +269,7 @@ fd_system_program_create_account( fd_exec_instr_ctx_t * ctx,
   if( FD_UNLIKELY( to->const_meta->info.lamports ) ) {
     /* Max msg_sz: 41 - 2 + 45 = 84 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Create Account: account %s already in use", FD_BASE58_ENCODE_32( to->pubkey ) );
+      "Create Account: account %s already in use", FD_BASE58_ENC_32_ALLOCA( to->pubkey ) );
     ctx->txn_ctx->custom_err = FD_SYSTEM_PROGRAM_ERR_ACCT_ALREADY_IN_USE;
     return FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR;
   }
@@ -574,7 +574,7 @@ fd_system_program_exec_transfer_with_seed( fd_exec_instr_ctx_t *                
   if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( ctx->instr, from_base_idx ) ) ) {
     /* Max msg_sz: 37 - 2 + 45 = 80 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Transfer: 'from' account %s must sign", FD_BASE58_ENCODE_32( &ctx->instr->acct_pubkeys[ from_base_idx ] ) );
+      "Transfer: 'from' account %s must sign", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ from_base_idx ] ) );
     return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
   }
 
@@ -600,8 +600,8 @@ fd_system_program_exec_transfer_with_seed( fd_exec_instr_ctx_t *                
     /* Log msg_sz can be more or less than 127 bytes */
     fd_log_collector_printf_inefficient_max_512( ctx,
       "Transfer: 'from' address %s does not match derived address %s",
-      FD_BASE58_ENCODE_32( &ctx->instr->acct_pubkeys[ from_idx ] ),
-      FD_BASE58_ENCODE_32( address_from_seed ) );
+      FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ from_idx ] ),
+      FD_BASE58_ENC_32_ALLOCA( address_from_seed ) );
     ctx->txn_ctx->custom_err = FD_SYSTEM_PROGRAM_ERR_ADDR_WITH_SEED_MISMATCH;
     return FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR;
   }

--- a/src/flamenco/runtime/program/fd_system_program_nonce.c
+++ b/src/flamenco/runtime/program/fd_system_program_nonce.c
@@ -150,7 +150,7 @@ fd_system_program_advance_nonce_account( fd_exec_instr_ctx_t *   ctx,
   if( FD_UNLIKELY( !fd_instr_acc_is_writable_idx( ctx->instr, instr_acc_idx ) ) ) {
     /* Max msg_sz: 52 - 2 + 45 = 95 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Authorize nonce account: Account %s must be writable", FD_BASE58_ENCODE_32( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
+      "Authorize nonce account: Account %s must be writable", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
     return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
   }
 
@@ -188,7 +188,7 @@ fd_system_program_advance_nonce_account( fd_exec_instr_ctx_t *   ctx,
     if( FD_UNLIKELY( !fd_instr_any_signed( ctx->instr, &data->authority ) ) ) {
       /* Max msg_sz: 50 - 2 + 45 = 93 < 127 => we can use printf */
       fd_log_collector_printf_dangerous_max_127( ctx,
-        "Advance nonce account: Account %s must be a signer", FD_BASE58_ENCODE_32( &data->authority ) );
+        "Advance nonce account: Account %s must be a signer", FD_BASE58_ENC_32_ALLOCA( &data->authority ) );
       return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
     }
 
@@ -245,7 +245,7 @@ fd_system_program_advance_nonce_account( fd_exec_instr_ctx_t *   ctx,
   case fd_nonce_state_enum_uninitialized: {
     /* Max msg_sz: 50 - 2 + 45 = 93 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Advance nonce account: Account %s state is invalid", FD_BASE58_ENCODE_32( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
+      "Advance nonce account: Account %s state is invalid", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
   }
 
@@ -318,7 +318,7 @@ fd_system_program_withdraw_nonce_account( fd_exec_instr_ctx_t * ctx,
   if( FD_UNLIKELY( !fd_instr_acc_is_writable_idx( ctx->instr, 0 ) ) ) {
     /* Max msg_sz: 51 - 2 + 45 = 94 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Withdraw nonce account: Account %s must be writable", FD_BASE58_ENCODE_32( &ctx->instr->acct_pubkeys[ 0 ] ) );
+      "Withdraw nonce account: Account %s must be writable", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ 0 ] ) );
     return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
   }
 
@@ -442,7 +442,7 @@ fd_system_program_withdraw_nonce_account( fd_exec_instr_ctx_t * ctx,
   if( FD_UNLIKELY( !fd_instr_any_signed( ctx->instr, signer ) ) ) {
     /* Max msg_sz: 44 - 2 + 45 = 87 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Withdraw nonce account: Account %s must sign", FD_BASE58_ENCODE_32( signer ) );
+      "Withdraw nonce account: Account %s must sign", FD_BASE58_ENC_32_ALLOCA( signer ) );
     return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
   }
 
@@ -532,7 +532,7 @@ fd_system_program_initialize_nonce_account( fd_exec_instr_ctx_t *   ctx,
   if( FD_UNLIKELY( !fd_instr_acc_is_writable_idx( ctx->instr, instr_acc_idx ) ) ) {
     /* Max msg_sz: 53 - 2 + 45 = 96 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Initialize nonce account: Account %s must be writable", FD_BASE58_ENCODE_32( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
+      "Initialize nonce account: Account %s must be writable", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
     return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
   }
 
@@ -618,7 +618,7 @@ fd_system_program_initialize_nonce_account( fd_exec_instr_ctx_t *   ctx,
 
     /* Max msg_sz: 53 - 2 + 45 = 96 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Initialize nonce account: Account %s state is invalid", FD_BASE58_ENCODE_32( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
+      "Initialize nonce account: Account %s state is invalid", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
 
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
   }
@@ -697,7 +697,7 @@ fd_system_program_authorize_nonce_account( fd_exec_instr_ctx_t *   ctx,
   if( FD_UNLIKELY( !fd_instr_acc_is_writable_idx( ctx->instr, instr_acc_idx ) ) ) {
     /* Max msg_sz: 52 - 2 + 45 = 95 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Authorize nonce account: Account %s must be writable", FD_BASE58_ENCODE_32( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
+      "Authorize nonce account: Account %s must be writable", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
     return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
   }
 
@@ -735,7 +735,7 @@ fd_system_program_authorize_nonce_account( fd_exec_instr_ctx_t *   ctx,
 
     /* Max msg_sz: 52 - 2 + 45 = 95 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Authorize nonce account: Account %s state is invalid", FD_BASE58_ENCODE_32( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
+      "Authorize nonce account: Account %s state is invalid", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
 
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
   }
@@ -748,7 +748,7 @@ fd_system_program_authorize_nonce_account( fd_exec_instr_ctx_t *   ctx,
     /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L227-L234 */
     /* Max msg_sz: 45 - 2 + 45 = 88 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Authorize nonce account: Account %s must sign", FD_BASE58_ENCODE_32( &data->authority ) );
+      "Authorize nonce account: Account %s must sign", FD_BASE58_ENC_32_ALLOCA( &data->authority ) );
     return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
   }
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
@@ -60,7 +60,7 @@ fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx ) {
         .hash = slot_ctx->slot_bank.banks_hash, // parent hash?
         .slot = slot_ctx->slot_bank.prev_slot,   // parent_slot
       };
-      // FD_LOG_DEBUG(( "fd_sysvar_slot_hash_update:  slot %ld,  hash %32J", slot_hash.slot, slot_hash.hash.key ));
+      FD_LOG_DEBUG(( "fd_sysvar_slot_hash_update:  slot %ld,  hash %s", slot_hash.slot, FD_BASE58_ENC_32_ALLOCA( slot_hash.hash.key ) ));
       fd_bincode_destroy_ctx_t ctx2 = { .valloc = slot_ctx->valloc };
 
       if (deq_fd_slot_hash_t_full( hashes ) )

--- a/src/flamenco/snapshot/fd_snapshot.c
+++ b/src/flamenco/snapshot/fd_snapshot.c
@@ -183,9 +183,9 @@ fd_snapshot_load( const char *         snapshotfile,
       fd_snapshot_hash(slot_ctx, tpool, &accounts_hash, check_hash);
 
       if (memcmp(fhash->uc, accounts_hash.uc, 32) != 0)
-        FD_LOG_ERR(("snapshot accounts_hash %32J != %32J", accounts_hash.hash, fhash->uc));
+        FD_LOG_ERR(( "snapshot accounts_hash %s != %s", FD_BASE58_ENC_32_ALLOCA( accounts_hash.hash ), FD_BASE58_ENC_32_ALLOCA( fhash->uc ) ));
       else
-        FD_LOG_NOTICE(("snapshot accounts_hash %32J verified successfully", accounts_hash.hash));
+        FD_LOG_NOTICE(( "snapshot accounts_hash %s verified successfully", FD_BASE58_ENC_32_ALLOCA( accounts_hash.hash) ));
     } else if (snapshot_type == FD_SNAPSHOT_TYPE_INCREMENTAL) {
       fd_hash_t accounts_hash;
 
@@ -198,9 +198,9 @@ fd_snapshot_load( const char *         snapshotfile,
       }
 
       if (memcmp(fhash->uc, accounts_hash.uc, 32) != 0)
-        FD_LOG_ERR(("incremental accounts_hash %32J != %32J", accounts_hash.hash, fhash->uc));
+        FD_LOG_ERR(("incremental accounts_hash %s != %s", FD_BASE58_ENC_32_ALLOCA( accounts_hash.hash ), FD_BASE58_ENC_32_ALLOCA( fhash->uc ) ));
       else
-        FD_LOG_NOTICE(("incremental accounts_hash %32J verified successfully", accounts_hash.hash));
+        FD_LOG_NOTICE(("incremental accounts_hash %s verified successfully", FD_BASE58_ENC_32_ALLOCA( accounts_hash.hash ) ));
     } else {
       FD_LOG_ERR(( "invalid snapshot type %u", snapshot_type ));
     }

--- a/src/flamenco/stakes/fd_stakes.c
+++ b/src/flamenco/stakes/fd_stakes.c
@@ -5,9 +5,6 @@
 #include "../runtime/program/fd_stake_program.h"
 #include "../runtime/sysvar/fd_sysvar_stake_history.h"
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 /* fd_stakes_accum_by_node converts Stakes (unordered list of (vote acc,
    active stake) tuples) to StakedNodes (rbtree mapping (node identity)
    => (active stake) ordered by node identity).  Returns the tree root. */
@@ -40,7 +37,7 @@ fd_stakes_accum_by_node( fd_vote_accounts_t const * in,
 
     fd_pubkey_t null_key = {0};
     if( memcmp( node_pubkey, null_key.uc, sizeof(fd_pubkey_t) ) == 0 ) {
-      FD_LOG_WARNING(( "vote account %32J skipped", n->elem.key.key ));
+      FD_LOG_WARNING(( "vote account %s skipped", FD_BASE58_ENC_32_ALLOCA( n->elem.key.key ) ));
       continue;
     }
     /* Check if node identity was previously visited */

--- a/src/flamenco/test_flamenco.c
+++ b/src/flamenco/test_flamenco.c
@@ -1,8 +1,5 @@
 #include "fd_flamenco.h"
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 int
 main( int     argc,
       char ** argv ) {
@@ -18,18 +15,20 @@ main( int     argc,
         0xb9,0x79,0x02,0x2e,0x4c,0xf6,0x2a,0x04,0x26,0x4e,0xef,0x55,0x94,0x0e,0xc8,0x57,
         0xb3,0x46,0xf1,0xa4,0x11,0x5b,0xaa,0x1a,0xc8,0x3d,0x3b,0x05,0xca,0xa8,0x23,0x00 };
 
-  static const char format[] = "%32J %64J %3J %J %32J ...";
+  static const char format[] = "%s %s %s %s";
   static const char expected[] =
       "Certusm1sa411sMpV9FPqU5dXAYhmmhygvxJ23S6hJ24 "
       "5eQS44iKV8B4b4gTt4tPZLPSHtD7F78fFDhbHDknsrAE1vUipnDf3pK6h5eZ8CqWqFgZPoYY6XHKUuvyt7BLWHpb "
-      "<unsupported Base58 width> "
-      "<unsupported Base58 width> "
       "<NULL> "
-      "...";
+      "<NULL>";
 
   ulong len;
   char buf[ 256UL ];
-  fd_cstr_printf( buf, 256UL, &len, format, buf32, buf64, buf32, buf32, NULL );
+  fd_cstr_printf( buf, 256UL, &len, format,
+                  FD_BASE58_ENC_32_ALLOCA( buf32 ),
+                  FD_BASE58_ENC_64_ALLOCA( buf64 ),
+                  FD_BASE58_ENC_32_ALLOCA( NULL ),
+                  FD_BASE58_ENC_64_ALLOCA( NULL ) );
   FD_TEST( 0==strcmp( buf, expected ) );
   FD_TEST( len==strlen( expected ) );
 

--- a/src/flamenco/types/fd_types_yaml.c
+++ b/src/flamenco/types/fd_types_yaml.c
@@ -6,9 +6,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-extra-args"
-
 #define FD_FLAMENCO_YAML_INDENT_BUFSZ (2UL*FD_FLAMENCO_YAML_MAX_INDENT+1UL)
 
 /* STATE_{...} identify the state of the YAML writer.  This is used
@@ -330,7 +327,7 @@ fd_flamenco_yaml_walk( void *       _self,
     break;
   }
   case FD_FLAMENCO_TYPE_HASH1024:
-    fprintf( file, "'%32J%32J%32J%32J'\n", arg, ((uchar *) arg)+32, ((uchar *) arg)+64, ((uchar *) arg)+96 );
+    fprintf( file, "'%s%s%s%s'\n", FD_BASE58_ENC_32_ALLOCA( arg ), FD_BASE58_ENC_32_ALLOCA( ((uchar *) arg)+32 ), FD_BASE58_ENC_32_ALLOCA( ((uchar *) arg)+64 ), FD_BASE58_ENC_32_ALLOCA( ((uchar *) arg)+96 ) );
     break;
   case FD_FLAMENCO_TYPE_SIG512: {
     char buf[ FD_BASE58_ENCODED_64_SZ ];

--- a/src/flamenco/vm/jit/fd_jit_compiler.c
+++ b/src/flamenco/vm/jit/fd_jit_compiler.c
@@ -1534,7 +1534,7 @@ fd_jit_compile( struct dasm_State **       Dst,
       break;
 
     default:
-      FD_LOG_WARNING(( "Unsupported opcode %x", opcode ));
+      FD_LOG_WARNING(( "Unsupported opcode %lx", opcode ));
       cur = text_end;
       break;
 

--- a/src/flamenco/vm/jit/fd_jit_compiler.dasc
+++ b/src/flamenco/vm/jit/fd_jit_compiler.dasc
@@ -1157,7 +1157,7 @@ fd_jit_compile( struct dasm_State **       Dst,
       break;
 
     default:
-      FD_LOG_WARNING(( "Unsupported opcode %x", opcode ));
+      FD_LOG_WARNING(( "Unsupported opcode %lx", opcode ));
       cur = text_end;
       break;
 

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
@@ -329,14 +329,14 @@ fd_vm_prepare_instruction( fd_instr_info_t const *  caller_instr,
   }
 
   if( FD_UNLIKELY( fd_account_find_idx_of_insn_account( instr_ctx, &callee_instr->program_id_pubkey )==-1 ) ) {
-    FD_LOG_WARNING(( "Unknown program %32J", &callee_instr->program_id_pubkey ));
+    FD_LOG_WARNING(( "Unknown program %s", FD_BASE58_ENC_32_ALLOCA( &callee_instr->program_id_pubkey ) ));
     return FD_EXECUTOR_INSTR_ERR_MISSING_ACC;
   }
 
   fd_account_meta_t const * program_meta = program_rec->const_meta;
 
   if( FD_UNLIKELY( !fd_account_is_executable( program_meta ) ) ) {
-    FD_LOG_WARNING(( "Account %32J is not executable", &callee_instr->program_id_pubkey ));
+    FD_LOG_WARNING(( "Account %s is not executable", FD_BASE58_ENC_32_ALLOCA( &callee_instr->program_id_pubkey ) ));
     return FD_EXECUTOR_INSTR_ERR_ACC_NOT_EXECUTABLE;
   }
 

--- a/src/waltz/tls/fd_tls.c
+++ b/src/waltz/tls/fd_tls.c
@@ -1598,8 +1598,9 @@ fd_tls_client_hs_wait_finished( fd_tls_t const *      const client,
   /* Verify that client and server's transcripts match */
 
   int match = 0;
-  for( ulong i=0; i<32UL; i++ )
+  for( ulong i=0; i<32UL; i++ ) {
     match |= server_fin.verify[i] ^ server_finished_expected[i];
+  }
   if( FD_UNLIKELY( match!=0 ) )
     return fd_tls_alert( &hs->base, FD_TLS_ALERT_DECRYPT_ERROR, FD_TLS_REASON_FINI_FAIL );
 


### PR DESCRIPTION
Custom format string specifiers conflict with compile time format string checks. Drive by: fix all format string bugs in the codebase and formating