### PR TITLE
ci: increase coverage report timeout to 60 mins

### DIFF
--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   coverage-report:
-    timeout-minutes: 30
+    timeout-minutes: 60
     name: Coverage Report
     runs-on: icelake
     environment:

--- a/.github/workflows/coverage_report_clusterfuzz.yml
+++ b/.github/workflows/coverage_report_clusterfuzz.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
 jobs:
   coverage-report-clusterfuzz:
-    timeout-minutes: 30
+    timeout-minutes: 60
     name: Coverage Report (ClusterFuzz)
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
The coverage report job sometimes takes slightly longer than 30 mins which is the current limit.
