### PR TITLE
version: fix missing version numbers

### DIFF
--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -72,28 +72,28 @@ cargo-plugin-bundle:
     cd ./plugin/bundle && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS)" ./cargo build --release --lib -p firedancer-plugin-bundle
 cargo-validator:
 	cd ./agave && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS)" ./cargo build --release --lib -p agave-validator
-cargo-solana:
-	cd ./agave && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS)" ./cargo build --release --bin solana
-cargo-ledger-tool:
-	cd ./agave && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS)" ./cargo build --release --bin agave-ledger-tool
+cargo-solana: $(OBJDIR)/lib/libfdctl_version.a
+	cd ./agave && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS) -L $(realpath $(OBJDIR)/lib) -l fdctl_version" ./cargo build --release --bin solana
+cargo-ledger-tool: $(OBJDIR)/lib/libfdctl_version.a
+	cd ./agave && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS) -L $(realpath $(OBJDIR)/lib) -l fdctl_version" ./cargo build --release --bin agave-ledger-tool
 else ifeq ($(RUST_PROFILE),release-with-debug)
 cargo-plugin-bundle:
 	cd ./plugin/bundle && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS)" ../../agave/cargo build --profile=release-with-debug --lib -p firedancer-plugin-bundle
 cargo-validator:
 	cd ./agave && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS)" ./cargo build --profile=release-with-debug --lib -p agave-validator
-cargo-solana:
-	cd ./agave && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS)" ./cargo build --profile=release-with-debug --bin solana
-cargo-ledger-tool:
-	cd ./agave && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS)" ./cargo build --profile=release-with-debug --bin agave-ledger-tool
+cargo-solana: $(OBJDIR)/lib/libfdctl_version.a
+	cd ./agave && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS) -L $(realpath $(OBJDIR)/lib) -l fdctl_version" ./cargo build --profile=release-with-debug --bin solana
+cargo-ledger-tool: $(OBJDIR)/lib/libfdctl_version.a
+	cd ./agave && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS) -L $(realpath $(OBJDIR)/lib) -l fdctl_version" ./cargo build --profile=release-with-debug --bin agave-ledger-tool
 else
 cargo-plugin-bundle:
     cd ./plugin/bundle && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS)" ./cargo build --lib -p firedancer-plugin-bundle
 cargo-validator:
 	cd ./agave && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS)" ./cargo build --lib -p agave-validator
-cargo-solana:
-	cd ./agave && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS)" ./cargo build --bin solana
-cargo-ledger-tool:
-	cd ./agave && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS)" ./cargo build --bin agave-ledger-tool
+cargo-solana: $(OBJDIR)/lib/libfdctl_version.a
+	cd ./agave && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS) -L $(realpath $(OBJDIR)/lib) -l fdctl_version" ./cargo build --bin solana
+cargo-ledger-tool: $(OBJDIR)/lib/libfdctl_version.a
+	cd ./agave && env --unset=LDFLAGS RUSTFLAGS="$(RUSTFLAGS) -L $(realpath $(OBJDIR)/lib) -l fdctl_version" ./cargo build --bin agave-ledger-tool
 endif
 
 # We sleep as a workaround for a bizarre problem where the build system

--- a/src/app/fdctl/version.c
+++ b/src/app/fdctl/version.c
@@ -15,5 +15,5 @@ ulong const fdctl_major_version     = FDCTL_MAJOR_VERSION;
 ulong const fdctl_minor_version     = FDCTL_MINOR_VERSION;
 ulong const fdctl_patch_version     = FDCTL_PATCH_VERSION;
 uint  const fdctl_commit_ref        = FDCTL_COMMIT_REF_U32;
-char  const fdctl_commit_ref_string[] = FD_EXPAND_THEN_STRINGIFY(FDCTL_COMMIT_REF_CSTR);
+char  const fdctl_commit_ref_string[] = FDCTL_COMMIT_REF_CSTR;
 char  const fdctl_version_string[]  = FD_EXPAND_THEN_STRINGIFY(FDCTL_MAJOR_VERSION) "." FD_EXPAND_THEN_STRINGIFY(FDCTL_MINOR_VERSION) "." FD_EXPAND_THEN_STRINGIFY(FDCTL_PATCH_VERSION);

--- a/src/app/firedancer/version.c
+++ b/src/app/firedancer/version.c
@@ -15,9 +15,9 @@ ulong const firedancer_major_version     = FIREDANCER_MAJOR_VERSION;
 ulong const firedancer_minor_version     = FIREDANCER_MINOR_VERSION;
 ulong const firedancer_patch_version     = FIREDANCER_PATCH_VERSION;
 uint  const firedancer_commit_ref        = FIREDANCER_COMMIT_REF_U32;
