### PR TITLE
txncache: improvements

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,7 @@
 /src/ballet/txn/fd_txn_parse.c @ptaffet-jump
 /src/disco/pack @ptaffet-jump @mmcgee-jump
 /src/disco/shred @ptaffet-jump @mmcgee-jump
+/src/flamenco/runtime/fd_txncache.c @mmcgee-jump @yufeng-jump
 /src/waltz/quic @nbridge-jump @ripatel-fd @akhinvasara-jumptrading
 /src/waltz/tls @ripatel-fd @mmcgee-jump
 /src/waltz/xdp @ripatel-fd @mmcgee-jump

--- a/src/app/firedancer-dev/commands/backtest.c
+++ b/src/app/firedancer-dev/commands/backtest.c
@@ -46,14 +46,12 @@ setup_topo_txncache( fd_topo_t *  topo,
                     char const * wksp_name,
                     ulong        max_rooted_slots,
                     ulong        max_live_slots,
-                    ulong        max_txn_per_slot,
-                    ulong        max_constipated_slots ) {
+                    ulong        max_txn_per_slot ) {
   fd_topo_obj_t * obj = fd_topob_obj( topo, "txncache", wksp_name );
 
   FD_TEST( fd_pod_insertf_ulong( topo->props, max_rooted_slots, "obj.%lu.max_rooted_slots", obj->id ) );
   FD_TEST( fd_pod_insertf_ulong( topo->props, max_live_slots,   "obj.%lu.max_live_slots",   obj->id ) );
   FD_TEST( fd_pod_insertf_ulong( topo->props, max_txn_per_slot, "obj.%lu.max_txn_per_slot", obj->id ) );
-  FD_TEST( fd_pod_insertf_ulong( topo->props, max_constipated_slots, "obj.%lu.max_constipated_slots", obj->id ) );
 
   return obj;
 }
