### PR TITLE
flamenco, runtime: align all vm regions to 16-bytes

### DIFF
--- a/src/ballet/bn254/fd_bn254.c
+++ b/src/ballet/bn254/fd_bn254.c
@@ -257,6 +257,12 @@ fd_bn254_pairing_is_one_syscall( uchar       out[32],
       sz = 0;
     }
   }
+  if( sz>0 ) {
+    fd_bn254_fp12_t tmp[1];
+    fd_bn254_miller_loop( tmp, p, q, sz );
+    fd_bn254_fp12_mul( r, r, tmp );
+    sz = 0;
+  }
 
   /* Compute the final exponentiation */
   fd_bn254_final_exp( r, r );

--- a/src/flamenco/types/fd_types.h
+++ b/src/flamenco/types/fd_types.h
@@ -405,13 +405,13 @@ typedef struct fd_solana_account_stored_meta_off fd_solana_account_stored_meta_o
 #define FD_SOLANA_ACCOUNT_STORED_META_OFF_FOOTPRINT sizeof(fd_solana_account_stored_meta_off_t)
 #define FD_SOLANA_ACCOUNT_STORED_META_OFF_ALIGN (8UL)
 
-/* Encoded Size: Fixed (56 bytes) */
+/* Encoded Size: Fixed (52 bytes) */
 struct __attribute__((packed)) fd_solana_account_meta {
   ulong lamports;
   ulong rent_epoch;
   uchar owner[32];
   uchar executable;
-  uchar padding[7];
+  uchar padding[3];
 };
 typedef struct fd_solana_account_meta fd_solana_account_meta_t;
 #define FD_SOLANA_ACCOUNT_META_FOOTPRINT sizeof(fd_solana_account_meta_t)
@@ -432,6 +432,7 @@ typedef struct fd_solana_account_meta_off fd_solana_account_meta_off_t;
 struct __attribute__((packed)) fd_solana_account_hdr {
   fd_solana_account_stored_meta_t meta;
   fd_solana_account_meta_t info;
+  uchar padding[4];
   fd_hash_t hash;
 };
 typedef struct fd_solana_account_hdr fd_solana_account_hdr_t;
@@ -441,6 +442,7 @@ typedef struct fd_solana_account_hdr fd_solana_account_hdr_t;
 struct __attribute__((packed)) fd_solana_account_hdr_off {
   uint meta_off;
   uint info_off;
+  uint padding_off;
   uint hash_off;
 };
 typedef struct fd_solana_account_hdr_off fd_solana_account_hdr_off_t;

--- a/src/flamenco/types/fd_types.json
+++ b/src/flamenco/types/fd_types.json
@@ -212,7 +212,7 @@
         { "name": "rent_epoch", "type": "ulong" },
         { "name": "owner", "type": "uchar[32]" },
         { "name": "executable", "type": "bool" },
-        { "name": "padding", "type": "array", "element": "uchar", "length": 7 }
+        { "name": "padding", "type": "array", "element": "uchar", "length": 3 }
       ]
     },
     {
@@ -222,6 +222,7 @@
       "fields": [
         { "name": "meta", "type": "solana_account_stored_meta" },
         { "name": "info", "type": "solana_account_meta" },
+        { "name": "padding", "type": "array", "element": "uchar", "length": 4 },
         { "name": "hash", "type": "hash" }
       ]
     },

--- a/src/flamenco/vm/fd_vm_private.h
+++ b/src/flamenco/vm/fd_vm_private.h
@@ -518,8 +518,8 @@ static inline void fd_vm_mem_st_8( fd_vm_t const * vm,
     fd_vm_t const * _vm       = (vm);                                                                       \
     uchar           _is_multi = 0;                                                                          \
     ulong           _vaddr    = (vaddr);                                                                    \
-    int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _vaddr, (align) )); \
     ulong           _haddr    = fd_vm_mem_haddr( vm, _vaddr, (sz), _vm->region_haddr, _vm->region_ld_sz, 0, 0UL, &_is_multi ); \
+    int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _haddr, (align) )); \
     if ( FD_UNLIKELY( sz > LONG_MAX ) ) {                                                                   \
       FD_VM_ERR_FOR_LOG_SYSCALL( _vm, FD_VM_ERR_SYSCALL_INVALID_LENGTH );                                   \
       return FD_VM_ERR_SIGSEGV;                                                                             \
@@ -547,8 +547,8 @@ static inline void fd_vm_mem_st_8( fd_vm_t const * vm,
     fd_vm_t const * _vm       = (vm);                                                                       \
     uchar           _is_multi = 0;                                                                          \
     ulong           _vaddr    = (vaddr);                                                                    \
-    int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _vaddr, (align) )); \
     ulong           _haddr    = fd_vm_mem_haddr( vm, _vaddr, (sz), _vm->region_haddr, _vm->region_st_sz, 1, 0UL, &_is_multi ); \
+    int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _haddr, (align) )); \
     if ( FD_UNLIKELY( sz > LONG_MAX ) ) {                                                                   \
       FD_VM_ERR_FOR_LOG_SYSCALL( _vm, FD_VM_ERR_SYSCALL_INVALID_LENGTH );                                   \
       return FD_VM_ERR_SIGSEGV;                                                                             \
@@ -568,8 +568,8 @@ static inline void fd_vm_mem_st_8( fd_vm_t const * vm,
     fd_vm_t const * _vm       = (vm);                                                                       \
     uchar           _is_multi = 0;                                                                          \
     ulong           _vaddr    = (vaddr);                                                                    \
-    int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _vaddr, (align) )); \
     ulong           _haddr    = fd_vm_mem_haddr( vm, _vaddr, (sz), _vm->region_haddr, _vm->region_ld_sz, 0, 0UL, &_is_multi ); \
+    int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _haddr, (align) )); \
     if ( FD_UNLIKELY( sz > LONG_MAX ) ) {                                                                   \
       FD_VM_ERR_FOR_LOG_SYSCALL( _vm, FD_VM_ERR_SYSCALL_INVALID_LENGTH );                                   \
       return FD_VM_ERR_SIGSEGV;                                                                             \

--- a/src/flamenco/vm/test_vm_base.c
+++ b/src/flamenco/vm/test_vm_base.c
@@ -1,7 +1,12 @@
 #include "fd_vm_private.h"
+#include <stddef.h>
+#include <assert.h>
 
 FD_STATIC_ASSERT( FD_VM_FOOTPRINT                       == sizeof( fd_vm_t ), vm_struct );
 FD_STATIC_ASSERT( FD_VM_ALIGN                           == alignof( fd_vm_t ), vm_struct );
+FD_STATIC_ASSERT( FD_VM_HOST_REGION_ALIGN               == alignof( fd_vm_t ), vm_struct );
+FD_STATIC_ASSERT( FD_VM_HOST_REGION_ALIGN               == offsetof( fd_vm_t, stack ) % FD_VM_HOST_REGION_ALIGN == 0, vm_struct );
+FD_STATIC_ASSERT( FD_VM_HOST_REGION_ALIGN               == offsetof( fd_vm_t, heap ) % FD_VM_HOST_REGION_ALIGN == 0, vm_struct );
 
 /* Verify error codes */
 


### PR DESCRIPTION
All vm memory regions need to be 8-byte aligned. This has consensus implications - Agave's vm checks that host physical addresses are aligned during address translation. If the host address is unaligned than address translation will fail. We need to match this behaviour.

Direct mapping means that we have to ensure that the account data region of borrowed accounts are therefore 8-byte aligned.