### PR TITLE
refactor(blockstore): API for persisting finalized blocks to archival file

### DIFF
--- a/src/app/fdctl/run/tiles/fd_rpcserv.c
+++ b/src/app/fdctl/run/tiles/fd_rpcserv.c
@@ -1,5 +1,6 @@
 /* Repair tile runs the repair protocol for a Firedancer node. */
 
+#include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
 #define _GNU_SOURCE
@@ -192,6 +193,11 @@ privileged_init( fd_topo_t *      topo,
   args->blockstore = fd_blockstore_join( fd_topo_obj_laddr( topo, blockstore_obj_id ) );
   FD_TEST( args->blockstore!=NULL );
   ctx->blockstore_fd = open( tile->replay.blockstore_file, O_RDONLY );
+  if ( FD_UNLIKELY(ctx->blockstore_fd == -1) ){
+    FD_LOG_WARNING(("%s: %s", tile->replay.blockstore_file, strerror( errno )));
+  }
+
+  args->blockstore_fd = ctx->blockstore_fd;
 
   void * alloc_shalloc = fd_alloc_new( alloc_shmem, 3UL );
   if( FD_UNLIKELY( !alloc_shalloc ) ) {

--- a/src/app/fdctl/run/topos/fd_firedancer.c
+++ b/src/app/fdctl/run/topos/fd_firedancer.c
@@ -624,6 +624,7 @@ fd_topo_initialize( config_t * config ) {
     } else if( FD_UNLIKELY( !strcmp( tile->name, "eqvoc" ) ) ) {
       strncpy( tile->eqvoc.identity_key_path, config->consensus.identity_path, sizeof(tile->eqvoc.identity_key_path) );
     } else if( FD_UNLIKELY( !strcmp( tile->name, "rpcsrv" ) ) ) {
+      strncpy( tile->replay.blockstore_file, config->blockstore.file, sizeof(tile->replay.blockstore_file) ); 
       tile->replay.funk_rec_max = config->tiles.replay.funk_rec_max;
       tile->replay.funk_sz_gb   = config->tiles.replay.funk_sz_gb;
       tile->replay.funk_txn_max = config->tiles.replay.funk_txn_max;

--- a/src/flamenco/runtime/fd_blockstore.h
+++ b/src/flamenco/runtime/fd_blockstore.h
@@ -706,4 +706,38 @@ fd_blockstore_log_mem_usage( fd_blockstore_t * blockstore );
 
 FD_PROTOTYPES_END
 
+/* fd_blockstore_ser is a serialization context for archiving a block to
+   disk. */
+
+struct fd_blockstore_ser {
+  fd_block_map_t * block_map;
+  fd_block_t     * block;
+  uchar          * data;
+};
+typedef struct fd_blockstore_ser fd_blockstore_ser_t;
+
+/* Archives a block and block map entry to fd. If fd is -1, no write is attempted */
+ulong
+fd_blockstore_block_checkpt( fd_blockstore_t * blockstore FD_PARAM_UNUSED, 
+                             fd_blockstore_ser_t * ser, 
+                             int fd, 
+                             ulong slot );
+
+/* Restores a block and block map entry from fd at given offset. As this used by
+   rpcserver, it must return an error code instead of throwing an error on failure */
+int
+fd_blockstore_block_meta_restore( fd_blockstore_t * blockstore,
+                                  int fd,
+                                  fd_block_idx_t * block_idx_entry,
+                                  fd_block_map_t * block_map_entry_out,
+                                  fd_block_t * block_out );
+/* Reads block data from fd into a given buf */
+int 
+fd_blockstore_block_data_restore( fd_blockstore_t * blockstore,
+                                  int fd,
+                                  fd_block_idx_t * block_idx_entry,
+                                  uchar * buf_out,
+                                  ulong buf_max,
+                                  ulong data_sz );
+
 #endif /* HEADER_fd_src_flamenco_runtime_fd_blockstore_h */


### PR DESCRIPTION
Also includes some bugfixes like:
- passing blockstore-file to rpcsrv 
- null check for parent chain (originally when user queries for the first block after snapshot, it would fail to find parent and err)