### PR TITLE
quic: fix hs_data_empty cache invalidation bug

### DIFF
--- a/contrib/quic/go_compat/go.mod
+++ b/contrib/quic/go_compat/go.mod
@@ -1,5 +1,6 @@
 module github.com/firedancer-io/firedancer/contrib/quic/go_compat
 
+// Set this to Go 1.23 to enable post-quantum key exchange
 go 1.22
 
 require (

--- a/contrib/quic/go_compat/main.go
+++ b/contrib/quic/go_compat/main.go
@@ -273,6 +273,7 @@ func serverTest(fdQuic *C.fd_quic_t) {
 	defer cancel()
 
 	C.fd_quic_config_anonymous(fdQuic, C.FD_QUIC_ROLE_SERVER)
+	fdQuic.config.retry = 1
 	fdQuic.config.net.ip_addr = 0x0100007f
 	fdQuic.config.net.listen_udp_port = 8000
 	C.fd_quic_init(fdQuic)
@@ -365,8 +366,8 @@ func main() {
 	}
 
 	quic_limits := C.fd_quic_limits_t{
-		conn_cnt:         1,
-		handshake_cnt:    1,
+		conn_cnt:         4,
+		handshake_cnt:    4,
 		conn_id_cnt:      4,
 		stream_id_cnt:    64,
 		inflight_pkt_cnt: 64,

--- a/src/waltz/quic/fd_quic_conn.h
+++ b/src/waltz/quic/fd_quic_conn.h
@@ -111,7 +111,6 @@ struct fd_quic_conn {
   uint               handshake_complete  : 1; /* have we completed a successful handshake? */
   uint               handshake_done_send : 1; /* do we need to send handshake-done to peer? */
   uint               handshake_done_ackd : 1; /* was handshake_done ack'ed? */
-  uint               hs_data_empty       : 1; /* has all hs_data been consumed? */
   fd_quic_tls_hs_t * tls_hs;
 
   /* amount of handshake data already sent from head of queue */

--- a/src/waltz/quic/tests/fd_quic_sandbox.c
+++ b/src/waltz/quic/tests/fd_quic_sandbox.c
@@ -303,7 +303,6 @@ fd_quic_sandbox_new_conn_established( fd_quic_sandbox_t * sandbox,
 
   /* Mock a completed handshake */
   conn->handshake_complete = 1;
-  conn->hs_data_empty      = 1;
   conn->peer_enc_level     = fd_quic_enc_level_appdata_id;
   conn->keys_avail         = 1U<<fd_quic_enc_level_appdata_id;
 

--- a/src/waltz/quic/tests/test_quic_tls_hs.c
+++ b/src/waltz/quic/tests/test_quic_tls_hs.c
@@ -16,7 +16,6 @@ static uchar const test_tp[] =
 typedef struct my_quic_tls my_quic_tls_t;
 struct my_quic_tls {
   int is_server;
-  int is_flush;
   int is_hs_complete;
 
   int state;

--- a/src/waltz/quic/tls/fd_quic_tls.c
+++ b/src/waltz/quic/tls/fd_quic_tls.c
@@ -156,7 +156,6 @@ fd_quic_tls_hs_new( fd_quic_tls_hs_t * self,
   // set properties on self
   self->quic_tls  = quic_tls;
   self->is_server = is_server;
-  self->is_flush  = 0;
   self->context   = context;
 
   /* initialize handshake data */
@@ -266,7 +265,7 @@ fd_quic_tls_sendmsg( void const * handshake,
                      void const * data,
                      ulong        data_sz,
                      uint         enc_level,
-                     int          flush ) {
+                     int          flush FD_PARAM_UNUSED ) {
 
   uint buf_sz = FD_QUIC_TLS_HS_DATA_SZ;
   if( data_sz > buf_sz ) {
@@ -276,7 +275,6 @@ fd_quic_tls_sendmsg( void const * handshake,
   /* Safe because the fd_tls_estate_{srv,cli}_t object is the first
      element of fd_quic_tls_hs_t */
   fd_quic_tls_hs_t * hs = (fd_quic_tls_hs_t *)handshake;
-  hs->is_flush |= flush;
 
   /* add handshake data to handshake for retrieval by user */
 

--- a/src/waltz/quic/tls/fd_quic_tls.h
+++ b/src/waltz/quic/tls/fd_quic_tls.h
@@ -125,7 +125,6 @@ struct fd_quic_tls_hs {
   fd_quic_tls_t * quic_tls;
 
   int             is_server;
-  int             is_flush;
   int             is_hs_complete;
 
   /* user defined context supplied in callbacks */


### PR DESCRIPTION
Fixes an issue where QUIC handshakes can stall if fd_quic has
nothing to send temporarily.  This occurs specifically when the
client sends an Initial packet that doesn't contain a complete
ClientHello.  This caused 'hs_data_empty' flag to be set which then
suppresses any more TLS handshake progress.  There was no logic to
reset 'hs_data_empty' when new data arrives.

With this fix, we always check for handshake data for as long as
a quic_tls_hs object exists.  The 'hs_data_empty' bit is removed.
