### PR TITLE
flamenco, ledger: correctly use blockstore APIs

### DIFF
--- a/src/flamenco/runtime/fd_rocksdb.c
+++ b/src/flamenco/runtime/fd_rocksdb.c
@@ -722,8 +722,6 @@ fd_rocksdb_import_block_blockstore( fd_rocksdb_t *    db,
 
   blockstore->lps = slot;
   blockstore->hcs = slot;
-  /* FIXME: this is the wrong thing to do. we should use the blockstore api's properly */
-  // blockstore->smr = slot;
 
   if( FD_LIKELY( block_map_entry ) ) {
     block_map_entry->flags = fd_uchar_set_bit( block_map_entry->flags, FD_BLOCK_FLAG_COMPLETED );

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -2951,9 +2951,6 @@ fd_runtime_block_eval_tpool( fd_exec_slot_ctx_t * slot_ctx,
 
   slot_ctx->slot_bank.transaction_count += block_info.txn_cnt;
 
-  /* progress to next slot next time */
-  slot_ctx->blockstore->smr++;
-
   fd_funk_start_write( slot_ctx->acc_mgr->funk );
   fd_runtime_save_slot_bank( slot_ctx );
   fd_funk_end_write( slot_ctx->acc_mgr->funk );


### PR DESCRIPTION
Changing `fd_ledger` to use the same blockstore publishing APIs as the live replay path.

- Use `fd_blockstore_publish` instead of manually calling `fd_blockstore_slot_remove`.
- Use on-demand block ingest all the time in ledger replay.

The first PR in a series of PRs aimed at making the logic inside live and offline more similar.