### PR TITLE
Added range APIs to smallset, set and set_dynamic and other cleanups

### DIFF
--- a/config/extra/with-extra-brutality.mk
+++ b/config/extra/with-extra-brutality.mk
@@ -1,3 +1,6 @@
+CPPFLAGS+=-DFD_FN_PURE="__attribute__((pure))"
+CPPFLAGS+=-DFD_FN_CONST="__attribute__((const))"
+
 ifdef FD_USING_CLANG
 
 CPPFLAGS+=-Winline

--- a/src/util/env/fd_env.h
+++ b/src/util/env/fd_env.h
@@ -57,13 +57,14 @@ FD_ENV_STRIP_CMDLINE_DECL( double,       double );
 
 #undef FD_ENV_STRIP_CMDLINE_DECL
 
-FD_PROTOTYPES_END
-
 /* returns 1 if the command line contains the given key, and removes
    it from the args, otherwise returns 0. */
+
 int
 fd_env_strip_cmdline_contains( int *        pargc,
                                char ***     pargv,
                                char const * key );
+
+FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_env_fd_env_h */

--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -229,19 +229,6 @@
 #define FD_HAS_DEEPASAN 0
 #endif
 
-/* FD_HAS_HANDHOLDING indicates if there is any *_HANDHOLDING check
-   enabled.  Unfortunately, there is no wildcard matching in C
-   macros.  Therefore, this lists needs to be kept up to date.*/
-
-#if FD_EQVOC_USE_HANDHOLDING || FD_FORKS_USE_HANDHOLDING || FD_GHOST_USE_HANDHOLDING || \
-FD_SCRATCH_USE_HANDHOLDING || FD_SPAD_USE_HANDHOLDING || FD_TOWER_USE_HANDHOLDING ||    \
-FD_TMPL_USE_HANDHOLDING || FD_TXN_HANDHOLDING || FD_FUNKIER_HANDHOLDING                 \
-|| FD_RUNTIME_ERR_HANDHOLDING
-#define FD_HAS_HANDHOLDING 1
-#else
-#define FD_HAS_HANDHOLDING 0
-#endif
-
 /* Base development environment ***************************************/
 
 /* The functionality provided by these vanilla headers are always
@@ -607,8 +594,6 @@ fd_type_pun_const( void const * p ) {
    replace a call to the function with the result of an earlier call to
    that function provide the inputs and memory used hasn't changed.
 
-   This macro will expand to nothing if HANDHOLDING checks are enabled.
-
    IMPORTANT SAFETY TIP!  Recent compilers seem to take an undocumented
    and debatable stance that pure functions do no writes to memory.
    This is a sufficient condition for the above but not a necessary one.
@@ -641,22 +626,27 @@ fd_type_pun_const( void const * p ) {
    TL;DR To be safe against the above vagaries, recommend using
    FD_FN_PURE to annotate functions that do no memory writes (including
    trivial memory writes) and try to design HPC APIs to avoid returning
-   multiple values as much as possible. */
+   multiple values as much as possible.
 
-#if FD_HAS_HANDHOLDING
+   Followup: FD_FN_PURE expands to nothing by default given additional
+   confusion between how current languages, compilers, CI, fuzzing, and
+   developers interpret this function attribute.  We keep it around
+   given it documents the intent of various APIs and so it can be
+   manually enabled to find implementation surprises during bullet
+   proofing (e.g. under compiler options like "extra-brutality").
+   Hopefully someday, pure function attributes will someday be handled
+   more consistently across the board. */
+
+#ifndef FD_FN_PURE
 #define FD_FN_PURE
-#else
-#define FD_FN_PURE __attribute__((pure))
 #endif
 
 /* FD_FN_CONST is like pure but also, even stronger, indicates that the
-   function does not depend on the state of memory.  This macro will
-   expand to nothing if HANDHOLDING checks are enabled. */
+   function does not depend on the state of memory.  See note above
+   about why this expands to nothing by default. */
 
-#if FD_HAS_HANDHOLDING
+#ifndef FD_FN_CONST
 #define FD_FN_CONST
-#else
-#define FD_FN_CONST __attribute__((const))
 #endif
 
 /* FD_FN_UNUSED indicates that it is okay if the function with static

--- a/src/util/tmpl/fd_deque.c
+++ b/src/util/tmpl/fd_deque.c
@@ -198,10 +198,10 @@ FD_FN_CONST static inline ulong DEQUE_(footprint)( void ) { return sizeof (DEQUE
 
 static inline void *
 DEQUE_(new)( void * shmem ) {
-#if FD_TMPL_USE_HANDHOLDING
-  if( FD_UNLIKELY( !shmem ) ) FD_LOG_CRIT(( "NULL shmem" ));
+# if FD_TMPL_USE_HANDHOLDING
+  if( FD_UNLIKELY( !shmem                                                ) ) FD_LOG_CRIT(( "NULL shmem" ));
   if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, DEQUE_(align)() ) ) ) FD_LOG_CRIT(( "unaligned shmem" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = (DEQUE_(private_t) *)shmem;
   /* These values are large enough that underflow/overflow will never
      happen in practical usage.  For example, it would take hundreds of
@@ -226,10 +226,10 @@ static inline void * DEQUE_(leave) ( DEQUE_T * deque ) { return (void *)DEQUE_(p
 
 static inline void *
 DEQUE_(delete)( void * shdeque ) {
-#if FD_TMPL_USE_HANDHOLDING
-  if( FD_UNLIKELY( !shdeque ) ) FD_LOG_CRIT(( "NULL shdeque" ));
+# if FD_TMPL_USE_HANDHOLDING
+  if( FD_UNLIKELY( !shdeque                                                ) ) FD_LOG_CRIT(( "NULL shdeque" ));
   if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shdeque, DEQUE_(align)() ) ) ) FD_LOG_CRIT(( "unaligned shdeque" ));
-#endif
+# endif
   return shdeque;
 }
 
@@ -262,9 +262,9 @@ DEQUE_(full)( DEQUE_T const * deque ) {
 static inline DEQUE_T *
 DEQUE_(push_head)( DEQUE_T * deque,
                    DEQUE_T   ele ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(full)( deque ) ) ) FD_LOG_CRIT(( "cannot push to full deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   hdr->start--;
   hdr->deque[ DEQUE_(private_slot)( hdr->start ) ] = ele;
@@ -274,9 +274,9 @@ DEQUE_(push_head)( DEQUE_T * deque,
 static inline DEQUE_T *
 DEQUE_(push_tail)( DEQUE_T * deque,
                    DEQUE_T   ele ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(full)( deque ) ) ) FD_LOG_CRIT(( "cannot push to full deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   hdr->deque[ DEQUE_(private_slot)( hdr->end ) ] = ele;
   hdr->end++;
@@ -285,9 +285,9 @@ DEQUE_(push_tail)( DEQUE_T * deque,
 
 static inline DEQUE_T
 DEQUE_(pop_head)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot pop from empty deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   DEQUE_T ele = hdr->deque[ DEQUE_(private_slot)( hdr->start ) ];
   hdr->start++;
@@ -296,9 +296,9 @@ DEQUE_(pop_head)( DEQUE_T * deque ) {
 
 static inline DEQUE_T
 DEQUE_(pop_tail)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot pop from empty deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   hdr->end--;
   return hdr->deque[ DEQUE_(private_slot)( hdr->end ) ];
@@ -352,10 +352,10 @@ DEQUE_(push_tail_wrap)( DEQUE_T * deque,
 
 static inline DEQUE_T
 DEQUE_(pop_idx_tail)( DEQUE_T * deque, ulong idx ) {
-#if FD_TMPL_USE_HANDHOLDING
-  if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) )    FD_LOG_CRIT(( "cannot pop from empty deque" ));
+# if FD_TMPL_USE_HANDHOLDING
+  if( FD_UNLIKELY( DEQUE_(empty)( deque )    ) ) FD_LOG_CRIT(( "cannot pop from empty deque" ));
   if( FD_UNLIKELY( idx>=DEQUE_(cnt)( deque ) ) ) FD_LOG_CRIT(( "index out of bounds" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   DEQUE_T * cur = &hdr->deque[ DEQUE_(private_slot)( hdr->start + idx ) ];
   DEQUE_T   ele = *cur;
@@ -386,12 +386,11 @@ DEQUE_(peek_tail)( DEQUE_T * deque ) {
   return hdr->deque + DEQUE_(private_slot)( hdr->end-1UL );
 }
 
-FD_FN_PURE
-static inline DEQUE_T *
+FD_FN_PURE static inline DEQUE_T *
 DEQUE_(peek_index)( DEQUE_T * deque, ulong idx ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( idx>=DEQUE_(cnt)( deque ) ) ) FD_LOG_CRIT(( "index out of bounds" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   return hdr->deque + DEQUE_(private_slot)( hdr->start + idx );
 }
@@ -412,12 +411,11 @@ DEQUE_(peek_tail_const)( DEQUE_T const * deque ) {
   return hdr->deque + DEQUE_(private_slot)( hdr->end-1UL );
 }
 
-FD_FN_PURE
-static inline DEQUE_T const *
+FD_FN_PURE static inline DEQUE_T const *
 DEQUE_(peek_index_const)( DEQUE_T const * deque, ulong idx ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( idx>=DEQUE_(cnt)( deque ) ) ) FD_LOG_CRIT(( "index out of bounds" ));
-#endif
+# endif
   DEQUE_(private_t) const * hdr = DEQUE_(private_const_hdr_from_deque)( deque );
   return hdr->deque + DEQUE_(private_slot)( hdr->start + idx );
 }
@@ -429,9 +427,9 @@ static inline DEQUE_T * DEQUE_(remove_tail)( DEQUE_T * deque ) { DEQUE_(private_
 
 static inline DEQUE_T *
 DEQUE_(push_head_nocopy)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(full)( deque ) ) ) FD_LOG_CRIT(( "cannot push to full deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   hdr->start--;
   return &hdr->deque[ DEQUE_(private_slot)( hdr->start ) ];
@@ -439,9 +437,9 @@ DEQUE_(push_head_nocopy)( DEQUE_T * deque ) {
 
 static inline DEQUE_T *
 DEQUE_(push_tail_nocopy)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(full)( deque ) ) ) FD_LOG_CRIT(( "cannot push to full deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   DEQUE_T * ele = &hdr->deque[ DEQUE_(private_slot)( hdr->end ) ];
   hdr->end++;
@@ -450,9 +448,9 @@ DEQUE_(push_tail_nocopy)( DEQUE_T * deque ) {
 
 static inline DEQUE_T *
 DEQUE_(pop_head_nocopy)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot pop from empty deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   DEQUE_T * ele = &hdr->deque[ DEQUE_(private_slot)( hdr->start ) ];
   hdr->start++;
@@ -461,9 +459,9 @@ DEQUE_(pop_head_nocopy)( DEQUE_T * deque ) {
 
 static inline DEQUE_T *
 DEQUE_(pop_tail_nocopy)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot pop from empty deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   hdr->end--;
   return &hdr->deque[ DEQUE_(private_slot)( hdr->end ) ];
@@ -519,18 +517,18 @@ DEQUE_(iter_prev)( DEQUE_T const * deque, DEQUE_(iter_t) iter ) {
 static inline DEQUE_T *
 DEQUE_(iter_ele)( DEQUE_T * deque, DEQUE_(iter_t) iter ) {
 DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( (iter<hdr->start) | (iter>hdr->end) ) ) FD_LOG_CRIT(( "iter out of bounds" ));
-#endif
+# endif
   return &hdr->deque[ DEQUE_(private_slot)( iter ) ];
 }
 
 static inline DEQUE_T const *
 DEQUE_(iter_ele_const)( DEQUE_T const * deque, DEQUE_(iter_t) iter ) {
   DEQUE_(private_t) const * hdr = DEQUE_(private_const_hdr_from_deque)( deque );
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( (iter<hdr->start) | (iter>hdr->end) ) ) FD_LOG_CRIT(( "iter out of bounds" ));
-#endif
+# endif
   return &hdr->deque[ DEQUE_(private_slot)( iter ) ];
 }
 

--- a/src/util/tmpl/fd_deque_dynamic.c
+++ b/src/util/tmpl/fd_deque_dynamic.c
@@ -172,10 +172,10 @@ DEQUE_(footprint)( ulong max ) {
 static inline void *
 DEQUE_(new)( void * shmem,
              ulong  max ) {
-#if FD_TMPL_USE_HANDHOLDING
-  if( FD_UNLIKELY( !shmem ) ) FD_LOG_CRIT(( "NULL shmem" ));
+# if FD_TMPL_USE_HANDHOLDING
+  if( FD_UNLIKELY( !shmem                                                ) ) FD_LOG_CRIT(( "NULL shmem" ));
   if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, DEQUE_(align)() ) ) ) FD_LOG_CRIT(( "unaligned shmem" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = (DEQUE_(private_t) *)shmem;
   hdr->max1  = max-1UL; /* Note: will wrap to ULONG_MAX if max==0 (and ULONG_MAX+1 will wrap back to 0) */
   hdr->cnt   = 0UL;
