### PR TITLE
flamenco: refactor txn_ctx/instr_ctx account getters API

### DIFF
--- a/src/flamenco/runtime/context/fd_exec_instr_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_instr_ctx.c
@@ -82,53 +82,85 @@ fd_exec_instr_ctx_delete( void * mem ) {
 }
 
 int
+fd_exec_instr_ctx_find_idx_of_instr_account( fd_exec_instr_ctx_t const * ctx,
+                                             fd_pubkey_t const *         pubkey ) {
+  for( int i=0; i<ctx->instr->acct_cnt; i++ ) {
+    if( memcmp( pubkey->uc, ctx->instr->acct_pubkeys[i].uc, sizeof(fd_pubkey_t) )==0 ) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+int
 fd_exec_instr_ctx_try_borrow_account( fd_exec_instr_ctx_t const * ctx,
                                       ulong                       idx,
+                                      fd_txn_account_t *          txn_account,
                                       fd_borrowed_account_t *     account ) {
   /* TODO this is slightly wrong. Agave returns NotEnoughAccountKeys when the account index is
      out of bounds in the transaction context and MissingAccount when the account index is out of
      bounds in the instruction context. */
 
-  /* Return a NotEnoughAccountKeys error if the idx is out of bounds.
-     https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L603 */
-  if( FD_UNLIKELY( idx >= ctx->instr->acct_cnt ) ) {
-    return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
-  }
-
-  fd_txn_account_t * instr_account = ctx->instr->accounts[idx];
-
   /* Return an AccountBorrowFailed error if the write is not acquirable.
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L605 */
-  int acquire_result = fd_txn_account_acquire_write( instr_account );
+  int acquire_result = fd_txn_account_acquire_write( txn_account );
   if( FD_UNLIKELY( !acquire_result ) ) {
     return FD_EXECUTOR_INSTR_ERR_ACC_BORROW_FAILED;
   }
 
   /* Create a BorrowedAccount upon success.
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L606 */
-  fd_borrowed_account_init( account, instr_account, ctx, (int)idx );
+  fd_borrowed_account_init( account, txn_account, ctx, (ushort)idx );
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
 
 int
-fd_exec_instr_ctx_try_borrow_account_with_key( fd_exec_instr_ctx_t *   ctx,
-                                               fd_pubkey_t const *     pubkey,
-                                               fd_borrowed_account_t * account ) {
-  for( ulong i = 0; i < ctx->instr->acct_cnt; i++ ) {
-    if( memcmp( pubkey->uc, ctx->instr->acct_pubkeys[i].uc, sizeof(fd_pubkey_t) )==0 ) {
-      return fd_exec_instr_ctx_try_borrow_account( ctx, i, account );
-    }
+fd_exec_instr_ctx_try_borrow_instr_account( fd_exec_instr_ctx_t const * ctx,
+                                            ulong                       idx,
+                                            fd_borrowed_account_t *     account ) {
+  /* Return a NotEnoughAccountKeys error if the idx is out of bounds.
+     https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L603 */
+  if( FD_UNLIKELY( idx>=ctx->instr->acct_cnt ) ) {
+    return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
   }
-  return FD_EXECUTOR_INSTR_ERR_MISSING_ACC;
+
+  fd_txn_account_t * instr_account = ctx->instr->accounts[idx];
+
+  return fd_exec_instr_ctx_try_borrow_account( ctx,
+                                               idx,
+                                               instr_account,
+                                               account );
 }
 
 int
-fd_exec_instr_ctx_find_idx_of_instr_account( fd_exec_instr_ctx_t const * ctx,
-                                             fd_pubkey_t const *         pubkey ) {
-  for( int i = 0; i < ctx->instr->acct_cnt; i++ ) {
+fd_exec_instr_ctx_try_borrow_instr_account_with_key( fd_exec_instr_ctx_t const * ctx,
+                                                     fd_pubkey_t const *         pubkey,
+                                                     fd_borrowed_account_t *     account ) {
+  for( ulong i=0; i<ctx->instr->acct_cnt; i++ ) {
     if( memcmp( pubkey->uc, ctx->instr->acct_pubkeys[i].uc, sizeof(fd_pubkey_t) )==0 ) {
-      return i;
+      return fd_exec_instr_ctx_try_borrow_instr_account( ctx, i, account );
     }
   }
-  return -1;
+
+  /* Return a NotEnoughAccountKeys error if the account is not found
+     in the instruction context to match the error code returned by
+     fd_exec_instr_ctx_try_borrow_instr_account. */
+  return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+}
+
+int
+fd_exec_instr_ctx_try_borrow_last_program_account( fd_exec_instr_ctx_t const * ctx,
+                                                   fd_borrowed_account_t *     account ) {
+  fd_txn_account_t * program_account = NULL;
+  fd_exec_txn_ctx_get_account_at_index( ctx->txn_ctx,
+                                        ctx->instr->program_id,
+                                        &program_account,
+                                        NULL );
+
+  /* The index_in_instruction for a borrowed program account is invalid,
+     so it is set to a sentinel value of USHORT_MAX. */
+  return fd_exec_instr_ctx_try_borrow_account( ctx,
+                                               USHORT_MAX,
+                                               program_account,
+                                               account );
 }

--- a/src/flamenco/runtime/context/fd_exec_instr_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_instr_ctx.h
@@ -41,7 +41,7 @@ struct __attribute__((aligned(8UL))) fd_exec_instr_ctx {
 /* Be careful when using this macro. There may be places where the error
    will need to be handled differently. */
 #define FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( ctx, idx, acc ) do { \
-  int err = fd_exec_instr_ctx_try_borrow_account( ctx, idx, acc );          \
+  int err = fd_exec_instr_ctx_try_borrow_instr_account( ctx, idx, acc );    \
   if( FD_UNLIKELY( err ) ) return err;                                      \
 } while (0)
 
@@ -71,34 +71,14 @@ fd_exec_instr_ctx_delete( void * mem );
 
    https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L490 */
 static inline int
-fd_exec_instr_ctx_check_num_insn_accounts( fd_exec_instr_ctx_t * ctx,
-                                           uint                  expected_accounts ) {
+fd_exec_instr_ctx_check_num_insn_accounts( fd_exec_instr_ctx_t const * ctx,
+                                           uint                        expected_accounts ) {
 
   if( FD_UNLIKELY( ctx->instr->acct_cnt<expected_accounts ) ) {
     return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
   }
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
-
-/* Mirrors Agave function solana_sdk::transaction_context::InstructionContext::try_borrow_account.
-
-   Borrows an account from the instruction context with a given account index.
-
-   https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L594 */
-
-int
-fd_exec_instr_ctx_try_borrow_account( fd_exec_instr_ctx_t const * ctx,
-                                      ulong                       idx,
-                                      fd_borrowed_account_t *     account );
-
-/* A wrapper around fd_exec_instr_ctx_try_borrow_account that accepts an account pubkey.
-
-   Borrows an account from the instruction context with a given pubkey. */
-
-int
-fd_exec_instr_ctx_try_borrow_account_with_key( fd_exec_instr_ctx_t *   ctx,
-                                               fd_pubkey_t const *     pubkey,
-                                               fd_borrowed_account_t * account );
 
 /* Mirrors Agave function solana_sdk::transaction_context::InstructionContext::find_index_of_instruction_account.
 
@@ -110,6 +90,49 @@ fd_exec_instr_ctx_try_borrow_account_with_key( fd_exec_instr_ctx_t *   ctx,
 int
 fd_exec_instr_ctx_find_idx_of_instr_account( fd_exec_instr_ctx_t const * ctx,
                                              fd_pubkey_t const *         pubkey );
+
+/* Mirrors Agave function solana_sdk::transaction_context::InstructionContext::get_number_of_program_accounts.
+
+   Strictly returns 1, as we only support one program account per instruction.
+
+   https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L480-L482 */
+
+static inline ushort
+fd_exec_instr_ctx_get_number_of_program_accounts( fd_exec_instr_ctx_t const * ctx ) {
+  (void) ctx;
+  return 1U;
+}
+
+/* Mirrors Agave function solana_sdk::transaction_context::InstructionContext::try_borrow_account.
+
+   Borrows an account from the instruction context with a given account index.
+
+   https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L594 */
+
+int
+fd_exec_instr_ctx_try_borrow_instr_account( fd_exec_instr_ctx_t const * ctx,
+                                            ulong                       idx,
+                                            fd_borrowed_account_t *     account );
+
+/* A wrapper around fd_exec_instr_ctx_try_borrow_account that accepts an account pubkey.
+
+   Borrows an account from the instruction context with a given pubkey. */
+
+int
+fd_exec_instr_ctx_try_borrow_instr_account_with_key( fd_exec_instr_ctx_t const * ctx,
+                                                     fd_pubkey_t const *         pubkey,
+                                                     fd_borrowed_account_t *     account );
+
+/* Mirrors Agave function solana_sdk::transaction_context::InstructionContext::try_borrow_last_program_account
+
+   Borrows the instruction's program account. Since there is only one program account per
+   instruction, this function simply borrows the instruction's only program account, despite the name.
+
+   https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L616 */
+
+int
+fd_exec_instr_ctx_try_borrow_last_program_account( fd_exec_instr_ctx_t const * ctx,
+                                                   fd_borrowed_account_t *     account );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -1641,7 +1641,7 @@ fd_runtime_finalize_txn( fd_exec_slot_ctx_t *         slot_ctx,
     for( ulong i=0UL; i<txn_ctx->accounts_cnt; i++ ) {
       /* We are only interested in saving writable accounts and the fee
          payer account. */
-      if( !fd_txn_account_is_writable_idx( txn_ctx, (int)i ) && i!=FD_FEE_PAYER_TXN_IDX ) {
+      if( !fd_exec_txn_ctx_account_is_writable_idx( txn_ctx, (int)i ) && i!=FD_FEE_PAYER_TXN_IDX ) {
         continue;
       }
 

--- a/src/flamenco/runtime/fd_system_ids.h
+++ b/src/flamenco/runtime/fd_system_ids.h
@@ -60,7 +60,7 @@ extern const fd_pubkey_t fd_solana_stake_program_buffer_address;
    not be writable.
 
    Whenever Agave changes the reserved account keys set, new feature-gated checks will need to be implemented in
-   `fd_txn_account_is_writable_idx()`, and additional functions will need to be added here.
+   `fd_exec_txn_ctx_account_is_writable_idx()`, and additional functions will need to be added here.
 
    Instead of maintaining a map of sysvars and builtins, Agave recommends checking the sysvar owner account, or checking
    the reserved keys below.

--- a/src/flamenco/runtime/fd_txn_account.h
+++ b/src/flamenco/runtime/fd_txn_account.h
@@ -63,6 +63,12 @@ fd_txn_account_is_executable( fd_txn_account_t const * acct ) {
   return !!acct->const_meta->info.executable;
 }
 
+static inline int
+fd_txn_account_is_mutable( fd_txn_account_t const * acct ) {
+  /* A txn account is mutable if meta is non NULL */
+  return acct->meta != NULL;
+}
+
 /* Setters */
 
 static inline void
@@ -137,7 +143,9 @@ fd_txn_account_acquire_read_is_safe( fd_txn_account_t const * acct ) {
 
 /* fd_txn_account_acquire_write acquires write/exclusive access.
    Causes all other write or read acquire attempts will fail.  Returns 1
-   on success, 0 on failure. */
+   on success, 0 on failure.
+
+   Mirrors a try_borrow_mut() call in Agave. */
 static inline int
 fd_txn_account_acquire_write( fd_txn_account_t * acct ) {
   if( FD_UNLIKELY( !fd_txn_account_acquire_write_is_safe( acct ) ) ) {
@@ -157,7 +165,7 @@ fd_txn_account_release_write( fd_txn_account_t * acct ) {
 }
 
 static inline void
-fd_txn_account_release_write_private(fd_txn_account_t * acct ) {
+fd_txn_account_release_write_private( fd_txn_account_t * acct ) {
   /* Only release if it is not yet released */
   if( !fd_txn_account_acquire_write_is_safe( acct ) ) {
     fd_txn_account_release_write( acct );

--- a/src/flamenco/runtime/info/fd_instr_info.c
+++ b/src/flamenco/runtime/info/fd_instr_info.c
@@ -46,7 +46,7 @@ fd_convert_txn_instr_to_instr( fd_exec_txn_ctx_t *    txn_ctx,
     instr->acct_txn_idxs[i] = acc_idx;
     instr->acct_pubkeys[i]  = account_keys[instr_acc_idxs[i]];
     instr->acct_flags[i]    = 0;
-    if( fd_txn_account_is_writable_idx( txn_ctx, (int)instr_acc_idxs[i]) ) {
+    if( fd_exec_txn_ctx_account_is_writable_idx( txn_ctx, (int)instr_acc_idxs[i]) ) {
         instr->acct_flags[i] |= FD_INSTR_ACCT_FLAGS_IS_WRITABLE;
     }
     if( fd_txn_is_signer( txn_descriptor, instr_acc_idxs[i] ) ) {

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -130,7 +130,10 @@ read_bpf_upgradeable_loader_state_for_program( fd_exec_txn_ctx_t *              
                                                uchar                               program_id,
                                                int *                               opt_err ) {
   fd_txn_account_t * rec = NULL;
-  int err = fd_exec_txn_ctx_get_account_view_idx( txn_ctx, program_id, &rec );
+  int err = fd_exec_txn_ctx_get_account_at_index( txn_ctx,
+                                                  program_id,
+                                                  &rec,
+                                                  fd_txn_account_check_exists );
   if( FD_UNLIKELY( err ) ) {
     *opt_err = err;
     return NULL;
@@ -331,8 +334,6 @@ write_program_data( fd_exec_instr_ctx_t *   instr_ctx,
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
 
-/* solana_sdk::transaction_context::BorrowedAccount::get_state() */
-/* https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L965-L969 */
 fd_bpf_upgradeable_loader_state_t *
 fd_bpf_loader_program_get_state( fd_txn_account_t const * acct,
                                  fd_spad_t *              spad,
@@ -357,8 +358,8 @@ fd_bpf_loader_program_get_state( fd_txn_account_t const * acct,
     return fd_bpf_upgradeable_loader_state_decode( mem, &ctx );
 }
 
-/* set_state() */
-/* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/sdk/src/transaction_context.rs#L976-L985 */
+/* Mirrors solana_sdk::transaction_context::BorrowedAccount::set_state()
+   https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L973 */
 int
 fd_bpf_loader_v3_program_set_state( fd_borrowed_account_t * borrowed_acct,
                                     fd_bpf_upgradeable_loader_state_t * state ) {
@@ -1834,18 +1835,18 @@ int
 fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
   FD_SPAD_FRAME_BEGIN( ctx->txn_ctx->spad ) {
     /* https://github.com/anza-xyz/agave/blob/77daab497df191ef485a7ad36ed291c1874596e5/programs/bpf_loader/src/lib.rs#L491-L529 */
-    fd_txn_account_t * program_account = NULL;
 
-    /* TODO: Agave uses `get_last_program_key`, we should have equivalent semantics:
-       https://github.com//anza-xyz/agave/blob/77daab497df191ef485a7ad36ed291c1874596e5/programs/bpf_loader/src/lib.rs#L491-L492 */
-    fd_pubkey_t const *     program_id      = &ctx->instr->program_id_pubkey;
-    int err = fd_exec_txn_ctx_get_account_view_idx( ctx->txn_ctx, ctx->instr->program_id, &program_account );
-    if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
+    /* https://github.com/anza-xyz/agave/blob/v2.1.14/programs/bpf_loader/src/lib.rs#L403-L404 */
+    fd_guarded_borrowed_account_t program_account;
+    int err = fd_exec_instr_ctx_try_borrow_last_program_account( ctx, &program_account );
+    if( FD_UNLIKELY( err ) ) {
       return err;
     }
 
+    fd_pubkey_t const * program_id = &ctx->instr->program_id_pubkey;
+
     /* Program management instruction */
-    if( FD_UNLIKELY( !memcmp( &fd_solana_native_loader_id, program_account->const_meta->info.owner, sizeof(fd_pubkey_t) ) ) ) {
+    if( FD_UNLIKELY( !memcmp( &fd_solana_native_loader_id, program_account.acct->const_meta->info.owner, sizeof(fd_pubkey_t) ) ) ) {
       if( FD_UNLIKELY( !memcmp( &fd_solana_bpf_loader_upgradeable_program_id, program_id, sizeof(fd_pubkey_t) ) ) ) {
         FD_EXEC_CU_UPDATE( ctx, UPGRADEABLE_LOADER_COMPUTE_UNITS );
         return process_loader_upgradeable_instruction( ctx );
@@ -1870,7 +1871,7 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
     /* https://github.com/anza-xyz/agave/blob/89872fdb074e6658646b2b57a299984f0059cc84/programs/bpf_loader/src/lib.rs#L445-L452 */
     /* Program invocation. Any invalid programs will be caught here or at the program load. */
     if( FD_UNLIKELY( !FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, remove_accounts_executable_flag_checks ) &&
-                     !fd_txn_account_is_executable( program_account ) ) ) {
+                     !fd_borrowed_account_is_executable( &program_account ) ) ) {
       fd_log_collector_msg_literal( ctx, "Program is not executable" );
       return FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID;
     }
@@ -1899,16 +1900,11 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
 
       Every error that comes out of this block is mapped to an InvalidAccountData instruction error in Agave. */
 
-    fd_txn_account_t * program_acc_view = NULL;
-    int                read_result      = fd_exec_txn_ctx_get_account_view_idx( ctx->txn_ctx, ctx->instr->program_id, &program_acc_view );
-    if( FD_UNLIKELY( read_result != FD_ACC_MGR_SUCCESS ) ) {
-      return FD_EXECUTOR_INSTR_ERR_MISSING_ACC;
-    }
-    fd_account_meta_t const * metadata = program_acc_view->const_meta;
+    fd_account_meta_t const * metadata = program_account.acct->const_meta;
     uchar is_deprecated = !memcmp( metadata->info.owner, &fd_solana_bpf_loader_deprecated_program_id, sizeof(fd_pubkey_t) );
 
     if( !memcmp( metadata->info.owner, &fd_solana_bpf_loader_upgradeable_program_id, sizeof(fd_pubkey_t) ) ) {
-      fd_bpf_upgradeable_loader_state_t * program_account_state = fd_bpf_loader_program_get_state( program_account, ctx->txn_ctx->spad, &err );
+      fd_bpf_upgradeable_loader_state_t * program_account_state = fd_bpf_loader_program_get_state( program_account.acct, ctx->txn_ctx->spad, &err );
       if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
         if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, remove_accounts_executable_flag_checks ) ) {
           return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
@@ -1929,7 +1925,10 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
 
       fd_txn_account_t * program_data_account = NULL;
       fd_pubkey_t *      programdata_pubkey   = (fd_pubkey_t *)&program_account_state->inner.program.programdata_address;
-      err = fd_exec_txn_ctx_get_account_executable_view( ctx->txn_ctx, programdata_pubkey, &program_data_account );
+      err = fd_exec_txn_ctx_get_executable_account( ctx->txn_ctx,
+                                                    programdata_pubkey,
+                                                    &program_data_account,
+                                                    fd_txn_account_check_exists );
       if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
         if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, remove_accounts_executable_flag_checks ) ) {
           return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
@@ -2007,6 +2006,9 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
       }
       return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
     }
+
+    /* https://github.com/anza-xyz/agave/blob/v2.1.14/programs/bpf_loader/src/lib.rs#L446 */
+    fd_borrowed_account_drop( &program_account );
 
     return fd_bpf_execute( ctx, prog, is_deprecated );
   } FD_SPAD_FRAME_END;

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.h
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.h
@@ -50,6 +50,12 @@
 
 FD_PROTOTYPES_BEGIN
 
+/* Mirrors solana_sdk::transaction_context::BorrowedAccount::get_state()
+
+   Acts on a fd_txn_account_t for ease of API use.
+
+   https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L965-L969 */
+
 fd_bpf_upgradeable_loader_state_t *
 fd_bpf_loader_program_get_state( fd_txn_account_t const * acc,
                                  fd_spad_t *              spad,

--- a/src/flamenco/runtime/program/fd_bpf_loader_serialization.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_serialization.c
@@ -174,7 +174,7 @@ fd_bpf_loader_input_serialize_aligned( fd_exec_instr_ctx_t *     ctx,
       /* Borrow the account without checking the error, as it is guaranteed to exist
          https://github.com/anza-xyz/agave/blob/v2.1.4/programs/bpf_loader/src/serialization.rs#L225 */
       fd_guarded_borrowed_account_t view_acc;
-      fd_exec_instr_ctx_try_borrow_account( ctx, i, &view_acc );
+      fd_exec_instr_ctx_try_borrow_instr_account( ctx, i, &view_acc );
 
       ulong acc_data_len = view_acc.acct->const_meta->dlen;
 
@@ -236,7 +236,7 @@ fd_bpf_loader_input_serialize_aligned( fd_exec_instr_ctx_t *     ctx,
       /* Borrow the account without checking the error, as it is guaranteed to exist
          https://github.com/anza-xyz/agave/blob/v2.1.4/programs/bpf_loader/src/serialization.rs#L225 */
       fd_guarded_borrowed_account_t view_acc;
-      fd_exec_instr_ctx_try_borrow_account( ctx, i, &view_acc );
+      fd_exec_instr_ctx_try_borrow_instr_account( ctx, i, &view_acc );
 
       /* https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/programs/bpf_loader/src/serialization.rs#L465 */
       fd_account_meta_t const * metadata = view_acc.acct->const_meta;
@@ -473,7 +473,7 @@ fd_bpf_loader_input_serialize_unaligned( fd_exec_instr_ctx_t *     ctx,
     /* Borrow the account without checking the error, as it is guaranteed to exist
          https://github.com/anza-xyz/agave/blob/v2.1.4/programs/bpf_loader/src/serialization.rs#L225 */
     fd_guarded_borrowed_account_t view_acc;
-    fd_exec_instr_ctx_try_borrow_account( ctx, i, &view_acc );
+    fd_exec_instr_ctx_try_borrow_instr_account( ctx, i, &view_acc );
 
     ulong acc_data_len = view_acc.acct->const_meta->dlen;
 
@@ -529,7 +529,7 @@ fd_bpf_loader_input_serialize_unaligned( fd_exec_instr_ctx_t *     ctx,
       /* Borrow the account without checking the error, as it is guaranteed to exist
          https://github.com/anza-xyz/agave/blob/v2.1.4/programs/bpf_loader/src/serialization.rs#L225 */
       fd_guarded_borrowed_account_t view_acc;
-      fd_exec_instr_ctx_try_borrow_account( ctx, i, &view_acc );
+      fd_exec_instr_ctx_try_borrow_instr_account( ctx, i, &view_acc );
 
       fd_account_meta_t const * metadata = view_acc.acct->const_meta;
 

--- a/src/flamenco/runtime/program/fd_config_program.c
+++ b/src/flamenco/runtime/program/fd_config_program.c
@@ -139,7 +139,7 @@ _process_config_instr( fd_exec_instr_ctx_t * ctx ) {
       /* Intentionally don't use the scoping macro here because Anza maps the
          error to missing required signature if the try borrow fails */
       fd_borrowed_account_t signer_account;
-      int borrow_err = fd_exec_instr_ctx_try_borrow_account( ctx, (uchar)counter, &signer_account );
+      int borrow_err = fd_exec_instr_ctx_try_borrow_instr_account( ctx, (uchar)counter, &signer_account );
       if( FD_UNLIKELY( borrow_err ) ) {
         /* Max msg_sz: 33 - 2 + 45 = 76 < 127 => we can use printf */
         fd_log_collector_printf_dangerous_max_127( ctx,

--- a/src/flamenco/runtime/program/fd_loader_v4_program.c
+++ b/src/flamenco/runtime/program/fd_loader_v4_program.c
@@ -775,15 +775,13 @@ fd_loader_v4_program_execute( fd_exec_instr_ctx_t * instr_ctx ) {
       }
     } else {
       /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L489 */
-      fd_txn_account_t * program = NULL;
-      rc = fd_exec_txn_ctx_get_account_view_idx( instr_ctx->txn_ctx, instr_ctx->instr->program_id, &program );
-      if( FD_UNLIKELY( rc ) ) {
-        return rc;
-      }
+      fd_guarded_borrowed_account_t program;
+      rc = fd_exec_instr_ctx_try_borrow_last_program_account( instr_ctx, &program );
+      if( FD_UNLIKELY( rc ) ) return rc;
 
       /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L490 */
       fd_loader_v4_state_t state = {0};
-      rc = fd_loader_v4_get_state( program, &state );
+      rc = fd_loader_v4_get_state( program.acct, &state );
       if( FD_UNLIKELY( rc ) ) {
         return rc;
       }

--- a/src/flamenco/runtime/program/fd_stake_program.c
+++ b/src/flamenco/runtime/program/fd_stake_program.c
@@ -2467,7 +2467,7 @@ get_optional_pubkey( fd_exec_instr_ctx_t *          ctx,
 static int
 get_stake_account( fd_exec_instr_ctx_t const * ctx,
                    fd_borrowed_account_t *     out ) {
-  int err = fd_exec_instr_ctx_try_borrow_account( ctx, 0, out );
+  int err = fd_exec_instr_ctx_try_borrow_instr_account( ctx, 0, out );
   if( FD_UNLIKELY( err ) ) return err;
 
   fd_borrowed_account_t * account = out;

--- a/src/flamenco/runtime/program/fd_system_program_nonce.c
+++ b/src/flamenco/runtime/program/fd_system_program_nonce.c
@@ -838,7 +838,7 @@ fd_system_program_exec_authorize_nonce_account( fd_exec_instr_ctx_t * ctx,
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L484-L485 */
 
   fd_guarded_borrowed_account_t account;
-  err = fd_exec_instr_ctx_try_borrow_account( ctx, 0, &account );
+  err = fd_exec_instr_ctx_try_borrow_instr_account( ctx, 0, &account );
   if( FD_UNLIKELY( err ) ) {
     return err;
   }
@@ -987,7 +987,7 @@ fd_check_transaction_age( fd_exec_txn_ctx_t * txn_ctx ) {
                    (uint)fd_system_program_instruction_enum_advance_nonce_account ) ) {
     return FD_RUNTIME_TXN_ERR_BLOCKHASH_NOT_FOUND;
   }
-  if( FD_UNLIKELY( !fd_txn_account_is_writable_idx( txn_ctx, instr_accts[0] ) ) ) {
+  if( FD_UNLIKELY( !fd_exec_txn_ctx_account_is_writable_idx( txn_ctx, instr_accts[0] ) ) ) {
     return FD_RUNTIME_TXN_ERR_BLOCKHASH_NOT_FOUND;
   }
 

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
@@ -202,7 +202,7 @@ fd_vm_prepare_instruction( fd_instr_info_t const *  caller_instr,
   }
 
   if( FD_FEATURE_ACTIVE( instr_ctx->txn_ctx->slot, instr_ctx->txn_ctx->features, lift_cpi_caller_restriction ) ) {
-    if( FD_UNLIKELY( -1==fd_exec_txn_ctx_find_idx_of_program_account( instr_ctx->txn_ctx, &callee_instr->program_id_pubkey ) ) ) {
+    if( FD_UNLIKELY( -1==fd_exec_txn_ctx_find_index_of_account( instr_ctx->txn_ctx, &callee_instr->program_id_pubkey ) ) ) {
       FD_BASE58_ENCODE_32_BYTES( callee_instr->program_id_pubkey.uc, id_b58 );
       fd_log_collector_msg_many( instr_ctx, 2, "Unknown program ", 16UL, id_b58, id_b58_len );
       FD_TXN_ERR_FOR_LOG_INSTR( instr_ctx->txn_ctx, FD_EXECUTOR_INSTR_ERR_MISSING_ACC, instr_ctx->txn_ctx->instr_err_idx );
@@ -223,7 +223,7 @@ fd_vm_prepare_instruction( fd_instr_info_t const *  caller_instr,
        Borrow the program account here.
        https://github.com/anza-xyz/agave/blob/v2.1.14/program-runtime/src/invoke_context.rs#L436-L437 */
     fd_guarded_borrowed_account_t borrowed_program_account;
-    int err = fd_exec_instr_ctx_try_borrow_account( instr_ctx, (ulong)program_idx, &borrowed_program_account );
+    int err = fd_exec_instr_ctx_try_borrow_instr_account( instr_ctx, (ulong)program_idx, &borrowed_program_account );
     if( FD_UNLIKELY( err ) ) {
       FD_TXN_ERR_FOR_LOG_INSTR( instr_ctx->txn_ctx, err, instr_ctx->txn_ctx->instr_err_idx );
       return err;

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
@@ -156,7 +156,7 @@ VM_SYCALL_CPI_UPDATE_CALLEE_ACC_FUNC( fd_vm_t *                          vm,
      TODO: Agave borrows before this function call. Consider refactoring to borrow the account at the same place as Agave.
      https://github.com/anza-xyz/agave/blob/v2.1.14/programs/bpf_loader/src/syscalls/cpi.rs#L893 */
   fd_guarded_borrowed_account_t callee_acc;
-  err = fd_exec_instr_ctx_try_borrow_account( vm->instr_ctx, instr_acc_idx, &callee_acc );
+  err = fd_exec_instr_ctx_try_borrow_instr_account( vm->instr_ctx, instr_acc_idx, &callee_acc );
   if( FD_UNLIKELY( err ) ) {
     /* No need to do anything if the account is missing from the borrowed accounts cache */
     return FD_VM_SUCCESS;
@@ -555,7 +555,7 @@ VM_SYSCALL_CPI_UPDATE_CALLER_ACC_FUNC( fd_vm_t *                          vm,
       TODO: Agave borrows before entering this function. We should consider doing the same.
       https://github.com/anza-xyz/agave/blob/v2.1.14/programs/bpf_loader/src/syscalls/cpi.rs#L1168-L1169 */
     fd_guarded_borrowed_account_t borrowed_callee_acc;
-    err = fd_exec_instr_ctx_try_borrow_account_with_key( vm->instr_ctx, pubkey, &borrowed_callee_acc );
+    err = fd_exec_instr_ctx_try_borrow_instr_account_with_key( vm->instr_ctx, pubkey, &borrowed_callee_acc );
     if( FD_UNLIKELY( err && ( err != FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT ) ) ) {
       return 1;
     }
@@ -611,7 +611,7 @@ VM_SYSCALL_CPI_UPDATE_CALLER_ACC_FUNC( fd_vm_t *                          vm,
        TODO: Agave borrows before entering this function. We should consider doing the same.
        https://github.com/anza-xyz/agave/blob/v2.1.14/programs/bpf_loader/src/syscalls/cpi.rs#L1168-L1169 */
     fd_guarded_borrowed_account_t borrowed_callee_acc;
-    err = fd_exec_instr_ctx_try_borrow_account_with_key( vm->instr_ctx, pubkey, &borrowed_callee_acc );
+    err = fd_exec_instr_ctx_try_borrow_instr_account_with_key( vm->instr_ctx, pubkey, &borrowed_callee_acc );
     if( FD_UNLIKELY( err && ( err != FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT ) ) ) {
       return 1;
     }


### PR DESCRIPTION
Notable changes:
- simplify txn_ctx account getter APIs to match Agave semantically and allow for users to pass in an account pre-condition checker function.
- Add `try_borrow_last_program_account` in the instr_ctx to match agave semantics and account borrowing checks.