### PR TITLE
Flamenco, Gossip: epoch slot fixes

### DIFF
--- a/src/flamenco/gossip/fd_gossip.c
+++ b/src/flamenco/gossip/fd_gossip.c
@@ -1927,14 +1927,6 @@ fd_gossip_handle_pull_req(fd_gossip_t * glob, const fd_gossip_peer_addr_t * from
     }
     misses++;
 
-    /* Record the ratio of hits to misses
-
-       These metrics are imprecise as the numbers will vary
-       per pull request. We keep them to surface
-       obvious issues like 100% miss rate.*/
-    glob->metrics.handle_pull_req_bloom_filter_result[ FD_METRICS_ENUM_PULL_REQ_BLOOM_FILTER_RESULT_V_HIT_IDX ] += hits;
-    glob->metrics.handle_pull_req_bloom_filter_result[ FD_METRICS_ENUM_PULL_REQ_BLOOM_FILTER_RESULT_V_MISS_IDX ] += misses;
-
     /* Add the value in already encoded form */
     if (newend + ele->datalen - buf > PACKET_DATA_SIZE) {
       /* Packet is getting too large. Flush it */
@@ -1951,6 +1943,13 @@ fd_gossip_handle_pull_req(fd_gossip_t * glob, const fd_gossip_peer_addr_t * from
     newend += ele->datalen;
     (*crds_len)++;
   }
+      /* Record the number of hits and misses
+
+       These metrics are imprecise as the numbers will vary
+       per pull request. We keep them to surface
+       obvious issues like 100% miss rate. */
+       glob->metrics.handle_pull_req_bloom_filter_result[ FD_METRICS_ENUM_PULL_REQ_BLOOM_FILTER_RESULT_V_HIT_IDX ] += hits;
+       glob->metrics.handle_pull_req_bloom_filter_result[ FD_METRICS_ENUM_PULL_REQ_BLOOM_FILTER_RESULT_V_MISS_IDX ] += misses;
 
   /* Flush final packet */
   if (newend > (uchar *)ctx.data) {

--- a/src/flamenco/gossip/fd_gossip.c
+++ b/src/flamenco/gossip/fd_gossip.c
@@ -20,7 +20,7 @@
 /* Maximum size of a network packet */
 #define PACKET_DATA_SIZE 1232
 /* How long do we remember values (in millisecs) */
-#define FD_GOSSIP_VALUE_EXPIRE ((ulong)(60e3))   /* 1 minute */
+#define FD_GOSSIP_VALUE_EXPIRE ((ulong)(3600e3))   /* 1 hr */
 /* Max age that values can be pushed/pulled (in millisecs) */
 #define FD_GOSSIP_PULL_TIMEOUT ((ulong)(15e3))   /* 15 seconds */
 /* Max number of validators that can be actively pinged */


### PR DESCRIPTION
Couple of independent fixes to improve Gossip performance

- [flamenco, gossip: bump CRDS value expiration time](https://github.com/firedancer-io/firedancer/commit/e25aea7d32c756d6e5767c0d118722e05b2e1abc)
  - CRDS values were initially discarded after 1 min. While this was fine for regularly updated entries (vote, contact info), epoch slots suffered as they aren't updated often (we see roughly 500 new entries in testnet per minute). This meant the table discarded useful epoch slot values too early, and therefore each pull request constructed bloom filters without these entries, causing a replenish spam from other validators. By extending the expiry window from 1 minute to 1 hour (Agave's equivalent is roughly 1 epoch, which we haven't tested), we hold on to these epoch slot entries longer and therefore reduce replenishes from pull requests.
  - Worth noting that we increase the expiry window for ALL CRDS values, which might be excessive. But given that Agave holds everything for much longer, this probably works fine for us. Running a node for longer than the expiry window (1hr) showed no table full errors either. 
  - We should explore holding older entries in a smarter manner. Do we really want to hold a full value for that long? Agave has a concept of a "purge" table that only stores the hashes of the CRDS value. We might want to adopt something like this if memory usage becomes an issue. 
- [flamenco, gossip: skip sigverify on epoch slot msgs](https://github.com/firedancer-io/firedancer/commit/e310969f86d43c29637a6a11f4a23c5ca57c86ab) skips verifying epoch slots, which significantly helps with the gossip message burst in start-up. 

