### PR TITLE
fdctl: remove vote key path check

### DIFF
--- a/src/app/fdctl/run/run.c
+++ b/src/app/fdctl/run/run.c
@@ -703,10 +703,6 @@ run_firedancer_init( config_t * const config,
   if( FD_UNLIKELY( -1==err && errno==ENOENT ) ) FD_LOG_ERR(( "[consensus.identity_path] key does not exist `%s`. You can generate an identity key at this path by running `fdctl keys new identity --config <toml>`", config->consensus.identity_path ));
   else if( FD_UNLIKELY( -1==err ) )             FD_LOG_ERR(( "could not stat [consensus.identity_path] `%s` (%i-%s)", config->consensus.identity_path, errno, fd_io_strerror( errno ) ));
 
-  err = stat( config->consensus.vote_account_path, &st );
-  if( FD_UNLIKELY( -1==err && errno==ENOENT ) ) FD_LOG_ERR(( "[consensus.vote_account_path] key does not exist `%s`. You can generate an vote key at this path by running `fdctl keys new vote --config <toml>`", config->consensus.vote_account_path ));
-  else if( FD_UNLIKELY( -1==err ) )             FD_LOG_ERR(( "could not stat [consensus.vote_account_path] `%s` (%i-%s)", config->consensus.vote_account_path, errno, fd_io_strerror( errno ) ));
-
   for( ulong i=0UL; i<config->consensus.authorized_voter_paths_cnt; i++ ) {
     err = stat( config->consensus.authorized_voter_paths[ i ], &st );
     if( FD_UNLIKELY( -1==err && errno==ENOENT ) ) FD_LOG_ERR(( "[consensus.authorized_voter_paths] key does not exist `%s`", config->consensus.authorized_voter_paths[ i ] ));


### PR DESCRIPTION
Fixes https://github.com/firedancer-io/firedancer/issues/3787

The voting private key does not need to be specified for the validator to start and a lot of operators only have the pubkey handy (which the Agave validator takes as a valid argument). This should also allow the validator to start without setting the voting key which translates to a non-voting validator.