### PR TITLE
[WIP] flamenco, vm: implement 2.1 SIMDs

### DIFF
--- a/src/ballet/sbpf/fd_sbpf_loader.c
+++ b/src/ballet/sbpf/fd_sbpf_loader.c
@@ -1227,7 +1227,8 @@ fd_sbpf_program_load( fd_sbpf_program_t *  prog,
                       void const *         _bin,
                       ulong                elf_sz,
                       fd_sbpf_syscalls_t * syscalls,
-                      int                  elf_deploy_checks ) {
+                      int                  elf_deploy_checks,
+                      int                  sbpf_version_header ) {
   fd_sbpf_loader_seterr( 0, 0 );
 
   int err;
@@ -1249,6 +1250,12 @@ fd_sbpf_program_load( fd_sbpf_program_t *  prog,
     .dynsym_cnt = 0U,
     .elf_deploy_checks = elf_deploy_checks
   };
+
+  /* Read the SBPF version from the header */
+  prog->sbpf_version = FD_SBPF_VERSION_1;
+  if ( sbpf_version_header ) {
+    prog->sbpf_version = elf->ehdr.e_version;
+  }
 
   /* Find dynamic section */
   if( FD_UNLIKELY( (err=fd_sbpf_find_dynamic( &loader, elf, elf_sz, &prog->info ))!=0 ) )

--- a/src/ballet/sbpf/fd_sbpf_loader.h
+++ b/src/ballet/sbpf/fd_sbpf_loader.h
@@ -12,6 +12,12 @@
 #include "../../util/fd_util_base.h"
 #include "../elf/fd_elf64.h"
 
+/* SBPF Versions *******************************************************/
+#define FD_SBPF_VERSION_1                       (1UL)
+#define FD_SBPF_VERSION_DYNAMIC_STACK_FRAMES    (2UL)
+#define FD_SBPF_VERSION_ARITHMETIC_IMPROVEMENTS (3UL)
+#define FD_SBPF_VERSION_STATIC_SYCALLS          (4UL)
+
 /* Error types ********************************************************/
 
 /* FIXME make error types more specific */
@@ -134,6 +140,9 @@ struct __attribute__((aligned(32UL))) fd_sbpf_program {
   void * calldests_shmem;
   /* Local join to bit vector of valid call destinations */
   fd_sbpf_calldests_t * calldests;
+
+  /* SBPF version */
+  ulong sbpf_version;
 };
 typedef struct fd_sbpf_program fd_sbpf_program_t;
 
@@ -217,7 +226,8 @@ fd_sbpf_program_load( fd_sbpf_program_t *  prog,
                       void const *         bin,
                       ulong                bin_sz,
                       fd_sbpf_syscalls_t * syscalls,
-                      int                  elf_deploy_checks );
+                      int                  elf_deploy_checks,
+                      int                  sbpf_version_header );
 
 /* fd_sbpf_program_delete destroys the program object and unformats the
    memory regions holding it. */

