### PR TITLE
Reduce default QUIC memory usage by 6 GiB

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -977,7 +977,7 @@ dynamic_port_range = "8900-9000"
         # Higher values reduce TPU packet loss over unreliable networks.
         # If this parameter is set too low, packet loss can cause some
         # large transactions to get dropped.  Must be 2 or larger.
-        txn_reassembly_count = 4194304
+        txn_reassembly_count = 131072
 
         # QUIC has a handshake process which establishes a secure
         # connection between two endpoints.  The handshake process is


### PR DESCRIPTION
Reduces reassembly parallelism, dropping mem usage from 9 GiB to
3 GiB.  (when using gigantic pages)

A bugfix to Agave client QUIC code was rolled out that greatly
reduces transaction data fragmentation on mainnet.  So Firedancer
nodes can reduce their reassembly buffers accordingly.
