### PR TITLE
codeql, chore: detect used parameters marked unused

### DIFF
--- a/contrib/codeql/nightly/WrongUnused.ql
+++ b/contrib/codeql/nightly/WrongUnused.ql
@@ -1,0 +1,54 @@
+/**
+ * @name Used parameter marked as unused
+ * @description A parameter is marked as unused, but is actually used.
+ * @id asymmetric-research/used-unused-param
+ * @kind problem
+ * @precision high
+ * @problem.severity warning
+ */
+
+import cpp
+import filter
+
+predicate isVoidCast(VariableAccess va) {
+    va.getFullyConverted().(Cast).getType().getName() = "void" and
+    not va.isInMacroExpansion()
+}
+
+abstract class MarkedUnusedParam extends Parameter {
+    predicate isOffending() {
+        exists(VariableAccess va |
+            va = this.getAnAccess() and
+            not isVoidCast(va)
+            and not va.isInMacroExpansion()
+        )
+    }
+}
+
+class AnnotatedUnusedParam extends MarkedUnusedParam {
+    AnnotatedUnusedParam() {
+        this.getAnAttribute().getName() = "unused"
+    }
+}
+
+class VoidCastUnusedParam extends MarkedUnusedParam {
+    VoidCastUnusedParam() {
+        exists(VariableAccess va |
+            va = this.getAnAccess() and
+            isVoidCast(va) and
+            not exists(Expr expr |
+                expr.getASuccessor*() = va
+                and expr.getFullyConverted().(Cast).getType().getName() != "void"
+            ) and
+            not va.isInMacroExpansion()
+        )
+    }
+}
+
+
+from MarkedUnusedParam p
+where p.isOffending() and
+not p.isInMacroExpansion() and
+included(p.getLocation()) and
+not p.getLocation().getFile().getBaseName() = "fd_rpc_service.c" /* lots of unimplmented stubs */
+select p.getLocation(), "Parameter is marked as unsued, but is actually used"

