### PR TITLE
quic_tls: maintain invariant

### DIFF
--- a/src/waltz/quic/tls/fd_quic_tls.c
+++ b/src/waltz/quic/tls/fd_quic_tls.c
@@ -297,7 +297,8 @@ fd_quic_tls_sendmsg( void const * handshake,
      head >= buf_sz implies wrap around */
   if( head >= buf_sz ) {
     /* wrap around implies entire unused block is contiguous */
-    if( head - tail < alloc_data_sz ) {
+    /* head - tail is bytes used */
+    if( buf_sz - (head - tail) < alloc_data_sz ) {
       /* not enough free */
       return 0;
     } else {
@@ -316,7 +317,7 @@ fd_quic_tls_sendmsg( void const * handshake,
 
       /* since we're skipping some free space at end of buffer,
          we need to free that also, upon pop */
-      alloc_head   = 0;
+      alloc_head   = buf_sz; /* maintain head >= tail */
       free_data_sz = alloc_data_sz + buf_sz - head;
     }
   }


### PR DESCRIPTION
This PR fixes a bug during wrap-around in the quic_tls_hs circular buffer. Currently, if we ever wrap-around to the front of the buffer, we set head back to 0. However, this violates the invariant that head >= tail, causing a crash when popping that data. 

Additionally, if head actually wrapped around, we'd use bytes_used (head-tail) rather than bytes_avail to check if we had enough available space.

The server never hit this issue, because it always wrote less data than buffer size so never wrapped around. Fixing it nevertheless.