### PR TITLE
feat: add release workflows

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -28,6 +28,10 @@ on:
         type: boolean
         description: Run arm builds
         default: false
+      save_artifacts:
+        type: boolean
+        description: Upload binaries as artifacts
+        default: false
       dry_run:
         type: boolean
         description: Print build matrix and exit
@@ -65,6 +69,10 @@ on:
       build_arm:
         type: boolean
         description: Run arm builds
+        default: false
+      save_artifacts:
+        type: boolean
+        description: Upload binaries as artifacts
         default: false
       dry_run:
         type: boolean
@@ -129,6 +137,20 @@ jobs:
         run: |
           contrib/build.sh --no-rust --no-clang ${{ env.BUILD_ARGS }}
 
+      - name: Locate bin directory
+        id: locate_bin
+        run: |
+          bin_dir=$(find build -type d -name bin | head -n1)
+          echo "bin_dir=$bin_dir" | tee -a $GITHUB_OUTPUT
+
+      - name: Upload binaries as artifacts
+        if: ${{ inputs.save_artifacts }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-binaries
+          path: ${{ steps.locate_bin.outputs.bin_dir }}/*
+          retention-days: 1
+
   build_clang:
     runs-on: 512G
     if: ${{ inputs.clang != 'none' }}
@@ -175,6 +197,20 @@ jobs:
       - name: Run clang builds
         run: |
           contrib/build.sh --no-rust --no-gcc ${{ env.BUILD_ARGS }}
+
+      - name: Locate bin directory
+        id: locate_bin
+        run: |
+          bin_dir=$(find build -type d -name bin | head -n1)
+          echo "bin_dir=$bin_dir" | tee -a $GITHUB_OUTPUT
+
+      - name: Upload binaries as artifacts
+        if: ${{ inputs.save_artifacts }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-binaries
+          path: ${{ steps.locate_bin.outputs.bin_dir }}/*
+          retention-days: 1
 
   build_arm:
     runs-on: ARM64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,149 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+    uses: ./.github/workflows/builds.yml
+    with:
+        # compiler,machine,target
+      gcc_exceptions: |
+        gcc-11.4.0,linux_gcc_x86_64,ALL;
+      verbose: false
+      build_arm: false
+      save_artifacts: true
+
+  package:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-binaries
+          path: binaries
+
+      - name: Package binaries into a .deb
+        run: |
+          set -e
+
+          version=$(git describe --tags --always --dirty | sed 's/^v//')
+          echo "Packaging version: $version"
+
+          mkdir -p deb_package/DEBIAN
+          mkdir -p deb_package/usr/local/bin
+
+          cp binaries/* deb_package/usr/local/bin/
+
+          cat <<EOF > deb_package/DEBIAN/control
+          Package: firedancer-tools
+          Version: ${version}
+          Section: net
+          Priority: optional
+          Architecture: amd64
+          Maintainer: Dev Team <dev@example.com>
+          Depends: libc6 (>= 2.27), libstdc++6 (>= 9), libgcc-s1 (>= 4.2)
+          Description: Firedancer client tools for the Solana blockchain.
+            Includes firedancer binaries such as fdctl and solana.
+          EOF
+
+          dpkg-deb --build deb_package
+          mv deb_package.deb firedancer-tools_x86_64.deb
+
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-deb
+          path: firedancer-tools_x86_64.deb
+          retention-days: 7
+
+  create-release:
+    needs: package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download .deb artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-deb
+          path: dist
+
+      - name: Create GitHub release with changelog
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          generate_release_notes: true
+          prerelease: true
+          files: dist/firedancer-tools_x86_64.deb
+
+  bump-version:
+    runs-on: ubuntu-latest
+    needs: create-release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Parse current version, bump patch, and get Solana version
+        id: parse_info
+        run: |
+          version=${{ github.ref_name }}
+          version="${version#v}"
+
+          minor_patch=$(echo "$version" | cut -d'.' -f2)
+          solana_version=$(echo "$version" | cut -d'.' -f3)
+
+          prev_minor=$((minor_patch / 100))
+          prev_patch=$((minor_patch % 100))
+
+          new_patch=$((prev_patch + 1))
+          patch_padded=$(printf "%02d" "$new_patch")
+          new_minor_patch="${prev_minor}${patch_padded}"
+
+          version_string="v0.${new_minor_patch}.${solana_version}"
+          branch_name="version-bump-${version_string}"
+          target_branch="v0.${prev_minor}"
+
+          echo "version_string=$version_string" | tee -a $GITHUB_OUTPUT
+          echo "branch_name=$branch_name" | tee -a $GITHUB_OUTPUT
+          echo "target_branch=$target_branch" | tee -a $GITHUB_OUTPUT
+
+      - name: Create branch and bump version
+        run: |
+          git checkout -b ${{ steps.parse_info.outputs.branch_name }}
+          ./contrib/bump-version.sh patch
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git commit -am "Bump version to ${{ steps.parse_info.outputs.version_string }}"
+          git push origin ${{ steps.parse_info.outputs.branch_name }}
+
+      - name: Create Pull Request
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Bump version to ${{ steps.parse_info.outputs.version_string }}',
+              head: '${{ steps.parse_info.outputs.branch_name }}',
+              base: '${{ steps.parse_info.outputs.target_branch }}'
+            })

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ join this cluster with other validators, you can define
 `[rpc.entrypoints]` in the configuration file to point at your first
 validator and run `fddev dev` again.
 
+## Installation prebuilt (Debian/Ubuntu)
+
+You can install prebuilt `firedancer-tools` packages for `linux_x86_64` using a `.deb` release from [GitHub Releases](https://github.com/firedancer-io/firedancer/releases):
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/firedancer-io/firedancer/main/install_firedancer.sh | bash -s <VERSION>
+```
+
 ## License
 Firedancer is available under the [Apache 2
 license](https://www.apache.org/licenses/LICENSE-2.0). Firedancer also

--- a/contrib/bump-version.sh
+++ b/contrib/bump-version.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION_MK="src/app/fdctl/version.mk"
+
+usage() {
+  echo "Usage: $0 [major|minor|patch]"
+  exit 1
+}
+
+bump_type="${1:-patch}"
+
+read_versions() {
+  VERSION_MAJOR=$(awk -F ':=' '/^VERSION_MAJOR/ { print $2 }' "$VERSION_MK" | xargs)
+  VERSION_MINOR=$(awk -F ':=' '/^VERSION_MINOR/ { print $2 }' "$VERSION_MK" | xargs)
+  VERSION_PATCH=$(awk -F ':=' '/^VERSION_PATCH/ { print $2 }' "$VERSION_MK" | xargs)
+
+  if [[ -z "$VERSION_MAJOR" || -z "$VERSION_MINOR" || -z "$VERSION_PATCH" ]]; then
+    echo "Error: Could not read version.mk properly"
+    exit 1
+  fi
+}
+
+bump_version() {
+  case "$bump_type" in
+    major)
+      VERSION_MAJOR=$((VERSION_MAJOR + 1))
+      VERSION_MINOR=0
+      VERSION_PATCH=0
+      ;;
+    minor)
+      VERSION_MINOR=$((VERSION_MINOR + 1))
+      VERSION_PATCH=0
+      ;;
+    patch)
+      VERSION_PATCH=$((VERSION_PATCH + 1))
+      ;;
+    *)
+      echo "Unknown bump type: $bump_type"
+      usage
+      ;;
+  esac
+}
+
+write_version_mk() {
+  {
+    echo "VERSION_MAJOR := $VERSION_MAJOR"
+    echo "VERSION_MINOR := $VERSION_MINOR"
+    echo "VERSION_PATCH := $VERSION_PATCH"
+  } > "$VERSION_MK"
+}
+
+main() {
+  read_versions
+  bump_version
+  write_version_mk
+
+  echo "Bumped version to: $VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH"
+}
+
+main

--- a/install_firedancer.sh
+++ b/install_firedancer.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <version>"
+  echo "Example: $0 0.410.20113"
+  exit 1
+fi
+
+VERSION="$1"
+TAG="v$VERSION"
+OWNER="firedancer-io"
+REPO="firedancer"
+DEB_NAME="firedancer-tools_x86_64.deb"
+URL="https://github.com/${OWNER}/${REPO}/releases/download/${TAG}/${DEB_NAME}"
+
+TMP_DIR=$(mktemp -d)
+DEB_PATH="${TMP_DIR}/${DEB_NAME}"
+
+echo "📥 Downloading .deb from: $URL"
+curl -sSLf -o "${DEB_PATH}" "$URL"
+
+echo "📦 Installing $DEB_NAME"
+sudo dpkg -i "${DEB_PATH}"
+
+echo "✅ Firedancer tools v$VERSION installed successfully!"


### PR DESCRIPTION
This PR introduces the following improvements to the release workflow:

💻 Single-command installation support:

- You can now install the latest released Firedancer tools with just one line:

`curl -sSfL https://raw.githubusercontent.com/firedancer-io/firedancer/main/install-fdctl.sh | bash -s <VERSION>`

✅ Reusable save_artifacts flag added to allow optional uploading of binaries as artifacts from builds.

📦 .deb packages are now generated for linux_x86_64 builds.

🚀 Tag-based release publishing is enabled via push.tags (v*).

🧱 Automatic version bump after release:

- Parses current version from tag.
- Bumps patch version.
- Creates a new branch and pull request targeting the appropriate base version (e.g., v0.3).

🧪 Tested locally in repo:
🔗 https://github.com/KVolodin/test_ci

⚠️ Notes:
To make full use of this workflow, make sure the GITHUB_TOKEN used by Actions has contents: write and pull-requests: write permissions. This is required to: