### PR TITLE
build: remove 2 more machine types

### DIFF
--- a/.github/workflows/on_nightly.yml
+++ b/.github/workflows/on_nightly.yml
@@ -25,11 +25,13 @@ jobs:
       gcc_exceptions: |
         ALL,linux_gcc_power9,ALL;
         ALL,linux_gcc_arm_n1,ALL;
-        gcc-8.5.0,linux_gcc_zen2;ALL;
-        gcc-8.5.0,linux_gcc_zen4;ALL;
-        gcc-9.5.0,linux_gcc_zen4;ALL;
+        gcc-8.5.0,linux_gcc_zen2,ALL;
+        gcc-8.5.0,linux_gcc_zen4,ALL;
+        gcc-9.5.0,linux_gcc_zen4,ALL;
         gcc-10.5.0,linux_gcc_zen4,ALL;
-        gcc-11.4.0,linux_gcc_zen4,ALL
+        gcc-11.4.0,linux_gcc_zen4,ALL;
+        ALL,linux_gcc_s390x,ALL;
+        ALL,linux_gcc_riscv,ALL
       verbose: false
       build_arm: true
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '0 3 * * *' }}


### PR DESCRIPTION
`linux_gcc_s390x` and `linux_gcc_riscv` will be added back once we have a stable Ubuntu CI runner