### PR TITLE
agave: allow disabling snapshots

### DIFF
--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -119,6 +119,7 @@ typedef struct {
   } rpc;
 
   struct {
+    int  enabled;
     int  incremental_snapshots;
     uint full_snapshot_interval_slots;
     uint incremental_snapshot_interval_slots;

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -325,6 +325,12 @@ dynamic_port_range = "8900-9000"
 # chain's state.  Other clients, especially as they bootstrap or catch
 # up to the head of the chain, may request a snapshot.
 [snapshots]
+    # If false, all snapshots (both full and incremental) will not be
+    # produced.  If snapshotting is disabled, this option is passed to
+    # the Agave client by setting the `--snapshot-interval-slots` flag
+    # to 0.
+    enabled = true
+
     # Enable incremental snapshots by setting this flag.  This option is
     # passed to the Agave client (inverted) with the
     # `--no-incremental-snapshots` flag.
@@ -333,7 +339,8 @@ dynamic_port_range = "8900-9000"
     # Set how frequently full snapshots are taken, measured in slots,
     # where one slot is about 400ms on production chains.  It's
     # recommended to leave this to the default or to set it to the same
-    # value that the known validators are using.
+    # value that the known validators are using.  Must be a multiple of
+    # the incremental snapshot interval.
     full_snapshot_interval_slots = 25000
 
     # Set how frequently incremental snapshots are taken, measured in

--- a/src/app/fdctl/config_parse.c
+++ b/src/app/fdctl/config_parse.c
@@ -260,6 +260,7 @@ fdctl_pod_to_cfg( config_t * config,
   CFG_POP      ( bool,   rpc.pubsub_enable_vote_subscription              );
   CFG_POP      ( bool,   rpc.bigtable_ledger_storage                      );
 
+  CFG_POP      ( bool,   snapshots.enabled                                );
   CFG_POP      ( bool,   snapshots.incremental_snapshots                  );
   CFG_POP      ( uint,   snapshots.full_snapshot_interval_slots           );
   CFG_POP      ( uint,   snapshots.incremental_snapshot_interval_slots    );

--- a/src/app/fdctl/run/run_agave.c
+++ b/src/app/fdctl/run/run_agave.c
@@ -136,9 +136,17 @@ agave_boot( config_t * config ) {
   if( config->rpc.bigtable_ledger_storage ) ADD1( "--enable-rpc-bigtable-ledger-storage" );
 
   /* snapshots */
+  if( config->snapshots.enabled ) {
+    if( config->snapshots.incremental_snapshots ) {
+      ADDU( "--full-snapshot-interval-slots", config->snapshots.full_snapshot_interval_slots );
+      ADDU( "--snapshot-interval-slots", config->snapshots.incremental_snapshot_interval_slots );
+    } else {
+      ADDU( "--snapshot-interval-slots", config->snapshots.full_snapshot_interval_slots );
+    }
+  } else {
+    ADDU( "--snapshot-interval-slots", (uint)0 );
+  }
   if( !config->snapshots.incremental_snapshots ) ADD1( "--no-incremental-snapshots" );
-  ADDU( "--full-snapshot-interval-slots", config->snapshots.full_snapshot_interval_slots );
-  ADDU( "--incremental-snapshot-interval-slots", config->snapshots.incremental_snapshot_interval_slots );
   ADD( "--snapshots", config->snapshots.path );
   if( strcmp( "", config->snapshots.incremental_path ) ) ADD( "--incremental-snapshot-archive-path", config->snapshots.incremental_path );
   ADDU( "--maximum-snapshots-to-retain", config->snapshots.maximum_full_snapshots_to_retain );


### PR DESCRIPTION
Allows snapshotting to be turned off per #3944. Also allows for a scenario if you want full snapshots but not incremental snapshots, whereby the originally passed `--full-snapshot-interval-slots` would have been ignored. 