### PR TITLE
flamenco: CPI use syscall error codes in preflight checks and check instr

### DIFF
--- a/src/flamenco/vm/fd_vm_base.h
+++ b/src/flamenco/vm/fd_vm_base.h
@@ -79,16 +79,6 @@
 #define FD_VM_SH_OVERFLOW           (-37) /* detected a shift overflow, equivalent to VeriferError::ShiftWithOverflow */
 #define FD_VM_TEXT_SZ_UNALIGNED     (-38) /* detected a text section that is not a multiple of 8 */
 
-/* Error codes related to CPI syscall.
-   FIXME: Should this be in fd_executor_err.h instead?
-          Or a separate file for syscall errors? */
-
-#define FD_VM_CPI_ERR_TOO_MANY_SIGNERS       (-39) /* detected too many signers */
-#define FD_VM_CPI_ERR_TOO_MANY_ACC_INFOS     (-40) /* detected too many account infos */
-#define FD_VM_CPI_ERR_INSTR_TOO_LARGE        (-41) /* detected too many account infos meta */
-#define FD_VM_CPI_ERR_INSTR_DATA_TOO_LARGE   (-42) /* detected instruction data too large */
-#define FD_VM_CPI_ERR_TOO_MANY_ACC_METAS     (-43) /* detected too many account metas */
-
 /* Syscall Errors
    https://github.com/anza-xyz/agave/blob/v2.0.7/programs/bpf_loader/src/syscalls/mod.rs#L81 */
 
@@ -114,6 +104,7 @@
 #define FD_VM_ERR_SYSCALL_INVALID_POINTER                         (-20)
 #define FD_VM_ERR_SYSCALL_ARITHMETIC_OVERFLOW                     (-21)
 
+/* Poseidon returns custom errors for some reason */
 #define FD_VM_ERR_SYSCALL_POSEIDON_INVALID_PARAMS                 (1)
 #define FD_VM_ERR_SYSCALL_POSEIDON_INVALID_ENDIANNESS             (2)
 

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
@@ -398,7 +398,7 @@ fd_vm_syscall_cpi_preflight_check( ulong signers_seeds_cnt,
   if( FD_UNLIKELY( signers_seeds_cnt > FD_CPI_MAX_SIGNER_CNT ) ) {
     // TODO: return SyscallError::TooManySigners
     FD_LOG_WARNING(("TODO: return too many signers" ));
-    return FD_VM_CPI_ERR_TOO_MANY_SIGNERS;
+    return FD_VM_ERR_SYSCALL_TOO_MANY_SIGNERS;
   }
 
   /* https://github.com/solana-labs/solana/blob/eb35a5ac1e7b6abe81947e22417f34508f89f091/programs/bpf_loader/src/syscalls/cpi.rs#L996-L997 */
@@ -406,7 +406,7 @@ fd_vm_syscall_cpi_preflight_check( ulong signers_seeds_cnt,
     if( FD_UNLIKELY( acct_info_cnt > FD_CPI_MAX_ACCOUNT_INFOS  ) ) {
       // TODO: return SyscallError::MaxInstructionAccountInfosExceeded
       FD_LOG_WARNING(( "TODO: return max instruction account infos exceeded" ));
-      return FD_VM_CPI_ERR_TOO_MANY_ACC_INFOS;
+      return FD_VM_ERR_SYSCALL_MAX_INSTRUCTION_ACCOUNT_INFOS_EXCEEDED;
     }
   } else {
     ulong adjusted_len = fd_ulong_sat_mul( acct_info_cnt, sizeof( fd_pubkey_t ) );
@@ -415,7 +415,7 @@ fd_vm_syscall_cpi_preflight_check( ulong signers_seeds_cnt,
          maximum that accounts that could be passed in an instruction
          TODO: return SyscallError::TooManyAccounts */
       FD_LOG_WARNING(( "TODO: return max instruction account infos exceeded" ));
-      return FD_VM_CPI_ERR_TOO_MANY_ACC_INFOS;
+      return FD_VM_ERR_SYSCALL_MAX_INSTRUCTION_ACCOUNT_INFOS_EXCEEDED;
     }
   }
 
@@ -435,12 +435,12 @@ fd_vm_syscall_cpi_check_instruction( fd_vm_t const * vm,
     if( FD_UNLIKELY( data_sz > FD_CPI_MAX_INSTRUCTION_DATA_LEN ) ) {
       FD_LOG_WARNING(( "cpi: data too long (%#lx)", data_sz ));
       // SyscallError::MaxInstructionDataLenExceeded
-      return FD_VM_CPI_ERR_INSTR_DATA_TOO_LARGE;
+      return FD_VM_ERR_SYSCALL_MAX_INSTRUCTION_DATA_LEN_EXCEEDED;
     }
     if( FD_UNLIKELY( acct_cnt > FD_CPI_MAX_INSTRUCTION_ACCOUNTS ) ) {
       FD_LOG_WARNING(( "cpi: too many accounts (%#lx)", acct_cnt ));
       // SyscallError::MaxInstructionAccountsExceeded
-      return FD_VM_CPI_ERR_TOO_MANY_ACC_METAS;
+      return FD_VM_ERR_SYSCALL_MAX_INSTRUCTION_ACCOUNTS_EXCEEDED;
     }
   } else {
     // https://github.com/solana-labs/solana/blob/dbf06e258ae418097049e845035d7d5502fe1327/programs/bpf_loader/src/syscalls/cpi.rs#L1114
@@ -448,7 +448,7 @@ fd_vm_syscall_cpi_check_instruction( fd_vm_t const * vm,
     if ( FD_UNLIKELY( tot_sz > FD_VM_MAX_CPI_INSTRUCTION_SIZE ) ) {
       FD_LOG_WARNING(( "cpi: instruction too long (%#lx)", tot_sz ));
       // SyscallError::InstructionTooLarge
-      return FD_VM_CPI_ERR_INSTR_TOO_LARGE;
+      return FD_VM_ERR_SYSCALL_INSTRUCTION_TOO_LARGE;
     }
   }
 

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
@@ -596,7 +596,10 @@ VM_SYSCALL_CPI_ENTRYPOINT( void *  _vm,
 
   /* Pre-flight checks ************************************************/
   int err = fd_vm_syscall_cpi_preflight_check( signers_seeds_cnt, acct_info_cnt, vm->instr_ctx->slot_ctx );
-  if( FD_UNLIKELY( err ) ) return err;
+  if( FD_UNLIKELY( err ) ) {
+    FD_VM_ERR_FOR_LOG_SYSCALL( vm, err );
+    return err;
+  }
   
   /* Translate instruction ********************************************/
   VM_SYSCALL_CPI_INSTR_T const * cpi_instruction =
@@ -640,7 +643,10 @@ VM_SYSCALL_CPI_ENTRYPOINT( void *  _vm,
   /* Instruction checks ***********************************************/
 
   err = fd_vm_syscall_cpi_check_instruction( vm, VM_SYSCALL_CPI_INSTR_ACCS_LEN( cpi_instruction ), VM_SYSCALL_CPI_INSTR_DATA_LEN( cpi_instruction ) );
-  if( FD_UNLIKELY( err ) ) return err;
+  if( FD_UNLIKELY( err ) ) {
+    FD_VM_ERR_FOR_LOG_SYSCALL( vm, err );
+    return err;
+  }
 
   /* Translate account infos ******************************************/
   VM_SYSCALL_CPI_ACC_INFO_T * acc_infos =


### PR DESCRIPTION
Realized there were existing mappings for these error codes. We don't need new ones