### PR TITLE
flamenco: epoch boundary stakes cache optimizations

### DIFF
--- a/src/flamenco/rewards/fd_rewards.c
+++ b/src/flamenco/rewards/fd_rewards.c
@@ -106,7 +106,7 @@ slot_in_year_for_inflation( fd_exec_slot_ctx_t * slot_ctx ) {
 static void
 calculate_stake_points_and_credits(
   fd_stake_history_t const *     stake_history,
-  fd_stake_t *                   stake,
+  fd_stake_t const *             stake,
   fd_vote_state_versioned_t *    vote_state_versioned,
   ulong *                        new_rate_activation_epoch,
   fd_calculated_stake_points_t * result
@@ -188,7 +188,7 @@ calculate_stake_points_and_credits(
 static int
 calculate_stake_rewards(
   fd_stake_history_t const *      stake_history,
-  fd_stake_state_v2_t *           stake_state,
+  fd_stake_t const *              stake,
   fd_vote_state_versioned_t *     vote_state_versioned,
   ulong                           rewarded_epoch,
   fd_point_value_t *              point_value,
@@ -196,12 +196,12 @@ calculate_stake_rewards(
   fd_calculated_stake_rewards_t * result
 ) {
     fd_calculated_stake_points_t stake_points_result = {0};
-    calculate_stake_points_and_credits( stake_history, &stake_state->inner.stake.stake, vote_state_versioned, new_rate_activation_epoch, &stake_points_result);
+    calculate_stake_points_and_credits( stake_history, stake, vote_state_versioned, new_rate_activation_epoch, &stake_points_result);
 
     // Drive credits_observed forward unconditionally when rewards are disabled
     // or when this is the stake's activation epoch
     if ( ( point_value->rewards == 0 ) ||
-         ( stake_state->inner.stake.stake.delegation.activation_epoch == rewarded_epoch ) ) {
+         ( stake->delegation.activation_epoch == rewarded_epoch ) ) {
         stake_points_result.force_credits_update_with_skipped_reward |= 1;
     }
 
@@ -236,14 +236,14 @@ calculate_stake_rewards(
 /* https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/programs/stake/src/rewards.rs#L33 */
 static int
 redeem_rewards( fd_stake_history_t const *      stake_history,
-                fd_stake_state_v2_t *           stake_state,
+                fd_stake_t const *              stake,
                 fd_vote_state_versioned_t *     vote_state_versioned,
                 ulong                           rewarded_epoch,
                 fd_point_value_t *              point_value,
                 ulong *                         new_rate_activation_epoch,
                 fd_calculated_stake_rewards_t * calculated_stake_rewards) {
 
-    int rc = calculate_stake_rewards( stake_history, stake_state, vote_state_versioned, rewarded_epoch, point_value, new_rate_activation_epoch, calculated_stake_rewards );
+    int rc = calculate_stake_rewards( stake_history, stake, vote_state_versioned, rewarded_epoch, point_value, new_rate_activation_epoch, calculated_stake_rewards );
     if ( FD_UNLIKELY( rc != 0 ) ) {
         return rc;
     }
@@ -254,7 +254,7 @@ redeem_rewards( fd_stake_history_t const *      stake_history,
 /* https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/programs/stake/src/points.rs#L70 */
 static int
 calculate_points(
-    fd_stake_t                * stake,
+    fd_stake_t const *          stake,
     fd_vote_state_versioned_t * vote_state_versioned,
     fd_stake_history_t const  * stake_history,
     ulong *                     new_rate_activation_epoch,
@@ -347,54 +347,26 @@ calculate_reward_points_partitioned(
         new_warmup_cooldown_rate_epoch = NULL;
     }
 
-    for ( ulong idx = 0; idx < temp_info->infos_len; idx++ ) {
+    for( ulong idx=0UL; idx<temp_info->stake_infos_len; idx++ ) {
         FD_SCRATCH_SCOPE_BEGIN {
-            fd_valloc_t valloc = fd_scratch_virtual();
-            fd_stake_t * stake = &temp_info->infos[idx].stake;
+            fd_stake_t const * stake = &temp_info->stake_infos[idx].stake;
 
-            if ( FD_UNLIKELY( stake->delegation.stake < minimum_stake_delegation ) ) {
+            if ( FD_UNLIKELY( stake->delegation.stake<minimum_stake_delegation ) ) {
                 continue;
             }
 
             /* Check that the vote account is present in our cache */
-            fd_vote_accounts_pair_t_mapnode_t key;
+            fd_vote_info_pair_t_mapnode_t query_key;
             fd_pubkey_t const * voter_acc = &stake->delegation.voter_pubkey;
-            fd_memcpy( &key.elem.key, voter_acc, sizeof(fd_pubkey_t) );
-            fd_epoch_bank_t const * epoch_bank = fd_exec_epoch_ctx_epoch_bank(
-                slot_ctx->epoch_ctx );
-            if ( FD_UNLIKELY( fd_vote_accounts_pair_t_map_find(
-                epoch_bank->stakes.vote_accounts.vote_accounts_pool,
-                epoch_bank->stakes.vote_accounts.vote_accounts_root,
-                &key ) == NULL ) ) {
+            fd_memcpy( &query_key.elem.account, voter_acc, sizeof(fd_pubkey_t) );
+            fd_vote_info_pair_t_mapnode_t * vote_state_info = fd_vote_info_pair_t_map_find( temp_info->vote_states_pool, temp_info->vote_states_root, &query_key );
+            if( FD_UNLIKELY( vote_state_info==NULL ) ) {
                 FD_LOG_DEBUG(( "vote account missing from cache" ));
                 continue;
             }
 
-            /* Check that the vote account is valid and has the correct owner */
-            // TODO: we need to cache this away...
-            FD_BORROWED_ACCOUNT_DECL(voter_acc_rec);
-            int err = fd_acc_mgr_view( slot_ctx->acc_mgr, slot_ctx->funk_txn, voter_acc, voter_acc_rec );
-            if ( FD_UNLIKELY( err ) ) {
-                FD_LOG_DEBUG(( "failed to read vote account from funk" ));
-                continue;
-            }
-            if( FD_UNLIKELY( memcmp( &voter_acc_rec->const_meta->info.owner, fd_solana_vote_program_id.key, sizeof(fd_pubkey_t) ) != 0 ) ) {
-                FD_LOG_DEBUG(( "vote account has wrong owner" ));
-                continue;
-            }
-            fd_bincode_decode_ctx_t decode = {
-                .data    = voter_acc_rec->const_data,
-                .dataend = voter_acc_rec->const_data + voter_acc_rec->const_meta->dlen,
-                .valloc  = valloc,
-            };
-            fd_vote_state_versioned_t vote_state[1] = {0};
-            if( FD_UNLIKELY( 0!=fd_vote_state_versioned_decode( vote_state, &decode ) ) ) {
-                FD_LOG_DEBUG(( "vote_state_versioned_decode failed" ));
-                continue;
-            }
-
             uint128 account_points;
-            err = calculate_points( stake, vote_state, stake_history, new_warmup_cooldown_rate_epoch, &account_points );
+            int err = calculate_points( stake, &vote_state_info->elem.state, stake_history, new_warmup_cooldown_rate_epoch, &account_points );
             if ( FD_UNLIKELY( err ) ) {
                 FD_LOG_DEBUG(( "failed to calculate points" ));
                 continue;
@@ -413,12 +385,14 @@ calculate_reward_points_partitioned(
 /* Calculate the partitioned stake rewards for a single stake/vote account pair, updates result with these. */
 static void
 calculate_stake_vote_rewards_account(
-    fd_exec_slot_ctx_t *                        slot_ctx,
-    fd_stake_history_t const *                  stake_history,
-    ulong                                       rewarded_epoch,
-    fd_point_value_t *                          point_value,
-    fd_pubkey_t const *                         stake_acc,
-    fd_calculate_stake_vote_rewards_result_t *  result
+    fd_exec_slot_ctx_t *                       slot_ctx,
+    fd_stake_history_t const *                 stake_history,
+    ulong                                      rewarded_epoch,
+    fd_point_value_t *                         point_value,
+    fd_pubkey_t const *                        stake_acc,
+    fd_stake_t const *                         stake,
+    fd_calculate_stake_vote_rewards_result_t * result,
+    fd_epoch_info_t *                          temp_info
 ) {
     FD_SCRATCH_SCOPE_BEGIN {
         int _err[1];
@@ -428,60 +402,26 @@ calculate_stake_vote_rewards_account(
             new_warmup_cooldown_rate_epoch = NULL;
         }
 
-        fd_epoch_bank_t const * epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
         ulong minimum_stake_delegation = get_minimum_stake_delegation( slot_ctx );
-
-        FD_BORROWED_ACCOUNT_DECL( stake_acc_rec );
-        if( fd_acc_mgr_view( slot_ctx->acc_mgr, slot_ctx->funk_txn, stake_acc, stake_acc_rec) != 0 ) {
-            FD_LOG_DEBUG(( "Stake acc not found %s", FD_BASE58_ENC_32_ALLOCA( stake_acc->uc ) ));
-            return;
-        }
-
-        fd_stake_state_v2_t stake_state[1] = {0};
-        if ( fd_stake_get_state( stake_acc_rec, &slot_ctx->valloc, stake_state ) != 0 ) {
-            FD_LOG_DEBUG(( "Failed to read stake state from stake account %s", FD_BASE58_ENC_32_ALLOCA( stake_acc ) ));
-            return;
-        }
-        if ( !fd_stake_state_v2_is_stake( stake_state ) ) {
-            FD_LOG_DEBUG(( "stake account does not have active delegation" ));
-            return;
-        }
-        fd_pubkey_t const * voter_acc = &stake_state->inner.stake.stake.delegation.voter_pubkey;
-
-        if ( FD_FEATURE_ACTIVE(slot_ctx, stake_minimum_delegation_for_rewards )) {
-            if ( stake_state->inner.stake.stake.delegation.stake < minimum_stake_delegation ) {
+        if( FD_FEATURE_ACTIVE(slot_ctx, stake_minimum_delegation_for_rewards ) ) {
+            if( stake->delegation.stake<minimum_stake_delegation ) {
                 return;
             }
         }
 
-        fd_vote_accounts_pair_t_mapnode_t key;
-        fd_memcpy( &key.elem.key, voter_acc, sizeof(fd_pubkey_t) );
-        if ( fd_vote_accounts_pair_t_map_find( epoch_bank->stakes.vote_accounts.vote_accounts_pool, epoch_bank->stakes.vote_accounts.vote_accounts_root, &key ) == NULL
-            && fd_vote_accounts_pair_t_map_find( slot_ctx->slot_bank.vote_account_keys.vote_accounts_pool, slot_ctx->slot_bank.vote_account_keys.vote_accounts_root, &key ) == NULL) {
-        return;
-        }
-
-        FD_BORROWED_ACCOUNT_DECL( voter_acc_rec );
-        int read_err = fd_acc_mgr_view( slot_ctx->acc_mgr, slot_ctx->funk_txn, voter_acc, voter_acc_rec );
-        if( read_err!=0 || memcmp( &voter_acc_rec->const_meta->info.owner, fd_solana_vote_program_id.key, sizeof(fd_pubkey_t) ) != 0 ) {
-        return;
-        }
-
-        fd_valloc_t valloc = fd_scratch_virtual();
-        fd_bincode_decode_ctx_t decode = {
-            .data    = voter_acc_rec->const_data,
-            .dataend = voter_acc_rec->const_data + voter_acc_rec->const_meta->dlen,
-            .valloc  = valloc,
-        };
-        fd_vote_state_versioned_t vote_state_versioned[1] = {0};
-        if( fd_vote_state_versioned_decode( vote_state_versioned, &decode ) != 0 ) {
-            FD_LOG_ERR(( "failed to decode vote state" ));
+        fd_pubkey_t const * voter_acc = &stake->delegation.voter_pubkey;
+        fd_vote_info_pair_t_mapnode_t key;
+        fd_memcpy( &key.elem.account, voter_acc, sizeof(fd_pubkey_t) );
+        fd_vote_info_pair_t_mapnode_t * vote_state_entry = fd_vote_info_pair_t_map_find( temp_info->vote_states_pool, temp_info->vote_states_root, &key );
+        if ( FD_UNLIKELY( vote_state_entry==NULL ) ) {
             return;
         }
 
+        fd_vote_state_versioned_t * vote_state = &vote_state_entry->elem.state;
+
         /* Note, this doesn't actually redeem any rewards.. this is a misnomer. */
         fd_calculated_stake_rewards_t calculated_stake_rewards[1] = {0};
-        int err = redeem_rewards( stake_history, stake_state, vote_state_versioned, rewarded_epoch, point_value, new_warmup_cooldown_rate_epoch, calculated_stake_rewards );
+        int err = redeem_rewards( stake_history, stake, vote_state, rewarded_epoch, point_value, new_warmup_cooldown_rate_epoch, calculated_stake_rewards );
         if ( err != 0) {
             FD_LOG_DEBUG(( "redeem_rewards failed for %s with error %d", FD_BASE58_ENC_32_ALLOCA( stake_acc->key ), err ));
             return;
@@ -489,15 +429,15 @@ calculate_stake_vote_rewards_account(
 
         /* Fetch the comission for the vote account */
         uchar commission = 0;
-        switch (vote_state_versioned->discriminant) {
+        switch (vote_state->discriminant) {
             case fd_vote_state_versioned_enum_current:
-                commission = vote_state_versioned->inner.current.commission;
+                commission = vote_state->inner.current.commission;
                 break;
             case fd_vote_state_versioned_enum_v0_23_5:
-                commission = vote_state_versioned->inner.v0_23_5.commission;
+                commission = vote_state->inner.v0_23_5.commission;
                 break;
             case fd_vote_state_versioned_enum_v1_14_11:
-                commission = vote_state_versioned->inner.v1_14_11.commission;
+                commission = vote_state->inner.v1_14_11.commission;
                 break;
             default:
                 FD_LOG_DEBUG(( "unsupported vote account" ));
@@ -558,12 +498,11 @@ calculate_stake_vote_rewards(
     fd_stake_history_t const *                 stake_history,
     ulong                                      rewarded_epoch,
     fd_point_value_t *                         point_value,
-    fd_calculate_stake_vote_rewards_result_t * result
+    fd_calculate_stake_vote_rewards_result_t * result,
+    fd_epoch_info_t                          * temp_info
 ) {
     fd_epoch_bank_t const * epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
-    ulong rewards_max_count = fd_ulong_sat_add(
-        fd_delegation_pair_t_map_size( epoch_bank->stakes.stake_delegations_pool, epoch_bank->stakes.stake_delegations_root ),
-        fd_stake_accounts_pair_t_map_size( slot_ctx->slot_bank.stake_account_keys.stake_accounts_pool, slot_ctx->slot_bank.stake_account_keys.stake_accounts_root ) );
+    ulong rewards_max_count = fd_delegation_pair_t_map_size( epoch_bank->stakes.stake_delegations_pool, epoch_bank->stakes.stake_delegations_root );
 
     /* Create the stake rewards pool and dlist. The pool will be destoyed after the stake rewards have been distributed. */
     result->stake_reward_calculation.pool = fd_stake_reward_pool_join(
@@ -585,12 +524,9 @@ calculate_stake_vote_rewards(
     /* Loop over all the delegations
 
         https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/runtime/src/bank/partitioned_epoch_rewards/calculation.rs#L367  */
-    for( fd_delegation_pair_t_mapnode_t const * n = fd_delegation_pair_t_map_minimum_const(
-         epoch_bank->stakes.stake_delegations_pool, epoch_bank->stakes.stake_delegations_root );
-         n;
-         n = fd_delegation_pair_t_map_successor_const( epoch_bank->stakes.stake_delegations_pool, n )
-    ) {
-        fd_pubkey_t const * stake_acc = &n->elem.account;
+    for( ulong i=0UL; i<temp_info->stake_infos_len; i++ ) {
+        fd_pubkey_t const * stake_acc = &temp_info->stake_infos[i].account;
+        fd_stake_t const * stake = &temp_info->stake_infos[i].stake;
 
         calculate_stake_vote_rewards_account(
             slot_ctx,
@@ -598,24 +534,9 @@ calculate_stake_vote_rewards(
             rewarded_epoch,
             point_value,
             stake_acc,
-            result );
-    }
-
-    /* Loop over all the stake accounts in the slot bank pool */
-    for ( fd_stake_accounts_pair_t_mapnode_t const * n =
-        fd_stake_accounts_pair_t_map_minimum_const(
-            slot_ctx->slot_bank.stake_account_keys.stake_accounts_pool, slot_ctx->slot_bank.stake_account_keys.stake_accounts_root );
-         n;
-         n = fd_stake_accounts_pair_t_map_successor_const( slot_ctx->slot_bank.stake_account_keys.stake_accounts_pool, n) ) {
-
-        fd_pubkey_t const * stake_acc = &n->elem.key;
-        calculate_stake_vote_rewards_account(
-            slot_ctx,
-            stake_history,
-            rewarded_epoch,
-            point_value,
-            stake_acc,
-            result );
+            stake,
+            result,
+            temp_info );
     }
 }
 
@@ -639,13 +560,14 @@ calculate_validator_rewards(
     /* Calculate the epoch reward points from stake/vote accounts */
     calculate_reward_points_partitioned( slot_ctx, stake_history, rewards, &result->point_value, temp_info );
 
-    /* Calculate the stake and vote rewards for each account */
     calculate_stake_vote_rewards(
         slot_ctx,
         stake_history,
         rewarded_epoch,
         &result->point_value,
-        &result->calculate_stake_vote_rewards_result );
+        &result->calculate_stake_vote_rewards_result,
+        temp_info
+    );
 }
 
 /* Calculate the number of blocks required to distribute rewards to all stake accounts.
@@ -760,6 +682,7 @@ calculate_rewards_for_partitioning(
         &validator_result->calculate_stake_vote_rewards_result.stake_reward_calculation,
         parent_blockhash,
         &result->stake_rewards_by_partition );
+
     result->stake_rewards_by_partition.total_stake_rewards_lamports =
         validator_result->calculate_stake_vote_rewards_result.stake_reward_calculation.total_stake_rewards_lamports;
 
@@ -1064,6 +987,7 @@ void
 fd_rewards_recalculate_partitioned_rewards(
     fd_exec_slot_ctx_t * slot_ctx
 ) {
+FD_SCRATCH_SCOPE_BEGIN {
     fd_sysvar_epoch_rewards_t epoch_rewards[1];
     if ( FD_UNLIKELY( fd_sysvar_epoch_rewards_read( epoch_rewards, slot_ctx ) == NULL ) ) {
       FD_LOG_NOTICE(( "failed to read sysvar epoch rewards - the sysvar may not have been created yet" ));
@@ -1071,14 +995,25 @@ fd_rewards_recalculate_partitioned_rewards(
       return;
     }
 
+    FD_LOG_NOTICE(( "recalculating partitioned rewards" ));
+
     if ( FD_UNLIKELY( epoch_rewards->active ) ) {
         /* If partitioned rewards are active, the rewarded epoch is always the immediately
            preceeding epoch.
 
            https://github.com/anza-xyz/agave/blob/2316fea4c0852e59c071f72d72db020017ffd7d0/runtime/src/bank/partitioned_epoch_rewards/calculation.rs#L566 */
+        FD_LOG_NOTICE(( "epoch rewards is active" ));
+
         fd_epoch_schedule_t * epoch_schedule = &fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx )->epoch_schedule;
         ulong epoch = fd_slot_to_epoch( epoch_schedule, slot_ctx->slot_bank.slot, NULL );
         ulong rewarded_epoch = fd_ulong_sat_sub( epoch, 1UL );
+
+        int _err[1] = {0};
+        ulong * new_warmup_cooldown_rate_epoch = fd_scratch_alloc( alignof(ulong), sizeof(ulong) );
+        int is_some = fd_new_warmup_cooldown_rate_epoch( slot_ctx, new_warmup_cooldown_rate_epoch, _err );
+        if( FD_UNLIKELY( !is_some ) ) {
+            new_warmup_cooldown_rate_epoch = NULL;
+        }
 
         fd_stake_history_t const * stake_history = fd_sysvar_cache_stake_history( slot_ctx->sysvar_cache );
         if( FD_UNLIKELY( !stake_history ) ) {
@@ -1090,6 +1025,24 @@ fd_rewards_recalculate_partitioned_rewards(
             .rewards = epoch_rewards->total_rewards
         };
 
+        /* Populate vote and stake state info from vote and stakes cache for the stake vote rewards calculation */
+        fd_stakes_t * stakes = &slot_ctx->epoch_ctx->epoch_bank.stakes;
+        fd_epoch_info_t epoch_info = {0};
+        fd_epoch_info_new( &epoch_info );
+
+        ulong stake_delegation_sz  = fd_delegation_pair_t_map_size( stakes->stake_delegations_pool, stakes->stake_delegations_root );
+        epoch_info.stake_infos_len = stake_delegation_sz;
+        epoch_info.stake_infos     = fd_scratch_alloc( FD_EPOCH_INFO_PAIR_ALIGN, FD_EPOCH_INFO_PAIR_FOOTPRINT*stake_delegation_sz );
+
+        fd_stake_history_entry_t _accumulator = {
+            .effective = 0,
+            .activating = 0,
+            .deactivating = 0
+        };
+
+        fd_accumulate_stake_infos( slot_ctx, stakes, stake_history, new_warmup_cooldown_rate_epoch, &_accumulator, &epoch_info );
+        fd_refresh_vote_accounts( slot_ctx, stake_history, new_warmup_cooldown_rate_epoch, &epoch_info );
+
         /* In future, the calculation will be cached in the snapshot, but for now we just re-calculate it
            (as Agave does). */
         fd_calculate_stake_vote_rewards_result_t calculate_stake_vote_rewards_result[1];
@@ -1098,7 +1051,8 @@ fd_rewards_recalculate_partitioned_rewards(
             stake_history,
             rewarded_epoch,
             &point_value,
-            calculate_stake_vote_rewards_result
+            calculate_stake_vote_rewards_result,
+            &epoch_info
         );
 
         /* Free the vote reward map, as this isn't actually used in this code path. */
@@ -1121,5 +1075,5 @@ fd_rewards_recalculate_partitioned_rewards(
     } else {
         set_epoch_reward_status_inactive( slot_ctx );
     }
-
+} FD_SCRATCH_SCOPE_END;
 }

--- a/src/flamenco/runtime/program/fd_stake_program.c
+++ b/src/flamenco/runtime/program/fd_stake_program.c
@@ -3186,15 +3186,15 @@ fd_stake_activating_and_deactivating( fd_delegation_t const *    self,
 /* Removes stake delegation from epoch stakes and updates vote account */
 static void
 fd_stakes_remove_stake_delegation( fd_exec_slot_ctx_t * slot_ctx, fd_borrowed_account_t * stake_account ) {
-  fd_stake_accounts_pair_t_mapnode_t key;
+  fd_account_keys_pair_t_mapnode_t key;
   fd_memcpy( key.elem.key.uc, stake_account->pubkey->uc, sizeof(fd_pubkey_t) );
-  if( slot_ctx->slot_bank.stake_account_keys.stake_accounts_pool==NULL ) {
+  if( slot_ctx->slot_bank.stake_account_keys.account_keys_pool==NULL ) {
     FD_LOG_DEBUG(("Stake accounts pool does not exist"));
     return;
   }
-  fd_stake_accounts_pair_t_mapnode_t * entry = fd_stake_accounts_pair_t_map_find( slot_ctx->slot_bank.stake_account_keys.stake_accounts_pool, slot_ctx->slot_bank.stake_account_keys.stake_accounts_root, &key );
+  fd_account_keys_pair_t_mapnode_t * entry = fd_account_keys_pair_t_map_find( slot_ctx->slot_bank.stake_account_keys.account_keys_pool, slot_ctx->slot_bank.stake_account_keys.account_keys_root, &key );
   if (FD_UNLIKELY( entry )) {
-    fd_stake_accounts_pair_t_map_remove( slot_ctx->slot_bank.stake_account_keys.stake_accounts_pool, &slot_ctx->slot_bank.stake_account_keys.stake_accounts_root, entry);
+    fd_account_keys_pair_t_map_remove( slot_ctx->slot_bank.stake_account_keys.account_keys_pool, &slot_ctx->slot_bank.stake_account_keys.account_keys_root, entry);
     // TODO: do we need a release here?
   }
 }
@@ -3216,25 +3216,25 @@ fd_stakes_upsert_stake_delegation( fd_exec_slot_ctx_t * slot_ctx, fd_borrowed_ac
 
   fd_delegation_pair_t_mapnode_t * entry = fd_delegation_pair_t_map_find( stakes->stake_delegations_pool, stakes->stake_delegations_root, &key);
   if( FD_UNLIKELY( !entry ) ) {
-    fd_stake_accounts_pair_t_mapnode_t key;
+    fd_account_keys_pair_t_mapnode_t key;
     fd_memcpy( key.elem.key.uc, stake_account->pubkey->uc, sizeof(fd_pubkey_t) );
-    if( slot_ctx->slot_bank.stake_account_keys.stake_accounts_pool==NULL) {
+    if( slot_ctx->slot_bank.stake_account_keys.account_keys_pool==NULL) {
       FD_LOG_DEBUG(("Stake accounts pool does not exist"));
       return;
     }
-    fd_stake_accounts_pair_t_mapnode_t * stake_entry = fd_stake_accounts_pair_t_map_find( slot_ctx->slot_bank.stake_account_keys.stake_accounts_pool, slot_ctx->slot_bank.stake_account_keys.stake_accounts_root, &key );
+    fd_account_keys_pair_t_mapnode_t * stake_entry = fd_account_keys_pair_t_map_find( slot_ctx->slot_bank.stake_account_keys.account_keys_pool, slot_ctx->slot_bank.stake_account_keys.account_keys_root, &key );
     if( stake_entry ) {
       stake_entry->elem.exists = 1;
     } else {
-      fd_stake_accounts_pair_t_mapnode_t * new_node = fd_stake_accounts_pair_t_map_acquire( slot_ctx->slot_bank.stake_account_keys.stake_accounts_pool );
-      ulong size = fd_stake_accounts_pair_t_map_size( slot_ctx->slot_bank.stake_account_keys.stake_accounts_pool, slot_ctx->slot_bank.stake_account_keys.stake_accounts_root );
-      FD_LOG_DEBUG(("Curr stake account size %lu %p", size, (void *)slot_ctx->slot_bank.stake_account_keys.stake_accounts_pool));
+      fd_account_keys_pair_t_mapnode_t * new_node = fd_account_keys_pair_t_map_acquire( slot_ctx->slot_bank.stake_account_keys.account_keys_pool );
+      ulong size = fd_account_keys_pair_t_map_size( slot_ctx->slot_bank.stake_account_keys.account_keys_pool, slot_ctx->slot_bank.stake_account_keys.account_keys_root );
+      FD_LOG_DEBUG(("Curr stake account size %lu %p", size, (void *)slot_ctx->slot_bank.stake_account_keys.account_keys_pool));
       if( new_node==NULL ) {
         FD_LOG_ERR(("Stake accounts keys map full %lu", size));
       }
       new_node->elem.exists = 1;
       fd_memcpy( new_node->elem.key.uc, stake_account->pubkey->uc, sizeof(fd_pubkey_t) );
-      fd_stake_accounts_pair_t_map_insert( slot_ctx->slot_bank.stake_account_keys.stake_accounts_pool, &slot_ctx->slot_bank.stake_account_keys.stake_accounts_root, new_node );
+      fd_account_keys_pair_t_map_insert( slot_ctx->slot_bank.stake_account_keys.account_keys_pool, &slot_ctx->slot_bank.stake_account_keys.account_keys_root, new_node );
     }
   }
 }

--- a/src/flamenco/runtime/program/fd_vote_program.h
+++ b/src/flamenco/runtime/program/fd_vote_program.h
@@ -81,8 +81,7 @@ fd_vote_commission_split( fd_vote_state_versioned_t * vote_state_versioned,
 
 void
 fd_vote_store_account( fd_exec_slot_ctx_t *    slot_ctx,
-                       fd_borrowed_account_t * vote_account,
-                       fd_spad_t *             spad );
+                       fd_borrowed_account_t * vote_account );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/snapshot/fd_snapshot.c
+++ b/src/flamenco/snapshot/fd_snapshot.c
@@ -44,11 +44,11 @@ fd_hashes_load( fd_exec_slot_ctx_t * slot_ctx ) {
 
   /* FIXME: Do not hardcode the number of vote accounts */
 
-  slot_ctx->slot_bank.stake_account_keys.stake_accounts_root = NULL;
-  slot_ctx->slot_bank.stake_account_keys.stake_accounts_pool = fd_stake_accounts_pair_t_map_alloc( slot_ctx->valloc, 100000UL );
+  slot_ctx->slot_bank.stake_account_keys.account_keys_root = NULL;
+  slot_ctx->slot_bank.stake_account_keys.account_keys_pool = fd_account_keys_pair_t_map_alloc( slot_ctx->valloc, 100000UL );
 
-  slot_ctx->slot_bank.vote_account_keys.vote_accounts_root = NULL;
-  slot_ctx->slot_bank.vote_account_keys.vote_accounts_pool = fd_vote_accounts_pair_t_map_alloc( slot_ctx->valloc, 100000UL );
+  slot_ctx->slot_bank.vote_account_keys.account_keys_root = NULL;
+  slot_ctx->slot_bank.vote_account_keys.account_keys_pool = fd_account_keys_pair_t_map_alloc( slot_ctx->valloc, 100000UL );
 
   slot_ctx->slot_bank.collected_execution_fees = 0UL;
   slot_ctx->slot_bank.collected_priority_fees  = 0UL;

--- a/src/flamenco/stakes/fd_stakes.h
+++ b/src/flamenco/stakes/fd_stakes.h
@@ -49,10 +49,18 @@ void
 fd_stakes_upsert_stake_delegation( fd_exec_slot_ctx_t * slot_ctx, fd_borrowed_account_t * stake_account, ulong * new_rate_activation_epoch );
 
 void
-refresh_vote_accounts( fd_exec_slot_ctx_t *       slot_ctx,
-                       fd_stake_history_t const * history,
-                       ulong *                    new_rate_activation_epoch,
-                       fd_epoch_info_t           *temp_info );
+fd_refresh_vote_accounts( fd_exec_slot_ctx_t *       slot_ctx,
+                          fd_stake_history_t const * history,
+                          ulong *                    new_rate_activation_epoch,
+                          fd_epoch_info_t           *temp_info );
+
+void 
+fd_accumulate_stake_infos( fd_exec_slot_ctx_t const * slot_ctx,
+                           fd_stakes_t const *        stakes,
+                           fd_stake_history_t const * history,
+                           ulong *                    new_rate_activation_epoch,
+                           fd_stake_history_entry_t * accumulator,
+                           fd_epoch_info_t *          temp_info );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/types/fd_type_names.c
+++ b/src/flamenco/types/fd_type_names.c
@@ -1,5 +1,5 @@
 // This is an auto-generated file. To add entries, edit fd_types.json
-#define FD_TYPE_NAME_COUNT 237
+#define FD_TYPE_NAME_COUNT 238
 static char const * fd_type_names[FD_TYPE_NAME_COUNT] = {
  "fd_hash",
  "fd_pubkey",
@@ -26,15 +26,13 @@ static char const * fd_type_names[FD_TYPE_NAME_COUNT] = {
  "fd_vote_accounts_pair_serializable",
  "fd_vote_accounts_serializable",
  "fd_vote_accounts",
- "fd_stake_accounts_pair",
- "fd_stake_accounts",
+ "fd_account_keys_pair",
+ "fd_account_keys",
  "fd_stake_weight",
  "fd_stake_weights",
  "fd_delegation",
  "fd_delegation_pair",
  "fd_stake",
- "fd_epoch_info_pair",
- "fd_epoch_info",
  "fd_stake_pair",
  "fd_stakes",
  "fd_stakes_serializable",
@@ -238,4 +236,7 @@ static char const * fd_type_names[FD_TYPE_NAME_COUNT] = {
  "fd_calculated_stake_points",
  "fd_calculated_stake_rewards",
  "fd_duplicate_slot_proof",
+ "fd_epoch_info_pair",
+ "fd_vote_info_pair",
+ "fd_epoch_info",
 };

--- a/src/flamenco/types/fd_types.c
+++ b/src/flamenco/types/fd_types.c
@@ -3431,48 +3431,48 @@ ulong fd_vote_accounts_size( fd_vote_accounts_t const * self ) {
   return size;
 }
 
-int fd_stake_accounts_pair_decode( fd_stake_accounts_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
+int fd_account_keys_pair_decode( fd_account_keys_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
   void const * data = ctx->data;
-  int err = fd_stake_accounts_pair_decode_preflight( ctx );
+  int err = fd_account_keys_pair_decode_preflight( ctx );
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
   ctx->data = data;
   if( !fd_is_null_alloc_virtual( ctx->valloc ) ) {
-    fd_stake_accounts_pair_new( self );
+    fd_account_keys_pair_new( self );
   }
-  fd_stake_accounts_pair_decode_unsafe( self, ctx );
+  fd_account_keys_pair_decode_unsafe( self, ctx );
   return FD_BINCODE_SUCCESS;
 }
-int fd_stake_accounts_pair_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
-  return fd_bincode_bytes_decode_preflight( 36, ctx );
+int fd_account_keys_pair_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
+  return fd_bincode_bytes_decode_preflight( 33, ctx );
 }
-void fd_stake_accounts_pair_decode_unsafe( fd_stake_accounts_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
+void fd_account_keys_pair_decode_unsafe( fd_account_keys_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
   fd_pubkey_decode_unsafe( &self->key, ctx );
-  fd_bincode_uint32_decode_unsafe( &self->exists, ctx );
+  fd_bincode_uint8_decode_unsafe( &self->exists, ctx );
 }
-int fd_stake_accounts_pair_encode( fd_stake_accounts_pair_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+int fd_account_keys_pair_encode( fd_account_keys_pair_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
   err = fd_pubkey_encode( &self->key, ctx );
   if( FD_UNLIKELY( err ) ) return err;
-  err = fd_bincode_uint32_encode( self->exists, ctx );
+  err = fd_bincode_uint8_encode( (uchar)(self->exists), ctx );
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
 enum {
-  fd_stake_accounts_pair_key_TAG = (0 << 6) | FD_ARCHIVE_META_STRUCT,
-  fd_stake_accounts_pair_exists_TAG = (1 << 6) | FD_ARCHIVE_META_UINT,
+  fd_account_keys_pair_key_TAG = (0 << 6) | FD_ARCHIVE_META_STRUCT,
+  fd_account_keys_pair_exists_TAG = (1 << 6) | FD_ARCHIVE_META_UCHAR,
 };
-int fd_stake_accounts_pair_decode_archival( fd_stake_accounts_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
+int fd_account_keys_pair_decode_archival( fd_account_keys_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
   void const * data = ctx->data;
-  int err = fd_stake_accounts_pair_decode_archival_preflight( ctx );
+  int err = fd_account_keys_pair_decode_archival_preflight( ctx );
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
   ctx->data = data;
   if( !fd_is_null_alloc_virtual( ctx->valloc ) ) {
-    fd_stake_accounts_pair_new( self );
+    fd_account_keys_pair_new( self );
   }
-  fd_stake_accounts_pair_decode_archival_unsafe( self, ctx );
+  fd_account_keys_pair_decode_archival_unsafe( self, ctx );
   return FD_BINCODE_SUCCESS;
 }
-int fd_stake_accounts_pair_decode_archival_preflight( fd_bincode_decode_ctx_t * ctx ) {
+int fd_account_keys_pair_decode_archival_preflight( fd_bincode_decode_ctx_t * ctx ) {
   int err;
   ushort tag = FD_ARCHIVE_META_SENTINAL;
   void * offset = NULL;
@@ -3481,7 +3481,7 @@ int fd_stake_accounts_pair_decode_archival_preflight( fd_bincode_decode_ctx_t * 
   if( FD_UNLIKELY( err ) ) return err;
   if( FD_UNLIKELY( tag == FD_ARCHIVE_META_SENTINAL ) ) break;
   switch( tag ) {
-  case (ushort)fd_stake_accounts_pair_key_TAG: {
+  case (ushort)fd_account_keys_pair_key_TAG: {
   err = fd_archive_decode_setup_length( ctx, &offset );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_pubkey_decode_archival_preflight( ctx );
@@ -3490,8 +3490,8 @@ int fd_stake_accounts_pair_decode_archival_preflight( fd_bincode_decode_ctx_t * 
   if( FD_UNLIKELY( err ) ) return err;
   break;
   }
-  case (ushort)fd_stake_accounts_pair_exists_TAG: {
-  err = fd_bincode_uint32_decode_preflight( ctx );
+  case (ushort)fd_account_keys_pair_exists_TAG: {
+  err = fd_bincode_uint8_decode_preflight( ctx );
   if( FD_UNLIKELY( err ) ) return err;
   break;
   }
@@ -3503,20 +3503,20 @@ int fd_stake_accounts_pair_decode_archival_preflight( fd_bincode_decode_ctx_t * 
   }
   return FD_BINCODE_SUCCESS;
 }
-void fd_stake_accounts_pair_decode_archival_unsafe( fd_stake_accounts_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
+void fd_account_keys_pair_decode_archival_unsafe( fd_account_keys_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
   ushort tag = FD_ARCHIVE_META_SENTINAL;
   void * offset = NULL;
   for(;;) {
   fd_bincode_uint16_decode( &tag, ctx );
   if( FD_UNLIKELY( tag == FD_ARCHIVE_META_SENTINAL ) ) break;
   switch( tag ) {
-  case (ushort)fd_stake_accounts_pair_key_TAG: {
+  case (ushort)fd_account_keys_pair_key_TAG: {
   fd_archive_decode_setup_length( ctx, &offset );
   fd_pubkey_decode_archival_unsafe( &self->key, ctx );
   break;
   }
-  case (ushort)fd_stake_accounts_pair_exists_TAG: {
-  fd_bincode_uint32_decode_unsafe( &self->exists, ctx );
+  case (ushort)fd_account_keys_pair_exists_TAG: {
+  fd_bincode_uint8_decode_unsafe( &self->exists, ctx );
   break;
   }
   default:
@@ -3525,10 +3525,10 @@ void fd_stake_accounts_pair_decode_archival_unsafe( fd_stake_accounts_pair_t * s
   }
   }
 }
-int fd_stake_accounts_pair_encode_archival( fd_stake_accounts_pair_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+int fd_account_keys_pair_encode_archival( fd_account_keys_pair_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
   void * offset = NULL;
-  err = fd_bincode_uint16_encode( (ushort)fd_stake_accounts_pair_key_TAG, ctx );
+  err = fd_bincode_uint16_encode( (ushort)fd_account_keys_pair_key_TAG, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_archive_encode_setup_length( ctx, &offset );
   if( FD_UNLIKELY( err ) ) return err;
@@ -3536,117 +3536,117 @@ int fd_stake_accounts_pair_encode_archival( fd_stake_accounts_pair_t const * sel
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_archive_encode_set_length( ctx, offset );
   if( FD_UNLIKELY( err ) ) return err;
-  err = fd_bincode_uint16_encode( (ushort)fd_stake_accounts_pair_exists_TAG, ctx );
+  err = fd_bincode_uint16_encode( (ushort)fd_account_keys_pair_exists_TAG, ctx );
   if( FD_UNLIKELY( err ) ) return err;
-  err = fd_bincode_uint32_encode( self->exists, ctx );
+  err = fd_bincode_uint8_encode( (uchar)(self->exists), ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_bincode_uint16_encode( FD_ARCHIVE_META_SENTINAL, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
-int fd_stake_accounts_pair_decode_offsets( fd_stake_accounts_pair_off_t * self, fd_bincode_decode_ctx_t * ctx ) {
+int fd_account_keys_pair_decode_offsets( fd_account_keys_pair_off_t * self, fd_bincode_decode_ctx_t * ctx ) {
   uchar const * data = ctx->data;
   int err;
   self->key_off = (uint)( (ulong)ctx->data - (ulong)data );
   err = fd_pubkey_decode_preflight( ctx );
   if( FD_UNLIKELY( err ) ) return err;
   self->exists_off = (uint)( (ulong)ctx->data - (ulong)data );
-  err = fd_bincode_uint32_decode_preflight( ctx );
+  err = fd_bincode_uint8_decode_preflight( ctx );
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
-void fd_stake_accounts_pair_new(fd_stake_accounts_pair_t * self) {
-  fd_memset( self, 0, sizeof(fd_stake_accounts_pair_t) );
+void fd_account_keys_pair_new(fd_account_keys_pair_t * self) {
+  fd_memset( self, 0, sizeof(fd_account_keys_pair_t) );
   fd_pubkey_new( &self->key );
 }
-void fd_stake_accounts_pair_destroy( fd_stake_accounts_pair_t * self, fd_bincode_destroy_ctx_t * ctx ) {
+void fd_account_keys_pair_destroy( fd_account_keys_pair_t * self, fd_bincode_destroy_ctx_t * ctx ) {
   fd_pubkey_destroy( &self->key, ctx );
 }
 
-ulong fd_stake_accounts_pair_footprint( void ){ return FD_STAKE_ACCOUNTS_PAIR_FOOTPRINT; }
-ulong fd_stake_accounts_pair_align( void ){ return FD_STAKE_ACCOUNTS_PAIR_ALIGN; }
+ulong fd_account_keys_pair_footprint( void ){ return FD_ACCOUNT_KEYS_PAIR_FOOTPRINT; }
+ulong fd_account_keys_pair_align( void ){ return FD_ACCOUNT_KEYS_PAIR_ALIGN; }
 
-void fd_stake_accounts_pair_walk( void * w, fd_stake_accounts_pair_t const * self, fd_types_walk_fn_t fun, const char *name, uint level ) {
-  fun( w, self, name, FD_FLAMENCO_TYPE_MAP, "fd_stake_accounts_pair", level++ );
+void fd_account_keys_pair_walk( void * w, fd_account_keys_pair_t const * self, fd_types_walk_fn_t fun, const char *name, uint level ) {
+  fun( w, self, name, FD_FLAMENCO_TYPE_MAP, "fd_account_keys_pair", level++ );
   fd_pubkey_walk( w, &self->key, fun, "key", level );
-  fun( w, &self->exists, "exists", FD_FLAMENCO_TYPE_UINT, "uint", level );
-  fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_stake_accounts_pair", level-- );
+  fun( w, &self->exists, "exists", FD_FLAMENCO_TYPE_UCHAR, "uchar", level );
+  fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_account_keys_pair", level-- );
 }
-ulong fd_stake_accounts_pair_size( fd_stake_accounts_pair_t const * self ) {
+ulong fd_account_keys_pair_size( fd_account_keys_pair_t const * self ) {
   ulong size = 0;
   size += fd_pubkey_size( &self->key );
-  size += sizeof(uint);
+  size += sizeof(char);
   return size;
 }
 
-int fd_stake_accounts_decode( fd_stake_accounts_t * self, fd_bincode_decode_ctx_t * ctx ) {
+int fd_account_keys_decode( fd_account_keys_t * self, fd_bincode_decode_ctx_t * ctx ) {
   void const * data = ctx->data;
-  int err = fd_stake_accounts_decode_preflight( ctx );
+  int err = fd_account_keys_decode_preflight( ctx );
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
   ctx->data = data;
   if( !fd_is_null_alloc_virtual( ctx->valloc ) ) {
-    fd_stake_accounts_new( self );
+    fd_account_keys_new( self );
   }
-  fd_stake_accounts_decode_unsafe( self, ctx );
+  fd_account_keys_decode_unsafe( self, ctx );
   return FD_BINCODE_SUCCESS;
 }
-int fd_stake_accounts_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
+int fd_account_keys_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
   int err;
-  ulong stake_accounts_len;
-  err = fd_bincode_uint64_decode( &stake_accounts_len, ctx );
+  ulong account_keys_len;
+  err = fd_bincode_uint64_decode( &account_keys_len, ctx );
   if( FD_UNLIKELY( err ) ) return err;
-  for( ulong i=0; i < stake_accounts_len; i++ ) {
-    err = fd_stake_accounts_pair_decode_preflight( ctx );
+  for( ulong i=0; i < account_keys_len; i++ ) {
+    err = fd_account_keys_pair_decode_preflight( ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   return FD_BINCODE_SUCCESS;
 }
-void fd_stake_accounts_decode_unsafe( fd_stake_accounts_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  ulong stake_accounts_len;
-  fd_bincode_uint64_decode_unsafe( &stake_accounts_len, ctx );
+void fd_account_keys_decode_unsafe( fd_account_keys_t * self, fd_bincode_decode_ctx_t * ctx ) {
+  ulong account_keys_len;
+  fd_bincode_uint64_decode_unsafe( &account_keys_len, ctx );
   if( !fd_is_null_alloc_virtual( ctx->valloc ) ) {
-    self->stake_accounts_pool = fd_stake_accounts_pair_t_map_alloc( ctx->valloc, fd_ulong_max(stake_accounts_len, 100000 ) );
-    self->stake_accounts_root = NULL;
+    self->account_keys_pool = fd_account_keys_pair_t_map_alloc( ctx->valloc, fd_ulong_max(account_keys_len, 100000 ) );
+    self->account_keys_root = NULL;
   }
-  for( ulong i=0; i < stake_accounts_len; i++ ) {
-    fd_stake_accounts_pair_t_mapnode_t * node = fd_stake_accounts_pair_t_map_acquire( self->stake_accounts_pool );
-    fd_stake_accounts_pair_new( &node->elem );
-    fd_stake_accounts_pair_decode_unsafe( &node->elem, ctx );
-    fd_stake_accounts_pair_t_map_insert( self->stake_accounts_pool, &self->stake_accounts_root, node );
+  for( ulong i=0; i < account_keys_len; i++ ) {
+    fd_account_keys_pair_t_mapnode_t * node = fd_account_keys_pair_t_map_acquire( self->account_keys_pool );
+    fd_account_keys_pair_new( &node->elem );
+    fd_account_keys_pair_decode_unsafe( &node->elem, ctx );
+    fd_account_keys_pair_t_map_insert( self->account_keys_pool, &self->account_keys_root, node );
   }
 }
-int fd_stake_accounts_encode( fd_stake_accounts_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+int fd_account_keys_encode( fd_account_keys_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
-  if( self->stake_accounts_root ) {
-    ulong stake_accounts_len = fd_stake_accounts_pair_t_map_size( self->stake_accounts_pool, self->stake_accounts_root );
-    err = fd_bincode_uint64_encode( stake_accounts_len, ctx );
+  if( self->account_keys_root ) {
+    ulong account_keys_len = fd_account_keys_pair_t_map_size( self->account_keys_pool, self->account_keys_root );
+    err = fd_bincode_uint64_encode( account_keys_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
-    for( fd_stake_accounts_pair_t_mapnode_t * n = fd_stake_accounts_pair_t_map_minimum( self->stake_accounts_pool, self->stake_accounts_root ); n; n = fd_stake_accounts_pair_t_map_successor( self->stake_accounts_pool, n ) ) {
-      err = fd_stake_accounts_pair_encode( &n->elem, ctx );
+    for( fd_account_keys_pair_t_mapnode_t * n = fd_account_keys_pair_t_map_minimum( self->account_keys_pool, self->account_keys_root ); n; n = fd_account_keys_pair_t_map_successor( self->account_keys_pool, n ) ) {
+      err = fd_account_keys_pair_encode( &n->elem, ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
   } else {
-    ulong stake_accounts_len = 0;
-    err = fd_bincode_uint64_encode( stake_accounts_len, ctx );
+    ulong account_keys_len = 0;
+    err = fd_bincode_uint64_encode( account_keys_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   return FD_BINCODE_SUCCESS;
 }
 enum {
-  fd_stake_accounts_stake_accounts_TAG = (0 << 6) | FD_ARCHIVE_META_MAP,
+  fd_account_keys_account_keys_TAG = (0 << 6) | FD_ARCHIVE_META_MAP,
 };
-int fd_stake_accounts_decode_archival( fd_stake_accounts_t * self, fd_bincode_decode_ctx_t * ctx ) {
+int fd_account_keys_decode_archival( fd_account_keys_t * self, fd_bincode_decode_ctx_t * ctx ) {
   void const * data = ctx->data;
-  int err = fd_stake_accounts_decode_archival_preflight( ctx );
+  int err = fd_account_keys_decode_archival_preflight( ctx );
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
   ctx->data = data;
   if( !fd_is_null_alloc_virtual( ctx->valloc ) ) {
-    fd_stake_accounts_new( self );
+    fd_account_keys_new( self );
   }
-  fd_stake_accounts_decode_archival_unsafe( self, ctx );
+  fd_account_keys_decode_archival_unsafe( self, ctx );
   return FD_BINCODE_SUCCESS;
 }
-int fd_stake_accounts_decode_archival_preflight( fd_bincode_decode_ctx_t * ctx ) {
+int fd_account_keys_decode_archival_preflight( fd_bincode_decode_ctx_t * ctx ) {
   int err;
   ushort tag = FD_ARCHIVE_META_SENTINAL;
   void * offset = NULL;
@@ -3655,14 +3655,14 @@ int fd_stake_accounts_decode_archival_preflight( fd_bincode_decode_ctx_t * ctx )
   if( FD_UNLIKELY( err ) ) return err;
   if( FD_UNLIKELY( tag == FD_ARCHIVE_META_SENTINAL ) ) break;
   switch( tag ) {
-  case (ushort)fd_stake_accounts_stake_accounts_TAG: {
+  case (ushort)fd_account_keys_account_keys_TAG: {
   err = fd_archive_decode_setup_length( ctx, &offset );
   if( FD_UNLIKELY( err ) ) return err;
-  ulong stake_accounts_len;
-  err = fd_bincode_uint64_decode( &stake_accounts_len, ctx );
+  ulong account_keys_len;
+  err = fd_bincode_uint64_decode( &account_keys_len, ctx );
   if( FD_UNLIKELY( err ) ) return err;
-  for( ulong i=0; i < stake_accounts_len; i++ ) {
-    err = fd_stake_accounts_pair_decode_archival_preflight( ctx );
+  for( ulong i=0; i < account_keys_len; i++ ) {
+    err = fd_account_keys_pair_decode_archival_preflight( ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   err = fd_archive_decode_check_length( ctx, offset );
@@ -3677,26 +3677,26 @@ int fd_stake_accounts_decode_archival_preflight( fd_bincode_decode_ctx_t * ctx )
   }
   return FD_BINCODE_SUCCESS;
 }
-void fd_stake_accounts_decode_archival_unsafe( fd_stake_accounts_t * self, fd_bincode_decode_ctx_t * ctx ) {
+void fd_account_keys_decode_archival_unsafe( fd_account_keys_t * self, fd_bincode_decode_ctx_t * ctx ) {
   ushort tag = FD_ARCHIVE_META_SENTINAL;
   void * offset = NULL;
   for(;;) {
   fd_bincode_uint16_decode( &tag, ctx );
   if( FD_UNLIKELY( tag == FD_ARCHIVE_META_SENTINAL ) ) break;
   switch( tag ) {
-  case (ushort)fd_stake_accounts_stake_accounts_TAG: {
+  case (ushort)fd_account_keys_account_keys_TAG: {
   fd_archive_decode_setup_length( ctx, &offset );
-  ulong stake_accounts_len;
-  fd_bincode_uint64_decode_unsafe( &stake_accounts_len, ctx );
+  ulong account_keys_len;
+  fd_bincode_uint64_decode_unsafe( &account_keys_len, ctx );
   if( !fd_is_null_alloc_virtual( ctx->valloc ) ) {
-    self->stake_accounts_pool = fd_stake_accounts_pair_t_map_alloc( ctx->valloc, fd_ulong_max(stake_accounts_len, 100000 ) );
-    self->stake_accounts_root = NULL;
+    self->account_keys_pool = fd_account_keys_pair_t_map_alloc( ctx->valloc, fd_ulong_max(account_keys_len, 100000 ) );
+    self->account_keys_root = NULL;
   }
-  for( ulong i=0; i < stake_accounts_len; i++ ) {
-    fd_stake_accounts_pair_t_mapnode_t * node = fd_stake_accounts_pair_t_map_acquire( self->stake_accounts_pool );
-    fd_stake_accounts_pair_new( &node->elem );
-    fd_stake_accounts_pair_decode_archival_unsafe( &node->elem, ctx );
-    fd_stake_accounts_pair_t_map_insert( self->stake_accounts_pool, &self->stake_accounts_root, node );
+  for( ulong i=0; i < account_keys_len; i++ ) {
+    fd_account_keys_pair_t_mapnode_t * node = fd_account_keys_pair_t_map_acquire( self->account_keys_pool );
+    fd_account_keys_pair_new( &node->elem );
+    fd_account_keys_pair_decode_archival_unsafe( &node->elem, ctx );
+    fd_account_keys_pair_t_map_insert( self->account_keys_pool, &self->account_keys_root, node );
   }
   break;
   }
@@ -3706,24 +3706,24 @@ void fd_stake_accounts_decode_archival_unsafe( fd_stake_accounts_t * self, fd_bi
   }
   }
 }
-int fd_stake_accounts_encode_archival( fd_stake_accounts_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+int fd_account_keys_encode_archival( fd_account_keys_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
   void * offset = NULL;
-  err = fd_bincode_uint16_encode( (ushort)fd_stake_accounts_stake_accounts_TAG, ctx );
+  err = fd_bincode_uint16_encode( (ushort)fd_account_keys_account_keys_TAG, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_archive_encode_setup_length( ctx, &offset );
   if( FD_UNLIKELY( err ) ) return err;
-  if( self->stake_accounts_root ) {
-    ulong stake_accounts_len = fd_stake_accounts_pair_t_map_size( self->stake_accounts_pool, self->stake_accounts_root );
-    err = fd_bincode_uint64_encode( stake_accounts_len, ctx );
+  if( self->account_keys_root ) {
+    ulong account_keys_len = fd_account_keys_pair_t_map_size( self->account_keys_pool, self->account_keys_root );
+    err = fd_bincode_uint64_encode( account_keys_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
-    for( fd_stake_accounts_pair_t_mapnode_t * n = fd_stake_accounts_pair_t_map_minimum( self->stake_accounts_pool, self->stake_accounts_root ); n; n = fd_stake_accounts_pair_t_map_successor( self->stake_accounts_pool, n ) ) {
-      err = fd_stake_accounts_pair_encode_archival( &n->elem, ctx );
+    for( fd_account_keys_pair_t_mapnode_t * n = fd_account_keys_pair_t_map_minimum( self->account_keys_pool, self->account_keys_root ); n; n = fd_account_keys_pair_t_map_successor( self->account_keys_pool, n ) ) {
+      err = fd_account_keys_pair_encode_archival( &n->elem, ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
   } else {
-    ulong stake_accounts_len = 0;
-    err = fd_bincode_uint64_encode( stake_accounts_len, ctx );
+    ulong account_keys_len = 0;
+    err = fd_bincode_uint64_encode( account_keys_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   err = fd_archive_encode_set_length( ctx, offset );
@@ -3732,49 +3732,49 @@ int fd_stake_accounts_encode_archival( fd_stake_accounts_t const * self, fd_binc
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
-int fd_stake_accounts_decode_offsets( fd_stake_accounts_off_t * self, fd_bincode_decode_ctx_t * ctx ) {
+int fd_account_keys_decode_offsets( fd_account_keys_off_t * self, fd_bincode_decode_ctx_t * ctx ) {
   uchar const * data = ctx->data;
   int err;
-  self->stake_accounts_off = (uint)( (ulong)ctx->data - (ulong)data );
-  ulong stake_accounts_len;
-  err = fd_bincode_uint64_decode( &stake_accounts_len, ctx );
+  self->account_keys_off = (uint)( (ulong)ctx->data - (ulong)data );
+  ulong account_keys_len;
+  err = fd_bincode_uint64_decode( &account_keys_len, ctx );
   if( FD_UNLIKELY( err ) ) return err;
-  for( ulong i=0; i < stake_accounts_len; i++ ) {
-    err = fd_stake_accounts_pair_decode_preflight( ctx );
+  for( ulong i=0; i < account_keys_len; i++ ) {
+    err = fd_account_keys_pair_decode_preflight( ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   return FD_BINCODE_SUCCESS;
 }
-void fd_stake_accounts_new(fd_stake_accounts_t * self) {
-  fd_memset( self, 0, sizeof(fd_stake_accounts_t) );
+void fd_account_keys_new(fd_account_keys_t * self) {
+  fd_memset( self, 0, sizeof(fd_account_keys_t) );
 }
-void fd_stake_accounts_destroy( fd_stake_accounts_t * self, fd_bincode_destroy_ctx_t * ctx ) {
-  for( fd_stake_accounts_pair_t_mapnode_t * n = fd_stake_accounts_pair_t_map_minimum(self->stake_accounts_pool, self->stake_accounts_root ); n; n = fd_stake_accounts_pair_t_map_successor(self->stake_accounts_pool, n) ) {
-    fd_stake_accounts_pair_destroy( &n->elem, ctx );
+void fd_account_keys_destroy( fd_account_keys_t * self, fd_bincode_destroy_ctx_t * ctx ) {
+  for( fd_account_keys_pair_t_mapnode_t * n = fd_account_keys_pair_t_map_minimum(self->account_keys_pool, self->account_keys_root ); n; n = fd_account_keys_pair_t_map_successor(self->account_keys_pool, n) ) {
+    fd_account_keys_pair_destroy( &n->elem, ctx );
   }
-  fd_valloc_free( ctx->valloc, fd_stake_accounts_pair_t_map_delete( fd_stake_accounts_pair_t_map_leave( self->stake_accounts_pool ) ) );
-  self->stake_accounts_pool = NULL;
-  self->stake_accounts_root = NULL;
+  fd_valloc_free( ctx->valloc, fd_account_keys_pair_t_map_delete( fd_account_keys_pair_t_map_leave( self->account_keys_pool ) ) );
+  self->account_keys_pool = NULL;
+  self->account_keys_root = NULL;
 }
 
-ulong fd_stake_accounts_footprint( void ){ return FD_STAKE_ACCOUNTS_FOOTPRINT; }
-ulong fd_stake_accounts_align( void ){ return FD_STAKE_ACCOUNTS_ALIGN; }
+ulong fd_account_keys_footprint( void ){ return FD_ACCOUNT_KEYS_FOOTPRINT; }
+ulong fd_account_keys_align( void ){ return FD_ACCOUNT_KEYS_ALIGN; }
 
-void fd_stake_accounts_walk( void * w, fd_stake_accounts_t const * self, fd_types_walk_fn_t fun, const char *name, uint level ) {
-  fun( w, self, name, FD_FLAMENCO_TYPE_MAP, "fd_stake_accounts", level++ );
-  if( self->stake_accounts_root ) {
-    for( fd_stake_accounts_pair_t_mapnode_t * n = fd_stake_accounts_pair_t_map_minimum(self->stake_accounts_pool, self->stake_accounts_root ); n; n = fd_stake_accounts_pair_t_map_successor( self->stake_accounts_pool, n ) ) {
-      fd_stake_accounts_pair_walk(w, &n->elem, fun, "stake_accounts", level );
+void fd_account_keys_walk( void * w, fd_account_keys_t const * self, fd_types_walk_fn_t fun, const char *name, uint level ) {
+  fun( w, self, name, FD_FLAMENCO_TYPE_MAP, "fd_account_keys", level++ );
+  if( self->account_keys_root ) {
+    for( fd_account_keys_pair_t_mapnode_t * n = fd_account_keys_pair_t_map_minimum(self->account_keys_pool, self->account_keys_root ); n; n = fd_account_keys_pair_t_map_successor( self->account_keys_pool, n ) ) {
+      fd_account_keys_pair_walk(w, &n->elem, fun, "account_keys", level );
     }
   }
-  fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_stake_accounts", level-- );
+  fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_account_keys", level-- );
 }
-ulong fd_stake_accounts_size( fd_stake_accounts_t const * self ) {
+ulong fd_account_keys_size( fd_account_keys_t const * self ) {
   ulong size = 0;
-  if( self->stake_accounts_root ) {
+  if( self->account_keys_root ) {
     size += sizeof(ulong);
-    for( fd_stake_accounts_pair_t_mapnode_t * n = fd_stake_accounts_pair_t_map_minimum( self->stake_accounts_pool, self->stake_accounts_root ); n; n = fd_stake_accounts_pair_t_map_successor( self->stake_accounts_pool, n ) ) {
-      size += fd_stake_accounts_pair_size( &n->elem );
+    for( fd_account_keys_pair_t_mapnode_t * n = fd_account_keys_pair_t_map_minimum( self->account_keys_pool, self->account_keys_root ); n; n = fd_account_keys_pair_t_map_successor( self->account_keys_pool, n ) ) {
+      size += fd_account_keys_pair_size( &n->elem );
     }
   } else {
     size += sizeof(ulong);
@@ -4377,166 +4377,6 @@ ulong fd_stake_size( fd_stake_t const * self ) {
   ulong size = 0;
   size += fd_delegation_size( &self->delegation );
   size += sizeof(ulong);
-  return size;
-}
-
-int fd_epoch_info_pair_decode( fd_epoch_info_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  void const * data = ctx->data;
-  int err = fd_epoch_info_pair_decode_preflight( ctx );
-  if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
-  ctx->data = data;
-  if( !fd_is_null_alloc_virtual( ctx->valloc ) ) {
-    fd_epoch_info_pair_new( self );
-  }
-  fd_epoch_info_pair_decode_unsafe( self, ctx );
-  return FD_BINCODE_SUCCESS;
-}
-int fd_epoch_info_pair_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
-  return fd_bincode_bytes_decode_preflight( 104, ctx );
-}
-void fd_epoch_info_pair_decode_unsafe( fd_epoch_info_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_pubkey_decode_unsafe( &self->account, ctx );
-  fd_stake_decode_unsafe( &self->stake, ctx );
-}
-int fd_epoch_info_pair_encode( fd_epoch_info_pair_t const * self, fd_bincode_encode_ctx_t * ctx ) {
-  int err;
-  err = fd_pubkey_encode( &self->account, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_stake_encode( &self->stake, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
-int fd_epoch_info_pair_decode_offsets( fd_epoch_info_pair_off_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  uchar const * data = ctx->data;
-  int err;
-  self->account_off = (uint)( (ulong)ctx->data - (ulong)data );
-  err = fd_pubkey_decode_preflight( ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->stake_off = (uint)( (ulong)ctx->data - (ulong)data );
-  err = fd_stake_decode_preflight( ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
-void fd_epoch_info_pair_new(fd_epoch_info_pair_t * self) {
-  fd_memset( self, 0, sizeof(fd_epoch_info_pair_t) );
-  fd_pubkey_new( &self->account );
-  fd_stake_new( &self->stake );
-}
-void fd_epoch_info_pair_destroy( fd_epoch_info_pair_t * self, fd_bincode_destroy_ctx_t * ctx ) {
-  fd_pubkey_destroy( &self->account, ctx );
-  fd_stake_destroy( &self->stake, ctx );
-}
-
-ulong fd_epoch_info_pair_footprint( void ){ return FD_EPOCH_INFO_PAIR_FOOTPRINT; }
-ulong fd_epoch_info_pair_align( void ){ return FD_EPOCH_INFO_PAIR_ALIGN; }
-
-void fd_epoch_info_pair_walk( void * w, fd_epoch_info_pair_t const * self, fd_types_walk_fn_t fun, const char *name, uint level ) {
-  fun( w, self, name, FD_FLAMENCO_TYPE_MAP, "fd_epoch_info_pair", level++ );
-  fd_pubkey_walk( w, &self->account, fun, "account", level );
-  fd_stake_walk( w, &self->stake, fun, "stake", level );
-  fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_epoch_info_pair", level-- );
-}
-ulong fd_epoch_info_pair_size( fd_epoch_info_pair_t const * self ) {
-  ulong size = 0;
-  size += fd_pubkey_size( &self->account );
-  size += fd_stake_size( &self->stake );
-  return size;
-}
-
-int fd_epoch_info_decode( fd_epoch_info_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  void const * data = ctx->data;
-  int err = fd_epoch_info_decode_preflight( ctx );
-  if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
-  ctx->data = data;
-  if( !fd_is_null_alloc_virtual( ctx->valloc ) ) {
-    fd_epoch_info_new( self );
-  }
-  fd_epoch_info_decode_unsafe( self, ctx );
-  return FD_BINCODE_SUCCESS;
-}
-int fd_epoch_info_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
-  int err;
-  ulong infos_len;
-  err = fd_bincode_uint64_decode( &infos_len, ctx );
-  if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
-  if( infos_len ) {
-    for( ulong i=0; i < infos_len; i++ ) {
-      err = fd_epoch_info_pair_decode_preflight( ctx );
-      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
-    }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-void fd_epoch_info_decode_unsafe( fd_epoch_info_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bincode_uint64_decode_unsafe( &self->infos_len, ctx );
-  if( self->infos_len ) {
-    self->infos = (fd_epoch_info_pair_t *)fd_valloc_malloc( ctx->valloc, FD_EPOCH_INFO_PAIR_ALIGN, FD_EPOCH_INFO_PAIR_FOOTPRINT*self->infos_len );
-    for( ulong i=0; i < self->infos_len; i++ ) {
-      fd_epoch_info_pair_new( self->infos + i );
-      fd_epoch_info_pair_decode_unsafe( self->infos + i, ctx );
-    }
-  } else
-    self->infos = NULL;
-}
-int fd_epoch_info_encode( fd_epoch_info_t const * self, fd_bincode_encode_ctx_t * ctx ) {
-  int err;
-  err = fd_bincode_uint64_encode( self->infos_len, ctx );
-  if( FD_UNLIKELY(err) ) return err;
-  if( self->infos_len ) {
-    for( ulong i=0; i < self->infos_len; i++ ) {
-      err = fd_epoch_info_pair_encode( self->infos + i, ctx );
-      if( FD_UNLIKELY( err ) ) return err;
-    }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_epoch_info_decode_offsets( fd_epoch_info_off_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  uchar const * data = ctx->data;
-  int err;
-  self->infos_off = (uint)( (ulong)ctx->data - (ulong)data );
-  ulong infos_len;
-  err = fd_bincode_uint64_decode( &infos_len, ctx );
-  if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
-  if( infos_len ) {
-    for( ulong i=0; i < infos_len; i++ ) {
-      err = fd_epoch_info_pair_decode_preflight( ctx );
-      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
-    }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-void fd_epoch_info_new(fd_epoch_info_t * self) {
-  fd_memset( self, 0, sizeof(fd_epoch_info_t) );
-}
-void fd_epoch_info_destroy( fd_epoch_info_t * self, fd_bincode_destroy_ctx_t * ctx ) {
-  if( self->infos ) {
-    for( ulong i=0; i < self->infos_len; i++ )
-      fd_epoch_info_pair_destroy( self->infos + i, ctx );
-    fd_valloc_free( ctx->valloc, self->infos );
-    self->infos = NULL;
-  }
-}
-
-ulong fd_epoch_info_footprint( void ){ return FD_EPOCH_INFO_FOOTPRINT; }
-ulong fd_epoch_info_align( void ){ return FD_EPOCH_INFO_ALIGN; }
-
-void fd_epoch_info_walk( void * w, fd_epoch_info_t const * self, fd_types_walk_fn_t fun, const char *name, uint level ) {
-  fun( w, self, name, FD_FLAMENCO_TYPE_MAP, "fd_epoch_info", level++ );
-  if( self->infos_len ) {
-    fun( w, NULL, "infos", FD_FLAMENCO_TYPE_ARR, "array", level++ );
-    for( ulong i=0; i < self->infos_len; i++ )
-      fd_epoch_info_pair_walk(w, self->infos + i, fun, "epoch_info_pair", level );
-    fun( w, NULL, "infos", FD_FLAMENCO_TYPE_ARR_END, "array", level-- );
-  }
-  fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_epoch_info", level-- );
-}
-ulong fd_epoch_info_size( fd_epoch_info_t const * self ) {
-  ulong size = 0;
-  do {
-    size += sizeof(ulong);
-    for( ulong i=0; i < self->infos_len; i++ )
-      size += fd_epoch_info_pair_size( self->infos + i );
-  } while(0);
   return size;
 }
 
@@ -15277,9 +15117,9 @@ int fd_slot_bank_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_sol_sysvar_last_restart_slot_decode_preflight( ctx );
   if( FD_UNLIKELY( err ) ) return err;
-  err = fd_stake_accounts_decode_preflight( ctx );
+  err = fd_account_keys_decode_preflight( ctx );
   if( FD_UNLIKELY( err ) ) return err;
-  err = fd_vote_accounts_decode_preflight( ctx );
+  err = fd_account_keys_decode_preflight( ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_bincode_uint64_decode_preflight( ctx );
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
@@ -15324,8 +15164,8 @@ void fd_slot_bank_decode_unsafe( fd_slot_bank_t * self, fd_bincode_decode_ctx_t 
   fd_bincode_uint64_decode_unsafe( &self->collected_rent, ctx );
   fd_vote_accounts_decode_unsafe( &self->epoch_stakes, ctx );
   fd_sol_sysvar_last_restart_slot_decode_unsafe( &self->last_restart_slot, ctx );
-  fd_stake_accounts_decode_unsafe( &self->stake_account_keys, ctx );
-  fd_vote_accounts_decode_unsafe( &self->vote_account_keys, ctx );
+  fd_account_keys_decode_unsafe( &self->stake_account_keys, ctx );
+  fd_account_keys_decode_unsafe( &self->vote_account_keys, ctx );
   fd_bincode_uint64_decode_unsafe( &self->lamports_per_signature, ctx );
   fd_bincode_uint64_decode_unsafe( &self->transaction_count, ctx );
   fd_slot_lthash_decode_unsafe( &self->lthash, ctx );
@@ -15375,9 +15215,9 @@ int fd_slot_bank_encode( fd_slot_bank_t const * self, fd_bincode_encode_ctx_t * 
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_sol_sysvar_last_restart_slot_encode( &self->last_restart_slot, ctx );
   if( FD_UNLIKELY( err ) ) return err;
-  err = fd_stake_accounts_encode( &self->stake_account_keys, ctx );
+  err = fd_account_keys_encode( &self->stake_account_keys, ctx );
   if( FD_UNLIKELY( err ) ) return err;
-  err = fd_vote_accounts_encode( &self->vote_account_keys, ctx );
+  err = fd_account_keys_encode( &self->vote_account_keys, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_bincode_uint64_encode( self->lamports_per_signature, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -15557,7 +15397,7 @@ int fd_slot_bank_decode_archival_preflight( fd_bincode_decode_ctx_t * ctx ) {
   case (ushort)fd_slot_bank_stake_account_keys_TAG: {
   err = fd_archive_decode_setup_length( ctx, &offset );
   if( FD_UNLIKELY( err ) ) return err;
-  err = fd_stake_accounts_decode_archival_preflight( ctx );
+  err = fd_account_keys_decode_archival_preflight( ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_archive_decode_check_length( ctx, offset );
   if( FD_UNLIKELY( err ) ) return err;
@@ -15566,7 +15406,7 @@ int fd_slot_bank_decode_archival_preflight( fd_bincode_decode_ctx_t * ctx ) {
   case (ushort)fd_slot_bank_vote_account_keys_TAG: {
   err = fd_archive_decode_setup_length( ctx, &offset );
   if( FD_UNLIKELY( err ) ) return err;
-  err = fd_vote_accounts_decode_archival_preflight( ctx );
+  err = fd_account_keys_decode_archival_preflight( ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_archive_decode_check_length( ctx, offset );
   if( FD_UNLIKELY( err ) ) return err;
@@ -15728,12 +15568,12 @@ void fd_slot_bank_decode_archival_unsafe( fd_slot_bank_t * self, fd_bincode_deco
   }
   case (ushort)fd_slot_bank_stake_account_keys_TAG: {
   fd_archive_decode_setup_length( ctx, &offset );
-  fd_stake_accounts_decode_archival_unsafe( &self->stake_account_keys, ctx );
+  fd_account_keys_decode_archival_unsafe( &self->stake_account_keys, ctx );
   break;
   }
   case (ushort)fd_slot_bank_vote_account_keys_TAG: {
   fd_archive_decode_setup_length( ctx, &offset );
-  fd_vote_accounts_decode_archival_unsafe( &self->vote_account_keys, ctx );
+  fd_account_keys_decode_archival_unsafe( &self->vote_account_keys, ctx );
   break;
   }
   case (ushort)fd_slot_bank_lamports_per_signature_TAG: {
@@ -15885,7 +15725,7 @@ int fd_slot_bank_encode_archival( fd_slot_bank_t const * self, fd_bincode_encode
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_archive_encode_setup_length( ctx, &offset );
   if( FD_UNLIKELY( err ) ) return err;
-  err = fd_stake_accounts_encode_archival( &self->stake_account_keys, ctx );
+  err = fd_account_keys_encode_archival( &self->stake_account_keys, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_archive_encode_set_length( ctx, offset );
   if( FD_UNLIKELY( err ) ) return err;
@@ -15893,7 +15733,7 @@ int fd_slot_bank_encode_archival( fd_slot_bank_t const * self, fd_bincode_encode
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_archive_encode_setup_length( ctx, &offset );
   if( FD_UNLIKELY( err ) ) return err;
-  err = fd_vote_accounts_encode_archival( &self->vote_account_keys, ctx );
+  err = fd_account_keys_encode_archival( &self->vote_account_keys, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_archive_encode_set_length( ctx, offset );
   if( FD_UNLIKELY( err ) ) return err;
@@ -16010,10 +15850,10 @@ int fd_slot_bank_decode_offsets( fd_slot_bank_off_t * self, fd_bincode_decode_ct
   err = fd_sol_sysvar_last_restart_slot_decode_preflight( ctx );
   if( FD_UNLIKELY( err ) ) return err;
   self->stake_account_keys_off = (uint)( (ulong)ctx->data - (ulong)data );
-  err = fd_stake_accounts_decode_preflight( ctx );
+  err = fd_account_keys_decode_preflight( ctx );
   if( FD_UNLIKELY( err ) ) return err;
   self->vote_account_keys_off = (uint)( (ulong)ctx->data - (ulong)data );
-  err = fd_vote_accounts_decode_preflight( ctx );
+  err = fd_account_keys_decode_preflight( ctx );
   if( FD_UNLIKELY( err ) ) return err;
   self->lamports_per_signature_off = (uint)( (ulong)ctx->data - (ulong)data );
   err = fd_bincode_uint64_decode_preflight( ctx );
@@ -16060,8 +15900,8 @@ void fd_slot_bank_new(fd_slot_bank_t * self) {
   fd_fee_rate_governor_new( &self->fee_rate_governor );
   fd_vote_accounts_new( &self->epoch_stakes );
   fd_sol_sysvar_last_restart_slot_new( &self->last_restart_slot );
-  fd_stake_accounts_new( &self->stake_account_keys );
-  fd_vote_accounts_new( &self->vote_account_keys );
+  fd_account_keys_new( &self->stake_account_keys );
+  fd_account_keys_new( &self->vote_account_keys );
   fd_slot_lthash_new( &self->lthash );
   fd_block_hash_queue_new( &self->block_hash_queue );
   fd_hash_new( &self->prev_banks_hash );
@@ -16075,8 +15915,8 @@ void fd_slot_bank_destroy( fd_slot_bank_t * self, fd_bincode_destroy_ctx_t * ctx
   fd_fee_rate_governor_destroy( &self->fee_rate_governor, ctx );
   fd_vote_accounts_destroy( &self->epoch_stakes, ctx );
   fd_sol_sysvar_last_restart_slot_destroy( &self->last_restart_slot, ctx );
-  fd_stake_accounts_destroy( &self->stake_account_keys, ctx );
-  fd_vote_accounts_destroy( &self->vote_account_keys, ctx );
+  fd_account_keys_destroy( &self->stake_account_keys, ctx );
+  fd_account_keys_destroy( &self->vote_account_keys, ctx );
   fd_slot_lthash_destroy( &self->lthash, ctx );
   fd_block_hash_queue_destroy( &self->block_hash_queue, ctx );
   fd_hash_destroy( &self->prev_banks_hash, ctx );
@@ -16106,8 +15946,8 @@ void fd_slot_bank_walk( void * w, fd_slot_bank_t const * self, fd_types_walk_fn_
   fun( w, &self->collected_rent, "collected_rent", FD_FLAMENCO_TYPE_ULONG, "ulong", level );
   fd_vote_accounts_walk( w, &self->epoch_stakes, fun, "epoch_stakes", level );
   fd_sol_sysvar_last_restart_slot_walk( w, &self->last_restart_slot, fun, "last_restart_slot", level );
-  fd_stake_accounts_walk( w, &self->stake_account_keys, fun, "stake_account_keys", level );
-  fd_vote_accounts_walk( w, &self->vote_account_keys, fun, "vote_account_keys", level );
+  fd_account_keys_walk( w, &self->stake_account_keys, fun, "stake_account_keys", level );
+  fd_account_keys_walk( w, &self->vote_account_keys, fun, "vote_account_keys", level );
   fun( w, &self->lamports_per_signature, "lamports_per_signature", FD_FLAMENCO_TYPE_ULONG, "ulong", level );
   fun( w, &self->transaction_count, "transaction_count", FD_FLAMENCO_TYPE_ULONG, "ulong", level );
   fd_slot_lthash_walk( w, &self->lthash, fun, "lthash", level );
@@ -16140,8 +15980,8 @@ ulong fd_slot_bank_size( fd_slot_bank_t const * self ) {
   size += sizeof(ulong);
   size += fd_vote_accounts_size( &self->epoch_stakes );
   size += fd_sol_sysvar_last_restart_slot_size( &self->last_restart_slot );
-  size += fd_stake_accounts_size( &self->stake_account_keys );
-  size += fd_vote_accounts_size( &self->vote_account_keys );
+  size += fd_account_keys_size( &self->stake_account_keys );
+  size += fd_account_keys_size( &self->vote_account_keys );
   size += sizeof(ulong);
   size += sizeof(ulong);
   size += fd_slot_lthash_size( &self->lthash );
@@ -33379,6 +33219,293 @@ ulong fd_duplicate_slot_proof_size( fd_duplicate_slot_proof_t const * self ) {
   return size;
 }
 
+int fd_epoch_info_pair_decode( fd_epoch_info_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
+  void const * data = ctx->data;
+  int err = fd_epoch_info_pair_decode_preflight( ctx );
+  if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
+  ctx->data = data;
+  if( !fd_is_null_alloc_virtual( ctx->valloc ) ) {
+    fd_epoch_info_pair_new( self );
+  }
+  fd_epoch_info_pair_decode_unsafe( self, ctx );
+  return FD_BINCODE_SUCCESS;
+}
+int fd_epoch_info_pair_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
+  return fd_bincode_bytes_decode_preflight( 104, ctx );
+}
+void fd_epoch_info_pair_decode_unsafe( fd_epoch_info_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
+  fd_pubkey_decode_unsafe( &self->account, ctx );
+  fd_stake_decode_unsafe( &self->stake, ctx );
+}
+int fd_epoch_info_pair_encode( fd_epoch_info_pair_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_encode( &self->account, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_stake_encode( &self->stake, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_epoch_info_pair_decode_offsets( fd_epoch_info_pair_off_t * self, fd_bincode_decode_ctx_t * ctx ) {
+  uchar const * data = ctx->data;
+  int err;
+  self->account_off = (uint)( (ulong)ctx->data - (ulong)data );
+  err = fd_pubkey_decode_preflight( ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  self->stake_off = (uint)( (ulong)ctx->data - (ulong)data );
+  err = fd_stake_decode_preflight( ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+void fd_epoch_info_pair_new(fd_epoch_info_pair_t * self) {
+  fd_memset( self, 0, sizeof(fd_epoch_info_pair_t) );
+  fd_pubkey_new( &self->account );
+  fd_stake_new( &self->stake );
+}
+void fd_epoch_info_pair_destroy( fd_epoch_info_pair_t * self, fd_bincode_destroy_ctx_t * ctx ) {
+  fd_pubkey_destroy( &self->account, ctx );
+  fd_stake_destroy( &self->stake, ctx );
+}
+
+ulong fd_epoch_info_pair_footprint( void ){ return FD_EPOCH_INFO_PAIR_FOOTPRINT; }
+ulong fd_epoch_info_pair_align( void ){ return FD_EPOCH_INFO_PAIR_ALIGN; }
+
+void fd_epoch_info_pair_walk( void * w, fd_epoch_info_pair_t const * self, fd_types_walk_fn_t fun, const char *name, uint level ) {
+  fun( w, self, name, FD_FLAMENCO_TYPE_MAP, "fd_epoch_info_pair", level++ );
+  fd_pubkey_walk( w, &self->account, fun, "account", level );
+  fd_stake_walk( w, &self->stake, fun, "stake", level );
+  fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_epoch_info_pair", level-- );
+}
+ulong fd_epoch_info_pair_size( fd_epoch_info_pair_t const * self ) {
+  ulong size = 0;
+  size += fd_pubkey_size( &self->account );
+  size += fd_stake_size( &self->stake );
+  return size;
+}
+
+int fd_vote_info_pair_decode( fd_vote_info_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
+  void const * data = ctx->data;
+  int err = fd_vote_info_pair_decode_preflight( ctx );
+  if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
+  ctx->data = data;
+  if( !fd_is_null_alloc_virtual( ctx->valloc ) ) {
+    fd_vote_info_pair_new( self );
+  }
+  fd_vote_info_pair_decode_unsafe( self, ctx );
+  return FD_BINCODE_SUCCESS;
+}
+int fd_vote_info_pair_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_decode_preflight( ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_vote_state_versioned_decode_preflight( ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+void fd_vote_info_pair_decode_unsafe( fd_vote_info_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
+  fd_pubkey_decode_unsafe( &self->account, ctx );
+  fd_vote_state_versioned_decode_unsafe( &self->state, ctx );
+}
+int fd_vote_info_pair_encode( fd_vote_info_pair_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_encode( &self->account, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_vote_state_versioned_encode( &self->state, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_vote_info_pair_decode_offsets( fd_vote_info_pair_off_t * self, fd_bincode_decode_ctx_t * ctx ) {
+  uchar const * data = ctx->data;
+  int err;
+  self->account_off = (uint)( (ulong)ctx->data - (ulong)data );
+  err = fd_pubkey_decode_preflight( ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  self->state_off = (uint)( (ulong)ctx->data - (ulong)data );
+  err = fd_vote_state_versioned_decode_preflight( ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+void fd_vote_info_pair_new(fd_vote_info_pair_t * self) {
+  fd_memset( self, 0, sizeof(fd_vote_info_pair_t) );
+  fd_pubkey_new( &self->account );
+  fd_vote_state_versioned_new( &self->state );
+}
+void fd_vote_info_pair_destroy( fd_vote_info_pair_t * self, fd_bincode_destroy_ctx_t * ctx ) {
+  fd_pubkey_destroy( &self->account, ctx );
+  fd_vote_state_versioned_destroy( &self->state, ctx );
+}
+
+ulong fd_vote_info_pair_footprint( void ){ return FD_VOTE_INFO_PAIR_FOOTPRINT; }
+ulong fd_vote_info_pair_align( void ){ return FD_VOTE_INFO_PAIR_ALIGN; }
+
+void fd_vote_info_pair_walk( void * w, fd_vote_info_pair_t const * self, fd_types_walk_fn_t fun, const char *name, uint level ) {
+  fun( w, self, name, FD_FLAMENCO_TYPE_MAP, "fd_vote_info_pair", level++ );
+  fd_pubkey_walk( w, &self->account, fun, "account", level );
+  fd_vote_state_versioned_walk( w, &self->state, fun, "state", level );
+  fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_vote_info_pair", level-- );
+}
+ulong fd_vote_info_pair_size( fd_vote_info_pair_t const * self ) {
+  ulong size = 0;
+  size += fd_pubkey_size( &self->account );
+  size += fd_vote_state_versioned_size( &self->state );
+  return size;
+}
+
+int fd_epoch_info_decode( fd_epoch_info_t * self, fd_bincode_decode_ctx_t * ctx ) {
+  void const * data = ctx->data;
+  int err = fd_epoch_info_decode_preflight( ctx );
+  if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
+  ctx->data = data;
+  if( !fd_is_null_alloc_virtual( ctx->valloc ) ) {
+    fd_epoch_info_new( self );
+  }
+  fd_epoch_info_decode_unsafe( self, ctx );
+  return FD_BINCODE_SUCCESS;
+}
+int fd_epoch_info_decode_preflight( fd_bincode_decode_ctx_t * ctx ) {
+  int err;
+  ulong stake_infos_len;
+  err = fd_bincode_uint64_decode( &stake_infos_len, ctx );
+  if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
+  if( stake_infos_len ) {
+    for( ulong i=0; i < stake_infos_len; i++ ) {
+      err = fd_epoch_info_pair_decode_preflight( ctx );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
+    }
+  }
+  ulong vote_states_len;
+  err = fd_bincode_uint64_decode( &vote_states_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  for( ulong i=0; i < vote_states_len; i++ ) {
+    err = fd_vote_info_pair_decode_preflight( ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+void fd_epoch_info_decode_unsafe( fd_epoch_info_t * self, fd_bincode_decode_ctx_t * ctx ) {
+  fd_bincode_uint64_decode_unsafe( &self->stake_infos_len, ctx );
+  if( self->stake_infos_len ) {
+    self->stake_infos = (fd_epoch_info_pair_t *)fd_valloc_malloc( ctx->valloc, FD_EPOCH_INFO_PAIR_ALIGN, FD_EPOCH_INFO_PAIR_FOOTPRINT*self->stake_infos_len );
+    for( ulong i=0; i < self->stake_infos_len; i++ ) {
+      fd_epoch_info_pair_new( self->stake_infos + i );
+      fd_epoch_info_pair_decode_unsafe( self->stake_infos + i, ctx );
+    }
+  } else
+    self->stake_infos = NULL;
+  ulong vote_states_len;
+  fd_bincode_uint64_decode_unsafe( &vote_states_len, ctx );
+  if( !fd_is_null_alloc_virtual( ctx->valloc ) ) {
+    self->vote_states_pool = fd_vote_info_pair_t_map_alloc( ctx->valloc, vote_states_len );
+    self->vote_states_root = NULL;
+  }
+  for( ulong i=0; i < vote_states_len; i++ ) {
+    fd_vote_info_pair_t_mapnode_t * node = fd_vote_info_pair_t_map_acquire( self->vote_states_pool );
+    fd_vote_info_pair_new( &node->elem );
+    fd_vote_info_pair_decode_unsafe( &node->elem, ctx );
+    fd_vote_info_pair_t_map_insert( self->vote_states_pool, &self->vote_states_root, node );
+  }
+}
+int fd_epoch_info_encode( fd_epoch_info_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->stake_infos_len, ctx );
+  if( FD_UNLIKELY(err) ) return err;
+  if( self->stake_infos_len ) {
+    for( ulong i=0; i < self->stake_infos_len; i++ ) {
+      err = fd_epoch_info_pair_encode( self->stake_infos + i, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  if( self->vote_states_root ) {
+    ulong vote_states_len = fd_vote_info_pair_t_map_size( self->vote_states_pool, self->vote_states_root );
+    err = fd_bincode_uint64_encode( vote_states_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( fd_vote_info_pair_t_mapnode_t * n = fd_vote_info_pair_t_map_minimum( self->vote_states_pool, self->vote_states_root ); n; n = fd_vote_info_pair_t_map_successor( self->vote_states_pool, n ) ) {
+      err = fd_vote_info_pair_encode( &n->elem, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong vote_states_len = 0;
+    err = fd_bincode_uint64_encode( vote_states_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_epoch_info_decode_offsets( fd_epoch_info_off_t * self, fd_bincode_decode_ctx_t * ctx ) {
+  uchar const * data = ctx->data;
+  int err;
+  self->stake_infos_off = (uint)( (ulong)ctx->data - (ulong)data );
+  ulong stake_infos_len;
+  err = fd_bincode_uint64_decode( &stake_infos_len, ctx );
+  if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
+  if( stake_infos_len ) {
+    for( ulong i=0; i < stake_infos_len; i++ ) {
+      err = fd_epoch_info_pair_decode_preflight( ctx );
+      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
+    }
+  }
+  self->vote_states_off = (uint)( (ulong)ctx->data - (ulong)data );
+  ulong vote_states_len;
+  err = fd_bincode_uint64_decode( &vote_states_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  for( ulong i=0; i < vote_states_len; i++ ) {
+    err = fd_vote_info_pair_decode_preflight( ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+void fd_epoch_info_new(fd_epoch_info_t * self) {
+  fd_memset( self, 0, sizeof(fd_epoch_info_t) );
+}
+void fd_epoch_info_destroy( fd_epoch_info_t * self, fd_bincode_destroy_ctx_t * ctx ) {
+  if( self->stake_infos ) {
+    for( ulong i=0; i < self->stake_infos_len; i++ )
+      fd_epoch_info_pair_destroy( self->stake_infos + i, ctx );
+    fd_valloc_free( ctx->valloc, self->stake_infos );
+    self->stake_infos = NULL;
+  }
+  for( fd_vote_info_pair_t_mapnode_t * n = fd_vote_info_pair_t_map_minimum(self->vote_states_pool, self->vote_states_root ); n; n = fd_vote_info_pair_t_map_successor(self->vote_states_pool, n) ) {
+    fd_vote_info_pair_destroy( &n->elem, ctx );
+  }
+  fd_valloc_free( ctx->valloc, fd_vote_info_pair_t_map_delete( fd_vote_info_pair_t_map_leave( self->vote_states_pool ) ) );
+  self->vote_states_pool = NULL;
+  self->vote_states_root = NULL;
+}
+
+ulong fd_epoch_info_footprint( void ){ return FD_EPOCH_INFO_FOOTPRINT; }
+ulong fd_epoch_info_align( void ){ return FD_EPOCH_INFO_ALIGN; }
+
+void fd_epoch_info_walk( void * w, fd_epoch_info_t const * self, fd_types_walk_fn_t fun, const char *name, uint level ) {
+  fun( w, self, name, FD_FLAMENCO_TYPE_MAP, "fd_epoch_info", level++ );
+  if( self->stake_infos_len ) {
+    fun( w, NULL, "stake_infos", FD_FLAMENCO_TYPE_ARR, "array", level++ );
+    for( ulong i=0; i < self->stake_infos_len; i++ )
+      fd_epoch_info_pair_walk(w, self->stake_infos + i, fun, "epoch_info_pair", level );
+    fun( w, NULL, "stake_infos", FD_FLAMENCO_TYPE_ARR_END, "array", level-- );
+  }
+  if( self->vote_states_root ) {
+    for( fd_vote_info_pair_t_mapnode_t * n = fd_vote_info_pair_t_map_minimum(self->vote_states_pool, self->vote_states_root ); n; n = fd_vote_info_pair_t_map_successor( self->vote_states_pool, n ) ) {
+      fd_vote_info_pair_walk(w, &n->elem, fun, "vote_states", level );
+    }
+  }
+  fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_epoch_info", level-- );
+}
+ulong fd_epoch_info_size( fd_epoch_info_t const * self ) {
+  ulong size = 0;
+  do {
+    size += sizeof(ulong);
+    for( ulong i=0; i < self->stake_infos_len; i++ )
+      size += fd_epoch_info_pair_size( self->stake_infos + i );
+  } while(0);
+  if( self->vote_states_root ) {
+    size += sizeof(ulong);
+    for( fd_vote_info_pair_t_mapnode_t * n = fd_vote_info_pair_t_map_minimum( self->vote_states_pool, self->vote_states_root ); n; n = fd_vote_info_pair_t_map_successor( self->vote_states_pool, n ) ) {
+      size += fd_vote_info_pair_size( &n->elem );
+    }
+  } else {
+    size += sizeof(ulong);
+  }
+  return size;
+}
+
 #define REDBLK_T fd_hash_hash_age_pair_t_mapnode_t
 #define REDBLK_NAME fd_hash_hash_age_pair_t_map
 #define REDBLK_IMPL_STYLE 2
@@ -33400,11 +33527,11 @@ long fd_vote_accounts_pair_serializable_t_map_compare( fd_vote_accounts_pair_ser
 long fd_vote_accounts_pair_t_map_compare( fd_vote_accounts_pair_t_mapnode_t * left, fd_vote_accounts_pair_t_mapnode_t * right ) {
   return memcmp( left->elem.key.uc, right->elem.key.uc, sizeof(right->elem.key) );
 }
-#define REDBLK_T fd_stake_accounts_pair_t_mapnode_t
-#define REDBLK_NAME fd_stake_accounts_pair_t_map
+#define REDBLK_T fd_account_keys_pair_t_mapnode_t
+#define REDBLK_NAME fd_account_keys_pair_t_map
 #define REDBLK_IMPL_STYLE 2
 #include "../../util/tmpl/fd_redblack.c"
-long fd_stake_accounts_pair_t_map_compare( fd_stake_accounts_pair_t_mapnode_t * left, fd_stake_accounts_pair_t_mapnode_t * right ) {
+long fd_account_keys_pair_t_map_compare( fd_account_keys_pair_t_mapnode_t * left, fd_account_keys_pair_t_mapnode_t * right ) {
   return memcmp( left->elem.key.uc, right->elem.key.uc, sizeof(right->elem.key) );
 }
 #define REDBLK_T fd_stake_weight_t_mapnode_t
@@ -33434,4 +33561,11 @@ long fd_stake_pair_t_map_compare( fd_stake_pair_t_mapnode_t * left, fd_stake_pai
 #include "../../util/tmpl/fd_redblack.c"
 long fd_clock_timestamp_vote_t_map_compare( fd_clock_timestamp_vote_t_mapnode_t * left, fd_clock_timestamp_vote_t_mapnode_t * right ) {
   return memcmp( left->elem.pubkey.uc, right->elem.pubkey.uc, sizeof(right->elem.pubkey) );
+}
+#define REDBLK_T fd_vote_info_pair_t_mapnode_t
+#define REDBLK_NAME fd_vote_info_pair_t_map
+#define REDBLK_IMPL_STYLE 2
+#include "../../util/tmpl/fd_redblack.c"
+long fd_vote_info_pair_t_map_compare( fd_vote_info_pair_t_mapnode_t * left, fd_vote_info_pair_t_mapnode_t * right ) {
+  return memcmp( left->elem.account.uc, right->elem.account.uc, sizeof(right->elem.account) );
 }

--- a/src/flamenco/types/fd_types.h
+++ b/src/flamenco/types/fd_types.h
@@ -543,56 +543,56 @@ typedef struct fd_vote_accounts_off fd_vote_accounts_off_t;
 #define FD_VOTE_ACCOUNTS_OFF_FOOTPRINT sizeof(fd_vote_accounts_off_t)
 #define FD_VOTE_ACCOUNTS_OFF_ALIGN (8UL)
 
-/* Encoded Size: Fixed (36 bytes) */
-struct __attribute__((aligned(8UL))) fd_stake_accounts_pair {
+/* Encoded Size: Fixed (33 bytes) */
+struct __attribute__((aligned(8UL))) fd_account_keys_pair {
   fd_pubkey_t key;
-  uint exists;
+  uchar exists;
 };
-typedef struct fd_stake_accounts_pair fd_stake_accounts_pair_t;
-#define FD_STAKE_ACCOUNTS_PAIR_FOOTPRINT sizeof(fd_stake_accounts_pair_t)
-#define FD_STAKE_ACCOUNTS_PAIR_ALIGN (8UL)
+typedef struct fd_account_keys_pair fd_account_keys_pair_t;
+#define FD_ACCOUNT_KEYS_PAIR_FOOTPRINT sizeof(fd_account_keys_pair_t)
+#define FD_ACCOUNT_KEYS_PAIR_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_stake_accounts_pair_off {
+struct __attribute__((aligned(8UL))) fd_account_keys_pair_off {
   uint key_off;
   uint exists_off;
 };
-typedef struct fd_stake_accounts_pair_off fd_stake_accounts_pair_off_t;
-#define FD_STAKE_ACCOUNTS_PAIR_OFF_FOOTPRINT sizeof(fd_stake_accounts_pair_off_t)
-#define FD_STAKE_ACCOUNTS_PAIR_OFF_ALIGN (8UL)
+typedef struct fd_account_keys_pair_off fd_account_keys_pair_off_t;
+#define FD_ACCOUNT_KEYS_PAIR_OFF_FOOTPRINT sizeof(fd_account_keys_pair_off_t)
+#define FD_ACCOUNT_KEYS_PAIR_OFF_ALIGN (8UL)
 
-typedef struct fd_stake_accounts_pair_t_mapnode fd_stake_accounts_pair_t_mapnode_t;
-#define REDBLK_T fd_stake_accounts_pair_t_mapnode_t
-#define REDBLK_NAME fd_stake_accounts_pair_t_map
+typedef struct fd_account_keys_pair_t_mapnode fd_account_keys_pair_t_mapnode_t;
+#define REDBLK_T fd_account_keys_pair_t_mapnode_t
+#define REDBLK_NAME fd_account_keys_pair_t_map
 #define REDBLK_IMPL_STYLE 1
 #include "../../util/tmpl/fd_redblack.c"
-struct fd_stake_accounts_pair_t_mapnode {
-    fd_stake_accounts_pair_t elem;
+struct fd_account_keys_pair_t_mapnode {
+    fd_account_keys_pair_t elem;
     ulong redblack_parent;
     ulong redblack_left;
     ulong redblack_right;
     int redblack_color;
 };
-static inline fd_stake_accounts_pair_t_mapnode_t *
-fd_stake_accounts_pair_t_map_alloc( fd_valloc_t valloc, ulong len ) {
+static inline fd_account_keys_pair_t_mapnode_t *
+fd_account_keys_pair_t_map_alloc( fd_valloc_t valloc, ulong len ) {
   if( FD_UNLIKELY( 0 == len ) ) len = 1; // prevent underflow
-  void * mem = fd_valloc_malloc( valloc, fd_stake_accounts_pair_t_map_align(), fd_stake_accounts_pair_t_map_footprint(len));
-  return fd_stake_accounts_pair_t_map_join(fd_stake_accounts_pair_t_map_new(mem, len));
+  void * mem = fd_valloc_malloc( valloc, fd_account_keys_pair_t_map_align(), fd_account_keys_pair_t_map_footprint(len));
+  return fd_account_keys_pair_t_map_join(fd_account_keys_pair_t_map_new(mem, len));
 }
 /* Encoded Size: Dynamic */
-struct __attribute__((aligned(8UL))) fd_stake_accounts {
-  fd_stake_accounts_pair_t_mapnode_t * stake_accounts_pool;
-  fd_stake_accounts_pair_t_mapnode_t * stake_accounts_root;
+struct __attribute__((aligned(8UL))) fd_account_keys {
+  fd_account_keys_pair_t_mapnode_t * account_keys_pool;
+  fd_account_keys_pair_t_mapnode_t * account_keys_root;
 };
-typedef struct fd_stake_accounts fd_stake_accounts_t;
-#define FD_STAKE_ACCOUNTS_FOOTPRINT sizeof(fd_stake_accounts_t)
-#define FD_STAKE_ACCOUNTS_ALIGN (8UL)
+typedef struct fd_account_keys fd_account_keys_t;
+#define FD_ACCOUNT_KEYS_FOOTPRINT sizeof(fd_account_keys_t)
+#define FD_ACCOUNT_KEYS_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_stake_accounts_off {
-  uint stake_accounts_off;
+struct __attribute__((aligned(8UL))) fd_account_keys_off {
+  uint account_keys_off;
 };
-typedef struct fd_stake_accounts_off fd_stake_accounts_off_t;
-#define FD_STAKE_ACCOUNTS_OFF_FOOTPRINT sizeof(fd_stake_accounts_off_t)
-#define FD_STAKE_ACCOUNTS_OFF_ALIGN (8UL)
+typedef struct fd_account_keys_off fd_account_keys_off_t;
+#define FD_ACCOUNT_KEYS_OFF_FOOTPRINT sizeof(fd_account_keys_off_t)
+#define FD_ACCOUNT_KEYS_OFF_ALIGN (8UL)
 
 /* fd_stake_weight_t assigns an Ed25519 public key (node identity) a stake weight number measured in lamports */
 /* Encoded Size: Fixed (40 bytes) */
@@ -704,39 +704,6 @@ struct __attribute__((aligned(8UL))) fd_stake_off {
 typedef struct fd_stake_off fd_stake_off_t;
 #define FD_STAKE_OFF_FOOTPRINT sizeof(fd_stake_off_t)
 #define FD_STAKE_OFF_ALIGN (8UL)
-
-/* Encoded Size: Fixed (104 bytes) */
-struct __attribute__((aligned(8UL))) fd_epoch_info_pair {
-  fd_pubkey_t account;
-  fd_stake_t stake;
-};
-typedef struct fd_epoch_info_pair fd_epoch_info_pair_t;
-#define FD_EPOCH_INFO_PAIR_FOOTPRINT sizeof(fd_epoch_info_pair_t)
-#define FD_EPOCH_INFO_PAIR_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_epoch_info_pair_off {
-  uint account_off;
-  uint stake_off;
-};
-typedef struct fd_epoch_info_pair_off fd_epoch_info_pair_off_t;
-#define FD_EPOCH_INFO_PAIR_OFF_FOOTPRINT sizeof(fd_epoch_info_pair_off_t)
-#define FD_EPOCH_INFO_PAIR_OFF_ALIGN (8UL)
-
-/* Encoded Size: Dynamic */
-struct __attribute__((aligned(8UL))) fd_epoch_info {
-  ulong infos_len;
-  fd_epoch_info_pair_t * infos;
-};
-typedef struct fd_epoch_info fd_epoch_info_t;
-#define FD_EPOCH_INFO_FOOTPRINT sizeof(fd_epoch_info_t)
-#define FD_EPOCH_INFO_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_epoch_info_off {
-  uint infos_off;
-};
-typedef struct fd_epoch_info_off fd_epoch_info_off_t;
-#define FD_EPOCH_INFO_OFF_FOOTPRINT sizeof(fd_epoch_info_off_t)
-#define FD_EPOCH_INFO_OFF_ALIGN (8UL)
 
 /* Encoded Size: Fixed (104 bytes) */
 struct __attribute__((aligned(8UL))) fd_stake_pair {
@@ -2642,8 +2609,8 @@ struct __attribute__((aligned(128UL))) fd_slot_bank {
   ulong collected_rent;
   fd_vote_accounts_t epoch_stakes;
   fd_sol_sysvar_last_restart_slot_t last_restart_slot;
-  fd_stake_accounts_t stake_account_keys;
-  fd_vote_accounts_t vote_account_keys;
+  fd_account_keys_t stake_account_keys;
+  fd_account_keys_t vote_account_keys;
   ulong lamports_per_signature;
   ulong transaction_count;
   fd_slot_lthash_t lthash;
@@ -5133,6 +5100,77 @@ typedef struct fd_duplicate_slot_proof_off fd_duplicate_slot_proof_off_t;
 #define FD_DUPLICATE_SLOT_PROOF_OFF_FOOTPRINT sizeof(fd_duplicate_slot_proof_off_t)
 #define FD_DUPLICATE_SLOT_PROOF_OFF_ALIGN (8UL)
 
+/* Encoded Size: Fixed (104 bytes) */
+struct __attribute__((aligned(8UL))) fd_epoch_info_pair {
+  fd_pubkey_t account;
+  fd_stake_t stake;
+};
+typedef struct fd_epoch_info_pair fd_epoch_info_pair_t;
+#define FD_EPOCH_INFO_PAIR_FOOTPRINT sizeof(fd_epoch_info_pair_t)
+#define FD_EPOCH_INFO_PAIR_ALIGN (8UL)
+
+struct __attribute__((aligned(8UL))) fd_epoch_info_pair_off {
+  uint account_off;
+  uint stake_off;
+};
+typedef struct fd_epoch_info_pair_off fd_epoch_info_pair_off_t;
+#define FD_EPOCH_INFO_PAIR_OFF_FOOTPRINT sizeof(fd_epoch_info_pair_off_t)
+#define FD_EPOCH_INFO_PAIR_OFF_ALIGN (8UL)
+
+/* Encoded Size: Dynamic */
+struct __attribute__((aligned(8UL))) fd_vote_info_pair {
+  fd_pubkey_t account;
+  fd_vote_state_versioned_t state;
+};
+typedef struct fd_vote_info_pair fd_vote_info_pair_t;
+#define FD_VOTE_INFO_PAIR_FOOTPRINT sizeof(fd_vote_info_pair_t)
+#define FD_VOTE_INFO_PAIR_ALIGN (8UL)
+
+struct __attribute__((aligned(8UL))) fd_vote_info_pair_off {
+  uint account_off;
+  uint state_off;
+};
+typedef struct fd_vote_info_pair_off fd_vote_info_pair_off_t;
+#define FD_VOTE_INFO_PAIR_OFF_FOOTPRINT sizeof(fd_vote_info_pair_off_t)
+#define FD_VOTE_INFO_PAIR_OFF_ALIGN (8UL)
+
+typedef struct fd_vote_info_pair_t_mapnode fd_vote_info_pair_t_mapnode_t;
+#define REDBLK_T fd_vote_info_pair_t_mapnode_t
+#define REDBLK_NAME fd_vote_info_pair_t_map
+#define REDBLK_IMPL_STYLE 1
+#include "../../util/tmpl/fd_redblack.c"
+struct fd_vote_info_pair_t_mapnode {
+    fd_vote_info_pair_t elem;
+    ulong redblack_parent;
+    ulong redblack_left;
+    ulong redblack_right;
+    int redblack_color;
+};
+static inline fd_vote_info_pair_t_mapnode_t *
+fd_vote_info_pair_t_map_alloc( fd_valloc_t valloc, ulong len ) {
+  if( FD_UNLIKELY( 0 == len ) ) len = 1; // prevent underflow
+  void * mem = fd_valloc_malloc( valloc, fd_vote_info_pair_t_map_align(), fd_vote_info_pair_t_map_footprint(len));
+  return fd_vote_info_pair_t_map_join(fd_vote_info_pair_t_map_new(mem, len));
+}
+/* Encoded Size: Dynamic */
+struct __attribute__((aligned(8UL))) fd_epoch_info {
+  ulong stake_infos_len;
+  fd_epoch_info_pair_t * stake_infos;
+  fd_vote_info_pair_t_mapnode_t * vote_states_pool;
+  fd_vote_info_pair_t_mapnode_t * vote_states_root;
+};
+typedef struct fd_epoch_info fd_epoch_info_t;
+#define FD_EPOCH_INFO_FOOTPRINT sizeof(fd_epoch_info_t)
+#define FD_EPOCH_INFO_ALIGN (8UL)
+
+struct __attribute__((aligned(8UL))) fd_epoch_info_off {
+  uint stake_infos_off;
+  uint vote_states_off;
+};
+typedef struct fd_epoch_info_off fd_epoch_info_off_t;
+#define FD_EPOCH_INFO_OFF_FOOTPRINT sizeof(fd_epoch_info_off_t)
+#define FD_EPOCH_INFO_OFF_ALIGN (8UL)
+
 
 FD_PROTOTYPES_BEGIN
 
@@ -5476,37 +5514,37 @@ int fd_vote_accounts_decode_archival_preflight( fd_bincode_decode_ctx_t * ctx );
 void fd_vote_accounts_decode_archival_unsafe( fd_vote_accounts_t * self, fd_bincode_decode_ctx_t * ctx );
 int fd_vote_accounts_encode_archival( fd_vote_accounts_t const * self, fd_bincode_encode_ctx_t * ctx );
 
-void fd_stake_accounts_pair_new( fd_stake_accounts_pair_t * self );
-int fd_stake_accounts_pair_decode( fd_stake_accounts_pair_t * self, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_accounts_pair_decode_preflight( fd_bincode_decode_ctx_t * ctx );
-void fd_stake_accounts_pair_decode_unsafe( fd_stake_accounts_pair_t * self, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_accounts_pair_decode_offsets( fd_stake_accounts_pair_off_t * self, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_accounts_pair_encode( fd_stake_accounts_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
-void fd_stake_accounts_pair_destroy( fd_stake_accounts_pair_t * self, fd_bincode_destroy_ctx_t * ctx );
-void fd_stake_accounts_pair_walk( void * w, fd_stake_accounts_pair_t const * self, fd_types_walk_fn_t fun, const char *name, uint level );
-ulong fd_stake_accounts_pair_size( fd_stake_accounts_pair_t const * self );
-ulong fd_stake_accounts_pair_footprint( void );
-ulong fd_stake_accounts_pair_align( void );
-int fd_stake_accounts_pair_decode_archival( fd_stake_accounts_pair_t * self, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_accounts_pair_decode_archival_preflight( fd_bincode_decode_ctx_t * ctx );
-void fd_stake_accounts_pair_decode_archival_unsafe( fd_stake_accounts_pair_t * self, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_accounts_pair_encode_archival( fd_stake_accounts_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
+void fd_account_keys_pair_new( fd_account_keys_pair_t * self );
+int fd_account_keys_pair_decode( fd_account_keys_pair_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_account_keys_pair_decode_preflight( fd_bincode_decode_ctx_t * ctx );
+void fd_account_keys_pair_decode_unsafe( fd_account_keys_pair_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_account_keys_pair_decode_offsets( fd_account_keys_pair_off_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_account_keys_pair_encode( fd_account_keys_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
+void fd_account_keys_pair_destroy( fd_account_keys_pair_t * self, fd_bincode_destroy_ctx_t * ctx );
+void fd_account_keys_pair_walk( void * w, fd_account_keys_pair_t const * self, fd_types_walk_fn_t fun, const char *name, uint level );
+ulong fd_account_keys_pair_size( fd_account_keys_pair_t const * self );
+ulong fd_account_keys_pair_footprint( void );
+ulong fd_account_keys_pair_align( void );
+int fd_account_keys_pair_decode_archival( fd_account_keys_pair_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_account_keys_pair_decode_archival_preflight( fd_bincode_decode_ctx_t * ctx );
+void fd_account_keys_pair_decode_archival_unsafe( fd_account_keys_pair_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_account_keys_pair_encode_archival( fd_account_keys_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
 
-void fd_stake_accounts_new( fd_stake_accounts_t * self );
-int fd_stake_accounts_decode( fd_stake_accounts_t * self, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_accounts_decode_preflight( fd_bincode_decode_ctx_t * ctx );
-void fd_stake_accounts_decode_unsafe( fd_stake_accounts_t * self, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_accounts_decode_offsets( fd_stake_accounts_off_t * self, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_accounts_encode( fd_stake_accounts_t const * self, fd_bincode_encode_ctx_t * ctx );
-void fd_stake_accounts_destroy( fd_stake_accounts_t * self, fd_bincode_destroy_ctx_t * ctx );
-void fd_stake_accounts_walk( void * w, fd_stake_accounts_t const * self, fd_types_walk_fn_t fun, const char *name, uint level );
-ulong fd_stake_accounts_size( fd_stake_accounts_t const * self );
-ulong fd_stake_accounts_footprint( void );
-ulong fd_stake_accounts_align( void );
-int fd_stake_accounts_decode_archival( fd_stake_accounts_t * self, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_accounts_decode_archival_preflight( fd_bincode_decode_ctx_t * ctx );
-void fd_stake_accounts_decode_archival_unsafe( fd_stake_accounts_t * self, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_accounts_encode_archival( fd_stake_accounts_t const * self, fd_bincode_encode_ctx_t * ctx );
+void fd_account_keys_new( fd_account_keys_t * self );
+int fd_account_keys_decode( fd_account_keys_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_account_keys_decode_preflight( fd_bincode_decode_ctx_t * ctx );
+void fd_account_keys_decode_unsafe( fd_account_keys_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_account_keys_decode_offsets( fd_account_keys_off_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_account_keys_encode( fd_account_keys_t const * self, fd_bincode_encode_ctx_t * ctx );
+void fd_account_keys_destroy( fd_account_keys_t * self, fd_bincode_destroy_ctx_t * ctx );
+void fd_account_keys_walk( void * w, fd_account_keys_t const * self, fd_types_walk_fn_t fun, const char *name, uint level );
+ulong fd_account_keys_size( fd_account_keys_t const * self );
+ulong fd_account_keys_footprint( void );
+ulong fd_account_keys_align( void );
+int fd_account_keys_decode_archival( fd_account_keys_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_account_keys_decode_archival_preflight( fd_bincode_decode_ctx_t * ctx );
+void fd_account_keys_decode_archival_unsafe( fd_account_keys_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_account_keys_encode_archival( fd_account_keys_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_stake_weight_new( fd_stake_weight_t * self );
 int fd_stake_weight_decode( fd_stake_weight_t * self, fd_bincode_decode_ctx_t * ctx );
@@ -5575,30 +5613,6 @@ void fd_stake_walk( void * w, fd_stake_t const * self, fd_types_walk_fn_t fun, c
 ulong fd_stake_size( fd_stake_t const * self );
 ulong fd_stake_footprint( void );
 ulong fd_stake_align( void );
-
-void fd_epoch_info_pair_new( fd_epoch_info_pair_t * self );
-int fd_epoch_info_pair_decode( fd_epoch_info_pair_t * self, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_info_pair_decode_preflight( fd_bincode_decode_ctx_t * ctx );
-void fd_epoch_info_pair_decode_unsafe( fd_epoch_info_pair_t * self, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_info_pair_decode_offsets( fd_epoch_info_pair_off_t * self, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_info_pair_encode( fd_epoch_info_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
-void fd_epoch_info_pair_destroy( fd_epoch_info_pair_t * self, fd_bincode_destroy_ctx_t * ctx );
-void fd_epoch_info_pair_walk( void * w, fd_epoch_info_pair_t const * self, fd_types_walk_fn_t fun, const char *name, uint level );
-ulong fd_epoch_info_pair_size( fd_epoch_info_pair_t const * self );
-ulong fd_epoch_info_pair_footprint( void );
-ulong fd_epoch_info_pair_align( void );
-
-void fd_epoch_info_new( fd_epoch_info_t * self );
-int fd_epoch_info_decode( fd_epoch_info_t * self, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_info_decode_preflight( fd_bincode_decode_ctx_t * ctx );
-void fd_epoch_info_decode_unsafe( fd_epoch_info_t * self, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_info_decode_offsets( fd_epoch_info_off_t * self, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_info_encode( fd_epoch_info_t const * self, fd_bincode_encode_ctx_t * ctx );
-void fd_epoch_info_destroy( fd_epoch_info_t * self, fd_bincode_destroy_ctx_t * ctx );
-void fd_epoch_info_walk( void * w, fd_epoch_info_t const * self, fd_types_walk_fn_t fun, const char *name, uint level );
-ulong fd_epoch_info_size( fd_epoch_info_t const * self );
-ulong fd_epoch_info_footprint( void );
-ulong fd_epoch_info_align( void );
 
 void fd_stake_pair_new( fd_stake_pair_t * self );
 int fd_stake_pair_decode( fd_stake_pair_t * self, fd_bincode_decode_ctx_t * ctx );
@@ -8622,6 +8636,42 @@ void fd_duplicate_slot_proof_walk( void * w, fd_duplicate_slot_proof_t const * s
 ulong fd_duplicate_slot_proof_size( fd_duplicate_slot_proof_t const * self );
 ulong fd_duplicate_slot_proof_footprint( void );
 ulong fd_duplicate_slot_proof_align( void );
+
+void fd_epoch_info_pair_new( fd_epoch_info_pair_t * self );
+int fd_epoch_info_pair_decode( fd_epoch_info_pair_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_epoch_info_pair_decode_preflight( fd_bincode_decode_ctx_t * ctx );
+void fd_epoch_info_pair_decode_unsafe( fd_epoch_info_pair_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_epoch_info_pair_decode_offsets( fd_epoch_info_pair_off_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_epoch_info_pair_encode( fd_epoch_info_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
+void fd_epoch_info_pair_destroy( fd_epoch_info_pair_t * self, fd_bincode_destroy_ctx_t * ctx );
+void fd_epoch_info_pair_walk( void * w, fd_epoch_info_pair_t const * self, fd_types_walk_fn_t fun, const char *name, uint level );
+ulong fd_epoch_info_pair_size( fd_epoch_info_pair_t const * self );
+ulong fd_epoch_info_pair_footprint( void );
+ulong fd_epoch_info_pair_align( void );
+
+void fd_vote_info_pair_new( fd_vote_info_pair_t * self );
+int fd_vote_info_pair_decode( fd_vote_info_pair_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_vote_info_pair_decode_preflight( fd_bincode_decode_ctx_t * ctx );
+void fd_vote_info_pair_decode_unsafe( fd_vote_info_pair_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_vote_info_pair_decode_offsets( fd_vote_info_pair_off_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_vote_info_pair_encode( fd_vote_info_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
+void fd_vote_info_pair_destroy( fd_vote_info_pair_t * self, fd_bincode_destroy_ctx_t * ctx );
+void fd_vote_info_pair_walk( void * w, fd_vote_info_pair_t const * self, fd_types_walk_fn_t fun, const char *name, uint level );
+ulong fd_vote_info_pair_size( fd_vote_info_pair_t const * self );
+ulong fd_vote_info_pair_footprint( void );
+ulong fd_vote_info_pair_align( void );
+
+void fd_epoch_info_new( fd_epoch_info_t * self );
+int fd_epoch_info_decode( fd_epoch_info_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_epoch_info_decode_preflight( fd_bincode_decode_ctx_t * ctx );
+void fd_epoch_info_decode_unsafe( fd_epoch_info_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_epoch_info_decode_offsets( fd_epoch_info_off_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_epoch_info_encode( fd_epoch_info_t const * self, fd_bincode_encode_ctx_t * ctx );
+void fd_epoch_info_destroy( fd_epoch_info_t * self, fd_bincode_destroy_ctx_t * ctx );
+void fd_epoch_info_walk( void * w, fd_epoch_info_t const * self, fd_types_walk_fn_t fun, const char *name, uint level );
+ulong fd_epoch_info_size( fd_epoch_info_t const * self );
+ulong fd_epoch_info_footprint( void );
+ulong fd_epoch_info_align( void );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/types/fd_types.json
+++ b/src/flamenco/types/fd_types.json
@@ -269,18 +269,18 @@
       ]
     },
     {
-      "name": "stake_accounts_pair",
+      "name": "account_keys_pair",
       "type": "struct",
       "fields": [
         { "name": "key", "type": "pubkey" },
-        { "name": "exists", "type": "uint" }
+        { "name": "exists", "type": "uchar" }
       ]
     },
     {
-      "name": "stake_accounts",
+      "name": "account_keys",
       "type": "struct",
       "fields": [
-        { "name": "stake_accounts", "type": "map", "element": "stake_accounts_pair", "key": "key", "minalloc":100000 }
+        { "name": "account_keys", "type": "map", "element": "account_keys_pair", "key": "key", "minalloc":100000 }
       ]
     },
     {
@@ -327,21 +327,6 @@
         { "name": "credits_observed", "type": "ulong" }
       ],
       "comment": "https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/state.rs#L539"
-    },
-    {
-      "name": "epoch_info_pair",
-      "type": "struct",
-      "fields": [
-        { "name": "account", "type": "pubkey" },
-        { "name": "stake", "type": "stake" }
-      ]
-    },
-    {
-      "name": "epoch_info",
-      "type": "struct",
-      "fields": [
-        { "name": "infos", "type": "vector", "element":"epoch_info_pair" }
-      ]
     },
     {
       "name": "stake_pair",
@@ -1203,8 +1188,8 @@
         { "name": "collected_rent",              "type": "ulong" },
         { "name": "epoch_stakes",                "type": "vote_accounts" },
         { "name": "last_restart_slot",           "type": "sol_sysvar_last_restart_slot" },
-        { "name": "stake_account_keys",          "type": "stake_accounts"},
-        { "name": "vote_account_keys",           "type": "vote_accounts" },
+        { "name": "stake_account_keys",          "type": "account_keys"},
+        { "name": "vote_account_keys",           "type": "account_keys" },
         { "name": "lamports_per_signature",      "type": "ulong" },
         { "name": "transaction_count",           "type": "ulong" },
         { "name": "lthash",                      "type": "slot_lthash" },
@@ -2779,6 +2764,30 @@
         { "name": "shred2", "type": "vector", "element": "uchar" }
       ],
       "comment": "https://github.com/anza-xyz/agave/blob/v2.0.3/ledger/src/blockstore_meta.rs#L150-L156"
+    },
+    {
+      "name": "epoch_info_pair",
+      "type": "struct",
+      "fields": [
+        { "name": "account", "type": "pubkey" },
+        { "name": "stake", "type": "stake" }
+      ]
+    },
+    {
+      "name": "vote_info_pair",
+      "type": "struct",
+      "fields": [
+        { "name": "account", "type": "pubkey" },
+        { "name": "state", "type": "vote_state_versioned" }
+      ]
+    },
+    {
+      "name": "epoch_info",
+      "type": "struct",
+      "fields": [
+        { "name": "stake_infos", "type": "vector", "element": "epoch_info_pair" },
+        { "name": "vote_states", "type": "map", "element": "vote_info_pair", "key": "account"}
+      ]
     }
   ]
 }


### PR DESCRIPTION
First pass at reworking stakes caching logic + caching duplicate-accessed information to avoid unnecessary account deserialization