### PR TITLE
Fast parallel compressed wksp checkpt/restore

### DIFF
--- a/src/app/fdctl/run/topos/fd_firedancer.c
+++ b/src/app/fdctl/run/topos/fd_firedancer.c
@@ -690,18 +690,16 @@ fd_topo_initialize( config_t * config ) {
     /* Make the status cache workspace match the parameters used to create the
        checkpoint. This is a bit nonintuitive because of the way
        fd_topo_create_workspace works. */
-    uint seed;
-    ulong part_max;
-    ulong data_max;
-    int err = fd_wksp_restore_preview( status_cache, &seed, &part_max, &data_max );
-    if( err ) FD_LOG_ERR(( "unable to restore %s: error %d", status_cache, err ));
+    fd_wksp_preview_t preview[1];
+    int err = fd_wksp_preview( status_cache, preview );
+    if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "unable to preview %s: error %d", status_cache, err ));
     fd_topo_wksp_t * wksp = &topo->workspaces[ topo->objs[ txncache_obj->id ].wksp_id ];
-    wksp->part_max = part_max;
+    wksp->part_max = preview->part_max;
     wksp->known_footprint = 0;
-    wksp->total_footprint = data_max;
+    wksp->total_footprint = preview->data_max;
     ulong page_sz = FD_SHMEM_GIGANTIC_PAGE_SZ;
     wksp->page_sz = page_sz;
-    ulong footprint = fd_wksp_footprint( part_max, data_max );
+    ulong footprint = fd_wksp_footprint( preview->part_max, preview->data_max );
     wksp->page_cnt = footprint / page_sz;
   }
 

--- a/src/app/rpcserver/main.c
+++ b/src/app/rpcserver/main.c
@@ -120,16 +120,14 @@ init_args_offline( int * argc, char *** argv, fd_rpcserver_args_t * args ) {
   } else {
     char const * restore = fd_env_strip_cmdline_cstr ( argc, argv, "--restore-blockstore", NULL, NULL );
     if( restore == NULL ) FD_LOG_ERR(( "must use --wksp-name-blockstore or --restore-blockstore in offline mode" ));
-    uint seed;
-    ulong part_max;
-    ulong data_max;
-    int err = fd_wksp_restore_preview( restore, &seed, &part_max, &data_max );
+    fd_wksp_preview_t preview[1];
+    int err = fd_wksp_preview( restore, preview );
     if( err ) FD_LOG_ERR(( "unable to restore %s: error %d", restore, err ));
-    ulong page_cnt = (data_max + FD_SHMEM_GIGANTIC_PAGE_SZ-1U)/FD_SHMEM_GIGANTIC_PAGE_SZ;
+    ulong page_cnt = (preview->data_max + FD_SHMEM_GIGANTIC_PAGE_SZ-1U)/FD_SHMEM_GIGANTIC_PAGE_SZ;
     wksp = fd_wksp_new_anonymous( FD_SHMEM_GIGANTIC_PAGE_SZ, page_cnt, 0, "wksp-blockstore", 0UL );
     if( !wksp ) FD_LOG_ERR(( "unable to restore %s: failed to create wksp", restore ));
     FD_LOG_NOTICE(( "restoring blockstore wksp %s", restore ));
-    fd_wksp_restore( wksp, restore, seed );
+    fd_wksp_restore( wksp, restore, preview->seed );
   }
   fd_wksp_tag_query_info_t info;
   ulong tag = 1;

--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -458,7 +458,7 @@ fd_topob_finish( fd_topo_t * topo,
       loose_sz += loose( topo, obj );
     }
 
-    ulong part_max = 1UL + (loose_sz / (64UL << 10));
+    ulong part_max = 3UL + (loose_sz / (64UL << 10)); /* 3 for initial alignment + actual alloc + residual padding */
     ulong offset = fd_ulong_align_up( fd_wksp_private_data_off( part_max ), fd_topo_workspace_align() );
 
     for( ulong j=0UL; j<topo->obj_cnt; j++ ) {

--- a/src/funk/fd_funk_filemap.c
+++ b/src/funk/fd_funk_filemap.c
@@ -305,14 +305,17 @@ fd_funk_recover_checkpoint( const char * funk_filename,
                             fd_funk_close_file_args_t * close_args_out ) {
   /* Make the funk workspace match the parameters used to create the
      checkpoint. */
-  uint seed;
-  ulong part_max;
-  ulong data_max;
-  int err = fd_wksp_restore_preview( checkpt_filename, &seed, &part_max, &data_max );
+
+  fd_wksp_preview_t preview[1];
+  int err = fd_wksp_preview( checkpt_filename, preview );
   if( FD_UNLIKELY( err ) ) {
-    FD_LOG_WARNING(( "unable to preview %s", checkpt_filename ));
+    FD_LOG_WARNING(( "unable to preview %s (%i-%s)", checkpt_filename, err, fd_wksp_strerror( err ) ));
     return NULL;
   }
+  uint  seed     = preview->seed;
+  ulong part_max = preview->part_max;
+  ulong data_max = preview->data_max;
+
   ulong total_sz = fd_wksp_footprint( part_max, data_max );
 
   int fd;

--- a/src/util/alloc/test_alloc.c
+++ b/src/util/alloc/test_alloc.c
@@ -62,7 +62,7 @@ test_main( int     argc,
 
   for( ulong i=0UL; i<2UL*alloc_cnt; i++ ) {
 
-#   if !FD_HAS_DEEPASAN
+    #if !FD_HAS_DEEPASAN
     if( (i & print_mask)==print_interval )  {
       char * info    = NULL;
       ulong  info_sz = 0UL;
@@ -75,7 +75,7 @@ test_main( int     argc,
       FD_LOG_DEBUG(( "fd_alloc_fprintf said:\n%*s", (int)(info_sz&INT_MAX), info ));
       free( info );
     }
-#   endif
+    #endif
 
     /* Determine if we should alloc or free this iteration.  If j==0,
        there are no outstanding allocs to free so we must alloc.  If
@@ -96,22 +96,21 @@ test_main( int     argc,
       ulong align    = fd_ulong_if( lg_align==lg_align_max+1, 0UL, 1UL<<lg_align );
 
       sz[j] = fd_rng_ulong_roll( rng, sz_max+1UL );
-#     if FD_HAS_DEEPASAN
+      #if FD_HAS_DEEPASAN
       /* Enforce 8 byte alignment requirements */
       align = fd_ulong_if( align < FD_ASAN_ALIGN, FD_ASAN_ALIGN, align );
       sz[j] = fd_ulong_if( sz[j] < FD_ASAN_ALIGN, FD_ASAN_ALIGN, sz[j] ); 
-#     endif
+      #endif
 
       /* Allocate it */
 
       ulong max;
       mem[j] = (uchar *)fd_alloc_malloc_at_least( alloc, align, sz[j], &max );
 
-#     if FD_HAS_DEEPASAN
-      if( mem[j] && sz[j] ) {
+      #if FD_HAS_DEEPASAN
+      if ( mem[j] && sz[j] )
         FD_TEST( fd_asan_query( mem[j], sz[j] ) == NULL );
-      }
-#     endif
+      #endif
 
       /* Check if the value is sane */
 
@@ -155,11 +154,10 @@ test_main( int     argc,
 
       fd_alloc_free( alloc, mem[k] );
 
-#     if FD_HAS_DEEPASAN
-      if( mem[k] && sz[k] ) {
-        FD_TEST( fd_asan_query( mem[k], sz[k] ) != NULL );
-      }
-#     endif
+      #if FD_HAS_DEEPASAN
+      if ( mem[k] && sz[k] )
+          FD_TEST( fd_asan_query( mem[k], sz[k] ) != NULL );
+      #endif
 
       /* Remove from outstanding allocations */
 
@@ -169,6 +167,127 @@ test_main( int     argc,
       pat[k] = pat[j];
 
     }
+  }
+
+  fd_alloc_leave( alloc );
+  fd_rng_delete( fd_rng_leave( rng ) );
+  return 0;
+}
+
+#define TEST2_SLOT_MAX 64
+
+static struct __attribute__((aligned(128))) {
+  ulong   lock;
+  uchar * mem;
+  ulong   sz;
+  ulong   pat;
+  ulong   src;
+} test2_slot[ TEST2_SLOT_MAX ];
+
+static int
+test2_main( int     argc,
+            char ** argv ) {
+  (void)argc; (void)argv;
+
+  ulong tile_idx = fd_tile_idx();
+
+  void * shalloc   = FD_VOLATILE_CONST( _shalloc   );
+  ulong  alloc_cnt = FD_VOLATILE_CONST( _alloc_cnt );
+  ulong  align_max = FD_VOLATILE_CONST( _align_max );
+  ulong  sz_max    = FD_VOLATILE_CONST( _sz_max    );
+
+  fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, (uint)tile_idx, 0UL ) );
+
+  fd_alloc_t * alloc = fd_alloc_join( shalloc, tile_idx );
+
+  int lg_align_max = fd_ulong_find_msb( align_max );
+
+  while( !FD_VOLATILE( _go ) ) FD_SPIN_PAUSE();
+
+  for( ulong i=0UL; i<(2UL*alloc_cnt); i++ ) {
+
+    /* Pick a random slot and lock it */
+
+    ulong idx;
+    for(;;) {
+      idx = (ulong)(fd_rng_uint( rng ) & (uint)(TEST2_SLOT_MAX-1));
+      ulong volatile * lock = &test2_slot[ idx ].lock;
+      if( FD_LIKELY( !lock[0] ) && FD_LIKELY( !FD_ATOMIC_CAS( lock, 0UL, 1UL ) ) ) break;
+      FD_SPIN_PAUSE();
+    }
+
+    /* If there is no allocation associated with this slot, allocate
+       some memory and fill it with a test pattern.  Otherwise, make
+       sure the test pattern is fine and free the memory.  Note that
+       this memory could have been allocated by another thread. */
+
+    uchar * mem = test2_slot[ idx ].mem;
+    if( !mem ) {
+
+      /* Pick the size and alignment randomly */
+
+      int   lg_align = fd_rng_int_roll( rng, lg_align_max+2 );
+      ulong align    = fd_ulong_if( lg_align==lg_align_max+1, 0UL, 1UL<<lg_align );
+      ulong sz       = fd_rng_ulong_roll( rng, sz_max+1UL );
+
+      /* Allocate it */
+
+      ulong max;
+      mem = (uchar *)fd_alloc_malloc_at_least( alloc, align, sz, &max );
+
+      /* Check if the value is sane */
+
+      if( !sz && mem )
+        FD_LOG_ERR(( "On tile %lu, alloc(%lu,%lu) failed, got %lx, expected NULL", tile_idx, align, sz, (ulong)mem ));
+
+      if( sz && !mem )
+        FD_LOG_ERR(( "On tile %lu, alloc(%lu,%lu) failed, got %lx, expected non-NULL", tile_idx, align, sz, (ulong)mem ));
+
+      if( !align ) align = FD_ALLOC_MALLOC_ALIGN_DEFAULT;
+      if( !fd_ulong_is_aligned( (ulong)mem, align ) )
+        FD_LOG_ERR(( "On tile %lu, alloc(%lu,%lu) failed, got %lx (misaligned)", tile_idx, align, sz, (ulong)mem ));
+
+      FD_TEST( mem ? (max>=sz) : (!max) );
+
+      /* Fill it with a bit pattern unique to this allocation */
+
+      ulong pat = (tile_idx<<32) | i;
+      ulong b;
+      for( b=0UL; (b+7UL)<sz; b+=8UL ) *((ulong *)(mem+b)) = pat;
+      for( ; b<sz; b++ ) mem[b] = ((uchar)tile_idx);
+
+      /* This allocation is now outstanding */
+
+      test2_slot[ idx ].mem = mem;
+      test2_slot[ idx ].sz  = sz;
+      test2_slot[ idx ].pat = pat;
+      test2_slot[ idx ].src = tile_idx;
+
+    } else {
+
+      /* Validate the bit pattern was preserved between alloc and free */
+
+      ulong sz  = test2_slot[ idx ].sz;
+      ulong pat = test2_slot[ idx ].pat;
+      ulong src = test2_slot[ idx ].src;
+
+      ulong b;
+      for( b=0UL; (b+7UL)<sz; b+=8UL )
+        if( (*(ulong *)(mem+b))!=pat ) { FD_LOG_WARNING(( "On tile %lu, memory corruption detected", tile_idx )); break; }
+      for( ; b<sz; b++ ) if( mem[b]!=((uchar)src) ) { FD_LOG_WARNING(( "On tile %lu, memory corruption detected", tile_idx )); break; }
+
+      /* Free the allocation */
+
+      fd_alloc_free( alloc, mem );
+
+      /* Remove from outstanding allocations */
+
+      test2_slot[ idx ].mem = NULL;
+    }
+
+    /* Release the lock */
+
+    FD_VOLATILE( test2_slot[ idx ].lock ) = 0UL;
   }
 
   fd_alloc_leave( alloc );
@@ -190,6 +309,7 @@ main( int     argc,
   ulong        sz_max    = fd_env_strip_cmdline_ulong( &argc, &argv, "--sz-max",    NULL,         73728UL );
   ulong        tag       = fd_env_strip_cmdline_ulong( &argc, &argv, "--tag",       NULL,          1234UL );
   ulong        tile_cnt  = fd_tile_cnt();
+  int          paired    = fd_env_strip_cmdline_int  ( &argc, &argv, "--paired",    NULL,               1 );
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, (uint)tile_cnt, 0UL ) );
 
@@ -281,8 +401,8 @@ main( int     argc,
 
   } while(0);
 
-  FD_LOG_NOTICE(( "Running torture test with --alloc-cnt %lu, --align-max %lu, --sz-max %lu on %lu tile(s)",
-                  alloc_cnt, align_max, sz_max, tile_cnt ));
+  FD_LOG_NOTICE(( "Running torture test with --alloc-cnt %lu, --align-max %lu, --sz-max %lu, --paired %i on %lu tile(s)",
+                  alloc_cnt, align_max, sz_max, paired, tile_cnt ));
 
   FD_COMPILER_MFENCE();
   FD_VOLATILE( _go        ) = 0;
@@ -293,7 +413,11 @@ main( int     argc,
   FD_COMPILER_MFENCE();
 
   fd_tile_exec_t * exec[ FD_TILE_MAX ];
-  for( ulong tile_idx=1UL; tile_idx<tile_cnt; tile_idx++ ) exec[tile_idx] = fd_tile_exec_new( tile_idx, test_main, 0, NULL );
+
+  if( paired )
+    for( ulong tile_idx=1UL; tile_idx<tile_cnt; tile_idx++ ) exec[tile_idx] = fd_tile_exec_new( tile_idx, test_main,  0, NULL );
+  else
+    for( ulong tile_idx=1UL; tile_idx<tile_cnt; tile_idx++ ) exec[tile_idx] = fd_tile_exec_new( tile_idx, test2_main, 0, NULL );
 
   /* Wait ~1/10 second to get ready and then go */
 
@@ -303,7 +427,8 @@ main( int     argc,
   FD_VOLATILE( _go ) = 1;
   FD_COMPILER_MFENCE();
 
-  test_main( 0, NULL );
+  if( paired ) test_main ( 0, NULL );
+  else         test2_main( 0, NULL );
 
   FD_LOG_NOTICE(( "Waiting for remote tiles to finish" ));
 

--- a/src/util/checkpt/fd_restore.c
+++ b/src/util/checkpt/fd_restore.c
@@ -38,17 +38,12 @@ fd_restore_private_lz4( LZ4_streamDecode_t * lz4,
     return 0UL;
   }
 
-  if( FD_UNLIKELY( cbuf_max<4UL ) ) {
-    FD_LOG_WARNING(( "not enough room to compress" ));
-    return 0UL;
-  }
-
-  /* Restore and validate header */
-
   if( FD_UNLIKELY( cbuf_max<4UL ) ) { /* 3 bytes for header, 1 byte minimum for body */
     FD_LOG_WARNING(( "truncated header" ));
     return 0UL;
   }
+
+  /* Restore and validate header */
 
   ulong ubuf_csz = (((ulong)(uchar)cbuf[0])      )
                  | (((ulong)(uchar)cbuf[1]) <<  8)

--- a/src/util/checkpt/test_checkpt_stream.c
+++ b/src/util/checkpt/test_checkpt_stream.c
@@ -89,10 +89,7 @@ main( int argc,
 
   /* Note: strerror tested in mmio */
 
-# define RESET(fd) do {                                                       \
-    if( FD_UNLIKELY( lseek( (fd), (off_t)0, SEEK_SET ) ) )                    \
-      FD_LOG_ERR(( "lseek failed (%i-%s)", errno, fd_io_strerror( errno ) )); \
-  } while(0)
+# define RESET(fd) do { ulong _dummy; FD_TEST( !fd_io_seek( (fd), 0L, FD_IO_SEEK_TYPE_SET, &_dummy ) ); } while(0)
 
   FD_LOG_NOTICE(( "Testing fd_checkpt_init_stream" ));
 
@@ -104,6 +101,11 @@ main( int argc,
 
   fd_checkpt_t * checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
 
+  FD_TEST( fd_checkpt_is_mmio( checkpt )==0       );
+  FD_TEST( fd_checkpt_fd     ( checkpt )==fd      );
+  FD_TEST( fd_checkpt_wbuf   ( checkpt )==wbuf    );
+  FD_TEST( fd_checkpt_wbuf_sz( checkpt )==wbuf_sz );
+
   FD_LOG_NOTICE(( "Testing fd_checkpt_fini" ));
 
   FD_TEST( !fd_checkpt_fini( NULL ) );                      /* NULL checkpt */
@@ -111,72 +113,152 @@ main( int argc,
 
   RESET( fd );
   checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
-  FD_TEST( !fd_checkpt_frame_open( checkpt, 0 ) );          /* open default (raw) frame */
+  FD_TEST( !fd_checkpt_open( checkpt, 0 ) );                /* open default (raw) frame */
   FD_TEST( !fd_checkpt_fini( checkpt ) );                   /* fini (in frame) */
   FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt ); /* fini (failed) */
 
-  FD_LOG_NOTICE(( "Testing fd_checkpt_frame_open" ));
+  FD_LOG_NOTICE(( "Testing fd_checkpt_open" ));
 
-  FD_TEST(  fd_checkpt_frame_open( NULL, 0 )==FD_CHECKPT_ERR_INVAL ); /* NULL checkpt */
-
-  RESET( fd );
-  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
-  FD_TEST( !fd_checkpt_frame_open( checkpt, style_raw ) );                       /* open raw frame */
-  FD_TEST(  fd_checkpt_frame_open( checkpt, style_raw )==FD_CHECKPT_ERR_INVAL ); /* in frame */
-  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );                      /* fini (failed) */
+  FD_TEST(  fd_checkpt_open( NULL, 0 )==FD_CHECKPT_ERR_INVAL ); /* NULL checkpt */
 
   RESET( fd );
   checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
-  FD_TEST( !fd_checkpt_frame_open( checkpt, style_lz4 ) );  /* open lz4 frame (if target supports, raw if not) */
+  FD_TEST( !fd_checkpt_open( checkpt, style_raw ) );                       /* open raw frame */
+  FD_TEST(  fd_checkpt_open( checkpt, style_raw )==FD_CHECKPT_ERR_INVAL ); /* in frame */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );                /* fini (failed) */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_open( checkpt, style_lz4 ) );        /* open lz4 frame (if target supports, raw if not) */
   FD_TEST( !fd_checkpt_fini( checkpt ) );                   /* fini (in frame) */
   FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt ); /* fini (failed) */
 
   RESET( fd );
   checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
-  FD_TEST(  fd_checkpt_frame_open( checkpt, -1 )==FD_CHECKPT_ERR_UNSUP ); /* unsupported frame */
-  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );               /* fini (failed) */
+  FD_TEST(  fd_checkpt_open( checkpt, -1 )==FD_CHECKPT_ERR_UNSUP ); /* unsupported frame */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );         /* fini (failed) */
 
-  FD_LOG_NOTICE(( "Testing fd_checkpt_frame_close" ));
+  FD_LOG_NOTICE(( "Testing fd_checkpt_close" ));
 
-  FD_TEST( fd_checkpt_frame_close( NULL )==FD_CHECKPT_ERR_INVAL ); /* NULL checkpt */
-
-  RESET( fd );
-  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
-  FD_TEST(  fd_checkpt_frame_close( checkpt )==FD_CHECKPT_ERR_INVAL ); /* close (not in frame) */
-  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );            /* fini (failed) */
+  FD_TEST( fd_checkpt_close( NULL )==FD_CHECKPT_ERR_INVAL ); /* NULL checkpt */
 
   RESET( fd );
   checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
-  FD_TEST( !fd_checkpt_frame_open( checkpt, style_raw ) );  /* open raw frame */
-  FD_TEST( !fd_checkpt_frame_close( checkpt ) );            /* close (in frame) */
+  FD_TEST(  fd_checkpt_close( checkpt )==FD_CHECKPT_ERR_INVAL ); /* close (not in frame) */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );      /* fini (failed) */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_open( checkpt, style_raw ) );        /* open raw frame */
+  FD_TEST( !fd_checkpt_close( checkpt ) );                  /* close (in frame) */
   FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt ); /* fini (normal) */
 
-  FD_LOG_NOTICE(( "Testing fd_checkpt_buf" ));
+  FD_LOG_NOTICE(( "Testing fd_checkpt_meta" ));
 
-  FD_TEST(  fd_checkpt_buf( NULL, in, data_sz )==FD_CHECKPT_ERR_INVAL ); /* NULL checkpt */
+  FD_TEST(  fd_checkpt_meta( NULL, in, data_sz )==FD_CHECKPT_ERR_INVAL ); /* NULL checkpt */
+
+  /* not in frame */
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST(  fd_checkpt_meta( checkpt, in, 1UL )==FD_CHECKPT_ERR_INVAL ); /* normal */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );              /* fini (failed) */
 
   RESET( fd );
   checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
-  FD_TEST(  fd_checkpt_buf( checkpt, in, 1UL )==FD_CHECKPT_ERR_INVAL ); /* not in frame */
-  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );             /* fini (normal) */
+  FD_TEST(  fd_checkpt_meta( checkpt, in, 0UL )==FD_CHECKPT_ERR_INVAL ); /* zero sz */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );              /* fini (failed) */
 
   RESET( fd );
   checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
-  FD_TEST(  fd_checkpt_buf( checkpt, in, 0UL )==FD_CHECKPT_ERR_INVAL ); /* zero sz (not in frame) */
-  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );             /* fini (normal) */
+  FD_TEST(  fd_checkpt_meta( checkpt, NULL, 0UL )==FD_CHECKPT_ERR_INVAL ); /* NULL with zero sz */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );                /* fini (failed) */
 
   RESET( fd );
   checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
-  FD_TEST(  fd_checkpt_buf( checkpt, NULL, 0UL )==FD_CHECKPT_ERR_INVAL ); /* NULL with zero sz (not in frame) */
-  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );               /* fini (normal) */
+  FD_TEST(  fd_checkpt_meta( checkpt, NULL, 1UL )==FD_CHECKPT_ERR_INVAL ); /* NULL */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );                /* fini (failed) */
 
   RESET( fd );
   checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
-  FD_TEST( !fd_checkpt_frame_open( checkpt, style_raw ) );  /* open raw frame */
-  FD_TEST( !fd_checkpt_buf( checkpt, in,   0UL ) );         /* zero sz */
-  FD_TEST( !fd_checkpt_buf( checkpt, NULL, 0UL ) );         /* NULL with zero sz */
-  FD_TEST( !fd_checkpt_frame_close( checkpt ) );            /* close (in frame) */
-  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt ); /* fini (normal) */
+  FD_TEST(  fd_checkpt_meta( checkpt, in, FD_CHECKPT_META_MAX+1UL )==FD_CHECKPT_ERR_INVAL ); /* too large */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );                                  /* fini (failed) */
+
+  /* raw frame */
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_open( checkpt, style_raw ) );                       /* open raw frame */
+  FD_TEST( !fd_checkpt_meta( checkpt, in,   1UL ) );                       /* normal */
+  FD_TEST( !fd_checkpt_meta( checkpt, in,   0UL ) );                       /* zero sz */
+  FD_TEST( !fd_checkpt_meta( checkpt, NULL, 0UL ) );                       /* NULL with zero sz */
+  FD_TEST(  fd_checkpt_meta( checkpt, NULL, 1UL )==FD_CHECKPT_ERR_INVAL ); /* NULL */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );                /* fini (failed) */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_open( checkpt, style_raw ) );                                         /* open raw frame */
+  FD_TEST(  fd_checkpt_meta( checkpt, in, FD_CHECKPT_META_MAX+1UL )==FD_CHECKPT_ERR_INVAL ); /* too large */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );                                  /* fini (failed) */
+
+  /* lz4 frame */
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_open( checkpt, style_lz4 ) );                       /* open lz4 frame */
+  FD_TEST( !fd_checkpt_meta( checkpt, in,   1UL ) );                       /* normal */
+  FD_TEST( !fd_checkpt_meta( checkpt, in,   0UL ) );                       /* zero sz */
+  FD_TEST( !fd_checkpt_meta( checkpt, NULL, 0UL ) );                       /* NULL with zero sz */
+  FD_TEST(  fd_checkpt_meta( checkpt, NULL, 1UL )==FD_CHECKPT_ERR_INVAL ); /* NULL */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );                /* fini (failed) */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_open( checkpt, style_lz4 ) );                                         /* open raw frame */
+  FD_TEST(  fd_checkpt_meta( checkpt, in, FD_CHECKPT_META_MAX+1UL )==FD_CHECKPT_ERR_INVAL ); /* too large */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );                                  /* fini (failed) */
+
+  FD_LOG_NOTICE(( "Testing fd_checkpt_data" ));
+
+  FD_TEST(  fd_checkpt_data( NULL, in, data_sz )==FD_CHECKPT_ERR_INVAL ); /* NULL checkpt */
+
+  /* not in frame */
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST(  fd_checkpt_data( checkpt, in, 1UL )==FD_CHECKPT_ERR_INVAL ); /* normal */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );              /* fini (failed) */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST(  fd_checkpt_data( checkpt, in, 0UL )==FD_CHECKPT_ERR_INVAL ); /* zero sz */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );              /* fini (failed) */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST(  fd_checkpt_data( checkpt, NULL, 0UL )==FD_CHECKPT_ERR_INVAL ); /* NULL with zero sz */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );                /* fini (failed) */
+
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST(  fd_checkpt_data( checkpt, NULL, 1UL )==FD_CHECKPT_ERR_INVAL ); /* NULL */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );                /* fini (failed) */
+
+  /* raw frame */
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_open( checkpt, style_raw ) );                       /* open raw frame */
+  FD_TEST( !fd_checkpt_data( checkpt, in,   1UL ) );                       /* normal */
+  FD_TEST( !fd_checkpt_data( checkpt, in,   0UL ) );                       /* zero sz */
+  FD_TEST( !fd_checkpt_data( checkpt, NULL, 0UL ) );                       /* NULL with zero sz */
+  FD_TEST(  fd_checkpt_data( checkpt, NULL, 1UL )==FD_CHECKPT_ERR_INVAL ); /* NULL */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );                /* fini (failed) */
+
+  /* lz4 frame */
+  RESET( fd );
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+  FD_TEST( !fd_checkpt_open( checkpt, style_lz4 ) );                       /* open lz4 frame */
+  FD_TEST( !fd_checkpt_data( checkpt, in,   1UL ) );                       /* normal */
+  FD_TEST( !fd_checkpt_data( checkpt, in,   0UL ) );                       /* zero sz */
+  FD_TEST( !fd_checkpt_data( checkpt, NULL, 0UL ) );                       /* NULL with zero sz */
+  FD_TEST(  fd_checkpt_data( checkpt, NULL, 1UL )==FD_CHECKPT_ERR_INVAL ); /* NULL */
+  FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );                /* fini (failed) */
 
   FD_LOG_NOTICE(( "Testing fd_restore_init_stream" ));
 
@@ -187,6 +269,11 @@ main( int argc,
   FD_TEST( !fd_restore_init_stream( _restore,    fd, rbuf, FD_RESTORE_RBUF_MIN-1UL ) ); /* too small rbuf */
   fd_restore_t * restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
 
+  FD_TEST( fd_restore_is_mmio( restore )==0       );
+  FD_TEST( fd_restore_fd     ( restore )==fd      );
+  FD_TEST( fd_restore_rbuf   ( restore )==rbuf    );
+  FD_TEST( fd_restore_rbuf_sz( restore )==rbuf_sz );
+
   FD_LOG_NOTICE(( "Testing fd_restore_fini" ));
 
   FD_TEST( !fd_restore_fini( NULL ) );                      /* NULL restore */
@@ -194,72 +281,183 @@ main( int argc,
 
   RESET( fd );
   restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
-  FD_TEST( !fd_restore_frame_open( restore, 0 ) );          /* open default (raw) frame */
+  FD_TEST( !fd_restore_open( restore, 0 ) );                /* open default (raw) frame */
   FD_TEST( !fd_restore_fini( restore ) );                   /* fini (in frame) */
   FD_TEST(  fd_restore_fini( restore )==(void *)_restore ); /* fini (failed) */
 
-  FD_LOG_NOTICE(( "Testing fd_restore_frame_open" ));
+  FD_LOG_NOTICE(( "Testing fd_restore_open" ));
 
-  FD_TEST(  fd_restore_frame_open( NULL, 0 )==FD_CHECKPT_ERR_INVAL ); /* NULL restore */
+  FD_TEST(  fd_restore_open( NULL, 0 )==FD_CHECKPT_ERR_INVAL ); /* NULL restore */
 
   RESET( fd );
   restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
-  FD_TEST( !fd_restore_frame_open( restore, style_raw )                       ); /* open raw frame */
-  FD_TEST(  fd_restore_frame_open( restore, style_raw )==FD_CHECKPT_ERR_INVAL ); /* in frame */
+  FD_TEST( !fd_restore_open( restore, style_raw )                       ); /* open raw frame */
+  FD_TEST(  fd_restore_open( restore, style_raw )==FD_CHECKPT_ERR_INVAL ); /* in frame */
   FD_TEST(  fd_restore_fini( restore )==(void *)_restore );                      /* fini (failed) */
 
   RESET( fd );
   restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
-  FD_TEST( !fd_restore_frame_open( restore, style_lz4 ) );  /* open lz4 frame (if target supports, raw if not) */
+  FD_TEST( !fd_restore_open( restore, style_lz4 ) );        /* open lz4 frame (if target supports, raw if not) */
   FD_TEST( !fd_restore_fini( restore ) );                   /* fini (in frame) */
   FD_TEST(  fd_restore_fini( restore )==(void *)_restore ); /* fini (failed) */
 
   RESET( fd );
   restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
-  FD_TEST(  fd_restore_frame_open( restore, -1 )==FD_CHECKPT_ERR_UNSUP ); /* unsupported frame */
-  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );               /* fini (failed) */
+  FD_TEST(  fd_restore_open( restore, -1 )==FD_CHECKPT_ERR_UNSUP ); /* unsupported frame */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );         /* fini (failed) */
 
-  FD_LOG_NOTICE(( "Testing fd_restore_frame_close" ));
+  FD_LOG_NOTICE(( "Testing fd_restore_close" ));
 
-  FD_TEST( fd_restore_frame_close( NULL )==FD_CHECKPT_ERR_INVAL ); /* NULL restore */
-
-  RESET( fd );
-  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
-  FD_TEST(  fd_restore_frame_close( restore )==FD_CHECKPT_ERR_INVAL ); /* close (not in frame) */
-  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );            /* fini (failed) */
+  FD_TEST( fd_restore_close( NULL )==FD_CHECKPT_ERR_INVAL ); /* NULL restore */
 
   RESET( fd );
   restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
-  FD_TEST( !fd_restore_frame_open( restore, style_raw ) );  /* open raw frame */
-  FD_TEST( !fd_restore_frame_close( restore           ) );  /* close (in frame) */
+  FD_TEST(  fd_restore_close( restore )==FD_CHECKPT_ERR_INVAL ); /* close (not in frame) */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );      /* fini (failed) */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_open( restore, style_raw ) );        /* open raw frame */
+  FD_TEST( !fd_restore_close( restore ) );                  /* close (in frame) */
   FD_TEST(  fd_restore_fini( restore )==(void *)_restore ); /* fini (normal) */
 
-  FD_LOG_NOTICE(( "Testing fd_restore_buf" ));
+  FD_LOG_NOTICE(( "Testing fd_restore_meta" ));
 
-  FD_TEST(  fd_restore_buf( NULL, in, data_sz )==FD_CHECKPT_ERR_INVAL ); /* NULL restore */
+  FD_TEST(  fd_restore_meta( NULL, in, data_sz )==FD_CHECKPT_ERR_INVAL ); /* NULL restore */
+
+  /* not in frame */
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST(  fd_restore_meta( restore, in, 1UL )==FD_CHECKPT_ERR_INVAL ); /* normal */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );              /* fini (failed) */
 
   RESET( fd );
   restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
-  FD_TEST(  fd_restore_buf( restore, in, 1UL )==FD_CHECKPT_ERR_INVAL ); /* not in frame */
-  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );             /* fini (normal) */
+  FD_TEST(  fd_restore_meta( restore, in, 0UL )==FD_CHECKPT_ERR_INVAL ); /* zero sz */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );              /* fini (failed) */
 
   RESET( fd );
   restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
-  FD_TEST(  fd_restore_buf( restore, in, 0UL )==FD_CHECKPT_ERR_INVAL ); /* zero sz (not in frame) */
-  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );             /* fini (normal) */
+  FD_TEST(  fd_restore_meta( restore, NULL, 0UL )==FD_CHECKPT_ERR_INVAL ); /* NULL with zero sz */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );                /* fini (failed) */
 
   RESET( fd );
   restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
-  FD_TEST(  fd_restore_buf( restore, NULL, 0UL )==FD_CHECKPT_ERR_INVAL ); /* NULL with zero sz (not in frame) */
-  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );               /* fini (normal) */
+  FD_TEST(  fd_restore_meta( restore, NULL, 1UL )==FD_CHECKPT_ERR_INVAL ); /* NULL */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );                /* fini (failed) */
 
   RESET( fd );
   restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
