### PR TITLE
pack: fix bundle issue in slot 0 of rotation

### DIFF
--- a/src/app/fdctl/run/tiles/fd_pack.c
+++ b/src/app/fdctl/run/tiles/fd_pack.c
@@ -594,12 +594,25 @@ after_credit( fd_pack_ctx_t *     ctx,
         int retval = fd_pack_insert_bundle_fini( ctx->pack, bundle, 1UL, ctx->leader_slot-1UL, 1, NULL );
         if( FD_UNLIKELY( retval<0 ) ) FD_LOG_WARNING(( "inserting initializer bundle returned %i", retval ));
         else {
-          /* Update the cached copy of the on-chain state. It won't be read
-             again until after scheduling the initializer bundle we just
-             inserted because peek_bundle_meta will return NULL */
+          /* Update the cached copy of the on-chain state.  This seems a
+             little dangerous, since we're updating it as if the bundle
+             succeeded without knowing if that's true, but here's why
+             it's safe:
 
-          *(ctx->crank->prev_config->block_builder) = *(top_meta->commission_pubkey);
-          ctx->crank->prev_config->commission_pct   = top_meta->commission;
+             From now until we get the rebate call for this initializer
+             bundle (which lets us know if it succeeded or failed), pack
+             will be in [Pending] state, which means peek_bundle_meta
+             will return NULL, so we won't read this state.
+
+             Then, if the initializer bundle failed, we'll go into
+             [Failed] IB state until the end of the block, which will
+             cause top_meta to remain NULL so we don't read these values
+             again.
+
+             Otherwise, the initializer bundle succeeded, which means
+             that these are the right values to use. */
+          fd_bundle_crank_apply( ctx->crank->gen, ctx->crank->prev_config, top_meta->commission_pubkey,
+                                 ctx->crank->tip_receiver_owner, ctx->crank->epoch, top_meta->commission );
         }
       } else {
         /* Already logged a warning in this case */

--- a/src/disco/plugin/fd_bundle_crank.c
+++ b/src/disco/plugin/fd_bundle_crank.c
@@ -393,3 +393,20 @@ fd_bundle_crank_generate( fd_bundle_crank_gen_t                       * gen,
     return sizeof(gen->crank2);
   }
 }
+
+void
+fd_bundle_crank_apply( fd_bundle_crank_gen_t                       * gen,
+                       fd_bundle_crank_tip_payment_config_t        * tip_payment_config,
+                       fd_acct_addr_t                       const  * new_block_builder,
+                       fd_acct_addr_t                              * tip_receiver_owner,
+                       ulong                                         epoch,
+                       ulong                                         block_builder_commission ) {
+
+  if( FD_UNLIKELY( epoch!=gen->configured_epoch ) ) fd_bundle_crank_update_epoch( gen, epoch );
+
+  memcpy( tip_receiver_owner,                gen->crank3->tip_distribution_program, sizeof(fd_acct_addr_t) );
+  memcpy( tip_payment_config->tip_receiver,  gen->crank3->new_tip_receiver,         sizeof(fd_acct_addr_t) );
+  memcpy( tip_payment_config->block_builder, new_block_builder,                     sizeof(fd_acct_addr_t) );
+
+  tip_payment_config->commission_pct = block_builder_commission;
+}

--- a/src/disco/plugin/fd_bundle_crank.h
+++ b/src/disco/plugin/fd_bundle_crank.h
@@ -142,6 +142,21 @@ fd_bundle_crank_generate( fd_bundle_crank_gen_t                       * gen,
                           fd_txn_t                                    * out_txn );
 
 
+/* fd_bundle_crank_apply updates tip_payment_config and
+   tip_receiver_owner as if the transaction produced by
+   fd_bundle_crank_generate with the same parameters executed
+   successfully.  Arguments have the same meaning as in _generate with
+   tip_payment_config playing the role of old_tip_payment_config (since
+   it's not old anymore). */
+void
+fd_bundle_crank_apply( fd_bundle_crank_gen_t                       * gen,
+                       fd_bundle_crank_tip_payment_config_t        * tip_payment_config,
+                       fd_acct_addr_t                       const  * new_block_builder,
+                       fd_acct_addr_t                              * tip_receiver_owner,
+                       ulong                                         epoch,
+                       ulong                                         block_builder_commission );
+
+
 /* These are fixed sized transactions, so sizeof() gives you the proper
    size of the payload. */
 typedef struct fd_bundle_crank_3 fd_bundle_crank_3_t; /* init and update */


### PR DESCRIPTION
Previously, the tip_receiver was not getting set in the cached copy of the on-chain state. This caused a loop:

- Start slot 0 in `[Not Ready]`
- Schedule an IB, transition to `[Pending]`
- IB completes successfully, transition to `[Ready]`
- Prior to scheduling a bundle, determine that it needs to be cranked because the tip_receiver doesn't seem right.
- Insert IB, schedule it instead of the bundle, transition to `[Pending]`
- Repeat until the end of the slot.

At the start of the next slot, when we get an updated copy of the on-chain state from the poh tile, this problem goes away.