### PR TITLE
funk: leaving tombstones in published records

### DIFF
--- a/src/app/ledger/main.c
+++ b/src/app/ledger/main.c
@@ -210,7 +210,7 @@ runtime_replay( fd_ledger_args_t * ledger_args ) {
       if( FD_UNLIKELY( err ) ) {
         FD_LOG_ERR(( "Failed to import block %lu", start_slot ));
       }
-      
+
       fd_blockstore_start_write( blockstore );
 
       /* Remove the previous block from the blockstore */
@@ -1217,7 +1217,7 @@ prune( fd_ledger_args_t * args ) {
                         fd_funk_val_sz( original_rec ) ) == 0 ));
     } else {
       fd_funk_rec_t * mod_rec = fd_funk_rec_modify( pruned_funk, rec );
-      int res = fd_funk_rec_remove( pruned_funk, mod_rec, 1 );
+      int res = fd_funk_rec_remove( pruned_funk, mod_rec );
       FD_TEST(( res == 0 ));
     }
   }

--- a/src/flamenco/runtime/fd_hashes.c
+++ b/src/flamenco/runtime/fd_hashes.c
@@ -525,7 +525,7 @@ fd_update_hash_bank_tpool( fd_exec_slot_ctx_t * slot_ctx,
       continue;
     }
 
-    fd_funk_rec_remove(funk, fd_funk_rec_modify(funk, task_info->rec), 1);
+    fd_funk_rec_remove(funk, fd_funk_rec_modify(funk, task_info->rec));
   }
 
   // Sanity-check LT Hash

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -3694,7 +3694,7 @@ fd_runtime_cleanup_incinerator( fd_exec_slot_ctx_t * slot_ctx ) {
   fd_funk_t * funk = slot_ctx->acc_mgr->funk;
   fd_funk_rec_t const * rec = fd_funk_rec_query( funk, slot_ctx->funk_txn, &id );
   if( rec )
-    fd_funk_rec_remove( funk, fd_funk_rec_modify( funk, rec ), 1 );
+    fd_funk_rec_remove( funk, fd_funk_rec_modify( funk, rec ));
 }
 
 void

--- a/src/flamenco/runtime/program/fd_bpf_program_util.c
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.c
@@ -53,7 +53,7 @@ fd_acc_mgr_cache_key( fd_pubkey_t const * pubkey ) {
   return id;
 }
 
-/* Similar to the below function, but gets the executable program content for the v4 loader. 
+/* Similar to the below function, but gets the executable program content for the v4 loader.
    Unlike the v3 loader, the programdata is stored in a single program account. The program must
    NOT be retracted to be added to the cache. */
 static int