@@ -408,10 +406,9 @@ backtest_topo( config_t * config ) {
   fd_topob_wksp( topo, "bank_busy"   );
   fd_topob_wksp( topo, "constipate"  );
   fd_topo_obj_t * txncache_obj = setup_topo_txncache( topo, "tcache",
-      config->firedancer.runtime.limits.max_rooted_slots,
-      config->firedancer.runtime.limits.max_live_slots,
-      config->firedancer.runtime.limits.max_transactions_per_slot,
-      fd_txncache_max_constipated_slots_est( config->firedancer.runtime.limits.snapshot_grace_period_seconds ) );
+      config->firedancer.runtime.limits.txncache.max_rooted_slots,
+      config->firedancer.runtime.limits.txncache.max_live_slots,
+      config->firedancer.runtime.limits.txncache.max_txn_per_slot );
   fd_topob_tile_uses( topo, replay_tile, txncache_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   FD_TEST( fd_pod_insertf_ulong( topo->props, txncache_obj->id, "txncache" ) );
   for( ulong i=0UL; i<bank_tile_cnt; i++ ) {

--- a/src/app/firedancer-dev/commands/sim.c
+++ b/src/app/firedancer-dev/commands/sim.c
@@ -36,14 +36,12 @@ setup_topo_txncache( fd_topo_t *  topo,
                      char const * wksp_name,
                      ulong        max_rooted_slots,
                      ulong        max_live_slots,
-                     ulong        max_txn_per_slot,
-                     ulong        max_constipated_slots ) {
+                     ulong        max_txn_per_slot ) {
   fd_topo_obj_t * obj = fd_topob_obj( topo, "txncache", wksp_name );
 
   FD_TEST( fd_pod_insertf_ulong( topo->props, max_rooted_slots, "obj.%lu.max_rooted_slots", obj->id ) );
   FD_TEST( fd_pod_insertf_ulong( topo->props, max_live_slots,   "obj.%lu.max_live_slots",   obj->id ) );
   FD_TEST( fd_pod_insertf_ulong( topo->props, max_txn_per_slot, "obj.%lu.max_txn_per_slot", obj->id ) );
-  FD_TEST( fd_pod_insertf_ulong( topo->props, max_constipated_slots, "obj.%lu.max_constipated_slots", obj->id ) );
 
   return obj;
 }
@@ -265,10 +263,9 @@ sim_topo( config_t * config ) {
   fd_topo_obj_t * root_slot_obj = fd_topob_obj( topo, "fseq", "root_slot" );
   fd_topo_obj_t * runtime_pub_obj = setup_topo_runtime_pub( topo, "runtime_pub", config->firedancer.runtime.heap_size_gib<<30 );
   fd_topo_obj_t * txncache_obj = setup_topo_txncache( topo, "tcache",
-      config->firedancer.runtime.limits.max_rooted_slots,
-      config->firedancer.runtime.limits.max_live_slots,
-      config->firedancer.runtime.limits.max_transactions_per_slot,
-      fd_txncache_max_constipated_slots_est( config->firedancer.runtime.limits.snapshot_grace_period_seconds ) );
+      config->firedancer.runtime.limits.txncache.max_rooted_slots,
+      config->firedancer.runtime.limits.txncache.max_live_slots,
+      config->firedancer.runtime.limits.txncache.max_txn_per_slot );
   fd_topo_obj_t * poh_slot_obj = fd_topob_obj( topo, "fseq", "poh_slot" );
   fd_topo_obj_t * constipated_obj = fd_topob_obj( topo, "fseq", "constipate" );
   FD_TEST( fd_pod_insertf_ulong( topo->props, blockstore_obj->id, "blockstore" ) );

--- a/src/app/firedancer-dev/config/tiny.toml
+++ b/src/app/firedancer-dev/config/tiny.toml
@@ -5,9 +5,12 @@ max_page_size = "huge"
 heap_size_gib = 4
 
 [runtime.limits]
-max_live_slots = 512
-snapshot_grace_period_seconds = 15
 max_vote_accounts = 32
+
+[runtime.limits.txncache]
+max_live_slots = 512
+max_txn_per_slot = 8192
+max_txn_per_slot_override = true
 
 [layout]
 verify_tile_count = 1

--- a/src/app/firedancer/callbacks.c
+++ b/src/app/firedancer/callbacks.c
@@ -90,7 +90,7 @@ fd_topo_obj_callbacks_t fd_obj_cb_fec_sets = {
 static ulong
 txncache_footprint( fd_topo_t const *     topo,
                     fd_topo_obj_t const * obj ) {
-  return fd_txncache_footprint( VAL("max_rooted_slots"), VAL("max_live_slots"), VAL("max_txn_per_slot"), VAL("max_constipated_slots") );
+  return fd_txncache_footprint( VAL("max_rooted_slots"), VAL("max_live_slots"), VAL("max_txn_per_slot") );
 }
 
 static ulong
@@ -102,7 +102,7 @@ txncache_align( fd_topo_t const *     topo FD_FN_UNUSED,
 static void
 txncache_new( fd_topo_t const *     topo,
               fd_topo_obj_t const * obj ) {
-  FD_TEST( fd_txncache_new( fd_topo_obj_laddr( topo, obj->id ), VAL("max_rooted_slots"), VAL("max_live_slots"), VAL("max_txn_per_slot"), VAL("max_constipated_slots") ) );
+  FD_TEST( fd_txncache_new( fd_topo_obj_laddr( topo, obj->id ), VAL("max_rooted_slots"), VAL("max_live_slots"), VAL("max_txn_per_slot") ) );
 }
 
 fd_topo_obj_callbacks_t fd_obj_cb_txncache = {

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -287,11 +287,68 @@ user = ""
     heap_size_gib = 50
 
     [runtime.limits]
-        max_rooted_slots = 300
-        max_live_slots = 2048
-        max_transactions_per_slot = 65536
-        snapshot_grace_period_seconds = 409
         max_vote_accounts = 2000000
+
+        # The txncache stores transactions that have been executed in
+        # the recent past.  It is the equivalent of Agave's status
+        # cache.  It is used for detecting and dropping transactions
+        # that have been executed in the recent past, and that somehow
+        # made their way into the execution pipeline.  Therefore, the
+        # txncache plays an important role in preventing replay attacks.
+        # To support highly concurrent execution, the txncache has been
+        # designed to be largely lockfree.  Moreover, the txncache is
+        # fork-aware, meaning that the same transaction is allowed to
+        # appear multiple times in the txncache, so long as the
+        # transaction has been executed on different forks.
+        [runtime.limits.txncache]
+            # The number of rooted slots to keep around in the txncache.
+            #
+            # This needs to be at least 151, since 151 most recent
+            # blockhashes are valid for use in transactions.  Any value
+            # less than 151 will cause the txncache, and hence the
+            # validator, to fail to start.
+            #
+            # By default, we keep around up to 300 rooted slots, which
+            # allows for about 2 minutes of history to be queried.
+            #
+            # Lowering this value will reduce the memory footprint
+            # imposed by the txncache.  However, it is not recommended
+            # to set this lower, unless the validator is in dire need of
+            # memory.
+            max_rooted_slots = 300
+
+            # The number of live slots to keep around in the txncache.
+            #
+            # By default, this is 4096 slots, which is about half an
+            # hour.  The network would have to go that long without
+            # rooting a slot to cause the txncache to run out of live
+            # slots, and hence crash.
+            #
+            # This needs to be at least as large as max_rooted_slots.
+            # Ideally a fair bit larger than max_rooted_slots to
+            # accommodate a sufficient number of slots that are not
+            # rooted.
+            #
+            # Lowering this value will reduce the memory footprint
+            # imposed by the txncache.  However, it is not recommended
+            # to set this lower than the default, unless the validator
+            # is in dire need of memory.
+            max_live_slots = 4096
+
+            # The maximum number of transactions per slot to provision
+            # in the txncache.
+            #
+            # A value of 0 instructs the txncache to automatically set a
+            # sensible value for this based on current mainnet
+            # conditions.  There's typically no reason to set this
+            # higher except for benchmarking.
+            #
+            # By default, the validator will fail to start if this is
+            # set to lower than what's necessary for current mainnet
+            # conditions.  To override this check for benchmarking
+            # purposes, set max_txn_per_slot_override to true.
+            max_txn_per_slot = 0
+            max_txn_per_slot_override = false
 
 # CPU cores in Firedancer are carefully managed.  Where a typical
 # program lets the operating system scheduler determine which threads to

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -107,11 +107,13 @@ struct fd_configf {
     ulong heap_size_gib;
 
     struct {
-      ulong max_rooted_slots;
-      ulong max_live_slots;
-      ulong max_transactions_per_slot;
-      ulong snapshot_grace_period_seconds;
       ulong max_vote_accounts;
+      struct {
+        ulong max_rooted_slots;
+        ulong max_live_slots;
+        ulong max_txn_per_slot;
+        int   max_txn_per_slot_override;
+      } txncache;
     } limits;
   } runtime;
 

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -90,10 +90,10 @@ fd_config_extract_podf( uchar *        pod,
 
   CFG_POP      ( ulong,  runtime.heap_size_gib                            );
 
-  CFG_POP      ( ulong,  runtime.limits.max_rooted_slots                  );
-  CFG_POP      ( ulong,  runtime.limits.max_live_slots                    );
-  CFG_POP      ( ulong,  runtime.limits.max_transactions_per_slot         );
-  CFG_POP      ( ulong,  runtime.limits.snapshot_grace_period_seconds     );
+  CFG_POP      ( ulong,  runtime.limits.txncache.max_rooted_slots         );
+  CFG_POP      ( ulong,  runtime.limits.txncache.max_live_slots           );
+  CFG_POP      ( ulong,  runtime.limits.txncache.max_txn_per_slot         );
+  CFG_POP      ( bool,   runtime.limits.txncache.max_txn_per_slot_override);
   CFG_POP      ( ulong,  runtime.limits.max_vote_accounts                 );
 
   return config;

--- a/src/discof/batch/fd_batch_tile.c
+++ b/src/discof/batch/fd_batch_tile.c
@@ -3,7 +3,6 @@
 #include "../../funk/fd_funk.h"
 #include "../../funk/fd_funk_filemap.h"
 #include "../../flamenco/runtime/fd_hashes.h"
-#include "../../flamenco/runtime/fd_txncache.h"
 #include "../../flamenco/snapshot/fd_snapshot_create.h"
 #include "../../flamenco/runtime/fd_runtime.h"
 #include "../../flamenco/runtime/fd_runtime_public.h"
@@ -26,7 +25,6 @@ struct fd_snapshot_tile_ctx {
   char            funk_file[ PATH_MAX ];
 
   /* Shared data structures. */
-  fd_txncache_t * status_cache;
   ulong         * is_constipated;
   fd_funk_t       funk[1];
 
@@ -178,20 +176,6 @@ unprivileged_init( fd_topo_t      * topo,
   memcpy( ctx->funk_file, tile->replay.funk_file, sizeof(tile->replay.funk_file) );
 
   /**********************************************************************/
-  /* status cache                                                       */
-  /**********************************************************************/
-
-  ulong status_cache_obj_id = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "txncache" );
-  if( FD_UNLIKELY( status_cache_obj_id==ULONG_MAX ) ) {
-    FD_LOG_ERR(( "no status cache object id" ));
-  }
-
-  ctx->status_cache = fd_txncache_join( fd_topo_obj_laddr( topo, status_cache_obj_id ) );
-  if( FD_UNLIKELY( !ctx->status_cache ) ) {
-    FD_LOG_ERR(( "no status cache" ));
-  }
-
-  /**********************************************************************/
   /* constipated fseq                                                   */
   /**********************************************************************/
 
@@ -259,7 +243,6 @@ produce_snapshot( fd_snapshot_tile_ctx_t * ctx, ulong batch_fseq ) {
     .out_dir                  = ctx->out_dir,
     .is_incremental           = (uchar)is_incremental,
     .funk                     = ctx->funk,
-    .status_cache             = ctx->status_cache,
     .tmp_fd                   = is_incremental ? ctx->tmp_inc_fd              : ctx->tmp_fd,
     .snapshot_fd              = is_incremental ? ctx->incremental_snapshot_fd : ctx->full_snapshot_fd,
     /* These parameters are ignored if the snapshot is not incremental. */

--- a/src/discof/exec/fd_exec_tile.c
+++ b/src/discof/exec/fd_exec_tile.c
@@ -651,11 +651,6 @@ unprivileged_init( fd_topo_t *      topo,
 
   FD_LOG_DEBUG(( "Just joined funk at file=%s", tile->exec.funk_file ));
 
-  //FIXME
-  /********************************************************************/
-  /* setup txncache                                                   */
-  /********************************************************************/
-
   /********************************************************************/
   /* setup txn ctx                                                    */
   /********************************************************************/
@@ -669,6 +664,22 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->txn_ctx->runtime_pub_wksp = ctx->runtime_public_wksp;
   if( FD_UNLIKELY( !ctx->txn_ctx->runtime_pub_wksp ) ) {
     FD_LOG_ERR(( "Failed to find public wksp" ));
+  }
+
+  /********************************************************************/
+  /* setup txncache                                                   */
+  /********************************************************************/
+  ulong txncache_id = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "txncache" );
+  if( FD_UNLIKELY( txncache_id == ULONG_MAX ) ) {
+    FD_LOG_CRIT(( "could not find txncache obj" ));
+  }
+  void * txncache_mem = fd_topo_obj_laddr( topo, txncache_id );
+  if( FD_UNLIKELY( txncache_mem == NULL ) ) {
+    FD_LOG_CRIT(( "could not find txncache mem" ));
+  }
+  ctx->txn_ctx->txncache = fd_txncache_join( txncache_mem );
+  if (ctx->txn_ctx->txncache == NULL) {
+    FD_LOG_CRIT(( "failed to join txncache" ));
   }
 
   /********************************************************************/

--- a/src/flamenco/fd_rwlock.h
+++ b/src/flamenco/fd_rwlock.h
@@ -37,6 +37,12 @@ fd_rwlock_unwrite( fd_rwlock_t * lock ) {
   lock->value = 0;
 }
 
+static inline int
+fd_rwlock_iswrite( fd_rwlock_t * lock ) {
+  return FD_VOLATILE_CONST(lock->value) == 0xFFFF;
+}
+
+/* Can be recursed. */
 static inline void
 fd_rwlock_read( fd_rwlock_t * lock ) {
 # if FD_HAS_THREADS

--- a/src/flamenco/runtime/Local.mk
+++ b/src/flamenco/runtime/Local.mk
@@ -38,15 +38,14 @@ $(call add-objs, tests/fd_dump_pb,fd_flamenco)
 
 $(call add-hdrs,fd_rent_lists.h)
 
-$(call make-unit-test,test_txncache,test_txncache,fd_flamenco fd_ballet fd_util)
-
 ifdef FD_HAS_SECP256K1
 $(call make-unit-test,test_txn_rw_conflicts,test_txn_rw_conflicts,fd_flamenco fd_funk fd_ballet fd_util, $(SECP256K1_LIBS))
 endif
 
 ifdef FD_HAS_ATOMIC
+$(call make-unit-test,test_txncache,test_txncache,fd_flamenco fd_ballet fd_util)
 $(call add-hdrs,fd_runtime.h fd_runtime_init.h fd_runtime_err.h)
-$(call add-objs,fd_runtime fd_runtime_init ,fd_flamenco)
+$(call add-objs,fd_runtime fd_runtime_init,fd_flamenco)
 endif
 
 endif
@@ -63,10 +62,7 @@ $(call make-bin,fd_blockstore_tool,fd_blockstore_tool,fd_util fd_flamenco fd_bal
 endif
 
 ifdef FD_HAS_ATOMIC
-
 ifdef FD_HAS_HOSTED
 #$(call make-unit-test,test_archive_block,test_archive_block, fd_flamenco fd_util fd_ballet,$(SECP256K1_LIBS))
-# TODO: Flakes
-# $(call run-unit-test,test_txncache,)
 endif
 endif

--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.h
@@ -68,7 +68,7 @@ struct fd_exec_txn_ctx {
 
   /* All pointers starting here are valid local joins in txn execution. */
   fd_features_t                   features;
-  fd_txncache_t *                 status_cache;
+  fd_txncache_t *                 txncache;
   ulong                           prev_lamports_per_signature;
   int                             enable_exec_recording;
   ulong                           total_epoch_stake;

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -51,9 +51,6 @@
 
 #define SECONDS_PER_YEAR ((double)(365.242199 * 24.0 * 60.0 * 60.0))
 
-/* TODO: increase this to default once we have enough memory to support a 95G status cache. */
-#define MAX_CACHE_TXNS_PER_SLOT (FD_TXNCACHE_DEFAULT_MAX_TRANSACTIONS_PER_SLOT / 8)
-
 void
 block_finalize_tpool_wrapper( void * para_arg_1,
                               void * para_arg_2,
@@ -572,7 +569,8 @@ void
 fd_runtime_finalize_txn( fd_exec_slot_ctx_t *         slot_ctx,
                          fd_capture_ctx_t *           capture_ctx,
                          fd_execute_txn_task_info_t * task_info,
-                         fd_spad_t *                  finalize_spad );
+                         fd_spad_t *                  finalize_spad,
+                         fd_txncache_t *              txncache );
 
 /* Epoch Boundary *************************************************************/
 

--- a/src/flamenco/runtime/fd_txncache.c
+++ b/src/flamenco/runtime/fd_txncache.c
@@ -1,13 +1,12 @@
 #include "fd_txncache.h"
 #include "../fd_rwlock.h"
+#include "../../ballet/base58/fd_base58.h"
 
 #define SORT_NAME        sort_slot_ascend
 #define SORT_KEY_T       ulong
 #define SORT_BEFORE(a,b) (a)<(b)
 #include "../../util/tmpl/fd_sort.c"
 
-/* TODO: This data structure needs a careful audit and testing. It may need
-   to be reworked to support better fork-aware behavior.  */
 
 /* The number of transactions in each page.  This needs to be high
    enough to amoritze the cost of caller code reserving pages from,
@@ -16,217 +15,391 @@
 
 #define FD_TXNCACHE_TXNS_PER_PAGE (16384UL)
 
-/* The number of unique entries in the hash lookup table for each
-   blockhash.  A higher value here uses more memory but enables faster
-   lookups. */
+/* Status code for an empty/available entry in one of the probed hash
+   tables.  The blockcache, nonce slotcache, nonce txn cache, and nonce
+   blockcache tables are linearly probed.  We generally use the max_slot
+   or the slot field to stash this status code. */
 
-#define FD_TXNCACHE_BLOCKCACHE_MAP_CNT (524288UL)
+#define FD_TXNCACHE_ENTRY_FREE      (ULONG_MAX)
+#define FD_TXNCACHE_ENTRY_FREE_UINT (UINT_MAX)
 
-/* The number of unique entries in the hash lookup table for each
-   (slot, blockhash).  This prevents all the entries needing to be in
-   one slotcache list, so insertions can happen concurrently. */
+/* Status code for an exclusively busied entry.  This means that the
+   entry is in the process of being created and concurrent competing
+   interests should retry until the entry is no longer in this state. */
 
-#define FD_TXNCACHE_SLOTCACHE_MAP_CNT (1024UL)
+#define FD_TXNCACHE_ENTRY_XBUSY      (ULONG_MAX-1UL)
+#define FD_TXNCACHE_ENTRY_XBUSY_UINT (UINT_MAX-1UL)
 
-/* Value for an empty blockcache `max_slot` or empty slotcache
-  `slot` entry. When the entries are set to this value, we can insert
-  to the entry, but stop iterating while running queries. */
+/* Placeholder max_slot value for a newly created blockcache or nonce
+   blockcache entry.  Will be atomically overwritten with a real value
+   shortly after. */
 
-#define FD_TXNCACHE_EMPTY_ENTRY (ULONG_MAX)
-
-/* Value for a deleted cache entry. We can insert to such entries,
-   and keep iterating while running queries. */
-
-#define FD_TXNCACHE_TOMBSTONE_ENTRY (ULONG_MAX-1UL)
-
-/* Placeholder value used for critical sections. */
-
-#define FD_TXNCACHE_TEMP_ENTRY (ULONG_MAX-2UL)
+#define FD_TXNCACHE_ENTRY_NEW      (ULONG_MAX-2UL)
+#define FD_TXNCACHE_ENTRY_NEW_UINT (UINT_MAX-2UL)
 
 struct fd_txncache_private_txn {
-  uint  blockcache_next; /* Pointer to the next element in the blockcache hash chain containing this entry from the pool. */
-  uint  slotblockcache_next;  /* Pointer to the next element in the slotcache hash chain containing this entry from the pool. */
-
-  ulong slot;            /* Slot that the transaction was executed.  A transaction might be in the cache
-                            multiple times if it was executed in a different slot on different forks.  The
-                            same slot will not appear multiple times however. */
-  uchar txnhash[ 20 ];   /* The transaction hash, truncated to 20 bytes.  The hash is not always the first 20
-                            bytes, but is 20 bytes starting at some arbitrary offset given by the key_offset value
-                            of the containing by_blockhash entry. */
-  uchar result;          /* The result of executing the transaction. This is the discriminant of the transaction
-                            result type. 0 means success. */
+  ulong slot;                            /* Slot that the transaction was executed.  A transaction might be in
+                                            the cache multiple times if it was executed in a different slot on
+                                            different forks.  The same slot will not appear multiple times
+                                            however. */
+  uint  blockcache_next;                 /* Pointer to the next element in the blockcache hash chain containing
+                                            this entry from the pool. */
+  uchar txnhash[ FD_TXNCACHE_KEY_SIZE ]; /* The transaction hash, truncated to 20 bytes.  The hash is not always
+                                            the first 20 bytes, but is 20 bytes starting at the offset value
+                                            given by the containing by_blockhash entry. */
 };
 
 typedef struct fd_txncache_private_txn fd_txncache_private_txn_t;
+FD_STATIC_ASSERT( sizeof(fd_txncache_private_txn_t)==32UL, txn_size );
 
 struct fd_txncache_private_txnpage {
-  ushort                    free; /* The number of free txn entries in this page. */
-  fd_txncache_private_txn_t txns[ FD_TXNCACHE_TXNS_PER_PAGE][ 1 ]; /* The transactions in the page. */
+  ushort                    free;                                   /* The number of free txn entries in this page. */
+  ushort                    _pad[ 3 ];                              /* Alignment forced padding.  Could be repurposed. */
+  fd_txncache_private_txn_t txns[ FD_TXNCACHE_TXNS_PER_PAGE ][ 1 ]; /* The transactions in the page. */
 };
 
 typedef struct fd_txncache_private_txnpage fd_txncache_private_txnpage_t;
 
+FD_STATIC_ASSERT( USHORT_MAX>=FD_TXNCACHE_TXNS_PER_PAGE, bump_size_of_free_cnt );
+
+/* A NOTE ON TXNHASH OFFSET:
+
+   To save memory, the Agave validator decided to truncate the hash of
+   transactions stored in this memory to 20 bytes rather than 32 bytes
+   or 64 bytes.  The bytes used are not the first 20 as you might
+   expect, but instead the first 20 starting at some random offset into
+   the transaction hash (starting between 0 and len(hash)-20, a/k/a 44
+   for signatures, and 12 for transaction hashes).
+
+   In an unfortunate turn, the offset is also propagated to peers via
+   snapshot responses, which only communicate the offset and the
+   respective 20 bytes.  To make sure we are deduplicating incoming
+   transactions correctly, we must replicate this system even though it
+   would be easier to just always take the first 20 bytes.  For
+   transactions that we insert into the cache ourselves, we do just
+   always use a key offset of zero, so the offset is only nonzero when
+   constructed form a peer snapshot. */
+
 struct fd_txncache_private_blockcache {
-  uchar blockhash[ 32 ]; /* The actual blockhash of these transactions. */
-  ulong max_slot;        /* The max slot we have seen that contains a transaction referencing this blockhash.
-                            The blockhash entry will not be purged until the lowest rooted slot is greater than this. */
-  ulong txnhash_offset;  /* To save memory, the Agave validator decided to truncate the hash of transactions stored in
-                            this memory to 20 bytes rather than 32 bytes.  The bytes used are not the first 20 as you
-                            might expect, but instead the first 20 starting at some random offset into the transaction
-                            hash (starting between 0 and len(hash)-20, a/k/a 44 for signatures, and 12 for hashes).
-
-                            In an unfortunate turn, the offset is also propogated to peers via. snapshot responses,
-                            which only communicate the offset and the respective 20 bytes.  To make sure we are
-                            deduplicating incoming transactions correctly, we must replicate this system even though
-                            it would be easier to just always take the first 20 bytes.  For transactions that we
-                            insert into the cache ourselves, we do just always use a key_offset of zero, so this is
-                            only nonzero when constructed form a peer snapshot. */
-
-  uint  heads[ FD_TXNCACHE_BLOCKCACHE_MAP_CNT ]; /* The hash table for the blockhash.  Each entry is a pointer to the head of a
-                                                    linked list of transactions that reference this blockhash.  As we add
-                                                    transactions to the bucket, the head pointer is updated to the new item, and
-                                                    the new item is pointed to the previous head. */
-
-  ushort pages_cnt;      /* The number of txnpages currently in use to store the transactions in this blockcache. */
-  uint * pages;          /* A list of the txnpages containing the transactions for this blockcache. */
+  uchar  blockhash[ 32 ]; /* The actual blockhash of these transactions. */
+  ulong  max_slot;        /* The max slot we have seen that contains a transaction referencing
+                             this blockhash.  The blockhash entry will not be purged until the
+                             lowest rooted slot is greater than this. */
+  ushort pages_cnt;       /* The number of txnpages currently in use to store the transactions in
+                             this blockcache. */
+  ushort _pad[ 1 ];       /* Alignment forced padding.  Could be repurposed. */
+  uint   heads[ ];        /* The hash table for the blockhash.  Each entry is a pointer to the
+                             head of a linked list of transactions that reference this blockhash.
+                             As we add transactions to the bucket, the head pointer is updated to
+                             the new item, and the new item is pointed to the previous head.
+                             This is a hash table of size max_txn_per_slot. */
+  // Logically, there's another field here:
+  // uint   pages[ ];        /* An array of the txnpages containing the transactions for this
+  //                            blockcache.  Size max_txnpages_per_blockhash. */
 };
 
 typedef struct fd_txncache_private_blockcache fd_txncache_private_blockcache_t;
 
-struct fd_txncache_private_slotblockcache {
+/* When querying a transaction, including a nonce transaction, we have
+   only the blockhash and the txnhash to work with.  The txnhash is what
+   ultimately uniquely identifies a transaction.  However, as described
+   above, txnhash values are truncated at a non-deterministic offset in
+   Agave.  In Agave, the offsets are randomly generated on a
+   per-blockhash basis.  In contrast, we always use an offset of 0.  So,
+   when it's not a nonce transaction loaded from an Agave snapshot, we
+   know for sure that the txnhash_offset is zero.  It is then pretty
+   straightforward to query the nonce txn hash table using the truncated
+   txnhash starting from offset 0.  Unfortunately, when loading from an
+   Agave snapshot, every nonce transaction could in theory reference a
+   unique blockhash, and every unique blockhash could have a different
+   txnhash_offset.  The upshot of all of this is that when nonce
+   transactions loaded from an Agave snapshot are present in the
+   txncache, we have two options:
+
+   (1) Query the nonce txn hash table multiple times, each time with a
+       different txnhash_offset, until either a match, or we have
+       checked all possible offsets.  This is similar to how TLBs that
+       support multiple page sizes work, where given a virtual address,
+       the TLB is first queried assuming a 4K mapping and its
+       corresponding split of the virtual address into a page offset and
+       a page index, and then a 2M mapping, and so on and so forth.
+
+   (2) Maintain a mapping from blockhash to txnhash_offset.  Query this
+       mapping to obtain the txnhash_offset, and then query the nonce
+       txn hash table using the properly truncated txnhash.
+
+   Here, we implement option (2), because we need queries to be fast.
+   The downsides of option (2) are that it introduces an additional
+   table that consumes memory, and the table potentially needs to be
+   purged.  We implement a few optimizations here.  First, we only
+   insert into this table the blockhashes that are loaded from an Agave
+   snapshot.  New blockhashes with our default txnhash_offset of zero
+   are not inserted.  If a query into this table misses, we can simply
+   assume that the txnhash_offset is zero.  This also means that
+   eventually, as replay goes on and higher slots get rooted and
+   transactions loaded from Agave snapshots are purged, this table will
+   be completely empty.  Second, we lazily and logically purge the
+   table.  Rather than actively removing entries from the table at the
+   end of each slot, like we do for the blockcache and the slotcache, we
+   record the max slot that references any valid entry in this table.
+   As described in the first optimization, we always use a default
+   offset of zero for new blockhashes and hence we never insert new
+   entries into this table after snapshot loading.  Therefore, we don't
+   have to actively purge anything to make space.  Moreover, when the
+   lowest rooted slot exceeds the recorded max slot, the entire table is
+   logically purged.  Thereafter we should not have to query this table
+   ever again.
+
+   One more note regarding snapshot loading ...
+
+   In yet another unfortunate turn, when loading the txncache from an
+   Agave snapshot, there's no easy way to tell if a transaction is a
+   nonce transaction or not.  The snapshot by itself doesn't contain the
+   actual transactions, only the blockhashes and the truncated txn
+   hashes.  So what we do is that we assume that all transactions from
+   the snapshot are nonce transactions.  This is conservative and safe,
+   because the nonce txn cache has enough capacity for max txns per
+   slot.  This does make querying for and inserting regular transactions
+   a little more complicated for as long as the nonce blockcache is
+   active.
+
+   The following describes the scheme for managing and querying nonce
+   txnhash offsets:
+
+   On insertion of a nonce transaction not loaded from an Agave
+   snapshot:
+   - If lowest rooted slot is greater than the table max slot, assume
+     offset is zero
+   - Query this table with blockhash
+   - If hit
+     - If the lowest rooted slot is no greater than the blockhash max
+       slot, update the blockhash max slot, as well as the table max
+       slot
+     - Otherwise, assume offset is zero
+   - If miss, assume offset is zero
+
+   On insertion of a nonce transaction loaded from an Agave snapshot:
+   - Query this table with blockhash
+   - If hit, update the blockhash max slot, as well as the table max
+     slot
+   - If miss, create a new entry in the table with the blockhash and
+     update the table max slot
+
+   On query of a nonce transaction:
+   - If lowest rooted slot is greater than the table max slot, assume
+     offset is zero
+   - Query this table with blockhash
+   - If hit
+     - If the lowest rooted slot is no greater than the blockhash max
+       slot, truncate the txnhash with the offset given by the hit
+     - Otherwise, truncate the txnhash with our default offset of zero
+   - If miss, truncate the txnhash with our default offset of zero
+
+   On query of a regular transaction:
+   - If lowest rooted slot is no greater than the table max slot, this
+     implies that this table has not been deactivated, which in turn
+     implies that there could be regular transactions in the nonce txn
+     cache.  So query for this transaction as if it were a nonce
+     transaction, except that if the nonce blockhash entry is expired,
+     then we don't bother with querying the nonce txn cache.
+   - Query this transaction in the main txn cache
+
+   On insertion of a regular transaction:
+   - If lowest rooted slot is greater than the table max slot, insert
+     into the main txn cache
+   - Query this table with blockhash
+   - If hit
+     - If the lowest rooted slot is no greater than the blockhash max
+       slot, insert as if it were a nonce transaction
+     - Otherwise, insert into the main txn cache
+   - If miss, insert into the main txn cache
+ */
+struct fd_txncache_private_nonce_blockcache {
   uchar blockhash[ 32 ]; /* The actual blockhash of these transactions. */
-  ulong txnhash_offset;  /* As described above. */
-  uint  heads[ FD_TXNCACHE_SLOTCACHE_MAP_CNT ]; /* A map of the head of a linked list of tansactions in this slot and blockhash */
+  uint  max_slot;        /* The max slot we have seen that contains a transaction referencing
+                            this blockhash.  The blockhash entry will not be purged until the
+                            lowest rooted slot is greater than this. */
+  uint  txnhash_offset;  /* As described above. */
 };
 
-typedef struct fd_txncache_private_slotblockcache fd_txncache_private_slotblockcache_t;
+typedef struct fd_txncache_private_nonce_blockcache fd_txncache_private_nonce_blockcache_t;
+FD_STATIC_ASSERT( sizeof(fd_txncache_private_nonce_blockcache_t)==40UL, nonce_blockcache_size );
 
-struct fd_txncache_private_slotcache {
-  ulong                                slot; /* The slot that this slotcache is for. */
-  fd_txncache_private_slotblockcache_t blockcache[ 300UL ];
+struct fd_txncache_private_nonce_txn {
+  uint  slot;                            /* Slot where the transaction was executed.  A transaction might be in
+                                            the cache multiple times if it was executed in a different slot on
+                                            different forks.  The same slot will not appear multiple times
+                                            however. */
+  uint  slotcache_next;                  /* Pointer to the next element in the per-slot doubly linked list
+                                            containing this entry from the nonce txn pool. */
+  union {
+    struct {
+      uint  slotcache_prev:31;           /* Pointer to the previous element in the per-slot doubly linked list
+                                            containing this entry from the nonce txn pool.  Used for updating
+                                            linked lists when we reprobe the nonce txn hash table.  If this
+                                            field points to the head of the linked list, it is instead an index
+                                            into the nonce_slotcache array. */
+      uint  slotcache_prev_is_head:1;    /* Whether the slotcache_prev field points to the head of the linked
+                                            list. */
+    };
+    uint    slotcache_prev_val;
+  };
+  uchar txnhash[ FD_TXNCACHE_KEY_SIZE ]; /* The transaction hash, truncated to 20 bytes.  The hash is not
+                                            always the first 20 bytes, but is 20 bytes starting at the offset
+                                            given by the txnhash_offset field. */
 };
 
-typedef struct fd_txncache_private_slotcache fd_txncache_private_slotcache_t;
+typedef struct fd_txncache_private_nonce_txn fd_txncache_private_nonce_txn_t;
+FD_STATIC_ASSERT( sizeof(fd_txncache_private_nonce_txn_t)==32UL, nonce_txn_size );
+
+/* Top bit unavailable due to slotcache_prev:31 */
+#define FD_TXNCACHE_NONCE_TXN_IDX_MAX       ((1U<<31)-1U)
+#define FD_TXNCACHE_NONCE_TXN_CNT_MAX       ((1U<<31))
+#define FD_TXNCACHE_NONCE_TXN_IDX_MASK      ((1U<<31)-1U) /* Helps suppress -Wconversion warnings... */
+/* Can't fully populate all bits because UINT_MAX means NULL. */
+#define FD_TXNCACHE_NONCE_SLOTCACHE_IDX_MAX ((1U<<31)-2U)
+#define FD_TXNCACHE_NONCE_SLOTCACHE_CNT_MAX ((1U<<31)-1U)
+
+struct fd_txncache_private_nonce_slotcache {
+  ulong slot;           /* The slot that this nonce slotcache is for. */
+  uint  nonce_slot_pop; /* The number of transactions in this slot. */
+  uint  head;           /* The head of the doubly linked list of nonce txns for this slot.  As
+                           we add nonce transactions to the list, the head pointer is updated to
+                           the new item, and the new item is pointed to the previous head. */
+};
+
+typedef struct fd_txncache_private_nonce_slotcache fd_txncache_private_nonce_slotcache_t;
 
 struct __attribute__((aligned(FD_TXNCACHE_ALIGN))) fd_txncache_private {
   fd_rwlock_t lock[ 1 ]; /* The txncache is a concurrent structure and will be accessed by multiple threads
                             concurrently.  Insertion and querying only take a read lock as they can be done
                             lockless but all other operations will take a write lock internally. */
 
+  ulong magic; /* ==FD_TXNCACHE_MAGIC */
+
+  ushort block_pop;
+  ushort slot_pop;
+  ushort block_pop_max;
+  ushort slot_pop_max;
+  uint   nonce_slot_pop_max;
+  ushort _metric_pad[ 6 ];
+
   ulong  root_slots_max;
-  ulong  live_slots_max;
-  ulong  constipated_slots_max; /* The max number of constipated slots that the txncache will support
-                                   while in a constipated mode. If this gets exceeded, this means
-                                   that the txncache was in a constipated state for too long without
-                                   being flushed. */
+  ulong  nonce_blockcache_max_slot; /* This is only accessed when the nonce blockcache is still active.
+                                       So initially there will be a bit of false sharing, but eventually
+                                       this should be a dead field. */
+  ulong  lowest_observed_slot;      /* This is only accessed towards the end of an insertion.  Immediately
+                                       afterwards we unlock. */
+
+  /* Cache line aligned. */
+
+  ulong  nonce_blockcache_deactivated_slot_delta; /* !=ULONG_MAX when the nonce blockcache is deactivated. */
+  ulong  txn_per_slot_max;
+  ulong  live_slots_max;       /* A note on live slots ...
+
+                                  The maximum number of live slots is the sum of the rooted and
+                                  unrooted slots.  The rooted slots are typically capped at 300
+                                  (implying we keep around 2 minutes of history around for queries and
+                                  snapshots).
+
+                                  For the unrooted slots, we must root at least one slot in an epoch
+                                  for an epoch transition to occur successfully to the next one, so
+                                  assuming every slot is unconfirmed for some reason, and the prior
+                                  epoch was rooted at the first slot in the epoch, and the next epoch
+                                  is rooted at the last slot, there could be
+
+                                      432,000 + 432,000 - 31 = 863,969
+
+                                  Live slots on the validator.  This is clearly impractical as each
+                                  bank consumes a lof of memory to store slot state, so the validator
+                                  would crash long before this. */
+  uint   nonce_txns_max;
+  ulong  nonce_blockcache_entries_max;
   ushort txnpages_per_blockhash_max;
   uint   txnpages_max;
 
-  ulong   root_slots_cnt; /* The number of root slots being tracked in the below array. */
-  ulong   root_slots_off; /* The highest N slots that have been rooted.  These slots are
-                             used to determine which transactions should be kept around to
-                             be queried and served to snapshot requests.  The actual
-                             footprint for this data (and other data below) are declared
-                             immediately following the struct.  I.e. these pointers point to
-                             memory not far after the struct. */
+  ulong  root_slots_cnt;       /* The number of root slots being tracked in the below array. */
+  ulong  root_slots_off;       /* The highest N slots that have been rooted.  These slots are
+                                  used to determine which transactions should be kept around to
+                                  be queried and served to snapshot requests.  The actual
+                                  footprint for this data (and other data below) are declared
+                                  immediately following the struct.  I.e. these pointers point to
+                                  memory not far after the struct. */
 
-  ulong blockcache_off; /* The actual cache of transactions.  This is a linear probed hash
-                           table that maps blockhashes to the transactions that reference them.
-                           The depth of the hash table is live_slots_max, since this is the
-                           maximum number of blockhashes that can be alive.  The loading factor
-                           if they were all alive would be 1.0, but this is rare because we
-                           will almost never fork repeatedly to hit this limit.  These
-                           blockcaches are just pointers to pages from the txnpages below, so
-                           they don't take up much memory. */
+  ulong  blockcache_t_sz;      /* The size of each blockcache table entry. */
+  ulong  blockcache_off;       /* The cache of transactions by blockhash.  This is a linear probed hash
+                                  table that maps blockhashes to the transactions that reference them.
+                                  The depth of the hash table is live_slots_max, since this is the
+                                  maximum number of blockhashes that can be alive.  The loading factor
+                                  if they were all alive would be 1.0, but this is rare because we
+                                  will almost never fork repeatedly to hit this limit.  These
+                                  blockcaches are just pointers to pages from the txnpages below, so
+                                  they don't take up much memory. */
+  ulong  txnpages_off;         /* The actual storage for the transactions.  The blockcache points to
+                                  these pages when storing transactions.  Transactions are grouped into
+                                  pages of size 16384 to make certain allocation and deallocation
+                                  operations faster (just the pages are acquired/released, rather than
+                                  each txn).  Array size is txnpages_max. */
+  ulong  txnpages_free_off;    /* Array of free txnpages.  Stores indices into the txnpages array. */
+  uint   txnpages_free_cnt;    /* The number of txnpages that are free.  The first this many elements
+                                  in the above array are the ones that are free.*/
 
-  ulong slotcache_off; /* The cache of transactions by slot instead of by blockhash, so we
-                          can quickly serialize the slot deltas for the root slots which are
-                          served to peers in snapshots.  Similar to the above, it uses the
-                          same underlying transaction storage, but different lookup tables. */
-
-  uint     txnpages_free_cnt; /* The number of pages in the txnpages that are not currently in use. */
-  ulong    txnpages_free_off; /* The index in the txnpages array that is free, for each of the free pages. */
-
-  ulong    txnpages_off; /* The actual storage for the transactions.  The blockcache points to these
-                            pages when storing transactions.  Transaction are grouped into pages of
-                            size 16384 to make certain allocation and deallocation operations faster
-                            (just the pages are acquired/released, rather than each txn). */
-
-  ulong blockcache_pages_off; /* The pages for the blockcache entries. */
-
-  ulong probed_entries_off; /* The map of index to number of entries which oveflowed over this index.
-                               Overflow for index i is defined as every entry j > i where j should have
-                               been inserted at k < i. */
-
-  ulong constipated_slots_cnt; /* The number of constipated root slots that can be supported and
-                                  that are tracked in the below array. */
-  ulong constipated_slots_off; /* The highest N slots that should be rooted will be in this
-                                  array, assuming that the latest slots were constipated
-                                  and not flushed. */
-
-  /* Constipation is used here in the same way Funk is constipated. The reason
-     this exists is to ensure that the set of rooted slots doesn't change while
-     the snapshot service is serializing the status cache into a snapshot. This
-     operation is usually very fast and only takes a few seconds.
-     TODO: Another implementation of this might be to continue rooting slots
-     to the same data structure but to temporarily stop evictions. Right now
-     this is implemented such that we maintain a separate array of all slots
-     that should be rooted. Once the constipation is removed, all of the
-     constipated slots will be registered en masse. */
-  int   is_constipated;        /* Is the status cache in a constipated state.*/
-  ulong is_constipated_off;
-
-  ulong magic; /* ==FD_TXNCACHE_MAGIC */
+  ulong  nonce_slotcache_off;  /* The cache of nonce transactions by slot, so we can quickly purge
+                                  nonce transactions by slot number.  This is a linearly probed hash
+                                  table that maps a slot number to a doubly linked list of nonce
+                                  transactions for that slot. */
+  ulong  nonce_txns_off;       /* The actual storage for nonce transactions.  The nonce slotcache
+                                  linked lists point to these.  Storage capacity is
+                                  live_slots_max*txn_per_slot_max.  This also doubles as a hash table
+                                  of nonce transactions.  The hash table is indexed by transaction hash
+                                  and linearly probed.  Ideally, storage capacity can be
+                                  live_slots_max*nonce_txn_per_slot_max, since nonce transactions
+                                  consume a higher amount of CU than the most barebones non-nonce
+                                  transaction.  Unfortunately, this storage is abused to store
+                                  non-nonce transactions as well on startup, so this is sized out for
+                                  that usage. */
+  ulong  nonce_blockcache_off; /* The mapping of blockhashes to nonce transaction hash offsets. */
 };
 
 FD_FN_PURE static ulong *
-fd_txncache_get_root_slots( fd_txncache_t * tc ) {
+fd_txncache_get_root_slots( fd_txncache_t const * tc ) {
   return (ulong *)( (uchar *)tc + tc->root_slots_off );
 }
 
-FD_FN_PURE static ulong *
-fd_txncache_get_constipated_slots( fd_txncache_t * tc ) {
-  return (ulong *)( (uchar *)tc + tc->constipated_slots_off );
-}
-
 FD_FN_PURE static fd_txncache_private_blockcache_t *
-fd_txncache_get_blockcache( fd_txncache_t * tc ) {
-  return (fd_txncache_private_blockcache_t *)( (uchar *)tc + tc->blockcache_off );
-}
-
-FD_FN_PURE static fd_txncache_private_blockcache_t *
-fd_txncache_get_blockcache_const( fd_txncache_t const * tc ) {
-  return (fd_txncache_private_blockcache_t *)( (uchar const *)tc + tc->blockcache_off );
-}
-
-FD_FN_PURE static fd_txncache_private_slotcache_t *
-fd_txncache_get_slotcache( fd_txncache_t * tc ) {
-  return (fd_txncache_private_slotcache_t *)( (uchar *)tc + tc->slotcache_off );
-}
-
-FD_FN_PURE static fd_txncache_private_slotcache_t *
-fd_txncache_get_slotcache_const( fd_txncache_t const * tc ) {
-  return (fd_txncache_private_slotcache_t *)( (uchar const *)tc + tc->slotcache_off );
+fd_txncache_get_blockcache_at_idx( fd_txncache_t const * tc, ulong idx ) {
+  return (fd_txncache_private_blockcache_t *)( (uchar *)tc + tc->blockcache_off + idx*tc->blockcache_t_sz );
 }
 
 FD_FN_PURE static uint *
-fd_txncache_get_txnpages_free( fd_txncache_t * tc ) {
+fd_txncache_get_blockcache_pages( fd_txncache_t const *                    tc,
+                                  fd_txncache_private_blockcache_t const * blockcache ) {
+  return (uint *)( blockcache->heads + tc->txn_per_slot_max );
+}
+
+FD_FN_PURE static fd_txncache_private_nonce_txn_t *
+fd_txncache_get_nonce_txns( fd_txncache_t const * tc ) {
+  return (fd_txncache_private_nonce_txn_t *)( (uchar *)tc + tc->nonce_txns_off );
+}
+
+FD_FN_PURE static fd_txncache_private_nonce_blockcache_t *
+fd_txncache_get_nonce_blockcache( fd_txncache_t const * tc ) {
+  return (fd_txncache_private_nonce_blockcache_t *)( (uchar *)tc + tc->nonce_blockcache_off );
+}
+
+FD_FN_PURE static fd_txncache_private_nonce_slotcache_t *
+fd_txncache_get_nonce_slotcache( fd_txncache_t const * tc ) {
+  return (fd_txncache_private_nonce_slotcache_t *)( (uchar *)tc + tc->nonce_slotcache_off );
+}
+
+FD_FN_PURE static uint *
+fd_txncache_get_txnpages_free( fd_txncache_t const * tc ) {
   return (uint *)( (uchar *)tc + tc->txnpages_free_off );
 }
 
 FD_FN_PURE static fd_txncache_private_txnpage_t *
-fd_txncache_get_txnpages( fd_txncache_t * tc ) {
+fd_txncache_get_txnpages( fd_txncache_t const * tc ) {
   return (fd_txncache_private_txnpage_t *)( (uchar *)tc + tc->txnpages_off );
-}
-
-FD_FN_PURE static ulong *
-fd_txncache_get_probed_entries( fd_txncache_t * tc ) {
-  return (ulong *)( (uchar *)tc + tc->probed_entries_off );
-}
-
-FD_FN_PURE static ulong *
-fd_txncache_get_probed_entries_const( fd_txncache_t const * tc ) {
-  return (ulong *)( (uchar const *)tc + tc->probed_entries_off );
 }
 
 FD_FN_CONST static ushort
@@ -275,8 +448,13 @@ fd_txncache_max_txnpages( ulong max_live_slots,
 
      pages, and the other blockhashes need 1 page each. */
 
-  ulong result = max_live_slots-1UL+max_live_slots*(1UL+(max_txn_per_slot-1UL)/FD_TXNCACHE_TXNS_PER_PAGE);
+  ulong result = max_live_slots-1UL+(1UL+(max_live_slots*max_txn_per_slot-1UL)/FD_TXNCACHE_TXNS_PER_PAGE);
   if( FD_UNLIKELY( result>UINT_MAX ) ) return 0;
+
+  /* Transaction index into the pages is stored in a uint. */
+  ulong txn_idx_max = result * FD_TXNCACHE_TXNS_PER_PAGE;
+  if( FD_UNLIKELY( txn_idx_max>UINT_MAX ) ) return 0;
+
   return (uint)result;
 }
 
@@ -288,12 +466,11 @@ fd_txncache_align( void ) {
 FD_FN_CONST ulong
 fd_txncache_footprint( ulong max_rooted_slots,
                        ulong max_live_slots,
-                       ulong max_txn_per_slot,
-                       ulong max_constipated_slots ) {
+                       ulong max_txn_per_slot ) {
   if( FD_UNLIKELY( max_rooted_slots<1UL || max_live_slots<1UL ) ) return 0UL;
   if( FD_UNLIKELY( max_live_slots<max_rooted_slots ) ) return 0UL;
   if( FD_UNLIKELY( max_txn_per_slot<1UL ) ) return 0UL;
-  if( FD_UNLIKELY( !fd_ulong_is_pow2( max_live_slots ) || !fd_ulong_is_pow2( max_txn_per_slot ) ) ) return 0UL;
+  if( FD_UNLIKELY( !fd_ulong_is_pow2( max_live_slots ) ) ) return 0UL;
 
   /* To save memory, txnpages are referenced as uint which is enough
      to support mainnet parameters without overflow. */
@@ -303,17 +480,23 @@ fd_txncache_footprint( ulong max_rooted_slots,
   ulong max_txnpages_per_blockhash = fd_txncache_max_txnpages_per_blockhash( max_txn_per_slot );
   if( FD_UNLIKELY( !max_txnpages_per_blockhash ) ) return 0UL;
 
+  ulong max_nonce_txns = max_live_slots*max_txn_per_slot;
+  if( FD_UNLIKELY( max_nonce_txns>FD_TXNCACHE_NONCE_TXN_CNT_MAX ) ) return 0UL;
+
+  ulong max_nonce_blockcache_entries = max_live_slots*max_txn_per_slot;
+
+  ulong blockcache_t_sz = fd_ulong_align_up( sizeof(fd_txncache_private_blockcache_t) + (max_txn_per_slot+max_txnpages_per_blockhash)*sizeof(uint), alignof(fd_txncache_private_blockcache_t) );
+
   ulong l;
   l = FD_LAYOUT_INIT;
-  l = FD_LAYOUT_APPEND( l, FD_TXNCACHE_ALIGN,                         sizeof(fd_txncache_t)                                   );
-  l = FD_LAYOUT_APPEND( l, alignof(ulong),                            max_rooted_slots*sizeof(ulong)                          ); /* root_slots */
-  l = FD_LAYOUT_APPEND( l, alignof(fd_txncache_private_blockcache_t), max_live_slots*sizeof(fd_txncache_private_blockcache_t) ); /* blockcache */
-  l = FD_LAYOUT_APPEND( l, alignof(uint),                             max_live_slots*max_txnpages_per_blockhash*sizeof(uint)  ); /* blockcache->pages */
-  l = FD_LAYOUT_APPEND( l, alignof(fd_txncache_private_slotcache_t),  max_live_slots*sizeof(fd_txncache_private_slotcache_t ) ); /* slotcache */
-  l = FD_LAYOUT_APPEND( l, alignof(uint),                             max_txnpages*sizeof(uint)                               ); /* txnpages_free */
-  l = FD_LAYOUT_APPEND( l, alignof(fd_txncache_private_txnpage_t),    max_txnpages*sizeof(fd_txncache_private_txnpage_t)      ); /* txnpages */
-  l = FD_LAYOUT_APPEND( l, alignof(ulong),                            max_live_slots*sizeof(ulong)                            ); /* probed entries */
-  l = FD_LAYOUT_APPEND( l, alignof(ulong),                            max_constipated_slots*sizeof(ulong)                     ); /* constipated slots */
+  l = FD_LAYOUT_APPEND( l, FD_TXNCACHE_ALIGN,                               sizeof(fd_txncache_t)                                                       );
+  l = FD_LAYOUT_APPEND( l, alignof(ulong),                                  max_rooted_slots*sizeof(ulong)                                              ); /* root_slots */
+  l = FD_LAYOUT_APPEND( l, alignof(fd_txncache_private_blockcache_t),       max_live_slots*blockcache_t_sz                                              ); /* blockcache */
+  l = FD_LAYOUT_APPEND( l, alignof(uint),                                   max_txnpages*sizeof(uint)                                                   ); /* txnpages_free */
+  l = FD_LAYOUT_APPEND( l, alignof(fd_txncache_private_txnpage_t),          max_txnpages*sizeof(fd_txncache_private_txnpage_t)                          ); /* txnpages */
+  l = FD_LAYOUT_APPEND( l, alignof(fd_txncache_private_nonce_slotcache_t),  max_live_slots*sizeof(fd_txncache_private_nonce_slotcache_t)                ); /* nonce_slotcache */
+  l = FD_LAYOUT_APPEND( l, alignof(fd_txncache_private_nonce_txn_t),        max_nonce_txns*sizeof(fd_txncache_private_nonce_txn_t)                      ); /* nonce_txns */
+  l = FD_LAYOUT_APPEND( l, alignof(fd_txncache_private_nonce_blockcache_t), max_nonce_blockcache_entries*sizeof(fd_txncache_private_nonce_blockcache_t) ); /* nonce_blockcache */
   return FD_LAYOUT_FINI( l, FD_TXNCACHE_ALIGN );
 }
 
@@ -321,8 +504,7 @@ void *
 fd_txncache_new( void * shmem,
                  ulong  max_rooted_slots,
                  ulong  max_live_slots,
-                 ulong  max_txn_per_slot,
-                 ulong  max_constipated_slots ) {
+                 ulong  max_txn_per_slot ) {
   fd_txncache_t * tc = (fd_txncache_t *)shmem;
 
   if( FD_UNLIKELY( !shmem ) ) {
@@ -339,59 +521,87 @@ fd_txncache_new( void * shmem,
   if( FD_UNLIKELY( !max_live_slots ) ) return NULL;
   if( FD_UNLIKELY( max_live_slots<max_rooted_slots ) ) return NULL;
   if( FD_UNLIKELY( !max_txn_per_slot ) ) return NULL;
-  if( FD_UNLIKELY( !fd_ulong_is_pow2( max_live_slots ) || !fd_ulong_is_pow2( max_txn_per_slot ) ) ) return NULL;
+  if( FD_UNLIKELY( !fd_ulong_is_pow2( max_live_slots ) ) ) return NULL;
 
-  uint max_txnpages                 = fd_txncache_max_txnpages( max_live_slots, max_txn_per_slot );
-  ushort max_txnpages_per_blockhash = fd_txncache_max_txnpages_per_blockhash( max_txn_per_slot );
+  uint   max_txnpages                 = fd_txncache_max_txnpages( max_live_slots, max_txn_per_slot );
+  ushort max_txnpages_per_blockhash   = fd_txncache_max_txnpages_per_blockhash( max_txn_per_slot );
+  ulong  max_nonce_txns               = max_live_slots*max_txn_per_slot;
+  ulong  max_nonce_blockcache_entries = max_live_slots*max_txn_per_slot;
 
   if( FD_UNLIKELY( !max_txnpages ) ) return NULL;
   if( FD_UNLIKELY( !max_txnpages_per_blockhash ) ) return NULL;
+  if( FD_UNLIKELY( max_nonce_txns>FD_TXNCACHE_NONCE_TXN_CNT_MAX ) ) return NULL;
+
+  ulong blockcache_t_sz = fd_ulong_align_up( sizeof(fd_txncache_private_blockcache_t) + (max_txn_per_slot+max_txnpages_per_blockhash)*sizeof(uint), alignof(fd_txncache_private_blockcache_t) );
 
   FD_SCRATCH_ALLOC_INIT( l, shmem );
-  fd_txncache_t * txncache  = FD_SCRATCH_ALLOC_APPEND( l,  FD_TXNCACHE_ALIGN,                        sizeof(fd_txncache_t)                                   );
-  void * _root_slots        = FD_SCRATCH_ALLOC_APPEND( l, alignof(ulong),                            max_rooted_slots*sizeof(ulong)                          );
-  void * _blockcache        = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_private_blockcache_t), max_live_slots*sizeof(fd_txncache_private_blockcache_t) );
-  void * _blockcache_pages  = FD_SCRATCH_ALLOC_APPEND( l, alignof(uint),                             max_live_slots*max_txnpages_per_blockhash*sizeof(uint)  );
-  void * _slotcache         = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_private_slotcache_t),  max_live_slots*sizeof(fd_txncache_private_slotcache_t ) );
-  void * _txnpages_free     = FD_SCRATCH_ALLOC_APPEND( l, alignof(uint),                             max_txnpages*sizeof(uint)                               );
-  void * _txnpages          = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_private_txnpage_t),    max_txnpages*sizeof(fd_txncache_private_txnpage_t)      );
-  void * _probed_entries    = FD_SCRATCH_ALLOC_APPEND( l, alignof(ulong),                            max_live_slots*sizeof(ulong)                            );
-  void * _constipated_slots = FD_SCRATCH_ALLOC_APPEND( l, alignof(ulong),                            max_constipated_slots*sizeof(ulong)                     );
+  fd_txncache_t * txncache = FD_SCRATCH_ALLOC_APPEND( l, FD_TXNCACHE_ALIGN,                               sizeof(fd_txncache_t)                                                       );
+  void * _root_slots       = FD_SCRATCH_ALLOC_APPEND( l, alignof(ulong),                                  max_rooted_slots*sizeof(ulong)                                              );
+  void * _blockcache       = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_private_blockcache_t),       max_live_slots*blockcache_t_sz                                              );
+  void * _txnpages_free    = FD_SCRATCH_ALLOC_APPEND( l, alignof(uint),                                   max_txnpages*sizeof(uint)                                                   );
+  void * _txnpages         = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_private_txnpage_t),          max_txnpages*sizeof(fd_txncache_private_txnpage_t)                          );
+  void * _nonce_slotcache  = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_private_nonce_slotcache_t),  max_live_slots*sizeof(fd_txncache_private_nonce_slotcache_t)                );
+  void * _nonce_txns       = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_private_nonce_txn_t),        max_nonce_txns*sizeof(fd_txncache_private_nonce_txn_t)                      );
+  void * _nonce_blockcache = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_private_nonce_blockcache_t), max_nonce_blockcache_entries*sizeof(fd_txncache_private_nonce_blockcache_t) );
+  ulong  _end              = FD_SCRATCH_ALLOC_FINI( l, FD_TXNCACHE_ALIGN );
+
+  txncache->blockcache_t_sz = blockcache_t_sz;
 
   /* We calculate and store the offsets for these allocations. */
   txncache->root_slots_off        = (ulong)_root_slots - (ulong)txncache;
   txncache->blockcache_off        = (ulong)_blockcache - (ulong)txncache;
-  txncache->slotcache_off         = (ulong)_slotcache - (ulong)txncache;
   txncache->txnpages_free_off     = (ulong)_txnpages_free - (ulong)txncache;
   txncache->txnpages_off          = (ulong)_txnpages - (ulong)txncache;
-  txncache->blockcache_pages_off  = (ulong)_blockcache_pages - (ulong)txncache;
-  txncache->probed_entries_off    = (ulong)_probed_entries - (ulong)txncache;
-  txncache->constipated_slots_off = (ulong)_constipated_slots - (ulong)txncache;
+  txncache->nonce_slotcache_off   = (ulong)_nonce_slotcache - (ulong)txncache;
+  txncache->nonce_txns_off        = (ulong)_nonce_txns - (ulong)txncache;
+  txncache->nonce_blockcache_off  = (ulong)_nonce_blockcache - (ulong)txncache;
 
-  tc->lock->value           = 0;
+  ulong root_slots_size = txncache->blockcache_off-txncache->root_slots_off;
+  ulong blockcache_size = txncache->txnpages_free_off-txncache->blockcache_off;
+  ulong txnpages_free_size = txncache->txnpages_off-txncache->txnpages_free_off;
+  ulong txnpages_size = txncache->nonce_slotcache_off-txncache->txnpages_off;
+  ulong nonce_slotcache_size = txncache->nonce_txns_off-txncache->nonce_slotcache_off;
+  ulong nonce_txns_size = txncache->nonce_blockcache_off-txncache->nonce_txns_off;
+  ulong nonce_blockcache_size = _end-(ulong)_nonce_blockcache;
+  ulong total_size = _end-(ulong)txncache;
+  FD_LOG_INFO(( "txncache footprint: root_slots %lu (%lu%%), blockcache %lu (%lu%%), txnpages_free %lu (%lu%%), txnpages %lu (%lu%%), nonce_slotcache %lu (%lu%%), nonce_txns %lu (%lu%%), nonce_blockcache %lu (%lu%%), total %lu",
+                root_slots_size, root_slots_size*100UL/total_size,
+                blockcache_size, blockcache_size*100UL/total_size,
+                txnpages_free_size, txnpages_free_size*100UL/total_size,
+                txnpages_size, txnpages_size*100UL/total_size,
+                nonce_slotcache_size, nonce_slotcache_size*100UL/total_size,
+                nonce_txns_size, nonce_txns_size*100UL/total_size,
+                nonce_blockcache_size, nonce_blockcache_size*100UL/total_size,
+                total_size ));
+
+  tc->lock->value           = 0U;
+  tc->block_pop             = 0U;
+  tc->slot_pop              = 0U;
+  tc->block_pop_max         = 0U;
+  tc->slot_pop_max          = 0U;
+  tc->nonce_slot_pop_max    = 0U;
   tc->root_slots_cnt        = 0UL;
-  tc->constipated_slots_cnt = 0UL;
 
-  tc->root_slots_max             = max_rooted_slots;
-  tc->live_slots_max             = max_live_slots;
-  tc->constipated_slots_max      = max_constipated_slots;
-  tc->txnpages_per_blockhash_max = max_txnpages_per_blockhash;
-  tc->txnpages_max               = max_txnpages;
+  tc->root_slots_max               = max_rooted_slots;
+  tc->txn_per_slot_max             = max_txn_per_slot;
+  tc->live_slots_max               = max_live_slots;
+  tc->nonce_txns_max               = (uint)max_nonce_txns;
+  tc->nonce_blockcache_entries_max = max_nonce_blockcache_entries;
+  tc->txnpages_per_blockhash_max   = max_txnpages_per_blockhash;
+  tc->txnpages_max                 = max_txnpages;
 
-  ulong * root_slots = (ulong *)_root_slots;
-  memset( root_slots, 0xFF, max_rooted_slots*sizeof(ulong) );
-
-  ulong * constipated_slots = (ulong *)_constipated_slots;
-  memset( constipated_slots, 0xFF, max_constipated_slots*sizeof(ulong) );
-
-  fd_txncache_private_blockcache_t * blockcache = (fd_txncache_private_blockcache_t *)_blockcache;
-  fd_txncache_private_slotcache_t  * slotcache  = (fd_txncache_private_slotcache_t *)_slotcache;
-  ulong * probed_entries = (ulong *)_probed_entries;
   for( ulong i=0UL; i<max_live_slots; i++ ) {
-    blockcache[ i ].max_slot = FD_TXNCACHE_EMPTY_ENTRY;
-    slotcache[ i ].slot      = FD_TXNCACHE_EMPTY_ENTRY;
-    probed_entries[ i ]      = 0UL;
+    fd_txncache_private_blockcache_t * blockcache = fd_txncache_get_blockcache_at_idx( tc, i );
+    blockcache->max_slot                          = FD_TXNCACHE_ENTRY_FREE;
   }
+  fd_memset( _root_slots,       0xFF, max_rooted_slots*sizeof(ulong) );
+  fd_memset( _nonce_txns,       0xFF, max_nonce_txns*sizeof(fd_txncache_private_nonce_txn_t)                      );
+  fd_memset( _nonce_blockcache, 0xFF, max_nonce_blockcache_entries*sizeof(fd_txncache_private_nonce_blockcache_t) );
+  fd_memset( _nonce_slotcache,  0xFF, max_live_slots*sizeof(fd_txncache_private_nonce_slotcache_t)                );
+
+  tc->nonce_blockcache_max_slot               = 0UL;
+  tc->lowest_observed_slot                    = ULONG_MAX;
+  tc->nonce_blockcache_deactivated_slot_delta = ULONG_MAX;
 
   tc->txnpages_free_cnt = max_txnpages;
   uint * txnpages_free  = _txnpages_free;
@@ -423,13 +633,6 @@ fd_txncache_join( void * shtc ) {
     return NULL;
   }
 
-  uchar * base = (uchar *)tc;
-  fd_txncache_private_blockcache_t * blockcache = (fd_txncache_private_blockcache_t *)( base + tc->blockcache_off );
-
-  void * _blockcache_pages = base + tc->blockcache_pages_off;
-  for( ulong i=0UL; i<tc->live_slots_max; i++ ) {
-    blockcache[ i ].pages       = (uint *)_blockcache_pages + i*tc->txnpages_per_blockhash_max;
-  }
   return tc;
 }
 
@@ -437,7 +640,8 @@ void *
 fd_txncache_leave( fd_txncache_t * tc ) {
   if( FD_UNLIKELY( !tc ) ) {
     FD_LOG_WARNING(( "NULL tc" ));
-    return NULL;  }
+    return NULL;
+  }
 
   return (void *)tc;
 }
@@ -469,79 +673,251 @@ fd_txncache_delete( void * shtc ) {
 }
 
 static void
-fd_txncache_remove_blockcache_idx( fd_txncache_t * tc,
-                                   ulong idx ) {
-  fd_txncache_private_blockcache_t * blockcache = fd_txncache_get_blockcache( tc );
-  ulong * probed_entries = fd_txncache_get_probed_entries( tc );
-  uint * txnpages_free = fd_txncache_get_txnpages_free( tc );
-
-  /* Check if removing this element caused there to be no overflow for a hash index. */
-  ulong hash_idx = FD_LOAD( ulong, blockcache[ idx ].blockhash )%tc->live_slots_max;
-
-  ulong j = hash_idx;
-  while( j != idx ) {
-    probed_entries[ j ]--;
-    /* If there is no overflow and the slot is a tombstone, mark it as free. */
-    if( probed_entries[ j ] == 0 && blockcache[ j ].max_slot == FD_TXNCACHE_TOMBSTONE_ENTRY ) {
-      blockcache[ j ].max_slot = FD_TXNCACHE_EMPTY_ENTRY;
-    }
-    j = (j+1)%tc->live_slots_max;
-  }
-
-  /* Remove from block cache. */
-  blockcache[ idx ].max_slot = (probed_entries[ idx ] == 0 ? FD_TXNCACHE_EMPTY_ENTRY : FD_TXNCACHE_TOMBSTONE_ENTRY);
-
-  /* Free pages. */
-  memcpy( txnpages_free+tc->txnpages_free_cnt, blockcache[ idx ].pages, blockcache[ idx ].pages_cnt*sizeof(uint) );
-  tc->txnpages_free_cnt += blockcache[ idx ].pages_cnt;
+fd_txncache_print_state( fd_txncache_t const * tc,
+                         char const *          prefix ) {
+  FD_LOG_INFO(( "%s: rooted %lu/%lu slots, txnpages %u/%u free, blockcache pop curr %u peak %u/%lu, nonce slotcache pop curr %u peak %u/%lu, nonce slotcache per slot pop peak %u/%lu",
+                prefix,
+                tc->root_slots_cnt, tc->root_slots_max,
+                tc->txnpages_free_cnt, tc->txnpages_max,
+                tc->block_pop, tc->block_pop_max, tc->live_slots_max,
+                tc->slot_pop, tc->slot_pop_max, tc->live_slots_max,
+                tc->nonce_slot_pop_max, tc->txn_per_slot_max ));
 }
 
 static void
-fd_txncache_remove_slotcache_idx( fd_txncache_t * tc,
-                                  ulong idx ) {
-  fd_txncache_private_slotcache_t * slotcache = fd_txncache_get_slotcache( tc );
-  slotcache[ idx ].slot = FD_TXNCACHE_TOMBSTONE_ENTRY;
+fd_txncache_print_insert( fd_txncache_insert_t const * txn,
+                          char const *                 prefix ) {
+
+  FD_BASE58_ENCODE_32_BYTES( txn->blockhash, blockhash );
+  if( txn->key_sz==32UL ) {
+    FD_BASE58_ENCODE_32_BYTES( txn->txnhash, key_str );
+    FD_LOG_NOTICE(( "%s: blockhash %s, slot %lu, key %s, res %u",
+                    prefix,
+                    blockhash,
+                    txn->slot,
+                    key_str,
+                    *(txn->result) ));
+  } else if( txn->key_sz==64UL ) {
+    FD_BASE58_ENCODE_64_BYTES( txn->txnhash, key_str );
+    FD_LOG_NOTICE(( "%s: blockhash %s, slot %lu, key %s, res %u",
+                    prefix,
+                    blockhash,
+                    txn->slot,
+                    key_str,
+                    *(txn->result) ));
+  } else {
+    FD_LOG_NOTICE(( "%s: blockhash %s, slot %lu, key %s, res %u",
+                    prefix,
+                    blockhash,
+                    txn->slot,
+                    "(unsupported key length)",
+                    *(txn->result) ));
+  }
+}
+
+/* Assumes key is at least sizeof(ulong) in size.  Inserted keys are
+   either the blockhash or the message hash (blake3) or the signature of
+   a landed transaction.  These are hard to forge, so even if we simply
+   take the first 8 bytes without any additional maths, the likelihood
+   of an attacker crafting payloads to cause excessive slowdowns in the
+   txncache is low.  Could easily add per-validator randomized maths to
+   make the life of an attacker even harder. */
+static inline ulong
+fd_txncache_key_hash( void const * key ) {
+  return FD_LOAD( ulong, key );
+}
+
+static void
+fd_txncache_remove_blockcache_idx( fd_txncache_t * tc,
+                                   ulong           idx ) {
+  fd_txncache_private_blockcache_t * blockcache = fd_txncache_get_blockcache_at_idx( tc, idx );
+  uint * txnpages_free = fd_txncache_get_txnpages_free( tc );
+
+  /* Remove from blockcache and make a hole at idx. */
+  blockcache->max_slot = FD_TXNCACHE_ENTRY_FREE;
+
+  /* Free pages. */
+  uint * pages = fd_txncache_get_blockcache_pages( tc, blockcache );
+  fd_memcpy( txnpages_free+tc->txnpages_free_cnt, pages, blockcache->pages_cnt*sizeof(uint) );
+  tc->txnpages_free_cnt += blockcache->pages_cnt;
+
+  /* Reprobe the hash table. */
+  for(;;) {
+    ulong hole = idx;
+
+    for(;;) {
+      idx        = (idx+1UL) & (tc->live_slots_max-1UL); /* live_slots_max is power of 2. */
+      blockcache = fd_txncache_get_blockcache_at_idx( tc, idx );
+
+      if( blockcache->max_slot==FD_TXNCACHE_ENTRY_FREE ) return;
+
+      ulong hash  = fd_txncache_key_hash( blockcache->blockhash );
+      ulong start = hash & (tc->live_slots_max-1UL);
+      if( !(((hole<start) & (start<=idx)) | ((hole>idx) & ((hole<start) | (start<=idx)))) ) break;
+    }
+
+    fd_txncache_private_blockcache_t * blockcache_hole = fd_txncache_get_blockcache_at_idx( tc, hole );
+
+    /* Move. */
+    fd_memcpy( blockcache_hole, blockcache, tc->blockcache_t_sz );
+
+    /* Make a hole at src of move. */
+    blockcache->max_slot = FD_TXNCACHE_ENTRY_FREE;
+  }
+}
+
+static void
+fd_txncache_remove_nonce_txn_idx( fd_txncache_t * tc,
+                                  uint            idx,
+                                  uint *          next_idx ) {
+  fd_txncache_private_nonce_txn_t * nonce_txns = fd_txncache_get_nonce_txns( tc );
+
+  /* Repair the linked list. */
+  if( FD_UNLIKELY( !nonce_txns[ idx ].slotcache_prev_is_head ) ) {
+    FD_LOG_CRIT(( "invariant violation: nonce txn %u has prev %u", idx, nonce_txns[ idx ].slotcache_prev_val ));
+  }
+  if( FD_LIKELY( nonce_txns[ idx ].slotcache_next!=UINT_MAX ) ) {
+    nonce_txns[ nonce_txns[ idx ].slotcache_next ].slotcache_prev_val = UINT_MAX;
+  }
+
+  /* Remove: make a hole at idx. */
+  nonce_txns[ idx ].slot               = FD_TXNCACHE_ENTRY_FREE_UINT;
+  nonce_txns[ idx ].slotcache_next     = UINT_MAX;
+  nonce_txns[ idx ].slotcache_prev_val = UINT_MAX;
+
+  /* Reprobe the hash table. */
+  for(;;) {
+    uint hole = idx;
+
+    for(;;) {
+      idx = (idx+1U)%tc->nonce_txns_max;
+
+      if( nonce_txns[ idx ].slot==FD_TXNCACHE_ENTRY_FREE_UINT ) return;
+
+      ulong key_hash = fd_txncache_key_hash( nonce_txns[ idx ].txnhash );
+      ulong start = key_hash%tc->nonce_txns_max;
+      if( !(((hole<start) & (start<=idx)) | ((hole>idx) & ((hole<start) | (start<=idx)))) ) break;
+    }
+
+    /* Move. */
+    nonce_txns[ hole ] = nonce_txns[ idx ];
+
+    /* Repair the linked list. */
+    if( FD_LIKELY( nonce_txns[ hole ].slotcache_prev_val!=UINT_MAX ) ) {
+      if( FD_UNLIKELY( nonce_txns[ hole ].slotcache_prev_is_head ) ) {
+        fd_txncache_private_nonce_slotcache_t * nonce_slotcache   = fd_txncache_get_nonce_slotcache( tc );
+        nonce_slotcache[ nonce_txns[ hole ].slotcache_prev ].head = hole;
+      }
+      if( FD_LIKELY( !nonce_txns[ hole ].slotcache_prev_is_head ) ) {
+        nonce_txns[ nonce_txns[ hole ].slotcache_prev ].slotcache_next = hole;
+      }
+    }
+    if( FD_LIKELY( nonce_txns[ hole ].slotcache_next!=UINT_MAX ) ) {
+      if( FD_UNLIKELY( nonce_txns[ nonce_txns[ hole ].slotcache_next ].slotcache_prev_is_head ) ) {
+        FD_LOG_CRIT(( "invariant violation: nonce txn %u (moved from %u) has next %u with prev %u being head prev_val 0x%x", hole, idx, nonce_txns[ hole ].slotcache_next, (uint)nonce_txns[ nonce_txns[ hole ].slotcache_next ].slotcache_prev, nonce_txns[ nonce_txns[ hole ].slotcache_next ].slotcache_prev_val ));
+      }
+      nonce_txns[ nonce_txns[ hole ].slotcache_next ].slotcache_prev = hole&FD_TXNCACHE_NONCE_TXN_IDX_MASK;
+    }
+    if( FD_UNLIKELY( *next_idx==idx ) ) {
+      *next_idx = hole;
+    }
+
+    /* Make a hole at src of move. */
+    nonce_txns[ idx ].slot               = FD_TXNCACHE_ENTRY_FREE_UINT;
+    nonce_txns[ idx ].slotcache_next     = UINT_MAX;
+    nonce_txns[ idx ].slotcache_prev_val = UINT_MAX;
+  }
+}
+
+static void
+fd_txncache_remove_nonce_slotcache_idx( fd_txncache_t * tc,
+                                        ulong           idx ) {
+  fd_txncache_private_nonce_slotcache_t * nonce_slotcache = fd_txncache_get_nonce_slotcache( tc );
+  fd_txncache_private_nonce_txn_t *       nonce_txns      = fd_txncache_get_nonce_txns( tc );
+
+  /* Remove all nonce txns in the slot. */
+  uint nonce_txn_idx = nonce_slotcache[ idx ].head;
+  while( nonce_txn_idx!=UINT_MAX ) {
+    uint next_nonce_txn_idx = nonce_txns[ nonce_txn_idx ].slotcache_next;
+    fd_txncache_remove_nonce_txn_idx( tc, nonce_txn_idx, &next_nonce_txn_idx );
+    nonce_slotcache[ idx ].nonce_slot_pop--;
+    nonce_txn_idx = next_nonce_txn_idx;
+  }
+  if( FD_UNLIKELY( nonce_slotcache[ idx ].nonce_slot_pop!=0U ) ) {
+    FD_LOG_CRIT(( "invariant violation: nonce slotcache %lu slot %lu has nonce_slot_pop %u after purging, tc->slot_pop %u", idx, nonce_slotcache[ idx ].slot, nonce_slotcache[ idx ].nonce_slot_pop, tc->slot_pop ));
+  }
+
+  /* Remove from slotcache and make a hole at idx. */
+  nonce_slotcache[ idx ].slot = FD_TXNCACHE_ENTRY_FREE;
+
+  /* Reprobe the hash table. */
+  for(;;) {
+    ulong hole = idx;
+
+    for(;;) {
+      idx = (idx+1UL) & (tc->live_slots_max-1UL); /* live_slots_max is power of 2. */
+
+      if( nonce_slotcache[ idx ].slot==FD_TXNCACHE_ENTRY_FREE ) return;
+
+      ulong start = nonce_slotcache[ idx ].slot & (tc->live_slots_max-1UL);
+      if( !(((hole<start) & (start<=idx)) | ((hole>idx) & ((hole<start) | (start<=idx)))) ) break;
+    }
+
+    nonce_slotcache[ hole ] = nonce_slotcache[ idx ];
+    /* Make a hole at src of move. */
+    nonce_slotcache[ idx ].slot = FD_TXNCACHE_ENTRY_FREE;
+  }
 }
 
 static void
 fd_txncache_purge_slot( fd_txncache_t * tc,
                         ulong           slot ) {
-  ulong not_purged_cnt = 0;
-  ulong purged_cnt = 0;
-  ulong max_distance = 0;
-  ulong sum_distance = 0;
-  ulong empty_entry_cnt = 0;
-  ulong tombstone_entry_cnt = 0;
-  fd_txncache_private_blockcache_t * blockcache = fd_txncache_get_blockcache( tc );
-  for( ulong i=0UL; i<tc->live_slots_max; i++ ) {
-    if( FD_LIKELY( blockcache[ i ].max_slot==FD_TXNCACHE_EMPTY_ENTRY || blockcache[ i ].max_slot==FD_TXNCACHE_TOMBSTONE_ENTRY || (blockcache[ i ].max_slot)>slot ) ) {
-      if( blockcache[ i ].max_slot==FD_TXNCACHE_EMPTY_ENTRY ) {
-        empty_entry_cnt++;
-      } else if ( blockcache[ i ].max_slot==FD_TXNCACHE_TOMBSTONE_ENTRY ) {
-        tombstone_entry_cnt++;
-      } else {
+  ulong not_purged_cnt = 0UL;
+  ulong purged_cnt     = 0UL;
+  ulong max_distance   = 0UL;
+  ulong sum_distance   = 0UL;
+  for( ulong i=0UL; i<tc->live_slots_max; /* manually advance i */ ) {
+    fd_txncache_private_blockcache_t * blockcache = fd_txncache_get_blockcache_at_idx( tc, i );
+    if( FD_UNLIKELY( blockcache->max_slot==FD_TXNCACHE_ENTRY_NEW ) ) {
+      FD_LOG_CRIT(( "invariant violation: blockcache %lu has max_slot set to ENTRY_NEW during purge", i ));
+    }
+    if( FD_LIKELY( blockcache->max_slot==FD_TXNCACHE_ENTRY_FREE || blockcache->max_slot>slot ) ) {
+      if( blockcache->max_slot!=FD_TXNCACHE_ENTRY_FREE ) {
         not_purged_cnt++;
-        ulong dist = blockcache[ i ].max_slot-slot;
-        max_distance = fd_ulong_max( max_distance, dist );
-        sum_distance += blockcache[ i ].max_slot-slot;
+        ulong dist    = blockcache->max_slot-slot;
+        max_distance  = fd_ulong_max( max_distance, dist );
+        sum_distance += dist;
       }
+      i++;
       continue;
     }
     fd_txncache_remove_blockcache_idx( tc, i );
+    tc->block_pop--; /* No atomic fetch and add because global lock is held. */
     purged_cnt++;
   }
   ulong avg_distance = (not_purged_cnt==0) ? ULONG_MAX : (sum_distance/not_purged_cnt);
-  FD_LOG_INFO(( "not purging cnt - purge_slot: %lu, purged_cnt: %lu, not_purged_cnt: %lu, empty_entry_cnt: %lu, tombstone_entry_cnt: %lu, max_distance: %lu, avg_distance: %lu",
-      slot, purged_cnt, not_purged_cnt, empty_entry_cnt, tombstone_entry_cnt, max_distance, avg_distance ));
+  FD_LOG_INFO(( "purge_slot: %lu, purged_cnt: %lu, not_purged_cnt: %lu, max_distance: %lu, avg_distance: %lu",
+                slot, purged_cnt, not_purged_cnt, max_distance, avg_distance ));
 
-  /* TODO: figure out how to make slotcache purging work with the max_slot purge for blockcache.
-     The blockcache and slotcache share txnpages and the aggressive purging from the blockcache
-     can lead to corruption in the slotcache. Does it make sense to generate the delta map (as
-     generated by Agave) from the blockcache when producing snapshots? TBD. */
-  fd_txncache_private_slotcache_t * slotcache = fd_txncache_get_slotcache( tc );
-  for( ulong i=0UL; i<tc->live_slots_max; i++ ) {
-    if( FD_LIKELY( slotcache[ i ].slot==FD_TXNCACHE_EMPTY_ENTRY || slotcache[ i ].slot==FD_TXNCACHE_TOMBSTONE_ENTRY || slotcache[ i ].slot>slot ) ) continue;
-    fd_txncache_remove_slotcache_idx( tc, i );
+  /* The whole txncache is write locked, so it is okay for the
+     blockcache and the slotcache to be out of sync for a short while.
+   */
+
+  fd_txncache_private_nonce_slotcache_t * nonce_slotcache = fd_txncache_get_nonce_slotcache( tc );
+  for( ulong i=0UL; i<tc->live_slots_max; /* manually advance i */ ) {
+    if( FD_LIKELY( nonce_slotcache[ i ].slot==FD_TXNCACHE_ENTRY_FREE || nonce_slotcache[ i ].slot>slot ) ) {
+      i++;
+      continue;
+    }
+    if( FD_LIKELY( !( tc->root_slots_cnt==0UL || tc->nonce_blockcache_deactivated_slot_delta==ULONG_MAX ) ) ) {
+      /* For slots loaded from an Agave snapshot, we insert all
+         transactions as nonce transactions.  This makes the nonce slot
+         population count inflated.  So we don't track these slots into
+         the max count. */
+      tc->nonce_slot_pop_max = fd_uint_max( tc->nonce_slot_pop_max, nonce_slotcache[ i ].nonce_slot_pop );
+    }
+    fd_txncache_remove_nonce_slotcache_idx( tc, i );
+    tc->slot_pop--; /* No atomic fetch and add because global lock is held. */
   }
 }
 
@@ -553,19 +929,30 @@ static void
 fd_txncache_register_root_slot_private( fd_txncache_t * tc,
                                         ulong           slot ) {
 
+  FD_TEST( fd_rwlock_iswrite( tc->lock ) );
+
   ulong * root_slots = fd_txncache_get_root_slots( tc );
   ulong idx;
   for( idx=0UL; idx<tc->root_slots_cnt; idx++ ) {
-    if( FD_UNLIKELY( root_slots[ idx ]==slot ) ) return;
-    if( FD_UNLIKELY( root_slots[ idx ]>slot ) ) break;
+    if( FD_UNLIKELY( root_slots[ idx ]==slot ) ) return; /* Slot already registered. */
+    if( FD_UNLIKELY( root_slots[ idx ]>slot  ) ) break;  /* Would like to insert at idx if pushing right, and idx-1 if evicting left. */
   }
 
   if( FD_UNLIKELY( tc->root_slots_cnt>=tc->root_slots_max ) ) {
     if( FD_LIKELY( idx ) ) {
+      if( FD_UNLIKELY( tc->nonce_blockcache_deactivated_slot_delta==ULONG_MAX ) ) {
+        if( FD_UNLIKELY( root_slots[ 0 ]>=tc->nonce_blockcache_max_slot ) ) {
+          tc->nonce_blockcache_deactivated_slot_delta = root_slots[ 0 ]-tc->lowest_observed_slot;
+          FD_LOG_INFO(( "deactivated nonce blockcache at slot %lu, delta %lu", root_slots[ 0 ], tc->nonce_blockcache_deactivated_slot_delta ));
+        }
+      }
       fd_txncache_purge_slot( tc, root_slots[ 0 ] );
       memmove( root_slots, root_slots+1UL, (idx-1UL)*sizeof(ulong) );
       root_slots[ (idx-1UL) ] = slot;
     } else {
+      /* Slot number too small to make its way into rooted slots.
+         Purge transactions that have slipped into the txncache
+         since the last purge. */
       fd_txncache_purge_slot( tc, slot );
     }
   } else {
@@ -583,55 +970,23 @@ fd_txncache_register_root_slot( fd_txncache_t * tc,
 
   fd_rwlock_write( tc->lock );
 
+  /* Update metrics because we might purge and reduce hash table
+     population. */
+  tc->block_pop_max = fd_ushort_max( tc->block_pop_max, tc->block_pop );
+  tc->slot_pop_max  = fd_ushort_max( tc->slot_pop_max,  tc->slot_pop );
+
   fd_txncache_register_root_slot_private( tc, slot );
 
   fd_rwlock_unwrite( tc->lock );
 }
 
 void
-fd_txncache_register_constipated_slot( fd_txncache_t * tc,
-                                       ulong           slot ) {
-
-  fd_rwlock_write( tc->lock );
-
-  if( FD_UNLIKELY( tc->constipated_slots_cnt>=tc->constipated_slots_max ) ) {
-    FD_LOG_ERR(( "Status cache has exceeded constipated max slot count" ));
-  }
-
-  ulong * constipated_slots = fd_txncache_get_constipated_slots( tc );
-  constipated_slots[ tc->constipated_slots_cnt++ ] = slot;
-
-  fd_rwlock_unwrite( tc->lock );
-
-}
-
-void
-fd_txncache_flush_constipated_slots( fd_txncache_t * tc ) {
-
-  /* Register all previously constipated slots and unconstipate registration
-     into the status cache. */
-
-  fd_rwlock_write( tc->lock );
-
-  ulong * constipated_slots = fd_txncache_get_constipated_slots( tc );
-  for( ulong i=0UL; i<tc->constipated_slots_cnt; i++ ) {
-    fd_txncache_register_root_slot_private( tc, constipated_slots[ i ] );
-  }
-  tc->constipated_slots_cnt = 0UL;
-
-  tc->is_constipated = 0;
-
-  fd_rwlock_unwrite( tc->lock );
-
-}
-
-void
 fd_txncache_root_slots( fd_txncache_t * tc,
                         ulong *         out_slots ) {
-  fd_rwlock_write( tc->lock );
+  fd_rwlock_read( tc->lock );
   ulong * root_slots = fd_txncache_get_root_slots( tc );
   memcpy( out_slots, root_slots, tc->root_slots_max*sizeof(ulong) );
-  fd_rwlock_unwrite( tc->lock );
+  fd_rwlock_unread( tc->lock );
 }
 
 #define FD_TXNCACHE_FIND_FOUND      (0)
@@ -639,89 +994,51 @@ fd_txncache_root_slots( fd_txncache_t * tc,
 #define FD_TXNCACHE_FIND_FULL       (2)
 
 static int
-fd_txncache_find_blockhash( fd_txncache_t const *               tc,
+fd_txncache_find_blockhash( fd_txncache_t *                     tc,
                             uchar const                         blockhash[ static 32 ],
-                            uint                                is_insert,
                             fd_txncache_private_blockcache_t ** out_blockcache ) {
-  ulong hash = FD_LOAD( ulong, blockhash );
-  fd_txncache_private_blockcache_t * tc_blockcache = fd_txncache_get_blockcache_const( tc );
-  ulong * probed_entries = fd_txncache_get_probed_entries_const( tc );
-  ulong first_tombstone = ULONG_MAX;
 
+  ulong hash = fd_txncache_key_hash( blockhash );
   for( ulong i=0UL; i<tc->live_slots_max; i++ ) {
     ulong blockcache_idx = (hash+i)%tc->live_slots_max;
-    fd_txncache_private_blockcache_t * blockcache = &tc_blockcache[ blockcache_idx ];
-
-    if( FD_UNLIKELY( blockcache->max_slot==FD_TXNCACHE_EMPTY_ENTRY ) ) {
-      if( first_tombstone != ULONG_MAX ) {
-        *out_blockcache = &tc_blockcache[ first_tombstone ];
-        return FD_TXNCACHE_FIND_FOUNDEMPTY;
-      }
+    fd_txncache_private_blockcache_t * blockcache = fd_txncache_get_blockcache_at_idx( tc, blockcache_idx );
+    if( FD_UNLIKELY( blockcache->max_slot==FD_TXNCACHE_ENTRY_FREE ) ) {
       *out_blockcache = blockcache;
       return FD_TXNCACHE_FIND_FOUNDEMPTY;
-    } else if ( blockcache->max_slot==FD_TXNCACHE_TOMBSTONE_ENTRY ) {
-      if( is_insert && first_tombstone == ULONG_MAX ) {
-        first_tombstone = blockcache_idx;
-      }
-      continue;
     }
-
-    while( FD_UNLIKELY( blockcache->max_slot==FD_TXNCACHE_TEMP_ENTRY ) ) {
+    while( FD_UNLIKELY( FD_VOLATILE_CONST( blockcache->max_slot )==FD_TXNCACHE_ENTRY_XBUSY ) ) {
       FD_SPIN_PAUSE();
     }
     FD_COMPILER_MFENCE(); /* Prevent reordering of the blockhash read to before the atomic lock
                              (highest_slot) has been fully released by the writer. */
     if( FD_LIKELY( !memcmp( blockcache->blockhash, blockhash, 32UL ) ) ) {
       *out_blockcache = blockcache;
-      if( is_insert ) {
-        /* Undo the probed entry changes since we found the blockhash. */
-        for( ulong j=hash%tc->live_slots_max; j!=fd_ulong_min(first_tombstone, blockcache_idx); ) {
-          probed_entries[ j ]--;
-          j = (j+1)%tc->live_slots_max;
-        }
-      }
       return FD_TXNCACHE_FIND_FOUND;
     }
-    /* If the entry we are passing is full and we haven't seen tombstones,
-       there is an overflow. */
-    if( is_insert && first_tombstone == ULONG_MAX ) {
-      probed_entries[ blockcache_idx ]++;
-    }
-  }
-
-  if( first_tombstone != ULONG_MAX ) {
-    *out_blockcache = &tc_blockcache[ first_tombstone ];
-    return FD_TXNCACHE_FIND_FOUNDEMPTY;
   }
   return FD_TXNCACHE_FIND_FULL;
 }
 
 static int
-fd_txncache_find_slot( fd_txncache_t const *              tc,
-                       ulong                              slot,
-                       uint                               is_insert,
-                       fd_txncache_private_slotcache_t ** out_slotcache ) {
-  fd_txncache_private_slotcache_t * tc_slotcache = fd_txncache_get_slotcache_const( tc );
+fd_txncache_find_nonce_slot( fd_txncache_t const *                     tc,
+                             ulong                                     slot,
+                             fd_txncache_private_nonce_slotcache_t * * out_nonce_slotcache ) {
+
+  fd_txncache_private_nonce_slotcache_t * tc_nonce_slotcache = fd_txncache_get_nonce_slotcache( tc );
   for( ulong i=0UL; i<tc->live_slots_max; i++ ) {
-    ulong slotcache_idx = (slot+i)%tc->live_slots_max;
-    fd_txncache_private_slotcache_t * slotcache = &tc_slotcache[ slotcache_idx ];
-    if( FD_UNLIKELY( slotcache->slot==FD_TXNCACHE_EMPTY_ENTRY ) ) {
-      *out_slotcache = slotcache;
+    ulong nonce_slotcache_idx = (slot+i)%tc->live_slots_max;
+    fd_txncache_private_nonce_slotcache_t * nonce_slotcache = &tc_nonce_slotcache[ nonce_slotcache_idx ];
+    if( FD_UNLIKELY( nonce_slotcache->slot==FD_TXNCACHE_ENTRY_FREE ) ) {
+      *out_nonce_slotcache = nonce_slotcache;
       return FD_TXNCACHE_FIND_FOUNDEMPTY;
-    } else if( FD_UNLIKELY( slotcache->slot==FD_TXNCACHE_TOMBSTONE_ENTRY ) ) {
-      if( is_insert ) {
-        *out_slotcache = slotcache;
-        return FD_TXNCACHE_FIND_FOUNDEMPTY;
-      }
-      continue;
     }
-    while( FD_UNLIKELY( slotcache->slot==FD_TXNCACHE_TEMP_ENTRY ) ) {
+    while( FD_UNLIKELY( FD_VOLATILE_CONST( nonce_slotcache->slot )==FD_TXNCACHE_ENTRY_XBUSY ) ) {
       FD_SPIN_PAUSE();
     }
     FD_COMPILER_MFENCE(); /* Prevent reordering of the slot read to before the atomic lock
                              (slot) has been fully released by the writer. */
-    if( FD_LIKELY( slotcache->slot==slot ) ) {
-      *out_slotcache = slotcache;
+    if( FD_LIKELY( nonce_slotcache->slot==slot ) ) {
+      *out_nonce_slotcache = nonce_slotcache;
       return FD_TXNCACHE_FIND_FOUND;
     }
   }
@@ -729,24 +1046,52 @@ fd_txncache_find_slot( fd_txncache_t const *              tc,
 }
 
 static int
-fd_txncache_find_slot_blockhash( fd_txncache_private_slotcache_t *       slotcache,
-                                 uchar const                             blockhash[ static 32 ],
-                                 fd_txncache_private_slotblockcache_t ** out_slotblockcache ) {
-  ulong hash = FD_LOAD( ulong, blockhash );
-  for( ulong i=0UL; i<300UL; i++ ) {
-    ulong slotblockcache_idx = (hash+i)%300UL;
-    fd_txncache_private_slotblockcache_t * slotblockcache = &slotcache->blockcache[ slotblockcache_idx ];
-    if( FD_UNLIKELY( slotblockcache->txnhash_offset==ULONG_MAX ) ) {
-      *out_slotblockcache = slotblockcache;
+fd_txncache_find_nonce_blockhash( fd_txncache_t *                            tc,
+                                  uchar const                                blockhash[ static 32 ],
+                                  fd_txncache_private_nonce_blockcache_t * * out_blockcache ) {
+
+  ulong hash = fd_txncache_key_hash( blockhash );
+  fd_txncache_private_nonce_blockcache_t * tc_nonce_blockcache = fd_txncache_get_nonce_blockcache( tc );
+  for( ulong i=0UL; i<tc->nonce_blockcache_entries_max; i++ ) {
+    ulong blockcache_idx = (hash+i)%tc->nonce_blockcache_entries_max;
+    fd_txncache_private_nonce_blockcache_t * nonce_blockcache = &tc_nonce_blockcache[ blockcache_idx ];
+    if( FD_UNLIKELY( nonce_blockcache->max_slot==FD_TXNCACHE_ENTRY_FREE_UINT ) ) {
+      *out_blockcache = nonce_blockcache;
       return FD_TXNCACHE_FIND_FOUNDEMPTY;
     }
-    while( FD_UNLIKELY( slotblockcache->txnhash_offset==ULONG_MAX-1UL ) ) {
+    while( FD_UNLIKELY( FD_VOLATILE_CONST( nonce_blockcache->max_slot )==FD_TXNCACHE_ENTRY_XBUSY_UINT ) ) {
       FD_SPIN_PAUSE();
     }
-    FD_COMPILER_MFENCE(); /* Prevent reordering of the blockhash read to before the atomic lock
-                             (txnhash_offset) has been fully released by the writer. */
-    if( FD_LIKELY( !memcmp( slotblockcache->blockhash, blockhash, 32UL ) ) ) {
-      *out_slotblockcache = slotblockcache;
+    FD_COMPILER_MFENCE();
+    if( FD_LIKELY( !memcmp( nonce_blockcache->blockhash, blockhash, 32UL ) ) ) {
+      *out_blockcache = nonce_blockcache;
+      return FD_TXNCACHE_FIND_FOUND;
+    }
+  }
+  return FD_TXNCACHE_FIND_FULL;
+}
+
+static int
+fd_txncache_find_nonce_txn( fd_txncache_t const *               tc,
+                            uchar const                         txnhash[ static FD_TXNCACHE_KEY_SIZE ],
+                            void *                              query_func_ctx,
+                            int ( * query_func )( ulong slot, void * ctx ),
+                            fd_txncache_private_nonce_txn_t * * out_nonce_txn ) {
+  ulong key_hash = fd_txncache_key_hash( txnhash );
+  fd_txncache_private_nonce_txn_t * nonce_txns = fd_txncache_get_nonce_txns( tc );
+  for( uint i=0U; i<tc->nonce_txns_max; i++ ) {
+    ulong nonce_txn_idx = (key_hash+i)%tc->nonce_txns_max;
+    fd_txncache_private_nonce_txn_t * nonce_txn = &nonce_txns[ nonce_txn_idx ];
+    if( FD_LIKELY( nonce_txn->slot==FD_TXNCACHE_ENTRY_FREE_UINT ) ) {
+      *out_nonce_txn = nonce_txn;
+      return FD_TXNCACHE_FIND_FOUNDEMPTY;
+    }
+    while( FD_UNLIKELY( FD_VOLATILE_CONST( nonce_txn->slot )==FD_TXNCACHE_ENTRY_XBUSY_UINT ) ) {
+      FD_SPIN_PAUSE();
+    }
+    FD_COMPILER_MFENCE();
+    if( FD_UNLIKELY( !memcmp( nonce_txn->txnhash, txnhash, FD_TXNCACHE_KEY_SIZE ) && ( !query_func || query_func( nonce_txn->slot, query_func_ctx ) ) ) ) {
+      *out_nonce_txn = nonce_txn;
       return FD_TXNCACHE_FIND_FOUND;
     }
   }
@@ -758,20 +1103,19 @@ fd_txncache_ensure_blockcache( fd_txncache_t *                     tc,
                                uchar const                         blockhash[ static 32 ],
                                fd_txncache_private_blockcache_t ** out_blockcache ) {
   for(;;) {
-    int blockcache_find = fd_txncache_find_blockhash( tc, blockhash, 1, out_blockcache );
+    int blockcache_find = fd_txncache_find_blockhash( tc, blockhash, out_blockcache );
     if( FD_LIKELY( blockcache_find==FD_TXNCACHE_FIND_FOUND ) ) return 1;
     else if( FD_UNLIKELY( blockcache_find==FD_TXNCACHE_FIND_FULL ) ) return 0;
 
-    if( FD_LIKELY( FD_ATOMIC_CAS( &(*out_blockcache)->max_slot, FD_TXNCACHE_EMPTY_ENTRY, FD_TXNCACHE_TEMP_ENTRY ) ||
-        FD_ATOMIC_CAS( &(*out_blockcache)->max_slot, FD_TXNCACHE_TOMBSTONE_ENTRY, FD_TXNCACHE_TEMP_ENTRY ) ) ) {
+    if( FD_LIKELY( FD_TXNCACHE_ENTRY_FREE==FD_ATOMIC_CAS( &((*out_blockcache)->max_slot), FD_TXNCACHE_ENTRY_FREE, FD_TXNCACHE_ENTRY_XBUSY ) ) ) {
       memcpy( (*out_blockcache)->blockhash, blockhash, 32UL );
-      memset( (*out_blockcache)->heads, 0xFF, FD_TXNCACHE_BLOCKCACHE_MAP_CNT*sizeof(uint) );
-      (*out_blockcache)->pages_cnt      = 0;
-      (*out_blockcache)->txnhash_offset = 0UL;
-      memset( (*out_blockcache)->pages, 0xFF, tc->txnpages_per_blockhash_max*sizeof(uint) );
+      memset( (*out_blockcache)->heads, 0xFF, tc->txn_per_slot_max*sizeof(uint) );
+      (*out_blockcache)->pages_cnt = 0;
+      uint * pages = fd_txncache_get_blockcache_pages( tc, *out_blockcache );
+      memset( pages, 0xFF, tc->txnpages_per_blockhash_max*sizeof(uint) );
+      FD_ATOMIC_FETCH_AND_ADD( &tc->block_pop, 1U );
       FD_COMPILER_MFENCE();
-      /* Set it to max unreserved value possible */
-      (*out_blockcache)->max_slot    = ULONG_MAX-3UL;
+      (*out_blockcache)->max_slot       = FD_TXNCACHE_ENTRY_NEW;
       return 1;
     }
     FD_SPIN_PAUSE();
@@ -779,19 +1123,18 @@ fd_txncache_ensure_blockcache( fd_txncache_t *                     tc,
 }
 
 static int
-fd_txncache_ensure_slotcache( fd_txncache_t *                    tc,
-                              ulong                              slot,
-                              fd_txncache_private_slotcache_t ** out_slotcache ) {
+fd_txncache_ensure_nonce_slotcache( fd_txncache_t *                           tc,
+                                    ulong                                     slot,
+                                    fd_txncache_private_nonce_slotcache_t * * out_slotcache ) {
   for(;;) {
-    int slotcache_find = fd_txncache_find_slot( tc, slot, 1, out_slotcache );
+    int slotcache_find = fd_txncache_find_nonce_slot( tc, slot, out_slotcache );
     if( FD_LIKELY( slotcache_find==FD_TXNCACHE_FIND_FOUND ) ) return 1;
     else if( FD_UNLIKELY( slotcache_find==FD_TXNCACHE_FIND_FULL ) ) return 0;
 
-    if( FD_LIKELY( FD_ATOMIC_CAS( &(*out_slotcache)->slot, FD_TXNCACHE_EMPTY_ENTRY, FD_TXNCACHE_TEMP_ENTRY ) ||
-        FD_ATOMIC_CAS( &(*out_slotcache)->slot, FD_TXNCACHE_TOMBSTONE_ENTRY, FD_TXNCACHE_TEMP_ENTRY ) ) ) {
-      for( ulong i=0UL; i<300UL; i++ ) {
-        (*out_slotcache)->blockcache[ i ].txnhash_offset = ULONG_MAX;
-      }
+    if( FD_LIKELY( FD_TXNCACHE_ENTRY_FREE==FD_ATOMIC_CAS( &(*out_slotcache)->slot, FD_TXNCACHE_ENTRY_FREE, FD_TXNCACHE_ENTRY_XBUSY ) ) ) {
+      (*out_slotcache)->nonce_slot_pop = 0U;
+      FD_ATOMIC_FETCH_AND_ADD( &tc->slot_pop, 1U );
+      (*out_slotcache)->head = UINT_MAX;
       FD_COMPILER_MFENCE();
       (*out_slotcache)->slot = slot;
       return 1;
@@ -801,45 +1144,119 @@ fd_txncache_ensure_slotcache( fd_txncache_t *                    tc,
 }
 
 static int
-fd_txncache_ensure_slotblockcache( fd_txncache_private_slotcache_t *       slotcache,
-                                   uchar const                             blockhash[ static 32 ],
-                                   fd_txncache_private_slotblockcache_t ** out_slotblockcache ) {
+fd_txncache_ensure_nonce_blockcache( fd_txncache_t *                            tc,
+                                     uchar const                                blockhash[ static 32 ],
+                                     fd_txncache_private_nonce_blockcache_t * * out_blockcache ) {
   for(;;) {
-    int slotblockcache_find = fd_txncache_find_slot_blockhash( slotcache, blockhash, out_slotblockcache );
-    if( FD_LIKELY( slotblockcache_find==FD_TXNCACHE_FIND_FOUND ) ) return 1;
-    else if( FD_UNLIKELY( slotblockcache_find==FD_TXNCACHE_FIND_FULL ) ) return 0;
+    int blockcache_find = fd_txncache_find_nonce_blockhash( tc, blockhash, out_blockcache );
+    if( FD_LIKELY( blockcache_find==FD_TXNCACHE_FIND_FOUND ) ) return 1;
+    else if( FD_UNLIKELY( blockcache_find==FD_TXNCACHE_FIND_FULL ) ) return 0;
 
-    if( FD_LIKELY( FD_ATOMIC_CAS( &(*out_slotblockcache)->txnhash_offset, ULONG_MAX, ULONG_MAX-1UL ) ) ) {
-      memcpy( (*out_slotblockcache)->blockhash, blockhash, 32UL );
-      memset( (*out_slotblockcache)->heads, 0xFF, FD_TXNCACHE_SLOTCACHE_MAP_CNT*sizeof(uint) );
+    if( FD_LIKELY( FD_TXNCACHE_ENTRY_FREE_UINT==FD_ATOMIC_CAS( &((*out_blockcache)->max_slot), FD_TXNCACHE_ENTRY_FREE_UINT, FD_TXNCACHE_ENTRY_XBUSY_UINT ) ) ) {
+      memcpy( (*out_blockcache)->blockhash, blockhash, 32UL );
+      (*out_blockcache)->txnhash_offset = 0UL;
       FD_COMPILER_MFENCE();
-      (*out_slotblockcache)->txnhash_offset = 0UL;
+      (*out_blockcache)->max_slot       = FD_TXNCACHE_ENTRY_NEW_UINT;
       return 1;
     }
     FD_SPIN_PAUSE();
   }
 }
 
+static int
+query_func_identical_slot( ulong slot, void * _ctx ) {
+  ulong * target_slot = (ulong *)_ctx;
+  if( FD_LIKELY( slot==*target_slot ) ) return 1;
+
+  return 0;
+}
+
+static fd_txncache_private_nonce_txn_t *
+fd_txncache_ensure_new_nonce_txn( fd_txncache_t *                          tc,
+                                  fd_txncache_private_nonce_blockcache_t * blockcache,
+                                  fd_txncache_insert_t const *             txn ) {
+
+  ulong txnhash_offset = 0UL;
+  if( FD_UNLIKELY( blockcache ) ) {
+    txnhash_offset = blockcache->txnhash_offset;
+  }
+  if( FD_UNLIKELY( txnhash_offset ) ) {
+    /* https://github.com/anza-xyz/agave/blob/v2.1.13/runtime/src/status_cache.rs#L185
+
+       We get these non-zero offset values only for slots loaded from
+       an Agave snapshot.  These slots will be gradually evicted over
+       time, and eventually all of our offsets will be 0.  Optimize
+       branch for the common case and accept a slow start.
+
+       Also note that Agave doesn't actually propagate key offsets
+       that exceed what's reasonable for a 32-byte transaction message
+       hash.  In other words, key offsets in Agave snapshots don't
+       actually exceed 11.  This is because Agave inserts the 32-byte
+       transaction message hash first, and the 64-byte transaction
+       signature second.  So any new blockcache entry will rng a key
+       offset in [0, 11].  However, we still do the following offset
+       capping, which Agave also does, in case things change.
+
+       Why 11 and not 12, you might ask.  The max key offset
+       calculation in Agave is off by one.  We replicate that here. */
+    ulong max_key_idx = fd_ulong_sat_sub( txn->key_sz, FD_TXNCACHE_KEY_SIZE+1UL );
+    txnhash_offset = fd_ulong_min( txnhash_offset, max_key_idx );
+  }
+
+  for(;;) {
+    fd_txncache_private_nonce_txn_t * nonce_txn;
+    ulong slot = txn->slot;
+    /* The query function checks if the nonce txn is already in the
+       table.  This is a cheap defensive check to catch duplicate
+       insertions.  We could easily remove this check and always try to
+       find an empty entry, but duplicate insertions really shouldn't be
+       allowed. */
+    int nonce_txn_find = fd_txncache_find_nonce_txn( tc, txn->txnhash+txnhash_offset, &slot, query_func_identical_slot, &nonce_txn );
+    if( FD_UNLIKELY( nonce_txn_find==FD_TXNCACHE_FIND_FULL ) ) {
+      FD_LOG_WARNING(( "nonce txn table full" ));
+      return NULL;
+    }
+    if( FD_UNLIKELY( nonce_txn_find==FD_TXNCACHE_FIND_FOUND ) ) FD_LOG_CRIT(( "invariant violation: nonce txn table found existing nonce txn for slot %u and the duplicate is for slot %lu", nonce_txn->slot, slot ));
+
+    if( FD_LIKELY( FD_TXNCACHE_ENTRY_FREE_UINT==FD_ATOMIC_CAS( &nonce_txn->slot, FD_TXNCACHE_ENTRY_FREE_UINT, FD_TXNCACHE_ENTRY_XBUSY_UINT ) ) ) {
+      memcpy( nonce_txn->txnhash, txn->txnhash+txnhash_offset, FD_TXNCACHE_KEY_SIZE );
+      return nonce_txn;
+    }
+    FD_SPIN_PAUSE();
+  }
+
+}
+
 static fd_txncache_private_txnpage_t *
 fd_txncache_ensure_txnpage( fd_txncache_t *                    tc,
                             fd_txncache_private_blockcache_t * blockcache ) {
   ushort page_cnt = blockcache->pages_cnt;
-  if( FD_UNLIKELY( page_cnt>tc->txnpages_per_blockhash_max ) ) return NULL;
+  if( FD_UNLIKELY( page_cnt>tc->txnpages_per_blockhash_max ) ) {
+    FD_LOG_NOTICE(( "pagecnt %u > txnpages_per_blockhash_max %u", page_cnt, tc->txnpages_per_blockhash_max ));
+    return NULL;
+  }
   fd_txncache_private_txnpage_t * txnpages = fd_txncache_get_txnpages( tc );
 
+  uint * pages = fd_txncache_get_blockcache_pages( tc, blockcache );
   if( FD_LIKELY( page_cnt ) ) {
-    uint txnpage_idx = blockcache->pages[ page_cnt-1 ];
+    uint txnpage_idx = pages[ page_cnt-1 ];
     ushort txnpage_free = txnpages[ txnpage_idx ].free;
     if( FD_LIKELY( txnpage_free ) ) {
       return &txnpages[ txnpage_idx ];
     }
   }
 
-  if( FD_UNLIKELY( page_cnt==tc->txnpages_per_blockhash_max ) ) return NULL;
-  if( FD_LIKELY( FD_ATOMIC_CAS( &blockcache->pages[ page_cnt ], UINT_MAX, UINT_MAX-1UL )==UINT_MAX ) ) {
+  if( FD_UNLIKELY( page_cnt==tc->txnpages_per_blockhash_max ) ) {
+    FD_LOG_NOTICE(( "pagecnt %u == txnpages_per_blockhash_max %u but we need more", page_cnt, tc->txnpages_per_blockhash_max ));
+    return NULL;
+  }
+  if( FD_LIKELY( FD_ATOMIC_CAS( &pages[ page_cnt ], FD_TXNCACHE_ENTRY_FREE_UINT, FD_TXNCACHE_ENTRY_XBUSY_UINT )==FD_TXNCACHE_ENTRY_FREE_UINT ) ) {
     ulong txnpages_free_cnt = tc->txnpages_free_cnt;
     for(;;) {
-      if( FD_UNLIKELY( !txnpages_free_cnt ) ) return NULL;
+      if( FD_UNLIKELY( !txnpages_free_cnt ) ) {
+        FD_LOG_NOTICE(( "txnpages_free_cnt %lu == 0 but we need more", txnpages_free_cnt ));
+        return NULL;
+      }
       ulong old_txnpages_free_cnt = FD_ATOMIC_CAS( &tc->txnpages_free_cnt, (uint)txnpages_free_cnt, (uint)(txnpages_free_cnt-1UL) );
       if( FD_LIKELY( old_txnpages_free_cnt==txnpages_free_cnt ) ) break;
       txnpages_free_cnt = old_txnpages_free_cnt;
@@ -851,26 +1268,26 @@ fd_txncache_ensure_txnpage( fd_txncache_t *                    tc,
     fd_txncache_private_txnpage_t * txnpage = &txnpages[ txnpage_idx ];
     txnpage->free = FD_TXNCACHE_TXNS_PER_PAGE;
     FD_COMPILER_MFENCE();
-    blockcache->pages[ page_cnt ] = txnpage_idx;
+    pages[ page_cnt ] = txnpage_idx;
     FD_COMPILER_MFENCE();
     blockcache->pages_cnt = (ushort)(page_cnt+1);
     return txnpage;
   } else {
-    uint txnpage_idx = blockcache->pages[ page_cnt ];
-    while( FD_UNLIKELY( txnpage_idx>=UINT_MAX-1UL ) ) {
-      txnpage_idx = blockcache->pages[ page_cnt ];
+    uint txnpage_idx = pages[ page_cnt ];
+    while( FD_UNLIKELY( txnpage_idx>=FD_TXNCACHE_ENTRY_XBUSY_UINT ) ) {
+      txnpage_idx = FD_VOLATILE_CONST( pages[ page_cnt ] );
       FD_SPIN_PAUSE();
     }
     return &txnpages[ txnpage_idx ];
   }
 }
 
+/* Returns 0 on failure, 1 on success. */
 static int
-fd_txncache_insert_txn( fd_txncache_t *                        tc,
-                        fd_txncache_private_blockcache_t *     blockcache,
-                        fd_txncache_private_slotblockcache_t * slotblockcache,
-                        fd_txncache_private_txnpage_t *        txnpage,
-                        fd_txncache_insert_t const *           txn ) {
+fd_txncache_insert_regular_txn_do( fd_txncache_t *                    tc,
+                                   fd_txncache_private_blockcache_t * blockcache,
+                                   fd_txncache_private_txnpage_t *    txnpage,
+                                   fd_txncache_insert_t const *       txn ) {
   fd_txncache_private_txnpage_t * txnpages = fd_txncache_get_txnpages( tc );
   ulong txnpage_idx = (ulong)(txnpage - txnpages);
 
@@ -880,15 +1297,13 @@ fd_txncache_insert_txn( fd_txncache_t *                        tc,
     if( FD_UNLIKELY( FD_ATOMIC_CAS( &txnpage->free, txnpage_free, txnpage_free-1UL )!=txnpage_free ) ) continue;
 
     ulong txn_idx = FD_TXNCACHE_TXNS_PER_PAGE-txnpage_free;
-    ulong txnhash_offset = blockcache->txnhash_offset;
-    ulong txnhash = FD_LOAD( ulong, txn->txnhash+txnhash_offset );
-    memcpy( txnpage->txns[ txn_idx ]->txnhash, txn->txnhash+txnhash_offset, 20UL );
-    txnpage->txns[ txn_idx ]->result = *txn->result;
-    txnpage->txns[ txn_idx ]->slot   = txn->slot;
+    ulong txnhash = fd_txncache_key_hash( txn->txnhash ); /* The main txn cache always offsets the txnhash by 0. */
+    memcpy( txnpage->txns[ txn_idx ]->txnhash, txn->txnhash, FD_TXNCACHE_KEY_SIZE );
+    txnpage->txns[ txn_idx ]->slot = txn->slot;
     FD_COMPILER_MFENCE();
 
     for(;;) {
-      ulong txn_bucket = txnhash%FD_TXNCACHE_BLOCKCACHE_MAP_CNT;
+      ulong txn_bucket = txnhash%tc->txn_per_slot_max;
       uint head = blockcache->heads[ txn_bucket ];
       txnpage->txns[ txn_idx ]->blockcache_next = head;
       FD_COMPILER_MFENCE();
@@ -897,18 +1312,8 @@ fd_txncache_insert_txn( fd_txncache_t *                        tc,
     }
 
     for(;;) {
-      ulong txn_bucket = txnhash%FD_TXNCACHE_SLOTCACHE_MAP_CNT;
-      uint head = slotblockcache->heads[ txn_bucket ];
-      txnpage->txns[ txn_idx ]->slotblockcache_next = head;
-      FD_COMPILER_MFENCE();
-      if( FD_LIKELY( FD_ATOMIC_CAS( &slotblockcache->heads[ txn_bucket ], head, (uint)(FD_TXNCACHE_TXNS_PER_PAGE*txnpage_idx+txn_idx) )==head ) ) break;
-      FD_SPIN_PAUSE();
-    }
-
-    for(;;) {
       ulong max_slot = blockcache->max_slot;
-
-      if( FD_UNLIKELY( txn->slot<=max_slot && max_slot != ULONG_MAX-3UL) ) break;
+      if( FD_UNLIKELY( txn->slot<=max_slot && max_slot!=FD_TXNCACHE_ENTRY_NEW ) ) break;
       if( FD_LIKELY( FD_ATOMIC_CAS( &blockcache->max_slot, max_slot, txn->slot )==max_slot ) ) break;
       FD_SPIN_PAUSE();
     }
@@ -916,41 +1321,191 @@ fd_txncache_insert_txn( fd_txncache_t *                        tc,
   }
 }
 
+static void
+fd_txncache_insert_nonce_txn_do( fd_txncache_t *                          tc,
+                                 fd_txncache_private_nonce_slotcache_t *  nonce_slotcache,
+                                 fd_txncache_private_nonce_blockcache_t * nonce_blockcache,
+                                 fd_txncache_private_nonce_txn_t *        nonce_txn,
+                                 fd_txncache_insert_t const *             txn ) {
+
+  fd_txncache_private_nonce_txn_t * nonce_txns = fd_txncache_get_nonce_txns( tc );
+  uint nonce_txn_idx = (uint)(nonce_txn-nonce_txns);
+  nonce_txn->slotcache_prev_is_head = 1;
+  nonce_txn->slotcache_prev         = ((uint)(nonce_slotcache-fd_txncache_get_nonce_slotcache( tc )))&FD_TXNCACHE_NONCE_TXN_IDX_MASK;
+  for(;;) {
+    uint head = FD_VOLATILE_CONST( nonce_slotcache->head );
+    nonce_txn->slotcache_next = head;
+    FD_COMPILER_MFENCE();
+    if( FD_LIKELY( FD_ATOMIC_CAS( &nonce_slotcache->head, head, nonce_txn_idx )==head ) ) {
+      if( FD_LIKELY( head!=UINT_MAX ) ) {
+        nonce_txns[ head ].slotcache_prev         = nonce_txn_idx&FD_TXNCACHE_NONCE_TXN_IDX_MASK;
+        nonce_txns[ head ].slotcache_prev_is_head = 0;
+      }
+      FD_ATOMIC_FETCH_AND_ADD( &nonce_slotcache->nonce_slot_pop, 1U );
+      break;
+    }
+    FD_SPIN_PAUSE();
+  }
+
+  ulong * root_slots = fd_txncache_get_root_slots( tc );
+  if( FD_UNLIKELY( nonce_blockcache && ( txn->flags&FD_TXNCACHE_FLAG_SNAPSHOT || tc->root_slots_cnt==0UL || nonce_blockcache->max_slot>=root_slots[ 0UL ] ) ) ) {
+    for(;;) {
+      uint max_slot     = FD_VOLATILE_CONST( nonce_blockcache->max_slot );
+      uint new_max_slot = (uint)txn->slot; /* Safe cast because we checked earlier. */
+      if( FD_UNLIKELY( new_max_slot<=max_slot && max_slot!=FD_TXNCACHE_ENTRY_NEW_UINT ) ) break;
+      if( FD_LIKELY( FD_ATOMIC_CAS( &nonce_blockcache->max_slot, max_slot, new_max_slot )==max_slot ) ) break;
+      FD_SPIN_PAUSE();
+    }
+    for(;;) {
+      ulong max_slot = FD_VOLATILE_CONST( tc->nonce_blockcache_max_slot );
+      if( FD_UNLIKELY( txn->slot<=max_slot ) ) break;
+      if( FD_LIKELY( FD_ATOMIC_CAS( &tc->nonce_blockcache_max_slot, max_slot, txn->slot )==max_slot ) ) break;
+      FD_SPIN_PAUSE();
+    }
+  }
+
+  if( FD_UNLIKELY( nonce_txn->slot!=FD_TXNCACHE_ENTRY_XBUSY_UINT ) ) {
+    FD_LOG_CRIT(( "invariant violation: nonce txn slot already set to %u", nonce_txn->slot ));
+  }
+  FD_COMPILER_MFENCE();
+  /* Safe cast because we checked for overflow at the very beginning of
+     insert. */
+  nonce_txn->slot = (uint)txn->slot;
+
+}
+
+/* Returns 0 on failure, 1 on success. */
+static int
+fd_txncache_insert_nonce_txn( fd_txncache_t *              tc,
+                              fd_txncache_insert_t const * txn ) {
+
+  fd_txncache_private_nonce_slotcache_t * nonce_slotcache;
+  if( FD_UNLIKELY( !fd_txncache_ensure_nonce_slotcache( tc, txn->slot, &nonce_slotcache ) ) ) {
+    fd_txncache_print_insert( txn, "failed to ensure nonce slotcache entry" );
+    fd_txncache_print_state( tc, "failed to ensure nonce slotcache entry" );
+    return 0;
+  }
+
+  fd_txncache_private_nonce_blockcache_t * nonce_blockcache = NULL;
+  if( FD_UNLIKELY( txn->flags&FD_TXNCACHE_FLAG_SNAPSHOT || tc->root_slots_cnt==0UL || tc->nonce_blockcache_deactivated_slot_delta==ULONG_MAX ) ) {
+    if( FD_UNLIKELY( !fd_txncache_ensure_nonce_blockcache( tc, txn->blockhash, &nonce_blockcache ) ) ) {
+      fd_txncache_print_insert( txn, "failed to ensure nonce blockcache entry" );
+      fd_txncache_print_state( tc, "failed to ensure nonce blockcache entry" );
+      return 0;
+    }
+  }
+
+  fd_txncache_private_nonce_txn_t * nonce_txn = fd_txncache_ensure_new_nonce_txn( tc, nonce_blockcache, txn );
+  if( FD_UNLIKELY( !nonce_txn ) ) {
+    fd_txncache_print_insert( txn, "failed to ensure nonce txn" );
+    fd_txncache_print_state( tc, "failed to ensure nonce txn" );
+    return 0;
+  }
+
+  fd_txncache_insert_nonce_txn_do( tc, nonce_slotcache, nonce_blockcache, nonce_txn, txn );
+
+  for(;;) {
+    ulong lowest_observed_slot = tc->lowest_observed_slot;
+    if( FD_UNLIKELY( txn->slot<lowest_observed_slot ) ) {
+      if( FD_LIKELY( FD_ATOMIC_CAS( &tc->lowest_observed_slot, lowest_observed_slot, txn->slot )==lowest_observed_slot ) ) {
+        break;
+      } else {
+        FD_SPIN_PAUSE();
+        continue;
+      }
+    }
+    break;
+  }
+
+  return 1;
+}
+
+/* Returns 0 on failure, 1 on success. */
+static int
+fd_txncache_insert_regular_txn( fd_txncache_t *              tc,
+                                fd_txncache_insert_t const * txn ) {
+
+  if( FD_UNLIKELY( tc->root_slots_cnt==0UL || tc->nonce_blockcache_deactivated_slot_delta==ULONG_MAX ) ) {
+    ulong * root_slots = fd_txncache_get_root_slots( tc );
+    fd_txncache_private_nonce_blockcache_t * nonce_blockcache;
+    int result = fd_txncache_find_nonce_blockhash( tc, txn->blockhash, &nonce_blockcache );
+    if( FD_LIKELY( result==FD_TXNCACHE_FIND_FOUND && ( tc->root_slots_cnt==0UL || nonce_blockcache->max_slot>=root_slots[ 0UL ] ) ) ) {
+      return fd_txncache_insert_nonce_txn( tc, txn );
+    }
+  }
+
+  /* Insert into the main txn cache.  This is the expected path after
+     the nonce blockcache has been deactivated. */
+  fd_txncache_private_blockcache_t * blockcache;
+  if( FD_UNLIKELY( !fd_txncache_ensure_blockcache( tc, txn->blockhash, &blockcache ) ) ) {
+    fd_txncache_print_insert( txn, "failed to ensure blockcache entry" );
+    fd_txncache_print_state( tc, "failed to ensure blockcache entry" );
+    return 0;
+  }
+
+  for(;;) {
+    fd_txncache_private_txnpage_t * txnpage = fd_txncache_ensure_txnpage( tc, blockcache );
+    if( FD_UNLIKELY( !txnpage ) ) {
+      fd_txncache_print_insert( txn, "failed to ensure txnpage" );
+      fd_txncache_print_state( tc, "failed to ensure txnpage" );
+      return 0;
+    }
+
+    int success = fd_txncache_insert_regular_txn_do( tc, blockcache, txnpage, txn );
+    if( FD_LIKELY( success ) ) break;
+    FD_SPIN_PAUSE();
+  }
+
+  for(;;) {
+    ulong lowest_observed_slot = tc->lowest_observed_slot;
+    if( FD_UNLIKELY( txn->slot<lowest_observed_slot ) ) {
+      if( FD_LIKELY( FD_ATOMIC_CAS( &tc->lowest_observed_slot, lowest_observed_slot, txn->slot )==lowest_observed_slot ) ) {
+        break;
+      } else {
+        FD_SPIN_PAUSE();
+        continue;
+      }
+    }
+    break;
+  }
+
+  return 1;
+}
+
 int
 fd_txncache_insert_batch( fd_txncache_t *              tc,
                           fd_txncache_insert_t const * txns,
                           ulong                        txns_cnt ) {
+
+  /* Validate input. */
+  for( ulong i=0UL; i<txns_cnt; i++ ) {
+    fd_txncache_insert_t const * txn = txns + i;
+    if( FD_UNLIKELY( txn->flags&FD_TXNCACHE_FLAG_REGULAR_TXN && txn->flags&FD_TXNCACHE_FLAG_NONCE_TXN ) ) {
+      FD_LOG_CRIT(( "invalid flags specified both REGULAR and NONCE: 0x%lx", txn->flags ));
+    }
+    if( FD_UNLIKELY( txn->slot>UINT_MAX ) ) {
+      FD_LOG_CRIT(( "slot too large: %lu", txn->slot ));
+    }
+  }
+
   fd_rwlock_read( tc->lock );
 
   for( ulong i=0UL; i<txns_cnt; i++ ) {
-    fd_txncache_private_blockcache_t * blockcache;
-    if( FD_UNLIKELY( !fd_txncache_ensure_blockcache( tc, txns[ i ].blockhash, &blockcache ) ) ) {
-      FD_LOG_WARNING(( "no blockcache found" ));
-      goto unlock_fail;
+    fd_txncache_insert_t const * txn = txns + i;
+    if( FD_UNLIKELY( txn->key_sz!=FD_TXNCACHE_KEY_SIZE && txn->key_sz!=32UL && txn->key_sz!=64UL ) ) {
+      FD_LOG_CRIT(( "unexpected key_sz %lu", txn->key_sz ));
     }
 
-    fd_txncache_private_slotcache_t * slotcache;
-    if( FD_UNLIKELY( !fd_txncache_ensure_slotcache( tc, txns[ i ].slot, &slotcache ) ) ) {
-      FD_LOG_WARNING(( "no slotcache found" ));
-      goto unlock_fail;
-    }
-
-    fd_txncache_private_slotblockcache_t * slotblockcache;
-    if( FD_UNLIKELY( !fd_txncache_ensure_slotblockcache( slotcache, txns[ i ].blockhash, &slotblockcache ) ) ) {
-      FD_LOG_WARNING(( "no slotblockcache found" ));
-      goto unlock_fail;
-    }
-
-    for(;;) {
-      fd_txncache_private_txnpage_t * txnpage = fd_txncache_ensure_txnpage( tc, blockcache );
-      if( FD_UNLIKELY( !txnpage ) ) {
+    if( FD_LIKELY( txn->flags&FD_TXNCACHE_FLAG_REGULAR_TXN ) ) {
+      if( FD_UNLIKELY( !fd_txncache_insert_regular_txn( tc, txn ) ) ) {
         goto unlock_fail;
-        FD_LOG_WARNING(( "no txnpage found" ));
       }
-
-      int success = fd_txncache_insert_txn( tc, blockcache, slotblockcache, txnpage, &txns[ i ] );
-      if( FD_LIKELY( success ) ) break;
-      FD_SPIN_PAUSE();
+    } else if( FD_LIKELY( txn->flags&FD_TXNCACHE_FLAG_NONCE_TXN ) ) {
+      if( FD_UNLIKELY( !fd_txncache_insert_nonce_txn( tc, txn ) ) ) {
+        goto unlock_fail;
+      }
+    } else {
+      FD_LOG_CRIT(( "unexpected flags 0x%lx", txn->flags ));
     }
   }
 
@@ -960,6 +1515,100 @@ fd_txncache_insert_batch( fd_txncache_t *              tc,
 unlock_fail:
   fd_rwlock_unread( tc->lock );
   return 0;
+}
+
+static void
+fd_txncache_query_nonce_txn( fd_txncache_t *             tc,
+                             fd_txncache_query_t const * query,
+                             void *                      query_func_ctx,
+                             int ( * query_func )( ulong slot, void * ctx ),
+                             int *                       out_result ) {
+
+  *out_result = FD_TXNCACHE_QUERY_ABSENT;
+  ulong * root_slots     = fd_txncache_get_root_slots( tc );
+  ulong   txnhash_offset = 0UL;
+  fd_txncache_private_nonce_blockcache_t * nonce_blockcache;
+  if( FD_UNLIKELY( tc->root_slots_cnt==0UL || tc->nonce_blockcache_deactivated_slot_delta==ULONG_MAX ) ) {
+    int result = fd_txncache_find_nonce_blockhash( tc, query->blockhash, &nonce_blockcache );
+    if( FD_LIKELY( result==FD_TXNCACHE_FIND_FOUND && ( tc->root_slots_cnt==0UL || nonce_blockcache->max_slot>=root_slots[ 0UL ] ) ) ) {
+      txnhash_offset = nonce_blockcache->txnhash_offset;
+    }
+  }
+
+  if( FD_UNLIKELY( txnhash_offset ) ) {
+    ulong max_key_idx = fd_ulong_sat_sub( query->key_sz, FD_TXNCACHE_KEY_SIZE+1UL );
+    txnhash_offset = fd_ulong_min( txnhash_offset, max_key_idx );
+  }
+  fd_txncache_private_nonce_txn_t * nonce_txn;
+  int nonce_txn_find = fd_txncache_find_nonce_txn( tc, query->txnhash+txnhash_offset, query_func_ctx, query_func, &nonce_txn );
+  if( FD_UNLIKELY( nonce_txn_find==FD_TXNCACHE_FIND_FOUND ) ) {
+    *out_result = FD_TXNCACHE_QUERY_PRESENT;
+  }
+}
+
+static void
+fd_txncache_query_regular_txn( fd_txncache_t *             tc,
+                               fd_txncache_query_t const * query,
+                               void *                      query_func_ctx,
+                               int ( * query_func )( ulong slot, void * ctx ),
+                               int *                       out_result ) {
+
+  *out_result = FD_TXNCACHE_QUERY_ABSENT;
+  if( FD_UNLIKELY( tc->root_slots_cnt==0UL || tc->nonce_blockcache_deactivated_slot_delta==ULONG_MAX ) ) {
+    /* The nonce blockcache initialized from the snapshot hasn't been
+       deactivated.  This implies that the regular transaction could be
+       in the nonce txn cache.  So check there too, before we check the
+       main txn cache. */
+    ulong * root_slots     = fd_txncache_get_root_slots( tc );
+    ulong   txnhash_offset = 0UL;
+    fd_txncache_private_nonce_blockcache_t * nonce_blockcache;
+    int result = fd_txncache_find_nonce_blockhash( tc, query->blockhash, &nonce_blockcache );
+    if( FD_LIKELY( result==FD_TXNCACHE_FIND_FOUND && ( tc->root_slots_cnt==0UL || nonce_blockcache->max_slot>=root_slots[ 0UL ] ) ) ) {
+      txnhash_offset = nonce_blockcache->txnhash_offset;
+      if( FD_UNLIKELY( txnhash_offset ) ) {
+        ulong max_key_idx = fd_ulong_sat_sub( query->key_sz, FD_TXNCACHE_KEY_SIZE+1UL );
+        txnhash_offset = fd_ulong_min( txnhash_offset, max_key_idx );
+      }
+      /* The query into the nonce txn cache is gated behind the
+         expiration check of the nonce blockcache entry, because if the
+         nonce blockcache entry is expired, then the regular txn can't
+         possibly be in the nonce txn cache.  In contrast, if it were an
+         actual query for nonce transaction, then we have to query the
+         nonce txn cache, regardless of whether the nonce blockcache
+         entry is expired or not.  It's just that when the nonce
+         blockcache entry is expired, we assume a txnhash offset of 0.
+         */
+      fd_txncache_private_nonce_txn_t * nonce_txn;
+      int nonce_txn_find = fd_txncache_find_nonce_txn( tc, query->txnhash+txnhash_offset, query_func_ctx, query_func, &nonce_txn );
+      if( FD_UNLIKELY( nonce_txn_find==FD_TXNCACHE_FIND_FOUND ) ) {
+        *out_result = FD_TXNCACHE_QUERY_PRESENT;
+        return;
+      }
+    }
+  }
+
+  /* Check the main txn cache.  This is the expected path after the
+     nonce blockcache has been deactivated. */
+  fd_txncache_private_blockcache_t * blockcache;
+  int result = fd_txncache_find_blockhash( tc, query->blockhash, &blockcache );
+
+  if( FD_UNLIKELY( result!=FD_TXNCACHE_FIND_FOUND ) ) {
+    return;
+  }
+
+  fd_txncache_private_txnpage_t * txnpages = fd_txncache_get_txnpages( tc );
+
+  ulong txnhash_offset = 0UL; /* The main txn cache always offsets the txnhash by 0. */
+  ulong head_idx       = fd_txncache_key_hash( query->txnhash+txnhash_offset ) % tc->txn_per_slot_max;
+  for( uint head=blockcache->heads[ head_idx ]; head!=UINT_MAX; head=txnpages[ head/FD_TXNCACHE_TXNS_PER_PAGE ].txns[ head%FD_TXNCACHE_TXNS_PER_PAGE ]->blockcache_next ) {
+    fd_txncache_private_txn_t * txn = txnpages[ head/FD_TXNCACHE_TXNS_PER_PAGE ].txns[ head%FD_TXNCACHE_TXNS_PER_PAGE ];
+    if( FD_UNLIKELY( !memcmp( query->txnhash+txnhash_offset, txn->txnhash, FD_TXNCACHE_KEY_SIZE ) ) ) {
+      if( FD_UNLIKELY( !query_func || query_func( txn->slot, query_func_ctx ) ) ) {
+        *out_result = FD_TXNCACHE_QUERY_PRESENT;
+        return;
+      }
+    }
+  }
 }
 
 void
@@ -969,29 +1618,32 @@ fd_txncache_query_batch( fd_txncache_t *             tc,
                          void *                      query_func_ctx,
                          int ( * query_func )( ulong slot, void * ctx ),
                          int *                       out_results ) {
-  fd_rwlock_read( tc->lock );
-  fd_txncache_private_txnpage_t * txnpages = fd_txncache_get_txnpages( tc );
+
+  /* Validate input. */
   for( ulong i=0UL; i<queries_cnt; i++ ) {
-    out_results[ i ] = 0;
-
     fd_txncache_query_t const * query = &queries[ i ];
-    fd_txncache_private_blockcache_t * blockcache;
-    int result = fd_txncache_find_blockhash( tc, query->blockhash, 0, &blockcache );
-
-    if( FD_UNLIKELY( result!=FD_TXNCACHE_FIND_FOUND ) ) {
-      continue;
+    if( FD_UNLIKELY( query->flags&FD_TXNCACHE_FLAG_REGULAR_TXN && query->flags&FD_TXNCACHE_FLAG_NONCE_TXN ) ) {
+      FD_LOG_CRIT(( "invalid flags specified both REGULAR and NONCE: 0x%lx", query->flags ));
     }
+    if( FD_UNLIKELY( query->flags&FD_TXNCACHE_FLAG_SNAPSHOT ) ) {
+      FD_LOG_CRIT(( "invalid flags specified SNAPSHOT on query: 0x%lx", query->flags ));
+    }
+    if( FD_UNLIKELY( query->key_sz!=32UL && query->key_sz!=64UL ) ) {
+      FD_LOG_CRIT(( "unexpected key_sz %lu", query->key_sz ));
+    }
+  }
 
-    ulong txnhash_offset = blockcache->txnhash_offset;
-    ulong head_hash = FD_LOAD( ulong, query->txnhash+txnhash_offset ) % FD_TXNCACHE_BLOCKCACHE_MAP_CNT;
-    for( uint head=blockcache->heads[ head_hash ]; head!=UINT_MAX; head=txnpages[ head/FD_TXNCACHE_TXNS_PER_PAGE ].txns[ head%FD_TXNCACHE_TXNS_PER_PAGE ]->blockcache_next ) {
-      fd_txncache_private_txn_t * txn = txnpages[ head/FD_TXNCACHE_TXNS_PER_PAGE ].txns[ head%FD_TXNCACHE_TXNS_PER_PAGE ];
-      if( FD_LIKELY( !memcmp( query->txnhash+txnhash_offset, txn->txnhash, 20UL ) ) ) {
-        if( FD_LIKELY( !query_func || query_func( txn->slot, query_func_ctx ) ) ) {
-          out_results[ i ] = 1;
-          break;
-        }
-      }
+  fd_rwlock_read( tc->lock );
+
+  for( ulong i=0UL; i<queries_cnt; i++ ) {
+    fd_txncache_query_t const * query = &queries[ i ];
+
+    if( FD_LIKELY( query->flags&FD_TXNCACHE_FLAG_REGULAR_TXN ) ) {
+      fd_txncache_query_regular_txn( tc, query, query_func_ctx, query_func, out_results+i );
+    } else if( FD_LIKELY( query->flags&FD_TXNCACHE_FLAG_NONCE_TXN ) ) {
+      fd_txncache_query_nonce_txn( tc, query, query_func_ctx, query_func, out_results+i );
+    } else {
+      FD_LOG_CRIT(( "unexpected flags 0x%lx", query->flags ));
     }
   }
 
@@ -999,186 +1651,54 @@ fd_txncache_query_batch( fd_txncache_t *             tc,
 }
 
 int
-fd_txncache_snapshot( fd_txncache_t * tc,
-                      void *          ctx,
-                      int ( * write )( uchar const * data, ulong data_sz, void * ctx ) ) {
-  if( !write ) {
-    FD_LOG_WARNING(("No write method provided to snapshotter"));
-    return 1;
-  }
-  fd_rwlock_read( tc->lock );
-
-  fd_txncache_private_txnpage_t * txnpages = fd_txncache_get_txnpages( tc );
-  ulong * root_slots = fd_txncache_get_root_slots( tc );
-  for( ulong i=0UL; i<tc->root_slots_cnt; i++ ) {
-    ulong slot = root_slots[ i ];
-
-    fd_txncache_private_slotcache_t * slotcache;
-    if( FD_UNLIKELY( FD_TXNCACHE_FIND_FOUND!=fd_txncache_find_slot( tc, slot, 0, &slotcache ) ) ) continue;
-
-    for( ulong j=0UL; j<300UL; j++ ) {
-      fd_txncache_private_slotblockcache_t * slotblockcache = &slotcache->blockcache[ j ];
-      if( FD_UNLIKELY( slotblockcache->txnhash_offset>=ULONG_MAX-1UL ) ) continue;
-
-      for( ulong k=0UL; k<FD_TXNCACHE_SLOTCACHE_MAP_CNT; k++ ) {
-        uint head = slotblockcache->heads[ k ];
-        for( ; head!=UINT_MAX; head=txnpages[ head/FD_TXNCACHE_TXNS_PER_PAGE ].txns[ head%FD_TXNCACHE_TXNS_PER_PAGE ]->slotblockcache_next ) {
-          fd_txncache_private_txn_t * txn = txnpages[ head/FD_TXNCACHE_TXNS_PER_PAGE ].txns[ head%FD_TXNCACHE_TXNS_PER_PAGE ];
-
-          fd_txncache_snapshot_entry_t entry = {
-            .slot      = slot,
-            .txn_idx   = slotblockcache->txnhash_offset,
-            .result    = txn->result
-          };
-          fd_memcpy( entry.blockhash, slotblockcache->blockhash, 32 );
-          fd_memcpy( entry.txnhash, txn->txnhash, 20 );
-          int err = write( (uchar*)&entry, sizeof(fd_txncache_snapshot_entry_t), ctx );
-          if( err ) {
-            fd_rwlock_unread( tc->lock );
-            return err;
-          }
-        }
-      }
-    }
+fd_txncache_set_nonce_txnhash_offset( fd_txncache_t * tc,
+                                      uchar           blockhash[ 32 ],
+                                      ulong           txnhash_offset ) {
+  if( FD_UNLIKELY( txnhash_offset>UINT_MAX ) ) {
+    FD_LOG_CRIT(( "crazy large txnhash_offset %lu", txnhash_offset ));
   }
 
-  fd_rwlock_unread( tc->lock );
-  return 0;
-}
-
-int
-fd_txncache_set_txnhash_offset( fd_txncache_t * tc,
-                                ulong slot,
-                                uchar blockhash[ 32 ],
-                                ulong txnhash_offset ) {
   fd_rwlock_read( tc->lock );
-  fd_txncache_private_blockcache_t * blockcache;
-  if( FD_UNLIKELY( !fd_txncache_ensure_blockcache( tc, blockhash, &blockcache ) ) ) goto unlock_fail;
 
-  blockcache->txnhash_offset = txnhash_offset;
-  fd_txncache_private_slotcache_t * slotcache;
-  if( FD_UNLIKELY( !fd_txncache_ensure_slotcache( tc, slot, &slotcache ) ) ) goto unlock_fail;
-
-  fd_txncache_private_slotblockcache_t * slotblockcache;
-  if( FD_UNLIKELY( !fd_txncache_ensure_slotblockcache( slotcache, blockhash, &slotblockcache ) ) ) goto unlock_fail;
-  slotblockcache->txnhash_offset = txnhash_offset;
+  fd_txncache_private_nonce_blockcache_t * blockcache;
+  if( FD_UNLIKELY( !fd_txncache_ensure_nonce_blockcache( tc, blockhash, &blockcache ) ) ) goto unlock_fail;
+  if( FD_UNLIKELY( blockcache->txnhash_offset!=0U && blockcache->txnhash_offset!=txnhash_offset ) ) {
+    FD_BASE58_ENCODE_32_BYTES( blockhash, blockhash_str );
+    FD_LOG_CRIT(( "blockhash %s: non-zero txnhash_offset %u being reset to a different value %lu this indicates that the snapshot is busted or not being parsed correctly", blockhash_str, blockcache->txnhash_offset, txnhash_offset ));
+  }
+  blockcache->txnhash_offset = (uint)txnhash_offset;
 
   fd_rwlock_unread( tc->lock );
-  return 0;
+  return 1;
 
 unlock_fail:
   fd_rwlock_unread( tc->lock );
-  return 1;
+  return 0;
 }
 
 int
-fd_txncache_is_rooted_slot( fd_txncache_t * tc,
-                            ulong slot ) {
-  fd_rwlock_read( tc->lock );
+fd_txncache_is_rooted_slot_locked( fd_txncache_t * tc,
+                                   ulong           slot ) {
 
   ulong * root_slots = fd_txncache_get_root_slots( tc );
+  /* TODO The root slots array is sorted; might be able to exploit that */
   for( ulong idx=0UL; idx<tc->root_slots_cnt; idx++ ) {
     if( FD_UNLIKELY( root_slots[ idx ]==slot ) ) {
-      fd_rwlock_unread( tc->lock );
       return 1;
     }
     if( FD_UNLIKELY( root_slots[ idx ]>slot ) ) break;
   }
 
-  fd_rwlock_unread( tc->lock );
   return 0;
 }
 
 int
-fd_txncache_get_entries( fd_txncache_t *         tc,
-                         fd_bank_slot_deltas_t * slot_deltas,
-                         fd_spad_t *             spad ) {
-
+fd_txncache_is_rooted_slot( fd_txncache_t * tc,
+                            ulong           slot ) {
   fd_rwlock_read( tc->lock );
 
-  slot_deltas->slot_deltas_len = tc->root_slots_cnt;
-  slot_deltas->slot_deltas     = fd_spad_alloc( spad, FD_SLOT_DELTA_ALIGN, tc->root_slots_cnt * sizeof(fd_slot_delta_t) );
-
-  fd_txncache_private_txnpage_t * txnpages   = fd_txncache_get_txnpages( tc );
-  ulong                         * root_slots = fd_txncache_get_root_slots( tc );
-
-  for( ulong i=0UL; i<tc->root_slots_cnt; i++ ) {
-    ulong slot = root_slots[ i ];
-
-    slot_deltas->slot_deltas[ i ].slot               = slot;
-    slot_deltas->slot_deltas[ i ].is_root            = 1;
-    slot_deltas->slot_deltas[ i ].slot_delta_vec     = fd_spad_alloc( spad, FD_STATUS_PAIR_ALIGN, FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS * sizeof(fd_status_pair_t) );
-    slot_deltas->slot_deltas[ i ].slot_delta_vec_len = 0UL;
-    ulong slot_delta_vec_len = 0UL;
-
-    fd_txncache_private_slotcache_t * slotcache;
-    if( FD_UNLIKELY( FD_TXNCACHE_FIND_FOUND!=fd_txncache_find_slot( tc, slot, 0, &slotcache ) ) ) {
-      continue;
-    }
-
-    for( ulong j=0UL; j<FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS; j++ ) {
-      fd_txncache_private_slotblockcache_t * slotblockcache = &slotcache->blockcache[ j ];
-      if( FD_UNLIKELY( slotblockcache->txnhash_offset>=ULONG_MAX-1UL ) ) {
-        continue;
-      }
-      fd_status_pair_t * status_pair = &slot_deltas->slot_deltas[ i ].slot_delta_vec[ slot_delta_vec_len++ ];
-      fd_memcpy( &status_pair->hash, slotblockcache->blockhash, sizeof(fd_hash_t) );
-      status_pair->value.txn_idx = slotblockcache->txnhash_offset;
-
-      /* First count through the number of etnries you expect to encounter
-         and size out the data structure to store them. */
-
-      ulong num_statuses = 0UL;
-      for( ulong k=0UL; k<FD_TXNCACHE_SLOTCACHE_MAP_CNT; k++ ) {
-        uint head = slotblockcache->heads[ k ];
-        for( ; head!=UINT_MAX; head=txnpages[ head/FD_TXNCACHE_TXNS_PER_PAGE ].txns[ head%FD_TXNCACHE_TXNS_PER_PAGE ]->slotblockcache_next ) {
-          num_statuses++;
-        }
-      }
-
-      status_pair->value.statuses_len = num_statuses;
-      status_pair->value.statuses     = fd_spad_alloc( spad, FD_CACHE_STATUS_ALIGN, num_statuses * sizeof(fd_cache_status_t) );
-      fd_memset( status_pair->value.statuses, 0, num_statuses * sizeof(fd_cache_status_t) );
-
-      /* Copy over every entry for the given slot into the slot deltas. */
-
-      num_statuses = 0UL;
-      for( ulong k=0UL; k<FD_TXNCACHE_SLOTCACHE_MAP_CNT; k++ ) {
-        uint head = slotblockcache->heads[ k ];
-        for( ; head!=UINT_MAX; head=txnpages[ head/FD_TXNCACHE_TXNS_PER_PAGE ].txns[ head%FD_TXNCACHE_TXNS_PER_PAGE ]->slotblockcache_next ) {
-          fd_txncache_private_txn_t * txn = txnpages[ head/FD_TXNCACHE_TXNS_PER_PAGE ].txns[ head%FD_TXNCACHE_TXNS_PER_PAGE ];
-          fd_memcpy( status_pair->value.statuses[ num_statuses ].key_slice, txn->txnhash, 20 );
-          status_pair->value.statuses[ num_statuses++ ].result.discriminant = txn->result;
-        }
-      }
-    }
-    slot_deltas->slot_deltas[ i ].slot_delta_vec_len = slot_delta_vec_len;
-  }
+  int rv = fd_txncache_is_rooted_slot_locked( tc, slot );
 
   fd_rwlock_unread( tc->lock );
-
-  return 0;
-
-}
-
-int
-fd_txncache_get_is_constipated( fd_txncache_t * tc ) {
-  fd_rwlock_read( tc->lock );
-
-  int is_constipated = tc->is_constipated;
-
-  fd_rwlock_unread( tc->lock );
-
-  return is_constipated;
-}
-
-int
-fd_txncache_set_is_constipated( fd_txncache_t * tc, int is_constipated ) {
-  fd_rwlock_read( tc->lock );
-
-  tc->is_constipated = is_constipated;
-
-  fd_rwlock_unread( tc->lock );
-
-  return 0;
+  return rv;
 }

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
@@ -193,7 +193,7 @@ fd_sysvar_slot_history_find_slot( fd_slot_history_global_t const * history,
   ulong blocks_len = history->bits_bitvec_len;
 
 
-  if( slot > history->next_slot - 1UL ) {
+  if( slot >= history->next_slot ) {
     return FD_SLOT_HISTORY_SLOT_FUTURE;
   } else if ( slot < fd_ulong_sat_sub( history->next_slot, slot_history_max_entries ) ) {
     return FD_SLOT_HISTORY_SLOT_TOO_OLD;

--- a/src/flamenco/runtime/tests/Local.mk
+++ b/src/flamenco/runtime/tests/Local.mk
@@ -25,3 +25,6 @@ run-runtime-test-nightly: $(OBJDIR)/bin/fd_ledger
 
 run-runtime-backtest-nightly: $(OBJDIR)/bin/fd_ledger
 	OBJDIR=$(OBJDIR) src/flamenco/runtime/tests/run_nightly_backtest.sh -l mainnet-327443157  -s snapshot-327493391-9z5sYZhTCUbMKvXKotuCqN1y5TTt9T4PpxJzE6FLoQiz.tar.zst -y 750 -m 950000000 -e 327593391 -c 2.1.11
+
+run-runtime-test-nightly-txncache: $(OBJDIR)/unit-test/test_txncache
+	$(OBJDIR)/unit-test/test_txncache

--- a/src/flamenco/runtime/tests/nightly_runner.sh
+++ b/src/flamenco/runtime/tests/nightly_runner.sh
@@ -49,3 +49,5 @@ if [ $status -eq 0 ]; then
 else
     send_slack_message "@here Nightly Backtest Ledger Tests Failed"
 fi
+
+make run-runtime-test-nightly-txncache > ~/nightly_run_txncache.txt

--- a/src/flamenco/runtime/tests/run_ledger_backtest.sh
+++ b/src/flamenco/runtime/tests/run_ledger_backtest.sh
@@ -140,43 +140,48 @@ fi
 echo_notice "Starting on-demand ingest and replay"
 echo "
 [layout]
-     affinity = \"auto\"
-     bank_tile_count = 1
-     shred_tile_count = 4
-     exec_tile_count = 4
- [tiles]
-     [tiles.archiver]
-         enabled = true
-         end_slot = $END_SLOT
-         archiver_path = \"$DUMP/$LEDGER/rocksdb\"
-     [tiles.replay]
-         snapshot = \"$SNAPSHOT\"
-         funk_sz_gb = $FUNK_PAGES
-         funk_txn_max = 64
-         funk_rec_max = $INDEX_MAX
-         cluster_version = \"$CLUSTER_VERSION\"
-         enable_features = [ \"$ONE_OFFS\" ]
-         funk_file = \"$DUMP/$LEDGER/backtest.funk\"
-     [tiles.gui]
-         enabled = false
- [blockstore]
-     shred_max = 16777216
-     block_max = 8192
-     txn_max = 1048576
-     alloc_max = 10737418240
-     file = \"$DUMP/$LEDGER/backtest.blockstore\"
- [consensus]
-     vote = false
- [development]
-     sandbox = false
-     no_agave = true
-     no_clone = true
- [log]
-     level_stderr = \"INFO\"
-     path = \"$LOG\"
- [paths]
-     identity_key = \"$DUMP_DIR/identity.json\"
-     vote_account = \"$DUMP_DIR/vote.json\"
+  affinity = \"auto\"
+  bank_tile_count = 1
+  shred_tile_count = 4
+  exec_tile_count = 4
+[tiles]
+  [tiles.archiver]
+    enabled = true
+    end_slot = $END_SLOT
+    archiver_path = \"$DUMP/$LEDGER/rocksdb\"
+  [tiles.replay]
+    snapshot = \"$SNAPSHOT\"
+    funk_sz_gb = $FUNK_PAGES
+    funk_txn_max = 64
+    funk_rec_max = $INDEX_MAX
+    cluster_version = \"$CLUSTER_VERSION\"
+    enable_features = [ \"$ONE_OFFS\" ]
+    funk_file = \"$DUMP/$LEDGER/backtest.funk\"
+  [tiles.gui]
+    enabled = false
+[blockstore]
+  shred_max = 16777216
+  block_max = 8192
+  txn_max = 1048576
+  alloc_max = 10737418240
+  file = \"$DUMP/$LEDGER/backtest.blockstore\"
+[consensus]
+  vote = false
+[runtime.limits.txncache]
+  max_rooted_slots = 300
+  max_live_slots = 512
+  max_txn_per_slot = 16384
+  max_txn_per_slot_override = true
+[development]
+  sandbox = false
+  no_agave = true
+  no_clone = true
+[log]
+  level_stderr = \"INFO\"
+  path = \"$LOG\"
+[paths]
+  identity_key = \"$DUMP_DIR/identity.json\"
+  vote_account = \"$DUMP_DIR/vote.json\"
 " > $DUMP_DIR/${LEDGER}_backtest.toml
 
 if [ ! -f $DUMP_DIR/identity.json ]; then

--- a/src/flamenco/snapshot/fd_snapshot.c
+++ b/src/flamenco/snapshot/fd_snapshot.c
@@ -428,7 +428,7 @@ fd_snapshot_load_prefetch_manifest( fd_snapshot_load_ctx_t * ctx ) {
   void * restore_mem = fd_spad_alloc( ctx->runtime_spad, fd_snapshot_restore_align(), fd_snapshot_restore_footprint() );
   void * loader_mem  = fd_spad_alloc( ctx->runtime_spad, fd_snapshot_loader_align(),  fd_snapshot_loader_footprint( ZSTD_WINDOW_SZ ) );
 
-  ctx->restore = fd_snapshot_restore_new( restore_mem, funk, funk_txn, ctx->runtime_spad, ctx->slot_ctx, restore_manifest, restore_status_cache, restore_rent_fresh_account );
+  ctx->restore = fd_snapshot_restore_new( restore_mem, funk, funk_txn, ctx->runtime_spad, ctx->slot_ctx, restore_manifest, NULL, restore_rent_fresh_account );
   if( FD_UNLIKELY( !ctx->restore ) ) {
     FD_LOG_ERR(( "Failed to fd_snapshot_restore_new" ));
   }

--- a/src/flamenco/snapshot/fd_snapshot_create.c
+++ b/src/flamenco/snapshot/fd_snapshot_create.c
@@ -850,45 +850,8 @@ fd_snapshot_create_write_version( fd_snapshot_ctx_t * snapshot_ctx ) {
 static inline void
 fd_snapshot_create_write_status_cache( fd_snapshot_ctx_t * snapshot_ctx ) {
 
-  /* First convert the existing status cache into a snapshot-friendly format. */
-
-  fd_bank_slot_deltas_t slot_deltas_new = {0};
-  int err = fd_txncache_get_entries( snapshot_ctx->status_cache,
-                                     &slot_deltas_new,
-                                     snapshot_ctx->spad );
-  if( FD_UNLIKELY( err ) ) {
-    FD_LOG_ERR(( "Failed to get entries from the status cache" ));
-  }
-  ulong   bank_slot_deltas_sz = fd_bank_slot_deltas_size( &slot_deltas_new );
-  uchar * out_status_cache    = fd_spad_alloc( snapshot_ctx->spad,
-                                               FD_BANK_SLOT_DELTAS_ALIGN,
-                                               bank_slot_deltas_sz );
-  fd_bincode_encode_ctx_t encode_status_cache = {
-    .data    = out_status_cache,
-    .dataend = out_status_cache + bank_slot_deltas_sz,
-  };
-  if( FD_UNLIKELY( fd_bank_slot_deltas_encode( &slot_deltas_new, &encode_status_cache ) ) ) {
-    FD_LOG_ERR(( "Failed to encode the status cache" ));
-  }
-
-  /* Now write out the encoded buffer to the tar archive. */
-
-  err = fd_tar_writer_new_file( snapshot_ctx->writer, FD_SNAPSHOT_STATUS_CACHE_FILE );
-  if( FD_UNLIKELY( err ) ) {
-    FD_LOG_ERR(( "Failed to create the status cache file" ));
-  }
-  err = fd_tar_writer_write_file_data( snapshot_ctx->writer, out_status_cache, bank_slot_deltas_sz );
-  if( FD_UNLIKELY( err ) ) {
-    FD_LOG_ERR(( "Failed to create the status cache file" ));
-  }
-  err = fd_tar_writer_fini_file( snapshot_ctx->writer );
-  if( FD_UNLIKELY( err ) ) {
-    FD_LOG_ERR(( "Failed to create the status cache file" ));
-  }
-
-  /* Registers all roots and unconstipates the status cache. */
-
-  fd_txncache_flush_constipated_slots( snapshot_ctx->status_cache );
+  (void)snapshot_ctx;
+  FD_LOG_CRIT(( "Agave snapshot generation is not supported" ));
 
 }
 

--- a/src/flamenco/snapshot/fd_snapshot_create.h
+++ b/src/flamenco/snapshot/fd_snapshot_create.h
@@ -53,7 +53,6 @@ struct fd_snapshot_ctx {
 
   /* The two data structures from the runtime referenced by the snapshot service. */
   fd_funk_t *       funk;                      /* Funk handle. */
-  fd_txncache_t *   status_cache;              /* Status cache handle. */
 
   uchar             is_incremental;            /* If it is incremental, set the fields and pass in data from the previous full snapshot. */
   ulong             last_snap_slot;            /* Full snapshot slot. */


### PR DESCRIPTION
- Support worst case transaction mix under mainnet conditions, including nonce transactions.
- Implement race free reprobing.
- Adjust struct layout for better cache line behavior: up to 43% speedup for queries.
- Make the size of txncache configurable.
- Add support for multiple key sizes.
- Remove support for serializing the txncache into a snapshot.
- Better support for key slicing after loading from an Agave snapshot.
- Remove redundant read lock acquisition in executor root slot check.
- More tests, including one that tries to simulate production op mixes.
- Add metrics.