### PR TITLE
flamenco, runtime: fix copying calldests into program cache

### DIFF
--- a/src/ballet/sbpf/fd_sbpf_loader.c
+++ b/src/ballet/sbpf/fd_sbpf_loader.c
@@ -599,11 +599,11 @@ fd_sbpf_program_new( void *                     prog_mem,
   /* Initialize calldests map */
 
   ulong pc_max = elf_info->rodata_sz / 8UL;
-  prog->calldests =
-    fd_sbpf_calldests_join( fd_sbpf_calldests_new(
+  prog->calldests_shmem = fd_sbpf_calldests_new(
         FD_SCRATCH_ALLOC_APPEND( laddr, fd_sbpf_calldests_align(),
                                         fd_sbpf_calldests_footprint( pc_max ) ),
-        pc_max ) );
+        pc_max );
+  prog->calldests = fd_sbpf_calldests_join( prog->calldests_shmem );
 
   return prog;
 }

--- a/src/ballet/sbpf/fd_sbpf_loader.h
+++ b/src/ballet/sbpf/fd_sbpf_loader.h
@@ -130,6 +130,8 @@ struct __attribute__((aligned(32UL))) fd_sbpf_program {
   ulong   entry_pc;  /* entrypoint PC (at text[ entry_pc - start_pc ]) ... FIXME: HMMMM ... CODE SEEMS TO USE TEXT[ ENTRY_PC ] */
 
   /* Bit vector of valid call destinations (bit count is rodata_sz) */
+  void * calldests_shmem;
+  /* Local join to bit vector of valid call destinations */
   fd_sbpf_calldests_t * calldests;
 };
 typedef struct fd_sbpf_program fd_sbpf_program_t;

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -499,9 +499,9 @@ execute( fd_exec_instr_ctx_t * instr_ctx, fd_sbpf_validated_program_t * prog, uc
     /* instr_ctx             */ instr_ctx,
     /* heap_max              */ heap_max, /* TODO configure heap allocator */
     /* entry_cu              */ instr_ctx->txn_ctx->compute_meter,
-    /* rodata                */ fd_sbpf_validated_program_rodata( prog ),
+    /* rodata                */ prog->rodata,
     /* rodata_sz             */ prog->rodata_sz,
-    /* text                  */ (ulong *)((ulong)fd_sbpf_validated_program_rodata( prog ) + (ulong)prog->text_off), /* Note: text_off is byte offset */
+    /* text                  */ (ulong *)((ulong)prog->rodata + (ulong)prog->text_off), /* Note: text_off is byte offset */
     /* text_cnt              */ prog->text_cnt,
     /* text_off              */ prog->text_off,
     /* text_sz               */ prog->text_sz,

--- a/src/flamenco/runtime/program/fd_bpf_program_util.h
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.h
@@ -16,8 +16,15 @@ struct fd_sbpf_validated_program {
 
   ulong rodata_sz;
 
-  fd_sbpf_calldests_t calldests[];
+  /* We keep the pointer to the calldests raw memory around, so that we can easily copy the entire
+     data structures (including the private header) later. */
+  void * calldests_shmem;
+  fd_sbpf_calldests_t * calldests;
 
+  uchar * rodata;
+
+  /* Backing memory for calldests and rodata */
+  // uchar calldests_shmem[];
   // uchar rodata[];
 };
 typedef struct fd_sbpf_validated_program fd_sbpf_validated_program_t;
@@ -25,7 +32,7 @@ typedef struct fd_sbpf_validated_program fd_sbpf_validated_program_t;
 FD_PROTOTYPES_BEGIN
 
 fd_sbpf_validated_program_t *
-fd_sbpf_validated_program_new( void * mem );
+fd_sbpf_validated_program_new( void * mem, fd_sbpf_elf_info_t const * elf_info );
 
 
 ulong
@@ -33,9 +40,6 @@ fd_sbpf_validated_program_align( void );
 
 ulong
 fd_sbpf_validated_program_footprint( fd_sbpf_elf_info_t const * elf_info );
-
-uchar *
-fd_sbpf_validated_program_rodata( fd_sbpf_validated_program_t * prog );
 
 /* FIXME: Implement this (or remove?) */
 ulong


### PR DESCRIPTION
Previously we copied the _joined_ calldests map from the loaded program into the validated program object. This did not include the private dynamic set header, so many operations on the copied set were UB.

Instead, we keep around a reference to the underlying memory for the calldests map, which we can then safely copy into the validated program.