### PR TITLE
replay: correctly initialize rent collection in slot context

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -2294,6 +2294,7 @@ init_snapshot( fd_replay_tile_ctx_t * ctx,
   ctx->slot_ctx->blockstore   = ctx->blockstore;
   ctx->slot_ctx->epoch_ctx    = ctx->epoch_ctx;
   ctx->slot_ctx->status_cache = ctx->status_cache;
+  fd_runtime_update_slots_per_epoch( ctx->slot_ctx, FD_DEFAULT_SLOTS_PER_EPOCH, ctx->runtime_spad );
 
   uchar is_snapshot = strlen( ctx->snapshot ) > 0;
   if( is_snapshot ) {


### PR DESCRIPTION
This PR fixes some some cases where `slots_per_epoch` was not being correctly initialized before accounts were loaded in the snapshot.