### PR TITLE
bundle: fix compile_protos warning

### DIFF
--- a/plugin/bundle/Cargo.toml
+++ b/plugin/bundle/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["staticlib"]
 
 [dependencies]
-tonic = { version = "0.12.2", features = ["tls-roots", "tls", "tls-webpki-roots"] }
+tonic = { version = "0.12.3", features = ["tls-roots", "tls", "tls-webpki-roots"] }
 prost = "0.13.3"
 prost-types = "0.13.3"
 log = "0.4.22"
@@ -19,7 +19,7 @@ thiserror = "1.0.64"
 bs58 = "0.5.1"
 
 [build-dependencies]
-tonic-build = "0.12.2"
+tonic-build = "0.12.3"
 protobuf-src = "2.1.0"
 prost-types = "0.13.3"
 

--- a/plugin/bundle/build.rs
+++ b/plugin/bundle/build.rs
@@ -34,5 +34,5 @@ fn main() -> Result<(), std::io::Error> {
             "InstructionErrorType",
             "#[cfg_attr(test, derive(enum_iterator::Sequence))]",
         )
-        .compile(&protos, &[proto_base_path])
+        .compile_protos(&protos, &[proto_base_path])
 }


### PR DESCRIPTION
semver rules upgrade tonic-build to 0.12.3 which deprecated some
function we were using. Causes a stray warning during build for
new checkouts.
