### PR TITLE
flamenco: Prevent executing precompiles if they are not native programs

### DIFF
--- a/contrib/test/test-vectors-fixtures/txn-fixtures/program-tests.list
+++ b/contrib/test/test-vectors-fixtures/txn-fixtures/program-tests.list
@@ -2778,3 +2778,4 @@ dump/test-vectors/txn/fixtures/programs/2ab448fbadb0b964c56472758c7a46920f8591e5
 dump/test-vectors/txn/fixtures/programs/e54e613fb6cab91a508bda54fff4d5ea2e238ee3_1777641.fix
 dump/test-vectors/txn/fixtures/programs/b7d8956145950269da4dc2215fd6f149d1261e0b_1768662.fix
 dump/test-vectors/txn/fixtures/programs/39376265439c3d3765a1a9b94d1beb3e643b6653_1769070.fix
+dump/test-vectors/txn/fixtures/programs/57afb0039f518ff8c83787ec6f23a325aed4faff_4150245.fix

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -114,6 +114,15 @@ fd_executor_lookup_native_program( fd_borrowed_account_t const * prog_acc ) {
        bizarrely owned by the system program. */
     is_native_program = 1;
   }
+
+  /* Prevent execution of precompiled programs if they are not native programs.
+     This should be removed once the move_precompile_verification_to_svm feature is activated. */
+  if( FD_UNLIKELY( !memcmp( owner, fd_solana_secp256r1_program_id.key, sizeof(fd_pubkey_t) ) ||
+                   !memcmp( owner, fd_solana_ed25519_sig_verify_program_id.key, sizeof(fd_pubkey_t) ) ||
+                   !memcmp( owner, fd_solana_keccak_secp_256k_program_id.key, sizeof(fd_pubkey_t) ) ) ) {
+    return NULL;
+  }
+
   fd_pubkey_t const * lookup_pubkey = is_native_program ? pubkey : owner;
   const fd_native_prog_info_t null_function = (const fd_native_prog_info_t) {0};
   return fd_native_program_fn_lookup_tbl_query( lookup_pubkey, &null_function )->fn;


### PR DESCRIPTION
We should not execute precompiled programs if they are not owned by the native loader