@@ -194,10 +194,10 @@ static inline void * DEQUE_(leave) ( DEQUE_T * deque   ) { return (void *)DEQUE_
 
 static inline void *
 DEQUE_(delete)( void * shdeque ) {
-#if FD_TMPL_USE_HANDHOLDING
-  if( FD_UNLIKELY( !shdeque ) ) FD_LOG_CRIT(( "NULL shdeque" ));
+# if FD_TMPL_USE_HANDHOLDING
+  if( FD_UNLIKELY( !shdeque                                                ) ) FD_LOG_CRIT(( "NULL shdeque" ));
   if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shdeque, DEQUE_(align)() ) ) ) FD_LOG_CRIT(( "unaligned shmem" ));
-#endif
+# endif
   return shdeque;
 }
 
@@ -233,9 +233,9 @@ DEQUE_(full)( DEQUE_T const * deque ) {
 static inline DEQUE_T *
 DEQUE_(push_head)( DEQUE_T * deque,
                    DEQUE_T   ele ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(full)( deque ) ) ) FD_LOG_CRIT(( "cannot push to full deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   ulong max1  = hdr->max1;
   ulong cnt   = hdr->cnt;
@@ -250,9 +250,9 @@ DEQUE_(push_head)( DEQUE_T * deque,
 static inline DEQUE_T *
 DEQUE_(push_tail)( DEQUE_T * deque,
                    DEQUE_T   ele ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(full)( deque ) ) ) FD_LOG_CRIT(( "cannot push to full deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   ulong max1 = hdr->max1;
   ulong cnt  = hdr->cnt;
@@ -267,9 +267,9 @@ DEQUE_(push_tail)( DEQUE_T * deque,
 static inline DEQUE_T
 DEQUE_(pop_head)( DEQUE_T * deque ) {
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot pop from empty deque" ));
-#endif
+# endif
   ulong max1  = hdr->max1;
   ulong cnt   = hdr->cnt;
   ulong start = hdr->start;
@@ -282,9 +282,9 @@ DEQUE_(pop_head)( DEQUE_T * deque ) {
 
 static inline DEQUE_T
 DEQUE_(pop_tail)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot pop from empty deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   ulong max1 = hdr->max1;
   ulong cnt  = hdr->cnt;
@@ -305,9 +305,9 @@ DEQUE_(push_head_wrap)( DEQUE_T * deque,
   ulong start = hdr->start;
   ulong end   = hdr->end;
 
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( max1==ULONG_MAX ) ) FD_LOG_CRIT(( "cannot push_head_wrap when max is zero" ));
-#endif
+# endif
 
   /* If the deque is full, pop and discard the tail. */
 
@@ -335,9 +335,9 @@ DEQUE_(push_tail_wrap)( DEQUE_T * deque,
   ulong start = hdr->start;
   ulong end   = hdr->end;
 
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( max1==ULONG_MAX ) ) FD_LOG_CRIT(( "cannot push_tail_wrap when max is zero" ));
-#endif
+# endif
 
   /* If the deque is full, pop and discard the head. */
 
@@ -358,10 +358,10 @@ DEQUE_(push_tail_wrap)( DEQUE_T * deque,
 
 static inline DEQUE_T
 DEQUE_(pop_idx_tail)( DEQUE_T * deque, ulong idx ) {
-#if FD_TMPL_USE_HANDHOLDING
-if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) )    FD_LOG_CRIT(( "cannot pop from empty deque" ));
-if( FD_UNLIKELY( idx>=DEQUE_(cnt)( deque ) ) ) FD_LOG_CRIT(( "index out of bounds" ));
-#endif
+# if FD_TMPL_USE_HANDHOLDING
+  if( FD_UNLIKELY( DEQUE_(empty)( deque )    ) ) FD_LOG_CRIT(( "cannot pop from empty deque" ));
+  if( FD_UNLIKELY( idx>=DEQUE_(cnt)( deque ) ) ) FD_LOG_CRIT(( "index out of bounds" ));
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
 
   ulong max1 = hdr->max1;
@@ -384,64 +384,58 @@ if( FD_UNLIKELY( idx>=DEQUE_(cnt)( deque ) ) ) FD_LOG_CRIT(( "index out of bound
   return ele;
 }
 
-FD_FN_PURE
-static inline DEQUE_T *
+FD_FN_PURE static inline DEQUE_T *
 DEQUE_(peek_head)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot peek on empty deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   return hdr->deque + hdr->start;
 }
 
-FD_FN_PURE
-static inline DEQUE_T *
+FD_FN_PURE static inline DEQUE_T *
 DEQUE_(peek_tail)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot peek on empty deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   return hdr->deque + DEQUE_(private_prev)( hdr->end, hdr->max1 );
 }
 
-FD_FN_PURE
-static inline DEQUE_T *
+FD_FN_PURE static inline DEQUE_T *
 DEQUE_(peek_index)( DEQUE_T * deque, ulong idx ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot peek on empty deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   ulong slot = hdr->start + idx;
         slot = fd_ulong_if( slot <= hdr->max1, slot, slot - hdr->max1 - 1UL );
   return hdr->deque + slot;
 }
 
-FD_FN_PURE
-static inline DEQUE_T const *
+FD_FN_PURE static inline DEQUE_T const *
 DEQUE_(peek_head_const)( DEQUE_T const * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot peek on empty deque" ));
-#endif
+# endif
   DEQUE_(private_t) const * hdr = DEQUE_(private_const_hdr_from_deque)( deque );
   return hdr->deque + hdr->start;
 }
 
-FD_FN_PURE
-static inline DEQUE_T const *
+FD_FN_PURE static inline DEQUE_T const *
 DEQUE_(peek_tail_const)( DEQUE_T const * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot peek on empty deque" ));
-#endif
+# endif
   DEQUE_(private_t) const * hdr = DEQUE_(private_const_hdr_from_deque)( deque );
   return hdr->deque + DEQUE_(private_prev)( hdr->end, hdr->max1 );
 }
 
-FD_FN_PURE
-static inline DEQUE_T const *
+FD_FN_PURE static inline DEQUE_T const *
 DEQUE_(peek_index_const)( DEQUE_T const * deque, ulong idx ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot peek on empty deque" ));
-#endif
+# endif
   DEQUE_(private_t) const * hdr = DEQUE_(private_const_hdr_from_deque)( deque );
   ulong slot = hdr->start + idx;
         slot = fd_ulong_if( slot <= hdr->max1, slot, slot - hdr->max1 - 1UL );
@@ -450,9 +444,9 @@ DEQUE_(peek_index_const)( DEQUE_T const * deque, ulong idx ) {
 
 static inline DEQUE_T *
 DEQUE_(insert_head)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(full)( deque ) ) ) FD_LOG_CRIT(( "cannot insert into full deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   ulong max1  = hdr->max1;
   ulong cnt   = hdr->cnt;
@@ -464,9 +458,9 @@ DEQUE_(insert_head)( DEQUE_T * deque ) {
 
 static inline DEQUE_T *
 DEQUE_(insert_tail)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(full)( deque ) ) ) FD_LOG_CRIT(( "cannot insert into full deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   ulong max1 = hdr->max1;
   ulong cnt  = hdr->cnt;
@@ -478,9 +472,9 @@ DEQUE_(insert_tail)( DEQUE_T * deque ) {
 
 static inline DEQUE_T *
 DEQUE_(remove_head)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot remove from empty deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   ulong max1  = hdr->max1;
   ulong cnt   = hdr->cnt;
@@ -492,9 +486,9 @@ DEQUE_(remove_head)( DEQUE_T * deque ) {
 
 static inline DEQUE_T *
 DEQUE_(remove_tail)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
-if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot remove from empty deque" ));
-#endif
+# if FD_TMPL_USE_HANDHOLDING
+  if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot remove from empty deque" ));
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   ulong max1 = hdr->max1;
   ulong cnt  = hdr->cnt;
@@ -506,9 +500,9 @@ if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot remove from em
 
 static inline DEQUE_T *
 DEQUE_(push_head_nocopy)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(full)( deque ) ) ) FD_LOG_CRIT(( "cannot push to full deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   ulong max1  = hdr->max1;
   ulong cnt   = hdr->cnt;
@@ -520,9 +514,9 @@ DEQUE_(push_head_nocopy)( DEQUE_T * deque ) {
 
 static inline DEQUE_T *
 DEQUE_(push_tail_nocopy)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(full)( deque ) ) ) FD_LOG_CRIT(( "cannot push to full deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   ulong max1 = hdr->max1;
   ulong cnt  = hdr->cnt;
@@ -535,9 +529,9 @@ DEQUE_(push_tail_nocopy)( DEQUE_T * deque ) {
 
 static inline DEQUE_T *
 DEQUE_(pop_head_nocopy)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot pop from empty deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   ulong max1  = hdr->max1;
   ulong cnt   = hdr->cnt;
@@ -550,9 +544,9 @@ DEQUE_(pop_head_nocopy)( DEQUE_T * deque ) {
 
 static inline DEQUE_T *
 DEQUE_(pop_tail_nocopy)( DEQUE_T * deque ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DEQUE_(empty)( deque ) ) ) FD_LOG_CRIT(( "cannot pop from empty deque" ));
-#endif
+# endif
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
   ulong max1 = hdr->max1;
   ulong cnt  = hdr->cnt;
@@ -623,18 +617,18 @@ DEQUE_(iter_prev)( DEQUE_T const * deque, DEQUE_(iter_t) iter ) {
 static inline DEQUE_T *
 DEQUE_(iter_ele)( DEQUE_T * deque, DEQUE_(iter_t) iter ) {
   DEQUE_(private_t) * hdr = DEQUE_(private_hdr_from_deque)( deque );
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( (iter.rem==0) | (iter.rem>hdr->cnt) ) ) FD_LOG_CRIT(( "iter out of bounds" ));
-#endif
+# endif
   return hdr->deque + iter.idx;
 }
 
 static inline DEQUE_T const *
 DEQUE_(iter_ele_const)( DEQUE_T const * deque, DEQUE_(iter_t) iter ) {
   DEQUE_(private_t) const * hdr = DEQUE_(private_const_hdr_from_deque)( deque );
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( (iter.rem==0) | (iter.rem>hdr->cnt) ) ) FD_LOG_CRIT(( "iter out of bounds" ));
-#endif
+# endif
   return hdr->deque + iter.idx;
 }
 

--- a/src/util/tmpl/fd_dlist.c
+++ b/src/util/tmpl/fd_dlist.c
@@ -320,25 +320,23 @@ DLIST_(is_empty)( DLIST_(t) const *   join,
   return DLIST_(private_idx_is_null)( DLIST_(private_idx)( DLIST_(private_const)( join )->head ) );
 }
 
-FD_FN_PURE
-static inline ulong
+FD_FN_PURE static inline ulong
 DLIST_(idx_peek_head)( DLIST_(t) const *   join,
                        DLIST_ELE_T const * pool ) {
   (void)pool;
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DLIST_(is_empty)( join, pool ) ) ) FD_LOG_CRIT(( "cannot peek on empty dlist" ));
-#endif
+# endif
   return DLIST_(private_idx)( DLIST_(private_const)( join )->head );
 }
 
-FD_FN_PURE
-static inline ulong
+FD_FN_PURE static inline ulong
 DLIST_(idx_peek_tail)( DLIST_(t) const *   join,
                        DLIST_ELE_T const * pool ) {
   (void)pool;
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DLIST_(is_empty)( join, pool ) ) ) FD_LOG_CRIT(( "cannot peek on empty dlist" ));
-#endif
+# endif
   return DLIST_(private_idx)( DLIST_(private_const)( join )->tail );
 }
 
@@ -381,9 +379,9 @@ DLIST_(idx_push_tail)( DLIST_(t) *   join,
 static inline ulong
 DLIST_(idx_pop_head)( DLIST_(t) *   join,
                       DLIST_ELE_T * pool ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DLIST_(is_empty)( join, pool ) ) ) FD_LOG_CRIT(( "cannot pop from empty dlist" ));
-#endif
+# endif
   DLIST_(private_t) * dlist = DLIST_(private)( join );
 
   ulong ele_idx  = DLIST_(private_idx)( dlist->head ); /* Not NULL as per contract */
@@ -399,9 +397,9 @@ DLIST_(idx_pop_head)( DLIST_(t) *   join,
 static inline ulong
 DLIST_(idx_pop_tail)( DLIST_(t) *   join,
                       DLIST_ELE_T * pool ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( DLIST_(is_empty)( join, pool ) ) ) FD_LOG_CRIT(( "cannot pop from empty dlist" ));
-#endif
+# endif
   DLIST_(private_t) * dlist = DLIST_(private)( join );
 
   ulong ele_idx  = DLIST_(private_idx)( dlist->tail ); /* Not NULL as per contract */

--- a/src/util/tmpl/fd_heap.c
+++ b/src/util/tmpl/fd_heap.c
@@ -474,9 +474,9 @@ HEAP_STATIC HEAP_(t) *
 HEAP_(idx_insert)( HEAP_(t) * heap,
                    ulong      n,
                    HEAP_T *   pool ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( n>=heap->ele_max ) ) FD_LOG_CRIT(( "n out of range" ));
-#endif
+# endif
 
   HEAP_IDX_T * _p_child = &heap->root;
 
@@ -542,15 +542,16 @@ HEAP_(idx_insert)( HEAP_(t) * heap,
   }
 
   heap->ele_cnt++;
-#if FD_TMPL_USE_HANDHOLDING
-  if( FD_UNLIKELY( HEAP_(verify)( heap, pool )==-1 ) ) FD_LOG_CRIT(( "heap corrupt" ));
-#endif
   return heap;
 }
 
 HEAP_STATIC HEAP_(t) *
 HEAP_(idx_remove_min)( HEAP_(t) * heap,
                        HEAP_T *   pool ) {
+# if FD_TMPL_USE_HANDHOLDING
+  if( FD_UNLIKELY( !heap->ele_cnt ) ) FD_LOG_CRIT(( "heap empty" ));
+# endif
+
   ulong d = (ulong)heap->root;
 
   HEAP_IDX_T * _p_child = &heap->root;
@@ -600,9 +601,6 @@ HEAP_(idx_remove_min)( HEAP_(t) * heap,
   }
 
   heap->ele_cnt--;
-#if FD_TMPL_USE_HANDHOLDING
-  if( FD_UNLIKELY( HEAP_(verify)( heap, pool )==-1 ) ) FD_LOG_CRIT(( "heap corrupt" ));
-#endif
   return heap;
 }
 

--- a/src/util/tmpl/fd_map.c
+++ b/src/util/tmpl/fd_map.c
@@ -285,7 +285,6 @@
 #include "../log/fd_log.h"
 #endif
 
-
 /* Implementation *****************************************************/
 
 #define MAP_(n)       FD_EXPAND_THEN_CONCAT3(MAP_NAME,_,n)
@@ -309,9 +308,9 @@ FD_FN_CONST static inline ulong MAP_(footprint)( void ) { return sizeof(MAP_T)*M
 
 static inline void *
 MAP_(new)( void *  shmem ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, MAP_(align)() ) ) ) FD_LOG_CRIT(( "unaligned shmem" ));
-#endif
+# endif
   MAP_T * map = (MAP_T *)shmem;
   for( ulong slot_idx=0UL; slot_idx<MAP_SLOT_CNT; slot_idx++ ) map[ slot_idx ].MAP_KEY = (MAP_KEY_NULL);
   return map;
@@ -324,12 +323,11 @@ static inline void *  MAP_(delete)( void *  shmap ) { return shmap; }
 FD_FN_CONST static inline ulong MAP_(key_max) ( void ) { return MAP_SLOT_MASK; }
 FD_FN_CONST static inline ulong MAP_(slot_cnt)( void ) { return MAP_SLOT_CNT;  }
 
-FD_FN_CONST
-static inline ulong
+FD_FN_CONST static inline ulong
 MAP_(slot_idx)( MAP_T const * map, MAP_T const * entry ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( ((ulong)(entry-map)>=MAP_SLOT_CNT) | (map>entry) ) ) FD_LOG_CRIT(( "index out of bounds" ));
-#endif
+# endif
   return (ulong)(entry-map);
 }
 
@@ -346,9 +344,9 @@ FD_FN_PURE static inline MAP_HASH_T MAP_(key_hash)( MAP_KEY_T key ) { return (MA
 FD_FN_UNUSED static MAP_T * /* Work around -Winline */
 MAP_(insert)( MAP_T *   map,
               MAP_KEY_T key ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( MAP_(key_inval)( key ) ) ) FD_LOG_CRIT(( "invalid key" ));
-#endif
+# endif
   MAP_HASH_T hash = MAP_(key_hash)( key );
   ulong slot = MAP_(private_start)( hash );
   MAP_T * m;
@@ -414,7 +412,7 @@ MAP_(remove)( MAP_T * map,
 
     MAP_MOVE( map[hole], map[slot] );
   }
-  __builtin_unreachable();
+  /* never get here */
 }
 
 static inline void
@@ -422,14 +420,13 @@ MAP_(clear)( MAP_T * map ) {
   for( ulong slot_idx=0UL; slot_idx<MAP_SLOT_CNT; slot_idx++ ) map[ slot_idx ].MAP_KEY = (MAP_KEY_NULL);
 }
 
-FD_FN_PURE
-FD_FN_UNUSED static MAP_T * /* Work around -Winline */
+FD_FN_PURE FD_FN_UNUSED static MAP_T * /* Work around -Winline */
 MAP_(query)( MAP_T *   map,
              MAP_KEY_T key,
              MAP_T *   null ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( MAP_KEY_INVAL( key ) ) ) FD_LOG_CRIT(( "invalid key" ));
-#endif
+# endif
   MAP_HASH_T hash = MAP_(key_hash)( key );
   ulong slot = MAP_(private_start)( hash );
   MAP_T * m;
@@ -465,8 +462,7 @@ MAP_(query)( MAP_T *   map,
   return m;
 }
 
-FD_FN_PURE
-static inline MAP_T const *
+FD_FN_PURE static inline MAP_T const *
 MAP_(query_const)( MAP_T const * map,
                    MAP_KEY_T     key,
                    MAP_T const * null ) {

--- a/src/util/tmpl/fd_map_chain.c
+++ b/src/util/tmpl/fd_map_chain.c
@@ -516,14 +516,13 @@ MAP_(iter_done)( MAP_(iter_t)      iter,
   return !iter.chain_rem;
 }
 
-FD_FN_PURE
-static inline MAP_(iter_t)
+FD_FN_PURE static inline MAP_(iter_t)
 MAP_(iter_next)( MAP_(iter_t)      iter,
                  MAP_(t) const *   join,
                  MAP_ELE_T const * pool ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( MAP_(iter_done)( iter, join, pool ) ) ) FD_LOG_CRIT(( "assumes not done" ));
-#endif
+# endif
   ulong chain_rem = iter.chain_rem;
   ulong ele_idx   = iter.ele_idx;
 
@@ -554,38 +553,35 @@ MAP_(iter_next)( MAP_(iter_t)      iter,
   return iter;
 }
 
-FD_FN_CONST
-static inline ulong
+FD_FN_CONST static inline ulong
 MAP_(iter_idx)( MAP_(iter_t)    iter,
                 MAP_(t) const * join,
                 MAP_ELE_T *     pool ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( MAP_(iter_done)( iter, join, pool ) ) ) FD_LOG_CRIT(( "assumes not done" ));
-#endif
+# endif
   (void)join; (void)pool;
   return iter.ele_idx;
 }
 
-FD_FN_CONST
-static inline MAP_ELE_T *
+FD_FN_CONST static inline MAP_ELE_T *
 MAP_(iter_ele)( MAP_(iter_t)    iter,
                 MAP_(t) const * join,
                 MAP_ELE_T *     pool ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( MAP_(iter_done)( iter, join, pool ) ) ) FD_LOG_CRIT(( "assumes not done" ));
-#endif
+# endif
   (void)join;
   return pool + iter.ele_idx;
 }
 
-FD_FN_CONST
-static inline MAP_ELE_T const *
+FD_FN_CONST static inline MAP_ELE_T const *
 MAP_(iter_ele_const) ( MAP_(iter_t)      iter,
                        MAP_(t) const *   join,
                        MAP_ELE_T const * pool ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( MAP_(iter_done)( iter, join, pool ) ) ) FD_LOG_CRIT(( "assumes not done" ));
-#endif
+# endif
   (void)join;
   return pool + iter.ele_idx;
 }
@@ -800,17 +796,17 @@ MAP_IMPL_STATIC MAP_(t) *
 MAP_(idx_insert)( MAP_(t) *   join,
                   ulong       ele_idx,
                   MAP_ELE_T * pool ) {
-#if FD_TMPL_USE_HANDHOLDING && !MAP_MULTI
+# if FD_TMPL_USE_HANDHOLDING && !MAP_MULTI
   if( FD_UNLIKELY( MAP_(idx_query)( join, &pool[ ele_idx ].MAP_KEY, 0UL, pool ) ) ) FD_LOG_CRIT(( "ele_idx already in map" ));
-#endif
+# endif
   MAP_(private_t) * map = MAP_(private)( join );
 
   MAP_IDX_T * head = MAP_(private_chain)( map ) + MAP_(private_chain_idx)( &pool[ ele_idx ].MAP_KEY, map->seed, map->chain_cnt );
 
-#if MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL
+# if MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL
   if( FD_UNLIKELY( !MAP_(private_idx_is_null)( *head ) ) ) pool[ *head ].MAP_PREV = MAP_(private_box)( ele_idx );
   pool[ ele_idx ].MAP_PREV = MAP_(private_box)( MAP_(private_idx_null)() );
-#endif
+# endif
   pool[ ele_idx ].MAP_NEXT = *head;
   *head = MAP_(private_box)( ele_idx );
 

--- a/src/util/tmpl/fd_map_dynamic.c
+++ b/src/util/tmpl/fd_map_dynamic.c
@@ -331,10 +331,10 @@ MAP_(footprint)( int lg_slot_cnt ) {
 static inline void *
 MAP_(new)( void *  shmem,
            int     lg_slot_cnt ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, MAP_(align)() ) ) ) FD_LOG_CRIT(( "unaligned shmem" ));
-  if( FD_UNLIKELY( (lg_slot_cnt<0) | (lg_slot_cnt>63)  ) ) FD_LOG_CRIT(( "invalid lg_slot_cnt" ));
-#endif
+  if( FD_UNLIKELY( (lg_slot_cnt<0) | (lg_slot_cnt>63)                  ) ) FD_LOG_CRIT(( "invalid lg_slot_cnt" ));
+# endif
   ulong slot_cnt  = 1UL<<lg_slot_cnt;
   ulong slot_mask = slot_cnt - 1UL;
   MAP_(private_t) * map = (MAP_(private_t) *)shmem;
@@ -368,9 +368,9 @@ FD_FN_PURE static inline ulong MAP_(slot_cnt)   ( MAP_T const * slot ) { return 
 
 FD_FN_CONST static inline ulong
 MAP_(slot_idx)( MAP_T const * map, MAP_T const * entry ) {
-#if FD_TMPL_USE_HANDHOLDING
-if( FD_UNLIKELY( ((ulong)(entry-map)>=MAP_(slot_cnt)( map )) | (map>entry) ) ) FD_LOG_CRIT(( "index out of bounds" ));
-#endif
+# if FD_TMPL_USE_HANDHOLDING
+  if( FD_UNLIKELY( ((ulong)(entry-map)>=MAP_(slot_cnt)( map )) | (map>entry) ) ) FD_LOG_CRIT(( "index out of bounds" ));
+# endif
   return (ulong)(entry-map);
 }
 
@@ -387,9 +387,9 @@ FD_FN_PURE static inline MAP_HASH_T MAP_(key_hash)( MAP_KEY_T key ) { return (MA
 FD_FN_UNUSED static MAP_T * /* Work around -Winline */
 MAP_(insert)( MAP_T *   map,
               MAP_KEY_T key ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( MAP_(key_inval)( key ) ) ) FD_LOG_CRIT(( "invalid key" ));
-#endif
+# endif
   MAP_(private_t) * hdr = MAP_(private_from_slot)( map );
 
   ulong key_cnt   = hdr->key_cnt;
@@ -467,7 +467,7 @@ MAP_(remove)( MAP_T * map,
 
     MAP_MOVE( map[hole], map[slot] );
   }
-  __builtin_unreachable();
+  /* never get here */
 }
 
 static inline void
@@ -480,14 +480,13 @@ MAP_(clear)( MAP_T * map ) {
     slot[ slot_idx ].MAP_KEY = (MAP_KEY_NULL);
 }
 
-FD_FN_PURE
-FD_FN_UNUSED static MAP_T * /* Work around -Winline */
+FD_FN_PURE FD_FN_UNUSED static MAP_T * /* Work around -Winline */
 MAP_(query)( MAP_T *   map,
              MAP_KEY_T key,
              MAP_T *   null ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( MAP_KEY_INVAL( key ) ) ) FD_LOG_CRIT(( "invalid key" ));
-#endif
+# endif
   ulong      slot_mask = MAP_(private_from_slot)( map )->slot_mask;
   MAP_HASH_T hash      = MAP_(key_hash)( key );
   ulong      slot      = MAP_(private_start)( hash, slot_mask );

--- a/src/util/tmpl/fd_map_giant.c
+++ b/src/util/tmpl/fd_map_giant.c
@@ -940,9 +940,9 @@ MAP_(verify)( MAP_T const * join ) {
 MAP_IMPL_STATIC MAP_T *
 MAP_(insert)( MAP_T *           join,
               MAP_KEY_T const * key ) {
-#if FD_TMPL_USE_HANDHOLDING
-  if( FD_UNLIKELY( MAP_(key_cnt)( join )+1>MAP_(key_max)( join ) ) ) FD_LOG_CRIT(( "map is full" ));
-#endif
+# if FD_TMPL_USE_HANDHOLDING
+  if( FD_UNLIKELY( MAP_(key_cnt)( join )>=MAP_(key_max)( join ) ) ) FD_LOG_CRIT(( "map is full" ));
+# endif
   MAP_(private_t) * map = MAP_(private)( join );
 
   /* Pop the free stack to allocate an element (this is guaranteed to
@@ -963,18 +963,18 @@ MAP_(insert)( MAP_T *           join,
   ulong * head = MAP_(private_list)( map ) + ( hash & (map->list_cnt-1UL) );
   MAP_(key_copy)( &ele->MAP_KEY, key );
   ele->MAP_NEXT = MAP_(private_box_next)( MAP_(private_unbox_idx)( *head ), 0 );
-#if MAP_MEMOIZE
+# if MAP_MEMOIZE
   ele->MAP_HASH = hash;
-#endif
+# endif
   *head = MAP_(private_box_next)( ele_idx, 0 );
   return ele;
 }
 
 MAP_IMPL_STATIC MAP_T *
 MAP_(pop_free_ele)( MAP_T * join ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( !MAP_(key_cnt)( join ) ) ) FD_LOG_CRIT(( "map is empty" ));
-#endif
+# endif
   MAP_(private_t) * map = MAP_(private)( join );
 
   /* Pop the free stack to allocate an element (this is guaranteed to

--- a/src/util/tmpl/fd_map_para.c
+++ b/src/util/tmpl/fd_map_para.c
@@ -12,7 +12,7 @@
    element managed by that chain, the chain's version number is
    increased by one (atomic fetch-and-or based) such that other
    potential users of keys managed by that chain detect and react
-   appropriately to a potentially concurrent conflicting operation is in
+   appropriately to a potentially concurrent conflicting operation in
    progress.  When an operation completes, the chain version number is
    increased by one again to notify other users the operation is no
    longer in progress and that the set of keys managed by that chain

--- a/src/util/tmpl/fd_pool.c
+++ b/src/util/tmpl/fd_pool.c
@@ -341,33 +341,30 @@ POOL_(ele_test)( POOL_T const * join,
   return (!ele) | ((idx<max) & ((ulong)ele==((ulong)join+(idx*sizeof(POOL_T))))); /* last test checks alignment */
 }
 
-FD_FN_CONST
-static inline ulong
+FD_FN_CONST static inline ulong
 POOL_(idx)( POOL_T const * join,
             POOL_T const * ele ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( !POOL_(ele_test)( join, ele ) ) ) FD_LOG_CRIT(( "no such element" ));
-#endif
-return ele ? (ulong)(ele-join) : POOL_IDX_NULL;
+# endif
+  return ele ? (ulong)(ele-join) : POOL_IDX_NULL;
 }
 
-FD_FN_CONST
-static inline POOL_T *
+FD_FN_CONST static inline POOL_T *
 POOL_(ele)( POOL_T *   join,
             ulong      idx ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( !POOL_(idx_test)( join, idx ) ) ) FD_LOG_CRIT(( "no such index" ));
-#endif
+# endif
   return (idx==POOL_IDX_NULL) ? NULL : (join + idx);
 }
 
-FD_FN_CONST
-static inline POOL_T const *
+FD_FN_CONST static inline POOL_T const *
 POOL_(ele_const)( POOL_T const *   join,
                   ulong            idx ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( !POOL_(idx_test)( join, idx ) ) ) FD_LOG_CRIT(( "no such index" ));
-#endif
+# endif
   return (idx==POOL_IDX_NULL) ? NULL : (join + idx);
 }
 
@@ -387,9 +384,9 @@ POOL_(used)( POOL_T const * join ) {
 static inline ulong
 POOL_(idx_acquire)( POOL_T * join ) {
   POOL_(private_t) * meta = POOL_(private_meta)( join );
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( !meta->free ) ) FD_LOG_CRIT(( "pool is full" ));
-#endif
+# endif
   ulong idx = meta->free_top;
   meta->free_top = (ulong)join[ idx ].POOL_NEXT;
   meta->free--;
@@ -400,15 +397,15 @@ static inline void
 POOL_(idx_release)( POOL_T * join,
                     ulong    idx ) {
   POOL_(private_t) * meta = POOL_(private_meta)( join );
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( (meta->max<=idx) | (idx==POOL_IDX_NULL) ) ) FD_LOG_CRIT(( "invalid index" ));
-#if POOL_SENTINEL
+# if POOL_SENTINEL
   if( FD_UNLIKELY( POOL_(idx_sentinel)( join )==idx ) ) FD_LOG_CRIT(( "cannot releaes sentinel" ));
   if( FD_UNLIKELY( meta->free>=meta->max-1 ) ) FD_LOG_CRIT(( "pool is empty" ));
-#else
+# else
   if( FD_UNLIKELY( meta->free>=meta->max ) ) FD_LOG_CRIT(( "pool is empty" ));
-#endif
-#endif
+# endif
+# endif
   join[ idx ].POOL_NEXT = (POOL_IDX_T)meta->free_top;
   meta->free_top = idx;
   meta->free++;

--- a/src/util/tmpl/fd_prq.c
+++ b/src/util/tmpl/fd_prq.c
@@ -393,9 +393,9 @@ PRQ_(footprint)( ulong max ) {
 static inline void *
 PRQ_(new)( void * mem,
            ulong  max ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( !mem | !fd_ulong_is_aligned( (ulong)mem, PRQ_(align)() ) ) ) FD_LOG_CRIT(( "invalid mem" ));
-#endif
+# endif
   /* FIXME: VALIDATE MEM AND MAX? */
   PRQ_(private_t) * prq = (PRQ_(private_t) *)mem;
   prq->cnt = 0UL;
@@ -415,9 +415,9 @@ PRQ_(insert)( PRQ_T *       heap,
               PRQ_T const * event ) {
   PRQ_(private_t) * prq = PRQ_(private_from_heap)( heap );
   ulong hole = prq->cnt++;
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( hole==prq->max ) ) FD_LOG_CRIT(( "prq full" ));
-#endif
+# endif
   PRQ_(private_fill_hole_up)( heap, hole, event );
   return heap;
 }
@@ -425,9 +425,9 @@ PRQ_(insert)( PRQ_T *       heap,
 static inline PRQ_T *
 PRQ_(remove_min)( PRQ_T * heap ) {
   PRQ_(private_t) * prq = PRQ_(private_from_heap)( heap );
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( prq->cnt==0UL ) ) FD_LOG_CRIT(( "prq empty" ));
-#endif
+# endif
   ulong cnt = --prq->cnt;
   PRQ_(private_fill_hole_dn)( heap, 0UL, cnt );
   return heap;
@@ -437,9 +437,9 @@ static inline PRQ_T *
 PRQ_(remove)( PRQ_T * heap,
               ulong   idx ) {
   PRQ_(private_t) * prq = PRQ_(private_from_heap)( heap );
-#if FD_TMPL_USE_HANDHOLDING
-if( FD_UNLIKELY( prq->cnt==0UL ) ) FD_LOG_CRIT(( "prq empty" ));
-#endif
+# if FD_TMPL_USE_HANDHOLDING
+  if( FD_UNLIKELY( prq->cnt==0UL ) ) FD_LOG_CRIT(( "prq empty" ));
+# endif
   ulong cnt = --prq->cnt;
   PRQ_(private_fill_hole)( heap, idx, cnt );
   return heap;

--- a/src/util/tmpl/fd_set_dynamic.c
+++ b/src/util/tmpl/fd_set_dynamic.c
@@ -157,6 +157,18 @@
      my_set_t * my_set_xor       ( my_set_t * z, my_set_t const * x, my_set_t const * y );        // z = (x u y) - (x n y)
      my_set_t * my_set_if        ( my_set_t * z, int c, my_set_t const * x, my_set_t const * y ); // z = c ? x : y
 
+     // Range APIs do fast operations for a contiguous range within a
+     // my_set.  Ranges are specified on the half-open interval [l,h).
+     // These all assume 0<=l<=h<=max.
+
+     my_set_t * my_set_range( my_set_t * z, ulong l, ulong h );        // z = r where r is the set with elements [l,h), fast O(max)
+
+     my_set_t * my_set_insert_range( my_set_t * z, ulong l, ulong h ); // z = z u r, fast O(h-l)
+     my_set_t * my_set_select_range( my_set_t * z, ulong l, ulong h ); // z = z n r, fast O(max-(h-l))
+     my_set_t * my_set_remove_range( my_set_t * z, ulong l, ulong h ); // z = z - r, fast O(h-l)
+
+     ulong my_set_range_cnt( my_set_t const * x, ulong l, ulong h );   // returns cnt( z n r ), in [0,h-l], fast O(h-l)
+
    With the exception of my_set_valid_idx and my_set_valid, all of these
    assume the inputs are value and will produce strictly valid outputs
    unless otherwise explicitly noted. */
@@ -233,10 +245,10 @@ SET_(footprint)( ulong max ) {
 FD_FN_UNUSED static void * /* Work around -Winline */
 SET_(new)( void * shmem,
            ulong  max ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, SET_(align)() ) ) ) FD_LOG_CRIT(( "unaligned shmem" ));
-  if( FD_UNLIKELY( (max<1UL) | (max>ULONG_MAX-63UL) ) ) FD_LOG_CRIT(( "max out of bounds" ));
-#endif
+  if( FD_UNLIKELY( (max<1UL) | (max>ULONG_MAX-63UL)                    ) ) FD_LOG_CRIT(( "max out of bounds" ));
+# endif
   SET_(private_t) * hdr = (SET_(private_t) *)shmem;
 
   ulong word_cnt = SET_(private_word_cnt)( max );
@@ -345,9 +357,9 @@ FD_FN_CONST static inline ulong SET_(const_iter_done)( ulong j ) { return !~j; }
 static inline SET_(t) *
 SET_(insert)( SET_(t) * set,
               ulong     idx ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( !SET_(valid_idx)( set, idx ) ) ) FD_LOG_CRIT(( "idx out of bounds" ));
-#endif
+# endif
   set[ idx >> 6 ] |= 1UL << (idx & 63UL);
   return set;
 }
@@ -355,9 +367,9 @@ SET_(insert)( SET_(t) * set,
 static inline SET_(t) *
 SET_(remove)( SET_(t) * set,
               ulong     idx ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( !SET_(valid_idx)( set, idx ) ) ) FD_LOG_CRIT(( "idx out of bounds" ));
-#endif
+# endif
   set[ idx >> 6 ] &= ~(1UL << (idx & 63UL));
   return set;
 }
@@ -366,9 +378,9 @@ static inline SET_(t) *
 SET_(insert_if)( SET_(t) * set,
                  int       c,
                  ulong     idx ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( !SET_(valid_idx)( set, idx ) ) ) FD_LOG_CRIT(( "idx out of bounds" ));
-#endif
+# endif
   set[ idx >> 6 ] |= ((ulong)!!c) << (idx & 63UL);
   return set;
 }
@@ -377,20 +389,19 @@ static inline SET_(t) *
 SET_(remove_if)( SET_(t) * set,
                  int       c,
                  ulong     idx ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( !SET_(valid_idx)( set, idx ) ) ) FD_LOG_CRIT(( "idx out of bounds" ));
-#endif
+# endif
   set[ idx >> 6 ] &= ~(((ulong)!!c) << (idx & 63UL));
   return set;
 }
 
-FD_FN_PURE
-static inline int
+FD_FN_PURE static inline int
 SET_(test)( SET_(t) const * set,
             ulong           idx ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( !SET_(valid_idx)( set, idx ) ) ) FD_LOG_CRIT(( "idx out of bounds" ));
-#endif
+# endif
   return (int)((set[ idx >> 6 ] >> (idx & 63UL)) & 1UL);
 }
 
@@ -510,6 +521,201 @@ SET_(if)( SET_(t) *       z,
           SET_(t) const * x,
           SET_(t) const * y ) {
   return SET_(copy)( z, c ? x : y );
+}
+
+static inline SET_(t) *
+SET_(range)( SET_(t) * set,
+             ulong     l,
+             ulong     h ) {
+  SET_(private_t) * hdr = SET_(private_hdr_from_set)( set );
+
+# if FD_TMPL_USE_HANDHOLDING
+  if( FD_UNLIKELY( !( (l<=h) & (h<=hdr->max) ) ) ) FD_LOG_CRIT(( "invalid range" ));
+# endif
+
+  ulong word_idx = 0UL;
+
+  /* Handle any complete leading zero words */
+
+  for( ulong stop_idx=l>>6; word_idx<stop_idx; word_idx++ ) set[ word_idx ] = 0UL; /* FIXME: Consider memset? */
+
+  /* Handle any mixed leading word.  Note that it is possible the range
+     also ends in this word. */
+
+  ulong zcnt = l & 63UL; // == l - (word_idx<<6); /* In [0,63] */
+  if( FD_LIKELY( zcnt ) ) set[ word_idx++ ] = ((1UL << fd_ulong_min( 64UL-zcnt, h-l ))-1UL) << zcnt; /* opt large range */
+
+  /* Handle any complete ones words.  Need to be careful as 64 word_idx
+     might already be past h if the range ended in the mixed leading
+     word. */
+
+  for( ulong stop_idx=h>>6; word_idx<stop_idx; word_idx++ ) set[ word_idx ] = ~0UL; /* FIXME: Consider memset? */
+
+  /* Handle any mixed trailing word.  Like the above, 64 word_idx might
+     already be past h at this point. */
+
+  ulong ocnt = h - fd_ulong_min( word_idx<<6, h ); /* in [0,63] */
+  if( FD_LIKELY( ocnt ) ) set[ word_idx++ ] = ((1UL << ocnt)-1UL); /* opt large range */
+
+  /* Handle any complete trailing zero words */
+
+  for( ulong stop_idx=hdr->word_cnt; word_idx<stop_idx; word_idx++ ) set[ word_idx ] = 0UL; /* FIXME: Consider memset? */
+
+  return set;
+}
+
+static inline SET_(t) *
+SET_(insert_range)( SET_(t) * set,
+                    ulong     l,
+                    ulong     h ) {
+
+# if FD_TMPL_USE_HANDHOLDING
+  SET_(private_t) * hdr = SET_(private_hdr_from_set)( set );
+  if( FD_UNLIKELY( !( (l<=h) & (h<=hdr->max) ) ) ) FD_LOG_CRIT(( "invalid range" ));
+# endif
+
+  /* Handle any complete leading zero words */
+
+  ulong word_idx = l>>6;
+
+  /* Handle any mixed leading word.  Note that it is possible the range
+     also ends in this word. */
+
+  ulong zcnt = l & 63UL; // == l - (word_idx<<6); /* In [0,63] */
+  if( FD_LIKELY( zcnt ) ) set[ word_idx++ ] |= ((1UL << fd_ulong_min( 64UL-zcnt, h-l ))-1UL) << zcnt; /* opt large range */
+
+  /* Handle any complete ones words.  Need to be careful as 64 word_idx
+     might already be past h if the range ended in the mixed leading
+     word. */
+
+  for( ulong stop_idx=h>>6; word_idx<stop_idx; word_idx++ ) set[ word_idx ] = ~0UL; /* FIXME: Consider memset? */
+
+  /* Handle any mixed trailing word.  Like the above, 64 word_idx might
+     already be past h at this point. */
+
+  ulong ocnt = h - fd_ulong_min( word_idx<<6, h ); /* in [0,63] */
+  if( FD_LIKELY( ocnt ) ) set[ word_idx++ ] |= ((1UL << ocnt)-1UL); /* opt large range */
+
+  /* Handle any complete trailing zero words */
+
+  return set;
+}
+
+static inline SET_(t) *
+SET_(select_range)( SET_(t) * set,
+                    ulong     l,
+                    ulong     h ) {
+  SET_(private_t) * hdr = SET_(private_hdr_from_set)( set );
+
+# if FD_TMPL_USE_HANDHOLDING
+  if( FD_UNLIKELY( !( (l<=h) & (h<=hdr->max) ) ) ) FD_LOG_CRIT(( "invalid range" ));
+# endif
+
+  ulong word_idx = 0UL;
+
+  /* Handle any complete leading zero words */
+
+  for( ulong stop_idx=l>>6; word_idx<stop_idx; word_idx++ ) set[ word_idx ] = 0UL; /* FIXME: Consider memset? */
+
+  /* Handle any mixed leading word.  Note that it is possible the range
+     also ends in this word. */
+
+  ulong zcnt = l & 63UL; // == l - (word_idx<<6); /* In [0,63] */
+  if( FD_LIKELY( zcnt ) ) set[ word_idx++ ] &= ((1UL << fd_ulong_min( 64UL-zcnt, h-l ))-1UL) << zcnt; /* opt large range */
+
+  /* Handle any complete ones words.  Need to be careful as 64 word_idx
+     might already be past h if the range ended in the mixed leading
+     word. */
+
+  word_idx = fd_ulong_max( word_idx, h>>6 );
+
+  /* Handle any mixed trailing word.  Like the above, 64 word_idx might
+     already be past h at this point. */
+
+  ulong ocnt = h - fd_ulong_min( word_idx<<6, h ); /* in [0,63] */
+  if( FD_LIKELY( ocnt ) ) set[ word_idx++ ] &= ((1UL << ocnt)-1UL); /* opt large range */
+
+  /* Handle any complete trailing zero words */
+
+  for( ulong stop_idx=hdr->word_cnt; word_idx<stop_idx; word_idx++ ) set[ word_idx ] = 0UL; /* FIXME: Consider memset? */
+
+  return set;
+}
+
+static inline SET_(t) *
+SET_(remove_range)( SET_(t) * set,
+                    ulong     l,
+                    ulong     h ) {
+
+# if FD_TMPL_USE_HANDHOLDING
+  SET_(private_t) * hdr = SET_(private_hdr_from_set)( set );
+  if( FD_UNLIKELY( !( (l<=h) & (h<=hdr->max) ) ) ) FD_LOG_CRIT(( "invalid range" ));
+# endif
+
+  /* Handle any complete leading zero words */
+
+  ulong word_idx = l>>6;
+
+  /* Handle any mixed leading word.  Note that it is possible the range
+     also ends in this word. */
+
+  ulong zcnt = l & 63UL; // == l - (word_idx<<6); /* In [0,63] */
+  if( FD_LIKELY( zcnt ) ) set[ word_idx++ ] &= ~(((1UL << fd_ulong_min( 64UL-zcnt, h-l ))-1UL) << zcnt); /* opt large range */
+
+  /* Handle any complete ones words.  Need to be careful as 64 word_idx
+     might already be past h if the range ended in the mixed leading
+     word. */
+
+  for( ulong stop_idx=h>>6; word_idx<stop_idx; word_idx++ ) set[ word_idx ] = 0UL; /* FIXME: Consider memset? */
+
+  /* Handle any mixed trailing word.  Like the above, 64 word_idx might
+     already be past h at this point. */
+
+  ulong ocnt = h - fd_ulong_min( word_idx<<6, h ); /* in [0,63] */
+  if( FD_LIKELY( ocnt ) ) set[ word_idx++ ] &= ~((1UL << ocnt)-1UL); /* opt large range */
+
+  /* Handle any complete trailing zero words */
+
+  return set;
+}
+
+FD_FN_PURE static inline ulong
+SET_(range_cnt)( SET_(t) const * set,
+                 ulong           l,
+                 ulong           h ) {
+
+# if FD_TMPL_USE_HANDHOLDING
+  SET_(private_t) const * hdr = SET_(private_hdr_from_set_const)( set );
+  if( FD_UNLIKELY( !( (l<=h) & (h<=hdr->max) ) ) ) FD_LOG_CRIT(( "invalid range" ));
+# endif
+
+  ulong cnt = 0UL;
+
+  /* Handle any complete leading zero words */
+
+  ulong word_idx = l>>6;
+
+  /* Handle any mixed leading word.  Note that it is possible the range
+     also ends in this word. */
+
+  ulong zcnt = l & 63UL; // == l - (word_idx<<6); /* In [0,63] */
+  if( FD_LIKELY( zcnt ) ) cnt += (ulong)fd_ulong_popcnt( set[ word_idx++ ] & (((1UL << fd_ulong_min( 64UL-zcnt, h-l ))-1UL) << zcnt) ); /* opt large range */
+
+  /* Handle any complete ones words.  Need to be careful as 64 word_idx
+     might already be past h if the range ended in the mixed leading
+     word. */
+
+  for( ulong stop_idx=h>>6; word_idx<stop_idx; word_idx++ ) cnt += (ulong)fd_ulong_popcnt( set[ word_idx ] );
+
+  /* Handle any mixed trailing word.  Like the above, 64 word_idx might
+     already be past h at this point. */
+
+  ulong ocnt = h - fd_ulong_min( word_idx<<6, h ); /* in [0,63] */
+  if( FD_LIKELY( ocnt ) ) cnt += (ulong)fd_ulong_popcnt( set[ word_idx++ ] & ((1UL << ocnt)-1UL) ); /* opt large range */
+
+  /* Handle any complete trailing zero words */
+
+  return cnt;
 }
 
 FD_PROTOTYPES_END

--- a/src/util/tmpl/fd_smallset.c
+++ b/src/util/tmpl/fd_smallset.c
@@ -13,8 +13,8 @@
      myset_t myset_null   ( void           ); // return {}
      myset_t myset_full   ( void           ); // return ~{}
      myset_t myset_full_if( int c          ); // return c ? ~{} : {}
-     myset_t myset_ele    ( ulong i        ); // return { i }
-     myset_t myset_ele_if ( int c, ulong i ); // return c ? { i } : {}
+     myset_t myset_ele    ( ulong i        ); // return { i }          // Assumes 0<=i<max
+     myset_t myset_ele_if ( int c, ulong i ); // return c ? { i } : {} // Assumes 0<=i<max
 
      // Index operations
      ulong myset_max  ( void      ); // return the maximum number of elements that can be held by the set,
@@ -62,11 +62,24 @@
      ulong        myset_iter_idx ( myset_iter_t iter );
 
      // Misc
+
      myset_t myset_insert( myset_t x, ulong i ); // short for myset_union   ( x, myset_ele( i ) )
      myset_t myset_remove( myset_t x, ulong i ); // short for myset_subtract( x, myset_ele( i ) )
 
-     myset_t myset_insert_if( int c, myset_t x, ulong i ); // Fast implementation of "c ? myset_insert( x, i ) : x;"
-     myset_t myset_remove_if( int c, myset_t x, ulong i ); // Fast implementation of "c ? myset_remove( x, i ) : y;"
+     myset_t myset_insert_if( int c, myset_t x, ulong i ); // Fast impl of "c ? myset_insert( x, i ) : x;"
+     myset_t myset_remove_if( int c, myset_t x, ulong i ); // Fast impl of "c ? myset_remove( x, i ) : x;"
+
+     // Range APIs do fast O(1) operations for a contiguous range within
+     // a myset.  Ranges are specified on the half-open interval [l,h).
+     // These all assume 0<=l<=h<=max.
+
+     myset_t myset_range( ulong l, ulong h );                   // returns set containing elements [l,h).
+
+     myset_t myset_insert_range( myset_t x, ulong l, ulong h ); // returns myset_union    ( x, myset_range( l, h ) )
+     myset_t myset_select_range( myset_t x, ulong l, ulong h ); // returns myset_intersect( x, myset_range( l, h ) )
+     myset_t myset_remove_range( myset_t x, ulong l, ulong h ); // returns myset_subtract ( x, myset_range( l, h ) )
+
+     ulong myset_range_cnt( myset_t x, ulong l, ulong h );      // returns myset_cnt( myset_select_range( x, l, h ) )
 
      // With the exceptions of myidx_valid_idx and myset_valid, all
      // these assume their inputs are valid and produce valid well
@@ -128,9 +141,10 @@
 #define SET_(x)FD_EXPAND_THEN_CONCAT3(SET_NAME,_,x)
 
 enum {
-  SET_(MAX)             = (SET_MAX),
-  SET_(PRIVATE_BIT_CNT) = 8*(int)sizeof(SET_TYPE),
-  SET_(PRIVATE_ZP_CNT)  = SET_(PRIVATE_BIT_CNT) - SET_(MAX)
+  SET_(MAX)              = (SET_MAX),
+  SET_(PRIVATE_BIT_CNT)  = 8*(int)sizeof(SET_TYPE),
+  SET_(PRIVATE_ZP_CNT)   = SET_(PRIVATE_BIT_CNT) - SET_(MAX),
+  SET_(PRIVATE_IDX_MASK) = SET_(PRIVATE_BIT_CNT) - 1
 };
 
 FD_STATIC_ASSERT( 0<SET_(MAX) && SET_(MAX)<=SET_(PRIVATE_BIT_CNT),              range );
@@ -153,21 +167,19 @@ SET_(full_if)( int c ) {
 /* Handles >=0 for negative types too */
 FD_FN_CONST static inline int SET_(valid_idx)( SET_IDX_T i ) { return ((ulong)(long)i)<((ulong)SET_(MAX)); }
 
-FD_FN_CONST
-static inline SET_(t)
+FD_FN_CONST static inline SET_(t)
 SET_(ele)( SET_IDX_T i ) {
-#if FD_TMPL_USE_HANDHOLDING
-if( FD_UNLIKELY( !SET_(valid_idx)( i ) ) ) FD_LOG_CRIT(( "invalid index" ));
-#endif
-return (SET_(t))(((SET_(t))1) << i);
+# if FD_TMPL_USE_HANDHOLDING
+  if( FD_UNLIKELY( !SET_(valid_idx)( i ) ) ) FD_LOG_CRIT(( "invalid index" ));
+# endif
+  return (SET_(t))(((SET_(t))1) << i);
 }
 
-FD_FN_CONST
-static inline SET_(t)
+FD_FN_CONST static inline SET_(t)
 SET_(ele_if)( int c, SET_IDX_T i ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( !SET_(valid_idx)( i ) ) ) FD_LOG_CRIT(( "invalid index" ));
-#endif
+# endif
   return (SET_(t))(((SET_(t))!!c) << i);
 }
 
@@ -175,28 +187,27 @@ FD_FN_CONST static inline SET_IDX_T SET_(max)  ( void      ) { return (SET_IDX_T
 FD_FN_CONST static inline SET_IDX_T SET_(cnt)  ( SET_(t) x ) { return (SET_IDX_T)SET_POPCNT(x);   }
 FD_FN_CONST static inline SET_IDX_T SET_(first)( SET_(t) x ) { return (SET_IDX_T)SET_FIND_LSB(x); }
 
-FD_FN_CONST static inline int SET_(valid)    ( SET_(t)   x ) { return !(x & ~SET_(full)());       }
-FD_FN_CONST static inline int SET_(is_null)  ( SET_(t)   x ) { return !x;                         }
-FD_FN_CONST static inline int SET_(is_full)  ( SET_(t)   x ) { return x==SET_(full)();            }
+FD_FN_CONST static inline int SET_(valid)    ( SET_(t)   x ) { return !(x & (SET_(t))~SET_(full)()); }
+FD_FN_CONST static inline int SET_(is_null)  ( SET_(t)   x ) { return !x;                            }
+FD_FN_CONST static inline int SET_(is_full)  ( SET_(t)   x ) { return x==SET_(full)();               }
 
-FD_FN_CONST
-static inline int
+FD_FN_CONST static inline int
 SET_(test) ( SET_(t) x, SET_IDX_T i ) {
-#if FD_TMPL_USE_HANDHOLDING
+# if FD_TMPL_USE_HANDHOLDING
   if( FD_UNLIKELY( !SET_(valid_idx)( i ) ) ) FD_LOG_CRIT(( "invalid index" ));
-#endif
+# endif
   return (int)((x>>i) & ((SET_(t))1));
 }
 
-FD_FN_CONST static inline int SET_(eq)       ( SET_(t)   x, SET_(t)   y ) { return x==y;                                }
-FD_FN_CONST static inline int SET_(subset)   ( SET_(t)   x, SET_(t)   y ) { return x==(x & y);                          }
+FD_FN_CONST static inline int SET_(eq)       ( SET_(t)   x, SET_(t)   y ) { return x==y;       }
+FD_FN_CONST static inline int SET_(subset)   ( SET_(t)   x, SET_(t)   y ) { return x==(x & y); }
 
 FD_FN_CONST static inline SET_(t) SET_(copy)      ( SET_(t) x ) { return x;                }
 FD_FN_CONST static inline SET_(t) SET_(complement)( SET_(t) x ) { return x ^ SET_(full)(); }
 
 FD_FN_CONST static inline SET_(t) SET_(union)    ( SET_(t) x, SET_(t) y ) { return x | y;  }
 FD_FN_CONST static inline SET_(t) SET_(intersect)( SET_(t) x, SET_(t) y ) { return x & y;  }
-FD_FN_CONST static inline SET_(t) SET_(subtract) ( SET_(t) x, SET_(t) y ) { return (SET_(t))(x & ~y); }
+FD_FN_CONST static inline SET_(t) SET_(subtract) ( SET_(t) x, SET_(t) y ) { return x & (SET_(t))~y; }
 FD_FN_CONST static inline SET_(t) SET_(xor)      ( SET_(t) x, SET_(t) y ) { return x ^ y;  }
 
 FD_FN_CONST static inline SET_(t) SET_(if)( int c, SET_(t) t, SET_(t) f ) { return c ? t : f; }
@@ -207,23 +218,37 @@ FD_FN_CONST static inline SET_(iter_t) SET_(iter_next)( SET_(iter_t) iter ) { re
 FD_FN_CONST static inline SET_IDX_T    SET_(iter_idx) ( SET_(iter_t) iter ) { return (SET_IDX_T)SET_FIND_LSB( iter ); }
 
 FD_FN_CONST static inline SET_(t) SET_(insert)( SET_(t) x, SET_IDX_T i ) { return x | SET_(ele)(i); }
-FD_FN_CONST static inline SET_(t) SET_(remove)( SET_(t) x, SET_IDX_T i ) { return (SET_(t))(x & ~SET_(ele)(i)); }
+FD_FN_CONST static inline SET_(t) SET_(remove)( SET_(t) x, SET_IDX_T i ) { return x & (SET_(t))~SET_(ele)(i); }
 
-FD_FN_CONST
-static inline SET_(t)
-SET_(insert_if)( int c, SET_(t) x, SET_IDX_T i ) {
-#if FD_TMPL_USE_HANDHOLDING
-  if( FD_UNLIKELY( !SET_(valid_idx)( i ) ) ) FD_LOG_CRIT(( "invalid index" ));
-#endif
-  return x | SET_(ele_if)(c,i);
+FD_FN_CONST static inline SET_(t) SET_(insert_if)( int c, SET_(t) x, SET_IDX_T i ) { return x |  SET_(ele_if)(c,i); }
+FD_FN_CONST static inline SET_(t) SET_(remove_if)( int c, SET_(t) x, SET_IDX_T i ) { return x & (SET_(t))~SET_(ele_if)(c,i); }
+
+FD_FN_CONST static inline SET_(t) SET_(range)( SET_IDX_T l, SET_IDX_T h ) {
+# if FD_TMPL_USE_HANDHOLDING
+  /* Note: the 0<=l test is commented because compilers make babies cry
+     with superfluous warnings when SET_IDX_T is an unsigned type. */
+  if( FD_UNLIKELY( !( /*(((SET_(t))0)<=l) &*/ (l<=h) & (h<=SET_(max)()) ) ) ) FD_LOG_CRIT(( "invalid range" ));
+# endif
+  /* Compute (2^h) - (2^l) == ones for bits [l,h), with no UB in the
+     case where l and/or h == BIT_CNT */
+  return (SET_(t))( (((SET_(t))(h<=(SET_IDX_T)SET_(PRIVATE_IDX_MASK))) << (h & (SET_IDX_T)SET_(PRIVATE_IDX_MASK)))
+                  - (((SET_(t))(l<=(SET_IDX_T)SET_(PRIVATE_IDX_MASK))) << (l & (SET_IDX_T)SET_(PRIVATE_IDX_MASK))) );
 }
 
-FD_FN_CONST static inline SET_(t)
-SET_(remove_if)( int c, SET_(t) x, SET_IDX_T i ) {
-#if FD_TMPL_USE_HANDHOLDING
-  if( FD_UNLIKELY( !SET_(valid_idx)( i ) ) ) FD_LOG_CRIT(( "invalid index" ));
-#endif
-  return (SET_(t))(x & ~SET_(ele_if)(c,i));
+FD_FN_CONST static inline SET_(t) SET_(insert_range)( SET_(t) x, SET_IDX_T l, SET_IDX_T h ) {
+  return x | SET_(range)(l,h);
+}
+
+FD_FN_CONST static inline SET_(t) SET_(select_range)( SET_(t) x, SET_IDX_T l, SET_IDX_T h ) {
+  return x & SET_(range)(l,h);
+}
+
+FD_FN_CONST static inline SET_(t) SET_(remove_range)( SET_(t) x, SET_IDX_T l, SET_IDX_T h ) {
+  return x & (SET_(t))~SET_(range)(l,h);
+}
+
+FD_FN_CONST static inline SET_IDX_T SET_(range_cnt)( SET_(t) x, SET_IDX_T l, SET_IDX_T h ) {
+  return (SET_IDX_T)SET_POPCNT( x & SET_(range)(l,h) );
 }
 
 FD_PROTOTYPES_END

--- a/src/util/tmpl/fd_treap.c
+++ b/src/util/tmpl/fd_treap.c
@@ -409,17 +409,17 @@
    works by essentially threading a doubly-linked list through elements
    in iteration order. The default is sets this to 0, meaning that the
    next and prev fields are not required. */
+
 #ifndef TREAP_OPTIMIZE_ITERATION
 #define TREAP_OPTIMIZE_ITERATION 0
 #endif
 
 #if TREAP_OPTIMIZE_ITERATION
 # ifndef  TREAP_NEXT
-#  define TREAP_NEXT next
+#   define TREAP_NEXT next
 # endif
-
 # ifndef  TREAP_PREV
-#  define TREAP_PREV prev
+#   define TREAP_PREV prev
 # endif
 #endif
 
@@ -460,10 +460,10 @@
 struct TREAP_(private) {
   ulong       ele_max; /* Maximum number of elements in underlying storage, in [0,TREAP_IDX_NULL] */
   ulong       ele_cnt; /* Current number of elements in treap, in [0,ele_max] */
-#if TREAP_OPTIMIZE_ITERATION
+# if TREAP_OPTIMIZE_ITERATION
   TREAP_IDX_T first;   /* Index of the left-most treap element, in [0,ele_max) or TREAP_IDX_NULL */
   TREAP_IDX_T last;    /* Index of the right-most treap element, in [0,ele_max) or TREAP_IDX_NULL */
-#endif
+# endif
   TREAP_IDX_T root;    /* Index of the root treap element, in [0,ele_max) or TREAP_IDX_NULL */
 };
 
@@ -633,10 +633,10 @@ TREAP_(new)( void * shmem,
   treap->ele_cnt = 0UL;
   treap->root    = (TREAP_IDX_T)TREAP_IDX_NULL;
 
-#if TREAP_OPTIMIZE_ITERATION
+# if TREAP_OPTIMIZE_ITERATION
   treap->first   = (TREAP_IDX_T)TREAP_IDX_NULL;
   treap->last    = (TREAP_IDX_T)TREAP_IDX_NULL;
-#endif
+# endif
 
   return treap;
 }
@@ -701,18 +701,18 @@ TREAP_(idx_insert)( TREAP_(t) * treap,
                     ulong       n,
                     TREAP_T *   pool ) {
 
-#if FD_TMPL_USE_HANDHOLDING
-  if( FD_UNLIKELY( n>=treap->ele_max ) ) FD_LOG_CRIT(( "index out of bounds" ));
-  if( FD_UNLIKELY( (treap->ele_cnt!=0xf173da2ce7111111) & (treap->ele_cnt+1>treap->ele_max) ) ) FD_LOG_CRIT(( "treap full" ));
-#endif
+# if FD_TMPL_USE_HANDHOLDING
+  if( FD_UNLIKELY( n>=treap->ele_max              ) ) FD_LOG_CRIT(( "index out of bounds" ));
+  if( FD_UNLIKELY( treap->ele_cnt>=treap->ele_max ) ) FD_LOG_CRIT(( "treap full" ));
+# endif
 
   /* Find leaf where to insert n */
 
   TREAP_IDX_T * _p_child = &treap->root;
-#if TREAP_OPTIMIZE_ITERATION
+# if TREAP_OPTIMIZE_ITERATION
   TREAP_IDX_T * _p_pnext = &treap->first; /* pointer to prev node's next idx */
   TREAP_IDX_T * _p_nprev = &treap->last;  /* pointer to next node's prev idx */
-#endif
+# endif
 
   ulong i = TREAP_IDX_NULL;
   for(;;) {
@@ -721,10 +721,10 @@ TREAP_(idx_insert)( TREAP_(t) * treap,
     i = j;
     int lt = TREAP_(lt)( pool + n, pool + i );
     _p_child = fd_ptr_if( lt, &pool[ i ].TREAP_LEFT, &pool[ i ].TREAP_RIGHT );
-#if TREAP_OPTIMIZE_ITERATION
+#   if TREAP_OPTIMIZE_ITERATION
     _p_pnext = fd_ptr_if( lt, _p_pnext,              &pool[ i ].TREAP_NEXT  );
     _p_nprev = fd_ptr_if( lt, &pool[ i ].TREAP_PREV, _p_nprev               );
-#endif
+#   endif
   }
 
   /* Insert n.  This might momentarily break the heap property. */
@@ -734,12 +734,12 @@ TREAP_(idx_insert)( TREAP_(t) * treap,
   pool[ n ].TREAP_RIGHT  = (TREAP_IDX_T)TREAP_IDX_NULL;
   *_p_child = (TREAP_IDX_T)n;
 
-#if TREAP_OPTIMIZE_ITERATION
+# if TREAP_OPTIMIZE_ITERATION
   pool[ n ].TREAP_PREV = *_p_nprev;
   pool[ n ].TREAP_NEXT = *_p_pnext;
   *_p_nprev = (TREAP_IDX_T)n;
   *_p_pnext = (TREAP_IDX_T)n;
-#endif
+# endif
 
   /* Bubble n up until the heap property is restored. */
 
@@ -785,9 +785,6 @@ TREAP_(idx_insert)( TREAP_(t) * treap,
   }
 
   treap->ele_cnt++;
-#if FD_TMPL_USE_HANDHOLDING
-  if( FD_UNLIKELY( (treap->ele_cnt!=0xf173da2ce7111111+1) && TREAP_(verify)( treap, pool )==-1 ) ) FD_LOG_CRIT(( "idx_insert: treap corrupt" ));
-#endif
   return treap;
 }
 
@@ -795,10 +792,10 @@ TREAP_(t) *
 TREAP_(idx_remove)( TREAP_(t) * treap,
                     ulong       d,
                     TREAP_T *   pool ) {
-#if FD_TMPL_USE_HANDHOLDING
-  if( FD_UNLIKELY( (treap->ele_cnt!=0xf173da2ce7111111) & (d>=treap->ele_max) ) ) FD_LOG_CRIT(( "index out of bounds" ));
-  if( FD_UNLIKELY( (treap->ele_cnt!=0xf173da2ce7111111) & (treap->ele_cnt<1)  ) ) FD_LOG_CRIT(( "index out of bounds" ));
-#endif
+# if FD_TMPL_USE_HANDHOLDING
+  if( FD_UNLIKELY( (d>=treap->ele_max) ) ) FD_LOG_CRIT(( "index out of bounds" ));
+  if( FD_UNLIKELY( (treap->ele_cnt<1)  ) ) FD_LOG_CRIT(( "index out of bounds" ));
+# endif
 
   /* Make a hole at d */
 
@@ -809,14 +806,14 @@ TREAP_(idx_remove)( TREAP_(t) * treap,
   TREAP_IDX_T * _t0      = fd_ptr_if( TREAP_IDX_IS_NULL( p ), &treap->root, &pool[ p ].TREAP_LEFT  );
   TREAP_IDX_T * _p_child = fd_ptr_if( d==(ulong)*_t0,         _t0,          &pool[ p ].TREAP_RIGHT );
 
-#if TREAP_OPTIMIZE_ITERATION
+# if TREAP_OPTIMIZE_ITERATION
   TREAP_IDX_T prev = pool[ d ].TREAP_PREV;
   TREAP_IDX_T next = pool[ d ].TREAP_NEXT;
   TREAP_IDX_T * _pnext = fd_ptr_if( TREAP_IDX_IS_NULL( prev ), &treap->first, &pool[ prev ].TREAP_NEXT );
   TREAP_IDX_T * _nprev = fd_ptr_if( TREAP_IDX_IS_NULL( next ), &treap->last,  &pool[ next ].TREAP_PREV );
   *_pnext = next;
   *_nprev = prev;
-#endif
+# endif
 
   for(;;) {
 
@@ -867,9 +864,6 @@ TREAP_(idx_remove)( TREAP_(t) * treap,
   }
 
   treap->ele_cnt--;
-#if FD_TMPL_USE_HANDHOLDING
-  if( FD_UNLIKELY( (treap->ele_cnt!=0xf173da2ce7111111-1) && TREAP_(verify)( treap, pool )==-1 ) ) FD_LOG_CRIT(( "idx_remove: treap corrupt" ));
-#endif
   return treap;
 }
 
@@ -1057,7 +1051,7 @@ TREAP_(merge)( TREAP_(t) * treap_a,
 # define STACK_IS_EMPTY (!stack_top)
 # define STACK_IS_FULL  (stack_top>=STACK_MAX)
 
-#if TREAP_OPTIMIZE_ITERATION
+# if TREAP_OPTIMIZE_ITERATION
 # define STACK_PUSH( imp, im, ia, ib, iaf, ial, ibf, ibl, mp, mn ) do { \
     stack[ stack_top ].idx_merge_parent = (imp);                        \
     stack[ stack_top ]._idx_merge       = (im);                         \
@@ -1084,7 +1078,7 @@ TREAP_(merge)( TREAP_(t) * treap_a,
     (mp)  = stack[ stack_top ].merged_prev;      \
     (mn)  = stack[ stack_top ].merged_next;      \
   } while(0)
-#else
+# else
 # define STACK_PUSH( imp, im, ia, ib ) do {      \
     stack[ stack_top ].idx_merge_parent = (imp); \
     stack[ stack_top ]._idx_merge       = (im);  \
@@ -1099,7 +1093,7 @@ TREAP_(merge)( TREAP_(t) * treap_a,
     (ia)  = stack[ stack_top ].idx_a;            \
     (ib)  = stack[ stack_top ].idx_b;            \
   } while(0)
-#endif
+# endif
 
   TREAP_IDX_T idx_merge_parent = TREAP_IDX_NULL;
 
@@ -1170,26 +1164,20 @@ TREAP_(merge)( TREAP_(t) * treap_a,
     if( FD_UNLIKELY( STACK_IS_FULL ) ) {
 
       /* Remove elements from B one-by-one and insert them into A.
-         O(B lg B) for the removes, O(B lg(A + B)) for the inserts. */
+         O(B lg B) for the removes, O(B lg(A + B)) for the inserts.  The
+         value for ele_cnt in temp_treap_b is a dummy value to avoid
+         handholding checks from spuriously firing. */
 
 #     if TREAP_OPTIMIZE_ITERATION
-      TREAP_(t) temp_treap_a = { .ele_max = treap_a->ele_max, .ele_cnt = 0UL, .root = idx_a, .first=idx_a_first, .last=idx_a_last };
-      TREAP_(t) temp_treap_b = { .ele_max = treap_b->ele_max, .ele_cnt = 0UL, .root = idx_b, .first=idx_b_first, .last=idx_b_last };
+      TREAP_(t) temp_treap_a = { .ele_max = treap_a->ele_max, .ele_cnt = 0UL,              .root = idx_a, .first=idx_a_first, .last=idx_a_last };
+      TREAP_(t) temp_treap_b = { .ele_max = treap_b->ele_max, .ele_cnt = treap_b->ele_max, .root = idx_b, .first=idx_b_first, .last=idx_b_last };
 #     else
-      TREAP_(t) temp_treap_a = { .ele_max = treap_a->ele_max, .ele_cnt = 0UL, .root = idx_a };
-      TREAP_(t) temp_treap_b = { .ele_max = treap_b->ele_max, .ele_cnt = 0UL, .root = idx_b };
+      TREAP_(t) temp_treap_a = { .ele_max = treap_a->ele_max, .ele_cnt = 0UL,              .root = idx_a };
+      TREAP_(t) temp_treap_b = { .ele_max = treap_b->ele_max, .ele_cnt = treap_b->ele_max, .root = idx_b };
 #     endif
       pool[ idx_a ].TREAP_PARENT = TREAP_IDX_NULL;
       pool[ idx_b ].TREAP_PARENT = TREAP_IDX_NULL;
       do {
-#if FD_TMPL_USE_HANDHOLDING
-        /* The temp treaps are not valid treaps, and are only used
-           internally.  The ele_cnt is never used.  To not trigger
-           handholding, we set it to a magic value, that signals
-           certain handholding checks to ignore it. */
-        temp_treap_a.ele_cnt = 0xf173da2ce7111111;
-        temp_treap_b.ele_cnt = 0xf173da2ce7111111;
-#endif
         TREAP_IDX_T idx_tmp = temp_treap_b.root;
         TREAP_(idx_remove)( &temp_treap_b, idx_tmp, pool );
         TREAP_(idx_insert)( &temp_treap_a, idx_tmp, pool );
@@ -1307,11 +1295,6 @@ TREAP_(merge)( TREAP_(t) * treap_a,
   treap_b->last     = TREAP_IDX_NULL;
 # endif
 
-#if FD_TMPL_USE_HANDHOLDING
-  if( FD_UNLIKELY( TREAP_(verify)( treap_a, pool )==-1 ) ) FD_LOG_CRIT(( "merge: treap_a corrupt" ));
-  if( FD_UNLIKELY( TREAP_(verify)( treap_b, pool )==-1 ) ) FD_LOG_CRIT(( "merge: treap_b corrupt" ));
-#endif
-
   return treap_a;
 
 # undef STACK_POP
@@ -1324,37 +1307,37 @@ TREAP_(merge)( TREAP_(t) * treap_a,
 TREAP_STATIC TREAP_(fwd_iter_t)
 TREAP_(fwd_iter_init)( TREAP_(t) const * treap,
                        TREAP_T const *   pool ) {
-#if TREAP_OPTIMIZE_ITERATION
+# if TREAP_OPTIMIZE_ITERATION
   (void)pool;
   return treap->first;
-#else
+# else
   ulong i = TREAP_IDX_NULL;
   ulong j = (ulong)treap->root;
   while( FD_LIKELY( !TREAP_IDX_IS_NULL( j ) ) ) { i = j; j = (ulong)pool[ j ].TREAP_LEFT; }
   return i;
-#endif
+# endif
 }
 
 TREAP_STATIC TREAP_(rev_iter_t)
 TREAP_(rev_iter_init)( TREAP_(t) const * treap,
                        TREAP_T const *   pool ) {
-#if TREAP_OPTIMIZE_ITERATION
+# if TREAP_OPTIMIZE_ITERATION
   (void)pool;
   return treap->last;
-#else
+# else
   ulong i = TREAP_IDX_NULL;
   ulong j = (ulong)treap->root;
   while( FD_LIKELY( !TREAP_IDX_IS_NULL( j ) ) ) { i = j; j = (ulong)pool[ j ].TREAP_RIGHT; }
   return i;
-#endif
+# endif
 }
 
 TREAP_STATIC TREAP_(fwd_iter_t)
 TREAP_(fwd_iter_next)( TREAP_(fwd_iter_t) i,
                        TREAP_T const *    pool ) {
-#if TREAP_OPTIMIZE_ITERATION
+# if TREAP_OPTIMIZE_ITERATION
   return pool[ i ].TREAP_NEXT;
-#else
+# else
   ulong r = (ulong)pool[ i ].TREAP_RIGHT;
 
   if( TREAP_IDX_IS_NULL( r ) ) {
@@ -1375,13 +1358,13 @@ TREAP_(fwd_iter_next)( TREAP_(fwd_iter_t) i,
   }
 
   return i;
-#endif
+# endif
 }
 
 TREAP_STATIC TREAP_(rev_iter_t)
 TREAP_(rev_iter_next)( TREAP_(rev_iter_t) i,
                        TREAP_T const *    pool ) {
-#if TREAP_OPTIMIZE_ITERATION
+# if TREAP_OPTIMIZE_ITERATION
   return pool[ i ].TREAP_PREV;
 #else
   ulong l = (ulong)pool[ i ].TREAP_LEFT;
@@ -1432,9 +1415,9 @@ TREAP_(verify)( TREAP_(t) const * treap,
     l = (ulong)pool[ l ].TREAP_LEFT;
     loop_cnt++;
   }
-#if TREAP_OPTIMIZE_ITERATION
+# if TREAP_OPTIMIZE_ITERATION
   TREAP_TEST( treap->first==i );
-#endif
+# endif
 
   /* In-order traverse the treap starting from the leftmost */
 
@@ -1447,11 +1430,11 @@ TREAP_(verify)( TREAP_(t) const * treap,
        NULL if i is the first element we are visiting. */
 
     if( FD_LIKELY( !TREAP_IDX_IS_NULL( l ) ) ) TREAP_TEST( !TREAP_(lt)( pool + i, pool + l ) ); /* Make sure ordering valid */
-#if TREAP_OPTIMIZE_ITERATION
+#   if TREAP_OPTIMIZE_ITERATION
     /* Check the l <-> i link */
     if( FD_LIKELY( !TREAP_IDX_IS_NULL( l ) ) ) TREAP_TEST( pool[ l ].TREAP_NEXT==i );
     if( FD_LIKELY( !TREAP_IDX_IS_NULL( i ) ) ) TREAP_TEST( pool[ i ].TREAP_PREV==l );
-#endif
+#   endif
 
 
     ulong p = (ulong)pool[ i ].TREAP_PARENT;
@@ -1506,9 +1489,9 @@ TREAP_(verify)( TREAP_(t) const * treap,
 
   }
 
-#if TREAP_OPTIMIZE_ITERATION
+# if TREAP_OPTIMIZE_ITERATION
   TREAP_TEST( treap->last==l );
-#endif
+# endif
 
   TREAP_TEST( cnt==ele_cnt ); /* Make sure we visited correct number of elements */
 

--- a/src/util/tmpl/test_heap.c
+++ b/src/util/tmpl/test_heap.c
@@ -204,10 +204,7 @@ main( int     argc,
   FD_EXPECT_LOG_CRIT( heap_ele_insert( heap, &f, pool ) );
   ulong min = heap_idx_peek_min( heap );
   FD_TEST( heap_idx_null() != min );
-  FD_EXPECT_LOG_CRIT( heap_ele_insert( heap, &pool[ min ], pool ) );
-  while( heap_idx_peek_min( heap ) != heap_idx_null() ) {
-    heap_ele_remove_min( heap, pool );
-  }
+  while( heap_idx_peek_min( heap ) != heap_idx_null() ) heap_ele_remove_min( heap, pool );
   FD_EXPECT_LOG_CRIT( heap_ele_remove_min( heap, pool ) );
 #else
   FD_LOG_WARNING(( "skip: testing handholding, requires hosted" ));

--- a/src/util/tmpl/test_pool.c
+++ b/src/util/tmpl/test_pool.c
@@ -143,8 +143,8 @@ main( int     argc,
       if( mypool_free( pool ) ) {
         ulong idx = mypool_idx_acquire( pool );
         FD_TEST( mypool_idx_test( pool, idx ) && idx<max );
-#       if FD_HAS_SENTINEL
-        FD_TEST( !idx );
+#       if HAS_SENTINEL
+        FD_TEST( !!idx );
 #       endif
         for( ulong acq=0UL; acq<acquired_cnt; acq++ ) FD_TEST( idx!=(ulong)acquired_idx[ acq ] );
         acquired_idx[ acquired_cnt++ ] = (ushort)idx;
@@ -163,7 +163,7 @@ main( int     argc,
       if( mypool_free( pool ) ) {
         myele_t * ele = mypool_ele_acquire( pool );
         FD_TEST( mypool_ele_test( pool, ele ) && ele );
-#       if FD_HAS_SENTINEL
+#       if HAS_SENTINEL
         FD_TEST( ele!=pool );
 #       endif
         ulong idx = mypool_idx( pool, ele );

--- a/src/util/tmpl/test_treap.c
+++ b/src/util/tmpl/test_treap.c
@@ -238,6 +238,7 @@ lreap_to_treap( lreap_t * in,
 
 static void
 test_merge( fd_rng_t * rng, int optimize_iteration ) {
+
 #define MERGE_VERIFY_AND_CLEAR()  do {                                        \
     if( optimize_iteration ) {                                                \
       FD_TEST( !lreap_verify( a, pool ) );                                    \
@@ -372,7 +373,6 @@ test_duplicate( fd_rng_t * rng ) {
   }
   treap_delete( treap_leave( treap ) );
 
-
   treap_t * a = treap_join( treap_new( _treap+0, ele_max ) );
   treap_t * b = treap_join( treap_new( _treap+1, ele_max ) );
 
@@ -385,8 +385,6 @@ test_duplicate( fd_rng_t * rng ) {
   treap_delete( treap_leave( a ) );
   treap_delete( treap_leave( b ) );
 }
-
-
 
 int
 main( int     argc,
@@ -638,4 +636,3 @@ main( int     argc,
   fd_halt();
   return 0;
 }
-


### PR DESCRIPTION
By popular demand.  Roughly 1-2 orders of magnitude faster for operations on large contiguous ranges of elements.

Drive by cleanups:

- util_base.h: FD_FN_PURE/FD_FN_CONST do not hint by default to help with various CI and fuzzing tools.  This also eliminates the need for maintaining the FD_HAS_HANDHOLDING.

- with-extra-brutality.mk: Hinting is still enabled manually with extra-brutality for various linting.

- src/env/env.h: a prototype outside FD_PROTOTYPE pair fixed

- test_pool.c: enabled some checks accidentally disabled due to a typo.

- Also did some minor linting around FD_FN_PURE / FD_FN_CONST in util/tmpl.

- And, also by popular demand, did a linting pass on handholding, eliminating a handful of checks that aren't actually handhold-y.  (This unfortunately touches a lot of files but "ignore whitespace" is your friend.)