### PR TITLE
quic: remove unused code

### DIFF
--- a/src/app/fdctl/run/tiles/fd_quic.c
+++ b/src/app/fdctl/run/tiles/fd_quic.c
@@ -83,7 +83,7 @@ quic_limits( fd_topo_tile_t const * tile ) {
     /* fd_quic will not issue nor use any new connection IDs after
        completing a handshake.  Connection migration is not supported
        either. */
-    .conn_id_cnt      = FD_QUIC_MAX_CONN_ID_PER_CONN,
+    .conn_id_cnt      = FD_QUIC_MIN_CONN_ID_CNT,
     .inflight_pkt_cnt = tile->quic.max_inflight_quic_packets,
     .tx_buf_sz        = 0,
     .rx_stream_cnt    = tile->quic.max_concurrent_streams_per_connection,

--- a/src/waltz/quic/fd_quic_conn.h
+++ b/src/waltz/quic/fd_quic_conn.h
@@ -57,16 +57,13 @@ struct fd_quic_conn {
   uint               established : 1;     /* used by clients to determine whether to
                                              switch the destination conn id used */
   uint               transport_params_set : 1;
-
-  uint               version;             /* QUIC version of the connection */
+  uint               called_conn_new : 1; /* whether we need to call conn_final on teardown */
 
   ulong              next_service_time;   /* time service should be called next */
   ulong              sched_service_time;  /* time service is scheduled for, if conn in service_queue */
   int                in_schedule;         /* whether the conn is in the service schedule */
-  uchar              called_conn_new;     /* whether we need to call conn_final on teardown */
 
-  /* we can have multiple connection ids */
-  ulong              our_conn_id[ FD_QUIC_MAX_CONN_ID_PER_CONN ];
+  ulong              our_conn_id;
 
   /* Save original destination connection id
      This will be used when we receive a retransmitted initial packet
@@ -89,10 +86,8 @@ struct fd_quic_conn {
 
   ulong              local_conn_id;       /* FIXME: hack to locally identify conns */
 
-  ushort             our_conn_id_cnt;     /* number of connection ids */
   ushort             peer_cnt;            /* number of peer endpoints */
 
-  ushort             cur_conn_id_idx;     /* currently used conn id */
   ushort             cur_peer_idx;        /* currently used peer endpoint */
 
   /* initial source connection id */

--- a/src/waltz/quic/fd_quic_pkt_meta.h
+++ b/src/waltz/quic/fd_quic_pkt_meta.h
@@ -69,11 +69,6 @@ struct fd_quic_pkt_meta {
                                        enc_level */
   uchar                  pn_space;    /* packet number space (must be consistent
                                        with enc_level)  */
-  uchar                  status;
-# define FD_QUIC_PKT_META_STATUS_UNUSED  ((uchar)0)
-# define FD_QUIC_PKT_META_STATUS_PENDING ((uchar)1)
-# define FD_QUIC_PKT_META_STATUS_SENT    ((uchar)2)
-
   uchar                  var_sz;      /* number of populated entries in var */
 
   /* does/should the referenced packet contain:

--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -21,11 +21,6 @@
 #define FD_QUIC_DISABLE_CRYPTO 0
 #endif
 
-enum {
-  FD_QUIC_TYPE_INGRESS = 1 << 0,
-  FD_QUIC_TYPE_EGRESS  = 1 << 1,
-};
-
 #define FD_QUIC_PKT_NUM_UNUSED  (~0ul)
 #define FD_QUIC_PKT_NUM_PENDING (~1ul)
 
@@ -185,8 +180,7 @@ fd_quic_conn_create( fd_quic_t *               quic,
                      fd_quic_conn_id_t const * peer_conn_id,
                      uint                      dst_ip_addr,
                      ushort                    dst_udp_port,
-                     int                       server,
-                     uint                      version );
+                     int                       server );
 
 /* fd_quic_conn_free frees up resources related to the connection and
    returns it to the connection free list. */

--- a/src/waltz/quic/tests/fd_quic_sandbox.c
+++ b/src/waltz/quic/tests/fd_quic_sandbox.c
@@ -305,8 +305,7 @@ fd_quic_sandbox_new_conn_established( fd_quic_sandbox_t * sandbox,
       /* peer_conn_id */ &peer_conn_id,
       /* dst_ip_addr  */ FD_QUIC_SANDBOX_PEER_IP4,
       /* dst_udp_addr */ FD_QUIC_SANDBOX_PEER_PORT,
-      /* server       */ quic->config.role == FD_QUIC_ROLE_SERVER,
-      /* version      */ 1 );
+      /* server       */ quic->config.role == FD_QUIC_ROLE_SERVER );
   if( FD_UNLIKELY( !conn ) ) {
     FD_LOG_WARNING(( "fd_quic_conn_create failed" ));
     return NULL;

--- a/src/waltz/quic/tests/fuzz_quic_wire.c
+++ b/src/waltz/quic/tests/fuzz_quic_wire.c
@@ -151,8 +151,7 @@ LLVMFuzzerTestOneInput( uchar const * data,
     fd_quic_conn_create( quic,
                          our_conn_id, &peer_conn_id,
                          dst_ip_addr,  (ushort)dst_udp_port,
-                         1,  /* we are the server */
-                         1   /* QUIC version 1 */ );
+                         1  /* we are the server */ );
   assert( conn );
 
   conn->tx_max_data                            =       512UL;


### PR DESCRIPTION
- Remove dead FD_QUIC_OPT defines
- Remove support for multiple SCIDs
- Reduce fd_quic tile conn ID cnt from 16 to 4
- Remove conn->version field (we only support and test v1)
- Remove unused FD_QUIC_PKT_META_STATUS enum
- Remove unused FD_QUIC_TYPE_{INGRESS,EGRESS} enum
