### PR TITLE
pack: don't include config program in list of builtins

### DIFF
--- a/src/ballet/pack/fd_pack_cost.h
+++ b/src/ballet/pack/fd_pack_cost.h
@@ -53,18 +53,17 @@ typedef struct fd_pack_builtin_prog_cost fd_pack_builtin_prog_cost_t;
 #define VOTE_PROG_COST 2100UL
 
 #define MAP_PERFECT_0  ( STAKE_PROG_ID           ), .cost_per_instr=         750UL
-#define MAP_PERFECT_1  ( CONFIG_PROG_ID          ), .cost_per_instr=         450UL
-#define MAP_PERFECT_2  ( VOTE_PROG_ID            ), .cost_per_instr=VOTE_PROG_COST
-#define MAP_PERFECT_3  ( SYS_PROG_ID             ), .cost_per_instr=         150UL
-#define MAP_PERFECT_4  ( COMPUTE_BUDGET_PROG_ID  ), .cost_per_instr=         150UL
-#define MAP_PERFECT_5  ( ADDR_LUT_PROG_ID        ), .cost_per_instr=         750UL
-#define MAP_PERFECT_6  ( BPF_UPGRADEABLE_PROG_ID ), .cost_per_instr=        2370UL
-#define MAP_PERFECT_7  ( BPF_LOADER_1_PROG_ID    ), .cost_per_instr=        1140UL
-#define MAP_PERFECT_8  ( BPF_LOADER_2_PROG_ID    ), .cost_per_instr=         570UL
-#define MAP_PERFECT_9  ( LOADER_V4_PROG_ID       ), .cost_per_instr=        2000UL
-#define MAP_PERFECT_10 ( KECCAK_SECP_PROG_ID     ), .cost_per_instr=         720UL
-#define MAP_PERFECT_11 ( ED25519_SV_PROG_ID      ), .cost_per_instr=         720UL
-#define MAP_PERFECT_12 ( SECP256R1_PROG_ID       ), .cost_per_instr=         720UL
+#define MAP_PERFECT_1  ( VOTE_PROG_ID            ), .cost_per_instr=VOTE_PROG_COST
+#define MAP_PERFECT_2  ( SYS_PROG_ID             ), .cost_per_instr=         150UL
+#define MAP_PERFECT_3  ( COMPUTE_BUDGET_PROG_ID  ), .cost_per_instr=         150UL
+#define MAP_PERFECT_4  ( ADDR_LUT_PROG_ID        ), .cost_per_instr=         750UL
+#define MAP_PERFECT_5  ( BPF_UPGRADEABLE_PROG_ID ), .cost_per_instr=        2370UL
+#define MAP_PERFECT_6  ( BPF_LOADER_1_PROG_ID    ), .cost_per_instr=        1140UL
+#define MAP_PERFECT_7  ( BPF_LOADER_2_PROG_ID    ), .cost_per_instr=         570UL
+#define MAP_PERFECT_8  ( LOADER_V4_PROG_ID       ), .cost_per_instr=        2000UL
+#define MAP_PERFECT_9  ( KECCAK_SECP_PROG_ID     ), .cost_per_instr=         720UL
+#define MAP_PERFECT_10 ( ED25519_SV_PROG_ID      ), .cost_per_instr=         720UL
+#define MAP_PERFECT_11 ( SECP256R1_PROG_ID       ), .cost_per_instr=         720UL
 
 #include "../../util/tmpl/fd_map_perfect.c"
 


### PR DESCRIPTION
With the activation of `migrate_config_program_to_core_bpf`, the config program should no longer be considered a builtin by pack.