### PR TITLE
feat(blockstore): entry batch windowing

### DIFF
--- a/src/app/fdctl/run/tiles/fd_repair.c
+++ b/src/app/fdctl/run/tiles/fd_repair.c
@@ -442,7 +442,7 @@ repair_get_shred( ulong  slot,
       fd_blockstore_end_read( blockstore );
       return -1L;
     }
-    shred_idx = (uint)meta->complete_idx;
+    shred_idx = (uint)meta->slot_complete_idx;
   }
   long sz = fd_buf_shred_query_copy_data( blockstore, slot, shred_idx, buf, buf_max );
 

--- a/src/disco/geyser/test_geyser.c
+++ b/src/disco/geyser/test_geyser.c
@@ -24,7 +24,7 @@ my_block_fun(ulong slot, fd_block_map_t const * meta, fd_hash_t const * parent, 
   char parent_hash[50];
   fd_base58_encode_32(parent->uc, 0, parent_hash);
   printf( "\"block\":{\"slot\":%lu,\"bank_hash\":\"%s\",\"parent_hash\":\"%s\",\"height\":%lu,\"data_sz\":%lu}\n",
-          slot, bank_hash, parent_hash, meta->height, data_sz );
+          slot, bank_hash, parent_hash, meta->block_height, data_sz );
 }
 
 static void

--- a/src/disco/rpcserver/fd_block_to_json.c
+++ b/src/disco/rpcserver/fd_block_to_json.c
@@ -676,7 +676,7 @@ fd_block_to_json( fd_webserver_t * ws,
   char phash[50];
   fd_base58_encode_32(parent_hash->uc, 0, phash);
   fd_web_reply_sprintf(ws, "\"blockHeight\":%lu,\"blockTime\":%ld,\"parentSlot\":%lu,\"blockhash\":\"%s\",\"previousBlockhash\":\"%s\"",
-                       meta->height, meta->ts/(long)1e9, meta->parent_slot, hash, phash);
+                       meta->block_height, meta->ts/(long)1e9, meta->parent_slot, hash, phash);
 
   if( rewards ) {
     fd_base58_encode_32(rewards->leader.uc, 0, hash);

--- a/src/disco/rpcserver/fd_rpc_service.c
+++ b/src/disco/rpcserver/fd_rpc_service.c
@@ -814,7 +814,7 @@ method_getEpochInfo(struct json_values* values, fd_rpc_ctx_t * ctx) {
     int ret = fd_blockstore_block_map_query_volatile(ctx->global->blockstore, ctx->global->blockstore_fd, slot, meta);
     fd_web_reply_sprintf(ws, "{\"jsonrpc\":\"2.0\",\"result\":{\"absoluteSlot\":%lu,\"blockHeight\":%lu,\"epoch\":%lu,\"slotIndex\":%lu,\"slotsInEpoch\":%lu,\"transactionCount\":%lu},\"id\":%s}" CRLF,
                          slot,
-                         (!ret ? meta->height : 0UL),
+                         (!ret ? meta->block_height : 0UL),
                          epoch,
                          slot_index,
                          fd_epoch_slot_cnt( &epoch_bank->epoch_schedule, epoch ),

--- a/src/disco/store/fd_store.c
+++ b/src/disco/store/fd_store.c
@@ -230,7 +230,7 @@ fd_store_shred_insert( fd_store_t * store,
     fd_blockstore_end_write( blockstore );
     return FD_BLOCKSTORE_OK;
   }
-  int rc = fd_buf_shred_insert( blockstore, shred );
+  int rc = fd_blockstore_shred_insert( blockstore, shred );
   fd_blockstore_end_write( blockstore );
 
   /* FIXME */
@@ -366,7 +366,7 @@ fd_store_slot_repair( fd_store_t * store,
   } else {
     /* We've received at least one shred, so fill in what's missing */
 
-    uint complete_idx = block_map_entry->complete_idx;
+    uint complete_idx = block_map_entry->slot_complete_idx;
 
     /* We don't know the last index yet */
     if( FD_UNLIKELY( complete_idx == UINT_MAX ) ) {

--- a/src/flamenco/runtime/fd_rocksdb.c
+++ b/src/flamenco/runtime/fd_rocksdb.c
@@ -567,7 +567,7 @@ fd_rocksdb_import_block_blockstore( fd_rocksdb_t *    db,
       fd_blockstore_end_write(blockstore);
       return -1;
     }
-    int rc = fd_buf_shred_insert( blockstore, shred );
+    int rc = fd_blockstore_shred_insert( blockstore, shred );
     if (rc != FD_BLOCKSTORE_OK_SLOT_COMPLETE && rc != FD_BLOCKSTORE_OK) {
       FD_LOG_WARNING(("failed to store shred %lu/%lu", slot, i));
       rocksdb_iter_destroy(iter);
@@ -609,12 +609,12 @@ fd_rocksdb_import_block_blockstore( fd_rocksdb_t *    db,
       (char const *)&slot_be, sizeof(ulong),
       &vallen,
       &err );
-    block_map_entry->height = 0;
+    block_map_entry->block_height = 0;
     if( FD_UNLIKELY( err ) ) {
       FD_LOG_WARNING(( "rocksdb: %s", err ));
       free( err );
     } else if(vallen == sizeof(ulong)) {
-      block_map_entry->height = *(ulong*)res;
+      block_map_entry->block_height = *(ulong*)res;
       free(res);
     }
 

--- a/src/flamenco/shredcap/fd_shredcap.c
+++ b/src/flamenco/shredcap/fd_shredcap.c
@@ -357,7 +357,7 @@ fd_shredcap_verify_slot( fd_shredcap_slot_hdr_t * slot_hdr,
 
     fd_shred_t * shred = (fd_shred_t*)rbuf;
     fd_blockstore_start_write( blockstore );
-    fd_buf_shred_insert( blockstore, shred );
+    fd_blockstore_shred_insert( blockstore, shred );
     fd_blockstore_end_write( blockstore );
     if ( FD_UNLIKELY( slot != shred->slot ) ) {
       FD_LOG_ERR(( "slot header's slot=%lu doesn't match shred's slot=%lu", slot, shred->slot ));
@@ -1050,7 +1050,7 @@ fd_shredcap_populate_blockstore( const char *      capture_dir,
 
         fd_shred_t * shred = (fd_shred_t*)capture_buf;
         fd_blockstore_start_write( blockstore );
-        fd_buf_shred_insert( blockstore, shred );
+        fd_blockstore_shred_insert( blockstore, shred );
         fd_blockstore_end_write( blockstore );
       }
 


### PR DESCRIPTION
Introduce entry batch support to the blockstore and replay in a backwards-compatible way. We continue to deshred and assemble entire blocks, but also add windowing metadata to support a caller copying out shreds and assembling smaller chunks (entry batches) so they don't have to wait for the whole block.