### PR TITLE
Add Power9 build target

### DIFF
--- a/config/machine/linux_gcc_power9.mk
+++ b/config/machine/linux_gcc_power9.mk
@@ -1,0 +1,17 @@
+BUILDDIR:=linux/gcc/power9
+
+include config/base.mk
+include config/extra/with-clang.mk
+include config/extra/with-debug.mk
+include config/extra/with-optimization.mk
+
+CPPFLAGS+=-D_XOPEN_SOURCE=700
+CPPFLAGS+=-DFD_HAS_INT128=1 -DFD_HAS_DOUBLE=1 -DFD_HAS_ALLOCA=1
+CPPFLAGS+=-DFD_ENV_STYLE=0 -DFD_IO_STYLE=0 -DFD_LOG_STYLE=0
+CPPFLAGS+=-DFD_HAS_ATOMIC=1
+
+FD_HAS_INT128:=1
+FD_HAS_DOUBLE:=1
+FD_HAS_ALLOCA:=1
+FD_HAS_ATOMIC:=1
+

--- a/src/app/backtest/Local.mk
+++ b/src/app/backtest/Local.mk
@@ -1,3 +1,5 @@
+ifdef FD_HAS_HOSTED
 ifdef FD_HAS_INT128
 $(call make-bin,fd_backtest_ctl,fd_backtest_ctl,fd_flamenco fd_funk fd_ballet fd_util)
+endif
 endif

--- a/src/app/rpcserver/Local.mk
+++ b/src/app/rpcserver/Local.mk
@@ -1,5 +1,7 @@
+ifdef FD_HAS_HOSTED
 ifdef FD_HAS_INT128
 CFLAGS+='-DFIREDANCER_VERSION="$(FIREDANCER_VERSION_MAJOR).$(FIREDANCER_VERSION_MINOR).$(FIREDANCER_VERSION_PATCH)"'
 
 $(call make-bin,fd_rpcserver,main,fd_flamenco fd_reedsol fd_disco fd_ballet fd_funk fd_shred fd_tango fd_choreo fd_waltz fd_util, $(SECP256K1_LIBS))
+endif
 endif

--- a/src/choreo/eqvoc/Local.mk
+++ b/src/choreo/eqvoc/Local.mk
@@ -1,5 +1,7 @@
 ifdef FD_HAS_INT128
 $(call add-hdrs,fd_eqvoc.h)
 $(call add-objs,fd_eqvoc,fd_choreo)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_eqvoc,test_eqvoc,fd_choreo fd_flamenco fd_ballet fd_util)
+endif
 endif

--- a/src/flamenco/runtime/program/zksdk/Local.mk
+++ b/src/flamenco/runtime/program/zksdk/Local.mk
@@ -1,5 +1,7 @@
 ifdef FD_HAS_INT128
 $(call add-hdrs,fd_zksdk.h)
 $(call add-objs,fd_zksdk,fd_flamenco)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_zksdk,test_zksdk,fd_flamenco fd_funk fd_ballet fd_util)
+endif
 endif

--- a/src/flamenco/types/Local.mk
+++ b/src/flamenco/types/Local.mk
@@ -10,7 +10,9 @@ $(call run-unit-test,test_types_meta)
 $(call run-unit-test,test_types_yaml)
 $(call run-unit-test,test_types_fixtures)
 $(call run-unit-test,test_cast)
+ifdef FD_HAS_HOSTED
 $(call make-fuzz-test,fuzz_types_decode,fuzz_types_decode,fd_flamenco fd_ballet fd_util)
+endif
 endif
 
 # "ConfirmedBlock" Protobuf definitions

--- a/src/funk/Local.mk
+++ b/src/funk/Local.mk
@@ -1,11 +1,11 @@
 $(call make-lib,fd_funk)
 $(call add-hdrs,fd_funk_base.h fd_funk_txn.h fd_funk_rec.h fd_funk_val.h fd_funk_part.h fd_funk_archive.h fd_funk_filemap.h fd_funk.h)
 $(call add-objs,fd_funk_base fd_funk_txn fd_funk_rec fd_funk_val fd_funk_part fd_funk_archive fd_funk_filemap fd_funk,fd_funk)
-$(call make-unit-test,test_funk_base,test_funk_base,fd_funk fd_util)
-$(call run-unit-test,test_funk_base)
 $(call make-unit-test,test_funk_txn,test_funk_txn,fd_funk fd_util)
 $(call run-unit-test,test_funk_txn)
 ifdef FD_HAS_HOSTED
+$(call make-unit-test,test_funk_base,test_funk_base,fd_funk fd_util)
+$(call run-unit-test,test_funk_base)
 $(call make-unit-test,test_funk_txn2,test_funk_txn2,fd_funk fd_util)
 $(call run-unit-test,test_funk_txn2)
 $(call make-unit-test,test_funk_file,test_funk_file,fd_funk fd_util)

--- a/src/funk/fd_funk_filemap.c
+++ b/src/funk/fd_funk_filemap.c
@@ -1,7 +1,5 @@
-#if FD_HAS_THREADS /* THREADS implies HOSTED */
 #define _GNU_SOURCE
-#endif
-
+#define _FILE_OFFSET_BITS 64
 #include "fd_funk_filemap.h"
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -415,7 +415,7 @@ __extension__ typedef unsigned __int128 uint128;
 
 #if defined(__aarch64__)
 #define FD_ASM_LG_ALIGN(lg_n) ".align " #lg_n "\n"
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__powerpc64__)
 #define FD_ASM_LG_ALIGN(lg_n) ".p2align " #lg_n "\n"
 #endif
 

--- a/src/waltz/quic/Local.mk
+++ b/src/waltz/quic/Local.mk
@@ -28,4 +28,6 @@ $(call add-objs,fd_quic_stream_pool,fd_quic)
 $(call add-hdrs,fd_quic_stream.h)
 $(call add-objs,fd_quic_stream,fd_quic)
 
+ifdef FD_HAS_HOSTED
 $(call make-bin,fd_quic_pcap,fd_quic_pcap_main,fd_quic fd_waltz fd_tls fd_ballet fd_util)
+endif


### PR DESCRIPTION
Adds an experimental target to ensure the code base stays portable
