### PR TITLE
flamenco: fix epoch rewards alignment to match agave

### DIFF
--- a/contrib/test/test-vectors-fixtures/syscall-fixtures/sol_get_sysvar.list
+++ b/contrib/test/test-vectors-fixtures/syscall-fixtures/sol_get_sysvar.list
@@ -233,3 +233,4 @@ dump/test-vectors/syscall/fixtures/sol_get_sysvar/fcec260292218da08ba11eb1c32895
 dump/test-vectors/syscall/fixtures/sol_get_sysvar/fe5b10c7c4c937285a58482fff6584fdee4ec40b_369105.fix
 dump/test-vectors/syscall/fixtures/sol_get_sysvar/fe9672b856c0a0b73273144ca508054a00bec84f_369105.fix
 dump/test-vectors/syscall/fixtures/sol_get_sysvar/ff060bdc718940d576da09a55876114ee42b868c_369105.fix
+dump/test-vectors/syscall/fixtures/sol_get_sysvar/dd94f78037944b6e5bc7874fd10614c6acceb6bc_257275.fix

--- a/src/flamenco/types/fd_types.h
+++ b/src/flamenco/types/fd_types.h
@@ -2295,7 +2295,7 @@ typedef struct fd_sysvar_fees_global fd_sysvar_fees_global_t;
 
 /* https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/sdk/program/src/epoch_rewards.rs#L14 */
 /* Encoded Size: Fixed (81 bytes) */
-struct __attribute__((aligned(8UL))) fd_sysvar_epoch_rewards {
+struct __attribute__((aligned(16UL))) fd_sysvar_epoch_rewards {
   ulong distribution_starting_block_height;
   ulong num_partitions;
   fd_hash_t parent_blockhash;
@@ -2306,9 +2306,9 @@ struct __attribute__((aligned(8UL))) fd_sysvar_epoch_rewards {
 };
 typedef struct fd_sysvar_epoch_rewards fd_sysvar_epoch_rewards_t;
 #define FD_SYSVAR_EPOCH_REWARDS_FOOTPRINT sizeof(fd_sysvar_epoch_rewards_t)
-#define FD_SYSVAR_EPOCH_REWARDS_ALIGN (8UL)
+#define FD_SYSVAR_EPOCH_REWARDS_ALIGN (16UL)
 
-struct __attribute__((aligned(8UL))) fd_sysvar_epoch_rewards_global {
+struct __attribute__((aligned(16UL))) fd_sysvar_epoch_rewards_global {
   ulong distribution_starting_block_height;
   ulong num_partitions;
   fd_hash_t parent_blockhash;
@@ -2319,7 +2319,7 @@ struct __attribute__((aligned(8UL))) fd_sysvar_epoch_rewards_global {
 };
 typedef struct fd_sysvar_epoch_rewards_global fd_sysvar_epoch_rewards_global_t;
 #define FD_SYSVAR_EPOCH_REWARDS_GLOBAL_FOOTPRINT sizeof(fd_sysvar_epoch_rewards_global_t)
-#define FD_SYSVAR_EPOCH_REWARDS_GLOBAL_ALIGN (8UL)
+#define FD_SYSVAR_EPOCH_REWARDS_GLOBAL_ALIGN (16UL)
 
 /* Encoded Size: Fixed (33 bytes) */
 struct __attribute__((aligned(8UL))) fd_config_keys_pair {

--- a/src/flamenco/types/fd_types.json
+++ b/src/flamenco/types/fd_types.json
@@ -980,6 +980,7 @@
     {
       "name": "sysvar_epoch_rewards",
       "type": "struct",
+      "alignment": "16",
       "fields": [
         { "name": "distribution_starting_block_height", "type": "ulong" },
         { "name": "num_partitions", "type": "ulong" },


### PR DESCRIPTION
Thanks to @anarcheuz for root causing this!