### PR TITLE
gui: sync metrics sampling

### DIFF
--- a/src/app/fdctl/run/tiles/fd_bundle.c
+++ b/src/app/fdctl/run/tiles/fd_bundle.c
@@ -86,9 +86,13 @@ during_housekeeping( fd_bundle_ctx_t * ctx ) {
 
 static inline void
 metrics_write( fd_bundle_ctx_t * ctx ) {
-  FD_MCNT_SET( BUNDLE, TRANSACTION_RECEIVED, ctx->metrics.txn_received );
   FD_MCNT_SET( BUNDLE, BUNDLE_RECEIVED, ctx->metrics.bundle_received );
   FD_MCNT_SET( BUNDLE, PACKET_RECEIVED, ctx->metrics.packet_received );
+}
+
+static inline void
+metrics_write_fixed_interval( fd_bundle_ctx_t * ctx ) {
+  FD_MCNT_SET( BUNDLE, TRANSACTION_RECEIVED, ctx->metrics.txn_received );
 }
 
 extern void
@@ -423,9 +427,10 @@ populate_allowed_fds( fd_topo_t const *      topo,
 #define STEM_CALLBACK_CONTEXT_TYPE  fd_bundle_ctx_t
 #define STEM_CALLBACK_CONTEXT_ALIGN alignof(fd_bundle_ctx_t)
 
-#define STEM_CALLBACK_DURING_HOUSEKEEPING during_housekeeping
-#define STEM_CALLBACK_METRICS_WRITE       metrics_write
-#define STEM_CALLBACK_AFTER_CREDIT        after_credit
+#define STEM_CALLBACK_DURING_HOUSEKEEPING          during_housekeeping
+#define STEM_CALLBACK_FIXED_METRICS_WRITE_INTERVAL metrics_write_fixed_interval
+#define STEM_CALLBACK_METRICS_WRITE                metrics_write
+#define STEM_CALLBACK_AFTER_CREDIT                 after_credit
 
 #include "../../../../disco/stem/fd_stem.c"
 

--- a/src/app/fdctl/run/tiles/fd_verify.c
+++ b/src/app/fdctl/run/tiles/fd_verify.c
@@ -30,6 +30,12 @@ scratch_footprint( fd_topo_tile_t const * tile ) {
 
 static inline void
 metrics_write( fd_verify_ctx_t * ctx ) {
+  (void)ctx;
+  return;
+}
+
+static inline void
+metrics_write_fixed_interval( fd_verify_ctx_t * ctx ) {
   FD_MCNT_SET( VERIFY, TRANSACTION_BUNDLE_PEER_FAILURE, ctx->metrics.bundle_peer_fail_cnt );
   FD_MCNT_SET( VERIFY, TRANSACTION_PARSE_FAILURE,       ctx->metrics.parse_fail_cnt );
   FD_MCNT_SET( VERIFY, TRANSACTION_DEDUP_FAILURE,       ctx->metrics.dedup_fail_cnt );
@@ -245,10 +251,11 @@ populate_allowed_fds( fd_topo_t const *      topo,
 #define STEM_CALLBACK_CONTEXT_TYPE  fd_verify_ctx_t
 #define STEM_CALLBACK_CONTEXT_ALIGN alignof(fd_verify_ctx_t)
 
-#define STEM_CALLBACK_METRICS_WRITE metrics_write
-#define STEM_CALLBACK_BEFORE_FRAG   before_frag
-#define STEM_CALLBACK_DURING_FRAG   during_frag
-#define STEM_CALLBACK_AFTER_FRAG    after_frag
+#define STEM_CALLBACK_FIXED_METRICS_WRITE_INTERVAL metrics_write_fixed_interval
+#define STEM_CALLBACK_METRICS_WRITE                metrics_write
+#define STEM_CALLBACK_BEFORE_FRAG                  before_frag
+#define STEM_CALLBACK_DURING_FRAG                  during_frag
+#define STEM_CALLBACK_AFTER_FRAG                   after_frag
 
 #include "../../../../disco/stem/fd_stem.c"
 

--- a/src/disco/gui/sankey_debug.py
+++ b/src/disco/gui/sankey_debug.py
@@ -105,6 +105,7 @@ block_engine:         {in_block_engine:10,}
 gossip:               {in_gossip:10,}
 udp:                  {in_udp:10,}
 quic:                 {in_quic:10,}
+pack_cranked:         {pack_cranked:10,}
 ----------------------------------------
 IN TOTAL:             {in_block_engine + in_gossip + in_udp + in_quic:10,}
 
@@ -133,7 +134,6 @@ COMPUTED RESOLV OUT:  {in_block_engine + in_udp + in_quic + in_gossip - verify_o
 RECONCILE RESOLV IN:  {recon_resolv_in:10,}
 RECONCILE RESOLV OUT: {recon_resolv_out:10,}
 
-pack_cranked:         {pack_cranked:10,}
 pack_retained:        {pack_retained:10,}
 pack_leader_slot:     {pack_leader_slot:10,}
 pack_expired:         {pack_expired:10,}

--- a/src/disco/pack/fd_pack.c
+++ b/src/disco/pack/fd_pack.c
@@ -1583,12 +1583,16 @@ fd_pack_metrics_write( fd_pack_t const * pack ) {
   ulong pending_votes  = treap_ele_cnt( pack->pending_votes   );
   ulong pending_bundle = treap_ele_cnt( pack->pending_bundles );
   ulong conflicting    = pack->pending_txn_cnt - pending_votes - pending_bundle - treap_ele_cnt( pack->pending );
-  FD_MGAUGE_SET( PACK, AVAILABLE_TRANSACTIONS_ALL,         pack->pending_txn_cnt       );
   FD_MGAUGE_SET( PACK, AVAILABLE_TRANSACTIONS_REGULAR,     pending_regular             );
   FD_MGAUGE_SET( PACK, AVAILABLE_TRANSACTIONS_VOTES,       pending_votes               );
   FD_MGAUGE_SET( PACK, AVAILABLE_TRANSACTIONS_CONFLICTING, conflicting                 );
   FD_MGAUGE_SET( PACK, AVAILABLE_TRANSACTIONS_BUNDLES,     pending_bundle              );
   FD_MGAUGE_SET( PACK, SMALLEST_PENDING_TRANSACTION,       pack->pending_smallest->cus );
+}
+
+void
+fd_pack_metrics_fixed_int_write( fd_pack_t const * pack ) {
+  FD_MGAUGE_SET(PACK, AVAILABLE_TRANSACTIONS_ALL, pack->pending_txn_cnt );
 }
 
 typedef struct {

--- a/src/disco/pack/fd_pack.h
+++ b/src/disco/pack/fd_pack.h
@@ -617,6 +617,11 @@ void
 fd_pack_metrics_write( fd_pack_t const * pack );
 
 
+/* fd_pack_metrics_fixed_int_write writes period metric values to the metrics
+   system which are intended to be written .  pack must be a valid local join. */
+void
+fd_pack_metrics_fixed_int_write( fd_pack_t const * pack );
+
 /* fd_pack_leave leaves a local join of a pack object.  Returns pack. */
 void * fd_pack_leave(  fd_pack_t * pack );
 /* fd_pack_delete unformats a memory region used to store a pack object

--- a/src/disco/quic/fd_quic_tile.c
+++ b/src/disco/quic/fd_quic_tile.c
@@ -116,21 +116,11 @@ before_credit( fd_quic_ctx_t *     ctx,
 
 static inline void
 metrics_write( fd_quic_ctx_t * ctx ) {
-  FD_MCNT_SET  ( QUIC, TXNS_RECEIVED_UDP,       ctx->metrics.txns_received_udp );
-  FD_MCNT_SET  ( QUIC, TXNS_RECEIVED_QUIC_FAST, ctx->metrics.txns_received_quic_fast );
-  FD_MCNT_SET  ( QUIC, TXNS_RECEIVED_QUIC_FRAG, ctx->metrics.txns_received_quic_frag );
   FD_MCNT_SET  ( QUIC, FRAGS_OK,                ctx->metrics.frag_ok_cnt );
   FD_MCNT_SET  ( QUIC, FRAGS_GAP,               ctx->metrics.frag_gap_cnt );
   FD_MCNT_SET  ( QUIC, FRAGS_DUP,               ctx->metrics.frag_dup_cnt );
-  FD_MCNT_SET  ( QUIC, TXNS_OVERRUN,            ctx->metrics.reasm_overrun );
-  FD_MCNT_SET  ( QUIC, TXNS_ABANDONED,          ctx->metrics.reasm_abandoned );
   FD_MCNT_SET  ( QUIC, TXN_REASMS_STARTED,      ctx->metrics.reasm_started );
   FD_MGAUGE_SET( QUIC, TXN_REASMS_ACTIVE,       (ulong)fd_long_max( ctx->metrics.reasm_active, 0L ) );
-
-  FD_MCNT_SET( QUIC, LEGACY_TXN_UNDERSZ, ctx->metrics.udp_pkt_too_small );
-  FD_MCNT_SET( QUIC, LEGACY_TXN_OVERSZ,  ctx->metrics.udp_pkt_too_large );
-  FD_MCNT_SET( QUIC, TXN_UNDERSZ,        ctx->metrics.quic_txn_too_small );
-  FD_MCNT_SET( QUIC, TXN_OVERSZ,         ctx->metrics.quic_txn_too_large );
 
   FD_MCNT_SET(   QUIC, RECEIVED_PACKETS, ctx->quic->metrics.net_rx_pkt_cnt );
   FD_MCNT_SET(   QUIC, RECEIVED_BYTES,   ctx->quic->metrics.net_rx_byte_cnt );
@@ -148,16 +138,6 @@ metrics_write( fd_quic_ctx_t * ctx ) {
   FD_MCNT_SET(   QUIC, CONNECTION_ERROR_NO_SLOTS,   ctx->quic->metrics.conn_err_no_slots_cnt );
   FD_MCNT_SET(   QUIC, CONNECTION_ERROR_RETRY_FAIL, ctx->quic->metrics.conn_err_retry_fail_cnt );
 
-  FD_MCNT_ENUM_COPY( QUIC, PKT_CRYPTO_FAILED,  ctx->quic->metrics.pkt_decrypt_fail_cnt );
-  FD_MCNT_ENUM_COPY( QUIC, PKT_NO_KEY,         ctx->quic->metrics.pkt_no_key_cnt );
-  FD_MCNT_SET(       QUIC, PKT_NO_CONN,        ctx->quic->metrics.pkt_no_conn_cnt );
-  FD_MCNT_SET(       QUIC, PKT_TX_ALLOC_FAIL,  ctx->quic->metrics.pkt_tx_alloc_fail_cnt );
-  FD_MCNT_SET(       QUIC, PKT_NET_HEADER_INVALID,  ctx->quic->metrics.pkt_net_hdr_err_cnt );
-  FD_MCNT_SET(       QUIC, PKT_QUIC_HEADER_INVALID, ctx->quic->metrics.pkt_quic_hdr_err_cnt );
-  FD_MCNT_SET(       QUIC, PKT_UNDERSZ,        ctx->quic->metrics.pkt_undersz_cnt );
-  FD_MCNT_SET(       QUIC, PKT_OVERSZ,         ctx->quic->metrics.pkt_oversz_cnt );
-  FD_MCNT_SET(       QUIC, PKT_VERNEG,         ctx->quic->metrics.pkt_verneg_cnt );
-
   FD_MCNT_SET(   QUIC, HANDSHAKES_CREATED,         ctx->quic->metrics.hs_created_cnt );
   FD_MCNT_SET(   QUIC, HANDSHAKE_ERROR_ALLOC_FAIL, ctx->quic->metrics.hs_err_alloc_fail_cnt );
 
@@ -171,6 +151,30 @@ metrics_write( fd_quic_ctx_t * ctx ) {
 
   FD_MHIST_COPY( QUIC, SERVICE_DURATION_SECONDS, ctx->quic->metrics.service_duration );
   FD_MHIST_COPY( QUIC, RECEIVE_DURATION_SECONDS, ctx->quic->metrics.receive_duration );
+}
+
+static inline void
+metrics_write_fixed_interval( fd_quic_ctx_t * ctx ) {
+  FD_MCNT_SET  ( QUIC, TXNS_RECEIVED_UDP,       ctx->metrics.txns_received_udp );
+  FD_MCNT_SET  ( QUIC, TXNS_RECEIVED_QUIC_FAST, ctx->metrics.txns_received_quic_fast );
+  FD_MCNT_SET  ( QUIC, TXNS_RECEIVED_QUIC_FRAG, ctx->metrics.txns_received_quic_frag );
+  FD_MCNT_SET  ( QUIC, TXNS_OVERRUN,            ctx->metrics.reasm_overrun );
+  FD_MCNT_SET  ( QUIC, TXNS_ABANDONED,          ctx->metrics.reasm_abandoned );
+
+  FD_MCNT_SET( QUIC, LEGACY_TXN_UNDERSZ, ctx->metrics.udp_pkt_too_small );
+  FD_MCNT_SET( QUIC, LEGACY_TXN_OVERSZ,  ctx->metrics.udp_pkt_too_large );
+  FD_MCNT_SET( QUIC, TXN_UNDERSZ,        ctx->metrics.quic_txn_too_small );
+  FD_MCNT_SET( QUIC, TXN_OVERSZ,         ctx->metrics.quic_txn_too_large );
+
+  FD_MCNT_ENUM_COPY( QUIC, PKT_CRYPTO_FAILED,  ctx->quic->metrics.pkt_decrypt_fail_cnt );
+  FD_MCNT_ENUM_COPY( QUIC, PKT_NO_KEY,         ctx->quic->metrics.pkt_no_key_cnt );
+  FD_MCNT_SET(       QUIC, PKT_NO_CONN,        ctx->quic->metrics.pkt_no_conn_cnt );
+  FD_MCNT_SET(       QUIC, PKT_TX_ALLOC_FAIL,  ctx->quic->metrics.pkt_tx_alloc_fail_cnt );
+  FD_MCNT_SET(       QUIC, PKT_NET_HEADER_INVALID,  ctx->quic->metrics.pkt_net_hdr_err_cnt );
+  FD_MCNT_SET(       QUIC, PKT_QUIC_HEADER_INVALID, ctx->quic->metrics.pkt_quic_hdr_err_cnt );
+  FD_MCNT_SET(       QUIC, PKT_UNDERSZ,        ctx->quic->metrics.pkt_undersz_cnt );
+  FD_MCNT_SET(       QUIC, PKT_OVERSZ,         ctx->quic->metrics.pkt_oversz_cnt );
+  FD_MCNT_SET(       QUIC, PKT_VERNEG,         ctx->quic->metrics.pkt_verneg_cnt );
 }
 
 static int
@@ -613,12 +617,13 @@ populate_allowed_fds( fd_topo_t const *      topo,
 #define STEM_CALLBACK_CONTEXT_TYPE  fd_quic_ctx_t
 #define STEM_CALLBACK_CONTEXT_ALIGN alignof(fd_quic_ctx_t)
 
-#define STEM_CALLBACK_DURING_HOUSEKEEPING during_housekeeping
-#define STEM_CALLBACK_METRICS_WRITE       metrics_write
-#define STEM_CALLBACK_BEFORE_CREDIT       before_credit
-#define STEM_CALLBACK_BEFORE_FRAG         before_frag
-#define STEM_CALLBACK_DURING_FRAG         during_frag
-#define STEM_CALLBACK_AFTER_FRAG          after_frag
+#define STEM_CALLBACK_DURING_HOUSEKEEPING          during_housekeeping
+#define STEM_CALLBACK_FIXED_METRICS_WRITE_INTERVAL metrics_write_fixed_interval
+#define STEM_CALLBACK_METRICS_WRITE                metrics_write
+#define STEM_CALLBACK_BEFORE_CREDIT                before_credit
+#define STEM_CALLBACK_BEFORE_FRAG                  before_frag
+#define STEM_CALLBACK_DURING_FRAG                  during_frag
+#define STEM_CALLBACK_AFTER_FRAG                   after_frag
 
 #include "../stem/fd_stem.c"
 


### PR DESCRIPTION
adds stem callback that runs at a fixed tick interval. this allows metrics to be sampled in sync across various tiles, which allows consumers of those metrics (the gui) to use them together coherently.