### PR TITLE
flamenco, runtime: don't store leader pointer in slot context

### DIFF
--- a/src/app/fdctl/run/tiles/fd_replay.c
+++ b/src/app/fdctl/run/tiles/fd_replay.c
@@ -828,7 +828,6 @@ prepare_new_block_execution( fd_replay_tile_ctx_t * ctx,
     FD_LOG_ERR(( "slot history read failed" ));
   }
 
-  FD_LOG_NOTICE(("Current leader: %s", FD_BASE58_ENC_32_ALLOCA( fork->slot_ctx.leader->uc ) ));
   if( is_new_epoch_in_new_block ) {
     publish_stake_weights( ctx, stem, &fork->slot_ctx );
   }
@@ -1301,7 +1300,6 @@ init_after_snapshot( fd_replay_tile_ctx_t * ctx ) {
   ulong snapshot_slot = ctx->slot_ctx->slot_bank.slot;
   if( FD_UNLIKELY( !snapshot_slot ) ) {
     fd_runtime_update_leaders(ctx->slot_ctx, ctx->slot_ctx->slot_bank.slot);
-    FD_LOG_WARNING(( "Updated leader %s", FD_BASE58_ENC_32_ALLOCA( ctx->slot_ctx->leader->uc) ));
 
     ctx->slot_ctx->slot_bank.prev_slot = 0UL;
     ctx->slot_ctx->slot_bank.slot = 1UL;

--- a/src/choreo/forks/fd_forks.c
+++ b/src/choreo/forks/fd_forks.c
@@ -242,8 +242,6 @@ slot_ctx_restore( ulong                 slot,
     FD_LOG_ERR(( "failed to read banks record: invalid magic number" ));
   }
   FD_TEST( !fd_runtime_sysvar_cache_load( slot_ctx_out ) );
-  slot_ctx_out->leader = fd_epoch_leaders_get( fd_exec_epoch_ctx_leaders( slot_ctx_out->epoch_ctx ),
-                                               slot );
 
   // TODO how do i get this info, ignoring rewards for now
   // slot_ctx_out->epoch_reward_status = ???

--- a/src/flamenco/runtime/context/fd_exec_slot_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_slot_ctx.h
@@ -58,8 +58,7 @@ struct __attribute__((aligned(8UL))) fd_exec_slot_ctx {
   fd_valloc_t                 valloc;
 
   fd_slot_bank_t              slot_bank;
-  // TODO this leader pointer could become invalid if forks cross epoch boundaries
-  fd_pubkey_t const *         leader; /* Current leader */
+
   ulong                       total_compute_units_requested;
 
   /* TODO figure out what to do with this */


### PR DESCRIPTION
This is updated inconsistently depending on the execution path taken. Looking this up is relatively cheap, so we do that instead.