### PR TITLE
quic: fix ping_sent flag

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -2860,7 +2860,6 @@ fd_quic_svc_poll( fd_quic_t *      quic,
       /* send PING */
       if( !( conn->flags & FD_QUIC_CONN_FLAGS_PING ) ) {
         conn->flags         |= FD_QUIC_CONN_FLAGS_PING;
-        conn->flags         &= ~FD_QUIC_CONN_FLAGS_PING_SENT;
         conn->upd_pkt_number = FD_QUIC_PKT_NUM_PENDING;     /* update to be sent in next packet */
       }
     }


### PR DESCRIPTION
There are currently 2 ping-related connection flags. One is CONN_FLAGS_PING and the other is CONN_FLAGS_PING_SENT. Ping_sent is intended to prevent sending new pings when there is already a ping in-flight. We should only ever unset it on reclaiming or retrying a pkt_meta. However, there is one extra unset right now during keep-alive (which, to be fair, is not in use rn). This PR fixes that. 