### PR TITLE
quic - fix key phase change

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -3659,7 +3659,7 @@ fd_quic_conn_tx( fd_quic_t *      quic,
         uchar sb = conn->spin_bit;
 
         /* one_rtt has a short header */
-        one_rtt.h0           = fd_quic_one_rtt_h0( sb, key_phase, pkt_num_len );
+        one_rtt.h0           = fd_quic_one_rtt_h0( sb, !!key_phase_tx, pkt_num_len );
         one_rtt.pkt_num_bits = 4 * 8;      /* actual number of bits to encode */
 
         /* destination */


### PR DESCRIPTION
This fixes an issue whereby the client initiates a key phase change, but it doesn't complete properly, and we lose the connection.
Also, it removes a line that broke the build.