### PR TITLE
flamenco: resetting starting balance for instructions sysvar

### DIFF
--- a/contrib/test/test-vectors-fixtures/txn-fixtures/program-tests.list
+++ b/contrib/test/test-vectors-fixtures/txn-fixtures/program-tests.list
@@ -2760,3 +2760,4 @@ dump/test-vectors/txn/fixtures/programs/9be1ddb02934e8c8876427e2b074a5051f713a32
 dump/test-vectors/txn/fixtures/programs/a45037de050ba8834d20ea95b380eccddefd6e7f_1655663.fix
 dump/test-vectors/txn/fixtures/programs/e2caaa961ea02c52430d673e0a6f2de8a126784a_1658208.fix
 dump/test-vectors/txn/fixtures/programs/fb1305b2e30e46cc2a321004c061888e84953432_1657414.fix
+dump/test-vectors/txn/fixtures/programs/5dc8ef5ae51a59f4a5e11d0641992354b09b5ef0_4184179.fix

--- a/src/flamenco/runtime/sysvar/fd_sysvar_instructions.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_instructions.c
@@ -31,6 +31,7 @@ instructions_serialized_size( fd_instr_info_t const *   instrs,
   return serialized_size;
 }
 
+/* https://github.com/anza-xyz/agave/blob/v2.1.1/svm/src/account_loader.rs#L547-L576 */
 int
 fd_sysvar_instructions_serialize_account( fd_exec_txn_ctx_t *      txn_ctx,
                                           fd_instr_info_t const *  instrs,
@@ -48,11 +49,15 @@ fd_sysvar_instructions_serialize_account( fd_exec_txn_ctx_t *      txn_ctx,
   rec->const_meta = rec->meta = meta;
   rec->const_data = rec->data = data;
 
+  /* Agave sets up the borrowed account for the instructions sysvar to contain
+     default values except for the data which is serialized into the account. */
+
   memcpy( rec->meta->info.owner, fd_sysvar_owner_id.key, sizeof(fd_pubkey_t) );
-  rec->meta->info.lamports = 0; // TODO: This cannot be right... well, it gets destroyed almost instantly...
+  rec->starting_lamports     = 0UL;
+  rec->meta->info.lamports   = 0UL; // TODO: This cannot be right... well, it gets destroyed almost instantly...
   rec->meta->info.executable = 0;
-  rec->meta->info.rent_epoch = 0;
-  rec->meta->dlen = serialized_sz;
+  rec->meta->info.rent_epoch = 0UL;
+  rec->meta->dlen            = serialized_sz;
 
   uchar * serialized_instructions = rec->data;
   ulong offset = 0;


### PR DESCRIPTION
we need to do this because the fuzzer can provide incorrect starting balances for the intructions sysvar. What we do now is still correct behavior because this is when the account is setup in both Agave and Firedancer. The account always has default values when data is serialized into it.