### PR TITLE
runtime: runtime scoped spad that replaces wksp and scratch allocations

### DIFF
--- a/src/app/fdctl/run/tiles/fd_batch.c
+++ b/src/app/fdctl/run/tiles/fd_batch.c
@@ -6,19 +6,18 @@
 
 #include "../../../../flamenco/runtime/fd_hashes.h"
 #include "../../../../flamenco/runtime/fd_txncache.h"
-#include "../../../../flamenco/runtime/fd_runtime.h"
 #include "../../../../flamenco/snapshot/fd_snapshot_create.h"
+#include "../../../../flamenco/runtime/fd_runtime.h"
 
 #include "generated/batch_seccomp.h"
 
 #include <errno.h>
 #include <unistd.h>
 
-#define SCRATCH_MAX         (1024UL << 24) /* 24 MiB */
-#define SCRATCH_DEPTH       (256UL)        /* 256 scratch frames */
-#define TPOOL_WORKER_MEM_SZ (1UL<<30UL)    /* 256MB */
-#define REPLAY_OUT_IDX      (0UL)
-#define EAH_REPLAY_OUT_SIG  (0UL)
+#define REPLAY_OUT_IDX     (0UL)
+#define EAH_REPLAY_OUT_SIG (0UL)
+
+#define MEM_FOOTPRINT      (8UL<<30)
 
 struct fd_snapshot_tile_ctx {
   /* User defined parameters. */
@@ -53,6 +52,9 @@ struct fd_snapshot_tile_ctx {
   /* Replay out link fields for epoch account hash. */
   fd_wksp_t *     replay_out_mem;
   ulong           replay_out_chunk;
+
+  /* Bump allocator */
+  fd_spad_t *     spad;
 };
 typedef struct fd_snapshot_tile_ctx fd_snapshot_tile_ctx_t;
 
@@ -95,9 +97,7 @@ FD_FN_PURE static inline ulong
 scratch_footprint( fd_topo_tile_t const * tile FD_PARAM_UNUSED ) {
   ulong l = FD_LAYOUT_INIT;
   l = FD_LAYOUT_APPEND( l, alignof(fd_snapshot_tile_ctx_t), sizeof(fd_snapshot_tile_ctx_t) );
-  l = FD_LAYOUT_APPEND( l, FD_SCRATCH_ALIGN_DEFAULT, tile->batch.hash_tpool_thread_count * TPOOL_WORKER_MEM_SZ );
-  l = FD_LAYOUT_APPEND( l, fd_scratch_smem_align(), fd_scratch_smem_footprint( SCRATCH_MAX   ) );
-  l = FD_LAYOUT_APPEND( l, fd_scratch_fmem_align(), fd_scratch_fmem_footprint( SCRATCH_DEPTH ) );
+  l = FD_LAYOUT_APPEND( l, fd_spad_align(), fd_ulong_align_up( MEM_FOOTPRINT, fd_spad_align() ) );
   return FD_LAYOUT_FINI( l, scratch_align() );
 }
 
@@ -175,10 +175,12 @@ unprivileged_init( fd_topo_t      * topo FD_PARAM_UNUSED,
   FD_SCRATCH_ALLOC_INIT( l, scratch );
   fd_snapshot_tile_ctx_t * ctx = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_snapshot_tile_ctx_t), sizeof(fd_snapshot_tile_ctx_t) );
   memset( ctx, 0, sizeof(fd_snapshot_tile_ctx_t) );
-  void * tpool_worker_mem    = FD_SCRATCH_ALLOC_APPEND( l, FD_SCRATCH_ALIGN_DEFAULT, tile->batch.hash_tpool_thread_count * TPOOL_WORKER_MEM_SZ );
-  void * scratch_smem        = FD_SCRATCH_ALLOC_APPEND( l, fd_scratch_smem_align(), fd_scratch_smem_footprint( SCRATCH_MAX    ) );
-  void * scratch_fmem        = FD_SCRATCH_ALLOC_APPEND( l, fd_scratch_fmem_align(), fd_scratch_fmem_footprint( SCRATCH_DEPTH ) );
+  void * spad_mem            = FD_SCRATCH_ALLOC_APPEND( l, fd_spad_align(), fd_ulong_align_up( MEM_FOOTPRINT, fd_spad_align() ) );
   ulong  scratch_alloc_mem   = FD_SCRATCH_ALLOC_FINI  ( l, scratch_align() );
+
+  if( FD_UNLIKELY( scratch_alloc_mem > (ulong)scratch + scratch_footprint(tile) ) ) {
+    FD_LOG_ERR(( "scratch overflow" ));
+  }
 
   ctx->full_interval           = tile->batch.full_interval;
   ctx->incremental_interval    = tile->batch.incremental_interval;
@@ -204,11 +206,19 @@ unprivileged_init( fd_topo_t      * topo FD_PARAM_UNUSED,
   if( FD_LIKELY( tile->batch.hash_tpool_thread_count>1UL ) ) {
     /* Start the tpool workers */
     for( ulong i=1UL; i<tile->batch.hash_tpool_thread_count; i++ ) {
-      if( FD_UNLIKELY( !fd_tpool_worker_push( ctx->tpool, i, (uchar *)tpool_worker_mem + TPOOL_WORKER_MEM_SZ*(i - 1U), TPOOL_WORKER_MEM_SZ ) ) ) {
+      if( FD_UNLIKELY( !fd_tpool_worker_push( ctx->tpool, i, NULL, 0UL ) ) ) {
         FD_LOG_ERR(( "failed to launch worker" ));
       }
     }
   }
+
+  /**********************************************************************/
+  /* spads                                                              */
+  /**********************************************************************/
+  /* FIXME: Define a bound for the size of the spad. It likely needs to be
+     larger than this. */
+  uchar * spad_mem_cur = spad_mem;
+  ctx->spad = fd_spad_join( fd_spad_new( spad_mem_cur, MEM_FOOTPRINT ) );
 
   /**********************************************************************/
   /* funk                                                               */
@@ -232,19 +242,6 @@ unprivileged_init( fd_topo_t      * topo FD_PARAM_UNUSED,
   ctx->status_cache = fd_txncache_join( fd_topo_obj_laddr( topo, status_cache_obj_id ) );
   if( FD_UNLIKELY( !ctx->status_cache ) ) {
     FD_LOG_ERR(( "no status cache" ));
-  }
-
-  /**********************************************************************/
-  /* scratch                                                            */
-  /**********************************************************************/
-
-  fd_scratch_attach( scratch_smem, scratch_fmem, SCRATCH_MAX, SCRATCH_DEPTH );
-
-  if( FD_UNLIKELY( scratch_alloc_mem != ( (ulong)scratch + scratch_footprint( tile ) ) ) ) {
-    FD_LOG_ERR(( "scratch_alloc_mem did not match scratch_footprint diff: %lu alloc: %lu footprint: %lu",
-                 scratch_alloc_mem - (ulong)scratch - scratch_footprint( tile ),
-                 scratch_alloc_mem,
-                 (ulong)scratch + scratch_footprint( tile ) ));
   }
 
   /**********************************************************************/
@@ -309,7 +306,8 @@ produce_snapshot( fd_snapshot_tile_ctx_t * ctx, ulong batch_fseq ) {
     /* These parameters are ignored if the snapshot is not incremental. */
     .last_snap_slot           = ctx->last_full_snap_slot,
     .last_snap_acc_hash       = &ctx->last_hash,
-    .last_snap_capitalization = ctx->last_capitalization
+    .last_snap_capitalization = ctx->last_capitalization,
+    .spad                     = ctx->spad
   };
 
   if( !is_incremental ) {
@@ -358,10 +356,9 @@ produce_snapshot( fd_snapshot_tile_ctx_t * ctx, ulong batch_fseq ) {
   }
 
   /* Now that the files are in an expected state, create the snapshot. */
-  FD_SCRATCH_SCOPE_BEGIN {
-    snapshot_ctx.valloc = fd_scratch_virtual();
+  FD_SPAD_FRAME_BEGIN( snapshot_ctx.spad ) {
     fd_snapshot_create_new_snapshot( &snapshot_ctx, &ctx->last_hash, &ctx->last_capitalization );
-  } FD_SCRATCH_SCOPE_END;
+  } FD_SPAD_FRAME_END;
 
   if( is_incremental ) {
     FD_LOG_NOTICE(( "Done creating a snapshot in %s", snapshot_ctx.out_dir ));
@@ -423,11 +420,11 @@ produce_eah( fd_snapshot_tile_ctx_t * ctx, fd_stem_context_t * stem, ulong batch
   }
 
   uint slot_magic = *(uint*)slot_val;
-  FD_SCRATCH_SCOPE_BEGIN {
+  FD_SPAD_FRAME_BEGIN( ctx->spad ) {
     fd_bincode_decode_ctx_t slot_decode_ctx = {
       .data    = (uchar*)slot_val + sizeof(uint),
       .dataend = (uchar*)slot_val + fd_funk_val_sz( slot_rec ),
-      .valloc  = fd_scratch_virtual()
+      .valloc  = fd_spad_virtual( ctx->spad )
     };
 
     if( FD_UNLIKELY( slot_magic!=FD_RUNTIME_ENC_BINCODE ) ) {
@@ -443,7 +440,8 @@ produce_eah( fd_snapshot_tile_ctx_t * ctx, fd_stem_context_t * stem, ulong batch
     /* At this point, calculate the epoch account hash. */
 
     fd_hash_t epoch_account_hash = {0};
-    fd_accounts_hash( funk, &slot_bank, fd_scratch_virtual(), ctx->tpool, &epoch_account_hash );
+
+    fd_accounts_hash( funk, &slot_bank, ctx->tpool, &epoch_account_hash, ctx->spad );
 
     FD_LOG_NOTICE(( "Done computing epoch account hash (%s)", FD_BASE58_ENC_32_ALLOCA( &epoch_account_hash ) ));
 
@@ -460,7 +458,7 @@ produce_eah( fd_snapshot_tile_ctx_t * ctx, fd_stem_context_t * stem, ulong batch
        snapshots to be created again. */
 
     fd_fseq_update( ctx->is_constipated, 0UL );
-  } FD_SCRATCH_SCOPE_END;
+  } FD_SPAD_FRAME_END;
 }
 
 static void
@@ -476,6 +474,8 @@ after_credit( fd_snapshot_tile_ctx_t * ctx,
   if( !batch_fseq ) {
     return;
   }
+
+  FD_LOG_WARNING(("HELLO HELLO"));
 
   if( FD_UNLIKELY( !ctx->is_funk_active ) ) {
     /* Setting these parameters are not required because we are joining the

--- a/src/choreo/forks/fd_forks.c
+++ b/src/choreo/forks/fd_forks.c
@@ -281,7 +281,7 @@ fd_forks_prepare( fd_forks_t const *    forks,
                   fd_blockstore_t *     blockstore,
                   fd_exec_epoch_ctx_t * epoch_ctx,
                   fd_funk_t *           funk,
-                  fd_valloc_t           valloc ) {
+                  fd_spad_t *           runtime_spad ) {
 
   /* Check the parent block is present in the blockstore and executed. */
 
@@ -311,15 +311,14 @@ fd_forks_prepare( fd_forks_t const *    forks,
 
     /* Format and join the slot_ctx */
 
-    fd_exec_slot_ctx_t * slot_ctx = fd_exec_slot_ctx_join( fd_exec_slot_ctx_new( &fork->slot_ctx,
-                                                                                 valloc ) );
+    fd_exec_slot_ctx_t * slot_ctx = fd_exec_slot_ctx_join( fd_exec_slot_ctx_new( &fork->slot_ctx, runtime_spad ) );
     if( FD_UNLIKELY( !slot_ctx ) ) {
       FD_LOG_ERR( ( "failed to new and join slot_ctx" ) );
     }
 
     /* Restore and decode w/ funk */
 
-    slot_ctx_restore( fork->slot, acc_mgr, blockstore, epoch_ctx, funk, valloc, slot_ctx );
+    slot_ctx_restore( fork->slot, acc_mgr, blockstore, epoch_ctx, funk, fd_spad_virtual( runtime_spad ), slot_ctx );
 
     /* Add to frontier */
 
@@ -431,7 +430,7 @@ fd_forks_update( fd_forks_t *      forks,
 }
 
 void
-fd_forks_publish( fd_forks_t * forks, ulong slot, fd_ghost_t const * ghost, fd_valloc_t valloc ) {
+fd_forks_publish( fd_forks_t * forks, ulong slot, fd_ghost_t const * ghost ) {
   fd_fork_t * tail = NULL;
   fd_fork_t * curr = NULL;
 
@@ -462,7 +461,7 @@ fd_forks_publish( fd_forks_t * forks, ulong slot, fd_ghost_t const * ghost, fd_v
                                                    &tail->slot,
                                                    NULL,
                                                    forks->pool );
-    if( FD_UNLIKELY( !fd_exec_slot_ctx_delete( fd_exec_slot_ctx_leave( &fork->slot_ctx ), valloc ) ) ) {
+    if( FD_UNLIKELY( !fd_exec_slot_ctx_delete( fd_exec_slot_ctx_leave( &fork->slot_ctx ) ) ) ) {
       FD_LOG_ERR( ( "could not delete fork slot ctx" ) );
     }
     ulong remove = fd_fork_frontier_idx_remove( forks->frontier,

--- a/src/choreo/forks/fd_forks.h
+++ b/src/choreo/forks/fd_forks.h
@@ -155,7 +155,7 @@ fd_forks_prepare( fd_forks_t const *    forks,
                   fd_blockstore_t *     blockstore,
                   fd_exec_epoch_ctx_t * epoch_ctx,
                   fd_funk_t *           funk,
-                  fd_valloc_t           valloc );
+                  fd_spad_t *           runtime_spad );
 
 /* fd_forks_update updates `blockstore` and `ghost` with the latest
    state resulting from replaying `slot`.  Assumes `slot` is a fork head
@@ -179,8 +179,7 @@ fd_forks_update( fd_forks_t *          forks,
 void
 fd_forks_publish( fd_forks_t *       fork,
                   ulong              root,
-                  fd_ghost_t const * ghost,
-                  fd_valloc_t        valloc );
+                  fd_ghost_t const * ghost );
 
 /* fd_forks_print prints a forks as a list of the frontiers and number
    of forks (pool eles acquired). */

--- a/src/choreo/tower/fd_tower.c
+++ b/src/choreo/tower/fd_tower.c
@@ -201,7 +201,8 @@ fd_tower_threshold_check( fd_tower_t const *    tower,
                           fd_epoch_t const *    epoch,
                           fd_funk_t *           funk,
                           fd_funk_txn_t const * txn,
-                          ulong                 slot ) {
+                          ulong                 slot,
+                          fd_spad_t *           runtime_spad ) {
 
   /* First, simulate a vote, popping off everything that would be
      expired by voting for the current slot. */
@@ -233,8 +234,8 @@ fd_tower_threshold_check( fd_tower_t const *    tower,
     fd_voter_t const * voter = &epoch_voters[i];
 
     /* Convert the landed_votes into tower's vote_slots interface. */
-    FD_SCRATCH_SCOPE_BEGIN {
-      void * mem = fd_scratch_alloc( fd_tower_align(), fd_tower_footprint() );
+    FD_SPAD_FRAME_BEGIN( runtime_spad ) {
+      void * mem = fd_spad_alloc( runtime_spad, fd_tower_align(), fd_tower_footprint() );
       fd_tower_t * voter_tower = fd_tower_join( fd_tower_new( mem ) );
       fd_tower_from_vote_acc( voter_tower, funk, txn, &voter->rec );
 
@@ -266,7 +267,7 @@ fd_tower_threshold_check( fd_tower_t const *    tower,
       if( FD_LIKELY( vote->slot >= threshold_slot ) ) {
         threshold_stake += voter->stake;
       }
-    } FD_SCRATCH_SCOPE_END;
+    } FD_SPAD_FRAME_END;
   }
 
   double threshold_pct = (double)threshold_stake / (double)epoch->total_stake;
@@ -317,7 +318,8 @@ fd_tower_vote_slot( fd_tower_t *          tower,
                     fd_epoch_t const *    epoch,
                     fd_funk_t *           funk,
                     fd_funk_txn_t const * txn,
-                    fd_ghost_t const *    ghost ) {
+                    fd_ghost_t const *    ghost,
+                    fd_spad_t *           runtime_spad ) {
 
   fd_tower_vote_t const * vote = fd_tower_votes_peek_tail_const( tower );
   fd_ghost_node_t const * root = fd_ghost_root( ghost );
@@ -344,7 +346,7 @@ fd_tower_vote_slot( fd_tower_t *          tower,
     /* The ghost head is on the same fork as our last vote slot, so we
        can vote fork it as long as we pass the threshold check. */
 
-    if( FD_LIKELY( fd_tower_threshold_check( tower, epoch, funk, txn, head->slot ) ) ) {
+    if( FD_LIKELY( fd_tower_threshold_check( tower, epoch, funk, txn, head->slot, runtime_spad ) ) ) {
       FD_LOG_DEBUG(( "[%s] success (threshold). best: %lu. vote: (slot: %lu conf: %lu)", __func__, head->slot, vote->slot, vote->conf ));
       return head->slot;
     }
@@ -461,7 +463,10 @@ fd_tower_to_vote_txn( fd_tower_t const *  tower,
                       fd_pubkey_t const * validator_identity,
                       fd_pubkey_t const * vote_authority,
                       fd_pubkey_t const * vote_acc,
-                      fd_txn_p_t *        vote_txn ) {
+                      fd_txn_p_t *        vote_txn,
+                      fd_spad_t *         runtime_spad ) {
+
+  FD_SPAD_FRAME_BEGIN( runtime_spad ) {
 
   fd_compact_vote_state_update_t tower_sync[1] = { 0 };
 
@@ -470,7 +475,7 @@ fd_tower_to_vote_txn( fd_tower_t const *  tower,
   tower_sync->has_timestamp = 1;
   tower_sync->timestamp     = ts;
   tower_sync->lockouts_len  = (ushort)fd_tower_votes_cnt( tower );
-  tower_sync->lockouts      = (fd_lockout_offset_t *)fd_scratch_alloc( alignof(fd_lockout_offset_t),tower_sync->lockouts_len * sizeof(fd_lockout_offset_t) );
+  tower_sync->lockouts      = (fd_lockout_offset_t *)fd_spad_alloc( runtime_spad, alignof(fd_lockout_offset_t),tower_sync->lockouts_len * sizeof(fd_lockout_offset_t) );
 
   ulong i         = 0UL;
   ulong curr_slot = tower_sync->root;
@@ -558,6 +563,8 @@ fd_tower_to_vote_txn( fd_tower_t const *  tower,
     program_id = 3; /* vote program */
   }
   vote_txn->payload_sz = fd_txn_add_instr( txn_meta_out, txn_out, program_id, ix_accs, 2, vote_ix_buf, vote_ix_size );
+
+  } FD_SPAD_FRAME_END;
 }
 
 int

--- a/src/choreo/tower/fd_tower.h
+++ b/src/choreo/tower/fd_tower.h
@@ -654,7 +654,8 @@ fd_tower_threshold_check( fd_tower_t const *    tower,
                           fd_epoch_t const *    epoch,
                           fd_funk_t *           funk,
                           fd_funk_txn_t const * txn,
-                          ulong                 slot );
+                          ulong                 slot,
+                          fd_spad_t *           runtime_spad );
 
 /* fd_tower_reset_slot returns the slot to reset PoH to when building
    the next leader block.  Assumes tower and ghost are both valid local
@@ -702,7 +703,8 @@ fd_tower_vote_slot( fd_tower_t *          tower,
                     fd_epoch_t const *    epoch,
                     fd_funk_t *           funk,
                     fd_funk_txn_t const * txn,
-                    fd_ghost_t const *    ghost );
+                    fd_ghost_t const *    ghost,
+                    fd_spad_t *           runtime_spad );
 
 /* fd_tower_simulate_vote simulates a vote on the vote tower for slot,
    returning the new height (cnt) for all the votes that would have been
@@ -751,7 +753,8 @@ fd_tower_to_vote_txn( fd_tower_t const *  tower,
                       fd_pubkey_t const * validator_identity,
                       fd_pubkey_t const * vote_authority,
                       fd_pubkey_t const * vote_acc,
-                      fd_txn_p_t *        vote_txn );
+                      fd_txn_p_t *        vote_txn,
+                      fd_spad_t *         runtime_spad );
 
 /* fd_tower_verify checks the tower is in a valid state. The cnt should
    be < FD_TOWER_VOTE_MAX, the vote slots and confirmation counts in the

--- a/src/disco/restart/fd_restart.c
+++ b/src/disco/restart/fd_restart.c
@@ -324,17 +324,18 @@ fd_restart_convert_raw_bitmap_to_runlength( fd_gossip_restart_last_voted_fork_sl
 }
 
 void
-fd_restart_init( fd_restart_t * restart,
-                 ulong funk_root,
-                 fd_hash_t * root_bank_hash,
+fd_restart_init( fd_restart_t *              restart,
+                 ulong                       funk_root,
+                 fd_hash_t *                 root_bank_hash,
                  fd_vote_accounts_t const ** epoch_stakes,
-                 fd_epoch_schedule_t * epoch_schedule,
-                 int tower_checkpt_fileno,
-                 fd_slot_history_t const * slot_history,
-                 fd_pubkey_t * my_pubkey,
-                 fd_pubkey_t * coordinator_pubkey,
-                 uchar * out_buf,
-                 ulong * out_buf_len ) {
+                 fd_epoch_schedule_t *       epoch_schedule,
+                 int                         tower_checkpt_fileno,
+                 fd_slot_history_t const *   slot_history,
+                 fd_pubkey_t *               my_pubkey,
+                 fd_pubkey_t *               coordinator_pubkey,
+                 uchar *                     out_buf,
+                 ulong *                     out_buf_len,
+                 fd_spad_t *                 runtime_spad ) {
   restart->funk_root                       = funk_root;
   restart->epoch_schedule                  = epoch_schedule;
   restart->root_epoch                      = fd_slot_to_epoch( epoch_schedule, restart->funk_root, NULL ),
@@ -358,7 +359,7 @@ fd_restart_init( fd_restart_t * restart,
   FD_TEST( RESTART_EPOCHS_MAX==2 );
   for( ulong e=0; e<RESTART_EPOCHS_MAX; e++ ) {
     if( epoch_stakes[e]->vote_accounts_root==NULL ) FD_LOG_ERR(( "vote account information is missing for epoch#%lu", restart->root_epoch+e ));
-    restart->num_vote_accts[e]                 = fd_stake_weights_by_node( epoch_stakes[e], restart->stake_weights[e] );
+    restart->num_vote_accts[e]                 = fd_stake_weights_by_node( epoch_stakes[e], restart->stake_weights[e], runtime_spad );
     restart->total_stake[e]                    = 0;
     restart->total_stake_received[e]           = 0;
     restart->total_stake_received_and_voted[e] = 0;

--- a/src/disco/restart/fd_restart.h
+++ b/src/disco/restart/fd_restart.h
@@ -98,17 +98,18 @@ fd_restart_join( void * restart );
    and out_buf_len with a gossip message -- the first gossip message sent
    in the wen-restart protocol (fd_gossip_restart_last_voted_fork_slots_t). */
 void
-fd_restart_init( fd_restart_t * restart,
-                 ulong funk_root,
-                 fd_hash_t * root_bank_hash,
+fd_restart_init( fd_restart_t *             restart,
+                 ulong                      funk_root,
+                 fd_hash_t *                root_bank_hash,
                  fd_vote_accounts_t const * epoch_stakes[],
-                 fd_epoch_schedule_t * epoch_schedule,
-                 int tower_checkpt_fileno,
-                 fd_slot_history_t const * slot_history,
-                 fd_pubkey_t * my_pubkey,
-                 fd_pubkey_t * coordinator_pubkey,
-                 uchar * out_buf,
-                 ulong * out_buf_len );
+                 fd_epoch_schedule_t *      epoch_schedule,
+                 int                        tower_checkpt_fileno,
+                 fd_slot_history_t const *  slot_history,
+                 fd_pubkey_t *              my_pubkey,
+                 fd_pubkey_t *              coordinator_pubkey,
+                 uchar *                    out_buf,
+                 ulong *                    out_buf_len,
+                 fd_spad_t *                runtime_spad );
 
 /* fd_restart_recv_gossip_msg is invoked for each gossip message received.
 

--- a/src/flamenco/fd_flamenco_base.h
+++ b/src/flamenco/fd_flamenco_base.h
@@ -1,7 +1,6 @@
 #ifndef HEADER_fd_src_flamenco_fd_flamenco_base_h
 #define HEADER_fd_src_flamenco_fd_flamenco_base_h
 
-#include "../util/scratch/fd_scratch.h"
 #include "../ballet/base58/fd_base58.h"
 #include "../ballet/sha256/fd_sha256.h"
 #include "types/fd_types_custom.h"

--- a/src/flamenco/genesis/fd_genesis_create.h
+++ b/src/flamenco/genesis/fd_genesis_create.h
@@ -50,6 +50,7 @@ FD_PROTOTYPES_BEGIN
 
    Assumes that caller is attached to an fd_scratch with sufficient
    memory to buffer intermediate data (16384 + 128*n space, 2 frames).
+   TODO: Replace with spad
 
    THIS METHOD IS NOT SAFE FOR PRODUCTION USE.
    It is intended for development only. */

--- a/src/flamenco/leaders/fd_leaders.c
+++ b/src/flamenco/leaders/fd_leaders.c
@@ -18,7 +18,7 @@ fd_epoch_leaders_footprint( ulong pub_cnt,
 }
 
 void *
-fd_epoch_leaders_new( void                    * shmem,
+fd_epoch_leaders_new( void  *                   shmem,
                       ulong                     epoch,
                       ulong                     slot0,
                       ulong                     slot_cnt,

--- a/src/flamenco/rewards/fd_rewards.h
+++ b/src/flamenco/rewards/fd_rewards.h
@@ -17,22 +17,22 @@ fd_update_rewards( fd_exec_slot_ctx_t * slot_ctx,
                    fd_hash_t const *    parent_blockhash,
                    ulong                parent_epoch,
                    fd_epoch_info_t *    temp_info,
-                   fd_valloc_t          valloc );
+                   fd_spad_t *          runtime_spad );
 
 void
 fd_begin_partitioned_rewards( fd_exec_slot_ctx_t * slot_ctx,
                               fd_hash_t const *    parent_blockhash,
                               ulong                parent_epoch,
                               fd_epoch_info_t *    temp_info,
-                              fd_valloc_t          valloc );
+                              fd_spad_t *          runtime_spad );
 
 void
 fd_rewards_recalculate_partitioned_rewards( fd_exec_slot_ctx_t * slot_ctx,
-                                            fd_valloc_t          valloc );
+                                            fd_spad_t *          runtime_spad );
 
 void
 fd_distribute_partitioned_epoch_rewards( fd_exec_slot_ctx_t * slot_ctx,
-                                         fd_valloc_t          valloc );
+                                         fd_spad_t *          runtime_spad );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/context/fd_capture_ctx.h
+++ b/src/flamenco/runtime/context/fd_capture_ctx.h
@@ -20,9 +20,6 @@ struct __attribute__((aligned(FD_CAPTURE_CTX_ALIGN))) fd_capture_ctx {
   char const *             checkpt_path;    /* Wksp checkpoint format */
   char const *             checkpt_archive; /* Funk archive format */
 
-  /* Prune */
-  fd_funk_t *              pruned_funk; /* Capturing accessed accounts during execution*/
-
   /*======== PROTOBUF ========*/
   char const *             dump_proto_output_dir;
   char const *             dump_proto_sig_filter;

--- a/src/flamenco/runtime/context/fd_exec_epoch_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_epoch_ctx.h
@@ -35,7 +35,7 @@ struct __attribute__((aligned(64UL))) fd_exec_epoch_ctx {
   ulong total_epoch_stake;
 };
 
-#define FD_EXEC_EPOCH_CTX_ALIGN (4096UL)
+#define FD_EXEC_EPOCH_CTX_ALIGN (alignof(fd_exec_epoch_ctx_t))
 #define FD_EXEC_EPOCH_CTX_MAGIC (0x3E64F44C9F44366AUL) /* random */
 
 FD_PROTOTYPES_BEGIN
@@ -113,7 +113,9 @@ fd_exec_epoch_ctx_leaders( fd_exec_epoch_ctx_t * ctx ) {
 }
 
 void
-fd_exec_epoch_ctx_from_prev( fd_exec_epoch_ctx_t * self, fd_exec_epoch_ctx_t * prev );
+fd_exec_epoch_ctx_from_prev( fd_exec_epoch_ctx_t * self, 
+                             fd_exec_epoch_ctx_t * prev,
+                             fd_spad_t *           runtime_spad );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/context/fd_exec_slot_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_slot_ctx.h
@@ -75,7 +75,7 @@ FD_PROTOTYPES_BEGIN
 
 void *
 fd_exec_slot_ctx_new( void *      mem,
-                      fd_valloc_t valloc );
+                      fd_spad_t * spad );
 
 fd_exec_slot_ctx_t *
 fd_exec_slot_ctx_join( void * mem );
@@ -84,21 +84,20 @@ void *
 fd_exec_slot_ctx_leave( fd_exec_slot_ctx_t * ctx );
 
 void *
-fd_exec_slot_ctx_delete( void *      mem,
-                         fd_valloc_t valloc );
+fd_exec_slot_ctx_delete( void * mem );
 
 /* fd_exec_slot_ctx_recover re-initializes the current epoch/slot
    context and recovers it from the manifest of a Solana Labs snapshot.
    Moves ownership of manifest to this function.  Assumes objects in
-   manifest were allocated using slot ctx valloc (U.B. otherwise).
-   Assumes that slot context and epoch context use same valloc.
+   manifest were allocated using a spad which is scoped to the replay tile.
+   Assumes that slot context and epoch context use same allocator.
    On return, manifest is destroyed.  Returns ctx on success.
    On failure, logs reason for error and returns NULL. */
 
 fd_exec_slot_ctx_t *
 fd_exec_slot_ctx_recover( fd_exec_slot_ctx_t *   ctx,
                           fd_solana_manifest_t * manifest,
-                          fd_valloc_t            valloc );
+                          fd_spad_t *            spad );
 
 /* fd_exec_slot_ctx_recover re-initializes the current slot
    context's status cache from the provided solana slot deltas.
@@ -108,14 +107,9 @@ fd_exec_slot_ctx_recover( fd_exec_slot_ctx_t *   ctx,
    On failure, logs reason for error and returns NULL. */
 
 fd_exec_slot_ctx_t *
-fd_exec_slot_ctx_recover_status_cache( fd_exec_slot_ctx_t *   ctx,
-                                       fd_bank_slot_deltas_t * slot_deltas );
-
-
-/* Free all allocated memory within a slot ctx */
-void
-fd_exec_slot_ctx_free( fd_exec_slot_ctx_t * ctx,
-                       fd_valloc_t          valloc );
+fd_exec_slot_ctx_recover_status_cache( fd_exec_slot_ctx_t *    ctx,
+                                       fd_bank_slot_deltas_t * slot_deltas,
+                                       fd_spad_t *             runtime_spad );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/fd_acc_mgr.c
+++ b/src/flamenco/runtime/fd_acc_mgr.c
@@ -379,99 +379,108 @@ fd_acc_mgr_save_task( void *tpool,
 }
 
 int
-fd_acc_mgr_save_many_tpool( fd_acc_mgr_t *          acc_mgr,
-                            fd_funk_txn_t *         txn,
+fd_acc_mgr_save_many_tpool( fd_acc_mgr_t *            acc_mgr,
+                            fd_funk_txn_t *           txn,
                             fd_borrowed_account_t * * accounts,
-                            ulong accounts_cnt,
-                            fd_tpool_t * tpool ) {
-  FD_SCRATCH_SCOPE_BEGIN {
-    fd_funk_t *        funk = acc_mgr->funk;
-    fd_wksp_t * wksp = fd_funk_wksp( funk );
-    fd_funk_rec_t * rec_map = fd_funk_rec_map( funk, wksp );
+                            ulong                     accounts_cnt,
+                            fd_tpool_t *              tpool,
+                            fd_spad_t *               runtime_spad ) {
 
-    ulong batch_cnt = fd_ulong_min(
-      fd_funk_rec_map_private_list_cnt( fd_funk_rec_map_key_max( rec_map ) ),
-      fd_ulong_pow2_up( fd_tpool_worker_cnt( tpool ) )
-    );
-    ulong batch_mask = (batch_cnt - 1UL);
+  FD_SPAD_FRAME_BEGIN( runtime_spad ) {
 
-    ulong * batch_szs = fd_scratch_alloc( 8UL, batch_cnt * sizeof(ulong) );
-    fd_memset( batch_szs, 0, batch_cnt * sizeof(ulong) );
+  fd_funk_t *     funk    = acc_mgr->funk;
+  fd_wksp_t *     wksp    = fd_funk_wksp( funk );
+  fd_funk_rec_t * rec_map = fd_funk_rec_map( funk, wksp );
 
-    /* Compute the batch sizes */
-    for( ulong i = 0; i < accounts_cnt; i++ ) {
-      ulong batch_idx = i & batch_mask;
-      batch_szs[batch_idx]++;
-    }
+  ulong batch_cnt = fd_ulong_min(
+    fd_funk_rec_map_private_list_cnt( fd_funk_rec_map_key_max( rec_map ) ),
+    fd_ulong_pow2_up( fd_tpool_worker_cnt( tpool ) )
+  );
+  ulong batch_mask = (batch_cnt - 1UL);
 
-    fd_borrowed_account_t * * task_accounts = fd_scratch_alloc( 8UL, accounts_cnt * sizeof(fd_borrowed_account_t *) );
-    fd_acc_mgr_save_task_info_t * task_infos = fd_scratch_alloc( 8UL, batch_cnt * sizeof(fd_acc_mgr_save_task_info_t) );
-    fd_borrowed_account_t * * task_accounts_cursor = task_accounts;
+  ulong * batch_szs = fd_spad_alloc( runtime_spad, 8UL, batch_cnt * sizeof(ulong) );
+  fd_memset( batch_szs, 0, batch_cnt * sizeof(ulong) );
 
-    /* Construct the batches */
-    for( ulong i = 0; i < batch_cnt; i++ ) {
-      ulong batch_sz = batch_szs[i];
-      fd_acc_mgr_save_task_info_t * task_info = &task_infos[i];
+  /* Compute the batch sizes */
+  for( ulong i = 0; i < accounts_cnt; i++ ) {
+    ulong batch_idx = i & batch_mask;
+    batch_szs[batch_idx]++;
+  }
 
-      task_info->accounts_cnt = 0;
-      task_info->accounts = task_accounts_cursor;
-      task_info->result = 0;
+  fd_borrowed_account_t * *     task_accounts        = fd_spad_alloc( runtime_spad, 8UL, accounts_cnt * sizeof(fd_borrowed_account_t *) );
+  fd_acc_mgr_save_task_info_t * task_infos           = fd_spad_alloc( runtime_spad, 8UL, batch_cnt * sizeof(fd_acc_mgr_save_task_info_t) );
+  fd_borrowed_account_t * *     task_accounts_cursor = task_accounts;
 
-      task_accounts_cursor += batch_sz;
-    }
+  /* Construct the batches */
+  for( ulong i = 0; i < batch_cnt; i++ ) {
+    ulong batch_sz = batch_szs[i];
+    fd_acc_mgr_save_task_info_t * task_info = &task_infos[i];
 
-    fd_funk_start_write( funk );
+    task_info->accounts_cnt = 0;
+    task_info->accounts = task_accounts_cursor;
+    task_info->result = 0;
 
-    for( ulong i = 0; i < accounts_cnt; i++ ) {
-      fd_borrowed_account_t * account = accounts[i];
+    task_accounts_cursor += batch_sz;
+  }
 
-      ulong batch_idx = i & batch_mask;
-      fd_acc_mgr_save_task_info_t * task_info = &task_infos[batch_idx];
-      task_info->accounts[task_info->accounts_cnt++] = account;
-      fd_funk_rec_key_t key = fd_acc_funk_key( account->pubkey );
-      fd_funk_rec_t * rec = (fd_funk_rec_t *)fd_funk_rec_query( funk, txn, &key );
-      if( rec == NULL ) {
-        int err;
-        rec = (fd_funk_rec_t *)fd_funk_rec_insert( funk, txn, &key, &err );
-        if( rec == NULL ) FD_LOG_ERR(( "unable to insert a new record, error %d", err ));
-      }
-      account->rec = rec;
-      if ( acc_mgr->slots_per_epoch != 0 )
-        fd_funk_part_set(funk, rec, (uint)fd_rent_lists_key_to_bucket( acc_mgr, rec ));
+  fd_funk_start_write( funk );
 
-      /* This check is to prevent a seg fault in the case where an account with
-         null data tries to get saved. This notably happens if firedancer is
-         attemping to execute a bad block. This should NEVER happen in the case
-         of a proper replay. */
-      if( FD_UNLIKELY( !account->const_meta ) ) {
-        FD_LOG_ERR(( "An account likely does not exist. This block could be invalid." ));
-      }
+  for( ulong i = 0; i < accounts_cnt; i++ ) {
+    fd_borrowed_account_t * account = accounts[i];
 
-      ulong reclen = sizeof(fd_account_meta_t)+account->const_meta->dlen;
+    ulong batch_idx = i & batch_mask;
+    fd_acc_mgr_save_task_info_t * task_info = &task_infos[batch_idx];
+    task_info->accounts[task_info->accounts_cnt++] = account;
+    fd_funk_rec_key_t key = fd_acc_funk_key( account->pubkey );
+    fd_funk_rec_t * rec = (fd_funk_rec_t *)fd_funk_rec_query( funk, txn, &key );
+    if( rec == NULL ) {
       int err;
-      if( fd_funk_val_truncate( account->rec, reclen, fd_funk_alloc( acc_mgr->funk, wksp ), wksp, &err ) == NULL ) {
-        FD_LOG_ERR(( "unable to allocate account value, err %d", err ));
-      }
+      rec = (fd_funk_rec_t *)fd_funk_rec_insert( funk, txn, &key, &err );
+      if( rec == NULL ) FD_LOG_ERR(( "unable to insert a new record, error %d", err ));
+    }
+    account->rec = rec;
+    if ( acc_mgr->slots_per_epoch != 0 )
+      fd_funk_part_set(funk, rec, (uint)fd_rent_lists_key_to_bucket( acc_mgr, rec ));
+
+    /* This check is to prevent a seg fault in the case where an account with
+        null data tries to get saved. This notably happens if firedancer is
+        attemping to execute a bad block. This should NEVER happen in the case
+        of a proper replay. */
+    if( FD_UNLIKELY( !account->const_meta ) ) {
+      FD_LOG_ERR(( "An account likely does not exist. This block could be invalid." ));
     }
 
-    fd_acc_mgr_save_task_args_t task_args = {
-      .acc_mgr = acc_mgr
-    };
-
-    /* Save accounts in a thread pool */
-
-    fd_tpool_exec_all_rrobin( tpool, 0, fd_tpool_worker_cnt( tpool ), fd_acc_mgr_save_task, task_infos, &task_args, NULL, 1, 0, batch_cnt );
-
-    fd_funk_end_write( funk );
-
-    /* Check results */
-    for( ulong i = 0; i < batch_cnt; i++ ) {
-      fd_acc_mgr_save_task_info_t * task_info = &task_infos[i];
-      if( task_info->result != FD_ACC_MGR_SUCCESS ) {
-        return task_info->result;
-      }
+    ulong reclen = sizeof(fd_account_meta_t)+account->const_meta->dlen;
+    int err;
+    if( FD_UNLIKELY( NULL == fd_funk_val_truncate( account->rec, 
+                                                   reclen, 
+                                                   fd_funk_alloc( acc_mgr->funk, wksp ), 
+                                                   wksp, 
+                                                   &err ) ) ) {
+      FD_LOG_ERR(( "unable to allocate account value, err %d", err ));
     }
+  }
 
-    return FD_ACC_MGR_SUCCESS;
-  } FD_SCRATCH_SCOPE_END;
+  fd_acc_mgr_save_task_args_t task_args = {
+    .acc_mgr = acc_mgr
+  };
+
+  /* Save accounts in a thread pool */
+
+  fd_tpool_exec_all_rrobin( tpool, 0, fd_tpool_worker_cnt( tpool ), fd_acc_mgr_save_task,
+                            task_infos, &task_args, NULL, 1, 0, batch_cnt );
+
+  fd_funk_end_write( funk );
+
+  /* Check results */
+  for( ulong i = 0; i < batch_cnt; i++ ) {
+    fd_acc_mgr_save_task_info_t * task_info = &task_infos[i];
+    if( task_info->result != FD_ACC_MGR_SUCCESS ) {
+      return task_info->result;
+    }
+  }
+
+  return FD_ACC_MGR_SUCCESS;
+
+  } FD_SPAD_FRAME_END;
 }

--- a/src/flamenco/runtime/fd_acc_mgr.h
+++ b/src/flamenco/runtime/fd_acc_mgr.h
@@ -262,7 +262,8 @@ fd_acc_mgr_save_many_tpool( fd_acc_mgr_t *           acc_mgr,
                             fd_funk_txn_t *          txn,
                             fd_borrowed_account_t ** accounts,
                             ulong                    accounts_cnt,
-                            fd_tpool_t *             tpool );
+                            fd_tpool_t *             tpool,
+                            fd_spad_t *              runtime_spad );
 
 void
 fd_acc_mgr_lock( fd_acc_mgr_t * acc_mgr );

--- a/src/flamenco/runtime/fd_borrowed_account.h
+++ b/src/flamenco/runtime/fd_borrowed_account.h
@@ -49,7 +49,7 @@ typedef struct fd_borrowed_account fd_borrowed_account_t;
 /* This macro provides the same scoping guarantees as the Agave client's
    borrowed account semantics. It allows for implict/explicit dropping of
    borrowed accounts' write locks. It's usage mirrors the use of
-   FD_SCRATCH_SCOPE_{BEGIN,END}. It is also safe to use the original
+   FD_SPAD_FRAME_{BEGIN,END}. It is also safe to use the original
    acquire/release api within the scoped macro in case you don't want
    variables to go out of scope. An example of this is in the extend
    instruction within the bpf loader.

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -45,11 +45,6 @@ typedef int (* fd_exec_instr_fn_t)( fd_exec_instr_ctx_t * ctx );
 fd_exec_instr_fn_t
 fd_executor_lookup_native_program( fd_borrowed_account_t const * account );
 
-/* TODO:FIXME: add documentation here */
-
-int
-fd_validate_fee_payer( fd_borrowed_account_t * account, fd_rent_t const * rent, ulong fee );
-
 int
 fd_executor_check_transactions( fd_exec_txn_ctx_t * txn_ctx );
 
@@ -57,7 +52,7 @@ int
 fd_executor_verify_precompiles( fd_exec_txn_ctx_t * txn_ctx );
 
 /* fd_execute_instr creates a new fd_exec_instr_ctx_t and performs
-   instruction processing.  Does fd_scratch allocations.  Returns an
+   instruction processing.  Does fd_spad_t allocations.  Returns an
    error code in FD_EXECUTOR_INSTR_{ERR_{...},SUCCESS}.
 
    IMPORTANT: instr_info must have the same lifetime as txn_ctx. This can
@@ -89,14 +84,8 @@ fd_executor_txn_uses_sysvar_instructions( fd_exec_txn_ctx_t const * txn_ctx );
 int
 fd_executor_validate_transaction_fee_payer( fd_exec_txn_ctx_t * txn_ctx );
 
-int
-fd_executor_setup_accessed_accounts_for_txn( fd_exec_txn_ctx_t * txn_ctx );
-
 void
 fd_executor_setup_borrowed_accounts_for_txn( fd_exec_txn_ctx_t * txn_ctx );
-
-int
-fd_executor_is_system_nonce_account( fd_borrowed_account_t * account );
 
 /*
   Validate the txn after execution for violations of various lamport balance and size rules

--- a/src/flamenco/runtime/fd_hashes.c
+++ b/src/flamenco/runtime/fd_hashes.c
@@ -45,13 +45,6 @@ fd_hash_account_deltas( fd_pubkey_hash_pair_list_t * lists, ulong lists_len, fd_
   // Init the number of hashes
   fd_memset( num_hashes, 0, sizeof(num_hashes) );
 
-  // FD_LOG_DEBUG(("sorting %d", pairs_len));
-  // long timer_sort = -fd_log_wallclock();
-  // sort_pubkey_hash_pair_inplace( pairs, pairs_len );
-  // timer_sort += fd_log_wallclock();
-  // FD_LOG_DEBUG(("sorting done %6.3f ms", (double)timer_sort*(1e-6)));
-
-  // FD_LOG_DEBUG(("fancy bmtree started"));
   for( ulong j = 0; j < FD_ACCOUNT_DELTAS_MAX_MERKLE_HEIGHT; ++j ) {
     fd_sha256_init( &shas[j] );
 }
@@ -63,8 +56,8 @@ fd_hash_account_deltas( fd_pubkey_hash_pair_list_t * lists, ulong lists_len, fd_
 
   fd_pubkey_hash_pair_t * prev_pair = NULL;
   for( ulong k = 0; k < lists_len; ++k ) {
-    fd_pubkey_hash_pair_t * pairs = lists[k].pairs;
-    ulong pairs_len               = lists[k].pairs_len;
+    fd_pubkey_hash_pair_t * pairs     = lists[k].pairs;
+    ulong                   pairs_len = lists[k].pairs_len;
     for( ulong i = 0; i < pairs_len; ++i ) {
 #ifdef VLOG
       FD_LOG_NOTICE(( "account delta hash X { \"key\":%ld, \"pubkey\":\"%s\", \"hash\":\"%s\" },",
@@ -93,11 +86,11 @@ fd_hash_account_deltas( fd_pubkey_hash_pair_list_t * lists, ulong lists_len, fd_
   }
 
   ulong tot_num_hashes = 0;
-  for (ulong k = 0; k < FD_ACCOUNT_DELTAS_MAX_MERKLE_HEIGHT; ++k ) {
+  for( ulong k = 0; k < FD_ACCOUNT_DELTAS_MAX_MERKLE_HEIGHT; ++k ) {
     tot_num_hashes += num_hashes[k];
   }
 
-  if (tot_num_hashes == 1) {
+  if( tot_num_hashes == 1 ) {
     return;
   }
 
@@ -378,10 +371,10 @@ fd_account_hash_task( void *tpool,
   }
 }
 
-void
+static void
 fd_collect_modified_accounts( fd_exec_slot_ctx_t *           slot_ctx,
                               fd_accounts_hash_task_data_t * task_data,
-                              fd_valloc_t                    valloc ) {
+                              fd_spad_t *                    runtime_spad ) {
   fd_acc_mgr_t *  acc_mgr = slot_ctx->acc_mgr;
   fd_funk_t *     funk    = acc_mgr->funk;
   fd_funk_txn_t * txn     = slot_ctx->funk_txn;
@@ -402,7 +395,7 @@ fd_collect_modified_accounts( fd_exec_slot_ctx_t *           slot_ctx,
     rec_cnt++;
   }
 
-  task_data->info = fd_valloc_malloc( valloc, alignof(fd_accounts_hash_task_info_t), rec_cnt * sizeof(fd_accounts_hash_task_info_t) );
+  task_data->info = fd_spad_alloc( runtime_spad, alignof(fd_accounts_hash_task_info_t), rec_cnt * sizeof(fd_accounts_hash_task_info_t) );
 
   /* Iterate over accounts that have been changed in the current
      database transaction. */
@@ -433,7 +426,7 @@ fd_update_hash_bank_tpool( fd_exec_slot_ctx_t * slot_ctx,
                            fd_hash_t *          hash,
                            ulong                signature_cnt,
                            fd_tpool_t *         tpool,
-                           fd_valloc_t          valloc ) {
+                           fd_spad_t *          runtime_spad ) {
   fd_acc_mgr_t *  acc_mgr = slot_ctx->acc_mgr;
   fd_funk_t *     funk    = acc_mgr->funk;
   fd_funk_txn_t * txn     = slot_ctx->funk_txn;
@@ -442,19 +435,22 @@ fd_update_hash_bank_tpool( fd_exec_slot_ctx_t * slot_ctx,
   fd_accounts_hash_task_data_t task_data;
 
   ulong wcnt = fd_tpool_worker_cnt( tpool );
-  task_data.lthash_values = fd_valloc_malloc( valloc, FD_LTHASH_VALUE_ALIGN, wcnt * FD_LTHASH_VALUE_FOOTPRINT );
+  task_data.lthash_values = fd_spad_alloc( runtime_spad, FD_LTHASH_VALUE_ALIGN, wcnt * FD_LTHASH_VALUE_FOOTPRINT );
   for( ulong i = 0; i < wcnt; i++ ) {
     fd_lthash_zero(&task_data.lthash_values[i]);
   }
 
   /* Find accounts which might have changed */
-  fd_collect_modified_accounts( slot_ctx, &task_data, valloc );
+  fd_collect_modified_accounts( slot_ctx, &task_data, runtime_spad );
 
-  fd_pubkey_hash_pair_t * dirty_keys = fd_valloc_malloc( valloc, FD_PUBKEY_HASH_PAIR_ALIGN, task_data.info_sz * FD_PUBKEY_HASH_PAIR_FOOTPRINT );
+  fd_pubkey_hash_pair_t * dirty_keys = fd_spad_alloc( runtime_spad,
+                                                      FD_PUBKEY_HASH_PAIR_ALIGN,
+                                                      task_data.info_sz * FD_PUBKEY_HASH_PAIR_FOOTPRINT );
   ulong dirty_key_cnt = 0;
 
   /* Find accounts which have changed */
-  fd_tpool_exec_all_rrobin( tpool, 0, wcnt, fd_account_hash_task, &task_data, NULL, NULL, 1, 0, task_data.info_sz );
+  fd_tpool_exec_all_rrobin( tpool, 0, wcnt, fd_account_hash_task, &task_data,
+                            NULL, NULL, 1, 0, task_data.info_sz );
 
   // Apply the lthash changes to the bank lthash
   fd_lthash_value_t * acc = (fd_lthash_value_t *)fd_type_pun( slot_ctx->slot_bank.lthash.lthash );
@@ -496,43 +492,48 @@ fd_update_hash_bank_tpool( fd_exec_slot_ctx_t * slot_ctx,
     fd_acct_addr_cstr( owner_string, acc_rec->meta->info.owner );
 
     FD_LOG_DEBUG(( "fd_acc_mgr_update_hash: %s "
-        "slot: %lu "
-        "lamports: %lu  "
-        "owner: %s "
-        "executable: %s,  "
-        "rent_epoch: %lu, "
-        "data_len: %lu",
-        acc_key_string,
-        slot_ctx->slot_bank.slot,
-        acc_rec->meta->info.lamports,
-        owner_string,
-        acc_rec->meta->info.executable ? "true" : "false",
-        acc_rec->meta->info.rent_epoch,
-        acc_rec->meta->dlen ));
+                   "slot: %lu "
+                   "lamports: %lu  "
+                   "owner: %s "
+                   "executable: %s,  "
+                   "rent_epoch: %lu, "
+                   "data_len: %lu",
+                   acc_key_string,
+                   slot_ctx->slot_bank.slot,
+                   acc_rec->meta->info.lamports,
+                   owner_string,
+                   acc_rec->meta->info.executable ? "true" : "false",
+                   acc_rec->meta->info.rent_epoch,
+                   acc_rec->meta->dlen ));
 
     if( capture_ctx != NULL && capture_ctx->capture != NULL ) {
-      fd_account_meta_t const * acc_meta = fd_acc_mgr_view_raw( slot_ctx->acc_mgr, slot_ctx->funk_txn, task_info->acc_pubkey, &task_info->rec, &err, NULL);
+      fd_account_meta_t const * acc_meta = fd_acc_mgr_view_raw( slot_ctx->acc_mgr,
+                                                                slot_ctx->funk_txn,
+                                                                task_info->acc_pubkey,
+                                                                &task_info->rec,
+                                                                &err,
+                                                                NULL);
       if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
         FD_LOG_WARNING(( "failed to view account during capture" ));
         continue;
       }
 
-      uchar const *       acc_data = (uchar *)acc_meta + acc_meta->hlen;
+      uchar const * acc_data = (uchar *)acc_meta + acc_meta->hlen;
 
-      err = fd_solcap_write_account(
-        capture_ctx->capture,
-        acc_key->uc,
-        &acc_rec->meta->info,
-        acc_data,
-        acc_rec->meta->dlen,
-        task_info->acc_hash->hash );
-      FD_TEST( err==0 );
+      err = fd_solcap_write_account( capture_ctx->capture,
+                                     acc_key->uc,
+                                     &acc_rec->meta->info,
+                                     acc_data,
+                                     acc_rec->meta->dlen,
+                                     task_info->acc_hash->hash );
+
+      if( FD_UNLIKELY( err ) ) {
+        FD_LOG_ERR(( "Unable to write out solcap file" ));
+      }
     }
   }
 
   /* Sort and hash "dirty keys" to the accounts delta hash. */
-
-  // FD_LOG_DEBUG(("slot %ld, dirty %ld", slot_ctx->slot_bank.slot, dirty_key_cnt));
 
   slot_ctx->signature_cnt = signature_cnt;
   fd_hash_bank( slot_ctx, capture_ctx, hash, dirty_keys, dirty_key_cnt);
@@ -548,20 +549,13 @@ fd_update_hash_bank_tpool( fd_exec_slot_ctx_t * slot_ctx,
     fd_funk_rec_remove( funk, fd_funk_rec_modify(funk, task_info->rec), task_info->rec->pair.xid->ul[0] );
   }
 
-  // Sanity-check LT Hash
-  //    fd_accounts_check_lthash( slot_ctx );
-
-  fd_valloc_free( valloc, task_data.info );
-  fd_valloc_free( valloc, task_data.lthash_values );
-  fd_valloc_free( valloc, dirty_keys );
-
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
 
 int
 fd_print_account_hashes( fd_exec_slot_ctx_t * slot_ctx,
                          fd_tpool_t *         tpool,
-                         fd_valloc_t          valloc ) {
+                         fd_spad_t *          runtime_spad ) {
 
   // fd_acc_mgr_t *  acc_mgr = slot_ctx->acc_mgr;
   // fd_funk_txn_t * txn     = slot_ctx->funk_txn;
@@ -569,19 +563,24 @@ fd_print_account_hashes( fd_exec_slot_ctx_t * slot_ctx,
   /* Collect list of changed accounts to be added to bank hash */
   fd_accounts_hash_task_data_t task_data;
 
-  fd_collect_modified_accounts( slot_ctx, &task_data, valloc );
+  fd_collect_modified_accounts( slot_ctx, &task_data, runtime_spad );
 
-  fd_pubkey_hash_pair_t * dirty_keys = fd_valloc_malloc( valloc, FD_PUBKEY_HASH_PAIR_ALIGN, task_data.info_sz * FD_PUBKEY_HASH_PAIR_FOOTPRINT );
+  fd_pubkey_hash_pair_t * dirty_keys = fd_spad_alloc( runtime_spad,
+                                                      FD_PUBKEY_HASH_PAIR_ALIGN,
+                                                      task_data.info_sz * FD_PUBKEY_HASH_PAIR_FOOTPRINT );
   ulong dirty_key_cnt = 0;
 
   ulong wcnt = fd_tpool_worker_cnt( tpool );
-  task_data.lthash_values = fd_valloc_malloc( valloc, FD_LTHASH_VALUE_ALIGN, wcnt * FD_LTHASH_VALUE_FOOTPRINT );
+  task_data.lthash_values = fd_spad_alloc( runtime_spad,
+                                           FD_LTHASH_VALUE_ALIGN,
+                                           wcnt * FD_LTHASH_VALUE_FOOTPRINT );
   for( ulong i = 0; i < wcnt; i++ ) {
     fd_lthash_zero(&task_data.lthash_values[i]);
   }
 
   /* Find accounts which have changed */
-  fd_tpool_exec_all_rrobin( tpool, 0, fd_tpool_worker_cnt( tpool ), fd_account_hash_task, task_data.info, NULL, NULL, 1, 0, task_data.info_sz );
+  fd_tpool_exec_all_rrobin( tpool, 0, fd_tpool_worker_cnt( tpool ), fd_account_hash_task, task_data.info,
+                            NULL, NULL, 1, 0, task_data.info_sz );
 
   for( ulong i = 0; i < task_data.info_sz; i++ ) {
     fd_accounts_hash_task_info_t * task_info = &task_data.info[i];
@@ -609,8 +608,6 @@ fd_print_account_hashes( fd_exec_slot_ctx_t * slot_ctx,
     fd_pubkey_hash_pair_t * dirty_entry = &dirty_keys[dirty_key_cnt++];
     dirty_entry->rec = task_info->rec;
     dirty_entry->hash = (fd_hash_t const *)task_info->acc_hash->hash;
-
-    // FD_TEST( err==0 );
   }
 
   /* Sort and hash "dirty keys" to the accounts delta hash. */
@@ -643,7 +640,7 @@ fd_print_account_hashes( fd_exec_slot_ctx_t * slot_ctx,
 
       fd_account_meta_t * metadata = (fd_account_meta_t *)raw_acc_data;
       uchar *             acc_data = fd_account_get_data(metadata);
-      char *              acc_data_str = fd_valloc_malloc( valloc, 8, 5*metadata->dlen + 1 );
+      char *              acc_data_str = fd_spad_alloc( runtime_spad, 8, 5*metadata->dlen + 1 );
 
       char * acc_data_str_cursor = acc_data_str;
       if (metadata->dlen > 0) {
@@ -665,25 +662,19 @@ fd_print_account_hashes( fd_exec_slot_ctx_t * slot_ctx,
                       metadata->info.rent_epoch,
                       metadata->dlen,
                       FD_BASE58_ENC_32_ALLOCA( dirty_keys[i].hash->hash ) ));
-
-      fd_valloc_free(valloc, acc_data_str);
     }
   }
 #endif
-
-  fd_valloc_free( valloc, task_data.info );
-  fd_valloc_free( valloc, task_data.lthash_values );
-  fd_valloc_free( valloc, dirty_keys );
 
   return 0;
 }
 
 void const *
 fd_hash_account( uchar                     hash[ static 32 ],
-                 fd_lthash_value_t       * lthash,
+                 fd_lthash_value_t *       lthash,
                  fd_account_meta_t const * m,
                  uchar const               pubkey[ static 32 ],
-                 uchar const             * data ) {
+                 uchar const *             data ) {
   ulong         lamports   = m->info.lamports;  /* >0UL */
   ulong         rent_epoch = m->info.rent_epoch;
   uchar         executable = m->info.executable & 0x1;
@@ -708,11 +699,11 @@ fd_hash_account( uchar                     hash[ static 32 ],
 }
 
 void const *
-fd_hash_account_current( uchar                      hash  [ static 32 ],
-                         fd_lthash_value_t         *lthash,
-                         fd_account_meta_t const   *account,
-                         uchar const                pubkey[ static 32 ],
-                         uchar const               *data ) {
+fd_hash_account_current( uchar                     hash[ static 32 ],
+                         fd_lthash_value_t *       lthash,
+                         fd_account_meta_t const * account,
+                         uchar const               pubkey[ static 32 ],
+                         uchar const *             data ) {
   return fd_hash_account( hash, lthash, account, pubkey, data );
 }
 
@@ -736,172 +727,228 @@ typedef struct accounts_hash accounts_hash_t;
 #define MAP_T    accounts_hash_t
 #include "../../util/tmpl/fd_map_dynamic.c"
 
-static fd_pubkey_hash_pair_t *
-fd_accounts_sorted_subrange( fd_funk_t         * funk,
-                             uint                range_idx,
-                             uint                range_cnt,
-                             ulong             * num_pairs_out,
-                             fd_lthash_value_t * lthash_values,
-                             ulong               n0,
-                             fd_valloc_t         valloc
- ) {
+/* fd_accounts_sorted_subrange_count will determine the number of accounts that
+   should be in the accounts slice for a given range_idx. This is split out to
+   from fd_accounts_sorted_subrange_gather to avoid dynamic resizing of the pair.
+   
+   TODO: The common code in these functions could be factored out. */
 
-  fd_wksp_t *     wksp = fd_funk_wksp( funk );
-  fd_funk_rec_t * rec_map  = fd_funk_rec_map( funk, wksp );
+static ulong
+fd_accounts_sorted_subrange_count( fd_funk_t * funk,
+                                   uint        range_idx,
+                                   uint        range_cnt ) {
+
+  fd_wksp_t *     wksp              = fd_funk_wksp( funk );
+  fd_funk_rec_t * rec_map           = fd_funk_rec_map( funk, wksp );
   ulong           num_iter_accounts = fd_funk_rec_map_key_max( rec_map );
-  ulong           max_pairs = ( range_cnt == 1U ? num_iter_accounts : 2UL*num_iter_accounts/range_cnt ); /* Initial estimate */
-  ulong           num_pairs = 0;
-  fd_pubkey_hash_pair_t * pairs = fd_valloc_malloc( valloc, FD_PUBKEY_HASH_PAIR_ALIGN, max_pairs * sizeof(fd_pubkey_hash_pair_t) );
-  FD_TEST(NULL != pairs);
-  ulong           range_len = ULONG_MAX/range_cnt;
-  ulong           range_min = range_len*range_idx;
-  ulong           range_max = ( range_idx+1U < range_cnt ? range_min+range_len-1U : ULONG_MAX );
-
-  fd_lthash_value_t accum;
-  fd_lthash_zero(&accum);
+  ulong           num_pairs         = 0UL;
+  ulong           range_len         = ULONG_MAX/range_cnt;
+  ulong           range_min         = range_len*range_idx;
+  ulong           range_max         = (range_idx+1U<range_cnt) ? (range_min+range_len-1U) : ULONG_MAX;
 
   for( ulong i = num_iter_accounts; i; --i ) {
     fd_funk_rec_t const * rec = rec_map + (i-1UL);
-    if ( ( rec->map_next >> 63 ) /* unused map entry */ ||
-         !fd_funk_key_is_acc( rec->pair.key ) || /* not a solana record */
-         ( rec->flags & FD_FUNK_REC_FLAG_ERASE ) || /* this is a tombstone */
-         ( rec->pair.xid->ul[0] | rec->pair.xid->ul[1] ) != 0 /* not root xid */ ) {
+    if ( (rec->map_next >> 63) ||                           /* unused map entry */
+         !fd_funk_key_is_acc( rec->pair.key ) ||            /* not a solana record */
+         (rec->flags & FD_FUNK_REC_FLAG_ERASE) ||           /* this is a tombstone */
+         (rec->pair.xid->ul[0] | rec->pair.xid->ul[1]) != 0 /* not root xid */ ) {
       continue;
     }
 
-    ulong n = __builtin_bswap64(rec->pair.key->ul[0]);
-    if( n < range_min || n > range_max ) {
+    ulong n = __builtin_bswap64( rec->pair.key->ul[0] );
+    if( n<range_min || n>range_max ) {
       continue;
     }
 
-    fd_account_meta_t * metadata = (fd_account_meta_t *) fd_funk_val_const( rec, wksp );
+    fd_account_meta_t * metadata = (fd_account_meta_t *)fd_funk_val_const( rec, wksp );
     int is_empty = (metadata->info.lamports == 0);
     if( is_empty ) {
       continue;
     }
 
-    uchar hash[32];
-    fd_lthash_value_t new_lthash_value;
-    fd_lthash_zero(&new_lthash_value);
+    if( (metadata->info.executable & ~1) != 0 ) {
+      continue;
+    }
 
-    fd_hash_account_current( (uchar *) hash, &new_lthash_value, metadata, rec->pair.key->uc, fd_account_get_data(metadata) );
+    num_pairs++;
+  }
+
+  return num_pairs;
+}
+
+static void
+fd_accounts_sorted_subrange_gather( fd_funk_t *             funk,
+                                    uint                    range_idx,
+                                    uint                    range_cnt,
+                                    ulong *                 num_pairs_out,
+                                    fd_lthash_value_t *     lthash_values_out,
+                                    ulong                   n0,
+                                    fd_pubkey_hash_pair_t * pairs ) {
+
+  fd_wksp_t *     wksp              = fd_funk_wksp( funk );
+  fd_funk_rec_t * rec_map           = fd_funk_rec_map( funk, wksp );
+  ulong           num_iter_accounts = fd_funk_rec_map_key_max( rec_map );
+  ulong           num_pairs         = 0UL;
+  ulong           range_len         = ULONG_MAX/range_cnt;
+  ulong           range_min         = range_len*range_idx;
+  ulong           range_max         = (range_idx+1U<range_cnt) ? (range_min+range_len-1U) : ULONG_MAX;
+
+  fd_lthash_value_t accum = {0};
+
+  for( ulong i = num_iter_accounts; i; --i ) {
+    fd_funk_rec_t const * rec = rec_map + (i-1UL);
+    if ( (rec->map_next >> 63) ||                           /* unused map entry */
+         !fd_funk_key_is_acc( rec->pair.key ) ||            /* not a solana record */
+         (rec->flags & FD_FUNK_REC_FLAG_ERASE) ||           /* this is a tombstone */
+         (rec->pair.xid->ul[0] | rec->pair.xid->ul[1]) != 0 /* not root xid */ ) {
+      continue;
+    }
+
+    ulong n = __builtin_bswap64( rec->pair.key->ul[0] );
+    if( n<range_min || n>range_max ) {
+      continue;
+    }
+    fd_account_meta_t * metadata = (fd_account_meta_t *)fd_funk_val_const( rec, wksp );
+    int is_empty = (metadata->info.lamports == 0);
+    if( is_empty ) {
+      continue;
+    }
+
+    /* FIXME: remove magic number */
+    uchar hash[32];
+    fd_lthash_value_t new_lthash_value = {0};
+
+    fd_hash_account_current( (uchar *)hash, &new_lthash_value, metadata, rec->pair.key->uc, fd_account_get_data( metadata ) );
     fd_lthash_add( &accum, &new_lthash_value );
 
-    fd_hash_t * h = (fd_hash_t *) metadata->hash;
+    fd_hash_t * h = (fd_hash_t *)metadata->hash;
     if( FD_LIKELY( (h->ul[0] | h->ul[1] | h->ul[2] | h->ul[3]) != 0 ) ) {
       if( FD_UNLIKELY( fd_acc_exists( metadata ) && memcmp( metadata->hash, &hash, 32 ) != 0 ) ) {
         FD_LOG_WARNING(( "snapshot hash (%s) doesn't match calculated hash (%s)", FD_BASE58_ENC_32_ALLOCA( metadata->hash ), FD_BASE58_ENC_32_ALLOCA( &hash ) ));
       }
-    } else
-      fd_memcpy( metadata->hash, &hash, 32 );
+    } else {
+      fd_memcpy( metadata->hash, &hash, sizeof(fd_hash_t) );
+    }
 
-    if( (metadata->info.executable & ~1) != 0 )
-      continue;
-
-    if( num_pairs == max_pairs ) {
-      /* Try again with a larger array */
-      fd_valloc_free( valloc, pairs );
-      max_pairs *= 2;
-      pairs = fd_valloc_malloc( valloc, FD_PUBKEY_HASH_PAIR_ALIGN, max_pairs * sizeof(fd_pubkey_hash_pair_t) );
-      FD_TEST(NULL != pairs);
-      num_pairs = 0;
-      fd_lthash_zero(&accum);
-      i = num_iter_accounts+1;
+    if( (metadata->info.executable & ~1) != 0 ) {
       continue;
     }
 
     fd_pubkey_hash_pair_t * pair = &pairs[num_pairs++];
-    pair->rec = rec;
-    pair->hash = (const fd_hash_t *)metadata->hash;
+    pair->rec                    = rec;
+    pair->hash                   = (const fd_hash_t *)metadata->hash;
   }
 
   sort_pubkey_hash_pair_inplace( pairs, num_pairs );
 
-  // FD_LOG_NOTICE(( "sorted_subrange %lx ... %lx => %lu pairs", range_min, range_max, num_pairs ));
   *num_pairs_out = num_pairs;
 
-  fd_lthash_add( &lthash_values[n0], &accum  );
-  return pairs;
+  fd_lthash_add( &lthash_values_out[n0], &accum  );
 }
 
 struct fd_subrange_task_info {
-  fd_funk_t * funk;
-  ulong num_lists;
+  fd_funk_t *                  funk;
+  ulong                        num_lists;
   fd_pubkey_hash_pair_list_t * lists;
-  fd_lthash_value_t *lthash_values;
-  fd_valloc_t valloc;
+  fd_lthash_value_t *          lthash_values;
 };
 typedef struct fd_subrange_task_info fd_subrange_task_info_t;
 
 static void
-fd_accounts_sorted_subrange_task( void *tpool,
-                                  ulong t0 FD_PARAM_UNUSED, ulong t1 FD_PARAM_UNUSED,
-                                  void *args FD_PARAM_UNUSED,
-                                  void *reduce FD_PARAM_UNUSED, ulong stride FD_PARAM_UNUSED,
-                                  ulong l0 FD_PARAM_UNUSED, ulong l1 FD_PARAM_UNUSED,
-                                  ulong m0, ulong m1 FD_PARAM_UNUSED,
-                                  ulong n0, ulong n1 FD_PARAM_UNUSED) {
+fd_accounts_sorted_subrange_count_task( void *tpool,
+                                        ulong t0 FD_PARAM_UNUSED, ulong t1 FD_PARAM_UNUSED,
+                                        void *args FD_PARAM_UNUSED,
+                                        void *reduce FD_PARAM_UNUSED, ulong stride FD_PARAM_UNUSED,
+                                        ulong l0 FD_PARAM_UNUSED, ulong l1 FD_PARAM_UNUSED,
+                                        ulong m0, ulong m1 FD_PARAM_UNUSED,
+                                        ulong n0 FD_PARAM_UNUSED, ulong n1 FD_PARAM_UNUSED) {
   fd_subrange_task_info_t * task_info = (fd_subrange_task_info_t *)tpool;
-  fd_pubkey_hash_pair_list_t * list = task_info->lists + m0;
-  list->pairs = fd_accounts_sorted_subrange( task_info->funk, (uint)m0, (uint)task_info->num_lists, &list->pairs_len, task_info->lthash_values, n0, task_info->valloc );
+  ulong num_pairs = fd_accounts_sorted_subrange_count( task_info->funk, (uint)m0, (uint)task_info->num_lists );
+  task_info->lists[m0].pairs_len = num_pairs;
+}
+
+static void
+fd_accounts_sorted_subrange_gather_task( void *tpool,
+                                         ulong t0 FD_PARAM_UNUSED, ulong t1 FD_PARAM_UNUSED,
+                                         void *args FD_PARAM_UNUSED,
+                                         void *reduce FD_PARAM_UNUSED, ulong stride FD_PARAM_UNUSED,
+                                         ulong l0 FD_PARAM_UNUSED, ulong l1 FD_PARAM_UNUSED,
+                                         ulong m0, ulong m1 FD_PARAM_UNUSED,
+                                         ulong n0, ulong n1 FD_PARAM_UNUSED) {
+  fd_subrange_task_info_t *    task_info = (fd_subrange_task_info_t *)tpool;
+  fd_pubkey_hash_pair_list_t * list      = task_info->lists + m0;
+  fd_accounts_sorted_subrange_gather( task_info->funk, (uint)m0, (uint)task_info->num_lists, 
+                                      &list->pairs_len, task_info->lthash_values, n0, list->pairs );
 }
 
 int
-fd_accounts_hash( fd_funk_t          * funk,
-                  fd_slot_bank_t     * slot_bank,
-                  fd_valloc_t          valloc,
-                  fd_tpool_t         * tpool,
-                  fd_hash_t          * accounts_hash ) {
+fd_accounts_hash( fd_funk_t *      funk,
+                  fd_slot_bank_t * slot_bank,
+                  fd_tpool_t *     tpool,
+                  fd_hash_t *      accounts_hash,
+                  fd_spad_t *      runtime_spad ) {
   FD_LOG_NOTICE(("accounts_hash start"));
 
   if( tpool == NULL || fd_tpool_worker_cnt( tpool ) <= 1U ) {
-    ulong                   num_pairs = 0;
-    fd_lthash_value_t *lthash_values = fd_valloc_malloc( valloc, FD_LTHASH_VALUE_ALIGN, FD_LTHASH_VALUE_FOOTPRINT );
-    fd_lthash_zero(&lthash_values[0]);
+    ulong               num_pairs     = 0UL;
+    fd_lthash_value_t * lthash_values = fd_spad_alloc( runtime_spad, FD_LTHASH_VALUE_ALIGN, FD_LTHASH_VALUE_FOOTPRINT );
+    fd_lthash_zero( &lthash_values[0] );
 
-    fd_pubkey_hash_pair_t * pairs = fd_accounts_sorted_subrange( funk, 0, 1, &num_pairs, lthash_values, 0, valloc );
-    FD_TEST(NULL != pairs);
+    fd_wksp_t *             wksp              = fd_funk_wksp( funk );
+    fd_funk_rec_t *         rec_map           = fd_funk_rec_map( funk, wksp );
+    ulong                   num_iter_accounts = fd_funk_rec_map_key_max( rec_map );
+    fd_pubkey_hash_pair_t * pairs             = fd_spad_alloc( runtime_spad,
+                                                               FD_PUBKEY_HASH_PAIR_ALIGN,
+                                                               num_iter_accounts * sizeof(fd_pubkey_hash_pair_t) );
+
+    fd_accounts_sorted_subrange_gather( funk, 0, 1, &num_pairs, lthash_values, 0, pairs );
+    if( FD_UNLIKELY( !pairs ) ) {
+      FD_LOG_ERR(( "failed to allocate memory for account hash" ));
+    }
     fd_pubkey_hash_pair_list_t list1 = { .pairs = pairs, .pairs_len = num_pairs };
     fd_hash_account_deltas( &list1, 1, accounts_hash );
-    fd_valloc_free( valloc, pairs );
 
-    fd_lthash_value_t * acc = (fd_lthash_value_t *)fd_type_pun(slot_bank->lthash.lthash);
+    fd_lthash_value_t * acc = (fd_lthash_value_t *)fd_type_pun( slot_bank->lthash.lthash );
     fd_lthash_add( acc, &lthash_values[0] );
 
-    fd_valloc_free( valloc, lthash_values );
   } else {
     ulong num_lists = fd_tpool_worker_cnt( tpool );
     FD_LOG_NOTICE(( "launching %lu hash tasks", num_lists ));
     fd_pubkey_hash_pair_list_t lists[num_lists];
 
-    fd_lthash_value_t *lthash_values = fd_valloc_malloc( valloc, FD_LTHASH_VALUE_ALIGN, num_lists * FD_LTHASH_VALUE_FOOTPRINT );
+    fd_lthash_value_t * lthash_values = fd_spad_alloc( runtime_spad, FD_LTHASH_VALUE_ALIGN, num_lists * FD_LTHASH_VALUE_FOOTPRINT );
     for( ulong i = 0; i < num_lists; i++ ) {
-      fd_lthash_zero(&lthash_values[i]);
+      fd_lthash_zero(&lthash_values[i] );
     }
 
+    /* First calculate how big the list needs to be sized out to be, bump
+       allocate the size of the array then caclulate the hash. */
+
     fd_subrange_task_info_t task_info = {
-      .funk = funk,
-      .num_lists = num_lists,
-      .lists = lists,
-      .lthash_values = lthash_values,
-      .valloc = valloc };
-    fd_tpool_exec_all_rrobin( tpool, 0UL, num_lists, fd_accounts_sorted_subrange_task, &task_info, NULL, NULL, 1, 0, num_lists );
-    fd_hash_account_deltas( lists, num_lists, accounts_hash );
-    for( ulong i = 0; i < num_lists; ++i ) {
-      fd_valloc_free( valloc, lists[i].pairs );
+      .funk          = funk,
+      .num_lists     = num_lists,
+      .lists         = lists,
+      .lthash_values = lthash_values
+    };
+
+    fd_tpool_exec_all_rrobin( tpool, 0UL, num_lists, fd_accounts_sorted_subrange_count_task, &task_info,
+                              NULL, NULL, 1, 0, num_lists );
+    for( ulong i=0UL; i<num_lists; i++ ) {
+      task_info.lists[i].pairs     = fd_spad_alloc( runtime_spad, FD_PUBKEY_HASH_PAIR_ALIGN, task_info.lists[i].pairs_len * sizeof(fd_pubkey_hash_pair_t) );
+      task_info.lists[i].pairs_len = 0UL;
     }
+
+    fd_tpool_exec_all_rrobin( tpool, 0UL, num_lists, fd_accounts_sorted_subrange_gather_task, &task_info, 
+                              NULL, NULL, 1, 0, num_lists );
+    fd_hash_account_deltas( lists, num_lists, accounts_hash );
     fd_lthash_value_t * acc = (fd_lthash_value_t *)fd_type_pun(slot_bank->lthash.lthash);
-    for( ulong i = 0; i < num_lists; i++ ) {
+    for( ulong i = 0UL; i < num_lists; i++ ) {
       fd_lthash_add( acc, &lthash_values[i] );
     }
 
-    fd_valloc_free( valloc, lthash_values );
   }
-  FD_LOG_NOTICE(("accounts_lthash %s", FD_LTHASH_ENC_32_ALLOCA( (fd_lthash_value_t *) slot_bank->lthash.lthash )));
-
-  // fd_accounts_check_lthash( slot_ctx );
-
-  FD_LOG_NOTICE(("accounts_hash %s", FD_BASE58_ENC_32_ALLOCA( accounts_hash->hash ) ));
+  FD_LOG_NOTICE(( "accounts_lthash %s", FD_LTHASH_ENC_32_ALLOCA( (fd_lthash_value_t *)slot_bank->lthash.lthash ) ));
+  FD_LOG_NOTICE(( "accounts_hash %s", FD_BASE58_ENC_32_ALLOCA( accounts_hash->hash ) ));
 
   return 0;
 }
@@ -911,21 +958,24 @@ fd_accounts_hash_inc_only( fd_exec_slot_ctx_t * slot_ctx,
                            fd_hash_t *          accounts_hash, 
                            fd_funk_txn_t *      child_txn, 
                            ulong                do_hash_verify,
-                           fd_valloc_t          valloc ) {
-  FD_LOG_NOTICE(("accounts_hash_inc_only start for txn %p, do_hash_verify=%s", (void *)child_txn, do_hash_verify ? "true" : "false" ));
+                           fd_spad_t *          spad ) {
+  FD_LOG_NOTICE(( "accounts_hash_inc_only start for txn %p, do_hash_verify=%s", (void *)child_txn, do_hash_verify ? "true" : "false" ));
 
-  fd_funk_t *     funk = slot_ctx->acc_mgr->funk;
-  fd_wksp_t *     wksp = fd_funk_wksp( funk );
-  fd_funk_rec_t * rec_map  = fd_funk_rec_map( funk, wksp );
+  FD_SPAD_FRAME_BEGIN( spad ) {
+
+  fd_funk_t *     funk    = slot_ctx->acc_mgr->funk;
+  fd_wksp_t *     wksp    = fd_funk_wksp( funk );
+  fd_funk_rec_t * rec_map = fd_funk_rec_map( funk, wksp );
 
   // How many total records are we dealing with?
   ulong                   num_iter_accounts = fd_funk_rec_map_key_cnt( rec_map );
-  ulong                   num_pairs = 0;
-  fd_pubkey_hash_pair_t * pairs = fd_valloc_malloc( valloc, FD_PUBKEY_HASH_PAIR_ALIGN, num_iter_accounts * sizeof(fd_pubkey_hash_pair_t) );
-  FD_TEST(NULL != pairs);
+  ulong                   num_pairs         = 0UL;
+  fd_pubkey_hash_pair_t * pairs             = fd_spad_alloc( spad, FD_PUBKEY_HASH_PAIR_ALIGN, num_iter_accounts * sizeof(fd_pubkey_hash_pair_t) );
+  if( FD_UNLIKELY( !pairs ) ) {
+    FD_LOG_ERR(( "failed to allocate memory for pairs" ));
+  }
 
-  fd_blake3_t *b3 = NULL;
-  fd_scratch_push();
+  fd_blake3_t * b3 = NULL;
 
   for (fd_funk_rec_t const *rec = fd_funk_txn_first_rec( funk, child_txn ); NULL != rec; rec = fd_funk_txn_next_rec(funk, rec)) {
     if ( !fd_funk_key_is_acc( rec->pair.key ) || ( rec->flags & FD_FUNK_REC_FLAG_ERASE ) )
@@ -937,12 +987,13 @@ fd_accounts_hash_inc_only( fd_exec_slot_ctx_t * slot_ctx,
     if (is_empty) {
       pairs[num_pairs].rec = rec;
 
-      fd_hash_t * hash = fd_scratch_alloc(alignof(fd_hash_t), sizeof(fd_hash_t));
-      if (NULL == b3)
-        b3 = fd_scratch_alloc(alignof(fd_blake3_t), sizeof(fd_blake3_t));
-      fd_blake3_init  ( b3 );
-      fd_blake3_append( b3, rec->pair.key->uc,   sizeof( fd_pubkey_t ) );
-      fd_blake3_fini  ( b3, hash );
+      fd_hash_t * hash = fd_spad_alloc( spad, alignof(fd_hash_t), sizeof(fd_hash_t) );
+      if( NULL == b3 ) {
+        b3 = fd_spad_alloc( spad, alignof(fd_blake3_t), sizeof(fd_blake3_t) );
+      }
+      fd_blake3_init( b3 );
+      fd_blake3_append( b3, rec->pair.key->uc, sizeof( fd_pubkey_t ) );
+      fd_blake3_fini( b3, hash );
 
       pairs[num_pairs].hash = hash;
       num_pairs++;
@@ -976,10 +1027,9 @@ fd_accounts_hash_inc_only( fd_exec_slot_ctx_t * slot_ctx,
   fd_pubkey_hash_pair_list_t list1 = { .pairs = pairs, .pairs_len = num_pairs };
   fd_hash_account_deltas( &list1, 1, accounts_hash );
 
-  fd_valloc_free( valloc, pairs );
-  fd_scratch_pop();
-
   FD_LOG_INFO(( "accounts_hash %s", FD_BASE58_ENC_32_ALLOCA( accounts_hash->hash) ));
+
+  } FD_SPAD_FRAME_END;
 
   return 0;
 }
@@ -989,11 +1039,11 @@ fd_accounts_hash_inc_only( fd_exec_slot_ctx_t * slot_ctx,
    way to generate an accounts hash from a subset of accounts from funk. */
 static int
 fd_accounts_hash_inc_no_txn( fd_funk_t *                 funk,
-                             fd_valloc_t                 valloc,
                              fd_hash_t *                 accounts_hash,
                              fd_funk_rec_key_t const * * pubkeys,
                              ulong                       pubkeys_len,
-                             ulong                       do_hash_verify ) {
+                             ulong                       do_hash_verify,
+                             fd_spad_t *                 spad ) {
   FD_LOG_NOTICE(( "accounts_hash_inc_no_txn" ));
 
   fd_wksp_t *     wksp    = fd_funk_wksp( funk );
@@ -1001,11 +1051,13 @@ fd_accounts_hash_inc_no_txn( fd_funk_t *                 funk,
 
   /* Pre-allocate the number of pubkey pairs that we are iterating over. */
 
+  FD_SPAD_FRAME_BEGIN( spad ) {
+
   ulong                   num_iter_accounts = fd_funk_rec_map_key_cnt( rec_map );
   ulong                   num_pairs         = 0UL;
-  fd_pubkey_hash_pair_t * pairs             = fd_valloc_malloc( valloc,
-                                                                FD_PUBKEY_HASH_PAIR_ALIGN,
-                                                                num_iter_accounts * sizeof(fd_pubkey_hash_pair_t) );
+  fd_pubkey_hash_pair_t * pairs             = fd_spad_alloc( spad,
+                                                             FD_PUBKEY_HASH_PAIR_ALIGN,
+                                                             num_iter_accounts * sizeof(fd_pubkey_hash_pair_t) );
 
   if( FD_UNLIKELY( !pairs ) ) {
     FD_LOG_ERR(( "failed to allocate memory for pairs" ));
@@ -1013,7 +1065,6 @@ fd_accounts_hash_inc_no_txn( fd_funk_t *                 funk,
 
   fd_blake3_t * b3 = NULL;
 
-  FD_SCRATCH_SCOPE_BEGIN {
 
   for( ulong i=0UL; i<pubkeys_len; i++ ) {
     fd_funk_rec_t const * rec = fd_funk_rec_query( funk, NULL, pubkeys[i] );
@@ -1024,13 +1075,13 @@ fd_accounts_hash_inc_no_txn( fd_funk_t *                 funk,
     if( is_empty ) {
       pairs[num_pairs].rec = rec;
 
-      fd_hash_t * hash = fd_scratch_alloc( alignof(fd_hash_t), sizeof(fd_hash_t) );
+      fd_hash_t * hash = fd_spad_alloc( spad, alignof(fd_hash_t), sizeof(fd_hash_t) );
       if( !b3 ) {
-        b3 = fd_scratch_alloc( alignof(fd_blake3_t), sizeof(fd_blake3_t) );
+        b3 = fd_spad_alloc( spad, alignof(fd_blake3_t), sizeof(fd_blake3_t) );
       }
-      fd_blake3_init  ( b3 );
+      fd_blake3_init( b3 );
       fd_blake3_append( b3, rec->pair.key->uc, sizeof(fd_pubkey_t) );
-      fd_blake3_fini  ( b3, hash );
+      fd_blake3_fini( b3, hash );
 
       pairs[ num_pairs ].hash = hash;
       num_pairs++;
@@ -1062,9 +1113,7 @@ fd_accounts_hash_inc_no_txn( fd_funk_t *                 funk,
   fd_pubkey_hash_pair_list_t list1 = { .pairs = pairs, .pairs_len = num_pairs };
   fd_hash_account_deltas( &list1, 1, accounts_hash );
 
-  fd_valloc_free( valloc, pairs );
-
-  } FD_SCRATCH_SCOPE_END;
+  } FD_SPAD_FRAME_END;
 
   FD_LOG_INFO(( "accounts_hash %s", FD_BASE58_ENC_32_ALLOCA( accounts_hash->hash ) ));
 
@@ -1076,14 +1125,14 @@ fd_snapshot_hash( fd_exec_slot_ctx_t * slot_ctx,
                   fd_tpool_t *         tpool,
                   fd_hash_t *          accounts_hash,
                   uint                 check_hash,
-                  fd_valloc_t          valloc ) {
-  (void) check_hash;
+                  fd_spad_t *          runtime_spad ) {
+  (void)check_hash;
 
   if( fd_should_snapshot_include_epoch_accounts_hash( slot_ctx ) ) {
     FD_LOG_NOTICE(( "snapshot is including epoch account hash" ));
     fd_sha256_t h;
-    fd_hash_t hash;
-    fd_accounts_hash( slot_ctx->acc_mgr->funk, &slot_ctx->slot_bank, valloc, tpool, &hash );
+    fd_hash_t   hash;
+    fd_accounts_hash( slot_ctx->acc_mgr->funk, &slot_ctx->slot_bank, tpool, &hash, runtime_spad );
 
     fd_sha256_init( &h );
     fd_sha256_append( &h, (uchar const *) hash.hash, sizeof( fd_hash_t ) );
@@ -1092,7 +1141,7 @@ fd_snapshot_hash( fd_exec_slot_ctx_t * slot_ctx,
 
     return 0;
   }
-  return fd_accounts_hash( slot_ctx->acc_mgr->funk, &slot_ctx->slot_bank, valloc, tpool, accounts_hash );
+  return fd_accounts_hash( slot_ctx->acc_mgr->funk, &slot_ctx->slot_bank, tpool, accounts_hash, runtime_spad );
 }
 
 int
@@ -1100,12 +1149,12 @@ fd_snapshot_inc_hash( fd_exec_slot_ctx_t * slot_ctx,
                       fd_hash_t *          accounts_hash,
                       fd_funk_txn_t *      child_txn,
                       uint                 do_hash_verify,
-                      fd_valloc_t          valloc ) {
+                      fd_spad_t *          spad ) {
 
   if( fd_should_snapshot_include_epoch_accounts_hash( slot_ctx ) ) {
     fd_sha256_t h;
-    fd_hash_t hash;
-    fd_accounts_hash_inc_only( slot_ctx, &hash, child_txn, do_hash_verify, valloc );
+    fd_hash_t   hash;
+    fd_accounts_hash_inc_only( slot_ctx, &hash, child_txn, do_hash_verify, spad );
 
     fd_sha256_init( &h );
     fd_sha256_append( &h, (uchar const *) hash.hash, sizeof( fd_hash_t ) );
@@ -1114,22 +1163,22 @@ fd_snapshot_inc_hash( fd_exec_slot_ctx_t * slot_ctx,
 
     return 0;
   }
-  return fd_accounts_hash_inc_only( slot_ctx, accounts_hash, child_txn, do_hash_verify, valloc );
+  return fd_accounts_hash_inc_only( slot_ctx, accounts_hash, child_txn, do_hash_verify, spad );
 }
 
 /* TODO: Combine with the above to get correct snapshot hash verification. */
 
 int
-fd_snapshot_service_hash( fd_hash_t       * accounts_hash,
-                          fd_hash_t       * snapshot_hash,
-                          fd_slot_bank_t  * slot_bank,
+fd_snapshot_service_hash( fd_hash_t *       accounts_hash,
+                          fd_hash_t *       snapshot_hash,
+                          fd_slot_bank_t *  slot_bank,
                           fd_epoch_bank_t * epoch_bank,
-                          fd_funk_t       * funk,
-                          fd_tpool_t      * tpool,
-                          fd_valloc_t       valloc ) {
+                          fd_funk_t *       funk,
+                          fd_tpool_t *      tpool,
+                          fd_spad_t *       runtime_spad ) {
 
   fd_sha256_t h;
-  fd_accounts_hash( funk, slot_bank, valloc, tpool, accounts_hash );
+  fd_accounts_hash( funk, slot_bank, tpool, accounts_hash, runtime_spad );
 
   int should_include_eah = epoch_bank->eah_stop_slot != ULONG_MAX && epoch_bank->eah_start_slot == ULONG_MAX;
 
@@ -1153,10 +1202,10 @@ fd_snapshot_service_inc_hash( fd_hash_t *                 accounts_hash,
                               fd_funk_t *                 funk,
                               fd_funk_rec_key_t const * * pubkeys,
                               ulong                       pubkeys_len,
-                              fd_valloc_t                 valloc ) {
+                              fd_spad_t *                 spad ) {
 
   fd_sha256_t h;
-  fd_accounts_hash_inc_no_txn( funk, valloc, accounts_hash, pubkeys, pubkeys_len, 0UL );
+  fd_accounts_hash_inc_no_txn( funk, accounts_hash, pubkeys, pubkeys_len, 0UL, spad );
 
   int should_include_eah = epoch_bank->eah_stop_slot != ULONG_MAX && epoch_bank->eah_start_slot == ULONG_MAX;
 
@@ -1174,10 +1223,10 @@ fd_snapshot_service_inc_hash( fd_hash_t *                 accounts_hash,
 
 /* Re-computes the lthash from the current slot */
 void
-fd_accounts_check_lthash( fd_funk_t     *  funk,
+fd_accounts_check_lthash( fd_funk_t *      funk,
                           fd_funk_txn_t *  funk_txn,
                           fd_slot_bank_t * slot_bank,
-                          fd_valloc_t      valloc ) {
+                          fd_spad_t *      runtime_spad ) {
 
   fd_wksp_t *     wksp = fd_funk_wksp( funk );
   fd_funk_rec_t * rec_map  = fd_funk_rec_map( funk, wksp );
@@ -1193,7 +1242,7 @@ fd_accounts_check_lthash( fd_funk_t     *  funk,
 
   fd_funk_txn_t ** txns = fd_alloca_check(sizeof(fd_funk_txn_t *), sizeof(fd_funk_txn_t *) * txn_cnt);
   if ( FD_UNLIKELY(NULL == txns))
-    FD_LOG_ERR(("Out of scratch space?"));
+    FD_LOG_ERR(( "Unable to allocate txn pointers" ));
 
   // Lay it flat to make it easier to walk backwards up the chain from
   // the root
@@ -1212,7 +1261,7 @@ fd_accounts_check_lthash( fd_funk_t     *  funk,
   int accounts_hash_slots = fd_ulong_find_msb(num_iter_accounts  ) + 1;
 
   FD_LOG_WARNING(("allocating memory for hash.  num_iter_accounts: %lu   slots: %d", num_iter_accounts, accounts_hash_slots));
-  void * hashmem = fd_valloc_malloc( valloc, accounts_hash_align(), accounts_hash_footprint(accounts_hash_slots));
+  void * hashmem = fd_spad_alloc( runtime_spad, accounts_hash_align(), accounts_hash_footprint(accounts_hash_slots));
   FD_LOG_WARNING(("initializing memory for hash"));
   accounts_hash_t * hash_map = accounts_hash_join(accounts_hash_new(hashmem, accounts_hash_slots));
 

--- a/src/flamenco/runtime/fd_hashes.h
+++ b/src/flamenco/runtime/fd_hashes.h
@@ -22,12 +22,12 @@ fd_update_hash_bank_tpool( fd_exec_slot_ctx_t * slot_ctx,
                            fd_hash_t *          hash,
                            ulong                signature_cnt,
                            fd_tpool_t *         tpool,
-                           fd_valloc_t          valloc );
+                           fd_spad_t *          runtime_spad );
 
 int
 fd_print_account_hashes( fd_exec_slot_ctx_t * slot_ctx,
                          fd_tpool_t *         tpool,
-                         fd_valloc_t          valloc );
+                         fd_spad_t *          runtime_spad );
 
 /* fd_hash_account is the method to compute the account
    hash.  It includes the following content:
@@ -60,11 +60,11 @@ fd_hash_account_current( uchar                      hash  [ static 32 ],
 /* Generate a complete accounts_hash of the entire account database. */
 
 int
-fd_accounts_hash( fd_funk_t          * funk,
-                  fd_slot_bank_t     * slot_bank,
-                  fd_valloc_t          valloc,
-                  fd_tpool_t         * tpool,
-                  fd_hash_t          * accounts_hash );
+fd_accounts_hash( fd_funk_t *      funk,
+                  fd_slot_bank_t * slot_bank,
+                  fd_tpool_t *     tpool,
+                  fd_hash_t *      accounts_hash,
+                  fd_spad_t *      runtime_spad );
 
 /* Generate a non-incremental hash of the entire account database, conditionally including in the epoch account hash. */
 int
@@ -72,7 +72,7 @@ fd_snapshot_hash( fd_exec_slot_ctx_t * slot_ctx,
                   fd_tpool_t *         tpool,
                   fd_hash_t *          accounts_hash,
                   uint                 check_hash,
-                  fd_valloc_t          valloc );
+                  fd_spad_t *          runtime_spad );
 
 /* Generate an incremental hash of the entire account database, conditionally including in the epoch account hash. */
 int
@@ -80,7 +80,7 @@ fd_snapshot_inc_hash( fd_exec_slot_ctx_t * slot_ctx,
                       fd_hash_t *          accounts_hash,
                       fd_funk_txn_t *      child_txn,
                       uint                 check_hash,
-                      fd_valloc_t          valloc );
+                      fd_spad_t *          spad );
 
 /* Generate a non-incremental hash of the entire account database, including
    the epoch account hash. It differs from fd_snapshot_hash in that this version
@@ -98,7 +98,7 @@ fd_snapshot_service_hash( fd_hash_t *       accounts_hash,
                           fd_epoch_bank_t * epoch_bank,
                           fd_funk_t *       funk,
                           fd_tpool_t *      tpool,
-                          fd_valloc_t       valloc );
+                          fd_spad_t *       runtime_spad );
 
 int
 fd_snapshot_service_inc_hash( fd_hash_t *                 accounts_hash,
@@ -108,13 +108,13 @@ fd_snapshot_service_inc_hash( fd_hash_t *                 accounts_hash,
                               fd_funk_t *                 funk,
                               fd_funk_rec_key_t const * * pubkeys,
                               ulong                       pubkeys_len,
-                              fd_valloc_t                 valloc );
+                              fd_spad_t *                 spad );
 
 void
-fd_accounts_check_lthash( fd_funk_t     *  funk,
+fd_accounts_check_lthash( fd_funk_t *      funk,
                           fd_funk_txn_t *  funk_txn,
                           fd_slot_bank_t * slot_bank,
-                          fd_valloc_t      valloc );
+                          fd_spad_t *      runtime_spad );
 
 void
 fd_calculate_epoch_accounts_hash_values(fd_exec_slot_ctx_t * slot_ctx);

--- a/src/flamenco/runtime/fd_rocksdb.c
+++ b/src/flamenco/runtime/fd_rocksdb.c
@@ -206,13 +206,18 @@ fd_rocksdb_get_meta( fd_rocksdb_t *   db,
   ulong ks = fd_ulong_bswap(slot);
   size_t vallen = 0;
 
-  char *err = NULL;
-  char *meta = rocksdb_get_cf(
-    db->db, db->ro, db->cf_handles[FD_ROCKSDB_CFIDX_META], (const char *) &ks, sizeof(ks), &vallen, &err);
+  char * err  = NULL;
+  char * meta = rocksdb_get_cf( db->db,
+                                db->ro,
+                                db->cf_handles[FD_ROCKSDB_CFIDX_META],
+                                (const char *) &ks,
+                                sizeof(ks),
+                                &vallen,
+                                &err );
 
-  if (NULL != err) {
+  if( NULL != err ) {
     FD_LOG_WARNING(( "%s", err ));
-    free (err);
+    free( err );
     return -2;
   }
 
@@ -223,8 +228,9 @@ fd_rocksdb_get_meta( fd_rocksdb_t *   db,
   ctx.data = meta;
   ctx.dataend = &meta[vallen];
   ctx.valloc  = valloc;
-  if ( fd_slot_meta_decode(m, &ctx) )
+  if( fd_slot_meta_decode( m, &ctx ) ) {
     FD_LOG_ERR(("fd_slot_meta_decode failed"));
+  }
 
   free(meta);
 
@@ -505,16 +511,16 @@ int
 fd_rocksdb_import_block_blockstore( fd_rocksdb_t *    db,
                                     fd_slot_meta_t *  m,
                                     fd_blockstore_t * blockstore,
-                                    int txnstatus,
-                                    const uchar *hash_override ) // How much effort should we go to here to confirm the size of the hash override?
-{
+                                    int               txnstatus,
+                                    const uchar *     hash_override,
+                                    fd_valloc_t       valloc ) {
   fd_blockstore_start_write( blockstore );
 
   ulong slot = m->slot;
   ulong start_idx = 0;
   ulong end_idx = m->received;
 
-  rocksdb_iterator_t* iter = rocksdb_create_iterator_cf(db->db, db->ro, db->cf_handles[FD_ROCKSDB_CFIDX_DATA_SHRED]);
+  rocksdb_iterator_t * iter = rocksdb_create_iterator_cf(db->db, db->ro, db->cf_handles[FD_ROCKSDB_CFIDX_DATA_SHRED]);
 
   char k[16];
   ulong slot_be = *((ulong *) &k[0]) = fd_ulong_bswap(slot);
@@ -635,11 +641,10 @@ fd_rocksdb_import_block_blockstore( fd_rocksdb_t *    db,
         FD_LOG_WARNING(( "rocksdb: %s", err ));
         free( err );
       } else {
-        fd_scratch_push();
         fd_bincode_decode_ctx_t decode = {
           .data    = res,
           .dataend = res + vallen,
-          .valloc  = fd_scratch_virtual(),
+          .valloc  = valloc,
         };
         fd_frozen_hash_versioned_t versioned;
         int decode_err = fd_frozen_hash_versioned_decode( &versioned, &decode );
@@ -650,7 +655,6 @@ fd_rocksdb_import_block_blockstore( fd_rocksdb_t *    db,
         fd_memcpy( block_map_entry->bank_hash.hash, versioned.inner.current.frozen_hash.hash, 32UL );
       cleanup:
         free( res );
-        fd_scratch_pop();
       }
     }
   }
@@ -747,9 +751,10 @@ fd_rocksdb_import_block_blockstore( fd_rocksdb_t *    db,
 
 int
 fd_rocksdb_import_block_shredcap( fd_rocksdb_t *               db,
-                                    fd_slot_meta_t *           metadata,
-                                    fd_io_buffered_ostream_t * ostream,
-                                    fd_io_buffered_ostream_t * bank_hash_ostream ) {
+                                  fd_slot_meta_t *             metadata,
+                                  fd_io_buffered_ostream_t *   ostream,
+                                  fd_io_buffered_ostream_t *   bank_hash_ostream,
+                                  fd_valloc_t                  valloc ) {
   ulong slot = metadata->slot;
 
   /* pre_slot_hdr_file_offset is the current offset within the file, but
@@ -905,11 +910,10 @@ fd_rocksdb_import_block_shredcap( fd_rocksdb_t *               db,
     FD_LOG_WARNING((" Could not get bank hash data due to err=%s",err ));
     free( err );
   } else {
-    fd_scratch_push();
     fd_bincode_decode_ctx_t decode = {
       .data    = res,
       .dataend = res + vallen,
-      .valloc  = fd_scratch_virtual(),
+      .valloc  = valloc,
     };
     fd_frozen_hash_versioned_t versioned;
     int decode_err = fd_frozen_hash_versioned_decode( &versioned, &decode );
@@ -923,7 +927,6 @@ fd_rocksdb_import_block_shredcap( fd_rocksdb_t *               db,
     fd_io_buffered_ostream_write( bank_hash_ostream, &bank_hash_entry, FD_SHREDCAP_BANK_HASH_ENTRY_FOOTPRINT );
   cleanup:
     free( res );
-    fd_scratch_pop();
   }
   return 0;
 }

--- a/src/flamenco/runtime/fd_rocksdb.h
+++ b/src/flamenco/runtime/fd_rocksdb.h
@@ -231,14 +231,16 @@ int
 fd_rocksdb_import_block_blockstore( fd_rocksdb_t *    db,
                                     fd_slot_meta_t *  m,
                                     fd_blockstore_t * blockstore,
-                                    int txnstatus,
-                                    const uchar *hash_override );
+                                    int               txnstatus,
+                                    const uchar *     hash_override,
+                                    fd_valloc_t       valloc );
 
 int
 fd_rocksdb_import_block_shredcap( fd_rocksdb_t *             db,
                                   fd_slot_meta_t *           metadata,
                                   fd_io_buffered_ostream_t * ostream,
-                                  fd_io_buffered_ostream_t * bank_hash_ostream );
+                                  fd_io_buffered_ostream_t * bank_hash_ostream,
+                                  fd_valloc_t                valloc );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -92,61 +92,73 @@ fd_runtime_compute_max_tick_height( ulong   ticks_per_slot,
 }
 
 void
-fd_runtime_update_leaders( fd_exec_slot_ctx_t * slot_ctx, ulong slot ) {
-  FD_SCRATCH_SCOPE_BEGIN {
-    fd_epoch_schedule_t schedule = slot_ctx->epoch_ctx->epoch_bank.epoch_schedule;
+fd_runtime_update_leaders( fd_exec_slot_ctx_t * slot_ctx, 
+                           ulong                slot,
+                           fd_spad_t *          runtime_spad ) {
 
-    FD_LOG_INFO(( "schedule->slots_per_epoch = %lu", schedule.slots_per_epoch ));
-    FD_LOG_INFO(( "schedule->leader_schedule_slot_offset = %lu", schedule.leader_schedule_slot_offset ));
-    FD_LOG_INFO(( "schedule->warmup = %d", schedule.warmup ));
-    FD_LOG_INFO(( "schedule->first_normal_epoch = %lu", schedule.first_normal_epoch ));
-    FD_LOG_INFO(( "schedule->first_normal_slot = %lu", schedule.first_normal_slot ));
+  FD_SPAD_FRAME_BEGIN( runtime_spad ) {
 
-    fd_vote_accounts_t const * epoch_vaccs = &slot_ctx->slot_bank.epoch_stakes;
+  fd_epoch_schedule_t schedule = slot_ctx->epoch_ctx->epoch_bank.epoch_schedule;
 
-    ulong epoch    = fd_slot_to_epoch( &schedule, slot, NULL );
-    ulong slot0    = fd_epoch_slot0( &schedule, epoch );
-    ulong slot_cnt = fd_epoch_slot_cnt( &schedule, epoch );
+  FD_LOG_INFO(( "schedule->slots_per_epoch = %lu", schedule.slots_per_epoch ));
+  FD_LOG_INFO(( "schedule->leader_schedule_slot_offset = %lu", schedule.leader_schedule_slot_offset ));
+  FD_LOG_INFO(( "schedule->warmup = %d", schedule.warmup ));
+  FD_LOG_INFO(( "schedule->first_normal_epoch = %lu", schedule.first_normal_epoch ));
+  FD_LOG_INFO(( "schedule->first_normal_slot = %lu", schedule.first_normal_slot ));
 
-    FD_LOG_INFO(( "starting rent list init" ));
+  fd_vote_accounts_t const * epoch_vaccs = &slot_ctx->slot_bank.epoch_stakes;
 
-    fd_acc_mgr_set_slots_per_epoch( slot_ctx, fd_epoch_slot_cnt(&schedule, epoch) );
-    FD_LOG_INFO(( "rent list init done" ));
+  ulong epoch    = fd_slot_to_epoch( &schedule, slot, NULL );
+  ulong slot0    = fd_epoch_slot0( &schedule, epoch );
+  ulong slot_cnt = fd_epoch_slot_cnt( &schedule, epoch );
 
-    ulong               vote_acc_cnt  = fd_vote_accounts_pair_t_map_size( epoch_vaccs->vote_accounts_pool, epoch_vaccs->vote_accounts_root );
-    fd_stake_weight_t * epoch_weights = fd_scratch_alloc( alignof(fd_stake_weight_t), vote_acc_cnt * sizeof(fd_stake_weight_t) );
-    if( FD_UNLIKELY( !epoch_weights ) ) {
-      FD_LOG_ERR(("fd_scratch_alloc() failed"));
+  FD_LOG_INFO(( "starting rent list init" ));
+
+  fd_acc_mgr_set_slots_per_epoch( slot_ctx, fd_epoch_slot_cnt( &schedule, epoch ) );
+  FD_LOG_INFO(( "rent list init done" ));
+
+  ulong               vote_acc_cnt  = fd_vote_accounts_pair_t_map_size( epoch_vaccs->vote_accounts_pool, epoch_vaccs->vote_accounts_root );
+  fd_stake_weight_t * epoch_weights = fd_spad_alloc( runtime_spad, alignof(fd_stake_weight_t), vote_acc_cnt * sizeof(fd_stake_weight_t) );
+  if( FD_UNLIKELY( !epoch_weights ) ) {
+    FD_LOG_ERR(( "fd_spad_alloc() failed" ));
+  }
+
+  ulong stake_weight_cnt = fd_stake_weights_by_node( epoch_vaccs, epoch_weights, runtime_spad );
+
+  if( FD_UNLIKELY( stake_weight_cnt == ULONG_MAX ) ) {
+    FD_LOG_ERR(( "fd_stake_weights_by_node() failed" ));
+  }
+
+  /* Derive leader schedule */
+
+  FD_LOG_INFO(( "stake_weight_cnt=%lu slot_cnt=%lu", stake_weight_cnt, slot_cnt ));
+  ulong epoch_leaders_footprint = fd_epoch_leaders_footprint( stake_weight_cnt, slot_cnt );
+  FD_LOG_INFO(( "epoch_leaders_footprint=%lu", epoch_leaders_footprint ));
+  if( FD_LIKELY( epoch_leaders_footprint ) ) {
+    if( FD_UNLIKELY( stake_weight_cnt>MAX_PUB_CNT ) ) {
+      FD_LOG_ERR(( "Stake weight count exceeded max" ));
+    }
+    if( FD_UNLIKELY( slot_cnt>MAX_SLOTS_CNT ) ) {
+      FD_LOG_ERR(( "Slot count exceeeded max" ));
     }
 
-    ulong stake_weight_cnt = fd_stake_weights_by_node(epoch_vaccs, epoch_weights);
-
-    if( FD_UNLIKELY( stake_weight_cnt == ULONG_MAX ) ) {
-      FD_LOG_ERR(("fd_stake_weights_by_node() failed"));
+    void *               epoch_leaders_mem = fd_exec_epoch_ctx_leaders( slot_ctx->epoch_ctx );
+    fd_epoch_leaders_t * leaders           = fd_epoch_leaders_join( fd_epoch_leaders_new( epoch_leaders_mem,
+                                                                                          epoch,
+                                                                                          slot0,
+                                                                                          slot_cnt,
+                                                                                          stake_weight_cnt,
+                                                                                          epoch_weights,
+                                                                                          0UL ) );
+    if( FD_UNLIKELY( !leaders ) ) {
+      FD_LOG_ERR(( "Unable to init and join fd_epoch_leaders" ));
     }
+  }
 
-    /* Derive leader schedule */
-
-    FD_LOG_INFO(( "stake_weight_cnt=%lu slot_cnt=%lu", stake_weight_cnt, slot_cnt ));
-    ulong epoch_leaders_footprint = fd_epoch_leaders_footprint( stake_weight_cnt, slot_cnt );
-    FD_LOG_INFO(( "epoch_leaders_footprint=%lu", epoch_leaders_footprint ));
-    if( FD_LIKELY( epoch_leaders_footprint ) ) {
-      FD_TEST( stake_weight_cnt <= MAX_PUB_CNT );
-      FD_TEST( slot_cnt <= MAX_SLOTS_CNT );
-      void *               epoch_leaders_mem = fd_exec_epoch_ctx_leaders( slot_ctx->epoch_ctx );
-      fd_epoch_leaders_t * leaders           = fd_epoch_leaders_join( fd_epoch_leaders_new( epoch_leaders_mem,
-                                                                                                       epoch,
-                                                                                                       slot0,
-                                                                                                       slot_cnt,
-                                                                                                       stake_weight_cnt,
-                                                                                                       epoch_weights,
-                                                                                                       0UL ) );
-      FD_TEST( leaders );
-    }
-  } FD_SCRATCH_SCOPE_END;
+  } FD_SPAD_FRAME_END;
 }
 
-/* Loads the sysvar cache. Expects acc_mgr, funk_txn, valloc to be non-NULL and valid. */
+/* Loads the sysvar cache. Expects acc_mgr, funk_txn to be non-NULL and valid. */
 int
 fd_runtime_sysvar_cache_load( fd_exec_slot_ctx_t * slot_ctx ) {
   if( FD_UNLIKELY( !slot_ctx->acc_mgr ) ) {
@@ -431,105 +443,109 @@ fd_validator_stake_pair_compare_before( fd_validator_stake_pair_t const * a,
 
 static void
 fd_runtime_distribute_rent_to_validators( fd_exec_slot_ctx_t * slot_ctx,
-                                          ulong                rent_to_be_distributed ) {
+                                          ulong                rent_to_be_distributed,
+                                          fd_spad_t *          runtime_spad ) {
 
-  FD_SCRATCH_SCOPE_BEGIN {
-    ulong total_staked = 0;
+  FD_SPAD_FRAME_BEGIN( runtime_spad ) {
 
-    fd_epoch_bank_t * epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
-    fd_vote_accounts_pair_t_mapnode_t *vote_accounts_pool = epoch_bank->stakes.vote_accounts.vote_accounts_pool;
-    fd_vote_accounts_pair_t_mapnode_t *vote_accounts_root = epoch_bank->stakes.vote_accounts.vote_accounts_root;
+  ulong total_staked = 0;
 
-    ulong num_validator_stakes = fd_vote_accounts_pair_t_map_size( vote_accounts_pool, vote_accounts_root );
-    fd_validator_stake_pair_t * validator_stakes = fd_scratch_alloc( 8UL, sizeof(fd_validator_stake_pair_t) * num_validator_stakes );
-    ulong i = 0;
+  fd_epoch_bank_t * epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
+  fd_vote_accounts_pair_t_mapnode_t *vote_accounts_pool = epoch_bank->stakes.vote_accounts.vote_accounts_pool;
+  fd_vote_accounts_pair_t_mapnode_t *vote_accounts_root = epoch_bank->stakes.vote_accounts.vote_accounts_root;
 
-    for( fd_vote_accounts_pair_t_mapnode_t *n = fd_vote_accounts_pair_t_map_minimum( vote_accounts_pool, vote_accounts_root );
-        n;
-        n = fd_vote_accounts_pair_t_map_successor( vote_accounts_pool, n ), i++) {
+  ulong num_validator_stakes = fd_vote_accounts_pair_t_map_size( vote_accounts_pool, vote_accounts_root );
+  fd_validator_stake_pair_t * validator_stakes = fd_spad_alloc( runtime_spad, 
+                                                                alignof(fd_validator_stake_pair_t),
+                                                                sizeof(fd_validator_stake_pair_t) * num_validator_stakes );
+  ulong i = 0;
 
-      validator_stakes[i].pubkey = n->elem.value.node_pubkey;
-      validator_stakes[i].stake = n->elem.stake;
+  for( fd_vote_accounts_pair_t_mapnode_t *n = fd_vote_accounts_pair_t_map_minimum( vote_accounts_pool, vote_accounts_root );
+      n;
+      n = fd_vote_accounts_pair_t_map_successor( vote_accounts_pool, n ), i++) {
 
-      total_staked += n->elem.stake;
+    validator_stakes[i].pubkey = n->elem.value.node_pubkey;
+    validator_stakes[i].stake = n->elem.stake;
 
+    total_staked += n->elem.stake;
+
+  }
+
+  sort_validator_stake_pair_inplace(validator_stakes, num_validator_stakes);
+
+  ulong validate_fee_collector_account = FD_FEATURE_ACTIVE(slot_ctx, validate_fee_collector_account);
+
+  ulong rent_distributed_in_initial_round = 0;
+
+  // We now do distribution, reusing the validator stakes array for the rent stares
+  for( i = 0; i < num_validator_stakes; i++ ) {
+    ulong staked = validator_stakes[i].stake;
+    ulong rent_share = (ulong)(((uint128)staked * (uint128)rent_to_be_distributed) / (uint128)total_staked);
+
+    validator_stakes[i].stake = rent_share;
+    rent_distributed_in_initial_round += rent_share;
+  }
+
+  ulong leftover_lamports = rent_to_be_distributed - rent_distributed_in_initial_round;
+
+  for( i = 0; i < num_validator_stakes; i++ ) {
+    if (leftover_lamports == 0) {
+      break;
     }
 
-    sort_validator_stake_pair_inplace(validator_stakes, num_validator_stakes);
+    /* Not using saturating sub because Agave doesn't.
+        https://github.com/anza-xyz/agave/blob/c88e6df566c5c17d71e9574785755683a8fb033a/runtime/src/bank/fee_distribution.rs#L207
+      */
+    leftover_lamports--;
+    validator_stakes[i].stake++;
+  }
 
-    ulong validate_fee_collector_account = FD_FEATURE_ACTIVE(slot_ctx, validate_fee_collector_account);
+  for( i = 0; i < num_validator_stakes; i++ ) {
+    ulong rent_to_be_paid = validator_stakes[i].stake;
 
-    ulong rent_distributed_in_initial_round = 0;
+    if( rent_to_be_paid > 0 ) {
+      fd_pubkey_t pubkey = validator_stakes[i].pubkey;
 
-    // We now do distribution, reusing the validator stakes array for the rent stares
-    for( i = 0; i < num_validator_stakes; i++ ) {
-      ulong staked = validator_stakes[i].stake;
-      ulong rent_share = (ulong)(((uint128)staked * (uint128)rent_to_be_distributed) / (uint128)total_staked);
+      FD_BORROWED_ACCOUNT_DECL(rec);
 
-      validator_stakes[i].stake = rent_share;
-      rent_distributed_in_initial_round += rent_share;
-    }
-
-    ulong leftover_lamports = rent_to_be_distributed - rent_distributed_in_initial_round;
-
-    for( i = 0; i < num_validator_stakes; i++ ) {
-      if (leftover_lamports == 0) {
-        break;
+      int err = fd_acc_mgr_view( slot_ctx->acc_mgr, slot_ctx->funk_txn, &pubkey, rec );
+      if( FD_UNLIKELY(err) ) {
+        FD_LOG_WARNING(( "cannot view pubkey %s. fd_acc_mgr_view failed (%d)", FD_BASE58_ENC_32_ALLOCA( &pubkey ), err ));
+        leftover_lamports = fd_ulong_sat_add( leftover_lamports, rent_to_be_paid );
+        continue;
       }
 
-      /* Not using saturating sub because Agave doesn't.
-         https://github.com/anza-xyz/agave/blob/c88e6df566c5c17d71e9574785755683a8fb033a/runtime/src/bank/fee_distribution.rs#L207
-       */
-      leftover_lamports--;
-      validator_stakes[i].stake++;
-    }
-
-    for( i = 0; i < num_validator_stakes; i++ ) {
-      ulong rent_to_be_paid = validator_stakes[i].stake;
-
-      if( rent_to_be_paid > 0 ) {
-        fd_pubkey_t pubkey = validator_stakes[i].pubkey;
-
-        FD_BORROWED_ACCOUNT_DECL(rec);
-
-        int err = fd_acc_mgr_view( slot_ctx->acc_mgr, slot_ctx->funk_txn, &pubkey, rec );
-        if( FD_UNLIKELY(err) ) {
-          FD_LOG_WARNING(( "cannot view pubkey %s. fd_acc_mgr_view failed (%d)", FD_BASE58_ENC_32_ALLOCA( &pubkey ), err ));
-          leftover_lamports = fd_ulong_sat_add( leftover_lamports, rent_to_be_paid );
-          continue;
-        }
-
-        if( FD_LIKELY( validate_fee_collector_account ) ) {
-          ulong burn;
-          if( FD_UNLIKELY( burn=fd_runtime_validate_fee_collector( slot_ctx, rec, rent_to_be_paid ) ) ) {
-            if( FD_UNLIKELY( burn!=rent_to_be_paid ) ) {
-              FD_LOG_ERR(( "expected burn(%lu)==rent_to_be_paid(%lu)", burn, rent_to_be_paid ));
-            }
-            leftover_lamports = fd_ulong_sat_add( leftover_lamports, rent_to_be_paid );
-            continue;
+      if( FD_LIKELY( validate_fee_collector_account ) ) {
+        ulong burn;
+        if( FD_UNLIKELY( burn=fd_runtime_validate_fee_collector( slot_ctx, rec, rent_to_be_paid ) ) ) {
+          if( FD_UNLIKELY( burn!=rent_to_be_paid ) ) {
+            FD_LOG_ERR(( "expected burn(%lu)==rent_to_be_paid(%lu)", burn, rent_to_be_paid ));
           }
-        }
-
-        err = fd_acc_mgr_modify( slot_ctx->acc_mgr, slot_ctx->funk_txn, &pubkey, 0, 0UL, rec );
-        if( FD_UNLIKELY(err) ) {
-          FD_LOG_WARNING(( "cannot modify pubkey %s. fd_acc_mgr_modify failed (%d)", FD_BASE58_ENC_32_ALLOCA( &pubkey ), err ));
           leftover_lamports = fd_ulong_sat_add( leftover_lamports, rent_to_be_paid );
           continue;
         }
-        rec->meta->info.lamports += rent_to_be_paid;
       }
-    } // end of iteration over validator_stakes
 
-    ulong old = slot_ctx->slot_bank.capitalization;
-    slot_ctx->slot_bank.capitalization = fd_ulong_sat_sub(slot_ctx->slot_bank.capitalization, leftover_lamports);
-    FD_LOG_DEBUG(( "fd_runtime_distribute_rent_to_validators: burn %lu, capitalization %lu->%lu ", leftover_lamports, old, slot_ctx->slot_bank.capitalization ));
+      err = fd_acc_mgr_modify( slot_ctx->acc_mgr, slot_ctx->funk_txn, &pubkey, 0, 0UL, rec );
+      if( FD_UNLIKELY(err) ) {
+        FD_LOG_WARNING(( "cannot modify pubkey %s. fd_acc_mgr_modify failed (%d)", FD_BASE58_ENC_32_ALLOCA( &pubkey ), err ));
+        leftover_lamports = fd_ulong_sat_add( leftover_lamports, rent_to_be_paid );
+        continue;
+      }
+      rec->meta->info.lamports += rent_to_be_paid;
+    }
+  } // end of iteration over validator_stakes
 
-  } FD_SCRATCH_SCOPE_END;
+  ulong old = slot_ctx->slot_bank.capitalization;
+  slot_ctx->slot_bank.capitalization = fd_ulong_sat_sub(slot_ctx->slot_bank.capitalization, leftover_lamports);
+  FD_LOG_DEBUG(( "fd_runtime_distribute_rent_to_validators: burn %lu, capitalization %lu->%lu ", leftover_lamports, old, slot_ctx->slot_bank.capitalization ));
+
+  } FD_SPAD_FRAME_END;
 }
 
 
 static void
-fd_runtime_distribute_rent( fd_exec_slot_ctx_t * slot_ctx ) {
+fd_runtime_distribute_rent( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_spad ) {
   ulong total_rent_collected = slot_ctx->slot_bank.collected_rent;
   fd_epoch_bank_t * epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
   ulong burned_portion = fd_runtime_calculate_rent_burn( total_rent_collected, &epoch_bank->rent );
@@ -541,7 +557,7 @@ fd_runtime_distribute_rent( fd_exec_slot_ctx_t * slot_ctx ) {
     return;
   }
 
-  fd_runtime_distribute_rent_to_validators( slot_ctx, rent_to_be_distributed );
+  fd_runtime_distribute_rent_to_validators( slot_ctx, rent_to_be_distributed, runtime_spad );
 }
 
 static int
@@ -561,13 +577,13 @@ fd_runtime_run_incinerator( fd_exec_slot_ctx_t * slot_ctx ) {
 }
 
 static void
-fd_runtime_freeze( fd_exec_slot_ctx_t * slot_ctx ) {
+fd_runtime_freeze( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_spad ) {
 
   /* https://github.com/anza-xyz/agave/blob/ced98f1ebe73f7e9691308afa757323003ff744f/runtime/src/bank.rs#L2820-L2821 */
   fd_runtime_collect_rent( slot_ctx );
   // self.collect_fees();
 
-  fd_sysvar_recent_hashes_update( slot_ctx );
+  fd_sysvar_recent_hashes_update( slot_ctx, runtime_spad );
 
   if( !FD_FEATURE_ACTIVE(slot_ctx, disable_fees_sysvar) )
     fd_sysvar_fees_update(slot_ctx);
@@ -630,7 +646,7 @@ fd_runtime_freeze( fd_exec_slot_ctx_t * slot_ctx ) {
     slot_ctx->slot_bank.collected_priority_fees = 0;
   }
 
-  fd_runtime_distribute_rent( slot_ctx );
+  fd_runtime_distribute_rent( slot_ctx, runtime_spad );
   fd_runtime_run_incinerator( slot_ctx );
 
   FD_LOG_DEBUG(( "fd_runtime_freeze: capitalization %lu ", slot_ctx->slot_bank.capitalization));
@@ -1065,7 +1081,7 @@ fd_runtime_finalize_txns_update_blockstore_meta( fd_exec_slot_ctx_t *         sl
 
 static int
 fd_runtime_block_sysvar_update_pre_execute( fd_exec_slot_ctx_t * slot_ctx,
-                                            fd_valloc_t          valloc ) {
+                                            fd_spad_t *          runtime_spad ) {
   // let (fee_rate_governor, fee_components_time_us) = measure_us!(
   //     FeeRateGovernor::new_derived(&parent.fee_rate_governor, parent.signature_count())
   // );
@@ -1076,7 +1092,7 @@ fd_runtime_block_sysvar_update_pre_execute( fd_exec_slot_ctx_t * slot_ctx,
 
   // TODO: move all these out to a fd_sysvar_update() call...
   long clock_update_time      = -fd_log_wallclock();
-  fd_sysvar_clock_update( slot_ctx, valloc );
+  fd_sysvar_clock_update( slot_ctx, runtime_spad );
   clock_update_time          += fd_log_wallclock();
   double clock_update_time_ms = (double)clock_update_time * 1e-6;
   FD_LOG_INFO(( "clock updated - slot: %lu, elapsed: %6.6f ms", slot_ctx->slot_bank.slot, clock_update_time_ms ));
@@ -1085,7 +1101,7 @@ fd_runtime_block_sysvar_update_pre_execute( fd_exec_slot_ctx_t * slot_ctx,
   }
   // It has to go into the current txn previous info but is not in slot 0
   if( slot_ctx->slot_bank.slot != 0 ) {
-    fd_sysvar_slot_hashes_update( slot_ctx, valloc );
+    fd_sysvar_slot_hashes_update( slot_ctx, runtime_spad );
   }
   fd_sysvar_last_restart_slot_update( slot_ctx );
 
@@ -1159,18 +1175,16 @@ fd_runtime_microblock_verify_ticks( fd_exec_slot_ctx_t *        slot_ctx,
   return FD_BLOCK_OK;
 }
 
-/*
-   A streaming version of this by batch is implemented in batch_verify_ticks.
-   This block_verify_ticks should only used for offline replay.
- */
+/* A streaming version of this by batch is implemented in batch_verify_ticks.
+   This block_verify_ticks should only used for offline replay. */
 ulong
 fd_runtime_block_verify_ticks( fd_blockstore_t * blockstore,
-                               ulong   slot,
-                               uchar * scratch_mem,
-                               ulong   scratch_sz,
-                               ulong   tick_height,
-                               ulong   max_tick_height,
-                               ulong   hashes_per_tick ) {
+                               ulong             slot,
+                               uchar *           block_data,
+                               ulong             block_data_sz,
+                               ulong             tick_height,
+                               ulong             max_tick_height,
+                               ulong             hashes_per_tick ) {
   ulong tick_count              = 0UL;
   ulong tick_hash_count         = 0UL;
   ulong has_trailing_entry      = 0UL;
@@ -1198,13 +1212,13 @@ fd_runtime_block_verify_ticks( fd_blockstore_t * blockstore,
     FD_TEST( fd_blockstore_batch_assemble( blockstore, 
                                            slot, 
                                            (uint) batch_idx, 
-                                           scratch_sz, 
-                                           scratch_mem, 
+                                           block_data_sz, 
+                                           block_data, 
                                            &batch_sz ) == FD_BLOCKSTORE_OK );
-    ulong micro_cnt = FD_LOAD( ulong, scratch_mem );
-    ulong       off = sizeof(ulong);
+    ulong micro_cnt = FD_LOAD( ulong, block_data );
+    ulong off       = sizeof(ulong);
     for( ulong i = 0UL; i < micro_cnt; i++ ){
-      fd_microblock_hdr_t const * hdr = fd_type_pun_const( ( scratch_mem + off ) );
+      fd_microblock_hdr_t const * hdr = fd_type_pun_const( ( block_data + off ) );
       off += sizeof(fd_microblock_hdr_t);
       tick_hash_count = fd_ulong_sat_add( tick_hash_count, hdr->hash_cnt );
       if( hdr->txn_cnt == 0UL ){
@@ -1227,7 +1241,7 @@ fd_runtime_block_verify_ticks( fd_blockstore_t * blockstore,
       uchar txn[FD_TXN_MAX_SZ];
       for( ulong j = 0; j < hdr->txn_cnt; j++ ) {
         ulong pay_sz = 0;
-        ulong txn_sz = fd_txn_parse_core( scratch_mem + off, fd_ulong_min( batch_sz - off, FD_TXN_MTU ), txn, NULL, &pay_sz );
+        ulong txn_sz = fd_txn_parse_core( block_data + off, fd_ulong_min( batch_sz - off, FD_TXN_MTU ), txn, NULL, &pay_sz );
         if( FD_UNLIKELY( !pay_sz ) ) FD_LOG_ERR(( "failed to parse transaction %lu in microblock %lu in slot %lu", j, i, slot ) );
         if( FD_UNLIKELY( !txn_sz || txn_sz > FD_TXN_MTU )) FD_LOG_ERR(( "failed to parse transaction %lu in microblock %lu in slot %lu. txn size: %lu", j, i, slot, txn_sz ));
         off += pay_sz;
@@ -1274,7 +1288,8 @@ fd_runtime_block_verify_ticks( fd_blockstore_t * blockstore,
 
 int
 fd_runtime_block_execute_prepare( fd_exec_slot_ctx_t * slot_ctx,
-                                  fd_valloc_t          valloc ) {
+                                  fd_spad_t *          runtime_spad ) {
+
   if( slot_ctx->slot_bank.slot != 0UL ) {
     fd_blockstore_start_write( slot_ctx->blockstore );
     fd_blockstore_block_height_update( slot_ctx->blockstore,
@@ -1295,7 +1310,7 @@ fd_runtime_block_execute_prepare( fd_exec_slot_ctx_t * slot_ctx,
   slot_ctx->total_compute_units_used           = 0UL;
 
   fd_funk_start_write( slot_ctx->acc_mgr->funk );
-  int result = fd_runtime_block_sysvar_update_pre_execute( slot_ctx, valloc );
+  int result = fd_runtime_block_sysvar_update_pre_execute( slot_ctx, runtime_spad );
   fd_funk_end_write( slot_ctx->acc_mgr->funk );
   if( FD_UNLIKELY( result != 0 ) ) {
     FD_LOG_WARNING(("updating sysvars failed"));
@@ -1316,22 +1331,29 @@ fd_runtime_block_execute_finalize_tpool( fd_exec_slot_ctx_t *    slot_ctx,
                                          fd_capture_ctx_t *      capture_ctx,
                                          fd_block_info_t const * block_info,
                                          fd_tpool_t *            tpool,
-                                         fd_valloc_t             valloc ) {
+                                         fd_spad_t *             runtime_spad ) {
+
   fd_funk_start_write( slot_ctx->acc_mgr->funk );
 
-  fd_sysvar_slot_history_update( slot_ctx, valloc );
+  fd_sysvar_slot_history_update( slot_ctx, runtime_spad );
 
   /* This slot is now "frozen" and can't be changed anymore. */
-  fd_runtime_freeze( slot_ctx );
+  fd_runtime_freeze( slot_ctx, runtime_spad );
 
-  int result = fd_bpf_scan_and_create_bpf_program_cache_entry_tpool( slot_ctx, slot_ctx->funk_txn, tpool );
+  int result = fd_bpf_scan_and_create_bpf_program_cache_entry_tpool( slot_ctx, slot_ctx->funk_txn, tpool, runtime_spad );
   if( FD_UNLIKELY( result ) ) {
     FD_LOG_WARNING(( "update bpf program cache failed" ));
     fd_funk_end_write( slot_ctx->acc_mgr->funk );
     return result;
   }
 
-  result = fd_update_hash_bank_tpool( slot_ctx, capture_ctx, &slot_ctx->slot_bank.banks_hash, block_info->signature_cnt, tpool, valloc );
+  result = fd_update_hash_bank_tpool( slot_ctx,
+                                      capture_ctx,
+                                      &slot_ctx->slot_bank.banks_hash,
+                                      block_info->signature_cnt,
+                                      tpool,
+                                      runtime_spad );
+
   if( FD_UNLIKELY( result!=FD_EXECUTOR_INSTR_SUCCESS ) ) {
     FD_LOG_WARNING(( "hashing bank failed" ));
     fd_funk_end_write( slot_ctx->acc_mgr->funk );
@@ -1366,14 +1388,15 @@ int
 fd_runtime_prepare_txns_start( fd_exec_slot_ctx_t *         slot_ctx,
                                fd_execute_txn_task_info_t * task_info,
                                fd_txn_p_t *                 txns,
-                               ulong                        txn_cnt ) {
+                               ulong                        txn_cnt,
+                               fd_spad_t *                  runtime_spad ) {
   int res = 0;
   /* Loop across transactions */
   for (ulong txn_idx = 0; txn_idx < txn_cnt; txn_idx++) {
     fd_txn_p_t * txn = &txns[txn_idx];
 
     /* Allocate/setup transaction context and task infos */
-    task_info[txn_idx].txn_ctx      = fd_valloc_malloc( fd_scratch_virtual(), FD_EXEC_TXN_CTX_ALIGN, FD_EXEC_TXN_CTX_FOOTPRINT );
+    task_info[txn_idx].txn_ctx      = fd_spad_alloc( runtime_spad, FD_EXEC_TXN_CTX_ALIGN, FD_EXEC_TXN_CTX_FOOTPRINT );
     fd_exec_txn_ctx_t * txn_ctx     = task_info[txn_idx].txn_ctx;
     task_info[txn_idx].exec_res     = 0;
     task_info[txn_idx].txn          = txn;
@@ -1501,6 +1524,10 @@ fd_runtime_finalize_txn( fd_exec_slot_ctx_t *         slot_ctx,
                          fd_capture_ctx_t *           capture_ctx,
                          fd_execute_txn_task_info_t * task_info ) {
 
+  /* TODO: Allocations should probably not be made out of the exec_spad in this
+     function. If they are, the size of the data needs to be accounted for in
+     the calculation of the bound of the spad as defined in fd_runtime.h. */
+
   FD_ATOMIC_FETCH_AND_ADD( &slot_ctx->slot_bank.collected_execution_fees, task_info->txn_ctx->execution_fee  );
   FD_ATOMIC_FETCH_AND_ADD( &slot_ctx->slot_bank.collected_priority_fees,  task_info->txn_ctx->priority_fee   );
   FD_ATOMIC_FETCH_AND_ADD( &slot_ctx->slot_bank.collected_rent,           task_info->txn_ctx->collected_rent );
@@ -1526,17 +1553,17 @@ fd_runtime_finalize_txn( fd_exec_slot_ctx_t *         slot_ctx,
 
   if( slot_ctx->status_cache ) {
     fd_txncache_insert_t status_insert;
-    uchar result;
+    uchar                result;
 
     result = exec_txn_err == 0 ? 1 : 0;
     fd_txncache_insert_t * curr_insert = &status_insert;
     curr_insert->blockhash = ((uchar *)txn_ctx->_txn_raw->raw + txn_ctx->txn_descriptor->recent_blockhash_off);
-    curr_insert->slot = slot_ctx->slot_bank.slot;
-    fd_hash_t * hash = &txn_ctx->blake_txn_msg_hash;
-    curr_insert->txnhash = hash->uc;
-    curr_insert->result = &result;
-    if( !fd_txncache_insert_batch( slot_ctx->status_cache, &status_insert, 1UL ) ) {
-      FD_LOG_DEBUG(("Status cache is full, this should not be possible"));
+    curr_insert->slot      = slot_ctx->slot_bank.slot;
+    fd_hash_t * hash       = &txn_ctx->blake_txn_msg_hash;
+    curr_insert->txnhash   = hash->uc;
+    curr_insert->result    = &result;
+    if( FD_UNLIKELY( !fd_txncache_insert_batch( slot_ctx->status_cache, &status_insert, 1UL ) ) ) {
+      FD_LOG_ERR(( "Status cache is full, this should not be possible" ));
     }
   }
 
@@ -1592,7 +1619,7 @@ fd_runtime_finalize_txn( fd_exec_slot_ctx_t *         slot_ctx,
               .valloc  = fd_spad_virtual( txn_ctx->spad ) };
 
           int err = fd_vote_state_versioned_decode( vsv, &decode_vsv );
-          if( err ) break; /* out of scratch scope */
+          if( err ) break; /* out of spad scope */
 
           fd_vote_block_timestamp_t const * ts = NULL;
           switch( vsv->discriminant ) {
@@ -1609,8 +1636,7 @@ fd_runtime_finalize_txn( fd_exec_slot_ctx_t *         slot_ctx,
             __builtin_unreachable();
           }
 
-          fd_valloc_t valloc = fd_spad_virtual( txn_ctx->spad );
-          fd_vote_record_timestamp_vote_with_slot( slot_ctx, acc_rec->pubkey, ts->timestamp, ts->slot, valloc );
+          fd_vote_record_timestamp_vote_with_slot( slot_ctx, acc_rec->pubkey, ts->timestamp, ts->slot, txn_ctx->spad );
         } FD_SPAD_FRAME_END;
         fd_funk_end_write( slot_ctx->acc_mgr->funk );
       }
@@ -1650,19 +1676,19 @@ fd_runtime_finalize_txn( fd_exec_slot_ctx_t *         slot_ctx,
 
 static int
 fd_runtime_prepare_and_execute_txn( fd_exec_slot_ctx_t const *   slot_ctx,
-                                    fd_spad_t *                  spad,
+                                    fd_spad_t *                  exec_spad,
                                     fd_txn_p_t *                 txn,
                                     fd_execute_txn_task_info_t * task_info ) {
 
   int res = 0;
 
-  task_info->txn_ctx              = fd_valloc_malloc( fd_scratch_virtual(), FD_EXEC_TXN_CTX_ALIGN, FD_EXEC_TXN_CTX_FOOTPRINT );
+  task_info->txn_ctx              = fd_spad_alloc( exec_spad, FD_EXEC_TXN_CTX_ALIGN, FD_EXEC_TXN_CTX_FOOTPRINT );
   fd_exec_txn_ctx_t * txn_ctx     = task_info->txn_ctx;
   task_info->exec_res             = -1;
   task_info->txn                  = txn;
   fd_txn_t const * txn_descriptor = (fd_txn_t const *) txn->_;
 
-  task_info->txn_ctx->spad = spad;
+  task_info->txn_ctx->spad = exec_spad;
 
   fd_rawtxn_b_t raw_txn = { .raw = txn->payload, .txn_sz = (ushort)txn->payload_sz };
 
@@ -1686,7 +1712,7 @@ fd_runtime_prepare_and_execute_txn( fd_exec_slot_ctx_t const *   slot_ctx,
 
   /* Execute */
   task_info->txn->flags |= FD_TXN_P_FLAGS_EXECUTE_SUCCESS;
-  task_info->exec_res = fd_execute_txn( task_info->txn_ctx );
+  task_info->exec_res    = fd_execute_txn( task_info->txn_ctx );
 
   if( task_info->exec_res==0 ) {
     fd_txn_reclaim_accounts( task_info->txn_ctx );
@@ -1707,7 +1733,6 @@ fd_runtime_prepare_execute_finalize_txn( fd_exec_slot_ctx_t *         slot_ctx,
                                          fd_txn_p_t *                 txn,
                                          fd_execute_txn_task_info_t * task_info ) {
   FD_SPAD_FRAME_BEGIN( spad ) {
-  FD_SCRATCH_SCOPE_BEGIN {
 
   int res = fd_runtime_prepare_and_execute_txn( slot_ctx, spad, txn, task_info );
 
@@ -1715,7 +1740,6 @@ fd_runtime_prepare_execute_finalize_txn( fd_exec_slot_ctx_t *         slot_ctx,
 
   return res;
 
-  } FD_SCRATCH_SCOPE_END;
   } FD_SPAD_FRAME_END;
 }
 
@@ -1725,30 +1749,31 @@ fd_runtime_prepare_execute_finalize_txn( fd_exec_slot_ctx_t *         slot_ctx,
 
 int
 fd_runtime_process_txns( fd_exec_slot_ctx_t * slot_ctx,
-                         fd_spad_t *          spad,
+                         fd_spad_t *          exec_spad,
                          fd_capture_ctx_t *   capture_ctx,
                          fd_txn_p_t *         txns,
                          ulong                txn_cnt ) {
 
-  FD_SCRATCH_SCOPE_BEGIN {
-    fd_execute_txn_task_info_t * task_infos = fd_scratch_alloc( 8, txn_cnt * sizeof(fd_execute_txn_task_info_t));
+  /* TODO: This probably should not get allocated out of the exec_spad and should
+     be allocated from the runtime_spad. */
+  fd_execute_txn_task_info_t * task_infos = fd_spad_alloc( exec_spad, 
+                                                           FD_SPAD_ALIGN,
+                                                           txn_cnt * sizeof(fd_execute_txn_task_info_t));
 
-    for( ulong i=0UL; i<txn_cnt; i++ ) {
-      txns[i].flags = FD_TXN_P_FLAGS_SANITIZE_SUCCESS;
+  for( ulong i=0UL; i<txn_cnt; i++ ) {
+    txns[i].flags = FD_TXN_P_FLAGS_SANITIZE_SUCCESS;
+  }
+
+  for( ulong i=0UL; i<txn_cnt; i++ ) {
+    int err = fd_runtime_prepare_execute_finalize_txn( slot_ctx, exec_spad, capture_ctx, &txns[i], &task_infos[i] );
+    if( FD_UNLIKELY( err ) ) {
+      return err;
     }
+  }
 
-    for( ulong i=0UL; i<txn_cnt; i++ ) {
-      int res = fd_runtime_prepare_execute_finalize_txn( slot_ctx, spad, capture_ctx, &txns[i], &task_infos[i] );
-      if ( FD_UNLIKELY( res != 0 ) ){
-        return res;
-      }
-    }
+  FD_ATOMIC_FETCH_AND_ADD( &slot_ctx->slot_bank.transaction_count, txn_cnt );
 
-    FD_ATOMIC_FETCH_AND_ADD( &slot_ctx->slot_bank.transaction_count, txn_cnt );
-
-    return 0;
-  } FD_SCRATCH_SCOPE_END;
-
+  return 0;
 }
 
 /* fd_runtime_execute_txn_task is a tpool wrapper around transaction execution. */
@@ -1818,16 +1843,22 @@ fd_runtime_execute_txn_task( void * tpool,
 
 static void FD_FN_UNUSED
 fd_txn_sigverify_task( void *tpool,
-                                       ulong t0 FD_PARAM_UNUSED, ulong t1 FD_PARAM_UNUSED,
-                                       void *args FD_PARAM_UNUSED,
-                                       void *reduce FD_PARAM_UNUSED, ulong stride FD_PARAM_UNUSED,
-                                       ulong l0 FD_PARAM_UNUSED, ulong l1 FD_PARAM_UNUSED,
-                                       ulong m0, ulong m1 FD_PARAM_UNUSED,
-                                       ulong n0 FD_PARAM_UNUSED, ulong n1 FD_PARAM_UNUSED ) {
+                       ulong t0 FD_PARAM_UNUSED, ulong t1 FD_PARAM_UNUSED,
+                       void *args FD_PARAM_UNUSED,
+                       void *reduce FD_PARAM_UNUSED, ulong stride FD_PARAM_UNUSED,
+                       ulong l0 FD_PARAM_UNUSED, ulong l1 FD_PARAM_UNUSED,
+                       ulong m0, ulong m1 FD_PARAM_UNUSED,
+                       ulong n0 FD_PARAM_UNUSED, ulong n1 FD_PARAM_UNUSED ) {
   fd_execute_txn_task_info_t * task_info = (fd_execute_txn_task_info_t *)tpool + m0;
 
+  ulong tile_idx = fd_tile_idx();
+  task_info->txn_ctx->spad = task_info->spads[ tile_idx ];
+  if( FD_UNLIKELY( !task_info->txn_ctx->spad ) ) {
+    FD_LOG_ERR(("spad is NULL"));
+  }
+
   /* the txn failed sanitize sometime earlier */
-  if( FD_UNLIKELY( !( task_info->txn->flags & FD_TXN_P_FLAGS_SANITIZE_SUCCESS ) ) ) {
+  if( FD_UNLIKELY( !(task_info->txn->flags & FD_TXN_P_FLAGS_SANITIZE_SUCCESS) ) ) {
     return;
   }
 
@@ -1857,8 +1888,6 @@ fd_txn_prep_and_exec_task( void  *tpool,
      tiles and tpool threads at the time of this comment. Eventually, this will
      change and the transaction context's spad will not be queried by tile
      index as every tile will correspond to one CPU core. */
-  ulong tile_idx = fd_tile_idx();
-  task_info->txn_ctx->spad = task_info->spads[ tile_idx ];
   if( FD_UNLIKELY( !task_info->txn_ctx->spad ) ) {
     FD_LOG_ERR(("spad is NULL"));
   }
@@ -1889,6 +1918,7 @@ fd_runtime_verify_txn_signatures_tpool( fd_execute_txn_task_info_t * task_info,
                                         ulong                        txn_cnt,
                                         fd_tpool_t *                 tpool ) {
   int res = 0;
+
   fd_tpool_exec_all_rrobin( tpool, 0, fd_tpool_worker_cnt( tpool ), fd_txn_sigverify_task, task_info, NULL, NULL, 1, 0, txn_cnt );
   for( ulong txn_idx = 0; txn_idx < txn_cnt; txn_idx++ ) {
     if( FD_UNLIKELY( !( task_info[txn_idx].txn->flags & FD_TXN_P_FLAGS_SANITIZE_SUCCESS ) ) ) {
@@ -1908,18 +1938,18 @@ fd_runtime_prep_and_exec_txns_tpool( fd_exec_slot_ctx_t *         slot_ctx,
                                      ulong                        txn_cnt,
                                      fd_tpool_t *                 tpool ) {
   int res = 0;
-  FD_SCRATCH_SCOPE_BEGIN {
 
-    fd_tpool_exec_all_rrobin( tpool, 0, fd_tpool_worker_cnt( tpool ), fd_txn_prep_and_exec_task, task_info, slot_ctx, task_info->txn_ctx->capture_ctx, 1, 0, txn_cnt );
+  fd_tpool_exec_all_rrobin( tpool, 0, fd_tpool_worker_cnt( tpool ), 
+                            fd_txn_prep_and_exec_task, task_info, slot_ctx,
+                            task_info->txn_ctx->capture_ctx, 1, 0, txn_cnt );
 
-    for( ulong txn_idx=0UL; txn_idx<txn_cnt; txn_idx++ ) {
-      if( FD_UNLIKELY( !( task_info[txn_idx].txn->flags & FD_TXN_P_FLAGS_SANITIZE_SUCCESS ) ) ) {
-        res |= task_info[txn_idx].exec_res;
-        continue;
-      }
+  for( ulong txn_idx=0UL; txn_idx<txn_cnt; txn_idx++ ) {
+    if( FD_UNLIKELY( !( task_info[txn_idx].txn->flags & FD_TXN_P_FLAGS_SANITIZE_SUCCESS ) ) ) {
+      res |= task_info[txn_idx].exec_res;
+      continue;
     }
+  }
 
-  } FD_SCRATCH_SCOPE_END;
   return res;
 }
 
@@ -1931,8 +1961,10 @@ fd_runtime_finalize_txns_tpool( fd_exec_slot_ctx_t *         slot_ctx,
                                 fd_capture_ctx_t *           capture_ctx,
                                 fd_execute_txn_task_info_t * task_info,
                                 ulong                        txn_cnt,
-                                fd_tpool_t *                 tpool ) {
-  FD_SCRATCH_SCOPE_BEGIN {
+                                fd_tpool_t *                 tpool,
+                                fd_spad_t *                  runtime_spad ) {
+
+    FD_SPAD_FRAME_BEGIN( runtime_spad ) {
 
     /* Store transaction metadata, including logs */
     fd_runtime_finalize_txns_update_blockstore_meta( slot_ctx, task_info, txn_cnt );
@@ -1942,11 +1974,13 @@ fd_runtime_finalize_txns_tpool( fd_exec_slot_ctx_t *         slot_ctx,
     ulong                  num_cache_txns = 0UL;
 
     if( FD_LIKELY( slot_ctx->status_cache ) ) {
-      status_insert = fd_scratch_alloc( alignof(fd_txncache_insert_t), txn_cnt * sizeof(fd_txncache_insert_t) );
-      results       = fd_scratch_alloc( alignof(uchar), txn_cnt * sizeof(uchar) );
+      status_insert = fd_spad_alloc( runtime_spad, alignof(fd_txncache_insert_t), txn_cnt * sizeof(fd_txncache_insert_t) );
+      results       = fd_spad_alloc( runtime_spad, FD_SPAD_ALIGN, txn_cnt * sizeof(uchar) );
     }
 
-    fd_borrowed_account_t * * accounts_to_save         = fd_scratch_alloc( 8UL, MAX_TX_ACCOUNT_LOCKS * txn_cnt * sizeof(fd_borrowed_account_t *) );
+    fd_borrowed_account_t * * accounts_to_save         = fd_spad_alloc( runtime_spad,
+                                                                        FD_SPAD_ALIGN,
+                                                                        MAX_TX_ACCOUNT_LOCKS * txn_cnt * sizeof(fd_borrowed_account_t*) );
     ulong                     acc_idx                  = 0UL;
     ulong                     nonvote_txn_count        = 0UL;
     ulong                     failed_txn_count         = 0UL;
@@ -2042,7 +2076,7 @@ fd_runtime_finalize_txns_tpool( fd_exec_slot_ctx_t *         slot_ctx,
                   .valloc  = fd_spad_virtual( txn_ctx->spad ) };
 
               int err = fd_vote_state_versioned_decode( vsv, &decode_vsv );
-              if( err ) break; /* out of scratch scope */
+              if( err ) break; /* out of spad scope */
 
               fd_vote_block_timestamp_t const * ts = NULL;
               switch( vsv->discriminant ) {
@@ -2059,8 +2093,11 @@ fd_runtime_finalize_txns_tpool( fd_exec_slot_ctx_t *         slot_ctx,
                 __builtin_unreachable();
               }
 
-              fd_valloc_t valloc = fd_spad_virtual( txn_ctx->spad );
-              fd_vote_record_timestamp_vote_with_slot( slot_ctx, acc_rec->pubkey, ts->timestamp, ts->slot, valloc );
+              fd_vote_record_timestamp_vote_with_slot( slot_ctx,
+                                                       acc_rec->pubkey,
+                                                       ts->timestamp,
+                                                       ts->slot,
+                                                       txn_ctx->spad );
             } FD_SPAD_FRAME_END;
           }
 
@@ -2083,8 +2120,12 @@ fd_runtime_finalize_txns_tpool( fd_exec_slot_ctx_t *         slot_ctx,
 
     /* All the accounts have been accumulated and can be saved */
 
-    // TODO: we need to use the txn ctx funk_txn, valloc, etc.
-    int err = fd_acc_mgr_save_many_tpool( slot_ctx->acc_mgr, slot_ctx->funk_txn, accounts_to_save, acc_idx, tpool );
+    int err = fd_acc_mgr_save_many_tpool( slot_ctx->acc_mgr,
+                                          slot_ctx->funk_txn,
+                                          accounts_to_save,
+                                          acc_idx,
+                                          tpool,
+                                          runtime_spad );
     if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
       FD_LOG_ERR(( "failed to save edits to accounts" ));
       return -1;
@@ -2097,7 +2138,8 @@ fd_runtime_finalize_txns_tpool( fd_exec_slot_ctx_t *         slot_ctx,
     }
 
   return 0;
-  } FD_SCRATCH_SCOPE_END;
+  
+  } FD_SPAD_FRAME_END;
 }
 
 struct fd_pubkey_map_node {
@@ -2146,64 +2188,68 @@ fd_runtime_generate_wave( fd_execute_txn_task_info_t * task_infos,
                           ulong *                      _incomplete_txn_idxs_cnt,
                           ulong *                      _incomplete_accounts_cnt,
                           fd_execute_txn_task_info_t * wave_task_infos,
-                          ulong *                      _wave_task_infos_cnt ) {
-  FD_SCRATCH_SCOPE_BEGIN {
-    int                    lg_slot_cnt  = fd_ulong_find_msb( prev_accounts_cnt ) + 1;
-    void *                 read_map_mem = fd_scratch_alloc( fd_pubkey_map_align(), fd_pubkey_map_footprint( lg_slot_cnt ) );
-    fd_pubkey_map_node_t * read_map     = fd_pubkey_map_join( fd_pubkey_map_new( read_map_mem, lg_slot_cnt ) );
+                          ulong *                      _wave_task_infos_cnt,
+                          fd_spad_t *                  runtime_spad ) {
 
-    void *                 write_map_mem = fd_scratch_alloc( fd_pubkey_map_align(), fd_pubkey_map_footprint( lg_slot_cnt ) );
-    fd_pubkey_map_node_t * write_map     = fd_pubkey_map_join( fd_pubkey_map_new( write_map_mem, lg_slot_cnt ) );
+  FD_SPAD_FRAME_BEGIN( runtime_spad ) {
 
-    ulong incomplete_txn_idxs_cnt = 0UL;
-    ulong wave_task_infos_cnt     = 0UL;
-    ulong accounts_in_wave        = 0UL;
-    for( ulong i=0UL; i<prev_incomplete_txn_idxs_cnt; i++ ) {
-      ulong txn_idx           = prev_incomplete_txn_idxs[i];
-      uint  is_executable_now = 1;
-      fd_execute_txn_task_info_t * task_info = &task_infos[txn_idx];
+  int                    lg_slot_cnt  = fd_ulong_find_msb( prev_accounts_cnt ) + 1;
+  void *                 read_map_mem = fd_spad_alloc( runtime_spad, fd_pubkey_map_align(), fd_pubkey_map_footprint( lg_slot_cnt ) );
+  fd_pubkey_map_node_t * read_map     = fd_pubkey_map_join( fd_pubkey_map_new( read_map_mem, lg_slot_cnt ) );
 
-      for( ulong j=0UL; j<task_info->txn_ctx->accounts_cnt; j++ ) {
-        ulong h = fd_hash( 0UL, &task_info->txn_ctx->accounts[j], sizeof( fd_pubkey_t ) );
-        if( fd_pubkey_map_query( write_map, h, NULL ) != NULL ) {
+  void *                 write_map_mem = fd_spad_alloc( runtime_spad, fd_pubkey_map_align(), fd_pubkey_map_footprint( lg_slot_cnt ) );
+  fd_pubkey_map_node_t * write_map     = fd_pubkey_map_join( fd_pubkey_map_new( write_map_mem, lg_slot_cnt ) );
+
+  ulong incomplete_txn_idxs_cnt = 0UL;
+  ulong wave_task_infos_cnt     = 0UL;
+  ulong accounts_in_wave        = 0UL;
+  for( ulong i=0UL; i<prev_incomplete_txn_idxs_cnt; i++ ) {
+    ulong txn_idx           = prev_incomplete_txn_idxs[i];
+    uint  is_executable_now = 1;
+    fd_execute_txn_task_info_t * task_info = &task_infos[txn_idx];
+
+    for( ulong j=0UL; j<task_info->txn_ctx->accounts_cnt; j++ ) {
+      ulong h = fd_hash( 0UL, &task_info->txn_ctx->accounts[j], sizeof( fd_pubkey_t ) );
+      if( fd_pubkey_map_query( write_map, h, NULL ) != NULL ) {
+        is_executable_now = 0;
+        break;
+      }
+      if( fd_txn_account_is_writable_idx( task_info->txn_ctx, (int)j ) ) {
+        if( fd_pubkey_map_query( read_map, h, NULL ) != NULL ) {
           is_executable_now = 0;
           break;
         }
-        if( fd_txn_account_is_writable_idx( task_info->txn_ctx, (int)j ) ) {
-          if( fd_pubkey_map_query( read_map, h, NULL ) != NULL ) {
-            is_executable_now = 0;
-            break;
-          }
-        }
       }
-
-      if( !is_executable_now ) {
-        incomplete_txn_idxs[incomplete_txn_idxs_cnt++] = txn_idx;
-      } else {
-        wave_task_infos[wave_task_infos_cnt++] = *task_info;
-      }
-
-      /* Include txn in wave */
-      for( ulong j=0UL; j<task_info->txn_ctx->accounts_cnt; j++ ) {
-        if( fd_txn_account_is_writable_idx( task_info->txn_ctx, (int)j ) ) {
-          uint ins_res = fd_pubkey_map_insert_if_not_in( write_map, task_info->txn_ctx->accounts[j] );
-          if( ins_res==2U ) {
-            accounts_in_wave++;
-          }
-        } else {
-          uint ins_res = fd_pubkey_map_insert_if_not_in( read_map, task_info->txn_ctx->accounts[j] );
-          if( ins_res==2UL ) {
-            accounts_in_wave++;
-          }
-        }
-      }
-
     }
 
-    *_incomplete_txn_idxs_cnt = incomplete_txn_idxs_cnt;
-    *_incomplete_accounts_cnt = prev_accounts_cnt - accounts_in_wave;
-    *_wave_task_infos_cnt     = wave_task_infos_cnt;
-  } FD_SCRATCH_SCOPE_END;
+    if( !is_executable_now ) {
+      incomplete_txn_idxs[incomplete_txn_idxs_cnt++] = txn_idx;
+    } else {
+      wave_task_infos[wave_task_infos_cnt++] = *task_info;
+    }
+
+    /* Include txn in wave */
+    for( ulong j=0UL; j<task_info->txn_ctx->accounts_cnt; j++ ) {
+      if( fd_txn_account_is_writable_idx( task_info->txn_ctx, (int)j ) ) {
+        uint ins_res = fd_pubkey_map_insert_if_not_in( write_map, task_info->txn_ctx->accounts[j] );
+        if( ins_res==2U ) {
+          accounts_in_wave++;
+        }
+      } else {
+        uint ins_res = fd_pubkey_map_insert_if_not_in( read_map, task_info->txn_ctx->accounts[j] );
+        if( ins_res==2UL ) {
+          accounts_in_wave++;
+        }
+      }
+    }
+
+  }
+
+  *_incomplete_txn_idxs_cnt = incomplete_txn_idxs_cnt;
+  *_incomplete_accounts_cnt = prev_accounts_cnt - accounts_in_wave;
+  *_wave_task_infos_cnt     = wave_task_infos_cnt;
+
+  } FD_SPAD_FRAME_END;
 }
 
 /* NOTE: Don't mess with this call without updating the transaction fuzzing harness appropriately!
@@ -2218,8 +2264,9 @@ fd_runtime_process_txns_in_waves_tpool( fd_exec_slot_ctx_t * slot_ctx,
                                         fd_txn_p_t *         all_txns,
                                         ulong                total_txn_cnt,
                                         fd_tpool_t *         tpool,
-                                        fd_spad_t * *        spads,
-                                        ulong                spad_cnt ) {
+                                        fd_spad_t * *        exec_spads,
+                                        ulong                exec_spad_cnt,
+                                        fd_spad_t *          runtime_spad ) {
   int dump_txn = capture_ctx && slot_ctx->slot_bank.slot >= capture_ctx->dump_proto_start_slot && capture_ctx->dump_txn_to_pb;
 
   /* As a note, the batch size of 128 is a relatively arbitrary number. The
@@ -2238,21 +2285,20 @@ fd_runtime_process_txns_in_waves_tpool( fd_exec_slot_ctx_t * slot_ctx,
 
   int res = 0;
   for( ulong i=0UL; i<num_batches; i++ ) {
-    FD_SCRATCH_SCOPE_BEGIN {
 
     fd_txn_p_t * txns    = all_txns + (batch_size * i);
     ulong        txn_cnt = ((i+1UL==num_batches) && rem) ? rem : batch_size;
 
-    fd_execute_txn_task_info_t * task_infos          = fd_scratch_alloc( 8UL, txn_cnt * sizeof(fd_execute_txn_task_info_t) );
-    fd_execute_txn_task_info_t * wave_task_infos     = fd_scratch_alloc( 8UL, txn_cnt * sizeof(fd_execute_txn_task_info_t) );
+    fd_execute_txn_task_info_t * task_infos          = fd_spad_alloc( runtime_spad, alignof(fd_execute_txn_task_info_t), txn_cnt * sizeof(fd_execute_txn_task_info_t) );
+    fd_execute_txn_task_info_t * wave_task_infos     = fd_spad_alloc( runtime_spad, alignof(fd_execute_txn_task_info_t), txn_cnt * sizeof(fd_execute_txn_task_info_t) );
     ulong                        wave_task_infos_cnt = 0UL;
 
-    res = fd_runtime_prepare_txns_start( slot_ctx, task_infos, txns, txn_cnt );
+    res = fd_runtime_prepare_txns_start( slot_ctx, task_infos, txns, txn_cnt, runtime_spad );
     if( res != 0 ) {
       FD_LOG_DEBUG(("Fail prep 1"));
     }
 
-    ulong * incomplete_txn_idxs     = fd_scratch_alloc( 8UL, txn_cnt * sizeof(ulong) );
+    ulong * incomplete_txn_idxs     = fd_spad_alloc( runtime_spad, alignof(ulong), txn_cnt * sizeof(ulong) );
     ulong   incomplete_txn_idxs_cnt = 0UL;
     ulong   incomplete_accounts_cnt = 0UL;
 
@@ -2266,36 +2312,43 @@ fd_runtime_process_txns_in_waves_tpool( fd_exec_slot_ctx_t * slot_ctx,
       task_infos[i].txn_ctx->capture_ctx             = capture_ctx;
     }
 
-    ulong * next_incomplete_txn_idxs     = fd_scratch_alloc( 8UL, txn_cnt * sizeof(ulong) );
+    ulong * next_incomplete_txn_idxs     = fd_spad_alloc( runtime_spad, alignof(ulong), txn_cnt * sizeof(ulong) );
     ulong   next_incomplete_txn_idxs_cnt = 0UL;
     ulong   next_incomplete_accounts_cnt = 0UL;
 
     while( incomplete_txn_idxs_cnt > 0 ) {
-      fd_runtime_generate_wave( task_infos, incomplete_txn_idxs, incomplete_txn_idxs_cnt, incomplete_accounts_cnt,
-                                next_incomplete_txn_idxs, &next_incomplete_txn_idxs_cnt, &next_incomplete_accounts_cnt,
-                                wave_task_infos, &wave_task_infos_cnt );
+      fd_runtime_generate_wave( task_infos,
+                                incomplete_txn_idxs,
+                                incomplete_txn_idxs_cnt,
+                                incomplete_accounts_cnt,
+                                next_incomplete_txn_idxs,
+                                &next_incomplete_txn_idxs_cnt,
+                                &next_incomplete_accounts_cnt,
+                                wave_task_infos,
+                                &wave_task_infos_cnt,
+                                runtime_spad );
       ulong * temp_incomplete_txn_idxs = incomplete_txn_idxs;
       incomplete_txn_idxs              = next_incomplete_txn_idxs;
       next_incomplete_txn_idxs         = temp_incomplete_txn_idxs;
       incomplete_txn_idxs_cnt          = next_incomplete_txn_idxs_cnt;
 
-      for( ulong i=0UL; i<spad_cnt; i++ ) {
+      for( ulong i=0UL; i<exec_spad_cnt; i++ ) {
         /* Borrowed accounts are allocated during prep and need to
-            persist till the end of finalize. This initial frame will
-            be holding that. */
-        fd_spad_push( spads[ i ] );
+           persist till the end of finalize. This initial frame will
+           be holding that. */
+        fd_spad_push( exec_spads[ i ] );
       }
 
-      /* Assign out spads to the transaction contexts */
+      /* Assign out spads to the transaction contexts. */
       for( ulong i=0UL; i<wave_task_infos_cnt; i++ ) {
-        wave_task_infos[i].spads = spads;
+        wave_task_infos[i].spads = exec_spads;
       }
 
       // Dump txns in waves
       if( dump_txn ) {
         for( ulong i = 0; i < wave_task_infos_cnt; ++i ) {
           /* Manual push/pop on the spad within the callee. */
-          fd_dump_txn_to_protobuf( wave_task_infos[i].txn_ctx, spads[0] );
+          fd_dump_txn_to_protobuf( wave_task_infos[i].txn_ctx, exec_spads[0] );
         }
       }
 
@@ -2311,28 +2364,31 @@ fd_runtime_process_txns_in_waves_tpool( fd_exec_slot_ctx_t * slot_ctx,
 
       /* We should ONLY be modifying the slot_ctx at this point. */
 
-      int finalize_res = fd_runtime_finalize_txns_tpool( slot_ctx, capture_ctx, wave_task_infos, wave_task_infos_cnt, tpool );
+      int finalize_res = fd_runtime_finalize_txns_tpool( slot_ctx, 
+                                                         capture_ctx,
+                                                         wave_task_infos,
+                                                         wave_task_infos_cnt,
+                                                         tpool,
+                                                         runtime_spad );
       if( finalize_res != 0 ) {
         FD_LOG_ERR(( "Fail finalize" ));
       }
 
-      for( ulong i=0UL; i<spad_cnt; i++ ) {
+      for( ulong i=0UL; i<exec_spad_cnt; i++ ) {
         /* The first frame, which holds borrowed accounts, can be
             pretty big, and there are additional dynamic allocations
             during finalize. */
-        if( FD_UNLIKELY( fd_spad_verify( spads[ i ] ) ) ) {
+        if( FD_UNLIKELY( fd_spad_verify( exec_spads[ i ] ) ) ) {
           FD_LOG_ERR(( "spad corrupted or overflown" ));
         }
         /* We indiscriminately pushed a frame to every spad.
             So it should be safe to indiscriminately pop here. */
-        fd_spad_pop( spads[ i ] );
-        if( FD_UNLIKELY( fd_spad_frame_used( spads[ i ] )!=0 ) ) {
-          FD_LOG_ERR(( "stray spad frame frame_used=%lu", fd_spad_frame_used( spads[ i ] ) ));
+        fd_spad_pop( exec_spads[ i ] );
+        if( FD_UNLIKELY( fd_spad_frame_used( exec_spads[ i ] )!=0 ) ) {
+          FD_LOG_ERR(( "stray spad frame frame_used=%lu", fd_spad_frame_used( exec_spads[ i ] ) ));
         }
       }
-
     }
-    } FD_SCRATCH_SCOPE_END;
   }
   slot_ctx->slot_bank.transaction_count += total_txn_cnt;
 
@@ -2358,94 +2414,86 @@ https://github.com/solana-labs/solana/blob/c091fd3da8014c0ef83b626318018f238f506
 static void
 fd_update_stake_delegations( fd_exec_slot_ctx_t * slot_ctx, 
                              fd_epoch_info_t *    temp_info ) {
-  FD_SCRATCH_SCOPE_BEGIN {
-    fd_epoch_bank_t * epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
-    fd_slot_bank_t *  slot_bank  = &slot_ctx->slot_bank;
-    fd_stakes_t *     stakes     = &epoch_bank->stakes;
+  fd_epoch_bank_t * epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
+  fd_slot_bank_t *  slot_bank  = &slot_ctx->slot_bank;
+  fd_stakes_t *     stakes     = &epoch_bank->stakes;
 
-    /* In one pass, iterate over all the stake infos and insert the updated values into the epoch stakes cache 
-       This assumes that there is enough memory pre-allocated for the stakes cache. */
-    for( ulong idx=0UL; idx<temp_info->stake_infos_len; idx++ ) {
-      // Fetch and store the delegation associated with this stake account
-      fd_delegation_pair_t_mapnode_t key;
-      fd_memcpy( &key.elem.account, &temp_info->stake_infos[idx].account, sizeof(fd_pubkey_t) );
-      fd_delegation_pair_t_mapnode_t * entry = fd_delegation_pair_t_map_find( stakes->stake_delegations_pool, stakes->stake_delegations_root, &key );
-      if( FD_LIKELY( entry==NULL ) ) {
-        entry = fd_delegation_pair_t_map_acquire( stakes->stake_delegations_pool );
-        fd_memcpy( &entry->elem.account, &temp_info->stake_infos[idx].account, sizeof(fd_pubkey_t) );
-        fd_memcpy( &entry->elem.delegation, &temp_info->stake_infos[idx].stake.delegation, sizeof(fd_delegation_t) );
-        fd_delegation_pair_t_map_insert( stakes->stake_delegations_pool, &stakes->stake_delegations_root, entry );
-      }
+  /* In one pass, iterate over all the stake infos and insert the updated values into the epoch stakes cache 
+      This assumes that there is enough memory pre-allocated for the stakes cache. */
+  for( ulong idx=0UL; idx<temp_info->stake_infos_len; idx++ ) {
+    // Fetch and store the delegation associated with this stake account
+    fd_delegation_pair_t_mapnode_t key;
+    fd_memcpy( &key.elem.account, &temp_info->stake_infos[idx].account, sizeof(fd_pubkey_t) );
+    fd_delegation_pair_t_mapnode_t * entry = fd_delegation_pair_t_map_find( stakes->stake_delegations_pool, stakes->stake_delegations_root, &key );
+    if( FD_LIKELY( entry==NULL ) ) {
+      entry = fd_delegation_pair_t_map_acquire( stakes->stake_delegations_pool );
+      fd_memcpy( &entry->elem.account, &temp_info->stake_infos[idx].account, sizeof(fd_pubkey_t) );
+      fd_memcpy( &entry->elem.delegation, &temp_info->stake_infos[idx].stake.delegation, sizeof(fd_delegation_t) );
+      fd_delegation_pair_t_map_insert( stakes->stake_delegations_pool, &stakes->stake_delegations_root, entry );
     }
+  }
 
-    fd_account_keys_pair_t_map_release_tree( slot_bank->stake_account_keys.account_keys_pool, slot_bank->stake_account_keys.account_keys_root );
-    slot_bank->stake_account_keys.account_keys_root = NULL;
-
-  } FD_SCRATCH_SCOPE_END;
+  fd_account_keys_pair_t_map_release_tree( slot_bank->stake_account_keys.account_keys_pool, slot_bank->stake_account_keys.account_keys_root );
+  slot_bank->stake_account_keys.account_keys_root = NULL;
 }
 
 /* Replace the stakes in T-2 (slot_ctx->slot_bank.epoch_stakes) by the stakes at T-1 (epoch_bank->next_epoch_stakes) */
 static void
 fd_update_epoch_stakes( fd_exec_slot_ctx_t * slot_ctx ) {
-  FD_SCRATCH_SCOPE_BEGIN {
-    fd_epoch_bank_t * epoch_bank = &slot_ctx->epoch_ctx->epoch_bank;
+  fd_epoch_bank_t * epoch_bank = &slot_ctx->epoch_ctx->epoch_bank;
 
-    /* Copy epoch_bank->next_epoch_stakes into slot_ctx->slot_bank.epoch_stakes */
-    fd_vote_accounts_pair_t_map_release_tree(
-      slot_ctx->slot_bank.epoch_stakes.vote_accounts_pool,
-      slot_ctx->slot_bank.epoch_stakes.vote_accounts_root );
-    slot_ctx->slot_bank.epoch_stakes.vote_accounts_root = NULL;
+  /* Copy epoch_bank->next_epoch_stakes into slot_ctx->slot_bank.epoch_stakes */
+  fd_vote_accounts_pair_t_map_release_tree(
+    slot_ctx->slot_bank.epoch_stakes.vote_accounts_pool,
+    slot_ctx->slot_bank.epoch_stakes.vote_accounts_root );
+  slot_ctx->slot_bank.epoch_stakes.vote_accounts_root = NULL;
 
-    for ( fd_vote_accounts_pair_t_mapnode_t * n = fd_vote_accounts_pair_t_map_minimum(
-      epoch_bank->next_epoch_stakes.vote_accounts_pool,
-      epoch_bank->next_epoch_stakes.vote_accounts_root );
-          n;
-          n = fd_vote_accounts_pair_t_map_successor( epoch_bank->next_epoch_stakes.vote_accounts_pool, n ) ) {
+  for( fd_vote_accounts_pair_t_mapnode_t * n = fd_vote_accounts_pair_t_map_minimum(
+        epoch_bank->next_epoch_stakes.vote_accounts_pool,
+        epoch_bank->next_epoch_stakes.vote_accounts_root );
+        n;
+        n = fd_vote_accounts_pair_t_map_successor( epoch_bank->next_epoch_stakes.vote_accounts_pool, n ) ) {
 
-      const fd_pubkey_t null_pubkey = {{ 0 }};
-      if ( memcmp( &n->elem.key, &null_pubkey, FD_PUBKEY_FOOTPRINT ) == 0 ) {
-        continue;
-      }
-
-      fd_vote_accounts_pair_t_mapnode_t * elem = fd_vote_accounts_pair_t_map_acquire(
-        slot_ctx->slot_bank.epoch_stakes.vote_accounts_pool );
-      if ( FD_UNLIKELY(
-          fd_vote_accounts_pair_t_map_free( slot_ctx->slot_bank.epoch_stakes.vote_accounts_pool ) == 0 ) ) {
-        FD_LOG_ERR(( "slot_ctx->slot_bank.epoch_stakes.vote_accounts_pool full" ));
-      }
-
-      fd_memcpy( &elem->elem, &n->elem, sizeof(fd_vote_accounts_pair_t));
-      fd_vote_accounts_pair_t_map_insert(
-        slot_ctx->slot_bank.epoch_stakes.vote_accounts_pool,
-        &slot_ctx->slot_bank.epoch_stakes.vote_accounts_root,
-        elem );
+    const fd_pubkey_t null_pubkey = {{ 0 }};
+    if( memcmp( &n->elem.key, &null_pubkey, FD_PUBKEY_FOOTPRINT ) == 0 ) {
+      continue;
     }
-  } FD_SCRATCH_SCOPE_END;
+
+    fd_vote_accounts_pair_t_mapnode_t * elem = fd_vote_accounts_pair_t_map_acquire(
+      slot_ctx->slot_bank.epoch_stakes.vote_accounts_pool );
+    if( FD_UNLIKELY( fd_vote_accounts_pair_t_map_free( slot_ctx->slot_bank.epoch_stakes.vote_accounts_pool ) == 0 ) ) {
+      FD_LOG_ERR(( "slot_ctx->slot_bank.epoch_stakes.vote_accounts_pool full" ));
+    }
+
+    fd_memcpy( &elem->elem, &n->elem, sizeof(fd_vote_accounts_pair_t));
+    fd_vote_accounts_pair_t_map_insert( slot_ctx->slot_bank.epoch_stakes.vote_accounts_pool,
+                                        &slot_ctx->slot_bank.epoch_stakes.vote_accounts_root,
+                                        elem );
+  }
 }
 
 /* Copy epoch_bank->stakes.vote_accounts into epoch_bank->next_epoch_stakes. */
-static void fd_update_next_epoch_stakes( fd_exec_slot_ctx_t * slot_ctx ) {
-  FD_SCRATCH_SCOPE_BEGIN {
-    fd_epoch_bank_t * epoch_bank = &slot_ctx->epoch_ctx->epoch_bank;
+static void 
+fd_update_next_epoch_stakes( fd_exec_slot_ctx_t * slot_ctx ) {
+  fd_epoch_bank_t * epoch_bank = &slot_ctx->epoch_ctx->epoch_bank;
 
-    /* Copy epoch_ctx->epoch_bank->stakes.vote_accounts into epoch_bank->next_epoch_stakes */
-    fd_vote_accounts_pair_t_map_release_tree(
-      epoch_bank->next_epoch_stakes.vote_accounts_pool,
-      epoch_bank->next_epoch_stakes.vote_accounts_root );
+  /* Copy epoch_ctx->epoch_bank->stakes.vote_accounts into epoch_bank->next_epoch_stakes */
+  fd_vote_accounts_pair_t_map_release_tree(
+    epoch_bank->next_epoch_stakes.vote_accounts_pool,
+    epoch_bank->next_epoch_stakes.vote_accounts_root );
 
-    epoch_bank->next_epoch_stakes.vote_accounts_pool = fd_exec_epoch_ctx_next_epoch_stakes_join( slot_ctx->epoch_ctx );
-    epoch_bank->next_epoch_stakes.vote_accounts_root = NULL;
+  epoch_bank->next_epoch_stakes.vote_accounts_pool = fd_exec_epoch_ctx_next_epoch_stakes_join( slot_ctx->epoch_ctx );
+  epoch_bank->next_epoch_stakes.vote_accounts_root = NULL;
 
-    for ( fd_vote_accounts_pair_t_mapnode_t * n = fd_vote_accounts_pair_t_map_minimum(
-      epoch_bank->stakes.vote_accounts.vote_accounts_pool,
-      epoch_bank->stakes.vote_accounts.vote_accounts_root );
-          n;
-          n = fd_vote_accounts_pair_t_map_successor( epoch_bank->stakes.vote_accounts.vote_accounts_pool, n ) ) {
-      fd_vote_accounts_pair_t_mapnode_t * elem = fd_vote_accounts_pair_t_map_acquire( epoch_bank->next_epoch_stakes.vote_accounts_pool );
-      fd_memcpy( &elem->elem, &n->elem, sizeof(fd_vote_accounts_pair_t));
-      fd_vote_accounts_pair_t_map_insert( epoch_bank->next_epoch_stakes.vote_accounts_pool, &epoch_bank->next_epoch_stakes.vote_accounts_root, elem );
-    }
-  } FD_SCRATCH_SCOPE_END;
+  for( fd_vote_accounts_pair_t_mapnode_t * n = fd_vote_accounts_pair_t_map_minimum(
+        epoch_bank->stakes.vote_accounts.vote_accounts_pool,
+        epoch_bank->stakes.vote_accounts.vote_accounts_root );
+        n;
+        n = fd_vote_accounts_pair_t_map_successor( epoch_bank->stakes.vote_accounts.vote_accounts_pool, n ) ) {
+    fd_vote_accounts_pair_t_mapnode_t * elem = fd_vote_accounts_pair_t_map_acquire( epoch_bank->next_epoch_stakes.vote_accounts_pool );
+    fd_memcpy( &elem->elem, &n->elem, sizeof(fd_vote_accounts_pair_t));
+    fd_vote_accounts_pair_t_map_insert( epoch_bank->next_epoch_stakes.vote_accounts_pool, &epoch_bank->next_epoch_stakes.vote_accounts_root, elem );
+  }
 }
 
 /* Mimics `bank.new_target_program_account()`. Assumes `out_rec` is a modifiable record.
@@ -2509,13 +2557,17 @@ static int
 fd_new_target_program_data_account( fd_exec_slot_ctx_t *    slot_ctx,
                                     fd_pubkey_t *           config_upgrade_authority_address,
                                     fd_borrowed_account_t * buffer_acc_rec,
-                                    fd_borrowed_account_t * new_target_program_data_account ) {
+                                    fd_borrowed_account_t * new_target_program_data_account,
+                                    fd_spad_t *             runtime_spad ) {
+
+  FD_SPAD_FRAME_BEGIN( runtime_spad ) {
+
   /* https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank/builtins/core_bpf_migration/mod.rs#L113-L116 */
   fd_bpf_upgradeable_loader_state_t state;
   fd_bincode_decode_ctx_t decode_ctx = {
-    .data = buffer_acc_rec->const_data,
+    .data    = buffer_acc_rec->const_data,
     .dataend = buffer_acc_rec->const_data + buffer_acc_rec->const_meta->dlen,
-    .valloc = fd_scratch_virtual()
+    .valloc  = fd_spad_virtual( runtime_spad ) 
   };
   int err = fd_bpf_upgradeable_loader_state_decode( &state, &decode_ctx );
   if( FD_UNLIKELY( err ) ) {
@@ -2571,6 +2623,8 @@ fd_new_target_program_data_account( fd_exec_slot_ctx_t *    slot_ctx,
   fd_memcpy( new_target_program_data_account->data + PROGRAMDATA_METADATA_SIZE, elf, buffer_acc_rec->const_meta->dlen - BUFFER_METADATA_SIZE );
 
   return FD_RUNTIME_EXECUTE_SUCCESS;
+
+  } FD_SPAD_FRAME_END;
 }
 
 /* Mimics `migrate_builtin_to_core_bpf()`. The arguments map as follows:
@@ -2585,9 +2639,10 @@ fd_new_target_program_data_account( fd_exec_slot_ctx_t *    slot_ctx,
 static void
 fd_migrate_builtin_to_core_bpf( fd_exec_slot_ctx_t * slot_ctx,
                                 fd_pubkey_t *        upgrade_authority_address,
-                                const fd_pubkey_t *  builtin_program_id,
-                                const fd_pubkey_t *  source_buffer_address,
-                                uchar                stateless ) {
+                                fd_pubkey_t const *  builtin_program_id,
+                                fd_pubkey_t const *  source_buffer_address,
+                                uchar                stateless,
+                                fd_spad_t *          runtime_spad ) {
   int err;
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank/builtins/core_bpf_migration/mod.rs#L242-L243
@@ -2718,7 +2773,11 @@ fd_migrate_builtin_to_core_bpf( fd_exec_slot_ctx_t * slot_ctx,
   new_target_program_data_account->meta->dlen = new_target_program_data_account_sz;
   new_target_program_data_account->meta->slot = slot_ctx->slot_bank.slot;
 
-  err = fd_new_target_program_data_account( slot_ctx, upgrade_authority_address, source_buffer_account, new_target_program_data_account );
+  err = fd_new_target_program_data_account( slot_ctx,
+                                            upgrade_authority_address,
+                                            source_buffer_account,
+                                            new_target_program_data_account,
+                                            runtime_spad );
   if( FD_UNLIKELY( err ) ) {
     FD_LOG_WARNING(( "Failed to write new program data state to %s", FD_BASE58_ENC_32_ALLOCA( target_program_data_address ) ));
     goto fail;
@@ -2728,7 +2787,8 @@ fd_migrate_builtin_to_core_bpf( fd_exec_slot_ctx_t * slot_ctx,
      https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank/builtins/core_bpf_migration/mod.rs#L268-L271 */
   err = fd_directly_invoke_loader_v3_deploy( slot_ctx,
                                              new_target_program_data_account->const_data + PROGRAMDATA_METADATA_SIZE,
-                                             new_target_program_data_account->const_meta->dlen - PROGRAMDATA_METADATA_SIZE );
+                                             new_target_program_data_account->const_meta->dlen - PROGRAMDATA_METADATA_SIZE,
+                                             runtime_spad );
   if( FD_UNLIKELY( err ) ) {
     FD_LOG_WARNING(( "Failed to deploy program %s", FD_BASE58_ENC_32_ALLOCA( builtin_program_id ) ));
     goto fail;
@@ -2767,102 +2827,116 @@ fail:
 
 /* https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank.rs#L6704 */
 static void
-fd_apply_builtin_program_feature_transitions( fd_exec_slot_ctx_t * slot_ctx ) {
-  FD_SCRATCH_SCOPE_BEGIN {
-    /* TODO: Set the upgrade authority properly from the core bpf migration config. Right now it's set to None.
+fd_apply_builtin_program_feature_transitions( fd_exec_slot_ctx_t * slot_ctx,
+                                              fd_spad_t *          runtime_spad ) {
+  /* TODO: Set the upgrade authority properly from the core bpf migration config. Right now it's set to None.
 
-       Migrate any necessary stateless builtins to core BPF. So far, the only "stateless" builtin
-       is the Feature program. Beginning checks in the `migrate_builtin_to_core_bpf` function will
-       fail if the program has already been migrated to BPF. */
-    fd_builtin_program_t const * builtins = fd_builtins();
-    for( ulong i=0UL; i<fd_num_builtins(); i++ ) {
-      /* https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank.rs#L6732-L6751 */
-      if( builtins[i].core_bpf_migration_config && FD_FEATURE_ACTIVE_OFFSET( slot_ctx, builtins[i].core_bpf_migration_config->enable_feature_offset ) ) {
-        FD_LOG_NOTICE(( "Migrating builtin program %s to core BPF", FD_BASE58_ENC_32_ALLOCA( builtins[i].pubkey->key ) ));
-        fd_migrate_builtin_to_core_bpf( slot_ctx, builtins[i].core_bpf_migration_config->upgrade_authority_address, builtins[i].core_bpf_migration_config->builtin_program_id, builtins[i].core_bpf_migration_config->source_buffer_address, 0 );
-      }
-      /* https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank.rs#L6753-L6774 */
-      if( builtins[i].enable_feature_offset!=NO_ENABLE_FEATURE_ID && FD_FEATURE_JUST_ACTIVATED_OFFSET( slot_ctx, builtins[i].enable_feature_offset ) ) {
-        FD_LOG_NOTICE(( "Enabling builtin program %s", FD_BASE58_ENC_32_ALLOCA( builtins[i].pubkey->key ) ));
-        fd_write_builtin_account( slot_ctx, *builtins[i].pubkey, builtins[i].data,strlen(builtins[i].data) );
-      }
-    }
+     Migrate any necessary stateless builtins to core BPF. So far, the only "stateless" builtin
+     is the Feature program. Beginning checks in the `migrate_builtin_to_core_bpf` function will
+     fail if the program has already been migrated to BPF. */
 
-    /* https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank.rs#L6776-L6793 */
-    fd_stateless_builtin_program_t const * stateless_builtins = fd_stateless_builtins();
-    for( ulong i=0UL; i<fd_num_stateless_builtins(); i++ ) {
-      if( stateless_builtins[i].core_bpf_migration_config && FD_FEATURE_ACTIVE_OFFSET( slot_ctx, stateless_builtins[i].core_bpf_migration_config->enable_feature_offset ) ) {
-        FD_LOG_NOTICE(( "Migrating stateless builtin program %s to core BPF", FD_BASE58_ENC_32_ALLOCA( stateless_builtins[i].pubkey->key ) ));
-        fd_migrate_builtin_to_core_bpf( slot_ctx, stateless_builtins[i].core_bpf_migration_config->upgrade_authority_address, stateless_builtins[i].core_bpf_migration_config->builtin_program_id, stateless_builtins[i].core_bpf_migration_config->source_buffer_address, 1 );
-      }
+  FD_SPAD_FRAME_BEGIN( runtime_spad ) {
+
+  fd_builtin_program_t const * builtins = fd_builtins();
+  for( ulong i=0UL; i<fd_num_builtins(); i++ ) {
+    /* https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank.rs#L6732-L6751 */
+    if( builtins[i].core_bpf_migration_config && FD_FEATURE_ACTIVE_OFFSET( slot_ctx, builtins[i].core_bpf_migration_config->enable_feature_offset ) ) {
+      FD_LOG_NOTICE(( "Migrating builtin program %s to core BPF", FD_BASE58_ENC_32_ALLOCA( builtins[i].pubkey->key ) ));
+      fd_migrate_builtin_to_core_bpf( slot_ctx,
+                                      builtins[i].core_bpf_migration_config->upgrade_authority_address,
+                                      builtins[i].core_bpf_migration_config->builtin_program_id,
+                                      builtins[i].core_bpf_migration_config->source_buffer_address,
+                                      0,
+                                      runtime_spad );
     }
+    /* https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank.rs#L6753-L6774 */
+    if( builtins[i].enable_feature_offset!=NO_ENABLE_FEATURE_ID && FD_FEATURE_JUST_ACTIVATED_OFFSET( slot_ctx, builtins[i].enable_feature_offset ) ) {
+      FD_LOG_NOTICE(( "Enabling builtin program %s", FD_BASE58_ENC_32_ALLOCA( builtins[i].pubkey->key ) ));
+      fd_write_builtin_account( slot_ctx, *builtins[i].pubkey, builtins[i].data,strlen(builtins[i].data) );
+    }
+  }
+
+  /* https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank.rs#L6776-L6793 */
+  fd_stateless_builtin_program_t const * stateless_builtins = fd_stateless_builtins();
+  for( ulong i=0UL; i<fd_num_stateless_builtins(); i++ ) {
+    if( stateless_builtins[i].core_bpf_migration_config && FD_FEATURE_ACTIVE_OFFSET( slot_ctx, stateless_builtins[i].core_bpf_migration_config->enable_feature_offset ) ) {
+      FD_LOG_NOTICE(( "Migrating stateless builtin program %s to core BPF", FD_BASE58_ENC_32_ALLOCA( stateless_builtins[i].pubkey->key ) ));
+      fd_migrate_builtin_to_core_bpf( slot_ctx,
+                                      stateless_builtins[i].core_bpf_migration_config->upgrade_authority_address,
+                                      stateless_builtins[i].core_bpf_migration_config->builtin_program_id,
+                                      stateless_builtins[i].core_bpf_migration_config->source_buffer_address,
+                                      1,
+                                      runtime_spad );
+    }
+  }
 
   } FD_SCRATCH_SCOPE_END;
 }
 
 static void
-fd_feature_activate( fd_exec_slot_ctx_t * slot_ctx,
-                    fd_feature_id_t const * id,
-                    uchar const       acct[ static 32 ] ) {
+fd_feature_activate( fd_exec_slot_ctx_t *   slot_ctx,
+                     fd_feature_id_t const * id,
+                     uchar const             acct[ static 32 ],
+                     fd_spad_t *             runtime_spad ) {
 
   // Skip reverted features from being activated
-  if ( id->reverted==1 ) {
+  if( id->reverted==1 ) {
     return;
   }
 
-  FD_BORROWED_ACCOUNT_DECL(acct_rec);
-  int err = fd_acc_mgr_view(slot_ctx->acc_mgr, slot_ctx->funk_txn, (fd_pubkey_t *)acct, acct_rec);
-  if (FD_UNLIKELY(err != FD_ACC_MGR_SUCCESS))
+  FD_BORROWED_ACCOUNT_DECL( acct_rec );
+  int err = fd_acc_mgr_view( slot_ctx->acc_mgr, slot_ctx->funk_txn, (fd_pubkey_t*)acct, acct_rec );
+  if( FD_UNLIKELY( err != FD_ACC_MGR_SUCCESS ) ) {
     return;
+  }
 
   fd_feature_t feature[1];
 
-  FD_SCRATCH_SCOPE_BEGIN
-  {
+  FD_SPAD_FRAME_BEGIN( runtime_spad ) {
 
-    fd_bincode_decode_ctx_t ctx = {
-        .data = acct_rec->const_data,
-        .dataend = acct_rec->const_data + acct_rec->const_meta->dlen,
-        .valloc = fd_scratch_virtual(),
+  fd_bincode_decode_ctx_t ctx = {
+      .data    = acct_rec->const_data,
+      .dataend = acct_rec->const_data + acct_rec->const_meta->dlen,
+      .valloc  = fd_spad_virtual( runtime_spad ),
+  };
+  int decode_err = fd_feature_decode( feature, &ctx );
+  if( FD_UNLIKELY( decode_err != FD_BINCODE_SUCCESS ) ) {
+    FD_LOG_ERR(( "Failed to decode feature account %s (%d)", FD_BASE58_ENC_32_ALLOCA( acct ), decode_err ));
+  }
+
+  if( feature->has_activated_at ) {
+    FD_LOG_INFO(( "feature already activated - acc: %s, slot: %lu", FD_BASE58_ENC_32_ALLOCA( acct ), feature->activated_at ));
+    fd_features_set(&slot_ctx->epoch_ctx->features, id, feature->activated_at);
+  } else {
+    FD_LOG_INFO(( "Feature %s not activated at %lu, activating", FD_BASE58_ENC_32_ALLOCA( acct ), feature->activated_at ));
+
+    FD_BORROWED_ACCOUNT_DECL( modify_acct_rec );
+    err = fd_acc_mgr_modify( slot_ctx->acc_mgr, slot_ctx->funk_txn, (fd_pubkey_t *)acct, 0, 0UL, modify_acct_rec );
+    if( FD_UNLIKELY( err != FD_ACC_MGR_SUCCESS ) ) {
+      return;
+    }
+
+    feature->has_activated_at = 1;
+    feature->activated_at     = slot_ctx->slot_bank.slot;
+    fd_bincode_encode_ctx_t encode_ctx = {
+      .data    = modify_acct_rec->data,
+      .dataend = modify_acct_rec->data + modify_acct_rec->meta->dlen,
     };
-    int decode_err = fd_feature_decode(feature, &ctx);
-    if (FD_UNLIKELY(decode_err != FD_BINCODE_SUCCESS)) {
-      FD_LOG_ERR(( "Failed to decode feature account %s (%d)", FD_BASE58_ENC_32_ALLOCA( acct ), decode_err ));
+    int encode_err = fd_feature_encode( feature, &encode_ctx );
+    if( FD_UNLIKELY( encode_err != FD_BINCODE_SUCCESS ) ) {
+      FD_LOG_ERR(( "Failed to encode feature account %s (%d)", FD_BASE58_ENC_32_ALLOCA( acct ), decode_err ));
     }
+  }
 
-    if( feature->has_activated_at ) {
-      FD_LOG_INFO(( "feature already activated - acc: %s, slot: %lu", FD_BASE58_ENC_32_ALLOCA( acct ), feature->activated_at ));
-      fd_features_set(&slot_ctx->epoch_ctx->features, id, feature->activated_at);
-    } else {
-      FD_LOG_INFO(( "Feature %s not activated at %lu, activating", FD_BASE58_ENC_32_ALLOCA( acct ), feature->activated_at ));
-
-      FD_BORROWED_ACCOUNT_DECL(modify_acct_rec);
-      err = fd_acc_mgr_modify(slot_ctx->acc_mgr, slot_ctx->funk_txn, (fd_pubkey_t *)acct, 0, 0UL, modify_acct_rec);
-      if (FD_UNLIKELY(err != FD_ACC_MGR_SUCCESS)) {
-        return;
-      }
-
-      feature->has_activated_at = 1;
-      feature->activated_at = slot_ctx->slot_bank.slot;
-      fd_bincode_encode_ctx_t encode_ctx = {
-        .data = modify_acct_rec->data,
-        .dataend = modify_acct_rec->data + modify_acct_rec->meta->dlen,
-      };
-      int encode_err = fd_feature_encode(feature, &encode_ctx);
-      if (FD_UNLIKELY(encode_err != FD_BINCODE_SUCCESS)) {
-        FD_LOG_ERR(( "Failed to encode feature account %s (%d)", FD_BASE58_ENC_32_ALLOCA( acct ), decode_err ));
-      }
-    }
-    /* No need to call destroy, since we are using fd_scratch allocator. */
-  } FD_SCRATCH_SCOPE_END;
+  } FD_SPAD_FRAME_END;
 }
 
 static void
-fd_features_activate( fd_exec_slot_ctx_t * slot_ctx ) {
+fd_features_activate( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_spad ) {
   for( fd_feature_id_t const * id = fd_feature_iter_init();
                                    !fd_feature_iter_done( id );
                                id = fd_feature_iter_next( id ) ) {
-    fd_feature_activate( slot_ctx, id, id->id.key );
+    fd_feature_activate( slot_ctx, id, id->id.key, runtime_spad );
   }
 }
 
@@ -2893,8 +2967,10 @@ fd_runtime_is_epoch_boundary( fd_epoch_bank_t * epoch_bank, ulong curr_slot, ulo
 static void 
 fd_runtime_process_new_epoch( fd_exec_slot_ctx_t * slot_ctx,
                               ulong                parent_epoch,
-                              fd_valloc_t          valloc ) {
+                              fd_spad_t *          runtime_spad ) {
   FD_LOG_NOTICE(( "fd_process_new_epoch start" ));
+
+  long start = fd_log_wallclock();
 
   ulong             slot;
   fd_epoch_bank_t * epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
@@ -2902,86 +2978,98 @@ fd_runtime_process_new_epoch( fd_exec_slot_ctx_t * slot_ctx,
 
   /* Activate new features
      https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank.rs#L6587-L6598 */
-  fd_features_activate( slot_ctx );
-  fd_features_restore( slot_ctx );
+  fd_features_activate( slot_ctx, runtime_spad );
+  fd_features_restore( slot_ctx, runtime_spad );
 
   /* Apply builtin program feature transitions
      https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank.rs#L6621-L6624 */
-  fd_apply_builtin_program_feature_transitions( slot_ctx );
+  fd_apply_builtin_program_feature_transitions( slot_ctx, runtime_spad );
 
   /* Change the speed of the poh clock
      https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank.rs#L6627-L6649 */
   if( FD_FEATURE_JUST_ACTIVATED( slot_ctx, update_hashes_per_tick6 ) ) {
     epoch_bank->hashes_per_tick = UPDATED_HASHES_PER_TICK6;
-  } else if( FD_FEATURE_JUST_ACTIVATED(slot_ctx, update_hashes_per_tick5 ) ) {
+  } else if( FD_FEATURE_JUST_ACTIVATED( slot_ctx, update_hashes_per_tick5 ) ) {
     epoch_bank->hashes_per_tick = UPDATED_HASHES_PER_TICK5;
   } else if( FD_FEATURE_JUST_ACTIVATED( slot_ctx, update_hashes_per_tick4 ) ) {
     epoch_bank->hashes_per_tick = UPDATED_HASHES_PER_TICK4;
-  } else if( FD_FEATURE_JUST_ACTIVATED(slot_ctx, update_hashes_per_tick3 ) ) {
+  } else if( FD_FEATURE_JUST_ACTIVATED( slot_ctx, update_hashes_per_tick3 ) ) {
     epoch_bank->hashes_per_tick = UPDATED_HASHES_PER_TICK3;
-  } else if( FD_FEATURE_JUST_ACTIVATED(slot_ctx, update_hashes_per_tick2 ) ) {
+  } else if( FD_FEATURE_JUST_ACTIVATED( slot_ctx, update_hashes_per_tick2 ) ) {
     epoch_bank->hashes_per_tick = UPDATED_HASHES_PER_TICK2;
   }
 
   /* Get the new rate activation epoch */
   int _err[1];
-  ulong * new_rate_activation_epoch = fd_scratch_alloc( alignof(ulong), sizeof(ulong) );
-  int     is_some                   = fd_new_warmup_cooldown_rate_epoch( slot_ctx, new_rate_activation_epoch, _err );
+  ulong   new_rate_activation_epoch_val = 0UL;
+  ulong * new_rate_activation_epoch     = &new_rate_activation_epoch_val;
+  int     is_some                       = fd_new_warmup_cooldown_rate_epoch( slot_ctx, new_rate_activation_epoch, _err );
   if( FD_UNLIKELY( !is_some ) ) {
     new_rate_activation_epoch = NULL;
   }
 
-  FD_SCRATCH_SCOPE_BEGIN {
+  fd_epoch_info_t temp_info = {0};
+  fd_epoch_info_new( &temp_info );
 
-    fd_epoch_info_t temp_info = {0};
-    fd_epoch_info_new( &temp_info );
-
-    /* If appropiate, use the stakes at T-1 to generate the leader schedule instead of T-2.
-       This is due to a subtlety in how Agave's stake caches interact when loading from snapshots.
-       See the comment in fd_exec_slot_ctx_recover_. */
-    if( slot_ctx->slot_bank.has_use_preceeding_epoch_stakes && slot_ctx->slot_bank.use_preceeding_epoch_stakes == epoch ) {
-      fd_update_epoch_stakes( slot_ctx );
-    }
-
-    /* Updates stake history sysvar accumulated values. */
-    fd_stakes_activate_epoch( slot_ctx, new_rate_activation_epoch, &temp_info, valloc );
-
-    /* Update the stakes epoch value to the new epoch */
-    epoch_bank->stakes.epoch = epoch;
-
-    fd_update_stake_delegations( slot_ctx, &temp_info );
-
-    /* Refresh vote accounts in stakes cache using updated stake weights, and merges slot bank vote accounts with the epoch bank vote accounts.
-     https://github.com/anza-xyz/agave/blob/v2.1.6/runtime/src/stakes.rs#L363-L370 */
-    fd_stake_history_t const * history = fd_sysvar_cache_stake_history( slot_ctx->sysvar_cache );
-    if( FD_UNLIKELY( !history ) ) {
-      FD_LOG_ERR(( "StakeHistory sysvar is missing from sysvar cache" ));
-    }
-    fd_refresh_vote_accounts( slot_ctx, history, new_rate_activation_epoch, &temp_info );
-
-    /* Distribute rewards */
-    fd_hash_t const * parent_blockhash = slot_ctx->slot_bank.block_hash_queue.last_hash;
-    if( ( FD_FEATURE_ACTIVE( slot_ctx, enable_partitioned_epoch_reward ) ||
-          FD_FEATURE_ACTIVE( slot_ctx, partitioned_epoch_rewards_superfeature ) ) ) {
-      FD_LOG_NOTICE(( "fd_begin_partitioned_rewards" ));
-      fd_begin_partitioned_rewards( slot_ctx, parent_blockhash, parent_epoch, &temp_info, valloc );
-    } else {
-      fd_update_rewards( slot_ctx, parent_blockhash, parent_epoch, &temp_info, valloc );
-    }
-
-    /* Replace stakes at T-2 (slot_ctx->slot_bank.epoch_stakes) by stakes at T-1 (epoch_bank->next_epoch_stakes) */
+  /* If appropiate, use the stakes at T-1 to generate the leader schedule instead of T-2.
+      This is due to a subtlety in how Agave's stake caches interact when loading from snapshots.
+      See the comment in fd_exec_slot_ctx_recover_. */
+  if( slot_ctx->slot_bank.has_use_preceeding_epoch_stakes && slot_ctx->slot_bank.use_preceeding_epoch_stakes == epoch ) {
     fd_update_epoch_stakes( slot_ctx );
+  }
 
-    /* Replace stakes at T-1 (epoch_bank->next_epoch_stakes) by updated stakes at T (stakes->vote_accounts) */
-    fd_update_next_epoch_stakes( slot_ctx );
+  /* Updates stake history sysvar accumulated values. */
+  fd_stakes_activate_epoch( slot_ctx, new_rate_activation_epoch, &temp_info, runtime_spad );
 
-    /* Update current leaders using slot_ctx->slot_bank.epoch_stakes (new T-2 stakes) */
-    fd_runtime_update_leaders( slot_ctx, slot_ctx->slot_bank.slot );
+  /* Update the stakes epoch value to the new epoch */
+  epoch_bank->stakes.epoch = epoch;
 
-    fd_calculate_epoch_accounts_hash_values( slot_ctx );
-  } FD_SCRATCH_SCOPE_END;
+  fd_update_stake_delegations( slot_ctx, &temp_info );
+
+  /* Refresh vote accounts in stakes cache using updated stake weights, and merges slot bank vote accounts with the epoch bank vote accounts.
+    https://github.com/anza-xyz/agave/blob/v2.1.6/runtime/src/stakes.rs#L363-L370 */
+  fd_stake_history_t const * history = fd_sysvar_cache_stake_history( slot_ctx->sysvar_cache );
+  if( FD_UNLIKELY( !history ) ) {
+    FD_LOG_ERR(( "StakeHistory sysvar is missing from sysvar cache" ));
+  }
+
+  /* In order to correctly handle the lifetimes of allocations for partitioned
+     epoch rewards, we will push a spad frame when rewards partitioning starts.
+     We will only pop this frame when all of the rewards for the epoch have
+     been distributed. As a note, this is technically not the most optimal use 
+     of memory as some data structures used can be freed when this function
+     exits, but this is okay since the additional allocations are on the order
+     of a few megabytes and are freed after a few thousand slots. */
+
+  fd_spad_push( runtime_spad );
+
+  fd_refresh_vote_accounts( slot_ctx, history, new_rate_activation_epoch, &temp_info, runtime_spad );
+
+  /* Distribute rewards */
+  fd_hash_t const * parent_blockhash = slot_ctx->slot_bank.block_hash_queue.last_hash;
+  if( FD_FEATURE_ACTIVE( slot_ctx, enable_partitioned_epoch_reward ) ||
+      FD_FEATURE_ACTIVE( slot_ctx, partitioned_epoch_rewards_superfeature ) ) {
+    FD_LOG_NOTICE(( "fd_begin_partitioned_rewards" ));
+    fd_begin_partitioned_rewards( slot_ctx, parent_blockhash, parent_epoch, &temp_info, runtime_spad );
+  } else {
+    fd_update_rewards( slot_ctx, parent_blockhash, parent_epoch, &temp_info, runtime_spad );
+  }
+
+  /* Replace stakes at T-2 (slot_ctx->slot_bank.epoch_stakes) by stakes at T-1 (epoch_bank->next_epoch_stakes) */
+  fd_update_epoch_stakes( slot_ctx );
+
+  /* Replace stakes at T-1 (epoch_bank->next_epoch_stakes) by updated stakes at T (stakes->vote_accounts) */
+  fd_update_next_epoch_stakes( slot_ctx );
+
+  /* Update current leaders using slot_ctx->slot_bank.epoch_stakes (new T-2 stakes) */
+  fd_runtime_update_leaders( slot_ctx, slot_ctx->slot_bank.slot, runtime_spad );
+
+  fd_calculate_epoch_accounts_hash_values( slot_ctx );
 
   FD_LOG_NOTICE(( "fd_process_new_epoch end" ));
+
+  long end = fd_log_wallclock();
+  FD_LOG_NOTICE(("fd_process_new_epoch took %ld ms", end - start));
 }
 
 /******************************************************************************/
@@ -3220,7 +3308,7 @@ fd_runtime_parse_microblock_txns( void const *                buf,
 static int
 fd_runtime_microblock_prepare( void const *           buf,
                                ulong                  buf_sz,
-                               fd_valloc_t            valloc,
+                               fd_spad_t *            runtime_spad,
                                fd_microblock_info_t * out_microblock_info ) {
 
   fd_microblock_info_t microblock_info = {
@@ -3235,7 +3323,7 @@ fd_runtime_microblock_prepare( void const *           buf,
   buf_off += hdr_sz;
 
   ulong txn_cnt        = microblock_info.microblock.hdr->txn_cnt;
-  microblock_info.txns = fd_valloc_malloc( valloc, alignof(fd_txn_p_t), txn_cnt * sizeof(fd_txn_p_t) );
+  microblock_info.txns = fd_spad_alloc( runtime_spad, alignof(fd_txn_p_t), txn_cnt * sizeof(fd_txn_p_t) );
   ulong txns_sz        = 0UL;
   if( FD_UNLIKELY( fd_runtime_parse_microblock_txns( (uchar *)buf + buf_off,
                                                      buf_sz - buf_off,
@@ -3244,7 +3332,6 @@ fd_runtime_microblock_prepare( void const *           buf,
                                                      &microblock_info.signature_cnt,
                                                      &microblock_info.account_cnt,
                                                      &txns_sz ) ) ) {
-    fd_valloc_free( valloc, microblock_info.txns );
     return -1;
   }
 
@@ -3258,7 +3345,7 @@ fd_runtime_microblock_prepare( void const *           buf,
 static int
 fd_runtime_microblock_batch_prepare( void const *                 buf,
                                      ulong                        buf_sz,
-                                     fd_valloc_t                  valloc,
+                                     fd_spad_t *                  runtime_spad,
                                      fd_microblock_batch_info_t * out_microblock_batch_info ) {
 
   fd_microblock_batch_info_t microblock_batch_info = {
@@ -3277,15 +3364,14 @@ fd_runtime_microblock_batch_prepare( void const *                 buf,
   buf_off             += sizeof(ulong);
 
   microblock_batch_info.microblock_cnt   = microblock_cnt;
-  microblock_batch_info.microblock_infos = fd_valloc_malloc( valloc, alignof(fd_microblock_info_t), microblock_cnt * sizeof(fd_microblock_info_t) );
+  microblock_batch_info.microblock_infos = fd_spad_alloc( runtime_spad, alignof(fd_microblock_info_t), microblock_cnt * sizeof(fd_microblock_info_t) );
 
   ulong signature_cnt = 0UL;
   ulong txn_cnt       = 0UL;
   ulong account_cnt   = 0UL;
   for( ulong i=0UL; i<microblock_cnt; i++ ) {
     fd_microblock_info_t * microblock_info = &microblock_batch_info.microblock_infos[i];
-    if( FD_UNLIKELY( fd_runtime_microblock_prepare( (uchar const *)buf + buf_off, buf_sz - buf_off, valloc, microblock_info ) ) ) {
-      fd_valloc_free( valloc, microblock_batch_info.microblock_infos );
+    if( FD_UNLIKELY( fd_runtime_microblock_prepare( (uchar const *)buf + buf_off, buf_sz - buf_off, runtime_spad, microblock_info ) ) ) {
       return -1;
     }
 
@@ -3310,7 +3396,7 @@ static int
 fd_runtime_block_prepare( fd_blockstore_t * blockstore,
                           fd_block_t *      block,
                           ulong             slot,
-                          fd_valloc_t       valloc,
+                          fd_spad_t *       runtime_spad,
                           fd_block_info_t * out_block_info ) {
   uchar const *                  buf         = fd_blockstore_block_data_laddr( blockstore, block );
   ulong const                    buf_sz      = block->data_sz;
@@ -3327,14 +3413,13 @@ fd_runtime_block_prepare( fd_blockstore_t * blockstore,
   ulong signature_cnt        = 0UL;
   ulong txn_cnt              = 0UL;
   ulong account_cnt          = 0UL;
-  block_info.microblock_batch_infos = fd_valloc_malloc( valloc, alignof(fd_microblock_batch_info_t), block->batch_cnt * sizeof(fd_microblock_batch_info_t) );
+  block_info.microblock_batch_infos = fd_spad_alloc( runtime_spad, alignof(fd_microblock_batch_info_t), block->batch_cnt * sizeof(fd_microblock_batch_info_t) );
 
   ulong buf_off = 0UL;
   for( microblock_batch_cnt=0UL; microblock_batch_cnt < batch_cnt; microblock_batch_cnt++ ) {
     ulong const batch_end_off = batch_laddr[ microblock_batch_cnt ].end_off;
     fd_microblock_batch_info_t * microblock_batch_info = block_info.microblock_batch_infos + microblock_batch_cnt;
- 
-    if( FD_UNLIKELY( fd_runtime_microblock_batch_prepare( buf + buf_off, batch_end_off - buf_off, valloc, microblock_batch_info ) ) ) {
+    if( FD_UNLIKELY( fd_runtime_microblock_batch_prepare( buf + buf_off, batch_end_off - buf_off, runtime_spad, microblock_batch_info ) ) ) {
       return -1;
     }
 
@@ -3408,10 +3493,10 @@ fd_runtime_block_collect_txns( fd_block_info_t const * block_info,
 /*******************************************************************************/
 
 static void
-fd_runtime_init_program( fd_exec_slot_ctx_t * slot_ctx, fd_valloc_t valloc ) {
-  fd_sysvar_recent_hashes_init( slot_ctx );
+fd_runtime_init_program( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_spad ) {
+  fd_sysvar_recent_hashes_init( slot_ctx, runtime_spad );
   fd_sysvar_clock_init( slot_ctx );
-  fd_sysvar_slot_history_init( slot_ctx, valloc );
+  fd_sysvar_slot_history_init( slot_ctx, runtime_spad );
   fd_sysvar_epoch_schedule_init( slot_ctx );
   if( !FD_FEATURE_ACTIVE( slot_ctx, disable_fees_sysvar ) ) {
     fd_sysvar_fees_init( slot_ctx );
@@ -3428,7 +3513,7 @@ static void
 fd_runtime_init_bank_from_genesis( fd_exec_slot_ctx_t *  slot_ctx,
                                    fd_genesis_solana_t * genesis_block,
                                    fd_hash_t const *     genesis_hash,
-                                   fd_valloc_t           valloc ) {
+                                   fd_spad_t *           runtime_spad ) {
   slot_ctx->slot_bank.slot = 0UL;
 
   memcpy( &slot_ctx->slot_bank.poh, genesis_hash->hash, FD_SHA256_HASH_SZ );
@@ -3460,7 +3545,7 @@ fd_runtime_init_bank_from_genesis( fd_exec_slot_ctx_t *  slot_ctx,
   slot_ctx->slot_bank.block_height    = 0UL;
 
   slot_ctx->slot_bank.block_hash_queue.ages_root = NULL;
-  slot_ctx->slot_bank.block_hash_queue.ages_pool = fd_hash_hash_age_pair_t_map_alloc( valloc, 400 );
+  slot_ctx->slot_bank.block_hash_queue.ages_pool = fd_hash_hash_age_pair_t_map_alloc( fd_spad_virtual( runtime_spad ), 400 );
   fd_hash_hash_age_pair_t_mapnode_t * node       = fd_hash_hash_age_pair_t_map_acquire( slot_ctx->slot_bank.block_hash_queue.ages_pool );
   node->elem = (fd_hash_hash_age_pair_t){
     .key = *genesis_hash,
@@ -3468,7 +3553,7 @@ fd_runtime_init_bank_from_genesis( fd_exec_slot_ctx_t *  slot_ctx,
   };
   fd_hash_hash_age_pair_t_map_insert( slot_ctx->slot_bank.block_hash_queue.ages_pool, &slot_ctx->slot_bank.block_hash_queue.ages_root, node );
   slot_ctx->slot_bank.block_hash_queue.last_hash_index = 0UL;
-  slot_ctx->slot_bank.block_hash_queue.last_hash       = fd_valloc_malloc( valloc, FD_HASH_ALIGN, FD_HASH_FOOTPRINT );
+  slot_ctx->slot_bank.block_hash_queue.last_hash       = fd_spad_alloc( runtime_spad, FD_HASH_ALIGN, FD_HASH_FOOTPRINT );
   fd_memcpy( slot_ctx->slot_bank.block_hash_queue.last_hash, genesis_hash, FD_HASH_FOOTPRINT );
   slot_ctx->slot_bank.block_hash_queue.max_age         = FD_BLOCKHASH_QUEUE_MAX_ENTRIES;
 
@@ -3496,13 +3581,14 @@ fd_runtime_init_bank_from_genesis( fd_exec_slot_ctx_t *  slot_ctx,
 
       fd_vote_block_timestamp_t last_timestamp = {0};
       fd_pubkey_t               node_pubkey    = {0};
-      FD_SCRATCH_SCOPE_BEGIN {
+      FD_SPAD_FRAME_BEGIN( runtime_spad ) {
         /* Deserialize content */
         fd_vote_state_versioned_t vs[1];
-        fd_bincode_decode_ctx_t decode =
-            { .data    = acc->account.data,
-              .dataend = acc->account.data + acc->account.data_len,
-              .valloc  = fd_scratch_virtual() };
+        fd_bincode_decode_ctx_t decode = { 
+          .data    = acc->account.data,
+          .dataend = acc->account.data + acc->account.data_len,
+          .valloc  = fd_spad_virtual( runtime_spad ) 
+        };
         int decode_err = fd_vote_state_versioned_decode( vs, &decode );
         if( FD_UNLIKELY( decode_err!=FD_BINCODE_SUCCESS ) ) {
           FD_LOG_WARNING(( "fd_vote_state_versioned_decode failed (%d)", decode_err ));
@@ -3527,7 +3613,7 @@ fd_runtime_init_bank_from_genesis( fd_exec_slot_ctx_t *  slot_ctx,
           __builtin_unreachable();
         }
 
-      } FD_SCRATCH_SCOPE_END;
+      } FD_SPAD_FRAME_END;
 
       fd_memcpy(node->elem.key.key, acc->key.key, sizeof(fd_pubkey_t));
       node->elem.stake = acc->account.lamports;
@@ -3556,7 +3642,7 @@ fd_runtime_init_bank_from_genesis( fd_exec_slot_ctx_t *  slot_ctx,
         .data = acc->account.data,
         .meta = &meta
       };
-      FD_TEST( fd_stake_get_state(&stake_account, valloc, &stake_state) == 0 );
+      FD_TEST( fd_stake_get_state( &stake_account, runtime_spad, &stake_state ) == 0 );
       if( !stake_state.inner.stake.stake.delegation.stake ) {
         continue;
       }
@@ -3589,11 +3675,11 @@ fd_runtime_init_bank_from_genesis( fd_exec_slot_ctx_t *  slot_ctx,
 
       if( found ) {
         /* Load feature activation */
-        FD_SCRATCH_SCOPE_BEGIN {
+        FD_SPAD_FRAME_BEGIN( runtime_spad ) {
           fd_bincode_decode_ctx_t decode = {
             .data = acc->account.data,
             .dataend = acc->account.data + acc->account.data_len,
-            .valloc = fd_scratch_virtual()
+            .valloc = fd_spad_virtual( runtime_spad )
           };
           fd_feature_t feature = {0};
           int err = fd_feature_decode( &feature, &decode );
@@ -3605,12 +3691,12 @@ fd_runtime_init_bank_from_genesis( fd_exec_slot_ctx_t *  slot_ctx,
             FD_LOG_DEBUG(( "Feature %s not activated (genesis)", FD_BASE58_ENC_32_ALLOCA( acc->key.key ) ));
             fd_features_set( &slot_ctx->epoch_ctx->features, found, ULONG_MAX );
           }
-        } FD_SCRATCH_SCOPE_END;
+        } FD_SPAD_FRAME_END;
       }
     }
   }
 
-  slot_ctx->slot_bank.epoch_stakes.vote_accounts_pool = fd_vote_accounts_pair_t_map_alloc( valloc, 100000 );  /* FIXME remove magic constant */
+  slot_ctx->slot_bank.epoch_stakes.vote_accounts_pool = fd_vote_accounts_pair_t_map_alloc( fd_spad_virtual( runtime_spad ), 100000 );  /* FIXME remove magic constant */
   slot_ctx->slot_bank.epoch_stakes.vote_accounts_root = NULL;
 
   fd_vote_accounts_pair_t_mapnode_t * next_pool = fd_exec_epoch_ctx_next_epoch_stakes_join( slot_ctx->epoch_ctx );
@@ -3661,7 +3747,7 @@ fd_runtime_init_bank_from_genesis( fd_exec_slot_ctx_t *  slot_ctx,
   };
 
   slot_ctx->slot_bank.capitalization             = capitalization;
-  slot_ctx->slot_bank.timestamp_votes.votes_pool = fd_clock_timestamp_vote_t_map_alloc( valloc, 10000 ); /* FIXME: remove magic constant */
+  slot_ctx->slot_bank.timestamp_votes.votes_pool = fd_clock_timestamp_vote_t_map_alloc( fd_spad_virtual( runtime_spad ), 10000 ); /* FIXME: remove magic constant */
   slot_ctx->slot_bank.timestamp_votes.votes_root = NULL;
 
 }
@@ -3670,7 +3756,7 @@ static int
 fd_runtime_process_genesis_block( fd_exec_slot_ctx_t * slot_ctx, 
                                   fd_capture_ctx_t *   capture_ctx, 
                                   fd_tpool_t *         tpool, 
-                                  fd_valloc_t          valloc ) {
+                                  fd_spad_t *          runtime_spad ) {
   ulong hashcnt_per_slot = slot_ctx->epoch_ctx->epoch_bank.hashes_per_tick * slot_ctx->epoch_ctx->epoch_bank.ticks_per_slot;
   while( hashcnt_per_slot-- ) {
     fd_sha256_hash( slot_ctx->slot_bank.poh.uc, sizeof(fd_hash_t), slot_ctx->slot_bank.poh.uc );
@@ -3686,12 +3772,12 @@ fd_runtime_process_genesis_block( fd_exec_slot_ctx_t * slot_ctx,
   slot_ctx->nonvote_failed_txn_count           = 0UL;
   slot_ctx->total_compute_units_used           = 0UL;
 
-  fd_sysvar_slot_history_update( slot_ctx, valloc );
+  fd_sysvar_slot_history_update( slot_ctx, runtime_spad );
 
-  fd_runtime_freeze( slot_ctx );
+  fd_runtime_freeze( slot_ctx, runtime_spad );
 
   /* sort and update bank hash */
-  int result = fd_update_hash_bank_tpool( slot_ctx, capture_ctx, &slot_ctx->slot_bank.banks_hash, slot_ctx->signature_cnt, tpool, valloc );
+  int result = fd_update_hash_bank_tpool( slot_ctx, capture_ctx, &slot_ctx->slot_bank.banks_hash, slot_ctx->signature_cnt, tpool,runtime_spad );
   if( FD_UNLIKELY( result != FD_EXECUTOR_INSTR_SUCCESS ) ) {
     FD_LOG_ERR(( "Failed to update bank hash with error=%d", result ));
   }
@@ -3709,7 +3795,8 @@ fd_runtime_read_genesis( fd_exec_slot_ctx_t * slot_ctx,
                          uchar                is_snapshot,
                          fd_capture_ctx_t *   capture_ctx,
                          fd_tpool_t *         tpool,
-                         fd_valloc_t          valloc ) {
+                         fd_spad_t *          runtime_spad ) {
+
   if( strlen( genesis_filepath ) == 0 ) {
     return;
   }
@@ -3729,15 +3816,15 @@ fd_runtime_read_genesis( fd_exec_slot_ctx_t * slot_ctx,
 
   fd_epoch_bank_t *   epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
 
-  FD_SCRATCH_SCOPE_BEGIN {
-    uchar * buf = fd_scratch_alloc( alignof(ulong), (ulong)sbuf.st_size );
+  FD_SPAD_FRAME_BEGIN( runtime_spad ) {
+    uchar * buf = fd_spad_alloc( runtime_spad, alignof(ulong), (ulong)sbuf.st_size );
     ssize_t n   = read( fd, buf, (ulong)sbuf.st_size );
     close( fd );
 
     fd_bincode_decode_ctx_t decode_ctx = {
       .data    = buf,
       .dataend = buf + n,
-      .valloc  = valloc,
+      .valloc  = fd_spad_virtual( runtime_spad ),
     };
     if( FD_UNLIKELY( fd_genesis_solana_decode( &genesis_block, &decode_ctx ) ) ) {
       FD_LOG_ERR(("fd_genesis_solana_decode failed"));
@@ -3746,7 +3833,7 @@ fd_runtime_read_genesis( fd_exec_slot_ctx_t * slot_ctx,
     // The hash is generated from the raw data... don't mess with this..
     fd_sha256_hash( buf, (ulong)n, genesis_hash.uc );
 
-  } FD_SCRATCH_SCOPE_END;
+  } FD_SPAD_FRAME_END;
 
   fd_memcpy( epoch_bank->genesis_hash.uc, genesis_hash.uc, sizeof(fd_hash_t) );
   epoch_bank->cluster_type = genesis_block.cluster_type;
@@ -3757,9 +3844,9 @@ fd_runtime_read_genesis( fd_exec_slot_ctx_t * slot_ctx,
     fd_runtime_init_bank_from_genesis( slot_ctx,
                                        &genesis_block, 
                                        &genesis_hash,
-                                       valloc );
+                                       runtime_spad );
 
-    fd_runtime_init_program( slot_ctx, valloc );
+    fd_runtime_init_program( slot_ctx, runtime_spad );
 
     FD_LOG_DEBUG(( "start genesis accounts - count: %lu", genesis_block.accounts_len ));
 
@@ -3798,25 +3885,25 @@ fd_runtime_read_genesis( fd_exec_slot_ctx_t * slot_ctx,
       fd_write_builtin_account( slot_ctx, a->pubkey, (const char *) a->string, a->string_len );
     }
 
-    fd_features_restore( slot_ctx );
+    fd_features_restore( slot_ctx, runtime_spad );
 
     slot_ctx->slot_bank.slot = 0UL;
 
-    int err = fd_runtime_process_genesis_block( slot_ctx, capture_ctx, tpool, valloc );
+    int err = fd_runtime_process_genesis_block( slot_ctx, capture_ctx, tpool, runtime_spad );
     if( FD_UNLIKELY( err ) ) {
       FD_LOG_ERR(( "Genesis slot 0 execute failed with error %d", err ));
     }
   }
 
   slot_ctx->slot_bank.stake_account_keys.account_keys_root = NULL;
-  slot_ctx->slot_bank.stake_account_keys.account_keys_pool = fd_account_keys_pair_t_map_alloc( valloc, 100000UL );
+  slot_ctx->slot_bank.stake_account_keys.account_keys_pool = fd_account_keys_pair_t_map_alloc( fd_spad_virtual( runtime_spad), 100000UL );
 
   slot_ctx->slot_bank.vote_account_keys.account_keys_root   = NULL;
-  slot_ctx->slot_bank.vote_account_keys.account_keys_pool   = fd_account_keys_pair_t_map_alloc( valloc, 100000UL );
+  slot_ctx->slot_bank.vote_account_keys.account_keys_pool   = fd_account_keys_pair_t_map_alloc( fd_spad_virtual( runtime_spad), 100000UL );
 
   fd_funk_end_write( slot_ctx->acc_mgr->funk );
 
-  fd_bincode_destroy_ctx_t ctx2 = { .valloc = valloc };
+  fd_bincode_destroy_ctx_t ctx2 = { .valloc = fd_spad_virtual( runtime_spad ) };
   fd_genesis_solana_destroy( &genesis_block, &ctx2 );
 }
 
@@ -3986,26 +4073,28 @@ fd_runtime_block_verify_tpool( fd_exec_slot_ctx_t *    slot_ctx,
                                fd_block_info_t const * block_info,
                                fd_hash_t       const * in_poh_hash,
                                fd_hash_t *             out_poh_hash,
-                               fd_valloc_t             valloc,
-                               fd_tpool_t *            tpool ) {
+                               fd_tpool_t *            tpool,
+                               fd_spad_t *             runtime_spad ) {
+
+  FD_SPAD_FRAME_BEGIN( runtime_spad ) {
+
   long block_verify_time = -fd_log_wallclock();
 
   fd_hash_t                    tmp_in_poh_hash           = *in_poh_hash;
   ulong                        poh_verification_info_cnt = block_info->microblock_cnt;
-  fd_poh_verification_info_t * poh_verification_info     = fd_valloc_malloc( valloc,
-                                                                             alignof(fd_poh_verification_info_t),
-                                                                             poh_verification_info_cnt * sizeof(fd_poh_verification_info_t));
+  fd_poh_verification_info_t * poh_verification_info     = fd_spad_alloc( runtime_spad,
+                                                                          alignof(fd_poh_verification_info_t),
+                                                                          poh_verification_info_cnt * sizeof(fd_poh_verification_info_t) );
   fd_runtime_block_verify_info_collect( block_info, &tmp_in_poh_hash, poh_verification_info );
 
-  uchar * block_data = fd_valloc_malloc( valloc, 128UL, FD_SHRED_DATA_PAYLOAD_MAX_PER_SLOT );
-  ulong tick_res = fd_runtime_block_verify_ticks(
-    slot_ctx->blockstore,
-    slot_ctx->slot_bank.slot,
-    block_data,
-    FD_SHRED_DATA_PAYLOAD_MAX_PER_SLOT,
-    slot_ctx->slot_bank.tick_height,
-    slot_ctx->slot_bank.max_tick_height,
-    slot_ctx->epoch_ctx->epoch_bank.hashes_per_tick
+  uchar * block_data = fd_spad_alloc( runtime_spad, 128UL, FD_SHRED_DATA_PAYLOAD_MAX_PER_SLOT );
+  ulong   tick_res   = fd_runtime_block_verify_ticks( slot_ctx->blockstore,
+                                                      slot_ctx->slot_bank.slot,
+                                                      block_data,
+                                                      FD_SHRED_DATA_PAYLOAD_MAX_PER_SLOT,
+                                                      slot_ctx->slot_bank.tick_height,
+                                                      slot_ctx->slot_bank.max_tick_height,
+                                                      slot_ctx->epoch_ctx->epoch_bank.hashes_per_tick
   );
   if( FD_UNLIKELY( tick_res != FD_BLOCK_OK ) ) {
     FD_LOG_WARNING(( "failed to verify ticks res %lu slot %lu", tick_res, slot_ctx->slot_bank.slot ));
@@ -4016,7 +4105,6 @@ fd_runtime_block_verify_tpool( fd_exec_slot_ctx_t *    slot_ctx,
 
   int result = fd_runtime_poh_verify_tpool( poh_verification_info, poh_verification_info_cnt, tpool );
   fd_memcpy( out_poh_hash->hash, poh_verification_info[poh_verification_info_cnt - 1].microblock_info->microblock.hdr->hash, sizeof(fd_hash_t) );
-  fd_valloc_free( valloc, poh_verification_info );
 
   block_verify_time          += fd_log_wallclock();
   double block_verify_time_ms = (double)block_verify_time * 1e-6;
@@ -4024,13 +4112,15 @@ fd_runtime_block_verify_tpool( fd_exec_slot_ctx_t *    slot_ctx,
   FD_LOG_INFO(( "verified block successfully - elapsed: %6.6f ms", block_verify_time_ms ));
 
   return result;
+
+  } FD_SPAD_FRAME_END;
 }
 
 static int
 fd_runtime_publish_old_txns( fd_exec_slot_ctx_t * slot_ctx,
                              fd_capture_ctx_t *   capture_ctx,
                              fd_tpool_t *         tpool,
-                             fd_valloc_t          valloc ) {
+                             fd_spad_t *          runtime_spad ) {
   /* Publish any transaction older than 31 slots */
   fd_funk_t *       funk       = slot_ctx->acc_mgr->funk;
   fd_funk_txn_t *   txnmap     = fd_funk_txn_map( funk, fd_funk_wksp( funk ) );
@@ -4081,8 +4171,8 @@ fd_runtime_publish_old_txns( fd_exec_slot_ctx_t * slot_ctx,
       }
 
       if( txn->xid.ul[0] >= epoch_bank->eah_start_slot ) {
-        if( !FD_FEATURE_ACTIVE( slot_ctx, accounts_lt_hash) ) {
-          fd_accounts_hash( slot_ctx->acc_mgr->funk, &slot_ctx->slot_bank, valloc, tpool, &slot_ctx->slot_bank.epoch_account_hash );
+        if( !FD_FEATURE_ACTIVE( slot_ctx, accounts_lt_hash ) ) {
+          fd_accounts_hash( slot_ctx->acc_mgr->funk, &slot_ctx->slot_bank, tpool, &slot_ctx->slot_bank.epoch_account_hash, runtime_spad );
         }
         epoch_bank->eah_start_slot = ULONG_MAX;
       }
@@ -4101,55 +4191,62 @@ fd_runtime_block_execute_tpool( fd_exec_slot_ctx_t *    slot_ctx,
                                 fd_capture_ctx_t *      capture_ctx,
                                 fd_block_info_t const * block_info,
                                 fd_tpool_t *            tpool,
-                                fd_spad_t * *           spads,
-                                ulong                   spad_cnt,
-                                fd_valloc_t             valloc ) {
-  FD_SCRATCH_SCOPE_BEGIN {
-    if ( capture_ctx != NULL && capture_ctx->capture ) {
-      fd_solcap_writer_set_slot( capture_ctx->capture, slot_ctx->slot_bank.slot );
-    }
+                                fd_spad_t * *           exec_spads,
+                                ulong                   exec_spad_cnt,
+                                fd_spad_t *             runtime_spad ) {
 
-    long block_execute_time = -fd_log_wallclock();
+  if ( capture_ctx != NULL && capture_ctx->capture ) {
+    fd_solcap_writer_set_slot( capture_ctx->capture, slot_ctx->slot_bank.slot );
+  }
 
-    int res = fd_runtime_block_execute_prepare( slot_ctx, valloc );
-    if( res != FD_RUNTIME_EXECUTE_SUCCESS ) {
-      return res;
-    }
+  long block_execute_time = -fd_log_wallclock();
 
-    ulong txn_cnt = block_info->txn_cnt;
-    fd_txn_p_t * txn_ptrs = fd_scratch_alloc( alignof(fd_txn_p_t), txn_cnt * sizeof(fd_txn_p_t) );
+  int res = fd_runtime_block_execute_prepare( slot_ctx, runtime_spad );
+  if( res != FD_RUNTIME_EXECUTE_SUCCESS ) {
+    return res;
+  }
 
-    fd_runtime_block_collect_txns( block_info, txn_ptrs );
+  ulong        txn_cnt  = block_info->txn_cnt;
+  fd_txn_p_t * txn_ptrs = fd_spad_alloc( runtime_spad, alignof(fd_txn_p_t), txn_cnt * sizeof(fd_txn_p_t) );
 
-    res = fd_runtime_process_txns_in_waves_tpool( slot_ctx, capture_ctx, txn_ptrs, txn_cnt, tpool, spads, spad_cnt );
-    if( res != FD_RUNTIME_EXECUTE_SUCCESS ) {
-      return res;
-    }
+  fd_runtime_block_collect_txns( block_info, txn_ptrs );
 
-    long block_finalize_time = -fd_log_wallclock();
-    res = fd_runtime_block_execute_finalize_tpool( slot_ctx, capture_ctx, block_info, tpool, valloc );
-    if( res != FD_RUNTIME_EXECUTE_SUCCESS ) {
-      return res;
-    }
+  res = fd_runtime_process_txns_in_waves_tpool( slot_ctx,
+                                                capture_ctx,
+                                                txn_ptrs,
+                                                txn_cnt,
+                                                tpool,
+                                                exec_spads,
+                                                exec_spad_cnt,
+                                                runtime_spad );
+  if( res != FD_RUNTIME_EXECUTE_SUCCESS ) {
+    return res;
+  }
 
-    slot_ctx->slot_bank.transaction_count += txn_cnt;
+  long block_finalize_time = -fd_log_wallclock();
+  res = fd_runtime_block_execute_finalize_tpool( slot_ctx, capture_ctx, block_info, tpool, runtime_spad );
+  if( res != FD_RUNTIME_EXECUTE_SUCCESS ) {
+    return res;
+  }
 
-    block_finalize_time += fd_log_wallclock();
-    double block_finalize_time_ms = (double)block_finalize_time * 1e-6;
-    FD_LOG_INFO(( "finalized block successfully - slot: %lu, elapsed: %6.6f ms", slot_ctx->slot_bank.slot, block_finalize_time_ms ));
+  slot_ctx->slot_bank.transaction_count += txn_cnt;
 
-    block_execute_time += fd_log_wallclock();
-    double block_execute_time_ms = (double)block_execute_time * 1e-6;
+  block_finalize_time += fd_log_wallclock();
+  double block_finalize_time_ms = (double)block_finalize_time * 1e-6;
+  FD_LOG_INFO(( "finalized block successfully - slot: %lu, elapsed: %6.6f ms", slot_ctx->slot_bank.slot, block_finalize_time_ms ));
 
-    FD_LOG_INFO(( "executed block successfully - slot: %lu, elapsed: %6.6f ms", slot_ctx->slot_bank.slot, block_execute_time_ms ));
+  block_execute_time += fd_log_wallclock();
+  double block_execute_time_ms = (double)block_execute_time * 1e-6;
 
-    return FD_RUNTIME_EXECUTE_SUCCESS;
-  } FD_SCRATCH_SCOPE_END;
+  FD_LOG_INFO(( "executed block successfully - slot: %lu, elapsed: %6.6f ms", slot_ctx->slot_bank.slot, block_execute_time_ms ));
+
+  return FD_RUNTIME_EXECUTE_SUCCESS;
 }
 
 int
 fd_runtime_block_pre_execute_process_new_epoch( fd_exec_slot_ctx_t * slot_ctx,
-                                                fd_valloc_t          valloc ) {
+                                                fd_spad_t *          runtime_spad ) {
+
   /* Update block height. */
   slot_ctx->slot_bank.block_height += 1UL;
 
@@ -4164,10 +4261,10 @@ fd_runtime_block_pre_execute_process_new_epoch( fd_exec_slot_ctx_t * slot_ctx,
     }
 
     if( FD_UNLIKELY( prev_epoch<new_epoch || !slot_idx ) ) {
-      FD_LOG_DEBUG(("Epoch boundary"));
+      FD_LOG_DEBUG(( "Epoch boundary" ));
       /* Epoch boundary! */
       fd_funk_start_write( slot_ctx->acc_mgr->funk );
-      fd_runtime_process_new_epoch( slot_ctx, new_epoch - 1UL, valloc );
+      fd_runtime_process_new_epoch( slot_ctx, new_epoch - 1UL, runtime_spad );
       fd_funk_end_write( slot_ctx->acc_mgr->funk );
     }
   }
@@ -4176,7 +4273,7 @@ fd_runtime_block_pre_execute_process_new_epoch( fd_exec_slot_ctx_t * slot_ctx,
       FD_FEATURE_ACTIVE( slot_ctx, enable_partitioned_epoch_reward ) ||
       FD_FEATURE_ACTIVE( slot_ctx, partitioned_epoch_rewards_superfeature ) ) ) {
     fd_funk_start_write( slot_ctx->acc_mgr->funk );
-    fd_distribute_partitioned_epoch_rewards( slot_ctx, valloc );
+    fd_distribute_partitioned_epoch_rewards( slot_ctx, runtime_spad );
     fd_funk_end_write( slot_ctx->acc_mgr->funk );
   }
 
@@ -4189,15 +4286,14 @@ fd_runtime_block_eval_tpool( fd_exec_slot_ctx_t * slot_ctx,
                              fd_tpool_t *         tpool,
                              ulong                scheduler,
                              ulong *              txn_cnt,
-                             fd_spad_t * *        spads,
-                             ulong                spad_cnt,
-                             fd_valloc_t          valloc ) {
-  /** offline replay */
+                             fd_spad_t * *        exec_spads,
+                             ulong                exec_spad_cnt,
+                             fd_spad_t *          runtime_spad ) {
+
+  /* offline replay */
   (void)scheduler;
 
-  FD_SCRATCH_SCOPE_BEGIN {
-
-  int err = fd_runtime_publish_old_txns( slot_ctx, capture_ctx, tpool, valloc );
+  int err = fd_runtime_publish_old_txns( slot_ctx, capture_ctx, tpool, runtime_spad );
   if( err != 0 ) {
     return err;
   }
@@ -4210,11 +4306,6 @@ fd_runtime_block_eval_tpool( fd_exec_slot_ctx_t * slot_ctx,
   fd_block_info_t block_info;
   int ret = FD_RUNTIME_EXECUTE_SUCCESS;
   do {
-    if( FD_UNLIKELY( (ret = fd_runtime_block_prepare( slot_ctx->blockstore, slot_ctx->block, slot, fd_scratch_virtual(), &block_info )) != FD_RUNTIME_EXECUTE_SUCCESS ) ) {
-      break;
-    }
-    *txn_cnt = block_info.txn_cnt;
-
     /* Use the blockhash as the funk xid */
     fd_funk_txn_xid_t xid;
 
@@ -4234,16 +4325,32 @@ fd_runtime_block_eval_tpool( fd_exec_slot_ctx_t * slot_ctx,
     }
     fd_blockstore_end_read( slot_ctx->blockstore );
 
-    if( FD_UNLIKELY( (ret = fd_runtime_block_pre_execute_process_new_epoch( slot_ctx, valloc )) != FD_RUNTIME_EXECUTE_SUCCESS ) ) {
+    if( FD_UNLIKELY( (ret = fd_runtime_block_pre_execute_process_new_epoch( slot_ctx, runtime_spad )) != FD_RUNTIME_EXECUTE_SUCCESS ) ) {
       break;
     }
 
-    if( FD_UNLIKELY( (ret = fd_runtime_block_verify_tpool( slot_ctx, &block_info, &slot_ctx->slot_bank.poh, &slot_ctx->slot_bank.poh, fd_scratch_virtual(), tpool )) != FD_RUNTIME_EXECUTE_SUCCESS ) ) {
+    /* All code here that makes runtime allocations is scoped to the end of
+       a block*/
+    FD_SPAD_FRAME_BEGIN( runtime_spad ) {
+
+    if( FD_UNLIKELY( (ret = fd_runtime_block_prepare( slot_ctx->blockstore,
+                                                      slot_ctx->block,
+                                                      slot,
+                                                      runtime_spad,
+                                                      &block_info )) != FD_RUNTIME_EXECUTE_SUCCESS ) ) {
       break;
     }
-    if( FD_UNLIKELY( (ret = fd_runtime_block_execute_tpool( slot_ctx, capture_ctx, &block_info, tpool, spads, spad_cnt, valloc )) != FD_RUNTIME_EXECUTE_SUCCESS ) ) {
+    *txn_cnt = block_info.txn_cnt;
+
+    if( FD_UNLIKELY( (ret = fd_runtime_block_verify_tpool( slot_ctx, &block_info, &slot_ctx->slot_bank.poh, &slot_ctx->slot_bank.poh, tpool, runtime_spad )) != FD_RUNTIME_EXECUTE_SUCCESS ) ) {
       break;
     }
+    if( FD_UNLIKELY( (ret = fd_runtime_block_execute_tpool( slot_ctx, capture_ctx, &block_info, tpool, exec_spads, exec_spad_cnt, runtime_spad )) != FD_RUNTIME_EXECUTE_SUCCESS ) ) {
+      break;
+    }
+
+    } FD_SPAD_FRAME_END;
+
   } while( 0 );
 
   // FIXME: better way of using starting slot
@@ -4276,102 +4383,12 @@ fd_runtime_block_eval_tpool( fd_exec_slot_ctx_t * slot_ctx,
   // FIXME: this shouldn't be doing this, it doesn't work with forking. punting changing it though
   slot_ctx->slot_bank.slot = slot+1UL;
 
-  } FD_SCRATCH_SCOPE_END;
-
   return 0;
 }
 
 /******************************************************************************/
 /* Debugging Tools                                                            */
 /******************************************************************************/
-
-static void
-fd_runtime_copy_program_data_acc_to_pruned_funk( fd_funk_t *          pruned_funk,
-                                                 fd_funk_txn_t *      prune_txn,
-                                                 fd_exec_slot_ctx_t * slot_ctx,
-                                                 fd_pubkey_t const *  program_pubkey,
-                                                 fd_valloc_t          valloc ) {
-  /* If account corresponds to bpf_upgradeable, copy over the programdata as well.
-     This is necessary for executing any bpf upgradeable program. */
-
-  fd_account_meta_t const * program_acc = fd_acc_mgr_view_raw( slot_ctx->acc_mgr, NULL,
-                                                               program_pubkey, NULL, NULL, NULL );
-
-  if( memcmp( program_acc->info.owner, fd_solana_bpf_loader_upgradeable_program_id.key, sizeof(fd_pubkey_t) ) ) {
-    return;
-  }
-
-  fd_bincode_decode_ctx_t ctx = {
-    .data    = (uchar *)program_acc + program_acc->hlen,
-    .dataend = (char *) ctx.data + program_acc->dlen,
-    .valloc  = valloc,
-  };
-
-  fd_bpf_upgradeable_loader_state_t loader_state;
-  if ( fd_bpf_upgradeable_loader_state_decode( &loader_state, &ctx ) ) {
-    FD_LOG_ERR(( "fd_bpf_upgradeable_loader_state_decode failed" ));
-  }
-
-  if( !fd_bpf_upgradeable_loader_state_is_program( &loader_state ) ) {
-    FD_LOG_ERR(( "fd_bpf_upgradeable_loader_state_is_program failed" ));
-  }
-
-  fd_pubkey_t * programdata_pubkey = (fd_pubkey_t *)&loader_state.inner.program.programdata_address;
-  fd_funk_rec_key_t programdata_reckey = fd_acc_funk_key( programdata_pubkey );
-
-  /* Copy over programdata record */
-  fd_funk_rec_t * new_rec_pd = fd_funk_rec_write_prepare( pruned_funk, prune_txn, &programdata_reckey,
-                                                          0, 1, NULL, NULL );
-  FD_TEST(( !!new_rec_pd ));
-}
-
-static void FD_FN_UNUSED
-fd_runtime_copy_accounts_to_pruned_funk( fd_funk_t *          pruned_funk,
-                                         fd_funk_txn_t *      prune_txn,
-                                         fd_exec_slot_ctx_t * slot_ctx,
-                                         fd_exec_txn_ctx_t *  txn_ctx,
-                                         fd_valloc_t          valloc ) {
-  /* This function is only responsible for copying over the account ids that are
-     modified. The account data is copied over after execution is complete. */
-
-  /* Copy over ALUTs */
-  fd_txn_acct_addr_lut_t * addr_luts = fd_txn_get_address_tables( (fd_txn_t *) txn_ctx->txn_descriptor );
-  for( ulong i = 0; i < txn_ctx->txn_descriptor->addr_table_lookup_cnt; i++ ) {
-    fd_txn_acct_addr_lut_t * addr_lut = &addr_luts[i];
-    fd_pubkey_t const * addr_lut_acc = (fd_pubkey_t *)((uchar *)txn_ctx->_txn_raw->raw + addr_lut->addr_off);
-    if ( addr_lut_acc ) {
-      fd_funk_rec_key_t acc_lut_rec_key = fd_acc_funk_key( addr_lut_acc );
-      fd_funk_rec_write_prepare( pruned_funk, prune_txn, &acc_lut_rec_key, 0, 1, NULL, NULL );
-    }
-  }
-
-  /* Get program id from top level instructions and copy over programdata */
-  fd_instr_info_t instrs[txn_ctx->txn_descriptor->instr_cnt];
-  for ( ushort i = 0; i < txn_ctx->txn_descriptor->instr_cnt; i++ ) {
-    fd_txn_instr_t const * txn_instr = &txn_ctx->txn_descriptor->instr[i];
-    fd_convert_txn_instr_to_instr( txn_ctx, txn_instr, txn_ctx->borrowed_accounts, &instrs[i] );
-    fd_pubkey_t program_pubkey = instrs[i].program_id_pubkey;
-    fd_funk_rec_key_t program_rec_key = fd_acc_funk_key( &program_pubkey );
-    fd_funk_rec_t *new_rec = fd_funk_rec_write_prepare(pruned_funk, prune_txn, &program_rec_key, 0, 1, NULL, NULL);
-    if ( !new_rec ) {
-      FD_LOG_NOTICE(("fd_funk_rec_write_prepare failed %s", FD_BASE58_ENC_32_ALLOCA( &program_pubkey ) ));
-      continue;
-    }
-
-    /* If account corresponds to bpf_upgradeable, copy over the programdata as well */
-    fd_runtime_copy_program_data_acc_to_pruned_funk( pruned_funk, prune_txn, slot_ctx, &program_pubkey, valloc );
-  }
-
-  /* Write out all accounts touched during the transaction, copy over all program data accounts for
-     any BPF upgradeable accounts in case they are a CPI's program account. */
-  for( ulong i = 0; i < txn_ctx->accounts_cnt; i++ ) {
-    fd_pubkey_t * acc_pubkey = (fd_pubkey_t *)&txn_ctx->accounts[i].key;
-    fd_funk_rec_key_t rec_key = fd_acc_funk_key( acc_pubkey );
-    fd_funk_rec_t * rec = fd_funk_rec_write_prepare( pruned_funk, prune_txn, &rec_key, 0, 1, NULL, NULL );
-    FD_TEST(( !!rec ));
-    fd_runtime_copy_program_data_acc_to_pruned_funk( pruned_funk, prune_txn, slot_ctx, acc_pubkey, valloc );
-  }
-}
 
 void
 fd_runtime_checkpt( fd_capture_ctx_t *   capture_ctx,
@@ -4402,46 +4419,6 @@ fd_runtime_checkpt( fd_capture_ctx_t *   capture_ctx,
     }
   }
 
-}
-
-void
-fd_runtime_collect_rent_accounts_prune( ulong slot, fd_exec_slot_ctx_t * slot_ctx, fd_capture_ctx_t * capture_ctx ) {
-  /* TODO: Test if this works across epoch boundaries */
-
-  /* As a note, the number of partitions are determined before execution begins.
-     The rent accounts for each slot are added to the pruned funk. The data in
-     the accounts is populated after execution is completed. */
-  fd_epoch_bank_t const * epoch_bank = fd_exec_epoch_ctx_epoch_bank_const( slot_ctx->epoch_ctx );
-  fd_epoch_schedule_t const * schedule = &epoch_bank->epoch_schedule;
-
-  ulong off;
-
-  fd_slot_to_epoch( schedule, slot, &off );
-
-  fd_funk_t * funk = slot_ctx->acc_mgr->funk;
-  fd_wksp_t * wksp = fd_funk_wksp( funk );
-  fd_funk_partvec_t * partvec = fd_funk_get_partvec( funk, wksp );
-  fd_funk_rec_t * rec_map = fd_funk_rec_map( funk, wksp );
-
-  for (fd_funk_rec_t const *rec_ro = fd_funk_part_head(partvec, (uint)off, rec_map);
-      rec_ro != NULL;
-      rec_ro = fd_funk_part_next(rec_ro, rec_map)) {
-
-    fd_pubkey_t const * key = fd_type_pun_const(rec_ro->pair.key[0].uc);
-    fd_funk_rec_key_t rec_key = fd_acc_funk_key( key );
-
-    fd_funk_txn_xid_t prune_xid;
-    fd_memset( &prune_xid, 0x42, sizeof(fd_funk_txn_xid_t));
-
-    fd_funk_txn_t * txn_map = fd_funk_txn_map( capture_ctx->pruned_funk, fd_funk_wksp( capture_ctx->pruned_funk ) );
-    fd_funk_txn_t * prune_txn = fd_funk_txn_query( &prune_xid, txn_map );
-
-    fd_funk_rec_t * rec = fd_funk_rec_write_prepare( capture_ctx->pruned_funk, prune_txn, &rec_key, 0, 1, NULL, NULL );
-    FD_TEST(( !!rec ));
-
-    int res = fd_funk_part_set( capture_ctx->pruned_funk, rec, (uint)off );
-    FD_TEST(( res == 0 ));
-  }
 }
 
 // TODO: add tracking account_state hashes so that we can verify our

--- a/src/flamenco/runtime/fd_runtime_init.h
+++ b/src/flamenco/runtime/fd_runtime_init.h
@@ -41,7 +41,7 @@ fd_runtime_save_epoch_bank_archival( fd_exec_slot_ctx_t * slot_ctx );
    snapshot. */
 
 void
-fd_features_restore( fd_exec_slot_ctx_t * slot_ctx );
+fd_features_restore( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_spad );
 
 /* Recover slot_bank and epoch_bank from funk. */
 
@@ -49,11 +49,11 @@ void
 fd_runtime_recover_banks( fd_exec_slot_ctx_t * slot_ctx, 
                           int                  delete_first, 
                           int                  clear_first,
-                          fd_valloc_t          valloc );
+                          fd_spad_t *          runtime_spad );
 
 void
 fd_runtime_delete_banks( fd_exec_slot_ctx_t * slot_ctx,
-                         fd_valloc_t          valloc );
+                         fd_spad_t *          runtime_spad );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/fd_txncache.c
+++ b/src/flamenco/runtime/fd_txncache.c
@@ -1089,12 +1089,13 @@ fd_txncache_is_rooted_slot( fd_txncache_t * tc,
 
 int
 fd_txncache_get_entries( fd_txncache_t *         tc,
-                         fd_bank_slot_deltas_t * slot_deltas ) {
+                         fd_bank_slot_deltas_t * slot_deltas,
+                         fd_spad_t *             spad ) {
 
   fd_rwlock_read( tc->lock );
   
   slot_deltas->slot_deltas_len = tc->root_slots_cnt;
-  slot_deltas->slot_deltas     = fd_scratch_alloc( FD_SLOT_DELTA_ALIGN, tc->root_slots_cnt * sizeof(fd_slot_delta_t) );
+  slot_deltas->slot_deltas     = fd_spad_alloc( spad, FD_SLOT_DELTA_ALIGN, tc->root_slots_cnt * sizeof(fd_slot_delta_t) );
 
   fd_txncache_private_txnpage_t * txnpages   = fd_txncache_get_txnpages( tc );
   ulong                         * root_slots = fd_txncache_get_root_slots( tc );
@@ -1104,7 +1105,7 @@ fd_txncache_get_entries( fd_txncache_t *         tc,
 
     slot_deltas->slot_deltas[ i ].slot               = slot;
     slot_deltas->slot_deltas[ i ].is_root            = 1;
-    slot_deltas->slot_deltas[ i ].slot_delta_vec     = fd_scratch_alloc( FD_STATUS_PAIR_ALIGN, FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS * sizeof(fd_status_pair_t) );
+    slot_deltas->slot_deltas[ i ].slot_delta_vec     = fd_spad_alloc( spad, FD_STATUS_PAIR_ALIGN, FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS * sizeof(fd_status_pair_t) );
     slot_deltas->slot_deltas[ i ].slot_delta_vec_len = 0UL;
     ulong slot_delta_vec_len = 0UL;
 
@@ -1134,7 +1135,7 @@ fd_txncache_get_entries( fd_txncache_t *         tc,
       }
 
       status_pair->value.statuses_len = num_statuses;
-      status_pair->value.statuses     = fd_scratch_alloc( FD_CACHE_STATUS_ALIGN, num_statuses * sizeof(fd_cache_status_t) );
+      status_pair->value.statuses     = fd_spad_alloc( spad, FD_CACHE_STATUS_ALIGN, num_statuses * sizeof(fd_cache_status_t) );
       fd_memset( status_pair->value.statuses, 0, num_statuses * sizeof(fd_cache_status_t) );
 
       /* Copy over every entry for the given slot into the slot deltas. */

--- a/src/flamenco/runtime/fd_txncache.h
+++ b/src/flamenco/runtime/fd_txncache.h
@@ -428,13 +428,12 @@ fd_txncache_is_rooted_slot( fd_txncache_t * tc,
 /* fd_txncache_get_entries is responsible for converting the rooted state of
    the status cache back into fd_bank_slot_deltas_t, which is the decoded
    format used by Agave. This is a helper method used to generate Agave-
-   compatible snapshots.
-   TODO: Currently all allocations are done via scratch. This should
-   probably be changed in the future. */
+   compatible snapshots. */
 
 int
 fd_txncache_get_entries( fd_txncache_t *         tc,
-                         fd_bank_slot_deltas_t * bank_slot_deltas );
+                         fd_bank_slot_deltas_t * bank_slot_deltas,
+                         fd_spad_t *             spad );
 
 /* fd_txncache_{is,set}_constipated is used to set and determine if the 
    status cache is currently in a constipated state. */

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.h
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.h
@@ -59,7 +59,7 @@ int
 fd_deploy_program( fd_exec_instr_ctx_t * instr_ctx,
                    uchar const *         programdata,
                    ulong                 programdata_size,
-                   fd_valloc_t           valloc );
+                   fd_spad_t *           spad );
 
 int
 fd_bpf_execute( fd_exec_instr_ctx_t * instr_ctx, fd_sbpf_validated_program_t * prog, uchar is_deprecated );
@@ -87,8 +87,9 @@ read_bpf_upgradeable_loader_state_for_program( fd_exec_txn_ctx_t * txn_ctx,
    https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank/builtins/core_bpf_migration/mod.rs#L155-L233 */
 int
 fd_directly_invoke_loader_v3_deploy( fd_exec_slot_ctx_t * slot_ctx,
-                                     uchar const *          elf,
-                                     ulong                elf_sz );
+                                     uchar const *        elf,
+                                     ulong                elf_sz,
+                                     fd_spad_t *          runtime_spad );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/program/fd_bpf_program_util.h
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.h
@@ -51,17 +51,20 @@ fd_sbpf_validated_program_from_sbpf_program( fd_sbpf_program_t const *     prog,
 
 int
 fd_bpf_scan_and_create_bpf_program_cache_entry( fd_exec_slot_ctx_t * slot_ctx,
-                                                fd_funk_txn_t *      funk_txn );
+                                                fd_funk_txn_t *      funk_txn,
+                                                fd_spad_t *          runtime_spad );
 
 int
 fd_bpf_check_and_create_bpf_program_cache_entry( fd_exec_slot_ctx_t * slot_ctx,
                                                  fd_funk_txn_t *      funk_txn,
-                                                 fd_pubkey_t const *  pubkey );
+                                                 fd_pubkey_t const *  pubkey,
+                                                 fd_spad_t *          runtime_spad );
 
 int
 fd_bpf_scan_and_create_bpf_program_cache_entry_tpool( fd_exec_slot_ctx_t * slot_ctx,
                                                       fd_funk_txn_t *      funk_txn,
-                                                      fd_tpool_t *         tpool );
+                                                      fd_tpool_t *         tpool,
+                                                      fd_spad_t *          runtime_spad );
 
 int
 fd_bpf_load_cache_entry( fd_exec_slot_ctx_t const *     slot_ctx,

--- a/src/flamenco/runtime/program/fd_config_program.c
+++ b/src/flamenco/runtime/program/fd_config_program.c
@@ -80,7 +80,7 @@ _process_config_instr( fd_exec_instr_ctx_t * ctx ) {
 
   /* https://github.com/solana-labs/solana/blob/v1.17.17/programs/config/src/config_processor.rs#L44-L49 */
 
-  fd_pubkey_t * current_signer_keys    = fd_scratch_alloc( alignof(fd_pubkey_t), sizeof(fd_pubkey_t) * current_data.keys_len );
+  fd_pubkey_t * current_signer_keys    = fd_spad_alloc( ctx->txn_ctx->spad, alignof(fd_pubkey_t), sizeof(fd_pubkey_t) * current_data.keys_len );
   ulong         current_signer_key_cnt = 0UL;
 
   for( ulong i=0UL; i < current_data.keys_len; i++ ) {
@@ -258,11 +258,9 @@ fd_config_program_execute( fd_exec_instr_ctx_t * ctx ) {
   FD_EXEC_CU_UPDATE( ctx, DEFAULT_COMPUTE_UNITS );
 
   FD_SPAD_FRAME_BEGIN( ctx->txn_ctx->spad ) {
-  FD_SCRATCH_SCOPE_BEGIN {
 
   int ret = _process_config_instr( ctx );
   return ret;
 
-  } FD_SCRATCH_SCOPE_END;
   } FD_SPAD_FRAME_END;
 }

--- a/src/flamenco/runtime/program/fd_loader_v4_program.c
+++ b/src/flamenco/runtime/program/fd_loader_v4_program.c
@@ -420,7 +420,7 @@ fd_loader_v4_program_instruction_deploy( fd_exec_instr_ctx_t * instr_ctx ) {
        end of the slot. Since programs cannot be invoked until the next slot anyways, doing this is okay.
 
        https://github.com/anza-xyz/agave/blob/09ef71223b24e30e59eaeaf5eb95e85f222c7de1/programs/loader-v4/src/lib.rs#L262-L269 */
-    err = fd_deploy_program( instr_ctx, programdata, buffer->const_meta->dlen - LOADER_V4_PROGRAM_DATA_OFFSET, fd_spad_virtual( instr_ctx->txn_ctx->spad ) );
+    err = fd_deploy_program( instr_ctx, programdata, buffer->const_meta->dlen - LOADER_V4_PROGRAM_DATA_OFFSET, instr_ctx->txn_ctx->spad );
     if( FD_UNLIKELY( err ) ) {
       return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
     }

--- a/src/flamenco/runtime/program/fd_stake_program.h
+++ b/src/flamenco/runtime/program/fd_stake_program.h
@@ -35,7 +35,7 @@ fd_stake_program_config_init( fd_exec_slot_ctx_t * global );
 
 int
 fd_stake_get_state( fd_borrowed_account_t const * self,
-                    fd_valloc_t                   valloc,
+                    fd_spad_t *                   spad,
                     fd_stake_state_v2_t *         out );
 
 fd_stake_history_entry_t

--- a/src/flamenco/runtime/program/fd_system_program.h
+++ b/src/flamenco/runtime/program/fd_system_program.h
@@ -42,7 +42,7 @@ int fd_system_program_exec_upgrade_nonce_account   ( fd_exec_instr_ctx_t * ctx  
 
 /* fd_load_nonce_account loads the state of a nonce account associated
    with a transaction (txn_ctx).  Attempts to create a new
-   fd_nonce_state_versions_t object at *state, using valloc as the heap
+   fd_nonce_state_versions_t object at *state, using spad as the bump
    allocator.  Returns 1 on success and transfers ownership of the new
    state object to the caller.  On failure, returns zero and does not
    create a new state object.  *perr is set to an executor error code. */
@@ -50,7 +50,7 @@ int fd_system_program_exec_upgrade_nonce_account   ( fd_exec_instr_ctx_t * ctx  
 int
 fd_load_nonce_account( fd_exec_txn_ctx_t const *   txn_ctx,
                        fd_nonce_state_versions_t * state,
-                       fd_valloc_t                 valloc,
+                       fd_spad_t *                 spad,
                        int *                       perr );
                        
 /* fd_check_transaction_age returns 0 if the transactions age is

--- a/src/flamenco/runtime/program/fd_system_program_nonce.c
+++ b/src/flamenco/runtime/program/fd_system_program_nonce.c
@@ -163,7 +163,7 @@ fd_system_program_advance_nonce_account( fd_exec_instr_ctx_t *   ctx,
   fd_bincode_decode_ctx_t decode =
     { .data    = account->const_data,
       .dataend = account->const_data + account->const_meta->dlen,
-      .valloc  = fd_scratch_virtual() };
+      .valloc  = fd_spad_virtual( ctx->txn_ctx->spad ) };
   if( FD_UNLIKELY( fd_nonce_state_versions_decode( versions, &decode )!=FD_BINCODE_SUCCESS ) )
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
 
@@ -330,7 +330,7 @@ fd_system_program_withdraw_nonce_account( fd_exec_instr_ctx_t * ctx,
   fd_bincode_decode_ctx_t decode =
     { .data    = from->const_data,
       .dataend = from->const_data + from->const_meta->dlen,
-      .valloc  = fd_scratch_virtual() };
+      .valloc  = fd_spad_virtual( ctx->txn_ctx->spad ) };
   if( FD_UNLIKELY( fd_nonce_state_versions_decode( versions, &decode )!=FD_BINCODE_SUCCESS ) )
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
 
@@ -544,7 +544,7 @@ fd_system_program_initialize_nonce_account( fd_exec_instr_ctx_t *   ctx,
   fd_bincode_decode_ctx_t decode =
     { .data    = account->const_data,
       .dataend = account->const_data + account->const_meta->dlen,
-      .valloc  = fd_scratch_virtual() };
+      .valloc  = fd_spad_virtual( ctx->txn_ctx->spad ) };
   if( FD_UNLIKELY( fd_nonce_state_versions_decode( versions, &decode )!=FD_BINCODE_SUCCESS ) )
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
 
@@ -709,7 +709,7 @@ fd_system_program_authorize_nonce_account( fd_exec_instr_ctx_t *   ctx,
   fd_bincode_decode_ctx_t decode =
     { .data    = account->const_data,
       .dataend = account->const_data + account->const_meta->dlen,
-      .valloc  = fd_scratch_virtual() };
+      .valloc  = fd_spad_virtual( ctx->txn_ctx->spad ) };
   if( FD_UNLIKELY( fd_nonce_state_versions_decode( versions, &decode )!=FD_BINCODE_SUCCESS ) )
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
 
@@ -851,7 +851,7 @@ fd_system_program_exec_upgrade_nonce_account( fd_exec_instr_ctx_t * ctx ) {
   fd_bincode_decode_ctx_t decode =
     { .data    = account->const_data,
       .dataend = account->const_data + account->const_meta->dlen,
-      .valloc  = fd_scratch_virtual() };
+      .valloc  = fd_spad_virtual( ctx->txn_ctx->spad ) };
   if( FD_UNLIKELY( fd_nonce_state_versions_decode( versions, &decode )!=FD_BINCODE_SUCCESS ) )
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
 
@@ -888,7 +888,7 @@ fd_system_program_exec_upgrade_nonce_account( fd_exec_instr_ctx_t * ctx ) {
 int
 fd_load_nonce_account( fd_exec_txn_ctx_t const *   txn_ctx,
                        fd_nonce_state_versions_t * state,
-                       fd_valloc_t                 valloc,
+                       fd_spad_t *                 spad,
                        int *                       perr ) {
 
   *perr = 0;
@@ -947,7 +947,7 @@ fd_load_nonce_account( fd_exec_txn_ctx_t const *   txn_ctx,
   fd_bincode_decode_ctx_t decode = {
     .data    = me_rec->const_data,
     .dataend = me_rec->const_data + me_rec->const_meta->dlen,
-    .valloc  = valloc
+    .valloc  = fd_spad_virtual( spad )
   };
 
   if( fd_nonce_state_versions_decode( state, &decode ) ) {
@@ -1036,7 +1036,7 @@ fd_check_transaction_age( fd_exec_txn_ctx_t * txn_ctx ) {
   fd_bincode_decode_ctx_t decode = {
     .data    = durable_nonce_rec->const_data,
     .dataend = durable_nonce_rec->const_data + durable_nonce_rec->const_meta->dlen,
-    .valloc  = fd_scratch_virtual()
+    .valloc  = fd_spad_virtual( txn_ctx->spad )
   };
 
   fd_nonce_state_versions_t state = {0};

--- a/src/flamenco/runtime/program/fd_vote_program.c
+++ b/src/flamenco/runtime/program/fd_vote_program.c
@@ -1,4 +1,3 @@
-#define FD_SCRATCH_USE_HANDHOLDING 1
 #include "fd_vote_program.h"
 #include "../../types/fd_types_yaml.h"
 #include "../fd_account.h"
@@ -99,7 +98,7 @@ increase_confirmation_count( fd_vote_lockout_t * self, uint by ) {
 
 /* from_vote_state_1_14_11 converts a "current" vote state object into
    the older "v1.14.11" version.  This destroys the "current" object in
-   the process.  valloc is the heap allocator to be used, which must be
+   the process.  spad is the bump allocator to be used, which must be
    the same as the one used for v1.14.11.
 */
 
@@ -107,14 +106,14 @@ increase_confirmation_count( fd_vote_lockout_t * self, uint by ) {
 static void
 from_vote_state_1_14_11( fd_vote_state_t *         vote_state,
                          fd_vote_state_1_14_11_t * vote_state_1_14_11, /* out */
-                         fd_valloc_t               valloc ) {
+                         fd_spad_t *               spad ) {
   vote_state_1_14_11->node_pubkey           = vote_state->node_pubkey;            /* copy */
   vote_state_1_14_11->authorized_withdrawer = vote_state->authorized_withdrawer;  /* copy */
   vote_state_1_14_11->commission            = vote_state->commission;             /* copy */
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/sdk/program/src/vote/state/vote_state_1_14_11.rs#L72
   if( vote_state->votes ) {
-    vote_state_1_14_11->votes = deq_fd_vote_lockout_t_alloc( valloc, deq_fd_landed_vote_t_cnt( vote_state->votes ) );
+    vote_state_1_14_11->votes = deq_fd_vote_lockout_t_alloc( fd_spad_virtual( spad ), deq_fd_landed_vote_t_cnt( vote_state->votes ) );
     for( deq_fd_landed_vote_t_iter_t iter = deq_fd_landed_vote_t_iter_init( vote_state->votes );
          !deq_fd_landed_vote_t_iter_done( vote_state->votes, iter );
          iter = deq_fd_landed_vote_t_iter_next( vote_state->votes, iter ) ) {
@@ -135,8 +134,6 @@ from_vote_state_1_14_11( fd_vote_state_t *         vote_state,
   vote_state->authorized_voters.pool  = NULL;
   vote_state->epoch_credits           = NULL;
 
-  fd_bincode_destroy_ctx_t destroy = { .valloc = valloc };
-  fd_vote_state_destroy( vote_state, &destroy );
 }
 
 /**********************************************************************/
@@ -146,14 +143,14 @@ from_vote_state_1_14_11( fd_vote_state_t *         vote_state,
 // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1074
 static int
 get_state( fd_borrowed_account_t const * self,
-           fd_valloc_t                   valloc,
+           fd_spad_t *                   spad,
            fd_vote_state_versioned_t *   versioned /* out */ ) {
   int rc;
 
   fd_bincode_decode_ctx_t decode_ctx;
   decode_ctx.data    = self->const_data;
   decode_ctx.dataend = &self->const_data[self->const_meta->dlen];
-  decode_ctx.valloc  = valloc;
+  decode_ctx.valloc  = fd_spad_virtual( spad );
 
   rc = fd_vote_state_versioned_decode( versioned, &decode_ctx );
   if( FD_UNLIKELY( rc != FD_BINCODE_SUCCESS ) )
@@ -206,10 +203,10 @@ set_state( ulong                       self_acct_idx,
 static void
 authorized_voters_new( ulong                         epoch,
                        fd_pubkey_t const *           pubkey,
-                       fd_valloc_t                   valloc,
+                       fd_spad_t *                   spad,
                        fd_vote_authorized_voters_t * authorized_voters /* out */ ) {
-  authorized_voters->pool  = fd_vote_authorized_voters_pool_alloc ( valloc, FD_VOTE_AUTHORIZED_VOTERS_MIN );
-  authorized_voters->treap = fd_vote_authorized_voters_treap_alloc( valloc, FD_VOTE_AUTHORIZED_VOTERS_MIN );
+  authorized_voters->pool  = fd_vote_authorized_voters_pool_alloc ( fd_spad_virtual( spad ), FD_VOTE_AUTHORIZED_VOTERS_MIN );
+  authorized_voters->treap = fd_vote_authorized_voters_treap_alloc( fd_spad_virtual( spad ), FD_VOTE_AUTHORIZED_VOTERS_MIN );
   if( 0 == fd_vote_authorized_voters_pool_free( authorized_voters->pool) ) {
     FD_LOG_ERR(( "Authorized_voter pool is empty" ));
   }
@@ -281,7 +278,7 @@ authorized_voters_purge_authorized_voters( fd_vote_authorized_voters_t * self,
 static fd_vote_authorized_voter_t *
 authorized_voters_get_or_calculate_authorized_voter_for_epoch( fd_vote_authorized_voters_t * self,
                                                                ulong                         epoch,
-                                                               int * existed ) {
+                                                               int *                         existed ) {
   *existed                                  = 0;
   ulong                        latest_epoch = 0;
   fd_vote_authorized_voter_t * res =
@@ -341,7 +338,7 @@ authorized_voters_get_and_cache_authorized_voter_for_epoch( fd_vote_authorized_v
 // https://github.com/anza-xyz/agave/blob/v2.0.1/sdk/program/src/vote/state/vote_state_versions.rs#L66
 static fd_landed_vote_t *
 landed_votes_from_lockouts( fd_vote_lockout_t * lockouts,
-                            fd_valloc_t         valloc ) {
+                            fd_spad_t *         spad ) {
   if( !lockouts ) return NULL;
 
   /* Allocate MAX_LOCKOUT_HISTORY (sane case) by default.  In case the
@@ -349,7 +346,7 @@ landed_votes_from_lockouts( fd_vote_lockout_t * lockouts,
 
   ulong cnt = deq_fd_vote_lockout_t_cnt( lockouts );
         cnt = fd_ulong_max( cnt, MAX_LOCKOUT_HISTORY );
-  fd_landed_vote_t * landed_votes = deq_fd_landed_vote_t_alloc( valloc, cnt );
+  fd_landed_vote_t * landed_votes = deq_fd_landed_vote_t_alloc( fd_spad_virtual( spad ), cnt );
 
   for( deq_fd_vote_lockout_t_iter_t iter = deq_fd_vote_lockout_t_iter_init( lockouts );
        !deq_fd_vote_lockout_t_iter_done( lockouts, iter );
@@ -388,7 +385,7 @@ is_uninitialized( fd_vote_state_versioned_t * self ) {
 // https://github.com/anza-xyz/agave/blob/v2.0.1/sdk/program/src/vote/state/vote_state_versions.rs#L73
 static void
 convert_to_current( fd_vote_state_versioned_t * self,
-                    fd_valloc_t                 valloc ) {
+                    fd_spad_t *                 spad ) {
   switch( self->discriminant ) {
   // https://github.com/anza-xyz/agave/blob/v2.0.1/sdk/program/src/vote/state/vote_state_versions.rs#L19
   case fd_vote_state_versioned_enum_v0_23_5: {
@@ -396,7 +393,7 @@ convert_to_current( fd_vote_state_versioned_t * self,
     fd_vote_authorized_voters_t authorized_voters;
     // https://github.com/anza-xyz/agave/blob/v2.0.1/sdk/program/src/vote/state/vote_state_versions.rs#L21
     authorized_voters_new(
-        state->authorized_voter_epoch, &state->authorized_voter, valloc, &authorized_voters );
+        state->authorized_voter_epoch, &state->authorized_voter, spad, &authorized_voters );
 
     /* Temporary to hold current */
     // https://github.com/anza-xyz/agave/blob/v2.0.1/sdk/program/src/vote/state/vote_state_versions.rs#L23
@@ -404,7 +401,7 @@ convert_to_current( fd_vote_state_versioned_t * self,
       .node_pubkey           = state->node_pubkey,            /* copy */
       .authorized_withdrawer = state->authorized_withdrawer,  /* copy */
       .commission            = state->commission,             /* copy */
-      .votes                 = landed_votes_from_lockouts( state->votes, valloc ),
+      .votes                 = landed_votes_from_lockouts( state->votes, spad ),
       .has_root_slot         = state->has_root_slot,  /* copy */
       .root_slot             = state->root_slot,      /* copy */
       .authorized_voters     = authorized_voters,
@@ -418,10 +415,6 @@ convert_to_current( fd_vote_state_versioned_t * self,
 
     /* Move objects */
     state->epoch_credits = NULL;
-
-    /* Deallocate objects owned by old vote state */
-    fd_bincode_destroy_ctx_t destroy = { .valloc = valloc };
-    fd_vote_state_0_23_5_destroy( state, &destroy );
 
     /* Emplace new vote state into target */
     self->discriminant = fd_vote_state_versioned_enum_current;
@@ -438,7 +431,7 @@ convert_to_current( fd_vote_state_versioned_t * self,
       .node_pubkey            = state->node_pubkey,            /* copy */
       .authorized_withdrawer  = state->authorized_withdrawer,  /* copy */
       .commission             = state->commission,             /* copy */
-      .votes                  = landed_votes_from_lockouts( state->votes, valloc ),
+      .votes                  = landed_votes_from_lockouts( state->votes, spad ),
       .has_root_slot          = state->has_root_slot,          /* copy */
       .root_slot              = state->root_slot,              /* copy */
       .authorized_voters      = state->authorized_voters,      /* move */
@@ -451,10 +444,6 @@ convert_to_current( fd_vote_state_versioned_t * self,
     state->authorized_voters.treap = NULL;
     state->authorized_voters.pool  = NULL;
     state->epoch_credits           = NULL;
-
-    /* Deallocate objects owned by old vote state */
-    fd_bincode_destroy_ctx_t destroy = { .valloc = valloc };
-    fd_vote_state_1_14_11_destroy( state, &destroy );
 
     /* Emplace new vote state into target */
     self->discriminant = fd_vote_state_versioned_enum_current;
@@ -477,11 +466,11 @@ convert_to_current( fd_vote_state_versioned_t * self,
 static void
 vote_state_new( fd_vote_init_t *              vote_init,
                 fd_sol_sysvar_clock_t const * clock,
-                fd_valloc_t                   valloc,
+                fd_spad_t *                   spad,
                 fd_vote_state_t *             vote_state /* out */ ) {
   vote_state->node_pubkey = vote_init->node_pubkey;
   authorized_voters_new(
-      clock->epoch, &vote_init->authorized_voter, valloc, &vote_state->authorized_voters );
+      clock->epoch, &vote_init->authorized_voter, spad, &vote_state->authorized_voters );
   // https://github.com/anza-xyz/agave/blob/v2.0.1/sdk/program/src/vote/state/mod.rs#L431
   vote_state->authorized_withdrawer = vote_init->authorized_withdrawer;
   vote_state->commission            = vote_init->commission;
@@ -814,7 +803,7 @@ set_vote_account_state( ulong                       vote_acct_idx,
       // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L184
       fd_vote_state_versioned_t v1_14_11;
       fd_vote_state_versioned_new_disc( &v1_14_11, fd_vote_state_versioned_enum_v1_14_11 );
-      from_vote_state_1_14_11( vote_state, &v1_14_11.inner.v1_14_11, fd_spad_virtual( ctx->txn_ctx->spad ) );
+      from_vote_state_1_14_11( vote_state, &v1_14_11.inner.v1_14_11, ctx->txn_ctx->spad );
       return set_state( vote_acct_idx, vote_account, &v1_14_11, ctx );
     }
 
@@ -828,7 +817,7 @@ set_vote_account_state( ulong                       vote_acct_idx,
     fd_vote_state_versioned_t v1_14_11;
     fd_vote_state_versioned_new_disc( &v1_14_11, fd_vote_state_versioned_enum_v1_14_11 );
 
-    from_vote_state_1_14_11( vote_state, &v1_14_11.inner.v1_14_11, fd_spad_virtual( ctx->txn_ctx->spad ) );
+    from_vote_state_1_14_11( vote_state, &v1_14_11.inner.v1_14_11, ctx->txn_ctx->spad );
     return set_state( vote_acct_idx, vote_account, &v1_14_11, ctx );
   }
 }
@@ -1458,13 +1447,11 @@ authorize( ulong                         vote_acct_idx,
            fd_exec_instr_ctx_t const *   ctx /* feature_set */ ) {
   int rc;
 
-  fd_valloc_t valloc = fd_spad_virtual( ctx->txn_ctx->spad );
-
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L857
   fd_vote_state_versioned_t vote_state_versioned;
-  rc = get_state( vote_account, valloc, &vote_state_versioned );
+  rc = get_state( vote_account, ctx->txn_ctx->spad, &vote_state_versioned );
   if( FD_UNLIKELY( rc ) ) return rc;
-  convert_to_current( &vote_state_versioned, valloc );
+  convert_to_current( &vote_state_versioned, ctx->txn_ctx->spad );
   fd_vote_state_t * vote_state = &vote_state_versioned.inner.current;
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L861
@@ -1514,13 +1501,11 @@ update_validator_identity( ulong                       vote_acct_idx,
                            fd_exec_instr_ctx_t const * ctx /* feature_set */ ) {
   int rc;
 
-  fd_valloc_t valloc = fd_spad_virtual( ctx->txn_ctx->spad );
-
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L900
   fd_vote_state_versioned_t vote_state_versioned;
-  rc = get_state( vote_account, valloc, &vote_state_versioned );
+  rc = get_state( vote_account, ctx->txn_ctx->spad, &vote_state_versioned );
   if( FD_UNLIKELY( rc ) ) return rc;
-  convert_to_current( &vote_state_versioned, valloc );
+  convert_to_current( &vote_state_versioned, ctx->txn_ctx->spad );
   fd_vote_state_t * vote_state = &vote_state_versioned.inner.current;
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L905
@@ -1562,7 +1547,6 @@ update_commission( ulong                       vote_acct_idx,
                    fd_exec_instr_ctx_t const * ctx /* feature_set */ ) {
   int rc;
 
-  fd_valloc_t valloc = fd_spad_virtual( ctx->txn_ctx->spad );
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L925
   fd_vote_state_versioned_t vote_state_versioned;
   fd_vote_state_t * vote_state = NULL;
@@ -1570,9 +1554,9 @@ update_commission( ulong                       vote_acct_idx,
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L927
   int enforce_commission_update_rule = 1;
   if (FD_FEATURE_ACTIVE( ctx->slot_ctx, allow_commission_decrease_at_any_time )) {
-    rc = get_state( vote_account, valloc, &vote_state_versioned );
+    rc = get_state( vote_account, ctx->txn_ctx->spad, &vote_state_versioned );
     if ( FD_LIKELY( rc==FD_EXECUTOR_INSTR_SUCCESS ) ) {
-      convert_to_current( &vote_state_versioned, valloc );
+      convert_to_current( &vote_state_versioned, ctx->txn_ctx->spad );
       vote_state = &vote_state_versioned.inner.current;
       enforce_commission_update_rule = commission > vote_state->commission;
     }
@@ -1589,9 +1573,9 @@ update_commission( ulong                       vote_acct_idx,
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L949
   if (NULL == vote_state) {
-    rc = get_state( vote_account, valloc, &vote_state_versioned );
+    rc = get_state( vote_account, ctx->txn_ctx->spad, &vote_state_versioned );
     if( FD_UNLIKELY( rc ) ) return rc;
-    convert_to_current( &vote_state_versioned, valloc );
+    convert_to_current( &vote_state_versioned, ctx->txn_ctx->spad );
     vote_state = &vote_state_versioned.inner.current;
   }
 
@@ -1622,13 +1606,11 @@ withdraw(
 ) {
   int rc;
 
-  fd_valloc_t valloc = fd_spad_virtual( ctx->txn_ctx->spad );
-
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1010
   fd_vote_state_versioned_t vote_state_versioned;
-  rc = get_state( vote_account, valloc, &vote_state_versioned );
+  rc = get_state( vote_account, ctx->txn_ctx->spad, &vote_state_versioned );
   if( FD_UNLIKELY( rc ) ) return rc;
-  convert_to_current( &vote_state_versioned, valloc );
+  convert_to_current( &vote_state_versioned, ctx->txn_ctx->spad );
   fd_vote_state_t * vote_state = &vote_state_versioned.inner.current;
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1014
@@ -1773,8 +1755,6 @@ initialize_account( ulong                         vote_acct_idx,
                     fd_exec_instr_ctx_t const *   ctx /* feature_set */ ) {
   int rc;
 
-  fd_valloc_t valloc = fd_spad_virtual( ctx->txn_ctx->spad );
-
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1067
   ulong data_len = vote_account->const_meta->dlen;
   if( FD_UNLIKELY( data_len != size_of_versioned( FD_FEATURE_ACTIVE(
@@ -1784,7 +1764,7 @@ initialize_account( ulong                         vote_acct_idx,
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1074
   fd_vote_state_versioned_t versioned;
-  rc = get_state( vote_account, valloc, &versioned );
+  rc = get_state( vote_account, ctx->txn_ctx->spad, &versioned );
   if( FD_UNLIKELY( rc ) ) return rc;
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1076
@@ -1806,7 +1786,7 @@ initialize_account( ulong                         vote_acct_idx,
   fd_vote_state_versioned_new( &versioned );
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1083
-  vote_state_new( vote_init, clock, valloc, &versioned.inner.current );
+  vote_state_new( vote_init, clock, ctx->txn_ctx->spad, &versioned.inner.current );
   return set_vote_account_state( vote_acct_idx, vote_account, &versioned.inner.current, ctx );
 }
 
@@ -1820,10 +1800,8 @@ verify_and_get_vote_state( fd_borrowed_account_t *       vote_account,
   int                       rc;
   fd_vote_state_versioned_t versioned;
 
-  fd_valloc_t valloc = fd_spad_virtual( ctx->txn_ctx->spad );
-
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1091
-  rc = get_state( vote_account, valloc, &versioned );
+  rc = get_state( vote_account, ctx->txn_ctx->spad, &versioned );
   if( FD_UNLIKELY( rc ) ) return rc;
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1093
@@ -1831,7 +1809,7 @@ verify_and_get_vote_state( fd_borrowed_account_t *       vote_account,
     return FD_EXECUTOR_INSTR_ERR_UNINITIALIZED_ACCOUNT;
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1097
-  convert_to_current( &versioned, valloc );
+  convert_to_current( &versioned, ctx->txn_ctx->spad );
   memcpy( vote_state, &versioned.inner.current, sizeof( fd_vote_state_t ) );
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1098
@@ -1908,8 +1886,6 @@ do_process_vote_state_update( fd_vote_state_t *           vote_state,
                               fd_exec_instr_ctx_t const * ctx /* feature_set */ ) {
   int rc;
 
-  fd_valloc_t valloc = fd_spad_virtual( ctx->txn_ctx->spad );
-
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1164
   rc = check_and_filter_proposed_vote_state(
       vote_state,
@@ -1918,7 +1894,7 @@ do_process_vote_state_update( fd_vote_state_t *           vote_state,
   if( FD_UNLIKELY( rc ) ) return rc;
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1177
-  fd_landed_vote_t * landed_votes = deq_fd_landed_vote_t_alloc( valloc, deq_fd_vote_lockout_t_cnt( vote_state_update->lockouts ) );
+  fd_landed_vote_t * landed_votes = deq_fd_landed_vote_t_alloc( fd_spad_virtual( ctx->txn_ctx->spad ), deq_fd_vote_lockout_t_cnt( vote_state_update->lockouts ) );
   for( deq_fd_vote_lockout_t_iter_t iter =
            deq_fd_vote_lockout_t_iter_init( vote_state_update->lockouts );
        !deq_fd_vote_lockout_t_iter_done( vote_state_update->lockouts, iter );
@@ -1946,6 +1922,11 @@ ulong
 fd_query_pubkey_stake( fd_pubkey_t const * pubkey, fd_vote_accounts_t const * vote_accounts ) {
   fd_vote_accounts_pair_t_mapnode_t key         = { 0 };
   key.elem.key                                  = *pubkey;
+  
+  if( !vote_accounts->vote_accounts_pool && !vote_accounts->vote_accounts_root ) {
+    return 0;
+  }
+
   fd_vote_accounts_pair_t_mapnode_t * vote_node = fd_vote_accounts_pair_t_map_find(
       vote_accounts->vote_accounts_pool, vote_accounts->vote_accounts_root, &key );
   return vote_node ? vote_node->elem.stake : 0;
@@ -2029,7 +2010,7 @@ do_process_tower_sync( fd_vote_state_t *           vote_state,
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1221
   err = process_new_vote_state(
       vote_state,
-      landed_votes_from_lockouts( tower_sync->lockouts, fd_spad_virtual( ctx->txn_ctx->spad ) ),
+      landed_votes_from_lockouts( tower_sync->lockouts, ctx->txn_ctx->spad ),
       tower_sync->has_root,
       tower_sync->root,
       tower_sync->has_timestamp,
@@ -2110,12 +2091,10 @@ fd_vote_decode_compact_update( fd_compact_vote_state_update_t * compact_update,
     vote_update->root     = ULONG_MAX;
   }
 
-  fd_valloc_t valloc = fd_spad_virtual( ctx->txn_ctx->spad );
-
   ulong lockouts_len = compact_update->lockouts_len;
   ulong lockouts_max = fd_ulong_max( lockouts_len, MAX_LOCKOUT_HISTORY );
 
-  vote_update->lockouts = deq_fd_vote_lockout_t_alloc( valloc, lockouts_max );
+  vote_update->lockouts = deq_fd_vote_lockout_t_alloc( fd_spad_virtual( ctx->txn_ctx->spad ), lockouts_max );
   ulong slot            = fd_ulong_if( vote_update->has_root, vote_update->root, 0 );
 
   for( ulong i=0; i < lockouts_len; ++i ) {
@@ -2140,25 +2119,18 @@ fd_vote_decode_compact_update( fd_compact_vote_state_update_t * compact_update,
 }
 
 void
-fd_vote_record_timestamp_vote( fd_exec_slot_ctx_t * slot_ctx,
-                               fd_pubkey_t const *  vote_acc,
-                               long                 timestamp,
-                               fd_valloc_t          valloc ) {
-  fd_vote_record_timestamp_vote_with_slot(
-      slot_ctx, vote_acc, timestamp, slot_ctx->slot_bank.slot, valloc );
-}
-
-void
 fd_vote_record_timestamp_vote_with_slot( fd_exec_slot_ctx_t * slot_ctx,
                                          fd_pubkey_t const *  vote_acc,
                                          long                 timestamp,
                                          ulong                slot,
-                                         fd_valloc_t          valloc ) {
+                                         fd_spad_t *          spad ) {
   fd_clock_timestamp_vote_t_mapnode_t * root = slot_ctx->slot_bank.timestamp_votes.votes_root;
   fd_clock_timestamp_vote_t_mapnode_t * pool = slot_ctx->slot_bank.timestamp_votes.votes_pool;
-  if( NULL == pool )
+  if( NULL == pool ) {
+    /* FIXME: Remove magic number. */
     pool = slot_ctx->slot_bank.timestamp_votes.votes_pool =
-        fd_clock_timestamp_vote_t_map_alloc( valloc, 15000 );
+        fd_clock_timestamp_vote_t_map_alloc( fd_spad_virtual( spad ), 15000 );
+  }
 
   fd_clock_timestamp_vote_t timestamp_vote = {
       .pubkey    = *vote_acc,
@@ -2187,8 +2159,6 @@ fd_vote_acc_credits( fd_exec_instr_ctx_t const * ctx,
                      ulong *                     result ) {
   int rc;
 
-  fd_valloc_t valloc = fd_spad_virtual( ctx->txn_ctx->spad );
-
   fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->slot_ctx->sysvar_cache );
   if( FD_UNLIKELY( !clock ) ) return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -2201,9 +2171,9 @@ fd_vote_acc_credits( fd_exec_instr_ctx_t const * ctx,
 
   rc = 0;
   fd_vote_state_versioned_t vote_state_versioned;
-  rc = get_state( &vote_account, valloc, &vote_state_versioned );
+  rc = get_state( &vote_account, ctx->txn_ctx->spad, &vote_state_versioned );
   if( FD_UNLIKELY( rc ) ) return rc;
-  convert_to_current( &vote_state_versioned, valloc );
+  convert_to_current( &vote_state_versioned, ctx->txn_ctx->spad );
   fd_vote_state_t * state = &vote_state_versioned.inner.current;
   if( deq_fd_vote_epoch_credits_t_empty( state->epoch_credits ) ) {
     *result = 0;
@@ -2838,15 +2808,15 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
 
 int
 fd_vote_get_state( fd_borrowed_account_t const * self,
-                   fd_valloc_t                   valloc,
+                   fd_spad_t *                   spad,
                    fd_vote_state_versioned_t *   versioned /* out */ ) {
-  return get_state( self, valloc, versioned );
+  return get_state( self, spad, versioned );
 }
 
 void
 fd_vote_convert_to_current( fd_vote_state_versioned_t * self,
-                            fd_valloc_t                 valloc ) {
-  convert_to_current( self, valloc );
+                            fd_spad_t *                 spad ) {
+  convert_to_current( self, spad );
 }
 
 static void

--- a/src/flamenco/runtime/program/fd_vote_program.h
+++ b/src/flamenco/runtime/program/fd_vote_program.h
@@ -53,19 +53,19 @@ fd_query_pubkey_stake( fd_pubkey_t const * pubkey, fd_vote_accounts_t const * vo
 
 int
 fd_vote_get_state( fd_borrowed_account_t const * self,
-                   fd_valloc_t                   valloc,
+                   fd_spad_t *                   spad,
                    fd_vote_state_versioned_t *   versioned /* out */ );
 
 void
 fd_vote_convert_to_current( fd_vote_state_versioned_t * self,
-                            fd_valloc_t                 valloc );
+                            fd_spad_t *                 spad );
 
 void
 fd_vote_record_timestamp_vote_with_slot( fd_exec_slot_ctx_t * slot_ctx,
                                          fd_pubkey_t const *  vote_acc,
                                          long                 timestamp,
                                          ulong                slot,
-                                         fd_valloc_t          valloc );
+                                         fd_spad_t *          spad );
 
 struct fd_commission_split {
   ulong voter_portion;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_cache.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_cache.h
@@ -57,7 +57,7 @@
 
 struct __attribute__((aligned(16UL))) fd_sysvar_cache_private {
   ulong       magic;  /* ==FD_SYSVAR_CACHE_MAGIC */
-  fd_valloc_t valloc;
+  fd_spad_t * runtime_spad;
 
   /* Declare the val_{...} values */
 # define X( type, name ) \
@@ -94,7 +94,7 @@ fd_sysvar_cache_footprint( void );
 
 fd_sysvar_cache_t *
 fd_sysvar_cache_new( void *      mem,
-                     fd_valloc_t valloc );
+                     fd_spad_t * runtime_spad );
 
 /* fd_sysvar_cache_delete destroys a given sysvar cache object and any
    heap allocations made.  Detaches from the valloc provided in

--- a/src/flamenco/runtime/sysvar/fd_sysvar_clock.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_clock.h
@@ -23,7 +23,8 @@ fd_sysvar_clock_init( fd_exec_slot_ctx_t * slot_ctx );
    of every slot, before execution commences. */
 
 int
-fd_sysvar_clock_update( fd_exec_slot_ctx_t * slot_ctx, fd_valloc_t valloc );
+fd_sysvar_clock_update( fd_exec_slot_ctx_t * slot_ctx, 
+                        fd_spad_t *          runtime_spad );
 
 /* Reads the current value of the clock sysvar */
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_recent_hashes.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_recent_hashes.h
@@ -17,11 +17,13 @@ FD_PROTOTYPES_BEGIN
 
 /* Initialize the recent hashes sysvar account. */
 void
-fd_sysvar_recent_hashes_init( fd_exec_slot_ctx_t * slot_ctx );
+fd_sysvar_recent_hashes_init( fd_exec_slot_ctx_t * slot_ctx,
+                              fd_spad_t *          runtime_spad );
 
 /* Update the recent hashes sysvar account. This should be called at the start of every slot, before execution commences. */
 void
-fd_sysvar_recent_hashes_update( fd_exec_slot_ctx_t * slot_ctx );
+fd_sysvar_recent_hashes_update( fd_exec_slot_ctx_t * slot_ctx,
+                                fd_spad_t *          runtime_spad );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
@@ -11,7 +11,7 @@
 fd_rent_t *
 fd_sysvar_rent_read( fd_rent_t *                result,
                      fd_exec_slot_ctx_t const * slot_ctx,
-                     fd_valloc_t                valloc ) {
+                     fd_spad_t *                runtime_spad ) {
 
   fd_rent_t const * ret = fd_sysvar_cache_rent( slot_ctx->sysvar_cache );
   if( FD_UNLIKELY( NULL != ret ) ) {
@@ -30,7 +30,7 @@ fd_sysvar_rent_read( fd_rent_t *                result,
   fd_bincode_decode_ctx_t decode = {
     .data    = rent_rec->const_data,
     .dataend = rent_rec->const_data + rent_rec->const_meta->dlen,
-    .valloc  = valloc
+    .valloc  = fd_spad_virtual( runtime_spad )
   };
   err = fd_rent_decode( result, &decode );
   if( FD_UNLIKELY( err ) ) {
@@ -43,7 +43,7 @@ fd_sysvar_rent_read( fd_rent_t *                result,
 
 static void
 write_rent( fd_exec_slot_ctx_t * slot_ctx,
-            fd_rent_t const * rent ) {
+            fd_rent_t const *    rent ) {
 
   uchar enc[ 32 ];
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_rent.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_rent.h
@@ -21,7 +21,7 @@ fd_sysvar_rent_init( fd_exec_slot_ctx_t * slot_ctx );
 fd_rent_t *
 fd_sysvar_rent_read( fd_rent_t *                result,
                      fd_exec_slot_ctx_t const * slot_ctx,
-                     fd_valloc_t                valloc );
+                     fd_spad_t *                runtime_spad );
 
 /* fd_rent_exempt_minimum_balance returns the minimum balance needed
    for an account with the given data_len to be rent exempt.  rent

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
@@ -34,57 +34,54 @@ void fd_sysvar_slot_hashes_init( fd_exec_slot_ctx_t * slot_ctx, fd_slot_hashes_t
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/slot_hashes.rs#L34 */
 void
-fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx, fd_valloc_t valloc ) {
-  FD_SCRATCH_SCOPE_BEGIN {
+fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_spad ) {
+  fd_slot_hashes_t slot_hashes;
+  if( !fd_sysvar_slot_hashes_read( &slot_hashes, slot_ctx, runtime_spad ) ) {
+    slot_hashes.hashes = deq_fd_slot_hash_t_alloc( fd_spad_virtual( runtime_spad ), FD_SYSVAR_SLOT_HASHES_CAP );
+    FD_TEST( slot_hashes.hashes );
+  }
 
-    fd_slot_hashes_t slot_hashes;
-    if( !fd_sysvar_slot_hashes_read( &slot_hashes, slot_ctx, valloc ) ) {
-      slot_hashes.hashes = deq_fd_slot_hash_t_alloc( valloc, FD_SYSVAR_SLOT_HASHES_CAP );
-      FD_TEST( slot_hashes.hashes );
+  fd_slot_hash_t * hashes = slot_hashes.hashes;
+
+  uchar found = 0;
+  for ( deq_fd_slot_hash_t_iter_t iter = deq_fd_slot_hash_t_iter_init( hashes );
+        !deq_fd_slot_hash_t_iter_done( hashes, iter );
+        iter = deq_fd_slot_hash_t_iter_next( hashes, iter ) ) {
+    fd_slot_hash_t * ele = deq_fd_slot_hash_t_iter_ele( hashes, iter );
+    if ( ele->slot == slot_ctx->slot_bank.slot ) {
+      memcpy( &ele->hash, &slot_ctx->slot_bank.banks_hash, sizeof(fd_hash_t) );
+      found = 1;
     }
+  }
 
-    fd_slot_hash_t * hashes = slot_hashes.hashes;
+  if ( !found ) {
+    // https://github.com/firedancer-io/solana/blob/08a1ef5d785fe58af442b791df6c4e83fe2e7c74/runtime/src/bank.rs#L2371
+    fd_slot_hash_t slot_hash = {
+      .hash = slot_ctx->slot_bank.banks_hash, // parent hash?
+      .slot = slot_ctx->slot_bank.prev_slot,   // parent_slot
+    };
+    FD_LOG_DEBUG(( "fd_sysvar_slot_hash_update:  slot %lu,  hash %s", slot_hash.slot, FD_BASE58_ENC_32_ALLOCA( slot_hash.hash.key ) ));
+    fd_bincode_destroy_ctx_t ctx2 = { .valloc = fd_spad_virtual( runtime_spad ) };
 
-    uchar found = 0;
-    for ( deq_fd_slot_hash_t_iter_t iter = deq_fd_slot_hash_t_iter_init( hashes );
-          !deq_fd_slot_hash_t_iter_done( hashes, iter );
-          iter = deq_fd_slot_hash_t_iter_next( hashes, iter ) ) {
-      fd_slot_hash_t * ele = deq_fd_slot_hash_t_iter_ele( hashes, iter );
-      if ( ele->slot == slot_ctx->slot_bank.slot ) {
-        memcpy( &ele->hash, &slot_ctx->slot_bank.banks_hash, sizeof(fd_hash_t) );
-        found = 1;
-      }
-    }
+    if (deq_fd_slot_hash_t_full( hashes ) )
+      fd_slot_hash_destroy( deq_fd_slot_hash_t_pop_tail_nocopy( hashes ), &ctx2 );
 
-    if ( !found ) {
-      // https://github.com/firedancer-io/solana/blob/08a1ef5d785fe58af442b791df6c4e83fe2e7c74/runtime/src/bank.rs#L2371
-      fd_slot_hash_t slot_hash = {
-        .hash = slot_ctx->slot_bank.banks_hash, // parent hash?
-        .slot = slot_ctx->slot_bank.prev_slot,   // parent_slot
-      };
-      FD_LOG_DEBUG(( "fd_sysvar_slot_hash_update:  slot %lu,  hash %s", slot_hash.slot, FD_BASE58_ENC_32_ALLOCA( slot_hash.hash.key ) ));
-      fd_bincode_destroy_ctx_t ctx2 = { .valloc = valloc };
+    deq_fd_slot_hash_t_push_head( hashes, slot_hash );
+  }
 
-      if (deq_fd_slot_hash_t_full( hashes ) )
-        fd_slot_hash_destroy( deq_fd_slot_hash_t_pop_tail_nocopy( hashes ), &ctx2 );
-
-      deq_fd_slot_hash_t_push_head( hashes, slot_hash );
-    }
-
-    write_slot_hashes( slot_ctx, &slot_hashes );
-    fd_bincode_destroy_ctx_t ctx = { .valloc = valloc };
-    fd_slot_hashes_destroy( &slot_hashes, &ctx );
-  } FD_SCRATCH_SCOPE_END;
+  write_slot_hashes( slot_ctx, &slot_hashes );
+  fd_bincode_destroy_ctx_t ctx = { .valloc = fd_spad_virtual( runtime_spad ) };
+  fd_slot_hashes_destroy( &slot_hashes, &ctx );
 }
 
 fd_slot_hashes_t *
 fd_sysvar_slot_hashes_read( fd_slot_hashes_t *    result,
                             fd_exec_slot_ctx_t *  slot_ctx,
-                            fd_valloc_t           valloc ) {
+                            fd_spad_t *           runtime_spad ) {
 
 //  FD_LOG_INFO(( "SysvarS1otHashes111111111111111111111111111 at slot %lu: " FD_LOG_HEX16_FMT, slot_ctx->slot_bank.slot, FD_LOG_HEX16_FMT_ARGS(     metadata.hash    ) ));
 
-  FD_BORROWED_ACCOUNT_DECL(rec);
+  FD_BORROWED_ACCOUNT_DECL( rec );
   int err = fd_acc_mgr_view( slot_ctx->acc_mgr, slot_ctx->funk_txn, (fd_pubkey_t const *)&fd_sysvar_slot_hashes_id, rec );
   if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) )
     return NULL;
@@ -92,7 +89,7 @@ fd_sysvar_slot_hashes_read( fd_slot_hashes_t *    result,
   fd_bincode_decode_ctx_t decode = {
     .data    = rec->const_data,
     .dataend = rec->const_data + rec->const_meta->dlen,
-    .valloc  = valloc /* !!! There is no reason to place this on the slot_ctx heap.  Use scratch instead. */
+    .valloc  = fd_spad_virtual( runtime_spad )
   };
 
   if( FD_UNLIKELY( fd_slot_hashes_decode( result, &decode )!=FD_BINCODE_SUCCESS ) )

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.h
@@ -20,7 +20,7 @@ void fd_sysvar_slot_hashes_init( fd_exec_slot_ctx_t * slot_ctx, fd_slot_hashes_t
 
 /* Update the slot hashes sysvar account. This should be called at the end of every slot, before execution commences. */
 void
-fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx, fd_valloc_t valloc );
+fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_spad );
 
 /* fd_sysvar_slot_hashes_read reads the slot hashes sysvar from the
    accounts manager.  On success, returns 0 and writes deserialized
@@ -29,7 +29,7 @@ fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx, fd_valloc_t valloc 
 fd_slot_hashes_t *
 fd_sysvar_slot_hashes_read( fd_slot_hashes_t *   result,
                             fd_exec_slot_ctx_t * slot_ctx,
-                            fd_valloc_t          valloc );
+                            fd_spad_t *          runtime_spad );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
@@ -52,28 +52,28 @@ int fd_sysvar_slot_history_write_history( fd_exec_slot_ctx_t * slot_ctx,
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/slot_history.rs#L16 */
 void
-fd_sysvar_slot_history_init( fd_exec_slot_ctx_t * slot_ctx, fd_valloc_t valloc ) {
+fd_sysvar_slot_history_init( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_spad ) {
   /* Create a new slot history instance */
-  fd_slot_history_t history = {0};
-  fd_slot_history_inner_t * inner = fd_valloc_malloc( valloc, 8UL, sizeof(fd_slot_history_inner_t) );
-  inner->blocks = fd_valloc_malloc( valloc, 8UL, sizeof(ulong) * blocks_len );
+  fd_slot_history_t         history = {0};
+  fd_slot_history_inner_t * inner   = fd_spad_alloc( runtime_spad, alignof(fd_slot_history_inner_t), sizeof(fd_slot_history_inner_t) );
+  inner->blocks = fd_spad_alloc( runtime_spad, alignof(ulong), sizeof(ulong) * blocks_len );
   memset( inner->blocks, 0, sizeof(ulong) * blocks_len );
   inner->blocks_len = blocks_len;
   history.bits.bits = inner;
-  history.bits.len = slot_history_max_entries;
+  history.bits.len  = slot_history_max_entries;
 
   /* TODO: handle slot != 0 init case */
   fd_sysvar_slot_history_set( &history, slot_ctx->slot_bank.slot );
   history.next_slot = slot_ctx->slot_bank.slot + 1;
 
   fd_sysvar_slot_history_write_history( slot_ctx, &history );
-  fd_bincode_destroy_ctx_t ctx = { .valloc = valloc };
+  fd_bincode_destroy_ctx_t ctx = { .valloc = fd_spad_virtual( runtime_spad ) };
   fd_slot_history_destroy( &history, &ctx );
 }
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/runtime/src/bank.rs#L2345 */
 int
-fd_sysvar_slot_history_update( fd_exec_slot_ctx_t * slot_ctx, fd_valloc_t valloc ) {
+fd_sysvar_slot_history_update( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_spad ) {
   /* Set current_slot, and update next_slot */
 
   fd_pubkey_t const * key = &fd_sysvar_slot_history_id;
@@ -86,7 +86,7 @@ fd_sysvar_slot_history_update( fd_exec_slot_ctx_t * slot_ctx, fd_valloc_t valloc
   fd_bincode_decode_ctx_t ctx;
   ctx.data    = rec->const_data;
   ctx.dataend = rec->const_data + rec->const_meta->dlen;
-  ctx.valloc  = valloc;
+  ctx.valloc  = fd_spad_virtual( runtime_spad );
   fd_slot_history_t history[1];
   if( fd_slot_history_decode( history, &ctx ) )
     FD_LOG_ERR(("fd_slot_history_decode failed"));
@@ -116,7 +116,7 @@ fd_sysvar_slot_history_update( fd_exec_slot_ctx_t * slot_ctx, fd_valloc_t valloc
   rec->meta->dlen = sz;
   fd_memcpy( rec->meta->info.owner, fd_sysvar_owner_id.key, sizeof(fd_pubkey_t) );
 
-  fd_bincode_destroy_ctx_t ctx_d = { .valloc = valloc };
+  fd_bincode_destroy_ctx_t ctx_d = { .valloc = fd_spad_virtual( runtime_spad ) };
   fd_slot_history_destroy( history, &ctx_d );
 
   return 0;
@@ -124,8 +124,8 @@ fd_sysvar_slot_history_update( fd_exec_slot_ctx_t * slot_ctx, fd_valloc_t valloc
 
 int
 fd_sysvar_slot_history_read( fd_exec_slot_ctx_t * slot_ctx,
-                            fd_valloc_t valloc,
-                            fd_slot_history_t * out_history) {
+                             fd_spad_t *          runtime_spad,
+                             fd_slot_history_t *  out_history ) {
   /* Set current_slot, and update next_slot */
 
   fd_pubkey_t const * key = &fd_sysvar_slot_history_id;
@@ -138,7 +138,7 @@ fd_sysvar_slot_history_read( fd_exec_slot_ctx_t * slot_ctx,
   fd_bincode_decode_ctx_t ctx;
   ctx.data    = rec->const_data;
   ctx.dataend = rec->const_data + rec->const_meta->dlen;
-  ctx.valloc  = valloc;
+  ctx.valloc  = fd_spad_virtual( runtime_spad );
   if( fd_slot_history_decode( out_history, &ctx ) )
     FD_LOG_ERR(("fd_slot_history_decode failed"));
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.h
@@ -14,17 +14,17 @@
 /* Initialize the slot history sysvar account. */
 void 
 fd_sysvar_slot_history_init( fd_exec_slot_ctx_t * slot_ctx,
-                             fd_valloc_t          valloc );
+                             fd_spad_t *          runtime_spad );
 
 /* Update the slot history sysvar account. This should be called at the end of every slot, after execution has concluded. */
 int
 fd_sysvar_slot_history_update( fd_exec_slot_ctx_t * slot_ctx,
-                               fd_valloc_t          valloc );
+                               fd_spad_t *          runtime_spad );
 
 /* Reads the current value of the slot history sysvar */
 int
 fd_sysvar_slot_history_read( fd_exec_slot_ctx_t * slot_ctx,
-                             fd_valloc_t          valloc, 
+                             fd_spad_t *          runtime_spad, 
                              fd_slot_history_t *  out_history );
 
 int

--- a/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.h
@@ -23,7 +23,7 @@ fd_sysvar_stake_history_init( fd_exec_slot_ctx_t * slot_ctx );
 void
 fd_sysvar_stake_history_update( fd_exec_slot_ctx_t *       slot_ctx,
                                 fd_stake_history_entry_t * entry,
-                                fd_valloc_t                valloc );
+                                fd_spad_t *                runtime_spad );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.h
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.h
@@ -18,8 +18,11 @@
 /* fd_exec_instr_test_runner_t provides fake fd_exec_instr_ctx_t to
    test processing of individual instructions. */
 
-struct fd_exec_instr_test_runner_private;
-typedef struct fd_exec_instr_test_runner_private fd_exec_instr_test_runner_t;
+struct fd_exec_instr_test_runner {
+  fd_funk_t * funk;
+  fd_spad_t * spad;
+};
+typedef struct fd_exec_instr_test_runner fd_exec_instr_test_runner_t;
 
 FD_PROTOTYPES_BEGIN
 

--- a/src/flamenco/runtime/tests/fd_exec_sol_compat.h
+++ b/src/flamenco/runtime/tests/fd_exec_sol_compat.h
@@ -18,10 +18,10 @@ void
 sol_compat_check_wksp_usage( void );
 
 fd_exec_instr_test_runner_t *
-sol_compat_setup_scratch_and_runner( void * fmem );
+sol_compat_setup_runner( void );
 
 void
-sol_compat_cleanup_scratch_and_runner( fd_exec_instr_test_runner_t * runner );
+sol_compat_cleanup_runner( fd_exec_instr_test_runner_t * runner );
 
 int
 sol_compat_instr_fixture( fd_exec_instr_test_runner_t * runner,

--- a/src/flamenco/runtime/tests/fd_vm_test.c
+++ b/src/flamenco/runtime/tests/fd_vm_test.c
@@ -72,8 +72,8 @@ fd_exec_vm_interp_test_run( fd_exec_instr_test_runner_t *         runner,
     return 0UL;
   }
 
-  fd_valloc_t valloc = fd_scratch_virtual();
-  fd_spad_t * spad = fd_exec_instr_test_runner_get_spad( runner );
+  fd_spad_t * spad   = fd_exec_instr_test_runner_get_spad( runner );
+  fd_valloc_t valloc = fd_spad_virtual( spad ); 
 
   /* Create effects */
   ulong output_end = (ulong) output_buf + output_bufsz;

--- a/src/flamenco/runtime/tests/run_ledger_test.sh
+++ b/src/flamenco/runtime/tests/run_ledger_test.sh
@@ -21,6 +21,7 @@ INDEX_MAX="--index-max 5000000"
 TRASH_HASH=""
 LOG="/tmp/ledger_log$$"
 TILE_CPUS="--tile-cpus 5-21"
+THREAD_MEM_BOUND="--thread-mem-bound 0"
 CLUSTER_VERSION=""
 DUMP_DIR=${DUMP_DIR:="./dump"}
 ONE_OFFS=""
@@ -158,6 +159,7 @@ set -x
     $FUNK_PAGES \
     $SNAPSHOT \
     $ONE_OFFS \
+    $THREAD_MEM_BOUND \
     --allocator wksp \
     $TILE_CPUS >& $LOG
 

--- a/src/flamenco/runtime/tests/run_ledger_tests_all.py
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.py
@@ -56,7 +56,7 @@ def worker(command_queue, available_params, error_occurred, error_event):
 
 
 def main(file_path):
-    cpu_batches = group_cpus_by_num_batches(num_batches=6)
+    cpu_batches = group_cpus_by_num_batches(num_batches=5)
     print("CPU Batches:", cpu_batches)
     # Define parameter ranges
     parameter_ranges = [ f'--tile-cpus {b[0]}-{b[-1]}' for b in cpu_batches ]

--- a/src/flamenco/runtime/tests/run_ledger_tests_all.txt
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.txt
@@ -1,86 +1,86 @@
-src/flamenco/runtime/tests/run_ledger_test.sh -t 105 -l v18multi-inverted -s snapshot-100-FpGocyQzYgnzjnvazuiDHPLkVPZt3vRvGvSNX1GBUMGT.tar.zst -p 50 -y 16 -m 5000000 -e 110 -c 1.18.6
-src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-519       -s snapshot-255311992-Fju7xb3XaTY6SBxkGcsKko15EGAqnvdfkXBd1o6agPDq.tar.zst -p 50 -y 16 -m 1000000 -e 255312007 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-251418170 -s snapshot-251418170-8sAkojR9PYTZvqiQZ1VWu27ewX5tXeVdC97wMXAtgHnT.tar.zst -p 50 -y 16 -m 2000000 -e 251418233 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257066033 -s snapshot-257066033-AD2nFFTCtZVmo5nXLVsQMV1hiQDjzoEBXibRicBJc5Vw.tar.zst -p 50 -y 16 -m 5000000 -e 257066038 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257066844 -s snapshot-257066844-B5JpRYzvMa4iyQeR8w9co4y7oEayphgbXVeQHXLDoWvV.tar.zst -p 50 -y 16 -m 5000000 -e 257066849 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257067457 -s snapshot-257067457-DxbpHefwdjLkPecZG2jLuqyQp8me9dFZQMQ8hZMyfhsw.tar.zst -p 50 -y 16 -m 5000000 -e 257067461 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257068890 -s snapshot-257068890-uRVtagPzKhYorycp4CRtKdWrYPij6iBxCYYXmqRvdSp.tar.zst -p 50 -y 16 -m 5000000 -e 257068895 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257181622 -s snapshot-257181622-Fy996aeLW7kZ6AbBcPd3Vst77pkHDSAXpaexGiVHbB4S.tar.zst -p 50 -y 16 -m 5000000 -e 257181624 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-254462437 -s snapshot-254462437-9HqBi19BJJRZfHeBS3ZpkeP9B5SAxBxz6Kwug29yLHac.tar.zst -p 50 -y 30 -m 20000000 -e 254463436 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-586       -s snapshot-253151900-HVhfam8TtRFVwFto5fWkhgR4mbBJmUxcnxeKZoW5MrSD.tar.zst -p 50 -y 16 -m 5000000 -e 253152100 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-262654839 -s snapshot-262654838-B6GkEWuehxZTZ77Ht9vWUzdX87BiWP5ohi84LMicYTBZ.tar.zst -p 50 -y 16 -m 20000000 -e 262654840 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257039990 -s snapshot-257039990-BSgErEc6ppN4p91meqPvUiXPiEhbakBNHMQQ4wKmceYv.tar.zst -p 50 -y 16 -m 20000000 -e 257040003 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257037451 -s snapshot-257037451-36ERh35nFMRFB8sLHLTUnAd41TuzKYSTyxsa2bgBoMEj.tar.zst -p 50 -y 16 -m 5000000 -e 257037454 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257035225 -s snapshot-257035225-EgwCNhhmffR38XWBXVp3GFs6fmtHKgzw5vEcD9e2oz14.tar.zst -p 50 -y 16 -m 5000000 -e 257035233 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257465453 -s snapshot-257465452-3QExADnJwC756Law388ELX6xhtjnBGwToKVoQUFDcQfn.tar.zst -p 50 -y 16 -m 80000000 -e 257465454 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257058865 -s snapshot-257058865-6SFEm7u5pLAhkm4vfiHiN3vMNkmZuyL2ACuaHznU52fi.tar.zst -p 50 -y 16 -m 5000000 -e 257058870 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257059815 -s snapshot-257059815-AmWkVebTmg6ih2VTEjMmU9WtXhT3RygEoSJBHfDpyAG3.tar.zst -p 50 -y 16 -m 5000000 -e 257059818 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257061172 -s snapshot-257061172-8e6cUSMUx2VZZBDzwXjEY6bGkzPgnUmqrDyr4uErG8BF.tar.zst -p 50 -y 16 -m 5000000 -e 257061175 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257222682 -s snapshot-257222682-Dudsosehu5xdHbqzG5sy72qEu6KyS9FmHnW7oV8pRoNn.tar.zst -p 50 -y 16 -m 5000000 -e 257222688 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-264890264 -s snapshot-264890263-G9sNBh5CPSU9A1nXtC6QE87o1NPkwyMPh7XVKG5mw1Ka.tar.zst -p 50 -y 16 -m 5000000 -e 264890265 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257229353 -s snapshot-257229353-9wETKbJxKf7ceWxtLFJN8VffLQJ2xQVXLUgrXtp6UMx.tar.zst  -p 50 -y 16 -m 5000000 -e 257229357 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257257983 -s snapshot-257257983-2BUVWgqWECejK8jk8XzJhYpYdMuJk2cnAshMcQZmN2Tz.tar.zst -p 50 -y 16 -m 5000000 -e 257257986 -c 1.19.0 --zst
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267728520 -s snapshot-267728520-AnKvgiQEYQMxnSp8U4pps7tR8c7pCJ3mMCE2Zqzij2ek.tar.zst -p 50 -y 16 -m 5000000 -e 267728522 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267651942 -s snapshot-267651941-7u1sT9iRtd26nJdk3CqywGmo857ufb715PSTmfrBxYiS.tar.zst -p 50 -y 16 -m 5000000 -e 267651943 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267081197 -s snapshot-267081196-9qwnybW2TVKfpMKJXKwFwfeW81qX2voqJYxd4qEaHPQu.tar.zst -p 50 -y 16 -m 5000000 -e 267081198 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267085604 -s snapshot-267085603-6JYpKrZVkmvsNvr83xTB63UsYDspCLUgsSAZLgJJZ3we.tar.zst -p 50 -y 16 -m 5000000 -e 267085605 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-265688706 -s snapshot-265688705-Hz56JjQuN4yfXGohYWMsYe2QJiTejQgGNLUaviVN16qP.tar.zst -p 50 -y 16 -m 5000000 -e 265688707 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-265330432 -s snapshot-265330431-BMvcRhxNoRtkZ5KLEKhhXM6GiWdTgdkoGLMe86xY4rF.tar.zst  -p 50 -y 16 -m 5000000 -e 265330433 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-268575190 -s snapshot-268575189-ABBpiGpcqgMs9SMNM4GTcpRPdwidgK6Vi1ZdRdQ4mpmA.tar.zst -p 50 -y 16 -m 5000000 -e 268575191 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-268129380 -s snapshot-268129379-Gr7yXEFt4jyfzSdWytELypb3CNeiYESJWFU6ioAKLJJC.tar.zst -p 50 -y 16 -m 5000000 -e 268129380 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-268163043 -s snapshot-268163042-GXTAsR6oTuEDAmubk2Z39n1cR31CtPqrnid779Wet4q5.tar.zst -p 50 -y 16 -m 5000000 -e 268163043 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-269511381 -s snapshot-269511380-FVV61CtscGVx675oAXF4o1DJeAHmzERLsYgJaTcF4WUS.tar.zst -p 50 -y 16 -m 5000000 -e 269511381 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-269567236 -s snapshot-269567235-4vutao6qjWLjxuvVE16zzFvstZSeSp4PfHvKsmwMUK18.tar.zst -p 50 -y 16 -m 5000000 -e 269567236 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-266134813 -s snapshot-266134812-DuBoJXN87QZWwhwi14ZoTqFYWPFKDpbBczo2U9a9Jidk.tar.zst -p 50 -y 16 -m 5000000 -e 266134814 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-266545736 -s snapshot-266545735-6FUAw2xdpPSw166xyWYpnXNqXogNkb1yPANZZiUqakK2.tar.zst -p 50 -y 16 -m 5000000 -e 266545737 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267059180 -s snapshot-267059179-93LQKWDQZRKdw44JLy1BwwwSh4gTp26zUkAfGdPRBRjJ.tar.zst -p 50 -y 16 -m 5000000 -e 267059181 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267580466 -s snapshot-267580465-EWeMRpeNFC9ue4qD6EFS6SkFrVJwmKnrSrwDHKLRr73h.tar.zst -p 50 -y 16 -m 5000000 -e 267580467 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-268196194 -s snapshot-268196193-57VFX99qvEzdE6aQ5GYMsa4ZdMJFawM657seKjWs7oMe.tar.zst -p 50 -y 16 -m 5000000 -e 268196195 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267766641 -s snapshot-267766640-36YeYWmcfiPXXXLMKuAohjM3SxzvXKDJSrG747zGB72B.tar.zst -p 50 -y 16 -m 5000000 -e 267766642 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-269648145 -s snapshot-269648144-7zWxbqhi4UFRNXxZBxAr8CsKt8MvnXJKwWiakAF4q5wu.tar.zst -p 50 -y 16 -m 5000000 -e 269648146 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l v201-small -s snapshot-100-38CM8ita1fT5SmSLUEeqQZffn2xsy9vKz3WJmsFSnhrJ.tar.zst -p 50 -y 16 -m 500000 -e 120 -c 2.0.1
-src/flamenco/runtime/tests/run_ledger_test.sh -l v20-harcoded-features -s snapshot-100-4EmZxoqF6P2fJJEKgvznd2BkfTvYzsFSup3gyDdV2mY1.tar.zst -p 50 -y 16 -m 500000 -e 700 -c 2.0.2
-src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-281546597 -s snapshot-281546592-5jvGg895YBu829SzrJA4rrExcLSpY1MgVwQshNcJX5EB.tar.zst -p 50 -y 16 -m 5000000 -e 281546597 -c 2.0.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-281688085 -s snapshot-281688080-6NHAVEju9WSsz7LQ3sLS9Yn2Tk9J7QByHRFEQLvXKqHG.tar.zst -p 50 -y 16 -m 5000000 -e 281688086 -c 2.0.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-277660422 -s snapshot-277660421-7fen26CUSpoKnaTXr3cAettDPuF6rsFcu7bEXNz9yhbM.tar.zst -p 50 -y 16 -m 5000000 -e 277660423 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-277876060 -s snapshot-277876059-9vTzJ6qWyH7qkw11V5Np8wutCtExSw5XzethrdFfsjUk.tar.zst -p 50 -y 16 -m 5000000 -e 277876061 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-277927063 -s snapshot-277927062-HqChvv7URAqMvvSx2WdfzL1HJFp21C1UoQHfzKxHyXtJ.tar.zst -p 50 -y 16 -m 5000000 -e 277927065 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l v203-bpf-loader -s snapshot-40-HDKtRRz86coYSVbyocSzPF7Y8xtNLCTUnaZtULrM4Nz9.tar.zst -p 50 -y 16 -m 5000000 -e 100 -c 2.0.3
-src/flamenco/runtime/tests/run_ledger_test.sh -l v203-move-stake -s snapshot-4467-5yzwTpG83nRbokX2iKNYPCPod6fJu3aE8pBEE4SyqLCb.tar.zst        -p 50 -y 16 -m 5000000 -e 4470 -o 7bTK6Jis8Xpfrs8ZoUfiMDPazTcdPcTWheZFJTA5Z6X4 -c 2.0.3
-src/flamenco/runtime/tests/run_ledger_test.sh -l v203-move-lamports -s snapshot-650-Q8pVZ4jfmzpAGwAytPs4PJXmb4iaBXwVhvVjc8AaAXh.tar.zst       -p 50 -y 16 -m 5000000 -e 655 -o 7bTK6Jis8Xpfrs8ZoUfiMDPazTcdPcTWheZFJTA5Z6X4 -c 2.0.3
-src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-283927487 -s snapshot-283927486-7gCbg5g4BnD9SkQUjpHvhepWsQTpo2WaZaA5bhcNBMhG.tar.zst -p 50 -y 16 -m 5000000 -e 283927497 -c 2.0.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-254462437-dm -s snapshot-254462437-9HqBi19BJJRZfHeBS3ZpkeP9B5SAxBxz6Kwug29yLHac.tar.zst -p 50 -y 30 -m 20000000 -e 254462836 -c 1.19.0 -o GJVDwRkUPNdk9QaK4VsU4g1N41QNxhy1hevjf8kz45Mq
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-281375356 -s snapshot-281375353-Bg81vkkW8K3UtrQoEn3wLsEpYwoHRQSihW4t5PiF1bBD.tar.zst -p 50 -y 16 -m 5000000 -e 281375359 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-282232100 -s snapshot-282232097-5ChH2XwaWrYaMvkemMQZmhMxabSNvXLKz3mZSCwhaW5W.tar.zst -p 50 -y 16 -m 5000000 -e 282232101 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-586-partitioned-epoch-rewards -s snapshot-253151900-HVhfam8TtRFVwFto5fWkhgR4mbBJmUxcnxeKZoW5MrSD.tar.zst -p 50 -y 16 -m 5000000 -e 253152100 -c 2.0.3 -o 9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257039990-partitioned-epoch-rewards -s snapshot-257039990-BSgErEc6ppN4p91meqPvUiXPiEhbakBNHMQQ4wKmceYv.tar.zst -p 50 -y 16 -m 20000000 -e 257040003 -c 2.0.3 -o 9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-282151715 -s snapshot-282151712-6qodKmgM9YNdoFzfRKPFmVh1Gv3McVzQ8pd1Gka1efdg.tar.zst -p 50 -y 16 -m 5000000 -e 282151717 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-286450148 -s snapshot-286450145-5kdyfTzRq8GHKgQAZNYLNGRR2MvoeG6CWrsm8uwG6QKF.tar.zst -p 50 -y 15 -m 5000000 -e 286450151 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l v203-multi-epoch-per-70 -s snapshot-70-7YBEAimmCAKQUbxAwwo6ZXNRfkjubnPgqAX8cQX3XXHQ.tar.zst -p 50 -y 16 -m 5000000 -e 631 -c 2.0.3 -o 9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK
-src/flamenco/runtime/tests/run_ledger_test.sh -l v203-multi-epoch-per-160 -s snapshot-160-Aq137keMhyfrccPizmmwngzDHfGW8fUSMkdoDrENxArL.tar.zst -p 50 -y 16 -m 5000000 -e 631 -c 2.0.3 -o 9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK
-src/flamenco/runtime/tests/run_ledger_test.sh -l v203-multi-epoch-per-400 -s snapshot-400-7YQEfWokKvabrikHpWNcZcYGRABeHgLUHjsBVWDYsPzr.tar.zst -p 50 -y 16 -m 5000000 -e 631 -c 2.0.3 -o 9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK
-src/flamenco/runtime/tests/run_ledger_test.sh -l v203-multi-epoch-per-superfeature-70 -s snapshot-70-Hjfc74VPRSX2udP54YuuV8qQKAq7sKse4do1GJGs4Dib.tar.zst -p 50 -y 16 -m 5000000 -e 631 -c 2.0.3 -o PERzQrt5gBD1XEe2c9XdFWqwgHY3mr7cYWbm5V772V8
-src/flamenco/runtime/tests/run_ledger_test.sh -l v203-multi-epoch-per-superfeature-160 -s snapshot-160-9kvex5W9axd5C2Yr4kTEDP6qQBHSkWXS4Rh9hFgKPPQc.tar.zst -p 50 -y 16 -m 5000000 -e 631 -c 2.0.3 -o PERzQrt5gBD1XEe2c9XdFWqwgHY3mr7cYWbm5V772V8
-src/flamenco/runtime/tests/run_ledger_test.sh -l v203-multi-epoch-per-superfeature-400 -s snapshot-400-F1ja3hM4JcRzBrxr7U3my1xqNo64fYkcwRgVijm4uux7.tar.zst -p 50 -y 16 -m 5000000 -e 631 -c 2.0.3 -o PERzQrt5gBD1XEe2c9XdFWqwgHY3mr7cYWbm5V772V8
-src/flamenco/runtime/tests/run_ledger_test.sh -l v208-zk-sdk-ledger -s snapshot-1-GNxLdkaRgGzZSKj79d7yUXK8Nd7dv87WckoCdzQYH4X2.tar.zst -p 50 -y 16 -m 500000 -e 82 -c 2.0.8
-src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-294739503 -s snapshot-294739500-2Y8hFyTtyMuHCgpe26Y1HostyWMZjFvskV5ZpaX6X62S.tar.zst -p 50 -y 16 -m 5000000 -e 294739505 -c 2.0.3
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-290621930 -s snapshot-290621927-AxDRmQNPmGzo1V7KRXfPXtDXTBU3AZj3MUEM1ns3CgH.tar.zst -p 50 -y 16 -m 5000000 -e 290621932 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l devnet-330914784 -s snapshot-330914783-BujhdWiXTfRPfFYMG3GZdEcNc18KyvCcAq9QL9e1i1Fk.tar.zst -p 50 -y 16 -m 5000000 -e 330914785 -c 2.0.8
-src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-mismatch-297489336 -s snapshot-297489335-BgExNqwDtYPo2YQ87C2bra6b5GK2eu52R8Budh85cRUp.tar.zst -p 50 -y 16 -m 5000000 -e 297489363 -c 2.0.3
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-300377724 -s snapshot-300377719-DWngYKosZegyeLAgHK5jVfMsSeuYjSZWJixE5VgcLDAM.tar.zst -p 50 -y 16 -m 5000000 -e 300377728 -c 1.18.23
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-300645644 -s snapshot-300645643-D2ZXqQffEoM6cgPGoC9LC4UfjyCMi1cqbhrceRPh4cE7.tar.zst -p 50 -y 16 -m 5000000 -e 300645644 -c 1.18.23
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-300648964 -s snapshot-300648963-BPSiWGgLbiof1b8Ui5qnM4eUDv8asDo9j7Bn8QvrvwUZ.tar.zst -p 50 -y 16 -m 5000000 -e 300648964 -c 1.18.23
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-301359740 -s snapshot-301359739-5L5b7KFLFiQYpmk7nHUJYX8fXMUG4qv7m6iBMWRN2V5h.tar.zst -p 50 -y 16 -m 5000000 -e 301359740 -c 1.18.23
-src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-302734641 -s snapshot-302734640-9e44jEVavfHC253DSBGSjTFt2diZrgcMHTRZtpUvisvr.tar.zst -p 50 -y 16 -m 5000000 -e 302734658 -c 2.0.10
-src/flamenco/runtime/tests/run_ledger_test.sh -l migrate-feature-program -s snapshot-500-Cz6iotFK7kNcGTpyUZeX4CHbT2uff2uzVW8RXXysBnVk.tar.zst -p 50 -y 16 -m 5000000 -e 675 -c 2.1.0 -o 4eohviozzEeivk1y9UbrnekbAFMDQyJz5JjA9Y6gyvky
-src/flamenco/runtime/tests/run_ledger_test.sh -l migrate-config-program -s snapshot-500-HCg5AHVPC6JAqZo4p6iMcDmo586ZjkxxPpxfAwCHqroy.tar.zst -p 50 -y 16 -m 5000000 -e 675 -c 2.1.0 -o 2Fr57nzzkLYXW695UdDxDeR5fhnZWSttZeZYemrnpGFV
-src/flamenco/runtime/tests/run_ledger_test.sh -l per-stake-history-new-rate-activation-epoch -s snapshot-50-47DbuHpi6gXmZKQ1FUSAAfkgnuWrkfTAtx3Hk5Gqsu5W.tar.zst -p 50 -y 16 -m 5000000 -e 675 -c 2.1.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l enable-get-epoch-stake-syscall -s snapshot-50-FfJQ3ePJx2s5BDymDoiLVRHDHj5doYNQBzyrqus8LocL.tar.zst -p 50 -y 16 -m 5000000 -e 686 -c 2.1.0 -o FKe75t4LXxGaQnVHdUKM6DSFifVVraGZ8LyNo7oPwy1Z
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257181032 -s snapshot-257181030-BiZi1ye6MeW8iq2xUBDrYYPSNuBVrXvzsHjPWvQ8ZytE.tar.zst -p 50 -y 16 -m 5000000 -e 257181035 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257047660 -s snapshot-257047658-Cp4XkpXueDWep78NCTQHCWmG5VszMBjKbGdAoXYLHBfh.tar.zst -p 50 -y 16 -m 5000000 -e 257047662 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257047659 -s snapshot-257047655-5r7etGHT6fJ5edRijJMtYr8xYJpE98ECWF8n7CCZUhDN.tar.zst -p 50 -y 16 -m 5000000 -e 257047660 -c 1.19.0
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-308445707 -s snapshot-308445706-EUsKyaEYAN9VZDSAeBhFET9sdTicGCsghwEF1y1BhTvU.tar.zst -p 50 -y 16 -m 5000000 -e 308445711 -c 2.0.18
-src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-307395181 -s snapshot-307395180-D41gdV5niSbDdwsfb8381krY5pDK4oGeHeS2V1A8ttFr.tar.zst -p 50 -y 16 -m 5000000 -e 307395190 -c 2.1.1
-src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-308392063 -s snapshot-308392062-FDuB6CFKod14xGRGmdiRpQx2uaKyp3GDkyai2Ba7eH8d.tar.zst -p 50 -y 16 -m 5000000 -e 308392090 -c 2.0.18
-src/flamenco/runtime/tests/run_ledger_test.sh -l devnet-350814254 -s snapshot-350814253-G5P3eNtkWUGkZ8b871wvf6d78wYxBJp637PCWJuQByZa.tar.zst -p 50 -y 16 -m 5000000 -e 350814284 -c 2.0.15
-src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-311586340 -s snapshot-311586340-13GSzvNzfBcz1KX6xBs55A8EKNWnCCRZ5Z84T1MSnuUm.tar.zst -p 50 -y 16 -m 5000000 -e 311586380 -c 2.1.1
+src/flamenco/runtime/tests/run_ledger_test.sh -t 105 -l v18multi-inverted -s snapshot-100-FpGocyQzYgnzjnvazuiDHPLkVPZt3vRvGvSNX1GBUMGT.tar.zst -p 60 -y 16 -m 5000000 -e 110 -c 1.18.6
+src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-519       -s snapshot-255311992-Fju7xb3XaTY6SBxkGcsKko15EGAqnvdfkXBd1o6agPDq.tar.zst -p 60 -y 16 -m 1000000 -e 255312007 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-251418170 -s snapshot-251418170-8sAkojR9PYTZvqiQZ1VWu27ewX5tXeVdC97wMXAtgHnT.tar.zst -p 60 -y 16 -m 2000000 -e 251418233 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257066033 -s snapshot-257066033-AD2nFFTCtZVmo5nXLVsQMV1hiQDjzoEBXibRicBJc5Vw.tar.zst -p 60 -y 16 -m 5000000 -e 257066038 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257066844 -s snapshot-257066844-B5JpRYzvMa4iyQeR8w9co4y7oEayphgbXVeQHXLDoWvV.tar.zst -p 60 -y 16 -m 5000000 -e 257066849 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257067457 -s snapshot-257067457-DxbpHefwdjLkPecZG2jLuqyQp8me9dFZQMQ8hZMyfhsw.tar.zst -p 60 -y 16 -m 5000000 -e 257067461 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257068890 -s snapshot-257068890-uRVtagPzKhYorycp4CRtKdWrYPij6iBxCYYXmqRvdSp.tar.zst -p 60 -y 16 -m 5000000 -e 257068895 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257181622 -s snapshot-257181622-Fy996aeLW7kZ6AbBcPd3Vst77pkHDSAXpaexGiVHbB4S.tar.zst -p 60 -y 16 -m 5000000 -e 257181624 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-254462437 -s snapshot-254462437-9HqBi19BJJRZfHeBS3ZpkeP9B5SAxBxz6Kwug29yLHac.tar.zst -p 60 -y 30 -m 20000000 -e 254463436 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-586       -s snapshot-253151900-HVhfam8TtRFVwFto5fWkhgR4mbBJmUxcnxeKZoW5MrSD.tar.zst -p 60 -y 16 -m 5000000 -e 253152100 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-262654839 -s snapshot-262654838-B6GkEWuehxZTZ77Ht9vWUzdX87BiWP5ohi84LMicYTBZ.tar.zst -p 60 -y 16 -m 20000000 -e 262654840 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257039990 -s snapshot-257039990-BSgErEc6ppN4p91meqPvUiXPiEhbakBNHMQQ4wKmceYv.tar.zst -p 60 -y 16 -m 20000000 -e 257040003 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257037451 -s snapshot-257037451-36ERh35nFMRFB8sLHLTUnAd41TuzKYSTyxsa2bgBoMEj.tar.zst -p 60 -y 16 -m 5000000 -e 257037454 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257035225 -s snapshot-257035225-EgwCNhhmffR38XWBXVp3GFs6fmtHKgzw5vEcD9e2oz14.tar.zst -p 60 -y 16 -m 5000000 -e 257035233 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257465453 -s snapshot-257465452-3QExADnJwC756Law388ELX6xhtjnBGwToKVoQUFDcQfn.tar.zst -p 60 -y 16 -m 80000000 -e 257465454 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257058865 -s snapshot-257058865-6SFEm7u5pLAhkm4vfiHiN3vMNkmZuyL2ACuaHznU52fi.tar.zst -p 60 -y 16 -m 5000000 -e 257058870 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257059815 -s snapshot-257059815-AmWkVebTmg6ih2VTEjMmU9WtXhT3RygEoSJBHfDpyAG3.tar.zst -p 60 -y 16 -m 5000000 -e 257059818 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257061172 -s snapshot-257061172-8e6cUSMUx2VZZBDzwXjEY6bGkzPgnUmqrDyr4uErG8BF.tar.zst -p 60 -y 16 -m 5000000 -e 257061175 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257222682 -s snapshot-257222682-Dudsosehu5xdHbqzG5sy72qEu6KyS9FmHnW7oV8pRoNn.tar.zst -p 60 -y 16 -m 5000000 -e 257222688 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-264890264 -s snapshot-264890263-G9sNBh5CPSU9A1nXtC6QE87o1NPkwyMPh7XVKG5mw1Ka.tar.zst -p 60 -y 16 -m 5000000 -e 264890265 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257229353 -s snapshot-257229353-9wETKbJxKf7ceWxtLFJN8VffLQJ2xQVXLUgrXtp6UMx.tar.zst  -p 60 -y 16 -m 5000000 -e 257229357 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257257983 -s snapshot-257257983-2BUVWgqWECejK8jk8XzJhYpYdMuJk2cnAshMcQZmN2Tz.tar.zst -p 60 -y 16 -m 5000000 -e 257257986 -c 1.19.0 --zst
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267728520 -s snapshot-267728520-AnKvgiQEYQMxnSp8U4pps7tR8c7pCJ3mMCE2Zqzij2ek.tar.zst -p 60 -y 16 -m 5000000 -e 267728522 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267651942 -s snapshot-267651941-7u1sT9iRtd26nJdk3CqywGmo857ufb715PSTmfrBxYiS.tar.zst -p 60 -y 16 -m 5000000 -e 267651943 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267081197 -s snapshot-267081196-9qwnybW2TVKfpMKJXKwFwfeW81qX2voqJYxd4qEaHPQu.tar.zst -p 60 -y 16 -m 5000000 -e 267081198 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267085604 -s snapshot-267085603-6JYpKrZVkmvsNvr83xTB63UsYDspCLUgsSAZLgJJZ3we.tar.zst -p 60 -y 16 -m 5000000 -e 267085605 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-265688706 -s snapshot-265688705-Hz56JjQuN4yfXGohYWMsYe2QJiTejQgGNLUaviVN16qP.tar.zst -p 60 -y 16 -m 5000000 -e 265688707 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-265330432 -s snapshot-265330431-BMvcRhxNoRtkZ5KLEKhhXM6GiWdTgdkoGLMe86xY4rF.tar.zst  -p 60 -y 16 -m 5000000 -e 265330433 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-268575190 -s snapshot-268575189-ABBpiGpcqgMs9SMNM4GTcpRPdwidgK6Vi1ZdRdQ4mpmA.tar.zst -p 60 -y 16 -m 5000000 -e 268575191 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-268129380 -s snapshot-268129379-Gr7yXEFt4jyfzSdWytELypb3CNeiYESJWFU6ioAKLJJC.tar.zst -p 60 -y 16 -m 5000000 -e 268129380 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-268163043 -s snapshot-268163042-GXTAsR6oTuEDAmubk2Z39n1cR31CtPqrnid779Wet4q5.tar.zst -p 60 -y 16 -m 5000000 -e 268163043 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-269511381 -s snapshot-269511380-FVV61CtscGVx675oAXF4o1DJeAHmzERLsYgJaTcF4WUS.tar.zst -p 60 -y 16 -m 5000000 -e 269511381 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-269567236 -s snapshot-269567235-4vutao6qjWLjxuvVE16zzFvstZSeSp4PfHvKsmwMUK18.tar.zst -p 60 -y 16 -m 5000000 -e 269567236 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-266134813 -s snapshot-266134812-DuBoJXN87QZWwhwi14ZoTqFYWPFKDpbBczo2U9a9Jidk.tar.zst -p 60 -y 16 -m 5000000 -e 266134814 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-266545736 -s snapshot-266545735-6FUAw2xdpPSw166xyWYpnXNqXogNkb1yPANZZiUqakK2.tar.zst -p 60 -y 16 -m 5000000 -e 266545737 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267059180 -s snapshot-267059179-93LQKWDQZRKdw44JLy1BwwwSh4gTp26zUkAfGdPRBRjJ.tar.zst -p 60 -y 16 -m 5000000 -e 267059181 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267580466 -s snapshot-267580465-EWeMRpeNFC9ue4qD6EFS6SkFrVJwmKnrSrwDHKLRr73h.tar.zst -p 60 -y 16 -m 5000000 -e 267580467 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-268196194 -s snapshot-268196193-57VFX99qvEzdE6aQ5GYMsa4ZdMJFawM657seKjWs7oMe.tar.zst -p 60 -y 16 -m 5000000 -e 268196195 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-267766641 -s snapshot-267766640-36YeYWmcfiPXXXLMKuAohjM3SxzvXKDJSrG747zGB72B.tar.zst -p 60 -y 16 -m 5000000 -e 267766642 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-269648145 -s snapshot-269648144-7zWxbqhi4UFRNXxZBxAr8CsKt8MvnXJKwWiakAF4q5wu.tar.zst -p 60 -y 16 -m 5000000 -e 269648146 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l v201-small -s snapshot-100-38CM8ita1fT5SmSLUEeqQZffn2xsy9vKz3WJmsFSnhrJ.tar.zst -p 60 -y 16 -m 500000 -e 120 -c 2.0.1
+src/flamenco/runtime/tests/run_ledger_test.sh -l v20-harcoded-features -s snapshot-100-4EmZxoqF6P2fJJEKgvznd2BkfTvYzsFSup3gyDdV2mY1.tar.zst -p 60 -y 16 -m 500000 -e 700 -c 2.0.2
+src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-281546597 -s snapshot-281546592-5jvGg895YBu829SzrJA4rrExcLSpY1MgVwQshNcJX5EB.tar.zst -p 60 -y 16 -m 5000000 -e 281546597 -c 2.0.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-281688085 -s snapshot-281688080-6NHAVEju9WSsz7LQ3sLS9Yn2Tk9J7QByHRFEQLvXKqHG.tar.zst -p 60 -y 16 -m 5000000 -e 281688086 -c 2.0.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-277660422 -s snapshot-277660421-7fen26CUSpoKnaTXr3cAettDPuF6rsFcu7bEXNz9yhbM.tar.zst -p 60 -y 16 -m 5000000 -e 277660423 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-277876060 -s snapshot-277876059-9vTzJ6qWyH7qkw11V5Np8wutCtExSw5XzethrdFfsjUk.tar.zst -p 60 -y 16 -m 5000000 -e 277876061 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-277927063 -s snapshot-277927062-HqChvv7URAqMvvSx2WdfzL1HJFp21C1UoQHfzKxHyXtJ.tar.zst -p 60 -y 16 -m 5000000 -e 277927065 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l v203-bpf-loader -s snapshot-40-HDKtRRz86coYSVbyocSzPF7Y8xtNLCTUnaZtULrM4Nz9.tar.zst -p 60 -y 16 -m 5000000 -e 100 -c 2.0.3
+src/flamenco/runtime/tests/run_ledger_test.sh -l v203-move-stake -s snapshot-4467-5yzwTpG83nRbokX2iKNYPCPod6fJu3aE8pBEE4SyqLCb.tar.zst        -p 60 -y 16 -m 5000000 -e 4470 -o 7bTK6Jis8Xpfrs8ZoUfiMDPazTcdPcTWheZFJTA5Z6X4 -c 2.0.3
+src/flamenco/runtime/tests/run_ledger_test.sh -l v203-move-lamports -s snapshot-650-Q8pVZ4jfmzpAGwAytPs4PJXmb4iaBXwVhvVjc8AaAXh.tar.zst       -p 60 -y 16 -m 5000000 -e 655 -o 7bTK6Jis8Xpfrs8ZoUfiMDPazTcdPcTWheZFJTA5Z6X4 -c 2.0.3
+src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-283927487 -s snapshot-283927486-7gCbg5g4BnD9SkQUjpHvhepWsQTpo2WaZaA5bhcNBMhG.tar.zst -p 60 -y 16 -m 5000000 -e 283927497 -c 2.0.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-254462437-dm -s snapshot-254462437-9HqBi19BJJRZfHeBS3ZpkeP9B5SAxBxz6Kwug29yLHac.tar.zst -p 60 -y 30 -m 20000000 -e 254462836 -c 1.19.0 -o GJVDwRkUPNdk9QaK4VsU4g1N41QNxhy1hevjf8kz45Mq
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-281375356 -s snapshot-281375353-Bg81vkkW8K3UtrQoEn3wLsEpYwoHRQSihW4t5PiF1bBD.tar.zst -p 60 -y 16 -m 5000000 -e 281375359 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-282232100 -s snapshot-282232097-5ChH2XwaWrYaMvkemMQZmhMxabSNvXLKz3mZSCwhaW5W.tar.zst -p 60 -y 16 -m 5000000 -e 282232101 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-586-partitioned-epoch-rewards -s snapshot-253151900-HVhfam8TtRFVwFto5fWkhgR4mbBJmUxcnxeKZoW5MrSD.tar.zst -p 60 -y 16 -m 5000000 -e 253152100 -c 2.0.3 -o 9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257039990-partitioned-epoch-rewards -s snapshot-257039990-BSgErEc6ppN4p91meqPvUiXPiEhbakBNHMQQ4wKmceYv.tar.zst -p 60 -y 16 -m 20000000 -e 257040003 -c 2.0.3 -o 9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-282151715 -s snapshot-282151712-6qodKmgM9YNdoFzfRKPFmVh1Gv3McVzQ8pd1Gka1efdg.tar.zst -p 60 -y 16 -m 5000000 -e 282151717 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-286450148 -s snapshot-286450145-5kdyfTzRq8GHKgQAZNYLNGRR2MvoeG6CWrsm8uwG6QKF.tar.zst -p 60 -y 15 -m 5000000 -e 286450151 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l v203-multi-epoch-per-70 -s snapshot-70-7YBEAimmCAKQUbxAwwo6ZXNRfkjubnPgqAX8cQX3XXHQ.tar.zst -p 60 -y 16 -m 5000000 -e 631 -c 2.0.3 -o 9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK
+src/flamenco/runtime/tests/run_ledger_test.sh -l v203-multi-epoch-per-160 -s snapshot-160-Aq137keMhyfrccPizmmwngzDHfGW8fUSMkdoDrENxArL.tar.zst -p 60 -y 16 -m 5000000 -e 631 -c 2.0.3 -o 9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK
+src/flamenco/runtime/tests/run_ledger_test.sh -l v203-multi-epoch-per-400 -s snapshot-400-7YQEfWokKvabrikHpWNcZcYGRABeHgLUHjsBVWDYsPzr.tar.zst -p 60 -y 16 -m 5000000 -e 631 -c 2.0.3 -o 9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK
+src/flamenco/runtime/tests/run_ledger_test.sh -l v203-multi-epoch-per-superfeature-70 -s snapshot-70-Hjfc74VPRSX2udP54YuuV8qQKAq7sKse4do1GJGs4Dib.tar.zst -p 60 -y 16 -m 5000000 -e 631 -c 2.0.3 -o PERzQrt5gBD1XEe2c9XdFWqwgHY3mr7cYWbm5V772V8
+src/flamenco/runtime/tests/run_ledger_test.sh -l v203-multi-epoch-per-superfeature-160 -s snapshot-160-9kvex5W9axd5C2Yr4kTEDP6qQBHSkWXS4Rh9hFgKPPQc.tar.zst -p 60 -y 16 -m 5000000 -e 631 -c 2.0.3 -o PERzQrt5gBD1XEe2c9XdFWqwgHY3mr7cYWbm5V772V8
+src/flamenco/runtime/tests/run_ledger_test.sh -l v203-multi-epoch-per-superfeature-400 -s snapshot-400-F1ja3hM4JcRzBrxr7U3my1xqNo64fYkcwRgVijm4uux7.tar.zst -p 60 -y 16 -m 5000000 -e 631 -c 2.0.3 -o PERzQrt5gBD1XEe2c9XdFWqwgHY3mr7cYWbm5V772V8
+src/flamenco/runtime/tests/run_ledger_test.sh -l v208-zk-sdk-ledger -s snapshot-1-GNxLdkaRgGzZSKj79d7yUXK8Nd7dv87WckoCdzQYH4X2.tar.zst -p 60 -y 16 -m 500000 -e 82 -c 2.0.8
+src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-294739503 -s snapshot-294739500-2Y8hFyTtyMuHCgpe26Y1HostyWMZjFvskV5ZpaX6X62S.tar.zst -p 60 -y 16 -m 5000000 -e 294739505 -c 2.0.3
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-290621930 -s snapshot-290621927-AxDRmQNPmGzo1V7KRXfPXtDXTBU3AZj3MUEM1ns3CgH.tar.zst -p 60 -y 16 -m 5000000 -e 290621932 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l devnet-330914784 -s snapshot-330914783-BujhdWiXTfRPfFYMG3GZdEcNc18KyvCcAq9QL9e1i1Fk.tar.zst -p 60 -y 16 -m 5000000 -e 330914785 -c 2.0.8
+src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-mismatch-297489336 -s snapshot-297489335-BgExNqwDtYPo2YQ87C2bra6b5GK2eu52R8Budh85cRUp.tar.zst -p 60 -y 16 -m 5000000 -e 297489363 -c 2.0.3
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-300377724 -s snapshot-300377719-DWngYKosZegyeLAgHK5jVfMsSeuYjSZWJixE5VgcLDAM.tar.zst -p 60 -y 16 -m 5000000 -e 300377728 -c 1.18.23
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-300645644 -s snapshot-300645643-D2ZXqQffEoM6cgPGoC9LC4UfjyCMi1cqbhrceRPh4cE7.tar.zst -p 60 -y 16 -m 5000000 -e 300645644 -c 1.18.23
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-300648964 -s snapshot-300648963-BPSiWGgLbiof1b8Ui5qnM4eUDv8asDo9j7Bn8QvrvwUZ.tar.zst -p 60 -y 16 -m 5000000 -e 300648964 -c 1.18.23
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-301359740 -s snapshot-301359739-5L5b7KFLFiQYpmk7nHUJYX8fXMUG4qv7m6iBMWRN2V5h.tar.zst -p 60 -y 16 -m 5000000 -e 301359740 -c 1.18.23
+src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-302734641 -s snapshot-302734640-9e44jEVavfHC253DSBGSjTFt2diZrgcMHTRZtpUvisvr.tar.zst -p 60 -y 16 -m 5000000 -e 302734658 -c 2.0.10
+src/flamenco/runtime/tests/run_ledger_test.sh -l migrate-feature-program -s snapshot-500-Cz6iotFK7kNcGTpyUZeX4CHbT2uff2uzVW8RXXysBnVk.tar.zst -p 60 -y 16 -m 5000000 -e 675 -c 2.1.0 -o 4eohviozzEeivk1y9UbrnekbAFMDQyJz5JjA9Y6gyvky
+src/flamenco/runtime/tests/run_ledger_test.sh -l migrate-config-program -s snapshot-500-HCg5AHVPC6JAqZo4p6iMcDmo586ZjkxxPpxfAwCHqroy.tar.zst -p 60 -y 16 -m 5000000 -e 675 -c 2.1.0 -o 2Fr57nzzkLYXW695UdDxDeR5fhnZWSttZeZYemrnpGFV
+src/flamenco/runtime/tests/run_ledger_test.sh -l per-stake-history-new-rate-activation-epoch -s snapshot-50-47DbuHpi6gXmZKQ1FUSAAfkgnuWrkfTAtx3Hk5Gqsu5W.tar.zst -p 60 -y 16 -m 5000000 -e 675 -c 2.1.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l enable-get-epoch-stake-syscall -s snapshot-50-FfJQ3ePJx2s5BDymDoiLVRHDHj5doYNQBzyrqus8LocL.tar.zst -p 60 -y 16 -m 5000000 -e 686 -c 2.1.0 -o FKe75t4LXxGaQnVHdUKM6DSFifVVraGZ8LyNo7oPwy1Z
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257181032 -s snapshot-257181030-BiZi1ye6MeW8iq2xUBDrYYPSNuBVrXvzsHjPWvQ8ZytE.tar.zst -p 60 -y 16 -m 5000000 -e 257181035 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257047660 -s snapshot-257047658-Cp4XkpXueDWep78NCTQHCWmG5VszMBjKbGdAoXYLHBfh.tar.zst -p 60 -y 16 -m 5000000 -e 257047662 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-257047659 -s snapshot-257047655-5r7etGHT6fJ5edRijJMtYr8xYJpE98ECWF8n7CCZUhDN.tar.zst -p 60 -y 16 -m 5000000 -e 257047660 -c 1.19.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-308445707 -s snapshot-308445706-EUsKyaEYAN9VZDSAeBhFET9sdTicGCsghwEF1y1BhTvU.tar.zst -p 60 -y 16 -m 5000000 -e 308445711 -c 2.0.18
+src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-307395181 -s snapshot-307395180-D41gdV5niSbDdwsfb8381krY5pDK4oGeHeS2V1A8ttFr.tar.zst -p 60 -y 16 -m 5000000 -e 307395190 -c 2.1.1
+src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-308392063 -s snapshot-308392062-FDuB6CFKod14xGRGmdiRpQx2uaKyp3GDkyai2Ba7eH8d.tar.zst -p 60 -y 16 -m 5000000 -e 308392090 -c 2.0.18
+src/flamenco/runtime/tests/run_ledger_test.sh -l devnet-350814254 -s snapshot-350814253-G5P3eNtkWUGkZ8b871wvf6d78wYxBJp637PCWJuQByZa.tar.zst -p 60 -y 16 -m 5000000 -e 350814284 -c 2.0.15
+src/flamenco/runtime/tests/run_ledger_test.sh -l testnet-311586340 -s snapshot-311586340-13GSzvNzfBcz1KX6xBs55A8EKNWnCCRZ5Z84T1MSnuUm.tar.zst -p 60 -y 16 -m 5000000 -e 311586380 -c 2.1.1

--- a/src/flamenco/shredcap/fd_shredcap.c
+++ b/src/flamenco/shredcap/fd_shredcap.c
@@ -170,7 +170,7 @@ fd_shredcap_ingest_rocksdb_to_capture( const char * rocksdb_dir,
       ulong cur_slot = metadata.slot;
       /* Import shreds for entire slot */
 
-      int err = fd_rocksdb_import_block_shredcap( &rocks_db, &metadata, ostream, bank_hash_ostream );
+      int err = fd_rocksdb_import_block_shredcap( &rocks_db, &metadata, ostream, bank_hash_ostream, valloc );
       if( FD_UNLIKELY( err ) ) {
         FD_LOG_ERR(( "fd_rocksdb_get_block failed at slot=%lu", cur_slot ));
       }

--- a/src/flamenco/snapshot/fd_snapshot.h
+++ b/src/flamenco/snapshot/fd_snapshot.h
@@ -46,10 +46,9 @@ typedef struct fd_snapshot_load_ctx fd_snapshot_load_ctx_t;
    source_cstr is either a local file system path.
    TODO: Add support for an HTTP url.
 
-   slot_ctx is a valid initialized slot context (a funk, acc_mgr, heap
-   valloc, zero-initialized slot bank).
+   slot_ctx is a valid initialized slot context.
 
-   valloc should have enough space to buffer the snapshot's manifest.
+   spad should have enough space to buffer the snapshot's manifest.
 
    If verify_hash!=0 calculates the snapshot hash.
 
@@ -71,7 +70,7 @@ fd_snapshot_load_new( uchar *                mem,
                       uint                   verify_hash,
                       uint                   check_hash,
                       int                    snapshot_type,
-                      fd_valloc_t            valloc );
+                      fd_spad_t *            spad );
 
 void
 fd_snapshot_load_init( fd_snapshot_load_ctx_t * ctx );
@@ -96,7 +95,7 @@ fd_snapshot_load_all( const char *         source_cstr,
                       uint                 verify_hash,
                       uint                 check_hash,
                       int                  snapshot_type,
-                      fd_valloc_t          valloc );
+                      fd_spad_t *          spad );
 
 void
 fd_snapshot_load_prefetch_manifest( fd_snapshot_load_ctx_t * ctx );

--- a/src/flamenco/snapshot/fd_snapshot_create.h
+++ b/src/flamenco/snapshot/fd_snapshot_create.h
@@ -46,7 +46,7 @@ struct fd_snapshot_ctx {
   /* These parameters are setup by the caller of the snapshot service. */
   ulong             slot;                      /* Slot for the snapshot. */
   char const *      out_dir;                   /* Output directory. */
-  fd_valloc_t       valloc;                    /* Allocator */
+  fd_spad_t *       spad;                      /* Bump allocator. */
 
   /* The two data structures from the runtime referenced by the snapshot service. */
   fd_funk_t *       funk;                      /* Funk handle. */

--- a/src/flamenco/snapshot/fd_snapshot_restore.c
+++ b/src/flamenco/snapshot/fd_snapshot_restore.c
@@ -15,7 +15,6 @@
 static void
 fd_snapshot_restore_discard_buf( fd_snapshot_restore_t * self ) {
   /* self->buf might be NULL */
-  fd_valloc_free( self->valloc, self->buf );
   self->buf     = NULL;
   self->buf_ctr = 0UL;
   self->buf_sz  = 0UL;
@@ -33,7 +32,13 @@ fd_snapshot_restore_prepare_buf( fd_snapshot_restore_t * self,
     return self->buf;
 
   fd_snapshot_restore_discard_buf( self );
-  uchar * buf = fd_valloc_malloc( self->valloc, 1UL, sz );
+  if( FD_UNLIKELY( sz>fd_spad_alloc_max( self->spad, FD_SPAD_ALIGN ) ) ) {
+    FD_LOG_WARNING(( "Attempting to allocate beyond size of spad" ));
+    self->failed=1;
+    return NULL;
+  }
+
+  uchar * buf = fd_spad_alloc( self->spad, FD_SPAD_ALIGN, sz );
   if( FD_UNLIKELY( !buf ) ) {
     self->failed = 1;
     return NULL;
@@ -57,12 +62,12 @@ fd_snapshot_restore_footprint( void ) {
 }
 
 fd_snapshot_restore_t *
-fd_snapshot_restore_new( void *                               mem,
-                         fd_acc_mgr_t *                       acc_mgr,
-                         fd_funk_txn_t *                      funk_txn,
-                         fd_valloc_t                          valloc,
-                         void *                               cb_manifest_ctx,
-                         fd_snapshot_restore_cb_manifest_fn_t cb_manifest,
+fd_snapshot_restore_new( void *                                   mem,
+                         fd_acc_mgr_t *                           acc_mgr,
+                         fd_funk_txn_t *                          funk_txn,
+                         fd_spad_t *                              spad,
+                         void *                                   cb_manifest_ctx,
+                         fd_snapshot_restore_cb_manifest_fn_t     cb_manifest,
                          fd_snapshot_restore_cb_status_cache_fn_t cb_status_cache ) {
 
   if( FD_UNLIKELY( !mem ) ) {
@@ -77,8 +82,8 @@ fd_snapshot_restore_new( void *                               mem,
     FD_LOG_WARNING(( "NULL acc_mgr" ));
     return NULL;
   }
-  if( FD_UNLIKELY( !valloc.vt ) ) {
-    FD_LOG_WARNING(( "NULL valloc" ));
+  if( FD_UNLIKELY( !spad ) ) {
+    FD_LOG_WARNING(( "NULL spad" ));
     return NULL;
   }
 
@@ -87,7 +92,7 @@ fd_snapshot_restore_new( void *                               mem,
   fd_memset( self, 0, sizeof(fd_snapshot_restore_t) );
   self->acc_mgr     = acc_mgr;
   self->funk_txn    = funk_txn;
-  self->valloc      = valloc;
+  self->spad        = spad;
   self->state       = STATE_DONE;
   self->buf         = NULL;
   self->buf_sz      = 0UL;
@@ -257,7 +262,7 @@ fd_snapshot_restore_manifest( fd_snapshot_restore_t * restore ) {
   fd_bincode_decode_ctx_t decode =
       { .data    = restore->buf,
         .dataend = restore->buf + restore->buf_sz,
-        .valloc  = restore->valloc };
+        .valloc  = fd_spad_virtual( restore->spad ) };
   int decode_err = fd_solana_manifest_decode( manifest, &decode );
   if( FD_UNLIKELY( decode_err!=FD_BINCODE_SUCCESS ) ) {
     /* TODO: The types generator does not yet handle OOM correctly.
@@ -290,18 +295,13 @@ fd_snapshot_restore_manifest( fd_snapshot_restore_t * restore ) {
 
   int err = 0;
   if( restore->cb_manifest ) {
-    err = restore->cb_manifest( restore->cb_manifest_ctx, manifest, restore->valloc );
+    err = restore->cb_manifest( restore->cb_manifest_ctx, manifest, restore->spad );
   }
 
   /* Read AccountVec map */
 
   if( FD_LIKELY( !err ) )
     err = fd_snapshot_accv_index( restore->accv_map, &accounts_db );
-
-  /* Discard superfluous fields that the callback didn't move */
-
-  fd_bincode_destroy_ctx_t destroy = { .valloc = restore->valloc };
-  fd_solana_accounts_db_fields_destroy( &accounts_db, &destroy );
 
   /* Discard buffer to reclaim heap space */
 
@@ -331,7 +331,7 @@ fd_snapshot_restore_status_cache( fd_snapshot_restore_t * restore ) {
   fd_bincode_decode_ctx_t decode =
       { .data    = restore->buf,
         .dataend = restore->buf + restore->buf_sz,
-        .valloc  = restore->valloc };
+        .valloc  = fd_spad_virtual( restore->spad ) };
   int decode_err = fd_bank_slot_deltas_decode( slot_deltas, &decode );
   if( FD_UNLIKELY( decode_err!=FD_BINCODE_SUCCESS ) ) {
     /* TODO: The types generator does not yet handle OOM correctly.
@@ -344,12 +344,7 @@ fd_snapshot_restore_status_cache( fd_snapshot_restore_t * restore ) {
   /* Move over objects and recover state. */
   /* TODO: we ignore the error from status cache restore for now since having the status cache is optional.
            Add status cache to all cases */
-  restore->cb_status_cache( restore->cb_status_cache_ctx, slot_deltas );
-
-  /* Discard superfluous fields that the callback didn't move */
-
-  fd_bincode_destroy_ctx_t destroy = { .valloc = restore->valloc };
-  fd_bank_slot_deltas_destroy( slot_deltas, &destroy );
+  restore->cb_status_cache( restore->cb_status_cache_ctx, slot_deltas, restore->spad );
 
   /* Discard buffer to reclaim heap space (which could be used by
      fd_funk accounts instead) */

--- a/src/flamenco/snapshot/fd_snapshot_restore.h
+++ b/src/flamenco/snapshot/fd_snapshot_restore.h
@@ -52,7 +52,7 @@ typedef struct fd_snapshot_restore fd_snapshot_restore_t;
 typedef int
 (* fd_snapshot_restore_cb_manifest_fn_t)( void *                 ctx,
                                           fd_solana_manifest_t * manifest,
-                                          fd_valloc_t            valloc );
+                                          fd_spad_t *            spad );
 
 /* fd_snapshot_restore_cb_status_cache_fn_t is a callback that provides the
    user of snapshot restore with the deserialized slot deltas.  The caller
@@ -64,7 +64,8 @@ typedef int
    API. */
 typedef int
 (* fd_snapshot_restore_cb_status_cache_fn_t)( void *                  ctx,
-                                              fd_bank_slot_deltas_t * slot_deltas );
+                                              fd_bank_slot_deltas_t * slot_deltas,
+                                              fd_spad_t *             spad );
 
 FD_PROTOTYPES_BEGIN
 
@@ -81,7 +82,7 @@ fd_snapshot_restore_footprint( void );
    region, which adheres to above alignment/footprint requirements.
    Returns qualified handle to object given restore object on success.
 
-   valloc is a memory allocator that outlives the snapshot restore
+   spad is a bump allocator that outlives the snapshot restore
    object.  This allocator is used to buffer the serialized snapshot
    manifest (ca ~500 MB) and account data.
 
@@ -107,13 +108,13 @@ fd_snapshot_restore_t *
 fd_snapshot_restore_new( void *                               mem,
                          fd_acc_mgr_t *                       acc_mgr,
                          fd_funk_txn_t *                      txn,
-                         fd_valloc_t                          valloc,
+                         fd_spad_t *                          spad,
                          void *                               cb_manifest_ctx,
                          fd_snapshot_restore_cb_manifest_fn_t cb_manifest,
                          fd_snapshot_restore_cb_status_cache_fn_t cb_status_cache );
 
 /* fd_snapshot_restore_delete destroys the given restore object and
-   frees any resources.  Returns main and scratch memory region back to
+   frees any resources.  Returns allocated memory region back to
    caller. */
 
 void *

--- a/src/flamenco/snapshot/fd_snapshot_restore_private.h
+++ b/src/flamenco/snapshot/fd_snapshot_restore_private.h
@@ -64,7 +64,7 @@ typedef struct fd_snapshot_accv_map fd_snapshot_accv_map_t;
 struct fd_snapshot_restore {
   fd_acc_mgr_t *    acc_mgr;
   fd_funk_txn_t *   funk_txn;
-  fd_valloc_t       valloc;
+  fd_spad_t *       spad;
 
   ulong slot;  /* Slot number the snapshot was taken at */
 

--- a/src/flamenco/snapshot/test_snapshot_restore.c
+++ b/src/flamenco/snapshot/test_snapshot_restore.c
@@ -23,8 +23,8 @@ static void *                  _cb_v_ctx      = NULL;
 int
 cb_manifest( void *                 ctx,
              fd_solana_manifest_t * manifest,
-             fd_valloc_t            valloc ) {
-  (void)valloc;
+             fd_spad_t *            spad ) {
+  (void)spad;
   _cb_v_manifest = manifest;
   _cb_v_ctx      = ctx;
   return _cb_retcode;
@@ -32,7 +32,9 @@ cb_manifest( void *                 ctx,
 
 int
 cb_status_cache( void *                  ctx,
-                 fd_bank_slot_deltas_t * cache ) {
+                 fd_bank_slot_deltas_t * cache,
+                 fd_spad_t *             spad ) {
+  (void)spad;
   _cb_v_cache = cache;
   _cb_v_ctx   = ctx;
   return _cb_retcode;
@@ -55,17 +57,6 @@ main( int     argc,
   FD_TEST( wksp );
   ulong const static_tag = 1UL;
 
-  ulong const fd_alloc_tag = 41UL;
-  fd_alloc_t * alloc = fd_alloc_join( fd_alloc_new( fd_wksp_alloc_laddr( wksp, fd_alloc_align(), fd_alloc_footprint(), fd_alloc_tag ), fd_alloc_tag ), 0UL );
-  FD_TEST( alloc );
-
-  ulong const scratch_tag = 90UL;
-  ulong   smax = 16384UL;
-  uchar * smem = fd_wksp_alloc_laddr( wksp, FD_SCRATCH_SMEM_ALIGN, smax, scratch_tag );
-  FD_TEST( smem );
-  ulong fmem[ 16 ];
-  fd_scratch_attach( smem, fmem, smax, 16UL );
-
   /* Setup slot context */
 
   ulong const txn_max =  16UL;
@@ -83,7 +74,9 @@ main( int     argc,
 
   void * restore_mem = fd_wksp_alloc_laddr( wksp, fd_snapshot_restore_align(), fd_snapshot_restore_footprint(), static_tag );
 
-  fd_valloc_t _valloc = fd_alloc_virtual( alloc );
+  fd_spad_t * _spad = fd_spad_new( fd_wksp_alloc_laddr( wksp, FD_SPAD_ALIGN, FD_SPAD_FOOTPRINT( 16384UL ), static_tag ), 16384UL );
+  fd_spad_push( _spad );
+  FD_LOG_WARNING(("SPAD %lu", _spad->mem_max));
 
   fd_funk_txn_xid_t xid[1] = {{ .ul = {4} }};
   ulong             restore_slot = 999UL;
@@ -94,28 +87,30 @@ main( int     argc,
      context that is waiting for a manifest. */
 
 # define NEW_RESTORE() \
-    fd_snapshot_restore_new( restore_mem, acc_mgr, NULL, _valloc, _dummy_ctx, cb_manifest, cb_status_cache )
+    fd_snapshot_restore_new( restore_mem, acc_mgr, NULL, _spad, _dummy_ctx, cb_manifest, cb_status_cache )
 
   /* NEW_RESTORE_POST_MANIFEST is a convenience macro to create a new
      snapshot restore context that pretends that the manifest has
      already been restored. */
 
 # define NEW_RESTORE_POST_MANIFEST() __extension__({ \
-    fd_snapshot_restore_t * restore = fd_snapshot_restore_new( restore_mem, acc_mgr, NULL, _valloc, _dummy_ctx, cb_manifest, cb_status_cache ); \
+    fd_snapshot_restore_t * restore = fd_snapshot_restore_new( restore_mem, acc_mgr, NULL, _spad, _dummy_ctx, cb_manifest, cb_status_cache ); \
     restore->manifest_done = MANIFEST_DONE_SEEN; \
     restore->slot          = restore_slot; \
     restore; \
   })
 
   /* Test invalid params */
-
-  FD_TEST( !fd_snapshot_restore_new( NULL,        acc_mgr, NULL, _valloc, NULL, cb_manifest, cb_status_cache ) );  /* NULL mem */
-  FD_TEST( !fd_snapshot_restore_new( restore_mem, NULL,    NULL, _valloc, NULL, cb_manifest, cb_status_cache ) );  /* NULL acc_mgr */
+  fd_spad_push( _spad );
+  FD_TEST( !fd_snapshot_restore_new( NULL,        acc_mgr, NULL, _spad, NULL, cb_manifest, cb_status_cache ) );  /* NULL mem */
+  FD_TEST( !fd_snapshot_restore_new( restore_mem, NULL,    NULL, _spad, NULL, cb_manifest, cb_status_cache ) );  /* NULL acc_mgr */
+  fd_spad_pop( _spad );
 
   /* Reject accounts before manifest */
 
   do {
-    fd_snapshot_restore_t * restore = fd_snapshot_restore_new( restore_mem, acc_mgr, NULL, _valloc, NULL, cb_manifest, cb_status_cache );
+    fd_spad_push( _spad );
+    fd_snapshot_restore_t * restore = fd_snapshot_restore_new( restore_mem, acc_mgr, NULL, _spad, NULL, cb_manifest, cb_status_cache );
     FD_TEST( restore );
     FD_TEST( restore->failed        == 0 );
     FD_TEST( restore->manifest_done == 0 );
@@ -128,63 +123,73 @@ main( int     argc,
     FD_TEST( EINVAL==fd_snapshot_restore_chunk( restore, "A", 1UL ) );
 
     fd_snapshot_restore_delete( restore );
+    fd_spad_pop( _spad );
   } while(0);
 
   /* Reject invalid status cache */
 
   do {
-    fd_snapshot_restore_t * restore = fd_snapshot_restore_new( restore_mem, acc_mgr, NULL, _valloc, NULL, cb_manifest, cb_status_cache );
+    fd_spad_push( _spad );
+    FD_LOG_WARNING(("SPAD %lu", _spad->mem_max));
+    fd_snapshot_restore_t * restore = fd_snapshot_restore_new( restore_mem, acc_mgr, NULL, _spad, NULL, cb_manifest, cb_status_cache );
     FD_TEST( restore );
     fd_tar_meta_t meta = { .name = "snapshots/status_cache", .typeflag = FD_TAR_TYPE_REGULAR };
     FD_TEST( 0==fd_snapshot_restore_file( restore, &meta, 18UL ) );
     FD_TEST( restore->buf );
     FD_TEST( EINVAL==fd_snapshot_restore_chunk( restore, "AAAAAAAAAAAAAAAAAA", 18UL ) );
     fd_snapshot_restore_delete( restore );
+    fd_spad_pop( _spad );
   } while(0);
 
   /* Reject invalid manifest */
 
   do {
-    fd_snapshot_restore_t * restore = fd_snapshot_restore_new( restore_mem, acc_mgr, NULL, _valloc, NULL, cb_manifest, cb_status_cache );
+    fd_spad_push( _spad );
+    fd_snapshot_restore_t * restore = fd_snapshot_restore_new( restore_mem, acc_mgr, NULL, _spad, NULL, cb_manifest, cb_status_cache );
     FD_TEST( restore );
     fd_tar_meta_t meta = { .name = "snapshots/123/123", .typeflag = FD_TAR_TYPE_REGULAR };
     FD_TEST( 0==fd_snapshot_restore_file( restore, &meta, 18UL ) );
     FD_TEST( restore->buf );
     FD_TEST( EINVAL==fd_snapshot_restore_chunk( restore, "AAAAAAAAAAAAAAAAAA", 18UL ) );
     fd_snapshot_restore_delete( restore );
+    fd_spad_pop( _spad );
   } while(0);
 
   /* Test status cache with size exceeding buffer size (out of memory) */
 
   do {
-    fd_snapshot_restore_t * restore = fd_snapshot_restore_new( restore_mem, acc_mgr, NULL, _valloc, NULL, cb_manifest, cb_status_cache );
+    fd_spad_push( _spad );
+    fd_snapshot_restore_t * restore = fd_snapshot_restore_new( restore_mem, acc_mgr, NULL, _spad, NULL, cb_manifest, cb_status_cache );
     FD_TEST( restore );
     fd_tar_meta_t meta = { .name = "snapshots/status_cache", .typeflag = FD_TAR_TYPE_REGULAR };
     FD_TEST( ENOMEM==fd_snapshot_restore_file( restore, &meta, ULONG_MAX ) );
     FD_TEST( restore->failed == 1 );
     fd_snapshot_restore_delete( restore );
+    fd_spad_pop( _spad );
   } while(0);
 
   /* Test manifest with size exceeding buffer size (out of memory) */
 
   do {
-    fd_snapshot_restore_t * restore = fd_snapshot_restore_new( restore_mem, acc_mgr, NULL, _valloc, NULL, cb_manifest, cb_status_cache );
+    fd_spad_push( _spad );
+    fd_snapshot_restore_t * restore = fd_snapshot_restore_new( restore_mem, acc_mgr, NULL, _spad, NULL, cb_manifest, cb_status_cache );
     FD_TEST( restore );
     fd_tar_meta_t meta = { .name = "snapshots/123/123", .typeflag = FD_TAR_TYPE_REGULAR };
     FD_TEST( ENOMEM==fd_snapshot_restore_file( restore, &meta, ULONG_MAX ) );
     FD_TEST( restore->failed == 1 );
     fd_snapshot_restore_delete( restore );
+    fd_spad_pop( _spad );
   } while(0);
 
   /* Test basic manifest */
 
   do {
-    fd_scratch_push();
+    fd_spad_push( _spad );
     fd_solana_manifest_t manifest[1] = {{ .bank = { .slot = 3UL } }};
     ulong manifest_sz = fd_solana_manifest_size( manifest );
 
     ulong   data_sz = manifest_sz;
-    uchar * data    = fd_scratch_alloc( 1UL, data_sz );
+    uchar * data    = fd_spad_alloc( _spad, 8UL, data_sz );
     fd_bincode_encode_ctx_t encode =
       { .data    = data,
         .dataend = data + manifest_sz + 1 };
@@ -206,27 +211,27 @@ main( int     argc,
     FD_TEST( restore->slot          == 3UL                );
 
     fd_snapshot_restore_delete( restore );
-    fd_scratch_pop();
+    fd_spad_pop( _spad );
   } while(0);
 
   /* Test basic status cache */
 
   do {
-    fd_scratch_push();
+    fd_spad_push( _spad );
     /* Create basic slot delta */
     fd_bank_slot_deltas_t cache[1];
     cache->slot_deltas_len = 1;
-    cache->slot_deltas = fd_scratch_alloc(fd_slot_delta_align(), fd_slot_delta_footprint());
+    cache->slot_deltas = fd_spad_alloc( _spad, fd_slot_delta_align(), fd_slot_delta_footprint() );
     cache->slot_deltas->is_root = 0;
     cache->slot_deltas->slot = 10;
     cache->slot_deltas->slot_delta_vec_len = 1;
-    cache->slot_deltas->slot_delta_vec = fd_scratch_alloc(fd_status_pair_align(), fd_status_pair_footprint());
+    cache->slot_deltas->slot_delta_vec = fd_spad_alloc( _spad, fd_status_pair_align(), fd_status_pair_footprint() );
 
     fd_status_pair_t * pair = cache->slot_deltas->slot_delta_vec;
     fd_memset( pair->hash.uc, 1UL, sizeof(fd_hash_t) );
     pair->value.txn_idx = 2;
     pair->value.statuses_len = 1;
-    pair->value.statuses = fd_scratch_alloc( fd_cache_status_align(), fd_cache_status_footprint() );
+    pair->value.statuses = fd_spad_alloc( _spad, fd_cache_status_align(), fd_cache_status_footprint() );
 
     fd_cache_status_t * status = pair->value.statuses;
     status->result.discriminant = 0;
@@ -235,7 +240,7 @@ main( int     argc,
     ulong sz = fd_bank_slot_deltas_size( cache );
 
     ulong   data_sz = sz;
-    uchar * data    = fd_scratch_alloc( 1UL, data_sz );
+    uchar * data    = fd_spad_alloc( _spad, 8UL, data_sz );
     fd_bincode_encode_ctx_t encode =
       { .data    = data,
         .dataend = data + sz + 1 };
@@ -256,18 +261,18 @@ main( int     argc,
     FD_TEST( restore->status_cache_done == 1   );
 
     fd_snapshot_restore_delete( restore );
-    fd_scratch_pop();
+    fd_spad_pop( _spad );
   } while(0);
 
   /* Ignore trailing data after manifest */
 
   do {
-    fd_scratch_push();
+    fd_spad_push( _spad );
     fd_solana_manifest_t manifest[1] = {0};
     ulong manifest_sz = fd_solana_manifest_size( manifest );
 
     ulong   data_sz = manifest_sz + 16UL;
-    uchar * data    = fd_scratch_alloc( 1UL, data_sz );
+    uchar * data    = fd_spad_alloc( _spad, 8UL, data_sz );
     fd_bincode_encode_ctx_t encode =
       { .data    = data,
         .dataend = data + manifest_sz + 1 };
@@ -288,12 +293,13 @@ main( int     argc,
     FD_TEST( 0==fd_snapshot_restore_chunk( restore, data, manifest_sz + 1 ) );
 
     fd_snapshot_restore_delete( restore );
-    fd_scratch_pop();
+    fd_spad_pop( _spad );
   } while(0);
 
   /* Test empty file */
 
   do {
+    fd_spad_push( _spad );
     fd_snapshot_restore_t * restore = NEW_RESTORE_POST_MANIFEST();
     FD_TEST( restore );
     _set_accv_sz( restore, /* slot */ 1UL, /* id */ 1UL, /* sz */ 0UL );
@@ -303,11 +309,13 @@ main( int     argc,
     FD_TEST( 0==fd_snapshot_restore_chunk( restore, NULL, 0UL ) );
     FD_TEST( restore->state == STATE_IGNORE );
     fd_snapshot_restore_delete( restore );
+    fd_spad_pop( _spad );
   } while(0);
 
   /* Test undersz AppendVec (torn header) */
 
   do {
+    fd_spad_push( _spad );
     fd_snapshot_restore_t * restore = NEW_RESTORE_POST_MANIFEST();
     FD_TEST( restore );
     restore->manifest_done = 1;
@@ -318,11 +326,13 @@ main( int     argc,
     FD_TEST( restore->failed == 1 );
 
     fd_snapshot_restore_delete( restore );
+    fd_spad_pop( _spad );
   } while(0);
 
   /* Test undersz AppendVec (no body) */
 
   do {
+    fd_spad_push( _spad );
     fd_snapshot_restore_t * restore = NEW_RESTORE_POST_MANIFEST();
     FD_TEST( restore );
     restore->manifest_done = 1;
@@ -339,11 +349,13 @@ main( int     argc,
     } while(0);
 
     fd_snapshot_restore_delete( restore );
+    fd_spad_pop( _spad );
   } while(0);
 
   /* Test undersz AppendVec (torn body) */
 
   do {
+    fd_spad_push( _spad );
     fd_snapshot_restore_t * restore = NEW_RESTORE_POST_MANIFEST();
     FD_TEST( restore );
     restore->manifest_done = 1;
@@ -360,11 +372,13 @@ main( int     argc,
     } while(0);
 
     fd_snapshot_restore_delete( restore );
+    fd_spad_pop( _spad );
   } while(0);
 
   /* Reject account with too high slot number */
 
   do {
+    fd_spad_push( _spad );
     fd_snapshot_restore_t * restore = NEW_RESTORE_POST_MANIFEST();
     FD_TEST( restore );
     restore->manifest_done = 1;
@@ -374,11 +388,13 @@ main( int     argc,
     FD_TEST( EINVAL==fd_snapshot_restore_file( restore, &accv_meta, sizeof(fd_solana_account_hdr_t) ) );
     FD_TEST( restore->failed == 1 );
     fd_snapshot_restore_delete( restore );
+    fd_spad_pop( _spad );
   } while(0);
 
   /* Dead accounts must be inserted into database too */
 
   do {
+    fd_spad_push( _spad );
     fd_snapshot_restore_t * restore = NEW_RESTORE_POST_MANIFEST();
     FD_TEST( restore );
     restore->manifest_done = MANIFEST_DONE_SEEN;
@@ -403,11 +419,13 @@ main( int     argc,
 
     fd_funk_txn_cancel( funk, restore->funk_txn, 0 );
     fd_snapshot_restore_delete( restore );
+    fd_spad_pop( _spad );
   } while(0);
 
   /* Old revision must not overrule dead account */
 
   do {
+    fd_spad_push( _spad );
     fd_snapshot_restore_t * restore = NEW_RESTORE_POST_MANIFEST();
     FD_TEST( restore );
     restore->manifest_done = MANIFEST_DONE_SEEN;
@@ -447,6 +465,7 @@ main( int     argc,
 
     fd_funk_txn_cancel( funk, restore->funk_txn, 0 );
     fd_snapshot_restore_delete( restore );
+    fd_spad_pop( _spad );
   } while(0);
 
   /* When an old revision is encountered, only that revision should be
@@ -454,6 +473,7 @@ main( int     argc,
      database. */
 
   do {
+    fd_spad_push( _spad );
     fd_snapshot_restore_t * restore = NEW_RESTORE_POST_MANIFEST();
     FD_TEST( restore );
     restore->manifest_done = MANIFEST_DONE_SEEN;
@@ -524,11 +544,13 @@ main( int     argc,
 
     fd_funk_txn_cancel( funk, restore->funk_txn, 0 );
     fd_snapshot_restore_delete( restore );
+    fd_spad_pop( _spad );
   } while(0);
 
   /* Test undersz AppendVec (real sz smaller than indicated sz) */
 
   do {
+    fd_spad_push( _spad );
     fd_snapshot_restore_t * restore = NEW_RESTORE_POST_MANIFEST();
     FD_TEST( restore );
     restore->manifest_done = 1;
@@ -539,11 +561,13 @@ main( int     argc,
     FD_TEST( restore->failed == 1 );
 
     fd_snapshot_restore_delete( restore );
+    fd_spad_pop( _spad );
   } while(0);
 
   /* Test accounts */
 
   do {
+    fd_spad_push( _spad );
     fd_snapshot_restore_t * restore = NEW_RESTORE_POST_MANIFEST();
     FD_TEST( restore );
     restore->manifest_done = MANIFEST_DONE_SEEN;
@@ -632,6 +656,7 @@ main( int     argc,
     FD_TEST( 0== fd_snapshot_restore_chunk( restore, "ABCD", 4UL ) );
 
     fd_snapshot_restore_delete( restore );
+    fd_spad_pop( _spad );
   } while(0);
 
 # undef NEW_RESTORE_POST_MANIFEST
@@ -640,11 +665,10 @@ main( int     argc,
 
   fd_funk_end_write( funk );
 
-  fd_wksp_free_laddr( fd_scratch_detach( NULL ) );
+  fd_wksp_free_laddr( fd_spad_delete( fd_spad_leave( _spad ) ) );
   fd_wksp_free_laddr( restore_mem );
   fd_wksp_free_laddr( fd_acc_mgr_delete( acc_mgr ) );
   fd_wksp_free_laddr( fd_funk_delete( fd_funk_leave( funk ) ) );
-  fd_wksp_free_laddr( fd_alloc_delete( fd_alloc_leave( alloc ) ) );
   fd_wksp_delete_anonymous( wksp );
 
   FD_LOG_NOTICE(( "pass" ));

--- a/src/flamenco/stakes/fd_stakes.h
+++ b/src/flamenco/stakes/fd_stakes.h
@@ -20,19 +20,20 @@ FD_PROTOTYPES_BEGIN
 
    Returns the number of items in weights (which is <= no of vote accs).
    On failure returns ULONG_MAX.  Reasons for failure include not enough
-   scratch space available. */
+   bump allocator space available. */
 #define STAKE_ACCOUNT_SIZE ( 200 )
 
 ulong
 fd_stake_weights_by_node( fd_vote_accounts_t const * accs,
-                          fd_stake_weight_t *        weights );
+                          fd_stake_weight_t *        weights,
+                          fd_spad_t *                runtime_spad );
 
 
 void
 fd_stakes_activate_epoch( fd_exec_slot_ctx_t *  slot_ctx,
                           ulong *               new_rate_activation_epoch,
                           fd_epoch_info_t *     temp_info,
-                          fd_valloc_t           valloc );
+                          fd_spad_t *           runtime_spad );
 
 fd_stake_history_entry_t 
 stake_and_activating( fd_delegation_t const * delegation,
@@ -60,7 +61,8 @@ void
 fd_refresh_vote_accounts( fd_exec_slot_ctx_t *       slot_ctx,
                           fd_stake_history_t const * history,
                           ulong *                    new_rate_activation_epoch,
-                          fd_epoch_info_t           *temp_info );
+                          fd_epoch_info_t *          temp_info,
+                          fd_spad_t *                runtime_spad );
 
 void 
 fd_accumulate_stake_infos( fd_exec_slot_ctx_t const * slot_ctx,
@@ -69,7 +71,7 @@ fd_accumulate_stake_infos( fd_exec_slot_ctx_t const * slot_ctx,
                            ulong *                    new_rate_activation_epoch,
                            fd_stake_history_entry_t * accumulator,
                            fd_epoch_info_t *          temp_info,
-                           fd_valloc_t                valloc );
+                           fd_spad_t *                runtime_spad );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/stakes/fd_stakes_from_snapshot.c
+++ b/src/flamenco/stakes/fd_stakes_from_snapshot.c
@@ -82,7 +82,8 @@ _get_stake_weights( fd_solana_manifest_t const * manifest,
   fd_stake_weight_t * weights = fd_scratch_alloc( alignof(fd_stake_weight_t), vote_acc_cnt * sizeof(fd_stake_weight_t) );
   if( FD_UNLIKELY( !weights ) ) FD_LOG_ERR(( "fd_scratch_alloc() failed" ));
 
-  ulong weight_cnt = fd_stake_weights_by_node( vaccs, weights );
+  /* FIXME: This will crash because the spad is not set up. */
+  ulong weight_cnt = fd_stake_weights_by_node( vaccs, weights, NULL );
   if( FD_UNLIKELY( weight_cnt==ULONG_MAX ) ) FD_LOG_ERR(( "fd_stake_weights_by_node() failed" ));
 
   *out_cnt = weight_cnt;

--- a/src/flamenco/vm/syscall/fd_vm_syscall_runtime.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_runtime.c
@@ -146,7 +146,7 @@ fd_vm_syscall_sol_get_rent_sysvar( /**/            void *  _vm,
   /* FIXME: is it possible to do the read in-place? */
   fd_rent_t rent[1];
   fd_rent_new( rent ); /* FIXME: probably should be init as not a distributed persistent object */
-  fd_sysvar_rent_read( rent, instr_ctx->slot_ctx, fd_spad_virtual( instr_ctx->txn_ctx->spad ) );
+  fd_sysvar_rent_read( rent, instr_ctx->slot_ctx, instr_ctx->txn_ctx->spad );
   /* FIXME: no delete function to match new (probably should be fini for the same reason anyway) */
 
   memcpy( out, rent, FD_RENT_FOOTPRINT );


### PR DESCRIPTION
Get rid of wksp and scratch allocations. Starting to remove the use of valloc in the runtime. Adding runtime scoped spad.

DOES NOT:
1. Remove scratch outside of runtime hot path + in blockstore/gossip/repair
2. Hasn't changed types to get rid of valloc completely
3. Need to add caller safety check before allocs everywhere