### PR TITLE
Minor fd_map_slot_para cleanups

### DIFF
--- a/src/util/tmpl/fd_map_slot_para.c
+++ b/src/util/tmpl/fd_map_slot_para.c
@@ -1132,8 +1132,8 @@ struct MAP_(iter_private) {
   ulong           memo;                    /* matching memo for iteration */
   ulong           ele_idx;                 /* If ele_rem>0, currernt matching element, ignored otherwise */
   ulong           ele_rem;                 /* Number of elements remaining to probe, in [0,probe_max] */
-  MAP_VERSION_T   version_lock0;           /* Index of first lock used by this iter, in [0,lock_cnt] */
-  MAP_VERSION_T   version_cnt;             /* Number of locks used by this iter, in [0,lock_cnt] (typically 1) */
+  ulong           version_lock0;           /* Index of first lock used by this iter, in [0,lock_cnt] */
+  ulong           version_cnt;             /* Number of locks used by this iter, in [0,lock_cnt] (typically 1) */
   MAP_VERSION_T   version[ MAP_LOCK_MAX ]; /* Direct mapped cache of version numbers for unlock */
 };
 
@@ -1302,9 +1302,9 @@ FD_FN_PURE static inline ulong MAP_(seed)     ( MAP_(t) const * join ) { return 
 FD_FN_PURE static inline void const * MAP_(shmap_const)( MAP_(t) const * join ) { return ((MAP_(shmem_t) const *)join->lock)-1; }
 FD_FN_PURE static inline void const * MAP_(shele_const)( MAP_(t) const * join ) { return join->ele;     }
 
-FD_FN_CONST void       * MAP_(ctx)      ( MAP_(t)       * join ) { return join->ctx; }
-FD_FN_CONST void const * MAP_(ctx_const)( MAP_(t) const * join ) { return join->ctx; }
-FD_FN_CONST ulong        MAP_(ctx_max)  ( MAP_(t) const * join ) { (void)join; return MAP_CTX_MAX; }
+FD_FN_CONST static inline void       * MAP_(ctx)      ( MAP_(t)       * join ) { return join->ctx; }
+FD_FN_CONST static inline void const * MAP_(ctx_const)( MAP_(t) const * join ) { return join->ctx; }
+FD_FN_CONST static inline ulong        MAP_(ctx_max)  ( MAP_(t) const * join ) { (void)join; return MAP_CTX_MAX; }
 
 FD_FN_PURE static inline void * MAP_(shmap)( MAP_(t) * join ) { return ((MAP_(shmem_t) *)join->lock)-1; }
 FD_FN_PURE static inline void * MAP_(shele)( MAP_(t) * join ) { return join->ele; }


### PR DESCRIPTION
- Use correct types in iterator when using custom versioned indexes.
- Add missing static inlines when generating a library instance.