### PR TITLE
QUIC - RTT handling code, improved packet expiry

### DIFF
--- a/src/waltz/quic/fd_quic_enum.h
+++ b/src/waltz/quic/fd_quic_enum.h
@@ -116,5 +116,16 @@
 #define FD_QUIC_PKT_NUM_UNUSED  (~0ul)
 #define FD_QUIC_PKT_NUM_PENDING (~1ul)
 
-#endif
+/* scheduling granularity */
+/* does not need to be remotely accurate */
+/* used for calculating an upper bound on the expected response of an ack */
+#define FD_QUIC_SCHED_GRANULARITY_US 10.0f
 
+/* RTT probe period */
+/* used to bound the time between RTT measurements */
+#define FD_QUIC_RTT_PERIOD_US 60e6f
+
+/* initial RTT, used before it's measured */
+#define FD_QUIC_INITIAL_RTT_US 200e3f
+
+#endif

--- a/src/waltz/quic/fd_quic_pkt_meta.h
+++ b/src/waltz/quic/fd_quic_pkt_meta.h
@@ -84,14 +84,16 @@ struct fd_quic_pkt_meta {
 # define          FD_QUIC_PKT_META_FLAGS_STREAM             (1u<<1u)
 # define          FD_QUIC_PKT_META_FLAGS_HS_DONE            (1u<<2u)
 # define          FD_QUIC_PKT_META_FLAGS_MAX_DATA           (1u<<3u)
-# define          FD_QUIC_PKT_META_FLAGS_MAX_STREAMS_UNIDIR (1u<<5u)
-# define          FD_QUIC_PKT_META_FLAGS_CLOSE              (1u<<8u)
+# define          FD_QUIC_PKT_META_FLAGS_MAX_STREAMS_UNIDIR (1u<<4u)
+# define          FD_QUIC_PKT_META_FLAGS_CLOSE              (1u<<5u)
+# define          FD_QUIC_PKT_META_FLAGS_PING               (1u<<6u)
   fd_quic_range_t        range;       /* CRYPTO data range; FIXME use pkt_meta var instead */
   ulong                  stream_id;   /* if this contains stream data,
                                          the stream id, else zero */
 
-  ulong                  expiry; /* time pkt_meta expires... this is the time the
-                                  ack is expected by */
+  ulong                  tx_time;     /* transmit time */
+  ulong                  expiry;      /* time pkt_meta expires... this is the time the
+                                         ack is expected by */
 
   fd_quic_pkt_meta_var_t var[FD_QUIC_PKT_META_VAR_MAX];
 

--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -131,6 +131,10 @@ struct fd_quic_pkt {
   uint               ack_flag;    /* ORed together: 0-don't ack  1-ack  2-cancel ack */
 # define ACK_FLAG_RQD     1
 # define ACK_FLAG_CANCEL  2
+
+  ulong              rtt_pkt_number; /* packet number used for rtt */
+  ulong              rtt_ack_time;
+  ulong              rtt_ack_delay;
 };
 
 struct fd_quic_frame_ctx {
@@ -380,6 +384,80 @@ fd_quic_conn_at_idx( fd_quic_state_t * quic_state, ulong idx ) {
   ulong addr = quic_state->conn_base;
   ulong sz   = quic_state->conn_sz;
   return (fd_quic_conn_t*)( addr + idx * sz );
+}
+
+/* called with round-trip-time (rtt) and the ack delay (from the spec)
+ * to sample the round trip times.
+ * Arguments:
+ *   conn            The connection to be updated
+ *   rtt_ticks       The round trip time in ticks
+ *   ack_delay       The ack_delay field supplied by the peer in peer units
+ *
+ * Updates:
+ *   smoothed_rtt    EMA over adjusted rtt
+ *   min_rtt         minimum unadjusted rtt over all samples
+ *   latest_rtt      the most recent rtt sample */
+static inline void
+fd_quic_sample_rtt( fd_quic_conn_t * conn, long rtt_ticks, long ack_delay ) {
+  /* for convenience */
+  fd_quic_conn_rtt_t * rtt = conn->rtt;
+
+  /* ack_delay is in peer units, so scale to put in ticks */
+  float ack_delay_ticks = (float)ack_delay * rtt->peer_ack_delay_scale;
+
+  /* bound ack_delay by peer_max_ack_delay */
+  ack_delay_ticks = fminf( ack_delay_ticks, rtt->peer_max_ack_delay_ticks );
+
+  /* minrtt is estimated from rtt_ticks without adjusting for ack_delay */
+  rtt->min_rtt = fminf( rtt->min_rtt, (float)rtt_ticks );
+
+  /* smoothed_rtt is calculated from adjusted rtt_ticks
+       except: ack_delay must not be subtracted if the result would be less than minrtt */
+  float adj_rtt = fmaxf( rtt->min_rtt, (float)rtt_ticks - (float)ack_delay_ticks );
+
+  rtt->latest_rtt = adj_rtt;
+
+  /* according to rfc 9002 */
+  if( !rtt->is_rtt_valid ) {
+    rtt->smoothed_rtt = adj_rtt;
+    rtt->var_rtt      = adj_rtt * 0.5f;
+    rtt->is_rtt_valid = 1;
+  } else {
+    rtt->smoothed_rtt = (7.f/8.f) * rtt->smoothed_rtt + (1.f/8.f) * adj_rtt;
+    float var_rtt_sample = fabsf( rtt->smoothed_rtt - adj_rtt );
+    rtt->var_rtt = (3.f/4.f) * rtt->var_rtt + (1.f/4.f) * var_rtt_sample;
+
+    FD_DEBUG({
+      double us_per_tick = 1.0 / (double)conn->quic->config.tick_per_us;
+      FD_LOG_NOTICE(( "conn_idx: %u  min_rtt: %f  smoothed_rtt: %f  var_rtt: %f  adj_rtt: %f  rtt_ticks: %f  ack_delay_ticks: %f  diff: %f",
+                       (uint)conn->conn_idx,
+                       us_per_tick * (double)rtt->min_rtt,
+                       us_per_tick * (double)rtt->smoothed_rtt,
+                       us_per_tick * (double)rtt->var_rtt,
+                       us_per_tick * (double)adj_rtt,
+                       us_per_tick * (double)rtt_ticks,
+                       us_per_tick * (double)ack_delay_ticks,
+                       us_per_tick * ( (double)rtt_ticks - (double)ack_delay_ticks ) ));
+    })
+  }
+
+}
+
+static inline ulong
+fd_quic_calc_expiry( fd_quic_conn_t * conn, ulong now ) {
+  /* Instead of a full implementation of PTO, we're setting an expiry
+     time per sent QUIC packet
+     This calculates the expiry time according to the PTO spec
+     6.2.1. Computing PTO
+     When an ack-eliciting packet is transmitted, the sender schedules
+     a timer for the PTO period as follows:
+     PTO = smoothed_rtt + max(4*rttvar, kGranularity) + max_ack_delay  */
+
+  fd_quic_conn_rtt_t * rtt = conn->rtt;
+
+  return now + (ulong)( rtt->smoothed_rtt
+                        + fmaxf( 4.0f * rtt->var_rtt, rtt->sched_granularity_ticks )
+                        + rtt->peer_max_ack_delay_ticks );
 }
 
 FD_PROTOTYPES_END

--- a/src/waltz/quic/tests/test_quic_bw.c
+++ b/src/waltz/quic/tests/test_quic_bw.c
@@ -259,8 +259,8 @@ main( int     argc,
   /* allow acks to go */
   for( unsigned j = 0; j < 10; ++j ) {
     FD_LOG_INFO(( "running services" ));
-    service_client( client_quic );;
-    service_server( server_quic );;
+    service_client( client_quic );
+    service_server( server_quic );
   }
 
   FD_TEST( client_quic->metrics.conn_closed_cnt==1 );


### PR DESCRIPTION
In normal running the client keeps sending us streams, and we send acks. Because acks aren't "mandatory ack" we don't get an RTT from them. So also added code to periodically (once per minute) throw in a ping.
Calculates smoothed_rtt and var_rtt (rttvar) according to spec. Uses these to set expiry on packets.

Follow up could include an implementation of the PTO (Probe Time Out) algorithms from the spec.