### PR TITLE
ripatel/v0.3 backports

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -3035,7 +3035,7 @@ fd_quic_tx_buffered_raw(
   pkt.ip4->verihl       = FD_IP4_VERIHL(4,5);
   pkt.ip4->tos          = (uchar)(config->net.dscp << 2); /* could make this per-connection or per-stream */
   pkt.ip4->net_tot_len  = (ushort)( 20 + 8 + payload_sz );
-  pkt.ip4->net_id       = *ipv4_id++;
+  pkt.ip4->net_id       = *ipv4_id;
   pkt.ip4->net_frag_off = 0x4000u; /* don't fragment */
   pkt.ip4->ttl          = 64; /* TODO make configurable */
   pkt.ip4->protocol     = FD_IP4_HDR_PROTOCOL_UDP;
@@ -3044,6 +3044,7 @@ fd_quic_tx_buffered_raw(
   pkt.udp->net_dport    = dst_udp_port;
   pkt.udp->net_len      = (ushort)( 8 + payload_sz );
   pkt.udp->check        = 0x0000;
+  *ipv4_id = (ushort)( *ipv4_id + 1 );
 
   /* TODO saddr could be zero -- should use the kernel routing table to
      determine an appropriate source address */

--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -2742,8 +2742,7 @@ void
 fd_quic_tls_cb_handshake_complete( fd_quic_tls_hs_t * hs,
                                    void *             context ) {
   (void)hs;
-  fd_quic_conn_t *           conn = (fd_quic_conn_t*)context;
-  fd_quic_conn_stream_rx_t * srx  = conn->srx;
+  fd_quic_conn_t * conn = (fd_quic_conn_t *)context;
 
   /* need to send quic handshake completion */
   switch( conn->state ) {
@@ -2761,13 +2760,6 @@ fd_quic_tls_cb_handshake_complete( fd_quic_tls_hs_t * hs,
       }
       conn->handshake_complete = 1;
       conn->state              = FD_QUIC_CONN_STATE_HANDSHAKE_COMPLETE;
-
-      if( conn->server ) {
-        /* Remove flow control limits */
-        srx->rx_sup_stream_id = (1UL<<60) + FD_QUIC_STREAM_TYPE_UNI_CLIENT;
-        srx->rx_max_data      = (1UL<<62UL) - 1UL;
-      }
-
       return;
 
     default:
@@ -4370,6 +4362,13 @@ fd_quic_conn_create( fd_quic_t *               quic,
   srx->rx_max_data       = our_tp->initial_max_data;
   srx->rx_tot_data       = 0;
   srx->rx_streams_active = 0L;
+
+  if( state->transport_params.initial_max_streams_uni_present ) {
+    srx->rx_sup_stream_id = (state->transport_params.initial_max_streams_uni<<2) + FD_QUIC_STREAM_TYPE_UNI_CLIENT;
+  }
+  if( state->transport_params.initial_max_data ) {
+    srx->rx_max_data = state->transport_params.initial_max_data;
+  }
 
   /* points to free tx space */
   conn->tx_ptr = conn->tx_buf;

--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -887,7 +887,7 @@ fd_quic_tx_enc_level( fd_quic_conn_t * conn, int acks ) {
 
       /* TODO consider this optimization... but we want to ack all handshakes, even if there is stream_data */
     case FD_QUIC_CONN_STATE_ACTIVE:
-      if( FD_LIKELY( conn->hs_data_empty ) ) {
+      if( FD_LIKELY( !conn->tls_hs ) ) {
         /* optimization for case where we have stream data to send */
 
         /* find stream data to send */
@@ -908,9 +908,8 @@ fd_quic_tx_enc_level( fd_quic_conn_t * conn, int acks ) {
   }
 
   /* Check for handshake data to send */
-  /* hs_data_empty is used to optimize the test */
   uint peer_enc_level = conn->peer_enc_level;
-  if( FD_UNLIKELY( !conn->hs_data_empty ) ) {
+  if( FD_UNLIKELY( conn->tls_hs ) ) {
     fd_quic_tls_hs_data_t * hs_data   = NULL;
 
     for( uint i = peer_enc_level; i < 4 && i < enc_level; ++i ) {
@@ -930,9 +929,6 @@ fd_quic_tx_enc_level( fd_quic_conn_t * conn, int acks ) {
         }
       }
     }
-
-    /* no hs_data was found, so set hs_data_empty */
-    conn->hs_data_empty = 1;
   }
 
   /* if we have acks to send or handshake data, then use that enc_level */
@@ -1610,6 +1606,7 @@ fd_quic_handle_v1_initial( fd_quic_t *               quic,
         FD_DEBUG( FD_LOG_WARNING( ( "failed to allocate QUIC conn" ) ) );
         return FD_QUIC_PARSE_FAIL;
       }
+      FD_DEBUG( FD_LOG_DEBUG(( "new connection allocated" )) );
 
       /* set the value for the caller */
       *p_conn = conn;
@@ -1768,8 +1765,6 @@ fd_quic_handle_v1_initial( fd_quic_t *               quic,
     ulong next_pkt_number = pkt_number  + 1UL;
     conn->exp_pkt_number[pn_space] = fd_ulong_max( conn->exp_pkt_number[pn_space], next_pkt_number );
   } while(0);
-
-  FD_DEBUG( FD_LOG_DEBUG(( "new connection success" )) );
 
   /* insert into service queue */
   fd_quic_svc_schedule( state, conn, FD_QUIC_SVC_INSTANT );
@@ -1988,7 +1983,6 @@ fd_quic_handle_v1_retry(
   /* have to rewind the handshake data */
   uint enc_level                 = fd_quic_enc_level_initial_id;
   conn->hs_sent_bytes[enc_level] = 0;
-  conn->hs_data_empty            = 0;
 
   /* send the INITIAL */
   conn->upd_pkt_number = FD_QUIC_PKT_NUM_PENDING;
@@ -3534,7 +3528,7 @@ fd_quic_gen_frames( fd_quic_conn_t *     conn,
         payload_ptr += fd_quic_gen_max_streams_frame( conn, payload_ptr, payload_end, pkt_meta, pkt_number, now );
         payload_ptr += fd_quic_gen_ping_frame       ( conn, payload_ptr, payload_end,           pkt_number      );
       }
-      if( FD_LIKELY( conn->hs_data_empty ) ) {
+      if( FD_LIKELY( !conn->tls_hs ) ) {
         payload_ptr = fd_quic_gen_stream_frames( conn, payload_ptr, payload_end, pkt_meta, pkt_number, now );
       }
     }
@@ -3957,8 +3951,9 @@ fd_quic_conn_tx( fd_quic_t *      quic,
       break;
     }
 
-    /* choose enc_level to tx at */
+    /* Refresh enc_level in case we can coalesce another packet */
     enc_level = fd_quic_tx_enc_level( conn, 0 /* acks */ );
+    FD_DEBUG( if( enc_level!=~0u) FD_LOG_DEBUG(( "Attempting to append enc_level=%u packet", enc_level )); )
   }
 
   /* unused pkt_meta? deallocate */
@@ -4348,7 +4343,6 @@ fd_quic_conn_create( fd_quic_t *               quic,
   conn->handshake_complete  = 0;
   conn->handshake_done_send = 0;
   conn->handshake_done_ackd = 0;
-  conn->hs_data_empty       = 0;
   conn->tls_hs              = NULL; /* created later */
 
   /* initialize stream_id members */
@@ -4753,7 +4747,6 @@ fd_quic_reclaim_pkt_meta( fd_quic_conn_t *     conn,
   if( flags & FD_QUIC_PKT_META_FLAGS_HS_DONE ) {
     conn->handshake_done_ackd = 1;
     conn->handshake_done_send = 0;
-    conn->hs_data_empty       = 1;
     fd_quic_state_t * state = fd_quic_get_state( conn->quic );
     fd_quic_tls_hs_delete( conn->tls_hs );
     fd_quic_tls_hs_pool_ele_release( state->hs_pool, conn->tls_hs );

--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -2794,6 +2794,7 @@ fd_quic_frame_handle_crypto_frame( void *                   vp_context,
   ulong rcv_hi  = rcv_off + rcv_sz;  /* in [0,2^63-1] */
 
   if( FD_UNLIKELY( rcv_sz > p_sz ) ) {
+    fd_quic_frame_error( context, FD_QUIC_CONN_REASON_FRAME_ENCODING_ERROR, __LINE__ );
     return FD_QUIC_PARSE_FAIL;
   }
 
@@ -5071,11 +5072,17 @@ fd_quic_frame_handle_ack_frame(
 
   /* walk thru ack ranges */
   for( ulong j = 0UL; j < ack_range_count; ++j ) {
-    if( FD_UNLIKELY(  p_end <= p ) ) return FD_QUIC_PARSE_FAIL;
+    if( FD_UNLIKELY( p_end <= p ) ) {
+      fd_quic_frame_error( &context, FD_QUIC_CONN_REASON_FRAME_ENCODING_ERROR, __LINE__ );
+      return FD_QUIC_PARSE_FAIL;
+    }
 
     fd_quic_ack_range_frag_t ack_range[1];
     ulong rc = fd_quic_decode_ack_range_frag( ack_range, p, (ulong)( p_end - p ) );
-    if( FD_UNLIKELY( rc == FD_QUIC_PARSE_FAIL ) ) return FD_QUIC_PARSE_FAIL;
+    if( FD_UNLIKELY( rc == FD_QUIC_PARSE_FAIL ) ) {
+      fd_quic_frame_error( &context, FD_QUIC_CONN_REASON_FRAME_ENCODING_ERROR, __LINE__ );
+      return FD_QUIC_PARSE_FAIL;
+    }
 
     /* ensure we have ulong local vars, regardless of ack_range definition */
     ulong gap    = (ulong)ack_range->gap;
@@ -5140,11 +5147,17 @@ fd_quic_frame_handle_ack_frame(
   /* ECN counts
      we currently ignore them, but we must process them to get to the following bytes */
   if( data->type & 1U ) {
-    if( FD_UNLIKELY(  p_end <= p ) ) return FD_QUIC_PARSE_FAIL;
+    if( FD_UNLIKELY( p_end <= p ) ) {
+      fd_quic_frame_error( &context, FD_QUIC_CONN_REASON_FRAME_ENCODING_ERROR, __LINE__ );
+      return FD_QUIC_PARSE_FAIL;
+    }
 
     fd_quic_ecn_counts_frag_t ecn_counts[1];
     ulong rc = fd_quic_decode_ecn_counts_frag( ecn_counts, p, (ulong)( p_end - p ) );
-    if( rc == FD_QUIC_PARSE_FAIL ) return FD_QUIC_PARSE_FAIL;
+    if( rc == FD_QUIC_PARSE_FAIL ) {
+      fd_quic_frame_error( &context, FD_QUIC_CONN_REASON_FRAME_ENCODING_ERROR, __LINE__ );
+      return FD_QUIC_PARSE_FAIL;
+    }
 
     p += rc;
   }
@@ -5162,7 +5175,7 @@ fd_quic_frame_handle_reset_stream_frame(
   fd_quic_frame_context_t * context = vp_context;
   context->pkt->ack_flag |= ACK_FLAG_RQD;  /* ack-eliciting */
   /* TODO implement */
-  return FD_QUIC_PARSE_FAIL;
+  return 0UL;
 }
 
 static ulong
@@ -5183,12 +5196,10 @@ fd_quic_frame_handle_new_token_frame(
     fd_quic_new_token_frame_t * data,
     uchar const * p,
     ulong p_sz) {
-  (void)context;
-  (void)data;
-  (void)p;
-  (void)p_sz;
+  /* FIXME A server MUST treat receipt of a NEW_TOKEN frame as a connection error of type PROTOCOL_VIOLATION. */
+  (void)context; (void)data; (void)p; (void)p_sz;
   /* ack-eliciting */
-  return FD_QUIC_PARSE_FAIL;
+  return 0UL;
 }
 
 void
@@ -5474,12 +5485,10 @@ fd_quic_frame_handle_path_challenge_frame(
     void * context,
     fd_quic_path_challenge_frame_t * data,
     uchar const * p,
-    ulong p_sz) {
-  (void)context;
-  (void)data;
-  (void)p;
-  (void)p_sz;
-  return FD_QUIC_PARSE_FAIL;
+    ulong  p_sz) {
+  /* FIXME The recipient of this frame MUST generate a PATH_RESPONSE frame (Section 19.18) containing the same Data value. */
+  (void)context; (void)data; (void)p; (void)p_sz;
+  return 0UL;
 }
 
 static ulong
@@ -5488,11 +5497,9 @@ fd_quic_frame_handle_path_response_frame(
     fd_quic_path_response_frame_t * data,
     uchar const * p,
     ulong p_sz) {
-  (void)context;
-  (void)data;
-  (void)p;
-  (void)p_sz;
-  return FD_QUIC_PARSE_FAIL;
+  /* We don't generate PATH_CHALLENGE frames, so this frame should never arrive */
+  (void)context; (void)data; (void)p; (void)p_sz;
+  return 0UL;
 }
 
 static void
@@ -5533,6 +5540,7 @@ fd_quic_frame_handle_conn_close_0_frame(
 
   ulong reason_phrase_length = data->reason_phrase_length;
   if( FD_UNLIKELY( reason_phrase_length > p_sz ) ) {
+    fd_quic_frame_error( vp_context, FD_QUIC_CONN_REASON_FRAME_ENCODING_ERROR, __LINE__ );
     return FD_QUIC_PARSE_FAIL;
   }
 
@@ -5566,6 +5574,7 @@ fd_quic_frame_handle_conn_close_1_frame(
 
   ulong reason_phrase_length = data->reason_phrase_length;
   if( FD_UNLIKELY( reason_phrase_length > p_sz ) ) {
+    fd_quic_frame_error( vp_context, FD_QUIC_CONN_REASON_FRAME_ENCODING_ERROR, __LINE__ );
     return FD_QUIC_PARSE_FAIL;
   }
 
@@ -5609,24 +5618,13 @@ fd_quic_frame_handle_handshake_done_frame(
     return FD_QUIC_PARSE_FAIL;
   }
 
-  if( FD_UNLIKELY( conn->state != FD_QUIC_CONN_STATE_HANDSHAKE_COMPLETE ) ) {
-    switch( conn->state ) {
-      case FD_QUIC_CONN_STATE_PEER_CLOSE:
-      case FD_QUIC_CONN_STATE_ABORT:
-      case FD_QUIC_CONN_STATE_CLOSE_PENDING:
-        /* connection closing... nothing to do */
-        return 0;
-
-      case FD_QUIC_CONN_STATE_HANDSHAKE:
-        /* still handshaking... assume packet was reordered */
-        return FD_QUIC_PARSE_FAIL;
-
-      case FD_QUIC_CONN_STATE_ACTIVE:
-        /* duplicate frame? */
-        return 0;
-    }
-
-    return FD_QUIC_PARSE_FAIL;
+  if( conn->state == FD_QUIC_CONN_STATE_HANDSHAKE ) {
+    /* still handshaking... assume packet was reordered */
+    context.pkt->ack_flag |= ACK_FLAG_CANCEL;
+    return 0UL;
+  } else if( conn->state != FD_QUIC_CONN_STATE_HANDSHAKE_COMPLETE ) {
+    /* duplicate frame or conn closing? */
+    return 0UL;
   }
 
   /* Instantly acknowledge the first HANDSHAKE_DONE frame */

--- a/src/waltz/quic/fd_quic_conn.h
+++ b/src/waltz/quic/fd_quic_conn.h
@@ -113,7 +113,6 @@ struct fd_quic_conn {
   uint               handshake_complete  : 1; /* have we completed a successful handshake? */
   uint               handshake_done_send : 1; /* do we need to send handshake-done to peer? */
   uint               handshake_done_ackd : 1; /* was handshake_done ack'ed? */
-  uint               hs_data_empty       : 1; /* has all hs_data been consumed? */
   fd_quic_tls_hs_t * tls_hs;
 
   /* amount of handshake data already sent from head of queue */

--- a/src/waltz/quic/tests/fd_quic_sandbox.c
+++ b/src/waltz/quic/tests/fd_quic_sandbox.c
@@ -303,7 +303,6 @@ fd_quic_sandbox_new_conn_established( fd_quic_sandbox_t * sandbox,
 
   /* Mock a completed handshake */
   conn->handshake_complete = 1;
-  conn->hs_data_empty      = 1;
   conn->peer_enc_level     = fd_quic_enc_level_appdata_id;
   conn->keys_avail         = 1U<<fd_quic_enc_level_appdata_id;
 

--- a/src/waltz/quic/tests/test_quic_tls_hs.c
+++ b/src/waltz/quic/tests/test_quic_tls_hs.c
@@ -16,7 +16,6 @@ static uchar const test_tp[] =
 typedef struct my_quic_tls my_quic_tls_t;
 struct my_quic_tls {
   int is_server;
-  int is_flush;
   int is_hs_complete;
 
   int state;

--- a/src/waltz/quic/tls/fd_quic_tls.c
+++ b/src/waltz/quic/tls/fd_quic_tls.c
@@ -156,7 +156,6 @@ fd_quic_tls_hs_new( fd_quic_tls_hs_t * self,
   // set properties on self
   self->quic_tls  = quic_tls;
   self->is_server = is_server;
-  self->is_flush  = 0;
   self->context   = context;
 
   /* initialize handshake data */
@@ -266,7 +265,7 @@ fd_quic_tls_sendmsg( void const * handshake,
                      void const * data,
                      ulong        data_sz,
                      uint         enc_level,
-                     int          flush ) {
+                     int          flush FD_PARAM_UNUSED ) {
 
   uint buf_sz = FD_QUIC_TLS_HS_DATA_SZ;
   if( data_sz > buf_sz ) {
@@ -276,7 +275,6 @@ fd_quic_tls_sendmsg( void const * handshake,
   /* Safe because the fd_tls_estate_{srv,cli}_t object is the first
      element of fd_quic_tls_hs_t */
   fd_quic_tls_hs_t * hs = (fd_quic_tls_hs_t *)handshake;
-  hs->is_flush |= flush;
 
   /* add handshake data to handshake for retrieval by user */
 

--- a/src/waltz/quic/tls/fd_quic_tls.h
+++ b/src/waltz/quic/tls/fd_quic_tls.h
@@ -125,7 +125,6 @@ struct fd_quic_tls_hs {
   fd_quic_tls_t * quic_tls;
 
   int             is_server;
-  int             is_flush;
   int             is_hs_complete;
 
   /* user defined context supplied in callbacks */


### PR DESCRIPTION
- **quic: less aggressive frame errors**
- **quic: accept streams before handshake confirmed**
- **quic: fix Identification field being always 0**
- **quic: fix hs_data_empty cache invalidation bug**
