### PR TITLE
flamenco: fix off-by-one bug in fd_vm_test

### DIFF
--- a/src/flamenco/runtime/tests/fd_vm_test.c
+++ b/src/flamenco/runtime/tests/fd_vm_test.c
@@ -140,7 +140,9 @@ do{
     memcpy( calldests, input->vm_ctx.call_whitelist->bytes, input->vm_ctx.call_whitelist->size );
     /* Make sure bits over max_pc are all 0s. */
     ulong mask = (1UL << (max_pc % 64)) - 1UL;
-    calldests[ max_pc / 64 ] &= mask;
+    if ( max_pc % 64 != 0) {
+      calldests[ max_pc / 64 ] &= mask;
+    }
   }
   ulong entry_pc = fd_ulong_min( input->vm_ctx.entry_pc, rodata_sz / 8UL - 1UL );
   if( input->vm_ctx.sbpf_version >= FD_SBPF_V3 ) {


### PR DESCRIPTION
When max_pc is a multiple of 64 we end doing an off-by-one bitmask AND. We actually don't need to apply a bitmask if the rodata size ends up being a multiple of 64 bytes.

