### PR TITLE
quic: remove common_hdr

### DIFF
--- a/src/waltz/quic/templ/fd_quic_parse_util.h
+++ b/src/waltz/quic/templ/fd_quic_parse_util.h
@@ -142,7 +142,21 @@ fd_quic_parse_bits( uchar const * buf, ulong cur_bit, ulong bits ) {
         );
 }
 
+/* fd_quic_extract_hdr_form extract the 'Header Form' bit, the first bit of a QUIC v1 packet.
+   Returns 1 if the packet is a long header packet, 0 if the packet is a short header packet.
+   Does not require decryption of the packet header. */
+static inline uchar
+fd_quic_extract_hdr_form( uchar hdr ) {
+  return hdr>>7;
+}
 
+/* fd_quic_extract_long_packet_type extracts the 'Long Packet Type' from
+   the first byte of a QUIC v1 long header packet.  Returns FD_QUIC_PKTTYPE_V1_{...}
+   in range [0,4).  Does not require decryption of the packet header. */
+static inline uchar
+fd_quic_extract_long_packet_type( uchar hdr ) {
+  return (hdr>>4)&3;
+}
 
 /* encode contiguous unaligned bits across bytes
    caller responsible for ensuring enough space for operation

--- a/src/waltz/quic/templ/fd_quic_templ.h
+++ b/src/waltz/quic/templ/fd_quic_templ.h
@@ -1,5 +1,3 @@
-/* TODO rename to fd_quic_pkt_templ.h */
-
 /* 17.2. Long Header Packets
    Long Header Packet {
      Header Form (1) = 1,
@@ -14,14 +12,6 @@
      Type-Specific Payload (..),
    }
    Figure 13: Long Header Packet Format */
-
-/* common to long and short header */
-FD_TEMPL_DEF_STRUCT_BEGIN(common_hdr)
-  FD_TEMPL_MBR_ELEM_BITS( hdr_form,           uchar, 1 )
-  FD_TEMPL_MBR_ELEM_BITS( fixed_bit,          uchar, 1 )
-  FD_TEMPL_MBR_ELEM_BITS( long_packet_type,   uchar, 2 )
-  FD_TEMPL_MBR_ELEM_BITS( type_specific_bits, uchar, 4 )
-FD_TEMPL_DEF_STRUCT_END(common_hdr)
 
 /* long header except first byte */
 FD_TEMPL_DEF_STRUCT_BEGIN(long_hdr)

--- a/src/waltz/quic/tests/test_quic_layout.c
+++ b/src/waltz/quic/tests/test_quic_layout.c
@@ -14,6 +14,8 @@ main( int argc, char ** argv ) {
 
 #include "../templ/fd_quic_dft.h"
 #include "../templ/fd_quic_templ.h"
+
+
 #include "../templ/fd_quic_undefs.h"
 
   printf( "\n" );


### PR DESCRIPTION
`common_hdr` had wrong documentation that said it could be used for short packets. The existing prod code did that but did not read any of the non-matching fields. `fuzz_quic_wire` had a minor bug because of it. After consulting with @ripatel-fd this PR removes `common_hdr` in favor of bit fiddling functions. Furthermore, it renames src/waltz/quic/templ/fd_quic_templ.h -> src/waltz/quic/templ/fd_quic_pkt_templ.h as per the TODO comment in the old src/waltz/quic/templ/fd_quic_templ.h