### PR TITLE
batch: remove duplicate check

### DIFF
--- a/src/app/fdctl/run/tiles/fd_batch.c
+++ b/src/app/fdctl/run/tiles/fd_batch.c
@@ -325,10 +325,6 @@ produce_snapshot( fd_snapshot_tile_ctx_t * ctx, ulong batch_fseq ) {
     .spad                     = ctx->spad
   };
 
-  if( !is_incremental ) {
-    ctx->last_full_snap_slot = snapshot_slot;
-  }
-
   /* If this isn't the first snapshot that this tile is creating, the
       permissions should be made to not acessible by users and should be
       renamed to the constant file that is expected. */


### PR DESCRIPTION
The exact same check is already done above, without any changes to the values used.