### PR TITLE
Level-triggered TX batch flush

### DIFF
--- a/src/app/fdctl/run/tiles/fd_net.c
+++ b/src/app/fdctl/run/tiles/fd_net.c
@@ -115,6 +115,10 @@ typedef struct {
   long        tx_flush_interval_ticks;
   long        next_tx_flush;
 
+  /* Flush every N packets */
+  ulong flush_pending;
+  ulong flush_wmark;
+
   fd_ip_t *   ip;
 
   struct {
@@ -438,12 +442,15 @@ after_frag( fd_net_ctx_t *      ctx,
   (void)tsorig;
   (void)stem;
 
+  int  flush_level   = ctx->flush_pending >= ctx->flush_wmark;
   long now           = fd_tickcount();
   long next_tx_flush = ctx->next_tx_flush;
   long deadline      = now + ctx->tx_flush_interval_ticks;
-  int  flush         = now > next_tx_flush;
+  int  flush_timeout = now > next_tx_flush;
+  int  flush         = flush_level || flush_timeout;
   fd_long_store_if( next_tx_flush==LONG_MAX, &ctx->next_tx_flush, deadline ); /* first packet of batch */
   fd_long_store_if( flush,                   &ctx->next_tx_flush, LONG_MAX ); /* last packet of batch */
+  ctx->flush_pending = flush ? 0UL : ctx->flush_pending+1UL;
 
   fd_aio_pkt_info_t aio_buf = { .buf = ctx->frame, .buf_sz = (ushort)sz };
   if( FD_UNLIKELY( route_loopback( ctx->src_ip_addr, sig ) ) ) {
@@ -749,6 +756,9 @@ unprivileged_init( fd_topo_t *      topo,
   } else if( FD_UNLIKELY( ctx->repair_serve_listen_port!=0 && ctx->repair_out->mcache==NULL ) ) {
     FD_LOG_ERR(( "repair serve listen port set but no out link was found" ));
   }
+
+  ctx->flush_wmark   = (ulong)( (double)tile->net.xdp_aio_depth * 0.7 );
+  ctx->flush_pending = 0UL;
 
   ulong scratch_top = FD_SCRATCH_ALLOC_FINI( l, 1UL );
   if( FD_UNLIKELY( scratch_top > (ulong)scratch + scratch_footprint( tile ) ) )


### PR DESCRIPTION
Adds logic to flush the net tile TX queue when more than 70% of the
queue is occupied by packets added after the last flush op.
