### PR TITLE
vm: temp disable vm-interp tests

### DIFF
--- a/contrib/test/run_test_vectors.sh
+++ b/contrib/test/run_test_vectors.sh
@@ -39,8 +39,8 @@ cat contrib/test/test-vectors-fixtures/syscall-fixtures/*.list | xargs -P 4 -n 1
 LOG=$LOG_PATH/test_exec_cpi
 cat contrib/test/test-vectors-fixtures/cpi-fixtures/*.list | xargs -P 4 -n 1000 ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG
 
-LOG=$LOG_PATH/test_exec_interp
-cat contrib/test/test-vectors-fixtures/vm-interp-fixtures/*.list | xargs -P 4 -n 1000 ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG
+# LOG=$LOG_PATH/test_exec_interp
+# cat contrib/test/test-vectors-fixtures/vm-interp-fixtures/*.list | xargs -P 4 -n 1000 ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG
 
 LOG=$LOG_PATH/test_exec_precompiles
 cat contrib/test/test-vectors-fixtures/precompile-fixtures/*.list | xargs -P 4 -n 1000 ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG


### PR DESCRIPTION
We need to regenerate fixtures.

Will be re-enabled in https://github.com/firedancer-io/firedancer/pull/3627