### PR TITLE
gui: add validator icons/names

### DIFF
--- a/src/app/fdctl/run/tiles/fd_gui.c
+++ b/src/app/fdctl/run/tiles/fd_gui.c
@@ -146,7 +146,7 @@ during_frag( fd_gui_ctx_t * ctx,
   uchar * src = (uchar *)fd_chunk_to_laddr( ctx->in_mem, chunk );
 
    /* ... todo... sigh, sz is not correct since it's too big */
-  if( FD_LIKELY( sig==FD_PLUGIN_MSG_GOSSIP_UPDATE || sig==FD_PLUGIN_MSG_VALIDATOR_INFO ) ) {
+  if( FD_LIKELY( sig==FD_PLUGIN_MSG_GOSSIP_UPDATE ) ) {
     ulong peer_cnt = ((ulong *)src)[ 0 ];
     FD_TEST( peer_cnt<=40200 );
     sz = 8UL + peer_cnt*FD_GOSSIP_LINK_MSG_SIZE;

--- a/src/app/fdctl/run/tiles/fd_plugin.c
+++ b/src/app/fdctl/run/tiles/fd_plugin.c
@@ -13,6 +13,7 @@
 #define IN_KIND_STARTP (5)
 #define IN_KIND_VOTEL  (6)
 #define IN_KIND_BUNDLE (7)
+#define IN_KIND_VALCFG (8)
 
 typedef struct {
   fd_wksp_t * mem;
@@ -57,7 +58,7 @@ during_frag( fd_plugin_ctx_t * ctx,
   ulong * dst = (ulong *)fd_chunk_to_laddr( ctx->out_mem, ctx->out_chunk );
 
   /* ... todo... sigh, sz is not correct since it's too big */
-  if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_GOSSIP ) && FD_LIKELY( sig==FD_PLUGIN_MSG_GOSSIP_UPDATE || sig==FD_PLUGIN_MSG_VALIDATOR_INFO ) ) {
+  if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_GOSSIP && sig==FD_PLUGIN_MSG_GOSSIP_UPDATE ) ) {
     ulong peer_cnt = ((ulong *)src)[ 0 ];
     FD_TEST( peer_cnt<=40200 );
     sz = 8UL + peer_cnt*FD_GOSSIP_LINK_MSG_SIZE;
@@ -97,7 +98,7 @@ after_frag( fd_plugin_ctx_t *   ctx,
       break;
     }
     case IN_KIND_GOSSIP: {
-      FD_TEST( sig==FD_PLUGIN_MSG_GOSSIP_UPDATE || sig==FD_PLUGIN_MSG_VOTE_ACCOUNT_UPDATE || sig==FD_PLUGIN_MSG_VALIDATOR_INFO || sig==FD_PLUGIN_MSG_BALANCE );
+      FD_TEST( sig==FD_PLUGIN_MSG_GOSSIP_UPDATE || sig==FD_PLUGIN_MSG_VOTE_ACCOUNT_UPDATE || sig==FD_PLUGIN_MSG_BALANCE );
       break;
     }
     case IN_KIND_STAKE: {
@@ -122,6 +123,10 @@ after_frag( fd_plugin_ctx_t *   ctx,
     }
     case IN_KIND_BUNDLE: {
       FD_TEST( sig==FD_PLUGIN_MSG_BLOCK_ENGINE_UPDATE );
+      break;
+    }
+    case IN_KIND_VALCFG: {
+      FD_TEST( sig==FD_PLUGIN_MSG_VALIDATOR_INFO );
       break;
     }
     default: FD_LOG_ERR(( "bad in_idx" ));
@@ -163,6 +168,7 @@ unprivileged_init( fd_topo_t *      topo,
     else if( FD_UNLIKELY( !strcmp( link->name, "startp_plugi" ) ) ) ctx->in_kind[ i ] = IN_KIND_STARTP;
     else if( FD_UNLIKELY( !strcmp( link->name, "votel_plugin" ) ) ) ctx->in_kind[ i ] = IN_KIND_VOTEL;
     else if( FD_UNLIKELY( !strcmp( link->name, "bundle_plugi" ) ) ) ctx->in_kind[ i ] = IN_KIND_BUNDLE;
+    else if( FD_UNLIKELY( !strcmp( link->name, "valcfg_plugi" ) ) ) ctx->in_kind[ i ] = IN_KIND_VALCFG;
     else FD_LOG_ERR(( "unexpected link name %s", link->name ));
   }
 

--- a/src/app/fdctl/run/tiles/fd_poh.c
+++ b/src/app/fdctl/run/tiles/fd_poh.c
@@ -597,6 +597,7 @@ poh_link_t replay_plugin;
 poh_link_t gossip_plugin;
 poh_link_t start_progress_plugin;
 poh_link_t vote_listener_plugin;
+poh_link_t validator_info_plugin;
 
 static void
 poh_link_wait_credit( poh_link_t * link ) {
@@ -2056,6 +2057,13 @@ fd_ext_plugin_publish_vote_listener( ulong   sig,
 }
 
 void
+fd_ext_plugin_publish_validator_info( ulong   sig,
+                                      uchar * data,
+                                      ulong   data_len ) {
+  poh_link_publish( &validator_info_plugin, sig, data, data_len );
+}
+
+void
 fd_ext_plugin_publish_periodic( ulong   sig,
                                 uchar * data,
                                 ulong   data_len ) {
@@ -2162,6 +2170,7 @@ unprivileged_init( fd_topo_t *      topo,
     poh_link_init( &gossip_plugin,         topo, tile, out1( topo, tile, "gossip_plugi" ).idx );
     poh_link_init( &start_progress_plugin, topo, tile, out1( topo, tile, "startp_plugi" ).idx );
     poh_link_init( &vote_listener_plugin,  topo, tile, out1( topo, tile, "votel_plugin" ).idx );
+    poh_link_init( &validator_info_plugin, topo, tile, out1( topo, tile, "valcfg_plugi" ).idx );
   } else {
     /* Mark these mcaches as "available", so the system boots, but the
        memory is not set so nothing will actually get published via.
@@ -2171,6 +2180,7 @@ unprivileged_init( fd_topo_t *      topo,
     gossip_plugin.mcache = (fd_frag_meta_t*)1;
     start_progress_plugin.mcache = (fd_frag_meta_t*)1;
     vote_listener_plugin.mcache = (fd_frag_meta_t*)1;
+    validator_info_plugin.mcache = (fd_frag_meta_t*)1;
     FD_COMPILER_MFENCE();
   }
 

--- a/src/app/fdctl/run/topos/fd_frankendancer.c
+++ b/src/app/fdctl/run/topos/fd_frankendancer.c
@@ -204,11 +204,12 @@ fd_topo_initialize( config_t * config ) {
     fd_topob_wksp( topo, "plugin"       );
 
     /**/                 fd_topob_link( topo, "plugin_out",   "plugin_out",   128UL,                                    8UL+40200UL*(58UL+12UL*34UL), 1UL );
-    /**/                 fd_topob_link( topo, "replay_plugi", "plugin_in",    128UL,                                    4098*8UL,               1UL );
+    /**/                 fd_topob_link( topo, "replay_plugi", "plugin_in",    128UL,                                    4098*8UL,                     1UL );
     /**/                 fd_topob_link( topo, "gossip_plugi", "plugin_in",    128UL,                                    8UL+40200UL*(58UL+12UL*34UL), 1UL );
-    /**/                 fd_topob_link( topo, "poh_plugin",   "plugin_in",    128UL,                                    16UL,                   1UL );
-    /**/                 fd_topob_link( topo, "startp_plugi", "plugin_in",    128UL,                                    56UL,                   1UL );
-    /**/                 fd_topob_link( topo, "votel_plugin", "plugin_in",    128UL,                                    8UL,                    1UL );
+    /**/                 fd_topob_link( topo, "poh_plugin",   "plugin_in",    128UL,                                    16UL,                         1UL );
+    /**/                 fd_topob_link( topo, "startp_plugi", "plugin_in",    128UL,                                    56UL,                         1UL );
+    /**/                 fd_topob_link( topo, "votel_plugin", "plugin_in",    128UL,                                    8UL,                          1UL );
+    /**/                 fd_topob_link( topo, "valcfg_plugi", "plugin_in",    128UL,                                    608UL,                        1UL );
 
     /**/                 fd_topob_tile( topo, "plugin",  "plugin",  "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0, 0 );
 
@@ -218,6 +219,7 @@ fd_topo_initialize( config_t * config ) {
     /**/                 fd_topob_tile_out( topo, "poh",    0UL,                        "startp_plugi", 0UL                                                );
     /**/                 fd_topob_tile_out( topo, "poh",    0UL,                        "votel_plugin", 0UL                                                );
     /**/                 fd_topob_tile_out( topo, "plugin", 0UL,                        "plugin_out",   0UL                                                );
+    /**/                 fd_topob_tile_out( topo, "poh",    0UL,                        "valcfg_plugi", 0UL                                                );
 
     /**/                 fd_topob_tile_in(  topo, "plugin", 0UL,           "metric_in", "replay_plugi", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     /**/                 fd_topob_tile_in(  topo, "plugin", 0UL,           "metric_in", "gossip_plugi", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
@@ -225,6 +227,7 @@ fd_topo_initialize( config_t * config ) {
     /**/                 fd_topob_tile_in(  topo, "plugin", 0UL,           "metric_in", "poh_plugin",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     /**/                 fd_topob_tile_in(  topo, "plugin", 0UL,           "metric_in", "startp_plugi", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     /**/                 fd_topob_tile_in(  topo, "plugin", 0UL,           "metric_in", "votel_plugin", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+    /**/                 fd_topob_tile_in(  topo, "plugin", 0UL,           "metric_in", "valcfg_plugi", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   }
 
   if( FD_LIKELY( config->tiles.gui.enabled ) ) {

--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -739,100 +739,78 @@ fd_gui_handle_vote_account_update( fd_gui_t *    gui,
 static void
 fd_gui_handle_validator_info_update( fd_gui_t *    gui,
                                      uchar const * msg ) {
-  ulong const * header = (ulong const *)fd_type_pun_const( msg );
-  ulong peer_cnt = header[ 0 ];
-
-  FD_TEST( peer_cnt<=40200UL );
+  uchar const * data = (uchar const *)fd_type_pun_const( msg );
 
   ulong added_cnt = 0UL;
-  ulong added[ 40200 ] = {0};
+  ulong added[ 1 ] = {0};
 
   ulong update_cnt = 0UL;
-  ulong updated[ 40200 ] = {0};
+  ulong updated[ 1 ] = {0};
 
   ulong removed_cnt = 0UL;
-  fd_pubkey_t removed[ 40200 ] = {0};
+  /* Unlike gossip or vote account updates, validator info messages come
+     in as info is disovered, and may contain as little as 1 validator
+     per message.  Therefore it doesn't make sense to use the remove
+     mechanism.  */
 
-  uchar const * data = (uchar const *)(header+1UL);
-  for( ulong i=0UL; i<gui->validator_info.info_cnt; i++ ) {
-    int found = 0;
-    for( ulong j=0UL; j<peer_cnt; j++ ) {
-      if( FD_UNLIKELY( !memcmp( gui->validator_info.info[ i ].pubkey, data+j*608UL, 32UL ) ) ) {
-        found = 1;
-        break;
-      }
-    }
-
-    if( FD_UNLIKELY( !found ) ) {
-      fd_memcpy( removed[ removed_cnt++ ].uc, gui->validator_info.info[ i ].pubkey->uc, 32UL );
-      if( FD_LIKELY( i+1UL!=gui->validator_info.info_cnt ) ) {
-        fd_memcpy( &gui->validator_info.info[ i ], &gui->validator_info.info[ gui->validator_info.info_cnt-1UL ], sizeof(struct fd_gui_validator_info) );
-        gui->validator_info.info_cnt--;
-        i--;
-      }
+  ulong before_peer_cnt = gui->validator_info.info_cnt;
+  int found = 0;
+  ulong found_idx;
+  for( ulong j=0UL; j<gui->validator_info.info_cnt; j++ ) {
+    if( FD_UNLIKELY( !memcmp( gui->validator_info.info[ j ].pubkey, data, 32UL ) ) ) {
+      found_idx = j;
+      found = 1;
+      break;
     }
   }
 
-  ulong before_peer_cnt = gui->validator_info.info_cnt;
-  for( ulong i=0UL; i<peer_cnt; i++ ) {
-    int found = 0;
-    ulong found_idx;
-    for( ulong j=0UL; j<gui->validator_info.info_cnt; j++ ) {
-      if( FD_UNLIKELY( !memcmp( gui->validator_info.info[ j ].pubkey, data+i*608UL, 32UL ) ) ) {
-        found_idx = j;
-        found = 1;
-        break;
-      }
-    }
+  if( FD_UNLIKELY( !found ) ) {
+    fd_memcpy( gui->validator_info.info[ gui->validator_info.info_cnt ].pubkey->uc, data, 32UL );
 
-    if( FD_UNLIKELY( !found ) ) {
-      fd_memcpy( gui->validator_info.info[ gui->validator_info.info_cnt ].pubkey->uc, data+i*608UL, 32UL );
+    strncpy( gui->validator_info.info[ gui->validator_info.info_cnt ].name, (char const *)(data+32UL), 64 );
+    gui->validator_info.info[ gui->validator_info.info_cnt ].name[ 63 ] = '\0';
 
-      strncpy( gui->validator_info.info[ gui->validator_info.info_cnt ].name, (char const *)(data+i*608UL+32UL), 64 );
-      gui->validator_info.info[ gui->validator_info.info_cnt ].name[ 63 ] = '\0';
+    strncpy( gui->validator_info.info[ gui->validator_info.info_cnt ].website, (char const *)(data+96UL), 128 );
+    gui->validator_info.info[ gui->validator_info.info_cnt ].website[ 127 ] = '\0';
 
-      strncpy( gui->validator_info.info[ gui->validator_info.info_cnt ].website, (char const *)(data+i*608UL+96UL), 128 );
-      gui->validator_info.info[ gui->validator_info.info_cnt ].website[ 127 ] = '\0';
+    strncpy( gui->validator_info.info[ gui->validator_info.info_cnt ].details, (char const *)(data+224UL), 256 );
+    gui->validator_info.info[ gui->validator_info.info_cnt ].details[ 255 ] = '\0';
 
-      strncpy( gui->validator_info.info[ gui->validator_info.info_cnt ].details, (char const *)(data+i*608UL+224UL), 256 );
-      gui->validator_info.info[ gui->validator_info.info_cnt ].details[ 255 ] = '\0';
+    strncpy( gui->validator_info.info[ gui->validator_info.info_cnt ].icon_uri, (char const *)(data+480UL), 128 );
+    gui->validator_info.info[ gui->validator_info.info_cnt ].icon_uri[ 127 ] = '\0';
 
-      strncpy( gui->validator_info.info[ gui->validator_info.info_cnt ].icon_uri, (char const *)(data+i*608UL+480UL), 128 );
-      gui->validator_info.info[ gui->validator_info.info_cnt ].icon_uri[ 127 ] = '\0';
+    gui->validator_info.info_cnt++;
+  } else {
+    int peer_updated =
+      memcmp( gui->validator_info.info[ found_idx ].pubkey->uc, data, 32UL ) ||
+      strncmp( gui->validator_info.info[ found_idx ].name, (char const *)(data+32UL), 64 ) ||
+      strncmp( gui->validator_info.info[ found_idx ].website, (char const *)(data+96UL), 128 ) ||
+      strncmp( gui->validator_info.info[ found_idx ].details, (char const *)(data+224UL), 256 ) ||
+      strncmp( gui->validator_info.info[ found_idx ].icon_uri, (char const *)(data+480UL), 128 );
 
-      gui->validator_info.info_cnt++;
-    } else {
-      int peer_updated =
-        memcmp( gui->validator_info.info[ found_idx ].pubkey->uc, data+i*608UL, 32UL ) ||
-        strncmp( gui->validator_info.info[ found_idx ].name, (char const *)(data+i*608UL+32UL), 64 ) ||
-        strncmp( gui->validator_info.info[ found_idx ].website, (char const *)(data+i*608UL+96UL), 128 ) ||
-        strncmp( gui->validator_info.info[ found_idx ].details, (char const *)(data+i*608UL+224UL), 256 ) ||
-        strncmp( gui->validator_info.info[ found_idx ].icon_uri, (char const *)(data+i*608UL+480UL), 128 );
+    if( FD_UNLIKELY( peer_updated ) ) {
+      updated[ update_cnt++ ] = found_idx;
 
-      if( FD_UNLIKELY( peer_updated ) ) {
-        updated[ update_cnt++ ] = found_idx;
+      fd_memcpy( gui->validator_info.info[ found_idx ].pubkey->uc, data, 32UL );
 
-        fd_memcpy( gui->validator_info.info[ found_idx ].pubkey->uc, data+i*608UL, 32UL );
+      strncpy( gui->validator_info.info[ found_idx ].name, (char const *)(data+32UL), 64 );
+      gui->validator_info.info[ found_idx ].name[ 63 ] = '\0';
 
-        strncpy( gui->validator_info.info[ found_idx ].name, (char const *)(data+i*608UL+32UL), 64 );
-        gui->validator_info.info[ found_idx ].name[ 63 ] = '\0';
+      strncpy( gui->validator_info.info[ found_idx ].website, (char const *)(data+96UL), 128 );
+      gui->validator_info.info[ found_idx ].website[ 127 ] = '\0';
 
-        strncpy( gui->validator_info.info[ found_idx ].website, (char const *)(data+i*608UL+96UL), 128 );
-        gui->validator_info.info[ found_idx ].website[ 127 ] = '\0';
+      strncpy( gui->validator_info.info[ found_idx ].details, (char const *)(data+224UL), 256 );
+      gui->validator_info.info[ found_idx ].details[ 255 ] = '\0';
 
-        strncpy( gui->validator_info.info[ found_idx ].details, (char const *)(data+i*608UL+224UL), 256 );
-        gui->validator_info.info[ found_idx ].details[ 255 ] = '\0';
-
-        strncpy( gui->validator_info.info[ found_idx ].icon_uri, (char const *)(data+i*608UL+480UL), 128 );
-        gui->validator_info.info[ found_idx ].icon_uri[ 127 ] = '\0';
-      }
+      strncpy( gui->validator_info.info[ found_idx ].icon_uri, (char const *)(data+480UL), 128 );
+      gui->validator_info.info[ found_idx ].icon_uri[ 127 ] = '\0';
     }
   }
 
   added_cnt = gui->validator_info.info_cnt - before_peer_cnt;
   for( ulong i=before_peer_cnt; i<gui->validator_info.info_cnt; i++ ) added[ i-before_peer_cnt ] = i;
 
-  fd_gui_printf_peers_validator_info_update( gui, updated, update_cnt, removed, removed_cnt, added, added_cnt );
+  fd_gui_printf_peers_validator_info_update( gui, updated, update_cnt, NULL, removed_cnt, added, added_cnt );
   fd_http_server_ws_broadcast( gui->http );
 }
 

--- a/src/disco/plugin/fd_plugin.h
+++ b/src/disco/plugin/fd_plugin.h
@@ -41,8 +41,9 @@ struct __attribute__((packed, aligned(8))) fd_replay_complete_msg {
 };
 typedef struct fd_replay_complete_msg fd_replay_complete_msg_t;
 
-#define FD_CLUSTER_NODE_CNT     (200U*201U - 1U)
-#define FD_GOSSIP_LINK_MSG_SIZE (58U + 12U * 6U)
+#define FD_CLUSTER_NODE_CNT        (200U*201U - 1U)
+#define FD_GOSSIP_LINK_MSG_SIZE    (58U + 12U * 6U)
+#define FD_VALIDATOR_INFO_MSG_SIZE (          608U)
 
 struct __attribute__((packed)) fd_gossip_update_msg {
   uchar  pubkey[32];			// 0..31


### PR DESCRIPTION
- Add link for validator info messages
- fix message size calculation in plugin
- send info messages as they are found in accounts db (rather than all at one at the end)

agave [diff](https://github.com/firedancer-io/agave/compare/5f63d808b5..jherrera/gui-fetch-peer-info-2~7)