### PR TITLE
ci: codeql ci improvements

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{matrix.language}})
-    runs-on: 'ubuntu-latest'
+    runs-on: 1T
 
     strategy:
       fail-fast: false
@@ -15,33 +15,48 @@ jobs:
         include:
         - language: c-cpp
           build-mode: manual
+          compiler: clang
+          machine: linux_clang_x86_64
+          compiler-version: 15.0.6
+          extras: rpath no-agave
+    env:
+      MACHINE: ${{ matrix.machine }}
+      EXTRAS: ${{ matrix.extras || '' }}
+      CC: ${{ matrix.compiler }}
+      CXX: ${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - name: Install system dependencies
-      shell: bash
-      run: |
-        sudo apt-get install -y gettext autopoint gcc-multilib protobuf-compiler llvm lcov libudev-dev cmake libclang-dev
-    - name: Install dependencies
-      shell: bash
-      run: |
-        echo "y" | ./deps.sh
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        queries: ./contrib/codeql/
-        config: |
-            disable-default-queries: true
-    - if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        MACHINE=linux_clang_noarch64 make -j unit-test
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
-        upload: 'always'
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/deps
+        with:
+          compiler: ${{ matrix.compiler }}
+          compiler-version: ${{ matrix.compiler-version }}
+      - uses: dtolnay/rust-toolchain@1.73.0
+      - name: clean targets
+        run: |
+          make clean --silent >/dev/null
+      - uses: ./.github/actions/submodule
+        with:
+          machine: ${{ matrix.machine }}
+          compiler: ${{ matrix.compiler }}
+          compiler-version: ${{ matrix.compiler-version }}
+        if: ${{ contains(matrix.targets, 'fdctl') && !contains(matrix.extras, 'no-agave') }}
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: ./contrib/codeql/
+          config: |
+              disable-default-queries: true
+      - if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          make -j fddev
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"
+          upload: 'always'
+

--- a/contrib/codeql/BuiltinExpectScopeTooNarrow.ql
+++ b/contrib/codeql/BuiltinExpectScopeTooNarrow.ql
@@ -30,3 +30,4 @@ where
        (e instanceof ConditionalExpr)) and
   included(builtinCall.getLocation())
 select builtinCall, "Use of __builtin_expect() in non-conditional context"
+

--- a/contrib/codeql/NonAnnotatedFormatFunction.ql
+++ b/contrib/codeql/NonAnnotatedFormatFunction.ql
@@ -1,6 +1,6 @@
 /**
  * Find calls to functions that likely expect a format string but are not annotated as such.
- * @id cpp/non-annotated-format-function
+ * @id asymmetric-research/non-annotated-format-function
  * @kind problem
  * @severity warning
  */
@@ -13,3 +13,4 @@ s.getParent().(FunctionCall).getTarget() = f and  /* ignores dynamic function ca
 not exists( Attribute attr | attr = f.getAnAttribute() | attr.getName() = "format" ) and
 f.getLocation().getFile().getRelativePath().regexpMatch("src/.*")
 select f, "Likely format string passed to non-format function"
+

--- a/contrib/codeql/RedundantNullCheck.ql
+++ b/contrib/codeql/RedundantNullCheck.ql
@@ -218,4 +218,4 @@
 
  select checked, deref, checked, "This null check is redundant because $@ in any case.", deref,
    "the value is dereferenced"
- 
+

--- a/contrib/codeql/UnclearOperatorPrecedence.ql
+++ b/contrib/codeql/UnclearOperatorPrecedence.ql
@@ -13,3 +13,4 @@ where
     bit.hasOperands(rel, other) and
     not rel.isParenthesised()
 select rel, "Operator precedence and paranthese hint at a likely issue"
+

--- a/contrib/codeql/filter.qll
+++ b/contrib/codeql/filter.qll
@@ -3,5 +3,5 @@
  */
 import cpp
 predicate included(Location loc) {
-  loc.getFile().getRelativePath().prefix(5) != "agave/"
+  loc.getFile().getRelativePath().prefix(6) != "agave/"
 }


### PR DESCRIPTION
analyse big fddev x86 build (instead noarch unit-test), fix included filter, fix query metadata, unify build by using existing workflows, move to on-prem (speeding up the query, despite much bigger compile target, from 10m 20s to 4m 32s)