### PR TITLE
fddev netns fixes

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -526,12 +526,20 @@ fdctl_cfg_from_env( int *      pargc,
   config->is_live_cluster = cluster != FD_CLUSTER_UNKNOWN;
 
   if( FD_UNLIKELY( config->development.netns.enabled ) ) {
-    /* not currently supporting multihoming on netns */
-    if( FD_UNLIKELY( strcmp( config->development.netns.interface0, config->tiles.net.interface ) ) )
+    if( !strcmp( config->tiles.net.interface, "" ) ) {
+      memcpy( config->tiles.net.interface, config->development.netns.interface0, sizeof(config->tiles.net.interface) );
+    }
+
+    if( !strcmp( config->development.pktgen.fake_dst_ip, "" ) ) {
+      memcpy( config->development.pktgen.fake_dst_ip, config->development.netns.interface1_addr, sizeof(config->development.netns.interface1_addr) );
+    }
+
+    if( FD_UNLIKELY( strcmp( config->development.netns.interface0, config->tiles.net.interface ) ) ) {
       FD_LOG_ERR(( "netns interface and firedancer interface are different. If you are using the "
                    "[development.netns] functionality to run Firedancer in a network namespace "
                    "for development, the configuration file must specify that "
-                   "[development.netns.interface0] is the same as [net.interface]" ));
+                   "[development.netns.interface0] is the same as [tiles.net.interface]" ));
+    }
 
     if( FD_UNLIKELY( !fd_cstr_to_ip4_addr( config->development.netns.interface0_addr, &config->tiles.net.ip_addr ) ) )
       FD_LOG_ERR(( "configuration specifies invalid netns IP address `%s`", config->development.netns.interface0_addr ));

--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -175,10 +175,10 @@ struct fdctl_config {
       int  enabled;
       char interface0     [ 16 ];
       char interface0_mac [ 32 ];
-      char interface0_addr[ 32 ];
+      char interface0_addr[ 16 ];
       char interface1     [ 16 ];
       char interface1_mac [ 32 ];
-      char interface1_addr[ 32 ];
+      char interface1_addr[ 16 ];
     } netns;
 
     struct {

--- a/src/app/fdctl/netconf.c
+++ b/src/app/fdctl/netconf.c
@@ -50,11 +50,7 @@ netconf_cmd_fn( args_t *   args,
   fd_fib4_fprintf( fib4_local, stdout );
   fd_fib4_leave( fib4_local );
 
-  char if_name[ IF_NAMESIZE ] = "???";
-  if( FD_UNLIKELY( !if_indextoname( tile->netlink.neigh_if_idx, if_name ) ) ) {
-    memcpy( if_name, "???", 4 );
-  }
-  printf( "\nNEIGHBOR TABLE (%u-%s)\n\n", tile->netlink.neigh_if_idx, if_name );
+  printf( "\nNEIGHBOR TABLE (%.16s)\n\n", tile->netlink.neigh_if );
   fd_neigh4_hmap_t neigh4[1];
   FD_TEST( fd_neigh4_hmap_join( neigh4, fd_topo_obj_laddr( topo, tile->netlink.neigh4_obj_id ), fd_topo_obj_laddr( topo, tile->netlink.neigh4_ele_obj_id ) ) );
   fd_neigh4_hmap_fprintf( neigh4, stdout );

--- a/src/app/fdctl/run/run.h
+++ b/src/app/fdctl/run/run.h
@@ -33,6 +33,9 @@ run_firedancer_init( config_t * const config,
                      int              init_workspaces );
 
 void
+fdctl_setup_netns( config_t * config );
+
+void
 run_firedancer( config_t * const config,
                 int              parent_pipefd,
                 int              init_workspaces );

--- a/src/app/fddev/bench.c
+++ b/src/app/fddev/bench.c
@@ -169,6 +169,7 @@ bench_cmd_fn( args_t *         args,
   update_config_for_dev( config );
 
   run_firedancer_init( config, 1 );
+  fdctl_setup_netns( config );
 
   fd_xdp_fds_t fds = fd_topo_install_xdp( &config->topo );
   (void)fds;

--- a/src/app/fddev/dev.c
+++ b/src/app/fddev/dev.c
@@ -150,6 +150,7 @@ run_firedancer_threaded( config_t * config , int init_workspaces) {
   fd_topo_print_log( 0, &config->topo );
 
   run_firedancer_init( config, init_workspaces );
+  fdctl_setup_netns( config );
 
   if( FD_UNLIKELY( config->development.debug_tile ) ) {
     fd_log_private_shared_lock[ 1 ] = 1;

--- a/src/app/fddev/pktgen.c
+++ b/src/app/fddev/pktgen.c
@@ -83,6 +83,7 @@ pktgen_cmd_fn( args_t *         args,
   /* FIXME this allocates lots of memory unnecessarily */
   initialize_workspaces( config );
   initialize_stacks( config );
+  fdctl_setup_netns( config );
   (void)fd_topo_install_xdp( &config->topo );;
   fd_topo_join_workspaces( &config->topo, FD_SHMEM_JOIN_MODE_READ_WRITE );
 

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -153,7 +153,7 @@ typedef struct {
       ulong netdev_dbl_buf_obj_id; /* dbl_buf containing netdev_tbl */
       ulong fib4_main_obj_id;      /* fib4 containing main route table */
       ulong fib4_local_obj_id;     /* fib4 containing local route table */
-      uint  neigh_if_idx;          /* neigh4 interface index */
+      char  neigh_if[ 16 ];        /* neigh4 interface name */
       ulong neigh4_obj_id;         /* neigh4 hash map header */
       ulong neigh4_ele_obj_id;     /* neigh4 hash map slots */
     } netlink;

--- a/src/waltz/mib/fd_netdev_netlink.c
+++ b/src/waltz/mib/fd_netdev_netlink.c
@@ -120,13 +120,14 @@ fd_netdev_netlink_load_table( fd_netdev_tbl_join_t * tbl,
       switch( rat->rta_type ) {
 
       case IFLA_IFNAME:
-        if( FD_UNLIKELY( rta_sz==0 || rta_sz>=IFNAMSIZ ) ) {
+        /* Includes trailing zero */
+        if( FD_UNLIKELY( rta_sz==0 || rta_sz>IFNAMSIZ ) ) {
           FD_LOG_WARNING(( "Error reading interface table: IFLA_IFNAME has unsupported size %lu", rta_sz ));
           err = EPROTO;
           goto fail;
         }
         memcpy( netdev->name, rta, rta_sz );
-        netdev->name[ rta_sz ] = '\0';
+        netdev->name[ rta_sz-1 ] = '\0';
         break;
 
       case IFLA_ADDRESS:


### PR DESCRIPTION
Fixes most fddev commands in a netns except fddev bench

- Add back netns support to fddev init sequence
- Fix netdev reading of interfaces with 15 char name length
- Better error message for fd_http_server_listen bind failure
- Run ethtool configure stages after entering netns
- Bring up loopback after entering netns
