### PR TITLE
pack: exempt votes and bundles from pacing, schedule votes first

### DIFF
--- a/src/disco/pack/fd_pack.c
+++ b/src/disco/pack/fd_pack.c
@@ -2252,19 +2252,8 @@ fd_pack_schedule_next_microblock( fd_pack_t *  pack,
                                   ulong        total_cus,
                                   float        vote_fraction,
                                   ulong        bank_tile,
+                                  int          schedule_flags,
                                   fd_txn_p_t * out ) {
-  /* Because we schedule bundles strictly in order, we need to limit
-     bundles to a single bank.  Otherwise, if a bundle is executing on a
-     certain bank and the next bundle conflicts with it, all the other
-     bank tiles will be idle until the first bundle completes. */
-  if( FD_LIKELY( bank_tile==0UL ) ) {
-    /* Try to schedule a bundle first */
-    int bundle_result = fd_pack_try_schedule_bundle( pack, bank_tile, out );
-    if( FD_UNLIKELY( bundle_result>0                         ) ) return (ulong)bundle_result;
-    if( FD_UNLIKELY( bundle_result==TRY_BUNDLE_HAS_CONFLICTS ) ) return 0UL;
-    /* in the NO_READY_BUNDLES or DOES_NOT_FIT case, we schedule like
-       normal. */
-  }
 
   /* TODO: Decide if these are exactly how we want to handle limits */
   total_cus = fd_ulong_min( total_cus, pack->lim->max_cost_per_block - pack->cumulative_block_cost );
@@ -2290,28 +2279,45 @@ fd_pack_schedule_next_microblock( fd_pack_t *  pack,
   ulong scheduled = 0UL;
   ulong byte_limit = pack->lim->max_data_bytes_per_block - pack->data_bytes_consumed - MICROBLOCK_DATA_OVERHEAD;
 
-  sched_return_t status, status1;
+  sched_return_t status = {0}, status1 = {0};
 
-  /* Schedule vote transactions */
-  status1= fd_pack_schedule_impl( pack, pack->pending_votes, vote_cus, vote_reserved_txns, byte_limit, bank_tile, pack->pending_votes_smallest, use_by_bank_txn, out+scheduled );
+  if( FD_LIKELY( schedule_flags & FD_PACK_SCHEDULE_VOTE ) ) {
+    /* Schedule vote transactions */
+    status1= fd_pack_schedule_impl( pack, pack->pending_votes, vote_cus, vote_reserved_txns, byte_limit, bank_tile, pack->pending_votes_smallest, use_by_bank_txn, out+scheduled );
 
-  scheduled                   += status1.txns_scheduled;
-  pack->cumulative_vote_cost  += status1.cus_scheduled;
-  pack->cumulative_block_cost += status1.cus_scheduled;
-  pack->data_bytes_consumed   += status1.bytes_scheduled;
-  byte_limit                  -= status1.bytes_scheduled;
-  use_by_bank_txn             += status1.txns_scheduled;
-  /* Add any remaining CUs/txns to the non-vote limits */
-  txn_limit += vote_reserved_txns - status1.txns_scheduled;
-  cu_limit  += vote_cus - status1.cus_scheduled;
+    scheduled                   += status1.txns_scheduled;
+    pack->cumulative_vote_cost  += status1.cus_scheduled;
+    pack->cumulative_block_cost += status1.cus_scheduled;
+    pack->data_bytes_consumed   += status1.bytes_scheduled;
+    byte_limit                  -= status1.bytes_scheduled;
+    use_by_bank_txn             += status1.txns_scheduled;
+    /* Add any remaining CUs/txns to the non-vote limits */
+    txn_limit += vote_reserved_txns - status1.txns_scheduled;
+    cu_limit  += vote_cus - status1.cus_scheduled;
+  }
+
+  /* Bundle can't mix with votes, so only try to schedule a bundle if we
+     didn't get any votes. */
+  if( FD_UNLIKELY( !!(schedule_flags & FD_PACK_SCHEDULE_BUNDLE) & (status1.txns_scheduled==0UL) ) ) {
+    int bundle_result = fd_pack_try_schedule_bundle( pack, bank_tile, out );
+    if( FD_UNLIKELY( bundle_result>0                         ) ) return (ulong)bundle_result;
+    if( FD_UNLIKELY( bundle_result==TRY_BUNDLE_HAS_CONFLICTS ) ) return 0UL;
+    /* in the NO_READY_BUNDLES or DOES_NOT_FIT case, we schedule like
+       normal. */
+    /* We have the early returns here because try_schedule_bundle does
+       the bookeeping internally, since the calculations are a bit
+       different in that case. */
+  }
 
 
   /* Fill any remaining space with non-vote transactions */
-  status = fd_pack_schedule_impl( pack, pack->pending,       cu_limit, txn_limit,          byte_limit, bank_tile, pack->pending_smallest,       use_by_bank_txn, out+scheduled );
+  if( FD_LIKELY( schedule_flags & FD_PACK_SCHEDULE_TXN ) ) {
+    status = fd_pack_schedule_impl( pack, pack->pending,       cu_limit, txn_limit,          byte_limit, bank_tile, pack->pending_smallest,       use_by_bank_txn, out+scheduled );
 
-  scheduled                   += status.txns_scheduled;
-  pack->cumulative_block_cost += status.cus_scheduled;
-  pack->data_bytes_consumed   += status.bytes_scheduled;
+    scheduled                   += status.txns_scheduled;
+    pack->cumulative_block_cost += status.cus_scheduled;
+    pack->data_bytes_consumed   += status.bytes_scheduled;
+  }
 
   ulong nonempty = (ulong)(scheduled>0UL);
   pack->microblock_cnt              += nonempty;

--- a/src/disco/pack/fd_pack.h
+++ b/src/disco/pack/fd_pack.h
@@ -496,6 +496,14 @@ void const * fd_pack_peek_bundle_meta( fd_pack_t const * pack );
    bundles.  pack must be a valid local join. */
 void fd_pack_set_initializer_bundles_ready( fd_pack_t * pack );
 
+
+/* FD_PACK_SCHEDULE_{VOTE,BUNDLE,TXN} form a set of bitflags used in
+   fd_pack_schedule_next_microblock below.  They control what types of
+   scheduling are allowed.  The names should be self-explanatory. */
+#define FD_PACK_SCHEDULE_VOTE   1
+#define FD_PACK_SCHEDULE_BUNDLE 2
+#define FD_PACK_SCHEDULE_TXN    4
+
 /* fd_pack_schedule_next_microblock schedules pending transactions.
    These transaction either form a microblock, which is a set of
    non-conflicting transactions, or a bundle.  The semantics of this
@@ -503,6 +511,24 @@ void fd_pack_set_initializer_bundles_ready( fd_pack_t * pack );
    there are some reasons why they both use this function.
 
    For both codepaths, pack must be a local join of a pack object.
+   schedule_flags must be a bitwise combination of the
+   FD_PACK_SCHEDULE_* values defined above.  When the bit is set
+   corresponding to a transaction type, this function will consider
+   scheduling transactions of that type.  Passing 0 for schedule_flags
+   is a no-op.  The full policy is as follows:
+    1. If the VOTE bit is set, attempt to schedule votes.  This is the
+       microblock case.
+    2. If the BUNDLE bit is set, and step 1 did not schedule any votes,
+       attempt to schedule bundles.  This is the bundle case.
+    3. If the TXN bit is set, and step 2 did not schedule any bundles
+       for a reason other than account conflicts, attempt to schedule
+       normal transactions.  This is the microblock case.
+   Note that it is possible to schedule a microblock containing both
+   votes and normal transactions, but bundles cannot be combined with
+   either other type.  Additionally, if the BUNDLE bit is not set, step
+   2 will not schedule any bundles for that reason, which is a reason
+   other than account conflicts, so that clause will always be
+   satisfied.
 
    Microblock case:
    Transactions part of the scheduled microblock are copied to out in no
@@ -536,7 +562,13 @@ void fd_pack_set_initializer_bundles_ready( fd_pack_t * pack );
    bundle.  The return value may be 0 if there are no eligible
    transactions at the moment. */
 
-ulong fd_pack_schedule_next_microblock( fd_pack_t * pack, ulong total_cus, float vote_fraction, ulong bank_tile, fd_txn_p_t * out );
+ulong
+fd_pack_schedule_next_microblock( fd_pack_t  * pack,
+                                  ulong        total_cus,
+                                  float        vote_fraction,
+                                  ulong        bank_tile,
+                                  int          schedule_flags,
+                                  fd_txn_p_t * out );
 
 
 /* fd_pack_rebate_cus adjusts the compute unit accounting for the


### PR DESCRIPTION
The policy is now:

**Bank 0 when pacing says it should be inactive (the first X ms of the block)**:
1.   If there's a vote, schedule it and return.
 1.  If there's a bundle (almost certainly schedulable), schedule it and return.

**Bank 0 when pacing says it should be active (the rest of the block)**:
   1. If there's a vote, schedule it and return.
  1.  If there's a bundle that can be scheduled, schedule it and return.
  1. If there weren't any bundles, or the next one doesn't fit in the rest of the block, try to schedule a normal transaction
  Note: if there was a bundle but it couldn't be scheduled because of account conflicts, don't schedule anything.

**Bank >0 when pacing says it should be inactive**:
  1.  If there's a vote, schedule it and return

**Bank >0 when pacing says it should be active**:
  1. If there's a vote, schedule it and return
  1. Try to schedule a normal transaction