### PR TITLE
quic: fix fd_tpu_reasm bounds check

### DIFF
--- a/src/app/fdctl/run/tiles/fd_verify.c
+++ b/src/app/fdctl/run/tiles/fd_verify.c
@@ -184,8 +184,8 @@ unprivileged_init( fd_topo_t *      topo,
     if( FD_UNLIKELY( link->is_reasm ) ) {
       fd_topo_wksp_t * link_wksp = &topo->workspaces[ topo->objs[ link->reasm_obj_id ].wksp_id ];
       ctx->in[i].mem = link_wksp->wksp;
-      ctx->in[i].chunk0 = fd_laddr_to_chunk( ctx->in[i].mem, link->reasm );
-      ctx->in[i].wmark  = ctx->in[i].chunk0 + (link->depth+link->burst-1) * FD_TPU_REASM_CHUNK_MTU;
+      ctx->in[i].chunk0 = fd_tpu_reasm_chunk0( link->reasm, link->reasm );
+      ctx->in[i].wmark  = fd_tpu_reasm_wmark ( link->reasm, link->reasm );
     } else {
       fd_topo_wksp_t * link_wksp = &topo->workspaces[ topo->objs[ link->dcache_obj_id ].wksp_id ];
       ctx->in[i].mem = link_wksp->wksp;

--- a/src/disco/quic/fd_tpu.h
+++ b/src/disco/quic/fd_tpu.h
@@ -197,6 +197,19 @@ fd_tpu_reasm_leave( fd_tpu_reasm_t * reasm );
 void *
 fd_tpu_reasm_delete( void * shreasm );
 
+/* fd_tpu_reasm_{chunk0,wmark} returns the chunk index of the {lowest,
+   highest} possible chunk value that fd_tpu_reasm_publish will write to
+   an mcache. */
+
+FD_FN_CONST ulong
+fd_tpu_reasm_chunk0( fd_tpu_reasm_t const * reasm,
+                     void const *           base );
+
+
+FD_FN_CONST ulong
+fd_tpu_reasm_wmark( fd_tpu_reasm_t const * reasm,
+                    void const *           base );
+
 /* Accessor API */
 
 /* fd_tpu_reasm_prepare starts a new stream reassembly.  If more than

--- a/src/disco/quic/fd_tpu_reasm_private.h
+++ b/src/disco/quic/fd_tpu_reasm_private.h
@@ -59,6 +59,12 @@ slot_get_data( fd_tpu_reasm_t * reasm,
   return fd_tpu_reasm_chunks_laddr( reasm ) + (slot_idx * FD_TPU_REASM_MTU);
 }
 
+FD_FN_PURE static inline uchar const *
+slot_get_data_const( fd_tpu_reasm_t const * reasm,
+                     ulong                  slot_idx ) {
+  return fd_tpu_reasm_chunks_laddr_const( reasm ) + (slot_idx * FD_TPU_REASM_MTU);
+}
+
 static FD_FN_UNUSED void
 slot_begin( fd_tpu_reasm_slot_t * slot ) {
   memset( slot, 0, sizeof(fd_tpu_reasm_slot_t) );

--- a/src/disco/quic/test_tpu_reasm.c
+++ b/src/disco/quic/test_tpu_reasm.c
@@ -129,6 +129,18 @@ main( int     argc,
   FD_TEST( reasm->pub_slots_off + (depth    * sizeof(uint))                <= sizeof(tpu_reasm_mem) );
   FD_TEST( reasm->chunks_off    + (slot_cnt * FD_TPU_REASM_MTU)            <= sizeof(tpu_reasm_mem) );
 
+  do {
+    void * base   = (void *)( (ulong)reasm - (4UL<<FD_CHUNK_LG_SZ) );
+    ulong  chunk0 = fd_tpu_reasm_chunk0( reasm, base );
+    ulong  wmark  = fd_tpu_reasm_wmark ( reasm, base );
+    FD_TEST( chunk0<wmark );
+
+    FD_TEST( chunk0 == (reasm->chunks_off>>FD_CHUNK_LG_SZ) + 4UL );
+    FD_TEST( wmark-chunk0 == (slot_cnt-1UL)*FD_TPU_REASM_CHUNK_MTU );
+    FD_TEST( fd_chunk_to_laddr( base, chunk0 ) == chunks );
+    FD_TEST( fd_chunk_to_laddr( base, wmark  ) == chunks+((slot_cnt-1UL)*FD_TPU_REASM_MTU) );
+  } while(0);
+
   /* Confirm that the data regions of slots don't overlap */
 
   memset( (uchar *)( (ulong)reasm + reasm->chunks_off ), 0, slot_cnt * FD_TPU_REASM_MTU );


### PR DESCRIPTION
Consumers of fd_tpu_reasm frags were using an incorrect range for bounds checking data chunks.  The range was set too low.

Thank you to @ptaffet-jump for finding this bug.