### PR TITLE
net 2.0: repair tile multihoming

### DIFF
--- a/src/app/fdctl/run/topos/fd_firedancer.c
+++ b/src/app/fdctl/run/topos/fd_firedancer.c
@@ -623,7 +623,6 @@ fd_topo_initialize( config_t * config ) {
     } else if( FD_UNLIKELY( !strcmp( tile->name, "repair" ) ) ) {
       tile->repair.repair_intake_listen_port =  config->tiles.repair.repair_intake_listen_port;
       tile->repair.repair_serve_listen_port =   config->tiles.repair.repair_serve_listen_port;
-      tile->repair.ip_addr = config->tiles.net.ip_addr;
       strncpy( tile->repair.good_peer_cache_file, config->tiles.repair.good_peer_cache_file, sizeof(tile->repair.good_peer_cache_file) );
 
       strncpy( tile->repair.identity_key_path, config->consensus.identity_path, sizeof(tile->repair.identity_key_path) );

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -344,7 +344,6 @@ typedef struct {
 
       /* non-config */
 
-      uint    ip_addr;
       int     good_peer_cache_file_fd;
       char    identity_key_path[ PATH_MAX ];
     } repair;

--- a/src/flamenco/repair/fd_repair.c
+++ b/src/flamenco/repair/fd_repair.c
@@ -451,7 +451,8 @@ fd_repair_sign_and_send( fd_repair_t *           glob,
   buflen += 64UL;
   fd_memcpy( buf + 4U, &sig, 64U );
 
-  (*glob->clnt_send_fun)( buf, buflen, addr, glob->fun_arg );
+  uint src_ip4_addr = 0U; /* unknown */
+  glob->clnt_send_fun( buf, buflen, addr, src_ip4_addr, glob->fun_arg );
 }
 
 static void
@@ -542,7 +543,7 @@ fd_repair_send_requests( fd_repair_t * glob ) {
       }
     }
 
-    fd_repair_sign_and_send(glob, &protocol, &active->addr);
+    fd_repair_sign_and_send( glob, &protocol, &active->addr );
 
   }
   glob->current_nonce = n;
@@ -720,7 +721,10 @@ fd_repair_continue( fd_repair_t * glob ) {
 }
 
 static void
