### PR TITLE
Use ppoll(2) instead of poll(2)

### DIFF
--- a/config/everything.mk
+++ b/config/everything.mk
@@ -13,7 +13,7 @@ CPPFLAGS+=-DFD_BUILD_INFO=\"$(OBJDIR)/info\"
 CPPFLAGS+=$(EXTRA_CPPFLAGS)
 
 # Auxiliary rules that should not set up dependencies
-AUX_RULES:=clean distclean help show-deps run-unit-test run-integration-test cov-report dist-cov-report
+AUX_RULES:=clean distclean help show-deps run-unit-test run-integration-test cov-report dist-cov-report seccomp-policies
 
 all: info bin include lib unit-test fuzz-test
 

--- a/src/app/fdctl/run/pidns.seccomppolicy
+++ b/src/app/fdctl/run/pidns.seccomppolicy
@@ -32,12 +32,13 @@ fsync: (eq (arg 0) logfile_fd)
 # process simply waits for any child to exit, and if this happens
 # terminates the whole process group with a diagnostic message.
 #
-# Pipe file descriptors are used with poll() to detect process exit (the
+# Pipe file descriptors are used with ppoll() to detect process exit (the
 # pipe will SIGHUP) rather than waitpid() so that we can wait for
 # grandchildren and the parent process, rather than just direct
-# children.  The third parameter to poll(), timeout, is an int, and we
-# pass -1.  The BPF program treats all args as ulongs though.
-poll: (and (eq (arg 2) "(unsigned int)-1"))
+# children.  The timeout and signal mask parameters of ppoll() are set
+# to NULL.  The BPF program treats all args as ulongs though.
+ppoll: (and (eq (arg 2) 0)
+            (eq (arg 3) 0))
 
 # supervisor: get exited process exit status
 #

--- a/src/app/fdctl/run/run.c
+++ b/src/app/fdctl/run/run.c
@@ -350,7 +350,7 @@ main_pid_namespace( void * _args ) {
      a group.  The parent process will also die if this process dies,
      due to getting SIGHUP on the pipe. */
   while( 1 ) {
-    if( FD_UNLIKELY( -1==poll( fds, 1+child_cnt, -1 ) ) ) FD_LOG_ERR(( "poll() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    if( FD_UNLIKELY( -1==ppoll( fds, 1+child_cnt, NULL, NULL ) ) ) FD_LOG_ERR(( "ppoll() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
 
     for( ulong i=0UL; i<1UL+child_cnt; i++ ) {
       if( FD_UNLIKELY( fds[ i ].revents ) ) {
@@ -727,7 +727,7 @@ run_firedancer_init( config_t * const config,
         write end to the child.  If any of the children die, the pipe
         will be closed, and pidns will get a HUP on the read end.
 
-        Then pidns can call poll() on both the write end of the main
+        Then pidns can call ppoll() on both the write end of the main
         pipe and the read end of all the child pipes.  If any of them
         raises SIGHUP, then pidns knows that the parent or a child has
         died, and it can terminate itself, which due to (a) and (b)

--- a/src/app/fdctl/run/tiles/fd_metric.c
+++ b/src/app/fdctl/run/tiles/fd_metric.c
@@ -13,7 +13,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <string.h>
-#include <poll.h>
 #include <stdio.h>
 
 #define FD_HTTP_SERVER_METRICS_MAX_CONNS          128

--- a/src/app/fdctl/run/tiles/generated/gui_seccomp.h
+++ b/src/app/fdctl/run/tiles/generated/gui_seccomp.h
@@ -43,8 +43,8 @@ static void populate_sock_filter_policy_gui( ulong out_cnt, struct sock_filter *
     BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_sendto, /* check_sendto */ 23, 0 ),
     /* allow close based on expression */
     BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_close, /* check_close */ 28, 0 ),
-    /* allow poll based on expression */
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_poll, /* check_poll */ 33, 0 ),
+    /* allow ppoll based on expression */
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_ppoll, /* check_ppoll */ 33, 0 ),
     /* none of the syscalls matched */
     { BPF_JMP | BPF_JA, 0, 0, /* RET_KILL_PROCESS */ 34 },
 //  check_write:
@@ -111,9 +111,9 @@ static void populate_sock_filter_policy_gui( ulong out_cnt, struct sock_filter *
     /* load syscall argument 0 in accumulator */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
     BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, gui_socket_fd, /* RET_KILL_PROCESS */ 2, /* RET_ALLOW */ 3 ),
-//  check_poll:
-    /* load syscall argument 2 in accumulator */
-    BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[2])),
+//  check_ppoll:
+    /* load syscall argument 3 in accumulator */
+    BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[3])),
     BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, 0, /* RET_ALLOW */ 1, /* RET_KILL_PROCESS */ 0 ),
 //  RET_KILL_PROCESS:
     /* KILL_PROCESS is placed before ALLOW since it's the fallthrough case. */

--- a/src/app/fdctl/run/tiles/generated/metric_seccomp.h
+++ b/src/app/fdctl/run/tiles/generated/metric_seccomp.h
@@ -43,8 +43,8 @@ static void populate_sock_filter_policy_metric( ulong out_cnt, struct sock_filte
     BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_sendto, /* check_sendto */ 23, 0 ),
     /* allow close based on expression */
     BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_close, /* check_close */ 28, 0 ),
-    /* allow poll based on expression */
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_poll, /* check_poll */ 33, 0 ),
+    /* allow ppoll based on expression */
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_ppoll, /* check_ppoll */ 33, 0 ),
     /* none of the syscalls matched */
     { BPF_JMP | BPF_JA, 0, 0, /* RET_KILL_PROCESS */ 34 },
 //  check_write:
