### PR TITLE
quic: further optimize packet number parser

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -1533,7 +1533,6 @@ fd_quic_handle_v1_initial( fd_quic_t *               quic,
                                              /* length of payload + num packet bytes */
 
   ulong   pkt_number       = (ulong)ULONG_MAX;
-  ulong   pkt_number_sz    = (ulong)ULONG_MAX;
   ulong   tot_sz           = (ulong)ULONG_MAX;
 
 # if !FD_QUIC_DISABLE_CRYPTO
@@ -1559,8 +1558,8 @@ fd_quic_handle_v1_initial( fd_quic_t *               quic,
        since the packet integrity is checked in fd_quic_crypto_decrypt? */
 
     /* number of bytes in the packet header */
-    pkt_number_sz = fd_quic_h0_pkt_num_len( cur_ptr[0] ) + 1u;
-    tot_sz        = pn_offset + body_sz; /* total including header and payload */
+    uint pkt_number_sz = fd_quic_h0_pkt_num_len( cur_ptr[0] ) + 1u;
+    /**/ tot_sz        = pn_offset + body_sz; /* total including header and payload */
 
     /* now we have decrypted packet number */
     pkt_number = fd_quic_pktnum_decode( cur_ptr+pn_offset, pkt_number_sz );
@@ -1703,7 +1702,6 @@ fd_quic_handle_v1_handshake(
                                                /* length of payload + num packet bytes */
 
   ulong    pkt_number       = (ulong)-1;
-  ulong    pkt_number_sz    = (ulong)-1;
   ulong    tot_sz           = (ulong)-1;
 
 # if !FD_QUIC_DISABLE_CRYPTO
@@ -1720,8 +1718,8 @@ fd_quic_handle_v1_handshake(
 # endif /* !FD_QUIC_DISABLE_CRYPTO */
 
   /* number of bytes in the packet header */
-  pkt_number_sz = fd_quic_h0_pkt_num_len( cur_ptr[0] ) + 1u;
-  tot_sz        = pn_offset + body_sz; /* total including header and payload */
+  uint pkt_number_sz = fd_quic_h0_pkt_num_len( cur_ptr[0] ) + 1u;
+  /**/ tot_sz        = pn_offset + body_sz; /* total including header and payload */
 
   /* now we have decrypted packet number */
   pkt_number = fd_quic_pktnum_decode( cur_ptr+pn_offset, pkt_number_sz );
@@ -1947,7 +1945,6 @@ fd_quic_handle_v1_one_rtt( fd_quic_t *           quic,
   ulong pn_offset        = one_rtt->pkt_num_pnoff;
 
   ulong pkt_number       = ULONG_MAX;
-  ulong pkt_number_sz    = ULONG_MAX;
 
 # if !FD_QUIC_DISABLE_CRYPTO
     /* this decrypts the header */
@@ -1967,7 +1964,7 @@ fd_quic_handle_v1_one_rtt( fd_quic_t *           quic,
     uint first = (uint)cur_ptr[0];
 
     /* number of bytes in the packet header */
-    pkt_number_sz = fd_quic_h0_pkt_num_len( cur_ptr[0] ) + 1u;
+    uint pkt_number_sz = fd_quic_h0_pkt_num_len( cur_ptr[0] ) + 1u;
 
     /* now we have decrypted packet number */
     pkt_number = fd_quic_pktnum_decode( cur_ptr+pn_offset, pkt_number_sz );

--- a/src/waltz/quic/templ/fd_quic_parse_util.h
+++ b/src/waltz/quic/templ/fd_quic_parse_util.h
@@ -115,16 +115,14 @@ fd_quic_varint_decode( uchar const * buf,
   }
 }
 
-static inline ulong
-fd_quic_pktnum_decode( uchar const * buf,
-                       ulong         sz ) {
-  uchar scratch[4] = {0};
-  uint n = 0;
-  switch( sz ) {
-  case 4: scratch[3] = buf[ n++ ]; __attribute__((fallthrough));
-  case 3: scratch[2] = buf[ n++ ]; __attribute__((fallthrough));
-  case 2: scratch[1] = buf[ n++ ]; __attribute__((fallthrough));
-  case 1: scratch[0] = buf[ n   ];
-  }
-  return FD_LOAD( uint, scratch );
+/* fd_quic_pktnum_decode extracts the compressed packet number from a
+   QUIC packet header.  May speculatively read up to 3 bytes outside the
+   packet number.  buf points to the first byte of the packet number.
+   sz is in [0,3]. */
+
+static inline uint
+fd_quic_pktnum_decode( uchar const buf[4],
+                       uint        sz ) {
+  uint src = fd_uint_bswap( FD_LOAD( uint, buf ) );
+  return src >> (32-8*sz);
 }

--- a/src/waltz/quic/tests/test_quic_proto.c
+++ b/src/waltz/quic/tests/test_quic_proto.c
@@ -231,10 +231,10 @@ test_varint_parse( void ) {
 void
 test_pktnum_parse( void ) {
   uchar buf[4] = {0x01, 0x02, 0x03, 0x04}; /* big endian */
-  FD_TEST( fd_quic_pktnum_decode( buf, 1UL )==      0x01 );
-  FD_TEST( fd_quic_pktnum_decode( buf, 2UL )==    0x0102 );
-  FD_TEST( fd_quic_pktnum_decode( buf, 3UL )==  0x010203 );
-  FD_TEST( fd_quic_pktnum_decode( buf, 4UL )==0x01020304 );
+  FD_TEST( fd_quic_pktnum_decode( buf, 1U )==      0x01 );
+  FD_TEST( fd_quic_pktnum_decode( buf, 2U )==    0x0102 );
+  FD_TEST( fd_quic_pktnum_decode( buf, 3U )==  0x010203 );
+  FD_TEST( fd_quic_pktnum_decode( buf, 4U )==0x01020304 );
 }
 
 /* Test crypto frame parser */


### PR DESCRIPTION
For all valid QUIC v1 packets, there are at least 16 bytes after
the packet number field.  (The AES-GCM MAC tag)

Thus, we can use a trailing read to make fd_quic_pktnum_decode
branchless.
