### PR TITLE
Fix CFLAGS pollution by rpcserver

### DIFF
--- a/src/app/rpcserver/Local.mk
+++ b/src/app/rpcserver/Local.mk
@@ -1,7 +1,5 @@
 ifdef FD_HAS_HOSTED
 ifdef FD_HAS_INT128
-CFLAGS+='-DFIREDANCER_VERSION="$(FIREDANCER_VERSION_MAJOR).$(FIREDANCER_VERSION_MINOR).$(FIREDANCER_VERSION_PATCH)"'
-
 $(call make-bin,fd_rpcserver,main,fd_disco fd_flamenco fd_reedsol fd_ballet fd_funk fd_tango fd_choreo fd_waltz fd_util, $(SECP256K1_LIBS))
 endif
 endif

--- a/src/disco/rpcserver/Local.mk
+++ b/src/disco/rpcserver/Local.mk
@@ -1,10 +1,7 @@
 ifdef FD_HAS_INT128
-CFLAGS+='-DFIREDANCER_VERSION="$(FIREDANCER_VERSION_MAJOR).$(FIREDANCER_VERSION_MINOR).$(FIREDANCER_VERSION_PATCH)"'
-
 $(call add-hdrs,fd_rpc_service.h)
 $(call add-objs,fd_block_to_json fd_methods fd_rpc_service fd_webserver json_lex keywords fd_stub_to_json base_enc,fd_disco)
 
 $(call make-unit-test,test_rpc_keywords,test_keywords keywords,fd_util)
 $(call make-fuzz-test,fuzz_json_lex,fuzz_json_lex json_lex,fd_util)
-
 endif

--- a/src/disco/rpcserver/fd_rpc_service.c
+++ b/src/disco/rpcserver/fd_rpc_service.c
@@ -17,6 +17,16 @@
 #include <netinet/in.h>
 #include <stdarg.h>
 
+#ifdef __has_include
+#if __has_include("../../app/fdctl/version.h")
+#include "../../app/fdctl/version.h"
+#define FIREDANCER_VERSION FD_STRINGIFY(FIREDANCER_VERSION_MAJOR) "." FD_STRINGIFY(FIREDANCER_VERSION_MINOR) "." FD_STRINGIFY(FIREDANCER_VERSION_PATCH)
+#endif
+#endif
+#ifndef FIREDANCER_VERSION
+#define FIREDANCER_VERSION "dev"
+#endif
+
 #define CRLF "\r\n"
 #define MATCH_STRING(_text_,_text_sz_,_str_) (_text_sz_ == sizeof(_str_)-1 && memcmp(_text_, _str_, sizeof(_str_)-1) == 0)
 #define EMIT_SIMPLE(_str_) fd_web_reply_append(ws, _str_, sizeof(_str_)-1)


### PR DESCRIPTION
Fixes a gnarly abuse of CFLAGS by rpcserver.
rpcserver added a define to CFLAGS (twice) that would be applied to all other compile units too