### PR TITLE
Revert "xdp: update bpf maps with multihome ips"

### DIFF
--- a/src/app/fdctl/run/tiles/fd_net.c
+++ b/src/app/fdctl/run/tiles/fd_net.c
@@ -576,8 +576,6 @@ privileged_init( fd_topo_t *      topo,
     if( FD_UNLIKELY( !lo_idx ) ) FD_LOG_ERR(( "if_nametoindex(lo) failed" ));
 
     fd_xdp_fds_t lo_fds = fd_xdp_install( lo_idx,
-                                          tile->net.multihome_ip_addrs_cnt,
-                                          tile->net.multihome_ip_addrs,
                                           tile->net.src_ip_addr,
                                           sizeof(udp_port_candidates)/sizeof(udp_port_candidates[0]),
                                           udp_port_candidates,

--- a/src/disco/topo/fd_topo_run.c
+++ b/src/disco/topo/fd_topo_run.c
@@ -210,8 +210,6 @@ fd_topo_install_xdp( fd_topo_t * topo ) {
   if( FD_UNLIKELY( !if_idx ) ) FD_LOG_ERR(( "if_nametoindex(%s) failed", net0_tile->net.interface ));
 
   fd_xdp_fds_t xdp_fds = fd_xdp_install( if_idx,
-                                         net0_tile->net.multihome_ip_addrs_cnt,
-                                         net0_tile->net.multihome_ip_addrs,
                                          net0_tile->net.src_ip_addr,
                                          sizeof(udp_port_candidates)/sizeof(udp_port_candidates[0]),
                                          udp_port_candidates,

--- a/src/waltz/xdp/fd_xdp1.c
+++ b/src/waltz/xdp/fd_xdp1.c
@@ -38,12 +38,10 @@ struct __attribute__((aligned(8))) bpf_link_create {
 
 fd_xdp_fds_t
 fd_xdp_install( uint           if_idx,
-                ulong          multihome_ip_addr_cnt,
-                uint   const * multihome_ip_addrs,
-                uint           src_ip_addr,
+                uint           ip_addr,
                 ulong          ports_cnt,
                 ushort const * ports,
-                char   const * xdp_mode ) {
+                char const *   xdp_mode ) {
   union bpf_attr attr = {
     .map_type    = BPF_MAP_TYPE_HASH,
     .map_name    = "fd_xdp_udp_dsts",
@@ -59,7 +57,7 @@ fd_xdp_install( uint           if_idx,
     if( FD_UNLIKELY( !port ) ) continue;  /* port 0 implies drop */
 
     uint value = 1U;
-    ulong key  = ((ulong)(src_ip_addr)<<16 ) | fd_ushort_bswap( port );
+    ulong key  = ((ulong)(ip_addr)<<16 ) | fd_ushort_bswap( port );
     union bpf_attr attr = {
       .map_fd   = (uint)udp_dsts_map_fd,
       .key      = (ulong)&key,
@@ -70,27 +68,6 @@ fd_xdp_install( uint           if_idx,
     if( FD_UNLIKELY( -1L==bpf( BPF_MAP_UPDATE_ELEM, &attr, sizeof(union bpf_attr) ) ) ) {
       FD_LOG_ERR(( "bpf_map_update_elem(fd=%d,key=%#lx,value=%#x,flags=0) failed (%i-%s)",
                     udp_dsts_map_fd, key, value, errno, fd_io_strerror( errno ) ));
-    }
-  }
-  /* Add multihoming ip addresses to the map as well */
-  for ( ulong i=0UL; i<multihome_ip_addr_cnt; i++ ) {
-    for( ulong bind_id=0UL; bind_id<ports_cnt; bind_id++ ) {
-      ushort port = (ushort)ports[bind_id];
-      if( FD_UNLIKELY( !port ) ) continue;  /* port 0 implies drop */
-
-      uint value = 1U;
-      ulong key  = ((ulong)(multihome_ip_addrs[i])<<16 ) | fd_ushort_bswap( port );
-      union bpf_attr attr = {
-        .map_fd   = (uint)udp_dsts_map_fd,
-        .key      = (ulong)&key,
-        .value    = (ulong)&value,
-        .flags    = 0UL
-      };
-
-      if( FD_UNLIKELY( -1L==bpf( BPF_MAP_UPDATE_ELEM, &attr, sizeof(union bpf_attr) ) ) ) {
-        FD_LOG_ERR(( "bpf_map_update_elem(fd=%d,key=%#lx,value=%#x,flags=0) failed (%i-%s)",
-                      udp_dsts_map_fd, key, value, errno, fd_io_strerror( errno ) ));
-      }
     }
   }
 

--- a/src/waltz/xdp/fd_xdp1.h
+++ b/src/waltz/xdp/fd_xdp1.h
@@ -27,11 +27,9 @@ typedef struct fd_xdp_fds fd_xdp_fds_t;
 
 fd_xdp_fds_t
 fd_xdp_install( uint           if_idx,
-                ulong          multihome_ip_addrs_cnt,
-                uint   const * multihome_ip_addrs,
-                uint           src_ip_addr,
+                uint           ip_addr,
                 ulong          ports_cnt,
                 ushort const * ports,
-                char   const * xdp_mode );
+                char const *   xdp_mode );
 
 #endif /* HEADER_fd_src_waltz_xdp_fd_xdp1_h */


### PR DESCRIPTION
Reverts firedancer-io/firedancer#3349

3349 does not correctly implement routing for return packets which leads to QUIC connection failures.