### PR TITLE
app, ledger: use fd_bpf_scan_and_create_bpf_program_cache_entry_tpool in ledger replay

### DIFF
--- a/src/app/ledger/main.c
+++ b/src/app/ledger/main.c
@@ -433,11 +433,12 @@ fd_ledger_main_setup( fd_ledger_args_t * args ) {
   fd_runtime_recover_banks( args->slot_ctx, 0, args->genesis==NULL );
 
   /* Finish other runtime setup steps */
-  fd_funk_start_write( funk );
   fd_features_restore( args->slot_ctx );
   fd_runtime_update_leaders( args->slot_ctx, args->slot_ctx->slot_bank.slot );
   fd_calculate_epoch_accounts_hash_values( args->slot_ctx );
-  fd_bpf_scan_and_create_bpf_program_cache_entry( args->slot_ctx, args->slot_ctx->funk_txn );
+
+  fd_funk_start_write( funk );
+  fd_bpf_scan_and_create_bpf_program_cache_entry_tpool( args->slot_ctx, args->slot_ctx->funk_txn, args->tpool );
   fd_funk_end_write( funk );
 
   /* Allocate memory for the account scratch space. In live execution, each of

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -2304,41 +2304,6 @@ fd_runtime_block_execute_prepare( fd_exec_slot_ctx_t * slot_ctx ) {
   return FD_RUNTIME_EXECUTE_SUCCESS;
 }
 
-int fd_runtime_block_execute_finalize(fd_exec_slot_ctx_t *slot_ctx,
-                                      fd_capture_ctx_t *capture_ctx,
-                                      fd_block_info_t const *block_info) {
-  fd_sysvar_slot_history_update(slot_ctx);
-
-  // this slot is frozen... and cannot change anymore...
-  fd_runtime_freeze(slot_ctx);
-
-  int result = fd_bpf_scan_and_create_bpf_program_cache_entry( slot_ctx, slot_ctx->funk_txn );
-  if( result != 0 ) {
-    FD_LOG_WARNING(("update bpf program cache failed"));
-    return result;
-  }
-
-  result = fd_update_hash_bank(slot_ctx, capture_ctx, &slot_ctx->slot_bank.banks_hash, block_info->signature_cnt);
-  if( result != FD_EXECUTOR_INSTR_SUCCESS ) {
-    FD_LOG_WARNING(("hashing bank failed"));
-    return result;
-  }
-
-  // result = fd_runtime_save_epoch_bank( slot_ctx );
-  // if (result != FD_EXECUTOR_INSTR_SUCCESS) {
-  //   FD_LOG_WARNING(( "save epoch bank failed" ));
-  //   return result;
-  // }
-
-  result = fd_runtime_save_slot_bank(slot_ctx);
-  if( result != FD_RUNTIME_EXECUTE_SUCCESS ) {
-    FD_LOG_WARNING(("failed to save slot bank"));
-    return result;
-  }
-
-  return FD_RUNTIME_EXECUTE_SUCCESS;
-}
-
 int
 fd_runtime_block_execute_finalize_tpool( fd_exec_slot_ctx_t * slot_ctx,
                                          fd_capture_ctx_t * capture_ctx,

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -2316,7 +2316,7 @@ fd_runtime_block_execute_finalize_tpool( fd_exec_slot_ctx_t * slot_ctx,
   // this slot is frozen... and cannot change anymore...
   fd_runtime_freeze(slot_ctx);
 
-  int result = fd_bpf_scan_and_create_bpf_program_cache_entry( slot_ctx, slot_ctx->funk_txn );
+  int result = fd_bpf_scan_and_create_bpf_program_cache_entry_tpool( slot_ctx, slot_ctx->funk_txn, tpool );
   if( result != 0 ) {
     FD_LOG_WARNING(("update bpf program cache failed"));
     fd_funk_end_write( slot_ctx->acc_mgr->funk );


### PR DESCRIPTION
We use `fd_bpf_scan_and_create_bpf_program_cache_entry_tpool` in live, so we should use it in ledger replay also