-  FD_TEST( !fd_restore_frame_open( restore, style_raw ) );  /* open raw frame */
-  FD_TEST( !fd_restore_buf( restore, in,   0UL ) );         /* zero sz */
-  FD_TEST( !fd_restore_buf( restore, NULL, 0UL ) );         /* NULL with zero sz */
-  FD_TEST( !fd_restore_frame_close( restore ) );            /* open raw frame */
-  FD_TEST(  fd_restore_fini( restore )==(void *)_restore ); /* fini (normal) */
+  FD_TEST(  fd_restore_meta( restore, in, FD_CHECKPT_META_MAX+1UL )==FD_CHECKPT_ERR_INVAL ); /* too large */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );                                  /* fini (failed) */
+
+  /* raw frame */
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_open( restore, style_raw ) );                       /* open raw frame */
+  /* normal checked end-to-end (nothing in fd yet) */
+  FD_TEST( !fd_restore_meta( restore, in,   0UL ) );                       /* zero sz */
+  FD_TEST( !fd_restore_meta( restore, NULL, 0UL ) );                       /* NULL with zero sz */
+  FD_TEST(  fd_restore_meta( restore, NULL, 1UL )==FD_CHECKPT_ERR_INVAL ); /* NULL */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );                /* fini (failed) */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_open( restore, style_raw ) );                                         /* open raw frame */
+  FD_TEST(  fd_restore_meta( restore, in, FD_CHECKPT_META_MAX+1UL )==FD_CHECKPT_ERR_INVAL ); /* too large */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );                                  /* fini (failed) */
+
+  /* lz4 frame */
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_open( restore, style_lz4 ) );                       /* open lz4 frame */
+  /* normal checked end-to-end (nothing in fd yet) */
+  FD_TEST( !fd_restore_meta( restore, in,   0UL ) );                       /* zero sz */
+  FD_TEST( !fd_restore_meta( restore, NULL, 0UL ) );                       /* NULL with zero sz */
+  FD_TEST(  fd_restore_meta( restore, NULL, 1UL )==FD_CHECKPT_ERR_INVAL ); /* NULL */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );                /* fini (failed) */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_open( restore, style_lz4 ) );                                         /* open raw frame */
+  FD_TEST(  fd_restore_meta( restore, in, FD_CHECKPT_META_MAX+1UL )==FD_CHECKPT_ERR_INVAL ); /* too large */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );                                  /* fini (failed) */
+
+  FD_LOG_NOTICE(( "Testing fd_restore_data" ));
+
+  FD_TEST(  fd_restore_data( NULL, in, data_sz )==FD_CHECKPT_ERR_INVAL ); /* NULL restore */
+
+  /* not in frame */
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST(  fd_restore_data( restore, in, 1UL )==FD_CHECKPT_ERR_INVAL ); /* normal */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );              /* fini (failed) */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST(  fd_restore_data( restore, in, 0UL )==FD_CHECKPT_ERR_INVAL ); /* zero sz */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );              /* fini (failed) */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST(  fd_restore_data( restore, NULL, 0UL )==FD_CHECKPT_ERR_INVAL ); /* NULL with zero sz */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );                /* fini (failed) */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST(  fd_restore_data( restore, NULL, 1UL )==FD_CHECKPT_ERR_INVAL ); /* NULL */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );                /* fini (failed) */
+
+  /* raw frame */
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_open( restore, style_raw ) );                       /* open raw frame */
+  /* normal checked end-to-end (nothing in fd yet) */
+  FD_TEST( !fd_restore_data( restore, in,   0UL ) );                       /* zero sz */
+  FD_TEST( !fd_restore_data( restore, NULL, 0UL ) );                       /* NULL with zero sz */
+  FD_TEST(  fd_restore_data( restore, NULL, 1UL )==FD_CHECKPT_ERR_INVAL ); /* NULL */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );                /* fini (failed) */
+
+  /* lz4 frame */
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_open( restore, style_lz4 ) );                       /* open lz4 frame */
+  /* normal checked end-to-end (nothing in fd yet) */
+  FD_TEST( !fd_restore_data( restore, in,   0UL ) );                       /* zero sz */
+  FD_TEST( !fd_restore_data( restore, NULL, 0UL ) );                       /* NULL with zero sz */
+  FD_TEST(  fd_restore_data( restore, NULL, 1UL )==FD_CHECKPT_ERR_INVAL ); /* NULL */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );                /* fini (failed) */
+
+  /* Test sz */
+
+  RESET( fd );
+  ulong ref_sz; FD_TEST( !fd_io_sz( fd, &ref_sz ) );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST(  fd_restore_sz( restore )==ref_sz );
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
+
+  /* Test seek */
+
+  FD_TEST(  fd_restore_seek( NULL, 0UL )==FD_CHECKPT_ERR_INVAL ); /* NULL restore */
+
+  /* Note: file is empty at this point so we don't test non-trivial
+     seeks here */
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_seek( restore, 0UL ) );              /* SOF */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore ); /* fini (failed) */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_open( restore, style_raw ) );                 /* open lz4 frame */
+  FD_TEST(  fd_restore_seek( restore, 0UL )==FD_CHECKPT_ERR_INVAL ); /* in frame */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );          /* fini (failed) */
+
+  RESET( fd );
+  restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+  FD_TEST( !fd_restore_open( restore, style_lz4 ) );                 /* open lz4 frame */
+  FD_TEST(  fd_restore_seek( restore, 0UL )==FD_CHECKPT_ERR_INVAL ); /* in frame */
+  FD_TEST(  fd_restore_fini( restore )==(void *)_restore );          /* fini (failed) */
 
   FD_LOG_NOTICE(( "Testing end-to-end" ));
 
