### PR TITLE
fd_pcapng usability fixes

### DIFF
--- a/src/util/net/fd_pcapng.c
+++ b/src/util/net/fd_pcapng.c
@@ -226,7 +226,7 @@ fd_pcapng_iter_delete( fd_pcapng_iter_t * iter ) {
   return mem;
 }
 
-fd_pcapng_frame_t const *
+fd_pcapng_frame_t *
 fd_pcapng_iter_next( fd_pcapng_iter_t * iter ) {
 
   static FD_TL fd_pcapng_frame_t pkt;
@@ -280,6 +280,7 @@ fd_pcapng_iter_next( fd_pcapng_iter_t * iter ) {
 
       fd_pcapng_idb_desc_t * iface = &iter->iface[ iter->iface_cnt++ ];
       memset( iface, 0, sizeof(fd_pcapng_idb_desc_t) );
+      iface->link_type = idb.link_type;
 
       /* Read options */
       for( uint j=0; j<FD_PCAPNG_MAX_OPT_CNT; j++ ) {

--- a/src/util/net/fd_pcapng.h
+++ b/src/util/net/fd_pcapng.h
@@ -115,7 +115,7 @@ fd_pcapng_iter_delete( fd_pcapng_iter_t * iter );
    are backed by a thread-local memory region that is valid until delete
    or next iter_next. */
 
-fd_pcapng_frame_t const *
+fd_pcapng_frame_t *
 fd_pcapng_iter_next( fd_pcapng_iter_t * iter );
 
 /* fd_pcapng_is_pkt returns 1 if given frame (non-NULL) is a regular
@@ -185,7 +185,8 @@ fd_pcapng_idb_defaults( fd_pcapng_idb_opts_t * opt,
 
 /* FD_PCAPNG_LINKTYPE_*: Link types (currently only Ethernet supported) */
 
-#define FD_PCAPNG_LINKTYPE_ETHERNET (1U)
+#define FD_PCAPNG_LINKTYPE_ETHERNET   (1U) /* IEEE 802.3 Ethernet */
+#define FD_PCAPNG_LINKTYPE_COOKED   (113U) /* Linux "cooked" capture */
 
 ulong
 fd_pcapng_fwrite_idb( uint                         link_type,

--- a/src/util/net/test_pcapng.c
+++ b/src/util/net/test_pcapng.c
@@ -187,6 +187,7 @@ test_pcapng_dogfood( void ) {
   FD_TEST( frame->data_sz==6UL );
   FD_TEST( frame->orig_sz==6UL );
   FD_TEST( frame->if_idx ==0UL );
+  FD_TEST( iter->iface[ frame->if_idx ].link_type==FD_PCAPNG_LINKTYPE_ETHERNET );
 
   frame = fd_pcapng_iter_next( iter );
   FD_TEST( frame );


### PR DESCRIPTION
- Return a mutable pointer in fd_pcapng_iter_next to allow for in-place packet mangling
- Fixes bug in parser where link_type is always zero
