### PR TITLE
sandbox: fix dumpable option

### DIFF
--- a/src/app/fdctl/config_parse.c
+++ b/src/app/fdctl/config_parse.c
@@ -96,7 +96,7 @@ fdctl_cfg_get_bool( int *                 out,
     return 0;
   }
   ulong u; fd_ulong_svw_dec( (uchar const *)info->val, &u );
-  *out = (int)u;
+  *out = fd_int_zz_dec( (uint)u );
   return 1;
 }
 

--- a/src/util/sandbox/fd_sandbox.c
+++ b/src/util/sandbox/fd_sandbox.c
@@ -653,8 +653,8 @@ fd_sandbox_private_enter_no_seccomp( uint        desired_uid,
 
   /* PR_SET_KEEPCAPS will already be 0 if we didn't need to raise
      CAP_SYS_ADMIN, but we always clear it anyway. */
-  if( -1==prctl( PR_SET_KEEPCAPS, 0 ) )        FD_LOG_ERR(( "prctl(PR_SET_KEEPCAPS, 0) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
-  if( -1==prctl( PR_SET_DUMPABLE, dumpable ) ) FD_LOG_ERR(( "prctl(PR_SET_DUMPABLE, 0) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  if( -1==prctl( PR_SET_KEEPCAPS, 0        ) ) FD_LOG_ERR(( "prctl(PR_SET_KEEPCAPS, 0) failed (%i-%s)",            errno, fd_io_strerror( errno ) ));
+  if( -1==prctl( PR_SET_DUMPABLE, dumpable ) ) FD_LOG_ERR(( "prctl(PR_SET_DUMPABLE, %i) failed (%i-%s)", dumpable, errno, fd_io_strerror( errno ) ));
 
   /* Now remount the filesystem root so no files are accessible any more. */
   fd_sandbox_private_pivot_root();


### PR DESCRIPTION
In fd_toml.c, `fd_toml_parse_boolean`, the value (0 or 1) gets inserted with `fd_pod_insert_int`, which does zig-zag encoding. Because we weren't doing zig-zag decoding on the parse side, true was returned as `2`, not `1`.