### PR TITLE
flamenco: make transaction parsing errors return sanitize failure error

### DIFF
--- a/contrib/test/test-vectors-fixtures/txn-fixtures/program-tests.list
+++ b/contrib/test/test-vectors-fixtures/txn-fixtures/program-tests.list
@@ -2778,3 +2778,4 @@ dump/test-vectors/txn/fixtures/programs/2ab448fbadb0b964c56472758c7a46920f8591e5
 dump/test-vectors/txn/fixtures/programs/e54e613fb6cab91a508bda54fff4d5ea2e238ee3_1777641.fix
 dump/test-vectors/txn/fixtures/programs/b7d8956145950269da4dc2215fd6f149d1261e0b_1768662.fix
 dump/test-vectors/txn/fixtures/programs/39376265439c3d3765a1a9b94d1beb3e643b6653_1769070.fix
+dump/test-vectors/txn/fixtures/programs/a6d7f4390dadb86e7aa5414a054cc6e239eec615_1094896.fix

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -781,6 +781,7 @@ _txn_context_create_and_exec( fd_exec_instr_test_runner_t *      runner,
   /* Create the raw txn (https://solana.com/docs/core/transactions#transaction-size) */
   uchar * txn_raw_begin = fd_scratch_alloc( alignof(uchar), 10000 ); // max txn size is 1232 but we allocate extra for safety
   uchar * txn_raw_cur_ptr = txn_raw_begin;
+  int txn_parse_error     = 0;
 
   /* Compact array of signatures (https://solana.com/docs/core/transactions#transaction)
      Note that although documentation interchangably refers to the signature cnt as a compact-u16
@@ -842,6 +843,11 @@ _txn_context_create_and_exec( fd_exec_instr_test_runner_t *      runner,
     // Compact array of 8-bit data
     pb_bytes_array_t * data = test_ctx->tx.message.instructions[i].data;
     if( data ) {
+      uint data_len_raw = data->size;
+      if( data_len_raw > USHORT_MAX ) {
+        txn_parse_error = -1;
+      }
+
       ushort data_len = (ushort) data->size;
       _add_compact_u16( &txn_raw_cur_ptr, data_len );
       _add_to_data( &txn_raw_cur_ptr, data->bytes, data_len );
@@ -907,6 +913,12 @@ _txn_context_create_and_exec( fd_exec_instr_test_runner_t *      runner,
 
   /* Setup the spad for account allocation */
   task_info->txn_ctx->spad = runner->spad;
+
+  /* Set the sanitize error if the txn was incorrectly formatted. */
+  if( txn_parse_error ) {
+    txn->flags          = 0U;
+    task_info->exec_res = FD_RUNTIME_TXN_ERR_SANITIZE_FAILURE;
+  }
 
   fd_runtime_pre_execute_check( task_info );
 

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -781,7 +781,6 @@ _txn_context_create_and_exec( fd_exec_instr_test_runner_t *      runner,
   /* Create the raw txn (https://solana.com/docs/core/transactions#transaction-size) */
   uchar * txn_raw_begin = fd_scratch_alloc( alignof(uchar), 10000 ); // max txn size is 1232 but we allocate extra for safety
   uchar * txn_raw_cur_ptr = txn_raw_begin;
-  int txn_parse_error     = 0;
 
   /* Compact array of signatures (https://solana.com/docs/core/transactions#transaction)
      Note that although documentation interchangably refers to the signature cnt as a compact-u16
@@ -845,7 +844,7 @@ _txn_context_create_and_exec( fd_exec_instr_test_runner_t *      runner,
     if( data ) {
       uint data_len_raw = data->size;
       if( data_len_raw > USHORT_MAX ) {
-        txn_parse_error = -1;
+        return NULL;
       }
 
       ushort data_len = (ushort) data->size;
@@ -913,12 +912,6 @@ _txn_context_create_and_exec( fd_exec_instr_test_runner_t *      runner,
 
   /* Setup the spad for account allocation */
   task_info->txn_ctx->spad = runner->spad;
-
-  /* Set the sanitize error if the txn was incorrectly formatted. */
-  if( txn_parse_error ) {
-    txn->flags          = 0U;
-    task_info->exec_res = FD_RUNTIME_TXN_ERR_SANITIZE_FAILURE;
-  }
 
   fd_runtime_pre_execute_check( task_info );
 


### PR DESCRIPTION
This only changes the test harness, so should have no effect elsewhere.