### PR TITLE
`ci`: set BUILDDIR such that clusterfuzz.yml fuzzer binaries end up in `clang-fuzz/`

### DIFF
--- a/.github/workflows/clusterfuzz.yml
+++ b/.github/workflows/clusterfuzz.yml
@@ -25,6 +25,7 @@ jobs:
     env:
       MACHINE: ${{ matrix.machine }}
       EXTRAS: fuzz asan ubsan
+      BUILDDIR: clang-fuzz
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This should fix the CI build for the "Clusterfuzz" fuzzers