### PR TITLE
pack: fix compute units

### DIFF
--- a/src/app/fdctl/external_functions.c
+++ b/src/app/fdctl/external_functions.c
@@ -5,8 +5,8 @@ extern void fd_ext_validator_main( const char ** args FD_PARAM_UNUSED ) {}
 extern void fd_ext_genesis_main( const char ** args FD_PARAM_UNUSED ) {}
 
 extern void * fd_ext_bank_pre_balance_info( void const * bank FD_PARAM_UNUSED, void * txns FD_PARAM_UNUSED, ulong txn_cnt FD_PARAM_UNUSED ) { return NULL; }
-extern void * fd_ext_bank_load_and_execute_txns( void const * bank FD_PARAM_UNUSED, void * txns FD_PARAM_UNUSED, ulong txn_cnt FD_PARAM_UNUSED, int * out_load_results FD_PARAM_UNUSED, int * out_executing_results FD_PARAM_UNUSED, int * out_executed_results FD_PARAM_UNUSED, uint * out_consumed_cus FD_PARAM_UNUSED ) { return NULL; }
-extern int  fd_ext_bank_execute_and_commit_bundle( void const * bank FD_PARAM_UNUSED, void * txns FD_PARAM_UNUSED, ulong txn_cnt FD_PARAM_UNUSED, uint * out_consumed_cus FD_PARAM_UNUSED ) { return 0; }
+extern int  fd_ext_bank_execute_and_commit_bundle( void const * bank FD_PARAM_UNUSED, void * txns FD_PARAM_UNUSED, ulong txn_cnt FD_PARAM_UNUSED, uint * actual_execution_cus FD_PARAM_UNUSED, uint * actual_acct_data_cus FD_PARAM_UNUSED ) { return 0; }
+extern void * fd_ext_bank_load_and_execute_txns( void const * bank FD_PARAM_UNUSED, void * txns FD_PARAM_UNUSED, ulong txn_cnt FD_PARAM_UNUSED, int * out_load_results FD_PARAM_UNUSED, int * out_executing_results FD_PARAM_UNUSED, int * out_executed_results FD_PARAM_UNUSED, uint * out_consumed_exec_cus FD_PARAM_UNUSED, uint * out_consumed_acct_data_cus FD_PARAM_UNUSED ) { return NULL; }
 extern void fd_ext_bank_acquire( void const * bank FD_PARAM_UNUSED ) {}
 extern void fd_ext_bank_release( void const * bank FD_PARAM_UNUSED ) {}
 extern void fd_ext_bank_release_thunks( void * load_and_execute_output FD_PARAM_UNUSED ) {}

--- a/src/disco/pack/fd_microblock.h
+++ b/src/disco/pack/fd_microblock.h
@@ -54,11 +54,11 @@ struct __attribute__((aligned(64))) fd_txn_p {
   union {
    struct {
      uint non_execution_cus;
-     uint requested_execution_cus;
+     uint requested_exec_plus_acct_data_cus;
    } pack_cu; /* Populated by pack. Bank reads these to populate the other struct of the union. */
    struct {
-     uint rebated_cus; /* requested_execution_cus-real execution CUs. Pack reads this for CU rebating. */
-     uint actual_consumed_cus; /* non_execution_cus+real execution CUs. PoH reads this for block CU counting. */
+     uint rebated_cus; /* requested_exec_plus_acct_data_cus-actual used CUs. Pack reads this for CU rebating. */
+     uint actual_consumed_cus; /* non_execution_cus+real execution CUs+real account data cus. PoH reads this for block CU counting. */
    } bank_cu; /* Populated by bank. */
    ulong blockhash_slot; /* Slot provided by resolv tile when txn arrives at the pack tile. Used when txn is in extra storage in pack. */
   };

--- a/src/disco/pack/fd_pack.h
+++ b/src/disco/pack/fd_pack.h
@@ -518,14 +518,15 @@ void fd_pack_set_initializer_bundles_ready( fd_pack_t * pack );
    though the block-level limits are respected.
 
    Both cases:
-   The non_execution_cus and requested_execution_cus fields of each
-   transaction will be populated with the non execution CUs and
-   requested execution CUs, respectively.  The sum of these two values
-   is the total cost of the transaction, i.e. what is used for all
-   limits, including the total_cus value.  The lower 3 bits of the flags
-   field will be populated (simple vote, bundle, initializer bundle).
-   Inspecting these flags is the proper way to tell which codepath
-   executed.
+   The non_execution_cus and requested_exec_plus_acct_data_cus fields of
+   each transaction will be populated with the non execution CUs and
+   requested execution CUs (including cus derived from the requested
+   loaded accounts data size), respectively.  The sum of these two
+   values is the total cost of the transaction, i.e. what is used for
+   all limits, including the total_cus value.  The lower 3 bits of the
+   flags field will be populated (simple vote, bundle, initializer
+   bundle). Inspecting these flags is the proper way to tell which
+   codepath executed.
 
    Returns the number of transactions in the scheduled microblock or
    bundle.  The return value may be 0 if there are no eligible

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -1721,8 +1721,7 @@ fd_runtime_finalize_txn( fd_exec_slot_ctx_t *         slot_ctx,
   }
 
   int is_vote = fd_txn_is_simple_vote_transaction( txn_ctx->txn_descriptor,
-                                                 txn_ctx->_txn_raw->raw,
-                                                 fd_solana_vote_program_id.key );
+                                                 txn_ctx->_txn_raw->raw );
   if( !is_vote ){
     FD_ATOMIC_FETCH_AND_ADD( &slot_ctx->nonvote_txn_count, 1 );
     if( FD_UNLIKELY( exec_txn_err ) ){

--- a/src/flamenco/runtime/tests/fd_pack_test.c
+++ b/src/flamenco/runtime/tests/fd_pack_test.c
@@ -41,11 +41,12 @@ do {
   }
   ulong rewards;
   uint compute_unit_limit;
+  ulong loaded_accounts_data_cost = 0UL;
   fd_compute_budget_program_finalize( cbp_state,
                                       input->instr_datas_count,
                                       &rewards,
-                                      &compute_unit_limit
-                                      );
+                                      &compute_unit_limit,
+                                      &loaded_accounts_data_cost );
   effects->rewards = rewards;
   effects->compute_unit_limit = compute_unit_limit;
 


### PR DESCRIPTION
The pack tile maintains compute cost for transactions in order to properly fill block. This PR some issues with the current calculation

- Use loaded accounts data cost
- Use the correct number of units for simple votes
- Use default 200k units for config program, which will be migrated to BPF