### PR TITLE
flamenco: more cpi fixes

### DIFF
--- a/contrib/test/test-vectors-fixtures/cpi-fixtures/cpi.list
+++ b/contrib/test/test-vectors-fixtures/cpi-fixtures/cpi.list
@@ -298,3 +298,14 @@ dump/test-vectors/cpi/fixtures/fc3e0cd05d2ffa80ec901fa0d3419afc122b20e6_1526935.
 dump/test-vectors/cpi/fixtures/fd71728879bb9d8c3433a227ec8d74e2348b0afa_3774804.fix
 dump/test-vectors/cpi/fixtures/fe1ec82e75d1bb7537344a0f551e62a9dd7a5b9c_1521346.fix
 dump/test-vectors/cpi/fixtures/fe36da89135b24576a0a11d16556dfb7d0607e37_2625834.fix
+dump/test-vectors/cpi/fixtures/4c46b521d19972db774a44ba0768020eb72f359a_1621543.fix
+dump/test-vectors/cpi/fixtures/524a7ac4a9f0c6e74b3e225b8ce7077d108bf863_1389766.fix
+dump/test-vectors/cpi/fixtures/5cdf91daa60cf293c0f25c143afd302bf6f77cdb_1775129.fix
+dump/test-vectors/cpi/fixtures/7148580eb993de02d8a9a0876cfb4c4be35019c6_1546075.fix
+dump/test-vectors/cpi/fixtures/71d18686732043a51a79034762eead0da2556e81_1702208.fix
+dump/test-vectors/cpi/fixtures/9a4286957e04f922d8134d1939a6f4bbe149f158_1312801.fix
+dump/test-vectors/cpi/fixtures/a142a39b9a15201948c10d6e12a4bb84629786e9_3408273.fix
+dump/test-vectors/cpi/fixtures/a8b2186646a2a830c558139a108cc41e9b2f6e0f_1469688.fix
+dump/test-vectors/cpi/fixtures/ab2f673af8296d9d2f7e670146a1cc53b823272b_1359152.fix
+dump/test-vectors/cpi/fixtures/c46194deca95fc72d00e24782cc8357fbd16a08c_3598926.fix
+


### PR DESCRIPTION
Use slice translator for byte array to allow for zero length translations

Implement W-permissioned translation on account info data length field

Re-translate with post length when updating caller

Log privilege escalation error messages in prepare_instruction