### PR TITLE
net: record the src IP address when running on localhost

### DIFF
--- a/src/disco/net/xdp/fd_xdp_tile.c
+++ b/src/disco/net/xdp/fd_xdp_tile.c
@@ -484,6 +484,9 @@ net_tx_route( fd_net_ctx_t * ctx,
   if( if_idx==1 ) {
     /* Set Ethernet src and dst address to 00:00:00:00:00:00 */
     memset( ctx->tx_op.mac_addrs, 0, 12UL );
+    /* Set the src IP address as 127.0.0.1 */
+    ctx->tx_op.src_ip = 0x0100007f;
+
     ctx->tx_op.if_idx = 1;
     return 1;
   }


### PR DESCRIPTION
When running FD with a local Agave, repair requests are not sent from FD because (1) the repair tile does not specify the src IP; (2) the net tile does not record the local IP. Therefore, repair requests are dropped by the xdp net tile.