### PR TITLE
Remove 'make rust' target for full Firedancer

### DIFF
--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -40,7 +40,7 @@ ifdef FD_HAS_NO_AGAVE
 ifdef FD_HAS_SECP256K1
 $(call make-lib,external_functions)
 $(call add-objs,external_functions,external_functions)
-$(call make-bin-rust,fdctl,main,fd_fdctl fdctl_shared fd_discof fd_disco fd_choreo fd_flamenco fd_funk fd_quic fd_tls fd_reedsol fd_ballet fd_waltz fd_tango fd_util external_functions, $(SECP256K1_LIBS))
+$(call make-bin,fdctl,main,fd_fdctl fdctl_shared fd_discof fd_disco fd_choreo fd_flamenco fd_funk fd_quic fd_tls fd_reedsol fd_ballet fd_waltz fd_tango fd_util external_functions, $(SECP256K1_LIBS))
 endif
 else
 $(call make-bin-rust,fdctl,main,fd_fdctl fdctl_shared fd_discoh fd_disco fd_flamenco fd_funk fd_quic fd_tls fd_reedsol fd_ballet fd_waltz fd_tango fd_util agave_validator firedancer_plugin_bundle)

--- a/src/app/fddev/Local.mk
+++ b/src/app/fddev/Local.mk
@@ -13,7 +13,7 @@ $(call add-objs,main1 dev1,fd_fddev)
 
 ifdef FD_HAS_NO_AGAVE
 ifdef FD_HAS_SECP256K1
-$(call make-bin-rust,fddev,main,fd_fddev fd_fdctl fddev_shared fdctl_shared fd_discof fd_disco fd_choreo fd_flamenco fd_funk fd_quic fd_tls fd_reedsol fd_ballet fd_waltz fd_tango fd_util external_functions, $(SECP256K1_LIBS))
+$(call make-bin,fddev,main,fd_fddev fd_fdctl fddev_shared fdctl_shared fd_discof fd_disco fd_choreo fd_flamenco fd_funk fd_quic fd_tls fd_reedsol fd_ballet fd_waltz fd_tango fd_util external_functions, $(SECP256K1_LIBS))
 endif
 else
 $(call make-bin-rust,fddev,main,fd_fddev fd_fdctl fddev_shared fdctl_shared fd_discoh fd_disco agave_validator firedancer_plugin_bundle fd_flamenco fd_funk fd_quic fd_tls fd_reedsol fd_ballet fd_waltz fd_tango fd_util)


### PR DESCRIPTION
Always build fdctl and fddev in 'make all'
