### PR TITLE
flamenco, fuzz: fix ubsan errors on vm interp harness

### DIFF
--- a/src/flamenco/runtime/tests/fd_vm_test.h
+++ b/src/flamenco/runtime/tests/fd_vm_test.h
@@ -18,8 +18,8 @@
 
 ulong
 fd_exec_vm_interp_test_run( fd_exec_instr_test_runner_t *         runner,
-                            fd_exec_test_syscall_context_t const *input,
-                            fd_exec_test_syscall_effects_t   **   output,
+                            void const *                          input,
+                            void **                               output,
                             void *                                output_buf,
                             ulong                                 output_bufsz );
 


### PR DESCRIPTION
Cleans up
- misaligned vm->rodata
- bad function pointer cast