### PR TITLE
repair: tweak peer selection

### DIFF
--- a/src/disco/consensus/test_consensus.c
+++ b/src/disco/consensus/test_consensus.c
@@ -715,7 +715,6 @@ main( void ) {
 //       FD_LOG_ERR( ( "error adding repair active peer" ) );
 //     }
 //     fd_repair_add_sticky( replay->repair, &_repair_peer_id );
-//     fd_repair_set_permanent( replay->repair, &_repair_peer_id );
 //   }
 
 //   /**********************************************************************/

--- a/src/flamenco/repair/fd_repair.h
+++ b/src/flamenco/repair/fd_repair.h
@@ -103,8 +103,6 @@ int fd_repair_need_orphan( fd_repair_t * glob, ulong slot );
 
 void fd_repair_add_sticky( fd_repair_t * glob, fd_pubkey_t const * id );
 
-void fd_repair_set_permanent( fd_repair_t * glob, fd_pubkey_t const * id );
-
 void fd_repair_set_stake_weights( fd_repair_t * repair,
                                   fd_stake_weight_t const * stake_weights,
                                   ulong stake_weights_cnt );

--- a/src/flamenco/repair/fd_repair_tool.c
+++ b/src/flamenco/repair/fd_repair_tool.c
@@ -145,7 +145,6 @@ main_loop( int * argc, char *** argv, fd_repair_t * glob, fd_repair_config_t * c
   if ( fd_repair_add_active_peer(glob, resolve_hostport(addr_cstr, &peeraddr), &id) )
     return -1;
   fd_repair_add_sticky(glob, &id);
-  fd_repair_set_permanent(glob, &id);
 
   char const * slot_cstr = fd_env_strip_cmdline_cstr ( argc, argv, "--slot", NULL, NULL );
   if ( slot_cstr == NULL )


### PR DESCRIPTION
- remove un-used concept of permanent repair peer, which simplifies the code
- wait until we have stake weights before sampling repair peers. these are sent quickly now, as we propagate them to repair as soon as we load the manifest from the incremental snapshot, rather than waiting for the full snapshot to load.
-- this means that _all_ repair peer selection is stake-weighted.
- use stake-weighted random sampling to select repair sticky peers

note that this isn't perfect stake-weighting, because it is influenced by the order of peer discovery. it's not clear yet if this is a problem

this algorithm results in higher-staked peers being selected with lower latencies