### PR TITLE
Raise 1 GiB page threshold

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -830,6 +830,12 @@ dynamic_port_range = "8900-9000"
     # virtualized environments like cloud providers.
     max_page_size = "gigantic"
 
+    # Workspaces are either fully backed by "huge" or "gigantic" pages.
+    # Workspaces with footprint equal to or greater than the given value
+    # in MiB are backed by "gigantic" pages unless disabled via
+    # max_page_size.
+    gigantic_page_threshold_mib = 128
+
 # Tiles are described in detail in the layout section above.  While the
 # layout configuration determines how many of each tile to place on
 # which CPU core to create a functioning system, below is the individual

--- a/src/app/fdctl/topos/fd_firedancer.c
+++ b/src/app/fdctl/topos/fd_firedancer.c
@@ -89,6 +89,7 @@ fd_topo_initialize( config_t * config ) {
 
   fd_topo_t * topo = { fd_topob_new( &config->topo, config->name ) };
   topo->max_page_size = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
+  topo->gigantic_page_threshold = config->hugetlbfs.gigantic_page_threshold_mib << 20;
 
   /*             topo, name */
   fd_topob_wksp( topo, "metric_in"  );

--- a/src/app/fdctl/topos/fd_frankendancer.c
+++ b/src/app/fdctl/topos/fd_frankendancer.c
@@ -21,6 +21,7 @@ fd_topo_initialize( config_t * config ) {
 
   fd_topo_t * topo = { fd_topob_new( &config->topo, config->name ) };
   topo->max_page_size = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
+  topo->gigantic_page_threshold = config->hugetlbfs.gigantic_page_threshold_mib << 20;
 
   /*             topo, name */
   fd_topob_wksp( topo, "metric_in"    );

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -233,6 +233,7 @@ struct fd_config {
     char huge_page_mount_path[ PATH_MAX ];
     char mount_path[ PATH_MAX ];
     char max_page_size[ 16 ];
+    ulong gigantic_page_threshold_mib;
   } hugetlbfs;
 
   struct {

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -284,6 +284,7 @@ fdctl_pod_to_cfg( config_t * config,
 
   CFG_POP      ( cstr,   hugetlbfs.mount_path                             );
   CFG_POP      ( cstr,   hugetlbfs.max_page_size                          );
+  CFG_POP      ( ulong,  hugetlbfs.gigantic_page_threshold_mib            );
 
   CFG_POP      ( cstr,   tiles.net.interface                              );
   CFG_POP      ( cstr,   tiles.net.xdp_mode                               );

--- a/src/disco/topo/fd_topo.c
+++ b/src/disco/topo/fd_topo.c
@@ -396,7 +396,7 @@ fd_topo_print_log( int         stdout,
 
     char size[ 24 ];
     fd_topo_mem_sz_string( wksp->page_sz * wksp->page_cnt, size );
-    PRINT( "  %2lu (%7s): %12s  page_cnt=%lu  page_sz=%-8s  numa_idx=%-2lu  footprint=%-10lu  loose=%lu\n", i, size, wksp->name, wksp->page_cnt, fd_shmem_page_sz_to_cstr( wksp->page_sz ), wksp->numa_idx, wksp->known_footprint, wksp->total_footprint - wksp->known_footprint );
+    PRINT( "  %2lu (%7s): %12s  page_cnt=%2lu  page_sz=%-8s  numa_idx=%-2lu  footprint=%-10lu  loose=%lu\n", i, size, wksp->name, wksp->page_cnt, fd_shmem_page_sz_to_cstr( wksp->page_sz ), wksp->numa_idx, wksp->known_footprint, wksp->total_footprint - wksp->known_footprint );
   }
 
   PRINT( "\nOBJECTS\n" );

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -438,6 +438,7 @@ struct fd_topo {
 # endif
 
   ulong          max_page_size; /* 2^21 or 2^30 */
+  ulong          gigantic_page_threshold; /* see [hugetlbfs.gigantic_page_threshold_mib]*/
 };
 typedef struct fd_topo fd_topo_t;
 

--- a/src/disco/topo/fd_topob.h
+++ b/src/disco/topo/fd_topob.h
@@ -144,7 +144,7 @@ void
 fd_topob_finish( fd_topo_t * topo,
                  ulong (* align    )( fd_topo_t const * topo, fd_topo_obj_t const * obj ),
                  ulong (* footprint)( fd_topo_t const * topo, fd_topo_obj_t const * obj ),
-                 ulong (* loose    )( fd_topo_t const * topo, fd_topo_obj_t const * obj) );
+                 ulong (* loose    )( fd_topo_t const * topo, fd_topo_obj_t const * obj ) );
 
 FD_PROTOTYPES_END
 


### PR DESCRIPTION
Adds a new gigantic_page_threshold_mib config option.
Workspaces now use up to 64 2 MiB huge pages.

Reduces memory usage by about 4 GiB.
