### PR TITLE
Belt-sand QUIC tile

### DIFF
--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -214,7 +214,6 @@ typedef struct {
       uint max_concurrent_connections;
       uint max_concurrent_streams_per_connection;
       uint max_concurrent_handshakes;
-      uint max_inflight_quic_packets;
       uint idle_timeout_millis;
       uint ack_delay_millis;
       int  retry;

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -900,13 +900,6 @@ dynamic_port_range = "8900-9000"
         #
         max_concurrent_handshakes = 4096
 
-        # QUIC has a concept of a "QUIC packet", there can be multiple
-        # of these inside a UDP packet.  Each QUIC packet we send to the
-        # peer needs to be acknowledged before we can discard it, as we
-        # may need to retransmit.  This setting configures how many such
-        # packets we can have in-flight to the peer and unacknowledged.
-        max_inflight_quic_packets = 64
-
         # QUIC has a concept of an idle connection, one where neither
         # the client nor the server has sent any packet to the other for
         # a period of time.  Once this timeout is reached the connection
@@ -1039,7 +1032,7 @@ dynamic_port_range = "8900-9000"
     # endpoint to clients to view it.
     [tiles.gui]
         # If the GUI is enabled.
-        # 
+        #
         # Names and icons of peer validators will not be displayed in
         # the GUI unless the program-id index is enabled, which can be
         # done by setting

--- a/src/app/fdctl/config_parse.c
+++ b/src/app/fdctl/config_parse.c
@@ -293,7 +293,6 @@ fdctl_pod_to_cfg( config_t * config,
   CFG_POP      ( uint,   tiles.quic.max_concurrent_connections            );
   CFG_POP      ( uint,   tiles.quic.max_concurrent_streams_per_connection );
   CFG_POP      ( uint,   tiles.quic.max_concurrent_handshakes             );
-  CFG_POP      ( uint,   tiles.quic.max_inflight_quic_packets             );
   CFG_POP      ( uint,   tiles.quic.idle_timeout_millis                   );
   CFG_POP      ( uint,   tiles.quic.ack_delay_millis                      );
   CFG_POP      ( bool,   tiles.quic.retry                                 );
@@ -453,7 +452,6 @@ fdctl_cfg_validate( config_t * cfg ) {
   CFG_HAS_NON_ZERO( tiles.quic.max_concurrent_streams_per_connection );
   CFG_HAS_NON_ZERO( tiles.quic.txn_reassembly_count );
   CFG_HAS_NON_ZERO( tiles.quic.max_concurrent_handshakes );
-  CFG_HAS_NON_ZERO( tiles.quic.max_inflight_quic_packets );
   CFG_HAS_NON_ZERO( tiles.quic.idle_timeout_millis );
 
   CFG_HAS_NON_ZERO( tiles.verify.signature_cache_size );

--- a/src/app/fdctl/run/topos/fd_firedancer.c
+++ b/src/app/fdctl/run/topos/fd_firedancer.c
@@ -474,11 +474,9 @@ fd_topo_initialize( config_t * config ) {
       fd_memcpy( tile->quic.src_mac_addr, config->tiles.net.mac_addr, 6 );
       strncpy( tile->quic.identity_key_path, config->consensus.identity_path, sizeof(tile->quic.identity_key_path) );
 
-      tile->quic.depth                          = topo->links[ tile->out_link_id[ 0 ] ].depth;
       tile->quic.reasm_cnt                      = config->tiles.quic.txn_reassembly_count;
       tile->quic.max_concurrent_connections     = config->tiles.quic.max_concurrent_connections;
       tile->quic.max_concurrent_handshakes      = config->tiles.quic.max_concurrent_handshakes;
-      tile->quic.max_inflight_quic_packets      = config->tiles.quic.max_inflight_quic_packets;
       tile->quic.ip_addr                        = config->tiles.net.ip_addr;
       tile->quic.quic_transaction_listen_port   = config->tiles.quic.quic_transaction_listen_port;
       tile->quic.idle_timeout_millis            = config->tiles.quic.idle_timeout_millis;

--- a/src/app/fdctl/run/topos/fd_frankendancer.c
+++ b/src/app/fdctl/run/topos/fd_frankendancer.c
@@ -360,11 +360,9 @@ fd_topo_initialize( config_t * config ) {
       fd_memcpy( tile->quic.src_mac_addr, config->tiles.net.mac_addr, 6 );
       strncpy( tile->quic.identity_key_path, config->consensus.identity_path, sizeof(tile->quic.identity_key_path) );
 
-      tile->quic.depth                          = topo->links[ tile->out_link_id[ 0 ] ].depth;
       tile->quic.reasm_cnt                      = config->tiles.quic.txn_reassembly_count;
       tile->quic.max_concurrent_connections     = config->tiles.quic.max_concurrent_connections;
       tile->quic.max_concurrent_handshakes      = config->tiles.quic.max_concurrent_handshakes;
-      tile->quic.max_inflight_quic_packets      = config->tiles.quic.max_inflight_quic_packets;
       tile->quic.ip_addr                        = config->tiles.net.ip_addr;
       tile->quic.quic_transaction_listen_port   = config->tiles.quic.quic_transaction_listen_port;
       tile->quic.idle_timeout_millis            = config->tiles.quic.idle_timeout_millis;

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -152,11 +152,9 @@ typedef struct {
     } net;
 
     struct {
-      ulong  depth;
       uint   reasm_cnt;
       ulong  max_concurrent_connections;
       ulong  max_concurrent_handshakes;
-      ulong  max_inflight_quic_packets;
       ulong  max_concurrent_streams_per_connection;
       uint   ip_addr;
       uchar  src_mac_addr[ 6 ];


### PR DESCRIPTION
- Remove unused max_inflight_quic_packets config option
  (Now hardcoded at 16 packets per connection.  We shouldn't ever
  send more than ~8 ACK-eliciting packets over the lifetime of a
  connection)

- Better error detection for incorrect config parameters

- Fix oversz scratch_footprint calculation

- Validate scratch_footprint on startup

- Remove redundant fd_quic_ctx_t->depth variable

- Log errno code for getrandom() startup error

- Remove defunct code for multiple input links

- Tighten bounds checks for the input link dcache
  (This adds an assumption that the input frag buffer is a dcache,
  but this is better than assuming that the input frag buffer is in
  a wksp, which is not true in contexts like CBMC.  This reveals a
  gap in the fd_topo APIs, which should teach a tile about the frag
  buffer bounds in a generic way)
