### PR TITLE
Quic: Move unfinished streams from send_streams to used_streams

### DIFF
--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -457,6 +457,14 @@ fd_quic_calc_expiry( fd_quic_conn_t * conn, ulong now ) {
                         + rtt->peer_max_ack_delay_ticks );
 }
 
+uchar *
+fd_quic_gen_stream_frames( fd_quic_conn_t *     conn,
+                           uchar *              payload_ptr,
+                           uchar *              payload_end,
+                           fd_quic_pkt_meta_t * pkt_meta,
+                           ulong                pkt_number,
+                           ulong                now );
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_waltz_quic_fd_quic_private_h */


### PR DESCRIPTION
Currently, unfinished streams in send_streams that have no data ready to transmit are simply skipped over. However, this leaves those 'stale' streams in send_streams for every iteration of generating stream frames. This change ensures that unfinished but data-less streams are moved from send_streams into used_streams. 