### PR TITLE
feat(repair): implement fec_set_chainer for repair tile

### DIFF
--- a/src/discof/repair/Local.mk
+++ b/src/discof/repair/Local.mk
@@ -1,3 +1,5 @@
 ifdef FD_HAS_SSE
 $(call add-objs,fd_repair_tile,fd_discof)
+$(call add-objs,fd_fec_chainer,fd_discof)
+$(call make-unit-test,test_fec_chainer,test_fec_chainer,fd_discof fd_flamenco fd_ballet fd_util)
 endif

--- a/src/discof/repair/fd_fec_chainer.c
+++ b/src/discof/repair/fd_fec_chainer.c
@@ -1,0 +1,312 @@
+#include "fd_fec_chainer.h"
+
+void *
+fd_fec_chainer_new( void * shmem, ulong fec_max, ulong seed ) {
+
+  if( FD_UNLIKELY( !shmem ) ) {
+    FD_LOG_WARNING(( "NULL mem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, fd_fec_chainer_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned mem" ));
+    return NULL;
+  }
+
+  ulong footprint = fd_fec_chainer_footprint( fec_max );
+  if( FD_UNLIKELY( !footprint ) ) {
+    FD_LOG_WARNING(( "bad fec_max (%lu)", fec_max ));
+    return NULL;
+  }
+
+  fd_wksp_t * wksp = fd_wksp_containing( shmem );
+  if( FD_UNLIKELY( !wksp ) ) {
+    FD_LOG_WARNING(( "shmem must be part of a workspace" ));
+    return NULL;
+  }
+
+  fd_memset( shmem, 0, footprint );
+
+  fd_fec_chainer_t * chainer;
+  int lg_fec_max = fd_ulong_find_msb( fd_ulong_pow2_up( fec_max ) ) + 2; /* +2 for fill ratio <= 0.25 */
+
+  FD_SCRATCH_ALLOC_INIT( l, shmem );
+  chainer         = FD_SCRATCH_ALLOC_APPEND( l, fd_fec_chainer_align(),  sizeof( fd_fec_chainer_t )               );
+  void * ancestry = FD_SCRATCH_ALLOC_APPEND( l, fd_fec_ancestry_align(), fd_fec_ancestry_footprint( fec_max )     );
+  void * frontier = FD_SCRATCH_ALLOC_APPEND( l, fd_fec_frontier_align(), fd_fec_frontier_footprint( fec_max )     );
+  void * orphaned = FD_SCRATCH_ALLOC_APPEND( l, fd_fec_orphaned_align(), fd_fec_orphaned_footprint( fec_max )     );
+  void * pool     = FD_SCRATCH_ALLOC_APPEND( l, fd_fec_pool_align(),     fd_fec_pool_footprint( fec_max )         );
+  void * parents  = FD_SCRATCH_ALLOC_APPEND( l, fd_fec_parents_align(),  fd_fec_parents_footprint( lg_fec_max )   );
+  void * children = FD_SCRATCH_ALLOC_APPEND( l, fd_fec_children_align(), fd_fec_children_footprint( lg_fec_max )  );
+  void * queue    = FD_SCRATCH_ALLOC_APPEND( l, fd_fec_queue_align(),    fd_fec_queue_footprint( fec_max )        );
+  void * out      = FD_SCRATCH_ALLOC_APPEND( l, fd_fec_out_align(),      fd_fec_out_footprint( fec_max )          );
+  FD_TEST( FD_SCRATCH_ALLOC_FINI( l, fd_fec_chainer_align() ) == (ulong)shmem + footprint );
+
+  chainer->ancestry = fd_fec_ancestry_new( ancestry, fec_max, seed );
+  chainer->frontier = fd_fec_frontier_new( frontier, fec_max, seed );
+  chainer->orphaned = fd_fec_orphaned_new( orphaned, fec_max, seed );
+  chainer->pool     = fd_fec_pool_new    ( pool,     fec_max       );
+  chainer->parents  = fd_fec_parents_new ( parents,  lg_fec_max    );
+  chainer->children = fd_fec_children_new( children, lg_fec_max    );
+  chainer->queue    = fd_fec_queue_new   ( queue,    fec_max       );
+  chainer->out      = fd_fec_out_new     ( out,      fec_max       );
+
+  return shmem;
+}
+
+fd_fec_chainer_t *
+fd_fec_chainer_join( void * shfec_chainer ) {
+  fd_fec_chainer_t * chainer = (fd_fec_chainer_t *)shfec_chainer;
+
+  if( FD_UNLIKELY( !chainer ) ) {
+    FD_LOG_WARNING(( "NULL chainer" ));
+    return NULL;
+  }
+
+  chainer->ancestry = fd_fec_ancestry_join( chainer->ancestry );
+  chainer->frontier = fd_fec_frontier_join( chainer->frontier );
+  chainer->orphaned = fd_fec_orphaned_join( chainer->orphaned );
+  chainer->pool     = fd_fec_pool_join    ( chainer->pool     );
+  chainer->parents  = fd_fec_parents_join ( chainer->parents  );
+  chainer->children = fd_fec_children_join( chainer->children );
+  chainer->queue    = fd_fec_queue_join   ( chainer->queue    );
+  chainer->out      = fd_fec_out_join     ( chainer->out      );
+
+  return chainer;
+}
+
+void *
+fd_fec_chainer_leave( fd_fec_chainer_t * chainer ) {
+
+  if( FD_UNLIKELY( !chainer ) ) {
+    FD_LOG_WARNING(( "NULL chainer" ));
+    return NULL;
+  }
+
+  return (void *)chainer;
+}
+
+void *
+fd_fec_chainer_delete( void * shchainer ) {
+  fd_fec_chainer_t * chainer = (fd_fec_chainer_t *)shchainer;
+
+  if( FD_UNLIKELY( !chainer ) ) {
+    FD_LOG_WARNING(( "NULL chainer" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned((ulong)chainer, fd_fec_chainer_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned chainer" ));
+    return NULL;
+  }
+
+  return chainer;
+}
+
+fd_fec_ele_t *
+fd_fec_chainer_init( fd_fec_chainer_t * chainer, ulong slot, uchar merkle_root[static FD_SHRED_MERKLE_ROOT_SZ] ) {
+  FD_TEST( fd_fec_pool_free( chainer->pool ) );
+  fd_fec_ele_t * root = fd_fec_pool_ele_acquire( chainer->pool );
+  FD_TEST( root );
+  root->key           = slot << 32 | ( UINT_MAX-1 ); // maintain invariant that no fec_set_idx=UINT_MAX lives in pool_ele
+  root->slot          = slot;
+  root->fec_set_idx   = UINT_MAX-1;
+  root->data_cnt      = 0;
+  root->data_complete = 1;
+  root->slot_complete = 1;
+  root->parent_off    = 0;
+  memcpy( root->merkle_root, merkle_root, FD_SHRED_MERKLE_ROOT_SZ );
+  memset( root->chained_merkle_root, 0, FD_SHRED_MERKLE_ROOT_SZ );
+
+  /* For the next slot that chains off the init slot, it will use the
+     parent_map and key with slot | UINT_MAX to look for its parent, so
+     we need to provide the artificial parent link between the last
+     fec_set_idx and UINT_MAX. This way it can query for
+     UINT_MAX -> UINT_MAX-1 -> get_pool_ele(UINT_MAX-1)*/
+
+  fd_fec_parent_t * p = fd_fec_parents_insert( chainer->parents, slot << 32 | UINT_MAX );
+  p->parent_key       = (slot << 32) | ( UINT_MAX - 1 );
+
+  fd_fec_frontier_ele_insert( chainer->frontier, root, chainer->pool );
+  return root;
+}
+
+void *
+fd_fec_chainer_fini( fd_fec_chainer_t * chainer ) {
+  return (void *)chainer;
+}
+
+FD_FN_PURE fd_fec_ele_t *
+fd_fec_chainer_query( fd_fec_chainer_t * chainer, ulong slot, uint fec_set_idx ) {
+  ulong key = slot << 32 | fec_set_idx;
+  fd_fec_ele_t * fec;
+  fec =                  fd_fec_frontier_ele_query( chainer->frontier, &key, NULL, chainer->pool );
+  fec = fd_ptr_if( !fec, fd_fec_ancestry_ele_query( chainer->ancestry, &key, NULL, chainer->pool ), fec );
+  fec = fd_ptr_if( !fec, fd_fec_orphaned_ele_query( chainer->orphaned, &key, NULL, chainer->pool ), fec );
+  return fec;
+}
+
+static int
+is_last_fec( ulong key ){
+  return ( (uint)fd_ulong_extract( key, 0, 31 ) & UINT_MAX ) == UINT_MAX; // lol fix
+}
+
+/* chain performs a BFS using chainer->deque to advance the frontier and
+   connect orphaned FECs to the tree. */
+
+static void
+chain( fd_fec_chainer_t * chainer ) {
+  while( FD_LIKELY( !fd_fec_queue_empty( chainer->queue ) ) ) {
+    ulong          key = fd_fec_queue_pop_head( chainer->queue );
+    fd_fec_ele_t * ele = fd_fec_orphaned_ele_query( chainer->orphaned, &key, NULL, chainer->pool );
+
+    if( FD_LIKELY( !ele ) ) continue;
+
+    /* Query for the parent_key. */
+
+    fd_fec_parent_t * parent_key = fd_fec_parents_query( chainer->parents, key, NULL );
+    if( FD_UNLIKELY( !parent_key ) ) continue; /* still orphaned */
+
+    /* If the parent is in the frontier, remove the parent and insert
+       into ancestry.  Otherwise check for parent in ancestry. */
+
+    if( FD_UNLIKELY( is_last_fec( parent_key->parent_key ) ) ) {
+      /* If the parent was the last fec of the previous slot, the parent_key
+         will be UINT_MAX. Need to query for the actual fec_set_idx of the
+         last FEC. This is the double query */
+      parent_key = fd_fec_parents_query( chainer->parents, parent_key->parent_key, NULL );
+      if( !parent_key ) continue; /* still orphaned */
+    }
+
+    fd_fec_ele_t * parent = fd_fec_frontier_ele_remove( chainer->frontier, &parent_key->parent_key, NULL, chainer->pool );
+    if( FD_LIKELY( parent ) ) fd_fec_ancestry_ele_insert( chainer->ancestry, parent, chainer->pool );
+    else parent = fd_fec_ancestry_ele_query( chainer->ancestry, &parent_key->parent_key, NULL, chainer->pool );
+
+    /* If the parent is not in frontier or ancestry, ele is still
+       orphaned. Note it is possible to have inserted ele's parent but
+       have ele still be orphaned, because parent is also orphaned. */
+
+    if( FD_UNLIKELY( !parent ) ) continue;
+
+    /* Remove ele from orphaned. */
+
+    fd_fec_ele_t * remove = fd_fec_orphaned_ele_remove( chainer->orphaned, &ele->key, NULL, chainer->pool );
+    FD_TEST( remove == ele );
+
+    /* Verify the chained merkle root. */
+
+    if ( FD_UNLIKELY( memcmp( ele->chained_merkle_root, parent->merkle_root, FD_SHRED_MERKLE_ROOT_SZ ) ) ) {
+      fd_fec_out_push_tail( chainer->out, (fd_fec_out_t){ .slot = ele->slot, .fec_set_idx = ele->fec_set_idx, .err = FD_FEC_CHAINER_ERR_MERKLE } );
+      continue;
+    }
+
+    /* Insert into frontier (ele is either advancing a fork or starting
+       a new fork) and deliver to `out`. */
+
+    fd_fec_frontier_ele_insert( chainer->frontier, ele, chainer->pool );
+    fd_fec_out_push_tail( chainer->out, (fd_fec_out_t){ .slot = ele->slot, .fec_set_idx = ele->fec_set_idx, .err = FD_FEC_CHAINER_SUCCESS } );
+
+    /* Check whether any of ele's children are orphaned and can be
+       chained into the frontier. */
+
+    /* TODO this BFS can be structured differently without using any
+       additional memory by reusing ele->next. */
+
+    if( FD_UNLIKELY( ele->slot_complete ) ) {
+      fd_fec_children_t * fec_children = fd_fec_children_query( chainer->children, ele->slot, NULL );
+      if( FD_UNLIKELY( !fec_children ) ) continue;
+      for( ulong off = fd_slot_child_offs_const_iter_init( fec_children->child_offs );
+            !fd_slot_child_offs_const_iter_done( off );
+            off = fd_slot_child_offs_const_iter_next( fec_children->child_offs, off ) ) {
+        ulong child_key = (ele->slot + off) << 32; /* always fec_set_idx 0 */
+        fd_fec_ele_t * child = fd_fec_orphaned_ele_query( chainer->orphaned, &child_key, NULL, chainer->pool );
+        if( FD_LIKELY( child ) ) {
+          fd_fec_queue_push_tail( chainer->queue, child_key );
+        }
+      }
+    } else {
+      ulong child_key = (ele->slot << 32) | (ele->key + ele->data_cnt);
+      fd_fec_queue_push_tail( chainer->queue, child_key );
+    }
+  }
+}
+
+fd_fec_ele_t *
+fd_fec_chainer_insert( fd_fec_chainer_t * chainer,
+                       ulong              slot,
+                       uint               fec_set_idx,
+                       uint               data_cnt,
+                       int                data_complete,
+                       int                slot_complete,
+                       ushort             parent_off,
+                       uchar const        merkle_root[static FD_SHRED_MERKLE_ROOT_SZ],
+                       uchar const        chained_merkle_root[static FD_SHRED_MERKLE_ROOT_SZ] ) {
+  ulong key = slot << 32 | fec_set_idx;
+
+  if( FD_UNLIKELY( fd_fec_chainer_query( chainer, slot, fec_set_idx ) ) ) {
+    fd_fec_out_push_tail( chainer->out, (fd_fec_out_t){ slot, fec_set_idx, .err = FD_FEC_CHAINER_ERR_UNIQUE } );
+    return NULL;
+  }
+
+# if FD_FEC_CHAINER_USE_HANDHOLDING
+  FD_TEST( fd_fec_pool_free( chainer->pool ) ); /* FIXME lru? */
+# endif
+
+  fd_fec_ele_t * ele = fd_fec_pool_ele_acquire( chainer->pool );
+  ele->key           = key;
+  ele->slot          = slot;
+  ele->fec_set_idx   = fec_set_idx;
+  ele->data_cnt      = data_cnt;
+  ele->data_complete = data_complete;
+  ele->slot_complete = slot_complete;
+  ele->parent_off    = parent_off;
+  memcpy( ele->merkle_root, merkle_root, FD_SHRED_MERKLE_ROOT_SZ );
+  memcpy( ele->chained_merkle_root, chained_merkle_root, FD_SHRED_MERKLE_ROOT_SZ );
+
+  /* If it is the first FEC set, derive and insert parent_key->key into
+     the parents map and parent_slot->slot into the children map. */
+
+  if ( FD_UNLIKELY( fec_set_idx == 0 ) ) {
+    ulong parent_slot = slot - parent_off;
+
+    fd_fec_parent_t * parent_key = fd_fec_parents_insert( chainer->parents, key );
+    parent_key->parent_key       = (parent_slot << 32) | UINT_MAX;
+
+    fd_fec_children_t * fec_children = fd_fec_children_query( chainer->children, parent_slot, NULL );
+    if( FD_LIKELY( !fec_children ) ) {
+      fec_children = fd_fec_children_insert( chainer->children, parent_slot );
+      fd_slot_child_offs_null( fec_children->child_offs );
+    }
+    fd_slot_child_offs_insert( fec_children->child_offs, parent_off );
+  }
+
+  /* Derive and insert the child_key->key into the parents map. */
+
+  ulong child_key = ( slot << 32 ) | ( fec_set_idx + data_cnt );
+  if( FD_UNLIKELY( slot_complete ) ) {
+
+    /* This is the last FEC set. There is a special case to add
+       a UINT_MAX -> fec_set_idx link because the child slots will chain
+       off of UINT_MAX, but the pool_ele will be keyed on fec_set_idx. */
+
+    fd_fec_parent_t * parent = fd_fec_parents_insert( chainer->parents, slot << 32 | UINT_MAX );
+    parent->parent_key       = key;
+
+  } else {
+
+    /* This is not the last FEC set. */
+    /* Key the child to point to ele (child's parent). */
+
+    fd_fec_parent_t * parent = fd_fec_parents_insert( chainer->parents, child_key );
+    parent->parent_key = key;
+  }
+
+  /* Push ele into the BFS deque and the orphaned map for processing. */
+
+  fd_fec_queue_push_tail( chainer->queue, key );
+  fd_fec_orphaned_ele_insert( chainer->orphaned, ele, chainer->pool );
+
+  chain( chainer );
+
+  return ele;
+}

--- a/src/discof/repair/fd_fec_chainer.h
+++ b/src/discof/repair/fd_fec_chainer.h
@@ -1,0 +1,369 @@
+#ifndef HEADER_fd_src_discof_repair_fd_fec_chainer_h
+#define HEADER_fd_src_discof_repair_fd_fec_chainer_h
+
+/* This provides APIs for chaining FEC sets.  The purpose of the chainer
+   is "chain" FEC sets as they are received asynchronously out-of-order
+   over the network (via Turbine and Repair).  The chainer both
+   validates and reorder these FEC sets, so that they are delivered
+   in-order to the calling application.
+
+   Every FEC set has a parent (the immediately preceding FEC set in the
+   slot or parent slot) and children (immediately succeeding FEC set(s)
+   for the same slot or child slots).  Because of forks, FEC sets can
+   have multiple children, but this will only be true across slots (ie.
+   the parent and child must be different slots).  The chainer treats
+   forks as "concurrent" with no particular order, so the calling
+   application will receive forking FEC sets in the order in which the
+   chainer is able to chain them.
+
+   There is a protocol violation called equivocation (also known as
+   "duplicates") that breaks the invariant that forks must be across
+   slots.  For example, equivocation can result in observing two or more
+   child FEC sets for a given parent FEC set in the same slot.
+   Equivocation can also result in other anomalies such as keying
+   collisions (this is detailed later in the documentation).  The
+   chainer makes a best-effort attempt to detect and error on
+   equivocation. Examples include checking merkle roots chain correctly
+   and checking FEC sets are unique.  Not all cases of equivocation
+   can be detected by the chainer however, as not all the necessary
+   information is yet available at this stage in the validator pipeline.
+   Ultimately, if there is equivocation, it is the responsibility of the
+   consensus module to handle it. */
+
+#include "../../ballet/shred/fd_shred.h"
+
+/* FD_FEC_CHAINER_USE_HANDHOLDING:  Define this to non-zero at compile time
+   to turn on additional runtime checks and logging. */
+
+#ifndef FD_FEC_CHAINER_USE_HANDHOLDING
+#define FD_FEC_CHAINER_USE_HANDHOLDING 1
+#endif
+
+#define FD_FEC_CHAINER_SUCCESS    ( 0)
+#define FD_FEC_CHAINER_ERR_UNIQUE (-1) /* key uniqueness conflict */
+#define FD_FEC_CHAINER_ERR_MERKLE (-2) /* chained merkle root conflict */
+
+/* fd_fec_chainer is a tree-like structure backed by three maps.  At any
+   given point in time, an element (FEC set) in the chainer is in one of
+   three possible positions with respect to the tree: a non-leaf, leaf,
+   or not connected.  This corresponds to the ancestry, frontier, or
+   orphaned maps, respectively.  Therefore, a given element will always
+   be present in exactly one of these maps, depending on where (and
+   whether) it currently is in the tree.
+
+   KEYING
+
+   The chainer keys FEC sets by concatenating the slot with fec_set_idx.
+   This uniquely identifies a FEC set in most cases.  It is possible to
+   receive over the network two or more different FEC sets with the same
+   slot and fec_set_idx due to equivocation as mentioned earlier.  In
+   general, the chainer expects the caller to handle equivocation and
+   assumes unique FEC sets will have unique keys (handholding is
+   available to verify this).
+
+   The map key is an encoding of the slot and fec_set_idx which uniquely
+   keys every FEC set.  The 32 msb of the key are the 32 lsb of the slot
+   and the 32 lsb of the key are the fec_set_idx, except when the FEC
+   set is the last one for the slot, in which case the 32 lsb are set to
+   UINT_MAX. By setting fec_set_idx to UINT_MAX, the chainer can easily
+   query for the last FEC set in any given slot
+
+   A useful property of the keying scheme above is a FEC set can infer
+   the key of its immediate child by adding data_cnt to its fec_set_idx.
+   For example, a FEC set for slot 0, fec_set_idx 0, data_cnt 32 knows
+   its child key is slot 0, fec_set_idx 32. The last FEC set in the slot
+   is special because the child(s) FEC set will have a different slot
+   number, so we know the fec_set_idx will be zero.
+
+   There is one exception to this keying scheme.  When the FEC set is
+   the last one in the slot, an extra insertion to the parent_map is
+   done. In the standard procedure, the second to last fec will create
+   the (n-1, n) entry, and the following child slot will create a
+   (UINT_MAX, 0) entry. Thus we insert an extra entry (n, UINT_MAX) in
+   the parent_map to connect the chain. This double insertion is only
+   done for the parent_map - the pool_ele will have an element with key
+   slot | fec_set_idx, not UINT_MAX.
+
+   Visually, the parent_map / elements looks like this:
+
+      - Arrows denote a child->parent entry in the parent_map.
+
+   parent_map                                             |  pool_ele (slot, fec_set_idx, completes)
+   ──────────────────────────────────────────────────────────────────────────────────────────────────
+   (slot, 0)                                              |  (slot, 0,  0)
+       ▲                                                  |
+       |                                                  |
+   (slot, 32)                                             |  (slot, 32, 0)
+       ▲                                                  |
+       |                                                  |
+   (slot, 64) <-- (slot, UINT_MAX)                        |  (slot, 64, 1)
+                        ▲                                 |
+                        |                                 |
+                  (slot + 1, 0)                           |  (slot + 1, 0, 0)
+                        ▲                                 |
+                        |                                 |
+                  (slot + 1, 32)                          |  (slot + 1, 32, 0)
+                        ▲                                 |
+                        |                                 |
+                  (slot + 1, 64) ◄── (slot + 1, UINT_MAX) |  (slot + 1, 64, 1)
+                        ▲                                 |
+                        | ...                             |
+
+   Thus we will have double entries for the last FEC set in a slot in
+   the parent map, but only one entry in the ancestry/orphan/frontier
+   pool. This means if we want to query for the last FEC set in a slot,
+   we need to query the parent_map twice - once with the fec_set_idx set
+   to UINT_MAX and once with the parent_key of the result.
+
+   INSERTING
+
+   When inserting a new FEC set, the chainer first checks whether the
+   parent is a FEC set already in the frontier map.  This indicates that
+   the new FEC set directly chains off the frontier.  If it does, the
+   parent FEC set is removed, and the new FEC set is inserted into the
+   frontier map.  This is the common case because we expect FEC sets to
+   chain linearly the vast majority (ie. not start new forks), so the
+   new FEC set is simply "advancing" the frontier.  The parent FEC set
+   is also added to the ancestry map, so that every leaf can trace back
+   to the root.
+
+   If the FEC set's parent is not already in the frontier, the chainer
+   checks the ancestry map next.  If the parent is in the ancestry map,
+   the chainer knows that this FEC set is starting a new fork, because
+   it is part of the tree (the ancestry) but not one of the leaves (the
+   frontier).  In this case, the new FEC set is simply inserted into the
+   frontier map, and now the frontier has an additional fork (leaf).
+
+   Lastly, if the FEC set's parent is not in the ancestry map, the
+   chainer knows that this FEC set is orphaned.  It is inserted into the
+   orphaned map for later retry of tree insertion when its ancestors
+   have been inserted.
+
+   Here are some more important details on forks. Note a FEC set can
+   only start a new fork when it is across a slot boundary (different
+   slot than its parent).  It is invalid for two FEC sets to chain off
+   the same parent FEC within the same slot - this would imply there are
+   two FECs keyed by the (same slot, fec_set_idx) combination, which as
+   detailed earlier, is equivocation.  Therefore, only the first FEC set
+   in a slot can start a fork from the last FEC set in a parent slot. We
+   know a FEC set is the first one in a slot when the fec_set_idx is 0,
+   and we know it is the last one when the last shred in the FEC set has
+   the SLOT_COMPLETE flag set.
+
+   QUERYING
+
+   The chainer can fast O(1) query any FEC set using the key.  As
+   mentioned earlier, any FEC set except the last one in a slot can
+   derive its direct child's key and therefore query for it.
+
+   For the special case of the first FEC set in a slot, the chainer can
+   derive the parent key by subtracting the parent_off from the slot and
+   querying for (slot, UINT_MAX).
+
+   CHAINING
+
+   As mentioned in the top-level documentation, the purpose of the
+   chainer is to chain FEC sets.  On insertion, the chainer will attempt
+   to chain as many FEC sets as possible to the frontier.  The chainer
+   does this by conducting a BFS from the just-inserted FEC set, looking
+   for parents and orphans to traverse.  See `chain` in the .c file for
+   the implementation.
+
+   */
+
+typedef struct fd_fec_chainer fd_fec_chainer_t; /* forward decl */
+
+struct fd_fec_ele {
+  ulong  key;  /* map key */
+  ulong  next; /* reserved for use by fd_pool and fd_map_chain */
+
+  ulong  slot;
+  uint   fec_set_idx;
+  uint   data_cnt;
+  int    data_complete;
+  int    slot_complete;
+  ushort parent_off;
+  uchar  merkle_root[FD_SHRED_MERKLE_ROOT_SZ];
+  uchar  chained_merkle_root[FD_SHRED_MERKLE_ROOT_SZ];
+};
+typedef struct fd_fec_ele fd_fec_ele_t;
+
+#define POOL_NAME   fd_fec_pool
+#define POOL_T      fd_fec_ele_t
+#include "../../util/tmpl/fd_pool.c"
+
+#define MAP_NAME    fd_fec_ancestry
+#define MAP_ELE_T   fd_fec_ele_t
+#include "../../util/tmpl/fd_map_chain.c"
+
+#define MAP_NAME    fd_fec_frontier
+#define MAP_ELE_T   fd_fec_ele_t
+#include "../../util/tmpl/fd_map_chain.c"
+
+#define MAP_NAME    fd_fec_orphaned
+#define MAP_ELE_T   fd_fec_ele_t
+#include "../../util/tmpl/fd_map_chain.c"
+
+struct fd_fec_parent {
+  ulong key;
+  ulong parent_key;
+};
+typedef struct fd_fec_parent fd_fec_parent_t;
+
+/* There are no FEC sets for the genesis block, so (0, 0) represents the
+   NULL map key. */
+
+#define MAP_NAME     fd_fec_parents
+#define MAP_T        fd_fec_parent_t
+#define MAP_MEMOIZE  0
+#include "../../util/tmpl/fd_map_dynamic.c"
+
+#define FD_FEC_CHILDREN_MAX (64) /* TODO size this more reasonably */
+FD_STATIC_ASSERT( FD_FEC_CHILDREN_MAX % 64 == 0, FD_FEC_CHILDREN_MAX must be a multiple of 64 bits per word );
+
+#define SET_NAME fd_slot_child_offs
+#define SET_MAX  FD_FEC_CHILDREN_MAX
+#include "../../util/tmpl/fd_set.c"
+
+/* FIXME consider alternate pooled tree-like representation eg. fd_ghost
+   maybe the ghost generic in tmpl? */
+
+struct fd_fec_children {
+  ulong                slot;
+  fd_slot_child_offs_t child_offs[FD_FEC_CHILDREN_MAX / 64];
+};
+typedef struct fd_fec_children fd_fec_children_t;
+
+#define MAP_NAME     fd_fec_children
+#define MAP_T        fd_fec_children_t
+#define MAP_KEY      slot
+#define MAP_MEMOIZE  0
+#include "../../util/tmpl/fd_map_dynamic.c"
+
+#define DEQUE_NAME fd_fec_queue
+#define DEQUE_T    ulong
+#include "../../util/tmpl/fd_deque_dynamic.c"
+
+struct fd_fec_out {
+  ulong slot;
+  uint  fec_set_idx;
+  int   err;
+};
+typedef struct fd_fec_out fd_fec_out_t;
+
+#define DEQUE_NAME fd_fec_out
+#define DEQUE_T    fd_fec_out_t
+#include "../../util/tmpl/fd_deque_dynamic.c"
+
+/* TODO deque probably not needed if reuse ele->next. */
+
+struct __attribute__((aligned(128UL))) fd_fec_chainer {
+  fd_fec_ancestry_t  * ancestry; /* map of key->fec. non-leaves of FEC tree */
+  fd_fec_frontier_t  * frontier; /* map of key->fec. leaves */
+  fd_fec_orphaned_t  * orphaned; /* map of key->fec. FECs not yet inserted to tree */
+  fd_fec_ele_t       * pool;     /* pool of FEC nodes backing the above maps / tree */
+  fd_fec_parent_t    * parents;  /* map of key->parent_key for fast O(1) querying */
+  fd_fec_children_t  * children; /* map of slot->child_offs for fast O(1) querying */
+  ulong              * queue;    /* queue of FEC keys for BFS chaining */
+  fd_fec_out_t       * out;      /* queue of FEC keys to deliver to application */
+};
+
+FD_PROTOTYPES_BEGIN
+
+/* Constructors */
+
+/* fd_fec_chainer_{align,footprint} return the required alignment and
+   footprint of a memory region suitable for use as chainer with up to
+   fec_max elements and slot_max slots. */
+
+FD_FN_CONST static inline ulong
+fd_fec_chainer_align( void ) {
+  return alignof(fd_fec_chainer_t);
+}
+
+FD_FN_CONST static inline ulong
+fd_fec_chainer_footprint( ulong fec_max ) {
+  int lg_fec_max  = fd_ulong_find_msb( fd_ulong_pow2_up( fec_max  ) ) + 2; /* +2 for fill ratio <= 0.25 */
+  return FD_LAYOUT_FINI(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_INIT,
+      alignof(fd_fec_chainer_t), sizeof(fd_fec_chainer_t)                ),
+      fd_fec_ancestry_align(),   fd_fec_ancestry_footprint( fec_max )    ),
+      fd_fec_frontier_align(),   fd_fec_frontier_footprint( fec_max )    ),
+      fd_fec_orphaned_align(),   fd_fec_orphaned_footprint( fec_max )    ),
+      fd_fec_pool_align(),       fd_fec_pool_footprint( fec_max )        ),
+      fd_fec_parents_align(),    fd_fec_parents_footprint( lg_fec_max )  ),
+      fd_fec_children_align(),   fd_fec_children_footprint( lg_fec_max ) ),
+      fd_fec_queue_align(),      fd_fec_queue_footprint( fec_max )       ),
+      fd_fec_out_align(),        fd_fec_out_footprint( fec_max )         ),
+    fd_fec_chainer_align() );
+}
+
+/* fd_fec_chainer_new formats an unused memory region for use as a
+   chainer.  mem is a non-NULL pointer to this region in the local
+   address space with the required footprint and alignment. */
+
+void *
+fd_fec_chainer_new( void * shmem, ulong fec_max, ulong seed );
+
+/* fd_fec_chainer_join joins the caller to the chainer.  chainer points
+   to the first byte of the memory region backing the chainer in the
+   caller's address space.
+
+   Returns a pointer in the local address space to chainer on
+   success. */
+
+fd_fec_chainer_t *
+fd_fec_chainer_join( void * chainer );
+
+/* fd_fec_chainer_leave leaves a current local join.  Returns a pointer
+   to the underlying shared memory region on success and NULL on failure
+   (logs details).  Reasons for failure include chainer is NULL. */
+
+void *
+fd_fec_chainer_leave( fd_fec_chainer_t * chainer );
+
+/* fd_fec_chainer_delete unformats a memory region used as a chainer.
+   Assumes only the nobody is joined to the region.  Returns a pointer
+   to the underlying shared memory region or NULL if used obviously in
+   error (e.g. chainer is obviously not a chainer ... logs details).
+   The ownership of the memory region is transferred to the caller. */
+
+void *
+fd_fec_chainer_delete( void * chainer );
+
+fd_fec_ele_t *
+fd_fec_chainer_init( fd_fec_chainer_t * chainer, ulong slot, uchar merkle_root[static FD_SHRED_MERKLE_ROOT_SZ] );
+
+FD_FN_PURE fd_fec_ele_t *
+fd_fec_chainer_query( fd_fec_chainer_t * chainer, ulong slot, uint fec_set_idx );
+
+/* fd_fec_chainer inserts a new FEC set into chainer.  Returns the newly
+   inserted fd_fec_ele_t, NULL on error.  Inserting this FEC set may
+   result in one or more FEC sets being ready for in-order delivery.
+   Caller can consume these FEC sets via the deque in chainer->out.
+
+   See top-level documentation for further details on insertion. */
+
+fd_fec_ele_t *
+fd_fec_chainer_insert( fd_fec_chainer_t * chainer,
+                       ulong              slot,
+                       uint               fec_set_idx,
+                       uint               data_cnt,
+                       int                data_complete,
+                       int                slot_complete,
+                       ushort             parent_off,
+                       uchar const        merkle_root[static FD_SHRED_MERKLE_ROOT_SZ],
+                       uchar const        chained_merkle_root[static FD_SHRED_MERKLE_ROOT_SZ] );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_discof_repair_fd_fec_chainer_h */

