### PR TITLE
Support selective fdctl topo

### DIFF
--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -67,6 +67,7 @@ $(call add-objs,run/tiles/fd_exec,fd_fdctl)
 endif
 
 # fdctl topologies
+$(call add-objs,run/topos/fd_topos_common,fd_fdctl)
 ifdef FD_HAS_NO_AGAVE
 $(call add-objs,run/topos/fd_firedancer,fd_fdctl)
 else

--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -714,7 +714,6 @@ fdctl_cfg_from_env( int *      pargc,
 
   fdctl_cfg_validate( config );
   validate_ports( config );
-  fd_topo_initialize( config );
 }
 
 int

--- a/src/app/fdctl/run/topos/fd_firedancer.c
+++ b/src/app/fdctl/run/topos/fd_firedancer.c
@@ -1,20 +1,15 @@
 /* Firedancer topology used for testing the full validator.
    Associated test script: test_firedancer.sh */
-#include "../../fdctl.h"
+#include "topos.h"
 
 #include "../tiles/fd_replay_notif.h"
-#include "../../../../choreo/fd_choreo_base.h"
 #include "../../../../disco/quic/fd_tpu.h"
 #include "../../../../disco/tiles.h"
 #include "../../../../disco/topo/fd_topob.h"
 #include "../../../../disco/topo/fd_pod_format.h"
-#include "../../../../disco/netlink/fd_netlink_tile.h" /* fd_netlink_topo_create */
 #include "../../../../flamenco/runtime/fd_blockstore.h"
 #include "../../../../flamenco/runtime/fd_runtime.h"
 #include "../../../../flamenco/runtime/fd_txncache.h"
-#include "../../../../util/tile/fd_tile_private.h"
-#include "../../../../util/shmem/fd_shmem_private.h"
-#include "../../../../util/net/fd_net_headers.h"
 
 #include <sys/sysinfo.h>
 #include <sys/random.h>
@@ -64,7 +59,19 @@ setup_topo_txncache( fd_topo_t *  topo,
 }
 
 void
