### PR TITLE
runtime: removing most local pointers from txn ctx setup

### DIFF
--- a/src/choreo/forks/fd_forks.c
+++ b/src/choreo/forks/fd_forks.c
@@ -247,7 +247,7 @@ slot_ctx_restore( ulong                 slot,
   } else {
     FD_LOG_ERR( ( "failed to read banks record: invalid magic number" ) );
   }
-  FD_TEST( !fd_runtime_sysvar_cache_load( slot_ctx_out ) );
+  FD_TEST( !fd_runtime_sysvar_cache_load( slot_ctx_out, runtime_spad ) );
 
   // TODO how do i get this info, ignoring rewards for now
   // slot_ctx_out->epoch_reward_status = ???

--- a/src/flamenco/runtime/context/fd_exec_slot_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_slot_ctx.c
@@ -25,7 +25,7 @@ fd_exec_slot_ctx_new( void *      mem,
   fd_exec_slot_ctx_t * self = (fd_exec_slot_ctx_t *)mem;
   fd_slot_bank_new( &self->slot_bank );
 
-  self->sysvar_cache = fd_sysvar_cache_new( fd_spad_alloc( runtime_spad, fd_sysvar_cache_align(), fd_sysvar_cache_footprint() ), runtime_spad );
+  self->sysvar_cache = fd_sysvar_cache_new( fd_spad_alloc( runtime_spad, fd_sysvar_cache_align(), fd_sysvar_cache_footprint() ) );
 
   /* This is inactive by default */
   self->epoch_reward_status.discriminant = fd_epoch_reward_status_enum_Inactive;

--- a/src/flamenco/runtime/context/fd_exec_slot_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_slot_ctx.h
@@ -60,6 +60,8 @@ struct __attribute__((aligned(8UL))) fd_exec_slot_ctx {
   ulong                       last_snapshot_slot;
 
   fd_rent_fresh_accounts_t    rent_fresh_accounts;
+  fd_wksp_t *                 runtime_wksp; /* TODO: this should hold wksp for runtime_spad. */
+  fd_wksp_t *                 funk_wksp; /* TODO: this should hold wksp for funk. */
 };
 
 #define FD_EXEC_SLOT_CTX_ALIGN     (alignof(fd_exec_slot_ctx_t))

--- a/src/flamenco/runtime/fd_borrowed_account.c
+++ b/src/flamenco/runtime/fd_borrowed_account.c
@@ -177,7 +177,7 @@ fd_borrowed_account_set_executable( fd_borrowed_account_t * borrowed_acct,
 
   /* To become executable an account must be rent exempt
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L1003-L1006 */
-  fd_rent_t const * rent = &borrowed_acct->instr_ctx->txn_ctx->epoch_bank->rent;
+  fd_rent_t const * rent = &borrowed_acct->instr_ctx->txn_ctx->rent;
   if( FD_UNLIKELY( acct->const_meta->info.lamports < fd_rent_exempt_minimum_balance( rent, acct->const_meta->dlen ) ) ) {
     return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_ACCOUNT_NOT_RENT_EXEMPT;
   }

--- a/src/flamenco/runtime/fd_borrowed_account.h
+++ b/src/flamenco/runtime/fd_borrowed_account.h
@@ -259,7 +259,7 @@ fd_borrowed_account_is_rent_exempt_at_data_length( fd_borrowed_account_t const *
 
   /* TODO: Add an is_exempt rent API to better match Agave and clean up code
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L990 */
-  fd_rent_t rent    = borrowed_acct->instr_ctx->txn_ctx->epoch_bank->rent;
+  fd_rent_t rent    = borrowed_acct->instr_ctx->txn_ctx->rent;
   ulong min_balance = fd_rent_exempt_minimum_balance( &rent, acct->const_meta->dlen );
   return acct->const_meta->info.lamports >= min_balance;
 }
@@ -286,7 +286,7 @@ fd_borrowed_account_is_executable( fd_borrowed_account_t const * borrowed_acct )
 
 FD_FN_PURE static inline int
 fd_borrowed_account_is_executable_internal( fd_borrowed_account_t const * borrowed_acct ) {
-  return !FD_FEATURE_ACTIVE( borrowed_acct->instr_ctx->txn_ctx->slot_bank->slot, borrowed_acct->instr_ctx->txn_ctx->features, remove_accounts_executable_flag_checks ) &&
+  return !FD_FEATURE_ACTIVE( borrowed_acct->instr_ctx->txn_ctx->slot, borrowed_acct->instr_ctx->txn_ctx->features, remove_accounts_executable_flag_checks ) &&
           fd_borrowed_account_is_executable( borrowed_acct );
 }
 

--- a/src/flamenco/runtime/fd_cost_tracker.c
+++ b/src/flamenco/runtime/fd_cost_tracker.c
@@ -55,7 +55,7 @@ get_signature_cost( fd_exec_txn_ctx_t const * txn_ctx ) {
 
   /* https://github.com/anza-xyz/agave/blob/v2.2.0/cost-model/src/cost_model.rs#L155-L160 */
   ulong ed25519_verify_cost;
-  if( FD_FEATURE_ACTIVE( txn_ctx->slot_bank->slot, txn_ctx->features, ed25519_precompile_verify_strict ) ) {
+  if( FD_FEATURE_ACTIVE( txn_ctx->slot, txn_ctx->features, ed25519_precompile_verify_strict ) ) {
     ed25519_verify_cost = fd_ulong_sat_mul( FD_PACK_COST_PER_ED25519_SIGNATURE, num_ed25519_instruction_signatures );
   } else {
     ed25519_verify_cost = fd_ulong_sat_mul( FD_PACK_COST_PER_NON_STRICT_ED25519_SIGNATURE, num_ed25519_instruction_signatures );
@@ -63,7 +63,7 @@ get_signature_cost( fd_exec_txn_ctx_t const * txn_ctx ) {
 
   /* https://github.com/anza-xyz/agave/blob/v2.2.0/cost-model/src/cost_model.rs#L162-L167 */
   ulong secp256r1_verify_cost = 0UL;
-  if( FD_FEATURE_ACTIVE( txn_ctx->slot_bank->slot, txn_ctx->features, enable_secp256r1_precompile ) ) {
+  if( FD_FEATURE_ACTIVE( txn_ctx->slot, txn_ctx->features, enable_secp256r1_precompile ) ) {
     secp256r1_verify_cost = fd_ulong_sat_mul( FD_PACK_COST_PER_SECP256R1_SIGNATURE, num_secp256r1_instruction_signatures );
   }
 

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -33,7 +33,7 @@ FD_PROTOTYPES_BEGIN
 /* https://github.com/anza-xyz/agave/blob/v2.0.9/runtime/src/bank.rs#L3239-L3251 */
 static inline ulong
 get_transaction_account_lock_limit( fd_exec_txn_ctx_t const * txn_ctx ) {
-  return fd_ulong_if( FD_FEATURE_ACTIVE( txn_ctx->slot_bank->slot, txn_ctx->features, increase_tx_account_lock_limit ), MAX_TX_ACCOUNT_LOCKS, 64UL );
+  return fd_ulong_if( FD_FEATURE_ACTIVE( txn_ctx->slot, txn_ctx->features, increase_tx_account_lock_limit ), MAX_TX_ACCOUNT_LOCKS, 64UL );
 }
 
 /* fd_exec_instr_fn_t processes an instruction.  Returns an error code

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -330,17 +330,20 @@ fd_runtime_update_leaders( fd_exec_slot_ctx_t * slot_ctx,
                            fd_spad_t *          runtime_spad );
 
 int
-fd_runtime_sysvar_cache_load( fd_exec_slot_ctx_t * slot_ctx );
+fd_runtime_sysvar_cache_load( fd_exec_slot_ctx_t * slot_ctx,
+                              fd_spad_t *          runtime_spad );
 
 /* TODO: Invoked by fd_executor: layering violation. Rent logic is deprecated
    and will be torn out entirely very soon. */
 ulong
-fd_runtime_collect_rent_from_account( fd_slot_bank_t const *  slot_bank,
-                                      fd_epoch_bank_t const * epoch_bank,
-                                      fd_features_t *         features,
-                                      fd_account_meta_t *     acc,
-                                      fd_pubkey_t const *     key,
-                                      ulong                   epoch );
+fd_runtime_collect_rent_from_account( ulong                       slot,
+                                      fd_epoch_schedule_t const * schedule,
+                                      fd_rent_t const *           rent,
+                                      double                      slots_per_year,
+                                      fd_features_t *             features,
+                                      fd_account_meta_t *         acc,
+                                      fd_pubkey_t const *         key,
+                                      ulong                       epoch );
 
 void
 fd_runtime_update_slots_per_epoch( fd_exec_slot_ctx_t * slot_ctx,

--- a/src/flamenco/runtime/fd_runtime_init.c
+++ b/src/flamenco/runtime/fd_runtime_init.c
@@ -33,7 +33,7 @@ fd_runtime_save_epoch_bank( fd_exec_slot_ctx_t * slot_ctx ) {
   ulong sz = sizeof(uint) + fd_epoch_bank_size(epoch_bank);
   fd_funk_rec_key_t id = fd_runtime_epoch_bank_key();
   int opt_err = 0;
-  fd_funk_rec_t *rec = fd_funk_rec_write_prepare(slot_ctx->acc_mgr->funk, slot_ctx->funk_txn, &id, sz, 1, NULL, &opt_err);
+  fd_funk_rec_t * rec = fd_funk_rec_write_prepare( slot_ctx->acc_mgr->funk, slot_ctx->funk_txn, &id, sz, 1, NULL, &opt_err );
   if (NULL == rec)
   {
     FD_LOG_WARNING(("fd_runtime_save_banks failed: %s", fd_funk_strerror(opt_err)));

--- a/src/flamenco/runtime/program/fd_bpf_program_util.c
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.c
@@ -144,16 +144,16 @@ fd_bpf_get_executable_program_content_for_v1_v2_loaders( fd_txn_account_t * prog
 }
 
 void
-fd_bpf_get_sbpf_versions( uint *                 sbpf_min_version,
-                          uint *                 sbpf_max_version,
-                          fd_slot_bank_t const * slot_bank,
-                          fd_features_t const *  features ) {
-  int disable_v0  = FD_FEATURE_ACTIVE( slot_bank->slot, *features, disable_sbpf_v0_execution );
-  int reenable_v0 = FD_FEATURE_ACTIVE( slot_bank->slot, *features, reenable_sbpf_v0_execution );
+fd_bpf_get_sbpf_versions( uint *                sbpf_min_version,
+                          uint *                sbpf_max_version,
+                          ulong                 slot,
+                          fd_features_t const * features ) {
+  int disable_v0  = FD_FEATURE_ACTIVE( slot, *features, disable_sbpf_v0_execution );
+  int reenable_v0 = FD_FEATURE_ACTIVE( slot, *features, reenable_sbpf_v0_execution );
   int enable_v0   = !disable_v0 || reenable_v0;
-  int enable_v1   = FD_FEATURE_ACTIVE( slot_bank->slot, *features, enable_sbpf_v1_deployment_and_execution );
-  int enable_v2   = FD_FEATURE_ACTIVE( slot_bank->slot, *features, enable_sbpf_v2_deployment_and_execution );
-  int enable_v3   = FD_FEATURE_ACTIVE( slot_bank->slot, *features, enable_sbpf_v3_deployment_and_execution );
+  int enable_v1   = FD_FEATURE_ACTIVE( slot, *features, enable_sbpf_v1_deployment_and_execution );
+  int enable_v2   = FD_FEATURE_ACTIVE( slot, *features, enable_sbpf_v2_deployment_and_execution );
+  int enable_v3   = FD_FEATURE_ACTIVE( slot, *features, enable_sbpf_v3_deployment_and_execution );
 
   *sbpf_min_version = enable_v0 ? FD_SBPF_V0 : FD_SBPF_V3;
   if( enable_v3 ) {
@@ -202,7 +202,7 @@ fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t *    slot_ctx,
     uint min_sbpf_version, max_sbpf_version;
     fd_bpf_get_sbpf_versions( &min_sbpf_version,
                               &max_sbpf_version,
-                              &slot_ctx->slot_bank,
+                              slot_ctx->slot_bank.slot,
                               &slot_ctx->epoch_ctx->features );
     if( fd_sbpf_elf_peek( &elf_info, program_data, program_data_len, /* deploy checks */ 0, min_sbpf_version, max_sbpf_version ) == NULL ) {
       FD_LOG_DEBUG(( "fd_sbpf_elf_peek() failed: %s", fd_sbpf_strerror() ));
@@ -256,7 +256,7 @@ fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t *    slot_ctx,
     }
     fd_exec_instr_ctx_t dummy_instr_ctx = {0};
     fd_exec_txn_ctx_t   dummy_txn_ctx   = {0};
-    dummy_txn_ctx.slot_bank = &slot_ctx->slot_bank;
+    dummy_txn_ctx.slot      = slot_ctx->slot_bank.slot;
     dummy_txn_ctx.features  = slot_ctx->epoch_ctx->features;
     dummy_instr_ctx.txn_ctx = &dummy_txn_ctx;
     vm = fd_vm_init( vm,

--- a/src/flamenco/runtime/program/fd_bpf_program_util.h
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.h
@@ -75,10 +75,10 @@ fd_bpf_load_cache_entry( fd_funk_t *                    funk,
                          fd_sbpf_validated_program_t ** valid_prog );
 
 void
-fd_bpf_get_sbpf_versions( uint *                 sbpf_min_version,
-                          uint *                 sbpf_max_version,
-                          fd_slot_bank_t const * slot_bank,
-                          fd_features_t const *  features );
+fd_bpf_get_sbpf_versions( uint *                sbpf_min_version,
+                          uint *                sbpf_max_version,
+                          ulong                 slot,
+                          fd_features_t const * features );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/program/fd_builtin_programs.c
+++ b/src/flamenco/runtime/program/fd_builtin_programs.c
@@ -258,7 +258,7 @@ fd_is_migrating_builtin_program( fd_exec_txn_ctx_t const * txn_ctx,
     fd_core_bpf_migration_config_t const * config = migrating_builtins[i];
     if( !memcmp( pubkey->uc, config->builtin_program_id->key, sizeof(fd_pubkey_t) ) ) {
       if( config->enable_feature_offset!=NO_ENABLE_FEATURE_ID &&
-        FD_FEATURE_ACTIVE_OFFSET( txn_ctx->slot_bank->slot, txn_ctx->features, config->enable_feature_offset ) ) {
+        FD_FEATURE_ACTIVE_OFFSET( txn_ctx->slot, txn_ctx->features, config->enable_feature_offset ) ) {
         /* The program has been migrated to BPF. */
         *migrated_yet = 1;
       }

--- a/src/flamenco/runtime/program/fd_compute_budget_program.c
+++ b/src/flamenco/runtime/program/fd_compute_budget_program.c
@@ -62,7 +62,7 @@ calculate_default_compute_unit_limit( fd_exec_txn_ctx_t const * ctx,
                                       ulong                     num_builtin_instrs,
                                       ulong                     num_non_builtin_instrs,
                                       ulong                     num_non_compute_budget_instrs ) {
-  if( FD_FEATURE_ACTIVE( ctx->slot_bank->slot, ctx->features, reserve_minimal_cus_for_builtin_instructions ) ) {
+  if( FD_FEATURE_ACTIVE( ctx->slot, ctx->features, reserve_minimal_cus_for_builtin_instructions ) ) {
     /* https://github.com/anza-xyz/agave/blob/v2.1.13/runtime-transaction/src/compute_budget_instruction_details.rs#L227-L234 */
     return fd_ulong_sat_add( fd_ulong_sat_mul( num_builtin_instrs, MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT ),
                              fd_ulong_sat_mul( num_non_builtin_instrs, DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT ) );
@@ -105,7 +105,7 @@ fd_executor_compute_budget_program_execute_instructions( fd_exec_txn_ctx_t * ctx
     fd_txn_instr_t const * instr = &ctx->txn_descriptor->instr[i];
 
     /* Track builtin vs non-builtin metrics only if SIMD-170 is active */
-    if( FD_FEATURE_ACTIVE( ctx->slot_bank->slot, ctx->features, reserve_minimal_cus_for_builtin_instructions ) ) {
+    if( FD_FEATURE_ACTIVE( ctx->slot, ctx->features, reserve_minimal_cus_for_builtin_instructions ) ) {
       /* Only `FD_PROGRAM_KIND_BUILTIN` gets charged as a builtin instruction */
       uchar program_kind = get_program_kind( ctx, instr );
       if( program_kind==FD_PROGRAM_KIND_BUILTIN ) {

--- a/src/flamenco/runtime/program/fd_config_program.c
+++ b/src/flamenco/runtime/program/fd_config_program.c
@@ -254,7 +254,7 @@ _process_config_instr( fd_exec_instr_ctx_t * ctx ) {
 int
 fd_config_program_execute( fd_exec_instr_ctx_t * ctx ) {
   /* Prevent execution of migrated native programs */
-  if( FD_UNLIKELY( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, migrate_config_program_to_core_bpf ) ) ) {
+  if( FD_UNLIKELY( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, migrate_config_program_to_core_bpf ) ) ) {
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
   }
 

--- a/src/flamenco/runtime/program/fd_loader_v4_program.c
+++ b/src/flamenco/runtime/program/fd_loader_v4_program.c
@@ -241,7 +241,7 @@ fd_loader_v4_program_instruction_truncate( fd_exec_instr_ctx_t *                
   }
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L165-L171 */
-  fd_rent_t const * rent = fd_sysvar_cache_rent( instr_ctx->txn_ctx->sysvar_cache );
+  fd_rent_t const * rent = (fd_rent_t const *)fd_sysvar_cache_rent( instr_ctx->txn_ctx->sysvar_cache );
   if( FD_UNLIKELY( rent==NULL ) ) {
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
   }
@@ -345,7 +345,7 @@ fd_loader_v4_program_instruction_deploy( fd_exec_instr_ctx_t * instr_ctx ) {
   /* These variables should exist outside of borrowed account scopes. */
   uchar                         source_program_present = !!( instr_ctx->instr->acct_cnt>2 );
   fd_loader_v4_state_t          program_state          = {0};
-  fd_sol_sysvar_clock_t const * clock                  = fd_sysvar_cache_clock( instr_ctx->txn_ctx->sysvar_cache );
+  fd_sol_sysvar_clock_t const * clock                  = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( instr_ctx->txn_ctx->sysvar_cache );
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L217-L219 */
   fd_pubkey_t const * authority_address = &instr_ctx->instr->acct_pubkeys[ 1UL ];
@@ -434,7 +434,7 @@ fd_loader_v4_program_instruction_deploy( fd_exec_instr_ctx_t * instr_ctx ) {
       https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L295-L303 */
   if( source_program_present ) {
       /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L296 */
-      fd_rent_t const * rent = fd_sysvar_cache_rent( instr_ctx->txn_ctx->sysvar_cache );
+      fd_rent_t const * rent = (fd_rent_t const *)fd_sysvar_cache_rent( instr_ctx->txn_ctx->sysvar_cache );
       if( FD_UNLIKELY( rent==NULL ) ) {
         return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
       }
@@ -513,7 +513,7 @@ fd_loader_v4_program_instruction_retract( fd_exec_instr_ctx_t * instr_ctx ) {
   }
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L344 */
-  fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( instr_ctx->txn_ctx->sysvar_cache );
+  fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( instr_ctx->txn_ctx->sysvar_cache );
   if( FD_UNLIKELY( clock==NULL ) ) {
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
   }
@@ -691,7 +691,7 @@ fd_loader_v4_program_instruction_finalize( fd_exec_instr_ctx_t * instr_ctx ) {
    https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L463-L526 */
 int
 fd_loader_v4_program_execute( fd_exec_instr_ctx_t * instr_ctx ) {
-  if( FD_UNLIKELY( !FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot_bank->slot, instr_ctx->txn_ctx->features, enable_program_runtime_v2_and_loader_v4 ) ) ) {
+  if( FD_UNLIKELY( !FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot, instr_ctx->txn_ctx->features, enable_program_runtime_v2_and_loader_v4 ) ) ) {
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
   }
 
@@ -795,7 +795,7 @@ fd_loader_v4_program_execute( fd_exec_instr_ctx_t * instr_ctx ) {
       }
 
       /* Handle `DelayedVisibility` case */
-      if( FD_UNLIKELY( state.slot>=instr_ctx->txn_ctx->slot_bank->slot ) ) {
+      if( FD_UNLIKELY( state.slot>=instr_ctx->txn_ctx->slot ) ) {
         fd_log_collector_msg_literal( instr_ctx, "Program is not deployed" );
         return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
       }

--- a/src/flamenco/runtime/program/fd_precompiles.c
+++ b/src/flamenco/runtime/program/fd_precompiles.c
@@ -123,7 +123,7 @@ fd_precompile_get_instr_data( fd_exec_txn_ctx_t *     txn_ctx,
 
 int
 fd_precompile_ed25519_execute( fd_exec_instr_ctx_t * ctx ) {
-  if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, move_precompile_verification_to_svm ) ) {
+  if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, move_precompile_verification_to_svm ) ) {
     fd_txn_instr_t const * instr = &ctx->txn_ctx->txn_descriptor->instr[ ctx->txn_ctx->current_instr_idx ];
     return fd_precompile_ed25519_verify( ctx->txn_ctx, instr );
   } else {
@@ -241,7 +241,7 @@ fd_precompile_ed25519_verify( fd_exec_txn_ctx_t *    txn_ctx,
 
 int
 fd_precompile_secp256k1_execute( fd_exec_instr_ctx_t * ctx ) {
-  if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, move_precompile_verification_to_svm ) ) {
+  if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, move_precompile_verification_to_svm ) ) {
     fd_txn_instr_t const * instr = &ctx->txn_ctx->txn_descriptor->instr[ ctx->txn_ctx->current_instr_idx ];
     return fd_precompile_secp256k1_verify( ctx->txn_ctx, instr );
   } else {
@@ -365,7 +365,7 @@ fd_precompile_secp256k1_verify( fd_exec_txn_ctx_t *    txn_ctx,
 
 int
 fd_precompile_secp256r1_execute( fd_exec_instr_ctx_t * ctx ) {
-  if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, move_precompile_verification_to_svm ) ) {
+  if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, move_precompile_verification_to_svm ) ) {
     fd_txn_instr_t const * instr = &ctx->txn_ctx->txn_descriptor->instr[ ctx->txn_ctx->current_instr_idx ];
     return fd_precompile_secp256r1_verify( ctx->txn_ctx, instr );
   } else {

--- a/src/flamenco/runtime/program/fd_stake_program.c
+++ b/src/flamenco/runtime/program/fd_stake_program.c
@@ -180,7 +180,7 @@ set_state( fd_borrowed_account_t *     borrowed_acct,
 // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/lib.rs#L29
 static inline ulong
 get_minimum_delegation( fd_exec_txn_ctx_t const * txn_ctx /* feature set */ ) {
-  return fd_ulong_if( FD_FEATURE_ACTIVE( txn_ctx->slot_bank->slot, txn_ctx->features, stake_raise_minimum_delegation_to_1_sol ),
+  return fd_ulong_if( FD_FEATURE_ACTIVE( txn_ctx->slot, txn_ctx->features, stake_raise_minimum_delegation_to_1_sol ),
                       MINIMUM_DELEGATION_SOL * LAMPORTS_PER_SOL,
                       1 );
 }
@@ -281,7 +281,7 @@ validate_split_amount( fd_exec_instr_ctx_t const * invoke_context,
   };
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L1042
-  fd_rent_t const * rent = fd_sysvar_cache_rent( invoke_context->txn_ctx->sysvar_cache );
+  fd_rent_t const * rent = (fd_rent_t const *)fd_sysvar_cache_rent( invoke_context->txn_ctx->sysvar_cache );
   if( FD_UNLIKELY( !rent ) )
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -291,7 +291,7 @@ validate_split_amount( fd_exec_instr_ctx_t const * invoke_context,
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L1048
   if( FD_UNLIKELY(
-           FD_FEATURE_ACTIVE( invoke_context->txn_ctx->slot_bank->slot, invoke_context->txn_ctx->features, require_rent_exempt_split_destination ) &&
+           FD_FEATURE_ACTIVE( invoke_context->txn_ctx->slot, invoke_context->txn_ctx->features, require_rent_exempt_split_destination ) &&
            source_is_active && source_remaining_balance!=0 &&
            destination_lamports<destination_rent_exempt_reserve ) ) {
     return FD_EXECUTOR_INSTR_ERR_INSUFFICIENT_FUNDS;
@@ -747,20 +747,20 @@ stake_deactivate( fd_stake_t * stake, ulong epoch, uint * custom_err ) {
 
 // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L62
 int
-fd_new_warmup_cooldown_rate_epoch( fd_slot_bank_t const *    slot_bank,
+fd_new_warmup_cooldown_rate_epoch( ulong                     slot,
                                    fd_sysvar_cache_t const * sysvar_cache,
                                    fd_features_t const *     features,
                                    /* out */ ulong *         epoch,
                                    int *                     err ) {
   *err = 0;
-  fd_epoch_schedule_t const * epoch_schedule = fd_sysvar_cache_epoch_schedule( sysvar_cache );
+  fd_epoch_schedule_t const * epoch_schedule = (fd_epoch_schedule_t const *)fd_sysvar_cache_epoch_schedule( sysvar_cache );
   if( FD_UNLIKELY( !epoch_schedule ) ) {
     *epoch = ULONG_MAX;
     *err   = FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
     return 1;
   }
   /* reduce_stake_warmup_cooldown is activated on all clusters, so we shouldn't have a `None` case. */
-  if( FD_LIKELY( FD_FEATURE_ACTIVE( slot_bank->slot, *features, reduce_stake_warmup_cooldown ) ) ) {
+  if( FD_LIKELY( FD_FEATURE_ACTIVE( slot, *features, reduce_stake_warmup_cooldown ) ) ) {
     ulong slot = features->reduce_stake_warmup_cooldown;
     *epoch     = fd_slot_to_epoch( epoch_schedule, slot, NULL );
     return 1;
@@ -830,7 +830,7 @@ get_if_mergeable( fd_exec_instr_ctx_t *         invoke_context, // not const to 
     ulong new_rate_activation_epoch = ULONG_MAX;
     int   err;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L1111
-    int   is_some = fd_new_warmup_cooldown_rate_epoch( invoke_context->txn_ctx->slot_bank,
+    int   is_some = fd_new_warmup_cooldown_rate_epoch( invoke_context->txn_ctx->slot,
                                                        invoke_context->txn_ctx->sysvar_cache,
                                                        &invoke_context->txn_ctx->features,
                                                        &new_rate_activation_epoch,
@@ -1138,12 +1138,12 @@ get_stake_status( fd_exec_instr_ctx_t const *    invoke_context,
                   fd_stake_t *                   stake,
                   fd_sol_sysvar_clock_t const *  clock,
                   fd_stake_activation_status_t * out ) {
-  fd_stake_history_t const * stake_history = fd_sysvar_cache_stake_history( invoke_context->txn_ctx->sysvar_cache );
+  fd_stake_history_t const * stake_history = (fd_stake_history_t const *)fd_sysvar_cache_stake_history( invoke_context->txn_ctx->sysvar_cache );
   if( FD_UNLIKELY( !stake_history ) )
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
   ulong new_rate_activation_epoch = ULONG_MAX;
   int   err;
-  int   is_some = fd_new_warmup_cooldown_rate_epoch( invoke_context->txn_ctx->slot_bank,
+  int   is_some = fd_new_warmup_cooldown_rate_epoch( invoke_context->txn_ctx->slot,
                                                      invoke_context->txn_ctx->sysvar_cache,
                                                      &invoke_context->txn_ctx->features,
                                                      &new_rate_activation_epoch,
@@ -1182,7 +1182,7 @@ redelegate_stake( fd_exec_instr_ctx_t const *   ctx,
                   uint *                        custom_err ) {
   ulong new_rate_activation_epoch = ULONG_MAX;
   int   err;
-  int   is_some = fd_new_warmup_cooldown_rate_epoch( ctx->txn_ctx->slot_bank,
+  int   is_some = fd_new_warmup_cooldown_rate_epoch( ctx->txn_ctx->slot,
                                                      ctx->txn_ctx->sysvar_cache,
                                                      &ctx->txn_ctx->features,
                                                      &new_rate_activation_epoch,
@@ -1615,9 +1615,9 @@ split( fd_exec_instr_ctx_t const * ctx,
     ulong minimum_delegation = get_minimum_delegation( ctx->txn_ctx );
 
     int is_active;
-    if( FD_UNLIKELY( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, require_rent_exempt_split_destination ) ) ) {
+    if( FD_UNLIKELY( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, require_rent_exempt_split_destination ) ) ) {
       // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L434
-      fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+      fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
       if( FD_UNLIKELY( !clock ) )
         return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -1929,11 +1929,11 @@ move_stake_or_lamports_shared_checks( fd_exec_instr_ctx_t *   invoke_context, //
       return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
 
     // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_state.rs#L177-L180
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( invoke_context->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( invoke_context->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !clock ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
-    fd_stake_history_t const * stake_history = fd_sysvar_cache_stake_history( invoke_context->txn_ctx->sysvar_cache );
+    fd_stake_history_t const * stake_history = (fd_stake_history_t const *)fd_sysvar_cache_stake_history( invoke_context->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !stake_history ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -2486,7 +2486,7 @@ get_stake_account( fd_exec_instr_ctx_t const * ctx,
 int
 fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
   /* Prevent execution of migrated native programs */
-  if( FD_UNLIKELY( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, migrate_stake_program_to_core_bpf ) ) ) {
+  if( FD_UNLIKELY( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, migrate_stake_program_to_core_bpf ) ) ) {
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
   }
 
@@ -2526,7 +2526,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
 
   /* The EpochRewards sysvar only exists after partitioned epoch rewards is activated.
      If the sysvar exists, check the `active` field */
-  fd_sysvar_epoch_rewards_t const * rewards = fd_sysvar_cache_epoch_rewards( ctx->txn_ctx->sysvar_cache );
+  fd_sysvar_epoch_rewards_t const * rewards = (fd_sysvar_epoch_rewards_t const *)fd_sysvar_cache_epoch_rewards( ctx->txn_ctx->sysvar_cache );
   int epoch_rewards_active = (NULL != rewards) ? rewards->active : false;
 
   if (epoch_rewards_active && instruction->discriminant!=fd_stake_instruction_enum_get_minimum_delegation) {
@@ -2560,7 +2560,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     rc = get_stake_account( ctx, &me );  /* acquire_write */
     if( FD_UNLIKELY( rc ) ) return rc;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L87
-    fd_rent_t const * rent = fd_sysvar_from_instr_acct_rent( ctx, 1, &rc );
+    fd_rent_t const * rent = (fd_rent_t const *)fd_sysvar_from_instr_acct_rent( ctx, 1, &rc );
     if( FD_UNLIKELY( !rent ) ) return rc;
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L88
@@ -2588,7 +2588,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     rc = get_stake_account( ctx, &me );
     if( FD_UNLIKELY( rc ) ) return rc;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L92
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 1, &rc );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_from_instr_acct_clock( ctx, 1, &rc );
     if( FD_UNLIKELY( !clock ) ) return rc;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L94
     if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) )
@@ -2631,7 +2631,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     if( ctx->instr->acct_cnt<2 )
       return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L110
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
     if( FD_UNLIKELY( !clock ) ) return rc;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L112
     fd_pubkey_t const * custodian_pubkey = NULL;
@@ -2672,11 +2672,11 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
       return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L131
     fd_sol_sysvar_clock_t const * clock =
-      fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
+    (fd_sol_sysvar_clock_t const *)fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
     if( FD_UNLIKELY( !clock ) ) return rc;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L133
     fd_stake_history_t const * stake_history =
-      fd_sysvar_from_instr_acct_stake_history( ctx, 3, &rc );
+    (fd_stake_history_t const *)fd_sysvar_from_instr_acct_stake_history( ctx, 3, &rc );
     if( FD_UNLIKELY( !stake_history ) ) return rc;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L138
     if( FD_UNLIKELY( ctx->instr->acct_cnt<5 ) )
@@ -2740,10 +2740,10 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     if( FD_UNLIKELY( ctx->instr->acct_cnt<2 ) )
       return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L169
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
     if( FD_UNLIKELY( rc ) ) return rc;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L171
-    fd_stake_history_t const * stake_history = fd_sysvar_from_instr_acct_stake_history( ctx, 3, &rc );
+    fd_stake_history_t const * stake_history = (fd_stake_history_t const *)fd_sysvar_from_instr_acct_stake_history( ctx, 3, &rc );
     if( FD_UNLIKELY( rc ) ) return rc;
 
     /* https://github.com/anza-xyz/agave/blob/v2.1.14/programs/stake/src/stake_instruction.rs#L175 */
@@ -2773,10 +2773,10 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     if( FD_UNLIKELY( ctx->instr->acct_cnt<2 ) )
       return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L191
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
     if( FD_UNLIKELY( !clock ) ) return rc;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L193
-    fd_stake_history_t const * stake_history = fd_sysvar_from_instr_acct_stake_history( ctx, 3, &rc );
+    fd_stake_history_t const * stake_history = (fd_stake_history_t const *)fd_sysvar_from_instr_acct_stake_history( ctx, 3, &rc );
     if( FD_UNLIKELY( !stake_history ) ) return rc;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L198
     if( FD_UNLIKELY( ctx->instr->acct_cnt<5 ) )
@@ -2788,7 +2788,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     uchar custodian_index           = 5;
     ulong new_rate_activation_epoch = ULONG_MAX;
     int   err;
-    int   is_some = fd_new_warmup_cooldown_rate_epoch( ctx->txn_ctx->slot_bank,
+    int   is_some = fd_new_warmup_cooldown_rate_epoch( ctx->txn_ctx->slot,
                                                        ctx->txn_ctx->sysvar_cache,
                                                        &ctx->txn_ctx->features,
                                                        &new_rate_activation_epoch,
@@ -2825,7 +2825,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     rc                         = get_stake_account( ctx, &me );
     if( FD_UNLIKELY( rc ) ) return rc;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L219
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 1, &rc );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_from_instr_acct_clock( ctx, 1, &rc );
     if( FD_UNLIKELY( !clock ) ) return rc;
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L221
@@ -2851,7 +2851,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     rc = get_stake_account( ctx, &me );
     if( FD_UNLIKELY( rc ) ) return rc;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L225
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !clock ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L226
@@ -2886,7 +2886,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     fd_stake_authorized_t authorized = { .staker     = *staker_pubkey,
                                           .withdrawer = *withdrawer_pubkey };
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L246
-    fd_rent_t const * rent = fd_sysvar_from_instr_acct_rent( ctx, 1, &rc );
+    fd_rent_t const * rent = (fd_rent_t const *)fd_sysvar_from_instr_acct_rent( ctx, 1, &rc );
     if( FD_UNLIKELY( !rent ) ) return rc;
 
     fd_stake_lockup_t lockup_default = {0};
@@ -2914,7 +2914,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     if( FD_UNLIKELY( rc ) ) return rc;
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L251
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 1, &rc );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_from_instr_acct_clock( ctx, 1, &rc );
     if( FD_UNLIKELY( !clock ) ) return rc;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L253
     if( FD_UNLIKELY( ctx->instr->acct_cnt<4 ) )
@@ -2961,7 +2961,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     if( FD_UNLIKELY( ctx->instr->acct_cnt<2 ) )
       return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L276
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
     if( FD_UNLIKELY( !clock ) ) return rc;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L277
     if( FD_UNLIKELY( ctx->instr->acct_cnt<4 ) )
@@ -3015,7 +3015,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
                                 .epoch          = lockup_checked->epoch,
                                 .custodian      = (fd_pubkey_t *)custodian_pubkey }; // FIXME
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L310
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !clock ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -3058,7 +3058,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) )
       return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L325
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !clock ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -3089,7 +3089,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
    */
   case fd_stake_instruction_enum_move_stake: {
     // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L359
-    if( FD_LIKELY( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, move_stake_and_move_lamports_ixs ) ) ) {
+    if( FD_LIKELY( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, move_stake_and_move_lamports_ixs ) ) ) {
       // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L361
       if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) )
         return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
@@ -3118,7 +3118,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
    */
   case fd_stake_instruction_enum_move_lamports: {
     // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L378
-    if( FD_LIKELY( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, move_stake_and_move_lamports_ixs ) ) ) {
+    if( FD_LIKELY( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, move_stake_and_move_lamports_ixs ) ) ) {
       // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L380
       if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) )
         return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;

--- a/src/flamenco/runtime/program/fd_stake_program.h
+++ b/src/flamenco/runtime/program/fd_stake_program.h
@@ -17,7 +17,7 @@
 FD_PROTOTYPES_BEGIN
 
 int
-fd_new_warmup_cooldown_rate_epoch( fd_slot_bank_t const *    slot_bank,
+fd_new_warmup_cooldown_rate_epoch( ulong                     slot,
                                    fd_sysvar_cache_t const * sysvar_cache,
                                    fd_features_t const *     features,
                                    /* out */ ulong *         epoch,

--- a/src/flamenco/runtime/program/fd_system_program_nonce.c
+++ b/src/flamenco/runtime/program/fd_system_program_nonce.c
@@ -35,7 +35,7 @@ require_acct_rent( fd_exec_instr_ctx_t * ctx,
     if( FD_UNLIKELY( err ) ) return err;
   } while(0);
 
-  fd_rent_t const * rent = fd_sysvar_cache_rent( ctx->txn_ctx->sysvar_cache );
+  fd_rent_t const * rent = (fd_rent_t const *)fd_sysvar_cache_rent( ctx->txn_ctx->sysvar_cache );
   if( FD_UNLIKELY( !rent ) )
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -44,21 +44,21 @@ require_acct_rent( fd_exec_instr_ctx_t * ctx,
 }
 
 static int
-require_acct_recent_blockhashes(
-  fd_exec_instr_ctx_t *             ctx,
-  ulong                             idx,
-  fd_recent_block_hashes_t const ** out ) {
+require_acct_recent_blockhashes( fd_exec_instr_ctx_t *             ctx,
+                                 ulong                             idx,
+                                 fd_recent_block_hashes_t const ** out ) {
 
   do {
     int err = require_acct( ctx, idx, &fd_sysvar_recent_block_hashes_id );
     if( FD_UNLIKELY( err ) ) return err;
   } while(0);
 
-  fd_recent_block_hashes_t const * rbh = fd_sysvar_cache_recent_block_hashes( ctx->txn_ctx->sysvar_cache );
-  if( FD_UNLIKELY( !rbh ) )
+  fd_recent_block_hashes_global_t const * rbh_global = fd_sysvar_cache_recent_block_hashes( ctx->txn_ctx->sysvar_cache );
+  if( FD_UNLIKELY( !rbh_global ) )
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
+  fd_bincode_decode_ctx_t decode = { .wksp = ctx->txn_ctx->runtime_pub_wksp };
+  fd_recent_block_hashes_convert_global_to_local( rbh_global, (fd_recent_block_hashes_t*)*out, &decode );
 
-  *out = rbh;
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
 
@@ -73,7 +73,7 @@ most_recent_block_hash( fd_exec_instr_ctx_t * ctx,
   /* The environment config blockhash comes from `bank.last_blockhash_and_lamports_per_signature()`,
      which takes the top element from the blockhash queue.
      https://github.com/anza-xyz/agave/blob/v2.1.6/programs/system/src/system_instruction.rs#L47 */
-  fd_hash_t const * last_hash = ctx->txn_ctx->slot_bank->block_hash_queue.last_hash;
+  fd_hash_t const * last_hash = ctx->txn_ctx->block_hash_queue.last_hash;
   if( FD_UNLIKELY( last_hash==NULL ) ) {
     // Agave panics if this blockhash was never set at the start of the txn batch
     ctx->txn_ctx->custom_err = FD_SYSTEM_PROGRAM_ERR_NONCE_NO_RECENT_BLOCKHASHES;
@@ -283,7 +283,8 @@ fd_system_program_exec_advance_nonce_account( fd_exec_instr_ctx_t * ctx ) {
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L427-L432 */
 
-  fd_recent_block_hashes_t const * recent_blockhashes = NULL;
+  fd_recent_block_hashes_t         recent_blockhashes_obj;
+  fd_recent_block_hashes_t const * recent_blockhashes = &recent_blockhashes_obj;
   do {
     err = require_acct_recent_blockhashes( ctx, 1UL, &recent_blockhashes );
     if( FD_UNLIKELY( err ) ) return err;
@@ -504,7 +505,8 @@ fd_system_program_exec_withdraw_nonce_account( fd_exec_instr_ctx_t * ctx,
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L445-L449 */
 
-  fd_recent_block_hashes_t const * recent_blockhashes = NULL;
+  fd_recent_block_hashes_t         recent_blockhashes_obj;
+  fd_recent_block_hashes_t const * recent_blockhashes = &recent_blockhashes_obj;
   do {
     int err = require_acct_recent_blockhashes( ctx, 2UL, &recent_blockhashes );
     if( FD_UNLIKELY( err ) ) return err;
@@ -668,7 +670,8 @@ fd_system_program_exec_initialize_nonce_account( fd_exec_instr_ctx_t * ctx,
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L466-L471 */
 
-  fd_recent_block_hashes_t const * recent_blockhashes = NULL;
+  fd_recent_block_hashes_t         recent_blockhashes_obj;
+  fd_recent_block_hashes_t const * recent_blockhashes = &recent_blockhashes_obj;
   do {
     err = require_acct_recent_blockhashes( ctx, 1UL, &recent_blockhashes );
     if( FD_UNLIKELY( err ) ) return err;
@@ -934,7 +937,7 @@ fd_system_program_exec_upgrade_nonce_account( fd_exec_instr_ctx_t * ctx ) {
    Note: We check 151 and not 150 due to a known bug in agave. */
 int
 fd_check_transaction_age( fd_exec_txn_ctx_t * txn_ctx ) {
-  fd_block_hash_queue_t hash_queue         = txn_ctx->slot_bank->block_hash_queue;
+  fd_block_hash_queue_t hash_queue         = txn_ctx->block_hash_queue;
   fd_hash_t *           last_blockhash     = hash_queue.last_hash;
 
   /* check_transaction_age */

--- a/src/flamenco/runtime/program/fd_vote_program.c
+++ b/src/flamenco/runtime/program/fd_vote_program.c
@@ -797,7 +797,7 @@ set_vote_account_state( fd_borrowed_account_t *     vote_account,
                         fd_vote_state_t *           vote_state,
                         fd_exec_instr_ctx_t const * ctx /* feature_set */ ) {
 
-  if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, vote_state_add_vote_latency ) ) {
+  if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, vote_state_add_vote_latency ) ) {
     /* This is a horrible conditional expression in Agave.
        The terms were broken up into their own variables. */
 
@@ -805,7 +805,7 @@ set_vote_account_state( fd_borrowed_account_t *     vote_account,
 
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L175
     int resize_needed      = vote_account->acct->const_meta->dlen < vsz;
-    int resize_rent_exempt = fd_rent_exempt_minimum_balance( &ctx->txn_ctx->epoch_bank->rent, vsz ) <=
+    int resize_rent_exempt = fd_rent_exempt_minimum_balance( &ctx->txn_ctx->rent, vsz ) <=
                                                              vote_account->acct->const_meta->info.lamports;
 
     /* The resize operation itself is part of the horrible conditional,
@@ -1284,8 +1284,8 @@ process_new_vote_state( fd_vote_state_t *           vote_state,
      credits for slots actually voted on and finalized. */
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L635
-  int timely_vote_credits                   = FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, timely_vote_credits );
-  int deprecate_unused_legacy_vote_plumbing = FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, deprecate_unused_legacy_vote_plumbing );
+  int timely_vote_credits                   = FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, timely_vote_credits );
+  int deprecate_unused_legacy_vote_plumbing = FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, deprecate_unused_legacy_vote_plumbing );
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L641
   ulong earned_credits      = timely_vote_credits ? 0 : 1;
@@ -1583,7 +1583,7 @@ update_commission( fd_borrowed_account_t *     vote_account,
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L927
   int enforce_commission_update_rule = 1;
-  if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, allow_commission_decrease_at_any_time ) ) {
+  if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, allow_commission_decrease_at_any_time ) ) {
     vote_state_versioned = get_state( vote_account->acct, ctx->txn_ctx->spad, &rc );
     if ( FD_LIKELY( rc==FD_EXECUTOR_INSTR_SUCCESS ) ) {
       convert_to_current( vote_state_versioned, ctx->txn_ctx->spad );
@@ -1594,7 +1594,7 @@ update_commission( fd_borrowed_account_t *     vote_account,
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L940
   if( FD_LIKELY( enforce_commission_update_rule &&
-                 FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, commission_updates_only_allowed_in_first_half_of_epoch ) ) ) {
+                 FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, commission_updates_only_allowed_in_first_half_of_epoch ) ) ) {
     if( FD_UNLIKELY( !is_commission_update_allowed( clock->slot, epoch_schedule ) ) ) {
       ctx->txn_ctx->custom_err = FD_VOTE_ERR_COMMISSION_UPDATE_TOO_LATE;
       return FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR;
@@ -1789,7 +1789,7 @@ initialize_account( fd_borrowed_account_t *       vote_account,
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1067
   ulong data_len = vote_account->acct->const_meta->dlen;
-  if( FD_UNLIKELY( data_len != size_of_versioned( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, vote_state_add_vote_latency ) ) ) ) {
+  if( FD_UNLIKELY( data_len != size_of_versioned( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, vote_state_add_vote_latency ) ) ) ) {
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
   }
 
@@ -1876,8 +1876,8 @@ process_vote_with_account( fd_borrowed_account_t *       vote_account,
   if( FD_UNLIKELY( rc ) ) return rc;
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1114
-  int timely_vote_credits                   = FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, timely_vote_credits );
-  int deprecate_unused_legacy_vote_plumbing = FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, deprecate_unused_legacy_vote_plumbing );
+  int timely_vote_credits                   = FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, timely_vote_credits );
+  int deprecate_unused_legacy_vote_plumbing = FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, deprecate_unused_legacy_vote_plumbing );
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L1117
   rc = process_vote( &vote_state, vote, slot_hashes, clock->epoch, clock->slot, timely_vote_credits, deprecate_unused_legacy_vote_plumbing, ctx );
@@ -1994,7 +1994,7 @@ process_vote_state_update( fd_borrowed_account_t *       vote_account,
           &vote_state_update->hash,
           0,
           fd_query_pubkey_stake( vote_account->acct->pubkey,
-          &ctx->txn_ctx->epoch_bank->stakes.vote_accounts ) );
+          &ctx->txn_ctx->stakes.vote_accounts ) );
 
       if( FD_LIKELY( vote_state_update->has_root ) ) {
         fd_bank_hash_cmp_entry_t * cmp =
@@ -2081,7 +2081,7 @@ process_tower_sync( fd_borrowed_account_t *       vote_account,
           &tower_sync->hash,
           0,
           fd_query_pubkey_stake( vote_account->acct->pubkey,
-          &ctx->txn_ctx->epoch_bank->stakes.vote_accounts ) );
+          &ctx->txn_ctx->stakes.vote_accounts ) );
 
       if( FD_LIKELY( tower_sync->has_root ) ) {
         fd_bank_hash_cmp_entry_t * cmp =
@@ -2196,7 +2196,7 @@ fd_vote_acc_credits( fd_exec_instr_ctx_t const * ctx,
                      ulong *                     result ) {
   int rc;
 
-  fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+  fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
   if( FD_UNLIKELY( !clock ) ) return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
   /* Read vote account */
@@ -2298,7 +2298,7 @@ process_authorize_with_seed_instruction(
   int rc = 0;
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L31
-  fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 1, &rc );
+  fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_from_instr_acct_clock( ctx, 1, &rc );
   if( FD_UNLIKELY( !clock ) ) return rc;
 
   fd_pubkey_t * expected_authority_keys[FD_TXN_SIG_MAX] = { 0 };
@@ -2439,7 +2439,7 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
    */
   case fd_vote_instruction_enum_initialize_account: {
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L72
-    fd_rent_t const * rent = fd_sysvar_from_instr_acct_rent( ctx, 1UL, &rc );
+    fd_rent_t const * rent = (fd_rent_t const *)fd_sysvar_from_instr_acct_rent( ctx, 1UL, &rc );
     if( FD_UNLIKELY( !rent ) ) return rc;
 
     if( FD_UNLIKELY( me.acct->const_meta->info.lamports <
@@ -2447,7 +2447,7 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
       return FD_EXECUTOR_INSTR_ERR_INSUFFICIENT_FUNDS;
 
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L76
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
     if( !clock ) return rc;
 
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L78
@@ -2473,7 +2473,7 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
    */
   case fd_vote_instruction_enum_authorize: {
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L87
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 1, &rc );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_from_instr_acct_clock( ctx, 1, &rc );
     if( !clock ) return rc;
 
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L89
@@ -2581,11 +2581,11 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
   case fd_vote_instruction_enum_update_commission: {
 
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L149
-    fd_epoch_schedule_t const * epoch_schedule = fd_sysvar_cache_epoch_schedule( ctx->txn_ctx->sysvar_cache );
+    fd_epoch_schedule_t const * epoch_schedule = (fd_epoch_schedule_t const *)fd_sysvar_cache_epoch_schedule( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !epoch_schedule ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L150
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !clock ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -2619,8 +2619,8 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
    * https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L154
    */
   case fd_vote_instruction_enum_vote_switch: {
-    if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, deprecate_legacy_vote_ixs ) &&
-        FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, enable_tower_sync_ix ) ) {
+    if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, deprecate_legacy_vote_ixs ) &&
+        FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, enable_tower_sync_ix ) ) {
       return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
     }
 
@@ -2635,11 +2635,17 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
 
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L155
     int err;
-    fd_slot_hashes_t const * slot_hashes = fd_sysvar_from_instr_acct_slot_hashes( ctx, 1, &err );
-    if( FD_UNLIKELY( !slot_hashes ) ) return err;
+    fd_slot_hashes_global_t const * slot_hashes_global = fd_sysvar_from_instr_acct_slot_hashes( ctx, 1, &err );
+    fd_slot_hashes_t slot_hashes[1];
+    if( FD_LIKELY( slot_hashes_global ) ) {
+      fd_bincode_decode_ctx_t decode = { .wksp = ctx->txn_ctx->runtime_pub_wksp };
+      fd_slot_hashes_convert_global_to_local( slot_hashes_global, slot_hashes, &decode );
+    } else {
+      return err;
+    }
 
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L157
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 2, &err );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_from_instr_acct_clock( ctx, 2, &err );
     if( FD_UNLIKELY( !clock ) ) return err;
 
     rc = process_vote_with_account( &me, slot_hashes, clock, vote, signers, ctx );
@@ -2666,8 +2672,8 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
    * https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L169
    */
   case fd_vote_instruction_enum_update_vote_state_switch: {
-    if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, deprecate_legacy_vote_ixs ) &&
-        FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, enable_tower_sync_ix ) ) {
+    if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, deprecate_legacy_vote_ixs ) &&
+        FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, enable_tower_sync_ix ) ) {
       return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
     }
 
@@ -2684,12 +2690,17 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
     }
 
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L171
-    fd_slot_hashes_t const * slot_hashes = fd_sysvar_cache_slot_hashes( ctx->txn_ctx->sysvar_cache );
-    if( FD_UNLIKELY( !slot_hashes ) )
+    fd_slot_hashes_global_t const * slot_hashes_global = fd_sysvar_cache_slot_hashes( ctx->txn_ctx->sysvar_cache );
+    fd_slot_hashes_t slot_hashes[1];
+    if( FD_LIKELY( slot_hashes_global ) ) {
+      fd_bincode_decode_ctx_t decode = { .wksp = ctx->txn_ctx->runtime_pub_wksp };
+      fd_slot_hashes_convert_global_to_local( slot_hashes_global, slot_hashes, &decode );
+    } else {
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
+    }
 
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L172
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !clock ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -2725,8 +2736,8 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
    */
   case fd_vote_instruction_enum_compact_update_vote_state_switch: {
     /* https://github.com/anza-xyz/agave/blob/dc4b9dcbbf859ff48f40d00db824bde063fdafcc/programs/vote/src/vote_processor.rs#L183-L191 */
-    if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, deprecate_legacy_vote_ixs ) &&
-        FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, enable_tower_sync_ix ) ) {
+    if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, deprecate_legacy_vote_ixs ) &&
+        FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, enable_tower_sync_ix ) ) {
       return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
     }
 
@@ -2745,11 +2756,16 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
       return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
 
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L185
-    fd_slot_hashes_t const * slot_hashes = fd_sysvar_cache_slot_hashes( ctx->txn_ctx->sysvar_cache );
-    if( FD_UNLIKELY( !slot_hashes ) )
+    fd_slot_hashes_global_t const * slot_hashes_global = fd_sysvar_cache_slot_hashes( ctx->txn_ctx->sysvar_cache );
+    fd_slot_hashes_t slot_hashes[1];
+    if( FD_LIKELY( slot_hashes_global ) ) {
+      fd_bincode_decode_ctx_t decode = { .wksp = ctx->txn_ctx->runtime_pub_wksp };
+      fd_slot_hashes_convert_global_to_local( slot_hashes_global, slot_hashes, &decode );
+    } else {
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
+    }
 
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !clock ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -2770,7 +2786,7 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
 
   case fd_vote_instruction_enum_tower_sync:
   case fd_vote_instruction_enum_tower_sync_switch: {
-    if( !FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, enable_tower_sync_ix ) ) {
+    if( !FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, enable_tower_sync_ix ) ) {
       return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
     }
 
@@ -2778,9 +2794,15 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
         ? &instruction->inner.tower_sync
         : &instruction->inner.tower_sync_switch.tower_sync;
 
-    fd_slot_hashes_t const *      slot_hashes = fd_sysvar_cache_slot_hashes( ctx->txn_ctx->sysvar_cache );
-    fd_sol_sysvar_clock_t const * clock       = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
-    if( FD_UNLIKELY( !slot_hashes || !clock ) ) {
+    fd_slot_hashes_global_t const * slot_hashes_global = fd_sysvar_cache_slot_hashes( ctx->txn_ctx->sysvar_cache );
+    fd_slot_hashes_t slot_hashes[1];
+    if( FD_LIKELY( slot_hashes_global ) ) {
+      fd_bincode_decode_ctx_t decode = { .wksp = ctx->txn_ctx->runtime_pub_wksp };
+      fd_slot_hashes_convert_global_to_local( slot_hashes_global, slot_hashes, &decode );
+    }
+
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+    if( FD_UNLIKELY( !slot_hashes_global || !clock ) ) {
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
     }
 
@@ -2801,10 +2823,10 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
       rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
       break;
     }
-    fd_rent_t const * rent_sysvar = fd_sysvar_cache_rent( ctx->txn_ctx->sysvar_cache );
+    fd_rent_t const * rent_sysvar = (fd_rent_t const *)fd_sysvar_cache_rent( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !rent_sysvar ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
-    fd_sol_sysvar_clock_t const * clock_sysvar = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock_sysvar = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !clock_sysvar ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -2847,7 +2869,7 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
     }
 
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L242
-    fd_sol_sysvar_clock_t const * clock = fd_sysvar_from_instr_acct_clock( ctx, 1, &rc );
+    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_from_instr_acct_clock( ctx, 1, &rc );
     if( FD_UNLIKELY( !clock ) ) return rc;
 
     rc = authorize( &me,

--- a/src/flamenco/runtime/program/fd_zk_elgamal_proof_program.c
+++ b/src/flamenco/runtime/program/fd_zk_elgamal_proof_program.c
@@ -10,7 +10,7 @@
 int
 fd_executor_zk_elgamal_proof_program_execute( fd_exec_instr_ctx_t * ctx ) {
   /* Feature-gate program activation */
-  if( FD_UNLIKELY( !FD_FEATURE_ACTIVE( ctx->txn_ctx->slot_bank->slot, ctx->txn_ctx->features, zk_elgamal_proof_program_enabled ) ) ) {
+  if( FD_UNLIKELY( !FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, zk_elgamal_proof_program_enabled ) ) ) {
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
   }
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_cache.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_cache.h
@@ -57,11 +57,10 @@
 
 struct __attribute__((aligned(16UL))) fd_sysvar_cache_private {
   ulong       magic;  /* ==FD_SYSVAR_CACHE_MAGIC */
-  fd_spad_t * runtime_spad;
 
   /* Declare the val_{...} values */
 # define X( type, name ) \
-  type##_t val_##name[1];
+  type##_global_t val_##name[1];
   FD_SYSVAR_CACHE_ITER(X)
 # undef X
 
@@ -93,8 +92,7 @@ fd_sysvar_cache_footprint( void );
    failure. */
 
 fd_sysvar_cache_t *
-fd_sysvar_cache_new( void *      mem,
-                     fd_spad_t * runtime_spad );
+fd_sysvar_cache_new( void * mem );
 
 /* fd_sysvar_cache_delete destroys a given sysvar cache object and any
    heap allocations made.  Detaches from the valloc provided in
@@ -114,29 +112,33 @@ fd_sysvar_cache_delete( fd_sysvar_cache_t * cache );
 void
 fd_sysvar_cache_restore( fd_sysvar_cache_t * cache,
                          fd_acc_mgr_t *      acc_mgr,
-                         fd_funk_txn_t *     funk_txn );
+                         fd_funk_txn_t *     funk_txn,
+                         fd_spad_t *         runtime_spad,
+                         fd_wksp_t *         wksp );
 
 /* fd_sysvar_cache_restore_{name} restores only the given sysvar object from the given slot context */
 
 # define X( type, name )                                               \
 void                                                                   \
 fd_sysvar_cache_restore_##name( fd_sysvar_cache_t * cache,             \
-                         fd_acc_mgr_t *      acc_mgr,                  \
-                         fd_funk_txn_t *     funk_txn );
+                                fd_acc_mgr_t *      acc_mgr,           \
+                                fd_funk_txn_t *     funk_txn,          \
+                                fd_spad_t *         runtime_spad,      \
+                                fd_wksp_t *         wksp );
   FD_SYSVAR_CACHE_ITER(X)
 # undef X
 
 /* Accessors for sysvars.  May return NULL. */
 
-FD_FN_PURE fd_sol_sysvar_clock_t             const * fd_sysvar_cache_clock              ( fd_sysvar_cache_t const * cache );
-FD_FN_PURE fd_epoch_schedule_t               const * fd_sysvar_cache_epoch_schedule     ( fd_sysvar_cache_t const * cache );
-FD_FN_PURE fd_sysvar_epoch_rewards_t         const * fd_sysvar_cache_epoch_rewards      ( fd_sysvar_cache_t const * cache );
-FD_FN_PURE fd_sysvar_fees_t                  const * fd_sysvar_cache_fees               ( fd_sysvar_cache_t const * cache );
-FD_FN_PURE fd_rent_t                         const * fd_sysvar_cache_rent               ( fd_sysvar_cache_t const * cache );
-FD_FN_PURE fd_slot_hashes_t                  const * fd_sysvar_cache_slot_hashes        ( fd_sysvar_cache_t const * cache );
-FD_FN_PURE fd_recent_block_hashes_t          const * fd_sysvar_cache_recent_block_hashes( fd_sysvar_cache_t const * cache );
-FD_FN_PURE fd_stake_history_t                const * fd_sysvar_cache_stake_history      ( fd_sysvar_cache_t const * cache );
-FD_FN_PURE fd_sol_sysvar_last_restart_slot_t const * fd_sysvar_cache_last_restart_slot  ( fd_sysvar_cache_t const * cache );
+FD_FN_PURE fd_sol_sysvar_clock_global_t             const * fd_sysvar_cache_clock              ( fd_sysvar_cache_t const * cache );
+FD_FN_PURE fd_epoch_schedule_global_t               const * fd_sysvar_cache_epoch_schedule     ( fd_sysvar_cache_t const * cache );
+FD_FN_PURE fd_sysvar_epoch_rewards_global_t         const * fd_sysvar_cache_epoch_rewards      ( fd_sysvar_cache_t const * cache );
+FD_FN_PURE fd_sysvar_fees_global_t                  const * fd_sysvar_cache_fees               ( fd_sysvar_cache_t const * cache );
+FD_FN_PURE fd_rent_global_t                         const * fd_sysvar_cache_rent               ( fd_sysvar_cache_t const * cache );
+FD_FN_PURE fd_slot_hashes_global_t                  const * fd_sysvar_cache_slot_hashes        ( fd_sysvar_cache_t const * cache );
+FD_FN_PURE fd_recent_block_hashes_global_t          const * fd_sysvar_cache_recent_block_hashes( fd_sysvar_cache_t const * cache );
+FD_FN_PURE fd_stake_history_global_t                const * fd_sysvar_cache_stake_history      ( fd_sysvar_cache_t const * cache );
+FD_FN_PURE fd_sol_sysvar_last_restart_slot_global_t const * fd_sysvar_cache_last_restart_slot  ( fd_sysvar_cache_t const * cache );
 
 /* fd_sysvar_from_instr_acct_{...} pretends to read a sysvar from an
    instruction account.  Checks that a given instruction account has
@@ -165,15 +167,15 @@ FD_FN_PURE fd_sol_sysvar_last_restart_slot_t const * fd_sysvar_cache_last_restar
        return value;
      } */
 
-fd_sol_sysvar_clock_t             const * fd_sysvar_from_instr_acct_clock              ( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
-fd_epoch_schedule_t               const * fd_sysvar_from_instr_acct_epoch_schedule     ( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
-fd_sysvar_epoch_rewards_t         const * fd_sysvar_from_instr_acct_epoch_rewards      ( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
-fd_sysvar_fees_t                  const * fd_sysvar_from_instr_acct_fees               ( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
-fd_rent_t                         const * fd_sysvar_from_instr_acct_rent               ( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
-fd_slot_hashes_t                  const * fd_sysvar_from_instr_acct_slot_hashes        ( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
-fd_recent_block_hashes_t          const * fd_sysvar_from_instr_acct_recent_block_hashes( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
-fd_stake_history_t                const * fd_sysvar_from_instr_acct_stake_history      ( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
-fd_sol_sysvar_last_restart_slot_t const * fd_sysvar_from_instr_acct_last_restart_slot  ( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
+fd_sol_sysvar_clock_global_t             const * fd_sysvar_from_instr_acct_clock              ( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
+fd_epoch_schedule_global_t               const * fd_sysvar_from_instr_acct_epoch_schedule     ( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
+fd_sysvar_epoch_rewards_global_t         const * fd_sysvar_from_instr_acct_epoch_rewards      ( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
+fd_sysvar_fees_global_t                  const * fd_sysvar_from_instr_acct_fees               ( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
+fd_rent_global_t                         const * fd_sysvar_from_instr_acct_rent               ( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
+fd_slot_hashes_global_t                  const * fd_sysvar_from_instr_acct_slot_hashes        ( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
+fd_recent_block_hashes_global_t          const * fd_sysvar_from_instr_acct_recent_block_hashes( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
+fd_stake_history_global_t                const * fd_sysvar_from_instr_acct_stake_history      ( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
+fd_sol_sysvar_last_restart_slot_global_t const * fd_sysvar_from_instr_acct_last_restart_slot  ( fd_exec_instr_ctx_t const * ctx, ulong acct_idx, int * err );
 
 /* fd_check_sysvar_account does a check on if an instruction account index
    matches the expected pubkey of a specific sysvar. */

--- a/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
@@ -52,7 +52,7 @@ fd_sysvar_clock_read( fd_sol_sysvar_clock_t *   result,
                       fd_sysvar_cache_t const * sysvar_cache,
                       fd_acc_mgr_t *            acc_mgr,
                       fd_funk_txn_t *           funk_txn ) {
-  fd_sol_sysvar_clock_t const * ret = fd_sysvar_cache_clock( sysvar_cache );
+  fd_sol_sysvar_clock_t const * ret = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( sysvar_cache );
   if( NULL != ret ) {
     fd_memcpy(result, ret, sizeof(fd_sol_sysvar_clock_t));
     return result;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.h
@@ -19,15 +19,15 @@ fd_sysvar_epoch_rewards_read( fd_sysvar_epoch_rewards_t * result,
    https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/sdk/program/src/epoch_rewards.rs#L44 */
 void
 fd_sysvar_epoch_rewards_distribute( fd_exec_slot_ctx_t * slot_ctx,
-                                    ulong                distributed );
+                                    ulong                distributed,
+                                    fd_spad_t *          runtime_spad );
 
 /* Set the EpochRewards sysvar to inactive
 
     https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs#L82 */
 void
-fd_sysvar_epoch_rewards_set_inactive(
-  fd_exec_slot_ctx_t * slot_ctx
-);
+fd_sysvar_epoch_rewards_set_inactive( fd_exec_slot_ctx_t * slot_ctx,
+                                      fd_spad_t *          runtime_spad );
 
 /* Initialize the EpochRewards sysvar account
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.c
@@ -54,7 +54,7 @@ fd_sysvar_epoch_schedule_read( fd_epoch_schedule_t *     result,
                                fd_sysvar_cache_t const * sysvar_cache,
                                fd_acc_mgr_t *            acc_mgr,
                                fd_funk_txn_t *           funk_txn ) {
-  fd_epoch_schedule_t const * ret = fd_sysvar_cache_epoch_schedule( sysvar_cache );
+  fd_epoch_schedule_t const * ret = (fd_epoch_schedule_t const *)fd_sysvar_cache_epoch_schedule( sysvar_cache );
   if( FD_UNLIKELY( NULL != ret ) ) {
     fd_memcpy(result, ret, sizeof(fd_epoch_schedule_t));
     return result;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_fees.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_fees.c
@@ -23,7 +23,7 @@ fd_sysvar_fees_read( fd_sysvar_fees_t *        result,
                      fd_sysvar_cache_t const * sysvar_cache,
                      fd_acc_mgr_t *            acc_mgr,
                      fd_funk_txn_t *           funk_txn ) {
-  fd_sysvar_fees_t const * ret = fd_sysvar_cache_fees( sysvar_cache );
+  fd_sysvar_fees_t const * ret = (fd_sysvar_fees_t const *)fd_sysvar_cache_fees( sysvar_cache );
   if( FD_UNLIKELY( NULL != ret ) ) {
     fd_memcpy(result, ret, sizeof(fd_sysvar_fees_t));
     return result;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.c
@@ -38,7 +38,7 @@ fd_sysvar_last_restart_slot_read( fd_sol_sysvar_last_restart_slot_t * result,
                                   fd_acc_mgr_t *                      acc_mgr,
                                   fd_funk_txn_t *                     funk_txn ) {
 
-  fd_sol_sysvar_last_restart_slot_t const * ret = fd_sysvar_cache_last_restart_slot( sysvar_cache );
+  fd_sol_sysvar_last_restart_slot_t const * ret = (fd_sol_sysvar_last_restart_slot_t const *)fd_sysvar_cache_last_restart_slot( sysvar_cache );
   if( FD_UNLIKELY( NULL != ret ) ) {
     fd_memcpy(result, ret, sizeof(fd_sol_sysvar_last_restart_slot_t));
     return result;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
@@ -14,7 +14,7 @@ fd_sysvar_rent_read( fd_sysvar_cache_t const * sysvar_cache,
                      fd_funk_txn_t *           funk_txn,
                      fd_spad_t *               spad ) {
 
-  fd_rent_t const * ret = fd_sysvar_cache_rent( sysvar_cache );
+  fd_rent_t const * ret = (fd_rent_t const *)fd_sysvar_cache_rent( sysvar_cache );
   if( FD_UNLIKELY( ret ) ) {
     return (fd_rent_t*)ret;
   }

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
@@ -13,7 +13,7 @@ FD_FN_UNUSED static const ulong slot_hashes_max_entries = 512;
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/sysvar/slot_hashes.rs#L12 */
 static const ulong slot_hashes_min_account_size = 20488;
 
-static void write_slot_hashes( fd_exec_slot_ctx_t * slot_ctx, fd_slot_hashes_t* slot_hashes ) {
+static void write_slot_hashes( fd_exec_slot_ctx_t * slot_ctx, fd_slot_hashes_t * slot_hashes ) {
   ulong sz = fd_slot_hashes_size( slot_hashes );
   if (sz < slot_hashes_min_account_size)
     sz = slot_hashes_min_account_size;
@@ -22,7 +22,7 @@ static void write_slot_hashes( fd_exec_slot_ctx_t * slot_ctx, fd_slot_hashes_t* 
   fd_bincode_encode_ctx_t ctx;
   ctx.data = enc;
   ctx.dataend = enc + sz;
-  if ( fd_slot_hashes_encode( slot_hashes, &ctx ) )
+  if( fd_slot_hashes_encode( slot_hashes, &ctx ) )
     FD_LOG_ERR(("fd_slot_hashes_encode failed"));
 
   fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_slot_hashes_id, enc, sz, slot_ctx->slot_bank.slot );
@@ -37,6 +37,7 @@ void
 fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_spad ) {
   fd_slot_hashes_t * slot_hashes = fd_sysvar_slot_hashes_read( slot_ctx, runtime_spad );
   if( !slot_hashes ) {
+    FD_LOG_WARNING(("NEVER CREATED THIS MF BEFORE"));
     uchar * deque_mem = fd_spad_alloc( runtime_spad,
                                        deq_fd_slot_hash_t_align(),
                                        deq_fd_slot_hash_t_footprint( FD_SYSVAR_SLOT_HASHES_CAP ) );

--- a/src/flamenco/runtime/tests/fd_dump_pb.c
+++ b/src/flamenco/runtime/tests/fd_dump_pb.c
@@ -315,7 +315,7 @@ create_txn_context_protobuf_from_txn( fd_exec_test_txn_context_t * txn_context_m
   txn_context_msg->blockhash_queue = output_blockhash_queue;
 
   // Iterate over all block hashes in the queue and save them
-  fd_block_hash_queue_t const * queue = &txn_ctx->slot_bank->block_hash_queue;
+  fd_block_hash_queue_t const * queue = &txn_ctx->block_hash_queue;
   fd_hash_hash_age_pair_t_mapnode_t * nn;
   for ( fd_hash_hash_age_pair_t_mapnode_t * n = fd_hash_hash_age_pair_t_map_minimum( queue->ages_pool, queue->ages_root ); n; n = nn ) {
     nn = fd_hash_hash_age_pair_t_map_successor( queue->ages_pool, n );
@@ -350,7 +350,7 @@ create_txn_context_protobuf_from_txn( fd_exec_test_txn_context_t * txn_context_m
 
   /* Transaction Context -> slot_ctx */
   txn_context_msg->has_slot_ctx  = true;
-  txn_context_msg->slot_ctx.slot = txn_ctx->slot_bank->slot;
+  txn_context_msg->slot_ctx.slot = txn_ctx->slot;
 }
 
 static void

--- a/src/flamenco/runtime/tests/fd_vm_test.c
+++ b/src/flamenco/runtime/tests/fd_vm_test.c
@@ -108,7 +108,7 @@ do{
   fd_vm_input_region_t    input_mem_regions[1000] = {0}; /* We can have a max of (3 * num accounts + 1) regions */
   fd_vm_acc_region_meta_t acc_region_metas[256]   = {0}; /* instr acc idx to idx */
   uint                    input_mem_regions_cnt   = 0U;
-  int                     direct_mapping          = FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot_bank->slot, instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping );
+  int                     direct_mapping          = FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot, instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping );
 
   uchar * input_ptr      = NULL;
   uchar   program_id_idx = instr_ctx->instr->program_id;
@@ -151,7 +151,7 @@ do{
   /* Setup syscalls. Have them all be no-ops */
   fd_sbpf_syscalls_t * syscalls = fd_sbpf_syscalls_new( fd_valloc_malloc( valloc, fd_sbpf_syscalls_align(), fd_sbpf_syscalls_footprint() ) );
   fd_vm_syscall_register_slot( syscalls,
-                               instr_ctx->txn_ctx->slot_bank->slot,
+                               instr_ctx->txn_ctx->slot,
                                &instr_ctx->txn_ctx->features,
                                0 );
 

--- a/src/flamenco/stakes/fd_stakes.c
+++ b/src/flamenco/stakes/fd_stakes.c
@@ -605,7 +605,7 @@ fd_stakes_activate_epoch( fd_exec_slot_ctx_t *  slot_ctx,
   /* Add a new entry to the Stake History sysvar for the previous epoch
      https://github.com/solana-labs/solana/blob/88aeaa82a856fc807234e7da0b31b89f2dc0e091/runtime/src/stakes.rs#L181-L192 */
 
-  fd_stake_history_t const * history = fd_sysvar_cache_stake_history( slot_ctx->sysvar_cache );
+  fd_stake_history_t const * history = (fd_stake_history_t const *)fd_sysvar_cache_stake_history( slot_ctx->sysvar_cache );
   if( FD_UNLIKELY( !history ) ) FD_LOG_ERR(( "StakeHistory sysvar is missing from sysvar cache" ));
 
   ulong stake_delegations_size = fd_delegation_pair_t_map_size(
@@ -646,8 +646,13 @@ fd_stakes_activate_epoch( fd_exec_slot_ctx_t *  slot_ctx,
 
   /* Refresh the sysvar cache stake history entry after updating the sysvar.
       We need to do this here because it is used in subsequent places in the epoch boundary. */
-  fd_stake_history_destroy( slot_ctx->sysvar_cache->val_stake_history );
-  fd_sysvar_cache_restore_stake_history( slot_ctx->sysvar_cache, slot_ctx->acc_mgr, slot_ctx->funk_txn );
+  // fd_stake_history_destroy( slot_ctx->sysvar_cache->val_stake_history );
+  /* TODO:FIXME: FIX THIS*/
+  fd_sysvar_cache_restore_stake_history( slot_ctx->sysvar_cache,
+                                         slot_ctx->acc_mgr,
+                                         slot_ctx->funk_txn,
+                                         runtime_spad,
+                                         slot_ctx->runtime_wksp );
 
 }
 

--- a/src/flamenco/types/fd_types.c
+++ b/src/flamenco/types/fd_types.c
@@ -1826,7 +1826,7 @@ void fd_stake_history_decode_inner_global( void * struct_mem, void * * alloc_mem
 int fd_stake_history_convert_global_to_local( void const * global_self, fd_stake_history_t * self, fd_bincode_decode_ctx_t * ctx ) {
   int err = 0;
   fd_stake_history_global_t const * mem = (fd_stake_history_global_t const *)global_self;
-  self->fd_stake_history_len    = mem->fd_stake_history_len; //static vector
+  self->fd_stake_history_len    = mem->fd_stake_history_len;
   self->fd_stake_history_size   = mem->fd_stake_history_size;
   self->fd_stake_history_offset = mem->fd_stake_history_offset;
   for( ulong i=0; i<self->fd_stake_history_len; i++ ) {
@@ -8489,7 +8489,7 @@ int fd_vote_prior_voters_convert_global_to_local( void const * global_self, fd_v
   int err = 0;
   fd_vote_prior_voters_global_t const * mem = (fd_vote_prior_voters_global_t const *)global_self;
   for( ulong i=0; i<32; i++ ) {
-    fd_vote_prior_voter_convert_global_to_local( &mem->buf[i], &self->buf[i], ctx );//local
+    fd_vote_prior_voter_convert_global_to_local( &mem->buf[i], &self->buf[i], ctx );
   }
   self->idx = mem->idx;
   self->is_empty = mem->is_empty;
@@ -8590,7 +8590,7 @@ int fd_vote_prior_voters_0_23_5_convert_global_to_local( void const * global_sel
   int err = 0;
   fd_vote_prior_voters_0_23_5_global_t const * mem = (fd_vote_prior_voters_0_23_5_global_t const *)global_self;
   for( ulong i=0; i<32; i++ ) {
-    fd_vote_prior_voter_0_23_5_convert_global_to_local( &mem->buf[i], &self->buf[i], ctx );//local
+    fd_vote_prior_voter_0_23_5_convert_global_to_local( &mem->buf[i], &self->buf[i], ctx );
   }
   self->idx = mem->idx;
   return FD_BINCODE_SUCCESS;
@@ -34892,7 +34892,7 @@ void * fd_cache_status_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx 
 }
 void fd_cache_status_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_cache_status_global_t * self = (fd_cache_status_global_t *)struct_mem;
-  fd_bincode_bytes_decode_unsafe( self->key_slice, 20, ctx ); // array array
+  fd_bincode_bytes_decode_unsafe( self->key_slice, 20, ctx );
   fd_txn_result_decode_inner_global( &self->result, alloc_mem, ctx );
 }
 int fd_cache_status_convert_global_to_local( void const * global_self, fd_cache_status_t * self, fd_bincode_decode_ctx_t * ctx ) {

--- a/src/flamenco/types/fd_types.h
+++ b/src/flamenco/types/fd_types.h
@@ -10,8 +10,8 @@
 /* sdk/program/src/feature.rs#L22 */
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_feature {
-  ulong activated_at; //op0
-  uchar has_activated_at; //op2
+  ulong activated_at;
+  uchar has_activated_at;
 };
 typedef struct fd_feature fd_feature_t;
 #define FD_FEATURE_FOOTPRINT sizeof(fd_feature_t)
@@ -80,7 +80,7 @@ typedef struct fd_hash_hash_age_pair_global fd_hash_hash_age_pair_global_t;
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_block_hash_vec {
   ulong last_hash_index;
-  fd_hash_t * last_hash; //op4
+  fd_hash_t * last_hash;
   ulong ages_len;
   fd_hash_hash_age_pair_t * ages;
   ulong max_age;
@@ -123,7 +123,7 @@ fd_hash_hash_age_pair_t_map_join_new( void * * alloc_mem, ulong len ) {
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_block_hash_queue {
   ulong last_hash_index;
-  fd_hash_t * last_hash; //op4
+  fd_hash_t * last_hash;
   fd_hash_hash_age_pair_t_mapnode_t * ages_pool;
   fd_hash_hash_age_pair_t_mapnode_t * ages_root;
   ulong max_age;
@@ -955,7 +955,7 @@ struct __attribute__((aligned(16UL))) fd_versioned_bank {
   ulong signature_count;
   ulong capitalization;
   ulong max_tick_height;
-  ulong* hashes_per_tick; //op3
+  ulong* hashes_per_tick;
   ulong ticks_per_slot;
   uint128 ns_per_slot;
   ulong genesis_creation_time;
@@ -1285,11 +1285,11 @@ struct __attribute__((aligned(16UL))) fd_solana_manifest {
   fd_versioned_bank_t bank;
   fd_solana_accounts_db_fields_t accounts_db;
   ulong lamports_per_signature;
-  fd_bank_incremental_snapshot_persistence_t * bank_incremental_snapshot_persistence; //op4
-  fd_hash_t * epoch_account_hash; //op4
+  fd_bank_incremental_snapshot_persistence_t * bank_incremental_snapshot_persistence;
+  fd_hash_t * epoch_account_hash;
   ulong versioned_epoch_stakes_len;
   fd_versioned_epoch_stakes_pair_t * versioned_epoch_stakes;
-  fd_slot_lthash_t * lthash; //op4
+  fd_slot_lthash_t * lthash;
 };
 typedef struct fd_solana_manifest fd_solana_manifest_t;
 #define FD_SOLANA_MANIFEST_FOOTPRINT sizeof(fd_solana_manifest_t)
@@ -1329,9 +1329,9 @@ typedef struct fd_rust_duration_global fd_rust_duration_global_t;
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_poh_config {
   fd_rust_duration_t target_tick_duration;
-  ulong* target_tick_count; //op3
-  ulong hashes_per_tick; //op0
-  uchar has_hashes_per_tick; //op2
+  ulong* target_tick_count;
+  ulong hashes_per_tick;
+  uchar has_hashes_per_tick;
 };
 typedef struct fd_poh_config fd_poh_config_t;
 #define FD_POH_CONFIG_FOOTPRINT sizeof(fd_poh_config_t)
@@ -1698,8 +1698,8 @@ struct __attribute__((aligned(8UL))) fd_vote_state_0_23_5 {
   fd_pubkey_t authorized_withdrawer;
   uchar commission;
   fd_vote_lockout_t * votes; /* fd_deque_dynamic (min cnt 32) */
-  ulong root_slot; //op0
-  uchar has_root_slot; //op2
+  ulong root_slot;
+  uchar has_root_slot;
   fd_vote_epoch_credits_t * epoch_credits; /* fd_deque_dynamic (min cnt 64) */
   fd_vote_block_timestamp_t last_timestamp;
 };
@@ -1776,8 +1776,8 @@ struct __attribute__((aligned(8UL))) fd_vote_state_1_14_11 {
   fd_pubkey_t authorized_withdrawer;
   uchar commission;
   fd_vote_lockout_t * votes; /* fd_deque_dynamic (min cnt 32) */
-  ulong root_slot; //op0
-  uchar has_root_slot; //op2
+  ulong root_slot;
+  uchar has_root_slot;
   fd_vote_authorized_voters_t authorized_voters;
   fd_vote_prior_voters_t prior_voters;
   fd_vote_epoch_credits_t * epoch_credits; /* fd_deque_dynamic (min cnt 64) */
@@ -1824,8 +1824,8 @@ struct __attribute__((aligned(8UL))) fd_vote_state {
   fd_pubkey_t authorized_withdrawer;
   uchar commission;
   fd_landed_vote_t * votes; /* fd_deque_dynamic (min cnt 32) */
-  ulong root_slot; //op0
-  uchar has_root_slot; //op2
+  ulong root_slot;
+  uchar has_root_slot;
   fd_vote_authorized_voters_t authorized_voters;
   fd_vote_prior_voters_t prior_voters;
   fd_vote_epoch_credits_t * epoch_credits; /* fd_deque_dynamic (min cnt 64) */
@@ -1885,11 +1885,11 @@ typedef struct fd_vote_state_versioned_global fd_vote_state_versioned_global_t;
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_vote_state_update {
   fd_vote_lockout_t * lockouts; /* fd_deque_dynamic (min cnt 32) */
-  ulong root; //op0
-  uchar has_root; //op2
+  ulong root;
+  uchar has_root;
   fd_hash_t hash;
-  long timestamp; //op0
-  uchar has_timestamp; //op2
+  long timestamp;
+  uchar has_timestamp;
 };
 typedef struct fd_vote_state_update fd_vote_state_update_t;
 #define FD_VOTE_STATE_UPDATE_FOOTPRINT sizeof(fd_vote_state_update_t)
@@ -1913,8 +1913,8 @@ struct __attribute__((aligned(8UL))) fd_compact_vote_state_update {
   ushort lockouts_len;
   fd_lockout_offset_t * lockouts;
   fd_hash_t hash;
-  long timestamp; //op0
-  uchar has_timestamp; //op2
+  long timestamp;
+  uchar has_timestamp;
 };
 typedef struct fd_compact_vote_state_update fd_compact_vote_state_update_t;
 #define FD_COMPACT_VOTE_STATE_UPDATE_FOOTPRINT sizeof(fd_compact_vote_state_update_t)
@@ -1970,8 +1970,8 @@ struct __attribute__((aligned(8UL))) fd_compact_tower_sync {
   ulong root;
   fd_lockout_offset_t * lockout_offsets; /* fd_deque_dynamic (min cnt 32) */
   fd_hash_t hash;
-  long timestamp; //op0
-  uchar has_timestamp; //op2
+  long timestamp;
+  uchar has_timestamp;
   fd_hash_t block_id;
 };
 typedef struct fd_compact_tower_sync fd_compact_tower_sync_t;
@@ -1995,11 +1995,11 @@ typedef struct fd_compact_tower_sync_global fd_compact_tower_sync_global_t;
 struct __attribute__((aligned(8UL))) fd_tower_sync {
   fd_vote_lockout_t * lockouts; /* fd_deque_dynamic */
   ulong lockouts_cnt;
-  ulong root; //op0
-  uchar has_root; //op2
+  ulong root;
+  uchar has_root;
   fd_hash_t hash;
-  long timestamp; //op0
-  uchar has_timestamp; //op2
+  long timestamp;
+  uchar has_timestamp;
   fd_hash_t block_id;
 };
 typedef struct fd_tower_sync fd_tower_sync_t;
@@ -2058,7 +2058,7 @@ typedef struct fd_slot_history_inner_global fd_slot_history_inner_global_t;
 /* https://github.com/tov/bv-rs/blob/107be3e9c45324e55844befa4c4239d4d3d092c6/src/bit_vec/inner.rs#L8 */
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_slot_history_bitvec {
-  fd_slot_history_inner_t * bits; //op4
+  fd_slot_history_inner_t * bits;
   ulong len;
 };
 typedef struct fd_slot_history_bitvec fd_slot_history_bitvec_t;
@@ -2542,8 +2542,8 @@ struct __attribute__((aligned(128UL))) fd_slot_bank {
   fd_hash_t prev_banks_hash;
   ulong parent_signature_cnt;
   ulong tick_height;
-  ulong use_preceeding_epoch_stakes; //op0
-  uchar has_use_preceeding_epoch_stakes; //op2
+  ulong use_preceeding_epoch_stakes;
+  uchar has_use_preceeding_epoch_stakes;
   fd_hard_forks_t hard_forks;
 };
 typedef struct fd_slot_bank fd_slot_bank_t;
@@ -2623,7 +2623,7 @@ deq_ulong_join_new( void * * alloc_mem, ulong max ) {
 struct __attribute__((aligned(8UL))) fd_vote {
   ulong * slots; /* fd_deque_dynamic */
   fd_hash_t hash;
-  long* timestamp; //op3
+  long* timestamp;
 };
 typedef struct fd_vote fd_vote_t;
 #define FD_VOTE_FOOTPRINT sizeof(fd_vote_t)
@@ -3087,7 +3087,7 @@ typedef struct fd_stake_instruction_initialize_global fd_stake_instruction_initi
 struct __attribute__((aligned(8UL))) fd_stake_lockup_custodian_args {
   fd_stake_lockup_t lockup;
   fd_sol_sysvar_clock_t clock;
-  fd_pubkey_t * custodian; //op4
+  fd_pubkey_t * custodian;
 };
 typedef struct fd_stake_lockup_custodian_args fd_stake_lockup_custodian_args_t;
 #define FD_STAKE_LOCKUP_CUSTODIAN_ARGS_FOOTPRINT sizeof(fd_stake_lockup_custodian_args_t)
@@ -3195,8 +3195,8 @@ typedef struct fd_authorize_checked_with_seed_args_global fd_authorize_checked_w
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/instruction.rs#L235 */
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_lockup_checked_args {
-  long* unix_timestamp; //op3
-  ulong* epoch; //op3
+  long* unix_timestamp;
+  ulong* epoch;
 };
 typedef struct fd_lockup_checked_args fd_lockup_checked_args_t;
 #define FD_LOCKUP_CHECKED_ARGS_FOOTPRINT sizeof(fd_lockup_checked_args_t)
@@ -3213,9 +3213,9 @@ typedef struct fd_lockup_checked_args_global fd_lockup_checked_args_global_t;
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/instruction.rs#L228 */
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_lockup_args {
-  long* unix_timestamp; //op3
-  ulong* epoch; //op3
-  fd_pubkey_t * custodian; //op4
+  long* unix_timestamp;
+  ulong* epoch;
+  fd_pubkey_t * custodian;
 };
 typedef struct fd_lockup_args fd_lockup_args_t;
 #define FD_LOCKUP_ARGS_FOOTPRINT sizeof(fd_lockup_args_t)
@@ -3715,7 +3715,7 @@ typedef struct fd_bpf_upgradeable_loader_program_instruction_global fd_bpf_upgra
 /*  */
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_bpf_upgradeable_loader_state_buffer {
-  fd_pubkey_t * authority_address; //op4
+  fd_pubkey_t * authority_address;
 };
 typedef struct fd_bpf_upgradeable_loader_state_buffer fd_bpf_upgradeable_loader_state_buffer_t;
 #define FD_BPF_UPGRADEABLE_LOADER_STATE_BUFFER_FOOTPRINT sizeof(fd_bpf_upgradeable_loader_state_buffer_t)
@@ -3748,7 +3748,7 @@ typedef struct fd_bpf_upgradeable_loader_state_program_global fd_bpf_upgradeable
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_bpf_upgradeable_loader_state_program_data {
   ulong slot;
-  fd_pubkey_t * upgrade_authority_address; //op4
+  fd_pubkey_t * upgrade_authority_address;
 };
 typedef struct fd_bpf_upgradeable_loader_state_program_data fd_bpf_upgradeable_loader_state_program_data_t;
 #define FD_BPF_UPGRADEABLE_LOADER_STATE_PROGRAM_DATA_FOOTPRINT sizeof(fd_bpf_upgradeable_loader_state_program_data_t)
@@ -3862,8 +3862,8 @@ struct __attribute__((aligned(8UL))) fd_lookup_table_meta {
   ulong deactivation_slot;
   ulong last_extended_slot;
   uchar last_extended_slot_start_index;
-  fd_pubkey_t authority; //op1
-  uchar has_authority; //op2
+  fd_pubkey_t authority;
+  uchar has_authority;
   ushort _padding;
 };
 typedef struct fd_lookup_table_meta fd_lookup_table_meta_t;
@@ -3943,8 +3943,8 @@ typedef struct fd_gossip_bitvec_u8_inner_global fd_gossip_bitvec_u8_inner_global
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_bitvec_u8 {
-  fd_gossip_bitvec_u8_inner_t bits; //op1
-  uchar has_bits; //op2
+  fd_gossip_bitvec_u8_inner_t bits;
+  uchar has_bits;
   ulong len;
 };
 typedef struct fd_gossip_bitvec_u8 fd_gossip_bitvec_u8_t;
@@ -3979,8 +3979,8 @@ typedef struct fd_gossip_bitvec_u64_inner_global fd_gossip_bitvec_u64_inner_glob
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_bitvec_u64 {
-  fd_gossip_bitvec_u64_inner_t bits; //op1
-  uchar has_bits; //op2
+  fd_gossip_bitvec_u64_inner_t bits;
+  uchar has_bits;
   ulong len;
 };
 typedef struct fd_gossip_bitvec_u64 fd_gossip_bitvec_u64_t;
@@ -4400,8 +4400,8 @@ struct __attribute__((aligned(8UL))) fd_gossip_version_v1 {
   ushort major;
   ushort minor;
   ushort patch;
-  uint commit; //op0
-  uchar has_commit; //op2
+  uint commit;
+  uchar has_commit;
 };
 typedef struct fd_gossip_version_v1 fd_gossip_version_v1_t;
 #define FD_GOSSIP_VERSION_V1_FOOTPRINT sizeof(fd_gossip_version_v1_t)
@@ -4427,8 +4427,8 @@ struct __attribute__((aligned(8UL))) fd_gossip_version_v2 {
   ushort major;
   ushort minor;
   ushort patch;
-  uint commit; //op0
-  uchar has_commit; //op2
+  uint commit;
+  uchar has_commit;
   uint feature_set;
 };
 typedef struct fd_gossip_version_v2 fd_gossip_version_v2_t;
@@ -4656,8 +4656,8 @@ typedef struct fd_restart_raw_offsets_bitvec_u8_inner_global fd_restart_raw_offs
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_restart_raw_offsets_bitvec {
-  fd_restart_raw_offsets_bitvec_u8_inner_t bits; //op1
-  uchar has_bits; //op2
+  fd_restart_raw_offsets_bitvec_u8_inner_t bits;
+  uchar has_bits;
   ulong len;
 };
 typedef struct fd_restart_raw_offsets_bitvec fd_restart_raw_offsets_bitvec_t;
@@ -5407,7 +5407,7 @@ typedef struct fd_pubkey_rewardinfo_pair_global fd_pubkey_rewardinfo_pair_global
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_optional_account {
-  fd_solana_account_t * account; //op4
+  fd_solana_account_t * account;
 };
 typedef struct fd_optional_account fd_optional_account_t;
 #define FD_OPTIONAL_ACCOUNT_FOOTPRINT sizeof(fd_optional_account_t)

--- a/src/flamenco/types/gen_stubs.py
+++ b/src/flamenco/types/gen_stubs.py
@@ -757,7 +757,7 @@ class StaticVectorMember(TypeNode):
         print('  }', file=body)
 
     def emitGlobalLocalConvert(self):
-        print(f'  self->{self.name}_len    = mem->{self.name}_len; //static vector', file=body)
+        print(f'  self->{self.name}_len    = mem->{self.name}_len;', file=body)
         print(f'  self->{self.name}_size   = mem->{self.name}_size;', file=body)
         print(f'  self->{self.name}_offset = mem->{self.name}_offset;', file=body)
         print(f'  for( ulong i=0; i<self->{self.name}_len; i++ ) {{', file=body)
@@ -1621,15 +1621,15 @@ class OptionMember(TypeNode):
     def emitMember(self):
         if self.flat:
             if self.element in simpletypes:
-                print(f'  {self.element} {self.name}; //op0', file=header)
+                print(f'  {self.element} {self.name};', file=header)
             else:
-                print(f'  {namespace}_{self.element}_t {self.name}; //op1', file=header)
-            print(f'  uchar has_{self.name}; //op2', file=header)
+                print(f'  {namespace}_{self.element}_t {self.name};', file=header)
+            print(f'  uchar has_{self.name};', file=header)
         else:
             if self.element in simpletypes:
-                print(f'  {self.element}* {self.name}; //op3', file=header)
+                print(f'  {self.element}* {self.name};', file=header)
             else:
-                print(f'  {namespace}_{self.element}_t * {self.name}; //op4', file=header)
+                print(f'  {namespace}_{self.element}_t * {self.name};', file=header)
 
     def emitMemberGlobal(self):
         if self.flat:
@@ -1919,7 +1919,7 @@ class ArrayMember(TypeNode):
         length = self.length
 
         if self.element == "uchar":
-            print(f'  fd_bincode_bytes_decode_unsafe( self->{self.name}, {length}, ctx ); // array array', file=body)
+            print(f'  fd_bincode_bytes_decode_unsafe( self->{self.name}, {length}, ctx );', file=body)
             return
 
         print(f'  for( ulong i=0; i<{length}; i++ ) {{', file=body)
@@ -1934,7 +1934,7 @@ class ArrayMember(TypeNode):
           print(f'  fd_memcpy( self->{self.name}, mem->{self.name}, {self.length} * sizeof({self.element}) );', file=body)
       else:
           print(f'  for( ulong i=0; i<{self.length}; i++ ) {{', file=body)
-          print(f'    {namespace}_{self.element}_convert_global_to_local( &mem->{self.name}[i], &self->{self.name}[i], ctx );//local', file=body)
+          print(f'    {namespace}_{self.element}_convert_global_to_local( &mem->{self.name}[i], &self->{self.name}[i], ctx );', file=body)
           print(f'  }}', file=body)
 
     def emitEncode(self):

--- a/src/flamenco/vm/fd_vm_private.h
+++ b/src/flamenco/vm/fd_vm_private.h
@@ -293,7 +293,7 @@ fd_vm_mem_cfg( fd_vm_t * vm ) {
   vm->region_haddr[FD_VM_STACK_REGION] = (ulong)vm->stack;  vm->region_ld_sz[FD_VM_STACK_REGION] = (uint)FD_VM_STACK_MAX; vm->region_st_sz[FD_VM_STACK_REGION] = (uint)FD_VM_STACK_MAX;
   vm->region_haddr[FD_VM_HEAP_REGION]  = (ulong)vm->heap;   vm->region_ld_sz[FD_VM_HEAP_REGION]  = (uint)vm->heap_max;    vm->region_st_sz[FD_VM_HEAP_REGION]  = (uint)vm->heap_max;
   vm->region_haddr[5]                  = 0UL;               vm->region_ld_sz[5]                  = (uint)0UL;             vm->region_st_sz[5]                  = (uint)0UL;
-  if( FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot_bank->slot, vm->instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping ) || !vm->input_mem_regions_cnt ) {
+  if( FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot, vm->instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping ) || !vm->input_mem_regions_cnt ) {
     /* When direct mapping is enabled, we don't use these fields because
        the load and stores are fragmented. */
     vm->region_haddr[FD_VM_INPUT_REGION] = 0UL;

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
@@ -201,7 +201,7 @@ fd_vm_prepare_instruction( fd_instr_info_t const *  caller_instr,
     }
   }
 
-  if( FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot_bank->slot, instr_ctx->txn_ctx->features, lift_cpi_caller_restriction ) ) {
+  if( FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot, instr_ctx->txn_ctx->features, lift_cpi_caller_restriction ) ) {
     if( FD_UNLIKELY( -1==fd_exec_txn_ctx_find_idx_of_program_account( instr_ctx->txn_ctx, &callee_instr->program_id_pubkey ) ) ) {
       FD_BASE58_ENCODE_32_BYTES( callee_instr->program_id_pubkey.uc, id_b58 );
       fd_log_collector_msg_many( instr_ctx, 2, "Unknown program ", 16UL, id_b58, id_b58_len );
@@ -239,7 +239,7 @@ fd_vm_prepare_instruction( fd_instr_info_t const *  caller_instr,
     /* Check that the program account is executable. We need to ensure that the
        program account is a valid instruction account.
        https://github.com/anza-xyz/agave/blob/v2.1.14/program-runtime/src/invoke_context.rs#L438 */
-    if( !FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot_bank->slot, instr_ctx->txn_ctx->features, remove_accounts_executable_flag_checks ) ) {
+    if( !FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot, instr_ctx->txn_ctx->features, remove_accounts_executable_flag_checks ) ) {
       if( FD_UNLIKELY( !fd_borrowed_account_is_executable( &borrowed_program_account ) ) ) {
         FD_BASE58_ENCODE_32_BYTES( callee_instr->program_id_pubkey.uc, id_b58 );
         fd_log_collector_msg_many( instr_ctx, 3, "Account ", 8UL, id_b58, id_b58_len, " is not executable", 18UL );
@@ -280,7 +280,7 @@ fd_vm_prepare_instruction( fd_instr_info_t const *  caller_instr,
 FD_STATIC_ASSERT( FD_CPI_MAX_ACCOUNT_INFOS==MAX_TX_ACCOUNT_LOCKS, cpi_max_account_info );
 static inline ulong
 get_cpi_max_account_infos( fd_exec_txn_ctx_t const * txn_ctx ) {
-  return fd_ulong_if( FD_FEATURE_ACTIVE( txn_ctx->slot_bank->slot, txn_ctx->features, increase_tx_account_lock_limit ), FD_CPI_MAX_ACCOUNT_INFOS, 64UL );
+  return fd_ulong_if( FD_FEATURE_ACTIVE( txn_ctx->slot, txn_ctx->features, increase_tx_account_lock_limit ), FD_CPI_MAX_ACCOUNT_INFOS, 64UL );
 }
 
 /* Maximum CPI instruction data size. 10 KiB was chosen to ensure that CPI
@@ -310,7 +310,7 @@ fd_vm_syscall_cpi_check_instruction( fd_vm_t const * vm,
                                      ulong           acct_cnt,
                                      ulong           data_sz ) {
   /* https://github.com/solana-labs/solana/blob/eb35a5ac1e7b6abe81947e22417f34508f89f091/programs/bpf_loader/src/syscalls/cpi.rs#L958-L959 */
-  if( FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot_bank->slot, vm->instr_ctx->txn_ctx->features, loosen_cpi_size_restriction ) ) {
+  if( FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot, vm->instr_ctx->txn_ctx->features, loosen_cpi_size_restriction ) ) {
     if( FD_UNLIKELY( data_sz > FD_CPI_MAX_INSTRUCTION_DATA_LEN ) ) {
       FD_LOG_WARNING(( "cpi: data too long (%#lx)", data_sz ));
       // SyscallError::MaxInstructionDataLenExceeded
@@ -356,7 +356,7 @@ fd_vm_syscall_cpi_is_precompile( fd_pubkey_t const * program_id, fd_exec_txn_ctx
   return fd_vm_syscall_cpi_check_id(program_id, fd_solana_keccak_secp_256k_program_id.key) |
          fd_vm_syscall_cpi_check_id(program_id, fd_solana_ed25519_sig_verify_program_id.key) |
          ( fd_vm_syscall_cpi_check_id(program_id, fd_solana_secp256r1_program_id.key) &&
-           FD_FEATURE_ACTIVE( txn_ctx->slot_bank->slot, txn_ctx->features, enable_secp256r1_precompile ) );
+           FD_FEATURE_ACTIVE( txn_ctx->slot, txn_ctx->features, enable_secp256r1_precompile ) );
 }
 
 /* fd_vm_syscall_cpi_check_authorized_program corresponds to
@@ -379,7 +379,7 @@ fd_vm_syscall_cpi_check_authorized_program( fd_pubkey_t const *       program_id
             || (fd_vm_syscall_cpi_check_id(program_id, fd_solana_bpf_loader_upgradeable_program_id.key)
                 && !((instruction_data_len != 0 && instruction_data[0] == 3)  /* is_upgrade_instruction() */
                     || (instruction_data_len != 0 && instruction_data[0] == 4)  /* is_set_authority_instruction() */
-                    || (FD_FEATURE_ACTIVE( txn_ctx->slot_bank->slot, txn_ctx->features, enable_bpf_loader_set_authority_checked_ix )
+                    || (FD_FEATURE_ACTIVE( txn_ctx->slot, txn_ctx->features, enable_bpf_loader_set_authority_checked_ix )
                         && (instruction_data_len != 0 && instruction_data[0] == 7)) /* is_set_authority_checked_instruction() */
                     || (instruction_data_len != 0 && instruction_data[0] == 5))) /* is_close_instruction */
             || fd_vm_syscall_cpi_is_precompile( program_id, txn_ctx ) );

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
@@ -801,7 +801,7 @@ VM_SYSCALL_CPI_ENTRYPOINT( void *  _vm,
 
   /* Agave consumes CU in translate_instruction
      https://github.com/anza-xyz/agave/blob/838c1952595809a31520ff1603a13f2c9123aa51/programs/bpf_loader/src/syscalls/cpi.rs#L445 */
-  if( FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot_bank->slot, vm->instr_ctx->txn_ctx->features, loosen_cpi_size_restriction ) ) {
+  if( FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot, vm->instr_ctx->txn_ctx->features, loosen_cpi_size_restriction ) ) {
     FD_VM_CU_UPDATE( vm, VM_SYSCALL_CPI_INSTR_DATA_LEN( cpi_instruction ) / FD_VM_CPI_BYTES_PER_UNIT );
   }
 
@@ -902,7 +902,7 @@ VM_SYSCALL_CPI_ENTRYPOINT( void *  _vm,
 
   /* Right after translating, Agave checks the number of account infos:
      https://github.com/anza-xyz/agave/blob/838c1952595809a31520ff1603a13f2c9123aa51/programs/bpf_loader/src/syscalls/cpi.rs#L822 */
-  if( FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot_bank->slot, vm->instr_ctx->txn_ctx->features, loosen_cpi_size_restriction ) ) {
+  if( FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot, vm->instr_ctx->txn_ctx->features, loosen_cpi_size_restriction ) ) {
     if( FD_UNLIKELY( acct_info_cnt > get_cpi_max_account_infos( vm->instr_ctx->txn_ctx ) ) ) {
       FD_VM_ERR_FOR_LOG_SYSCALL( vm, FD_VM_SYSCALL_ERR_MAX_INSTRUCTION_ACCOUNT_INFOS_EXCEEDED );
       return FD_VM_SYSCALL_ERR_MAX_INSTRUCTION_ACCOUNT_INFOS_EXCEEDED;

--- a/src/flamenco/vm/syscall/fd_vm_syscall_crypto.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_crypto.c
@@ -71,7 +71,7 @@ fd_vm_syscall_sol_alt_bn128_group_op( void *  _vm,
   case FD_VM_SYSCALL_SOL_ALT_BN128_MUL:
     /* Compute scalar mul */
     if( FD_LIKELY( fd_bn254_g1_scalar_mul_syscall( call_result, input, input_sz,
-                                                   FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot_bank->slot, vm->instr_ctx->txn_ctx->features, fix_alt_bn128_multiplication_input_length ) )==0 ) ) {
+                                                   FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot, vm->instr_ctx->txn_ctx->features, fix_alt_bn128_multiplication_input_length ) )==0 ) ) {
       ret = 0UL; /* success */
     }
     break;

--- a/src/flamenco/vm/syscall/fd_vm_syscall_curve.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_curve.c
@@ -34,7 +34,7 @@ fd_vm_syscall_sol_curve_validate_point( /**/            void *  _vm,
 
   default:
     /* https://github.com/anza-xyz/agave/blob/5b3390b99a6e7665439c623062c1a1dda2803524/programs/bpf_loader/src/syscalls/mod.rs#L919-L928 */
-    if( FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot_bank->slot, vm->instr_ctx->txn_ctx->features, abort_on_invalid_curve ) ) {
+    if( FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot, vm->instr_ctx->txn_ctx->features, abort_on_invalid_curve ) ) {
       FD_VM_ERR_FOR_LOG_SYSCALL( vm, FD_VM_SYSCALL_ERR_INVALID_ATTRIBUTE );
       return FD_VM_SYSCALL_ERR_INVALID_ATTRIBUTE; /* SyscallError::InvalidAttribute */
     }
@@ -239,7 +239,7 @@ soft_error:
 
 invalid_error:
   /* https://github.com/anza-xyz/agave/blob/5b3390b99a6e7665439c623062c1a1dda2803524/programs/bpf_loader/src/syscalls/mod.rs#L1135-L1156 */
-  if( FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot_bank->slot, vm->instr_ctx->txn_ctx->features, abort_on_invalid_curve ) ) {
+  if( FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot, vm->instr_ctx->txn_ctx->features, abort_on_invalid_curve ) ) {
     FD_VM_ERR_FOR_LOG_SYSCALL( vm, FD_VM_SYSCALL_ERR_INVALID_ATTRIBUTE );
     return FD_VM_SYSCALL_ERR_INVALID_ATTRIBUTE; /* SyscallError::InvalidAttribute */
   }
@@ -374,7 +374,7 @@ fd_vm_syscall_sol_curve_multiscalar_mul( void *  _vm,
 
   default:
     /* https://github.com/anza-xyz/agave/blob/5b3390b99a6e7665439c623062c1a1dda2803524/programs/bpf_loader/src/syscalls/mod.rs#L1262-L1271 */
-    if( FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot_bank->slot, vm->instr_ctx->txn_ctx->features, abort_on_invalid_curve ) ) {
+    if( FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot, vm->instr_ctx->txn_ctx->features, abort_on_invalid_curve ) ) {
       FD_VM_ERR_FOR_LOG_SYSCALL( vm, FD_VM_SYSCALL_ERR_INVALID_ATTRIBUTE );
       return FD_VM_SYSCALL_ERR_INVALID_ATTRIBUTE; /* SyscallError::InvalidAttribute */
     }

--- a/src/flamenco/vm/syscall/fd_vm_syscall_runtime.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_runtime.c
@@ -292,7 +292,7 @@ fd_vm_syscall_sol_get_epoch_stake( /**/            void *  _vm,
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.0/programs/bpf_loader/src/syscalls/mod.rs#L2103-L2104 */
   const fd_pubkey_t * vote_address = FD_VM_MEM_HADDR_LD( vm, var_addr, FD_VM_ALIGN_RUST_PUBKEY, FD_PUBKEY_FOOTPRINT );
-  *_ret = fd_query_pubkey_stake( vote_address, &vm->instr_ctx->txn_ctx->epoch_bank->stakes.vote_accounts );
+  *_ret = fd_query_pubkey_stake( vote_address, &vm->instr_ctx->txn_ctx->stakes.vote_accounts );
 
   return FD_VM_SUCCESS;
 }

--- a/src/flamenco/vm/syscall/test_vm_syscall_curve.c
+++ b/src/flamenco/vm/syscall/test_vm_syscall_curve.c
@@ -101,7 +101,7 @@ main( int     argc,
       /* mem_regions_cnt  */ 0UL,
       /* mem_regions_accs */ NULL,
       /* is_deprecated    */ 0,
-      /* direct mapping   */ FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot_bank->slot, instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping )
+      /* direct mapping   */ FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot, instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping )
   );
   FD_TEST( vm_ok );
 

--- a/src/flamenco/vm/syscall/test_vm_syscalls.c
+++ b/src/flamenco/vm/syscall/test_vm_syscalls.c
@@ -244,7 +244,7 @@ main( int     argc,
       /* mem_regions_cnt  */ (uint)mem_regions_cnt,
       /* mem_regions_accs */ NULL,
       /* is_deprecated    */ 0,
-      /* direct mapping   */ FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot_bank->slot, instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping )
+      /* direct mapping   */ FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot, instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping )
   );
   FD_TEST( vm_ok );
 

--- a/src/flamenco/vm/test_vm_instr.c
+++ b/src/flamenco/vm/test_vm_instr.c
@@ -465,7 +465,7 @@ run_input( test_input_t const * input,
       /* mem_regions_cnt  */ input->region_boundary_cnt ? input->region_boundary_cnt : 1,
       /* mem_regions_accs */ NULL,
       /* is_deprecated    */ 0,
-      /* direct mapping   */ FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot_bank->slot, instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping )
+      /* direct mapping   */ FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot, instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping )
   );
   assert( vm_ok );
 

--- a/src/flamenco/vm/test_vm_interp.c
+++ b/src/flamenco/vm/test_vm_interp.c
@@ -53,7 +53,7 @@ test_program_success( char *                test_case_name,
       /* mem_regions_cnt  */ 0UL,
       /* mem_regions_accs */ NULL,
       /* is_deprecated    */ 0,
-      /* direct mapping   */ FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot_bank->slot, instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping )
+      /* direct mapping   */ FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot, instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping )
   );
   FD_TEST( vm_ok );
 
@@ -247,7 +247,7 @@ test_0cu_exit( void ) {
       /* mem_regions_cnt  */ 0UL,
       /* mem_regions_accs */ NULL,
       /* is_deprecated    */ 0,
-      /* direct mapping   */ FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot_bank->slot, instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping )
+      /* direct mapping   */ FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot, instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping )
   );
   FD_TEST( vm_ok );
 
@@ -278,7 +278,7 @@ test_0cu_exit( void ) {
       /* mem_regions_cnt  */ 0UL,
       /* mem_regions_accs */ NULL,
       /* is_deprecated    */ 0,
-      /* direct mapping   */ FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot_bank->slot, instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping )
+      /* direct mapping   */ FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot, instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping )
   );
   FD_TEST( vm_ok );
 

--- a/src/flamenco/vm/test_vm_util.c
+++ b/src/flamenco/vm/test_vm_util.c
@@ -36,8 +36,9 @@ test_vm_minimal_exec_instr_ctx( fd_valloc_t valloc ) {
   fd_features_disable_all( &epoch_ctx->features );
   fd_features_set( &epoch_ctx->features, fd_feature_id_query(TEST_VM_REJECT_CALLX_R10_FEATURE_PREFIX), 0UL );
 
-  txn_ctx->slot_bank = &slot_ctx->slot_bank;
-  txn_ctx->features  = epoch_ctx->features;
+  txn_ctx->block_hash_queue = slot_ctx->slot_bank.block_hash_queue;
+  txn_ctx->slot             = slot_ctx->slot_bank.slot;
+  txn_ctx->features         = epoch_ctx->features;
 
   return ctx;
 }


### PR DESCRIPTION
This lays the groundwork for the sandbox. Only the stakes, bhq, and bank hash cmp needs to be globally addressed.