### PR TITLE
quic: use random TLS public key

### DIFF
--- a/contrib/tango.lua
+++ b/contrib/tango.lua
@@ -78,8 +78,6 @@ local link_hashes = {
 	[0xdb6a44] = "poh_shred",
 	[0xb8e9a5] = "crds_shred",
 	[0x6e5d41] = "shred_store",
-	[0x863a9a] = "quic_sign",
-	[0x9b7f2f] = "sign_quic",
 	[0xc650c9] = "shred_sign",
 	[0xd408b5] = "sign_shred"       
 }

--- a/src/app/fdctl/run/tiles/fd_quic.c
+++ b/src/app/fdctl/run/tiles/fd_quic.c
@@ -3,8 +3,6 @@
 #include "generated/quic_seccomp.h"
 
 #include "../../../../disco/metrics/fd_metrics.h"
-#include "../../../../disco/keyguard/fd_keyload.h"
-#include "../../../../disco/keyguard/fd_keyguard.h"
 #include "../../../../waltz/quic/fd_quic.h"
 #include "../../../../waltz/xdp/fd_xsk_aio.h"
 #include "../../../../waltz/xdp/fd_xsk.h"
@@ -36,11 +34,15 @@ typedef struct {
 
   fd_stem_context_t * stem;
 
-  uchar identity_public_key[ 32UL ];
   fd_quic_t *      quic;
   const fd_aio_t * quic_rx_aio;
+  fd_aio_t         quic_tx_aio[1];
 
-  fd_keyguard_client_t keyguard_client[1];
+# define ED25519_PRIV_KEY_SZ (32)
+# define ED25519_PUB_KEY_SZ  (32)
+  uchar            tls_priv_key[ ED25519_PRIV_KEY_SZ ];
+  uchar            tls_pub_key [ ED25519_PUB_KEY_SZ  ];
+  fd_sha512_t      sha512[1]; /* used for signing */
 
   uchar buffer[ FD_NET_MTU ];
 
@@ -492,13 +494,7 @@ quic_tx_aio_send( void *                    _ctx,
 static void
 privileged_init( fd_topo_t *      topo,
                  fd_topo_tile_t * tile ) {
-  void * scratch = fd_topo_obj_laddr( topo, tile->tile_obj_id );
-
-  FD_SCRATCH_ALLOC_INIT( l, scratch );
-  fd_quic_ctx_t * ctx = FD_SCRATCH_ALLOC_APPEND( l, alignof( fd_quic_ctx_t ), sizeof( fd_quic_ctx_t ) );
-
-  uchar const * public_key = fd_keyload_load( tile->quic.identity_key_path, 1 /* public key only */ );
-  fd_memcpy( ctx->identity_public_key, public_key, 32UL );
+  (void)topo; (void)tile;
 
   /* The fd_quic implementation calls fd_log_wallclock() internally
      which itself calls clock_gettime() which on most kernels is not a
@@ -513,10 +509,13 @@ privileged_init( fd_topo_t *      topo,
 }
 
 static void
-fd_quic_tls_cv_signer( void *        signer_ctx,
-                       uchar         signature[ static 64 ],
-                       uchar const   payload[ static 130] ) {
-  fd_keyguard_client_sign( signer_ctx, signature, payload, 130UL, FD_KEYGUARD_SIGN_TYPE_ED25519 );
+quic_tls_cv_sign( void *      signer_ctx,
+                  uchar       signature[ static 64 ],
+                  uchar const payload[ static 130 ] ) {
+  fd_quic_ctx_t * ctx = signer_ctx;
+  fd_sha512_t * sha512 = fd_sha512_join( ctx->sha512 );
+  fd_ed25519_sign( signature, payload, 130UL, ctx->tls_pub_key, ctx->tls_priv_key, sha512 );
+  fd_sha512_leave( sha512 );
 }
 
 static void
@@ -524,16 +523,14 @@ unprivileged_init( fd_topo_t *      topo,
                    fd_topo_tile_t * tile ) {
   void * scratch = fd_topo_obj_laddr( topo, tile->tile_obj_id );
 
-  if( FD_UNLIKELY( tile->in_cnt<2UL ||
-                   strcmp( topo->links[ tile->in_link_id[ 0UL ] ].name, "net_quic" ) ||
-                   strcmp( topo->links[ tile->in_link_id[ tile->in_cnt-1UL ] ].name, "sign_quic" ) ) )
+  if( FD_UNLIKELY( tile->in_cnt<1UL ||
+                   strcmp( topo->links[ tile->in_link_id[ 0UL ] ].name, "net_quic" ) ) )
     FD_LOG_ERR(( "quic tile has none or unexpected input links %lu %s %s",
                  tile->in_cnt, topo->links[ tile->in_link_id[ 0 ] ].name, topo->links[ tile->in_link_id[ 1 ] ].name ));
 
-  if( FD_UNLIKELY( tile->out_cnt!=3UL ||
+  if( FD_UNLIKELY( tile->out_cnt!=2UL ||
                    strcmp( topo->links[ tile->out_link_id[ 0UL ] ].name, "quic_verify" ) ||
-                   strcmp( topo->links[ tile->out_link_id[ 1UL ] ].name, "quic_net" ) ||
-                   strcmp( topo->links[ tile->out_link_id[ 2UL ] ].name, "quic_sign" ) ) )
+                   strcmp( topo->links[ tile->out_link_id[ 1UL ] ].name, "quic_net" ) ) )
     FD_LOG_ERR(( "quic tile has none or unexpected output links %lu %s %s",
                  tile->out_cnt, topo->links[ tile->out_link_id[ 0 ] ].name, topo->links[ tile->out_link_id[ 1 ] ].name ));
 
@@ -548,15 +545,12 @@ unprivileged_init( fd_topo_t *      topo,
 
   /* End privileged allocs */
 
-  fd_topo_link_t * sign_in = &topo->links[ tile->in_link_id[ tile->in_cnt-1UL ] ];
-  fd_topo_link_t * sign_out = &topo->links[ tile->out_link_id[ 2UL ] ];
-  FD_TEST( fd_keyguard_client_join( fd_keyguard_client_new( ctx->keyguard_client,
-                                                            sign_out->mcache,
-                                                            sign_out->dcache,
-                                                            sign_in->mcache,
-                                                            sign_in->dcache ) ) );
+  FD_TEST( getrandom( ctx->tls_priv_key, ED25519_PRIV_KEY_SZ, 0 )==ED25519_PRIV_KEY_SZ );
+  fd_sha512_t * sha512 = fd_sha512_join( fd_sha512_new( ctx->sha512 ) );
+  fd_ed25519_public_from_private( ctx->tls_pub_key, ctx->tls_priv_key, sha512 );
+  fd_sha512_leave( sha512 );
 
-  fd_aio_t * quic_tx_aio = fd_aio_join( fd_aio_new( FD_SCRATCH_ALLOC_APPEND( l, fd_aio_align(), fd_aio_footprint() ), ctx, quic_tx_aio_send ) );
+  fd_aio_t * quic_tx_aio = fd_aio_join( fd_aio_new( ctx->quic_tx_aio, ctx, quic_tx_aio_send ) );
   if( FD_UNLIKELY( !quic_tx_aio ) ) FD_LOG_ERR(( "fd_aio_join failed" ));
 
   fd_quic_limits_t limits = quic_limits( tile );
@@ -578,10 +572,10 @@ unprivileged_init( fd_topo_t *      topo,
   quic->config.initial_rx_max_stream_data = FD_TXN_MTU;
   quic->config.retry                      = tile->quic.retry;
   fd_memcpy( quic->config.link.src_mac_addr, tile->quic.src_mac_addr, 6 );
-  fd_memcpy( quic->config.identity_public_key, ctx->identity_public_key, 32UL );
+  fd_memcpy( quic->config.identity_public_key, ctx->tls_pub_key, ED25519_PUB_KEY_SZ );
 
-  quic->config.sign         = fd_quic_tls_cv_signer;
-  quic->config.sign_ctx     = ctx->keyguard_client;
+  quic->config.sign         = quic_tls_cv_sign;
+  quic->config.sign_ctx     = ctx;
 
   quic->cb.conn_new         = quic_conn_new;
   quic->cb.conn_hs_complete = NULL;

--- a/src/app/fdctl/run/tiles/fd_sign.c
+++ b/src/app/fdctl/run/tiles/fd_sign.c
@@ -233,11 +233,6 @@ unprivileged_init_sensitive( fd_topo_t *      topo,
       FD_TEST( !strcmp( out_link->name, "sign_shred" ) );
       FD_TEST( in_link->mtu==32UL );
       FD_TEST( out_link->mtu==64UL );
-    } else if( !strcmp( in_link->name, "quic_sign" ) ) {
-      ctx->in_role[ i ] = FD_KEYGUARD_ROLE_QUIC;
-      FD_TEST( !strcmp( out_link->name, "sign_quic" ) );
-      FD_TEST( in_link->mtu==130UL );
-      FD_TEST( out_link->mtu==64UL );
     } else if ( !strcmp( in_link->name, "gossip_sign" ) ) {
       ctx->in_role[ i ] = FD_KEYGUARD_ROLE_GOSSIP;
       FD_TEST( !strcmp( out_link->name, "sign_gossip" ) );

--- a/src/app/fdctl/run/topos/fd_firedancer.c
+++ b/src/app/fdctl/run/topos/fd_firedancer.c
@@ -83,9 +83,6 @@ fd_topo_initialize( config_t * config ) {
 
   fd_topob_wksp( topo, "poh_shred"    );
 
-  fd_topob_wksp( topo, "quic_sign"    );
-  fd_topob_wksp( topo, "sign_quic"    );
-
   fd_topob_wksp( topo, "shred_sign"   );
   fd_topob_wksp( topo, "sign_shred"   );
 
@@ -155,8 +152,6 @@ fd_topo_initialize( config_t * config ) {
   /* See long comment in fd_shred.c for an explanation about the size of this dcache. */
   FOR(shred_tile_cnt)  fd_topob_link( topo, "shred_storei", "shred_storei", 0,        65536UL,                                  4UL*FD_SHRED_STORE_MTU,        4UL+config->tiles.shred.max_pending_shred_sets );
 
-  FOR(quic_tile_cnt)   fd_topob_link( topo, "quic_sign",    "quic_sign",    0,        128UL,                                    130UL,                         1UL );
-  FOR(quic_tile_cnt)   fd_topob_link( topo, "sign_quic",    "sign_quic",    0,        128UL,                                    64UL,                          1UL );
   FOR(shred_tile_cnt)  fd_topob_link( topo, "shred_sign",   "shred_sign",   0,        128UL,                                    32UL,                          1UL );
   FOR(shred_tile_cnt)  fd_topob_link( topo, "sign_shred",   "sign_shred",   0,        128UL,                                    64UL,                          1UL );
 
@@ -348,13 +343,6 @@ fd_topo_initialize( config_t * config ) {
      so there's at most one fragment in flight at a time anyway.  The
      sign links are also not polled by the mux, instead the tiles will
      read the sign responses out of band in a dedicated spin loop. */
-  for( ulong i=0UL; i<quic_tile_cnt; i++ ) {
-    /**/               fd_topob_tile_in(  topo, "sign",   0UL,           "metric_in", "quic_sign",      i,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED   );
-    /**/               fd_topob_tile_out( topo, "quic",     i,                        "quic_sign",      i                                                  );
-    /**/               fd_topob_tile_in(  topo, "quic",     i,           "metric_in", "sign_quic",      i,          FD_TOPOB_UNRELIABLE, FD_TOPOB_UNPOLLED );
-    /**/               fd_topob_tile_out( topo, "sign",   0UL,                        "sign_quic",      i                                                  );
-  }
-
   for( ulong i=0UL; i<shred_tile_cnt; i++ ) {
     /**/               fd_topob_tile_in(  topo, "sign",   0UL,           "metric_in", "shred_sign",    i,            FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED   );
     /**/               fd_topob_tile_out( topo, "shred",  i,                          "shred_sign",    i                                                    );

--- a/src/app/fdctl/run/topos/fd_frankendancer.c
+++ b/src/app/fdctl/run/topos/fd_frankendancer.c
@@ -33,8 +33,6 @@ fd_topo_initialize( config_t * config ) {
   fd_topob_wksp( topo, "stake_out"    );
   fd_topob_wksp( topo, "metric_in"    );
 
-  fd_topob_wksp( topo, "quic_sign"    );
-  fd_topob_wksp( topo, "sign_quic"    );
   fd_topob_wksp( topo, "shred_sign"   );
   fd_topob_wksp( topo, "sign_shred"   );
 
@@ -79,8 +77,6 @@ fd_topo_initialize( config_t * config ) {
   /* See long comment in fd_shred.c for an explanation about the size of this dcache. */
   FOR(shred_tile_cnt)  fd_topob_link( topo, "shred_store",  "shred_store",  0,        16384UL,                                  4UL*FD_SHRED_STORE_MTU, 4UL+config->tiles.shred.max_pending_shred_sets );
 
-  FOR(quic_tile_cnt)   fd_topob_link( topo, "quic_sign",    "quic_sign",    0,        128UL,                                    130UL,                  1UL );
-  FOR(quic_tile_cnt)   fd_topob_link( topo, "sign_quic",    "sign_quic",    0,        128UL,                                    64UL,                   1UL );
   FOR(shred_tile_cnt)  fd_topob_link( topo, "shred_sign",   "shred_sign",   0,        128UL,                                    32UL,                   1UL );
   FOR(shred_tile_cnt)  fd_topob_link( topo, "sign_shred",   "sign_shred",   0,        128UL,                                    64UL,                   1UL );
 
@@ -222,12 +218,6 @@ fd_topo_initialize( config_t * config ) {
      sign links are also not polled by the mux, instead the tiles will
      read the sign responses out of band in a dedicated spin loop. */
 
-  for( ulong i=0UL; i<quic_tile_cnt; i++ ) {
-    /**/               fd_topob_tile_in(  topo, "sign",   0UL,           "metric_in", "quic_sign",      i,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED   );
-    /**/               fd_topob_tile_out( topo, "quic",     i,                        "quic_sign",      i                                                  );
-    /**/               fd_topob_tile_in(  topo, "quic",     i,           "metric_in", "sign_quic",      i,          FD_TOPOB_UNRELIABLE, FD_TOPOB_UNPOLLED );
-    /**/               fd_topob_tile_out( topo, "sign",   0UL,                        "sign_quic",      i                                                  );
-  }
   for( ulong i=0UL; i<shred_tile_cnt; i++ ) {
     /**/               fd_topob_tile_in(  topo, "sign",   0UL,           "metric_in", "shred_sign",     i,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED   );
     /**/               fd_topob_tile_out( topo, "shred",  i,                          "shred_sign",     i                                                  );

--- a/src/disco/keyguard/fd_keyguard.h
+++ b/src/disco/keyguard/fd_keyguard.h
@@ -19,7 +19,6 @@ FD_PROTOTYPES_BEGIN
 #define FD_KEYGUARD_ROLE_VOTER   (0)  /* vote transaction sender */
 #define FD_KEYGUARD_ROLE_GOSSIP  (1)  /* gossip participant */
 #define FD_KEYGUARD_ROLE_LEADER  (2)  /* block producer (shreds) */
-#define FD_KEYGUARD_ROLE_QUIC    (3)  /* QUIC tile */
 #define FD_KEYGUARD_ROLE_REPAIR  (4)  /* Repair tile */
 #define FD_KEYGUARD_ROLE_BUNDLE  (5)  /* Bundle tile */
 #define FD_KEYGUARD_ROLE_CNT     (6)  /* number of known roles */

--- a/src/disco/keyguard/fd_keyguard_authorize.c
+++ b/src/disco/keyguard/fd_keyguard_authorize.c
@@ -150,14 +150,6 @@ fd_keyguard_payload_authorize( fd_keyguard_authority_t const * authority,
     /* no further restrictions on shred */
     return 1;
 
-  case FD_KEYGUARD_ROLE_QUIC:
-    if( FD_UNLIKELY( payload_mask != FD_KEYGUARD_PAYLOAD_TLS_CV ) ) {
-      FD_LOG_WARNING(( "unauthorized payload type for quic (mask=%#lx)", payload_mask ));
-      return 0;
-    }
-    /* no further restrictions on TLS CertificateVerify */
-    return 1;
-
   case FD_KEYGUARD_ROLE_BUNDLE:
     if( FD_UNLIKELY( payload_mask != FD_KEYGUARD_PAYLOAD_BUNDLE ) ) {
       FD_LOG_WARNING(( "unauthorized payload type for bundle (mask=%#lx)", payload_mask ));


### PR DESCRIPTION
Agave TPU clients ignore the server's TLS public key.
Thus, we can generate a random throwaway key on startup instead of
reusing the identity key.  This improves our security architecture
and removes a potential performance bottleneck with the keyguard tile.
