### PR TITLE
feat(replay): optimize shred->replay link and shred rx windowing

### DIFF
--- a/src/app/fdctl/topos/fd_firedancer.c
+++ b/src/app/fdctl/topos/fd_firedancer.c
@@ -191,7 +191,7 @@ fd_topo_initialize( config_t * config ) {
 
   FOR(shred_tile_cnt)  fd_topob_link( topo, "shred_sign",   "shred_sign",   128UL,                                    32UL,                          1UL );
   FOR(shred_tile_cnt)  fd_topob_link( topo, "sign_shred",   "sign_shred",   128UL,                                    64UL,                          1UL );
-  FOR(shred_tile_cnt)  fd_topob_link( topo, "shred_replay", "shred_replay", 128UL,                                    128UL,                         config->tiles.shred.max_pending_shred_sets );
+  FOR(shred_tile_cnt)  fd_topob_link( topo, "shred_replay", "shred_replay", 65536UL,                                  128UL,                         config->tiles.shred.max_pending_shred_sets );
 
   /**/                 fd_topob_link( topo, "gossip_sign",  "gossip_sign",  128UL,                                    2048UL,                        1UL );
   /**/                 fd_topob_link( topo, "sign_gossip",  "sign_gossip",  128UL,                                    64UL,                          1UL );

--- a/src/discof/replay/test_replay.c
+++ b/src/discof/replay/test_replay.c
@@ -1,13 +1,11 @@
-#if 0
 #include "fd_replay.h"
-#include <sys/resource.h>
 
 int
 fd_replay_verify_init_map( fd_replay_t const * replay ) {
   fd_replay_slice_t * slice_map      = replay->slice_map;
   ulong               prev_deque_loc = 0;
-  for( ulong i = 0; i < replay->block_max; i++ ) {
-    fd_replay_slice_t * slice_map_entry = slice_map + i;
+  for( ulong i = 0; i < fd_replay_slice_map_slot_cnt( replay->slice_map ); i++ ) {
+    fd_replay_slice_t * slice_map_entry = &slice_map[i];
     FD_TEST( fd_replay_slice_deque_cnt( slice_map_entry->deque ) == 0 );
     FD_TEST( fd_replay_slice_deque_max( slice_map_entry->deque ) == replay->slice_max );
     if( i == 0 ) {
@@ -35,7 +33,7 @@ main( int argc, char ** argv ) {
   ulong  fec_max       = 16;
   ulong  slice_max     = 16;
   ulong  block_max     = 16;
-  void * replay_mem    = fd_wksp_alloc_laddr( wksp, fd_replay_align(), fd_replay_footprint( fec_max, slice_max ), 1UL );
+  void * replay_mem    = fd_wksp_alloc_laddr( wksp, fd_replay_align(), fd_replay_footprint( fec_max, slice_max, block_max ), 1UL );
   fd_replay_t * replay = fd_replay_join( fd_replay_new( replay_mem, fec_max, slice_max, block_max ) );
   FD_TEST( replay );
 
@@ -61,10 +59,5 @@ main( int argc, char ** argv ) {
   FD_TEST( fd_replay_fec_query( replay, 42, 84 ) );
 
   fd_halt();
-  return 0;
-}
-#endif
-
-int main( void ) {
   return 0;
 }


### PR DESCRIPTION
This PR changes how the shred tile notifies replay tile that a FEC set is complete. Previously this was encoded in a single bit on a common message type.

Now the shred tile publishes different message types indicated in the sig. This simplifies the logic in both the shred and replay tiles by obviating the need to conditionally publish on `COMPLETES` later, due to blockstore insertion timing.