### PR TITLE
flamenco: various transaction loading fixes

### DIFF
--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -19,6 +19,7 @@
 #include "program/fd_system_program.h"
 #include "program/fd_vote_program.h"
 #include "program/fd_zk_elgamal_proof_program.h"
+#include "sysvar/fd_sysvar_cache.h"
 #include "sysvar/fd_sysvar_slot_history.h"
 #include "sysvar/fd_sysvar_epoch_schedule.h"
 #include "sysvar/fd_sysvar_instructions.h"
@@ -270,7 +271,7 @@ fd_executor_verify_precompiles( fd_exec_txn_ctx_t * txn_ctx ) {
   return FD_RUNTIME_EXECUTE_SUCCESS;
 }
 
-/* https://github.com/anza-xyz/agave/blob/ae18213c19ea5335dfc75e6b6116def0f0910aff/svm/src/account_loader.rs#L458-L475 */
+/* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/account_loader.rs#L410-427 */
 static int
 accumulate_and_check_loaded_account_data_size( ulong   acc_size,
                                                ulong   requested_loaded_accounts_data_size,
@@ -282,9 +283,9 @@ accumulate_and_check_loaded_account_data_size( ulong   acc_size,
   return FD_RUNTIME_EXECUTE_SUCCESS;
 }
 
-/* https://github.com/anza-xyz/agave/blob/ae18213c19ea5335dfc75e6b6116def0f0910aff/svm/src/account_loader.rs#L261-L442 */
+/* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/account_loader.rs#L191-L372 */
 int
-fd_executor_check_txn_program_accounts_and_data_sz( fd_exec_txn_ctx_t * txn_ctx ) {
+fd_executor_load_transaction_accounts( fd_exec_txn_ctx_t * txn_ctx ) {
 
   ulong requested_loaded_accounts_data_size = 0UL;
 
@@ -294,71 +295,158 @@ fd_executor_check_txn_program_accounts_and_data_sz( fd_exec_txn_ctx_t * txn_ctx 
   requested_loaded_accounts_data_size = txn_ctx->loaded_accounts_data_size_limit;
 
   ulong accumulated_account_size = 0UL;
+  
+  /* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/account_loader.rs#L217-L296 */
+  /* In the agave client, this loop is responsible for loading in all of the
+     accounts in the transaction. This contains a LOT of special casing as their
+     accounts database is handled very differently than the FD client. 
+      
+     The logic is as follows:
+     1. If the account is the instructions sysvar, then load in the compiled
+        instructions from the transactions into the sysvar's data.
+     2. If the account is a fee payer, then it is already loaded.
+     3. If the account is an account override, then handle seperately. Account
+        overrides are used for simulating transactions.
+     4. If the account is not writable and not an instruction account and it is
+        in the loaded program cache, then load in a dummy account with the
+        correct owner and the executable flag set to true.
+     5. Otherwise load in the account from the accounts DB. If the account is
+        writable try to collect rent from the account. 
+        
+     After the account is loaded accumulate the data size to make sure the
+     transaction doesn't violate the transaction loading limit.
 
-  // https://github.com/anza-xyz/agave/blob/eff8961dcf7880aa7e438463203611a8a0088554/svm/src/account_loader.rs#L315-L335
+     In the firedancer client only some of these steps are necessary because
+     all of the accounts are loaded in from the accounts db into borrowed
+     accounts already. The instruction sysvar gets loaded in later in 
+     fd_execute_txn
+     1. If the account is writable, try to collect fees on the account. Unlike
+        the agave client, this is also done on the fee payer account. The agave
+        client tries to collect rent on the fee payer while the fee is being
+        collected in validate_fees().
+     2. If the account is not writable and it is not an instruction account
+        and would be in the loaded program cache, then it should be replaced
+        with a dummy value. 
+     */
+
+  fd_epoch_schedule_t const * schedule = fd_sysvar_cache_epoch_schedule( txn_ctx->slot_ctx->sysvar_cache );
+  ulong                       epoch    = fd_slot_to_epoch( schedule, txn_ctx->slot_ctx->slot_bank.slot, NULL );
+
   for( ulong i=0UL; i<txn_ctx->accounts_cnt; i++ ) {
-    // Check for max loaded acct size
     fd_borrowed_account_t * acct = NULL;
-    int err        = fd_txn_borrowed_account_view_idx( txn_ctx, (uchar)i, &acct );
+  
+    int   err      = fd_txn_borrowed_account_view_idx( txn_ctx, (uchar)i, &acct );
     ulong acc_size = err==FD_ACC_MGR_SUCCESS ? acct->const_meta->dlen : 0UL;
 
-    err = accumulate_and_check_loaded_account_data_size( acc_size, requested_loaded_accounts_data_size, &accumulated_account_size );
+    /* Try to collect rent on all writable accounts. If rent is collected
+       successfully, update the starting lamports accordingly to avoid
+       unbalanced lamports issues during instruction execution. 
+       TODO: the rent epoch check in the conditional should probably be moved
+       to inside fd_runtime_collect_rent_account. */
+    if( fd_txn_account_is_writable_idx( txn_ctx, (int)i ) && acct->const_meta->info.rent_epoch<=epoch ) {
+      fd_runtime_collect_rent_account( txn_ctx->slot_ctx, acct->meta, acct->pubkey, epoch );
+      acct->starting_lamports = acct->meta->info.lamports;
+    }
+
+    err = accumulate_and_check_loaded_account_data_size( acc_size,
+                                                         requested_loaded_accounts_data_size,
+                                                         &accumulated_account_size );
+
     if( FD_UNLIKELY( err!=FD_RUNTIME_EXECUTE_SUCCESS ) ) {
       return err;
     }
   }
 
-  // https://github.com/anza-xyz/agave/blob/ae18213c19ea5335dfc75e6b6116def0f0910aff/svm/src/account_loader.rs#L377-L433
-  ushort instr_cnt = txn_ctx->txn_descriptor->instr_cnt;
+  ushort      instr_cnt = txn_ctx->txn_descriptor->instr_cnt;
+  fd_pubkey_t program_owners[instr_cnt];
+  ushort      program_owners_cnt = 0;  
+
+  /* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/account_loader.rs#L297-L358 */
   for( ushort i=0; i<instr_cnt; i++ ) {
     fd_txn_instr_t const * instr = &txn_ctx->txn_descriptor->instr[i];
 
-    // https://github.com/anza-xyz/agave/blob/ae18213c19ea5335dfc75e6b6116def0f0910aff/svm/src/account_loader.rs#L384-L386
+    /* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/account_loader.rs#L304-306 */
     fd_borrowed_account_t * program_account = NULL;
     int err = fd_txn_borrowed_account_view_idx( txn_ctx, instr->program_id, &program_account );
     if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
       return FD_RUNTIME_TXN_ERR_PROGRAM_ACCOUNT_NOT_FOUND;
     }
 
-    // https://github.com/anza-xyz/agave/blob/ae18213c19ea5335dfc75e6b6116def0f0910aff/svm/src/account_loader.rs#L387-L389
+    /* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/account_loader.rs#L307-309 */
     if( FD_UNLIKELY( !memcmp( program_account->pubkey->key, fd_solana_native_loader_id.key, sizeof(fd_pubkey_t) ) ) ) {
       continue;
     }
 
-    // https://github.com/anza-xyz/agave/blob/ae18213c19ea5335dfc75e6b6116def0f0910aff/svm/src/account_loader.rs#L397-L400
+    /* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/account_loader.rs#L317-320 */
     if( FD_UNLIKELY( !fd_account_is_executable( program_account->const_meta ) ) ) {
-      return FD_RUNTIME_TXN_ERR_INVALID_PROGRAM_FOR_EXECUTION;
+      /* In the agave client if an account is not writable and it is not an
+         instruction account then a dummy account is loaded in that has the
+         executable flag set to true. This is a hack to mirror those semantics.
+         https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/account_loader.rs#L239-249 */
+
+      if( fd_txn_account_is_writable_idx( txn_ctx, instr->program_id ) ) {
+        return FD_RUNTIME_TXN_ERR_INVALID_PROGRAM_FOR_EXECUTION;
+      }
+
+      /* If it is not an instruction account */
+      fd_rawtxn_b_t *        txn_raw   = txn_ctx->_txn_raw;
+      fd_txn_instr_t const * txn_instr = &txn_ctx->txn_descriptor->instr[i];
+
+      for( ushort j=0; j<instr_cnt; j++ ) {
+        uchar const * instr_acc_idxs = fd_txn_get_instr_accts( txn_instr, txn_raw->raw );
+        for( ushort k=0; k<txn_instr->acct_cnt; k++ ) {
+          if( instr_acc_idxs[k]==instr->program_id ) {
+            return FD_RUNTIME_TXN_ERR_INVALID_PROGRAM_FOR_EXECUTION;
+          }
+        }
+      }
     }
 
-    // https://github.com/anza-xyz/agave/blob/ae18213c19ea5335dfc75e6b6116def0f0910aff/svm/src/account_loader.rs#L402-L405
-    // No FD_UNLIKELY or FD_LIKELY since it holds true for all native program invocations
+    /* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/account_loader.rs#L322-325 */
     if( !memcmp( program_account->const_meta->info.owner, fd_solana_native_loader_id.key, sizeof(fd_pubkey_t) ) ) {
       continue;
     }
 
-    /* https://github.com/anza-xyz/agave/blob/ae18213c19ea5335dfc75e6b6116def0f0910aff/svm/src/account_loader.rs#L406-L410
-       Side note: I don't think there's a single condition where this statement evaluates to false since builtins_start_index
-       seems to be tied to accounts.len(), so I'll skip this check. Moving on... */
+    /* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/account_loader.rs#L326-330
+       The agave client does checks on the program account's owners as well.
+       However, it is important to not do these checks multiple times as the
+       total size of accounts and their owners are accumulated: duplicate owners
+       should be avoided. */
 
-    // https://github.com/anza-xyz/agave/blob/ae18213c19ea5335dfc75e6b6116def0f0910aff/svm/src/account_loader.rs#L412-L429
+    /* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/account_loader.rs#L334-353 */
     FD_BORROWED_ACCOUNT_DECL( owner_account );
     err = fd_acc_mgr_view( txn_ctx->slot_ctx->acc_mgr, txn_ctx->slot_ctx->funk_txn, (fd_pubkey_t *) program_account->const_meta->info.owner, owner_account );
     if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
       return FD_RUNTIME_TXN_ERR_PROGRAM_ACCOUNT_NOT_FOUND;
     }
 
-    // https://github.com/anza-xyz/agave/blob/ae18213c19ea5335dfc75e6b6116def0f0910aff/svm/src/account_loader.rs#L413-L418
-    if( FD_UNLIKELY( memcmp( owner_account->const_meta->info.owner, fd_solana_native_loader_id.key, sizeof(fd_pubkey_t) )
-                  || !fd_account_is_executable( owner_account->const_meta ) ) ) {
+    for( ushort i=0; i<program_owners_cnt; i++ ) {
+      if( !memcmp( program_owners[i].key, owner_account->pubkey, sizeof(fd_pubkey_t) ) ) {
+        /* If the account has already been seen, skip the owner checks*/
+        goto skip_owner_checks;
+      }
+    }
+
+    /* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/account_loader.rs#L335-341 */
+    if( FD_UNLIKELY( memcmp( owner_account->const_meta->info.owner, fd_solana_native_loader_id.key, sizeof(fd_pubkey_t) ) ||
+                     !fd_account_is_executable( owner_account->const_meta ) ) ) {
       return FD_RUNTIME_TXN_ERR_INVALID_PROGRAM_FOR_EXECUTION;
     }
 
-    // https://github.com/anza-xyz/agave/blob/ae18213c19ea5335dfc75e6b6116def0f0910aff/svm/src/account_loader.rs#L419-L424
-    // TODO: Agave's implementation seems to double-count if the owner is part of the account keys...
-    err = accumulate_and_check_loaded_account_data_size( owner_account->const_meta->dlen, requested_loaded_accounts_data_size, &accumulated_account_size );
+    /* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/account_loader.rs#L342-347 */
+    /* Count the owner's data in the loaded account size for program accounts.
+       However, it is important to not double count repeated owners. */
+    err = accumulate_and_check_loaded_account_data_size( owner_account->const_meta->dlen, 
+                                                         requested_loaded_accounts_data_size, 
+                                                         &accumulated_account_size );
     if( FD_UNLIKELY( err!=FD_RUNTIME_EXECUTE_SUCCESS ) ) {
       return err;
     }
+
+    fd_memcpy( &program_owners[program_owners_cnt++], owner_account->pubkey, sizeof(fd_pubkey_t) );
+
+    skip_owner_checks:
+    (void)err;
   }
 
   return FD_RUNTIME_EXECUTE_SUCCESS;
@@ -1578,9 +1666,9 @@ fd_execute_txn( fd_exec_txn_ctx_t * txn_ctx ) {
       return FD_EXECUTOR_INSTR_ERR_MAX_INSN_TRACE_LENS_EXCEEDED;
     }
 
+    /* TODO: This needs to get moved to fd_executor_load_transaction_accounts */
     int ret = 0;
-
-    if ( FD_UNLIKELY( use_sysvar_instructions ) ) {
+    if( FD_UNLIKELY( use_sysvar_instructions ) ) {
       ret = fd_sysvar_instructions_serialize_account( txn_ctx, (fd_instr_info_t const *)txn_ctx->instr_infos, txn_ctx->txn_descriptor->instr_cnt );
       if( ret != FD_ACC_MGR_SUCCESS ) {
         FD_LOG_WARNING(( "sysvar instrutions failed to serialize" ));

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -134,7 +134,7 @@ FD_FN_CONST char const *
 fd_executor_instr_strerror( int err );
 
 int
-fd_executor_check_txn_program_accounts_and_data_sz( fd_exec_txn_ctx_t * txn_ctx );
+fd_executor_load_transaction_accounts( fd_exec_txn_ctx_t * txn_ctx );
 
 static inline int
 fd_exec_consume_cus( fd_exec_txn_ctx_t * txn_ctx,

--- a/src/flamenco/runtime/program/fd_config_program.h
+++ b/src/flamenco/runtime/program/fd_config_program.h
@@ -18,7 +18,7 @@ FD_PROTOTYPES_BEGIN
    for the config program. */
 
 int
-fd_config_program_execute( fd_exec_instr_ctx_t * ctx ) ;
+fd_config_program_execute( fd_exec_instr_ctx_t * ctx );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/tests/run_ledger_tests_all.txt
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.txt
@@ -63,3 +63,5 @@ src/flamenco/runtime/tests/run_ledger_test.sh -l v203-multi-epoch-per-superfeatu
 src/flamenco/runtime/tests/run_ledger_test.sh -l v203-multi-epoch-per-superfeature-160 -s snapshot-160-9kvex5W9axd5C2Yr4kTEDP6qQBHSkWXS4Rh9hFgKPPQc.tar.zst -p 30 -y 16 -m 5000000 -e 631 -c 2.0.3 -o PERzQrt5gBD1XEe2c9XdFWqwgHY3mr7cYWbm5V772V8
 src/flamenco/runtime/tests/run_ledger_test.sh -l v203-multi-epoch-per-superfeature-400 -s snapshot-400-F1ja3hM4JcRzBrxr7U3my1xqNo64fYkcwRgVijm4uux7.tar.zst -p 30 -y 16 -m 5000000 -e 631 -c 2.0.3 -o PERzQrt5gBD1XEe2c9XdFWqwgHY3mr7cYWbm5V772V8
 src/flamenco/runtime/tests/run_ledger_test.sh -l v208-zk-sdk-ledger -s snapshot-1-GNxLdkaRgGzZSKj79d7yUXK8Nd7dv87WckoCdzQYH4X2.tar.zst -p 30 -y 16 -m 500000 -e 82 -c 2.0.8
+src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-294739503 -s snapshot-294739500-2Y8hFyTtyMuHCgpe26Y1HostyWMZjFvskV5ZpaX6X62S.tar.zst -p 30 -y 16 -m 5000000 -e 294739505 -c 2.0.3
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-290621930 -s snapshot-290621927-AxDRmQNPmGzo1V7KRXfPXtDXTBU3AZj3MUEM1ns3CgH.tar.zst -p 30 -y 16 -m 5000000 -e 290621932 -c 1.19.0

--- a/src/flamenco/runtime/tests/test_exec_instr.c
+++ b/src/flamenco/runtime/tests/test_exec_instr.c
@@ -1,6 +1,7 @@
 #define FD_SCRATCH_USE_HANDHOLDING 1
 #define WKSP_TAG 2
 
+#include "../../fd_flamenco.h"
 #include "../../fd_flamenco_base.h"
 #include "fd_exec_instr_test.h"
 #include <errno.h>
@@ -59,6 +60,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
+  fd_flamenco_boot( NULL, NULL );
 
   /* TODO switch to leap API and set up a thread pool once available */
   ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );

--- a/src/flamenco/runtime/tests/test_exec_sol_compat.c
+++ b/src/flamenco/runtime/tests/test_exec_sol_compat.c
@@ -1,5 +1,6 @@
 #define FD_SCRATCH_USE_HANDHOLDING 1
 #include "../../fd_flamenco_base.h"
+#include "../../fd_flamenco.h"
 #include "fd_exec_sol_compat.h"
 #include <errno.h>
 #include <fcntl.h>
@@ -58,6 +59,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
+  fd_flamenco_boot( NULL, NULL );
   sol_compat_wksp_init();
   ulong fmem[ 64 ];
 


### PR DESCRIPTION
1. mocking executable flag for non-writable, non-instruction accounts
2. fixing double counting owners size bug
3. collecting rent from writable accounts