### PR TITLE
Fix typo Update cli.md

### DIFF
--- a/book/api/cli.md
+++ b/book/api/cli.md
@@ -12,7 +12,7 @@ abbreviated log output to `stderr` and nothing will be written to
 
 | Arguments | Description |
 |----------|-------------|
-| `--config` | Path to a configuation TOML file to run the validator with |
+| `--config` | Path to a configuration TOML file to run the validator with |
 
 ::: details Capabilities
 


### PR DESCRIPTION
# Fix Typo in cli.md

## Description:

This pull request corrects a typographical error in the `cli.md` file, where "configuation" was used instead of the correct spelling "configuration."

## Changes:
- Corrected "configuation" to "configuration" in the `cli.md`.

## File(s) Modified:
- `book/api/cli.md`

## Justification:

Fixing typographical errors in documentation improves clarity and reduces potential confusion, especially for users referring to setup or configuration instructions.

## Checklist:
- [x] Typographical error corrected.
- [x] Documentation is clear and concise.

## Related Issues:
- N/A

## Additional Notes:
This is a minor documentation fix that does not affect the functionality of the code.
