### PR TITLE
fdctl: substitute {user} and {home} in ledger.accounts_path

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -189,8 +189,14 @@ dynamic_port_range = "8900-9000"
 
     # Absolute directory path to place the accounts database in.  If
     # this is empty, it will default to the `accounts` subdirectory of
-    # the ledger `path` above.  This option is passed to the Agave
-    # client with the `--accounts` argument.
+    # the ledger `path` above.
+    #
+    # Two substitutions will be performed on this string.  If "{user}"
+    # is present it will be replaced with the user running Firedancer,
+    # as above, and "{name}" will be replaced with the name of the
+    # Firedancer instance.
+    #
+    # This option is passed to the Agave client with the `--accounts` argument.
     accounts_path = ""
 
     # Maximum number of shreds to keep in root slots in the ledger

--- a/src/app/shared/fd_config.c
+++ b/src/app/shared/fd_config.c
@@ -316,6 +316,11 @@ fdctl_cfg_from_env( int *      pargc,
     FD_TEST( fd_cstr_printf_check( config->ledger.path, sizeof(config->ledger.path), NULL, "%s/ledger", config->scratch_directory ) );
   }
 
+  if( FD_UNLIKELY( strcmp( config->ledger.accounts_path, "" ) ) ) {
+    replace( config->ledger.accounts_path, "{user}", config->user );
+    replace( config->ledger.accounts_path, "{name}", config->name );
+  }
+
   if( FD_UNLIKELY( strcmp( config->snapshots.path, "" ) ) ) {
     replace( config->snapshots.path, "{user}", config->user );
     replace( config->snapshots.path, "{name}", config->name );


### PR DESCRIPTION
`{user}` and `{home}` variables are substituted in a lot of paths, but not `[ledger.accounts_path]` which can lead to some confusion. This PR adds the corresponding `replace` calls, and updates the documentation in default config. 