### PR TITLE
pack, bank: cu improvements

### DIFF
--- a/src/disco/pack/fd_pack_cost.h
+++ b/src/disco/pack/fd_pack_cost.h
@@ -277,12 +277,12 @@ fd_pack_compute_cost( fd_txn_t const * txn,
 
   non_builtin_cnt = fd_ulong_min( non_builtin_cnt, FD_COMPUTE_BUDGET_MAX_CU_LIMIT/FD_COMPUTE_BUDGET_DEFAULT_INSTR_CU_LIMIT );
 
-  ulong non_builtin_cost = fd_ulong_if( (cbp->flags & FD_COMPUTE_BUDGET_PROGRAM_FLAG_SET_CU) && (non_builtin_cnt>0UL),
-                                        (ulong)*compute,
-                                        non_builtin_cnt*FD_COMPUTE_BUDGET_DEFAULT_INSTR_CU_LIMIT
-                                       ); /* <= FD_COMPUTE_BUDGET_MAX_CU_LIMIT */
+  ulong execution_cost = fd_ulong_if( (cbp->flags & FD_COMPUTE_BUDGET_PROGRAM_FLAG_SET_CU) && (non_builtin_cnt>0UL),
+                                      (ulong)*compute,
+                                      builtin_cost + non_builtin_cnt*FD_COMPUTE_BUDGET_DEFAULT_INSTR_CU_LIMIT
+                                    ); /* <= FD_COMPUTE_BUDGET_MAX_CU_LIMIT */
 
-  fd_ulong_store_if( !!opt_execution_cost,            opt_execution_cost,            builtin_cost + non_builtin_cost );
+  fd_ulong_store_if( !!opt_execution_cost,            opt_execution_cost,            execution_cost                );
   fd_ulong_store_if( !!opt_fee,                       opt_fee,                       *fee                          );
   fd_ulong_store_if( !!opt_precompile_sig_cnt,        opt_precompile_sig_cnt,        precompile_sig_cnt            );
   fd_ulong_store_if( !!opt_loaded_accounts_data_cost, opt_loaded_accounts_data_cost, *loaded_account_data_cost     );
@@ -294,7 +294,7 @@ fd_pack_compute_cost( fd_txn_t const * txn,
 #endif
 
   /* <= FD_PACK_MAX_COST, so no overflow concerns */
-  return signature_cost + writable_cost + builtin_cost + instr_data_cost + non_builtin_cost + *loaded_account_data_cost;
+  return signature_cost + writable_cost + execution_cost + instr_data_cost + *loaded_account_data_cost;
 }
 #undef MAP_PERFECT_HASH_PP
 #undef PERFECT_HASH

--- a/src/discoh/bank/fd_bank_tile.c
+++ b/src/discoh/bank/fd_bank_tile.c
@@ -271,14 +271,11 @@ handle_microblock( fd_bank_ctx_t *     ctx,
        loading stage. ... todo ... enforce this check after SIMD-170
        is released. */
     if( FD_UNLIKELY( actual_execution_cus+actual_acct_data_cus > requested_exec_plus_acct_data_cus ) ) {
-      FD_LOG_DEBUG(( "Actual CUs unexpectedly exceeded requested amount. actual_execution_cus (%u) actual_acct_data_cus "
+      FD_LOG_HEXDUMP_WARNING(( "txn", txn->payload, txn->payload_sz ));
+      FD_LOG_WARNING(( "Actual CUs unexpectedly exceeded requested amount. actual_execution_cus (%u) actual_acct_data_cus "
                    "(%u) requested_exec_plus_acct_data_cus (%u) is_simple_vote (%i) exec_failed (%i)",
                    actual_execution_cus, actual_acct_data_cus, requested_exec_plus_acct_data_cus, is_simple_vote,
                    transaction_err[ sanitized_idx-1UL ] ));
-      FD_LOG_HEXDUMP_DEBUG(( "txn", txn->payload, txn->payload_sz ));
-
-      actual_execution_cus = requested_exec_plus_acct_data_cus;
-      actual_acct_data_cus = 0UL;
     }
 
     txn->bank_cu.actual_consumed_cus = non_execution_cus + actual_execution_cus + actual_acct_data_cus;
@@ -434,13 +431,12 @@ handle_bundle( fd_bank_ctx_t *     ctx,
     txn->bank_cu.rebated_cus = requested_exec_plus_acct_data_cus + non_execution_cus;
 
     if( FD_LIKELY( (txn->flags & (FD_TXN_P_FLAGS_SANITIZE_SUCCESS|FD_TXN_P_FLAGS_EXECUTE_SUCCESS))==(FD_TXN_P_FLAGS_SANITIZE_SUCCESS|FD_TXN_P_FLAGS_EXECUTE_SUCCESS) ) ) {
-      txn->bank_cu.actual_consumed_cus = non_execution_cus + consumed_cus[ i ];
-      /* FD_TEST( consumed_cus[ i ] <= requested_exec_plus_acct_data_cus ); */
       if( FD_UNLIKELY( consumed_cus[ i ] > requested_exec_plus_acct_data_cus ) ) {
-        FD_LOG_DEBUG(( "transaction %lu in bundle consumed %u CUs > requested %u CUs", i, consumed_cus[ i ], requested_exec_plus_acct_data_cus ));
-        FD_LOG_HEXDUMP_DEBUG(( "txn", txn->payload, txn->payload_sz ));
-        consumed_cus[ i ] = requested_exec_plus_acct_data_cus;
+        FD_LOG_HEXDUMP_WARNING(( "txn", txn->payload, txn->payload_sz ));
+        FD_LOG_WARNING(( "transaction %lu in bundle consumed %u CUs > requested %u CUs", i, consumed_cus[ i ], requested_exec_plus_acct_data_cus ));
       }
+
+      txn->bank_cu.actual_consumed_cus = non_execution_cus + consumed_cus[ i ];
       txn->bank_cu.rebated_cus = requested_exec_plus_acct_data_cus - consumed_cus[ i ];
     }
   }


### PR DESCRIPTION
- We were double counting builtin costs (which is safe, but undesirable)
- print warning log when cu invariants are violated