### PR TITLE
quic: fix FD_QUIC_FRAME_TYPES off-by-one

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -5798,7 +5798,7 @@ fd_quic_frame_handle_conn_close_0_frame(
     return FD_QUIC_PARSE_FAIL;
   }
 
-  /* the information here can be invaluble for debugging */
+  /* the information here can be invaluable for debugging */
   FD_DEBUG(
     char reason_buf[256] = {0};
     ulong reason_len = fd_ulong_min( sizeof(reason_buf)-1, reason_phrase_length );
@@ -5831,7 +5831,7 @@ fd_quic_frame_handle_conn_close_1_frame(
     return FD_QUIC_PARSE_FAIL;
   }
 
-  /* the information here can be invaluble for debugging */
+  /* the information here can be invaluable for debugging */
   FD_DEBUG(
     char reason_buf[256] = {0};
     ulong reason_len = fd_ulong_min( sizeof(reason_buf)-1, reason_phrase_length );

--- a/src/waltz/quic/templ/fd_quic_frame.c
+++ b/src/waltz/quic/templ/fd_quic_frame.c
@@ -46,7 +46,7 @@
   X(0x1d, 18, conn_close_1,        "Section 19.19",  _, _, 0, 1,   N,  )   \
   X(0x1e, 19, handshake_done,      "Section 19.20",  _, _, _, 1,    ,  )
 
-#define FD_QUIC_FRAME_TYPE_CNT (0x20) /* lookup tables should have this many entries */
+#define FD_QUIC_FRAME_TYPE_CNT (0x1f) /* lookup tables should have this many entries */
 
 
 /* Lookup table for allowed frame types *******************************/


### PR DESCRIPTION
\+ drive-by typo fixes