### PR TITLE
syscall_pda_cus: cus were not correctly updated in the case of an error

### DIFF
--- a/contrib/test/test-vectors-fixtures/syscall-fixtures/try_find_program_address.list
+++ b/contrib/test/test-vectors-fixtures/syscall-fixtures/try_find_program_address.list
@@ -13,3 +13,4 @@ dump/test-vectors/syscall/fixtures/try_find_program_address/d3e7db89c3cce9108a14
 dump/test-vectors/syscall/fixtures/try_find_program_address/ec866785e8574e21ea478482374422e091ce794a_5898.fix
 dump/test-vectors/syscall/fixtures/try_find_program_address/f461b693c74ee0419f3bcf1db6c43f6fb7dc2ad3_6888.fix
 dump/test-vectors/syscall/fixtures/try_find_program_address/fee80a4e7a81c0388760a08e54bfec4fca9794d8_6452.fix
+dump/test-vectors/syscall/fixtures/try_find_program_address/d6a5add962547812679d386de1133f182a327230_2273084.fix

--- a/src/flamenco/vm/fd_vm_private.h
+++ b/src/flamenco/vm/fd_vm_private.h
@@ -544,26 +544,38 @@ static inline void fd_vm_mem_st_8( fd_vm_t const * vm,
     (void const *)_haddr;                                                                                   \
   }))
 
+static inline void *
+FD_VM_MEM_HADDR_ST_( fd_vm_t const *vm, ulong vaddr, ulong align, ulong sz, int *err ) {
+  fd_vm_t const * _vm       = (vm);
+  uchar           _is_multi = 0;
+  ulong           _vaddr    = (vaddr);
+  ulong           _haddr    = fd_vm_mem_haddr( vm, _vaddr, (sz), _vm->region_haddr, _vm->region_st_sz, 1, 0UL, &_is_multi );
+  int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _haddr, (align) ));
+  if ( FD_UNLIKELY( sz > LONG_MAX ) ) {
+    FD_VM_ERR_FOR_LOG_SYSCALL( _vm, FD_VM_ERR_SYSCALL_INVALID_LENGTH );
+    *err = FD_VM_ERR_SIGSEGV;
+    return 0;
+  }
+  if( FD_UNLIKELY( (!_haddr) | _is_multi) ) {
+    FD_VM_ERR_FOR_LOG_EBPF( _vm, FD_VM_ERR_EBPF_ACCESS_VIOLATION );
+    *err = FD_VM_ERR_SIGSEGV;
+    return 0;
+  }
+  if ( FD_UNLIKELY( _sigbus ) ) {
+    FD_VM_ERR_FOR_LOG_SYSCALL( _vm, FD_VM_ERR_SYSCALL_UNALIGNED_POINTER );
+    *err = FD_VM_ERR_SIGSEGV;
+    return 0;
+  }
+  return (void *)_haddr;
+}
+
 #define FD_VM_MEM_HADDR_ST( vm, vaddr, align, sz ) (__extension__({                                         \
-    fd_vm_t const * _vm       = (vm);                                                                       \
-    uchar           _is_multi = 0;                                                                          \
-    ulong           _vaddr    = (vaddr);                                                                    \
-    ulong           _haddr    = fd_vm_mem_haddr( vm, _vaddr, (sz), _vm->region_haddr, _vm->region_st_sz, 1, 0UL, &_is_multi ); \
-    int             _sigbus   = fd_vm_is_check_align_enabled( vm ) & (!fd_ulong_is_aligned( _haddr, (align) )); \
-    if ( FD_UNLIKELY( sz > LONG_MAX ) ) {                                                                   \
-      FD_VM_ERR_FOR_LOG_SYSCALL( _vm, FD_VM_ERR_SYSCALL_INVALID_LENGTH );                                   \
-      return FD_VM_ERR_SIGSEGV;                                                                             \
-    }                                                                                                       \
-    if( FD_UNLIKELY( (!_haddr) | _is_multi) ) {                                                             \
-      FD_VM_ERR_FOR_LOG_EBPF( _vm, FD_VM_ERR_EBPF_ACCESS_VIOLATION );                                       \
-      return FD_VM_ERR_SIGSEGV;                                                                             \
-    }                                                                                                       \
-    if ( FD_UNLIKELY( _sigbus ) ) {                                                                         \
-      FD_VM_ERR_FOR_LOG_SYSCALL( _vm, FD_VM_ERR_SYSCALL_UNALIGNED_POINTER );                                \
-      return FD_VM_ERR_SIGSEGV;                                                                             \
-    }                                                                                                       \
-    (void *)_haddr;                                                                                         \
-  }))
+    int _err = 0;                                                                                           \
+    void * ret = FD_VM_MEM_HADDR_ST_( vm, vaddr, align, sz, &_err );                                        \
+    if ( FD_UNLIKELY( 0 != _err ))                                                                          \
+      return _err;                                                                                          \
+    ret;                                                                                                    \
+}))
 
 #define FD_VM_MEM_HADDR_ST_UNCHECKED( vm, vaddr, align, sz ) (__extension__({                               \
     fd_vm_t const * _vm       = (vm);                                                                       \

--- a/src/flamenco/vm/syscall/fd_vm_syscall_pda.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_pda.c
@@ -209,8 +209,19 @@ fd_vm_syscall_sol_try_find_program_address( void *  _vm,
     int err = fd_vm_derive_pda( vm, NULL, program_id_vaddr, seeds_vaddr, seeds_cnt, bump_seed, derived );
     if( FD_LIKELY( err==FD_VM_SUCCESS ) ) {
       /* Stop looking if we have found a valid PDA */
-      fd_pubkey_t * out_haddr = FD_VM_MEM_HADDR_ST( vm, out_vaddr, FD_VM_ALIGN_RUST_U8, sizeof(fd_pubkey_t) );
-      uchar * out_bump_seed_haddr = FD_VM_MEM_HADDR_ST( vm, out_bump_seed_vaddr, FD_VM_ALIGN_RUST_U8, 1UL );
+      int err = 0;
+      fd_pubkey_t * out_haddr = FD_VM_MEM_HADDR_ST_( vm, out_vaddr, FD_VM_ALIGN_RUST_U8, sizeof(fd_pubkey_t), &err );
+      if( FD_UNLIKELY( 0 != err ) ) {
+        FD_VM_CU_UPDATE( vm, owed_cus );
+        *_ret = 0UL;
+        return err;
+      }
+      uchar * out_bump_seed_haddr = FD_VM_MEM_HADDR_ST_( vm, out_bump_seed_vaddr, FD_VM_ALIGN_RUST_U8, 1UL, &err );
+      if( FD_UNLIKELY( 0 != err ) ) {
+        FD_VM_CU_UPDATE( vm, owed_cus );
+        *_ret = 0UL;
+        return err;
+      }
 
       /* Do the overlap check, which is only included for this syscall */
       FD_VM_MEM_CHECK_NON_OVERLAPPING( vm, out_vaddr, 32UL, out_bump_seed_vaddr, 1UL );


### PR DESCRIPTION

keven approved of restructuring of the vm accessor

