### PR TITLE
Move dev instructions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,26 @@
+## Developing
+Firedancer currently only supports Linux and requires a relatively new
+kernel, at least v4.18 to build.
+
+```console
+$ git clone --recurse-submodules https://github.com/firedancer-io/firedancer.git
+$ cd firedancer
+$ ./deps.sh +dev
+$ make -j run
+```
+
+The `make run` target runs the `fddev dev` command. This development
+command will ensure your system is configured correctly before creating
+a genesis block, some keys, a faucet, and then starting a validator on
+the local machine. `fddev` will use `sudo` to make privileged changes to
+system configuration where needed. If `sudo` is not available, you may
+need to run the command as root.
+
+By default `fddev` will create a new development cluster, if you wish to
+join this cluster with other validators, you can define
+`[rpc.entrypoints]` in the configuration file to point at your first
+validator and run `fddev dev` again.
+
 ## Firedancer Code Style Guide
 
 Below is an incomplete list of code style rules.

--- a/README.md
+++ b/README.md
@@ -36,29 +36,6 @@ is not ready for test or production use and has no releases.
 Frankendancer is currently available on both Solana testnet and
 mainnet-beta.
 
-## Developing
-Firedancer currently only supports Linux and requires a relatively new
-kernel, at least v4.18 to build.
-
-```console
-$ git clone --recurse-submodules https://github.com/firedancer-io/firedancer.git
-$ cd firedancer
-$ ./deps.sh +dev
-$ make -j run
-```
-
-The `make run` target runs the `fddev dev` command. This development
-command will ensure your system is configured correctly before creating
-a genesis block, some keys, a faucet, and then starting a validator on
-the local machine. `fddev` will use `sudo` to make privileged changes to
-system configuration where needed. If `sudo` is not available, you may
-need to run the command as root.
-
-By default `fddev` will create a new development cluster, if you wish to
-join this cluster with other validators, you can define
-`[rpc.entrypoints]` in the configuration file to point at your first
-validator and run `fddev dev` again.
-
 ## License
 Firedancer is available under the [Apache 2
 license](https://www.apache.org/licenses/LICENSE-2.0). Firedancer also


### PR DESCRIPTION
The README should be operator oriented, not dev oriented.
Some operators seemed to blindly run 'deps.sh +dev' and 'make -j run'
thinking they are the instructions to run a production node.

Developers will know to look in CONTRIBUTING.md.
