### PR TITLE
sandbox: limit cap_last_cap to <= 64

### DIFF
--- a/src/util/sandbox/fd_sandbox.c
+++ b/src/util/sandbox/fd_sandbox.c
@@ -553,7 +553,7 @@ fd_sandbox_private_read_cap_last_cap( void ) {
   ulong cap_last_cap = strtoul( buf, &end, 10 );
   if( *end!='\n' ) FD_LOG_ERR(( "read(/proc/sys/kernel/cap_last_cap) returned malformed data" ));
   if( close( fd ) ) FD_LOG_ERR(( "close(/proc/sys/kernel/cap_last_cap) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
-  if( !cap_last_cap || cap_last_cap>128 ) FD_LOG_ERR(( "read(/proc/sys/kernel/cap_last_cap) returned invalid data" ));
+  if( !cap_last_cap || cap_last_cap>=64 ) FD_LOG_ERR(( "read(/proc/sys/kernel/cap_last_cap) returned invalid data" ));
 
   return cap_last_cap;
 }


### PR DESCRIPTION
Nit, but if we were to encounter a kernel that has > 63 caps, `struct __user_cap_data_struct   data[2] = { { 0 } }` would be too small