### PR TITLE
quic: improve clock model

### DIFF
--- a/src/disco/quic/fd_quic_tile.h
+++ b/src/disco/quic/fd_quic_tile.h
@@ -40,10 +40,6 @@ typedef struct {
 
   fd_wksp_t * verify_out_mem;
 
-  double ns_per_tick;
-  ulong  last_tick;
-  ulong  last_wall;
-
   struct {
     ulong txns_received_udp;
     ulong txns_received_quic_fast;

--- a/src/waltz/quic/fd_quic_ack_tx.c
+++ b/src/waltz/quic/fd_quic_ack_tx.c
@@ -93,7 +93,8 @@ fd_quic_gen_ack_frames( fd_quic_ack_gen_t * gen,
                         uchar *             payload_ptr,
                         uchar *             payload_end,
                         uint                enc_level,
-                        ulong               now ) {
+                        ulong               now,
+                        float               tick_per_us ) {
 
   FD_ACK_DEBUG( FD_LOG_DEBUG(( "[ACK gen] elicited=%d", gen->is_elicited )); )
   /* Never generate an ACK frame if no ACK-eliciting packet is pending.
@@ -108,11 +109,14 @@ fd_quic_gen_ack_frames( fd_quic_ack_gen_t * gen,
       break;
     }
 
+    ulong ack_delay_ticks = fd_ulong_sat_sub( now, ack->ts );
+    ulong ack_delay_us    = (ulong)( (float)ack_delay_ticks / tick_per_us );
+
     if( FD_UNLIKELY( ack->pkt_number.offset_lo == ack->pkt_number.offset_hi ) ) continue;
     fd_quic_ack_frame_t ack_frame = {
       .type            = 0x02, /* type 0x02 is the base ack, 0x03 indicates ECN */
       .largest_ack     = ack->pkt_number.offset_hi - 1U,
-      .ack_delay       = fd_ulong_sat_sub( now, ack->ts ) / 1000, /* microseconds */
+      .ack_delay       = ack_delay_us,
       .ack_range_count = 0, /* no fragments */
       .first_ack_range = ack->pkt_number.offset_hi - ack->pkt_number.offset_lo - 1U,
     };

--- a/src/waltz/quic/fd_quic_ack_tx.h
+++ b/src/waltz/quic/fd_quic_ack_tx.h
@@ -120,7 +120,8 @@ fd_quic_gen_ack_frames( fd_quic_ack_gen_t * gen,
                         uchar *             payload_ptr,
                         uchar *             payload_end,
                         uint                enc_level,
-                        ulong               now );
+                        ulong               tickcount,
+                        float               tick_per_us );
 
 FD_PROTOTYPES_END
 

--- a/src/waltz/quic/fd_quic_enum.h
+++ b/src/waltz/quic/fd_quic_enum.h
@@ -110,8 +110,6 @@
 #define FD_QUIC_RETRY_SECRET_SZ 16
 /* RETRY iv size in bytes */
 #define FD_QUIC_RETRY_IV_SZ 12
-/* Retry token lifetime in seconds */
-#define FD_QUIC_RETRY_TOKEN_LIFETIME (3)
 
 #define FD_QUIC_STREAM_ID_UNUSED (ULONG_MAX)
 

--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -159,7 +159,7 @@ fd_quic_get_state_const( fd_quic_t const * quic ) {
    args
      quic        managing quic
      conn        connection to service
-     now         the current time in ns */
+     now         the current timestamp */
 void
 fd_quic_conn_service( fd_quic_t *      quic,
                       fd_quic_conn_t * conn,

--- a/src/waltz/quic/fd_quic_retry.h
+++ b/src/waltz/quic/fd_quic_retry.h
@@ -214,7 +214,7 @@ fd_quic_retry_create(
     fd_quic_conn_id_t const * orig_dst_conn_id,
     fd_quic_conn_id_t const * src_conn_id,
     ulong                     retry_src_conn_id,
-    ulong                     wallclock /* ns since unix epoch */
+    ulong                     expire_at
 );
 
 int
@@ -225,7 +225,8 @@ fd_quic_retry_server_verify(
     ulong *                   retry_src_conn_id, /* out */
     uchar const               retry_secret[ FD_QUIC_RETRY_SECRET_SZ ],
     uchar const               retry_iv[ FD_QUIC_RETRY_IV_SZ ],
-    ulong                     now /* ns since unix epoch */
+    ulong                     now,
+    ulong                     ttl
 );
 
 int

--- a/src/waltz/quic/fd_quic_retry_private.h
+++ b/src/waltz/quic/fd_quic_retry_private.h
@@ -20,7 +20,9 @@
 
 /* FD_QUIC_RETRY_EXPIRE_SHIFT: Expiry timestamps (unix nanos) are right-
    shifted 22 bits to avoid leaking high-precision timing information.
-   This results in a precision of ~4.19 ms. */
+   This results in a precision of ~4.19 ms.
+
+   FIXME this breaks when using slower fd_quic clocks */
 
 #define FD_QUIC_RETRY_EXPIRE_SHIFT (22)
 

--- a/src/waltz/quic/tests/fd_quic_test_helpers.c
+++ b/src/waltz/quic/tests/fd_quic_test_helpers.c
@@ -74,12 +74,6 @@ fd_quic_test_cb_tls_keylog( void *       quic_ctx,
     fd_pcapng_fwrite_tls_key_log( (uchar const *)line, (uint)strlen( line ), fd_quic_test_pcap );
 }
 
-ulong
-fd_quic_test_now( void * context ) {
-  (void)context;
-  return (ulong)fd_log_wallclock();
-}
-
 static void
 flush_pcap( void ) {
   fflush( fd_quic_test_pcap );
@@ -147,7 +141,6 @@ fd_quic_config_anonymous( fd_quic_t * quic,
   quic->cb.stream_notify    = fd_quic_test_cb_stream_notify;
   quic->cb.stream_rx        = fd_quic_test_cb_stream_rx;
   quic->cb.tls_keylog       = fd_quic_test_cb_tls_keylog;
-  quic->cb.now              = fd_quic_test_now;
   quic->cb.now_ctx          = NULL;
 }
 

--- a/src/waltz/quic/tests/fd_quic_test_helpers.h
+++ b/src/waltz/quic/tests/fd_quic_test_helpers.h
@@ -183,11 +183,6 @@ fd_quic_netem_send( void *                    ctx, /* fd_quic_net_em_t */
                     ulong *                   opt_batch_idx,
                     int                       flush );
 
-/* fd_quic_test_now is a fd_quic clock source based on fd_log_wallclock */
-
-ulong
-fd_quic_test_now( void * context );
-
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_waltz_quic_tests_fd_quic_helpers_h */

--- a/src/waltz/quic/tests/fuzz_quic.c
+++ b/src/waltz/quic/tests/fuzz_quic.c
@@ -15,9 +15,6 @@
 #include "../fd_quic_proto.h"
 
 #include "fd_quic_test_helpers.h"
-#include "../../tls/test_tls_helper.h"
-
-#include "../../../ballet/x509/fd_x509_mock.h"
 
 fd_quic_t *server_quic = NULL;
 
@@ -25,12 +22,6 @@ uchar scratch[0x4000];
 size_t scratch_sz = 0x4000;
 
 fd_aio_t _aio[1];
-
-
-ulong test_clock(void *ctx) {
-  (void)ctx;
-  return (ulong)fd_log_wallclock();
-}
 
 int test_aio_send_func(void *ctx, fd_aio_pkt_info_t const *batch,
                        ulong batch_cnt, ulong *opt_batch_idx, int flush) {
@@ -122,9 +113,6 @@ void init_quic(void) {
   fd_aio_t *aio = fd_aio_join(shaio);
   assert(aio);
 
-  server_quic->cb.now     = test_clock;
-  server_quic->cb.now_ctx = NULL;
-
   fd_quic_set_aio_net_tx(server_quic, aio);
   fd_quic_init( server_quic );
 }
@@ -175,9 +163,6 @@ int LLVMFuzzerInitialize(int *argc, char ***argv) {
   fd_quic_config_t *server_config = &server_quic->config;
   server_config->idle_timeout = 5e6;
   server_config->retry = 1;
-
-  server_quic->cb.now = test_clock;
-  server_quic->cb.now_ctx = NULL;
 
   server_quic->config.initial_rx_max_stream_data = 1 << 14;
   // server_quic->config.retry = 1;

--- a/src/waltz/quic/tests/test_quic_ack_tx.c
+++ b/src/waltz/quic/tests/test_quic_ack_tx.c
@@ -9,6 +9,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
+  float tick_per_us = 1000.0f;
 
   fd_quic_ack_gen_t gen[1];
 
@@ -78,19 +79,19 @@ main( int     argc,
   gen->is_elicited = 1;
 
   /* requested wrong encryption level */
-  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+sizeof(buf), 1U, 2009UL )==buf );
+  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+sizeof(buf), 1U, 2009UL, tick_per_us )==buf );
   FD_TEST( gen->tail==0UL && gen->head==FD_QUIC_ACK_QUEUE_CNT );
   FD_TEST( gen->is_elicited==1 );
 
   /* not enough buffer space */
   for( ulong j=0UL; j<=4UL; j++ ) {
-    FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+j, 0U, 2009UL )==buf );
+    FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+j, 0U, 2009UL, tick_per_us )==buf );
     FD_TEST( gen->tail==0UL && gen->head==FD_QUIC_ACK_QUEUE_CNT );
     FD_TEST( gen->is_elicited==1 );
   }
 
   /* generate one frame */
