### PR TITLE
Fix scratch usage in fuzz_json_lex

### DIFF
--- a/src/disco/rpcserver/fuzz_json_lex.c
+++ b/src/disco/rpcserver/fuzz_json_lex.c
@@ -31,6 +31,7 @@ int LLVMFuzzerInitialize(int *argc, char ***argv) {
 int
 LLVMFuzzerTestOneInput(uchar const *data, ulong size) {
   fd_scratch_attach( scratch_mem, scratch_fmem, SMAX, FMAX );
+  fd_scratch_push();
   json_lex_state_new(lex_state, (const char *)data, size);
   for (;;) {
     long token_type = json_lex_next_token(lex_state);
@@ -53,6 +54,7 @@ LLVMFuzzerTestOneInput(uchar const *data, ulong size) {
   }
 
   json_lex_state_delete(lex_state);
+  fd_scratch_pop();
   fd_scratch_detach( NULL );
   return 0;
 }


### PR DESCRIPTION
Fixes a bug that prevents the fuzz_json_lex harness from running
with 'handholding' enabled.
