### PR TITLE
Add format attributes to fd_log_collector_printf_<...> functions

### DIFF
--- a/src/flamenco/log_collector/fd_log_collector.h
+++ b/src/flamenco/log_collector/fd_log_collector.h
@@ -223,6 +223,7 @@ FD_STATIC_ASSERT( 2*FD_LOG_COLLECTOR_PRINTF_MAX_2B <= FD_LOG_COLLECTOR_EXTRA, "I
    we serialize msg_sz as a variable int, we must guarantee
    that msg_sz <= 127, i.e. fits in 1 byte, otherwise we'd have
    to memmove the log msg. */
+__attribute__ ((format (printf, 2, 3)))
 static inline void
 fd_log_collector_printf_dangerous_max_127( fd_exec_instr_ctx_t * ctx,
                                            char const * fmt, ... ) {
@@ -280,6 +281,7 @@ fd_log_collector_printf_dangerous_max_127( fd_exec_instr_ctx_t * ctx,
 
    Moreover, we need to guarantee that the log buf is big enough
    to fit the log msg.  Hence we further limit msg_sz < 2000. */
+__attribute__ ((format (printf, 2, 3)))
 static inline void
 fd_log_collector_printf_dangerous_128_to_2k( fd_exec_instr_ctx_t * ctx,
                                              char const * fmt, ... ) {
@@ -329,6 +331,7 @@ fd_log_collector_printf_dangerous_128_to_2k( fd_exec_instr_ctx_t * ctx,
    the complexity when msg_sz can be below or above 127, for
    example in many error messages where we have to print 2
    pubkeys. */
+__attribute__ ((format (printf, 2, 3)))
 static inline void
 fd_log_collector_printf_inefficient_max_512( fd_exec_instr_ctx_t * ctx,
                                              char const * fmt, ... ) {


### PR DESCRIPTION
Before this change, the compiler would not detect format string bugs like this example. (Not in the live codebase, introduced locally for demonstration)

```c
  /* Max msg_sz: 22 - 4 + 44 + 10 = 72 < 127 => we can use printf */
  fd_log_collector_printf_dangerous_max_127( ctx, "Program %s invoke [%s]", ctx->program_id_base58, ctx->depth+1 );
```

This is because the compiler does not know that it should check format strings on the `fd_log_collector_printf_dangerous_max_127` function.
As such, the compile succeeds (`MACHINE=linux_clang_haswell EXTRAS="no-agave" make -j`).

This change adds the [format attribute](https://gcc.gnu.org/onlinedocs/gcc-3.2/gcc/Function-Attributes.html) to the `fd_log_collector_printf_<...>` functions.
After the change, compilation will spot the example bug.

```
src/flamenco/runtime/sysvar/../../log_collector/fd_log_collector.h:377:101: error: format specifies type 'char *' but the argument has type 'uint' (aka 'unsigned int') [-Werror,-Wformat]
  377 |   fd_log_collector_printf_dangerous_max_127( ctx, "Program %s invoke [%s]", ctx->program_id_base58, ctx->depth+1 );
      |                                                                       ~~                            ^~~~~~~~~~~~
      |                                                                       %u
```
