### PR TITLE
blockstore: add locks on txn map modification

### DIFF
--- a/src/flamenco/runtime/fd_blockstore.h
+++ b/src/flamenco/runtime/fd_blockstore.h
@@ -810,7 +810,11 @@ fd_blockstore_slot_remove( fd_blockstore_t * blockstore, ulong slot );
      O(1).  Returns the current `consumed_idx` for the shred's slot if
      insert is successful, otherwise returns FD_SHRED_IDX_NULL on error.
      Reasons for error include this shred is already in the blockstore or
-     the blockstore is full. */
+     the blockstore is full.
+
+     fd_blockstore_shred_insert will manage locking, so the caller
+     should NOT be acquiring the blockstore read/write lock before
+     calling this function. */
 
 void
 fd_blockstore_shred_insert( fd_blockstore_t * blockstore, fd_shred_t const * shred );

--- a/src/flamenco/runtime/fd_rocksdb.c
+++ b/src/flamenco/runtime/fd_rocksdb.c
@@ -574,8 +574,8 @@ fd_rocksdb_import_block_blockstore( fd_rocksdb_t *    db,
       fd_blockstore_end_write(blockstore);
       return -1;
     }
-    fd_blockstore_shred_insert( blockstore, shred );
     fd_blockstore_end_write(blockstore);
+    fd_blockstore_shred_insert( blockstore, shred );
     // if (rc != FD_BLOCKSTORE_SUCCESS_SLOT_COMPLETE && rc != FD_BLOCKSTORE_SUCCESS) {
     //   FD_LOG_WARNING(("failed to store shred %lu/%lu", slot, i));
     //   rocksdb_iter_destroy(iter);


### PR DESCRIPTION
solves the occasional seg fault when inserting into txn_map 