--- a/src/ballet/sbpf/fuzz_sbpf_loader.c
+++ b/src/ballet/sbpf/fuzz_sbpf_loader.c
@@ -52,7 +52,7 @@ LLVMFuzzerTestOneInput( uchar const * data,
     fd_sbpf_syscalls_insert( syscalls, *x );
 
   /* Load program */
-  int res = fd_sbpf_program_load( prog, data, size, syscalls, 0 );
+  int res = fd_sbpf_program_load( prog, data, size, syscalls, 0, 1 );
 
   /* Should be able to load at least one program and not load at least one program */
   if ( FD_UNLIKELY( !res ) ) {

--- a/src/ballet/sbpf/test_sbpf_load_prog.c
+++ b/src/ballet/sbpf/test_sbpf_load_prog.c
@@ -91,7 +91,7 @@ main( int     argc,
   for( uint const * x = _syscalls; *x; x++ )
     fd_sbpf_syscalls_insert( syscalls, *x );
 
-  int load_err = fd_sbpf_program_load( prog, bin_buf, bin_sz, syscalls, 1 );
+  int load_err = fd_sbpf_program_load( prog, bin_buf, bin_sz, syscalls, 1, 1 );
 
   FD_LOG_HEXDUMP_NOTICE(( "Output rodata segment", prog->rodata, prog->rodata_sz ));
 

--- a/src/ballet/sbpf/test_sbpf_loader.c
+++ b/src/ballet/sbpf/test_sbpf_loader.c
@@ -52,7 +52,7 @@ void test_duplicate_entrypoint_entry( void ) {
   for( uint const * x = _syscalls; *x; x++ )
       fd_sbpf_syscalls_insert( syscalls, *x );
 
-  int res = fd_sbpf_program_load( prog, duplicate_entrypoint_entry_elf, duplicate_entrypoint_entry_elf_sz, syscalls, /* deploy checks */ 1 );
+  int res = fd_sbpf_program_load( prog, duplicate_entrypoint_entry_elf, duplicate_entrypoint_entry_elf_sz, syscalls, /* deploy checks */ 1, 1 );
   FD_TEST( res == 0 );
 
   // end of boilerplate

--- a/src/flamenco/features/fd_features_generated.c
+++ b/src/flamenco/features/fd_features_generated.c
@@ -1229,6 +1229,24 @@ fd_feature_id_t const ids[] = {
     .name       = "partitioned_epoch_rewards_superfeature",
     .cleaned_up = {UINT_MAX, UINT_MAX, UINT_MAX} },
 
+  { .index      = offsetof(fd_features_t, sbpf_version_dynamic_frames)>>3,
+    .id         = {"\x6e\x64\x3d\x1c\xc3\x70\xb5\x94\xb7\xdf\xb1\xb0\xc4\x1a\x9a\xdd\xea\x64\xee\x31\x29\x1d\x77\x1d\x29\xdc\xd9\x1e\x9e\x05\xb9\xd4"},
+                  /* 8RvVua5yJVxtumWa76YYfUb7qktRGGAD4nFtBYeHqSDy */
+    .name       = "sbpf_version_dynamic_frames",
+    .cleaned_up = {UINT_MAX, UINT_MAX, UINT_MAX} },
+
+  { .index      = offsetof(fd_features_t, sbpf_version_arithmetic_improvements)>>3,
+    .id         = {"\xee\x68\x0d\x98\x17\xa5\x7c\x51\xd5\x4d\x85\x1e\x2d\x1c\xcd\x01\x64\xc8\x7a\x77\x27\xad\x21\x81\x38\xfc\xa1\x0d\x15\x64\x98\x1b"},
+                  /* H3e4KHE2nctvqdm1DPTw1q5xt858JdaBxene37FberJv */
+    .name       = "sbpf_version_arithmetic_improvements",
+    .cleaned_up = {UINT_MAX, UINT_MAX, UINT_MAX} },
+
+  { .index      = offsetof(fd_features_t, sbpf_version_static_syscalls)>>3,
+    .id         = {"\x38\xc1\x2f\x73\x9c\x5d\xb2\x18\x63\x33\x59\x50\xa2\x94\xa4\x92\x9a\x2b\xe8\x06\xab\x79\x28\x54\x28\x75\x8d\x5f\x23\x8b\x6b\x83"},
+                  /* 4pYgjxhp1EkCLuQc32xh2A38V9QLR3cxB9VvkQJGZQLi */
+    .name       = "sbpf_version_static_syscalls",
+    .cleaned_up = {UINT_MAX, UINT_MAX, UINT_MAX} },
+
   { .index = ULONG_MAX }
 };
 
@@ -1443,6 +1461,9 @@ fd_feature_id_query( ulong prefix ) {
   case 0x0b9047b5bb9ef961: return &ids[ 200 ];
   case 0xa5a66405d0ab6309: return &ids[ 201 ];
   case 0x81fcbfa0d0f6b105: return &ids[ 202 ];
+  case 0x94b570c31c3d646e: return &ids[ 203 ];
+  case 0x517ca517980d68ee: return &ids[ 204 ];
+  case 0x18b25d9c732fc138: return &ids[ 205 ];
   default: break;
   }
 
@@ -1654,5 +1675,8 @@ FD_STATIC_ASSERT( offsetof( fd_features_t, zk_elgamal_proof_program_enabled     
 FD_STATIC_ASSERT( offsetof( fd_features_t, move_stake_and_move_lamports_ixs                        )>>3==200UL, layout );
 FD_STATIC_ASSERT( offsetof( fd_features_t, deprecate_legacy_vote_ixs                               )>>3==201UL, layout );
 FD_STATIC_ASSERT( offsetof( fd_features_t, partitioned_epoch_rewards_superfeature                  )>>3==202UL, layout );
+FD_STATIC_ASSERT( offsetof( fd_features_t, sbpf_version_dynamic_frames                             )>>3==203UL, layout );
+FD_STATIC_ASSERT( offsetof( fd_features_t, sbpf_version_arithmetic_improvements                    )>>3==204UL, layout );
+FD_STATIC_ASSERT( offsetof( fd_features_t, sbpf_version_static_syscalls                            )>>3==205UL, layout );
 
 FD_STATIC_ASSERT( sizeof( fd_features_t )>>3==FD_FEATURE_ID_CNT, layout );

--- a/src/flamenco/features/fd_features_generated.h
+++ b/src/flamenco/features/fd_features_generated.h
@@ -6,7 +6,7 @@
 
 /* FEATURE_ID_CNT is the number of features in ids */
 
-#define FD_FEATURE_ID_CNT (203UL)
+#define FD_FEATURE_ID_CNT (206UL)
 
 union fd_features {
 
@@ -216,6 +216,9 @@ union fd_features {
     /* 0x0b9047b5bb9ef961 */ ulong move_stake_and_move_lamports_ixs;
     /* 0xa5a66405d0ab6309 */ ulong deprecate_legacy_vote_ixs;
     /* 0x81fcbfa0d0f6b105 */ ulong partitioned_epoch_rewards_superfeature;
+    /* 0x94b570c31c3d646e */ ulong sbpf_version_dynamic_frames;
+    /* 0x517ca517980d68ee */ ulong sbpf_version_arithmetic_improvements;
+    /* 0x18b25d9c732fc138 */ ulong sbpf_version_static_syscalls;
   };
 
 };

--- a/src/flamenco/features/feature_map.json
+++ b/src/flamenco/features/feature_map.json
@@ -201,5 +201,8 @@
   {"name":"zk_elgamal_proof_program_enabled","pubkey":"zkhiy5oLowR7HY4zogXjCjeMXyruLqBwSWH21qcFtnv"},
   {"name":"move_stake_and_move_lamports_ixs","pubkey":"7bTK6Jis8Xpfrs8ZoUfiMDPazTcdPcTWheZFJTA5Z6X4"},
   {"name":"deprecate_legacy_vote_ixs","pubkey":"depVvnQ2UysGrhwdiwU42tCadZL8GcBb1i2GYhMopQv"},
-  {"name":"partitioned_epoch_rewards_superfeature","pubkey":"PERzQrt5gBD1XEe2c9XdFWqwgHY3mr7cYWbm5V772V8"}
+  {"name":"partitioned_epoch_rewards_superfeature","pubkey":"PERzQrt5gBD1XEe2c9XdFWqwgHY3mr7cYWbm5V772V8"},
+  {"name":"sbpf_version_dynamic_frames","pubkey":"8RvVua5yJVxtumWa76YYfUb7qktRGGAD4nFtBYeHqSDy"},
+  {"name":"sbpf_version_arithmetic_improvements","pubkey":"H3e4KHE2nctvqdm1DPTw1q5xt858JdaBxene37FberJv"},
+  {"name":"sbpf_version_static_syscalls","pubkey":"4pYgjxhp1EkCLuQc32xh2A38V9QLR3cxB9VvkQJGZQLi"}
 ]

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -274,7 +274,8 @@ deploy_program( fd_exec_instr_ctx_t * instr_ctx,
   }
 
   /* Load program */
-  int err = fd_sbpf_program_load( prog, programdata, programdata_size, syscalls, deploy_mode );
+  int err = fd_sbpf_program_load( prog, programdata, programdata_size, syscalls, deploy_mode, 
+    FD_FEATURE_ACTIVE( instr_ctx->slot_ctx, sbpf_version_dynamic_frames ) );
   if( FD_UNLIKELY( err ) ) {
     FD_LOG_WARNING(( "fd_sbpf_program_load() failed: %s", fd_sbpf_strerror() ));
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;

--- a/src/flamenco/runtime/program/fd_bpf_program_util.c
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.c
@@ -164,7 +164,8 @@ fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t    * slot_ctx,
 
     /* Load program. */
 
-    if( FD_UNLIKELY( 0!=fd_sbpf_program_load( prog, program_data, program_data_len, syscalls, false ) ) ) {
+    if( FD_UNLIKELY( 0!=fd_sbpf_program_load( prog, program_data, program_data_len, syscalls, false,
+      FD_FEATURE_ACTIVE( slot_ctx, sbpf_version_dynamic_frames ) ) ) ) {
       /* Remove pending funk record */
       FD_LOG_DEBUG(( "fd_sbpf_program_load() failed: %s", fd_sbpf_strerror() ));
       fd_funk_rec_remove( funk, rec, 0 );

--- a/src/flamenco/vm/fd_vm.c
+++ b/src/flamenco/vm/fd_vm.c
@@ -303,8 +303,13 @@ fd_vm_validate( fd_vm_t const * vm ) {
 
       if ( vm->sbpf_version == FD_SBPF_VERSION_STATIC_SYCALLS ) {
         /* Check the jump offset is to a code location inside the same function */
-        if ( i < function_start_instruction || i > function_end_instruction ) {
+        if ( jmp_dst < (long)function_start_instruction || jmp_dst > (long)function_end_instruction ) {
           return FD_VM_ERR_JUMP_OUT_OF_CODE;
+        }
+
+        /* Check that the jump does not jump to the middle of a LDDW instruction */
+        if ( FD_UNLIKELY( fd_sbpf_instr( text[ jmp_dst ] ).opcode.raw==0 ) ) {
+          return FD_VM_ERR_JUMP_TO_MIDDLE_OF_LDDW;
         }
       }
 

--- a/src/flamenco/vm/fd_vm.c
+++ b/src/flamenco/vm/fd_vm.c
@@ -171,6 +171,7 @@ fd_vm_validate( fd_vm_t const * vm ) {
 # define FD_INVALID     ((uchar)8) /* The opcode is invalid */
 # define FD_CHECK_CALLX ((uchar)9) /* Validation should check that callx has valid register number */
 # define FD_CHECK_ADD   ((uchar)10) /* Validation should check that the instruction is a valid ADD instruction */
+# define FD_CHECK_CALL_IMM ((uchar)11) /* Validation should check that callimm jumps to a valid program counter */
 
   static uchar const validation_map[ 256 ] = {
     /* 0x00 */ FD_INVALID,    /* 0x01 */ FD_INVALID,    /* 0x02 */ FD_INVALID,    /* 0x03 */ FD_INVALID,
@@ -206,7 +207,7 @@ fd_vm_validate( fd_vm_t const * vm ) {
     /* 0x78 */ FD_INVALID,    /* 0x79 */ FD_VALID,      /* 0x7a */ FD_CHECK_ST,   /* 0x7b */ FD_CHECK_ST,
     /* 0x7c */ FD_VALID,      /* 0x7d */ FD_CHECK_JMP,  /* 0x7e */ FD_INVALID,    /* 0x7f */ FD_VALID,
     /* 0x80 */ FD_INVALID,    /* 0x81 */ FD_INVALID,    /* 0x82 */ FD_INVALID,    /* 0x83 */ FD_INVALID,
-    /* 0x84 */ FD_VALID,      /* 0x85 */ FD_VALID,      /* 0x86 */ FD_INVALID,    /* 0x87 */ FD_VALID,
+    /* 0x84 */ FD_VALID,      /* 0x85 */ FD_CHECK_CALL_IMM, /* 0x86 */ FD_INVALID,    /* 0x87 */ FD_VALID,
     /* 0x88 */ FD_INVALID,    /* 0x89 */ FD_INVALID,    /* 0x8a */ FD_INVALID,    /* 0x8b */ FD_INVALID,
     /* 0x8c */ FD_INVALID,    /* 0x8d */ FD_CHECK_CALLX,/* 0x8e */ FD_INVALID,    /* 0x8f */ FD_INVALID,
     /* 0x90 */ FD_INVALID,    /* 0x91 */ FD_INVALID,    /* 0x92 */ FD_INVALID,    /* 0x93 */ FD_INVALID,
@@ -353,6 +354,16 @@ fd_vm_validate( fd_vm_t const * vm ) {
          https://github.com/solana-labs/rbpf/blob/v0.8.1/src/verifier.rs#L218 */
       if( FD_UNLIKELY( instr.imm > 9 ) ) {
         return FD_VM_ERR_INVALID_REG;
+      }
+      break;
+    }
+
+    case FD_CHECK_CALL_IMM: {
+      /* Check that the destination is a valid calldest */
+      if ( vm->sbpf_version == FD_SBPF_VERSION_STATIC_SYCALLS ) {
+        if ( FD_UNLIKELY( fd_sbpf_calldests_test( vm->calldests, instr.imm ) ) ) {
+          return FD_VM_ERR_INVALID_FUNCTION;
+        }
       }
       break;
     }

--- a/src/flamenco/vm/fd_vm.h
+++ b/src/flamenco/vm/fd_vm.h
@@ -205,7 +205,7 @@ struct __attribute__((aligned(FD_VM_HOST_REGION_ALIGN))) fd_vm {
      enabled AND we halt on a segfault caused by a store on an invalid vaddr. */
   ulong segv_store_vaddr;
 
-  /* SBPF version of this program */
+   /* The SBPF version of the executed program. */
   ulong sbpf_version;
 };
 

--- a/src/flamenco/vm/fd_vm.h
+++ b/src/flamenco/vm/fd_vm.h
@@ -214,11 +214,7 @@ struct __attribute__((aligned(FD_VM_HOST_REGION_ALIGN))) fd_vm {
 
 FD_PROTOTYPES_BEGIN
 
-/* SBPF Versions */
-#define FD_VM_SBPF_VERSION_1                       (1UL)
-#define FD_VM_SBPF_VERSION_DYNAMIC_STACK_FRAMES    (2UL)
-#define FD_VM_SBPF_VERSION_ARITHMETIC_IMPROVEMENTS (3UL)
-#define FD_VM_SBPF_VERSION_STATIC_SYCALLS          (4UL)
+
 
 /* FIXME: FD_VM_T NEEDS PROPER CONSTRUCTORS */
 

--- a/src/flamenco/vm/fd_vm.h
+++ b/src/flamenco/vm/fd_vm.h
@@ -204,12 +204,21 @@ struct __attribute__((aligned(FD_VM_HOST_REGION_ALIGN))) fd_vm {
   /* Agave reports different error codes (for developers to understand the failure cause) if direct mapping is 
      enabled AND we halt on a segfault caused by a store on an invalid vaddr. */
   ulong segv_store_vaddr;
+
+  /* SBPF version of this program */
+  ulong sbpf_version;
 };
 
 /* FIXME: MOVE ABOVE INTO PRIVATE WHEN CONSTRUCTORS READY */
 /**********************************************************************/
 
 FD_PROTOTYPES_BEGIN
+
+/* SBPF Versions */
+#define FD_VM_SBPF_VERSION_1                       (1UL)
+#define FD_VM_SBPF_VERSION_DYNAMIC_STACK_FRAMES    (2UL)
+#define FD_VM_SBPF_VERSION_ARITHMETIC_IMPROVEMENTS (3UL)
+#define FD_VM_SBPF_VERSION_STATIC_SYCALLS          (4UL)
 
 /* FIXME: FD_VM_T NEEDS PROPER CONSTRUCTORS */
 

--- a/src/flamenco/vm/fd_vm_base.h
+++ b/src/flamenco/vm/fd_vm_base.h
@@ -79,6 +79,7 @@
 #define FD_VM_SH_OVERFLOW           (-37) /* detected a shift overflow, equivalent to VeriferError::ShiftWithOverflow */
 #define FD_VM_TEXT_SZ_UNALIGNED     (-38) /* detected a text section that is not a multiple of 8 */
 #define FD_VM_ERR_INVALID_R10_WRITE (-39) /* detected a write to R10 */
+#define FD_VM_ERR_INVALID_FUNCTION  (-40) /* invalid function at instruction */
 
 /* Syscall Errors
    https://github.com/anza-xyz/agave/blob/v2.0.7/programs/bpf_loader/src/syscalls/mod.rs#L81 */

--- a/src/flamenco/vm/fd_vm_base.h
+++ b/src/flamenco/vm/fd_vm_base.h
@@ -41,6 +41,7 @@
 #define FD_VM_ERR_SIGCOST     (-16) /* compute unit limit exceeded (syscalls that exceed their budget should use this too) */
 #define FD_VM_ERR_INVALID_PDA (-17) /* the computed pda was not a valid ed25519 point */
 #define FD_VM_ERR_SIGFPE      (-18) /* divide by zero */
+#define FD_VM_ERR_INVAL_JUMP  (-19) /* invalid jump to function not registered */
 
 /* FIXME: Are these exact matches to Solana?  If so, provide link, if
    not, document and refine name / consolidate further. */

--- a/src/flamenco/vm/fd_vm_base.h
+++ b/src/flamenco/vm/fd_vm_base.h
@@ -80,6 +80,7 @@
 #define FD_VM_TEXT_SZ_UNALIGNED     (-38) /* detected a text section that is not a multiple of 8 */
 #define FD_VM_ERR_INVALID_R10_WRITE (-39) /* detected a write to R10 */
 #define FD_VM_ERR_INVALID_FUNCTION  (-40) /* invalid function at instruction */
+#define FD_VM_ERR_JUMP_OUT_OF_CODE  (-41) /* invalid jump out of current function */
 
 /* Syscall Errors
    https://github.com/anza-xyz/agave/blob/v2.0.7/programs/bpf_loader/src/syscalls/mod.rs#L81 */

--- a/src/flamenco/vm/fd_vm_base.h
+++ b/src/flamenco/vm/fd_vm_base.h
@@ -64,23 +64,24 @@
    info arg.  FIXME: Are these exact matches to Solana?  If so, provide
    link, if not, document and refine name / consolidate further. */
 
-#define FD_VM_ERR_INVALID_OPCODE    (-25) /* detected an invalid opcode */
-#define FD_VM_ERR_INVALID_SRC_REG   (-26) /* detected an invalid source register */
-#define FD_VM_ERR_INVALID_DST_REG   (-27) /* detected an invalid destination register */
-#define FD_VM_ERR_INF_LOOP          (-28) /* detected an infinite loop */
-#define FD_VM_ERR_JMP_OUT_OF_BOUNDS (-29) /* detected an out of bounds jump */
-#define FD_VM_ERR_JMP_TO_ADDL_IMM   (-30) /* detected a jump to an addl imm */
-#define FD_VM_ERR_INVALID_END_IMM   (-31) /* detected an invalid immediate for an endianness conversion instruction */
-#define FD_VM_ERR_INCOMPLETE_LDQ    (-32) /* detected an incomplete ldq at program end */
-#define FD_VM_ERR_LDQ_NO_ADDL_IMM   (-33) /* detected a ldq without an addl imm following it */
-#define FD_VM_ERR_NO_SUCH_EXT_CALL  (-34) /* detected a call imm with no function was registered for that immediate */
-#define FD_VM_ERR_INVALID_REG       (-35) /* detected an invalid register */
-#define FD_VM_ERR_BAD_TEXT          (-36) /* detected a bad text section (overflow, outside rodata boundary, etc.,)*/
-#define FD_VM_SH_OVERFLOW           (-37) /* detected a shift overflow, equivalent to VeriferError::ShiftWithOverflow */
-#define FD_VM_TEXT_SZ_UNALIGNED     (-38) /* detected a text section that is not a multiple of 8 */
-#define FD_VM_ERR_INVALID_R10_WRITE (-39) /* detected a write to R10 */
-#define FD_VM_ERR_INVALID_FUNCTION  (-40) /* invalid function at instruction */
-#define FD_VM_ERR_JUMP_OUT_OF_CODE  (-41) /* invalid jump out of current function */
+#define FD_VM_ERR_INVALID_OPCODE         (-25) /* detected an invalid opcode */
+#define FD_VM_ERR_INVALID_SRC_REG        (-26) /* detected an invalid source register */
+#define FD_VM_ERR_INVALID_DST_REG        (-27) /* detected an invalid destination register */
+#define FD_VM_ERR_INF_LOOP               (-28) /* detected an infinite loop */
+#define FD_VM_ERR_JMP_OUT_OF_BOUNDS      (-29) /* detected an out of bounds jump */
+#define FD_VM_ERR_JMP_TO_ADDL_IMM        (-30) /* detected a jump to an addl imm */
+#define FD_VM_ERR_INVALID_END_IMM        (-31) /* detected an invalid immediate for an endianness conversion instruction */
+#define FD_VM_ERR_INCOMPLETE_LDQ         (-32) /* detected an incomplete ldq at program end */
+#define FD_VM_ERR_LDQ_NO_ADDL_IMM        (-33) /* detected a ldq without an addl imm following it */
+#define FD_VM_ERR_NO_SUCH_EXT_CALL       (-34) /* detected a call imm with no function was registered for that immediate */
+#define FD_VM_ERR_INVALID_REG            (-35) /* detected an invalid register */
+#define FD_VM_ERR_BAD_TEXT               (-36) /* detected a bad text section (overflow, outside rodata boundary, etc.,)*/
+#define FD_VM_SH_OVERFLOW                (-37) /* detected a shift overflow, equivalent to VeriferError::ShiftWithOverflow */
+#define FD_VM_TEXT_SZ_UNALIGNED          (-38) /* detected a text section that is not a multiple of 8 */
+#define FD_VM_ERR_INVALID_R10_WRITE      (-39) /* detected a write to R10 */
+#define FD_VM_ERR_INVALID_FUNCTION       (-40) /* invalid function at instruction */
+#define FD_VM_ERR_JUMP_OUT_OF_CODE       (-41) /* invalid jump out of current function */
+#define FD_VM_ERR_JUMP_TO_MIDDLE_OF_LDDW (-42) /* jump to middle of LDDW instruction */
 
 /* Syscall Errors
    https://github.com/anza-xyz/agave/blob/v2.0.7/programs/bpf_loader/src/syscalls/mod.rs#L81 */

--- a/src/flamenco/vm/fd_vm_base.h
+++ b/src/flamenco/vm/fd_vm_base.h
@@ -78,6 +78,7 @@
 #define FD_VM_ERR_BAD_TEXT          (-36) /* detected a bad text section (overflow, outside rodata boundary, etc.,)*/
 #define FD_VM_SH_OVERFLOW           (-37) /* detected a shift overflow, equivalent to VeriferError::ShiftWithOverflow */
 #define FD_VM_TEXT_SZ_UNALIGNED     (-38) /* detected a text section that is not a multiple of 8 */
+#define FD_VM_ERR_INVALID_R10_WRITE (-39) /* detected a write to R10 */
 
 /* Syscall Errors
    https://github.com/anza-xyz/agave/blob/v2.0.7/programs/bpf_loader/src/syscalls/mod.rs#L81 */
@@ -421,6 +422,13 @@ FD_PROTOTYPES_END
    size, in bytes, that a transaction is allowed to load */
 
 #define FD_VM_LOADED_ACCOUNTS_DATA_SIZE_LIMIT           (64UL*1024UL*1024UL) /* 64MiB */
+
+/* SBPF Versions *******************************************************/
+/* FIXME: have one place for these definitions */
+#define FD_SBPF_VERSION_1                       (1UL)
+#define FD_SBPF_VERSION_DYNAMIC_STACK_FRAMES    (2UL)
+#define FD_SBPF_VERSION_ARITHMETIC_IMPROVEMENTS (3UL)
+#define FD_SBPF_VERSION_STATIC_SYCALLS          (4UL)
 
 /* fd_vm_disasm API ***************************************************/
 

--- a/src/flamenco/vm/fd_vm_tool.c
+++ b/src/flamenco/vm/fd_vm_tool.c
@@ -82,7 +82,7 @@ fd_vm_tool_prog_create( fd_vm_tool_prog_t * tool_prog,
   fd_vm_syscall_register_all( syscalls, 0 );
 
   /* Load program */
-  if( FD_UNLIKELY( 0!=fd_sbpf_program_load( prog, bin_buf, bin_sz, syscalls, false ) ) )
+  if( FD_UNLIKELY( 0!=fd_sbpf_program_load( prog, bin_buf, bin_sz, syscalls, false, true ) ) )
     FD_LOG_ERR(( "fd_sbpf_program_load() failed: %s", fd_sbpf_strerror() ));
 
   tool_prog->bin_buf  = bin_buf;


### PR DESCRIPTION
Implementing the vm changes that will be included in the 2.1 release:

SBPF V1:
- [SIMD-0161](https://github.com/solana-foundation/solana-improvement-documents/blob/0cc74f86f28e1698e34cca8431143886843f829a/proposals/0161-sbpf-feature-gating.md): SBPF versioning and feature gating
- [SIMD-0166](https://github.com/solana-foundation/solana-improvement-documents/blob/c5fba114ae4081ad39080f3c6bb62ee7e4dea9f3/proposals/0166-dynamic-stack-frames.md): SBPF Dynamic stack frames

SBPF V2:
- [SIMD-0173](https://github.com/solana-foundation/solana-improvement-documents/blob/06e14a6644e2c583addd918298bb3125d88ba59a/proposals/0173-sbpf-instruction-encoding-improvements.md): SBPF instruction encoding improvements
- [SIMD-0174](https://github.com/solana-foundation/solana-improvement-documents/blob/42ba0ff81a193f71238dc8e0426d4b053bc44fc3/proposals/0174-sbpf-arithmetics-improvements.md): SBPF arithmetics improvements

SBPF V3:
- [SIMD-0178](https://github.com/solana-foundation/solana-improvement-documents/blob/16c0bed961a3372bc2d003471d4fc008bbdfce7b/proposals/0178-static-syscalls.md): SBPF Static Syscalls
- [SIMD-0179](https://github.com/solana-foundation/solana-improvement-documents/blob/128cf8ff18a2d8c1ef956e501312203b35657f01/proposals/0179-stricter-verification.md): SBPF stricter verification constraints
- [SIMD-0189](https://github.com/solana-foundation/solana-improvement-documents/blob/51bec4277c9184d92d03edcdf17c4eabad99ef0a/proposals/0189-sbpf-stricter-elf-headers.md): SBPF stricter ELF headers

Still WIP, I will likely split this into separate PRs when they are all implemented.