### PR TITLE
fix static analysis findings + simplify query

### DIFF
--- a/contrib/codeql/nightly/SurelyWrongConstPure.ql
+++ b/contrib/codeql/nightly/SurelyWrongConstPure.ql
@@ -20,39 +20,14 @@ class ConstFunc extends RFunc {
   ConstFunc() { this.getAnAttribute().getName() = "const" }
 }
 
-abstract class ShouldBeFunc extends Function { }
 
-class ShouldBePure extends ShouldBeFunc {
-  Function off;
-
-  ShouldBePure() {
-    (
-      off instanceof RFunc or
-      off instanceof ShouldBeFunc
-    ) and
-    not this instanceof RFunc and
-    this.getACallToThisFunction().getEnclosingFunction() = off and
-    this.getLocation().getFile().getRelativePath().matches("src/%")
-  }
-
-  Function getOff() { result = off }
-}
-
-string directOrNot(Function off) {
-  /* alternativly we could make this query a path-query */
-  result = "is" and off instanceof RFunc
-  or
-  result = "is called by a" and off instanceof ShouldBeFunc
-}
-
-from ShouldBePure f, Function off
+from RFunc r, Function f
 where
-  off = f.getOff() and
   (
     /* for a nightly query, we only want known non-const/non-pure functions */
     f.hasName("fd_log_private_1") or
     f.hasName("fd_log_private_2") or
     f.hasName("fd_log_wallclock()") or
     f.getName().matches("fd_valloc_%")
-  )
-select off, f + " is called via " + off + " which " + directOrNot(off) + " const/pure function"
+  ) and r.calls*(f)
+select r, f + " is called (transitively) by " + r + " which is marked as " + r.getAnAttribute().getName()

--- a/src/discof/eqvoc/fd_eqvoc_tile.c
+++ b/src/discof/eqvoc/fd_eqvoc_tile.c
@@ -120,7 +120,7 @@ static void
 during_frag( fd_eqvoc_tile_ctx_t * ctx,
              ulong                 in_idx,
              ulong                 seq FD_PARAM_UNUSED,
-             ulong                 sig FD_PARAM_UNUSED,
+             ulong                 sig,
              ulong                 chunk,
              ulong                 sz,
              ulong                 ctl FD_PARAM_UNUSED ) {

--- a/src/discoh/bank/fd_bank_tile.c
+++ b/src/discoh/bank/fd_bank_tile.c
@@ -481,7 +481,6 @@ after_frag( fd_bank_ctx_t *     ctx,
             ulong               tsorig,
             fd_stem_context_t * stem ) {
   (void)in_idx;
-  (void)tsorig;
   ulong slot = fd_disco_poh_sig_slot( sig );
   if( FD_UNLIKELY( slot!=ctx->rebates_for_slot ) ) {
     /* If pack has already moved on to a new slot, the rebates are no

--- a/src/flamenco/runtime/fd_cost_tracker.c
+++ b/src/flamenco/runtime/fd_cost_tracker.c
@@ -221,7 +221,7 @@ get_allocated_accounts_data_size( fd_transaction_cost_t const * self ) {
 }
 
 /* https://github.com/anza-xyz/agave/blob/v2.2.0/cost-model/src/cost_tracker.rs#L277-L322 */
-FD_FN_PURE static inline int
+static inline int
 would_fit( fd_cost_tracker_t const *     self,
            fd_exec_txn_ctx_t const *     txn_ctx,
            fd_transaction_cost_t const * tx_cost ) {

--- a/src/funk/fd_funk_rec.h
+++ b/src/funk/fd_funk_rec.h
@@ -185,7 +185,7 @@ fd_funk_rec_query_global( fd_funk_t *               funk,
    valloc. NULL is returned if the query fails. The query is always
    against the root transaction. */
 
-FD_FN_PURE void *
+void *
 fd_funk_rec_query_safe( fd_funk_t *               funk,
                         fd_funk_rec_key_t const * key,
                         fd_valloc_t               valloc,

--- a/src/funkier/fd_funkier_txn.c
+++ b/src/funkier/fd_funkier_txn.c
@@ -735,7 +735,7 @@ fd_funkier_txn_last_rec( fd_funkier_t *           funk,
 /* Return the next record in a transaction. Returns NULL if the
    transaction has no more records. */
 
-FD_FN_PURE fd_funkier_rec_t const *
+fd_funkier_rec_t const *
 fd_funkier_txn_next_rec( fd_funkier_t *           funk,
                          fd_funkier_rec_t const * rec ) {
   ulong rec_idx = rec->next_idx;
@@ -745,7 +745,7 @@ fd_funkier_txn_next_rec( fd_funkier_t *           funk,
   return rec_pool.ele + rec_idx;
 }
 
-FD_FN_PURE fd_funkier_rec_t const *
+fd_funkier_rec_t const *
 fd_funkier_txn_prev_rec( fd_funkier_t *           funk,
                          fd_funkier_rec_t const * rec ) {
   ulong rec_idx = rec->prev_idx;

--- a/src/funkier/fd_funkier_txn.h
+++ b/src/funkier/fd_funkier_txn.h
@@ -191,14 +191,14 @@ typedef struct fd_funkier_rec fd_funkier_rec_t;
 /* Return the first (oldest) record in a transaction. Returns NULL if the
    transaction has no records yet. */
 
-FD_FN_PURE fd_funkier_rec_t const *
+fd_funkier_rec_t const *
 fd_funkier_txn_first_rec( fd_funkier_t *           funk,
                           fd_funkier_txn_t const * txn );
 
 /* Return the last (newest) record in a transaction. Returns NULL if the
    transaction has no records yet. */
 
-FD_FN_PURE fd_funkier_rec_t const *
+fd_funkier_rec_t const *
 fd_funkier_txn_last_rec( fd_funkier_t *           funk,
                          fd_funkier_txn_t const * txn );
 


### PR DESCRIPTION
For the const/pure violations:
* fd_funkier_txn_first_rec → fd_funkier_rec_pool → POOL_(join) → FD_LOG_WARNING
* fd_funkier_txn_last_rec → fd_funkier_rec_pool → POOL_(join) → FD_LOG_WARNING
* fd_funkier_txn_next_rec → fd_funkier_rec_pool → POOL_(join) → FD_LOG_WARNING
* would_fit → fd_account_costs_pair_t_map_find → REDBLK_(find) → REDBLK_(validate_element)(pool, x) → FD_LOG_ERR
* fd_funk_rec_query_safe → fd_funk_rec_query_xid_safe → fd_valloc_malloc
