### PR TITLE
snapshot: fix incremental snapshot loading

### DIFF
--- a/src/app/fdctl/run/tiles/fd_replay.c
+++ b/src/app/fdctl/run/tiles/fd_replay.c
@@ -1951,16 +1951,16 @@ read_snapshot( void * _ctx,
        stake weights. After this, repair will kick off concurrently with loading 
        the rest of the snapshots. */
 
-  if( strlen( incremental )>0UL ) {
-    uchar *                  tmp_mem      = fd_scratch_alloc( fd_snapshot_load_ctx_align(), fd_snapshot_load_ctx_footprint() );
-    fd_snapshot_load_ctx_t * tmp_snap_ctx = fd_snapshot_load_new( tmp_mem, incremental, ctx->slot_ctx, ctx->tpool, false, false, FD_SNAPSHOT_TYPE_FULL );
-    fd_snapshot_load_prefetch_manifest( tmp_snap_ctx );
-    kickoff_repair_orphans( ctx, stem );
-  }
+    if( strlen( incremental )>0UL ) {
+      uchar *                  tmp_mem      = fd_scratch_alloc( fd_snapshot_load_ctx_align(), fd_snapshot_load_ctx_footprint() );
+      fd_snapshot_load_ctx_t * tmp_snap_ctx = fd_snapshot_load_new( tmp_mem, incremental, ctx->slot_ctx, ctx->tpool, false, false, FD_SNAPSHOT_TYPE_FULL );
+      fd_snapshot_load_prefetch_manifest( tmp_snap_ctx );
+      kickoff_repair_orphans( ctx, stem );
+    }
 
     /* In order to kick off repair effectively we need the snapshot slot and
        the stake weights. These are both available in the manifest. We will
-       try to load in the manifest from the latest snapshot that is availble,
+       try to load in the manifest from the latest snapshot that is available,
        then setup the blockstore and publish the stake weights. After this,
        repair will kick off concurrently with loading the rest of the snapshots. */
 
@@ -1968,12 +1968,20 @@ read_snapshot( void * _ctx,
     fd_snapshot_load_ctx_t * snap_ctx = fd_snapshot_load_new( mem, snapshot, ctx->slot_ctx, ctx->tpool, false, false, FD_SNAPSHOT_TYPE_FULL );
   
     fd_snapshot_load_init( snap_ctx );
-    fd_snapshot_load_manifest_and_status_cache( snap_ctx );
 
+    /* If we have an incremental snapshot, load the manifest and the status cache without initialising
+       the objects because they have already been initialised when we load the incremental snapshot */
     if( strlen( incremental )<=0UL ) {
+      fd_snapshot_load_manifest_and_status_cache( snap_ctx, FD_SNAPSHOT_RESTORE_NONE );
+
       /* If we don't have an incremental snapshot, we can still kick off
          sending the stake weights and snapshot slot to repair. */
       kickoff_repair_orphans( ctx, stem );
+    } else {
+      /* If we don't have an incremental snapshot load manifest and the status cash and initialise 
+         the objects because we don't have these from the incremental snapshot. */
+      fd_snapshot_load_manifest_and_status_cache( snap_ctx,
+       FD_SNAPSHOT_RESTORE_MANIFEST | FD_SNAPSHOT_RESTORE_STATUS_CACHE );
     }
 
     fd_snapshot_load_accounts( snap_ctx );

--- a/src/flamenco/snapshot/fd_snapshot.c
+++ b/src/flamenco/snapshot/fd_snapshot.c
@@ -129,7 +129,9 @@ fd_snapshot_load_init( fd_snapshot_load_ctx_t * ctx ) {
 }
 
 void
-fd_snapshot_load_manifest_and_status_cache( fd_snapshot_load_ctx_t * ctx ) {
+fd_snapshot_load_manifest_and_status_cache( 
+  fd_snapshot_load_ctx_t * ctx,
+  int restore_manifest_flags ) {
 
   fd_scratch_push();
   size_t slen = strlen( ctx->snapshot_file );
@@ -150,7 +152,15 @@ fd_snapshot_load_manifest_and_status_cache( fd_snapshot_load_ctx_t * ctx ) {
   void * restore_mem = fd_valloc_malloc( valloc, fd_snapshot_restore_align(), fd_snapshot_restore_footprint() );
   void * loader_mem  = fd_valloc_malloc( valloc, fd_snapshot_loader_align(),  fd_snapshot_loader_footprint( ZSTD_WINDOW_SZ ) );
 
-  ctx->restore = fd_snapshot_restore_new( restore_mem, acc_mgr, funk_txn, valloc, ctx->slot_ctx, restore_manifest, restore_status_cache );
+  ctx->restore = fd_snapshot_restore_new( 
+    restore_mem,
+    acc_mgr,
+    funk_txn,
+    valloc,
+    ctx->slot_ctx, 
+    (restore_manifest_flags & FD_SNAPSHOT_RESTORE_MANIFEST) ? restore_manifest : NULL,
+    (restore_manifest_flags & FD_SNAPSHOT_RESTORE_STATUS_CACHE) ? restore_status_cache : NULL );
+  
   ctx->loader  = fd_snapshot_loader_new ( loader_mem, ZSTD_WINDOW_SZ );
 
   if( FD_UNLIKELY( !ctx->restore || !ctx->loader ) ) {
@@ -282,7 +292,8 @@ fd_snapshot_load_all( const char *         source_cstr,
   fd_snapshot_load_ctx_t * ctx = fd_snapshot_load_new( mem, source_cstr, slot_ctx, tpool, verify_hash, check_hash, snapshot_type );
 
   fd_snapshot_load_init( ctx );
-  fd_snapshot_load_manifest_and_status_cache( ctx );
+  fd_snapshot_load_manifest_and_status_cache( ctx, 
+    FD_SNAPSHOT_RESTORE_STATUS_CACHE | FD_SNAPSHOT_RESTORE_MANIFEST );
   fd_snapshot_load_accounts( ctx );
   fd_snapshot_load_fini( ctx );
 

--- a/src/flamenco/snapshot/fd_snapshot.h
+++ b/src/flamenco/snapshot/fd_snapshot.h
@@ -9,6 +9,12 @@
 
 FD_PROTOTYPES_BEGIN
 
+/* Whether to initialize these objects inside fd_snapshot_load_manifest_and_status_cache,
+   or just advance the tar cursor. */
+#define FD_SNAPSHOT_RESTORE_NONE         (0)
+#define FD_SNAPSHOT_RESTORE_MANIFEST     (1)
+#define FD_SNAPSHOT_RESTORE_STATUS_CACHE (2)
+
 struct fd_snapshot_load_ctx;
 typedef struct fd_snapshot_load_ctx fd_snapshot_load_ctx_t;
 
@@ -70,8 +76,11 @@ fd_snapshot_load_new( uchar *                mem,
 void
 fd_snapshot_load_init( fd_snapshot_load_ctx_t * ctx );
 
+/* restore_manifest_flags controls if the manifest and status cache objects are initialized or not.*/
 void
-fd_snapshot_load_manifest_and_status_cache( fd_snapshot_load_ctx_t * ctx );
+fd_snapshot_load_manifest_and_status_cache( 
+  fd_snapshot_load_ctx_t * ctx,
+  int restore_manifest_flags );
 
 void
 fd_snapshot_load_accounts( fd_snapshot_load_ctx_t * ctx );


### PR DESCRIPTION
In the case where we have an incremental snapshot, the status cache and the slot context were first being initialized from the incremental snapshot preflight manifest load, and then again when we loaded the full snapshot manifest.

This meant that the validators slot number is set first to the incremental snapshots slot number, then jumps back to the full snapshots slot number. This causes repair to get stuck in a loop.

Therefore, if we have an incremental snapshot this PR skips initializing the status cash and the slot context when we load in the _full_ snapshot - because these will have already been initialized by the incremental snapshot preflight manifest load. 