### PR TITLE
flamenco: set error kind properly for instructions

### DIFF
--- a/contrib/test/txn-fixtures/program-tests.list
+++ b/contrib/test/txn-fixtures/program-tests.list
@@ -1,4 +1,5 @@
 dump/test-vectors/txn/fixtures/programs/2418705d8008ed1bd58108b4e9ce43ae111a1cdc_1870939.fix
+dump/test-vectors/txn/fixtures/programs/308129c271ce81ab4b217bf262dd43e855b5b119_3709853.fix
 dump/test-vectors/txn/fixtures/programs/31837b434273533d354985aa1dfdde5edf8fabe1_85273.fix
 dump/test-vectors/txn/fixtures/programs/81e2a423431d64b80c68120e7e1e04d5829b7bbc_2924287.fix
 dump/test-vectors/txn/fixtures/programs/923cbadb9bcfc4bfc32f3985b4faeade40521a38_2611281.fix

--- a/src/flamenco/runtime/context/fd_exec_instr_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_instr_ctx.h
@@ -40,6 +40,11 @@ struct __attribute__((aligned(8UL))) fd_exec_instr_ctx {
 
 FD_PROTOTYPES_BEGIN
 
+#define FD_INSTR_ERR_FOR_LOG_INSTR( instr_ctx, err ) (__extension__({ \
+    instr_ctx->txn_ctx->exec_err = err;                               \
+    instr_ctx->txn_ctx->exec_err_kind = FD_EXECUTOR_ERR_KIND_INSTR;   \
+  }))
+
 /* Constructors */
 
 void *

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -17,7 +17,10 @@
 #define FD_EXEC_CU_UPDATE( ctx, cost ) do {               \
   fd_exec_instr_ctx_t * _ctx = (ctx);                     \
   int err = fd_exec_consume_cus( _ctx->txn_ctx, (cost) ); \
-  if( FD_UNLIKELY( err ) ) return err;                    \
+  if( FD_UNLIKELY( err ) ) {                              \
+   FD_INSTR_ERR_FOR_LOG_INSTR( _ctx, err );               \
+   return err;                                            \
+  }                                                       \
   } while(0)
 
 FD_PROTOTYPES_BEGIN

--- a/src/flamenco/runtime/program/fd_compute_budget_program.c
+++ b/src/flamenco/runtime/program/fd_compute_budget_program.c
@@ -148,5 +148,6 @@ int fd_executor_compute_budget_program_execute_instructions( fd_exec_txn_ctx_t *
 
 
 int fd_compute_budget_program_execute( fd_exec_instr_ctx_t * ctx ) {
-  return fd_exec_consume_cus( ctx->txn_ctx, 150UL );
+  FD_EXEC_CU_UPDATE( ctx, DEFAULT_COMPUTE_UNITS );
+  return FD_EXECUTOR_INSTR_SUCCESS;
 }

--- a/src/flamenco/runtime/program/fd_config_program.c
+++ b/src/flamenco/runtime/program/fd_config_program.c
@@ -257,8 +257,11 @@ fd_config_program_execute( fd_exec_instr_ctx_t * ctx ) {
 
   FD_SCRATCH_SCOPE_BEGIN {
 
-  int ret = _process_config_instr( ctx );
-  return ret;
+  int rc = _process_config_instr( ctx );
+  if( FD_UNLIKELY( rc ) ) {
+    FD_INSTR_ERR_FOR_LOG_INSTR( ctx, rc );
+  }
+  return rc;
 
   } FD_SCRATCH_SCOPE_END;
 }

--- a/src/flamenco/runtime/program/fd_stake_program.c
+++ b/src/flamenco/runtime/program/fd_stake_program.c
@@ -2455,8 +2455,10 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
   fd_pubkey_t const * signers[FD_TXN_SIG_MAX] = {0};
   fd_instr_get_signers( ctx->instr, signers );
 
+  int rc;
   if( FD_UNLIKELY( ctx->instr->data==NULL ) ) {
-    return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+    rc = FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+    goto done;
   }
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L79
@@ -2471,8 +2473,10 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
   /* Fail if the number of bytes consumed by deserialize exceeds 1232
      (hardcoded constant by Agave limited_deserialize) */
   if( decode_result!=FD_BINCODE_SUCCESS ||
-      (ulong)ctx->instr->data + 1232UL<(ulong)decode.data )
-    return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+      (ulong)ctx->instr->data + 1232UL<(ulong)decode.data ) {
+    rc = FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+    goto done;
+  }
 
   /* The EpochRewards sysvar only exists after partitioned epoch rewards is activated.
      If the sysvar exists, check the `active` field */
