### PR TITLE
net: use gossip ip as net tile ip

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -523,13 +523,12 @@ fdctl_cfg_from_env( int *      pargc,
       FD_LOG_ERR(( "configuration specifies network interface `%s` which does not exist", config->tiles.net.interface ));
     uint iface_ip = listen_address( config->tiles.net.interface );
     if( FD_UNLIKELY( strcmp( config->gossip.host, "" ) ) ) {
-      uint gossip_ip_addr = iface_ip;
-      int  has_gossip_ip4 = 0;
+      int has_gossip_ip4 = 0;
       if( FD_UNLIKELY( strlen( config->gossip.host )<=15UL ) ) {
         /* Only sets gossip_ip_addr if it's a valid IPv4 address, otherwise assume it's a DNS name */
-        has_gossip_ip4 = fd_cstr_to_ip4_addr( config->gossip.host, &gossip_ip_addr );
+        has_gossip_ip4 = fd_cstr_to_ip4_addr( config->gossip.host, &iface_ip );
       }
-      if ( FD_UNLIKELY( !fd_ip4_addr_is_public( gossip_ip_addr ) && config->is_live_cluster && has_gossip_ip4 ) )
+      if ( FD_UNLIKELY( !fd_ip4_addr_is_public( iface_ip ) && config->is_live_cluster && has_gossip_ip4 ) )
         FD_LOG_ERR(( "Trying to use [gossip.host] " FD_IP4_ADDR_FMT " for listening to incoming "
                      "transactions, but it is part of a private network and will not be routable "
                      "for other Solana network nodes.",


### PR DESCRIPTION
When peers send packets, they set the destination to our gossip IP. If the gossip IP is different than the interface IP we determine using `listen_address` (for example, if the interface has multiple IPs which is the case for double zero), the incoming packets never gets routed to FD.