@@ -62,7 +62,7 @@ fd_bpf_get_executable_program_content_for_v4_loader( fd_borrowed_account_t * pro
                                                      ulong                 * program_data_len ) {
   int err;
   fd_loader_v4_state_t state = {0};
-  
+
   /* Get the current loader v4 state. This implicitly also checks the dlen. */
   err = fd_loader_v4_get_state( program_acc, &state );
   if( FD_UNLIKELY( err ) ) {
@@ -73,7 +73,7 @@ fd_bpf_get_executable_program_content_for_v4_loader( fd_borrowed_account_t * pro
   if( FD_UNLIKELY( fd_loader_v4_status_is_retracted( &state ) ) ) {
     return -1;
   }
-  
+
   *program_data     = program_acc->const_data + LOADER_V4_PROGRAM_DATA_OFFSET;
   *program_data_len = program_acc->const_meta->dlen - LOADER_V4_PROGRAM_DATA_OFFSET;
   return 0;
@@ -224,7 +224,7 @@ fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t    * slot_ctx,
     if( FD_UNLIKELY( 0!=fd_sbpf_program_load( prog, program_data, program_data_len, syscalls, false ) ) ) {
       /* Remove pending funk record */
       FD_LOG_DEBUG(( "fd_sbpf_program_load() failed: %s", fd_sbpf_strerror() ));
-      fd_funk_rec_remove( funk, rec, 0 );
+      fd_funk_rec_remove( funk, rec );
       return -1;
     }
 
@@ -267,7 +267,7 @@ fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t    * slot_ctx,
     if( FD_UNLIKELY( res ) ) {
       /* Remove pending funk record */
       FD_LOG_DEBUG(( "fd_vm_validate() failed" ));
-      fd_funk_rec_remove( funk, rec, 0 );
+      fd_funk_rec_remove( funk, rec );
       return -1;
     }
 

--- a/src/funk/fd_funk_archive.c
+++ b/src/funk/fd_funk_archive.c
@@ -56,6 +56,7 @@ fd_funk_archive( fd_funk_t *  funk,
       ARCH_WRITE( rec->pair.key, sizeof(rec->pair.key) );
       ARCH_WRITE( &rec->part, sizeof(rec->part) );
       ARCH_WRITE( &rec->val_sz, sizeof(rec->val_sz) );
+      ARCH_WRITE( &rec->flags, sizeof(rec->flags) );
       if( rec->val_sz ) {
         ARCH_WRITE( fd_wksp_laddr_fast( wksp, rec->val_gaddr ), rec->val_sz );
       }
@@ -128,6 +129,7 @@ fd_funk_unarchive( fd_funk_t *  funk,
   fd_memset( &pair, 0, sizeof(pair) );
   uint part;
   uint val_sz;
+  ulong flags;
 
   for(;;) {
     ARCH_READ( &type, sizeof(type) );
@@ -138,6 +140,7 @@ fd_funk_unarchive( fd_funk_t *  funk,
       ARCH_READ( pair.key, sizeof(pair.key) );
       ARCH_READ( &part, sizeof(part) );
       ARCH_READ( &val_sz, sizeof(val_sz) );
+      ARCH_READ( &flags, sizeof(flags) );
 
       if( FD_UNLIKELY( fd_funk_rec_map_is_full( rec_map ) ) ) {
         FD_LOG_WARNING(( "archive %s has too many records to fit in given funk", filename ));
@@ -155,7 +158,7 @@ fd_funk_unarchive( fd_funk_t *  funk,
       rec->next_idx = FD_FUNK_REC_IDX_NULL;
       rec->txn_cidx = fd_funk_txn_cidx( FD_FUNK_TXN_IDX_NULL );
       rec->tag      = 0U;
-      rec->flags    = 0UL;
+      rec->flags    = flags;
 
       int first_born = fd_funk_rec_idx_is_null( rec_prev_idx );
       if( first_born ) funk->rec_head_idx               = rec_idx;

--- a/src/funk/test_funk_common.h
+++ b/src/funk/test_funk_common.h
@@ -140,8 +140,7 @@ rec_insert( funk_t * funk,
 
 void
 rec_remove( funk_t * funk,
-            rec_t *  rec,
-            int      erase );
+            rec_t *  rec );
 
 /* Mini funk API */
 

--- a/src/funk/test_funk_common.hpp
+++ b/src/funk/test_funk_common.hpp
@@ -170,7 +170,7 @@ struct fake_funk {
       auto key = rec->real_id();
       auto* rec2 = fd_funk_rec_query(_real, txn2, &key);
       assert(rec2 != NULL);
-      assert(fd_funk_rec_remove(_real, (fd_funk_rec_t *)rec2, 1) == FD_FUNK_SUCCESS);
+      assert(fd_funk_rec_remove(_real, (fd_funk_rec_t *)rec2) == FD_FUNK_SUCCESS);
 
       rec->_erased = true;
       rec->_data.clear();

--- a/src/funk/test_funk_part.c
+++ b/src/funk/test_funk_part.c
@@ -113,7 +113,7 @@ main( int     argc,
       fd_funk_rec_key_t * key = &recs[i];
       fd_funk_rec_t * rec = fd_funk_rec_write_prepare(funk, txn, key, 0, 0, NULL, NULL);
       if (rec && !(rec->flags & FD_FUNK_REC_FLAG_ERASE)) {
-        int err = fd_funk_rec_remove(funk, rec, 1);
+        int err = fd_funk_rec_remove(funk, rec);
         FD_TEST(!err);
       }
       break;

--- a/src/funk/test_funk_rec.c
+++ b/src/funk/test_funk_rec.c
@@ -128,24 +128,15 @@ main( int     argc,
       FD_TEST( !fd_funk_rec_modify( tst,  rec_map+rec_max      ) );
       FD_TEST( !fd_funk_rec_modify( tst,  (fd_funk_rec_t *)1UL ) );
 
-      FD_TEST( fd_funk_rec_remove( NULL, NULL,                  0 )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( NULL, (fd_funk_rec_t *)trec, 0 )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst,  NULL,                  0 )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst,  rec_map+rec_max,       0 )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst,  (fd_funk_rec_t *)1UL,  0 )==FD_FUNK_ERR_INVAL );
-
-      FD_TEST( fd_funk_rec_remove( NULL, NULL,                  1 )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( NULL, (fd_funk_rec_t *)trec, 1 )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst,  NULL,                  1 )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst,  rec_map+rec_max,       1 )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst,  (fd_funk_rec_t *)1UL,  1 )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( NULL, NULL                  )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( NULL, (fd_funk_rec_t *)trec )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( tst,  NULL                  )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( tst,  rec_map+rec_max       )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( tst,  (fd_funk_rec_t *)1UL  )==FD_FUNK_ERR_INVAL );
 
       if( trec ) {
         if( is_frozen ) {
-          FD_TEST( fd_funk_rec_remove( tst, (fd_funk_rec_t *)trec, 0 )==FD_FUNK_ERR_FROZEN );
-          FD_TEST( fd_funk_rec_remove( tst, (fd_funk_rec_t *)trec, 1 )==FD_FUNK_ERR_FROZEN );
-        } else {
-          FD_TEST( fd_funk_rec_remove( tst, (fd_funk_rec_t *)trec, 0 )==FD_FUNK_ERR_XID );
+          FD_TEST( fd_funk_rec_remove( tst, (fd_funk_rec_t *)trec )==FD_FUNK_ERR_FROZEN );
         }
       }
 
@@ -257,21 +248,14 @@ main( int     argc,
       FD_TEST( !fd_funk_rec_modify( tst,  rec_map+rec_max      ) );
       FD_TEST( !fd_funk_rec_modify( tst,  (fd_funk_rec_t *)1UL ) );
 
-      FD_TEST( fd_funk_rec_remove( NULL, NULL,                  0 )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( NULL, (fd_funk_rec_t *)trec, 0 )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst,  NULL,                  0 )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst,  rec_map+rec_max,       0 )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst,  (fd_funk_rec_t *)1UL,  0 )==FD_FUNK_ERR_INVAL );
-
-      FD_TEST( fd_funk_rec_remove( NULL, NULL,                  1 )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( NULL, (fd_funk_rec_t *)trec, 1 )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst,  NULL,                  1 )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst,  rec_map+rec_max,       1 )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst,  (fd_funk_rec_t *)1UL,  1 )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( NULL, NULL                  )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( NULL, (fd_funk_rec_t *)trec )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( tst,  NULL                  )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( tst,  rec_map+rec_max       )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( tst,  (fd_funk_rec_t *)1UL  )==FD_FUNK_ERR_INVAL );
 
       if( trec && ttxn_is_frozen ) {
-        FD_TEST( fd_funk_rec_remove( tst, (fd_funk_rec_t *)trec, 0 )==FD_FUNK_ERR_FROZEN );
-        FD_TEST( fd_funk_rec_remove( tst, (fd_funk_rec_t *)trec, 1 )==FD_FUNK_ERR_FROZEN );
+        FD_TEST( fd_funk_rec_remove( tst, (fd_funk_rec_t *)trec )==FD_FUNK_ERR_FROZEN );
       }
 
       int err;
@@ -414,9 +398,7 @@ main( int     argc,
       }
       ulong rkey = rrec->key;
 
-      int erase = (!rxid) | (int)(r & 1U); r >>= 1;
-
-      rec_remove( ref, rrec, erase );
+      rec_remove( ref, rrec );
 
       fd_funk_txn_t const * ttxn = rxid ? fd_funk_txn_query( xid_set( txid, rxid ), txn_map ) : NULL;
       fd_funk_rec_t const * trec = fd_funk_rec_query( tst, ttxn, key_set( tkey, rkey ) );
@@ -424,7 +406,7 @@ main( int     argc,
 
       fd_funk_rec_t * _trec = fd_funk_rec_modify( tst, trec );
       FD_TEST( trec==(fd_funk_rec_t const *)_trec );
-      FD_TEST( !fd_funk_rec_remove( tst, _trec, erase ) );
+      FD_TEST( !fd_funk_rec_remove( tst, _trec ) );
 
     } else if( op>=2 ) { /* Prepare 8x as publish and cancel combined */
 

--- a/src/funk/test_funk_val.c
+++ b/src/funk/test_funk_val.c
@@ -522,15 +522,13 @@ main( int     argc,
       }
       ulong rkey = rrec->key;
 
-      int erase = (!rxid) | (int)(r & 1U); r >>= 1;
-
-      rec_remove( ref, rrec, erase );
+      rec_remove( ref, rrec );
 
       fd_funk_txn_t const * ttxn = rxid ? fd_funk_txn_query( xid_set( txid, rxid ), txn_map ) : NULL;
       fd_funk_rec_t const * trec = fd_funk_rec_query( tst, ttxn, key_set( tkey, rkey ) );
 
       fd_funk_rec_t * _trec = fd_funk_rec_modify( tst, trec );
-      FD_TEST( !fd_funk_rec_remove( tst, _trec, erase ) );
+      FD_TEST( !fd_funk_rec_remove( tst, _trec ) );
 
     } else if( op>=2 ) { /* Prepare 8x as publish and cancel combined */
 


### PR DESCRIPTION
Now funk records when removed will not lose their data and will be published into the root of funk. However, they will contain the erase flag. This will dneote that they will be tombstones. This is needed for snapshotting as well as for debugging