### PR TITLE
flamenco: init parent_signature_cnt and lamports_per_signature to non 0

### DIFF
--- a/src/flamenco/runtime/context/fd_exec_slot_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_slot_ctx.c
@@ -251,8 +251,9 @@ fd_exec_slot_ctx_recover_( fd_exec_slot_ctx_t *   slot_ctx,
   slot_bank->prev_slot = oldbank->parent_slot;
   fd_memcpy(&slot_bank->banks_hash, &oldbank->hash, sizeof(oldbank->hash));
   fd_memcpy(&slot_bank->fee_rate_governor, &oldbank->fee_rate_governor, sizeof(oldbank->fee_rate_governor));
-  slot_bank->lamports_per_signature = oldbank->fee_calculator.lamports_per_signature;
-  slot_ctx->prev_lamports_per_signature = oldbank->fee_calculator.lamports_per_signature;
+  slot_bank->lamports_per_signature = manifest->lamports_per_signature;
+  slot_ctx->prev_lamports_per_signature = manifest->lamports_per_signature;
+  slot_ctx->parent_signature_cnt = oldbank->signature_count;
   if( oldbank->hashes_per_tick )
     epoch_bank->hashes_per_tick = *oldbank->hashes_per_tick;
   else

--- a/src/flamenco/runtime/fd_blockstore.c
+++ b/src/flamenco/runtime/fd_blockstore.c
@@ -236,6 +236,7 @@ fd_blockstore_init( fd_blockstore_t * blockstore, fd_slot_bank_t const * slot_ba
 
   block_map_entry->height          = slot_bank->block_height;
   block_map_entry->bank_hash       = slot_bank->banks_hash;
+  block_map_entry->block_hash      = slot_bank->poh;
   block_map_entry->flags           = fd_uchar_set_bit(
                                      fd_uchar_set_bit(
                                      fd_uchar_set_bit(
@@ -309,7 +310,7 @@ fd_txn_key_hash( fd_txn_key_t const * k, ulong seed ) {
 static void
 fd_blockstore_scan_block( fd_blockstore_t * blockstore, ulong slot, fd_block_t * block ) {
 
-#define MAX_MICROS ( 16 << 10 )
+#define MAX_MICROS ( 1 << 17 )
   fd_block_micro_t micros[MAX_MICROS];
   ulong            micros_cnt = 0;
 #define MAX_TXNS ( 1 << 17 )

--- a/src/flamenco/runtime/tests/run_ledger_tests_all.txt
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.txt
@@ -71,3 +71,4 @@ src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-300377724 -s snapshot-3
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-300645644 -s snapshot-300645643-D2ZXqQffEoM6cgPGoC9LC4UfjyCMi1cqbhrceRPh4cE7.tar.zst -p 50 -y 16 -m 5000000 -e 300645644 -c 1.18.23
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-300648964 -s snapshot-300648963-BPSiWGgLbiof1b8Ui5qnM4eUDv8asDo9j7Bn8QvrvwUZ.tar.zst -p 50 -y 16 -m 5000000 -e 300648964 -c 1.18.23
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-301359740 -s snapshot-301359739-5L5b7KFLFiQYpmk7nHUJYX8fXMUG4qv7m6iBMWRN2V5h.tar.zst -p 50 -y 16 -m 5000000 -e 301359740 -c 1.18.23
+src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-302734641 -s snapshot-302734640-9e44jEVavfHC253DSBGSjTFt2diZrgcMHTRZtpUvisvr.tar.zst -p 50 -y 16 -m 5000000 -e 302734658 -c 2.0.10


### PR DESCRIPTION
These values are involved in the computation of new derived lamports_per_signature values in sysvar.  We derive incorrect lamports_per_signature if these two are not initialized properly.

Also bump the limit on the number of microblocks per block in the blockstore.  The runtime has no similar limits and can handle blocks with a large number of microblocks just fine.  There's no reason for the blockstore to have such a limit.