### PR TITLE
Clean up fd_ballet prototypes

### DIFF
--- a/src/ballet/aes/fd_aes_gcm_ref.c
+++ b/src/ballet/aes/fd_aes_gcm_ref.c
@@ -209,7 +209,7 @@ fd_gcm128_decrypt( fd_aes_gcm_ref_t * ctx,
   return 0;
 }
 
-void
+static void
 fd_gcm128_finish( fd_aes_gcm_ref_t * ctx ) {
 
   ulong alen = ctx->len.u[0] << 3;  // 176

--- a/src/ballet/bmtree/fd_wbmtree.c
+++ b/src/ballet/bmtree/fd_wbmtree.c
@@ -34,31 +34,6 @@ fd_wbmtree32_init      ( void * mem, ulong leaf_cnt )
   return mem;
 }
 
-fd_wbmtree32_t*
-fd_wbmtree32_join      ( void * mem )
-{
-  if( FD_UNLIKELY( !mem ) ) {
-    FD_LOG_WARNING(( "NULL mem" ));
-    return NULL;
-  }
-
-  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)mem, fd_wbmtree32_align() ) ) ) {
-    FD_LOG_WARNING(( "misaligned mem" ));
-    return NULL;
-  }
-  fd_wbmtree32_t* hdr = (fd_wbmtree32_t*) mem;
-  return hdr;
-}
-
-void *
-fd_wbmtree32_leave      ( fd_wbmtree32_t* hdr ) {
-  if( FD_UNLIKELY( !hdr ) ) {
-    FD_LOG_WARNING(( "NULL mem" ));
-    return NULL;
-  }
-  return (void *) hdr;
-}
-
 void
 fd_wbmtree32_append    ( fd_wbmtree32_t * bmt, fd_wbmtree32_leaf_t const * leaf, ulong leaf_cnt, uchar *mbuf  )
 {
@@ -114,21 +89,6 @@ fd_wbmtree32_fini      ( fd_wbmtree32_t * bmt)
   }
 
   return &this[0].hash[1];
-}
-
-void *
-fd_wbmtree32_delete( void * shblock ) {
-  if( FD_UNLIKELY( !shblock ) ) {
-    FD_LOG_WARNING(( "NULL shblock" ));
-    return NULL;
-  }
-
-  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shblock, fd_wbmtree32_align() ) ) ) {
-    FD_LOG_WARNING(( "misaligned shblock" ));
-    return NULL;
-  }
-
-  return shblock;
 }
 
 ulong            fd_wbmtree32_align     ( void ) { return alignof(fd_wbmtree32_t); }

--- a/src/ballet/bmtree/fd_wbmtree.h
+++ b/src/ballet/bmtree/fd_wbmtree.h
@@ -39,7 +39,6 @@ FD_PROTOTYPES_BEGIN
 ulong            fd_wbmtree32_align     ( void );
 ulong            fd_wbmtree32_footprint ( ulong leaf_cnt );
 fd_wbmtree32_t*  fd_wbmtree32_init      ( void * mem, ulong leaf_cnt );
-fd_wbmtree32_t*  fd_wbmtree32_join      ( void * mem );
 void             fd_wbmtree32_append    ( fd_wbmtree32_t * bmt, fd_wbmtree32_leaf_t const * leaf, ulong leaf_cnt, uchar *mbuf );
 uchar *          fd_wbmtree32_fini      ( fd_wbmtree32_t * bmt);
 

--- a/src/ballet/ed25519/fd_curve25519.h
+++ b/src/ballet/ed25519/fd_curve25519.h
@@ -76,6 +76,10 @@ fd_ed25519_point_t *
 fd_ed25519_point_neg( fd_ed25519_point_t *       r,
                       fd_ed25519_point_t const * a );
 
+fd_ed25519_point_t *
+fd_ed25519_point_dbl( fd_ed25519_point_t *       r,
+                      fd_ed25519_point_t const * a );
+
 /* fd_ed25519_point_is_zero returns 1 if a == 0 (point at infinity), 0 otherwise. */
 int
 fd_ed25519_point_is_zero( fd_ed25519_point_t const * a );

--- a/src/ballet/http/fd_http_server.c
+++ b/src/ballet/http/fd_http_server.c
@@ -1174,7 +1174,7 @@ fd_http_server_poll( fd_http_server_t * http ) {
   return 1;
 }
 