-  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+16, 0U, 2011UL )==buf+5UL );
+  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+16, 0U, 2011UL, tick_per_us )==buf+5UL );
   FD_TEST( gen->tail==1UL && gen->head==FD_QUIC_ACK_QUEUE_CNT );
   fd_quic_ack_frame_t ack_frame[2];
   FD_TEST( fd_quic_decode_ack_frame( ack_frame, buf, 5UL )==5UL );
@@ -103,7 +104,7 @@ main( int     argc,
 
   /* generate two frames */
   gen->tail = 0UL;
-  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+sizeof(buf), 0U, 2011UL )==buf+10UL );
+  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+sizeof(buf), 0U, 2011UL, tick_per_us )==buf+10UL );
   FD_TEST( gen->tail==2UL && gen->head==FD_QUIC_ACK_QUEUE_CNT );
   FD_TEST( fd_quic_decode_ack_frame( ack_frame,   buf,     128UL )==5UL );
   FD_TEST( fd_quic_decode_ack_frame( ack_frame+1, buf+5UL, 128UL )==5UL );
@@ -116,7 +117,7 @@ main( int     argc,
 
   /* generate last frame */
   gen->tail = gen->head - 1;
-  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+sizeof(buf), 2U, 1UL )==buf+6UL );
+  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+sizeof(buf), 2U, 1UL, tick_per_us )==buf+6UL );
   FD_TEST( gen->tail==gen->head );
   FD_TEST( fd_quic_decode_ack_frame( ack_frame, buf, 128UL )==6UL );
   FD_TEST( ack_frame[0].type           ==0x02 );
