### PR TITLE
flamenco: fix fee deposit checks

### DIFF
--- a/src/flamenco/runtime/fd_acc_mgr.c
+++ b/src/flamenco/runtime/fd_acc_mgr.c
@@ -119,8 +119,10 @@ fd_acc_mgr_view_raw( fd_acc_mgr_t *         acc_mgr,
   // TODO/FIXME: this check causes issues with some metadata writes
 
   fd_account_meta_t const * metadata = fd_type_pun_const( raw );
-  if( metadata->magic != FD_ACCOUNT_META_MAGIC )
+  if( metadata->magic != FD_ACCOUNT_META_MAGIC ) {
+    fd_int_store_if( !!opt_err, opt_err, FD_ACC_MGR_ERR_WRONG_MAGIC );
     return NULL;
+  }
 
   return metadata;
 }
@@ -223,8 +225,10 @@ fd_acc_mgr_modify_raw( fd_acc_mgr_t *        acc_mgr,
     fd_account_meta_init( ret );
   }
 
-  if( ret->magic != FD_ACCOUNT_META_MAGIC )
-    FD_LOG_ERR(( "bad magic" ));
+  if( ret->magic != FD_ACCOUNT_META_MAGIC ) {
+    fd_int_store_if( !!opt_err, opt_err, FD_ACC_MGR_ERR_WRONG_MAGIC );
+    return NULL;
+  }
 
   return ret;
 }

--- a/src/flamenco/runtime/tests/run_ledger_tests_all.txt
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.txt
@@ -67,3 +67,7 @@ src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-294739503 -s snapshot-2
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-290621930 -s snapshot-290621927-AxDRmQNPmGzo1V7KRXfPXtDXTBU3AZj3MUEM1ns3CgH.tar.zst -p 50 -y 16 -m 5000000 -e 290621932 -c 1.19.0
 src/flamenco/runtime/tests/run_ledger_test.sh -l devnet-330914784 -s snapshot-330914783-BujhdWiXTfRPfFYMG3GZdEcNc18KyvCcAq9QL9e1i1Fk.tar.zst -p 50 -y 16 -m 5000000 -e 330914785 -c 2.0.8
 src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-mismatch-297489336 -s snapshot-297489335-BgExNqwDtYPo2YQ87C2bra6b5GK2eu52R8Budh85cRUp.tar.zst -p 50 -y 16 -m 5000000 -e 297489363 -c 2.0.3
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-300377724 -s snapshot-300377719-DWngYKosZegyeLAgHK5jVfMsSeuYjSZWJixE5VgcLDAM.tar.zst -p 50 -y 16 -m 5000000 -e 300377728 -c 1.18.23
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-300645644 -s snapshot-300645643-D2ZXqQffEoM6cgPGoC9LC4UfjyCMi1cqbhrceRPh4cE7.tar.zst -p 50 -y 16 -m 5000000 -e 300645644 -c 1.18.23
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-300648964 -s snapshot-300648963-BPSiWGgLbiof1b8Ui5qnM4eUDv8asDo9j7Bn8QvrvwUZ.tar.zst -p 50 -y 16 -m 5000000 -e 300648964 -c 1.18.23
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-301359740 -s snapshot-301359739-5L5b7KFLFiQYpmk7nHUJYX8fXMUG4qv7m6iBMWRN2V5h.tar.zst -p 50 -y 16 -m 5000000 -e 301359740 -c 1.18.23


### PR DESCRIPTION
- Rent state transition check should based be on post deposit balance
- Check should be based on post burn fees
- Allow a leader to be created if dead and purged because we see mainnet leaders that have 0 balance, for example: 9e7XGRqQqEvppx4Lkj6P1S7k65yWQpf3vcNzWecKSzDd CYkkaM5KwoxaFtZcximkm1DFYnABdiUUUvJg1WURDRsh
- Make sure capitalization is always properly adjusted on check failure