-void
+static void
 fd_http_server_evict_until( fd_http_server_t * http,
                             ulong              off ) {
   conn_treap_fwd_iter_t next;

--- a/src/ballet/sbpf/fd_sbpf_loader.c
+++ b/src/ballet/sbpf/fd_sbpf_loader.c
@@ -19,7 +19,7 @@ static FD_TL char fd_sbpf_errbuf[ FD_SBPF_ERRBUF_SZ ] = {0};
 /* fd_sbpf_loader_seterr remembers the error ID and line number of the
    current file at which the last error occurred. */
 
-__attribute__((cold,noinline)) int
+__attribute__((cold,noinline)) static int
 fd_sbpf_loader_seterr( int err,
                        int srcln ) {
   ldr_errno     = err;
@@ -237,7 +237,7 @@ fd_sbpf_load_phdrs( fd_sbpf_elf_info_t *  info,
 }
 
 /* FD_SBPF_SECTION_NAME_SZ_MAX is the maximum length of a symbol name cstr
-   including zero terminator. 
+   including zero terminator.
    https://github.com/solana-labs/rbpf/blob/c168a8715da668a71584ea46696d85f25c8918f6/src/elf_parser/mod.rs#L12 */
 #define FD_SBPF_SECTION_NAME_SZ_MAX (16UL)
 
@@ -655,7 +655,7 @@ struct fd_sbpf_loader {
 typedef struct fd_sbpf_loader fd_sbpf_loader_t;
 
 /* FD_SBPF_SYM_NAME_SZ_MAX is the maximum length of a symbol name cstr
-   including zero terminator. 
+   including zero terminator.
    https://github.com/solana-labs/rbpf/blob/c168a8715da668a71584ea46696d85f25c8918f6/src/elf_parser/mod.rs#L13 */
 #define FD_SBPF_SYM_NAME_SZ_MAX (64UL)
 
@@ -1102,7 +1102,7 @@ fd_sbpf_hash_calls( fd_sbpf_loader_t *    loader,
     /* Check for collision with syscall ID
        https://github.com/solana-labs/rbpf/blob/57139e9e1fca4f01155f7d99bc55cdcc25b0bc04/src/program.rs#L142-L146 */
     REQUIRE( !fd_sbpf_syscalls_query( loader->syscalls, pc_hash, NULL ) );
-    
+
     FD_STORE( uint, ptr+4UL, pc_hash );
   }
 

--- a/src/flamenco/runtime/program/fd_vote_program.c
+++ b/src/flamenco/runtime/program/fd_vote_program.c
@@ -54,7 +54,7 @@
 #define ACCOUNTS_MAX 4 /* Vote instructions take in at most 4 accounts */
 
 #define DEFAULT_COMPUTE_UNITS 2100UL
-extern fd_flamenco_yaml_t * fd_get_types_yaml(void);
+
 /**********************************************************************/
 /* size_of                                                            */
 /**********************************************************************/

--- a/src/util/sandbox/fd_sandbox.c
+++ b/src/util/sandbox/fd_sandbox.c
@@ -1,5 +1,5 @@
 #define _GNU_SOURCE
-#include "fd_sandbox.h"
+#include "fd_sandbox_private.h"
 
 #include "../cstr/fd_cstr.h"
 #include "../log/fd_log.h"

--- a/src/util/scratch/fd_scratch.c
+++ b/src/util/scratch/fd_scratch.c
@@ -16,7 +16,7 @@ FD_TL ulong fd_alloca_check_private_sz;
 
 /* fd_valloc virtual function table */
 
-void *
+static void *
 fd_scratch_malloc_virtual( void * _self,
                            ulong  align,
                            ulong  sz ) {
@@ -24,7 +24,7 @@ fd_scratch_malloc_virtual( void * _self,
   return fd_scratch_alloc( align, sz );
 }
 
-void
+static void
 fd_scratch_free_virtual( void * _self,
                          void * _addr ) {
   (void)_self; (void)_addr;

--- a/src/util/spad/fd_spad.c
+++ b/src/util/spad/fd_spad.c
@@ -112,7 +112,7 @@ fd_spad_publish_debug( fd_spad_t * spad,
 }
 
 /* fd_valloc virtual function table for spad */
-void *
+static void *
 fd_spad_valloc_malloc( void * _self,
                                ulong  align,
                                ulong  sz ) {
@@ -124,7 +124,7 @@ fd_spad_valloc_malloc( void * _self,
   return rv;
 }
 
-void
+static void
 fd_spad_valloc_free( void * _self,
                              void * _addr ) {
   (void)_self; (void)_addr;

--- a/src/util/textstream/fd_textstream.c
+++ b/src/util/textstream/fd_textstream.c
@@ -45,7 +45,8 @@ void fd_textstream_clear( fd_textstream_t * strm ) {
   strm->last_blk = blk;
 }
 
-fd_textstream_blk_t * fd_textstream_new_blk( fd_textstream_t * strm ) {
+static fd_textstream_blk_t *
+fd_textstream_new_blk( fd_textstream_t * strm ) {
   fd_textstream_blk_t * blk = (fd_textstream_blk_t *)
     fd_valloc_malloc(strm->valloc, alignof(fd_textstream_blk_t), sizeof(fd_textstream_blk_t) + strm->alloc_sz);
   if ( blk == NULL )

--- a/src/waltz/xdp/fd_xsk_aio.c
+++ b/src/waltz/xdp/fd_xsk_aio.c
@@ -295,7 +295,7 @@ fd_xsk_aio_service( fd_xsk_aio_t * xsk_aio ) {
 }
 
 
-void
+static void
 fd_xsk_aio_tx_complete( fd_xsk_aio_t * xsk_aio ) {
   ulong tx_completed = fd_xsk_tx_complete( xsk_aio->xsk,
                                            xsk_aio->tx_stack       + xsk_aio->tx_top,


### PR DESCRIPTION
- Add missing 'static' modifiers to internal functions
- Remove unused functions
- Add missing prototypes for global functions
