### PR TITLE
pack: SIMD-170: set conservative limits for builtins

### DIFF
--- a/src/ballet/pack/fd_pack_cost.h
+++ b/src/ballet/pack/fd_pack_cost.h
@@ -50,20 +50,21 @@ typedef struct fd_pack_builtin_prog_cost fd_pack_builtin_prog_cost_t;
 #define MAP_PERFECT_HASH_R( ptr ) PERFECT_HASH( fd_uint_load_4( (uchar const *)ptr->b + 8UL ) )
 
 
-#define VOTE_PROG_COST 2100UL
+#define VOTE_PROG_COST 3000UL
 
-#define MAP_PERFECT_0  ( STAKE_PROG_ID           ), .cost_per_instr=         750UL
-#define MAP_PERFECT_1  ( VOTE_PROG_ID            ), .cost_per_instr=VOTE_PROG_COST
-#define MAP_PERFECT_2  ( SYS_PROG_ID             ), .cost_per_instr=         150UL
-#define MAP_PERFECT_3  ( COMPUTE_BUDGET_PROG_ID  ), .cost_per_instr=         150UL
-#define MAP_PERFECT_4  ( ADDR_LUT_PROG_ID        ), .cost_per_instr=         750UL
-#define MAP_PERFECT_5  ( BPF_UPGRADEABLE_PROG_ID ), .cost_per_instr=        2370UL
-#define MAP_PERFECT_6  ( BPF_LOADER_1_PROG_ID    ), .cost_per_instr=        1140UL
-#define MAP_PERFECT_7  ( BPF_LOADER_2_PROG_ID    ), .cost_per_instr=         570UL
-#define MAP_PERFECT_8  ( LOADER_V4_PROG_ID       ), .cost_per_instr=        2000UL
-#define MAP_PERFECT_9  ( KECCAK_SECP_PROG_ID     ), .cost_per_instr=         720UL
-#define MAP_PERFECT_10 ( ED25519_SV_PROG_ID      ), .cost_per_instr=         720UL
-#define MAP_PERFECT_11 ( SECP256R1_PROG_ID       ), .cost_per_instr=         720UL
+#define MAP_PERFECT_0  ( STAKE_PROG_ID           ), .cost_per_instr=        3000UL
+#define MAP_PERFECT_1  ( CONFIG_PROG_ID          ), .cost_per_instr=        3000UL
+#define MAP_PERFECT_2  ( VOTE_PROG_ID            ), .cost_per_instr=VOTE_PROG_COST
+#define MAP_PERFECT_3  ( SYS_PROG_ID             ), .cost_per_instr=        3000UL
+#define MAP_PERFECT_4  ( COMPUTE_BUDGET_PROG_ID  ), .cost_per_instr=        3000UL
+#define MAP_PERFECT_5  ( ADDR_LUT_PROG_ID        ), .cost_per_instr=        3000UL
+#define MAP_PERFECT_6  ( BPF_UPGRADEABLE_PROG_ID ), .cost_per_instr=        3000UL
+#define MAP_PERFECT_7  ( BPF_LOADER_1_PROG_ID    ), .cost_per_instr=        3000UL
+#define MAP_PERFECT_8  ( BPF_LOADER_2_PROG_ID    ), .cost_per_instr=        3000UL
+#define MAP_PERFECT_9  ( LOADER_V4_PROG_ID       ), .cost_per_instr=        3000UL
+#define MAP_PERFECT_10 ( KECCAK_SECP_PROG_ID     ), .cost_per_instr=        3000UL
+#define MAP_PERFECT_11 ( ED25519_SV_PROG_ID      ), .cost_per_instr=        3000UL
+#define MAP_PERFECT_12 ( SECP256R1_PROG_ID       ), .cost_per_instr=        3000UL
 
 #include "../../util/tmpl/fd_map_perfect.c"
 


### PR DESCRIPTION
The cost for built-ins will change to 3,000 lamports in SIMD-170. In order for our blocks not to be rejected when `apply_cost_tracker_during_replay` is activated, we need to charge this higher amount before the feature gate is activated.