### PR TITLE
add an additional check on the upper bound of the shred34 shred count

### DIFF
--- a/src/discof/store/fd_storei_tile.c
+++ b/src/discof/store/fd_storei_tile.c
@@ -289,7 +289,7 @@ after_frag( fd_store_tile_ctx_t * ctx,
   }
 
   /* everything else is shred */
-  FD_TEST( ctx->s34_buffer->shred_cnt>0UL );
+  FD_TEST( (ctx->s34_buffer->shred_cnt>0UL) & (ctx->s34_buffer->shred_cnt<=34UL) );
 
   if( FD_UNLIKELY( ctx->is_trusted ) ) {
     /* this slot is coming from our leader pipeline */


### PR DESCRIPTION
shred34 can contain up to 34 shreds, so a check was added to enforce this