### PR TITLE
Add ethtool-loopback stage

### DIFF
--- a/book/api/cli.md
+++ b/book/api/cli.md
@@ -58,8 +58,8 @@ monitor by sending Ctrl+C or `SIGINT`.
 
 ## `configure`
 Configures the operating system so that it can run Firedancer. See
-[the guide](/guide/initializing) for more information. There are three
-possible stages to each configure command:
+[the guide](/guide/initializing) for more information. There are the
+following stages to each configure command:
 
  - `hugetlbfs` Reserves huge and gigantic pages for use by Firedancer
     and mounts huge page filesystems for then under a path in the
@@ -69,6 +69,7 @@ possible stages to each configure command:
     device.
  - `ethtool-gro` Disables generic receive offload (GRO) on the network
     device.
+ - `ethtool-loopback` Disables UDP segmentation on the loopback device.
 
 ::: code-group
 
@@ -95,7 +96,8 @@ and configure the number of combined channels on the network device.
 |------------|--------|
 | `root` | increase `/proc/sys/vm/nr_hugepages` and mount hugetblfs filesystems. Only applies for the `hugetlbfs` stage |
 | `root` | increase network device channels with `ethtool --set-channels`. Only applies for the `ethtool-channels` stage |
-| `root` | disable network device generic-receive-offload (gro) with `ethtool --set-offload generic-receive-offload off`. Only applies for the `ethtool-gro` stage |
+| `root` | disable network device generic-receive-offload (gro) with `ethtool --offload IFACE generic-receive-offload off`. Only applies for the `ethtool-gro` stage |
+| `root` | disable network device tx-udp-segmentation with `ethtool --offload lo tx-udp-segmentation off`. Only applies for the `ethtool-loopback` stage |
 | `CAP_SYS_ADMIN` | set kernel parameters in `/proc/sys`. Only applies for the `sysctl` stage |
 
 :::
@@ -144,7 +146,7 @@ style `identity.json` key file. The command writes diagnostic messages
 from logs to `stderr`.
 
 ```sh [bash]
-$ fdctl keys pubkey ~/.firedancer/fd1/identity.json 
+$ fdctl keys pubkey ~/.firedancer/fd1/identity.json
 Fe4StcZSQ228dKK2hni7aCP7ZprNhj8QKWzFe5usGFYF
 ```
 

