### PR TITLE
flamenco: allow dead accounts to be borrowed

### DIFF
--- a/contrib/test/test-vectors-fixtures/cpi-fixtures/cpi.list
+++ b/contrib/test/test-vectors-fixtures/cpi-fixtures/cpi.list
@@ -1,3 +1,4 @@
 dump/test-vectors/cpi/fixtures/callee_not_executable_log.fix
 dump/test-vectors/cpi/fixtures/cpi_prepare_missing_acct.fix
 dump/test-vectors/cpi/fixtures/18387a7e499df53e20db216f4520bca9ce0727e7_1582213.fix
+dump/test-vectors/cpi/fixtures/dead_non_executable_callee.fix

--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.c
@@ -86,7 +86,7 @@ fd_exec_txn_ctx_delete( void * mem ) {
 int
 fd_txn_borrowed_account_view_idx( fd_exec_txn_ctx_t * ctx,
                                   uchar idx,
-                                  fd_borrowed_account_t * *  account ) {
+                                  fd_borrowed_account_t * * account ) {
   if( FD_UNLIKELY( idx>=ctx->accounts_cnt ) ) {
     return FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT;
   }
@@ -97,6 +97,20 @@ fd_txn_borrowed_account_view_idx( fd_exec_txn_ctx_t * ctx,
   if( FD_UNLIKELY( !fd_acc_exists( txn_account->const_meta ) ) ) {
     return FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT;
   }
+
+  return FD_ACC_MGR_SUCCESS;
+}
+
+int
+fd_txn_borrowed_account_view_idx_allow_dead( fd_exec_txn_ctx_t * ctx,
+                                             uchar idx,
+                                             fd_borrowed_account_t * * account ) {
+  if( FD_UNLIKELY( idx>=ctx->accounts_cnt ) ) {
+    return FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT;
+  }
+
+  fd_borrowed_account_t * txn_account = &ctx->borrowed_accounts[idx];
+  *account = txn_account;
 
   return FD_ACC_MGR_SUCCESS;
 }

--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.h
@@ -161,6 +161,18 @@ int
 fd_txn_borrowed_account_view_idx( fd_exec_txn_ctx_t * ctx,
                                   uchar idx,
                                   fd_borrowed_account_t * * account );
+
+/* Same as above, except that this function doesn't check if the account
+   is dead (0 balance, 0 data, etc.) or not. When agave obtains a
+   borrowed account, it doesn't always check if the account is dead or
+   not. For example
+   https://github.com/firedancer-io/agave/blob/838c1952595809a31520ff1603a13f2c9123aa51/program-runtime/src/invoke_context.rs#L453
+   This function allows us to more closely emulate that behavior. */
+int
+fd_txn_borrowed_account_view_idx_allow_dead( fd_exec_txn_ctx_t * ctx,
+                                             uchar idx,
+                                             fd_borrowed_account_t * * account );
+
 int
 fd_txn_borrowed_account_view( fd_exec_txn_ctx_t * ctx,
                               fd_pubkey_t const *      pubkey,

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
@@ -324,7 +324,9 @@ fd_vm_prepare_instruction( fd_instr_info_t const *  caller_instr,
   fd_borrowed_account_t * program_rec = NULL;
 
   /* Caller is in charge of setting an appropriate sentinel value (i.e., UCHAR_MAX) for callee_instr->program_id if not found. */
-  int err = fd_txn_borrowed_account_view_idx( instr_ctx->txn_ctx, callee_instr->program_id, &program_rec );
+  /* We allow dead accounts to be borrowed here because that's what agave currently does.
+     https://github.com/firedancer-io/agave/blob/838c1952595809a31520ff1603a13f2c9123aa51/program-runtime/src/invoke_context.rs#L453 */
+  int err = fd_txn_borrowed_account_view_idx_allow_dead( instr_ctx->txn_ctx, callee_instr->program_id, &program_rec );
   if( FD_UNLIKELY( err ) ) {
     /* https://github.com/anza-xyz/agave/blob/a9ac3f55fcb2bc735db0d251eda89897a5dbaaaa/program-runtime/src/invoke_context.rs#L434 */
     FD_BASE58_ENCODE_32_BYTES( callee_instr->program_id_pubkey.uc, id_b58 );


### PR DESCRIPTION
Error code mismatch on a CPI fixture.  FD errors out as missing account, and agave errors out as account not executable.  This is due to a mismatch in account borrowing behavior.  FD does extra dead account check that agave doesn't.  This commit fixes that.