### PR TITLE
gui: fix slot completed updates

### DIFF
--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -38,7 +38,7 @@ fd_gui_new( void *             shmem,
     return NULL;
   }
 
-  if( FD_UNLIKELY( topo->tile_cnt>128UL ) ) {
+  if( FD_UNLIKELY( topo->tile_cnt>FD_GUI_TILE_TIMER_TILE_CNT ) ) {
     FD_LOG_WARNING(( "too many tiles" ));
     return NULL;
   }
@@ -1264,11 +1264,11 @@ fd_gui_handle_completed_slot( fd_gui_t * gui,
        then later we replay this one anyway to track the bank fork. */
 
     if( FD_LIKELY( _slot<gui->summary.slot_optimistically_confirmed ) ) {
-      slot->level = FD_GUI_SLOT_LEVEL_COMPLETED;
-    } else {
       /* Cluster might have already optimistically confirmed by the time
          we finish replaying it. */
       slot->level = FD_GUI_SLOT_LEVEL_OPTIMISTICALLY_CONFIRMED;
+    } else {
+      slot->level = FD_GUI_SLOT_LEVEL_COMPLETED;
     }
   }
   slot->total_txn_cnt          = total_txn_count;

--- a/src/disco/gui/fd_gui.h
+++ b/src/disco/gui/fd_gui.h
@@ -12,6 +12,7 @@
 #define FD_GUI_SLOTS_CNT (864000UL)
 #define FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS (10L) /* 10 second moving average */
 #define FD_GUI_TPS_HISTORY_SAMPLE_CNT              (150UL)
+#define FD_GUI_TILE_TIMER_TILE_CNT                 (128UL)
 
 #define FD_GUI_SLOT_LEVEL_INCOMPLETE               (0)
 #define FD_GUI_SLOT_LEVEL_COMPLETED                (1)
@@ -173,12 +174,12 @@ struct fd_gui_slot {
      Points to first sample after slot start sample. */
   ulong                  tile_timers_begin_snap_idx;
   /* Snapshot at slot start. */
-  fd_gui_tile_timers_t   tile_timers_begin[ 128 ];
+  fd_gui_tile_timers_t   tile_timers_begin[ FD_GUI_TILE_TIMER_TILE_CNT ];
   /* Index into periodic sample array. Exclusive.
      Points to one past last sample before slot end sample. */
   ulong                  tile_timers_end_snap_idx;
   /* Snapshot at slot end. */
-  fd_gui_tile_timers_t   tile_timers_end[ 128 ];
+  fd_gui_tile_timers_t   tile_timers_end[ FD_GUI_TILE_TIMER_TILE_CNT ];
 };
 
 typedef struct fd_gui_slot fd_gui_slot_t;
@@ -257,7 +258,7 @@ struct fd_gui {
     fd_gui_tile_prime_metric_t tile_prime_metric_cur[ 1 ];
 
     ulong                tile_timers_snap_idx;
-    fd_gui_tile_timers_t tile_timers_snap[ 432000UL ][ 128 ]; /* TODO: This can only store about 1 hour of samples */
+    fd_gui_tile_timers_t tile_timers_snap[ 432000UL ][ FD_GUI_TILE_TIMER_TILE_CNT ]; /* TODO: This can only store about 1 hour of samples */
   } summary;
 
   fd_gui_slot_t slots[ FD_GUI_SLOTS_CNT ][ 1 ];

--- a/src/disco/gui/fd_gui_printf.c
+++ b/src/disco/gui/fd_gui_printf.c
@@ -962,8 +962,7 @@ fd_gui_printf_ts_tile_timers( fd_gui_t *                   gui,
 void
 fd_gui_printf_slot( fd_gui_t * gui,
                     ulong      _slot ) {
-  ulong slots_sz = sizeof(gui->slots) / sizeof(gui->slots[ 0 ]);
-  fd_gui_slot_t * slot = gui->slots[ _slot % slots_sz ];
+  fd_gui_slot_t * slot = gui->slots[ _slot % FD_GUI_SLOTS_CNT ];
 
   char const * level;
   switch( slot->level ) {
@@ -975,7 +974,7 @@ fd_gui_printf_slot( fd_gui_t * gui,
     default:                                         level = "unknown"; break;
   }
 
-  fd_gui_slot_t * parent_slot = gui->slots[ slot->parent_slot % slots_sz ];
+  fd_gui_slot_t * parent_slot = gui->slots[ slot->parent_slot % FD_GUI_SLOTS_CNT ];
   if( FD_UNLIKELY( parent_slot->slot!=slot->parent_slot ) ) parent_slot = NULL;
 
   long duration_nanos = LONG_MAX;
@@ -1049,8 +1048,7 @@ void
 fd_gui_printf_slot_request( fd_gui_t * gui,
                             ulong      _slot,
                             ulong      id ) {
-  ulong slots_sz = sizeof(gui->slots) / sizeof(gui->slots[ 0 ]);
-  fd_gui_slot_t * slot = gui->slots[ _slot % slots_sz ];
+  fd_gui_slot_t * slot = gui->slots[ _slot % FD_GUI_SLOTS_CNT ];
 
   char const * level;
   switch( slot->level ) {
@@ -1062,7 +1060,7 @@ fd_gui_printf_slot_request( fd_gui_t * gui,
     default:                                         level = "unknown"; break;
   }
 
-  fd_gui_slot_t * parent_slot = gui->slots[ slot->parent_slot % slots_sz ];
+  fd_gui_slot_t * parent_slot = gui->slots[ slot->parent_slot % FD_GUI_SLOTS_CNT ];
   if( FD_UNLIKELY( parent_slot->slot!=slot->parent_slot ) ) parent_slot = NULL;
 
   long duration_nanos = LONG_MAX;


### PR DESCRIPTION
We are seeing slots starting off in an optimistically confirmed state in the GUI, rather than the completed state that a slot should usually start from.  This is because of a bug relating to the timing of replay completion relative to optimistic confirmation and the handling of slot states in the GUI when those two events happen out of order, i.e. when a higher slot is optimistically confirmed before replay completes for a lower slot.  This PR fixes that.