### PR TITLE
quic: more nits

### DIFF
--- a/src/app/fdctl/run/tiles/fd_quic.c
+++ b/src/app/fdctl/run/tiles/fd_quic.c
@@ -328,7 +328,7 @@ quic_stream_new( fd_quic_stream_t * stream,
 
   /* Wire up with QUIC stream */
 
-  stream->context = slot;
+  fd_quic_stream_set_context( stream, slot );
 
   /* Wind up for next iteration */
 

--- a/src/waltz/quic/fd_quic.h
+++ b/src/waltz/quic/fd_quic.h
@@ -106,15 +106,15 @@ typedef struct fd_quic_state_private fd_quic_state_t;
    (i.e. outlasts joins, until fd_quic_delete) */
 
 struct __attribute__((aligned(16UL))) fd_quic_limits {
-  ulong  conn_cnt;              /* instance-wide, max concurrent conn count              */
-  ulong  handshake_cnt;         /* instance-wide, max concurrent handshake count         */
+  ulong  conn_cnt;              /* instance-wide, max concurrent conn count                  */
+  ulong  handshake_cnt;         /* instance-wide, max concurrent handshake count             */
 
-  ulong  conn_id_cnt;           /* per-conn, max conn ID count (min 4UL)                 */
-  ulong  stream_id_cnt;         /* per-conn, max concurrent stream ID count              */
-  ulong  rx_stream_cnt;         /* per-conn, max concurrent stream count                 */
-  ulong  inflight_pkt_cnt;      /* per-conn, max inflight packet count                   */
+  ulong  conn_id_cnt;           /* per-conn, max conn ID count (min FD_QUIC_MIN_CONN_ID_CNT) */
+  ulong  stream_id_cnt;         /* per-conn, max concurrent stream ID count                  */
+  ulong  rx_stream_cnt;         /* per-conn, max concurrent stream count                     */
+  ulong  inflight_pkt_cnt;      /* per-conn, max inflight packet count                       */
 
-  ulong  tx_buf_sz;             /* per-stream, tx buf sz in bytes                        */
+  ulong  tx_buf_sz;             /* per-stream, tx buf sz in bytes                            */
   /* the user consumes rx directly from the network buffer */
 
   ulong  stream_pool_cnt;  /* instance-wide, number of streams in stream pool */
@@ -147,8 +147,8 @@ struct __attribute__((aligned(16UL))) fd_quic_config {
   ulong idle_timeout;
 # define FD_QUIC_DEFAULT_IDLE_TIMEOUT (ulong)(1e9) /* 1s */
 
-  /* ack_delay: median delay on outgoing ACKs.  Greater delays allow
-     fd_quic to coalesce packet ACKs. */
+  /* ack_delay: median delay on outgoing ACKs (ns).  Greater delays
+     allow fd_quic to coalesce packet ACKs. */
   ulong ack_delay;
 # define FD_QUIC_DEFAULT_ACK_DELAY (ulong)(50e6) /* 50ms */
 

--- a/src/waltz/quic/fd_quic_ack_tx.h
+++ b/src/waltz/quic/fd_quic_ack_tx.h
@@ -29,7 +29,7 @@
 
 struct __attribute__((aligned(16))) fd_quic_ack {
   fd_quic_range_t pkt_number;  /* Range of packet numbers being ACKed */
-  ulong           ts;          /* timestamp of highest packet number */
+  ulong           ts;          /* timestamp of highest packet number in ns */
   uchar           enc_level;   /* in [0,4) */
   /* FIXME enc_level should technically be pn_space instead */
   uchar           _pad[7];

--- a/src/waltz/quic/fd_quic_conn_id.h
+++ b/src/waltz/quic/fd_quic_conn_id.h
@@ -8,7 +8,7 @@
 /* TODO move this into more reasonable place */
 #define FD_QUIC_MAX_CONN_ID_SZ 20
 
-/* Firedancer connection ids will sized thus */
+/* Firedancer connection ids are sized thus */
 #define FD_QUIC_CONN_ID_SZ 8
 
 /* pad fd_quic_conn_id struct */

--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -54,10 +54,7 @@ typedef struct fd_quic_svc_queue fd_quic_svc_queue_t;
    lifetime of join. */
 
 struct __attribute__((aligned(16UL))) fd_quic_state_private {
-  /* Flags */
-  ulong flags;
-
-  ulong now; /* the time we entered into fd_quic_service, or fd_quic_aio_cb_receive */
+  ulong now; /* the time we entered into fd_quic_service, or fd_quic_aio_cb_receive in ns */
 
   /* transport_params: Template for QUIC-TLS transport params extension.
      Contains a mix of mutable and immutable fields.  Immutable fields

--- a/src/waltz/quic/fd_quic_stream.c
+++ b/src/waltz/quic/fd_quic_stream.c
@@ -166,7 +166,6 @@ void
 fd_quic_stream_delete( fd_quic_stream_t * stream ) {
   /* stream pointing to itself is not a member of any list */
   stream->next = stream->prev = stream;
-  stream->list_memb = FD_QUIC_STREAM_LIST_MEMB_NONE;
 }
 
 

--- a/src/waltz/quic/fd_quic_stream.h
+++ b/src/waltz/quic/fd_quic_stream.h
@@ -72,12 +72,6 @@ struct fd_quic_stream {
 
 # define FD_QUIC_DEFAULT_INITIAL_RX_MAX_STREAM_DATA 1280  // IPv6 minimum MTU
 
-  uint list_memb; /* list membership */
-# define FD_QUIC_STREAM_LIST_MEMB_NONE   0
-# define FD_QUIC_STREAM_LIST_MEMB_UNUSED 1
-# define FD_QUIC_STREAM_LIST_MEMB_USED   2
-# define FD_QUIC_STREAM_LIST_MEMB_SEND   3
-
   /* flow control */
   ulong  tx_max_stream_data; /* the limit on the number of bytes we are allowed to send
                                   to the peer on this stream


### PR DESCRIPTION
This PR improves QUIC readability, as notices while auditing the code:

It is motivated by the following: 
* @ripatel-fd expressed the goal to have more code "fit on one screen". To this end, this PR removes some duplicate initializations and unused fields. While more such code exists, this PR is conservative with removals in areas where the duplicate initializations might aid readability. 
* Prefer defined constant over magic numbers
* Documentation for time units on fields
* Misc documentation improvements