### PR TITLE
quic - removed incorrect line setting stream_cnt to stream_pool_cnt

### DIFF
--- a/src/waltz/quic/fd_quic_conn.c
+++ b/src/waltz/quic/fd_quic_conn.c
@@ -61,8 +61,6 @@ fd_quic_conn_footprint_ext( fd_quic_limits_t const * limits,
   if( FD_UNLIKELY( limits->initial_stream_cnt[2] > limits->stream_cnt[2] ) ) return 0UL;
   if( FD_UNLIKELY( limits->initial_stream_cnt[3] > limits->stream_cnt[3] ) ) return 0UL;
 
-  stream_cnt = layout->stream_cnt = limits->stream_pool_cnt;
-
   ulong off  = 0;
 
   off += sizeof( fd_quic_conn_t );


### PR DESCRIPTION
The bad line makes every connection allocate enough memory for a stream_map containing every stream in the pool plus some overhead per stream. This is unnecessary since only a tiny fraction of the streams are allowed in each connection stream_map.