### PR TITLE
quic: remove fd_quic_stream_send gather list

### DIFF
--- a/src/app/fddev/tiles/fd_benchs.c
+++ b/src/app/fddev/tiles/fd_benchs.c
@@ -428,13 +428,10 @@ during_frag( void * _ctx,
       return;
     } else {
       int fin = 1;
-      fd_aio_pkt_info_t   batch[1]  = { { .buf    = fd_chunk_to_laddr( ctx->mem, chunk ),
-                                          .buf_sz = (ushort)sz } };
-      ulong               batch_cnt = 1;
-      int rtn = fd_quic_stream_send( stream, batch, batch_cnt, fin );
+      int rtn = fd_quic_stream_send( stream, fd_chunk_to_laddr( ctx->mem, chunk ), sz, fin );
       ctx->packet_cnt++;
 
-      if( FD_LIKELY( rtn == 1UL ) ) {
+      if( FD_LIKELY( rtn == FD_QUIC_SUCCESS ) ) {
         /* after using, fetch a new stream */
         ctx->stream = stream = fd_quic_conn_new_stream( ctx->quic_conn, FD_QUIC_TYPE_UNIDIR );
         if( FD_LIKELY( stream ) ) {

--- a/src/app/fddev/txn.c
+++ b/src/app/fddev/txn.c
@@ -14,7 +14,7 @@ FD_IMPORT_BINARY(sample_transaction, "src/waltz/quic/tests/quic_txn.bin");
 
 static int g_conn_hs_complete = 0;
 static int g_conn_final = 0;
-static int g_stream_notify = 0;
+static ulong g_stream_notify = 0UL;
 
 #define MAX_TXN_COUNT 128
 
@@ -70,7 +70,7 @@ cb_stream_notify( fd_quic_stream_t * stream,
   (void)stream;
   (void)stream_ctx;
   (void)notify_type;
-  g_stream_notify = 1;
+  g_stream_notify += 1;
 }
 
 static void
@@ -97,20 +97,25 @@ send_quic_transactions( fd_quic_t *         quic,
   if( FD_UNLIKELY( conn->state != FD_QUIC_CONN_STATE_ACTIVE ) )
     FD_LOG_ERR(( "unable to connect to QUIC endpoint at "FD_IP4_ADDR_FMT":%hu, is it running? state is %d", FD_IP4_ADDR_FMT_ARGS(dst_ip), dst_port, conn->state ));
 
-  fd_quic_stream_t * stream = fd_quic_conn_new_stream( conn, FD_QUIC_TYPE_UNIDIR );
-  FD_TEST( stream );
-
   ulong sent = 0;
-  while( sent < count ) {
-    int res = fd_quic_stream_send( stream, pkt + sent, count - sent, 1 );
-    if( FD_UNLIKELY( res < 0 ) ) FD_LOG_ERR(( "fd_quic_stream_send failed (%d)", res ));
-    sent += (ulong)res;
+  while( sent < count && !g_conn_final ) {
+    fd_quic_stream_t * stream = fd_quic_conn_new_stream( conn, FD_QUIC_TYPE_UNIDIR );
+    if( FD_UNLIKELY( !stream ) ) {
+      fd_quic_service( quic );
+      fd_quic_udpsock_service( udpsock );
+      continue;
+    }
+
+    fd_aio_pkt_info_t * chunk = pkt + sent;
+    int res = fd_quic_stream_send( stream, chunk->buf, chunk->buf_sz, 1 );
+    if( FD_UNLIKELY( res != FD_QUIC_SUCCESS ) ) FD_LOG_ERR(( "fd_quic_stream_send failed (%d)", res ));
+    sent += 1UL;
 
     fd_quic_service( quic );
     fd_quic_udpsock_service( udpsock );
   }
 
-  while ( FD_UNLIKELY( !( g_stream_notify || g_conn_final ) ) ) {
+  while( FD_LIKELY( g_stream_notify!=count && !g_conn_final ) ) {
     fd_quic_service( quic );
     fd_quic_udpsock_service( udpsock );
   }

--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -998,11 +998,11 @@ fd_quic_conn_new_stream( fd_quic_conn_t * conn,
 
 int
 fd_quic_stream_send( fd_quic_stream_t *  stream,
-                     fd_aio_pkt_info_t * batch,
-                     ulong               batch_sz,
+                     void const *        data,
+                     ulong               data_sz,
                      int                 fin ) {
   if( FD_UNLIKELY( stream->state & FD_QUIC_STREAM_STATE_TX_FIN ) ) {
-    return FD_QUIC_SEND_ERR_STREAM_FIN;
+    return FD_QUIC_SEND_ERR_FIN;
   }
 
   fd_quic_conn_t * conn = stream->conn;
@@ -1032,32 +1032,21 @@ fd_quic_stream_send( fd_quic_stream_t *  stream,
   ulong allowed_conn   = conn->tx_max_data - conn->tx_tot_data;
   ulong allowed        = allowed_conn < allowed_stream ? allowed_conn : allowed_stream;
   ulong allocated      = 0UL;
-  ulong buffers_queued = 0;
 
-  /* visit each buffer in batch and store in tx_buf if there is sufficient
-     space */
-  for( ulong j=0; j<batch_sz; ++j ) {
-    ulong         data_sz = batch[j].buf_sz;
-    uchar const * data    = batch[j].buf;
-
-    if( data_sz > fd_quic_buffer_avail( tx_buf ) ) {
-      break;
-    }
-
-    if( data_sz + allocated > allowed ) {
-      break;
-    }
-
-    /* store data from data into tx_buf
-       this stores, but does not move the head offset */
-    fd_quic_buffer_store( tx_buf, data, data_sz );
-
-    /* advance head */
-    tx_buf->head += data_sz;
-
-    /* account for buffers sent/queued */
-    buffers_queued++;
+  if( data_sz > fd_quic_buffer_avail( tx_buf ) ) {
+    return FD_QUIC_SEND_ERR_FLOW;
   }
+
+  if( data_sz + allocated > allowed ) {
+    return FD_QUIC_SEND_ERR_FLOW;
+  }
+
+  /* store data from data into tx_buf
+      this stores, but does not move the head offset */
+  fd_quic_buffer_store( tx_buf, data, data_sz );
+
+  /* advance head */
+  tx_buf->head += data_sz;
 
   /* adjust flow control limits on stream and connection */
   stream->tx_tot_data += allocated;
@@ -1073,18 +1062,14 @@ fd_quic_stream_send( fd_quic_stream_t *  stream,
 
   /* don't actually set fin flag if we didn't add the last
      byte to the buffer */
-  if( fin && buffers_queued==batch_sz ) {
+  if( fin ) {
     fd_quic_stream_fin( stream );
-  }
-
-  if( batch_sz>0 && buffers_queued==0 ) {
-    return 0;
   }
 
   /* schedule send */
   fd_quic_reschedule_conn( conn, 0 );
 
-  return (int)buffers_queued;
+  return FD_QUIC_SUCCESS;
 }
 
 void

--- a/src/waltz/quic/fd_quic.h
+++ b/src/waltz/quic/fd_quic.h
@@ -549,15 +549,15 @@ FD_QUIC_API fd_quic_stream_t *
 fd_quic_conn_new_stream( fd_quic_conn_t * conn,
                          int              type );
 
-/* fd_quic_stream_send sends a vector of buffers on a stream in order.
+/* fd_quic_stream_send sends a chunk on a stream in order.
 
    Use fd_quic_conn_new_stream to create a new stream for sending
    or use the new stream callback to obtain a stream for replying.
 
    args
      stream         the stream to send on
-     batch          a pointer to an array of buffers
-     batch_sz       the size of the batch
+     data           points to first byte of buffer (ignored if data_sz==0)
+     data_sz        number of bytes to send
      fin            final: bool
                       set to indicate the stream is finalized by the last byte
                       in the batch
@@ -566,12 +566,12 @@ fd_quic_conn_new_stream( fd_quic_conn_t * conn,
                         or via the fd_quic_stream_fin(...) function
 
    returns
-     >=0   number of buffers sent - remaining blocked
+       0   success
       <0   one of FD_QUIC_SEND_ERR_{INVAL_STREAM,INVAL_CONN,AGAIN} */
 FD_QUIC_API int
 fd_quic_stream_send( fd_quic_stream_t *  stream,
-                     fd_aio_pkt_info_t * batch,
-                     ulong               batch_sz,
+                     void const *        data,
+                     ulong               data_sz,
                      int                 fin );
 
 /* fd_quic_stream_fin: finish sending on a stream.  Called to signal

--- a/src/waltz/quic/fd_quic_enum.h
+++ b/src/waltz/quic/fd_quic_enum.h
@@ -53,11 +53,13 @@
    ...INVAL_STREAM: Not allowed to send for stream ID (e.g. not open)
    ...INVAL_CONN:   Connection not in valid state for sending
    ...FIN:          Not allowed to send, stream finished
-   ...STREAM_STATE: Stream is not (yet) in valid state to send */
+   ...STREAM_STATE: Stream is not (yet) in valid state to send
+   ...FLOW:         Out of buffer space, retry later */
 #define FD_QUIC_SEND_ERR_INVAL_STREAM (-1)
 #define FD_QUIC_SEND_ERR_INVAL_CONN   (-2)
-#define FD_QUIC_SEND_ERR_STREAM_FIN   (-3)
-#define FD_QUIC_SEND_ERR_STREAM_STATE (-3)
+#define FD_QUIC_SEND_ERR_FIN          (-3)
+#define FD_QUIC_SEND_ERR_STREAM_STATE (-4)
+#define FD_QUIC_SEND_ERR_FLOW         (-5)
 
 /* FD_QUIC_MIN_CONN_ID_CNT: min permitted conn ID count per conn */
 #define FD_QUIC_MIN_CONN_ID_CNT (4UL)

--- a/src/waltz/quic/tests/arp/test_quic_arp_client.c
+++ b/src/waltz/quic/tests/arp/test_quic_arp_client.c
@@ -106,16 +106,13 @@ send_fibre_main( void * vp_args ) {
     }
 
     /* attempt to send to server */
-    int               fin       = 0;
-    char              request[] = "request";
-    fd_aio_pkt_info_t batch[1]  = {{ .buf = request, .buf_sz = sizeof( request ) }};
-    ulong             batch_sz  = 1UL;
-
-    int rc = fd_quic_stream_send( client_stream, batch, batch_sz, fin );
+    int  fin       = 0;
+    char request[] = "request";
+    int rc = fd_quic_stream_send( client_stream, request, sizeof(request), fin );
 
     FD_LOG_WARNING(( "CLIENT fd_quic_stream_send returned %d", rc ));
 
-    FD_TEST( rc == 1 );
+    FD_TEST( rc == 0 );
 
     ulong DURATION = (ulong)100e6;
     next_send_time = now + DURATION;

--- a/src/waltz/quic/tests/arp/test_quic_arp_server.c
+++ b/src/waltz/quic/tests/arp/test_quic_arp_server.c
@@ -43,11 +43,9 @@ my_stream_receive_cb( fd_quic_stream_t * stream,
   /* send back "received" */
   int               send_fin = 0UL; /* do not close stream */
   char              reply[]  = "received";
-  fd_aio_pkt_info_t batch[1] = {{ .buf = reply, .buf_sz = sizeof( reply ) }};
-  ulong             batch_sz = 1UL;
 
-  int rc = fd_quic_stream_send( stream, batch, batch_sz, send_fin );
-  if( rc != 1 ) {
+  int rc = fd_quic_stream_send( stream, reply, sizeof(reply), send_fin );
+  if( rc!=FD_QUIC_SUCCESS ) {
     FD_LOG_WARNING(( "SERVER fd_quic_stream_send failed. rc: %d", rc ));
   }
 

--- a/src/waltz/quic/tests/fd_quic_stream_spam.h
+++ b/src/waltz/quic/tests/fd_quic_stream_spam.h
@@ -3,12 +3,6 @@
 
 #include "../fd_quic.h"
 
-/* fd_quic_stream_spam_t is a simple load generator that sends sub-MTU
-   size unidirectional streams at max rate. */
-
-struct fd_quic_stream_spam_private;
-typedef struct fd_quic_stream_spam_private fd_quic_stream_spam_t;
-
 /* fd_quic_stream_gen_spam_t is a virtual fn that generates a random
    stream buffer to be sent given a stream ID.  pkt points to a packet
    info to be filled in.  On entry, pkt->buf is a writable buffer of
@@ -22,17 +16,21 @@ typedef void
                                fd_aio_pkt_info_t * pkt,
                                fd_quic_stream_t *  stream );
 
+/* fd_quic_stream_spam_t is a simple load generator that sends sub-MTU
+   size unidirectional streams at max rate. */
+
+struct fd_quic_stream_spam_private {
+  fd_quic_stream_gen_spam_t gen_fn;
+  void *                    gen_ctx;
+  fd_quic_stream_t *        stream;
+};
+
+typedef struct fd_quic_stream_spam_private fd_quic_stream_spam_t;
+
 FD_PROTOTYPES_BEGIN
-
-ulong
-fd_quic_stream_spam_align( void );
-
-ulong
-fd_quic_stream_spam_footprint( ulong stream_cnt );
 
 void *
 fd_quic_stream_spam_new( void *                    mem,
-                         ulong                     stream_cnt,
                          fd_quic_stream_gen_spam_t gen_fn,
                          void *                    gen_ctx );
 

--- a/src/waltz/quic/tests/test_quic_bw.c
+++ b/src/waltz/quic/tests/test_quic_bw.c
@@ -180,9 +180,7 @@ main( int     argc,
   FD_TEST( client_stream );
 
   char buf[ 1232UL ] = "Hello world!\x00-   ";
-  ulong buf_sz = sizeof(buf);
-  fd_aio_pkt_info_t batch[1] = {{ buf, (ushort)buf_sz }};
-  int rc = fd_quic_stream_send( client_stream, batch, 1, 1 );
+  int rc = fd_quic_stream_send( client_stream, buf, sizeof(buf), 1 );
   FD_LOG_INFO(( "fd_quic_stream_send returned %d", rc ));
 
   long last_ts = fd_log_wallclock();
@@ -196,7 +194,7 @@ main( int     argc,
 
     client_stream = fd_quic_conn_new_stream( client_conn, FD_QUIC_TYPE_UNIDIR );
     if( !client_stream ) continue;
-    fd_quic_stream_send( client_stream, batch, 1, 1 );
+    fd_quic_stream_send( client_stream, buf, sizeof(buf), 1 );
 
     long t = fd_log_wallclock();
     if( t >= rprt_ts ) {

--- a/src/waltz/quic/tests/test_quic_client_flood.c
+++ b/src/waltz/quic/tests/test_quic_client_flood.c
@@ -192,10 +192,11 @@ run_quic_client(
     for( ulong j = 0; j < batch_sz; ++j ) {
 
       if( cur_stream ) {
-        int rc = fd_quic_stream_send( cur_stream, batches[msg_sz - MSG_SZ_MIN], 1 /* batch_sz */, 1 /* fin */ ); /* fin: close stream after sending. last byte of transmission */
+        fd_aio_pkt_info_t * chunk = batches[msg_sz - MSG_SZ_MIN];
+        int rc = fd_quic_stream_send( cur_stream, chunk->buf, chunk->buf_sz, 1 /* fin */ ); /* fin: close stream after sending. last byte of transmission */
         FD_LOG_DEBUG(( "fd_quic_stream_send returned %d", rc ));
 
-        if( rc == 1 ) {
+        if( rc == FD_QUIC_SUCCESS ) {
           sent++;
           /* successful - stream will begin closing */
           /* stream and meta will be recycled when quic notifies the stream

--- a/src/waltz/quic/tests/test_quic_conn.c
+++ b/src/waltz/quic/tests/test_quic_conn.c
@@ -374,7 +374,6 @@ main( int argc, char ** argv ) {
   populate_stream_meta( quic_limits.stream_cnt[ FD_QUIC_STREAM_TYPE_UNI_CLIENT ] );
 
   char buf[512] = "Hello world!\x00-   ";
-  fd_aio_pkt_info_t batch[1] = {{ buf, sizeof( buf ) }};
 
   int done  = 0;
 
@@ -412,9 +411,9 @@ main( int argc, char ** argv ) {
 
           FD_LOG_DEBUG(( "sending: %d", (int)k ));
 
-          int rc = fd_quic_stream_send( stream, batch, 1 /* batch_sz */, 1 /* fin */ );
+          int rc = fd_quic_stream_send( stream, buf, sizeof(buf), 1 /* fin */ );
 
-          if( rc == 1 ) {
+          if( rc == FD_QUIC_SUCCESS ) {
             /* successful - stream will begin closing */
             /* stream and meta will be recycled when quic notifies the stream
                is closed via my_stream_notify_cb */

--- a/src/waltz/quic/tests/test_quic_drops.c
+++ b/src/waltz/quic/tests/test_quic_drops.c
@@ -115,12 +115,12 @@ mitm_tx( void *                    ctx,
       }
       continue;
     }
-    
+
     /* send new packet */
     fd_aio_pkt_info_t batch_0[1] = { batch[j] };
     fd_aio_send( mitm_ctx->dst, batch_0, 1UL, NULL, 1 );
     PCAP(batch_0,1UL);
-      
+
     /* we aren't dropping or reordering, but we might have a prior reorder */
     if( mitm_ctx->reorder_sz > 0UL ) {
       fd_aio_pkt_info_t batch_1[1] = {{ .buf = mitm_ctx->reorder_buf, .buf_sz = (ushort)mitm_ctx->reorder_sz }};
@@ -284,7 +284,6 @@ client_fibre_fn( void * vp_arg ) {
   fd_quic_stream_t * stream = NULL;
 
   uchar buf[] = "Hello World!";
-  fd_aio_pkt_info_t batch[1] = {{ .buf = buf, .buf_sz = sizeof( buf ) }};
 
   ulong period_ns = (ulong)1e6;
   ulong next_send = now + period_ns;
@@ -367,9 +366,9 @@ client_fibre_fn( void * vp_arg ) {
     next_send = now + period_ns;
 
     /* have a stream, so send */
-    int rc = fd_quic_stream_send( stream, batch, 1 /* batch_sz */, 1 /* fin */ );
+    int rc = fd_quic_stream_send( stream, buf, sizeof(buf), 1 /* fin */ );
 
-    if( rc == 1 ) {
+    if( rc == FD_QUIC_SUCCESS ) {
       /* successful - stream will begin closing */
 
       if( ++sent % 15 == 0 ) {

--- a/src/waltz/quic/tests/test_quic_hs.c
+++ b/src/waltz/quic/tests/test_quic_hs.c
@@ -171,7 +171,6 @@ main( int argc, char ** argv ) {
   FD_LOG_NOTICE(( "Sending data over streams" ));
 
   char buf[512] = "Hello world!\x00-   ";
-  fd_aio_pkt_info_t batch[1] = {{ buf, sizeof( buf ) }};
 
   for( unsigned j = 0; j < 16; ++j ) {
     ulong ct = fd_quic_get_next_wakeup( client_quic );
@@ -195,9 +194,9 @@ main( int argc, char ** argv ) {
     buf[16] = (char)( ( j % 10 ) + '0' );
     int rc = 0;
     if( j&1 ) {
-      rc = fd_quic_stream_send( client_stream,   batch, 1, 0 );
+      rc = fd_quic_stream_send( client_stream,   buf, sizeof(buf), 0 );
     } else {
-      rc = fd_quic_stream_send( client_stream_0, batch, 1, 0 );
+      rc = fd_quic_stream_send( client_stream_0, buf, sizeof(buf), 0 );
     }
 
     FD_LOG_INFO(( "fd_quic_stream_send returned %d", rc ));

--- a/src/waltz/quic/tests/test_quic_key_phase.c
+++ b/src/waltz/quic/tests/test_quic_key_phase.c
@@ -241,8 +241,7 @@ client_fibre_fn( void * vp_arg ) {
   fd_quic_conn_t *   conn   = NULL;
   fd_quic_stream_t * stream = NULL;
 
-  uchar buf[] = "Hello World!";
-  fd_aio_pkt_info_t batch[1] = {{ .buf = buf, .buf_sz = sizeof( buf ) }};
+  static uchar const buf[] = "Hello World!";
 
   ulong period_ns = (ulong)1e6;
   ulong next_send = now;
@@ -336,9 +335,9 @@ client_fibre_fn( void * vp_arg ) {
     next_send = now + period_ns;
 
     /* have a stream, so send */
-    int rc = fd_quic_stream_send( stream, batch, 1 /* batch_sz */, 1 /* fin */ );
+    int rc = fd_quic_stream_send( stream, buf, sizeof(buf), 1 /* fin */ );
 
-    if( rc == 1 ) {
+    if( rc == FD_QUIC_SUCCESS ) {
       /* successful - stream will begin closing */
 
       /* ensure new stream used for next send */

--- a/src/waltz/quic/tests/test_quic_retry_integration.c
+++ b/src/waltz/quic/tests/test_quic_retry_integration.c
@@ -181,7 +181,6 @@ main( int argc, char ** argv ) {
   FD_LOG_NOTICE(( "Sending data over streams" ));
 
   char buf[512] = "Hello world!\x00-   ";
-  fd_aio_pkt_info_t batch[1] = {{ buf, sizeof( buf ) }};
 
   for( unsigned j = 0; j < 16; ++j ) {
     ulong ct = fd_quic_get_next_wakeup( client_quic );
@@ -205,9 +204,9 @@ main( int argc, char ** argv ) {
     buf[16] = (char)( ( j % 10 ) + '0' );
     int rc = 0;
     if( j&1 ) {
-      rc = fd_quic_stream_send( client_stream,   batch, 1, 0 );
+      rc = fd_quic_stream_send( client_stream,   buf, sizeof(buf), 0 );
     } else {
-      rc = fd_quic_stream_send( client_stream_0, batch, 1, 0 );
+      rc = fd_quic_stream_send( client_stream_0, buf, sizeof(buf), 0 );
     }
 
     FD_LOG_INFO(( "fd_quic_stream_send returned %d", rc ));


### PR DESCRIPTION
fd_quic_stream_send previously accepted a gather list of chunks.
All those chunks are then sent over the same stream.

This commit simplifies the API to instead only take one chunk.
A bug is fixed in fddev/txn.c that incorrectly sends multiple txns
over the same stream.
Otherwise, all other callers only sent one chunk per call anyways.
