### PR TITLE
flamenco, vm: fix OOB in tracing code

### DIFF
--- a/src/flamenco/vm/fd_vm_interp_core.c
+++ b/src/flamenco/vm/fd_vm_interp_core.c
@@ -174,7 +174,7 @@ interp_exec:
   /* Note: when tracing or optimizing for code footprint, all
      instruction execution starts here such that this is only point
      where exe tracing diagnostics are needed. */
-
+  if( FD_UNLIKELY( pc>=text_cnt ) ) goto sigtext;
   fd_vm_trace_event_exe( vm->trace, pc, ic + ( pc - pc0 - ic_correction ), cu, reg, vm->text + pc, vm->text_cnt - pc, ic_correction, frame_cnt );
 # endif
 


### PR DESCRIPTION
The `pc>=text_cnt` check happens in `FD_VM_INTERP_INSTR_EXEC`, _after_ `fd_vm_trace_event_exe` is called. This leads to an OOB in the tracing code. Moving the call to create the trace event after the check guarantees that pc is always valid.