### PR TITLE
flamenco, vm: correct overlap checks in get_processed_sibling_instruction

### DIFF
--- a/src/flamenco/vm/syscall/fd_vm_syscall_macros.h
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_macros.h
@@ -252,9 +252,9 @@ FD_VM_MEM_HADDR_ST_( fd_vm_t const *vm, ulong vaddr, ulong align, ulong sz, int 
 }))
 
 /* FIXME: use overlap logic from runtime? */
-#define FD_VM_MEM_CHECK_NON_OVERLAPPING( vm, vaddr0, sz0, vaddr1, sz1 ) do {                                    \
-  if( FD_UNLIKELY(( ((vaddr0 > vaddr1) &&  (fd_ulong_sat_sub(vaddr0, vaddr1) < sz1)) ) ||                        \
-                  ( ((vaddr1 >= vaddr0) && (fd_ulong_sat_sub(vaddr1, vaddr0) < sz0)) ) )) {                      \
+#define FD_VM_MEM_CHECK_NON_OVERLAPPING( vm, addr0, sz0, addr1, sz1 ) do {                                      \
+  if( FD_UNLIKELY(( ((addr0> addr1) && (fd_ulong_sat_sub(addr0, addr1) < sz1)) ) ||                             \
+                  ( ((addr1>=addr0) && (fd_ulong_sat_sub(addr1, addr0) < sz0)) ) )) {                           \
     FD_VM_ERR_FOR_LOG_SYSCALL( vm, FD_VM_SYSCALL_ERR_COPY_OVERLAPPING );                                        \
     return FD_VM_SYSCALL_ERR_COPY_OVERLAPPING;                                                                  \
   }                                                                                                             \

--- a/src/flamenco/vm/syscall/fd_vm_syscall_runtime.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_runtime.c
@@ -208,9 +208,9 @@ fd_vm_syscall_sol_get_sysvar( /**/            void *  _vm,
     return FD_VM_SYSCALL_ERR_ABORT;
   }
 
-  /* https://github.com/anza-xyz/agave/blob/v2.1.0/programs/bpf_loader/src/syscalls/sysvar.rs#L210-L213 
+  /* https://github.com/anza-xyz/agave/blob/v2.1.0/programs/bpf_loader/src/syscalls/sysvar.rs#L210-L213
      We don't need this, we already checked we can store in out_vaddr with requested sz. */
-  
+
   /* https://github.com/anza-xyz/agave/blob/v2.1.0/programs/bpf_loader/src/syscalls/sysvar.rs#L215-L221 */
   if( FD_UNLIKELY( memcmp( sysvar_id->uc, fd_sysvar_clock_id.uc,             FD_PUBKEY_FOOTPRINT ) &&
                    memcmp( sysvar_id->uc, fd_sysvar_epoch_schedule_id.uc,    FD_PUBKEY_FOOTPRINT ) &&
@@ -262,7 +262,7 @@ fd_vm_syscall_sol_get_epoch_stake( /**/            void *  _vm,
   fd_vm_t * vm = (fd_vm_t *)_vm;
 
   /* Var addr of 0 returns the total active stake on the cluster.
-  
+
      https://github.com/anza-xyz/agave/blob/v2.1.0/programs/bpf_loader/src/syscalls/mod.rs#L2057-L2075 */
   if( FD_UNLIKELY( var_addr==0UL ) ) {
     /* https://github.com/anza-xyz/agave/blob/v2.1.0/programs/bpf_loader/src/syscalls/mod.rs#L2065-L2066 */
@@ -536,23 +536,23 @@ fd_vm_syscall_sol_get_processed_sibling_instruction(
          https://github.com/anza-xyz/agave/blob/70089cce5119c9afaeb2986e2ecaa6d4505ec15d/programs/bpf_loader/src/syscalls/mod.rs#L1469 */
 
       FD_VM_MEM_CHECK_NON_OVERLAPPING( vm,
-        result_meta_vaddr, FD_VM_SYSCALL_PROCESSED_SIBLING_INSTRUCTION_SIZE,
-        result_program_id_vaddr, sizeof(fd_pubkey_t) );
+        (ulong)result_meta_haddr, FD_VM_SYSCALL_PROCESSED_SIBLING_INSTRUCTION_SIZE,
+        (ulong)result_program_id_haddr, sizeof(fd_pubkey_t) );
       FD_VM_MEM_CHECK_NON_OVERLAPPING( vm,
-        result_meta_vaddr, FD_VM_SYSCALL_PROCESSED_SIBLING_INSTRUCTION_SIZE,
-        result_accounts_vaddr, accounts_meta_total_size );
+        (ulong)result_meta_haddr, FD_VM_SYSCALL_PROCESSED_SIBLING_INSTRUCTION_SIZE,
+        (ulong)result_accounts_haddr, accounts_meta_total_size );
       FD_VM_MEM_CHECK_NON_OVERLAPPING( vm,
-        result_meta_vaddr, FD_VM_SYSCALL_PROCESSED_SIBLING_INSTRUCTION_SIZE,
-        result_data_vaddr, result_meta_haddr->data_len );
+        (ulong)result_meta_haddr, FD_VM_SYSCALL_PROCESSED_SIBLING_INSTRUCTION_SIZE,
+        (ulong)result_data_haddr, result_meta_haddr->data_len );
       FD_VM_MEM_CHECK_NON_OVERLAPPING( vm,
-        result_program_id_vaddr, sizeof(fd_pubkey_t),
-        result_data_vaddr, result_meta_haddr->data_len );
+        (ulong)result_program_id_haddr, sizeof(fd_pubkey_t),
+        (ulong)result_data_haddr, result_meta_haddr->data_len );
       FD_VM_MEM_CHECK_NON_OVERLAPPING( vm,
-        result_program_id_vaddr, sizeof(fd_pubkey_t),
-        result_accounts_vaddr, accounts_meta_total_size );
+        (ulong)result_program_id_haddr, sizeof(fd_pubkey_t),
+        (ulong)result_accounts_haddr, accounts_meta_total_size );
       FD_VM_MEM_CHECK_NON_OVERLAPPING( vm,
-        result_data_vaddr, result_meta_haddr->data_len,
-        result_accounts_vaddr, accounts_meta_total_size );
+        (ulong)result_data_haddr, result_meta_haddr->data_len,
+        (ulong)result_accounts_haddr, accounts_meta_total_size );
 
       /* Copy the instruction into the result addresses
          https://github.com/anza-xyz/agave/blob/70089cce5119c9afaeb2986e2ecaa6d4505ec15d/programs/bpf_loader/src/syscalls/mod.rs#L1506-L1528


### PR DESCRIPTION
These should be done on the host addresses, not the virtual addresses. This is the only place remaining where this was incorrect.