### PR TITLE
Complete the implementation of wen-restart

### DIFF
--- a/src/app/fdctl/run/topos/fd_firedancer.c
+++ b/src/app/fdctl/run/topos/fd_firedancer.c
@@ -635,6 +635,7 @@ fd_topo_initialize( config_t * config ) {
       tile->replay.exec_tile_count = config->layout.exec_tile_count;
       tile->replay.in_wen_restart  = config->tiles.replay.in_wen_restart;
       strncpy( tile->replay.tower_checkpt, config->tiles.replay.tower_checkpt, sizeof(tile->replay.tower_checkpt) );
+      fd_memcpy( tile->replay.expected_genesis_hash, config->consensus.expected_genesis_hash, FD_BASE58_ENCODED_32_SZ );
       fd_memcpy( tile->replay.wen_restart_coordinator, config->tiles.replay.wen_restart_coordinator, FD_BASE58_ENCODED_32_SZ );
 
       /* not specified by [tiles.replay] */

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -269,6 +269,7 @@ typedef struct {
       char  cluster_version[ 32 ];
       int   in_wen_restart;
       char  tower_checkpt[ PATH_MAX ];
+      char  expected_genesis_hash[ FD_BASE58_ENCODED_32_SZ ];
       char  wen_restart_coordinator[ FD_BASE58_ENCODED_32_SZ ];
       int   plugins_enabled;
 


### PR DESCRIPTION
This PR extends PR #3830 and achieves the following while moving wen-restart into a separate tile.

1. Generate a snapshot at the end of wen-restart; Insert a hard fork and calculate a new shred version.
2. Fix tower checkpoint by checkpointing all the voted slots from the last voted slot back to the ghost root; Some of these slots may not be in the tower.
3. Improve the code style.