### PR TITLE
blockstore: archival file as a circular buffer

### DIFF
--- a/src/app/fdctl/run/tiles/fd_replay.c
+++ b/src/app/fdctl/run/tiles/fd_replay.c
@@ -1395,7 +1395,7 @@ read_snapshot( void * _ctx,
   FD_LOG_NOTICE(( "finished fd_bpf_scan_and_create_bpf_program_cache_entry..." ));
 
   fd_blockstore_start_write( ctx->slot_ctx->blockstore );
-  fd_blockstore_init( ctx->slot_ctx->blockstore, ctx->blockstore_fd, &ctx->slot_ctx->slot_bank );
+  fd_blockstore_init( ctx->slot_ctx->blockstore, ctx->blockstore_fd, FD_BLOCKSTORE_ARCHIVE_MIN_SIZE, &ctx->slot_ctx->slot_bank );
   fd_blockstore_end_write( ctx->slot_ctx->blockstore );
 }
 
@@ -1430,7 +1430,7 @@ init_after_snapshot( fd_replay_tile_ctx_t * ctx ) {
     FD_LOG_NOTICE(( "finished fd_bpf_scan_and_create_bpf_program_cache_entry..." ));
 
     fd_blockstore_start_write( ctx->slot_ctx->blockstore );
-    fd_blockstore_init( ctx->slot_ctx->blockstore, ctx->blockstore_fd, &ctx->slot_ctx->slot_bank );
+    fd_blockstore_init( ctx->slot_ctx->blockstore, ctx->blockstore_fd, FD_BLOCKSTORE_ARCHIVE_MIN_SIZE, &ctx->slot_ctx->slot_bank );
     fd_blockstore_end_write( ctx->slot_ctx->blockstore );
   }
   fd_fseq_update( ctx->smr, snapshot_slot );

--- a/src/app/ledger/main.c
+++ b/src/app/ledger/main.c
@@ -1032,7 +1032,7 @@ replay( fd_ledger_args_t * args ) {
 
   fd_ledger_main_setup( args );
 
-  fd_blockstore_init( args->blockstore, -1, &args->slot_ctx->slot_bank );
+  fd_blockstore_init( args->blockstore, -1, FD_BLOCKSTORE_ARCHIVE_MIN_SIZE, &args->slot_ctx->slot_bank );
 
   FD_LOG_WARNING(( "setup done" ));
 

--- a/src/flamenco/runtime/Local.mk
+++ b/src/flamenco/runtime/Local.mk
@@ -46,6 +46,7 @@ $(call add-hdrs,fd_txncache.h)
 $(call add-objs,fd_txncache,fd_flamenco)
 ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_txncache,test_txncache,fd_flamenco fd_util)
+$(call make-unit-test,test_archive_block,test_archive_block, fd_flamenco fd_util fd_ballet,$(SECP256K1_LIBS))
 # TODO: Flakes
 # $(call run-unit-test,test_txncache,)
 endif

--- a/src/flamenco/runtime/fd_blockstore.c
+++ b/src/flamenco/runtime/fd_blockstore.c
@@ -58,7 +58,13 @@ fd_blockstore_new( void * shmem,
   fd_rwseq_new( &blockstore->lock );
   FD_COMPILER_MFENCE();
 
-  blockstore->off  = 0;
+  blockstore->archiver = (fd_blockstore_archiver_t){
+      .magic       = FD_BLOCKSTORE_MAGIC,
+      .fd_size_max = FD_BLOCKSTORE_ARCHIVE_MIN_SIZE,
+      .head        = FD_BLOCKSTORE_ARCHIVE_START,
+      .tail        = FD_BLOCKSTORE_ARCHIVE_START,
+      .num_blocks  = 0,
+  };
 
   blockstore->lps = FD_SLOT_NULL;
   blockstore->hcs = FD_SLOT_NULL;
@@ -190,7 +196,83 @@ static inline void check_read_write_err( int err ) {
   }
 }
 