@@ -128,7 +129,7 @@ main( int     argc,
 
   /* refuse to generate ACK frames when no ACK eliciting frame was received */
   gen->tail = gen->head - 1;
-  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+sizeof(buf), 2U, 1UL )==buf );
+  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+sizeof(buf), 2U, 1UL, tick_per_us )==buf );
   FD_TEST( gen->tail==gen->head-1 );
   FD_TEST( gen->is_elicited==0 );
 

--- a/src/waltz/quic/tests/test_quic_bw.c
+++ b/src/waltz/quic/tests/test_quic_bw.c
@@ -162,6 +162,8 @@ main( int     argc,
   }
 
   FD_LOG_NOTICE(( "Initializing QUICs" ));
+  fd_quic_set_clock_tickcount( server_quic );
+  fd_quic_set_clock_tickcount( client_quic );
   FD_TEST( fd_quic_init( server_quic ) );
   FD_TEST( fd_quic_init( client_quic ) );
 

--- a/src/waltz/quic/tests/test_quic_client_flood.c
+++ b/src/waltz/quic/tests/test_quic_client_flood.c
@@ -63,12 +63,6 @@ void my_connection_closed( fd_quic_conn_t * conn, void * vp_context ) {
   client_complete = 1;
 }
 
-ulong
-test_clock( void * ctx ) {
-  (void)ctx;
-  return (ulong)fd_log_wallclock();
-}
-
 void
 run_quic_client(
   fd_quic_t *               quic,
@@ -91,8 +85,6 @@ run_quic_client(
     quic->cb.conn_final       = my_connection_closed;
     quic->cb.stream_rx        = my_stream_rx_cb;
     quic->cb.stream_notify    = my_stream_notify_cb;
-    quic->cb.now              = test_clock;
-    quic->cb.now_ctx          = NULL;
 
     /* use XSK XDP AIO for QUIC ingress/egress */
     fd_quic_set_aio_net_tx( quic, udpsock->aio );

--- a/src/waltz/quic/tests/test_quic_concurrency.c
+++ b/src/waltz/quic/tests/test_quic_concurrency.c
@@ -7,16 +7,9 @@
    encrypted packets. */
 
 #include "fd_quic_sandbox.h"
-#include "../fd_quic_proto.h"
 #include "../fd_quic_proto.c"
 #include "../fd_quic_private.h"
 #include "../../../tango/tempo/fd_tempo.h"
-
-static ulong
-quic_now( void * ctx ) {
-  (void)ctx;
-  return (ulong)fd_log_wallclock();
-}
 
 int
 main( int     argc,
@@ -74,7 +67,6 @@ main( int     argc,
   FD_TEST( sandbox );
   FD_TEST( fd_quic_sandbox_init( sandbox, FD_QUIC_ROLE_SERVER ) );
   fd_quic_t * const quic = sandbox->quic;
-  quic->cb.now = quic_now;
   quic->config.idle_timeout = (ulong)100000e9;
   fd_quic_state_t * state = fd_quic_get_state( quic );
   state->now = fd_quic_now( quic );

--- a/src/waltz/quic/tests/test_quic_idle_conns.c
+++ b/src/waltz/quic/tests/test_quic_idle_conns.c
@@ -74,7 +74,6 @@ run_quic_client( fd_quic_t *         quic,
   quic->cb.conn_new         = cb_conn_new;
   quic->cb.conn_hs_complete = cb_conn_handshake_complete;
   quic->cb.conn_final       = cb_conn_final;
-  quic->cb.now              = fd_quic_test_now;
 
   fd_quic_set_aio_net_tx( quic, udpsock->aio );
   FD_TEST( fd_quic_init( quic ) );

--- a/src/waltz/quic/tests/test_quic_txns.c
+++ b/src/waltz/quic/tests/test_quic_txns.c
@@ -101,7 +101,6 @@ run_quic_client( fd_quic_t *         quic,
   quic->cb.conn_hs_complete = cb_conn_handshake_complete;
   quic->cb.conn_final = cb_conn_final;
   quic->cb.stream_notify = cb_stream_notify;
-  quic->cb.now = fd_quic_test_now;
 
   fd_quic_set_aio_net_tx( quic, udpsock->aio );
   FD_TEST( fd_quic_init( quic ) );


### PR DESCRIPTION
- Make fd_quic agnostic to clock tick rate
- Add high-level API for using RDTSC as the fd_quic clock
- Refresh clock every packet (fixes a timeout bug when making the
  first few API calls to fd_quic_process_packet)
- Simplify use of RDTSC in fd_quic_tile
