### PR TITLE
sysvar: fix fd_epoch_slot0 < to <=

### DIFF
--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.c
@@ -98,7 +98,7 @@ fd_epoch_slot_cnt( fd_epoch_schedule_t const * schedule,
 ulong
 fd_epoch_slot0( fd_epoch_schedule_t const * schedule,
                 ulong                       epoch ) {
-  if( FD_UNLIKELY( epoch < schedule->first_normal_epoch ) ) {
+  if( FD_UNLIKELY( epoch <= schedule->first_normal_epoch ) ) {
     ulong power = fd_ulong_if( epoch<64UL, 1UL<<epoch, ULONG_MAX );
     return fd_ulong_sat_mul( power-1UL, FD_EPOCH_LEN_MIN );
   }


### PR DESCRIPTION
Compare with agave logic:
https://github.com/firedancer-io/agave/blob/a00f1b5cdea9a7d5a70f8d24b86ea3ae66feff11/sdk/epoch-schedule/src/lib.rs#L189-L200
```rust
    pub fn get_first_slot_in_epoch(&self, epoch: u64) -> u64 {
        if epoch <= self.first_normal_epoch {
            2u64.saturating_pow(epoch as u32)
                .saturating_sub(1)
                .saturating_mul(MINIMUM_SLOTS_PER_EPOCH)
        } else {
            epoch
                .saturating_sub(self.first_normal_epoch)
                .saturating_mul(self.slots_per_epoch)
                .saturating_add(self.first_normal_slot)
        }
    }
```
