### PR TITLE
add format attributs to printf like functions

### DIFF
--- a/src/app/fdctl/caps.c
+++ b/src/app/fdctl/caps.c
@@ -9,6 +9,7 @@
 #include <sys/syscall.h>
 #include <linux/capability.h>
 
+__attribute__ ((format (printf, 2, 3)))
 static void
 fd_caps_private_add_error( fd_caps_ctx_t * ctx,
                            char const *    fmt,

--- a/src/ballet/http/fd_http_server.h
+++ b/src/ballet/http/fd_http_server.h
@@ -347,7 +347,7 @@ fd_http_server_stage_len( fd_http_server_t * http );
 void
 fd_http_server_printf( fd_http_server_t * http,
                        char const *       fmt,
-                       ... );
+                       ... )  __attribute__((format (printf, 2, 3)));
 
 /* fd_http_server_memcpy appends the data provided to the end of the
    staging area of the outgoing ring buffer.  Assumes http is a current

--- a/src/ballet/http/test_http_server.c
+++ b/src/ballet/http/test_http_server.c
@@ -37,7 +37,7 @@ test_oring( void ) {
 
   for( ulong i=1UL; i<32UL; i++ ) {
     for( ulong j=0UL; j<1024UL; j++ ) {
-      for( ulong k=0UL; k<i; k++ ) fd_http_server_printf( http, "%c", 'a'+i );
+      for( ulong k=0UL; k<i; k++ ) fd_http_server_printf( http, "%c", (char)('a'+i) );
 
       fd_http_server_response_t response;
       if( i>8 ) {

--- a/src/disco/topo/fd_pod_format.h
+++ b/src/disco/topo/fd_pod_format.h
@@ -46,6 +46,7 @@ FD_POD_IMPL( double, DOUBLE )
 
 #undef FD_POD_IMPL
 
+__attribute__ ((format (printf, 3, 4)))
 static inline ulong
 fd_pod_insertf_cstr( uchar      * FD_RESTRICT pod,
                      char const * FD_RESTRICT str,
@@ -69,6 +70,7 @@ fd_pod_insertf_cstr( uchar      * FD_RESTRICT pod,
    IMPORTANT!  THIS IS AN INVALIDATING OPERATION */
 
 #define FD_POD_IMPL(type,TYPE)                                                  \
+__attribute__ ((format (printf, 3, 4)))                                         \
 static inline int                                                               \
 fd_pod_replacef_##type( uchar      * FD_RESTRICT pod,                           \
                         type                     val,                           \
@@ -110,6 +112,7 @@ FD_POD_IMPL( double, DOUBLE )
    result on success or def on failure. */
 
 #define FD_POD_IMPL(type,TYPE)                                                  \
+__attribute__ ((format (printf, 3, 4)))                                         \
 static inline type                                                              \
 fd_pod_queryf_##type( uchar const * FD_RESTRICT  pod,                           \
                       type                       def,                           \


### PR DESCRIPTION
Similar to https://github.com/firedancer-io/firedancer/pull/3131, this PR adds format attributes to functions that take a format string. This enables checking format strings at compile time. The now annotated functions were discovered with a CodeQL query, that discovers such functions. Credits to @marctrem for the query idea. We will run this query periodically to check for regressions / new non-annotated printf like functions.

Adding these attributes uncovered a minor bug in test code, also fixed in this PR.