### PR TITLE
flamenco: propagate all cpi syscall and instr errors

### DIFF
--- a/contrib/test/test-vectors-fixtures/txn-fixtures/program-tests.list
+++ b/contrib/test/test-vectors-fixtures/txn-fixtures/program-tests.list
@@ -2775,3 +2775,4 @@ dump/test-vectors/txn/fixtures/programs/txn-3VZwmGFE78PAGbUV9SuPE4EgqAkB7kQLDuoE
 dump/test-vectors/txn/fixtures/programs/txn-5V5uB8Ro1rVPmRJPH5Yhfxr5sPAXEFWGsA4d2YbBDaTEaJn6Key9VuCEvuRaZCi6ziBfAtRUH1shuma9SNqsHSKP.fix
 dump/test-vectors/txn/fixtures/programs/txn-CA7V2nP2oagjGvqaqRRm7kyRpk2Q58gA3vFHQs7NvYv4Y6bNtoNX1xp5fuQPPL2ZNStqszAuGmDYfEG64BQhpKd.fix
 dump/test-vectors/txn/fixtures/programs/2ab448fbadb0b964c56472758c7a46920f8591e5_3041321.fix
+dump/test-vectors/txn/fixtures/programs/e54e613fb6cab91a508bda54fff4d5ea2e238ee3_1777641.fix


### PR DESCRIPTION
Adds error propagation for all cpi-related syscall and instr errors.