@@ -2481,14 +2485,14 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
 
   if (epoch_rewards_active && instruction->discriminant!=fd_stake_instruction_enum_get_minimum_delegation) {
     ctx->txn_ctx->custom_err = FD_STAKE_ERR_EPOCH_REWARDS_ACTIVE;
-    return FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR;
+    rc = FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR;
+    goto done;
   }
 
   /* Replicate stake account changes to bank caches after processing the
      transaction's instructions. */
   ctx->txn_ctx->dirty_stake_acc = 1;
 
-  int rc;
   // PLEASE PRESERVE SWITCH-CASE ORDERING TO MIRROR AGAVE IMPL:
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L84
   switch( instruction->discriminant ) {
@@ -2508,10 +2512,14 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L86
     fd_borrowed_account_t * me = NULL;
     rc = get_stake_account( ctx, &me );  /* acquire_write */
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L87
     fd_rent_t const * rent = fd_sysvar_from_instr_acct_rent( ctx, 1, &rc );
-    if( FD_UNLIKELY( !rent ) ) return rc;
+    if( FD_UNLIKELY( !rent ) ) {
+      goto done;
+    }
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L88
     rc = initialize( ctx, me, 0, authorized, lockup, rent );
@@ -2535,17 +2543,25 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L91
     fd_borrowed_account_t * me = NULL;
     rc = get_stake_account( ctx, &me );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L92
     fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 1, &rc );
