### PR TITLE
quic: reschedule service when any pkt_meta

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -4478,15 +4478,21 @@ fd_quic_pkt_meta_retry( fd_quic_t *          quic,
 
     if( enc_level == ~0u ) return;
 
+    int exit = 0;
     if( force ) {
       /* we're forcing, quit when we've freed enough */
-      if( cnt_freed >= min_freed ) return;
+      if( cnt_freed >= min_freed ) exit = 1;
     } else {
       /* not forcing, so quit if nothing has expired */
       if( expiry > now ) {
-        return;
+        exit = 1;
       }
     }
+
+    if( exit ) {
+      if( expiry != ~0ul ) fd_quic_svc_schedule1( conn, FD_QUIC_SVC_WAIT );
+      return;
+    };
 
     fd_quic_pkt_meta_list_t * sent     = &pool->sent_pkt_meta[enc_level];
     fd_quic_pkt_meta_t *      pkt_meta = sent->head;


### PR DESCRIPTION
Because a connection can be in at most one service queue, we take the earlier timer. However, this means we may have no timer to fire when pkt_meta expire in the future. This PR fixes that - it ensures that if we have any pkt_meta at all, the connection will be scheduled again. 

Note this is quite crude - because the service queues prevent dynamic timers at moment, we aren't rescheduling for the exact expiry of the pkt_meta. However, this at least guarantees we will eventually service this connection once the pkt_meta expires.

We do the rescheduling in pkt_meta_retry(), where we've just searched through the pkt_meta. This relies on conn_service always calling pkt_meta_retry. When that changes, we'll want to make sure this still works.