### PR TITLE
codeql: stop dataflow at termination

### DIFF
--- a/contrib/codeql/nightly/GenericDoubleFree.qll
+++ b/contrib/codeql/nightly/GenericDoubleFree.qll
@@ -11,6 +11,7 @@ class CandidateCall extends Call {
       this.getLocation().getFile().getBaseName().matches("%_ci.%") or
       this.getLocation().getFile().getBaseName() = "main.c" /* annoying mismatch with funk_init */
     )
+    and not exists(FunctionCall t | t.getTarget().getName() = "fd_log_private_2" | dominates(this, t))
   }
 }
 


### PR DESCRIPTION
Normally CodeQL should pick up on that by itself, but this additional constraint is correct and removes the false positive from code scanning