### PR TITLE
Double the XDP fill ring depth

### DIFF
--- a/src/disco/net/fd_net_tile.c
+++ b/src/disco/net/fd_net_tile.c
@@ -909,7 +909,7 @@ net_xsk_bootstrap( fd_net_ctx_t * ctx,
   fd_xsk_t * xsk = &ctx->xsk[ xsk_idx ];
 
   ulong const frame_sz  = FD_NET_MTU;
-  ulong const fr_depth  = ctx->xsk[ xsk_idx ].ring_fr.depth;
+  ulong const fr_depth  = ctx->xsk[ xsk_idx ].ring_fr.depth/2UL;
 
   fd_xdp_ring_t * fill      = &xsk->ring_fr;
   uint            fill_prod = fill->cached_prod;
@@ -999,7 +999,7 @@ privileged_init( fd_topo_t *      topo,
     .if_queue_id = (uint)tile->kind_id,
     .bind_flags  = tile->net.zero_copy ? XDP_ZEROCOPY : XDP_COPY,
 
-    .fr_depth  = tile->net.xdp_rx_queue_size,
+    .fr_depth  = tile->net.xdp_rx_queue_size*2,
     .rx_depth  = tile->net.xdp_rx_queue_size,
     .cr_depth  = tile->net.xdp_tx_queue_size,
     .tx_depth  = tile->net.xdp_tx_queue_size,


### PR DESCRIPTION
Fixes slight latency increases (~200ns) with some XDP configs.

The XDP skb path seems to only consume fill ring entries when
receiving a packet.  The fill ring is thus mostly full for these
configs.

Consider a scenario where ksoftirqd consumes a packet, consumes
a fill ring descriptor, and allocates a RX ring descriptor.
When the net tile concurrently runs on a different CPU, it might
have seen the updated cache line carrying the RX producer seqno,
but not yet the FILL consumer seqno (data race).

In this case, the net tile will refuse to consume the RX frag as
it doesn't have space to return that frag to FILL (since FILL
appeared full to it).  The net tile then starts spinning (about 30
iterations or so on EPYC 7502P).

By doubling the FILL ring depth, the net tile will always have
enough space to return frags to FILL by the time the FILL cons
seqno is updated.
