### PR TITLE
Fix stray int3 in fd_map_giant.c

### DIFF
--- a/src/util/tmpl/fd_map_giant.c
+++ b/src/util/tmpl/fd_map_giant.c
@@ -711,7 +711,7 @@ MAP_(verify_key)( MAP_T *           join,
                   MAP_KEY_T const * key,
                   ulong             cnt ) {
 # define MAP_TEST(c) do {                                                        \
-    if( FD_UNLIKELY( !(c) ) ) { FD_LOG_WARNING(( "FAIL: %s", #c )); __asm("int $3"); return -1; } \
+    if( FD_UNLIKELY( !(c) ) ) { FD_LOG_WARNING(( "FAIL: %s", #c )); return -1; } \
   } while(0)
 
   MAP_(private_t) * map = MAP_(private)( join );


### PR DESCRIPTION
Removes a leftover debugging instruction