--- a/src/discof/repair/test_fec_chainer.c
+++ b/src/discof/repair/test_fec_chainer.c
@@ -1,0 +1,200 @@
+#include "fd_fec_chainer.h"
+
+void
+test_fec_ordering( fd_wksp_t * wksp ){
+  ulong fec_max = 32;
+
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_fec_chainer_align(), fd_fec_chainer_footprint( fec_max ), 1UL );
+  FD_TEST( mem );
+  fd_fec_chainer_t * chainer = fd_fec_chainer_join( fd_fec_chainer_new( mem, fec_max, 0UL ) );
+
+  uchar mr_root[FD_SHRED_MERKLE_ROOT_SZ] = { 1 };
+  uchar mr1_0  [FD_SHRED_MERKLE_ROOT_SZ] = { 2 };
+  uchar mr1_32 [FD_SHRED_MERKLE_ROOT_SZ] = { 3 };
+  uchar mr2_0  [FD_SHRED_MERKLE_ROOT_SZ] = { 4 };
+  uchar mr2_32 [FD_SHRED_MERKLE_ROOT_SZ] = { 5 };
+  uchar mr3_0  [FD_SHRED_MERKLE_ROOT_SZ] = { 6 };
+  uchar mr3_32 [FD_SHRED_MERKLE_ROOT_SZ] = { 7 };
+  uchar mr3_64 [FD_SHRED_MERKLE_ROOT_SZ] = { 8 };
+
+  /* Receive (0, 64) -> (1, 32) -> (1, 0) -> (2, 0) -> (3, 64) -> (2, 32) -> (3, 32) -> (3, 0) */
+  ulong keys[7] = { 1UL << 32 | 0,
+                    1UL << 32 | 32,
+                    2UL << 32 | 0,
+                    2UL << 32 | 32,
+                    3UL << 32 | 0,
+                    3UL << 32 | 32,
+                    3UL << 32 | 64 };
+
+  fd_fec_ele_t * f0_64 = fd_fec_chainer_init( chainer, 0, mr_root );
+  FD_TEST( fd_fec_frontier_ele_query( chainer->frontier, &f0_64->key, NULL, chainer->pool ) == f0_64 );
+
+  fd_fec_ele_t * f1_32 = fd_fec_chainer_insert( chainer, 1, 32, 32, 1, 1, 1, mr1_32, mr1_0 );
+  FD_TEST( !fd_fec_frontier_ele_query( chainer->frontier, &f1_32->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_ancestry_ele_query( chainer->ancestry, &f1_32->key, NULL, chainer->pool ) );
+  FD_TEST(  fd_fec_orphaned_ele_query( chainer->orphaned, &f1_32->key, NULL, chainer->pool ) == f1_32 );
+
+  fd_fec_ele_t * f1_0 = fd_fec_chainer_insert( chainer, 1, 0, 32, 0, 0, 1, mr1_0, mr_root );
+  FD_TEST( !fd_fec_frontier_ele_query( chainer->frontier, &f1_0->key, NULL, chainer->pool ) );
+  FD_TEST(  fd_fec_ancestry_ele_query( chainer->ancestry, &f1_0->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_orphaned_ele_query( chainer->orphaned, &f1_0->key, NULL, chainer->pool ) );
+
+  FD_TEST(  fd_fec_frontier_ele_query( chainer->frontier, &f1_32->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_ancestry_ele_query( chainer->ancestry, &f1_32->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_orphaned_ele_query( chainer->orphaned, &f1_32->key, NULL, chainer->pool ) );
+
+  fd_fec_ele_t * f2_0 = fd_fec_chainer_insert( chainer, 2, 0, 32, 0, 0, 1, mr2_0, mr1_32 );
+  FD_TEST(  fd_fec_frontier_ele_query( chainer->frontier, &f2_0->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_ancestry_ele_query( chainer->ancestry, &f2_0->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_orphaned_ele_query( chainer->orphaned, &f2_0->key, NULL, chainer->pool ) );
+
+  FD_TEST( !fd_fec_frontier_ele_query( chainer->frontier, &f1_32->key, NULL, chainer->pool ) );
+  FD_TEST(  fd_fec_ancestry_ele_query( chainer->ancestry, &f1_32->key, NULL, chainer->pool ) );
+
+  fd_fec_ele_t * f3_64 = fd_fec_chainer_insert( chainer, 3, 64, 32, 1, 1, 2, mr3_64, mr3_32 );
+  FD_TEST( !fd_fec_frontier_ele_query( chainer->frontier, &f3_64->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_ancestry_ele_query( chainer->ancestry, &f3_64->key, NULL, chainer->pool ) );
+  FD_TEST(  fd_fec_orphaned_ele_query( chainer->orphaned, &f3_64->key, NULL, chainer->pool ) );
+
+  FD_TEST(  fd_fec_frontier_ele_query( chainer->frontier, &f2_0->key, NULL, chainer->pool ) );
+
+  fd_fec_ele_t * f2_32 = fd_fec_chainer_insert( chainer, 2, 32, 32, 1, 1, 1, mr2_32, mr2_0 );
+  FD_TEST(  fd_fec_frontier_ele_query( chainer->frontier, &f2_32->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_ancestry_ele_query( chainer->ancestry, &f2_32->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_orphaned_ele_query( chainer->orphaned, &f2_32->key, NULL, chainer->pool ) );
+
+  FD_TEST(  fd_fec_ancestry_ele_query( chainer->ancestry, &f2_0->key, NULL, chainer->pool ) );
+
+  fd_fec_ele_t * f3_32 = fd_fec_chainer_insert( chainer, 3, 32, 32, 0, 0, 2, mr3_32, mr3_0 );
+  FD_TEST( !fd_fec_frontier_ele_query( chainer->frontier, &f3_32->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_ancestry_ele_query( chainer->ancestry, &f3_32->key, NULL, chainer->pool ) );
+  FD_TEST(  fd_fec_orphaned_ele_query( chainer->orphaned, &f3_32->key, NULL, chainer->pool ) );
+
+  fd_fec_ele_t * f3_0 = fd_fec_chainer_insert( chainer, 3, 0, 32, 0, 0, 2, mr3_0, mr1_32 );
+  FD_TEST( !fd_fec_frontier_ele_query( chainer->frontier, &f3_0->key, NULL, chainer->pool ) );
+  FD_TEST(  fd_fec_ancestry_ele_query( chainer->ancestry, &f3_0->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_orphaned_ele_query( chainer->orphaned, &f3_0->key, NULL, chainer->pool ) );
+
+  FD_TEST(  fd_fec_frontier_ele_query( chainer->frontier, &f3_64->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_orphaned_ele_query( chainer->orphaned, &f3_64->key, NULL, chainer->pool ) );
+  FD_TEST(  fd_fec_ancestry_ele_query( chainer->ancestry, &f3_32->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_orphaned_ele_query( chainer->orphaned, &f3_32->key, NULL, chainer->pool ) );
+
+  ulong i = 0;
+  while ( !fd_fec_out_empty( chainer->out ) ) {
+    fd_fec_out_t out = fd_fec_out_pop_head( chainer->out );
+    ulong        key = out.slot << 32 | out.fec_set_idx;
+    // FD_LOG_NOTICE(( "%lu: (%lu, %u) %lu %lu", i, out.slot, out.fec_set_idx, key, keys[i] ));
+    FD_TEST( out.err == FD_FEC_CHAINER_SUCCESS );
+    FD_TEST( key == keys[i] );
+    i++;
+  }
+
+  fd_fec_out_t actual[1];
+  fd_fec_out_t expected[1];
+
+  /* Chained merkle root conflict for first FEC of slot 4 (doesn't chain
+     correctly off last FEC of slot 3).
+
+     (3, 64) formerly in the frontier now expected to be in the ancestry
+     because (4, 0) is a child. But since (4, 0) is an invalid child, it
+     shouldn't actually be inserted into the frontier. */
+
+  fd_fec_ele_t * f4_0 = fd_fec_chainer_insert( chainer, 4, 0, 32, 0, 0, 1, (uchar[FD_SHRED_MERKLE_ROOT_SZ]){ 9 }, (uchar[FD_SHRED_MERKLE_ROOT_SZ]){ 42 } /* invalid chained merkle root */ );
+  FD_TEST( !fd_fec_frontier_ele_query( chainer->frontier, &f4_0->key, NULL, chainer->pool ) );
+  FD_TEST(  fd_fec_ancestry_ele_query( chainer->ancestry, &f3_64->key, NULL, chainer->pool ) );
+  FD_TEST(  fd_fec_out_cnt( chainer->out ) == 1 );
+  *actual   = fd_fec_out_pop_head( chainer->out );
+  *expected = (fd_fec_out_t){ 4, 0, .err = FD_FEC_CHAINER_ERR_MERKLE };
+  FD_TEST( 0 == memcmp( actual, expected, sizeof(fd_fec_out_t) ) );
+
+  /* Equivocating FEC (slot 3, fec_set_idx 0) that chains off slot 2
+     instead of slot 1 (parent_off = 1 instead of 2) with the correct
+     chained merkle root. */
+
+  fd_fec_ele_t * f3_0_eqvoc = fd_fec_chainer_insert( chainer, 3, 0, 32, 0, 0, 1, (uchar[FD_SHRED_MERKLE_ROOT_SZ]){ 9 }, mr2_32 );
+  FD_TEST( !f3_0_eqvoc );
+  FD_TEST(  fd_fec_out_cnt( chainer->out ) == 1 );
+  *actual   = fd_fec_out_pop_head( chainer->out );
+  *expected = (fd_fec_out_t){ 3, 0, .err = FD_FEC_CHAINER_ERR_UNIQUE };
+  FD_TEST( 0 == memcmp( actual, expected, sizeof(fd_fec_out_t) ) );
+
+  /* TODO more robust testing */
+
+  fd_wksp_free_laddr( fd_fec_chainer_delete( fd_fec_chainer_leave( chainer ) ) );
+
+}
+
+void
+test_single_fec( fd_wksp_t * wksp ){
+  ulong fec_max = 32;
+
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_fec_chainer_align(), fd_fec_chainer_footprint( fec_max ), 1UL );
+  FD_TEST( mem );
+  fd_fec_chainer_t * chainer = fd_fec_chainer_join( fd_fec_chainer_new( mem, fec_max, 0UL ) );
+
+  uchar mr_root[FD_SHRED_MERKLE_ROOT_SZ] = { 1 };
+  uchar mr1_0  [FD_SHRED_MERKLE_ROOT_SZ] = { 2 };
+  uchar mr2_0  [FD_SHRED_MERKLE_ROOT_SZ] = { 4 };
+  uchar mr3_0  [FD_SHRED_MERKLE_ROOT_SZ] = { 6 };
+
+  /* Receive (0, 64) -> (1, 0) -> (3, 0) -> (2, 0)
+     single FEC slots */
+  ulong keys[3] = { 1UL << 32 | 0,
+                    2UL << 32 | 0,
+                    3UL << 32 | 0 };
+
+  fd_fec_ele_t * f0_64 = fd_fec_chainer_init( chainer, 0, mr_root );
+  FD_TEST( fd_fec_frontier_ele_query( chainer->frontier, &f0_64->key, NULL, chainer->pool ) == f0_64 );
+
+  fd_fec_ele_t * f1_0 = fd_fec_chainer_insert( chainer, 1, 0, 32, 1, 1, 1, mr1_0, mr_root );
+  FD_TEST( fd_fec_frontier_ele_query( chainer->frontier, &f1_0->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_ancestry_ele_query( chainer->ancestry, &f1_0->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_orphaned_ele_query( chainer->orphaned, &f1_0->key, NULL, chainer->pool ) );
+
+  fd_fec_ele_t * f3_0 = fd_fec_chainer_insert( chainer, 3, 0, 32, 1, 1, 1, mr3_0, mr2_0 );
+  FD_TEST( !fd_fec_frontier_ele_query( chainer->frontier, &f3_0->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_ancestry_ele_query( chainer->ancestry, &f3_0->key, NULL, chainer->pool ) );
+  FD_TEST( fd_fec_orphaned_ele_query( chainer->orphaned, &f3_0->key, NULL, chainer->pool ) );
+
+  FD_TEST( fd_fec_frontier_ele_query( chainer->frontier, &f1_0->key, NULL, chainer->pool ) );
+
+  fd_fec_ele_t * f2_0 = fd_fec_chainer_insert( chainer, 2, 0, 32, 1, 1, 1, mr2_0, mr1_0 );
+  FD_TEST( !fd_fec_frontier_ele_query( chainer->frontier, &f2_0->key, NULL, chainer->pool ) );
+  FD_TEST( fd_fec_ancestry_ele_query( chainer->ancestry, &f2_0->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_orphaned_ele_query( chainer->orphaned, &f2_0->key, NULL, chainer->pool ) );
+
+  FD_TEST( fd_fec_frontier_ele_query( chainer->frontier, &f3_0->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_ancestry_ele_query( chainer->ancestry, &f3_0->key, NULL, chainer->pool ) );
+  FD_TEST( !fd_fec_orphaned_ele_query( chainer->orphaned, &f3_0->key, NULL, chainer->pool ) );
+
+  ulong i = 0;
+  while ( !fd_fec_out_empty( chainer->out ) ) {
+    fd_fec_out_t out = fd_fec_out_pop_head( chainer->out );
+    ulong        key = out.slot << 32 | out.fec_set_idx;
+    // FD_LOG_NOTICE(( "%lu: (%lu, %u) %lu %lu", i, out.slot, out.fec_set_idx, key, keys[i] ));
+    FD_TEST( out.err == FD_FEC_CHAINER_SUCCESS );
+    FD_TEST( key == keys[i] );
+    i++;
+  }
+
+  fd_wksp_free_laddr( fd_fec_chainer_delete( fd_fec_chainer_leave( chainer ) ) );
+
+}
+
+int
+main( int argc, char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  ulong  page_cnt  = 1;
+  char * _page_sz  = "gigantic";
+  ulong  numa_idx  = fd_shmem_numa_idx( 0 );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  FD_TEST( wksp );
+
+  test_fec_ordering( wksp );
+  test_single_fec( wksp );
+
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
This provides APIs for chaining FEC sets.  Every FEC set has a parent (the immediately preceding FEC set in the slot or parent slot) and children (immediately succeeding FEC set(s) for the same slot or child slots).

The purpose of the chainer is connect FEC set parents with their children as they are received asynchronously out-of-order from the network via Turbine and Repair, and to both validate and deliver these FEC sets in-order to the caling application.

Because of forks, FEC sets can have multiple children, but this will only be true across slots (ie. the parent and child must be different slots). There is a protocol violation called equivocation (also known as "duplicates") that can break this invariant.  Equivocation can also result in other anomalies such as keying collisions (doc later). The chainer makes a best-effort attempt to detect and validate equivocation.  Examples include checking merkle roots chain correctly and checking FEC sets do not overlap.  Not all cases of equivocation can be detected by the chainer however, as not all the necessary information is available at this stage in the validator pipeline. Ultimately, if there is equivocation, it is the responsibility of the consensus module to finalize handling.