### PR TITLE
[FIX] Reverse the is_cooked logic in quic_pcap_iter_run_pcap

### DIFF
--- a/src/waltz/quic/fd_quic_pcap_main.c
+++ b/src/waltz/quic/fd_quic_pcap_main.c
@@ -479,9 +479,9 @@ quic_pcap_iter_run_pcap( quic_pcap_iter_t * iter ) {
     ulong sz = fd_pcap_iter_next( pcap, pkt, sizeof(pkt), &ts );
     if( FD_UNLIKELY( !sz ) ) break;
     if( is_cooked ) {
-      quic_pcap_iter_deliver_ethernet( iter, pkt, sz );
-    } else {
       quic_pcap_iter_deliver_cooked( iter, pkt, sz );
+    } else {
+      quic_pcap_iter_deliver_ethernet( iter, pkt, sz );
     }
   }
 


### PR DESCRIPTION
This PR fixes the reversed logic for FD_PCAP_ITER_TYPE_ETHERNET vs FD_PCAP_ITER_TYPE_COOKED in the `quic_pcap_iter_run_pcap()` function. Currently, the `switch` statement sets `is_cooked` based on the pcap_iter_type, but the subsequent `if (is_cooked)` branch calls `quic_pcap_iter_deliver_ethernet()` instead of `quic_pcap_iter_deliver_cooked()`. 

By swapping these function calls, we ensure that:
- `is_cooked = 0` (Ethernet) calls `quic_pcap_iter_deliver_ethernet()`
- `is_cooked = 1` (Cooked) calls `quic_pcap_iter_deliver_cooked()`

This correction aligns the code with the intended link-type handling. 

Fixes #4529.