### PR TITLE
flamenco: remove warning log from compute budget program

### DIFF
--- a/src/flamenco/runtime/program/fd_compute_budget_program.c
+++ b/src/flamenco/runtime/program/fd_compute_budget_program.c
@@ -63,8 +63,6 @@ fd_executor_compute_budget_program_execute_instructions( fd_exec_txn_ctx_t * ctx
 
     int ret = fd_compute_budget_program_instruction_decode( &instruction, &decode_ctx );
     if ( ret ) {
-      FD_LOG_WARNING(("fd_compute_budget_program_instruction_decode failed"));
-      FD_LOG_HEXDUMP_WARNING(("cbi data", data, instr->data_sz));
       FD_TXN_ERR_FOR_LOG_INSTR( ctx, FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA, i );
       return FD_RUNTIME_TXN_ERR_INSTRUCTION_ERROR;
     }


### PR DESCRIPTION
This warning floods stdout