### PR TITLE
Remove unused tiles.net.multihome_ip_addrs config option

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -504,34 +504,6 @@ fdctl_cfg_from_env( int *      pargc,
     config->tiles.net.ip_addr = iface_ip;
     mac_address( config->tiles.net.interface, config->tiles.net.mac_addr );
 
-    /* support for multihomed hosts */
-    ulong multi_cnt = config->tiles.net.multihome_ip_addrs_cnt;
-    for( ulong j = 0; j < multi_cnt; ++j ) {
-      int success = fd_cstr_to_ip4_addr( config->tiles.net.multihome_ip_addrs[j],
-          &config->tiles.net.multihome_ip4_addrs[j] );
-      if( !success ) {
-        FD_LOG_ERR(( "configuration option [tiles.net.multihome_ip_addrs] "
-                     "specifies malformed IP address `%s`",
-                     config->tiles.net.multihome_ip_addrs[j] ));
-      }
-    }
-
-    /* look for duplicate addresses */
-    /* there's only a few, so do the O(n^2) comparison */
-    for( ulong j = 0; j < multi_cnt; ++j ) {
-      if( config->tiles.net.ip_addr == config->tiles.net.multihome_ip4_addrs[j] ) {
-        FD_LOG_ERR(( "configuration option [tiles.net.multihome_ip_addrs] "
-                     "specifies an address that matches [tiles.net.src_ip_addr]" ));
-      }
-      for( ulong k = j+1; k < multi_cnt; ++k ) {
-        if( config->tiles.net.multihome_ip4_addrs[j] == config->tiles.net.multihome_ip4_addrs[k] ) {
-          FD_LOG_ERR(( "configuration option [tiles.net.multihome_ip_addrs] "
-                       "specifies duplicate ip addresses `%s`",
-                       config->tiles.net.multihome_ip_addrs[j] ));
-        }
-      }
-    }
-
   }
 
   username_to_id( config );

--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -223,10 +223,6 @@ typedef struct {
       uint flush_timeout_micros;
 
       uint send_buffer_size;
-
-      ulong multihome_ip_addrs_cnt; /* number of home ip addresses */
-      char  multihome_ip_addrs[FD_NET_MAX_SRC_ADDR][32];
-      uint  multihome_ip4_addrs[FD_NET_MAX_SRC_ADDR];
     } net;
 
     struct {

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -891,13 +891,6 @@ dynamic_port_range = "8900-9000"
         # this really be configurable?
         send_buffer_size = 16384
 
-        # The XDP program will filter packets that aren't destined for
-        # the IPv4 address of the interface bound above, but sometimes a
-        # validator may advertise multiple IP addresses.  In this case
-        # the additional addresses can be specified here, and packets
-        # addressed to them will be accepted.
-        multihome_ip_addrs = []
-
     # QUIC tiles are responsible for serving network traffic, including
     # parsing and responding to packets and managing connection timeouts
     # and state machines.  These tiles implement the QUIC protocol,

--- a/src/app/fdctl/config_parse.c
+++ b/src/app/fdctl/config_parse.c
@@ -292,7 +292,6 @@ fdctl_pod_to_cfg( config_t * config,
   CFG_POP      ( uint,   tiles.net.xdp_aio_depth                          );
   CFG_POP      ( uint,   tiles.net.flush_timeout_micros                   );
   CFG_POP      ( uint,   tiles.net.send_buffer_size                       );
-  CFG_POP_ARRAY( cstr,   tiles.net.multihome_ip_addrs                     );
 
   CFG_POP      ( ushort, tiles.quic.regular_transaction_listen_port       );
   CFG_POP      ( ushort, tiles.quic.quic_transaction_listen_port          );

--- a/src/app/fdctl/run/topos/fd_firedancer.c
+++ b/src/app/fdctl/run/topos/fd_firedancer.c
@@ -531,12 +531,6 @@ fd_topo_initialize( config_t * config ) {
       tile->net.repair_intake_listen_port      = config->tiles.repair.repair_intake_listen_port;
       tile->net.repair_serve_listen_port       = config->tiles.repair.repair_serve_listen_port;
 
-      /* multihome support */
-      ulong multi_cnt = tile->net.multihome_ip_addrs_cnt = config->tiles.net.multihome_ip_addrs_cnt;
-      for( ulong j = 0; j < multi_cnt; ++j ) {
-        tile->net.multihome_ip_addrs[j] = config->tiles.net.multihome_ip4_addrs[j];
-      }
-
     } else if( FD_UNLIKELY( !strcmp( tile->name, "quic" ) ) ) {
       fd_memcpy( tile->quic.src_mac_addr, config->tiles.net.mac_addr, 6 );
 

--- a/src/app/fdctl/run/topos/fd_frankendancer.c
+++ b/src/app/fdctl/run/topos/fd_frankendancer.c
@@ -352,11 +352,6 @@ fd_topo_initialize( config_t * config ) {
       tile->net.quic_transaction_listen_port   = config->tiles.quic.quic_transaction_listen_port;
       tile->net.legacy_transaction_listen_port = config->tiles.quic.regular_transaction_listen_port;
 
-      /* multihome support */
-      ulong multi_cnt = tile->net.multihome_ip_addrs_cnt = config->tiles.net.multihome_ip_addrs_cnt;
-      for( ulong j = 0; j < multi_cnt; ++j ) {
-        tile->net.multihome_ip_addrs[j] = config->tiles.net.multihome_ip4_addrs[j];
-      }
     } else if( FD_UNLIKELY( !strcmp( tile->name, "quic" ) ) ) {
       fd_memcpy( tile->quic.src_mac_addr, config->tiles.net.mac_addr, 6 );
 

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -142,10 +142,6 @@ typedef struct {
       ushort gossip_listen_port;
       ushort repair_intake_listen_port;
       ushort repair_serve_listen_port;
-
-      /* multihoming support */
-      ulong multihome_ip_addrs_cnt;
-      uint  multihome_ip_addrs[FD_NET_MAX_SRC_ADDR];
     } net;
 
     struct {


### PR DESCRIPTION
This config option does nothing at all right now.
It won't be supported in the future either.