--- a/book/snippets/commands/configure-check.ansi
+++ b/book/snippets/commands/configure-check.ansi
@@ -3,4 +3,5 @@ $ fdctl configure check all
 [93mWARNING[0m sysctl ... not configured ... kernel parameter `/proc/sys/vm/max_map_count` is too low (got 65536 but expected at least 1000000)
 [93mWARNING[0m ethtool-channels ... not configured ... device `ens3f0` does not have right number of channels (got 1 but expected 2)
 [93mWARNING[0m ethtool-gro ... not configured ... device `ens3f0` has generic-receive-offload enabled. Should be disabled
+[93mWARNING[0m ethtool-loopback ... not configured ... device `lo` has tx-udp-segmentation enabled. Should be disabled
 [31mERR    [0m failed to configure some stages

--- a/book/snippets/commands/configure-init.ansi
+++ b/book/snippets/commands/configure-init.ansi
@@ -19,3 +19,6 @@ $ fdctl configure init all
 [32mNOTICE [0m ethtool-gro ... unconfigured ... device `ens3f0` has generic-receive-offload enabled. Should be disabled
 [32mNOTICE [0m ethtool-gro ... configuring
 [32mNOTICE [0m ethtool-gro ... RUN: `ethtool --offload ens3f0 generic-receive-offload off`
+[32mNOTICE [0m ethtool-loopback ... unconfigured ... device `lo` has tx-udp-segmentation enabled. Should be disabled
+[32mNOTICE [0m ethtool-loopback ... configuring
+[32mNOTICE [0m ethtool-loopback ... RUN: `ethtool --offload lo tx-udp-segmentation off`

--- a/book/snippets/configure.ansi
+++ b/book/snippets/configure.ansi
@@ -7,3 +7,4 @@
 [32mNOTICE [0m sysctl ... already valid
 [32mNOTICE [0m ethtool-channels ... already valid
 [32mNOTICE [0m ethtool-gro ... already valid
+[32mNOTICE [0m ethtool-loopback ... already valid

--- a/book/snippets/ethtool-loopback.ansi
+++ b/book/snippets/ethtool-loopback.ansi
@@ -1,0 +1,7 @@
+$ sudo fdctl configure init ethtool-loopback
+[32mNOTICE [0m ethtool-loopback ... unconfigured ... device `lo` has tx-udp-segmentation enabled. Should be disabled
+[32mNOTICE [0m ethtool-loopback ... configuring
+[32mNOTICE [0m ethtool-loopback ... RUN: `ethtool --offload lo tx-udp-segmentation off`
+
+$ ethtool --show-offload lo | grep tx-udp-segmentation
+tx-udp-segmentation: off

--- a/contrib/test/setup_fd_only_follower.sh
+++ b/contrib/test/setup_fd_only_follower.sh
@@ -61,7 +61,7 @@ name = \"fd2test\"
         entrypoints = [\"$1\"]
         peer_ports = [8700]
         gossip_listen_port = 8800
-    
+
     [tiles.repair]
         repair_intake_listen_port = 8801
         repair_serve_listen_port = 8802
@@ -92,7 +92,7 @@ name = \"fd2test\"
 sudo $FD_DIR/build/native/$CC/bin/fddev configure init kill --config $(readlink -f fddev.toml)
 sudo $FD_DIR/build/native/$CC/bin/fddev configure init hugetlbfs --config $(readlink -f fddev.toml)
 sudo $FD_DIR/build/native/$CC/bin/fddev configure init ethtool-channels --config $(readlink -f fddev.toml)
-sudo $FD_DIR/build/native/$CC/bin/fddev configure init ethtool-gro --config $(readlink -f fddev.toml)
+sudo $FD_DIR/build/native/$CC/bin/fddev configure init ethtool-gro ethtool-loopback --config $(readlink -f fddev.toml)
 sudo $FD_DIR/build/native/$CC/bin/fddev configure init keys --config $(readlink -f fddev.toml)
 
 sudo gdb -iex="set debuginfod enabled on" -ex=r --args $FD_DIR/build/native/$CC/bin/fddev dev --no-configure --log-path $(readlink -f fddev.log) --config $(readlink -f fddev.toml) --no-solana --no-sandbox --no-clone

--- a/contrib/test/setup_fd_only_leader.sh
+++ b/contrib/test/setup_fd_only_leader.sh
@@ -44,7 +44,7 @@ name = \"fd1\"
         entrypoints = [\"$PRIMARY_IP\"]
         peer_ports = [8001]
         gossip_listen_port = 8700
-    
+
     [tiles.repair]
         repair_intake_listen_port = 8701
         repair_serve_listen_port = 8702
@@ -79,7 +79,7 @@ name = \"fd1\"
 sudo $FD_DIR/build/native/$CC/bin/fddev configure init kill --config $(readlink -f fddev.toml)
 sudo $FD_DIR/build/native/$CC/bin/fddev configure init hugetlbfs --config $(readlink -f fddev.toml)
 sudo $FD_DIR/build/native/$CC/bin/fddev configure init ethtool-channels --config $(readlink -f fddev.toml)
-sudo $FD_DIR/build/native/$CC/bin/fddev configure init ethtool-gro --config $(readlink -f fddev.toml)
+sudo $FD_DIR/build/native/$CC/bin/fddev configure init ethtool-gro ethtool-loopback --config $(readlink -f fddev.toml)
 sudo $FD_DIR/build/native/$CC/bin/fddev configure init keys --config $(readlink -f fddev.toml)
 
 sudo gdb -iex="set debuginfod enabled on" -ex=r --args $FD_DIR/build/native/$CC/bin/fddev dev --no-configure --log-path $(readlink -f fddev.log) --config $(readlink -f fddev.toml) --no-solana --no-sandbox --no-clone

--- a/contrib/test/test_firedancer.sh
+++ b/contrib/test/test_firedancer.sh
@@ -130,7 +130,7 @@ name = \"fd1test\"
         entrypoints = [\"$PRIMARY_IP\"]
         peer_ports = [8001]
         gossip_listen_port = 8700
-    
+
     [tiles.repair]
         repair_intake_listen_port = 8701
         repair_serve_listen_port = 8702
@@ -158,7 +158,7 @@ name = \"fd1test\"
 sudo $FD_DIR/build/native/$CC/bin/fddev configure init kill --config $(readlink -f fddev.toml)
 sudo $FD_DIR/build/native/$CC/bin/fddev configure init hugetlbfs --config $(readlink -f fddev.toml)
 sudo $FD_DIR/build/native/$CC/bin/fddev configure init ethtool-channels --config $(readlink -f fddev.toml)
-sudo $FD_DIR/build/native/$CC/bin/fddev configure init ethtool-gro --config $(readlink -f fddev.toml)
+sudo $FD_DIR/build/native/$CC/bin/fddev configure init ethtool-gro ethtool-loopback --config $(readlink -f fddev.toml)
 sudo $FD_DIR/build/native/$CC/bin/fddev configure init keys --config $(readlink -f fddev.toml)
 
 sudo $FD_DIR/build/native/$CC/bin/fddev dev --no-configure --log-path $(readlink -f fddev.log) --config $(readlink -f fddev.toml) --no-solana --no-sandbox --no-clone &

--- a/contrib/test/test_firedancer_genesis.sh
+++ b/contrib/test/test_firedancer_genesis.sh
@@ -40,7 +40,7 @@ name = \"fd1test\"
         entrypoints = [\"$PRIMARY_IP\"]
         peer_ports = [8001]
         gossip_listen_port = 8700
-    
+
     [tiles.repair]
         repair_intake_listen_port = 8701
         repair_serve_listen_port = 8702
@@ -69,7 +69,7 @@ name = \"fd1test\"
 sudo $FD_DIR/build/native/$CC/bin/fddev configure init kill --config $(readlink -f fddev.toml)
 sudo $FD_DIR/build/native/$CC/bin/fddev configure init hugetlbfs --config $(readlink -f fddev.toml)
 sudo $FD_DIR/build/native/$CC/bin/fddev configure init ethtool-channels --config $(readlink -f fddev.toml)
-sudo $FD_DIR/build/native/$CC/bin/fddev configure init ethtool-gro --config $(readlink -f fddev.toml)
+sudo $FD_DIR/build/native/$CC/bin/fddev configure init ethtool-gro ethtool-loopback --config $(readlink -f fddev.toml)
 sudo $FD_DIR/build/native/$CC/bin/fddev configure init keys --config $(readlink -f fddev.toml)
 
 sudo gdb -iex="set debuginfod enabled on" -ex=r --args $FD_DIR/build/native/$CC/bin/fddev dev --no-configure --log-path $(readlink -f fddev.log) --config $(readlink -f fddev.toml) --no-solana --no-sandbox --no-clone

--- a/contrib/test/test_firedancer_leader.sh
+++ b/contrib/test/test_firedancer_leader.sh
@@ -98,7 +98,7 @@ name = \"fd1\"
 sudo $FD_DIR/$OBJDIR/bin/fddev configure init kill --config $(readlink -f fddev.toml)
 sudo $FD_DIR/$OBJDIR/bin/fddev configure init hugetlbfs --config $(readlink -f fddev.toml)
 sudo $FD_DIR/$OBJDIR/bin/fddev configure init ethtool-channels --config $(readlink -f fddev.toml)
-sudo $FD_DIR/$OBJDIR/bin/fddev configure init ethtool-gro --config $(readlink -f fddev.toml)
+sudo $FD_DIR/$OBJDIR/bin/fddev configure init ethtool-gro ethtool-loopback --config $(readlink -f fddev.toml)
 sudo $FD_DIR/$OBJDIR/bin/fddev configure init keys --config $(readlink -f fddev.toml)
 
 sudo gdb -iex="set debuginfod enabled on" -ex=r --args $FD_DIR/$OBJDIR/bin/fddev dev --no-configure --log-path $(readlink -f fddev.log) --config $(readlink -f fddev.toml) --no-solana --no-sandbox --no-clone

--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -67,6 +67,7 @@ $(call add-objs,configure/hugetlbfs,fd_fdctl)
 $(call add-objs,configure/sysctl,fd_fdctl)
 $(call add-objs,configure/ethtool-channels,fd_fdctl)
 $(call add-objs,configure/ethtool-gro,fd_fdctl)
+$(call add-objs,configure/ethtool-loopback,fd_fdctl)
 
 ifdef FD_HAS_NO_AGAVE
 ifdef FD_HAS_SECP256K1

--- a/src/app/fdctl/configure/configure.h
+++ b/src/app/fdctl/configure/configure.h
@@ -67,6 +67,7 @@ extern configure_stage_t fd_cfg_stage_hugetlbfs;
 extern configure_stage_t fd_cfg_stage_sysctl;
 extern configure_stage_t fd_cfg_stage_ethtool_channels;
 extern configure_stage_t fd_cfg_stage_ethtool_gro;
+extern configure_stage_t fd_cfg_stage_ethtool_loopback;
 extern configure_stage_t fd_cfg_stage_workspace;
 
 extern configure_stage_t * STAGES[];

--- a/src/app/fdctl/configure/ethtool-gro.c
+++ b/src/app/fdctl/configure/ethtool-gro.c
@@ -1,3 +1,9 @@
+/* This stage disables the "Generic Receive Offload" ethtool feature on the
+   main and loopback interfaces.  If left enabled, GRO will mangle UDP
+   packets in a way that causes AF_XDP packets to get corrupted.
+
+   TLDR GRO and AF_XDP are incompatible. */
+
 #include "configure.h"
 
 #include <stdio.h>
@@ -21,7 +27,7 @@ static void
 init_perm( fd_caps_ctx_t *  caps,
            config_t * const config ) {
   (void)config;
-  fd_caps_check_root( caps, NAME, "disable network device generic-receive-offload (gro) with `ethtool --set-offload generic-receive-offload off`" );
+  fd_caps_check_root( caps, NAME, "disable network device generic-receive-offload (gro) with `ethtool --offload generic-receive-offload off`" );
 }
 
 static int
@@ -114,6 +120,7 @@ init( config_t * const config ) {
   } else {
     init_device( config->tiles.net.interface );
   }
+  init_device( "lo" );
 }
 
 static configure_result_t

--- a/src/app/fdctl/configure/ethtool-loopback.c
+++ b/src/app/fdctl/configure/ethtool-loopback.c
@@ -1,0 +1,199 @@
+/* This stage disables the "tx-udp-segmentation" offload on the loopback
+   interface.  If left enabled, AF_XDP will drop loopback UDP packets sent
+   by processes that enable TX segmentation via SOL_UDP/UDP_SEGMENT sockopt
+   or cmsg.
+
+   TLDR tx-udp-segmentation and AF_XDP are incompatible. */
+
+#include "configure.h"
+
+#include <net/if.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <linux/if.h>
+#include <linux/ethtool.h>
+#include <linux/sockios.h>
+
+#define NAME "ethtool-loopback"
+#define MAX_FEATURES (1024)
+
+#define UDPSEG_FEATURE "tx-udp-segmentation"
+static char const udpseg_feature[] = UDPSEG_FEATURE;
+
+static int
+enabled( config_t * const config ) {
+  /* FIXME support for netns is missing */
+  return !config->development.netns.enabled;
+}
+
+static void
+init_perm( fd_caps_ctx_t *  caps,
+           config_t * const config ) {
+  (void)config;
+  fd_caps_check_root( caps, NAME, "disable loopback " UDPSEG_FEATURE " with `ethtool --offload lo " UDPSEG_FEATURE " off`" );
+}
+
+/* ethtool_ioctl wraps ioctl(sock,SIOCETHTOOL,"lo",*) */
+
+static int
+ethtool_ioctl( int    sock,
+               void * data ) {
+  struct ifreq ifr = {0};
+  strcpy( ifr.ifr_name, "lo" );
+  ifr.ifr_data = data;
+  return ioctl( sock, SIOCETHTOOL, &ifr );
+}
+
+/* find_feature_index finds the index of an ethtool feature. */
+
+static int
+find_feature_index( int          sock,
+                    char const * feature ) {
+
+  struct {
+    struct ethtool_sset_info r;
+    uint   data[1];
+  } set_info = { .r = {
+    .cmd       = ETHTOOL_GSSET_INFO,
+    .sset_mask = fd_ulong_mask_bit( ETH_SS_FEATURES )
+  } };
+  if( FD_UNLIKELY( ethtool_ioctl( sock, &set_info ) ) ) {
+    FD_LOG_ERR(( "error configuring network device, ioctl(SIOCETHTOOL,ETHTOOL_GSSET_INFO) failed (%i-%s)",
+                 errno, fd_io_strerror( errno ) ));
+  }
+  uint const feature_cnt = fd_uint_min( set_info.data[0], MAX_FEATURES );
+
+  static struct {
+    struct ethtool_gstrings r;
+    char data[ MAX_FEATURES * ETH_GSTRING_LEN ];
+  } get_strings;
+  get_strings.r = (struct ethtool_gstrings) {
+    .cmd        = ETHTOOL_GSTRINGS,
+    .string_set = ETH_SS_FEATURES,
+    .len        = feature_cnt
+  };
+  if( FD_UNLIKELY( ethtool_ioctl( sock, &get_strings ) ) ) {
+    FD_LOG_ERR(( "error configuring network device, ioctl(SIOCETHTOOL,ETHTOOL_GSTRINGS) failed (%i-%s)",
+                 errno, fd_io_strerror( errno ) ));
+  }
+
+  for( uint j=0UL; j<feature_cnt; j++ ) {
+    char const * str = get_strings.data + (j*ETH_GSTRING_LEN);
+    if( 0==strncmp( str, feature, ETH_GSTRING_LEN ) ) return (int)j;
+  }
+  return -1;
+}
+
+/* get_feature_state checks if the ethtool feature at index is set.
+   Returns 1 if enabled, 0 if disabled.  Terminates app on failure. */
+
+static _Bool
+get_feature_state( int sock,
+                   int index ) {
+  FD_TEST( index>0 && index<MAX_FEATURES );
+
+  struct {
+    struct ethtool_gfeatures r;
+    struct ethtool_get_features_block data[ (MAX_FEATURES+31)/32 ];
+  } get_features;
+  get_features.r = (struct ethtool_gfeatures) {
+    .cmd  = ETHTOOL_GFEATURES,
+    .size = (MAX_FEATURES+31)/32
+  };
+  if( FD_UNLIKELY( ethtool_ioctl( sock, &get_features ) ) ) {
+    FD_LOG_ERR(( "error configuring network device, ioctl(SIOCETHTOOL,ETHTOOL_GFEATURES) failed (%i-%s)",
+                 errno, fd_io_strerror( errno ) ));
+  }
+
+  uint bucket = (uint)index / 32u;
+  uint offset = (uint)index % 32u;
+  return fd_uint_extract_bit( get_features.data[ bucket ].active, (int)offset );
+}
+
+/* change_feature updates the ethtool feature at the specified index.
+   state==1 implies enable, state==0 implies disable.  Terminates app on
+   failure. */
+
+static void
+change_feature( int   sock,
+                int   index,
+                _Bool state ) {
+  FD_TEST( index>0 && index<MAX_FEATURES );
+  uint bucket = (uint)index / 32u;
+  uint offset = (uint)index % 32u;
+
+  struct {
+    struct ethtool_sfeatures r;
+    struct ethtool_set_features_block data[ (MAX_FEATURES+31)/32 ];
+  } set_features = {0};
+  set_features.r = (struct ethtool_sfeatures) {
+    .cmd  = ETHTOOL_SFEATURES,
+    .size = bucket+1,
+  };
+
+  set_features.data[ bucket ].valid     = 1u<<offset;
+  set_features.data[ bucket ].requested = ((uint)state)<<offset;
+
+  if( FD_UNLIKELY( ethtool_ioctl( sock, &set_features ) ) ) {
+    FD_LOG_ERR(( "error configuring network device, ioctl(SIOCETHTOOL,ETHTOOL_SFEATURES) failed (%i-%s)",
+                 errno, fd_io_strerror( errno ) ));
+  }
+}
+
+static void
+init( config_t * const config FD_PARAM_UNUSED ) {
+  int sock = socket( AF_INET, SOCK_DGRAM, 0 );
+  if( FD_UNLIKELY( sock < 0 ) )
+    FD_LOG_ERR(( "error configuring network device, socket(AF_INET,SOCK_DGRAM,0) failed (%i-%s)",
+                 errno, fd_io_strerror( errno ) ));
+
+  int feature_idx = find_feature_index( sock, udpseg_feature );
+  if( feature_idx<0 ) return;
+
+  FD_LOG_NOTICE(( "RUN: `ethtool --offload lo " UDPSEG_FEATURE " off`" ));
+
+  change_feature( sock, feature_idx, 0 ); /* disable */
+
+  if( FD_UNLIKELY( close( sock ) ) )
+    FD_LOG_ERR(( "error configuring network device, close() socket failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+}
+
+static configure_result_t
+check( config_t * const config FD_PARAM_UNUSED ) {
+  int sock = socket( AF_INET, SOCK_DGRAM, 0 );
+  if( FD_UNLIKELY( sock < 0 ) )
+    FD_LOG_ERR(( "error configuring network device, socket(AF_INET,SOCK_DGRAM,0) failed (%i-%s)",
+                 errno, fd_io_strerror( errno ) ));
+
+  int feature_idx = find_feature_index( sock, udpseg_feature );
+  if( feature_idx<0 ) {
+    FD_LOG_INFO(( "device `lo` missing ethtool offload `" UDPSEG_FEATURE "`, ignoring" ));
+    CONFIGURE_OK(); /* returns */
+  }
+
+  _Bool udpseg_enabled = get_feature_state( sock, feature_idx );
+
+  if( FD_UNLIKELY( close( sock ) ) )
+    FD_LOG_ERR(( "error configuring network device, close() socket failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+
+  if( udpseg_enabled ) {
+    NOT_CONFIGURED( "device `lo` has " UDPSEG_FEATURE " enabled. Should be disabled" );
+  }
+
+  CONFIGURE_OK();
+}
+
+configure_stage_t fd_cfg_stage_ethtool_loopback = {
+  .name            = NAME,
+  .always_recreate = 0,
+  .enabled         = enabled,
+  .init_perm       = init_perm,
+  .fini_perm       = NULL,
+  .init            = init,
+  .fini            = NULL,
+  .check           = check,
+};
+
+#undef NAME

--- a/src/app/fdctl/fdctl.h
+++ b/src/app/fdctl/fdctl.h
@@ -13,7 +13,7 @@
 extern fd_topo_run_tile_t * TILES[];
 
 
-#define CONFIGURE_STAGE_COUNT 10
+#define CONFIGURE_STAGE_COUNT 11
 struct configure_stage;
 
 typedef union {

--- a/src/app/fdctl/main.c
+++ b/src/app/fdctl/main.c
@@ -7,7 +7,7 @@ configure_stage_t * STAGES[ CONFIGURE_STAGE_COUNT ] = {
   &fd_cfg_stage_sysctl,
   &fd_cfg_stage_ethtool_channels,
   &fd_cfg_stage_ethtool_gro,
-  NULL,
+  &fd_cfg_stage_ethtool_loopback,
   NULL,
   NULL,
   NULL,

--- a/src/app/fdctl/run/run.c
+++ b/src/app/fdctl/run/run.c
@@ -663,6 +663,7 @@ initialize_stacks( config_t * const config ) {
 extern configure_stage_t fd_cfg_stage_hugetlbfs;
 extern configure_stage_t fd_cfg_stage_ethtool_channels;
 extern configure_stage_t fd_cfg_stage_ethtool_gro;
+extern configure_stage_t fd_cfg_stage_ethtool_loopback;
 extern configure_stage_t fd_cfg_stage_sysctl;
 
 static void
@@ -682,6 +683,11 @@ check_configure( config_t * const config ) {
   if( FD_UNLIKELY( check.result!=CONFIGURE_OK ) )
     FD_LOG_ERR(( "Network %s. You can run `fdctl configure init ethtool-gro` to disable generic-receive-offload "
                  "as required.", check.message ));
+
+  check = fd_cfg_stage_ethtool_loopback.check( config );
+  if( FD_UNLIKELY( check.result!=CONFIGURE_OK ) )
+    FD_LOG_ERR(( "Network %s. You can run `fdctl configure init ethtool-loopback` to disable tx-udp-segmentation "
+                 "on the loopback device.", check.message ));
 
   check = fd_cfg_stage_sysctl.check( config );
   if( FD_UNLIKELY( check.result!=CONFIGURE_OK ) )

--- a/src/app/fdctl/run/tiles/fd_net.c
+++ b/src/app/fdctl/run/tiles/fd_net.c
@@ -185,6 +185,8 @@ net_rx_aio_send( void *                    _ctx,
     ushort udp_srcport = fd_ushort_bswap( *(ushort *)( udp+0UL    ) );
     ushort udp_dstport = fd_ushort_bswap( *(ushort *)( udp+2UL    ) );
 
+    FD_DTRACE_PROBE_4( net_tile_pkt_rx, ip_srcaddr, udp_srcport, udp_dstport, batch[i].buf_sz );
+
     ushort proto;
     fd_net_out_ctx_t * out;
     if(      FD_UNLIKELY( udp_dstport==ctx->shred_listen_port ) ) {

--- a/src/app/fddev/main1.c
+++ b/src/app/fddev/main1.c
@@ -22,6 +22,7 @@ configure_stage_t * STAGES[ CONFIGURE_STAGE_COUNT ] = {
   &fd_cfg_stage_sysctl,
   &fd_cfg_stage_ethtool_channels,
   &fd_cfg_stage_ethtool_gro,
+  &fd_cfg_stage_ethtool_loopback,
   &fd_cfg_stage_keys,
   &fd_cfg_stage_genesis,
 #ifdef FD_HAS_NO_AGAVE


### PR DESCRIPTION
Fixes Agave<>Firedancer connectivity on loopback.

Agave's QUIC client, the quinn library, uses UDP segmentation which
is incompatible with AF_XDP.  The ethtool-loopback fdctl stage is
introduced to disable the UDP segmentation feature using ethtool.

If the ethtool tx-udp-segmentation feature is enabled on the
loopback device, any sendmsg() calls that send more than one packet
via UDP_SEGMENT result in all packets getting lost.
