### PR TITLE
quic: rewrite key update logic

### DIFF
--- a/src/waltz/quic/crypto/fd_quic_crypto_suites.h
+++ b/src/waltz/quic/crypto/fd_quic_crypto_suites.h
@@ -78,8 +78,7 @@ struct fd_quic_crypto_secrets {
   uchar secret[FD_QUIC_NUM_ENC_LEVELS][2][FD_QUIC_SECRET_SZ];
 
   /* new secret for switching keys during key update */
-  uchar new_secret   [2][FD_QUIC_SECRET_SZ];
-  uchar new_secret_sz[2];
+  uchar new_secret[2][FD_QUIC_SECRET_SZ];
 };
 
 /* fd_quic_gen_initial_secret generates the initial secret according to spec
@@ -104,16 +103,9 @@ fd_quic_gen_secrets(
     fd_quic_crypto_secrets_t * secrets,
     uint                       enc_level );
 
-
-/* generate new secrets
-
-   Used during key update to generate new secrets from the
-   existing secrets
-
-   see rfc9001 section 6, rfc8446 section 7.2 */
 void
-fd_quic_gen_new_secrets( fd_quic_crypto_secrets_t * secrets );
-
+fd_quic_key_update_derive( fd_quic_crypto_secrets_t * secrets,
+                           fd_quic_crypto_keys_t      new_keys[2] );
 
 /* fd_quic_gen_keys
 
@@ -128,15 +120,6 @@ fd_quic_gen_keys(
     fd_quic_crypto_keys_t * keys,
     uchar const             secret[ 32 ] );
 
-
-/* generates packet key and iv key
-   used by key update
-
-   TODO this overlaps with fd_quic_gen_keys, split into gen_hp_keys and gen_pkt_keys */
-void
-fd_quic_gen_new_keys(
-    fd_quic_crypto_keys_t * keys,
-    uchar const             secret[ 32 ] );
 
 /* encrypt a packet according to rfc9001 packet protection and header protection
 

--- a/src/waltz/quic/fd_quic.h
+++ b/src/waltz/quic/fd_quic.h
@@ -499,8 +499,7 @@ fd_quic_conn_close( fd_quic_conn_t * conn,
 /* Service API ********************************************************/
 
 /* fd_quic_get_next_wakeup returns the next requested service time.
-   The returned timestamp is relative to a value previously returned by
-   fd_quic_now_t.  This is only intended for unit tests. */
+   This is only intended for unit tests. */
 
 FD_QUIC_API ulong
 fd_quic_get_next_wakeup( fd_quic_t * quic );

--- a/src/waltz/quic/fd_quic_conn.c
+++ b/src/waltz/quic/fd_quic_conn.c
@@ -1,9 +1,7 @@
 #include "fd_quic_conn.h"
 #include "fd_quic_common.h"
-#include "../../util/fd_util.h"
 #include "fd_quic_enum.h"
 #include "fd_quic_pkt_meta.h"
-#include "fd_quic_private.h"
 
 /* define a map for stream_id -> stream* */
 #define MAP_NAME              fd_quic_stream_map

