### PR TITLE
Fix fd_redblack symbol visibility

### DIFF
--- a/src/disco/rpcserver/fd_rpc_service.c
+++ b/src/disco/rpcserver/fd_rpc_service.c
@@ -565,7 +565,7 @@ struct product_rb_node {
 typedef struct product_rb_node product_rb_node_t;
 #define REDBLK_T product_rb_node_t
 #define REDBLK_NAME product_rb
-FD_FN_PURE long product_rb_compare(product_rb_node_t* left, product_rb_node_t* right) {
+FD_FN_PURE static long product_rb_compare(product_rb_node_t* left, product_rb_node_t* right) {
   for( uint i = 0; i < sizeof(fd_pubkey_t)/sizeof(ulong); ++i ) {
     ulong a = left->key.ul[i];
     ulong b = right->key.ul[i];
@@ -574,7 +574,6 @@ FD_FN_PURE long product_rb_compare(product_rb_node_t* left, product_rb_node_t* r
   return 0;
 }
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_NAME
 
 static int
 method_getBlockProduction(struct json_values* values, fd_rpc_ctx_t * ctx) {
@@ -1023,7 +1022,7 @@ struct leader_rb_node {
 typedef struct leader_rb_node leader_rb_node_t;
 #define REDBLK_T leader_rb_node_t
 #define REDBLK_NAME leader_rb
-FD_FN_PURE long leader_rb_compare(leader_rb_node_t* left, leader_rb_node_t* right) {
+FD_FN_PURE static long leader_rb_compare(leader_rb_node_t* left, leader_rb_node_t* right) {
   for( uint i = 0; i < sizeof(fd_pubkey_t)/sizeof(ulong); ++i ) {
     ulong a = left->key.ul[i];
     ulong b = right->key.ul[i];

--- a/src/flamenco/types/fd_types.c
+++ b/src/flamenco/types/fd_types.c
@@ -32291,8 +32291,6 @@ ulong fd_duplicate_slot_proof_size( fd_duplicate_slot_proof_t const * self ) {
 #define REDBLK_NAME fd_hash_hash_age_pair_t_map
 #define REDBLK_IMPL_STYLE 2
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_T
-#undef REDBLK_NAME
 long fd_hash_hash_age_pair_t_map_compare( fd_hash_hash_age_pair_t_mapnode_t * left, fd_hash_hash_age_pair_t_mapnode_t * right ) {
   return memcmp( left->elem.key.uc, right->elem.key.uc, sizeof(right->elem.key) );
 }
@@ -32300,8 +32298,6 @@ long fd_hash_hash_age_pair_t_map_compare( fd_hash_hash_age_pair_t_mapnode_t * le
 #define REDBLK_NAME fd_vote_accounts_pair_t_map
 #define REDBLK_IMPL_STYLE 2
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_T
-#undef REDBLK_NAME
 long fd_vote_accounts_pair_t_map_compare( fd_vote_accounts_pair_t_mapnode_t * left, fd_vote_accounts_pair_t_mapnode_t * right ) {
   return memcmp( left->elem.key.uc, right->elem.key.uc, sizeof(right->elem.key) );
 }
@@ -32309,8 +32305,6 @@ long fd_vote_accounts_pair_t_map_compare( fd_vote_accounts_pair_t_mapnode_t * le
 #define REDBLK_NAME fd_stake_accounts_pair_t_map
 #define REDBLK_IMPL_STYLE 2
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_T
-#undef REDBLK_NAME
 long fd_stake_accounts_pair_t_map_compare( fd_stake_accounts_pair_t_mapnode_t * left, fd_stake_accounts_pair_t_mapnode_t * right ) {
   return memcmp( left->elem.key.uc, right->elem.key.uc, sizeof(right->elem.key) );
 }
@@ -32318,8 +32312,6 @@ long fd_stake_accounts_pair_t_map_compare( fd_stake_accounts_pair_t_mapnode_t * 
 #define REDBLK_NAME fd_stake_weight_t_map
 #define REDBLK_IMPL_STYLE 2
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_T
-#undef REDBLK_NAME
 long fd_stake_weight_t_map_compare( fd_stake_weight_t_mapnode_t * left, fd_stake_weight_t_mapnode_t * right ) {
   return memcmp( left->elem.key.uc, right->elem.key.uc, sizeof(right->elem.key) );
 }
@@ -32327,8 +32319,6 @@ long fd_stake_weight_t_map_compare( fd_stake_weight_t_mapnode_t * left, fd_stake
 #define REDBLK_NAME fd_delegation_pair_t_map
 #define REDBLK_IMPL_STYLE 2
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_T
-#undef REDBLK_NAME
 long fd_delegation_pair_t_map_compare( fd_delegation_pair_t_mapnode_t * left, fd_delegation_pair_t_mapnode_t * right ) {
   return memcmp( left->elem.account.uc, right->elem.account.uc, sizeof(right->elem.account) );
 }
@@ -32336,8 +32326,6 @@ long fd_delegation_pair_t_map_compare( fd_delegation_pair_t_mapnode_t * left, fd
 #define REDBLK_NAME fd_stake_pair_t_map
 #define REDBLK_IMPL_STYLE 2
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_T
-#undef REDBLK_NAME
 long fd_stake_pair_t_map_compare( fd_stake_pair_t_mapnode_t * left, fd_stake_pair_t_mapnode_t * right ) {
   return memcmp( left->elem.account.uc, right->elem.account.uc, sizeof(right->elem.account) );
 }
@@ -32345,8 +32333,6 @@ long fd_stake_pair_t_map_compare( fd_stake_pair_t_mapnode_t * left, fd_stake_pai
 #define REDBLK_NAME fd_clock_timestamp_vote_t_map
 #define REDBLK_IMPL_STYLE 2
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_T
-#undef REDBLK_NAME
 long fd_clock_timestamp_vote_t_map_compare( fd_clock_timestamp_vote_t_mapnode_t * left, fd_clock_timestamp_vote_t_mapnode_t * right ) {
   return memcmp( left->elem.pubkey.uc, right->elem.pubkey.uc, sizeof(right->elem.pubkey) );
 }

--- a/src/flamenco/types/fd_types.h
+++ b/src/flamenco/types/fd_types.h
@@ -103,8 +103,6 @@ typedef struct fd_hash_hash_age_pair_t_mapnode fd_hash_hash_age_pair_t_mapnode_t
 #define REDBLK_NAME fd_hash_hash_age_pair_t_map
 #define REDBLK_IMPL_STYLE 1
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_T
-#undef REDBLK_NAME
 struct fd_hash_hash_age_pair_t_mapnode {
     fd_hash_hash_age_pair_t elem;
     ulong redblack_parent;
@@ -498,8 +496,6 @@ typedef struct fd_vote_accounts_pair_t_mapnode fd_vote_accounts_pair_t_mapnode_t
 #define REDBLK_NAME fd_vote_accounts_pair_t_map
 #define REDBLK_IMPL_STYLE 1
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_T
-#undef REDBLK_NAME
 struct fd_vote_accounts_pair_t_mapnode {
     fd_vote_accounts_pair_t elem;
     ulong redblack_parent;
@@ -551,8 +547,6 @@ typedef struct fd_stake_accounts_pair_t_mapnode fd_stake_accounts_pair_t_mapnode
 #define REDBLK_NAME fd_stake_accounts_pair_t_map
 #define REDBLK_IMPL_STYLE 1
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_T
-#undef REDBLK_NAME
 struct fd_stake_accounts_pair_t_mapnode {
     fd_stake_accounts_pair_t elem;
     ulong redblack_parent;
@@ -605,8 +599,6 @@ typedef struct fd_stake_weight_t_mapnode fd_stake_weight_t_mapnode_t;
 #define REDBLK_NAME fd_stake_weight_t_map
 #define REDBLK_IMPL_STYLE 1
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_T
-#undef REDBLK_NAME
 struct fd_stake_weight_t_mapnode {
     fd_stake_weight_t elem;
     ulong redblack_parent;
@@ -717,8 +709,6 @@ typedef struct fd_delegation_pair_t_mapnode fd_delegation_pair_t_mapnode_t;
 #define REDBLK_NAME fd_delegation_pair_t_map
 #define REDBLK_IMPL_STYLE 1
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_T
-#undef REDBLK_NAME
 struct fd_delegation_pair_t_mapnode {
     fd_delegation_pair_t elem;
     ulong redblack_parent;
@@ -762,8 +752,6 @@ typedef struct fd_stake_pair_t_mapnode fd_stake_pair_t_mapnode_t;
 #define REDBLK_NAME fd_stake_pair_t_map
 #define REDBLK_IMPL_STYLE 1
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_T
-#undef REDBLK_NAME
 struct fd_stake_pair_t_mapnode {
     fd_stake_pair_t elem;
     ulong redblack_parent;
@@ -2200,8 +2188,6 @@ typedef struct fd_clock_timestamp_vote_t_mapnode fd_clock_timestamp_vote_t_mapno
 #define REDBLK_NAME fd_clock_timestamp_vote_t_map
 #define REDBLK_IMPL_STYLE 1
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_T
-#undef REDBLK_NAME
 struct fd_clock_timestamp_vote_t_mapnode {
     fd_clock_timestamp_vote_t elem;
     ulong redblack_parent;

--- a/src/flamenco/types/fd_types_custom.c
+++ b/src/flamenco/types/fd_types_custom.c
@@ -372,8 +372,7 @@ int fd_archive_decode_skip_field( fd_bincode_decode_ctx_t * ctx, ushort tag ) {
 #define REDBLK_NAME fd_vote_reward_t_map
 #define REDBLK_IMPL_STYLE 2
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_T
-#undef REDBLK_NAME
+
 long fd_vote_reward_t_map_compare( fd_vote_reward_t_mapnode_t * left, fd_vote_reward_t_mapnode_t * right ) {
   return memcmp( left->elem.pubkey.uc, right->elem.pubkey.uc, sizeof(right->elem.pubkey) );
 }

--- a/src/flamenco/types/fd_types_custom.h
+++ b/src/flamenco/types/fd_types_custom.h
@@ -258,8 +258,6 @@ typedef struct fd_vote_reward_t_mapnode fd_vote_reward_t_mapnode_t;
 #define REDBLK_NAME fd_vote_reward_t_map
 #define REDBLK_IMPL_STYLE 1
 #include "../../util/tmpl/fd_redblack.c"
-#undef REDBLK_T
-#undef REDBLK_NAME
 struct fd_vote_reward_t_mapnode {
     fd_vote_reward_t elem;
     ulong redblack_parent;
@@ -388,7 +386,7 @@ typedef struct fd_epoch_reward_status fd_epoch_reward_status_t;
 enum {
 fd_epoch_reward_status_enum_Active = 0,
 fd_epoch_reward_status_enum_Inactive = 1,
-}; 
+};
 
 /*******************************************************************************************/
 #endif

--- a/src/flamenco/types/gen_stubs.py
+++ b/src/flamenco/types/gen_stubs.py
@@ -866,8 +866,6 @@ class MapMember:
         print(f"#define REDBLK_NAME {mapname}", file=header)
         print(f"#define REDBLK_IMPL_STYLE 1", file=header)
         print(f'#include "../../util/tmpl/fd_redblack.c"', file=header)
-        print(f"#undef REDBLK_T", file=header)
-        print(f"#undef REDBLK_NAME", file=header)
         print(f"struct {nodename} {{", file=header)
         print(f"    {element_type} elem;", file=header)
         print(f"    ulong redblack_parent;", file=header)
@@ -893,8 +891,6 @@ class MapMember:
         print(f'#define REDBLK_NAME {mapname}', file=body)
         print(f'#define REDBLK_IMPL_STYLE 2', file=body)
         print(f'#include "../../util/tmpl/fd_redblack.c"', file=body)
-        print(f'#undef REDBLK_T', file=body)
-        print(f'#undef REDBLK_NAME', file=body)
         print(f'long {mapname}_compare( {nodename} * left, {nodename} * right ) {{', file=body)
         key = self.key
         if key == "pubkey" or key == "account" or key == "key":

--- a/src/util/tmpl/test_redblack.c
+++ b/src/util/tmpl/test_redblack.c
@@ -13,11 +13,12 @@ struct my_rb_node {
 typedef struct my_rb_node my_rb_node_t;
 #define REDBLK_T my_rb_node_t
 #define REDBLK_NAME my_rb
-#include "fd_redblack.c"
 
-long my_rb_compare(my_rb_node_t* left, my_rb_node_t* right) {
+static long my_rb_compare(my_rb_node_t* left, my_rb_node_t* right) {
   return (long)(left->key - right->key);
 }
+
+#include "fd_redblack.c"
 
 #define SCRATCH_ALIGN     (128UL)
 #define SCRATCH_FOOTPRINT (1UL<<16)
@@ -78,7 +79,7 @@ main( int     argc,
 
     my_rb_release_tree(pool, root);
   }
-  
+
   ulong* list = (ulong*)malloc(max * sizeof(ulong));
 
   for (ulong iter = 0; iter < 1000; ++iter) {
@@ -106,7 +107,7 @@ main( int     argc,
       FD_LOG_ERR(("did not get NULL as expected"));
 
     assert(!my_rb_verify(pool, root));
-    
+
     node = my_rb_minimum(pool, root);
     if (node->key != 1 || node->val != node->key*17UL)
       FD_LOG_ERR(("did not get right value"));
@@ -115,7 +116,7 @@ main( int     argc,
       if (node->key != ++j || node->val != node->key*17UL)
         FD_LOG_ERR(("did not get right value"));
     }
-      
+
     node = my_rb_maximum(pool, root);
     if (node->key != max || node->val != node->key*17UL)
       FD_LOG_ERR(("did not get right value"));
@@ -124,7 +125,7 @@ main( int     argc,
       if (node->key != --j || node->val != node->key*17UL)
         FD_LOG_ERR(("did not get right value"));
     }
-      
+
     for (ulong i = 0; i <= max+1; ++i) {
       my_rb_node_t key;
       key.key = i;
@@ -161,12 +162,12 @@ main( int     argc,
     }
     if (root != NULL)
       FD_LOG_ERR(("final root wrong"));
-    
+
     assert(!my_rb_verify(pool, root));
   }
 
   free(list);
-  
+
   // Try 3 interesting cases
   for (ulong c = 0; c < 3; ++c) {
     my_rb_node_t* root = NULL;
@@ -218,9 +219,9 @@ main( int     argc,
 
     my_rb_release_tree(pool, root);
   }
-  
+
   (void) my_rb_delete( my_rb_leave( pool ));
-  
+
   fd_rng_delete( fd_rng_leave( rng ) );
 
   FD_LOG_NOTICE(( "pass" ));

--- a/src/util/tmpl/test_redblack2.c
+++ b/src/util/tmpl/test_redblack2.c
@@ -34,15 +34,16 @@ typedef struct rbnode_struct rbnode;
 #define REDBLK_RIGHT u.rb.right
 #define REDBLK_COLOR u.rb.color
 #define REDBLK_NEXTFREE u.nf
+
+long rb_compare(rbnode* left, rbnode* right) {
+  return (long)(left->key - right->key);
+}
+
 #include "fd_redblack.c"
 
 typedef rbnode rbtree;
 
 static rbnode* pool = NULL;
-
-long rb_compare(rbnode* left, rbnode* right) {
-  return (long)(left->key - right->key);
-}
 
 static rbtree *tree_create( void );
 static void tree_destroy(rbtree *rbt);


### PR DESCRIPTION
Fixes an issue where fd_redblack produces externally linked symbols
even if the implementation style is set to 'local use only'.
