### PR TITLE
runtime: remove unreachable code

### DIFF
--- a/src/ballet/shred/fuzz_shred_parse.c
+++ b/src/ballet/shred/fuzz_shred_parse.c
@@ -144,7 +144,6 @@ LLVMFuzzerTestOneInput( uchar const * data,
   default:
     /* unknown variant */
     abort();
-    break;
   }
 
 # undef BOUNDS_CHECK

--- a/src/flamenco/capture/fd_solcap_diff.c
+++ b/src/flamenco/capture/fd_solcap_diff.c
@@ -162,27 +162,27 @@ fd_solcap_differ_sync( fd_solcap_differ_t * diff, ulong start_slot, ulong end_sl
   ulong prev_slot0 = diff->preimage[ 0 ].slot;
   ulong prev_slot1 = diff->preimage[ 1 ].slot;
 
+  int res;
   for(;;) {
     ulong slot0 = diff->preimage[ 0 ].slot;
     ulong slot1 = diff->preimage[ 1 ].slot;
 
     /* Handle cases where slot is skipped in one or the other */
-    if ( FD_UNLIKELY( prev_slot0 < slot1 && slot0 > slot1 ) ) {
+    if( FD_UNLIKELY( prev_slot0 < slot1 && slot0 > slot1 ) ) {
       FD_LOG_WARNING(("Slot range (%lu,%lu) skipped in file=%s\n",
                       prev_slot0, slot0, diff->file_paths[0]));
     }
-    else if ( FD_UNLIKELY( prev_slot1 < slot0 && slot1 > slot0 ) ) {
+    else if( FD_UNLIKELY( prev_slot1 < slot0 && slot1 > slot0 ) ) {
       FD_LOG_WARNING(("Slot range (%lu,%lu) skipped in file=%s\n",
                       prev_slot1, slot1, diff->file_paths[1]));
     }
 
     if( slot0 == slot1 ) {
       if ( slot0 < start_slot ) {
-        int res;
         res = fd_solcap_differ_advance( diff, 0 );
-        if( FD_UNLIKELY( res <= 0 ) ) return res;
+        if( FD_UNLIKELY( res <= 0 ) ) break;
         res = fd_solcap_differ_advance( diff, 1 );
-        if( FD_UNLIKELY( res <= 0 ) ) return res;
+        if( FD_UNLIKELY( res <= 0 ) ) break;
       }
       else if ( slot0 > end_slot ) {
         return 0;
@@ -193,14 +193,14 @@ fd_solcap_differ_sync( fd_solcap_differ_t * diff, ulong start_slot, ulong end_sl
     }
     else {
       ulong idx = slot0>slot1;
-      int res = fd_solcap_differ_advance( diff, idx );
-      if( FD_UNLIKELY( res<=0 ) ) return res;
+      res = fd_solcap_differ_advance( diff, idx );
+      if( FD_UNLIKELY( res<=0 ) ) break;
     }
     prev_slot0 = slot0;
     prev_slot1 = slot1;
   }
 
-  return 0;
+  return res;
 }
 
 static int

--- a/src/flamenco/rewards/fd_rewards.c
+++ b/src/flamenco/rewards/fd_rewards.c
@@ -438,7 +438,6 @@ calculate_reward_points_partitioned(
             int err = fd_acc_mgr_view( slot_ctx->acc_mgr, slot_ctx->funk_txn, stake_acc, stake_acc_rec);
             if ( err != FD_ACC_MGR_SUCCESS && err != FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT ) {
                 FD_LOG_ERR(( "failed to read stake account from funk" ));
-                continue;
             }
             if ( err == FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT ) {
                 FD_LOG_DEBUG(( "stake account not found %s", FD_BASE58_ENC_32_ALLOCA( stake_acc->uc ) ));
@@ -573,7 +572,6 @@ calculate_stake_vote_rewards_account(
         fd_vote_state_versioned_t vote_state_versioned[1] = {0};
         if( fd_vote_state_versioned_decode( vote_state_versioned, &decode ) != 0 ) {
             FD_LOG_ERR(( "failed to decode vote state" ));
-            return;
         }
 
         /* Note, this doesn't actually redeem any rewards.. this is a misnomer. */

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -1444,7 +1444,7 @@ fd_execute_txn_finalize( fd_exec_txn_ctx_t * txn_ctx,
 
     int ret = fd_acc_mgr_save_non_tpool( txn_ctx->acc_mgr, txn_ctx->funk_txn, acc_rec );
     if( ret != FD_ACC_MGR_SUCCESS ) {
-      FD_LOG_ERR(( "failed to save edits to accounts" ));
+      FD_LOG_WARNING(( "failed to save edits to accounts" ));
       return -1;
     }
 

--- a/src/flamenco/runtime/fd_rocksdb.c
+++ b/src/flamenco/runtime/fd_rocksdb.c
@@ -361,8 +361,6 @@ fd_rocksdb_get_slot( ulong cf_idx, char const * key ) {
     default: /* all other cfs have the slot at the start */
       return fd_ulong_bswap( *((ulong *)&key[0]) ); /* The key is just the slot number */
   }
-
-  return fd_ulong_bswap( *((ulong *)key) );
 }
 
 void

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -1906,7 +1906,7 @@ fd_runtime_finalize_txns_tpool( fd_exec_slot_ctx_t *         slot_ctx,
     // TODO: we need to use the txn ctx funk_txn, valloc, etc.
     int err = fd_acc_mgr_save_many_tpool( slot_ctx->acc_mgr, slot_ctx->funk_txn, accounts_to_save, acc_idx, tpool );
     if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
-      FD_LOG_ERR(( "failed to save edits to accounts" ));
+      FD_LOG_WARNING(( "failed to save edits to accounts" ));
       return -1;
     }
 
@@ -2848,9 +2848,9 @@ fd_runtime_publish_old_txns( fd_exec_slot_ctx_t * slot_ctx,
       FD_LOG_DEBUG(("publishing %s (slot %lu)", FD_BASE58_ENC_32_ALLOCA( &txn->xid ), txn->xid.ul[0]));
 
       fd_funk_start_write(funk);
-      ulong publish_err = fd_funk_txn_publish(funk, txn, 1);
-      if (publish_err == 0) {
-        FD_LOG_ERR(("publish err"));
+      ulong publish_err = fd_funk_txn_publish( funk, txn, 1 );
+      if( publish_err == 0 ) {
+        FD_LOG_WARNING(( "fd_funk_txn_publish failed" ));
         return -1;
       }
       if( slot_ctx->status_cache ) {

--- a/src/flamenco/runtime/fd_runtime_init.c
+++ b/src/flamenco/runtime/fd_runtime_init.c
@@ -249,9 +249,9 @@ fd_runtime_delete_banks( fd_exec_slot_ctx_t * slot_ctx ) {
    address. */
 
 static void
-fd_feature_restore( fd_exec_slot_ctx_t * slot_ctx,
+fd_feature_restore( fd_exec_slot_ctx_t *    slot_ctx,
                     fd_feature_id_t const * id,
-                    uchar const       acct[ static 32 ] ) {
+                    uchar const             acct[ static 32 ] ) {
 
   FD_BORROWED_ACCOUNT_DECL(acct_rec);
   int err = fd_acc_mgr_view(slot_ctx->acc_mgr, slot_ctx->funk_txn, (fd_pubkey_t *)acct, acct_rec);
@@ -273,9 +273,8 @@ fd_feature_restore( fd_exec_slot_ctx_t * slot_ctx,
         .valloc = fd_scratch_virtual(),
     };
     int decode_err = fd_feature_decode(feature, &ctx);
-    if (FD_UNLIKELY(decode_err != FD_BINCODE_SUCCESS))
-    {
-      FD_LOG_ERR(("Failed to decode feature account %s (%d)", FD_BASE58_ENC_32_ALLOCA( acct ), decode_err));
+    if( FD_UNLIKELY( decode_err != FD_BINCODE_SUCCESS ) ) {
+      FD_LOG_WARNING(( "Failed to decode feature account %s (%d)", FD_BASE58_ENC_32_ALLOCA( acct ), decode_err ));
       return;
     }
 

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -886,7 +886,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
       uchar bump_seed = 0;
       err = fd_pubkey_find_program_address( instr_ctx, program_id, 1UL, seeds, &seed_sz, derived_address, &bump_seed );
       if( FD_UNLIKELY( err ) ) {
-        FD_LOG_ERR(( "Unable to find a viable program address bump seed" )); // Solana panics, error code is undefined
+        FD_LOG_WARNING(( "fd_pubkey_find_program_address failed. Agave would panic here. Continuing ..." ));
         return err;
       }
       if( FD_UNLIKELY( memcmp( derived_address, programdata_key, sizeof(fd_pubkey_t) ) ) ) {

--- a/src/flamenco/runtime/program/fd_bpf_program_util.c
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.c
@@ -279,7 +279,6 @@ fd_bpf_scan_and_create_bpf_program_cache_entry_tpool( fd_exec_slot_ctx_t * slot_
   fd_funk_txn_t * cache_txn = fd_funk_txn_prepare( funk, slot_ctx->funk_txn, &cache_xid, 1 );
   if( !cache_txn ) {
     FD_LOG_ERR(( "fd_funk_txn_prepare() failed" ));
-    return -1;
   }
 
   fd_funk_txn_t * parent_txn = slot_ctx->funk_txn;
@@ -322,7 +321,6 @@ fd_bpf_scan_and_create_bpf_program_cache_entry_tpool( fd_exec_slot_ctx_t * slot_
 
   if( fd_funk_txn_publish_into_parent( funk, cache_txn, 1 ) != FD_FUNK_SUCCESS ) {
     FD_LOG_ERR(( "fd_funk_txn_publish_into_parent() failed" ));
-    return -1;
   }
 
   slot_ctx->funk_txn = parent_txn;
@@ -345,7 +343,7 @@ fd_bpf_scan_and_create_bpf_program_cache_entry( fd_exec_slot_ctx_t * slot_ctx,
 
   fd_funk_txn_t * cache_txn = fd_funk_txn_prepare( funk, slot_ctx->funk_txn, &cache_xid, 1 );
   if( !cache_txn ) {
-    FD_LOG_ERR(( "fd_funk_txn_prepare() failed" ));
+    FD_LOG_WARNING(( "fd_funk_txn_prepare() failed" ));
     return -1;
   }
 
@@ -373,7 +371,7 @@ fd_bpf_scan_and_create_bpf_program_cache_entry( fd_exec_slot_ctx_t * slot_ctx,
   FD_LOG_DEBUG(( "loaded program cache: %lu", cnt));
 
   if( fd_funk_txn_publish_into_parent( funk, cache_txn, 1 ) != FD_FUNK_SUCCESS ) {
-    FD_LOG_ERR(( "fd_funk_txn_publish_into_parent() failed" ));
+    FD_LOG_WARNING(( "fd_funk_txn_publish_into_parent() failed" ));
     return -1;
   }
 

--- a/src/flamenco/snapshot/fd_snapshot.c
+++ b/src/flamenco/snapshot/fd_snapshot.c
@@ -130,7 +130,6 @@ fd_snapshot_load( const char *         snapshotfile,
   switch (snapshot_type) {
   case FD_SNAPSHOT_TYPE_UNSPECIFIED:
     FD_LOG_ERR(("fd_snapshot_load(\"%s\", verify-hash=%s, check-hash=%s, FD_SNAPSHOT_TYPE_UNSPECIFIED)", snapshotfile, verify_hash ? "true" : "false", check_hash ? "true" : "false"));
-    break;
   case FD_SNAPSHOT_TYPE_FULL:
     FD_LOG_NOTICE(("fd_snapshot_load(\"%s\", verify-hash=%s, check-hash=%s, FD_SNAPSHOT_TYPE_FULL)", snapshotfile, verify_hash ? "true" : "false", check_hash ? "true" : "false"));
     break;
@@ -139,7 +138,6 @@ fd_snapshot_load( const char *         snapshotfile,
     break;
   default:
     FD_LOG_ERR(("fd_snapshot_load(\"%s\", verify-hash=%s, check-hash=%s, huh?)", snapshotfile, verify_hash ? "true" : "false", check_hash ? "true" : "false"));
-    break;
   }
 
   fd_funk_start_write( slot_ctx->acc_mgr->funk );

--- a/src/flamenco/types/fd_types_yaml.c
+++ b/src/flamenco/types/fd_types_yaml.c
@@ -342,7 +342,6 @@ fd_flamenco_yaml_walk( void *       _self,
     break;
   default:
     FD_LOG_CRIT(( "unknown type %#x", (uint)type ));
-    break;
   }
 
   /* Remember that we processed an element in the current level */

--- a/src/flamenco/vm/fd_vm_disasm.c
+++ b/src/flamenco/vm/fd_vm_disasm.c
@@ -183,7 +183,6 @@ fd_vm_disasm_instr_jmp( fd_sbpf_instr_t            instr,
   case FD_SBPF_OPCODE_SOURCE_MODE_REG:
     OUT_PRINTF( "%s%s r%d, r%d, lbb_%ld", op_name, suffix, instr.dst_reg, instr.src_reg, (long)pc+(long)instr.offset+1L );
     return FD_VM_SUCCESS;
-    break;
   default: break;
   }
 

--- a/src/funk/fd_funk_part.c
+++ b/src/funk/fd_funk_part.c
@@ -163,7 +163,6 @@ fd_funk_set_num_partitions( fd_funk_t * funk, uint num_part ) {
   partvec = (fd_funk_partvec_t *)fd_alloc_malloc_at_least( alloc, fd_funk_partvec_align(), fd_funk_partvec_footprint(num_part), &tmp_max );
   if( FD_UNLIKELY( !partvec ) ) {
     FD_LOG_ERR(( "partvec alloc failed" ));
-    return;
   }
   partvec->num_part = num_part;
   funk->partvec_gaddr = fd_wksp_gaddr_fast( wksp, partvec );


### PR DESCRIPTION
Cleans up error paths. Removes unreachable code. In some cases, replaces fatal errors with warnings. 