### PR TITLE
syscalls: fix more fuzz mismatches

### DIFF
--- a/src/ballet/bn254/fd_bn254.c
+++ b/src/ballet/bn254/fd_bn254.c
@@ -257,6 +257,12 @@ fd_bn254_pairing_is_one_syscall( uchar       out[32],
       sz = 0;
     }
   }
+  if( sz>0 ) {
+    fd_bn254_fp12_t tmp[1];
+    fd_bn254_miller_loop( tmp, p, q, sz );
+    fd_bn254_fp12_mul( r, r, tmp );
+    sz = 0;
+  }
 
   /* Compute the final exponentiation */
   fd_bn254_final_exp( r, r );

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -1727,15 +1727,19 @@ fd_exec_vm_syscall_test_run( fd_exec_instr_test_runner_t * runner,
   if( input->has_exec_effects ){
     cpi_exec_effects = &input->exec_effects;
   }
-  uchar * rodata = input->vm_ctx.rodata ? input->vm_ctx.rodata->bytes : NULL;
+
   ulong rodata_sz = input->vm_ctx.rodata ? input->vm_ctx.rodata->size : 0UL;
+  uchar * rodata = fd_valloc_malloc( valloc, 8UL, rodata_sz );
+  if ( input->vm_ctx.rodata != NULL ) {
+    fd_memcpy( rodata, input->vm_ctx.rodata, rodata_sz );
+  }
 
   /* Load input data regions */
   fd_vm_input_region_t * input_regions = NULL;
   uint input_regions_count = 0U;
   if( !!(input->vm_ctx.input_data_regions_count) ) {
     input_regions       = fd_valloc_malloc( valloc, alignof(fd_vm_input_region_t), sizeof(fd_vm_input_region_t) * input->vm_ctx.input_data_regions_count );
-    input_regions_count = setup_vm_input_regions( input_regions, input->vm_ctx.input_data_regions, input->vm_ctx.input_data_regions_count );
+    input_regions_count = setup_vm_input_regions( input_regions, input->vm_ctx.input_data_regions, input->vm_ctx.input_data_regions_count, valloc );
     if ( !input_regions_count ) {
       goto error;
     }

--- a/src/flamenco/runtime/tests/fd_vm_test.c
+++ b/src/flamenco/runtime/tests/fd_vm_test.c
@@ -178,7 +178,7 @@ do{
 
   /* Load input data regions */
   fd_vm_input_region_t * input_regions     = fd_valloc_malloc( valloc, alignof(fd_vm_input_region_t), sizeof(fd_vm_input_region_t) * input->vm_ctx.input_data_regions_count );
-  uint                   input_regions_cnt = setup_vm_input_regions( input_regions, input->vm_ctx.input_data_regions, input->vm_ctx.input_data_regions_count );
+  uint                   input_regions_cnt = setup_vm_input_regions( input_regions, input->vm_ctx.input_data_regions, input->vm_ctx.input_data_regions_count, valloc );
 
   if (input->vm_ctx.heap_max > FD_VM_HEAP_DEFAULT) {
     break;
@@ -338,7 +338,8 @@ do{
 uint
 setup_vm_input_regions( fd_vm_input_region_t *                   input,
                         fd_exec_test_input_data_region_t const * test_input,
-                        ulong                                    test_input_count ) {
+                        ulong                                    test_input_count,
+                        fd_valloc_t                              valloc ) {
   ulong offset = 0UL;
   uint input_idx = 0UL;
   for( ulong i=0; i<test_input_count; i++ ) {
@@ -348,8 +349,10 @@ setup_vm_input_regions( fd_vm_input_region_t *                   input,
       continue; /* skip empty regions https://github.com/anza-xyz/agave/blob/3072c1a72b2edbfa470ca869f1ea891dfb6517f2/programs/bpf_loader/src/serialization.rs#L136 */
     }
 
+    uchar * haddr = fd_valloc_malloc( valloc, 8UL, array->size );
+    fd_memcpy( haddr, array->bytes, array->size );
     input[input_idx].vaddr_offset     = offset;
-    input[input_idx].haddr            = (ulong)array->bytes;
+    input[input_idx].haddr            = (ulong)haddr;
     input[input_idx].region_sz        = array->size;
     input[input_idx].is_writable      = region->is_writable;
 

--- a/src/flamenco/runtime/tests/fd_vm_test.h
+++ b/src/flamenco/runtime/tests/fd_vm_test.h
@@ -47,7 +47,8 @@ setup_vm_acc_region_metas( fd_vm_acc_region_meta_t * acc_regions_meta,
 uint
 setup_vm_input_regions( fd_vm_input_region_t *                   input,
                        fd_exec_test_input_data_region_t const * test_input,
-                       ulong                                    test_input_count );
+                       ulong                                    test_input_count,
+                       fd_valloc_t                              valloc );
 
 ulong
 load_from_vm_input_regions( fd_vm_input_region_t const *        input,

--- a/src/flamenco/types/fd_types.h
+++ b/src/flamenco/types/fd_types.h
@@ -405,13 +405,13 @@ typedef struct fd_solana_account_stored_meta_off fd_solana_account_stored_meta_o
 #define FD_SOLANA_ACCOUNT_STORED_META_OFF_FOOTPRINT sizeof(fd_solana_account_stored_meta_off_t)
 #define FD_SOLANA_ACCOUNT_STORED_META_OFF_ALIGN (8UL)
 
-/* Encoded Size: Fixed (56 bytes) */
+/* Encoded Size: Fixed (52 bytes) */
 struct __attribute__((packed)) fd_solana_account_meta {
   ulong lamports;
   ulong rent_epoch;
   uchar owner[32];
   uchar executable;
-  uchar padding[7];
+  uchar padding[3];
 };
 typedef struct fd_solana_account_meta fd_solana_account_meta_t;
 #define FD_SOLANA_ACCOUNT_META_FOOTPRINT sizeof(fd_solana_account_meta_t)
@@ -432,6 +432,7 @@ typedef struct fd_solana_account_meta_off fd_solana_account_meta_off_t;
 struct __attribute__((packed)) fd_solana_account_hdr {
   fd_solana_account_stored_meta_t meta;
   fd_solana_account_meta_t info;
+  uchar padding[4];
   fd_hash_t hash;
 };
 typedef struct fd_solana_account_hdr fd_solana_account_hdr_t;
@@ -441,6 +442,7 @@ typedef struct fd_solana_account_hdr fd_solana_account_hdr_t;
 struct __attribute__((packed)) fd_solana_account_hdr_off {
   uint meta_off;
   uint info_off;
+  uint padding_off;
   uint hash_off;
 };
 typedef struct fd_solana_account_hdr_off fd_solana_account_hdr_off_t;

--- a/src/flamenco/types/fd_types.json
+++ b/src/flamenco/types/fd_types.json
@@ -212,7 +212,7 @@
         { "name": "rent_epoch", "type": "ulong" },
         { "name": "owner", "type": "uchar[32]" },
         { "name": "executable", "type": "bool" },
-        { "name": "padding", "type": "array", "element": "uchar", "length": 7 }
+        { "name": "padding", "type": "array", "element": "uchar", "length": 3 }
       ]
     },
     {
@@ -222,6 +222,7 @@
       "fields": [
         { "name": "meta", "type": "solana_account_stored_meta" },
         { "name": "info", "type": "solana_account_meta" },
+        { "name": "padding", "type": "array", "element": "uchar", "length": 4 },
         { "name": "hash", "type": "hash" }
       ]
     },

--- a/src/flamenco/vm/fd_vm_private.h
+++ b/src/flamenco/vm/fd_vm_private.h
@@ -518,8 +518,8 @@ static inline void fd_vm_mem_st_8( fd_vm_t const * vm,
     fd_vm_t const * _vm       = (vm);                                                                       \
     uchar           _is_multi = 0;                                                                          \
     ulong           _vaddr    = (vaddr);                                                                    \
-    int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _vaddr, (align) )); \
     ulong           _haddr    = fd_vm_mem_haddr( vm, _vaddr, (sz), _vm->region_haddr, _vm->region_ld_sz, 0, 0UL, &_is_multi ); \
+    int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _haddr, (align) )); \
     if ( FD_UNLIKELY( sz > LONG_MAX ) ) {                                                                   \
       FD_VM_ERR_FOR_LOG_SYSCALL( _vm, FD_VM_ERR_SYSCALL_INVALID_LENGTH );                                   \
       return FD_VM_ERR_SIGSEGV;                                                                             \
@@ -547,8 +547,8 @@ static inline void fd_vm_mem_st_8( fd_vm_t const * vm,
     fd_vm_t const * _vm       = (vm);                                                                       \
     uchar           _is_multi = 0;                                                                          \
     ulong           _vaddr    = (vaddr);                                                                    \
-    int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _vaddr, (align) )); \
     ulong           _haddr    = fd_vm_mem_haddr( vm, _vaddr, (sz), _vm->region_haddr, _vm->region_st_sz, 1, 0UL, &_is_multi ); \
+    int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _haddr, (align) )); \
     if ( FD_UNLIKELY( sz > LONG_MAX ) ) {                                                                   \
       FD_VM_ERR_FOR_LOG_SYSCALL( _vm, FD_VM_ERR_SYSCALL_INVALID_LENGTH );                                   \
       return FD_VM_ERR_SIGSEGV;                                                                             \
@@ -568,8 +568,8 @@ static inline void fd_vm_mem_st_8( fd_vm_t const * vm,
     fd_vm_t const * _vm       = (vm);                                                                       \
     uchar           _is_multi = 0;                                                                          \
     ulong           _vaddr    = (vaddr);                                                                    \
-    int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _vaddr, (align) )); \
     ulong           _haddr    = fd_vm_mem_haddr( vm, _vaddr, (sz), _vm->region_haddr, _vm->region_ld_sz, 0, 0UL, &_is_multi ); \
+    int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _haddr, (align) )); \
     if ( FD_UNLIKELY( sz > LONG_MAX ) ) {                                                                   \
       FD_VM_ERR_FOR_LOG_SYSCALL( _vm, FD_VM_ERR_SYSCALL_INVALID_LENGTH );                                   \
       return FD_VM_ERR_SIGSEGV;                                                                             \

--- a/src/flamenco/vm/test_vm_base.c
+++ b/src/flamenco/vm/test_vm_base.c
@@ -1,7 +1,12 @@
 #include "fd_vm_private.h"
+#include <stddef.h>
+#include <assert.h>
 
 FD_STATIC_ASSERT( FD_VM_FOOTPRINT                       == sizeof( fd_vm_t ), vm_struct );
 FD_STATIC_ASSERT( FD_VM_ALIGN                           == alignof( fd_vm_t ), vm_struct );
+FD_STATIC_ASSERT( FD_VM_HOST_REGION_ALIGN               == alignof( fd_vm_t ), vm_struct );
+FD_STATIC_ASSERT( FD_VM_HOST_REGION_ALIGN               == offsetof( fd_vm_t, stack ) % FD_VM_HOST_REGION_ALIGN == 0, vm_struct );
+FD_STATIC_ASSERT( FD_VM_HOST_REGION_ALIGN               == offsetof( fd_vm_t, heap ) % FD_VM_HOST_REGION_ALIGN == 0, vm_struct );
 
 /* Verify error codes */
 

--- a/src/flamenco/vm/test_vm_base.c
+++ b/src/flamenco/vm/test_vm_base.c
@@ -5,8 +5,8 @@
 FD_STATIC_ASSERT( FD_VM_FOOTPRINT                       == sizeof( fd_vm_t ), vm_struct );
 FD_STATIC_ASSERT( FD_VM_ALIGN                           == alignof( fd_vm_t ), vm_struct );
 FD_STATIC_ASSERT( FD_VM_HOST_REGION_ALIGN               == alignof( fd_vm_t ), vm_struct );
-FD_STATIC_ASSERT( FD_VM_HOST_REGION_ALIGN               == offsetof( fd_vm_t, stack ) % FD_VM_HOST_REGION_ALIGN == 0, vm_struct );
-FD_STATIC_ASSERT( FD_VM_HOST_REGION_ALIGN               == offsetof( fd_vm_t, heap ) % FD_VM_HOST_REGION_ALIGN == 0, vm_struct );
+FD_STATIC_ASSERT( offsetof( fd_vm_t, stack ) % FD_VM_HOST_REGION_ALIGN == 0, vm_struct );
+FD_STATIC_ASSERT( offsetof( fd_vm_t, heap )  % FD_VM_HOST_REGION_ALIGN == 0, vm_struct );
 
 /* Verify error codes */
 


### PR DESCRIPTION
- [x] Memory alignment should be checked against host address, not virtual, see [Agave's code](https://github.com/anza-xyz/agave/blob/f9f8b60ca15fa721c6cdd816c99dfd4e9123fd77/programs/bpf_loader/src/syscalls/mod.rs#L586)
- [x] Pairing issue, if last component has P=0 or Q=0, last miller loop is skipped
- [x] Align mem regions to 16 bytes (some to 8)
- [x] Align mem regions in tests to 16 bytes (see https://github.com/firedancer-io/solfuzz-agave/pull/130)
