### PR TITLE
flamenco: clean up instr info

### DIFF
--- a/src/ballet/txn/fd_txn.h
+++ b/src/ballet/txn/fd_txn.h
@@ -724,7 +724,7 @@ fd_txn_parse( uchar const * payload, ulong payload_sz, void * out_buf, fd_txn_pa
 */
 
 static inline int
-fd_txn_is_writable( fd_txn_t const * txn, int idx ) {
+fd_txn_is_writable( fd_txn_t const * txn, ushort idx ) {
   if (txn->transaction_version == FD_TXN_V0 && idx >= txn->acct_addr_cnt) {
     if (idx < (txn->acct_addr_cnt + txn->addr_table_adtl_writable_cnt)) {
       return 1;

--- a/src/flamenco/log_collector/fd_log_collector.h
+++ b/src/flamenco/log_collector/fd_log_collector.h
@@ -164,7 +164,7 @@ fd_log_collector_msg( fd_exec_instr_ctx_t * ctx,
 
 /* fd_log_collector_msg_many logs a msg supplied as many
    buffers.  msg := msg0 | msg1 | ... | msgN
-   
+
    num_buffers informs the number of (char const * msg, ulong sz) pairs
    in the function call.
    NOTE: you must explicitly pass in ulong values for sz, either by cast
@@ -387,8 +387,9 @@ fd_log_collector_program_invoke( fd_exec_instr_ctx_t * ctx ) {
     return;
   }
 
+  fd_pubkey_t const * program_id_pubkey = &ctx->txn_ctx->account_keys[ ctx->instr->program_id ];
   /* Cache ctx->program_id_base58 */
-  fd_base58_encode_32( ctx->instr->program_id_pubkey.uc, NULL, ctx->program_id_base58 );
+  fd_base58_encode_32( program_id_pubkey->uc, NULL, ctx->program_id_base58 );
   /* Max msg_sz: 22 - 4 + 44 + 10 = 72 < 127 => we can use printf */
   fd_log_collector_printf_dangerous_max_127( ctx, "Program %s invoke [%u]", ctx->program_id_base58, ctx->depth+1 );
 }

--- a/src/flamenco/runtime/context/fd_exec_instr_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_instr_ctx.c
@@ -85,7 +85,8 @@ int
 fd_exec_instr_ctx_find_idx_of_instr_account( fd_exec_instr_ctx_t const * ctx,
                                              fd_pubkey_t const *         pubkey ) {
   for( int i=0; i<ctx->instr->acct_cnt; i++ ) {
-    if( memcmp( pubkey->uc, ctx->instr->acct_pubkeys[i].uc, sizeof(fd_pubkey_t) )==0 ) {
+    ushort idx_in_txn = ctx->instr->accounts[ i ].index_in_transaction;
+    if( memcmp( pubkey->uc, ctx->txn_ctx->account_keys[ idx_in_txn ].uc, sizeof(fd_pubkey_t) )==0 ) {
       return i;
     }
   }
@@ -93,13 +94,47 @@ fd_exec_instr_ctx_find_idx_of_instr_account( fd_exec_instr_ctx_t const * ctx,
 }
 
 int
+fd_exec_instr_ctx_get_key_of_account_at_index( fd_exec_instr_ctx_t const * ctx,
+                                               ushort                      idx_in_instr,
+                                               fd_pubkey_t const * *       key ) {
+  ushort idx_in_txn;
+  int err = fd_exec_instr_ctx_get_index_of_instr_account_in_transaction( ctx,
+                                                                         idx_in_instr,
+                                                                         &idx_in_txn );
+  if( FD_UNLIKELY( err ) ) {
+    return err;
+  }
+
+  return fd_exec_txn_ctx_get_key_of_account_at_index( ctx->txn_ctx,
+                                                      idx_in_txn,
+                                                      key );
+}
+
+int
+fd_exec_instr_ctx_get_last_program_key( fd_exec_instr_ctx_t const * ctx,
+                                        fd_pubkey_t const * *       key ) {
+  return fd_exec_txn_ctx_get_key_of_account_at_index( ctx->txn_ctx,
+                                                      ctx->instr->program_id,
+                                                      key );
+}
+
+int
 fd_exec_instr_ctx_try_borrow_account( fd_exec_instr_ctx_t const * ctx,
-                                      ulong                       idx,
-                                      fd_txn_account_t *          txn_account,
+                                      ushort                      idx_in_instr,
+                                      ushort                      idx_in_txn,
                                       fd_borrowed_account_t *     account ) {
-  /* TODO this is slightly wrong. Agave returns NotEnoughAccountKeys when the account index is
-     out of bounds in the transaction context and MissingAccount when the account index is out of
-     bounds in the instruction context. */
+  /* Get the account from the transaction context using idx_in_txn.
+     https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L600-L602 */
+  fd_txn_account_t * txn_account = NULL;
+  int err = fd_exec_txn_ctx_get_account_at_index( ctx->txn_ctx,
+                                                  idx_in_txn,
+                                                  &txn_account,
+                                                  NULL );
+  if( FD_UNLIKELY( err ) ) {
+    /* Return a MissingAccount error if the account is not found.
+       https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L603 */
+    return FD_EXECUTOR_INSTR_ERR_MISSING_ACC;
+  }
 
   /* Return an AccountBorrowFailed error if the write is not acquirable.
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L605 */
@@ -110,25 +145,30 @@ fd_exec_instr_ctx_try_borrow_account( fd_exec_instr_ctx_t const * ctx,
 
   /* Create a BorrowedAccount upon success.
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L606 */
-  fd_borrowed_account_init( account, txn_account, ctx, (ushort)idx );
+  fd_borrowed_account_init( account,
+                            txn_account,
+                            ctx,
+                            idx_in_instr );
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
 
 int
 fd_exec_instr_ctx_try_borrow_instr_account( fd_exec_instr_ctx_t const * ctx,
-                                            ulong                       idx,
+                                            ushort                      idx,
                                             fd_borrowed_account_t *     account ) {
-  /* Return a NotEnoughAccountKeys error if the idx is out of bounds.
-     https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L603 */
-  if( FD_UNLIKELY( idx>=ctx->instr->acct_cnt ) ) {
-    return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+  /* Find the index of the account in the transaction context.
+     https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L649-L650 */
+  ushort idx_in_txn;
+  int err = fd_exec_instr_ctx_get_index_of_instr_account_in_transaction( ctx,
+                                                                         idx,
+                                                                         &idx_in_txn );
+  if( FD_UNLIKELY( err ) ) {
+    return err;
   }
-
-  fd_txn_account_t * instr_account = ctx->instr->accounts[idx];
 
   return fd_exec_instr_ctx_try_borrow_account( ctx,
                                                idx,
-                                               instr_account,
+                                               idx_in_txn,
                                                account );
 }
 
@@ -136,8 +176,9 @@ int
 fd_exec_instr_ctx_try_borrow_instr_account_with_key( fd_exec_instr_ctx_t const * ctx,
                                                      fd_pubkey_t const *         pubkey,
                                                      fd_borrowed_account_t *     account ) {
-  for( ulong i=0; i<ctx->instr->acct_cnt; i++ ) {
-    if( memcmp( pubkey->uc, ctx->instr->acct_pubkeys[i].uc, sizeof(fd_pubkey_t) )==0 ) {
+  for( ushort i=0; i<ctx->instr->acct_cnt; i++ ) {
+    ushort idx_in_txn = ctx->instr->accounts[ i ].index_in_transaction;
+    if( memcmp( pubkey->uc, ctx->txn_ctx->account_keys[ idx_in_txn ].uc, sizeof(fd_pubkey_t) )==0 ) {
       return fd_exec_instr_ctx_try_borrow_instr_account( ctx, i, account );
     }
   }
@@ -151,16 +192,40 @@ fd_exec_instr_ctx_try_borrow_instr_account_with_key( fd_exec_instr_ctx_t const *
 int
 fd_exec_instr_ctx_try_borrow_last_program_account( fd_exec_instr_ctx_t const * ctx,
                                                    fd_borrowed_account_t *     account ) {
-  fd_txn_account_t * program_account = NULL;
-  fd_exec_txn_ctx_get_account_at_index( ctx->txn_ctx,
-                                        ctx->instr->program_id,
-                                        &program_account,
-                                        NULL );
-
   /* The index_in_instruction for a borrowed program account is invalid,
      so it is set to a sentinel value of USHORT_MAX. */
   return fd_exec_instr_ctx_try_borrow_account( ctx,
                                                USHORT_MAX,
-                                               program_account,
+                                               ctx->instr->program_id,
                                                account );
+}
+
+int
+fd_exec_instr_ctx_get_signers( fd_exec_instr_ctx_t const * ctx,
+                               fd_pubkey_t const *         signers[static FD_TXN_SIG_MAX] ) {
+  ulong j = 0UL;
+  for( ushort i=0; i<ctx->instr->acct_cnt && j<FD_TXN_SIG_MAX; i++ )
+    if( fd_instr_acc_is_signer_idx( ctx->instr, i ) ) {
+      ushort idx_in_txn = ctx->instr->accounts[i].index_in_transaction;
+      int err = fd_exec_txn_ctx_get_key_of_account_at_index( ctx->txn_ctx,
+                                                             idx_in_txn,
+                                                             &signers[j++] );
+      if( FD_UNLIKELY( err ) ) {
+        return err;
+      }
+    }
+  return FD_EXECUTOR_INSTR_SUCCESS;
+}
+
+int
+fd_exec_instr_ctx_any_signed( fd_exec_instr_ctx_t const * ctx,
+                              fd_pubkey_t const *         pubkey ) {
+  int is_signer = 0;
+  for( ushort j=0; j<ctx->instr->acct_cnt; j++ ) {
+    ushort idx_in_txn = ctx->instr->accounts[ j ].index_in_transaction;
+    is_signer |=
+      ( ( !!fd_instr_acc_is_signer_idx( ctx->instr, j ) ) &
+        ( 0==memcmp( pubkey->key, ctx->txn_ctx->account_keys[ idx_in_txn ].key, sizeof(fd_pubkey_t) ) ) );
+  }
+  return is_signer;
 }

--- a/src/flamenco/runtime/context/fd_exec_instr_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_instr_ctx.h
@@ -70,6 +70,7 @@ fd_exec_instr_ctx_delete( void * mem );
    FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS otherwise.
 
    https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L490 */
+
 static inline int
 fd_exec_instr_ctx_check_num_insn_accounts( fd_exec_instr_ctx_t const * ctx,
                                            uint                        expected_accounts ) {
@@ -91,6 +92,24 @@ int
 fd_exec_instr_ctx_find_idx_of_instr_account( fd_exec_instr_ctx_t const * ctx,
                                              fd_pubkey_t const *         pubkey );
 
+/* Mirrors Agave function solana_sdk::transaction_context::InstructionContext::get_index_of_instruction_account_in_transaction
+
+   https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L552 */
+
+static inline int
+fd_exec_instr_ctx_get_index_of_instr_account_in_transaction( fd_exec_instr_ctx_t const * ctx,
+                                                             ushort                      idx_in_instr,
+                                                             ushort *                    idx_in_txn ) {
+  /* Return a NotEnoughAccountKeys error if the idx is out of bounds.
+     https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L559 */
+  if( FD_UNLIKELY( idx_in_instr>=ctx->instr->acct_cnt ) ) {
+    return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+  }
+
+  *idx_in_txn = ctx->instr->accounts[ idx_in_instr ].index_in_transaction;
+  return FD_EXECUTOR_INSTR_SUCCESS;
+}
+
 /* Mirrors Agave function solana_sdk::transaction_context::InstructionContext::get_number_of_program_accounts.
 
    Strictly returns 1, as we only support one program account per instruction.
@@ -103,6 +122,24 @@ fd_exec_instr_ctx_get_number_of_program_accounts( fd_exec_instr_ctx_t const * ct
   return 1U;
 }
 
+/* A helper function to get the pubkey of an account using its instruction context index */
+int
+fd_exec_instr_ctx_get_key_of_account_at_index( fd_exec_instr_ctx_t const * ctx,
+                                               ushort                      idx_in_instr,
+                                               fd_pubkey_t const * *       key );
+
+/* Mirrors Agave function solana_sdk::transaction_context::InstructionContext::get_last_program_key.
+
+   There can only be one program per instruction, so this function simply retrieves
+   that program's pubkey, despite the name implying multiple programs per instruction.
+   The function exists to match semantics with Agave.
+
+   https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L582 */
+
+int
+fd_exec_instr_ctx_get_last_program_key( fd_exec_instr_ctx_t const * ctx,
+                                        fd_pubkey_t const * *       key );
+
 /* Mirrors Agave function solana_sdk::transaction_context::InstructionContext::try_borrow_account.
 
    Borrows an account from the instruction context with a given account index.
@@ -111,7 +148,7 @@ fd_exec_instr_ctx_get_number_of_program_accounts( fd_exec_instr_ctx_t const * ct
 
 int
 fd_exec_instr_ctx_try_borrow_instr_account( fd_exec_instr_ctx_t const * ctx,
-                                            ulong                       idx,
+                                            ushort                      idx,
                                             fd_borrowed_account_t *     account );
 
 /* A wrapper around fd_exec_instr_ctx_try_borrow_account that accepts an account pubkey.
@@ -133,6 +170,43 @@ fd_exec_instr_ctx_try_borrow_instr_account_with_key( fd_exec_instr_ctx_t const *
 int
 fd_exec_instr_ctx_try_borrow_last_program_account( fd_exec_instr_ctx_t const * ctx,
                                                    fd_borrowed_account_t *     account );
+
+/* Mirrors Agave function solana_sdk::transaction_context::InstructionContext::get_signers
+
+   https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L684 */
+
+int
+fd_exec_instr_ctx_get_signers( fd_exec_instr_ctx_t const * ctx,
+                               fd_pubkey_t const *         signers[ static FD_TXN_SIG_MAX ] );
+
+/* fd_exec_instr_ctx_any_signed matches
+   solana_system_program::system_processor::Address::is_signer
+
+   Scans instruction accounts for matching signer.
+
+   Returns 1 if *any* instruction account with the given pubkey is a
+   signer and 0 otherwise.  Note that the same account/pubkey can be
+   specified as multiple different instruction accounts that might not
+   all have the signer bit.
+
+   https://github.com/anza-xyz/agave/blob/v2.1.14/programs/system/src/system_processor.rs#L35-L41 */
+
+FD_FN_PURE int
+fd_exec_instr_ctx_any_signed( fd_exec_instr_ctx_t const * ctx,
+                              fd_pubkey_t const *         pubkey );
+
+/* Although fd_signers_contains does not take an instruction context,
+   it is included here for relevance to signer helper functions
+
+   Loop conditions could be optimized to allow for unroll/vectorize */
+
+static inline int
+fd_signers_contains( fd_pubkey_t const * signers[ static FD_TXN_SIG_MAX ],
+                     fd_pubkey_t const * pubkey ) {
+  for( ulong i=0; i<FD_TXN_SIG_MAX && signers[i]; i++ )
+    if( 0==memcmp( signers[i], pubkey, sizeof( fd_pubkey_t ) ) ) return 1;
+  return 0;
+}
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.h
@@ -262,7 +262,7 @@ fd_exec_txn_ctx_find_index_of_account( fd_exec_txn_ctx_t const * ctx,
 
 typedef int fd_txn_account_condition_fn_t ( fd_txn_account_t *        acc,
                                             fd_exec_txn_ctx_t const * ctx,
-                                            int                       idx );
+                                            ushort                    idx );
 
 /* Mirrors Agave function solana_sdk::transaction_context::get_account_at_index
 
@@ -274,7 +274,7 @@ typedef int fd_txn_account_condition_fn_t ( fd_txn_account_t *        acc,
 
 int
 fd_exec_txn_ctx_get_account_at_index( fd_exec_txn_ctx_t *             ctx,
-                                      uchar                           idx,
+                                      ushort                          idx,
                                       fd_txn_account_t * *            account,
                                       fd_txn_account_condition_fn_t * condition );
 
@@ -295,6 +295,15 @@ fd_exec_txn_ctx_get_executable_account( fd_exec_txn_ctx_t *             ctx,
                                         fd_txn_account_t * *            account,
                                         fd_txn_account_condition_fn_t * condition );
 
+/* Mirrors Agave function solana_sdk::transaction_context::get_key_of_account_at_index
+
+   https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L212 */
+
+int
+fd_exec_txn_ctx_get_key_of_account_at_index( fd_exec_txn_ctx_t *  ctx,
+                                             ushort               idx,
+                                             fd_pubkey_t const * * key );
+
 void
 fd_exec_txn_ctx_reset_return_data( fd_exec_txn_ctx_t * ctx );
 
@@ -312,14 +321,14 @@ fd_exec_txn_ctx_reset_return_data( fd_exec_txn_ctx_t * ctx );
 /* https://github.com/anza-xyz/agave/blob/v2.1.1/sdk/program/src/message/versions/v0/loaded.rs#L137-L150 */
 
 int
-fd_exec_txn_ctx_account_is_writable_idx( fd_exec_txn_ctx_t const * ctx, int idx );
+fd_exec_txn_ctx_account_is_writable_idx( fd_exec_txn_ctx_t const * txn_ctx, ushort idx );
 
 /* This flat function does the same as the function above, but uses the
    exact arguments needed instead of the full fd_exec_txn_ctx_t */
 
 int
 fd_exec_txn_account_is_writable_idx_flat( const ulong           slot,
-                                          const int             idx,
+                                          const ushort          idx,
                                           const fd_pubkey_t *   addr_at_idx,
                                           const fd_txn_t *      txn_descriptor,
                                           const fd_features_t * features,
@@ -340,12 +349,12 @@ fd_txn_account_has_bpf_loader_upgradeable( const fd_pubkey_t * account_keys,
 int
 fd_txn_account_check_exists( fd_txn_account_t *        acc,
                              fd_exec_txn_ctx_t const * ctx,
-                             int                       idx );
+                             ushort                    idx );
 
 int
 fd_txn_account_check_is_writable( fd_txn_account_t *        acc,
                                   fd_exec_txn_ctx_t const * ctx,
-                                  int                       idx );
+                                  ushort                    idx );
 
 /* The fee payer is a valid modifiable account if it is passed in as writable
    in the message via a valid signature. We ignore if the account has been
@@ -356,7 +365,7 @@ fd_txn_account_check_is_writable( fd_txn_account_t *        acc,
 int
 fd_txn_account_check_fee_payer_writable( fd_txn_account_t *        acc,
                                          fd_exec_txn_ctx_t const * ctx,
-                                         int                       idx );
+                                         ushort                    idx );
 
 /* Checks if the account is mutable and borrows the account mutably.
 
@@ -372,7 +381,7 @@ fd_txn_account_check_fee_payer_writable( fd_txn_account_t *        acc,
 int
 fd_txn_account_check_borrow_mut( fd_txn_account_t *        acc,
                                  fd_exec_txn_ctx_t const * ctx,
-                                 int                       idx );
+                                 ushort                    idx );
 
 
 FD_PROTOTYPES_END

--- a/src/flamenco/runtime/fd_borrowed_account.h
+++ b/src/flamenco/runtime/fd_borrowed_account.h
@@ -340,7 +340,13 @@ fd_borrowed_account_is_writable( fd_borrowed_account_t const * borrowed_acct ) {
 
 FD_FN_PURE static inline int
 fd_borrowed_account_is_owned_by_current_program( fd_borrowed_account_t const * borrowed_acct ) {
-  return memcmp( borrowed_acct->instr_ctx->instr->program_id_pubkey.key,
+  fd_pubkey_t const * program_id_pubkey = NULL;
+  int err = fd_exec_instr_ctx_get_last_program_key( borrowed_acct->instr_ctx, &program_id_pubkey );
+  if( FD_UNLIKELY( err ) ) {
+    return err;
+  }
+
+  return memcmp( program_id_pubkey->key,
                  borrowed_acct->acct->const_meta->info.owner, sizeof(fd_pubkey_t) ) == 0;
 }
 

--- a/src/flamenco/runtime/fd_cost_tracker.c
+++ b/src/flamenco/runtime/fd_cost_tracker.c
@@ -92,7 +92,7 @@ calculate_allocated_accounts_data_size( fd_exec_txn_ctx_t const * txn_ctx,
     void const *     payload = txn_ctx->_txn_raw->raw;
 
     ulong allocated_accounts_data_size = 0UL;
-    for( ushort i=0UL; i<txn->instr_cnt; i++ ) {
+    for( ushort i=0; i<txn->instr_cnt; i++ ) {
       fd_txn_instr_t const * instr      = &txn->instr[ i ];
       fd_acct_addr_t const * accounts   = fd_txn_get_acct_addrs( txn, payload );
       fd_acct_addr_t const * prog_id    = accounts + instr->program_id;

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -1328,7 +1328,7 @@ if( FD_UNLIKELY( cond1 ) ) { \
     for( fd_txn_acct_iter_t iter=fd_txn_acct_iter_init( TXN(txn), FD_TXN_ACCT_CAT_WRITABLE );
          iter!=fd_txn_acct_iter_end() && NO_CONFLICT;
          iter=fd_txn_acct_iter_next( iter ) ) {
-      int idx                     = (int)fd_txn_acct_iter_idx( iter );
+      ushort idx                     = (ushort)fd_txn_acct_iter_idx( iter );
       fd_acct_addr_t writable_acc = txn_accts[ idx ];
 
       /* Check whether writable_acc is demoted to a read-only account */
@@ -1867,10 +1867,10 @@ fd_runtime_finalize_txn( fd_exec_slot_ctx_t *         slot_ctx,
     int dirty_vote_acc  = txn_ctx->dirty_vote_acc;
     int dirty_stake_acc = txn_ctx->dirty_stake_acc;
 
-    for( ulong i=0UL; i<txn_ctx->accounts_cnt; i++ ) {
+    for( ushort i=0; i<txn_ctx->accounts_cnt; i++ ) {
       /* We are only interested in saving writable accounts and the fee
          payer account. */
-      if( !fd_exec_txn_ctx_account_is_writable_idx( txn_ctx, (int)i ) && i!=FD_FEE_PAYER_TXN_IDX ) {
+      if( !fd_exec_txn_ctx_account_is_writable_idx( txn_ctx, i ) && i!=FD_FEE_PAYER_TXN_IDX ) {
         continue;
       }
 

--- a/src/flamenco/runtime/info/fd_instr_info.c
+++ b/src/flamenco/runtime/info/fd_instr_info.c
@@ -1,82 +1,71 @@
 #include "fd_instr_info.h"
-
-#include "../fd_borrowed_account.h"
+#include "../context/fd_exec_txn_ctx.h"
 #include "../../../util/bits/fd_uwide.h"
 
 void
-fd_convert_txn_instr_to_instr( fd_exec_txn_ctx_t *    txn_ctx,
-                               fd_txn_instr_t const * txn_instr,
-                               fd_txn_account_t *     accounts,
-                               fd_instr_info_t *      instr ) {
+fd_instr_info_accumulate_starting_lamports( fd_instr_info_t *         instr,
+                                            fd_exec_txn_ctx_t const * txn_ctx,
+                                            ushort                    idx_in_callee,
+                                            ushort                    idx_in_txn ) {
+  if( FD_LIKELY( !instr->is_duplicate[ idx_in_callee ] ) ) {
+    if( txn_ctx->accounts[ idx_in_txn ].const_meta ) {
+      fd_uwide_inc(
+        &instr->starting_lamports_h, &instr->starting_lamports_l,
+        instr->starting_lamports_h, instr->starting_lamports_l,
+        txn_ctx->accounts[ idx_in_txn ].const_meta->info.lamports );
+    }
+  }
+}
+
+void
+fd_instr_info_init_from_txn_instr( fd_instr_info_t *      instr,
+                                   fd_exec_txn_ctx_t *    txn_ctx,
+                                   fd_txn_instr_t const * txn_instr ) {
 
   fd_txn_t const *      txn_descriptor = txn_ctx->txn_descriptor;
-  fd_rawtxn_b_t const * txn_raw = txn_ctx->_txn_raw;
-  const fd_pubkey_t *   account_keys = txn_ctx->account_keys;
+  fd_rawtxn_b_t const * txn_raw        = txn_ctx->_txn_raw;
+  uchar *               instr_acc_idxs = (uchar *)txn_raw->raw + txn_instr->acct_off;
 
-  instr->program_id        = txn_instr->program_id;
-  instr->program_id_pubkey = account_keys[txn_instr->program_id];
+  instr->program_id = txn_instr->program_id;
 
   /* See note in fd_instr_info.h. TLDR capping this value at 256 should have
      literally 0 effect on program execution, down to the error codes. This
      is purely for the sake of not increasing the overall memory footprint of the
      transaction context. If this change causes issues, we may need to increase
      the array sizes in the instr info. */
-  instr->acct_cnt          = fd_ushort_min( txn_instr->acct_cnt, FD_INSTR_ACCT_MAX );
-  instr->data_sz           = txn_instr->data_sz;
-  instr->data              = (uchar *)txn_raw->raw + txn_instr->data_off;
+  instr->acct_cnt = fd_ushort_min( txn_instr->acct_cnt, FD_INSTR_ACCT_MAX );
+  instr->data_sz  = txn_instr->data_sz;
+  instr->data     = (uchar *)txn_raw->raw + txn_instr->data_off;
 
-  uchar acc_idx_seen[256];
-  memset(acc_idx_seen, 0, 256);
-  uchar * instr_acc_idxs = (uchar *)txn_raw->raw + txn_instr->acct_off;
-  for( ulong i = 0; i < instr->acct_cnt; i++ ) {
-    if( accounts != NULL ) {
-      instr->accounts[i] = &accounts[instr_acc_idxs[i]];
-    } else {
-      instr->accounts[i] = NULL;
-    }
+  uchar acc_idx_seen[ FD_INSTR_ACCT_MAX ];
+  memset(acc_idx_seen, 0, FD_INSTR_ACCT_MAX);
 
-    uchar acc_idx = instr_acc_idxs[i];
+  for( ushort i=0; i<instr->acct_cnt; i++ ) {
+    ushort acc_idx = instr_acc_idxs[i];
 
-    instr->is_duplicate[i] = acc_idx_seen[acc_idx];
-    if( FD_LIKELY( !acc_idx_seen[acc_idx] ) ) {
-      /* This is the first time seeing this account */
-      acc_idx_seen[acc_idx] = 1;
-    }
+    fd_instr_info_setup_instr_account( instr,
+                                       acc_idx_seen,
+                                       acc_idx,
+                                       acc_idx,
+                                       i,
+                                       (uchar)fd_exec_txn_ctx_account_is_writable_idx( txn_ctx, instr_acc_idxs[i] ),
+                                       (uchar)fd_txn_is_signer( txn_descriptor, instr_acc_idxs[i] ) );
 
-    instr->acct_txn_idxs[i] = acc_idx;
-    instr->acct_pubkeys[i]  = account_keys[instr_acc_idxs[i]];
-    instr->acct_flags[i]    = 0;
-    if( fd_exec_txn_ctx_account_is_writable_idx( txn_ctx, (int)instr_acc_idxs[i]) ) {
-        instr->acct_flags[i] |= FD_INSTR_ACCT_FLAGS_IS_WRITABLE;
-    }
-    if( fd_txn_is_signer( txn_descriptor, instr_acc_idxs[i] ) ) {
-      instr->acct_flags[i] |= FD_INSTR_ACCT_FLAGS_IS_SIGNER;
-    }
   }
 }
 
 int
-fd_instr_any_signed( fd_instr_info_t const * info,
-                     fd_pubkey_t const *     pubkey ) {
-  int is_signer = 0;
-  for( ulong j=0UL; j < info->acct_cnt; j++ )
-    is_signer |=
-      ( ( !!fd_instr_acc_is_signer_idx( info, j ) ) &
-        ( 0==memcmp( pubkey->key, info->acct_pubkeys[j].key, sizeof(fd_pubkey_t) ) ) );
-  return is_signer;
-}
-
-/* https://github.com/anza-xyz/agave/blob/9706a6464665f7ebd6ead47f0d12f853ccacbab9/sdk/src/transaction_context.rs#L40 */
-int
 fd_instr_info_sum_account_lamports( fd_instr_info_t const * instr,
+                                    fd_exec_txn_ctx_t *     txn_ctx,
                                     ulong *                 total_lamports_h,
                                     ulong *                 total_lamports_l ) {
   *total_lamports_h = 0UL;
   *total_lamports_l = 0UL;
   for( ulong i=0UL; i<instr->acct_cnt; ++i ) {
-    if( instr->accounts[i] == NULL ||
-        instr->is_duplicate[i]     ||
-        instr->accounts[i]->const_meta == NULL ) {
+    ushort idx_in_txn = instr->accounts[i].index_in_transaction;
+
+    if( txn_ctx->accounts[ idx_in_txn ].const_meta == NULL ||
+        instr->is_duplicate[i] ) {
       continue;
     }
 
@@ -85,7 +74,7 @@ fd_instr_info_sum_account_lamports( fd_instr_info_t const * instr,
     ulong tmp_total_lamports_l = 0UL;
 
     fd_uwide_inc( &tmp_total_lamports_h, &tmp_total_lamports_l, *total_lamports_h, *total_lamports_l,
-                  instr->accounts[i]->const_meta->info.lamports );
+                  txn_ctx->accounts[ idx_in_txn ].const_meta->info.lamports );
 
     if( tmp_total_lamports_h < *total_lamports_h ) {
       return FD_EXECUTOR_INSTR_ERR_ARITHMETIC_OVERFLOW;

--- a/src/flamenco/runtime/info/fd_instr_info.h
+++ b/src/flamenco/runtime/info/fd_instr_info.h
@@ -4,9 +4,6 @@
 #include "../../fd_flamenco_base.h"
 #include "../../types/fd_types.h"
 #include "../fd_txn_account.h"
-// TODO: rename to _MASK
-#define FD_INSTR_ACCT_FLAGS_IS_SIGNER   (0x01U)
-#define FD_INSTR_ACCT_FLAGS_IS_WRITABLE (0x02U)
 
 /* While the maximum number of instruction accounts allowed for instruction
    execution is 256, it is entirely possible to have a transaction with more
@@ -23,87 +20,111 @@
    any extra accounts should (ideally) have literally 0 impact on program execution, whether
    or not they are present in the instr info. This keeps the transaction context size from
    blowing up to around 3MB in size. */
-#define FD_INSTR_ACCT_MAX (256)
+#define FD_INSTR_ACCT_MAX               (256)
+#define FD_INSTR_ACCT_FLAGS_IS_SIGNER   (0x01U)
+#define FD_INSTR_ACCT_FLAGS_IS_WRITABLE (0x02U)
+
+struct fd_instruction_account {
+  ushort index_in_transaction;
+  ushort index_in_caller;
+  ushort index_in_callee;
+  uchar is_writable;
+  uchar is_signer;
+};
+
+typedef struct fd_instruction_account fd_instruction_account_t;
 
 struct fd_instr_info {
-  uchar               program_id;
-  ushort              data_sz;
-  ushort              acct_cnt;
+  uchar                    program_id;
+  ushort                   data_sz;
+  ushort                   acct_cnt;
 
-  uchar *             data;
-  fd_pubkey_t         program_id_pubkey;
+  uchar *                  data;
 
-  uchar               acct_txn_idxs[FD_INSTR_ACCT_MAX];
-  uchar               acct_flags[FD_INSTR_ACCT_MAX];
-  fd_pubkey_t         acct_pubkeys[FD_INSTR_ACCT_MAX];
-  uchar               is_duplicate[FD_INSTR_ACCT_MAX];
+  fd_instruction_account_t accounts[ FD_INSTR_ACCT_MAX ];
+  uchar                    is_duplicate[ FD_INSTR_ACCT_MAX ];
 
-  /* Indexed by index in instruction, not by index in transaction. */
-  fd_txn_account_t *  accounts[FD_INSTR_ACCT_MAX];
-
-  /* fd_uwide representation of uint_128 */
-  ulong               starting_lamports_h;
-  ulong               starting_lamports_l;
+  /* TODO: convert to fd_uwide_t representation of uint_128 */
+  ulong                    starting_lamports_h;
+  ulong                    starting_lamports_l;
 };
 
 typedef struct fd_instr_info fd_instr_info_t;
 
 FD_PROTOTYPES_BEGIN
 
+static inline fd_instruction_account_t
+fd_instruction_account_init( ushort idx_in_txn,
+                             ushort idx_in_caller,
+                             ushort idx_in_callee,
+                             uchar  is_writable,
+                             uchar  is_signer ) {
+  fd_instruction_account_t acc = {
+    .index_in_transaction = idx_in_txn,
+    .index_in_caller      = idx_in_caller,
+    .index_in_callee      = idx_in_callee,
+    .is_writable          = is_writable,
+    .is_signer            = is_signer,
+  };
+  return acc;
+}
+
+static inline void
+fd_instr_info_setup_instr_account( fd_instr_info_t * instr,
+                                   uchar             acc_idx_seen[ FD_INSTR_ACCT_MAX ],
+                                   ushort            idx_in_txn,
+                                   ushort            idx_in_caller,
+                                   ushort            idx_in_callee,
+                                   uchar             is_writable,
+                                   uchar             is_signer ) {
+  instr->is_duplicate[ idx_in_callee ] = acc_idx_seen[ idx_in_txn ];
+  if( FD_LIKELY( !acc_idx_seen[ idx_in_txn ] ) ) {
+    /* This is the first time seeing this account */
+    acc_idx_seen[ idx_in_txn ] = 1;
+  }
+
+  instr->accounts[ idx_in_callee ] = fd_instruction_account_init( idx_in_txn,
+                                                                  idx_in_caller,
+                                                                  idx_in_callee,
+                                                                  is_writable,
+                                                                  is_signer );
+}
+
+/* fd_instr_info_accumulate_starting_lamports accumulates the starting lamports fields
+   when setting up an fd_instr_info_t object.
+   Note that the caller must zero out the starting lamports fields in fd_instr_info_t
+   beforehand. */
+
 void
-fd_convert_txn_instr_to_instr( fd_exec_txn_ctx_t *     txn_ctx,
-                               fd_txn_instr_t const *  txn_instr,
-                               fd_txn_account_t *      accts,
-                               fd_instr_info_t *       instr );
+fd_instr_info_accumulate_starting_lamports( fd_instr_info_t *         instr,
+                                            fd_exec_txn_ctx_t const * txn_ctx,
+                                            ushort                    idx_in_callee,
+                                            ushort                    idx_in_txn );
+
+void
+fd_instr_info_init_from_txn_instr( fd_instr_info_t *      instr,
+                                   fd_exec_txn_ctx_t *    txn_ctx,
+                                   fd_txn_instr_t const * txn_instr );
 
 FD_FN_PURE static inline int
 fd_instr_acc_is_writable_idx( fd_instr_info_t const * instr,
-                              ulong                   idx ) {
-  return !!(instr->acct_flags[idx] & FD_INSTR_ACCT_FLAGS_IS_WRITABLE);
-}
-
-static inline int
-fd_instr_acc_is_writable(fd_instr_info_t const * instr, fd_pubkey_t const * acc) {
-  for( uchar i = 0; i < instr->acct_cnt; i++ ) {
-    if( memcmp( &instr->acct_pubkeys[i], acc, sizeof( fd_pubkey_t ) )==0 ) {
-      return fd_instr_acc_is_writable_idx( instr, i );
-    }
+                              ushort                  idx ) {
+  if( FD_UNLIKELY( idx>=instr->acct_cnt ) ) {
+    return FD_EXECUTOR_INSTR_ERR_MISSING_ACC;
   }
 
-  return 0;
+  return !!(instr->accounts[idx].is_writable);
 }
 
 FD_FN_PURE static inline int
 fd_instr_acc_is_signer_idx( fd_instr_info_t const * instr,
-                            ulong                   idx ) {
-  return !!(instr->acct_flags[idx] & FD_INSTR_ACCT_FLAGS_IS_SIGNER);
-}
-
-static inline int
-fd_instr_acc_is_signer(fd_instr_info_t const * instr, fd_pubkey_t const * acc) {
-  for( uchar i = 0; i < instr->acct_cnt; i++ ) {
-    if( memcmp( &instr->acct_pubkeys[i], acc, sizeof( fd_pubkey_t ) )==0 ) {
-      return fd_instr_acc_is_signer_idx( instr, i );
-    }
+                            ushort                  idx ) {
+  if( FD_UNLIKELY( idx>=instr->acct_cnt ) ) {
+    return FD_EXECUTOR_INSTR_ERR_MISSING_ACC;
   }
 
-  return 0;
+  return !!(instr->accounts[idx].is_signer);
 }
-
-/* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L35-L41
-
-   fd_instr_any_signed matches
-   solana_system_program::system_processor::Address::is_signer
-   Scans instruction accounts for matching signer.
-
-   Returns 1 if *any* instruction account with the given pubkey is a
-   signer and 0 otherwise.  Note that the same account/pubkey can be
-   specified as multiple different instruction accounts that might not
-   all have the signer bit. */
-
-FD_FN_PURE int
-fd_instr_any_signed( fd_instr_info_t const * info,
-                     fd_pubkey_t const *     pubkey );
 
 /* fd_instr_info_sum_account_lamports returns the sum of lamport account
    balances of all instruction accounts in the context.
@@ -112,26 +133,22 @@ fd_instr_any_signed( fd_instr_info_t const * info,
 
 int
 fd_instr_info_sum_account_lamports( fd_instr_info_t const * instr,
+                                    fd_exec_txn_ctx_t *     txn_ctx,
                                     ulong *                 total_lamports_h,
                                     ulong *                 total_lamports_l );
 
-static inline void
-fd_instr_get_signers( fd_instr_info_t const * self,
-                      fd_pubkey_t const *     signers[static FD_TXN_SIG_MAX] ) {
-  ulong j = 0UL;
-  for( uchar i = 0; i < self->acct_cnt && j < FD_TXN_SIG_MAX; i++ )
-    if( fd_instr_acc_is_signer_idx( self, i ) )
-      signers[j++] = &self->acct_pubkeys[i];
-}
+static inline uchar
+fd_instr_get_acc_flags( fd_instr_info_t const * instr,
+                        ushort                  idx ) {
+  if( FD_UNLIKELY( idx>=instr->acct_cnt ) ) {
+    return 0;
+  }
 
-/* Loop conditions could be optimized to allow for unroll/vectorize */
+  uchar flags = 0;
+  if( instr->accounts[idx].is_signer )   flags |= FD_INSTR_ACCT_FLAGS_IS_SIGNER;
+  if( instr->accounts[idx].is_writable ) flags |= FD_INSTR_ACCT_FLAGS_IS_WRITABLE;
 
-static inline int
-fd_instr_signers_contains( fd_pubkey_t const * signers[FD_TXN_SIG_MAX],
-                           fd_pubkey_t const * pubkey ) {
-  for( ulong i = 0; i < FD_TXN_SIG_MAX && signers[i]; i++ )
-    if( 0==memcmp( signers[i], pubkey, sizeof( fd_pubkey_t ) ) ) return 1;
-  return 0;
+  return flags;
 }
 
 FD_PROTOTYPES_END

--- a/src/flamenco/runtime/program/fd_address_lookup_table_program.c
+++ b/src/flamenco/runtime/program/fd_address_lookup_table_program.c
@@ -887,12 +887,15 @@ close_lookup_table( fd_exec_instr_ctx_t * ctx ) {
   fd_borrowed_account_drop( &authority_acct );
 
   /* https://github.com/solana-labs/solana/blob/v1.17.4/programs/address-lookup-table/src/processor.rs#L411 */
-  if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) ) {
-    return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+  err = fd_exec_instr_ctx_check_num_insn_accounts( ctx, 3 );
+  if( FD_UNLIKELY( err ) ) {
+    return err;
   }
 
-  /* https://github.com/solana-labs/solana/blob/v1.17.4/programs/address-lookup-table/src/processor.rs#L412-L420 */
-  if( FD_UNLIKELY( ctx->instr->accounts[0]==ctx->instr->accounts[2] ) ) {
+  /* It's ok to directly access the instruction accounts because we already verified 3 expected instruction accounts.
+     https://github.com/solana-labs/solana/blob/v1.17.4/programs/address-lookup-table/src/processor.rs#L412-L420 */
+  if( FD_UNLIKELY( ctx->instr->accounts[0].index_in_transaction ==
+                   ctx->instr->accounts[2].index_in_transaction ) ) {
     fd_log_collector_msg_literal( ctx, "Lookup table cannot be the recipient of reclaimed lamports" );
     return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
   }

--- a/src/flamenco/runtime/program/fd_loader_v4_program.c
+++ b/src/flamenco/runtime/program/fd_loader_v4_program.c
@@ -130,7 +130,11 @@ fd_loader_v4_program_instruction_write( fd_exec_instr_ctx_t *                   
   FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( instr_ctx, 0UL, &program );
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L95-L97 */
-  fd_pubkey_t const * authority_address = &instr_ctx->instr->acct_pubkeys[ 1UL ];
+  fd_pubkey_t const * authority_address = NULL;
+  err = fd_exec_instr_ctx_get_key_of_account_at_index( instr_ctx, 1UL, &authority_address );
+  if( FD_UNLIKELY( err ) ) {
+    return err;
+  }
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L98-L103 */
   fd_loader_v4_state_t state = {0};
@@ -195,7 +199,11 @@ fd_loader_v4_program_instruction_truncate( fd_exec_instr_ctx_t *                
   FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( instr_ctx, 0UL, &program );
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L131-L133 */
-  fd_pubkey_t const * authority_address = &instr_ctx->instr->acct_pubkeys[ 1UL ];
+  fd_pubkey_t const * authority_address = NULL;
+  err = fd_exec_instr_ctx_get_key_of_account_at_index( instr_ctx, 1UL, &authority_address );
+  if( FD_UNLIKELY( err ) ) {
+    return err;
+  }
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L134C9-L135 */
   uchar is_initialization = !!( new_size>0UL && program.acct->const_meta->dlen<LOADER_V4_PROGRAM_DATA_OFFSET );
@@ -348,7 +356,11 @@ fd_loader_v4_program_instruction_deploy( fd_exec_instr_ctx_t * instr_ctx ) {
   fd_sol_sysvar_clock_t const * clock                  = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( instr_ctx->txn_ctx->sysvar_cache );
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L217-L219 */
-  fd_pubkey_t const * authority_address = &instr_ctx->instr->acct_pubkeys[ 1UL ];
+  fd_pubkey_t const * authority_address = NULL;
+  err = fd_exec_instr_ctx_get_key_of_account_at_index( instr_ctx, 1UL, &authority_address );
+  if( FD_UNLIKELY( err ) ) {
+    return err;
+  }
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L216 */
   fd_guarded_borrowed_account_t program;
@@ -503,7 +515,11 @@ fd_loader_v4_program_instruction_retract( fd_exec_instr_ctx_t * instr_ctx ) {
   FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( instr_ctx, 0UL, &program );
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L335-L337 */
-  fd_pubkey_t const * authority_address = &instr_ctx->instr->acct_pubkeys[ 1UL ];
+  fd_pubkey_t const * authority_address = NULL;
+  err = fd_exec_instr_ctx_get_key_of_account_at_index( instr_ctx, 1UL, &authority_address );
+  if( FD_UNLIKELY( err ) ) {
+    return err;
+  }
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L338-L343 */
   fd_loader_v4_state_t state = {0};
@@ -560,10 +576,18 @@ fd_loader_v4_program_instruction_transfer_authority( fd_exec_instr_ctx_t * instr
   FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( instr_ctx, 0UL, &program );
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L378-L380 */
-  fd_pubkey_t const * authority_address = &instr_ctx->instr->acct_pubkeys[ 1UL ];
+  fd_pubkey_t const * authority_address = NULL;
+  err = fd_exec_instr_ctx_get_key_of_account_at_index( instr_ctx, 1UL, &authority_address );
+  if( FD_UNLIKELY( err ) ) {
+    return err;
+  }
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L381-L383 */
-  fd_pubkey_t const * new_authority_address = &instr_ctx->instr->acct_pubkeys[ 2UL ];
+  fd_pubkey_t const * new_authority_address = NULL;
+  err = fd_exec_instr_ctx_get_key_of_account_at_index( instr_ctx, 2UL, &new_authority_address );
+  if( FD_UNLIKELY( err ) ) {
+    return err;
+  }
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L384-L389 */
   fd_loader_v4_state_t state = {0};
@@ -615,9 +639,13 @@ fd_loader_v4_program_instruction_finalize( fd_exec_instr_ctx_t * instr_ctx ) {
 
   /* Contains variables that need to be accessed in multiple borrowed account scopes.
      https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L410-L412 */
-  fd_pubkey_t const *  authority_address       = &instr_ctx->instr->acct_pubkeys[ 1UL ];
-  fd_pubkey_t const *  address_of_next_version = &instr_ctx->instr->acct_pubkeys[ 2UL ];
-  fd_loader_v4_state_t state                   = {0};
+  fd_pubkey_t const * authority_address = NULL;
+  err = fd_exec_instr_ctx_get_key_of_account_at_index( instr_ctx, 1UL, &authority_address );
+  if( FD_UNLIKELY( err ) ) {
+    return err;
+  }
+
+  fd_loader_v4_state_t state = {0};
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L409 */
   fd_guarded_borrowed_account_t program;
@@ -668,7 +696,10 @@ fd_loader_v4_program_instruction_finalize( fd_exec_instr_ctx_t * instr_ctx ) {
     return FD_EXECUTOR_INSTR_ERR_ACC_IMMUTABLE;
   }
 
-  /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L440 */
+  /* https://github.com/anza-xyz/agave/blob/v2.2.0/programs/loader-v4/src/lib.rs#L463 */
+  fd_pubkey_t * address_of_next_version = next_version.acct->pubkey;
+
+  /* https://github.com/anza-xyz/agave/blob/v2.2.0/programs/loader-v4/src/lib.rs#L464 */
   fd_borrowed_account_drop( &next_version );
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L441 */
@@ -696,11 +727,16 @@ fd_loader_v4_program_execute( fd_exec_instr_ctx_t * instr_ctx ) {
   }
 
   FD_SPAD_FRAME_BEGIN( instr_ctx->txn_ctx->spad ) {
-    /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L470 */
-    fd_pubkey_t const * program_id = &instr_ctx->instr->program_id_pubkey;
+    int rc = FD_EXECUTOR_INSTR_SUCCESS;
+
+    /* https://github.com/anza-xyz/agave/blob/v2.2.0/programs/loader-v4/src/lib.rs#L494 */
+    fd_pubkey_t const * program_id = NULL;
+    rc = fd_exec_instr_ctx_get_last_program_key( instr_ctx, &program_id );
+    if( FD_UNLIKELY( rc ) ) {
+      return rc;
+    }
 
     /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L471-L488 */
-    int rc = FD_EXECUTOR_INSTR_SUCCESS;
     if( !memcmp( program_id, fd_solana_bpf_loader_v4_program_id.key, sizeof(fd_pubkey_t) ) ) {
       /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L472 */
       FD_EXEC_CU_UPDATE( instr_ctx, LOADER_V4_DEFAULT_COMPUTE_UNITS );
@@ -777,7 +813,9 @@ fd_loader_v4_program_execute( fd_exec_instr_ctx_t * instr_ctx ) {
       /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L489 */
       fd_guarded_borrowed_account_t program;
       rc = fd_exec_instr_ctx_try_borrow_last_program_account( instr_ctx, &program );
-      if( FD_UNLIKELY( rc ) ) return rc;
+      if( FD_UNLIKELY( rc ) ) {
+        return rc;
+      }
 
       /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L490 */
       fd_loader_v4_state_t state = {0};
@@ -798,12 +836,15 @@ fd_loader_v4_program_execute( fd_exec_instr_ctx_t * instr_ctx ) {
         return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
       }
 
+      /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L508 */
+      fd_borrowed_account_drop( &program );
+
       /* See note in `fd_bpf_loader_program_execute()` as to why we must tie the cache into consensus :(
          https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L496-L502 */
       fd_sbpf_validated_program_t * prog = NULL;
       if( FD_UNLIKELY( fd_bpf_load_cache_entry( instr_ctx->txn_ctx->acc_mgr->funk,
                                                 instr_ctx->txn_ctx->funk_txn,
-                                                &instr_ctx->instr->program_id_pubkey,
+                                                program_id,
                                                 &prog )!=0 ) ) {
         fd_log_collector_msg_literal( instr_ctx, "Program is not cached" );
         return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;

--- a/src/flamenco/runtime/program/fd_stake_program.c
+++ b/src/flamenco/runtime/program/fd_stake_program.c
@@ -341,13 +341,13 @@ authorized_check( fd_stake_authorized_t const * self,
   switch( stake_authorize.discriminant ) {
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/sdk/program/src/stake/state.rs#L365
   case fd_stake_authorize_enum_staker:
-    if( FD_LIKELY( fd_instr_signers_contains( signers, &self->staker ) ) ) {
+    if( FD_LIKELY( fd_signers_contains( signers, &self->staker ) ) ) {
       return 0;
     }
     return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/sdk/program/src/stake/state.rs#L366
   case fd_stake_authorize_enum_withdrawer:
-    if( FD_LIKELY( fd_instr_signers_contains( signers, &self->withdrawer ) ) ) {
+    if( FD_LIKELY( fd_signers_contains( signers, &self->withdrawer ) ) ) {
       return 0;
     }
     return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
@@ -369,8 +369,8 @@ authorized_authorize( fd_stake_authorized_t *                  self,
   switch( stake_authorize->discriminant ) {
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/sdk/program/src/stake/state.rs#L379
   case fd_stake_authorize_enum_staker:
-    if( FD_UNLIKELY( !fd_instr_signers_contains( signers, &self->staker ) &&
-                      !fd_instr_signers_contains( signers, &self->withdrawer ) ) ) {
+    if( FD_UNLIKELY( !fd_signers_contains( signers, &self->staker ) &&
+                      !fd_signers_contains( signers, &self->withdrawer ) ) ) {
       return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
     }
     self->staker = *new_authorized;
@@ -389,7 +389,7 @@ authorized_authorize( fd_stake_authorized_t *                  self,
           *custom_err = FD_STAKE_ERR_CUSTODIAN_MISSING;
           return FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR;
         } else {
-          if( FD_UNLIKELY( !fd_instr_signers_contains( signers, custodian ) ) ) {
+          if( FD_UNLIKELY( !fd_signers_contains( signers, custodian ) ) ) {
             *custom_err = FD_STAKE_ERR_CUSTODIAN_SIGNATURE_MISSING;
             return FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR;
           }
@@ -421,10 +421,10 @@ set_lockup_meta( fd_stake_meta_t *             self,
                  fd_sol_sysvar_clock_t const * clock ) {
   // FIXME FD_LIKELY
   if( lockup_is_in_force( &self->lockup, clock, NULL ) ) {
-    if( !fd_instr_signers_contains( signers, &self->lockup.custodian ) ) {
+    if( !fd_signers_contains( signers, &self->lockup.custodian ) ) {
       return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
     }
-  } else if( !fd_instr_signers_contains( signers, &self->authorized.withdrawer ) ) {
+  } else if( !fd_signers_contains( signers, &self->authorized.withdrawer ) ) {
     return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
   }
 
@@ -1349,7 +1349,9 @@ authorize_with_seed( fd_exec_instr_ctx_t const *   ctx,
   if( FD_LIKELY( fd_instr_acc_is_signer_idx( ctx->instr, authority_base_index ) ) ) {
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L289
-    fd_pubkey_t const * base_pubkey = &ctx->instr->acct_pubkeys[authority_base_index];
+    fd_pubkey_t const * base_pubkey = NULL;
+    rc = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, authority_base_index, &base_pubkey );
+    if( FD_UNLIKELY( rc ) ) return rc;
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L293
     rc = fd_pubkey_create_with_seed( ctx,
@@ -1746,8 +1748,11 @@ split( fd_exec_instr_ctx_t const * ctx,
   }
   case fd_stake_state_v2_enum_uninitialized: {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L523
-    fd_pubkey_t const * stake_pubkey = &ctx->instr->acct_pubkeys[stake_account_index];
-    if( FD_UNLIKELY( !fd_instr_signers_contains( signers, stake_pubkey ) ) ) {
+    fd_pubkey_t const * stake_pubkey = NULL;
+    rc = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, stake_account_index, &stake_pubkey );
+    if( FD_UNLIKELY( rc ) ) return rc;
+
+    if( FD_UNLIKELY( !fd_signers_contains( signers, stake_pubkey ) ) ) {
       // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L527
       return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
     }
@@ -1810,8 +1815,18 @@ merge( fd_exec_instr_ctx_t *         ctx, // not const to log
   if( FD_UNLIKELY( memcmp( &source_account.acct->const_meta->info.owner, fd_solana_stake_program_id.key, 32UL ) ) )
     return FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID;
 
-  // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L569
-  if( FD_UNLIKELY( !memcmp( &ctx->instr->acct_pubkeys[stake_account_index], &ctx->instr->acct_pubkeys[source_account_index], sizeof(fd_pubkey_t) ) ) )
+  ushort stake_acc_idx_in_txn;
+  ushort source_acc_idx_in_txn;
+
+  rc = fd_exec_instr_ctx_get_index_of_instr_account_in_transaction( ctx, stake_account_index, &stake_acc_idx_in_txn );
+  if( FD_UNLIKELY( rc ) ) return rc;
+
+  rc = fd_exec_instr_ctx_get_index_of_instr_account_in_transaction( ctx, source_account_index, &source_acc_idx_in_txn );
+  if( FD_UNLIKELY( rc ) ) return rc;
+
+  /* Close the stake_account-reference loophole
+     https://github.com/anza-xyz/agave/blob/v2.1.14/programs/stake/src/stake_state.rs#L569-L574 */
+  if( FD_UNLIKELY( stake_acc_idx_in_txn==source_acc_idx_in_txn ) )
     return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.14/programs/stake/src/stake_state.rs#L575 */
@@ -1896,7 +1911,7 @@ move_stake_or_lamports_shared_checks( fd_exec_instr_ctx_t *   invoke_context, //
                                       fd_borrowed_account_t * source_account,
                                       ulong                   lamports,
                                       fd_borrowed_account_t * destination_account,
-                                      ulong                   stake_authority_index,
+                                      ushort                  stake_authority_index,
                                       merge_kind_t *          source_merge_kind,
                                       merge_kind_t *          destination_merge_kind,
                                       uint *                  custom_err ) {
@@ -1907,7 +1922,11 @@ move_stake_or_lamports_shared_checks( fd_exec_instr_ctx_t *   invoke_context, //
       return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
     }
 
-    fd_pubkey_t const * stake_authority_pubkey = &invoke_context->instr->acct_pubkeys[stake_authority_index];
+    // https://github.com/anza-xyz/agave/blob/v2.1.14/programs/stake/src/stake_state.rs#L132
+    fd_pubkey_t const * stake_authority_pubkey = NULL;
+    rc = fd_exec_instr_ctx_get_key_of_account_at_index( invoke_context, stake_authority_index, &stake_authority_pubkey );
+    if( FD_UNLIKELY( rc ) ) return rc;
+
     fd_pubkey_t const * signers[FD_TXN_SIG_MAX] = { stake_authority_pubkey };
 
     // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_state.rs#L158
@@ -1979,10 +1998,10 @@ move_stake_or_lamports_shared_checks( fd_exec_instr_ctx_t *   invoke_context, //
 // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_state.rs#L789
 static int
 move_stake(fd_exec_instr_ctx_t * ctx, // not const to log
-           ulong                 source_account_index,
+           ushort                source_account_index,
            ulong                 lamports,
-           ulong                 destination_account_index,
-           ulong                 stake_authority_index,
+           ushort                destination_account_index,
+           ushort                stake_authority_index,
            uint *                custom_err ) {
   int rc;
 
@@ -2136,10 +2155,10 @@ move_stake(fd_exec_instr_ctx_t * ctx, // not const to log
 // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_state.rs#L928
 static int
 move_lamports(fd_exec_instr_ctx_t * ctx, // not const to log
-              ulong                 source_account_index,
+              ushort                source_account_index,
               ulong                 lamports,
-              ulong                 destination_account_index,
-              ulong                 stake_authority_index ) {
+              ushort                destination_account_index,
+              ushort                stake_authority_index ) {
   int rc;
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.14/programs/stake/src/stake_state.rs#L759 */
@@ -2212,7 +2231,9 @@ withdraw( fd_exec_instr_ctx_t const *   ctx,
 
   int rc;
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L809
-  fd_pubkey_t const * withdraw_authority_pubkey = &ctx->instr->acct_pubkeys[withdraw_authority_index];
+  fd_pubkey_t const * withdraw_authority_pubkey = NULL;
+  rc = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, withdraw_authority_index, &withdraw_authority_pubkey );
+  if( FD_UNLIKELY( rc ) ) return rc;
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L813
   int is_signer = fd_instr_acc_is_signer_idx( ctx->instr, withdraw_authority_index );
@@ -2278,7 +2299,7 @@ withdraw( fd_exec_instr_ctx_t const *   ctx,
   }
   case fd_stake_state_v2_enum_uninitialized: {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L846
-    if( FD_UNLIKELY( !fd_instr_signers_contains( signers, stake_account.acct->pubkey ) ) ) {
+    if( FD_UNLIKELY( !fd_signers_contains( signers, stake_account.acct->pubkey ) ) ) {
       return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
     }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L850
@@ -2299,7 +2320,8 @@ withdraw( fd_exec_instr_ctx_t const *   ctx,
   if( custodian_index ) {
     int is_signer = fd_instr_acc_is_signer_idx( ctx->instr, *custodian_index );
     if( is_signer ) {
-      custodian_pubkey = &ctx->instr->acct_pubkeys[*custodian_index];
+      int err = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, *custodian_index, &custodian_pubkey );
+      if( FD_UNLIKELY( err ) ) return err;
     } else {
       custodian_pubkey = NULL;
     }
@@ -2361,15 +2383,16 @@ withdraw( fd_exec_instr_ctx_t const *   ctx,
 static int
 deactivate_delinquent( fd_exec_instr_ctx_t *   ctx,
                        fd_borrowed_account_t * stake_account,
-                       ulong                   delinquent_vote_account_index,
-                       ulong                   reference_vote_account_index,
+                       ushort                  delinquent_vote_account_index,
+                       ushort                  reference_vote_account_index,
                        ulong                   current_epoch,
                        uint *                  custom_err ) {
   int rc;
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L911
-  fd_pubkey_t const * delinquent_vote_account_pubkey =
-      &ctx->instr->acct_pubkeys[delinquent_vote_account_index];
+  fd_pubkey_t const * delinquent_vote_account_pubkey = NULL;
+  rc = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, delinquent_vote_account_index, &delinquent_vote_account_pubkey );
+  if( FD_UNLIKELY( rc ) ) return rc;
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.14/programs/stake/src/stake_state.rs#L915 */
   fd_guarded_borrowed_account_t delinquent_vote_account;
@@ -2446,7 +2469,7 @@ deactivate_delinquent( fd_exec_instr_ctx_t *   ctx,
 // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L25
 static int
 get_optional_pubkey( fd_exec_instr_ctx_t *          ctx,
-                     ulong                          acc_idx,
+                     ushort                         acc_idx,
                      int                            should_be_signer,
                      /* out */ fd_pubkey_t const ** pubkey ) {
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L32
@@ -2456,7 +2479,8 @@ get_optional_pubkey( fd_exec_instr_ctx_t *          ctx,
       return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
     }
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L39
-    *pubkey = &ctx->instr->acct_pubkeys[acc_idx];
+    int err = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, acc_idx, pubkey );
+    if( FD_UNLIKELY( err ) ) return err;
   } else {
     *pubkey = NULL;
   }
@@ -2494,7 +2518,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L77
   fd_pubkey_t const * signers[FD_TXN_SIG_MAX] = {0};
-  fd_instr_get_signers( ctx->instr, signers );
+  fd_exec_instr_ctx_get_signers( ctx, signers );
 
   if( FD_UNLIKELY( ctx->instr->data==NULL ) ) {
     return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
@@ -2874,11 +2898,19 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     if( FD_UNLIKELY( rc ) ) return rc;
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L230
-    if( FD_UNLIKELY( ctx->instr->acct_cnt<4 ) )
-      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
-    // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L231-L236
-    fd_pubkey_t const * staker_pubkey     = &ctx->instr->acct_pubkeys[2];
-    fd_pubkey_t const * withdrawer_pubkey = &ctx->instr->acct_pubkeys[3];
+    rc = fd_exec_instr_ctx_check_num_insn_accounts( ctx, 4UL );
+    if( FD_UNLIKELY( rc ) ) return rc;
+
+    /* https://github.com/anza-xyz/agave/blob/v2.1.14/programs/stake/src/stake_instruction.rs#L230-L236 */
+    fd_pubkey_t const * staker_pubkey     = NULL;
+    fd_pubkey_t const * withdrawer_pubkey = NULL;
+
+    rc = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, 2UL, &staker_pubkey );
+    if( FD_UNLIKELY( rc ) ) return rc;
+
+    rc = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, 3UL, &withdrawer_pubkey );
+    if( FD_UNLIKELY( rc ) ) return rc;
+
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L237
     if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( ctx->instr, 3 ) ) )
       return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
@@ -2919,8 +2951,12 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L253
     if( FD_UNLIKELY( ctx->instr->acct_cnt<4 ) )
       return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
-    // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L254
-    fd_pubkey_t const * authorized_pubkey = &ctx->instr->acct_pubkeys[3];
+
+    // https://github.com/anza-xyz/agave/blob/v2.1.14/programs/stake/src/stake_instruction.rs#L253
+    fd_pubkey_t const * authorized_pubkey = NULL;
+    rc = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, 3UL, &authorized_pubkey );
+    if( FD_UNLIKELY( rc ) ) return rc;
+
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L257
     int is_signer = fd_instr_acc_is_signer_idx( ctx->instr, 3 );
     if( FD_UNLIKELY( !is_signer ) ) return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
@@ -2964,10 +3000,14 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_from_instr_acct_clock( ctx, 2, &rc );
     if( FD_UNLIKELY( !clock ) ) return rc;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L277
-    if( FD_UNLIKELY( ctx->instr->acct_cnt<4 ) )
+    if( FD_UNLIKELY( fd_exec_instr_ctx_check_num_insn_accounts( ctx, 4U) ) )
       return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
-    // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L278
-    fd_pubkey_t const * authorized_pubkey = &ctx->instr->acct_pubkeys[3];
+
+    // https://github.com/anza-xyz/agave/blob/v2.1.14/programs/stake/src/stake_instruction.rs#L277-L280
+    fd_pubkey_t const * authorized_pubkey = NULL;
+    rc = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, 3UL, &authorized_pubkey );
+    if( FD_UNLIKELY( rc ) ) return rc;
+
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L281
     int is_signer = fd_instr_acc_is_signer_idx( ctx->instr, 3 );
     if( FD_UNLIKELY( !is_signer ) ) return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;

--- a/src/flamenco/runtime/program/fd_system_program.c
+++ b/src/flamenco/runtime/program/fd_system_program.c
@@ -57,8 +57,8 @@ verify_seed_address( fd_exec_instr_ctx_t * ctx,
 static int
 fd_system_program_transfer_verified( fd_exec_instr_ctx_t * ctx,
                                      ulong                 transfer_amount,
-                                     ulong                 from_acct_idx,
-                                     ulong                 to_acct_idx ) {
+                                     ushort                from_acct_idx,
+                                     ushort                to_acct_idx ) {
   int err;
 
   /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L191-L192 */
@@ -112,15 +112,16 @@ fd_system_program_transfer_verified( fd_exec_instr_ctx_t * ctx,
 static int
 fd_system_program_transfer( fd_exec_instr_ctx_t * ctx,
                             ulong                 transfer_amount,
-                            ulong                 from_acct_idx,
-                            ulong                 to_acct_idx ) {
+                            ushort                from_acct_idx,
+                            ushort                to_acct_idx ) {
 
   /* https://github.com/anza-xyz/agave/blob/v2.0.9/programs/system/src/system_processor.rs#L222-L232 */
 
   if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( ctx->instr, from_acct_idx ) ) ) {
     /* Max msg_sz: 37 - 2 + 45 = 80 < 127 => we can use printf */
+    ushort idx_in_txn = ctx->instr->accounts[ from_acct_idx ].index_in_transaction;
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Transfer: `from` account %s must sign", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ from_acct_idx ] ) );
+      "Transfer: `from` account %s must sign", FD_BASE58_ENC_32_ALLOCA( &ctx->txn_ctx->account_keys[ idx_in_txn ] ) );
     return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
   }
 
@@ -145,7 +146,7 @@ fd_system_program_allocate( fd_exec_instr_ctx_t *   ctx,
 
   /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L78-L85 */
 
-  if( FD_UNLIKELY( !fd_instr_any_signed( ctx->instr, authority ) ) ) {
+  if( FD_UNLIKELY( !fd_exec_instr_ctx_any_signed( ctx, authority ) ) ) {
     /* Max msg_sz: 35 - 2 + 45 = 78 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
       "Allocate: 'to' account %s must sign", FD_BASE58_ENC_32_ALLOCA( authority ) );
@@ -202,7 +203,7 @@ fd_system_program_assign( fd_exec_instr_ctx_t *   ctx,
 
   /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L125-L128 */
 
-  if( FD_UNLIKELY( !fd_instr_any_signed( ctx->instr, authority ) ) ) {
+  if( FD_UNLIKELY( !fd_exec_instr_ctx_any_signed( ctx, authority ) ) ) {
     /* Max msg_sz: 28 - 2 + 45 = 71 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
       "Assign: account %s must sign", FD_BASE58_ENC_32_ALLOCA( authority ) );
@@ -238,8 +239,8 @@ fd_system_program_allocate_and_assign( fd_exec_instr_ctx_t *   ctx,
 
 static int
 fd_system_program_create_account( fd_exec_instr_ctx_t * ctx,
-                                  ulong                 from_acct_idx,
-                                  ulong                 to_acct_idx,
+                                  ushort                from_acct_idx,
+                                  ushort                to_acct_idx,
                                   ulong                 lamports,
                                   ulong                 space,
                                   fd_pubkey_t const *   owner,
@@ -295,8 +296,14 @@ fd_system_program_exec_create_account( fd_exec_instr_ctx_t *                    
   /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L333-L339
      Authorization check is lifted out from 'allocate' to here. */
 
-  ulong const from_acct_idx    = 0UL;
-  ulong const to_acct_idx      = 1UL;
+  ushort const from_acct_idx = 0UL;
+  ushort const to_acct_idx   = 1UL;
+
+  /* https://github.com/anza-xyz/agave/blob/v2.1.14/programs/system/src/system_processor.rs#L317-L320 */
+  fd_pubkey_t const * authority = NULL;
+  int err = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, to_acct_idx, &authority );
+  if( FD_UNLIKELY( err ) ) return err;
+
   return fd_system_program_create_account(
       ctx,
       from_acct_idx,
@@ -304,7 +311,7 @@ fd_system_program_exec_create_account( fd_exec_instr_ctx_t *                    
       create_acc->lamports,
       create_acc->space,
       &create_acc->owner,
-      &ctx->instr->acct_pubkeys[to_acct_idx] );
+      authority );
 }
 
 /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L381-L393
@@ -365,19 +372,21 @@ int
 fd_system_program_exec_create_account_with_seed( fd_exec_instr_ctx_t *                                            ctx,
                                                  fd_system_program_instruction_create_account_with_seed_t const * args ) {
 
-  fd_instr_info_t const * instr = ctx->instr;
-
   /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L360 */
 
-  if( FD_UNLIKELY( instr->acct_cnt < 2 ) )
+  if( FD_UNLIKELY( fd_exec_instr_ctx_check_num_insn_accounts( ctx, 2UL) ) )
     return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
 
   /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L361-L367 */
 
+  fd_pubkey_t const * to_address = NULL;
+  int err = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, 1UL, &to_address );
+  if( FD_UNLIKELY( err ) ) return err;
+
   do {
     int err = verify_seed_address(
         ctx,
-        &instr->acct_pubkeys[1],
+        to_address,
         &args->base,
         (char const *)args->seed,
         args->seed_len,
@@ -387,8 +396,8 @@ fd_system_program_exec_create_account_with_seed( fd_exec_instr_ctx_t *          
 
   /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L368-L379 */
 
-  ulong const from_acct_idx    = 0UL;
-  ulong const to_acct_idx      = 1UL;
+  ushort const from_acct_idx = 0UL;
+  ushort const to_acct_idx   = 1UL;
   return fd_system_program_create_account(
       ctx,
       from_acct_idx,
@@ -528,30 +537,35 @@ fd_system_program_exec_transfer_with_seed( fd_exec_instr_ctx_t *                
 
   /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L410 */
 
-  if( FD_UNLIKELY( ctx->instr->acct_cnt < 3 ) )
+  if( FD_UNLIKELY( fd_exec_instr_ctx_check_num_insn_accounts( ctx, 3UL ) ) )
     return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
 
   /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L411-L421
      Inlined call to system_processor::transfer_with_seed */
 
-  ulong const from_idx      = 0UL;
-  ulong const from_base_idx = 1UL;
-  ulong const to_idx        = 2UL;
+  ushort const from_idx      = 0UL;
+  ushort const from_base_idx = 1UL;
+  ushort const to_idx        = 2UL;
 
   if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( ctx->instr, from_base_idx ) ) ) {
     /* Max msg_sz: 37 - 2 + 45 = 80 < 127 => we can use printf */
+    ushort idx_in_txn = ctx->instr->accounts[ from_base_idx ].index_in_transaction;
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Transfer: 'from' account %s must sign", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ from_base_idx ] ) );
+      "Transfer: 'from' account %s must sign", FD_BASE58_ENC_32_ALLOCA( &ctx->txn_ctx->account_keys[ idx_in_txn ] ) );
     return FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
   }
 
-  /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L283-L290 */
+  /* https://github.com/anza-xyz/agave/blob/v2.2.0/programs/system/src/system_processor.rs#L267-L274 */
+
+  fd_pubkey_t const * base = NULL;
+  int err = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, from_base_idx, &base );
+  if( FD_UNLIKELY( err ) ) return err;
 
   fd_pubkey_t address_from_seed[1];
   do {
     int err = fd_pubkey_create_with_seed(
         ctx,
-        ctx->instr->acct_pubkeys[ from_base_idx ].uc,
+        base->uc,
         (char const *)args->from_seed,
         args->from_seed_len,
         args->from_owner.uc,
@@ -559,15 +573,18 @@ fd_system_program_exec_transfer_with_seed( fd_exec_instr_ctx_t *                
     if( FD_UNLIKELY( err ) ) return err;
   } while(0);
 
-  /* https://github.com/solana-labs/solana/blob/v1.17.22/programs/system/src/system_processor.rs#L292-L303 */
+  /* https://github.com/anza-xyz/agave/blob/v2.2.0/programs/system/src/system_processor.rs#L276-L287 */
+  fd_pubkey_t const * from_key = NULL;
+  err = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, from_idx, &from_key );
+  if( FD_UNLIKELY( err ) ) return err;
 
   if( FD_UNLIKELY( 0!=memcmp( address_from_seed->uc,
-                              ctx->instr->acct_pubkeys[ from_idx ].uc,
+                              from_key->uc,
                               sizeof(fd_pubkey_t) ) ) ) {
     /* Log msg_sz can be more or less than 127 bytes */
     fd_log_collector_printf_inefficient_max_512( ctx,
       "Transfer: 'from' address %s does not match derived address %s",
-      FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ from_idx ] ),
+      FD_BASE58_ENC_32_ALLOCA( from_key ),
       FD_BASE58_ENC_32_ALLOCA( address_from_seed ) );
     ctx->txn_ctx->custom_err = FD_SYSTEM_PROGRAM_ERR_ADDR_WITH_SEED_MISMATCH;
     return FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR;

--- a/src/flamenco/runtime/program/fd_system_program_nonce.c
+++ b/src/flamenco/runtime/program/fd_system_program_nonce.c
@@ -9,17 +9,15 @@
 
 static int
 require_acct( fd_exec_instr_ctx_t * ctx,
-              ulong                 idx,
+              ushort                idx,
               fd_pubkey_t const *   pubkey ) {
 
-  /* https://github.com/solana-labs/solana/blob/v1.17.23/program-runtime/src/sysvar_cache.rs#L228-L229 */
+  /* https://github.com/anza-xyz/agave/blob/v2.1.14/program-runtime/src/sysvar_cache.rs#L290-L294 */
+  fd_pubkey_t const * acc_key = NULL;
+  int err = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, idx, &acc_key );
+  if( FD_UNLIKELY( err ) ) return err;
 
-  if( FD_UNLIKELY( ctx->instr->acct_cnt <= idx ) )
-    return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
-
-  /* https://github.com/solana-labs/solana/blob/v1.17.23/program-runtime/src/sysvar_cache.rs#L230-L232 */
-
-  if( FD_UNLIKELY( 0!=memcmp( ctx->instr->acct_pubkeys[idx].uc, pubkey->uc, sizeof(fd_pubkey_t) ) ) )
+  if( FD_UNLIKELY( 0!=memcmp( acc_key, pubkey->uc, sizeof(fd_pubkey_t) ) ) )
     return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
 
   return FD_EXECUTOR_INSTR_SUCCESS;
@@ -27,7 +25,7 @@ require_acct( fd_exec_instr_ctx_t * ctx,
 
 static int
 require_acct_rent( fd_exec_instr_ctx_t * ctx,
-                   ulong                 idx,
+                   ushort                idx,
                    fd_rent_t const **    out_rent ) {
 
   do {
@@ -45,7 +43,7 @@ require_acct_rent( fd_exec_instr_ctx_t * ctx,
 
 static int
 require_acct_recent_blockhashes( fd_exec_instr_ctx_t *             ctx,
-                                 ulong                             idx,
+                                 ushort                            idx,
                                  fd_recent_block_hashes_t const ** out ) {
 
   do {
@@ -140,14 +138,14 @@ fd_system_program_set_nonce_state( fd_borrowed_account_t *           account,
 static int
 fd_system_program_advance_nonce_account( fd_exec_instr_ctx_t *   ctx,
                                          fd_borrowed_account_t * account,
-                                         ulong                   instr_acc_idx ) {
+                                         ushort                  instr_acc_idx ) {
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L25-L32 */
 
   if( FD_UNLIKELY( !fd_instr_acc_is_writable_idx( ctx->instr, instr_acc_idx ) ) ) {
     /* Max msg_sz: 52 - 2 + 45 = 95 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Authorize nonce account: Account %s must be writable", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
+      "Authorize nonce account: Account %s must be writable", FD_BASE58_ENC_32_ALLOCA( account->acct->pubkey) );
     return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
   }
 
@@ -193,7 +191,7 @@ fd_system_program_advance_nonce_account( fd_exec_instr_ctx_t *   ctx,
 
     /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L37-L44 */
 
-    if( FD_UNLIKELY( !fd_instr_any_signed( ctx->instr, &data->authority ) ) ) {
+    if( FD_UNLIKELY( !fd_exec_instr_ctx_any_signed( ctx, &data->authority ) ) ) {
       /* Max msg_sz: 50 - 2 + 45 = 93 < 127 => we can use printf */
       fd_log_collector_printf_dangerous_max_127( ctx,
         "Advance nonce account: Account %s must be a signer", FD_BASE58_ENC_32_ALLOCA( &data->authority ) );
@@ -252,7 +250,7 @@ fd_system_program_advance_nonce_account( fd_exec_instr_ctx_t *   ctx,
   case fd_nonce_state_enum_uninitialized: {
     /* Max msg_sz: 50 - 2 + 45 = 93 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Advance nonce account: Account %s state is invalid", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
+      "Advance nonce account: Account %s state is invalid", FD_BASE58_ENC_32_ALLOCA( account->acct->pubkey ) );
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
   }
 
@@ -327,10 +325,10 @@ fd_system_program_withdraw_nonce_account( fd_exec_instr_ctx_t * ctx,
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L84-L91 */
 
-  if( FD_UNLIKELY( !fd_instr_acc_is_writable_idx( ctx->instr, 0 ) ) ) {
+  if( FD_UNLIKELY( !fd_instr_acc_is_writable_idx( ctx->instr, from_acct_idx ) ) ) {
     /* Max msg_sz: 51 - 2 + 45 = 94 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Withdraw nonce account: Account %s must be writable", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ 0 ] ) );
+      "Withdraw nonce account: Account %s must be writable", FD_BASE58_ENC_32_ALLOCA( from.acct->pubkey ) );
     return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
   }
 
@@ -460,7 +458,7 @@ fd_system_program_withdraw_nonce_account( fd_exec_instr_ctx_t * ctx,
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L135-L142 */
 
-  if( FD_UNLIKELY( !fd_instr_any_signed( ctx->instr, signer ) ) ) {
+  if( FD_UNLIKELY( !fd_exec_instr_ctx_any_signed( ctx, signer ) ) ) {
     /* Max msg_sz: 44 - 2 + 45 = 87 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
       "Withdraw nonce account: Account %s must sign", FD_BASE58_ENC_32_ALLOCA( signer ) );
@@ -533,16 +531,15 @@ fd_system_program_exec_withdraw_nonce_account( fd_exec_instr_ctx_t * ctx,
 static int
 fd_system_program_initialize_nonce_account( fd_exec_instr_ctx_t *   ctx,
                                             fd_borrowed_account_t * account,
-                                            ulong                   instr_acc_idx,
                                             fd_pubkey_t const *     authorized,
                                             fd_rent_t const *       rent ) {
 
-  /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L159-L166 */
+  /* https://github.com/anza-xyz/agave/blob/v2.2.0/programs/system/src/system_instruction.rs#L167-L174 */
 
   if( FD_UNLIKELY( !fd_borrowed_account_is_writable( account ) ) ) {
     /* Max msg_sz: 53 - 2 + 45 = 96 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Initialize nonce account: Account %s must be writable", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
+      "Initialize nonce account: Account %s must be writable", FD_BASE58_ENC_32_ALLOCA( account->acct->pubkey ) );
     return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
   }
 
@@ -639,7 +636,7 @@ fd_system_program_initialize_nonce_account( fd_exec_instr_ctx_t *   ctx,
 
     /* Max msg_sz: 53 - 2 + 45 = 96 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Initialize nonce account: Account %s state is invalid", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
+      "Initialize nonce account: Account %s state is invalid", FD_BASE58_ENC_32_ALLOCA( account->acct->pubkey ) );
 
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
   }
@@ -698,7 +695,7 @@ fd_system_program_exec_initialize_nonce_account( fd_exec_instr_ctx_t * ctx,
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L480 */
 
-  err = fd_system_program_initialize_nonce_account( ctx, &account, instr_acc_idx, authorized, rent );
+  err = fd_system_program_initialize_nonce_account( ctx, &account, authorized, rent );
 
   /* Implicit drop */
 
@@ -712,7 +709,7 @@ fd_system_program_exec_initialize_nonce_account( fd_exec_instr_ctx_t * ctx,
 static int
 fd_system_program_authorize_nonce_account( fd_exec_instr_ctx_t *   ctx,
                                            fd_borrowed_account_t * account,
-                                           ulong                   instr_acc_idx,
+                                           ushort                  instr_acc_idx,
                                            fd_pubkey_t const *     nonce_authority ) {
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L206-L213 */
@@ -720,7 +717,7 @@ fd_system_program_authorize_nonce_account( fd_exec_instr_ctx_t *   ctx,
   if( FD_UNLIKELY( !fd_instr_acc_is_writable_idx( ctx->instr, instr_acc_idx ) ) ) {
     /* Max msg_sz: 52 - 2 + 45 = 95 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Authorize nonce account: Account %s must be writable", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
+      "Authorize nonce account: Account %s must be writable", FD_BASE58_ENC_32_ALLOCA( account->acct->pubkey ) );
     return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
   }
 
@@ -769,7 +766,7 @@ fd_system_program_authorize_nonce_account( fd_exec_instr_ctx_t *   ctx,
 
     /* Max msg_sz: 52 - 2 + 45 = 95 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,
-      "Authorize nonce account: Account %s state is invalid", FD_BASE58_ENC_32_ALLOCA( &ctx->instr->acct_pubkeys[ instr_acc_idx ] ) );
+      "Authorize nonce account: Account %s state is invalid", FD_BASE58_ENC_32_ALLOCA( account->acct->pubkey ) );
 
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
   }
@@ -778,7 +775,7 @@ fd_system_program_authorize_nonce_account( fd_exec_instr_ctx_t *   ctx,
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/sdk/program/src/nonce/state/mod.rs#L85-L89 */
 
-  if( FD_UNLIKELY( !fd_instr_any_signed( ctx->instr, &data->authority ) ) ) {
+  if( FD_UNLIKELY( !fd_exec_instr_ctx_any_signed( ctx, &data->authority ) ) ) {
     /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L227-L234 */
     /* Max msg_sz: 45 - 2 + 45 = 88 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( ctx,

--- a/src/flamenco/runtime/program/fd_vote_program.c
+++ b/src/flamenco/runtime/program/fd_vote_program.c
@@ -503,7 +503,7 @@ static inline int
 verify_authorized_signer( fd_pubkey_t const * authorized,
                           fd_pubkey_t const * signers[static FD_TXN_SIG_MAX] ) {
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_state/mod.rs#L989
-  return fd_instr_signers_contains( signers, authorized ) ?
+  return fd_signers_contains( signers, authorized ) ?
     FD_EXECUTOR_INSTR_SUCCESS :
     FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
 }
@@ -1625,7 +1625,7 @@ static int
 withdraw( fd_exec_instr_ctx_t const *   ctx,
           fd_borrowed_account_t *       vote_account,
           ulong                         lamports,
-          ulong                         to_account_index,
+          ushort                        to_account_index,
           fd_pubkey_t const *           signers[static FD_TXN_SIG_MAX],
           fd_rent_t const *             rent_sysvar,
           fd_sol_sysvar_clock_t const * clock ) {
@@ -2318,8 +2318,10 @@ process_authorize_with_seed_instruction(
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L33
   if( fd_instr_acc_is_signer_idx( ctx->instr, 2 ) ) {
 
-    // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L35
-    fd_pubkey_t const * base_pubkey = &ctx->instr->acct_pubkeys[2];
+    // https://github.com/anza-xyz/agave/blob/v2.1.14/programs/vote/src/vote_processor.rs#L34
+    fd_pubkey_t const * base_pubkey = NULL;
+    rc = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, 2UL, &base_pubkey );
+    if( FD_UNLIKELY( rc ) ) return rc;
 
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L37
     expected_authority_keys[0] = &single_signer;
@@ -2408,7 +2410,7 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L69
   fd_pubkey_t const * signers[FD_TXN_SIG_MAX] = { 0 };
-  fd_instr_get_signers( ctx->instr, signers );
+  fd_exec_instr_ctx_get_signers( ctx, signers );
 
   // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L70
   if( FD_UNLIKELY( ctx->instr->data==NULL ) ) {
@@ -2540,9 +2542,12 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
       break;
     }
 
-    // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L116
-    fd_pubkey_t const * new_authority = &ctx->instr->acct_pubkeys[3];
+    // https://github.com/anza-xyz/agave/blob/v2.1.14/programs/vote/src/vote_processor.rs#L99-L100
+    fd_pubkey_t const * new_authority = NULL;
+    rc = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, 3UL, &new_authority );
+    if( FD_UNLIKELY( rc ) ) return rc;
 
+    // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L116
     if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( ctx->instr, 3 ) ) ) {
       // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L117
       rc = FD_EXECUTOR_INSTR_ERR_MISSING_REQUIRED_SIGNATURE;
@@ -2576,8 +2581,10 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
       break;
     }
 
-    // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L132
-    fd_pubkey_t const * node_pubkey = &ctx->instr->acct_pubkeys[1];
+    // https://github.com/anza-xyz/agave/blob/v2.1.14/programs/vote/src/vote_processor.rs#L118-L120
+    fd_pubkey_t const * node_pubkey = NULL;
+    rc = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, 1UL, &node_pubkey );
+    if( FD_UNLIKELY( rc ) ) return rc;
 
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L135
     rc = update_validator_identity( &me, node_pubkey, signers, ctx );
@@ -2867,8 +2874,10 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
       break;
     }
 
-    // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L236
-    fd_pubkey_t const * voter_pubkey = &ctx->instr->acct_pubkeys[3];
+    // https://github.com/anza-xyz/agave/blob/v2.1.14/programs/vote/src/vote_processor.rs#L243-L245
+    fd_pubkey_t const * voter_pubkey = NULL;
+    rc = fd_exec_instr_ctx_get_key_of_account_at_index( ctx, 3UL, &voter_pubkey );
+    if( FD_UNLIKELY( rc ) ) return rc;
 
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L239
     if( FD_UNLIKELY( !fd_instr_acc_is_signer_idx( ctx->instr, 3 ) ) ) {

--- a/src/flamenco/runtime/program/zksdk/fd_zksdk.c
+++ b/src/flamenco/runtime/program/zksdk/fd_zksdk.c
@@ -160,8 +160,8 @@ fd_zksdk_process_verify_proof( fd_exec_instr_ctx_t * ctx ) {
   }
 
   /* https://github.com/anza-xyz/agave/blob/v2.0.1/programs/zk-elgamal-proof/src/lib.rs#L42 */
-  uint accessed_accounts = 0U;
-  uchar const * context = NULL;
+  ushort        accessed_accounts = 0U;
+  uchar const * context           = NULL;
   /* Note: instr_id is guaranteed to be valid, to access values in the arrays. */
   ulong context_sz = fd_zksdk_context_sz[instr_id];
   ulong proof_data_sz = context_sz + fd_zksdk_proof_sz[instr_id];
@@ -213,13 +213,13 @@ fd_zksdk_process_verify_proof( fd_exec_instr_ctx_t * ctx ) {
   /* Create context state if accounts are provided with the instruction
      https://github.com/anza-xyz/agave/blob/v2.0.1/programs/zk-elgamal-proof/src/lib.rs#L92 */
   if( instr_acc_cnt > accessed_accounts ) {
-    fd_pubkey_t                   context_state_authority[1];
+    fd_pubkey_t context_state_authority[1];
 
     /* Obtain the context_state_authority by borrowing the account temporarily in a local scope.
        https://github.com/anza-xyz/agave/blob/v2.1.14/programs/zk-elgamal-proof/src/lib.rs#L94-L99 */
     do {
       fd_guarded_borrowed_account_t _acc;
-      FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( ctx, accessed_accounts+1, &_acc );
+      FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( ctx, (ushort)(accessed_accounts+1), &_acc );
       fd_memcpy( context_state_authority, _acc.acct->pubkey, sizeof(fd_pubkey_t) );
     } while(0);
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_cache.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_cache.c
@@ -138,32 +138,33 @@ fd_sysvar_cache_restore_##name( cache, acc_mgr, funk_txn, runtime_spad, wksp );
 # undef X
 }
 
-# define X( type, name )                                               \
-  type##_global_t const *                                              \
-  fd_sysvar_from_instr_acct_##name( fd_exec_instr_ctx_t const * ctx,   \
-                                    ulong                       idx,   \
-                                    int *                       err ) {\
-                                                                       \
-    if( FD_UNLIKELY( idx >= ctx->instr->acct_cnt ) ) {                 \
-      *err = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;                \
-      return NULL;                                                     \
-    }                                                                  \
-                                                                       \
-    fd_sysvar_cache_t const * cache = ctx->txn_ctx->sysvar_cache;      \
-    type##_global_t const * val = fd_sysvar_cache_##name ( cache );    \
-                                                                       \
-    fd_pubkey_t const * addr_have = &ctx->instr->acct_pubkeys[idx];    \
-    fd_pubkey_t const * addr_want = &fd_sysvar_##name##_id;            \
-    if( 0!=memcmp( addr_have, addr_want, sizeof(fd_pubkey_t) ) ) {     \
-      *err = FD_EXECUTOR_INSTR_ERR_INVALID_ARG;                        \
-      return NULL;                                                     \
-    }                                                                  \
-                                                                       \
-    *err = val ?                                                       \
-           FD_EXECUTOR_INSTR_SUCCESS :                                 \
-           FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;                   \
-    return val;                                                        \
-                                                                       \
+# define X( type, name )                                                       \
+  type##_global_t const *                                                      \
+  fd_sysvar_from_instr_acct_##name( fd_exec_instr_ctx_t const * ctx,           \
+                                    ulong                       idx,           \
+                                    int *                       err ) {        \
+                                                                               \
+    if( FD_UNLIKELY( idx >= ctx->instr->acct_cnt ) ) {                         \
+      *err = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;                        \
+      return NULL;                                                             \
+    }                                                                          \
+                                                                               \
+    fd_sysvar_cache_t const * cache = ctx->txn_ctx->sysvar_cache;              \
+    type##_global_t const * val = fd_sysvar_cache_##name ( cache );            \
+                                                                               \
+    ushort idx_in_txn = ctx->instr->accounts[idx].index_in_transaction;        \
+    fd_pubkey_t const * addr_have = &ctx->txn_ctx->account_keys[ idx_in_txn ]; \
+    fd_pubkey_t const * addr_want = &fd_sysvar_##name##_id;                    \
+    if( 0!=memcmp( addr_have, addr_want, sizeof(fd_pubkey_t) ) ) {             \
+      *err = FD_EXECUTOR_INSTR_ERR_INVALID_ARG;                                \
+      return NULL;                                                             \
+    }                                                                          \
+                                                                               \
+    *err = val ?                                                               \
+           FD_EXECUTOR_INSTR_SUCCESS :                                         \
+           FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;                           \
+    return val;                                                                \
+                                                                               \
   }
   FD_SYSVAR_CACHE_ITER(X)
 # undef X
@@ -173,14 +174,14 @@ int
 fd_check_sysvar_account( fd_exec_instr_ctx_t const * ctx,
                          ulong                       insn_acc_idx,
                          fd_pubkey_t const *         expected_id ) {
-  uchar const *       instr_acc_idxs = ctx->instr->acct_txn_idxs;
-  fd_pubkey_t const * txn_accs       = ctx->txn_ctx->account_keys;
+  fd_pubkey_t const * txn_accs = ctx->txn_ctx->account_keys;
 
   if( insn_acc_idx>=ctx->instr->acct_cnt ) {
     return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
   }
 
-  fd_pubkey_t const * insn_acc_key = &txn_accs[ instr_acc_idxs[ insn_acc_idx ] ];
+  ushort              idx_in_txn   = ctx->instr->accounts[ insn_acc_idx ].index_in_transaction;
+  fd_pubkey_t const * insn_acc_key = &txn_accs[ idx_in_txn ];
 
   if( memcmp( expected_id, insn_acc_key, sizeof(fd_pubkey_t) ) ) {
     return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_instructions.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_instructions.c
@@ -103,16 +103,17 @@ fd_sysvar_instructions_serialize_account( fd_exec_txn_ctx_t *      txn_ctx,
 
     for ( ushort j = 0; j < instr->acct_cnt; j++ ) {
       // flags
-      FD_STORE( uchar, serialized_instructions + offset, instr->acct_flags[j] );
+      FD_STORE( uchar, serialized_instructions + offset, fd_instr_get_acc_flags( instr, j ) );
       offset += sizeof(uchar);
 
       // pubkey
-      FD_STORE( fd_pubkey_t, serialized_instructions + offset, instr->acct_pubkeys[j] );
+      ushort idx_in_txn = instr->accounts[j].index_in_transaction;
+      FD_STORE( fd_pubkey_t, serialized_instructions + offset, txn_ctx->account_keys[ idx_in_txn ] );
       offset += sizeof(fd_pubkey_t);
     }
 
     // program_id_pubkey
-    FD_STORE( fd_pubkey_t, serialized_instructions + offset, instr->program_id_pubkey );
+    FD_STORE( fd_pubkey_t, serialized_instructions + offset, txn_ctx->account_keys[ instr->program_id ] );
     offset += sizeof(fd_pubkey_t);
 
     // instr_data_len

--- a/src/flamenco/runtime/tests/fd_vm_test.c
+++ b/src/flamenco/runtime/tests/fd_vm_test.c
@@ -37,11 +37,15 @@ fd_setup_vm_acc_region_metas( fd_vm_acc_region_meta_t * acc_regions_meta,
   uint cur_region = 0UL;
   for( ulong i=0UL; i<instr_ctx->instr->acct_cnt; i++ ) {
     cur_region++;
-    fd_txn_account_t const * acc = instr_ctx->instr->accounts[i];
+
+    ushort           idx_in_txn = instr_ctx->instr->accounts[i].index_in_transaction;
+    fd_txn_account_t acc        = instr_ctx->txn_ctx->accounts[idx_in_txn];
+
     acc_regions_meta[i].region_idx          = cur_region;
-    acc_regions_meta[i].has_data_region     = acc->const_meta->dlen>0UL;
+    acc_regions_meta[i].has_data_region     = acc.const_meta->dlen>0UL;
     acc_regions_meta[i].has_resizing_region = !vm->is_deprecated;
-    if( acc->const_meta->dlen>0UL ) {
+
+    if( acc.const_meta->dlen>0UL ) {
       cur_region++;
     }
     if( vm->is_deprecated ) {

--- a/src/flamenco/vm/syscall/fd_vm_syscall.h
+++ b/src/flamenco/vm/syscall/fd_vm_syscall.h
@@ -707,25 +707,11 @@ FD_VM_SYSCALL_DECL( sol_try_find_program_address );
 
 /* fd_vm_syscall_cpi **************************************************/
 
-/* Represents an account for a CPI */
-/* FIXME: DOES THIS GO HERE?  MAYBE GROUP WITH ADMIN OR OUTSIDE SYSCALL? */
-
-struct fd_instruction_account {
-  ushort index_in_transaction;
-  ushort index_in_caller;
-  ushort index_in_callee;
-  uint is_signer;
-  uint is_writable;
-};
-
-typedef struct fd_instruction_account fd_instruction_account_t;
-
 /* Prepare instruction method */
 /* FIXME: DOES THIS GO HERE?  MAYBE GROUP WITH ADMIN OR OUTSIDE SYSCALL? */
 
 int
-fd_vm_prepare_instruction( fd_instr_info_t const *  caller_instr,
-                           fd_instr_info_t *        callee_instr,
+fd_vm_prepare_instruction( fd_instr_info_t *        callee_instr,
                            fd_exec_instr_ctx_t *    instr_ctx,
                            fd_instruction_account_t instruction_accounts[256],
                            ulong *                  instruction_accounts_cnt,


### PR DESCRIPTION
Cleans up redundant storage of account pubkeys in `fd_instr_info_t` and matches Agave more accurately by using both transaction-wide and instruction-wide account indexing

Other notable changes:
- makes all functions that take instruction account indices as ushort instead of int or ulong. This matches the 16-bit `IndexOfAccount` type in Agave.
- Helper functions in `fd_instr_info.c` to setup instruction accounts.