### PR TITLE
SIMD-0166: SBPF dynamic stack frames

### DIFF
--- a/src/flamenco/vm/fd_vm.h
+++ b/src/flamenco/vm/fd_vm.h
@@ -15,7 +15,7 @@ typedef struct fd_vm fd_vm_t;
 /* A fd_vm_shadow_t holds stack frame information not accessible from
    within a program. */
 
-struct fd_vm_shadow { ulong r6; ulong r7; ulong r8; ulong r9; ulong pc; };
+struct fd_vm_shadow { ulong r6; ulong r7; ulong r8; ulong r9; ulong r10; ulong pc; };
 typedef struct fd_vm_shadow fd_vm_shadow_t;
 
 /* fd_vm_input_region_t holds information about fragmented memory regions 
@@ -220,7 +220,7 @@ FD_PROTOTYPES_BEGIN
    integer power of 2.  FOOTPRINT is a multiple of align. 
    These are provided to facilitate compile time declarations. */
 #define FD_VM_ALIGN     FD_VM_HOST_REGION_ALIGN
-#define FD_VM_FOOTPRINT (527296UL)
+#define FD_VM_FOOTPRINT (527808UL)
 
 /* fd_vm_{align,footprint} give the needed alignment and footprint
    of a memory region suitable to hold an fd_vm_t.

--- a/src/flamenco/vm/fd_vm_private.h
+++ b/src/flamenco/vm/fd_vm_private.h
@@ -107,6 +107,8 @@ typedef struct fd_vm_vec fd_vm_vec_t;
 #define FD_VM_SBPF_REJECT_RODATA_STACK_OVERLAP(v)  ( v >= FD_SBPF_V3 )
 #define FD_VM_SBPF_ENABLE_ELF_VADDR(v)             ( v >= FD_SBPF_V3 )
 
+#define FD_VM_SBPF_DYNAMIC_STACK_FRAMES_ALIGN      (64U)
+
 #define FD_VM_OFFSET_MASK (0xffffffffUL)
 
 FD_PROTOTYPES_BEGIN

--- a/src/flamenco/vm/instr_test/v2/int_math.instr
+++ b/src/flamenco/vm/instr_test/v2/int_math.instr
@@ -33,9 +33,12 @@ $ op=07 dst=4 src=8 off=5a5a r4=       7ffffffff imm=ffffffff : ok  r4=       7f
 $ op=07 dst=5 src=7 off=5a5a r5=        80000000 imm=80000000 : ok  r5=               0  # zero
 $ op=07 dst=6 src=6 off=5a5a r6=               0 imm=80000000 : ok  r6=ffffffff80000000  # subtract, underflow
 $ op=07 dst=9 src=a off=0000 r9=               0 imm=       0 : ok  r9=               0  # zero
+$ op=07 dst=b src=0 off=0000 r11=             40 imm=       3 : ok  vfy                  # unaligned dynamic stack frame - SIMD-0166
+$ op=07 dst=b src=0 off=0000 r11=             40 imm=       0 : ok  r11=             40  # dynamic stack frame - SIMD-0166
+$ op=07 dst=b src=0 off=0000 r11=             40 imm=      40 : ok  r11=             80  # dynamic stack frame - SIMD-0166
+$ op=07 dst=b src=0 off=0000 r11=             40 imm=ffffffc0 : ok  r11=              0  # dynamic stack frame - SIMD-0166
 $ op=07 dst=9 src=b                                           : vfy                      # invalid src
 $ op=07 dst=a src=1                                           : vfy                      # invalid dst
-$ op=07 dst=b src=1                                           : vfy                      # invalid dst
 
 # add64 reg, reg
 $ op=0f dst=0 src=0 off=a5a5 r0= 101010101010101                      : ok  r0= 202020202020202  # src==dst


### PR DESCRIPTION
[SIMD-0166](https://github.com/solana-foundation/solana-improvement-documents/blob/c5fba114ae4081ad39080f3c6bb62ee7e4dea9f3/proposals/0166-dynamic-stack-frames.md): SBPF Dynamic stack frames

Implementation details:
- Enabling dynamic stack frames automagically disables gaps. This should be coherent with the work done for direct mapping.
- Minor cleanup of the register checks, including R11. Agave has a specific error for R10 that we don't have, but since all errors are mismatched I don't think we really need to add one.
- Stack alignment set to 64, I made comments in SIMD-0166 about that. If we decide to reduce it, we just need to change it in the macro.