### PR TITLE
flamenco, blockstore: deserialize per-batch and allow trailing bytes

### DIFF
--- a/src/app/ledger/main.c
+++ b/src/app/ledger/main.c
@@ -235,21 +235,16 @@ runtime_replay( fd_ledger_args_t * ledger_args ) {
 
     fd_blockstore_start_read( blockstore );
     fd_block_t * blk = fd_blockstore_block_query( blockstore, slot );
+    fd_blockstore_end_read( blockstore );
     if( blk == NULL ) {
       FD_LOG_WARNING(( "failed to read slot %lu", slot ));
-      fd_blockstore_end_read( blockstore );
       continue;
     }
-
-    uchar * val = fd_blockstore_block_data_laddr( blockstore, blk );
-    ulong   sz  = blk->data_sz;
-    fd_blockstore_end_read( blockstore );
+    ledger_args->slot_ctx->block = blk;
 
     ulong blk_txn_cnt = 0;
     FD_TEST( fd_runtime_block_eval_tpool( ledger_args->slot_ctx,
                                           ledger_args->capture_ctx,
-                                          val,
-                                          sz,
                                           ledger_args->tpool,
                                           1,
                                           &blk_txn_cnt,

--- a/src/ballet/shred/fd_deshredder.c
+++ b/src/ballet/shred/fd_deshredder.c
@@ -9,10 +9,9 @@ fd_deshredder_init( fd_deshredder_t *   shredder,
                     ulong               shred_cnt ) {
   shredder->shreds    = shreds;
   shredder->shred_cnt = (uint)shred_cnt;
-  shredder->data_off  = 0U;
   shredder->buf       = buf;
   shredder->bufsz     = bufsz;
-  shredder->result    = -FD_SHRED_EPIPE;
+  shredder->result    = FD_SHRED_EPIPE;
 }
 
 long
@@ -23,8 +22,10 @@ fd_deshredder_next( fd_deshredder_t * const shredder ) {
   /* Consume shreds, appending each shred buffer into entry buffer */
   for(;;) {
     /* Sanity check: No unexpected "end of shred batch" */
-    if( FD_UNLIKELY( shredder->shred_cnt == 0U ) )
+    if( FD_UNLIKELY( shredder->shred_cnt == 0U ) ) {
+      shredder->result = FD_SHRED_EPIPE;
       break;
+    }
 
     fd_shred_t const * shred = *shredder->shreds;
 

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -304,8 +304,9 @@ fd_runtime_block_verify_tpool( fd_block_info_t const * block_info,
                                fd_tpool_t * tpool );
 
 int
-fd_runtime_block_prepare( void const * buf,
-                          ulong buf_sz,
+fd_runtime_block_prepare( fd_blockstore_t const * blockstore,
+                          fd_block_t const * block,
+                          ulong slot,
                           fd_valloc_t valloc,
                           fd_block_info_t * out_block_info );
 
@@ -316,8 +317,6 @@ fd_runtime_block_collect_txns( fd_block_info_t const * block_info,
 int
 fd_runtime_block_eval_tpool( fd_exec_slot_ctx_t * slot_ctx,
                              fd_capture_ctx_t * capture_ctx,
-                             const void * block,
-                             ulong blocklen,
                              fd_tpool_t * tpool,
                              ulong scheduler,
                              ulong * txn_cnt,

--- a/src/flamenco/runtime/tests/run_ledger_tests_all.txt
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.txt
@@ -79,3 +79,5 @@ src/flamenco/runtime/tests/run_ledger_test.sh -l enable-get-epoch-stake-syscall 
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257181032 -s snapshot-257181030-BiZi1ye6MeW8iq2xUBDrYYPSNuBVrXvzsHjPWvQ8ZytE.tar.zst -p 50 -y 16 -m 5000000 -e 257181035 -c 1.19.0
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257047660 -s snapshot-257047658-Cp4XkpXueDWep78NCTQHCWmG5VszMBjKbGdAoXYLHBfh.tar.zst -p 50 -y 16 -m 5000000 -e 257047662 -c 1.19.0
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257047659 -s snapshot-257047655-5r7etGHT6fJ5edRijJMtYr8xYJpE98ECWF8n7CCZUhDN.tar.zst -p 50 -y 16 -m 5000000 -e 257047660 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-308445707 -s snapshot-308445706-EUsKyaEYAN9VZDSAeBhFET9sdTicGCsghwEF1y1BhTvU.tar.zst -p 50 -y 16 -m 5000000 -e 308445711 -c 2.0.18
+src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-307395181 -s snapshot-307395180-D41gdV5niSbDdwsfb8381krY5pDK4oGeHeS2V1A8ttFr.tar.zst -p 50 -y 16 -m 5000000 -e 307395190 -c 2.1.1


### PR DESCRIPTION
Agave has this notion of a batch of data shreds.  The presence of one of the COMPLETE flags in a data shred marks the end of a batch. Moreover, bincode deserialization of microblocks is performed on a per-batch basis.  Precisely a single array of microblocks is expected to be deserialized from a batch.  Trailing bytes in each batch are ignored by default.

Block parsers in both the runtime and the blockstore lack the notion of a batch, and consequently do not properly handle blocks with trailing bytes, such as
https://explorer.solana.com/block/308445708
which has 7335 trailing bytes in the last batch.