### PR TITLE
flamenco, fuzz: use spad debugging variants in harness setup and teardown

### DIFF
--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -102,7 +102,7 @@ fd_exec_instr_test_runner_new( void * mem,
 
   /* Create spad */
   runner->spad = fd_spad_join( fd_spad_new( spad_mem, FD_RUNTIME_TRANSACTION_EXECUTION_FOOTPRINT_FUZZ ) );
-  fd_spad_push( runner->spad );
+  fd_spad_push_debug( runner->spad );
   return runner;
 }
 
@@ -114,7 +114,7 @@ fd_exec_instr_test_runner_delete( fd_exec_instr_test_runner_t * runner ) {
   if( FD_UNLIKELY( fd_spad_verify( runner->spad ) ) ) {
     FD_LOG_ERR(( "fd_spad_verify() failed" ));
   }
-  fd_spad_pop( runner->spad );
+  fd_spad_pop_debug( runner->spad );
   if( FD_UNLIKELY( fd_spad_frame_used( runner->spad )!=0 ) ) {
     FD_LOG_ERR(( "stray spad frame frame_used=%lu", fd_spad_frame_used( runner->spad ) ));
   }
@@ -337,7 +337,7 @@ fd_exec_test_instr_context_create( fd_exec_instr_test_runner_t *        runner,
     }
 
     if( borrowed_accts[j].const_meta ) {
-      uchar * data = fd_spad_alloc( txn_ctx->spad, FD_ACCOUNT_REC_ALIGN, FD_ACC_TOT_SZ_MAX );
+      uchar * data = fd_spad_alloc_debug( txn_ctx->spad, FD_ACCOUNT_REC_ALIGN, FD_ACC_TOT_SZ_MAX );
       ulong   dlen = borrowed_accts[j].const_meta->dlen;
       fd_memcpy( data, borrowed_accts[j].const_meta, sizeof(fd_account_meta_t)+dlen );
       borrowed_accts[j].const_meta = (fd_account_meta_t*)data;
@@ -1448,7 +1448,7 @@ fd_exec_vm_syscall_test_run( fd_exec_instr_test_runner_t * runner,
   fd_vm_input_region_t * input_regions = NULL;
   uint input_regions_count = 0U;
   if( !!(input->vm_ctx.input_data_regions_count) ) {
-    input_regions       = fd_spad_alloc( spad, alignof(fd_vm_input_region_t), sizeof(fd_vm_input_region_t) * input->vm_ctx.input_data_regions_count );
+    input_regions       = fd_spad_alloc_debug( spad, alignof(fd_vm_input_region_t), sizeof(fd_vm_input_region_t) * input->vm_ctx.input_data_regions_count );
     input_regions_count = fd_setup_vm_input_regions( input_regions, input->vm_ctx.input_data_regions, input->vm_ctx.input_data_regions_count, spad );
     if ( !input_regions_count ) {
       goto error;

--- a/src/flamenco/runtime/tests/fd_vm_test.c
+++ b/src/flamenco/runtime/tests/fd_vm_test.c
@@ -91,11 +91,11 @@ do{
     break;
   }
   ulong   rodata_sz = input->vm_ctx.rodata->size;
-  uchar * rodata = fd_spad_alloc( spad, 8UL, rodata_sz );
+  uchar * rodata = fd_spad_alloc_debug( spad, 8UL, rodata_sz );
   memcpy( rodata, input->vm_ctx.rodata->bytes, rodata_sz );
 
   /* Load input data regions */
-  fd_vm_input_region_t * input_regions     = fd_spad_alloc( spad, alignof(fd_vm_input_region_t), sizeof(fd_vm_input_region_t) * input->vm_ctx.input_data_regions_count );
+  fd_vm_input_region_t * input_regions     = fd_spad_alloc_debug( spad, alignof(fd_vm_input_region_t), sizeof(fd_vm_input_region_t) * input->vm_ctx.input_data_regions_count );
   uint                   input_regions_cnt = fd_setup_vm_input_regions( input_regions, input->vm_ctx.input_data_regions, input->vm_ctx.input_data_regions_count, spad );
 
   if (input->vm_ctx.heap_max > FD_VM_HEAP_DEFAULT) {
@@ -319,7 +319,7 @@ fd_setup_vm_input_regions( fd_vm_input_region_t *                   input,
       continue; /* skip empty regions https://github.com/anza-xyz/agave/blob/3072c1a72b2edbfa470ca869f1ea891dfb6517f2/programs/bpf_loader/src/serialization.rs#L136 */
     }
 
-    uchar * haddr = fd_spad_alloc( spad, 8UL, array->size );
+    uchar * haddr = fd_spad_alloc_debug( spad, 8UL, array->size );
     fd_memcpy( haddr, array->bytes, array->size );
     input[input_idx].vaddr_offset     = offset;
     input[input_idx].haddr            = (ulong)haddr;


### PR DESCRIPTION
Use spad debugging variants to track violations on spad memory (namely alloc overflow)