@@ -111,9 +111,9 @@ static void populate_sock_filter_policy_metric( ulong out_cnt, struct sock_filte
     /* load syscall argument 0 in accumulator */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
     BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, metrics_socket_fd, /* RET_KILL_PROCESS */ 2, /* RET_ALLOW */ 3 ),
-//  check_poll:
-    /* load syscall argument 2 in accumulator */
-    BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[2])),
+//  check_ppoll:
+    /* load syscall argument 3 in accumulator */
+    BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[3])),
     BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, 0, /* RET_ALLOW */ 1, /* RET_KILL_PROCESS */ 0 ),
 //  RET_KILL_PROCESS:
     /* KILL_PROCESS is placed before ALLOW since it's the fallthrough case. */

--- a/src/app/fdctl/run/tiles/gui.seccomppolicy
+++ b/src/app/fdctl/run/tiles/gui.seccomppolicy
@@ -65,5 +65,5 @@ close: (not (or (eq (arg 0) 2)
 
 # server: serving pages over HTTP requires polling connections
 #
-# arg 2 is the timeout.
-poll: (eq (arg 2) 0)
+# arg 3 is the signal mask.
+ppoll: (eq (arg 3) 0)

--- a/src/app/fdctl/run/tiles/metric.seccomppolicy
+++ b/src/app/fdctl/run/tiles/metric.seccomppolicy
@@ -65,5 +65,5 @@ close: (not (or (eq (arg 0) 2)
 
 # server: serving pages over HTTP requires polling connections
 #
-# arg 2 is the timeout.
-poll: (eq (arg 2) 0)
+# arg 3 is the signal mask.
+ppoll: (eq (arg 3) 0)

--- a/src/util/sandbox/fd_sandbox.c
+++ b/src/util/sandbox/fd_sandbox.c
@@ -26,7 +26,7 @@
 #error "Target operating system is unsupported by seccomp."
 #endif
 
-#if !defined(__x86_64__)
+#if !defined(__x86_64__) && !defined(__aarch64__)
 #error "Target architecture is unsupported by seccomp."
 #else
 
@@ -158,7 +158,7 @@ fd_sandbox_private_check_exact_file_descriptors( ulong       allowed_file_descri
        since dent->d_name field is variable length, the records are not
        always aligned and the cast below is going to be unaligned anyway
        however...
-       
+
        If we don't align it the compiler might prove somthing weird and
        trash this code, and also ASAN would flag it as an error.  So we
        just align it anyway. */
@@ -209,7 +209,7 @@ fd_sandbox_private_check_exact_file_descriptors( ulong       allowed_file_descri
 
         FD_LOG_ERR(( "unexpected file descriptor %d open %s", fd, target ));
       }
-      
+
       offset += dent->d_reclen;
     }
   }
@@ -387,12 +387,12 @@ void
 fd_sandbox_private_set_rlimits( ulong rlimit_file_cnt ) {
   struct rlimit_setting rlimits[] = {
     { .resource=RLIMIT_NOFILE,     .limit=rlimit_file_cnt },
-    /* The man page for setrlimit(2) states about RLIMIT_NICE: 
-    
+    /* The man page for setrlimit(2) states about RLIMIT_NICE:
+
           The useful range for this limit is thus from 1 (corresponding
           to a nice value of 19) to 40 (corresponding to a nice value of
           -20).
-       
+
        But this is misleading.  The range of values is from 0 to 40,
        even though the "useful" range is 1 to 40, because a value of 0
        and a value of 1 for the rlimit both map to a nice value of 19.
@@ -569,9 +569,9 @@ fd_sandbox_private_enter_no_seccomp( uint        desired_uid,
   /* Read the highest capability index on the currently running kernel
      from /proc */
   ulong cap_last_cap = fd_sandbox_private_read_cap_last_cap();
-  
+
   /* The ordering here is quite delicate and should be preserved ...
-  
+
       | Action                 | Must happen before          | Reason
       |------------------------|-----------------------------|-------------------------------------
       | Check file descriptors | Pivot root                  | Requires access to /proc filesystem
@@ -646,7 +646,7 @@ fd_sandbox_private_enter_no_seccomp( uint        desired_uid,
 
   /* PR_SET_KEEPCAPS will already be 0 if we didn't need to raise
      CAP_SYS_ADMIN, but we always clear it anyway. */
-  if( -1==prctl( PR_SET_KEEPCAPS, 0 ) ) FD_LOG_ERR(( "prctl(PR_SET_KEEPCAPS, 0) failed (%i-%s)", errno, fd_io_strerror( errno ) )); 
+  if( -1==prctl( PR_SET_KEEPCAPS, 0 ) ) FD_LOG_ERR(( "prctl(PR_SET_KEEPCAPS, 0) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
   if( -1==prctl( PR_SET_DUMPABLE, 0 ) ) FD_LOG_ERR(( "prctl(PR_SET_DUMPABLE, 0) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
 
   /* Now remount the filesystem root so no files are accessible any more. */


### PR DESCRIPTION
The 'poll' Linux syscall is not available on some Linux architectures
like arm64, unlike 'ppoll'.  Since our seccomp policy compiler only
supports one policy across all architectures, use 'ppoll' instead.

Also fixes a make dependency issue that prevents 'make seccomp-policies'
from completing if the generated headers are broken.

Co-authored-by: Charles Moyes <cmoyes@jumptrading.com>
