### PR TITLE
net 2.0: shred tile multihoming

### DIFF
--- a/src/app/fdctl/run/topos/fd_firedancer.c
+++ b/src/app/fdctl/run/topos/fd_firedancer.c
@@ -581,7 +581,6 @@ fd_topo_initialize( config_t * config ) {
       strncpy( tile->shred.identity_key_path, config->consensus.identity_path, sizeof(tile->shred.identity_key_path) );
 
       tile->shred.depth                         = topo->links[ tile->out_link_id[ 0 ] ].depth;
-      tile->shred.ip_addr                       = config->tiles.net.ip_addr;
       tile->shred.fec_resolver_depth            = config->tiles.shred.max_pending_shred_sets;
       tile->shred.expected_shred_version        = config->consensus.expected_shred_version;
       tile->shred.shred_listen_port             = config->tiles.shred.shred_listen_port;

--- a/src/app/fdctl/run/topos/fd_frankendancer.c
+++ b/src/app/fdctl/run/topos/fd_frankendancer.c
@@ -423,7 +423,6 @@ fd_topo_initialize( config_t * config ) {
       strncpy( tile->shred.identity_key_path, config->consensus.identity_path, sizeof(tile->shred.identity_key_path) );
 
       tile->shred.depth                         = topo->links[ tile->out_link_id[ 0 ] ].depth;
-      tile->shred.ip_addr                       = config->tiles.net.ip_addr;
       tile->shred.fec_resolver_depth            = config->tiles.shred.max_pending_shred_sets;
       tile->shred.expected_shred_version        = config->consensus.expected_shred_version;
       tile->shred.shred_listen_port             = config->tiles.shred.shred_listen_port;

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -217,7 +217,6 @@ typedef struct {
 
     struct {
       ulong  depth;
-      uint   ip_addr;
       ulong  fec_resolver_depth;
       char   identity_key_path[ PATH_MAX ];
       ushort shred_listen_port;


### PR DESCRIPTION
Always set src IP address of outgoing shred packets to 0,
delegating src addr selection to layer 3.
