### PR TITLE
quic - ensure varint encoding handles overflow properly

### DIFF
--- a/src/waltz/quic/templ/fd_quic_parse_util.h
+++ b/src/waltz/quic/templ/fd_quic_parse_util.h
@@ -6,15 +6,21 @@
 #include "../fd_quic_common.h"
 
 static inline uint
-fd_quic_varint_min_sz( ulong val ) {
-  val = fd_ulong_min( val, 0x3fffffffffffffffUL );
+fd_quic_varint_min_sz_unsafe( ulong val ) {
   int sz_class = fd_uint_find_msb( (uint)fd_ulong_find_msb( val|0x3fUL ) + 2 ) - 2;
   return 1U<<sz_class;
 }
 
 static inline uint
+fd_quic_varint_min_sz( ulong val ) {
+  return fd_quic_varint_min_sz_unsafe( fd_ulong_min( val, 0x3fffffffffffffffUL ) );
+}
+
+static inline uint
 fd_quic_varint_encode( uchar out[8],
                        ulong val ) {
+  /* max out at 0x3fffffffffffffffUL */
+  val = fd_ulong_min( val, 0x3fffffffffffffffUL );
 
   /* input byte pattern:
      - sz 1: aa 00 00 00 00 00 00 00
@@ -22,7 +28,7 @@ fd_quic_varint_encode( uchar out[8],
      - sz 4: aa bb cc dd 00 00 00 00
      - sz 8: aa bb cc dd ee ff ff gg */
 
-  uint sz = fd_quic_varint_min_sz( val );
+  uint sz = fd_quic_varint_min_sz_unsafe( val );
 
   /* shifted byte pattern
      - sz 1: 00 00 00 00 00 00 00 aa

--- a/src/waltz/quic/tests/test_quic_proto.c
+++ b/src/waltz/quic/tests/test_quic_proto.c
@@ -108,16 +108,16 @@ test_varint_encode( void ) {
   FD_TEST( buf[0]==0xff && buf[1]==0xff && buf[2]==0xff && buf[3]==0xff &&
            buf[4]==0xff && buf[5]==0xff && buf[6]==0xff && buf[7]==0xff );
 
-  /* Truncate oversize numbers */
+  /* Saturate oversize numbers */
   v.i = 0x4000000000000000UL;
   FD_TEST( fd_quic_encode_varint_test( buf, sizeof(buf), &v )==8UL );
-  FD_TEST( buf[0]==0xc0 && buf[1]==0x00 && buf[2]==0x00 && buf[3]==0x00 &&
-           buf[4]==0x00 && buf[5]==0x00 && buf[6]==0x00 && buf[7]==0x00 );
+  FD_TEST( buf[0]==0xff && buf[1]==0xff && buf[2]==0xff && buf[3]==0xff &&
+           buf[4]==0xff && buf[5]==0xff && buf[6]==0xff && buf[7]==0xff );
 
   v.i = 0x8000000000000000UL;
   FD_TEST( fd_quic_encode_varint_test( buf, sizeof(buf), &v )==8UL );
-  FD_TEST( buf[0]==0xc0 && buf[1]==0x00 && buf[2]==0x00 && buf[3]==0x00 &&
-           buf[4]==0x00 && buf[5]==0x00 && buf[6]==0x00 && buf[7]==0x00 );
+  FD_TEST( buf[0]==0xff && buf[1]==0xff && buf[2]==0xff && buf[3]==0xff &&
+           buf[4]==0xff && buf[5]==0xff && buf[6]==0xff && buf[7]==0xff );
 
   v.i = 0xffffffffffffffffUL;
   FD_TEST( fd_quic_encode_varint_test( buf, sizeof(buf), &v )==8UL );


### PR DESCRIPTION
If a value beyond 2^62-1 was supplied to fd_quic_varint_encode, it would assume the 62 low order bits contained the value.
This fix defensively limits the value to at most 2^62-1, thereby avoiding truncation.