### PR TITLE
flamenco: cpi fixes numero cuatro

### DIFF
--- a/contrib/test/test-vectors-fixtures/cpi-fixtures/cpi.list
+++ b/contrib/test/test-vectors-fixtures/cpi-fixtures/cpi.list
@@ -316,4 +316,5 @@ dump/test-vectors/cpi/fixtures/b1f8e781c1f43d18cf390f767ba28918bb35b836_2155599.
 dump/test-vectors/cpi/fixtures/c8f94a7e5f7cde3fcd5df1df128fa1b58793cc7b_1656630.fix
 dump/test-vectors/cpi/fixtures/d31de2a96ee8efa36691a9892c517f31ce47fde4_2075382.fix
 dump/test-vectors/cpi/fixtures/fb11fe9f3de77dfd1c47194c84449c16fdc00871_2234472.fix
-
+dump/test-vectors/cpi/fixtures/bcd3a29f55d80f60c8cfdd9a1ec186810e9b53d3_360598.fix
+dump/test-vectors/cpi/fixtures/d727b3b402bd305343cdbf835a52c8b3cfca28f0_361070.fix

--- a/src/flamenco/vm/syscall/fd_vm_cpi.h
+++ b/src/flamenco/vm/syscall/fd_vm_cpi.h
@@ -152,4 +152,30 @@ struct __attribute__((packed)) fd_vm_rc_refcell_ref {
 };
 typedef struct fd_vm_rc_refcell_ref fd_vm_rc_refcell_ref_t;
 
+/* https://github.com/anza-xyz/agave/blob/v2.1.6/programs/bpf_loader/src/syscalls/cpi.rs#L81
+
+   This struct abstracts over the Rust/C ABI differences for the
+   cross-program-invocation (CPI) syscall.
+   It serves the same purpose as the corresponding struct in Agave.
+   Essentially, it caches the results of translations that have been
+   performed leading up to the CPI.
+   Or, in the case of direct mapping, it sometimes stores the vm
+   virtual addresses for translation later on.
+   In direct mapping, translation is sometimes delayed because
+   "permissions on the realloc region can change during CPI".
+ */
+struct fd_vm_cpi_caller_account {
+  ulong *       lamports;
+  fd_pubkey_t * owner;
+  ulong         orig_data_len;
+  uchar *       serialized_data; /* NULL if direct mapping */
+  ulong         serialized_data_len;
+  ulong         vm_data_vaddr;
+  union {
+    ulong * translated; /* Set if direct mapping false */
+    ulong   vaddr;      /* Set if direct mapping */
+  } ref_to_len_in_vm;
+};
+typedef struct fd_vm_cpi_caller_account fd_vm_cpi_caller_account_t;
+
 #endif /* HEADER_fd_src_flamenco_vm_syscall_fd_vm_cpi_h */


### PR DESCRIPTION
Add the equivalent of CallerAccount.  This allows us to do a read-only translation on AccountInfo, matching the translation permission in Agave. Additionally, translations are now properly cached or delayed, rather than repeated unconditionally.