### PR TITLE
flamenco: cpi fixes

### DIFF
--- a/contrib/test/test-vectors-fixtures/cpi-fixtures/cpi.list
+++ b/contrib/test/test-vectors-fixtures/cpi-fixtures/cpi.list
@@ -308,4 +308,12 @@ dump/test-vectors/cpi/fixtures/a142a39b9a15201948c10d6e12a4bb84629786e9_3408273.
 dump/test-vectors/cpi/fixtures/a8b2186646a2a830c558139a108cc41e9b2f6e0f_1469688.fix
 dump/test-vectors/cpi/fixtures/ab2f673af8296d9d2f7e670146a1cc53b823272b_1359152.fix
 dump/test-vectors/cpi/fixtures/c46194deca95fc72d00e24782cc8357fbd16a08c_3598926.fix
+dump/test-vectors/cpi/fixtures/131b541dd326f6574f930c679e5652ef9c9339c3_1824279.fix
+dump/test-vectors/cpi/fixtures/630cdab059f00d56a5eaf1234d2b05583cc45cdc_1905368.fix
+dump/test-vectors/cpi/fixtures/6bd9c9855f0717b8ef6dd2e2731feb7d8627c8d1_1742726.fix
+dump/test-vectors/cpi/fixtures/ae01be05c8899fe70a7273f7d480bcb6e1a18a89_1992600.fix
+dump/test-vectors/cpi/fixtures/b1f8e781c1f43d18cf390f767ba28918bb35b836_2155599.fix
+dump/test-vectors/cpi/fixtures/c8f94a7e5f7cde3fcd5df1df128fa1b58793cc7b_1656630.fix
+dump/test-vectors/cpi/fixtures/d31de2a96ee8efa36691a9892c517f31ce47fde4_2075382.fix
+dump/test-vectors/cpi/fixtures/fb11fe9f3de77dfd1c47194c84449c16fdc00871_2234472.fix
 


### PR DESCRIPTION
Hoist translate_instruction final checks into the right place

Move MaxInstructionTraceLengthExceeded check to right before instruction execution