### PR TITLE
flamenco, repair: cache good repair peers to file

### DIFF
--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -278,6 +278,7 @@ typedef struct {
     struct {
       ushort repair_intake_listen_port;
       ushort repair_serve_listen_port;
+      char   good_peer_cache_file[ PATH_MAX ];
     } repair;
 
     struct {

--- a/src/app/fdctl/config_parse.c
+++ b/src/app/fdctl/config_parse.c
@@ -367,6 +367,7 @@ fdctl_pod_to_cfg( config_t * config,
 
   CFG_POP      ( ushort, tiles.repair.repair_intake_listen_port           );
   CFG_POP      ( ushort, tiles.repair.repair_serve_listen_port            );
+  CFG_POP      ( cstr,   tiles.repair.good_peer_cache_file                );
 
   CFG_POP      ( cstr,   tiles.replay.capture                             );
   CFG_POP      ( cstr,   tiles.replay.funk_checkpt                        );

--- a/src/app/fdctl/run/tiles/generated/repair_seccomp.h
+++ b/src/app/fdctl/run/tiles/generated/repair_seccomp.h
@@ -21,34 +21,60 @@
 #else
 # error "Target architecture is unsupported by seccomp."
 #endif
-static const unsigned int sock_filter_policy_repair_instr_cnt = 14;
+static const unsigned int sock_filter_policy_repair_instr_cnt = 27;
 
-static void populate_sock_filter_policy_repair( ulong out_cnt, struct sock_filter * out, unsigned int logfile_fd) {
-  FD_TEST( out_cnt >= 14 );
-  struct sock_filter filter[14] = {
+static void populate_sock_filter_policy_repair( ulong out_cnt, struct sock_filter * out, unsigned int logfile_fd, unsigned int good_peer_cache_file_fd) {
+  FD_TEST( out_cnt >= 27 );
+  struct sock_filter filter[27] = {
     /* Check: Jump to RET_KILL_PROCESS if the script's arch != the runtime arch */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, ( offsetof( struct seccomp_data, arch ) ) ),
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, ARCH_NR, 0, /* RET_KILL_PROCESS */ 10 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, ARCH_NR, 0, /* RET_KILL_PROCESS */ 23 ),
     /* loading syscall number in accumulator */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, ( offsetof( struct seccomp_data, nr ) ) ),
     /* allow write based on expression */
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_write, /* check_write */ 2, 0 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_write, /* check_write */ 5, 0 ),
+    /* allow lseek based on expression */
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_lseek, /* check_lseek */ 10, 0 ),
+    /* allow ftruncate based on expression */
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_ftruncate, /* check_ftruncate */ 11, 0 ),
     /* allow fsync based on expression */
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_fsync, /* check_fsync */ 5, 0 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_fsync, /* check_fsync */ 14, 0 ),
+    /* allow read based on expression */
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_read, /* check_read */ 15, 0 ),
     /* none of the syscalls matched */
-    { BPF_JMP | BPF_JA, 0, 0, /* RET_KILL_PROCESS */ 6 },
+    { BPF_JMP | BPF_JA, 0, 0, /* RET_KILL_PROCESS */ 16 },
 //  check_write:
     /* load syscall argument 0 in accumulator */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, 2, /* RET_ALLOW */ 5, /* lbl_1 */ 0 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, 2, /* RET_ALLOW */ 15, /* lbl_1 */ 0 ),
 //  lbl_1:
     /* load syscall argument 0 in accumulator */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, logfile_fd, /* RET_ALLOW */ 3, /* RET_KILL_PROCESS */ 2 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, logfile_fd, /* RET_ALLOW */ 13, /* lbl_2 */ 0 ),
+//  lbl_2:
+    /* load syscall argument 0 in accumulator */
+    BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, good_peer_cache_file_fd, /* RET_ALLOW */ 11, /* RET_KILL_PROCESS */ 10 ),
+//  check_lseek:
+    /* load syscall argument 0 in accumulator */
+    BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, good_peer_cache_file_fd, /* RET_ALLOW */ 9, /* RET_KILL_PROCESS */ 8 ),
+//  check_ftruncate:
+    /* load syscall argument 0 in accumulator */
+    BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, good_peer_cache_file_fd, /* lbl_3 */ 0, /* RET_KILL_PROCESS */ 6 ),
+//  lbl_3:
+    /* load syscall argument 1 in accumulator */
+    BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[1])),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, 0, /* RET_ALLOW */ 5, /* RET_KILL_PROCESS */ 4 ),
 //  check_fsync:
     /* load syscall argument 0 in accumulator */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, logfile_fd, /* RET_ALLOW */ 1, /* RET_KILL_PROCESS */ 0 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, logfile_fd, /* RET_ALLOW */ 3, /* RET_KILL_PROCESS */ 2 ),