-char  const firedancer_commit_ref_string[] = FD_EXPAND_THEN_STRINGIFY(FIREDANCER_COMMIT_REF_CSTR);
+char  const firedancer_commit_ref_string[] = FIREDANCER_COMMIT_REF_CSTR;
 char  const firedancer_version_string[]  = FD_EXPAND_THEN_STRINGIFY(FIREDANCER_MAJOR_VERSION) "." FD_EXPAND_THEN_STRINGIFY(FIREDANCER_MINOR_VERSION) "." FD_EXPAND_THEN_STRINGIFY(FIREDANCER_PATCH_VERSION);
 
 // Some shared code assumes the fdctl version numbers, just replace them
-char  const fdctl_commit_ref_string[] = FD_EXPAND_THEN_STRINGIFY(FIREDANCER_COMMIT_REF_CSTR);
+char  const fdctl_commit_ref_string[] = FIREDANCER_COMMIT_REF_CSTR;
 char  const fdctl_version_string[]  = FD_EXPAND_THEN_STRINGIFY(FIREDANCER_MAJOR_VERSION) "." FD_EXPAND_THEN_STRINGIFY(FIREDANCER_MINOR_VERSION) "." FD_EXPAND_THEN_STRINGIFY(FIREDANCER_PATCH_VERSION);

--- a/src/disco/gui/fd_gui_printf.c
+++ b/src/disco/gui/fd_gui_printf.c
@@ -8,7 +8,16 @@
 
 #include "../../ballet/http/fd_http_server_private.h"
 #include "../../ballet/utf8/fd_utf8.h"
+
+#ifdef __has_include
+#if __has_include("../../app/fdctl/version.h")
 #include "../../app/fdctl/version.h"
+#endif
+#endif
+
+#ifndef FDCTL_COMMIT_REF_CSTR
+#define FDCTL_COMMIT_REF_CSTR "0000000000000000000000000000000000000000"
+#endif
 
 static void
 jsonp_strip_trailing_comma( fd_gui_t * gui ) {
@@ -196,11 +205,7 @@ fd_gui_printf_cluster( fd_gui_t * gui ) {
 void
 fd_gui_printf_commit_hash( fd_gui_t * gui ) {
   jsonp_open_envelope( gui, "summary", "commit_hash" );
-#ifdef FDCTL_COMMIT_REF_CSTR
-    jsonp_string( gui, "value", FD_EXPAND_THEN_STRINGIFY(FDCTL_COMMIT_REF_CSTR) );
-#else
-    jsonp_string( gui, "value", "0000000000000000000000000000000000000000" );
-#endif
+    jsonp_string( gui, "value", FDCTL_COMMIT_REF_CSTR );
   jsonp_close_envelope( gui );
 }
 

--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -19,15 +19,6 @@
 
 #endif //__cplusplus
 
-/* Versioning macros **************************************************/
-
-/* FD_VERSION_{MAJOR,MINOR,PATCH} programmatically specify the
-   firedancer version. */
-
-#define FD_VERSION_MAJOR (0)
-#define FD_VERSION_MINOR (0)
-#define FD_VERSION_PATCH (0)
-
 /* Build target capabilities ******************************************/
 
 /* Different build targets often have different levels of support for

--- a/src/util/log/fd_log.c
+++ b/src/util/log/fd_log.c
@@ -47,6 +47,22 @@
 
 #include "../tile/fd_tile_private.h"
 
+#ifdef __has_include
+#if __has_include("../../app/fdctl/version.h")
+#include "../../app/fdctl/version.h"
+#endif
+#endif
+
+#ifndef FDCTL_MAJOR_VERSION
+#define FDCTL_MAJOR_VERSION 0
+#endif
+#ifndef FDCTL_MINOR_VERSION
+#define FDCTL_MINOR_VERSION 0
+#endif
+#ifndef FDCTL_PATCH_VERSION
+#define FDCTL_PATCH_VERSION 0
+#endif
+
 #ifdef FD_BUILD_INFO
 FD_IMPORT_CSTR( fd_log_build_info, FD_BUILD_INFO );
 #else
@@ -1027,7 +1043,7 @@ fd_log_private_open_path( int          cmdline,
     fd_log_wallclock_cstr( fd_log_wallclock(), tag );
     for( ulong b=0UL; tag[b]; b++ ) if( tag[b]==' ' || tag[b]=='-' || tag[b]=='.' || tag[b]==':' ) tag[b] = '_';
     ulong len; fd_cstr_printf( fd_log_private_path, 1024UL, &len, "/tmp/fd-%i.%i.%i_%lu_%s_%s_%s",
-                              FD_VERSION_MAJOR, FD_VERSION_MINOR, FD_VERSION_PATCH,
+                              FDCTL_MAJOR_VERSION, FDCTL_MINOR_VERSION, FDCTL_PATCH_VERSION,
                               fd_log_group_id(), fd_log_user(), fd_log_host(), tag );
     if( len==1023UL ) { fd_log_private_fprintf_0( STDERR_FILENO, "default log path too long; unable to boot\n" ); exit(1); }
   }


### PR DESCRIPTION
- display correct version number when compiling agave cli tools like `solana`
- use correct version number for default log file directory

agave [diff](https://github.com/firedancer-io/agave/compare/876929e4775880f3f10bd71c1a823d01e3f5c2ab..jherrera/fix-cli-versions~3)