### PR TITLE
Only enable 'unclean fd_log exit' for fdctl

### DIFF
--- a/config/base.mk
+++ b/config/base.mk
@@ -2,7 +2,7 @@ BASEDIR?=build
 
 OPT?=opt
 SHELL:=bash
-CPPFLAGS:=-isystem ./$(OPT)/include -DFD_LOG_UNCLEAN_EXIT=1 -DFD_HAS_BACKTRACE=0
+CPPFLAGS:=-isystem ./$(OPT)/include -DFD_HAS_BACKTRACE=0
 RUSTFLAGS:=-C force-frame-pointers=yes
 CC:=gcc
 CFLAGS=-std=c17 -fwrapv

--- a/src/app/fdctl/main1.c
+++ b/src/app/fdctl/main1.c
@@ -148,6 +148,7 @@ fdctl_boot( int *        pargc,
             char ***     pargv,
             config_t   * config,
             char const * log_path ) {
+  fd_log_enable_unclean_exit(); /* Don't call atexit handlers on FD_LOG_ERR */
   fd_log_level_core_set( 5 ); /* Don't dump core for FD_LOG_ERR during boot */
   fd_log_colorize_set( should_colorize() ); /* Colorize during boot until we can determine from config */
   fd_log_level_stderr_set( 2 ); /* Only NOTICE and above will be logged during boot until fd_log is initialized */

--- a/src/util/log/fd_log.h
+++ b/src/util/log/fd_log.h
@@ -582,6 +582,8 @@ void fd_log_level_stderr_set ( int level );
 void fd_log_level_flush_set  ( int level );
 void fd_log_level_core_set   ( int level );
 
+void fd_log_enable_unclean_exit( void );
+
 /* These functions are for fd_log internal use only. */
 
 void

--- a/src/waltz/quic/tests/fd_quic_test_helpers.c
+++ b/src/waltz/quic/tests/fd_quic_test_helpers.c
@@ -79,6 +79,11 @@ fd_quic_test_now( void * context ) {
   return (ulong)fd_log_wallclock();
 }
 
+static void
+flush_pcap( void ) {
+  fflush( fd_quic_test_pcap );
+}
+
 /* Test runtime */
 
 void
@@ -90,6 +95,7 @@ fd_quic_test_boot( int *    pargc,
     FD_LOG_NOTICE(( "Logging to --pcap %s", _pcap ));
     fd_quic_test_pcap = fopen( _pcap, "ab" );
     FD_TEST( fd_quic_test_pcap );
+    atexit( flush_pcap );
   }
 }
 


### PR DESCRIPTION
Fixes a bug where packets don't make it to pcap traces if a QUIC unit test fails