### PR TITLE
flamenco: remove orig_meta from fd_txn_account_t

### DIFF
--- a/src/flamenco/runtime/fd_acc_mgr.c
+++ b/src/flamenco/runtime/fd_acc_mgr.c
@@ -106,9 +106,8 @@ fd_acc_mgr_view( fd_acc_mgr_t *        acc_mgr,
 
   fd_memcpy(account->pubkey, pubkey, sizeof(fd_pubkey_t));
 
-  account->orig_rec  = account->const_rec;
-  account->orig_meta = account->const_meta = meta;
-  account->orig_data = account->const_data = (uchar const *)meta + meta->hlen;
+  account->const_meta = meta;
+  account->const_data = (uchar const *)meta + meta->hlen;
 
   if( ULONG_MAX == account->starting_dlen )
     account->starting_dlen = meta->dlen;
@@ -207,9 +206,9 @@ fd_acc_mgr_modify( fd_acc_mgr_t *      acc_mgr,
                  meta->info.rent_epoch, meta->dlen ));
 #endif
 
-  account->orig_rec  = account->const_rec  = account->rec;
-  account->orig_meta = account->const_meta = account->meta = meta;
-  account->orig_data = account->const_data = account->data = (uchar *)meta + meta->hlen;
+  account->const_rec  = account->rec;
+  account->const_meta = account->meta = meta;
+  account->const_data = account->data = (uchar *)meta + meta->hlen;
 
   if( ULONG_MAX == account->starting_dlen )
     account->starting_dlen = meta->dlen;

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -878,7 +878,7 @@ fd_txn_copy_meta( fd_exec_txn_ctx_t * txn_ctx, uchar * dest, ulong dest_sz ) {
 
     pre_balances[idx]  = pre;
     post_balances[idx] = ( acct->meta ? acct->meta->info.lamports :
-                           ( acct->orig_meta ? acct->orig_meta->info.lamports : pre ) );
+                           ( acct->const_meta ? acct->const_meta->info.lamports : pre ) );
   }
 
   if( txn_ctx->return_data.len ) {

--- a/src/flamenco/runtime/fd_txn_account.c
+++ b/src/flamenco/runtime/fd_txn_account.c
@@ -64,8 +64,8 @@ fd_txn_account_make_readonly( fd_txn_account_t * acct, void * buf ) {
   ulong dlen           = ( acct->const_meta != NULL ) ? acct->const_meta->dlen : 0;
   uchar * new_raw_data = fd_txn_account_init_data( acct, buf );
 
-  acct->orig_meta = acct->const_meta = (fd_account_meta_t *)new_raw_data;
-  acct->orig_data = acct->const_data = new_raw_data + sizeof(fd_account_meta_t);
+  acct->const_meta = (fd_account_meta_t *)new_raw_data;
+  acct->const_data = new_raw_data + sizeof(fd_account_meta_t);
   ((fd_account_meta_t *)new_raw_data)->dlen = dlen;
 
   return acct;
@@ -83,22 +83,6 @@ fd_txn_account_make_mutable( fd_txn_account_t * acct, void * buf ) {
   acct->meta->dlen = dlen;
 
   return acct;
-}
-
-void *
-fd_txn_account_restore( fd_txn_account_t * acct ) {
-  fd_account_meta_t * meta       = acct->meta;
-  uint                is_changed = meta != acct->orig_meta;
-
-  acct->const_meta = acct->orig_meta;
-  acct->const_data = acct->orig_data;
-  acct->const_rec  = acct->orig_rec;
-
-  if( is_changed ) {
-    return meta;
-  }
-
-  return NULL;
 }
 
 /* Factory constructor impl */

--- a/src/flamenco/runtime/fd_txn_account.h
+++ b/src/flamenco/runtime/fd_txn_account.h
@@ -22,10 +22,6 @@ struct __attribute__((aligned(8UL))) fd_txn_account {
   uchar                     * data;
   fd_funk_rec_t             * rec;
 
-  fd_account_meta_t const   * orig_meta;
-  uchar             const   * orig_data;
-  fd_funk_rec_t     const   * orig_rec;
-
   /* consider making this a struct or removing entirely if not needed */
   ulong                       starting_dlen;
   ulong                       starting_lamports;
@@ -102,13 +98,6 @@ fd_txn_account_make_mutable( fd_txn_account_t * acct,
 fd_txn_account_t *
 fd_txn_account_make_readonly( fd_txn_account_t * acct,
                             void *          buf );
-
-/* Restores the original contents of the account shared data into
-   its read-only fields (const_meta, const_data, const_rec).
-   If the account metadata was modified, returns a pointer to metadata,
-   otherwise returns null. */
-void *
-fd_txn_account_restore( fd_txn_account_t * acct );
 
 static inline int
 fd_txn_account_checked_add_lamports( fd_txn_account_t * acct, ulong lamports ) {


### PR DESCRIPTION
orig_meta was not being used, as it is the same as const_meta for read-only accounts. `fd_txn_account_restore` was also not being used at all.