### PR TITLE
flamenco: Add low-level txn account vtable helpers

### DIFF
--- a/src/app/ledger/main.c
+++ b/src/app/ledger/main.c
@@ -18,7 +18,6 @@
 #include "../../flamenco/types/fd_types.h"
 #include "../../flamenco/runtime/fd_runtime.h"
 #include "../../flamenco/runtime/fd_runtime_public.h"
-#include "../../flamenco/runtime/fd_borrowed_account.h"
 #include "../../flamenco/runtime/fd_rocksdb.h"
 #include "../../flamenco/runtime/fd_txncache.h"
 #include "../../flamenco/rewards/fd_rewards.h"

--- a/src/discof/restart/fd_restart_tile.c
+++ b/src/discof/restart/fd_restart_tile.c
@@ -490,8 +490,8 @@ after_credit( fd_restart_tile_ctx_t * ctx,
         FD_LOG_ERR(( "fd_txn_account_init_from_funk_readonly(slot_history) failed: %d", err ));
 
       fd_bincode_decode_ctx_t sysvar_decode_ctx = {
-        .data    = rec->const_data,
-        .dataend = rec->const_data + rec->const_meta->dlen,
+        .data    = rec->vt->get_data( rec ),
+        .dataend = rec->vt->get_data( rec ) + rec->vt->get_data_len( rec ),
       };
       ulong total_sz = 0UL;
       err = fd_slot_history_decode_footprint( &sysvar_decode_ctx, &total_sz );

--- a/src/flamenco/rewards/fd_rewards.c
+++ b/src/flamenco/rewards/fd_rewards.c
@@ -897,9 +897,9 @@ calculate_rewards_and_distribute_vote_rewards( fd_exec_slot_ctx_t *             
       FD_LOG_ERR(( "Unable to modify vote account" ));
     }
 
-    vote_rec->meta->slot = slot_ctx->slot_bank.slot;
+    vote_rec->vt->set_slot( vote_rec, slot_ctx->slot_bank.slot );
 
-    if( FD_UNLIKELY( fd_txn_account_checked_add_lamports( vote_rec, vote_reward_node->elem.vote_rewards ) ) ) {
+    if( FD_UNLIKELY( vote_rec->vt->checked_add_lamports( vote_rec, vote_reward_node->elem.vote_rewards ) ) ) {
       FD_LOG_ERR(( "Adding lamports to vote account would cause overflow" ));
     }
 
@@ -940,7 +940,7 @@ distribute_epoch_reward_to_stake_acc( fd_exec_slot_ctx_t * slot_ctx,
     FD_LOG_ERR(( "Unable to modify stake account" ));
   }
 
-  stake_acc_rec->meta->slot = slot_ctx->slot_bank.slot;
+  stake_acc_rec->vt->set_slot( stake_acc_rec, slot_ctx->slot_bank.slot );
 
   fd_stake_state_v2_t stake_state[1] = {0};
   if( fd_stake_get_state( stake_acc_rec, stake_state ) != 0 ) {
@@ -953,7 +953,7 @@ distribute_epoch_reward_to_stake_acc( fd_exec_slot_ctx_t * slot_ctx,
     return 1;
   }
 
-  if( fd_txn_account_checked_add_lamports( stake_acc_rec, reward_lamports ) ) {
+  if( stake_acc_rec->vt->checked_add_lamports( stake_acc_rec, reward_lamports ) ) {
     FD_LOG_DEBUG(( "failed to add lamports to stake account" ));
     return 1;
   }

--- a/src/flamenco/runtime/context/fd_exec_instr_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_instr_ctx.c
@@ -138,8 +138,8 @@ fd_exec_instr_ctx_try_borrow_account( fd_exec_instr_ctx_t const * ctx,
 
   /* Return an AccountBorrowFailed error if the write is not acquirable.
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L605 */
-  int acquire_result = fd_txn_account_acquire_write( txn_account );
-  if( FD_UNLIKELY( !acquire_result ) ) {
+  int borrow_res = txn_account->vt->try_borrow_mut( txn_account );
+  if( FD_UNLIKELY( !borrow_res ) ) {
     return FD_EXECUTOR_INSTR_ERR_ACC_BORROW_FAILED;
   }
 

--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.c
@@ -357,7 +357,7 @@ fd_txn_account_check_exists( fd_txn_account_t *        acc,
                              ushort                    idx ) {
   (void) ctx;
   (void) idx;
-  return fd_account_meta_exists( acc->const_meta );
+  return fd_account_meta_exists( acc->vt->get_meta( acc ) );
 }
 
 int
@@ -382,5 +382,5 @@ fd_txn_account_check_borrow_mut( fd_txn_account_t *        acc,
                                  ushort                    idx ) {
   (void) ctx;
   (void) idx;
-  return fd_txn_account_is_mutable( acc ) && fd_txn_account_acquire_write( acc );
+  return acc->vt->is_mutable( acc ) && acc->vt->try_borrow_mut( acc );
 }

--- a/src/flamenco/runtime/fd_borrowed_account.c
+++ b/src/flamenco/runtime/fd_borrowed_account.c
@@ -14,9 +14,9 @@ fd_borrowed_account_get_data_mut( fd_borrowed_account_t * borrowed_acct,
   }
 
   if ( data_out != NULL )
-    *data_out = acct->data;
+    *data_out = acct->vt->get_data_mut( acct );
   if ( dlen_out != NULL )
-    *dlen_out = acct->meta->dlen;
+    *dlen_out = acct->vt->get_data_len( acct );
 
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
@@ -52,7 +52,7 @@ fd_borrowed_account_set_owner( fd_borrowed_account_t * borrowed_acct,
 
   /* Don't copy the account if the owner does not change
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L757 */
-  if( !memcmp( acct->const_meta->info.owner, owner, sizeof( fd_pubkey_t ) ) ) {
+  if( !memcmp( acct->vt->get_owner( acct ), owner, sizeof( fd_pubkey_t ) ) ) {
     return FD_EXECUTOR_INSTR_SUCCESS;
   }
 
@@ -60,7 +60,7 @@ fd_borrowed_account_set_owner( fd_borrowed_account_t * borrowed_acct,
 
   /* Copy into owner
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L761 */
-  memcpy( acct->meta->info.owner, owner, sizeof(fd_pubkey_t) );
+  acct->vt->set_owner( acct, owner );
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
 
@@ -74,7 +74,7 @@ fd_borrowed_account_set_lamports( fd_borrowed_account_t * borrowed_acct,
   /* An account not owned by the program cannot have its blanace decrease
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L775 */
   if( FD_UNLIKELY( ( !fd_borrowed_account_is_owned_by_current_program( borrowed_acct ) ) &&
-                   ( lamports < acct->const_meta->info.lamports ) ) ) {
+                   ( lamports < acct->vt->get_lamports( acct ) ) ) ) {
     return FD_EXECUTOR_INSTR_ERR_EXTERNAL_ACCOUNT_LAMPORT_SPEND;
   }
 
@@ -92,13 +92,13 @@ fd_borrowed_account_set_lamports( fd_borrowed_account_t * borrowed_acct,
 
   /* Don't copy the account if the lamports do not change
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L787 */
-  if( fd_txn_account_get_lamports( acct ) == lamports ) {
+  if( acct->vt->get_lamports( acct ) == lamports ) {
     return FD_EXECUTOR_INSTR_SUCCESS;
   }
 
   /* Agave self.touch() is a no-op */
 
-  fd_txn_account_set_lamports( acct, lamports );
+  acct->vt->set_lamports( acct, lamports );
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
 
@@ -127,8 +127,7 @@ fd_borrowed_account_set_data_from_slice( fd_borrowed_account_t * borrowed_acct,
   }
 
   /* AccountSharedData::set_data_from_slice() */
-  acct->meta->dlen = data_sz;
-  fd_memcpy( acct->data, data, data_sz );
+  acct->vt->set_data( acct, data, data_sz );
 
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
@@ -149,7 +148,7 @@ fd_borrowed_account_set_data_length( fd_borrowed_account_t * borrowed_acct,
     return err;
   }
 
-  ulong old_len = acct->const_meta->dlen;
+  ulong old_len = acct->vt->get_data_len( acct );
 
   /* Don't copy the account if the length does not change
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L886 */
@@ -166,7 +165,7 @@ fd_borrowed_account_set_data_length( fd_borrowed_account_t * borrowed_acct,
 
   /* Resize the account
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L891 */
-  fd_txn_account_resize( acct, new_len );
+  acct->vt->resize( acct, new_len );
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
 
@@ -178,7 +177,7 @@ fd_borrowed_account_set_executable( fd_borrowed_account_t * borrowed_acct,
   /* To become executable an account must be rent exempt
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L1003-L1006 */
   fd_rent_t const * rent = &borrowed_acct->instr_ctx->txn_ctx->rent;
-  if( FD_UNLIKELY( acct->const_meta->info.lamports < fd_rent_exempt_minimum_balance( rent, acct->const_meta->dlen ) ) ) {
+  if( FD_UNLIKELY( acct->vt->get_lamports( acct ) < fd_rent_exempt_minimum_balance( rent, acct->vt->get_data_len( acct ) ) ) ) {
     return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_ACCOUNT_NOT_RENT_EXEMPT;
   }
 
@@ -209,7 +208,7 @@ fd_borrowed_account_set_executable( fd_borrowed_account_t * borrowed_acct,
   /* Agave self.touch() is a no-op */
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L1027 */
-  fd_txn_account_set_executable( acct, is_executable );
+  acct->vt->set_executable( acct, is_executable );
 
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
@@ -220,7 +219,7 @@ fd_borrowed_account_update_accounts_resize_delta( fd_borrowed_account_t * borrow
                                                   int *                   err ) {
   fd_exec_instr_ctx_t const * instr_ctx  = borrowed_acct->instr_ctx;
   fd_txn_account_t *          acct       = borrowed_acct->acct;
-  ulong                       size_delta = fd_ulong_sat_sub( new_len, acct->const_meta->dlen );
+  ulong                       size_delta = fd_ulong_sat_sub( new_len, acct->vt->get_data_len( acct ) );
 
   /* TODO: The size delta should never exceed the value of ULONG_MAX so this
      could be replaced with a normal addition. However to match execution with

--- a/src/flamenco/runtime/fd_borrowed_account.h
+++ b/src/flamenco/runtime/fd_borrowed_account.h
@@ -15,6 +15,8 @@
 
 /* TODO: Not all Agave Borrowed Account API functions are implemented here */
 
+/* TODO: check that borrow is active when calling these APIs */
+
 struct fd_borrowed_account {
   ulong                       magic;
   fd_txn_account_t *          acct;
@@ -53,7 +55,7 @@ fd_borrowed_account_init( fd_borrowed_account_t *     borrowed_acct,
 
 static inline void
 fd_borrowed_account_drop( fd_borrowed_account_t * borrowed_acct ) {
-  fd_txn_account_release_write_private( borrowed_acct->acct );
+  borrowed_acct->acct->vt->drop( borrowed_acct->acct );
 }
 
 /* Destructor  */
@@ -61,7 +63,7 @@ fd_borrowed_account_drop( fd_borrowed_account_t * borrowed_acct ) {
 static inline void
 fd_borrowed_account_destroy( fd_borrowed_account_t * borrowed_acct ) {
   if( FD_LIKELY( borrowed_acct->magic == FD_BORROWED_ACCOUNT_MAGIC ) ) {
-    fd_txn_account_release_write_private( borrowed_acct->acct );
+    fd_borrowed_account_drop( borrowed_acct );
   }
 
   FD_COMPILER_MFENCE();
@@ -78,9 +80,14 @@ fd_borrowed_account_destroy( fd_borrowed_account_t * borrowed_acct ) {
 
    https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L817 */
 
-static inline void const *
+static inline uchar const *
 fd_borrowed_account_get_data( fd_borrowed_account_t const * borrowed_acct ) {
-  return borrowed_acct->acct->const_data;
+  return borrowed_acct->acct->vt->get_data( borrowed_acct->acct );
+}
+
+static inline ulong
+fd_borrowed_account_get_data_len( fd_borrowed_account_t const * borrowed_acct ) {
+  return borrowed_acct->acct->vt->get_data_len( borrowed_acct->acct );
 }
 
 /* fd_borrowed_account_get_data_mut mirrors Agave function
@@ -98,8 +105,8 @@ fd_borrowed_account_get_data_mut( fd_borrowed_account_t * borrowed_acct,
                                   ulong *                 dlen_out );
 
 static inline fd_pubkey_t const *
-fd_borrowed_account_get_owner( fd_borrowed_account_t * borrowed_acct ) {
-  return (fd_pubkey_t const *) borrowed_acct->acct->const_meta->info.owner;
+fd_borrowed_account_get_owner( fd_borrowed_account_t const * borrowed_acct ) {
+  return borrowed_acct->acct->vt->get_owner( borrowed_acct->acct );
 }
 
 /* fd_borrowed_account_get_lamports mirrors Agave function
@@ -112,7 +119,7 @@ fd_borrowed_account_get_owner( fd_borrowed_account_t * borrowed_acct ) {
 
 static inline ulong
 fd_borrowed_account_get_lamports( fd_borrowed_account_t const * borrowed_acct ) {
-  return fd_txn_account_get_lamports( borrowed_acct->acct );
+  return borrowed_acct->acct->vt->get_lamports( borrowed_acct->acct );
 }
 
 /* fd_borrowed_account_get_rent_epoch mirrors Agave function
@@ -122,9 +129,12 @@ fd_borrowed_account_get_lamports( fd_borrowed_account_t const * borrowed_acct ) 
 
 static inline ulong
 fd_borrowed_account_get_rent_epoch( fd_borrowed_account_t const * borrowed_acct ) {
-  FD_TEST( borrowed_acct->acct->const_meta != NULL );
-  /* TODO: rent_epoch should be a property of fd_txn_account_t */
-  return borrowed_acct->acct->const_meta->info.rent_epoch;
+  return borrowed_acct->acct->vt->get_rent_epoch( borrowed_acct->acct );
+}
+
+static inline fd_account_meta_t const *
+fd_borrowed_account_get_acc_meta( fd_borrowed_account_t const * borrowed_acct ) {
+  return borrowed_acct->acct->vt->get_meta( borrowed_acct->acct );
 }
 
 /* Setters */
@@ -203,7 +213,7 @@ static inline int
 fd_borrowed_account_checked_add_lamports( fd_borrowed_account_t * borrowed_acct,
                                           ulong                   lamports ) {
   ulong balance_post = 0UL;
-  int err = fd_ulong_checked_add( borrowed_acct->acct->const_meta->info.lamports,
+  int err = fd_ulong_checked_add( borrowed_acct->acct->vt->get_lamports( borrowed_acct->acct ),
                                   lamports,
                                   &balance_post );
   if( FD_UNLIKELY( err ) ) {
@@ -226,7 +236,7 @@ static inline int
 fd_borrowed_account_checked_sub_lamports( fd_borrowed_account_t * borrowed_acct,
                                           ulong                   lamports ) {
   ulong balance_post = 0UL;
-  int err = fd_ulong_checked_sub( borrowed_acct->acct->const_meta->info.lamports,
+  int err = fd_ulong_checked_sub( borrowed_acct->acct->vt->get_lamports( borrowed_acct->acct ),
                                   lamports,
                                   &balance_post );
   if( FD_UNLIKELY( err ) ) {
@@ -258,13 +268,13 @@ fd_borrowed_account_update_accounts_resize_delta( fd_borrowed_account_t * borrow
 static inline int
 fd_borrowed_account_is_rent_exempt_at_data_length( fd_borrowed_account_t const * borrowed_acct ) {
   fd_txn_account_t * acct = borrowed_acct->acct;
-  FD_TEST( acct->const_meta != NULL );
+  if( FD_UNLIKELY( ( acct->vt->get_meta( acct ) == NULL ) ) ) FD_LOG_ERR(( "account is not setup" ));
 
   /* TODO: Add an is_exempt rent API to better match Agave and clean up code
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L990 */
   fd_rent_t rent    = borrowed_acct->instr_ctx->txn_ctx->rent;
-  ulong min_balance = fd_rent_exempt_minimum_balance( &rent, acct->const_meta->dlen );
-  return acct->const_meta->info.lamports >= min_balance;
+  ulong min_balance = fd_rent_exempt_minimum_balance( &rent, acct->vt->get_data_len( acct ) );
+  return acct->vt->get_lamports( acct ) >= min_balance;
 }
 
 /* fd_borrowed_account_is_executable mirrors Agave function
@@ -277,7 +287,7 @@ fd_borrowed_account_is_rent_exempt_at_data_length( fd_borrowed_account_t const *
 
 FD_FN_PURE static inline int
 fd_borrowed_account_is_executable( fd_borrowed_account_t const * borrowed_acct ) {
-  return fd_txn_account_is_executable( borrowed_acct->acct );
+  return borrowed_acct->acct->vt->is_executable( borrowed_acct->acct );
 }
 
 /* fd_borrowed_account_is_executable_internal is a private function for deprecating the `is_executable` flag.
@@ -291,6 +301,11 @@ FD_FN_PURE static inline int
 fd_borrowed_account_is_executable_internal( fd_borrowed_account_t const * borrowed_acct ) {
   return !FD_FEATURE_ACTIVE( borrowed_acct->instr_ctx->txn_ctx->slot, borrowed_acct->instr_ctx->txn_ctx->features, remove_accounts_executable_flag_checks ) &&
           fd_borrowed_account_is_executable( borrowed_acct );
+}
+
+FD_FN_PURE static inline int
+fd_borrowed_account_is_mutable( fd_borrowed_account_t const * borrowed_acct ) {
+  return borrowed_acct->acct->vt->is_mutable( borrowed_acct->acct );
 }
 
 /* fd_borrowed_account_is_signer mirrors the Agave function
@@ -347,7 +362,7 @@ fd_borrowed_account_is_owned_by_current_program( fd_borrowed_account_t const * b
   }
 
   return memcmp( program_id_pubkey->key,
-                 borrowed_acct->acct->const_meta->info.owner, sizeof(fd_pubkey_t) ) == 0;
+                 borrowed_acct->acct->vt->get_owner( borrowed_acct->acct ), sizeof(fd_pubkey_t) ) == 0;
 }
 
 /* fd_borrowed_account_can_data_be changed mirrors Agave function
@@ -396,7 +411,7 @@ fd_borrowed_account_can_data_be_resized( fd_borrowed_account_t const * borrowed_
 
   /* Only the owner can change the length of the data
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L1095 */
-  if( FD_UNLIKELY( ( acct->const_meta->dlen != new_length ) &
+  if( FD_UNLIKELY( ( acct->vt->get_data_len( acct ) != new_length ) &
                    ( !fd_borrowed_account_is_owned_by_current_program( borrowed_acct ) ) ) ) {
     *err = FD_EXECUTOR_INSTR_ERR_ACC_DATA_SIZE_CHANGED;
     return 0;
@@ -411,7 +426,7 @@ fd_borrowed_account_can_data_be_resized( fd_borrowed_account_t const * borrowed_
 
   /* The resize can not exceed the per-transaction maximum
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L1104-L1108 */
-  long length_delta = fd_long_sat_sub( (long)new_length, (long)acct->const_meta->dlen );
+  long length_delta = fd_long_sat_sub( (long)new_length, (long)acct->vt->get_data_len( acct ) );
   long new_accounts_resize_delta = fd_long_sat_add( (long)borrowed_acct->instr_ctx->txn_ctx->accounts_resize_delta, length_delta );
   if( FD_UNLIKELY( new_accounts_resize_delta > MAX_PERMITTED_ACCOUNT_DATA_ALLOCS_PER_TXN ) ) {
     *err = FD_EXECUTOR_INSTR_ERR_MAX_ACCS_DATA_ALLOCS_EXCEEDED;
@@ -426,8 +441,8 @@ FD_FN_PURE static inline int
 fd_borrowed_account_is_zeroed( fd_borrowed_account_t const * borrowed_acct ) {
   fd_txn_account_t * acct = borrowed_acct->acct;
   /* TODO: optimize this */
-  uchar const * data = ((uchar *) acct->const_meta) + acct->const_meta->hlen;
-  for( ulong i=0UL; i < acct->const_meta->dlen; i++ )
+  uchar const * data = acct->vt->get_data( acct );
+  for( ulong i=0UL; i < acct->vt->get_data_len( acct ); i++ )
     if( data[i] != 0 )
       return 0;
   return 1;

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -330,8 +330,7 @@ fd_runtime_collect_rent_from_account( ulong                       slot,
                                       fd_rent_t const *           rent,
                                       double                      slots_per_year,
                                       fd_features_t *             features,
-                                      fd_account_meta_t *         acc,
-                                      fd_pubkey_t const *         key,
+                                      fd_txn_account_t *          acc,
                                       ulong                       epoch );
 
 void

--- a/src/flamenco/runtime/fd_runtime_init.c
+++ b/src/flamenco/runtime/fd_runtime_init.c
@@ -266,7 +266,7 @@ fd_feature_restore( fd_exec_slot_ctx_t *    slot_ctx,
   }
 
   /* Skip accounts that are not owned by the feature program */
-  if( FD_UNLIKELY( memcmp( acct_rec->const_meta->info.owner, fd_solana_feature_program_id.key, sizeof(fd_pubkey_t) ) ) ) {
+  if( FD_UNLIKELY( memcmp( acct_rec->vt->get_owner( acct_rec ), fd_solana_feature_program_id.key, sizeof(fd_pubkey_t) ) ) ) {
     return;
   }
 
@@ -278,8 +278,8 @@ fd_feature_restore( fd_exec_slot_ctx_t *    slot_ctx,
   FD_SPAD_FRAME_BEGIN( runtime_spad ) {
 
     fd_bincode_decode_ctx_t ctx = {
-      .data    = acct_rec->const_data,
-      .dataend = acct_rec->const_data + acct_rec->const_meta->dlen,
+      .data    = acct_rec->vt->get_data( acct_rec ),
+      .dataend = acct_rec->vt->get_data( acct_rec ) + acct_rec->vt->get_data_len( acct_rec ),
     };
 
     ulong total_sz   = 0UL;

--- a/src/flamenco/runtime/fd_txn_account.c
+++ b/src/flamenco/runtime/fd_txn_account.c
@@ -1,5 +1,4 @@
 #include "fd_txn_account.h"
-#include "fd_acc_mgr.h"
 #include "fd_runtime.h"
 
 fd_txn_account_t *
@@ -17,14 +16,18 @@ fd_txn_account_init( void * ptr ) {
   memset( ptr, 0, FD_TXN_ACCOUNT_FOOTPRINT );
 
   fd_txn_account_t * ret = (fd_txn_account_t *)ptr;
-  ret->const_data        = NULL;
-  ret->const_meta        = NULL;
-  ret->meta              = NULL;
-  ret->data              = NULL;
-  ret->meta_gaddr        = 0UL;
-  ret->data_gaddr        = 0UL;
-  ret->starting_dlen     = ULONG_MAX;
-  ret->starting_lamports = ULONG_MAX;
+  ret->private_state.meta_gaddr = 0UL;
+  ret->private_state.data_gaddr = 0UL;
+  ret->starting_dlen            = ULONG_MAX;
+  ret->starting_lamports        = ULONG_MAX;
+
+  ret->private_state.const_data = NULL;
+  ret->private_state.const_meta = NULL;
+  ret->private_state.meta       = NULL;
+  ret->private_state.data       = NULL;
+
+  /* Defaults to writable vtable */
+  ret->vt                       = &fd_txn_account_writable_vtable;
 
   FD_COMPILER_MFENCE();
   ret->magic = FD_TXN_ACCOUNT_MAGIC;
@@ -37,8 +40,8 @@ fd_txn_account_init( void * ptr ) {
    default values for the txn account */
 void
 fd_txn_account_setup_common( fd_txn_account_t * acct ) {
-  fd_account_meta_t const * meta = acct->const_meta ?
-                                   acct->const_meta : acct->meta;
+  fd_account_meta_t const * meta = acct->private_state.const_meta ?
+                                   acct->private_state.const_meta : acct->private_state.meta;
 
   if( ULONG_MAX == acct->starting_dlen ) {
     acct->starting_dlen = meta->dlen;
@@ -50,19 +53,53 @@ fd_txn_account_setup_common( fd_txn_account_t * acct ) {
 }
 
 void
-fd_txn_account_setup_sentinel_meta( fd_txn_account_t * acct,
-                                    fd_spad_t *        spad,
-                                    fd_wksp_t *        spad_wksp ) {
-  fd_account_meta_t * sentinel = fd_spad_alloc( spad, FD_ACCOUNT_REC_ALIGN, sizeof(fd_account_meta_t) );
-  fd_memset( sentinel, 0, sizeof(fd_account_meta_t) );
-  sentinel->magic           = FD_ACCOUNT_META_MAGIC;
-  sentinel->info.rent_epoch = ULONG_MAX;
-  acct->const_meta          = sentinel;
-  acct->starting_lamports   = 0UL;
-  acct->starting_dlen       = 0UL;
-  acct->meta_gaddr          = fd_wksp_gaddr( spad_wksp, sentinel );
+fd_txn_account_init_from_meta_and_data_mutable( fd_txn_account_t *  acct,
+                                                fd_account_meta_t * meta,
+                                                uchar *             data ) {
+  acct->private_state.const_data = data;
+  acct->private_state.const_meta = meta;
+  acct->private_state.data       = data;
+  acct->private_state.meta       = meta;
+  acct->vt                       = &fd_txn_account_writable_vtable;
 }
 
+void
+fd_txn_account_init_from_meta_and_data_readonly( fd_txn_account_t *        acct,
+                                                 fd_account_meta_t const * meta,
+                                                 uchar const *             data ) {
+
+  acct->private_state.const_data = data;
+  acct->private_state.const_meta = meta;
+  acct->vt                       = &fd_txn_account_readonly_vtable;
+}
+
+void
+fd_txn_account_setup_sentinel_meta_readonly( fd_txn_account_t * acct,
+                                             fd_spad_t *        spad,
+                                             fd_wksp_t *        spad_wksp ) {
+
+  fd_account_meta_t * sentinel = fd_spad_alloc( spad, FD_ACCOUNT_REC_ALIGN, sizeof(fd_account_meta_t) );
+  fd_memset( sentinel, 0, sizeof(fd_account_meta_t) );
+
+  sentinel->magic                 = FD_ACCOUNT_META_MAGIC;
+  sentinel->info.rent_epoch       = ULONG_MAX;
+  acct->private_state.const_meta = sentinel;
+  acct->starting_lamports         = 0UL;
+  acct->starting_dlen             = 0UL;
+  acct->private_state.meta_gaddr  = fd_wksp_gaddr( spad_wksp, sentinel );
+}
+
+void
+fd_txn_account_setup_meta_mutable( fd_txn_account_t * acct,
+                                   fd_spad_t *        spad,
+                                   ulong              sz ) {
+  fd_account_meta_t * meta = fd_spad_alloc( spad, alignof(fd_account_meta_t), sizeof(fd_account_meta_t) + sz );
+  void * data = (uchar *)meta + sizeof(fd_account_meta_t);
+
+  acct->private_state.const_meta = acct->private_state.meta = meta;
+  acct->private_state.const_data = acct->private_state.data = data;
+  acct->vt                       = &fd_txn_account_writable_vtable;
+}
 
 void
 fd_txn_account_setup_readonly( fd_txn_account_t *        acct,
@@ -73,8 +110,9 @@ fd_txn_account_setup_readonly( fd_txn_account_t *        acct,
   /* We don't copy the metadata into a buffer here, because we assume
      that we are holding read locks on the account, because we are inside
      a transaction. */
-  acct->const_meta = meta;
-  acct->const_data = (uchar const *)meta + meta->hlen;
+  acct->private_state.const_meta = meta;
+  acct->private_state.const_data = (uchar const *)meta + meta->hlen;
+  acct->vt                       = &fd_txn_account_readonly_vtable;
 
   fd_txn_account_setup_common( acct );
 }
@@ -85,38 +123,25 @@ fd_txn_account_setup_mutable( fd_txn_account_t *        acct,
                               fd_account_meta_t *       meta ) {
   fd_memcpy(acct->pubkey, pubkey, sizeof(fd_pubkey_t));
 
-  acct->const_rec  = acct->rec;
-  acct->const_meta = acct->meta = meta;
-  acct->const_data = acct->data = (uchar *)meta + meta->hlen;
+  acct->private_state.const_rec  = acct->private_state.rec;
+  acct->private_state.const_meta = acct->private_state.meta = meta;
+  acct->private_state.const_data = acct->private_state.data = (uchar *)meta + meta->hlen;
+  acct->vt                       = &fd_txn_account_writable_vtable;
 
   fd_txn_account_setup_common( acct );
 }
 
 /* Operators impl */
 
-void
-fd_txn_account_resize( fd_txn_account_t * acct,
-                       ulong              dlen ) {
-  /* Because the memory for an account is preallocated for the transaction
-     up to the max account size, we only need to zero out bytes (for the case
-     where the account grew) and update the account dlen. */
-  ulong old_sz    = acct->meta->dlen;
-  ulong new_sz    = dlen;
-  ulong memset_sz = fd_ulong_sat_sub( new_sz, old_sz );
-  fd_memset( acct->data+old_sz, 0, memset_sz );
-
-  acct->meta->dlen = dlen;
-}
-
 /* Internal helper to initialize account data */
 uchar *
 fd_txn_account_init_data( fd_txn_account_t * acct, void * buf ) {
   /* Assumes that buf is pointing to account data */
   uchar * new_raw_data = (uchar *)buf;
-  ulong   dlen         = ( acct->const_meta != NULL ) ? acct->const_meta->dlen : 0;
+  ulong   dlen         = ( acct->private_state.const_meta != NULL ) ? acct->private_state.const_meta->dlen : 0;
 
-  if( acct->const_meta != NULL ) {
-    fd_memcpy( new_raw_data, (uchar *)acct->const_meta, sizeof(fd_account_meta_t)+dlen );
+  if( acct->private_state.const_meta != NULL ) {
+    fd_memcpy( new_raw_data, (uchar *)acct->private_state.const_meta, sizeof(fd_account_meta_t)+dlen );
   } else {
     /* Account did not exist, set up metadata */
     fd_account_meta_init( (fd_account_meta_t *)new_raw_data );
@@ -129,20 +154,21 @@ fd_txn_account_t *
 fd_txn_account_make_mutable( fd_txn_account_t * acct,
                              void *             buf,
                              fd_wksp_t *        wksp ) {
-  if( FD_UNLIKELY( acct->data != NULL ) ) {
+  if( FD_UNLIKELY( acct->private_state.data != NULL ) ) {
     FD_LOG_ERR(( "borrowed account is already mutable" ));
   }
 
-  ulong   dlen         = ( acct->const_meta != NULL ) ? acct->const_meta->dlen : 0UL;
+  ulong   dlen         = ( acct->private_state.const_meta != NULL ) ? acct->private_state.const_meta->dlen : 0UL;
   uchar * new_raw_data = fd_txn_account_init_data( acct, buf );
 
-  acct->const_meta = acct->meta = (fd_account_meta_t *)new_raw_data;
-  acct->const_data = acct->data = new_raw_data + sizeof(fd_account_meta_t);
-  acct->meta->dlen = dlen;
+  acct->private_state.const_meta = acct->private_state.meta = (fd_account_meta_t *)new_raw_data;
+  acct->private_state.const_data = acct->private_state.data = new_raw_data + sizeof(fd_account_meta_t);
+  acct->private_state.meta->dlen = dlen;
 
   /* update global addresses of meta and data after copying into buffer */
-  acct->meta_gaddr = fd_wksp_gaddr( wksp, acct->meta );
-  acct->data_gaddr = fd_wksp_gaddr( wksp, acct->data );
+  acct->private_state.meta_gaddr = fd_wksp_gaddr( wksp, acct->private_state.meta );
+  acct->private_state.data_gaddr = fd_wksp_gaddr( wksp, acct->private_state.data );
+  acct->vt                       = &fd_txn_account_writable_vtable;
 
   return acct;
 }
@@ -160,7 +186,7 @@ fd_txn_account_init_from_funk_readonly( fd_txn_account_t *    acct,
   fd_account_meta_t const * meta = fd_funk_get_acc_meta_readonly( funk,
                                                                   funk_txn,
                                                                   pubkey,
-                                                                  &acct->const_rec,
+                                                                  &acct->private_state.const_rec,
                                                                   &err,
                                                                   NULL );
 
@@ -177,9 +203,9 @@ fd_txn_account_init_from_funk_readonly( fd_txn_account_t *    acct,
   }
 
   /* setup global addresses of meta and data for exec and replay tile sharing */
-  fd_wksp_t * funk_wksp = fd_funk_wksp( funk );
-  acct->meta_gaddr = fd_wksp_gaddr( funk_wksp, acct->const_meta );
-  acct->data_gaddr = fd_wksp_gaddr( funk_wksp, acct->const_data );
+  fd_wksp_t * funk_wksp          = fd_funk_wksp( funk );
+  acct->private_state.meta_gaddr = fd_wksp_gaddr( funk_wksp, acct->private_state.const_meta );
+  acct->private_state.data_gaddr = fd_wksp_gaddr( funk_wksp, acct->private_state.const_data );
 
   fd_txn_account_setup_readonly( acct, pubkey, meta );
 
@@ -202,7 +228,7 @@ fd_txn_account_init_from_funk_mutable( fd_txn_account_t *  acct,
                                                            pubkey,
                                                            do_create,
                                                            min_data_sz,
-                                                           &acct->rec,
+                                                           &acct->private_state.rec,
                                                            &prepare,
                                                            &err );
 
@@ -222,7 +248,7 @@ fd_txn_account_init_from_funk_mutable( fd_txn_account_t *  acct,
 
   /* trigger a segfault if the exec tile calls this function,
      as funk will be mapped read-only */
-  acct->data[0] = acct->data[0];
+  acct->private_state.data[0] = acct->private_state.data[0];
 
   return FD_ACC_MGR_SUCCESS;
 }
@@ -232,14 +258,14 @@ fd_txn_account_init_from_funk_mutable( fd_txn_account_t *  acct,
 int
 fd_txn_account_save_internal( fd_txn_account_t * acct,
                               fd_funk_t *        funk ) {
-  if( acct->rec == NULL ) {
+  if( acct->private_state.rec == NULL ) {
     return FD_ACC_MGR_ERR_WRITE_FAILED;
   }
 
   fd_wksp_t * wksp = fd_funk_wksp( funk );
-  ulong reclen = sizeof(fd_account_meta_t)+acct->const_meta->dlen;
-  uchar * raw = fd_funk_val( acct->rec, wksp );
-  fd_memcpy( raw, acct->meta, reclen );
+  ulong reclen = sizeof(fd_account_meta_t)+acct->private_state.const_meta->dlen;
+  uchar * raw = fd_funk_val( acct->private_state.rec, wksp );
+  fd_memcpy( raw, acct->private_state.meta, reclen );
 
   return FD_ACC_MGR_SUCCESS;
 }
@@ -249,17 +275,17 @@ fd_txn_account_save( fd_txn_account_t * acct,
                      fd_funk_t *        funk,
                      fd_funk_txn_t *    txn,
                      fd_wksp_t *        acc_data_wksp ) {
-  acct->meta = fd_wksp_laddr( acc_data_wksp, acct->meta_gaddr );
-  acct->data = fd_wksp_laddr( acc_data_wksp, acct->data_gaddr );
+  acct->private_state.meta = fd_wksp_laddr( acc_data_wksp, acct->private_state.meta_gaddr );
+  acct->private_state.data = fd_wksp_laddr( acc_data_wksp, acct->private_state.data_gaddr );
 
-  if( acct->meta == NULL ) {
+  if( acct->private_state.meta == NULL ) {
     /* The meta is NULL so the account is not writable. */
     FD_LOG_DEBUG(( "fd_txn_account_save: account is not writable: %s", FD_BASE58_ENC_32_ALLOCA( acct->pubkey ) ));
     return FD_ACC_MGR_ERR_WRITE_FAILED;
   }
 
-  acct->const_meta = acct->meta;
-  acct->const_data = acct->data;
+  acct->private_state.const_meta = acct->private_state.meta;
+  acct->private_state.const_data = acct->private_state.data;
 
   fd_funk_rec_key_t key = fd_funk_acc_key( acct->pubkey );
 
@@ -271,8 +297,8 @@ fd_txn_account_save( fd_txn_account_t * acct,
   fd_funk_rec_t * rec = fd_funk_rec_prepare( funk, txn, &key, prepare, &err );
   if( rec == NULL ) FD_LOG_ERR(( "unable to insert a new record, error %d", err ));
 
-  acct->rec = rec;
-  ulong reclen = sizeof(fd_account_meta_t)+acct->const_meta->dlen;
+  acct->private_state.rec = rec;
+  ulong reclen = sizeof(fd_account_meta_t)+acct->private_state.const_meta->dlen;
   fd_wksp_t * wksp = fd_funk_wksp( funk );
   if( fd_funk_val_truncate( rec, reclen, fd_funk_alloc( funk, wksp ), wksp, &err ) == NULL ) {
     FD_LOG_ERR(( "unable to allocate account value, err %d", err ));
@@ -321,3 +347,413 @@ fd_txn_account_mutable_fini( fd_txn_account_t * acct,
     fd_funk_rec_publish( &acct->prepared_rec );
   }
 }
+
+/* read/write mutual exclusion */
+
+FD_FN_PURE int
+fd_txn_account_acquire_write_is_safe( fd_txn_account_t const * acct ) {
+  return (!acct->private_state.refcnt_excl);
+}
+
+/* fd_txn_account_acquire_write acquires write/exclusive access.
+   Causes all other write or read acquire attempts will fail.  Returns 1
+   on success, 0 on failure.
+
+   Mirrors a try_borrow_mut() call in Agave. */
+int
+fd_txn_account_acquire_write( fd_txn_account_t * acct ) {
+  if( FD_UNLIKELY( !fd_txn_account_acquire_write_is_safe( acct ) ) ) {
+    return 0;
+  }
+  acct->private_state.refcnt_excl = (ushort)1;
+  return 1;
+}
+
+/* fd_txn_account_release_write{_private} releases a write/exclusive
+   access handle. The private version should only be used by fd_borrowed_account_drop
+   and fd_borrowed_account_destroy. */
+void
+fd_txn_account_release_write( fd_txn_account_t * acct ) {
+  FD_TEST( acct->private_state.refcnt_excl==1U );
+  acct->private_state.refcnt_excl = (ushort)0;
+}
+
+void
+fd_txn_account_release_write_private( fd_txn_account_t * acct ) {
+  /* Only release if it is not yet released */
+  if( !fd_txn_account_acquire_write_is_safe( acct ) ) {
+    fd_txn_account_release_write( acct );
+  }
+}
+
+/* Vtable API Impls */
+
+fd_account_meta_t const *
+fd_txn_account_get_acc_meta( fd_txn_account_t const * acct ) {
+  return acct->private_state.const_meta;
+}
+
+uchar const *
+fd_txn_account_get_acc_data( fd_txn_account_t const * acct ) {
+  return acct->private_state.const_data;
+}
+
+fd_funk_rec_t const *
+fd_txn_account_get_acc_rec( fd_txn_account_t const * acct ) {
+  return acct->private_state.const_rec;
+}
+
+uchar *
+fd_txn_account_get_acc_data_mut_writable( fd_txn_account_t const * acct ) {
+  return acct->private_state.data;
+}
+
+void
+fd_txn_account_set_meta_readonly( fd_txn_account_t *        acct,
+                                  fd_account_meta_t const * meta ) {
+  acct->private_state.const_meta = meta;
+}
+
+void
+fd_txn_account_set_meta_mutable_writable( fd_txn_account_t *  acct,
+                                 fd_account_meta_t * meta ) {
+  acct->private_state.const_meta = acct->private_state.meta = meta;
+}
+
+ulong
+fd_txn_account_get_data_len( fd_txn_account_t const * acct ) {
+  if( FD_UNLIKELY( !acct->private_state.const_meta ) ) FD_LOG_ERR(("account is not setup" ));
+  return acct->private_state.const_meta->dlen;
+}
+
+int
+fd_txn_account_is_executable( fd_txn_account_t const * acct ) {
+  if( FD_UNLIKELY( !acct->private_state.const_meta ) ) FD_LOG_ERR(("account is not setup" ));
+  return !!acct->private_state.const_meta->info.executable;
+}
+
+fd_pubkey_t const *
+fd_txn_account_get_owner( fd_txn_account_t const * acct ) {
+  if( FD_UNLIKELY( !acct->private_state.const_meta ) ) FD_LOG_ERR(("account is not setup" ));
+  return (fd_pubkey_t const *)acct->private_state.const_meta->info.owner;
+}
+
+ulong
+fd_txn_account_get_lamports( fd_txn_account_t const * acct ) {
+  /* (!const_meta_) considered an internal error */
+  if( FD_UNLIKELY( !acct->private_state.const_meta ) ) return 0UL;
+  return acct->private_state.const_meta->info.lamports;
+}
+
+ulong
+fd_txn_account_get_rent_epoch( fd_txn_account_t const * acct ) {
+  if( FD_UNLIKELY( !acct->private_state.const_meta ) ) FD_LOG_ERR(("account is not setup" ));
+  return acct->private_state.const_meta->info.rent_epoch;
+}
+
+fd_hash_t const *
+fd_txn_account_get_hash( fd_txn_account_t const * acct ) {
+  if( FD_UNLIKELY( !acct->private_state.const_meta ) ) FD_LOG_ERR(("account is not setup" ));
+  return (fd_hash_t const *)acct->private_state.const_meta->hash;
+}
+
+fd_solana_account_meta_t const *
+fd_txn_account_get_info( fd_txn_account_t const * acct ) {
+  if( FD_UNLIKELY( !acct->private_state.const_meta ) ) FD_LOG_ERR(("account is not setup" ));
+  return &acct->private_state.const_meta->info;
+}
+
+void
+fd_txn_account_set_executable_writable( fd_txn_account_t * acct, int is_executable ) {
+  if( FD_UNLIKELY( !acct->private_state.meta ) ) FD_LOG_ERR(("account is not mutable" ));
+  acct->private_state.meta->info.executable = !!is_executable;
+}
+
+void
+fd_txn_account_set_owner_writable( fd_txn_account_t * acct, fd_pubkey_t const * owner ) {
+  if( FD_UNLIKELY( !acct->private_state.meta ) ) FD_LOG_ERR(("account is not mutable" ));
+  fd_memcpy( acct->private_state.meta->info.owner, owner, sizeof(fd_pubkey_t) );
+}
+
+void
+fd_txn_account_set_lamports_writable( fd_txn_account_t * acct, ulong lamports ) {
+  if( FD_UNLIKELY( !acct->private_state.meta ) ) FD_LOG_ERR(("account is not mutable" ));
+  acct->private_state.meta->info.lamports = lamports;
+}
+
+int
+fd_txn_account_checked_add_lamports_writable( fd_txn_account_t * acct, ulong lamports ) {
+  ulong balance_post = 0UL;
+  int err = fd_ulong_checked_add( acct->vt->get_lamports( acct ), lamports, &balance_post );
+  if( FD_UNLIKELY( err ) ) {
+    return FD_EXECUTOR_INSTR_ERR_ARITHMETIC_OVERFLOW;
+  }
+
+  acct->vt->set_lamports( acct, balance_post );
+  return FD_EXECUTOR_INSTR_SUCCESS;
+}
+
+int
+fd_txn_account_checked_sub_lamports_writable( fd_txn_account_t * acct, ulong lamports ) {
+  ulong balance_post = 0UL;
+  int err = fd_ulong_checked_sub( acct->vt->get_lamports( acct ),
+                                  lamports,
+                                  &balance_post );
+  if( FD_UNLIKELY( err ) ) {
+    return FD_EXECUTOR_INSTR_ERR_ARITHMETIC_OVERFLOW;
+  }
+
+  acct->vt->set_lamports( acct, balance_post );
+  return FD_EXECUTOR_INSTR_SUCCESS;
+}
+
+void
+fd_txn_account_set_rent_epoch_writable( fd_txn_account_t * acct, ulong rent_epoch ) {
+  if( FD_UNLIKELY( !acct->private_state.meta ) ) FD_LOG_ERR(("account is not mutable" ));
+  acct->private_state.meta->info.rent_epoch = rent_epoch;
+}
+
+void
+fd_txn_account_set_data_writable( fd_txn_account_t * acct,
+                                  void const *       data,
+                                  ulong              data_sz) {
+  if( FD_UNLIKELY( !acct->private_state.meta ) ) FD_LOG_ERR(("account is not mutable" ));
+  acct->private_state.meta->dlen = data_sz;
+  fd_memcpy( acct->private_state.data, data, data_sz );
+}
+
+void
+fd_txn_account_set_data_len_writable( fd_txn_account_t * acct,
+                                      ulong              data_len ) {
+  if( FD_UNLIKELY( !acct->private_state.meta ) ) FD_LOG_ERR(("account is not mutable" ));
+  acct->private_state.meta->dlen = data_len;
+}
+
+void
+fd_txn_account_set_slot_writable( fd_txn_account_t * acct,
+                         ulong              slot ) {
+  if( FD_UNLIKELY( !acct->private_state.meta ) ) FD_LOG_ERR(("account is not mutable" ));
+  acct->private_state.meta->slot = slot;
+}
+
+void
+fd_txn_account_set_hash_writable( fd_txn_account_t * acct,
+                                  fd_hash_t const *  hash ) {
+  if( FD_UNLIKELY( !acct->private_state.meta ) ) FD_LOG_ERR(("account is not mutable" ));
+  memcpy( acct->private_state.meta->hash, hash->hash, sizeof(fd_hash_t) );
+}
+
+void
+fd_txn_account_clear_owner_writable( fd_txn_account_t * acct ) {
+  if( FD_UNLIKELY( !acct->private_state.meta ) ) FD_LOG_ERR(("account is not mutable" ));
+  fd_memset( acct->private_state.meta->info.owner, 0, sizeof(fd_pubkey_t) );
+}
+
+void
+fd_txn_account_set_meta_info_writable( fd_txn_account_t *               acct,
+                                       fd_solana_account_meta_t const * info ) {
+  if( FD_UNLIKELY( !acct->private_state.meta ) ) FD_LOG_ERR(("account is not mutable" ));
+  fd_memcpy( &acct->private_state.meta->info, info, sizeof(fd_solana_account_meta_t) );
+}
+
+void
+fd_txn_account_resize_writable( fd_txn_account_t * acct,
+                                ulong              dlen ) {
+  if( FD_UNLIKELY( !acct->private_state.meta ) ) FD_LOG_ERR(("account is not mutable" ));
+  /* Because the memory for an account is preallocated for the transaction
+     up to the max account size, we only need to zero out bytes (for the case
+     where the account grew) and update the account dlen. */
+  ulong old_sz    = acct->private_state.meta->dlen;
+  ulong new_sz    = dlen;
+  ulong memset_sz = fd_ulong_sat_sub( new_sz, old_sz );
+  fd_memset( acct->private_state.data+old_sz, 0, memset_sz );
+
+  acct->private_state.meta->dlen = dlen;
+}
+
+uchar *
+fd_txn_account_get_acc_data_mut_readonly( fd_txn_account_t const * acct FD_PARAM_UNUSED ) {
+  FD_LOG_ERR(( "account is not mutable" ));
+  return NULL;
+}
+
+void
+fd_txn_account_set_meta_mutable_readonly( fd_txn_account_t *  acct FD_PARAM_UNUSED,
+                                          fd_account_meta_t * meta FD_PARAM_UNUSED ) {
+  FD_LOG_ERR(( "cannot set meta as mutable in a readonly account!" ));
+}
+
+void
+fd_txn_account_set_executable_readonly( fd_txn_account_t * acct FD_PARAM_UNUSED,
+                                        int                is_executable FD_PARAM_UNUSED ) {
+  FD_LOG_ERR(( "cannot set executable in a readonly account!" ));
+}
+
+void
+fd_txn_account_set_owner_readonly( fd_txn_account_t * acct FD_PARAM_UNUSED,
+                                   fd_pubkey_t const * owner FD_PARAM_UNUSED ) {
+  FD_LOG_ERR(( "cannot set owner in a readonly account!" ));
+}
+
+void
+fd_txn_account_set_lamports_readonly( fd_txn_account_t * acct FD_PARAM_UNUSED,
+                                      ulong lamports FD_PARAM_UNUSED ) {
+  FD_LOG_ERR(( "cannot set lamports in a readonly account!" ));
+}
+
+int
+fd_txn_account_checked_add_lamports_readonly( fd_txn_account_t * acct FD_PARAM_UNUSED,
+                                              ulong              lamports FD_PARAM_UNUSED ) {
+  FD_LOG_ERR(( "cannot do a checked add to lamports in a readonly account!" ));
+  return FD_EXECUTOR_INSTR_SUCCESS;
+}
+
+int
+fd_txn_account_checked_sub_lamports_readonly( fd_txn_account_t * acct FD_PARAM_UNUSED,
+                                              ulong              lamports FD_PARAM_UNUSED ) {
+  FD_LOG_ERR(( "cannot do a checked sub to lamports in a readonly account!" ));
+  return FD_EXECUTOR_INSTR_SUCCESS;
+}
+
+void
+fd_txn_account_set_rent_epoch_readonly( fd_txn_account_t * acct FD_PARAM_UNUSED,
+                                        ulong              rent_epoch FD_PARAM_UNUSED ) {
+  FD_LOG_ERR(( "cannot set rent epoch in a readonly account!" ));
+}
+
+void
+fd_txn_account_set_data_readonly( fd_txn_account_t * acct FD_PARAM_UNUSED,
+                                  void const *       data FD_PARAM_UNUSED,
+                                  ulong              data_sz FD_PARAM_UNUSED ) {
+  FD_LOG_ERR(( "cannot set data in a readonly account!" ));
+}
+
+void
+fd_txn_account_set_data_len_readonly( fd_txn_account_t * acct FD_PARAM_UNUSED,
+                                      ulong              data_len FD_PARAM_UNUSED ) {
+  FD_LOG_ERR(( "cannot set data_len in a readonly account!" ));
+}
+
+void
+fd_txn_account_set_slot_readonly( fd_txn_account_t * acct FD_PARAM_UNUSED,
+                                  ulong              slot FD_PARAM_UNUSED ) {
+  FD_LOG_ERR(("cannot set slot in a readonly account!"));
+}
+
+void
+fd_txn_account_set_hash_readonly( fd_txn_account_t * acct FD_PARAM_UNUSED,
+                                  fd_hash_t const *  hash FD_PARAM_UNUSED ) {
+  FD_LOG_ERR(("cannot set hash in a readonly account!"));
+}
+
+void
+fd_txn_account_clear_owner_readonly( fd_txn_account_t * acct FD_PARAM_UNUSED ) {
+  FD_LOG_ERR(("cannot clear owner in a readonly account!"));
+}
+
+void
+fd_txn_account_set_meta_info_readonly( fd_txn_account_t *               acct FD_PARAM_UNUSED,
+                                       fd_solana_account_meta_t const * info FD_PARAM_UNUSED ) {
+  FD_LOG_ERR(("cannot set meta info in a readonly account!"));
+}
+
+void
+fd_txn_account_resize_readonly( fd_txn_account_t * acct FD_PARAM_UNUSED,
+                                ulong              dlen FD_PARAM_UNUSED ) {
+  FD_LOG_ERR(( "cannot resize a readonly account!" ));
+}
+
+ushort
+fd_txn_account_is_borrowed( fd_txn_account_t const * acct ) {
+  return !!acct->private_state.refcnt_excl;
+}
+
+int
+fd_txn_account_is_mutable( fd_txn_account_t const * acct ) {
+  /* A txn account is mutable if meta is non NULL */
+  return acct->private_state.meta != NULL;
+}
+
+int
+fd_txn_account_is_readonly( fd_txn_account_t const * acct ) {
+  /* A txn account is readonly if only the const_meta_ field is non NULL */
+  return acct->private_state.const_meta!=NULL && acct->private_state.meta==NULL;
+}
+
+int
+fd_txn_account_try_borrow_mut( fd_txn_account_t * acct ) {
+  return fd_txn_account_acquire_write( acct );
+}
+
+void
+fd_txn_account_drop( fd_txn_account_t * acct ) {
+  fd_txn_account_release_write_private( acct );
+}
+
+void
+fd_txn_account_set_readonly( fd_txn_account_t * acct ) {
+  acct->private_state.meta = NULL;
+  acct->private_state.data = NULL;
+  acct->private_state.rec  = NULL;
+  acct->vt                 = &fd_txn_account_readonly_vtable;
+}
+
+void
+fd_txn_account_set_mutable( fd_txn_account_t * acct ) {
+  acct->private_state.meta = (void *)acct->private_state.const_meta;
+  acct->private_state.data = (void *)acct->private_state.const_data;
+  acct->private_state.rec  = (void *)acct->private_state.const_rec;
+  acct->vt                 = &fd_txn_account_writable_vtable;
+}
+
+/* vtable definitions */
+
+#define FD_TXN_ACCOUNT_VTABLE_DEF( type )                             \
+const fd_txn_account_vtable_t                                         \
+fd_txn_account_##type##_vtable = {                                    \
+  .get_meta             = fd_txn_account_get_acc_meta,                \
+  .get_data             = fd_txn_account_get_acc_data,                \
+  .get_rec              = fd_txn_account_get_acc_rec,                 \
+                                                                      \
+  .get_data_mut         = fd_txn_account_get_acc_data_mut_##type,     \
+                                                                      \
+  .set_meta_readonly    = fd_txn_account_set_meta_readonly,           \
+  .set_meta_mutable     = fd_txn_account_set_meta_mutable_##type,     \
+                                                                      \
+  .get_data_len         = fd_txn_account_get_data_len,                \
+  .is_executable        = fd_txn_account_is_executable,               \
+  .get_owner            = fd_txn_account_get_owner,                   \
+  .get_lamports         = fd_txn_account_get_lamports,                \
+  .get_rent_epoch       = fd_txn_account_get_rent_epoch,              \
+  .get_hash             = fd_txn_account_get_hash,                    \
+  .get_info             = fd_txn_account_get_info,                    \
+                                                                      \
+  .set_executable       = fd_txn_account_set_executable_##type,       \
+  .set_owner            = fd_txn_account_set_owner_##type,            \
+  .set_lamports         = fd_txn_account_set_lamports_##type,         \
+  .checked_add_lamports = fd_txn_account_checked_add_lamports_##type, \
+  .checked_sub_lamports = fd_txn_account_checked_sub_lamports_##type, \
+  .set_rent_epoch       = fd_txn_account_set_rent_epoch_##type,       \
+  .set_data             = fd_txn_account_set_data_##type,             \
+  .set_data_len         = fd_txn_account_set_data_len_##type,         \
+  .set_slot             = fd_txn_account_set_slot_##type,             \
+  .set_hash             = fd_txn_account_set_hash_##type,             \
+  .clear_owner          = fd_txn_account_clear_owner_##type,          \
+  .set_info             = fd_txn_account_set_meta_info_##type,        \
+  .resize               = fd_txn_account_resize_##type,               \
+                                                                      \
+  .is_borrowed          = fd_txn_account_is_borrowed,                 \
+  .is_mutable           = fd_txn_account_is_mutable,                  \
+  .is_readonly          = fd_txn_account_is_readonly,                 \
+                                                                      \
+  .try_borrow_mut       = fd_txn_account_try_borrow_mut,              \
+  .drop                 = fd_txn_account_drop,                        \
+                                                                      \
+  .set_readonly         = fd_txn_account_set_readonly,                \
+  .set_mutable          = fd_txn_account_set_mutable                  \
+}
+
+FD_TXN_ACCOUNT_VTABLE_DEF( readonly );
+FD_TXN_ACCOUNT_VTABLE_DEF( writable );
+
+#undef FD_TXN_ACCOUNT_VTABLE_DEF

--- a/src/flamenco/runtime/fd_txn_account.h
+++ b/src/flamenco/runtime/fd_txn_account.h
@@ -2,49 +2,34 @@
 #define HEADER_fd_src_flamenco_runtime_fd_txn_account_h
 
 #include "../../ballet/txn/fd_txn.h"
-#include "../types/fd_types.h"
-#include "../../funk/fd_funk_rec.h"
 #include "program/fd_program_util.h"
+#include "fd_txn_account_private.h"
+#include "fd_txn_account_vtable.h"
 
 struct fd_acc_mgr;
 typedef struct fd_acc_mgr fd_acc_mgr_t;
 
 struct __attribute__((aligned(8UL))) fd_txn_account {
-  ulong                       magic;
+  ulong                           magic;
 
-  fd_pubkey_t                 pubkey[1];
+  fd_pubkey_t                     pubkey[1];
 
-  fd_account_meta_t const   * const_meta;
-  uchar             const   * const_data;
-  fd_funk_rec_t     const   * const_rec;
+  fd_txn_account_private_state_t  private_state;
 
-  fd_account_meta_t         * meta;
-  uchar                     * data;
-  fd_funk_rec_t             * rec;
-
-  ulong                       meta_gaddr;
-  ulong                       data_gaddr;
-
-  /* consider making this a struct or removing entirely if not needed */
-  ulong                       starting_dlen;
-  ulong                       starting_lamports;
+  ulong                           starting_dlen;
+  ulong                           starting_lamports;
 
   /* only used when obtaining a mutable fd_txn_account_t from funk */
-  fd_funk_rec_prepare_t       prepared_rec;
+  fd_funk_rec_prepare_t           prepared_rec;
 
-  /* Provide read/write mutual exclusion semantics.
-     Used for single-threaded logic only, thus not comparable to a
-     data synchronization lock. */
-
-  ushort                      refcnt_excl;
-  ushort                      refcnt_shared;
+  fd_txn_account_vtable_t const * vt;
 };
 typedef struct fd_txn_account fd_txn_account_t;
 #define FD_TXN_ACCOUNT_FOOTPRINT (sizeof(fd_txn_account_t))
 #define FD_TXN_ACCOUNT_ALIGN     (8UL)
 #define FD_TXN_ACCOUNT_MAGIC     (0xF15EDF1C51F51AA1UL)
 
-#define FD_TXN_ACCOUNT_DECL(_x)  fd_txn_account_t _x[1];
+#define FD_TXN_ACCOUNT_DECL(_x)  fd_txn_account_t _x[1]; fd_txn_account_init( _x );
 
 FD_PROTOTYPES_BEGIN
 
@@ -52,47 +37,35 @@ FD_PROTOTYPES_BEGIN
 fd_txn_account_t *
 fd_txn_account_init( void * ptr );
 
+/* Assigns account meta and data for a readonly txn account */
 void
-fd_txn_account_setup_sentinel_meta( fd_txn_account_t * acct,
-                                    fd_spad_t *        spad,
-                                    fd_wksp_t *        spad_wksp );
+fd_txn_account_init_from_meta_and_data_mutable( fd_txn_account_t *  acct,
+                                                fd_account_meta_t * meta,
+                                                uchar *             data );
 
-/* Accessors */
-
-/* Returns the total size of the account shared data */
-FD_FN_PURE static inline ulong
-fd_txn_account_raw_size( fd_txn_account_t const * acct ) {
-  ulong dlen = ( acct->const_meta != NULL ) ? acct->const_meta->dlen : 0;
-  return sizeof(fd_account_meta_t) + dlen;
-}
-
-static inline int
-fd_txn_account_is_executable( fd_txn_account_t const * acct ) {
-  return !!acct->const_meta->info.executable;
-}
-
-static inline int
-fd_txn_account_is_mutable( fd_txn_account_t const * acct ) {
-  /* A txn account is mutable if meta is non NULL */
-  return acct->meta != NULL;
-}
-
-/* Setters */
-
-static inline void
-fd_txn_account_set_lamports( fd_txn_account_t * acct, ulong lamports ) {
-  acct->meta->info.lamports = lamports;
-}
-
-static inline void
-fd_txn_account_set_executable( fd_txn_account_t * acct, int is_executable ) {
-  acct->meta->info.executable = !!is_executable;
-}
-
-/* Resizes the account data */
+/* Assigns account meta and data for a mutable txn account */
 void
-fd_txn_account_resize( fd_txn_account_t * acct,
-                       ulong              dlen );
+fd_txn_account_init_from_meta_and_data_readonly( fd_txn_account_t *       acct,
+                                                fd_account_meta_t const * meta,
+                                                uchar const *             data );
+
+/* Sets up a readonly sentinel account meta for the txn object.
+   Allocates from the given spad and uses the spad_wksp to set the
+   meta gaddr field.
+
+   Intended for use in the executor tile only, where txn accounts
+   must be setup readonly. */
+void
+fd_txn_account_setup_sentinel_meta_readonly( fd_txn_account_t * acct,
+                                             fd_spad_t *        spad,
+                                             fd_wksp_t *        spad_wksp );
+
+/* Sets up a mutable account meta for the txn_account.
+   Allocates a mutable account meta object from the given spad with the given sz. */
+void
+fd_txn_account_setup_meta_mutable( fd_txn_account_t * acct,
+                                   fd_spad_t *        spad,
+                                   ulong              sz );
 
 /* Operators */
 
@@ -103,68 +76,6 @@ fd_txn_account_t *
 fd_txn_account_make_mutable( fd_txn_account_t * acct,
                              void *             buf,
                              fd_wksp_t *        wksp );
-
-static inline int
-fd_txn_account_checked_add_lamports( fd_txn_account_t * acct, ulong lamports ) {
-  ulong balance_post = 0UL;
-  int err = fd_ulong_checked_add( acct->const_meta->info.lamports, lamports, &balance_post );
-  if( FD_UNLIKELY( err ) ) {
-    return FD_EXECUTOR_INSTR_ERR_ARITHMETIC_OVERFLOW;
-  }
-
-  fd_txn_account_set_lamports( acct, balance_post );
-  return FD_EXECUTOR_INSTR_SUCCESS;
-}
-
-static inline ulong
-fd_txn_account_get_lamports( fd_txn_account_t const * acct ) {
-  /* (!meta) considered an internal error */
-  if( FD_UNLIKELY( !acct->const_meta ) ) return 0UL;
-  return acct->const_meta->info.lamports;
-}
-
-/* read/write mutual exclusion */
-
-FD_FN_PURE static inline int
-fd_txn_account_acquire_write_is_safe( fd_txn_account_t const * acct ) {
-  return (!acct->refcnt_excl) & (!acct->refcnt_shared);
-}
-
-FD_FN_PURE static inline int
-fd_txn_account_acquire_read_is_safe( fd_txn_account_t const * acct ) {
-  return (!acct->refcnt_excl);
-}
-
-/* fd_txn_account_acquire_write acquires write/exclusive access.
-   Causes all other write or read acquire attempts will fail.  Returns 1
-   on success, 0 on failure.
-
-   Mirrors a try_borrow_mut() call in Agave. */
-static inline int
-fd_txn_account_acquire_write( fd_txn_account_t * acct ) {
-  if( FD_UNLIKELY( !fd_txn_account_acquire_write_is_safe( acct ) ) ) {
-    return 0;
-  }
-  acct->refcnt_excl = (ushort)1;
-  return 1;
-}
-
-/* fd_txn_account_release_write{_private} releases a write/exclusive
-   access handle. The private version should only be used by fd_borrowed_account_drop
-   and fd_borrowed_account_destroy. */
-static inline void
-fd_txn_account_release_write( fd_txn_account_t * acct ) {
-  FD_TEST( acct->refcnt_excl==1U );
-  acct->refcnt_excl = (ushort)0;
-}
-
-static inline void
-fd_txn_account_release_write_private( fd_txn_account_t * acct ) {
-  /* Only release if it is not yet released */
-  if( !fd_txn_account_acquire_write_is_safe( acct ) ) {
-    fd_txn_account_release_write( acct );
-  }
-}
 
 /* Factory constructors from funk (Accounts DB) */
 

--- a/src/flamenco/runtime/fd_txn_account_private.h
+++ b/src/flamenco/runtime/fd_txn_account_private.h
@@ -1,0 +1,26 @@
+#ifndef HEADER_fd_src_flamenco_runtime_fd_txn_account_private_h
+#define HEADER_fd_src_flamenco_runtime_fd_txn_account_private_h
+
+#include "../types/fd_types.h"
+#include "../../funk/fd_funk_rec.h"
+
+struct __attribute__((aligned(8UL))) fd_txn_account_private_state {
+  fd_account_meta_t const * const_meta;
+  uchar const *             const_data;
+  fd_funk_rec_t const *     const_rec;
+
+  fd_account_meta_t *       meta;
+  uchar *                   data;
+  fd_funk_rec_t *           rec;
+
+  ulong                     meta_gaddr;
+  ulong                     data_gaddr;
+
+  /* Provide borrowing semantics.
+     Used for single-threaded logic only, thus not comparable to a
+     data synchronization lock. */
+  ushort                    refcnt_excl;
+};
+typedef struct fd_txn_account_private_state fd_txn_account_private_state_t;
+
+#endif /* HEADER_fd_src_flamenco_runtime_fd_txn_account_private_h */

--- a/src/flamenco/runtime/fd_txn_account_vtable.h
+++ b/src/flamenco/runtime/fd_txn_account_vtable.h
@@ -1,0 +1,109 @@
+#ifndef HEADER_fd_src_flamenco_runtime_fd_txn_account_vtable_h
+#define HEADER_fd_src_flamenco_runtime_fd_txn_account_vtable_h
+
+#include "../types/fd_types.h"
+#include "../../funk/fd_funk_rec.h"
+
+struct fd_txn_account;
+typedef struct fd_txn_account fd_txn_account_t;
+
+/* Low-level API function defs */
+
+/* Const getters */
+typedef fd_account_meta_t        const * (* fd_txn_account_get_acc_meta_fn_t)         ( fd_txn_account_t const * acct );
+typedef uchar                    const * (* fd_txn_account_get_acc_data_fn_t)         ( fd_txn_account_t const * acct );
+typedef fd_funk_rec_t            const * (* fd_txn_account_get_acc_rec_fn_t)          ( fd_txn_account_t const * acct );
+typedef uchar *                          (* fd_txn_account_get_acc_data_mut_fn_t)     ( fd_txn_account_t const * acct );
+
+typedef void                             (* fd_txn_account_set_meta_readonly_fn_t)    ( fd_txn_account_t * acct, fd_account_meta_t const * meta );
+typedef void                             (* fd_txn_account_set_meta_mutable_fn_t)     ( fd_txn_account_t * acct, fd_account_meta_t * meta );
+
+typedef ulong                            (* fd_txn_account_get_data_len_fn_t)         ( fd_txn_account_t const * acct );
+typedef int                              (* fd_txn_account_is_executable_fn_t)        ( fd_txn_account_t const * acct );
+typedef fd_pubkey_t              const * (* fd_txn_account_get_owner_fn_t)            ( fd_txn_account_t const * acct );
+typedef ulong                            (* fd_txn_account_get_lamports_fn_t)         ( fd_txn_account_t const * acct );
+typedef ulong                            (* fd_txn_account_get_rent_epoch_fn_t)       ( fd_txn_account_t const * acct );
+typedef fd_hash_t                const * (* fd_txn_account_get_hash_fn_t)             ( fd_txn_account_t const * acct );
+typedef fd_solana_account_meta_t const * (* fd_txn_account_get_info_fn_t)             ( fd_txn_account_t const * acct );
+
+/* Setters */
+typedef void                             (* fd_txn_account_set_executable_fn_t)       ( fd_txn_account_t * acct, int is_executable );
+typedef void                             (* fd_txn_account_set_owner_fn_t)            ( fd_txn_account_t * acct, fd_pubkey_t const * owner );
+typedef void                             (* fd_txn_account_set_lamports_fn_t)         ( fd_txn_account_t * acct, ulong lamports );
+typedef int                              (* fd_txn_account_checked_add_lamports_fn_t) ( fd_txn_account_t * acct, ulong lamports );
+typedef int                              (* fd_txn_account_checked_sub_lamports_fn_t) ( fd_txn_account_t * acct, ulong lamports );
+typedef void                             (* fd_txn_account_set_rent_epoch_fn_t)       ( fd_txn_account_t * acct, ulong rent_epoch );
+typedef void                             (* fd_txn_account_set_data_fn_t)             ( fd_txn_account_t * acct, void const * new_data, ulong data_sz );
+typedef void                             (* fd_txn_account_set_data_len_fn_t)         ( fd_txn_account_t * acct, ulong data_len );
+typedef void                             (* fd_txn_account_set_slot_fn_t)             ( fd_txn_account_t * acct, ulong slot );
+typedef void                             (* fd_txn_account_set_hash_fn_t)             ( fd_txn_account_t * acct, fd_hash_t const * hash );
+typedef void                             (* fd_txn_account_clear_owner_fn_t)          ( fd_txn_account_t * acct );
+typedef void                             (* fd_txn_account_set_meta_info_fn_t)        ( fd_txn_account_t * acct, fd_solana_account_meta_t const * info );
+typedef void                             (* fd_txn_account_resize_fn_t)               ( fd_txn_account_t * acct, ulong data_len );
+
+/* Attribute Accessors */
+typedef ushort                           (* fd_txn_account_is_borrowed_fn_t)          ( fd_txn_account_t const * acct );
+typedef int                              (* fd_txn_acccount_is_mutable_fn_t)          ( fd_txn_account_t const * acct );
+typedef int                              (* fd_txn_account_is_readonly_fn_t)          ( fd_txn_account_t const * acct );
+
+/* Borrow */
+typedef int                              (* fd_txn_account_try_borrow_mut_fn_t)       ( fd_txn_account_t * acct );
+typedef void                             (* fd_txn_account_drop_fn_t)                 ( fd_txn_account_t * acct );
+
+/* Permissions mutators */
+typedef void                             (* fd_txn_account_set_readonly_fn_t)         ( fd_txn_account_t * acct );
+typedef void                             (* fd_txn_account_set_mutable_fn_t)          ( fd_txn_account_t * acct );
+
+struct fd_txn_account_vtable {
+  /* Const getters */
+  fd_txn_account_get_acc_meta_fn_t         get_meta;
+  fd_txn_account_get_acc_data_fn_t         get_data;
+  fd_txn_account_get_acc_rec_fn_t          get_rec;
+
+  fd_txn_account_get_acc_data_mut_fn_t     get_data_mut;
+
+  fd_txn_account_set_meta_readonly_fn_t    set_meta_readonly;
+  fd_txn_account_set_meta_mutable_fn_t     set_meta_mutable;
+
+  fd_txn_account_get_data_len_fn_t         get_data_len;
+  fd_txn_account_is_executable_fn_t        is_executable;
+  fd_txn_account_get_owner_fn_t            get_owner;
+  fd_txn_account_get_lamports_fn_t         get_lamports;
+  fd_txn_account_get_rent_epoch_fn_t       get_rent_epoch;
+  fd_txn_account_get_hash_fn_t             get_hash;
+  fd_txn_account_get_info_fn_t             get_info;
+
+  /* Setters */
+  fd_txn_account_set_executable_fn_t       set_executable;
+  fd_txn_account_set_owner_fn_t            set_owner;
+  fd_txn_account_set_lamports_fn_t         set_lamports;
+  fd_txn_account_checked_add_lamports_fn_t checked_add_lamports;
+  fd_txn_account_checked_sub_lamports_fn_t checked_sub_lamports;
+  fd_txn_account_set_rent_epoch_fn_t       set_rent_epoch;
+  fd_txn_account_set_data_fn_t             set_data;
+  fd_txn_account_set_data_len_fn_t         set_data_len;
+  fd_txn_account_set_slot_fn_t             set_slot;
+  fd_txn_account_set_hash_fn_t             set_hash;
+  fd_txn_account_clear_owner_fn_t          clear_owner;
+  fd_txn_account_set_meta_info_fn_t        set_info;
+  fd_txn_account_resize_fn_t               resize;
+
+  /* Attribute accessors */
+  fd_txn_account_is_borrowed_fn_t          is_borrowed;
+  fd_txn_acccount_is_mutable_fn_t          is_mutable;
+  fd_txn_account_is_readonly_fn_t          is_readonly;
+
+  /* Borrow */
+  fd_txn_account_try_borrow_mut_fn_t        try_borrow_mut;
+  fd_txn_account_drop_fn_t                  drop;
+
+  /* Permissions mutators */
+  fd_txn_account_set_readonly_fn_t          set_readonly;
+  fd_txn_account_set_mutable_fn_t           set_mutable;
+};
+typedef struct fd_txn_account_vtable fd_txn_account_vtable_t;
+
+extern const fd_txn_account_vtable_t fd_txn_account_writable_vtable;
+extern const fd_txn_account_vtable_t fd_txn_account_readonly_vtable;
+
+#endif /* HEADER_fd_src_flamenco_runtime_fd_txn_account_vtable_h */

--- a/src/flamenco/runtime/info/fd_instr_info.c
+++ b/src/flamenco/runtime/info/fd_instr_info.c
@@ -8,11 +8,12 @@ fd_instr_info_accumulate_starting_lamports( fd_instr_info_t *         instr,
                                             ushort                    idx_in_callee,
                                             ushort                    idx_in_txn ) {
   if( FD_LIKELY( !instr->is_duplicate[ idx_in_callee ] ) ) {
-    if( txn_ctx->accounts[ idx_in_txn ].const_meta ) {
+    fd_txn_account_t const * account = &txn_ctx->accounts[ idx_in_txn ];
+    if( account->vt->get_meta( account ) ) {
       fd_uwide_inc(
         &instr->starting_lamports_h, &instr->starting_lamports_l,
         instr->starting_lamports_h, instr->starting_lamports_l,
-        txn_ctx->accounts[ idx_in_txn ].const_meta->info.lamports );
+        account->vt->get_lamports( account ) );
     }
   }
 }
@@ -63,8 +64,9 @@ fd_instr_info_sum_account_lamports( fd_instr_info_t const * instr,
   *total_lamports_l = 0UL;
   for( ulong i=0UL; i<instr->acct_cnt; ++i ) {
     ushort idx_in_txn = instr->accounts[i].index_in_transaction;
+    fd_txn_account_t const * account = &txn_ctx->accounts[ idx_in_txn ];
 
-    if( txn_ctx->accounts[ idx_in_txn ].const_meta == NULL ||
+    if( account->vt->get_meta( account ) == NULL ||
         instr->is_duplicate[i] ) {
       continue;
     }
@@ -74,7 +76,7 @@ fd_instr_info_sum_account_lamports( fd_instr_info_t const * instr,
     ulong tmp_total_lamports_l = 0UL;
 
     fd_uwide_inc( &tmp_total_lamports_h, &tmp_total_lamports_l, *total_lamports_h, *total_lamports_l,
-                  txn_ctx->accounts[ idx_in_txn ].const_meta->info.lamports );
+                  account->vt->get_lamports( account ) );
 
     if( tmp_total_lamports_h < *total_lamports_h ) {
       return FD_EXECUTOR_INSTR_ERR_ARITHMETIC_OVERFLOW;

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -119,8 +119,8 @@ read_bpf_upgradeable_loader_state_for_program( fd_exec_txn_ctx_t *              
   }
 
   fd_bincode_decode_ctx_t ctx = {
-    .data    = rec->const_data,
-    .dataend = rec->const_data + rec->const_meta->dlen,
+    .data    = rec->vt->get_data( rec ),
+    .dataend = rec->vt->get_data( rec ) + rec->vt->get_data_len( rec ),
   };
 
   ulong total_sz = 0UL;
@@ -295,10 +295,10 @@ write_program_data( fd_exec_instr_ctx_t *   instr_ctx,
   }
 
   ulong write_offset = fd_ulong_sat_add( program_data_offset, bytes_len );
-  if( FD_UNLIKELY( program.acct->const_meta->dlen<write_offset ) ) {
+  if( FD_UNLIKELY( fd_borrowed_account_get_data_len( &program )<write_offset ) ) {
     /* Max msg_sz: 24 - 6 + 2*20 = 58 < 127 => we can use printf */
     fd_log_collector_printf_dangerous_max_127( instr_ctx,
-      "Write overflow %lu < %lu", program.acct->const_meta->dlen, write_offset );
+      "Write overflow %lu < %lu", fd_borrowed_account_get_data_len( &program ), write_offset );
     return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
   }
 
@@ -318,8 +318,8 @@ fd_bpf_loader_program_get_state( fd_txn_account_t const * acct,
                                  fd_spad_t *              spad,
                                  int *                    err ) {
     fd_bincode_decode_ctx_t ctx = {
-      .data    = acct->const_data,
-      .dataend = acct->const_data + acct->const_meta->dlen,
+      .data    = acct->vt->get_data( acct ),
+      .dataend = acct->vt->get_data( acct ) + acct->vt->get_data_len( acct ),
     };
 
     ulong total_sz = 0UL;
@@ -405,7 +405,8 @@ common_close_account( fd_pubkey_t * authority_address,
   fd_guarded_borrowed_account_t recipient_account;
   FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( instr_ctx, 1UL, &recipient_account );
 
-  err = fd_borrowed_account_checked_add_lamports( &recipient_account, close_account.acct->const_meta->info.lamports );
+  err = fd_borrowed_account_checked_add_lamports( &recipient_account,
+                                                  fd_borrowed_account_get_lamports( &close_account ) );
   if( FD_UNLIKELY( err ) ) {
     return err;
   }
@@ -845,12 +846,12 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
         fd_log_collector_msg_literal( instr_ctx, "Program account already initialized" );
         return FD_EXECUTOR_INSTR_ERR_ACC_ALREADY_INITIALIZED;
       }
-      if( FD_UNLIKELY( program.acct->const_meta->dlen<SIZE_OF_PROGRAM ) ) {
+      if( FD_UNLIKELY( fd_borrowed_account_get_data_len( &program )<SIZE_OF_PROGRAM ) ) {
         fd_log_collector_msg_literal( instr_ctx, "Program account too small" );
         return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
       }
-      if( FD_UNLIKELY( program.acct->const_meta->info.lamports<fd_rent_exempt_minimum_balance( rent,
-                                                                                           program.acct->const_meta->dlen ) ) ) {
+      if( FD_UNLIKELY( fd_borrowed_account_get_lamports( &program )<fd_rent_exempt_minimum_balance( rent,
+                                                                                                    fd_borrowed_account_get_data_len( &program ) ) ) ) {
         fd_log_collector_msg_literal( instr_ctx, "Program account not rent-exempt" );
         return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_ACCOUNT_NOT_RENT_EXEMPT;
       }
@@ -892,12 +893,12 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
       }
       buffer_key         = buffer.acct->pubkey;
       buffer_data_offset = BUFFER_METADATA_SIZE;
-      buffer_data_len    = fd_ulong_sat_sub( buffer.acct->const_meta->dlen, buffer_data_offset );
+      buffer_data_len    = fd_ulong_sat_sub( fd_borrowed_account_get_data_len( &buffer ), buffer_data_offset );
       /* UpgradeableLoaderState::size_of_program_data( max_data_len ) */
       programdata_len    = fd_ulong_sat_add( PROGRAMDATA_METADATA_SIZE,
                                              instruction->inner.deploy_with_max_data_len.max_data_len );
 
-      if( FD_UNLIKELY( buffer.acct->const_meta->dlen<BUFFER_METADATA_SIZE || buffer_data_len==0UL ) ) {
+      if( FD_UNLIKELY( fd_borrowed_account_get_data_len( &buffer )<BUFFER_METADATA_SIZE || buffer_data_len==0UL ) ) {
         fd_log_collector_msg_literal( instr_ctx, "Buffer account too small" );
         return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
       }
@@ -948,7 +949,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
         fd_guarded_borrowed_account_t buffer;
         FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( instr_ctx, 3UL, &buffer );
 
-        err = fd_borrowed_account_checked_add_lamports( &payer, buffer.acct->const_meta->info.lamports );
+        err = fd_borrowed_account_checked_add_lamports( &payer, fd_borrowed_account_get_lamports( &buffer ) );
         if( FD_UNLIKELY( err ) ) {
           return err;
         }
@@ -999,11 +1000,11 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
       /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/bpf_loader/src/lib.rs#L648-L649 */
       FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( instr_ctx, 3UL, &buffer );
 
-      if( FD_UNLIKELY( buffer_data_offset>buffer.acct->const_meta->dlen ) ) {
+      if( FD_UNLIKELY( buffer_data_offset>fd_borrowed_account_get_data_len( &buffer ) ) ) {
         return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
       }
 
-      const uchar * buffer_data = buffer.acct->const_data + buffer_data_offset;
+      const uchar * buffer_data = fd_borrowed_account_get_data( &buffer ) + buffer_data_offset;
 
       err = fd_deploy_program( instr_ctx, buffer_data, buffer_data_len, instr_ctx->txn_ctx->spad );
       if( FD_UNLIKELY( err ) ) {
@@ -1033,10 +1034,10 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
         }
 
         /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L675-L689 */
-        if( FD_UNLIKELY( PROGRAMDATA_METADATA_SIZE+buffer_data_len>programdata.acct->const_meta->dlen ) ) {
+        if( FD_UNLIKELY( PROGRAMDATA_METADATA_SIZE+buffer_data_len>fd_borrowed_account_get_data_len( &programdata ) ) ) {
           return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
         }
-        if( FD_UNLIKELY( buffer_data_offset>buffer.acct->const_meta->dlen ) ) {
+        if( FD_UNLIKELY( buffer_data_offset>fd_borrowed_account_get_data_len( &buffer ) ) ) {
           return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
         }
 
@@ -1054,10 +1055,10 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
         fd_guarded_borrowed_account_t buffer;
         FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( instr_ctx, 3UL, &buffer );
 
-        if( FD_UNLIKELY( buffer_data_offset>buffer.acct->const_meta->dlen ) ) {
+        if( FD_UNLIKELY( buffer_data_offset>fd_borrowed_account_get_data_len( &buffer ) ) ) {
           return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
         }
-        const uchar * src_slice = buffer.acct->const_data + buffer_data_offset;
+        const uchar * src_slice = fd_borrowed_account_get_data( &buffer ) + buffer_data_offset;
         fd_memcpy( dst_slice, src_slice, dst_slice_len );
         /* Update buffer data length.
           BUFFER_METADATA_SIZE == UpgradeableLoaderState::size_of_buffer(0) */
@@ -1148,7 +1149,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
         fd_log_collector_msg_literal( instr_ctx, "Program account not writeable" );
         return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
       }
-      if( FD_UNLIKELY( memcmp( &program.acct->const_meta->info.owner, program_id, sizeof(fd_pubkey_t) ) ) ) {
+      if( FD_UNLIKELY( memcmp( fd_borrowed_account_get_owner( &program ), program_id, sizeof(fd_pubkey_t) ) ) ) {
         fd_log_collector_msg_literal( instr_ctx, "Program account not owned by loader" );
         return FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID;
       }
@@ -1198,10 +1199,10 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
         fd_log_collector_msg_literal( instr_ctx, "Invalid Buffer account" );
         return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
       }
-      buffer_lamports    = buffer.acct->const_meta->info.lamports;
+      buffer_lamports    = fd_borrowed_account_get_lamports( &buffer );
       buffer_data_offset = BUFFER_METADATA_SIZE;
-      buffer_data_len    = fd_ulong_sat_sub( buffer.acct->const_meta->dlen, buffer_data_offset );
-      if( FD_UNLIKELY( buffer.acct->const_meta->dlen<BUFFER_METADATA_SIZE || buffer_data_len==0UL ) ) {
+      buffer_data_len    = fd_ulong_sat_sub( fd_borrowed_account_get_data_len( &buffer ), buffer_data_offset );
+      if( FD_UNLIKELY( fd_borrowed_account_get_data_len( &buffer )<BUFFER_METADATA_SIZE || buffer_data_len==0UL ) ) {
         fd_log_collector_msg_literal( instr_ctx, "Buffer account too small" );
         return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
       }
@@ -1223,13 +1224,13 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
 
       fd_rent_t const * rent = &instr_ctx->txn_ctx->rent;
 
-      programdata_balance_required = fd_ulong_max( 1UL, fd_rent_exempt_minimum_balance( rent, programdata.acct->const_meta->dlen ) );
+      programdata_balance_required = fd_ulong_max( 1UL, fd_rent_exempt_minimum_balance( rent, fd_borrowed_account_get_data_len( &programdata ) ) );
 
-      if( FD_UNLIKELY( programdata.acct->const_meta->dlen<fd_ulong_sat_add( PROGRAMDATA_METADATA_SIZE, buffer_data_len ) ) ) {
+      if( FD_UNLIKELY( fd_borrowed_account_get_data_len( &programdata )<fd_ulong_sat_add( PROGRAMDATA_METADATA_SIZE, buffer_data_len ) ) ) {
         fd_log_collector_msg_literal( instr_ctx, "ProgramData account not large enough" );
         return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
       }
-      if( FD_UNLIKELY( fd_ulong_sat_add( programdata.acct->const_meta->info.lamports, buffer_lamports )<programdata_balance_required ) ) {
+      if( FD_UNLIKELY( fd_ulong_sat_add( fd_borrowed_account_get_lamports( &programdata ), buffer_lamports )<programdata_balance_required ) ) {
         fd_log_collector_msg_literal( instr_ctx, "Buffer account balance too low to fund upgrade" );
         return FD_EXECUTOR_INSTR_ERR_INSUFFICIENT_FUNDS;
       }
@@ -1276,11 +1277,11 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
       /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/bpf_loader/src/lib.rs#L827-L828 */
       FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( instr_ctx, 2UL, &buffer );
 
-      if( FD_UNLIKELY( buffer_data_offset>buffer.acct->const_meta->dlen ) ) {
+      if( FD_UNLIKELY( buffer_data_offset>fd_borrowed_account_get_data_len( &buffer ) ) ) {
         return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
       }
 
-      const uchar * buffer_data = buffer.acct->const_data + buffer_data_offset;
+      const uchar * buffer_data = fd_borrowed_account_get_data( &buffer ) + buffer_data_offset;
       err = fd_deploy_program( instr_ctx, buffer_data, buffer_data_len, instr_ctx->txn_ctx->spad );
       if( FD_UNLIKELY( err ) ) {
         return err;
@@ -1305,7 +1306,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
 
         /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L846-L875 */
         /* We want to copy over the data and zero out the rest */
-        if( FD_UNLIKELY( programdata_data_offset+buffer_data_len>programdata.acct->const_meta->dlen ) ) {
+        if( FD_UNLIKELY( programdata_data_offset+buffer_data_len>fd_borrowed_account_get_data_len( &programdata ) ) ) {
           return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
         }
 
@@ -1322,13 +1323,13 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
         fd_guarded_borrowed_account_t buffer;
         FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( instr_ctx, 2UL, &buffer );
 
-        if( FD_UNLIKELY( buffer_data_offset>buffer.acct->const_meta->dlen ) ){
+        if( FD_UNLIKELY( buffer_data_offset>fd_borrowed_account_get_data_len( &buffer ) ) ){
           return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
         }
 
-        const uchar * src_slice = buffer.acct->const_data + buffer_data_offset;
+        const uchar * src_slice = fd_borrowed_account_get_data( &buffer ) + buffer_data_offset;
         fd_memcpy( dst_slice, src_slice, dst_slice_len );
-        fd_memset( dst_slice + dst_slice_len, 0, programdata.acct->const_meta->dlen - programdata_data_offset - dst_slice_len );
+        fd_memset( dst_slice + dst_slice_len, 0, fd_borrowed_account_get_data_len( &programdata ) - programdata_data_offset - dst_slice_len );
 
         /* implicit drop of buffer */
       } while (0);
@@ -1343,7 +1344,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
       fd_guarded_borrowed_account_t spill;
       FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( instr_ctx, 3UL, &spill );
 
-      ulong spill_addend = fd_ulong_sat_sub( fd_ulong_sat_add( programdata.acct->const_meta->info.lamports, buffer_lamports ),
+      ulong spill_addend = fd_ulong_sat_sub( fd_ulong_sat_add( fd_borrowed_account_get_lamports( &programdata ), buffer_lamports ),
                                             programdata_balance_required );
       err = fd_borrowed_account_checked_add_lamports( &spill, spill_addend );
       if( FD_UNLIKELY( err ) ) {
@@ -1598,7 +1599,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
         fd_guarded_borrowed_account_t recipient_account;
         FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( instr_ctx, 1UL, &recipient_account );
 
-        err = fd_borrowed_account_checked_add_lamports( &recipient_account, close_account.acct->const_meta->info.lamports );
+        err = fd_borrowed_account_checked_add_lamports( &recipient_account, fd_borrowed_account_get_lamports( &close_account ) );
         if( FD_UNLIKELY( err ) ) {
           return err;
         }
@@ -1646,7 +1647,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
           fd_log_collector_msg_literal( instr_ctx, "Program account is not writable" );
           return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
         }
-        if( FD_UNLIKELY( memcmp( program_account.acct->const_meta->info.owner, program_id, sizeof(fd_pubkey_t) ) ) ) {
+        if( FD_UNLIKELY( memcmp( fd_borrowed_account_get_owner( &program_account ), program_id, sizeof(fd_pubkey_t) ) ) ) {
           fd_log_collector_msg_literal( instr_ctx, "Program account not owned by loader" );
           return FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID;
         }
@@ -1724,7 +1725,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
 
       fd_pubkey_t * programdata_key = programdata_account.acct->pubkey;
 
-      if( FD_UNLIKELY( memcmp( program_id, programdata_account.acct->const_meta->info.owner, sizeof(fd_pubkey_t) ) ) ) {
+      if( FD_UNLIKELY( memcmp( program_id, fd_borrowed_account_get_owner( &programdata_account ), sizeof(fd_pubkey_t) ) ) ) {
         fd_log_collector_msg_literal( instr_ctx, "ProgramData owner is invalid" );
         return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_OWNER;
       }
@@ -1741,7 +1742,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
         fd_log_collector_msg_literal( instr_ctx, "Program account is not writable" );
         return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
       }
-      if( FD_UNLIKELY( memcmp( program_id, program_account.acct->const_meta->info.owner, sizeof(fd_pubkey_t) ) ) ) {
+      if( FD_UNLIKELY( memcmp( program_id, fd_borrowed_account_get_owner( &program_account ), sizeof(fd_pubkey_t) ) ) ) {
         fd_log_collector_msg_literal( instr_ctx, "Program account not owned by loader" );
         return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_OWNER;
       }
@@ -1765,7 +1766,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
       fd_borrowed_account_drop( &program_account );
 
       /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1191-L1230 */
-      ulong old_len = programdata_account.acct->const_meta->dlen;
+      ulong old_len = fd_borrowed_account_get_data_len( &programdata_account );
       ulong new_len = fd_ulong_sat_add( old_len, additional_bytes );
       if( FD_UNLIKELY( new_len>MAX_PERMITTED_DATA_LENGTH ) ) {
         /* Max msg_sz: 85 - 6 + 2*20 = 119 < 127 => we can use printf */
@@ -1806,7 +1807,7 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
 
       /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1232-L1256 */
       fd_rent_t const * rent             = &instr_ctx->txn_ctx->rent;
-      ulong             balance          = programdata_account.acct->const_meta->info.lamports;
+      ulong             balance          = fd_borrowed_account_get_lamports( &programdata_account );
       ulong             min_balance      = fd_ulong_max( fd_rent_exempt_minimum_balance( rent, new_len ), 1UL );
       ulong             required_payment = fd_ulong_sat_sub( min_balance, balance );
 
@@ -1858,12 +1859,12 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
         return err;
       }
 
-      if( FD_UNLIKELY( PROGRAMDATA_METADATA_SIZE>programdata_account.acct->const_meta->dlen ) ) {
+      if( FD_UNLIKELY( PROGRAMDATA_METADATA_SIZE>fd_borrowed_account_get_data_len( &programdata_account ) ) ) {
         return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
       }
 
-      uchar * programdata_data = programdata_account.acct->data + PROGRAMDATA_METADATA_SIZE;
-      ulong   programdata_size = new_len                   - PROGRAMDATA_METADATA_SIZE;
+      uchar const * programdata_data = fd_borrowed_account_get_data( &programdata_account ) + PROGRAMDATA_METADATA_SIZE;
+      ulong         programdata_size = new_len - PROGRAMDATA_METADATA_SIZE;
 
       err = fd_deploy_program( instr_ctx, programdata_data, programdata_size, instr_ctx->txn_ctx->spad );
       if( FD_UNLIKELY( err ) ) {
@@ -1927,7 +1928,7 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
     }
 
     /* Program management instruction */
-    if( FD_UNLIKELY( !memcmp( &fd_solana_native_loader_id, program_account.acct->const_meta->info.owner, sizeof(fd_pubkey_t) ) ) ) {
+    if( FD_UNLIKELY( !memcmp( &fd_solana_native_loader_id, fd_borrowed_account_get_owner( &program_account ), sizeof(fd_pubkey_t) ) ) ) {
       /* https://github.com/anza-xyz/agave/blob/v2.2.3/programs/bpf_loader/src/lib.rs#L416 */
       fd_borrowed_account_drop( &program_account );
 
@@ -1984,7 +1985,7 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
 
       Every error that comes out of this block is mapped to an InvalidAccountData instruction error in Agave. */
 
-    fd_account_meta_t const * metadata = program_account.acct->const_meta;
+    fd_account_meta_t const * metadata = fd_borrowed_account_get_acc_meta( &program_account );
     uchar is_deprecated = !memcmp( metadata->info.owner, &fd_solana_bpf_loader_deprecated_program_id, sizeof(fd_pubkey_t) );
 
     if( !memcmp( metadata->info.owner, &fd_solana_bpf_loader_upgradeable_program_id, sizeof(fd_pubkey_t) ) ) {
@@ -2020,7 +2021,7 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
         return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
       }
 
-      if( FD_UNLIKELY( program_data_account->const_meta->dlen<PROGRAMDATA_METADATA_SIZE ) ) {
+      if( FD_UNLIKELY( program_data_account->vt->get_data_len( program_data_account )<PROGRAMDATA_METADATA_SIZE ) ) {
         fd_log_collector_msg_literal( ctx, "Program is not deployed" );
         if( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, remove_accounts_executable_flag_checks ) ) {
           return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;

--- a/src/flamenco/runtime/program/fd_bpf_loader_serialization.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_serialization.c
@@ -79,8 +79,8 @@ write_account( fd_borrowed_account_t *   account,
                int                       is_aligned,
                int                       copy_account_data ) {
 
-  uchar const * data = account ? account->acct->const_data       : NULL;
-  ulong         dlen = account ? account->acct->const_meta->dlen : 0UL;
+  uchar const * data = account ? fd_borrowed_account_get_data( account )     : NULL;
+  ulong         dlen = account ? fd_borrowed_account_get_data_len( account ) : 0UL;
 
   if( copy_account_data ) {
     /* Copy the account data into input region buffer */
@@ -175,7 +175,7 @@ fd_bpf_loader_input_serialize_aligned( fd_exec_instr_ctx_t *     ctx,
       fd_guarded_borrowed_account_t view_acc;
       fd_exec_instr_ctx_try_borrow_instr_account( ctx, i, &view_acc );
 
-      ulong acc_data_len = view_acc.acct->const_meta->dlen;
+      ulong acc_data_len = fd_borrowed_account_get_data_len( &view_acc );
 
       serialized_size += sizeof(uchar)               // is_signer
                        + sizeof(uchar)               // is_writable
@@ -238,7 +238,7 @@ fd_bpf_loader_input_serialize_aligned( fd_exec_instr_ctx_t *     ctx,
       fd_exec_instr_ctx_try_borrow_instr_account( ctx, i, &view_acc );
 
       /* https://github.com/anza-xyz/agave/blob/b5f5c3cdd3f9a5859c49ebc27221dc27e143d760/programs/bpf_loader/src/serialization.rs#L465 */
-      fd_account_meta_t const * metadata = view_acc.acct->const_meta;
+      fd_account_meta_t const * metadata = fd_borrowed_account_get_acc_meta( &view_acc );
 
       uchar is_signer = (uchar)fd_instr_acc_is_signer_idx( ctx->instr, (uchar)i );
       FD_STORE( uchar, serialized_params, is_signer );
@@ -353,7 +353,7 @@ fd_bpf_loader_input_deserialize_aligned( fd_exec_instr_ctx_t * ctx,
       start += sizeof(fd_pubkey_t); // owner
 
       ulong lamports = FD_LOAD( ulong, buffer+start );
-      if( lamports!=view_acc.acct->const_meta->info.lamports ) {
+      if( lamports!=fd_borrowed_account_get_lamports( &view_acc ) ) {
         int err = fd_borrowed_account_set_lamports( &view_acc, lamports );
         if( FD_UNLIKELY( err ) ) {
           return err;
@@ -369,7 +369,7 @@ fd_bpf_loader_input_deserialize_aligned( fd_exec_instr_ctx_t * ctx,
 
       uchar * post_data = buffer+start;
 
-      fd_account_meta_t const * metadata_check = view_acc.acct->const_meta;
+      fd_account_meta_t const * metadata_check = fd_borrowed_account_get_acc_meta( &view_acc );
       if( FD_UNLIKELY( fd_ulong_sat_sub( post_len, metadata_check->dlen )>MAX_PERMITTED_DATA_INCREASE ||
                        post_len>MAX_PERMITTED_DATA_LENGTH ) ) {
         return FD_EXECUTOR_INSTR_ERR_INVALID_REALLOC;
@@ -386,8 +386,8 @@ fd_bpf_loader_input_deserialize_aligned( fd_exec_instr_ctx_t * ctx,
             return err;
           }
 
-        } else if( FD_UNLIKELY( view_acc.acct->const_meta->dlen!=post_len ||
-                                memcmp( view_acc.acct->const_data, post_data, post_len ) ) ) {
+        } else if( FD_UNLIKELY( fd_borrowed_account_get_data_len( &view_acc )!=post_len ||
+                                memcmp( fd_borrowed_account_get_data( &view_acc ), post_data, post_len ) ) ) {
           return err;
         }
         start += pre_len;
@@ -419,7 +419,7 @@ fd_bpf_loader_input_deserialize_aligned( fd_exec_instr_ctx_t * ctx,
                which has now been extended. */
               memcpy( acc_data+pre_len, buffer+start, allocated_bytes );
           }
-        } else if( FD_UNLIKELY( view_acc.acct->const_meta->dlen!=post_len ) ) {
+        } else if( FD_UNLIKELY( fd_borrowed_account_get_data_len( &view_acc )!=post_len ) ) {
           return err;
         }
       }
@@ -428,7 +428,7 @@ fd_bpf_loader_input_deserialize_aligned( fd_exec_instr_ctx_t * ctx,
       start += MAX_PERMITTED_DATA_INCREASE;
       start += alignment_offset;
       start += sizeof(ulong); // rent epoch
-      if( memcmp( view_acc.acct->const_meta->info.owner, owner, sizeof(fd_pubkey_t) ) ) {
+      if( memcmp( fd_borrowed_account_get_owner( &view_acc ), owner, sizeof(fd_pubkey_t) ) ) {
         int err = fd_borrowed_account_set_owner( &view_acc, owner );
         if( FD_UNLIKELY( err ) ) {
           return err;
@@ -471,7 +471,7 @@ fd_bpf_loader_input_serialize_unaligned( fd_exec_instr_ctx_t *     ctx,
     fd_guarded_borrowed_account_t view_acc;
     fd_exec_instr_ctx_try_borrow_instr_account( ctx, i, &view_acc );
 
-    ulong acc_data_len = view_acc.acct->const_meta->dlen;
+    ulong acc_data_len = fd_borrowed_account_get_data_len( &view_acc );
 
     pre_lens[i] = acc_data_len;
 
@@ -527,7 +527,7 @@ fd_bpf_loader_input_serialize_unaligned( fd_exec_instr_ctx_t *     ctx,
       fd_guarded_borrowed_account_t view_acc;
       fd_exec_instr_ctx_try_borrow_instr_account( ctx, i, &view_acc );
 
-      fd_account_meta_t const * metadata = view_acc.acct->const_meta;
+      fd_account_meta_t const * metadata = fd_borrowed_account_get_acc_meta( &view_acc );
 
       uchar is_signer = (uchar)fd_instr_acc_is_signer_idx( ctx->instr, (uchar)i );
       FD_STORE( uchar, serialized_params, is_signer );
@@ -614,7 +614,7 @@ fd_bpf_loader_input_deserialize_unaligned( fd_exec_instr_ctx_t * ctx,
       FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( ctx, i, &view_acc );
 
       ulong lamports = FD_LOAD( ulong, input_cursor );
-      if( view_acc.acct->const_meta && view_acc.acct->const_meta->info.lamports!=lamports ) {
+      if( fd_borrowed_account_get_acc_meta( &view_acc ) && fd_borrowed_account_get_lamports( &view_acc )!=lamports ) {
         int err = fd_borrowed_account_set_lamports( &view_acc, lamports );
         if( FD_UNLIKELY( err ) ) {
           return err;
@@ -627,7 +627,7 @@ fd_bpf_loader_input_deserialize_unaligned( fd_exec_instr_ctx_t * ctx,
       if( copy_account_data ) {
         ulong   pre_len   = pre_lens[i];
         uchar * post_data = input_cursor;
-        if( view_acc.acct->const_meta ) {
+        if( fd_borrowed_account_get_acc_meta( &view_acc ) ) {
           int err = 0;
           if( fd_borrowed_account_can_data_be_resized( &view_acc, pre_len, &err ) &&
               fd_borrowed_account_can_data_be_changed( &view_acc, &err ) ) {
@@ -635,8 +635,8 @@ fd_bpf_loader_input_deserialize_unaligned( fd_exec_instr_ctx_t * ctx,
             if( FD_UNLIKELY( err ) ) {
               return err;
             }
-          } else if( view_acc.acct->const_meta->dlen != pre_len ||
-                     memcmp( post_data, view_acc.acct->const_data, pre_len ) ) {
+          } else if( fd_borrowed_account_get_data_len( &view_acc ) != pre_len ||
+                     memcmp( post_data, fd_borrowed_account_get_data( &view_acc ), pre_len ) ) {
             return err;
           }
         }

--- a/src/flamenco/runtime/program/fd_builtin_programs.c
+++ b/src/flamenco/runtime/program/fd_builtin_programs.c
@@ -142,12 +142,11 @@ fd_write_builtin_account( fd_exec_slot_ctx_t * slot_ctx,
   int err = fd_txn_account_init_from_funk_mutable( rec, &pubkey, funk, txn, 1, sz );
   FD_TEST( !err );
 
-  rec->meta->dlen            = sz;
-  rec->meta->info.lamports   = 1UL;
-  rec->meta->info.rent_epoch = 0UL;
-  rec->meta->info.executable = 1;
-  fd_memcpy( rec->meta->info.owner, fd_solana_native_loader_id.key, 32 );
-  memcpy( rec->data, data, sz );
+  rec->vt->set_data( rec, data, sz );
+  rec->vt->set_lamports( rec, 1UL );
+  rec->vt->set_rent_epoch( rec, 0UL );
+  rec->vt->set_executable( rec, 1 );
+  rec->vt->set_owner( rec, &fd_solana_native_loader_id );
 
   fd_txn_account_mutable_fini( rec, funk, txn );
 
@@ -180,12 +179,11 @@ write_inline_spl_native_mint_program_account( fd_exec_slot_ctx_t * slot_ctx ) {
   int err = fd_txn_account_init_from_funk_mutable( rec, key, funk, txn, 1, sizeof(data) );
   FD_TEST( !err );
 
-  rec->meta->dlen            = sizeof(data);
-  rec->meta->info.lamports   = 1000000000UL;
-  rec->meta->info.rent_epoch = 1UL;
-  rec->meta->info.executable = 0;
-  fd_memcpy( rec->meta->info.owner, fd_solana_spl_token_id.key, 32 );
-  memcpy( rec->data, data, sizeof(data) );
+  rec->vt->set_lamports( rec, 1000000000UL );
+  rec->vt->set_rent_epoch( rec, 1UL );
+  rec->vt->set_executable( rec, 0 );
+  rec->vt->set_owner( rec, &fd_solana_spl_token_id );
+  rec->vt->set_data( rec, data, sizeof(data) );
 
   fd_txn_account_mutable_fini( rec, funk, txn );
 

--- a/src/flamenco/runtime/program/fd_config_program.c
+++ b/src/flamenco/runtime/program/fd_config_program.c
@@ -68,15 +68,15 @@ _process_config_instr( fd_exec_instr_ctx_t * ctx ) {
 
   /* https://github.com/solana-labs/solana/blob/v1.17.17/programs/config/src/config_processor.rs#L29-L31 */
 
-  if( FD_UNLIKELY( 0!=memcmp( &config_acc_rec.acct->const_meta->info.owner, fd_solana_config_program_id.key, sizeof(fd_pubkey_t) ) ) ) {
+  if( FD_UNLIKELY( 0!=memcmp( fd_borrowed_account_get_owner( &config_acc_rec ), fd_solana_config_program_id.key, sizeof(fd_pubkey_t) ) ) ) {
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_OWNER;
   }
 
   /* https://github.com/solana-labs/solana/blob/v1.17.17/programs/config/src/config_processor.rs#L33-L40 */
 
   fd_bincode_decode_ctx_t config_acc_state_decode_context = {
-    .data    = config_acc_rec.acct->const_data,
-    .dataend = config_acc_rec.acct->const_data + config_acc_rec.acct->const_meta->dlen,
+    .data    = fd_borrowed_account_get_data( &config_acc_rec ),
+    .dataend = (uchar *)fd_borrowed_account_get_data( &config_acc_rec ) + fd_borrowed_account_get_data_len( &config_acc_rec ),
   };
   total_sz      = 0UL;
   decode_result = fd_config_keys_decode_footprint( &config_acc_state_decode_context, &total_sz );
@@ -228,7 +228,7 @@ _process_config_instr( fd_exec_instr_ctx_t * ctx ) {
   /* Upgrade to writable handle
     https://github.com/solana-labs/solana/blob/v1.17.17/programs/config/src/config_processor.rs#L130-L133 */
 
-  if( FD_UNLIKELY( config_acc_rec.acct->const_meta->dlen<ctx->instr->data_sz ) ) {
+  if( FD_UNLIKELY( fd_borrowed_account_get_data_len( &config_acc_rec )<ctx->instr->data_sz ) ) {
     fd_log_collector_msg_literal( ctx, "instruction data too large" );
     return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
   }

--- a/src/flamenco/runtime/program/fd_loader_v4_program.c
+++ b/src/flamenco/runtime/program/fd_loader_v4_program.c
@@ -50,11 +50,11 @@ int
 fd_loader_v4_get_state( fd_txn_account_t const * program,
                         fd_loader_v4_state_t *   state ) {
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L32 */
-  if( FD_UNLIKELY( program->const_meta->dlen<LOADER_V4_PROGRAM_DATA_OFFSET ) ) {
+  if( FD_UNLIKELY( program->vt->get_data_len( program )<LOADER_V4_PROGRAM_DATA_OFFSET ) ) {
     return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
   }
 
-  fd_loader_v4_state_t const * in_state = fd_type_pun_const( program->const_data );
+  fd_loader_v4_state_t const * in_state = fd_type_pun_const( program->vt->get_data( program ) );
   *state = *in_state;
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
@@ -69,7 +69,7 @@ check_program_account( fd_exec_instr_ctx_t *         instr_ctx,
                        fd_loader_v4_state_t *        state ) {
   int err;
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L62-L65 */
-  if( FD_UNLIKELY( memcmp( program->acct->const_meta->info.owner, fd_solana_bpf_loader_v4_program_id.key, sizeof(fd_pubkey_t) ) ) ) {
+  if( FD_UNLIKELY( memcmp( fd_borrowed_account_get_owner( program ), fd_solana_bpf_loader_v4_program_id.key, sizeof(fd_pubkey_t) ) ) ) {
     fd_log_collector_msg_literal( instr_ctx, "Program not owned by loader" );
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_OWNER;
   }
@@ -206,12 +206,12 @@ fd_loader_v4_program_instruction_truncate( fd_exec_instr_ctx_t *                
   }
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L134C9-L135 */
-  uchar is_initialization = !!( new_size>0UL && program.acct->const_meta->dlen<LOADER_V4_PROGRAM_DATA_OFFSET );
+  uchar is_initialization = !!( new_size>0UL && fd_borrowed_account_get_data_len( &program )<LOADER_V4_PROGRAM_DATA_OFFSET );
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L136-L164 */
   if( is_initialization ) {
     /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L137-L140 */
-    if( FD_UNLIKELY( memcmp( program.acct->const_meta->info.owner, fd_solana_bpf_loader_v4_program_id.key, sizeof(fd_pubkey_t) ) ) ) {
+    if( FD_UNLIKELY( memcmp( fd_borrowed_account_get_owner( &program ), fd_solana_bpf_loader_v4_program_id.key, sizeof(fd_pubkey_t) ) ) ) {
       fd_log_collector_msg_literal( instr_ctx, "Program not owned by loader" );
       return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_OWNER;
     }
@@ -262,12 +262,12 @@ fd_loader_v4_program_instruction_truncate( fd_exec_instr_ctx_t *                
                                             1UL );
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L172-L193 */
-  if( FD_UNLIKELY( program.acct->const_meta->info.lamports<required_lamports ) ) {
+  if( FD_UNLIKELY( fd_borrowed_account_get_lamports( &program )<required_lamports ) ) {
     /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L174-L179 */
     fd_log_collector_printf_dangerous_max_127( instr_ctx,
       "Insufficient lamports, %lu are required", required_lamports );
     return FD_EXECUTOR_INSTR_ERR_INSUFFICIENT_FUNDS;
-  } else if( program.acct->const_meta->info.lamports>required_lamports ) {
+  } else if( fd_borrowed_account_get_lamports( &program )>required_lamports ) {
     /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L182-L183 */
     fd_guarded_borrowed_account_t recipient;
     FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( instr_ctx, 2UL, &recipient );
@@ -279,7 +279,7 @@ fd_loader_v4_program_instruction_truncate( fd_exec_instr_ctx_t *                
     }
 
     /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L190 */
-    ulong lamports_to_receive = fd_ulong_sat_sub( program.acct->const_meta->info.lamports,
+    ulong lamports_to_receive = fd_ulong_sat_sub( fd_borrowed_account_get_lamports( &program ),
                                                   required_lamports );
     err = fd_borrowed_account_checked_sub_lamports( &program, lamports_to_receive );
     if( FD_UNLIKELY( err ) ) {
@@ -310,7 +310,7 @@ fd_loader_v4_program_instruction_truncate( fd_exec_instr_ctx_t *                
     /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L200-L205 */
     if( is_initialization ) {
       /* https://github.com/anza-xyz/agave/blob/09ef71223b24e30e59eaeaf5eb95e85f222c7de1/programs/loader-v4/src/lib.rs#L197 */
-      program.acct->meta->info.executable = true;
+      fd_borrowed_account_set_executable( &program, 1 );
 
       /* Serialize into the program account directly. Note that an error is impossible
           because `new_program_dlen` > `LOADER_V4_PROGRAM_DATA_OFFSET`.
@@ -425,17 +425,17 @@ fd_loader_v4_program_instruction_deploy( fd_exec_instr_ctx_t * instr_ctx ) {
   }
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L261-L264 */
-  if( FD_UNLIKELY( buffer->acct->const_meta->dlen<LOADER_V4_PROGRAM_DATA_OFFSET ) ) {
+  if( FD_UNLIKELY( fd_borrowed_account_get_data_len( buffer )<LOADER_V4_PROGRAM_DATA_OFFSET ) ) {
     return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
   }
-  uchar const * programdata = buffer->acct->const_data + LOADER_V4_PROGRAM_DATA_OFFSET;
+  uchar const * programdata = fd_borrowed_account_get_data( buffer ) + LOADER_V4_PROGRAM_DATA_OFFSET;
 
   /* Our program cache is fundamentally different from Agave's. Here, they would perform verifications and
       add the program to their cache, but we only perform verifications now and defer cache population to the
       end of the slot. Since programs cannot be invoked until the next slot anyways, doing this is okay.
 
       https://github.com/anza-xyz/agave/blob/09ef71223b24e30e59eaeaf5eb95e85f222c7de1/programs/loader-v4/src/lib.rs#L262-L269 */
-  err = fd_deploy_program( instr_ctx, programdata, buffer->acct->const_meta->dlen - LOADER_V4_PROGRAM_DATA_OFFSET, instr_ctx->txn_ctx->spad );
+  err = fd_deploy_program( instr_ctx, programdata, fd_borrowed_account_get_data_len( buffer ) - LOADER_V4_PROGRAM_DATA_OFFSET, instr_ctx->txn_ctx->spad );
   if( FD_UNLIKELY( err ) ) {
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
   }
@@ -452,13 +452,15 @@ fd_loader_v4_program_instruction_deploy( fd_exec_instr_ctx_t * instr_ctx ) {
       }
 
       /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L297 */
-      ulong required_lamports = fd_rent_exempt_minimum_balance( rent, buffer->acct->const_meta->dlen );
+      ulong required_lamports = fd_rent_exempt_minimum_balance( rent, fd_borrowed_account_get_data_len( buffer ) );
 
       /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L298 */
-      ulong transfer_lamports = fd_ulong_sat_sub( required_lamports, program.acct->const_meta->info.lamports );
+      ulong transfer_lamports = fd_ulong_sat_sub( required_lamports, fd_borrowed_account_get_lamports( &program ) );
 
       /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L299 */
-      err = fd_borrowed_account_set_data_from_slice( &program, buffer->acct->const_data, buffer->acct->const_meta->dlen );
+      err = fd_borrowed_account_set_data_from_slice( &program,
+                                                     fd_borrowed_account_get_data( buffer ),
+                                                     fd_borrowed_account_get_data_len( buffer ) );
       if( FD_UNLIKELY( err ) ) {
         return err;
       }
@@ -672,7 +674,7 @@ fd_loader_v4_program_instruction_finalize( fd_exec_instr_ctx_t * instr_ctx ) {
   FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK(instr_ctx, 2UL, &next_version );
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L426-L429 */
-  if( FD_UNLIKELY( memcmp( next_version.acct->const_meta->info.owner, fd_solana_bpf_loader_v4_program_id.key, sizeof(fd_pubkey_t) ) ) ) {
+  if( FD_UNLIKELY( memcmp( fd_borrowed_account_get_owner( &next_version ), fd_solana_bpf_loader_v4_program_id.key, sizeof(fd_pubkey_t) ) ) ) {
     fd_log_collector_msg_literal( instr_ctx, "Next version is not owned by loader" );
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_OWNER;
   }

--- a/src/flamenco/runtime/program/fd_stake_program.c
+++ b/src/flamenco/runtime/program/fd_stake_program.c
@@ -132,8 +132,8 @@ get_state( fd_txn_account_t const * self,
   int rc;
 
   fd_bincode_decode_ctx_t bincode_ctx = {
-    .data    = self->const_data,
-    .dataend = self->const_data + self->const_meta->dlen,
+    .data    = self->vt->get_data( self ),
+    .dataend = self->vt->get_data( self ) + self->vt->get_data_len( self ),
   };
 
   ulong total_sz = 0UL;
@@ -162,8 +162,8 @@ set_state( fd_borrowed_account_t *     borrowed_acct,
     return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
 
   fd_bincode_encode_ctx_t encode = {
-    .data    = borrowed_acct->acct->data,
-    .dataend = borrowed_acct->acct->data + serialized_size,
+    .data    = data,
+    .dataend = data + serialized_size,
   };
   do {
     int err = fd_stake_state_v2_encode( state, &encode );
@@ -214,7 +214,7 @@ validate_delegated_amount( fd_borrowed_account_t *      account,
                            fd_exec_txn_ctx_t const *    txn_ctx,
                            validated_delegated_info_t * out,
                            uint *                       custom_err ) {
-  ulong stake_amount = fd_ulong_sat_sub( account->acct->const_meta->info.lamports, meta->rent_exempt_reserve );
+  ulong stake_amount = fd_ulong_sat_sub( fd_borrowed_account_get_lamports( account ), meta->rent_exempt_reserve );
 
   if( FD_UNLIKELY( stake_amount<get_minimum_delegation( txn_ctx ) ) ) {
     *custom_err = FD_STAKE_ERR_INSUFFICIENT_DELEGATION;
@@ -246,7 +246,7 @@ validate_split_amount( fd_exec_instr_ctx_t const * invoke_context,
   FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( invoke_context, source_account_index, &source_account );
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L1005
-  source_lamports = source_account.acct->const_meta->info.lamports;
+  source_lamports = fd_borrowed_account_get_lamports( &source_account );
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.14/programs/stake/src/stake_state.rs#L1006 */
   fd_borrowed_account_drop( &source_account );
@@ -259,8 +259,8 @@ validate_split_amount( fd_exec_instr_ctx_t const * invoke_context,
   FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( invoke_context, destination_account_index, &destination_account );
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L1009-1010
-  destination_lamports = destination_account.acct->const_meta->info.lamports;
-  destination_data_len = destination_account.acct->const_meta->dlen;
+  destination_lamports = fd_borrowed_account_get_lamports( &destination_account );
+  destination_data_len = fd_borrowed_account_get_data_len( &destination_account );
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.14/programs/stake/src/stake_state.rs#L1011 */
   fd_borrowed_account_drop( &destination_account );
@@ -1238,7 +1238,7 @@ initialize( fd_borrowed_account_t *       stake_account,
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L220
 
-  if( FD_UNLIKELY( stake_account->acct->const_meta->dlen!=stake_state_v2_size_of() ) )
+  if( FD_UNLIKELY( fd_borrowed_account_get_data_len( stake_account )!=stake_state_v2_size_of() ) )
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L224
@@ -1250,10 +1250,10 @@ initialize( fd_borrowed_account_t *       stake_account,
 
   if( FD_LIKELY( stake_state.discriminant==fd_stake_state_v2_enum_uninitialized ) ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L225
-    ulong rent_exempt_reserve = fd_rent_exempt_minimum_balance( rent, stake_account->acct->const_meta->dlen );
+    ulong rent_exempt_reserve = fd_rent_exempt_minimum_balance( rent, fd_borrowed_account_get_data_len( stake_account ) );
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L226
-    if( FD_LIKELY( stake_account->acct->const_meta->info.lamports>=rent_exempt_reserve ) ) {
+    if( FD_LIKELY( fd_borrowed_account_get_lamports( stake_account )>=rent_exempt_reserve ) ) {
       fd_stake_state_v2_t initialized = {
         .discriminant = fd_stake_state_v2_enum_initialized,
         .inner = { .initialized = { .meta = { .rent_exempt_reserve = rent_exempt_reserve,
@@ -1391,7 +1391,7 @@ delegate( fd_exec_instr_ctx_t const *   ctx,
   FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( ctx, vote_account_index, &vote_account );
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L323
-  if( FD_UNLIKELY( memcmp( &vote_account.acct->const_meta->info.owner, fd_solana_vote_program_id.key, 32UL ) ) )
+  if( FD_UNLIKELY( memcmp( fd_borrowed_account_get_owner( &vote_account ), fd_solana_vote_program_id.key, 32UL ) ) )
     return FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID;
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L3326
   vote_pubkey = vote_account.acct->pubkey;
@@ -1568,11 +1568,11 @@ split( fd_exec_instr_ctx_t const * ctx,
   FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( ctx, split_index, &split );
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L409
-  if( FD_UNLIKELY( memcmp( &split.acct->const_meta->info.owner, fd_solana_stake_program_id.key, 32UL ) ) )
+  if( FD_UNLIKELY( memcmp( fd_borrowed_account_get_owner( &split ), fd_solana_stake_program_id.key, 32UL ) ) )
     return FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID;
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L412
-  if( FD_UNLIKELY( split.acct->const_meta->dlen!=stake_state_v2_size_of() ) )
+  if( FD_UNLIKELY( fd_borrowed_account_get_data_len( &split )!=stake_state_v2_size_of() ) )
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L415
@@ -1583,7 +1583,7 @@ split( fd_exec_instr_ctx_t const * ctx,
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
   }
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L418
-  split_lamport_balance = split.acct->const_meta->info.lamports;
+  split_lamport_balance = fd_borrowed_account_get_lamports( &split );
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.14/programs/stake/src/stake_state.rs#L419 */
   fd_borrowed_account_drop( &split );
@@ -1594,7 +1594,7 @@ split( fd_exec_instr_ctx_t const * ctx,
   FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( ctx, stake_account_index, &stake_account );
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L422
-  if( FD_UNLIKELY( lamports>stake_account.acct->const_meta->info.lamports ) )
+  if( FD_UNLIKELY( lamports>fd_borrowed_account_get_lamports( &stake_account ) ) )
     return FD_EXECUTOR_INSTR_ERR_INSUFFICIENT_FUNDS;
 
   rc = get_state( stake_account.acct, &stake_state );
@@ -1767,7 +1767,7 @@ split( fd_exec_instr_ctx_t const * ctx,
   FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( ctx, stake_account_index, &stake_account );
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L537
-  if( FD_UNLIKELY( lamports==stake_account.acct->const_meta->info.lamports ) ) {
+  if( FD_UNLIKELY( lamports==fd_borrowed_account_get_lamports( &stake_account ) ) ) {
     fd_stake_state_v2_t uninitialized = {0};
     uninitialized.discriminant        = fd_stake_state_v2_enum_uninitialized;
     rc                                = set_state( &stake_account, &uninitialized );
@@ -1812,7 +1812,7 @@ merge( fd_exec_instr_ctx_t *         ctx, // not const to log
   FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( ctx, source_account_index, &source_account );
 
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L565
-  if( FD_UNLIKELY( memcmp( &source_account.acct->const_meta->info.owner, fd_solana_stake_program_id.key, 32UL ) ) )
+  if( FD_UNLIKELY( memcmp( fd_borrowed_account_get_owner( &source_account ), fd_solana_stake_program_id.key, 32UL ) ) )
     return FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID;
 
   ushort stake_acc_idx_in_txn;
@@ -1842,7 +1842,7 @@ merge( fd_exec_instr_ctx_t *         ctx, // not const to log
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L579
   rc = get_if_mergeable( ctx,
                          &stake_account_state,
-                         stake_account.acct->const_meta->info.lamports,
+                         fd_borrowed_account_get_lamports( &stake_account ),
                          clock,
                          stake_history,
                          &stake_merge_kind,
@@ -1864,7 +1864,7 @@ merge( fd_exec_instr_ctx_t *         ctx, // not const to log
   //https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L594
   rc = get_if_mergeable( ctx,
                          &source_account_state,
-                         source_account.acct->const_meta->info.lamports,
+                         fd_borrowed_account_get_lamports( &source_account ),
                          clock,
                          stake_history,
                          &source_merge_kind,
@@ -1896,7 +1896,7 @@ merge( fd_exec_instr_ctx_t *         ctx, // not const to log
   if( FD_UNLIKELY( rc ) ) return rc;
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L611-L613
-  ulong lamports = source_account.acct->const_meta->info.lamports;
+  ulong lamports = fd_borrowed_account_get_lamports( &source_account );
   rc = fd_borrowed_account_checked_sub_lamports( &source_account, lamports );
   if( FD_UNLIKELY( rc ) ) return rc;
   rc = fd_borrowed_account_checked_add_lamports( &stake_account, lamports );
@@ -1930,8 +1930,8 @@ move_stake_or_lamports_shared_checks( fd_exec_instr_ctx_t *   invoke_context, //
     fd_pubkey_t const * signers[FD_TXN_SIG_MAX] = { stake_authority_pubkey };
 
     // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_state.rs#L158
-    if( FD_UNLIKELY( memcmp( &source_account->acct->const_meta->info.owner, fd_solana_stake_program_id.key, sizeof(fd_pubkey_t) ) ||
-                     memcmp( &destination_account->acct->const_meta->info.owner, fd_solana_stake_program_id.key, sizeof(fd_pubkey_t) ) ) )
+    if( FD_UNLIKELY( memcmp( fd_borrowed_account_get_owner( source_account ), fd_solana_stake_program_id.key, sizeof(fd_pubkey_t) ) ||
+                     memcmp( fd_borrowed_account_get_owner( destination_account ), fd_solana_stake_program_id.key, sizeof(fd_pubkey_t) ) ) )
       return FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID;
 
     // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_state.rs#L163
@@ -1963,7 +1963,7 @@ move_stake_or_lamports_shared_checks( fd_exec_instr_ctx_t *   invoke_context, //
 
     rc = get_if_mergeable( invoke_context,
                          &source_account_state,
-                         source_account->acct->const_meta->info.lamports,
+                         fd_borrowed_account_get_lamports( source_account ),
                          clock,
                          stake_history,
                          source_merge_kind,
@@ -1981,7 +1981,7 @@ move_stake_or_lamports_shared_checks( fd_exec_instr_ctx_t *   invoke_context, //
 
     rc = get_if_mergeable( invoke_context,
                          &destination_account_state,
-                         destination_account->acct->const_meta->info.lamports,
+                         fd_borrowed_account_get_lamports( destination_account ),
                          clock,
                          stake_history,
                          destination_merge_kind,
@@ -2027,8 +2027,8 @@ move_stake(fd_exec_instr_ctx_t * ctx, // not const to log
   if( FD_UNLIKELY( rc ) ) return rc;
 
   // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_state.rs#L816
-  if( FD_UNLIKELY( source_account.acct->const_meta->dlen!=stake_state_v2_size_of() ||
-                   destination_account.acct->const_meta->dlen!=stake_state_v2_size_of() ) )
+  if( FD_UNLIKELY( fd_borrowed_account_get_data_len( &source_account )!=stake_state_v2_size_of() ||
+  fd_borrowed_account_get_data_len( &destination_account )!=stake_state_v2_size_of() ) )
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
 
   // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_state.rs#L823
@@ -2187,7 +2187,7 @@ move_lamports(fd_exec_instr_ctx_t * ctx, // not const to log
   ulong source_free_lamports;
   switch( source_merge_kind.discriminant ) {
     case merge_kind_fully_active: {
-      source_free_lamports = fd_ulong_sat_sub( fd_ulong_sat_sub( source_account.acct->const_meta->info.lamports,
+      source_free_lamports = fd_ulong_sat_sub( fd_ulong_sat_sub( fd_borrowed_account_get_lamports( &source_account ),
                                                                  source_merge_kind.inner.fully_active.stake.delegation.stake ),
                                                 source_merge_kind.inner.fully_active.meta.rent_exempt_reserve );
 
@@ -2340,13 +2340,13 @@ withdraw( fd_exec_instr_ctx_t const *   ctx,
   if( FD_UNLIKELY( rc ) ) return rc;
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L877
-  if( FD_UNLIKELY( is_staked && lamports_and_reserve>stake_account.acct->const_meta->info.lamports ) ) {
+  if( FD_UNLIKELY( is_staked && lamports_and_reserve>fd_borrowed_account_get_lamports( &stake_account ) ) ) {
     return FD_EXECUTOR_INSTR_ERR_INSUFFICIENT_FUNDS;
   }
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L883
-  if( FD_UNLIKELY( lamports!=stake_account.acct->const_meta->info.lamports &&
-                    lamports_and_reserve>stake_account.acct->const_meta->info.lamports ) ) {
+  if( FD_UNLIKELY( lamports!=fd_borrowed_account_get_lamports( &stake_account  ) &&
+                    lamports_and_reserve>fd_borrowed_account_get_lamports( &stake_account ) ) ) {
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L886
     FD_TEST( !is_staked );
     return FD_EXECUTOR_INSTR_ERR_INSUFFICIENT_FUNDS;
@@ -2354,7 +2354,7 @@ withdraw( fd_exec_instr_ctx_t const *   ctx,
 
   // FIXME FD_LIKELY
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L891
-  if( lamports==stake_account.acct->const_meta->info.lamports ) {
+  if( lamports==fd_borrowed_account_get_lamports( &stake_account ) ) {
     fd_stake_state_v2_t uninitialized = {0};
     uninitialized.discriminant        = fd_stake_state_v2_enum_uninitialized;
     rc                                = set_state( &stake_account, &uninitialized );
@@ -2399,7 +2399,7 @@ deactivate_delinquent( fd_exec_instr_ctx_t *   ctx,
   FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( ctx, delinquent_vote_account_index, &delinquent_vote_account );
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L917
-  if( FD_UNLIKELY( memcmp( &delinquent_vote_account.acct->const_meta->info.owner, fd_solana_vote_program_id.key, 32UL ) ) )
+  if( FD_UNLIKELY( memcmp( fd_borrowed_account_get_owner( &delinquent_vote_account ), fd_solana_vote_program_id.key, 32UL ) ) )
     return FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID;
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L920-L922
@@ -2414,7 +2414,7 @@ deactivate_delinquent( fd_exec_instr_ctx_t *   ctx,
   FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( ctx, reference_vote_account_index, &reference_vote_account );
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L926
-  if( FD_UNLIKELY( memcmp( &reference_vote_account.acct->const_meta->info.owner, fd_solana_vote_program_id.key, 32UL ) ) )
+  if( FD_UNLIKELY( memcmp( fd_borrowed_account_get_owner( &reference_vote_account ), fd_solana_vote_program_id.key, 32UL ) ) )
     return FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID;
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L929-L932
@@ -2497,7 +2497,7 @@ get_stake_account( fd_exec_instr_ctx_t const * ctx,
   fd_borrowed_account_t * account = out;
 
   // https://github.com/https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L62-L65
-  if( FD_UNLIKELY( memcmp( account->acct->const_meta->info.owner, fd_solana_stake_program_id.key, 32UL ) ) )
+  if( FD_UNLIKELY( memcmp( fd_borrowed_account_get_owner( account ), fd_solana_stake_program_id.key, 32UL ) ) )
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_OWNER;
 
   return FD_EXECUTOR_INSTR_SUCCESS;
@@ -3192,27 +3192,22 @@ static void
 write_stake_config( fd_exec_slot_ctx_t * slot_ctx, fd_stake_config_t const * stake_config ) {
   ulong                   data_sz  = fd_stake_config_size( stake_config );
   fd_pubkey_t const *     acc_key  = &fd_solana_stake_program_config_id;
-  fd_account_meta_t *     acc_meta = NULL;
-  uchar *                 acc_data = NULL;
+
   FD_TXN_ACCOUNT_DECL(rec);
   int err = fd_txn_account_init_from_funk_mutable( rec, acc_key, slot_ctx->funk, slot_ctx->funk_txn, 1, data_sz );
   FD_TEST( !err );
 
-  acc_meta                  = rec->meta;
-  acc_data                  = rec->data;
-  acc_meta->dlen            = data_sz;
-  acc_meta->info.lamports   = 960480UL;
-  acc_meta->info.rent_epoch = 0UL;
-  acc_meta->info.executable = 0;
+  rec->vt->set_lamports( rec, 960480UL );
+  rec->vt->set_rent_epoch( rec, 0UL );
+  rec->vt->set_executable( rec, 0 );
 
   fd_bincode_encode_ctx_t ctx3;
-  ctx3.data    = acc_data;
-  ctx3.dataend = acc_data + data_sz;
+  ctx3.data    = rec->vt->get_data_mut( rec );
+  ctx3.dataend = rec->vt->get_data_mut( rec ) + data_sz;
   if( fd_stake_config_encode( stake_config, &ctx3 ) )
     FD_LOG_ERR( ( "fd_stake_config_encode failed" ) );
 
-  fd_memset( acc_data, 0, data_sz );
-  fd_memcpy( acc_data, stake_config, sizeof( fd_stake_config_t ) );
+  rec->vt->set_data( rec, stake_config, data_sz );
 
   fd_txn_account_mutable_fini( rec, slot_ctx->funk, slot_ctx->funk_txn );
 }
@@ -3261,7 +3256,7 @@ fd_stakes_remove_stake_delegation( fd_exec_slot_ctx_t * slot_ctx, fd_txn_account
 /* Updates stake delegation in epoch stakes */
 static void
 fd_stakes_upsert_stake_delegation( fd_exec_slot_ctx_t * slot_ctx, fd_txn_account_t * stake_account ) {
-  FD_TEST( stake_account->const_meta->info.lamports!=0 );
+  FD_TEST( stake_account->vt->get_lamports( stake_account )!=0 );
   fd_epoch_bank_t * epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
   fd_stakes_t * stakes = &epoch_bank->stakes;
 
@@ -3299,16 +3294,16 @@ fd_stakes_upsert_stake_delegation( fd_exec_slot_ctx_t * slot_ctx, fd_txn_account
 }
 
 void fd_store_stake_delegation( fd_exec_slot_ctx_t * slot_ctx, fd_txn_account_t * stake_account ) {
-  fd_pubkey_t const * owner = (fd_pubkey_t const *)stake_account->const_meta->info.owner;
+  fd_pubkey_t const * owner = stake_account->vt->get_owner( stake_account );
 
   if( memcmp( owner->uc, fd_solana_stake_program_id.key, sizeof(fd_pubkey_t) ) ) {
       return;
   }
 
-  int is_empty  = stake_account->const_meta->info.lamports==0;
+  int is_empty  = stake_account->vt->get_lamports( stake_account )==0;
   int is_uninit = 1;
-  if( stake_account->const_meta->dlen>=4 ) {
-    uint prefix = FD_LOAD( uint, stake_account->const_data );
+  if( stake_account->vt->get_data_len( stake_account )>=4 ) {
+    uint prefix = FD_LOAD( uint, stake_account->vt->get_data( stake_account ) );
     is_uninit = ( prefix==fd_stake_state_v2_enum_uninitialized );
   }
 

--- a/src/flamenco/runtime/program/fd_system_program_nonce.c
+++ b/src/flamenco/runtime/program/fd_system_program_nonce.c
@@ -105,24 +105,22 @@ fd_system_program_set_nonce_state( fd_borrowed_account_t *           account,
   /* https://github.com/solana-labs/solana/blob/v1.17.23/sdk/src/transaction_context.rs#L1021
      => https://github.com/solana-labs/solana/blob/v1.17.23/sdk/src/transaction_context.rs#L868 */
 
-  do {
-    int err = 99999;
-    if( FD_UNLIKELY( !fd_borrowed_account_can_data_be_changed( account, &err ) ) ) {
-      return err;
-    }
-  } while(0);
+  uchar * data = NULL;
+  ulong   dlen = 0UL;
+  int err = fd_borrowed_account_get_data_mut( account, &data, &dlen );
+  if( FD_UNLIKELY( err ) ) return err;
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/sdk/src/transaction_context.rs#L1024-L1026 */
 
-  if( FD_UNLIKELY( fd_nonce_state_versions_size( new_state ) > account->acct->meta->dlen ) )
+  if( FD_UNLIKELY( fd_nonce_state_versions_size( new_state ) > fd_borrowed_account_get_data_len( account ) ) )
     return FD_EXECUTOR_INSTR_ERR_ACC_DATA_TOO_SMALL;
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/sdk/src/transaction_context.rs#L1027 */
 
   do {
     fd_bincode_encode_ctx_t encode =
-      { .data    = account->acct->data,
-        .dataend = account->acct->data + account->acct->meta->dlen };
+      { .data    = data,
+        .dataend = data + dlen };
     int err = fd_nonce_state_versions_encode( new_state, &encode );
     if( FD_UNLIKELY( err ) ) {
       return FD_EXECUTOR_INSTR_ERR_GENERIC_ERR;
@@ -153,8 +151,8 @@ fd_system_program_advance_nonce_account( fd_exec_instr_ctx_t *   ctx,
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L34 */
 
   fd_bincode_decode_ctx_t decode = {
-    .data    = account->acct->const_data,
-    .dataend = account->acct->const_data + account->acct->const_meta->dlen
+    .data    = fd_borrowed_account_get_data( account ),
+    .dataend = fd_borrowed_account_get_data( account ) + fd_borrowed_account_get_data_len( account )
   };
 
   ulong total_sz = 0UL;
@@ -332,8 +330,8 @@ fd_system_program_withdraw_nonce_account( fd_exec_instr_ctx_t * ctx,
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L93 */
 
   fd_bincode_decode_ctx_t decode = {
-    .data    = from.acct->const_data,
-    .dataend = from.acct->const_data + from.acct->const_meta->dlen
+    .data    = fd_borrowed_account_get_data( &from ),
+    .dataend = fd_borrowed_account_get_data( &from ) + fd_borrowed_account_get_data_len( &from )
   };
   ulong total_sz = 0UL;
   err = fd_nonce_state_versions_decode_footprint( &decode, &total_sz );
@@ -368,10 +366,10 @@ fd_system_program_withdraw_nonce_account( fd_exec_instr_ctx_t * ctx,
   case fd_nonce_state_enum_uninitialized: {
     /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L95-L106 */
 
-    if( FD_UNLIKELY( requested_lamports > from.acct->const_meta->info.lamports ) ) {
+    if( FD_UNLIKELY( requested_lamports > fd_borrowed_account_get_lamports( &from ) ) ) {
       /* Max msg_sz: 59 - 6 + 20 + 20 = 93 < 127 => we can use printf */
       fd_log_collector_printf_dangerous_max_127( ctx,
-        "Withdraw nonce account: insufficient lamports %lu, need %lu", from.acct->const_meta->info.lamports, requested_lamports );
+        "Withdraw nonce account: insufficient lamports %lu, need %lu", fd_borrowed_account_get_lamports( &from ), requested_lamports );
       return FD_EXECUTOR_INSTR_ERR_INSUFFICIENT_FUNDS;
     }
 
@@ -386,7 +384,7 @@ fd_system_program_withdraw_nonce_account( fd_exec_instr_ctx_t * ctx,
     /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L107-L132 */
     fd_nonce_data_t * data = &state->inner.initialized;
 
-    if( requested_lamports == from.acct->const_meta->info.lamports ) {
+    if( requested_lamports == fd_borrowed_account_get_lamports( &from ) ) {
         /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L108-L117 */
 
       /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L109 */
@@ -427,7 +425,7 @@ fd_system_program_withdraw_nonce_account( fd_exec_instr_ctx_t * ctx,
 
       /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L120 */
 
-      ulong min_balance = fd_rent_exempt_minimum_balance( rent, from.acct->const_meta->dlen );
+      ulong min_balance = fd_rent_exempt_minimum_balance( rent, fd_borrowed_account_get_data_len( &from ) );
 
       ulong amount;
       if( FD_UNLIKELY( __builtin_uaddl_overflow( requested_lamports, min_balance, &amount ) ) )
@@ -435,10 +433,10 @@ fd_system_program_withdraw_nonce_account( fd_exec_instr_ctx_t * ctx,
 
       /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L121-L129 */
 
-      if( FD_UNLIKELY( amount > from.acct->const_meta->info.lamports ) ) {
+      if( FD_UNLIKELY( amount > fd_borrowed_account_get_lamports( &from ) ) ) {
         /* Max msg_sz: 59 - 6 + 20 + 20 = 93 < 127 => we can use printf */
         fd_log_collector_printf_dangerous_max_127( ctx,
-          "Withdraw nonce account: insufficient lamports %lu, need %lu", from.acct->const_meta->info.lamports, amount );
+          "Withdraw nonce account: insufficient lamports %lu, need %lu", fd_borrowed_account_get_lamports( &from ), amount );
         return FD_EXECUTOR_INSTR_ERR_INSUFFICIENT_FUNDS;
       }
 
@@ -543,8 +541,8 @@ fd_system_program_initialize_nonce_account( fd_exec_instr_ctx_t *   ctx,
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L168 */
 
   fd_bincode_decode_ctx_t decode = {
-    .data    = account->acct->const_data,
-    .dataend = account->acct->const_data + account->acct->const_meta->dlen
+    .data    = fd_borrowed_account_get_data( account ),
+    .dataend = fd_borrowed_account_get_data( account ) + fd_borrowed_account_get_data_len( account )
   };
 
   ulong total_sz = 0UL;
@@ -580,14 +578,14 @@ fd_system_program_initialize_nonce_account( fd_exec_instr_ctx_t *   ctx,
 
     /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L170 */
 
-    ulong min_balance = fd_rent_exempt_minimum_balance( rent, account->acct->const_meta->dlen );
+    ulong min_balance = fd_rent_exempt_minimum_balance( rent, fd_borrowed_account_get_data_len( account ) );
 
     /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L171-L179 */
 
-    if( FD_UNLIKELY( account->acct->const_meta->info.lamports < min_balance ) ) {
+    if( FD_UNLIKELY( fd_borrowed_account_get_lamports( account ) < min_balance ) ) {
       /* Max msg_sz: 61 - 6 + 20 + 20 = 95 < 127 => we can use printf */
       fd_log_collector_printf_dangerous_max_127( ctx,
-        "Initialize nonce account: insufficient lamports %lu, need %lu", account->acct->const_meta->info.lamports, min_balance );
+        "Initialize nonce account: insufficient lamports %lu, need %lu", fd_borrowed_account_get_lamports( account ), min_balance );
       return FD_EXECUTOR_INSTR_ERR_INSUFFICIENT_FUNDS;
     }
 
@@ -721,8 +719,8 @@ fd_system_program_authorize_nonce_account( fd_exec_instr_ctx_t *   ctx,
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_instruction.rs#L214-L215 */
 
   fd_bincode_decode_ctx_t decode = {
-    .data    = account->acct->const_data,
-    .dataend = account->acct->const_data + account->acct->const_meta->dlen
+    .data    = fd_borrowed_account_get_data( account ),
+    .dataend = fd_borrowed_account_get_data( account ) + fd_borrowed_account_get_data_len( account )
   };
 
   ulong total_sz = 0UL;
@@ -867,7 +865,7 @@ fd_system_program_exec_upgrade_nonce_account( fd_exec_instr_ctx_t * ctx ) {
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L492-L494 */
 
-  if( FD_UNLIKELY( 0!=memcmp( account.acct->const_meta->info.owner, fd_solana_system_program_id.key, sizeof(fd_pubkey_t) ) ) )
+  if( FD_UNLIKELY( 0!=memcmp( fd_borrowed_account_get_owner( &account ), fd_solana_system_program_id.key, sizeof(fd_pubkey_t) ) ) )
     return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_OWNER;
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L495-L497 */
@@ -878,8 +876,8 @@ fd_system_program_exec_upgrade_nonce_account( fd_exec_instr_ctx_t * ctx ) {
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L498 */
 
   fd_bincode_decode_ctx_t decode = {
-    .data    = account.acct->const_data,
-    .dataend = account.acct->const_data + account.acct->const_meta->dlen
+    .data    = fd_borrowed_account_get_data( &account ),
+    .dataend = fd_borrowed_account_get_data( &account ) + fd_borrowed_account_get_data_len( &account )
   };
 
   ulong total_sz = 0UL;
@@ -996,14 +994,14 @@ fd_check_transaction_age( fd_exec_txn_ctx_t * txn_ctx ) {
 
   /* https://github.com/anza-xyz/agave/blob/16de8b75ebcd57022409b422de557dd37b1de8db/sdk/src/nonce_account.rs#L28-L42 */
   /* verify_nonce_account */
-  uchar const * owner_pubkey = durable_nonce_rec->const_meta->info.owner;
+  fd_pubkey_t const * owner_pubkey = durable_nonce_rec->vt->get_owner( durable_nonce_rec );
   if( FD_UNLIKELY( memcmp( owner_pubkey, fd_solana_system_program_id.key, sizeof( fd_pubkey_t ) ) ) ) {
     return FD_RUNTIME_TXN_ERR_BLOCKHASH_NOT_FOUND;
   }
 
   fd_bincode_decode_ctx_t decode = {
-    .data    = durable_nonce_rec->const_data,
-    .dataend = durable_nonce_rec->const_data + durable_nonce_rec->const_meta->dlen,
+    .data    = durable_nonce_rec->vt->get_data( durable_nonce_rec ),
+    .dataend = durable_nonce_rec->vt->get_data( durable_nonce_rec )+ durable_nonce_rec->vt->get_data_len( durable_nonce_rec ),
   };
 
   ulong total_sz = 0UL;
@@ -1076,18 +1074,18 @@ fd_check_transaction_age( fd_exec_txn_ctx_t * txn_ctx ) {
           FD_LOG_ERR(( "fd_nonce_state_versions_size( &new_state ) %lu > FD_ACC_NONCE_SZ_MAX %lu", fd_nonce_state_versions_size( &new_state ), FD_ACC_NONCE_SZ_MAX ));
         }
         /* make_modifiable uses the old length for the data copy */
-        ulong old_tot_len = sizeof(fd_account_meta_t)+rollback_nonce_rec->const_meta->dlen;
+        ulong old_tot_len = sizeof(fd_account_meta_t)+rollback_nonce_rec->vt->get_data_len( rollback_nonce_rec );
         void * borrowed_account_data = fd_spad_alloc( txn_ctx->spad, FD_ACCOUNT_REC_ALIGN, fd_ulong_max( FD_ACC_NONCE_TOT_SZ_MAX, old_tot_len ) );
         fd_txn_account_make_mutable( rollback_nonce_rec,
                                      borrowed_account_data,
                                      txn_ctx->spad_wksp );
-        if( FD_UNLIKELY( fd_nonce_state_versions_size( &new_state ) > rollback_nonce_rec->meta->dlen ) ) {
+        if( FD_UNLIKELY( fd_nonce_state_versions_size( &new_state ) > rollback_nonce_rec->vt->get_data_len( rollback_nonce_rec ) ) ) {
           return FD_RUNTIME_TXN_ERR_BLOCKHASH_NOT_FOUND;
         }
         do {
           fd_bincode_encode_ctx_t encode_ctx =
-            { .data    = rollback_nonce_rec->data,
-              .dataend = rollback_nonce_rec->data + rollback_nonce_rec->meta->dlen };
+            { .data    = rollback_nonce_rec->vt->get_data_mut( rollback_nonce_rec ),
+              .dataend = rollback_nonce_rec->vt->get_data_mut( rollback_nonce_rec ) + rollback_nonce_rec->vt->get_data_len( rollback_nonce_rec ) };
           int err = fd_nonce_state_versions_encode( &new_state, &encode_ctx );
           if( FD_UNLIKELY( err ) ) {
             return FD_RUNTIME_TXN_ERR_BLOCKHASH_NOT_FOUND;

--- a/src/flamenco/runtime/sysvar/fd_sysvar.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar.c
@@ -6,7 +6,7 @@
 /* https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/runtime/src/bank.rs#L1813 */
 int
 fd_sysvar_set( fd_exec_slot_ctx_t * slot_ctx,
-               uchar const *        owner,
+               fd_pubkey_t const *  owner,
                fd_pubkey_t const *  pubkey,
                void const *         data,
                ulong                sz,
@@ -21,16 +21,16 @@ fd_sysvar_set( fd_exec_slot_ctx_t * slot_ctx,
   if( FD_UNLIKELY( err != FD_ACC_MGR_SUCCESS ) )
     return FD_ACC_MGR_ERR_READ_FAILED;
 
-  fd_memcpy(rec->data, data, sz);
+  fd_memcpy(rec->vt->get_data_mut( rec ), data, sz);
 
   /* https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/runtime/src/bank.rs#L1825 */
-  fd_acc_lamports_t lamports_before = rec->meta->info.lamports;
+  fd_acc_lamports_t lamports_before = rec->vt->get_lamports( rec );
   fd_epoch_bank_t * epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
   /* https://github.com/anza-xyz/agave/blob/ae18213c19ea5335dfc75e6b6116def0f0910aff/runtime/src/bank.rs#L6184
      The account passed in via the updater is always the current sysvar account, so we take the max of the
      current account lamports and the minimum rent exempt balance needed. */
   fd_acc_lamports_t lamports_after = fd_ulong_max( lamports_before, fd_rent_exempt_minimum_balance( &epoch_bank->rent, sz ) );
-  rec->meta->info.lamports = lamports_after;
+  rec->vt->set_lamports( rec, lamports_after );
 
   /* https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/runtime/src/bank.rs#L1826 */
   if       ( lamports_after > lamports_before ) {
@@ -39,9 +39,9 @@ fd_sysvar_set( fd_exec_slot_ctx_t * slot_ctx,
     slot_ctx->slot_bank.capitalization -= ( lamports_before - lamports_after );
   }
 
-  rec->meta->dlen = sz;
-  fd_memcpy(rec->meta->info.owner, owner, 32);
-  rec->meta->slot = slot;
+  rec->vt->set_data_len( rec, sz );
+  rec->vt->set_owner( rec, owner );
+  rec->vt->set_slot( rec, slot );
 
   fd_txn_account_mutable_fini( rec, funk, funk_txn );
   return 0;

--- a/src/flamenco/runtime/sysvar/fd_sysvar.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar.h
@@ -10,7 +10,7 @@
 
 int
 fd_sysvar_set( fd_exec_slot_ctx_t * state,
-               uchar const *        owner,
+               fd_pubkey_t const *  owner,
                fd_pubkey_t const *  pubkey,
                void const *         data,
                ulong                sz,

--- a/src/flamenco/runtime/sysvar/fd_sysvar_cache.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_cache.c
@@ -90,56 +90,56 @@ FD_SYSVAR_CACHE_ITER(X)
 #define HANDLE_GLOBAL_1( type, mem, decode)     type##_decode_global( mem, &decode );
 #define HANDLE_GLOBAL_0( type, mem, decode)     type##_decode( mem, &decode );
 
-# define X( type, name, is_global )                                             \
-void                                                                            \
-fd_sysvar_cache_restore_##name(                                                 \
-  fd_sysvar_cache_t * cache,                                                    \
-  fd_funk_t *         funk,                                                     \
-  fd_funk_txn_t *     funk_txn,                                                 \
-  fd_spad_t *         runtime_spad,                                             \
-  fd_wksp_t *         wksp ) {                                                  \
-  do {                                                                          \
-    fd_pubkey_t const * pubkey = &fd_sysvar_##name##_id;                        \
-    FD_TXN_ACCOUNT_DECL( account );                                             \
-    int view_err = fd_txn_account_init_from_funk_readonly( account,             \
-                                                           pubkey,              \
-                                                           funk,                \
-                                                           funk_txn );          \
-    if( view_err==FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT ) break;                       \
-                                                                                \
-    if( view_err!=FD_ACC_MGR_SUCCESS ) {                                        \
-      char pubkey_cstr[ FD_BASE58_ENCODED_32_SZ ];                              \
-      FD_LOG_ERR(( "fd_txn_account_init_from_funk_readonly(%s) failed (%d-%s)", \
-                   fd_acct_addr_cstr( pubkey_cstr, pubkey->key ),               \
-                   view_err, fd_acc_mgr_strerror( view_err ) ));                \
-    }                                                                           \
-                                                                                \
-    if( account->const_meta->info.lamports == 0UL ) break;                      \
-                                                                                \
-    /* Decode new value                                                         \
-      type##_decode() does not do heap allocations on failure */                \
-    fd_bincode_decode_ctx_t decode = {                                          \
-      .data    = account->const_data,                                           \
-      .dataend = account->const_data + account->const_meta->dlen,               \
-      .wksp    = wksp                                                           \
-    };                                                                          \
-    ulong total_sz    = 0UL;                                                    \
-    int   err         = type##_decode_footprint( &decode, &total_sz );          \
-    cache->has_##name = (err==FD_BINCODE_SUCCESS);                              \
-    if( FD_UNLIKELY( err ) ) {                                                  \
-      FD_LOG_WARNING(( "failed to decode footprint" ));                         \
-      break;                                                                    \
-    }                                                                           \
-                                                                                \
-    type##_t * mem = fd_spad_alloc( runtime_spad,                               \
-                                    type##_align(),                             \
-                                    total_sz );                                 \
-    if( FD_UNLIKELY( !mem ) ) {                                                 \
-      FD_LOG_ERR(( "memory allocation failed" ));                               \
-    }                                                                           \
-    HANDLE_GLOBAL_##is_global( type, mem, decode )                              \
-    fd_memcpy( cache->val_##name, mem, sizeof(type##_t) );                      \
-  } while(0);                                                                   \
+# define X( type, name, is_global )                                                       \
+void                                                                                      \
+fd_sysvar_cache_restore_##name(                                                           \
+  fd_sysvar_cache_t * cache,                                                              \
+  fd_funk_t *         funk,                                                               \
+  fd_funk_txn_t *     funk_txn,                                                           \
+  fd_spad_t *         runtime_spad,                                                       \
+  fd_wksp_t *         wksp ) {                                                            \
+  do {                                                                                    \
+    fd_pubkey_t const * pubkey = &fd_sysvar_##name##_id;                                  \
+    FD_TXN_ACCOUNT_DECL( account );                                                       \
+    int view_err = fd_txn_account_init_from_funk_readonly( account,                       \
+                                                           pubkey,                        \
+                                                           funk,                          \
+                                                           funk_txn );                    \
+    if( view_err==FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT ) break;                                 \
+                                                                                          \
+    if( view_err!=FD_ACC_MGR_SUCCESS ) {                                                  \
+      char pubkey_cstr[ FD_BASE58_ENCODED_32_SZ ];                                        \
+      FD_LOG_ERR(( "fd_txn_account_init_from_funk_readonly(%s) failed (%d-%s)",           \
+                   fd_acct_addr_cstr( pubkey_cstr, pubkey->key ),                         \
+                   view_err, fd_acc_mgr_strerror( view_err ) ));                          \
+    }                                                                                     \
+                                                                                          \
+    if( account->vt->get_lamports( account ) == 0UL ) break;                              \
+                                                                                          \
+    /* Decode new value                                                                   \
+      type##_decode() does not do heap allocations on failure */                          \
+    fd_bincode_decode_ctx_t decode = {                                                    \
+      .data    = account->vt->get_data( account ),                                        \
+      .dataend = account->vt->get_data( account ) + account->vt->get_data_len( account ), \
+      .wksp    = wksp                                                                     \
+    };                                                                                    \
+    ulong total_sz    = 0UL;                                                              \
+    int   err         = type##_decode_footprint( &decode, &total_sz );                    \
+    cache->has_##name = (err==FD_BINCODE_SUCCESS);                                        \
+    if( FD_UNLIKELY( err ) ) {                                                            \
+      FD_LOG_WARNING(( "failed to decode footprint" ));                                   \
+      break;                                                                              \
+    }                                                                                     \
+                                                                                          \
+    type##_t * mem = fd_spad_alloc( runtime_spad,                                         \
+                                    type##_align(),                                       \
+                                    total_sz );                                           \
+    if( FD_UNLIKELY( !mem ) ) {                                                           \
+      FD_LOG_ERR(( "memory allocation failed" ));                                         \
+    }                                                                                     \
+    HANDLE_GLOBAL_##is_global( type, mem, decode )                                        \
+    fd_memcpy( cache->val_##name, mem, sizeof(type##_t) );                                \
+  } while(0);                                                                             \
 }
   FD_SYSVAR_CACHE_ITER(X)
 # undef X

--- a/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
@@ -43,7 +43,7 @@ write_clock( fd_exec_slot_ctx_t *    slot_ctx,
   if( fd_sol_sysvar_clock_encode( clock, &ctx ) )
     FD_LOG_ERR(("fd_sol_sysvar_clock_encode failed"));
 
-  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, (fd_pubkey_t *) &fd_sysvar_clock_id, enc, sz, slot_ctx->slot_bank.slot );
+  fd_sysvar_set( slot_ctx, &fd_sysvar_owner_id, (fd_pubkey_t *) &fd_sysvar_clock_id, enc, sz, slot_ctx->slot_bank.slot );
 }
 
 
@@ -64,8 +64,8 @@ fd_sysvar_clock_read( fd_sol_sysvar_clock_t *   result,
     return NULL;
 
   fd_bincode_decode_ctx_t ctx = {
-    .data    = acc->const_data,
-    .dataend = acc->const_data + acc->const_meta->dlen,
+    .data    = acc->vt->get_data( acc ),
+    .dataend = acc->vt->get_data( acc ) + acc->vt->get_data_len( acc ),
   };
 
   ulong total_sz = 0UL;
@@ -355,8 +355,8 @@ fd_sysvar_clock_update( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_spad 
   }
 
   fd_bincode_decode_ctx_t ctx = {
-    .data    = rec->const_data,
-    .dataend = rec->const_data + rec->const_meta->dlen
+    .data    = rec->vt->get_data( rec ),
+    .dataend = rec->vt->get_data( rec ) + rec->vt->get_data_len( rec )
   };
 
   ulong total_sz = 0UL;
@@ -447,20 +447,20 @@ fd_sysvar_clock_update( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_spad 
   }
 
   fd_bincode_encode_ctx_t e_ctx = {
-    .data    = acc->data,
-    .dataend = acc->data+sz,
+    .data    = acc->vt->get_data_mut( acc ),
+    .dataend = acc->vt->get_data_mut( acc )+sz,
   };
   if( fd_sol_sysvar_clock_encode( clock, &e_ctx ) ) {
     return FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR;
   }
 
   ulong lamps = fd_rent_exempt_minimum_balance( &epoch_bank->rent, sz );
-  if( acc->meta->info.lamports < lamps ) {
-    acc->meta->info.lamports = lamps;
+  if( acc->vt->get_lamports( acc ) < lamps ) {
+    acc->vt->set_lamports( acc, lamps );
   }
 
-  acc->meta->dlen = sz;
-  fd_memcpy( acc->meta->info.owner, fd_sysvar_owner_id.key, sizeof(fd_pubkey_t) );
+  acc->vt->set_data_len( acc, sz );
+  acc->vt->set_owner( acc, &fd_sysvar_owner_id );
 
   fd_txn_account_mutable_fini( acc, slot_ctx->funk, slot_ctx->funk_txn );
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.c
@@ -18,7 +18,7 @@ write_epoch_rewards( fd_exec_slot_ctx_t * slot_ctx, fd_sysvar_epoch_rewards_t * 
     FD_LOG_ERR(("fd_sysvar_epoch_rewards_encode failed"));
   }
 
-  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_epoch_rewards_id, enc, sz, slot_ctx->slot_bank.slot );
+  fd_sysvar_set( slot_ctx, &fd_sysvar_owner_id, &fd_sysvar_epoch_rewards_id, enc, sz, slot_ctx->slot_bank.slot );
 }
 
 fd_sysvar_epoch_rewards_t *
@@ -39,8 +39,8 @@ fd_sysvar_epoch_rewards_read( fd_sysvar_epoch_rewards_t * result,
   }
 
   fd_bincode_decode_ctx_t decode = {
-    .data    = acc->const_data,
-    .dataend = acc->const_data + acc->const_meta->dlen
+    .data    = acc->vt->get_data( acc ),
+    .dataend = acc->vt->get_data( acc ) + acc->vt->get_data_len( acc )
   };
 
   ulong total_sz = 0UL;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.c
@@ -46,7 +46,7 @@ write_epoch_schedule( fd_exec_slot_ctx_t  * slot_ctx,
   if ( fd_epoch_schedule_encode( epoch_schedule, &ctx ) )
     FD_LOG_ERR(("fd_epoch_schedule_encode failed"));
 
-  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_epoch_schedule_id, enc, sz, slot_ctx->slot_bank.slot );
+  fd_sysvar_set( slot_ctx, &fd_sysvar_owner_id, &fd_sysvar_epoch_schedule_id, enc, sz, slot_ctx->slot_bank.slot );
 }
 
 fd_epoch_schedule_t *
@@ -66,8 +66,8 @@ fd_sysvar_epoch_schedule_read( fd_epoch_schedule_t *     result,
     return NULL;
 
   fd_bincode_decode_ctx_t decode = {
-    .data    = acc->const_data,
-    .dataend = acc->const_data + acc->const_meta->dlen
+    .data    = acc->vt->get_data( acc ),
+    .dataend = acc->vt->get_data( acc ) + acc->vt->get_data_len( acc )
   };
 
   ulong total_sz = 0UL;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_fees.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_fees.c
@@ -15,7 +15,7 @@ write_fees( fd_exec_slot_ctx_t* slot_ctx, fd_sysvar_fees_t* fees ) {
   if ( fd_sysvar_fees_encode( fees, &ctx ) )
     FD_LOG_ERR(("fd_sysvar_fees_encode failed"));
 
-  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_fees_id, enc, sz, slot_ctx->slot_bank.slot );
+  fd_sysvar_set( slot_ctx, &fd_sysvar_owner_id, &fd_sysvar_fees_id, enc, sz, slot_ctx->slot_bank.slot );
 }
 
 fd_sysvar_fees_t *
@@ -35,8 +35,8 @@ fd_sysvar_fees_read( fd_sysvar_fees_t *        result,
     return NULL;
 
   fd_bincode_decode_ctx_t decode = {
-    .data    = acc->const_data,
-    .dataend = acc->const_data + acc->const_meta->dlen
+    .data    = acc->vt->get_data( acc ),
+    .dataend = acc->vt->get_data( acc ) + acc->vt->get_data_len( acc )
   };
 
   ulong total_sz = 0UL;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_instructions.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_instructions.c
@@ -59,25 +59,21 @@ fd_sysvar_instructions_serialize_account( fd_exec_txn_ctx_t *      txn_ctx,
         - spad memory is sized out for allocations for 128 (max number) accounts
         - sizeof(fd_account_meta_t) + serialized_sz will always be less than FD_ACC_TOT_SZ_MAX
         - at most 127 accounts could be using spad memory right now, so this allocation is safe */
-  if( rec->meta==NULL ) {
-    fd_account_meta_t * meta = fd_spad_alloc( txn_ctx->spad, alignof(fd_account_meta_t), sizeof(fd_account_meta_t) + serialized_sz );
-    void * data = (uchar *)meta + sizeof(fd_account_meta_t);
-
-    rec->const_meta = rec->meta = meta;
-    rec->const_data = rec->data = data;
+  if( !rec->vt->is_mutable( rec ) ) {
+    fd_txn_account_setup_meta_mutable( rec, txn_ctx->spad, serialized_sz );
   }
 
   /* Agave sets up the borrowed account for the instructions sysvar to contain
      default values except for the data which is serialized into the account. */
 
-  memcpy( rec->meta->info.owner, fd_sysvar_owner_id.key, sizeof(fd_pubkey_t) );
-  rec->starting_lamports     = 0UL;
-  rec->meta->info.lamports   = 0UL; // TODO: This cannot be right... well, it gets destroyed almost instantly...
-  rec->meta->info.executable = 0;
-  rec->meta->info.rent_epoch = 0UL;
-  rec->meta->dlen            = serialized_sz;
+  rec->vt->set_owner( rec, &fd_sysvar_owner_id );
+  rec->vt->set_lamports( rec, 0UL );
+  rec->vt->set_executable( rec, 0 );
+  rec->vt->set_rent_epoch( rec, 0UL );
+  rec->vt->set_data_len( rec, serialized_sz );
+  rec->starting_lamports = 0UL;
 
-  uchar * serialized_instructions = rec->data;
+  uchar * serialized_instructions = rec->vt->get_data_mut( rec );
   ulong offset = 0;
 
   // TODO: do we needs bounds checking?
@@ -148,10 +144,10 @@ fd_sysvar_instructions_update_current_instr_idx( fd_exec_txn_ctx_t * txn_ctx,
 
   /* Store the current instruction index
      https://github.com/anza-xyz/agave/blob/v2.1.14/svm/src/message_processor.rs#L58-L61 */
-  uchar * serialized_current_instr_idx = rec->data + (rec->meta->dlen - sizeof(ushort));
+  uchar * serialized_current_instr_idx = rec->vt->get_data_mut( rec ) + (rec->vt->get_data_len( rec ) - sizeof(ushort));
   FD_STORE( ushort, serialized_current_instr_idx, current_instr_idx );
 
-  fd_txn_account_release_write( rec );
+  rec->vt->drop( rec );
 
   return FD_EXECUTOR_INSTR_SUCCESS;
 }

--- a/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.c
@@ -26,7 +26,7 @@ fd_sysvar_last_restart_slot_init( fd_exec_slot_ctx_t * slot_ctx ) {
   FD_TEST( err==FD_BINCODE_SUCCESS );
 
   fd_sysvar_set( slot_ctx,
-                 fd_sysvar_owner_id.key,
+                 &fd_sysvar_owner_id,
                  &fd_sysvar_last_restart_slot_id,
                  enc, sz,
                  slot_ctx->slot_bank.slot );
@@ -49,8 +49,8 @@ fd_sysvar_last_restart_slot_read( fd_sol_sysvar_last_restart_slot_t * result,
   if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) return NULL;
 
   fd_bincode_decode_ctx_t decode = {
-    .data    = acc->const_data,
-    .dataend = acc->const_data + acc->const_meta->dlen
+    .data    = acc->vt->get_data( acc ),
+    .dataend = acc->vt->get_data( acc ) + acc->vt->get_data_len( acc )
   };
 
   ulong total_sz = 0UL;
@@ -95,7 +95,7 @@ fd_sysvar_last_restart_slot_update( fd_exec_slot_ctx_t * slot_ctx ) {
   /* https://github.com/solana-labs/solana/blob/v1.18.18/runtime/src/bank.rs#L2122-L2130 */
   if( !has_current_last_restart_slot || current_last_restart_slot != last_restart_slot ) {
     fd_sysvar_set(
-        slot_ctx, fd_sysvar_owner_id.key,
+        slot_ctx, &fd_sysvar_owner_id,
         &fd_sysvar_last_restart_slot_id,
         &last_restart_slot, sizeof(ulong),
         slot_ctx->slot_bank.slot );

--- a/src/flamenco/runtime/sysvar/fd_sysvar_recent_hashes.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_recent_hashes.c
@@ -64,7 +64,7 @@ fd_sysvar_recent_hashes_init( fd_exec_slot_ctx_t * slot_ctx,
   uchar * enc = fd_spad_alloc( runtime_spad, FD_SPAD_ALIGN, sz );
   fd_memset( enc, 0, sz );
   encode_rbh_from_blockhash_queue( slot_ctx, enc );
-  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_recent_block_hashes_id, enc, sz, slot_ctx->slot_bank.slot );
+  fd_sysvar_set( slot_ctx, &fd_sysvar_owner_id, &fd_sysvar_recent_block_hashes_id, enc, sz, slot_ctx->slot_bank.slot );
 
   } FD_SPAD_FRAME_END;
 }
@@ -123,7 +123,7 @@ fd_sysvar_recent_hashes_update( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runti
 
   /* Set the sysvar from the encoded data */
   fd_sysvar_set( slot_ctx,
-                 fd_sysvar_owner_id.key,
+                 &fd_sysvar_owner_id,
                  &fd_sysvar_recent_block_hashes_id,
                  enc_start,
                  sz,

--- a/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
@@ -28,8 +28,8 @@ fd_sysvar_rent_read( fd_sysvar_cache_t const * sysvar_cache,
   }
 
   fd_bincode_decode_ctx_t decode = {
-    .data    = rent_rec->const_data,
-    .dataend = rent_rec->const_data + rent_rec->const_meta->dlen
+    .data    = rent_rec->vt->get_data( rent_rec ),
+    .dataend = rent_rec->vt->get_data( rent_rec ) + rent_rec->vt->get_data_len( rent_rec )
   };
 
   ulong total_sz = 0UL;
@@ -63,7 +63,7 @@ write_rent( fd_exec_slot_ctx_t * slot_ctx,
   if( fd_rent_encode( rent, &ctx ) )
     FD_LOG_ERR(("fd_rent_encode failed"));
 
-  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_rent_id, enc, sz, slot_ctx->slot_bank.slot );
+  fd_sysvar_set( slot_ctx, &fd_sysvar_owner_id, &fd_sysvar_rent_id, enc, sz, slot_ctx->slot_bank.slot );
 }
 
 void

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
@@ -25,7 +25,7 @@ static void write_slot_hashes( fd_exec_slot_ctx_t * slot_ctx, fd_slot_hashes_t *
   if( fd_slot_hashes_encode( slot_hashes, &ctx ) )
     FD_LOG_ERR(("fd_slot_hashes_encode failed"));
 
-  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_slot_hashes_id, enc, sz, slot_ctx->slot_bank.slot );
+  fd_sysvar_set( slot_ctx, &fd_sysvar_owner_id, &fd_sysvar_slot_hashes_id, enc, sz, slot_ctx->slot_bank.slot );
 }
 
 void fd_sysvar_slot_hashes_init( fd_exec_slot_ctx_t * slot_ctx, fd_slot_hashes_t * slot_hashes ) {
@@ -89,8 +89,8 @@ fd_sysvar_slot_hashes_read( fd_exec_slot_ctx_t *  slot_ctx,
     return NULL;
 
   fd_bincode_decode_ctx_t decode = {
-    .data    = rec->const_data,
-    .dataend = rec->const_data + rec->const_meta->dlen,
+    .data    = rec->vt->get_data( rec ),
+    .dataend = rec->vt->get_data( rec ) + rec->vt->get_data_len( rec )
   };
 
   ulong total_sz = 0UL;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.c
@@ -18,7 +18,7 @@ write_stake_history( fd_exec_slot_ctx_t * slot_ctx,
   if( FD_UNLIKELY( fd_stake_history_encode( stake_history, &encode )!=FD_BINCODE_SUCCESS ) )
     FD_LOG_ERR(("fd_stake_history_encode failed"));
 
-  fd_sysvar_set( slot_ctx, fd_sysvar_owner_id.key, &fd_sysvar_stake_history_id, enc, sizeof(enc), slot_ctx->slot_bank.slot );
+  fd_sysvar_set( slot_ctx, &fd_sysvar_owner_id, &fd_sysvar_stake_history_id, enc, sizeof(enc), slot_ctx->slot_bank.slot );
 }
 
 static fd_stake_history_t *
@@ -30,8 +30,8 @@ fd_sysvar_stake_history_read( fd_exec_slot_ctx_t * slot_ctx,
     return NULL;
 
   fd_bincode_decode_ctx_t ctx = {
-    .data    = stake_rec->const_data,
-    .dataend = (char *)stake_rec->const_data + stake_rec->const_meta->dlen,
+    .data    = stake_rec->vt->get_data( stake_rec),
+    .dataend = stake_rec->vt->get_data( stake_rec) + stake_rec->vt->get_data_len( stake_rec),
   };
 
   ulong total_sz = 0UL;

--- a/src/flamenco/runtime/test_txn_rw_conflicts.c
+++ b/src/flamenco/runtime/test_txn_rw_conflicts.c
@@ -126,15 +126,15 @@ void add_address_lookup_table( fd_funk_t *     funk,
   table.inner.lookup_table.meta.last_extended_slot = 0; /* this makes fd_get_active_addresses_len return 2 */
 
   fd_bincode_encode_ctx_t encode_ctx = {
-    .data    = rec->data,
-    .dataend = rec->data + FD_LOOKUP_TABLE_META_SIZE
+    .data    = rec->vt->get_data_mut( rec ),
+    .dataend = rec->vt->get_data_mut( rec ) + FD_LOOKUP_TABLE_META_SIZE
   };
   int err = fd_address_lookup_table_state_encode( &table, &encode_ctx );
   FD_TEST( err==0 );
 
-  rec->meta->dlen = rec_sz;
-  fd_memcpy( rec->meta->info.owner, fd_solana_address_lookup_table_program_id.key, sizeof(fd_pubkey_t) );
-  fd_memcpy( rec->data+FD_LOOKUP_TABLE_META_SIZE, alt_acct_data, alt_acct_data_sz );
+  rec->vt->set_data_len( rec, rec_sz );
+  rec->vt->set_owner( rec, &fd_solana_address_lookup_table_program_id );
+  fd_memcpy( rec->vt->get_data_mut( rec )+FD_LOOKUP_TABLE_META_SIZE, alt_acct_data, alt_acct_data_sz );
   fd_txn_account_mutable_fini( rec, funk, funk_txn );
   /* other metadata fields (e.g., slot, hash, ...) are ommited */
 

--- a/src/flamenco/runtime/tests/fd_dump_pb.c
+++ b/src/flamenco/runtime/tests/fd_dump_pb.c
@@ -40,21 +40,21 @@ dump_account_state( fd_txn_account_t const *    txn_account,
     fd_memcpy(output_account->address, txn_account->pubkey, sizeof(fd_pubkey_t));
 
     // Lamports
-    output_account->lamports = (uint64_t) txn_account->const_meta->info.lamports;
+    output_account->lamports = (uint64_t) txn_account->vt->get_lamports( txn_account );
 
     // Data
-    output_account->data = fd_spad_alloc( spad, alignof(pb_bytes_array_t), PB_BYTES_ARRAY_T_ALLOCSIZE( txn_account->const_meta->dlen ) );
-    output_account->data->size = (pb_size_t) txn_account->const_meta->dlen;
-    fd_memcpy(output_account->data->bytes, txn_account->const_data, txn_account->const_meta->dlen);
+    output_account->data = fd_spad_alloc( spad, alignof(pb_bytes_array_t), PB_BYTES_ARRAY_T_ALLOCSIZE( txn_account->vt->get_data_len( txn_account ) ) );
+    output_account->data->size = (pb_size_t) txn_account->vt->get_data_len( txn_account );
+    fd_memcpy(output_account->data->bytes, txn_account->vt->get_data( txn_account ), txn_account->vt->get_data_len( txn_account ) );
 
     // Executable
-    output_account->executable = (bool) txn_account->const_meta->info.executable;
+    output_account->executable = (bool) txn_account->vt->is_executable( txn_account );
 
     // Rent epoch
-    output_account->rent_epoch = (uint64_t) txn_account->const_meta->info.rent_epoch;
+    output_account->rent_epoch = (uint64_t) txn_account->vt->get_rent_epoch( txn_account );
 
     // Owner
-    fd_memcpy(output_account->owner, txn_account->const_meta->info.owner, sizeof(fd_pubkey_t));
+    fd_memcpy(output_account->owner, txn_account->vt->get_owner( txn_account ), sizeof(fd_pubkey_t));
 
     // Seed address (not present)
     output_account->has_seed_addr = false;
@@ -108,17 +108,17 @@ dump_lut_account_and_contained_accounts(  fd_exec_slot_ctx_t const *     slot_ct
   FD_TXN_ACCOUNT_DECL( alut_account );
   fd_pubkey_t const * alut_pubkey = (fd_pubkey_t const *)((uchar *)txn_payload + lookup_table->addr_off);
   uchar account_exists = dump_account_if_not_already_dumped( slot_ctx, alut_pubkey, spad, out_account_states, out_account_states_count, alut_account );
-  if( !account_exists || alut_account->const_meta->dlen<FD_LOOKUP_TABLE_META_SIZE ) {
+  if( !account_exists || alut_account->vt->get_data_len( alut_account )<FD_LOOKUP_TABLE_META_SIZE ) {
     return;
   }
 
   /* Decode the ALUT account and find its referenced writable and readonly indices */
-  if( alut_account->const_meta->dlen & 0x1fUL ) {
+  if( alut_account->vt->get_data_len( alut_account ) & 0x1fUL ) {
     return;
   }
 
-  fd_pubkey_t * lookup_addrs = (fd_pubkey_t *)&alut_account->const_data[FD_LOOKUP_TABLE_META_SIZE];
-  ulong lookup_addrs_cnt     = ( alut_account->const_meta->dlen - FD_LOOKUP_TABLE_META_SIZE ) >> 5UL; // = (dlen - 56) / 32
+  fd_pubkey_t * lookup_addrs = (fd_pubkey_t *)&alut_account->vt->get_data( alut_account )[FD_LOOKUP_TABLE_META_SIZE];
+  ulong lookup_addrs_cnt     = ( alut_account->vt->get_data_len( alut_account ) - FD_LOOKUP_TABLE_META_SIZE ) >> 5UL; // = (dlen - 56) / 32
   for( ulong i=0UL; i<lookup_addrs_cnt; i++ ) {
     fd_pubkey_t const * referenced_pubkey = &lookup_addrs[i];
     dump_account_if_not_already_dumped( slot_ctx, referenced_pubkey, spad, out_account_states, out_account_states_count, NULL );
@@ -753,10 +753,11 @@ create_txn_context_protobuf_from_txn( fd_exec_test_txn_context_t * txn_context_m
 
   // Dump executable accounts
   for( ulong i = 0; i < txn_ctx->executable_cnt; ++i ) {
-    if( !txn_ctx->executable_accounts[i].const_meta ) {
+    fd_txn_account_t * acc = &txn_ctx->executable_accounts[i];
+    if( !acc->vt->get_meta( acc ) ) {
       continue;
     }
-    dump_account_state( &txn_ctx->executable_accounts[i], &txn_context_msg->account_shared_data[txn_context_msg->account_shared_data_count++], spad );
+    dump_account_state( acc, &txn_context_msg->account_shared_data[txn_context_msg->account_shared_data_count++], spad );
   }
 
   // Dump LUT accounts

--- a/src/flamenco/stakes/fd_stakes.c
+++ b/src/flamenco/stakes/fd_stakes.c
@@ -193,8 +193,8 @@ deserialize_and_update_vote_account( fd_exec_slot_ctx_t *                slot_ct
 
   // Deserialize the vote account and ensure its in the correct state
   fd_bincode_decode_ctx_t decode = {
-    .data    = vote_account->const_data,
-    .dataend = vote_account->const_data + vote_account->const_meta->dlen,
+    .data    = vote_account->vt->get_data( vote_account ),
+    .dataend = vote_account->vt->get_data( vote_account ) + vote_account->vt->get_data_len( vote_account ),
   };
 
   ulong total_sz = 0UL;
@@ -472,7 +472,7 @@ accumulate_stake_cache_delegations( fd_delegation_pair_t_mapnode_t * *      dele
                                                        &n->elem.account,
                                                        slot_ctx->funk,
                                                        slot_ctx->funk_txn );
-      if( FD_UNLIKELY( rc!=FD_ACC_MGR_SUCCESS || acc->const_meta->info.lamports==0UL ) ) {
+      if( FD_UNLIKELY( rc!=FD_ACC_MGR_SUCCESS || acc->vt->get_lamports( acc )==0UL ) ) {
         continue;
       }
 
@@ -607,7 +607,7 @@ fd_accumulate_stake_infos( fd_exec_slot_ctx_t const * slot_ctx,
        n = fd_account_keys_pair_t_map_successor( slot_ctx->slot_bank.stake_account_keys.account_keys_pool, n ) ) {
     FD_TXN_ACCOUNT_DECL( acc );
     int rc = fd_txn_account_init_from_funk_readonly(acc, &n->elem.key, slot_ctx->funk, slot_ctx->funk_txn );
-    if( FD_UNLIKELY( rc!=FD_ACC_MGR_SUCCESS || acc->const_meta->info.lamports==0UL ) ) {
+    if( FD_UNLIKELY( rc!=FD_ACC_MGR_SUCCESS || acc->vt->get_lamports( acc )==0UL ) ) {
       continue;
     }
 
@@ -712,8 +712,8 @@ write_stake_state( fd_txn_account_t *    stake_acc_rec,
   ulong encoded_stake_state_size = fd_stake_state_v2_size(stake_state);
 
   fd_bincode_encode_ctx_t ctx = {
-    .data = stake_acc_rec->data,
-    .dataend = stake_acc_rec->data + encoded_stake_state_size,
+    .data    = stake_acc_rec->vt->get_data_mut( stake_acc_rec ),
+    .dataend = stake_acc_rec->vt->get_data_mut( stake_acc_rec ) + encoded_stake_state_size,
   };
   if( FD_UNLIKELY( fd_stake_state_v2_encode( stake_state, &ctx ) != FD_BINCODE_SUCCESS ) ) {
     FD_LOG_ERR(( "fd_stake_state_encode failed" ));

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
@@ -153,12 +153,12 @@ VM_SYCALL_CPI_UPDATE_CALLEE_ACC_FUNC( fd_vm_t *                          vm,
     return FD_VM_SUCCESS;
   }
 
-  if( FD_UNLIKELY( !callee_acc.acct->meta ) ) {
+  if( FD_UNLIKELY( !fd_borrowed_account_is_mutable( &callee_acc ) ) ) {
     /* If the account is not modifiable, we can't change it (and it can't have been changed by the callee) */
     return FD_VM_SUCCESS;
   }
 
-  if( callee_acc.acct->meta->info.lamports!=*(caller_account->lamports) ) {
+  if( fd_borrowed_account_get_lamports( &callee_acc )!=*(caller_account->lamports) ) {
     err = fd_borrowed_account_set_lamports( &callee_acc, *(caller_account->lamports) );
     if( FD_UNLIKELY( err ) ) {
       FD_VM_ERR_FOR_LOG_INSTR( vm, err );
@@ -181,8 +181,8 @@ VM_SYCALL_CPI_UPDATE_CALLEE_ACC_FUNC( fd_vm_t *                          vm,
         FD_VM_ERR_FOR_LOG_INSTR( vm, err );
         return -1;
       }
-    } else if( FD_UNLIKELY( caller_account->serialized_data_len!=callee_acc.acct->const_meta->dlen ||
-                            memcmp( callee_acc.acct->const_data, caller_account->serialized_data, caller_account->serialized_data_len ) ) ) {
+    } else if( FD_UNLIKELY( caller_account->serialized_data_len!=fd_borrowed_account_get_data_len( &callee_acc ) ||
+                            memcmp( fd_borrowed_account_get_data( &callee_acc ), caller_account->serialized_data, caller_account->serialized_data_len ) ) ) {
       FD_VM_ERR_FOR_LOG_INSTR( vm, err );
       return -1;
     }
@@ -190,7 +190,7 @@ VM_SYCALL_CPI_UPDATE_CALLEE_ACC_FUNC( fd_vm_t *                          vm,
   } else { /* Direct mapping enabled */
     ulong * ref_to_len = FD_VM_MEM_HADDR_ST( vm, caller_account->ref_to_len_in_vm.vaddr, alignof(ulong), sizeof(ulong) );
     ulong   orig_len   = caller_account->orig_data_len;
-    ulong   prev_len   = callee_acc.acct->const_meta->dlen;
+    ulong   prev_len   = fd_borrowed_account_get_data_len( &callee_acc );
     ulong   post_len   = *ref_to_len;
 
     int err;
@@ -238,7 +238,7 @@ VM_SYCALL_CPI_UPDATE_CALLEE_ACC_FUNC( fd_vm_t *                          vm,
     }
   }
 
-  if( FD_UNLIKELY( memcmp( callee_acc.acct->meta->info.owner, caller_account->owner, sizeof(fd_pubkey_t) ) ) ) {
+  if( FD_UNLIKELY( memcmp( fd_borrowed_account_get_owner( &callee_acc ), caller_account->owner, sizeof(fd_pubkey_t) ) ) ) {
     err = fd_borrowed_account_set_owner( &callee_acc, caller_account->owner );
     if( FD_UNLIKELY( err ) ) {
       FD_VM_ERR_FOR_LOG_INSTR( vm, err );
@@ -303,7 +303,7 @@ VM_SYSCALL_CPI_TRANSLATE_AND_UPDATE_ACCOUNTS_FUNC(
     FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( vm->instr_ctx, instruction_accounts[i].index_in_caller, &callee_acct );
 
     fd_pubkey_t const *       account_key = callee_acct.acct->pubkey;
-    fd_account_meta_t const * acc_meta    = callee_acct.acct->const_meta;
+    fd_account_meta_t const * acc_meta    = fd_borrowed_account_get_acc_meta( &callee_acct );
 
     /* If the account is known and executable, we only need to consume the compute units.
        Executable accounts can't be modified, so we don't need to update the callee account. */
@@ -560,17 +560,17 @@ VM_SYSCALL_CPI_UPDATE_CALLER_ACC_FUNC( fd_vm_t *                          vm,
 
     fd_txn_account_t * callee_acc = borrowed_callee_acc.acct;
     /* Update the caller account lamports with the value from the callee */
-    *(caller_account->lamports) = callee_acc->const_meta->info.lamports;
+    *(caller_account->lamports) = callee_acc->vt->get_lamports( callee_acc );
 
     /* Update the caller account owner with the value from the callee */
-    uchar const * updated_owner = callee_acc->const_meta->info.owner;
+    fd_pubkey_t const * updated_owner = callee_acc->vt->get_owner( callee_acc );
     if( updated_owner ) fd_memcpy( caller_account->owner, updated_owner, sizeof(fd_pubkey_t) );
     else                fd_memset( caller_account->owner, 0,             sizeof(fd_pubkey_t) );
 
     /* Update the caller account data with the value from the callee */
     VM_SYSCALL_CPI_ACC_INFO_DATA( vm, caller_acc_info, caller_acc_data );
 
-    ulong const updated_data_len = callee_acc->const_meta->dlen;
+    ulong const updated_data_len = callee_acc->vt->get_data_len( callee_acc );
     if( !updated_data_len ) fd_memset( (void*)caller_acc_data, 0, caller_acc_data_len );
 
     if( caller_acc_data_len != updated_data_len ) {
@@ -601,7 +601,7 @@ VM_SYSCALL_CPI_UPDATE_CALLER_ACC_FUNC( fd_vm_t *                          vm,
         https://github.com/solana-labs/solana/blob/2afde1b028ed4593da5b6c735729d8994c4bfac6/programs/bpf_loader/src/syscalls/cpi.rs#L1534 */
     }
 
-    fd_memcpy( caller_acc_data, callee_acc->const_data, updated_data_len );
+    fd_memcpy( caller_acc_data, callee_acc->vt->get_data( callee_acc ), updated_data_len );
   } else { /* Direct mapping enabled */
 
     /* Look up the borrowed account from the instruction context, which will
@@ -617,10 +617,10 @@ VM_SYSCALL_CPI_UPDATE_CALLER_ACC_FUNC( fd_vm_t *                          vm,
     fd_txn_account_t * callee_acc = borrowed_callee_acc.acct;
 
     /* Update the caller account lamports with the value from the callee */
-    *(caller_account->lamports) = callee_acc->const_meta->info.lamports;
+    *(caller_account->lamports) = callee_acc->vt->get_lamports( callee_acc );
 
     /* Update the caller account owner with the value from the callee */
-    uchar const * updated_owner = callee_acc->const_meta->info.owner;
+    fd_pubkey_t const * updated_owner = callee_acc->vt->get_owner( callee_acc );
     if( updated_owner ) {
       fd_memcpy( caller_account->owner, updated_owner, sizeof(fd_pubkey_t) );
     } else {
@@ -636,26 +636,26 @@ VM_SYSCALL_CPI_UPDATE_CALLER_ACC_FUNC( fd_vm_t *                          vm,
 
     uchar zero_all_mapped_spare_capacity = 0;
     /* This case can only be triggered if the original length is more than 0 */
-    if( callee_acc->const_meta->dlen < original_len ) {
-      ulong new_len = callee_acc->const_meta->dlen;
+    if( callee_acc->vt->get_data_len( callee_acc ) < original_len ) {
+      ulong new_len = callee_acc->vt->get_data_len( callee_acc );
       /* Allocate into the buffer to make sure that the original data len
          is still valid but don't change the dlen. Zero out the rest of the
          memory which is not used. */
-      fd_txn_account_resize( callee_acc, original_len );
-      callee_acc->meta->dlen = new_len;
+      callee_acc->vt->resize( callee_acc, original_len );
+      callee_acc->vt->set_data_len( callee_acc, new_len );
       zero_all_mapped_spare_capacity = 1;
     }
 
     /* Update the account data region if an account data region exists. We
        know that one exists iff the original len was non-zero. */
     ulong acc_region_idx = vm->acc_region_metas[instr_acc_idx].region_idx;
-    if( original_len && vm->input_mem_regions[ acc_region_idx ].haddr!=(ulong)callee_acc->data ) {
-      vm->input_mem_regions[ acc_region_idx ].haddr = (ulong)callee_acc->data;
+    if( original_len && vm->input_mem_regions[ acc_region_idx ].haddr!=(ulong)callee_acc->vt->get_data_mut( callee_acc ) ) {
+      vm->input_mem_regions[ acc_region_idx ].haddr = (ulong)callee_acc->vt->get_data_mut( callee_acc );
       zero_all_mapped_spare_capacity = 1;
     }
 
     ulong prev_len = caller_acc_data_len;
-    ulong post_len = callee_acc->const_meta->dlen;
+    ulong post_len = callee_acc->vt->get_data_len( callee_acc );
 
     /* Do additional handling in the case where the data size has changed in
        the course of the callee's CPI. */
@@ -699,8 +699,8 @@ VM_SYSCALL_CPI_UPDATE_CALLER_ACC_FUNC( fd_vm_t *                          vm,
        prev_len > post_len, then dlen should be equal to original_len. */
     ulong spare_len = fd_ulong_sat_sub( fd_ulong_if( zero_all_mapped_spare_capacity, original_len, prev_len ), post_len );
     if( FD_UNLIKELY( spare_len ) ) {
-      if( callee_acc->const_meta->dlen>spare_len ) {
-        memset( callee_acc->data+callee_acc->const_meta->dlen-spare_len, 0, spare_len );
+      if( callee_acc->vt->get_data_len( callee_acc )>spare_len ) {
+        memset( callee_acc->vt->get_data_mut( callee_acc ) + callee_acc->vt->get_data_len( callee_acc ) - spare_len, 0, spare_len );
       }
     }
 
@@ -714,7 +714,7 @@ VM_SYSCALL_CPI_UPDATE_CALLER_ACC_FUNC( fd_vm_t *                          vm,
         resizing_idx++;
       }
       uchar * to_slice   = (uchar*)vm->input_mem_regions[ resizing_idx ].haddr;
-      uchar * from_slice = callee_acc->data + original_len;
+      uchar * from_slice = callee_acc->vt->get_data_mut( callee_acc ) + original_len;
 
       fd_memcpy( to_slice, from_slice, realloc_bytes_used );
     }

--- a/src/flamenco/vm/syscall/fd_vm_syscall_runtime.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_runtime.c
@@ -246,8 +246,8 @@ fd_vm_syscall_sol_get_sysvar( /**/            void *  _vm,
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.0/programs/bpf_loader/src/syscalls/sysvar.rs#L223-L228
      Note the length check is at the very end to fail after performing sufficient checks. */
-  const uchar * sysvar_buf     = sysvar_account->const_data;
-  ulong         sysvar_buf_len = sysvar_account->const_meta->dlen;
+  const uchar * sysvar_buf     = sysvar_account->vt->get_data( sysvar_account );
+  ulong         sysvar_buf_len = sysvar_account->vt->get_data_len( sysvar_account );
 
   if( FD_UNLIKELY( offset_length>sysvar_buf_len ) ) {
     *_ret = 1UL;


### PR DESCRIPTION
Hides internal private state of `fd_txn_account_t`, specifically the `const_meta`, `meta`, `const_data`, `data`, `const_rec`, `rec`, `recnt_excl`, and `meta/data gaddr` fields. Makes these fields accessble through function pointer tables to control access based on whether the account is mutable or readonly.

Agave uses a similar readable/writable account API implementation here: https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/account/src/lib.rs#L188