### PR TITLE
gossip: fix msg discriminant check

### DIFF
--- a/src/flamenco/gossip/fd_gossip.c
+++ b/src/flamenco/gossip/fd_gossip.c
@@ -1910,7 +1910,7 @@ fd_gossip_handle_pull_req(fd_gossip_t * glob, const fd_gossip_peer_addr_t * from
 /* Handle any gossip message */
 static void
 fd_gossip_recv(fd_gossip_t * glob, const fd_gossip_peer_addr_t * from, fd_gossip_msg_t * gmsg) {
-  if ( FD_LIKELY( gmsg->discriminant <= 6 ) ) {
+  if ( FD_LIKELY( gmsg->discriminant < FD_METRICS_COUNTER_GOSSIP_RECEIVED_GOSSIP_MESSAGES_CNT ) ) {
     glob->metrics.recv_message[gmsg->discriminant] += 1UL;
   } else {
     glob->metrics.recv_unknown_message += 1UL;


### PR DESCRIPTION
`gmsg->discriminant` it is directly attacker controlled and there are only discriminants [0,5].
https://github.com/firedancer-io/firedancer/blob/811b8abc0eb10bfb77ba0c8f5d07071aa880364e/src/flamenco/types/fd_types.h#L8112-L8119

What is funny is that the code is accidentally correct, because of the way the metrics are laid out [2]:
https://github.com/firedancer-io/firedancer/blob/ac6b5bbe2c7aae2df4e70ffd2b06f4d4dc62756a/src/flamenco/gossip/fd_gossip.h#L157-L158

A message with a discriminant == 6, would land in the true case do an off by one increase, but this value would be `recv_unknown_message` which is exactly what the false branch would have done anyway :D
https://github.com/firedancer-io/firedancer/blob/ac6b5bbe2c7aae2df4e70ffd2b06f4d4dc62756a/src/flamenco/gossip/fd_gossip.c#L1913-L1917