### PR TITLE
Fix parsing of 'account_index_exclude_keys' config option

### DIFF
--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -69,9 +69,9 @@ typedef struct {
     ulong account_indexes_cnt;
     char  account_indexes[ 4 ][ 32 ];
     ulong account_index_include_keys_cnt;
-    char  account_index_include_keys[ 32 ][ 32 ];
+    char  account_index_include_keys[ 32 ][ FD_BASE58_ENCODED_32_SZ ];
     ulong account_index_exclude_keys_cnt;
-    char  account_index_exclude_keys[ 32 ][ 32 ];
+    char  account_index_exclude_keys[ 32 ][ FD_BASE58_ENCODED_32_SZ ];
     char  accounts_index_path[ PATH_MAX ];
     char  accounts_hash_cache_path[ PATH_MAX ];
     int   require_tower;


### PR DESCRIPTION
Closes #4104.