### PR TITLE
fix(http): header name comparison

### DIFF
--- a/src/flamenco/snapshot/fd_snapshot_http.c
+++ b/src/flamenco/snapshot/fd_snapshot_http.c
@@ -369,9 +369,9 @@ fd_snapshot_http_resp( fd_snapshot_http_t * this ) {
   /* Find content-length */
 
   this->content_len = ULONG_MAX;
-  const ulong target_len = sizeof("content-length:")-1;
+  const ulong target_len = sizeof("content-length")-1;
   for( ulong i = 0; i < header_cnt; ++i ) {
-    if( headers[i].name_len==target_len && strncasecmp( headers[i].name, "content-length:", target_len ) == 0 ) {
+    if( headers[i].name_len==target_len && strncasecmp( headers[i].name, "content-length", target_len ) == 0 ) {
       this->content_len = strtoul( headers[i].value, NULL, 10 );
       break;
     }


### PR DESCRIPTION
#3395 manifested a latent bug in the original strcmp which included the colon which isn't actually parsed out into header.name