### PR TITLE
add apt update in deps.sh

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -191,9 +191,9 @@ check_debian_pkgs () {
   fi
 
   if [[ -z "${SUDO}" ]]; then
-    PACKAGE_INSTALL_CMD=( apt-get install -y ${MISSING_DEBS[*]} )
+    PACKAGE_INSTALL_CMD=( apt-get update && apt-get install -y ${MISSING_DEBS[*]} )
   else
-    PACKAGE_INSTALL_CMD=( "${SUDO}" apt-get install -y ${MISSING_DEBS[*]} )
+    PACKAGE_INSTALL_CMD=( "${SUDO}" apt-get update && apt-get install -y ${MISSING_DEBS[*]} )
   fi
 }
 


### PR DESCRIPTION
if no apt update. apt install may failed like below

```
[?] This is fixed by the following command:
        apt-get install -y autoconf gettext automake autopoint flex bison build-essential gcc-multilib protobuf-compiler llvm lcov libgmp-dev libudev-dev cmake libclang-dev pkgconf
[?] Install missing system packages? (y/N) y
[+] Installing missing packages
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package protobuf-compiler is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'protobuf-compiler' has no installation candidate
E: Unable to locate package llvm
E: Unable to locate package lcov
E: Unable to locate package libclang-dev
```