### PR TITLE
flamenco, tests: limit number of cpu cores used in run-runtime-test

### DIFF
--- a/src/flamenco/runtime/tests/run_ledger_tests_all.py
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.py
@@ -53,7 +53,7 @@ def worker(command_queue, available_params, error_occurred, error_event):
 
 
 def main(file_path):
-    cpu_batches = group_cpus_by_num_batches(num_batches=5)
+    cpu_batches = group_cpus_by_batch_size(batch_size=10)[:5]
     print("CPU Batches:", cpu_batches)
     # Define parameter ranges
     parameter_ranges = [ f'--tile-cpus {b[0]}-{b[-1]}' for b in cpu_batches ]


### PR DESCRIPTION
Ensures that we don't use too many cores on large boxes, which causes us to use an excessive amount of memory on boxes with large core counts. This limits the ledger tests to using 5 batches of 10 cores.

Ledger replay in CI is 8m 19s with this change.