### PR TITLE
pack: trim list of unwritable accounts

### DIFF
--- a/src/disco/pack/fd_pack.c
+++ b/src/disco/pack/fd_pack.c
@@ -251,9 +251,7 @@ typedef struct fd_pack_bitset_acct_mapping fd_pack_bitset_acct_mapping_t;
 #define MAP_PERFECT_23 ( KECCAK_SECP_PROG_ID      ),
 #define MAP_PERFECT_24 ( COMPUTE_BUDGET_PROG_ID   ),
 #define MAP_PERFECT_25 ( ADDR_LUT_PROG_ID         ),
-#define MAP_PERFECT_26 ( NATIVE_MINT_ID           ),
-#define MAP_PERFECT_27 ( TOKEN_PROG_ID            ),
-#define MAP_PERFECT_28 ( SECP256R1_PROG_ID        ),
+#define MAP_PERFECT_26 ( SECP256R1_PROG_ID        ),
 
 #include "../../util/tmpl/fd_map_perfect.c"
 

--- a/src/disco/pack/test_pack.c
+++ b/src/disco/pack/test_pack.c
@@ -1159,11 +1159,9 @@ test_reject_writes_to_sysvars( void ) {
     "KeccakSecp256k11111111111111111111111111111",
     "ComputeBudget111111111111111111111111111111",
     "AddressLookupTab1e1111111111111111111111111",
-    "So11111111111111111111111111111111111111112",
-    "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
     "Secp256r1SigVerify1111111111111111111111111"
   };
-  for( ulong i=0UL; i<29UL; i++ ) {
+  for( ulong i=0UL; i<27UL; i++ ) {
     make_transaction( i, 1000001U, 500U, 11.0, "A", "B", NULL, NULL );
     /* Replace A with the sysvar */
     fd_base58_decode_32( sysvars[ i ], payload_scratch[ i ] + 97UL );


### PR DESCRIPTION
The extras section is not consensus-critical, but was used for either accounts that seemed like they should be on the list or as a DoS-mitigation measure. Now that we have penalty treaps and CU pacing, the impact of a transaction write-locking one of these accounts is pretty minimal.