### PR TITLE
Fix IP header handling in gossip and repair

### DIFF
--- a/src/discof/repair/fd_repair_tile.c
+++ b/src/discof/repair/fd_repair_tile.c
@@ -152,21 +152,20 @@ send_packet( fd_repair_tile_ctx_t * ctx,
   fd_memcpy( packet, ( is_intake ? ctx->intake_hdr : ctx->serve_hdr ), sizeof(fd_net_hdrs_t) );
   fd_net_hdrs_t * hdr = (fd_net_hdrs_t *)packet;
 
-  hdr->udp->net_dport = dst_port;
-
-  hdr->ip4->saddr = src_ip_addr;
-  hdr->ip4->daddr = dst_ip_addr;
-  hdr->ip4->net_id = fd_ushort_bswap( ctx->net_id++ );
-  hdr->ip4->check  = 0U;
-  hdr->ip4->net_tot_len  = fd_ushort_bswap( (ushort)(payload_sz + sizeof(fd_ip4_hdr_t)+sizeof(fd_udp_hdr_t)) );
-  hdr->ip4->check  = fd_ip4_hdr_check_fast( ( fd_ip4_hdr_t const *)FD_ADDRESS_OF_PACKED_MEMBER( hdr->ip4 ) );
+  hdr->ip4->saddr       = src_ip_addr;
+  hdr->ip4->daddr       = dst_ip_addr;
+  hdr->ip4->net_id      = fd_ushort_bswap( ctx->net_id++ );
+  hdr->ip4->check       = 0U;
+  hdr->ip4->net_tot_len = fd_ushort_bswap( (ushort)(payload_sz + sizeof(fd_ip4_hdr_t)+sizeof(fd_udp_hdr_t)) );
+  hdr->ip4->check       = fd_ip4_hdr_check_fast( hdr->buf+14 );
 
   ulong packet_sz = payload_sz + sizeof(fd_net_hdrs_t);
   fd_memcpy( packet+sizeof(fd_net_hdrs_t), payload, payload_sz );
-  hdr->udp->net_len   = fd_ushort_bswap( (ushort)(payload_sz + sizeof(fd_udp_hdr_t)) );
-  hdr->udp->check = fd_ip4_udp_check( *(uint *)FD_ADDRESS_OF_PACKED_MEMBER( hdr->ip4->saddr_c ),
-                                      *(uint *)FD_ADDRESS_OF_PACKED_MEMBER( hdr->ip4->daddr_c ),
-                                      (fd_udp_hdr_t const *)FD_ADDRESS_OF_PACKED_MEMBER( hdr->udp ),
+  hdr->udp->net_dport = dst_port;
+  hdr->udp->net_len = fd_ushort_bswap( (ushort)(payload_sz + sizeof(fd_udp_hdr_t)) );
+  hdr->udp->check = fd_ip4_udp_check( hdr->ip4->saddr,
+                                      hdr->ip4->daddr,
+                                      (fd_udp_hdr_t const *)hdr->buf + 34,
                                       packet + sizeof(fd_net_hdrs_t) );
 
   ulong tspub = fd_frag_meta_ts_comp( fd_tickcount() );
@@ -380,20 +379,24 @@ after_frag( fd_repair_tile_ctx_t * ctx,
 
   ctx->stem = stem;
   ulong hdr_sz = fd_disco_netmux_sig_hdr_sz( sig );
-  fd_net_hdrs_t * hdr = (fd_net_hdrs_t *)ctx->buffer;
+  fd_eth_hdr_t const * eth = (fd_eth_hdr_t const *)ctx->buffer;
+  fd_ip4_hdr_t const * ip4 = (fd_ip4_hdr_t const *)( eth+1 );
+  fd_udp_hdr_t const * udp = (fd_udp_hdr_t const *)( (ulong)ip4 + FD_IP4_GET_LEN( *ip4 ) );
+  if( FD_UNLIKELY( (ulong)(udp+1) > (ulong)eth+sz ) ) return;
 
   fd_repair_peer_addr_t peer_addr;
-  peer_addr.l = 0;
-  peer_addr.addr = hdr->ip4->saddr;
-  peer_addr.port = hdr->udp->net_sport; /* FIXME IP OPTIONS HANDLING */
+  peer_addr.l    = 0;
+  peer_addr.addr = ip4->saddr;
+  peer_addr.port = udp->net_sport;
 
-  ushort dport = hdr->udp->net_dport;
-  if( ctx->repair_intake_addr.port == dport )
-    fd_repair_recv_clnt_packet( ctx->repair, ctx->buffer + hdr_sz, sz - hdr_sz, &peer_addr, hdr->ip4->daddr );
-  else if( ctx->repair_serve_addr.port == dport )
-    fd_repair_recv_serv_packet( ctx->repair, ctx->buffer + hdr_sz, sz - hdr_sz, &peer_addr, hdr->ip4->daddr );
-  else
-    FD_LOG_WARNING(( "received packet for port %u, which seems wrong", (uint)fd_ushort_bswap( dport ) ));
+  ushort dport = udp->net_dport;
+  if( ctx->repair_intake_addr.port == dport ) {
+    fd_repair_recv_clnt_packet( ctx->repair, ctx->buffer + hdr_sz, sz - hdr_sz, &peer_addr, ip4->daddr );
+  } else if( ctx->repair_serve_addr.port == dport ) {
+    fd_repair_recv_serv_packet( ctx->repair, ctx->buffer + hdr_sz, sz - hdr_sz, &peer_addr, ip4->daddr );
+  } else {
+    FD_LOG_ERR(( "Unexpectedly received packet for port %u", (uint)fd_ushort_bswap( dport ) ));
+  }
 }
 
 static inline void
@@ -474,7 +477,7 @@ privileged_init( fd_topo_t *      topo,
 
   tile->repair.good_peer_cache_file_fd = open( tile->repair.good_peer_cache_file, O_RDWR | O_CREAT, 0644 );
   if( FD_UNLIKELY( tile->repair.good_peer_cache_file_fd==-1 ) ) {
-    FD_LOG_WARNING(( "Failed to open the good peer cache file (%i-%s)", errno, fd_io_strerror( errno ) ));
+    FD_LOG_WARNING(( "Failed to open the good peer cache file (%s) (%i-%s)", tile->repair.good_peer_cache_file, errno, fd_io_strerror( errno ) ));
   }
   ctx->repair_config.good_peer_cache_file_fd = tile->repair.good_peer_cache_file_fd;
 

--- a/src/util/net/fd_net_headers.h
+++ b/src/util/net/fd_net_headers.h
@@ -4,10 +4,13 @@
 #include "fd_udp.h"
 #include "fd_eth.h"
 
-typedef struct __attribute__((packed)) {
-  fd_eth_hdr_t eth[1];
-  fd_ip4_hdr_t ip4[1];
-  fd_udp_hdr_t udp[1];
+typedef union {
+  struct __attribute__((packed)) {
+    fd_eth_hdr_t eth[1];
+    fd_ip4_hdr_t ip4[1];
+    fd_udp_hdr_t udp[1];
+  };
+  uchar buf[ 42 ];
 } fd_net_hdrs_t;
 
 FD_PROTOTYPES_BEGIN


### PR DESCRIPTION
- Use IHL=5 optimized IPv4 checksum calculation when sending
- Fix support for incoming packets with IP options

Closes #4462