### PR TITLE
fdctl: fix symbol collision with configure stages

### DIFF
--- a/src/app/fdctl/configure/configure.h
+++ b/src/app/fdctl/configure/configure.h
@@ -63,11 +63,11 @@ typedef struct configure_stage {
   configure_result_t (*check)    ( config_t * const config );
 } configure_stage_t;
 
-extern configure_stage_t hugetlbfs;
-extern configure_stage_t sysctl;
-extern configure_stage_t ethtool_channels;
-extern configure_stage_t ethtool_gro;
-extern configure_stage_t workspace;
+extern configure_stage_t fd_cfg_stage_hugetlbfs;
+extern configure_stage_t fd_cfg_stage_sysctl;
+extern configure_stage_t fd_cfg_stage_ethtool_channels;
+extern configure_stage_t fd_cfg_stage_ethtool_gro;
+extern configure_stage_t fd_cfg_stage_workspace;
 
 extern configure_stage_t * STAGES[];
 

--- a/src/app/fdctl/configure/ethtool-channels.c
+++ b/src/app/fdctl/configure/ethtool-channels.c
@@ -210,7 +210,7 @@ check( config_t * const config ) {
   CONFIGURE_OK();
 }
 
-configure_stage_t ethtool_channels = {
+configure_stage_t fd_cfg_stage_ethtool_channels = {
   .name            = NAME,
   .always_recreate = 0,
   .enabled         = enabled,

--- a/src/app/fdctl/configure/ethtool-gro.c
+++ b/src/app/fdctl/configure/ethtool-gro.c
@@ -175,7 +175,7 @@ check( config_t * const config ) {
   CONFIGURE_OK();
 }
 
-configure_stage_t ethtool_gro = {
+configure_stage_t fd_cfg_stage_ethtool_gro = {
   .name            = NAME,
   .always_recreate = 0,
   .enabled         = enabled,

--- a/src/app/fdctl/configure/hugetlbfs.c
+++ b/src/app/fdctl/configure/hugetlbfs.c
@@ -394,7 +394,7 @@ check( config_t * const config ) {
   CONFIGURE_OK();
 }
 
-configure_stage_t hugetlbfs = {
+configure_stage_t fd_cfg_stage_hugetlbfs = {
   .name            = "hugetlbfs",
   .always_recreate = 0,
   .enabled         = NULL,

--- a/src/app/fdctl/configure/sysctl.c
+++ b/src/app/fdctl/configure/sysctl.c
@@ -113,7 +113,7 @@ check( config_t * const config ) {
   CONFIGURE_OK();
 }
 
-configure_stage_t sysctl = {
+configure_stage_t fd_cfg_stage_sysctl = {
   .name            = NAME,
   .always_recreate = 0,
   .enabled         = NULL,

--- a/src/app/fdctl/main.c
+++ b/src/app/fdctl/main.c
@@ -3,10 +3,10 @@
 #include "configure/configure.h"
 
 configure_stage_t * STAGES[ CONFIGURE_STAGE_COUNT ] = {
-  &hugetlbfs,
-  &sysctl,
-  &ethtool_channels,
-  &ethtool_gro,
+  &fd_cfg_stage_hugetlbfs,
+  &fd_cfg_stage_sysctl,
+  &fd_cfg_stage_ethtool_channels,
+  &fd_cfg_stage_ethtool_gro,
   NULL,
   NULL,
   NULL,

--- a/src/app/fdctl/run/run.c
+++ b/src/app/fdctl/run/run.c
@@ -661,30 +661,30 @@ initialize_stacks( config_t * const config ) {
   if( FD_UNLIKELY( setegid( gid ) ) ) FD_LOG_ERR(( "setegid() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
 }
 
-extern configure_stage_t hugetlbfs;
-extern configure_stage_t ethtool_channels;
-extern configure_stage_t ethtool_gro;
-extern configure_stage_t sysctl;
+extern configure_stage_t fd_cfg_stage_hugetlbfs;
+extern configure_stage_t fd_cfg_stage_ethtool_channels;
+extern configure_stage_t fd_cfg_stage_ethtool_gro;
+extern configure_stage_t fd_cfg_stage_sysctl;
 
 static void
 check_configure( config_t * const config ) {
-  configure_result_t check = hugetlbfs.check( config );
+  configure_result_t check = fd_cfg_stage_hugetlbfs.check( config );
   if( FD_UNLIKELY( check.result!=CONFIGURE_OK ) )
     FD_LOG_ERR(( "Huge pages are not configured correctly: %s. You can run `fdctl configure init hugetlbfs` "
                  "to create the mounts correctly. This must be done after every system restart before running "
                  "Firedancer.", check.message ));
 
-  check = ethtool_channels.check( config );
+  check = fd_cfg_stage_ethtool_channels.check( config );
   if( FD_UNLIKELY( check.result!=CONFIGURE_OK ) )
     FD_LOG_ERR(( "Network %s. You can run `fdctl configure init ethtool-channels` to set the number of channels on the "
                  "network device correctly.", check.message ));
 
-  check = ethtool_gro.check( config );
+  check = fd_cfg_stage_ethtool_gro.check( config );
   if( FD_UNLIKELY( check.result!=CONFIGURE_OK ) )
     FD_LOG_ERR(( "Network %s. You can run `fdctl configure init ethtool-gro` to disable generic-receive-offload "
                  "as required.", check.message ));
 
-  check = sysctl.check( config );
+  check = fd_cfg_stage_sysctl.check( config );
   if( FD_UNLIKELY( check.result!=CONFIGURE_OK ) )
     FD_LOG_ERR(( "Kernel parameters are not configured correctly: %s. You can run `fdctl configure init sysctl` "
                  "to set kernel parameters correctly.", check.message ));

--- a/src/app/fddev/configure/blockstore.c
+++ b/src/app/fddev/configure/blockstore.c
@@ -206,7 +206,7 @@ check( config_t * const config ) {
   }
 }
 
-configure_stage_t blockstore = {
+configure_stage_t fd_cfg_stage_blockstore = {
   .name            = NAME,
   .always_recreate = 1,
   .init            = init,

--- a/src/app/fddev/configure/genesis.c
+++ b/src/app/fddev/configure/genesis.c
@@ -281,7 +281,7 @@ check( config_t * const config ) {
   PARTIALLY_CONFIGURED( "`%s` already exists", genesis_path );
 }
 
-configure_stage_t genesis = {
+configure_stage_t fd_cfg_stage_genesis = {
   .name            = NAME,
   .init            = init,
   .fini            = fini,

--- a/src/app/fddev/configure/keys.c
+++ b/src/app/fddev/configure/keys.c
@@ -67,7 +67,7 @@ check( config_t * const config ) {
   CONFIGURE_OK();
 }
 
-configure_stage_t keys = {
+configure_stage_t fd_cfg_stage_keys = {
   .name            = NAME,
   .always_recreate = 0,
   .enabled         = NULL,

--- a/src/app/fddev/configure/kill.c
+++ b/src/app/fddev/configure/kill.c
@@ -156,7 +156,7 @@ check( config_t * const config ) {
   PARTIALLY_CONFIGURED( "kill existing instances" );
 }
 
-configure_stage_t _kill = {
+configure_stage_t fd_cfg_stage_kill = {
   .name            = NAME,
   .always_recreate = 1,
   .enabled         = NULL,

--- a/src/app/fddev/configure/netns.c
+++ b/src/app/fddev/configure/netns.c
@@ -124,7 +124,7 @@ check( config_t * const config ) {
   CONFIGURE_OK();
 }
 
-configure_stage_t netns = {
+configure_stage_t fd_cfg_stage_netns = {
   .name            = NAME,
   .always_recreate = 0,
   .enabled         = enabled,

--- a/src/app/fddev/main1.c
+++ b/src/app/fddev/main1.c
@@ -9,25 +9,25 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-extern configure_stage_t _kill;
-extern configure_stage_t netns;
-extern configure_stage_t genesis;
-extern configure_stage_t blockstore;
-extern configure_stage_t keys;
+extern configure_stage_t fd_cfg_stage_kill;
+extern configure_stage_t fd_cfg_stage_netns;
+extern configure_stage_t fd_cfg_stage_genesis;
+extern configure_stage_t fd_cfg_stage_blockstore;
+extern configure_stage_t fd_cfg_stage_keys;
 
 configure_stage_t * STAGES[ CONFIGURE_STAGE_COUNT ] = {
-  &_kill,
-  &netns,
-  &hugetlbfs,
-  &sysctl,
-  &ethtool_channels,
-  &ethtool_gro,
-  &keys,
-  &genesis,
+  &fd_cfg_stage_kill,
+  &fd_cfg_stage_netns,
+  &fd_cfg_stage_hugetlbfs,
+  &fd_cfg_stage_sysctl,
+  &fd_cfg_stage_ethtool_channels,
+  &fd_cfg_stage_ethtool_gro,
+  &fd_cfg_stage_keys,
+  &fd_cfg_stage_genesis,
 #ifdef FD_HAS_NO_AGAVE
   NULL,
 #else
-  &blockstore,
+  &fd_cfg_stage_blockstore,
 #endif
   NULL,
 };


### PR DESCRIPTION
Fixes a symbol collision reported by the mold linker

    mold: warning: symbol type mismatch: sysctl
    >>> defined in build/native/gcc/lib/libfd_fdctl.a(sysctl.o) as STT_OBJECT
    >>> defined in /lib64/libc.so.6 as STT_FUNC
