### PR TITLE
flamenco: add support for entry batches to live replay

### DIFF
--- a/src/flamenco/runtime/fd_blockstore.h
+++ b/src/flamenco/runtime/fd_blockstore.h
@@ -234,7 +234,7 @@ struct fd_block {
   ulong batch_cnt;
   ulong micros_gaddr; /* ptr to the list of fd_blockstore_micro_t */
   ulong micros_cnt;
-  ulong txns_gaddr;   /* ptr to the list of fd_blockstore_txn_ref_t */
+  ulong txns_gaddr;   /* ptr to the list of fd_block_txn_t */
   ulong txns_cnt;
   ulong txns_meta_gaddr; /* ptr to the allocation for txn meta data */
   ulong txns_meta_sz;

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -70,10 +70,12 @@ struct fd_block_txn_iter {
 typedef struct fd_block_txn_iter fd_block_txn_iter_t;
 
 struct fd_raw_block_txn_iter {
+  fd_block_entry_batch_t const * curr_batch;
+  uchar const * orig_data;
+  ulong remaining_batches;
   ulong remaining_microblocks;
   ulong remaining_txns;
   ulong curr_offset;
-  ulong data_sz;
 
   ulong curr_txn_sz;
 };
@@ -488,16 +490,18 @@ fd_txn_p_t *
 fd_block_txn_iter_ele( fd_block_info_t const * block_info, fd_block_txn_iter_t iter );
 
 fd_raw_block_txn_iter_t
-fd_raw_block_txn_iter_init( uchar const * data, ulong data_sz );
+fd_raw_block_txn_iter_init( uchar const *                  orig_data,
+                            fd_block_entry_batch_t const * batches,
+                            ulong                          batch_cnt );
 
 ulong
 fd_raw_block_txn_iter_done( fd_raw_block_txn_iter_t iter );
 
 fd_raw_block_txn_iter_t
-fd_raw_block_txn_iter_next( uchar const * data, fd_raw_block_txn_iter_t iter );
+fd_raw_block_txn_iter_next( fd_raw_block_txn_iter_t iter );
 
 void
-fd_raw_block_txn_iter_ele( uchar const * data, fd_raw_block_txn_iter_t iter, fd_txn_p_t * out_txn );
+fd_raw_block_txn_iter_ele( fd_raw_block_txn_iter_t iter, fd_txn_p_t * out_txn );
 
 FD_PROTOTYPES_END
 


### PR DESCRIPTION
Re-working the live transaction iterator to support iterating over batches, not just entire blocks. This enables us to correctly support shreds with trailing bytes in the live client, and will be useful for when we move to a streaming architecture.

Also re-wrote the original iterator to be easier to understand and documented.