### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/book/guide/tuning.md
+++ b/book/guide/tuning.md
@@ -220,7 +220,7 @@ it down to the relevant information,
 
 Here we see what is happening. The blockstore is completely busy
 spending 99.973% of its time storing data, while the PoH and shred tiles
-are in back-pressure waiting for the the blockstore to catch up. The
+are in back-pressure waiting for the blockstore to catch up. The
 blockstore is an Agave component built on RocksDB that is not rewritten
 as part of Frankendancer.
 

--- a/src/ballet/base58/fd_base58_tmpl.c
+++ b/src/ballet/base58/fd_base58_tmpl.c
@@ -76,7 +76,7 @@ SUFFIX(fd_base58_encode)( uchar const * bytes,
 # if N==32
 
   /* The worst case is if binary[7] is (2^32)-1. In that case
-     intermediate[8] will be be just over 2^63, which is fine. */
+     intermediate[8] will be just over 2^63, which is fine. */
 
   for( ulong i=0UL; i < BINARY_SZ; i++ )
     for( ulong j=0UL; j < INTERMEDIATE_SZ-1UL; j++ )

--- a/src/funk/fd_funk_val.h
+++ b/src/funk/fd_funk_val.h
@@ -151,7 +151,7 @@ fd_funk_val_write( fd_funk_rec_t *   rec,     /* Assumed in caller's address spa
 /* fd_funk_val_copy copies sz bytes starting at data into the record
    value, replacing the existing record value.  rec's value will be able
    to accommodate at least sz_est in the future without resizing on
-   return.  If sz_est is 0 on entry, it will be be set to sz as a
+   return.  If sz_est is 0 on entry, it will be set to sz as a
    reasonable default before any argument checking.
 
    data points to the bytes to write.  [data,data+sz) should not overlap


### PR DESCRIPTION
remove redundant words in comment