### PR TITLE
quic: only service one conn in fd_quic_service

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -2726,7 +2726,7 @@ fd_quic_service( fd_quic_t * quic ) {
 
   /* service events */
   fd_quic_conn_t * conn = NULL;
-  while( 1 ) {
+  do {
     fd_quic_rb_event_t * event =
         rb_service_queue_minimum( rb_service_queue,
                                   state->rb_service_queue_root );
@@ -2811,7 +2811,7 @@ fd_quic_service( fd_quic_t * quic ) {
           fd_quic_schedule_conn( conn );
         }
     }
-  }
+  } while(0);
 
   return handled_event;
 }


### PR DESCRIPTION
Most fd_quic users run a main loop like so:

```
  for(;;) {
    fd_quic_service( ... );
    fd_quic_process_packet( ... );
  }
```

fd_quic_service's execution time is currently unbounded which can
starve RX from cycles at high concurrent connection counts.

Improves performance for all connection counts (from 1 to ~40k) 
