### PR TITLE
flamenco: keep sysvar cache in sync with multiple epoch rewards sysvar updates within a slot

### DIFF
--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.c
@@ -49,6 +49,9 @@ fd_sysvar_epoch_rewards_read(
   return result;
 }
 
+/* Since there are multiple sysvar epoch rewards updates within a single slot,
+   we need to ensure that the cache stays updated after each change (versus with other
+   sysvars which only get updated once per slot and then synced up after) */
 void
 fd_sysvar_epoch_rewards_distribute(
     fd_exec_slot_ctx_t * slot_ctx,
@@ -65,6 +68,9 @@ fd_sysvar_epoch_rewards_distribute(
     epoch_rewards->distributed_rewards += distributed;
 
     write_epoch_rewards( slot_ctx, epoch_rewards );
+
+    /* Sync the epoch rewards sysvar cache entry with the account */
+    fd_sysvar_cache_restore_epoch_rewards( slot_ctx->sysvar_cache, slot_ctx->acc_mgr, slot_ctx->funk_txn );
 }
 
 void
@@ -86,6 +92,9 @@ fd_sysvar_epoch_rewards_set_inactive(
     epoch_rewards->active = 0;
 
     write_epoch_rewards( slot_ctx, epoch_rewards );
+
+    /* Sync the epoch rewards sysvar cache entry with the account */
+    fd_sysvar_cache_restore_epoch_rewards( slot_ctx->sysvar_cache, slot_ctx->acc_mgr, slot_ctx->funk_txn );
 }
 
 /* Create EpochRewards syavar with calculated rewards


### PR DESCRIPTION
When distributing partitioned epoch rewards, there are multiple updates to the epoch rewards sysvar within a single slot, which updates the sysvar account but NOT the sysvar cache. When a subsequent update is performed within a single slot, the update ends up happening on a stale cache entry and causing the updated stale value to get written back into the account, causing a mismatching epoch rewards sysvar account. We should make sure to restore the sysvar cache before we perform subsequent updates on a sysvar within a single slot.