### PR TITLE
slot 0 is a valid argument value for "wait for supermajority" when starting Agave validator

### DIFF
--- a/src/app/fdctl/run/run_agave.c
+++ b/src/app/fdctl/run/run_agave.c
@@ -75,11 +75,9 @@ agave_boot( config_t * config ) {
   if( !config->consensus.poh_speed_test ) ADD1( "--no-poh-speed-test" );
   if( strcmp( config->consensus.expected_genesis_hash, "" ) )
     ADD( "--expected-genesis-hash", config->consensus.expected_genesis_hash );
-  if( config->consensus.wait_for_supermajority_at_slot ) {
-    ADDU( "--wait-for-supermajority", config->consensus.wait_for_supermajority_at_slot );
-    if( strcmp( config->consensus.expected_bank_hash, "" ) )
-      ADD( "--expected-bank-hash", config->consensus.expected_bank_hash );
-  }
+  ADDU( "--wait-for-supermajority", config->consensus.wait_for_supermajority_at_slot );
+  if( strcmp( config->consensus.expected_bank_hash, "" ) )
+    ADD( "--expected-bank-hash", config->consensus.expected_bank_hash );
   if( config->consensus.expected_shred_version )
     ADDH( "--expected-shred-version", config->consensus.expected_shred_version );
   if( !config->consensus.wait_for_vote_to_start_leader )


### PR DESCRIPTION
**Problem:**
In Agave, 'validator_config.wait_for_supermajority' is of type option. So the default value is none not zero. Slot 0 is a valid setting for this config. So it needs to be passed in when starting agave if user requested in firedancer toml config. 

**Solution:**
Remove non-zero conditional check on appending '--wait-for-supermajority' to agave restart params.

Requesting this to be patched on Frankendancer release branch as well.
