### PR TITLE
flamenco: cpi deduplicate acc meta presence checks

### DIFF
--- a/src/flamenco/runtime/program/fd_address_lookup_table_program.c
+++ b/src/flamenco/runtime/program/fd_address_lookup_table_program.c
@@ -318,8 +318,8 @@ create_lookup_table( fd_exec_instr_ctx_t *       ctx,
   if( required_lamports>0UL ) {
     // Create account metas
     FD_SPAD_FRAME_BEGIN( ctx->txn_ctx->spad ) {
-      fd_vm_rust_account_meta_t * acct_metas = (fd_vm_rust_account_meta_t *)
-                                                fd_spad_alloc( ctx->txn_ctx->spad, FD_VM_RUST_ACCOUNT_META_ALIGN, 2 * sizeof(fd_vm_rust_account_meta_t) );
+      fd_vm_account_meta_t * acct_metas = (fd_vm_account_meta_t *)
+                                                fd_spad_alloc( ctx->txn_ctx->spad, FD_VM_RUST_ACCOUNT_META_ALIGN, 2 * sizeof(fd_vm_account_meta_t) );
       fd_native_cpi_create_account_meta( payer_key, 1, 1, &acct_metas[0] );
       fd_native_cpi_create_account_meta( lut_key,   0, 1, &acct_metas[1] );
 
@@ -348,8 +348,8 @@ create_lookup_table( fd_exec_instr_ctx_t *       ctx,
   }
 
   FD_SPAD_FRAME_BEGIN( ctx->txn_ctx->spad ) {
-    fd_vm_rust_account_meta_t * acct_metas = ( fd_vm_rust_account_meta_t * )
-                                              fd_spad_alloc( ctx->txn_ctx->spad, FD_VM_RUST_ACCOUNT_META_ALIGN, sizeof(fd_vm_rust_account_meta_t) );
+    fd_vm_account_meta_t * acct_metas = ( fd_vm_account_meta_t * )
+                                              fd_spad_alloc( ctx->txn_ctx->spad, FD_VM_RUST_ACCOUNT_META_ALIGN, sizeof(fd_vm_account_meta_t) );
     fd_native_cpi_create_account_meta( lut_key, 1, 1, &acct_metas[0] );
 
     // Create signers list
@@ -701,8 +701,8 @@ extend_lookup_table( fd_exec_instr_ctx_t *       ctx,
 
     FD_SPAD_FRAME_BEGIN( ctx->txn_ctx->spad ) {
       // Create account metas
-      fd_vm_rust_account_meta_t * acct_metas = (fd_vm_rust_account_meta_t *)
-                                                fd_spad_alloc( ctx->txn_ctx->spad, FD_VM_RUST_ACCOUNT_META_ALIGN, 2 * sizeof(fd_vm_rust_account_meta_t) );
+      fd_vm_account_meta_t * acct_metas = (fd_vm_account_meta_t *)
+                                                fd_spad_alloc( ctx->txn_ctx->spad, FD_VM_RUST_ACCOUNT_META_ALIGN, 2 * sizeof(fd_vm_account_meta_t) );
       fd_native_cpi_create_account_meta( payer_key, 1, 1, &acct_metas[0] );
       fd_native_cpi_create_account_meta( lut_key,   0, 1, &acct_metas[1] );
 

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -950,10 +950,10 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
       instr.discriminant         = fd_system_program_instruction_enum_create_account;
       instr.inner.create_account = create_acct;
 
-      fd_vm_rust_account_meta_t * acct_metas = (fd_vm_rust_account_meta_t*)
+      fd_vm_account_meta_t * acct_metas = (fd_vm_account_meta_t*)
                                                 fd_spad_alloc( instr_ctx->txn_ctx->spad,
                                                                   FD_VM_RUST_ACCOUNT_META_ALIGN,
-                                                                  3UL * sizeof(fd_vm_rust_account_meta_t) );
+                                                                  3UL * sizeof(fd_vm_account_meta_t) );
       fd_native_cpi_create_account_meta( payer_key,       1U, 1U, &acct_metas[ 0UL ] );
       fd_native_cpi_create_account_meta( programdata_key, 1U, 1U, &acct_metas[ 1UL ] );
       fd_native_cpi_create_account_meta( buffer_key,      0U, 1U, &acct_metas[ 2UL ] );
@@ -1761,10 +1761,10 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
           .inner.transfer = required_payment
         };
 
-        fd_vm_rust_account_meta_t * acct_metas = (fd_vm_rust_account_meta_t *)
+        fd_vm_account_meta_t * acct_metas = (fd_vm_account_meta_t *)
                                                   fd_spad_alloc( instr_ctx->txn_ctx->spad,
                                                                     FD_VM_RUST_ACCOUNT_META_ALIGN,
-                                                                    2UL * sizeof(fd_vm_rust_account_meta_t) );
+                                                                    2UL * sizeof(fd_vm_account_meta_t) );
         fd_native_cpi_create_account_meta( payer_key,       1UL, 1UL, &acct_metas[ 0UL ] );
         fd_native_cpi_create_account_meta( programdata_key, 0UL, 1UL, &acct_metas[ 1UL ] );
 

--- a/src/flamenco/runtime/program/fd_native_cpi.c
+++ b/src/flamenco/runtime/program/fd_native_cpi.c
@@ -26,36 +26,6 @@ fd_native_cpi_execute_system_program_instruction( fd_exec_instr_ctx_t * ctx,
     }
   }
 
-  uchar acc_idx_seen[256];
-  memset( acc_idx_seen, 0, 256 );
-
-  instr_info->acct_cnt = (ushort)acct_metas_len;
-  for ( ulong j = 0; j < acct_metas_len; j++ ) {
-    fd_vm_rust_account_meta_t const * acct_meta = &acct_metas[j];
-
-    for ( ulong k = 0; k < ctx->instr->acct_cnt; k++ ) {
-      if ( memcmp( acct_meta->pubkey, ctx->instr->acct_pubkeys[k].uc, sizeof(fd_pubkey_t) ) == 0 ) {
-        instr_info->acct_pubkeys[j]  = ctx->instr->acct_pubkeys[k];
-        instr_info->acct_txn_idxs[j] = ctx->instr->acct_txn_idxs[k];
-        instr_info->acct_flags[j]    = 0;
-        instr_info->accounts[j]      = ctx->instr->accounts[k];
-
-        instr_info->is_duplicate[j] = acc_idx_seen[k];
-        if( FD_LIKELY( !acc_idx_seen[k] ) ) {
-          /* This is the first time seeing this account */
-          acc_idx_seen[k] = 1;
-        }
-
-        if( acct_meta->is_writable ) {
-          instr_info->acct_flags[j] |= FD_INSTR_ACCT_FLAGS_IS_WRITABLE;
-        }
-        if( acct_meta->is_signer ) {
-          instr_info->acct_flags[j] |= FD_INSTR_ACCT_FLAGS_IS_SIGNER;
-        }
-        break;
-      }
-    }
-  }
 
   fd_bincode_encode_ctx_t ctx2;
   uchar buf[4096UL]; // Size that is large enough for the instruction
@@ -68,8 +38,10 @@ fd_native_cpi_execute_system_program_instruction( fd_exec_instr_ctx_t * ctx,
 
   instr_info->data = buf;
   instr_info->data_sz = sizeof(buf);
-  int exec_err = fd_vm_prepare_instruction( ctx->instr, instr_info, ctx, instruction_accounts,
-                                            &instruction_accounts_cnt, signers, signers_cnt );
+  int exec_err = fd_vm_prepare_instruction( ctx->instr, instr_info, ctx,
+                                            acct_metas, acct_metas_len,
+                                            instruction_accounts, &instruction_accounts_cnt,
+                                            signers, signers_cnt );
   if( exec_err != FD_EXECUTOR_INSTR_SUCCESS ) {
     return exec_err;
   }

--- a/src/flamenco/runtime/program/fd_native_cpi.c
+++ b/src/flamenco/runtime/program/fd_native_cpi.c
@@ -7,7 +7,7 @@
 int
 fd_native_cpi_execute_system_program_instruction( fd_exec_instr_ctx_t * ctx,
                                                   fd_system_program_instruction_t const * instr,
-                                                  fd_vm_rust_account_meta_t const * acct_metas,
+                                                  fd_vm_account_meta_t const * acct_metas,
                                                   ulong acct_metas_len,
                                                   fd_pubkey_t const * signers,
                                                   ulong signers_cnt ) {
@@ -79,7 +79,7 @@ fd_native_cpi_execute_system_program_instruction( fd_exec_instr_ctx_t * ctx,
 
 void
 fd_native_cpi_create_account_meta( fd_pubkey_t const * key, uchar is_signer,
-                                   uchar is_writable, fd_vm_rust_account_meta_t * meta ) {
+                                   uchar is_writable, fd_vm_account_meta_t * meta ) {
   meta->is_signer = is_signer;
   meta->is_writable = is_writable;
   fd_memcpy( meta->pubkey, key->key, sizeof(fd_pubkey_t) );

--- a/src/flamenco/runtime/program/fd_native_cpi.h
+++ b/src/flamenco/runtime/program/fd_native_cpi.h
@@ -7,17 +7,17 @@
 
 FD_PROTOTYPES_BEGIN
 
-int 
+int
 fd_native_cpi_execute_system_program_instruction( fd_exec_instr_ctx_t * ctx,
                                                   fd_system_program_instruction_t const * instr,
-                                                  fd_vm_rust_account_meta_t const * acct_metas,
+                                                  fd_vm_account_meta_t const * acct_metas,
                                                   ulong acct_metas_len,
                                                   fd_pubkey_t const * signers,
                                                   ulong signers_cnt );
 
 void
-fd_native_cpi_create_account_meta( fd_pubkey_t const * key, uchar is_signer, 
-                                   uchar is_writable, fd_vm_rust_account_meta_t * meta );
+fd_native_cpi_create_account_meta( fd_pubkey_t const * key, uchar is_signer,
+                                   uchar is_writable, fd_vm_account_meta_t * meta );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/vm/syscall/fd_vm_cpi.h
+++ b/src/flamenco/vm/syscall/fd_vm_cpi.h
@@ -119,6 +119,9 @@ struct __attribute__((packed)) fd_vm_rust_account_info {
 
 typedef struct fd_vm_rust_account_info fd_vm_rust_account_info_t;
 
+/* Use the rust version for internal representation of account meta */
+typedef fd_vm_rust_account_meta_t fd_vm_account_meta_t;
+
 /* These define the in-memory layout of Rc<Refcell<T>> types to
    facilitate checks on Rust AccountInfo fields.
  */

--- a/src/flamenco/vm/syscall/fd_vm_syscall.h
+++ b/src/flamenco/vm/syscall/fd_vm_syscall.h
@@ -724,13 +724,15 @@ typedef struct fd_instruction_account fd_instruction_account_t;
 /* FIXME: DOES THIS GO HERE?  MAYBE GROUP WITH ADMIN OR OUTSIDE SYSCALL? */
 
 int
-fd_vm_prepare_instruction( fd_instr_info_t const *  caller_instr,
-                           fd_instr_info_t *        callee_instr,
-                           fd_exec_instr_ctx_t *    instr_ctx,
-                           fd_instruction_account_t instruction_accounts[256],
-                           ulong *                  instruction_accounts_cnt,
-                           fd_pubkey_t const *      signers,
-                           ulong                    signers_cnt );
+fd_vm_prepare_instruction( fd_instr_info_t const *      caller_instr,
+                           fd_instr_info_t *            callee_instr,
+                           fd_exec_instr_ctx_t *        instr_ctx,
+                           fd_vm_account_meta_t const * caller_account_metas,
+                           ulong                        caller_account_metas_cnt,
+                           fd_instruction_account_t     instruction_accounts[256],
+                           ulong *                      instruction_accounts_cnt,
+                           fd_pubkey_t const *          signers,
+                           ulong                        signers_cnt );
 
 /* syscall(a22b9c85) "sol_invoke_signed_c"
    Dispatch a cross program invocation.  Inputs are in C ABI.

--- a/src/flamenco/vm/syscall/fd_vm_syscall_runtime.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_runtime.c
@@ -539,7 +539,7 @@ fd_vm_syscall_sol_get_processed_sibling_instruction(
         result_meta_haddr->data_len);
 
       ulong accounts_meta_total_size = fd_ulong_sat_mul( result_meta_haddr->accounts_len, FD_VM_RUST_ACCOUNT_META_SIZE );
-      fd_vm_rust_account_meta_t * result_accounts_haddr = FD_VM_MEM_SLICE_HADDR_ST(
+      fd_vm_account_meta_t * result_accounts_haddr = FD_VM_MEM_SLICE_HADDR_ST(
         vm,
         result_accounts_vaddr,
         FD_VM_RUST_ACCOUNT_META_ALIGN,


### PR DESCRIPTION
We check for presence of account metas in transaction accounts twice. This merges the transaction account iterations across the two functions. Also has the added benefit of conforming with Agave's behavior of checking for presence in both transaction accounts list and instruction accounts list in one loop
- **flamenco: type alias for account meta to be used internally**
- **flamenco: (cpi) deduplicate account meta presence**