@@ -279,21 +477,30 @@ main( int argc,
 
     /* checkpt/restore a single buffer in a single frame */
 
+    memset( out, 0, data_sz );
+
     RESET( fd );
     checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
-    FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
-    FD_TEST( !fd_checkpt_buf( checkpt, in, data_sz ) );
-    FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+    FD_TEST( !fd_checkpt_open_advanced( checkpt, style, &off_open ) );
+    FD_TEST( !fd_checkpt_data( checkpt, in, data_sz ) );
+    FD_TEST( !fd_checkpt_close_advanced( checkpt, &off_close ) );
     FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
 
-    if( style==style_raw ) FD_TEST( (off_close-off_open)==data_sz );
+    ulong csz;
+    FD_TEST( !fd_io_seek( fd, 0L, FD_IO_SEEK_TYPE_CUR, &csz ) );
+    FD_TEST( csz==(off_close-off_open) );
+    if( style==style_raw ) FD_TEST( csz==data_sz );
 
-    memset( out, 0, data_sz );
     RESET( fd );
     restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
-    FD_TEST( !fd_restore_frame_open( restore, style ) );
-    FD_TEST( !fd_restore_buf( restore, out, data_sz ) );
-    FD_TEST( !fd_restore_frame_close( restore ) );
+
+    FD_TEST( !fd_restore_seek( restore, csz                               ) ); /* to eof */
+    FD_TEST( !fd_restore_seek( restore, fd_rng_ulong_roll( rng, csz+1UL ) ) ); /* to arb position */
+    FD_TEST( !fd_restore_seek( restore, 0UL                               ) ); /* to sof */
+
+    FD_TEST( !fd_restore_open( restore, style ) );
+    FD_TEST( !fd_restore_data( restore, out, data_sz ) );
+    FD_TEST( !fd_restore_close( restore ) );
     FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
 
     FD_TEST( !memcmp( in, out, data_sz ) );
@@ -305,18 +512,18 @@ main( int argc,
 
     RESET( fd );
     checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
-    FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+    FD_TEST( !fd_checkpt_open_advanced( checkpt, style, &off_open ) );
     ibuf = in;
     rem  = data_sz;
     while( rem ) {
       ulong r      = fd_rng_ulong( rng );
       ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
       ulong buf_sz = fd_ulong_min( rem, r & mask ); /* In [0,128KiB) biased toward small */
-      FD_TEST( !fd_checkpt_buf( checkpt, ibuf, buf_sz ) );
+      FD_TEST( !fd_checkpt_data( checkpt, ibuf, buf_sz ) );
       ibuf += buf_sz;
       rem  -= buf_sz;
     }
-    FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+    FD_TEST( !fd_checkpt_close_advanced( checkpt, &off_close ) );
     FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
 
     if( style==style_raw ) FD_TEST( (off_close-off_open)==data_sz );
@@ -326,18 +533,18 @@ main( int argc,
     memset( out, 0, data_sz );
     RESET( fd );
     restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
-    FD_TEST( !fd_restore_frame_open( restore, style ) );
+    FD_TEST( !fd_restore_open( restore, style ) );
     obuf = out;
     rem  = data_sz;
     while( rem ) {
       ulong r      = fd_rng_ulong( rng );
       ulong mask   = (1UL << fd_rng_int_roll( rng, 18 )) - 1UL;
       ulong buf_sz = fd_ulong_min( rem, r & mask ); /* In [0,128KiB) biased toward small */
-      FD_TEST( !fd_restore_buf( restore, obuf, buf_sz ) );
+      FD_TEST( !fd_restore_data( restore, obuf, buf_sz ) );
       obuf += buf_sz;
       rem  -= buf_sz;
     }
-    FD_TEST( !fd_restore_frame_close( restore ) );
+    FD_TEST( !fd_restore_close( restore ) );
     FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
 
     FD_TEST( !memcmp( in, out, data_sz ) );
@@ -353,7 +560,7 @@ main( int argc,
     RESET( fd );
     checkpt  = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
     frame_sz = 0UL;
-    FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+    FD_TEST( !fd_checkpt_open_advanced( checkpt, style, &off_open ) );
     ibuf     = in;
     rem      = data_sz;
     while( rem ) {
@@ -363,17 +570,17 @@ main( int argc,
       for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
         if( FD_LIKELY( r & 7UL ) ) break;
         r >>= 3;
-        FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+        FD_TEST( !fd_checkpt_close_advanced( checkpt, &off_close ) );
         if( style==style_raw ) FD_TEST( (off_close-off_open)==frame_sz );
         frame_sz = 0UL;
-        FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+        FD_TEST( !fd_checkpt_open_advanced( checkpt, style, &off_open ) );
       }
-      FD_TEST( !fd_checkpt_buf( checkpt, ibuf, buf_sz ) );
+      FD_TEST( !fd_checkpt_data( checkpt, ibuf, buf_sz ) );
       ibuf     += buf_sz;
       rem      -= buf_sz;
       frame_sz += buf_sz;
     }
-    FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+    FD_TEST( !fd_checkpt_close_advanced( checkpt, &off_close ) );
     FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
 
     if( style==style_raw ) FD_TEST( (off_close-off_open)==frame_sz );
@@ -382,7 +589,7 @@ main( int argc,
 
     RESET( fd );
     restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
-    FD_TEST( !fd_restore_frame_open( restore, style ) );
+    FD_TEST( !fd_restore_open( restore, style ) );
     obuf = out;
     rem  = data_sz;
     while( rem ) {
@@ -392,15 +599,15 @@ main( int argc,
       for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
         if( FD_LIKELY( r & 7UL ) ) break;
         r >>= 3;
-        FD_TEST( !fd_restore_frame_close( restore ) );
-        FD_TEST( !fd_restore_frame_open( restore, style ) );
+        FD_TEST( !fd_restore_close( restore ) );
+        FD_TEST( !fd_restore_open( restore, style ) );
       }
-      FD_TEST( !fd_restore_buf( restore, obuf, buf_sz ) );
+      FD_TEST( !fd_restore_data( restore, obuf, buf_sz ) );
       if( FD_LIKELY( buf_sz ) ) FD_TEST( !memcmp( in+(data_sz-rem), obuf, buf_sz ) ); /* Test immedate avail */
       obuf += buf_sz;
       rem  -= buf_sz;
     }
-    FD_TEST( !fd_restore_frame_close( restore ) );
+    FD_TEST( !fd_restore_close( restore ) );
     FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
 
     FD_TEST( !memcmp( in, out, data_sz ) );
@@ -415,7 +622,7 @@ main( int argc,
     checkpt  = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
     style    = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
     frame_sz = 0UL;
-    FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+    FD_TEST( !fd_checkpt_open_advanced( checkpt, style, &off_open ) );
     ibuf     = in;
     rem      = data_sz;
     while( rem ) {
@@ -425,19 +632,19 @@ main( int argc,
       for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
         if( FD_LIKELY( r & 7UL ) ) break;
         r >>= 3;
-        FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+        FD_TEST( !fd_checkpt_close_advanced( checkpt, &off_close ) );
         if( style==style_raw ) FD_TEST( (off_close-off_open)==frame_sz );
         /* FIXME: consider comparing frame bytes when raw? */
         style    = fd_int_if( !(r & 1UL), style_raw, style_lz4 ); r >>= 1;
         frame_sz = 0UL;
-        FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+        FD_TEST( !fd_checkpt_open_advanced( checkpt, style, &off_open ) );
       }
-      FD_TEST( !fd_checkpt_buf( checkpt, ibuf, buf_sz ) );
+      FD_TEST( !fd_checkpt_data( checkpt, ibuf, buf_sz ) );
       ibuf     += buf_sz;
       rem      -= buf_sz;
       frame_sz += buf_sz;
     }
-    FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+    FD_TEST( !fd_checkpt_close_advanced( checkpt, &off_close ) );
     FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
 
     fd_rng_seq_set( rng, rng_seq ); fd_rng_idx_set( rng, rng_idx ); /* Restore to recreate same checkpt open/buf/close */
@@ -447,7 +654,7 @@ main( int argc,
     RESET( fd );
     restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
     style   = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
-    FD_TEST( !fd_restore_frame_open( restore, style ) );
+    FD_TEST( !fd_restore_open( restore, style ) );
     obuf = out;
     rem  = data_sz;
     while( rem ) {
@@ -457,19 +664,91 @@ main( int argc,
       for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
         if( FD_LIKELY( r & 7UL ) ) break;
         r >>= 3;
-        FD_TEST( !fd_restore_frame_close( restore ) );
+        FD_TEST( !fd_restore_close( restore ) );
         style = fd_int_if( !(r & 1UL), style_raw, style_lz4 ); r >>= 1;
-        FD_TEST( !fd_restore_frame_open( restore, style ) );
+        FD_TEST( !fd_restore_open( restore, style ) );
       }
-      FD_TEST( !fd_restore_buf( restore, obuf, buf_sz ) );
+      FD_TEST( !fd_restore_data( restore, obuf, buf_sz ) );
       if( FD_LIKELY( buf_sz ) ) FD_TEST( !memcmp( in+(data_sz-rem), obuf, buf_sz ) ); /* Test immedate avail */
       obuf += buf_sz;
       rem  -= buf_sz;
     }
-    FD_TEST( !fd_restore_frame_close( restore ) );
+    FD_TEST( !fd_restore_close( restore ) );
     FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
 
     FD_TEST( !memcmp( in, out, data_sz ) );
+
+    /* Test non-trivial gather/scatter (to stress out lz4 compressor and
+       gather/scatter optimizations) */
+
+    /* Pick two non-overlapping regions */
+
+    ulong i0 = fd_rng_ulong_roll( rng, data_sz+1UL );
+    ulong i1 = fd_rng_ulong_roll( rng, data_sz+1UL );
+    ulong i2 = fd_rng_ulong_roll( rng, data_sz+1UL );
+    ulong i3 = fd_rng_ulong_roll( rng, data_sz+1UL );
+    fd_swap_if( i0>i2, i0, i2 ); fd_swap_if( i1>i3, i1, i3 );
+    fd_swap_if( i0>i1, i0, i1 ); fd_swap_if( i2>i3, i2, i3 );
+    fd_swap_if( i1>i2, i1, i2 );
+    ulong sza = i1-i0;
+    ulong szb = i3-i2;
+
+    /* Concat regions of in */
+
+    uchar tmp[ BUF_MAX ];
+    if( FD_LIKELY( sza ) ) memcpy( tmp,     in+i0, sza );
+    if( FD_LIKELY( szb ) ) memcpy( tmp+sza, in+i2, szb );
+
+    memset( out, 0, data_sz );
+
+    /* Checkpt contiguous regions */
+
+    RESET( fd );
+    style   = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
+    checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+    FD_TEST( !fd_checkpt_open( checkpt, style ) );
+    FD_TEST( !fd_checkpt_data( checkpt, tmp,     sza ) );
+    FD_TEST( !fd_checkpt_data( checkpt, tmp+sza, szb ) );
+    FD_TEST( !fd_checkpt_close( checkpt ) );
+    FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
+
+    /* Restore into discontiguous regions */
+
+    RESET( fd );
+    restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+    FD_TEST( !fd_restore_open( restore, style ) );
+    FD_TEST( !fd_restore_data( restore, out+i0, sza ) );
+    FD_TEST( !fd_restore_data( restore, out+i2, szb ) );
+    FD_TEST( !fd_restore_close( restore ) );
+    FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
+
+    FD_TEST( !memcmp( in+i0, out+i0, sza ) );
+    FD_TEST( !memcmp( in+i2, out+i2, szb ) );
+
+    memset( out, 0, data_sz );
+
+    /* Checkpt discontiguous regions */
+
+    RESET( fd );
+    style   = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
+    checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
+    FD_TEST( !fd_checkpt_open( checkpt, style ) );
+    FD_TEST( !fd_checkpt_data( checkpt, in+i0, sza ) );
+    FD_TEST( !fd_checkpt_data( checkpt, in+i2, szb ) );
+    FD_TEST( !fd_checkpt_close( checkpt ) );
+    FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
+
+    /* Restore into contiguous region */
+
+    RESET( fd );
+    restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
+    FD_TEST( !fd_restore_open( restore, style ) );
+    FD_TEST( !fd_restore_data( restore, out,     sza ) );
+    FD_TEST( !fd_restore_data( restore, out+sza, szb ) );
+    FD_TEST( !fd_restore_close( restore ) );
+    FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
+
+    FD_TEST( !memcmp( tmp, out, sza+szb ) );
 
     /* checkpt(mmio)/restore(stream) with mixed sized buffers (including
        0 sized) distributed over multiple mixed style frames (including
@@ -482,7 +761,7 @@ main( int argc,
     checkpt  = fd_checkpt_init_mmio( _checkpt, mmio, mmio_sz ); FD_TEST( checkpt==_checkpt );
     style    = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
     frame_sz = 0UL;
-    FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+    FD_TEST( !fd_checkpt_open_advanced( checkpt, style, &off_open ) );
     ibuf     = in;
     rem      = data_sz;
     while( rem ) {
@@ -492,19 +771,19 @@ main( int argc,
       for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
         if( FD_LIKELY( r & 7UL ) ) break;
         r >>= 3;
-        FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+        FD_TEST( !fd_checkpt_close_advanced( checkpt, &off_close ) );
         if( style==style_raw ) FD_TEST( (off_close-off_open)==frame_sz );
         /* FIXME: consider comparing frame bytes when raw? */
         style    = fd_int_if( !(r & 1UL), style_raw, style_lz4 ); r >>= 1;
         frame_sz = 0UL;
-        FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+        FD_TEST( !fd_checkpt_open_advanced( checkpt, style, &off_open ) );
       }
-      FD_TEST( !fd_checkpt_buf( checkpt, ibuf, buf_sz ) );
+      FD_TEST( !fd_checkpt_data( checkpt, ibuf, buf_sz ) );
       ibuf     += buf_sz;
       rem      -= buf_sz;
       frame_sz += buf_sz;
     }
-    FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+    FD_TEST( !fd_checkpt_close_advanced( checkpt, &off_close ) );
     FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
 
     RESET( fd );
@@ -518,7 +797,7 @@ main( int argc,
     RESET( fd );
     restore = fd_restore_init_stream( _restore, fd, rbuf, rbuf_sz ); FD_TEST( restore==_restore );
     style   = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
-    FD_TEST( !fd_restore_frame_open( restore, style ) );
+    FD_TEST( !fd_restore_open( restore, style ) );
     obuf = out;
     rem  = data_sz;
     while( rem ) {
@@ -528,16 +807,16 @@ main( int argc,
       for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
         if( FD_LIKELY( r & 7UL ) ) break;
         r >>= 3;
-        FD_TEST( !fd_restore_frame_close( restore ) );
+        FD_TEST( !fd_restore_close( restore ) );
         style = fd_int_if( !(r & 1UL), style_raw, style_lz4 ); r >>= 1;
-        FD_TEST( !fd_restore_frame_open( restore, style ) );
+        FD_TEST( !fd_restore_open( restore, style ) );
       }
-      FD_TEST( !fd_restore_buf( restore, obuf, buf_sz ) );
+      FD_TEST( !fd_restore_data( restore, obuf, buf_sz ) );
       if( FD_LIKELY( buf_sz ) ) FD_TEST( !memcmp( in+(data_sz-rem), obuf, buf_sz ) ); /* Test immedate avail */
       obuf += buf_sz;
       rem  -= buf_sz;
     }
-    FD_TEST( !fd_restore_frame_close( restore ) );
+    FD_TEST( !fd_restore_close( restore ) );
     FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
 
     FD_TEST( !memcmp( in, out, data_sz ) );
@@ -552,7 +831,7 @@ main( int argc,
     checkpt  = fd_checkpt_init_stream( _checkpt, fd, wbuf, wbuf_sz ); FD_TEST( checkpt==_checkpt );
     style    = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
     frame_sz = 0UL;
-    FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+    FD_TEST( !fd_checkpt_open_advanced( checkpt, style, &off_open ) );
     ibuf     = in;
     rem      = data_sz;
     while( rem ) {
@@ -562,19 +841,19 @@ main( int argc,
       for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
         if( FD_LIKELY( r & 7UL ) ) break;
         r >>= 3;
-        FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+        FD_TEST( !fd_checkpt_close_advanced( checkpt, &off_close ) );
         if( style==style_raw ) FD_TEST( (off_close-off_open)==frame_sz );
         /* FIXME: consider comparing frame bytes when raw? */
         style    = fd_int_if( !(r & 1UL), style_raw, style_lz4 ); r >>= 1;
         frame_sz = 0UL;
-        FD_TEST( !fd_checkpt_frame_open_advanced( checkpt, style, &off_open ) );
+        FD_TEST( !fd_checkpt_open_advanced( checkpt, style, &off_open ) );
       }
-      FD_TEST( !fd_checkpt_buf( checkpt, ibuf, buf_sz ) );
+      FD_TEST( !fd_checkpt_data( checkpt, ibuf, buf_sz ) );
       ibuf     += buf_sz;
       rem      -= buf_sz;
       frame_sz += buf_sz;
     }
-    FD_TEST( !fd_checkpt_frame_close_advanced( checkpt, &off_close ) );
+    FD_TEST( !fd_checkpt_close_advanced( checkpt, &off_close ) );
     FD_TEST(  fd_checkpt_fini( checkpt )==(void *)_checkpt );
 
     fd_rng_seq_set( rng, rng_seq ); fd_rng_idx_set( rng, rng_idx ); /* Restore to recreate same checkpt open/buf/close */
@@ -587,7 +866,7 @@ main( int argc,
 
     restore = fd_restore_init_mmio( _restore, mmio, rsz ); FD_TEST( restore==_restore );
     style   = fd_int_if( !(fd_rng_ulong( rng ) & 1UL), style_raw, style_lz4 );
-    FD_TEST( !fd_restore_frame_open( restore, style ) );
+    FD_TEST( !fd_restore_open( restore, style ) );
     obuf = out;
     rem  = data_sz;
     while( rem ) {
@@ -597,16 +876,16 @@ main( int argc,
       for( ulong i=0UL; i<11UL; i++ ) { /* Random break up inputs into frames (including empty ones) */
         if( FD_LIKELY( r & 7UL ) ) break;
         r >>= 3;
-        FD_TEST( !fd_restore_frame_close( restore ) );
+        FD_TEST( !fd_restore_close( restore ) );
         style = fd_int_if( !(r & 1UL), style_raw, style_lz4 ); r >>= 1;
-        FD_TEST( !fd_restore_frame_open( restore, style ) );
+        FD_TEST( !fd_restore_open( restore, style ) );
       }
-      FD_TEST( !fd_restore_buf( restore, obuf, buf_sz ) );
+      FD_TEST( !fd_restore_data( restore, obuf, buf_sz ) );
       if( FD_LIKELY( buf_sz ) ) FD_TEST( !memcmp( in+(data_sz-rem), obuf, buf_sz ) ); /* Test immedate avail */
       obuf += buf_sz;
       rem  -= buf_sz;
     }
-    FD_TEST( !fd_restore_frame_close( restore ) );
+    FD_TEST( !fd_restore_close( restore ) );
     FD_TEST(  fd_restore_fini( restore )==(void *)_restore );
 
     FD_TEST( !memcmp( in, out, data_sz ) );

--- a/src/util/fd_util.h
+++ b/src/util/fd_util.h
@@ -5,43 +5,46 @@
 //#include "sanitize/fd_msan.h"     /* includes fd_util_base.h */
 //#include "bits/fd_bits.h"         /* includes sanitize/fd_msan.h */
 //#include "sanitize/fd_asan.h"     /* includes fd_util_base.h" */
-//#include "sanitize/fd_sanitize.h" /* includes sanitize/fd_asan.h */
-//#include "wksp/fd_wksp.h"         /* includes sanitize/fd_asan.h */
-//#include "cstr/fd_cstr.h"         /* includes bits/fd_bits.h */
+//#include "sanitize/fd_msan.h"     /* includes fd_util_base.h" */
+//#include "sanitize/fd_sanitize.h" /* includes sanitize/fd_asan.h sanitize/fd_msan.h */
 //#include "io/fd_io.h"             /* includes bits/fd_bits.h */
 #include "spad/fd_spad.h"           /* includes bits/fd_bits.h */
+//#include "cstr/fd_cstr.h"         /* includes bits/fd_bits.h */
 //#include "pod/fd_pod.h"           /* includes cstr/fd_cstr.h */
 //#include "env/fd_env.h"           /* includes cstr/fd_cstr.h */
 //#include "log/fd_log.h"           /* includes env/fd_env.h io/fd_io.h */
+//#include "checkpt/fd_checkpt.h"   /* includes log/fd_log.h */
 //#include "shmem/fd_shmem.h"       /* includes log/fd_log.h */
-#include "checkpt/fd_checkpt.h"     /* includes log/fd_log.h */
 //#include "tile/fd_tile.h"         /* includes shmem/fd_shmem.h */
-//#include "wksp/fd_wksp.h"         /* includes shmem/fd_shmem.h pod/fd_pod.h */
-//#include "valloc/fd_valloc.h"     /* includes fd_util_base.h */
+//#include "wksp/fd_wksp.h"         /* includes pod/fd_pod.h shmem/shmem.h checkpt/fd_checkpt.h sanitize/fd_sanitize.h */
 //#include "scratch/fd_scratch.h"   /* includes tile/fd_tile.h sanitize/fd_sanitize.h valloc/fd_valloc.h */
-#include "math/fd_stat.h"           /* includes bits/fd_bits.h */
-#include "bits/fd_sat.h"
-#include "hist/fd_histf.h"
+#include "tpool/fd_tpool.h"         /* includes tile/fd_tile.h scratch/fd_scratch.h */
+#include "alloc/fd_alloc.h"         /* includes wksp/fd_wksp.h valloc/fd_valloc.h */
 #include "rng/fd_rng.h"             /* includes bits/fd_bits.h */
-#include "tpool/fd_tpool.h"         /* includes tile/fd_tile.h and scratch/fd_scratch.h */
-#include "alloc/fd_alloc.h"         /* includes wksp/fd_wksp.h */
-#include "sandbox/fd_sandbox.h"
+
+/* FIXME: Should these be optional APIs? */
+#include "sandbox/fd_sandbox.h"     /* includes fd_util_base.h */
+#include "math/fd_stat.h"           /* includes bits/fd_bits.h */
+#include "bits/fd_sat.h"            /* includes bits/fd_bits.h */
+#include "hist/fd_histf.h"          /* includes log/fd_log.h */
 
 /* Additional fd_util APIs that are not included by default */
 
-//#include "archive/fd_ar.h"  /* includes fd_util_base.h */
-//#include "net/fd_eth.h"     /* includes bits/fd_bits.h */
-//#include "net/fd_ip4.h"     /* includes bits/fd_bits.h */
-//#include "net/fd_pcap.h"    /* includes net/fd_eth.h */
-//#include "net/fd_igmp.h"    /* includes net/fd_ip4.h */
-//#include "net/fd_udp.h"     /* includes net/fd_ip4.h */
-//#include "bits/fd_float.h"  /* includes bits/fd_bits.h */
-//#include "bits/fd_uwide.h"  /* includes bits/fd_bits.h */
-//#include "math/fd_sqrt.h"   /* includes bits/fd_bits.h */
-//#include "math/fd_fxp.h"    /* includes math/fd_sqrt.h, (!FD_HAS_INT128) bits/fd_uwide.h */
-//#include "simd/fd_sse.h"    /* includes bits/fd_bits.h, requires FD_HAS_SSE */
-//#include "simd/fd_avx.h"    /* includes bits/fd_bits.h, requires FD_HAS_AVX */
-//#include "simd/fd_avx512.h" /* includes bits/fd_bits.h, requires FD_HAS_AVX512 */
+//#include "archive/fd_ar.h"        /* includes fd_util_base.h */
+//#include "net/fd_pcapng.h"        /* includes fd_util_base.h */
+//#include "net/fd_eth.h"           /* includes bits/fd_bits.h */
+//#include "net/fd_ip4.h"           /* includes bits/fd_bits.h */
+//#include "net/fd_igmp.h"          /* includes net/fd_ip4.h */
+//#include "net/fd_udp.h"           /* includes net/fd_ip4.h */
+//#include "net/fd_net_headers.h */ /* includes net/fd_udp.h net/fd_eth.h */
+//#include "net/fd_pcap.h"          /* includes net/fd_eth.h log/fd_log.h */
+//#include "bits/fd_float.h"        /* includes bits/fd_bits.h */
+//#include "bits/fd_uwide.h"        /* includes bits/fd_bits.h */
+//#include "math/fd_sqrt.h"         /* includes bits/fd_bits.h */
+//#include "math/fd_fxp.h"          /* includes math/fd_sqrt.h, (!FD_HAS_INT128) bits/fd_uwide.h */
+//#include "simd/fd_sse.h"          /* includes bits/fd_bits.h, requires FD_HAS_SSE */
+//#include "simd/fd_avx.h"          /* includes bits/fd_bits.h, requires FD_HAS_AVX */
+//#include "simd/fd_avx512.h"       /* includes bits/fd_bits.h, requires FD_HAS_AVX512 */
 
 FD_PROTOTYPES_BEGIN
 

--- a/src/util/fd_util.h
+++ b/src/util/fd_util.h
@@ -16,9 +16,9 @@
 //#include "checkpt/fd_checkpt.h"   /* includes log/fd_log.h */
 //#include "shmem/fd_shmem.h"       /* includes log/fd_log.h */
 //#include "tile/fd_tile.h"         /* includes shmem/fd_shmem.h */
-//#include "wksp/fd_wksp.h"         /* includes pod/fd_pod.h shmem/shmem.h checkpt/fd_checkpt.h sanitize/fd_sanitize.h */
 //#include "scratch/fd_scratch.h"   /* includes tile/fd_tile.h sanitize/fd_sanitize.h valloc/fd_valloc.h */
-#include "tpool/fd_tpool.h"         /* includes tile/fd_tile.h scratch/fd_scratch.h */
+//#include "tpool/fd_tpool.h"       /* includes tile/fd_tile.h scratch/fd_scratch.h */
+//#include "wksp/fd_wksp.h"         /* includes pod/fd_pod.h tpool/fd_tpool.h checkpt/fd_checkpt.h sanitize/fd_sanitize.h */
 #include "alloc/fd_alloc.h"         /* includes wksp/fd_wksp.h valloc/fd_valloc.h */
 #include "rng/fd_rng.h"             /* includes bits/fd_bits.h */
 

--- a/src/util/hist/fd_histf.h
+++ b/src/util/hist/fd_histf.h
@@ -5,8 +5,7 @@
    bucketed exponentially up to a maximum value, with an overflow bucket
    for any other measurements. */
 
-#include <math.h>
-#include "../bits/fd_bits.h"
+#include <math.h> /* FIXME: HMMM */
 #include "../log/fd_log.h"
 #if FD_HAS_AVX
 #include "../simd/fd_avx.h"

--- a/src/util/net/fd_igmp.h
+++ b/src/util/net/fd_igmp.h
@@ -1,8 +1,6 @@
 #ifndef HEADER_fd_src_util_net_fd_igmp_h
 #define HEADER_fd_src_util_net_fd_igmp_h
 
-#include <string.h>
-
 #include "fd_ip4.h"
 
 /* FIXME: IGMP CRASH COURSE HERE */

--- a/src/util/rng/fd_rng.h
+++ b/src/util/rng/fd_rng.h
@@ -472,7 +472,7 @@ FD_PROTOTYPES_END
 
 #if FD_HAS_X86
 
-#include <immintrin.h>
+#include <immintrin.h> /* FIXME: HMMM */
 
 /* rdrand reads sz cryptographically secure bytes using the RDRAND x86
    instruction.  Returns 1 if the read succeeded, 0 on failure.

--- a/src/util/sandbox/fd_sandbox.h
+++ b/src/util/sandbox/fd_sandbox.h
@@ -5,7 +5,7 @@
 
 #include "../fd_util_base.h"
 
-#include <linux/filter.h>
+#include <linux/filter.h> /* FIXME: HMMMM */
 
 FD_PROTOTYPES_BEGIN
 

--- a/src/util/wksp/Local.mk
+++ b/src/util/wksp/Local.mk
@@ -1,20 +1,23 @@
 $(call add-hdrs,fd_wksp.h)
 $(call add-objs,fd_wksp_admin fd_wksp_user fd_wksp_helper fd_wksp_used_treap fd_wksp_free_treap fd_wksp_io,fd_util)
-$(call make-bin,fd_wksp_ctl,fd_wksp_ctl,fd_util) # Just a stub on HAS_HOSTED
+$(call add-objs,fd_wksp_io fd_wksp_checkpt_v1 fd_wksp_restore_v1 fd_wksp_checkpt_v2 fd_wksp_restore_v2,fd_util)
+$(call make-bin,fd_wksp_ctl,fd_wksp_ctl,fd_util) # Just a stub if not HAS_HOSTED
 
 ifdef FD_HAS_HOSTED # This tests need fd_shmem API support currently only available on hosted targets
-
 $(call make-unit-test,test_wksp_used_treap,test_wksp_used_treap,fd_util)
-$(call run-unit-test,test_wksp_used_treap)
 $(call make-unit-test,test_wksp_free_treap,test_wksp_free_treap,fd_util)
-$(call run-unit-test,test_wksp_free_treap)
 $(call make-unit-test,test_wksp_admin,test_wksp_admin,fd_util)
-$(call run-unit-test,test_wksp_admin)
 $(call make-unit-test,test_wksp_user,test_wksp_user,fd_util)
-$(call run-unit-test,test_wksp_user)
 $(call make-unit-test,test_wksp_helper,test_wksp_helper,fd_util)
+$(call make-unit-test,test_wksp_tpool,test_wksp_tpool,fd_util)
 $(call make-unit-test,test_wksp,test_wksp,fd_util)
-$(call run-unit-test,test_wksp)
-$(call add-test-scripts,test_wksp_ctl)
 
+$(call run-unit-test,test_wksp_used_treap)
+$(call run-unit-test,test_wksp_free_treap)
+$(call run-unit-test,test_wksp_admin)
+$(call run-unit-test,test_wksp_user)
+#$(call run-unit-test,test_wksp_helper) # FIXME: why was this not enabled?
+$(call run-unit-test,test_wksp)
+
+$(call add-test-scripts,test_wksp_ctl)
 endif

--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -3,7 +3,8 @@
 
 #include "../pod/fd_pod.h"
 #include "../shmem/fd_shmem.h"
-#include "../sanitize/fd_asan.h"
+#include "../checkpt/fd_checkpt.h"
+#include "../sanitize/fd_sanitize.h"
 
 /* API for creating NUMA-aware and TLB-efficient workspaces used for
    complex inter-thread and inter-process shared memory communication

--- a/src/util/wksp/fd_wksp_admin.c
+++ b/src/util/wksp/fd_wksp_admin.c
@@ -211,7 +211,7 @@ fd_wksp_new( void *       shmem,
   void * wksp_data = (void*)((ulong)wksp + fd_wksp_private_pinfo_off());
   fd_asan_poison( wksp_data, footprint - fd_wksp_private_pinfo_off() );
   fd_wksp_private_pinfo_t * pinfo = fd_wksp_private_pinfo( wksp );
-  for( ulong i=0; i<part_max; i++ ) { 
+  for( ulong i=0; i<part_max; i++ ) {
     fd_asan_unpoison( &pinfo[ i ], FD_WKSP_PRIVATE_PINFO_FOOTPRINT );
   }
   #endif

--- a/src/util/wksp/fd_wksp_checkpt_v1.c
+++ b/src/util/wksp/fd_wksp_checkpt_v1.c
@@ -1,0 +1,239 @@
+#include "fd_wksp_private.h"
+
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+/* fd_wksp_private_checkpt_v1_write writes size sz buffer buf to the
+   output stream checkpt.  Assumes checkpt is valid and not in a
+   prepare.  Returns 0 on success and non-zero on failure (will be an
+   errno compat error code). */
+
+static inline int
+fd_wksp_private_checkpt_v1_write( fd_io_buffered_ostream_t * checkpt,
+                                  void const *               buf,
+                                  ulong                      sz ) {
+  return fd_io_buffered_ostream_write( checkpt, buf, sz );
+}
+
+/* fd_wksp_private_checkpt_v1_prepare prepares to write at most max
+   bytes to the output stream checkpt.  Assumes checkpt is valid and not
+   in a prepare and max is at most checkpt's wbuf_sz.  Returns the
+   location in the caller's address space for preparing the max bytes on
+   success (*_err will be 0) and NULL on failure (*_err will be an errno
+   compat error code). */
+
+static inline void *
+fd_wksp_private_checkpt_v1_prepare( fd_io_buffered_ostream_t * checkpt,
+                                    ulong                      max,
+                                    int *                      _err ) {
+  if( FD_UNLIKELY( fd_io_buffered_ostream_peek_sz( checkpt )<max ) ) {
+    int err = fd_io_buffered_ostream_flush( checkpt );
+    if( FD_UNLIKELY( err ) ) {
+      *_err = err;
+      return NULL;
+    }
+    /* At this point, peek_sz==wbuf_sz and wbuf_sz>=max */
+  }
+  /* At this point, peek_sz>=max */
+  *_err = 0;
+  return fd_io_buffered_ostream_peek( checkpt );
+}
+
+/* fd_wksp_private_checkpt_v1_publish publishes prepared bytes
+   [prepare,next) to checkpt.  Assumes checkpt is in a prepare and the
+   number of bytes to publish is at most the prepare's max.  checkpt
+   will not be in a prepare on return. */
+
+static inline void
+fd_wksp_private_checkpt_v1_publish( fd_io_buffered_ostream_t * checkpt,
+                                    void *                     next ) {
+  fd_io_buffered_ostream_seek( checkpt, (ulong)next - (ulong)fd_io_buffered_ostream_peek( checkpt ) );
+}
+
+/* fd_wksp_private_checkpt_v1_cancel cancels a prepare.  Assumes checkpt
+   is valid and in a prepare.  checkpt will not be in a prepare on
+   return. */
+
+//static inline void fd_wksp_private_checkpt_v1_cancel( fd_io_buffered_ostream_t * checkpt ) { (void)checkpt; }
+
+/* fd_wksp_private_checkpt_v1_ulong checkpoints the value v into a
+   checkpt.  p points to the location in a prepare where v should be
+   encoded.  Assumes this location has svw_enc_sz(v) available (at least
+   1 and at most 9).  Returns the location of the first byte after the
+   encoded value (will be prep+svw_enc_sz(val)). */
+
+static inline void * fd_wksp_private_checkpt_v1_ulong( void * prep, ulong val ) { return fd_ulong_svw_enc( (uchar *)prep, val ); }
+
+/* fd_wksp_private_checkpt_v1_buf checkpoints a variable length buffer buf
+   of size sz into a checkpt.  p points to the location in a prepare
+   region where buf should be encoded.  Assumes this location has
+   svw_enc_sz(sz)+sz bytes available (at least 1+sz and at most 9+sz).
+   Returns the location of the first byte after the encoded buffer (will
+   be prep+svw_enc_sz(sz)+sz).  Zero sz is fine (and NULL buf is fine if
+   sz is zero). */
+
+static inline void *
+fd_wksp_private_checkpt_v1_buf( void *       prep,
+                                void const * buf,
+                                ulong        sz ) {
+  prep = fd_wksp_private_checkpt_v1_ulong( (uchar *)prep, sz );
+  if( FD_LIKELY( sz ) ) fd_memcpy( prep, buf, sz );
+  return (uchar *)prep + sz;
+}
+
+int
+fd_wksp_private_checkpt_v1( fd_tpool_t * tpool,
+                            ulong        t0,
+                            ulong        t1,
+                            fd_wksp_t *  wksp,
+                            char const * path,
+                            ulong        mode,
+                            char const * uinfo ) {
+  (void)tpool; (void)t0; (void)t1; /* Note: Thread parallel v1 checkpoint not supported */
+
+  char const * binfo = fd_log_build_info;
+
+//FD_LOG_INFO(( "Checkpt wksp \"%s\" to \"%s\" (mode 0%03lo), uinfo \"%s\"", wksp->name, path, mode, uinfo ));
+
+  mode_t old_mask = umask( (mode_t)0 );
+  int fd = open( path, O_CREAT|O_EXCL|O_WRONLY, (mode_t)mode );
+  umask( old_mask );
+  if( FD_UNLIKELY( fd==-1 ) ) {
+    FD_LOG_WARNING(( "open(\"%s\",O_CREAT|O_EXCL|O_WRONLY,0%03lo) failed (%i-%s)", path, mode, errno, fd_io_strerror( errno ) ));
+    return FD_WKSP_ERR_FAIL;
+  }
+
+# define WBUF_ALIGN     ( 4096UL)
+# define WBUF_FOOTPRINT (65536UL)
+
+  uchar                    wbuf[ WBUF_FOOTPRINT ] __attribute__((aligned(WBUF_ALIGN)));
+  fd_io_buffered_ostream_t checkpt[ 1 ];
+  fd_io_buffered_ostream_init( checkpt, fd, wbuf, WBUF_FOOTPRINT );
+
+  int     err;
+  uchar * prep;
+
+  err = fd_wksp_private_lock( wksp ); if( FD_UNLIKELY( err ) ) goto fini; /* logs details */
+
+  /* Do basic wksp checks */
+
+  ulong data_lo = wksp->gaddr_lo;
+  ulong data_hi = wksp->gaddr_hi;
+  if( FD_UNLIKELY( !((0UL<data_lo) & (data_lo<=data_hi)) ) ) goto corrupt_wksp;
+
+  //FD_LOG_INFO(( "Checkpt header and metadata" ));
+
+  ulong binfo_len = fd_cstr_nlen( binfo, FD_WKSP_CHECKPT_V1_BINFO_MAX-1UL );
+  ulong uinfo_len = fd_cstr_nlen( uinfo, FD_WKSP_CHECKPT_V1_UINFO_MAX-1UL );
+
+  prep = fd_wksp_private_checkpt_v1_prepare( checkpt, WBUF_FOOTPRINT, &err ); if( FD_UNLIKELY( !prep ) ) goto io_err;
+  prep = fd_wksp_private_checkpt_v1_ulong( prep, wksp->magic                                );
+  prep = fd_wksp_private_checkpt_v1_ulong( prep, (ulong)FD_WKSP_CHECKPT_STYLE_V1            );
+  prep = fd_wksp_private_checkpt_v1_ulong( prep, (ulong)wksp->seed                          );
+  prep = fd_wksp_private_checkpt_v1_ulong( prep, wksp->part_max                             );
+  prep = fd_wksp_private_checkpt_v1_ulong( prep, wksp->data_max                             );
+  prep = fd_wksp_private_checkpt_v1_ulong( prep, (ulong)fd_log_wallclock()                  );
+  prep = fd_wksp_private_checkpt_v1_ulong( prep, fd_log_app_id()                            );
+  prep = fd_wksp_private_checkpt_v1_ulong( prep, fd_log_thread_id()                         );
+  prep = fd_wksp_private_checkpt_v1_ulong( prep, fd_log_host_id()                           );
+  prep = fd_wksp_private_checkpt_v1_ulong( prep, fd_log_cpu_id()                            );
+  prep = fd_wksp_private_checkpt_v1_ulong( prep, fd_log_group_id()                          );
+  prep = fd_wksp_private_checkpt_v1_ulong( prep, fd_log_tid()                               );
+  prep = fd_wksp_private_checkpt_v1_ulong( prep, fd_log_user_id()                           );
+  prep = fd_wksp_private_checkpt_v1_buf  ( prep, wksp->name,      strlen( wksp->name      ) );
+  prep = fd_wksp_private_checkpt_v1_buf  ( prep, fd_log_app(),    strlen( fd_log_app()    ) );
+  prep = fd_wksp_private_checkpt_v1_buf  ( prep, fd_log_thread(), strlen( fd_log_thread() ) );
+  prep = fd_wksp_private_checkpt_v1_buf  ( prep, fd_log_host(),   strlen( fd_log_host()   ) );
+  prep = fd_wksp_private_checkpt_v1_buf  ( prep, fd_log_cpu(),    strlen( fd_log_cpu()    ) );
+  prep = fd_wksp_private_checkpt_v1_buf  ( prep, fd_log_group(),  strlen( fd_log_group()  ) );
+  prep = fd_wksp_private_checkpt_v1_buf  ( prep, fd_log_user(),   strlen( fd_log_user()   ) );
+  prep = fd_wksp_private_checkpt_v1_buf  ( prep, binfo,           binfo_len                 );
+  prep = fd_wksp_private_checkpt_v1_buf  ( prep, uinfo,           uinfo_len                 );
+  fd_wksp_private_checkpt_v1_publish( checkpt, prep );
+
+//FD_LOG_INFO(( "Checkpt allocations" ));
+
+  ulong part_max = wksp->part_max;
+  fd_wksp_private_pinfo_t * pinfo = fd_wksp_private_pinfo( wksp );
+
+  ulong cycle_tag = wksp->cycle_tag++;
+
+  ulong gaddr_last = data_lo;
+
+  ulong i = fd_wksp_private_pinfo_idx( wksp->part_head_cidx );
+  while( !fd_wksp_private_pinfo_idx_is_null( i ) ) {
+    if( FD_UNLIKELY( i>=part_max ) || FD_UNLIKELY( pinfo[ i ].cycle_tag==cycle_tag ) ) goto corrupt_wksp;
+    pinfo[ i ].cycle_tag = cycle_tag; /* mark i as visited */
+
+    /* Do basic partition checks */
+
+    ulong gaddr_lo = pinfo[ i ].gaddr_lo;
+    ulong gaddr_hi = pinfo[ i ].gaddr_hi;
+    ulong tag      = pinfo[ i ].tag;
+
+    if( FD_UNLIKELY( !((gaddr_last==gaddr_lo) & (gaddr_lo<gaddr_hi) & (gaddr_hi<=data_hi)) ) ) goto corrupt_wksp;
+
+    gaddr_last = gaddr_hi;
+
+    /* If an allocated partition, checkpt it */
+
+    if( tag ) { /* ~50/50 */
+
+      ulong sz = gaddr_hi - gaddr_lo;
+      void * laddr_lo = fd_wksp_laddr_fast( wksp, gaddr_lo );
+
+      /* Checkpt partition header */
+
+      prep = fd_wksp_private_checkpt_v1_prepare( checkpt, 3UL*9UL, &err ); if( FD_UNLIKELY( !prep ) ) goto io_err;
+      prep = fd_wksp_private_checkpt_v1_ulong( prep, tag      );
+      prep = fd_wksp_private_checkpt_v1_ulong( prep, gaddr_lo );
+      prep = fd_wksp_private_checkpt_v1_ulong( prep, sz       );
+      fd_wksp_private_checkpt_v1_publish( checkpt, prep );
+
+      /* Checkpt partition data */
+
+      err = fd_wksp_private_checkpt_v1_write( checkpt, laddr_lo, sz ); if( FD_UNLIKELY( err ) ) goto io_err;
+    }
+
+    /* Advance to next partition */
+
+    i = fd_wksp_private_pinfo_idx( pinfo[ i ].next_cidx );
+  }
+
+//FD_LOG_INFO(( "Checkpt footer" ));
+
+  prep = fd_wksp_private_checkpt_v1_prepare( checkpt, 1UL*9UL, &err ); if( FD_UNLIKELY( !prep ) ) goto io_err;
+  prep = fd_wksp_private_checkpt_v1_ulong( prep, 0UL ); /* tags are never 0 above */
+  fd_wksp_private_checkpt_v1_publish( checkpt, prep );
+
+  err = fd_io_buffered_ostream_flush( checkpt ); if( FD_UNLIKELY( err ) ) goto io_err;
+
+  fd_wksp_private_unlock( wksp );
+
+//FD_LOG_INFO(( "Checkpt successful" ));
+
+  /* note: err == 0 at this point */
+
+fini: /* note: wksp unlocked at this point */
+  fd_io_buffered_ostream_fini( checkpt );
+  if( FD_UNLIKELY( err ) && FD_UNLIKELY( unlink( path ) ) )
+    FD_LOG_WARNING(( "unlink(\"%s\") failed (%i-%s); attempting to continue", path, errno, fd_io_strerror( errno ) ));
+  if( FD_UNLIKELY( close( fd ) ) )
+    FD_LOG_WARNING(( "close(\"%s\") failed (%i-%s); attempting to continue", path, errno, fd_io_strerror( errno ) ));
+  return err;
+
+io_err: /* Failed due to I/O error ... clean up and log (note: wksp locked at this point) */
+  fd_wksp_private_unlock( wksp );
+  FD_LOG_WARNING(( "Checkpt wksp \"%s\" to \"%s\" failed due to I/O error (%i-%s)",
+                   wksp->name, path, err, fd_io_strerror( err ) ));
+  err = FD_WKSP_ERR_FAIL;
+  goto fini;
+
+corrupt_wksp: /* Failed due to wksp corruption ... clean up and log (note: wksp locked at this point) */
+  fd_wksp_private_unlock( wksp );
+  FD_LOG_WARNING(( "Checkpt wksp \"%s\" to \"%s\" failed due to wksp corruption", wksp->name, path ));
+  err = FD_WKSP_ERR_CORRUPT;
+  goto fini;
+}

--- a/src/util/wksp/fd_wksp_checkpt_v2.c
+++ b/src/util/wksp/fd_wksp_checkpt_v2.c
@@ -1,0 +1,590 @@
+#include "fd_wksp_private.h"
+
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+/* This is an implementation detail and not strictly part of the v2
+   specification. */
+
+#define FD_WKSP_CHECKPT_V2_CGROUP_MAX (1024UL)
+
+int
+fd_wksp_private_checkpt_v2( fd_tpool_t * tpool,
+                            ulong        t0,
+                            ulong        t1,
+                            fd_wksp_t *  wksp,
+                            char const * path,
+                            ulong        mode,
+                            char const * uinfo,
+                            int          frame_style_compressed ) {
+
+  (void)tpool; (void)t0; (void)t1; /* Thread parallelization not currently implemented */
+
+  char const * binfo = fd_log_build_info;
+
+  if( FD_UNLIKELY( !fd_checkpt_frame_style_is_supported( frame_style_compressed ) ) ) {
+    FD_LOG_WARNING(( "compressed frames are not supported on this target" ));
+    return FD_WKSP_ERR_INVAL;
+  }
+
+  int err_fail;
+
+  int            locked  =  0;
+  int            fd      = -1;
+  fd_checkpt_t * checkpt = NULL;
+
+  fd_wksp_private_pinfo_t * pinfo = fd_wksp_private_pinfo( wksp );
+
+  char const * name     = wksp->name;
+  ulong        name_len = fd_shmem_name_len( name );
+  if( FD_UNLIKELY( !name_len ) ) {
+    FD_LOG_WARNING(( "checkpt wksp to \"%s\" failed due to bad name; attempting to continue", path ));
+    err_fail = FD_WKSP_ERR_CORRUPT;
+    goto fail;
+  }
+
+  /* Lock the wksp */
+
+  {
+    int _err = fd_wksp_private_lock( wksp ); /* logs details */
+    if( FD_UNLIKELY( _err ) ) {
+      FD_LOG_WARNING(( "checkpt wksp \"%s\" to \"%s\" failed due to being locked; attempting to continue", name, path ));
+      err_fail = _err;
+      goto fail;
+    }
+    locked = 1;
+  }
+
+  /* Determine a reasonable number of cgroups (note: in principle we
+     could thread parallelize this but it probably isn't worth the extra
+     complexity). */
+
+  ulong cgroup_cnt;
+  ulong alloc_cnt = 0UL;
+
+  {
+#   define WKSP_TEST( c ) do {                                                                                  \
+      if( FD_UNLIKELY( !(c) ) ) {                                                                               \
+        FD_LOG_WARNING(( "checkpt wksp \"%s\" to \"%s\" failed due to failing test %s; attempting to continue", \
+                         name, path, #c ));                                                                     \
+        err_fail = FD_WKSP_ERR_CORRUPT;                                                                         \
+        goto fail;                                                                                              \
+      }                                                                                                         \
+    } while(0)
+
+    /* Count the number of allocations by traversing over all partitions
+       in reverse order by gaddr_lo (same iteration we will do to assign
+       partitions to cgroups), validating as we go. */
+
+    ulong part_max  = wksp->part_max;
+    ulong data_lo   = wksp->gaddr_lo;
+    ulong data_hi   = wksp->gaddr_hi;
+    ulong cycle_tag = wksp->cycle_tag++;
+
+    WKSP_TEST( (0UL<data_lo) & (data_lo<=data_hi) ); /* Valid data region */
+
+    ulong gaddr_last = data_hi;
+
+    ulong part_idx = fd_wksp_private_pinfo_idx( wksp->part_tail_cidx );
+    while( !fd_wksp_private_pinfo_idx_is_null( part_idx ) ) {
+
+      /* Load partition metadata and validate it */
+
+      WKSP_TEST( part_idx<part_max );                      /* Valid idx */
+      WKSP_TEST( pinfo[ part_idx ].cycle_tag!=cycle_tag ); /* No cycles */
+      pinfo[ part_idx ].cycle_tag = cycle_tag;             /* Mark part_idx as visited */
+
+      ulong gaddr_lo = pinfo[ part_idx ].gaddr_lo;
+      ulong gaddr_hi = pinfo[ part_idx ].gaddr_hi;
+      ulong tag      = pinfo[ part_idx ].tag;
+
+      WKSP_TEST( (data_lo<=gaddr_lo) & (gaddr_lo<gaddr_hi) & (gaddr_hi==gaddr_last) ); /* Valid partition range */
+      gaddr_last = gaddr_lo;
+
+      /* If this partition holds an allocation, count it */
+
+      alloc_cnt += (ulong)(tag>0UL);
+
+      /* Advance to the previous partition */
+
+      part_idx = fd_wksp_private_pinfo_idx( pinfo[ part_idx ].prev_cidx );
+    }
+
+    WKSP_TEST( gaddr_last==data_lo ); /* Complete partitioning */
+
+    /* Compute a reasonable cgroup_cnt for alloc_cnt.  To do this,
+       let N be the number of allocations.  We assume they have IID
+       sizes with mean U and standard deviation S.  If we assign each
+       allocation to 1 of M cgroups IID uniform random (we will do
+       better below but we pessimize here), in the limit of N>>M>>1, a
+       cgroup's load (total number of allocation bytes assigned to a
+       cgroup to compress) is Gaussian (by central limit theorem) with
+       mean (N/M)U with standard deviation sqrt(N/M) sqrt(U^2+S^2).
+
+       That is, we are load balanced on average (yay) but there is some
+       natural imbalance expected due to statistical fluctuations (boo).
+       Noting that allocation sizes are positive, if we further assume
+       that S<~U typically (note that it is theoretically possible to
+       have a positive valued random variable with S arbitrarily larger
+       than U), then the cgroup load standard deviation is typically
+       less than sqrt(2N/M) U.
+
+       The load for each cgroup will be approximately independent of
+       each other for M>>1.  Extremal value statistics for a Gaussian
+       then implies that the least loaded cgroup is typically likely to
+       have more than (N/M)U - sqrt(2N/M) U sqrt(2 ln M) load.  We want
+       this to be positive such such that the least loaded cgroup will
+       typically have some load:
+
+            (N/M)U >> sqrt((4 N ln M)/M))U
+         -> (N/M)  >> 4 ln M
+
+       That is, we want pick the number of cgroups such that the number
+       of allocations per cgroup on average much greater than a few
+       times the natural log of the number of cgroups.
+
+       Given the number of cgroups is at most CGROUP_MAX ~ 1024, the
+       above implies if we target more than ~28 allocations per cgroup
+       on average, each cgroup is likely to get some load and cgroups
+       will be reasonably load balanced on average.  We use 32 below for
+       computational convenience. */
+
+    cgroup_cnt = fd_ulong_min( (alloc_cnt+31UL)/32UL, FD_WKSP_CHECKPT_V2_CGROUP_MAX );
+
+#   undef WKSP_TEST
+  }
+
+  /* Assign allocations to cgroups (note: in principle we could thread
+     parallelize this but it also probably isn't worth the extra
+     complexity). */
+
+  uint  cgroup_head_cidx[ FD_WKSP_CHECKPT_V2_CGROUP_MAX ]; /* Head of a linked list for partitions assigned to each cgroup */
+  ulong cgroup_alloc_cnt[ FD_WKSP_CHECKPT_V2_CGROUP_MAX ]; /* Number of partitions in each cgroup */
+
+  {
+
+    /* Initialize the cgroups to empty */
+
+    ulong cgroup_load[ FD_WKSP_CHECKPT_V2_CGROUP_MAX ];
+
+    uint null_cidx = fd_wksp_private_pinfo_cidx( FD_WKSP_PRIVATE_PINFO_IDX_NULL );
+    for( ulong cgroup_idx=0UL; cgroup_idx<cgroup_cnt; cgroup_idx++ ) {
+      cgroup_head_cidx[ cgroup_idx ] = null_cidx;
+      cgroup_alloc_cnt[ cgroup_idx ] = 0UL;
+      cgroup_load     [ cgroup_idx ] = 0UL;
+    }
+
+    /* Configure cgroup sampling */
+
+    ulong cgroup_cursor = 0UL;
+    ulong cgroup_idx    = 0UL;
+
+    /* For all partitions in reverse order by gaddr_lo */
+
+    ulong part_idx = fd_wksp_private_pinfo_idx( wksp->part_tail_cidx );
+    while( !fd_wksp_private_pinfo_idx_is_null( part_idx ) ) {
+
+      /* Load partition metadata */
+
+      ulong gaddr_lo = pinfo[ part_idx ].gaddr_lo;
+      ulong gaddr_hi = pinfo[ part_idx ].gaddr_hi;
+      ulong tag      = pinfo[ part_idx ].tag;
+
+      /* If this partition holds an allocation, deterministically assign
+         it to a cgroup in an approximately load balanced way such that
+         the assignments will be identical for the same set of
+         allocations and cgroup_cnt. */
+
+      if( tag ) { /* ~50/50 */
+
+        /* Sample a handful of cgroups and pick the least loaded to
+           approximate a greedy load balance method.  We consider the
+           most recently assigned cgroup (which was thought to be
+           lightly loaded at the previous assignment), a cyclically
+           sampled cgroup (ala striping) and two pseudo-randomly sampled
+           cgroups based on the common hash of gaddr_lo (ala random
+           assignment).  We don't care if our samples collide; we are
+           just trying to improve on load balance over straight striping
+           and random sampling (both of which are already asymptotically
+           are load balanced as per the above).
+
+           We could use a min-heap here but that would be
+           algorithmically more expensive, more complex to implement and
+           unlikely to improve load balance much futher (it would be
+           the greedy load balance method, which is also asymptotically
+           optimal but not perfect ... perfect load balance is a
+           computationally hard knapsack like problem but pretty good
+           load balance is easy). */
+
+        {
+          ulong h = fd_ulong_hash( gaddr_lo );
+
+          ulong i0 = cgroup_idx;             ulong l0 = cgroup_load[ i0 ];
+          ulong i1 = cgroup_cursor;          ulong l1 = cgroup_load[ i1 ];
+          ulong i2 =  h        % cgroup_cnt; ulong l2 = cgroup_load[ i2 ];
+          ulong i3 = (h >> 32) % cgroup_cnt; ulong l3 = cgroup_load[ i3 ];
+
+          i0 = fd_ulong_if( l0<=l1, i0, i1 ); l0 = fd_ulong_min( l0, l1 );
+          i1 = fd_ulong_if( l2<=l3, i2, i3 ); l1 = fd_ulong_min( l2, l3 );
+          i0 = fd_ulong_if( l0<=l1, i0, i1 ); l0 = fd_ulong_min( l0, l1 );
+
+          cgroup_cursor = fd_ulong_if( cgroup_cursor<cgroup_cnt-1UL, cgroup_cursor+1UL, 0UL );
+          cgroup_idx    = i0;
+        }
+
+        /* Update this cgroup's partition count and load.  The load is
+           currently the total uncompressed bytes of partition metadata
+           and data (TODO: consider adding a fixed base cost here to
+           account for fixed computational overheads too.  This would be
+           an order of magnitude ballpark of the cost of doing 2
+           fd_checkpt_buf relative to the marginal cost of checkpointing
+           an additional byte for some representative target ... note
+           that specific target details should not be incorporated into
+           this because then specific checkpt byte stream would be
+           sensitive to who wrote the checkpt and ideally checkpt should
+           be bit-for-bit identical for identical wksp regardless of the
+           target details). */
+
+        cgroup_alloc_cnt[ cgroup_idx ]++;
+        cgroup_load     [ cgroup_idx ] += 3UL*sizeof(ulong) + (gaddr_hi - gaddr_lo);
+
+        /* Push this partition onto the cgroup's stack.  Since we are
+           iterating over partitions in reverse order by gaddr_lo, the
+           stack for each cgroup can be treated as a linked list in
+           sorted order by gaddr_lo (helps with metdata
+           compressibility). */
+
+        pinfo[ part_idx ].stack_cidx   = cgroup_head_cidx[ cgroup_idx ];
+        cgroup_head_cidx[ cgroup_idx ] = fd_wksp_private_pinfo_cidx( part_idx );
+      }
+
+      /* Advance to the previous partition */
+
+      part_idx = fd_wksp_private_pinfo_idx( pinfo[ part_idx ].prev_cidx );
+    }
+  }
+
+  /* At this point, each wksp partitions to checkpt have been assigned
+     to a cgroup, the cgroups are approximately load balanced and the
+     partitions for each cgroup are given in a singly linked list sorted
+     in ascending order by gaddr_lo. */
+
+  /* Create the checkpt file */
+
+  {
+    mode_t old_mask = umask( (mode_t)0 );
+    fd = open( path, O_CREAT|O_EXCL|O_WRONLY, (mode_t)mode );
+    umask( old_mask );
+    if( FD_UNLIKELY( fd==-1 ) ) {
+      FD_LOG_WARNING(( "checkpt wksp \"%s\" to \"%s\" failed opening file with flags_O_CREAT|O_EXCL|O_WRONLY in mode 0%03lo "
+                      "(%i-%s); attempting to continue", name, path, mode, errno, fd_io_strerror( errno ) ));
+      err_fail = FD_WKSP_ERR_FAIL;
+      goto fail;
+    }
+  }
+
+  /* Initialize the checkpt */
+
+  ulong frame_off[ FD_WKSP_CHECKPT_V2_CGROUP_MAX+6UL ];
+  ulong frame_cnt = 0UL;
+
+  fd_checkpt_t  _checkpt[ 1 ];
+  uchar         wbuf[ FD_CHECKPT_WBUF_MIN ];
+
+  checkpt = fd_checkpt_init_stream( _checkpt, fd, wbuf, FD_CHECKPT_WBUF_MIN ); /* logs details */
+  if( FD_UNLIKELY( !checkpt ) ) {
+    FD_LOG_WARNING(( "checkpt wksp \"%s\" to \"%s\" failed when initializing; attempting to continue", name, path ));
+    err_fail = FD_WKSP_ERR_FAIL;
+    goto fail;
+  }
+
+# define CHECKPT_OPEN(frame_style) do {                                                                                \
+    int _err = fd_checkpt_open_advanced( checkpt, (frame_style), &frame_off[ frame_cnt ] );                            \
+    if( FD_UNLIKELY( _err ) ) {                                                                                        \
+      FD_LOG_WARNING(( "checkpt wksp \"%s\" to \"%s\" failed when opening a %s frame (%i-%s); attempting to continue", \
+                       name, path, #frame_style, _err, fd_checkpt_strerror( _err ) ));                                 \
+      err_fail = FD_WKSP_ERR_FAIL;                                                                                     \
+      goto fail;                                                                                                       \
+    }                                                                                                                  \
+  } while(0)
+
+# define CHECKPT_CLOSE() do {                                                                                       \
+    frame_cnt++;                                                                                                    \
+    int   _err = fd_checkpt_close_advanced( checkpt, &frame_off[ frame_cnt ] ); /* logs details */                  \
+    if( FD_UNLIKELY( _err ) ) {                                                                                     \
+      FD_LOG_WARNING(( "checkpt wksp \"%s\" to \"%s\" failed when closing a frame (%i-%s); attempting to continue", \
+                       name, path, _err, fd_checkpt_strerror( _err ) ));                                            \
+      err_fail = FD_WKSP_ERR_FAIL;                                                                                  \
+      goto fail;                                                                                                    \
+    }                                                                                                               \
+  } while(0)
+
+  /* Note: sz must be at most FD_CHECKPT_META_MAX */
+# define CHECKPT_META( meta, sz ) do {                                                                                \
+    ulong _sz  = (sz);                                                                                                \
+    int   _err = fd_checkpt_meta( checkpt, (meta), _sz ); /* logs details */                                          \
+    if( FD_UNLIKELY( _err ) ) {                                                                                       \
+      FD_LOG_WARNING(( "checkpt to \"%s\" failed when writing %lu bytes metadata %s (%i-%s); attempting to continue", \
+                       path, _sz, #meta, _err, fd_checkpt_strerror( _err ) ));                                        \
+      err_fail = FD_WKSP_ERR_FAIL;                                                                                    \
+      goto fail;                                                                                                      \
+    }                                                                                                                 \
+  } while(0)
+
+  /* Note: data must exist and be unchanged until frame close */
+# define CHECKPT_DATA( data, sz ) do {                                                                            \
+    ulong _sz  = (sz);                                                                                            \
+    int   _err = fd_checkpt_data( checkpt, (data), _sz ); /* logs details */                                      \
+    if( FD_UNLIKELY( _err ) ) {                                                                                   \
+      FD_LOG_WARNING(( "checkpt to \"%s\" failed when writing %lu bytes data %s (%i-%s); attempting to continue", \
+                       path, _sz, #data, _err, fd_checkpt_strerror( _err ) ));                                    \
+      err_fail = FD_WKSP_ERR_FAIL;                                                                                \
+      goto fail;                                                                                                  \
+    }                                                                                                             \
+  } while(0)
+
+  /* Checkpt the header */
+
+  {
+    fd_wksp_checkpt_v2_hdr_t hdr[1];
+
+    hdr->magic                  = wksp->magic;
+    hdr->style                  = FD_WKSP_CHECKPT_STYLE_V2;
+    hdr->frame_style_compressed = frame_style_compressed;
+    hdr->reserved               = 0U;
+    memset( hdr->name, 0,    FD_SHMEM_NAME_MAX ); /* Make sure trailing zeros clear */
+    memcpy( hdr->name, name, name_len          );
+    hdr->seed                   = wksp->seed;
+    hdr->part_max               = wksp->part_max;
+    hdr->data_max               = wksp->data_max;
+
+    CHECKPT_OPEN( FD_CHECKPT_FRAME_STYLE_RAW );
+    CHECKPT_DATA( hdr, sizeof(fd_wksp_checkpt_v2_hdr_t) );
+    CHECKPT_CLOSE();
+  }
+
+  /* Checkpt the info */
+
+  {
+    fd_wksp_checkpt_v2_info_t info[1];
+    char                      buf[ 65536 ];
+    char *                    p = buf;
+
+    info->mode      = mode;
+    info->wallclock = fd_log_wallclock();
+    info->app_id    = fd_log_app_id   ();
+    info->thread_id = fd_log_thread_id();
+    info->host_id   = fd_log_host_id  ();
+    info->cpu_id    = fd_log_cpu_id   ();
+    info->group_id  = fd_log_group_id ();
+    info->tid       = fd_log_tid      ();
+    info->user_id   = fd_log_user_id  ();
+
+#   define APPEND_CSTR( field, cstr, len ) do { \
+      ulong _len = (len);                       \
+      memcpy( p, (cstr), _len );                \
+      p[ _len ] = '\0';                         \
+      info->sz_##field = _len + 1UL;            \
+      p += info->sz_##field;                    \
+    } while(0)
+
+    APPEND_CSTR( app,    fd_log_app(),    strlen( fd_log_app()    ) ); /* appends at most FD_LOG_NAME_MAX ~ 40 B */
+    APPEND_CSTR( thread, fd_log_thread(), strlen( fd_log_thread() ) ); /* " */
+    APPEND_CSTR( host,   fd_log_host(),   strlen( fd_log_host()   ) ); /* " */
+    APPEND_CSTR( cpu,    fd_log_cpu(),    strlen( fd_log_cpu()    ) ); /* " */
+    APPEND_CSTR( group,  fd_log_group(),  strlen( fd_log_group()  ) ); /* " */
+    APPEND_CSTR( user,   fd_log_user(),   strlen( fd_log_user()   ) ); /* " */
+    APPEND_CSTR( path,   path,            strlen( path            ) ); /* appends at most PATH_MAX-1 ~ 4 KiB */
+    APPEND_CSTR( binfo,  binfo,           fd_cstr_nlen( binfo, FD_WKSP_CHECKPT_V2_BINFO_MAX-1UL ) ); /* appends at most 16 KiB */
+    APPEND_CSTR( uinfo,  uinfo,           fd_cstr_nlen( uinfo, FD_WKSP_CHECKPT_V2_UINFO_MAX-1UL ) ); /* " */
+
+#   undef APPEND_CSTR
+
+    /* Write the info */
+
+    CHECKPT_OPEN( frame_style_compressed );
+    CHECKPT_DATA( info, sizeof(fd_wksp_checkpt_v2_info_t) );
+    CHECKPT_DATA( buf,  (ulong)(p-buf)                    );
+    CHECKPT_CLOSE();
+  }
+
+  /* Checkpt the volume cgroups.  Note: This implementation just
+     checkpoints 1 volume with at most CGROUP_MAX cgroup_cnt groups.
+
+     Note: this loop can be parallelized over multiple threads if
+     willing to leave holes in the file (and then maybe do a second pass
+     to compact the holes or maybe do a planning pass and then a real
+     pass or maybe leave the holes and do a second pass of run length
+     and entropy coding or maybe write to separate files and distribute
+     as a multiple files or maybe use non-POSIX filesystem mojo to
+     stitch together the separate files to appear as one file or ...) */
+
+  for( ulong cgroup_idx=0UL; cgroup_idx<cgroup_cnt; cgroup_idx++ ) {
+
+    CHECKPT_OPEN( frame_style_compressed );
+
+    /* Write cgroup commands */
+
+    fd_wksp_checkpt_v2_cmd_t cmd[1];
+
+    ulong part_idx = fd_wksp_private_pinfo_idx( cgroup_head_cidx[ cgroup_idx ] );
+    while( !fd_wksp_private_pinfo_idx_is_null( part_idx ) ) {
+
+      /* Command: "meta (tag,gaddr_lo,gaddr_hi)" */
+
+      cmd->meta.tag      = pinfo[ part_idx ].tag;      /* Note: non-zero */
+      cmd->meta.gaddr_lo = pinfo[ part_idx ].gaddr_lo;
+      cmd->meta.gaddr_hi = pinfo[ part_idx ].gaddr_hi;
+
+      CHECKPT_META( cmd, sizeof(fd_wksp_checkpt_v2_cmd_t) );
+
+      part_idx = fd_wksp_private_pinfo_idx( pinfo[ part_idx ].stack_cidx );
+    }
+
+    /* Command: "corresponding data follows" */
+
+    cmd->data.tag        = 0UL;
+    cmd->data.cgroup_cnt = ULONG_MAX;
+    cmd->data.frame_off  = ULONG_MAX;
+
+    CHECKPT_META( cmd, sizeof(fd_wksp_checkpt_v2_cmd_t) );
+
+    /* Write cgroup partition data */
+
+    part_idx = fd_wksp_private_pinfo_idx( cgroup_head_cidx[ cgroup_idx ] );
+    while( !fd_wksp_private_pinfo_idx_is_null( part_idx ) ) {
+      ulong gaddr_lo = pinfo[ part_idx ].gaddr_lo;
+      ulong gaddr_hi = pinfo[ part_idx ].gaddr_hi;
+
+      CHECKPT_DATA( fd_wksp_laddr_fast( wksp, gaddr_lo ), gaddr_hi - gaddr_lo );
+
+      part_idx = fd_wksp_private_pinfo_idx( pinfo[ part_idx ].stack_cidx );
+    }
+
+    CHECKPT_CLOSE();
+
+  }
+
+  /* Checkpt the volume appendix.  This starts with a command that
+     indicates this frame is an appendix for cgroup_cnt cgroups (this
+     can be used in a streaming restore to tell when it has reached the
+     appendix and in a parallel restore of the appendix so a parallel
+     restore thread knows how much it needs to decompress), the offsets
+     of each cgroup frame (so parallel restore threads can seek to the
+     partitions assigned to them) and the number of partitions in each
+     cgroup frame (so that the pinfo on restore can be partitioned over
+     parallel restore threads upfront non-atomically and
+     deterministically). */
+
+  {
+    fd_wksp_checkpt_v2_cmd_t cmd[1];
+
+    /* Command: "appendix for a volume with cgroup_cnt frames and no
+       previous volumes" */
+
+    cmd->appendix.tag        = 0UL;
+    cmd->appendix.cgroup_cnt = cgroup_cnt;
+    cmd->appendix.frame_off  = 0UL;
+
+    CHECKPT_OPEN( frame_style_compressed );
+    CHECKPT_META( cmd,              sizeof(fd_wksp_checkpt_v2_cmd_t) ); /* Note: must be meta for restore */
+    CHECKPT_DATA( frame_off+2UL,    cgroup_cnt*sizeof(ulong)         );
+    CHECKPT_DATA( cgroup_alloc_cnt, cgroup_cnt*sizeof(ulong)         );
+    CHECKPT_CLOSE();
+  }
+
+  /* Checkpt the volumes frame */
+
+  {
+    fd_wksp_checkpt_v2_cmd_t cmd[1];
+
+    /* Command: "no more volumes */
+
+    cmd->volumes.tag        = 0UL;
+    cmd->volumes.cgroup_cnt = ULONG_MAX;
+    cmd->volumes.frame_off  = frame_off[ frame_cnt-1 ];
+
+    CHECKPT_OPEN( frame_style_compressed );
+    CHECKPT_META( cmd, sizeof(fd_wksp_checkpt_v2_cmd_t) );
+    CHECKPT_CLOSE();
+  }
+
+  /* Checkpt the footer */
+
+  {
+    fd_wksp_checkpt_v2_ftr_t ftr[1];
+
+    /* Command: "footer for a checkpt with cgroup_cnt total cgroup
+       frames" */
+
+    ftr->alloc_cnt                   = alloc_cnt;
+    ftr->cgroup_cnt                  = cgroup_cnt;
+    ftr->volume_cnt                  = 1UL;
+    ftr->frame_off                   = frame_off[ frame_cnt-1U ];
+    ftr->checkpt_sz                  = frame_off[ frame_cnt ] + sizeof(fd_wksp_checkpt_v2_ftr_t);
+    ftr->data_max                    = wksp->data_max;
+    ftr->part_max                    = wksp->part_max;
+    ftr->seed                        = wksp->seed;
+    memset( ftr->name, 0,    FD_SHMEM_NAME_MAX ); /* Make sure trailing zeros clear */
+    memcpy( ftr->name, name, name_len          );
+    ftr->reserved                    = 0U;
+    ftr->frame_style_compressed      = frame_style_compressed;
+    ftr->style                       = FD_WKSP_CHECKPT_STYLE_V2;
+    ftr->unmagic                     = ~wksp->magic;
+
+    CHECKPT_OPEN( FD_CHECKPT_FRAME_STYLE_RAW );
+    CHECKPT_DATA( ftr, sizeof(fd_wksp_checkpt_v2_ftr_t) );
+    CHECKPT_CLOSE();
+  }
+
+# undef CHECKPT_DATA
+# undef CHECKPT_META
+# undef CHECKPT_CLOSE
+# undef CHECKPT_OPEN
+
+  /* Finalize the checkpt */
+
+  if( FD_UNLIKELY( !fd_checkpt_fini( checkpt ) ) ) { /* logs details */
+    FD_LOG_WARNING(( "checkpt wksp \"%s\" to \"%s\" failed when finalizing; attempting to continue", name, path ));
+    checkpt  = NULL;
+    err_fail = FD_WKSP_ERR_FAIL;
+    goto fail;
+  }
+
+  /* Close the file */
+
+  if( FD_UNLIKELY( close( fd ) ) ) {
+    FD_LOG_WARNING(( "checkpt wksp \"%s\" to \"%s\" failed when closing; attempting to continue", name, path ));
+    fd       = -1;
+    err_fail = FD_WKSP_ERR_FAIL;
+    goto fail;
+  }
+
+  /* Unlock the wksp */
+
+  fd_wksp_private_unlock( wksp );
+  locked = 0;
+
+  return FD_WKSP_SUCCESS;
+
+fail:
+
+  /* Release resources that might be reserved */
+
+  if( FD_LIKELY( checkpt ) ) {
+    if( FD_UNLIKELY( fd_checkpt_in_frame( checkpt ) ) && FD_UNLIKELY( fd_checkpt_close( checkpt ) ) )
+      FD_LOG_WARNING(( "fd_checkpt_close failed; attempting to continue" ));
+
+    if( FD_UNLIKELY( !fd_checkpt_fini( checkpt ) ) ) /* logs details */
+      FD_LOG_WARNING(( "fd_checkpt_fini failed; attempting to continue" ));
+  }
+
+  if( FD_LIKELY( fd!=-1 ) && FD_UNLIKELY( close( fd ) ) )
+    FD_LOG_WARNING(( "close(\"%s\") failed (%i-%s); attempting to continue", path, errno, fd_io_strerror( errno ) ));
+
+  if( FD_LIKELY( locked ) ) fd_wksp_private_unlock( wksp );
+
+  return err_fail;
+}

--- a/src/util/wksp/fd_wksp_ctl_help
+++ b/src/util/wksp/fd_wksp_ctl_help
@@ -9,6 +9,9 @@ help
 tag val
 - Sets the tag for subsequent wksp allocations to val.  Default is 1.
 
+supported-styles
+- Prints the supported checkpt styles for this target.
+
 new wksp page_cnt page_sz cpu_idx_seq mode
 - Create a workspace named wksp from page_cnt page_sz pages distributed
   over numa nodes near cpu_idx_seq.  The region will have the unix
@@ -89,10 +92,15 @@ checkpt wksp checkpt mode style info
   octal).  The style of checkpt is given by style.  info is a string
   that the user can use to provide additional information about the
   checkpoint.  Supported styles include:
-    0 - default (currently this is raw)
-    1 - raw ... all workspace allocations (partitions with a non-zero
+    0 - default ... currently this 3 if the target supports it and
+        2 if not.
+    1 - v1 ... all workspace allocations (partitions with a non-zero
         tag) will be checkpointed.  Minimal compression and hashing will
         be done to the checkpoint file.
+    2 - v2 ... like v1 but uses a different layout under the hood
+        to support fast parallel checkpt and restore.
+    3 - v3 ... like v2 but also uses supports fast parallel compressed
+        checkpt and restore.
 
 checkpt-query checkpt verbose
 - Query the checkpoint at the path checkpt.  Verbose indicates the

--- a/src/util/wksp/fd_wksp_free_treap.c
+++ b/src/util/wksp/fd_wksp_free_treap.c
@@ -16,7 +16,7 @@ fd_wksp_private_free_treap_query( ulong                     sz,
     if( FD_UNLIKELY( i>=part_max                     ) ) return FD_WKSP_PRIVATE_PINFO_IDX_NULL; /* Bad index */
     if( FD_UNLIKELY( pinfo[ i ].cycle_tag==cycle_tag ) ) return FD_WKSP_PRIVATE_PINFO_IDX_NULL; /* Cycle detected */
     pinfo[ i ].cycle_tag = cycle_tag;                                                           /* Mark i as visited */
-   
+
     ulong part_sz = fd_wksp_private_pinfo_sz( pinfo + i );
     if( sz>part_sz ) i = fd_wksp_private_pinfo_idx( pinfo[ i ].right_cidx ); /* Partition list and left too small, go right */
     else {
@@ -142,7 +142,7 @@ fd_wksp_private_free_treap_insert( ulong                     n,
       if( fd_wksp_private_pinfo_idx_is_null( k ) ) break;
       TEST( fd_wksp_private_pinfo_idx( pinfo[ k ].parent_cidx )==j ); /* Make sure good prev */
       j = k;
-    } 
+    }
 
     pinfo[ n ].in_same     = 1U;
     pinfo[ n ].left_cidx   = fd_wksp_private_pinfo_cidx( FD_WKSP_PRIVATE_PINFO_IDX_NULL );
@@ -183,7 +183,7 @@ fd_wksp_private_free_treap_insert( ulong                     n,
     ulong il = fd_wksp_private_pinfo_idx( pinfo[ i ].left_cidx   ); /* Validated above */
   //ulong ir = fd_wksp_private_pinfo_idx( pinfo[ i ].right_cidx  ); /* Validated above */
     ulong p  = fd_wksp_private_pinfo_idx( pinfo[ i ].parent_cidx ); /* Validated above */
-    _p_child_cidx = fd_wksp_private_pinfo_idx_is_null( p )                 ? &wksp->part_free_cidx 
+    _p_child_cidx = fd_wksp_private_pinfo_idx_is_null( p )                 ? &wksp->part_free_cidx
                   : (fd_wksp_private_pinfo_idx( pinfo[ p ].left_cidx )==i) ? &pinfo[ p ].left_cidx   /* Validated above */
                   :                                                          &pinfo[ p ].right_cidx;
 

--- a/src/util/wksp/fd_wksp_helper.c
+++ b/src/util/wksp/fd_wksp_helper.c
@@ -186,7 +186,7 @@ fd_wksp_delete_named( char const * name ) {
     fd_shmem_leave( shwksp, NULL, NULL );
     return FD_WKSP_ERR_FAIL;
   }
-    
+
   fd_shmem_leave( shwksp, NULL, NULL ); /* logs details, after the unlink as per UNIX file semantics */
   return FD_WKSP_SUCCESS;
 }
@@ -525,4 +525,3 @@ fd_wksp_pod_unmap( void * obj ) {
 
   fd_wksp_unmap( obj ); /* logs details */
 }
-

--- a/src/util/wksp/fd_wksp_io.c
+++ b/src/util/wksp/fd_wksp_io.c
@@ -1,16 +1,142 @@
 #include "fd_wksp_private.h"
 
+#include <stdio.h>
 #include <errno.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <sys/stat.h>
+
+/* fd_wksp_private_checkpt_read reads up to the leading buf_max bytes at
+   path into buf.  On success, returns 0 and *_buf_sz will contain the
+   number of bytes read.  Returns a fd_io_strerror compatible error code
+   on failure and *_buf_sz will be unchanged (buf might have been
+   clobbered). */
+
+static int
+fd_wksp_private_checkpt_read( char const * path,       /* Assumes valid */
+                              void *       buf,        /* Assumes valid */
+                              ulong        buf_max,    /* Assumes buf_max>=12 */
+                              ulong *      _buf_sz ) { /* Assumes non-NULL */
+
+  int fd = open( path, O_RDONLY, (mode_t)0 );
+  if( FD_UNLIKELY( fd==-1 ) ) return errno;
+
+  int err = fd_io_read( fd, buf, 12UL, buf_max, _buf_sz );
+
+  if( FD_UNLIKELY( close( fd ) ) )
+    FD_LOG_WARNING(( "close(\"%s\") failed (%i-%s); attempting to continue", path, errno, fd_io_strerror( errno ) ));
+
+  return err;
+}
 
 int
-fd_wksp_checkpt( fd_wksp_t *  wksp,
-                 char const * path,
-                 ulong        mode,
-                 int          style,
-                 char const * uinfo ) { /* TODO: CONSIDER ALLOWING SUBSET OF TAGS */
+fd_wksp_preview( char const *        path,
+                 fd_wksp_preview_t * _opt_preview ) {
+
+  /* Check input args */
+
+  if( FD_UNLIKELY( !path ) ) return FD_WKSP_ERR_INVAL;
+
+  fd_wksp_preview_t stack_preview[1];
+  if( !_opt_preview ) _opt_preview = stack_preview; /* cmov */
+
+  /* Read the wksp checkpt header.  165 is large enough to
+     handle decoding an arbitrarily corrupted V1 header (14 worst case
+     SVW encoded ulongs at 9 bytes each followed by a worst case
+     non-'\0' bytes of name at 39==FD_SHMEM_NAME_MAX-1 bytes) and an
+     arbitrarily corrupted V2 header (a 80 byte struct stored
+     uncompressed). */
+
+  uchar buf[ 165 ];
+  ulong buf_sz;
+  int   err = fd_wksp_private_checkpt_read( path, buf, 165UL, &buf_sz );
+  if( FD_UNLIKELY( err ) ) return FD_WKSP_ERR_FAIL;
+
+  /* If we read a supported valid V2 header, return the requested
+     preview info */
+
+  fd_wksp_checkpt_v2_hdr_t * v2 = (fd_wksp_checkpt_v2_hdr_t *)buf;
+
+  ulong name_len = fd_shmem_name_len( v2->name ); /* tail reading safe */
+
+  if( FD_LIKELY( (sizeof(fd_wksp_checkpt_v2_hdr_t)<=buf_sz                         ) &     /* header not truncated */
+                 (v2->magic==FD_WKSP_MAGIC                                         ) &     /* with valid magic */
+                 (v2->style==FD_WKSP_CHECKPT_STYLE_V2                              ) &     /* with valid style */
+                 (fd_checkpt_frame_style_is_supported( v2->frame_style_compressed )) &     /* with supported compression */
+                 (v2->reserved==0U                                                 ) &     /* with expected reserved */
+                 (name_len>0UL                                                     ) &     /* with valid name */
+                 /* ignore seed (arbitrary) */
+                 (fd_wksp_footprint( v2->part_max, v2->data_max )>0UL              ) ) ) { /* with valid part_max / data_max */
+    _opt_preview->style    = v2->style;
+    _opt_preview->seed     = v2->seed;
+    _opt_preview->part_max = v2->part_max;
+    _opt_preview->data_max = v2->data_max;
+    memcpy( _opt_preview->name, v2->name, name_len+1UL );
+    return FD_WKSP_SUCCESS;
+  }
+
+  /* Otherwise, if we read a supported valid V1 header, return the
+     requested preview info */
+
+  uchar const * cur = buf;
+
+  ulong magic;     cur = fd_ulong_svw_dec( cur, &magic     ); /* safe to tail read */
+  ulong style_ul;  cur = fd_ulong_svw_dec( cur, &style_ul  ); /* " */
+  ulong seed_ul;   cur = fd_ulong_svw_dec( cur, &seed_ul   ); /* " */
+  ulong part_max;  cur = fd_ulong_svw_dec( cur, &part_max  ); /* " */
+  ulong data_max;  cur = fd_ulong_svw_dec( cur, &data_max  ); /* " */
+  ulong ts_ul;     cur = fd_ulong_svw_dec( cur, &ts_ul     ); /* " */
+  ulong app_id;    cur = fd_ulong_svw_dec( cur, &app_id    ); /* " */
+  ulong thread_id; cur = fd_ulong_svw_dec( cur, &thread_id ); /* " */
+  ulong host_id;   cur = fd_ulong_svw_dec( cur, &host_id   ); /* " */
+  ulong cpu_id;    cur = fd_ulong_svw_dec( cur, &cpu_id    ); /* " */
+  ulong group_id;  cur = fd_ulong_svw_dec( cur, &group_id  ); /* " */
+  ulong tid;       cur = fd_ulong_svw_dec( cur, &tid       ); /* " */
+  ulong user_id;   cur = fd_ulong_svw_dec( cur, &user_id   ); /* " */
+  /* name_len */   cur = fd_ulong_svw_dec( cur, &name_len  ); /* " */
+
+  char  name[ FD_SHMEM_NAME_MAX ];
+  ulong name_len_safe = fd_ulong_min( name_len, FD_SHMEM_NAME_MAX-1UL );
+  memcpy( name, cur, name_len_safe );
+  name[ name_len_safe ] = '\0';
+
+  if( FD_LIKELY( (((ulong)(cur-buf))<=buf_sz                            ) &     /* header not truncated */
+                 (magic   ==FD_WKSP_MAGIC                               ) &     /* with valid magic */
+                 (style_ul==(ulong)FD_WKSP_CHECKPT_STYLE_V1             ) &     /* with valid style */
+                 (seed_ul ==(ulong)(uint)seed_ul                        ) &     /* with valid seed */
+                 (fd_wksp_footprint( part_max, data_max )>0UL           ) &     /* with valid part_max / data_max */
+                 /* ignore ts_ul     (metadata) */
+                 /* ignore app_id    (metadata) */
+                 /* ignore thread_id (metadata) */
+                 /* ignore host_id   (metadata) */
+                 /* ignore cpu_id    (metadata) */
+                 /* ignore group_id  (metadata) */
+                 /* ignore tid_id    (metadata) */
+                 /* ignore user_id   (metadata) */
+                 ((name_len>0UL) & (fd_shmem_name_len( name )==name_len)) ) ) { /* with valid name */
+    _opt_preview->style    = (int)style_ul;
+    _opt_preview->seed     = (uint)seed_ul;
+    _opt_preview->part_max = part_max;
+    _opt_preview->data_max = data_max;
+    memcpy( _opt_preview->name, name, name_len+1UL );
+    return FD_WKSP_SUCCESS;
+  }
+
+  /* Otherwise, this is not a supported valid wksp checkpt header */
+
+  return FD_WKSP_ERR_CORRUPT;
+}
+
+int
+fd_wksp_checkpt_tpool( fd_tpool_t * tpool,
+                       ulong        t0,
+                       ulong        t1,
+                       fd_wksp_t *  wksp,
+                       char const * path,
+                       ulong        mode,
+                       int          style,
+                       char const * uinfo ) { /* TODO: CONSIDER ALLOWING SUBSET OF TAGS */
+
+  /* Check input args */
 
   if( FD_UNLIKELY( !wksp ) ) {
     FD_LOG_WARNING(( "NULL wksp" ));
@@ -27,228 +153,37 @@ fd_wksp_checkpt( fd_wksp_t *  wksp,
     return FD_WKSP_ERR_INVAL;
   }
 
-  style = fd_int_if( !!style, style, FD_WKSP_CHECKPT_STYLE_DEFAULT );
+  style = fd_int_if( !!style, style, FD_HAS_LZ4 ? FD_WKSP_CHECKPT_STYLE_V3 : FD_WKSP_CHECKPT_STYLE_V2 );
 
   if( FD_UNLIKELY( !uinfo ) ) uinfo = "";
 
+  char const * binfo = fd_log_build_info;
+  if( FD_UNLIKELY( !binfo ) ) binfo = "";
+
+  /* Checkpt with the appropriate style */
+
   switch( style ) {
-
-  case FD_WKSP_CHECKPT_STYLE_RAW: {
-
-  //FD_LOG_INFO(( "Checkpt wksp \"%s\" to \"%s\" (mode 0%03lo), style %i, uinfo \"%s\"", wksp->name, path, mode, style, uinfo ));
-
-    mode_t old_mask = umask( (mode_t)0 );
-    int fd = open( path, O_CREAT|O_EXCL|O_WRONLY, (mode_t)mode );
-    umask( old_mask );
-    if( FD_UNLIKELY( fd==-1 ) ) {
-      FD_LOG_WARNING(( "open(\"%s\",O_CREAT|O_EXCL|O_WRONLY,0%03lo) failed (%i-%s)", path, mode, errno, fd_io_strerror( errno ) ));
-      return FD_WKSP_ERR_FAIL;
-    }
-
-#   define WBUF_ALIGN     ( 4096UL)
-#   define WBUF_FOOTPRINT (65536UL)
-
-    uchar                    wbuf[ WBUF_FOOTPRINT ] __attribute__((aligned(WBUF_ALIGN)));
-    fd_io_buffered_ostream_t checkpt[ 1 ];
-    fd_io_buffered_ostream_init( checkpt, fd, wbuf, WBUF_FOOTPRINT );
-
-    int     err;
-    uchar * prep;
-
-    err = fd_wksp_private_lock( wksp ); if( FD_UNLIKELY( err ) ) goto fini; /* logs details */
-
-    /* Do basic wksp checks (TODO: CONSIDER RUNNING VERIFY ON WKSP
-       HERE AND ELIMINATING THIS CHECK AND THE CHECKS BELOW) */
-
-    ulong data_lo = wksp->gaddr_lo;
-    ulong data_hi = wksp->gaddr_hi;
-    if( FD_UNLIKELY( !((0UL<data_lo) & (data_lo<=data_hi)) ) ) goto corrupt_wksp;
-
-  //FD_LOG_INFO(( "Checkpt header and metadata" ));
-
-    prep = fd_wksp_private_checkpt_prepare( checkpt, WBUF_FOOTPRINT, &err ); if( FD_UNLIKELY( !prep ) ) goto io_err;
-    prep = fd_wksp_private_checkpt_ulong( prep, wksp->magic                                                          );
-    prep = fd_wksp_private_checkpt_ulong( prep, (ulong)(uint)style                                                   );
-    prep = fd_wksp_private_checkpt_ulong( prep, (ulong)wksp->seed                                                    );
-    prep = fd_wksp_private_checkpt_ulong( prep, wksp->part_max                                                       );
-    prep = fd_wksp_private_checkpt_ulong( prep, wksp->data_max                                                       );
-    prep = fd_wksp_private_checkpt_ulong( prep, (ulong)fd_log_wallclock()                                            );
-    prep = fd_wksp_private_checkpt_ulong( prep, fd_log_app_id()                                                      );
-    prep = fd_wksp_private_checkpt_ulong( prep, fd_log_thread_id()                                                   );
-    prep = fd_wksp_private_checkpt_ulong( prep, fd_log_host_id()                                                     );
-    prep = fd_wksp_private_checkpt_ulong( prep, fd_log_cpu_id()                                                      );
-    prep = fd_wksp_private_checkpt_ulong( prep, fd_log_group_id()                                                    );
-    prep = fd_wksp_private_checkpt_ulong( prep, fd_log_tid()                                                         );
-    prep = fd_wksp_private_checkpt_ulong( prep, fd_log_user_id()                                                     );
-    prep = fd_wksp_private_checkpt_buf  ( prep, wksp->name,        strlen( wksp->name      )                         );
-    prep = fd_wksp_private_checkpt_buf  ( prep, fd_log_app(),      strlen( fd_log_app()    )                         );
-    prep = fd_wksp_private_checkpt_buf  ( prep, fd_log_thread(),   strlen( fd_log_thread() )                         );
-    prep = fd_wksp_private_checkpt_buf  ( prep, fd_log_host(),     strlen( fd_log_host()   )                         );
-    prep = fd_wksp_private_checkpt_buf  ( prep, fd_log_cpu(),      strlen( fd_log_cpu()    )                         );
-    prep = fd_wksp_private_checkpt_buf  ( prep, fd_log_group(),    strlen( fd_log_group()  )                         );
-    prep = fd_wksp_private_checkpt_buf  ( prep, fd_log_user(),     strlen( fd_log_user()   )                         );
-    prep = fd_wksp_private_checkpt_buf  ( prep, fd_log_build_info, fd_ulong_min( fd_log_build_info_sz-1UL, 16383UL ) );
-    prep = fd_wksp_private_checkpt_buf  ( prep, uinfo,             fd_cstr_nlen( uinfo, 16383UL )                    );
-    fd_wksp_private_checkpt_publish( checkpt, prep );
-
-  //FD_LOG_INFO(( "Checkpt allocations" ));
-
-    ulong part_max = wksp->part_max;
-    fd_wksp_private_pinfo_t * pinfo = fd_wksp_private_pinfo( wksp );
-
-    ulong cycle_tag = wksp->cycle_tag++;
-
-    ulong gaddr_last = data_lo;
-
-    ulong i = fd_wksp_private_pinfo_idx( wksp->part_head_cidx );
-    while( !fd_wksp_private_pinfo_idx_is_null( i ) ) {
-      if( FD_UNLIKELY( i>=part_max ) || FD_UNLIKELY( pinfo[ i ].cycle_tag==cycle_tag ) ) goto corrupt_wksp;
-      pinfo[ i ].cycle_tag = cycle_tag; /* mark i as visited */
-
-      /* Do basic partition checks */
-
-      ulong gaddr_lo = pinfo[ i ].gaddr_lo;
-      ulong gaddr_hi = pinfo[ i ].gaddr_hi;
-      ulong tag      = pinfo[ i ].tag;
-
-      if( FD_UNLIKELY( !((gaddr_last==gaddr_lo) & (gaddr_lo<gaddr_hi) & (gaddr_hi<=data_hi)) ) ) goto corrupt_wksp;
-
-      gaddr_last = gaddr_hi;
-
-      /* If an allocated partition, checkpt it */
-
-      if( tag ) { /* ~50/50 */
-
-        ulong sz = gaddr_hi - gaddr_lo;
-        void * laddr_lo = fd_wksp_laddr_fast( wksp, gaddr_lo );
-
-        /* Checkpt partition header */
-
-        prep = fd_wksp_private_checkpt_prepare( checkpt, 3UL*9UL, &err ); if( FD_UNLIKELY( !prep ) ) goto io_err;
-        prep = fd_wksp_private_checkpt_ulong( prep, tag      );
-        prep = fd_wksp_private_checkpt_ulong( prep, gaddr_lo );
-        prep = fd_wksp_private_checkpt_ulong( prep, sz       );
-        fd_wksp_private_checkpt_publish( checkpt, prep );
-
-        /* Checkpt partition data */
-
-        err = fd_wksp_private_checkpt_write( checkpt, laddr_lo, sz ); if( FD_UNLIKELY( err ) ) goto io_err;
-      }
-
-      /* Advance to next partition */
-
-      i = fd_wksp_private_pinfo_idx( pinfo[ i ].next_cidx );
-    }
-
-  //FD_LOG_INFO(( "Checkpt footer" ));
-
-    prep = fd_wksp_private_checkpt_prepare( checkpt, 1UL*9UL, &err ); if( FD_UNLIKELY( !prep ) ) goto io_err;
-    prep = fd_wksp_private_checkpt_ulong( prep, 0UL ); /* tags are never 0 above */
-    fd_wksp_private_checkpt_publish( checkpt, prep );
-
-    err = fd_io_buffered_ostream_flush( checkpt ); if( FD_UNLIKELY( err ) ) goto io_err;
-
-    fd_wksp_private_unlock( wksp );
-
-  //FD_LOG_INFO(( "Checkpt successful" ));
-
-    /* note: err == 0 at this point */
-
-  fini: /* note: wksp unlocked at this point */
-    fd_io_buffered_ostream_fini( checkpt );
-    if( FD_UNLIKELY( err ) && FD_UNLIKELY( unlink( path ) ) )
-      FD_LOG_WARNING(( "unlink(\"%s\") failed (%i-%s); attempting to continue", path, errno, fd_io_strerror( errno ) ));
-    if( FD_UNLIKELY( close( fd ) ) )
-      FD_LOG_WARNING(( "close(\"%s\") failed (%i-%s); attempting to continue", path, errno, fd_io_strerror( errno ) ));
-    return err;
-
-  io_err: /* Failed due to I/O error ... clean up and log (note: wksp locked at this point) */
-    fd_wksp_private_unlock( wksp );
-    FD_LOG_WARNING(( "Checkpt wksp \"%s\" to \"%s\" failed due to I/O error (%i-%s)",
-                     wksp->name, path, err, fd_io_strerror( err ) ));
-    err = FD_WKSP_ERR_FAIL;
-    goto fini;
-
-  corrupt_wksp: /* Failed due to wksp corruption ... clean up and log (note: wksp locked at this point) */
-    fd_wksp_private_unlock( wksp );
-    FD_LOG_WARNING(( "Checkpt wksp \"%s\" to \"%s\" failed due to wksp corruption", wksp->name, path ));
-    err = FD_WKSP_ERR_CORRUPT;
-    goto fini;
-
-#   undef WBUF_FOOTPRINT
-#   undef WBUF_ALIGN
-
-  } /* FD_WKSP_CHECKPT_STYLE_RAW */
-
-  default:
-    break;
+  case FD_WKSP_CHECKPT_STYLE_V1: return fd_wksp_private_checkpt_v1( tpool, t0, t1, wksp, path, mode, uinfo );
+  case FD_WKSP_CHECKPT_STYLE_V2: return fd_wksp_private_checkpt_v2( tpool, t0, t1, wksp, path, mode, uinfo,
+                                                                    FD_CHECKPT_FRAME_STYLE_RAW );
+  case FD_WKSP_CHECKPT_STYLE_V3: return fd_wksp_private_checkpt_v2( tpool, t0, t1, wksp, path, mode, uinfo,
+                                                                    FD_CHECKPT_FRAME_STYLE_LZ4 );
+  break;
   }
 
   FD_LOG_WARNING(( "unsupported style" ));
   return FD_WKSP_ERR_INVAL;
 }
 
-/*********************************************************************/
-
 int
-fd_wksp_private_restore_ulong( fd_io_buffered_istream_t * in,
-                               ulong *                    _val ) {
-  ulong         csz;
-  uchar const * buf;
-  uchar         _buf[9UL];
+fd_wksp_restore_tpool( fd_tpool_t * tpool,
+                       ulong        t0,
+                       ulong        t1,
+                       fd_wksp_t *  wksp,
+                       char const * path,
+                       uint         new_seed ) {
 
-  /* Read the encoded val */
-
-  ulong peek_sz = fd_io_buffered_istream_peek_sz( in );
-
-  if( FD_LIKELY( peek_sz>=9UL ) ) { /* encoded val already prefetched */
-    buf = fd_io_buffered_istream_peek( in );
-    csz = fd_ulong_svw_dec_sz( buf );
-    fd_io_buffered_istream_seek( in, csz );
-  } else { /* encoded val not guaranteed prefetched (this will also implicitly prefetch for future restores) */
-    int err;
-    err = fd_io_buffered_istream_read( in, _buf,     1UL     ); if( FD_UNLIKELY( err ) ) { *_val = 0UL; return err; }
-    csz = fd_ulong_svw_dec_sz( _buf );
-    err = fd_io_buffered_istream_read( in, _buf+1UL, csz-1UL ); if( FD_UNLIKELY( err ) ) { *_val = 0UL; return err; }
-    buf = _buf;
-  }
-
-  /* Decode encoded val */
-
-  *_val = fd_ulong_svw_dec_fixed( buf, csz );
-  return 0;
-}
-
-int
-fd_wksp_private_restore_buf( fd_io_buffered_istream_t * in,
-                             void *                     buf,
-                             ulong                      buf_max,
-                             ulong *                    _buf_sz ) {
-
-  /* Restore buf_sz */
-
-  ulong buf_sz;
-  int   err = fd_wksp_private_restore_ulong( in, &buf_sz );
-  if( FD_UNLIKELY( (!!err) | (buf_sz>buf_max) ) ) { /* I/O error, unexpected EOF, or buf_max too small */
-    if( !!err ) err = EPROTO; /* cmov */
-    *_buf_sz = 0UL;
-    return err;
-  }
-
-  /* Restore buf */
-
-  err = fd_io_buffered_istream_read( in, buf, buf_sz );
-  *_buf_sz = fd_ulong_if( !err, buf_sz, 0UL );
-  return err;
-}
-
-/* TODO: CONSIDER ALLOWING RANGE OF TAGS?  CONSIDER OPS LIKE KEEPING
-   EXISTING PARTITIONS / REPLACE CONFLICTING / ETC? */
-
-int
-fd_wksp_restore( fd_wksp_t *  wksp,
-                 char const * path,
-                 uint         new_seed ) {
+  /* Check input args */
 
   if( FD_UNLIKELY( !wksp ) ) {
     FD_LOG_WARNING(( "NULL wksp" ));
@@ -260,296 +195,66 @@ fd_wksp_restore( fd_wksp_t *  wksp,
     return FD_WKSP_ERR_INVAL;
   }
 
-  FD_LOG_INFO(( "Restore checkpt \"%s\" into wksp \"%s\" (seed %u)", path, wksp->name, new_seed ));
+  /* new_seed arbitrary */
 
-  int fd = open( path, O_RDONLY, (mode_t)0 );
-  if( FD_UNLIKELY( fd==-1 ) ) {
-    FD_LOG_WARNING(( "open(\"%s\",O_RDONLY,0) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
-    return FD_WKSP_ERR_FAIL;
+  /* Determine which version to use */
+
+  fd_wksp_preview_t preview[1];
+  int err = fd_wksp_preview( path, preview );
+  if( FD_UNLIKELY( err ) ) {
+    FD_LOG_WARNING(( "\"%s\" does not appear to be a supported wksp checkpt", path ));
+    return err;
   }
 
-# define RBUF_ALIGN     (4096UL)
-# define RBUF_FOOTPRINT (65536UL)
+  /* Restore with the appropriate version */
 
-  uchar                    rbuf[ RBUF_FOOTPRINT ] __attribute__((aligned( RBUF_ALIGN )));
-  fd_io_buffered_istream_t restore[1];
-  fd_io_buffered_istream_init( restore, fd, rbuf, RBUF_FOOTPRINT );
-
-  int err;
-
-  err = fd_wksp_private_lock( wksp ); if( FD_UNLIKELY( err ) ) goto fini; /* logs details */
-
-  ulong                     wksp_part_max = wksp->part_max;
-  ulong                     wksp_data_max = wksp->data_max;
-  ulong                     wksp_data_lo  = wksp->gaddr_lo;
-  ulong                     wksp_data_hi  = wksp->gaddr_hi;
-  fd_wksp_private_pinfo_t * wksp_pinfo    = fd_wksp_private_pinfo( wksp );
-  int                       wksp_dirty    = 0;
-
-  char const * err_info;
-
-# define RESTORE_ULONG(v) do {                               \
-    err = fd_wksp_private_restore_ulong( restore, &v );      \
-    if( FD_UNLIKELY( err ) ) { err_info = #v; goto io_err; } \
-  } while(0)
-
-# define RESTORE_CSTR(v,max) do {                                         \
-    err = fd_wksp_private_restore_buf( restore, v, (max)-1UL, &v##_len ); \
-    if( FD_UNLIKELY( err ) ) { err_info = #v; goto io_err; }              \
-    v[v##_len] = '\0';                                                    \
-  } while(0)
-
-# define TEST(c) do { if( FD_UNLIKELY( !(c) ) ) { err_info = #c; goto stream_err; } } while(0)
-
-  FD_LOG_INFO(( "Restore header" ));
-
-  ulong magic;    RESTORE_ULONG( magic    );                                  TEST( magic   ==FD_WKSP_MAGIC      );
-  ulong style_ul; RESTORE_ULONG( style_ul ); int style = (int)(uint)style_ul; TEST( style_ul==(ulong)(uint)style );
-
-  FD_LOG_INFO(( "checkpt_magic  %016lx", magic ));
-  FD_LOG_INFO(( "checkpt_style  %i",     style ));
-
-  switch( style ) {
-
-  case FD_WKSP_CHECKPT_STYLE_RAW: {
-
-    FD_LOG_INFO(( "Restore metadata" ));
-
-    ulong seed_ul;   RESTORE_ULONG( seed_ul   ); uint seed = (uint)seed_ul; TEST( seed_ul==(ulong)seed                    );
-    ulong part_max;  RESTORE_ULONG( part_max  );
-    ulong data_max;  RESTORE_ULONG( data_max  );                            TEST( fd_wksp_footprint( part_max, data_max ) );
-
-    ulong ts_ul;     RESTORE_ULONG( ts_ul     ); long ts = (long)ts_ul;     TEST( ts_ul==(ulong)ts                        );
-    ulong app_id;    RESTORE_ULONG( app_id    );
-    ulong thread_id; RESTORE_ULONG( thread_id );
-    ulong host_id;   RESTORE_ULONG( host_id   );
-    ulong cpu_id;    RESTORE_ULONG( cpu_id    );
-    ulong group_id;  RESTORE_ULONG( group_id  );                            TEST( group_id>=2UL                           );
-    ulong tid;       RESTORE_ULONG( tid       );
-    ulong user_id;   RESTORE_ULONG( user_id   );
-
-    char name[ FD_SHMEM_NAME_MAX ]; ulong name_len; RESTORE_CSTR( name, FD_SHMEM_NAME_MAX );
-    TEST( fd_shmem_name_len( name )==name_len );
-
-    char app   [ FD_LOG_NAME_MAX ]; ulong app_len;    RESTORE_CSTR( app,    FD_LOG_NAME_MAX ); TEST( strlen( app    )==app_len    );
-    char thread[ FD_LOG_NAME_MAX ]; ulong thread_len; RESTORE_CSTR( thread, FD_LOG_NAME_MAX ); TEST( strlen( thread )==thread_len );
-    char host  [ FD_LOG_NAME_MAX ]; ulong host_len;   RESTORE_CSTR( host,   FD_LOG_NAME_MAX ); TEST( strlen( host   )==host_len   );
-    char cpu   [ FD_LOG_NAME_MAX ]; ulong cpu_len;    RESTORE_CSTR( cpu,    FD_LOG_NAME_MAX ); TEST( strlen( cpu    )==cpu_len    );
-    char group [ FD_LOG_NAME_MAX ]; ulong group_len;  RESTORE_CSTR( group,  FD_LOG_NAME_MAX ); TEST( strlen( group  )==group_len  );
-    char user  [ FD_LOG_NAME_MAX ]; ulong user_len;   RESTORE_CSTR( user,   FD_LOG_NAME_MAX ); TEST( strlen( user   )==user_len   );
-
-    char ts_cstr[ FD_LOG_WALLCLOCK_CSTR_BUF_SZ ]; fd_log_wallclock_cstr( ts, ts_cstr );
-
-    FD_LOG_INFO(( "checkpt_ts     %-20li \"%s\"", ts,        ts_cstr ));
-    FD_LOG_INFO(( "checkpt_app    %-20lu \"%s\"", app_id,    app     ));
-    FD_LOG_INFO(( "checkpt_thread %-20lu \"%s\"", thread_id, thread  ));
-    FD_LOG_INFO(( "checkpt_host   %-20lu \"%s\"", host_id,   host    ));
-    FD_LOG_INFO(( "checkpt_cpu    %-20lu \"%s\"", cpu_id,    cpu     ));
-    FD_LOG_INFO(( "checkpt_group  %-20lu \"%s\"", group_id,  group   ));
-    FD_LOG_INFO(( "checkpt_tid    %-20lu",        tid                ));
-    FD_LOG_INFO(( "checkpt_user   %-20lu \"%s\"", user_id,   user    ));
-
-    char buf[ 16384 ]; ulong buf_len;
-
-    RESTORE_CSTR( buf, 16384UL ); TEST( strlen( buf )==buf_len );
-    FD_LOG_INFO(( "checkpt_build\n\t%s", buf ) );
-
-    RESTORE_CSTR( buf, 16384UL ); TEST( strlen( buf )==buf_len );
-    FD_LOG_INFO(( "checkpt_info\n\t%s", buf ));
-
-    FD_LOG_INFO(( "shmem_name     \"%s\"", name     ));
-    FD_LOG_INFO(( "seed           %-20u",  seed     ));
-    FD_LOG_INFO(( "part_max       %-20lu", part_max ));
-    FD_LOG_INFO(( "data_max       %-20lu", data_max ));
-
-    ulong data_lo = fd_wksp_private_data_off( part_max );
-    ulong data_hi = data_lo + data_max;
-
-    FD_LOG_INFO(( "Restore allocations" ));
-
-    ulong wksp_part_cnt = 0UL;
-
-    for(;;) {
-
-      /* Restore the allocation header */
-
-      ulong tag;      RESTORE_ULONG( tag      ); if( FD_UNLIKELY( !tag ) ) break; /* Optimize for lots of partitions */
-      ulong gaddr_lo; RESTORE_ULONG( gaddr_lo );
-      ulong sz;       RESTORE_ULONG( sz       );
-
-      ulong gaddr_hi = gaddr_lo + sz;
-
-      TEST( (data_lo<=gaddr_lo) & (gaddr_lo<gaddr_hi) & (gaddr_hi<=data_hi) );
-
-      if( FD_UNLIKELY( wksp_part_cnt>=wksp_part_max ) ) {
-        FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed because too few wksp partitions (part_max checkpt %lu, wksp %lu)",
-                         path, wksp->name, part_max, wksp_part_max ));
-        goto unlock;
-      }
-
-      if( FD_UNLIKELY( !((wksp_data_lo<=gaddr_lo) & (gaddr_hi<=wksp_data_hi)) ) ) {
-        FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed because checkpt partition [0x%016lx,0x%016lx) tag %lu "
-                         "does not fit into wksp data region [0x%016lx,0x%016lx) (data_max checkpt %lu, wksp %lu)",
-                         path, wksp->name, gaddr_lo, gaddr_hi, tag, wksp_data_lo, wksp_data_hi, data_max, wksp_data_max ));
-        goto unlock;
-      }
-
-      /* Restore the allocation payload into the wksp and record this
-         allocation in the wksp */
-
-      wksp_dirty = 1;
-
-      #if FD_HAS_DEEPASAN
-      /* Poison the restored allocations. Potentially under poison to respect
-         manual poisoning alignment requirements. Don't poison if the allocation
-         is smaller than FD_ASAN_ALIGN. */
-      ulong laddr_lo = (ulong)fd_wksp_laddr_fast( wksp, gaddr_lo );
-      ulong laddr_hi = laddr_lo + sz;
-      ulong aligned_laddr_lo = fd_ulong_align_up( laddr_lo, FD_ASAN_ALIGN );
-      ulong aligned_laddr_hi = fd_ulong_align_dn( laddr_hi, FD_ASAN_ALIGN );
-      if( aligned_laddr_lo < aligned_laddr_hi ) {
-        fd_asan_poison( (void*)aligned_laddr_lo, aligned_laddr_hi - aligned_laddr_lo );
-      }
-      #endif
-
-      err = fd_io_buffered_istream_read( restore, fd_wksp_laddr_fast( wksp, gaddr_lo ), sz );
-      if( FD_UNLIKELY( err ) ) {
-        FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed because of I/O error (%i-%s)",
-                         path, wksp->name, err, fd_io_strerror( err ) ));
-        goto unlock;
-      }
-
-      wksp_pinfo[ wksp_part_cnt ].gaddr_lo = gaddr_lo;
-      wksp_pinfo[ wksp_part_cnt ].gaddr_hi = gaddr_hi;
-      wksp_pinfo[ wksp_part_cnt ].tag      = tag;
-      wksp_part_cnt++;
-    }
-
-    FD_LOG_INFO(( "Rebuilding wksp with restored allocations" ));
-
-    wksp_dirty = 1;
-
-    for( ulong i=wksp_part_cnt; i<wksp_part_max; i++ ) wksp_pinfo[ i ].tag = 0UL; /* Remove all remaining old allocations */
-    err = fd_wksp_rebuild( wksp, new_seed ); /* logs details */
-    if( FD_UNLIKELY( err ) ) { /* wksp dirty */
-      FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed because of rebuild error", path, wksp->name ));
-      goto unlock;
-    }
-
-    wksp_dirty = 0;
-
-    FD_LOG_INFO(( "Restore successful" ));
-    break;
-
-  } /* FD_WKSP_CHECKPT_STYLE_RAW */
-
-  default:
-    err_info = "unsupported style";
-    goto stream_err;
+  switch( preview->style ) {
+  case FD_WKSP_CHECKPT_STYLE_V1: return fd_wksp_private_restore_v1( tpool, t0, t1, wksp, path, new_seed );
+  case FD_WKSP_CHECKPT_STYLE_V2: return fd_wksp_private_restore_v2( tpool, t0, t1, wksp, path, new_seed );
+  /* note: v3 is really v2 with compressed frames */
+  default: break; /* never get here (preview already checked) */
   }
 
-  /* err = 0 at this point */
-
-unlock: /* note: wksp locked at this point */
-
-  /* If wksp is not clean, reset it to get it back to a clean state
-     (TODO: consider FD_LOG_CRIT here if rebuild fails though it
-     shouldn't) */
-
-  if( wksp_dirty ) {
-    FD_LOG_WARNING(( "wksp \"%s\" dirty; attempting to reset it and continue", wksp->name ));
-    for( ulong i=0UL; i<wksp_part_max; i++ ) wksp_pinfo[ i ].tag = 0UL;
-    fd_wksp_rebuild( wksp, new_seed ); /* logs details */
-    err = FD_WKSP_ERR_CORRUPT;
-  }
-
-  fd_wksp_private_unlock( wksp );
-
-fini: /* Note: wksp unlocked at this point */
-
-  fd_io_buffered_istream_fini( restore );
-
-  if( FD_UNLIKELY( close( fd ) ) )
-    FD_LOG_WARNING(( "close(\"%s\") failed (%i-%s); attempting to continue", path, errno, fd_io_strerror( errno ) ));
-
-  return err;
-
-io_err: /* Note: wksp locked at this point */
-
-  FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed (%s) due to I/O error (%i-%s)",
-                   path, wksp->name, err_info, err, fd_io_strerror( err ) ));
-  err = FD_WKSP_ERR_FAIL;
-
-  goto unlock;
-
-stream_err: /* Note: wksp locked at this point */
-
-  FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed due to checkpt format error (%s)", path, wksp->name, err_info ));
-  err = FD_WKSP_ERR_FAIL;
-
-  goto unlock;
-
-# undef TEST
-# undef RESTORE_CSTR
-# undef RESTORE_ULONG
-# undef RBUF_FOOTPRINT
-# undef RBUF_ALIGN
+  FD_LOG_WARNING(( "unsupported style" ));
+  return FD_WKSP_ERR_CORRUPT;
 }
 
 int
-fd_wksp_restore_preview( char const * path,
-                         uint *       out_seed,
-                         ulong *      out_part_max,
-                         ulong *      out_data_max ) {
-  if( FD_UNLIKELY( !path ) ) {
-    FD_LOG_WARNING(( "NULL path" ));
-    return FD_WKSP_ERR_INVAL;
-  }
+fd_wksp_printf( int          fd,
+                char const * path,
+                int          verbose ) {
 
-  int fd = open( path, O_RDONLY, (mode_t)0 );
-  if( FD_UNLIKELY( fd==-1 ) ) {
-    FD_LOG_WARNING(( "open(\"%s\",O_RDONLY,0) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
-    return FD_WKSP_ERR_FAIL;
-  }
+  int ret = 0;
+# define TRAP(expr) do { int _err = (expr); if( FD_UNLIKELY( _err<0 ) ) { return _err; } ret += _err; } while(0)
 
-# define RBUF_ALIGN     (4096UL)
-# define RBUF_FOOTPRINT (65536UL)
+  if( verbose<0 ) return ret;
 
-  uchar                    rbuf[ RBUF_FOOTPRINT ] __attribute__((aligned( RBUF_ALIGN )));
-  fd_io_buffered_istream_t restore[1];
-  fd_io_buffered_istream_init( restore, fd, rbuf, RBUF_FOOTPRINT );
+  TRAP( dprintf( fd, "checkpt %s (verbose %i)\n", path, verbose ) );
 
-  int err = FD_WKSP_SUCCESS;
+  fd_wksp_preview_t preview[1];
+  int err = fd_wksp_preview( path, preview );
+  if( FD_UNLIKELY( err ) )
+    TRAP( dprintf( fd, "\tinvalid or unsupported (%i-%s)\n", err, fd_wksp_strerror( err ) ) );
+  else
+    TRAP( dprintf( fd, "\tstyle                  %-20i\n"
+                       "\tname                   %s\n"
+                       "\tseed                   %-20u\n"
+                       "\tpart_max               %-20lu\n"
+                       "\tdata_max               %-20lu\n",
+                       preview->style, preview->name, preview->seed, preview->part_max, preview->data_max ) );
 
-# define RESTORE_ULONG(v) do {                               \
-    err = fd_wksp_private_restore_ulong( restore, &v );      \
-    if( FD_UNLIKELY( err ) ) { goto io_err; } \
-  } while(0)
+  if( verbose<1 ) return ret;
 
-  ulong magic;    RESTORE_ULONG( magic    );
-  if( magic!=FD_WKSP_MAGIC ) { err = FD_WKSP_ERR_FAIL; goto io_err; }
-  ulong style_ul; RESTORE_ULONG( style_ul ); int style = (int)(uint)style_ul;
-
-  switch( style ) {
-  case FD_WKSP_CHECKPT_STYLE_RAW: {
-    ulong tseed_ul;   RESTORE_ULONG( tseed_ul  ); *out_seed = (uint)tseed_ul;
-    ulong tpart_max;  RESTORE_ULONG( tpart_max ); *out_part_max = tpart_max;
-    ulong tdata_max;  RESTORE_ULONG( tdata_max ); *out_data_max = tdata_max;
-    break;
-  } /* FD_WKSP_CHECKPT_STYLE_RAW */
-
-  default:
-    err = FD_WKSP_ERR_FAIL;
+  switch( preview->style ) {
+  case FD_WKSP_CHECKPT_STYLE_V1: TRAP( fd_wksp_private_printf_v1( fd, path, verbose ) ); break;
+  case FD_WKSP_CHECKPT_STYLE_V2: TRAP( fd_wksp_private_printf_v2( fd, path, verbose ) ); break;
+  /* note: v3 is really v2 with compressed frames */
+  default: /* never get here (preview already checked) */
+    TRAP( dprintf( fd, "unsupported style" ) );
     break;
   }
 
- io_err:
-  fd_io_buffered_istream_fini( restore );
+# undef TRAP
 
-  if( FD_UNLIKELY( close( fd ) ) )
-    FD_LOG_WARNING(( "close(\"%s\") failed (%i-%s); attempting to continue", path, errno, fd_io_strerror( errno ) ));
-
-  return err;
-
-#undef RESTORE_ULONG
+  return ret;
 }

--- a/src/util/wksp/fd_wksp_restore_v1.c
+++ b/src/util/wksp/fd_wksp_restore_v1.c
@@ -1,0 +1,488 @@
+#include "fd_wksp_private.h"
+
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+/* fd_wksp_private_restore_ulong restores a ulong from the stream in.
+   Returns 0 on success and, on return, *_val will contain the restored
+   val.  Returns non-zero on failure (will be an errno compat error
+   code) and, on failure, *_val will be zero.  This will implicitly read
+   ahead for future restores. */
+
+static int
+fd_wksp_private_restore_v1_ulong( fd_io_buffered_istream_t * in,
+                                  ulong *                    _val ) {
+  ulong         csz;
+  uchar const * buf;
+  uchar         _buf[9UL];
+
+  /* Read the encoded val */
+
+  ulong peek_sz = fd_io_buffered_istream_peek_sz( in );
+
+  if( FD_LIKELY( peek_sz>=9UL ) ) { /* encoded val already prefetched */
+    buf = fd_io_buffered_istream_peek( in );
+    csz = fd_ulong_svw_dec_sz( buf );
+    fd_io_buffered_istream_seek( in, csz );
+  } else { /* encoded val not guaranteed prefetched (this will also implicitly prefetch for future restores) */
+    int err;
+    err = fd_io_buffered_istream_read( in, _buf,     1UL     ); if( FD_UNLIKELY( err ) ) { *_val = 0UL; return err; }
+    csz = fd_ulong_svw_dec_sz( _buf );
+    err = fd_io_buffered_istream_read( in, _buf+1UL, csz-1UL ); if( FD_UNLIKELY( err ) ) { *_val = 0UL; return err; }
+    buf = _buf;
+  }
+
+  /* Decode encoded val */
+
+  *_val = fd_ulong_svw_dec_fixed( buf, csz );
+  return 0;
+}
+
+/* fd_wksp_private_restore_buf restores a variable length buffer buf of
+   maximum size buf_max from the stream in.  Returns 0 on success and,
+   on success, buf will contain the buffer and *_buf_sz will contain the
+   buffer's size (will be in [0,buf_max]).  Returns non-zero on failure
+   (will be an errno compat error code) and, on failure, buf will be
+   clobbered and *_buf_sz will be zero.  This will implicitly read ahead
+   for future restores.  Zero buf_max is fine (and NULL buf is fine if
+   buf_max is zero). */
+
+static int
+fd_wksp_private_restore_v1_buf( fd_io_buffered_istream_t * in,
+                                void *                     buf,
+                                ulong                      buf_max,
+                                ulong *                    _buf_sz ) {
+
+  /* Restore buf_sz */
+
+  ulong buf_sz;
+  int   err = fd_wksp_private_restore_v1_ulong( in, &buf_sz );
+  if( FD_UNLIKELY( (!!err) | (buf_sz>buf_max) ) ) { /* I/O error, unexpected EOF, or buf_max too small */
+    if( !!err ) err = EPROTO; /* cmov */
+    *_buf_sz = 0UL;
+    return err;
+  }
+
+  /* Restore buf */
+
+  err = fd_io_buffered_istream_read( in, buf, buf_sz );
+  *_buf_sz = fd_ulong_if( !err, buf_sz, 0UL );
+  return err;
+}
+
+#define RESTORE_ULONG(v) do {                                \
+    err = fd_wksp_private_restore_v1_ulong( restore, &v );   \
+    if( FD_UNLIKELY( err ) ) { err_info = #v; goto io_err; } \
+  } while(0)
+
+/* Note: on success, v_len==strlen( v ) and will be in [0,max).  Assumes
+   max is positive. */
+
+#define RESTORE_CSTR(v,max) do {                                              \
+    err = fd_wksp_private_restore_v1_buf( restore, v, (max)-1UL, &v##_len );  \
+    if( FD_UNLIKELY( err ) ) { err_info = #v; goto io_err; }                  \
+    v[v##_len] = '\0'; /* v##_len in [0,max) at this point */                 \
+    if( FD_UNLIKELY( strlen( v )!=v##_len ) ) { err_info = #v; goto io_err; } \
+  } while(0)
+
+#define RBUF_ALIGN     (4096UL)
+#define RBUF_FOOTPRINT (65536UL)
+
+int
+fd_wksp_private_restore_v1( fd_tpool_t * tpool,
+                            ulong        t0,
+                            ulong        t1,
+                            fd_wksp_t *  wksp,
+                            char const * path,
+                            uint         new_seed ) {
+  (void)tpool; (void)t0; (void)t1; /* Note: Thread parallel v1 checkpoint not supported */
+
+  FD_LOG_INFO(( "Restore checkpt \"%s\" into wksp \"%s\" (seed %u)", path, wksp->name, new_seed ));
+
+  int fd = open( path, O_RDONLY, (mode_t)0 );
+  if( FD_UNLIKELY( fd==-1 ) ) {
+    FD_LOG_WARNING(( "open(\"%s\",O_RDONLY,0) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
+    return FD_WKSP_ERR_FAIL;
+  }
+
+  uchar                    rbuf[ RBUF_FOOTPRINT ] __attribute__((aligned( RBUF_ALIGN )));
+  fd_io_buffered_istream_t restore[1];
+  fd_io_buffered_istream_init( restore, fd, rbuf, RBUF_FOOTPRINT );
+
+  int err;
+
+  err = fd_wksp_private_lock( wksp ); if( FD_UNLIKELY( err ) ) goto fini; /* logs details */
+
+  ulong                     wksp_part_max = wksp->part_max;
+  ulong                     wksp_data_max = wksp->data_max;
+  ulong                     wksp_data_lo  = wksp->gaddr_lo;
+  ulong                     wksp_data_hi  = wksp->gaddr_hi;
+  fd_wksp_private_pinfo_t * wksp_pinfo    = fd_wksp_private_pinfo( wksp );
+  int                       wksp_dirty    = 0;
+
+  char const * err_info;
+
+# define RESTORE_TEST(c) do { if( FD_UNLIKELY( !(c) ) ) { err_info = #c; goto stream_err; } } while(0)
+
+  ulong orig_part_max;
+  ulong orig_data_max;
+
+  {
+    FD_LOG_INFO(( "Restore header (v1)" ));
+
+    ulong magic;     RESTORE_ULONG( magic     );
+    ulong style_ul;  RESTORE_ULONG( style_ul  );
+    ulong seed_ul;   RESTORE_ULONG( seed_ul   );
+    ulong part_max;  RESTORE_ULONG( part_max  );
+    ulong data_max;  RESTORE_ULONG( data_max  );
+    ulong ts_ul;     RESTORE_ULONG( ts_ul     ); /* considered metadata */
+    ulong app_id;    RESTORE_ULONG( app_id    ); /* " */
+    ulong thread_id; RESTORE_ULONG( thread_id ); /* " */
+    ulong host_id;   RESTORE_ULONG( host_id   ); /* " */
+    ulong cpu_id;    RESTORE_ULONG( cpu_id    ); /* " */
+    ulong group_id;  RESTORE_ULONG( group_id  ); /* " */
+    ulong tid;       RESTORE_ULONG( tid       ); /* " */
+    ulong user_id;   RESTORE_ULONG( user_id   ); /* " */
+
+    char name[ FD_SHMEM_NAME_MAX ]; ulong name_len; RESTORE_CSTR( name, FD_SHMEM_NAME_MAX );
+
+    RESTORE_TEST( magic==FD_WKSP_MAGIC                                   );
+    RESTORE_TEST( style_ul==(ulong)FD_WKSP_CHECKPT_STYLE_V1              );
+    RESTORE_TEST( seed_ul==(ulong)(uint)seed_ul                          );
+    RESTORE_TEST( fd_wksp_footprint( part_max, data_max )>0UL            );
+    RESTORE_TEST( (name_len>0UL) & (fd_shmem_name_len( name )==name_len) );
+
+    FD_LOG_INFO(( "Restore metadata (v1)" ));
+
+    char ts_cstr[ FD_LOG_WALLCLOCK_CSTR_BUF_SZ ];
+    fd_log_wallclock_cstr( (long)ts_ul, ts_cstr );
+
+    char app   [ FD_LOG_NAME_MAX              ]; ulong app_len;    RESTORE_CSTR( app,    FD_LOG_NAME_MAX              );
+    char thread[ FD_LOG_NAME_MAX              ]; ulong thread_len; RESTORE_CSTR( thread, FD_LOG_NAME_MAX              );
+    char host  [ FD_LOG_NAME_MAX              ]; ulong host_len;   RESTORE_CSTR( host,   FD_LOG_NAME_MAX              );
+    char cpu   [ FD_LOG_NAME_MAX              ]; ulong cpu_len;    RESTORE_CSTR( cpu,    FD_LOG_NAME_MAX              );
+    char group [ FD_LOG_NAME_MAX              ]; ulong group_len;  RESTORE_CSTR( group,  FD_LOG_NAME_MAX              );
+    char user  [ FD_LOG_NAME_MAX              ]; ulong user_len;   RESTORE_CSTR( user,   FD_LOG_NAME_MAX              );
+    char binfo [ FD_WKSP_CHECKPT_V1_BINFO_MAX ]; ulong binfo_len;  RESTORE_CSTR( binfo,  FD_WKSP_CHECKPT_V1_BINFO_MAX );
+    char uinfo [ FD_WKSP_CHECKPT_V1_UINFO_MAX ]; ulong uinfo_len;  RESTORE_CSTR( uinfo,  FD_WKSP_CHECKPT_V1_UINFO_MAX );
+
+    /* Note: this mirrors v2 */
+
+    FD_LOG_INFO(( "\n"
+                  "\tstyle                  %-20i\n"       /* verbose 0 info */
+                  "\tname                   %s\n"
+                  "\tseed                   %-20u\n"
+                  "\tpart_max               %-20lu\n"
+                  "\tdata_max               %-20lu\n"
+                  "\tmagic                  %016lx\n"      /* verbose 1 info */
+                  "\twallclock              %-20li (%s)\n"
+                  "\tapp                    %-20lu (%s)\n"
+                  "\tthread                 %-20lu (%s)\n"
+                  "\thost                   %-20lu (%s)\n"
+                  "\tcpu                    %-20lu (%s)\n"
+                  "\tgroup                  %-20lu (%s)\n"
+                  "\ttid                    %-20lu\n"
+                  "\tuser                   %-20lu (%s)\n"
+                  "\tbinfo\n\t\t%s\n"                     /* verbose 2 info */
+                  "\tuinfo\n\t\t%s",
+                  (int)style_ul, name, (uint)seed_ul, part_max, data_max,
+                  magic, (long)ts_ul, ts_cstr,
+                  app_id,    app,
+                  thread_id, thread,
+                  host_id,   host,
+                  cpu_id,    cpu,
+                  group_id,  group,
+                  tid,
+                  user_id,   user,
+                  binfo,
+                  uinfo ));
+
+    orig_part_max = part_max;
+    orig_data_max = data_max;
+  }
+
+  FD_LOG_INFO(( "Restore allocations" ));
+
+  ulong orig_data_lo  = fd_wksp_private_data_off( orig_part_max );
+  ulong orig_data_hi  = orig_data_lo + orig_data_max;
+  ulong wksp_part_cnt = 0UL;
+
+  for(;;) {
+
+    /* Restore the allocation header */
+
+    ulong tag;      RESTORE_ULONG( tag      ); if( FD_UNLIKELY( !tag ) ) break; /* Optimize for lots of partitions */
+    ulong gaddr_lo; RESTORE_ULONG( gaddr_lo );
+    ulong sz;       RESTORE_ULONG( sz       );
+
+    ulong gaddr_hi = gaddr_lo + sz;
+
+    RESTORE_TEST( (orig_data_lo<=gaddr_lo) & (gaddr_lo<gaddr_hi) & (gaddr_hi<=orig_data_hi) );
+
+    if( FD_UNLIKELY( wksp_part_cnt>=wksp_part_max ) ) {
+      FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed because too few wksp partitions (part_max checkpt %lu, wksp %lu)",
+                       path, wksp->name, orig_part_max, wksp_part_max ));
+      goto unlock;
+    }
+
+    if( FD_UNLIKELY( !((wksp_data_lo<=gaddr_lo) & (gaddr_hi<=wksp_data_hi)) ) ) {
+      FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed because checkpt partition [0x%016lx,0x%016lx) tag %lu "
+                       "does not fit into wksp data region [0x%016lx,0x%016lx) (data_max checkpt %lu, wksp %lu)",
+                       path, wksp->name, gaddr_lo, gaddr_hi, tag, wksp_data_lo, wksp_data_hi, orig_data_max, wksp_data_max ));
+      goto unlock;
+    }
+
+    /* Restore the allocation payload into the wksp and record this
+       allocation in the wksp */
+
+    wksp_dirty = 1;
+
+    #if FD_HAS_DEEPASAN
+    /* Poison the restored allocations. Potentially under poison to respect
+       manual poisoning alignment requirements. Don't poison if the allocation
+       is smaller than FD_ASAN_ALIGN. */
+    ulong laddr_lo = (ulong)fd_wksp_laddr_fast( wksp, gaddr_lo );
+    ulong laddr_hi = laddr_lo + sz;
+    ulong aligned_laddr_lo = fd_ulong_align_up( laddr_lo, FD_ASAN_ALIGN );
+    ulong aligned_laddr_hi = fd_ulong_align_dn( laddr_hi, FD_ASAN_ALIGN );
+    if( aligned_laddr_lo < aligned_laddr_hi ) {
+      fd_asan_poison( (void*)aligned_laddr_lo, aligned_laddr_hi - aligned_laddr_lo );
+    }
+    #endif
+
+    err = fd_io_buffered_istream_read( restore, fd_wksp_laddr_fast( wksp, gaddr_lo ), sz );
+    if( FD_UNLIKELY( err ) ) {
+      FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed because of I/O error (%i-%s)",
+                       path, wksp->name, err, fd_io_strerror( err ) ));
+      goto unlock;
+    }
+
+    wksp_pinfo[ wksp_part_cnt ].gaddr_lo = gaddr_lo;
+    wksp_pinfo[ wksp_part_cnt ].gaddr_hi = gaddr_hi;
+    wksp_pinfo[ wksp_part_cnt ].tag      = tag;
+    wksp_part_cnt++;
+  }
+
+  FD_LOG_INFO(( "Rebuilding wksp with restored allocations" ));
+
+  wksp_dirty = 1;
+
+  for( ulong i=wksp_part_cnt; i<wksp_part_max; i++ ) wksp_pinfo[ i ].tag = 0UL; /* Remove all remaining old allocations */
+  err = fd_wksp_rebuild( wksp, new_seed ); /* logs details */
+  if( FD_UNLIKELY( err ) ) { /* wksp dirty */
+    FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed because of rebuild error", path, wksp->name ));
+    goto unlock;
+  }
+
+  wksp_dirty = 0;
+
+  FD_LOG_INFO(( "Restore successful" ));
+
+  /* err = 0 at this point */
+
+unlock: /* note: wksp locked at this point */
+
+  /* If wksp is not clean, reset it to get it back to a clean state */
+
+  if( wksp_dirty ) {
+    FD_LOG_WARNING(( "wksp \"%s\" dirty; attempting to reset it and continue", wksp->name ));
+    for( ulong i=0UL; i<wksp_part_max; i++ ) wksp_pinfo[ i ].tag = 0UL;
+    fd_wksp_rebuild( wksp, new_seed ); /* logs details */
+    err = FD_WKSP_ERR_CORRUPT;
+  }
+
+  fd_wksp_private_unlock( wksp );
+
+fini: /* Note: wksp unlocked at this point */
+
+  fd_io_buffered_istream_fini( restore );
+
+  if( FD_UNLIKELY( close( fd ) ) )
+    FD_LOG_WARNING(( "close(\"%s\") failed (%i-%s); attempting to continue", path, errno, fd_io_strerror( errno ) ));
+
+  return err;
+
+io_err: /* Note: wksp locked at this point */
+
+  FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed (%s) due to I/O error (%i-%s)",
+                   path, wksp->name, err_info, err, fd_io_strerror( err ) ));
+  err = FD_WKSP_ERR_FAIL;
+
+  goto unlock;
+
+stream_err: /* Note: wksp locked at this point */
+
+  FD_LOG_WARNING(( "Restore \"%s\" to wksp \"%s\" failed due to checkpt format error (%s)", path, wksp->name, err_info ));
+  err = FD_WKSP_ERR_FAIL;
+
+  goto unlock;
+
+# undef RESTORE_TEST
+}
+
+int
+fd_wksp_private_printf_v1( int          out,
+                           char const * path,
+                           int          verbose ) {
+
+# define TRAP(x)         do { err = (x); if( FD_UNLIKELY( err<0 ) ) { ret = err; goto done; } ret += err; } while(0)
+# define RESTORE_TEST(c) do { if( FD_UNLIKELY( !(c) ) ) { err_info = #c; goto stream_err; } } while(0)
+
+  int                        fd      = -1;
+  fd_io_buffered_istream_t * restore = NULL;
+  int                        ret     = 0;
+  int                        err;
+  char const *               err_info;
+  uchar                      rbuf[ RBUF_FOOTPRINT ] __attribute__((aligned( RBUF_ALIGN )));
+  fd_io_buffered_istream_t   _restore[1];
+
+  fd = open( path, O_RDONLY, (mode_t)0 );
+  if( FD_UNLIKELY( fd==-1 ) ) TRAP( dprintf( out, "\topen(O_RDONLY) failed (%i-%s)\n", errno, fd_io_strerror( errno ) ) );
+
+  restore = fd_io_buffered_istream_init( _restore, fd, rbuf, RBUF_FOOTPRINT );
+
+  /* Print the header and metadata (note: fd_wksp_private_printf
+     already printed the preview info and verbose is at least 1) */
+
+  ulong orig_part_max;
+  ulong orig_data_max;
+
+  {
+    ulong magic;     RESTORE_ULONG( magic     );
+    ulong style_ul;  RESTORE_ULONG( style_ul  );
+    ulong seed_ul;   RESTORE_ULONG( seed_ul   );
+    ulong part_max;  RESTORE_ULONG( part_max  );
+    ulong data_max;  RESTORE_ULONG( data_max  );
+    ulong ts_ul;     RESTORE_ULONG( ts_ul     ); /* considered metadata */
+    ulong app_id;    RESTORE_ULONG( app_id    ); /* " */
+    ulong thread_id; RESTORE_ULONG( thread_id ); /* " */
+    ulong host_id;   RESTORE_ULONG( host_id   ); /* " */
+    ulong cpu_id;    RESTORE_ULONG( cpu_id    ); /* " */
+    ulong group_id;  RESTORE_ULONG( group_id  ); /* " */
+    ulong tid;       RESTORE_ULONG( tid       ); /* " */
+    ulong user_id;   RESTORE_ULONG( user_id   ); /* " */
+
+    char name[ FD_SHMEM_NAME_MAX ]; ulong name_len; RESTORE_CSTR( name, FD_SHMEM_NAME_MAX );
+
+    RESTORE_TEST( magic==FD_WKSP_MAGIC                                   );
+    RESTORE_TEST( style_ul==(ulong)FD_WKSP_CHECKPT_STYLE_V1              );
+    RESTORE_TEST( seed_ul==(ulong)(uint)seed_ul                          );
+    RESTORE_TEST( fd_wksp_footprint( part_max, data_max )>0UL            );
+    RESTORE_TEST( (name_len>0UL) & (fd_shmem_name_len( name )==name_len) );
+
+    char app   [ FD_LOG_NAME_MAX              ]; ulong app_len;    RESTORE_CSTR( app,    FD_LOG_NAME_MAX              );
+    char thread[ FD_LOG_NAME_MAX              ]; ulong thread_len; RESTORE_CSTR( thread, FD_LOG_NAME_MAX              );
+    char host  [ FD_LOG_NAME_MAX              ]; ulong host_len;   RESTORE_CSTR( host,   FD_LOG_NAME_MAX              );
+    char cpu   [ FD_LOG_NAME_MAX              ]; ulong cpu_len;    RESTORE_CSTR( cpu,    FD_LOG_NAME_MAX              );
+    char group [ FD_LOG_NAME_MAX              ]; ulong group_len;  RESTORE_CSTR( group,  FD_LOG_NAME_MAX              );
+    char user  [ FD_LOG_NAME_MAX              ]; ulong user_len;   RESTORE_CSTR( user,   FD_LOG_NAME_MAX              );
+    char binfo [ FD_WKSP_CHECKPT_V1_BINFO_MAX ]; ulong binfo_len;  RESTORE_CSTR( binfo,  FD_WKSP_CHECKPT_V1_BINFO_MAX );
+    char uinfo [ FD_WKSP_CHECKPT_V1_UINFO_MAX ]; ulong uinfo_len;  RESTORE_CSTR( uinfo,  FD_WKSP_CHECKPT_V1_UINFO_MAX );
+
+    char ts_cstr[ FD_LOG_WALLCLOCK_CSTR_BUF_SZ ];
+    fd_log_wallclock_cstr( (long)ts_ul, ts_cstr );
+
+    /* Note: this mirrors v2 printf */
+
+    if( verbose>=1 )
+      TRAP( dprintf( out,
+                   //"\tstyle                  %-20i\n"        /* verbose 0 info (already printed) */
+                   //"\tname                   %s\n"
+                   //"\tseed                   %-20u\n"
+                   //"\tpart_max               %-20lu\n"
+                   //"\tdata_max               %-20lu\n"
+                     "\tmagic                  %016lx\n"       /* verbose 1 info */
+                     "\twallclock              %-20li (%s)\n"
+                     "\tapp                    %-20lu (%s)\n"
+                     "\tthread                 %-20lu (%s)\n"
+                     "\thost                   %-20lu (%s)\n"
+                     "\tcpu                    %-20lu (%s)\n"
+                     "\tgroup                  %-20lu (%s)\n"
+                     "\ttid                    %-20lu\n"
+                     "\tuser                   %-20lu (%s)\n",
+                     magic,
+                     (long)ts_ul, ts_cstr,
+                     app_id,      app,
+                     thread_id,   thread,
+                     host_id,     host,
+                     cpu_id,      cpu,
+                     group_id,    group,
+                     tid,
+                     user_id,     user ) );
+    if( verbose>=2 )
+      TRAP( dprintf( out, "\tbinfo\n\t\t%s\n"
+                          "\tuinfo\n\t\t%s\n", binfo, uinfo ) ); /* verbose 2 info */
+
+    orig_part_max = part_max;
+    orig_data_max = data_max;
+  }
+
+  if( verbose>=3 ) {
+
+    ulong orig_data_lo = fd_wksp_private_data_off( orig_part_max );
+    ulong orig_data_hi = orig_data_lo + orig_data_max;
+
+    ulong alloc_tot = 0UL;
+    ulong alloc_cnt = 0UL;
+    ulong alloc_big = 0UL;
+
+    if( verbose>=4 ) TRAP( dprintf( out, "\tgaddr          [0x%016lx,0x%016lx)\n", orig_data_lo, orig_data_hi ) );
+
+    for(;;) {
+
+      /* Print partition metadata */
+
+      ulong tag;      RESTORE_ULONG( tag      ); if( !tag ) break; /* no more partitions */
+      ulong gaddr_lo; RESTORE_ULONG( gaddr_lo );
+      ulong sz;       RESTORE_ULONG( sz       );
+
+      ulong gaddr_hi = gaddr_lo + sz;
+
+      RESTORE_TEST( (orig_data_lo<=gaddr_lo) & (gaddr_lo<gaddr_hi) & (gaddr_hi<=orig_data_hi) );
+
+      if( verbose>=4 ) TRAP( dprintf( out, "\tpartition      [0x%016lx,0x%016lx) sz %20lu tag %20lu\n", gaddr_lo, gaddr_hi, sz, tag ) );
+
+      alloc_cnt += 1UL;
+      alloc_tot += sz;
+      alloc_big  = fd_ulong_max( alloc_big, sz );
+
+      /* Skip partition data (TODO: add verbose 5 for pretty printing
+         the raw partition data too). */
+
+      int err = fd_io_buffered_istream_skip( restore, sz );
+      if( FD_UNLIKELY( err ) ) { err_info = "partition data"; goto io_err; }
+    }
+
+    TRAP( dprintf( out, "\t%20lu bytes used (%20lu blocks, largest %20lu bytes)\n"
+                        "\t%20lu bytes free (%20s blocks, largest %20s bytes)\n"
+                        "\t%20lu errors detected\n"
+                        , alloc_tot, alloc_cnt, alloc_big, orig_data_max-alloc_tot, "-", "-", 0UL /* no err if we got here */ ) );
+
+  }
+
+done:
+  if( FD_LIKELY( restore ) ) fd_io_buffered_istream_fini( restore );
+  if( FD_LIKELY( fd!=-1  ) ) close( fd ); /* TODO: Consider trapping (but we might be in a dprintf err) */
+  return ret;
+
+io_err:
+  if( err<0 ) TRAP( dprintf( out, "\tFAIL: io: %s (unexpected end of file)\n", err_info ) );
+  else        TRAP( dprintf( out, "\tFAIL: io: %s (%i-%s)\n", err_info, err, fd_io_strerror( err ) ) );
+  goto done;
+
+stream_err:
+  TRAP( dprintf( fd, "\tFAIL: stream: %s\n", err_info ) );
+  goto done;
+
+# undef RESTORE_TEST
+# undef TRAP
+}
+
+#undef RBUF_FOOTPRINT
+#undef RBUF_ALIGN
+
+#undef RESTORE_CSTR
+#undef RESTORE_ULONG

--- a/src/util/wksp/fd_wksp_restore_v2.c
+++ b/src/util/wksp/fd_wksp_restore_v2.c
@@ -1,0 +1,1148 @@
+#include "fd_wksp_private.h"
+
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+/* This is an implementation detail and not strictly part of the v2
+   specification. */
+
+#define FD_WKSP_RESTORE_V2_CGROUP_MAX (1024UL)
+
+/* Note: restore not in frame on entry, restore at off on exit.  Jumps
+   to fail on error (logs details). */
+
+#define RESTORE_SEEK(off) do {                                                          \
+    ulong _off = (off);                                                                 \
+    if( FD_UNLIKELY( fd_restore_seek( restore, _off ) ) ) goto fail; /* logs details */ \
+  } while(0)
+
+/* Note: restore not in frame and at start of frame on entry, restore in
+   frame on exit.  Jumps to fail on error (logs details). */
+
+#define RESTORE_OPEN(frame_style) do {                                                                                \
+    if( FD_UNLIKELY( fd_restore_open_advanced( restore, (frame_style), &frame_off ) ) ) goto fail; /* logs details */ \
+  } while(0)
+
+/* Note: restore in frame on entry, restore just after frame on exit.
+   Assumes frame fully processed.  Jumps to fail on error (logs
+   details).  */
+
+#define RESTORE_CLOSE() do {                                                                            \
+    if( FD_UNLIKELY( fd_restore_close_advanced( restore, &frame_off ) ) ) goto fail; /* logs details */ \
+  } while(0)
+
+/* Note: restore in frame at meta and sz must be at most
+   FD_RESTORE_META_MAX on entry, restore in frame at just past meta with
+   meta ready on exit.  Jumps to fail on error (logs details). */
+
+#define RESTORE_META( meta, sz ) do {                                        \
+    ulong _sz  = (sz);                                                       \
+    int   _err = fd_restore_meta( restore, (meta), _sz ); /* logs details */ \
+    if( FD_UNLIKELY( _err ) ) {                                              \
+      FD_LOG_WARNING(( "fd_restore_meta( %s, %lu ) failed (%i-%s)",          \
+                       #meta, _sz, _err, fd_checkpt_strerror( _err ) ));     \
+      goto fail;                                                             \
+    }                                                                        \
+  } while(0)
+
+/* Note: restore in frame at data on entry, restore in frame just past
+   data on exit, data potentially not ready until frame close and should
+   exist untouched until then (logs details). */
+
+#define RESTORE_DATA( data, sz ) do {                                        \
+    ulong _sz  = (sz);                                                       \
+    int   _err = fd_restore_data( restore, (data), _sz ); /* logs details */ \
+    if( FD_UNLIKELY( _err ) ) {                                              \
+      FD_LOG_WARNING(( "fd_restore_data( %s, %lu ) failed (%i-%s)",          \
+                       #data, _sz, _err, fd_checkpt_strerror( _err ) ));     \
+      goto fail;                                                             \
+    }                                                                        \
+  } while(0)
+
+/* Note: jumps to fail if c is not true (logs details) */
+
+#define RESTORE_TEST( c ) do {                          \
+    if( FD_UNLIKELY( !(c) ) ) {                         \
+      FD_LOG_WARNING(( "restore test %s failed", #c )); \
+      goto fail;                                        \
+    }                                                   \
+  } while(0)
+
+/* fd_wksp_restore_v2_hdr restores the header frame from a wksp checkpt.
+   Assumes restore is valid and at the frame start and hdr is valid.  On
+   success, returns SUCCESS, *hdr will be populated with a valid data
+   and restore will be just after the frame end.  On failure, returns
+   FAIL, *hdr is clobbered and the caller should not assume anything
+   about the restore state. */
+
+static int
+fd_wksp_restore_v2_hdr( fd_restore_t *             restore,
+                        fd_wksp_checkpt_v2_hdr_t * hdr ) {
+  ulong frame_off;
+
+  RESTORE_OPEN( FD_CHECKPT_FRAME_STYLE_RAW );
+  RESTORE_DATA( hdr, sizeof(fd_wksp_checkpt_v2_hdr_t) );
+  RESTORE_CLOSE();
+
+  ulong name_len = fd_shmem_name_len( hdr->name );
+  /* FIXME: CHECK TRAILING 0 OF NAME? */
+
+  RESTORE_TEST( hdr->magic==FD_WKSP_MAGIC                                          );
+  RESTORE_TEST( hdr->style==FD_WKSP_CHECKPT_STYLE_V2                               );
+  RESTORE_TEST( fd_checkpt_frame_style_is_supported( hdr->frame_style_compressed ) );
+  RESTORE_TEST( hdr->reserved==0U                                                  );
+  RESTORE_TEST( name_len>0UL                                                       );
+  /* ignore seed (arbitrary) */
+  RESTORE_TEST( fd_wksp_footprint( hdr->part_max, hdr->data_max )>0UL              );
+
+  return FD_WKSP_SUCCESS;
+
+fail:
+  return FD_WKSP_ERR_FAIL;
+}
+
+/* fd_wksp_restore_v2_info restores the info frame from a wksp checkpt.
+   Assumes restore is valid and at the frame start, hdr has info from
+   the corresponding header, info_buf has room for buf_max bytes and
+   info_cstr is valid.  On success, returns SUCCESS, *info will be
+   populated with a valid data, info_cstr will be populated with
+   pointers into info_buf to valid info cstr (indexed in the same order
+   as the info fields) and restore will be just after the frame end.  On
+   failure, returns FAIL, info, info_buf and info might be clobbered and
+   the restore state is unknown. */
+
+static int
+fd_wksp_restore_v2_info( fd_restore_t *                   restore,
+                         fd_wksp_checkpt_v2_hdr_t const * hdr,
+                         fd_wksp_checkpt_v2_info_t *      info,
+                         char *                           info_buf,
+                         ulong                            info_buf_max,
+                         char const *                     info_cstr[ 9 ] ) {
+  ulong frame_off;
+
+  RESTORE_OPEN( hdr->frame_style_compressed );
+  RESTORE_META( info, sizeof(fd_wksp_checkpt_v2_info_t) );
+  ulong info_buf_sz = info->sz_app
+                    + info->sz_thread
+                    + info->sz_host
+                    + info->sz_cpu
+                    + info->sz_group
+                    + info->sz_user
+                    + info->sz_path
+                    + info->sz_binfo
+                    + info->sz_uinfo;
+  RESTORE_TEST( info_buf_sz<=info_buf_max );
+  RESTORE_DATA( info_buf, info_buf_sz );
+  RESTORE_CLOSE();
+
+  char const * p = info_buf;
+
+# define NEXT( sz, max ) (__extension__({                   \
+    char const * _cstr = p;                                 \
+    ulong        _sz   = (sz);                              \
+    ulong        _max  = (max);                             \
+    RESTORE_TEST( (0UL<_sz) & (_sz<=_max) );                \
+    RESTORE_TEST( fd_cstr_nlen( _cstr, _max )==(_sz-1UL) ); \
+    p += _sz;                                               \
+    _cstr;                                                  \
+  }))
+
+  info_cstr[0] = NEXT( info->sz_app,    FD_LOG_NAME_MAX              );
+  info_cstr[1] = NEXT( info->sz_thread, FD_LOG_NAME_MAX              );
+  info_cstr[2] = NEXT( info->sz_host,   FD_LOG_NAME_MAX              );
+  info_cstr[3] = NEXT( info->sz_cpu,    FD_LOG_NAME_MAX              );
+  info_cstr[4] = NEXT( info->sz_group,  FD_LOG_NAME_MAX              );
+  info_cstr[5] = NEXT( info->sz_user,   FD_LOG_NAME_MAX              );
+  info_cstr[6] = NEXT( info->sz_path,   PATH_MAX                     );
+  info_cstr[7] = NEXT( info->sz_binfo,  FD_WKSP_CHECKPT_V2_BINFO_MAX );
+  info_cstr[8] = NEXT( info->sz_uinfo,  FD_WKSP_CHECKPT_V2_UINFO_MAX );
+
+# undef NEXT
+
+  return FD_WKSP_SUCCESS;
+
+fail:
+  return FD_WKSP_ERR_FAIL;
+}
+
+/* fd_wksp_restore_v2_ftr restores the footer frame from a wksp checkpt.
+   Assumes restore is valid and at the frame start, hdr has info from
+   the corresponding hdr and ftr is valid.  On success, returns SUCCESS,
+   *ftr will be populated with a valid data and restore will be just
+   after the frame end.  On failure, returns FAIL, *ftr is clobbered and
+   the caller should not assume anything about the restore state.
+
+   IMPORTANT SAFETY TIP!  This only validates the ftr and hdr are
+   compatible.  It is up to the caller to validate alloc_cnt,
+   cgroup_cnt, volume_cnt, and frame_off as those may not have been
+   known when hdr was written and ftr is restored. */
+
+static int
+fd_wksp_restore_v2_ftr( fd_restore_t *                   restore,
+                        fd_wksp_checkpt_v2_hdr_t const * hdr,
+                        fd_wksp_checkpt_v2_ftr_t *       ftr,
+                        ulong                            checkpt_sz ) {
+  ulong frame_off;
+
+  RESTORE_OPEN( FD_CHECKPT_FRAME_STYLE_RAW );
+  RESTORE_DATA( ftr, sizeof(fd_wksp_checkpt_v2_ftr_t) );
+  RESTORE_CLOSE();
+
+  RESTORE_TEST( frame_off      ==checkpt_sz );
+  RESTORE_TEST( ftr->checkpt_sz==checkpt_sz );
+
+  RESTORE_TEST( ftr->data_max                        ==hdr->data_max               );
+  RESTORE_TEST( ftr->part_max                        ==hdr->part_max               );
+  RESTORE_TEST( ftr->seed                            ==hdr->seed                   );
+  RESTORE_TEST( !memcmp( ftr->name, hdr->name, FD_SHMEM_NAME_MAX )                 );
+  RESTORE_TEST( ftr->reserved                        ==hdr->reserved               );
+  RESTORE_TEST( ftr->frame_style_compressed          ==hdr->frame_style_compressed );
+  RESTORE_TEST( ftr->style                           ==hdr->style                  );
+  RESTORE_TEST( ftr->unmagic                         ==~hdr->magic                 );
+
+  return FD_WKSP_SUCCESS;
+
+fail:
+  return FD_WKSP_ERR_FAIL;
+}
+
+/* fd_wksp_private_restore_v2_common does the common parts of a
+   streaming and a parallel wksp restore (restores the header and info
+   frames and pretty prints them to the log).  Assumes wksp and restore
+   are valid and restore is on the first header byte.  On success,
+   returns SUCCESS and the restore will have processed the header and
+   info frames and will be positioned just after the info frame.  On
+   failure, returns FAIL and restore and hdr will be in an indeterminant
+   state. */
+
+static int
+fd_wksp_private_restore_v2_common( fd_wksp_checkpt_v2_hdr_t * hdr,
+                                   fd_restore_t *             restore ) {
+
+  FD_LOG_INFO(( "Restoring header and info (v2 frames 0:1)" ));
+
+  RESTORE_TEST( !fd_wksp_restore_v2_hdr( restore, hdr ) );
+
+  fd_wksp_checkpt_v2_info_t info[1];
+  char                      info_buf[ 65536 ];
+  char const *              info_cstr[9];
+
+  RESTORE_TEST( !fd_wksp_restore_v2_info( restore, hdr, info, info_buf, 65536UL, info_cstr ) );
+
+  /* Note: this mirrors printf below */
+
+  char info_wallclock[ FD_LOG_WALLCLOCK_CSTR_BUF_SZ ];
+  fd_log_wallclock_cstr( info->wallclock, info_wallclock );
+
+  FD_LOG_INFO(( "\n"
+                "\tstyle                  %-20i\n"       /* verbose 0 info */
+                "\tname                   %s\n"
+                "\tseed                   %-20u\n"
+                "\tpart_max               %-20lu\n"
+                "\tdata_max               %-20lu\n"
+                "\tmagic                  %016lx\n"      /* verbose 1 info */
+                "\twallclock              %-20li (%s)\n"
+                "\tapp                    %-20lu (%s)\n"
+                "\tthread                 %-20lu (%s)\n"
+                "\thost                   %-20lu (%s)\n"
+                "\tcpu                    %-20lu (%s)\n"
+                "\tgroup                  %-20lu (%s)\n"
+                "\ttid                    %-20lu\n"
+                "\tuser                   %-20lu (%s)\n"
+                "\tframe_style_compressed %-20i\n"       /* (v2 specific) */
+                "\tmode                   %03lo",        /* (v2 specific) */
+                hdr->style, hdr->name, hdr->seed, hdr->part_max, hdr->data_max,
+                hdr->magic, info->wallclock, info_wallclock,
+                info->app_id,    info_cstr[0],
+                info->thread_id, info_cstr[1],
+                info->host_id,   info_cstr[2],
+                info->cpu_id,    info_cstr[3],
+                info->group_id,  info_cstr[4],
+                info->tid,
+                info->user_id,   info_cstr[5],
+                hdr->frame_style_compressed,
+                info->mode ));
+
+  /* The below info cstr are potentially long enough to be truncated by
+     the logger.  So we break them into separate log messages to log as
+     much detail as possible. */
+
+  FD_LOG_INFO(( "path\n\t\t%s",  info_cstr[6] )); /* verbose 2 info (v2 specific) */
+  FD_LOG_INFO(( "binfo\n\t\t%s", info_cstr[7] )); /* verbose 2 info */
+  FD_LOG_INFO(( "uinfo\n\t\t%s", info_cstr[8] )); /* verbose 2 info */
+
+  return FD_WKSP_SUCCESS;
+
+fail:
+  return FD_WKSP_ERR_FAIL;
+}
+
+/* fd_wksp_private_restore_v2_cgroup restores a cgroup's allocation into
+   wksp.  hdr contains the corresponding restore header info, frame_off
+   is where the cgroup frame to restore is located and partitions
+   [part_lo,part_hi) are the wksp partition indices to use for this
+   frame's allocations.  Assumes all inputs have already been validated.
+   Returns SUCCESS (0) on success and FAIL (negative) on failure.  On
+   return, in both cases, *_dirty will be 1/0 if wksp was/was not
+   modified.  On error, the restore state is indeterminant. */
+
+static int
+fd_wksp_private_restore_v2_cgroup( fd_wksp_t *                      wksp,
+                                   fd_restore_t *                   restore,
+                                   fd_wksp_checkpt_v2_hdr_t const * hdr,
+                                   ulong                            frame_off_lo,
+                                   ulong                            frame_off_hi,
+                                   ulong                            part_lo,
+                                   ulong                            part_hi,
+                                   int *                            _dirty ) {
+  int dirty = 0;
+
+  fd_wksp_private_pinfo_t * pinfo    = fd_wksp_private_pinfo( wksp );
+  ulong                     data_lo  = wksp->gaddr_lo;
+  ulong                     data_hi  = wksp->gaddr_hi;
+
+  ulong hdr_data_lo = fd_wksp_private_data_off( hdr->part_max );
+  ulong hdr_data_hi = hdr_data_lo + hdr->data_max;
+
+  ulong frame_off;
+  RESTORE_SEEK( frame_off_lo );
+  RESTORE_OPEN( hdr->frame_style_compressed );
+
+  /* For all cgroup allocation metadata */
+
+  fd_wksp_checkpt_v2_cmd_t cmd[1];
+
+  for( ulong part_idx=part_lo; part_idx<part_hi; part_idx++ ) {
+
+    RESTORE_META( cmd, sizeof(fd_wksp_checkpt_v2_cmd_t) );
+    RESTORE_TEST( fd_wksp_checkpt_v2_cmd_is_meta( cmd ) );
+
+    ulong tag      = cmd->meta.tag;      /* non-zero */
+    ulong gaddr_lo = cmd->meta.gaddr_lo;
+    ulong gaddr_hi = cmd->meta.gaddr_hi;
+
+    RESTORE_TEST( (hdr_data_lo<=gaddr_lo) & (gaddr_lo<gaddr_hi) & (gaddr_hi<=hdr_data_hi) );
+    /* Note: disjoint [gaddr_lo,gaddr_hi) tested on rebuild */
+
+    if( FD_UNLIKELY( !((data_lo<=gaddr_lo) & (gaddr_hi<=data_hi)) ) ) {
+      FD_LOG_WARNING(( "restore failed because checkpt partition [0x%016lx,0x%016lx) tag %lu does not fit into current "
+                       "wksp data region [0x%016lx,0x%016lx) (data_max checkpt %lu, wksp %lu)",
+                       gaddr_lo, gaddr_hi, tag, data_lo, data_hi, hdr->data_max, wksp->data_max ));
+      goto fail;
+    }
+
+    dirty = 1;
+    pinfo[ part_idx ].gaddr_lo = gaddr_lo;
+    pinfo[ part_idx ].gaddr_hi = gaddr_hi;
+    pinfo[ part_idx ].tag      = tag;
+  }
+
+  /* Restore the data command */
+
+  RESTORE_META( cmd, sizeof(fd_wksp_checkpt_v2_cmd_t) );
+  RESTORE_TEST( fd_wksp_checkpt_v2_cmd_is_data( cmd ) );
+
+  /* For all cgroup allocation data */
+
+  for( ulong part_idx=part_lo; part_idx<part_hi; part_idx++ ) {
+    ulong gaddr_lo = pinfo[ part_idx ].gaddr_lo;
+    ulong gaddr_hi = pinfo[ part_idx ].gaddr_hi;
+
+    /* Restore the allocation into the wksp data region */
+
+    dirty = 1;
+    RESTORE_DATA( fd_wksp_laddr_fast( wksp, gaddr_lo ), gaddr_hi - gaddr_lo );
+  }
+
+  /* Close the frame */
+
+  RESTORE_CLOSE();
+
+  RESTORE_TEST( (frame_off_lo<frame_off) & (frame_off<=frame_off_hi) ); /* == hi if compactly stored */
+
+  *_dirty = dirty;
+  return FD_WKSP_SUCCESS;
+
+fail:
+  *_dirty = dirty;
+  return FD_WKSP_ERR_FAIL;
+}
+
+/* fd_wksp_private_restore_v2_node dispatches cgroup restore work to
+   tpool threads [t0,t1).  If any errors were encountered while
+   restoring cgroups, returns the first error encountered on the lowest
+   indexed thread in the int location pointed to by _err.  If any
+   modifications were made to wksp (whether or not there were errors),
+   the int location pointed to by _dirty will be set to 1.  Assumes
+   caller is thread t0 and threads (t0,t1) are available.  Note that we
+   could do this with FD_MAP_REDUCE but FD_MAP_REDUCE assumes that
+   fd_scratch space is available and we can't guarantee that here.
+   Likewise, we could use tpool_exec_all with a TASKQ model but
+   reduction of results is less efficient. */
+
+static void
+fd_wksp_private_restore_v2_node( void * tpool,
+                                 ulong  tpool_t0,
+                                 ulong  tpool_t1,          /* Assumes t1>t0 */
+                                 void * _wksp,
+                                 void * _restore,
+                                 ulong  _hdr,
+                                 ulong  _cgroup_frame_off,
+                                 ulong  _cgroup_pinfo_lo,
+                                 ulong  _cgroup_nxt,
+                                 ulong  cgroup_cnt,
+                                 ulong  _err,
+                                 ulong  _dirty ) {
+
+  /* This node is responsible for threads [t0,t1).  If this range has
+     more than one thread, split the range into left and right halves,
+     have the first right half thread handle the right half, use this
+     thread to handle the left half and then reduce the results from
+     the two halves. */
+
+  ulong tpool_cnt = tpool_t1 - tpool_t0;
+  if( tpool_cnt>1UL ) {
+    ulong tpool_ts = tpool_t0 + fd_tpool_private_split( tpool_cnt );
+
+    int err0; int dirty0;
+    int err1; int dirty1;
+
+    fd_tpool_exec( tpool, tpool_ts, fd_wksp_private_restore_v2_node,
+                   tpool, tpool_ts, tpool_t1, _wksp, _restore, _hdr, _cgroup_frame_off, _cgroup_pinfo_lo, _cgroup_nxt, cgroup_cnt,
+                   (ulong)&err1, (ulong)&dirty1 );
+    fd_wksp_private_restore_v2_node(
+                   tpool, tpool_t0, tpool_ts, _wksp, _restore, _hdr, _cgroup_frame_off, _cgroup_pinfo_lo, _cgroup_nxt, cgroup_cnt,
+                   (ulong)&err0, (ulong)&dirty0 );
+    fd_tpool_wait( tpool, tpool_ts );
+
+    *(int *)_err   = fd_int_if( !!err0, err0, err1 ); /* Return first error encountered */
+    *(int *)_dirty = dirty0 | dirty1;                 /* Accumulate the dirty flag */
+    return;
+  }
+
+  /* This node is responsible for a single thread.  Unpack the input
+     arguments. */
+
+  fd_wksp_t *                      wksp             = (fd_wksp_t *)               _wksp;
+  fd_restore_t *                   restore          = (fd_restore_t *)            _restore; /* FIXME: CLONE RESTORE */
+  fd_wksp_checkpt_v2_hdr_t const * hdr              = (fd_wksp_checkpt_v2_hdr_t *)_hdr;
+  ulong const *                    cgroup_frame_off = (ulong *)                   _cgroup_frame_off;
+  ulong const *                    cgroup_pinfo_lo  = (ulong *)                   _cgroup_pinfo_lo;
+
+  int err   = FD_WKSP_SUCCESS;
+  int dirty = 0;
+
+  /* Since we can't have multiple threads operate concurrently on the
+     same restore object, make a new restore object safe for use by this
+     thread (technically could use restore directly on original thread
+     t0). */
+
+  fd_restore_t _restore_local[1];
+  fd_restore_t * restore_local =
+    fd_restore_init_mmio( _restore_local, fd_restore_mmio( restore ), fd_restore_mmio_sz( restore ) ); /* logs details */
+  if( FD_UNLIKELY( !restore_local ) ) {
+    err = FD_WKSP_ERR_FAIL;
+    goto done;
+  }
+
+  for(;;) {
+
+    /* Get the next cgroup to restore.  Use a dynamic task queue model
+       here because we assume that restore a single cgroups requires a
+       large amount of work and the amount of work is highly variable.
+       Note that using an atomic increment for the cgroup_nxt counter
+       assumes:
+
+         cgroup_cnt << ULONG_MAX - TILE_MAX.
+
+       We could use a slower atomic CAS based version instead if we want
+       to insure that cgroup_nxt is never incremented beyond cgroup_cnt.
+       We could also use a block partitioning or CUDA style striping if
+       wanting to do a deterministic distribution but these might not
+       load balance as well in various extreme circumstances. */
+
+#   if FD_HAS_ATOMIC
+    FD_COMPILER_MFENCE();
+    ulong cgroup_idx = FD_ATOMIC_FETCH_AND_ADD( (ulong *)_cgroup_nxt, 1UL );
+    FD_COMPILER_MFENCE();
+#   else /* Note: this assumes platforms without HAS_ATOMIC will not be running this multithreaded */
+    ulong cgroup_idx = (*(ulong *)_cgroup_nxt) + 1UL;
+#   endif
+
+    if( FD_UNLIKELY( cgroup_idx>=cgroup_cnt ) ) break; /* No more cgroups to process */
+
+    /* Restore this cgroup */
+
+    int dirty_cgroup;
+    err = fd_wksp_private_restore_v2_cgroup( wksp, restore_local, hdr,
+                                             cgroup_frame_off[ cgroup_idx ], cgroup_frame_off[ cgroup_idx+1UL ],
+                                             cgroup_pinfo_lo [ cgroup_idx ], cgroup_pinfo_lo [ cgroup_idx+1UL ],
+                                             &dirty_cgroup ); /* logs details */
+    dirty |= dirty_cgroup;
+    if( FD_UNLIKELY( err ) ) break; /* abort if we encountered an error */
+
+  }
+
+  fd_restore_fini( restore_local );
+
+done:
+  *(int *)_err   = err;
+  *(int *)_dirty = dirty;
+}
+
+/* fd_wksp_private_restore_v2_mmio replaces all the allocations in a
+   wksp with the allocations in the restore.  Assumes all inputs have
+   are valid, restore is positioned on the first byte of the header, has
+   the given size and is seekable.  Returns SUCCESS on success and the
+   restore will be positioned just after the footer.  Returns FAIL if an
+   error occurred before wksp was not modified and CORRUPT if an error
+   occurred after.  On failure, the restore state is indeterminant.
+   Uses tpool threads [t0,t1) to do the restore.  Assumes the caller is
+   thread t0 and threads (t0,t1) are available for dispatch. */
+
+static int
+fd_wksp_private_restore_v2_mmio( fd_tpool_t *   tpool,
+                                 ulong          t0,
+                                 ulong          t1,
+                                 fd_wksp_t *    wksp,
+                                 fd_restore_t * restore,
+                                 uint           new_seed ) {
+
+  ulong frame_off;
+
+  int locked = 0; /* is the wksp currently locked? */
+  int dirty  = 0; /* has the wksp been modified? */
+
+  /* Restore and validate the header, info, and footer.  In principle
+     this could be parallelized but probably not worth it. */
+
+  ulong restore_sz = fd_restore_sz( restore );
+
+  ulong frame_off_hdr  = 0UL;
+  ulong frame_off_info = frame_off_hdr + sizeof(fd_wksp_checkpt_v2_hdr_t);
+  ulong frame_off_ftr  = restore_sz    - sizeof(fd_wksp_checkpt_v2_ftr_t);
+
+  RESTORE_TEST( /*(0UL<=frame_off_hdr) &*/ (frame_off_hdr<frame_off_info) & (frame_off_info<frame_off_ftr) & (frame_off_ftr<restore_sz) );
+
+  fd_wksp_checkpt_v2_hdr_t hdr[1];
+
+//RESTORE_SEEK( frame_off_hdr );
+  RESTORE_TEST( !fd_wksp_private_restore_v2_common( hdr, restore ) );
+
+  FD_LOG_INFO(( "Restoring footer" ));
+
+  fd_wksp_checkpt_v2_ftr_t ftr[1];
+
+  RESTORE_SEEK( frame_off_ftr );
+  RESTORE_TEST( !fd_wksp_restore_v2_ftr( restore, hdr, ftr, restore_sz ) );
+
+  ulong frame_off_volumes = ftr->frame_off;
+
+  RESTORE_TEST( (frame_off_info<frame_off_volumes) & (frame_off_volumes<frame_off_ftr) );
+
+  if( FD_UNLIKELY( ftr->alloc_cnt>wksp->part_max ) ) {
+    FD_LOG_WARNING(( "restore failed because there are too few wksp partitions to restore allocations into "
+                     "(ftr alloc_cnt %lu, hdr part_max %lu, wksp part_max %lu)",
+                     ftr->alloc_cnt, hdr->part_max, wksp->part_max ));
+    goto fail;
+  }
+
+  FD_LOG_INFO(( "Restoring volumes" ));
+
+  fd_wksp_checkpt_v2_cmd_t cmd[1];
+
+  RESTORE_SEEK( frame_off_volumes );
+  RESTORE_OPEN( hdr->frame_style_compressed );
+  RESTORE_META( cmd, sizeof(fd_wksp_checkpt_v2_cmd_t) );
+  RESTORE_CLOSE();
+
+  RESTORE_TEST( (cmd->volumes.tag==0UL) & (cmd->volumes.cgroup_cnt==ULONG_MAX) ); /* frame_off_appendix tested below */
+  RESTORE_TEST( (frame_off_volumes<frame_off) & (frame_off<=frame_off_ftr) );     /* ==frame_off_ftr if compactly stored */
+
+  FD_LOG_INFO(( "Locking wksp" ));
+
+  if( FD_UNLIKELY( fd_wksp_private_lock( wksp ) ) ) goto fail; /* logs details */
+  locked = 1;
+
+  /* For all volumes */
+
+  ulong alloc_rem  = ftr->alloc_cnt;  /* Number of allocations remaining to process */
+  ulong cgroup_rem = ftr->cgroup_cnt; /* Number of cgroups     remaining to process */
+  ulong volume_rem = ftr->volume_cnt; /* Number of volumes     remaining to process */
+
+  ulong frame_off_volume_lo = frame_off_info;
+  ulong frame_off_volume_hi = frame_off_volumes;
+  ulong frame_off_appendix  = cmd->volumes.frame_off;
+
+  while( frame_off_appendix ) {
+
+    /* Verify we still have volumes remaining and the appendix location
+       is between the info frame and the next volume (or the footer if
+       the last volume) */
+
+    RESTORE_TEST( (volume_rem>0UL) & (frame_off_volume_lo<frame_off_appendix) & (frame_off_appendix<frame_off_volume_hi) );
+
+    /* Now that we know where this volume's appendix is supposed to be,
+       seek to it and then restore and validate it. */
+
+    FD_LOG_INFO(( "Restoring volume appendix" ));
+
+    RESTORE_SEEK( frame_off_appendix );
+
+    ulong cgroup_frame_off[ FD_WKSP_RESTORE_V2_CGROUP_MAX+1UL ];
+    ulong cgroup_pinfo_lo [ FD_WKSP_RESTORE_V2_CGROUP_MAX+1UL ];
+    ulong cgroup_cnt;
+
+    ulong frame_off_prev;
+
+    {
+      RESTORE_OPEN( hdr->frame_style_compressed );
+
+      fd_wksp_checkpt_v2_cmd_t cmd[1];
+
+      RESTORE_META( cmd, sizeof(fd_wksp_checkpt_v2_cmd_t) );
+      RESTORE_TEST( fd_wksp_checkpt_v2_cmd_is_appendix( cmd ) );
+
+      cgroup_cnt     = cmd->appendix.cgroup_cnt;
+      frame_off_prev = cmd->appendix.frame_off;
+
+      if( FD_UNLIKELY( cgroup_cnt>FD_WKSP_RESTORE_V2_CGROUP_MAX ) ) {
+        FD_LOG_WARNING(( "increase FD_WKSP_RESTORE_V2_CGROUP_MAX for this target" ));
+        goto fail;
+      }
+
+      RESTORE_DATA( cgroup_frame_off, cgroup_cnt*sizeof(ulong) );
+      RESTORE_DATA( cgroup_pinfo_lo,  cgroup_cnt*sizeof(ulong) ); /* cgroup_alloc_cnt now, pinfo cgroup partitioning later */
+      RESTORE_CLOSE();
+
+      /* Verify this cgroups frames are between the previous appendix frame
+         (or the info frame if the first volume) and this appendix frame
+         and ordered.  Also, verify the cgroup allocation counts,
+         convert the counts into a partitioning of wksp's pinfo array
+         and make sure we have enough partitions in the wksp to attempt
+         the restore.  In principle, this loop could be parallelized but
+         probably not worth it. */
+
+      cgroup_frame_off[ cgroup_cnt ] = frame_off_appendix;
+      cgroup_pinfo_lo [ cgroup_cnt ] = alloc_rem;
+
+      for( ulong cgroup_rem=cgroup_cnt; cgroup_rem; cgroup_rem-- ) {
+
+        ulong cgroup_idx = cgroup_rem - 1UL;
+        RESTORE_TEST( cgroup_frame_off[ cgroup_idx ] < cgroup_frame_off[ cgroup_idx+1UL ] );
+
+        ulong cgroup_alloc_cnt = cgroup_pinfo_lo[ cgroup_idx ];
+        RESTORE_TEST( cgroup_alloc_cnt<=alloc_rem );
+        alloc_rem -= cgroup_alloc_cnt;
+        cgroup_pinfo_lo[ cgroup_idx ] = alloc_rem;
+
+      }
+
+      RESTORE_TEST( fd_ulong_max( frame_off_prev, frame_off_info ) < cgroup_frame_off[0] );
+    }
+
+    /* At this point, we know how to do an embarassingly parallel
+       restore directly into the wksp.  Dispatch work to tpool threads
+       [t0,t1).  This assumes we are tpool thread t0 and threads (t0,t1)
+       are available for dispatch.  On return from the dispatch, err
+       will contain the error code from the lowest indexed cgroup_idx
+       that encountered an error (if any error was encountered, some
+       cgroups might not have been processed) and dirty_node will
+       contain non-zero if the wksp was modified. */
+
+    FD_LOG_INFO(( "Restoring volume cgroups" ));
+
+    ulong cgroup_nxt[1];
+
+    FD_COMPILER_MFENCE();
+    FD_VOLATILE( cgroup_nxt[0] ) = 0UL;
+    FD_COMPILER_MFENCE();
+
+    int err;
+    int dirty_node;
+    fd_wksp_private_restore_v2_node( (void *)tpool, t0, t1,
+                                     (void *)wksp, (void *)restore, (ulong)hdr, (ulong)cgroup_frame_off, (ulong)cgroup_pinfo_lo,
+                                     (ulong)cgroup_nxt, cgroup_cnt, (ulong)&err, (ulong)&dirty_node );
+    dirty |= dirty_node;
+    if( FD_UNLIKELY( err ) ) goto fail;
+
+    /* Advance to the next volume */
+
+    cgroup_rem -= cgroup_cnt;
+    volume_rem--;
+    /* frame_off_volume_lo unchanged */
+    frame_off_volume_hi = cgroup_frame_off[ 0 ];
+    frame_off_appendix  = frame_off_prev;
+  }
+
+  /* Make sure we got all volumes and all cgroups and position the
+     restore at the location it would have been at in a streaming
+     restore. */
+
+  RESTORE_TEST( alloc_rem ==0UL );
+  RESTORE_TEST( cgroup_rem==0UL );
+  RESTORE_TEST( volume_rem==0UL );
+
+  RESTORE_SEEK( restore_sz );
+
+  /* Free any remaining old allocations and rebuild the wksp with our
+     freshly restored allocations.  In principle the free loop can be
+     parallelized but it is probably not worth it. */
+
+  FD_LOG_INFO(( "Rebuilding wksp" ));
+
+  dirty = 1;
+
+  fd_wksp_private_pinfo_t * pinfo    = fd_wksp_private_pinfo( wksp );
+  ulong                     part_max = wksp->part_max;
+
+  for( ulong part_idx=ftr->alloc_cnt; part_idx<part_max; part_idx++ ) pinfo[ part_idx ].tag = 0UL;
+
+  if( FD_UNLIKELY( fd_wksp_rebuild( wksp, new_seed ) ) ) goto fail; /* logs details */
+
+  FD_LOG_INFO(( "Unlocking wksp" ));
+
+  fd_wksp_private_unlock( wksp );
+
+  return FD_WKSP_SUCCESS;
+
+fail: /* Release resources that might be reserved */
+
+  if( FD_LIKELY( locked ) ) fd_wksp_private_unlock( wksp );
+
+  return fd_int_if( dirty, FD_WKSP_ERR_CORRUPT, FD_WKSP_ERR_FAIL );
+}
+
+/* fd_wksp_private_restore_v2_stream is identical to
+   fd_wksp_private_restore_v2_mmio (above) but usable when restore is
+   not using memory mapped i/o under the hood.  This includes when the
+   restore is from a non-seekable file descriptor (e.g. when the restore
+   is from a pipe or socket but this will work fine if used on mmio
+   restores too).  Restore must be compactly stored.  Exact same
+   behaviors. */
+
+static int
+fd_wksp_private_restore_v2_stream( fd_wksp_t *    wksp,
+                                   fd_restore_t * restore,
+                                   uint           new_seed ) {
+  ulong frame_off;
+
+  int locked = 0; /* is the wksp currently locked */
+  int dirty  = 0; /* has the wksp been modified? */
+
+  fd_wksp_checkpt_v2_hdr_t hdr[1];
+
+  RESTORE_TEST( !fd_wksp_private_restore_v2_common( hdr, restore ) );
+
+  FD_LOG_INFO(( "Locking wksp" ));
+
+  if( FD_UNLIKELY( fd_wksp_private_lock( wksp ) ) ) goto fail; /* logs details */
+  locked = 1;
+
+  fd_wksp_private_pinfo_t * pinfo    = fd_wksp_private_pinfo( wksp );
+  ulong                     part_max = wksp->part_max;
+  ulong                     data_max = wksp->data_max;
+  ulong                     data_lo  = wksp->gaddr_lo;
+  ulong                     data_hi  = wksp->gaddr_hi;
+
+  ulong hdr_data_max = hdr->data_max;
+  ulong hdr_data_lo  = fd_wksp_private_data_off( hdr->part_max );
+  ulong hdr_data_hi  = hdr_data_lo + hdr_data_max;
+
+  /* For all volumes in the checkpt */
+
+  ulong ftr_alloc_cnt  = 0UL;
+  ulong ftr_cgroup_cnt = 0UL;
+  ulong ftr_volume_cnt = 0UL;
+  ulong frame_off_prev = 0UL;
+
+  for(;;) {
+
+    FD_LOG_INFO(( "Restoring volume %lu", ftr_volume_cnt ));
+
+    ulong vol_cgroup_cnt = 0UL;
+
+    ulong vol_cgroup_frame_off[ FD_WKSP_RESTORE_V2_CGROUP_MAX ];
+    ulong vol_cgroup_alloc_cnt[ FD_WKSP_RESTORE_V2_CGROUP_MAX ];
+
+    ulong vol_appendix_frame_off[ FD_WKSP_RESTORE_V2_CGROUP_MAX ];
+    ulong vol_appendix_alloc_cnt[ FD_WKSP_RESTORE_V2_CGROUP_MAX ];
+
+    /* For all cgroups in the volume */
+
+    for(;;) {
+
+      ulong part_lo = ftr_alloc_cnt;
+
+      /* Open the frame and read the leading command to determine if the
+         frame is a cgroup, appendix (which ends the volume) or an end
+         of volumes frame (which ends the checkpt).  If it is an
+         appendix, validate and close the frame and proceed to the next
+         volume.  If it is the end of volumes, validate and close the
+         frame and proceed to footer processing.  Otherwise, proceed to
+         processing a cgroup frame. */
+
+      RESTORE_OPEN( hdr->frame_style_compressed );
+
+      fd_wksp_checkpt_v2_cmd_t cmd[1];
+
+      RESTORE_META( cmd, sizeof(fd_wksp_checkpt_v2_cmd_t) );
+
+      if( FD_UNLIKELY( fd_wksp_checkpt_v2_cmd_is_appendix( cmd ) ) ) {
+        RESTORE_TEST( cmd->appendix.frame_off==frame_off_prev );
+        frame_off_prev = frame_off;
+
+        RESTORE_DATA( vol_appendix_frame_off, vol_cgroup_cnt*sizeof(ulong) );
+        RESTORE_DATA( vol_appendix_alloc_cnt, vol_cgroup_cnt*sizeof(ulong) );
+        RESTORE_CLOSE();
+
+        RESTORE_TEST( !memcmp( vol_appendix_frame_off, vol_cgroup_frame_off, vol_cgroup_cnt*sizeof(ulong) ) );
+        RESTORE_TEST( !memcmp( vol_appendix_alloc_cnt, vol_cgroup_alloc_cnt, vol_cgroup_cnt*sizeof(ulong) ) );
+
+        break;
+      }
+
+      if( FD_UNLIKELY( fd_wksp_checkpt_v2_cmd_is_volumes( cmd ) ) ) {
+        RESTORE_TEST( cmd->volumes.frame_off==frame_off_prev );
+        frame_off_prev = frame_off;
+
+        RESTORE_CLOSE();
+
+        goto restore_footer;
+      }
+
+      /* At this point, we have read the leading command of a cgroup frame.
+         Restore the cgroup allocation metadata. */
+
+      if( FD_UNLIKELY( vol_cgroup_cnt>=FD_WKSP_RESTORE_V2_CGROUP_MAX ) ) {
+        FD_LOG_WARNING(( "increase FD_WKSP_RESTORE_V2_CGROUP_MAX" ));
+        goto fail;
+      }
+
+      vol_cgroup_frame_off[ vol_cgroup_cnt ] = frame_off;
+
+      for(;;) {
+        if( FD_UNLIKELY( fd_wksp_checkpt_v2_cmd_is_data( cmd ) ) ) break;
+        RESTORE_TEST( fd_wksp_checkpt_v2_cmd_is_meta( cmd ) );
+
+        ulong tag      = cmd->meta.tag;      /* non-zero */
+        ulong gaddr_lo = cmd->meta.gaddr_lo;
+        ulong gaddr_hi = cmd->meta.gaddr_hi;
+
+        RESTORE_TEST( (hdr_data_lo<=gaddr_lo) & (gaddr_lo<gaddr_hi) & (gaddr_hi<=hdr_data_hi) );
+        /* Note: disjoint [gaddr_lo,gaddr_hi) tested on rebuild */
+
+        if( FD_UNLIKELY( !((data_lo<=gaddr_lo) & (gaddr_hi<=data_hi)) ) ) {
+          FD_LOG_WARNING(( "restore failed because checkpt allocation [0x%016lx,0x%016lx) tag %lu does not fit into the wksp "
+                           "data region [0x%016lx,0x%016lx) (hdr_data_max %lu, wksp_data_max %lu)",
+                           gaddr_lo, gaddr_hi, tag, data_lo, data_hi, hdr_data_max, data_max ));
+          goto fail;
+        }
+
+        if( FD_UNLIKELY( ftr_alloc_cnt>=part_max ) ) {
+          FD_LOG_WARNING(( "restore failed because there are too few wksp partitions to restore allocations into "
+                           "(alloc_cnt %lu, hdr_part_max %lu, wksp_part_max %lu)",
+                           ftr_alloc_cnt, hdr->part_max, wksp->part_max ));
+          goto fail;
+        }
+
+        dirty = 1;
+        pinfo[ ftr_alloc_cnt ].gaddr_lo = gaddr_lo;
+        pinfo[ ftr_alloc_cnt ].gaddr_hi = gaddr_hi;
+        pinfo[ ftr_alloc_cnt ].tag      = tag;
+        ftr_alloc_cnt++;
+
+        RESTORE_META( cmd, sizeof(fd_wksp_checkpt_v2_cmd_t) );
+      }
+
+      /* At this point, we have restored all cgroup allocation metadata
+         into the pinfo array at [part_lo,ftr_alloc_cnt).  Restore the
+         corresponding cgroup allocation data. */
+
+      for( ulong part_idx=part_lo; part_idx<ftr_alloc_cnt; part_idx++ ) {
+        ulong gaddr_lo = pinfo[ part_idx ].gaddr_lo;
+        ulong gaddr_hi = pinfo[ part_idx ].gaddr_hi;
+
+        dirty = 1;
+        RESTORE_DATA( fd_wksp_laddr_fast( wksp, gaddr_lo ), gaddr_hi - gaddr_lo );
+      }
+
+      /* Close the cgroup frame */
+
+      RESTORE_CLOSE();
+
+      /* Update verification info */
+
+      vol_cgroup_alloc_cnt[ vol_cgroup_cnt ] = ftr_alloc_cnt - part_lo;
+      vol_cgroup_cnt++;
+
+    }
+
+    /* Update verification info */
+
+    ftr_cgroup_cnt += vol_cgroup_cnt;
+    ftr_volume_cnt++;
+  }
+
+restore_footer:
+
+  /* At this point, the checkpt is positioned at the start of the
+     footer.  Restore and validate it.  Note that checkpt data has been
+     fully decompressed into the wksp pinfo and data region but the wksp
+     indexing structures have not been rebuilt.  Further note that
+     restoring the footer is pure validation. */
+
+  FD_LOG_INFO(( "Restoring footer" ));
+
+  fd_wksp_checkpt_v2_ftr_t ftr[1];
+
+  RESTORE_TEST( !fd_wksp_restore_v2_ftr( restore, hdr, ftr, frame_off + sizeof(fd_wksp_checkpt_v2_ftr_t) ) );
+
+  RESTORE_TEST( ftr->alloc_cnt ==ftr_alloc_cnt  );
+  RESTORE_TEST( ftr->cgroup_cnt==ftr_cgroup_cnt );
+  RESTORE_TEST( ftr->volume_cnt==ftr_volume_cnt );
+  RESTORE_TEST( ftr->frame_off ==frame_off_prev );
+
+  FD_LOG_INFO(( "Rebuilding wksp" ));
+
+  /* Free any remaining old allocations and rebuild the wksp with
+     the freshly restored allocations */
+
+  dirty = 1;
+  for( ulong part_idx=ftr_alloc_cnt; part_idx<part_max; part_idx++ ) pinfo[ part_idx ].tag = 0UL;
+
+  if( FD_UNLIKELY( fd_wksp_rebuild( wksp, new_seed ) ) ) goto fail; /* logs details */
+
+  FD_LOG_INFO(( "Unlocking wksp" ));
+
+  fd_wksp_private_unlock( wksp );
+
+  return FD_WKSP_SUCCESS;
+
+fail: /* Release resources that might be reserved */
+
+  if( FD_LIKELY( locked ) ) fd_wksp_private_unlock( wksp );
+
+  return fd_int_if( dirty, FD_WKSP_ERR_CORRUPT, FD_WKSP_ERR_FAIL );
+}
+
+int
+fd_wksp_private_restore_v2( fd_tpool_t * tpool,
+                            ulong        t0,
+                            ulong        t1,
+                            fd_wksp_t *  wksp,
+                            char const * path,
+                            uint         new_seed ) {
+
+  FD_LOG_INFO(( "Restoring checkpt \"%s\" into wksp \"%s\" (seed %u)", path, wksp->name, new_seed ));
+
+  int            fd      = -1;
+  void const *   mmio    = NULL;
+  ulong          mmio_sz = 0UL;
+  fd_restore_t * restore = NULL;
+
+  fd_restore_t   _restore[ 1 ];
+  uchar          rbuf[ FD_RESTORE_RBUF_MIN ];
+
+  FD_LOG_INFO(( "Opening checkpt" ));
+
+  fd = open( path, O_RDONLY, (mode_t)0 );
+  if( FD_UNLIKELY( fd==-1 ) ) {
+    FD_LOG_WARNING(( "open(\"%s\",O_RDONLY,0) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
+    goto fail;
+  }
+
+  int err = fd_io_mmio_init( fd, FD_IO_MMIO_MODE_READ_ONLY, &mmio, &mmio_sz );
+  if( FD_LIKELY( !err ) ) {
+
+    FD_LOG_INFO(( "Restoring checkpt with mmio" ));
+
+    /* FIXME: consider trimming off prefix / suffix here (i.e. scan for
+       MAGIC / ~MAGIC) */
+
+    restore = fd_restore_init_mmio( _restore, mmio, mmio_sz ); /* logs details */
+    if( FD_UNLIKELY( !restore ) ) goto fail;
+
+    err = fd_wksp_private_restore_v2_mmio( tpool, t0, t1, wksp, restore, new_seed ); /* logs details */
+    if( FD_UNLIKELY( err ) ) goto fail;
+
+  } else {
+
+    FD_LOG_INFO(( "\"%s\" does not appear to support mmio (%i-%s); restoring checkpt with streaming",
+                  path, err, fd_io_strerror( err ) ));
+
+    /* FIXME: consider trimming off prefix (i.e. scan for MAGIC) here */
+
+    restore = fd_restore_init_stream( _restore, fd, rbuf, FD_RESTORE_RBUF_MIN ); /* logs details */
+    if( FD_UNLIKELY( !restore ) ) goto fail;
+
+    err = fd_wksp_private_restore_v2_stream( wksp, restore, new_seed ); /* logs details */
+    if( FD_UNLIKELY( err ) ) goto fail;
+
+  }
+
+  FD_LOG_INFO(( "Closing checkpt" ));
+
+  if( FD_UNLIKELY( !fd_restore_fini( restore ) ) ) /* logs details */
+    FD_LOG_WARNING(( "fd_restore_fini failed; attempting to continue" ));
+
+  if( FD_LIKELY( mmio_sz ) ) fd_io_mmio_fini( mmio, mmio_sz );
+
+  if( FD_UNLIKELY( close( fd ) ) )
+    FD_LOG_WARNING(( "close(\"%s\") failed (%i-%s); attempting to continue", path, errno, fd_io_strerror( errno ) ));
+
+  return err;
+
+fail:
+
+  if( FD_LIKELY( restore ) ) {
+    if( FD_UNLIKELY( fd_restore_in_frame( restore ) ) && FD_UNLIKELY( fd_restore_close( restore ) ) )
+      FD_LOG_WARNING(( "fd_restore_close failed; attempting to continue" ));
+
+    if( FD_UNLIKELY( !fd_restore_fini( restore ) ) ) /* logs details */
+      FD_LOG_WARNING(( "fd_restore_fini failed; attempting to continue" ));
+  }
+
+  if( FD_LIKELY( mmio_sz ) ) fd_io_mmio_fini( mmio, mmio_sz );
+
+  if( FD_LIKELY( fd!=-1 ) && FD_UNLIKELY( close( fd ) ) )
+    FD_LOG_WARNING(( "close(\"%s\") failed (%i-%s); attempting to continue", path, errno, fd_io_strerror( errno ) ));
+
+  return FD_WKSP_ERR_FAIL;
+}
+
+int
+fd_wksp_private_printf_v2( int          out,
+                           char const * path,
+                           int          verbose ) {
+
+  int ret = 0;
+# define TRAP(x) do { int _err = (x); if( FD_UNLIKELY( _err<0 ) ) { ret = _err; goto fail; } ret += _err; } while(0)
+
+  int            fd      = -1;
+  fd_restore_t * restore = NULL;
+
+  fd_restore_t _restore[ 1 ];
+  uchar        rbuf[ FD_RESTORE_RBUF_MIN ];
+
+  /* Print the header and metadata */
+
+  if( verbose>=1 ) {
+
+     /* Open the restore */
+
+    fd = open( path, O_RDONLY, (mode_t)0 );
+    if( FD_UNLIKELY( fd==-1 ) ) {
+      FD_LOG_WARNING(( "open(\"%s\",O_RDONLY,0) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
+      goto fail;
+    }
+
+    restore = fd_restore_init_stream( _restore, fd, rbuf, FD_RESTORE_RBUF_MIN ); /* logs details */
+    if( FD_UNLIKELY( !restore ) ) goto fail;
+
+    /* Restore the header */
+
+    fd_wksp_checkpt_v2_hdr_t hdr[1];
+
+    RESTORE_TEST( !fd_wksp_restore_v2_hdr( restore, hdr ) );
+
+    /* Restore the info */
+
+    fd_wksp_checkpt_v2_info_t info[1];
+    char                      info_buf[ 65536 ];
+    char const *              info_cstr[ 9 ];
+
+    RESTORE_TEST( !fd_wksp_restore_v2_info( restore, hdr, info, info_buf, 65536UL, info_cstr ) );
+
+    char info_wallclock[ FD_LOG_WALLCLOCK_CSTR_BUF_SZ ];
+    fd_log_wallclock_cstr( info->wallclock, info_wallclock );
+
+    /* Pretty print the header and info */
+
+    TRAP( dprintf( out,
+                 //"\tstyle                  %-20i\n"        /* verbose 0 info (already printed) */
+                 //"\tname                   %s\n"
+                 //"\tseed                   %-20u\n"
+                 //"\tpart_max               %-20lu\n"
+                 //"\tdata_max               %-20lu\n"
+                   "\tmagic                  %016lx\n"      /* verbose 1 info */
+                   "\twallclock              %-20li (%s)\n"
+                   "\tapp                    %-20lu (%s)\n"
+                   "\tthread                 %-20lu (%s)\n"
+                   "\thost                   %-20lu (%s)\n"
+                   "\tcpu                    %-20lu (%s)\n"
+                   "\tgroup                  %-20lu (%s)\n"
+                   "\ttid                    %-20lu\n"
+                   "\tuser                   %-20lu (%s)\n"
+                   "\tframe_style_compressed %-20i\n",      /* (v2 specific) */
+                   hdr->magic,
+                   info->wallclock, info_wallclock,
+                   info->app_id,    info_cstr[0],
+                   info->thread_id, info_cstr[1],
+                   info->host_id,   info_cstr[2],
+                   info->cpu_id,    info_cstr[3],
+                   info->group_id,  info_cstr[4],
+                   info->tid,
+                   info->user_id,   info_cstr[5],
+                   hdr->frame_style_compressed ) );
+
+    if( verbose>=2 )
+      TRAP( dprintf( out, "\tmode                   %03lo\n" /* (v2 specific) */
+                          "\tpath\n\t\t%s\n"                 /* (v2 specific) */
+                          "\tbinfo\n\t\t%s\n"
+                          "\tuinfo\n\t\t%s\n",
+                          info->mode, info_cstr[6], info_cstr[7], info_cstr[8] ) );
+
+    /* FIXME: consider implement handling of verbose>=3.  Since data in a
+       compressed frame can't be easily skipped over (due to sequential
+       dependencies between compressed data bufs inherently induced by
+       compression algos), we would:
+
+       Use stat to get the size of the checkpt, seek to the end of the
+       file and restore the footer frame to get the appendix frame
+       location, seek to the appendix frame, and restore it to get the
+       cgroup frame offsets and partition counts.  Then, for each cgroup,
+       seek to the cgruop frame, init a streaming restore, open the frame,
+       restore the partition count and partition metadata (which is
+       conveniently located at the start of a cgroup frame), close it and
+       fini the restore.  Omitting for now as this isn't particularly
+       important functionality. */
+
+    /* Finish restoring */
+
+    if( FD_UNLIKELY( !fd_restore_fini( restore ) ) ) /* logs details */
+      FD_LOG_WARNING(( "fd_restore_fini failed; attempting to continue" ));
+
+    if( FD_UNLIKELY( close( fd ) ) )
+      FD_LOG_WARNING(( "close failed (%i-%s); attempting to continue", errno, fd_io_strerror( errno ) ));
+  }
+
+# undef TRAP
+
+  return ret;
+
+fail: /* Release resources that might be reserved */
+
+  if( FD_LIKELY( restore ) ) {
+    if( FD_UNLIKELY( fd_restore_in_frame( restore ) ) && FD_UNLIKELY( fd_restore_close( restore ) ) )
+      FD_LOG_WARNING(( "fd_restore_close failed; attempting to continue" ));
+
+    if( FD_UNLIKELY( !fd_restore_fini( restore ) ) ) /* logs details */
+      FD_LOG_WARNING(( "fd_restore_fini failed; attempting to continue" ));
+  }
+
+  if( FD_LIKELY( fd!=-1 ) && FD_UNLIKELY( close( fd ) ) )
+    FD_LOG_WARNING(( "close failed (%i-%s); attempting to continue", errno, fd_io_strerror( errno ) ));
+
+  return ret;
+}
+
+#undef RESTORE_TEST
+#undef RESTORE_DATA
+#undef RESTORE_META
+#undef RESTORE_CLOSE
+#undef RESTORE_OPEN
+#undef RESTORE_SEEK

--- a/src/util/wksp/fd_wksp_used_treap.c
+++ b/src/util/wksp/fd_wksp_used_treap.c
@@ -140,7 +140,7 @@ fd_wksp_private_used_treap_insert( ulong                     n,
     ulong il = fd_wksp_private_pinfo_idx( pinfo[ i ].left_cidx   ); /* Validated above */
   //ulong ir = fd_wksp_private_pinfo_idx( pinfo[ i ].right_cidx  ); /* Validated above */
     ulong p  = fd_wksp_private_pinfo_idx( pinfo[ i ].parent_cidx ); /* Validated above */
-    _p_child_cidx = fd_wksp_private_pinfo_idx_is_null( p )                 ? &wksp->part_used_cidx 
+    _p_child_cidx = fd_wksp_private_pinfo_idx_is_null( p )                 ? &wksp->part_used_cidx
                   : (fd_wksp_private_pinfo_idx( pinfo[ p ].left_cidx )==i) ? &pinfo[ p ].left_cidx   /* Validated above */
                   :                                                          &pinfo[ p ].right_cidx;
 

--- a/src/util/wksp/test_wksp.c
+++ b/src/util/wksp/test_wksp.c
@@ -89,13 +89,13 @@ test_main( int     argc,
 
       sz[j]  = fd_rng_ulong_roll( rng, sz_max+1UL );
       #if FD_HAS_DEEPASAN
-        /* Due to manual asan poisoning requirements, must have a byte alignment must be 
+        /* Due to manual asan poisoning requirements, must have a byte alignment must be
            8. For the same reason the size must also be at least 8. */
         sz[j] = fd_ulong_align_up( sz[j], FD_ASAN_ALIGN );
         align = fd_ulong_if( align < FD_ASAN_ALIGN, FD_ASAN_ALIGN, align );
-      #endif 
+      #endif
       tag[j] = fd_rng_ulong( rng ) | 1UL;
-      
+
       /* Allocate it */
 
       ulong glo;
@@ -130,7 +130,7 @@ test_main( int     argc,
       #if FD_HAS_DEEPASAN
       if ( mem[j] && sz[j] )
         FD_TEST( fd_asan_query( mem[j], sz[j] ) == NULL );
-      #endif 
+      #endif
 
       /* This allocation is now outstanding */
 
@@ -244,4 +244,3 @@ main( int     argc,
 }
 
 #undef OUTSTANDING_MAX
-

--- a/src/util/wksp/test_wksp_admin.c
+++ b/src/util/wksp/test_wksp_admin.c
@@ -97,7 +97,7 @@ main( int     argc,
   FD_TEST(  fd_wksp_leave( wksp )==shwksp );
 
   /* Test delete */
-  
+
   FD_TEST( !fd_wksp_delete( NULL        )     );
   FD_TEST( !fd_wksp_delete( scratch+1UL )     );
   FD_TEST(  fd_wksp_delete( shwksp )==scratch );
@@ -118,4 +118,3 @@ main( int     argc,
   fd_halt();
   return 0;
 }
-

--- a/src/util/wksp/test_wksp_ctl
+++ b/src/util/wksp/test_wksp_ctl
@@ -24,7 +24,6 @@ CPU_IDX=0
 MODE=0600
 
 CHECKPT=test_fd_wksp_ctl.checkpt
-STYLE=0
 INFO="The quick brown fox jumps over the lazy dog"
 
 # Disable the permanent log
@@ -99,144 +98,154 @@ GADDR1=$("$BIN"/fd_wksp_ctl tag 1234 alloc "$WKSP" 4096 4096 || fail alloc $?)
 GADDR2=$("$BIN"/fd_wksp_ctl tag 1234 alloc "$WKSP" 4096 4096 || fail alloc $?)
 GADDR3=$("$BIN"/fd_wksp_ctl tag 2345 alloc "$WKSP" 4096 4096 || fail alloc $?)
 
-echo Testing checkpt
+SUPPORTED_STYLES=$("$BIN"/fd_wksp_ctl supported-styles || fail supported-styles $?)
 
-"$BIN"/fd_wksp_ctl checkpt                                              && fail checkpt $?
-"$BIN"/fd_wksp_ctl checkpt "$WKSP"                                      && fail checkpt $?
-"$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT"                          && fail checkpt $?
-"$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" "$MODE"                  && fail checkpt $?
-"$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" "$MODE" "$STYLE"         && fail checkpt $?
-"$BIN"/fd_wksp_ctl checkpt bad/name "$CHECKPT" "$MODE" "$STYLE" "$INFO" && fail checkpt $?
-"$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" -1      "$STYLE" "$INFO" && fail checkpt $?
-"$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" "$MODE" -1       "$INFO" && fail checkpt $?
-"$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" "$MODE" "$STYLE" "$INFO" || fail checkpt $?
-"$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" "$MODE" "$STYLE" "$INFO" && fail checkpt $?
+for STYLE in $SUPPORTED_STYLES; do
+  echo Testing with checkpt style "$STYLE"
 
-echo Testing checkpt-query
+  echo Testing checkpt
 
-"$BIN"/fd_wksp_ctl checkpt-query              && fail checkpt-query $?
-"$BIN"/fd_wksp_ctl checkpt-query "$CHECKPT"   && fail checkpt-query $?
-"$BIN"/fd_wksp_ctl checkpt-query "$CHECKPT" 0 \
-                   checkpt-query "$CHECKPT" 1 \
-                   checkpt-query "$CHECKPT" 2 || fail checkpt-query $?
+  "$BIN"/fd_wksp_ctl checkpt                                              && fail checkpt $?
+  "$BIN"/fd_wksp_ctl checkpt "$WKSP"                                      && fail checkpt $?
+  "$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT"                          && fail checkpt $?
+  "$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" "$MODE"                  && fail checkpt $?
+  "$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" "$MODE" "$STYLE"         && fail checkpt $?
+  "$BIN"/fd_wksp_ctl checkpt bad/name "$CHECKPT" "$MODE" "$STYLE" "$INFO" && fail checkpt $?
+  "$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" -1      "$STYLE" "$INFO" && fail checkpt $?
+  "$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" "$MODE" -1       "$INFO" && fail checkpt $?
+  "$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" "$MODE" "$STYLE" "$INFO" || fail checkpt $?
+  "$BIN"/fd_wksp_ctl checkpt "$WKSP"  "$CHECKPT" "$MODE" "$STYLE" "$INFO" && fail checkpt $?
 
-echo Testing info
+  echo Testing checkpt-query
 
-"$BIN"/fd_wksp_ctl info         && fail info $?
-"$BIN"/fd_wksp_ctl info "$WKSP" && fail info $?
-"$BIN"/fd_wksp_ctl info bad     1234 \
-                   info "$WKSP"    0 \
-                   info "$WKSP" 4096 \
-                   info "$WKSP"    2 \
-                   info "$WKSP" 1234 \
-                   info "$WKSP" 2345 \
-                   info "$WKSP" 1234 \
-|| fail info $? # Yes ... a fail here is success from cmd exec POV (fail is logged)
+  "$BIN"/fd_wksp_ctl checkpt-query              && fail checkpt-query $?
+  "$BIN"/fd_wksp_ctl checkpt-query "$CHECKPT"   && fail checkpt-query $?
+  "$BIN"/fd_wksp_ctl checkpt-query "$CHECKPT" 0 \
+                     checkpt-query "$CHECKPT" 1 \
+                     checkpt-query "$CHECKPT" 2 \
+                     checkpt-query "$CHECKPT" 3 \
+                     checkpt-query "$CHECKPT" 4 \
+                     checkpt-query "$CHECKPT" 5 || fail checkpt-query $?
 
-echo Testing memset
+  echo Testing info
 
-"$BIN"/fd_wksp_ctl memset              && fail memset $?
-"$BIN"/fd_wksp_ctl memset "$GADDR"     && fail memset $?
-"$BIN"/fd_wksp_ctl memset bad/name 0   || fail memset $? # Yes ... a fail here is success from cmd exec POV (fail is logged)
-"$BIN"/fd_wksp_ctl memset "$GADDR" 0   || fail memset $?
+  "$BIN"/fd_wksp_ctl info         && fail info $?
+  "$BIN"/fd_wksp_ctl info "$WKSP" && fail info $?
+  "$BIN"/fd_wksp_ctl info bad     1234 \
+                     info "$WKSP"    0 \
+                     info "$WKSP" 4096 \
+                     info "$WKSP"    2 \
+                     info "$WKSP" 1234 \
+                     info "$WKSP" 2345 \
+                     info "$WKSP" 1234 \
+  || fail info $? # Yes ... a fail here is success from cmd exec POV (fail is logged)
 
-echo Testing check
+  echo Testing memset
 
-"$BIN"/fd_wksp_ctl check            && fail check $?
-"$BIN"/fd_wksp_ctl check bad/name   && fail check $?
-"$BIN"/fd_wksp_ctl check "$WKSP"    || fail check $?
+  "$BIN"/fd_wksp_ctl memset              && fail memset $?
+  "$BIN"/fd_wksp_ctl memset "$GADDR"     && fail memset $?
+  "$BIN"/fd_wksp_ctl memset bad/name 0   || fail memset $? # Yes ... a fail here is success from cmd exec POV (fail is logged)
+  "$BIN"/fd_wksp_ctl memset "$GADDR" 0   || fail memset $?
 
-echo Testing verify
+  echo Testing check
 
-"$BIN"/fd_wksp_ctl verify            && fail verify $?
-"$BIN"/fd_wksp_ctl verify bad/name   && fail verify $?
-"$BIN"/fd_wksp_ctl verify "$WKSP"    || fail verify $?
+  "$BIN"/fd_wksp_ctl check            && fail check $?
+  "$BIN"/fd_wksp_ctl check bad/name   && fail check $?
+  "$BIN"/fd_wksp_ctl check "$WKSP"    || fail check $?
 
-echo Testing rebuild
+  echo Testing verify
 
-"$BIN"/fd_wksp_ctl rebuild              && fail rebuild $?
-"$BIN"/fd_wksp_ctl rebuild "$WKSP"      && fail rebuild $?
-"$BIN"/fd_wksp_ctl rebuild bad/name -   && fail rebuild $?
-"$BIN"/fd_wksp_ctl rebuild "$WKSP"  -   \
-                   rebuild "$WKSP"  123 \
-|| fail rebuild $?
+  "$BIN"/fd_wksp_ctl verify            && fail verify $?
+  "$BIN"/fd_wksp_ctl verify bad/name   && fail verify $?
+  "$BIN"/fd_wksp_ctl verify "$WKSP"    || fail verify $?
 
-echo Testing usage
+  echo Testing rebuild
 
-"$BIN"/fd_wksp_ctl usage               && fail usage $?
-"$BIN"/fd_wksp_ctl usage bad/name      && fail usage $?
-"$BIN"/fd_wksp_ctl usage bad/name      1 \
-                   usage "$WKSP"       1 \
-                   usage "$WKSP"    1234 \
-                   usage "$WKSP"    2345 \
-|| fail usage $?
+  "$BIN"/fd_wksp_ctl rebuild              && fail rebuild $?
+  "$BIN"/fd_wksp_ctl rebuild "$WKSP"      && fail rebuild $?
+  "$BIN"/fd_wksp_ctl rebuild bad/name -   && fail rebuild $?
+  "$BIN"/fd_wksp_ctl rebuild "$WKSP"  -   \
+                     rebuild "$WKSP"  123 \
+  || fail rebuild $?
 
-echo Testing query
+  echo Testing usage
 
-"$BIN"/fd_wksp_ctl query          && fail query $?
-"$BIN"/fd_wksp_ctl query bad/name && fail query $?
-"$BIN"/fd_wksp_ctl query "$WKSP"  || fail query $?
+  "$BIN"/fd_wksp_ctl usage               && fail usage $?
+  "$BIN"/fd_wksp_ctl usage bad/name      && fail usage $?
+  "$BIN"/fd_wksp_ctl usage bad/name      1 \
+                     usage "$WKSP"       1 \
+                     usage "$WKSP"    1234 \
+                     usage "$WKSP"    2345 \
+  || fail usage $?
 
-echo Testing tag-query
+  echo Testing query
 
-"$BIN"/fd_wksp_ctl tag-query          && fail tag-query $?
-"$BIN"/fd_wksp_ctl tag-query bad/name \
-                   tag-query "$GADDR"   \
-                   tag-query "$GADDR1"  \
-                   tag-query "$GADDR2"  \
-                   tag-query "$GADDR3"  \
-|| fail tag-query $? # Yes ... a fail here is success from cmd exec POV (fail is logged)
+  "$BIN"/fd_wksp_ctl query          && fail query $?
+  "$BIN"/fd_wksp_ctl query bad/name && fail query $?
+  "$BIN"/fd_wksp_ctl query "$WKSP"  || fail query $?
 
-echo Testing tag-free
+  echo Testing tag-query
 
-"$BIN"/fd_wksp_ctl tag-free         && fail tag-free $?
-"$BIN"/fd_wksp_ctl tag-free "$WKSP" && fail tag-free $?
-"$BIN"/fd_wksp_ctl tag-free bad     1234 \
-                   tag-free "$WKSP"    0 \
-                   tag-free "$WKSP" 4096 \
-                   tag-free "$WKSP"    2 \
-                   tag-free "$WKSP" 1234 \
-                   tag-free "$WKSP" 2345 \
-                   tag-free "$WKSP" 1234 \
-|| fail tag-free $? # Yes ... a fail here is success from cmd exec POV (fail is logged)
+  "$BIN"/fd_wksp_ctl tag-query          && fail tag-query $?
+  "$BIN"/fd_wksp_ctl tag-query bad/name \
+                     tag-query "$GADDR"   \
+                     tag-query "$GADDR1"  \
+                     tag-query "$GADDR2"  \
+                     tag-query "$GADDR3"  \
+  || fail tag-query $? # Yes ... a fail here is success from cmd exec POV (fail is logged)
 
-echo Testing free
+  echo Testing tag-free
 
-"$BIN"/fd_wksp_ctl free          && fail free $?
-"$BIN"/fd_wksp_ctl free bad/name || fail free $? # Yes ... a fail here is success from cmd exec POV (fail is logged)
-"$BIN"/fd_wksp_ctl free "$GADDR" || fail free $?
-"$BIN"/fd_wksp_ctl free "$GADDR" || fail free $? # Yes ... a fail here is success from cmd exec POV (fail is logged)
+  "$BIN"/fd_wksp_ctl tag-free         && fail tag-free $?
+  "$BIN"/fd_wksp_ctl tag-free "$WKSP" && fail tag-free $?
+  "$BIN"/fd_wksp_ctl tag-free bad     1234 \
+                     tag-free "$WKSP"    0 \
+                     tag-free "$WKSP" 4096 \
+                     tag-free "$WKSP"    2 \
+                     tag-free "$WKSP" 1234 \
+                     tag-free "$WKSP" 2345 \
+                     tag-free "$WKSP" 1234 \
+  || fail tag-free $? # Yes ... a fail here is success from cmd exec POV (fail is logged)
 
-echo Testing reset
+  echo Testing free
 
-"$BIN"/fd_wksp_ctl reset          && fail reset $?
-"$BIN"/fd_wksp_ctl reset bad/name && fail reset $?
-"$BIN"/fd_wksp_ctl reset "$WKSP"  || fail reset $?
+  "$BIN"/fd_wksp_ctl free          && fail free $?
+  "$BIN"/fd_wksp_ctl free bad/name || fail free $? # Yes ... a fail here is success from cmd exec POV (fail is logged)
+  "$BIN"/fd_wksp_ctl free "$GADDR" || fail free $?
+  "$BIN"/fd_wksp_ctl free "$GADDR" || fail free $? # Yes ... a fail here is success from cmd exec POV (fail is logged)
 
-echo Testing restore
+  echo Testing reset
 
-"$BIN"/fd_wksp_ctl restore                         && fail restore $?
-"$BIN"/fd_wksp_ctl restore "$WKSP"                 && fail restore $?
-"$BIN"/fd_wksp_ctl restore "$WKSP"  "$CHECKPT"     && fail restore $?
-"$BIN"/fd_wksp_ctl restore bad/name "$CHECKPT"     && fail restore $?
-"$BIN"/fd_wksp_ctl restore "$WKSP"  "$CHECKPT" -   query "$WKSP" check "$WKSP" \
-                   restore "$WKSP"  "$CHECKPT" 123 query "$WKSP" check "$WKSP" \
-                   restore "$WKSP"  "$CHECKPT" 123 query "$WKSP" check "$WKSP" \
-                   restore "$WKSP"  "$CHECKPT" 234 query "$WKSP" check "$WKSP" \
-|| fail restore $?
-rm -fv "$CHECKPT"
+  "$BIN"/fd_wksp_ctl reset          && fail reset $?
+  "$BIN"/fd_wksp_ctl reset bad/name && fail reset $?
+  "$BIN"/fd_wksp_ctl reset "$WKSP"  || fail reset $?
 
-# Test checkpt empty wksp, query empty checkpt, restore empty to empty,
-# restore non-empty to empty
+  echo Testing restore
 
-"$BIN"/fd_wksp_ctl reset         "$WKSP"                                          \
-                   checkpt       "$WKSP" "$CHECKPT" "$MODE" "$STYLE" "$INFO"      \
-                   checkpt-query "$CHECKPT" 2                                     \
-                   restore       "$WKSP" "$CHECKPT" - query "$WKSP" check "$WKSP" \
-                   alloc         "$WKSP" 1 1          query "$WKSP" check "$WKSP" \
-                   restore       "$WKSP" "$CHECKPT" - query "$WKSP" check "$WKSP" \
-|| fail reset $?
-rm -fv "$CHECKPT"
+  "$BIN"/fd_wksp_ctl restore                         && fail restore $?
+  "$BIN"/fd_wksp_ctl restore "$WKSP"                 && fail restore $?
+  "$BIN"/fd_wksp_ctl restore "$WKSP"  "$CHECKPT"     && fail restore $?
+  "$BIN"/fd_wksp_ctl restore bad/name "$CHECKPT"     && fail restore $?
+  "$BIN"/fd_wksp_ctl restore "$WKSP"  "$CHECKPT" -   query "$WKSP" check "$WKSP" \
+                     restore "$WKSP"  "$CHECKPT" 123 query "$WKSP" check "$WKSP" \
+                     restore "$WKSP"  "$CHECKPT" 123 query "$WKSP" check "$WKSP" \
+                     restore "$WKSP"  "$CHECKPT" 234 query "$WKSP" check "$WKSP" \
+  || fail restore $?
+
+  rm -fv "$CHECKPT"
+
+  # Test checkpt empty wksp, query empty checkpt, restore empty to empty,
+  # restore non-empty to empty
+
+  "$BIN"/fd_wksp_ctl reset         "$WKSP"                                          \
+                     checkpt       "$WKSP" "$CHECKPT" "$MODE" "$STYLE" "$INFO"      \
+                     checkpt-query "$CHECKPT" 2                                     \
+                     restore       "$WKSP" "$CHECKPT" - query "$WKSP" check "$WKSP" \
+                     alloc         "$WKSP" 1 1          query "$WKSP" check "$WKSP" \
+                     restore       "$WKSP" "$CHECKPT" - query "$WKSP" check "$WKSP" \
+  || fail reset $?
+  rm -fv "$CHECKPT"
+done
 
 echo Testing delete
 
@@ -244,25 +253,29 @@ echo Testing delete
 "$BIN"/fd_wksp_ctl delete bad/name && fail delete $?
 "$BIN"/fd_wksp_ctl delete "$WKSP"  || fail delete $?
 
-echo Testing multi
+for STYLE in $SUPPORTED_STYLES; do
+  echo Testing with style "$STYLE"
 
-"$BIN"/fd_wksp_ctl new           "$WKSP" "$PAGE_CNT" $PAGE_SZ $CPU_IDX $MODE check "$WKSP" \
-                   query         "$WKSP"                                     check "$WKSP" \
-                   alloc         "$WKSP" 1 1                                 check "$WKSP" \
-                   alloc         "$WKSP" 2 2                                 check "$WKSP" \
-                   alloc         "$WKSP" 4 3                                 check "$WKSP" \
-                   query         "$WKSP"                                     check "$WKSP" \
-                   checkpt       "$WKSP" "$CHECKPT" "$MODE" "$STYLE" "$INFO" check "$WKSP" \
-                   checkpt-query "$CHECKPT" 2                                check "$WKSP" \
-                   reset         "$WKSP"                                     check "$WKSP" \
-                   alloc         "$WKSP" 8 8                                 check "$WKSP" \
-                   restore       "$WKSP" "$CHECKPT" -                        check "$WKSP" \
-                   query         "$WKSP"                                     check "$WKSP" \
-                   reset         "$WKSP"                                     check "$WKSP" \
-                   query         "$WKSP"                                     check "$WKSP" \
-                   delete        "$WKSP"                                                   \
-|| fail multi $?
-rm -fv "$CHECKPT"
+  echo Testing multi
+
+  "$BIN"/fd_wksp_ctl new           "$WKSP" "$PAGE_CNT" $PAGE_SZ $CPU_IDX $MODE check "$WKSP" \
+                     query         "$WKSP"                                     check "$WKSP" \
+                     alloc         "$WKSP" 1 1                                 check "$WKSP" \
+                     alloc         "$WKSP" 2 2                                 check "$WKSP" \
+                     alloc         "$WKSP" 4 3                                 check "$WKSP" \
+                     query         "$WKSP"                                     check "$WKSP" \
+                     checkpt       "$WKSP" "$CHECKPT" "$MODE" "$STYLE" "$INFO" check "$WKSP" \
+                     checkpt-query "$CHECKPT" 2                                check "$WKSP" \
+                     reset         "$WKSP"                                     check "$WKSP" \
+                     alloc         "$WKSP" 8 8                                 check "$WKSP" \
+                     restore       "$WKSP" "$CHECKPT" -                        check "$WKSP" \
+                     query         "$WKSP"                                     check "$WKSP" \
+                     reset         "$WKSP"                                     check "$WKSP" \
+                     query         "$WKSP"                                     check "$WKSP" \
+                     delete        "$WKSP"                                                   \
+  || fail multi $?
+  rm -fv "$CHECKPT"
+done
 
 echo pass
 echo Log N/A

--- a/src/util/wksp/test_wksp_helper.c
+++ b/src/util/wksp/test_wksp_helper.c
@@ -142,7 +142,7 @@ main( int     argc,
     cstr2[0] = '\0'; FD_TEST( !fd_wksp_cstr_laddr( laddr1,      NULL  )        );
     cstr2[0] = '\0'; FD_TEST(  fd_wksp_cstr_laddr( laddr1,      cstr2 )==cstr2 );
     FD_TEST( !strcmp( cstr1, cstr2 ) );
- 
+
     /* Test fd_wksp_unmap */
 
     fd_wksp_unmap( NULL   );
@@ -153,7 +153,7 @@ main( int     argc,
     fd_wksp_cstr_free( NULL  );
     fd_wksp_cstr_free( cstr1 );
     fd_wksp_cstr_free( cstr1 );
-  
+
     FD_TEST( fd_wksp_cstr_tag( cstr1 )==0UL );
     fd_wksp_cstr_memset( NULL, 255 );
 
@@ -197,4 +197,3 @@ main( int     argc,
   fd_halt();
   return 0;
 }
-

--- a/src/util/wksp/test_wksp_tpool.c
+++ b/src/util/wksp/test_wksp_tpool.c
@@ -1,0 +1,203 @@
+#include "../fd_util.h"
+/* FIXME: CLEANUP */
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+static FD_TL fd_rng_t rng_mem[1];
+
+static FD_FOR_ALL_BEGIN( rng_init, 1L ) {
+  fd_rng_t ** _rng = (fd_rng_t **)_a0;
+  _rng[ tpool_t0 ] = fd_rng_join( fd_rng_new( rng_mem, (uint)tpool_t0, 0UL ) );
+} FD_FOR_ALL_END
+
+static FD_FOR_ALL_BEGIN( rng_fini, 1L ) {
+  fd_rng_t ** _rng = (fd_rng_t **)_a0;
+  fd_rng_delete( fd_rng_leave( _rng[ tpool_t0 ] ) );
+} FD_FOR_ALL_END
+
+typedef struct {
+  ulong gaddr0;
+  ulong sz;
+} alloc_info_t;
+
+static FD_FOR_ALL_BEGIN( alloc_init, 1L ) {
+  fd_wksp_t *          wksp = (fd_wksp_t *)         _a0;
+  alloc_info_t const * info = (alloc_info_t const *)_a1;
+
+  for( long idx=block_i0; idx<block_i1; idx++ ) {
+    ulong gaddr0 = info[ idx ].gaddr0;   /* !=0 */
+    ulong sz     = info[ idx ].sz;       /* >0  */
+    ulong tag    = (ulong)(idx+1L);      /* >0, unique */
+    int   c      = 1+(int)(tag % 255UL); /* in [1,255] */
+    memset( fd_wksp_laddr_fast( wksp, gaddr0 ), c, sz ); /* Fill allocation region with test pattern */
+  }
+
+} FD_FOR_ALL_END
+
+static FD_FOR_ALL_BEGIN( alloc_zero, 1L ) {
+  fd_wksp_t *          wksp = (fd_wksp_t *)         _a0;
+  alloc_info_t const * info = (alloc_info_t const *)_a1;
+
+  for( long idx=block_i0; idx<block_i1; idx++ ) {
+    ulong gaddr0 = info[ idx ].gaddr0; /* !=0 */
+    ulong sz     = info[ idx ].sz;     /* >0  */
+    memset( fd_wksp_laddr_fast( wksp, gaddr0 ), 0, sz ); /* Zero out allocation region */
+  }
+
+} FD_FOR_ALL_END
+
+static FD_FOR_ALL_BEGIN( alloc_test, 1L ) {
+  fd_wksp_t *          wksp = (fd_wksp_t *)         _a0;
+  alloc_info_t const * info = (alloc_info_t const *)_a1;
+
+  fd_rng_t * rng  = ((fd_rng_t **)_a2)[ tpool_t0 ];
+
+  for( long idx=block_i0; idx<block_i1; idx++ ) {
+    ulong gaddr0 = info[ idx ].gaddr0;   /* !=0 */
+    ulong sz     = info[ idx ].sz;       /* >0  */
+    ulong tag    = (ulong)(idx+1L);      /* >0, unique  */
+    int   c      = 1+(int)(tag % 255UL); /* in [1,255] */
+
+    /* Verify that the first, last and randomly chosen byte of the
+       allocation region matches the allocation tag */
+
+    FD_TEST( fd_wksp_tag( wksp, gaddr0                                )==tag );
+    FD_TEST( fd_wksp_tag( wksp, gaddr0 + fd_rng_ulong_roll( rng, sz ) )==tag );
+    FD_TEST( fd_wksp_tag( wksp, gaddr0 + sz - 1UL                     )==tag );
+
+    /* Verify that the test pattern in the allocation region is correct */
+
+    uchar * laddr0 = (uchar *)fd_wksp_laddr_fast( wksp, gaddr0 );
+    for( ulong off=0UL; off<sz; off++ ) FD_TEST( ((int)laddr0[off])==c );
+  }
+
+} FD_FOR_ALL_END
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  char const * path       = fd_env_strip_cmdline_cstr ( &argc, &argv, "--path",       NULL,            NULL );
+  char const * _mode      = fd_env_strip_cmdline_cstr ( &argc, &argv, "--mode",       NULL,          "0600" );
+  int          keep       = fd_env_strip_cmdline_int  ( &argc, &argv, "--keep",       NULL,               0 );
+  ulong        worker_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--worker-cnt", NULL,   fd_tile_cnt() );
+  char const * _wksp      = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",       NULL,            NULL );
+  char const * _page_sz   = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",    NULL,      "gigantic" );
+  ulong        page_cnt   = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",   NULL,             1UL );
+  ulong        near_cpu   = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",   NULL, fd_log_cpu_id() );
+  ulong        iter_max   = fd_env_strip_cmdline_ulong( &argc, &argv, "--iter-max",   NULL,           100UL );
+
+  char tmp_path[256];
+  if( !path ) path = fd_cstr_printf( tmp_path, 256UL, NULL, "/tmp/test_wksp_tpool.%lu.%li", fd_log_group_id(), fd_log_wallclock() );
+
+  ulong mode = fd_cstr_to_ulong_octal( _mode );
+
+  FD_LOG_NOTICE(( "Using --path %s --mode 0%03lo --keep %i", path, mode, keep ));
+
+  FD_LOG_NOTICE(( "Creating thread pool (--worker-cnt %lu)", worker_cnt ));
+  static uchar _tpool[ FD_TPOOL_FOOTPRINT(FD_TILE_MAX) ] __attribute__((aligned(FD_TPOOL_ALIGN)));
+  fd_tpool_t * tpool = fd_tpool_init( _tpool, worker_cnt ); /* logs details */
+  if( FD_UNLIKELY( !tpool ) ) FD_LOG_ERR(( "fd_tpool_init failed" ));
+
+  FD_LOG_NOTICE(( "Adding tiles as workers to thread pool" ));
+
+  for( ulong worker_idx=1UL; worker_idx<worker_cnt; worker_idx++ )
+    if( FD_UNLIKELY( !fd_tpool_worker_push( tpool, worker_idx, NULL, 0UL ) ) ) FD_LOG_ERR(( "fd_tpool_worker_push failed" ));
+
+  FD_LOG_NOTICE(( "Creating random number generators" ));
+
+  static fd_rng_t * _rng[ FD_TILE_MAX ];
+  FD_FOR_ALL( rng_init, tpool, 0UL, worker_cnt, 0L, (long)worker_cnt, _rng );
+  fd_rng_t * rng = _rng[0];
+
+  fd_wksp_t * wksp;
+  if( _wksp ) {
+    FD_LOG_NOTICE(( "Attaching to --wksp %s", _wksp ));
+    wksp = fd_wksp_attach( _wksp );
+  } else {
+    FD_LOG_NOTICE(( "--wksp not specified, using an anonymous local workspace (--page-sz %s --page-cnt %lu --near-cpu %lu)",
+                    _page_sz, page_cnt, near_cpu ));
+    wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
+  }
+
+  FD_LOG_NOTICE(( "Testing (--iter-max %lu)", iter_max ));
+
+  for( ulong iter=0UL; iter<iter_max; iter++ ) {
+    FD_LOG_NOTICE(( "iter %lu", iter ));
+
+    /* Reset the wksp and fill it with randomly aligned and sized allocations */
+
+    uint seed0 = fd_rng_uint( rng );
+    fd_wksp_reset( wksp, seed0 );
+
+#   define ALLOC_MAX (8192L)
+    static alloc_info_t info[ ALLOC_MAX ];
+
+    long alloc_cnt;
+    for( alloc_cnt=0L; alloc_cnt<ALLOC_MAX; alloc_cnt++ ) {
+      uint  mask   = (1U << fd_rng_uint_roll( rng, 21U )) - 1U; /* Pick a mask that is all ones in the N least significant bits
+                                                                   where N is uniform random in [0,20] */
+      ulong align  = 1UL << fd_rng_uint_roll( rng, 7U );        /* Pick a random alignment in 1,2,4,...64 */
+      ulong sz     = 1UL + (ulong)(fd_rng_uint( rng ) & mask);  /* Pick a random size power law distributed in [1,1MiB] */
+      ulong tag    = (ulong)(alloc_cnt+1L);                     /* Pick a unique non-zero tag for this allocation */
+      ulong gaddr0 = fd_wksp_alloc( wksp, align, sz, tag );     /* Do the allocation */
+      if( FD_UNLIKELY( !gaddr0 ) ) break;                       /* If wksp is full, we are done */
+      info[ alloc_cnt ].gaddr0 = gaddr0;                        /* Save alloc details for thread parallel use below */
+      info[ alloc_cnt ].sz     = sz;
+    }
+
+    /* Fill each allocations with a test pattern */
+
+    FD_FOR_ALL( alloc_init, tpool, 0UL, worker_cnt, 0L, alloc_cnt, wksp, info );
+
+    /* Blow away any existing file at path and then thread parallel
+       checkpt the wksp to path with a random style */
+
+    unlink( path );
+
+    ulong t0    = 0UL;
+    ulong t1    = 1UL + fd_rng_ulong_roll( rng, worker_cnt );
+    int   style = (int)fd_rng_uint_roll( rng, FD_HAS_LZ4 ? 4U : 3U );
+
+    FD_TEST( !fd_wksp_checkpt_tpool( tpool, t0, t1, wksp, path, mode, style, "test_wksp_tpool" ) );
+
+    /* Zero out all the allocations */
+
+    FD_FOR_ALL( alloc_zero, tpool,0UL,worker_cnt, 0L,alloc_cnt, wksp, info );
+
+    /* Restore the wksp from the checkpt using a different range of
+       threads and seed. */
+
+    ulong t2    = 0UL;
+    ulong t3    = 1UL + fd_rng_ulong_roll( rng, worker_cnt );
+    uint  seed1 = fd_rng_uint( rng );
+    FD_TEST( !fd_wksp_restore_tpool( tpool, t2, t3, wksp, path, seed1 ) );
+
+    /* Test all the allocations are as expected */
+
+    FD_FOR_ALL( alloc_test, tpool,0UL,worker_cnt, 0L,alloc_cnt, wksp, info, _rng );
+
+    /* TODO: TEST THERE ARE NO OTHER ALLOCATIONS IN THE WKSP TOO! */
+  }
+
+  FD_LOG_NOTICE(( "Cleaning up" ));
+
+  if( FD_LIKELY( !keep ) && FD_UNLIKELY( unlink( path ) ) )
+    FD_LOG_WARNING(( "unlink(%s) failed (%i-%s); attempting to continue", path, errno, fd_io_strerror( errno ) ));
+
+  if( _wksp ) fd_wksp_detach( wksp );
+  else        fd_wksp_delete_anonymous( wksp );
+
+  FD_FOR_ALL( rng_fini, tpool,0UL,worker_cnt, 0L,(long)worker_cnt, _rng );
+
+  /* Note: fini automatically pops all worker threads */
+
+  fd_tpool_fini( tpool ); /* logs details */
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
Very few top level changes:

- The raw style is now called the v1 style (the raw style macro still exists for backward compat) but is otherwise unchanged (i.e. should backward compatible with existing wksp checkpts).

- Added v2 (uncompressed) and v3 (compressed) styles.

- Preview function API refined for more general usages across all versions (this required minor changes to the one place outside wksp where preview was getting called).  Updated apps accordingly.

Under the hood, v2 and v3 formats have many useful properties for fast checkpt / restore performance and for long term archival purposes (these semantics are also usable for ultra high performance snapshot distribution and recovery).

- v2/v3 support writing a checkpt with an arbitrary number parallel threads and restoring with an arbitrary and potentially different number of parallel threads.  Thus performance can be scaled out to theoretical memory or network bandwidth (v2) and compression library (v3) limits.  (Currently only thread parallelization of v2 restore is implemented but that is by far the most important case practically.)

- The v2 and v3 wksp allocation data frames will further be bit level identical regardless of the number of threads used on checkpt / restore.

- While v2/v3 metadata (which store information about the environment in which the checkpt was made among other things) obviously can vary from run-to-run and host-to-host, this information can quickly identified and ignored without having to process the whole checkpt.

- These two features make it much easier to have multiple hosts create what should be bit-level identical checkpt files and then distribute them torrent style from multiple servers to multiple clients concurrently (and thus avoid having a network hot spot on a single server with the "blessed" checkpt).

- Thus, at one extreme, a huge v3 (compressed) checkpoint can be written directly out a network socket zero copy / single pass / single threaded / O(1) scratch memory and read from an archival copy of the checkpoint in DRAM via zero copy memory mapped I/O with as many parallel threads to restore.  And similarly for the other extreme (and all intermediate combinations).

- Current checkpt implementation load balances over multiple parallel restore threads via a high performance approximation to a greedy load balance algorithm.  Restore implementation uses a taskq model for further load balancing restores.

- Tweaked wksp allocation to always use fully trimmed partitions for an allocation such that there isn't a lot of waste in a wksp checkpt.  (Previous behavior would allow an allocation request to use an untrimmed or partially trimmed partition if part_max was inadequate.  But these can be arbitrarily sized which then can bloat a checkpt if checkpointing a wksp with all partitions full.)

- Added a supported-styles command to fd_wksp_ctl to identify which styles are supported on the target.

- Based on the recent checkpt API additions.

- Minor whitespace cleanups and fixed missing return in fd_wksp_usage.

Lower level APIs were improved to support implementing this cleanly.  This includes checkpt API improvements (including optimizing handling of checkpoint metadata versus bulk data) and io APIs improvements (including portable memory mapped IO APIs),  See the include commits for more details.