### PR TITLE
Add fetch param to deps.sh

### DIFF
--- a/contrib/docker/ubuntu2004/Dockerfile
+++ b/contrib/docker/ubuntu2004/Dockerfile
@@ -32,7 +32,7 @@ ARG MACHINE=linux_gcc_x86_64
 ARG GITTAG
 RUN git clone --recurse-submodules https://github.com/firedancer-io/firedancer.git ${WORKDIR} && \
 	[ -n ${GITTAG} ] && git checkout ${GITTAG} && \
-	FD_AUTO_INSTALL_PACKAGES=1 DEBIAN_FRONTEND=noninteractive ./deps.sh check install && \
+	FD_AUTO_INSTALL_PACKAGES=1 DEBIAN_FRONTEND=noninteractive ./deps.sh fetch check install && \
 	MACHINE=${MACHINE} make -j all rust --output-sync=target && \
 	cp -a $(find build -type d -name bin) build/out
 


### PR DESCRIPTION
Without fetch param, it will generate the following error : 

[+] Building 0/1 line 333: cd: /firedancer/opt/git/zstd/lib: No such file or directory
