### PR TITLE
Make secp256k1 a dev-only dependency

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -135,10 +135,10 @@ fetch () {
   fi
   checkout_repo zstd      https://github.com/facebook/zstd          "v1.5.6"
   checkout_repo lz4       https://github.com/lz4/lz4                "v1.10.0"
-  checkout_repo secp256k1 https://github.com/bitcoin-core/secp256k1 "v0.5.0"
   checkout_repo s2n       https://github.com/awslabs/s2n-bignum     "" "efa579c"
   #checkout_repo openssl   https://github.com/openssl/openssl        "openssl-3.3.1"
   if [[ $DEVMODE == 1 ]]; then
+    checkout_repo secp256k1 https://github.com/bitcoin-core/secp256k1 "v0.5.0"
     checkout_repo rocksdb   https://github.com/facebook/rocksdb       "v9.7.4"
     checkout_repo snappy    https://github.com/google/snappy          "1.2.1"
     checkout_repo luajit    https://github.com/LuaJIT/LuaJIT          "v2.0.5"


### PR DESCRIPTION
Operators keep having issues with the secp256k1 dependency.
Demote it to 'deps.sh +dev' only, since it's only required for
full Firedancer, but not Frankendancer.
