### PR TITLE
Fix noarch128 build

### DIFF
--- a/src/app/fddev/Local.mk
+++ b/src/app/fddev/Local.mk
@@ -3,6 +3,7 @@ ifdef FD_HAS_LINUX
 ifdef FD_HAS_ALLOCA
 ifdef FD_HAS_DOUBLE
 ifdef FD_HAS_INT128
+ifdef FD_HAS_SSE
 
 include src/app/fdctl/with-version.mk
 
@@ -64,6 +65,7 @@ $(call make-integration-test,test_fddev,tests/test_fddev,fd_fddev fd_fdctl fd_di
 endif
 $(call run-integration-test,test_fddev)
 
+endif
 endif
 endif
 endif

--- a/src/app/rpcserver/fd_block_to_json.c
+++ b/src/app/rpcserver/fd_block_to_json.c
@@ -855,6 +855,7 @@ fd_account_to_json( fd_webserver_t * ws,
     }
     encstr = "base64";
     break;
+# if FD_HAS_ZSTD
   case FD_ENC_BASE64_ZSTD: {
     size_t const cBuffSize = ZSTD_compressBound( val_sz );
     void * cBuff = fd_scratch_alloc( 1, cBuffSize );
@@ -865,6 +866,7 @@ fd_account_to_json( fd_webserver_t * ws,
     encstr = "base64+zstd";
     break;
   }
+# endif /* FD_HAS_ZSTD */
   default:
     return "unsupported encoding";
   }

--- a/src/disco/stem/fd_stem.c
+++ b/src/disco/stem/fd_stem.c
@@ -128,6 +128,8 @@
    fragment that was received.  If the producer is not respecting flow
    control, these may be corrupt or torn and should not be trusted. */
 
+#if FD_HAS_SSE
+
 #include "../topo/fd_topo.h"
 #include "../metrics/fd_metrics.h"
 #include "../../tango/fd_tango.h"
@@ -688,3 +690,5 @@ stem_run( fd_topo_t *      topo,
              fd_alloca( STEM_SCRATCH_ALIGN, stem_scratch_footprint( polled_in_cnt, tile->out_cnt, reliable_cons_cnt ) ),
              ctx );
 }
+
+#endif /* FD_HAS_SSE */


### PR DESCRIPTION
- Guard zstd dependency in fd_block_to_json
- Only compile fd_stem when SSE is enabled
- Only compile fddev when SSE is enabled
