### PR TITLE
Deduplicate entrypoints config

### DIFF
--- a/contrib/test/setup_fd_only_follower.sh
+++ b/contrib/test/setup_fd_only_follower.sh
@@ -55,13 +55,9 @@ name = \"fd2test\"
     verify_tile_count = 16
     shred_tile_count = 1
 [gossip]
+    entrypoints = [\"$1:8700\"]
     port = 8800
 [tiles]
-    [tiles.gossip]
-        entrypoints = [\"$1\"]
-        peer_ports = [8700]
-        gossip_listen_port = 8800
-
     [tiles.repair]
         repair_intake_listen_port = 8801
         repair_serve_listen_port = 8802

--- a/contrib/test/setup_fd_only_leader.sh
+++ b/contrib/test/setup_fd_only_leader.sh
@@ -38,13 +38,9 @@ name = \"fd1\"
     verify_tile_count = 20
     shred_tile_count = 4
 [gossip]
+    entrypoints = [\"$PRIMARY_IP:8001\"]
     port = 8700
 [tiles]
-    [tiles.gossip]
-        entrypoints = [\"$PRIMARY_IP\"]
-        peer_ports = [8001]
-        gossip_listen_port = 8700
-
     [tiles.repair]
         repair_intake_listen_port = 8701
         repair_serve_listen_port = 8702

--- a/contrib/test/test_firedancer.sh
+++ b/contrib/test/test_firedancer.sh
@@ -124,13 +124,9 @@ name = \"fd1test\"
     affinity = \"1-32\"
     bank_tile_count = 1
 [gossip]
+    entrypoints = [\"$PRIMARY_IP:8001\"]
     port = 8700
 [tiles]
-    [tiles.gossip]
-        entrypoints = [\"$PRIMARY_IP\"]
-        peer_ports = [8001]
-        gossip_listen_port = 8700
-
     [tiles.repair]
         repair_intake_listen_port = 8701
         repair_serve_listen_port = 8702

--- a/contrib/test/test_firedancer_genesis.sh
+++ b/contrib/test/test_firedancer_genesis.sh
@@ -34,13 +34,9 @@ name = \"fd1test\"
     verify_tile_count = 16
     shred_tile_count = 1
 [gossip]
+    entrypoints = [\"$PRIMARY_IP:8001\"]
     port = 8700
 [tiles]
-    [tiles.gossip]
-        entrypoints = [\"$PRIMARY_IP\"]
-        peer_ports = [8001]
-        gossip_listen_port = 8700
-
     [tiles.repair]
         repair_intake_listen_port = 8701
         repair_serve_listen_port = 8702

--- a/contrib/test/test_firedancer_leader.sh
+++ b/contrib/test/test_firedancer_leader.sh
@@ -45,12 +45,9 @@ name = \"fd1\"
     verify_tile_count = 16
     shred_tile_count = 1
 [gossip]
+    entrypoints = [\"$PRIMARY_IP:8001\"]
     port = 8700
 [tiles]
-    [tiles.gossip]
-        entrypoints = [\"$PRIMARY_IP\"]
-        peer_ports = [8001]
-        gossip_listen_port = 8700
     [tiles.repair]
         repair_intake_listen_port = 8701
         repair_serve_listen_port = 8702

--- a/contrib/test/test_firedancer_leader2.sh
+++ b/contrib/test/test_firedancer_leader2.sh
@@ -42,14 +42,11 @@ name = \"fd1\"
     shred_tile_count = 4
     net_tile_count = 1
 [gossip]
+    entrypoints = [\"$PRIMARY_IP:8001\"]
     port = 8700
 [tiles]
     [tiles.pack]
         max_pending_transactions = 32768
-    [tiles.gossip]
-        entrypoints = [\"$PRIMARY_IP\"]
-        peer_ports = [8001]
-        gossip_listen_port = 8700
     [tiles.repair]
         repair_intake_listen_port = 8701
         repair_serve_listen_port = 8702

--- a/contrib/test/test_firedancer_mainnet.sh
+++ b/contrib/test/test_firedancer_mainnet.sh
@@ -68,12 +68,9 @@ echo "
     affinity = \"1-32\"
     bank_tile_count = 1
 [gossip]
+    entrypoints = [\"$ENTRYPOINT:$ENTRYPOINT_PORT\"]
     port = 8820
 [tiles]
-    [tiles.gossip]
-        entrypoints = [\"$ENTRYPOINT\"]
-        peer_ports = [$ENTRYPOINT_PORT]
-        gossip_listen_port = 8820
     [tiles.repair]
         repair_intake_listen_port = 8821
         repair_serve_listen_port = 8822

--- a/contrib/test/test_firedancer_testnet.sh
+++ b/contrib/test/test_firedancer_testnet.sh
@@ -71,12 +71,9 @@ echo "
     affinity = \"1-32\"
     bank_tile_count = 1
 [gossip]
+    entrypoints = [\"$ENTRYPOINT:$ENTRYPOINT_PORT\", \"$ENTRYPOINT_BACKUP:$ENTRYPOINT_BACKUP_PORT\"]
     port = 8720
 [tiles]
-    [tiles.gossip]
-        entrypoints = [\"$ENTRYPOINT\", \"$ENTRYPOINT_BACKUP\"]
-        peer_ports = [$ENTRYPOINT_PORT, $ENTRYPOINT_BACKUP_PORT]
-        gossip_listen_port = 8720
     [tiles.repair]
         repair_intake_listen_port = 8721
         repair_serve_listen_port = 8722

--- a/src/app/fdctl/config/default-firedancer.toml
+++ b/src/app/fdctl/config/default-firedancer.toml
@@ -8,10 +8,6 @@
     port = 8700
 
 [tiles]
-    [tiles.gossip]
-        peer_ports = []
-        gossip_listen_port = 8700
-
     [tiles.repair]
         repair_intake_listen_port = 8701
         repair_serve_listen_port = 8702

--- a/src/app/shared/Local.mk
+++ b/src/app/shared/Local.mk
@@ -11,6 +11,7 @@ $(call add-hdrs,fd_file_util.h)
 
 $(call add-objs,fd_config fd_config_parse,fdctl_shared)
 $(call make-unit-test,test_config_parse,test_config_parse,fd_fdctl fdctl_shared fd_ballet fd_util)
+$(call run-unit-test,test_config_parse)
 $(call make-fuzz-test,fuzz_fdctl_config,fuzz_fdctl_config,fd_fdctl fdctl_shared fd_ballet fd_util)
 
 $(call add-objs,commands/help,fdctl_shared)

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -3,6 +3,7 @@
 
 #include "fd_cap_chk.h"
 #include "../../disco/topo/fd_topo.h"
+#include "../../util/net/fd_net_headers.h" /* fd_ip4_port_t */
 
 #include <net/if.h>
 #include <linux/limits.h>
@@ -161,8 +162,11 @@ struct fd_config {
   } ledger;
 
   struct {
+#   define FD_CONFIG_GOSSIP_ENTRYPOINTS_MAX 16
     ulong  entrypoints_cnt;
-    char   entrypoints[ 16 ][ 256 ];
+    char   entrypoints[ FD_CONFIG_GOSSIP_ENTRYPOINTS_MAX ][ 262 ];
+    ulong         resolved_entrypoints_cnt;
+    fd_ip4_port_t resolved_entrypoints[ FD_CONFIG_GOSSIP_ENTRYPOINTS_MAX ];
     int    port_check;
     ushort port;
     char   host[ 256 ];
@@ -381,14 +385,6 @@ struct fd_config {
     } gui;
 
     /* Firedancer-only tile configs */
-
-    struct {
-      ulong  entrypoints_cnt;
-      char   entrypoints[16][256];
-      ushort gossip_listen_port;
-      ulong  peer_ports_cnt;
-      ushort peer_ports[16];
-    } gossip;
 
     struct {
       ushort repair_intake_listen_port;

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -391,10 +391,6 @@ fdctl_pod_to_cfg( config_t * config,
 
   CFG_POP      ( bool,   consensus.vote                                   );
 
-  CFG_POP_ARRAY( cstr,   tiles.gossip.entrypoints                         );
-  CFG_POP      ( ushort, tiles.gossip.gossip_listen_port                  );
-  CFG_POP_ARRAY( ushort, tiles.gossip.peer_ports                          );
-
   CFG_POP      ( ushort, tiles.repair.repair_intake_listen_port           );
   CFG_POP      ( ushort, tiles.repair.repair_serve_listen_port            );
   CFG_POP      ( cstr,   tiles.repair.good_peer_cache_file                );

--- a/src/app/shared/test_config_parse.c
+++ b/src/app/shared/test_config_parse.c
@@ -2,8 +2,8 @@
 #include "../../ballet/toml/fd_toml.h"
 
 static char const cfg_str_1[] =
-  "[tiles.gossip]\n"
-  "  entrypoints = [\"208.91.106.45\"]";
+  "[gossip]\n"
+  "  entrypoints = [\"208.91.106.45:8080\"]";
 
 static char const cfg_str_2[] =
   "wumbo = \"mini\"";
@@ -27,8 +27,8 @@ main( int     argc,
   static config_t config[1];
   FD_TEST( fdctl_pod_to_cfg( config, pod ) == config );
 
-  FD_TEST( config->tiles.gossip.entrypoints_cnt == 1 );
-  FD_TEST( 0==strcmp( config->tiles.gossip.entrypoints[0], "208.91.106.45" ) );
+  FD_TEST( config->gossip.entrypoints_cnt == 1 );
+  FD_TEST( 0==strcmp( config->gossip.entrypoints[0], "208.91.106.45:8080" ) );
 
   /* Reject unrecognized config keys */
 
@@ -47,16 +47,16 @@ main( int     argc,
 
   /* Ensure we can selectively override a field */
 
-  config->tiles.gossip.gossip_listen_port = 9191;
-  config->tiles.gossip.entrypoints_cnt = 2;
-  strcpy( config->tiles.gossip.entrypoints[0], "foo" );
-  strcpy( config->tiles.gossip.entrypoints[1], "bar" );
+  config->gossip.port = 9191;
+  config->gossip.entrypoints_cnt = 2;
+  strcpy( config->gossip.entrypoints[0], "foo" );
+  strcpy( config->gossip.entrypoints[1], "bar" );
   pod = fd_pod_join( fd_pod_new( pod_mem, sizeof(pod_mem) ) );
   FD_TEST( fd_toml_parse( cfg_str_1, sizeof(cfg_str_1)-1, pod, scratch, sizeof(scratch), NULL ) == FD_TOML_SUCCESS );
   FD_TEST( fdctl_pod_to_cfg( config, pod ) == config );
-  FD_TEST( config->tiles.gossip.entrypoints_cnt == 1 );
-  FD_TEST( 0==strcmp( config->tiles.gossip.entrypoints[0], "208.91.106.45" ) );
-  FD_TEST( config->tiles.gossip.gossip_listen_port == 9191 );  /* unchanged */
+  FD_TEST( config->gossip.entrypoints_cnt == 1 );
+  FD_TEST( 0==strcmp( config->gossip.entrypoints[0], "208.91.106.45:8080" ) );
+  FD_TEST( config->gossip.port == 9191 );  /* unchanged */
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -5,6 +5,7 @@
 #include "../../tango/fd_tango.h"
 #include "../../waltz/xdp/fd_xdp1.h"
 #include "../../ballet/base58/fd_base58.h"
+#include "../../util/net/fd_net_headers.h"
 
 /* Maximum number of workspaces that may be present in a topology. */
 #define FD_TOPO_MAX_WKSPS         (256UL)
@@ -321,15 +322,11 @@ typedef struct {
       float cu_price_spread;
     } benchg;
 
-    /* Firedancer-only tile configs */
-
     struct {
       ushort  gossip_listen_port;
+#     define FD_TOPO_GOSSIP_ENTRYPOINTS_MAX 16
       ulong   entrypoints_cnt;
-      uint    entrypoints[16];
-      ulong   peer_ports_cnt;
-      ushort  peer_ports[16];
-
+      fd_ip4_port_t entrypoints[ FD_TOPO_GOSSIP_ENTRYPOINTS_MAX ];
       uint    ip_addr;
       char    identity_key_path[ PATH_MAX ];
       ushort  tvu_port;

--- a/src/discof/gossip/fd_gossip_tile.c
+++ b/src/discof/gossip/fd_gossip_tile.c
@@ -951,7 +951,7 @@ unprivileged_init( fd_topo_t *      topo,
     FD_LOG_ERR( ( "error setting gossip config" ) );
   }
 
-  fd_gossip_set_entrypoints( ctx->gossip, tile->gossip.entrypoints, tile->gossip.entrypoints_cnt, tile->gossip.peer_ports );
+  fd_gossip_set_entrypoints( ctx->gossip, tile->gossip.entrypoints, tile->gossip.entrypoints_cnt );
 
   fd_gossip_update_addr( ctx->gossip, &ctx->gossip_config.my_addr );
 

--- a/src/discof/restart/test/restart_fd.sh
+++ b/src/discof/restart/test/restart_fd.sh
@@ -37,14 +37,11 @@ echo "
     shred_tile_count = 1
     bank_tile_count = 1
 [gossip]
+    entrypoints = [\"$PRIMARY_IP:8001\"]
     port = 8700
 [tiles]
     [tiles.pack]
         use_consumed_cus = false
-    [tiles.gossip]
-        entrypoints = [\"$PRIMARY_IP\"]
-        peer_ports = [8001]
-        gossip_listen_port = 8700
     [tiles.repair]
         repair_intake_listen_port = 9055
         repair_serve_listen_port = 9056

--- a/src/flamenco/gossip/fd_gossip.c
+++ b/src/flamenco/gossip/fd_gossip.c
@@ -1971,17 +1971,18 @@ fd_gossip_recv(fd_gossip_t * glob, const fd_gossip_peer_addr_t * from, fd_gossip
 
 /* Initiate connection to a peer */
 int
-fd_gossip_add_active_peer( fd_gossip_t * glob, fd_gossip_peer_addr_t * addr ) {
+fd_gossip_add_active_peer( fd_gossip_t *                 glob,
+                           fd_gossip_peer_addr_t const * addr ) {
   fd_gossip_lock( glob );
-  fd_active_elem_t * val = fd_active_table_query(glob->actives, addr, NULL);
-  if (val == NULL) {
-    if (fd_active_table_is_full(glob->actives)) {
-      FD_LOG_WARNING(("too many actives"));
+  fd_active_elem_t * val = fd_active_table_query( glob->actives, addr, NULL );
+  if( val==NULL ) {
+    if( fd_active_table_is_full( glob->actives )) {
+      FD_LOG_WARNING(( "too many actives" ));
       fd_gossip_unlock( glob );
       return -1;
     }
-    val = fd_active_table_insert(glob->actives, addr);
-    fd_active_new_value(val);
+    val = fd_active_table_insert( glob->actives, addr );
+    fd_active_new_value( val );
     val->pingcount = 0; /* Incremented in fd_gossip_make_ping */
   }
   fd_gossip_unlock( glob );
@@ -2516,19 +2517,15 @@ fd_gossip_set_stake_weights( fd_gossip_t * gossip,
 }
 
 void
-fd_gossip_set_entrypoints( fd_gossip_t * gossip,
-                           uint const * entrypoints,
-                           ulong entrypoints_cnt,
-                           ushort const * ports ) {
+fd_gossip_set_entrypoints( fd_gossip_t *         gossip,
+                           fd_ip4_port_t const * entrypoints,
+                           ulong                 entrypoints_cnt ) {
   gossip->entrypoints_cnt = entrypoints_cnt;
-  for( ulong i = 0UL; i<entrypoints_cnt; i++) {
-    fd_gossip_peer_addr_t addr;
-    addr.addr = entrypoints[i];
-    addr.port = fd_ushort_bswap( ports[i] );
+  for( ulong i=0UL; i<entrypoints_cnt; i++ ) {
     FD_LOG_NOTICE(( "gossip initial peer - addr: " FD_IP4_ADDR_FMT ":%u",
-      FD_IP4_ADDR_FMT_ARGS( addr.addr ), fd_ushort_bswap( addr.port ) ));
-    fd_gossip_add_active_peer( gossip, &addr );
-    gossip->entrypoints[i] = addr;
+      FD_IP4_ADDR_FMT_ARGS( entrypoints[i].addr ), fd_ushort_bswap( entrypoints[i].port ) ));
+    fd_gossip_add_active_peer( gossip, &entrypoints[i] );
+    gossip->entrypoints[i] = entrypoints[i];
   }
 }
 

--- a/src/flamenco/gossip/fd_gossip.h
+++ b/src/flamenco/gossip/fd_gossip.h
@@ -4,6 +4,7 @@
 #include "../types/fd_types.h"
 #include "../../util/valloc/fd_valloc.h"
 #include "../../disco/metrics/generated/fd_metrics_gossip.h"
+#include "../../util/net/fd_net_headers.h" /* fd_ip4_port_t */
 
 /* Max number of validators that can be known */
 #define FD_PEER_KEY_MAX (1<<14)
@@ -47,16 +48,7 @@ fd_gossip_t * fd_gossip_join     ( void * shmap );
 void *        fd_gossip_leave    ( fd_gossip_t * join );
 void *        fd_gossip_delete   ( void * shmap );
 
-
-union fd_gossip_peer_addr {
-    struct {
-        uint   addr;  /* IPv4 address, network byte order (big endian) */
-        ushort port;  /* port number, network byte order (big endian) */
-        ushort pad;   /* Must be zero */
-    };
-    ulong l;          /* Combined port and address */
-};
-typedef union fd_gossip_peer_addr fd_gossip_peer_addr_t;
+typedef union fd_ip4_port fd_gossip_peer_addr_t;
 
 int
 fd_gossip_from_soladdr(fd_gossip_peer_addr_t * dst, fd_gossip_socket_addr_t const * src );
@@ -125,7 +117,7 @@ int fd_gossip_update_tpu_vote_addr( fd_gossip_t * glob, const fd_gossip_peer_add
 void fd_gossip_set_shred_version( fd_gossip_t * glob, ushort shred_version );
 
 /* Add a peer to talk to */
-int fd_gossip_add_active_peer( fd_gossip_t * glob, fd_gossip_peer_addr_t * addr );
+int fd_gossip_add_active_peer( fd_gossip_t * glob, fd_gossip_peer_addr_t const * addr );
 
 /* Publish an outgoing value. The source id and wallclock are set by this function. The gossip key for the value is optionally returned. */
 int fd_gossip_push_value( fd_gossip_t * glob, fd_crds_data_t* data, fd_hash_t * key_opt );
@@ -155,10 +147,10 @@ void fd_gossip_set_stake_weights( fd_gossip_t * gossip, fd_stake_weight_t const 
 /* fd_gossip_set_entrypoints sets ip and ports for initial known
    validators to gossip to.  These values are set by the operator
    at startup.  This function should only be called at startup. */
-void fd_gossip_set_entrypoints( fd_gossip_t * gossip,
-                                uint const * allowed_entrypoints, /* big endian ipv4 addresses (allowed_entrypoints_cnt many) */
-                                ulong allowed_entrypoints_cnt,    /* number of allowed entrypoints, assumed to be in [1, FD_ACTIVE_KEY_MAX] */
-                                ushort const * ports );           /* gossip ports of the peers (allowed_entrypoints_cnt many) */
+void
+fd_gossip_set_entrypoints( fd_gossip_t *         gossip,
+                           fd_ip4_port_t const * entrypoints,
+                           ulong                 entrypoint_cnt );
 
 uint fd_gossip_is_allowed_entrypoint( fd_gossip_t * gossip, fd_gossip_peer_addr_t * addr );
 

--- a/src/util/net/fd_net_headers.h
+++ b/src/util/net/fd_net_headers.h
@@ -56,4 +56,14 @@ fd_ip4_udp_hdr_init( fd_ip4_udp_hdrs_t * hdrs,
 
 FD_PROTOTYPES_END
 
+union fd_ip4_port {
+  struct {
+    uint   addr;  /* net order */
+    ushort port;  /* net order */
+  };
+  ulong l;
+};
+
+typedef union fd_ip4_port fd_ip4_port_t;
+
 #endif /* HEADER_fd_src_util_net_headers_h */


### PR DESCRIPTION
Makes gossip tile use the 1.5 configuration for entrypoints (gossip.entrypoints).
Removes the 'peer_ports' separate array for port numbers.

Now accepts FQDN:PORT syntax like "example.org:1234" or "192.168.1.2:1234".

Closes https://github.com/firedancer-io/firedancer/issues/4510