-fd_topo_initialize( config_t * config ) {
+fd_topos_create_validator( fd_topo_t *                 topo,
+                           config_t *                  config,
+                           fd_topos_affinity_t const * affinity ) {
+
+  ulong const * tile_to_cpu = affinity->tile_to_cpu;
+
+  int is_agave_auto_affinity = !strcmp( config->layout.agave_affinity, "auto" );
+  if( FD_UNLIKELY( affinity->is_auto != is_agave_auto_affinity ) ) {
+    FD_LOG_ERR(( "The CPU affinity string in the configuration file under [layout.affinity] and [layout.agave_affinity] must both be set to 'auto' or both be set to a specific CPU affinity string." ));
+  }
+
+  /* Generate topology */
+
   ulong net_tile_cnt    = config->layout.net_tile_count;
   ulong shred_tile_cnt  = config->layout.shred_tile_count;
   ulong quic_tile_cnt   = config->layout.quic_tile_count;
@@ -77,17 +84,15 @@ fd_topo_initialize( config_t * config ) {
 
   int enable_rpc = ( config->rpc.port != 0 );
 
-  fd_topo_t * topo = { fd_topob_new( &config->topo, config->name ) };
-  topo->max_page_size = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
+  fd_topob_wksp( topo, "metric_in" );
+  fd_topos_add_net_tile( topo, config, affinity->tile_to_cpu );
 
   /*             topo, name */
-  fd_topob_wksp( topo, "netbase"     );
-  fd_topob_wksp( topo, "net_netlink" );
-  fd_topob_wksp( topo, "net_shred"   );
-  fd_topob_wksp( topo, "net_gossip"  );
-  fd_topob_wksp( topo, "net_repair"  );
-  fd_topob_wksp( topo, "net_quic"    );
-  fd_topob_wksp( topo, "net_voter"   );
+  fd_topob_wksp( topo, "net_shred"  );
+  fd_topob_wksp( topo, "net_gossip" );
+  fd_topob_wksp( topo, "net_repair" );
+  fd_topob_wksp( topo, "net_quic"   );
+  fd_topob_wksp( topo, "net_voter"  );
 
   fd_topob_wksp( topo, "quic_verify"  );
   fd_topob_wksp( topo, "verify_dedup" );
@@ -95,7 +100,6 @@ fd_topo_initialize( config_t * config ) {
 
   fd_topob_wksp( topo, "shred_storei" );
   fd_topob_wksp( topo, "stake_out"    );
-  fd_topob_wksp( topo, "metric_in"    );
 
   fd_topob_wksp( topo, "poh_shred"    );
 
@@ -136,8 +140,6 @@ fd_topo_initialize( config_t * config ) {
   fd_topob_wksp( topo, "voter_dedup"  );
   fd_topob_wksp( topo, "batch_replay" );
 
-  fd_topob_wksp( topo, "net"        );
-  fd_topob_wksp( topo, "netlnk"     );
   fd_topob_wksp( topo, "quic"       );
   fd_topob_wksp( topo, "verify"     );
   fd_topob_wksp( topo, "dedup"      );
@@ -168,7 +170,6 @@ fd_topo_initialize( config_t * config ) {
   #define FOR(cnt) for( ulong i=0UL; i<cnt; i++ )
 
   /*                                  topo, link_name,      wksp_name,      depth,                                    mtu,                           burst */
-  FOR(net_tile_cnt)    fd_topob_link( topo, "net_netlink",  "net_netlink",  128UL,                                    0UL,                           0UL );
   FOR(net_tile_cnt)    fd_topob_link( topo, "net_gossip",   "net_gossip",   config->tiles.net.send_buffer_size,       FD_NET_MTU,                    1UL );
   FOR(net_tile_cnt)    fd_topob_link( topo, "net_repair",   "net_repair",   config->tiles.net.send_buffer_size,       FD_NET_MTU,                    1UL );
   FOR(net_tile_cnt)    fd_topob_link( topo, "net_quic",     "net_quic",     config->tiles.net.send_buffer_size,       FD_NET_MTU,                    1UL );
@@ -223,33 +224,7 @@ fd_topo_initialize( config_t * config ) {
 
   /**/                 fd_topob_link( topo, "batch_replay", "batch_replay", 128UL,                                    32UL,                          1UL   );
 
-  ushort parsed_tile_to_cpu[ FD_TILE_MAX ];
-  /* Unassigned tiles will be floating, unless auto topology is enabled. */
-  for( ulong i=0UL; i<FD_TILE_MAX; i++ ) parsed_tile_to_cpu[ i ] = USHORT_MAX;
-
-  int is_auto_affinity = !strcmp( config->layout.affinity, "auto" );
-  int is_bench_auto_affinity = !strcmp( config->development.bench.affinity, "auto" );
-
-  if( FD_UNLIKELY( is_auto_affinity != is_bench_auto_affinity ) ) {
-    FD_LOG_ERR(( "The CPU affinity string in the configuration file under [layout.affinity] and [development.bench.affinity] must all be set to 'auto' or all be set to a specific CPU affinity string." ));
-  }
-
-  ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_tile_private_cpus_parse( config->layout.affinity, parsed_tile_to_cpu );
-
-  ulong tile_to_cpu[ FD_TILE_MAX ];
-  for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
-    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && parsed_tile_to_cpu[ i ]>=fd_numa_cpu_cnt() ) )
-      FD_LOG_ERR(( "The CPU affinity string in the configuration file under [layout.affinity] specifies a CPU index of %hu, but the system "
-                   "only has %lu CPUs. You should either change the CPU allocations in the affinity string, or increase the number of CPUs "
-                   "in the system.",
-                   parsed_tile_to_cpu[ i ], fd_numa_cpu_cnt() ));
-    tile_to_cpu[ i ] = fd_ulong_if( parsed_tile_to_cpu[ i ]==USHORT_MAX, ULONG_MAX, (ulong)parsed_tile_to_cpu[ i ] );
-  }
-
   /*                                              topo, tile_name, tile_wksp, metrics_wksp, cpu_idx,                       is_agave */
-  FOR(net_tile_cnt)                fd_topob_tile( topo, "net",     "net",     "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0 );
-  fd_topo_tile_t * netlink_tile =  fd_topob_tile( topo, "netlnk" , "netlnk",  "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0 );
   FOR(quic_tile_cnt)               fd_topob_tile( topo, "quic",    "quic",    "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0 );
   FOR(verify_tile_cnt)             fd_topob_tile( topo, "verify",  "verify",  "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0 );
   /**/                             fd_topob_tile( topo, "dedup",   "dedup",   "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0 );
@@ -345,29 +320,9 @@ fd_topo_initialize( config_t * config ) {
   fd_topob_tile_uses( topo, snaps_tile,  constipated_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   FD_TEST( fd_pod_insertf_ulong( topo->props, constipated_obj->id, "constipate" ) );
 
-  if( FD_LIKELY( !is_auto_affinity ) ) {
-    if( FD_UNLIKELY( affinity_tile_cnt<topo->tile_cnt ) )
-      FD_LOG_ERR(( "The topology you are using has %lu tiles, but the CPU affinity specified in the config tile as [layout.affinity] only provides for %lu cores. "
-                   "You should either increase the number of cores dedicated to Firedancer in the affinity string, or decrease the number of cores needed by reducing "
-                   "the total tile count. You can reduce the tile count by decreasing individual tile counts in the [layout] section of the configuration file.",
-                   topo->tile_cnt, affinity_tile_cnt ));
-    if( FD_UNLIKELY( affinity_tile_cnt>topo->tile_cnt ) )
-      FD_LOG_WARNING(( "The topology you are using has %lu tiles, but the CPU affinity specified in the config tile as [layout.affinity] provides for %lu cores. "
-                       "Not all cores in the affinity will be used by Firedancer. You may wish to increase the number of tiles in the system by increasing "
-                       "individual tile counts in the [layout] section of the configuration file.",
-                       topo->tile_cnt, affinity_tile_cnt ));
-  }
-
-  /* The netlink tile shares various objects to net tiles */
-  fd_netlink_topo_create( netlink_tile, topo, config );
-  for( ulong i=0UL; i<net_tile_cnt; i++ ) {
-    ulong net_tile_id = fd_topo_find_tile( topo, "net", i ); FD_TEST( net_tile_id!=ULONG_MAX );
-    fd_netlink_topo_join( topo, netlink_tile, &topo->tiles[ net_tile_id ] );
-  }
-  fd_topob_tile_in( topo, "netlnk", 0UL, "metric_in", "net_netlink", 0UL, FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
+  fd_topos_detect_affinity_mismatch( topo, affinity );
 
   /*                                      topo, tile_name, tile_kind_id, fseq_wksp,   link_name,      link_kind_id, reliable,            polled */
-  FOR(net_tile_cnt)    fd_topob_tile_out( topo, "net",     i,                         "net_netlink",  i                                                  );
   FOR(net_tile_cnt) for( ulong j=0UL; j<shred_tile_cnt; j++ )
                        fd_topob_tile_in(  topo, "net",     i,            "metric_in", "shred_net",    j,            FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED ); /* No reliable consumers of networking fragments, may be dropped or overrun */
   FOR(net_tile_cnt)    fd_topob_tile_out( topo, "net",     i,                         "net_shred",    i                                                  );
@@ -528,15 +483,6 @@ fd_topo_initialize( config_t * config ) {
     fd_topo_tile_t * tile = &topo->tiles[ i ];
 
     if( FD_UNLIKELY( !strcmp( tile->name, "net" ) ) ) {
-      strncpy( tile->net.interface,    config->tiles.net.interface, sizeof(tile->net.interface) );
-      memcpy(  tile->net.src_mac_addr, config->tiles.net.mac_addr,  6UL );
-
-      tile->net.tx_flush_timeout_ns            = (long)config->tiles.net.flush_timeout_micros * 1000L;
-      tile->net.xdp_rx_queue_size              = config->tiles.net.xdp_rx_queue_size;
-      tile->net.xdp_tx_queue_size              = config->tiles.net.xdp_tx_queue_size;
-      tile->net.src_ip_addr                    = config->tiles.net.ip_addr;
-      tile->net.zero_copy                      = 0==strcmp( config->tiles.net.xdp_mode, "drv" ); /* only enable for drv */
-      fd_memcpy( tile->net.xdp_mode, config->tiles.net.xdp_mode, 8 );
 
       tile->net.shred_listen_port              = config->tiles.shred.shred_listen_port;
       tile->net.quic_transaction_listen_port   = config->tiles.quic.quic_transaction_listen_port;
@@ -544,16 +490,6 @@ fd_topo_initialize( config_t * config ) {
       tile->net.gossip_listen_port             = config->gossip.port;
       tile->net.repair_intake_listen_port      = config->tiles.repair.repair_intake_listen_port;
       tile->net.repair_serve_listen_port       = config->tiles.repair.repair_serve_listen_port;
-
-      tile->net.netdev_dbl_buf_obj_id = netlink_tile->netlink.netdev_dbl_buf_obj_id;
-      tile->net.fib4_main_obj_id      = netlink_tile->netlink.fib4_main_obj_id;
-      tile->net.fib4_local_obj_id     = netlink_tile->netlink.fib4_local_obj_id;
-      tile->net.neigh4_obj_id         = netlink_tile->netlink.neigh4_obj_id;
-      tile->net.neigh4_ele_obj_id     = netlink_tile->netlink.neigh4_ele_obj_id;
-
-    } else if( FD_UNLIKELY( !strcmp( tile->name, "netlnk" ) ) ) {
-
-      /* already configured */
 
     } else if( FD_UNLIKELY( !strcmp( tile->name, "quic" ) ) ) {
       fd_memcpy( tile->quic.src_mac_addr, config->tiles.net.mac_addr, 6 );
@@ -679,8 +615,6 @@ fd_topo_initialize( config_t * config ) {
       FD_LOG_NOTICE(("config->consensus.identity_path: %s", config->consensus.identity_path));
       FD_LOG_NOTICE(("config->consensus.vote_account_path: %s", config->consensus.vote_account_path));
 
-    } else if( FD_UNLIKELY( !strcmp( tile->name, "bhole" ) ) ) {
-
     } else if( FD_UNLIKELY( !strcmp( tile->name, "sign" ) ) ) {
       strncpy( tile->sign.identity_key_path, config->consensus.identity_path, sizeof(tile->sign.identity_key_path) );
 
@@ -689,8 +623,6 @@ fd_topo_initialize( config_t * config ) {
         FD_LOG_ERR(( "failed to parse prometheus listen address `%s`", config->tiles.metric.prometheus_listen_address ));
       tile->metric.prometheus_listen_port = config->tiles.metric.prometheus_listen_port;
 
-    } else if( FD_UNLIKELY( !strcmp( tile->name, "rtpool" ) ) ) {
-      /* Nothing for now */
     } else if( FD_UNLIKELY( !strcmp( tile->name, "pack" ) ) ) {
       strncpy( tile->pack.identity_key_path, config->consensus.identity_path, sizeof(tile->pack.identity_key_path) );
 
@@ -728,8 +660,6 @@ fd_topo_initialize( config_t * config ) {
       strncpy( tile->batch.out_dir, config->tiles.batch.out_dir, sizeof(tile->batch.out_dir) );
       tile->batch.hash_tpool_thread_count = config->tiles.batch.hash_tpool_thread_count;
       strncpy( tile->replay.funk_file, config->tiles.replay.funk_file, sizeof(tile->replay.funk_file) );
-    } else if( FD_UNLIKELY( !strcmp( tile->name, "btpool" ) ) ) {
-      /* Nothing for now */
     } else if( FD_UNLIKELY( !strcmp( tile->name, "gui" ) ) ) {
       if( FD_UNLIKELY( !fd_cstr_to_ip4_addr( config->tiles.gui.gui_listen_address, &tile->gui.listen_addr ) ) )
         FD_LOG_ERR(( "failed to parse gui listen address `%s`", config->tiles.gui.gui_listen_address ));
@@ -737,18 +667,8 @@ fd_topo_initialize( config_t * config ) {
       tile->gui.is_voting = strcmp( config->consensus.vote_account_path, "" );
       strncpy( tile->gui.cluster, config->cluster, sizeof(tile->gui.cluster) );
       strncpy( tile->gui.identity_key_path, config->consensus.identity_path, sizeof(tile->gui.identity_key_path) );
-    } else if( FD_UNLIKELY( !strcmp( tile->name, "plugin" ) ) ) {
-
-    } else if( FD_UNLIKELY( !strcmp( tile->name, "exec" ) ) ) {
-
-    } else {
-      FD_LOG_ERR(( "unknown tile name %lu `%s`", i, tile->name ));
     }
   }
-
-  if( FD_UNLIKELY( is_auto_affinity ) ) fd_topob_auto_layout( topo );
-
-  fd_topob_finish( topo, fdctl_obj_align, fdctl_obj_footprint, fdctl_obj_loose );
 
   const char * status_cache = config->tiles.replay.status_cache;
   if ( strlen( status_cache ) > 0 ) {

--- a/src/app/fdctl/run/topos/fd_frankendancer.c
+++ b/src/app/fdctl/run/topos/fd_frankendancer.c
@@ -1,16 +1,26 @@
-#include "../../fdctl.h"
-
+#include "topos.h"
 #include "../../../../disco/quic/fd_tpu.h"
 #include "../../../../disco/tiles.h"
 #include "../../../../disco/topo/fd_topob.h"
 #include "../../../../disco/topo/fd_pod_format.h"
 #include "../../../../disco/plugin/fd_plugin.h"
-#include "../../../../disco/netlink/fd_netlink_tile.h" /* fd_netlink_topo_create */
-#include "../../../../util/tile/fd_tile_private.h"
-#include "../../../../util/shmem/fd_shmem_private.h"
+#include "../../../../util/tile/fd_tile_private.h" /* fd_tile_private_cpus_parse */
+#include "../../../../util/shmem/fd_shmem_private.h" /* fd_numa_cpu_cnt() */
 
 void
-fd_topo_initialize( config_t * config ) {
+fd_topos_create_validator( fd_topo_t *                 topo,
+                           config_t *                  config,
+                           fd_topos_affinity_t const * affinity ) {
+
+  ulong const * tile_to_cpu = affinity->tile_to_cpu;
+
+  int is_agave_auto_affinity = !strcmp( config->layout.agave_affinity, "auto" );
+  if( FD_UNLIKELY( affinity->is_auto != is_agave_auto_affinity ) ) {
+    FD_LOG_ERR(( "The CPU affinity string in the configuration file under [layout.affinity] and [layout.agave_affinity] must both be set to 'auto' or both be set to a specific CPU affinity string." ));
+  }
+
+  /* Generate topology */
+
   ulong net_tile_cnt    = config->layout.net_tile_count;
   ulong quic_tile_cnt   = config->layout.quic_tile_count;
   ulong verify_tile_cnt = config->layout.verify_tile_count;
@@ -18,11 +28,10 @@ fd_topo_initialize( config_t * config ) {
   ulong bank_tile_cnt   = config->layout.bank_tile_count;
   ulong shred_tile_cnt  = config->layout.shred_tile_count;
 
-  fd_topo_t * topo = { fd_topob_new( &config->topo, config->name ) };
-  topo->max_page_size = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
+  fd_topob_wksp( topo, "metric_in" );
+  fd_topos_add_net_tile( topo, config, affinity->tile_to_cpu );
 
   /*             topo, name */
-  fd_topob_wksp( topo, "netbase"      );
   fd_topob_wksp( topo, "net_quic"     );
   fd_topob_wksp( topo, "net_shred"    );
   fd_topob_wksp( topo, "quic_verify"  );
@@ -36,14 +45,10 @@ fd_topo_initialize( config_t * config ) {
   fd_topob_wksp( topo, "gossip_dedup" );
   fd_topob_wksp( topo, "shred_store"  );
   fd_topob_wksp( topo, "stake_out"    );
-  fd_topob_wksp( topo, "metric_in"    );
 
   fd_topob_wksp( topo, "shred_sign"   );
   fd_topob_wksp( topo, "sign_shred"   );
 
-  fd_topob_wksp( topo, "net"          );
-  fd_topob_wksp( topo, "net_netlink"  );
-  fd_topob_wksp( topo, "netlnk"       );
   fd_topob_wksp( topo, "quic"         );
   fd_topob_wksp( topo, "verify"       );
   fd_topob_wksp( topo, "dedup"        );
@@ -60,7 +65,6 @@ fd_topo_initialize( config_t * config ) {
   #define FOR(cnt) for( ulong i=0UL; i<cnt; i++ )
 
   /*                                  topo, link_name,      wksp_name,      depth,                                    mtu,                    burst */
-  FOR(net_tile_cnt)    fd_topob_link( topo, "net_netlink",  "net_netlink",  128UL,                                    0UL,                    0UL );
   FOR(net_tile_cnt)    fd_topob_link( topo, "net_quic",     "net_quic",     config->tiles.net.send_buffer_size,       FD_NET_MTU,             1UL );
   FOR(net_tile_cnt)    fd_topob_link( topo, "net_shred",    "net_shred",    config->tiles.net.send_buffer_size,       FD_NET_MTU,             1UL );
   FOR(quic_tile_cnt)   fd_topob_link( topo, "quic_net",     "net_quic",     config->tiles.net.send_buffer_size,       FD_NET_MTU,             1UL );
@@ -87,34 +91,7 @@ fd_topo_initialize( config_t * config ) {
   FOR(shred_tile_cnt)  fd_topob_link( topo, "shred_sign",   "shred_sign",   128UL,                                    32UL,                   1UL );
   FOR(shred_tile_cnt)  fd_topob_link( topo, "sign_shred",   "sign_shred",   128UL,                                    64UL,                   1UL );
 
-  ushort parsed_tile_to_cpu[ FD_TILE_MAX ];
-  /* Unassigned tiles will be floating, unless auto topology is enabled. */
-  for( ulong i=0UL; i<FD_TILE_MAX; i++ ) parsed_tile_to_cpu[ i ] = USHORT_MAX;
-
-  int is_auto_affinity = !strcmp( config->layout.affinity, "auto" );
-  int is_agave_auto_affinity = !strcmp( config->layout.agave_affinity, "auto" );
-
-  if( FD_UNLIKELY( is_auto_affinity != is_agave_auto_affinity ) ) {
-    FD_LOG_ERR(( "The CPU affinity string in the configuration file under [layout.affinity] and [layout.agave_affinity] must both be set to 'auto' or both be set to a specific CPU affinity string." ));
-  }
-
-  ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_tile_private_cpus_parse( config->layout.affinity, parsed_tile_to_cpu );
-
-  ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
-  for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
-    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && parsed_tile_to_cpu[ i ]>=fd_numa_cpu_cnt() ) )
-      FD_LOG_ERR(( "The CPU affinity string in the configuration file under [layout.affinity] specifies a CPU index of %hu, but the system "
-                   "only has %lu CPUs. You should either change the CPU allocations in the affinity string, or increase the number of CPUs "
-                   "in the system.",
-                   parsed_tile_to_cpu[ i ], fd_numa_cpu_cnt() ));
-    tile_to_cpu[ i ] = fd_ulong_if( parsed_tile_to_cpu[ i ]==USHORT_MAX, ULONG_MAX, (ulong)parsed_tile_to_cpu[ i ] );
-  }
-
   /*                                  topo, tile_name, tile_wksp, metrics_wksp, cpu_idx,                       is_agave */
-  FOR(net_tile_cnt)    fd_topob_tile( topo, "net",     "net",     "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0 );
-  fd_topo_tile_t * netlink_tile =
-  /**/                 fd_topob_tile( topo, "netlnk" , "netlnk",  "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0 );
   FOR(quic_tile_cnt)   fd_topob_tile( topo, "quic",    "quic",    "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0 );
   FOR(verify_tile_cnt) fd_topob_tile( topo, "verify",  "verify",  "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0 );
   /**/                 fd_topob_tile( topo, "dedup",   "dedup",   "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0 );
@@ -128,16 +105,7 @@ fd_topo_initialize( config_t * config ) {
   /**/                 fd_topob_tile( topo, "metric",  "metric",  "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0 );
   /**/                 fd_topob_tile( topo, "cswtch",  "cswtch",  "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0 );
 
-  /* The netlink tile shares various objects to net tiles */
-  fd_netlink_topo_create( netlink_tile, topo, config );
-  for( ulong i=0UL; i<net_tile_cnt; i++ ) {
-    ulong net_tile_id = fd_topo_find_tile( topo, "net", i ); FD_TEST( net_tile_id!=ULONG_MAX );
-    fd_netlink_topo_join( topo, netlink_tile, &topo->tiles[ net_tile_id ] );
-  }
-
   /*                                      topo, tile_name, tile_kind_id, fseq_wksp,   link_name,      link_kind_id, reliable,            polled */
-  FOR(net_tile_cnt)    fd_topob_tile_in(  topo, "netlnk",  0UL,          "metric_in", "net_netlink",  i,            FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
-  FOR(net_tile_cnt)    fd_topob_tile_out( topo, "net",     i,                         "net_netlink",  i                                                  );
   FOR(net_tile_cnt) for( ulong j=0UL; j<quic_tile_cnt; j++ )
                        fd_topob_tile_in(  topo, "net",     i,            "metric_in", "quic_net",     j,            FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED ); /* No reliable consumers of networking fragments, may be dropped or overrun */
   FOR(net_tile_cnt) for( ulong j=0UL; j<shred_tile_cnt; j++ )
@@ -278,17 +246,17 @@ fd_topo_initialize( config_t * config ) {
     }
   }
 
-  if( FD_LIKELY( !is_auto_affinity ) ) {
-    if( FD_UNLIKELY( affinity_tile_cnt<topo->tile_cnt ) )
+  if( FD_LIKELY( !affinity->is_auto ) ) {
+    if( FD_UNLIKELY( affinity->tile_cnt<topo->tile_cnt ) )
       FD_LOG_ERR(( "The topology you are using has %lu tiles, but the CPU affinity specified in the config tile as [layout.affinity] only provides for %lu cores. "
                    "You should either increase the number of cores dedicated to Firedancer in the affinity string, or decrease the number of cores needed by reducing "
                    "the total tile count. You can reduce the tile count by decreasing individual tile counts in the [layout] section of the configuration file.",
-                   topo->tile_cnt, affinity_tile_cnt ));
-    if( FD_UNLIKELY( affinity_tile_cnt>topo->tile_cnt ) )
+                   topo->tile_cnt, affinity->tile_cnt ));
+    if( FD_UNLIKELY( affinity->tile_cnt>topo->tile_cnt ) )
       FD_LOG_WARNING(( "The topology you are using has %lu tiles, but the CPU affinity specified in the config tile as [layout.affinity] provides for %lu cores. "
                        "Not all cores in the affinity will be used by Firedancer. You may wish to increase the number of tiles in the system by increasing "
                        "individual tile counts in the [layout] section of the configuration file.",
-                       topo->tile_cnt, affinity_tile_cnt ));
+                       topo->tile_cnt, affinity->tile_cnt ));
 
     if( FD_LIKELY( strcmp( "", config->layout.agave_affinity ) ) ) {
       ushort agave_cpu[ FD_TILE_MAX ];
@@ -346,29 +314,10 @@ fd_topo_initialize( config_t * config ) {
     fd_topo_tile_t * tile = &topo->tiles[ i ];
 
     if( FD_UNLIKELY( !strcmp( tile->name, "net" ) ) ) {
-      strncpy( tile->net.interface,    config->tiles.net.interface, sizeof(tile->net.interface) );
-      memcpy(  tile->net.src_mac_addr, config->tiles.net.mac_addr,  6UL );
-
-      tile->net.tx_flush_timeout_ns = (long)config->tiles.net.flush_timeout_micros * 1000L;
-      tile->net.xdp_rx_queue_size = config->tiles.net.xdp_rx_queue_size;
-      tile->net.xdp_tx_queue_size = config->tiles.net.xdp_tx_queue_size;
-      tile->net.src_ip_addr       = config->tiles.net.ip_addr;
-      tile->net.zero_copy         = 0==strcmp( config->tiles.net.xdp_mode, "drv" ); /* only enable for drv */
-      fd_memcpy( tile->net.xdp_mode, config->tiles.net.xdp_mode, 8 );
 
       tile->net.shred_listen_port              = config->tiles.shred.shred_listen_port;
       tile->net.quic_transaction_listen_port   = config->tiles.quic.quic_transaction_listen_port;
       tile->net.legacy_transaction_listen_port = config->tiles.quic.regular_transaction_listen_port;
-
-      tile->net.netdev_dbl_buf_obj_id = netlink_tile->netlink.netdev_dbl_buf_obj_id;
-      tile->net.fib4_main_obj_id      = netlink_tile->netlink.fib4_main_obj_id;
-      tile->net.fib4_local_obj_id     = netlink_tile->netlink.fib4_local_obj_id;
-      tile->net.neigh4_obj_id         = netlink_tile->netlink.neigh4_obj_id;
-      tile->net.neigh4_ele_obj_id     = netlink_tile->netlink.neigh4_ele_obj_id;
-
-    } else if( FD_UNLIKELY( !strcmp( tile->name, "netlnk" ) ) ) {
-
-      /* already configured */
 
     } else if( FD_UNLIKELY( !strcmp( tile->name, "quic" ) ) ) {
       fd_memcpy( tile->quic.src_mac_addr, config->tiles.net.mac_addr, 6 );
@@ -394,8 +343,6 @@ fd_topo_initialize( config_t * config ) {
     } else if( FD_UNLIKELY( !strcmp( tile->name, "dedup" ) ) ) {
       tile->dedup.tcache_depth = config->tiles.dedup.signature_cache_size;
 
-    } else if( FD_UNLIKELY( !strcmp( tile->name, "resolv" ) ) ) {
-
     } else if( FD_UNLIKELY( !strcmp( tile->name, "pack" ) ) ) {
       strncpy( tile->pack.identity_key_path, config->consensus.identity_path, sizeof(tile->pack.identity_key_path) );
 
@@ -404,8 +351,6 @@ fd_topo_initialize( config_t * config ) {
       tile->pack.larger_max_cost_per_block     = config->development.bench.larger_max_cost_per_block;
       tile->pack.larger_shred_limits_per_block = config->development.bench.larger_shred_limits_per_block;
       tile->pack.use_consumed_cus              = config->tiles.pack.use_consumed_cus;
-
-    } else if( FD_UNLIKELY( !strcmp( tile->name, "bank" ) ) ) {
 
     } else if( FD_UNLIKELY( !strcmp( tile->name, "poh" ) ) ) {
       strncpy( tile->poh.identity_key_path, config->consensus.identity_path, sizeof(tile->poh.identity_key_path) );
@@ -436,8 +381,6 @@ fd_topo_initialize( config_t * config ) {
         FD_LOG_ERR(( "failed to parse prometheus listen address `%s`", config->tiles.metric.prometheus_listen_address ));
       tile->metric.prometheus_listen_port = config->tiles.metric.prometheus_listen_port;
 
-    } else if( FD_UNLIKELY( !strcmp( tile->name, "cswtch" ) ) ) {
-
     } else if( FD_UNLIKELY( !strcmp( tile->name, "gui" ) ) ) {
       if( FD_UNLIKELY( !fd_cstr_to_ip4_addr( config->tiles.gui.gui_listen_address, &tile->gui.listen_addr ) ) )
         FD_LOG_ERR(( "failed to parse gui listen address `%s`", config->tiles.gui.gui_listen_address ));
@@ -446,15 +389,8 @@ fd_topo_initialize( config_t * config ) {
       strncpy( tile->gui.cluster, config->cluster, sizeof(tile->gui.cluster) );
       strncpy( tile->gui.identity_key_path, config->consensus.identity_path, sizeof(tile->gui.identity_key_path) );
 
-    } else if( FD_UNLIKELY( !strcmp( tile->name, "plugin" ) ) ) {
-
-    } else {
-      FD_LOG_ERR(( "unknown tile name %lu `%s`", i, tile->name ));
     }
   }
 
-  if( FD_UNLIKELY( is_auto_affinity ) ) fd_topob_auto_layout( topo );
-
-  fd_topob_finish( topo, fdctl_obj_align, fdctl_obj_footprint, fdctl_obj_loose );
   config->topo = *topo;
 }

--- a/src/app/fdctl/run/topos/fd_topos_common.c
+++ b/src/app/fdctl/run/topos/fd_topos_common.c
@@ -1,0 +1,98 @@
+#include "topos.h"
+#include "../../fdctl.h"
+#include "../../../../disco/topo/fd_topob.h"
+#include "../../../../disco/netlink/fd_netlink_tile.h" /* fd_netlink_topo_create */
+#include "../../../../util/tile/fd_tile_private.h" /* fd_tile_private_cpus_parse */
+#include "../../../../util/shmem/fd_shmem_private.h" /* fd_numa_cpu_cnt() */
+
+void
+fd_topos_affinity( fd_topos_affinity_t * affinity,
+                   char const *          affinity_str ) {
+  memset( affinity, 0, sizeof(fd_topos_affinity_t) );
+
+  ushort parsed_tile_to_cpu[ FD_TILE_MAX ];
+  /* Unassigned tiles will be floating, unless auto topology is enabled. */
+  for( ulong i=0UL; i<FD_TILE_MAX; i++ ) parsed_tile_to_cpu[ i ] = USHORT_MAX;
+
+  affinity->is_auto = !strcmp( affinity_str, "auto" );
+
+  affinity->tile_cnt = 0UL;
+  if( FD_LIKELY( !affinity->is_auto ) ) affinity->tile_cnt = fd_tile_private_cpus_parse( affinity_str, parsed_tile_to_cpu );
+
+  for( ulong i=0UL; i<affinity->tile_cnt; i++ ) {
+    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && parsed_tile_to_cpu[ i ]>=fd_numa_cpu_cnt() ) )
+      FD_LOG_ERR(( "The CPU affinity string in the configuration file under [layout.affinity] specifies a CPU index of %hu, but the system "
+                   "only has %lu CPUs. You should either change the CPU allocations in the affinity string, or increase the number of CPUs "
+                   "in the system.",
+                   parsed_tile_to_cpu[ i ], fd_numa_cpu_cnt() ));
+    affinity->tile_to_cpu[ i ] = fd_ulong_if( parsed_tile_to_cpu[ i ]==USHORT_MAX, ULONG_MAX, (ulong)parsed_tile_to_cpu[ i ] );
+  }
+}
+
+void
+fd_topos_detect_affinity_mismatch( fd_topo_t const *           topo,
+                                   fd_topos_affinity_t const * affinity ) {
+  if( FD_LIKELY( !affinity->is_auto ) ) {
+    if( FD_UNLIKELY( affinity->tile_cnt<topo->tile_cnt ) )
+      FD_LOG_ERR(( "The topology you are using has %lu tiles, but the CPU affinity specified in the config tile as [layout.affinity] only provides for %lu cores. "
+                   "You should either increase the number of cores dedicated to Firedancer in the affinity string, or decrease the number of cores needed by reducing "
+                   "the total tile count. You can reduce the tile count by decreasing individual tile counts in the [layout] section of the configuration file.",
+                   topo->tile_cnt, affinity->tile_cnt ));
+    if( FD_UNLIKELY( affinity->tile_cnt>topo->tile_cnt ) )
+      FD_LOG_WARNING(( "The topology you are using has %lu tiles, but the CPU affinity specified in the config tile as [layout.affinity] provides for %lu cores. "
+                       "Not all cores in the affinity will be used by Firedancer. You may wish to increase the number of tiles in the system by increasing "
+                       "individual tile counts in the [layout] section of the configuration file.",
+                       topo->tile_cnt, affinity->tile_cnt ));
+  }
+}
+
+void
+fd_topos_seal( fd_topo_t *                 topo,
+               fd_topos_affinity_t const * affinity ) {
+  if( FD_UNLIKELY( affinity->is_auto ) ) fd_topob_auto_layout( topo );
+  fd_topob_finish( topo, fdctl_obj_align, fdctl_obj_footprint, fdctl_obj_loose );
+}
+
+
+void
+fd_topos_add_net_tile( fd_topo_t *      topo,
+                       config_t const * config,
+                       ulong const      tile_to_cpu[ FD_TILE_MAX ] ) {
+  ulong net_tile_cnt = config->layout.net_tile_count;
+
+  fd_topob_wksp( topo, "net"          );
+  fd_topob_wksp( topo, "netlnk"       );
+  fd_topob_wksp( topo, "netbase"      );
+  fd_topob_wksp( topo, "net_netlink"  );
+
+  fd_topob_link( topo, "net_netlink", "net_netlink", 128UL, 0UL, 0UL );
+
+  fd_topo_tile_t * netlink_tile = fd_topob_tile( topo, "netlnk", "netlnk", "metric_in", tile_to_cpu[ topo->tile_cnt ], 0 );
+  fd_netlink_topo_create( netlink_tile, topo, config );
+
+  for( ulong i=0UL; i<net_tile_cnt; i++ ) {
+
+    fd_topo_tile_t * tile = fd_topob_tile( topo, "net", "net", "metric_in", tile_to_cpu[ topo->tile_cnt ], 0 );
+    fd_topob_tile_in(  topo, "netlnk", 0UL, "metric_in", "net_netlink", i, FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
+    fd_topob_tile_out( topo, "net",    i,                "net_netlink", i );
+    fd_netlink_topo_join( topo, netlink_tile, tile );
+
+    strncpy( tile->net.interface,    config->tiles.net.interface, sizeof(tile->net.interface) );
+    memcpy(  tile->net.src_mac_addr, config->tiles.net.mac_addr,  6UL );
+
+    tile->net.tx_flush_timeout_ns = (long)config->tiles.net.flush_timeout_micros * 1000L;
+    tile->net.xdp_rx_queue_size = config->tiles.net.xdp_rx_queue_size;
+    tile->net.xdp_tx_queue_size = config->tiles.net.xdp_tx_queue_size;
+    tile->net.src_ip_addr       = config->tiles.net.ip_addr;
+    tile->net.zero_copy         = !!strcmp( config->tiles.net.xdp_mode, "skb" ); /* disable zc for skb */
+    fd_memset( tile->net.xdp_mode, 0, 4 );
+    fd_memcpy( tile->net.xdp_mode, config->tiles.net.xdp_mode, strnlen( config->tiles.net.xdp_mode, 3 ) );  /* GCC complains about strncpy */
+
+    tile->net.netdev_dbl_buf_obj_id = netlink_tile->netlink.netdev_dbl_buf_obj_id;
+    tile->net.fib4_main_obj_id      = netlink_tile->netlink.fib4_main_obj_id;
+    tile->net.fib4_local_obj_id     = netlink_tile->netlink.fib4_local_obj_id;
+    tile->net.neigh4_obj_id         = netlink_tile->netlink.neigh4_obj_id;
+    tile->net.neigh4_ele_obj_id     = netlink_tile->netlink.neigh4_ele_obj_id;
+
+  }
+}

--- a/src/app/fdctl/run/topos/topos.h
+++ b/src/app/fdctl/run/topos/topos.h
@@ -3,7 +3,38 @@
 
 #include "../../config.h"
 
+struct fd_topos_affinity {
+  ulong tile_to_cpu[ FD_TILE_MAX ];
+  ulong tile_cnt;
+  int   is_auto;
+};
+
+typedef struct fd_topos_affinity fd_topos_affinity_t;
+
+FD_PROTOTYPES_BEGIN
+
 void
-fd_topo_initialize( config_t * config );
+fd_topos_affinity( fd_topos_affinity_t * affinity,
+                   char const *          affinity_str );
+
+void
+fd_topos_create_validator( fd_topo_t *                 topo,
+                           config_t *                  config,
+                           fd_topos_affinity_t const * affinity );
+
+void
+fd_topos_add_net_tile( fd_topo_t *      topo,
+                       config_t const * config,
+                       ulong const      tile_to_cpu[ FD_TILE_MAX ] );
+
+void
+fd_topos_detect_affinity_mismatch( fd_topo_t const *           topo,
+                                   fd_topos_affinity_t const * affinity );
+
+void
+fd_topos_seal( fd_topo_t *                 topo,
+               fd_topos_affinity_t const * affinity );
+
+FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_app_fdctl_run_topos_h */

--- a/src/app/fddev/dev.c
+++ b/src/app/fddev/dev.c
@@ -5,6 +5,8 @@
 
 #include "../fdctl/configure/configure.h"
 #include "../fdctl/run/run.h"
+#include "../fdctl/run/topos/topos.h"
+#include "../../disco/topo/fd_topob.h"
 
 #include <stdio.h>
 #include <unistd.h>
@@ -179,6 +181,11 @@ run_firedancer_threaded( config_t * config , int init_workspaces) {
 void
 dev_cmd_fn( args_t *         args,
             config_t * const config ) {
+  fd_topo_t * topo = { fd_topob_new( &config->topo, config->name, fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size ) ) };
+  fd_topos_affinity_t affinity[1]; fd_topos_affinity( affinity, config->development.pktgen.affinity );
+  fd_topos_create_validator( topo, config, affinity );
+  fd_topos_seal( topo, affinity );
+
   if( FD_LIKELY( !args->dev.no_configure ) ) {
     args_t configure_args = {
       .configure.command = CONFIGURE_CMD_INIT,

--- a/src/app/fddev/load.c
+++ b/src/app/fddev/load.c
@@ -100,7 +100,7 @@ load_cmd_fn( args_t *         args,
   if( FD_UNLIKELY( !args->load.connections ) )
     args->load.connections = config->layout.quic_tile_count;
 
-  fd_topo_t * topo = { fd_topob_new( &config->topo, config->name ) };
+  fd_topo_t * topo = { fd_topob_new( &config->topo, config->name, fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size ) ) };
   topo->max_page_size = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
   add_bench_topo( topo,
                   args->load.affinity,

--- a/src/app/fddev/pktgen.c
+++ b/src/app/fddev/pktgen.c
@@ -1,52 +1,21 @@
 #include "fddev.h"
 #include "../fdctl/configure/configure.h" /* CONFIGURE_CMD_INIT */
 #include "../fdctl/run/run.h" /* fdctl_check_configure */
+#include "../fdctl/run/topos/topos.h"
 #include "../../disco/topo/fd_topob.h"
-#include "../../util/shmem/fd_shmem_private.h" /* fd_numa_cpu_cnt */
-#include "../../util/tile/fd_tile_private.h" /* fd_tile_private_cpus_parse */
 
 static void
-add_pktgen_topo( fd_topo_t *  topo,
-                 char const * affinity,
-                 uint         fake_dst_ip ) {
+add_pktgen_topo( fd_topo_t *           topo,
+                 fd_topos_affinity_t * affinity,
+                 uint                  fake_dst_ip ) {
   fd_topob_wksp( topo, "pktgen" );
 
-  int is_auto_affinity = !strcmp( affinity, "auto" );
-
-  ushort parsed_tile_to_cpu[ FD_TILE_MAX ];
-  for( ulong i=0UL; i<FD_TILE_MAX; i++ ) parsed_tile_to_cpu[ i ] = USHORT_MAX;
-
-  ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_tile_private_cpus_parse( affinity, parsed_tile_to_cpu );
-
-  ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
-  for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
-    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && parsed_tile_to_cpu[ i ]>=fd_numa_cpu_cnt() ) )
-      FD_LOG_ERR(( "The CPU affinity string in the configuration file under [development.pktgen.affinity] specifies a CPU index of %hu, but the system "
-                   "only has %lu CPUs. You should either change the CPU allocations in the affinity string, or increase the number of CPUs "
-                   "in the system.",
-                   parsed_tile_to_cpu[ i ], fd_numa_cpu_cnt() ));
-    tile_to_cpu[ i ] = fd_ulong_if( parsed_tile_to_cpu[ i ]==USHORT_MAX, ULONG_MAX, (ulong)parsed_tile_to_cpu[ i ] );
-  }
-  if( FD_LIKELY( !is_auto_affinity ) ) {
-    if( FD_UNLIKELY( affinity_tile_cnt<1UL ) )
-      FD_LOG_ERR(( "Invalid [development.pktgen.affinity]" ));
-    else if( FD_UNLIKELY( affinity_tile_cnt>1UL ) )
-      FD_LOG_WARNING(( "The pktgen topology you are using has 1 tile, but the CPU affinity specified "
-                       "in the [development.pktgen.affinity] provides for %lu cores. The extra cores will be unused.",
-                       affinity_tile_cnt ));
-  }
-
-  fd_topo_tile_t * pktgen_tile = fd_topob_tile( topo, "pktgen", "pktgen", "pktgen", tile_to_cpu[ 0 ], 0 );
+  fd_topo_tile_t * pktgen_tile = fd_topob_tile( topo, "pktgen", "pktgen", "pktgen", affinity->tile_to_cpu[ topo->tile_cnt ], 0 );
   pktgen_tile->pktgen.fake_dst_ip = fake_dst_ip;
 
   fd_topob_link( topo, "pktgen_out", "pktgen", 2048UL, FD_NET_MTU, 1UL );
   fd_topob_tile_out( topo, "pktgen", 0UL, "pktgen_out", 0UL );
   fd_topob_tile_in( topo, "net", 0UL, "metric_in", "pktgen_out", 0UL, 0, 1 );
-
-  /* This will blow away previous auto topology layouts and recompute an auto topology. */
-  if( FD_UNLIKELY( is_auto_affinity ) ) fd_topob_auto_layout( topo );
-  fd_topob_finish( topo, fdctl_obj_align, fdctl_obj_footprint, fdctl_obj_loose );
 }
 
 void
@@ -65,20 +34,26 @@ pktgen_cmd_fn( args_t *         args,
     FD_LOG_ERR(( "Invalid [development.pktgen.fake_dst_ip]" ));
   }
 
-  add_pktgen_topo( &config->topo,
-                   config->development.pktgen.affinity,
-                   fake_dst_ip );
+  fd_topo_t * topo = { fd_topob_new( &config->topo, config->name, fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size ) ) };
+  fd_topos_affinity_t affinity[1]; fd_topos_affinity( affinity, config->development.pktgen.affinity );
+  fd_topob_wksp( topo, "metric_in" );
+  fd_topos_add_net_tile( topo, config, affinity->tile_to_cpu );
+  add_pktgen_topo( &config->topo, affinity, fake_dst_ip );
+  fd_topos_detect_affinity_mismatch( topo, affinity );
+  fd_topos_seal( topo, affinity );
 
   if( FD_LIKELY( !args->dev.no_configure ) ) {
     args_t configure_args = {
       .configure.command = CONFIGURE_CMD_INIT,
     };
-    for( ulong i=0; i<CONFIGURE_STAGE_COUNT; i++ )
-      configure_args.configure.stages[ i ] = STAGES[ i ];
+    configure_args.configure.stages[ 0 ] = &fd_cfg_stage_hugetlbfs;
+    configure_args.configure.stages[ 1 ] = &fd_cfg_stage_sysctl;
+    configure_args.configure.stages[ 2 ] = &fd_cfg_stage_ethtool_channels;
+    configure_args.configure.stages[ 3 ] = &fd_cfg_stage_ethtool_gro;
+    configure_args.configure.stages[ 4 ] = &fd_cfg_stage_ethtool_loopback;
     configure_cmd_fn( &configure_args, config );
   }
 
-  update_config_for_dev( config );
   fdctl_check_configure( config );
   /* FIXME this allocates lots of memory unnecessarily */
   initialize_workspaces( config );

--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -4,8 +4,9 @@
 #include "../../util/shmem/fd_shmem_private.h"
 
 fd_topo_t *
-fd_topob_new( void * mem,
-              char const * app_name ) {
+fd_topob_new( void *       mem,
+              char const * app_name,
+              ulong        max_page_size ) {
   fd_topo_t * topo = (fd_topo_t *)mem;
 
   if( FD_UNLIKELY( !topo ) ) {
@@ -25,7 +26,15 @@ fd_topob_new( void * mem,
   if( FD_UNLIKELY( strlen( app_name )>=sizeof(topo->app_name) ) ) FD_LOG_ERR(( "app_name too long: %s", app_name ));
   strncpy( topo->app_name, app_name, sizeof(topo->app_name) );
 
-  topo->max_page_size = FD_SHMEM_GIGANTIC_PAGE_SZ;
+  switch( max_page_size ) {
+  case FD_SHMEM_HUGE_PAGE_SZ:
+  case FD_SHMEM_GIGANTIC_PAGE_SZ:
+    break;
+  default:
+    FD_LOG_ERR(( "Unsupported page size: %#lx", max_page_size ));
+  }
+
+  topo->max_page_size = max_page_size;
 
   return topo;
 }

--- a/src/disco/topo/fd_topob.h
+++ b/src/disco/topo/fd_topob.h
@@ -29,8 +29,9 @@ FD_PROTOTYPES_BEGIN
    with no tiles, objects, links. */
 
 fd_topo_t *
-fd_topob_new( void * mem,
-              char const * app_name );
+fd_topob_new( void *       mem,
+              char const * app_name,
+              ulong        max_page_size );
 
 /* Add a workspace with the given name to the topology.  Workspace names
    must be unique and adding the same workspace twice will produce an


### PR DESCRIPTION
Allows running `fddev pktgen` and `fddev load` without Firedancer tiles