### PR TITLE
Fix XDP sendto startup failure

### DIFF
--- a/src/app/fdctl/config.h
+++ b/src/app/fdctl/config.h
@@ -217,7 +217,7 @@ struct fdctl_config {
       uint   ip_addr;
       uchar  mac_addr[6];
       char   xdp_mode[ 8 ];
-      int    xdp_force_zero_copy;
+      int    xdp_zero_copy;
 
       uint xdp_rx_queue_size;
       uint xdp_tx_queue_size;

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -893,7 +893,7 @@ dynamic_port_range = "8900-9000"
         # the xdp_mode option above).  If the kernel/hardware does not
         # support zero copy, `fdctl run` will fail to start up with
         # "operation not supported".
-        xdp_force_zero_copy = false
+        xdp_zero_copy = false
 
         # XDP uses metadata queues shared across the kernel and
         # userspace to relay events about incoming and outgoing packets.

--- a/src/app/fdctl/config_parse.c
+++ b/src/app/fdctl/config_parse.c
@@ -287,7 +287,7 @@ fdctl_pod_to_cfg( config_t * config,
 
   CFG_POP      ( cstr,   tiles.net.interface                              );
   CFG_POP      ( cstr,   tiles.net.xdp_mode                               );
-  CFG_POP      ( bool,   tiles.net.xdp_force_zero_copy                    );
+  CFG_POP      ( bool,   tiles.net.xdp_zero_copy                          );
   CFG_POP      ( uint,   tiles.net.xdp_rx_queue_size                      );
   CFG_POP      ( uint,   tiles.net.xdp_tx_queue_size                      );
   CFG_POP      ( uint,   tiles.net.flush_timeout_micros                   );

--- a/src/disco/net/fd_net_tile.c
+++ b/src/disco/net/fd_net_tile.c
@@ -997,7 +997,11 @@ privileged_init( fd_topo_t *      topo,
   fd_xsk_params_t params0 = {
     .if_idx      = if_idx,
     .if_queue_id = (uint)tile->kind_id,
-    .bind_flags  = tile->net.zero_copy ? XDP_ZEROCOPY : 0,
+
+    /* Some kernels produce EOPNOTSUP errors on sendto calls when
+       starting up without either XDP_ZEROCOPY or XDP_COPY
+       (e.g. 5.14.0-503.23.1.el9_5 with i40e) */
+    .bind_flags  = tile->net.zero_copy ? XDP_ZEROCOPY : XDP_COPY,
 
     .fr_depth  = tile->net.xdp_rx_queue_size*2,
     .rx_depth  = tile->net.xdp_rx_queue_size,

--- a/src/disco/net/fd_net_tile_topo.c
+++ b/src/disco/net/fd_net_tile_topo.c
@@ -50,7 +50,7 @@ fd_topos_net_tiles( fd_topo_t *      topo,
     tile->net.xdp_rx_queue_size = config->tiles.net.xdp_rx_queue_size;
     tile->net.xdp_tx_queue_size = config->tiles.net.xdp_tx_queue_size;
     tile->net.src_ip_addr       = config->tiles.net.ip_addr;
-    tile->net.zero_copy         = config->tiles.net.xdp_force_zero_copy;
+    tile->net.zero_copy         = config->tiles.net.xdp_zero_copy;
     fd_memset( tile->net.xdp_mode, 0, 4 );
     fd_memcpy( tile->net.xdp_mode, config->tiles.net.xdp_mode, strnlen( config->tiles.net.xdp_mode, 3 ) );  /* GCC complains about strncpy */
 


### PR DESCRIPTION
Fixes a failure seen on i40e where binding to an XDP socket without
flags succeeds initially, but then fails on the first sendto call.