-    if( FD_UNLIKELY( !clock ) ) return rc;
+    if( FD_UNLIKELY( !clock ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L94
-    if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) )
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+    if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L95
     fd_pubkey_t const * custodian_pubkey = NULL;
     rc = get_optional_pubkey( ctx, 3, 0, &custodian_pubkey );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L98
     rc = authorize( ctx,
@@ -2576,18 +2592,26 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L108
     fd_borrowed_account_t * me = NULL;
     rc                         = get_stake_account( ctx, &me );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L109
-    if( ctx->instr->acct_cnt<2 )
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+    if( ctx->instr->acct_cnt<2 ) {
+      rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L110
     fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
-    if( FD_UNLIKELY( !clock ) ) return rc;
+    if( FD_UNLIKELY( !clock ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L112
     fd_pubkey_t const * custodian_pubkey = NULL;
     rc = get_optional_pubkey( ctx, 3, 0, &custodian_pubkey );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L115
     rc = authorize_with_seed( ctx,
@@ -2618,21 +2642,31 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L129
     fd_borrowed_account_t * me = NULL;
     rc                         = get_stake_account( ctx, &me );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L130
-    if( FD_UNLIKELY( ctx->instr->acct_cnt<2 ) )
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+    if( FD_UNLIKELY( ctx->instr->acct_cnt<2 ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L131
     fd_sol_sysvar_clock_t const * clock =
       fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
-    if( FD_UNLIKELY( !clock ) ) return rc;
+    if( FD_UNLIKELY( !clock ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L133
     fd_stake_history_t const * stake_history =
       fd_sysvar_from_instr_acct_stake_history( ctx, 3, &rc );
-    if( FD_UNLIKELY( !stake_history ) ) return rc;
+    if( FD_UNLIKELY( !stake_history ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L138
-    if( FD_UNLIKELY( ctx->instr->acct_cnt<5 ) )
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+    if( FD_UNLIKELY( ctx->instr->acct_cnt<5 ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      goto done;
+    }
     fd_borrowed_account_release_write( me );  /* implicit drop */
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L140
@@ -2660,10 +2694,14 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L153
     fd_borrowed_account_t * me = NULL;
     rc                         = get_stake_account( ctx, &me );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L154
-    if( FD_UNLIKELY( ctx->instr->acct_cnt<2 ) )
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+    if( FD_UNLIKELY( ctx->instr->acct_cnt<2 ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      goto done;
+    }
     fd_borrowed_account_release_write( me );  /* implicit drop */
 
     //https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L156
@@ -2683,16 +2721,24 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L167
     fd_borrowed_account_t * me = NULL;
     rc                         = get_stake_account( ctx, &me );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L168
-    if( FD_UNLIKELY( ctx->instr->acct_cnt<2 ) )
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+    if( FD_UNLIKELY( ctx->instr->acct_cnt<2 ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L169
     fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L171
     fd_stake_history_t const * stake_history = fd_sysvar_from_instr_acct_stake_history( ctx, 3, &rc );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
 
     fd_borrowed_account_release_write( me );  /* implicit drop */
 
@@ -2715,27 +2761,38 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L189
     fd_borrowed_account_t * me = NULL;
     rc = get_stake_account( ctx, &me );  /* calls acquire_write */
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L190
-    if( FD_UNLIKELY( ctx->instr->acct_cnt<2 ) )
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+    if( FD_UNLIKELY( ctx->instr->acct_cnt<2 ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L191
     fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
-    if( FD_UNLIKELY( !clock ) ) return rc;
+    if( FD_UNLIKELY( !clock ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L193
     fd_stake_history_t const * stake_history = fd_sysvar_from_instr_acct_stake_history( ctx, 3, &rc );
-    if( FD_UNLIKELY( !stake_history ) ) return rc;
+    if( FD_UNLIKELY( !stake_history ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L198
-    if( FD_UNLIKELY( ctx->instr->acct_cnt<5 ) )
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+    if( FD_UNLIKELY( ctx->instr->acct_cnt<5 ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      goto done;
+    }
 
     fd_borrowed_account_release_write( me );  /* implicit drop */
 
     uchar custodian_index           = 5;
     ulong new_rate_activation_epoch = ULONG_MAX;
-    int   err;
-    int   is_some = new_warmup_cooldown_rate_epoch( ctx, &new_rate_activation_epoch, &err );
-    if( FD_UNLIKELY( err ) ) return err;
+    int   is_some = new_warmup_cooldown_rate_epoch( ctx, &new_rate_activation_epoch, &rc );
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L200
     rc = withdraw(
@@ -2765,10 +2822,14 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L218
     fd_borrowed_account_t * me = NULL;
     rc                         = get_stake_account( ctx, &me );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L219
     fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 1, &rc );
-    if( FD_UNLIKELY( !clock ) ) return rc;
+    if( FD_UNLIKELY( !clock ) ) {
+      goto done;
+    }
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L221
     rc = deactivate( ctx, me, 0, clock, signers, &ctx->txn_ctx->custom_err );
@@ -2791,11 +2852,15 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L224
     fd_borrowed_account_t * me = NULL;
     rc = get_stake_account( ctx, &me );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L225
     fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->slot_ctx->sysvar_cache );
-    if( FD_UNLIKELY( !clock ) )
-      return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
+    if( FD_UNLIKELY( !clock ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L226
     rc = set_lockup( ctx, me, 0, lockup, signers, clock );
 
@@ -2815,23 +2880,31 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L229
     fd_borrowed_account_t * me = NULL;
     rc = get_stake_account( ctx, &me );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L230
-    if( FD_UNLIKELY( ctx->instr->acct_cnt<4 ) )
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+    if( FD_UNLIKELY( ctx->instr->acct_cnt<4 ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L231-L236
     fd_pubkey_t const * staker_pubkey     = &ctx->instr->acct_pubkeys[2];
     fd_pubkey_t const * withdrawer_pubkey = &ctx->instr->acct_pubkeys[3];
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L237
-    if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( ctx->instr, 3 ) ) )
-      return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
+    if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( ctx->instr, 3 ) ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L241
     fd_stake_authorized_t authorized = { .staker     = *staker_pubkey,
                                           .withdrawer = *withdrawer_pubkey };
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L246
     fd_rent_t const * rent = fd_sysvar_from_instr_acct_rent( ctx, 1, &rc );
-    if( FD_UNLIKELY( !rent ) ) return rc;
+    if( FD_UNLIKELY( !rent ) ) {
+      goto done;
+    }
 
     fd_stake_lockup_t lockup_default = {0};
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L247
@@ -2855,23 +2928,34 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L250
     fd_borrowed_account_t * me = NULL;
     rc                         = get_stake_account( ctx, &me );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L251
     fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 1, &rc );
-    if( FD_UNLIKELY( !clock ) ) return rc;
+    if( FD_UNLIKELY( !clock ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L253
-    if( FD_UNLIKELY( ctx->instr->acct_cnt<4 ) )
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+    if( FD_UNLIKELY( ctx->instr->acct_cnt<4 ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L254
     fd_pubkey_t const * authorized_pubkey = &ctx->instr->acct_pubkeys[3];
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L257
     int is_signer = fd_instr_acc_is_signer_idx( ctx->instr, 3 );
-    if( FD_UNLIKELY( !is_signer ) ) return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
+    if( FD_UNLIKELY( !is_signer ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L260
     fd_pubkey_t const * custodian_pubkey = NULL;
     rc = get_optional_pubkey( ctx, 4, 0, &custodian_pubkey );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L263
     rc = authorize( ctx,
@@ -2903,26 +2987,39 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L273
     fd_borrowed_account_t * me = NULL;
     rc                         = get_stake_account( ctx, &me );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L274
-    if( FD_UNLIKELY( ctx->instr->acct_cnt<2 ) )
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+    if( FD_UNLIKELY( ctx->instr->acct_cnt<2 ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L276
     fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
-    if( FD_UNLIKELY( !clock ) ) return rc;
+    if( FD_UNLIKELY( !clock ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L277
-    if( FD_UNLIKELY( ctx->instr->acct_cnt<4 ) )
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+    if( FD_UNLIKELY( ctx->instr->acct_cnt<4 ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L278
     fd_pubkey_t const * authorized_pubkey = &ctx->instr->acct_pubkeys[3];
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L281
     int is_signer = fd_instr_acc_is_signer_idx( ctx->instr, 3 );
-    if( FD_UNLIKELY( !is_signer ) ) return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
+    if( FD_UNLIKELY( !is_signer ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L284
     fd_pubkey_t const * custodian_pubkey = NULL;
     rc = get_optional_pubkey( ctx, 4, 0, &custodian_pubkey );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L287
     rc = authorize_with_seed( ctx,
@@ -2955,20 +3052,26 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L301
     fd_borrowed_account_t * me = NULL;
     rc = get_stake_account( ctx, &me );  /* acquire_write */
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L302
     fd_pubkey_t const * custodian_pubkey = NULL;
     rc = get_optional_pubkey( ctx, 2, 1, &custodian_pubkey );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L305
     fd_lockup_args_t lockup = { .unix_timestamp = lockup_checked->unix_timestamp,
                                 .epoch          = lockup_checked->epoch,
                                 .custodian      = (fd_pubkey_t *)custodian_pubkey }; // FIXME
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L310
     fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->slot_ctx->sysvar_cache );
-    if( FD_UNLIKELY( !clock ) )
-      return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
+    if( FD_UNLIKELY( !clock ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
+      goto done;
+    }
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L311
     rc = set_lockup( ctx, me, 0, &lockup, signers, clock );
@@ -3006,14 +3109,20 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L322
     fd_borrowed_account_t * me = NULL;
     rc                         = get_stake_account( ctx, &me );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L323
-    if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) )
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+    if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) ) {
+      rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      goto done;
+    }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L325
     fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->slot_ctx->sysvar_cache );
-    if( FD_UNLIKELY( !clock ) )
-      return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
+    if( FD_UNLIKELY( !clock ) ){
+      rc = FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
+      goto done;
+    }
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L326
     rc = deactivate_delinquent( ctx, me, 0, 1, 2, clock->epoch, &ctx->txn_ctx->custom_err );
@@ -3030,9 +3139,12 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
   case fd_stake_instruction_enum_redelegate: {
     fd_borrowed_account_t * me = NULL;
     rc                         = get_stake_account( ctx, &me );
-    if( FD_UNLIKELY( rc ) ) return rc;
+    if( FD_UNLIKELY( rc ) ) {
+      goto done;
+    }
 
-    return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+    rc = FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+    goto done;
   }
   /* MoveStake
    *
@@ -3046,8 +3158,10 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L359
     if( FD_LIKELY( FD_FEATURE_ACTIVE( ctx->slot_ctx, move_stake_and_move_lamports_ixs ) ) ) {
       // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L361
-      if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) )
-        return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) ) {
+        rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+        goto done;
+      }
 
       ulong lamports = instruction->inner.move_stake;
       // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L362
@@ -3059,7 +3173,8 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
                        &ctx->txn_ctx->custom_err );
     } else {
       // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L372
-      return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+      rc = FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+      goto done;
     }
     break;
   }
@@ -3075,8 +3190,10 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L378
     if( FD_LIKELY( FD_FEATURE_ACTIVE( ctx->slot_ctx, move_stake_and_move_lamports_ixs ) ) ) {
       // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L380
-      if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) )
-        return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+      if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) ) {
+        rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+        goto done;
+      }
 
       // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L381
       ulong lamports = instruction->inner.move_lamports;
@@ -3089,7 +3206,8 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
                        2UL );
     } else {
       // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L391
-      return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+      rc = FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+      goto done;
     }
     break;
   }
@@ -3098,6 +3216,9 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
   }
 
 done:
+  if( FD_UNLIKELY( rc ) ) {
+    FD_INSTR_ERR_FOR_LOG_INSTR( ctx, rc );
+  }
   return rc;
 }
 

--- a/src/flamenco/runtime/program/fd_system_program.c
+++ b/src/flamenco/runtime/program/fd_system_program.c
@@ -615,9 +615,11 @@ fd_system_program_execute( fd_exec_instr_ctx_t * ctx ) {
   FD_EXEC_CU_UPDATE( ctx, 150UL );
 
   /* Deserialize the SystemInstruction enum */
+  int rc = FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
   uchar * data = ctx->instr->data;
   if( FD_UNLIKELY( data==NULL ) ) {
-    return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+    rc = FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+    goto done;
   }
 
   fd_system_program_instruction_t instruction;
@@ -627,81 +629,83 @@ fd_system_program_execute( fd_exec_instr_ctx_t * ctx ) {
       .valloc  = fd_scratch_virtual() };
   /* Fail if the number of bytes consumed by deserialize exceeds 1232 */
   if( fd_system_program_instruction_decode( &instruction, &decode ) ||
-      (ulong)data + 1232UL < (ulong)decode.data )
-    return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
-
-  int result = FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
+      (ulong)data + 1232UL < (ulong)decode.data ) {
+    rc = FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
+    goto done;
+  }
 
   switch( instruction.discriminant ) {
   case fd_system_program_instruction_enum_create_account: {
-    result = fd_system_program_exec_create_account(
+    rc = fd_system_program_exec_create_account(
         ctx, &instruction.inner.create_account );
     break;
   }
   case fd_system_program_instruction_enum_assign: {
-    result = fd_system_program_exec_assign(
+    rc = fd_system_program_exec_assign(
         ctx, &instruction.inner.assign );
     break;
   }
   case fd_system_program_instruction_enum_transfer: {
-    result = fd_system_program_exec_transfer(
+    rc = fd_system_program_exec_transfer(
         ctx, instruction.inner.transfer );
     break;
   }
   case fd_system_program_instruction_enum_create_account_with_seed: {
-    result = fd_system_program_exec_create_account_with_seed(
+    rc = fd_system_program_exec_create_account_with_seed(
         ctx, &instruction.inner.create_account_with_seed );
     break;
   }
   case fd_system_program_instruction_enum_advance_nonce_account: {
-    result = fd_system_program_exec_advance_nonce_account( ctx );
+    rc = fd_system_program_exec_advance_nonce_account( ctx );
     break;
   }
   case fd_system_program_instruction_enum_withdraw_nonce_account: {
-    result = fd_system_program_exec_withdraw_nonce_account(
+    rc = fd_system_program_exec_withdraw_nonce_account(
         ctx, instruction.inner.withdraw_nonce_account );
     break;
   }
   case fd_system_program_instruction_enum_initialize_nonce_account: {
-    result = fd_system_program_exec_initialize_nonce_account(
+    rc = fd_system_program_exec_initialize_nonce_account(
         ctx, &instruction.inner.initialize_nonce_account );
     break;
   }
   case fd_system_program_instruction_enum_authorize_nonce_account: {
-    result = fd_system_program_exec_authorize_nonce_account(
+    rc = fd_system_program_exec_authorize_nonce_account(
         ctx, &instruction.inner.authorize_nonce_account );
     break;
   }
   case fd_system_program_instruction_enum_allocate: {
-    result = fd_system_program_exec_allocate( ctx, instruction.inner.allocate );
+    rc = fd_system_program_exec_allocate( ctx, instruction.inner.allocate );
     break;
   }
   case fd_system_program_instruction_enum_allocate_with_seed: {
     // https://github.com/solana-labs/solana/blob/b00d18cec4011bb452e3fe87a3412a3f0146942e/runtime/src/system_instruction_processor.rs#L525
-    result = fd_system_program_exec_allocate_with_seed(
+    rc = fd_system_program_exec_allocate_with_seed(
         ctx, &instruction.inner.allocate_with_seed );
     break;
   }
   case fd_system_program_instruction_enum_assign_with_seed: {
     // https://github.com/solana-labs/solana/blob/b00d18cec4011bb452e3fe87a3412a3f0146942e/runtime/src/system_instruction_processor.rs#L545
-    result = fd_system_program_exec_assign_with_seed(
+    rc = fd_system_program_exec_assign_with_seed(
         ctx, &instruction.inner.assign_with_seed );
     break;
   }
   case fd_system_program_instruction_enum_transfer_with_seed: {
     // https://github.com/solana-labs/solana/blob/b00d18cec4011bb452e3fe87a3412a3f0146942e/runtime/src/system_instruction_processor.rs#L412
-    result = fd_system_program_exec_transfer_with_seed(
+    rc = fd_system_program_exec_transfer_with_seed(
         ctx, &instruction.inner.transfer_with_seed );
     break;
   }
   case fd_system_program_instruction_enum_upgrade_nonce_account: {
     // https://github.com/solana-labs/solana/blob/b00d18cec4011bb452e3fe87a3412a3f0146942e/runtime/src/system_instruction_processor.rs#L491
-    result = fd_system_program_exec_upgrade_nonce_account( ctx );
+    rc = fd_system_program_exec_upgrade_nonce_account( ctx );
     break;
   }
   }
 
-  fd_bincode_destroy_ctx_t destroy = { .valloc = ctx->valloc };
-  fd_system_program_instruction_destroy( &instruction, &destroy );
-  return result;
+done:
+  if( FD_UNLIKELY( rc ) ) {
+    FD_INSTR_ERR_FOR_LOG_INSTR( ctx, rc );
+  }
+  return rc;
 }

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -321,6 +321,8 @@ fd_exec_test_instr_context_create( fd_exec_instr_test_runner_t *        runner,
   txn_ctx->accounts_resize_delta   = 0;
   txn_ctx->instr_info_cnt          = 0;
   txn_ctx->instr_trace_length      = 0;
+  txn_ctx->exec_err                = 0;
+  txn_ctx->exec_err_kind           = FD_EXECUTOR_ERR_KIND_EBPF;
 
   memset( txn_ctx->_txn_raw, 0, sizeof(fd_rawtxn_b_t) );
   memset( txn_ctx->return_data.program_id.key, 0, sizeof(fd_pubkey_t) );

--- a/src/flamenco/runtime/tests/fd_exec_sol_compat.c
+++ b/src/flamenco/runtime/tests/fd_exec_sol_compat.c
@@ -478,7 +478,7 @@ sol_compat_txn_fixture( fd_exec_instr_test_runner_t * runner,
 
     // Compare effects
     fd_exec_test_txn_result_t * effects = (fd_exec_test_txn_result_t *) output;
-    int ok = sol_compat_cmp_txn( effects, &fixture->output );
+    int ok = sol_compat_cmp_txn( &fixture->output, effects );
 
     // Cleanup
     pb_release( &fd_exec_test_txn_fixture_t_msg, fixture );


### PR DESCRIPTION
VM and instruction error codes were being mixed up due to error kinds not being set correctly for instructions.