-fd_repair_recv_ping(fd_repair_t * glob, fd_gossip_ping_t const * ping, fd_gossip_peer_addr_t const * from) {
+fd_repair_handle_ping( fd_repair_t *                 glob,
+                       fd_gossip_ping_t const *      ping,
+                       fd_gossip_peer_addr_t const * peer_addr,
+                       uint                          self_ip4_addr ) {
   fd_repair_protocol_t protocol;
   fd_repair_protocol_new_disc(&protocol, fd_repair_protocol_enum_pong);
   fd_gossip_ping_t * pong = &protocol.inner.pong;
@@ -745,11 +749,15 @@ fd_repair_recv_ping(fd_repair_t * glob, fd_gossip_ping_t const * ping, fd_gossip
   FD_TEST(0 == fd_repair_protocol_encode(&protocol, &ctx));
   ulong buflen = (ulong)((uchar*)ctx.data - buf);
 
-  (*glob->clnt_send_fun)(buf, buflen, from, glob->fun_arg);
+  glob->clnt_send_fun( buf, buflen, peer_addr, self_ip4_addr, glob->fun_arg );
 }
 
 int
-fd_repair_recv_clnt_packet(fd_repair_t * glob, uchar const * msg, ulong msglen, fd_gossip_peer_addr_t const * from) {
+fd_repair_recv_clnt_packet( fd_repair_t *                 glob,
+                            uchar const *                 msg,
+                            ulong                         msglen,
+                            fd_repair_peer_addr_t const * src_addr,
+                            uint                          dst_ip4_addr ) {
   fd_repair_lock( glob );
   FD_SCRATCH_SCOPE_BEGIN {
     while( 1 ) {
@@ -777,7 +785,7 @@ fd_repair_recv_clnt_packet(fd_repair_t * glob, uchar const * msg, ulong msglen, 
 
       switch( gmsg->discriminant ) {
       case fd_repair_response_enum_ping:
-        fd_repair_recv_ping( glob, &gmsg->inner.ping, from );
+        fd_repair_handle_ping( glob, &gmsg->inner.ping, src_addr, dst_ip4_addr );
         break;
       }
 
@@ -810,7 +818,7 @@ fd_repair_recv_clnt_packet(fd_repair_t * glob, uchar const * msg, ulong msglen, 
     if( shred == NULL ) {
       FD_LOG_WARNING(("invalid shread"));
     } else {
-      (*glob->deliver_fun)(shred, shredlen, from, &val->id, glob->fun_arg);
+      glob->deliver_fun(shred, shredlen, src_addr, &val->id, glob->fun_arg);
     }
   } FD_SCRATCH_SCOPE_END;
   return 0;
@@ -1207,7 +1215,10 @@ fd_repair_set_stake_weights( fd_repair_t * repair,
 }
 
 static void
-fd_repair_send_ping(fd_repair_t * glob, fd_gossip_peer_addr_t const * addr, fd_pinged_elem_t * val) {
+fd_repair_send_ping( fd_repair_t *                 glob,
+                     fd_gossip_peer_addr_t const * dst_addr,
+                     uint                          src_ip4_addr,
+                     fd_pinged_elem_t *            val ) {
   fd_repair_response_t gmsg;
   fd_repair_response_new_disc( &gmsg, fd_repair_response_enum_ping );
   fd_gossip_ping_t * ping = &gmsg.inner.ping;
@@ -1219,7 +1230,7 @@ fd_repair_send_ping(fd_repair_t * glob, fd_gossip_peer_addr_t const * addr, fd_p
 
   fd_sha256_hash( pre_image, FD_PING_PRE_IMAGE_SZ, &ping->token );
 
-  (*glob->sign_fun)( glob->sign_arg, ping->signature.uc, pre_image, FD_PING_PRE_IMAGE_SZ, FD_KEYGUARD_SIGN_TYPE_SHA256_ED25519 );
+  glob->sign_fun( glob->sign_arg, ping->signature.uc, pre_image, FD_PING_PRE_IMAGE_SZ, FD_KEYGUARD_SIGN_TYPE_SHA256_ED25519 );
 
   fd_bincode_encode_ctx_t ctx;
   uchar buf[1024];
@@ -1228,7 +1239,7 @@ fd_repair_send_ping(fd_repair_t * glob, fd_gossip_peer_addr_t const * addr, fd_p
   FD_TEST(0 == fd_repair_response_encode(&gmsg, &ctx));
   ulong buflen = (ulong)((uchar*)ctx.data - buf);
 
-  (*glob->serv_send_fun)(buf, buflen, addr, glob->fun_arg);
+  glob->serv_send_fun( buf, buflen, dst_addr, src_ip4_addr, glob->fun_arg );
 }
 
 static void
@@ -1266,7 +1277,11 @@ fd_repair_recv_pong(fd_repair_t * glob, fd_gossip_ping_t const * pong, fd_gossip
 }
 
 int
-fd_repair_recv_serv_packet(fd_repair_t * glob, uchar const * msg, ulong msglen, fd_gossip_peer_addr_t const * from) {
+fd_repair_recv_serv_packet( fd_repair_t *                 glob,
+                            uchar const *                 msg,
+                            ulong                         msglen,
+                            fd_repair_peer_addr_t const * peer_addr,
+                            uint                          self_ip4_addr ) {
   FD_SCRATCH_SCOPE_BEGIN {
     fd_bincode_decode_ctx_t ctx = {
       .data    = msg,
@@ -1295,7 +1310,7 @@ fd_repair_recv_serv_packet(fd_repair_t * glob, uchar const * msg, ulong msglen, 
     switch( protocol->discriminant ) {
       case fd_repair_protocol_enum_pong:
         fd_repair_lock( glob );
-        fd_repair_recv_pong( glob, &protocol->inner.pong, from );
+        fd_repair_recv_pong( glob, &protocol->inner.pong, peer_addr );
         fd_repair_unlock( glob );
         return 0;
       case fd_repair_protocol_enum_window_index: {
@@ -1340,7 +1355,7 @@ fd_repair_recv_serv_packet(fd_repair_t * glob, uchar const * msg, ulong msglen, 
 
     fd_repair_lock( glob );
 
-    fd_pinged_elem_t * val = fd_pinged_table_query(glob->pinged, from, NULL);
+    fd_pinged_elem_t * val = fd_pinged_table_query( glob->pinged, peer_addr, NULL) ;
     if( val == NULL || !val->good || !fd_hash_eq( &val->id, &header->sender ) ) {
       /* Need to ping this client */
       if( val == NULL ) {
@@ -1349,13 +1364,13 @@ fd_repair_recv_serv_packet(fd_repair_t * glob, uchar const * msg, ulong msglen, 
           fd_repair_unlock( glob );
           return 0;
         }
-        val = fd_pinged_table_insert(glob->pinged, from);
+        val = fd_pinged_table_insert( glob->pinged, peer_addr );
         for ( ulong i = 0; i < FD_HASH_FOOTPRINT / sizeof(ulong); i++ )
           val->token.ul[i] = fd_rng_ulong(glob->rng);
       }
       fd_hash_copy( &val->id, &header->sender );
       val->good = 0;
-      fd_repair_send_ping( glob, from, val );
+      fd_repair_send_ping( glob, peer_addr, self_ip4_addr, val );
 
     } else {
       uchar buf[FD_SHRED_MAX_SZ + sizeof(uint)];
@@ -1365,7 +1380,7 @@ fd_repair_recv_serv_packet(fd_repair_t * glob, uchar const * msg, ulong msglen, 
           long sz = (*glob->serv_get_shred_fun)( wi->slot, (uint)wi->shred_index, buf, FD_SHRED_MAX_SZ, glob->fun_arg );
           if( sz < 0 ) break;
           *(uint *)(buf + sz) = wi->header.nonce;
-          (*glob->serv_send_fun)( buf, (ulong)sz + sizeof(uint), from, glob->fun_arg );
+          glob->serv_send_fun( buf, (ulong)sz + sizeof(uint), peer_addr, self_ip4_addr, glob->fun_arg );
           break;
         }
 
@@ -1374,7 +1389,7 @@ fd_repair_recv_serv_packet(fd_repair_t * glob, uchar const * msg, ulong msglen, 
           long sz = (*glob->serv_get_shred_fun)( wi->slot, UINT_MAX, buf, FD_SHRED_MAX_SZ, glob->fun_arg );
           if( sz < 0 ) break;
           *(uint *)(buf + sz) = wi->header.nonce;
-          (*glob->serv_send_fun)( buf, (ulong)sz + sizeof(uint), from, glob->fun_arg );
+          glob->serv_send_fun( buf, (ulong)sz + sizeof(uint), peer_addr, self_ip4_addr, glob->fun_arg );
           break;
         }
 
@@ -1388,7 +1403,7 @@ fd_repair_recv_serv_packet(fd_repair_t * glob, uchar const * msg, ulong msglen, 
             long sz = (*glob->serv_get_shred_fun)( slot, UINT_MAX, buf, FD_SHRED_MAX_SZ, glob->fun_arg );
             if( sz < 0 ) continue;
             *(uint *)(buf + sz) = wi->header.nonce;
-            (*glob->serv_send_fun)( buf, (ulong)sz + sizeof(uint), from, glob->fun_arg );
+            glob->serv_send_fun( buf, (ulong)sz + sizeof(uint), peer_addr, self_ip4_addr, glob->fun_arg );
           }
           break;
         }

--- a/src/flamenco/repair/fd_repair.h
+++ b/src/flamenco/repair/fd_repair.h
@@ -37,7 +37,7 @@ typedef long (*fd_repair_serv_get_shred_fun)( ulong slot, uint shred_idx, void *
 typedef ulong (*fd_repair_serv_get_parent_fun)( ulong slot, void * arg );
 
 /* Callback for sending a packet. addr is the address of the destination. */
-typedef void (*fd_repair_send_packet_fun)( uchar const * msg, size_t msglen, fd_repair_peer_addr_t const * addr, void * arg );
+typedef void (*fd_repair_send_packet_fun)( uchar const * msg, size_t msglen, fd_repair_peer_addr_t const * dst_addr, uint src_ip4_addr, void * arg );
 
 /* Callback signing */
 typedef void (*fd_repair_sign_fun)( void * ctx, uchar * sig, uchar const * buffer, ulong len, int sign_type );
@@ -86,10 +86,22 @@ int fd_repair_start( fd_repair_t * glob );
 int fd_repair_continue( fd_repair_t * glob );
 
 /* Pass a raw client response packet into the protocol. addr is the address of the sender */
-int fd_repair_recv_clnt_packet( fd_repair_t * glob, uchar const * msg, ulong msglen, fd_repair_peer_addr_t const * addr );
+int
+fd_repair_recv_clnt_packet( fd_repair_t *                 glob,
+                            uchar const *                 msg,
+                            ulong                         msglen,
+                            fd_repair_peer_addr_t const * src_addr,
+                            uint                          dst_ip4_addr );
 
-/* Pass a raw service request packet into the protocol. addr is the address of the sender */
-int fd_repair_recv_serv_packet( fd_repair_t * glob, uchar const * msg, ulong msglen, fd_repair_peer_addr_t const * addr );
+/* Pass a raw service request packet into the protocol.
+   src_addr is the address of the sender
+   dst_ip4_addr is the dst IPv4 address of the incoming packet (i.e. our IP) */
+int
+fd_repair_recv_serv_packet( fd_repair_t *                 glob,
+                            uchar const *                 msg,
+                            ulong                         msglen,
+                            fd_repair_peer_addr_t const * src_addr,
+                            uint                          dst_ip4_addr );
 
 /* Determine if the request queue is full */
 int fd_repair_is_full( fd_repair_t * glob );

--- a/src/flamenco/repair/fd_repair_tool.c
+++ b/src/flamenco/repair/fd_repair_tool.c
@@ -55,9 +55,12 @@ repair_from_sockaddr( fd_repair_peer_addr_t * dst, uchar const * src ) {
 }
 
 static void
-send_packet( uchar const * data, size_t sz, fd_repair_peer_addr_t const * addr, void * arg ) {
+send_packet( uchar const * data,
+             size_t        sz,
+             fd_repair_peer_addr_t const * addr,
+             uint          src_ip4_addr FD_PARAM_UNUSED,
+             void *        arg FD_PARAM_UNUSED ) {
   // FD_LOG_HEXDUMP_NOTICE(("send: ", data, sz));
-  (void)arg;
   uchar saddr[sizeof(struct sockaddr_in)];
   int saddrlen = repair_to_sockaddr(saddr, addr);
   if ( sendto(sockfd, data, sz, MSG_DONTWAIT,
@@ -220,7 +223,7 @@ main_loop( int * argc, char *** argv, fd_repair_t * glob, fd_repair_config_t * c
       fd_repair_peer_addr_t from;
       repair_from_sockaddr( &from, msgs[i].msg_hdr.msg_name );
       FD_LOG_HEXDUMP_NOTICE(("recv: ", bufs[i], (ulong)msgs[i].msg_len));
-      fd_repair_recv_clnt_packet(glob, bufs[i], (ulong)msgs[i].msg_len, &from);
+      fd_repair_recv_clnt_packet( glob, bufs[i], (ulong)msgs[i].msg_len, &from, 0 );
     }
   }
 


### PR DESCRIPTION
- When directly replying to a packet, set src addr of reply to dst addr of request
- When initiating a request async, rely on layer 3 src selection