-/* build the archival file index */
+ulong
+fd_blockstore_archiver_lrw_slot( fd_blockstore_t * blockstore, int fd, fd_block_map_t * lrw_block_map, fd_block_t * lrw_block ) {
+  fd_block_idx_t * block_idx = fd_blockstore_block_idx( blockstore );
+  if ( FD_UNLIKELY ( fd_block_idx_key_cnt( block_idx ) == 0 ) ) {
+    return FD_SLOT_NULL;
+  }
+
+  fd_block_idx_t lrw_block_idx = { 0 };
+  lrw_block_idx.off = blockstore->archiver.head;
+  int err = fd_blockstore_block_meta_restore(&blockstore->archiver, fd, &lrw_block_idx, lrw_block_map,  lrw_block);
+  check_read_write_err( err );
+  return lrw_block_map->slot;
+}
+
+bool 
+fd_blockstore_archiver_verify( fd_blockstore_t * blockstore, fd_blockstore_archiver_t * fd_metadata ) {
+  return ( fd_metadata->head < FD_BLOCKSTORE_ARCHIVE_START ) 
+         || ( fd_metadata->tail < FD_BLOCKSTORE_ARCHIVE_START )
+         || ( fd_metadata->fd_size_max != blockstore->archiver.fd_size_max ) // should be initialized same as archive file
+         || ( fd_metadata->magic != FD_BLOCKSTORE_MAGIC );
+}
+
+#define check_read_err_safe( cond, msg )            \
+  do {                                              \
+    if( FD_UNLIKELY( cond ) ) {                     \
+      FD_LOG_WARNING(( "[%s] %s", __func__, msg )); \
+      return FD_BLOCKSTORE_ERR_SLOT_MISSING;        \
+    }                                               \
+  } while(0);
+
+/* Where read_off is where to start reading from */
+/* Guarantees that read_off is at the end of what we just finished on return. */
+static int read_with_wraparound( fd_blockstore_archiver_t * archvr, 
+                                 int fd, 
+                                 uchar * dst, 
+                                 ulong dst_sz, 
+                                 ulong * rsz, 
+                                 ulong * read_off ) {
+  check_read_err_safe( lseek( fd, (long)*read_off, SEEK_SET ) == -1, 
+                       "failed to seek to read offset" );
+  
+  ulong remaining_sz = archvr->fd_size_max - *read_off;
+  if ( remaining_sz < dst_sz ) {
+    int err = fd_io_read( fd, dst, remaining_sz, remaining_sz, rsz );
+    check_read_err_safe( err, "failed to read file near end" );
+    *read_off = FD_BLOCKSTORE_ARCHIVE_START;
+    check_read_err_safe( lseek( fd, (long)*read_off, SEEK_SET ) == -1,
+                         "failed to seek to file start" );
+    err = fd_io_read( fd, dst + remaining_sz, dst_sz - remaining_sz, dst_sz - remaining_sz, rsz );
+    check_read_err_safe( err, "failed to read file near start" );
+    *read_off = FD_BLOCKSTORE_ARCHIVE_START + *rsz;
+  } else {
+    int err = fd_io_read( fd, dst, dst_sz, dst_sz, rsz );
+    check_read_err_safe( err, "failed to read file" );
+    *read_off += *rsz;
+  }
+  // if we read to EOF, set read_off ready for next read
+  // In reality should never be > blockstore->fd_size_max
+  if ( *read_off >= archvr->fd_size_max ) {
+    *read_off = FD_BLOCKSTORE_ARCHIVE_START;
+  }
+
+  return FD_BLOCKSTORE_OK;
+}
+
+static ulong
+wrap_offset( fd_blockstore_archiver_t * archvr, ulong off ) {
+  if ( off == archvr->fd_size_max ) {
+    return FD_BLOCKSTORE_ARCHIVE_START;
+  } else if ( off > archvr->fd_size_max ) {
+    return FD_BLOCKSTORE_ARCHIVE_START + ( off - archvr->fd_size_max );
+  } else {
+    return off;
+  }
+}
+
+/* Build the archival file index */
 
 static inline void build_idx( fd_blockstore_t * blockstore, int fd ) {
   if ( FD_UNLIKELY( fd == -1 ) ) {
@@ -200,7 +282,6 @@ static inline void build_idx( fd_blockstore_t * blockstore, int fd ) {
   FD_LOG_NOTICE(( "[%s] building index of blockstore archival file", __func__ ));
 
   fd_block_idx_t * block_idx = fd_blockstore_block_idx( blockstore );
-
   fd_block_map_t block_map_out = { 0 };
   fd_block_t     block_out     = { 0 };
 
@@ -213,16 +294,42 @@ static inline void build_idx( fd_blockstore_t * blockstore, int fd ) {
 
   lseek( fd, 0, SEEK_SET );
   int err = 0;
-  ulong off = 0;
   ulong rsz = 0;
-  ulong end = (ulong)sz;
-  while ( FD_LIKELY( off < end ) ) {
-    err = fd_io_read( fd, &block_map_out, sizeof(block_map_out), sizeof(block_map_out), &rsz );
+
+  fd_blockstore_archiver_t metadata;
+  err = fd_io_read( fd, &metadata, sizeof(fd_blockstore_archiver_t), sizeof(fd_blockstore_archiver_t), &rsz );
+  check_read_write_err( err );
+  if ( fd_blockstore_archiver_verify( blockstore, &metadata ) ) {
+    FD_LOG_ERR(( "[%s] archival file was invalid: blockstore may have been crashed or been killed mid-write.", __func__ ));
+    return;
+  }
+
+  blockstore->archiver = metadata;
+  ulong off          = metadata.head;
+  ulong total_blocks = metadata.num_blocks;
+  ulong blocks_read  = 0;
+
+  /* If the file has content, but is perfectly filled, then off == end at the start. 
+    Then it is impossible to distinguish from an empty file except for num_blocks field. */
+
+  while ( FD_LIKELY( blocks_read < total_blocks ) ) {
+    blocks_read++;
+    fd_block_idx_t block_idx_entry = { 0 };
+    block_idx_entry.off = off;
+    err = fd_blockstore_block_meta_restore( &blockstore->archiver, fd, &block_idx_entry, &block_map_out,  &block_out );
     check_read_write_err( err );
 
+    if( FD_UNLIKELY( fd_block_idx_key_cnt( block_idx ) == fd_block_idx_key_max( block_idx ) )  ) {
+      /* evict a block */
+      fd_block_map_t  lrw_block_map;
+      fd_block_t      lrw_block;
+      ulong lrw_slot = fd_blockstore_archiver_lrw_slot( blockstore, fd, &lrw_block_map, &lrw_block );
 
-    if( FD_UNLIKELY( fd_block_idx_key_cnt( block_idx ) == fd_block_idx_key_max( block_idx ) ) ) {
-      FD_LOG_ERR(( "[%s] existing archival file exceeded idx_max. offset: %lu", __func__, off ));
+      fd_block_idx_t * lrw_block_index = fd_block_idx_query( block_idx, lrw_slot, NULL );
+      fd_block_idx_remove( block_idx, lrw_block_index );
+      
+      blockstore->archiver.head = wrap_offset(&blockstore->archiver, blockstore->archiver.head + lrw_block.data_sz + sizeof(fd_block_map_t) + sizeof(fd_block_t));;
+      blockstore->archiver.num_blocks--;
     }
     if ( FD_UNLIKELY( fd_block_idx_query( block_idx, block_map_out.slot, NULL ) ) ) {
       FD_LOG_ERR(( "[%s] existing archival file contained duplicates of slot %lu", __func__, block_map_out.slot ));
@@ -232,23 +339,25 @@ static inline void build_idx( fd_blockstore_t * blockstore, int fd ) {
     idx_entry->off             = off;
     idx_entry->block_hash      = block_map_out.block_hash;
     idx_entry->bank_hash       = block_map_out.bank_hash;
+    blockstore->mrw_slot       = block_map_out.slot;
 
-    err = fd_io_read( fd, &block_out, sizeof(block_out), sizeof(block_out), &rsz );
-    check_read_write_err( err );
+    FD_LOG_NOTICE(( "[%s] read block (%lu/%lu) at offset: %lu. slot no: %lu", __func__, blocks_read, total_blocks, off, block_map_out.slot ));
 
-    off_t lseek_off = lseek( fd, (long)block_out.data_sz, SEEK_CUR ); /* seek past block data */
-    if ( FD_UNLIKELY( lseek_off == -1 && errno != EINVAL /* seek past EOF */ ) ) {  
-      FD_LOG_ERR(( "[%s] archival file was invalid: blockstore may have been crashed or been killed mid-write. offset: %lu", __func__, off ));
-    }
-
-    off = (ulong)lseek_off;
+    /* seek past data */
+    off = wrap_offset( &blockstore->archiver, off + sizeof(fd_block_map_t) + sizeof(fd_block_t) + block_out.data_sz );
+    check_read_write_err( lseek( fd, (long)off, SEEK_SET ) == -1);
   }
-
   FD_LOG_NOTICE(( "[%s] successfully indexed blockstore archival file. entries: %lu", __func__, fd_block_idx_key_cnt( block_idx ) ));
 }
 
 fd_blockstore_t *
-fd_blockstore_init( fd_blockstore_t * blockstore, int fd, fd_slot_bank_t const * slot_bank ) {
+fd_blockstore_init( fd_blockstore_t * blockstore, int fd, ulong fd_size_max, fd_slot_bank_t const * slot_bank ) {
+  if ( fd_size_max < FD_BLOCKSTORE_ARCHIVE_MIN_SIZE ) {
+    FD_LOG_ERR(( "archive file size too small" ));
+    return NULL;
+  }
+  blockstore->archiver.fd_size_max = fd_size_max;
+
   build_idx( blockstore, fd );
   lseek( fd, 0, SEEK_END );
 
@@ -548,75 +657,213 @@ fd_blockstore_buffered_shreds_remove( fd_blockstore_t * blockstore, ulong slot )
   return FD_BLOCKSTORE_OK;
 }
 
+/** Where write_off is where we want to write to, and we return
+    the next valid location to write to (either wraparound, or
+    right after where we just wrote ) */
+static ulong write_with_wraparound( fd_blockstore_archiver_t * archvr, 
+                                   int fd, 
+                                   uchar * src, 
+                                   ulong src_sz,
+                                   ulong write_off ) {
+
+  if ( FD_UNLIKELY( lseek( fd, (long)write_off, SEEK_SET ) == -1 ) ) {
+    FD_LOG_ERR(( "[%s] failed to seek to offset %lu", __func__, write_off ));
+  }
+  ulong wsz;
+  ulong remaining_sz = archvr->fd_size_max - write_off;
+  if ( remaining_sz < src_sz ) {
+    int err = fd_io_write( fd, src, remaining_sz, remaining_sz, &wsz );
+    check_read_write_err( err );
+    write_off = FD_BLOCKSTORE_ARCHIVE_START;
+    if ( FD_UNLIKELY( lseek( fd, (long)write_off, SEEK_SET ) == -1 ) ) {
+      FD_LOG_ERR(( "[%s] failed to seek to offset %lu", __func__, write_off ));
+    }
+    err = fd_io_write( fd, src + remaining_sz, src_sz - remaining_sz, src_sz - remaining_sz, &wsz );
+    check_read_write_err( err );
+    write_off += wsz;
+  } else {
+    int err = fd_io_write( fd, src, src_sz, src_sz, &wsz );
+    check_read_write_err( err );
+    write_off += wsz;
+  }
+  if ( write_off >= archvr->fd_size_max ) {
+    write_off = FD_BLOCKSTORE_ARCHIVE_START;
+  }
+  return write_off;
+}
+
+static void start_archive_write( fd_blockstore_archiver_t * archvr, int fd ) {
+  /* Invalidates the blocks that will be overwritten by marking them as free space */
+  if ( FD_UNLIKELY( lseek( fd, 0, SEEK_SET ) == -1 ) ) {
+    FD_LOG_ERR(( "[%s] failed to seek to start", __func__ ));
+  }
+  ulong wsz;
+  int err = fd_io_write( fd, archvr, sizeof(fd_blockstore_archiver_t), sizeof(fd_blockstore_archiver_t), &wsz );
+  check_read_write_err( err );
+}
+
+static void end_archive_write( fd_blockstore_archiver_t * archvr,
+                               int fd ) {
+  if ( FD_UNLIKELY( lseek( fd, 0, SEEK_SET ) == -1 ) ) {
+    FD_LOG_ERR(( "[%s] failed to seek to start", __func__ ));
+  }
+  ulong wsz;
+  int err = fd_io_write( fd, archvr, sizeof(fd_blockstore_archiver_t), sizeof(fd_blockstore_archiver_t), &wsz );
+  check_read_write_err( err );
+}
+
+/* Clears any to be overwritten blocks in the archive from the index and updates archvr */
+static void
+fd_blockstore_lrw_archive_clear( fd_blockstore_t * blockstore, int fd, ulong wsz, ulong write_off ) {
+  fd_blockstore_archiver_t * archvr = &blockstore->archiver;
+  fd_block_idx_t * block_idx        = fd_blockstore_block_idx( blockstore );
+  
+  ulong non_wrapped_end = write_off + wsz;
+  ulong wrapped_end     = wrap_offset(archvr, non_wrapped_end);
+  bool mrw_wraps        = non_wrapped_end > archvr->fd_size_max;
+
+  if ( FD_UNLIKELY( fd_block_idx_key_cnt( block_idx ) == 0 ) ) {
+    return;
+  }
+
+  fd_block_map_t lrw_block_map;
+  fd_block_t     lrw_block;
+
+  ulong lrw_slot = fd_blockstore_archiver_lrw_slot( blockstore, fd, &lrw_block_map, &lrw_block );
+  fd_block_idx_t * lrw_block_index = fd_block_idx_query( block_idx, lrw_slot, NULL );
+
+  while( lrw_block_index && 
+        ( ( lrw_block_index->off >= write_off && lrw_block_index->off < non_wrapped_end ) ||
+          ( mrw_wraps && lrw_block_index->off < wrapped_end ) ) ){
+      /* evict blocks */
+      FD_LOG_DEBUG(( "[%s] overwriting lrw block %lu", __func__, lrw_block_map.slot ));
+      fd_block_idx_remove( block_idx, lrw_block_index );
+
+      archvr->head = wrap_offset(archvr, archvr->head + lrw_block.data_sz + sizeof(fd_block_map_t) + sizeof(fd_block_t));
+      archvr->num_blocks--;
+
+      lrw_slot        = fd_blockstore_archiver_lrw_slot( blockstore, fd, &lrw_block_map, &lrw_block );
+      lrw_block_index = fd_block_idx_query(block_idx, lrw_slot, NULL);
+
+      if ( lrw_block_index && (lrw_block_index->off != archvr->head) ){
+        FD_LOG_ERR(( "[%s] block index mismatch %lu != %lu", __func__, lrw_block_index->off, archvr->head ));
+      }
+  }
+}
+
+/* Performs any block index & updates mrw after archiving a block. We start guaranteed having */
+
+static void fd_blockstore_post_checkpt_update( fd_blockstore_t * blockstore, 
+                                               fd_blockstore_ser_t * ser, 
+                                               int fd,
+                                               ulong slot, 
+                                               ulong wsz, 
+                                               ulong write_off ) {
+  fd_blockstore_archiver_t * archvr = &blockstore->archiver;
+  fd_block_idx_t * block_idx        = fd_blockstore_block_idx( blockstore );
+
+  /* Successfully archived block, so update index and offset. */
+
+  if ( fd_block_idx_key_cnt( block_idx ) == fd_block_idx_key_max( block_idx ) ){
+    /* make space if needed */
+    fd_block_map_t lrw_block_map_out;
+    fd_block_t     lrw_block_out;
+    ulong lrw_slot = fd_blockstore_archiver_lrw_slot( blockstore, fd, &lrw_block_map_out, &lrw_block_out );
+    fd_block_idx_t * lrw_block_index  = fd_block_idx_query(block_idx, lrw_slot, NULL);
+    fd_block_idx_remove( block_idx, lrw_block_index );
+
+    archvr->head = wrap_offset(archvr, archvr->head + lrw_block_out.data_sz + sizeof(fd_block_map_t) + sizeof(fd_block_t));
+    archvr->num_blocks--;
+  }
+
+  fd_block_idx_t * idx_entry = fd_block_idx_insert( fd_blockstore_block_idx( blockstore ), slot );
+  idx_entry->off             = write_off;
+  idx_entry->block_hash      = ser->block_map->block_hash;
+  idx_entry->bank_hash       = ser->block_map->bank_hash;
+  
+  archvr->num_blocks++;
+  archvr->tail = wrap_offset( archvr, write_off + wsz);;
+  blockstore->mrw_slot = slot;
+}
+
 ulong
-fd_blockstore_block_checkpt( fd_blockstore_t * blockstore FD_PARAM_UNUSED,
+fd_blockstore_block_checkpt( fd_blockstore_t * blockstore,
                              fd_blockstore_ser_t * ser,
                              int fd,
                              ulong slot ) {
+  ulong write_off = blockstore->archiver.tail;
+  ulong og_write_off = write_off;
   if ( FD_UNLIKELY( fd == -1 ) ) {
     FD_LOG_DEBUG(( "[%s] fd is -1", __func__ ));
     return 0;
   }
-  ulong off = 0;
-  ulong wsz; 
-  int err = fd_io_write( fd, ser->block_map, sizeof(fd_block_map_t), sizeof(fd_block_map_t), &wsz );
-  check_read_write_err( err );
-  off += wsz; 
-  err = fd_io_write( fd, ser->block, sizeof(fd_block_t), sizeof(fd_block_t), &wsz );
-  check_read_write_err( err );
-  off += wsz;
-  err = fd_io_write( fd, ser->data, ser->block->data_sz, ser->block->data_sz, &wsz );
-  check_read_write_err( err );
-  off += wsz;
+  if ( FD_UNLIKELY( lseek( fd, (long)write_off, SEEK_SET ) == -1 ) ) {
+    FD_LOG_ERR(( "[%s] failed to seek to offset %lu", __func__, write_off ));
+  }
 
-  FD_LOG_DEBUG(( "[%s] archived block %lu", __func__, slot ));
-  return off;
+  ulong total_wsz = sizeof(fd_block_map_t) + sizeof(fd_block_t) + ser->block->data_sz;
+
+  /* clear any potential overwrites */
+  fd_blockstore_lrw_archive_clear( blockstore, fd, total_wsz, write_off );
+
+  start_archive_write( &blockstore->archiver, fd );
+
+  write_off = write_with_wraparound( &blockstore->archiver, fd, (uchar*)ser->block_map, sizeof(fd_block_map_t), write_off );
+  write_off = write_with_wraparound( &blockstore->archiver, fd, (uchar*)ser->block, sizeof(fd_block_t), write_off );
+  write_off = write_with_wraparound( &blockstore->archiver, fd, ser->data, ser->block->data_sz, write_off );
+
+  fd_blockstore_post_checkpt_update( blockstore, ser, fd, slot, total_wsz, og_write_off );
+
+  end_archive_write( &blockstore->archiver, fd );
+
+  FD_LOG_NOTICE(( "[%s] archived block %lu at %lu: size %lu", __func__, slot, og_write_off, total_wsz ));
+  return total_wsz;
 }
 
 int
-fd_blockstore_block_meta_restore( fd_blockstore_t * blockstore FD_PARAM_UNUSED,
+fd_blockstore_block_meta_restore( fd_blockstore_archiver_t * archvr,
                                   int fd,
                                   fd_block_idx_t * block_idx_entry,
                                   fd_block_map_t * block_map_entry_out,
                                   fd_block_t * block_out ) { 
-  if( FD_UNLIKELY( lseek( fd, (long)block_idx_entry->off, SEEK_SET ) == -1 ) ) {
-    FD_LOG_WARNING(( "failed to seek" ));
-    return FD_BLOCKSTORE_ERR_SLOT_MISSING;
-  }
   ulong rsz; 
-  int err = fd_io_read( fd, block_map_entry_out, sizeof(fd_block_map_t), sizeof(fd_block_map_t), &rsz );
-  // Not throwing on error here because we want to return the error code to the caller
-  err |= fd_io_read( fd, block_out, sizeof(fd_block_t), sizeof(fd_block_t), &rsz );
-  if( FD_UNLIKELY( err ) ) {
-    FD_LOG_WARNING(( "failed to read and/or block_map_entry" ));
-    return FD_BLOCKSTORE_ERR_SLOT_MISSING;
-  }
+  ulong read_off = block_idx_entry->off;
+  int err = read_with_wraparound( archvr, 
+                                  fd, 
+                                  (uchar *)fd_type_pun(block_map_entry_out), 
+                                  sizeof(fd_block_map_t), 
+                                  &rsz, 
+                                  &read_off );
+  check_read_err_safe( err, "failed to read block map" );
+  err = read_with_wraparound( archvr, 
+                              fd, 
+                              (uchar *)fd_type_pun(block_out), 
+                              sizeof(fd_block_t), 
+                              &rsz, 
+                              &read_off );
+  check_read_err_safe( err, "failed to read block" );
   return FD_BLOCKSTORE_OK;
 }
 
 int
-fd_blockstore_block_data_restore( fd_blockstore_t * blockstore FD_PARAM_UNUSED, 
+fd_blockstore_block_data_restore( fd_blockstore_archiver_t * archvr, 
                                   int fd, 
                                   fd_block_idx_t * block_idx_entry,
                                   uchar * buf_out,
                                   ulong buf_max, 
                                   ulong data_sz ) {
-                                
+  ulong data_off = wrap_offset(archvr, block_idx_entry->off + sizeof(fd_block_map_t) + sizeof(fd_block_t));
   if( FD_UNLIKELY( buf_max < data_sz ) ) {
     FD_LOG_ERR(( "[%s] data_out_sz %lu < data_sz %lu", __func__, buf_max, data_sz ));
     return -1;
   }
-  ulong data_off = block_idx_entry->off + sizeof(fd_block_map_t) + sizeof(fd_block_t);
   if( FD_UNLIKELY( lseek( fd, (long)data_off, SEEK_SET ) == -1 ) ) {
     FD_LOG_WARNING(( "failed to seek" ));
     return FD_BLOCKSTORE_ERR_SLOT_MISSING;
   }  
   ulong rsz; 
-  int err = fd_io_read( fd, buf_out, data_sz, data_sz, &rsz );
-  if( FD_UNLIKELY( err ) ) {
-    FD_LOG_WARNING(( "failed to read block data" ));
-    return FD_BLOCKSTORE_ERR_SLOT_MISSING;
-  }
+  int err = read_with_wraparound( archvr, fd, buf_out, data_sz, &rsz, &data_off );
+  check_read_err_safe( err, "failed to read block data" );
   return FD_BLOCKSTORE_OK;
 }
 
@@ -683,9 +930,7 @@ fd_blockstore_publish( fd_blockstore_t * blockstore, int fd, ulong smr ) {
 
       fd_block_idx_t * block_idx = fd_blockstore_block_idx( blockstore );
 
-      if( FD_UNLIKELY( fd_block_idx_key_cnt( block_idx ) == fd_block_idx_key_max( block_idx ) ) ) {
-        FD_LOG_WARNING(( "[%s] reached blockstore idx_max limit. not archiving finalized block: %lu", __func__, slot ));
-      } else if( FD_UNLIKELY( fd_block_idx_query( block_idx, slot, NULL ) ) ) {
+      if( FD_UNLIKELY( fd_block_idx_query( block_idx, slot, NULL ) ) ) {
         FD_LOG_ERR(( "[%s] invariant violation. attempted to re-archive finalized block: %lu", __func__, slot ));
       } else {
         fd_blockstore_ser_t ser = {
@@ -693,15 +938,7 @@ fd_blockstore_publish( fd_blockstore_t * blockstore, int fd, ulong smr ) {
           .block     = block,
           .data      = data
         };
-        ulong wsz = fd_blockstore_block_checkpt( blockstore,&ser, fd, slot );
-
-        /* Successfully archived block, so update index and offset. */
-
-        fd_block_idx_t * idx_entry = fd_block_idx_insert( fd_blockstore_block_idx( blockstore ), slot );
-        idx_entry->off             = blockstore->off;
-        blockstore->off            = blockstore->off + wsz;
-        idx_entry->block_hash      = block_map_entry->block_hash;
-        idx_entry->bank_hash       = block_map_entry->bank_hash;
+        fd_blockstore_block_checkpt( blockstore, &ser, fd, slot );
       }
     }
 
@@ -1157,13 +1394,14 @@ fd_blockstore_block_data_query_volatile( fd_blockstore_t *    blockstore,
   }
 
   if ( FD_UNLIKELY( off < ULONG_MAX ) ) { /* optimize for non-archival queries */
+    FD_LOG_DEBUG( ( "Querying archive for block %lu", slot ) );
     fd_block_t block_out;
-    int err = fd_blockstore_block_meta_restore( blockstore, fd, idx_entry, block_map_entry_out, &block_out );
+    int err = fd_blockstore_block_meta_restore( &blockstore->archiver, fd, idx_entry, block_map_entry_out, &block_out );
     if( FD_UNLIKELY( err ) ) {
       return FD_BLOCKSTORE_ERR_SLOT_MISSING;
     }
     uchar * block_data = fd_valloc_malloc( alloc, 128UL, block_out.data_sz );
-    err = fd_blockstore_block_data_restore( blockstore,
+    err = fd_blockstore_block_data_restore( &blockstore->archiver,
                                             fd, 
                                             idx_entry,   
                                             block_data, 

--- a/src/flamenco/runtime/fd_blockstore.h
+++ b/src/flamenco/runtime/fd_blockstore.h
@@ -37,7 +37,8 @@
 
 /* TODO this can be removed if we explicitly manage a memory pool for
    the fd_block_map_t entries */
-#define FD_BLOCKSTORE_CHILD_SLOT_MAX (32UL) /* the maximum # of children a slot can have */
+#define FD_BLOCKSTORE_CHILD_SLOT_MAX    (32UL)        /* the maximum # of children a slot can have */
+#define FD_BLOCKSTORE_ARCHIVE_MIN_SIZE  (1UL << 26UL) /* 64MB := ceil(MAX_DATA_SHREDS_PER_SLOT*1228) */
 
 // TODO centralize these
 // https://github.com/firedancer-io/solana/blob/v1.17.5/sdk/program/src/clock.rs#L34
@@ -261,6 +262,7 @@ typedef struct fd_block_map fd_block_map_t;
 
 struct fd_block_idx {
   ulong     slot;
+  ulong     next;
   uint      hash;
   ulong     off;
   fd_hash_t block_hash;
@@ -302,6 +304,20 @@ ulong fd_txn_key_hash(fd_txn_key_t const * k, ulong seed);
 #define MAP_KEY_HASH(k,seed) fd_txn_key_hash(k, seed)
 #include "../../util/tmpl/fd_map_giant.c"
 
+/* fd_blockstore_archiver outlines the format of metadata
+   at the start of an archive file - needed so that archive
+   files can be read back on initialization. */
+
+struct fd_blockstore_archiver {
+  ulong magic;
+  ulong fd_size_max;      /* maximum size of the archival file */
+  ulong num_blocks;       /* number of blocks in the archival file. needed for reading back */
+  ulong head;             /* location of least recently written block */
+  ulong tail;             /* location after most recently written block */
+};
+typedef struct fd_blockstore_archiver fd_blockstore_archiver_t;
+#define FD_BLOCKSTORE_ARCHIVE_START sizeof(fd_blockstore_archiver_t)
+
 struct __attribute__((aligned(FD_BLOCKSTORE_ALIGN))) fd_blockstore {
 /* clang-format on */
 
@@ -318,7 +334,8 @@ struct __attribute__((aligned(FD_BLOCKSTORE_ALIGN))) fd_blockstore {
 
   /* Persistence */
 
-  ulong off; /* current offset in the archival file */
+  fd_blockstore_archiver_t archiver;
+  ulong mrw_slot; /* most recently written slot */
 
   /* Slot metadata */
 
@@ -413,7 +430,7 @@ fd_blockstore_delete( void * shblockstore );
    file.  */
 
 fd_blockstore_t *
-fd_blockstore_init( fd_blockstore_t * blockstore, int fd, fd_slot_bank_t const * slot_bank );
+fd_blockstore_init( fd_blockstore_t * blockstore, int fd, ulong fd_size_max, fd_slot_bank_t const * slot_bank );
 
 /* fd_blockstore_fini finalizes a blockstore. */
 
@@ -718,28 +735,39 @@ struct fd_blockstore_ser {
 };
 typedef struct fd_blockstore_ser fd_blockstore_ser_t;
 
-/* Archives a block and block map entry to fd. If fd is -1, no write is attempted */
+/* Archives a block and block map entry to fd at blockstore->off, and does
+   any necessary bookkeeping.
+   If fd is -1, no write is attempted. Returns written size */
 ulong
-fd_blockstore_block_checkpt( fd_blockstore_t * blockstore FD_PARAM_UNUSED, 
+fd_blockstore_block_checkpt( fd_blockstore_t * blockstore, 
                              fd_blockstore_ser_t * ser, 
                              int fd, 
                              ulong slot );
 
 /* Restores a block and block map entry from fd at given offset. As this used by
-   rpcserver, it must return an error code instead of throwing an error on failure */
+   rpcserver, it must return an error code instead of throwing an error on failure. */
 int
-fd_blockstore_block_meta_restore( fd_blockstore_t * blockstore,
+fd_blockstore_block_meta_restore( fd_blockstore_archiver_t * archvr,
                                   int fd,
                                   fd_block_idx_t * block_idx_entry,
                                   fd_block_map_t * block_map_entry_out,
                                   fd_block_t * block_out );
-/* Reads block data from fd into a given buf */
+
+/* Reads block data from fd into a given buf. Modifies data_off similarly to
+   meta_restore */
 int 
-fd_blockstore_block_data_restore( fd_blockstore_t * blockstore,
+fd_blockstore_block_data_restore( fd_blockstore_archiver_t * archvr,
                                   int fd,
                                   fd_block_idx_t * block_idx_entry,
                                   uchar * buf_out,
                                   ulong buf_max,
                                   ulong data_sz );
+
+/* Returns 0 if the archive metadata is valid */
+bool
+fd_blockstore_archiver_verify( fd_blockstore_t * blockstore, fd_blockstore_archiver_t * archiver );
+
+ulong
+fd_blockstore_archiver_lrw_slot( fd_blockstore_t * blockstore, int fd, fd_block_map_t * lrw_block_map, fd_block_t * lrw_block );
 
 #endif /* HEADER_fd_src_flamenco_runtime_fd_blockstore_h */

--- a/src/flamenco/runtime/test_archive_block.c
+++ b/src/flamenco/runtime/test_archive_block.c
@@ -1,0 +1,327 @@
+#include "../../util/fd_util.h"
+
+#if FD_HAS_INT128
+
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+#include  "fd_blockstore.h"
+
+ulong shred_max = 128;
+ulong block_max = 128;
+ulong txn_max = 128;
+
+#define GENERATE_BLOCK_DATA( ser, block_map_entry, block, slot, data_sz )              \
+  uchar data[data_sz];                                                                 \
+  for( ulong i = 0; i < data_sz; i++ ) {                                               \
+    data[i] = (uchar) rand();                                                          \
+  }                                                                                    \
+  fd_block_t block = { .data_gaddr = 0, .data_sz = data_sz, .rewards = { 0 }};         \
+  block.rewards.collected_fees = slot; /* used for meaningful check test */            \
+  fd_block_map_t block_map_entry = { 0 };                                              \
+  block_map_entry.parent_slot = slot;  /* bc query_block needs an existing parent */   \
+  block_map_entry.slot = slot;                                                         \
+  block_map_entry.ts = (long) time(NULL); /* used for meaningful check test */         \
+  fd_blockstore_ser_t ser = {                                                          \
+    .block_map = &block_map_entry,                                                     \
+    .block = &block,                                                                   \
+    .data = data                                                                       \
+  };
+
+#define CREATE_BLOCKSTORE( blockstore, slot_bank, mem, fake_hash )                     \
+  void * mem = fd_wksp_alloc_laddr( wksp,                                              \
+                                    fd_blockstore_align(),                             \
+                                    fd_blockstore_footprint( shred_max,                \
+                                                             block_max,                \
+                                                             idx_max,                  \
+                                                             txn_max ),                \
+                                    1UL );                                             \
+  FD_TEST( mem );                                                                      \
+  fd_blockstore_t * blockstore = fd_blockstore_join( fd_blockstore_new( mem,           \
+                                                                        1,             \
+                                                                        0,             \
+                                                                        shred_max,     \
+                                                                        block_max,     \
+                                                                        idx_max,       \
+                                                                        txn_max ) );   \
+  FD_TEST( blockstore );                                                               \
+  fd_slot_bank_t slot_bank = {                                                         \
+      .slot = 1,                                                                       \
+      .prev_slot = 0,                                                                  \
+      .banks_hash = {.hash = {0}},                                                     \
+      .block_height = 1,                                                               \
+  };                                                                                   \
+  fd_slot_bank_new( &slot_bank );                                                      \
+  fd_hash_t fake_hash = {.hash = {1}};                                                 \
+  slot_bank.block_hash_queue.last_hash = &fake_hash;                                   \
+  slot_bank.block_hash_queue.last_hash_index = 0;
+
+#define CLOSE_BLOCKSTORE  fd_wksp_free_laddr( mem );
+
+bool
+blocks_equal(fd_block_t* block1, fd_block_t* block2) {
+  return block1->data_sz == block2->data_sz && block1->rewards.collected_fees == block2->rewards.collected_fees;
+}
+
+fd_block_map_t 
+query_block(bool expect, fd_blockstore_t * blockstore, int fd, ulong slotn){
+  ulong blk_sz;
+  fd_block_map_t meta[1];
+  fd_block_rewards_t rewards[1];
+  fd_hash_t parent_hash;
+  uchar * blk_data = NULL;
+  fd_valloc_t valloc = fd_alloc_virtual( fd_blockstore_alloc(blockstore) ); 
+  bool success = fd_blockstore_block_data_query_volatile( blockstore, fd, slotn, valloc, &parent_hash, meta, rewards, &blk_data, &blk_sz ) == 0;
+  if ( blk_data ) {
+    fd_alloc_free( fd_blockstore_alloc(blockstore), blk_data );
+  }
+
+  if ( success != expect ) {
+    FD_LOG_ERR(("query_block failed for slot %lu", slotn));
+  } else {
+    FD_LOG_NOTICE(("query_block matches expected for slot %lu", slotn));
+  }
+
+  return meta[0];
+}
+
+void
+test_archive_many_blocks( fd_wksp_t * wksp, int fd, ulong fd_size_max, ulong idx_max, ulong blocks ) {
+  /**
+    Tests archiving blocks that will exceed the blockstore's capacity
+    and will require the file to be overwritten.
+   */
+
+  // ensure fd is cleared
+  FD_TEST( ftruncate(fd, 0) == 0 );
+  FD_LOG_NOTICE(("fd is %d", fd));
+
+  CREATE_BLOCKSTORE(blockstore, slot_bank, mem, fake_hash);
+  FD_TEST(fd_blockstore_init(blockstore, fd, fd_size_max,&slot_bank));
+
+  /* Store blocks that have been written to compare them later */
+  fd_block_map_t * block_map_record = fd_alloc_malloc( fd_blockstore_alloc(blockstore), 
+                                                      fd_block_map_align(),
+                                                        sizeof(fd_block_map_t) * (blocks + 1) );
+  int max_data_sz_pow = 20;
+  uchar buf_out[ (1 << max_data_sz_pow) ]; 
+
+  fd_block_map_t block_map_entry;
+  fd_block_t     block;
+
+  for( ulong slot = 1; slot <= blocks; slot++ ){
+    ulong data_sz = (ulong) (1 << (rand() % 18 + 2));
+    ulong prev_lrw_slot = fd_blockstore_archiver_lrw_slot( blockstore, fd, &block_map_entry, &block );
+
+    GENERATE_BLOCK_DATA( ser, block_map_entry, block, slot, data_sz );
+    FD_LOG_NOTICE( ( "slot %lu, data_sz %lu", slot, data_sz ) );
+    block_map_record[slot] = block_map_entry;
+
+    /* Checkpoint the generated data */
+
+    fd_blockstore_block_checkpt( blockstore, &ser, fd, slot );
+
+    /* Read back the data from archive */
+
+    fd_block_idx_t * block_idx_entry = fd_block_idx_query( fd_blockstore_block_idx(blockstore), slot, NULL );
+    fd_block_map_t block_map_entry_out;
+    fd_block_t block_out;
+    //ulong read_off = block_idx_entry->off;
+    fd_blockstore_block_meta_restore(&blockstore->archiver, fd, block_idx_entry, &block_map_entry_out, &block_out);
+    //read_off = wrap_offset(&blockstore->archiver, read_off + sizeof(fd_block_map_t) + sizeof(fd_block_t));
+    fd_blockstore_block_data_restore(&blockstore->archiver, fd, block_idx_entry, buf_out, block_out.data_sz, block_out.data_sz);
+
+    /* Check data read back matches data written */
+
+    FD_TEST( memcmp(buf_out, data, block_out.data_sz) == 0 );
+    FD_TEST( blocks_equal(&block, &block_out) );
+    FD_TEST( block_map_entry_out.slot == slot );
+
+    /* Check that blocks are evicted or stay in file as expected */
+    ulong lrw_slot = fd_blockstore_archiver_lrw_slot( blockstore, fd, &block_map_entry, &block );
+
+    if( lrw_slot != prev_lrw_slot && slot != 1) {
+      query_block(false, blockstore, fd, prev_lrw_slot);              // no longer in archive
+    }
+    query_block(true, blockstore, fd, lrw_slot); // should be in archive
+    query_block(true, blockstore, fd, slot); // should be in archive
+
+    if ( slot % 10 == 0 ) {
+      // periodically check all blocks in the block_idx match the blocks in the archive
+      // and blocks in archive match what we store in memory
+      for( ulong s = lrw_slot; s != blockstore->mrw_slot; s++ ){
+        fd_block_map_t blk_map = query_block(true, blockstore, fd, s);
+        FD_TEST( memcmp( &blk_map, &block_map_record[s], sizeof(fd_block_map_t)) == 0 );
+      }
+    }
+  }
+  FD_LOG_NOTICE(("key count: %lu", fd_block_idx_key_cnt(fd_blockstore_block_idx(blockstore))));
+  fd_alloc_free( fd_blockstore_alloc(blockstore), block_map_record );
+  CLOSE_BLOCKSTORE
+}
+
+void test_blockstore_archive_big( fd_wksp_t * wksp, int fd, ulong first_idx_max, ulong replay_idx_max ){
+  /*
+    This test assumes that the limit on blocks in the blockstore file is the size, not idx max.
+  */
+  FD_TEST( ftruncate(fd, 0) == 0 );
+
+  ulong idx_max = first_idx_max;
+  CREATE_BLOCKSTORE(blockstore, slot_bank, mem, fake_hash);
+  FD_TEST(fd_blockstore_init(blockstore, fd, FD_BLOCKSTORE_ARCHIVE_MIN_SIZE, &slot_bank));
+
+  for( ulong slot = 1; slot <= first_idx_max; slot++ ){
+    ulong data_sz = (ulong) (1 << (rand() % 18 + 2));
+
+    GENERATE_BLOCK_DATA( ser, block_map_entry, block, slot, data_sz );
+    FD_LOG_NOTICE( ( "slot %lu, data_sz %lu", slot, data_sz ) );
+
+    /* Checkpoint the generated data */
+
+    fd_blockstore_block_checkpt( blockstore, &ser, fd, slot );
+  }
+  fd_block_map_t lrw_block_map;
+  fd_block_t     lrw_block;
+
+  ulong lrw1 = fd_blockstore_archiver_lrw_slot( blockstore, fd, &lrw_block_map, &lrw_block);
+
+  idx_max = replay_idx_max;
+  CREATE_BLOCKSTORE( blockstore2, slot_bank2, mem2, fake_hash2 );
+
+  // initialize from fd that was created from the test_archive_many_blocks
+  FD_TEST(fd_blockstore_init(blockstore2, fd, FD_BLOCKSTORE_ARCHIVE_MIN_SIZE, &slot_bank2));
+
+  ulong lrw2 = fd_blockstore_archiver_lrw_slot( blockstore2, fd, &lrw_block_map, &lrw_block);
+  FD_TEST( lrw2 >= lrw1 );
+
+  for ( ulong slot = lrw2; slot != first_idx_max; slot++ ){
+    query_block(true, blockstore2, fd, slot);
+  }
+  for ( ulong slot = lrw1; slot != lrw2; slot++ ){
+    query_block(false, blockstore2, fd, slot);
+  }
+}
+
+void test_blockstore_archive_small( fd_wksp_t * wksp, int fd, ulong first_idx_max, ulong replay_idx_max ){
+  /**
+    This test assumes that the blockstore can fit first_idx_max blocks in the archive file without evicting.
+    Tests the blockstore's ability to read from archive files that have valid data.
+    Will store the max_idx number of blocks in the archive file; read back that data,
+    and then try to insert more.
+   */
+  FD_TEST( ftruncate(fd, 0) == 0 );
+
+  // large fd - limit on blocks in archive should be idx_max
+  test_archive_many_blocks( wksp, fd, FD_BLOCKSTORE_ARCHIVE_MIN_SIZE, first_idx_max, first_idx_max );
+  ulong last_archived = first_idx_max;
+
+  ulong idx_max = replay_idx_max; 
+  CREATE_BLOCKSTORE( blockstore, slot_bank, mem, fake_hash );
+
+  // initialize from fd that was created from the test_archive_many_blocks
+  FD_TEST(fd_blockstore_init(blockstore, fd, FD_BLOCKSTORE_ARCHIVE_MIN_SIZE, &slot_bank));
+  fd_block_idx_t * block_idx = fd_blockstore_block_idx(blockstore);
+
+  if( first_idx_max < replay_idx_max ){
+    FD_LOG_WARNING(("The following tests are meaninful only when first_idx_max >= replay_idx_max, skipping."));
+    return;
+  }
+  FD_TEST(fd_block_idx_key_cnt( block_idx) == fd_block_idx_key_max( block_idx ));
+
+  /* LRW and MRW slot should be properly populated */
+
+  fd_block_map_t lrw_block_map;
+  fd_block_t     lrw_block;
+  ulong lrw_slot = fd_blockstore_archiver_lrw_slot( blockstore, fd, &lrw_block_map, &lrw_block );
+  FD_LOG_NOTICE(("lrw_slot: %lu, mrw_slot: %lu", lrw_slot, blockstore->mrw_slot));
+  FD_TEST( lrw_slot == last_archived - (idx_max - 1) + 1);
+  FD_TEST( blockstore->mrw_slot == last_archived);
+
+  /* Insert slot idx_max + 1 into the blockstore, should succeed */
+
+  ulong slot = last_archived + 1;
+  ulong data_sz = 1024;
+  GENERATE_BLOCK_DATA( ser, block_map_entry, block, slot, data_sz );
+  fd_blockstore_block_checkpt( blockstore, &ser, fd, slot);
+
+  /* Check that LRW was evicted, and MRW is updated */
+  
+  lrw_slot = fd_blockstore_archiver_lrw_slot( blockstore, fd, &lrw_block_map, &lrw_block);
+  FD_TEST( lrw_slot == slot - fd_block_idx_key_max( block_idx ) + 1);
+  FD_TEST( blockstore->mrw_slot == slot);
+
+  for(ulong i = lrw_slot; i != blockstore->mrw_slot; i++){
+    // can be reasonably sure that the blocks are read from file properly, as
+    // the slot key is derived from block_map_out read from the file.
+    FD_TEST( fd_block_idx_query(block_idx, i, NULL) );
+  }
+  CLOSE_BLOCKSTORE
+}
+
+void
+test_blockstore_metadata_invalid( int fd ){
+  FD_TEST( ftruncate(fd, 0) == 0 );
+  fd_blockstore_t blockstore;
+  blockstore.archiver.fd_size_max = 0x6000;
+
+  fd_blockstore_archiver_t metadata = { .magic = FD_BLOCKSTORE_MAGIC, 
+                                        .fd_size_max = 0x6000, 
+                                        .head = 2, 
+                                        .tail = 3 };
+  FD_TEST( fd_blockstore_archiver_verify(&blockstore, &metadata) );
+  metadata.fd_size_max = 0x5000;
+  FD_TEST( fd_blockstore_archiver_verify(&blockstore, &metadata) );
+}
+
+int 
+main( int argc, char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  ulong  page_cnt = 1;
+  char * _page_sz = "gigantic";
+  ulong  numa_idx = fd_shmem_numa_idx( 0 );
+  FD_LOG_NOTICE( ( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)",
+                   page_cnt,
+                   _page_sz,
+                   numa_idx ) );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ),
+                                            page_cnt,
+                                            fd_shmem_cpu_idx( numa_idx ),
+                                            "wksp",
+                                            0UL );
+  FD_TEST( wksp );
+
+  const char * file = fd_env_strip_cmdline_cstr( &argc, &argv, "--blockstore-file", NULL, NULL);
+  int fd = open(file, O_RDWR | O_CREAT, 0666);
+  FD_TEST( fd > 0 );
+
+  test_blockstore_archive_big(wksp, fd, 1 << 12, 1 << 11);
+  test_blockstore_archive_small(wksp, fd, 128, 128);
+  test_blockstore_archive_small(wksp, fd, 128, 64);
+  test_blockstore_metadata_invalid(fd);
+
+  // tested archive with smaller fd size ( on order of 20KB ), by setting FD_BLOCKSTORE_ARCHIVE_MIN_SIZE 
+  ulong small_fd_size_max = FD_BLOCKSTORE_ARCHIVE_MIN_SIZE;
+  test_archive_many_blocks(wksp, fd, small_fd_size_max, 4, 128);         // small idx_mas
+  test_archive_many_blocks(wksp, fd, small_fd_size_max, 256, 512);      
+  test_archive_many_blocks(wksp, fd, small_fd_size_max, 1 << 12, 1025);  // idx_max > blocks
+  test_archive_many_blocks(wksp, fd, small_fd_size_max, 1 << 13, 1<<15); // large blocks
+
+  //test_archive_many_blocks(wksp, fd, small_fd_size_max, 1 << 13, 1<<20); // 1 million blocks
+
+  fd_halt();
+  return 0;
+}
+
+#else 
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_INT128 capability" ));
+  fd_halt();
+  return 0;
+}
+
+#endif // FD_HAS_INT128


### PR DESCRIPTION
test_archive_block tests:
- when blocks written greatly exceed block_idx
- when blocks written greatly exceed file size 
- rereading from an archive file and continuing to update the archive
- rereading from an archive file that has overwritten blocks / wrapped around blocks