### PR TITLE
find more impure/non-const functions

### DIFF
--- a/src/app/fddev/tiles/fd_benchs.c
+++ b/src/app/fddev/tiles/fd_benchs.c
@@ -257,7 +257,7 @@ populate_quic_config( fd_quic_config_t * config ) {
   config->net.dscp = 0;
 }
 
-FD_FN_PURE static inline ulong
+static inline ulong
 scratch_footprint( fd_topo_tile_t const * tile ) {
   (void)tile;
   ulong l = FD_LAYOUT_INIT;

--- a/src/disco/quic/fd_quic_tile.c
+++ b/src/disco/quic/fd_quic_tile.c
@@ -51,7 +51,7 @@ scratch_align( void ) {
   return fd_ulong_max( alignof(fd_quic_ctx_t), fd_quic_align() );
 }
 
-FD_FN_PURE static inline ulong
+static inline ulong
 scratch_footprint( fd_topo_tile_t const * tile ) {
   ulong out_depth = tile->quic.out_depth;
   ulong reasm_max = tile->quic.reasm_cnt;

--- a/src/flamenco/vm/fd_vm_private.h
+++ b/src/flamenco/vm/fd_vm_private.h
@@ -461,7 +461,7 @@ fd_vm_mem_haddr( fd_vm_t const *    vm,
   return fd_ulong_if( sz<=sz_max, vm_region_haddr[ region ] + offset, sentinel );
 }
 
-FD_FN_PURE static inline ulong
+static inline ulong
 fd_vm_mem_haddr_fast( fd_vm_t const * vm,
                       ulong           vaddr,
                       ulong   const * vm_region_haddr ) { /* indexed [0,6) */

--- a/src/funk/fd_funk_rec.h
+++ b/src/funk/fd_funk_rec.h
@@ -191,7 +191,7 @@ fd_funk_rec_query_safe( fd_funk_t *               funk,
                         fd_valloc_t               valloc,
                         ulong *                   result_len );
 
-FD_FN_PURE void *
+void *
 fd_funk_rec_query_xid_safe( fd_funk_t *               funk,
                             fd_funk_rec_key_t const * key,
                             fd_funk_txn_xid_t const * xid,

--- a/src/funkier/fd_funkier.h
+++ b/src/funkier/fd_funkier.h
@@ -352,7 +352,7 @@ FD_FN_PURE static inline ulong fd_funkier_txn_max( fd_funkier_t * funk ) { retur
 /* fd_funkier_txn_map returns the funk's transaction map join. This
    join can copied by value and is generally stored as a stack variable. */
 
-FD_FN_PURE static inline fd_funkier_txn_map_t
+static inline fd_funkier_txn_map_t
 fd_funkier_txn_map( fd_funkier_t * funk,       /* Assumes current local join */
                     fd_wksp_t * wksp ) {       /* Assumes wksp == fd_funkier_wksp( funk ) */
   fd_funkier_txn_map_t join;
@@ -367,7 +367,7 @@ fd_funkier_txn_map( fd_funkier_t * funk,       /* Assumes current local join */
 /* fd_funkier_txn_pool returns the funk's transaction pool join. This
    join can copied by value and is generally stored as a stack variable. */
 
-FD_FN_PURE static inline fd_funkier_txn_pool_t
+static inline fd_funkier_txn_pool_t
 fd_funkier_txn_pool( fd_funkier_t * funk,    /* Assumes current local join */
                      fd_wksp_t * wksp ) {    /* Assumes wksp == fd_funkier_wksp( funk ) */
   fd_funkier_txn_pool_t join;
@@ -435,7 +435,7 @@ FD_FN_PURE static inline ulong fd_funkier_rec_max( fd_funkier_t * funk ) { retur
 /* fd_funkier_rec_map returns the funk's record map join. This
    join can copied by value and is generally stored as a stack variable. */
 
-FD_FN_PURE static inline fd_funkier_rec_map_t
+static inline fd_funkier_rec_map_t
 fd_funkier_rec_map( fd_funkier_t * funk,    /* Assumes current local join */
                     fd_wksp_t * wksp ) {    /* Assumes wksp == fd_funkier_wksp( funk ) */
   fd_funkier_rec_map_t join;
@@ -450,7 +450,7 @@ fd_funkier_rec_map( fd_funkier_t * funk,    /* Assumes current local join */
 /* fd_funkier_rec_pool returns the funk's record pool join. This
    join can copied by value and is generally stored as a stack variable. */
 
-FD_FN_PURE static inline fd_funkier_rec_pool_t
+static inline fd_funkier_rec_pool_t
 fd_funkier_rec_pool( fd_funkier_t * funk,    /* Assumes current local join */
                      fd_wksp_t * wksp ) {    /* Assumes wksp == fd_funkier_wksp( funk ) */
   fd_funkier_rec_pool_t join;

--- a/src/util/tmpl/fd_map_slot_para.c
+++ b/src/util/tmpl/fd_map_slot_para.c
@@ -1433,7 +1433,7 @@ MAP_(iter_init)( MAP_(t) *      join,
 MAP_STATIC MAP_(iter_t) *
 MAP_(iter_next)( MAP_(iter_t) * iter );
 
-MAP_STATIC FD_FN_PURE int MAP_(verify)( MAP_(t) const * join );
+MAP_STATIC int MAP_(verify)( MAP_(t) const * join );
 
 MAP_STATIC FD_FN_CONST char const * MAP_(strerror)( int err );
 

--- a/src/util/tmpl/test_map_slot_para.c
+++ b/src/util/tmpl/test_map_slot_para.c
@@ -22,7 +22,7 @@ typedef struct myele myele_t;
 #define MAP_MEMOIZE          0
 #define MAP_MEMO             mymemo
 #define MAP_KEY_EQ_IS_SLOW   0
-#define MAP_ELE_IS_FREE(c,e) (__extension__({ FD_TEST( *(ulong *)c==0x0123456789abcdefUL ); !e->used; }))
+#define MAP_ELE_IS_FREE(c,e) (!e->used)
 #define MAP_ELE_FREE(c,e)    FD_TEST( *(ulong *)c==0x0123456789abcdefUL ); e->used = 0
 #define MAP_ELE_MOVE(c,d,s)  FD_TEST( *(ulong *)c==0x0123456789abcdefUL ); *d = *s; s->used = 0
 #define MAP_IMPL_STYLE       0


### PR DESCRIPTION
These are more hidden. Explanation for each:

```
fd_funkier_rec_pool: fd_funkier_rec_pool_join
fd_funkier_txn_pool: fd_funkier_txn_pool_join
fd_funkier_rec_map: fd_funkier_rec_map_join
fd_funkier_txn_map: fd_funkier_txn_map_join
fd_benches scratch_footprint: quic_limits_ext
fd_vm_mem_haddr_fast: fd_vm_find_input_mem_region
MAP_ELE_IS_FREE: MAP_(private_ele_is_free)MAP_ELE_IS_FREE, can't use side effect, as this is used in a pure func
fd_funk_rec_query_xid_safe: fd_valloc_malloc/free
fd_map_slot_para verify: direct
fd_quic_tile  scratch_footprint: quic_limits
```

I plan on PRing a CodeQL query to nightly that catches frequent offenders like logs and memory allocation, plus the query I used to find these as a dev query.