--- a/src/app/fdctl/run/tiles/fd_bank.c
+++ b/src/app/fdctl/run/tiles/fd_bank.c
@@ -322,9 +322,6 @@ handle_bundle( fd_bank_ctx_t *     ctx,
                ulong               sig,
                ulong               sz,
                fd_stem_context_t * stem ) {
-  (void)seq;
-  (void)stem;
-
   uchar * dst = (uchar *)fd_chunk_to_laddr( ctx->out_mem, ctx->out_chunk );
   fd_txn_p_t * txns = (fd_txn_p_t *)dst;
 

--- a/src/app/fdctl/run/tiles/fd_plugin.c
+++ b/src/app/fdctl/run/tiles/fd_plugin.c
@@ -86,11 +86,8 @@ after_frag( fd_plugin_ctx_t *   ctx,
             ulong               sz,
             ulong               tsorig,
             fd_stem_context_t * stem ) {
-  (void)in_idx;
   (void)seq;
-  (void)sz;
   (void)tsorig;
-  (void)stem;
 
   switch( ctx->in_kind[ in_idx ] ) {
     case IN_KIND_REPLAY: {

--- a/src/app/fdctl/run/tiles/fd_poh.c
+++ b/src/app/fdctl/run/tiles/fd_poh.c
@@ -1699,7 +1699,6 @@ before_frag( fd_poh_ctx_t * ctx,
              ulong          in_idx,
              ulong          seq,
              ulong          sig ) {
-  (void)in_idx;
   (void)seq;
 
   if( FD_LIKELY( ctx->in_kind[ in_idx ]==IN_KIND_BANK ) ) {

--- a/src/app/fdctl/run/tiles/fd_poh_int.c
+++ b/src/app/fdctl/run/tiles/fd_poh_int.c
@@ -309,7 +309,6 @@ after_frag( fd_poh_ctx_t *      ctx,
             ulong               sz,
             ulong               tsorig,
             fd_stem_context_t * stem ) {
-  (void)in_idx;
   (void)seq;
   (void)tsorig;
   (void)stem;

--- a/src/app/fdctl/run/tiles/fd_resolv.c
+++ b/src/app/fdctl/run/tiles/fd_resolv.c
@@ -189,7 +189,6 @@ before_frag( fd_resolv_ctx_t * ctx,
              ulong             in_idx,
              ulong             seq,
              ulong             sig ) {
-  (void)in_idx;
   (void)sig;
 
   if( FD_UNLIKELY( ctx->in[in_idx].kind==FD_RESOLV_IN_KIND_BANK ) ) return 0;
@@ -308,7 +307,6 @@ after_frag( fd_resolv_ctx_t *   ctx,
             ulong               tsorig,
             fd_stem_context_t * stem ) {
   (void)seq;
-  (void)sig;
   (void)sz;
 
   if( FD_UNLIKELY( ctx->in[in_idx].kind==FD_RESOLV_IN_KIND_BANK ) ) {

--- a/src/app/fdctl/run/tiles/fd_shred.c
+++ b/src/app/fdctl/run/tiles/fd_shred.c
@@ -293,9 +293,6 @@ before_frag( fd_shred_ctx_t * ctx,
              ulong            in_idx,
              ulong            seq,
              ulong            sig ) {
-  (void)ctx;
-  (void)seq;
-
   if( FD_LIKELY( ctx->in_kind[ in_idx ]==IN_KIND_POH ) ) ctx->poh_in_expect_seq = seq+1UL;
 
   if( FD_LIKELY( ctx->in_kind[ in_idx ]==IN_KIND_NET ) )     return fd_disco_netmux_sig_proto( sig )!=DST_PROTO_SHRED;

--- a/src/app/fdctl/run/tiles/fd_sign.c
+++ b/src/app/fdctl/run/tiles/fd_sign.c
@@ -104,7 +104,6 @@ during_frag_sensitive( void * _ctx,
   (void)seq;
   (void)sig;
   (void)chunk;
-  (void)sz;
 
   fd_sign_ctx_t * ctx = (fd_sign_ctx_t *)_ctx;
   FD_TEST( in_idx<MAX_IN );

--- a/src/app/fdctl/run/tiles/fd_verify.c
+++ b/src/app/fdctl/run/tiles/fd_verify.c
@@ -41,9 +41,6 @@ before_frag( fd_verify_ctx_t * ctx,
              ulong             in_idx,
              ulong             seq,
              ulong             sig ) {
-  (void)in_idx;
-  (void)sig;
-
   /* Bundle tile can produce both "bundles" and "packets", a packet is a
      regular transaction and should be round-robined between verify
      tiles, while bundles need to go through verify:0 currently to
@@ -148,8 +145,8 @@ after_frag( fd_verify_ctx_t *   ctx,
 }
 
 static void
-privileged_init( FD_PARAM_UNUSED fd_topo_t *      topo,
-                 FD_PARAM_UNUSED fd_topo_tile_t * tile ) {
+privileged_init( fd_topo_t *      topo,
+                 fd_topo_tile_t * tile ) {
   void * scratch = fd_topo_obj_laddr( topo, tile->tile_obj_id );
 
   FD_SCRATCH_ALLOC_INIT( l, scratch );

--- a/src/app/fdctl/set_identity.c
+++ b/src/app/fdctl/set_identity.c
@@ -349,8 +349,6 @@ err:
 static void FD_FN_SENSITIVE
 set_identity( args_t *         args,
               config_t * const config ) {
-  (void)args;
-
   uchar check_public_key[ 32 ];
   fd_sha512_t sha512[1];
   FD_TEST( fd_sha512_join( fd_sha512_new( sha512 ) ) );

--- a/src/app/fddev/bench.c
+++ b/src/app/fddev/bench.c
@@ -26,9 +26,6 @@ void
 bench_cmd_args( int *    pargc,
                 char *** pargv,
                 args_t * args ) {
-  (void)pargc;
-  (void)pargv;
-  (void)args;
   args->load.no_quic = fd_env_strip_cmdline_contains( pargc, pargv, "--no-quic" );
 }
 

--- a/src/app/fddev/dev1.c
+++ b/src/app/fddev/dev1.c
@@ -65,8 +65,6 @@ dev1_cmd_perm( args_t *         args,
 void
 dev1_cmd_fn( args_t *         args,
              config_t * const config ) {
-  (void)args;
-
   if( FD_LIKELY( !args->dev1.no_configure ) ) {
     args_t configure_args = {
       .configure.command = CONFIGURE_CMD_INIT,

--- a/src/app/fddev/quic_trace/fd_quic_trace_frame.c
+++ b/src/app/fddev/quic_trace/fd_quic_trace_frame.c
@@ -129,7 +129,7 @@ fd_quic_trace_stream_e_frame(
     fd_quic_trace_frame_ctx_t * context,
     fd_quic_stream_e_frame_t *  data,
     uchar const *               p    FD_PARAM_UNUSED,
-    ulong                       p_sz FD_PARAM_UNUSED ) {
+    ulong                       p_sz ) {
   if( data->length > p_sz ) return FD_QUIC_PARSE_FAIL;
   printf( "ts=%20ld conn_id=%016lx src_ip=%08x src_port=%5hu pktnum=%8lu sid=%8lu off=%4lu (e) len=%4lu (e) fin=%i\n",
           fd_log_wallclock(),

--- a/src/app/fddev/quic_trace/fd_quic_trace_main.c
+++ b/src/app/fddev/quic_trace/fd_quic_trace_main.c
@@ -49,8 +49,6 @@ quic_trace_cmd_args( int *    pargc,
 void
 quic_trace_cmd_fn( args_t *         args,
                    config_t * const config ) {
-  (void)args;
-
   fd_topo_t * topo = &config->topo;
   fd_topo_join_workspaces( topo, FD_SHMEM_JOIN_MODE_READ_ONLY );
   fd_topo_fill( topo );

--- a/src/app/fddev/quic_trace/fd_quic_trace_rx_tile.c
+++ b/src/app/fddev/quic_trace/fd_quic_trace_rx_tile.c
@@ -16,8 +16,6 @@ before_frag( void * _ctx FD_FN_UNUSED,
              ulong  in_idx,
              ulong  seq,
              ulong  sig ) {
-  (void)sig;
-
   /* Skip non-QUIC packets */
   ulong proto = fd_disco_netmux_sig_proto( sig );
   if( proto!=DST_PROTO_TPU_QUIC ) return 1;
@@ -318,14 +316,14 @@ fd_quic_trace_pkt( void *          ctx,
 }
 
 static void
-after_frag( void * _ctx FD_FN_UNUSED,
+after_frag( void * _ctx,
             ulong  in_idx,
             ulong  seq,
             ulong  sig,
             ulong  sz,
             ulong  tsorig,
             fd_stem_context_t * stem ) {
-  (void)in_idx; (void)seq; (void)sig; (void)sz; (void)tsorig; (void)stem;
+  (void)in_idx; (void)seq; (void)sig; (void)tsorig; (void)stem;
 
   fd_quic_ctx_t * ctx = &fd_quic_trace_ctx;
 

--- a/src/app/fddev/tiles/fd_benchs.c
+++ b/src/app/fddev/tiles/fd_benchs.c
@@ -174,8 +174,6 @@ static void
 quic_stream_notify( fd_quic_stream_t * stream,
                     void *             stream_ctx,
                     int                type ) {
-  (void)stream;
-  (void)stream_ctx;
   (void)type;
 
   fd_benchs_ctx_t * ctx = (fd_benchs_ctx_t*)stream_ctx;
@@ -259,7 +257,6 @@ populate_quic_config( fd_quic_config_t * config ) {
 
 static inline ulong
 scratch_footprint( fd_topo_tile_t const * tile ) {
-  (void)tile;
   ulong l = FD_LAYOUT_INIT;
   l = FD_LAYOUT_APPEND( l, alignof( fd_benchs_ctx_t ), sizeof( fd_benchs_ctx_t ) );
   if( !tile->benchs.no_quic ) {
@@ -560,11 +557,6 @@ quic_tx_aio_send( void *                    _ctx,
                   ulong                     batch_cnt,
                   ulong *                   opt_batch_idx,
                   int                       flush ) {
-  (void)batch;
-  (void)batch_cnt;
-  (void)opt_batch_idx;
-  (void)flush;
-
   fd_benchs_ctx_t * ctx = _ctx;
 
   /* quic adds ip and udp headers which we don't need */

--- a/src/app/ledger/main.c
+++ b/src/app/ledger/main.c
@@ -176,7 +176,7 @@ init_spads( fd_ledger_args_t * args, int has_tpool ) {
 
 static void
 fd_create_snapshot_task( void FD_PARAM_UNUSED *tpool,
-                         ulong t0 FD_PARAM_UNUSED, ulong t1 FD_PARAM_UNUSED,
+                         ulong t0, ulong t1,
                          void *args FD_PARAM_UNUSED,
                          void *reduce FD_PARAM_UNUSED, ulong stride FD_PARAM_UNUSED,
                          ulong l0 FD_PARAM_UNUSED, ulong l1 FD_PARAM_UNUSED,

--- a/src/ballet/bn254/fd_bn254_field_ext.c
+++ b/src/ballet/bn254/fd_bn254_field_ext.c
@@ -266,7 +266,7 @@ fd_bn254_fp2_mul_by_i( fd_bn254_fp2_t * r,
    https://eprint.iacr.org/2010/354, Alg. 8. */
 static inline fd_bn254_fp2_t *
 fd_bn254_fp2_inv( fd_bn254_fp2_t * r,
-                  FD_PARAM_UNUSED fd_bn254_fp2_t const * a ) {
+                  fd_bn254_fp2_t const * a ) {
   fd_bn254_fp_t t0[1], t1[1];
   fd_bn254_fp_sqr( t0, &a->el[0] );
   fd_bn254_fp_sqr( t1, &a->el[1] );

--- a/src/ballet/bn254/fd_poseidon.c
+++ b/src/ballet/bn254/fd_poseidon.c
@@ -32,9 +32,9 @@ fd_poseidon_apply_sbox_partial( fd_bn254_scalar_t state[] ) {
 }
 
 static inline void
-fd_poseidon_apply_mds( FD_FN_UNUSED fd_bn254_scalar_t   state[],
-                       FD_FN_UNUSED ulong const       width,
-                       FD_FN_UNUSED fd_poseidon_par_t const * params ) {
+fd_poseidon_apply_mds( fd_bn254_scalar_t   state[],
+                       ulong const       width,
+                       fd_poseidon_par_t const * params ) {
   fd_bn254_scalar_t x[FD_POSEIDON_MAX_WIDTH+1] = { 0 };
   /* Vector-matrix multiplication (state vector times mds matrix) */
   for( ulong i=0; i<width; i++ ) {

--- a/src/ballet/ed25519/test_ed25519.c
+++ b/src/ballet/ed25519/test_ed25519.c
@@ -714,7 +714,7 @@ test_point_validate( FD_PARAM_UNUSED fd_rng_t * rng ) {
 /**********************************************************************/
 
 void
-test_sc_validate( FD_PARAM_UNUSED fd_rng_t * rng ) {
+test_sc_validate( fd_rng_t * rng ) {
   uchar _in [64]; uchar * in  = _in;
   uchar _out[32]; uchar * out = _out;
 

--- a/src/ballet/ed25519/test_ristretto255.c
+++ b/src/ballet/ed25519/test_ristretto255.c
@@ -135,7 +135,7 @@ test_point_decompress( FD_FN_UNUSED fd_rng_t * rng ) {
 }
 
 void
-test_point_compress( FD_FN_UNUSED fd_rng_t * rng ) {
+test_point_compress( fd_rng_t * rng ) {
   uchar                   _s[32]; uchar *                   s = _s;
   fd_ristretto255_point_t _h[1];  fd_ristretto255_point_t * h = _h;
 
@@ -383,7 +383,7 @@ fd_rng_b256( fd_rng_t * rng,
 }
 
 static void FD_FN_NO_ASAN
-test_multiscalar_mul( FD_FN_UNUSED fd_rng_t * rng ) {
+test_multiscalar_mul( fd_rng_t * rng ) {
   fd_ristretto255_point_t _h[1];       fd_ristretto255_point_t * h = _h;
 
   /* Correctness */

--- a/src/ballet/http/fuzz_httpserver.c
+++ b/src/ballet/http/fuzz_httpserver.c
@@ -221,8 +221,6 @@ void close_callback( ulong conn_id, int reason, void * ctx ) {
 }
 
 fd_http_server_response_t request_callback( fd_http_server_request_t const * request ) {
-    (void)request;
-
     fd_http_server_response_t resp;
     memset(&resp, 0, sizeof(fd_http_server_response_t));
 

--- a/src/disco/geyser/fd_geyser.c
+++ b/src/disco/geyser/fd_geyser.c
@@ -212,7 +212,6 @@ replay_sham_link_during_frag( fd_geyser_t * ctx, fd_replay_notif_msg_t * state, 
 
 static void
 replay_sham_link_after_frag(fd_geyser_t * ctx, fd_replay_notif_msg_t * msg) {
-  (void)ctx;
   if( msg->type == FD_REPLAY_SLOT_TYPE ) {
     ulong slotn = msg->slot_exec.slot;
     if( ctx->execute_fun != NULL ) {

--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -1358,8 +1358,6 @@ fd_gui_handle_balance_update( fd_gui_t * gui,
 static void
 fd_gui_handle_start_progress( fd_gui_t *    gui,
                               uchar const * msg ) {
-  (void)gui;
-
   uchar type = msg[ 0 ];
 
   switch (type) {

--- a/src/disco/net/fd_net_tile.c
+++ b/src/disco/net/fd_net_tile.c
@@ -854,8 +854,6 @@ static void
 before_credit( fd_net_ctx_t *      ctx,
                fd_stem_context_t * stem,
                int *               charge_busy ) {
-  (void)stem;
-
   /* A previous send attempt was overrun.  A corrupt copy of the packet was
      placed into an XDP frame, but the frame was not yet submitted to the
      TX ring.  Return the tx buffer to the free list. */

--- a/src/disco/shred/fd_shred_cap.c
+++ b/src/disco/shred/fd_shred_cap.c
@@ -22,9 +22,9 @@
 /* } */
 
 int
-fd_shred_cap_archive( fd_shred_cap_ctx_t * ctx FD_PARAM_UNUSED,
+fd_shred_cap_archive( fd_shred_cap_ctx_t * ctx,
                       fd_shred_t const *   shred,
-                      uchar                flags  FD_PARAM_UNUSED) {
+                      uchar                flags ) {
   ulong  wsz;
   ulong  shred_len = fd_shred_sz( shred );
   ushort hdr_len = sizeof( fd_shred_cap_hdr_t );

--- a/src/disco/topo/fd_topo.c
+++ b/src/disco/topo/fd_topo.c
@@ -188,8 +188,6 @@ fd_topo_fill( fd_topo_t * topo ) {
 
 FD_FN_CONST static ulong
 fd_topo_tile_extra_huge_pages( fd_topo_tile_t const * tile ) {
-  (void)tile;
-
   /* Every tile maps an additional set of pages for the stack. */
   ulong extra_pages = (FD_TILE_PRIVATE_STACK_SZ/FD_SHMEM_HUGE_PAGE_SZ)+2UL;
 

--- a/src/flamenco/repair/fd_repair.c
+++ b/src/flamenco/repair/fd_repair.c
@@ -725,7 +725,6 @@ fd_repair_continue( fd_repair_t * glob ) {
 
 static void
 fd_repair_recv_ping(fd_repair_t * glob, fd_gossip_ping_t const * ping, fd_gossip_peer_addr_t const * from) {
-  (void)from;
   fd_repair_protocol_t protocol;
   fd_repair_protocol_new_disc(&protocol, fd_repair_protocol_enum_pong);
   fd_gossip_ping_t * pong = &protocol.inner.pong;

--- a/src/flamenco/runtime/fd_acc_mgr.c
+++ b/src/flamenco/runtime/fd_acc_mgr.c
@@ -363,7 +363,7 @@ typedef struct fd_acc_mgr_save_task_info fd_acc_mgr_save_task_info_t;
 static void
 fd_acc_mgr_save_task( void *tpool,
                       ulong t0 FD_PARAM_UNUSED, ulong t1 FD_PARAM_UNUSED,
-                      void *args FD_PARAM_UNUSED,
+                      void *args,
                       void *reduce FD_PARAM_UNUSED, ulong stride FD_PARAM_UNUSED,
                       ulong l0 FD_PARAM_UNUSED, ulong l1 FD_PARAM_UNUSED,
                       ulong m0, ulong m1 FD_PARAM_UNUSED,

--- a/src/flamenco/runtime/fd_hashes.c
+++ b/src/flamenco/runtime/fd_hashes.c
@@ -325,7 +325,7 @@ fd_account_hash_task( void *tpool,
                       void *reduce FD_PARAM_UNUSED, ulong stride FD_PARAM_UNUSED,
                       ulong l0 FD_PARAM_UNUSED, ulong l1 FD_PARAM_UNUSED,
                       ulong m0, ulong m1 FD_PARAM_UNUSED,
-                      ulong n0 FD_PARAM_UNUSED, ulong n1 FD_PARAM_UNUSED) {
+                      ulong n0, ulong n1 FD_PARAM_UNUSED) {
   fd_accounts_hash_task_info_t * task_info = ((fd_accounts_hash_task_data_t *)tpool)->info + m0;
   fd_exec_slot_ctx_t * slot_ctx = task_info->slot_ctx;
   int err = 0;

--- a/src/flamenco/runtime/program/fd_bpf_program_util.c
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.c
@@ -300,8 +300,8 @@ fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t *    slot_ctx,
 static void FD_FN_UNUSED
 fd_bpf_scan_task( void * tpool,
                   ulong t0 FD_PARAM_UNUSED, ulong t1 FD_PARAM_UNUSED,
-                  void * args FD_PARAM_UNUSED,
-                  void * reduce FD_PARAM_UNUSED, ulong stride FD_PARAM_UNUSED,
+                  void * args,
+                  void * reduce , ulong stride FD_PARAM_UNUSED,
                   ulong l0 FD_PARAM_UNUSED, ulong l1 FD_PARAM_UNUSED,
                   ulong m0, ulong m1 FD_PARAM_UNUSED,
                   ulong n0 FD_PARAM_UNUSED, ulong n1 FD_PARAM_UNUSED  ) {

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -1279,7 +1279,7 @@ fd_exec_txn_test_run( fd_exec_instr_test_runner_t * runner, // Runner only conta
 
 
 ulong
-fd_sbpf_program_load_test_run( FD_PARAM_UNUSED fd_exec_instr_test_runner_t * runner,
+fd_sbpf_program_load_test_run( fd_exec_instr_test_runner_t * runner,
                                void const *                  input_,
                                void **                       output_,
                                void *                        output_buf,

--- a/src/flamenco/snapshot/fd_snapshot_main.c
+++ b/src/flamenco/snapshot/fd_snapshot_main.c
@@ -122,9 +122,6 @@ static int
 fd_snapshot_dumper_on_manifest( void *                 _d,
                                 fd_solana_manifest_t * manifest,
                                 fd_spad_t *            spad ) {
-
-  (void)spad;
-
   fd_snapshot_dumper_t * d = _d;
   if( !d->want_manifest ) return 0;
   d->want_manifest = 0;
@@ -452,7 +449,7 @@ cmd_dump( int     argc,
   if( FD_UNLIKELY( !spad ) ) {
     FD_LOG_ERR(( "Failed to allocate spad" ));
   }
-  fd_spad_push( spad );  
+  fd_spad_push( spad );
 
   /* With dump context */
 

--- a/src/flamenco/types/fd_types_custom.h
+++ b/src/flamenco/types/fd_types_custom.h
@@ -121,7 +121,7 @@ static inline void
 fd_flamenco_txn_destroy( fd_flamenco_txn_t const * self FD_FN_UNUSED ) {}
 
 FD_FN_CONST static inline ulong
-fd_flamenco_txn_size( fd_flamenco_txn_t const * self FD_FN_UNUSED ) {
+fd_flamenco_txn_size( fd_flamenco_txn_t const * self) {
   return self->raw_sz;
 }
 

--- a/src/flamenco/vm/syscall/fd_vm_syscall_util.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_util.c
@@ -11,7 +11,7 @@
 #include "../../runtime/fd_account.h"
 
 int
-fd_vm_syscall_abort( FD_PARAM_UNUSED void *  _vm,
+fd_vm_syscall_abort( /**/            void *  _vm,
                      FD_PARAM_UNUSED ulong   r1,
                      FD_PARAM_UNUSED ulong   r2,
                      FD_PARAM_UNUSED ulong   r3,

--- a/src/funk/test_funk_file.cxx
+++ b/src/funk/test_funk_file.cxx
@@ -6,8 +6,6 @@ extern "C" {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
-  (void)argc;
-  (void)argv;
   srand(1234);
 
   fake_funk ff(&argc, &argv);

--- a/src/funk/test_funk_txn2.cxx
+++ b/src/funk/test_funk_txn2.cxx
@@ -2,8 +2,6 @@
 #include <stdio.h>
 
 int main(int argc, char** argv) {
-  (void)argc;
-  (void)argv;
   srand(1234);
 
   fake_funk ff(&argc, &argv);

--- a/src/funkier/test_funkier_file.cxx
+++ b/src/funkier/test_funkier_file.cxx
@@ -6,8 +6,6 @@ extern "C" {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
-  (void)argc;
-  (void)argv;
   srand(1234);
 
   fake_funk ff(&argc, &argv);

--- a/src/funkier/test_funkier_txn2.cxx
+++ b/src/funkier/test_funkier_txn2.cxx
@@ -2,8 +2,6 @@
 #include <stdio.h>
 
 int main(int argc, char** argv) {
-  (void)argc;
-  (void)argv;
   srand(1234);
 
   fake_funk ff(&argc, &argv);

--- a/src/util/tmpl/fd_dlist.c
+++ b/src/util/tmpl/fd_dlist.c
@@ -615,7 +615,7 @@ FD_FN_CONST static inline DLIST_ELE_T *
 DLIST_(iter_ele)( DLIST_(iter_t)    iter,
                   DLIST_(t) const * join,
                   DLIST_ELE_T *     pool ) {
-  (void)join; (void)pool;
+  (void)join;
   return pool + iter;
 }
 
@@ -623,7 +623,7 @@ FD_FN_CONST static inline DLIST_ELE_T const *
 DLIST_(iter_ele_const)( DLIST_(iter_t)      iter,
                         DLIST_(t) const *   join,
                         DLIST_ELE_T const * pool ) {
-  (void)join; (void)pool;
+  (void)join;
   return pool + iter;
 }
 

--- a/src/util/tmpl/fd_map_chain.c
+++ b/src/util/tmpl/fd_map_chain.c
@@ -561,7 +561,7 @@ FD_FN_CONST static inline MAP_ELE_T *
 MAP_(iter_ele)( MAP_(iter_t)    iter,
                 MAP_(t) const * join,
                 MAP_ELE_T *     pool ) {
-  (void)join; (void)pool;
+  (void)join;
   return pool + iter.ele_idx;
 }
 
@@ -569,7 +569,7 @@ FD_FN_CONST static inline MAP_ELE_T const *
 MAP_(iter_ele_const) ( MAP_(iter_t)      iter,
                        MAP_(t) const *   join,
                        MAP_ELE_T const * pool ) {
-  (void)join; (void)pool;
+  (void)join;
   return pool + iter.ele_idx;
 }
 

--- a/src/util/tpool/test_tpool.c
+++ b/src/util/tpool/test_tpool.c
@@ -21,7 +21,7 @@ tile_self_push_main( int     argc,
 static int
 tile_spin_main( int     argc,
                 char ** argv ) {
-  (void)argc; (void)argv;
+  (void)argc;
   ulong const * done = (ulong const *)argv;
   while( !FD_VOLATILE_CONST( *done ) ) FD_SPIN_PAUSE();
   return 0;

--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -1982,7 +1982,6 @@ ulong
 fd_quic_handle_v1_zero_rtt( fd_quic_t * quic, fd_quic_conn_t * conn, fd_quic_pkt_t const * pkt, uchar const * cur_ptr, ulong cur_sz ) {
   (void)pkt;
   (void)quic;
-  (void)conn;
   (void)cur_ptr;
   (void)cur_sz;
   /* since we do not support zero-rtt, simply fail the packet */
@@ -5134,7 +5133,6 @@ fd_quic_handle_reset_stream_frame(
     uchar const *                  p    FD_PARAM_UNUSED,
     ulong                          p_sz FD_PARAM_UNUSED ) {
   /* TODO implement */
-  (void)data;
   FD_DTRACE_PROBE_4( quic_handle_reset_stream_frame, context->conn->our_conn_id, data->stream_id, data->app_proto_err_code, data->final_size );
   return 0UL;
 }
@@ -5145,7 +5143,6 @@ fd_quic_handle_stop_sending_frame(
     fd_quic_stop_sending_frame_t * data,
     uchar const *                  p    FD_PARAM_UNUSED,
     ulong                          p_sz FD_PARAM_UNUSED ) {
-  (void)data;
   FD_DTRACE_PROBE_3( quic_handle_stop_sending_frame, context->conn->our_conn_id, data->stream_id, data->app_proto_err_code );
   return 0UL;
 }
@@ -5157,8 +5154,8 @@ fd_quic_handle_new_token_frame(
     uchar const *               p    FD_PARAM_UNUSED,
     ulong                       p_sz FD_PARAM_UNUSED ) {
   /* FIXME A server MUST treat receipt of a NEW_TOKEN frame as a connection error of type PROTOCOL_VIOLATION. */
-  FD_DTRACE_PROBE_1( quic_handle_new_token_frame, context->conn->our_conn_id );
   (void)data;
+  FD_DTRACE_PROBE_1( quic_handle_new_token_frame, context->conn->our_conn_id );
   return 0UL;
 }
 
@@ -5347,7 +5344,6 @@ fd_quic_handle_data_blocked_frame(
 
   /* Since we do not do runtime allocations, we will not attempt
      to find more memory in the case of DATA_BLOCKED. */
-  (void)data;
   return 0;
 }
 
@@ -5378,7 +5374,6 @@ fd_quic_handle_streams_blocked_frame(
      value
      We can support this in the future, but as of 2024-Dec, the
      Agave TPU client does not currently use it */
-  (void)data;
   return 0;
 }
 

--- a/src/waltz/quic/fd_quic_pcap_main.c
+++ b/src/waltz/quic/fd_quic_pcap_main.c
@@ -284,7 +284,6 @@ quic_pcap_iter_deliver_initial(
 ) {
   (void)iter;
   (void)ip4_saddr;
-  (void)out_pkt_sz;
 
   fd_quic_initial_t initial[1];
   ulong rc = fd_quic_decode_initial( initial, data, data_sz );

--- a/src/waltz/quic/tests/test_quic_client_flood.c
+++ b/src/waltz/quic/tests/test_quic_client_flood.c
@@ -43,7 +43,6 @@ void my_handshake_complete( fd_quic_conn_t * conn, void * vp_context ) {
 
 /* Connection closed */
 void my_connection_closed( fd_quic_conn_t * conn, void * vp_context ) {
-  (void)conn;
   (void)vp_context;
 
   FD_LOG_INFO(( "client conn closed (code=%u)", conn->reason ));

--- a/src/waltz/quic/tests/test_quic_idle_conns.c
+++ b/src/waltz/quic/tests/test_quic_idle_conns.c
@@ -35,7 +35,6 @@ cb_conn_new( fd_quic_conn_t  * conn,
 void
 cb_conn_handshake_complete( fd_quic_conn_t * conn,
                             void *           quic_ctx ) {
-  (void)conn;
   (void)quic_ctx;
 
   conn_meta_t * conn_meta = &g_conn_meta[conn->conn_idx];
@@ -49,7 +48,6 @@ cb_conn_handshake_complete( fd_quic_conn_t * conn,
 void
 cb_conn_final( fd_quic_conn_t * conn,
                void *           quic_ctx ) {
-  (void)conn;
   (void)quic_ctx;
 
   conn_meta_t * conn_meta = &g_conn_meta[conn->conn_idx];

--- a/src/waltz/quic/tests/test_quic_streams.c
+++ b/src/waltz/quic/tests/test_quic_streams.c
@@ -11,7 +11,7 @@ my_stream_rx_cb( fd_quic_conn_t * conn,
                  uchar const *    data,
                  ulong            data_sz,
                  int              fin ) {
-  (void)conn; (void)fin;
+  (void)conn;
 
   /* Derive expected payload */
 

--- a/src/waltz/quic/tests/test_quic_tls_hs.c
+++ b/src/waltz/quic/tests/test_quic_tls_hs.c
@@ -26,7 +26,6 @@ static void
 my_hs_complete( fd_quic_tls_hs_t *           hs,
                 void *                       context ) {
   (void)hs;
-  (void)context;
 
   FD_LOG_DEBUG(( "callback handshake complete" ));
 

--- a/src/waltz/quic/tests/test_quic_txns.c
+++ b/src/waltz/quic/tests/test_quic_txns.c
@@ -30,7 +30,6 @@ cb_conn_new( fd_quic_conn_t  * conn,
 void
 cb_conn_handshake_complete( fd_quic_conn_t * conn,
                             void *           quic_ctx ) {
-  (void)conn;
   (void)quic_ctx;
   FD_LOG_NOTICE(( "cb_conn_handshake_complete %lu", conn->tx_max_data ));
   g_handshake_complete = 1;
@@ -54,8 +53,6 @@ cb_stream_notify( fd_quic_stream_t * stream,
                   int                notify_type ) {
   (void)stream;
   (void)stream_ctx;
-
-  stream = NULL;
 
   if( notify_type == FD_QUIC_STREAM_NOTIFY_END ) {
     sent_cnt++;

--- a/src/waltz/tls/fd_tls.c
+++ b/src/waltz/tls/fd_tls.c
@@ -1252,8 +1252,6 @@ fd_tls_client_hs_wait_ee( fd_tls_t const *      const client,
                           ulong                 const record_sz,
                           uint                  const encryption_level ) {
 
-  (void)client;
-
   if( FD_UNLIKELY( encryption_level != FD_TLS_LEVEL_HANDSHAKE ) )
     return fd_tls_alert( &handshake->base, FD_TLS_ALERT_INTERNAL_ERROR, FD_TLS_REASON_WRONG_ENC_LVL );
 
@@ -1357,7 +1355,7 @@ fd_tls_client_handle_cert_req( fd_tls_estate_cli_t * const handshake,
 
   /* For now, just ignore the content of the certificate request.
      TODO: This is obviously not compliant. */
-  (void)req; (void)req_sz;
+  (void)req;
 
   handshake->client_cert = 1;
   handshake->base.state  = FD_TLS_HS_WAIT_CERT;


### PR DESCRIPTION
CodeQL query to detect such parameters + fix current offenses.
Afaik gcc/clang don't optimize based on parameters marked as unused, so this is not a bug fix, but just for the hygine of the codebase. We want to avoid a user of an API thinking: "oh, I can pass a wrong value for this argument, because it is unused anyway.", but it actually isn't.
