### PR TITLE
gui: moving window average and max for tile primary metrics

### DIFF
--- a/book/api/websocket.md
+++ b/book/api/websocket.md
@@ -587,21 +587,18 @@ potential underflow.
 | Field               | Type                | Description
 |---------------------|---------------------|------------
 | next_leader_slot    | `number\|null`      | The next leader slot |
-| tile_primary_metric | `TilePrimaryMetric` | Per-tile-type primary metrics.  Some of these are point-in-time values (P), and some are aggregated since the end of the previous leader slot (A) |
+| tile_primary_metric | `TilePrimaryMetric` | Per-tile-type primary metrics.  Some of these are point-in-time values (P), and some are 1-second moving window averages (W) |
 
 **`TilePrimaryMetric`**
 | Field   | Type     | Description |
 |---------|----------|-------------|
-| net_in  | `number` | Ingress bytes per second (P) |
+| net_in  | `number` | Ingress bytes per second (W) |
 | quic    | `number` | Active QUIC connections (P) |
-| verify  | `number` | Fraction of transactions that failed sigverify (A) |
-| dedup   | `number` | Fraction of transactions deduplicated (A) |
+| verify  | `number` | Fraction of transactions that failed sigverify (W) |
+| dedup   | `number` | Fraction of transactions deduplicated (W) |
 | pack    | `number` | Fraction of pack buffer filled (P) |
-| bank    | `number` | Execution TPS (P) |
-| poh     | `number` | Fraction of time spent hashing (P) |
-| shred   | `number` | Shreds processed per second (P) |
-| store   | `number` | 50% percentile latency (A) |
-| net_out | `number` | Egress bytes per second (P) |
+| bank    | `number` | Execution TPS (W) |
+| net_out | `number` | Egress bytes per second (W) |
 
 
 #### `summary.live_tile_timers`
@@ -931,7 +928,7 @@ are skipped on the currently active fork.
 |---------------------|---------------------------|-------------|
 | publish             | `SlotPublish`             | General information about the slot |
 | waterfall           | `TxnWaterfall\|null`      | If the slot is not `mine`, will be `null`. Otherwise, a waterfall showing reasons transactions were acquired since the end of the prior leader slot |
-| tile_primary_metric | `TilePrimaryMetric\|null` | If the slot is not `mine`, will be `null`. Otherwise, per-tile-type primary metrics since the end of the prior leader slot |
+| tile_primary_metric | `TilePrimaryMetric\|null` | If the slot is not `mine`, will be `null`. Otherwise, max value of per-tile-type primary metrics since the end of the prior leader slot |
 
 #### `slot.query`
 | frequency   | type           | example |
@@ -1064,7 +1061,7 @@ are skipped on the currently active fork.
 |---------------------|---------------------------|-------------|
 | publish             | `SlotPublish`             | General information about the slot |
 | waterfall           | `TxnWaterfall\|null`      | If the slot is not `mine`, will be `null`. Otherwise, a waterfall showing reasons transactions were acquired since the end of the prior leader slot |
-| tile_primary_metric | `TilePrimaryMetric\|null` | If the slot is not `mine`, will be `null`. Otherwise, per-tile-type primary metrics since the end of the prior leader slot |
+| tile_primary_metric | `TilePrimaryMetric\|null` | If the slot is not `mine`, will be `null`. Otherwise, max value of per-tile-type primary metrics since the end of the prior leader slot |
 | tile_timers         | `TsTileTimers[]\|null`    | If the slot is not `mine`, will be `null`. Otherwise, an array of `TsTileTimers` samples from the slot, sorted earliest to latest. We store this information for the most recently completed 4096 leader slots. This will be `null` for leader slots before that |
 
 **`TxnWaterfall`**

--- a/src/disco/gui/fd_gui_printf.h
+++ b/src/disco/gui/fd_gui_printf.h
@@ -89,7 +89,5 @@ fd_gui_printf_live_txn_waterfall( fd_gui_t *               gui,
                                   ulong                    next_leader_slot );
 
 void
-fd_gui_printf_live_tile_prime_metric( fd_gui_t *                   gui,
-                                      fd_gui_tile_prime_metric_t * prev,
-                                      fd_gui_tile_prime_metric_t * cur,
-                                      ulong                        next_leader_slot );
+fd_gui_printf_live_tile_prime_metric( fd_gui_t * gui,
+                                      ulong      next_leader_slot );


### PR DESCRIPTION
Currently live values are computed from the end of the prior leader slot.  Change to a 1-second moving average.  Also change queries for our slots to return max within slot, so this would tell us for example the peak number of QUIC connections or peak fullness of the pack buffer that we observed within a slot.