### PR TITLE
flamenco, fuzz: add stubbed binaries to CI for CPI test vectors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
           - test-case: linux_gcc_x86_64
             machine: linux_gcc_x86_64
             label: X64
-            extras: rpath
+            extras: "rpath fuzz-stubs"
             targets: "all integration-test fdctl"
             compiler: gcc
             compiler-version: 12.4.0
@@ -48,7 +48,7 @@ jobs:
           - test-case: linux_gcc_icelake
             machine: linux_gcc_icelake
             label: icelake
-            extras: rpath
+            extras: "rpath fuzz-stubs"
             targets: "all integration-test fdctl"
             compiler: gcc
             compiler-version: 12.4.0
@@ -57,7 +57,7 @@ jobs:
           - test-case: linux_clang_x86_64
             machine: linux_clang_x86_64
             label: X64
-            extras: rpath
+            extras: "rpath fuzz-stubs"
             targets: "all integration-test fdctl"
             compiler: clang
             compiler-version: 15.0.6
@@ -66,7 +66,7 @@ jobs:
           - test-case: linux_clang_icelake
             machine: linux_clang_icelake
             label: icelake
-            extras: "asan ubsan rpath"
+            extras: "asan ubsan rpath fuzz-stubs"
             targets: "all integration-test fdctl"
             compiler: clang
             compiler-version: 15.0.6
@@ -75,7 +75,7 @@ jobs:
           - test-case: native
             machine: native
             label: 512G
-            extras: rpath
+            extras: "rpath fuzz-stubs"
             targets: "all integration-test fdctl"
             compiler: clang
             compiler-version: 15.0.6

--- a/config/extra/with-fuzz-stubs.mk
+++ b/config/extra/with-fuzz-stubs.mk
@@ -1,0 +1,1 @@
+FD_HAS_FUZZ_STUBS:=1

--- a/config/extra/with-fuzz.mk
+++ b/config/extra/with-fuzz.mk
@@ -1,3 +1,4 @@
+include config/extra/with-fuzz-stubs.mk
 FD_HAS_FUZZ:=1
 
 CPPFLAGS+=-fno-omit-frame-pointer

--- a/contrib/test/ci_tests.sh
+++ b/contrib/test/ci_tests.sh
@@ -2,6 +2,7 @@
 
 # ci_tests.sh builds and runs the tests that are required on every CI
 # commit.  May optionally export coverage data.
+# NOTE: Use EXTRAS=fuzz-stubs to build stubbed binaries for fuzz tests.
 #
 # WARNING: Running this script will destroy your build directory.
 

--- a/contrib/test/run_test_vectors.sh
+++ b/contrib/test/run_test_vectors.sh
@@ -36,9 +36,6 @@ cd ../..
 LOG=$LOG_PATH/test_exec_syscall
 cat contrib/test/test-vectors-fixtures/syscall-fixtures/*.list | xargs -P 4 -n 1000 ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG
 
-LOG=$LOG_PATH/test_exec_cpi
-cat contrib/test/test-vectors-fixtures/cpi-fixtures/*.list | xargs -P 4 -n 1000 ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG
-
 # LOG=$LOG_PATH/test_exec_interp
 # cat contrib/test/test-vectors-fixtures/vm-interp-fixtures/*.list | xargs -P 4 -n 1000 ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG
 
@@ -57,5 +54,15 @@ cat contrib/test/test-vectors-fixtures/instr-fixtures/*.list | xargs -P 4 -n 100
 
 LOG=$LOG_PATH/test_vm_validate
 cat contrib/test/test-vectors-fixtures/vm-validate-fixtures/*.list | xargs -P 4 -n 1000 ./$OBJDIR/unit-test/test_exec_sol_compat --log-path $LOG
+
+# check if ./$OBJDIR/unit-test/test_exec_sol_compat_stubbed exists
+if [ -f ./$OBJDIR/unit-test/test_exec_sol_compat_stubbed ]; then
+  LOG=$LOG_PATH/test_exec_cpi
+  cat contrib/test/test-vectors-fixtures/cpi-fixtures/*.list | xargs -P 4 -n 1000 ./$OBJDIR/unit-test/test_exec_sol_compat_stubbed --log-path $LOG
+else
+  # skip stubbed tests if the binary does not exist
+  echo -e "\e[38;5;214mNOTICE:\e[0m Skipping stubbed tests due to missing stub binary"
+  echo "Build with EXTRAS=fuzz-stubs to build the stub binary"
+fi
 
 echo Test vectors success

--- a/src/flamenco/runtime/tests/Local.mk
+++ b/src/flamenco/runtime/tests/Local.mk
@@ -11,12 +11,13 @@ $(call make-unit-test,test_exec_instr,test_exec_instr,fd_flamenco fd_funk fd_bal
 $(call make-unit-test,test_exec_sol_compat,test_exec_sol_compat,fd_flamenco fd_funk fd_ballet fd_util fd_disco,$(SECP256K1_LIBS))
 $(call make-shared,libfd_exec_sol_compat.so,fd_exec_sol_compat,fd_flamenco fd_funk fd_ballet fd_util fd_disco,$(SECP256K1_LIBS))
 
-ifdef FD_HAS_FUZZ
+ifdef FD_HAS_FUZZ_STUBS
 # The --wrap flag stubs out a function so that we can replace it with our own implementation in the fuzz harness(es)
 # See __wrap_fd_execute_instr in  fd_exec_instr_test.c for example
-# We guard this with FD_HAS_FUZZ because the --wrap flag may not be portable across linkers
+# We guard this with FD_HAS_FUZZ_STUBS because the --wrap flag may not be portable across linkers
 WRAP_FLAGS += -Xlinker --wrap=fd_execute_instr
 $(call make-shared,libfd_exec_sol_compat_stubbed.so,fd_exec_sol_compat,fd_flamenco fd_funk fd_ballet fd_util fd_disco,$(SECP256K1_LIBS) $(WRAP_FLAGS))
+$(call make-unit-test,test_exec_sol_compat_stubbed,test_exec_sol_compat,fd_flamenco fd_funk fd_ballet fd_util fd_disco,$(SECP256K1_LIBS) $(WRAP_FLAGS))
 endif
 
 endif


### PR DESCRIPTION
Creates a `fuzz-stubs` extra that builds stubbed fuzz binaries for CPI fuzz harness. This is then used in our CI test workflows. Additional changes to `run_test_vectors.sh` to (optionally) pickup the stubbed binary.