### PR TITLE
fuzz: set our conn id != 0

### DIFF
--- a/src/waltz/quic/tests/fuzz_quic_wire.c
+++ b/src/waltz/quic/tests/fuzz_quic_wire.c
@@ -146,7 +146,7 @@ LLVMFuzzerTestOneInput( uchar const * data,
   fd_quic_state_t * state = fd_quic_get_state( quic );
 
   /* Create dummy connection */
-  ulong             our_conn_id  = 0UL;
+  ulong             our_conn_id  = ULONG_MAX;
   fd_quic_conn_id_t peer_conn_id = { .sz=8 };
   uint              dst_ip_addr  = 0U;
   ushort            dst_udp_port = (ushort)0;


### PR DESCRIPTION
in normal operation this will never happen p=1/2**64, but the fuzzer hardcodes it, which triggers handholding checks