### PR TITLE
flamenco: fix bpf loader new authority key err mismatch

### DIFF
--- a/contrib/test/test-vectors-fixtures/instr-fixtures/bpf-loader-v3.list
+++ b/contrib/test/test-vectors-fixtures/instr-fixtures/bpf-loader-v3.list
@@ -39,3 +39,4 @@ dump/test-vectors/instr/fixtures/bpf-loader-v3/eb7e3f6e34370904d9b548ba01f0c31de
 dump/test-vectors/instr/fixtures/bpf-loader-v3/ebb6121c4fda5aa97797f7c64cde7b3512988c68_2107873.fix
 dump/test-vectors/instr/fixtures/bpf-loader-v3/ee793211a0e0a229c8c46d38e7602b4996472c3b_2107012.fix
 dump/test-vectors/instr/fixtures/bpf-loader-v3/f342d13bfc80d3157b8cb2db667554f0afc5c084_2106693.fix
+dump/test-vectors/instr/fixtures/bpf-loader-v3/563de3c9f47a55ba8869987836ee0a62d009a144_2867406.fix

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -1413,12 +1413,10 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
         return err;
       }
 
-      /* https://github.com/anza-xyz/agave/blob/v2.1.14/programs/bpf_loader/src/lib.rs#L901-L906 */
+      /* Don't check the error here because the new_authority key is allowed to be NULL until further checks.
+         https://github.com/anza-xyz/agave/blob/v2.1.14/programs/bpf_loader/src/lib.rs#L901-L906 */
       fd_pubkey_t const * new_authority = NULL;
-      err = fd_exec_instr_ctx_get_key_of_account_at_index( instr_ctx, 2UL, &new_authority );
-      if( FD_UNLIKELY( err ) ) {
-        return err;
-      }
+      fd_exec_instr_ctx_get_key_of_account_at_index( instr_ctx, 2UL, &new_authority );
 
       fd_bpf_upgradeable_loader_state_t * account_state = fd_bpf_loader_program_get_state( account.acct,
                                                                                            spad,


### PR DESCRIPTION
Agave did not error out immediately when obtaining the new authority key while we were returning the error. See https://github.com/anza-xyz/agave/blob/v2.1.14/programs/bpf_loader/src/lib.rs#L901-L906