### PR TITLE
quic: only support one DCID

### DIFF
--- a/src/waltz/quic/fd_quic_conn.h
+++ b/src/waltz/quic/fd_quic_conn.h
@@ -82,13 +82,10 @@ struct fd_quic_conn {
 
   /* Peer network endpoints – have multiple connection ids and ip:port */
   /* TODO: footprint allows specifying conn_id_cnt but hardcoded limit used here */
-  fd_quic_endpoint_t  peer[ FD_QUIC_MAX_CONN_ID_PER_CONN ];
+  fd_quic_net_endpoint_t peer[1];
+  fd_quic_conn_id_t      peer_cids[1]; /* FIXME support new/retire conn ID */
 
   ulong              local_conn_id;       /* FIXME: hack to locally identify conns */
-
-  ushort             peer_cnt;            /* number of peer endpoints */
-
-  ushort             cur_peer_idx;        /* currently used peer endpoint */
 
   /* initial source connection id */
   fd_quic_conn_id_t  initial_source_conn_id;

--- a/src/waltz/quic/fd_quic_conn_id.h
+++ b/src/waltz/quic/fd_quic_conn_id.h
@@ -8,11 +8,6 @@
 /* TODO move this into more reasonable place */
 #define FD_QUIC_MAX_CONN_ID_SZ 20
 
-/* max number of connection ids per connection */
-/* NOTE QUINN seems to ignore our active_connection_id_limit transport parameter */
-/*      So setting this to 16 */
-#define FD_QUIC_MAX_CONN_ID_PER_CONN 16
-
 /* Firedancer connection ids will sized thus */
 #define FD_QUIC_CONN_ID_SZ 8
 
@@ -90,16 +85,6 @@ struct fd_quic_net_endpoint {
   ushort udp_port;
 };
 typedef struct fd_quic_net_endpoint fd_quic_net_endpoint_t;
-
-/* fd_quic_endpoint_t identifies a QUIC endpoint, including UDP/IP
-   endpoint and QUIC conn ID. */
-
-struct fd_quic_endpoint {
-  fd_quic_conn_id_t      conn_id;
-  fd_quic_net_endpoint_t net;
-  uchar                  mac_addr[6];
-};
-typedef struct fd_quic_endpoint fd_quic_endpoint_t;
 
 #endif /* HEADER_fd_src_waltz_quic_fd_quic_conn_id_h */
 


### PR DESCRIPTION
Decreases the fd_quic_conn_t footprint by about 600 bytes.

Removes support for the NEW_CONNECTION_ID frame.  fd_quic only ever
uses the first available connection ID anyways, and doesn't
implement RETIRE_CONNECTION_ID.  The conn ID state is thus dead
weight.
