### PR TITLE
flamenco: slow path store fix

### DIFF
--- a/contrib/test/test-vectors-fixtures/vm-interp-fixtures/vm_interp-fixtures.list
+++ b/contrib/test/test-vectors-fixtures/vm-interp-fixtures/vm_interp-fixtures.list
@@ -17,3 +17,10 @@ dump/test-vectors/vm_interp/fixtures/latest/7e976da17999dbc45759de01d264afa802b3
 dump/test-vectors/vm_interp/fixtures/latest/d29abc7e8d7d355fe80f3eff3c9e6377bb29166d_333338.fix
 dump/test-vectors/vm_interp/fixtures/latest/d69d83c85eb43901e6e76077cc842604c52a8bb4_309007.fix
 dump/test-vectors/vm_interp/fixtures/latest/f0d189518d4ac5c5f85436ae05ef886e817ce8de_345393.fix
+dump/test-vectors/vm_interp/fixtures/latest/07ad4e69ed6182f4f9d276d3cb6b0042733730ff_2863395.fix
+dump/test-vectors/vm_interp/fixtures/latest/1ea5c8efad8d8b5f79b971e6cf9640a2510ae857_2921064.fix
+dump/test-vectors/vm_interp/fixtures/latest/54ac99800dfd4f3ff63128dc1af04aa8962e721b_2893118.fix
+dump/test-vectors/vm_interp/fixtures/latest/b4348a3757750a5cb2402b60bd5bef835defe8d6_2817811.fix
+dump/test-vectors/vm_interp/fixtures/latest/dd128dd420081b02aaf411b882848e8e5197039f_2878549.fix
+dump/test-vectors/vm_interp/fixtures/latest/e0d8da79888696b0e1a820c1a7e453169670123b_2839164.fix
+dump/test-vectors/vm_interp/fixtures/latest/f369fda1a7fa95147ac5c2fd1528cd5a20aa38cb_2907171.fix

--- a/src/flamenco/vm/fd_vm_interp_core.c
+++ b/src/flamenco/vm/fd_vm_interp_core.c
@@ -529,8 +529,17 @@ interp_exec:
     int   sigsegv         = !haddr;
     if( FD_UNLIKELY( sigsegv ) ) {
       vm->segv_store_vaddr = vaddr;
-      ushort val = (ushort)imm;
-      fd_vm_mem_st_try( vm, vaddr, sizeof(ushort), (uchar*)&val );
+
+      if( vm->direct_mapping ) {
+        /* Only execute slow path partial store when direct mapping is enabled.
+           Note that Agave implements direct mapping as an UnalignedMemoryMapping.
+           When account memory regions are not aligned, there are edge cases that require
+           the slow path partial store.
+           https://github.com/anza-xyz/sbpf/blob/410a627313124252ab1abbd3a3b686c03301bb2a/src/memory_region.rs#L388-L419 */
+        ushort val = (ushort)imm;
+        fd_vm_mem_st_try( vm, vaddr, sizeof(ushort), (uchar*)&val );
+      }
+
       goto sigsegv;
     } /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
     fd_vm_mem_st_2( vm, vaddr, haddr, (ushort)imm, is_multi_region );
@@ -558,8 +567,13 @@ interp_exec:
     int   sigsegv         = !haddr;
     if( FD_UNLIKELY( sigsegv ) ) {
       vm->segv_store_vaddr = vaddr;
-      ushort val = (ushort)reg_src;
-      fd_vm_mem_st_try( vm, vaddr, sizeof(ushort), (uchar*)&val );
+
+      if( vm->direct_mapping ) {
+        /* See FD_SBPF_OP_STH for details */
+        ushort val = (ushort)reg_src;
+        fd_vm_mem_st_try( vm, vaddr, sizeof(ushort), (uchar*)&val );
+      }
+
       goto sigsegv;
     } /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
     fd_vm_mem_st_2( vm, vaddr, haddr, (ushort)reg_src, is_multi_region );
@@ -816,8 +830,13 @@ interp_exec:
     int   sigsegv         = !haddr;
     if( FD_UNLIKELY( sigsegv ) ) {
       vm->segv_store_vaddr = vaddr;
-      uint val = (uint)imm;
-      fd_vm_mem_st_try( vm, vaddr, sizeof(uint), (uchar*)&val );
+
+      if( vm->direct_mapping ) {
+        /* See FD_SBPF_OP_STH for details */
+        uint val = (uint)imm;
+        fd_vm_mem_st_try( vm, vaddr, sizeof(uint), (uchar*)&val );
+      }
+
       goto sigsegv;
     } /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
     fd_vm_mem_st_4( vm, vaddr, haddr, imm, is_multi_region );
@@ -886,8 +905,13 @@ interp_exec:
     int   sigsegv         = !haddr;
     if( FD_UNLIKELY( sigsegv ) ) {
       vm->segv_store_vaddr = vaddr;
-      uint val = (uint)reg_src;
-      fd_vm_mem_st_try( vm, vaddr, sizeof(uint), (uchar*)&val );
+
+      if( vm->direct_mapping ) {
+        /* See FD_SBPF_OP_STH for details */
+        uint val = (uint)reg_src;
+        fd_vm_mem_st_try( vm, vaddr, sizeof(uint), (uchar*)&val );
+      }
+
       goto sigsegv;
     } /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
     fd_vm_mem_st_4( vm, vaddr, haddr, (uint)reg_src, is_multi_region );
@@ -926,8 +950,13 @@ interp_exec:
     int   sigsegv         = !haddr;
     if( FD_UNLIKELY( sigsegv ) ) {
       vm->segv_store_vaddr = vaddr;
-      ulong val = (ulong)(long)(int)imm;
-      fd_vm_mem_st_try( vm, vaddr, sizeof(ulong), (uchar*)&val );
+
+      if( vm->direct_mapping ) {
+        /* See FD_SBPF_OP_STH for details */
+        ulong val = (ulong)(long)(int)imm;
+        fd_vm_mem_st_try( vm, vaddr, sizeof(ulong), (uchar*)&val );
+      }
+
       goto sigsegv;
     } /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
     fd_vm_mem_st_8( vm, vaddr, haddr, (ulong)(long)(int)imm, is_multi_region );
@@ -970,8 +999,13 @@ interp_exec:
     ulong haddr           = fd_vm_mem_haddr( vm, vaddr, sizeof(ulong), region_haddr, region_st_sz, 1, 0UL, &is_multi_region );
     int   sigsegv         = !haddr;
     if( FD_UNLIKELY( sigsegv ) ) {
-      vm->segv_store_vaddr = vaddr;;
-      fd_vm_mem_st_try( vm, vaddr, sizeof(ulong), (uchar*)&reg_src );
+      vm->segv_store_vaddr = vaddr;
+
+      if( vm->direct_mapping ) {
+        /* See FD_SBPF_OP_STH for details */
+        fd_vm_mem_st_try( vm, vaddr, sizeof(ulong), (uchar*)&reg_src );
+      }
+
       goto sigsegv;
     } /* Note: untaken branches don't consume BTB */ /* FIXME: sigbus */
     fd_vm_mem_st_8( vm, vaddr, haddr, reg_src, is_multi_region );


### PR DESCRIPTION
Agave only executes the slow path partial store when the memory region is an `UnalignedMemoryRegion` AKA direct mapping.