### PR TITLE
build: link libsecp256k1.a

### DIFF
--- a/config/extra/with-secp256k1.mk
+++ b/config/extra/with-secp256k1.mk
@@ -1,6 +1,7 @@
 ifneq (,$(wildcard $(OPT)/lib/libsecp256k1.a))
 FD_HAS_SECP256K1:=1
 CFLAGS+=-DFD_HAS_SECP256K1=1
+LDFLAGS+=$(OPT)/lib/libsecp256k1.a
 SECP256K1_LIBS:=$(OPT)/lib/libsecp256k1.a
 else
 $(warning "secp256k1 not installed, skipping")


### PR DESCRIPTION
using the secp256k1 extra does not add the linker flag `LDFLAGS+=$(OPT)/lib/libsecp256k1.a` required for linking