### PR TITLE
snapshot: fix incremental snapshot loading

### DIFF
--- a/src/app/ledger/main.c
+++ b/src/app/ledger/main.c
@@ -1141,11 +1141,11 @@ ingest( fd_ledger_args_t * args ) {
 
   /* Load in snapshot(s) */
   if( args->snapshot ) {
-    fd_snapshot_load_all( args->snapshot, slot_ctx, args->tpool, args->verify_acc_hash, args->check_acc_hash , FD_SNAPSHOT_TYPE_FULL );
+    fd_snapshot_load_all( args->snapshot, slot_ctx, NULL, args->tpool, args->verify_acc_hash, args->check_acc_hash , FD_SNAPSHOT_TYPE_FULL );
     FD_LOG_NOTICE(( "imported %lu records from snapshot", fd_funk_rec_cnt( fd_funk_rec_map( funk, fd_funk_wksp( funk ) ) ) ));
   }
   if( args->incremental ) {
-    fd_snapshot_load_all( args->incremental, slot_ctx, args->tpool, args->verify_acc_hash, args->check_acc_hash, FD_SNAPSHOT_TYPE_INCREMENTAL );
+    fd_snapshot_load_all( args->incremental, slot_ctx, NULL, args->tpool, args->verify_acc_hash, args->check_acc_hash, FD_SNAPSHOT_TYPE_INCREMENTAL );
     FD_LOG_NOTICE(( "imported %lu records from incremental snapshot", fd_funk_rec_cnt( fd_funk_rec_map( funk, fd_funk_wksp( funk ) ) ) ));
   }
 
@@ -1293,11 +1293,11 @@ replay( fd_ledger_args_t * args ) {
   if( !rec_cnt ) {
     /* Load in snapshot(s) */
     if( args->snapshot ) {
-      fd_snapshot_load_all( args->snapshot, args->slot_ctx, args->tpool, args->verify_acc_hash, args->check_acc_hash, FD_SNAPSHOT_TYPE_FULL );
+      fd_snapshot_load_all( args->snapshot, args->slot_ctx, NULL, args->tpool, args->verify_acc_hash, args->check_acc_hash, FD_SNAPSHOT_TYPE_FULL );
       FD_LOG_NOTICE(( "imported %lu records from snapshot", fd_funk_rec_cnt( fd_funk_rec_map( funk, fd_funk_wksp( funk ) ) ) ));
     }
     if( args->incremental ) {
-      fd_snapshot_load_all( args->incremental, args->slot_ctx, args->tpool, args->verify_acc_hash, args->check_acc_hash, FD_SNAPSHOT_TYPE_INCREMENTAL );
+      fd_snapshot_load_all( args->incremental, args->slot_ctx, NULL, args->tpool, args->verify_acc_hash, args->check_acc_hash, FD_SNAPSHOT_TYPE_INCREMENTAL );
       FD_LOG_NOTICE(( "imported %lu records from snapshot", fd_funk_rec_cnt( fd_funk_rec_map( funk, fd_funk_wksp( funk ) ) ) ));
     }
     if( args->genesis ) {
@@ -1352,11 +1352,11 @@ prune( fd_ledger_args_t * args ) {
   if( !rec_cnt ) {
     /* Load in snapshot(s) */
     if( args->snapshot ) {
-      fd_snapshot_load_all( args->snapshot, args->slot_ctx, args->tpool, args->verify_acc_hash, args->check_acc_hash, FD_SNAPSHOT_TYPE_FULL );
+      fd_snapshot_load_all( args->snapshot, args->slot_ctx, NULL, args->tpool, args->verify_acc_hash, args->check_acc_hash, FD_SNAPSHOT_TYPE_FULL );
       FD_LOG_NOTICE(( "imported %lu records from snapshot", fd_funk_rec_cnt( fd_funk_rec_map( funk, fd_funk_wksp( funk ) ) ) ));
     }
     if( args->incremental ) {
-      fd_snapshot_load_all( args->incremental, args->slot_ctx, args->tpool, args->verify_acc_hash, args->check_acc_hash, FD_SNAPSHOT_TYPE_INCREMENTAL );
+      fd_snapshot_load_all( args->incremental, args->slot_ctx, NULL, args->tpool, args->verify_acc_hash, args->check_acc_hash, FD_SNAPSHOT_TYPE_INCREMENTAL );
       FD_LOG_NOTICE(( "imported %lu records from snapshot", fd_funk_rec_cnt( fd_funk_rec_map( funk, fd_funk_wksp( funk ) ) ) ));
     }
   }
@@ -1461,11 +1461,11 @@ prune( fd_ledger_args_t * args ) {
 
   /* Load in snapshot(s) */
   if( args->snapshot ) {
-    fd_snapshot_load_all( args->snapshot, args->slot_ctx, args->tpool, 0, 0, FD_SNAPSHOT_TYPE_FULL );
+    fd_snapshot_load_all( args->snapshot, args->slot_ctx, NULL, args->tpool, 0, 0, FD_SNAPSHOT_TYPE_FULL );
     FD_LOG_NOTICE(( "reload: imported %lu records from snapshot", fd_funk_rec_cnt( fd_funk_rec_map( funk, fd_funk_wksp( funk ) ) ) ));
   }
   if( args->incremental ) {
-    fd_snapshot_load_all( args->incremental, args->slot_ctx, args->tpool, 0, 0, FD_SNAPSHOT_TYPE_INCREMENTAL );
+    fd_snapshot_load_all( args->incremental, args->slot_ctx, NULL, args->tpool, 0, 0, FD_SNAPSHOT_TYPE_INCREMENTAL );
     FD_LOG_NOTICE(( "reload: imported %lu records from snapshot", fd_funk_rec_cnt( fd_funk_rec_map( funk, fd_funk_wksp( funk ) ) ) ));
   }
 

--- a/src/disco/consensus/test_consensus.c
+++ b/src/disco/consensus/test_consensus.c
@@ -556,7 +556,7 @@ main( void ) {
 //     FD_TEST( epoch_bank );
 //     FD_TEST( fd_slot_to_epoch( &epoch_bank->epoch_schedule, i, NULL ) ==
 //              fd_slot_to_epoch( &epoch_bank->epoch_schedule, j, NULL ) );
-//     fd_snapshot_load_all( incremental_snapshot, snapshot_slot_ctx, 1, 1, FD_SNAPSHOT_TYPE_INCREMENTAL );
+//     fd_snapshot_load_all( incremental_snapshot, NULL, snapshot_slot_ctx, 1, 1, FD_SNAPSHOT_TYPE_INCREMENTAL );
 //   }
 
 //   ulong snapshot_slot = snapshot_slot_ctx->slot_bank.slot;

--- a/src/flamenco/snapshot/fd_snapshot.h
+++ b/src/flamenco/snapshot/fd_snapshot.h
@@ -9,6 +9,12 @@
 
 FD_PROTOTYPES_BEGIN
 
+/* Whether to initialize these objects inside fd_snapshot_load_manifest_and_status_cache,
+   or just advance the tar cursor. */
+#define FD_SNAPSHOT_RESTORE_NONE         (0)
+#define FD_SNAPSHOT_RESTORE_MANIFEST     (1)
+#define FD_SNAPSHOT_RESTORE_STATUS_CACHE (2)
+
 struct fd_snapshot_load_ctx;
 typedef struct fd_snapshot_load_ctx fd_snapshot_load_ctx_t;
 
@@ -70,8 +76,11 @@ fd_snapshot_load_new( uchar *                mem,
 void
 fd_snapshot_load_init( fd_snapshot_load_ctx_t * ctx );
 
+/* restore_manifest_flags controls if the manifest and status cache objects are initialized or not. */
 void
-fd_snapshot_load_manifest_and_status_cache( fd_snapshot_load_ctx_t * ctx );
+fd_snapshot_load_manifest_and_status_cache( fd_snapshot_load_ctx_t * ctx,
+                                            ulong *                  base_slot_override,
+                                            int                      restore_manifest_flags );
 
 void
 fd_snapshot_load_accounts( fd_snapshot_load_ctx_t * ctx );
@@ -82,6 +91,7 @@ fd_snapshot_load_fini( fd_snapshot_load_ctx_t * ctx );
 void
 fd_snapshot_load_all( const char *         source_cstr,
                       fd_exec_slot_ctx_t * slot_ctx,
+                      ulong *              base_slot_override,
                       fd_tpool_t *         tpool,
                       uint                 verify_hash,
                       uint                 check_hash,
@@ -89,6 +99,9 @@ fd_snapshot_load_all( const char *         source_cstr,
 
 void
 fd_snapshot_load_prefetch_manifest( fd_snapshot_load_ctx_t * ctx );
+
+ulong
+fd_snapshot_get_slot( fd_snapshot_load_ctx_t * ctx );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/snapshot/fd_snapshot_restore.c
+++ b/src/flamenco/snapshot/fd_snapshot_restore.c
@@ -81,10 +81,6 @@ fd_snapshot_restore_new( void *                               mem,
     FD_LOG_WARNING(( "NULL valloc" ));
     return NULL;
   }
-  if( FD_UNLIKELY( !cb_manifest ) ) {
-    FD_LOG_WARNING(( "NULL callback" ));
-    return NULL;
-  }
 
   FD_SCRATCH_ALLOC_INIT( l, mem );
   fd_snapshot_restore_t * self = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_snapshot_restore_t), sizeof(fd_snapshot_restore_t) );
@@ -292,7 +288,10 @@ fd_snapshot_restore_manifest( fd_snapshot_restore_t * restore ) {
   /* Move over objects and recover state
      This destroys all remaining fields with the slot context valloc. */
 
-  int err = restore->cb_manifest( restore->cb_manifest_ctx, manifest );
+  int err = 0;
+  if( restore->cb_manifest ) {
+    err = restore->cb_manifest( restore->cb_manifest_ctx, manifest );
+  }
 
   /* Read AccountVec map */
 
@@ -698,6 +697,11 @@ fd_snapshot_restore_chunk( void *       restore_,
   }
 
   return 0;
+}
+
+ulong
+fd_snapshot_restore_get_slot( fd_snapshot_restore_t * restore ) {
+  return restore->slot;
 }
 
 /* fd_snapshot_restore_t implements the consumer interface of a TAR

--- a/src/flamenco/snapshot/fd_snapshot_restore.h
+++ b/src/flamenco/snapshot/fd_snapshot_restore.h
@@ -140,6 +140,9 @@ fd_snapshot_restore_chunk( void *       restore,
 
 /* fd_snapshot_restore_tar_vt implements fd_tar_read_vtable_t. */
 
+ulong
+fd_snapshot_restore_get_slot( fd_snapshot_restore_t * restore );
+
 extern fd_tar_read_vtable_t const fd_snapshot_restore_tar_vt;
 
 FD_PROTOTYPES_END

--- a/src/flamenco/snapshot/test_snapshot_restore.c
+++ b/src/flamenco/snapshot/test_snapshot_restore.c
@@ -109,7 +109,6 @@ main( int     argc,
 
   FD_TEST( !fd_snapshot_restore_new( NULL,        acc_mgr, NULL, _valloc, NULL, cb_manifest, cb_status_cache ) );  /* NULL mem */
   FD_TEST( !fd_snapshot_restore_new( restore_mem, NULL,    NULL, _valloc, NULL, cb_manifest, cb_status_cache ) );  /* NULL acc_mgr */
-  FD_TEST( !fd_snapshot_restore_new( restore_mem, acc_mgr, NULL, _valloc, NULL, NULL, NULL        ) );  /* NULL callback */
 
   /* Reject accounts before manifest */
 


### PR DESCRIPTION
- don't initialize the slot context and status cache from the full snapshot when loading with an incremental snapshot.
- use the base slot of the full snapshot to verify the filename of the incremental snapshot