+//  check_read:
+    /* load syscall argument 0 in accumulator */
+    BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, good_peer_cache_file_fd, /* RET_ALLOW */ 1, /* RET_KILL_PROCESS */ 0 ),
 //  RET_KILL_PROCESS:
     /* KILL_PROCESS is placed before ALLOW since it's the fallthrough case. */
     BPF_STMT( BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS ),

--- a/src/app/fdctl/run/tiles/repair.seccomppolicy
+++ b/src/app/fdctl/run/tiles/repair.seccomppolicy
@@ -1,18 +1,37 @@
 # logfile_fd: It can be disabled by configuration, but typically tiles
 #             will open a log file on boot and write all messages there.
-unsigned int logfile_fd
+# good_peer_cache_file_fd: The list of known good repair peers, which we read
+#                          at boot and then periodically write to.
+unsigned int logfile_fd, unsigned int good_peer_cache_file_fd
 
 # logging: all log messages are written to a file and/or pipe
 #
 # 'WARNING' and above are written to the STDERR pipe, while all messages
 # are always written to the log file.
 #
+# good_peer_cache_file: we periodically write out the good peers to the file
+# 
 # arg 0 is the file descriptor to write to.  The boot process ensures
 # that descriptor 2 is always STDERR.
 write: (or (eq (arg 0) 2)
-           (eq (arg 0) logfile_fd))
+           (eq (arg 0) logfile_fd)
+           (eq (arg 0) good_peer_cache_file_fd))
+
+# good_peer_cache_file_fd:
+#
+# We need to seek to the start of the file when we read it in.
+lseek: (eq (arg 0) good_peer_cache_file_fd)
+
+# good_peer_cache_file_fd:
+#
+# We need to truncate the file to 0 before we start writing to it.
+ftruncate: (and (eq (arg 0) good_peer_cache_file_fd) 
+                (eq (arg 1) 0))
 
 # logging: 'WARNING' and above fsync the logfile to disk immediately
 #
 # arg 0 is the file descriptor to fsync.
 fsync: (eq (arg 0) logfile_fd)
+
+# good_peer_cache_file: we read in the good peer cache file on boot
+read: (eq (arg 0) good_peer_cache_file_fd)

--- a/src/app/fdctl/run/topos/fd_firedancer.c
+++ b/src/app/fdctl/run/topos/fd_firedancer.c
@@ -591,6 +591,8 @@ fd_topo_initialize( config_t * config ) {
       tile->repair.repair_intake_listen_port =  config->tiles.repair.repair_intake_listen_port;
       tile->repair.repair_serve_listen_port =   config->tiles.repair.repair_serve_listen_port;
       tile->repair.ip_addr = config->tiles.net.ip_addr;
+      strncpy( tile->repair.good_peer_cache_file,
+      config->tiles.repair.good_peer_cache_file, sizeof(config->tiles.repair.good_peer_cache_file) );
 
       memcpy( tile->repair.src_mac_addr, config->tiles.net.mac_addr, 6 );
       strncpy( tile->repair.identity_key_path, config->consensus.identity_path, sizeof(tile->repair.identity_key_path) );

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -296,11 +296,13 @@ typedef struct {
     struct {
       ushort  repair_intake_listen_port;
       ushort  repair_serve_listen_port;
+      char    good_peer_cache_file[ PATH_MAX ];
 
       /* non-config */
 
       uint    ip_addr;
       uchar   src_mac_addr[ 6 ];
+      int     good_peer_cache_file_fd;
       char    identity_key_path[ PATH_MAX ];
     } repair;
 

--- a/src/flamenco/repair/fd_repair.h
+++ b/src/flamenco/repair/fd_repair.h
@@ -59,6 +59,7 @@ struct fd_repair_config {
     void * fun_arg;
     fd_repair_sign_fun sign_fun;
     void * sign_arg;
+    int good_peer_cache_file_fd;
 };
 typedef struct fd_repair_config fd_repair_config_t;
 


### PR DESCRIPTION
We periodically cache the known good repair peers to a file, so that we can request from these when we restart. This reduces startup times.