### PR TITLE
Quic: Fix NetEm Reorder, and pkt_meta->expiry margin sign

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -3595,7 +3595,7 @@ fd_quic_conn_tx( fd_quic_t *      quic,
 
     /* initialize expiry */
     pkt_meta->expiry = now + conn->idle_timeout;
-    ulong margin = (ulong)(conn->rtt->smoothed_rtt) - (ulong)(3 * conn->rtt->var_rtt);
+    ulong margin = (ulong)(conn->rtt->smoothed_rtt) + (ulong)(3 * conn->rtt->var_rtt);
     if( margin < pkt_meta->expiry ) {
       pkt_meta->expiry -= margin;
     }

--- a/src/waltz/quic/tests/fd_quic_test_helpers.h
+++ b/src/waltz/quic/tests/fd_quic_test_helpers.h
@@ -181,14 +181,19 @@ fd_quic_udpsock_service( fd_quic_udpsock_t const * udpsock );
 
 /* fd_quic_netem injects packet loss and reordering into an aio link. */
 
+struct fd_quic_netem_reorder_buf {
+  ulong sz;
+  uchar buf[2048];
+};
+
 struct fd_quic_netem {
   fd_aio_t         local;
   fd_aio_t const * dst;
   float            thresh_drop;
   float            thresh_reorder;
 
-  ulong reorder_sz;
-  uchar reorder_buf[2048];
+  struct fd_quic_netem_reorder_buf reorder_buf[2];
+  int                              reorder_mru; /* most recently written reorder buf */
 };
 
 typedef struct fd_quic_netem fd_quic_netem_t;


### PR DESCRIPTION
Fixes drops caused by the old reorder emulation by adding an extra buffer space. Respects reordering and avoids starvation via weighted coin toss. 

Also fixes a previous bug in calculating margin of safety on pkt_meta expiry. 