--- a/src/waltz/quic/fd_quic_pkt_meta.h
+++ b/src/waltz/quic/fd_quic_pkt_meta.h
@@ -78,8 +78,6 @@ struct fd_quic_pkt_meta {
        FD_QUIC_PKT_META_FLAGS_MAX_DATA            max_data frame
        FD_QUIC_PKT_META_FLAGS_MAX_STREAMS_UNIDIR  max_streams frame (unidir)
        FD_QUIC_PKT_META_FLAGS_CLOSE               close frame
-       FD_QUIC_PKT_META_FLAGS_KEY_UPDATE          indicates key update was in effect
-       FD_QUIC_PKT_META_FLAGS_KEY_PHASE           set only if key_phase was set in the short-header
        FD_QUIC_PKT_META_FLAGS_PING                set to send a PING frame
 
      some of these flags are mutually exclusive */
@@ -90,8 +88,6 @@ struct fd_quic_pkt_meta {
 # define          FD_QUIC_PKT_META_FLAGS_MAX_DATA           (1u<<3u)
 # define          FD_QUIC_PKT_META_FLAGS_MAX_STREAMS_UNIDIR (1u<<5u)
 # define          FD_QUIC_PKT_META_FLAGS_CLOSE              (1u<<8u)
-# define          FD_QUIC_PKT_META_FLAGS_KEY_UPDATE         (1u<<9u)
-# define          FD_QUIC_PKT_META_FLAGS_KEY_PHASE          (1u<<10u)
   fd_quic_range_t        range;       /* range of bytes referred to by this meta */
                                       /* stream data or crypto data */
                                       /* we currently do not put both in the same packet */

--- a/src/waltz/quic/tests/Local.mk
+++ b/src/waltz/quic/tests/Local.mk
@@ -46,6 +46,6 @@ $(call make-fuzz-test,fuzz_quic,fuzz_quic,fd_quic fd_tls fd_ballet fd_waltz fd_u
 $(call make-fuzz-test,fuzz_quic_wire,fuzz_quic_wire,fd_quic fd_tls fd_ballet fd_waltz fd_util)
 endif
 
-$(call make-unit-test,test_quic_key_phase,  test_quic_key_phase,  fd_quic fd_tls fd_ballet fd_waltz fd_util fd_fibre)
-#$(call run-unit-test,test_quic_key_phase)  -- FIXME broken due to next_wakeup logic
+$(call make-unit-test,test_quic_key_phase,test_quic_key_phase,fd_quic fd_tls fd_ballet fd_waltz fd_util fd_fibre)
+$(call run-unit-test,test_quic_key_phase)
 endif

--- a/src/waltz/quic/tests/test_quic_key_phase.c
+++ b/src/waltz/quic/tests/test_quic_key_phase.c
@@ -1,19 +1,8 @@
 #include "../fd_quic.h"
 #include "fd_quic_test_helpers.h"
-#include "../../../util/net/fd_pcapng.h"
-
 #include "../../../util/fibre/fd_fibre.h"
 
 #include <stdlib.h>
-
-
-/* force a key phase change */
-/* returns FD_QUIC_SUCCESS (0) on success */
-/* all other return values indicate failure */
-/* temporarily here */
-int
-fd_quic_conn_force_key_phase_change( fd_quic_conn_t * conn );
-
 
 /* number of streams to send/receive between key phase changes */
 #define NUM_STREAMS 1000
@@ -23,124 +12,23 @@ fd_quic_conn_force_key_phase_change( fd_quic_conn_t * conn );
 
 /* done flags */
 
-int client_done = 0;
-int server_done = 0;
+static int client_done = 0;
+static int server_done = 0;
 
 /* received count */
-ulong rcvd                 = 0;
-ulong tot_rcvd             = 0;
-ulong tot_key_phase_change = 0;
+static ulong rcvd                 = 0;
+static ulong tot_rcvd             = 0;
+static ulong tot_key_phase_change = 0;
 
 /* some randomness stuff */
 
 /* fibres for client and server */
 
-fd_fibre_t * client_fibre = NULL;
-fd_fibre_t * server_fibre = NULL;
+static fd_fibre_t * client_fibre = NULL;
+static fd_fibre_t * server_fibre = NULL;
 
-/* "net" fibre for dropping and pcapping */
-
-fd_fibre_t * net_fibre = NULL;
-
-struct net_fibre_args {
-  fd_fibre_pipe_t * input;
-  fd_fibre_pipe_t * release;
-  float             thresh;
-  int               dir; /* 0=client->server  1=server->client */
-};
-typedef struct net_fibre_args net_fibre_args_t;
-
-
-/* man-in-the-middle for testing drops */
-
-struct mitm_ctx {
-  fd_aio_t         local;
-  fd_aio_t const * dst;
-  fd_aio_t const * pcap;
-  int              server;
-};
-typedef struct mitm_ctx mitm_ctx_t;
-
-static int
-mitm_tx( void *                    ctx,
-         fd_aio_pkt_info_t const * batch,
-         ulong                     batch_cnt,
-         ulong *                   opt_batch_idx,
-         int                       flush ) {
-  (void)flush;
-  (void)opt_batch_idx;
-
-  mitm_ctx_t * mitm_ctx = (mitm_ctx_t*)ctx;
-
-  /* each time data transfers, the schedule might change
-     so wake the other fibre */
-  if( client_fibre &&  mitm_ctx->server ) fd_fibre_wake( client_fibre );
-  if( server_fibre && !mitm_ctx->server ) fd_fibre_wake( server_fibre );
-
-  /* write to pcap */
-#define PCAP( batch, batch_cnt ) \
-  if( mitm_ctx->pcap ) { \
-    fd_aio_send( mitm_ctx->pcap, (batch), (batch_cnt), NULL, 1 ); \
-  }
-
-  /* go packet by packet */
-  for( ulong j = 0UL; j < batch_cnt; ++j ) {
-    /* send new packet */
-    fd_aio_pkt_info_t batch_0[1] = { batch[j] };
-    fd_aio_send( mitm_ctx->dst, batch_0, 1UL, NULL, 1 );
-    PCAP(batch_0,1UL);
-  }
-
-  return FD_AIO_SUCCESS;
-}
-
-static void
-mitm_link( fd_quic_t * quic_a, fd_quic_t * quic_b, mitm_ctx_t * mitm, fd_aio_t const * pcap ) {
-  fd_aio_t const * rx_b = fd_quic_get_aio_net_rx( quic_b );
-
-  /* create a new aio for mitm */
-
-  FD_TEST( fd_aio_join( fd_aio_new( &mitm->local, mitm, mitm_tx ) ) );
-
-  mitm->dst  = rx_b;
-  mitm->pcap = pcap;
-
-  fd_quic_set_aio_net_tx( quic_a, &mitm->local );
-}
-
-static void
-mitm_set_server( mitm_ctx_t * mitm_ctx, int server ) {
-  mitm_ctx->server = server;
-}
-
-
-fd_aio_pcapng_t pcap_client_to_server;
-fd_aio_pcapng_t pcap_server_to_client;
-
-static void
-my_tls_keylog( void *       quic_ctx,
-               char const * line ) {
-  (void)quic_ctx;
-  FD_LOG_WARNING(( "SECRET: %s", line ));
-  fd_pcapng_fwrite_tls_key_log( (uchar const *)line, (uint)strlen( line ), pcap_server_to_client.pcapng );
-}
-
-
-int state           = 0;
-int server_complete = 0;
-int client_complete = 0;
-
-extern uchar pkt_full[];
-extern ulong pkt_full_sz;
-
-uchar fail = 0;
-
-void
-my_stream_notify_cb( fd_quic_stream_t * stream, void * ctx, int type ) {
-  (void)stream;
-  (void)ctx;
-  (void)type;
-}
+static int server_complete = 0;
+static int client_complete = 0;
 
 int
 my_stream_rx_cb( fd_quic_conn_t * conn,
@@ -149,11 +37,7 @@ my_stream_rx_cb( fd_quic_conn_t * conn,
                  uchar const *    data,
                  ulong            data_sz,
                  int              fin ) {
-  (void)conn; (void)data; (void)fin;
-
-  FD_LOG_DEBUG(( "received data from peer.  stream_id: %lu  size: %lu offset: %lu\n",
-                (ulong)stream_id, data_sz, offset ));
-
+  (void)conn; (void)stream_id; (void)offset; (void)data; (void)data_sz; (void)fin;
   rcvd++;
   tot_rcvd++;
   return FD_QUIC_SUCCESS;
@@ -174,7 +58,7 @@ my_cb_conn_final( fd_quic_conn_t * conn,
 
   fd_quic_conn_t ** ppconn = (fd_quic_conn_t**)fd_quic_conn_get_context( conn );
   if( ppconn ) {
-    FD_LOG_NOTICE(( "my_cb_conn_final %p SUCCESS", (void*)*ppconn ));
+    FD_LOG_INFO(( "my_cb_conn_final %p SUCCESS", (void*)*ppconn ));
     *ppconn = NULL;
   }}
 
@@ -183,7 +67,7 @@ my_connection_new( fd_quic_conn_t * conn,
                    void *           vp_context ) {
   (void)vp_context;
 
-  FD_LOG_NOTICE(( "SERVER - handshake complete" ));
+  FD_LOG_INFO(( "SERVER - handshake complete" ));
 
   server_complete = 1;
 
@@ -192,31 +76,28 @@ my_connection_new( fd_quic_conn_t * conn,
   }
 
   server_conn = conn;
-
-  (void)conn;
 }
 
 void
 my_handshake_complete( fd_quic_conn_t * conn,
                        void *           vp_context ) {
-  (void)vp_context;
+  (void)conn; (void)vp_context;
 
-  FD_LOG_NOTICE(( "CLIENT - handshake complete" ));
+  FD_LOG_INFO(( "CLIENT - handshake complete" ));
 
   client_complete = 1;
-
-  (void)conn;
 }
 
 /* global "clock" */
-ulong now = (ulong)1e18;
+static ulong now = (ulong)1e18;
 
-ulong test_clock( void * ctx ) {
+static ulong
+test_clock( void * ctx ) {
   (void)ctx;
   return now;
 }
 
-long
+static long
 test_fibre_clock(void) {
   return (long)now;
 }
@@ -228,7 +109,7 @@ struct client_args {
 };
 typedef struct client_args client_args_t;
 
-void
+static void
 client_fibre_fn( void * vp_arg ) {
   client_args_t * args = (client_args_t*)vp_arg;
 
@@ -270,7 +151,7 @@ client_fibre_fn( void * vp_arg ) {
 
   uint last_key_phase = conn->key_phase;
 
-  FD_LOG_NOTICE(( "CLIENT - connection established - key_phase: %u", (uint)conn->key_phase ));
+  FD_LOG_INFO(( "CLIENT - connection established - key_phase: %u", (uint)conn->key_phase ));
 
   while( !client_done ) {
     ulong next_wakeup = fd_quic_get_next_wakeup( quic );
@@ -286,8 +167,8 @@ client_fibre_fn( void * vp_arg ) {
     }
 
     /* report key phase changes, when complete */
-    if( !conn->key_phase_upd && last_key_phase != conn->key_phase ) {
-      FD_LOG_NOTICE(( "CLIENT - key phase changed to %u", (uint)conn->key_phase ));
+    if( !conn->key_update && last_key_phase != conn->key_phase ) {
+      FD_LOG_INFO(( "CLIENT - key phase changed to %u", (uint)conn->key_phase ));
       last_key_phase = conn->key_phase;
 
       tot_key_phase_change++;
@@ -297,24 +178,17 @@ client_fibre_fn( void * vp_arg ) {
     }
 
     if( rcvd == NUM_STREAMS ) {
-      if( conn->key_phase_upd ) {
+      if( conn->key_update ) {
         /* key phase update should have completed long ago */
         FD_LOG_ERR(( "Unexpectedly in a key phase change" ));
       }
 
-      FD_LOG_NOTICE(( "CLIENT - received %u - starting key phase change", (uint)rcvd ));
+      FD_LOG_INFO(( "CLIENT - received %u - starting key phase change", (uint)rcvd ));
 
       /* reset count */
       rcvd = 0;
 
-      int rtn = fd_quic_conn_force_key_phase_change( conn );
-      if( rtn == FD_QUIC_FAILED ) {
-        FD_LOG_ERR(( "fd_quic_conn_force_key_phase_change returned error - "
-            "state: %u  peer_enc_level: %u  key_phase_upd: %u",
-            (uint)conn->state,
-            (uint)conn->peer_enc_level,
-            (uint)conn->key_phase_upd ));
-      }
+      conn->key_update = 1;  /* force a key update */
     }
 
     if( !stream ) {
@@ -365,7 +239,7 @@ struct server_args {
 typedef struct server_args server_args_t;
 
 
-void
+static void
 server_fibre_fn( void * vp_arg ) {
   server_args_t * args = (server_args_t*)vp_arg;
 
@@ -382,9 +256,9 @@ server_fibre_fn( void * vp_arg ) {
     if( server_conn ) {
       if( last_key_phase == -1u ) {
         last_key_phase = server_conn->key_phase;
-        FD_LOG_NOTICE(( "SERVER - connection established - key_phase: %u", (uint)last_key_phase ));
-      } else if( !server_conn->key_phase_upd && last_key_phase != server_conn->key_phase ) {
-        FD_LOG_NOTICE(( "SERVER - key phase changed to %u", (uint)server_conn->key_phase ));
+        FD_LOG_INFO(( "SERVER - connection established - key_phase: %u", (uint)last_key_phase ));
+      } else if( last_key_phase != server_conn->key_phase ) {
+        FD_LOG_INFO(( "SERVER - key phase changed to %u", (uint)server_conn->key_phase ));
         last_key_phase = server_conn->key_phase;
       }
     }
@@ -408,8 +282,8 @@ main( int argc, char ** argv ) {
   ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
   if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
 
-  char const * _page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"                   );
-  ulong        page_cnt  = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 2UL                          );
+  char const * _page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "normal"                     );
+  ulong        page_cnt  = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 800UL                        );
   ulong        numa_idx  = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx",  NULL, fd_shmem_numa_idx( cpu_idx ) );
 
   ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
@@ -419,30 +293,30 @@ main( int argc, char ** argv ) {
   fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
-  fd_quic_limits_t const quic_limits = {
-    .conn_cnt           = 10,
-    .conn_id_cnt        = 10,
-    .handshake_cnt      = 10,
-    .stream_pool_cnt    = 512,
-    .inflight_pkt_cnt   = 1024,
-    .tx_buf_sz          = 1<<14
+  FD_LOG_INFO(( "Creating server QUIC" ));
+  fd_quic_limits_t const server_limits = {
+    .conn_cnt           =  2,
+    .conn_id_cnt        =  4,
+    .handshake_cnt      =  2,
+    .inflight_pkt_cnt   = 16
   };
-
-  ulong quic_footprint = fd_quic_footprint( &quic_limits );
-  FD_TEST( quic_footprint );
-  FD_LOG_NOTICE(( "QUIC footprint: %lu bytes", quic_footprint ));
-
-  FD_LOG_NOTICE(( "Creating server QUIC" ));
-  fd_quic_t * server_quic = fd_quic_new_anonymous( wksp, &quic_limits, FD_QUIC_ROLE_SERVER, rng );
+  fd_quic_t * server_quic = fd_quic_new_anonymous( wksp, &server_limits, FD_QUIC_ROLE_SERVER, rng );
   FD_TEST( server_quic );
 
-  FD_LOG_NOTICE(( "Creating client QUIC" ));
-  fd_quic_t * client_quic = fd_quic_new_anonymous( wksp, &quic_limits, FD_QUIC_ROLE_CLIENT, rng );
+  FD_LOG_INFO(( "Creating client QUIC" ));
+  fd_quic_limits_t const client_limits = {
+    .conn_cnt         =   2,
+    .conn_id_cnt      =   4,
+    .handshake_cnt    =   2,
+    .inflight_pkt_cnt = 530,
+    .stream_id_cnt    = 512,
+    .stream_pool_cnt  = 512,
+    .tx_buf_sz        =  32,
+  };
+  fd_quic_t * client_quic = fd_quic_new_anonymous( wksp, &client_limits, FD_QUIC_ROLE_CLIENT, rng );
   FD_TEST( client_quic );
 
   client_quic->cb.conn_hs_complete = my_handshake_complete;
-  client_quic->cb.stream_rx        = my_stream_rx_cb;
-  client_quic->cb.stream_notify    = my_stream_notify_cb;
   client_quic->cb.conn_final       = my_cb_conn_final;
 
   client_quic->cb.now     = test_clock;
@@ -452,35 +326,15 @@ main( int argc, char ** argv ) {
 
   server_quic->cb.conn_new       = my_connection_new;
   server_quic->cb.stream_rx      = my_stream_rx_cb;
-  server_quic->cb.stream_notify  = my_stream_notify_cb;
   server_quic->cb.conn_final     = my_cb_conn_final;
-  server_quic->cb.tls_keylog     = my_tls_keylog;
 
   server_quic->cb.now     = test_clock;
   server_quic->cb.now_ctx = NULL;
 
   server_quic->config.initial_rx_max_stream_data = 1<<15;
 
-  /* pcap */
-  FILE * pcap_file = fopen( "test_quic_drops.pcapng", "wb" );
-  FD_TEST( pcap_file );
-  printf( "pcap_file: %p\n", (void*)pcap_file ); fflush( stdout );
-
-  FD_TEST( 1UL == fd_aio_pcapng_start( pcap_file ) );
-  fflush( pcap_file );
-
-  FD_TEST( fd_aio_pcapng_join( &pcap_client_to_server, NULL, pcap_file ) );
-  FD_TEST( fd_aio_pcapng_join( &pcap_server_to_client, NULL, pcap_file ) );
-
-  FD_LOG_NOTICE(( "Attaching AIOs" ));
-  mitm_ctx_t mitm_client_to_server;
-  mitm_ctx_t mitm_server_to_client;
-
-  mitm_link( client_quic, server_quic, &mitm_client_to_server, fd_aio_pcapng_get_aio( &pcap_client_to_server ) );
-  mitm_link( server_quic, client_quic, &mitm_server_to_client, fd_aio_pcapng_get_aio( &pcap_server_to_client ) );
-
-  mitm_set_server( &mitm_client_to_server, 0 );
-  mitm_set_server( &mitm_server_to_client, 1 );
+  fd_quic_virtual_pair_t vp;
+  fd_quic_virtual_pair_init( &vp, /*a*/ client_quic, /*b*/ server_quic );
 
   FD_LOG_NOTICE(( "Initializing QUICs" ));
   FD_TEST( fd_quic_init( client_quic ) );
@@ -518,13 +372,9 @@ main( int argc, char ** argv ) {
     now = (ulong)timeout;
   }
 
-
-  FD_TEST( fd_aio_pcapng_leave( &pcap_client_to_server ) );
-  FD_TEST( fd_aio_pcapng_leave( &pcap_server_to_client ) );
-
+  FD_LOG_NOTICE(( "Passed %lu key updates", tot_key_phase_change ));
   FD_LOG_NOTICE(( "Cleaning up" ));
-  //fd_quic_virtual_pair_fini( &vp );
-  // TODO clean up mitm_ctx and aio
+  fd_quic_virtual_pair_fini( &vp );
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( server_quic ) ) );
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( client_quic ) ) );
   fd_wksp_delete_anonymous( wksp );
@@ -534,26 +384,4 @@ main( int argc, char ** argv ) {
   fd_quic_test_halt();
   fd_halt();
   return 0;
-}
-
-int
-fd_quic_conn_force_key_phase_change( fd_quic_conn_t * conn ) {
-  int sanity =  !!conn
-             && conn->state         == FD_QUIC_CONN_STATE_ACTIVE
-             && conn->key_phase_upd == 0;
-
-  if( FD_UNLIKELY( !sanity ) ) {
-    return FD_QUIC_FAILED;
-  }
-
-  /* generate new secrets */
-  fd_quic_gen_new_secrets( &conn->secrets );
-
-  /* generate new keys */
-  fd_quic_gen_new_keys( &conn->new_keys[0], conn->secrets.new_secret[0] );
-  fd_quic_gen_new_keys( &conn->new_keys[1], conn->secrets.new_secret[1] );
-
-  conn->key_phase_upd = 1;
-
-  return FD_QUIC_SUCCESS;
 }


### PR DESCRIPTION
Fixes conn failure if more than 'inflight_pkt_cnt' ACKs are sent during a key update.

Simplifies key update logic overall.

Internals:
- Always keep precomputed updated keys and secrets around
- Don't track key phase information in pkt_meta
- Immediately commit key update secrets once an incoming packet
  with a different key phase passes encryption
- Rationale: If packets with an old key phase get reordered past
  the packet that updated the key phase, those old packets will
  just fail decryption without any side effects
- The RFC and the old code used more complex methods for hardening
  key updates against reordering (e.g. using ACKs) but those are
  not necessary if key updates are only followed, not initiated
- Simplify key update initiation (only for testing)
- Fix test_quic_key_phase and delete redundant code
