### PR TITLE
quic: simplify encryption key indexing

### DIFF
--- a/src/app/fddev/quic_trace/fd_quic_trace_rx_tile.c
+++ b/src/app/fddev/quic_trace/fd_quic_trace_rx_tile.c
@@ -92,9 +92,10 @@ fd_quic_trace_initial( void *  _ctx FD_FN_UNUSED,
   if( !keys ) {
     /* Set secrets->initial_secret */
     fd_quic_crypto_secrets_t secrets[1];
-    fd_quic_gen_initial_secret(
+    fd_quic_gen_initial_secrets(
         secrets,
-        initial->dst_conn_id, initial->dst_conn_id_len );
+        initial->dst_conn_id, initial->dst_conn_id_len,
+        /* is_client */ 0 );
 
     /* Derive secrets->secret[0][0] */
     fd_tls_hkdf_expand_label(

--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -19,8 +19,6 @@
 #include "templ/fd_quic_parse_util.h"
 #include "tls/fd_quic_tls.h"
 
-#include <assert.h>
-#include <string.h>
 #include <fcntl.h>   /* for keylog open(2)  */
 #include <unistd.h>  /* for keylog close(2) */
 
@@ -1289,28 +1287,24 @@ fd_quic_abandon_enc_level( fd_quic_conn_t * conn,
   }
 }
 
-void
+static void
 fd_quic_gen_initial_secret_and_keys(
     fd_quic_conn_t *          conn,
-    fd_quic_conn_id_t const * dst_conn_id ) {
+    fd_quic_conn_id_t const * dst_conn_id,
+    int                       is_server ) {
 
-  fd_quic_gen_initial_secret(
+  fd_quic_gen_initial_secrets(
       &conn->secrets,
-      dst_conn_id->conn_id, dst_conn_id->sz );
+      dst_conn_id->conn_id, dst_conn_id->sz,
+      is_server );
 
-  fd_quic_gen_secrets(
-      &conn->secrets,
-      fd_quic_enc_level_initial_id ); /* generate initial secrets */
-
-  /* gen initial keys */
   fd_quic_gen_keys(
       &conn->keys[ fd_quic_enc_level_initial_id ][ 0 ],
       conn->secrets.secret[ fd_quic_enc_level_initial_id ][ 0 ] );
 
-  /* gen initial keys */
   fd_quic_gen_keys(
       &conn->keys[ fd_quic_enc_level_initial_id ][ 1 ],
-      conn->secrets.secret   [ fd_quic_enc_level_initial_id ][ 1 ] );
+      conn->secrets.secret[ fd_quic_enc_level_initial_id ][ 1 ] );
 }
 
 static ulong
@@ -1622,7 +1616,7 @@ fd_quic_handle_v1_initial( fd_quic_t *               quic,
       conn->tls_hs = tls_hs;
       quic->metrics.hs_created_cnt++;
 
-      fd_quic_gen_initial_secret_and_keys( conn, conn_id );
+      fd_quic_gen_initial_secret_and_keys( conn, conn_id, /* is_server */ 1 );
     } else {
       /* connection may have been torn down */
       FD_DEBUG( FD_LOG_DEBUG(( "unknown connection ID" )); )
@@ -1641,12 +1635,10 @@ fd_quic_handle_v1_initial( fd_quic_t *               quic,
 
 # if !FD_QUIC_DISABLE_CRYPTO
   /* this decrypts the header */
-  int server = conn->server;
-
   if( FD_UNLIKELY(
         fd_quic_crypto_decrypt_hdr( cur_ptr, cur_sz,
                                     pn_offset,
-                                    &conn->keys[0][!server] ) != FD_QUIC_SUCCESS ) ) {
+                                    &conn->keys[0][0] ) != FD_QUIC_SUCCESS ) ) {
     /* As this is an INITIAL packet, change the status to DEAD, and allow
         it to be reaped */
     FD_DEBUG( FD_LOG_DEBUG(( "fd_quic_crypto_decrypt_hdr failed" )) );
@@ -1672,7 +1664,7 @@ fd_quic_handle_v1_initial( fd_quic_t *               quic,
         fd_quic_crypto_decrypt( cur_ptr, tot_sz,
                                 pn_offset,
                                 pkt_number,
-                                &conn->keys[0][!server] ) != FD_QUIC_SUCCESS ) ) {
+                                &conn->keys[0][0] ) != FD_QUIC_SUCCESS ) ) {
     FD_DEBUG( FD_LOG_DEBUG(( "fd_quic_crypto_decrypt failed" )) );
     quic->metrics.pkt_decrypt_fail_cnt++;
     return FD_QUIC_PARSE_FAIL;
@@ -1793,12 +1785,10 @@ fd_quic_handle_v1_handshake(
 
 # if !FD_QUIC_DISABLE_CRYPTO
   /* this decrypts the header */
-  int server = conn->server;
-
   if( FD_UNLIKELY(
         fd_quic_crypto_decrypt_hdr( cur_ptr, cur_sz,
                                     pn_offset,
-                                    &conn->keys[2][!server] ) != FD_QUIC_SUCCESS ) ) {
+                                    &conn->keys[2][0] ) != FD_QUIC_SUCCESS ) ) {
     quic->metrics.pkt_decrypt_fail_cnt++;
     return FD_QUIC_PARSE_FAIL;
   }
