### PR TITLE
quic: remove unused sni option

### DIFF
--- a/src/app/fddev/tiles/fd_benchs.c
+++ b/src/app/fddev/tiles/fd_benchs.c
@@ -358,7 +358,7 @@ during_frag( fd_benchs_ctx_t * ctx,
       uint   dest_ip   = 0;
       ushort dest_port = fd_ushort_bswap( ctx->quic_port );
 
-      ctx->quic_conn = fd_quic_connect( ctx->quic, dest_ip, dest_port, "client" );
+      ctx->quic_conn = fd_quic_connect( ctx->quic, dest_ip, dest_port );
 
       /* failed? try later */
       if( FD_UNLIKELY( !ctx->quic_conn ) ) {

--- a/src/app/fddev/txn.c
+++ b/src/app/fddev/txn.c
@@ -88,7 +88,7 @@ send_quic_transactions( fd_quic_t *         quic,
   quic->cb.conn_hs_complete = cb_conn_hs_complete;
   quic->cb.stream_notify    = cb_stream_notify;
 
-  fd_quic_conn_t * conn = fd_quic_connect( quic, dst_ip, dst_port, NULL );
+  fd_quic_conn_t * conn = fd_quic_connect( quic, dst_ip, dst_port );
   while ( FD_LIKELY( !( g_conn_hs_complete || g_conn_final ) ) ) {
     fd_quic_service( quic );
     fd_quic_udpsock_service( udpsock );

--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -323,6 +323,7 @@ fd_quic_init( fd_quic_t * quic ) {
 
   if( FD_UNLIKELY( !config->role          ) ) { FD_LOG_WARNING(( "cfg.role not set"      )); return NULL; }
   if( FD_UNLIKELY( !config->idle_timeout  ) ) { FD_LOG_WARNING(( "zero cfg.idle_timeout" )); return NULL; }
+  if( FD_UNLIKELY( !quic->cb.now          ) ) { FD_LOG_WARNING(( "NULL cb.now"           )); return NULL; }
 
   do {
     ulong x = 0U;
@@ -1507,7 +1508,6 @@ fd_quic_handle_v1_initial( fd_quic_t *               quic,
           state->tls,
           (void*)conn,
           1 /*is_server*/,
-          quic->config.sni,
           tp );
       conn->tls_hs = tls_hs;
       quic->metrics.hs_created_cnt++;
@@ -4151,8 +4151,7 @@ fd_quic_conn_free( fd_quic_t *      quic,
 fd_quic_conn_t *
 fd_quic_connect( fd_quic_t *  quic,
                  uint         dst_ip_addr,
-                 ushort       dst_udp_port,
-                 char const * sni ) {
+                 ushort       dst_udp_port ) {
 
   fd_quic_state_t * state = fd_quic_get_state( quic );
 
@@ -4228,7 +4227,6 @@ fd_quic_connect( fd_quic_t *  quic,
       state->tls,
       (void*)conn,
       0 /*is_server*/,
-      sni,
       tp );
   quic->metrics.hs_created_cnt++;
 

--- a/src/waltz/quic/fd_quic.h
+++ b/src/waltz/quic/fd_quic.h
@@ -169,11 +169,6 @@ struct __attribute__((aligned(16UL))) fd_quic_config {
 # define FD_QUIC_PATH_LEN 1023UL
   char keylog_file[ FD_QUIC_PATH_LEN+1UL ];
 
-  /* Server name indication (client only)
-     FIXME: Extend server to validate SNI */
-# define FD_QUIC_SNI_LEN (255UL)
-  char sni[ FD_QUIC_SNI_LEN+1UL ];
-
   ulong initial_rx_max_stream_data; /* per-stream, rx buf sz in bytes, set by the user. */
 
   /* Network config ****************************************/
@@ -507,14 +502,12 @@ fd_quic_fini( fd_quic_t * quic );
 
    args
      dst_ip_addr   destination ip address
-     dst_udp_port  destination port number
-     sni           server name indication cstr, max 253 chars, nullable */
+     dst_udp_port  destination port number */
 
 FD_QUIC_API fd_quic_conn_t *
 fd_quic_connect( fd_quic_t *  quic,  /* requires exclusive access */
                  uint         dst_ip_addr,
-                 ushort       dst_udp_port,
-                 char const * sni );
+                 ushort       dst_udp_port );
 
 /* fd_quic_conn_close asynchronously initiates a shutdown of the conn.
    The given reason code is returned to the peer via a CONNECTION_CLOSE

--- a/src/waltz/quic/tests/fd_quic_test_helpers.c
+++ b/src/waltz/quic/tests/fd_quic_test_helpers.c
@@ -7,7 +7,6 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
-#include "../../../ballet/ed25519/fd_ed25519.h"
 #include "../../../ballet/txn/fd_txn.h" /* FD_TXN_MTU */
 #include "../../../util/net/fd_eth.h"
 #include "../../../util/net/fd_ip4.h"
@@ -80,7 +79,7 @@ fd_quic_test_cb_tls_keylog( void *       quic_ctx,
     fd_pcapng_fwrite_tls_key_log( (uchar const *)line, (uint)strlen( line ), fd_quic_test_pcap );
 }
 
-static ulong
+ulong
 fd_quic_test_now( void * context ) {
   (void)context;
   return (ulong)fd_log_wallclock();
@@ -139,7 +138,6 @@ fd_quic_config_anonymous( fd_quic_t * quic,
   config->ack_delay        = FD_QUIC_DEFAULT_ACK_DELAY;
   config->ack_threshold    = FD_QUIC_DEFAULT_ACK_THRESHOLD;
   config->initial_rx_max_stream_data = FD_TXN_MTU;
-  strcpy( config->sni, "local" );
 
   /* Default callbacks */
   quic->cb.conn_new         = fd_quic_test_cb_conn_new;

--- a/src/waltz/quic/tests/fd_quic_test_helpers.h
+++ b/src/waltz/quic/tests/fd_quic_test_helpers.h
@@ -176,6 +176,11 @@ fd_quic_netem_send( void *                    ctx, /* fd_quic_net_em_t */
                     ulong *                   opt_batch_idx,
                     int                       flush );
 
+/* fd_quic_test_now is a fd_quic clock source based on fd_log_wallclock */
+
+ulong
+fd_quic_test_now( void * context );
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_waltz_quic_tests_fd_quic_helpers_h */

--- a/src/waltz/quic/tests/test_quic_bw.c
+++ b/src/waltz/quic/tests/test_quic_bw.c
@@ -184,8 +184,7 @@ main( int     argc,
   fd_quic_conn_t * client_conn = fd_quic_connect(
       client_quic,
       server_quic->config.net.ip_addr,
-      server_quic->config.net.listen_udp_port,
-      server_quic->config.sni );
+      server_quic->config.net.listen_udp_port );
 
   FD_TEST( conn_final_cnt==0 );
 

--- a/src/waltz/quic/tests/test_quic_client_flood.c
+++ b/src/waltz/quic/tests/test_quic_client_flood.c
@@ -103,7 +103,7 @@ run_quic_client(
     FD_LOG_NOTICE(( "Starting QUIC client" ));
 
     /* make a connection from client to the server */
-    client_conn = fd_quic_connect( quic, dst_ip, dst_port, NULL );
+    client_conn = fd_quic_connect( quic, dst_ip, dst_port );
 
     /* do general processing */
     while ( !client_complete ) {

--- a/src/waltz/quic/tests/test_quic_conformance.c
+++ b/src/waltz/quic/tests/test_quic_conformance.c
@@ -428,7 +428,6 @@ test_quic_server_alpn_fail( fd_quic_sandbox_t * sandbox,
       state->tls,
       (void*)conn,
       1 /*is_server*/,
-      quic->config.sni,
       tp );
   conn->tls_hs = tls_hs;
 

--- a/src/waltz/quic/tests/test_quic_conn.c
+++ b/src/waltz/quic/tests/test_quic_conn.c
@@ -425,8 +425,7 @@ main( int argc, char ** argv ) {
           client_conn = fd_quic_connect(
               client_quic,
               server_quic->config.net.ip_addr,
-              server_quic->config.net.listen_udp_port,
-              server_quic->config.sni );
+              server_quic->config.net.listen_udp_port );
 
           if( !client_conn ) {
             FD_LOG_ERR(( "fd_quic_connect failed" ));

--- a/src/waltz/quic/tests/test_quic_drops.c
+++ b/src/waltz/quic/tests/test_quic_drops.c
@@ -185,8 +185,7 @@ client_fibre_fn( void * vp_arg ) {
 
       conn = fd_quic_connect( quic,
               server_quic->config.net.ip_addr,
-              server_quic->config.net.listen_udp_port,
-              server_quic->config.sni );
+              server_quic->config.net.listen_udp_port );
 
       if( !conn ) {
         FD_LOG_WARNING(( "Client unable to obtain a connection. now: %lu", (ulong)now ));

--- a/src/waltz/quic/tests/test_quic_hs.c
+++ b/src/waltz/quic/tests/test_quic_hs.c
@@ -128,8 +128,7 @@ main( int argc, char ** argv ) {
   fd_quic_conn_t * client_conn = fd_quic_connect(
       client_quic,
       server_quic->config.net.ip_addr,
-      server_quic->config.net.listen_udp_port,
-      server_quic->config.sni );
+      server_quic->config.net.listen_udp_port );
   FD_TEST( client_conn );
 
   /* do general processing */

--- a/src/waltz/quic/tests/test_quic_idle_conns.c
+++ b/src/waltz/quic/tests/test_quic_idle_conns.c
@@ -1,10 +1,8 @@
 #include "../fd_quic.h"
 #include "fd_quic_test_helpers.h"
-#include "../../../ballet/base64/fd_base64.h"
 #include "../../../util/net/fd_ip4.h"
 
 #include <stdio.h>
-#include <errno.h>
 #include <string.h>
 
 
@@ -98,13 +96,6 @@ cb_stream_receive( fd_quic_stream_t * stream,
   (void)fin;
 }
 
-ulong
-cb_now( void * context ) {
-  (void)context;
-  return (ulong)fd_log_wallclock();
-}
-
-
 void
 run_quic_client( fd_quic_t *         quic,
                  fd_quic_udpsock_t * udpsock,
@@ -117,8 +108,7 @@ run_quic_client( fd_quic_t *         quic,
   quic->cb.stream_new       = cb_stream_new;
   quic->cb.stream_notify    = cb_stream_notify;
   quic->cb.stream_receive   = cb_stream_receive;
-  quic->cb.now              = cb_now;
-  quic->cb.now_ctx          = NULL;
+  quic->cb.now              = fd_quic_test_now;
 
   fd_quic_set_aio_net_tx( quic, udpsock->aio );
   FD_TEST( fd_quic_init( quic ) );
@@ -131,7 +121,7 @@ run_quic_client( fd_quic_t *         quic,
 
     if( g_dead > 0 ) {
       /* start a new connection */
-      fd_quic_conn_t * conn = fd_quic_connect( quic, dst_ip, dst_port, NULL );
+      fd_quic_conn_t * conn = fd_quic_connect( quic, dst_ip, dst_port );
 
       if( conn ) {
         g_conn_meta[conn->conn_idx].conn     = conn;

--- a/src/waltz/quic/tests/test_quic_key_phase.c
+++ b/src/waltz/quic/tests/test_quic_key_phase.c
@@ -1,5 +1,4 @@
 #include "../fd_quic.h"
-#include "../fd_quic_private.h"
 #include "fd_quic_test_helpers.h"
 #include "../../../util/net/fd_pcapng.h"
 
@@ -251,8 +250,7 @@ client_fibre_fn( void * vp_arg ) {
 
   conn = fd_quic_connect( quic,
           server_quic->config.net.ip_addr,
-          server_quic->config.net.listen_udp_port,
-          server_quic->config.sni );
+          server_quic->config.net.listen_udp_port );
 
   if( !conn ) {
     FD_LOG_ERR(( "Client unable to obtain a connection. now: %lu", (ulong)now ));

--- a/src/waltz/quic/tests/test_quic_retry_integration.c
+++ b/src/waltz/quic/tests/test_quic_retry_integration.c
@@ -126,8 +126,7 @@ main( int argc, char ** argv ) {
   fd_quic_conn_t * client_conn = fd_quic_connect(
       client_quic,
       server_quic->config.net.ip_addr,
-      server_quic->config.net.listen_udp_port,
-      server_quic->config.sni );
+      server_quic->config.net.listen_udp_port );
   FD_TEST( client_conn );
 
   /* do general processing */

--- a/src/waltz/quic/tests/test_quic_streams.c
+++ b/src/waltz/quic/tests/test_quic_streams.c
@@ -156,8 +156,7 @@ main( int     argc,
   fd_quic_conn_t * client_conn = fd_quic_connect(
       client_quic,
       server_quic->config.net.ip_addr,
-      server_quic->config.net.listen_udp_port,
-      server_quic->config.sni );
+      server_quic->config.net.listen_udp_port );
   FD_TEST( client_conn );
 
   /* do general processing */

--- a/src/waltz/quic/tests/test_quic_tls_hs.c
+++ b/src/waltz/quic/tests/test_quic_tls_hs.c
@@ -1,13 +1,9 @@
 /* test_quic_tls_hs performs a handshake using the fd_quic_tls API.
    (fd_quic_tls is a light wrapper over fd_tls) */
 
-#include <signal.h>
-
 #include "../../tls/test_tls_helper.h"
 #include "../tls/fd_quic_tls.h"
 #include "../templ/fd_quic_transport_params.h"
-#include "../../../util/net/fd_ip4.h"
-#include "../../../ballet/x509/fd_x509_mock.h"
 
 // test transport parameters
 static uchar const test_tp[] =
@@ -99,7 +95,6 @@ main( int     argc,
       quic_tls,
       tls_client,
       0 /* is_server */,
-      "localhost",
       tmp_tp ) );
 
   my_quic_tls_t    tls_server[1] = {0};
@@ -109,7 +104,6 @@ main( int     argc,
       quic_tls,
       tls_server,
       1 /* is_server */,
-      "localhost",
       tmp_tp ) );
 
   // generate initial secrets for client

--- a/src/waltz/quic/tests/test_quic_txns.c
+++ b/src/waltz/quic/tests/test_quic_txns.c
@@ -88,13 +88,6 @@ cb_stream_receive( fd_quic_stream_t * stream,
 }
 
 ulong
-cb_now( void * context ) {
-  (void)context;
-  return (ulong)fd_log_wallclock();
-}
-
-
-ulong
 findch( char * buf, ulong buf_sz, char ch ) {
   for( ulong j = 0UL; j < buf_sz; ++j ) {
     char cur = buf[j];
@@ -133,8 +126,7 @@ run_quic_client( fd_quic_t *         quic,
   quic->cb.stream_new = cb_stream_new;
   quic->cb.stream_notify = cb_stream_notify;
   quic->cb.stream_receive = cb_stream_receive;
-  quic->cb.now = cb_now;
-  quic->cb.now_ctx = NULL;
+  quic->cb.now = fd_quic_test_now;
 
   fd_quic_set_aio_net_tx( quic, udpsock->aio );
   FD_TEST( fd_quic_init( quic ) );
@@ -147,7 +139,7 @@ run_quic_client( fd_quic_t *         quic,
       /* if no connection, try making one */
       FD_LOG_NOTICE(( "Creating connection" ));
 
-      gbl_conn = fd_quic_connect( quic, dst_ip, dst_port, NULL );
+      gbl_conn = fd_quic_connect( quic, dst_ip, dst_port );
 
       continue;
     }

--- a/src/waltz/quic/tls/fd_quic_tls.c
+++ b/src/waltz/quic/tls/fd_quic_tls.c
@@ -149,7 +149,6 @@ fd_quic_tls_hs_new( fd_quic_tls_hs_t * self,
                     fd_quic_tls_t *    quic_tls,
                     void *             context,
                     int                is_server,
-                    char const *       hostname,
                     fd_quic_transport_params_t const * self_transport_params ) {
   // clear the handshake bits
   fd_memset( self, 0, sizeof(fd_quic_tls_hs_t) );
@@ -191,9 +190,6 @@ fd_quic_tls_hs_new( fd_quic_tls_hs_t * self,
   } else {
     fd_tls_estate_cli_new( &self->hs.cli );
   }
-
-  /* TODO set TLS hostname if client */
-  (void)hostname;
 
   /* Set QUIC transport params */
   self->self_transport_params = *self_transport_params;

--- a/src/waltz/quic/tls/fd_quic_tls.h
+++ b/src/waltz/quic/tls/fd_quic_tls.h
@@ -199,7 +199,6 @@ fd_quic_tls_hs_new( fd_quic_tls_hs_t * self,
                     fd_quic_tls_t *    quic_tls,
                     void *             context,
                     int                is_server,
-                    char const *       hostname,
                     fd_quic_transport_params_t const * self_transport_params );
 
 void


### PR DESCRIPTION
Also clean up usages of fd_log_wallclock as the fd_quic clock src
