### PR TITLE
gui: fetch validator config at startup

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -1135,15 +1135,6 @@ dynamic_port_range = "8900-9000"
     # endpoint to clients to view it.
     [tiles.gui]
         # If the GUI is enabled.
-        #
-        # Names and icons of peer validators will not be displayed in
-        # the GUI unless the program-id index is enabled, which can be
-        # done by setting
-        #
-        # [ledger]
-        #   account_indexes = ["program-id"]
-        #
-        # In your configuration above.
         enabled = true
 
         # The address to listen on.  By default, if enabled, the GUI


### PR DESCRIPTION
Addresses https://github.com/firedancer-io/firedancer/issues/4127

Applies this [patch](https://github.com/firedancer-io/agave/compare/3ef78d374c..jherrera/gui-fetch-peer-info~6) to `firedancer: gui, send peer table information`