### PR TITLE
Bootstrap CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,5 @@
+/CODEOWNERS @firedancer-admin
+
 /src/ballet/txn/fd_txn_parse.c @ptaffet-jump
 /src/disco/pack @ptaffet-jump @mmcgee-jump
 /src/disco/shred @ptaffet-jump @mmcgee-jump


### PR DESCRIPTION
CODEOWNERS is only enforceable if modifications to the CODEOWNERS
file are protected.
