### PR TITLE
firedancer: exec model changes pt1

### DIFF
--- a/src/app/fdctl/config.c
+++ b/src/app/fdctl/config.c
@@ -9,6 +9,7 @@
 #include "../../flamenco/runtime/fd_blockstore.h"
 #include "../../flamenco/runtime/fd_txncache.h"
 #include "../../flamenco/runtime/fd_runtime.h"
+#include "../../flamenco/runtime/fd_runtime_public.h"
 #endif
 #include "../../funk/fd_funk.h"
 #include "../../waltz/ip/fd_fib4.h"
@@ -65,12 +66,14 @@ fdctl_obj_align( fd_topo_t const *     topo,
   } else if( FD_UNLIKELY( !strcmp( obj->name, "keyswitch" ) ) ) {
     return fd_keyswitch_align();
 #if FD_HAS_NO_AGAVE
-  } else if( FD_UNLIKELY( !strcmp( obj->name, "replay_pub" ) ) ) {
+  } else if( FD_UNLIKELY( !strcmp( obj->name, "runtime_pub" ) ) ) {
     return fd_runtime_public_align();
   } else if( FD_UNLIKELY( !strcmp( obj->name, "blockstore" ) ) ) {
     return fd_blockstore_align();
   } else if( FD_UNLIKELY( !strcmp( obj->name, "txncache" ) ) ) {
     return fd_txncache_align();
+  } else if( FD_UNLIKELY( !strcmp( obj->name, "exec_spad" ) ) ) {
+    return fd_spad_align();
 #endif /* FD_HAS_NO_AGAVE */
   } else {
     FD_LOG_ERR(( "unknown object `%s`", obj->name ));
@@ -120,12 +123,14 @@ fdctl_obj_footprint( fd_topo_t const *     topo,
   } else if( FD_UNLIKELY( !strcmp( obj->name, "keyswitch" ) ) ) {
     return fd_keyswitch_footprint();
 #if FD_HAS_NO_AGAVE
-  } else if( FD_UNLIKELY( !strcmp( obj->name, "replay_pub" ) ) ) {
+  } else if( FD_UNLIKELY( !strcmp( obj->name, "runtime_pub" ) ) ) {
     return fd_runtime_public_footprint();
   } else if( FD_UNLIKELY( !strcmp( obj->name, "blockstore" ) ) ) {
     return fd_blockstore_footprint( VAL("shred_max"), VAL("block_max"), VAL("idx_max"), VAL("txn_max") ) + VAL("alloc_max");
   } else if( FD_UNLIKELY( !strcmp( obj->name, "txncache" ) ) ) {
     return fd_txncache_footprint( VAL("max_rooted_slots"), VAL("max_live_slots"), VAL("max_txn_per_slot"), FD_TXNCACHE_DEFAULT_MAX_CONSTIPATED_SLOTS );
+  } else if( FD_UNLIKELY( !strcmp( obj->name, "exec_spad" ) ) ) {
+    return fd_spad_footprint( FD_RUNTIME_TRANSACTION_EXECUTION_FOOTPRINT_DEFAULT );
 #endif /* FD_HAS_NO_AGAVE */
   } else {
     FD_LOG_ERR(( "unknown object `%s`", obj->name ));

--- a/src/app/fdctl/topos/fd_firedancer.c
+++ b/src/app/fdctl/topos/fd_firedancer.c
@@ -11,6 +11,7 @@
 #include "../../../disco/topo/fd_pod_format.h"
 #include "../../../flamenco/runtime/fd_blockstore.h"
 #include "../../../flamenco/runtime/fd_runtime.h"
+#include "../../../flamenco/runtime/fd_runtime_public.h"
 #include "../../../flamenco/runtime/fd_txncache.h"
 #include "../../../util/tile/fd_tile_private.h"
 
@@ -49,12 +50,12 @@ setup_topo_blockstore( fd_topo_t *  topo,
 }
 
 fd_topo_obj_t *
-setup_topo_replay_pub( fd_topo_t *  topo, char const * wksp_name ) {
-  fd_topo_obj_t * obj = fd_topob_obj( topo, "replay_pub", wksp_name );
+setup_topo_runtime_pub( fd_topo_t *  topo, char const * wksp_name ) {
+  fd_topo_obj_t * obj = fd_topob_obj( topo, "runtime_pub", wksp_name );
 
   FD_TEST( fd_pod_insertf_ulong( topo->props, 12UL,        "obj.%lu.wksp_tag",   obj->id ) );
 
-  ulong footprint = fd_runtime_public_footprint( );
+  ulong footprint = fd_runtime_public_footprint();
   FD_TEST( fd_pod_insertf_ulong( topo->props, footprint,  "obj.%lu.loose", obj->id ) );
 
   return obj;
@@ -185,8 +186,8 @@ fd_topo_initialize( config_t * config ) {
 
   fd_topob_wksp( topo, "replay_exec"  );
 
-  fd_topob_wksp( topo, "voter_sign" );
-  fd_topob_wksp( topo, "sign_voter" );
+  fd_topob_wksp( topo, "voter_sign"   );
+  fd_topob_wksp( topo, "sign_voter"   );
 
   fd_topob_wksp( topo, "crds_shred"   );
   fd_topob_wksp( topo, "gossip_repai" );
@@ -196,8 +197,8 @@ fd_topo_initialize( config_t * config ) {
   fd_topob_wksp( topo, "store_repair" );
   fd_topob_wksp( topo, "repair_store" );
 
-  fd_topob_wksp( topo, "repair_sign" );
-  fd_topob_wksp( topo, "sign_repair" );
+  fd_topob_wksp( topo, "repair_sign"  );
+  fd_topob_wksp( topo, "sign_repair"  );
 
   fd_topob_wksp( topo, "store_replay" );
   fd_topob_wksp( topo, "repair_repla" );
@@ -217,31 +218,33 @@ fd_topo_initialize( config_t * config ) {
   fd_topob_wksp( topo, "rstart_store" );
   fd_topob_wksp( topo, "store_rstart" );
 
-  fd_topob_wksp( topo, "quic"       );
-  fd_topob_wksp( topo, "verify"     );
-  fd_topob_wksp( topo, "dedup"      );
-  fd_topob_wksp( topo, "shred"      );
-  fd_topob_wksp( topo, "pack"       );
-  fd_topob_wksp( topo, "storei"     );
-  fd_topob_wksp( topo, "sign"       );
-  fd_topob_wksp( topo, "repair"     );
-  fd_topob_wksp( topo, "gossip"     );
-  fd_topob_wksp( topo, "metric"     );
-  fd_topob_wksp( topo, "replay"     );
-  fd_topob_wksp( topo, "replay_pub" );
-  fd_topob_wksp( topo, "exec"       );
-  fd_topob_wksp( topo, "rtpool"     );
-  fd_topob_wksp( topo, "bhole"      );
-  fd_topob_wksp( topo, "bstore"     );
-  fd_topob_wksp( topo, "tcache"     );
-  fd_topob_wksp( topo, "pohi"       );
-  fd_topob_wksp( topo, "voter"      );
-  fd_topob_wksp( topo, "poh_slot"   );
-  fd_topob_wksp( topo, "eqvoc"      );
-  fd_topob_wksp( topo, "batch"      );
-  fd_topob_wksp( topo, "btpool"     );
-  fd_topob_wksp( topo, "constipate" );
-  fd_topob_wksp( topo, "restart"    );
+  fd_topob_wksp( topo, "quic"        );
+  fd_topob_wksp( topo, "verify"      );
+  fd_topob_wksp( topo, "dedup"       );
+  fd_topob_wksp( topo, "shred"       );
+  fd_topob_wksp( topo, "pack"        );
+  fd_topob_wksp( topo, "storei"      );
+  fd_topob_wksp( topo, "sign"        );
+  fd_topob_wksp( topo, "repair"      );
+  fd_topob_wksp( topo, "gossip"      );
+  fd_topob_wksp( topo, "metric"      );
+  fd_topob_wksp( topo, "replay"      );
+  fd_topob_wksp( topo, "runtime_pub" );
+  fd_topob_wksp( topo, "exec"        );
+  fd_topob_wksp( topo, "rtpool"      );
+  fd_topob_wksp( topo, "bhole"       );
+  fd_topob_wksp( topo, "bstore"      );
+  fd_topob_wksp( topo, "tcache"      );
+  fd_topob_wksp( topo, "pohi"        );
+  fd_topob_wksp( topo, "voter"       );
+  fd_topob_wksp( topo, "poh_slot"    );
+  fd_topob_wksp( topo, "eqvoc"       );
+  fd_topob_wksp( topo, "batch"       );
+  fd_topob_wksp( topo, "btpool"      );
+  fd_topob_wksp( topo, "constipate"  );
+  fd_topob_wksp( topo, "restart"     );
+  fd_topob_wksp( topo, "exec_spad"   );
+  fd_topob_wksp( topo, "exec_fseq"   );
 
   if( enable_rpc ) fd_topob_wksp( topo, "rpcsrv" );
 
@@ -264,7 +267,7 @@ fd_topo_initialize( config_t * config ) {
 
   /**/                 fd_topob_link( topo, "gossip_sign",  "gossip_sign",  128UL,                                    2048UL,                        1UL );
   /**/                 fd_topob_link( topo, "sign_gossip",  "sign_gossip",  128UL,                                    64UL,                          1UL );
-  FOR(exec_tile_cnt)   fd_topob_link( topo, "replay_exec",  "replay_exec",   128UL,                                   sizeof(fd_txn_p_t),            FD_TXN_MAX_PER_SLOT );
+  FOR(exec_tile_cnt)   fd_topob_link( topo, "replay_exec",  "replay_exec",   128UL,                                   10240UL,                       1UL );
 
   /**/                 fd_topob_link( topo, "gossip_verif", "gossip_verif", config->tiles.verify.receive_buffer_size, FD_TPU_MTU,                    1UL );
   /**/                 fd_topob_link( topo, "gossip_eqvoc", "gossip_eqvoc", 128UL,                                    FD_TPU_MTU,                    1UL );
@@ -370,8 +373,9 @@ fd_topo_initialize( config_t * config ) {
   fd_topo_tile_t * store_tile  = &topo->tiles[ fd_topo_find_tile( topo, "storei", 0UL ) ];
   fd_topo_tile_t * replay_tile = &topo->tiles[ fd_topo_find_tile( topo, "replay", 0UL ) ];
   fd_topo_tile_t * repair_tile = &topo->tiles[ fd_topo_find_tile( topo, "repair", 0UL ) ];
-  fd_topo_tile_t * snaps_tile  = &topo->tiles[ fd_topo_find_tile( topo, "batch",  0UL ) ];
-  fd_topo_tile_t * pack_tile   = &topo->tiles[ fd_topo_find_tile( topo, "pack", 0UL ) ];
+  fd_topo_tile_t * batch_tile  = &topo->tiles[ fd_topo_find_tile( topo, "batch" , 0UL ) ];
+  fd_topo_tile_t * pack_tile   = &topo->tiles[ fd_topo_find_tile( topo, "pack"  , 0UL ) ];
+  fd_topo_tile_t * exec_tile   = &topo->tiles[ fd_topo_find_tile( topo, "exec"  , 0UL ) ];
 
   /* Create a shared blockstore to be used by store and replay. */
   fd_topo_obj_t * blockstore_obj = setup_topo_blockstore( topo,
@@ -391,16 +395,17 @@ fd_topo_initialize( config_t * config ) {
 
   FD_TEST( fd_pod_insertf_ulong( topo->props, blockstore_obj->id, "blockstore" ) );
 
-  fd_topo_obj_t *  replay_pub_obj = setup_topo_replay_pub( topo, "replay_pub" );
-  fd_topob_tile_uses( topo, replay_tile, replay_pub_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
-  fd_topob_tile_uses( topo, snaps_tile,  replay_pub_obj, FD_SHMEM_JOIN_MODE_READ_ONLY );
-  fd_topob_tile_uses( topo, pack_tile,  replay_pub_obj, FD_SHMEM_JOIN_MODE_READ_ONLY );
-  FD_TEST( fd_pod_insertf_ulong( topo->props, replay_pub_obj->id, "replay_pub" ) );
+  fd_topo_obj_t * runtime_pub_obj = setup_topo_runtime_pub( topo, "runtime_pub" );
+  fd_topob_tile_uses( topo, replay_tile, runtime_pub_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+  fd_topob_tile_uses( topo, batch_tile,  runtime_pub_obj, FD_SHMEM_JOIN_MODE_READ_ONLY );
+  fd_topob_tile_uses( topo, pack_tile,  runtime_pub_obj, FD_SHMEM_JOIN_MODE_READ_ONLY );
+  fd_topob_tile_uses( topo, exec_tile,  runtime_pub_obj, FD_SHMEM_JOIN_MODE_READ_ONLY );
+  FD_TEST( fd_pod_insertf_ulong( topo->props, runtime_pub_obj->id, "runtime_pub" ) );
 
   /* Create a txncache to be used by replay. */
   fd_topo_obj_t * txncache_obj = setup_topo_txncache( topo, "tcache", FD_TXNCACHE_DEFAULT_MAX_ROOTED_SLOTS, FD_TXNCACHE_DEFAULT_MAX_LIVE_SLOTS, MAX_CACHE_TXNS_PER_SLOT );
   fd_topob_tile_uses( topo, replay_tile, txncache_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
-  fd_topob_tile_uses( topo, snaps_tile, txncache_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+  fd_topob_tile_uses( topo, batch_tile, txncache_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
 
   FD_TEST( fd_pod_insertf_ulong( topo->props, txncache_obj->id, "txncache" ) );
 
@@ -411,6 +416,21 @@ fd_topo_initialize( config_t * config ) {
     fd_topob_tile_uses( topo, pack_tile, busy_obj, FD_SHMEM_JOIN_MODE_READ_ONLY );
     FD_TEST( fd_pod_insertf_ulong( topo->props, busy_obj->id, "bank_busy.%lu", i ) );
   }
+
+  for( ulong i=0UL; i<exec_tile_cnt; i++ ) {
+    fd_topo_obj_t * exec_spad_obj = fd_topob_obj( topo, "exec_spad", "exec_spad" );
+    fd_topob_tile_uses( topo, replay_tile, exec_spad_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+    fd_topob_tile_uses( topo, exec_tile, exec_spad_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+    FD_TEST( fd_pod_insertf_ulong( topo->props, exec_spad_obj->id, "exec_spad.%lu", i ) );
+  }
+
+  for( ulong i=0UL; i<exec_tile_cnt; i++ ) {
+    fd_topo_obj_t * exec_spad_obj = fd_topob_obj( topo, "fseq", "exec_fseq" );
+    fd_topob_tile_uses( topo, replay_tile, exec_spad_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+    fd_topob_tile_uses( topo, exec_tile, exec_spad_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+    FD_TEST( fd_pod_insertf_ulong( topo->props, exec_spad_obj->id, "exec_fseq.%lu", i ) );
+  }
+
   /* There's another special fseq that's used to communicate the shred
      version from the Agave boot path to the shred tile. */
   fd_topo_obj_t * poh_shred_obj = fd_topob_obj( topo, "fseq", "poh_shred" );
@@ -440,7 +460,7 @@ fd_topo_initialize( config_t * config ) {
 
   fd_topo_obj_t * constipated_obj = fd_topob_obj( topo, "fseq", "constipate" );
   fd_topob_tile_uses( topo, replay_tile, constipated_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
-  fd_topob_tile_uses( topo, snaps_tile,  constipated_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+  fd_topob_tile_uses( topo, batch_tile,  constipated_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   FD_TEST( fd_pod_insertf_ulong( topo->props, constipated_obj->id, "constipate" ) );
 
   if( FD_LIKELY( !is_auto_affinity ) ) {
@@ -537,7 +557,8 @@ fd_topo_initialize( config_t * config ) {
   FOR(exec_tile_cnt)   fd_topob_tile_out( topo, "replay",  0UL,                       "replay_exec",   i                                                  ); /* TODO check order in fd_replay.c macros*/
   FOR(shred_tile_cnt)  fd_topob_tile_in(  topo, "replay",  0UL,          "metric_in", "shred_replay",  i,            FD_TOPOB_RELIABLE,     FD_TOPOB_POLLED );
 
-  FOR(exec_tile_cnt)   fd_topob_tile_in(  topo, "exec",    i,             "metric_in", "replay_exec",  i,            FD_TOPOB_RELIABLE, FD_TOPOB_POLLED     );
+
+  FOR(exec_tile_cnt)   fd_topob_tile_in(  topo, "exec",  i,             "metric_in", "replay_exec",  i,            FD_TOPOB_RELIABLE, FD_TOPOB_POLLED     );
 
   /**/                 fd_topob_tile_in(  topo, "sender",  0UL,          "metric_in",  "stake_out",    0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED   ); /* No reliable consumers of networking fragments, may be dropped or overrun */
   /**/                 fd_topob_tile_in(  topo, "sender",  0UL,          "metric_in",  "gossip_voter", 0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED   ); /* No reliable consumers of networking fragments, may be dropped or overrun */
@@ -801,7 +822,7 @@ fd_topo_initialize( config_t * config ) {
     } else if( FD_UNLIKELY( !strcmp( tile->name, "plugin" ) ) ) {
 
     } else if( FD_UNLIKELY( !strcmp( tile->name, "exec" ) ) ) {
-
+      strncpy( tile->exec.funk_file, config->tiles.replay.funk_file, sizeof(tile->exec.funk_file) );
     } else if( FD_UNLIKELY( !strcmp( tile->name, "rstart" ) ) ) {
       tile->restart.in_wen_restart = config->tiles.restart.in_wen_restart;
       strncpy( tile->restart.funk_file, config->tiles.replay.funk_file, sizeof(tile->replay.funk_file) );

--- a/src/app/shared/commands/run/run.c
+++ b/src/app/shared/commands/run/run.c
@@ -21,6 +21,7 @@
 #include "../../../../flamenco/runtime/fd_blockstore.h"
 #include "../../../../flamenco/runtime/fd_txncache.h"
 #include "../../../../flamenco/runtime/fd_runtime.h"
+#include "../../../../flamenco/runtime/fd_runtime_public.h"
 #endif
 #include "../../../../funk/fd_funk.h"
 #include "../../../../waltz/ip/fd_fib4.h"
@@ -582,12 +583,14 @@ fdctl_obj_new( fd_topo_t const *     topo,
   } else if( FD_UNLIKELY( !strcmp( obj->name, "keyswitch" ) ) ) {
     FD_TEST( fd_keyswitch_new( laddr, FD_KEYSWITCH_STATE_UNLOCKED ) );
 #if FD_HAS_NO_AGAVE
-  } else if( FD_UNLIKELY( !strcmp( obj->name, "replay_pub" ) ) ) {
+  } else if( FD_UNLIKELY( !strcmp( obj->name, "runtime_pub" ) ) ) {
     FD_TEST( fd_runtime_public_new( laddr ) );
   } else if( FD_UNLIKELY( !strcmp( obj->name, "blockstore" ) ) ) {
     FD_TEST( fd_blockstore_new( laddr, VAL("wksp_tag"), VAL("seed"), VAL("shred_max"), VAL("block_max"), VAL("idx_max"), VAL("txn_max") ) );
   } else if( FD_UNLIKELY( !strcmp( obj->name, "txncache" ) ) ) {
     FD_TEST( fd_txncache_new( laddr, VAL("max_rooted_slots"), VAL("max_live_slots"), VAL("max_txn_per_slot"), FD_TXNCACHE_DEFAULT_MAX_CONSTIPATED_SLOTS ) );
+  } else if( FD_UNLIKELY( !strcmp( obj->name, "exec_spad" ) ) ) {
+    FD_TEST( fd_spad_new( laddr, FD_RUNTIME_TRANSACTION_EXECUTION_FOOTPRINT_DEFAULT ) );
 #endif /* FD_HAS_NO_AGAVE */
   } else {
     FD_LOG_ERR(( "unknown object `%s`", obj->name ));

--- a/src/choreo/forks/fd_forks.h
+++ b/src/choreo/forks/fd_forks.h
@@ -26,7 +26,7 @@ struct fd_fork {
                  consensus, publishing) and should definitely not be
                  removed. */
   uint  end_idx; /* the end_idx of the last batch executed on this fork */
-  fd_exec_slot_ctx_t slot_ctx;
+  fd_exec_slot_ctx_t * slot_ctx;
 };
 
 typedef struct fd_fork fd_fork_t;
@@ -126,15 +126,15 @@ fd_forks_delete( void * forks );
    and no one else is joined, and non-NULL slot_ctx.  Inserts the first
    fork into the frontier containing slot_ctx.  This should be the
    slot_ctx from loading a snapshot, restoring a bank from Funk, or the
-   genesis slot_ctx.  The slot_ctx will be copied into an element
-   acquired from the memory pool owned by forks.  Returns fork on
-   success, NULL on failure.
+   genesis slot_ctx.  The slot_ctx is assumed to be in the same address
+   space as the forks data structure and that a valid local join exists.
+   Returns fork on success, NULL on failure.
 
    In general, this should be called by the same process that formatted
    forks' memory, ie. the caller of fd_forks_new. */
 
 fd_fork_t *
-fd_forks_init( fd_forks_t * forks, fd_exec_slot_ctx_t const * slot_ctx );
+fd_forks_init( fd_forks_t * forks, fd_exec_slot_ctx_t * slot_ctx );
 
 /* fd_forks_query queries for the fork corresponding to slot in the
    frontier.  Returns the fork if found, otherwise NULL. */

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -307,7 +307,7 @@ typedef struct {
     } restart;
 
     struct {
-      ulong dummy;
+      char funk_file[ PATH_MAX ];
     } exec;
 
     struct {

--- a/src/discof/exec/fd_exec_tile.c
+++ b/src/discof/exec/fd_exec_tile.c
@@ -1,18 +1,65 @@
+#include <stdlib.h>
 #define _GNU_SOURCE
-
 #include "../../disco/tiles.h"
 #include "generated/fd_exec_tile_seccomp.h"
 
+#include "../../disco/topo/fd_pod_format.h"
+
+#include "../../flamenco/runtime/fd_runtime.h"
+#include "../../flamenco/runtime/fd_runtime_public.h"
+#include "../../flamenco/runtime/fd_executor.h"
+#include "../../flamenco/runtime/fd_hashes.h"
+
+#include "../../funk/fd_funk.h"
+#include "../../funk/fd_funk_filemap.h"
+
 struct fd_exec_tile_ctx {
-  ulong  replay_exec_in_idx;
-  ulong  tile_cnt;
-  ulong  tile_idx;
 
-  fd_wksp_t * replay_in_mem;
-  ulong       replay_in_chunk0;
-  ulong       replay_in_wmark;
+  /* link-related data structures. */
+  ulong                 replay_exec_in_idx;
+  ulong                 tile_cnt;
+  ulong                 tile_idx;
 
-  fd_txn_p_t txn; /* current txn */
+  fd_wksp_t *           replay_in_mem;
+  ulong                 replay_in_chunk0;
+  ulong                 replay_in_wmark;
+
+  /* Runtime public and local joins of its members. */
+  fd_wksp_t *           runtime_public_wksp;
+  fd_runtime_public_t * runtime_public;
+  fd_spad_t const *     runtime_spad;
+
+  /* Management around exec spad and frame lifetimes. We will always
+     have 1 frame pushed onto the spad. This frame will contain the
+     txn_ctx. Any allocations made for the scope of an epoch boundary
+     will live in the next spad frame. Then, all allocations made for
+     the scope of the slot ctx will live in the next spad frame.
+     Finally, any state used for actually executing the transaction
+     will use the remaining frames. The pending_{n}_pop variables are
+     used to manage lifetimes we recieve slot/epoch updates. */
+  fd_spad_t *           exec_spad;
+  fd_wksp_t *           exec_spad_wksp;
+  int                   pending_txn_pop;
+  int                   pending_slot_pop;
+  int                   pending_epoch_pop;
+
+  /* Funk-specific setup.  */
+  fd_funk_t *           funk;
+  fd_wksp_t *           funk_wksp;
+
+  /* Data structures related to managing and executing the transaction.
+     The fd_txn_p_t is refreshed with every transaction and is sent
+     from the dispatch/replay tile. The fd_exec_txn_ctx_t * is a valid
+     local join that lives in the top-most frame of the spad that is
+     setup when the exec tile is booted; its members are refreshed on
+     the slot/epoch boundary. */
+  fd_txn_p_t            txn;
+  fd_exec_txn_ctx_t *   txn_ctx;
+  int                   exec_res;
+  uint                  flags;
+
+  ulong *               exec_fseq;
+
 };
 typedef struct fd_exec_tile_ctx fd_exec_tile_ctx_t;
 
@@ -25,9 +72,198 @@ FD_FN_PURE static inline ulong
 scratch_footprint( fd_topo_tile_t const * tile FD_PARAM_UNUSED ) {
   /* clang-format off */
   ulong l = FD_LAYOUT_INIT;
-  l       = FD_LAYOUT_APPEND( l, alignof(fd_exec_tile_ctx_t), sizeof(fd_exec_tile_ctx_t) );
+  l       = FD_LAYOUT_APPEND( l, alignof(fd_exec_tile_ctx_t),  sizeof(fd_exec_tile_ctx_t) );
   return FD_LAYOUT_FINI( l, scratch_align() );
   /* clang-format on */
+}
+
+static void
+prepare_new_epoch_execution( fd_exec_tile_ctx_t *            ctx,
+                             fd_runtime_public_epoch_msg_t * epoch_msg ) {
+
+  /* If we need to refresh epoch-level information, we need to pop off
+     the transaction-level, slot-level, and epoch-level frames. */
+  if( FD_LIKELY( ctx->pending_txn_pop ) ) {
+    fd_spad_pop( ctx->exec_spad );
+    ctx->pending_txn_pop = 0;
+  }
+  if( FD_LIKELY( ctx->pending_slot_pop ) ) {
+    fd_spad_pop( ctx->exec_spad );
+    ctx->pending_slot_pop = 0;
+  }
+  if( FD_LIKELY( ctx->pending_epoch_pop ) ) {
+    fd_spad_pop( ctx->exec_spad );
+    ctx->pending_epoch_pop = 0;
+  }
+  fd_spad_push( ctx->exec_spad );
+  ctx->pending_epoch_pop = 1;
+
+  ctx->txn_ctx->features          = epoch_msg->features;
+  ctx->txn_ctx->total_epoch_stake = epoch_msg->total_epoch_stake;
+  ctx->txn_ctx->schedule          = epoch_msg->epoch_schedule;
+  ctx->txn_ctx->rent              = epoch_msg->rent;
+  ctx->txn_ctx->slots_per_year    = epoch_msg->slots_per_year;
+
+  uchar * stakes_enc = fd_wksp_laddr( ctx->runtime_public_wksp, epoch_msg->stakes_encoded_gaddr );
+  if( FD_UNLIKELY( !stakes_enc ) ) {
+    FD_LOG_ERR(( "Could not get laddr for encoded stakes" ));
+  }
+
+  fd_bincode_decode_ctx_t decode = {
+    .data    = stakes_enc,
+    .dataend = stakes_enc + epoch_msg->stakes_encoded_sz
+  };
+  ulong total_sz = 0UL;
+  int   err      = fd_stakes_decode_footprint( &decode, &total_sz );
+  if( FD_UNLIKELY( err ) ) {
+    FD_LOG_ERR(( "Could not decode stakes footprint" ));
+  }
+
+  uchar *       stakes_mem = fd_spad_alloc( ctx->exec_spad, fd_stakes_align(), total_sz );
+  fd_stakes_t * stakes     = fd_stakes_decode( stakes_mem, &decode );
+  if( FD_UNLIKELY( !stakes ) ) {
+    FD_LOG_ERR(( "Could not decode stakes" ));
+  }
+  ctx->txn_ctx->stakes = *stakes;
+}
+
+static void
+prepare_new_slot_execution( fd_exec_tile_ctx_t *           ctx,
+                            fd_runtime_public_slot_msg_t * slot_msg ) {
+
+  /* If we need to refresh slot-level information, we need to pop off
+     the transaction-level and slot-level frame. */
+  if( FD_LIKELY( ctx->pending_txn_pop ) ) {
+    fd_spad_pop( ctx->exec_spad );
+    ctx->pending_txn_pop = 0;
+  }
+  if( FD_LIKELY( ctx->pending_slot_pop ) ) {
+    fd_spad_pop( ctx->exec_spad );
+    ctx->pending_slot_pop = 0;
+  }
+  fd_spad_push( ctx->exec_spad );
+  ctx->pending_slot_pop = 1;
+
+  fd_funk_txn_t * txn_map = fd_funk_txn_map( ctx->funk, ctx->funk_wksp );
+  if( FD_UNLIKELY( !txn_map ) ) {
+    FD_LOG_ERR(( "Could not find valid funk transaction map" ));
+  }
+  fd_funk_txn_xid_t xid = { .ul = { slot_msg->slot, slot_msg->slot } };
+  fd_funk_txn_t * funk_txn = fd_funk_txn_query( &xid, txn_map );
+  if( FD_UNLIKELY( !funk_txn ) ) {
+    FD_LOG_ERR(( "Could not find valid funk transaction" ));
+  }
+  ctx->txn_ctx->funk_txn = funk_txn;
+
+  ctx->txn_ctx->slot                        = slot_msg->slot;
+  ctx->txn_ctx->prev_lamports_per_signature = slot_msg->prev_lamports_per_signature;
+  ctx->txn_ctx->fee_rate_governor           = slot_msg->fee_rate_governor;
+
+  ctx->txn_ctx->sysvar_cache = fd_wksp_laddr( ctx->runtime_public_wksp, slot_msg->sysvar_cache_gaddr );
+  if( FD_UNLIKELY( !ctx->txn_ctx->sysvar_cache ) ) {
+    FD_LOG_ERR(( "Could not find valid sysvar cache" ));
+  }
+
+  uchar * block_hash_queue_enc = fd_wksp_laddr( ctx->runtime_public_wksp, slot_msg->block_hash_queue_encoded_gaddr );
+  fd_bincode_decode_ctx_t decode = {
+    .data    = block_hash_queue_enc,
+    .dataend = block_hash_queue_enc + slot_msg->block_hash_queue_encoded_sz
+  };
+
+  ulong total_sz = 0UL;
+  int   err      = fd_block_hash_queue_decode_footprint( &decode, &total_sz );
+  if( FD_UNLIKELY( err ) ) {
+    FD_LOG_ERR(( "Could not decode block hash queue footprint" ));
+  }
+
+  uchar * block_hash_queue_mem = fd_spad_alloc( ctx->exec_spad, fd_block_hash_queue_align(), total_sz );
+  fd_block_hash_queue_t * block_hash_queue = fd_block_hash_queue_decode( block_hash_queue_mem, &decode );
+  if( FD_UNLIKELY( !block_hash_queue ) ) {
+    FD_LOG_ERR(( "Could not decode block hash queue" ));
+  }
+
+  ctx->txn_ctx->block_hash_queue = *block_hash_queue;
+}
+
+static void
+execute_txn( fd_exec_tile_ctx_t * ctx ) {
+  if( FD_LIKELY( ctx->pending_txn_pop ) ) {
+    fd_spad_pop( ctx->exec_spad );
+    ctx->pending_txn_pop = 0;
+  }
+  fd_spad_push( ctx->exec_spad );
+  ctx->pending_txn_pop = 1;
+
+  fd_execute_txn_task_info_t task_info = {
+    .txn_ctx  = ctx->txn_ctx,
+    .exec_res = 0,
+    .txn      = &ctx->txn,
+  };
+
+  fd_txn_t const * txn_descriptor = (fd_txn_t const *)task_info.txn->_;
+  fd_rawtxn_b_t    raw_txn        = {
+    .raw    = task_info.txn->payload,
+    .txn_sz = (ushort)task_info.txn->payload_sz
+  };
+
+  fd_exec_txn_ctx_setup( ctx->txn_ctx, txn_descriptor, &raw_txn );
+
+  int err = fd_executor_setup_accessed_accounts_for_txn( ctx->txn_ctx );
+  if( FD_UNLIKELY( err ) ) {
+    task_info.txn->flags = 0U;
+    task_info.exec_res   = err;
+    ctx->flags = 0U;
+    return;
+  }
+
+  if( FD_UNLIKELY( fd_executor_txn_verify( ctx->txn_ctx )!=0 ) ) {
+    FD_LOG_WARNING(( "sigverify failed: %s", FD_BASE58_ENC_64_ALLOCA( (uchar *)ctx->txn_ctx->_txn_raw->raw+ctx->txn_ctx->txn_descriptor->signature_off ) ));
+    task_info.txn->flags = 0U;
+    task_info.exec_res   = FD_RUNTIME_TXN_ERR_SIGNATURE_FAILURE;
+    ctx->flags = 0U;
+    return;
+  }
+
+  task_info.txn->flags |= FD_TXN_P_FLAGS_SANITIZE_SUCCESS;
+
+  fd_runtime_pre_execute_check( &task_info, 0 );
+  if( FD_UNLIKELY( !( task_info.txn->flags & FD_TXN_P_FLAGS_SANITIZE_SUCCESS ) ) ) {
+    ctx->flags = 0U;
+    return;
+  }
+
+  /* Execute */
+  task_info.txn->flags |= FD_TXN_P_FLAGS_EXECUTE_SUCCESS;
+  ctx->exec_res         = fd_execute_txn( &task_info );
+  ctx->flags            = FD_TXN_P_FLAGS_EXECUTE_SUCCESS;
+
+  if( FD_LIKELY( ctx->exec_res==FD_EXECUTOR_INSTR_SUCCESS ) ) {
+    fd_txn_reclaim_accounts( task_info.txn_ctx );
+  }
+}
+
+static void
+hash_accounts( fd_exec_tile_ctx_t *                ctx,
+               fd_runtime_public_hash_bank_msg_t * msg ) {
+
+  ulong             start_idx = msg->start_idx;
+  ulong             end_idx   = msg->end_idx;
+  fd_lthash_value_t lt_hash;
+  fd_lthash_zero( &lt_hash );
+
+  fd_accounts_hash_task_info_t * task_info = fd_wksp_laddr( ctx->runtime_public_wksp, msg->task_infos_gaddr );
+  if( FD_UNLIKELY( !task_info ) ) {
+    FD_LOG_ERR(( "Unable to join task info array" ));
+  }
+
+  for( ulong i=start_idx; i<=end_idx; i++ ) {
+    fd_account_hash( ctx->txn_ctx->acc_mgr,
+                     ctx->txn_ctx->funk_txn,
+                     &task_info[i],
+                     &lt_hash,
+                     ctx->txn_ctx->slot,
+                     &ctx->txn_ctx->features );
+  }
 }
 
 static void
@@ -47,27 +283,64 @@ during_frag( fd_exec_tile_ctx_t * ctx,
                     ctx->replay_in_chunk0,
                     ctx->replay_in_wmark ));
     }
-    uchar * txn = fd_chunk_to_laddr( ctx->replay_in_mem, chunk );
-    fd_memcpy( &ctx->txn, txn, sz );
-    FD_LOG_HEXDUMP_DEBUG(( "exec tile received txn: ", txn, sz ));
+
+    if( FD_LIKELY( sig==EXEC_NEW_TXN_SIG ) ) {
+      fd_runtime_public_txn_msg_t * txn = (fd_runtime_public_txn_msg_t *)fd_chunk_to_laddr( ctx->replay_in_mem, chunk );
+      fd_memcpy( &ctx->txn, &txn->txn, sizeof(fd_txn_p_t) );
+      execute_txn( ctx );
+      return;
+    } else if( sig==EXEC_NEW_SLOT_SIG ) {
+      fd_runtime_public_slot_msg_t * msg = fd_chunk_to_laddr( ctx->replay_in_mem, chunk );
+      FD_LOG_NOTICE(( "new slot=%lu msg recvd", msg->slot ));
+      prepare_new_slot_execution( ctx, msg );
+      return;
+    } else if( sig==EXEC_NEW_EPOCH_SIG ) {
+      fd_runtime_public_epoch_msg_t * msg = fd_chunk_to_laddr( ctx->replay_in_mem, chunk );
+      FD_LOG_NOTICE(( "new epoch=%lu msg recvd", msg->epoch_schedule.slots_per_epoch ));
+      prepare_new_epoch_execution( ctx, msg );
+      return;
+    } else if( sig==EXEC_HASH_ACCS_SIG ) {
+      fd_runtime_public_hash_bank_msg_t * msg = fd_chunk_to_laddr( ctx->replay_in_mem, chunk );
+      FD_LOG_NOTICE(( "hash accs=%lu msg recvd", msg->end_idx - msg->start_idx ));
+      hash_accounts( ctx, msg );
+      return;
+    } else {
+      FD_LOG_ERR(( "Unknown signature" ));
+    }
+
   }
 }
 
 static void
-after_frag( fd_exec_tile_ctx_t * ctx FD_PARAM_UNUSED,
+after_frag( fd_exec_tile_ctx_t * ctx    FD_PARAM_UNUSED,
             ulong                in_idx FD_PARAM_UNUSED,
-            ulong                seq,
+            ulong                seq    FD_PARAM_UNUSED,
             ulong                sig,
-            ulong                sz,
-            ulong                tsorig,
-            ulong                tspub,
-            fd_stem_context_t *  stem ) {
-  (void)seq;
-  (void)sig;
-  (void)sz;
-  (void)tsorig;
-  (void)tspub;
-  (void)stem;
+            ulong                sz     FD_PARAM_UNUSED,
+            ulong                tsorig FD_PARAM_UNUSED,
+            ulong                tspub  FD_PARAM_UNUSED,
+            fd_stem_context_t *  stem   FD_PARAM_UNUSED ) {
+
+  if( sig==EXEC_NEW_SLOT_SIG ) {
+    FD_LOG_DEBUG(( "Sending ack for new slot msg" ));
+    fd_fseq_update( ctx->exec_fseq, fd_exec_fseq_set_slot_done() );
+  } else if( sig==EXEC_NEW_EPOCH_SIG ) {
+    FD_LOG_DEBUG(( "Sending ack for new epoch msg" ));
+    fd_fseq_update( ctx->exec_fseq, fd_exec_fseq_set_epoch_done() );
+
+  } else if( sig==EXEC_NEW_TXN_SIG ) {
+    FD_LOG_DEBUG(( "Sending ack for new txn msg" ));
+    /* At this point we can assume that the transaction is done
+       executing. The replay tile will be repsonsible for commiting
+       the transaction back to funk. */
+    ctx->txn_ctx->exec_err = ctx->exec_res;
+    ctx->txn_ctx->flags    = ctx->flags;
+    fd_fseq_update( ctx->exec_fseq, fd_exec_fseq_set_txn_done() );
+  } else if( sig==EXEC_HASH_ACCS_SIG ) {
+    FD_LOG_NOTICE(( "Sending ack for hash accs msg" ));
+  } else {
+    FD_LOG_ERR(( "Unknown message signature" ));
+  }
 }
 
 static void
@@ -78,24 +351,175 @@ privileged_init( fd_topo_t *      topo FD_PARAM_UNUSED,
 static void
 unprivileged_init( fd_topo_t *      topo,
                    fd_topo_tile_t * tile ) {
+
+  /********************************************************************/
+  /* validate allocations                                             */
+  /********************************************************************/
+
   void * scratch = fd_topo_obj_laddr( topo, tile->tile_obj_id );
 
   FD_SCRATCH_ALLOC_INIT( l, scratch );
   fd_exec_tile_ctx_t * ctx = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_exec_tile_ctx_t), sizeof(fd_exec_tile_ctx_t) );
+  ulong scratch_alloc_mem = FD_SCRATCH_ALLOC_FINI( l, scratch_align() );
+  if( FD_UNLIKELY( scratch_alloc_mem - (ulong)scratch  - scratch_footprint( tile ) ) ) {
+    FD_LOG_ERR( ( "Scratch_alloc_mem did not match scratch_footprint diff: %lu alloc: %lu footprint: %lu",
+      scratch_alloc_mem - (ulong)scratch - scratch_footprint( tile ),
+      scratch_alloc_mem,
+      (ulong)scratch + scratch_footprint( tile ) ) );
+  }
+
+  /********************************************************************/
+  /* validate links                                                   */
+  /********************************************************************/
 
   ctx->tile_cnt = fd_topo_tile_name_cnt( topo, tile->name );
   ctx->tile_idx = tile->kind_id;
 
+
+  /* First find and setup the in-link from replay to exec. */
   ctx->replay_exec_in_idx = fd_topo_find_tile_in_link( topo, tile, "replay_exec", ctx->tile_idx );
-  FD_TEST( ctx->replay_exec_in_idx != ULONG_MAX );
+  if( FD_UNLIKELY( ctx->replay_exec_in_idx==ULONG_MAX ) ) {
+    FD_LOG_ERR(( "Could not find replay_exec in-link" ));
+  }
   fd_topo_link_t * replay_exec_in_link = &topo->links[tile->in_link_id[ctx->replay_exec_in_idx]];
-  ctx->replay_in_mem = topo->workspaces[topo->objs[replay_exec_in_link->dcache_obj_id].wksp_id].wksp;
+  if( FD_UNLIKELY( !replay_exec_in_link) ) {
+    FD_LOG_ERR(( "Invalid replay_exec in-link" ));
+  }
+  ctx->replay_in_mem    = topo->workspaces[topo->objs[replay_exec_in_link->dcache_obj_id].wksp_id].wksp;
   ctx->replay_in_chunk0 = fd_dcache_compact_chunk0( ctx->replay_in_mem, replay_exec_in_link->dcache );
   ctx->replay_in_wmark  = fd_dcache_compact_wmark( ctx->replay_in_mem,
                                                    replay_exec_in_link->dcache,
                                                    replay_exec_in_link->mtu );
 
-  FD_SCRATCH_ALLOC_FINI( l, scratch_align() );
+  /********************************************************************/
+  /* runtime public                                                   */
+  /********************************************************************/
+
+  ulong runtime_obj_id = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "runtime_pub" );
+  if( FD_UNLIKELY( runtime_obj_id==ULONG_MAX ) ) {
+    FD_LOG_ERR(( "Could not find topology object for runtime public" ));
+  }
+
+  ctx->runtime_public_wksp = topo->workspaces[ topo->objs[ runtime_obj_id ].wksp_id ].wksp;
+
+  if( FD_UNLIKELY( ctx->runtime_public_wksp==NULL ) ) {
+    FD_LOG_ERR(( "No runtime_public workspace" ));
+  }
+
+  ctx->runtime_public = fd_runtime_public_join( fd_topo_obj_laddr( topo, runtime_obj_id ) );
+  if( FD_UNLIKELY( !ctx->runtime_public ) ) {
+    FD_LOG_ERR(( "Failed to join runtime public" ));
+  }
+
+  ctx->runtime_spad = fd_runtime_public_join_and_get_runtime_spad( ctx->runtime_public );
+  if( FD_UNLIKELY( !ctx->runtime_spad ) ) {
+    FD_LOG_ERR(( "Failed to get and join runtime spad" ));
+  }
+
+  /********************************************************************/
+  /* spad allocator                                                   */
+  /********************************************************************/
+
+  /* First join the correct exec spad and hten the correct runtime spad
+     which lives inside of the runtime public wksp. */
+
+  ulong exec_spad_obj_id = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "exec_spad.%lu", ctx->tile_idx );
+  if( FD_UNLIKELY( exec_spad_obj_id==ULONG_MAX ) ) {
+    FD_LOG_ERR(( "Could not find topology object for exec spad" ));
+  }
+
+  ctx->exec_spad = fd_spad_join( fd_topo_obj_laddr( topo, exec_spad_obj_id ) );
+  if( FD_UNLIKELY( !ctx->exec_spad ) ) {
+    FD_LOG_ERR(( "Failed to join exec spad" ));
+  }
+  ctx->exec_spad_wksp = fd_wksp_containing( ctx->exec_spad );
+
+  ctx->pending_txn_pop   = 0;
+  ctx->pending_slot_pop  = 0;
+  ctx->pending_epoch_pop = 0;
+
+  /********************************************************************/
+  /* funk-specific setup                                              */
+  /********************************************************************/
+
+  /* Setting these parameters are not required because we are joining
+     the funk that was setup in the replay tile. */
+  FD_LOG_NOTICE(( "Trying to join funk at file=%s", tile->exec.funk_file ));
+  ctx->funk = fd_funk_open_file( tile->exec.funk_file,
+                                  1UL,
+                                  0UL,
+                                  0UL,
+                                  0UL,
+                                  0UL,
+                                  FD_FUNK_READONLY,
+                                  NULL );
+  ctx->funk_wksp = fd_funk_wksp( ctx->funk );
+  if( FD_UNLIKELY( !ctx->funk ) ) {
+    FD_LOG_ERR(( "failed to join a funk" ));
+  }
+
+  FD_LOG_NOTICE(( "Just joined funk at file=%s", tile->exec.funk_file ));
+
+  /********************************************************************/
+  /* setup txn ctx                                                    */
+  /********************************************************************/
+
+  fd_spad_push( ctx->exec_spad );
+  ctx->pending_txn_pop  = 0;
+  ctx->pending_slot_pop = 0;
+  uchar * txn_ctx_mem   = fd_spad_alloc( ctx->exec_spad, FD_EXEC_TXN_CTX_ALIGN, FD_EXEC_TXN_CTX_FOOTPRINT );
+  ctx->txn_ctx          = fd_exec_txn_ctx_join( fd_exec_txn_ctx_new( txn_ctx_mem ), ctx->exec_spad, ctx->exec_spad_wksp );
+
+  uchar *        acc_mgr_mem     = fd_spad_alloc( ctx->exec_spad, FD_ACC_MGR_ALIGN, FD_ACC_MGR_FOOTPRINT );
+  fd_acc_mgr_t * acc_mgr         = fd_acc_mgr_new( acc_mgr_mem, ctx->funk );
+  ctx->txn_ctx->acc_mgr          = acc_mgr;
+  if( FD_UNLIKELY( !ctx->txn_ctx->acc_mgr ) ) {
+    FD_LOG_ERR(( "Failed to create account manager" ));
+  }
+
+  ctx->txn_ctx->runtime_pub_wksp = ctx->runtime_public_wksp;
+  if( FD_UNLIKELY( !ctx->txn_ctx->runtime_pub_wksp ) ) {
+    FD_LOG_ERR(( "Failed to find public wksp" ));
+  }
+
+  /********************************************************************/
+  /* setup exec fseq                                                  */
+  /********************************************************************/
+
+  ulong exec_fseq_id = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "exec_fseq.%lu", ctx->tile_idx );
+  ctx->exec_fseq = fd_fseq_join( fd_topo_obj_laddr( topo, exec_fseq_id ) );
+  if( FD_UNLIKELY( !ctx->exec_fseq ) ) {
+    FD_LOG_ERR(( "exec tile %lu has no fseq", ctx->tile_idx ));
+  }
+  fd_fseq_update( ctx->exec_fseq, FD_EXEC_STATE_NOT_BOOTED );
+
+
+  ulong txn_ctx_gaddr = fd_wksp_gaddr( ctx->exec_spad_wksp, ctx->txn_ctx );
+  if( FD_UNLIKELY( !txn_ctx_gaddr ) ) {
+    FD_LOG_ERR(( "Could not get gaddr for txn_ctx" ));
+  }
+
+  ulong exec_spad_gaddr = fd_wksp_gaddr( ctx->exec_spad_wksp, ctx->exec_spad );
+  if( FD_UNLIKELY( !exec_spad_gaddr ) ) {
+    FD_LOG_ERR(( "Could not get gaddr for exec_spad" ));
+  }
+
+  if( FD_UNLIKELY( txn_ctx_gaddr-exec_spad_gaddr>UINT_MAX ) ) {
+    FD_LOG_ERR(( "Txn ctx offset from exec spad is too large" ));
+  }
+
+  uint txn_ctx_offset = (uint)(txn_ctx_gaddr-exec_spad_gaddr);
+  fd_fseq_update( ctx->exec_fseq, fd_exec_fseq_set_booted( txn_ctx_offset ) );
+
+  FD_LOG_NOTICE(( "Done booting exec tile idx=%lu", ctx->tile_idx ));
+}
+
+static void
+after_credit( fd_exec_tile_ctx_t * ctx,
+              fd_stem_context_t *  stem        FD_PARAM_UNUSED,
+              int *                opt_poll_in FD_PARAM_UNUSED,
+              int *                charge_busy FD_PARAM_UNUSED ) {
+  (void)ctx;
 }
 
 static ulong
@@ -133,8 +557,10 @@ populate_allowed_fds( fd_topo_t const *      topo,
 #define STEM_CALLBACK_CONTEXT_TYPE  fd_exec_tile_ctx_t
 #define STEM_CALLBACK_CONTEXT_ALIGN alignof(fd_exec_tile_ctx_t)
 
-#define STEM_CALLBACK_DURING_FRAG during_frag
-#define STEM_CALLBACK_AFTER_FRAG  after_frag
+#define STEM_CALLBACK_DURING_FRAG  during_frag
+#define STEM_CALLBACK_AFTER_FRAG   after_frag
+#define STEM_CALLBACK_AFTER_CREDIT after_credit
+
 
 #include "../../disco/stem/fd_stem.c"
 

--- a/src/discof/store/fd_storei_tile.c
+++ b/src/discof/store/fd_storei_tile.c
@@ -451,6 +451,7 @@ fd_store_tile_slot_prepare( fd_store_tile_ctx_t * ctx,
           uint data_cnt = consumed_idx != UINT_MAX ? idx - consumed_idx : idx + 1;
           replay_sig = fd_disco_repair_replay_sig( slot, data_cnt, (ushort)( slot - parent_slot ), complete_idx == idx );
           fd_stem_publish( stem, REPLAY_OUT_IDX, replay_sig, ctx->replay_out_chunk, 0, 0UL, tsorig, tspub );
+          ctx->replay_out_chunk = fd_dcache_compact_next( ctx->replay_out_chunk, 0, ctx->replay_out_chunk0, ctx->replay_out_wmark );
           consumed_idx = idx;
         }
       }

--- a/src/flamenco/runtime/Local.mk
+++ b/src/flamenco/runtime/Local.mk
@@ -30,6 +30,9 @@ $(call add-objs,fd_txncache,fd_flamenco)
 $(call add-hdrs,fd_cost_tracker.h)
 $(call add-objs,fd_cost_tracker,fd_flamenco)
 
+$(call add-hdrs,fd_runtime_public.h)
+$(call add-objs,fd_runtime_public,fd_flamenco)
+
 $(call add-hdrs, tests/fd_dump_pb.h)
 $(call add-objs, tests/fd_dump_pb,fd_flamenco)
 

--- a/src/flamenco/runtime/context/fd_exec_epoch_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_epoch_ctx.c
@@ -1,7 +1,7 @@
 #include "fd_exec_epoch_ctx.h"
 #include <assert.h>
 #include "../sysvar/fd_sysvar_stake_history.h"
-#include "../fd_runtime.h"
+#include "../fd_runtime_public.h"
 
 /* TODO remove this */
 #define MAX_LG_SLOT_CNT   10UL
@@ -232,10 +232,10 @@ fd_exec_epoch_ctx_from_prev( fd_exec_epoch_ctx_t * self,
   fd_memcpy( &self->features, &prev->features, sizeof(fd_features_t) );
 
   self->bank_hash_cmp     = prev->bank_hash_cmp;
-  self->replay_public    = prev->replay_public;
+  self->runtime_public    = prev->runtime_public;
   self->total_epoch_stake = 0UL;
 
-  fd_memcpy( &self->replay_public->features, &prev->features, sizeof(fd_features_t) );
+  fd_memcpy( &self->runtime_public->features, &prev->features, sizeof(fd_features_t) );
 
   fd_epoch_bank_t * old_epoch_bank = fd_exec_epoch_ctx_epoch_bank( prev );
 

--- a/src/flamenco/runtime/context/fd_exec_epoch_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_epoch_ctx.h
@@ -31,9 +31,9 @@ struct __attribute__((aligned(64UL))) fd_exec_epoch_ctx {
   fd_features_t              features;
   fd_epoch_bank_t            epoch_bank;
 
-  fd_bank_hash_cmp_t       * bank_hash_cmp;
-  fd_runtime_public_t      * replay_public;
-  int                        constipate_root; /* Used for constipation in offline replay .*/
+  fd_bank_hash_cmp_t *       bank_hash_cmp;
+  fd_runtime_public_t *      runtime_public;
+  int                        constipate_root; /* Used for constipation in offline replay. */
   ulong                      total_epoch_stake;
 };
 

--- a/src/flamenco/runtime/context/fd_exec_slot_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_slot_ctx.h
@@ -51,8 +51,8 @@ struct __attribute__((aligned(8UL))) fd_exec_slot_ctx {
   fd_slot_history_t *         slot_history;
 
   int                         enable_exec_recording; /* Enable/disable execution metadata
-                                                     recording, e.g. txn logs.  Analogue
-                                                     of Agave's ExecutionRecordingConfig. */
+                                                        recording, e.g. txn logs.  Analogue
+                                                        of Agave's ExecutionRecordingConfig. */
 
   ulong                       root_slot;
   ulong                       snapshot_freq;

--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.c
@@ -27,7 +27,9 @@ fd_exec_txn_ctx_new( void * mem ) {
 }
 
 fd_exec_txn_ctx_t *
-fd_exec_txn_ctx_join( void * mem ) {
+fd_exec_txn_ctx_join( void *      mem,
+                      fd_spad_t * spad,
+                      fd_wksp_t * spad_wksp ) {
   if( FD_UNLIKELY( !mem ) ) {
     FD_LOG_WARNING(( "NULL block" ));
     return NULL;
@@ -39,6 +41,10 @@ fd_exec_txn_ctx_join( void * mem ) {
     FD_LOG_WARNING(( "bad magic" ));
     return NULL;
   }
+
+  /* Rejoin the wksp */
+  ctx->spad      = spad;
+  ctx->spad_wksp = spad_wksp;
 
   return ctx;
 }
@@ -276,11 +282,17 @@ fd_exec_txn_ctx_from_exec_slot_ctx( fd_exec_slot_ctx_t const * slot_ctx,
 
   txn_ctx->acc_mgr = fd_wksp_laddr( runtime_pub_wksp, acc_mgr_gaddr );
   if( FD_UNLIKELY( !txn_ctx->acc_mgr ) ) {
-    FD_LOG_ERR(( "Could not find valid account manager" ));
+    FD_LOG_ERR(( "Could not find valid account manager %lu", acc_mgr_gaddr ));
   }
   txn_ctx->acc_mgr->funk = fd_wksp_laddr( funk_wksp, funk_gaddr );
+  if( FD_UNLIKELY( !txn_ctx->acc_mgr->funk ) ) {
+    FD_LOG_ERR(( "Could not find valid account manager %lu", acc_mgr_gaddr ));
+  }
 
   txn_ctx->sysvar_cache = fd_wksp_laddr( runtime_pub_wksp, sysvar_cache_gaddr );
+  if( FD_UNLIKELY( !txn_ctx->sysvar_cache ) ) {
+    FD_LOG_ERR(( "Could not find valid sysvar cache" ));
+  }
 
   txn_ctx->features     = slot_ctx->epoch_ctx->features;
   txn_ctx->status_cache = slot_ctx->status_cache;

--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.h
@@ -61,29 +61,34 @@ struct __attribute__((aligned(8UL))) fd_exec_txn_ctx {
   ulong magic; /* ==FD_EXEC_TXN_CTX_MAGIC */
 
   /* TODO: These are fields borrowed from the slot and epoch ctx. This
-     could be refactored even further. */
+     could be refactored even further. Currently these fields are not
+     all valid local joins. */
 
-  /* local */
+
+  uint flags;
+
+
   fd_features_t                   features;
   fd_sysvar_cache_t const *       sysvar_cache;
   fd_txncache_t *                 status_cache;
   ulong                           prev_lamports_per_signature;
   int                             enable_exec_recording;
   ulong                           total_epoch_stake;
-  fd_bank_hash_cmp_t *            bank_hash_cmp;
+  fd_bank_hash_cmp_t *            bank_hash_cmp; /* FIXME: broken */
   fd_funk_txn_t *                 funk_txn;
   fd_acc_mgr_t *                  acc_mgr;
   fd_wksp_t *                     runtime_pub_wksp;
   ulong                           slot;
   fd_fee_rate_governor_t          fee_rate_governor;
-  fd_block_hash_queue_t           block_hash_queue; /* TODO:FIXME: make globally addressable */
+  fd_block_hash_queue_t           block_hash_queue;
 
   fd_epoch_schedule_t             schedule;
   fd_rent_t                       rent;
   double                          slots_per_year;
-  fd_stakes_t                     stakes; /* TODO:FIXME: Handle global addressable stuff */
+  fd_stakes_t                     stakes;
 
   fd_spad_t *                     spad;                                        /* Sized out to handle the worst case footprint of single transaction execution. */
+  fd_wksp_t *                     spad_wksp;                                   /* Workspace for the spad. */
 
   ulong                           paid_fees;
   ulong                           compute_unit_limit;                          /* Compute unit limit for this transaction. */
@@ -206,7 +211,7 @@ void *
 fd_exec_txn_ctx_new( void * mem );
 
 fd_exec_txn_ctx_t *
-fd_exec_txn_ctx_join( void * mem );
+fd_exec_txn_ctx_join( void * mem, fd_spad_t * spad, fd_wksp_t * spad_wksp );
 
 void *
 fd_exec_txn_ctx_leave( fd_exec_txn_ctx_t * ctx );

--- a/src/flamenco/runtime/fd_acc_mgr.h
+++ b/src/flamenco/runtime/fd_acc_mgr.h
@@ -250,7 +250,8 @@ fd_acc_mgr_save( fd_acc_mgr_t *     acc_mgr,
 int
 fd_acc_mgr_save_non_tpool( fd_acc_mgr_t *     acc_mgr,
                            fd_funk_txn_t *    txn,
-                           fd_txn_account_t * account );
+                           fd_txn_account_t * account,
+                           fd_wksp_t *        wksp );
 
 int
 fd_acc_mgr_save_many_tpool( fd_acc_mgr_t *      acc_mgr,

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -75,8 +75,7 @@ int
 fd_execute_txn_prepare_start( fd_exec_slot_ctx_t const * slot_ctx,
                               fd_exec_txn_ctx_t *        txn_ctx,
                               fd_txn_t const *           txn_descriptor,
-                              fd_rawtxn_b_t const *      txn_raw,
-                              fd_spad_t *                spad );
+                              fd_rawtxn_b_t const *      txn_raw );
 
 /*
   Execute the given transaction.
@@ -93,6 +92,9 @@ fd_executor_validate_transaction_fee_payer( fd_exec_txn_ctx_t * txn_ctx );
 
 void
 fd_executor_setup_borrowed_accounts_for_txn( fd_exec_txn_ctx_t * txn_ctx );
+
+int
+fd_executor_setup_accessed_accounts_for_txn( fd_exec_txn_ctx_t * txn_ctx );
 
 /*
   Validate the txn after execution for violations of various lamport balance and size rules

--- a/src/flamenco/runtime/fd_hashes.h
+++ b/src/flamenco/runtime/fd_hashes.h
@@ -14,10 +14,52 @@ struct __attribute__((aligned(FD_PUBKEY_HASH_PAIR_ALIGN))) fd_pubkey_hash_pair {
 typedef struct fd_pubkey_hash_pair fd_pubkey_hash_pair_t;
 #define FD_PUBKEY_HASH_PAIR_FOOTPRINT (sizeof(fd_pubkey_hash_pair_t))
 
+struct fd_accounts_hash_task_info {
+  fd_exec_slot_ctx_t *  slot_ctx;
+  fd_pubkey_t           acc_pubkey[1];
+  fd_hash_t             acc_hash[1];
+  fd_funk_rec_t const * rec;
+  uint                  should_erase;
+  uint                  hash_changed;
+};
+typedef struct fd_accounts_hash_task_info fd_accounts_hash_task_info_t;
+
+struct fd_accounts_hash_task_data {
+  fd_accounts_hash_task_info_t * info;
+  ulong                          info_sz;
+  fd_lthash_value_t *            lthash_values;
+  ulong                          num_recs;
+};
+typedef struct fd_accounts_hash_task_data fd_accounts_hash_task_data_t;
+
 union fd_features;
 typedef union fd_features fd_features_t;
 
 FD_PROTOTYPES_BEGIN
+
+int
+fd_update_hash_bank_exec_hash( fd_exec_slot_ctx_t *           slot_ctx,
+                               fd_hash_t *                    hash,
+                               fd_capture_ctx_t *             capture_ctx,
+                               fd_accounts_hash_task_data_t * task_datas,
+                               ulong                          task_datas_cnt,
+                               fd_lthash_value_t *            lt_hashes,
+                               ulong                          lt_hashes_cnt,
+                               ulong                          signature_cnt,
+                               fd_spad_t *                    runtime_spad );
+
+void
+fd_collect_modified_accounts( fd_exec_slot_ctx_t *           slot_ctx,
+                              fd_accounts_hash_task_data_t * task_data,
+                              fd_spad_t *                    runtime_spad );
+
+void
+fd_account_hash( fd_acc_mgr_t *                 acc_mgr,
+                 fd_funk_txn_t *                funk_txn,
+                 fd_accounts_hash_task_info_t * task_info,
+                 fd_lthash_value_t *            lt_hash,
+                 ulong                          slot,
+                 fd_features_t *                features );
 
 int
 fd_update_hash_bank_tpool( fd_exec_slot_ctx_t * slot_ctx,

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -253,17 +253,6 @@ FD_STATIC_ASSERT( FD_BPF_ALIGN_OF_U128==FD_ACCOUNT_REC_DATA_ALIGN, input_data_al
 
 FD_STATIC_ASSERT( FD_RUNTIME_MERKLE_VERIFICATION_FOOTPRINT <= FD_RUNTIME_TRANSACTION_EXECUTION_FOOTPRINT_DEFAULT, merkle verify footprint exceeds txn execution footprint );
 
-/* definition of the public/readable workspace */
-struct fd_runtime_public {
-  // FIXME:  This is a non-fork-aware copy of the currently active
-  // features.  Once the epoch_ctx and the slot_ctx get moved into
-  // this workspace AND we make the epoch_ctx properly fork aware at
-  // the epoch boundary, we can remove this copy of the features map
-  // and just use the epoch_ctx (or slot_ctx) copy directly.
-  fd_features_t features;
-};
-typedef struct fd_runtime_public fd_runtime_public_t;
-
 /* Helpers for runtime public frame management. */
 
 /* Helpers for runtime spad frame management. */
@@ -458,13 +447,10 @@ fd_runtime_process_txns_in_microblock_stream( fd_exec_slot_ctx_t * slot_ctx,
                                               fd_spad_t *          runtime_spad,
                                               fd_cost_tracker_t *  cost_tracker_opt );
 
-/* fd_runtime_process_txns and fd_runtime_execute_txns_in_waves_tpool are
-   both entrypoints for executing transactions. Currently, the former is used
-   in the leader pipeline as conflict-free microblocks are streamed in from the
-   pack tile. The latter is used for replaying non-leader blocks. Currently the
-   entire block must be received to start replaying. This allows us to scheedule
-   out all of the transactions. Eventually, transactions will be executed in
-   a streamed fashion.*/
+int
+fd_runtime_finalize_txn( fd_exec_slot_ctx_t *         slot_ctx,
+                         fd_capture_ctx_t *           capture_ctx,
+                         fd_execute_txn_task_info_t * task_info );
 
 /* Epoch Boundary *************************************************************/
 
@@ -544,20 +530,6 @@ fd_runtime_read_genesis( fd_exec_slot_ctx_t * slot_ctx,
                          fd_capture_ctx_t *   capture_ctx,
                          fd_tpool_t *         tpool,
                          fd_spad_t *          spad );
-
-ulong
-fd_runtime_public_footprint ( void );
-
-fd_runtime_public_t *
-fd_runtime_public_join ( void * ptr ) ;
-
-void *
-fd_runtime_public_new ( void * ptr ) ;
-
-FD_FN_CONST static inline ulong
-fd_runtime_public_align( void ) {
-  return alignof(fd_runtime_public_t);
-}
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/fd_runtime_public.c
+++ b/src/flamenco/runtime/fd_runtime_public.c
@@ -1,0 +1,85 @@
+#include "fd_runtime_public.h"
+
+ulong
+fd_runtime_public_footprint( void ) {
+  return sizeof(fd_runtime_public_t) +
+         fd_spad_align() +
+         fd_spad_footprint( FD_RUNTIME_BLOCK_EXECUTION_FOOTPRINT );
+}
+
+fd_runtime_public_t *
+fd_runtime_public_join( void * shmem ) {
+  fd_runtime_public_t * pub = (fd_runtime_public_t *)shmem;
+
+  if( FD_UNLIKELY( pub->magic!=FD_RUNTIME_PUBLIC_MAGIC ) ) {
+    FD_LOG_WARNING(( "Bad Magic" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( pub->runtime_spad_gaddr==0UL ) ) {
+    FD_LOG_WARNING(( "Bad runtime spad allocation" ));
+    return NULL;
+  }
+
+  fd_wksp_t * wksp = fd_wksp_containing( shmem );
+  if( FD_UNLIKELY( !wksp ) ) {
+    FD_LOG_WARNING(( "No wksp containing shmem found" ));
+    return NULL;
+  }
+
+  return pub;
+}
+
+void *
+fd_runtime_public_new( void * shmem ) {
+  fd_memset( shmem, 0, sizeof(fd_runtime_public_t) );
+
+  fd_runtime_public_t * runtime_public = (fd_runtime_public_t *)shmem;
+
+  fd_wksp_t * wksp = fd_wksp_containing( shmem );
+  if( FD_UNLIKELY( !wksp ) ) {
+    FD_LOG_WARNING(( "No wksp containing shmem found" ));
+    return NULL;
+  }
+
+  runtime_public->magic = FD_RUNTIME_PUBLIC_MAGIC;
+
+  /* The runtime_spad will in the contiguous region after the region's
+     header. */
+  uchar * spad_ptr = (uchar *)fd_ulong_align_up( (ulong)((uchar *)shmem + sizeof(fd_runtime_public_t)), fd_spad_align() );
+  spad_ptr = fd_spad_new( spad_ptr, FD_RUNTIME_BLOCK_EXECUTION_FOOTPRINT );
+  if( FD_UNLIKELY( !spad_ptr ) ) {
+    FD_LOG_WARNING(( "Unable to create spad" ));
+    return NULL;
+  }
+
+  runtime_public->runtime_spad_gaddr = fd_wksp_gaddr( wksp, spad_ptr );
+  if( FD_UNLIKELY( !runtime_public->runtime_spad_gaddr ) ) {
+    FD_LOG_WARNING(( "Unable to get runtime spad gaddr" ));
+    return NULL;
+  }
+
+  return shmem;
+}
+
+fd_spad_t *
+fd_runtime_public_join_and_get_runtime_spad( fd_runtime_public_t const * runtime_public ) {
+  if( FD_UNLIKELY( !runtime_public ) )  {
+    FD_LOG_WARNING(( "Invalid runtime_public" ));
+    return NULL;
+  }
+
+  fd_wksp_t * wksp = fd_wksp_containing( runtime_public );
+  if( FD_UNLIKELY( !wksp ) ) {
+    FD_LOG_WARNING(( "No wksp found" ));
+    return NULL;
+  }
+
+  void * spad_laddr = fd_wksp_laddr( wksp, runtime_public->runtime_spad_gaddr );
+  if( FD_UNLIKELY( !spad_laddr ) ) {
+    FD_LOG_WARNING(( "Unable to get spad laddr" ));
+    return NULL;
+  }
+
+  return fd_spad_join( spad_laddr );
+}

--- a/src/flamenco/runtime/fd_runtime_public.h
+++ b/src/flamenco/runtime/fd_runtime_public.h
@@ -1,0 +1,130 @@
+#ifndef HEADER_fd_src_flamenco_runtime_fd_runtime_public_h
+#define HEADER_fd_src_flamenco_runtime_fd_runtime_public_h
+
+#include "../fd_flamenco_base.h"
+#include "fd_runtime.h"
+#include "../features/fd_features.h"
+
+/* definition of the public/readable workspace */
+#define FD_RUNTIME_PUBLIC_MAGIC (0xF17EDA2C9A7B1C21UL)
+
+#define EXEC_NEW_SLOT_SIG  (0xABC123UL)
+#define EXEC_NEW_EPOCH_SIG (0xDEF456UL)
+#define EXEC_NEW_TXN_SIG   (0x777777UL)
+#define EXEC_HASH_ACCS_SIG (0x888888UL)
+
+#define FD_EXEC_STATE_NOT_BOOTED (0xFFFFFFFFUL)
+#define FD_EXEC_STATE_BOOTED     (1<<1UL      )
+#define FD_EXEC_STATE_EPOCH_DONE (1<<2UL      )
+#define FD_EXEC_STATE_SLOT_DONE  (1<<3UL      )
+#define FD_EXEC_STATE_TXN_DONE   (1<<4UL      )
+#define FD_EXEC_STATE_IDLE       (1<<5UL      )
+
+static uint FD_FN_UNUSED
+fd_exec_fseq_get_state( ulong fseq ) {
+  return (uint)(fseq & 0xFFFFFFFFU);
+}
+
+static ulong FD_FN_UNUSED
+fd_exec_fseq_set_slot_done( void ) {
+  return (ulong)FD_EXEC_STATE_SLOT_DONE;
+}
+
+static ulong FD_FN_UNUSED
+fd_exec_fseq_set_booted( uint offset ) {
+  ulong state = ((ulong)offset << 32UL);
+  state      |= FD_EXEC_STATE_BOOTED;
+  return state;
+}
+
+static uint FD_FN_UNUSED
+fd_exec_fseq_get_booted_offset( ulong fseq ) {
+  return (uint)(fseq >> 32UL);
+}
+
+static ulong FD_FN_UNUSED
+fd_exec_fseq_set_epoch_done( void ) {
+  return FD_EXEC_STATE_EPOCH_DONE;
+}
+
+static ulong FD_FN_UNUSED
+fd_exec_fseq_set_txn_done( void ) {
+  return FD_EXEC_STATE_TXN_DONE;
+}
+
+static ulong FD_FN_UNUSED
+fd_exec_fseq_set_idle( void ) {
+  return FD_EXEC_STATE_IDLE;
+}
+
+struct fd_runtime_public_epoch_msg {
+  fd_features_t       features;
+  ulong               total_epoch_stake;
+  fd_epoch_schedule_t epoch_schedule;
+  fd_rent_t           rent;
+  double              slots_per_year;
+  ulong               stakes_encoded_gaddr;
+  ulong               stakes_encoded_sz;
+};
+typedef struct fd_runtime_public_epoch_msg fd_runtime_public_epoch_msg_t;
+
+struct fd_runtime_public_slot_msg {
+  ulong                  slot;
+  ulong                  prev_lamports_per_signature;
+  fd_fee_rate_governor_t fee_rate_governor;
+  ulong                  sysvar_cache_gaddr;
+  ulong                  block_hash_queue_encoded_gaddr;
+  ulong                  block_hash_queue_encoded_sz;
+};
+typedef struct fd_runtime_public_slot_msg fd_runtime_public_slot_msg_t;
+
+struct fd_runtime_public_txn_msg {
+  fd_txn_p_t txn;
+};
+typedef struct fd_runtime_public_txn_msg fd_runtime_public_txn_msg_t;
+
+struct fd_runtime_public_hash_bank_msg {
+  ulong task_infos_gaddr;
+  ulong start_idx;
+  ulong end_idx;
+};
+typedef struct fd_runtime_public_hash_bank_msg fd_runtime_public_hash_bank_msg_t;
+
+struct fd_runtime_public {
+  /* FIXME:  This is a non-fork-aware copy of the currently active
+     features.  Once the epoch_ctx and the slot_ctx get moved into
+     this workspace AND we make the epoch_ctx properly fork aware at
+     the epoch boundary, we can remove this copy of the features map
+     and just use the epoch_ctx (or slot_ctx) copy directly. */
+
+  /* TODO: Maybe it is better to split out the runtime_spad_gaddr into
+     a different shared struct? I think it is okay because it is part of
+     the runtime. */
+  ulong         magic;
+  fd_features_t features;
+  ulong         runtime_spad_gaddr;
+};
+typedef struct fd_runtime_public fd_runtime_public_t;
+
+FD_FN_CONST static inline ulong
+fd_runtime_public_align( void ) {
+  return alignof(fd_runtime_public_t);
+}
+
+ulong
+fd_runtime_public_footprint( void );
+
+void *
+fd_runtime_public_new( void * shmem );
+
+fd_runtime_public_t *
+fd_runtime_public_join( void * shmem );
+
+/* Returns a local join of the runtime spad */
+fd_spad_t *
+fd_runtime_public_join_and_get_runtime_spad( fd_runtime_public_t const * runtime_public );
+
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_flamenco_runtime_fd_runtime_public_h */

--- a/src/flamenco/runtime/fd_txn_account.c
+++ b/src/flamenco/runtime/fd_txn_account.c
@@ -72,15 +72,22 @@ fd_txn_account_make_readonly( fd_txn_account_t * acct, void * buf ) {
 }
 
 fd_txn_account_t *
-fd_txn_account_make_mutable( fd_txn_account_t * acct, void * buf ) {
-  if( FD_UNLIKELY( acct->data != NULL ) ) FD_LOG_ERR(( "borrowed account is already mutable" ));
+fd_txn_account_make_mutable( fd_txn_account_t * acct,
+                             void *             buf,
+                             fd_wksp_t *        wksp ) {
+  if( FD_UNLIKELY( acct->data != NULL ) ) {
+    FD_LOG_ERR(( "borrowed account is already mutable" ));
+  }
 
-  ulong   dlen         = ( acct->const_meta != NULL ) ? acct->const_meta->dlen : 0;
+  ulong   dlen         = ( acct->const_meta != NULL ) ? acct->const_meta->dlen : 0UL;
   uchar * new_raw_data = fd_txn_account_init_data( acct, buf );
 
   acct->const_meta = acct->meta = (fd_account_meta_t *)new_raw_data;
   acct->const_data = acct->data = new_raw_data + sizeof(fd_account_meta_t);
   acct->meta->dlen = dlen;
+
+  acct->meta_gaddr = fd_wksp_gaddr( wksp, acct->meta );
+  acct->data_gaddr = fd_wksp_gaddr( wksp, acct->data );
 
   return acct;
 }

--- a/src/flamenco/runtime/fd_txn_account.h
+++ b/src/flamenco/runtime/fd_txn_account.h
@@ -22,6 +22,9 @@ struct __attribute__((aligned(8UL))) fd_txn_account {
   uchar                     * data;
   fd_funk_rec_t             * rec;
 
+  ulong                       meta_gaddr;
+  ulong                       data_gaddr;
+
   /* consider making this a struct or removing entirely if not needed */
   ulong                       starting_dlen;
   ulong                       starting_lamports;
@@ -79,11 +82,13 @@ fd_txn_account_resize( fd_txn_account_t * acct,
 
 /* Operators */
 
-/* buf is a handle to the account shared data.
-   Sets the account shared data as mutable. */
+/* buf is a handle to the account shared data. Sets the account shared
+   data as mutable. Also, gaddr aware pointers for account metadata and
+   data are stored in the txn account. */
 fd_txn_account_t *
 fd_txn_account_make_mutable( fd_txn_account_t * acct,
-                          void *          buf );
+                             void *             buf,
+                             fd_wksp_t *        wksp );
 
 /* In Agave, dummy accounts are sometimes created that contain metadata
    that differs from what's in the accounts DB.  For example, see
@@ -93,11 +98,11 @@ fd_txn_account_make_mutable( fd_txn_account_t * acct,
    borrowed accounts without those modification writing through to
    funk. */
 
-/* buf is a handle to the account shared data.
-   Sets the account shared data as read only. */
+/* buf is a handle to the account shared data. Sets the account shared
+   data as read only. */
 fd_txn_account_t *
 fd_txn_account_make_readonly( fd_txn_account_t * acct,
-                            void *          buf );
+                              void *             buf );
 
 static inline int
 fd_txn_account_checked_add_lamports( fd_txn_account_t * acct, ulong lamports ) {

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -2021,7 +2021,7 @@ fd_directly_invoke_loader_v3_deploy( fd_exec_slot_ctx_t * slot_ctx,
                                      ulong                elf_sz,
                                      fd_spad_t *          runtime_spad ) {
   /* Set up a dummy instr and txn context */
-  fd_exec_txn_ctx_t * txn_ctx            = fd_exec_txn_ctx_join( fd_exec_txn_ctx_new( fd_spad_alloc( runtime_spad, FD_EXEC_TXN_CTX_ALIGN, FD_EXEC_TXN_CTX_FOOTPRINT ) ) );
+  fd_exec_txn_ctx_t * txn_ctx            = fd_exec_txn_ctx_join( fd_exec_txn_ctx_new( fd_spad_alloc( runtime_spad, FD_EXEC_TXN_CTX_ALIGN, FD_EXEC_TXN_CTX_FOOTPRINT ) ), runtime_spad, fd_wksp_containing( runtime_spad ) );
   fd_funk_t *         funk               = slot_ctx->acc_mgr->funk;
   fd_wksp_t *         funk_wksp          = fd_funk_wksp( funk );
   fd_wksp_t *         runtime_wksp       = fd_wksp_containing( slot_ctx );

--- a/src/flamenco/runtime/program/fd_vote_program.c
+++ b/src/flamenco/runtime/program/fd_vote_program.c
@@ -1983,9 +1983,13 @@ process_vote_state_update( fd_borrowed_account_t *       vote_account,
   // tie in code for fd_bank_hash_cmp that helps us detect if we have forked from the cluster.
   //
   // There is no corresponding code in anza
+
   if( !deq_fd_vote_lockout_t_empty( vote_state_update->lockouts ) ) {
     fd_vote_lockout_t * lockout = deq_fd_vote_lockout_t_peek_tail( vote_state_update->lockouts );
     fd_bank_hash_cmp_t * bank_hash_cmp = ctx->txn_ctx->bank_hash_cmp;
+    if( lockout ) {
+      FD_LOG_DEBUG(( "bank hash from slot=%lu hash=%s", lockout->slot, FD_BASE58_ENC_32_ALLOCA(&vote_state_update->hash) ));
+    }
     if( FD_LIKELY( lockout && bank_hash_cmp ) ) {
       fd_bank_hash_cmp_lock( bank_hash_cmp );
       fd_bank_hash_cmp_insert(
@@ -2072,6 +2076,10 @@ process_tower_sync( fd_borrowed_account_t *       vote_account,
 
   if( !deq_fd_vote_lockout_t_empty( tower_sync->lockouts ) ) {
     fd_vote_lockout_t * lockout = deq_fd_vote_lockout_t_peek_tail( tower_sync->lockouts );
+    if( lockout ) {
+      FD_LOG_DEBUG(( "Bank hash=%s for slot=%lu", FD_BASE58_ENC_32_ALLOCA(&tower_sync->hash), lockout->slot ));
+    }
+
     fd_bank_hash_cmp_t * bank_hash_cmp = ctx->txn_ctx->bank_hash_cmp;
     if( FD_LIKELY( lockout && bank_hash_cmp ) ) {
       fd_bank_hash_cmp_lock( bank_hash_cmp );

--- a/src/flamenco/runtime/sysvar/fd_sysvar_cache.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_cache.c
@@ -109,6 +109,7 @@ fd_sysvar_cache_restore_##name(                                           \
     int   err         = type##_decode_footprint( &decode, &total_sz );    \
     cache->has_##name = (err==FD_BINCODE_SUCCESS);                        \
     if( FD_UNLIKELY( err ) ) {                                            \
+      FD_LOG_WARNING(( "failed to decode footprint" ));                   \
       break;                                                              \
     }                                                                     \
                                                                           \

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -382,7 +382,7 @@ fd_exec_test_instr_context_create( fd_exec_instr_test_runner_t *        runner,
 
   fd_exec_epoch_ctx_t * epoch_ctx     = fd_exec_epoch_ctx_join( fd_exec_epoch_ctx_new( epoch_ctx_mem, vote_acct_max ) );
   fd_exec_slot_ctx_t *  slot_ctx      = fd_exec_slot_ctx_join ( fd_exec_slot_ctx_new ( slot_ctx_mem, runner->spad ) );
-  fd_exec_txn_ctx_t *   txn_ctx       = fd_exec_txn_ctx_join  ( fd_exec_txn_ctx_new  ( txn_ctx_mem   ) );
+  fd_exec_txn_ctx_t *   txn_ctx       = fd_exec_txn_ctx_join  ( fd_exec_txn_ctx_new  ( txn_ctx_mem ), runner->spad, fd_wksp_containing( runner->spad ) );
 
   assert( epoch_ctx );
   assert( slot_ctx  );
@@ -985,7 +985,8 @@ _txn_context_create_and_exec( fd_exec_instr_test_runner_t *      runner,
   fd_runtime_prepare_txns_start( slot_ctx, task_info, txn, 1UL, runner->spad );
 
   /* Setup the spad for account allocation */
-  task_info->txn_ctx->spad = runner->spad;
+  task_info->txn_ctx->spad      = runner->spad;
+  task_info->txn_ctx->spad_wksp = fd_wksp_containing( runner->spad );
 
   fd_runtime_pre_execute_check( task_info, 0 );
 

--- a/src/flamenco/types/fd_types.c
+++ b/src/flamenco/types/fd_types.c
@@ -11496,7 +11496,7 @@ void fd_slot_hashes_decode_inner_global( void * struct_mem, void * * alloc_mem, 
 int fd_slot_hashes_convert_global_to_local( void const * global_self, fd_slot_hashes_t * self, fd_bincode_decode_ctx_t * ctx ) {
   int err = 0;
   fd_slot_hashes_global_t const * mem = (fd_slot_hashes_global_t const *)global_self;
-  self->hashes = deq_fd_slot_hash_t_join( fd_wksp_laddr_fast( ctx->wksp, mem->hashes_gaddr ) );
+  self->hashes = deq_fd_slot_hash_t_join( fd_wksp_laddr( ctx->wksp, mem->hashes_gaddr ) );
   return FD_BINCODE_SUCCESS;
 }
 void fd_slot_hashes_new(fd_slot_hashes_t * self) {


### PR DESCRIPTION
This pr shifts transaction execution out of a tpool into exec tiles. Also is responsible for managing concurrency management around the tiles. 

This pr also changes hashing logic to support lists of accounts to support hashing in exec tiles as well.

All items for follow up:
1. exec tiles for epoch boundary
2. exec tiles for hashing
3. exec tiles for bpf cache
4. change replay_exec links so that there is just 1 outgoing link with multiple consumers
5. fixing stake weighted bank hash cmp