### PR TITLE
ballet: use wider key type in fd_sbpf_syscalls

### DIFF
--- a/contrib/test/test-vectors-fixtures/elf-loader-fixtures/elf-loader-fixtures.list
+++ b/contrib/test/test-vectors-fixtures/elf-loader-fixtures/elf-loader-fixtures.list
@@ -195,3 +195,4 @@ dump/test-vectors/elf_loader/fixtures/9994b7390f6cabbbba4ec1dd2f0aad49.00000532.
 dump/test-vectors/elf_loader/fixtures/d7f6c3e47c2728b762dc6ad701517a06.0000086a.honggfuzz.fix
 dump/test-vectors/elf_loader/fixtures/ffb92cef69b61454f0a9adba40bd553a.0000053a.honggfuzz.fix
 dump/test-vectors/elf_loader/fixtures/8db0b4fdfe6345f79f8e86a8c6e94bfa.00000876.honggfuzz.fix
+dump/test-vectors/elf_loader/fixtures/zero_key_syscall_hash.fix

--- a/src/ballet/sbpf/fd_sbpf_loader.c
+++ b/src/ballet/sbpf/fd_sbpf_loader.c
@@ -1009,7 +1009,7 @@ fd_sbpf_r_bpf_64_32( fd_sbpf_loader_t   const * loader,
 
     /* Check for collision with syscall ID
        https://github.com/solana-labs/rbpf/blob/57139e9e1fca4f01155f7d99bc55cdcc25b0bc04/src/program.rs#L142-L146 */
-    REQUIRE( !fd_sbpf_syscalls_query( loader->syscalls, hash, NULL ) );
+    REQUIRE( !fd_sbpf_syscalls_query( loader->syscalls, (ulong)hash, NULL ) );
     V = (uint)hash;
   } else {
     /* FIXME Should cache Murmur hashes.
@@ -1020,7 +1020,7 @@ fd_sbpf_r_bpf_64_32( fd_sbpf_loader_t   const * loader,
     /* Ensure that requested syscall ID exists only when deploying
        https://github.com/solana-labs/rbpf/blob/v0.8.0/src/elf.rs#L1097 */
     if ( FD_UNLIKELY( loader->elf_deploy_checks ) ) {
-      REQUIRE( fd_sbpf_syscalls_query( loader->syscalls, hash, NULL ) );
+      REQUIRE( fd_sbpf_syscalls_query( loader->syscalls, (ulong)hash, NULL ) );
     }
 
     V = hash;
@@ -1101,7 +1101,7 @@ fd_sbpf_hash_calls( fd_sbpf_loader_t *    loader,
     uint pc_hash = fd_pchash( (uint)target_pc );
     /* Check for collision with syscall ID
        https://github.com/solana-labs/rbpf/blob/57139e9e1fca4f01155f7d99bc55cdcc25b0bc04/src/program.rs#L142-L146 */
-    REQUIRE( !fd_sbpf_syscalls_query( loader->syscalls, pc_hash, NULL ) );
+    REQUIRE( !fd_sbpf_syscalls_query( loader->syscalls, (ulong)pc_hash, NULL ) );
 
     FD_STORE( uint, ptr+4UL, pc_hash );
   }

--- a/src/ballet/sbpf/fd_sbpf_loader.h
+++ b/src/ballet/sbpf/fd_sbpf_loader.h
@@ -57,8 +57,13 @@ typedef int
 #define FD_SBPF_SYSCALLS_LG_SLOT_CNT (7)
 #define FD_SBPF_SYSCALLS_SLOT_CNT    (1UL<<FD_SBPF_SYSCALLS_LG_SLOT_CNT)
 
+/* The syscalls map keys should technically be of type uint since they are
+   just murmur32 hashes. However, Agave's BTree allows the full range to be
+   used as a key [0, UINT_MAX]. So we need to define a wider key type to
+   allow for a NULL value that is outside this range. We use ulong here. */
+
 struct fd_sbpf_syscalls {
-  uint                   key;  /* Murmur3-32 hash of function name */
+  ulong                  key;  /* Murmur3-32 hash of function name */
   fd_sbpf_syscall_func_t func; /* Function pointer */
   char const *           name; /* Infinite lifetime pointer to function name */
 };
@@ -67,9 +72,9 @@ typedef struct fd_sbpf_syscalls fd_sbpf_syscalls_t;
 
 #define MAP_NAME              fd_sbpf_syscalls
 #define MAP_T                 fd_sbpf_syscalls_t
-#define MAP_KEY_T             uint
-#define MAP_KEY_NULL          0U
-#define MAP_KEY_INVAL(k)      !(k)
+#define MAP_HASH_T            ulong
+#define MAP_KEY_NULL          ULONG_MAX         /* Any number greater than UINT_MAX works */
+#define MAP_KEY_INVAL(k)      ( k > UINT_MAX )  /* Force keys to uint size */
 #define MAP_KEY_EQUAL(k0,k1)  (k0)==(k1)
 #define MAP_KEY_EQUAL_IS_SLOW 0
 #define MAP_KEY_HASH(k)       (k)

--- a/src/ballet/sbpf/fuzz_sbpf_loader.c
+++ b/src/ballet/sbpf/fuzz_sbpf_loader.c
@@ -50,7 +50,7 @@ LLVMFuzzerTestOneInput( uchar const * data,
   FD_TEST( syscalls );
 
   for( uint const * x = _syscalls; *x; x++ )
-    fd_sbpf_syscalls_insert( syscalls, *x );
+    fd_sbpf_syscalls_insert( syscalls, (ulong)*x );
 
   /* Load program */
   int res = fd_sbpf_program_load( prog, data, size, syscalls, 0 );

--- a/src/ballet/sbpf/test_sbpf_load_prog.c
+++ b/src/ballet/sbpf/test_sbpf_load_prog.c
@@ -89,7 +89,7 @@ main( int     argc,
   /* Load and reloc program */
 
   for( uint const * x = _syscalls; *x; x++ )
-    fd_sbpf_syscalls_insert( syscalls, *x );
+    fd_sbpf_syscalls_insert( syscalls, (ulong)*x );
 
   int load_err = fd_sbpf_program_load( prog, bin_buf, bin_sz, syscalls, 1 );
 

--- a/src/ballet/sbpf/test_sbpf_loader.c
+++ b/src/ballet/sbpf/test_sbpf_loader.c
@@ -51,7 +51,7 @@ void test_duplicate_entrypoint_entry( void ) {
 
   fd_sbpf_syscalls_t * syscalls = fd_sbpf_syscalls_new( fd_valloc_malloc( valloc, fd_sbpf_syscalls_align(), fd_sbpf_syscalls_footprint() ));
   for( uint const * x = _syscalls; *x; x++ )
-      fd_sbpf_syscalls_insert( syscalls, *x );
+      fd_sbpf_syscalls_insert( syscalls, (ulong)*x );
 
   int res = fd_sbpf_program_load( prog, duplicate_entrypoint_entry_elf, duplicate_entrypoint_entry_elf_sz, syscalls, /* deploy checks */ 1 );
   FD_TEST( res == 0 );

--- a/src/flamenco/runtime/tests/fd_vm_test.c
+++ b/src/flamenco/runtime/tests/fd_vm_test.c
@@ -156,11 +156,9 @@ do{
                                0 );
 
   for( ulong i=0; i< fd_sbpf_syscalls_slot_cnt(); i++ ){
-    fd_sbpf_syscalls_t * syscall = fd_sbpf_syscalls_query( syscalls, syscalls[i].key, NULL );
-    if ( !syscall ) {
-      continue;
+    if( !fd_sbpf_syscalls_key_inval( syscalls[i].key ) ) {
+      syscalls[i].func = fd_vm_syscall_noop;
     }
-    syscall->func = fd_vm_syscall_noop;
   }
 
   /* Setup trace */

--- a/src/flamenco/vm/fd_vm.c
+++ b/src/flamenco/vm/fd_vm.c
@@ -118,7 +118,7 @@ fd_vm_strerror( int err ) {
   case FD_VM_ERR_SIGCOST:     return "SIGCOST compute unit limit exceeded";
   case FD_VM_ERR_SIGFPE:      return "SIGFPE division by zero";
   case FD_VM_ERR_SIGFPE_OF:   return "SIGFPE division overflow";
-  case FD_VM_ERR_SIGSYSCALL:  return "SIGSYSCALL syscall error"; 
+  case FD_VM_ERR_SIGSYSCALL:  return "SIGSYSCALL syscall error";
   case FD_VM_ERR_SIGABORT:    return "SIGABORT abort error";
 
   /* VM validate error codes */
@@ -443,7 +443,7 @@ fd_vm_validate( fd_vm_t const * vm ) {
       }
       uint syscall_key = FD_VM_SBPF_STATIC_SYSCALLS_LIST[ imm ];
       /* check active syscall */
-      fd_sbpf_syscalls_t const * syscall = fd_sbpf_syscalls_query_const( vm->syscalls, syscall_key, NULL );
+      fd_sbpf_syscalls_t const * syscall = fd_sbpf_syscalls_query_const( vm->syscalls, (ulong)syscall_key, NULL );
       if( FD_UNLIKELY( !syscall ) ) {
         return FD_VM_INVALID_SYSCALL;
       }

--- a/src/flamenco/vm/fd_vm_disasm.c
+++ b/src/flamenco/vm/fd_vm_disasm.c
@@ -146,7 +146,7 @@ fd_vm_disasm_instr_jmp( fd_sbpf_instr_t            instr,
   if( FD_UNLIKELY( instr.opcode.normal.op_mode==FD_SBPF_OPCODE_JMP_OP_MODE_CALL ) ) {
     switch ( instr.opcode.normal.op_src ) {
     case FD_SBPF_OPCODE_SOURCE_MODE_IMM: {
-      fd_sbpf_syscalls_t const * syscall = syscalls ? fd_sbpf_syscalls_query_const( syscalls, instr.imm, NULL ) : NULL;
+      fd_sbpf_syscalls_t const * syscall = syscalls ? fd_sbpf_syscalls_query_const( syscalls, (ulong)instr.imm, NULL ) : NULL;
       if( syscall ) { /* FIXME: THESE CODE PATHS CURRENTLY NOT EXERCISED BY UNIT TEST */
         char const * name = syscall->name;
         if( name ) OUT_PRINTF( "syscall%s %s",     suffix, name      );

--- a/src/flamenco/vm/fd_vm_interp_core.c
+++ b/src/flamenco/vm/fd_vm_interp_core.c
@@ -764,7 +764,7 @@ interp_exec:
 
   FD_VM_INTERP_BRANCH_BEGIN(0x85depr) { /* FD_SBPF_OP_CALL_IMM */
 
-    fd_sbpf_syscalls_t const * syscall = imm!=fd_sbpf_syscalls_key_null() ? fd_sbpf_syscalls_query_const( syscalls, imm, NULL ) : NULL;
+    fd_sbpf_syscalls_t const * syscall = imm!=fd_sbpf_syscalls_key_null() ? fd_sbpf_syscalls_query_const( syscalls, (ulong)imm, NULL ) : NULL;
     if( FD_UNLIKELY( !syscall ) ) { /* Optimize for the syscall case */
 
       /* Note we do the stack push before updating the pc(*). This implies
@@ -927,7 +927,7 @@ interp_exec:
   FD_VM_INTERP_BRANCH_BEGIN(0x95) { /* FD_SBPF_OP_SYSCALL */
     /* imm has already been validated to not overflow */
     uint syscall_key = FD_VM_SBPF_STATIC_SYSCALLS_LIST[ imm ];
-    fd_sbpf_syscalls_t const * syscall = fd_sbpf_syscalls_query_const( syscalls, syscall_key, NULL );
+    fd_sbpf_syscalls_t const * syscall = fd_sbpf_syscalls_query_const( syscalls, (ulong)syscall_key, NULL );
 
     /* this check is probably useless, as validation includes checking that the
        syscall is active in this epoch.

--- a/src/flamenco/vm/syscall/fd_vm_syscall.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall.c
@@ -6,7 +6,7 @@ fd_vm_syscall_register( fd_sbpf_syscalls_t *   syscalls,
                         fd_sbpf_syscall_func_t func ) {
   if( FD_UNLIKELY( (!syscalls) | (!name) ) ) return FD_VM_ERR_INVAL;
 
-  fd_sbpf_syscalls_t * syscall = fd_sbpf_syscalls_insert( syscalls, fd_murmur3_32( name, strlen( name ), 0U ) );
+  fd_sbpf_syscalls_t * syscall = fd_sbpf_syscalls_insert( syscalls, (ulong)fd_murmur3_32( name, strlen( name ), 0U ) );
   if( FD_UNLIKELY( !syscall ) ) return FD_VM_ERR_INVAL; /* name (or hash of name) already in map */
 
   syscall->func = func;


### PR DESCRIPTION
Agave's syscall map implementation considers the full u32 range [0, UINT_MAX] as valid key entries, whereas firedancer's map reserves one value as the NULL key (i.e., 0). This means 0 is a valid entry in the Agave map and not ours. To fit the full range, we use a ulong key instead and define a value outside of the uint range to be the null key (i.e., ULONG_MAX)
