### PR TITLE
ci: only test noarch64 on GCC 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: true
       matrix:
         test-case:
-          - linux_gcc_noarch64-gcc-12
           - linux_gcc_noarch64        # least capable target
           - linux_gcc_x86_64
           - linux_gcc_icelake         #  most capable target
@@ -28,15 +27,6 @@ jobs:
           - native-no-agave
         # Attach additional params to machine types
         include:
-          - test-case: linux_gcc_noarch64-gcc-12 
-            machine: linux_gcc_noarch64
-            label: X64
-            extras: rpath
-            targets: "all"
-            compiler: gcc
-            compiler-version: 12.4.0
-            run-unit-tests: false
-            run-integration-tests: false
           - test-case: linux_gcc_noarch64
             machine: linux_gcc_noarch64
             label: X64
@@ -133,7 +123,7 @@ jobs:
         run: |
           source /opt/${{ matrix.compiler }}/${{ matrix.compiler }}-${{ matrix.compiler-version }}/activate
           FIREDANCER_CI_COMMIT=none ./contrib/make-j ${{ matrix.targets }}
-      
+
       - name: run unit tests
         if: ${{ matrix.run-unit-tests }}
         run: |


### PR DESCRIPTION
There is little value in testing noarch64 on two GCC versions.
GCC 12 has plenty of coverage on other targets.