@@ -1823,7 +1813,7 @@ fd_quic_handle_v1_handshake(
         fd_quic_crypto_decrypt( cur_ptr, tot_sz,
                                 pn_offset,
                                 pkt_number,
-                                &conn->keys[2][!server] ) != FD_QUIC_SUCCESS ) ) {
+                                &conn->keys[2][0] ) != FD_QUIC_SUCCESS ) ) {
     /* remove connection from map, and insert into free list */
     FD_DEBUG( FD_LOG_DEBUG(( "fd_quic_crypto_decrypt failed" )) );
     quic->metrics.pkt_decrypt_fail_cnt++;
@@ -1893,7 +1883,7 @@ fd_quic_handle_v1_retry(
 ) {
   (void)pkt;
 
-  if( FD_UNLIKELY ( quic->config.role == FD_QUIC_ROLE_SERVER ) ) {
+  if( FD_UNLIKELY( quic->config.role == FD_QUIC_ROLE_SERVER ) ) {
     if( FD_UNLIKELY( conn ) ) { /* likely a misbehaving client w/o a conn */
       fd_quic_conn_error( conn, FD_QUIC_CONN_REASON_PROTOCOL_VIOLATION, __LINE__ );
     }
@@ -1927,7 +1917,7 @@ fd_quic_handle_v1_retry(
   conn->hs_sent_bytes[fd_quic_enc_level_initial_id] = 0;
 
   /* Need to regenerate keys using the retry source connection id */
-  fd_quic_gen_initial_secret_and_keys( conn, &conn->retry_src_conn_id );
+  fd_quic_gen_initial_secret_and_keys( conn, &conn->retry_src_conn_id, /* is_server */ 0 );
 
   /* The token length is the remaining bytes in the retry packet after subtracting known fields. */
   conn->token_len = retry_token_sz;
@@ -2047,12 +2037,11 @@ fd_quic_handle_v1_one_rtt( fd_quic_t *      quic,
     return FD_QUIC_PARSE_FAIL;
   }
 
-  int server = conn->server;
 # if !FD_QUIC_DISABLE_CRYPTO
   if( FD_UNLIKELY(
         fd_quic_crypto_decrypt_hdr( cur_ptr, tot_sz,
                                     pn_offset,
-                                    &conn->keys[3][!server] ) != FD_QUIC_SUCCESS ) ) {
+                                    &conn->keys[3][0] ) != FD_QUIC_SUCCESS ) ) {
     FD_DEBUG( FD_LOG_DEBUG(( "fd_quic_crypto_decrypt_hdr failed" )) );
     quic->metrics.pkt_decrypt_fail_cnt++;
     return FD_QUIC_PARSE_FAIL;
@@ -2075,7 +2064,7 @@ fd_quic_handle_v1_one_rtt( fd_quic_t *      quic,
 # if !FD_QUIC_DISABLE_CRYPTO
   /* If the key phase bit flips, decrypt with the new pair of keys
       instead.  Note that the key phase bit is untrusted at this point. */
-  fd_quic_crypto_keys_t * keys = current_key_phase ? &conn->keys[3][!server] : &conn->new_keys[!server];
+  fd_quic_crypto_keys_t * keys = current_key_phase ? &conn->keys[3][0] : &conn->new_keys[0];
 
   /* this decrypts the header and payload */
   if( FD_UNLIKELY(
@@ -2533,7 +2522,6 @@ fd_quic_tls_cb_secret( fd_quic_tls_hs_t *           hs,
 
   fd_quic_conn_t *  conn   = (fd_quic_conn_t*)context;
   fd_quic_t *       quic   = conn->quic;
-  int               server = conn->server;
 
   /* look up suite */
   /* set secrets */
@@ -2543,8 +2531,8 @@ fd_quic_tls_cb_secret( fd_quic_tls_hs_t *           hs,
 
   fd_quic_crypto_secrets_t * crypto_secret = &conn->secrets;
 
-  memcpy( crypto_secret->secret[enc_level][!server], secret->read_secret,  FD_QUIC_SECRET_SZ );
-  memcpy( crypto_secret->secret[enc_level][ server], secret->write_secret, FD_QUIC_SECRET_SZ );
+  memcpy( crypto_secret->secret[enc_level][0], secret->read_secret,  FD_QUIC_SECRET_SZ );
+  memcpy( crypto_secret->secret[enc_level][1], secret->write_secret, FD_QUIC_SECRET_SZ );
 
   conn->keys_avail = fd_uint_set_bit( conn->keys_avail, (int)enc_level );
 
@@ -3788,11 +3776,8 @@ fd_quic_conn_tx( fd_quic_t *      quic,
     ulong   cipher_text_sz = conn->tx_sz;
     ulong   frames_sz      = (ulong)( payload_ptr - frame_start ); /* including padding */
 
-    int server = conn->server;
-
-    fd_quic_crypto_keys_t * hp_keys  = &conn->keys[enc_level][server];
-    fd_quic_crypto_keys_t * pkt_keys = key_phase_upd ? &conn->new_keys[server]
-                                                     : &conn->keys[enc_level][server];
+    fd_quic_crypto_keys_t * hp_keys  = &conn->keys[enc_level][1];
+    fd_quic_crypto_keys_t * pkt_keys = key_phase_upd ? &conn->new_keys[1] : &conn->keys[enc_level][1];
 
     if( FD_UNLIKELY( fd_quic_crypto_encrypt( conn->tx_ptr, &cipher_text_sz, hdr_ptr, hdr_sz,
           frame_start, frames_sz, pkt_keys, hp_keys, pkt_number ) != FD_QUIC_SUCCESS ) ) {
@@ -4203,7 +4188,7 @@ fd_quic_connect( fd_quic_t *  quic,
   quic->metrics.hs_created_cnt++;
   conn->tls_hs = tls_hs;
 
-  fd_quic_gen_initial_secret_and_keys( conn, &peer_conn_id );
+  fd_quic_gen_initial_secret_and_keys( conn, &peer_conn_id, /* is_server */ 0 );
 
   fd_quic_svc_schedule( state, conn, FD_QUIC_SVC_INSTANT );
 

--- a/src/waltz/quic/fd_quic_conn.h
+++ b/src/waltz/quic/fd_quic_conn.h
@@ -123,11 +123,12 @@ struct fd_quic_conn {
   ulong hs_ackd_bytes[4];
 
   /* Keys for header and packet protection
-       secrets:    Contains 'master' secrets used to derive other keys
-       keys:       Current pair of keys for each encryption level
-       new_keys:   App keys to use for the next key update.  Once app
-                   keys are available these are always kept up-to-date
-       keys_avail: Bit set of available keys, LSB indexed by enc level */
+       secrets:     Contains 'master' secrets used to derive other keys
+       keys[e][d]:  Current pair of keys for each encryption level (e)
+                    and direction (d==0 is incoming, d==1 is outgoing)
+       new_keys[e]: App keys to use for the next key update.  Once app
+                    keys are available these are always kept up-to-date
+       keys_avail:  Bit set of available keys, LSB indexed by enc level */
   fd_quic_crypto_secrets_t secrets;
   fd_quic_crypto_keys_t    keys[FD_QUIC_NUM_ENC_LEVELS][2];
   fd_quic_crypto_keys_t    new_keys[2];

--- a/src/waltz/quic/fd_quic_pcap_main.c
+++ b/src/waltz/quic/fd_quic_pcap_main.c
@@ -295,8 +295,7 @@ quic_pcap_iter_deliver_initial(
   data_sz     = tot_sz;
 
   fd_quic_crypto_secrets_t secrets[1];
-  fd_quic_gen_initial_secret( secrets, initial->dst_conn_id, initial->dst_conn_id_len );
-  fd_quic_gen_secrets( secrets, fd_quic_enc_level_initial_id );
+  fd_quic_gen_initial_secrets( secrets, initial->dst_conn_id, initial->dst_conn_id_len, /* is_server */ 1 );
 
   fd_quic_crypto_keys_t keys[1];
   fd_quic_gen_keys( keys, secrets->secret[ fd_quic_enc_level_initial_id ][ 0 ] );

--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -7,7 +7,6 @@
 #include "fd_quic_stream.h"
 #include "log/fd_quic_log_tx.h"
 #include "fd_quic_pkt_meta.h"
-#include "crypto/fd_quic_crypto_suites.h"
 #include "tls/fd_quic_tls.h"
 #include "fd_quic_stream_pool.h"
 

--- a/src/waltz/quic/tests/fd_quic_sandbox.c
+++ b/src/waltz/quic/tests/fd_quic_sandbox.c
@@ -400,7 +400,7 @@ fd_quic_sandbox_send_ping_pkt( fd_quic_sandbox_t * sandbox,
   pkt_buf[13] = 0x01;  /* PING frame */
   memset( pkt_buf+14, 0, 18UL );
 
-  fd_quic_crypto_keys_t * keys = &conn->keys[fd_quic_enc_level_appdata_id][!conn->server];
+  fd_quic_crypto_keys_t * keys = &conn->keys[fd_quic_enc_level_appdata_id][0];
   ulong out_sz = 48UL;
   int crypt_res = fd_quic_crypto_encrypt( pkt_buf, &out_sz, pkt_buf, 13UL, pkt_buf+13, 19UL, keys, keys, pktnum );
   FD_TEST( crypt_res==FD_QUIC_SUCCESS );

--- a/src/waltz/quic/tests/test_quic_crypto.c
+++ b/src/waltz/quic/tests/test_quic_crypto.c
@@ -1,10 +1,3 @@
-#include <stdio.h>
-#include <unistd.h>
-#include <string.h>
-#include <signal.h>
-#include <arpa/inet.h>
-
-#include "../fd_quic.h"
 #include "../crypto/fd_quic_crypto_suites.h"
 
 FD_IMPORT_BINARY( test_client_initial,   "src/waltz/quic/fixtures/rfc9001-client-initial-payload.bin"   );
@@ -123,13 +116,12 @@ main( int     argc,
   fd_quic_crypto_secrets_t secrets;
 
   /* initial salt is based on quic version */
-  fd_quic_gen_initial_secret(
+  fd_quic_gen_initial_secrets(
       &secrets,
-      test_dst_conn_id, sizeof( test_dst_conn_id ) );
+      test_dst_conn_id, sizeof( test_dst_conn_id ),
+      /* is_server */ 1 );
   FD_TEST( 0==memcmp( secrets.initial_secret, expected_initial_secret, sizeof( expected_initial_secret ) ) );
   FD_LOG_INFO(( "fd_quic_gen_initial_secret: PASSED" ));
-
-  fd_quic_gen_secrets( &secrets, fd_quic_enc_level_initial_id );
 
   /* initial secrets are derived from the initial client destination connection id
      both client and server initial secrets are derived here */

--- a/verification/stubs/fd_quic_crypto.c
+++ b/verification/stubs/fd_quic_crypto.c
@@ -36,23 +36,11 @@ fd_quic_gen_keys(
 }
 
 int
-fd_quic_gen_secrets(
-    fd_quic_crypto_secrets_t * secrets,
-    uint                       enc_level,
-    fd_hmac_fn_t               hmac_fn,
-    ulong                      hash_sz ) {
-  assert( hmac_fn==fd_hmac_sha256 );
-  assert( hash_sz==32UL );
-  assert( enc_level<FD_QUIC_NUM_ENC_LEVELS );
-  __CPROVER_havoc_slice( secrets->secret, 32UL );
-  return FD_QUIC_SUCCESS;
-}
-
-int
-fd_quic_gen_initial_secret(
+fd_quic_gen_initial_secrets(
     fd_quic_crypto_secrets_t * secrets,
     uchar const *              conn_id,
-    ulong                      conn_id_sz ) {
+    ulong                      conn_id_sz,
+    int                        is_server ) {
   __CPROVER_r_ok( conn_id,      conn_id_sz      );
   __CPROVER_havoc_slice( secrets->secret, 32UL );
   int res;  __CPROVER_assume( res==FD_QUIC_SUCCESS || res==FD_QUIC_FAILED );


### PR DESCRIPTION
Indexes QUIC keys by (incoming, outgoing) instead of (client, server).
