### PR TITLE
syscalls: fix fuzz issues

### DIFF
--- a/src/flamenco/vm/fd_vm_private.h
+++ b/src/flamenco/vm/fd_vm_private.h
@@ -508,12 +508,12 @@ static inline void fd_vm_mem_st_8( fd_vm_t const * vm,
     ulong           _vaddr    = (vaddr);                                                                    \
     int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _vaddr, (align) )); \
     ulong           _haddr    = fd_vm_mem_haddr( vm, _vaddr, (sz), _vm->region_haddr, _vm->region_ld_sz, 0, 0UL, &_is_multi ); \
-    if( FD_UNLIKELY( (!_haddr) | _is_multi) ) {                                                             \
-      FD_VM_ERR_FOR_LOG_EBPF( _vm, FD_VM_ERR_EBPF_ACCESS_VIOLATION );                                       \
-      return FD_VM_ERR_SIGSEGV;                                                                             \
-    }                                                                                                       \
     if ( FD_UNLIKELY( sz > LONG_MAX ) ) {                                                                   \
       FD_VM_ERR_FOR_LOG_SYSCALL( _vm, FD_VM_ERR_SYSCALL_INVALID_LENGTH );                                   \
+      return FD_VM_ERR_SIGSEGV;                                                                             \
+    }                                                                                                       \
+    if( FD_UNLIKELY( (!_haddr) | _is_multi) ) {                                                             \
+      FD_VM_ERR_FOR_LOG_EBPF( _vm, FD_VM_ERR_EBPF_ACCESS_VIOLATION );                                       \
       return FD_VM_ERR_SIGSEGV;                                                                             \
     }                                                                                                       \
     if ( FD_UNLIKELY( _sigbus ) ) {                                                                         \
@@ -537,12 +537,12 @@ static inline void fd_vm_mem_st_8( fd_vm_t const * vm,
     ulong           _vaddr    = (vaddr);                                                                    \
     int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _vaddr, (align) )); \
     ulong           _haddr    = fd_vm_mem_haddr( vm, _vaddr, (sz), _vm->region_haddr, _vm->region_st_sz, 1, 0UL, &_is_multi ); \
-    if( FD_UNLIKELY( (!_haddr) | _is_multi) ) {                                                             \
-      FD_VM_ERR_FOR_LOG_EBPF( _vm, FD_VM_ERR_EBPF_ACCESS_VIOLATION );                                       \
-      return FD_VM_ERR_SIGSEGV;                                                                             \
-    }                                                                                                       \
     if ( FD_UNLIKELY( sz > LONG_MAX ) ) {                                                                   \
       FD_VM_ERR_FOR_LOG_SYSCALL( _vm, FD_VM_ERR_SYSCALL_INVALID_LENGTH );                                   \
+      return FD_VM_ERR_SIGSEGV;                                                                             \
+    }                                                                                                       \
+    if( FD_UNLIKELY( (!_haddr) | _is_multi) ) {                                                             \
+      FD_VM_ERR_FOR_LOG_EBPF( _vm, FD_VM_ERR_EBPF_ACCESS_VIOLATION );                                       \
       return FD_VM_ERR_SIGSEGV;                                                                             \
     }                                                                                                       \
     if ( FD_UNLIKELY( _sigbus ) ) {                                                                         \
@@ -558,12 +558,12 @@ static inline void fd_vm_mem_st_8( fd_vm_t const * vm,
     ulong           _vaddr    = (vaddr);                                                                    \
     int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _vaddr, (align) )); \
     ulong           _haddr    = fd_vm_mem_haddr( vm, _vaddr, (sz), _vm->region_haddr, _vm->region_ld_sz, 0, 0UL, &_is_multi ); \
-    if( FD_UNLIKELY( (!_haddr) | _is_multi ) ) {                                                            \
-      FD_VM_ERR_FOR_LOG_EBPF( _vm, FD_VM_ERR_EBPF_ACCESS_VIOLATION );                                       \
-      return FD_VM_ERR_SIGSEGV;                                                                             \
-    }                                                                                                       \
     if ( FD_UNLIKELY( sz > LONG_MAX ) ) {                                                                   \
       FD_VM_ERR_FOR_LOG_SYSCALL( _vm, FD_VM_ERR_SYSCALL_INVALID_LENGTH );                                   \
+      return FD_VM_ERR_SIGSEGV;                                                                             \
+    }                                                                                                       \
+    if( FD_UNLIKELY( (!_haddr) | _is_multi ) ) {                                                            \
+      FD_VM_ERR_FOR_LOG_EBPF( _vm, FD_VM_ERR_EBPF_ACCESS_VIOLATION );                                       \
       return FD_VM_ERR_SIGSEGV;                                                                             \
     }                                                                                                       \
     if ( FD_UNLIKELY( _sigbus ) ) {                                                                         \


### PR DESCRIPTION
- order of invalid length vs access violation
- order of exec vs mem mapping in syscall curve family
- msm special case with points_len==0