### PR TITLE
runtime: fixing global types decode/encode

### DIFF
--- a/src/flamenco/rewards/fd_rewards.c
+++ b/src/flamenco/rewards/fd_rewards.c
@@ -659,7 +659,7 @@ calculate_validator_rewards( fd_exec_slot_ctx_t *                      slot_ctx,
                              ulong                                     exec_spad_cnt,
                              fd_spad_t *                               runtime_spad ) {
     /* https://github.com/firedancer-io/solana/blob/dab3da8e7b667d7527565bddbdbecf7ec1fb868e/runtime/src/bank.rs#L2759-L2786 */
-  fd_stake_history_t const * stake_history = (fd_stake_history_t const *)fd_sysvar_cache_stake_history( slot_ctx->sysvar_cache );
+  fd_stake_history_t const * stake_history = fd_sysvar_cache_stake_history( slot_ctx->sysvar_cache );
   if( FD_UNLIKELY( !stake_history ) ) {
     FD_LOG_ERR(( "StakeHistory sysvar is missing from sysvar cache" ));
   }
@@ -1179,7 +1179,7 @@ fd_rewards_recalculate_partitioned_rewards( fd_exec_slot_ctx_t * slot_ctx,
       new_warmup_cooldown_rate_epoch = NULL;
     }
 
-    fd_stake_history_t const * stake_history = (fd_stake_history_t const *)fd_sysvar_cache_stake_history( slot_ctx->sysvar_cache );
+    fd_stake_history_t const * stake_history = fd_sysvar_cache_stake_history( slot_ctx->sysvar_cache );
     if( FD_UNLIKELY( !stake_history ) ) {
       FD_LOG_ERR(( "StakeHistory sysvar is missing from sysvar cache" ));
     }

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -273,7 +273,7 @@ fd_runtime_validate_fee_collector( fd_exec_slot_ctx_t const * slot_ctx,
      We already know that the post deposit balance is >0 because we are paying a >0 amount.
      So TLDR we just check if the account is rent exempt.
    */
-  ulong minbal = fd_rent_exempt_minimum_balance( (fd_rent_t const *)fd_sysvar_cache_rent( slot_ctx->sysvar_cache ), collector->const_meta->dlen );
+  ulong minbal = fd_rent_exempt_minimum_balance( fd_sysvar_cache_rent( slot_ctx->sysvar_cache ), collector->const_meta->dlen );
   if( FD_UNLIKELY( collector->const_meta->info.lamports + fee < minbal ) ) {
     FD_BASE58_ENCODE_32_BYTES( collector->pubkey->key, _out_key );
     FD_LOG_WARNING(("cannot pay a rent paying account (%s)", _out_key ));
@@ -2304,7 +2304,7 @@ fd_new_target_program_account( fd_exec_slot_ctx_t * slot_ctx,
   };
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank/builtins/core_bpf_migration/mod.rs#L89-L90 */
-  fd_rent_t const * rent = (fd_rent_t const *)fd_sysvar_cache_rent( slot_ctx->sysvar_cache );
+  fd_rent_t const * rent = fd_sysvar_cache_rent( slot_ctx->sysvar_cache );
   if( FD_UNLIKELY( rent==NULL ) ) {
     return -1;
   }
@@ -2377,7 +2377,7 @@ fd_new_target_program_data_account( fd_exec_slot_ctx_t * slot_ctx,
   }
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank/builtins/core_bpf_migration/mod.rs#L127-L132 */
-  const fd_rent_t * rent = (fd_rent_t const *)fd_sysvar_cache_rent( slot_ctx->sysvar_cache );
+  const fd_rent_t * rent = fd_sysvar_cache_rent( slot_ctx->sysvar_cache );
   if( FD_UNLIKELY( rent==NULL ) ) {
     return -1;
   }
@@ -2854,7 +2854,7 @@ fd_runtime_process_new_epoch( fd_exec_slot_ctx_t * slot_ctx,
 
   /* Refresh vote accounts in stakes cache using updated stake weights, and merges slot bank vote accounts with the epoch bank vote accounts.
     https://github.com/anza-xyz/agave/blob/v2.1.6/runtime/src/stakes.rs#L363-L370 */
-  fd_stake_history_t const * history = (fd_stake_history_t const *)fd_sysvar_cache_stake_history( slot_ctx->sysvar_cache );
+  fd_stake_history_t const * history = fd_sysvar_cache_stake_history( slot_ctx->sysvar_cache );
   if( FD_UNLIKELY( !history ) ) {
     FD_LOG_ERR(( "StakeHistory sysvar is missing from sysvar cache" ));
   }

--- a/src/flamenco/runtime/program/fd_loader_v4_program.c
+++ b/src/flamenco/runtime/program/fd_loader_v4_program.c
@@ -249,7 +249,7 @@ fd_loader_v4_program_instruction_truncate( fd_exec_instr_ctx_t *                
   }
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L165-L171 */
-  fd_rent_t const * rent = (fd_rent_t const *)fd_sysvar_cache_rent( instr_ctx->txn_ctx->sysvar_cache );
+  fd_rent_t const * rent = fd_sysvar_cache_rent( instr_ctx->txn_ctx->sysvar_cache );
   if( FD_UNLIKELY( rent==NULL ) ) {
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
   }
@@ -353,7 +353,7 @@ fd_loader_v4_program_instruction_deploy( fd_exec_instr_ctx_t * instr_ctx ) {
   /* These variables should exist outside of borrowed account scopes. */
   uchar                         source_program_present = !!( instr_ctx->instr->acct_cnt>2 );
   fd_loader_v4_state_t          program_state          = {0};
-  fd_sol_sysvar_clock_t const * clock                  = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( instr_ctx->txn_ctx->sysvar_cache );
+  fd_sol_sysvar_clock_t const * clock                  = fd_sysvar_cache_clock( instr_ctx->txn_ctx->sysvar_cache );
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L217-L219 */
   fd_pubkey_t const * authority_address = NULL;
@@ -446,7 +446,7 @@ fd_loader_v4_program_instruction_deploy( fd_exec_instr_ctx_t * instr_ctx ) {
       https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L295-L303 */
   if( source_program_present ) {
       /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L296 */
-      fd_rent_t const * rent = (fd_rent_t const *)fd_sysvar_cache_rent( instr_ctx->txn_ctx->sysvar_cache );
+      fd_rent_t const * rent = fd_sysvar_cache_rent( instr_ctx->txn_ctx->sysvar_cache );
       if( FD_UNLIKELY( rent==NULL ) ) {
         return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
       }
@@ -529,7 +529,7 @@ fd_loader_v4_program_instruction_retract( fd_exec_instr_ctx_t * instr_ctx ) {
   }
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.4/programs/loader-v4/src/lib.rs#L344 */
-  fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( instr_ctx->txn_ctx->sysvar_cache );
+  fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( instr_ctx->txn_ctx->sysvar_cache );
   if( FD_UNLIKELY( clock==NULL ) ) {
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
   }

--- a/src/flamenco/runtime/program/fd_stake_program.c
+++ b/src/flamenco/runtime/program/fd_stake_program.c
@@ -281,7 +281,7 @@ validate_split_amount( fd_exec_instr_ctx_t const * invoke_context,
   };
 
   // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L1042
-  fd_rent_t const * rent = (fd_rent_t const *)fd_sysvar_cache_rent( invoke_context->txn_ctx->sysvar_cache );
+  fd_rent_t const * rent = fd_sysvar_cache_rent( invoke_context->txn_ctx->sysvar_cache );
   if( FD_UNLIKELY( !rent ) )
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -753,7 +753,7 @@ fd_new_warmup_cooldown_rate_epoch( ulong                     slot,
                                    /* out */ ulong *         epoch,
                                    int *                     err ) {
   *err = 0;
-  fd_epoch_schedule_t const * epoch_schedule = (fd_epoch_schedule_t const *)fd_sysvar_cache_epoch_schedule( sysvar_cache );
+  fd_epoch_schedule_t const * epoch_schedule = fd_sysvar_cache_epoch_schedule( sysvar_cache );
   if( FD_UNLIKELY( !epoch_schedule ) ) {
     *epoch = ULONG_MAX;
     *err   = FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
@@ -1138,7 +1138,7 @@ get_stake_status( fd_exec_instr_ctx_t const *    invoke_context,
                   fd_stake_t *                   stake,
                   fd_sol_sysvar_clock_t const *  clock,
                   fd_stake_activation_status_t * out ) {
-  fd_stake_history_t const * stake_history = (fd_stake_history_t const *)fd_sysvar_cache_stake_history( invoke_context->txn_ctx->sysvar_cache );
+  fd_stake_history_t const * stake_history = fd_sysvar_cache_stake_history( invoke_context->txn_ctx->sysvar_cache );
   if( FD_UNLIKELY( !stake_history ) )
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
   ulong new_rate_activation_epoch = ULONG_MAX;
@@ -1619,7 +1619,7 @@ split( fd_exec_instr_ctx_t const * ctx,
     int is_active;
     if( FD_UNLIKELY( FD_FEATURE_ACTIVE( ctx->txn_ctx->slot, ctx->txn_ctx->features, require_rent_exempt_split_destination ) ) ) {
       // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_state.rs#L434
-      fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+      fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
       if( FD_UNLIKELY( !clock ) )
         return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -1948,11 +1948,11 @@ move_stake_or_lamports_shared_checks( fd_exec_instr_ctx_t *   invoke_context, //
       return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
 
     // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_state.rs#L177-L180
-    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( invoke_context->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( invoke_context->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !clock ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
-    fd_stake_history_t const * stake_history = (fd_stake_history_t const *)fd_sysvar_cache_stake_history( invoke_context->txn_ctx->sysvar_cache );
+    fd_stake_history_t const * stake_history = fd_sysvar_cache_stake_history( invoke_context->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !stake_history ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -2550,7 +2550,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
 
   /* The EpochRewards sysvar only exists after partitioned epoch rewards is activated.
      If the sysvar exists, check the `active` field */
-  fd_sysvar_epoch_rewards_t const * rewards = (fd_sysvar_epoch_rewards_t const *)fd_sysvar_cache_epoch_rewards( ctx->txn_ctx->sysvar_cache );
+  fd_sysvar_epoch_rewards_t const * rewards = fd_sysvar_cache_epoch_rewards( ctx->txn_ctx->sysvar_cache );
   int epoch_rewards_active = (NULL != rewards) ? rewards->active : false;
 
   if (epoch_rewards_active && instruction->discriminant!=fd_stake_instruction_enum_get_minimum_delegation) {
@@ -2875,7 +2875,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     rc = get_stake_account( ctx, &me );
     if( FD_UNLIKELY( rc ) ) return rc;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L225
-    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !clock ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L226
@@ -3055,7 +3055,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
                                 .epoch          = lockup_checked->epoch,
                                 .custodian      = (fd_pubkey_t *)custodian_pubkey }; // FIXME
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L310
-    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !clock ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -3098,7 +3098,7 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
     if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) )
       return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
     // https://github.com/anza-xyz/agave/blob/c8685ce0e1bb9b26014f1024de2cd2b8c308cbde/programs/stake/src/stake_instruction.rs#L325
-    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !clock ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 

--- a/src/flamenco/runtime/program/fd_system_program_nonce.c
+++ b/src/flamenco/runtime/program/fd_system_program_nonce.c
@@ -33,7 +33,7 @@ require_acct_rent( fd_exec_instr_ctx_t * ctx,
     if( FD_UNLIKELY( err ) ) return err;
   } while(0);
 
-  fd_rent_t const * rent = (fd_rent_t const *)fd_sysvar_cache_rent( ctx->txn_ctx->sysvar_cache );
+  fd_rent_t const * rent = fd_sysvar_cache_rent( ctx->txn_ctx->sysvar_cache );
   if( FD_UNLIKELY( !rent ) )
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -42,9 +42,9 @@ require_acct_rent( fd_exec_instr_ctx_t * ctx,
 }
 
 static int
-require_acct_recent_blockhashes( fd_exec_instr_ctx_t *             ctx,
-                                 ushort                            idx,
-                                 fd_recent_block_hashes_t const ** out ) {
+require_acct_recent_blockhashes( fd_exec_instr_ctx_t *        ctx,
+                                 ushort                       idx,
+                                 fd_recent_block_hashes_t * * out ) {
 
   do {
     int err = require_acct( ctx, idx, &fd_sysvar_recent_block_hashes_id );
@@ -52,10 +52,11 @@ require_acct_recent_blockhashes( fd_exec_instr_ctx_t *             ctx,
   } while(0);
 
   fd_recent_block_hashes_global_t const * rbh_global = fd_sysvar_cache_recent_block_hashes( ctx->txn_ctx->sysvar_cache );
-  if( FD_UNLIKELY( !rbh_global ) )
+  if( FD_UNLIKELY( !rbh_global ) ) {
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
-  fd_bincode_decode_ctx_t decode = { .wksp = ctx->txn_ctx->runtime_pub_wksp };
-  fd_recent_block_hashes_convert_global_to_local( rbh_global, (fd_recent_block_hashes_t*)*out, &decode );
+  }
+
+  (*out)->hashes = deq_fd_block_block_hash_entry_t_join( fd_wksp_laddr_fast( ctx->txn_ctx->runtime_pub_wksp, rbh_global->hashes_gaddr ) );
 
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
@@ -278,8 +279,8 @@ fd_system_program_exec_advance_nonce_account( fd_exec_instr_ctx_t * ctx ) {
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L427-L432 */
 
-  fd_recent_block_hashes_t         recent_blockhashes_obj;
-  fd_recent_block_hashes_t const * recent_blockhashes = &recent_blockhashes_obj;
+  fd_recent_block_hashes_t   recent_blockhashes_obj;
+  fd_recent_block_hashes_t * recent_blockhashes = &recent_blockhashes_obj;
   do {
     err = require_acct_recent_blockhashes( ctx, 1UL, &recent_blockhashes );
     if( FD_UNLIKELY( err ) ) return err;
@@ -500,8 +501,8 @@ fd_system_program_exec_withdraw_nonce_account( fd_exec_instr_ctx_t * ctx,
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L445-L449 */
 
-  fd_recent_block_hashes_t         recent_blockhashes_obj;
-  fd_recent_block_hashes_t const * recent_blockhashes = &recent_blockhashes_obj;
+  fd_recent_block_hashes_t   recent_blockhashes_obj;
+  fd_recent_block_hashes_t * recent_blockhashes = &recent_blockhashes_obj;
   do {
     int err = require_acct_recent_blockhashes( ctx, 2UL, &recent_blockhashes );
     if( FD_UNLIKELY( err ) ) return err;
@@ -664,8 +665,8 @@ fd_system_program_exec_initialize_nonce_account( fd_exec_instr_ctx_t * ctx,
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L466-L471 */
 
-  fd_recent_block_hashes_t         recent_blockhashes_obj;
-  fd_recent_block_hashes_t const * recent_blockhashes = &recent_blockhashes_obj;
+  fd_recent_block_hashes_t   recent_blockhashes_obj;
+  fd_recent_block_hashes_t * recent_blockhashes = &recent_blockhashes_obj;
   do {
     err = require_acct_recent_blockhashes( ctx, 1UL, &recent_blockhashes );
     if( FD_UNLIKELY( err ) ) return err;

--- a/src/flamenco/runtime/program/fd_vote_program.c
+++ b/src/flamenco/runtime/program/fd_vote_program.c
@@ -2204,7 +2204,7 @@ fd_vote_acc_credits( fd_exec_instr_ctx_t const * ctx,
                      ulong *                     result ) {
   int rc;
 
-  fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+  fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
   if( FD_UNLIKELY( !clock ) ) return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
   /* Read vote account */
@@ -2596,11 +2596,11 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
   case fd_vote_instruction_enum_update_commission: {
 
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L149
-    fd_epoch_schedule_t const * epoch_schedule = (fd_epoch_schedule_t const *)fd_sysvar_cache_epoch_schedule( ctx->txn_ctx->sysvar_cache );
+    fd_epoch_schedule_t const * epoch_schedule = fd_sysvar_cache_epoch_schedule( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !epoch_schedule ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L150
-    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !clock ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -2653,8 +2653,7 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
     fd_slot_hashes_global_t const * slot_hashes_global = fd_sysvar_from_instr_acct_slot_hashes( ctx, 1, &err );
     fd_slot_hashes_t slot_hashes[1];
     if( FD_LIKELY( slot_hashes_global ) ) {
-      fd_bincode_decode_ctx_t decode = { .wksp = ctx->txn_ctx->runtime_pub_wksp };
-      fd_slot_hashes_convert_global_to_local( slot_hashes_global, slot_hashes, &decode );
+      slot_hashes->hashes = deq_fd_slot_hash_t_join( fd_wksp_laddr_fast( ctx->txn_ctx->runtime_pub_wksp, slot_hashes_global->hashes_gaddr ) );
     } else {
       return err;
     }
@@ -2708,14 +2707,13 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
     fd_slot_hashes_global_t const * slot_hashes_global = fd_sysvar_cache_slot_hashes( ctx->txn_ctx->sysvar_cache );
     fd_slot_hashes_t slot_hashes[1];
     if( FD_LIKELY( slot_hashes_global ) ) {
-      fd_bincode_decode_ctx_t decode = { .wksp = ctx->txn_ctx->runtime_pub_wksp };
-      fd_slot_hashes_convert_global_to_local( slot_hashes_global, slot_hashes, &decode );
+      slot_hashes->hashes = deq_fd_slot_hash_t_join( fd_wksp_laddr_fast( ctx->txn_ctx->runtime_pub_wksp, slot_hashes_global->hashes_gaddr ) );
     } else {
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
     }
 
     // https://github.com/anza-xyz/agave/blob/v2.0.1/programs/vote/src/vote_processor.rs#L172
-    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !clock ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -2774,13 +2772,12 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
     fd_slot_hashes_global_t const * slot_hashes_global = fd_sysvar_cache_slot_hashes( ctx->txn_ctx->sysvar_cache );
     fd_slot_hashes_t slot_hashes[1];
     if( FD_LIKELY( slot_hashes_global ) ) {
-      fd_bincode_decode_ctx_t decode = { .wksp = ctx->txn_ctx->runtime_pub_wksp };
-      fd_slot_hashes_convert_global_to_local( slot_hashes_global, slot_hashes, &decode );
+      slot_hashes->hashes = deq_fd_slot_hash_t_join( fd_wksp_laddr_fast( ctx->txn_ctx->runtime_pub_wksp, slot_hashes_global->hashes_gaddr ) );
     } else {
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
     }
 
-    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !clock ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 
@@ -2812,11 +2809,10 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
     fd_slot_hashes_global_t const * slot_hashes_global = fd_sysvar_cache_slot_hashes( ctx->txn_ctx->sysvar_cache );
     fd_slot_hashes_t slot_hashes[1];
     if( FD_LIKELY( slot_hashes_global ) ) {
-      fd_bincode_decode_ctx_t decode = { .wksp = ctx->txn_ctx->runtime_pub_wksp };
-      fd_slot_hashes_convert_global_to_local( slot_hashes_global, slot_hashes, &decode );
+      slot_hashes->hashes = deq_fd_slot_hash_t_join( fd_wksp_laddr_fast( ctx->txn_ctx->runtime_pub_wksp, slot_hashes_global->hashes_gaddr ) );
     }
 
-    fd_sol_sysvar_clock_t const * clock = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !slot_hashes_global || !clock ) ) {
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
     }
@@ -2838,10 +2834,10 @@ fd_vote_program_execute( fd_exec_instr_ctx_t * ctx ) {
       rc = FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
       break;
     }
-    fd_rent_t const * rent_sysvar = (fd_rent_t const *)fd_sysvar_cache_rent( ctx->txn_ctx->sysvar_cache );
+    fd_rent_t const * rent_sysvar = fd_sysvar_cache_rent( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !rent_sysvar ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
-    fd_sol_sysvar_clock_t const * clock_sysvar = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
+    fd_sol_sysvar_clock_t const * clock_sysvar = fd_sysvar_cache_clock( ctx->txn_ctx->sysvar_cache );
     if( FD_UNLIKELY( !clock_sysvar ) )
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
@@ -52,7 +52,7 @@ fd_sysvar_clock_read( fd_sol_sysvar_clock_t *   result,
                       fd_sysvar_cache_t const * sysvar_cache,
                       fd_funk_t *               funk,
                       fd_funk_txn_t *           funk_txn ) {
-  fd_sol_sysvar_clock_t const * ret = (fd_sol_sysvar_clock_t const *)fd_sysvar_cache_clock( sysvar_cache );
+  fd_sol_sysvar_clock_t const * ret = fd_sysvar_cache_clock( sysvar_cache );
   if( NULL != ret ) {
     fd_memcpy(result, ret, sizeof(fd_sol_sysvar_clock_t));
     return result;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.c
@@ -26,7 +26,7 @@ fd_sysvar_epoch_rewards_read( fd_sysvar_epoch_rewards_t * result,
                               fd_sysvar_cache_t const *   sysvar_cache,
                               fd_funk_t *                 funk,
                               fd_funk_txn_t *             funk_txn ) {
-  fd_sysvar_epoch_rewards_t const * ret = (fd_sysvar_epoch_rewards_t const *)fd_sysvar_cache_epoch_rewards( sysvar_cache );
+  fd_sysvar_epoch_rewards_t const * ret = fd_sysvar_cache_epoch_rewards( sysvar_cache );
   if( FD_UNLIKELY( NULL != ret ) ) {
     fd_memcpy(result, ret, sizeof(fd_sysvar_epoch_rewards_t));
     return result;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.c
@@ -54,7 +54,7 @@ fd_sysvar_epoch_schedule_read( fd_epoch_schedule_t *     result,
                                fd_sysvar_cache_t const * sysvar_cache,
                                fd_funk_t *               funk,
                                fd_funk_txn_t *           funk_txn ) {
-  fd_epoch_schedule_t const * ret = (fd_epoch_schedule_t const *)fd_sysvar_cache_epoch_schedule( sysvar_cache );
+  fd_epoch_schedule_t const * ret = fd_sysvar_cache_epoch_schedule( sysvar_cache );
   if( FD_UNLIKELY( NULL != ret ) ) {
     fd_memcpy(result, ret, sizeof(fd_epoch_schedule_t));
     return result;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_fees.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_fees.c
@@ -23,7 +23,7 @@ fd_sysvar_fees_read( fd_sysvar_fees_t *        result,
                      fd_sysvar_cache_t const * sysvar_cache,
                      fd_funk_t *               funk,
                      fd_funk_txn_t *           funk_txn ) {
-  fd_sysvar_fees_t const * ret = (fd_sysvar_fees_t const *)fd_sysvar_cache_fees( sysvar_cache );
+  fd_sysvar_fees_t const * ret = fd_sysvar_cache_fees( sysvar_cache );
   if( FD_UNLIKELY( NULL != ret ) ) {
     fd_memcpy(result, ret, sizeof(fd_sysvar_fees_t));
     return result;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.c
@@ -38,7 +38,7 @@ fd_sysvar_last_restart_slot_read( fd_sol_sysvar_last_restart_slot_t * result,
                                   fd_funk_t *                         funk,
                                   fd_funk_txn_t *                     funk_txn ) {
 
-  fd_sol_sysvar_last_restart_slot_t const * ret = (fd_sol_sysvar_last_restart_slot_t const *)fd_sysvar_cache_last_restart_slot( sysvar_cache );
+  fd_sol_sysvar_last_restart_slot_t const * ret = fd_sysvar_cache_last_restart_slot( sysvar_cache );
   if( FD_UNLIKELY( NULL != ret ) ) {
     fd_memcpy(result, ret, sizeof(fd_sol_sysvar_last_restart_slot_t));
     return result;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
@@ -14,7 +14,7 @@ fd_sysvar_rent_read( fd_sysvar_cache_t const * sysvar_cache,
                      fd_funk_txn_t *           funk_txn,
                      fd_spad_t *               spad ) {
 
-  fd_rent_t const * ret = (fd_rent_t const *)fd_sysvar_cache_rent( sysvar_cache );
+  fd_rent_t const * ret = fd_sysvar_cache_rent( sysvar_cache );
   if( FD_UNLIKELY( ret ) ) {
     return (fd_rent_t*)ret;
   }

--- a/src/flamenco/runtime/tests/fd_exec_instr_test.c
+++ b/src/flamenco/runtime/tests/fd_exec_instr_test.c
@@ -612,7 +612,7 @@ fd_exec_test_instr_context_create( fd_exec_instr_test_runner_t *        runner,
   /* Handle undefined behavior if sysvars are malicious (!!!) */
 
   /* Override epoch bank rent setting */
-  fd_rent_t const * rent = (fd_rent_t const *)fd_sysvar_cache_rent( slot_ctx->sysvar_cache );
+  fd_rent_t const * rent = fd_sysvar_cache_rent( slot_ctx->sysvar_cache );
   if( rent ) {
     epoch_bank->rent = *rent;
   }
@@ -621,8 +621,7 @@ fd_exec_test_instr_context_create( fd_exec_instr_test_runner_t *        runner,
   fd_recent_block_hashes_global_t const * rbh_global = fd_sysvar_cache_recent_block_hashes( slot_ctx->sysvar_cache );
   fd_recent_block_hashes_t rbh[1];
   if( rbh_global ) {
-    fd_bincode_decode_ctx_t decode = { .wksp = runtime_wksp };
-    fd_recent_block_hashes_convert_global_to_local( rbh_global, rbh, &decode );
+    rbh->hashes = deq_fd_block_block_hash_entry_t_join( fd_wksp_laddr_fast( runtime_wksp, rbh_global->hashes_gaddr ) );
   }
 
   if( rbh_global && !deq_fd_block_block_hash_entry_t_empty( rbh->hashes ) ) {
@@ -867,7 +866,7 @@ _txn_context_create_and_exec( fd_exec_instr_test_runner_t *      runner,
   fd_sysvar_cache_restore( slot_ctx->sysvar_cache, funk, funk_txn, runner->spad, fd_wksp_containing( slot_ctx ) );
 
   /* A NaN rent exemption threshold is U.B. in Solana Labs */
-  fd_rent_t const * rent = (fd_rent_t const *)fd_sysvar_cache_rent( slot_ctx->sysvar_cache );
+  fd_rent_t const * rent = fd_sysvar_cache_rent( slot_ctx->sysvar_cache );
   if( ( !fd_double_is_normal( rent->exemption_threshold ) ) |
       ( rent->exemption_threshold     <      0.0 ) |
       ( rent->exemption_threshold     >    999.0 ) |
@@ -892,8 +891,7 @@ _txn_context_create_and_exec( fd_exec_instr_test_runner_t *      runner,
   fd_recent_block_hashes_global_t const * rbh_global = fd_sysvar_cache_recent_block_hashes( slot_ctx->sysvar_cache );
   fd_recent_block_hashes_t rbh[1];
   if( rbh_global ) {
-    fd_bincode_decode_ctx_t decode = { .wksp = fd_wksp_containing( runner->spad ) };
-    fd_recent_block_hashes_convert_global_to_local( rbh_global, rbh, &decode );
+    rbh->hashes = deq_fd_block_block_hash_entry_t_join( fd_wksp_laddr_fast( fd_wksp_containing( runner->spad ), rbh_global->hashes_gaddr ) );
   }
 
   if( rbh_global && !deq_fd_block_block_hash_entry_t_empty( rbh->hashes ) ) {
@@ -1230,8 +1228,7 @@ _block_context_create_and_exec( fd_exec_instr_test_runner_t *        runner,
   fd_recent_block_hashes_global_t const * rbh_global = fd_sysvar_cache_recent_block_hashes( slot_ctx->sysvar_cache );
   fd_recent_block_hashes_t rbh[1];
   if( rbh_global ) {
-    fd_bincode_decode_ctx_t decode = { .wksp = fd_wksp_containing( runner->spad ) };
-    fd_recent_block_hashes_convert_global_to_local( rbh_global, rbh, &decode );
+    rbh->hashes = deq_fd_block_block_hash_entry_t_join( fd_wksp_laddr_fast( fd_wksp_containing( runner->spad ), rbh_global->hashes_gaddr ) );
   }
 
   if( rbh_global && !deq_fd_block_block_hash_entry_t_empty( rbh->hashes ) ) {

--- a/src/flamenco/runtime/tests/fd_exec_sol_compat.c
+++ b/src/flamenco/runtime/tests/fd_exec_sol_compat.c
@@ -77,9 +77,9 @@ sol_compat_wksp_init( ulong wksp_page_sz ) {
   spad_mem = fd_wksp_alloc_laddr( wksp, FD_SPAD_ALIGN, FD_SPAD_FOOTPRINT( FD_RUNTIME_TRANSACTION_EXECUTION_FOOTPRINT_FUZZ ), WKSP_INIT_ALLOC_TAG ); /* 4738713960 B */
   FD_TEST( spad_mem );
 
-  features.struct_size         = sizeof(sol_compat_features_t);
+  features.struct_size        = sizeof(sol_compat_features_t);
   features.hardcoded_features = fd_wksp_alloc_laddr( wksp, 8UL, FD_FEATURE_ID_CNT * sizeof(ulong), WKSP_INIT_ALLOC_TAG );
-  features.supported_features  = fd_wksp_alloc_laddr( wksp, 8UL, FD_FEATURE_ID_CNT * sizeof(ulong), WKSP_INIT_ALLOC_TAG );
+  features.supported_features = fd_wksp_alloc_laddr( wksp, 8UL, FD_FEATURE_ID_CNT * sizeof(ulong), WKSP_INIT_ALLOC_TAG );
 
   for( const fd_feature_id_t * current_feature = fd_feature_iter_init(); !fd_feature_iter_done( current_feature ); current_feature = fd_feature_iter_next( current_feature ) ) {
     // Skip reverted features

--- a/src/flamenco/stakes/fd_stakes.c
+++ b/src/flamenco/stakes/fd_stakes.c
@@ -521,7 +521,7 @@ fd_accumulate_stake_infos( fd_exec_slot_ctx_t const * slot_ctx,
      do not have access to iterators at a specific index in constant or logarithmic time. */
   ulong worker_cnt                                         = fd_ulong_min( stake_delegations_pool_sz,
                                                                            fd_ulong_min( fd_tpool_worker_cnt( tpool ), exec_spads_cnt ) );
-  fd_delegation_pair_t_mapnode_t ** batch_delegation_roots = fd_spad_alloc( runtime_spad, alignof(fd_delegation_pair_t_mapnode_t *),
+  fd_delegation_pair_t_mapnode_t * * batch_delegation_roots = fd_spad_alloc( runtime_spad, alignof(fd_delegation_pair_t_mapnode_t *),
                                                                                       ( worker_cnt + 1 )*sizeof(fd_delegation_pair_t_mapnode_t *) );
 
   ulong * idx_starts = fd_spad_alloc( runtime_spad, alignof(ulong), worker_cnt * sizeof(ulong) );
@@ -611,7 +611,7 @@ fd_stakes_activate_epoch( fd_exec_slot_ctx_t *  slot_ctx,
   /* Add a new entry to the Stake History sysvar for the previous epoch
      https://github.com/solana-labs/solana/blob/88aeaa82a856fc807234e7da0b31b89f2dc0e091/runtime/src/stakes.rs#L181-L192 */
 
-  fd_stake_history_t const * history = (fd_stake_history_t const *)fd_sysvar_cache_stake_history( slot_ctx->sysvar_cache );
+  fd_stake_history_t const * history = fd_sysvar_cache_stake_history( slot_ctx->sysvar_cache );
   if( FD_UNLIKELY( !history ) ) FD_LOG_ERR(( "StakeHistory sysvar is missing from sysvar cache" ));
 
   ulong stake_delegations_size = fd_delegation_pair_t_map_size(

--- a/src/flamenco/types/fd_bincode.h
+++ b/src/flamenco/types/fd_bincode.h
@@ -26,6 +26,7 @@ struct fd_bincode_encode_ctx {
   void * data;
   /* End of buffer */
   void * dataend;
+  fd_wksp_t * wksp;
 };
 typedef struct fd_bincode_encode_ctx fd_bincode_encode_ctx_t;
 

--- a/src/flamenco/types/fd_types.c
+++ b/src/flamenco/types/fd_types.c
@@ -35,18 +35,6 @@ void fd_hash_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_dec
   fd_bincode_bytes_decode_unsafe( struct_mem, sizeof(fd_hash_t), ctx );
   return;
 }
-void * fd_hash_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bincode_bytes_decode_unsafe( mem, sizeof(fd_hash_t), ctx );
-  return mem;
-}
-void fd_hash_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bincode_bytes_decode_unsafe( struct_mem, sizeof(fd_hash_t), ctx );
-  return;
-}
-int fd_hash_convert_global_to_local( void const * global_self, fd_hash_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_memcpy( self, global_self, sizeof(fd_hash_t) );
-  return FD_BINCODE_SUCCESS;
-}
 
 void fd_signature_new( fd_signature_t * self ) { }
 void fd_signature_destroy( fd_signature_t * self ) { }
@@ -79,18 +67,6 @@ void fd_signature_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincod
   fd_bincode_bytes_decode_unsafe( struct_mem, sizeof(fd_signature_t), ctx );
   return;
 }
-void * fd_signature_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bincode_bytes_decode_unsafe( mem, sizeof(fd_signature_t), ctx );
-  return mem;
-}
-void fd_signature_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bincode_bytes_decode_unsafe( struct_mem, sizeof(fd_signature_t), ctx );
-  return;
-}
-int fd_signature_convert_global_to_local( void const * global_self, fd_signature_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_memcpy( self, global_self, sizeof(fd_signature_t) );
-  return FD_BINCODE_SUCCESS;
-}
 
 void fd_gossip_ip4_addr_new( fd_gossip_ip4_addr_t * self ) { }
 void fd_gossip_ip4_addr_destroy( fd_gossip_ip4_addr_t * self ) { }
@@ -119,18 +95,6 @@ void * fd_gossip_ip4_addr_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
 void fd_gossip_ip4_addr_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_bincode_bytes_decode_unsafe( struct_mem, sizeof(fd_gossip_ip4_addr_t), ctx );
   return;
-}
-void * fd_gossip_ip4_addr_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bincode_bytes_decode_unsafe( mem, sizeof(fd_gossip_ip4_addr_t), ctx );
-  return mem;
-}
-void fd_gossip_ip4_addr_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bincode_bytes_decode_unsafe( struct_mem, sizeof(fd_gossip_ip4_addr_t), ctx );
-  return;
-}
-int fd_gossip_ip4_addr_convert_global_to_local( void const * global_self, fd_gossip_ip4_addr_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_memcpy( self, global_self, sizeof(fd_gossip_ip4_addr_t) );
-  return FD_BINCODE_SUCCESS;
 }
 
 void fd_gossip_ip6_addr_new( fd_gossip_ip6_addr_t * self ) { }
@@ -161,20 +125,18 @@ void fd_gossip_ip6_addr_decode_inner( void * struct_mem, void * * alloc_mem, fd_
   fd_bincode_bytes_decode_unsafe( struct_mem, sizeof(fd_gossip_ip6_addr_t), ctx );
   return;
 }
-void * fd_gossip_ip6_addr_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bincode_bytes_decode_unsafe( mem, sizeof(fd_gossip_ip6_addr_t), ctx );
-  return mem;
-}
-void fd_gossip_ip6_addr_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bincode_bytes_decode_unsafe( struct_mem, sizeof(fd_gossip_ip6_addr_t), ctx );
-  return;
-}
-int fd_gossip_ip6_addr_convert_global_to_local( void const * global_self, fd_gossip_ip6_addr_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_memcpy( self, global_self, sizeof(fd_gossip_ip6_addr_t) );
-  return FD_BINCODE_SUCCESS;
-}
 
 int fd_feature_encode( fd_feature_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_bool_encode( self->has_activated_at, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_activated_at ) {
+    err = fd_bincode_uint64_encode( self->activated_at, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_feature_encode_global( fd_feature_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
   err = fd_bincode_bool_encode( self->has_activated_at, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -244,13 +206,6 @@ void fd_feature_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_b
     }
   }
 }
-int fd_feature_convert_global_to_local( void const * global_self, fd_feature_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_feature_global_t const * mem = (fd_feature_global_t const *)global_self;
-  self->activated_at = mem->activated_at;
-  self->has_activated_at = mem->has_activated_at;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_feature_new(fd_feature_t * self) {
   fd_memset( self, 0, sizeof(fd_feature_t) );
 }
@@ -314,24 +269,6 @@ void fd_fee_calculator_decode_inner( void * struct_mem, void * * alloc_mem, fd_b
   fd_fee_calculator_t * self = (fd_fee_calculator_t *)struct_mem;
   fd_bincode_uint64_decode_unsafe( &self->lamports_per_signature, ctx );
 }
-void * fd_fee_calculator_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_fee_calculator_global_t * self = (fd_fee_calculator_global_t *)mem;
-  fd_fee_calculator_new( (fd_fee_calculator_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_fee_calculator_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_fee_calculator_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_fee_calculator_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_fee_calculator_global_t * self = (fd_fee_calculator_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->lamports_per_signature, ctx );
-}
-int fd_fee_calculator_convert_global_to_local( void const * global_self, fd_fee_calculator_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_fee_calculator_global_t const * mem = (fd_fee_calculator_global_t const *)global_self;
-  self->lamports_per_signature = mem->lamports_per_signature;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_fee_calculator_new(fd_fee_calculator_t * self) {
   fd_memset( self, 0, sizeof(fd_fee_calculator_t) );
 }
@@ -394,29 +331,6 @@ void fd_hash_age_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode
   fd_fee_calculator_decode_inner( &self->fee_calculator, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->hash_index, ctx );
   fd_bincode_uint64_decode_unsafe( &self->timestamp, ctx );
-}
-void * fd_hash_age_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_hash_age_global_t * self = (fd_hash_age_global_t *)mem;
-  fd_hash_age_new( (fd_hash_age_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_hash_age_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_hash_age_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_hash_age_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_hash_age_global_t * self = (fd_hash_age_global_t *)struct_mem;
-  fd_fee_calculator_decode_inner_global( &self->fee_calculator, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->hash_index, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->timestamp, ctx );
-}
-int fd_hash_age_convert_global_to_local( void const * global_self, fd_hash_age_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_hash_age_global_t const * mem = (fd_hash_age_global_t const *)global_self;
-  err = fd_fee_calculator_convert_global_to_local( &mem->fee_calculator, &self->fee_calculator, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->hash_index = mem->hash_index;
-  self->timestamp = mem->timestamp;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_hash_age_new(fd_hash_age_t * self) {
   fd_memset( self, 0, sizeof(fd_hash_age_t) );
@@ -482,28 +396,6 @@ void fd_hash_hash_age_pair_decode_inner( void * struct_mem, void * * alloc_mem, 
   fd_hash_decode_inner( &self->key, alloc_mem, ctx );
   fd_hash_age_decode_inner( &self->val, alloc_mem, ctx );
 }
-void * fd_hash_hash_age_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_hash_hash_age_pair_global_t * self = (fd_hash_hash_age_pair_global_t *)mem;
-  fd_hash_hash_age_pair_new( (fd_hash_hash_age_pair_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_hash_hash_age_pair_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_hash_hash_age_pair_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_hash_hash_age_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_hash_hash_age_pair_global_t * self = (fd_hash_hash_age_pair_global_t *)struct_mem;
-  fd_hash_decode_inner_global( &self->key, alloc_mem, ctx );
-  fd_hash_age_decode_inner_global( &self->val, alloc_mem, ctx );
-}
-int fd_hash_hash_age_pair_convert_global_to_local( void const * global_self, fd_hash_hash_age_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_hash_hash_age_pair_global_t const * mem = (fd_hash_hash_age_pair_global_t const *)global_self;
-  err = fd_hash_convert_global_to_local( &mem->key, &self->key, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_hash_age_convert_global_to_local( &mem->val, &self->val, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_hash_hash_age_pair_new(fd_hash_hash_age_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_hash_hash_age_pair_t) );
   fd_hash_new( &self->key );
@@ -548,6 +440,34 @@ int fd_block_hash_vec_encode( fd_block_hash_vec_t const * self, fd_bincode_encod
   if( self->ages_len ) {
     for( ulong i=0; i < self->ages_len; i++ ) {
       err = fd_hash_hash_age_pair_encode( self->ages + i, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  err = fd_bincode_uint64_encode( self->max_age, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_block_hash_vec_encode_global( fd_block_hash_vec_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->last_hash_index, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->last_hash_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    fd_hash_t * last_hash = fd_wksp_laddr_fast( ctx->wksp, self->last_hash_gaddr );
+    err = fd_hash_encode( last_hash, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_uint64_encode( self->ages_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->ages_len ) {
+    uchar * ages_laddr = fd_wksp_laddr_fast( ctx->wksp, self->ages_gaddr );
+    fd_hash_hash_age_pair_t * ages = (fd_hash_hash_age_pair_t *)ages_laddr;
+    for( ulong i=0; i < self->ages_len; i++ ) {
+      err = fd_hash_hash_age_pair_encode( &ages[i], ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
   }
@@ -648,7 +568,7 @@ void fd_block_hash_vec_decode_inner_global( void * struct_mem, void * * alloc_me
       self->last_hash_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
       fd_hash_new( *alloc_mem );
       *alloc_mem = (uchar *)*alloc_mem + FD_HASH_FOOTPRINT;
-      fd_hash_decode_inner_global( fd_wksp_laddr_fast( ctx->wksp, self->last_hash_gaddr ), alloc_mem, ctx );
+      fd_hash_decode_inner( fd_wksp_laddr_fast( ctx->wksp, self->last_hash_gaddr ), alloc_mem, ctx );
     } else {
       self->last_hash_gaddr = 0UL;
     }
@@ -660,22 +580,13 @@ void fd_block_hash_vec_decode_inner_global( void * struct_mem, void * * alloc_me
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_HASH_HASH_AGE_PAIR_FOOTPRINT*self->ages_len;
     for( ulong i=0; i < self->ages_len; i++ ) {
-      fd_hash_hash_age_pair_new( (fd_hash_hash_age_pair_t *)(cur_mem + FD_HASH_HASH_AGE_PAIR_FOOTPRINT * i) );
-      fd_hash_hash_age_pair_decode_inner_global( cur_mem + FD_HASH_HASH_AGE_PAIR_FOOTPRINT * i, alloc_mem, ctx );
+      fd_hash_hash_age_pair_new( (fd_hash_hash_age_pair_t *)fd_type_pun(cur_mem + FD_HASH_HASH_AGE_PAIR_FOOTPRINT * i) );
+      fd_hash_hash_age_pair_decode_inner( cur_mem + FD_HASH_HASH_AGE_PAIR_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->ages_gaddr = 0UL;
+  }
   fd_bincode_uint64_decode_unsafe( &self->max_age, ctx );
-}
-int fd_block_hash_vec_convert_global_to_local( void const * global_self, fd_block_hash_vec_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_block_hash_vec_global_t const * mem = (fd_block_hash_vec_global_t const *)global_self;
-  self->last_hash_index = mem->last_hash_index;
-  self->last_hash = fd_wksp_laddr_fast( ctx->wksp, mem->last_hash_gaddr );
-  self->ages_len = mem->ages_len;
-  self->ages     = fd_wksp_laddr_fast( ctx->wksp, mem->ages_gaddr );
-  self->max_age = mem->max_age;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_block_hash_vec_new(fd_block_hash_vec_t * self) {
   fd_memset( self, 0, sizeof(fd_block_hash_vec_t) );
@@ -716,7 +627,7 @@ ulong fd_block_hash_vec_size( fd_block_hash_vec_t const * self ) {
   ulong size = 0;
   size += sizeof(ulong);
   size += sizeof(char);
-  if( NULL !=  self->last_hash ) {
+  if( NULL != self->last_hash ) {
     size += fd_hash_size( self->last_hash );
   }
   do {
@@ -746,6 +657,39 @@ int fd_block_hash_queue_encode( fd_block_hash_queue_t const * self, fd_bincode_e
     err = fd_bincode_uint64_encode( ages_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     for( fd_hash_hash_age_pair_t_mapnode_t * n = fd_hash_hash_age_pair_t_map_minimum( self->ages_pool, self->ages_root ); n; n = fd_hash_hash_age_pair_t_map_successor( self->ages_pool, n ) ) {
+      err = fd_hash_hash_age_pair_encode( &n->elem, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong ages_len = 0;
+    err = fd_bincode_uint64_encode( ages_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_uint64_encode( self->max_age, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_block_hash_queue_encode_global( fd_block_hash_queue_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->last_hash_index, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->last_hash_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    fd_hash_t * last_hash = fd_wksp_laddr_fast( ctx->wksp, self->last_hash_gaddr );
+    err = fd_hash_encode( last_hash, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  fd_hash_hash_age_pair_t_mapnode_t * ages_root = fd_hash_hash_age_pair_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->ages_root_gaddr ) );
+  fd_hash_hash_age_pair_t_mapnode_t * ages_pool = fd_hash_hash_age_pair_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->ages_pool_gaddr ) );
+  if( ages_root ) {
+    ulong ages_len = fd_hash_hash_age_pair_t_map_size( ages_pool, ages_root );
+    err = fd_bincode_uint64_encode( ages_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( fd_hash_hash_age_pair_t_mapnode_t * n = fd_hash_hash_age_pair_t_map_minimum( ages_pool, ages_root ); n; n = fd_hash_hash_age_pair_t_map_successor( ages_pool, n ) ) {
       err = fd_hash_hash_age_pair_encode( &n->elem, ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
@@ -849,7 +793,7 @@ void fd_block_hash_queue_decode_inner_global( void * struct_mem, void * * alloc_
       self->last_hash_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
       fd_hash_new( *alloc_mem );
       *alloc_mem = (uchar *)*alloc_mem + FD_HASH_FOOTPRINT;
-      fd_hash_decode_inner_global( fd_wksp_laddr_fast( ctx->wksp, self->last_hash_gaddr ), alloc_mem, ctx );
+      fd_hash_decode_inner( fd_wksp_laddr_fast( ctx->wksp, self->last_hash_gaddr ), alloc_mem, ctx );
     } else {
       self->last_hash_gaddr = 0UL;
     }
@@ -859,26 +803,15 @@ void fd_block_hash_queue_decode_inner_global( void * struct_mem, void * * alloc_
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, fd_hash_hash_age_pair_t_map_align() );
   fd_hash_hash_age_pair_t_mapnode_t * ages_pool = fd_hash_hash_age_pair_t_map_join_new( alloc_mem, fd_ulong_max( ages_len, 400 ) );
   fd_hash_hash_age_pair_t_mapnode_t * ages_root = NULL;
-  self->ages_root_gaddr = 0UL;
   for( ulong i=0; i < ages_len; i++ ) {
     fd_hash_hash_age_pair_t_mapnode_t * node = fd_hash_hash_age_pair_t_map_acquire( ages_pool );
-    fd_hash_hash_age_pair_new( &node->elem );
+    fd_hash_hash_age_pair_new( (fd_hash_hash_age_pair_t *)fd_type_pun(&node->elem) );
     fd_hash_hash_age_pair_decode_inner( &node->elem, alloc_mem, ctx );
     fd_hash_hash_age_pair_t_map_insert( ages_pool, &ages_root, node );
   }
-  self->ages_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, ages_pool );
-  self->ages_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, ages_root );
+  self->ages_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_hash_hash_age_pair_t_map_leave( ages_pool ) );
+  self->ages_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_hash_hash_age_pair_t_map_leave( ages_root ) );
   fd_bincode_uint64_decode_unsafe( &self->max_age, ctx );
-}
-int fd_block_hash_queue_convert_global_to_local( void const * global_self, fd_block_hash_queue_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_block_hash_queue_global_t const * mem = (fd_block_hash_queue_global_t const *)global_self;
-  self->last_hash_index = mem->last_hash_index;
-  self->last_hash = fd_wksp_laddr_fast( ctx->wksp, mem->last_hash_gaddr );
-  self->ages_pool = fd_wksp_laddr_fast( ctx->wksp, mem->ages_pool_gaddr );
-  self->ages_root = fd_wksp_laddr_fast( ctx->wksp, mem->ages_root_gaddr );
-  self->max_age = mem->max_age;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_block_hash_queue_new(fd_block_hash_queue_t * self) {
   fd_memset( self, 0, sizeof(fd_block_hash_queue_t) );
@@ -918,7 +851,7 @@ ulong fd_block_hash_queue_size( fd_block_hash_queue_t const * self ) {
   ulong size = 0;
   size += sizeof(ulong);
   size += sizeof(char);
-  if( NULL !=  self->last_hash ) {
+  if( NULL != self->last_hash ) {
     size += fd_hash_size( self->last_hash );
   }
   if( self->ages_root ) {
@@ -986,32 +919,6 @@ void fd_fee_rate_governor_decode_inner( void * struct_mem, void * * alloc_mem, f
   fd_bincode_uint64_decode_unsafe( &self->max_lamports_per_signature, ctx );
   fd_bincode_uint8_decode_unsafe( &self->burn_percent, ctx );
 }
-void * fd_fee_rate_governor_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_fee_rate_governor_global_t * self = (fd_fee_rate_governor_global_t *)mem;
-  fd_fee_rate_governor_new( (fd_fee_rate_governor_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_fee_rate_governor_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_fee_rate_governor_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_fee_rate_governor_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_fee_rate_governor_global_t * self = (fd_fee_rate_governor_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->target_lamports_per_signature, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->target_signatures_per_slot, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->min_lamports_per_signature, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->max_lamports_per_signature, ctx );
-  fd_bincode_uint8_decode_unsafe( &self->burn_percent, ctx );
-}
-int fd_fee_rate_governor_convert_global_to_local( void const * global_self, fd_fee_rate_governor_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_fee_rate_governor_global_t const * mem = (fd_fee_rate_governor_global_t const *)global_self;
-  self->target_lamports_per_signature = mem->target_lamports_per_signature;
-  self->target_signatures_per_slot = mem->target_signatures_per_slot;
-  self->min_lamports_per_signature = mem->min_lamports_per_signature;
-  self->max_lamports_per_signature = mem->max_lamports_per_signature;
-  self->burn_percent = mem->burn_percent;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_fee_rate_governor_new(fd_fee_rate_governor_t * self) {
   fd_memset( self, 0, sizeof(fd_fee_rate_governor_t) );
 }
@@ -1077,26 +984,6 @@ void fd_slot_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincod
   fd_slot_pair_t * self = (fd_slot_pair_t *)struct_mem;
   fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
   fd_bincode_uint64_decode_unsafe( &self->val, ctx );
-}
-void * fd_slot_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_slot_pair_global_t * self = (fd_slot_pair_global_t *)mem;
-  fd_slot_pair_new( (fd_slot_pair_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_slot_pair_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_slot_pair_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_slot_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_slot_pair_global_t * self = (fd_slot_pair_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->val, ctx );
-}
-int fd_slot_pair_convert_global_to_local( void const * global_self, fd_slot_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_slot_pair_global_t const * mem = (fd_slot_pair_global_t const *)global_self;
-  self->slot = mem->slot;
-  self->val = mem->val;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_slot_pair_new(fd_slot_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_slot_pair_t) );
@@ -1176,36 +1063,6 @@ void fd_hard_forks_decode_inner( void * struct_mem, void * * alloc_mem, fd_binco
     }
   } else
     self->hard_forks = NULL;
-}
-void * fd_hard_forks_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_hard_forks_global_t * self = (fd_hard_forks_global_t *)mem;
-  fd_hard_forks_new( (fd_hard_forks_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_hard_forks_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_hard_forks_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_hard_forks_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_hard_forks_global_t * self = (fd_hard_forks_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->hard_forks_len, ctx );
-  if( self->hard_forks_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_SLOT_PAIR_ALIGN );
-    self->hard_forks_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_SLOT_PAIR_FOOTPRINT*self->hard_forks_len;
-    for( ulong i=0; i < self->hard_forks_len; i++ ) {
-      fd_slot_pair_new( (fd_slot_pair_t *)(cur_mem + FD_SLOT_PAIR_FOOTPRINT * i) );
-      fd_slot_pair_decode_inner_global( cur_mem + FD_SLOT_PAIR_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->hard_forks_gaddr = 0UL;
-}
-int fd_hard_forks_convert_global_to_local( void const * global_self, fd_hard_forks_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_hard_forks_global_t const * mem = (fd_hard_forks_global_t const *)global_self;
-  self->hard_forks_len = mem->hard_forks_len;
-  self->hard_forks     = fd_wksp_laddr_fast( ctx->wksp, mem->hard_forks_gaddr );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_hard_forks_new(fd_hard_forks_t * self) {
   fd_memset( self, 0, sizeof(fd_hard_forks_t) );
@@ -1299,34 +1156,6 @@ void fd_inflation_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincod
   fd_bincode_double_decode_unsafe( &self->foundation_term, ctx );
   fd_bincode_double_decode_unsafe( &self->unused, ctx );
 }
-void * fd_inflation_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_inflation_global_t * self = (fd_inflation_global_t *)mem;
-  fd_inflation_new( (fd_inflation_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_inflation_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_inflation_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_inflation_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_inflation_global_t * self = (fd_inflation_global_t *)struct_mem;
-  fd_bincode_double_decode_unsafe( &self->initial, ctx );
-  fd_bincode_double_decode_unsafe( &self->terminal, ctx );
-  fd_bincode_double_decode_unsafe( &self->taper, ctx );
-  fd_bincode_double_decode_unsafe( &self->foundation, ctx );
-  fd_bincode_double_decode_unsafe( &self->foundation_term, ctx );
-  fd_bincode_double_decode_unsafe( &self->unused, ctx );
-}
-int fd_inflation_convert_global_to_local( void const * global_self, fd_inflation_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_inflation_global_t const * mem = (fd_inflation_global_t const *)global_self;
-  self->initial = mem->initial;
-  self->terminal = mem->terminal;
-  self->taper = mem->taper;
-  self->foundation = mem->foundation;
-  self->foundation_term = mem->foundation_term;
-  self->unused = mem->unused;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_inflation_new(fd_inflation_t * self) {
   fd_memset( self, 0, sizeof(fd_inflation_t) );
 }
@@ -1399,28 +1228,6 @@ void fd_rent_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_dec
   fd_bincode_uint64_decode_unsafe( &self->lamports_per_uint8_year, ctx );
   fd_bincode_double_decode_unsafe( &self->exemption_threshold, ctx );
   fd_bincode_uint8_decode_unsafe( &self->burn_percent, ctx );
-}
-void * fd_rent_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_rent_global_t * self = (fd_rent_global_t *)mem;
-  fd_rent_new( (fd_rent_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_rent_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_rent_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_rent_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_rent_global_t * self = (fd_rent_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->lamports_per_uint8_year, ctx );
-  fd_bincode_double_decode_unsafe( &self->exemption_threshold, ctx );
-  fd_bincode_uint8_decode_unsafe( &self->burn_percent, ctx );
-}
-int fd_rent_convert_global_to_local( void const * global_self, fd_rent_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_rent_global_t const * mem = (fd_rent_global_t const *)global_self;
-  self->lamports_per_uint8_year = mem->lamports_per_uint8_year;
-  self->exemption_threshold = mem->exemption_threshold;
-  self->burn_percent = mem->burn_percent;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_rent_new(fd_rent_t * self) {
   fd_memset( self, 0, sizeof(fd_rent_t) );
@@ -1499,32 +1306,6 @@ void fd_epoch_schedule_decode_inner( void * struct_mem, void * * alloc_mem, fd_b
   fd_bincode_uint64_decode_unsafe( &self->first_normal_epoch, ctx );
   fd_bincode_uint64_decode_unsafe( &self->first_normal_slot, ctx );
 }
-void * fd_epoch_schedule_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_epoch_schedule_global_t * self = (fd_epoch_schedule_global_t *)mem;
-  fd_epoch_schedule_new( (fd_epoch_schedule_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_epoch_schedule_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_epoch_schedule_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_epoch_schedule_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_epoch_schedule_global_t * self = (fd_epoch_schedule_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->slots_per_epoch, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->leader_schedule_slot_offset, ctx );
-  fd_bincode_bool_decode_unsafe( &self->warmup, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->first_normal_epoch, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->first_normal_slot, ctx );
-}
-int fd_epoch_schedule_convert_global_to_local( void const * global_self, fd_epoch_schedule_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_epoch_schedule_global_t const * mem = (fd_epoch_schedule_global_t const *)global_self;
-  self->slots_per_epoch = mem->slots_per_epoch;
-  self->leader_schedule_slot_offset = mem->leader_schedule_slot_offset;
-  self->warmup = mem->warmup;
-  self->first_normal_epoch = mem->first_normal_epoch;
-  self->first_normal_slot = mem->first_normal_slot;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_epoch_schedule_new(fd_epoch_schedule_t * self) {
   fd_memset( self, 0, sizeof(fd_epoch_schedule_t) );
 }
@@ -1600,32 +1381,6 @@ void fd_rent_collector_decode_inner( void * struct_mem, void * * alloc_mem, fd_b
   fd_epoch_schedule_decode_inner( &self->epoch_schedule, alloc_mem, ctx );
   fd_bincode_double_decode_unsafe( &self->slots_per_year, ctx );
   fd_rent_decode_inner( &self->rent, alloc_mem, ctx );
-}
-void * fd_rent_collector_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_rent_collector_global_t * self = (fd_rent_collector_global_t *)mem;
-  fd_rent_collector_new( (fd_rent_collector_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_rent_collector_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_rent_collector_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_rent_collector_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_rent_collector_global_t * self = (fd_rent_collector_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->epoch, ctx );
-  fd_epoch_schedule_decode_inner_global( &self->epoch_schedule, alloc_mem, ctx );
-  fd_bincode_double_decode_unsafe( &self->slots_per_year, ctx );
-  fd_rent_decode_inner_global( &self->rent, alloc_mem, ctx );
-}
-int fd_rent_collector_convert_global_to_local( void const * global_self, fd_rent_collector_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_rent_collector_global_t const * mem = (fd_rent_collector_global_t const *)global_self;
-  self->epoch = mem->epoch;
-  err = fd_epoch_schedule_convert_global_to_local( &mem->epoch_schedule, &self->epoch_schedule, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->slots_per_year = mem->slots_per_year;
-  err = fd_rent_convert_global_to_local( &mem->rent, &self->rent, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_rent_collector_new(fd_rent_collector_t * self) {
   fd_memset( self, 0, sizeof(fd_rent_collector_t) );
@@ -1705,30 +1460,6 @@ void fd_stake_history_entry_decode_inner( void * struct_mem, void * * alloc_mem,
   fd_bincode_uint64_decode_unsafe( &self->activating, ctx );
   fd_bincode_uint64_decode_unsafe( &self->deactivating, ctx );
 }
-void * fd_stake_history_entry_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_history_entry_global_t * self = (fd_stake_history_entry_global_t *)mem;
-  fd_stake_history_entry_new( (fd_stake_history_entry_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_stake_history_entry_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_stake_history_entry_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_stake_history_entry_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_history_entry_global_t * self = (fd_stake_history_entry_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->epoch, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->effective, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->activating, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->deactivating, ctx );
-}
-int fd_stake_history_entry_convert_global_to_local( void const * global_self, fd_stake_history_entry_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stake_history_entry_global_t const * mem = (fd_stake_history_entry_global_t const *)global_self;
-  self->epoch = mem->epoch;
-  self->effective = mem->effective;
-  self->activating = mem->activating;
-  self->deactivating = mem->deactivating;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_stake_history_entry_new(fd_stake_history_entry_t * self) {
   fd_memset( self, 0, sizeof(fd_stake_history_entry_t) );
 }
@@ -1805,35 +1536,6 @@ void fd_stake_history_decode_inner( void * struct_mem, void * * alloc_mem, fd_bi
   for( ulong i=0; i<self->fd_stake_history_len; i++ ) {
     fd_stake_history_entry_decode_inner( self->fd_stake_history + i, alloc_mem, ctx );
   }
-}
-void * fd_stake_history_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_history_global_t * self = (fd_stake_history_global_t *)mem;
-  fd_stake_history_new( (fd_stake_history_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_stake_history_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_stake_history_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_stake_history_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_history_global_t * self = (fd_stake_history_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->fd_stake_history_len, ctx );
-  self->fd_stake_history_size = 512;
-  self->fd_stake_history_offset = 0;
-  for( ulong i=0; i<self->fd_stake_history_len; i++ ) {
-    fd_stake_history_entry_decode_inner_global( self->fd_stake_history + i, alloc_mem, ctx );
-  }
-}
-int fd_stake_history_convert_global_to_local( void const * global_self, fd_stake_history_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stake_history_global_t const * mem = (fd_stake_history_global_t const *)global_self;
-  self->fd_stake_history_len    = mem->fd_stake_history_len;
-  self->fd_stake_history_size   = mem->fd_stake_history_size;
-  self->fd_stake_history_offset = mem->fd_stake_history_offset;
-  for( ulong i=0; i<self->fd_stake_history_len; i++ ) {
-    err = fd_stake_history_entry_convert_global_to_local( &mem->fd_stake_history[i], &self->fd_stake_history[i], ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-  }
-  return FD_BINCODE_SUCCESS;
 }
 void fd_stake_history_new(fd_stake_history_t * self) {
   fd_memset( self, 0, sizeof(fd_stake_history_t) );
@@ -1936,40 +1638,6 @@ void fd_solana_account_decode_inner( void * struct_mem, void * * alloc_mem, fd_b
   fd_bincode_bool_decode_unsafe( &self->executable, ctx );
   fd_bincode_uint64_decode_unsafe( &self->rent_epoch, ctx );
 }
-void * fd_solana_account_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_solana_account_global_t * self = (fd_solana_account_global_t *)mem;
-  fd_solana_account_new( (fd_solana_account_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_solana_account_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_solana_account_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_solana_account_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_solana_account_global_t * self = (fd_solana_account_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->lamports, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->data_len, ctx );
-  if( self->data_len ) {
-    self->data_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    fd_bincode_bytes_decode_unsafe( *alloc_mem, self->data_len, ctx );
-    *alloc_mem = (uchar *)(*alloc_mem) + self->data_len;
-  } else
-    self->data_gaddr = 0UL;
-  fd_pubkey_decode_inner_global( &self->owner, alloc_mem, ctx );
-  fd_bincode_bool_decode_unsafe( &self->executable, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->rent_epoch, ctx );
-}
-int fd_solana_account_convert_global_to_local( void const * global_self, fd_solana_account_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_solana_account_global_t const * mem = (fd_solana_account_global_t const *)global_self;
-  self->lamports = mem->lamports;
-  self->data_len = mem->data_len;
-  self->data     = fd_wksp_laddr_fast( ctx->wksp, mem->data_gaddr );
-  err = fd_pubkey_convert_global_to_local( &mem->owner, &self->owner, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->executable = mem->executable;
-  self->rent_epoch = mem->rent_epoch;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_solana_account_new(fd_solana_account_t * self) {
   fd_memset( self, 0, sizeof(fd_solana_account_t) );
   fd_pubkey_new( &self->owner );
@@ -2049,30 +1717,6 @@ void fd_vote_accounts_pair_decode_inner( void * struct_mem, void * * alloc_mem, 
   fd_bincode_uint64_decode_unsafe( &self->stake, ctx );
   fd_solana_account_decode_inner( &self->value, alloc_mem, ctx );
 }
-void * fd_vote_accounts_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_accounts_pair_global_t * self = (fd_vote_accounts_pair_global_t *)mem;
-  fd_vote_accounts_pair_new( (fd_vote_accounts_pair_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_vote_accounts_pair_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_vote_accounts_pair_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_vote_accounts_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_accounts_pair_global_t * self = (fd_vote_accounts_pair_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->key, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->stake, ctx );
-  fd_solana_account_decode_inner_global( &self->value, alloc_mem, ctx );
-}
-int fd_vote_accounts_pair_convert_global_to_local( void const * global_self, fd_vote_accounts_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_accounts_pair_global_t const * mem = (fd_vote_accounts_pair_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->key, &self->key, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->stake = mem->stake;
-  err = fd_solana_account_convert_global_to_local( &mem->value, &self->value, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_vote_accounts_pair_new(fd_vote_accounts_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_accounts_pair_t) );
   fd_pubkey_new( &self->key );
@@ -2108,6 +1752,25 @@ int fd_vote_accounts_encode( fd_vote_accounts_t const * self, fd_bincode_encode_
     err = fd_bincode_uint64_encode( vote_accounts_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     for( fd_vote_accounts_pair_t_mapnode_t * n = fd_vote_accounts_pair_t_map_minimum( self->vote_accounts_pool, self->vote_accounts_root ); n; n = fd_vote_accounts_pair_t_map_successor( self->vote_accounts_pool, n ) ) {
+      err = fd_vote_accounts_pair_encode( &n->elem, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong vote_accounts_len = 0;
+    err = fd_bincode_uint64_encode( vote_accounts_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_vote_accounts_encode_global( fd_vote_accounts_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  fd_vote_accounts_pair_t_mapnode_t * vote_accounts_root = fd_vote_accounts_pair_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->vote_accounts_root_gaddr ) );
+  fd_vote_accounts_pair_t_mapnode_t * vote_accounts_pool = fd_vote_accounts_pair_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->vote_accounts_pool_gaddr ) );
+  if( vote_accounts_root ) {
+    ulong vote_accounts_len = fd_vote_accounts_pair_t_map_size( vote_accounts_pool, vote_accounts_root );
+    err = fd_bincode_uint64_encode( vote_accounts_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( fd_vote_accounts_pair_t_mapnode_t * n = fd_vote_accounts_pair_t_map_minimum( vote_accounts_pool, vote_accounts_root ); n; n = fd_vote_accounts_pair_t_map_successor( vote_accounts_pool, n ) ) {
       err = fd_vote_accounts_pair_encode( &n->elem, ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
@@ -2176,22 +1839,14 @@ void fd_vote_accounts_decode_inner_global( void * struct_mem, void * * alloc_mem
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, fd_vote_accounts_pair_t_map_align() );
   fd_vote_accounts_pair_t_mapnode_t * vote_accounts_pool = fd_vote_accounts_pair_t_map_join_new( alloc_mem, fd_ulong_max( vote_accounts_len, 15000 ) );
   fd_vote_accounts_pair_t_mapnode_t * vote_accounts_root = NULL;
-  self->vote_accounts_root_gaddr = 0UL;
   for( ulong i=0; i < vote_accounts_len; i++ ) {
     fd_vote_accounts_pair_t_mapnode_t * node = fd_vote_accounts_pair_t_map_acquire( vote_accounts_pool );
-    fd_vote_accounts_pair_new( &node->elem );
+    fd_vote_accounts_pair_new( (fd_vote_accounts_pair_t *)fd_type_pun(&node->elem) );
     fd_vote_accounts_pair_decode_inner( &node->elem, alloc_mem, ctx );
     fd_vote_accounts_pair_t_map_insert( vote_accounts_pool, &vote_accounts_root, node );
   }
-  self->vote_accounts_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, vote_accounts_pool );
-  self->vote_accounts_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, vote_accounts_root );
-}
-int fd_vote_accounts_convert_global_to_local( void const * global_self, fd_vote_accounts_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_accounts_global_t const * mem = (fd_vote_accounts_global_t const *)global_self;
-  self->vote_accounts_pool = fd_wksp_laddr_fast( ctx->wksp, mem->vote_accounts_pool_gaddr );
-  self->vote_accounts_root = fd_wksp_laddr_fast( ctx->wksp, mem->vote_accounts_root_gaddr );
-  return FD_BINCODE_SUCCESS;
+  self->vote_accounts_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_vote_accounts_pair_t_map_leave( vote_accounts_pool ) );
+  self->vote_accounts_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_vote_accounts_pair_t_map_leave( vote_accounts_root ) );
 }
 void fd_vote_accounts_new(fd_vote_accounts_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_accounts_t) );
@@ -2267,27 +1922,6 @@ void fd_account_keys_pair_decode_inner( void * struct_mem, void * * alloc_mem, f
   fd_pubkey_decode_inner( &self->key, alloc_mem, ctx );
   fd_bincode_uint8_decode_unsafe( &self->exists, ctx );
 }
-void * fd_account_keys_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_account_keys_pair_global_t * self = (fd_account_keys_pair_global_t *)mem;
-  fd_account_keys_pair_new( (fd_account_keys_pair_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_account_keys_pair_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_account_keys_pair_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_account_keys_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_account_keys_pair_global_t * self = (fd_account_keys_pair_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->key, alloc_mem, ctx );
-  fd_bincode_uint8_decode_unsafe( &self->exists, ctx );
-}
-int fd_account_keys_pair_convert_global_to_local( void const * global_self, fd_account_keys_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_account_keys_pair_global_t const * mem = (fd_account_keys_pair_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->key, &self->key, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->exists = mem->exists;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_account_keys_pair_new(fd_account_keys_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_account_keys_pair_t) );
   fd_pubkey_new( &self->key );
@@ -2319,6 +1953,25 @@ int fd_account_keys_encode( fd_account_keys_t const * self, fd_bincode_encode_ct
     err = fd_bincode_uint64_encode( account_keys_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     for( fd_account_keys_pair_t_mapnode_t * n = fd_account_keys_pair_t_map_minimum( self->account_keys_pool, self->account_keys_root ); n; n = fd_account_keys_pair_t_map_successor( self->account_keys_pool, n ) ) {
+      err = fd_account_keys_pair_encode( &n->elem, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong account_keys_len = 0;
+    err = fd_bincode_uint64_encode( account_keys_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_account_keys_encode_global( fd_account_keys_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  fd_account_keys_pair_t_mapnode_t * account_keys_root = fd_account_keys_pair_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->account_keys_root_gaddr ) );
+  fd_account_keys_pair_t_mapnode_t * account_keys_pool = fd_account_keys_pair_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->account_keys_pool_gaddr ) );
+  if( account_keys_root ) {
+    ulong account_keys_len = fd_account_keys_pair_t_map_size( account_keys_pool, account_keys_root );
+    err = fd_bincode_uint64_encode( account_keys_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( fd_account_keys_pair_t_mapnode_t * n = fd_account_keys_pair_t_map_minimum( account_keys_pool, account_keys_root ); n; n = fd_account_keys_pair_t_map_successor( account_keys_pool, n ) ) {
       err = fd_account_keys_pair_encode( &n->elem, ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
@@ -2387,22 +2040,14 @@ void fd_account_keys_decode_inner_global( void * struct_mem, void * * alloc_mem,
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, fd_account_keys_pair_t_map_align() );
   fd_account_keys_pair_t_mapnode_t * account_keys_pool = fd_account_keys_pair_t_map_join_new( alloc_mem, fd_ulong_max( account_keys_len, 100000 ) );
   fd_account_keys_pair_t_mapnode_t * account_keys_root = NULL;
-  self->account_keys_root_gaddr = 0UL;
   for( ulong i=0; i < account_keys_len; i++ ) {
     fd_account_keys_pair_t_mapnode_t * node = fd_account_keys_pair_t_map_acquire( account_keys_pool );
-    fd_account_keys_pair_new( &node->elem );
+    fd_account_keys_pair_new( (fd_account_keys_pair_t *)fd_type_pun(&node->elem) );
     fd_account_keys_pair_decode_inner( &node->elem, alloc_mem, ctx );
     fd_account_keys_pair_t_map_insert( account_keys_pool, &account_keys_root, node );
   }
-  self->account_keys_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, account_keys_pool );
-  self->account_keys_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, account_keys_root );
-}
-int fd_account_keys_convert_global_to_local( void const * global_self, fd_account_keys_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_account_keys_global_t const * mem = (fd_account_keys_global_t const *)global_self;
-  self->account_keys_pool = fd_wksp_laddr_fast( ctx->wksp, mem->account_keys_pool_gaddr );
-  self->account_keys_root = fd_wksp_laddr_fast( ctx->wksp, mem->account_keys_root_gaddr );
-  return FD_BINCODE_SUCCESS;
+  self->account_keys_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_account_keys_pair_t_map_leave( account_keys_pool ) );
+  self->account_keys_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_account_keys_pair_t_map_leave( account_keys_root ) );
 }
 void fd_account_keys_new(fd_account_keys_t * self) {
   fd_memset( self, 0, sizeof(fd_account_keys_t) );
@@ -2478,27 +2123,6 @@ void fd_stake_weight_decode_inner( void * struct_mem, void * * alloc_mem, fd_bin
   fd_pubkey_decode_inner( &self->key, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->stake, ctx );
 }
-void * fd_stake_weight_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_weight_global_t * self = (fd_stake_weight_global_t *)mem;
-  fd_stake_weight_new( (fd_stake_weight_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_stake_weight_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_stake_weight_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_stake_weight_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_weight_global_t * self = (fd_stake_weight_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->key, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->stake, ctx );
-}
-int fd_stake_weight_convert_global_to_local( void const * global_self, fd_stake_weight_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stake_weight_global_t const * mem = (fd_stake_weight_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->key, &self->key, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->stake = mem->stake;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_stake_weight_new(fd_stake_weight_t * self) {
   fd_memset( self, 0, sizeof(fd_stake_weight_t) );
   fd_pubkey_new( &self->key );
@@ -2530,6 +2154,25 @@ int fd_stake_weights_encode( fd_stake_weights_t const * self, fd_bincode_encode_
     err = fd_bincode_uint64_encode( stake_weights_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     for( fd_stake_weight_t_mapnode_t * n = fd_stake_weight_t_map_minimum( self->stake_weights_pool, self->stake_weights_root ); n; n = fd_stake_weight_t_map_successor( self->stake_weights_pool, n ) ) {
+      err = fd_stake_weight_encode( &n->elem, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong stake_weights_len = 0;
+    err = fd_bincode_uint64_encode( stake_weights_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_stake_weights_encode_global( fd_stake_weights_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  fd_stake_weight_t_mapnode_t * stake_weights_root = fd_stake_weight_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->stake_weights_root_gaddr ) );
+  fd_stake_weight_t_mapnode_t * stake_weights_pool = fd_stake_weight_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->stake_weights_pool_gaddr ) );
+  if( stake_weights_root ) {
+    ulong stake_weights_len = fd_stake_weight_t_map_size( stake_weights_pool, stake_weights_root );
+    err = fd_bincode_uint64_encode( stake_weights_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( fd_stake_weight_t_mapnode_t * n = fd_stake_weight_t_map_minimum( stake_weights_pool, stake_weights_root ); n; n = fd_stake_weight_t_map_successor( stake_weights_pool, n ) ) {
       err = fd_stake_weight_encode( &n->elem, ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
@@ -2598,22 +2241,14 @@ void fd_stake_weights_decode_inner_global( void * struct_mem, void * * alloc_mem
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, fd_stake_weight_t_map_align() );
   fd_stake_weight_t_mapnode_t * stake_weights_pool = fd_stake_weight_t_map_join_new( alloc_mem, stake_weights_len );
   fd_stake_weight_t_mapnode_t * stake_weights_root = NULL;
-  self->stake_weights_root_gaddr = 0UL;
   for( ulong i=0; i < stake_weights_len; i++ ) {
     fd_stake_weight_t_mapnode_t * node = fd_stake_weight_t_map_acquire( stake_weights_pool );
-    fd_stake_weight_new( &node->elem );
+    fd_stake_weight_new( (fd_stake_weight_t *)fd_type_pun(&node->elem) );
     fd_stake_weight_decode_inner( &node->elem, alloc_mem, ctx );
     fd_stake_weight_t_map_insert( stake_weights_pool, &stake_weights_root, node );
   }
-  self->stake_weights_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, stake_weights_pool );
-  self->stake_weights_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, stake_weights_root );
-}
-int fd_stake_weights_convert_global_to_local( void const * global_self, fd_stake_weights_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stake_weights_global_t const * mem = (fd_stake_weights_global_t const *)global_self;
-  self->stake_weights_pool = fd_wksp_laddr_fast( ctx->wksp, mem->stake_weights_pool_gaddr );
-  self->stake_weights_root = fd_wksp_laddr_fast( ctx->wksp, mem->stake_weights_root_gaddr );
-  return FD_BINCODE_SUCCESS;
+  self->stake_weights_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_stake_weight_t_map_leave( stake_weights_pool ) );
+  self->stake_weights_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_stake_weight_t_map_leave( stake_weights_root ) );
 }
 void fd_stake_weights_new(fd_stake_weights_t * self) {
   fd_memset( self, 0, sizeof(fd_stake_weights_t) );
@@ -2704,33 +2339,6 @@ void fd_delegation_decode_inner( void * struct_mem, void * * alloc_mem, fd_binco
   fd_bincode_uint64_decode_unsafe( &self->deactivation_epoch, ctx );
   fd_bincode_double_decode_unsafe( &self->warmup_cooldown_rate, ctx );
 }
-void * fd_delegation_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_delegation_global_t * self = (fd_delegation_global_t *)mem;
-  fd_delegation_new( (fd_delegation_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_delegation_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_delegation_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_delegation_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_delegation_global_t * self = (fd_delegation_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->voter_pubkey, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->stake, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->activation_epoch, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->deactivation_epoch, ctx );
-  fd_bincode_double_decode_unsafe( &self->warmup_cooldown_rate, ctx );
-}
-int fd_delegation_convert_global_to_local( void const * global_self, fd_delegation_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_delegation_global_t const * mem = (fd_delegation_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->voter_pubkey, &self->voter_pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->stake = mem->stake;
-  self->activation_epoch = mem->activation_epoch;
-  self->deactivation_epoch = mem->deactivation_epoch;
-  self->warmup_cooldown_rate = mem->warmup_cooldown_rate;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_delegation_new(fd_delegation_t * self) {
   fd_memset( self, 0, sizeof(fd_delegation_t) );
   fd_pubkey_new( &self->voter_pubkey );
@@ -2799,28 +2407,6 @@ void fd_delegation_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_
   fd_pubkey_decode_inner( &self->account, alloc_mem, ctx );
   fd_delegation_decode_inner( &self->delegation, alloc_mem, ctx );
 }
-void * fd_delegation_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_delegation_pair_global_t * self = (fd_delegation_pair_global_t *)mem;
-  fd_delegation_pair_new( (fd_delegation_pair_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_delegation_pair_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_delegation_pair_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_delegation_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_delegation_pair_global_t * self = (fd_delegation_pair_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->account, alloc_mem, ctx );
-  fd_delegation_decode_inner_global( &self->delegation, alloc_mem, ctx );
-}
-int fd_delegation_pair_convert_global_to_local( void const * global_self, fd_delegation_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_delegation_pair_global_t const * mem = (fd_delegation_pair_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->account, &self->account, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_delegation_convert_global_to_local( &mem->delegation, &self->delegation, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_delegation_pair_new(fd_delegation_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_delegation_pair_t) );
   fd_pubkey_new( &self->account );
@@ -2885,27 +2471,6 @@ void fd_stake_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_de
   fd_delegation_decode_inner( &self->delegation, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->credits_observed, ctx );
 }
-void * fd_stake_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_global_t * self = (fd_stake_global_t *)mem;
-  fd_stake_new( (fd_stake_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_stake_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_stake_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_stake_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_global_t * self = (fd_stake_global_t *)struct_mem;
-  fd_delegation_decode_inner_global( &self->delegation, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->credits_observed, ctx );
-}
-int fd_stake_convert_global_to_local( void const * global_self, fd_stake_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stake_global_t const * mem = (fd_stake_global_t const *)global_self;
-  err = fd_delegation_convert_global_to_local( &mem->delegation, &self->delegation, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->credits_observed = mem->credits_observed;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_stake_new(fd_stake_t * self) {
   fd_memset( self, 0, sizeof(fd_stake_t) );
   fd_delegation_new( &self->delegation );
@@ -2968,28 +2533,6 @@ void fd_stake_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_binco
   fd_pubkey_decode_inner( &self->account, alloc_mem, ctx );
   fd_stake_decode_inner( &self->stake, alloc_mem, ctx );
 }
-void * fd_stake_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_pair_global_t * self = (fd_stake_pair_global_t *)mem;
-  fd_stake_pair_new( (fd_stake_pair_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_stake_pair_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_stake_pair_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_stake_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_pair_global_t * self = (fd_stake_pair_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->account, alloc_mem, ctx );
-  fd_stake_decode_inner_global( &self->stake, alloc_mem, ctx );
-}
-int fd_stake_pair_convert_global_to_local( void const * global_self, fd_stake_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stake_pair_global_t const * mem = (fd_stake_pair_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->account, &self->account, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_stake_convert_global_to_local( &mem->stake, &self->stake, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_stake_pair_new(fd_stake_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_stake_pair_t) );
   fd_pubkey_new( &self->account );
@@ -3025,6 +2568,33 @@ int fd_stakes_encode( fd_stakes_t const * self, fd_bincode_encode_ctx_t * ctx ) 
     err = fd_bincode_uint64_encode( stake_delegations_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     for( fd_delegation_pair_t_mapnode_t * n = fd_delegation_pair_t_map_minimum( self->stake_delegations_pool, self->stake_delegations_root ); n; n = fd_delegation_pair_t_map_successor( self->stake_delegations_pool, n ) ) {
+      err = fd_delegation_pair_encode( &n->elem, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong stake_delegations_len = 0;
+    err = fd_bincode_uint64_encode( stake_delegations_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_uint64_encode( self->unused, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->epoch, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_stake_history_encode( &self->stake_history, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_stakes_encode_global( fd_stakes_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_vote_accounts_encode_global( &self->vote_accounts, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  fd_delegation_pair_t_mapnode_t * stake_delegations_root = fd_delegation_pair_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->stake_delegations_root_gaddr ) );
+  fd_delegation_pair_t_mapnode_t * stake_delegations_pool = fd_delegation_pair_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->stake_delegations_pool_gaddr ) );
+  if( stake_delegations_root ) {
+    ulong stake_delegations_len = fd_delegation_pair_t_map_size( stake_delegations_pool, stake_delegations_root );
+    err = fd_bincode_uint64_encode( stake_delegations_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( fd_delegation_pair_t_mapnode_t * n = fd_delegation_pair_t_map_minimum( stake_delegations_pool, stake_delegations_root ); n; n = fd_delegation_pair_t_map_successor( stake_delegations_pool, n ) ) {
       err = fd_delegation_pair_encode( &n->elem, ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
@@ -3112,31 +2682,17 @@ void fd_stakes_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bi
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, fd_delegation_pair_t_map_align() );
   fd_delegation_pair_t_mapnode_t * stake_delegations_pool = fd_delegation_pair_t_map_join_new( alloc_mem, stake_delegations_len );
   fd_delegation_pair_t_mapnode_t * stake_delegations_root = NULL;
-  self->stake_delegations_root_gaddr = 0UL;
   for( ulong i=0; i < stake_delegations_len; i++ ) {
     fd_delegation_pair_t_mapnode_t * node = fd_delegation_pair_t_map_acquire( stake_delegations_pool );
-    fd_delegation_pair_new( &node->elem );
+    fd_delegation_pair_new( (fd_delegation_pair_t *)fd_type_pun(&node->elem) );
     fd_delegation_pair_decode_inner( &node->elem, alloc_mem, ctx );
     fd_delegation_pair_t_map_insert( stake_delegations_pool, &stake_delegations_root, node );
   }
-  self->stake_delegations_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, stake_delegations_pool );
-  self->stake_delegations_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, stake_delegations_root );
+  self->stake_delegations_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_delegation_pair_t_map_leave( stake_delegations_pool ) );
+  self->stake_delegations_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_delegation_pair_t_map_leave( stake_delegations_root ) );
   fd_bincode_uint64_decode_unsafe( &self->unused, ctx );
   fd_bincode_uint64_decode_unsafe( &self->epoch, ctx );
-  fd_stake_history_decode_inner_global( &self->stake_history, alloc_mem, ctx );
-}
-int fd_stakes_convert_global_to_local( void const * global_self, fd_stakes_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stakes_global_t const * mem = (fd_stakes_global_t const *)global_self;
-  err = fd_vote_accounts_convert_global_to_local( &mem->vote_accounts, &self->vote_accounts, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->stake_delegations_pool = fd_wksp_laddr_fast( ctx->wksp, mem->stake_delegations_pool_gaddr );
-  self->stake_delegations_root = fd_wksp_laddr_fast( ctx->wksp, mem->stake_delegations_root_gaddr );
-  self->unused = mem->unused;
-  self->epoch = mem->epoch;
-  err = fd_stake_history_convert_global_to_local( &mem->stake_history, &self->stake_history, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  fd_stake_history_decode_inner( &self->stake_history, alloc_mem, ctx );
 }
 void fd_stakes_new(fd_stakes_t * self) {
   fd_memset( self, 0, sizeof(fd_stakes_t) );
@@ -3195,6 +2751,33 @@ int fd_stakes_stake_encode( fd_stakes_stake_t const * self, fd_bincode_encode_ct
     err = fd_bincode_uint64_encode( stake_delegations_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     for( fd_stake_pair_t_mapnode_t * n = fd_stake_pair_t_map_minimum( self->stake_delegations_pool, self->stake_delegations_root ); n; n = fd_stake_pair_t_map_successor( self->stake_delegations_pool, n ) ) {
+      err = fd_stake_pair_encode( &n->elem, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong stake_delegations_len = 0;
+    err = fd_bincode_uint64_encode( stake_delegations_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_uint64_encode( self->unused, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->epoch, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_stake_history_encode( &self->stake_history, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_stakes_stake_encode_global( fd_stakes_stake_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_vote_accounts_encode_global( &self->vote_accounts, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  fd_stake_pair_t_mapnode_t * stake_delegations_root = fd_stake_pair_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->stake_delegations_root_gaddr ) );
+  fd_stake_pair_t_mapnode_t * stake_delegations_pool = fd_stake_pair_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->stake_delegations_pool_gaddr ) );
+  if( stake_delegations_root ) {
+    ulong stake_delegations_len = fd_stake_pair_t_map_size( stake_delegations_pool, stake_delegations_root );
+    err = fd_bincode_uint64_encode( stake_delegations_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( fd_stake_pair_t_mapnode_t * n = fd_stake_pair_t_map_minimum( stake_delegations_pool, stake_delegations_root ); n; n = fd_stake_pair_t_map_successor( stake_delegations_pool, n ) ) {
       err = fd_stake_pair_encode( &n->elem, ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
@@ -3282,31 +2865,17 @@ void fd_stakes_stake_decode_inner_global( void * struct_mem, void * * alloc_mem,
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, fd_stake_pair_t_map_align() );
   fd_stake_pair_t_mapnode_t * stake_delegations_pool = fd_stake_pair_t_map_join_new( alloc_mem, stake_delegations_len );
   fd_stake_pair_t_mapnode_t * stake_delegations_root = NULL;
-  self->stake_delegations_root_gaddr = 0UL;
   for( ulong i=0; i < stake_delegations_len; i++ ) {
     fd_stake_pair_t_mapnode_t * node = fd_stake_pair_t_map_acquire( stake_delegations_pool );
-    fd_stake_pair_new( &node->elem );
+    fd_stake_pair_new( (fd_stake_pair_t *)fd_type_pun(&node->elem) );
     fd_stake_pair_decode_inner( &node->elem, alloc_mem, ctx );
     fd_stake_pair_t_map_insert( stake_delegations_pool, &stake_delegations_root, node );
   }
-  self->stake_delegations_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, stake_delegations_pool );
-  self->stake_delegations_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, stake_delegations_root );
+  self->stake_delegations_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_stake_pair_t_map_leave( stake_delegations_pool ) );
+  self->stake_delegations_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_stake_pair_t_map_leave( stake_delegations_root ) );
   fd_bincode_uint64_decode_unsafe( &self->unused, ctx );
   fd_bincode_uint64_decode_unsafe( &self->epoch, ctx );
-  fd_stake_history_decode_inner_global( &self->stake_history, alloc_mem, ctx );
-}
-int fd_stakes_stake_convert_global_to_local( void const * global_self, fd_stakes_stake_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stakes_stake_global_t const * mem = (fd_stakes_stake_global_t const *)global_self;
-  err = fd_vote_accounts_convert_global_to_local( &mem->vote_accounts, &self->vote_accounts, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->stake_delegations_pool = fd_wksp_laddr_fast( ctx->wksp, mem->stake_delegations_pool_gaddr );
-  self->stake_delegations_root = fd_wksp_laddr_fast( ctx->wksp, mem->stake_delegations_root_gaddr );
-  self->unused = mem->unused;
-  self->epoch = mem->epoch;
-  err = fd_stake_history_convert_global_to_local( &mem->stake_history, &self->stake_history, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  fd_stake_history_decode_inner( &self->stake_history, alloc_mem, ctx );
 }
 void fd_stakes_stake_new(fd_stakes_stake_t * self) {
   fd_memset( self, 0, sizeof(fd_stakes_stake_t) );
@@ -3409,34 +2978,6 @@ void fd_bank_incremental_snapshot_persistence_decode_inner( void * struct_mem, v
   fd_hash_decode_inner( &self->incremental_hash, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->incremental_capitalization, ctx );
 }
-void * fd_bank_incremental_snapshot_persistence_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bank_incremental_snapshot_persistence_global_t * self = (fd_bank_incremental_snapshot_persistence_global_t *)mem;
-  fd_bank_incremental_snapshot_persistence_new( (fd_bank_incremental_snapshot_persistence_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_bank_incremental_snapshot_persistence_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_bank_incremental_snapshot_persistence_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_bank_incremental_snapshot_persistence_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bank_incremental_snapshot_persistence_global_t * self = (fd_bank_incremental_snapshot_persistence_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->full_slot, ctx );
-  fd_hash_decode_inner_global( &self->full_hash, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->full_capitalization, ctx );
-  fd_hash_decode_inner_global( &self->incremental_hash, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->incremental_capitalization, ctx );
-}
-int fd_bank_incremental_snapshot_persistence_convert_global_to_local( void const * global_self, fd_bank_incremental_snapshot_persistence_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_bank_incremental_snapshot_persistence_global_t const * mem = (fd_bank_incremental_snapshot_persistence_global_t const *)global_self;
-  self->full_slot = mem->full_slot;
-  err = fd_hash_convert_global_to_local( &mem->full_hash, &self->full_hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->full_capitalization = mem->full_capitalization;
-  err = fd_hash_convert_global_to_local( &mem->incremental_hash, &self->incremental_hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->incremental_capitalization = mem->incremental_capitalization;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_bank_incremental_snapshot_persistence_new(fd_bank_incremental_snapshot_persistence_t * self) {
   fd_memset( self, 0, sizeof(fd_bank_incremental_snapshot_persistence_t) );
   fd_hash_new( &self->full_hash );
@@ -3531,38 +3072,6 @@ void fd_node_vote_accounts_decode_inner( void * struct_mem, void * * alloc_mem, 
     self->vote_accounts = NULL;
   fd_bincode_uint64_decode_unsafe( &self->total_stake, ctx );
 }
-void * fd_node_vote_accounts_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_node_vote_accounts_global_t * self = (fd_node_vote_accounts_global_t *)mem;
-  fd_node_vote_accounts_new( (fd_node_vote_accounts_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_node_vote_accounts_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_node_vote_accounts_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_node_vote_accounts_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_node_vote_accounts_global_t * self = (fd_node_vote_accounts_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->vote_accounts_len, ctx );
-  if( self->vote_accounts_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_PUBKEY_ALIGN );
-    self->vote_accounts_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_PUBKEY_FOOTPRINT*self->vote_accounts_len;
-    for( ulong i=0; i < self->vote_accounts_len; i++ ) {
-      fd_pubkey_new( (fd_pubkey_t *)(cur_mem + FD_PUBKEY_FOOTPRINT * i) );
-      fd_pubkey_decode_inner_global( cur_mem + FD_PUBKEY_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->vote_accounts_gaddr = 0UL;
-  fd_bincode_uint64_decode_unsafe( &self->total_stake, ctx );
-}
-int fd_node_vote_accounts_convert_global_to_local( void const * global_self, fd_node_vote_accounts_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_node_vote_accounts_global_t const * mem = (fd_node_vote_accounts_global_t const *)global_self;
-  self->vote_accounts_len = mem->vote_accounts_len;
-  self->vote_accounts     = fd_wksp_laddr_fast( ctx->wksp, mem->vote_accounts_gaddr );
-  self->total_stake = mem->total_stake;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_node_vote_accounts_new(fd_node_vote_accounts_t * self) {
   fd_memset( self, 0, sizeof(fd_node_vote_accounts_t) );
 }
@@ -3637,28 +3146,6 @@ void fd_pubkey_node_vote_accounts_pair_decode_inner( void * struct_mem, void * *
   fd_pubkey_decode_inner( &self->key, alloc_mem, ctx );
   fd_node_vote_accounts_decode_inner( &self->value, alloc_mem, ctx );
 }
-void * fd_pubkey_node_vote_accounts_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_pubkey_node_vote_accounts_pair_global_t * self = (fd_pubkey_node_vote_accounts_pair_global_t *)mem;
-  fd_pubkey_node_vote_accounts_pair_new( (fd_pubkey_node_vote_accounts_pair_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_pubkey_node_vote_accounts_pair_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_pubkey_node_vote_accounts_pair_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_pubkey_node_vote_accounts_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_pubkey_node_vote_accounts_pair_global_t * self = (fd_pubkey_node_vote_accounts_pair_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->key, alloc_mem, ctx );
-  fd_node_vote_accounts_decode_inner_global( &self->value, alloc_mem, ctx );
-}
-int fd_pubkey_node_vote_accounts_pair_convert_global_to_local( void const * global_self, fd_pubkey_node_vote_accounts_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_pubkey_node_vote_accounts_pair_global_t const * mem = (fd_pubkey_node_vote_accounts_pair_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->key, &self->key, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_node_vote_accounts_convert_global_to_local( &mem->value, &self->value, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_pubkey_node_vote_accounts_pair_new(fd_pubkey_node_vote_accounts_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_pubkey_node_vote_accounts_pair_t) );
   fd_pubkey_new( &self->key );
@@ -3723,28 +3210,6 @@ void fd_pubkey_pubkey_pair_decode_inner( void * struct_mem, void * * alloc_mem, 
   fd_pubkey_decode_inner( &self->key, alloc_mem, ctx );
   fd_pubkey_decode_inner( &self->value, alloc_mem, ctx );
 }
-void * fd_pubkey_pubkey_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_pubkey_pubkey_pair_global_t * self = (fd_pubkey_pubkey_pair_global_t *)mem;
-  fd_pubkey_pubkey_pair_new( (fd_pubkey_pubkey_pair_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_pubkey_pubkey_pair_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_pubkey_pubkey_pair_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_pubkey_pubkey_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_pubkey_pubkey_pair_global_t * self = (fd_pubkey_pubkey_pair_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->key, alloc_mem, ctx );
-  fd_pubkey_decode_inner_global( &self->value, alloc_mem, ctx );
-}
-int fd_pubkey_pubkey_pair_convert_global_to_local( void const * global_self, fd_pubkey_pubkey_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_pubkey_pubkey_pair_global_t const * mem = (fd_pubkey_pubkey_pair_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->key, &self->key, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_pubkey_convert_global_to_local( &mem->value, &self->value, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_pubkey_pubkey_pair_new(fd_pubkey_pubkey_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_pubkey_pubkey_pair_t) );
   fd_pubkey_new( &self->key );
@@ -3790,6 +3255,34 @@ int fd_epoch_stakes_encode( fd_epoch_stakes_t const * self, fd_bincode_encode_ct
   if( self->epoch_authorized_voters_len ) {
     for( ulong i=0; i < self->epoch_authorized_voters_len; i++ ) {
       err = fd_pubkey_pubkey_pair_encode( self->epoch_authorized_voters + i, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_epoch_stakes_encode_global( fd_epoch_stakes_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_stakes_encode_global( &self->stakes, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->total_stake, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->node_id_to_vote_accounts_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->node_id_to_vote_accounts_len ) {
+    uchar * node_id_to_vote_accounts_laddr = fd_wksp_laddr_fast( ctx->wksp, self->node_id_to_vote_accounts_gaddr );
+    fd_pubkey_node_vote_accounts_pair_t * node_id_to_vote_accounts = (fd_pubkey_node_vote_accounts_pair_t *)node_id_to_vote_accounts_laddr;
+    for( ulong i=0; i < self->node_id_to_vote_accounts_len; i++ ) {
+      err = fd_pubkey_node_vote_accounts_pair_encode( &node_id_to_vote_accounts[i], ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  err = fd_bincode_uint64_encode( self->epoch_authorized_voters_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->epoch_authorized_voters_len ) {
+    uchar * epoch_authorized_voters_laddr = fd_wksp_laddr_fast( ctx->wksp, self->epoch_authorized_voters_gaddr );
+    fd_pubkey_pubkey_pair_t * epoch_authorized_voters = (fd_pubkey_pubkey_pair_t *)epoch_authorized_voters_laddr;
+    for( ulong i=0; i < self->epoch_authorized_voters_len; i++ ) {
+      err = fd_pubkey_pubkey_pair_encode( &epoch_authorized_voters[i], ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
   }
@@ -3886,11 +3379,12 @@ void fd_epoch_stakes_decode_inner_global( void * struct_mem, void * * alloc_mem,
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_FOOTPRINT*self->node_id_to_vote_accounts_len;
     for( ulong i=0; i < self->node_id_to_vote_accounts_len; i++ ) {
-      fd_pubkey_node_vote_accounts_pair_new( (fd_pubkey_node_vote_accounts_pair_t *)(cur_mem + FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_FOOTPRINT * i) );
-      fd_pubkey_node_vote_accounts_pair_decode_inner_global( cur_mem + FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_FOOTPRINT * i, alloc_mem, ctx );
+      fd_pubkey_node_vote_accounts_pair_new( (fd_pubkey_node_vote_accounts_pair_t *)fd_type_pun(cur_mem + FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_FOOTPRINT * i) );
+      fd_pubkey_node_vote_accounts_pair_decode_inner( cur_mem + FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->node_id_to_vote_accounts_gaddr = 0UL;
+  }
   fd_bincode_uint64_decode_unsafe( &self->epoch_authorized_voters_len, ctx );
   if( self->epoch_authorized_voters_len ) {
     *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_PUBKEY_PUBKEY_PAIR_ALIGN );
@@ -3898,23 +3392,12 @@ void fd_epoch_stakes_decode_inner_global( void * struct_mem, void * * alloc_mem,
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_PUBKEY_PUBKEY_PAIR_FOOTPRINT*self->epoch_authorized_voters_len;
     for( ulong i=0; i < self->epoch_authorized_voters_len; i++ ) {
-      fd_pubkey_pubkey_pair_new( (fd_pubkey_pubkey_pair_t *)(cur_mem + FD_PUBKEY_PUBKEY_PAIR_FOOTPRINT * i) );
-      fd_pubkey_pubkey_pair_decode_inner_global( cur_mem + FD_PUBKEY_PUBKEY_PAIR_FOOTPRINT * i, alloc_mem, ctx );
+      fd_pubkey_pubkey_pair_new( (fd_pubkey_pubkey_pair_t *)fd_type_pun(cur_mem + FD_PUBKEY_PUBKEY_PAIR_FOOTPRINT * i) );
+      fd_pubkey_pubkey_pair_decode_inner( cur_mem + FD_PUBKEY_PUBKEY_PAIR_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->epoch_authorized_voters_gaddr = 0UL;
-}
-int fd_epoch_stakes_convert_global_to_local( void const * global_self, fd_epoch_stakes_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_epoch_stakes_global_t const * mem = (fd_epoch_stakes_global_t const *)global_self;
-  err = fd_stakes_convert_global_to_local( &mem->stakes, &self->stakes, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->total_stake = mem->total_stake;
-  self->node_id_to_vote_accounts_len = mem->node_id_to_vote_accounts_len;
-  self->node_id_to_vote_accounts     = fd_wksp_laddr_fast( ctx->wksp, mem->node_id_to_vote_accounts_gaddr );
-  self->epoch_authorized_voters_len = mem->epoch_authorized_voters_len;
-  self->epoch_authorized_voters     = fd_wksp_laddr_fast( ctx->wksp, mem->epoch_authorized_voters_gaddr );
-  return FD_BINCODE_SUCCESS;
+  }
 }
 void fd_epoch_stakes_new(fd_epoch_stakes_t * self) {
   fd_memset( self, 0, sizeof(fd_epoch_stakes_t) );
@@ -3980,6 +3463,14 @@ int fd_epoch_epoch_stakes_pair_encode( fd_epoch_epoch_stakes_pair_t const * self
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
+int fd_epoch_epoch_stakes_pair_encode_global( fd_epoch_epoch_stakes_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->key, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_epoch_stakes_encode_global( &self->value, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
 int fd_epoch_epoch_stakes_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_epoch_epoch_stakes_pair_t);
   void const * start_data = ctx->data;
@@ -4022,14 +3513,6 @@ void fd_epoch_epoch_stakes_pair_decode_inner_global( void * struct_mem, void * *
   fd_epoch_epoch_stakes_pair_global_t * self = (fd_epoch_epoch_stakes_pair_global_t *)struct_mem;
   fd_bincode_uint64_decode_unsafe( &self->key, ctx );
   fd_epoch_stakes_decode_inner_global( &self->value, alloc_mem, ctx );
-}
-int fd_epoch_epoch_stakes_pair_convert_global_to_local( void const * global_self, fd_epoch_epoch_stakes_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_epoch_epoch_stakes_pair_global_t const * mem = (fd_epoch_epoch_stakes_pair_global_t const *)global_self;
-  self->key = mem->key;
-  err = fd_epoch_stakes_convert_global_to_local( &mem->value, &self->value, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_epoch_epoch_stakes_pair_new(fd_epoch_epoch_stakes_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_epoch_epoch_stakes_pair_t) );
@@ -4092,27 +3575,6 @@ void fd_pubkey_u64_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_
   fd_pubkey_u64_pair_t * self = (fd_pubkey_u64_pair_t *)struct_mem;
   fd_pubkey_decode_inner( &self->_0, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->_1, ctx );
-}
-void * fd_pubkey_u64_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_pubkey_u64_pair_global_t * self = (fd_pubkey_u64_pair_global_t *)mem;
-  fd_pubkey_u64_pair_new( (fd_pubkey_u64_pair_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_pubkey_u64_pair_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_pubkey_u64_pair_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_pubkey_u64_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_pubkey_u64_pair_global_t * self = (fd_pubkey_u64_pair_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->_0, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->_1, ctx );
-}
-int fd_pubkey_u64_pair_convert_global_to_local( void const * global_self, fd_pubkey_u64_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_pubkey_u64_pair_global_t const * mem = (fd_pubkey_u64_pair_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->_0, &self->_0, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->_1 = mem->_1;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_pubkey_u64_pair_new(fd_pubkey_u64_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_pubkey_u64_pair_t) );
@@ -4252,64 +3714,6 @@ void fd_unused_accounts_decode_inner( void * struct_mem, void * * alloc_mem, fd_
     }
   } else
     self->unused3 = NULL;
-}
-void * fd_unused_accounts_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_unused_accounts_global_t * self = (fd_unused_accounts_global_t *)mem;
-  fd_unused_accounts_new( (fd_unused_accounts_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_unused_accounts_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_unused_accounts_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_unused_accounts_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_unused_accounts_global_t * self = (fd_unused_accounts_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->unused1_len, ctx );
-  if( self->unused1_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_PUBKEY_ALIGN );
-    self->unused1_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_PUBKEY_FOOTPRINT*self->unused1_len;
-    for( ulong i=0; i < self->unused1_len; i++ ) {
-      fd_pubkey_new( (fd_pubkey_t *)(cur_mem + FD_PUBKEY_FOOTPRINT * i) );
-      fd_pubkey_decode_inner_global( cur_mem + FD_PUBKEY_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->unused1_gaddr = 0UL;
-  fd_bincode_uint64_decode_unsafe( &self->unused2_len, ctx );
-  if( self->unused2_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_PUBKEY_ALIGN );
-    self->unused2_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_PUBKEY_FOOTPRINT*self->unused2_len;
-    for( ulong i=0; i < self->unused2_len; i++ ) {
-      fd_pubkey_new( (fd_pubkey_t *)(cur_mem + FD_PUBKEY_FOOTPRINT * i) );
-      fd_pubkey_decode_inner_global( cur_mem + FD_PUBKEY_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->unused2_gaddr = 0UL;
-  fd_bincode_uint64_decode_unsafe( &self->unused3_len, ctx );
-  if( self->unused3_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_PUBKEY_U64_PAIR_ALIGN );
-    self->unused3_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_PUBKEY_U64_PAIR_FOOTPRINT*self->unused3_len;
-    for( ulong i=0; i < self->unused3_len; i++ ) {
-      fd_pubkey_u64_pair_new( (fd_pubkey_u64_pair_t *)(cur_mem + FD_PUBKEY_U64_PAIR_FOOTPRINT * i) );
-      fd_pubkey_u64_pair_decode_inner_global( cur_mem + FD_PUBKEY_U64_PAIR_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->unused3_gaddr = 0UL;
-}
-int fd_unused_accounts_convert_global_to_local( void const * global_self, fd_unused_accounts_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_unused_accounts_global_t const * mem = (fd_unused_accounts_global_t const *)global_self;
-  self->unused1_len = mem->unused1_len;
-  self->unused1     = fd_wksp_laddr_fast( ctx->wksp, mem->unused1_gaddr );
-  self->unused2_len = mem->unused2_len;
-  self->unused2     = fd_wksp_laddr_fast( ctx->wksp, mem->unused2_gaddr );
-  self->unused3_len = mem->unused3_len;
-  self->unused3     = fd_wksp_laddr_fast( ctx->wksp, mem->unused3_gaddr );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_unused_accounts_new(fd_unused_accounts_t * self) {
   fd_memset( self, 0, sizeof(fd_unused_accounts_t) );
@@ -4457,6 +3861,98 @@ int fd_versioned_bank_encode( fd_versioned_bank_t const * self, fd_bincode_encod
   if( self->epoch_stakes_len ) {
     for( ulong i=0; i < self->epoch_stakes_len; i++ ) {
       err = fd_epoch_epoch_stakes_pair_encode( self->epoch_stakes + i, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  err = fd_bincode_bool_encode( (uchar)(self->is_delta), ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_versioned_bank_encode_global( fd_versioned_bank_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_block_hash_vec_encode_global( &self->blockhash_queue, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->ancestors_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->ancestors_len ) {
+    uchar * ancestors_laddr = fd_wksp_laddr_fast( ctx->wksp, self->ancestors_gaddr );
+    fd_slot_pair_t * ancestors = (fd_slot_pair_t *)ancestors_laddr;
+    for( ulong i=0; i < self->ancestors_len; i++ ) {
+      err = fd_slot_pair_encode( &ancestors[i], ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  err = fd_hash_encode( &self->hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_hash_encode( &self->parent_hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->parent_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_hard_forks_encode( &self->hard_forks, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->transaction_count, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->tick_height, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->signature_count, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->capitalization, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->max_tick_height, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->hashes_per_tick_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    ulong * hashes_per_tick = fd_wksp_laddr_fast( ctx->wksp, self->hashes_per_tick_gaddr );
+    err = fd_bincode_uint64_encode( hashes_per_tick[0], ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_uint64_encode( self->ticks_per_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint128_encode( self->ns_per_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->genesis_creation_time, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_double_encode( self->slots_per_year, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->accounts_data_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->epoch, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->block_height, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_pubkey_encode( &self->collector_id, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->collector_fees, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_fee_calculator_encode( &self->fee_calculator, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_fee_rate_governor_encode( &self->fee_rate_governor, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->collected_rent, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_rent_collector_encode( &self->rent_collector, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_epoch_schedule_encode( &self->epoch_schedule, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_inflation_encode( &self->inflation, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_stakes_encode_global( &self->stakes, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_unused_accounts_encode( &self->unused_accounts, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->epoch_stakes_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->epoch_stakes_len ) {
+    uchar * epoch_stakes_laddr = fd_wksp_laddr_fast( ctx->wksp, self->epoch_stakes_gaddr );
+    fd_epoch_epoch_stakes_pair_global_t * epoch_stakes = (fd_epoch_epoch_stakes_pair_global_t *)epoch_stakes_laddr;
+    for( ulong i=0; i < self->epoch_stakes_len; i++ ) {
+      err = fd_epoch_epoch_stakes_pair_encode_global( &epoch_stakes[i], ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
   }
@@ -4657,15 +4153,16 @@ void fd_versioned_bank_decode_inner_global( void * struct_mem, void * * alloc_me
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_SLOT_PAIR_FOOTPRINT*self->ancestors_len;
     for( ulong i=0; i < self->ancestors_len; i++ ) {
-      fd_slot_pair_new( (fd_slot_pair_t *)(cur_mem + FD_SLOT_PAIR_FOOTPRINT * i) );
-      fd_slot_pair_decode_inner_global( cur_mem + FD_SLOT_PAIR_FOOTPRINT * i, alloc_mem, ctx );
+      fd_slot_pair_new( (fd_slot_pair_t *)fd_type_pun(cur_mem + FD_SLOT_PAIR_FOOTPRINT * i) );
+      fd_slot_pair_decode_inner( cur_mem + FD_SLOT_PAIR_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->ancestors_gaddr = 0UL;
-  fd_hash_decode_inner_global( &self->hash, alloc_mem, ctx );
-  fd_hash_decode_inner_global( &self->parent_hash, alloc_mem, ctx );
+  }
+  fd_hash_decode_inner( &self->hash, alloc_mem, ctx );
+  fd_hash_decode_inner( &self->parent_hash, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->parent_slot, ctx );
-  fd_hard_forks_decode_inner_global( &self->hard_forks, alloc_mem, ctx );
+  fd_hard_forks_decode_inner( &self->hard_forks, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->transaction_count, ctx );
   fd_bincode_uint64_decode_unsafe( &self->tick_height, ctx );
   fd_bincode_uint64_decode_unsafe( &self->signature_count, ctx );
@@ -4691,16 +4188,16 @@ void fd_versioned_bank_decode_inner_global( void * struct_mem, void * * alloc_me
   fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
   fd_bincode_uint64_decode_unsafe( &self->epoch, ctx );
   fd_bincode_uint64_decode_unsafe( &self->block_height, ctx );
-  fd_pubkey_decode_inner_global( &self->collector_id, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->collector_id, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->collector_fees, ctx );
-  fd_fee_calculator_decode_inner_global( &self->fee_calculator, alloc_mem, ctx );
-  fd_fee_rate_governor_decode_inner_global( &self->fee_rate_governor, alloc_mem, ctx );
+  fd_fee_calculator_decode_inner( &self->fee_calculator, alloc_mem, ctx );
+  fd_fee_rate_governor_decode_inner( &self->fee_rate_governor, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->collected_rent, ctx );
-  fd_rent_collector_decode_inner_global( &self->rent_collector, alloc_mem, ctx );
-  fd_epoch_schedule_decode_inner_global( &self->epoch_schedule, alloc_mem, ctx );
-  fd_inflation_decode_inner_global( &self->inflation, alloc_mem, ctx );
+  fd_rent_collector_decode_inner( &self->rent_collector, alloc_mem, ctx );
+  fd_epoch_schedule_decode_inner( &self->epoch_schedule, alloc_mem, ctx );
+  fd_inflation_decode_inner( &self->inflation, alloc_mem, ctx );
   fd_stakes_decode_inner_global( &self->stakes, alloc_mem, ctx );
-  fd_unused_accounts_decode_inner_global( &self->unused_accounts, alloc_mem, ctx );
+  fd_unused_accounts_decode_inner( &self->unused_accounts, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->epoch_stakes_len, ctx );
   if( self->epoch_stakes_len ) {
     *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_EPOCH_EPOCH_STAKES_PAIR_ALIGN );
@@ -4708,63 +4205,13 @@ void fd_versioned_bank_decode_inner_global( void * struct_mem, void * * alloc_me
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_EPOCH_EPOCH_STAKES_PAIR_FOOTPRINT*self->epoch_stakes_len;
     for( ulong i=0; i < self->epoch_stakes_len; i++ ) {
-      fd_epoch_epoch_stakes_pair_new( (fd_epoch_epoch_stakes_pair_t *)(cur_mem + FD_EPOCH_EPOCH_STAKES_PAIR_FOOTPRINT * i) );
+      fd_epoch_epoch_stakes_pair_new( (fd_epoch_epoch_stakes_pair_t *)fd_type_pun(cur_mem + FD_EPOCH_EPOCH_STAKES_PAIR_FOOTPRINT * i) );
       fd_epoch_epoch_stakes_pair_decode_inner_global( cur_mem + FD_EPOCH_EPOCH_STAKES_PAIR_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->epoch_stakes_gaddr = 0UL;
+  }
   fd_bincode_bool_decode_unsafe( &self->is_delta, ctx );
-}
-int fd_versioned_bank_convert_global_to_local( void const * global_self, fd_versioned_bank_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_versioned_bank_global_t const * mem = (fd_versioned_bank_global_t const *)global_self;
-  err = fd_block_hash_vec_convert_global_to_local( &mem->blockhash_queue, &self->blockhash_queue, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->ancestors_len = mem->ancestors_len;
-  self->ancestors     = fd_wksp_laddr_fast( ctx->wksp, mem->ancestors_gaddr );
-  err = fd_hash_convert_global_to_local( &mem->hash, &self->hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_hash_convert_global_to_local( &mem->parent_hash, &self->parent_hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->parent_slot = mem->parent_slot;
-  err = fd_hard_forks_convert_global_to_local( &mem->hard_forks, &self->hard_forks, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->transaction_count = mem->transaction_count;
-  self->tick_height = mem->tick_height;
-  self->signature_count = mem->signature_count;
-  self->capitalization = mem->capitalization;
-  self->max_tick_height = mem->max_tick_height;
-  self->hashes_per_tick = fd_wksp_laddr_fast( ctx->wksp, mem->hashes_per_tick_gaddr );
-  self->ticks_per_slot = mem->ticks_per_slot;
-  self->ns_per_slot = mem->ns_per_slot;
-  self->genesis_creation_time = mem->genesis_creation_time;
-  self->slots_per_year = mem->slots_per_year;
-  self->accounts_data_len = mem->accounts_data_len;
-  self->slot = mem->slot;
-  self->epoch = mem->epoch;
-  self->block_height = mem->block_height;
-  err = fd_pubkey_convert_global_to_local( &mem->collector_id, &self->collector_id, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->collector_fees = mem->collector_fees;
-  err = fd_fee_calculator_convert_global_to_local( &mem->fee_calculator, &self->fee_calculator, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_fee_rate_governor_convert_global_to_local( &mem->fee_rate_governor, &self->fee_rate_governor, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->collected_rent = mem->collected_rent;
-  err = fd_rent_collector_convert_global_to_local( &mem->rent_collector, &self->rent_collector, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_epoch_schedule_convert_global_to_local( &mem->epoch_schedule, &self->epoch_schedule, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_inflation_convert_global_to_local( &mem->inflation, &self->inflation, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_stakes_convert_global_to_local( &mem->stakes, &self->stakes, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_unused_accounts_convert_global_to_local( &mem->unused_accounts, &self->unused_accounts, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->epoch_stakes_len = mem->epoch_stakes_len;
-  self->epoch_stakes     = fd_wksp_laddr_fast( ctx->wksp, mem->epoch_stakes_gaddr );
-  self->is_delta = mem->is_delta;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_versioned_bank_new(fd_versioned_bank_t * self) {
   fd_memset( self, 0, sizeof(fd_versioned_bank_t) );
@@ -4880,7 +4327,7 @@ ulong fd_versioned_bank_size( fd_versioned_bank_t const * self ) {
   size += sizeof(ulong);
   size += sizeof(ulong);
   size += sizeof(char);
-  if( NULL !=  self->hashes_per_tick ) {
+  if( NULL != self->hashes_per_tick ) {
     size += sizeof(ulong);
   }
   size += sizeof(ulong);
@@ -4963,32 +4410,6 @@ void fd_bank_hash_stats_decode_inner( void * struct_mem, void * * alloc_mem, fd_
   fd_bincode_uint64_decode_unsafe( &self->total_data_len, ctx );
   fd_bincode_uint64_decode_unsafe( &self->num_executable_accounts, ctx );
 }
-void * fd_bank_hash_stats_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bank_hash_stats_global_t * self = (fd_bank_hash_stats_global_t *)mem;
-  fd_bank_hash_stats_new( (fd_bank_hash_stats_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_bank_hash_stats_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_bank_hash_stats_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_bank_hash_stats_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bank_hash_stats_global_t * self = (fd_bank_hash_stats_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->num_updated_accounts, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->num_removed_accounts, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->num_lamports_stored, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->total_data_len, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->num_executable_accounts, ctx );
-}
-int fd_bank_hash_stats_convert_global_to_local( void const * global_self, fd_bank_hash_stats_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_bank_hash_stats_global_t const * mem = (fd_bank_hash_stats_global_t const *)global_self;
-  self->num_updated_accounts = mem->num_updated_accounts;
-  self->num_removed_accounts = mem->num_removed_accounts;
-  self->num_lamports_stored = mem->num_lamports_stored;
-  self->total_data_len = mem->total_data_len;
-  self->num_executable_accounts = mem->num_executable_accounts;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_bank_hash_stats_new(fd_bank_hash_stats_t * self) {
   fd_memset( self, 0, sizeof(fd_bank_hash_stats_t) );
 }
@@ -5060,31 +4481,6 @@ void fd_bank_hash_info_decode_inner( void * struct_mem, void * * alloc_mem, fd_b
   fd_hash_decode_inner( &self->accounts_hash, alloc_mem, ctx );
   fd_bank_hash_stats_decode_inner( &self->stats, alloc_mem, ctx );
 }
-void * fd_bank_hash_info_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bank_hash_info_global_t * self = (fd_bank_hash_info_global_t *)mem;
-  fd_bank_hash_info_new( (fd_bank_hash_info_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_bank_hash_info_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_bank_hash_info_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_bank_hash_info_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bank_hash_info_global_t * self = (fd_bank_hash_info_global_t *)struct_mem;
-  fd_hash_decode_inner_global( &self->accounts_delta_hash, alloc_mem, ctx );
-  fd_hash_decode_inner_global( &self->accounts_hash, alloc_mem, ctx );
-  fd_bank_hash_stats_decode_inner_global( &self->stats, alloc_mem, ctx );
-}
-int fd_bank_hash_info_convert_global_to_local( void const * global_self, fd_bank_hash_info_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_bank_hash_info_global_t const * mem = (fd_bank_hash_info_global_t const *)global_self;
-  err = fd_hash_convert_global_to_local( &mem->accounts_delta_hash, &self->accounts_delta_hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_hash_convert_global_to_local( &mem->accounts_hash, &self->accounts_hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_bank_hash_stats_convert_global_to_local( &mem->stats, &self->stats, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_bank_hash_info_new(fd_bank_hash_info_t * self) {
   fd_memset( self, 0, sizeof(fd_bank_hash_info_t) );
   fd_hash_new( &self->accounts_delta_hash );
@@ -5153,27 +4549,6 @@ void fd_slot_map_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bi
   fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
   fd_hash_decode_inner( &self->hash, alloc_mem, ctx );
 }
-void * fd_slot_map_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_slot_map_pair_global_t * self = (fd_slot_map_pair_global_t *)mem;
-  fd_slot_map_pair_new( (fd_slot_map_pair_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_slot_map_pair_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_slot_map_pair_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_slot_map_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_slot_map_pair_global_t * self = (fd_slot_map_pair_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-  fd_hash_decode_inner_global( &self->hash, alloc_mem, ctx );
-}
-int fd_slot_map_pair_convert_global_to_local( void const * global_self, fd_slot_map_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_slot_map_pair_global_t const * mem = (fd_slot_map_pair_global_t const *)global_self;
-  self->slot = mem->slot;
-  err = fd_hash_convert_global_to_local( &mem->hash, &self->hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_slot_map_pair_new(fd_slot_map_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_slot_map_pair_t) );
   fd_hash_new( &self->hash );
@@ -5235,26 +4610,6 @@ void fd_snapshot_acc_vec_decode_inner( void * struct_mem, void * * alloc_mem, fd
   fd_snapshot_acc_vec_t * self = (fd_snapshot_acc_vec_t *)struct_mem;
   fd_bincode_uint64_decode_unsafe( &self->id, ctx );
   fd_bincode_uint64_decode_unsafe( &self->file_sz, ctx );
-}
-void * fd_snapshot_acc_vec_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_snapshot_acc_vec_global_t * self = (fd_snapshot_acc_vec_global_t *)mem;
-  fd_snapshot_acc_vec_new( (fd_snapshot_acc_vec_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_snapshot_acc_vec_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_snapshot_acc_vec_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_snapshot_acc_vec_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_snapshot_acc_vec_global_t * self = (fd_snapshot_acc_vec_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->id, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->file_sz, ctx );
-}
-int fd_snapshot_acc_vec_convert_global_to_local( void const * global_self, fd_snapshot_acc_vec_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_snapshot_acc_vec_global_t const * mem = (fd_snapshot_acc_vec_global_t const *)global_self;
-  self->id = mem->id;
-  self->file_sz = mem->file_sz;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_snapshot_acc_vec_new(fd_snapshot_acc_vec_t * self) {
   fd_memset( self, 0, sizeof(fd_snapshot_acc_vec_t) );
@@ -5339,38 +4694,6 @@ void fd_snapshot_slot_acc_vecs_decode_inner( void * struct_mem, void * * alloc_m
     }
   } else
     self->account_vecs = NULL;
-}
-void * fd_snapshot_slot_acc_vecs_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_snapshot_slot_acc_vecs_global_t * self = (fd_snapshot_slot_acc_vecs_global_t *)mem;
-  fd_snapshot_slot_acc_vecs_new( (fd_snapshot_slot_acc_vecs_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_snapshot_slot_acc_vecs_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_snapshot_slot_acc_vecs_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_snapshot_slot_acc_vecs_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_snapshot_slot_acc_vecs_global_t * self = (fd_snapshot_slot_acc_vecs_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->account_vecs_len, ctx );
-  if( self->account_vecs_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_SNAPSHOT_ACC_VEC_ALIGN );
-    self->account_vecs_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_SNAPSHOT_ACC_VEC_FOOTPRINT*self->account_vecs_len;
-    for( ulong i=0; i < self->account_vecs_len; i++ ) {
-      fd_snapshot_acc_vec_new( (fd_snapshot_acc_vec_t *)(cur_mem + FD_SNAPSHOT_ACC_VEC_FOOTPRINT * i) );
-      fd_snapshot_acc_vec_decode_inner_global( cur_mem + FD_SNAPSHOT_ACC_VEC_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->account_vecs_gaddr = 0UL;
-}
-int fd_snapshot_slot_acc_vecs_convert_global_to_local( void const * global_self, fd_snapshot_slot_acc_vecs_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_snapshot_slot_acc_vecs_global_t const * mem = (fd_snapshot_slot_acc_vecs_global_t const *)global_self;
-  self->slot = mem->slot;
-  self->account_vecs_len = mem->account_vecs_len;
-  self->account_vecs     = fd_wksp_laddr_fast( ctx->wksp, mem->account_vecs_gaddr );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_snapshot_slot_acc_vecs_new(fd_snapshot_slot_acc_vecs_t * self) {
   fd_memset( self, 0, sizeof(fd_snapshot_slot_acc_vecs_t) );
@@ -5470,47 +4793,6 @@ void fd_reward_type_inner_decode_inner( fd_reward_type_inner_t * self, void * * 
   }
   }
 }
-void fd_reward_type_inner_decode_inner_global( fd_reward_type_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    break;
-  }
-  case 2: {
-    break;
-  }
-  case 3: {
-    break;
-  }
-  }
-}
-int fd_reward_type_convert_global_to_local_inner( fd_reward_type_inner_global_t const * mem, fd_reward_type_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    break;
-  }
-  case 2: {
-    break;
-  }
-  case 3: {
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_reward_type_convert_global_to_local( void const * global_self, fd_reward_type_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_reward_type_global_t const * mem = (fd_reward_type_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_reward_type_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_reward_type_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_reward_type_t * self = (fd_reward_type_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -5523,19 +4805,6 @@ void * fd_reward_type_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   void * * alloc_mem = &alloc_region;
   fd_reward_type_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_reward_type_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_reward_type_t * self = (fd_reward_type_t *)mem;
-  fd_reward_type_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_reward_type_t);
-  void * * alloc_mem = &alloc_region;
-  fd_reward_type_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_reward_type_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_reward_type_global_t * self = (fd_reward_type_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_reward_type_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_reward_type_inner_new( fd_reward_type_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -5741,70 +5010,6 @@ void fd_solana_accounts_db_fields_decode_inner( void * struct_mem, void * * allo
   } else
     self->historical_roots_with_hash = NULL;
 }
-void * fd_solana_accounts_db_fields_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_solana_accounts_db_fields_global_t * self = (fd_solana_accounts_db_fields_global_t *)mem;
-  fd_solana_accounts_db_fields_new( (fd_solana_accounts_db_fields_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_solana_accounts_db_fields_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_solana_accounts_db_fields_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_solana_accounts_db_fields_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_solana_accounts_db_fields_global_t * self = (fd_solana_accounts_db_fields_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->storages_len, ctx );
-  if( self->storages_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_SNAPSHOT_SLOT_ACC_VECS_ALIGN );
-    self->storages_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_SNAPSHOT_SLOT_ACC_VECS_FOOTPRINT*self->storages_len;
-    for( ulong i=0; i < self->storages_len; i++ ) {
-      fd_snapshot_slot_acc_vecs_new( (fd_snapshot_slot_acc_vecs_t *)(cur_mem + FD_SNAPSHOT_SLOT_ACC_VECS_FOOTPRINT * i) );
-      fd_snapshot_slot_acc_vecs_decode_inner_global( cur_mem + FD_SNAPSHOT_SLOT_ACC_VECS_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->storages_gaddr = 0UL;
-  fd_bincode_uint64_decode_unsafe( &self->version, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-  fd_bank_hash_info_decode_inner_global( &self->bank_hash_info, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->historical_roots_len, ctx );
-  if( self->historical_roots_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), 8UL );
-    self->historical_roots_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + sizeof(ulong)*self->historical_roots_len;
-    for( ulong i=0; i < self->historical_roots_len; i++ ) {
-      fd_bincode_uint64_decode_unsafe( (ulong*)(cur_mem + sizeof(ulong) * i), ctx );
-    }
-  } else
-    self->historical_roots_gaddr = 0UL;
-  fd_bincode_uint64_decode_unsafe( &self->historical_roots_with_hash_len, ctx );
-  if( self->historical_roots_with_hash_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_SLOT_MAP_PAIR_ALIGN );
-    self->historical_roots_with_hash_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_SLOT_MAP_PAIR_FOOTPRINT*self->historical_roots_with_hash_len;
-    for( ulong i=0; i < self->historical_roots_with_hash_len; i++ ) {
-      fd_slot_map_pair_new( (fd_slot_map_pair_t *)(cur_mem + FD_SLOT_MAP_PAIR_FOOTPRINT * i) );
-      fd_slot_map_pair_decode_inner_global( cur_mem + FD_SLOT_MAP_PAIR_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->historical_roots_with_hash_gaddr = 0UL;
-}
-int fd_solana_accounts_db_fields_convert_global_to_local( void const * global_self, fd_solana_accounts_db_fields_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_solana_accounts_db_fields_global_t const * mem = (fd_solana_accounts_db_fields_global_t const *)global_self;
-  self->storages_len = mem->storages_len;
-  self->storages     = fd_wksp_laddr_fast( ctx->wksp, mem->storages_gaddr );
-  self->version = mem->version;
-  self->slot = mem->slot;
-  err = fd_bank_hash_info_convert_global_to_local( &mem->bank_hash_info, &self->bank_hash_info, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->historical_roots_len = mem->historical_roots_len;
-  self->historical_roots     = fd_wksp_laddr_fast( ctx->wksp, mem->historical_roots_gaddr );
-  self->historical_roots_with_hash_len = mem->historical_roots_with_hash_len;
-  self->historical_roots_with_hash     = fd_wksp_laddr_fast( ctx->wksp, mem->historical_roots_with_hash_gaddr );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_solana_accounts_db_fields_new(fd_solana_accounts_db_fields_t * self) {
   fd_memset( self, 0, sizeof(fd_solana_accounts_db_fields_t) );
   fd_bank_hash_info_new( &self->bank_hash_info );
@@ -5895,6 +5100,34 @@ int fd_versioned_epoch_stakes_current_encode( fd_versioned_epoch_stakes_current_
   if( self->epoch_authorized_voters_len ) {
     for( ulong i=0; i < self->epoch_authorized_voters_len; i++ ) {
       err = fd_pubkey_pubkey_pair_encode( self->epoch_authorized_voters + i, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_versioned_epoch_stakes_current_encode_global( fd_versioned_epoch_stakes_current_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_stakes_stake_encode_global( &self->stakes, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->total_stake, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->node_id_to_vote_accounts_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->node_id_to_vote_accounts_len ) {
+    uchar * node_id_to_vote_accounts_laddr = fd_wksp_laddr_fast( ctx->wksp, self->node_id_to_vote_accounts_gaddr );
+    fd_pubkey_node_vote_accounts_pair_t * node_id_to_vote_accounts = (fd_pubkey_node_vote_accounts_pair_t *)node_id_to_vote_accounts_laddr;
+    for( ulong i=0; i < self->node_id_to_vote_accounts_len; i++ ) {
+      err = fd_pubkey_node_vote_accounts_pair_encode( &node_id_to_vote_accounts[i], ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  err = fd_bincode_uint64_encode( self->epoch_authorized_voters_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->epoch_authorized_voters_len ) {
+    uchar * epoch_authorized_voters_laddr = fd_wksp_laddr_fast( ctx->wksp, self->epoch_authorized_voters_gaddr );
+    fd_pubkey_pubkey_pair_t * epoch_authorized_voters = (fd_pubkey_pubkey_pair_t *)epoch_authorized_voters_laddr;
+    for( ulong i=0; i < self->epoch_authorized_voters_len; i++ ) {
+      err = fd_pubkey_pubkey_pair_encode( &epoch_authorized_voters[i], ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
   }
@@ -5991,11 +5224,12 @@ void fd_versioned_epoch_stakes_current_decode_inner_global( void * struct_mem, v
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_FOOTPRINT*self->node_id_to_vote_accounts_len;
     for( ulong i=0; i < self->node_id_to_vote_accounts_len; i++ ) {
-      fd_pubkey_node_vote_accounts_pair_new( (fd_pubkey_node_vote_accounts_pair_t *)(cur_mem + FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_FOOTPRINT * i) );
-      fd_pubkey_node_vote_accounts_pair_decode_inner_global( cur_mem + FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_FOOTPRINT * i, alloc_mem, ctx );
+      fd_pubkey_node_vote_accounts_pair_new( (fd_pubkey_node_vote_accounts_pair_t *)fd_type_pun(cur_mem + FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_FOOTPRINT * i) );
+      fd_pubkey_node_vote_accounts_pair_decode_inner( cur_mem + FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->node_id_to_vote_accounts_gaddr = 0UL;
+  }
   fd_bincode_uint64_decode_unsafe( &self->epoch_authorized_voters_len, ctx );
   if( self->epoch_authorized_voters_len ) {
     *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_PUBKEY_PUBKEY_PAIR_ALIGN );
@@ -6003,23 +5237,12 @@ void fd_versioned_epoch_stakes_current_decode_inner_global( void * struct_mem, v
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_PUBKEY_PUBKEY_PAIR_FOOTPRINT*self->epoch_authorized_voters_len;
     for( ulong i=0; i < self->epoch_authorized_voters_len; i++ ) {
-      fd_pubkey_pubkey_pair_new( (fd_pubkey_pubkey_pair_t *)(cur_mem + FD_PUBKEY_PUBKEY_PAIR_FOOTPRINT * i) );
-      fd_pubkey_pubkey_pair_decode_inner_global( cur_mem + FD_PUBKEY_PUBKEY_PAIR_FOOTPRINT * i, alloc_mem, ctx );
+      fd_pubkey_pubkey_pair_new( (fd_pubkey_pubkey_pair_t *)fd_type_pun(cur_mem + FD_PUBKEY_PUBKEY_PAIR_FOOTPRINT * i) );
+      fd_pubkey_pubkey_pair_decode_inner( cur_mem + FD_PUBKEY_PUBKEY_PAIR_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->epoch_authorized_voters_gaddr = 0UL;
-}
-int fd_versioned_epoch_stakes_current_convert_global_to_local( void const * global_self, fd_versioned_epoch_stakes_current_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_versioned_epoch_stakes_current_global_t const * mem = (fd_versioned_epoch_stakes_current_global_t const *)global_self;
-  err = fd_stakes_stake_convert_global_to_local( &mem->stakes, &self->stakes, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->total_stake = mem->total_stake;
-  self->node_id_to_vote_accounts_len = mem->node_id_to_vote_accounts_len;
-  self->node_id_to_vote_accounts     = fd_wksp_laddr_fast( ctx->wksp, mem->node_id_to_vote_accounts_gaddr );
-  self->epoch_authorized_voters_len = mem->epoch_authorized_voters_len;
-  self->epoch_authorized_voters     = fd_wksp_laddr_fast( ctx->wksp, mem->epoch_authorized_voters_gaddr );
-  return FD_BINCODE_SUCCESS;
+  }
 }
 void fd_versioned_epoch_stakes_current_new(fd_versioned_epoch_stakes_current_t * self) {
   fd_memset( self, 0, sizeof(fd_versioned_epoch_stakes_current_t) );
@@ -6123,24 +5346,6 @@ void fd_versioned_epoch_stakes_inner_decode_inner_global( fd_versioned_epoch_sta
   }
   }
 }
-int fd_versioned_epoch_stakes_convert_global_to_local_inner( fd_versioned_epoch_stakes_inner_global_t const * mem, fd_versioned_epoch_stakes_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_versioned_epoch_stakes_current_convert_global_to_local( &mem->Current, &self->Current, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_versioned_epoch_stakes_convert_global_to_local( void const * global_self, fd_versioned_epoch_stakes_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_versioned_epoch_stakes_global_t const * mem = (fd_versioned_epoch_stakes_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_versioned_epoch_stakes_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_versioned_epoch_stakes_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_versioned_epoch_stakes_t * self = (fd_versioned_epoch_stakes_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -6154,6 +5359,23 @@ void * fd_versioned_epoch_stakes_decode( void * mem, fd_bincode_decode_ctx_t * c
   fd_versioned_epoch_stakes_decode_inner( mem, alloc_mem, ctx );
   return self;
 }
+int fd_versioned_epoch_stakes_inner_encode_global( fd_versioned_epoch_stakes_inner_global_t const * self, uint discriminant, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  switch (discriminant) {
+  case 0: {
+    err = fd_versioned_epoch_stakes_current_encode_global( &self->Current, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_versioned_epoch_stakes_encode_global( fd_versioned_epoch_stakes_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err = fd_bincode_uint32_encode( self->discriminant, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fd_versioned_epoch_stakes_inner_encode_global( &self->inner, self->discriminant, ctx );
+}
+
 void * fd_versioned_epoch_stakes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_versioned_epoch_stakes_t * self = (fd_versioned_epoch_stakes_t *)mem;
   fd_versioned_epoch_stakes_new( self );
@@ -6248,6 +5470,14 @@ int fd_versioned_epoch_stakes_pair_encode( fd_versioned_epoch_stakes_pair_t cons
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
+int fd_versioned_epoch_stakes_pair_encode_global( fd_versioned_epoch_stakes_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->epoch, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_versioned_epoch_stakes_encode_global( &self->val, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
 int fd_versioned_epoch_stakes_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_versioned_epoch_stakes_pair_t);
   void const * start_data = ctx->data;
@@ -6290,14 +5520,6 @@ void fd_versioned_epoch_stakes_pair_decode_inner_global( void * struct_mem, void
   fd_versioned_epoch_stakes_pair_global_t * self = (fd_versioned_epoch_stakes_pair_global_t *)struct_mem;
   fd_bincode_uint64_decode_unsafe( &self->epoch, ctx );
   fd_versioned_epoch_stakes_decode_inner_global( &self->val, alloc_mem, ctx );
-}
-int fd_versioned_epoch_stakes_pair_convert_global_to_local( void const * global_self, fd_versioned_epoch_stakes_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_versioned_epoch_stakes_pair_global_t const * mem = (fd_versioned_epoch_stakes_pair_global_t const *)global_self;
-  self->epoch = mem->epoch;
-  err = fd_versioned_epoch_stakes_convert_global_to_local( &mem->val, &self->val, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_versioned_epoch_stakes_pair_new(fd_versioned_epoch_stakes_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_versioned_epoch_stakes_pair_t) );
@@ -6371,31 +5593,6 @@ void fd_reward_info_decode_inner( void * struct_mem, void * * alloc_mem, fd_binc
   fd_bincode_uint64_decode_unsafe( &self->post_balance, ctx );
   fd_bincode_uint64_decode_unsafe( &self->commission, ctx );
 }
-void * fd_reward_info_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_reward_info_global_t * self = (fd_reward_info_global_t *)mem;
-  fd_reward_info_new( (fd_reward_info_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_reward_info_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_reward_info_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_reward_info_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_reward_info_global_t * self = (fd_reward_info_global_t *)struct_mem;
-  fd_reward_type_decode_inner_global( &self->reward_type, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->lamports, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->post_balance, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->commission, ctx );
-}
-int fd_reward_info_convert_global_to_local( void const * global_self, fd_reward_info_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_reward_info_global_t const * mem = (fd_reward_info_global_t const *)global_self;
-  err = fd_reward_type_convert_global_to_local( &mem->reward_type, &self->reward_type, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->lamports = mem->lamports;
-  self->post_balance = mem->post_balance;
-  self->commission = mem->commission;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_reward_info_new(fd_reward_info_t * self) {
   fd_memset( self, 0, sizeof(fd_reward_info_t) );
   fd_reward_type_new( &self->reward_type );
@@ -6457,24 +5654,6 @@ void fd_slot_lthash_decode_inner( void * struct_mem, void * * alloc_mem, fd_binc
   fd_slot_lthash_t * self = (fd_slot_lthash_t *)struct_mem;
   fd_bincode_bytes_decode_unsafe( &self->lthash[0], sizeof(self->lthash), ctx );
 }
-void * fd_slot_lthash_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_slot_lthash_global_t * self = (fd_slot_lthash_global_t *)mem;
-  fd_slot_lthash_new( (fd_slot_lthash_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_slot_lthash_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_slot_lthash_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_slot_lthash_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_slot_lthash_global_t * self = (fd_slot_lthash_global_t *)struct_mem;
-  fd_bincode_bytes_decode_unsafe( &self->lthash[0], sizeof(self->lthash), ctx );
-}
-int fd_slot_lthash_convert_global_to_local( void const * global_self, fd_slot_lthash_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_slot_lthash_global_t const * mem = (fd_slot_lthash_global_t const *)global_self;
-  fd_memcpy( &self->lthash[0], &mem->lthash[0], sizeof(self->lthash) );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_slot_lthash_new(fd_slot_lthash_t * self) {
   fd_memset( self, 0, sizeof(fd_slot_lthash_t) );
 }
@@ -6533,6 +5712,56 @@ int fd_solana_manifest_encode( fd_solana_manifest_t const * self, fd_bincode_enc
     err = fd_bincode_bool_encode( 1, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     err = fd_slot_lthash_encode( self->lthash, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_solana_manifest_encode_global( fd_solana_manifest_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_versioned_bank_encode_global( &self->bank, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_solana_accounts_db_fields_encode( &self->accounts_db, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->lamports_per_signature, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->bank_incremental_snapshot_persistence_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    fd_bank_incremental_snapshot_persistence_t * bank_incremental_snapshot_persistence = fd_wksp_laddr_fast( ctx->wksp, self->bank_incremental_snapshot_persistence_gaddr );
+    err = fd_bank_incremental_snapshot_persistence_encode( bank_incremental_snapshot_persistence, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  if( self->epoch_account_hash_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    fd_hash_t * epoch_account_hash = fd_wksp_laddr_fast( ctx->wksp, self->epoch_account_hash_gaddr );
+    err = fd_hash_encode( epoch_account_hash, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_uint64_encode( self->versioned_epoch_stakes_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->versioned_epoch_stakes_len ) {
+    uchar * versioned_epoch_stakes_laddr = fd_wksp_laddr_fast( ctx->wksp, self->versioned_epoch_stakes_gaddr );
+    fd_versioned_epoch_stakes_pair_global_t * versioned_epoch_stakes = (fd_versioned_epoch_stakes_pair_global_t *)versioned_epoch_stakes_laddr;
+    for( ulong i=0; i < self->versioned_epoch_stakes_len; i++ ) {
+      err = fd_versioned_epoch_stakes_pair_encode_global( &versioned_epoch_stakes[i], ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  if( self->lthash_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    fd_slot_lthash_t * lthash = fd_wksp_laddr_fast( ctx->wksp, self->lthash_gaddr );
+    err = fd_slot_lthash_encode( lthash, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   } else {
     err = fd_bincode_bool_encode( 0, ctx );
@@ -6682,7 +5911,7 @@ void * fd_solana_manifest_decode_global( void * mem, fd_bincode_decode_ctx_t * c
 void fd_solana_manifest_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_solana_manifest_global_t * self = (fd_solana_manifest_global_t *)struct_mem;
   fd_versioned_bank_decode_inner_global( &self->bank, alloc_mem, ctx );
-  fd_solana_accounts_db_fields_decode_inner_global( &self->accounts_db, alloc_mem, ctx );
+  fd_solana_accounts_db_fields_decode_inner( &self->accounts_db, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->lamports_per_signature, ctx );
   if( ctx->data == ctx->dataend ) return;
   {
@@ -6693,7 +5922,7 @@ void fd_solana_manifest_decode_inner_global( void * struct_mem, void * * alloc_m
       self->bank_incremental_snapshot_persistence_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
       fd_bank_incremental_snapshot_persistence_new( *alloc_mem );
       *alloc_mem = (uchar *)*alloc_mem + FD_BANK_INCREMENTAL_SNAPSHOT_PERSISTENCE_FOOTPRINT;
-      fd_bank_incremental_snapshot_persistence_decode_inner_global( fd_wksp_laddr_fast( ctx->wksp, self->bank_incremental_snapshot_persistence_gaddr ), alloc_mem, ctx );
+      fd_bank_incremental_snapshot_persistence_decode_inner( fd_wksp_laddr_fast( ctx->wksp, self->bank_incremental_snapshot_persistence_gaddr ), alloc_mem, ctx );
     } else {
       self->bank_incremental_snapshot_persistence_gaddr = 0UL;
     }
@@ -6707,7 +5936,7 @@ void fd_solana_manifest_decode_inner_global( void * struct_mem, void * * alloc_m
       self->epoch_account_hash_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
       fd_hash_new( *alloc_mem );
       *alloc_mem = (uchar *)*alloc_mem + FD_HASH_FOOTPRINT;
-      fd_hash_decode_inner_global( fd_wksp_laddr_fast( ctx->wksp, self->epoch_account_hash_gaddr ), alloc_mem, ctx );
+      fd_hash_decode_inner( fd_wksp_laddr_fast( ctx->wksp, self->epoch_account_hash_gaddr ), alloc_mem, ctx );
     } else {
       self->epoch_account_hash_gaddr = 0UL;
     }
@@ -6720,11 +5949,12 @@ void fd_solana_manifest_decode_inner_global( void * struct_mem, void * * alloc_m
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_VERSIONED_EPOCH_STAKES_PAIR_FOOTPRINT*self->versioned_epoch_stakes_len;
     for( ulong i=0; i < self->versioned_epoch_stakes_len; i++ ) {
-      fd_versioned_epoch_stakes_pair_new( (fd_versioned_epoch_stakes_pair_t *)(cur_mem + FD_VERSIONED_EPOCH_STAKES_PAIR_FOOTPRINT * i) );
+      fd_versioned_epoch_stakes_pair_new( (fd_versioned_epoch_stakes_pair_t *)fd_type_pun(cur_mem + FD_VERSIONED_EPOCH_STAKES_PAIR_FOOTPRINT * i) );
       fd_versioned_epoch_stakes_pair_decode_inner_global( cur_mem + FD_VERSIONED_EPOCH_STAKES_PAIR_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->versioned_epoch_stakes_gaddr = 0UL;
+  }
   if( ctx->data == ctx->dataend ) return;
   {
     uchar o;
@@ -6734,26 +5964,11 @@ void fd_solana_manifest_decode_inner_global( void * struct_mem, void * * alloc_m
       self->lthash_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
       fd_slot_lthash_new( *alloc_mem );
       *alloc_mem = (uchar *)*alloc_mem + FD_SLOT_LTHASH_FOOTPRINT;
-      fd_slot_lthash_decode_inner_global( fd_wksp_laddr_fast( ctx->wksp, self->lthash_gaddr ), alloc_mem, ctx );
+      fd_slot_lthash_decode_inner( fd_wksp_laddr_fast( ctx->wksp, self->lthash_gaddr ), alloc_mem, ctx );
     } else {
       self->lthash_gaddr = 0UL;
     }
   }
-}
-int fd_solana_manifest_convert_global_to_local( void const * global_self, fd_solana_manifest_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_solana_manifest_global_t const * mem = (fd_solana_manifest_global_t const *)global_self;
-  err = fd_versioned_bank_convert_global_to_local( &mem->bank, &self->bank, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_solana_accounts_db_fields_convert_global_to_local( &mem->accounts_db, &self->accounts_db, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->lamports_per_signature = mem->lamports_per_signature;
-  self->bank_incremental_snapshot_persistence = fd_wksp_laddr_fast( ctx->wksp, mem->bank_incremental_snapshot_persistence_gaddr );
-  self->epoch_account_hash = fd_wksp_laddr_fast( ctx->wksp, mem->epoch_account_hash_gaddr );
-  self->versioned_epoch_stakes_len = mem->versioned_epoch_stakes_len;
-  self->versioned_epoch_stakes     = fd_wksp_laddr_fast( ctx->wksp, mem->versioned_epoch_stakes_gaddr );
-  self->lthash = fd_wksp_laddr_fast( ctx->wksp, mem->lthash_gaddr );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_solana_manifest_new(fd_solana_manifest_t * self) {
   fd_memset( self, 0, sizeof(fd_solana_manifest_t) );
@@ -6819,11 +6034,11 @@ ulong fd_solana_manifest_size( fd_solana_manifest_t const * self ) {
   size += fd_solana_accounts_db_fields_size( &self->accounts_db );
   size += sizeof(ulong);
   size += sizeof(char);
-  if( NULL !=  self->bank_incremental_snapshot_persistence ) {
+  if( NULL != self->bank_incremental_snapshot_persistence ) {
     size += fd_bank_incremental_snapshot_persistence_size( self->bank_incremental_snapshot_persistence );
   }
   size += sizeof(char);
-  if( NULL !=  self->epoch_account_hash ) {
+  if( NULL != self->epoch_account_hash ) {
     size += fd_hash_size( self->epoch_account_hash );
   }
   do {
@@ -6832,7 +6047,7 @@ ulong fd_solana_manifest_size( fd_solana_manifest_t const * self ) {
       size += fd_versioned_epoch_stakes_pair_size( self->versioned_epoch_stakes + i );
   } while(0);
   size += sizeof(char);
-  if( NULL !=  self->lthash ) {
+  if( NULL != self->lthash ) {
     size += fd_slot_lthash_size( self->lthash );
   }
   return size;
@@ -6876,26 +6091,6 @@ void fd_rust_duration_decode_inner( void * struct_mem, void * * alloc_mem, fd_bi
   fd_bincode_uint64_decode_unsafe( &self->seconds, ctx );
   fd_bincode_uint32_decode_unsafe( &self->nanoseconds, ctx );
 }
-void * fd_rust_duration_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_rust_duration_global_t * self = (fd_rust_duration_global_t *)mem;
-  fd_rust_duration_new( (fd_rust_duration_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_rust_duration_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_rust_duration_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_rust_duration_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_rust_duration_global_t * self = (fd_rust_duration_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->seconds, ctx );
-  fd_bincode_uint32_decode_unsafe( &self->nanoseconds, ctx );
-}
-int fd_rust_duration_convert_global_to_local( void const * global_self, fd_rust_duration_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_rust_duration_global_t const * mem = (fd_rust_duration_global_t const *)global_self;
-  self->seconds = mem->seconds;
-  self->nanoseconds = mem->nanoseconds;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_rust_duration_new(fd_rust_duration_t * self) {
   fd_memset( self, 0, sizeof(fd_rust_duration_t) );
 }
@@ -6926,6 +6121,28 @@ int fd_poh_config_encode( fd_poh_config_t const * self, fd_bincode_encode_ctx_t 
     err = fd_bincode_bool_encode( 1, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     err = fd_bincode_uint64_encode( self->target_tick_count[0], ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_bool_encode( self->has_hashes_per_tick, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_hashes_per_tick ) {
+    err = fd_bincode_uint64_encode( self->hashes_per_tick, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_poh_config_encode_global( fd_poh_config_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_rust_duration_encode( &self->target_tick_duration, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->target_tick_count_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    ulong * target_tick_count = fd_wksp_laddr_fast( ctx->wksp, self->target_tick_count_gaddr );
+    err = fd_bincode_uint64_encode( target_tick_count[0], ctx );
     if( FD_UNLIKELY( err ) ) return err;
   } else {
     err = fd_bincode_bool_encode( 0, ctx );
@@ -7015,7 +6232,7 @@ void * fd_poh_config_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) 
 }
 void fd_poh_config_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_poh_config_global_t * self = (fd_poh_config_global_t *)struct_mem;
-  fd_rust_duration_decode_inner_global( &self->target_tick_duration, alloc_mem, ctx );
+  fd_rust_duration_decode_inner( &self->target_tick_duration, alloc_mem, ctx );
   {
     uchar o;
     fd_bincode_bool_decode_unsafe( &o, ctx );
@@ -7036,16 +6253,6 @@ void fd_poh_config_decode_inner_global( void * struct_mem, void * * alloc_mem, f
       fd_bincode_uint64_decode_unsafe( &self->hashes_per_tick, ctx );
     }
   }
-}
-int fd_poh_config_convert_global_to_local( void const * global_self, fd_poh_config_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_poh_config_global_t const * mem = (fd_poh_config_global_t const *)global_self;
-  err = fd_rust_duration_convert_global_to_local( &mem->target_tick_duration, &self->target_tick_duration, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->target_tick_count = fd_wksp_laddr_fast( ctx->wksp, mem->target_tick_count_gaddr );
-  self->hashes_per_tick = mem->hashes_per_tick;
-  self->has_hashes_per_tick = mem->has_hashes_per_tick;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_poh_config_new(fd_poh_config_t * self) {
   fd_memset( self, 0, sizeof(fd_poh_config_t) );
@@ -7083,7 +6290,7 @@ ulong fd_poh_config_size( fd_poh_config_t const * self ) {
   ulong size = 0;
   size += fd_rust_duration_size( &self->target_tick_duration );
   size += sizeof(char);
-  if( NULL !=  self->target_tick_count ) {
+  if( NULL != self->target_tick_count ) {
     size += sizeof(ulong);
   }
   size += sizeof(char);
@@ -7099,6 +6306,19 @@ int fd_string_pubkey_pair_encode( fd_string_pubkey_pair_t const * self, fd_binco
   if( FD_UNLIKELY(err) ) return err;
   if( self->string_len ) {
     err = fd_bincode_bytes_encode( self->string, self->string_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_pubkey_encode( &self->pubkey, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_string_pubkey_pair_encode_global( fd_string_pubkey_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->string_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->string_len ) {
+    uchar * string_laddr = fd_wksp_laddr_fast( ctx->wksp, self->string_gaddr );
+    err = fd_bincode_bytes_encode( string_laddr, self->string_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   err = fd_pubkey_encode( &self->pubkey, ctx );
@@ -7164,18 +6384,10 @@ void fd_string_pubkey_pair_decode_inner_global( void * struct_mem, void * * allo
     self->string_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
     fd_bincode_bytes_decode_unsafe( *alloc_mem, self->string_len, ctx );
     *alloc_mem = (uchar *)(*alloc_mem) + self->string_len;
-  } else
+  } else {
     self->string_gaddr = 0UL;
-  fd_pubkey_decode_inner_global( &self->pubkey, alloc_mem, ctx );
-}
-int fd_string_pubkey_pair_convert_global_to_local( void const * global_self, fd_string_pubkey_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_string_pubkey_pair_global_t const * mem = (fd_string_pubkey_pair_global_t const *)global_self;
-  self->string_len = mem->string_len;
-  self->string     = fd_wksp_laddr_fast( ctx->wksp, mem->string_gaddr );
-  err = fd_pubkey_convert_global_to_local( &mem->pubkey, &self->pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  }
+  fd_pubkey_decode_inner( &self->pubkey, alloc_mem, ctx );
 }
 void fd_string_pubkey_pair_new(fd_string_pubkey_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_string_pubkey_pair_t) );
@@ -7245,28 +6457,6 @@ void fd_pubkey_account_pair_decode_inner( void * struct_mem, void * * alloc_mem,
   fd_pubkey_decode_inner( &self->key, alloc_mem, ctx );
   fd_solana_account_decode_inner( &self->account, alloc_mem, ctx );
 }
-void * fd_pubkey_account_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_pubkey_account_pair_global_t * self = (fd_pubkey_account_pair_global_t *)mem;
-  fd_pubkey_account_pair_new( (fd_pubkey_account_pair_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_pubkey_account_pair_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_pubkey_account_pair_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_pubkey_account_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_pubkey_account_pair_global_t * self = (fd_pubkey_account_pair_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->key, alloc_mem, ctx );
-  fd_solana_account_decode_inner_global( &self->account, alloc_mem, ctx );
-}
-int fd_pubkey_account_pair_convert_global_to_local( void const * global_self, fd_pubkey_account_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_pubkey_account_pair_global_t const * mem = (fd_pubkey_account_pair_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->key, &self->key, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_solana_account_convert_global_to_local( &mem->account, &self->account, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_pubkey_account_pair_new(fd_pubkey_account_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_pubkey_account_pair_t) );
   fd_pubkey_new( &self->key );
@@ -7326,6 +6516,60 @@ int fd_genesis_solana_encode( fd_genesis_solana_t const * self, fd_bincode_encod
   err = fd_bincode_uint64_encode( self->unused, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_poh_config_encode( &self->poh_config, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->__backwards_compat_with_v0_23, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_fee_rate_governor_encode( &self->fee_rate_governor, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_rent_encode( &self->rent, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_inflation_encode( &self->inflation, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_epoch_schedule_encode( &self->epoch_schedule, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint32_encode( self->cluster_type, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_genesis_solana_encode_global( fd_genesis_solana_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->creation_time, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->accounts_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->accounts_len ) {
+    uchar * accounts_laddr = fd_wksp_laddr_fast( ctx->wksp, self->accounts_gaddr );
+    fd_pubkey_account_pair_t * accounts = (fd_pubkey_account_pair_t *)accounts_laddr;
+    for( ulong i=0; i < self->accounts_len; i++ ) {
+      err = fd_pubkey_account_pair_encode( &accounts[i], ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  err = fd_bincode_uint64_encode( self->native_instruction_processors_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->native_instruction_processors_len ) {
+    uchar * native_instruction_processors_laddr = fd_wksp_laddr_fast( ctx->wksp, self->native_instruction_processors_gaddr );
+    fd_string_pubkey_pair_global_t * native_instruction_processors = (fd_string_pubkey_pair_global_t *)native_instruction_processors_laddr;
+    for( ulong i=0; i < self->native_instruction_processors_len; i++ ) {
+      err = fd_string_pubkey_pair_encode_global( &native_instruction_processors[i], ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  err = fd_bincode_uint64_encode( self->rewards_pools_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->rewards_pools_len ) {
+    uchar * rewards_pools_laddr = fd_wksp_laddr_fast( ctx->wksp, self->rewards_pools_gaddr );
+    fd_pubkey_account_pair_t * rewards_pools = (fd_pubkey_account_pair_t *)rewards_pools_laddr;
+    for( ulong i=0; i < self->rewards_pools_len; i++ ) {
+      err = fd_pubkey_account_pair_encode( &rewards_pools[i], ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  err = fd_bincode_uint64_encode( self->ticks_per_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->unused, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_poh_config_encode_global( &self->poh_config, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_bincode_uint64_encode( self->__backwards_compat_with_v0_23, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -7476,11 +6720,12 @@ void fd_genesis_solana_decode_inner_global( void * struct_mem, void * * alloc_me
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_PUBKEY_ACCOUNT_PAIR_FOOTPRINT*self->accounts_len;
     for( ulong i=0; i < self->accounts_len; i++ ) {
-      fd_pubkey_account_pair_new( (fd_pubkey_account_pair_t *)(cur_mem + FD_PUBKEY_ACCOUNT_PAIR_FOOTPRINT * i) );
-      fd_pubkey_account_pair_decode_inner_global( cur_mem + FD_PUBKEY_ACCOUNT_PAIR_FOOTPRINT * i, alloc_mem, ctx );
+      fd_pubkey_account_pair_new( (fd_pubkey_account_pair_t *)fd_type_pun(cur_mem + FD_PUBKEY_ACCOUNT_PAIR_FOOTPRINT * i) );
+      fd_pubkey_account_pair_decode_inner( cur_mem + FD_PUBKEY_ACCOUNT_PAIR_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->accounts_gaddr = 0UL;
+  }
   fd_bincode_uint64_decode_unsafe( &self->native_instruction_processors_len, ctx );
   if( self->native_instruction_processors_len ) {
     *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_STRING_PUBKEY_PAIR_ALIGN );
@@ -7488,11 +6733,12 @@ void fd_genesis_solana_decode_inner_global( void * struct_mem, void * * alloc_me
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_STRING_PUBKEY_PAIR_FOOTPRINT*self->native_instruction_processors_len;
     for( ulong i=0; i < self->native_instruction_processors_len; i++ ) {
-      fd_string_pubkey_pair_new( (fd_string_pubkey_pair_t *)(cur_mem + FD_STRING_PUBKEY_PAIR_FOOTPRINT * i) );
+      fd_string_pubkey_pair_new( (fd_string_pubkey_pair_t *)fd_type_pun(cur_mem + FD_STRING_PUBKEY_PAIR_FOOTPRINT * i) );
       fd_string_pubkey_pair_decode_inner_global( cur_mem + FD_STRING_PUBKEY_PAIR_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->native_instruction_processors_gaddr = 0UL;
+  }
   fd_bincode_uint64_decode_unsafe( &self->rewards_pools_len, ctx );
   if( self->rewards_pools_len ) {
     *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_PUBKEY_ACCOUNT_PAIR_ALIGN );
@@ -7500,46 +6746,21 @@ void fd_genesis_solana_decode_inner_global( void * struct_mem, void * * alloc_me
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_PUBKEY_ACCOUNT_PAIR_FOOTPRINT*self->rewards_pools_len;
     for( ulong i=0; i < self->rewards_pools_len; i++ ) {
-      fd_pubkey_account_pair_new( (fd_pubkey_account_pair_t *)(cur_mem + FD_PUBKEY_ACCOUNT_PAIR_FOOTPRINT * i) );
-      fd_pubkey_account_pair_decode_inner_global( cur_mem + FD_PUBKEY_ACCOUNT_PAIR_FOOTPRINT * i, alloc_mem, ctx );
+      fd_pubkey_account_pair_new( (fd_pubkey_account_pair_t *)fd_type_pun(cur_mem + FD_PUBKEY_ACCOUNT_PAIR_FOOTPRINT * i) );
+      fd_pubkey_account_pair_decode_inner( cur_mem + FD_PUBKEY_ACCOUNT_PAIR_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->rewards_pools_gaddr = 0UL;
+  }
   fd_bincode_uint64_decode_unsafe( &self->ticks_per_slot, ctx );
   fd_bincode_uint64_decode_unsafe( &self->unused, ctx );
   fd_poh_config_decode_inner_global( &self->poh_config, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->__backwards_compat_with_v0_23, ctx );
-  fd_fee_rate_governor_decode_inner_global( &self->fee_rate_governor, alloc_mem, ctx );
-  fd_rent_decode_inner_global( &self->rent, alloc_mem, ctx );
-  fd_inflation_decode_inner_global( &self->inflation, alloc_mem, ctx );
-  fd_epoch_schedule_decode_inner_global( &self->epoch_schedule, alloc_mem, ctx );
+  fd_fee_rate_governor_decode_inner( &self->fee_rate_governor, alloc_mem, ctx );
+  fd_rent_decode_inner( &self->rent, alloc_mem, ctx );
+  fd_inflation_decode_inner( &self->inflation, alloc_mem, ctx );
+  fd_epoch_schedule_decode_inner( &self->epoch_schedule, alloc_mem, ctx );
   fd_bincode_uint32_decode_unsafe( &self->cluster_type, ctx );
-}
-int fd_genesis_solana_convert_global_to_local( void const * global_self, fd_genesis_solana_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_genesis_solana_global_t const * mem = (fd_genesis_solana_global_t const *)global_self;
-  self->creation_time = mem->creation_time;
-  self->accounts_len = mem->accounts_len;
-  self->accounts     = fd_wksp_laddr_fast( ctx->wksp, mem->accounts_gaddr );
-  self->native_instruction_processors_len = mem->native_instruction_processors_len;
-  self->native_instruction_processors     = fd_wksp_laddr_fast( ctx->wksp, mem->native_instruction_processors_gaddr );
-  self->rewards_pools_len = mem->rewards_pools_len;
-  self->rewards_pools     = fd_wksp_laddr_fast( ctx->wksp, mem->rewards_pools_gaddr );
-  self->ticks_per_slot = mem->ticks_per_slot;
-  self->unused = mem->unused;
-  err = fd_poh_config_convert_global_to_local( &mem->poh_config, &self->poh_config, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->__backwards_compat_with_v0_23 = mem->__backwards_compat_with_v0_23;
-  err = fd_fee_rate_governor_convert_global_to_local( &mem->fee_rate_governor, &self->fee_rate_governor, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_rent_convert_global_to_local( &mem->rent, &self->rent, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_inflation_convert_global_to_local( &mem->inflation, &self->inflation, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_epoch_schedule_convert_global_to_local( &mem->epoch_schedule, &self->epoch_schedule, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->cluster_type = mem->cluster_type;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_genesis_solana_new(fd_genesis_solana_t * self) {
   fd_memset( self, 0, sizeof(fd_genesis_solana_t) );
@@ -7690,32 +6911,6 @@ void fd_sol_sysvar_clock_decode_inner( void * struct_mem, void * * alloc_mem, fd
   fd_bincode_uint64_decode_unsafe( &self->leader_schedule_epoch, ctx );
   fd_bincode_uint64_decode_unsafe( (ulong *) &self->unix_timestamp, ctx );
 }
-void * fd_sol_sysvar_clock_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_sol_sysvar_clock_global_t * self = (fd_sol_sysvar_clock_global_t *)mem;
-  fd_sol_sysvar_clock_new( (fd_sol_sysvar_clock_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_sol_sysvar_clock_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_sol_sysvar_clock_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_sol_sysvar_clock_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_sol_sysvar_clock_global_t * self = (fd_sol_sysvar_clock_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-  fd_bincode_uint64_decode_unsafe( (ulong *) &self->epoch_start_timestamp, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->epoch, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->leader_schedule_epoch, ctx );
-  fd_bincode_uint64_decode_unsafe( (ulong *) &self->unix_timestamp, ctx );
-}
-int fd_sol_sysvar_clock_convert_global_to_local( void const * global_self, fd_sol_sysvar_clock_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_sol_sysvar_clock_global_t const * mem = (fd_sol_sysvar_clock_global_t const *)global_self;
-  self->slot = mem->slot;
-  self->epoch_start_timestamp = mem->epoch_start_timestamp;
-  self->epoch = mem->epoch;
-  self->leader_schedule_epoch = mem->leader_schedule_epoch;
-  self->unix_timestamp = mem->unix_timestamp;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_sol_sysvar_clock_new(fd_sol_sysvar_clock_t * self) {
   fd_memset( self, 0, sizeof(fd_sol_sysvar_clock_t) );
 }
@@ -7777,24 +6972,6 @@ void fd_sol_sysvar_last_restart_slot_decode_inner( void * struct_mem, void * * a
   fd_sol_sysvar_last_restart_slot_t * self = (fd_sol_sysvar_last_restart_slot_t *)struct_mem;
   fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
 }
-void * fd_sol_sysvar_last_restart_slot_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_sol_sysvar_last_restart_slot_global_t * self = (fd_sol_sysvar_last_restart_slot_global_t *)mem;
-  fd_sol_sysvar_last_restart_slot_new( (fd_sol_sysvar_last_restart_slot_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_sol_sysvar_last_restart_slot_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_sol_sysvar_last_restart_slot_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_sol_sysvar_last_restart_slot_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_sol_sysvar_last_restart_slot_global_t * self = (fd_sol_sysvar_last_restart_slot_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-}
-int fd_sol_sysvar_last_restart_slot_convert_global_to_local( void const * global_self, fd_sol_sysvar_last_restart_slot_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_sol_sysvar_last_restart_slot_global_t const * mem = (fd_sol_sysvar_last_restart_slot_global_t const *)global_self;
-  self->slot = mem->slot;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_sol_sysvar_last_restart_slot_new(fd_sol_sysvar_last_restart_slot_t * self) {
   fd_memset( self, 0, sizeof(fd_sol_sysvar_last_restart_slot_t) );
 }
@@ -7852,26 +7029,6 @@ void fd_vote_lockout_decode_inner( void * struct_mem, void * * alloc_mem, fd_bin
   fd_vote_lockout_t * self = (fd_vote_lockout_t *)struct_mem;
   fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
   fd_bincode_uint32_decode_unsafe( &self->confirmation_count, ctx );
-}
-void * fd_vote_lockout_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_lockout_global_t * self = (fd_vote_lockout_global_t *)mem;
-  fd_vote_lockout_new( (fd_vote_lockout_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_vote_lockout_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_vote_lockout_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_vote_lockout_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_lockout_global_t * self = (fd_vote_lockout_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-  fd_bincode_uint32_decode_unsafe( &self->confirmation_count, ctx );
-}
-int fd_vote_lockout_convert_global_to_local( void const * global_self, fd_vote_lockout_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_lockout_global_t const * mem = (fd_vote_lockout_global_t const *)global_self;
-  self->slot = mem->slot;
-  self->confirmation_count = mem->confirmation_count;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_vote_lockout_new(fd_vote_lockout_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_lockout_t) );
@@ -7933,26 +7090,6 @@ void fd_lockout_offset_decode_inner( void * struct_mem, void * * alloc_mem, fd_b
   fd_bincode_varint_decode_unsafe( &self->offset, ctx );
   fd_bincode_uint8_decode_unsafe( &self->confirmation_count, ctx );
 }
-void * fd_lockout_offset_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_lockout_offset_global_t * self = (fd_lockout_offset_global_t *)mem;
-  fd_lockout_offset_new( (fd_lockout_offset_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_lockout_offset_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_lockout_offset_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_lockout_offset_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_lockout_offset_global_t * self = (fd_lockout_offset_global_t *)struct_mem;
-  fd_bincode_varint_decode_unsafe( &self->offset, ctx );
-  fd_bincode_uint8_decode_unsafe( &self->confirmation_count, ctx );
-}
-int fd_lockout_offset_convert_global_to_local( void const * global_self, fd_lockout_offset_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_lockout_offset_global_t const * mem = (fd_lockout_offset_global_t const *)global_self;
-  self->offset = mem->offset;
-  self->confirmation_count = mem->confirmation_count;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_lockout_offset_new(fd_lockout_offset_t * self) {
   fd_memset( self, 0, sizeof(fd_lockout_offset_t) );
 }
@@ -8012,27 +7149,6 @@ void fd_vote_authorized_voter_decode_inner( void * struct_mem, void * * alloc_me
   fd_vote_authorized_voter_t * self = (fd_vote_authorized_voter_t *)struct_mem;
   fd_bincode_uint64_decode_unsafe( &self->epoch, ctx );
   fd_pubkey_decode_inner( &self->pubkey, alloc_mem, ctx );
-}
-void * fd_vote_authorized_voter_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_authorized_voter_global_t * self = (fd_vote_authorized_voter_global_t *)mem;
-  fd_vote_authorized_voter_new( (fd_vote_authorized_voter_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_vote_authorized_voter_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_vote_authorized_voter_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_vote_authorized_voter_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_authorized_voter_global_t * self = (fd_vote_authorized_voter_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->epoch, ctx );
-  fd_pubkey_decode_inner_global( &self->pubkey, alloc_mem, ctx );
-}
-int fd_vote_authorized_voter_convert_global_to_local( void const * global_self, fd_vote_authorized_voter_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_authorized_voter_global_t const * mem = (fd_vote_authorized_voter_global_t const *)global_self;
-  self->epoch = mem->epoch;
-  err = fd_pubkey_convert_global_to_local( &mem->pubkey, &self->pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_vote_authorized_voter_new(fd_vote_authorized_voter_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_authorized_voter_t) );
@@ -8100,29 +7216,6 @@ void fd_vote_prior_voter_decode_inner( void * struct_mem, void * * alloc_mem, fd
   fd_pubkey_decode_inner( &self->pubkey, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->epoch_start, ctx );
   fd_bincode_uint64_decode_unsafe( &self->epoch_end, ctx );
-}
-void * fd_vote_prior_voter_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_prior_voter_global_t * self = (fd_vote_prior_voter_global_t *)mem;
-  fd_vote_prior_voter_new( (fd_vote_prior_voter_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_vote_prior_voter_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_vote_prior_voter_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_vote_prior_voter_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_prior_voter_global_t * self = (fd_vote_prior_voter_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->pubkey, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->epoch_start, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->epoch_end, ctx );
-}
-int fd_vote_prior_voter_convert_global_to_local( void const * global_self, fd_vote_prior_voter_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_prior_voter_global_t const * mem = (fd_vote_prior_voter_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->pubkey, &self->pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->epoch_start = mem->epoch_start;
-  self->epoch_end = mem->epoch_end;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_vote_prior_voter_new(fd_vote_prior_voter_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_prior_voter_t) );
@@ -8198,31 +7291,6 @@ void fd_vote_prior_voter_0_23_5_decode_inner( void * struct_mem, void * * alloc_
   fd_bincode_uint64_decode_unsafe( &self->epoch_end, ctx );
   fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
 }
-void * fd_vote_prior_voter_0_23_5_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_prior_voter_0_23_5_global_t * self = (fd_vote_prior_voter_0_23_5_global_t *)mem;
-  fd_vote_prior_voter_0_23_5_new( (fd_vote_prior_voter_0_23_5_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_vote_prior_voter_0_23_5_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_vote_prior_voter_0_23_5_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_vote_prior_voter_0_23_5_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_prior_voter_0_23_5_global_t * self = (fd_vote_prior_voter_0_23_5_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->pubkey, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->epoch_start, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->epoch_end, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-}
-int fd_vote_prior_voter_0_23_5_convert_global_to_local( void const * global_self, fd_vote_prior_voter_0_23_5_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_prior_voter_0_23_5_global_t const * mem = (fd_vote_prior_voter_0_23_5_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->pubkey, &self->pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->epoch_start = mem->epoch_start;
-  self->epoch_end = mem->epoch_end;
-  self->slot = mem->slot;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_vote_prior_voter_0_23_5_new(fd_vote_prior_voter_0_23_5_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_prior_voter_0_23_5_t) );
   fd_pubkey_new( &self->pubkey );
@@ -8294,28 +7362,6 @@ void fd_vote_epoch_credits_decode_inner( void * struct_mem, void * * alloc_mem, 
   fd_bincode_uint64_decode_unsafe( &self->credits, ctx );
   fd_bincode_uint64_decode_unsafe( &self->prev_credits, ctx );
 }
-void * fd_vote_epoch_credits_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_epoch_credits_global_t * self = (fd_vote_epoch_credits_global_t *)mem;
-  fd_vote_epoch_credits_new( (fd_vote_epoch_credits_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_vote_epoch_credits_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_vote_epoch_credits_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_vote_epoch_credits_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_epoch_credits_global_t * self = (fd_vote_epoch_credits_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->epoch, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->credits, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->prev_credits, ctx );
-}
-int fd_vote_epoch_credits_convert_global_to_local( void const * global_self, fd_vote_epoch_credits_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_epoch_credits_global_t const * mem = (fd_vote_epoch_credits_global_t const *)global_self;
-  self->epoch = mem->epoch;
-  self->credits = mem->credits;
-  self->prev_credits = mem->prev_credits;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_vote_epoch_credits_new(fd_vote_epoch_credits_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_epoch_credits_t) );
 }
@@ -8377,26 +7423,6 @@ void fd_vote_block_timestamp_decode_inner( void * struct_mem, void * * alloc_mem
   fd_vote_block_timestamp_t * self = (fd_vote_block_timestamp_t *)struct_mem;
   fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
   fd_bincode_uint64_decode_unsafe( (ulong *) &self->timestamp, ctx );
-}
-void * fd_vote_block_timestamp_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_block_timestamp_global_t * self = (fd_vote_block_timestamp_global_t *)mem;
-  fd_vote_block_timestamp_new( (fd_vote_block_timestamp_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_vote_block_timestamp_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_vote_block_timestamp_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_vote_block_timestamp_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_block_timestamp_global_t * self = (fd_vote_block_timestamp_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-  fd_bincode_uint64_decode_unsafe( (ulong *) &self->timestamp, ctx );
-}
-int fd_vote_block_timestamp_convert_global_to_local( void const * global_self, fd_vote_block_timestamp_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_block_timestamp_global_t const * mem = (fd_vote_block_timestamp_global_t const *)global_self;
-  self->slot = mem->slot;
-  self->timestamp = mem->timestamp;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_vote_block_timestamp_new(fd_vote_block_timestamp_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_block_timestamp_t) );
@@ -8468,32 +7494,6 @@ void fd_vote_prior_voters_decode_inner( void * struct_mem, void * * alloc_mem, f
   }
   fd_bincode_uint64_decode_unsafe( &self->idx, ctx );
   fd_bincode_bool_decode_unsafe( &self->is_empty, ctx );
-}
-void * fd_vote_prior_voters_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_prior_voters_global_t * self = (fd_vote_prior_voters_global_t *)mem;
-  fd_vote_prior_voters_new( (fd_vote_prior_voters_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_vote_prior_voters_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_vote_prior_voters_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_vote_prior_voters_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_prior_voters_global_t * self = (fd_vote_prior_voters_global_t *)struct_mem;
-  for( ulong i=0; i<32; i++ ) {
-    fd_vote_prior_voter_decode_inner( self->buf + i, alloc_mem, ctx );
-  }
-  fd_bincode_uint64_decode_unsafe( &self->idx, ctx );
-  fd_bincode_bool_decode_unsafe( &self->is_empty, ctx );
-}
-int fd_vote_prior_voters_convert_global_to_local( void const * global_self, fd_vote_prior_voters_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_prior_voters_global_t const * mem = (fd_vote_prior_voters_global_t const *)global_self;
-  for( ulong i=0; i<32; i++ ) {
-    fd_vote_prior_voter_convert_global_to_local( &mem->buf[i], &self->buf[i], ctx );
-  }
-  self->idx = mem->idx;
-  self->is_empty = mem->is_empty;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_vote_prior_voters_new(fd_vote_prior_voters_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_prior_voters_t) );
@@ -8571,30 +7571,6 @@ void fd_vote_prior_voters_0_23_5_decode_inner( void * struct_mem, void * * alloc
   }
   fd_bincode_uint64_decode_unsafe( &self->idx, ctx );
 }
-void * fd_vote_prior_voters_0_23_5_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_prior_voters_0_23_5_global_t * self = (fd_vote_prior_voters_0_23_5_global_t *)mem;
-  fd_vote_prior_voters_0_23_5_new( (fd_vote_prior_voters_0_23_5_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_vote_prior_voters_0_23_5_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_vote_prior_voters_0_23_5_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_vote_prior_voters_0_23_5_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_prior_voters_0_23_5_global_t * self = (fd_vote_prior_voters_0_23_5_global_t *)struct_mem;
-  for( ulong i=0; i<32; i++ ) {
-    fd_vote_prior_voter_0_23_5_decode_inner( self->buf + i, alloc_mem, ctx );
-  }
-  fd_bincode_uint64_decode_unsafe( &self->idx, ctx );
-}
-int fd_vote_prior_voters_0_23_5_convert_global_to_local( void const * global_self, fd_vote_prior_voters_0_23_5_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_prior_voters_0_23_5_global_t const * mem = (fd_vote_prior_voters_0_23_5_global_t const *)global_self;
-  for( ulong i=0; i<32; i++ ) {
-    fd_vote_prior_voter_0_23_5_convert_global_to_local( &mem->buf[i], &self->buf[i], ctx );
-  }
-  self->idx = mem->idx;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_vote_prior_voters_0_23_5_new(fd_vote_prior_voters_0_23_5_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_prior_voters_0_23_5_t) );
   for( ulong i=0; i<32; i++ )
@@ -8663,27 +7639,6 @@ void fd_landed_vote_decode_inner( void * struct_mem, void * * alloc_mem, fd_binc
   fd_bincode_uint8_decode_unsafe( &self->latency, ctx );
   fd_vote_lockout_decode_inner( &self->lockout, alloc_mem, ctx );
 }
-void * fd_landed_vote_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_landed_vote_global_t * self = (fd_landed_vote_global_t *)mem;
-  fd_landed_vote_new( (fd_landed_vote_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_landed_vote_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_landed_vote_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_landed_vote_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_landed_vote_global_t * self = (fd_landed_vote_global_t *)struct_mem;
-  fd_bincode_uint8_decode_unsafe( &self->latency, ctx );
-  fd_vote_lockout_decode_inner_global( &self->lockout, alloc_mem, ctx );
-}
-int fd_landed_vote_convert_global_to_local( void const * global_self, fd_landed_vote_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_landed_vote_global_t const * mem = (fd_landed_vote_global_t const *)global_self;
-  self->latency = mem->latency;
-  err = fd_vote_lockout_convert_global_to_local( &mem->lockout, &self->lockout, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_landed_vote_new(fd_landed_vote_t * self) {
   fd_memset( self, 0, sizeof(fd_landed_vote_t) );
   fd_vote_lockout_new( &self->lockout );
@@ -8748,6 +7703,62 @@ int fd_vote_state_0_23_5_encode( fd_vote_state_0_23_5_t const * self, fd_bincode
     if( FD_UNLIKELY( err ) ) return err;
     for( deq_fd_vote_epoch_credits_t_iter_t iter = deq_fd_vote_epoch_credits_t_iter_init( self->epoch_credits ); !deq_fd_vote_epoch_credits_t_iter_done( self->epoch_credits, iter ); iter = deq_fd_vote_epoch_credits_t_iter_next( self->epoch_credits, iter ) ) {
       fd_vote_epoch_credits_t const * ele = deq_fd_vote_epoch_credits_t_iter_ele_const( self->epoch_credits, iter );
+      err = fd_vote_epoch_credits_encode( ele, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong epoch_credits_len = 0;
+    err = fd_bincode_uint64_encode( epoch_credits_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_vote_block_timestamp_encode( &self->last_timestamp, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_vote_state_0_23_5_encode_global( fd_vote_state_0_23_5_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_encode( &self->node_pubkey, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_pubkey_encode( &self->authorized_voter, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->authorized_voter_epoch, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_vote_prior_voters_0_23_5_encode( &self->prior_voters, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_pubkey_encode( &self->authorized_withdrawer, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint8_encode( (uchar)(self->commission), ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->votes_gaddr ) {
+  uchar * votes_laddr = fd_wksp_laddr_fast( ctx->wksp, self->votes_gaddr );
+   fd_vote_lockout_t * votes = deq_fd_vote_lockout_t_join( votes_laddr );
+    ulong votes_len = deq_fd_vote_lockout_t_cnt( votes );
+    err = fd_bincode_uint64_encode( votes_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( deq_fd_vote_lockout_t_iter_t iter = deq_fd_vote_lockout_t_iter_init( votes ); !deq_fd_vote_lockout_t_iter_done( votes, iter ); iter = deq_fd_vote_lockout_t_iter_next( votes, iter ) ) {
+      fd_vote_lockout_t const * ele = deq_fd_vote_lockout_t_iter_ele_const( votes, iter );
+      err = fd_vote_lockout_encode( ele, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong votes_len = 0;
+    err = fd_bincode_uint64_encode( votes_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_bool_encode( self->has_root_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_root_slot ) {
+    err = fd_bincode_uint64_encode( self->root_slot, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  if( self->epoch_credits_gaddr ) {
+  uchar * epoch_credits_laddr = fd_wksp_laddr_fast( ctx->wksp, self->epoch_credits_gaddr );
+   fd_vote_epoch_credits_t * epoch_credits = deq_fd_vote_epoch_credits_t_join( epoch_credits_laddr );
+    ulong epoch_credits_len = deq_fd_vote_epoch_credits_t_cnt( epoch_credits );
+    err = fd_bincode_uint64_encode( epoch_credits_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( deq_fd_vote_epoch_credits_t_iter_t iter = deq_fd_vote_epoch_credits_t_iter_init( epoch_credits ); !deq_fd_vote_epoch_credits_t_iter_done( epoch_credits, iter ); iter = deq_fd_vote_epoch_credits_t_iter_next( epoch_credits, iter ) ) {
+      fd_vote_epoch_credits_t const * ele = deq_fd_vote_epoch_credits_t_iter_ele_const( epoch_credits, iter );
       err = fd_vote_epoch_credits_encode( ele, ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
@@ -8868,23 +7879,23 @@ void * fd_vote_state_0_23_5_decode_global( void * mem, fd_bincode_decode_ctx_t *
 }
 void fd_vote_state_0_23_5_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_vote_state_0_23_5_global_t * self = (fd_vote_state_0_23_5_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->node_pubkey, alloc_mem, ctx );
-  fd_pubkey_decode_inner_global( &self->authorized_voter, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->node_pubkey, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->authorized_voter, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->authorized_voter_epoch, ctx );
-  fd_vote_prior_voters_0_23_5_decode_inner_global( &self->prior_voters, alloc_mem, ctx );
-  fd_pubkey_decode_inner_global( &self->authorized_withdrawer, alloc_mem, ctx );
+  fd_vote_prior_voters_0_23_5_decode_inner( &self->prior_voters, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->authorized_withdrawer, alloc_mem, ctx );
   fd_bincode_uint8_decode_unsafe( &self->commission, ctx );
   ulong votes_len;
   fd_bincode_uint64_decode_unsafe( &votes_len, ctx );
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, deq_fd_vote_lockout_t_align() );
   ulong votes_max = fd_ulong_max( votes_len, 32 );
-  self->votes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
   fd_vote_lockout_t * votes = deq_fd_vote_lockout_t_join_new( alloc_mem, votes_max );
   for( ulong i=0; i < votes_len; i++ ) {
     fd_vote_lockout_t * elem = deq_fd_vote_lockout_t_push_tail_nocopy( votes );
-    fd_vote_lockout_new( elem );
-    fd_vote_lockout_decode_inner_global( elem, alloc_mem, ctx );
+    fd_vote_lockout_new( (fd_vote_lockout_t*)fd_type_pun( elem ) );
+    fd_vote_lockout_decode_inner( elem, alloc_mem, ctx );
   }
+  self->votes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, deq_fd_vote_lockout_t_leave( votes ) );
   {
     uchar o;
     fd_bincode_bool_decode_unsafe( &o, ctx );
@@ -8897,35 +7908,14 @@ void fd_vote_state_0_23_5_decode_inner_global( void * struct_mem, void * * alloc
   fd_bincode_uint64_decode_unsafe( &epoch_credits_len, ctx );
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, deq_fd_vote_epoch_credits_t_align() );
   ulong epoch_credits_max = fd_ulong_max( epoch_credits_len, 64 );
-  self->epoch_credits_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
   fd_vote_epoch_credits_t * epoch_credits = deq_fd_vote_epoch_credits_t_join_new( alloc_mem, epoch_credits_max );
   for( ulong i=0; i < epoch_credits_len; i++ ) {
     fd_vote_epoch_credits_t * elem = deq_fd_vote_epoch_credits_t_push_tail_nocopy( epoch_credits );
-    fd_vote_epoch_credits_new( elem );
-    fd_vote_epoch_credits_decode_inner_global( elem, alloc_mem, ctx );
+    fd_vote_epoch_credits_new( (fd_vote_epoch_credits_t*)fd_type_pun( elem ) );
+    fd_vote_epoch_credits_decode_inner( elem, alloc_mem, ctx );
   }
-  fd_vote_block_timestamp_decode_inner_global( &self->last_timestamp, alloc_mem, ctx );
-}
-int fd_vote_state_0_23_5_convert_global_to_local( void const * global_self, fd_vote_state_0_23_5_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_state_0_23_5_global_t const * mem = (fd_vote_state_0_23_5_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->node_pubkey, &self->node_pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_pubkey_convert_global_to_local( &mem->authorized_voter, &self->authorized_voter, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->authorized_voter_epoch = mem->authorized_voter_epoch;
-  err = fd_vote_prior_voters_0_23_5_convert_global_to_local( &mem->prior_voters, &self->prior_voters, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_pubkey_convert_global_to_local( &mem->authorized_withdrawer, &self->authorized_withdrawer, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->commission = mem->commission;
-  self->votes = deq_fd_vote_lockout_t_join( fd_wksp_laddr_fast( ctx->wksp, mem->votes_gaddr ) );
-  self->root_slot = mem->root_slot;
-  self->has_root_slot = mem->has_root_slot;
-  self->epoch_credits = deq_fd_vote_epoch_credits_t_join( fd_wksp_laddr_fast( ctx->wksp, mem->epoch_credits_gaddr ) );
-  err = fd_vote_block_timestamp_convert_global_to_local( &mem->last_timestamp, &self->last_timestamp, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  self->epoch_credits_gaddr = fd_wksp_gaddr_fast( ctx->wksp, deq_fd_vote_epoch_credits_t_leave( epoch_credits ) );
+  fd_vote_block_timestamp_decode_inner( &self->last_timestamp, alloc_mem, ctx );
 }
 void fd_vote_state_0_23_5_new(fd_vote_state_0_23_5_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_state_0_23_5_t) );
@@ -9061,6 +8051,28 @@ int fd_vote_authorized_voters_encode( fd_vote_authorized_voters_t const * self, 
   }
   return FD_BINCODE_SUCCESS;
 }
+int fd_vote_authorized_voters_encode_global( fd_vote_authorized_voters_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  fd_vote_authorized_voter_t * pool = fd_vote_authorized_voters_pool_join( fd_wksp_laddr_fast( ctx->wksp, self->pool_gaddr ) );
+  fd_vote_authorized_voters_treap_t * treap = fd_vote_authorized_voters_treap_join( fd_wksp_laddr_fast( ctx->wksp, self->treap_gaddr ) );
+  if( treap ) {
+    ulong fd_vote_authorized_voters_len = fd_vote_authorized_voters_treap_ele_cnt( treap );
+    err = fd_bincode_uint64_encode( fd_vote_authorized_voters_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( fd_vote_authorized_voters_treap_fwd_iter_t iter = fd_vote_authorized_voters_treap_fwd_iter_init( treap, pool );
+         !fd_vote_authorized_voters_treap_fwd_iter_done( iter );
+         iter = fd_vote_authorized_voters_treap_fwd_iter_next( iter, pool ) ) {
+      fd_vote_authorized_voter_t * ele = fd_vote_authorized_voters_treap_fwd_iter_ele( iter, pool );
+      err = fd_vote_authorized_voter_encode( ele, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong fd_vote_authorized_voters_len = 0;
+    err = fd_bincode_uint64_encode( fd_vote_authorized_voters_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
 int fd_vote_authorized_voters_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_vote_authorized_voters_t);
   void const * start_data = ctx->data;
@@ -9125,10 +8137,8 @@ void fd_vote_authorized_voters_decode_inner_global( void * struct_mem, void * * 
   fd_bincode_uint64_decode_unsafe( &fd_vote_authorized_voters_treap_len, ctx );
   ulong fd_vote_authorized_voters_treap_max = fd_ulong_max( fd_vote_authorized_voters_treap_len, FD_VOTE_AUTHORIZED_VOTERS_MIN );
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, fd_vote_authorized_voters_pool_align() );
-  self->pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
   fd_vote_authorized_voter_t * pool = fd_vote_authorized_voters_pool_join_new( alloc_mem, fd_vote_authorized_voters_treap_max );
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, fd_vote_authorized_voters_treap_align() );
-  self->treap_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
   fd_vote_authorized_voters_treap_t * treap = fd_vote_authorized_voters_treap_join_new( alloc_mem, fd_vote_authorized_voters_treap_max );
   for( ulong i=0; i < fd_vote_authorized_voters_treap_len; i++ ) {
     fd_vote_authorized_voter_t * ele = fd_vote_authorized_voters_pool_ele_acquire( pool );
@@ -9141,13 +8151,8 @@ void fd_vote_authorized_voters_decode_inner_global( void * struct_mem, void * * 
     }
     fd_vote_authorized_voters_treap_ele_insert( treap, ele, pool ); /* this cannot fail */
   }
-}
-int fd_vote_authorized_voters_convert_global_to_local( void const * global_self, fd_vote_authorized_voters_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_authorized_voters_global_t const * mem = (fd_vote_authorized_voters_global_t const *)global_self;
-  self->pool  = fd_vote_authorized_voters_pool_join( fd_wksp_laddr_fast( ctx->wksp, mem->pool_gaddr ) );
-  self->treap = fd_vote_authorized_voters_treap_join( fd_wksp_laddr_fast( ctx->wksp, mem->treap_gaddr ) );
-  return FD_BINCODE_SUCCESS;
+  self->pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_vote_authorized_voters_pool_leave( pool ) );
+  self->treap_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_vote_authorized_voters_treap_leave( treap ) );
 }
 void fd_vote_authorized_voters_new(fd_vote_authorized_voters_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_authorized_voters_t) );
@@ -9231,6 +8236,60 @@ int fd_vote_state_1_14_11_encode( fd_vote_state_1_14_11_t const * self, fd_binco
     if( FD_UNLIKELY( err ) ) return err;
     for( deq_fd_vote_epoch_credits_t_iter_t iter = deq_fd_vote_epoch_credits_t_iter_init( self->epoch_credits ); !deq_fd_vote_epoch_credits_t_iter_done( self->epoch_credits, iter ); iter = deq_fd_vote_epoch_credits_t_iter_next( self->epoch_credits, iter ) ) {
       fd_vote_epoch_credits_t const * ele = deq_fd_vote_epoch_credits_t_iter_ele_const( self->epoch_credits, iter );
+      err = fd_vote_epoch_credits_encode( ele, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong epoch_credits_len = 0;
+    err = fd_bincode_uint64_encode( epoch_credits_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_vote_block_timestamp_encode( &self->last_timestamp, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_vote_state_1_14_11_encode_global( fd_vote_state_1_14_11_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_encode( &self->node_pubkey, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_pubkey_encode( &self->authorized_withdrawer, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint8_encode( (uchar)(self->commission), ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->votes_gaddr ) {
+  uchar * votes_laddr = fd_wksp_laddr_fast( ctx->wksp, self->votes_gaddr );
+   fd_vote_lockout_t * votes = deq_fd_vote_lockout_t_join( votes_laddr );
+    ulong votes_len = deq_fd_vote_lockout_t_cnt( votes );
+    err = fd_bincode_uint64_encode( votes_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( deq_fd_vote_lockout_t_iter_t iter = deq_fd_vote_lockout_t_iter_init( votes ); !deq_fd_vote_lockout_t_iter_done( votes, iter ); iter = deq_fd_vote_lockout_t_iter_next( votes, iter ) ) {
+      fd_vote_lockout_t const * ele = deq_fd_vote_lockout_t_iter_ele_const( votes, iter );
+      err = fd_vote_lockout_encode( ele, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong votes_len = 0;
+    err = fd_bincode_uint64_encode( votes_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_bool_encode( self->has_root_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_root_slot ) {
+    err = fd_bincode_uint64_encode( self->root_slot, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_vote_authorized_voters_encode_global( &self->authorized_voters, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_vote_prior_voters_encode( &self->prior_voters, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->epoch_credits_gaddr ) {
+  uchar * epoch_credits_laddr = fd_wksp_laddr_fast( ctx->wksp, self->epoch_credits_gaddr );
+   fd_vote_epoch_credits_t * epoch_credits = deq_fd_vote_epoch_credits_t_join( epoch_credits_laddr );
+    ulong epoch_credits_len = deq_fd_vote_epoch_credits_t_cnt( epoch_credits );
+    err = fd_bincode_uint64_encode( epoch_credits_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( deq_fd_vote_epoch_credits_t_iter_t iter = deq_fd_vote_epoch_credits_t_iter_init( epoch_credits ); !deq_fd_vote_epoch_credits_t_iter_done( epoch_credits, iter ); iter = deq_fd_vote_epoch_credits_t_iter_next( epoch_credits, iter ) ) {
+      fd_vote_epoch_credits_t const * ele = deq_fd_vote_epoch_credits_t_iter_ele_const( epoch_credits, iter );
       err = fd_vote_epoch_credits_encode( ele, ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
@@ -9348,20 +8407,20 @@ void * fd_vote_state_1_14_11_decode_global( void * mem, fd_bincode_decode_ctx_t 
 }
 void fd_vote_state_1_14_11_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_vote_state_1_14_11_global_t * self = (fd_vote_state_1_14_11_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->node_pubkey, alloc_mem, ctx );
-  fd_pubkey_decode_inner_global( &self->authorized_withdrawer, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->node_pubkey, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->authorized_withdrawer, alloc_mem, ctx );
   fd_bincode_uint8_decode_unsafe( &self->commission, ctx );
   ulong votes_len;
   fd_bincode_uint64_decode_unsafe( &votes_len, ctx );
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, deq_fd_vote_lockout_t_align() );
   ulong votes_max = fd_ulong_max( votes_len, 32 );
-  self->votes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
   fd_vote_lockout_t * votes = deq_fd_vote_lockout_t_join_new( alloc_mem, votes_max );
   for( ulong i=0; i < votes_len; i++ ) {
     fd_vote_lockout_t * elem = deq_fd_vote_lockout_t_push_tail_nocopy( votes );
-    fd_vote_lockout_new( elem );
-    fd_vote_lockout_decode_inner_global( elem, alloc_mem, ctx );
+    fd_vote_lockout_new( (fd_vote_lockout_t*)fd_type_pun( elem ) );
+    fd_vote_lockout_decode_inner( elem, alloc_mem, ctx );
   }
+  self->votes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, deq_fd_vote_lockout_t_leave( votes ) );
   {
     uchar o;
     fd_bincode_bool_decode_unsafe( &o, ctx );
@@ -9371,39 +8430,19 @@ void fd_vote_state_1_14_11_decode_inner_global( void * struct_mem, void * * allo
     }
   }
   fd_vote_authorized_voters_decode_inner_global( &self->authorized_voters, alloc_mem, ctx );
-  fd_vote_prior_voters_decode_inner_global( &self->prior_voters, alloc_mem, ctx );
+  fd_vote_prior_voters_decode_inner( &self->prior_voters, alloc_mem, ctx );
   ulong epoch_credits_len;
   fd_bincode_uint64_decode_unsafe( &epoch_credits_len, ctx );
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, deq_fd_vote_epoch_credits_t_align() );
   ulong epoch_credits_max = fd_ulong_max( epoch_credits_len, 64 );
-  self->epoch_credits_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
   fd_vote_epoch_credits_t * epoch_credits = deq_fd_vote_epoch_credits_t_join_new( alloc_mem, epoch_credits_max );
   for( ulong i=0; i < epoch_credits_len; i++ ) {
     fd_vote_epoch_credits_t * elem = deq_fd_vote_epoch_credits_t_push_tail_nocopy( epoch_credits );
-    fd_vote_epoch_credits_new( elem );
-    fd_vote_epoch_credits_decode_inner_global( elem, alloc_mem, ctx );
+    fd_vote_epoch_credits_new( (fd_vote_epoch_credits_t*)fd_type_pun( elem ) );
+    fd_vote_epoch_credits_decode_inner( elem, alloc_mem, ctx );
   }
-  fd_vote_block_timestamp_decode_inner_global( &self->last_timestamp, alloc_mem, ctx );
-}
-int fd_vote_state_1_14_11_convert_global_to_local( void const * global_self, fd_vote_state_1_14_11_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_state_1_14_11_global_t const * mem = (fd_vote_state_1_14_11_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->node_pubkey, &self->node_pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_pubkey_convert_global_to_local( &mem->authorized_withdrawer, &self->authorized_withdrawer, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->commission = mem->commission;
-  self->votes = deq_fd_vote_lockout_t_join( fd_wksp_laddr_fast( ctx->wksp, mem->votes_gaddr ) );
-  self->root_slot = mem->root_slot;
-  self->has_root_slot = mem->has_root_slot;
-  err = fd_vote_authorized_voters_convert_global_to_local( &mem->authorized_voters, &self->authorized_voters, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_vote_prior_voters_convert_global_to_local( &mem->prior_voters, &self->prior_voters, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->epoch_credits = deq_fd_vote_epoch_credits_t_join( fd_wksp_laddr_fast( ctx->wksp, mem->epoch_credits_gaddr ) );
-  err = fd_vote_block_timestamp_convert_global_to_local( &mem->last_timestamp, &self->last_timestamp, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  self->epoch_credits_gaddr = fd_wksp_gaddr_fast( ctx->wksp, deq_fd_vote_epoch_credits_t_leave( epoch_credits ) );
+  fd_vote_block_timestamp_decode_inner( &self->last_timestamp, alloc_mem, ctx );
 }
 void fd_vote_state_1_14_11_new(fd_vote_state_1_14_11_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_state_1_14_11_t) );
@@ -9567,6 +8606,60 @@ int fd_vote_state_encode( fd_vote_state_t const * self, fd_bincode_encode_ctx_t 
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
+int fd_vote_state_encode_global( fd_vote_state_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_encode( &self->node_pubkey, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_pubkey_encode( &self->authorized_withdrawer, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint8_encode( (uchar)(self->commission), ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->votes_gaddr ) {
+  uchar * votes_laddr = fd_wksp_laddr_fast( ctx->wksp, self->votes_gaddr );
+   fd_landed_vote_t * votes = deq_fd_landed_vote_t_join( votes_laddr );
+    ulong votes_len = deq_fd_landed_vote_t_cnt( votes );
+    err = fd_bincode_uint64_encode( votes_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( deq_fd_landed_vote_t_iter_t iter = deq_fd_landed_vote_t_iter_init( votes ); !deq_fd_landed_vote_t_iter_done( votes, iter ); iter = deq_fd_landed_vote_t_iter_next( votes, iter ) ) {
+      fd_landed_vote_t const * ele = deq_fd_landed_vote_t_iter_ele_const( votes, iter );
+      err = fd_landed_vote_encode( ele, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong votes_len = 0;
+    err = fd_bincode_uint64_encode( votes_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_bool_encode( self->has_root_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_root_slot ) {
+    err = fd_bincode_uint64_encode( self->root_slot, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_vote_authorized_voters_encode_global( &self->authorized_voters, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_vote_prior_voters_encode( &self->prior_voters, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->epoch_credits_gaddr ) {
+  uchar * epoch_credits_laddr = fd_wksp_laddr_fast( ctx->wksp, self->epoch_credits_gaddr );
+   fd_vote_epoch_credits_t * epoch_credits = deq_fd_vote_epoch_credits_t_join( epoch_credits_laddr );
+    ulong epoch_credits_len = deq_fd_vote_epoch_credits_t_cnt( epoch_credits );
+    err = fd_bincode_uint64_encode( epoch_credits_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( deq_fd_vote_epoch_credits_t_iter_t iter = deq_fd_vote_epoch_credits_t_iter_init( epoch_credits ); !deq_fd_vote_epoch_credits_t_iter_done( epoch_credits, iter ); iter = deq_fd_vote_epoch_credits_t_iter_next( epoch_credits, iter ) ) {
+      fd_vote_epoch_credits_t const * ele = deq_fd_vote_epoch_credits_t_iter_ele_const( epoch_credits, iter );
+      err = fd_vote_epoch_credits_encode( ele, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong epoch_credits_len = 0;
+    err = fd_bincode_uint64_encode( epoch_credits_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_vote_block_timestamp_encode( &self->last_timestamp, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
 int fd_vote_state_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_vote_state_t);
   void const * start_data = ctx->data;
@@ -9672,20 +8765,20 @@ void * fd_vote_state_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) 
 }
 void fd_vote_state_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_vote_state_global_t * self = (fd_vote_state_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->node_pubkey, alloc_mem, ctx );
-  fd_pubkey_decode_inner_global( &self->authorized_withdrawer, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->node_pubkey, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->authorized_withdrawer, alloc_mem, ctx );
   fd_bincode_uint8_decode_unsafe( &self->commission, ctx );
   ulong votes_len;
   fd_bincode_uint64_decode_unsafe( &votes_len, ctx );
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, deq_fd_landed_vote_t_align() );
   ulong votes_max = fd_ulong_max( votes_len, 32 );
-  self->votes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
   fd_landed_vote_t * votes = deq_fd_landed_vote_t_join_new( alloc_mem, votes_max );
   for( ulong i=0; i < votes_len; i++ ) {
     fd_landed_vote_t * elem = deq_fd_landed_vote_t_push_tail_nocopy( votes );
-    fd_landed_vote_new( elem );
-    fd_landed_vote_decode_inner_global( elem, alloc_mem, ctx );
+    fd_landed_vote_new( (fd_landed_vote_t*)fd_type_pun( elem ) );
+    fd_landed_vote_decode_inner( elem, alloc_mem, ctx );
   }
+  self->votes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, deq_fd_landed_vote_t_leave( votes ) );
   {
     uchar o;
     fd_bincode_bool_decode_unsafe( &o, ctx );
@@ -9695,39 +8788,19 @@ void fd_vote_state_decode_inner_global( void * struct_mem, void * * alloc_mem, f
     }
   }
   fd_vote_authorized_voters_decode_inner_global( &self->authorized_voters, alloc_mem, ctx );
-  fd_vote_prior_voters_decode_inner_global( &self->prior_voters, alloc_mem, ctx );
+  fd_vote_prior_voters_decode_inner( &self->prior_voters, alloc_mem, ctx );
   ulong epoch_credits_len;
   fd_bincode_uint64_decode_unsafe( &epoch_credits_len, ctx );
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, deq_fd_vote_epoch_credits_t_align() );
   ulong epoch_credits_max = fd_ulong_max( epoch_credits_len, 64 );
-  self->epoch_credits_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
   fd_vote_epoch_credits_t * epoch_credits = deq_fd_vote_epoch_credits_t_join_new( alloc_mem, epoch_credits_max );
   for( ulong i=0; i < epoch_credits_len; i++ ) {
     fd_vote_epoch_credits_t * elem = deq_fd_vote_epoch_credits_t_push_tail_nocopy( epoch_credits );
-    fd_vote_epoch_credits_new( elem );
-    fd_vote_epoch_credits_decode_inner_global( elem, alloc_mem, ctx );
+    fd_vote_epoch_credits_new( (fd_vote_epoch_credits_t*)fd_type_pun( elem ) );
+    fd_vote_epoch_credits_decode_inner( elem, alloc_mem, ctx );
   }
-  fd_vote_block_timestamp_decode_inner_global( &self->last_timestamp, alloc_mem, ctx );
-}
-int fd_vote_state_convert_global_to_local( void const * global_self, fd_vote_state_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_state_global_t const * mem = (fd_vote_state_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->node_pubkey, &self->node_pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_pubkey_convert_global_to_local( &mem->authorized_withdrawer, &self->authorized_withdrawer, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->commission = mem->commission;
-  self->votes = deq_fd_landed_vote_t_join( fd_wksp_laddr_fast( ctx->wksp, mem->votes_gaddr ) );
-  self->root_slot = mem->root_slot;
-  self->has_root_slot = mem->has_root_slot;
-  err = fd_vote_authorized_voters_convert_global_to_local( &mem->authorized_voters, &self->authorized_voters, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_vote_prior_voters_convert_global_to_local( &mem->prior_voters, &self->prior_voters, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->epoch_credits = deq_fd_vote_epoch_credits_t_join( fd_wksp_laddr_fast( ctx->wksp, mem->epoch_credits_gaddr ) );
-  err = fd_vote_block_timestamp_convert_global_to_local( &mem->last_timestamp, &self->last_timestamp, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  self->epoch_credits_gaddr = fd_wksp_gaddr_fast( ctx->wksp, deq_fd_vote_epoch_credits_t_leave( epoch_credits ) );
+  fd_vote_block_timestamp_decode_inner( &self->last_timestamp, alloc_mem, ctx );
 }
 void fd_vote_state_new(fd_vote_state_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_state_t) );
@@ -9919,34 +8992,6 @@ void fd_vote_state_versioned_inner_decode_inner_global( fd_vote_state_versioned_
   }
   }
 }
-int fd_vote_state_versioned_convert_global_to_local_inner( fd_vote_state_versioned_inner_global_t const * mem, fd_vote_state_versioned_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_vote_state_0_23_5_convert_global_to_local( &mem->v0_23_5, &self->v0_23_5, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 1: {
-    err = fd_vote_state_1_14_11_convert_global_to_local( &mem->v1_14_11, &self->v1_14_11, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 2: {
-    err = fd_vote_state_convert_global_to_local( &mem->current, &self->current, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_vote_state_versioned_convert_global_to_local( void const * global_self, fd_vote_state_versioned_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_state_versioned_global_t const * mem = (fd_vote_state_versioned_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_vote_state_versioned_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_vote_state_versioned_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_vote_state_versioned_t * self = (fd_vote_state_versioned_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -9960,6 +9005,33 @@ void * fd_vote_state_versioned_decode( void * mem, fd_bincode_decode_ctx_t * ctx
   fd_vote_state_versioned_decode_inner( mem, alloc_mem, ctx );
   return self;
 }
+int fd_vote_state_versioned_inner_encode_global( fd_vote_state_versioned_inner_global_t const * self, uint discriminant, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  switch (discriminant) {
+  case 0: {
+    err = fd_vote_state_0_23_5_encode_global( &self->v0_23_5, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 1: {
+    err = fd_vote_state_1_14_11_encode_global( &self->v1_14_11, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 2: {
+    err = fd_vote_state_encode_global( &self->current, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_vote_state_versioned_encode_global( fd_vote_state_versioned_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err = fd_bincode_uint32_encode( self->discriminant, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fd_vote_state_versioned_inner_encode_global( &self->inner, self->discriminant, ctx );
+}
+
 void * fd_vote_state_versioned_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_vote_state_versioned_t * self = (fd_vote_state_versioned_t *)mem;
   fd_vote_state_versioned_new( self );
@@ -10122,6 +9194,40 @@ int fd_vote_state_update_encode( fd_vote_state_update_t const * self, fd_bincode
   }
   return FD_BINCODE_SUCCESS;
 }
+int fd_vote_state_update_encode_global( fd_vote_state_update_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  if( self->lockouts_gaddr ) {
+  uchar * lockouts_laddr = fd_wksp_laddr_fast( ctx->wksp, self->lockouts_gaddr );
+   fd_vote_lockout_t * lockouts = deq_fd_vote_lockout_t_join( lockouts_laddr );
+    ulong lockouts_len = deq_fd_vote_lockout_t_cnt( lockouts );
+    err = fd_bincode_uint64_encode( lockouts_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( deq_fd_vote_lockout_t_iter_t iter = deq_fd_vote_lockout_t_iter_init( lockouts ); !deq_fd_vote_lockout_t_iter_done( lockouts, iter ); iter = deq_fd_vote_lockout_t_iter_next( lockouts, iter ) ) {
+      fd_vote_lockout_t const * ele = deq_fd_vote_lockout_t_iter_ele_const( lockouts, iter );
+      err = fd_vote_lockout_encode( ele, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong lockouts_len = 0;
+    err = fd_bincode_uint64_encode( lockouts_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_bool_encode( self->has_root, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_root ) {
+    err = fd_bincode_uint64_encode( self->root, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_hash_encode( &self->hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_bool_encode( self->has_timestamp, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_timestamp ) {
+    err = fd_bincode_int64_encode( self->timestamp, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
 int fd_vote_state_update_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_vote_state_update_t);
   void const * start_data = ctx->data;
@@ -10215,13 +9321,13 @@ void fd_vote_state_update_decode_inner_global( void * struct_mem, void * * alloc
   fd_bincode_uint64_decode_unsafe( &lockouts_len, ctx );
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, deq_fd_vote_lockout_t_align() );
   ulong lockouts_max = fd_ulong_max( lockouts_len, 32 );
-  self->lockouts_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
   fd_vote_lockout_t * lockouts = deq_fd_vote_lockout_t_join_new( alloc_mem, lockouts_max );
   for( ulong i=0; i < lockouts_len; i++ ) {
     fd_vote_lockout_t * elem = deq_fd_vote_lockout_t_push_tail_nocopy( lockouts );
-    fd_vote_lockout_new( elem );
-    fd_vote_lockout_decode_inner_global( elem, alloc_mem, ctx );
+    fd_vote_lockout_new( (fd_vote_lockout_t*)fd_type_pun( elem ) );
+    fd_vote_lockout_decode_inner( elem, alloc_mem, ctx );
   }
+  self->lockouts_gaddr = fd_wksp_gaddr_fast( ctx->wksp, deq_fd_vote_lockout_t_leave( lockouts ) );
   {
     uchar o;
     fd_bincode_bool_decode_unsafe( &o, ctx );
@@ -10230,7 +9336,7 @@ void fd_vote_state_update_decode_inner_global( void * struct_mem, void * * alloc
       fd_bincode_uint64_decode_unsafe( &self->root, ctx );
     }
   }
-  fd_hash_decode_inner_global( &self->hash, alloc_mem, ctx );
+  fd_hash_decode_inner( &self->hash, alloc_mem, ctx );
   {
     uchar o;
     fd_bincode_bool_decode_unsafe( &o, ctx );
@@ -10239,18 +9345,6 @@ void fd_vote_state_update_decode_inner_global( void * struct_mem, void * * alloc
       fd_bincode_int64_decode_unsafe( &self->timestamp, ctx );
     }
   }
-}
-int fd_vote_state_update_convert_global_to_local( void const * global_self, fd_vote_state_update_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_state_update_global_t const * mem = (fd_vote_state_update_global_t const *)global_self;
-  self->lockouts = deq_fd_vote_lockout_t_join( fd_wksp_laddr_fast( ctx->wksp, mem->lockouts_gaddr ) );
-  self->root = mem->root;
-  self->has_root = mem->has_root;
-  err = fd_hash_convert_global_to_local( &mem->hash, &self->hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->timestamp = mem->timestamp;
-  self->has_timestamp = mem->has_timestamp;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_vote_state_update_new(fd_vote_state_update_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_state_update_t) );
@@ -10350,6 +9444,30 @@ int fd_compact_vote_state_update_encode( fd_compact_vote_state_update_t const * 
   }
   return FD_BINCODE_SUCCESS;
 }
+int fd_compact_vote_state_update_encode_global( fd_compact_vote_state_update_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->root, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_compact_u16_encode( &self->lockouts_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->lockouts_len ) {
+    uchar * lockouts_laddr = fd_wksp_laddr_fast( ctx->wksp, self->lockouts_gaddr );
+    fd_lockout_offset_t * lockouts = (fd_lockout_offset_t *)lockouts_laddr;
+    for( ulong i=0; i < self->lockouts_len; i++ ) {
+      err = fd_lockout_offset_encode( &lockouts[i], ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  err = fd_hash_encode( &self->hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_bool_encode( self->has_timestamp, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_timestamp ) {
+    err = fd_bincode_int64_encode( self->timestamp, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
 int fd_compact_vote_state_update_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_compact_vote_state_update_t);
   void const * start_data = ctx->data;
@@ -10436,12 +9554,13 @@ void fd_compact_vote_state_update_decode_inner_global( void * struct_mem, void *
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_LOCKOUT_OFFSET_FOOTPRINT*self->lockouts_len;
     for( ulong i=0; i < self->lockouts_len; i++ ) {
-      fd_lockout_offset_new( (fd_lockout_offset_t *)(cur_mem + FD_LOCKOUT_OFFSET_FOOTPRINT * i) );
-      fd_lockout_offset_decode_inner_global( cur_mem + FD_LOCKOUT_OFFSET_FOOTPRINT * i, alloc_mem, ctx );
+      fd_lockout_offset_new( (fd_lockout_offset_t *)fd_type_pun(cur_mem + FD_LOCKOUT_OFFSET_FOOTPRINT * i) );
+      fd_lockout_offset_decode_inner( cur_mem + FD_LOCKOUT_OFFSET_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->lockouts_gaddr = 0UL;
-  fd_hash_decode_inner_global( &self->hash, alloc_mem, ctx );
+  }
+  fd_hash_decode_inner( &self->hash, alloc_mem, ctx );
   {
     uchar o;
     fd_bincode_bool_decode_unsafe( &o, ctx );
@@ -10450,18 +9569,6 @@ void fd_compact_vote_state_update_decode_inner_global( void * struct_mem, void *
       fd_bincode_int64_decode_unsafe( &self->timestamp, ctx );
     }
   }
-}
-int fd_compact_vote_state_update_convert_global_to_local( void const * global_self, fd_compact_vote_state_update_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_compact_vote_state_update_global_t const * mem = (fd_compact_vote_state_update_global_t const *)global_self;
-  self->root = mem->root;
-  self->lockouts_len = mem->lockouts_len;
-  self->lockouts     = fd_wksp_laddr_fast( ctx->wksp, mem->lockouts_gaddr );
-  err = fd_hash_convert_global_to_local( &mem->hash, &self->hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->timestamp = mem->timestamp;
-  self->has_timestamp = mem->has_timestamp;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_compact_vote_state_update_new(fd_compact_vote_state_update_t * self) {
   fd_memset( self, 0, sizeof(fd_compact_vote_state_update_t) );
@@ -10524,6 +9631,14 @@ int fd_compact_vote_state_update_switch_encode( fd_compact_vote_state_update_swi
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
+int fd_compact_vote_state_update_switch_encode_global( fd_compact_vote_state_update_switch_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_compact_vote_state_update_encode_global( &self->compact_vote_state_update, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_hash_encode( &self->hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
 int fd_compact_vote_state_update_switch_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_compact_vote_state_update_switch_t);
   void const * start_data = ctx->data;
@@ -10565,16 +9680,7 @@ void * fd_compact_vote_state_update_switch_decode_global( void * mem, fd_bincode
 void fd_compact_vote_state_update_switch_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_compact_vote_state_update_switch_global_t * self = (fd_compact_vote_state_update_switch_global_t *)struct_mem;
   fd_compact_vote_state_update_decode_inner_global( &self->compact_vote_state_update, alloc_mem, ctx );
-  fd_hash_decode_inner_global( &self->hash, alloc_mem, ctx );
-}
-int fd_compact_vote_state_update_switch_convert_global_to_local( void const * global_self, fd_compact_vote_state_update_switch_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_compact_vote_state_update_switch_global_t const * mem = (fd_compact_vote_state_update_switch_global_t const *)global_self;
-  err = fd_compact_vote_state_update_convert_global_to_local( &mem->compact_vote_state_update, &self->compact_vote_state_update, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_hash_convert_global_to_local( &mem->hash, &self->hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  fd_hash_decode_inner( &self->hash, alloc_mem, ctx );
 }
 void fd_compact_vote_state_update_switch_new(fd_compact_vote_state_update_switch_t * self) {
   fd_memset( self, 0, sizeof(fd_compact_vote_state_update_switch_t) );
@@ -10612,6 +9718,38 @@ int fd_compact_tower_sync_encode( fd_compact_tower_sync_t const * self, fd_binco
     if( FD_UNLIKELY( err ) ) return err;
     for( deq_fd_lockout_offset_t_iter_t iter = deq_fd_lockout_offset_t_iter_init( self->lockout_offsets ); !deq_fd_lockout_offset_t_iter_done( self->lockout_offsets, iter ); iter = deq_fd_lockout_offset_t_iter_next( self->lockout_offsets, iter ) ) {
       fd_lockout_offset_t const * ele = deq_fd_lockout_offset_t_iter_ele_const( self->lockout_offsets, iter );
+      err = fd_lockout_offset_encode( ele, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ushort lockout_offsets_len = 0;
+    err = fd_bincode_compact_u16_encode( &lockout_offsets_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_hash_encode( &self->hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_bool_encode( self->has_timestamp, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_timestamp ) {
+    err = fd_bincode_int64_encode( self->timestamp, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_hash_encode( &self->block_id, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_compact_tower_sync_encode_global( fd_compact_tower_sync_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->root, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->lockout_offsets_gaddr ) {
+  uchar * lockout_offsets_laddr = fd_wksp_laddr_fast( ctx->wksp, self->lockout_offsets_gaddr );
+   fd_lockout_offset_t * lockout_offsets = deq_fd_lockout_offset_t_join( lockout_offsets_laddr );
+    ushort lockout_offsets_len = (ushort)deq_fd_lockout_offset_t_cnt( lockout_offsets );
+    err = fd_bincode_compact_u16_encode( &lockout_offsets_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( deq_fd_lockout_offset_t_iter_t iter = deq_fd_lockout_offset_t_iter_init( lockout_offsets ); !deq_fd_lockout_offset_t_iter_done( lockout_offsets, iter ); iter = deq_fd_lockout_offset_t_iter_next( lockout_offsets, iter ) ) {
+      fd_lockout_offset_t const * ele = deq_fd_lockout_offset_t_iter_ele_const( lockout_offsets, iter );
       err = fd_lockout_offset_encode( ele, ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
@@ -10715,14 +9853,14 @@ void fd_compact_tower_sync_decode_inner_global( void * struct_mem, void * * allo
   fd_bincode_compact_u16_decode_unsafe( &lockout_offsets_len, ctx );
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, deq_fd_lockout_offset_t_align() );
   ulong lockout_offsets_max = fd_ulong_max( lockout_offsets_len, 32 );
-  self->lockout_offsets_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
   fd_lockout_offset_t * lockout_offsets = deq_fd_lockout_offset_t_join_new( alloc_mem, lockout_offsets_max );
   for( ulong i=0; i < lockout_offsets_len; i++ ) {
     fd_lockout_offset_t * elem = deq_fd_lockout_offset_t_push_tail_nocopy( lockout_offsets );
-    fd_lockout_offset_new( elem );
-    fd_lockout_offset_decode_inner_global( elem, alloc_mem, ctx );
+    fd_lockout_offset_new( (fd_lockout_offset_t*)fd_type_pun( elem ) );
+    fd_lockout_offset_decode_inner( elem, alloc_mem, ctx );
   }
-  fd_hash_decode_inner_global( &self->hash, alloc_mem, ctx );
+  self->lockout_offsets_gaddr = fd_wksp_gaddr_fast( ctx->wksp, deq_fd_lockout_offset_t_leave( lockout_offsets ) );
+  fd_hash_decode_inner( &self->hash, alloc_mem, ctx );
   {
     uchar o;
     fd_bincode_bool_decode_unsafe( &o, ctx );
@@ -10731,20 +9869,7 @@ void fd_compact_tower_sync_decode_inner_global( void * struct_mem, void * * allo
       fd_bincode_int64_decode_unsafe( &self->timestamp, ctx );
     }
   }
-  fd_hash_decode_inner_global( &self->block_id, alloc_mem, ctx );
-}
-int fd_compact_tower_sync_convert_global_to_local( void const * global_self, fd_compact_tower_sync_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_compact_tower_sync_global_t const * mem = (fd_compact_tower_sync_global_t const *)global_self;
-  self->root = mem->root;
-  self->lockout_offsets = deq_fd_lockout_offset_t_join( fd_wksp_laddr_fast( ctx->wksp, mem->lockout_offsets_gaddr ) );
-  err = fd_hash_convert_global_to_local( &mem->hash, &self->hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->timestamp = mem->timestamp;
-  self->has_timestamp = mem->has_timestamp;
-  err = fd_hash_convert_global_to_local( &mem->block_id, &self->block_id, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  fd_hash_decode_inner( &self->block_id, alloc_mem, ctx );
 }
 void fd_compact_tower_sync_new(fd_compact_tower_sync_t * self) {
   fd_memset( self, 0, sizeof(fd_compact_tower_sync_t) );
@@ -10817,21 +9942,6 @@ ulong fd_compact_tower_sync_size( fd_compact_tower_sync_t const * self ) {
   return size;
 }
 
-int fd_tower_sync_convert_global_to_local( void const * global_self, fd_tower_sync_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_tower_sync_global_t const * mem = (fd_tower_sync_global_t const *)global_self;
-  self->lockouts = deq_fd_vote_lockout_t_join( fd_wksp_laddr_fast( ctx->wksp, mem->lockouts_gaddr ) );
-  self->lockouts_cnt = mem->lockouts_cnt;
-  self->root = mem->root;
-  self->has_root = mem->has_root;
-  err = fd_hash_convert_global_to_local( &mem->hash, &self->hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->timestamp = mem->timestamp;
-  self->has_timestamp = mem->has_timestamp;
-  err = fd_hash_convert_global_to_local( &mem->block_id, &self->block_id, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_tower_sync_new(fd_tower_sync_t * self) {
   fd_memset( self, 0, sizeof(fd_tower_sync_t) );
   fd_hash_new( &self->hash );
@@ -10922,6 +10032,14 @@ int fd_tower_sync_switch_encode( fd_tower_sync_switch_t const * self, fd_bincode
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
+int fd_tower_sync_switch_encode_global( fd_tower_sync_switch_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_tower_sync_encode_global( &self->tower_sync, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_hash_encode( &self->hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
 int fd_tower_sync_switch_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_tower_sync_switch_t);
   void const * start_data = ctx->data;
@@ -10963,16 +10081,7 @@ void * fd_tower_sync_switch_decode_global( void * mem, fd_bincode_decode_ctx_t *
 void fd_tower_sync_switch_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_tower_sync_switch_global_t * self = (fd_tower_sync_switch_global_t *)struct_mem;
   fd_tower_sync_decode_inner_global( &self->tower_sync, alloc_mem, ctx );
-  fd_hash_decode_inner_global( &self->hash, alloc_mem, ctx );
-}
-int fd_tower_sync_switch_convert_global_to_local( void const * global_self, fd_tower_sync_switch_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_tower_sync_switch_global_t const * mem = (fd_tower_sync_switch_global_t const *)global_self;
-  err = fd_tower_sync_convert_global_to_local( &mem->tower_sync, &self->tower_sync, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_hash_convert_global_to_local( &mem->hash, &self->hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  fd_hash_decode_inner( &self->hash, alloc_mem, ctx );
 }
 void fd_tower_sync_switch_new(fd_tower_sync_switch_t * self) {
   fd_memset( self, 0, sizeof(fd_tower_sync_switch_t) );
@@ -11055,35 +10164,6 @@ void fd_slot_history_inner_decode_inner( void * struct_mem, void * * alloc_mem, 
   } else
     self->blocks = NULL;
 }
-void * fd_slot_history_inner_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_slot_history_inner_global_t * self = (fd_slot_history_inner_global_t *)mem;
-  fd_slot_history_inner_new( (fd_slot_history_inner_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_slot_history_inner_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_slot_history_inner_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_slot_history_inner_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_slot_history_inner_global_t * self = (fd_slot_history_inner_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->blocks_len, ctx );
-  if( self->blocks_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), 8UL );
-    self->blocks_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + sizeof(ulong)*self->blocks_len;
-    for( ulong i=0; i < self->blocks_len; i++ ) {
-      fd_bincode_uint64_decode_unsafe( (ulong*)(cur_mem + sizeof(ulong) * i), ctx );
-    }
-  } else
-    self->blocks_gaddr = 0UL;
-}
-int fd_slot_history_inner_convert_global_to_local( void const * global_self, fd_slot_history_inner_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_slot_history_inner_global_t const * mem = (fd_slot_history_inner_global_t const *)global_self;
-  self->blocks_len = mem->blocks_len;
-  self->blocks     = fd_wksp_laddr_fast( ctx->wksp, mem->blocks_gaddr );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_slot_history_inner_new(fd_slot_history_inner_t * self) {
   fd_memset( self, 0, sizeof(fd_slot_history_inner_t) );
 }
@@ -11121,6 +10201,22 @@ int fd_slot_history_bitvec_encode( fd_slot_history_bitvec_t const * self, fd_bin
     err = fd_bincode_bool_encode( 1, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     err = fd_slot_history_inner_encode( self->bits, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_uint64_encode( self->len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_slot_history_bitvec_encode_global( fd_slot_history_bitvec_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  if( self->bits_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    fd_slot_history_inner_t * bits = fd_wksp_laddr_fast( ctx->wksp, self->bits_gaddr );
+    err = fd_slot_history_inner_encode( bits, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   } else {
     err = fd_bincode_bool_encode( 0, ctx );
@@ -11198,19 +10294,12 @@ void fd_slot_history_bitvec_decode_inner_global( void * struct_mem, void * * all
       self->bits_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
       fd_slot_history_inner_new( *alloc_mem );
       *alloc_mem = (uchar *)*alloc_mem + FD_SLOT_HISTORY_INNER_FOOTPRINT;
-      fd_slot_history_inner_decode_inner_global( fd_wksp_laddr_fast( ctx->wksp, self->bits_gaddr ), alloc_mem, ctx );
+      fd_slot_history_inner_decode_inner( fd_wksp_laddr_fast( ctx->wksp, self->bits_gaddr ), alloc_mem, ctx );
     } else {
       self->bits_gaddr = 0UL;
     }
   }
   fd_bincode_uint64_decode_unsafe( &self->len, ctx );
-}
-int fd_slot_history_bitvec_convert_global_to_local( void const * global_self, fd_slot_history_bitvec_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_slot_history_bitvec_global_t const * mem = (fd_slot_history_bitvec_global_t const *)global_self;
-  self->bits = fd_wksp_laddr_fast( ctx->wksp, mem->bits_gaddr );
-  self->len = mem->len;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_slot_history_bitvec_new(fd_slot_history_bitvec_t * self) {
   fd_memset( self, 0, sizeof(fd_slot_history_bitvec_t) );
@@ -11238,7 +10327,7 @@ void fd_slot_history_bitvec_walk( void * w, fd_slot_history_bitvec_t const * sel
 ulong fd_slot_history_bitvec_size( fd_slot_history_bitvec_t const * self ) {
   ulong size = 0;
   size += sizeof(char);
-  if( NULL !=  self->bits ) {
+  if( NULL != self->bits ) {
     size += fd_slot_history_inner_size( self->bits );
   }
   size += sizeof(ulong);
@@ -11248,6 +10337,14 @@ ulong fd_slot_history_bitvec_size( fd_slot_history_bitvec_t const * self ) {
 int fd_slot_history_encode( fd_slot_history_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
   err = fd_slot_history_bitvec_encode( &self->bits, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->next_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_slot_history_encode_global( fd_slot_history_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_slot_history_bitvec_encode_global( &self->bits, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_bincode_uint64_encode( self->next_slot, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -11295,14 +10392,6 @@ void fd_slot_history_decode_inner_global( void * struct_mem, void * * alloc_mem,
   fd_slot_history_global_t * self = (fd_slot_history_global_t *)struct_mem;
   fd_slot_history_bitvec_decode_inner_global( &self->bits, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->next_slot, ctx );
-}
-int fd_slot_history_convert_global_to_local( void const * global_self, fd_slot_history_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_slot_history_global_t const * mem = (fd_slot_history_global_t const *)global_self;
-  err = fd_slot_history_bitvec_convert_global_to_local( &mem->bits, &self->bits, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->next_slot = mem->next_slot;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_slot_history_new(fd_slot_history_t * self) {
   fd_memset( self, 0, sizeof(fd_slot_history_t) );
@@ -11366,27 +10455,6 @@ void fd_slot_hash_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincod
   fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
   fd_hash_decode_inner( &self->hash, alloc_mem, ctx );
 }
-void * fd_slot_hash_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_slot_hash_global_t * self = (fd_slot_hash_global_t *)mem;
-  fd_slot_hash_new( (fd_slot_hash_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_slot_hash_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_slot_hash_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_slot_hash_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_slot_hash_global_t * self = (fd_slot_hash_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-  fd_hash_decode_inner_global( &self->hash, alloc_mem, ctx );
-}
-int fd_slot_hash_convert_global_to_local( void const * global_self, fd_slot_hash_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_slot_hash_global_t const * mem = (fd_slot_hash_global_t const *)global_self;
-  self->slot = mem->slot;
-  err = fd_hash_convert_global_to_local( &mem->hash, &self->hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_slot_hash_new(fd_slot_hash_t * self) {
   fd_memset( self, 0, sizeof(fd_slot_hash_t) );
   fd_hash_new( &self->hash );
@@ -11419,6 +10487,26 @@ int fd_slot_hashes_encode( fd_slot_hashes_t const * self, fd_bincode_encode_ctx_
     if( FD_UNLIKELY( err ) ) return err;
     for( deq_fd_slot_hash_t_iter_t iter = deq_fd_slot_hash_t_iter_init( self->hashes ); !deq_fd_slot_hash_t_iter_done( self->hashes, iter ); iter = deq_fd_slot_hash_t_iter_next( self->hashes, iter ) ) {
       fd_slot_hash_t const * ele = deq_fd_slot_hash_t_iter_ele_const( self->hashes, iter );
+      err = fd_slot_hash_encode( ele, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong hashes_len = 0;
+    err = fd_bincode_uint64_encode( hashes_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_slot_hashes_encode_global( fd_slot_hashes_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  if( self->hashes_gaddr ) {
+  uchar * hashes_laddr = fd_wksp_laddr_fast( ctx->wksp, self->hashes_gaddr );
+   fd_slot_hash_t * hashes = deq_fd_slot_hash_t_join( hashes_laddr );
+    ulong hashes_len = deq_fd_slot_hash_t_cnt( hashes );
+    err = fd_bincode_uint64_encode( hashes_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( deq_fd_slot_hash_t_iter_t iter = deq_fd_slot_hash_t_iter_init( hashes ); !deq_fd_slot_hash_t_iter_done( hashes, iter ); iter = deq_fd_slot_hash_t_iter_next( hashes, iter ) ) {
+      fd_slot_hash_t const * ele = deq_fd_slot_hash_t_iter_ele_const( hashes, iter );
       err = fd_slot_hash_encode( ele, ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
@@ -11485,19 +10573,13 @@ void fd_slot_hashes_decode_inner_global( void * struct_mem, void * * alloc_mem, 
   fd_bincode_uint64_decode_unsafe( &hashes_len, ctx );
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, deq_fd_slot_hash_t_align() );
   ulong hashes_max = fd_ulong_max( hashes_len, 512 );
-  self->hashes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
   fd_slot_hash_t * hashes = deq_fd_slot_hash_t_join_new( alloc_mem, hashes_max );
   for( ulong i=0; i < hashes_len; i++ ) {
     fd_slot_hash_t * elem = deq_fd_slot_hash_t_push_tail_nocopy( hashes );
-    fd_slot_hash_new( elem );
-    fd_slot_hash_decode_inner_global( elem, alloc_mem, ctx );
+    fd_slot_hash_new( (fd_slot_hash_t*)fd_type_pun( elem ) );
+    fd_slot_hash_decode_inner( elem, alloc_mem, ctx );
   }
-}
-int fd_slot_hashes_convert_global_to_local( void const * global_self, fd_slot_hashes_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_slot_hashes_global_t const * mem = (fd_slot_hashes_global_t const *)global_self;
-  self->hashes = deq_fd_slot_hash_t_join( fd_wksp_laddr_fast( ctx->wksp, mem->hashes_gaddr ) );
-  return FD_BINCODE_SUCCESS;
+  self->hashes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, deq_fd_slot_hash_t_leave( hashes ) );
 }
 void fd_slot_hashes_new(fd_slot_hashes_t * self) {
   fd_memset( self, 0, sizeof(fd_slot_hashes_t) );
@@ -11585,28 +10667,6 @@ void fd_block_block_hash_entry_decode_inner( void * struct_mem, void * * alloc_m
   fd_hash_decode_inner( &self->blockhash, alloc_mem, ctx );
   fd_fee_calculator_decode_inner( &self->fee_calculator, alloc_mem, ctx );
 }
-void * fd_block_block_hash_entry_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_block_block_hash_entry_global_t * self = (fd_block_block_hash_entry_global_t *)mem;
-  fd_block_block_hash_entry_new( (fd_block_block_hash_entry_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_block_block_hash_entry_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_block_block_hash_entry_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_block_block_hash_entry_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_block_block_hash_entry_global_t * self = (fd_block_block_hash_entry_global_t *)struct_mem;
-  fd_hash_decode_inner_global( &self->blockhash, alloc_mem, ctx );
-  fd_fee_calculator_decode_inner_global( &self->fee_calculator, alloc_mem, ctx );
-}
-int fd_block_block_hash_entry_convert_global_to_local( void const * global_self, fd_block_block_hash_entry_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_block_block_hash_entry_global_t const * mem = (fd_block_block_hash_entry_global_t const *)global_self;
-  err = fd_hash_convert_global_to_local( &mem->blockhash, &self->blockhash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_fee_calculator_convert_global_to_local( &mem->fee_calculator, &self->fee_calculator, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_block_block_hash_entry_new(fd_block_block_hash_entry_t * self) {
   fd_memset( self, 0, sizeof(fd_block_block_hash_entry_t) );
   fd_hash_new( &self->blockhash );
@@ -11641,6 +10701,26 @@ int fd_recent_block_hashes_encode( fd_recent_block_hashes_t const * self, fd_bin
     if( FD_UNLIKELY( err ) ) return err;
     for( deq_fd_block_block_hash_entry_t_iter_t iter = deq_fd_block_block_hash_entry_t_iter_init( self->hashes ); !deq_fd_block_block_hash_entry_t_iter_done( self->hashes, iter ); iter = deq_fd_block_block_hash_entry_t_iter_next( self->hashes, iter ) ) {
       fd_block_block_hash_entry_t const * ele = deq_fd_block_block_hash_entry_t_iter_ele_const( self->hashes, iter );
+      err = fd_block_block_hash_entry_encode( ele, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong hashes_len = 0;
+    err = fd_bincode_uint64_encode( hashes_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_recent_block_hashes_encode_global( fd_recent_block_hashes_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  if( self->hashes_gaddr ) {
+  uchar * hashes_laddr = fd_wksp_laddr_fast( ctx->wksp, self->hashes_gaddr );
+   fd_block_block_hash_entry_t * hashes = deq_fd_block_block_hash_entry_t_join( hashes_laddr );
+    ulong hashes_len = deq_fd_block_block_hash_entry_t_cnt( hashes );
+    err = fd_bincode_uint64_encode( hashes_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( deq_fd_block_block_hash_entry_t_iter_t iter = deq_fd_block_block_hash_entry_t_iter_init( hashes ); !deq_fd_block_block_hash_entry_t_iter_done( hashes, iter ); iter = deq_fd_block_block_hash_entry_t_iter_next( hashes, iter ) ) {
+      fd_block_block_hash_entry_t const * ele = deq_fd_block_block_hash_entry_t_iter_ele_const( hashes, iter );
       err = fd_block_block_hash_entry_encode( ele, ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
@@ -11707,19 +10787,13 @@ void fd_recent_block_hashes_decode_inner_global( void * struct_mem, void * * all
   fd_bincode_uint64_decode_unsafe( &hashes_len, ctx );
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, deq_fd_block_block_hash_entry_t_align() );
   ulong hashes_max = fd_ulong_max( hashes_len, 151 );
-  self->hashes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
   fd_block_block_hash_entry_t * hashes = deq_fd_block_block_hash_entry_t_join_new( alloc_mem, hashes_max );
   for( ulong i=0; i < hashes_len; i++ ) {
     fd_block_block_hash_entry_t * elem = deq_fd_block_block_hash_entry_t_push_tail_nocopy( hashes );
-    fd_block_block_hash_entry_new( elem );
-    fd_block_block_hash_entry_decode_inner_global( elem, alloc_mem, ctx );
+    fd_block_block_hash_entry_new( (fd_block_block_hash_entry_t*)fd_type_pun( elem ) );
+    fd_block_block_hash_entry_decode_inner( elem, alloc_mem, ctx );
   }
-}
-int fd_recent_block_hashes_convert_global_to_local( void const * global_self, fd_recent_block_hashes_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_recent_block_hashes_global_t const * mem = (fd_recent_block_hashes_global_t const *)global_self;
-  self->hashes = deq_fd_block_block_hash_entry_t_join( fd_wksp_laddr_fast( ctx->wksp, mem->hashes_gaddr ) );
-  return FD_BINCODE_SUCCESS;
+  self->hashes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, deq_fd_block_block_hash_entry_t_leave( hashes ) );
 }
 void fd_recent_block_hashes_new(fd_recent_block_hashes_t * self) {
   fd_memset( self, 0, sizeof(fd_recent_block_hashes_t) );
@@ -11886,62 +10960,6 @@ void fd_slot_meta_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincod
   } else
     self->entry_end_indexes = NULL;
 }
-void * fd_slot_meta_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_slot_meta_global_t * self = (fd_slot_meta_global_t *)mem;
-  fd_slot_meta_new( (fd_slot_meta_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_slot_meta_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_slot_meta_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_slot_meta_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_slot_meta_global_t * self = (fd_slot_meta_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->consumed, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->received, ctx );
-  fd_bincode_uint64_decode_unsafe( (ulong *) &self->first_shred_timestamp, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->last_index, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->parent_slot, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->next_slot_len, ctx );
-  if( self->next_slot_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), 8UL );
-    self->next_slot_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + sizeof(ulong)*self->next_slot_len;
-    for( ulong i=0; i < self->next_slot_len; i++ ) {
-      fd_bincode_uint64_decode_unsafe( (ulong*)(cur_mem + sizeof(ulong) * i), ctx );
-    }
-  } else
-    self->next_slot_gaddr = 0UL;
-  fd_bincode_uint8_decode_unsafe( &self->is_connected, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->entry_end_indexes_len, ctx );
-  if( self->entry_end_indexes_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), 8UL );
-    self->entry_end_indexes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + sizeof(uint)*self->entry_end_indexes_len;
-    for( ulong i=0; i < self->entry_end_indexes_len; i++ ) {
-      fd_bincode_uint32_decode_unsafe( (uint*)(cur_mem + sizeof(uint) * i), ctx );
-    }
-  } else
-    self->entry_end_indexes_gaddr = 0UL;
-}
-int fd_slot_meta_convert_global_to_local( void const * global_self, fd_slot_meta_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_slot_meta_global_t const * mem = (fd_slot_meta_global_t const *)global_self;
-  self->slot = mem->slot;
-  self->consumed = mem->consumed;
-  self->received = mem->received;
-  self->first_shred_timestamp = mem->first_shred_timestamp;
-  self->last_index = mem->last_index;
-  self->parent_slot = mem->parent_slot;
-  self->next_slot_len = mem->next_slot_len;
-  self->next_slot     = fd_wksp_laddr_fast( ctx->wksp, mem->next_slot_gaddr );
-  self->is_connected = mem->is_connected;
-  self->entry_end_indexes_len = mem->entry_end_indexes_len;
-  self->entry_end_indexes     = fd_wksp_laddr_fast( ctx->wksp, mem->entry_end_indexes_gaddr );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_slot_meta_new(fd_slot_meta_t * self) {
   fd_memset( self, 0, sizeof(fd_slot_meta_t) );
 }
@@ -12043,29 +11061,6 @@ void fd_clock_timestamp_vote_decode_inner( void * struct_mem, void * * alloc_mem
   fd_bincode_uint64_decode_unsafe( (ulong *) &self->timestamp, ctx );
   fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
 }
-void * fd_clock_timestamp_vote_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_clock_timestamp_vote_global_t * self = (fd_clock_timestamp_vote_global_t *)mem;
-  fd_clock_timestamp_vote_new( (fd_clock_timestamp_vote_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_clock_timestamp_vote_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_clock_timestamp_vote_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_clock_timestamp_vote_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_clock_timestamp_vote_global_t * self = (fd_clock_timestamp_vote_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->pubkey, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( (ulong *) &self->timestamp, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-}
-int fd_clock_timestamp_vote_convert_global_to_local( void const * global_self, fd_clock_timestamp_vote_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_clock_timestamp_vote_global_t const * mem = (fd_clock_timestamp_vote_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->pubkey, &self->pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->timestamp = mem->timestamp;
-  self->slot = mem->slot;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_clock_timestamp_vote_new(fd_clock_timestamp_vote_t * self) {
   fd_memset( self, 0, sizeof(fd_clock_timestamp_vote_t) );
   fd_pubkey_new( &self->pubkey );
@@ -12099,6 +11094,25 @@ int fd_clock_timestamp_votes_encode( fd_clock_timestamp_votes_t const * self, fd
     err = fd_bincode_uint64_encode( votes_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     for( fd_clock_timestamp_vote_t_mapnode_t * n = fd_clock_timestamp_vote_t_map_minimum( self->votes_pool, self->votes_root ); n; n = fd_clock_timestamp_vote_t_map_successor( self->votes_pool, n ) ) {
+      err = fd_clock_timestamp_vote_encode( &n->elem, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong votes_len = 0;
+    err = fd_bincode_uint64_encode( votes_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_clock_timestamp_votes_encode_global( fd_clock_timestamp_votes_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  fd_clock_timestamp_vote_t_mapnode_t * votes_root = fd_clock_timestamp_vote_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->votes_root_gaddr ) );
+  fd_clock_timestamp_vote_t_mapnode_t * votes_pool = fd_clock_timestamp_vote_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->votes_pool_gaddr ) );
+  if( votes_root ) {
+    ulong votes_len = fd_clock_timestamp_vote_t_map_size( votes_pool, votes_root );
+    err = fd_bincode_uint64_encode( votes_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( fd_clock_timestamp_vote_t_mapnode_t * n = fd_clock_timestamp_vote_t_map_minimum( votes_pool, votes_root ); n; n = fd_clock_timestamp_vote_t_map_successor( votes_pool, n ) ) {
       err = fd_clock_timestamp_vote_encode( &n->elem, ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
@@ -12167,22 +11181,14 @@ void fd_clock_timestamp_votes_decode_inner_global( void * struct_mem, void * * a
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, fd_clock_timestamp_vote_t_map_align() );
   fd_clock_timestamp_vote_t_mapnode_t * votes_pool = fd_clock_timestamp_vote_t_map_join_new( alloc_mem, fd_ulong_max( votes_len, 15000 ) );
   fd_clock_timestamp_vote_t_mapnode_t * votes_root = NULL;
-  self->votes_root_gaddr = 0UL;
   for( ulong i=0; i < votes_len; i++ ) {
     fd_clock_timestamp_vote_t_mapnode_t * node = fd_clock_timestamp_vote_t_map_acquire( votes_pool );
-    fd_clock_timestamp_vote_new( &node->elem );
+    fd_clock_timestamp_vote_new( (fd_clock_timestamp_vote_t *)fd_type_pun(&node->elem) );
     fd_clock_timestamp_vote_decode_inner( &node->elem, alloc_mem, ctx );
     fd_clock_timestamp_vote_t_map_insert( votes_pool, &votes_root, node );
   }
-  self->votes_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, votes_pool );
-  self->votes_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, votes_root );
-}
-int fd_clock_timestamp_votes_convert_global_to_local( void const * global_self, fd_clock_timestamp_votes_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_clock_timestamp_votes_global_t const * mem = (fd_clock_timestamp_votes_global_t const *)global_self;
-  self->votes_pool = fd_wksp_laddr_fast( ctx->wksp, mem->votes_pool_gaddr );
-  self->votes_root = fd_wksp_laddr_fast( ctx->wksp, mem->votes_root_gaddr );
-  return FD_BINCODE_SUCCESS;
+  self->votes_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_clock_timestamp_vote_t_map_leave( votes_pool ) );
+  self->votes_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_clock_timestamp_vote_t_map_leave( votes_root ) );
 }
 void fd_clock_timestamp_votes_new(fd_clock_timestamp_votes_t * self) {
   fd_memset( self, 0, sizeof(fd_clock_timestamp_votes_t) );
@@ -12252,25 +11258,6 @@ void * fd_sysvar_fees_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
 void fd_sysvar_fees_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_sysvar_fees_t * self = (fd_sysvar_fees_t *)struct_mem;
   fd_fee_calculator_decode_inner( &self->fee_calculator, alloc_mem, ctx );
-}
-void * fd_sysvar_fees_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_sysvar_fees_global_t * self = (fd_sysvar_fees_global_t *)mem;
-  fd_sysvar_fees_new( (fd_sysvar_fees_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_sysvar_fees_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_sysvar_fees_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_sysvar_fees_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_sysvar_fees_global_t * self = (fd_sysvar_fees_global_t *)struct_mem;
-  fd_fee_calculator_decode_inner_global( &self->fee_calculator, alloc_mem, ctx );
-}
-int fd_sysvar_fees_convert_global_to_local( void const * global_self, fd_sysvar_fees_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_sysvar_fees_global_t const * mem = (fd_sysvar_fees_global_t const *)global_self;
-  err = fd_fee_calculator_convert_global_to_local( &mem->fee_calculator, &self->fee_calculator, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_sysvar_fees_new(fd_sysvar_fees_t * self) {
   fd_memset( self, 0, sizeof(fd_sysvar_fees_t) );
@@ -12357,37 +11344,6 @@ void fd_sysvar_epoch_rewards_decode_inner( void * struct_mem, void * * alloc_mem
   fd_bincode_uint64_decode_unsafe( &self->distributed_rewards, ctx );
   fd_bincode_bool_decode_unsafe( &self->active, ctx );
 }
-void * fd_sysvar_epoch_rewards_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_sysvar_epoch_rewards_global_t * self = (fd_sysvar_epoch_rewards_global_t *)mem;
-  fd_sysvar_epoch_rewards_new( (fd_sysvar_epoch_rewards_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_sysvar_epoch_rewards_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_sysvar_epoch_rewards_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_sysvar_epoch_rewards_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_sysvar_epoch_rewards_global_t * self = (fd_sysvar_epoch_rewards_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->distribution_starting_block_height, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->num_partitions, ctx );
-  fd_hash_decode_inner_global( &self->parent_blockhash, alloc_mem, ctx );
-  fd_bincode_uint128_decode_unsafe( &self->total_points, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->total_rewards, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->distributed_rewards, ctx );
-  fd_bincode_bool_decode_unsafe( &self->active, ctx );
-}
-int fd_sysvar_epoch_rewards_convert_global_to_local( void const * global_self, fd_sysvar_epoch_rewards_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_sysvar_epoch_rewards_global_t const * mem = (fd_sysvar_epoch_rewards_global_t const *)global_self;
-  self->distribution_starting_block_height = mem->distribution_starting_block_height;
-  self->num_partitions = mem->num_partitions;
-  err = fd_hash_convert_global_to_local( &mem->parent_blockhash, &self->parent_blockhash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->total_points = mem->total_points;
-  self->total_rewards = mem->total_rewards;
-  self->distributed_rewards = mem->distributed_rewards;
-  self->active = mem->active;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_sysvar_epoch_rewards_new(fd_sysvar_epoch_rewards_t * self) {
   fd_memset( self, 0, sizeof(fd_sysvar_epoch_rewards_t) );
   fd_hash_new( &self->parent_blockhash );
@@ -12459,27 +11415,6 @@ void fd_config_keys_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd
   fd_config_keys_pair_t * self = (fd_config_keys_pair_t *)struct_mem;
   fd_pubkey_decode_inner( &self->key, alloc_mem, ctx );
   fd_bincode_bool_decode_unsafe( &self->signer, ctx );
-}
-void * fd_config_keys_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_config_keys_pair_global_t * self = (fd_config_keys_pair_global_t *)mem;
-  fd_config_keys_pair_new( (fd_config_keys_pair_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_config_keys_pair_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_config_keys_pair_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_config_keys_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_config_keys_pair_global_t * self = (fd_config_keys_pair_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->key, alloc_mem, ctx );
-  fd_bincode_bool_decode_unsafe( &self->signer, ctx );
-}
-int fd_config_keys_pair_convert_global_to_local( void const * global_self, fd_config_keys_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_config_keys_pair_global_t const * mem = (fd_config_keys_pair_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->key, &self->key, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->signer = mem->signer;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_config_keys_pair_new(fd_config_keys_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_config_keys_pair_t) );
@@ -12572,40 +11507,6 @@ void fd_stake_config_decode_inner( void * struct_mem, void * * alloc_mem, fd_bin
   fd_bincode_double_decode_unsafe( &self->warmup_cooldown_rate, ctx );
   fd_bincode_uint8_decode_unsafe( &self->slash_penalty, ctx );
 }
-void * fd_stake_config_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_config_global_t * self = (fd_stake_config_global_t *)mem;
-  fd_stake_config_new( (fd_stake_config_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_stake_config_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_stake_config_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_stake_config_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_config_global_t * self = (fd_stake_config_global_t *)struct_mem;
-  fd_bincode_compact_u16_decode_unsafe( &self->config_keys_len, ctx );
-  if( self->config_keys_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_CONFIG_KEYS_PAIR_ALIGN );
-    self->config_keys_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_CONFIG_KEYS_PAIR_FOOTPRINT*self->config_keys_len;
-    for( ulong i=0; i < self->config_keys_len; i++ ) {
-      fd_config_keys_pair_new( (fd_config_keys_pair_t *)(cur_mem + FD_CONFIG_KEYS_PAIR_FOOTPRINT * i) );
-      fd_config_keys_pair_decode_inner_global( cur_mem + FD_CONFIG_KEYS_PAIR_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->config_keys_gaddr = 0UL;
-  fd_bincode_double_decode_unsafe( &self->warmup_cooldown_rate, ctx );
-  fd_bincode_uint8_decode_unsafe( &self->slash_penalty, ctx );
-}
-int fd_stake_config_convert_global_to_local( void const * global_self, fd_stake_config_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stake_config_global_t const * mem = (fd_stake_config_global_t const *)global_self;
-  self->config_keys_len = mem->config_keys_len;
-  self->config_keys     = fd_wksp_laddr_fast( ctx->wksp, mem->config_keys_gaddr );
-  self->warmup_cooldown_rate = mem->warmup_cooldown_rate;
-  self->slash_penalty = mem->slash_penalty;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_stake_config_new(fd_stake_config_t * self) {
   fd_memset( self, 0, sizeof(fd_stake_config_t) );
 }
@@ -12653,6 +11554,21 @@ int fd_feature_entry_encode( fd_feature_entry_t const * self, fd_bincode_encode_
   if( FD_UNLIKELY(err) ) return err;
   if( self->description_len ) {
     err = fd_bincode_bytes_encode( self->description, self->description_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_uint64_encode( self->since_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_feature_entry_encode_global( fd_feature_entry_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_encode( &self->pubkey, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->description_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->description_len ) {
+    uchar * description_laddr = fd_wksp_laddr_fast( ctx->wksp, self->description_gaddr );
+    err = fd_bincode_bytes_encode( description_laddr, self->description_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   err = fd_bincode_uint64_encode( self->since_slot, ctx );
@@ -12716,25 +11632,16 @@ void * fd_feature_entry_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx
 }
 void fd_feature_entry_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_feature_entry_global_t * self = (fd_feature_entry_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->pubkey, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->pubkey, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->description_len, ctx );
   if( self->description_len ) {
     self->description_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
     fd_bincode_bytes_decode_unsafe( *alloc_mem, self->description_len, ctx );
     *alloc_mem = (uchar *)(*alloc_mem) + self->description_len;
-  } else
+  } else {
     self->description_gaddr = 0UL;
+  }
   fd_bincode_uint64_decode_unsafe( &self->since_slot, ctx );
-}
-int fd_feature_entry_convert_global_to_local( void const * global_self, fd_feature_entry_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_feature_entry_global_t const * mem = (fd_feature_entry_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->pubkey, &self->pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->description_len = mem->description_len;
-  self->description     = fd_wksp_laddr_fast( ctx->wksp, mem->description_gaddr );
-  self->since_slot = mem->since_slot;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_feature_entry_new(fd_feature_entry_t * self) {
   fd_memset( self, 0, sizeof(fd_feature_entry_t) );
@@ -12815,6 +11722,58 @@ int fd_firedancer_bank_encode( fd_firedancer_bank_t const * self, fd_bincode_enc
   err = fd_bincode_uint64_encode( self->collected_rent, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_vote_accounts_encode( &self->epoch_stakes, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_sol_sysvar_last_restart_slot_encode( &self->last_restart_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_firedancer_bank_encode_global( fd_firedancer_bank_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_stakes_encode_global( &self->stakes, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_recent_block_hashes_encode_global( &self->recent_block_hashes, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_clock_timestamp_votes_encode_global( &self->timestamp_votes, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->prev_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_hash_encode( &self->poh, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_hash_encode( &self->banks_hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_fee_rate_governor_encode( &self->fee_rate_governor, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->capitalization, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->block_height, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->lamports_per_signature, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->hashes_per_tick, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->ticks_per_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint128_encode( self->ns_per_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->genesis_creation_time, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_double_encode( self->slots_per_year, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->max_tick_height, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_inflation_encode( &self->inflation, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_epoch_schedule_encode( &self->epoch_schedule, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_rent_encode( &self->rent, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->collected_fees, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->collected_rent, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_vote_accounts_encode_global( &self->epoch_stakes, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_sol_sysvar_last_restart_slot_encode( &self->last_restart_slot, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -12931,9 +11890,9 @@ void fd_firedancer_bank_decode_inner_global( void * struct_mem, void * * alloc_m
   fd_clock_timestamp_votes_decode_inner_global( &self->timestamp_votes, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
   fd_bincode_uint64_decode_unsafe( &self->prev_slot, ctx );
-  fd_hash_decode_inner_global( &self->poh, alloc_mem, ctx );
-  fd_hash_decode_inner_global( &self->banks_hash, alloc_mem, ctx );
-  fd_fee_rate_governor_decode_inner_global( &self->fee_rate_governor, alloc_mem, ctx );
+  fd_hash_decode_inner( &self->poh, alloc_mem, ctx );
+  fd_hash_decode_inner( &self->banks_hash, alloc_mem, ctx );
+  fd_fee_rate_governor_decode_inner( &self->fee_rate_governor, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->capitalization, ctx );
   fd_bincode_uint64_decode_unsafe( &self->block_height, ctx );
   fd_bincode_uint64_decode_unsafe( &self->lamports_per_signature, ctx );
@@ -12943,53 +11902,13 @@ void fd_firedancer_bank_decode_inner_global( void * struct_mem, void * * alloc_m
   fd_bincode_uint64_decode_unsafe( &self->genesis_creation_time, ctx );
   fd_bincode_double_decode_unsafe( &self->slots_per_year, ctx );
   fd_bincode_uint64_decode_unsafe( &self->max_tick_height, ctx );
-  fd_inflation_decode_inner_global( &self->inflation, alloc_mem, ctx );
-  fd_epoch_schedule_decode_inner_global( &self->epoch_schedule, alloc_mem, ctx );
-  fd_rent_decode_inner_global( &self->rent, alloc_mem, ctx );
+  fd_inflation_decode_inner( &self->inflation, alloc_mem, ctx );
+  fd_epoch_schedule_decode_inner( &self->epoch_schedule, alloc_mem, ctx );
+  fd_rent_decode_inner( &self->rent, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->collected_fees, ctx );
   fd_bincode_uint64_decode_unsafe( &self->collected_rent, ctx );
   fd_vote_accounts_decode_inner_global( &self->epoch_stakes, alloc_mem, ctx );
-  fd_sol_sysvar_last_restart_slot_decode_inner_global( &self->last_restart_slot, alloc_mem, ctx );
-}
-int fd_firedancer_bank_convert_global_to_local( void const * global_self, fd_firedancer_bank_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_firedancer_bank_global_t const * mem = (fd_firedancer_bank_global_t const *)global_self;
-  err = fd_stakes_convert_global_to_local( &mem->stakes, &self->stakes, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_recent_block_hashes_convert_global_to_local( &mem->recent_block_hashes, &self->recent_block_hashes, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_clock_timestamp_votes_convert_global_to_local( &mem->timestamp_votes, &self->timestamp_votes, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->slot = mem->slot;
-  self->prev_slot = mem->prev_slot;
-  err = fd_hash_convert_global_to_local( &mem->poh, &self->poh, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_hash_convert_global_to_local( &mem->banks_hash, &self->banks_hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_fee_rate_governor_convert_global_to_local( &mem->fee_rate_governor, &self->fee_rate_governor, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->capitalization = mem->capitalization;
-  self->block_height = mem->block_height;
-  self->lamports_per_signature = mem->lamports_per_signature;
-  self->hashes_per_tick = mem->hashes_per_tick;
-  self->ticks_per_slot = mem->ticks_per_slot;
-  self->ns_per_slot = mem->ns_per_slot;
-  self->genesis_creation_time = mem->genesis_creation_time;
-  self->slots_per_year = mem->slots_per_year;
-  self->max_tick_height = mem->max_tick_height;
-  err = fd_inflation_convert_global_to_local( &mem->inflation, &self->inflation, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_epoch_schedule_convert_global_to_local( &mem->epoch_schedule, &self->epoch_schedule, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_rent_convert_global_to_local( &mem->rent, &self->rent, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->collected_fees = mem->collected_fees;
-  self->collected_rent = mem->collected_rent;
-  err = fd_vote_accounts_convert_global_to_local( &mem->epoch_stakes, &self->epoch_stakes, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_sol_sysvar_last_restart_slot_convert_global_to_local( &mem->last_restart_slot, &self->last_restart_slot, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  fd_sol_sysvar_last_restart_slot_decode_inner( &self->last_restart_slot, alloc_mem, ctx );
 }
 void fd_firedancer_bank_new(fd_firedancer_bank_t * self) {
   fd_memset( self, 0, sizeof(fd_firedancer_bank_t) );
@@ -13141,47 +12060,6 @@ void fd_cluster_type_inner_decode_inner( fd_cluster_type_inner_t * self, void * 
   }
   }
 }
-void fd_cluster_type_inner_decode_inner_global( fd_cluster_type_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    break;
-  }
-  case 2: {
-    break;
-  }
-  case 3: {
-    break;
-  }
-  }
-}
-int fd_cluster_type_convert_global_to_local_inner( fd_cluster_type_inner_global_t const * mem, fd_cluster_type_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    break;
-  }
-  case 2: {
-    break;
-  }
-  case 3: {
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_cluster_type_convert_global_to_local( void const * global_self, fd_cluster_type_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_cluster_type_global_t const * mem = (fd_cluster_type_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_cluster_type_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_cluster_type_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_cluster_type_t * self = (fd_cluster_type_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -13194,19 +12072,6 @@ void * fd_cluster_type_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   void * * alloc_mem = &alloc_region;
   fd_cluster_type_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_cluster_type_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_cluster_type_t * self = (fd_cluster_type_t *)mem;
-  fd_cluster_type_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_cluster_type_t);
-  void * * alloc_mem = &alloc_region;
-  fd_cluster_type_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_cluster_type_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_cluster_type_global_t * self = (fd_cluster_type_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_cluster_type_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_cluster_type_inner_new( fd_cluster_type_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -13327,29 +12192,6 @@ void fd_rent_fresh_account_decode_inner( void * struct_mem, void * * alloc_mem, 
   fd_pubkey_decode_inner( &self->pubkey, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->present, ctx );
 }
-void * fd_rent_fresh_account_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_rent_fresh_account_global_t * self = (fd_rent_fresh_account_global_t *)mem;
-  fd_rent_fresh_account_new( (fd_rent_fresh_account_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_rent_fresh_account_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_rent_fresh_account_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_rent_fresh_account_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_rent_fresh_account_global_t * self = (fd_rent_fresh_account_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->partition, ctx );
-  fd_pubkey_decode_inner_global( &self->pubkey, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->present, ctx );
-}
-int fd_rent_fresh_account_convert_global_to_local( void const * global_self, fd_rent_fresh_account_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_rent_fresh_account_global_t const * mem = (fd_rent_fresh_account_global_t const *)global_self;
-  self->partition = mem->partition;
-  err = fd_pubkey_convert_global_to_local( &mem->pubkey, &self->pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->present = mem->present;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_rent_fresh_account_new(fd_rent_fresh_account_t * self) {
   fd_memset( self, 0, sizeof(fd_rent_fresh_account_t) );
   fd_pubkey_new( &self->pubkey );
@@ -13438,38 +12280,6 @@ void fd_rent_fresh_accounts_decode_inner( void * struct_mem, void * * alloc_mem,
   } else
     self->fresh_accounts = NULL;
 }
-void * fd_rent_fresh_accounts_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_rent_fresh_accounts_global_t * self = (fd_rent_fresh_accounts_global_t *)mem;
-  fd_rent_fresh_accounts_new( (fd_rent_fresh_accounts_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_rent_fresh_accounts_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_rent_fresh_accounts_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_rent_fresh_accounts_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_rent_fresh_accounts_global_t * self = (fd_rent_fresh_accounts_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->total_count, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->fresh_accounts_len, ctx );
-  if( self->fresh_accounts_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_RENT_FRESH_ACCOUNT_ALIGN );
-    self->fresh_accounts_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_RENT_FRESH_ACCOUNT_FOOTPRINT*self->fresh_accounts_len;
-    for( ulong i=0; i < self->fresh_accounts_len; i++ ) {
-      fd_rent_fresh_account_new( (fd_rent_fresh_account_t *)(cur_mem + FD_RENT_FRESH_ACCOUNT_FOOTPRINT * i) );
-      fd_rent_fresh_account_decode_inner_global( cur_mem + FD_RENT_FRESH_ACCOUNT_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->fresh_accounts_gaddr = 0UL;
-}
-int fd_rent_fresh_accounts_convert_global_to_local( void const * global_self, fd_rent_fresh_accounts_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_rent_fresh_accounts_global_t const * mem = (fd_rent_fresh_accounts_global_t const *)global_self;
-  self->total_count = mem->total_count;
-  self->fresh_accounts_len = mem->fresh_accounts_len;
-  self->fresh_accounts     = fd_wksp_laddr_fast( ctx->wksp, mem->fresh_accounts_gaddr );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_rent_fresh_accounts_new(fd_rent_fresh_accounts_t * self) {
   fd_memset( self, 0, sizeof(fd_rent_fresh_accounts_t) );
 }
@@ -13543,6 +12353,48 @@ int fd_epoch_bank_encode( fd_epoch_bank_t const * self, fd_bincode_encode_ctx_t 
     if( FD_UNLIKELY( err ) ) return err;
   }
   err = fd_vote_accounts_encode( &self->next_epoch_stakes, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_epoch_schedule_encode( &self->rent_epoch_schedule, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_epoch_bank_encode_global( fd_epoch_bank_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_stakes_encode_global( &self->stakes, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->hashes_per_tick, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->ticks_per_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint128_encode( self->ns_per_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->genesis_creation_time, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_double_encode( self->slots_per_year, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->max_tick_height, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_inflation_encode( &self->inflation, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_epoch_schedule_encode( &self->epoch_schedule, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_rent_encode( &self->rent, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->eah_start_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->eah_stop_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->eah_interval, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_hash_encode( &self->genesis_hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint32_encode( self->cluster_type, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  for( ulong i=0; i<3; i++ ) {
+    err = fd_bincode_uint32_encode( self->cluster_version[i], ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_vote_accounts_encode_global( &self->next_epoch_stakes, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_epoch_schedule_encode( &self->rent_epoch_schedule, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -13647,49 +12499,19 @@ void fd_epoch_bank_decode_inner_global( void * struct_mem, void * * alloc_mem, f
   fd_bincode_uint64_decode_unsafe( &self->genesis_creation_time, ctx );
   fd_bincode_double_decode_unsafe( &self->slots_per_year, ctx );
   fd_bincode_uint64_decode_unsafe( &self->max_tick_height, ctx );
-  fd_inflation_decode_inner_global( &self->inflation, alloc_mem, ctx );
-  fd_epoch_schedule_decode_inner_global( &self->epoch_schedule, alloc_mem, ctx );
-  fd_rent_decode_inner_global( &self->rent, alloc_mem, ctx );
+  fd_inflation_decode_inner( &self->inflation, alloc_mem, ctx );
+  fd_epoch_schedule_decode_inner( &self->epoch_schedule, alloc_mem, ctx );
+  fd_rent_decode_inner( &self->rent, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->eah_start_slot, ctx );
   fd_bincode_uint64_decode_unsafe( &self->eah_stop_slot, ctx );
   fd_bincode_uint64_decode_unsafe( &self->eah_interval, ctx );
-  fd_hash_decode_inner_global( &self->genesis_hash, alloc_mem, ctx );
+  fd_hash_decode_inner( &self->genesis_hash, alloc_mem, ctx );
   fd_bincode_uint32_decode_unsafe( &self->cluster_type, ctx );
   for( ulong i=0; i<3; i++ ) {
     fd_bincode_uint32_decode_unsafe( self->cluster_version + i, ctx );
   }
   fd_vote_accounts_decode_inner_global( &self->next_epoch_stakes, alloc_mem, ctx );
-  fd_epoch_schedule_decode_inner_global( &self->rent_epoch_schedule, alloc_mem, ctx );
-}
-int fd_epoch_bank_convert_global_to_local( void const * global_self, fd_epoch_bank_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_epoch_bank_global_t const * mem = (fd_epoch_bank_global_t const *)global_self;
-  err = fd_stakes_convert_global_to_local( &mem->stakes, &self->stakes, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->hashes_per_tick = mem->hashes_per_tick;
-  self->ticks_per_slot = mem->ticks_per_slot;
-  self->ns_per_slot = mem->ns_per_slot;
-  self->genesis_creation_time = mem->genesis_creation_time;
-  self->slots_per_year = mem->slots_per_year;
-  self->max_tick_height = mem->max_tick_height;
-  err = fd_inflation_convert_global_to_local( &mem->inflation, &self->inflation, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_epoch_schedule_convert_global_to_local( &mem->epoch_schedule, &self->epoch_schedule, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_rent_convert_global_to_local( &mem->rent, &self->rent, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->eah_start_slot = mem->eah_start_slot;
-  self->eah_stop_slot = mem->eah_stop_slot;
-  self->eah_interval = mem->eah_interval;
-  err = fd_hash_convert_global_to_local( &mem->genesis_hash, &self->genesis_hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->cluster_type = mem->cluster_type;
-  fd_memcpy( self->cluster_version, mem->cluster_version, 3 * sizeof(uint) );
-  err = fd_vote_accounts_convert_global_to_local( &mem->next_epoch_stakes, &self->next_epoch_stakes, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_epoch_schedule_convert_global_to_local( &mem->rent_epoch_schedule, &self->rent_epoch_schedule, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  fd_epoch_schedule_decode_inner( &self->rent_epoch_schedule, alloc_mem, ctx );
 }
 void fd_epoch_bank_new(fd_epoch_bank_t * self) {
   fd_memset( self, 0, sizeof(fd_epoch_bank_t) );
@@ -13805,6 +12627,68 @@ int fd_slot_bank_encode( fd_slot_bank_t const * self, fd_bincode_encode_ctx_t * 
   err = fd_slot_lthash_encode( &self->lthash, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_block_hash_queue_encode( &self->block_hash_queue, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_hash_encode( &self->prev_banks_hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->parent_signature_cnt, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->tick_height, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_bool_encode( self->has_use_preceeding_epoch_stakes, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_use_preceeding_epoch_stakes ) {
+    err = fd_bincode_uint64_encode( self->use_preceeding_epoch_stakes, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_hard_forks_encode( &self->hard_forks, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_rent_fresh_accounts_encode( &self->rent_fresh_accounts, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_slot_bank_encode_global( fd_slot_bank_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_clock_timestamp_votes_encode_global( &self->timestamp_votes, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->prev_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_hash_encode( &self->poh, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_hash_encode( &self->banks_hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_hash_encode( &self->epoch_account_hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_fee_rate_governor_encode( &self->fee_rate_governor, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->capitalization, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->block_height, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->max_tick_height, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->collected_execution_fees, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->collected_priority_fees, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->collected_rent, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_vote_accounts_encode_global( &self->epoch_stakes, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_sol_sysvar_last_restart_slot_encode( &self->last_restart_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_account_keys_encode_global( &self->stake_account_keys, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_account_keys_encode_global( &self->vote_account_keys, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->lamports_per_signature, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->transaction_count, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_slot_lthash_encode( &self->lthash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_block_hash_queue_encode_global( &self->block_hash_queue, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_hash_encode( &self->prev_banks_hash, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -13956,10 +12840,10 @@ void fd_slot_bank_decode_inner_global( void * struct_mem, void * * alloc_mem, fd
   fd_clock_timestamp_votes_decode_inner_global( &self->timestamp_votes, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
   fd_bincode_uint64_decode_unsafe( &self->prev_slot, ctx );
-  fd_hash_decode_inner_global( &self->poh, alloc_mem, ctx );
-  fd_hash_decode_inner_global( &self->banks_hash, alloc_mem, ctx );
-  fd_hash_decode_inner_global( &self->epoch_account_hash, alloc_mem, ctx );
-  fd_fee_rate_governor_decode_inner_global( &self->fee_rate_governor, alloc_mem, ctx );
+  fd_hash_decode_inner( &self->poh, alloc_mem, ctx );
+  fd_hash_decode_inner( &self->banks_hash, alloc_mem, ctx );
+  fd_hash_decode_inner( &self->epoch_account_hash, alloc_mem, ctx );
+  fd_fee_rate_governor_decode_inner( &self->fee_rate_governor, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->capitalization, ctx );
   fd_bincode_uint64_decode_unsafe( &self->block_height, ctx );
   fd_bincode_uint64_decode_unsafe( &self->max_tick_height, ctx );
@@ -13967,14 +12851,14 @@ void fd_slot_bank_decode_inner_global( void * struct_mem, void * * alloc_mem, fd
   fd_bincode_uint64_decode_unsafe( &self->collected_priority_fees, ctx );
   fd_bincode_uint64_decode_unsafe( &self->collected_rent, ctx );
   fd_vote_accounts_decode_inner_global( &self->epoch_stakes, alloc_mem, ctx );
-  fd_sol_sysvar_last_restart_slot_decode_inner_global( &self->last_restart_slot, alloc_mem, ctx );
+  fd_sol_sysvar_last_restart_slot_decode_inner( &self->last_restart_slot, alloc_mem, ctx );
   fd_account_keys_decode_inner_global( &self->stake_account_keys, alloc_mem, ctx );
   fd_account_keys_decode_inner_global( &self->vote_account_keys, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->lamports_per_signature, ctx );
   fd_bincode_uint64_decode_unsafe( &self->transaction_count, ctx );
-  fd_slot_lthash_decode_inner_global( &self->lthash, alloc_mem, ctx );
+  fd_slot_lthash_decode_inner( &self->lthash, alloc_mem, ctx );
   fd_block_hash_queue_decode_inner_global( &self->block_hash_queue, alloc_mem, ctx );
-  fd_hash_decode_inner_global( &self->prev_banks_hash, alloc_mem, ctx );
+  fd_hash_decode_inner( &self->prev_banks_hash, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->parent_signature_cnt, ctx );
   fd_bincode_uint64_decode_unsafe( &self->tick_height, ctx );
   {
@@ -13985,55 +12869,8 @@ void fd_slot_bank_decode_inner_global( void * struct_mem, void * * alloc_mem, fd
       fd_bincode_uint64_decode_unsafe( &self->use_preceeding_epoch_stakes, ctx );
     }
   }
-  fd_hard_forks_decode_inner_global( &self->hard_forks, alloc_mem, ctx );
-  fd_rent_fresh_accounts_decode_inner_global( &self->rent_fresh_accounts, alloc_mem, ctx );
-}
-int fd_slot_bank_convert_global_to_local( void const * global_self, fd_slot_bank_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_slot_bank_global_t const * mem = (fd_slot_bank_global_t const *)global_self;
-  err = fd_clock_timestamp_votes_convert_global_to_local( &mem->timestamp_votes, &self->timestamp_votes, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->slot = mem->slot;
-  self->prev_slot = mem->prev_slot;
-  err = fd_hash_convert_global_to_local( &mem->poh, &self->poh, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_hash_convert_global_to_local( &mem->banks_hash, &self->banks_hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_hash_convert_global_to_local( &mem->epoch_account_hash, &self->epoch_account_hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_fee_rate_governor_convert_global_to_local( &mem->fee_rate_governor, &self->fee_rate_governor, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->capitalization = mem->capitalization;
-  self->block_height = mem->block_height;
-  self->max_tick_height = mem->max_tick_height;
-  self->collected_execution_fees = mem->collected_execution_fees;
-  self->collected_priority_fees = mem->collected_priority_fees;
-  self->collected_rent = mem->collected_rent;
-  err = fd_vote_accounts_convert_global_to_local( &mem->epoch_stakes, &self->epoch_stakes, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_sol_sysvar_last_restart_slot_convert_global_to_local( &mem->last_restart_slot, &self->last_restart_slot, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_account_keys_convert_global_to_local( &mem->stake_account_keys, &self->stake_account_keys, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_account_keys_convert_global_to_local( &mem->vote_account_keys, &self->vote_account_keys, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->lamports_per_signature = mem->lamports_per_signature;
-  self->transaction_count = mem->transaction_count;
-  err = fd_slot_lthash_convert_global_to_local( &mem->lthash, &self->lthash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_block_hash_queue_convert_global_to_local( &mem->block_hash_queue, &self->block_hash_queue, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_hash_convert_global_to_local( &mem->prev_banks_hash, &self->prev_banks_hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->parent_signature_cnt = mem->parent_signature_cnt;
-  self->tick_height = mem->tick_height;
-  self->use_preceeding_epoch_stakes = mem->use_preceeding_epoch_stakes;
-  self->has_use_preceeding_epoch_stakes = mem->has_use_preceeding_epoch_stakes;
-  err = fd_hard_forks_convert_global_to_local( &mem->hard_forks, &self->hard_forks, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_rent_fresh_accounts_convert_global_to_local( &mem->rent_fresh_accounts, &self->rent_fresh_accounts, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  fd_hard_forks_decode_inner( &self->hard_forks, alloc_mem, ctx );
+  fd_rent_fresh_accounts_decode_inner( &self->rent_fresh_accounts, alloc_mem, ctx );
 }
 void fd_slot_bank_new(fd_slot_bank_t * self) {
   fd_memset( self, 0, sizeof(fd_slot_bank_t) );
@@ -14193,30 +13030,6 @@ void fd_prev_epoch_inflation_rewards_decode_inner( void * struct_mem, void * * a
   fd_bincode_double_decode_unsafe( &self->validator_rate, ctx );
   fd_bincode_double_decode_unsafe( &self->foundation_rate, ctx );
 }
-void * fd_prev_epoch_inflation_rewards_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_prev_epoch_inflation_rewards_global_t * self = (fd_prev_epoch_inflation_rewards_global_t *)mem;
-  fd_prev_epoch_inflation_rewards_new( (fd_prev_epoch_inflation_rewards_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_prev_epoch_inflation_rewards_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_prev_epoch_inflation_rewards_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_prev_epoch_inflation_rewards_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_prev_epoch_inflation_rewards_global_t * self = (fd_prev_epoch_inflation_rewards_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->validator_rewards, ctx );
-  fd_bincode_double_decode_unsafe( &self->prev_epoch_duration_in_years, ctx );
-  fd_bincode_double_decode_unsafe( &self->validator_rate, ctx );
-  fd_bincode_double_decode_unsafe( &self->foundation_rate, ctx );
-}
-int fd_prev_epoch_inflation_rewards_convert_global_to_local( void const * global_self, fd_prev_epoch_inflation_rewards_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_prev_epoch_inflation_rewards_global_t const * mem = (fd_prev_epoch_inflation_rewards_global_t const *)global_self;
-  self->validator_rewards = mem->validator_rewards;
-  self->prev_epoch_duration_in_years = mem->prev_epoch_duration_in_years;
-  self->validator_rate = mem->validator_rate;
-  self->foundation_rate = mem->foundation_rate;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_prev_epoch_inflation_rewards_new(fd_prev_epoch_inflation_rewards_t * self) {
   fd_memset( self, 0, sizeof(fd_prev_epoch_inflation_rewards_t) );
 }
@@ -14264,6 +13077,37 @@ int fd_vote_encode( fd_vote_t const * self, fd_bincode_encode_ctx_t * ctx ) {
     err = fd_bincode_bool_encode( 1, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     err = fd_bincode_int64_encode( self->timestamp[0], ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_vote_encode_global( fd_vote_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  if( self->slots_gaddr ) {
+  uchar * slots_laddr = fd_wksp_laddr_fast( ctx->wksp, self->slots_gaddr );
+   ulong * slots = deq_ulong_join( slots_laddr );
+    ulong slots_len = deq_ulong_cnt( slots );
+    err = fd_bincode_uint64_encode( slots_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( deq_ulong_iter_t iter = deq_ulong_iter_init( slots ); !deq_ulong_iter_done( slots, iter ); iter = deq_ulong_iter_next( slots, iter ) ) {
+      ulong const * ele = deq_ulong_iter_ele_const( slots, iter );
+      err = fd_bincode_uint64_encode( ele[0], ctx );
+    }
+  } else {
+    ulong slots_len = 0;
+    err = fd_bincode_uint64_encode( slots_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_hash_encode( &self->hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->timestamp_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    long * timestamp = fd_wksp_laddr_fast( ctx->wksp, self->timestamp_gaddr );
+    err = fd_bincode_int64_encode( timestamp[0], ctx );
     if( FD_UNLIKELY( err ) ) return err;
   } else {
     err = fd_bincode_bool_encode( 0, ctx );
@@ -14349,13 +13193,13 @@ void fd_vote_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_binc
   ulong slots_len;
   fd_bincode_uint64_decode_unsafe( &slots_len, ctx );
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, deq_ulong_align() );
-  self->slots_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
   ulong * slots = deq_ulong_join_new( alloc_mem, slots_len );
   for( ulong i=0; i < slots_len; i++ ) {
     ulong * elem = deq_ulong_push_tail_nocopy( slots );
     fd_bincode_uint64_decode_unsafe( elem, ctx );
   }
-  fd_hash_decode_inner_global( &self->hash, alloc_mem, ctx );
+  self->slots_gaddr = fd_wksp_gaddr_fast( ctx->wksp, deq_ulong_leave( slots ) );
+  fd_hash_decode_inner( &self->hash, alloc_mem, ctx );
   {
     uchar o;
     fd_bincode_bool_decode_unsafe( &o, ctx );
@@ -14368,15 +13212,6 @@ void fd_vote_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_binc
       self->timestamp_gaddr = 0UL;
     }
   }
-}
-int fd_vote_convert_global_to_local( void const * global_self, fd_vote_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_global_t const * mem = (fd_vote_global_t const *)global_self;
-  self->slots = deq_ulong_join( fd_wksp_laddr_fast( ctx->wksp, mem->slots_gaddr ) );
-  err = fd_hash_convert_global_to_local( &mem->hash, &self->hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->timestamp = fd_wksp_laddr_fast( ctx->wksp, mem->timestamp_gaddr );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_vote_new(fd_vote_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_t) );
@@ -14430,7 +13265,7 @@ ulong fd_vote_size( fd_vote_t const * self ) {
   }
   size += fd_hash_size( &self->hash );
   size += sizeof(char);
-  if( NULL !=  self->timestamp ) {
+  if( NULL != self->timestamp ) {
     size += sizeof(long);
   }
   return size;
@@ -14483,33 +13318,6 @@ void fd_vote_init_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincod
   fd_pubkey_decode_inner( &self->authorized_voter, alloc_mem, ctx );
   fd_pubkey_decode_inner( &self->authorized_withdrawer, alloc_mem, ctx );
   fd_bincode_uint8_decode_unsafe( &self->commission, ctx );
-}
-void * fd_vote_init_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_init_global_t * self = (fd_vote_init_global_t *)mem;
-  fd_vote_init_new( (fd_vote_init_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_vote_init_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_vote_init_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_vote_init_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_init_global_t * self = (fd_vote_init_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->node_pubkey, alloc_mem, ctx );
-  fd_pubkey_decode_inner_global( &self->authorized_voter, alloc_mem, ctx );
-  fd_pubkey_decode_inner_global( &self->authorized_withdrawer, alloc_mem, ctx );
-  fd_bincode_uint8_decode_unsafe( &self->commission, ctx );
-}
-int fd_vote_init_convert_global_to_local( void const * global_self, fd_vote_init_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_init_global_t const * mem = (fd_vote_init_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->node_pubkey, &self->node_pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_pubkey_convert_global_to_local( &mem->authorized_voter, &self->authorized_voter, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_pubkey_convert_global_to_local( &mem->authorized_withdrawer, &self->authorized_withdrawer, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->commission = mem->commission;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_vote_init_new(fd_vote_init_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_init_t) );
@@ -14587,35 +13395,6 @@ void fd_vote_authorize_inner_decode_inner( fd_vote_authorize_inner_t * self, voi
   }
   }
 }
-void fd_vote_authorize_inner_decode_inner_global( fd_vote_authorize_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    break;
-  }
-  }
-}
-int fd_vote_authorize_convert_global_to_local_inner( fd_vote_authorize_inner_global_t const * mem, fd_vote_authorize_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_vote_authorize_convert_global_to_local( void const * global_self, fd_vote_authorize_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_authorize_global_t const * mem = (fd_vote_authorize_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_vote_authorize_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_vote_authorize_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_vote_authorize_t * self = (fd_vote_authorize_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -14628,19 +13407,6 @@ void * fd_vote_authorize_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   void * * alloc_mem = &alloc_region;
   fd_vote_authorize_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_vote_authorize_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_authorize_t * self = (fd_vote_authorize_t *)mem;
-  fd_vote_authorize_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_vote_authorize_t);
-  void * * alloc_mem = &alloc_region;
-  fd_vote_authorize_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_vote_authorize_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_authorize_global_t * self = (fd_vote_authorize_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_vote_authorize_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_vote_authorize_inner_new( fd_vote_authorize_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -14742,28 +13508,6 @@ void fd_vote_authorize_pubkey_decode_inner( void * struct_mem, void * * alloc_me
   fd_pubkey_decode_inner( &self->pubkey, alloc_mem, ctx );
   fd_vote_authorize_decode_inner( &self->vote_authorize, alloc_mem, ctx );
 }
-void * fd_vote_authorize_pubkey_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_authorize_pubkey_global_t * self = (fd_vote_authorize_pubkey_global_t *)mem;
-  fd_vote_authorize_pubkey_new( (fd_vote_authorize_pubkey_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_vote_authorize_pubkey_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_vote_authorize_pubkey_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_vote_authorize_pubkey_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_authorize_pubkey_global_t * self = (fd_vote_authorize_pubkey_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->pubkey, alloc_mem, ctx );
-  fd_vote_authorize_decode_inner_global( &self->vote_authorize, alloc_mem, ctx );
-}
-int fd_vote_authorize_pubkey_convert_global_to_local( void const * global_self, fd_vote_authorize_pubkey_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_authorize_pubkey_global_t const * mem = (fd_vote_authorize_pubkey_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->pubkey, &self->pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_vote_authorize_convert_global_to_local( &mem->vote_authorize, &self->vote_authorize, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_vote_authorize_pubkey_new(fd_vote_authorize_pubkey_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_authorize_pubkey_t) );
   fd_pubkey_new( &self->pubkey );
@@ -14793,6 +13537,14 @@ ulong fd_vote_authorize_pubkey_size( fd_vote_authorize_pubkey_t const * self ) {
 int fd_vote_switch_encode( fd_vote_switch_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
   err = fd_vote_encode( &self->vote, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_hash_encode( &self->hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_vote_switch_encode_global( fd_vote_switch_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_vote_encode_global( &self->vote, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_hash_encode( &self->hash, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -14839,16 +13591,7 @@ void * fd_vote_switch_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx )
 void fd_vote_switch_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_vote_switch_global_t * self = (fd_vote_switch_global_t *)struct_mem;
   fd_vote_decode_inner_global( &self->vote, alloc_mem, ctx );
-  fd_hash_decode_inner_global( &self->hash, alloc_mem, ctx );
-}
-int fd_vote_switch_convert_global_to_local( void const * global_self, fd_vote_switch_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_switch_global_t const * mem = (fd_vote_switch_global_t const *)global_self;
-  err = fd_vote_convert_global_to_local( &mem->vote, &self->vote, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_hash_convert_global_to_local( &mem->hash, &self->hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  fd_hash_decode_inner( &self->hash, alloc_mem, ctx );
 }
 void fd_vote_switch_new(fd_vote_switch_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_switch_t) );
@@ -14879,6 +13622,14 @@ ulong fd_vote_switch_size( fd_vote_switch_t const * self ) {
 int fd_update_vote_state_switch_encode( fd_update_vote_state_switch_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
   err = fd_vote_state_update_encode( &self->vote_state_update, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_hash_encode( &self->hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_update_vote_state_switch_encode_global( fd_update_vote_state_switch_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_vote_state_update_encode_global( &self->vote_state_update, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_hash_encode( &self->hash, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -14925,16 +13676,7 @@ void * fd_update_vote_state_switch_decode_global( void * mem, fd_bincode_decode_
 void fd_update_vote_state_switch_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_update_vote_state_switch_global_t * self = (fd_update_vote_state_switch_global_t *)struct_mem;
   fd_vote_state_update_decode_inner_global( &self->vote_state_update, alloc_mem, ctx );
-  fd_hash_decode_inner_global( &self->hash, alloc_mem, ctx );
-}
-int fd_update_vote_state_switch_convert_global_to_local( void const * global_self, fd_update_vote_state_switch_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_update_vote_state_switch_global_t const * mem = (fd_update_vote_state_switch_global_t const *)global_self;
-  err = fd_vote_state_update_convert_global_to_local( &mem->vote_state_update, &self->vote_state_update, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_hash_convert_global_to_local( &mem->hash, &self->hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  fd_hash_decode_inner( &self->hash, alloc_mem, ctx );
 }
 void fd_update_vote_state_switch_new(fd_update_vote_state_switch_t * self) {
   fd_memset( self, 0, sizeof(fd_update_vote_state_switch_t) );
@@ -14972,6 +13714,23 @@ int fd_vote_authorize_with_seed_args_encode( fd_vote_authorize_with_seed_args_t 
   if( FD_UNLIKELY(err) ) return err;
   if( self->current_authority_derived_key_seed_len ) {
     err = fd_bincode_bytes_encode( self->current_authority_derived_key_seed, self->current_authority_derived_key_seed_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_pubkey_encode( &self->new_authority, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_vote_authorize_with_seed_args_encode_global( fd_vote_authorize_with_seed_args_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_vote_authorize_encode( &self->authorization_type, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_pubkey_encode( &self->current_authority_derived_key_owner, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->current_authority_derived_key_seed_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->current_authority_derived_key_seed_len ) {
+    uchar * current_authority_derived_key_seed_laddr = fd_wksp_laddr_fast( ctx->wksp, self->current_authority_derived_key_seed_gaddr );
+    err = fd_bincode_bytes_encode( current_authority_derived_key_seed_laddr, self->current_authority_derived_key_seed_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   err = fd_pubkey_encode( &self->new_authority, ctx );
@@ -15038,29 +13797,17 @@ void * fd_vote_authorize_with_seed_args_decode_global( void * mem, fd_bincode_de
 }
 void fd_vote_authorize_with_seed_args_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_vote_authorize_with_seed_args_global_t * self = (fd_vote_authorize_with_seed_args_global_t *)struct_mem;
-  fd_vote_authorize_decode_inner_global( &self->authorization_type, alloc_mem, ctx );
-  fd_pubkey_decode_inner_global( &self->current_authority_derived_key_owner, alloc_mem, ctx );
+  fd_vote_authorize_decode_inner( &self->authorization_type, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->current_authority_derived_key_owner, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->current_authority_derived_key_seed_len, ctx );
   if( self->current_authority_derived_key_seed_len ) {
     self->current_authority_derived_key_seed_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
     fd_bincode_bytes_decode_unsafe( *alloc_mem, self->current_authority_derived_key_seed_len, ctx );
     *alloc_mem = (uchar *)(*alloc_mem) + self->current_authority_derived_key_seed_len;
-  } else
+  } else {
     self->current_authority_derived_key_seed_gaddr = 0UL;
-  fd_pubkey_decode_inner_global( &self->new_authority, alloc_mem, ctx );
-}
-int fd_vote_authorize_with_seed_args_convert_global_to_local( void const * global_self, fd_vote_authorize_with_seed_args_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_authorize_with_seed_args_global_t const * mem = (fd_vote_authorize_with_seed_args_global_t const *)global_self;
-  err = fd_vote_authorize_convert_global_to_local( &mem->authorization_type, &self->authorization_type, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_pubkey_convert_global_to_local( &mem->current_authority_derived_key_owner, &self->current_authority_derived_key_owner, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->current_authority_derived_key_seed_len = mem->current_authority_derived_key_seed_len;
-  self->current_authority_derived_key_seed     = fd_wksp_laddr_fast( ctx->wksp, mem->current_authority_derived_key_seed_gaddr );
-  err = fd_pubkey_convert_global_to_local( &mem->new_authority, &self->new_authority, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  }
+  fd_pubkey_decode_inner( &self->new_authority, alloc_mem, ctx );
 }
 void fd_vote_authorize_with_seed_args_new(fd_vote_authorize_with_seed_args_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_authorize_with_seed_args_t) );
@@ -15110,6 +13857,21 @@ int fd_vote_authorize_checked_with_seed_args_encode( fd_vote_authorize_checked_w
   if( FD_UNLIKELY(err) ) return err;
   if( self->current_authority_derived_key_seed_len ) {
     err = fd_bincode_bytes_encode( self->current_authority_derived_key_seed, self->current_authority_derived_key_seed_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_vote_authorize_checked_with_seed_args_encode_global( fd_vote_authorize_checked_with_seed_args_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_vote_authorize_encode( &self->authorization_type, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_pubkey_encode( &self->current_authority_derived_key_owner, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->current_authority_derived_key_seed_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->current_authority_derived_key_seed_len ) {
+    uchar * current_authority_derived_key_seed_laddr = fd_wksp_laddr_fast( ctx->wksp, self->current_authority_derived_key_seed_gaddr );
+    err = fd_bincode_bytes_encode( current_authority_derived_key_seed_laddr, self->current_authority_derived_key_seed_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   return FD_BINCODE_SUCCESS;
@@ -15171,26 +13933,16 @@ void * fd_vote_authorize_checked_with_seed_args_decode_global( void * mem, fd_bi
 }
 void fd_vote_authorize_checked_with_seed_args_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_vote_authorize_checked_with_seed_args_global_t * self = (fd_vote_authorize_checked_with_seed_args_global_t *)struct_mem;
-  fd_vote_authorize_decode_inner_global( &self->authorization_type, alloc_mem, ctx );
-  fd_pubkey_decode_inner_global( &self->current_authority_derived_key_owner, alloc_mem, ctx );
+  fd_vote_authorize_decode_inner( &self->authorization_type, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->current_authority_derived_key_owner, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->current_authority_derived_key_seed_len, ctx );
   if( self->current_authority_derived_key_seed_len ) {
     self->current_authority_derived_key_seed_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
     fd_bincode_bytes_decode_unsafe( *alloc_mem, self->current_authority_derived_key_seed_len, ctx );
     *alloc_mem = (uchar *)(*alloc_mem) + self->current_authority_derived_key_seed_len;
-  } else
+  } else {
     self->current_authority_derived_key_seed_gaddr = 0UL;
-}
-int fd_vote_authorize_checked_with_seed_args_convert_global_to_local( void const * global_self, fd_vote_authorize_checked_with_seed_args_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_authorize_checked_with_seed_args_global_t const * mem = (fd_vote_authorize_checked_with_seed_args_global_t const *)global_self;
-  err = fd_vote_authorize_convert_global_to_local( &mem->authorization_type, &self->authorization_type, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_pubkey_convert_global_to_local( &mem->current_authority_derived_key_owner, &self->current_authority_derived_key_owner, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->current_authority_derived_key_seed_len = mem->current_authority_derived_key_seed_len;
-  self->current_authority_derived_key_seed     = fd_wksp_laddr_fast( ctx->wksp, mem->current_authority_derived_key_seed_gaddr );
-  return FD_BINCODE_SUCCESS;
+  }
 }
 void fd_vote_authorize_checked_with_seed_args_new(fd_vote_authorize_checked_with_seed_args_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_authorize_checked_with_seed_args_t) );
@@ -15444,11 +14196,11 @@ void fd_vote_instruction_inner_decode_inner( fd_vote_instruction_inner_t * self,
 void fd_vote_instruction_inner_decode_inner_global( fd_vote_instruction_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
   switch (discriminant) {
   case 0: {
-    fd_vote_init_decode_inner_global( &self->initialize_account, alloc_mem, ctx );
+    fd_vote_init_decode_inner( &self->initialize_account, alloc_mem, ctx );
     break;
   }
   case 1: {
-    fd_vote_authorize_pubkey_decode_inner_global( &self->authorize, alloc_mem, ctx );
+    fd_vote_authorize_pubkey_decode_inner( &self->authorize, alloc_mem, ctx );
     break;
   }
   case 2: {
@@ -15471,7 +14223,7 @@ void fd_vote_instruction_inner_decode_inner_global( fd_vote_instruction_inner_gl
     break;
   }
   case 7: {
-    fd_vote_authorize_decode_inner_global( &self->authorize_checked, alloc_mem, ctx );
+    fd_vote_authorize_decode_inner( &self->authorize_checked, alloc_mem, ctx );
     break;
   }
   case 8: {
@@ -15508,95 +14260,6 @@ void fd_vote_instruction_inner_decode_inner_global( fd_vote_instruction_inner_gl
   }
   }
 }
-int fd_vote_instruction_convert_global_to_local_inner( fd_vote_instruction_inner_global_t const * mem, fd_vote_instruction_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_vote_init_convert_global_to_local( &mem->initialize_account, &self->initialize_account, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 1: {
-    err = fd_vote_authorize_pubkey_convert_global_to_local( &mem->authorize, &self->authorize, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 2: {
-    err = fd_vote_convert_global_to_local( &mem->vote, &self->vote, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 3: {
-    self->withdraw = mem->withdraw;
-    break;
-  }
-  case 4: {
-    break;
-  }
-  case 5: {
-    self->update_commission = mem->update_commission;
-    break;
-  }
-  case 6: {
-    err = fd_vote_switch_convert_global_to_local( &mem->vote_switch, &self->vote_switch, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 7: {
-    err = fd_vote_authorize_convert_global_to_local( &mem->authorize_checked, &self->authorize_checked, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 8: {
-    err = fd_vote_state_update_convert_global_to_local( &mem->update_vote_state, &self->update_vote_state, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 9: {
-    err = fd_update_vote_state_switch_convert_global_to_local( &mem->update_vote_state_switch, &self->update_vote_state_switch, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 10: {
-    err = fd_vote_authorize_with_seed_args_convert_global_to_local( &mem->authorize_with_seed, &self->authorize_with_seed, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 11: {
-    err = fd_vote_authorize_checked_with_seed_args_convert_global_to_local( &mem->authorize_checked_with_seed, &self->authorize_checked_with_seed, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 12: {
-    err = fd_compact_vote_state_update_convert_global_to_local( &mem->compact_update_vote_state, &self->compact_update_vote_state, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 13: {
-    err = fd_compact_vote_state_update_switch_convert_global_to_local( &mem->compact_update_vote_state_switch, &self->compact_update_vote_state_switch, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 14: {
-    err = fd_tower_sync_convert_global_to_local( &mem->tower_sync, &self->tower_sync, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 15: {
-    err = fd_tower_sync_switch_convert_global_to_local( &mem->tower_sync_switch, &self->tower_sync_switch, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_vote_instruction_convert_global_to_local( void const * global_self, fd_vote_instruction_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_vote_instruction_global_t const * mem = (fd_vote_instruction_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_vote_instruction_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_vote_instruction_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_vote_instruction_t * self = (fd_vote_instruction_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -15610,6 +14273,93 @@ void * fd_vote_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_vote_instruction_decode_inner( mem, alloc_mem, ctx );
   return self;
 }
+int fd_vote_instruction_inner_encode_global( fd_vote_instruction_inner_global_t const * self, uint discriminant, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  switch (discriminant) {
+  case 0: {
+    err = fd_vote_init_encode( &self->initialize_account, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 1: {
+    err = fd_vote_authorize_pubkey_encode( &self->authorize, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 2: {
+    err = fd_vote_encode_global( &self->vote, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 3: {
+    err = fd_bincode_uint64_encode( self->withdraw, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 5: {
+    err = fd_bincode_uint8_encode( (uchar)(self->update_commission), ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 6: {
+    err = fd_vote_switch_encode_global( &self->vote_switch, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 7: {
+    err = fd_vote_authorize_encode( &self->authorize_checked, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 8: {
+    err = fd_vote_state_update_encode_global( &self->update_vote_state, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 9: {
+    err = fd_update_vote_state_switch_encode_global( &self->update_vote_state_switch, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 10: {
+    err = fd_vote_authorize_with_seed_args_encode_global( &self->authorize_with_seed, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 11: {
+    err = fd_vote_authorize_checked_with_seed_args_encode_global( &self->authorize_checked_with_seed, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 12: {
+    err = fd_compact_vote_state_update_encode_global( &self->compact_update_vote_state, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 13: {
+    err = fd_compact_vote_state_update_switch_encode_global( &self->compact_update_vote_state_switch, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 14: {
+    err = fd_tower_sync_encode_global( &self->tower_sync, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 15: {
+    err = fd_tower_sync_switch_encode_global( &self->tower_sync_switch, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_vote_instruction_encode_global( fd_vote_instruction_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err = fd_bincode_uint32_encode( self->discriminant, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fd_vote_instruction_inner_encode_global( &self->inner, self->discriminant, ctx );
+}
+
 void * fd_vote_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_vote_instruction_t * self = (fd_vote_instruction_t *)mem;
   fd_vote_instruction_new( self );
@@ -16050,29 +14800,6 @@ void fd_system_program_instruction_create_account_decode_inner( void * struct_me
   fd_bincode_uint64_decode_unsafe( &self->space, ctx );
   fd_pubkey_decode_inner( &self->owner, alloc_mem, ctx );
 }
-void * fd_system_program_instruction_create_account_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_system_program_instruction_create_account_global_t * self = (fd_system_program_instruction_create_account_global_t *)mem;
-  fd_system_program_instruction_create_account_new( (fd_system_program_instruction_create_account_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_system_program_instruction_create_account_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_system_program_instruction_create_account_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_system_program_instruction_create_account_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_system_program_instruction_create_account_global_t * self = (fd_system_program_instruction_create_account_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->lamports, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->space, ctx );
-  fd_pubkey_decode_inner_global( &self->owner, alloc_mem, ctx );
-}
-int fd_system_program_instruction_create_account_convert_global_to_local( void const * global_self, fd_system_program_instruction_create_account_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_system_program_instruction_create_account_global_t const * mem = (fd_system_program_instruction_create_account_global_t const *)global_self;
-  self->lamports = mem->lamports;
-  self->space = mem->space;
-  err = fd_pubkey_convert_global_to_local( &mem->owner, &self->owner, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_system_program_instruction_create_account_new(fd_system_program_instruction_create_account_t * self) {
   fd_memset( self, 0, sizeof(fd_system_program_instruction_create_account_t) );
   fd_pubkey_new( &self->owner );
@@ -16107,6 +14834,25 @@ int fd_system_program_instruction_create_account_with_seed_encode( fd_system_pro
   if( FD_UNLIKELY(err) ) return err;
   if( self->seed_len ) {
     err = fd_bincode_bytes_encode( self->seed, self->seed_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_uint64_encode( self->lamports, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->space, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_pubkey_encode( &self->owner, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_system_program_instruction_create_account_with_seed_encode_global( fd_system_program_instruction_create_account_with_seed_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_encode( &self->base, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->seed_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->seed_len ) {
+    uchar * seed_laddr = fd_wksp_laddr_fast( ctx->wksp, self->seed_gaddr );
+    err = fd_bincode_bytes_encode( seed_laddr, self->seed_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   err = fd_bincode_uint64_encode( self->lamports, ctx );
@@ -16180,30 +14926,18 @@ void * fd_system_program_instruction_create_account_with_seed_decode_global( voi
 }
 void fd_system_program_instruction_create_account_with_seed_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_system_program_instruction_create_account_with_seed_global_t * self = (fd_system_program_instruction_create_account_with_seed_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->base, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->base, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->seed_len, ctx );
   if( self->seed_len ) {
     self->seed_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
     fd_bincode_bytes_decode_unsafe( *alloc_mem, self->seed_len, ctx );
     *alloc_mem = (uchar *)(*alloc_mem) + self->seed_len;
-  } else
+  } else {
     self->seed_gaddr = 0UL;
+  }
   fd_bincode_uint64_decode_unsafe( &self->lamports, ctx );
   fd_bincode_uint64_decode_unsafe( &self->space, ctx );
-  fd_pubkey_decode_inner_global( &self->owner, alloc_mem, ctx );
-}
-int fd_system_program_instruction_create_account_with_seed_convert_global_to_local( void const * global_self, fd_system_program_instruction_create_account_with_seed_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_system_program_instruction_create_account_with_seed_global_t const * mem = (fd_system_program_instruction_create_account_with_seed_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->base, &self->base, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->seed_len = mem->seed_len;
-  self->seed     = fd_wksp_laddr_fast( ctx->wksp, mem->seed_gaddr );
-  self->lamports = mem->lamports;
-  self->space = mem->space;
-  err = fd_pubkey_convert_global_to_local( &mem->owner, &self->owner, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  fd_pubkey_decode_inner( &self->owner, alloc_mem, ctx );
 }
 void fd_system_program_instruction_create_account_with_seed_new(fd_system_program_instruction_create_account_with_seed_t * self) {
   fd_memset( self, 0, sizeof(fd_system_program_instruction_create_account_with_seed_t) );
@@ -16251,6 +14985,23 @@ int fd_system_program_instruction_allocate_with_seed_encode( fd_system_program_i
   if( FD_UNLIKELY(err) ) return err;
   if( self->seed_len ) {
     err = fd_bincode_bytes_encode( self->seed, self->seed_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_uint64_encode( self->space, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_pubkey_encode( &self->owner, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_system_program_instruction_allocate_with_seed_encode_global( fd_system_program_instruction_allocate_with_seed_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_encode( &self->base, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->seed_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->seed_len ) {
+    uchar * seed_laddr = fd_wksp_laddr_fast( ctx->wksp, self->seed_gaddr );
+    err = fd_bincode_bytes_encode( seed_laddr, self->seed_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   err = fd_bincode_uint64_encode( self->space, ctx );
@@ -16319,28 +15070,17 @@ void * fd_system_program_instruction_allocate_with_seed_decode_global( void * me
 }
 void fd_system_program_instruction_allocate_with_seed_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_system_program_instruction_allocate_with_seed_global_t * self = (fd_system_program_instruction_allocate_with_seed_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->base, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->base, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->seed_len, ctx );
   if( self->seed_len ) {
     self->seed_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
     fd_bincode_bytes_decode_unsafe( *alloc_mem, self->seed_len, ctx );
     *alloc_mem = (uchar *)(*alloc_mem) + self->seed_len;
-  } else
+  } else {
     self->seed_gaddr = 0UL;
+  }
   fd_bincode_uint64_decode_unsafe( &self->space, ctx );
-  fd_pubkey_decode_inner_global( &self->owner, alloc_mem, ctx );
-}
-int fd_system_program_instruction_allocate_with_seed_convert_global_to_local( void const * global_self, fd_system_program_instruction_allocate_with_seed_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_system_program_instruction_allocate_with_seed_global_t const * mem = (fd_system_program_instruction_allocate_with_seed_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->base, &self->base, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->seed_len = mem->seed_len;
-  self->seed     = fd_wksp_laddr_fast( ctx->wksp, mem->seed_gaddr );
-  self->space = mem->space;
-  err = fd_pubkey_convert_global_to_local( &mem->owner, &self->owner, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  fd_pubkey_decode_inner( &self->owner, alloc_mem, ctx );
 }
 void fd_system_program_instruction_allocate_with_seed_new(fd_system_program_instruction_allocate_with_seed_t * self) {
   fd_memset( self, 0, sizeof(fd_system_program_instruction_allocate_with_seed_t) );
@@ -16386,6 +15126,21 @@ int fd_system_program_instruction_assign_with_seed_encode( fd_system_program_ins
   if( FD_UNLIKELY(err) ) return err;
   if( self->seed_len ) {
     err = fd_bincode_bytes_encode( self->seed, self->seed_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_pubkey_encode( &self->owner, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_system_program_instruction_assign_with_seed_encode_global( fd_system_program_instruction_assign_with_seed_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_encode( &self->base, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->seed_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->seed_len ) {
+    uchar * seed_laddr = fd_wksp_laddr_fast( ctx->wksp, self->seed_gaddr );
+    err = fd_bincode_bytes_encode( seed_laddr, self->seed_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   err = fd_pubkey_encode( &self->owner, ctx );
@@ -16449,26 +15204,16 @@ void * fd_system_program_instruction_assign_with_seed_decode_global( void * mem,
 }
 void fd_system_program_instruction_assign_with_seed_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_system_program_instruction_assign_with_seed_global_t * self = (fd_system_program_instruction_assign_with_seed_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->base, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->base, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->seed_len, ctx );
   if( self->seed_len ) {
     self->seed_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
     fd_bincode_bytes_decode_unsafe( *alloc_mem, self->seed_len, ctx );
     *alloc_mem = (uchar *)(*alloc_mem) + self->seed_len;
-  } else
+  } else {
     self->seed_gaddr = 0UL;
-  fd_pubkey_decode_inner_global( &self->owner, alloc_mem, ctx );
-}
-int fd_system_program_instruction_assign_with_seed_convert_global_to_local( void const * global_self, fd_system_program_instruction_assign_with_seed_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_system_program_instruction_assign_with_seed_global_t const * mem = (fd_system_program_instruction_assign_with_seed_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->base, &self->base, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->seed_len = mem->seed_len;
-  self->seed     = fd_wksp_laddr_fast( ctx->wksp, mem->seed_gaddr );
-  err = fd_pubkey_convert_global_to_local( &mem->owner, &self->owner, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  }
+  fd_pubkey_decode_inner( &self->owner, alloc_mem, ctx );
 }
 void fd_system_program_instruction_assign_with_seed_new(fd_system_program_instruction_assign_with_seed_t * self) {
   fd_memset( self, 0, sizeof(fd_system_program_instruction_assign_with_seed_t) );
@@ -16512,6 +15257,21 @@ int fd_system_program_instruction_transfer_with_seed_encode( fd_system_program_i
   if( FD_UNLIKELY(err) ) return err;
   if( self->from_seed_len ) {
     err = fd_bincode_bytes_encode( self->from_seed, self->from_seed_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_pubkey_encode( &self->from_owner, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_system_program_instruction_transfer_with_seed_encode_global( fd_system_program_instruction_transfer_with_seed_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->lamports, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->from_seed_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->from_seed_len ) {
+    uchar * from_seed_laddr = fd_wksp_laddr_fast( ctx->wksp, self->from_seed_gaddr );
+    err = fd_bincode_bytes_encode( from_seed_laddr, self->from_seed_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   err = fd_pubkey_encode( &self->from_owner, ctx );
@@ -16581,19 +15341,10 @@ void fd_system_program_instruction_transfer_with_seed_decode_inner_global( void 
     self->from_seed_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
     fd_bincode_bytes_decode_unsafe( *alloc_mem, self->from_seed_len, ctx );
     *alloc_mem = (uchar *)(*alloc_mem) + self->from_seed_len;
-  } else
+  } else {
     self->from_seed_gaddr = 0UL;
-  fd_pubkey_decode_inner_global( &self->from_owner, alloc_mem, ctx );
-}
-int fd_system_program_instruction_transfer_with_seed_convert_global_to_local( void const * global_self, fd_system_program_instruction_transfer_with_seed_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_system_program_instruction_transfer_with_seed_global_t const * mem = (fd_system_program_instruction_transfer_with_seed_global_t const *)global_self;
-  self->lamports = mem->lamports;
-  self->from_seed_len = mem->from_seed_len;
-  self->from_seed     = fd_wksp_laddr_fast( ctx->wksp, mem->from_seed_gaddr );
-  err = fd_pubkey_convert_global_to_local( &mem->from_owner, &self->from_owner, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  }
+  fd_pubkey_decode_inner( &self->from_owner, alloc_mem, ctx );
 }
 void fd_system_program_instruction_transfer_with_seed_new(fd_system_program_instruction_transfer_with_seed_t * self) {
   fd_memset( self, 0, sizeof(fd_system_program_instruction_transfer_with_seed_t) );
@@ -16806,11 +15557,11 @@ void fd_system_program_instruction_inner_decode_inner( fd_system_program_instruc
 void fd_system_program_instruction_inner_decode_inner_global( fd_system_program_instruction_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
   switch (discriminant) {
   case 0: {
-    fd_system_program_instruction_create_account_decode_inner_global( &self->create_account, alloc_mem, ctx );
+    fd_system_program_instruction_create_account_decode_inner( &self->create_account, alloc_mem, ctx );
     break;
   }
   case 1: {
-    fd_pubkey_decode_inner_global( &self->assign, alloc_mem, ctx );
+    fd_pubkey_decode_inner( &self->assign, alloc_mem, ctx );
     break;
   }
   case 2: {
@@ -16829,11 +15580,11 @@ void fd_system_program_instruction_inner_decode_inner_global( fd_system_program_
     break;
   }
   case 6: {
-    fd_pubkey_decode_inner_global( &self->initialize_nonce_account, alloc_mem, ctx );
+    fd_pubkey_decode_inner( &self->initialize_nonce_account, alloc_mem, ctx );
     break;
   }
   case 7: {
-    fd_pubkey_decode_inner_global( &self->authorize_nonce_account, alloc_mem, ctx );
+    fd_pubkey_decode_inner( &self->authorize_nonce_account, alloc_mem, ctx );
     break;
   }
   case 8: {
@@ -16857,77 +15608,6 @@ void fd_system_program_instruction_inner_decode_inner_global( fd_system_program_
   }
   }
 }
-int fd_system_program_instruction_convert_global_to_local_inner( fd_system_program_instruction_inner_global_t const * mem, fd_system_program_instruction_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_system_program_instruction_create_account_convert_global_to_local( &mem->create_account, &self->create_account, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 1: {
-    err = fd_pubkey_convert_global_to_local( &mem->assign, &self->assign, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 2: {
-    self->transfer = mem->transfer;
-    break;
-  }
-  case 3: {
-    err = fd_system_program_instruction_create_account_with_seed_convert_global_to_local( &mem->create_account_with_seed, &self->create_account_with_seed, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 4: {
-    break;
-  }
-  case 5: {
-    self->withdraw_nonce_account = mem->withdraw_nonce_account;
-    break;
-  }
-  case 6: {
-    err = fd_pubkey_convert_global_to_local( &mem->initialize_nonce_account, &self->initialize_nonce_account, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 7: {
-    err = fd_pubkey_convert_global_to_local( &mem->authorize_nonce_account, &self->authorize_nonce_account, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 8: {
-    self->allocate = mem->allocate;
-    break;
-  }
-  case 9: {
-    err = fd_system_program_instruction_allocate_with_seed_convert_global_to_local( &mem->allocate_with_seed, &self->allocate_with_seed, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 10: {
-    err = fd_system_program_instruction_assign_with_seed_convert_global_to_local( &mem->assign_with_seed, &self->assign_with_seed, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 11: {
-    err = fd_system_program_instruction_transfer_with_seed_convert_global_to_local( &mem->transfer_with_seed, &self->transfer_with_seed, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 12: {
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_system_program_instruction_convert_global_to_local( void const * global_self, fd_system_program_instruction_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_system_program_instruction_global_t const * mem = (fd_system_program_instruction_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_system_program_instruction_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_system_program_instruction_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_system_program_instruction_t * self = (fd_system_program_instruction_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -16941,6 +15621,73 @@ void * fd_system_program_instruction_decode( void * mem, fd_bincode_decode_ctx_t
   fd_system_program_instruction_decode_inner( mem, alloc_mem, ctx );
   return self;
 }
+int fd_system_program_instruction_inner_encode_global( fd_system_program_instruction_inner_global_t const * self, uint discriminant, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  switch (discriminant) {
+  case 0: {
+    err = fd_system_program_instruction_create_account_encode( &self->create_account, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 1: {
+    err = fd_pubkey_encode( &self->assign, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 2: {
+    err = fd_bincode_uint64_encode( self->transfer, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 3: {
+    err = fd_system_program_instruction_create_account_with_seed_encode_global( &self->create_account_with_seed, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 5: {
+    err = fd_bincode_uint64_encode( self->withdraw_nonce_account, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 6: {
+    err = fd_pubkey_encode( &self->initialize_nonce_account, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 7: {
+    err = fd_pubkey_encode( &self->authorize_nonce_account, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 8: {
+    err = fd_bincode_uint64_encode( self->allocate, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 9: {
+    err = fd_system_program_instruction_allocate_with_seed_encode_global( &self->allocate_with_seed, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 10: {
+    err = fd_system_program_instruction_assign_with_seed_encode_global( &self->assign_with_seed, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 11: {
+    err = fd_system_program_instruction_transfer_with_seed_encode_global( &self->transfer_with_seed, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_system_program_instruction_encode_global( fd_system_program_instruction_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err = fd_bincode_uint32_encode( self->discriminant, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fd_system_program_instruction_inner_encode_global( &self->inner, self->discriminant, ctx );
+}
+
 void * fd_system_program_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_system_program_instruction_t * self = (fd_system_program_instruction_t *)mem;
   fd_system_program_instruction_new( self );
@@ -17362,77 +16109,6 @@ void fd_system_error_inner_decode_inner( fd_system_error_inner_t * self, void * 
   }
   }
 }
-void fd_system_error_inner_decode_inner_global( fd_system_error_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    break;
-  }
-  case 2: {
-    break;
-  }
-  case 3: {
-    break;
-  }
-  case 4: {
-    break;
-  }
-  case 5: {
-    break;
-  }
-  case 6: {
-    break;
-  }
-  case 7: {
-    break;
-  }
-  case 8: {
-    break;
-  }
-  }
-}
-int fd_system_error_convert_global_to_local_inner( fd_system_error_inner_global_t const * mem, fd_system_error_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    break;
-  }
-  case 2: {
-    break;
-  }
-  case 3: {
-    break;
-  }
-  case 4: {
-    break;
-  }
-  case 5: {
-    break;
-  }
-  case 6: {
-    break;
-  }
-  case 7: {
-    break;
-  }
-  case 8: {
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_system_error_convert_global_to_local( void const * global_self, fd_system_error_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_system_error_global_t const * mem = (fd_system_error_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_system_error_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_system_error_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_system_error_t * self = (fd_system_error_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -17445,19 +16121,6 @@ void * fd_system_error_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   void * * alloc_mem = &alloc_region;
   fd_system_error_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_system_error_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_system_error_t * self = (fd_system_error_t *)mem;
-  fd_system_error_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_system_error_t);
-  void * * alloc_mem = &alloc_region;
-  fd_system_error_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_system_error_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_system_error_global_t * self = (fd_system_error_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_system_error_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_system_error_inner_new( fd_system_error_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -17608,28 +16271,6 @@ void fd_stake_authorized_decode_inner( void * struct_mem, void * * alloc_mem, fd
   fd_pubkey_decode_inner( &self->staker, alloc_mem, ctx );
   fd_pubkey_decode_inner( &self->withdrawer, alloc_mem, ctx );
 }
-void * fd_stake_authorized_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_authorized_global_t * self = (fd_stake_authorized_global_t *)mem;
-  fd_stake_authorized_new( (fd_stake_authorized_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_stake_authorized_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_stake_authorized_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_stake_authorized_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_authorized_global_t * self = (fd_stake_authorized_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->staker, alloc_mem, ctx );
-  fd_pubkey_decode_inner_global( &self->withdrawer, alloc_mem, ctx );
-}
-int fd_stake_authorized_convert_global_to_local( void const * global_self, fd_stake_authorized_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stake_authorized_global_t const * mem = (fd_stake_authorized_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->staker, &self->staker, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_pubkey_convert_global_to_local( &mem->withdrawer, &self->withdrawer, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_stake_authorized_new(fd_stake_authorized_t * self) {
   fd_memset( self, 0, sizeof(fd_stake_authorized_t) );
   fd_pubkey_new( &self->staker );
@@ -17699,29 +16340,6 @@ void fd_stake_lockup_decode_inner( void * struct_mem, void * * alloc_mem, fd_bin
   fd_bincode_uint64_decode_unsafe( &self->epoch, ctx );
   fd_pubkey_decode_inner( &self->custodian, alloc_mem, ctx );
 }
-void * fd_stake_lockup_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_lockup_global_t * self = (fd_stake_lockup_global_t *)mem;
-  fd_stake_lockup_new( (fd_stake_lockup_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_stake_lockup_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_stake_lockup_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_stake_lockup_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_lockup_global_t * self = (fd_stake_lockup_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( (ulong *) &self->unix_timestamp, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->epoch, ctx );
-  fd_pubkey_decode_inner_global( &self->custodian, alloc_mem, ctx );
-}
-int fd_stake_lockup_convert_global_to_local( void const * global_self, fd_stake_lockup_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stake_lockup_global_t const * mem = (fd_stake_lockup_global_t const *)global_self;
-  self->unix_timestamp = mem->unix_timestamp;
-  self->epoch = mem->epoch;
-  err = fd_pubkey_convert_global_to_local( &mem->custodian, &self->custodian, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_stake_lockup_new(fd_stake_lockup_t * self) {
   fd_memset( self, 0, sizeof(fd_stake_lockup_t) );
   fd_pubkey_new( &self->custodian );
@@ -17786,28 +16404,6 @@ void fd_stake_instruction_initialize_decode_inner( void * struct_mem, void * * a
   fd_stake_authorized_decode_inner( &self->authorized, alloc_mem, ctx );
   fd_stake_lockup_decode_inner( &self->lockup, alloc_mem, ctx );
 }
-void * fd_stake_instruction_initialize_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_instruction_initialize_global_t * self = (fd_stake_instruction_initialize_global_t *)mem;
-  fd_stake_instruction_initialize_new( (fd_stake_instruction_initialize_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_stake_instruction_initialize_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_stake_instruction_initialize_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_stake_instruction_initialize_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_instruction_initialize_global_t * self = (fd_stake_instruction_initialize_global_t *)struct_mem;
-  fd_stake_authorized_decode_inner_global( &self->authorized, alloc_mem, ctx );
-  fd_stake_lockup_decode_inner_global( &self->lockup, alloc_mem, ctx );
-}
-int fd_stake_instruction_initialize_convert_global_to_local( void const * global_self, fd_stake_instruction_initialize_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stake_instruction_initialize_global_t const * mem = (fd_stake_instruction_initialize_global_t const *)global_self;
-  err = fd_stake_authorized_convert_global_to_local( &mem->authorized, &self->authorized, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_stake_lockup_convert_global_to_local( &mem->lockup, &self->lockup, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_stake_instruction_initialize_new(fd_stake_instruction_initialize_t * self) {
   fd_memset( self, 0, sizeof(fd_stake_instruction_initialize_t) );
   fd_stake_authorized_new( &self->authorized );
@@ -17844,6 +16440,24 @@ int fd_stake_lockup_custodian_args_encode( fd_stake_lockup_custodian_args_t cons
     err = fd_bincode_bool_encode( 1, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     err = fd_pubkey_encode( self->custodian, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_stake_lockup_custodian_args_encode_global( fd_stake_lockup_custodian_args_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_stake_lockup_encode( &self->lockup, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_sol_sysvar_clock_encode( &self->clock, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->custodian_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    fd_pubkey_t * custodian = fd_wksp_laddr_fast( ctx->wksp, self->custodian_gaddr );
+    err = fd_pubkey_encode( custodian, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   } else {
     err = fd_bincode_bool_encode( 0, ctx );
@@ -17914,8 +16528,8 @@ void * fd_stake_lockup_custodian_args_decode_global( void * mem, fd_bincode_deco
 }
 void fd_stake_lockup_custodian_args_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_stake_lockup_custodian_args_global_t * self = (fd_stake_lockup_custodian_args_global_t *)struct_mem;
-  fd_stake_lockup_decode_inner_global( &self->lockup, alloc_mem, ctx );
-  fd_sol_sysvar_clock_decode_inner_global( &self->clock, alloc_mem, ctx );
+  fd_stake_lockup_decode_inner( &self->lockup, alloc_mem, ctx );
+  fd_sol_sysvar_clock_decode_inner( &self->clock, alloc_mem, ctx );
   {
     uchar o;
     fd_bincode_bool_decode_unsafe( &o, ctx );
@@ -17924,21 +16538,11 @@ void fd_stake_lockup_custodian_args_decode_inner_global( void * struct_mem, void
       self->custodian_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
       fd_pubkey_new( *alloc_mem );
       *alloc_mem = (uchar *)*alloc_mem + FD_PUBKEY_FOOTPRINT;
-      fd_pubkey_decode_inner_global( fd_wksp_laddr_fast( ctx->wksp, self->custodian_gaddr ), alloc_mem, ctx );
+      fd_pubkey_decode_inner( fd_wksp_laddr_fast( ctx->wksp, self->custodian_gaddr ), alloc_mem, ctx );
     } else {
       self->custodian_gaddr = 0UL;
     }
   }
-}
-int fd_stake_lockup_custodian_args_convert_global_to_local( void const * global_self, fd_stake_lockup_custodian_args_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stake_lockup_custodian_args_global_t const * mem = (fd_stake_lockup_custodian_args_global_t const *)global_self;
-  err = fd_stake_lockup_convert_global_to_local( &mem->lockup, &self->lockup, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_sol_sysvar_clock_convert_global_to_local( &mem->clock, &self->clock, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->custodian = fd_wksp_laddr_fast( ctx->wksp, mem->custodian_gaddr );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_stake_lockup_custodian_args_new(fd_stake_lockup_custodian_args_t * self) {
   fd_memset( self, 0, sizeof(fd_stake_lockup_custodian_args_t) );
@@ -17973,7 +16577,7 @@ ulong fd_stake_lockup_custodian_args_size( fd_stake_lockup_custodian_args_t cons
   size += fd_stake_lockup_size( &self->lockup );
   size += fd_sol_sysvar_clock_size( &self->clock );
   size += sizeof(char);
-  if( NULL !=  self->custodian ) {
+  if( NULL != self->custodian ) {
     size += fd_pubkey_size( self->custodian );
   }
   return size;
@@ -18023,35 +16627,6 @@ void fd_stake_authorize_inner_decode_inner( fd_stake_authorize_inner_t * self, v
   }
   }
 }
-void fd_stake_authorize_inner_decode_inner_global( fd_stake_authorize_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    break;
-  }
-  }
-}
-int fd_stake_authorize_convert_global_to_local_inner( fd_stake_authorize_inner_global_t const * mem, fd_stake_authorize_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_stake_authorize_convert_global_to_local( void const * global_self, fd_stake_authorize_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_authorize_global_t const * mem = (fd_stake_authorize_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_stake_authorize_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_stake_authorize_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_stake_authorize_t * self = (fd_stake_authorize_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -18064,19 +16639,6 @@ void * fd_stake_authorize_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   void * * alloc_mem = &alloc_region;
   fd_stake_authorize_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_stake_authorize_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_authorize_t * self = (fd_stake_authorize_t *)mem;
-  fd_stake_authorize_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_stake_authorize_t);
-  void * * alloc_mem = &alloc_region;
-  fd_stake_authorize_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_stake_authorize_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_authorize_global_t * self = (fd_stake_authorize_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_stake_authorize_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_stake_authorize_inner_new( fd_stake_authorize_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -18178,28 +16740,6 @@ void fd_stake_instruction_authorize_decode_inner( void * struct_mem, void * * al
   fd_pubkey_decode_inner( &self->pubkey, alloc_mem, ctx );
   fd_stake_authorize_decode_inner( &self->stake_authorize, alloc_mem, ctx );
 }
-void * fd_stake_instruction_authorize_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_instruction_authorize_global_t * self = (fd_stake_instruction_authorize_global_t *)mem;
-  fd_stake_instruction_authorize_new( (fd_stake_instruction_authorize_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_stake_instruction_authorize_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_stake_instruction_authorize_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_stake_instruction_authorize_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_instruction_authorize_global_t * self = (fd_stake_instruction_authorize_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->pubkey, alloc_mem, ctx );
-  fd_stake_authorize_decode_inner_global( &self->stake_authorize, alloc_mem, ctx );
-}
-int fd_stake_instruction_authorize_convert_global_to_local( void const * global_self, fd_stake_instruction_authorize_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stake_instruction_authorize_global_t const * mem = (fd_stake_instruction_authorize_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->pubkey, &self->pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_stake_authorize_convert_global_to_local( &mem->stake_authorize, &self->stake_authorize, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_stake_instruction_authorize_new(fd_stake_instruction_authorize_t * self) {
   fd_memset( self, 0, sizeof(fd_stake_instruction_authorize_t) );
   fd_pubkey_new( &self->pubkey );
@@ -18236,6 +16776,23 @@ int fd_authorize_with_seed_args_encode( fd_authorize_with_seed_args_t const * se
   if( FD_UNLIKELY(err) ) return err;
   if( self->authority_seed_len ) {
     err = fd_bincode_bytes_encode( self->authority_seed, self->authority_seed_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_pubkey_encode( &self->authority_owner, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_authorize_with_seed_args_encode_global( fd_authorize_with_seed_args_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_encode( &self->new_authorized_pubkey, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_stake_authorize_encode( &self->stake_authorize, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->authority_seed_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->authority_seed_len ) {
+    uchar * authority_seed_laddr = fd_wksp_laddr_fast( ctx->wksp, self->authority_seed_gaddr );
+    err = fd_bincode_bytes_encode( authority_seed_laddr, self->authority_seed_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   err = fd_pubkey_encode( &self->authority_owner, ctx );
@@ -18302,29 +16859,17 @@ void * fd_authorize_with_seed_args_decode_global( void * mem, fd_bincode_decode_
 }
 void fd_authorize_with_seed_args_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_authorize_with_seed_args_global_t * self = (fd_authorize_with_seed_args_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->new_authorized_pubkey, alloc_mem, ctx );
-  fd_stake_authorize_decode_inner_global( &self->stake_authorize, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->new_authorized_pubkey, alloc_mem, ctx );
+  fd_stake_authorize_decode_inner( &self->stake_authorize, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->authority_seed_len, ctx );
   if( self->authority_seed_len ) {
     self->authority_seed_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
     fd_bincode_bytes_decode_unsafe( *alloc_mem, self->authority_seed_len, ctx );
     *alloc_mem = (uchar *)(*alloc_mem) + self->authority_seed_len;
-  } else
+  } else {
     self->authority_seed_gaddr = 0UL;
-  fd_pubkey_decode_inner_global( &self->authority_owner, alloc_mem, ctx );
-}
-int fd_authorize_with_seed_args_convert_global_to_local( void const * global_self, fd_authorize_with_seed_args_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_authorize_with_seed_args_global_t const * mem = (fd_authorize_with_seed_args_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->new_authorized_pubkey, &self->new_authorized_pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_stake_authorize_convert_global_to_local( &mem->stake_authorize, &self->stake_authorize, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->authority_seed_len = mem->authority_seed_len;
-  self->authority_seed     = fd_wksp_laddr_fast( ctx->wksp, mem->authority_seed_gaddr );
-  err = fd_pubkey_convert_global_to_local( &mem->authority_owner, &self->authority_owner, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  }
+  fd_pubkey_decode_inner( &self->authority_owner, alloc_mem, ctx );
 }
 void fd_authorize_with_seed_args_new(fd_authorize_with_seed_args_t * self) {
   fd_memset( self, 0, sizeof(fd_authorize_with_seed_args_t) );
@@ -18372,6 +16917,21 @@ int fd_authorize_checked_with_seed_args_encode( fd_authorize_checked_with_seed_a
   if( FD_UNLIKELY(err) ) return err;
   if( self->authority_seed_len ) {
     err = fd_bincode_bytes_encode( self->authority_seed, self->authority_seed_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_pubkey_encode( &self->authority_owner, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_authorize_checked_with_seed_args_encode_global( fd_authorize_checked_with_seed_args_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_stake_authorize_encode( &self->stake_authorize, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->authority_seed_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->authority_seed_len ) {
+    uchar * authority_seed_laddr = fd_wksp_laddr_fast( ctx->wksp, self->authority_seed_gaddr );
+    err = fd_bincode_bytes_encode( authority_seed_laddr, self->authority_seed_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   err = fd_pubkey_encode( &self->authority_owner, ctx );
@@ -18435,26 +16995,16 @@ void * fd_authorize_checked_with_seed_args_decode_global( void * mem, fd_bincode
 }
 void fd_authorize_checked_with_seed_args_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_authorize_checked_with_seed_args_global_t * self = (fd_authorize_checked_with_seed_args_global_t *)struct_mem;
-  fd_stake_authorize_decode_inner_global( &self->stake_authorize, alloc_mem, ctx );
+  fd_stake_authorize_decode_inner( &self->stake_authorize, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->authority_seed_len, ctx );
   if( self->authority_seed_len ) {
     self->authority_seed_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
     fd_bincode_bytes_decode_unsafe( *alloc_mem, self->authority_seed_len, ctx );
     *alloc_mem = (uchar *)(*alloc_mem) + self->authority_seed_len;
-  } else
+  } else {
     self->authority_seed_gaddr = 0UL;
-  fd_pubkey_decode_inner_global( &self->authority_owner, alloc_mem, ctx );
-}
-int fd_authorize_checked_with_seed_args_convert_global_to_local( void const * global_self, fd_authorize_checked_with_seed_args_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_authorize_checked_with_seed_args_global_t const * mem = (fd_authorize_checked_with_seed_args_global_t const *)global_self;
-  err = fd_stake_authorize_convert_global_to_local( &mem->stake_authorize, &self->stake_authorize, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->authority_seed_len = mem->authority_seed_len;
-  self->authority_seed     = fd_wksp_laddr_fast( ctx->wksp, mem->authority_seed_gaddr );
-  err = fd_pubkey_convert_global_to_local( &mem->authority_owner, &self->authority_owner, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  }
+  fd_pubkey_decode_inner( &self->authority_owner, alloc_mem, ctx );
 }
 void fd_authorize_checked_with_seed_args_new(fd_authorize_checked_with_seed_args_t * self) {
   fd_memset( self, 0, sizeof(fd_authorize_checked_with_seed_args_t) );
@@ -18505,6 +17055,30 @@ int fd_lockup_checked_args_encode( fd_lockup_checked_args_t const * self, fd_bin
     err = fd_bincode_bool_encode( 1, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     err = fd_bincode_uint64_encode( self->epoch[0], ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_lockup_checked_args_encode_global( fd_lockup_checked_args_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  if( self->unix_timestamp_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    long * unix_timestamp = fd_wksp_laddr_fast( ctx->wksp, self->unix_timestamp_gaddr );
+    err = fd_bincode_int64_encode( unix_timestamp[0], ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  if( self->epoch_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    ulong * epoch = fd_wksp_laddr_fast( ctx->wksp, self->epoch_gaddr );
+    err = fd_bincode_uint64_encode( epoch[0], ctx );
     if( FD_UNLIKELY( err ) ) return err;
   } else {
     err = fd_bincode_bool_encode( 0, ctx );
@@ -18615,13 +17189,6 @@ void fd_lockup_checked_args_decode_inner_global( void * struct_mem, void * * all
     }
   }
 }
-int fd_lockup_checked_args_convert_global_to_local( void const * global_self, fd_lockup_checked_args_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_lockup_checked_args_global_t const * mem = (fd_lockup_checked_args_global_t const *)global_self;
-  self->unix_timestamp = fd_wksp_laddr_fast( ctx->wksp, mem->unix_timestamp_gaddr );
-  self->epoch = fd_wksp_laddr_fast( ctx->wksp, mem->epoch_gaddr );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_lockup_checked_args_new(fd_lockup_checked_args_t * self) {
   fd_memset( self, 0, sizeof(fd_lockup_checked_args_t) );
 }
@@ -18654,11 +17221,11 @@ void fd_lockup_checked_args_walk( void * w, fd_lockup_checked_args_t const * sel
 ulong fd_lockup_checked_args_size( fd_lockup_checked_args_t const * self ) {
   ulong size = 0;
   size += sizeof(char);
-  if( NULL !=  self->unix_timestamp ) {
+  if( NULL != self->unix_timestamp ) {
     size += sizeof(long);
   }
   size += sizeof(char);
-  if( NULL !=  self->epoch ) {
+  if( NULL != self->epoch ) {
     size += sizeof(ulong);
   }
   return size;
@@ -18688,6 +17255,40 @@ int fd_lockup_args_encode( fd_lockup_args_t const * self, fd_bincode_encode_ctx_
     err = fd_bincode_bool_encode( 1, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     err = fd_pubkey_encode( self->custodian, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_lockup_args_encode_global( fd_lockup_args_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  if( self->unix_timestamp_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    long * unix_timestamp = fd_wksp_laddr_fast( ctx->wksp, self->unix_timestamp_gaddr );
+    err = fd_bincode_int64_encode( unix_timestamp[0], ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  if( self->epoch_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    ulong * epoch = fd_wksp_laddr_fast( ctx->wksp, self->epoch_gaddr );
+    err = fd_bincode_uint64_encode( epoch[0], ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  if( self->custodian_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    fd_pubkey_t * custodian = fd_wksp_laddr_fast( ctx->wksp, self->custodian_gaddr );
+    err = fd_pubkey_encode( custodian, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   } else {
     err = fd_bincode_bool_encode( 0, ctx );
@@ -18828,19 +17429,11 @@ void fd_lockup_args_decode_inner_global( void * struct_mem, void * * alloc_mem, 
       self->custodian_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
       fd_pubkey_new( *alloc_mem );
       *alloc_mem = (uchar *)*alloc_mem + FD_PUBKEY_FOOTPRINT;
-      fd_pubkey_decode_inner_global( fd_wksp_laddr_fast( ctx->wksp, self->custodian_gaddr ), alloc_mem, ctx );
+      fd_pubkey_decode_inner( fd_wksp_laddr_fast( ctx->wksp, self->custodian_gaddr ), alloc_mem, ctx );
     } else {
       self->custodian_gaddr = 0UL;
     }
   }
-}
-int fd_lockup_args_convert_global_to_local( void const * global_self, fd_lockup_args_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_lockup_args_global_t const * mem = (fd_lockup_args_global_t const *)global_self;
-  self->unix_timestamp = fd_wksp_laddr_fast( ctx->wksp, mem->unix_timestamp_gaddr );
-  self->epoch = fd_wksp_laddr_fast( ctx->wksp, mem->epoch_gaddr );
-  self->custodian = fd_wksp_laddr_fast( ctx->wksp, mem->custodian_gaddr );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_lockup_args_new(fd_lockup_args_t * self) {
   fd_memset( self, 0, sizeof(fd_lockup_args_t) );
@@ -18883,15 +17476,15 @@ void fd_lockup_args_walk( void * w, fd_lockup_args_t const * self, fd_types_walk
 ulong fd_lockup_args_size( fd_lockup_args_t const * self ) {
   ulong size = 0;
   size += sizeof(char);
-  if( NULL !=  self->unix_timestamp ) {
+  if( NULL != self->unix_timestamp ) {
     size += sizeof(long);
   }
   size += sizeof(char);
-  if( NULL !=  self->epoch ) {
+  if( NULL != self->epoch ) {
     size += sizeof(ulong);
   }
   size += sizeof(char);
-  if( NULL !=  self->custodian ) {
+  if( NULL != self->custodian ) {
     size += fd_pubkey_size( self->custodian );
   }
   return size;
@@ -19121,11 +17714,11 @@ void fd_stake_instruction_inner_decode_inner( fd_stake_instruction_inner_t * sel
 void fd_stake_instruction_inner_decode_inner_global( fd_stake_instruction_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
   switch (discriminant) {
   case 0: {
-    fd_stake_instruction_initialize_decode_inner_global( &self->initialize, alloc_mem, ctx );
+    fd_stake_instruction_initialize_decode_inner( &self->initialize, alloc_mem, ctx );
     break;
   }
   case 1: {
-    fd_stake_instruction_authorize_decode_inner_global( &self->authorize, alloc_mem, ctx );
+    fd_stake_instruction_authorize_decode_inner( &self->authorize, alloc_mem, ctx );
     break;
   }
   case 2: {
@@ -19157,7 +17750,7 @@ void fd_stake_instruction_inner_decode_inner_global( fd_stake_instruction_inner_
     break;
   }
   case 10: {
-    fd_stake_authorize_decode_inner_global( &self->authorize_checked, alloc_mem, ctx );
+    fd_stake_authorize_decode_inner( &self->authorize_checked, alloc_mem, ctx );
     break;
   }
   case 11: {
@@ -19187,91 +17780,6 @@ void fd_stake_instruction_inner_decode_inner_global( fd_stake_instruction_inner_
   }
   }
 }
-int fd_stake_instruction_convert_global_to_local_inner( fd_stake_instruction_inner_global_t const * mem, fd_stake_instruction_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_stake_instruction_initialize_convert_global_to_local( &mem->initialize, &self->initialize, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 1: {
-    err = fd_stake_instruction_authorize_convert_global_to_local( &mem->authorize, &self->authorize, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 2: {
-    break;
-  }
-  case 3: {
-    self->split = mem->split;
-    break;
-  }
-  case 4: {
-    self->withdraw = mem->withdraw;
-    break;
-  }
-  case 5: {
-    break;
-  }
-  case 6: {
-    err = fd_lockup_args_convert_global_to_local( &mem->set_lockup, &self->set_lockup, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 7: {
-    break;
-  }
-  case 8: {
-    err = fd_authorize_with_seed_args_convert_global_to_local( &mem->authorize_with_seed, &self->authorize_with_seed, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 9: {
-    break;
-  }
-  case 10: {
-    err = fd_stake_authorize_convert_global_to_local( &mem->authorize_checked, &self->authorize_checked, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 11: {
-    err = fd_authorize_checked_with_seed_args_convert_global_to_local( &mem->authorize_checked_with_seed, &self->authorize_checked_with_seed, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 12: {
-    err = fd_lockup_checked_args_convert_global_to_local( &mem->set_lockup_checked, &self->set_lockup_checked, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 13: {
-    break;
-  }
-  case 14: {
-    break;
-  }
-  case 15: {
-    break;
-  }
-  case 16: {
-    self->move_stake = mem->move_stake;
-    break;
-  }
-  case 17: {
-    self->move_lamports = mem->move_lamports;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_stake_instruction_convert_global_to_local( void const * global_self, fd_stake_instruction_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_instruction_global_t const * mem = (fd_stake_instruction_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_stake_instruction_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_stake_instruction_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_stake_instruction_t * self = (fd_stake_instruction_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -19285,6 +17793,73 @@ void * fd_stake_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) 
   fd_stake_instruction_decode_inner( mem, alloc_mem, ctx );
   return self;
 }
+int fd_stake_instruction_inner_encode_global( fd_stake_instruction_inner_global_t const * self, uint discriminant, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  switch (discriminant) {
+  case 0: {
+    err = fd_stake_instruction_initialize_encode( &self->initialize, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 1: {
+    err = fd_stake_instruction_authorize_encode( &self->authorize, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 3: {
+    err = fd_bincode_uint64_encode( self->split, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 4: {
+    err = fd_bincode_uint64_encode( self->withdraw, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 6: {
+    err = fd_lockup_args_encode_global( &self->set_lockup, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 8: {
+    err = fd_authorize_with_seed_args_encode_global( &self->authorize_with_seed, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 10: {
+    err = fd_stake_authorize_encode( &self->authorize_checked, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 11: {
+    err = fd_authorize_checked_with_seed_args_encode_global( &self->authorize_checked_with_seed, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 12: {
+    err = fd_lockup_checked_args_encode_global( &self->set_lockup_checked, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 16: {
+    err = fd_bincode_uint64_encode( self->move_stake, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 17: {
+    err = fd_bincode_uint64_encode( self->move_lamports, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_stake_instruction_encode_global( fd_stake_instruction_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err = fd_bincode_uint32_encode( self->discriminant, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fd_stake_instruction_inner_encode_global( &self->inner, self->discriminant, ctx );
+}
+
 void * fd_stake_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_stake_instruction_t * self = (fd_stake_instruction_t *)mem;
   fd_stake_instruction_new( self );
@@ -19675,30 +18250,6 @@ void fd_stake_meta_decode_inner( void * struct_mem, void * * alloc_mem, fd_binco
   fd_stake_authorized_decode_inner( &self->authorized, alloc_mem, ctx );
   fd_stake_lockup_decode_inner( &self->lockup, alloc_mem, ctx );
 }
-void * fd_stake_meta_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_meta_global_t * self = (fd_stake_meta_global_t *)mem;
-  fd_stake_meta_new( (fd_stake_meta_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_stake_meta_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_stake_meta_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_stake_meta_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_meta_global_t * self = (fd_stake_meta_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->rent_exempt_reserve, ctx );
-  fd_stake_authorized_decode_inner_global( &self->authorized, alloc_mem, ctx );
-  fd_stake_lockup_decode_inner_global( &self->lockup, alloc_mem, ctx );
-}
-int fd_stake_meta_convert_global_to_local( void const * global_self, fd_stake_meta_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stake_meta_global_t const * mem = (fd_stake_meta_global_t const *)global_self;
-  self->rent_exempt_reserve = mem->rent_exempt_reserve;
-  err = fd_stake_authorized_convert_global_to_local( &mem->authorized, &self->authorized, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_stake_lockup_convert_global_to_local( &mem->lockup, &self->lockup, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_stake_meta_new(fd_stake_meta_t * self) {
   fd_memset( self, 0, sizeof(fd_stake_meta_t) );
   fd_stake_authorized_new( &self->authorized );
@@ -19760,24 +18311,6 @@ void fd_stake_flags_decode_inner( void * struct_mem, void * * alloc_mem, fd_binc
   fd_stake_flags_t * self = (fd_stake_flags_t *)struct_mem;
   fd_bincode_uint8_decode_unsafe( &self->bits, ctx );
 }
-void * fd_stake_flags_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_flags_global_t * self = (fd_stake_flags_global_t *)mem;
-  fd_stake_flags_new( (fd_stake_flags_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_stake_flags_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_stake_flags_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_stake_flags_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_flags_global_t * self = (fd_stake_flags_global_t *)struct_mem;
-  fd_bincode_uint8_decode_unsafe( &self->bits, ctx );
-}
-int fd_stake_flags_convert_global_to_local( void const * global_self, fd_stake_flags_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stake_flags_global_t const * mem = (fd_stake_flags_global_t const *)global_self;
-  self->bits = mem->bits;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_stake_flags_new(fd_stake_flags_t * self) {
   fd_memset( self, 0, sizeof(fd_stake_flags_t) );
 }
@@ -19830,25 +18363,6 @@ void * fd_stake_state_v2_initialized_decode( void * mem, fd_bincode_decode_ctx_t
 void fd_stake_state_v2_initialized_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_stake_state_v2_initialized_t * self = (fd_stake_state_v2_initialized_t *)struct_mem;
   fd_stake_meta_decode_inner( &self->meta, alloc_mem, ctx );
-}
-void * fd_stake_state_v2_initialized_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_state_v2_initialized_global_t * self = (fd_stake_state_v2_initialized_global_t *)mem;
-  fd_stake_state_v2_initialized_new( (fd_stake_state_v2_initialized_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_stake_state_v2_initialized_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_stake_state_v2_initialized_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_stake_state_v2_initialized_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_state_v2_initialized_global_t * self = (fd_stake_state_v2_initialized_global_t *)struct_mem;
-  fd_stake_meta_decode_inner_global( &self->meta, alloc_mem, ctx );
-}
-int fd_stake_state_v2_initialized_convert_global_to_local( void const * global_self, fd_stake_state_v2_initialized_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stake_state_v2_initialized_global_t const * mem = (fd_stake_state_v2_initialized_global_t const *)global_self;
-  err = fd_stake_meta_convert_global_to_local( &mem->meta, &self->meta, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_stake_state_v2_initialized_new(fd_stake_state_v2_initialized_t * self) {
   fd_memset( self, 0, sizeof(fd_stake_state_v2_initialized_t) );
@@ -19914,31 +18428,6 @@ void fd_stake_state_v2_stake_decode_inner( void * struct_mem, void * * alloc_mem
   fd_stake_meta_decode_inner( &self->meta, alloc_mem, ctx );
   fd_stake_decode_inner( &self->stake, alloc_mem, ctx );
   fd_stake_flags_decode_inner( &self->stake_flags, alloc_mem, ctx );
-}
-void * fd_stake_state_v2_stake_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_state_v2_stake_global_t * self = (fd_stake_state_v2_stake_global_t *)mem;
-  fd_stake_state_v2_stake_new( (fd_stake_state_v2_stake_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_stake_state_v2_stake_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_stake_state_v2_stake_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_stake_state_v2_stake_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_state_v2_stake_global_t * self = (fd_stake_state_v2_stake_global_t *)struct_mem;
-  fd_stake_meta_decode_inner_global( &self->meta, alloc_mem, ctx );
-  fd_stake_decode_inner_global( &self->stake, alloc_mem, ctx );
-  fd_stake_flags_decode_inner_global( &self->stake_flags, alloc_mem, ctx );
-}
-int fd_stake_state_v2_stake_convert_global_to_local( void const * global_self, fd_stake_state_v2_stake_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_stake_state_v2_stake_global_t const * mem = (fd_stake_state_v2_stake_global_t const *)global_self;
-  err = fd_stake_meta_convert_global_to_local( &mem->meta, &self->meta, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_stake_convert_global_to_local( &mem->stake, &self->stake, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_stake_flags_convert_global_to_local( &mem->stake_flags, &self->stake_flags, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_stake_state_v2_stake_new(fd_stake_state_v2_stake_t * self) {
   fd_memset( self, 0, sizeof(fd_stake_state_v2_stake_t) );
@@ -20038,53 +18527,6 @@ void fd_stake_state_v2_inner_decode_inner( fd_stake_state_v2_inner_t * self, voi
   }
   }
 }
-void fd_stake_state_v2_inner_decode_inner_global( fd_stake_state_v2_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    fd_stake_state_v2_initialized_decode_inner_global( &self->initialized, alloc_mem, ctx );
-    break;
-  }
-  case 2: {
-    fd_stake_state_v2_stake_decode_inner_global( &self->stake, alloc_mem, ctx );
-    break;
-  }
-  case 3: {
-    break;
-  }
-  }
-}
-int fd_stake_state_v2_convert_global_to_local_inner( fd_stake_state_v2_inner_global_t const * mem, fd_stake_state_v2_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    err = fd_stake_state_v2_initialized_convert_global_to_local( &mem->initialized, &self->initialized, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 2: {
-    err = fd_stake_state_v2_stake_convert_global_to_local( &mem->stake, &self->stake, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 3: {
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_stake_state_v2_convert_global_to_local( void const * global_self, fd_stake_state_v2_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_state_v2_global_t const * mem = (fd_stake_state_v2_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_stake_state_v2_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_stake_state_v2_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_stake_state_v2_t * self = (fd_stake_state_v2_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -20097,19 +18539,6 @@ void * fd_stake_state_v2_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   void * * alloc_mem = &alloc_region;
   fd_stake_state_v2_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_stake_state_v2_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_state_v2_t * self = (fd_stake_state_v2_t *)mem;
-  fd_stake_state_v2_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_stake_state_v2_t);
-  void * * alloc_mem = &alloc_region;
-  fd_stake_state_v2_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_stake_state_v2_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_stake_state_v2_global_t * self = (fd_stake_state_v2_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_stake_state_v2_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_stake_state_v2_inner_new( fd_stake_state_v2_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -20263,31 +18692,6 @@ void fd_nonce_data_decode_inner( void * struct_mem, void * * alloc_mem, fd_binco
   fd_hash_decode_inner( &self->durable_nonce, alloc_mem, ctx );
   fd_fee_calculator_decode_inner( &self->fee_calculator, alloc_mem, ctx );
 }
-void * fd_nonce_data_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_nonce_data_global_t * self = (fd_nonce_data_global_t *)mem;
-  fd_nonce_data_new( (fd_nonce_data_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_nonce_data_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_nonce_data_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_nonce_data_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_nonce_data_global_t * self = (fd_nonce_data_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->authority, alloc_mem, ctx );
-  fd_hash_decode_inner_global( &self->durable_nonce, alloc_mem, ctx );
-  fd_fee_calculator_decode_inner_global( &self->fee_calculator, alloc_mem, ctx );
-}
-int fd_nonce_data_convert_global_to_local( void const * global_self, fd_nonce_data_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_nonce_data_global_t const * mem = (fd_nonce_data_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->authority, &self->authority, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_hash_convert_global_to_local( &mem->durable_nonce, &self->durable_nonce, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_fee_calculator_convert_global_to_local( &mem->fee_calculator, &self->fee_calculator, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_nonce_data_new(fd_nonce_data_t * self) {
   fd_memset( self, 0, sizeof(fd_nonce_data_t) );
   fd_pubkey_new( &self->authority );
@@ -20365,38 +18769,6 @@ void fd_nonce_state_inner_decode_inner( fd_nonce_state_inner_t * self, void * * 
   }
   }
 }
-void fd_nonce_state_inner_decode_inner_global( fd_nonce_state_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    fd_nonce_data_decode_inner_global( &self->initialized, alloc_mem, ctx );
-    break;
-  }
-  }
-}
-int fd_nonce_state_convert_global_to_local_inner( fd_nonce_state_inner_global_t const * mem, fd_nonce_state_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    err = fd_nonce_data_convert_global_to_local( &mem->initialized, &self->initialized, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_nonce_state_convert_global_to_local( void const * global_self, fd_nonce_state_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_nonce_state_global_t const * mem = (fd_nonce_state_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_nonce_state_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_nonce_state_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_nonce_state_t * self = (fd_nonce_state_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -20409,19 +18781,6 @@ void * fd_nonce_state_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   void * * alloc_mem = &alloc_region;
   fd_nonce_state_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_nonce_state_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_nonce_state_t * self = (fd_nonce_state_t *)mem;
-  fd_nonce_state_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_nonce_state_t);
-  void * * alloc_mem = &alloc_region;
-  fd_nonce_state_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_nonce_state_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_nonce_state_global_t * self = (fd_nonce_state_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_nonce_state_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_nonce_state_inner_new( fd_nonce_state_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -20553,41 +18912,6 @@ void fd_nonce_state_versions_inner_decode_inner( fd_nonce_state_versions_inner_t
   }
   }
 }
-void fd_nonce_state_versions_inner_decode_inner_global( fd_nonce_state_versions_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    fd_nonce_state_decode_inner_global( &self->legacy, alloc_mem, ctx );
-    break;
-  }
-  case 1: {
-    fd_nonce_state_decode_inner_global( &self->current, alloc_mem, ctx );
-    break;
-  }
-  }
-}
-int fd_nonce_state_versions_convert_global_to_local_inner( fd_nonce_state_versions_inner_global_t const * mem, fd_nonce_state_versions_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_nonce_state_convert_global_to_local( &mem->legacy, &self->legacy, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 1: {
-    err = fd_nonce_state_convert_global_to_local( &mem->current, &self->current, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_nonce_state_versions_convert_global_to_local( void const * global_self, fd_nonce_state_versions_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_nonce_state_versions_global_t const * mem = (fd_nonce_state_versions_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_nonce_state_versions_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_nonce_state_versions_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_nonce_state_versions_t * self = (fd_nonce_state_versions_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -20600,19 +18924,6 @@ void * fd_nonce_state_versions_decode( void * mem, fd_bincode_decode_ctx_t * ctx
   void * * alloc_mem = &alloc_region;
   fd_nonce_state_versions_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_nonce_state_versions_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_nonce_state_versions_t * self = (fd_nonce_state_versions_t *)mem;
-  fd_nonce_state_versions_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_nonce_state_versions_t);
-  void * * alloc_mem = &alloc_region;
-  fd_nonce_state_versions_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_nonce_state_versions_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_nonce_state_versions_global_t * self = (fd_nonce_state_versions_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_nonce_state_versions_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_nonce_state_versions_inner_new( fd_nonce_state_versions_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -20747,26 +19058,6 @@ void fd_compute_budget_program_instruction_request_units_deprecated_decode_inner
   fd_bincode_uint32_decode_unsafe( &self->units, ctx );
   fd_bincode_uint32_decode_unsafe( &self->additional_fee, ctx );
 }
-void * fd_compute_budget_program_instruction_request_units_deprecated_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_compute_budget_program_instruction_request_units_deprecated_global_t * self = (fd_compute_budget_program_instruction_request_units_deprecated_global_t *)mem;
-  fd_compute_budget_program_instruction_request_units_deprecated_new( (fd_compute_budget_program_instruction_request_units_deprecated_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_compute_budget_program_instruction_request_units_deprecated_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_compute_budget_program_instruction_request_units_deprecated_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_compute_budget_program_instruction_request_units_deprecated_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_compute_budget_program_instruction_request_units_deprecated_global_t * self = (fd_compute_budget_program_instruction_request_units_deprecated_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->units, ctx );
-  fd_bincode_uint32_decode_unsafe( &self->additional_fee, ctx );
-}
-int fd_compute_budget_program_instruction_request_units_deprecated_convert_global_to_local( void const * global_self, fd_compute_budget_program_instruction_request_units_deprecated_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_compute_budget_program_instruction_request_units_deprecated_global_t const * mem = (fd_compute_budget_program_instruction_request_units_deprecated_global_t const *)global_self;
-  self->units = mem->units;
-  self->additional_fee = mem->additional_fee;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_compute_budget_program_instruction_request_units_deprecated_new(fd_compute_budget_program_instruction_request_units_deprecated_t * self) {
   fd_memset( self, 0, sizeof(fd_compute_budget_program_instruction_request_units_deprecated_t) );
 }
@@ -20875,64 +19166,6 @@ void fd_compute_budget_program_instruction_inner_decode_inner( fd_compute_budget
   }
   }
 }
-void fd_compute_budget_program_instruction_inner_decode_inner_global( fd_compute_budget_program_instruction_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    fd_compute_budget_program_instruction_request_units_deprecated_decode_inner_global( &self->request_units_deprecated, alloc_mem, ctx );
-    break;
-  }
-  case 1: {
-    fd_bincode_uint32_decode_unsafe( &self->request_heap_frame, ctx );
-    break;
-  }
-  case 2: {
-    fd_bincode_uint32_decode_unsafe( &self->set_compute_unit_limit, ctx );
-    break;
-  }
-  case 3: {
-    fd_bincode_uint64_decode_unsafe( &self->set_compute_unit_price, ctx );
-    break;
-  }
-  case 4: {
-    fd_bincode_uint32_decode_unsafe( &self->set_loaded_accounts_data_size_limit, ctx );
-    break;
-  }
-  }
-}
-int fd_compute_budget_program_instruction_convert_global_to_local_inner( fd_compute_budget_program_instruction_inner_global_t const * mem, fd_compute_budget_program_instruction_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_compute_budget_program_instruction_request_units_deprecated_convert_global_to_local( &mem->request_units_deprecated, &self->request_units_deprecated, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 1: {
-    self->request_heap_frame = mem->request_heap_frame;
-    break;
-  }
-  case 2: {
-    self->set_compute_unit_limit = mem->set_compute_unit_limit;
-    break;
-  }
-  case 3: {
-    self->set_compute_unit_price = mem->set_compute_unit_price;
-    break;
-  }
-  case 4: {
-    self->set_loaded_accounts_data_size_limit = mem->set_loaded_accounts_data_size_limit;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_compute_budget_program_instruction_convert_global_to_local( void const * global_self, fd_compute_budget_program_instruction_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_compute_budget_program_instruction_global_t const * mem = (fd_compute_budget_program_instruction_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_compute_budget_program_instruction_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_compute_budget_program_instruction_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_compute_budget_program_instruction_t * self = (fd_compute_budget_program_instruction_t *)struct_mem;
   ushort tmp = 0;
@@ -20947,21 +19180,6 @@ void * fd_compute_budget_program_instruction_decode( void * mem, fd_bincode_deco
   void * * alloc_mem = &alloc_region;
   fd_compute_budget_program_instruction_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_compute_budget_program_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_compute_budget_program_instruction_t * self = (fd_compute_budget_program_instruction_t *)mem;
-  fd_compute_budget_program_instruction_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_compute_budget_program_instruction_t);
-  void * * alloc_mem = &alloc_region;
-  fd_compute_budget_program_instruction_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_compute_budget_program_instruction_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_compute_budget_program_instruction_global_t * self = (fd_compute_budget_program_instruction_global_t *)struct_mem;
-  ushort tmp = 0;
-  fd_bincode_compact_u16_decode_unsafe( &tmp, ctx );
-  self->discriminant = tmp;
-  fd_compute_budget_program_instruction_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_compute_budget_program_instruction_inner_new( fd_compute_budget_program_instruction_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -21174,36 +19392,6 @@ void fd_config_keys_decode_inner( void * struct_mem, void * * alloc_mem, fd_binc
   } else
     self->keys = NULL;
 }
-void * fd_config_keys_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_config_keys_global_t * self = (fd_config_keys_global_t *)mem;
-  fd_config_keys_new( (fd_config_keys_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_config_keys_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_config_keys_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_config_keys_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_config_keys_global_t * self = (fd_config_keys_global_t *)struct_mem;
-  fd_bincode_compact_u16_decode_unsafe( &self->keys_len, ctx );
-  if( self->keys_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_CONFIG_KEYS_PAIR_ALIGN );
-    self->keys_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_CONFIG_KEYS_PAIR_FOOTPRINT*self->keys_len;
-    for( ulong i=0; i < self->keys_len; i++ ) {
-      fd_config_keys_pair_new( (fd_config_keys_pair_t *)(cur_mem + FD_CONFIG_KEYS_PAIR_FOOTPRINT * i) );
-      fd_config_keys_pair_decode_inner_global( cur_mem + FD_CONFIG_KEYS_PAIR_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->keys_gaddr = 0UL;
-}
-int fd_config_keys_convert_global_to_local( void const * global_self, fd_config_keys_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_config_keys_global_t const * mem = (fd_config_keys_global_t const *)global_self;
-  self->keys_len = mem->keys_len;
-  self->keys     = fd_wksp_laddr_fast( ctx->wksp, mem->keys_gaddr );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_config_keys_new(fd_config_keys_t * self) {
   fd_memset( self, 0, sizeof(fd_config_keys_t) );
 }
@@ -21293,33 +19481,6 @@ void fd_bpf_loader_program_instruction_write_decode_inner( void * struct_mem, vo
   } else
     self->bytes = NULL;
 }
-void * fd_bpf_loader_program_instruction_write_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_loader_program_instruction_write_global_t * self = (fd_bpf_loader_program_instruction_write_global_t *)mem;
-  fd_bpf_loader_program_instruction_write_new( (fd_bpf_loader_program_instruction_write_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_bpf_loader_program_instruction_write_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_bpf_loader_program_instruction_write_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_bpf_loader_program_instruction_write_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_loader_program_instruction_write_global_t * self = (fd_bpf_loader_program_instruction_write_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->offset, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->bytes_len, ctx );
-  if( self->bytes_len ) {
-    self->bytes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    fd_bincode_bytes_decode_unsafe( *alloc_mem, self->bytes_len, ctx );
-    *alloc_mem = (uchar *)(*alloc_mem) + self->bytes_len;
-  } else
-    self->bytes_gaddr = 0UL;
-}
-int fd_bpf_loader_program_instruction_write_convert_global_to_local( void const * global_self, fd_bpf_loader_program_instruction_write_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_bpf_loader_program_instruction_write_global_t const * mem = (fd_bpf_loader_program_instruction_write_global_t const *)global_self;
-  self->offset = mem->offset;
-  self->bytes_len = mem->bytes_len;
-  self->bytes     = fd_wksp_laddr_fast( ctx->wksp, mem->bytes_gaddr );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_bpf_loader_program_instruction_write_new(fd_bpf_loader_program_instruction_write_t * self) {
   fd_memset( self, 0, sizeof(fd_bpf_loader_program_instruction_write_t) );
 }
@@ -21395,38 +19556,6 @@ void fd_bpf_loader_program_instruction_inner_decode_inner( fd_bpf_loader_program
   }
   }
 }
-void fd_bpf_loader_program_instruction_inner_decode_inner_global( fd_bpf_loader_program_instruction_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    fd_bpf_loader_program_instruction_write_decode_inner_global( &self->write, alloc_mem, ctx );
-    break;
-  }
-  case 1: {
-    break;
-  }
-  }
-}
-int fd_bpf_loader_program_instruction_convert_global_to_local_inner( fd_bpf_loader_program_instruction_inner_global_t const * mem, fd_bpf_loader_program_instruction_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_bpf_loader_program_instruction_write_convert_global_to_local( &mem->write, &self->write, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 1: {
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_bpf_loader_program_instruction_convert_global_to_local( void const * global_self, fd_bpf_loader_program_instruction_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_loader_program_instruction_global_t const * mem = (fd_bpf_loader_program_instruction_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_bpf_loader_program_instruction_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_bpf_loader_program_instruction_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_bpf_loader_program_instruction_t * self = (fd_bpf_loader_program_instruction_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -21439,19 +19568,6 @@ void * fd_bpf_loader_program_instruction_decode( void * mem, fd_bincode_decode_c
   void * * alloc_mem = &alloc_region;
   fd_bpf_loader_program_instruction_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_bpf_loader_program_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_loader_program_instruction_t * self = (fd_bpf_loader_program_instruction_t *)mem;
-  fd_bpf_loader_program_instruction_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_bpf_loader_program_instruction_t);
-  void * * alloc_mem = &alloc_region;
-  fd_bpf_loader_program_instruction_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_bpf_loader_program_instruction_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_loader_program_instruction_global_t * self = (fd_bpf_loader_program_instruction_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_bpf_loader_program_instruction_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_bpf_loader_program_instruction_inner_new( fd_bpf_loader_program_instruction_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -21587,33 +19703,6 @@ void fd_loader_v4_program_instruction_write_decode_inner( void * struct_mem, voi
   } else
     self->bytes = NULL;
 }
-void * fd_loader_v4_program_instruction_write_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_loader_v4_program_instruction_write_global_t * self = (fd_loader_v4_program_instruction_write_global_t *)mem;
-  fd_loader_v4_program_instruction_write_new( (fd_loader_v4_program_instruction_write_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_loader_v4_program_instruction_write_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_loader_v4_program_instruction_write_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_loader_v4_program_instruction_write_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_loader_v4_program_instruction_write_global_t * self = (fd_loader_v4_program_instruction_write_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->offset, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->bytes_len, ctx );
-  if( self->bytes_len ) {
-    self->bytes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    fd_bincode_bytes_decode_unsafe( *alloc_mem, self->bytes_len, ctx );
-    *alloc_mem = (uchar *)(*alloc_mem) + self->bytes_len;
-  } else
-    self->bytes_gaddr = 0UL;
-}
-int fd_loader_v4_program_instruction_write_convert_global_to_local( void const * global_self, fd_loader_v4_program_instruction_write_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_loader_v4_program_instruction_write_global_t const * mem = (fd_loader_v4_program_instruction_write_global_t const *)global_self;
-  self->offset = mem->offset;
-  self->bytes_len = mem->bytes_len;
-  self->bytes     = fd_wksp_laddr_fast( ctx->wksp, mem->bytes_gaddr );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_loader_v4_program_instruction_write_new(fd_loader_v4_program_instruction_write_t * self) {
   fd_memset( self, 0, sizeof(fd_loader_v4_program_instruction_write_t) );
 }
@@ -21674,24 +19763,6 @@ void * fd_loader_v4_program_instruction_truncate_decode( void * mem, fd_bincode_
 void fd_loader_v4_program_instruction_truncate_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_loader_v4_program_instruction_truncate_t * self = (fd_loader_v4_program_instruction_truncate_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->new_size, ctx );
-}
-void * fd_loader_v4_program_instruction_truncate_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_loader_v4_program_instruction_truncate_global_t * self = (fd_loader_v4_program_instruction_truncate_global_t *)mem;
-  fd_loader_v4_program_instruction_truncate_new( (fd_loader_v4_program_instruction_truncate_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_loader_v4_program_instruction_truncate_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_loader_v4_program_instruction_truncate_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_loader_v4_program_instruction_truncate_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_loader_v4_program_instruction_truncate_global_t * self = (fd_loader_v4_program_instruction_truncate_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->new_size, ctx );
-}
-int fd_loader_v4_program_instruction_truncate_convert_global_to_local( void const * global_self, fd_loader_v4_program_instruction_truncate_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_loader_v4_program_instruction_truncate_global_t const * mem = (fd_loader_v4_program_instruction_truncate_global_t const *)global_self;
-  self->new_size = mem->new_size;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_loader_v4_program_instruction_truncate_new(fd_loader_v4_program_instruction_truncate_t * self) {
   fd_memset( self, 0, sizeof(fd_loader_v4_program_instruction_truncate_t) );
@@ -21799,65 +19870,6 @@ void fd_loader_v4_program_instruction_inner_decode_inner( fd_loader_v4_program_i
   }
   }
 }
-void fd_loader_v4_program_instruction_inner_decode_inner_global( fd_loader_v4_program_instruction_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    fd_loader_v4_program_instruction_write_decode_inner_global( &self->write, alloc_mem, ctx );
-    break;
-  }
-  case 1: {
-    fd_loader_v4_program_instruction_truncate_decode_inner_global( &self->truncate, alloc_mem, ctx );
-    break;
-  }
-  case 2: {
-    break;
-  }
-  case 3: {
-    break;
-  }
-  case 4: {
-    break;
-  }
-  case 5: {
-    break;
-  }
-  }
-}
-int fd_loader_v4_program_instruction_convert_global_to_local_inner( fd_loader_v4_program_instruction_inner_global_t const * mem, fd_loader_v4_program_instruction_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_loader_v4_program_instruction_write_convert_global_to_local( &mem->write, &self->write, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 1: {
-    err = fd_loader_v4_program_instruction_truncate_convert_global_to_local( &mem->truncate, &self->truncate, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 2: {
-    break;
-  }
-  case 3: {
-    break;
-  }
-  case 4: {
-    break;
-  }
-  case 5: {
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_loader_v4_program_instruction_convert_global_to_local( void const * global_self, fd_loader_v4_program_instruction_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_loader_v4_program_instruction_global_t const * mem = (fd_loader_v4_program_instruction_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_loader_v4_program_instruction_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_loader_v4_program_instruction_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_loader_v4_program_instruction_t * self = (fd_loader_v4_program_instruction_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -21870,19 +19882,6 @@ void * fd_loader_v4_program_instruction_decode( void * mem, fd_bincode_decode_ct
   void * * alloc_mem = &alloc_region;
   fd_loader_v4_program_instruction_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_loader_v4_program_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_loader_v4_program_instruction_t * self = (fd_loader_v4_program_instruction_t *)mem;
-  fd_loader_v4_program_instruction_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_loader_v4_program_instruction_t);
-  void * * alloc_mem = &alloc_region;
-  fd_loader_v4_program_instruction_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_loader_v4_program_instruction_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_loader_v4_program_instruction_global_t * self = (fd_loader_v4_program_instruction_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_loader_v4_program_instruction_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_loader_v4_program_instruction_inner_new( fd_loader_v4_program_instruction_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -22061,33 +20060,6 @@ void fd_bpf_upgradeable_loader_program_instruction_write_decode_inner( void * st
   } else
     self->bytes = NULL;
 }
-void * fd_bpf_upgradeable_loader_program_instruction_write_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_upgradeable_loader_program_instruction_write_global_t * self = (fd_bpf_upgradeable_loader_program_instruction_write_global_t *)mem;
-  fd_bpf_upgradeable_loader_program_instruction_write_new( (fd_bpf_upgradeable_loader_program_instruction_write_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_bpf_upgradeable_loader_program_instruction_write_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_bpf_upgradeable_loader_program_instruction_write_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_bpf_upgradeable_loader_program_instruction_write_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_upgradeable_loader_program_instruction_write_global_t * self = (fd_bpf_upgradeable_loader_program_instruction_write_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->offset, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->bytes_len, ctx );
-  if( self->bytes_len ) {
-    self->bytes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    fd_bincode_bytes_decode_unsafe( *alloc_mem, self->bytes_len, ctx );
-    *alloc_mem = (uchar *)(*alloc_mem) + self->bytes_len;
-  } else
-    self->bytes_gaddr = 0UL;
-}
-int fd_bpf_upgradeable_loader_program_instruction_write_convert_global_to_local( void const * global_self, fd_bpf_upgradeable_loader_program_instruction_write_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_bpf_upgradeable_loader_program_instruction_write_global_t const * mem = (fd_bpf_upgradeable_loader_program_instruction_write_global_t const *)global_self;
-  self->offset = mem->offset;
-  self->bytes_len = mem->bytes_len;
-  self->bytes     = fd_wksp_laddr_fast( ctx->wksp, mem->bytes_gaddr );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_bpf_upgradeable_loader_program_instruction_write_new(fd_bpf_upgradeable_loader_program_instruction_write_t * self) {
   fd_memset( self, 0, sizeof(fd_bpf_upgradeable_loader_program_instruction_write_t) );
 }
@@ -22149,24 +20121,6 @@ void fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_deco
   fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t * self = (fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t *)struct_mem;
   fd_bincode_uint64_decode_unsafe( &self->max_data_len, ctx );
 }
-void * fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_global_t * self = (fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_global_t *)mem;
-  fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_new( (fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_global_t * self = (fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->max_data_len, ctx );
-}
-int fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_convert_global_to_local( void const * global_self, fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_global_t const * mem = (fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_global_t const *)global_self;
-  self->max_data_len = mem->max_data_len;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_new(fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t * self) {
   fd_memset( self, 0, sizeof(fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t) );
 }
@@ -22219,24 +20173,6 @@ void * fd_bpf_upgradeable_loader_program_instruction_extend_program_decode( void
 void fd_bpf_upgradeable_loader_program_instruction_extend_program_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_bpf_upgradeable_loader_program_instruction_extend_program_t * self = (fd_bpf_upgradeable_loader_program_instruction_extend_program_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->additional_bytes, ctx );
-}
-void * fd_bpf_upgradeable_loader_program_instruction_extend_program_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_upgradeable_loader_program_instruction_extend_program_global_t * self = (fd_bpf_upgradeable_loader_program_instruction_extend_program_global_t *)mem;
-  fd_bpf_upgradeable_loader_program_instruction_extend_program_new( (fd_bpf_upgradeable_loader_program_instruction_extend_program_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_bpf_upgradeable_loader_program_instruction_extend_program_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_bpf_upgradeable_loader_program_instruction_extend_program_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_bpf_upgradeable_loader_program_instruction_extend_program_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_upgradeable_loader_program_instruction_extend_program_global_t * self = (fd_bpf_upgradeable_loader_program_instruction_extend_program_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->additional_bytes, ctx );
-}
-int fd_bpf_upgradeable_loader_program_instruction_extend_program_convert_global_to_local( void const * global_self, fd_bpf_upgradeable_loader_program_instruction_extend_program_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_bpf_upgradeable_loader_program_instruction_extend_program_global_t const * mem = (fd_bpf_upgradeable_loader_program_instruction_extend_program_global_t const *)global_self;
-  self->additional_bytes = mem->additional_bytes;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_bpf_upgradeable_loader_program_instruction_extend_program_new(fd_bpf_upgradeable_loader_program_instruction_extend_program_t * self) {
   fd_memset( self, 0, sizeof(fd_bpf_upgradeable_loader_program_instruction_extend_program_t) );
@@ -22365,80 +20301,6 @@ void fd_bpf_upgradeable_loader_program_instruction_inner_decode_inner( fd_bpf_up
   }
   }
 }
-void fd_bpf_upgradeable_loader_program_instruction_inner_decode_inner_global( fd_bpf_upgradeable_loader_program_instruction_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    fd_bpf_upgradeable_loader_program_instruction_write_decode_inner_global( &self->write, alloc_mem, ctx );
-    break;
-  }
-  case 2: {
-    fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_decode_inner_global( &self->deploy_with_max_data_len, alloc_mem, ctx );
-    break;
-  }
-  case 3: {
-    break;
-  }
-  case 4: {
-    break;
-  }
-  case 5: {
-    break;
-  }
-  case 6: {
-    fd_bpf_upgradeable_loader_program_instruction_extend_program_decode_inner_global( &self->extend_program, alloc_mem, ctx );
-    break;
-  }
-  case 7: {
-    break;
-  }
-  }
-}
-int fd_bpf_upgradeable_loader_program_instruction_convert_global_to_local_inner( fd_bpf_upgradeable_loader_program_instruction_inner_global_t const * mem, fd_bpf_upgradeable_loader_program_instruction_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    err = fd_bpf_upgradeable_loader_program_instruction_write_convert_global_to_local( &mem->write, &self->write, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 2: {
-    err = fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_convert_global_to_local( &mem->deploy_with_max_data_len, &self->deploy_with_max_data_len, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 3: {
-    break;
-  }
-  case 4: {
-    break;
-  }
-  case 5: {
-    break;
-  }
-  case 6: {
-    err = fd_bpf_upgradeable_loader_program_instruction_extend_program_convert_global_to_local( &mem->extend_program, &self->extend_program, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 7: {
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_bpf_upgradeable_loader_program_instruction_convert_global_to_local( void const * global_self, fd_bpf_upgradeable_loader_program_instruction_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_upgradeable_loader_program_instruction_global_t const * mem = (fd_bpf_upgradeable_loader_program_instruction_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_bpf_upgradeable_loader_program_instruction_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_bpf_upgradeable_loader_program_instruction_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_bpf_upgradeable_loader_program_instruction_t * self = (fd_bpf_upgradeable_loader_program_instruction_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -22451,19 +20313,6 @@ void * fd_bpf_upgradeable_loader_program_instruction_decode( void * mem, fd_binc
   void * * alloc_mem = &alloc_region;
   fd_bpf_upgradeable_loader_program_instruction_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_bpf_upgradeable_loader_program_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_upgradeable_loader_program_instruction_t * self = (fd_bpf_upgradeable_loader_program_instruction_t *)mem;
-  fd_bpf_upgradeable_loader_program_instruction_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_bpf_upgradeable_loader_program_instruction_t);
-  void * * alloc_mem = &alloc_region;
-  fd_bpf_upgradeable_loader_program_instruction_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_bpf_upgradeable_loader_program_instruction_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_upgradeable_loader_program_instruction_global_t * self = (fd_bpf_upgradeable_loader_program_instruction_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_bpf_upgradeable_loader_program_instruction_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_bpf_upgradeable_loader_program_instruction_inner_new( fd_bpf_upgradeable_loader_program_instruction_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -22630,6 +20479,20 @@ int fd_bpf_upgradeable_loader_state_buffer_encode( fd_bpf_upgradeable_loader_sta
   }
   return FD_BINCODE_SUCCESS;
 }
+int fd_bpf_upgradeable_loader_state_buffer_encode_global( fd_bpf_upgradeable_loader_state_buffer_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  if( self->authority_address_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    fd_pubkey_t * authority_address = fd_wksp_laddr_fast( ctx->wksp, self->authority_address_gaddr );
+    err = fd_pubkey_encode( authority_address, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
 int fd_bpf_upgradeable_loader_state_buffer_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_bpf_upgradeable_loader_state_buffer_t);
   void const * start_data = ctx->data;
@@ -22695,17 +20558,11 @@ void fd_bpf_upgradeable_loader_state_buffer_decode_inner_global( void * struct_m
       self->authority_address_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
       fd_pubkey_new( *alloc_mem );
       *alloc_mem = (uchar *)*alloc_mem + FD_PUBKEY_FOOTPRINT;
-      fd_pubkey_decode_inner_global( fd_wksp_laddr_fast( ctx->wksp, self->authority_address_gaddr ), alloc_mem, ctx );
+      fd_pubkey_decode_inner( fd_wksp_laddr_fast( ctx->wksp, self->authority_address_gaddr ), alloc_mem, ctx );
     } else {
       self->authority_address_gaddr = 0UL;
     }
   }
-}
-int fd_bpf_upgradeable_loader_state_buffer_convert_global_to_local( void const * global_self, fd_bpf_upgradeable_loader_state_buffer_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_bpf_upgradeable_loader_state_buffer_global_t const * mem = (fd_bpf_upgradeable_loader_state_buffer_global_t const *)global_self;
-  self->authority_address = fd_wksp_laddr_fast( ctx->wksp, mem->authority_address_gaddr );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_bpf_upgradeable_loader_state_buffer_new(fd_bpf_upgradeable_loader_state_buffer_t * self) {
   fd_memset( self, 0, sizeof(fd_bpf_upgradeable_loader_state_buffer_t) );
@@ -22732,7 +20589,7 @@ void fd_bpf_upgradeable_loader_state_buffer_walk( void * w, fd_bpf_upgradeable_l
 ulong fd_bpf_upgradeable_loader_state_buffer_size( fd_bpf_upgradeable_loader_state_buffer_t const * self ) {
   ulong size = 0;
   size += sizeof(char);
-  if( NULL !=  self->authority_address ) {
+  if( NULL != self->authority_address ) {
     size += fd_pubkey_size( self->authority_address );
   }
   return size;
@@ -22771,25 +20628,6 @@ void fd_bpf_upgradeable_loader_state_program_decode_inner( void * struct_mem, vo
   fd_bpf_upgradeable_loader_state_program_t * self = (fd_bpf_upgradeable_loader_state_program_t *)struct_mem;
   fd_pubkey_decode_inner( &self->programdata_address, alloc_mem, ctx );
 }
-void * fd_bpf_upgradeable_loader_state_program_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_upgradeable_loader_state_program_global_t * self = (fd_bpf_upgradeable_loader_state_program_global_t *)mem;
-  fd_bpf_upgradeable_loader_state_program_new( (fd_bpf_upgradeable_loader_state_program_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_bpf_upgradeable_loader_state_program_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_bpf_upgradeable_loader_state_program_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_bpf_upgradeable_loader_state_program_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_upgradeable_loader_state_program_global_t * self = (fd_bpf_upgradeable_loader_state_program_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->programdata_address, alloc_mem, ctx );
-}
-int fd_bpf_upgradeable_loader_state_program_convert_global_to_local( void const * global_self, fd_bpf_upgradeable_loader_state_program_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_bpf_upgradeable_loader_state_program_global_t const * mem = (fd_bpf_upgradeable_loader_state_program_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->programdata_address, &self->programdata_address, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_bpf_upgradeable_loader_state_program_new(fd_bpf_upgradeable_loader_state_program_t * self) {
   fd_memset( self, 0, sizeof(fd_bpf_upgradeable_loader_state_program_t) );
   fd_pubkey_new( &self->programdata_address );
@@ -22820,6 +20658,22 @@ int fd_bpf_upgradeable_loader_state_program_data_encode( fd_bpf_upgradeable_load
     err = fd_bincode_bool_encode( 1, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     err = fd_pubkey_encode( self->upgrade_authority_address, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_bpf_upgradeable_loader_state_program_data_encode_global( fd_bpf_upgradeable_loader_state_program_data_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->upgrade_authority_address_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    fd_pubkey_t * upgrade_authority_address = fd_wksp_laddr_fast( ctx->wksp, self->upgrade_authority_address_gaddr );
+    err = fd_pubkey_encode( upgrade_authority_address, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   } else {
     err = fd_bincode_bool_encode( 0, ctx );
@@ -22896,18 +20750,11 @@ void fd_bpf_upgradeable_loader_state_program_data_decode_inner_global( void * st
       self->upgrade_authority_address_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
       fd_pubkey_new( *alloc_mem );
       *alloc_mem = (uchar *)*alloc_mem + FD_PUBKEY_FOOTPRINT;
-      fd_pubkey_decode_inner_global( fd_wksp_laddr_fast( ctx->wksp, self->upgrade_authority_address_gaddr ), alloc_mem, ctx );
+      fd_pubkey_decode_inner( fd_wksp_laddr_fast( ctx->wksp, self->upgrade_authority_address_gaddr ), alloc_mem, ctx );
     } else {
       self->upgrade_authority_address_gaddr = 0UL;
     }
   }
-}
-int fd_bpf_upgradeable_loader_state_program_data_convert_global_to_local( void const * global_self, fd_bpf_upgradeable_loader_state_program_data_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_bpf_upgradeable_loader_state_program_data_global_t const * mem = (fd_bpf_upgradeable_loader_state_program_data_global_t const *)global_self;
-  self->slot = mem->slot;
-  self->upgrade_authority_address = fd_wksp_laddr_fast( ctx->wksp, mem->upgrade_authority_address_gaddr );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_bpf_upgradeable_loader_state_program_data_new(fd_bpf_upgradeable_loader_state_program_data_t * self) {
   fd_memset( self, 0, sizeof(fd_bpf_upgradeable_loader_state_program_data_t) );
@@ -22936,7 +20783,7 @@ ulong fd_bpf_upgradeable_loader_state_program_data_size( fd_bpf_upgradeable_load
   ulong size = 0;
   size += sizeof(ulong);
   size += sizeof(char);
-  if( NULL !=  self->upgrade_authority_address ) {
+  if( NULL != self->upgrade_authority_address ) {
     size += fd_pubkey_size( self->upgrade_authority_address );
   }
   return size;
@@ -23023,7 +20870,7 @@ void fd_bpf_upgradeable_loader_state_inner_decode_inner_global( fd_bpf_upgradeab
     break;
   }
   case 2: {
-    fd_bpf_upgradeable_loader_state_program_decode_inner_global( &self->program, alloc_mem, ctx );
+    fd_bpf_upgradeable_loader_state_program_decode_inner( &self->program, alloc_mem, ctx );
     break;
   }
   case 3: {
@@ -23031,37 +20878,6 @@ void fd_bpf_upgradeable_loader_state_inner_decode_inner_global( fd_bpf_upgradeab
     break;
   }
   }
-}
-int fd_bpf_upgradeable_loader_state_convert_global_to_local_inner( fd_bpf_upgradeable_loader_state_inner_global_t const * mem, fd_bpf_upgradeable_loader_state_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    err = fd_bpf_upgradeable_loader_state_buffer_convert_global_to_local( &mem->buffer, &self->buffer, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 2: {
-    err = fd_bpf_upgradeable_loader_state_program_convert_global_to_local( &mem->program, &self->program, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 3: {
-    err = fd_bpf_upgradeable_loader_state_program_data_convert_global_to_local( &mem->program_data, &self->program_data, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_bpf_upgradeable_loader_state_convert_global_to_local( void const * global_self, fd_bpf_upgradeable_loader_state_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_bpf_upgradeable_loader_state_global_t const * mem = (fd_bpf_upgradeable_loader_state_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_bpf_upgradeable_loader_state_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_bpf_upgradeable_loader_state_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_bpf_upgradeable_loader_state_t * self = (fd_bpf_upgradeable_loader_state_t *)struct_mem;
@@ -23076,6 +20892,33 @@ void * fd_bpf_upgradeable_loader_state_decode( void * mem, fd_bincode_decode_ctx
   fd_bpf_upgradeable_loader_state_decode_inner( mem, alloc_mem, ctx );
   return self;
 }
+int fd_bpf_upgradeable_loader_state_inner_encode_global( fd_bpf_upgradeable_loader_state_inner_global_t const * self, uint discriminant, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  switch (discriminant) {
+  case 1: {
+    err = fd_bpf_upgradeable_loader_state_buffer_encode_global( &self->buffer, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 2: {
+    err = fd_bpf_upgradeable_loader_state_program_encode( &self->program, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 3: {
+    err = fd_bpf_upgradeable_loader_state_program_data_encode_global( &self->program_data, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_bpf_upgradeable_loader_state_encode_global( fd_bpf_upgradeable_loader_state_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err = fd_bincode_uint32_encode( self->discriminant, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fd_bpf_upgradeable_loader_state_inner_encode_global( &self->inner, self->discriminant, ctx );
+}
+
 void * fd_bpf_upgradeable_loader_state_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_bpf_upgradeable_loader_state_t * self = (fd_bpf_upgradeable_loader_state_t *)mem;
   fd_bpf_upgradeable_loader_state_new( self );
@@ -23256,29 +21099,6 @@ void fd_loader_v4_state_decode_inner( void * struct_mem, void * * alloc_mem, fd_
   fd_pubkey_decode_inner( &self->authority_address_or_next_version, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->status, ctx );
 }
-void * fd_loader_v4_state_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_loader_v4_state_global_t * self = (fd_loader_v4_state_global_t *)mem;
-  fd_loader_v4_state_new( (fd_loader_v4_state_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_loader_v4_state_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_loader_v4_state_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_loader_v4_state_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_loader_v4_state_global_t * self = (fd_loader_v4_state_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-  fd_pubkey_decode_inner_global( &self->authority_address_or_next_version, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->status, ctx );
-}
-int fd_loader_v4_state_convert_global_to_local( void const * global_self, fd_loader_v4_state_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_loader_v4_state_global_t const * mem = (fd_loader_v4_state_global_t const *)global_self;
-  self->slot = mem->slot;
-  err = fd_pubkey_convert_global_to_local( &mem->authority_address_or_next_version, &self->authority_address_or_next_version, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->status = mem->status;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_loader_v4_state_new(fd_loader_v4_state_t * self) {
   fd_memset( self, 0, sizeof(fd_loader_v4_state_t) );
   fd_pubkey_new( &self->authority_address_or_next_version );
@@ -23343,27 +21163,6 @@ void fd_frozen_hash_status_decode_inner( void * struct_mem, void * * alloc_mem, 
   fd_hash_decode_inner( &self->frozen_hash, alloc_mem, ctx );
   fd_bincode_bool_decode_unsafe( &self->is_duplicate_confirmed, ctx );
 }
-void * fd_frozen_hash_status_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_frozen_hash_status_global_t * self = (fd_frozen_hash_status_global_t *)mem;
-  fd_frozen_hash_status_new( (fd_frozen_hash_status_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_frozen_hash_status_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_frozen_hash_status_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_frozen_hash_status_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_frozen_hash_status_global_t * self = (fd_frozen_hash_status_global_t *)struct_mem;
-  fd_hash_decode_inner_global( &self->frozen_hash, alloc_mem, ctx );
-  fd_bincode_bool_decode_unsafe( &self->is_duplicate_confirmed, ctx );
-}
-int fd_frozen_hash_status_convert_global_to_local( void const * global_self, fd_frozen_hash_status_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_frozen_hash_status_global_t const * mem = (fd_frozen_hash_status_global_t const *)global_self;
-  err = fd_hash_convert_global_to_local( &mem->frozen_hash, &self->frozen_hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->is_duplicate_confirmed = mem->is_duplicate_confirmed;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_frozen_hash_status_new(fd_frozen_hash_status_t * self) {
   fd_memset( self, 0, sizeof(fd_frozen_hash_status_t) );
   fd_hash_new( &self->frozen_hash );
@@ -23426,32 +21225,6 @@ void fd_frozen_hash_versioned_inner_decode_inner( fd_frozen_hash_versioned_inner
   }
   }
 }
-void fd_frozen_hash_versioned_inner_decode_inner_global( fd_frozen_hash_versioned_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    fd_frozen_hash_status_decode_inner_global( &self->current, alloc_mem, ctx );
-    break;
-  }
-  }
-}
-int fd_frozen_hash_versioned_convert_global_to_local_inner( fd_frozen_hash_versioned_inner_global_t const * mem, fd_frozen_hash_versioned_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_frozen_hash_status_convert_global_to_local( &mem->current, &self->current, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_frozen_hash_versioned_convert_global_to_local( void const * global_self, fd_frozen_hash_versioned_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_frozen_hash_versioned_global_t const * mem = (fd_frozen_hash_versioned_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_frozen_hash_versioned_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_frozen_hash_versioned_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_frozen_hash_versioned_t * self = (fd_frozen_hash_versioned_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -23464,19 +21237,6 @@ void * fd_frozen_hash_versioned_decode( void * mem, fd_bincode_decode_ctx_t * ct
   void * * alloc_mem = &alloc_region;
   fd_frozen_hash_versioned_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_frozen_hash_versioned_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_frozen_hash_versioned_t * self = (fd_frozen_hash_versioned_t *)mem;
-  fd_frozen_hash_versioned_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_frozen_hash_versioned_t);
-  void * * alloc_mem = &alloc_region;
-  fd_frozen_hash_versioned_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_frozen_hash_versioned_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_frozen_hash_versioned_global_t * self = (fd_frozen_hash_versioned_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_frozen_hash_versioned_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_frozen_hash_versioned_inner_new( fd_frozen_hash_versioned_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -23569,6 +21329,24 @@ int fd_lookup_table_meta_encode( fd_lookup_table_meta_t const * self, fd_bincode
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
+int fd_lookup_table_meta_encode_global( fd_lookup_table_meta_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->deactivation_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->last_extended_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint8_encode( (uchar)(self->last_extended_slot_start_index), ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_bool_encode( self->has_authority, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_authority ) {
+    err = fd_pubkey_encode( &self->authority, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_uint16_encode( self->_padding, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
 int fd_lookup_table_meta_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_lookup_table_meta_t);
   void const * start_data = ctx->data;
@@ -23642,21 +21420,10 @@ void fd_lookup_table_meta_decode_inner_global( void * struct_mem, void * * alloc
     self->has_authority = !!o;
     if( o ) {
       fd_pubkey_new( &self->authority );
-      fd_pubkey_decode_inner_global( &self->authority, alloc_mem, ctx );
+      fd_pubkey_decode_inner( &self->authority, alloc_mem, ctx );
     }
   }
   fd_bincode_uint16_decode_unsafe( &self->_padding, ctx );
-}
-int fd_lookup_table_meta_convert_global_to_local( void const * global_self, fd_lookup_table_meta_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_lookup_table_meta_global_t const * mem = (fd_lookup_table_meta_global_t const *)global_self;
-  self->deactivation_slot = mem->deactivation_slot;
-  self->last_extended_slot = mem->last_extended_slot;
-  self->last_extended_slot_start_index = mem->last_extended_slot_start_index;
-  self->authority = mem->authority;
-  self->has_authority = mem->has_authority;
-  self->_padding = mem->_padding;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_lookup_table_meta_new(fd_lookup_table_meta_t * self) {
   fd_memset( self, 0, sizeof(fd_lookup_table_meta_t) );
@@ -23703,6 +21470,12 @@ int fd_address_lookup_table_encode( fd_address_lookup_table_t const * self, fd_b
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
+int fd_address_lookup_table_encode_global( fd_address_lookup_table_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_lookup_table_meta_encode_global( &self->meta, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
 int fd_address_lookup_table_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_address_lookup_table_t);
   void const * start_data = ctx->data;
@@ -23741,13 +21514,6 @@ void * fd_address_lookup_table_decode_global( void * mem, fd_bincode_decode_ctx_
 void fd_address_lookup_table_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_address_lookup_table_global_t * self = (fd_address_lookup_table_global_t *)struct_mem;
   fd_lookup_table_meta_decode_inner_global( &self->meta, alloc_mem, ctx );
-}
-int fd_address_lookup_table_convert_global_to_local( void const * global_self, fd_address_lookup_table_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_address_lookup_table_global_t const * mem = (fd_address_lookup_table_global_t const *)global_self;
-  err = fd_lookup_table_meta_convert_global_to_local( &mem->meta, &self->meta, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_address_lookup_table_new(fd_address_lookup_table_t * self) {
   fd_memset( self, 0, sizeof(fd_address_lookup_table_t) );
@@ -23829,27 +21595,6 @@ void fd_address_lookup_table_state_inner_decode_inner_global( fd_address_lookup_
   }
   }
 }
-int fd_address_lookup_table_state_convert_global_to_local_inner( fd_address_lookup_table_state_inner_global_t const * mem, fd_address_lookup_table_state_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    err = fd_address_lookup_table_convert_global_to_local( &mem->lookup_table, &self->lookup_table, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_address_lookup_table_state_convert_global_to_local( void const * global_self, fd_address_lookup_table_state_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_address_lookup_table_state_global_t const * mem = (fd_address_lookup_table_state_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_address_lookup_table_state_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_address_lookup_table_state_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_address_lookup_table_state_t * self = (fd_address_lookup_table_state_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -23863,6 +21608,23 @@ void * fd_address_lookup_table_state_decode( void * mem, fd_bincode_decode_ctx_t
   fd_address_lookup_table_state_decode_inner( mem, alloc_mem, ctx );
   return self;
 }
+int fd_address_lookup_table_state_inner_encode_global( fd_address_lookup_table_state_inner_global_t const * self, uint discriminant, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  switch (discriminant) {
+  case 1: {
+    err = fd_address_lookup_table_encode_global( &self->lookup_table, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_address_lookup_table_state_encode_global( fd_address_lookup_table_state_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err = fd_bincode_uint32_encode( self->discriminant, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fd_address_lookup_table_state_inner_encode_global( &self->inner, self->discriminant, ctx );
+}
+
 void * fd_address_lookup_table_state_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_address_lookup_table_state_t * self = (fd_address_lookup_table_state_t *)mem;
   fd_address_lookup_table_state_new( self );
@@ -24005,31 +21767,6 @@ void fd_gossip_bitvec_u8_inner_decode_inner( void * struct_mem, void * * alloc_m
   } else
     self->vec = NULL;
 }
-void * fd_gossip_bitvec_u8_inner_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_bitvec_u8_inner_global_t * self = (fd_gossip_bitvec_u8_inner_global_t *)mem;
-  fd_gossip_bitvec_u8_inner_new( (fd_gossip_bitvec_u8_inner_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_bitvec_u8_inner_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_bitvec_u8_inner_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_bitvec_u8_inner_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_bitvec_u8_inner_global_t * self = (fd_gossip_bitvec_u8_inner_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->vec_len, ctx );
-  if( self->vec_len ) {
-    self->vec_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    fd_bincode_bytes_decode_unsafe( *alloc_mem, self->vec_len, ctx );
-    *alloc_mem = (uchar *)(*alloc_mem) + self->vec_len;
-  } else
-    self->vec_gaddr = 0UL;
-}
-int fd_gossip_bitvec_u8_inner_convert_global_to_local( void const * global_self, fd_gossip_bitvec_u8_inner_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_bitvec_u8_inner_global_t const * mem = (fd_gossip_bitvec_u8_inner_global_t const *)global_self;
-  self->vec_len = mem->vec_len;
-  self->vec     = fd_wksp_laddr_fast( ctx->wksp, mem->vec_gaddr );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_gossip_bitvec_u8_inner_new(fd_gossip_bitvec_u8_inner_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_bitvec_u8_inner_t) );
 }
@@ -24057,6 +21794,18 @@ ulong fd_gossip_bitvec_u8_inner_size( fd_gossip_bitvec_u8_inner_t const * self )
 }
 
 int fd_gossip_bitvec_u8_encode( fd_gossip_bitvec_u8_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_bool_encode( self->has_bits, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_bits ) {
+    err = fd_gossip_bitvec_u8_inner_encode( &self->bits, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_uint64_encode( self->len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_gossip_bitvec_u8_encode_global( fd_gossip_bitvec_u8_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
   err = fd_bincode_bool_encode( self->has_bits, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -24129,18 +21878,10 @@ void fd_gossip_bitvec_u8_decode_inner_global( void * struct_mem, void * * alloc_
     self->has_bits = !!o;
     if( o ) {
       fd_gossip_bitvec_u8_inner_new( &self->bits );
-      fd_gossip_bitvec_u8_inner_decode_inner_global( &self->bits, alloc_mem, ctx );
+      fd_gossip_bitvec_u8_inner_decode_inner( &self->bits, alloc_mem, ctx );
     }
   }
   fd_bincode_uint64_decode_unsafe( &self->len, ctx );
-}
-int fd_gossip_bitvec_u8_convert_global_to_local( void const * global_self, fd_gossip_bitvec_u8_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_bitvec_u8_global_t const * mem = (fd_gossip_bitvec_u8_global_t const *)global_self;
-  self->bits = mem->bits;
-  self->has_bits = mem->has_bits;
-  self->len = mem->len;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_bitvec_u8_new(fd_gossip_bitvec_u8_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_bitvec_u8_t) );
@@ -24230,35 +21971,6 @@ void fd_gossip_bitvec_u64_inner_decode_inner( void * struct_mem, void * * alloc_
   } else
     self->vec = NULL;
 }
-void * fd_gossip_bitvec_u64_inner_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_bitvec_u64_inner_global_t * self = (fd_gossip_bitvec_u64_inner_global_t *)mem;
-  fd_gossip_bitvec_u64_inner_new( (fd_gossip_bitvec_u64_inner_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_bitvec_u64_inner_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_bitvec_u64_inner_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_bitvec_u64_inner_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_bitvec_u64_inner_global_t * self = (fd_gossip_bitvec_u64_inner_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->vec_len, ctx );
-  if( self->vec_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), 8UL );
-    self->vec_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + sizeof(ulong)*self->vec_len;
-    for( ulong i=0; i < self->vec_len; i++ ) {
-      fd_bincode_uint64_decode_unsafe( (ulong*)(cur_mem + sizeof(ulong) * i), ctx );
-    }
-  } else
-    self->vec_gaddr = 0UL;
-}
-int fd_gossip_bitvec_u64_inner_convert_global_to_local( void const * global_self, fd_gossip_bitvec_u64_inner_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_bitvec_u64_inner_global_t const * mem = (fd_gossip_bitvec_u64_inner_global_t const *)global_self;
-  self->vec_len = mem->vec_len;
-  self->vec     = fd_wksp_laddr_fast( ctx->wksp, mem->vec_gaddr );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_gossip_bitvec_u64_inner_new(fd_gossip_bitvec_u64_inner_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_bitvec_u64_inner_t) );
 }
@@ -24291,6 +22003,18 @@ ulong fd_gossip_bitvec_u64_inner_size( fd_gossip_bitvec_u64_inner_t const * self
 }
 
 int fd_gossip_bitvec_u64_encode( fd_gossip_bitvec_u64_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_bool_encode( self->has_bits, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_bits ) {
+    err = fd_gossip_bitvec_u64_inner_encode( &self->bits, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_uint64_encode( self->len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_gossip_bitvec_u64_encode_global( fd_gossip_bitvec_u64_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
   err = fd_bincode_bool_encode( self->has_bits, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -24363,18 +22087,10 @@ void fd_gossip_bitvec_u64_decode_inner_global( void * struct_mem, void * * alloc
     self->has_bits = !!o;
     if( o ) {
       fd_gossip_bitvec_u64_inner_new( &self->bits );
-      fd_gossip_bitvec_u64_inner_decode_inner_global( &self->bits, alloc_mem, ctx );
+      fd_gossip_bitvec_u64_inner_decode_inner( &self->bits, alloc_mem, ctx );
     }
   }
   fd_bincode_uint64_decode_unsafe( &self->len, ctx );
-}
-int fd_gossip_bitvec_u64_convert_global_to_local( void const * global_self, fd_gossip_bitvec_u64_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_bitvec_u64_global_t const * mem = (fd_gossip_bitvec_u64_global_t const *)global_self;
-  self->bits = mem->bits;
-  self->has_bits = mem->has_bits;
-  self->len = mem->len;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_bitvec_u64_new(fd_gossip_bitvec_u64_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_bitvec_u64_t) );
@@ -24451,31 +22167,6 @@ void fd_gossip_ping_decode_inner( void * struct_mem, void * * alloc_mem, fd_binc
   fd_pubkey_decode_inner( &self->from, alloc_mem, ctx );
   fd_hash_decode_inner( &self->token, alloc_mem, ctx );
   fd_signature_decode_inner( &self->signature, alloc_mem, ctx );
-}
-void * fd_gossip_ping_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_ping_global_t * self = (fd_gossip_ping_global_t *)mem;
-  fd_gossip_ping_new( (fd_gossip_ping_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_ping_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_ping_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_ping_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_ping_global_t * self = (fd_gossip_ping_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->from, alloc_mem, ctx );
-  fd_hash_decode_inner_global( &self->token, alloc_mem, ctx );
-  fd_signature_decode_inner_global( &self->signature, alloc_mem, ctx );
-}
-int fd_gossip_ping_convert_global_to_local( void const * global_self, fd_gossip_ping_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_ping_global_t const * mem = (fd_gossip_ping_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->from, &self->from, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_hash_convert_global_to_local( &mem->token, &self->token, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_signature_convert_global_to_local( &mem->signature, &self->signature, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_ping_new(fd_gossip_ping_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_ping_t) );
@@ -24557,41 +22248,6 @@ void fd_gossip_ip_addr_inner_decode_inner( fd_gossip_ip_addr_inner_t * self, voi
   }
   }
 }
-void fd_gossip_ip_addr_inner_decode_inner_global( fd_gossip_ip_addr_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    fd_gossip_ip4_addr_decode_inner_global( &self->ip4, alloc_mem, ctx );
-    break;
-  }
-  case 1: {
-    fd_gossip_ip6_addr_decode_inner_global( &self->ip6, alloc_mem, ctx );
-    break;
-  }
-  }
-}
-int fd_gossip_ip_addr_convert_global_to_local_inner( fd_gossip_ip_addr_inner_global_t const * mem, fd_gossip_ip_addr_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_gossip_ip4_addr_convert_global_to_local( &mem->ip4, &self->ip4, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 1: {
-    err = fd_gossip_ip6_addr_convert_global_to_local( &mem->ip6, &self->ip6, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_gossip_ip_addr_convert_global_to_local( void const * global_self, fd_gossip_ip_addr_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_ip_addr_global_t const * mem = (fd_gossip_ip_addr_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_gossip_ip_addr_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_gossip_ip_addr_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_gossip_ip_addr_t * self = (fd_gossip_ip_addr_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -24604,19 +22260,6 @@ void * fd_gossip_ip_addr_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   void * * alloc_mem = &alloc_region;
   fd_gossip_ip_addr_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_gossip_ip_addr_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_ip_addr_t * self = (fd_gossip_ip_addr_t *)mem;
-  fd_gossip_ip_addr_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_ip_addr_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_ip_addr_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_ip_addr_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_ip_addr_global_t * self = (fd_gossip_ip_addr_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_gossip_ip_addr_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_gossip_ip_addr_inner_new( fd_gossip_ip_addr_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -24790,47 +22433,6 @@ void fd_gossip_prune_data_decode_inner( void * struct_mem, void * * alloc_mem, f
   fd_pubkey_decode_inner( &self->destination, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
 }
-void * fd_gossip_prune_data_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_prune_data_global_t * self = (fd_gossip_prune_data_global_t *)mem;
-  fd_gossip_prune_data_new( (fd_gossip_prune_data_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_prune_data_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_prune_data_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_prune_data_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_prune_data_global_t * self = (fd_gossip_prune_data_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->pubkey, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->prunes_len, ctx );
-  if( self->prunes_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_PUBKEY_ALIGN );
-    self->prunes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_PUBKEY_FOOTPRINT*self->prunes_len;
-    for( ulong i=0; i < self->prunes_len; i++ ) {
-      fd_pubkey_new( (fd_pubkey_t *)(cur_mem + FD_PUBKEY_FOOTPRINT * i) );
-      fd_pubkey_decode_inner_global( cur_mem + FD_PUBKEY_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->prunes_gaddr = 0UL;
-  fd_signature_decode_inner_global( &self->signature, alloc_mem, ctx );
-  fd_pubkey_decode_inner_global( &self->destination, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
-}
-int fd_gossip_prune_data_convert_global_to_local( void const * global_self, fd_gossip_prune_data_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_prune_data_global_t const * mem = (fd_gossip_prune_data_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->pubkey, &self->pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->prunes_len = mem->prunes_len;
-  self->prunes     = fd_wksp_laddr_fast( ctx->wksp, mem->prunes_gaddr );
-  err = fd_signature_convert_global_to_local( &mem->signature, &self->signature, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_pubkey_convert_global_to_local( &mem->destination, &self->destination, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->wallclock = mem->wallclock;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_gossip_prune_data_new(fd_gossip_prune_data_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_prune_data_t) );
   fd_pubkey_new( &self->pubkey );
@@ -24951,44 +22553,6 @@ void fd_gossip_prune_sign_data_decode_inner( void * struct_mem, void * * alloc_m
   fd_pubkey_decode_inner( &self->destination, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
 }
-void * fd_gossip_prune_sign_data_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_prune_sign_data_global_t * self = (fd_gossip_prune_sign_data_global_t *)mem;
-  fd_gossip_prune_sign_data_new( (fd_gossip_prune_sign_data_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_prune_sign_data_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_prune_sign_data_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_prune_sign_data_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_prune_sign_data_global_t * self = (fd_gossip_prune_sign_data_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->pubkey, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->prunes_len, ctx );
-  if( self->prunes_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_PUBKEY_ALIGN );
-    self->prunes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_PUBKEY_FOOTPRINT*self->prunes_len;
-    for( ulong i=0; i < self->prunes_len; i++ ) {
-      fd_pubkey_new( (fd_pubkey_t *)(cur_mem + FD_PUBKEY_FOOTPRINT * i) );
-      fd_pubkey_decode_inner_global( cur_mem + FD_PUBKEY_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->prunes_gaddr = 0UL;
-  fd_pubkey_decode_inner_global( &self->destination, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
-}
-int fd_gossip_prune_sign_data_convert_global_to_local( void const * global_self, fd_gossip_prune_sign_data_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_prune_sign_data_global_t const * mem = (fd_gossip_prune_sign_data_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->pubkey, &self->pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->prunes_len = mem->prunes_len;
-  self->prunes     = fd_wksp_laddr_fast( ctx->wksp, mem->prunes_gaddr );
-  err = fd_pubkey_convert_global_to_local( &mem->destination, &self->destination, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->wallclock = mem->wallclock;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_gossip_prune_sign_data_new(fd_gossip_prune_sign_data_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_prune_sign_data_t) );
   fd_pubkey_new( &self->pubkey );
@@ -25039,6 +22603,19 @@ int fd_gossip_prune_sign_data_with_prefix_encode( fd_gossip_prune_sign_data_with
   if( FD_UNLIKELY(err) ) return err;
   if( self->prefix_len ) {
     err = fd_bincode_bytes_encode( self->prefix, self->prefix_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_gossip_prune_sign_data_encode( &self->data, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_gossip_prune_sign_data_with_prefix_encode_global( fd_gossip_prune_sign_data_with_prefix_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->prefix_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->prefix_len ) {
+    uchar * prefix_laddr = fd_wksp_laddr_fast( ctx->wksp, self->prefix_gaddr );
+    err = fd_bincode_bytes_encode( prefix_laddr, self->prefix_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   err = fd_gossip_prune_sign_data_encode( &self->data, ctx );
@@ -25104,18 +22681,10 @@ void fd_gossip_prune_sign_data_with_prefix_decode_inner_global( void * struct_me
     self->prefix_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
     fd_bincode_bytes_decode_unsafe( *alloc_mem, self->prefix_len, ctx );
     *alloc_mem = (uchar *)(*alloc_mem) + self->prefix_len;
-  } else
+  } else {
     self->prefix_gaddr = 0UL;
-  fd_gossip_prune_sign_data_decode_inner_global( &self->data, alloc_mem, ctx );
-}
-int fd_gossip_prune_sign_data_with_prefix_convert_global_to_local( void const * global_self, fd_gossip_prune_sign_data_with_prefix_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_prune_sign_data_with_prefix_global_t const * mem = (fd_gossip_prune_sign_data_with_prefix_global_t const *)global_self;
-  self->prefix_len = mem->prefix_len;
-  self->prefix     = fd_wksp_laddr_fast( ctx->wksp, mem->prefix_gaddr );
-  err = fd_gossip_prune_sign_data_convert_global_to_local( &mem->data, &self->data, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
+  }
+  fd_gossip_prune_sign_data_decode_inner( &self->data, alloc_mem, ctx );
 }
 void fd_gossip_prune_sign_data_with_prefix_new(fd_gossip_prune_sign_data_with_prefix_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_prune_sign_data_with_prefix_t) );
@@ -25185,27 +22754,6 @@ void fd_gossip_socket_addr_old_decode_inner( void * struct_mem, void * * alloc_m
   fd_gossip_ip_addr_decode_inner( &self->addr, alloc_mem, ctx );
   fd_bincode_uint16_decode_unsafe( &self->port, ctx );
 }
-void * fd_gossip_socket_addr_old_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_socket_addr_old_global_t * self = (fd_gossip_socket_addr_old_global_t *)mem;
-  fd_gossip_socket_addr_old_new( (fd_gossip_socket_addr_old_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_socket_addr_old_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_socket_addr_old_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_socket_addr_old_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_socket_addr_old_global_t * self = (fd_gossip_socket_addr_old_global_t *)struct_mem;
-  fd_gossip_ip_addr_decode_inner_global( &self->addr, alloc_mem, ctx );
-  fd_bincode_uint16_decode_unsafe( &self->port, ctx );
-}
-int fd_gossip_socket_addr_old_convert_global_to_local( void const * global_self, fd_gossip_socket_addr_old_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_socket_addr_old_global_t const * mem = (fd_gossip_socket_addr_old_global_t const *)global_self;
-  err = fd_gossip_ip_addr_convert_global_to_local( &mem->addr, &self->addr, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->port = mem->port;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_gossip_socket_addr_old_new(fd_gossip_socket_addr_old_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_socket_addr_old_t) );
   fd_gossip_ip_addr_new( &self->addr );
@@ -25267,27 +22815,6 @@ void fd_gossip_socket_addr_ip4_decode_inner( void * struct_mem, void * * alloc_m
   fd_gossip_socket_addr_ip4_t * self = (fd_gossip_socket_addr_ip4_t *)struct_mem;
   fd_gossip_ip4_addr_decode_inner( &self->addr, alloc_mem, ctx );
   fd_bincode_uint16_decode_unsafe( &self->port, ctx );
-}
-void * fd_gossip_socket_addr_ip4_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_socket_addr_ip4_global_t * self = (fd_gossip_socket_addr_ip4_global_t *)mem;
-  fd_gossip_socket_addr_ip4_new( (fd_gossip_socket_addr_ip4_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_socket_addr_ip4_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_socket_addr_ip4_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_socket_addr_ip4_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_socket_addr_ip4_global_t * self = (fd_gossip_socket_addr_ip4_global_t *)struct_mem;
-  fd_gossip_ip4_addr_decode_inner_global( &self->addr, alloc_mem, ctx );
-  fd_bincode_uint16_decode_unsafe( &self->port, ctx );
-}
-int fd_gossip_socket_addr_ip4_convert_global_to_local( void const * global_self, fd_gossip_socket_addr_ip4_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_socket_addr_ip4_global_t const * mem = (fd_gossip_socket_addr_ip4_global_t const *)global_self;
-  err = fd_gossip_ip4_addr_convert_global_to_local( &mem->addr, &self->addr, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->port = mem->port;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_socket_addr_ip4_new(fd_gossip_socket_addr_ip4_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_socket_addr_ip4_t) );
@@ -25360,31 +22887,6 @@ void fd_gossip_socket_addr_ip6_decode_inner( void * struct_mem, void * * alloc_m
   fd_bincode_uint16_decode_unsafe( &self->port, ctx );
   fd_bincode_uint32_decode_unsafe( &self->flowinfo, ctx );
   fd_bincode_uint32_decode_unsafe( &self->scope_id, ctx );
-}
-void * fd_gossip_socket_addr_ip6_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_socket_addr_ip6_global_t * self = (fd_gossip_socket_addr_ip6_global_t *)mem;
-  fd_gossip_socket_addr_ip6_new( (fd_gossip_socket_addr_ip6_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_socket_addr_ip6_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_socket_addr_ip6_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_socket_addr_ip6_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_socket_addr_ip6_global_t * self = (fd_gossip_socket_addr_ip6_global_t *)struct_mem;
-  fd_gossip_ip6_addr_decode_inner_global( &self->addr, alloc_mem, ctx );
-  fd_bincode_uint16_decode_unsafe( &self->port, ctx );
-  fd_bincode_uint32_decode_unsafe( &self->flowinfo, ctx );
-  fd_bincode_uint32_decode_unsafe( &self->scope_id, ctx );
-}
-int fd_gossip_socket_addr_ip6_convert_global_to_local( void const * global_self, fd_gossip_socket_addr_ip6_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_socket_addr_ip6_global_t const * mem = (fd_gossip_socket_addr_ip6_global_t const *)global_self;
-  err = fd_gossip_ip6_addr_convert_global_to_local( &mem->addr, &self->addr, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->port = mem->port;
-  self->flowinfo = mem->flowinfo;
-  self->scope_id = mem->scope_id;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_socket_addr_ip6_new(fd_gossip_socket_addr_ip6_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_socket_addr_ip6_t) );
@@ -25464,41 +22966,6 @@ void fd_gossip_socket_addr_inner_decode_inner( fd_gossip_socket_addr_inner_t * s
   }
   }
 }
-void fd_gossip_socket_addr_inner_decode_inner_global( fd_gossip_socket_addr_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    fd_gossip_socket_addr_ip4_decode_inner_global( &self->ip4, alloc_mem, ctx );
-    break;
-  }
-  case 1: {
-    fd_gossip_socket_addr_ip6_decode_inner_global( &self->ip6, alloc_mem, ctx );
-    break;
-  }
-  }
-}
-int fd_gossip_socket_addr_convert_global_to_local_inner( fd_gossip_socket_addr_inner_global_t const * mem, fd_gossip_socket_addr_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_gossip_socket_addr_ip4_convert_global_to_local( &mem->ip4, &self->ip4, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 1: {
-    err = fd_gossip_socket_addr_ip6_convert_global_to_local( &mem->ip6, &self->ip6, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_gossip_socket_addr_convert_global_to_local( void const * global_self, fd_gossip_socket_addr_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_socket_addr_global_t const * mem = (fd_gossip_socket_addr_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_gossip_socket_addr_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_gossip_socket_addr_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_gossip_socket_addr_t * self = (fd_gossip_socket_addr_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -25511,19 +22978,6 @@ void * fd_gossip_socket_addr_decode( void * mem, fd_bincode_decode_ctx_t * ctx )
   void * * alloc_mem = &alloc_region;
   fd_gossip_socket_addr_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_gossip_socket_addr_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_socket_addr_t * self = (fd_gossip_socket_addr_t *)mem;
-  fd_gossip_socket_addr_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_socket_addr_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_socket_addr_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_socket_addr_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_socket_addr_global_t * self = (fd_gossip_socket_addr_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_gossip_socket_addr_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_gossip_socket_addr_inner_new( fd_gossip_socket_addr_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -25713,59 +23167,6 @@ void fd_gossip_contact_info_v1_decode_inner( void * struct_mem, void * * alloc_m
   fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
   fd_bincode_uint16_decode_unsafe( &self->shred_version, ctx );
 }
-void * fd_gossip_contact_info_v1_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_contact_info_v1_global_t * self = (fd_gossip_contact_info_v1_global_t *)mem;
-  fd_gossip_contact_info_v1_new( (fd_gossip_contact_info_v1_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_contact_info_v1_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_contact_info_v1_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_contact_info_v1_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_contact_info_v1_global_t * self = (fd_gossip_contact_info_v1_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->id, alloc_mem, ctx );
-  fd_gossip_socket_addr_decode_inner_global( &self->gossip, alloc_mem, ctx );
-  fd_gossip_socket_addr_decode_inner_global( &self->tvu, alloc_mem, ctx );
-  fd_gossip_socket_addr_decode_inner_global( &self->tvu_fwd, alloc_mem, ctx );
-  fd_gossip_socket_addr_decode_inner_global( &self->repair, alloc_mem, ctx );
-  fd_gossip_socket_addr_decode_inner_global( &self->tpu, alloc_mem, ctx );
-  fd_gossip_socket_addr_decode_inner_global( &self->tpu_fwd, alloc_mem, ctx );
-  fd_gossip_socket_addr_decode_inner_global( &self->tpu_vote, alloc_mem, ctx );
-  fd_gossip_socket_addr_decode_inner_global( &self->rpc, alloc_mem, ctx );
-  fd_gossip_socket_addr_decode_inner_global( &self->rpc_pubsub, alloc_mem, ctx );
-  fd_gossip_socket_addr_decode_inner_global( &self->serve_repair, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
-  fd_bincode_uint16_decode_unsafe( &self->shred_version, ctx );
-}
-int fd_gossip_contact_info_v1_convert_global_to_local( void const * global_self, fd_gossip_contact_info_v1_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_contact_info_v1_global_t const * mem = (fd_gossip_contact_info_v1_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->id, &self->id, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_gossip_socket_addr_convert_global_to_local( &mem->gossip, &self->gossip, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_gossip_socket_addr_convert_global_to_local( &mem->tvu, &self->tvu, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_gossip_socket_addr_convert_global_to_local( &mem->tvu_fwd, &self->tvu_fwd, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_gossip_socket_addr_convert_global_to_local( &mem->repair, &self->repair, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_gossip_socket_addr_convert_global_to_local( &mem->tpu, &self->tpu, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_gossip_socket_addr_convert_global_to_local( &mem->tpu_fwd, &self->tpu_fwd, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_gossip_socket_addr_convert_global_to_local( &mem->tpu_vote, &self->tpu_vote, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_gossip_socket_addr_convert_global_to_local( &mem->rpc, &self->rpc, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_gossip_socket_addr_convert_global_to_local( &mem->rpc_pubsub, &self->rpc_pubsub, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_gossip_socket_addr_convert_global_to_local( &mem->serve_repair, &self->serve_repair, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->wallclock = mem->wallclock;
-  self->shred_version = mem->shred_version;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_gossip_contact_info_v1_new(fd_gossip_contact_info_v1_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_contact_info_v1_t) );
   fd_pubkey_new( &self->id );
@@ -25879,32 +23280,6 @@ void fd_gossip_vote_decode_inner( void * struct_mem, void * * alloc_mem, fd_binc
   fd_pubkey_decode_inner( &self->from, alloc_mem, ctx );
   fd_flamenco_txn_decode_inner( &self->txn, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
-}
-void * fd_gossip_vote_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_vote_global_t * self = (fd_gossip_vote_global_t *)mem;
-  fd_gossip_vote_new( (fd_gossip_vote_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_vote_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_vote_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_vote_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_vote_global_t * self = (fd_gossip_vote_global_t *)struct_mem;
-  fd_bincode_uint8_decode_unsafe( &self->index, ctx );
-  fd_pubkey_decode_inner_global( &self->from, alloc_mem, ctx );
-  fd_flamenco_txn_decode_inner_global( &self->txn, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
-}
-int fd_gossip_vote_convert_global_to_local( void const * global_self, fd_gossip_vote_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_vote_global_t const * mem = (fd_gossip_vote_global_t const *)global_self;
-  self->index = mem->index;
-  err = fd_pubkey_convert_global_to_local( &mem->from, &self->from, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_flamenco_txn_convert_global_to_local( &mem->txn, &self->txn, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->wallclock = mem->wallclock;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_vote_new(fd_gossip_vote_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_vote_t) );
@@ -26021,48 +23396,6 @@ void fd_gossip_lowest_slot_decode_inner( void * struct_mem, void * * alloc_mem, 
   fd_bincode_uint64_decode_unsafe( &self->i_dont_know, ctx );
   fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
 }
-void * fd_gossip_lowest_slot_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_lowest_slot_global_t * self = (fd_gossip_lowest_slot_global_t *)mem;
-  fd_gossip_lowest_slot_new( (fd_gossip_lowest_slot_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_lowest_slot_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_lowest_slot_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_lowest_slot_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_lowest_slot_global_t * self = (fd_gossip_lowest_slot_global_t *)struct_mem;
-  fd_bincode_uint8_decode_unsafe( &self->u8, ctx );
-  fd_pubkey_decode_inner_global( &self->from, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->root, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->lowest, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->slots_len, ctx );
-  if( self->slots_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), 8UL );
-    self->slots_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + sizeof(ulong)*self->slots_len;
-    for( ulong i=0; i < self->slots_len; i++ ) {
-      fd_bincode_uint64_decode_unsafe( (ulong*)(cur_mem + sizeof(ulong) * i), ctx );
-    }
-  } else
-    self->slots_gaddr = 0UL;
-  fd_bincode_uint64_decode_unsafe( &self->i_dont_know, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
-}
-int fd_gossip_lowest_slot_convert_global_to_local( void const * global_self, fd_gossip_lowest_slot_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_lowest_slot_global_t const * mem = (fd_gossip_lowest_slot_global_t const *)global_self;
-  self->u8 = mem->u8;
-  err = fd_pubkey_convert_global_to_local( &mem->from, &self->from, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->root = mem->root;
-  self->lowest = mem->lowest;
-  self->slots_len = mem->slots_len;
-  self->slots     = fd_wksp_laddr_fast( ctx->wksp, mem->slots_gaddr );
-  self->i_dont_know = mem->i_dont_know;
-  self->wallclock = mem->wallclock;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_gossip_lowest_slot_new(fd_gossip_lowest_slot_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_lowest_slot_t) );
   fd_pubkey_new( &self->from );
@@ -26175,41 +23508,6 @@ void fd_gossip_slot_hashes_decode_inner( void * struct_mem, void * * alloc_mem, 
     self->hashes = NULL;
   fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
 }
-void * fd_gossip_slot_hashes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_slot_hashes_global_t * self = (fd_gossip_slot_hashes_global_t *)mem;
-  fd_gossip_slot_hashes_new( (fd_gossip_slot_hashes_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_slot_hashes_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_slot_hashes_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_slot_hashes_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_slot_hashes_global_t * self = (fd_gossip_slot_hashes_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->from, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->hashes_len, ctx );
-  if( self->hashes_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_SLOT_HASH_ALIGN );
-    self->hashes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_SLOT_HASH_FOOTPRINT*self->hashes_len;
-    for( ulong i=0; i < self->hashes_len; i++ ) {
-      fd_slot_hash_new( (fd_slot_hash_t *)(cur_mem + FD_SLOT_HASH_FOOTPRINT * i) );
-      fd_slot_hash_decode_inner_global( cur_mem + FD_SLOT_HASH_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->hashes_gaddr = 0UL;
-  fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
-}
-int fd_gossip_slot_hashes_convert_global_to_local( void const * global_self, fd_gossip_slot_hashes_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_slot_hashes_global_t const * mem = (fd_gossip_slot_hashes_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->from, &self->from, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->hashes_len = mem->hashes_len;
-  self->hashes     = fd_wksp_laddr_fast( ctx->wksp, mem->hashes_gaddr );
-  self->wallclock = mem->wallclock;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_gossip_slot_hashes_new(fd_gossip_slot_hashes_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_slot_hashes_t) );
   fd_pubkey_new( &self->from );
@@ -26260,6 +23558,16 @@ int fd_gossip_slots_encode( fd_gossip_slots_t const * self, fd_bincode_encode_ct
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
+int fd_gossip_slots_encode_global( fd_gossip_slots_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->first_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->num, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_gossip_bitvec_u8_encode_global( &self->slots, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
 int fd_gossip_slots_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_gossip_slots_t);
   void const * start_data = ctx->data;
@@ -26306,15 +23614,6 @@ void fd_gossip_slots_decode_inner_global( void * struct_mem, void * * alloc_mem,
   fd_bincode_uint64_decode_unsafe( &self->first_slot, ctx );
   fd_bincode_uint64_decode_unsafe( &self->num, ctx );
   fd_gossip_bitvec_u8_decode_inner_global( &self->slots, alloc_mem, ctx );
-}
-int fd_gossip_slots_convert_global_to_local( void const * global_self, fd_gossip_slots_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_slots_global_t const * mem = (fd_gossip_slots_global_t const *)global_self;
-  self->first_slot = mem->first_slot;
-  self->num = mem->num;
-  err = fd_gossip_bitvec_u8_convert_global_to_local( &mem->slots, &self->slots, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_slots_new(fd_gossip_slots_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_slots_t) );
@@ -26401,35 +23700,6 @@ void fd_gossip_flate2_slots_decode_inner( void * struct_mem, void * * alloc_mem,
   } else
     self->compressed = NULL;
 }
-void * fd_gossip_flate2_slots_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_flate2_slots_global_t * self = (fd_gossip_flate2_slots_global_t *)mem;
-  fd_gossip_flate2_slots_new( (fd_gossip_flate2_slots_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_flate2_slots_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_flate2_slots_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_flate2_slots_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_flate2_slots_global_t * self = (fd_gossip_flate2_slots_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->first_slot, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->num, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->compressed_len, ctx );
-  if( self->compressed_len ) {
-    self->compressed_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    fd_bincode_bytes_decode_unsafe( *alloc_mem, self->compressed_len, ctx );
-    *alloc_mem = (uchar *)(*alloc_mem) + self->compressed_len;
-  } else
-    self->compressed_gaddr = 0UL;
-}
-int fd_gossip_flate2_slots_convert_global_to_local( void const * global_self, fd_gossip_flate2_slots_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_flate2_slots_global_t const * mem = (fd_gossip_flate2_slots_global_t const *)global_self;
-  self->first_slot = mem->first_slot;
-  self->num = mem->num;
-  self->compressed_len = mem->compressed_len;
-  self->compressed     = fd_wksp_laddr_fast( ctx->wksp, mem->compressed_gaddr );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_gossip_flate2_slots_new(fd_gossip_flate2_slots_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_flate2_slots_t) );
 }
@@ -26513,7 +23783,7 @@ void fd_gossip_slots_enum_inner_decode_inner( fd_gossip_slots_enum_inner_t * sel
 void fd_gossip_slots_enum_inner_decode_inner_global( fd_gossip_slots_enum_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
   switch (discriminant) {
   case 0: {
-    fd_gossip_flate2_slots_decode_inner_global( &self->flate2, alloc_mem, ctx );
+    fd_gossip_flate2_slots_decode_inner( &self->flate2, alloc_mem, ctx );
     break;
   }
   case 1: {
@@ -26521,29 +23791,6 @@ void fd_gossip_slots_enum_inner_decode_inner_global( fd_gossip_slots_enum_inner_
     break;
   }
   }
-}
-int fd_gossip_slots_enum_convert_global_to_local_inner( fd_gossip_slots_enum_inner_global_t const * mem, fd_gossip_slots_enum_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_gossip_flate2_slots_convert_global_to_local( &mem->flate2, &self->flate2, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 1: {
-    err = fd_gossip_slots_convert_global_to_local( &mem->uncompressed, &self->uncompressed, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_gossip_slots_enum_convert_global_to_local( void const * global_self, fd_gossip_slots_enum_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_slots_enum_global_t const * mem = (fd_gossip_slots_enum_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_gossip_slots_enum_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_slots_enum_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_gossip_slots_enum_t * self = (fd_gossip_slots_enum_t *)struct_mem;
@@ -26558,6 +23805,28 @@ void * fd_gossip_slots_enum_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) 
   fd_gossip_slots_enum_decode_inner( mem, alloc_mem, ctx );
   return self;
 }
+int fd_gossip_slots_enum_inner_encode_global( fd_gossip_slots_enum_inner_global_t const * self, uint discriminant, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  switch (discriminant) {
+  case 0: {
+    err = fd_gossip_flate2_slots_encode( &self->flate2, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 1: {
+    err = fd_gossip_slots_encode_global( &self->uncompressed, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_gossip_slots_enum_encode_global( fd_gossip_slots_enum_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err = fd_bincode_uint32_encode( self->discriminant, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fd_gossip_slots_enum_inner_encode_global( &self->inner, self->discriminant, ctx );
+}
+
 void * fd_gossip_slots_enum_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_gossip_slots_enum_t * self = (fd_gossip_slots_enum_t *)mem;
   fd_gossip_slots_enum_new( self );
@@ -26684,6 +23953,26 @@ int fd_gossip_epoch_slots_encode( fd_gossip_epoch_slots_t const * self, fd_binco
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
+int fd_gossip_epoch_slots_encode_global( fd_gossip_epoch_slots_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint8_encode( (uchar)(self->u8), ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_pubkey_encode( &self->from, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->slots_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->slots_len ) {
+    uchar * slots_laddr = fd_wksp_laddr_fast( ctx->wksp, self->slots_gaddr );
+    fd_gossip_slots_enum_global_t * slots = (fd_gossip_slots_enum_global_t *)slots_laddr;
+    for( ulong i=0; i < self->slots_len; i++ ) {
+      err = fd_gossip_slots_enum_encode_global( &slots[i], ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  err = fd_bincode_uint64_encode( self->wallclock, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
 int fd_gossip_epoch_slots_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_gossip_epoch_slots_t);
   void const * start_data = ctx->data;
@@ -26749,7 +24038,7 @@ void * fd_gossip_epoch_slots_decode_global( void * mem, fd_bincode_decode_ctx_t 
 void fd_gossip_epoch_slots_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_gossip_epoch_slots_global_t * self = (fd_gossip_epoch_slots_global_t *)struct_mem;
   fd_bincode_uint8_decode_unsafe( &self->u8, ctx );
-  fd_pubkey_decode_inner_global( &self->from, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->from, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->slots_len, ctx );
   if( self->slots_len ) {
     *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_GOSSIP_SLOTS_ENUM_ALIGN );
@@ -26757,23 +24046,13 @@ void fd_gossip_epoch_slots_decode_inner_global( void * struct_mem, void * * allo
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_GOSSIP_SLOTS_ENUM_FOOTPRINT*self->slots_len;
     for( ulong i=0; i < self->slots_len; i++ ) {
-      fd_gossip_slots_enum_new( (fd_gossip_slots_enum_t *)(cur_mem + FD_GOSSIP_SLOTS_ENUM_FOOTPRINT * i) );
+      fd_gossip_slots_enum_new( (fd_gossip_slots_enum_t *)fd_type_pun(cur_mem + FD_GOSSIP_SLOTS_ENUM_FOOTPRINT * i) );
       fd_gossip_slots_enum_decode_inner_global( cur_mem + FD_GOSSIP_SLOTS_ENUM_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->slots_gaddr = 0UL;
+  }
   fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
-}
-int fd_gossip_epoch_slots_convert_global_to_local( void const * global_self, fd_gossip_epoch_slots_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_epoch_slots_global_t const * mem = (fd_gossip_epoch_slots_global_t const *)global_self;
-  self->u8 = mem->u8;
-  err = fd_pubkey_convert_global_to_local( &mem->from, &self->from, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->slots_len = mem->slots_len;
-  self->slots     = fd_wksp_laddr_fast( ctx->wksp, mem->slots_gaddr );
-  self->wallclock = mem->wallclock;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_epoch_slots_new(fd_gossip_epoch_slots_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_epoch_slots_t) );
@@ -26818,6 +24097,26 @@ ulong fd_gossip_epoch_slots_size( fd_gossip_epoch_slots_t const * self ) {
 }
 
 int fd_gossip_version_v1_encode( fd_gossip_version_v1_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_encode( &self->from, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->wallclock, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint16_encode( self->major, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint16_encode( self->minor, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint16_encode( self->patch, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_bool_encode( self->has_commit, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_commit ) {
+    err = fd_bincode_uint32_encode( self->commit, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_gossip_version_v1_encode_global( fd_gossip_version_v1_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
   err = fd_pubkey_encode( &self->from, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -26903,7 +24202,7 @@ void * fd_gossip_version_v1_decode_global( void * mem, fd_bincode_decode_ctx_t *
 }
 void fd_gossip_version_v1_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_gossip_version_v1_global_t * self = (fd_gossip_version_v1_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->from, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->from, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
   fd_bincode_uint16_decode_unsafe( &self->major, ctx );
   fd_bincode_uint16_decode_unsafe( &self->minor, ctx );
@@ -26916,19 +24215,6 @@ void fd_gossip_version_v1_decode_inner_global( void * struct_mem, void * * alloc
       fd_bincode_uint32_decode_unsafe( &self->commit, ctx );
     }
   }
-}
-int fd_gossip_version_v1_convert_global_to_local( void const * global_self, fd_gossip_version_v1_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_version_v1_global_t const * mem = (fd_gossip_version_v1_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->from, &self->from, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->wallclock = mem->wallclock;
-  self->major = mem->major;
-  self->minor = mem->minor;
-  self->patch = mem->patch;
-  self->commit = mem->commit;
-  self->has_commit = mem->has_commit;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_version_v1_new(fd_gossip_version_v1_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_version_v1_t) );
@@ -26973,6 +24259,28 @@ ulong fd_gossip_version_v1_size( fd_gossip_version_v1_t const * self ) {
 }
 
 int fd_gossip_version_v2_encode( fd_gossip_version_v2_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_encode( &self->from, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->wallclock, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint16_encode( self->major, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint16_encode( self->minor, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint16_encode( self->patch, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_bool_encode( self->has_commit, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_commit ) {
+    err = fd_bincode_uint32_encode( self->commit, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_uint32_encode( self->feature_set, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_gossip_version_v2_encode_global( fd_gossip_version_v2_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
   err = fd_pubkey_encode( &self->from, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -27063,7 +24371,7 @@ void * fd_gossip_version_v2_decode_global( void * mem, fd_bincode_decode_ctx_t *
 }
 void fd_gossip_version_v2_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_gossip_version_v2_global_t * self = (fd_gossip_version_v2_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->from, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->from, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
   fd_bincode_uint16_decode_unsafe( &self->major, ctx );
   fd_bincode_uint16_decode_unsafe( &self->minor, ctx );
@@ -27077,20 +24385,6 @@ void fd_gossip_version_v2_decode_inner_global( void * struct_mem, void * * alloc
     }
   }
   fd_bincode_uint32_decode_unsafe( &self->feature_set, ctx );
-}
-int fd_gossip_version_v2_convert_global_to_local( void const * global_self, fd_gossip_version_v2_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_version_v2_global_t const * mem = (fd_gossip_version_v2_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->from, &self->from, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->wallclock = mem->wallclock;
-  self->major = mem->major;
-  self->minor = mem->minor;
-  self->patch = mem->patch;
-  self->commit = mem->commit;
-  self->has_commit = mem->has_commit;
-  self->feature_set = mem->feature_set;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_version_v2_new(fd_gossip_version_v2_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_version_v2_t) );
@@ -27194,34 +24488,6 @@ void fd_gossip_version_v3_decode_inner( void * struct_mem, void * * alloc_mem, f
   fd_bincode_uint32_decode_unsafe( &self->feature_set, ctx );
   fd_bincode_compact_u16_decode_unsafe( &self->client, ctx );
 }
-void * fd_gossip_version_v3_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_version_v3_global_t * self = (fd_gossip_version_v3_global_t *)mem;
-  fd_gossip_version_v3_new( (fd_gossip_version_v3_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_version_v3_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_version_v3_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_version_v3_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_version_v3_global_t * self = (fd_gossip_version_v3_global_t *)struct_mem;
-  fd_bincode_compact_u16_decode_unsafe( &self->major, ctx );
-  fd_bincode_compact_u16_decode_unsafe( &self->minor, ctx );
-  fd_bincode_compact_u16_decode_unsafe( &self->patch, ctx );
-  fd_bincode_uint32_decode_unsafe( &self->commit, ctx );
-  fd_bincode_uint32_decode_unsafe( &self->feature_set, ctx );
-  fd_bincode_compact_u16_decode_unsafe( &self->client, ctx );
-}
-int fd_gossip_version_v3_convert_global_to_local( void const * global_self, fd_gossip_version_v3_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_version_v3_global_t const * mem = (fd_gossip_version_v3_global_t const *)global_self;
-  self->major = mem->major;
-  self->minor = mem->minor;
-  self->patch = mem->patch;
-  self->commit = mem->commit;
-  self->feature_set = mem->feature_set;
-  self->client = mem->client;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_gossip_version_v3_new(fd_gossip_version_v3_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_version_v3_t) );
 }
@@ -27299,31 +24565,6 @@ void fd_gossip_node_instance_decode_inner( void * struct_mem, void * * alloc_mem
   fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
   fd_bincode_uint64_decode_unsafe( (ulong *) &self->timestamp, ctx );
   fd_bincode_uint64_decode_unsafe( &self->token, ctx );
-}
-void * fd_gossip_node_instance_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_node_instance_global_t * self = (fd_gossip_node_instance_global_t *)mem;
-  fd_gossip_node_instance_new( (fd_gossip_node_instance_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_node_instance_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_node_instance_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_node_instance_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_node_instance_global_t * self = (fd_gossip_node_instance_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->from, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
-  fd_bincode_uint64_decode_unsafe( (ulong *) &self->timestamp, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->token, ctx );
-}
-int fd_gossip_node_instance_convert_global_to_local( void const * global_self, fd_gossip_node_instance_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_node_instance_global_t const * mem = (fd_gossip_node_instance_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->from, &self->from, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->wallclock = mem->wallclock;
-  self->timestamp = mem->timestamp;
-  self->token = mem->token;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_node_instance_new(fd_gossip_node_instance_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_node_instance_t) );
@@ -27442,48 +24683,6 @@ void fd_gossip_duplicate_shred_decode_inner( void * struct_mem, void * * alloc_m
   } else
     self->chunk = NULL;
 }
-void * fd_gossip_duplicate_shred_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_duplicate_shred_global_t * self = (fd_gossip_duplicate_shred_global_t *)mem;
-  fd_gossip_duplicate_shred_new( (fd_gossip_duplicate_shred_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_duplicate_shred_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_duplicate_shred_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_duplicate_shred_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_duplicate_shred_global_t * self = (fd_gossip_duplicate_shred_global_t *)struct_mem;
-  fd_bincode_uint16_decode_unsafe( &self->duplicate_shred_index, ctx );
-  fd_pubkey_decode_inner_global( &self->from, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-  fd_bincode_uint32_decode_unsafe( &self->_unused, ctx );
-  fd_bincode_uint8_decode_unsafe( &self->_unused_shred_type, ctx );
-  fd_bincode_uint8_decode_unsafe( &self->num_chunks, ctx );
-  fd_bincode_uint8_decode_unsafe( &self->chunk_index, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->chunk_len, ctx );
-  if( self->chunk_len ) {
-    self->chunk_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    fd_bincode_bytes_decode_unsafe( *alloc_mem, self->chunk_len, ctx );
-    *alloc_mem = (uchar *)(*alloc_mem) + self->chunk_len;
-  } else
-    self->chunk_gaddr = 0UL;
-}
-int fd_gossip_duplicate_shred_convert_global_to_local( void const * global_self, fd_gossip_duplicate_shred_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_duplicate_shred_global_t const * mem = (fd_gossip_duplicate_shred_global_t const *)global_self;
-  self->duplicate_shred_index = mem->duplicate_shred_index;
-  err = fd_pubkey_convert_global_to_local( &mem->from, &self->from, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->wallclock = mem->wallclock;
-  self->slot = mem->slot;
-  self->_unused = mem->_unused;
-  self->_unused_shred_type = mem->_unused_shred_type;
-  self->num_chunks = mem->num_chunks;
-  self->chunk_index = mem->chunk_index;
-  self->chunk_len = mem->chunk_len;
-  self->chunk     = fd_wksp_laddr_fast( ctx->wksp, mem->chunk_gaddr );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_gossip_duplicate_shred_new(fd_gossip_duplicate_shred_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_duplicate_shred_t) );
   fd_pubkey_new( &self->from );
@@ -27600,44 +24799,6 @@ void fd_gossip_incremental_snapshot_hashes_decode_inner( void * struct_mem, void
     self->hashes = NULL;
   fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
 }
-void * fd_gossip_incremental_snapshot_hashes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_incremental_snapshot_hashes_global_t * self = (fd_gossip_incremental_snapshot_hashes_global_t *)mem;
-  fd_gossip_incremental_snapshot_hashes_new( (fd_gossip_incremental_snapshot_hashes_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_incremental_snapshot_hashes_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_incremental_snapshot_hashes_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_incremental_snapshot_hashes_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_incremental_snapshot_hashes_global_t * self = (fd_gossip_incremental_snapshot_hashes_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->from, alloc_mem, ctx );
-  fd_slot_hash_decode_inner_global( &self->base_hash, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->hashes_len, ctx );
-  if( self->hashes_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_SLOT_HASH_ALIGN );
-    self->hashes_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_SLOT_HASH_FOOTPRINT*self->hashes_len;
-    for( ulong i=0; i < self->hashes_len; i++ ) {
-      fd_slot_hash_new( (fd_slot_hash_t *)(cur_mem + FD_SLOT_HASH_FOOTPRINT * i) );
-      fd_slot_hash_decode_inner_global( cur_mem + FD_SLOT_HASH_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->hashes_gaddr = 0UL;
-  fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
-}
-int fd_gossip_incremental_snapshot_hashes_convert_global_to_local( void const * global_self, fd_gossip_incremental_snapshot_hashes_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_incremental_snapshot_hashes_global_t const * mem = (fd_gossip_incremental_snapshot_hashes_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->from, &self->from, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_slot_hash_convert_global_to_local( &mem->base_hash, &self->base_hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->hashes_len = mem->hashes_len;
-  self->hashes     = fd_wksp_laddr_fast( ctx->wksp, mem->hashes_gaddr );
-  self->wallclock = mem->wallclock;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_gossip_incremental_snapshot_hashes_new(fd_gossip_incremental_snapshot_hashes_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_incremental_snapshot_hashes_t) );
   fd_pubkey_new( &self->from );
@@ -27724,28 +24885,6 @@ void fd_gossip_socket_entry_decode_inner( void * struct_mem, void * * alloc_mem,
   fd_bincode_uint8_decode_unsafe( &self->key, ctx );
   fd_bincode_uint8_decode_unsafe( &self->index, ctx );
   fd_bincode_compact_u16_decode_unsafe( &self->offset, ctx );
-}
-void * fd_gossip_socket_entry_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_socket_entry_global_t * self = (fd_gossip_socket_entry_global_t *)mem;
-  fd_gossip_socket_entry_new( (fd_gossip_socket_entry_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_socket_entry_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_socket_entry_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_socket_entry_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_socket_entry_global_t * self = (fd_gossip_socket_entry_global_t *)struct_mem;
-  fd_bincode_uint8_decode_unsafe( &self->key, ctx );
-  fd_bincode_uint8_decode_unsafe( &self->index, ctx );
-  fd_bincode_compact_u16_decode_unsafe( &self->offset, ctx );
-}
-int fd_gossip_socket_entry_convert_global_to_local( void const * global_self, fd_gossip_socket_entry_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_socket_entry_global_t const * mem = (fd_gossip_socket_entry_global_t const *)global_self;
-  self->key = mem->key;
-  self->index = mem->index;
-  self->offset = mem->offset;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_socket_entry_new(fd_gossip_socket_entry_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_socket_entry_t) );
@@ -27909,75 +25048,6 @@ void fd_gossip_contact_info_v2_decode_inner( void * struct_mem, void * * alloc_m
   } else
     self->extensions = NULL;
 }
-void * fd_gossip_contact_info_v2_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_contact_info_v2_global_t * self = (fd_gossip_contact_info_v2_global_t *)mem;
-  fd_gossip_contact_info_v2_new( (fd_gossip_contact_info_v2_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_contact_info_v2_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_contact_info_v2_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_contact_info_v2_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_contact_info_v2_global_t * self = (fd_gossip_contact_info_v2_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->from, alloc_mem, ctx );
-  fd_bincode_varint_decode_unsafe( &self->wallclock, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->outset, ctx );
-  fd_bincode_uint16_decode_unsafe( &self->shred_version, ctx );
-  fd_gossip_version_v3_decode_inner_global( &self->version, alloc_mem, ctx );
-  fd_bincode_compact_u16_decode_unsafe( &self->addrs_len, ctx );
-  if( self->addrs_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_GOSSIP_IP_ADDR_ALIGN );
-    self->addrs_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_GOSSIP_IP_ADDR_FOOTPRINT*self->addrs_len;
-    for( ulong i=0; i < self->addrs_len; i++ ) {
-      fd_gossip_ip_addr_new( (fd_gossip_ip_addr_t *)(cur_mem + FD_GOSSIP_IP_ADDR_FOOTPRINT * i) );
-      fd_gossip_ip_addr_decode_inner_global( cur_mem + FD_GOSSIP_IP_ADDR_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->addrs_gaddr = 0UL;
-  fd_bincode_compact_u16_decode_unsafe( &self->sockets_len, ctx );
-  if( self->sockets_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_GOSSIP_SOCKET_ENTRY_ALIGN );
-    self->sockets_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_GOSSIP_SOCKET_ENTRY_FOOTPRINT*self->sockets_len;
-    for( ulong i=0; i < self->sockets_len; i++ ) {
-      fd_gossip_socket_entry_new( (fd_gossip_socket_entry_t *)(cur_mem + FD_GOSSIP_SOCKET_ENTRY_FOOTPRINT * i) );
-      fd_gossip_socket_entry_decode_inner_global( cur_mem + FD_GOSSIP_SOCKET_ENTRY_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->sockets_gaddr = 0UL;
-  fd_bincode_compact_u16_decode_unsafe( &self->extensions_len, ctx );
-  if( self->extensions_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), 8UL );
-    self->extensions_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + sizeof(uint)*self->extensions_len;
-    for( ulong i=0; i < self->extensions_len; i++ ) {
-      fd_bincode_uint32_decode_unsafe( (uint*)(cur_mem + sizeof(uint) * i), ctx );
-    }
-  } else
-    self->extensions_gaddr = 0UL;
-}
-int fd_gossip_contact_info_v2_convert_global_to_local( void const * global_self, fd_gossip_contact_info_v2_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_contact_info_v2_global_t const * mem = (fd_gossip_contact_info_v2_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->from, &self->from, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->wallclock = mem->wallclock;
-  self->outset = mem->outset;
-  self->shred_version = mem->shred_version;
-  err = fd_gossip_version_v3_convert_global_to_local( &mem->version, &self->version, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->addrs_len = mem->addrs_len;
-  self->addrs     = fd_wksp_laddr_fast( ctx->wksp, mem->addrs_gaddr );
-  self->sockets_len = mem->sockets_len;
-  self->sockets     = fd_wksp_laddr_fast( ctx->wksp, mem->sockets_gaddr );
-  self->extensions_len = mem->extensions_len;
-  self->extensions     = fd_wksp_laddr_fast( ctx->wksp, mem->extensions_gaddr );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_gossip_contact_info_v2_new(fd_gossip_contact_info_v2_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_contact_info_v2_t) );
   fd_pubkey_new( &self->from );
@@ -28091,24 +25161,6 @@ void fd_restart_run_length_encoding_inner_decode_inner( void * struct_mem, void 
   fd_restart_run_length_encoding_inner_t * self = (fd_restart_run_length_encoding_inner_t *)struct_mem;
   fd_bincode_compact_u16_decode_unsafe( &self->bits, ctx );
 }
-void * fd_restart_run_length_encoding_inner_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_restart_run_length_encoding_inner_global_t * self = (fd_restart_run_length_encoding_inner_global_t *)mem;
-  fd_restart_run_length_encoding_inner_new( (fd_restart_run_length_encoding_inner_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_restart_run_length_encoding_inner_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_restart_run_length_encoding_inner_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_restart_run_length_encoding_inner_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_restart_run_length_encoding_inner_global_t * self = (fd_restart_run_length_encoding_inner_global_t *)struct_mem;
-  fd_bincode_compact_u16_decode_unsafe( &self->bits, ctx );
-}
-int fd_restart_run_length_encoding_inner_convert_global_to_local( void const * global_self, fd_restart_run_length_encoding_inner_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_restart_run_length_encoding_inner_global_t const * mem = (fd_restart_run_length_encoding_inner_global_t const *)global_self;
-  self->bits = mem->bits;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_restart_run_length_encoding_inner_new(fd_restart_run_length_encoding_inner_t * self) {
   fd_memset( self, 0, sizeof(fd_restart_run_length_encoding_inner_t) );
 }
@@ -28185,36 +25237,6 @@ void fd_restart_run_length_encoding_decode_inner( void * struct_mem, void * * al
     }
   } else
     self->offsets = NULL;
-}
-void * fd_restart_run_length_encoding_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_restart_run_length_encoding_global_t * self = (fd_restart_run_length_encoding_global_t *)mem;
-  fd_restart_run_length_encoding_new( (fd_restart_run_length_encoding_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_restart_run_length_encoding_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_restart_run_length_encoding_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_restart_run_length_encoding_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_restart_run_length_encoding_global_t * self = (fd_restart_run_length_encoding_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->offsets_len, ctx );
-  if( self->offsets_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_RESTART_RUN_LENGTH_ENCODING_INNER_ALIGN );
-    self->offsets_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_RESTART_RUN_LENGTH_ENCODING_INNER_FOOTPRINT*self->offsets_len;
-    for( ulong i=0; i < self->offsets_len; i++ ) {
-      fd_restart_run_length_encoding_inner_new( (fd_restart_run_length_encoding_inner_t *)(cur_mem + FD_RESTART_RUN_LENGTH_ENCODING_INNER_FOOTPRINT * i) );
-      fd_restart_run_length_encoding_inner_decode_inner_global( cur_mem + FD_RESTART_RUN_LENGTH_ENCODING_INNER_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->offsets_gaddr = 0UL;
-}
-int fd_restart_run_length_encoding_convert_global_to_local( void const * global_self, fd_restart_run_length_encoding_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_restart_run_length_encoding_global_t const * mem = (fd_restart_run_length_encoding_global_t const *)global_self;
-  self->offsets_len = mem->offsets_len;
-  self->offsets     = fd_wksp_laddr_fast( ctx->wksp, mem->offsets_gaddr );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_restart_run_length_encoding_new(fd_restart_run_length_encoding_t * self) {
   fd_memset( self, 0, sizeof(fd_restart_run_length_encoding_t) );
@@ -28299,31 +25321,6 @@ void fd_restart_raw_offsets_bitvec_u8_inner_decode_inner( void * struct_mem, voi
   } else
     self->bits = NULL;
 }
-void * fd_restart_raw_offsets_bitvec_u8_inner_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_restart_raw_offsets_bitvec_u8_inner_global_t * self = (fd_restart_raw_offsets_bitvec_u8_inner_global_t *)mem;
-  fd_restart_raw_offsets_bitvec_u8_inner_new( (fd_restart_raw_offsets_bitvec_u8_inner_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_restart_raw_offsets_bitvec_u8_inner_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_restart_raw_offsets_bitvec_u8_inner_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_restart_raw_offsets_bitvec_u8_inner_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_restart_raw_offsets_bitvec_u8_inner_global_t * self = (fd_restart_raw_offsets_bitvec_u8_inner_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->bits_len, ctx );
-  if( self->bits_len ) {
-    self->bits_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    fd_bincode_bytes_decode_unsafe( *alloc_mem, self->bits_len, ctx );
-    *alloc_mem = (uchar *)(*alloc_mem) + self->bits_len;
-  } else
-    self->bits_gaddr = 0UL;
-}
-int fd_restart_raw_offsets_bitvec_u8_inner_convert_global_to_local( void const * global_self, fd_restart_raw_offsets_bitvec_u8_inner_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_restart_raw_offsets_bitvec_u8_inner_global_t const * mem = (fd_restart_raw_offsets_bitvec_u8_inner_global_t const *)global_self;
-  self->bits_len = mem->bits_len;
-  self->bits     = fd_wksp_laddr_fast( ctx->wksp, mem->bits_gaddr );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_restart_raw_offsets_bitvec_u8_inner_new(fd_restart_raw_offsets_bitvec_u8_inner_t * self) {
   fd_memset( self, 0, sizeof(fd_restart_raw_offsets_bitvec_u8_inner_t) );
 }
@@ -28351,6 +25348,18 @@ ulong fd_restart_raw_offsets_bitvec_u8_inner_size( fd_restart_raw_offsets_bitvec
 }
 
 int fd_restart_raw_offsets_bitvec_encode( fd_restart_raw_offsets_bitvec_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_bool_encode( self->has_bits, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_bits ) {
+    err = fd_restart_raw_offsets_bitvec_u8_inner_encode( &self->bits, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_uint64_encode( self->len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_restart_raw_offsets_bitvec_encode_global( fd_restart_raw_offsets_bitvec_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
   err = fd_bincode_bool_encode( self->has_bits, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -28423,18 +25432,10 @@ void fd_restart_raw_offsets_bitvec_decode_inner_global( void * struct_mem, void 
     self->has_bits = !!o;
     if( o ) {
       fd_restart_raw_offsets_bitvec_u8_inner_new( &self->bits );
-      fd_restart_raw_offsets_bitvec_u8_inner_decode_inner_global( &self->bits, alloc_mem, ctx );
+      fd_restart_raw_offsets_bitvec_u8_inner_decode_inner( &self->bits, alloc_mem, ctx );
     }
   }
   fd_bincode_uint64_decode_unsafe( &self->len, ctx );
-}
-int fd_restart_raw_offsets_bitvec_convert_global_to_local( void const * global_self, fd_restart_raw_offsets_bitvec_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_restart_raw_offsets_bitvec_global_t const * mem = (fd_restart_raw_offsets_bitvec_global_t const *)global_self;
-  self->bits = mem->bits;
-  self->has_bits = mem->has_bits;
-  self->len = mem->len;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_restart_raw_offsets_bitvec_new(fd_restart_raw_offsets_bitvec_t * self) {
   fd_memset( self, 0, sizeof(fd_restart_raw_offsets_bitvec_t) );
@@ -28472,6 +25473,12 @@ ulong fd_restart_raw_offsets_bitvec_size( fd_restart_raw_offsets_bitvec_t const 
 int fd_restart_raw_offsets_encode( fd_restart_raw_offsets_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
   err = fd_restart_raw_offsets_bitvec_encode( &self->offsets, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_restart_raw_offsets_encode_global( fd_restart_raw_offsets_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_restart_raw_offsets_bitvec_encode_global( &self->offsets, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
@@ -28513,13 +25520,6 @@ void * fd_restart_raw_offsets_decode_global( void * mem, fd_bincode_decode_ctx_t
 void fd_restart_raw_offsets_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_restart_raw_offsets_global_t * self = (fd_restart_raw_offsets_global_t *)struct_mem;
   fd_restart_raw_offsets_bitvec_decode_inner_global( &self->offsets, alloc_mem, ctx );
-}
-int fd_restart_raw_offsets_convert_global_to_local( void const * global_self, fd_restart_raw_offsets_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_restart_raw_offsets_global_t const * mem = (fd_restart_raw_offsets_global_t const *)global_self;
-  err = fd_restart_raw_offsets_bitvec_convert_global_to_local( &mem->offsets, &self->offsets, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_restart_raw_offsets_new(fd_restart_raw_offsets_t * self) {
   fd_memset( self, 0, sizeof(fd_restart_raw_offsets_t) );
@@ -28596,7 +25596,7 @@ void fd_restart_slots_offsets_inner_decode_inner( fd_restart_slots_offsets_inner
 void fd_restart_slots_offsets_inner_decode_inner_global( fd_restart_slots_offsets_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
   switch (discriminant) {
   case 0: {
-    fd_restart_run_length_encoding_decode_inner_global( &self->run_length_encoding, alloc_mem, ctx );
+    fd_restart_run_length_encoding_decode_inner( &self->run_length_encoding, alloc_mem, ctx );
     break;
   }
   case 1: {
@@ -28604,29 +25604,6 @@ void fd_restart_slots_offsets_inner_decode_inner_global( fd_restart_slots_offset
     break;
   }
   }
-}
-int fd_restart_slots_offsets_convert_global_to_local_inner( fd_restart_slots_offsets_inner_global_t const * mem, fd_restart_slots_offsets_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_restart_run_length_encoding_convert_global_to_local( &mem->run_length_encoding, &self->run_length_encoding, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 1: {
-    err = fd_restart_raw_offsets_convert_global_to_local( &mem->raw_offsets, &self->raw_offsets, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_restart_slots_offsets_convert_global_to_local( void const * global_self, fd_restart_slots_offsets_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_restart_slots_offsets_global_t const * mem = (fd_restart_slots_offsets_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_restart_slots_offsets_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_restart_slots_offsets_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_restart_slots_offsets_t * self = (fd_restart_slots_offsets_t *)struct_mem;
@@ -28641,6 +25618,28 @@ void * fd_restart_slots_offsets_decode( void * mem, fd_bincode_decode_ctx_t * ct
   fd_restart_slots_offsets_decode_inner( mem, alloc_mem, ctx );
   return self;
 }
+int fd_restart_slots_offsets_inner_encode_global( fd_restart_slots_offsets_inner_global_t const * self, uint discriminant, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  switch (discriminant) {
+  case 0: {
+    err = fd_restart_run_length_encoding_encode( &self->run_length_encoding, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 1: {
+    err = fd_restart_raw_offsets_encode_global( &self->raw_offsets, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_restart_slots_offsets_encode_global( fd_restart_slots_offsets_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err = fd_bincode_uint32_encode( self->discriminant, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fd_restart_slots_offsets_inner_encode_global( &self->inner, self->discriminant, ctx );
+}
+
 void * fd_restart_slots_offsets_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_restart_slots_offsets_t * self = (fd_restart_slots_offsets_t *)mem;
   fd_restart_slots_offsets_new( self );
@@ -28765,6 +25764,22 @@ int fd_gossip_restart_last_voted_fork_slots_encode( fd_gossip_restart_last_voted
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
+int fd_gossip_restart_last_voted_fork_slots_encode_global( fd_gossip_restart_last_voted_fork_slots_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_encode( &self->from, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->wallclock, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_restart_slots_offsets_encode_global( &self->offsets, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->last_voted_slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_hash_encode( &self->last_voted_hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint16_encode( self->shred_version, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
 int fd_gossip_restart_last_voted_fork_slots_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_gossip_restart_last_voted_fork_slots_t);
   void const * start_data = ctx->data;
@@ -28817,26 +25832,12 @@ void * fd_gossip_restart_last_voted_fork_slots_decode_global( void * mem, fd_bin
 }
 void fd_gossip_restart_last_voted_fork_slots_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_gossip_restart_last_voted_fork_slots_global_t * self = (fd_gossip_restart_last_voted_fork_slots_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->from, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->from, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
   fd_restart_slots_offsets_decode_inner_global( &self->offsets, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->last_voted_slot, ctx );
-  fd_hash_decode_inner_global( &self->last_voted_hash, alloc_mem, ctx );
+  fd_hash_decode_inner( &self->last_voted_hash, alloc_mem, ctx );
   fd_bincode_uint16_decode_unsafe( &self->shred_version, ctx );
-}
-int fd_gossip_restart_last_voted_fork_slots_convert_global_to_local( void const * global_self, fd_gossip_restart_last_voted_fork_slots_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_restart_last_voted_fork_slots_global_t const * mem = (fd_gossip_restart_last_voted_fork_slots_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->from, &self->from, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->wallclock = mem->wallclock;
-  err = fd_restart_slots_offsets_convert_global_to_local( &mem->offsets, &self->offsets, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->last_voted_slot = mem->last_voted_slot;
-  err = fd_hash_convert_global_to_local( &mem->last_voted_hash, &self->last_voted_hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->shred_version = mem->shred_version;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_restart_last_voted_fork_slots_new(fd_gossip_restart_last_voted_fork_slots_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_restart_last_voted_fork_slots_t) );
@@ -28931,36 +25932,6 @@ void fd_gossip_restart_heaviest_fork_decode_inner( void * struct_mem, void * * a
   fd_hash_decode_inner( &self->last_slot_hash, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->observed_stake, ctx );
   fd_bincode_uint16_decode_unsafe( &self->shred_version, ctx );
-}
-void * fd_gossip_restart_heaviest_fork_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_restart_heaviest_fork_global_t * self = (fd_gossip_restart_heaviest_fork_global_t *)mem;
-  fd_gossip_restart_heaviest_fork_new( (fd_gossip_restart_heaviest_fork_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_restart_heaviest_fork_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_restart_heaviest_fork_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_restart_heaviest_fork_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_restart_heaviest_fork_global_t * self = (fd_gossip_restart_heaviest_fork_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->from, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->wallclock, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->last_slot, ctx );
-  fd_hash_decode_inner_global( &self->last_slot_hash, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->observed_stake, ctx );
-  fd_bincode_uint16_decode_unsafe( &self->shred_version, ctx );
-}
-int fd_gossip_restart_heaviest_fork_convert_global_to_local( void const * global_self, fd_gossip_restart_heaviest_fork_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_restart_heaviest_fork_global_t const * mem = (fd_gossip_restart_heaviest_fork_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->from, &self->from, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->wallclock = mem->wallclock;
-  self->last_slot = mem->last_slot;
-  err = fd_hash_convert_global_to_local( &mem->last_slot_hash, &self->last_slot_hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->observed_stake = mem->observed_stake;
-  self->shred_version = mem->shred_version;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_restart_heaviest_fork_new(fd_gossip_restart_heaviest_fork_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_restart_heaviest_fork_t) );
@@ -29193,23 +26164,23 @@ void fd_crds_data_inner_decode_inner( fd_crds_data_inner_t * self, void * * allo
 void fd_crds_data_inner_decode_inner_global( fd_crds_data_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
   switch (discriminant) {
   case 0: {
-    fd_gossip_contact_info_v1_decode_inner_global( &self->contact_info_v1, alloc_mem, ctx );
+    fd_gossip_contact_info_v1_decode_inner( &self->contact_info_v1, alloc_mem, ctx );
     break;
   }
   case 1: {
-    fd_gossip_vote_decode_inner_global( &self->vote, alloc_mem, ctx );
+    fd_gossip_vote_decode_inner( &self->vote, alloc_mem, ctx );
     break;
   }
   case 2: {
-    fd_gossip_lowest_slot_decode_inner_global( &self->lowest_slot, alloc_mem, ctx );
+    fd_gossip_lowest_slot_decode_inner( &self->lowest_slot, alloc_mem, ctx );
     break;
   }
   case 3: {
-    fd_gossip_slot_hashes_decode_inner_global( &self->snapshot_hashes, alloc_mem, ctx );
+    fd_gossip_slot_hashes_decode_inner( &self->snapshot_hashes, alloc_mem, ctx );
     break;
   }
   case 4: {
-    fd_gossip_slot_hashes_decode_inner_global( &self->accounts_hashes, alloc_mem, ctx );
+    fd_gossip_slot_hashes_decode_inner( &self->accounts_hashes, alloc_mem, ctx );
     break;
   }
   case 5: {
@@ -29225,19 +26196,19 @@ void fd_crds_data_inner_decode_inner_global( fd_crds_data_inner_global_t * self,
     break;
   }
   case 8: {
-    fd_gossip_node_instance_decode_inner_global( &self->node_instance, alloc_mem, ctx );
+    fd_gossip_node_instance_decode_inner( &self->node_instance, alloc_mem, ctx );
     break;
   }
   case 9: {
-    fd_gossip_duplicate_shred_decode_inner_global( &self->duplicate_shred, alloc_mem, ctx );
+    fd_gossip_duplicate_shred_decode_inner( &self->duplicate_shred, alloc_mem, ctx );
     break;
   }
   case 10: {
-    fd_gossip_incremental_snapshot_hashes_decode_inner_global( &self->incremental_snapshot_hashes, alloc_mem, ctx );
+    fd_gossip_incremental_snapshot_hashes_decode_inner( &self->incremental_snapshot_hashes, alloc_mem, ctx );
     break;
   }
   case 11: {
-    fd_gossip_contact_info_v2_decode_inner_global( &self->contact_info_v2, alloc_mem, ctx );
+    fd_gossip_contact_info_v2_decode_inner( &self->contact_info_v2, alloc_mem, ctx );
     break;
   }
   case 12: {
@@ -29245,93 +26216,10 @@ void fd_crds_data_inner_decode_inner_global( fd_crds_data_inner_global_t * self,
     break;
   }
   case 13: {
-    fd_gossip_restart_heaviest_fork_decode_inner_global( &self->restart_heaviest_fork, alloc_mem, ctx );
+    fd_gossip_restart_heaviest_fork_decode_inner( &self->restart_heaviest_fork, alloc_mem, ctx );
     break;
   }
   }
-}
-int fd_crds_data_convert_global_to_local_inner( fd_crds_data_inner_global_t const * mem, fd_crds_data_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_gossip_contact_info_v1_convert_global_to_local( &mem->contact_info_v1, &self->contact_info_v1, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 1: {
-    err = fd_gossip_vote_convert_global_to_local( &mem->vote, &self->vote, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 2: {
-    err = fd_gossip_lowest_slot_convert_global_to_local( &mem->lowest_slot, &self->lowest_slot, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 3: {
-    err = fd_gossip_slot_hashes_convert_global_to_local( &mem->snapshot_hashes, &self->snapshot_hashes, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 4: {
-    err = fd_gossip_slot_hashes_convert_global_to_local( &mem->accounts_hashes, &self->accounts_hashes, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 5: {
-    err = fd_gossip_epoch_slots_convert_global_to_local( &mem->epoch_slots, &self->epoch_slots, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 6: {
-    err = fd_gossip_version_v1_convert_global_to_local( &mem->version_v1, &self->version_v1, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 7: {
-    err = fd_gossip_version_v2_convert_global_to_local( &mem->version_v2, &self->version_v2, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 8: {
-    err = fd_gossip_node_instance_convert_global_to_local( &mem->node_instance, &self->node_instance, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 9: {
-    err = fd_gossip_duplicate_shred_convert_global_to_local( &mem->duplicate_shred, &self->duplicate_shred, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 10: {
-    err = fd_gossip_incremental_snapshot_hashes_convert_global_to_local( &mem->incremental_snapshot_hashes, &self->incremental_snapshot_hashes, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 11: {
-    err = fd_gossip_contact_info_v2_convert_global_to_local( &mem->contact_info_v2, &self->contact_info_v2, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 12: {
-    err = fd_gossip_restart_last_voted_fork_slots_convert_global_to_local( &mem->restart_last_voted_fork_slots, &self->restart_last_voted_fork_slots, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 13: {
-    err = fd_gossip_restart_heaviest_fork_convert_global_to_local( &mem->restart_heaviest_fork, &self->restart_heaviest_fork, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_crds_data_convert_global_to_local( void const * global_self, fd_crds_data_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_crds_data_global_t const * mem = (fd_crds_data_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_crds_data_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_crds_data_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_crds_data_t * self = (fd_crds_data_t *)struct_mem;
@@ -29346,6 +26234,88 @@ void * fd_crds_data_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_crds_data_decode_inner( mem, alloc_mem, ctx );
   return self;
 }
+int fd_crds_data_inner_encode_global( fd_crds_data_inner_global_t const * self, uint discriminant, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  switch (discriminant) {
+  case 0: {
+    err = fd_gossip_contact_info_v1_encode( &self->contact_info_v1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 1: {
+    err = fd_gossip_vote_encode( &self->vote, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 2: {
+    err = fd_gossip_lowest_slot_encode( &self->lowest_slot, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 3: {
+    err = fd_gossip_slot_hashes_encode( &self->snapshot_hashes, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 4: {
+    err = fd_gossip_slot_hashes_encode( &self->accounts_hashes, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 5: {
+    err = fd_gossip_epoch_slots_encode_global( &self->epoch_slots, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 6: {
+    err = fd_gossip_version_v1_encode_global( &self->version_v1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 7: {
+    err = fd_gossip_version_v2_encode_global( &self->version_v2, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 8: {
+    err = fd_gossip_node_instance_encode( &self->node_instance, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 9: {
+    err = fd_gossip_duplicate_shred_encode( &self->duplicate_shred, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 10: {
+    err = fd_gossip_incremental_snapshot_hashes_encode( &self->incremental_snapshot_hashes, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 11: {
+    err = fd_gossip_contact_info_v2_encode( &self->contact_info_v2, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 12: {
+    err = fd_gossip_restart_last_voted_fork_slots_encode_global( &self->restart_last_voted_fork_slots, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 13: {
+    err = fd_gossip_restart_heaviest_fork_encode( &self->restart_heaviest_fork, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_crds_data_encode_global( fd_crds_data_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err = fd_bincode_uint32_encode( self->discriminant, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fd_crds_data_inner_encode_global( &self->inner, self->discriminant, ctx );
+}
+
 void * fd_crds_data_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_crds_data_t * self = (fd_crds_data_t *)mem;
   fd_crds_data_new( self );
@@ -29733,6 +26703,24 @@ int fd_crds_bloom_encode( fd_crds_bloom_t const * self, fd_bincode_encode_ctx_t 
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
+int fd_crds_bloom_encode_global( fd_crds_bloom_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->keys_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->keys_len ) {
+    uchar * keys_laddr = fd_wksp_laddr_fast( ctx->wksp, self->keys_gaddr );
+    ulong * keys = (ulong *)keys_laddr;
+    for( ulong i=0; i < self->keys_len; i++ ) {
+      err = fd_bincode_uint64_encode( keys[i], ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  err = fd_gossip_bitvec_u64_encode_global( &self->bits, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->num_bits_set, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
 int fd_crds_bloom_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_crds_bloom_t);
   void const * start_data = ctx->data;
@@ -29802,20 +26790,11 @@ void fd_crds_bloom_decode_inner_global( void * struct_mem, void * * alloc_mem, f
     for( ulong i=0; i < self->keys_len; i++ ) {
       fd_bincode_uint64_decode_unsafe( (ulong*)(cur_mem + sizeof(ulong) * i), ctx );
     }
-  } else
+  } else {
     self->keys_gaddr = 0UL;
+  }
   fd_gossip_bitvec_u64_decode_inner_global( &self->bits, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->num_bits_set, ctx );
-}
-int fd_crds_bloom_convert_global_to_local( void const * global_self, fd_crds_bloom_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_crds_bloom_global_t const * mem = (fd_crds_bloom_global_t const *)global_self;
-  self->keys_len = mem->keys_len;
-  self->keys     = fd_wksp_laddr_fast( ctx->wksp, mem->keys_gaddr );
-  err = fd_gossip_bitvec_u64_convert_global_to_local( &mem->bits, &self->bits, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->num_bits_set = mem->num_bits_set;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_crds_bloom_new(fd_crds_bloom_t * self) {
   fd_memset( self, 0, sizeof(fd_crds_bloom_t) );
@@ -29857,6 +26836,16 @@ ulong fd_crds_bloom_size( fd_crds_bloom_t const * self ) {
 int fd_crds_filter_encode( fd_crds_filter_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
   err = fd_crds_bloom_encode( &self->filter, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->mask, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint32_encode( self->mask_bits, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_crds_filter_encode_global( fd_crds_filter_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_crds_bloom_encode_global( &self->filter, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_bincode_uint64_encode( self->mask, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -29911,15 +26900,6 @@ void fd_crds_filter_decode_inner_global( void * struct_mem, void * * alloc_mem, 
   fd_bincode_uint64_decode_unsafe( &self->mask, ctx );
   fd_bincode_uint32_decode_unsafe( &self->mask_bits, ctx );
 }
-int fd_crds_filter_convert_global_to_local( void const * global_self, fd_crds_filter_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_crds_filter_global_t const * mem = (fd_crds_filter_global_t const *)global_self;
-  err = fd_crds_bloom_convert_global_to_local( &mem->filter, &self->filter, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->mask = mem->mask;
-  self->mask_bits = mem->mask_bits;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_crds_filter_new(fd_crds_filter_t * self) {
   fd_memset( self, 0, sizeof(fd_crds_filter_t) );
   fd_crds_bloom_new( &self->filter );
@@ -29951,6 +26931,14 @@ int fd_crds_value_encode( fd_crds_value_t const * self, fd_bincode_encode_ctx_t 
   err = fd_signature_encode( &self->signature, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_crds_data_encode( &self->data, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_crds_value_encode_global( fd_crds_value_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_signature_encode( &self->signature, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_crds_data_encode_global( &self->data, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
@@ -29994,17 +26982,8 @@ void * fd_crds_value_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) 
 }
 void fd_crds_value_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_crds_value_global_t * self = (fd_crds_value_global_t *)struct_mem;
-  fd_signature_decode_inner_global( &self->signature, alloc_mem, ctx );
+  fd_signature_decode_inner( &self->signature, alloc_mem, ctx );
   fd_crds_data_decode_inner_global( &self->data, alloc_mem, ctx );
-}
-int fd_crds_value_convert_global_to_local( void const * global_self, fd_crds_value_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_crds_value_global_t const * mem = (fd_crds_value_global_t const *)global_self;
-  err = fd_signature_convert_global_to_local( &mem->signature, &self->signature, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_crds_data_convert_global_to_local( &mem->data, &self->data, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_crds_value_new(fd_crds_value_t * self) {
   fd_memset( self, 0, sizeof(fd_crds_value_t) );
@@ -30037,6 +27016,14 @@ int fd_gossip_pull_req_encode( fd_gossip_pull_req_t const * self, fd_bincode_enc
   err = fd_crds_filter_encode( &self->filter, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_crds_value_encode( &self->value, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_gossip_pull_req_encode_global( fd_gossip_pull_req_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_crds_filter_encode_global( &self->filter, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_crds_value_encode_global( &self->value, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
@@ -30083,15 +27070,6 @@ void fd_gossip_pull_req_decode_inner_global( void * struct_mem, void * * alloc_m
   fd_crds_filter_decode_inner_global( &self->filter, alloc_mem, ctx );
   fd_crds_value_decode_inner_global( &self->value, alloc_mem, ctx );
 }
-int fd_gossip_pull_req_convert_global_to_local( void const * global_self, fd_gossip_pull_req_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_pull_req_global_t const * mem = (fd_gossip_pull_req_global_t const *)global_self;
-  err = fd_crds_filter_convert_global_to_local( &mem->filter, &self->filter, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_crds_value_convert_global_to_local( &mem->value, &self->value, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_gossip_pull_req_new(fd_gossip_pull_req_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_pull_req_t) );
   fd_crds_filter_new( &self->filter );
@@ -30127,6 +27105,22 @@ int fd_gossip_pull_resp_encode( fd_gossip_pull_resp_t const * self, fd_bincode_e
   if( self->crds_len ) {
     for( ulong i=0; i < self->crds_len; i++ ) {
       err = fd_crds_value_encode( self->crds + i, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_gossip_pull_resp_encode_global( fd_gossip_pull_resp_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_encode( &self->pubkey, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->crds_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->crds_len ) {
+    uchar * crds_laddr = fd_wksp_laddr_fast( ctx->wksp, self->crds_gaddr );
+    fd_crds_value_global_t * crds = (fd_crds_value_global_t *)crds_laddr;
+    for( ulong i=0; i < self->crds_len; i++ ) {
+      err = fd_crds_value_encode_global( &crds[i], ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
   }
@@ -30190,7 +27184,7 @@ void * fd_gossip_pull_resp_decode_global( void * mem, fd_bincode_decode_ctx_t * 
 }
 void fd_gossip_pull_resp_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_gossip_pull_resp_global_t * self = (fd_gossip_pull_resp_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->pubkey, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->pubkey, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->crds_len, ctx );
   if( self->crds_len ) {
     *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_CRDS_VALUE_ALIGN );
@@ -30198,20 +27192,12 @@ void fd_gossip_pull_resp_decode_inner_global( void * struct_mem, void * * alloc_
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_CRDS_VALUE_FOOTPRINT*self->crds_len;
     for( ulong i=0; i < self->crds_len; i++ ) {
-      fd_crds_value_new( (fd_crds_value_t *)(cur_mem + FD_CRDS_VALUE_FOOTPRINT * i) );
+      fd_crds_value_new( (fd_crds_value_t *)fd_type_pun(cur_mem + FD_CRDS_VALUE_FOOTPRINT * i) );
       fd_crds_value_decode_inner_global( cur_mem + FD_CRDS_VALUE_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->crds_gaddr = 0UL;
-}
-int fd_gossip_pull_resp_convert_global_to_local( void const * global_self, fd_gossip_pull_resp_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_pull_resp_global_t const * mem = (fd_gossip_pull_resp_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->pubkey, &self->pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->crds_len = mem->crds_len;
-  self->crds     = fd_wksp_laddr_fast( ctx->wksp, mem->crds_gaddr );
-  return FD_BINCODE_SUCCESS;
+  }
 }
 void fd_gossip_pull_resp_new(fd_gossip_pull_resp_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_pull_resp_t) );
@@ -30260,6 +27246,22 @@ int fd_gossip_push_msg_encode( fd_gossip_push_msg_t const * self, fd_bincode_enc
   if( self->crds_len ) {
     for( ulong i=0; i < self->crds_len; i++ ) {
       err = fd_crds_value_encode( self->crds + i, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_gossip_push_msg_encode_global( fd_gossip_push_msg_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_encode( &self->pubkey, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->crds_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->crds_len ) {
+    uchar * crds_laddr = fd_wksp_laddr_fast( ctx->wksp, self->crds_gaddr );
+    fd_crds_value_global_t * crds = (fd_crds_value_global_t *)crds_laddr;
+    for( ulong i=0; i < self->crds_len; i++ ) {
+      err = fd_crds_value_encode_global( &crds[i], ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
   }
@@ -30323,7 +27325,7 @@ void * fd_gossip_push_msg_decode_global( void * mem, fd_bincode_decode_ctx_t * c
 }
 void fd_gossip_push_msg_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_gossip_push_msg_global_t * self = (fd_gossip_push_msg_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->pubkey, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->pubkey, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->crds_len, ctx );
   if( self->crds_len ) {
     *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_CRDS_VALUE_ALIGN );
@@ -30331,20 +27333,12 @@ void fd_gossip_push_msg_decode_inner_global( void * struct_mem, void * * alloc_m
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_CRDS_VALUE_FOOTPRINT*self->crds_len;
     for( ulong i=0; i < self->crds_len; i++ ) {
-      fd_crds_value_new( (fd_crds_value_t *)(cur_mem + FD_CRDS_VALUE_FOOTPRINT * i) );
+      fd_crds_value_new( (fd_crds_value_t *)fd_type_pun(cur_mem + FD_CRDS_VALUE_FOOTPRINT * i) );
       fd_crds_value_decode_inner_global( cur_mem + FD_CRDS_VALUE_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->crds_gaddr = 0UL;
-}
-int fd_gossip_push_msg_convert_global_to_local( void const * global_self, fd_gossip_push_msg_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_push_msg_global_t const * mem = (fd_gossip_push_msg_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->pubkey, &self->pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->crds_len = mem->crds_len;
-  self->crds     = fd_wksp_laddr_fast( ctx->wksp, mem->crds_gaddr );
-  return FD_BINCODE_SUCCESS;
+  }
 }
 void fd_gossip_push_msg_new(fd_gossip_push_msg_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_push_msg_t) );
@@ -30421,28 +27415,6 @@ void fd_gossip_prune_msg_decode_inner( void * struct_mem, void * * alloc_mem, fd
   fd_gossip_prune_msg_t * self = (fd_gossip_prune_msg_t *)struct_mem;
   fd_pubkey_decode_inner( &self->pubkey, alloc_mem, ctx );
   fd_gossip_prune_data_decode_inner( &self->data, alloc_mem, ctx );
-}
-void * fd_gossip_prune_msg_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_prune_msg_global_t * self = (fd_gossip_prune_msg_global_t *)mem;
-  fd_gossip_prune_msg_new( (fd_gossip_prune_msg_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_gossip_prune_msg_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_gossip_prune_msg_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_gossip_prune_msg_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_prune_msg_global_t * self = (fd_gossip_prune_msg_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->pubkey, alloc_mem, ctx );
-  fd_gossip_prune_data_decode_inner_global( &self->data, alloc_mem, ctx );
-}
-int fd_gossip_prune_msg_convert_global_to_local( void const * global_self, fd_gossip_prune_msg_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_gossip_prune_msg_global_t const * mem = (fd_gossip_prune_msg_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->pubkey, &self->pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_gossip_prune_data_convert_global_to_local( &mem->data, &self->data, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_prune_msg_new(fd_gossip_prune_msg_t * self) {
   fd_memset( self, 0, sizeof(fd_gossip_prune_msg_t) );
@@ -30583,61 +27555,18 @@ void fd_gossip_msg_inner_decode_inner_global( fd_gossip_msg_inner_global_t * sel
     break;
   }
   case 3: {
-    fd_gossip_prune_msg_decode_inner_global( &self->prune_msg, alloc_mem, ctx );
+    fd_gossip_prune_msg_decode_inner( &self->prune_msg, alloc_mem, ctx );
     break;
   }
   case 4: {
-    fd_gossip_ping_decode_inner_global( &self->ping, alloc_mem, ctx );
+    fd_gossip_ping_decode_inner( &self->ping, alloc_mem, ctx );
     break;
   }
   case 5: {
-    fd_gossip_ping_decode_inner_global( &self->pong, alloc_mem, ctx );
+    fd_gossip_ping_decode_inner( &self->pong, alloc_mem, ctx );
     break;
   }
   }
-}
-int fd_gossip_msg_convert_global_to_local_inner( fd_gossip_msg_inner_global_t const * mem, fd_gossip_msg_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_gossip_pull_req_convert_global_to_local( &mem->pull_req, &self->pull_req, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 1: {
-    err = fd_gossip_pull_resp_convert_global_to_local( &mem->pull_resp, &self->pull_resp, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 2: {
-    err = fd_gossip_push_msg_convert_global_to_local( &mem->push_msg, &self->push_msg, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 3: {
-    err = fd_gossip_prune_msg_convert_global_to_local( &mem->prune_msg, &self->prune_msg, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 4: {
-    err = fd_gossip_ping_convert_global_to_local( &mem->ping, &self->ping, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 5: {
-    err = fd_gossip_ping_convert_global_to_local( &mem->pong, &self->pong, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_gossip_msg_convert_global_to_local( void const * global_self, fd_gossip_msg_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_gossip_msg_global_t const * mem = (fd_gossip_msg_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_gossip_msg_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_gossip_msg_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_gossip_msg_t * self = (fd_gossip_msg_t *)struct_mem;
@@ -30652,6 +27581,48 @@ void * fd_gossip_msg_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_gossip_msg_decode_inner( mem, alloc_mem, ctx );
   return self;
 }
+int fd_gossip_msg_inner_encode_global( fd_gossip_msg_inner_global_t const * self, uint discriminant, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  switch (discriminant) {
+  case 0: {
+    err = fd_gossip_pull_req_encode_global( &self->pull_req, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 1: {
+    err = fd_gossip_pull_resp_encode_global( &self->pull_resp, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 2: {
+    err = fd_gossip_push_msg_encode_global( &self->push_msg, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 3: {
+    err = fd_gossip_prune_msg_encode( &self->prune_msg, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 4: {
+    err = fd_gossip_ping_encode( &self->ping, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 5: {
+    err = fd_gossip_ping_encode( &self->pong, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_gossip_msg_encode_global( fd_gossip_msg_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err = fd_bincode_uint32_encode( self->discriminant, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fd_gossip_msg_inner_encode_global( &self->inner, self->discriminant, ctx );
+}
+
 void * fd_gossip_msg_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_gossip_msg_t * self = (fd_gossip_msg_t *)mem;
   fd_gossip_msg_new( self );
@@ -30886,26 +27857,6 @@ void fd_addrlut_create_decode_inner( void * struct_mem, void * * alloc_mem, fd_b
   fd_bincode_uint64_decode_unsafe( &self->recent_slot, ctx );
   fd_bincode_uint8_decode_unsafe( &self->bump_seed, ctx );
 }
-void * fd_addrlut_create_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_addrlut_create_global_t * self = (fd_addrlut_create_global_t *)mem;
-  fd_addrlut_create_new( (fd_addrlut_create_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_addrlut_create_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_addrlut_create_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_addrlut_create_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_addrlut_create_global_t * self = (fd_addrlut_create_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->recent_slot, ctx );
-  fd_bincode_uint8_decode_unsafe( &self->bump_seed, ctx );
-}
-int fd_addrlut_create_convert_global_to_local( void const * global_self, fd_addrlut_create_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_addrlut_create_global_t const * mem = (fd_addrlut_create_global_t const *)global_self;
-  self->recent_slot = mem->recent_slot;
-  self->bump_seed = mem->bump_seed;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_addrlut_create_new(fd_addrlut_create_t * self) {
   fd_memset( self, 0, sizeof(fd_addrlut_create_t) );
 }
@@ -30984,36 +27935,6 @@ void fd_addrlut_extend_decode_inner( void * struct_mem, void * * alloc_mem, fd_b
     }
   } else
     self->new_addrs = NULL;
-}
-void * fd_addrlut_extend_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_addrlut_extend_global_t * self = (fd_addrlut_extend_global_t *)mem;
-  fd_addrlut_extend_new( (fd_addrlut_extend_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_addrlut_extend_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_addrlut_extend_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_addrlut_extend_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_addrlut_extend_global_t * self = (fd_addrlut_extend_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->new_addrs_len, ctx );
-  if( self->new_addrs_len ) {
-    *alloc_mem = (void*)fd_ulong_align_up( (ulong)(*alloc_mem), FD_PUBKEY_ALIGN );
-    self->new_addrs_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    uchar * cur_mem = (uchar *)(*alloc_mem);
-    *alloc_mem = (uchar *)(*alloc_mem) + FD_PUBKEY_FOOTPRINT*self->new_addrs_len;
-    for( ulong i=0; i < self->new_addrs_len; i++ ) {
-      fd_pubkey_new( (fd_pubkey_t *)(cur_mem + FD_PUBKEY_FOOTPRINT * i) );
-      fd_pubkey_decode_inner_global( cur_mem + FD_PUBKEY_FOOTPRINT * i, alloc_mem, ctx );
-    }
-  } else
-    self->new_addrs_gaddr = 0UL;
-}
-int fd_addrlut_extend_convert_global_to_local( void const * global_self, fd_addrlut_extend_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_addrlut_extend_global_t const * mem = (fd_addrlut_extend_global_t const *)global_self;
-  self->new_addrs_len = mem->new_addrs_len;
-  self->new_addrs     = fd_wksp_laddr_fast( ctx->wksp, mem->new_addrs_gaddr );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_addrlut_extend_new(fd_addrlut_extend_t * self) {
   fd_memset( self, 0, sizeof(fd_addrlut_extend_t) );
@@ -31126,59 +28047,6 @@ void fd_addrlut_instruction_inner_decode_inner( fd_addrlut_instruction_inner_t *
   }
   }
 }
-void fd_addrlut_instruction_inner_decode_inner_global( fd_addrlut_instruction_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    fd_addrlut_create_decode_inner_global( &self->create_lut, alloc_mem, ctx );
-    break;
-  }
-  case 1: {
-    break;
-  }
-  case 2: {
-    fd_addrlut_extend_decode_inner_global( &self->extend_lut, alloc_mem, ctx );
-    break;
-  }
-  case 3: {
-    break;
-  }
-  case 4: {
-    break;
-  }
-  }
-}
-int fd_addrlut_instruction_convert_global_to_local_inner( fd_addrlut_instruction_inner_global_t const * mem, fd_addrlut_instruction_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_addrlut_create_convert_global_to_local( &mem->create_lut, &self->create_lut, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 1: {
-    break;
-  }
-  case 2: {
-    err = fd_addrlut_extend_convert_global_to_local( &mem->extend_lut, &self->extend_lut, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 3: {
-    break;
-  }
-  case 4: {
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_addrlut_instruction_convert_global_to_local( void const * global_self, fd_addrlut_instruction_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_addrlut_instruction_global_t const * mem = (fd_addrlut_instruction_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_addrlut_instruction_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_addrlut_instruction_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_addrlut_instruction_t * self = (fd_addrlut_instruction_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -31191,19 +28059,6 @@ void * fd_addrlut_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx 
   void * * alloc_mem = &alloc_region;
   fd_addrlut_instruction_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_addrlut_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_addrlut_instruction_t * self = (fd_addrlut_instruction_t *)mem;
-  fd_addrlut_instruction_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_addrlut_instruction_t);
-  void * * alloc_mem = &alloc_region;
-  fd_addrlut_instruction_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_addrlut_instruction_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_addrlut_instruction_global_t * self = (fd_addrlut_instruction_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_addrlut_instruction_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_addrlut_instruction_inner_new( fd_addrlut_instruction_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -31374,35 +28229,6 @@ void fd_repair_request_header_decode_inner( void * struct_mem, void * * alloc_me
   fd_bincode_uint64_decode_unsafe( (ulong *) &self->timestamp, ctx );
   fd_bincode_uint32_decode_unsafe( &self->nonce, ctx );
 }
-void * fd_repair_request_header_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_repair_request_header_global_t * self = (fd_repair_request_header_global_t *)mem;
-  fd_repair_request_header_new( (fd_repair_request_header_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_repair_request_header_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_repair_request_header_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_repair_request_header_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_repair_request_header_global_t * self = (fd_repair_request_header_global_t *)struct_mem;
-  fd_signature_decode_inner_global( &self->signature, alloc_mem, ctx );
-  fd_pubkey_decode_inner_global( &self->sender, alloc_mem, ctx );
-  fd_pubkey_decode_inner_global( &self->recipient, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( (ulong *) &self->timestamp, ctx );
-  fd_bincode_uint32_decode_unsafe( &self->nonce, ctx );
-}
-int fd_repair_request_header_convert_global_to_local( void const * global_self, fd_repair_request_header_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_repair_request_header_global_t const * mem = (fd_repair_request_header_global_t const *)global_self;
-  err = fd_signature_convert_global_to_local( &mem->signature, &self->signature, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_pubkey_convert_global_to_local( &mem->sender, &self->sender, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_pubkey_convert_global_to_local( &mem->recipient, &self->recipient, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->timestamp = mem->timestamp;
-  self->nonce = mem->nonce;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_repair_request_header_new(fd_repair_request_header_t * self) {
   fd_memset( self, 0, sizeof(fd_repair_request_header_t) );
   fd_signature_new( &self->signature );
@@ -31480,29 +28306,6 @@ void fd_repair_window_index_decode_inner( void * struct_mem, void * * alloc_mem,
   fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
   fd_bincode_uint64_decode_unsafe( &self->shred_index, ctx );
 }
-void * fd_repair_window_index_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_repair_window_index_global_t * self = (fd_repair_window_index_global_t *)mem;
-  fd_repair_window_index_new( (fd_repair_window_index_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_repair_window_index_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_repair_window_index_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_repair_window_index_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_repair_window_index_global_t * self = (fd_repair_window_index_global_t *)struct_mem;
-  fd_repair_request_header_decode_inner_global( &self->header, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->shred_index, ctx );
-}
-int fd_repair_window_index_convert_global_to_local( void const * global_self, fd_repair_window_index_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_repair_window_index_global_t const * mem = (fd_repair_window_index_global_t const *)global_self;
-  err = fd_repair_request_header_convert_global_to_local( &mem->header, &self->header, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->slot = mem->slot;
-  self->shred_index = mem->shred_index;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_repair_window_index_new(fd_repair_window_index_t * self) {
   fd_memset( self, 0, sizeof(fd_repair_window_index_t) );
   fd_repair_request_header_new( &self->header );
@@ -31572,29 +28375,6 @@ void fd_repair_highest_window_index_decode_inner( void * struct_mem, void * * al
   fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
   fd_bincode_uint64_decode_unsafe( &self->shred_index, ctx );
 }
-void * fd_repair_highest_window_index_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_repair_highest_window_index_global_t * self = (fd_repair_highest_window_index_global_t *)mem;
-  fd_repair_highest_window_index_new( (fd_repair_highest_window_index_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_repair_highest_window_index_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_repair_highest_window_index_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_repair_highest_window_index_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_repair_highest_window_index_global_t * self = (fd_repair_highest_window_index_global_t *)struct_mem;
-  fd_repair_request_header_decode_inner_global( &self->header, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->shred_index, ctx );
-}
-int fd_repair_highest_window_index_convert_global_to_local( void const * global_self, fd_repair_highest_window_index_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_repair_highest_window_index_global_t const * mem = (fd_repair_highest_window_index_global_t const *)global_self;
-  err = fd_repair_request_header_convert_global_to_local( &mem->header, &self->header, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->slot = mem->slot;
-  self->shred_index = mem->shred_index;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_repair_highest_window_index_new(fd_repair_highest_window_index_t * self) {
   fd_memset( self, 0, sizeof(fd_repair_highest_window_index_t) );
   fd_repair_request_header_new( &self->header );
@@ -31659,27 +28439,6 @@ void fd_repair_orphan_decode_inner( void * struct_mem, void * * alloc_mem, fd_bi
   fd_repair_request_header_decode_inner( &self->header, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
 }
-void * fd_repair_orphan_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_repair_orphan_global_t * self = (fd_repair_orphan_global_t *)mem;
-  fd_repair_orphan_new( (fd_repair_orphan_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_repair_orphan_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_repair_orphan_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_repair_orphan_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_repair_orphan_global_t * self = (fd_repair_orphan_global_t *)struct_mem;
-  fd_repair_request_header_decode_inner_global( &self->header, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-}
-int fd_repair_orphan_convert_global_to_local( void const * global_self, fd_repair_orphan_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_repair_orphan_global_t const * mem = (fd_repair_orphan_global_t const *)global_self;
-  err = fd_repair_request_header_convert_global_to_local( &mem->header, &self->header, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->slot = mem->slot;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_repair_orphan_new(fd_repair_orphan_t * self) {
   fd_memset( self, 0, sizeof(fd_repair_orphan_t) );
   fd_repair_request_header_new( &self->header );
@@ -31741,27 +28500,6 @@ void fd_repair_ancestor_hashes_decode_inner( void * struct_mem, void * * alloc_m
   fd_repair_ancestor_hashes_t * self = (fd_repair_ancestor_hashes_t *)struct_mem;
   fd_repair_request_header_decode_inner( &self->header, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-}
-void * fd_repair_ancestor_hashes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_repair_ancestor_hashes_global_t * self = (fd_repair_ancestor_hashes_global_t *)mem;
-  fd_repair_ancestor_hashes_new( (fd_repair_ancestor_hashes_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_repair_ancestor_hashes_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_repair_ancestor_hashes_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_repair_ancestor_hashes_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_repair_ancestor_hashes_global_t * self = (fd_repair_ancestor_hashes_global_t *)struct_mem;
-  fd_repair_request_header_decode_inner_global( &self->header, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
-}
-int fd_repair_ancestor_hashes_convert_global_to_local( void const * global_self, fd_repair_ancestor_hashes_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_repair_ancestor_hashes_global_t const * mem = (fd_repair_ancestor_hashes_global_t const *)global_self;
-  err = fd_repair_request_header_convert_global_to_local( &mem->header, &self->header, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->slot = mem->slot;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_repair_ancestor_hashes_new(fd_repair_ancestor_hashes_t * self) {
   fd_memset( self, 0, sizeof(fd_repair_ancestor_hashes_t) );
@@ -31936,110 +28674,6 @@ void fd_repair_protocol_inner_decode_inner( fd_repair_protocol_inner_t * self, v
   }
   }
 }
-void fd_repair_protocol_inner_decode_inner_global( fd_repair_protocol_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    break;
-  }
-  case 2: {
-    break;
-  }
-  case 3: {
-    break;
-  }
-  case 4: {
-    break;
-  }
-  case 5: {
-    break;
-  }
-  case 6: {
-    break;
-  }
-  case 7: {
-    fd_gossip_ping_decode_inner_global( &self->pong, alloc_mem, ctx );
-    break;
-  }
-  case 8: {
-    fd_repair_window_index_decode_inner_global( &self->window_index, alloc_mem, ctx );
-    break;
-  }
-  case 9: {
-    fd_repair_highest_window_index_decode_inner_global( &self->highest_window_index, alloc_mem, ctx );
-    break;
-  }
-  case 10: {
-    fd_repair_orphan_decode_inner_global( &self->orphan, alloc_mem, ctx );
-    break;
-  }
-  case 11: {
-    fd_repair_ancestor_hashes_decode_inner_global( &self->ancestor_hashes, alloc_mem, ctx );
-    break;
-  }
-  }
-}
-int fd_repair_protocol_convert_global_to_local_inner( fd_repair_protocol_inner_global_t const * mem, fd_repair_protocol_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    break;
-  }
-  case 2: {
-    break;
-  }
-  case 3: {
-    break;
-  }
-  case 4: {
-    break;
-  }
-  case 5: {
-    break;
-  }
-  case 6: {
-    break;
-  }
-  case 7: {
-    err = fd_gossip_ping_convert_global_to_local( &mem->pong, &self->pong, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 8: {
-    err = fd_repair_window_index_convert_global_to_local( &mem->window_index, &self->window_index, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 9: {
-    err = fd_repair_highest_window_index_convert_global_to_local( &mem->highest_window_index, &self->highest_window_index, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 10: {
-    err = fd_repair_orphan_convert_global_to_local( &mem->orphan, &self->orphan, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 11: {
-    err = fd_repair_ancestor_hashes_convert_global_to_local( &mem->ancestor_hashes, &self->ancestor_hashes, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_repair_protocol_convert_global_to_local( void const * global_self, fd_repair_protocol_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_repair_protocol_global_t const * mem = (fd_repair_protocol_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_repair_protocol_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_repair_protocol_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_repair_protocol_t * self = (fd_repair_protocol_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -32052,19 +28686,6 @@ void * fd_repair_protocol_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   void * * alloc_mem = &alloc_region;
   fd_repair_protocol_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_repair_protocol_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_repair_protocol_t * self = (fd_repair_protocol_t *)mem;
-  fd_repair_protocol_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_repair_protocol_t);
-  void * * alloc_mem = &alloc_region;
-  fd_repair_protocol_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_repair_protocol_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_repair_protocol_global_t * self = (fd_repair_protocol_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_repair_protocol_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_repair_protocol_inner_new( fd_repair_protocol_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -32314,32 +28935,6 @@ void fd_repair_response_inner_decode_inner( fd_repair_response_inner_t * self, v
   }
   }
 }
-void fd_repair_response_inner_decode_inner_global( fd_repair_response_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    fd_gossip_ping_decode_inner_global( &self->ping, alloc_mem, ctx );
-    break;
-  }
-  }
-}
-int fd_repair_response_convert_global_to_local_inner( fd_repair_response_inner_global_t const * mem, fd_repair_response_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    err = fd_gossip_ping_convert_global_to_local( &mem->ping, &self->ping, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_repair_response_convert_global_to_local( void const * global_self, fd_repair_response_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_repair_response_global_t const * mem = (fd_repair_response_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_repair_response_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_repair_response_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_repair_response_t * self = (fd_repair_response_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -32352,19 +28947,6 @@ void * fd_repair_response_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   void * * alloc_mem = &alloc_region;
   fd_repair_response_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_repair_response_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_repair_response_t * self = (fd_repair_response_t *)mem;
-  fd_repair_response_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_repair_response_t);
-  void * * alloc_mem = &alloc_region;
-  fd_repair_response_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_repair_response_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_repair_response_global_t * self = (fd_repair_response_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_repair_response_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_repair_response_inner_new( fd_repair_response_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -33139,183 +29721,6 @@ void fd_instr_error_enum_inner_decode_inner_global( fd_instr_error_enum_inner_gl
   }
   }
 }
-int fd_instr_error_enum_convert_global_to_local_inner( fd_instr_error_enum_inner_global_t const * mem, fd_instr_error_enum_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    break;
-  }
-  case 2: {
-    break;
-  }
-  case 3: {
-    break;
-  }
-  case 4: {
-    break;
-  }
-  case 5: {
-    break;
-  }
-  case 6: {
-    break;
-  }
-  case 7: {
-    break;
-  }
-  case 8: {
-    break;
-  }
-  case 9: {
-    break;
-  }
-  case 10: {
-    break;
-  }
-  case 11: {
-    break;
-  }
-  case 12: {
-    break;
-  }
-  case 13: {
-    break;
-  }
-  case 14: {
-    break;
-  }
-  case 15: {
-    break;
-  }
-  case 16: {
-    break;
-  }
-  case 17: {
-    break;
-  }
-  case 18: {
-    break;
-  }
-  case 19: {
-    break;
-  }
-  case 20: {
-    break;
-  }
-  case 21: {
-    break;
-  }
-  case 22: {
-    break;
-  }
-  case 23: {
-    break;
-  }
-  case 24: {
-    break;
-  }
-  case 25: {
-    self->custom = mem->custom;
-    break;
-  }
-  case 26: {
-    break;
-  }
-  case 27: {
-    break;
-  }
-  case 28: {
-    break;
-  }
-  case 29: {
-    break;
-  }
-  case 30: {
-    break;
-  }
-  case 31: {
-    break;
-  }
-  case 32: {
-    break;
-  }
-  case 33: {
-    break;
-  }
-  case 34: {
-    break;
-  }
-  case 35: {
-    break;
-  }
-  case 36: {
-    break;
-  }
-  case 37: {
-    break;
-  }
-  case 38: {
-    break;
-  }
-  case 39: {
-    break;
-  }
-  case 40: {
-    break;
-  }
-  case 41: {
-    break;
-  }
-  case 42: {
-    break;
-  }
-  case 43: {
-    break;
-  }
-  case 44: {
-    strcpy( self->borsh_io_error, mem->borsh_io_error);
-    break;
-  }
-  case 45: {
-    break;
-  }
-  case 46: {
-    break;
-  }
-  case 47: {
-    break;
-  }
-  case 48: {
-    break;
-  }
-  case 49: {
-    break;
-  }
-  case 50: {
-    break;
-  }
-  case 51: {
-    break;
-  }
-  case 52: {
-    break;
-  }
-  case 53: {
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_instr_error_enum_convert_global_to_local( void const * global_self, fd_instr_error_enum_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_instr_error_enum_global_t const * mem = (fd_instr_error_enum_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_instr_error_enum_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_instr_error_enum_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_instr_error_enum_t * self = (fd_instr_error_enum_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -33329,6 +29734,31 @@ void * fd_instr_error_enum_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_instr_error_enum_decode_inner( mem, alloc_mem, ctx );
   return self;
 }
+int fd_instr_error_enum_inner_encode_global( fd_instr_error_enum_inner_global_t const * self, uint discriminant, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  switch (discriminant) {
+  case 25: {
+    err = fd_bincode_uint32_encode( self->custom, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 44: {
+    ulong slen = strlen( (char *) self->borsh_io_error );
+    err = fd_bincode_uint64_encode( slen, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    err = fd_bincode_bytes_encode( (uchar *) self->borsh_io_error, slen, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_instr_error_enum_encode_global( fd_instr_error_enum_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err = fd_bincode_uint32_encode( self->discriminant, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fd_instr_error_enum_inner_encode_global( &self->inner, self->discriminant, ctx );
+}
+
 void * fd_instr_error_enum_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_instr_error_enum_t * self = (fd_instr_error_enum_t *)mem;
   fd_instr_error_enum_new( self );
@@ -33810,6 +30240,14 @@ int fd_txn_instr_error_encode( fd_txn_instr_error_t const * self, fd_bincode_enc
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
+int fd_txn_instr_error_encode_global( fd_txn_instr_error_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint8_encode( (uchar)(self->instr_idx), ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_instr_error_enum_encode_global( &self->error, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
 int fd_txn_instr_error_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_txn_instr_error_t);
   void const * start_data = ctx->data;
@@ -33852,14 +30290,6 @@ void fd_txn_instr_error_decode_inner_global( void * struct_mem, void * * alloc_m
   fd_txn_instr_error_global_t * self = (fd_txn_instr_error_global_t *)struct_mem;
   fd_bincode_uint8_decode_unsafe( &self->instr_idx, ctx );
   fd_instr_error_enum_decode_inner_global( &self->error, alloc_mem, ctx );
-}
-int fd_txn_instr_error_convert_global_to_local( void const * global_self, fd_txn_instr_error_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_txn_instr_error_global_t const * mem = (fd_txn_instr_error_global_t const *)global_self;
-  self->instr_idx = mem->instr_idx;
-  err = fd_instr_error_enum_convert_global_to_local( &mem->error, &self->error, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_txn_instr_error_new(fd_txn_instr_error_t * self) {
   fd_memset( self, 0, sizeof(fd_txn_instr_error_t) );
@@ -34375,135 +30805,6 @@ void fd_txn_error_enum_inner_decode_inner_global( fd_txn_error_enum_inner_global
   }
   }
 }
-int fd_txn_error_enum_convert_global_to_local_inner( fd_txn_error_enum_inner_global_t const * mem, fd_txn_error_enum_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    break;
-  }
-  case 2: {
-    break;
-  }
-  case 3: {
-    break;
-  }
-  case 4: {
-    break;
-  }
-  case 5: {
-    break;
-  }
-  case 6: {
-    break;
-  }
-  case 7: {
-    break;
-  }
-  case 8: {
-    err = fd_txn_instr_error_convert_global_to_local( &mem->instruction_error, &self->instruction_error, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  case 9: {
-    break;
-  }
-  case 10: {
-    break;
-  }
-  case 11: {
-    break;
-  }
-  case 12: {
-    break;
-  }
-  case 13: {
-    break;
-  }
-  case 14: {
-    break;
-  }
-  case 15: {
-    break;
-  }
-  case 16: {
-    break;
-  }
-  case 17: {
-    break;
-  }
-  case 18: {
-    break;
-  }
-  case 19: {
-    break;
-  }
-  case 20: {
-    break;
-  }
-  case 21: {
-    break;
-  }
-  case 22: {
-    break;
-  }
-  case 23: {
-    break;
-  }
-  case 24: {
-    break;
-  }
-  case 25: {
-    break;
-  }
-  case 26: {
-    break;
-  }
-  case 27: {
-    break;
-  }
-  case 28: {
-    break;
-  }
-  case 29: {
-    break;
-  }
-  case 30: {
-    self->duplicate_instruction = mem->duplicate_instruction;
-    break;
-  }
-  case 31: {
-    self->insufficient_funds_for_rent = mem->insufficient_funds_for_rent;
-    break;
-  }
-  case 32: {
-    break;
-  }
-  case 33: {
-    break;
-  }
-  case 34: {
-    break;
-  }
-  case 35: {
-    self->program_execution_temporarily_restricted = mem->program_execution_temporarily_restricted;
-    break;
-  }
-  case 36: {
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_txn_error_enum_convert_global_to_local( void const * global_self, fd_txn_error_enum_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_txn_error_enum_global_t const * mem = (fd_txn_error_enum_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_txn_error_enum_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_txn_error_enum_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_txn_error_enum_t * self = (fd_txn_error_enum_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -34517,6 +30818,38 @@ void * fd_txn_error_enum_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_txn_error_enum_decode_inner( mem, alloc_mem, ctx );
   return self;
 }
+int fd_txn_error_enum_inner_encode_global( fd_txn_error_enum_inner_global_t const * self, uint discriminant, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  switch (discriminant) {
+  case 8: {
+    err = fd_txn_instr_error_encode_global( &self->instruction_error, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 30: {
+    err = fd_bincode_uint8_encode( (uchar)(self->duplicate_instruction), ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 31: {
+    err = fd_bincode_uint8_encode( (uchar)(self->insufficient_funds_for_rent), ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  case 35: {
+    err = fd_bincode_uint8_encode( (uchar)(self->program_execution_temporarily_restricted), ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_txn_error_enum_encode_global( fd_txn_error_enum_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err = fd_bincode_uint32_encode( self->discriminant, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fd_txn_error_enum_inner_encode_global( &self->inner, self->discriminant, ctx );
+}
+
 void * fd_txn_error_enum_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_txn_error_enum_t * self = (fd_txn_error_enum_t *)mem;
   fd_txn_error_enum_new( self );
@@ -34952,27 +31285,6 @@ void fd_txn_result_inner_decode_inner_global( fd_txn_result_inner_global_t * sel
   }
   }
 }
-int fd_txn_result_convert_global_to_local_inner( fd_txn_result_inner_global_t const * mem, fd_txn_result_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    err = fd_txn_error_enum_convert_global_to_local( &mem->error, &self->error, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_txn_result_convert_global_to_local( void const * global_self, fd_txn_result_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_txn_result_global_t const * mem = (fd_txn_result_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_txn_result_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_txn_result_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_txn_result_t * self = (fd_txn_result_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -34986,6 +31298,23 @@ void * fd_txn_result_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_txn_result_decode_inner( mem, alloc_mem, ctx );
   return self;
 }
+int fd_txn_result_inner_encode_global( fd_txn_result_inner_global_t const * self, uint discriminant, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  switch (discriminant) {
+  case 1: {
+    err = fd_txn_error_enum_encode_global( &self->error, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    break;
+  }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_txn_result_encode_global( fd_txn_result_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err = fd_bincode_uint32_encode( self->discriminant, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fd_txn_result_inner_encode_global( &self->inner, self->discriminant, ctx );
+}
+
 void * fd_txn_result_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_txn_result_t * self = (fd_txn_result_t *)mem;
   fd_txn_result_new( self );
@@ -35087,6 +31416,14 @@ int fd_cache_status_encode( fd_cache_status_t const * self, fd_bincode_encode_ct
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
+int fd_cache_status_encode_global( fd_cache_status_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_bytes_encode( self->key_slice, 20, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_txn_result_encode_global( &self->result, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
 int fd_cache_status_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_cache_status_t);
   void const * start_data = ctx->data;
@@ -35130,14 +31467,6 @@ void fd_cache_status_decode_inner_global( void * struct_mem, void * * alloc_mem,
   fd_bincode_bytes_decode_unsafe( self->key_slice, 20, ctx );
   fd_txn_result_decode_inner_global( &self->result, alloc_mem, ctx );
 }
-int fd_cache_status_convert_global_to_local( void const * global_self, fd_cache_status_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_cache_status_global_t const * mem = (fd_cache_status_global_t const *)global_self;
-  fd_memcpy( self->key_slice, mem->key_slice, 20 * sizeof(uchar) );
-  err = fd_txn_result_convert_global_to_local( &mem->result, &self->result, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_cache_status_new(fd_cache_status_t * self) {
   fd_memset( self, 0, sizeof(fd_cache_status_t) );
   fd_txn_result_new( &self->result );
@@ -35171,6 +31500,22 @@ int fd_status_value_encode( fd_status_value_t const * self, fd_bincode_encode_ct
   if( self->statuses_len ) {
     for( ulong i=0; i < self->statuses_len; i++ ) {
       err = fd_cache_status_encode( self->statuses + i, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_status_value_encode_global( fd_status_value_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->txn_idx, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->statuses_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->statuses_len ) {
+    uchar * statuses_laddr = fd_wksp_laddr_fast( ctx->wksp, self->statuses_gaddr );
+    fd_cache_status_global_t * statuses = (fd_cache_status_global_t *)statuses_laddr;
+    for( ulong i=0; i < self->statuses_len; i++ ) {
+      err = fd_cache_status_encode_global( &statuses[i], ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
   }
@@ -35242,19 +31587,12 @@ void fd_status_value_decode_inner_global( void * struct_mem, void * * alloc_mem,
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_CACHE_STATUS_FOOTPRINT*self->statuses_len;
     for( ulong i=0; i < self->statuses_len; i++ ) {
-      fd_cache_status_new( (fd_cache_status_t *)(cur_mem + FD_CACHE_STATUS_FOOTPRINT * i) );
+      fd_cache_status_new( (fd_cache_status_t *)fd_type_pun(cur_mem + FD_CACHE_STATUS_FOOTPRINT * i) );
       fd_cache_status_decode_inner_global( cur_mem + FD_CACHE_STATUS_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->statuses_gaddr = 0UL;
-}
-int fd_status_value_convert_global_to_local( void const * global_self, fd_status_value_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_status_value_global_t const * mem = (fd_status_value_global_t const *)global_self;
-  self->txn_idx = mem->txn_idx;
-  self->statuses_len = mem->statuses_len;
-  self->statuses     = fd_wksp_laddr_fast( ctx->wksp, mem->statuses_gaddr );
-  return FD_BINCODE_SUCCESS;
+  }
 }
 void fd_status_value_new(fd_status_value_t * self) {
   fd_memset( self, 0, sizeof(fd_status_value_t) );
@@ -35300,6 +31638,14 @@ int fd_status_pair_encode( fd_status_pair_t const * self, fd_bincode_encode_ctx_
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
+int fd_status_pair_encode_global( fd_status_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_hash_encode( &self->hash, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_status_value_encode_global( &self->value, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
 int fd_status_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
   *total_sz += sizeof(fd_status_pair_t);
   void const * start_data = ctx->data;
@@ -35340,17 +31686,8 @@ void * fd_status_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx )
 }
 void fd_status_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_status_pair_global_t * self = (fd_status_pair_global_t *)struct_mem;
-  fd_hash_decode_inner_global( &self->hash, alloc_mem, ctx );
+  fd_hash_decode_inner( &self->hash, alloc_mem, ctx );
   fd_status_value_decode_inner_global( &self->value, alloc_mem, ctx );
-}
-int fd_status_pair_convert_global_to_local( void const * global_self, fd_status_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_status_pair_global_t const * mem = (fd_status_pair_global_t const *)global_self;
-  err = fd_hash_convert_global_to_local( &mem->hash, &self->hash, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_status_value_convert_global_to_local( &mem->value, &self->value, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_status_pair_new(fd_status_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_status_pair_t) );
@@ -35389,6 +31726,24 @@ int fd_slot_delta_encode( fd_slot_delta_t const * self, fd_bincode_encode_ctx_t 
   if( self->slot_delta_vec_len ) {
     for( ulong i=0; i < self->slot_delta_vec_len; i++ ) {
       err = fd_status_pair_encode( self->slot_delta_vec + i, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_slot_delta_encode_global( fd_slot_delta_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->slot, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_bool_encode( (uchar)(self->is_root), ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->slot_delta_vec_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->slot_delta_vec_len ) {
+    uchar * slot_delta_vec_laddr = fd_wksp_laddr_fast( ctx->wksp, self->slot_delta_vec_gaddr );
+    fd_status_pair_global_t * slot_delta_vec = (fd_status_pair_global_t *)slot_delta_vec_laddr;
+    for( ulong i=0; i < self->slot_delta_vec_len; i++ ) {
+      err = fd_status_pair_encode_global( &slot_delta_vec[i], ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
   }
@@ -35464,20 +31819,12 @@ void fd_slot_delta_decode_inner_global( void * struct_mem, void * * alloc_mem, f
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_STATUS_PAIR_FOOTPRINT*self->slot_delta_vec_len;
     for( ulong i=0; i < self->slot_delta_vec_len; i++ ) {
-      fd_status_pair_new( (fd_status_pair_t *)(cur_mem + FD_STATUS_PAIR_FOOTPRINT * i) );
+      fd_status_pair_new( (fd_status_pair_t *)fd_type_pun(cur_mem + FD_STATUS_PAIR_FOOTPRINT * i) );
       fd_status_pair_decode_inner_global( cur_mem + FD_STATUS_PAIR_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->slot_delta_vec_gaddr = 0UL;
-}
-int fd_slot_delta_convert_global_to_local( void const * global_self, fd_slot_delta_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_slot_delta_global_t const * mem = (fd_slot_delta_global_t const *)global_self;
-  self->slot = mem->slot;
-  self->is_root = mem->is_root;
-  self->slot_delta_vec_len = mem->slot_delta_vec_len;
-  self->slot_delta_vec     = fd_wksp_laddr_fast( ctx->wksp, mem->slot_delta_vec_gaddr );
-  return FD_BINCODE_SUCCESS;
+  }
 }
 void fd_slot_delta_new(fd_slot_delta_t * self) {
   fd_memset( self, 0, sizeof(fd_slot_delta_t) );
@@ -35524,6 +31871,20 @@ int fd_bank_slot_deltas_encode( fd_bank_slot_deltas_t const * self, fd_bincode_e
   if( self->slot_deltas_len ) {
     for( ulong i=0; i < self->slot_deltas_len; i++ ) {
       err = fd_slot_delta_encode( self->slot_deltas + i, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_bank_slot_deltas_encode_global( fd_bank_slot_deltas_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->slot_deltas_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->slot_deltas_len ) {
+    uchar * slot_deltas_laddr = fd_wksp_laddr_fast( ctx->wksp, self->slot_deltas_gaddr );
+    fd_slot_delta_global_t * slot_deltas = (fd_slot_delta_global_t *)slot_deltas_laddr;
+    for( ulong i=0; i < self->slot_deltas_len; i++ ) {
+      err = fd_slot_delta_encode_global( &slot_deltas[i], ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
   }
@@ -35591,18 +31952,12 @@ void fd_bank_slot_deltas_decode_inner_global( void * struct_mem, void * * alloc_
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_SLOT_DELTA_FOOTPRINT*self->slot_deltas_len;
     for( ulong i=0; i < self->slot_deltas_len; i++ ) {
-      fd_slot_delta_new( (fd_slot_delta_t *)(cur_mem + FD_SLOT_DELTA_FOOTPRINT * i) );
+      fd_slot_delta_new( (fd_slot_delta_t *)fd_type_pun(cur_mem + FD_SLOT_DELTA_FOOTPRINT * i) );
       fd_slot_delta_decode_inner_global( cur_mem + FD_SLOT_DELTA_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->slot_deltas_gaddr = 0UL;
-}
-int fd_bank_slot_deltas_convert_global_to_local( void const * global_self, fd_bank_slot_deltas_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_bank_slot_deltas_global_t const * mem = (fd_bank_slot_deltas_global_t const *)global_self;
-  self->slot_deltas_len = mem->slot_deltas_len;
-  self->slot_deltas     = fd_wksp_laddr_fast( ctx->wksp, mem->slot_deltas_gaddr );
-  return FD_BINCODE_SUCCESS;
+  }
 }
 void fd_bank_slot_deltas_new(fd_bank_slot_deltas_t * self) {
   fd_memset( self, 0, sizeof(fd_bank_slot_deltas_t) );
@@ -35676,28 +32031,6 @@ void fd_pubkey_rewardinfo_pair_decode_inner( void * struct_mem, void * * alloc_m
   fd_pubkey_decode_inner( &self->pubkey, alloc_mem, ctx );
   fd_reward_info_decode_inner( &self->reward_info, alloc_mem, ctx );
 }
-void * fd_pubkey_rewardinfo_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_pubkey_rewardinfo_pair_global_t * self = (fd_pubkey_rewardinfo_pair_global_t *)mem;
-  fd_pubkey_rewardinfo_pair_new( (fd_pubkey_rewardinfo_pair_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_pubkey_rewardinfo_pair_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_pubkey_rewardinfo_pair_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_pubkey_rewardinfo_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_pubkey_rewardinfo_pair_global_t * self = (fd_pubkey_rewardinfo_pair_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->pubkey, alloc_mem, ctx );
-  fd_reward_info_decode_inner_global( &self->reward_info, alloc_mem, ctx );
-}
-int fd_pubkey_rewardinfo_pair_convert_global_to_local( void const * global_self, fd_pubkey_rewardinfo_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_pubkey_rewardinfo_pair_global_t const * mem = (fd_pubkey_rewardinfo_pair_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->pubkey, &self->pubkey, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_reward_info_convert_global_to_local( &mem->reward_info, &self->reward_info, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_pubkey_rewardinfo_pair_new(fd_pubkey_rewardinfo_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_pubkey_rewardinfo_pair_t) );
   fd_pubkey_new( &self->pubkey );
@@ -35730,6 +32063,20 @@ int fd_optional_account_encode( fd_optional_account_t const * self, fd_bincode_e
     err = fd_bincode_bool_encode( 1, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     err = fd_solana_account_encode( self->account, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  } else {
+    err = fd_bincode_bool_encode( 0, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_optional_account_encode_global( fd_optional_account_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  if( self->account_gaddr ) {
+    err = fd_bincode_bool_encode( 1, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    fd_solana_account_t * account = fd_wksp_laddr_fast( ctx->wksp, self->account_gaddr );
+    err = fd_solana_account_encode( account, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   } else {
     err = fd_bincode_bool_encode( 0, ctx );
@@ -35802,17 +32149,11 @@ void fd_optional_account_decode_inner_global( void * struct_mem, void * * alloc_
       self->account_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
       fd_solana_account_new( *alloc_mem );
       *alloc_mem = (uchar *)*alloc_mem + FD_SOLANA_ACCOUNT_FOOTPRINT;
-      fd_solana_account_decode_inner_global( fd_wksp_laddr_fast( ctx->wksp, self->account_gaddr ), alloc_mem, ctx );
+      fd_solana_account_decode_inner( fd_wksp_laddr_fast( ctx->wksp, self->account_gaddr ), alloc_mem, ctx );
     } else {
       self->account_gaddr = 0UL;
     }
   }
-}
-int fd_optional_account_convert_global_to_local( void const * global_self, fd_optional_account_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_optional_account_global_t const * mem = (fd_optional_account_global_t const *)global_self;
-  self->account = fd_wksp_laddr_fast( ctx->wksp, mem->account_gaddr );
-  return FD_BINCODE_SUCCESS;
 }
 void fd_optional_account_new(fd_optional_account_t * self) {
   fd_memset( self, 0, sizeof(fd_optional_account_t) );
@@ -35839,7 +32180,7 @@ void fd_optional_account_walk( void * w, fd_optional_account_t const * self, fd_
 ulong fd_optional_account_size( fd_optional_account_t const * self ) {
   ulong size = 0;
   size += sizeof(char);
-  if( NULL !=  self->account ) {
+  if( NULL != self->account ) {
     size += fd_solana_account_size( self->account );
   }
   return size;
@@ -35887,28 +32228,6 @@ void fd_calculated_stake_points_decode_inner( void * struct_mem, void * * alloc_
   fd_bincode_uint128_decode_unsafe( &self->points, ctx );
   fd_bincode_uint64_decode_unsafe( &self->new_credits_observed, ctx );
   fd_bincode_uint8_decode_unsafe( &self->force_credits_update_with_skipped_reward, ctx );
-}
-void * fd_calculated_stake_points_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_calculated_stake_points_global_t * self = (fd_calculated_stake_points_global_t *)mem;
-  fd_calculated_stake_points_new( (fd_calculated_stake_points_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_calculated_stake_points_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_calculated_stake_points_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_calculated_stake_points_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_calculated_stake_points_global_t * self = (fd_calculated_stake_points_global_t *)struct_mem;
-  fd_bincode_uint128_decode_unsafe( &self->points, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->new_credits_observed, ctx );
-  fd_bincode_uint8_decode_unsafe( &self->force_credits_update_with_skipped_reward, ctx );
-}
-int fd_calculated_stake_points_convert_global_to_local( void const * global_self, fd_calculated_stake_points_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_calculated_stake_points_global_t const * mem = (fd_calculated_stake_points_global_t const *)global_self;
-  self->points = mem->points;
-  self->new_credits_observed = mem->new_credits_observed;
-  self->force_credits_update_with_skipped_reward = mem->force_credits_update_with_skipped_reward;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_calculated_stake_points_new(fd_calculated_stake_points_t * self) {
   fd_memset( self, 0, sizeof(fd_calculated_stake_points_t) );
@@ -35976,28 +32295,6 @@ void fd_calculated_stake_rewards_decode_inner( void * struct_mem, void * * alloc
   fd_bincode_uint64_decode_unsafe( &self->staker_rewards, ctx );
   fd_bincode_uint64_decode_unsafe( &self->voter_rewards, ctx );
   fd_bincode_uint64_decode_unsafe( &self->new_credits_observed, ctx );
-}
-void * fd_calculated_stake_rewards_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_calculated_stake_rewards_global_t * self = (fd_calculated_stake_rewards_global_t *)mem;
-  fd_calculated_stake_rewards_new( (fd_calculated_stake_rewards_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_calculated_stake_rewards_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_calculated_stake_rewards_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_calculated_stake_rewards_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_calculated_stake_rewards_global_t * self = (fd_calculated_stake_rewards_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->staker_rewards, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->voter_rewards, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->new_credits_observed, ctx );
-}
-int fd_calculated_stake_rewards_convert_global_to_local( void const * global_self, fd_calculated_stake_rewards_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_calculated_stake_rewards_global_t const * mem = (fd_calculated_stake_rewards_global_t const *)global_self;
-  self->staker_rewards = mem->staker_rewards;
-  self->voter_rewards = mem->voter_rewards;
-  self->new_credits_observed = mem->new_credits_observed;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_calculated_stake_rewards_new(fd_calculated_stake_rewards_t * self) {
   fd_memset( self, 0, sizeof(fd_calculated_stake_rewards_t) );
@@ -36093,40 +32390,6 @@ void fd_duplicate_slot_proof_decode_inner( void * struct_mem, void * * alloc_mem
   } else
     self->shred2 = NULL;
 }
-void * fd_duplicate_slot_proof_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_duplicate_slot_proof_global_t * self = (fd_duplicate_slot_proof_global_t *)mem;
-  fd_duplicate_slot_proof_new( (fd_duplicate_slot_proof_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_duplicate_slot_proof_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_duplicate_slot_proof_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_duplicate_slot_proof_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_duplicate_slot_proof_global_t * self = (fd_duplicate_slot_proof_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->shred1_len, ctx );
-  if( self->shred1_len ) {
-    self->shred1_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    fd_bincode_bytes_decode_unsafe( *alloc_mem, self->shred1_len, ctx );
-    *alloc_mem = (uchar *)(*alloc_mem) + self->shred1_len;
-  } else
-    self->shred1_gaddr = 0UL;
-  fd_bincode_uint64_decode_unsafe( &self->shred2_len, ctx );
-  if( self->shred2_len ) {
-    self->shred2_gaddr = fd_wksp_gaddr_fast( ctx->wksp, *alloc_mem );
-    fd_bincode_bytes_decode_unsafe( *alloc_mem, self->shred2_len, ctx );
-    *alloc_mem = (uchar *)(*alloc_mem) + self->shred2_len;
-  } else
-    self->shred2_gaddr = 0UL;
-}
-int fd_duplicate_slot_proof_convert_global_to_local( void const * global_self, fd_duplicate_slot_proof_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_duplicate_slot_proof_global_t const * mem = (fd_duplicate_slot_proof_global_t const *)global_self;
-  self->shred1_len = mem->shred1_len;
-  self->shred1     = fd_wksp_laddr_fast( ctx->wksp, mem->shred1_gaddr );
-  self->shred2_len = mem->shred2_len;
-  self->shred2     = fd_wksp_laddr_fast( ctx->wksp, mem->shred2_gaddr );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_duplicate_slot_proof_new(fd_duplicate_slot_proof_t * self) {
   fd_memset( self, 0, sizeof(fd_duplicate_slot_proof_t) );
 }
@@ -36199,28 +32462,6 @@ void fd_epoch_info_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_
   fd_pubkey_decode_inner( &self->account, alloc_mem, ctx );
   fd_stake_decode_inner( &self->stake, alloc_mem, ctx );
 }
-void * fd_epoch_info_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_epoch_info_pair_global_t * self = (fd_epoch_info_pair_global_t *)mem;
-  fd_epoch_info_pair_new( (fd_epoch_info_pair_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_epoch_info_pair_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_epoch_info_pair_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_epoch_info_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_epoch_info_pair_global_t * self = (fd_epoch_info_pair_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->account, alloc_mem, ctx );
-  fd_stake_decode_inner_global( &self->stake, alloc_mem, ctx );
-}
-int fd_epoch_info_pair_convert_global_to_local( void const * global_self, fd_epoch_info_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_epoch_info_pair_global_t const * mem = (fd_epoch_info_pair_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->account, &self->account, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_stake_convert_global_to_local( &mem->stake, &self->stake, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_epoch_info_pair_new(fd_epoch_info_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_epoch_info_pair_t) );
   fd_pubkey_new( &self->account );
@@ -36252,6 +32493,14 @@ int fd_vote_info_pair_encode( fd_vote_info_pair_t const * self, fd_bincode_encod
   err = fd_pubkey_encode( &self->account, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_vote_state_versioned_encode( &self->state, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_vote_info_pair_encode_global( fd_vote_info_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_pubkey_encode( &self->account, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_vote_state_versioned_encode_global( &self->state, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   return FD_BINCODE_SUCCESS;
 }
@@ -36295,17 +32544,8 @@ void * fd_vote_info_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ct
 }
 void fd_vote_info_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_vote_info_pair_global_t * self = (fd_vote_info_pair_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->account, alloc_mem, ctx );
+  fd_pubkey_decode_inner( &self->account, alloc_mem, ctx );
   fd_vote_state_versioned_decode_inner_global( &self->state, alloc_mem, ctx );
-}
-int fd_vote_info_pair_convert_global_to_local( void const * global_self, fd_vote_info_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_vote_info_pair_global_t const * mem = (fd_vote_info_pair_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->account, &self->account, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  err = fd_vote_state_versioned_convert_global_to_local( &mem->state, &self->state, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_vote_info_pair_new(fd_vote_info_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_vote_info_pair_t) );
@@ -36349,6 +32589,37 @@ int fd_epoch_info_encode( fd_epoch_info_t const * self, fd_bincode_encode_ctx_t 
     if( FD_UNLIKELY( err ) ) return err;
     for( fd_vote_info_pair_t_mapnode_t * n = fd_vote_info_pair_t_map_minimum( self->vote_states_pool, self->vote_states_root ); n; n = fd_vote_info_pair_t_map_successor( self->vote_states_pool, n ) ) {
       err = fd_vote_info_pair_encode( &n->elem, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong vote_states_len = 0;
+    err = fd_bincode_uint64_encode( vote_states_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  err = fd_bincode_uint64_encode( self->stake_infos_new_keys_start_idx, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_epoch_info_encode_global( fd_epoch_info_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->stake_infos_len, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->stake_infos_len ) {
+    uchar * stake_infos_laddr = fd_wksp_laddr_fast( ctx->wksp, self->stake_infos_gaddr );
+    fd_epoch_info_pair_t * stake_infos = (fd_epoch_info_pair_t *)stake_infos_laddr;
+    for( ulong i=0; i < self->stake_infos_len; i++ ) {
+      err = fd_epoch_info_pair_encode( &stake_infos[i], ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  }
+  fd_vote_info_pair_global_t_mapnode_t * vote_states_root = fd_vote_info_pair_global_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->vote_states_root_gaddr ) );
+  fd_vote_info_pair_global_t_mapnode_t * vote_states_pool = fd_vote_info_pair_global_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->vote_states_pool_gaddr ) );
+  if( vote_states_root ) {
+    ulong vote_states_len = fd_vote_info_pair_global_t_map_size( vote_states_pool, vote_states_root );
+    err = fd_bincode_uint64_encode( vote_states_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( fd_vote_info_pair_global_t_mapnode_t * n = fd_vote_info_pair_global_t_map_minimum( vote_states_pool, vote_states_root ); n; n = fd_vote_info_pair_global_t_map_successor( vote_states_pool, n ) ) {
+      err = fd_vote_info_pair_encode_global( &n->elem, ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
   } else {
@@ -36444,36 +32715,26 @@ void fd_epoch_info_decode_inner_global( void * struct_mem, void * * alloc_mem, f
     uchar * cur_mem = (uchar *)(*alloc_mem);
     *alloc_mem = (uchar *)(*alloc_mem) + FD_EPOCH_INFO_PAIR_FOOTPRINT*self->stake_infos_len;
     for( ulong i=0; i < self->stake_infos_len; i++ ) {
-      fd_epoch_info_pair_new( (fd_epoch_info_pair_t *)(cur_mem + FD_EPOCH_INFO_PAIR_FOOTPRINT * i) );
-      fd_epoch_info_pair_decode_inner_global( cur_mem + FD_EPOCH_INFO_PAIR_FOOTPRINT * i, alloc_mem, ctx );
+      fd_epoch_info_pair_new( (fd_epoch_info_pair_t *)fd_type_pun(cur_mem + FD_EPOCH_INFO_PAIR_FOOTPRINT * i) );
+      fd_epoch_info_pair_decode_inner( cur_mem + FD_EPOCH_INFO_PAIR_FOOTPRINT * i, alloc_mem, ctx );
     }
-  } else
+  } else {
     self->stake_infos_gaddr = 0UL;
+  }
   ulong vote_states_len;
   fd_bincode_uint64_decode_unsafe( &vote_states_len, ctx );
-  *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, fd_vote_info_pair_t_map_align() );
-  fd_vote_info_pair_t_mapnode_t * vote_states_pool = fd_vote_info_pair_t_map_join_new( alloc_mem, vote_states_len );
-  fd_vote_info_pair_t_mapnode_t * vote_states_root = NULL;
-  self->vote_states_root_gaddr = 0UL;
+  *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, fd_vote_info_pair_global_t_map_align() );
+  fd_vote_info_pair_global_t_mapnode_t * vote_states_pool = fd_vote_info_pair_global_t_map_join_new( alloc_mem, vote_states_len );
+  fd_vote_info_pair_global_t_mapnode_t * vote_states_root = NULL;
   for( ulong i=0; i < vote_states_len; i++ ) {
-    fd_vote_info_pair_t_mapnode_t * node = fd_vote_info_pair_t_map_acquire( vote_states_pool );
-    fd_vote_info_pair_new( &node->elem );
-    fd_vote_info_pair_decode_inner( &node->elem, alloc_mem, ctx );
-    fd_vote_info_pair_t_map_insert( vote_states_pool, &vote_states_root, node );
+    fd_vote_info_pair_global_t_mapnode_t * node = fd_vote_info_pair_global_t_map_acquire( vote_states_pool );
+    fd_vote_info_pair_new( (fd_vote_info_pair_t *)fd_type_pun(&node->elem) );
+    fd_vote_info_pair_decode_inner_global( &node->elem, alloc_mem, ctx );
+    fd_vote_info_pair_global_t_map_insert( vote_states_pool, &vote_states_root, node );
   }
-  self->vote_states_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, vote_states_pool );
-  self->vote_states_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, vote_states_root );
+  self->vote_states_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_vote_info_pair_global_t_map_leave( vote_states_pool ) );
+  self->vote_states_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_vote_info_pair_global_t_map_leave( vote_states_root ) );
   fd_bincode_uint64_decode_unsafe( &self->stake_infos_new_keys_start_idx, ctx );
-}
-int fd_epoch_info_convert_global_to_local( void const * global_self, fd_epoch_info_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_epoch_info_global_t const * mem = (fd_epoch_info_global_t const *)global_self;
-  self->stake_infos_len = mem->stake_infos_len;
-  self->stake_infos     = fd_wksp_laddr_fast( ctx->wksp, mem->stake_infos_gaddr );
-  self->vote_states_pool = fd_wksp_laddr_fast( ctx->wksp, mem->vote_states_pool_gaddr );
-  self->vote_states_root = fd_wksp_laddr_fast( ctx->wksp, mem->vote_states_root_gaddr );
-  self->stake_infos_new_keys_start_idx = mem->stake_infos_new_keys_start_idx;
-  return FD_BINCODE_SUCCESS;
 }
 void fd_epoch_info_new(fd_epoch_info_t * self) {
   fd_memset( self, 0, sizeof(fd_epoch_info_t) );
@@ -36587,34 +32848,6 @@ void fd_usage_cost_details_decode_inner( void * struct_mem, void * * alloc_mem, 
   fd_bincode_uint64_decode_unsafe( &self->loaded_accounts_data_size_cost, ctx );
   fd_bincode_uint64_decode_unsafe( &self->allocated_accounts_data_size, ctx );
 }
-void * fd_usage_cost_details_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_usage_cost_details_global_t * self = (fd_usage_cost_details_global_t *)mem;
-  fd_usage_cost_details_new( (fd_usage_cost_details_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_usage_cost_details_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_usage_cost_details_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_usage_cost_details_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_usage_cost_details_global_t * self = (fd_usage_cost_details_global_t *)struct_mem;
-  fd_bincode_uint64_decode_unsafe( &self->signature_cost, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->write_lock_cost, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->data_bytes_cost, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->programs_execution_cost, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->loaded_accounts_data_size_cost, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->allocated_accounts_data_size, ctx );
-}
-int fd_usage_cost_details_convert_global_to_local( void const * global_self, fd_usage_cost_details_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_usage_cost_details_global_t const * mem = (fd_usage_cost_details_global_t const *)global_self;
-  self->signature_cost = mem->signature_cost;
-  self->write_lock_cost = mem->write_lock_cost;
-  self->data_bytes_cost = mem->data_bytes_cost;
-  self->programs_execution_cost = mem->programs_execution_cost;
-  self->loaded_accounts_data_size_cost = mem->loaded_accounts_data_size_cost;
-  self->allocated_accounts_data_size = mem->allocated_accounts_data_size;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_usage_cost_details_new(fd_usage_cost_details_t * self) {
   fd_memset( self, 0, sizeof(fd_usage_cost_details_t) );
 }
@@ -36692,38 +32925,6 @@ void fd_transaction_cost_inner_decode_inner( fd_transaction_cost_inner_t * self,
   }
   }
 }
-void fd_transaction_cost_inner_decode_inner_global( fd_transaction_cost_inner_global_t * self, void * * alloc_mem, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  switch (discriminant) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    fd_usage_cost_details_decode_inner_global( &self->transaction, alloc_mem, ctx );
-    break;
-  }
-  }
-}
-int fd_transaction_cost_convert_global_to_local_inner( fd_transaction_cost_inner_global_t const * mem, fd_transaction_cost_inner_t * self, uint discriminant, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  switch( discriminant ) {
-  case 0: {
-    break;
-  }
-  case 1: {
-    err = fd_usage_cost_details_convert_global_to_local( &mem->transaction, &self->transaction, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    break;
-  }
-  }
-  return FD_BINCODE_SUCCESS;
-}
-int fd_transaction_cost_convert_global_to_local( void const * global_self, fd_transaction_cost_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  fd_transaction_cost_global_t const * mem = (fd_transaction_cost_global_t const *)global_self;
-  uint discriminant = mem->discriminant;
-  self->discriminant = mem->discriminant;
-  int err = fd_transaction_cost_convert_global_to_local_inner( &mem->inner, &self->inner, discriminant, ctx );
-  return FD_BINCODE_SUCCESS;
-}
 void fd_transaction_cost_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_transaction_cost_t * self = (fd_transaction_cost_t *)struct_mem;
   fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
@@ -36736,19 +32937,6 @@ void * fd_transaction_cost_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   void * * alloc_mem = &alloc_region;
   fd_transaction_cost_decode_inner( mem, alloc_mem, ctx );
   return self;
-}
-void * fd_transaction_cost_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_transaction_cost_t * self = (fd_transaction_cost_t *)mem;
-  fd_transaction_cost_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_transaction_cost_t);
-  void * * alloc_mem = &alloc_region;
-  fd_transaction_cost_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_transaction_cost_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_transaction_cost_global_t * self = (fd_transaction_cost_global_t *)struct_mem;
-  fd_bincode_uint32_decode_unsafe( &self->discriminant, ctx );
-  fd_transaction_cost_inner_decode_inner_global( &self->inner, alloc_mem, self->discriminant, ctx );
 }
 void fd_transaction_cost_inner_new( fd_transaction_cost_inner_t * self, uint discriminant ) {
   switch( discriminant ) {
@@ -36868,27 +33056,6 @@ void fd_account_costs_pair_decode_inner( void * struct_mem, void * * alloc_mem, 
   fd_pubkey_decode_inner( &self->key, alloc_mem, ctx );
   fd_bincode_uint64_decode_unsafe( &self->cost, ctx );
 }
-void * fd_account_costs_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_account_costs_pair_global_t * self = (fd_account_costs_pair_global_t *)mem;
-  fd_account_costs_pair_new( (fd_account_costs_pair_t *)self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_account_costs_pair_global_t);
-  void * * alloc_mem = &alloc_region;
-  fd_account_costs_pair_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_account_costs_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_account_costs_pair_global_t * self = (fd_account_costs_pair_global_t *)struct_mem;
-  fd_pubkey_decode_inner_global( &self->key, alloc_mem, ctx );
-  fd_bincode_uint64_decode_unsafe( &self->cost, ctx );
-}
-int fd_account_costs_pair_convert_global_to_local( void const * global_self, fd_account_costs_pair_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_account_costs_pair_global_t const * mem = (fd_account_costs_pair_global_t const *)global_self;
-  err = fd_pubkey_convert_global_to_local( &mem->key, &self->key, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->cost = mem->cost;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_account_costs_pair_new(fd_account_costs_pair_t * self) {
   fd_memset( self, 0, sizeof(fd_account_costs_pair_t) );
   fd_pubkey_new( &self->key );
@@ -36920,6 +33087,25 @@ int fd_account_costs_encode( fd_account_costs_t const * self, fd_bincode_encode_
     err = fd_bincode_uint64_encode( account_costs_len, ctx );
     if( FD_UNLIKELY( err ) ) return err;
     for( fd_account_costs_pair_t_mapnode_t * n = fd_account_costs_pair_t_map_minimum( self->account_costs_pool, self->account_costs_root ); n; n = fd_account_costs_pair_t_map_successor( self->account_costs_pool, n ) ) {
+      err = fd_account_costs_pair_encode( &n->elem, ctx );
+      if( FD_UNLIKELY( err ) ) return err;
+    }
+  } else {
+    ulong account_costs_len = 0;
+    err = fd_bincode_uint64_encode( account_costs_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return FD_BINCODE_SUCCESS;
+}
+int fd_account_costs_encode_global( fd_account_costs_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  fd_account_costs_pair_t_mapnode_t * account_costs_root = fd_account_costs_pair_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->account_costs_root_gaddr ) );
+  fd_account_costs_pair_t_mapnode_t * account_costs_pool = fd_account_costs_pair_t_map_join( fd_wksp_laddr_fast( ctx->wksp, self->account_costs_pool_gaddr ) );
+  if( account_costs_root ) {
+    ulong account_costs_len = fd_account_costs_pair_t_map_size( account_costs_pool, account_costs_root );
+    err = fd_bincode_uint64_encode( account_costs_len, ctx );
+    if( FD_UNLIKELY( err ) ) return err;
+    for( fd_account_costs_pair_t_mapnode_t * n = fd_account_costs_pair_t_map_minimum( account_costs_pool, account_costs_root ); n; n = fd_account_costs_pair_t_map_successor( account_costs_pool, n ) ) {
       err = fd_account_costs_pair_encode( &n->elem, ctx );
       if( FD_UNLIKELY( err ) ) return err;
     }
@@ -36988,22 +33174,14 @@ void fd_account_costs_decode_inner_global( void * struct_mem, void * * alloc_mem
   *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, fd_account_costs_pair_t_map_align() );
   fd_account_costs_pair_t_mapnode_t * account_costs_pool = fd_account_costs_pair_t_map_join_new( alloc_mem, fd_ulong_max( account_costs_len, 4096 ) );
   fd_account_costs_pair_t_mapnode_t * account_costs_root = NULL;
-  self->account_costs_root_gaddr = 0UL;
   for( ulong i=0; i < account_costs_len; i++ ) {
     fd_account_costs_pair_t_mapnode_t * node = fd_account_costs_pair_t_map_acquire( account_costs_pool );
-    fd_account_costs_pair_new( &node->elem );
+    fd_account_costs_pair_new( (fd_account_costs_pair_t *)fd_type_pun(&node->elem) );
     fd_account_costs_pair_decode_inner( &node->elem, alloc_mem, ctx );
     fd_account_costs_pair_t_map_insert( account_costs_pool, &account_costs_root, node );
   }
-  self->account_costs_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, account_costs_pool );
-  self->account_costs_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, account_costs_root );
-}
-int fd_account_costs_convert_global_to_local( void const * global_self, fd_account_costs_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_account_costs_global_t const * mem = (fd_account_costs_global_t const *)global_self;
-  self->account_costs_pool = fd_wksp_laddr_fast( ctx->wksp, mem->account_costs_pool_gaddr );
-  self->account_costs_root = fd_wksp_laddr_fast( ctx->wksp, mem->account_costs_root_gaddr );
-  return FD_BINCODE_SUCCESS;
+  self->account_costs_pool_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_account_costs_pair_t_map_leave( account_costs_pool ) );
+  self->account_costs_root_gaddr = fd_wksp_gaddr_fast( ctx->wksp, fd_account_costs_pair_t_map_leave( account_costs_root ) );
 }
 void fd_account_costs_new(fd_account_costs_t * self) {
   fd_memset( self, 0, sizeof(fd_account_costs_t) );
@@ -37050,6 +33228,34 @@ int fd_cost_tracker_encode( fd_cost_tracker_t const * self, fd_bincode_encode_ct
   err = fd_bincode_uint64_encode( self->vote_cost_limit, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_account_costs_encode( &self->cost_by_writable_accounts, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->block_cost, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->vote_cost, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->transaction_count, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->allocated_accounts_data_size, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->transaction_signature_count, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->secp256k1_instruction_signature_count, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->ed25519_instruction_signature_count, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->secp256r1_instruction_signature_count, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  return FD_BINCODE_SUCCESS;
+}
+int fd_cost_tracker_encode_global( fd_cost_tracker_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  int err;
+  err = fd_bincode_uint64_encode( self->account_cost_limit, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->block_cost_limit, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_bincode_uint64_encode( self->vote_cost_limit, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fd_account_costs_encode_global( &self->cost_by_writable_accounts, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_bincode_uint64_encode( self->block_cost, ctx );
   if( FD_UNLIKELY( err ) ) return err;
@@ -37152,24 +33358,6 @@ void fd_cost_tracker_decode_inner_global( void * struct_mem, void * * alloc_mem,
   fd_bincode_uint64_decode_unsafe( &self->ed25519_instruction_signature_count, ctx );
   fd_bincode_uint64_decode_unsafe( &self->secp256r1_instruction_signature_count, ctx );
 }
-int fd_cost_tracker_convert_global_to_local( void const * global_self, fd_cost_tracker_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  int err = 0;
-  fd_cost_tracker_global_t const * mem = (fd_cost_tracker_global_t const *)global_self;
-  self->account_cost_limit = mem->account_cost_limit;
-  self->block_cost_limit = mem->block_cost_limit;
-  self->vote_cost_limit = mem->vote_cost_limit;
-  err = fd_account_costs_convert_global_to_local( &mem->cost_by_writable_accounts, &self->cost_by_writable_accounts, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  self->block_cost = mem->block_cost;
-  self->vote_cost = mem->vote_cost;
-  self->transaction_count = mem->transaction_count;
-  self->allocated_accounts_data_size = mem->allocated_accounts_data_size;
-  self->transaction_signature_count = mem->transaction_signature_count;
-  self->secp256k1_instruction_signature_count = mem->secp256k1_instruction_signature_count;
-  self->ed25519_instruction_signature_count = mem->ed25519_instruction_signature_count;
-  self->secp256r1_instruction_signature_count = mem->secp256r1_instruction_signature_count;
-  return FD_BINCODE_SUCCESS;
-}
 void fd_cost_tracker_new(fd_cost_tracker_t * self) {
   fd_memset( self, 0, sizeof(fd_cost_tracker_t) );
   fd_account_costs_new( &self->cost_by_writable_accounts );
@@ -37268,6 +33456,13 @@ long fd_clock_timestamp_vote_t_map_compare( fd_clock_timestamp_vote_t_mapnode_t 
 #define REDBLK_IMPL_STYLE 2
 #include "../../util/tmpl/fd_redblack.c"
 long fd_vote_info_pair_t_map_compare( fd_vote_info_pair_t_mapnode_t * left, fd_vote_info_pair_t_mapnode_t * right ) {
+  return memcmp( left->elem.account.uc, right->elem.account.uc, sizeof(right->elem.account) );
+}
+#define REDBLK_T fd_vote_info_pair_global_t_mapnode_t
+#define REDBLK_NAME fd_vote_info_pair_global_t_map
+#define REDBLK_IMPL_STYLE 2
+#include "../../util/tmpl/fd_redblack.c"
+long fd_vote_info_pair_global_t_map_compare( fd_vote_info_pair_global_t_mapnode_t * left, fd_vote_info_pair_global_t_mapnode_t * right ) {
   return memcmp( left->elem.account.uc, right->elem.account.uc, sizeof(right->elem.account) );
 }
 #define REDBLK_T fd_account_costs_pair_t_mapnode_t

--- a/src/flamenco/types/fd_types.h
+++ b/src/flamenco/types/fd_types.h
@@ -34,13 +34,6 @@ typedef struct fd_fee_calculator fd_fee_calculator_t;
 #define FD_FEE_CALCULATOR_FOOTPRINT sizeof(fd_fee_calculator_t)
 #define FD_FEE_CALCULATOR_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_fee_calculator_global {
-  ulong lamports_per_signature;
-};
-typedef struct fd_fee_calculator_global fd_fee_calculator_global_t;
-#define FD_FEE_CALCULATOR_GLOBAL_FOOTPRINT sizeof(fd_fee_calculator_global_t)
-#define FD_FEE_CALCULATOR_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (24 bytes) */
 struct __attribute__((aligned(8UL))) fd_hash_age {
   fd_fee_calculator_t fee_calculator;
@@ -51,15 +44,6 @@ typedef struct fd_hash_age fd_hash_age_t;
 #define FD_HASH_AGE_FOOTPRINT sizeof(fd_hash_age_t)
 #define FD_HASH_AGE_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_hash_age_global {
-  fd_fee_calculator_t fee_calculator;
-  ulong hash_index;
-  ulong timestamp;
-};
-typedef struct fd_hash_age_global fd_hash_age_global_t;
-#define FD_HASH_AGE_GLOBAL_FOOTPRINT sizeof(fd_hash_age_global_t)
-#define FD_HASH_AGE_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (56 bytes) */
 struct __attribute__((aligned(8UL))) fd_hash_hash_age_pair {
   fd_hash_t key;
@@ -68,14 +52,6 @@ struct __attribute__((aligned(8UL))) fd_hash_hash_age_pair {
 typedef struct fd_hash_hash_age_pair fd_hash_hash_age_pair_t;
 #define FD_HASH_HASH_AGE_PAIR_FOOTPRINT sizeof(fd_hash_hash_age_pair_t)
 #define FD_HASH_HASH_AGE_PAIR_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_hash_hash_age_pair_global {
-  fd_hash_t key;
-  fd_hash_age_t val;
-};
-typedef struct fd_hash_hash_age_pair_global fd_hash_hash_age_pair_global_t;
-#define FD_HASH_HASH_AGE_PAIR_GLOBAL_FOOTPRINT sizeof(fd_hash_hash_age_pair_global_t)
-#define FD_HASH_HASH_AGE_PAIR_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_block_hash_vec {
@@ -155,17 +131,6 @@ typedef struct fd_fee_rate_governor fd_fee_rate_governor_t;
 #define FD_FEE_RATE_GOVERNOR_FOOTPRINT sizeof(fd_fee_rate_governor_t)
 #define FD_FEE_RATE_GOVERNOR_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_fee_rate_governor_global {
-  ulong target_lamports_per_signature;
-  ulong target_signatures_per_slot;
-  ulong min_lamports_per_signature;
-  ulong max_lamports_per_signature;
-  uchar burn_percent;
-};
-typedef struct fd_fee_rate_governor_global fd_fee_rate_governor_global_t;
-#define FD_FEE_RATE_GOVERNOR_GLOBAL_FOOTPRINT sizeof(fd_fee_rate_governor_global_t)
-#define FD_FEE_RATE_GOVERNOR_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (16 bytes) */
 struct __attribute__((aligned(8UL))) fd_slot_pair {
   ulong slot;
@@ -175,14 +140,6 @@ typedef struct fd_slot_pair fd_slot_pair_t;
 #define FD_SLOT_PAIR_FOOTPRINT sizeof(fd_slot_pair_t)
 #define FD_SLOT_PAIR_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_slot_pair_global {
-  ulong slot;
-  ulong val;
-};
-typedef struct fd_slot_pair_global fd_slot_pair_global_t;
-#define FD_SLOT_PAIR_GLOBAL_FOOTPRINT sizeof(fd_slot_pair_global_t)
-#define FD_SLOT_PAIR_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_hard_forks {
   ulong hard_forks_len;
@@ -191,14 +148,6 @@ struct __attribute__((aligned(8UL))) fd_hard_forks {
 typedef struct fd_hard_forks fd_hard_forks_t;
 #define FD_HARD_FORKS_FOOTPRINT sizeof(fd_hard_forks_t)
 #define FD_HARD_FORKS_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_hard_forks_global {
-  ulong hard_forks_len;
-  ulong hard_forks_gaddr;
-};
-typedef struct fd_hard_forks_global fd_hard_forks_global_t;
-#define FD_HARD_FORKS_GLOBAL_FOOTPRINT sizeof(fd_hard_forks_global_t)
-#define FD_HARD_FORKS_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Fixed (48 bytes) */
 struct __attribute__((aligned(8UL))) fd_inflation {
@@ -213,18 +162,6 @@ typedef struct fd_inflation fd_inflation_t;
 #define FD_INFLATION_FOOTPRINT sizeof(fd_inflation_t)
 #define FD_INFLATION_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_inflation_global {
-  double initial;
-  double terminal;
-  double taper;
-  double foundation;
-  double foundation_term;
-  double unused;
-};
-typedef struct fd_inflation_global fd_inflation_global_t;
-#define FD_INFLATION_GLOBAL_FOOTPRINT sizeof(fd_inflation_global_t)
-#define FD_INFLATION_GLOBAL_ALIGN (8UL)
-
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/rent.rs#L11 */
 /* Encoded Size: Fixed (17 bytes) */
 struct __attribute__((aligned(8UL))) fd_rent {
@@ -235,15 +172,6 @@ struct __attribute__((aligned(8UL))) fd_rent {
 typedef struct fd_rent fd_rent_t;
 #define FD_RENT_FOOTPRINT sizeof(fd_rent_t)
 #define FD_RENT_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_rent_global {
-  ulong lamports_per_uint8_year;
-  double exemption_threshold;
-  uchar burn_percent;
-};
-typedef struct fd_rent_global fd_rent_global_t;
-#define FD_RENT_GLOBAL_FOOTPRINT sizeof(fd_rent_global_t)
-#define FD_RENT_GLOBAL_ALIGN (8UL)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/epoch_schedule.rs#L26 */
 /* Encoded Size: Fixed (33 bytes) */
@@ -258,17 +186,6 @@ typedef struct fd_epoch_schedule fd_epoch_schedule_t;
 #define FD_EPOCH_SCHEDULE_FOOTPRINT sizeof(fd_epoch_schedule_t)
 #define FD_EPOCH_SCHEDULE_ALIGN (1UL)
 
-struct __attribute__((aligned(1UL))) fd_epoch_schedule_global {
-  ulong slots_per_epoch;
-  ulong leader_schedule_slot_offset;
-  uchar warmup;
-  ulong first_normal_epoch;
-  ulong first_normal_slot;
-};
-typedef struct fd_epoch_schedule_global fd_epoch_schedule_global_t;
-#define FD_EPOCH_SCHEDULE_GLOBAL_FOOTPRINT sizeof(fd_epoch_schedule_global_t)
-#define FD_EPOCH_SCHEDULE_GLOBAL_ALIGN (1UL)
-
 /* Encoded Size: Fixed (66 bytes) */
 struct __attribute__((aligned(8UL))) fd_rent_collector {
   ulong epoch;
@@ -279,16 +196,6 @@ struct __attribute__((aligned(8UL))) fd_rent_collector {
 typedef struct fd_rent_collector fd_rent_collector_t;
 #define FD_RENT_COLLECTOR_FOOTPRINT sizeof(fd_rent_collector_t)
 #define FD_RENT_COLLECTOR_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_rent_collector_global {
-  ulong epoch;
-  fd_epoch_schedule_t epoch_schedule;
-  double slots_per_year;
-  fd_rent_t rent;
-};
-typedef struct fd_rent_collector_global fd_rent_collector_global_t;
-#define FD_RENT_COLLECTOR_GLOBAL_FOOTPRINT sizeof(fd_rent_collector_global_t)
-#define FD_RENT_COLLECTOR_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Fixed (32 bytes) */
 struct __attribute__((aligned(8UL))) fd_stake_history_entry {
@@ -301,16 +208,6 @@ typedef struct fd_stake_history_entry fd_stake_history_entry_t;
 #define FD_STAKE_HISTORY_ENTRY_FOOTPRINT sizeof(fd_stake_history_entry_t)
 #define FD_STAKE_HISTORY_ENTRY_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_stake_history_entry_global {
-  ulong epoch;
-  ulong effective;
-  ulong activating;
-  ulong deactivating;
-};
-typedef struct fd_stake_history_entry_global fd_stake_history_entry_global_t;
-#define FD_STAKE_HISTORY_ENTRY_GLOBAL_FOOTPRINT sizeof(fd_stake_history_entry_global_t)
-#define FD_STAKE_HISTORY_ENTRY_GLOBAL_ALIGN (8UL)
-
 /* https://github.com/firedancer-io/solana/blob/v1.17/sdk/program/src/stake_history.rs#L12-L75 */
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_stake_history {
@@ -322,16 +219,6 @@ struct __attribute__((aligned(8UL))) fd_stake_history {
 typedef struct fd_stake_history fd_stake_history_t;
 #define FD_STAKE_HISTORY_FOOTPRINT sizeof(fd_stake_history_t)
 #define FD_STAKE_HISTORY_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_stake_history_global {
-  ulong fd_stake_history_len;
-  ulong fd_stake_history_size;
-  ulong fd_stake_history_offset;
-  fd_stake_history_entry_global_t fd_stake_history[512];
-};
-typedef struct fd_stake_history_global fd_stake_history_global_t;
-#define FD_STAKE_HISTORY_GLOBAL_FOOTPRINT sizeof(fd_stake_history_global_t)
-#define FD_STAKE_HISTORY_GLOBAL_ALIGN (8UL)
 
 /* https://github.com/anza-xyz/agave/blob/6ac4fe32e28d8ceb4085072b61fa0c6cb09baac1/sdk/src/account.rs#L37 */
 /* Encoded Size: Dynamic */
@@ -347,18 +234,6 @@ typedef struct fd_solana_account fd_solana_account_t;
 #define FD_SOLANA_ACCOUNT_FOOTPRINT sizeof(fd_solana_account_t)
 #define FD_SOLANA_ACCOUNT_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_solana_account_global {
-  ulong lamports;
-  ulong data_len;
-  ulong data_gaddr;
-  fd_pubkey_t owner;
-  uchar executable;
-  ulong rent_epoch;
-};
-typedef struct fd_solana_account_global fd_solana_account_global_t;
-#define FD_SOLANA_ACCOUNT_GLOBAL_FOOTPRINT sizeof(fd_solana_account_global_t)
-#define FD_SOLANA_ACCOUNT_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (48 bytes) */
 struct __attribute__((packed)) fd_solana_account_stored_meta {
   ulong write_version_obsolete;
@@ -368,15 +243,6 @@ struct __attribute__((packed)) fd_solana_account_stored_meta {
 typedef struct fd_solana_account_stored_meta fd_solana_account_stored_meta_t;
 #define FD_SOLANA_ACCOUNT_STORED_META_FOOTPRINT sizeof(fd_solana_account_stored_meta_t)
 #define FD_SOLANA_ACCOUNT_STORED_META_ALIGN (8UL)
-
-struct __attribute__((packed)) fd_solana_account_stored_meta_global {
-  ulong write_version_obsolete;
-  ulong data_len;
-  uchar pubkey[32];
-};
-typedef struct fd_solana_account_stored_meta_global fd_solana_account_stored_meta_global_t;
-#define FD_SOLANA_ACCOUNT_STORED_META_GLOBAL_FOOTPRINT sizeof(fd_solana_account_stored_meta_global_t)
-#define FD_SOLANA_ACCOUNT_STORED_META_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Fixed (52 bytes) */
 struct __attribute__((packed)) fd_solana_account_meta {
@@ -390,17 +256,6 @@ typedef struct fd_solana_account_meta fd_solana_account_meta_t;
 #define FD_SOLANA_ACCOUNT_META_FOOTPRINT sizeof(fd_solana_account_meta_t)
 #define FD_SOLANA_ACCOUNT_META_ALIGN (8UL)
 
-struct __attribute__((packed)) fd_solana_account_meta_global {
-  ulong lamports;
-  ulong rent_epoch;
-  uchar owner[32];
-  uchar executable;
-  uchar padding[3];
-};
-typedef struct fd_solana_account_meta_global fd_solana_account_meta_global_t;
-#define FD_SOLANA_ACCOUNT_META_GLOBAL_FOOTPRINT sizeof(fd_solana_account_meta_global_t)
-#define FD_SOLANA_ACCOUNT_META_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (136 bytes) */
 struct __attribute__((packed)) fd_solana_account_hdr {
   fd_solana_account_stored_meta_t meta;
@@ -411,16 +266,6 @@ struct __attribute__((packed)) fd_solana_account_hdr {
 typedef struct fd_solana_account_hdr fd_solana_account_hdr_t;
 #define FD_SOLANA_ACCOUNT_HDR_FOOTPRINT sizeof(fd_solana_account_hdr_t)
 #define FD_SOLANA_ACCOUNT_HDR_ALIGN (8UL)
-
-struct __attribute__((packed)) fd_solana_account_hdr_global {
-  fd_solana_account_stored_meta_t meta;
-  fd_solana_account_meta_t info;
-  uchar padding[4];
-  fd_hash_t hash;
-};
-typedef struct fd_solana_account_hdr_global fd_solana_account_hdr_global_t;
-#define FD_SOLANA_ACCOUNT_HDR_GLOBAL_FOOTPRINT sizeof(fd_solana_account_hdr_global_t)
-#define FD_SOLANA_ACCOUNT_HDR_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Fixed (104 bytes) */
 struct __attribute__((packed)) fd_account_meta {
@@ -435,18 +280,6 @@ typedef struct fd_account_meta fd_account_meta_t;
 #define FD_ACCOUNT_META_FOOTPRINT sizeof(fd_account_meta_t)
 #define FD_ACCOUNT_META_ALIGN (8UL)
 
-struct __attribute__((packed)) fd_account_meta_global {
-  ushort magic;
-  ushort hlen;
-  ulong dlen;
-  uchar hash[32];
-  ulong slot;
-  fd_solana_account_meta_t info;
-};
-typedef struct fd_account_meta_global fd_account_meta_global_t;
-#define FD_ACCOUNT_META_GLOBAL_FOOTPRINT sizeof(fd_account_meta_global_t)
-#define FD_ACCOUNT_META_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_vote_accounts_pair {
   fd_pubkey_t key;
@@ -456,15 +289,6 @@ struct __attribute__((aligned(8UL))) fd_vote_accounts_pair {
 typedef struct fd_vote_accounts_pair fd_vote_accounts_pair_t;
 #define FD_VOTE_ACCOUNTS_PAIR_FOOTPRINT sizeof(fd_vote_accounts_pair_t)
 #define FD_VOTE_ACCOUNTS_PAIR_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_vote_accounts_pair_global {
-  fd_pubkey_t key;
-  ulong stake;
-  fd_solana_account_global_t value;
-};
-typedef struct fd_vote_accounts_pair_global fd_vote_accounts_pair_global_t;
-#define FD_VOTE_ACCOUNTS_PAIR_GLOBAL_FOOTPRINT sizeof(fd_vote_accounts_pair_global_t)
-#define FD_VOTE_ACCOUNTS_PAIR_GLOBAL_ALIGN (8UL)
 
 typedef struct fd_vote_accounts_pair_t_mapnode fd_vote_accounts_pair_t_mapnode_t;
 #define REDBLK_T fd_vote_accounts_pair_t_mapnode_t
@@ -512,14 +336,6 @@ typedef struct fd_account_keys_pair fd_account_keys_pair_t;
 #define FD_ACCOUNT_KEYS_PAIR_FOOTPRINT sizeof(fd_account_keys_pair_t)
 #define FD_ACCOUNT_KEYS_PAIR_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_account_keys_pair_global {
-  fd_pubkey_t key;
-  uchar exists;
-};
-typedef struct fd_account_keys_pair_global fd_account_keys_pair_global_t;
-#define FD_ACCOUNT_KEYS_PAIR_GLOBAL_FOOTPRINT sizeof(fd_account_keys_pair_global_t)
-#define FD_ACCOUNT_KEYS_PAIR_GLOBAL_ALIGN (8UL)
-
 typedef struct fd_account_keys_pair_t_mapnode fd_account_keys_pair_t_mapnode_t;
 #define REDBLK_T fd_account_keys_pair_t_mapnode_t
 #define REDBLK_NAME fd_account_keys_pair_t_map
@@ -566,14 +382,6 @@ struct __attribute__((aligned(8UL))) fd_stake_weight {
 typedef struct fd_stake_weight fd_stake_weight_t;
 #define FD_STAKE_WEIGHT_FOOTPRINT sizeof(fd_stake_weight_t)
 #define FD_STAKE_WEIGHT_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_stake_weight_global {
-  fd_pubkey_t key;
-  ulong stake;
-};
-typedef struct fd_stake_weight_global fd_stake_weight_global_t;
-#define FD_STAKE_WEIGHT_GLOBAL_FOOTPRINT sizeof(fd_stake_weight_global_t)
-#define FD_STAKE_WEIGHT_GLOBAL_ALIGN (8UL)
 
 typedef struct fd_stake_weight_t_mapnode fd_stake_weight_t_mapnode_t;
 #define REDBLK_T fd_stake_weight_t_mapnode_t
@@ -625,17 +433,6 @@ typedef struct fd_delegation fd_delegation_t;
 #define FD_DELEGATION_FOOTPRINT sizeof(fd_delegation_t)
 #define FD_DELEGATION_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_delegation_global {
-  fd_pubkey_t voter_pubkey;
-  ulong stake;
-  ulong activation_epoch;
-  ulong deactivation_epoch;
-  double warmup_cooldown_rate;
-};
-typedef struct fd_delegation_global fd_delegation_global_t;
-#define FD_DELEGATION_GLOBAL_FOOTPRINT sizeof(fd_delegation_global_t)
-#define FD_DELEGATION_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (96 bytes) */
 struct __attribute__((aligned(8UL))) fd_delegation_pair {
   fd_pubkey_t account;
@@ -644,14 +441,6 @@ struct __attribute__((aligned(8UL))) fd_delegation_pair {
 typedef struct fd_delegation_pair fd_delegation_pair_t;
 #define FD_DELEGATION_PAIR_FOOTPRINT sizeof(fd_delegation_pair_t)
 #define FD_DELEGATION_PAIR_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_delegation_pair_global {
-  fd_pubkey_t account;
-  fd_delegation_t delegation;
-};
-typedef struct fd_delegation_pair_global fd_delegation_pair_global_t;
-#define FD_DELEGATION_PAIR_GLOBAL_FOOTPRINT sizeof(fd_delegation_pair_global_t)
-#define FD_DELEGATION_PAIR_GLOBAL_ALIGN (8UL)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/state.rs#L539 */
 /* Encoded Size: Fixed (72 bytes) */
@@ -663,14 +452,6 @@ typedef struct fd_stake fd_stake_t;
 #define FD_STAKE_FOOTPRINT sizeof(fd_stake_t)
 #define FD_STAKE_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_stake_global {
-  fd_delegation_t delegation;
-  ulong credits_observed;
-};
-typedef struct fd_stake_global fd_stake_global_t;
-#define FD_STAKE_GLOBAL_FOOTPRINT sizeof(fd_stake_global_t)
-#define FD_STAKE_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (104 bytes) */
 struct __attribute__((aligned(8UL))) fd_stake_pair {
   fd_pubkey_t account;
@@ -679,14 +460,6 @@ struct __attribute__((aligned(8UL))) fd_stake_pair {
 typedef struct fd_stake_pair fd_stake_pair_t;
 #define FD_STAKE_PAIR_FOOTPRINT sizeof(fd_stake_pair_t)
 #define FD_STAKE_PAIR_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_stake_pair_global {
-  fd_pubkey_t account;
-  fd_stake_t stake;
-};
-typedef struct fd_stake_pair_global fd_stake_pair_global_t;
-#define FD_STAKE_PAIR_GLOBAL_FOOTPRINT sizeof(fd_stake_pair_global_t)
-#define FD_STAKE_PAIR_GLOBAL_ALIGN (8UL)
 
 typedef struct fd_delegation_pair_t_mapnode fd_delegation_pair_t_mapnode_t;
 #define REDBLK_T fd_delegation_pair_t_mapnode_t
@@ -728,7 +501,7 @@ struct __attribute__((aligned(8UL))) fd_stakes_global {
   ulong stake_delegations_root_gaddr;
   ulong unused;
   ulong epoch;
-  fd_stake_history_global_t stake_history;
+  fd_stake_history_t stake_history;
 };
 typedef struct fd_stakes_global fd_stakes_global_t;
 #define FD_STAKES_GLOBAL_FOOTPRINT sizeof(fd_stakes_global_t)
@@ -774,7 +547,7 @@ struct __attribute__((aligned(8UL))) fd_stakes_stake_global {
   ulong stake_delegations_root_gaddr;
   ulong unused;
   ulong epoch;
-  fd_stake_history_global_t stake_history;
+  fd_stake_history_t stake_history;
 };
 typedef struct fd_stakes_stake_global fd_stakes_stake_global_t;
 #define FD_STAKES_STAKE_GLOBAL_FOOTPRINT sizeof(fd_stakes_stake_global_t)
@@ -792,17 +565,6 @@ typedef struct fd_bank_incremental_snapshot_persistence fd_bank_incremental_snap
 #define FD_BANK_INCREMENTAL_SNAPSHOT_PERSISTENCE_FOOTPRINT sizeof(fd_bank_incremental_snapshot_persistence_t)
 #define FD_BANK_INCREMENTAL_SNAPSHOT_PERSISTENCE_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_bank_incremental_snapshot_persistence_global {
-  ulong full_slot;
-  fd_hash_t full_hash;
-  ulong full_capitalization;
-  fd_hash_t incremental_hash;
-  ulong incremental_capitalization;
-};
-typedef struct fd_bank_incremental_snapshot_persistence_global fd_bank_incremental_snapshot_persistence_global_t;
-#define FD_BANK_INCREMENTAL_SNAPSHOT_PERSISTENCE_GLOBAL_FOOTPRINT sizeof(fd_bank_incremental_snapshot_persistence_global_t)
-#define FD_BANK_INCREMENTAL_SNAPSHOT_PERSISTENCE_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_node_vote_accounts {
   ulong vote_accounts_len;
@@ -813,15 +575,6 @@ typedef struct fd_node_vote_accounts fd_node_vote_accounts_t;
 #define FD_NODE_VOTE_ACCOUNTS_FOOTPRINT sizeof(fd_node_vote_accounts_t)
 #define FD_NODE_VOTE_ACCOUNTS_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_node_vote_accounts_global {
-  ulong vote_accounts_len;
-  ulong vote_accounts_gaddr;
-  ulong total_stake;
-};
-typedef struct fd_node_vote_accounts_global fd_node_vote_accounts_global_t;
-#define FD_NODE_VOTE_ACCOUNTS_GLOBAL_FOOTPRINT sizeof(fd_node_vote_accounts_global_t)
-#define FD_NODE_VOTE_ACCOUNTS_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_pubkey_node_vote_accounts_pair {
   fd_pubkey_t key;
@@ -831,14 +584,6 @@ typedef struct fd_pubkey_node_vote_accounts_pair fd_pubkey_node_vote_accounts_pa
 #define FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_FOOTPRINT sizeof(fd_pubkey_node_vote_accounts_pair_t)
 #define FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_pubkey_node_vote_accounts_pair_global {
-  fd_pubkey_t key;
-  fd_node_vote_accounts_global_t value;
-};
-typedef struct fd_pubkey_node_vote_accounts_pair_global fd_pubkey_node_vote_accounts_pair_global_t;
-#define FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_GLOBAL_FOOTPRINT sizeof(fd_pubkey_node_vote_accounts_pair_global_t)
-#define FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (64 bytes) */
 struct __attribute__((aligned(8UL))) fd_pubkey_pubkey_pair {
   fd_pubkey_t key;
@@ -847,14 +592,6 @@ struct __attribute__((aligned(8UL))) fd_pubkey_pubkey_pair {
 typedef struct fd_pubkey_pubkey_pair fd_pubkey_pubkey_pair_t;
 #define FD_PUBKEY_PUBKEY_PAIR_FOOTPRINT sizeof(fd_pubkey_pubkey_pair_t)
 #define FD_PUBKEY_PUBKEY_PAIR_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_pubkey_pubkey_pair_global {
-  fd_pubkey_t key;
-  fd_pubkey_t value;
-};
-typedef struct fd_pubkey_pubkey_pair_global fd_pubkey_pubkey_pair_global_t;
-#define FD_PUBKEY_PUBKEY_PAIR_GLOBAL_FOOTPRINT sizeof(fd_pubkey_pubkey_pair_global_t)
-#define FD_PUBKEY_PUBKEY_PAIR_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_epoch_stakes {
@@ -907,14 +644,6 @@ typedef struct fd_pubkey_u64_pair fd_pubkey_u64_pair_t;
 #define FD_PUBKEY_U64_PAIR_FOOTPRINT sizeof(fd_pubkey_u64_pair_t)
 #define FD_PUBKEY_U64_PAIR_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_pubkey_u64_pair_global {
-  fd_pubkey_t _0;
-  ulong _1;
-};
-typedef struct fd_pubkey_u64_pair_global fd_pubkey_u64_pair_global_t;
-#define FD_PUBKEY_U64_PAIR_GLOBAL_FOOTPRINT sizeof(fd_pubkey_u64_pair_global_t)
-#define FD_PUBKEY_U64_PAIR_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_unused_accounts {
   ulong unused1_len;
@@ -927,18 +656,6 @@ struct __attribute__((aligned(8UL))) fd_unused_accounts {
 typedef struct fd_unused_accounts fd_unused_accounts_t;
 #define FD_UNUSED_ACCOUNTS_FOOTPRINT sizeof(fd_unused_accounts_t)
 #define FD_UNUSED_ACCOUNTS_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_unused_accounts_global {
-  ulong unused1_len;
-  ulong unused1_gaddr;
-  ulong unused2_len;
-  ulong unused2_gaddr;
-  ulong unused3_len;
-  ulong unused3_gaddr;
-};
-typedef struct fd_unused_accounts_global fd_unused_accounts_global_t;
-#define FD_UNUSED_ACCOUNTS_GLOBAL_FOOTPRINT sizeof(fd_unused_accounts_global_t)
-#define FD_UNUSED_ACCOUNTS_GLOBAL_ALIGN (8UL)
 
 /* https://github.com/solana-labs/solana/blob/88aeaa82a856fc807234e7da0b31b89f2dc0e091/runtime/src/bank.rs#L967 */
 /* Encoded Size: Dynamic */
@@ -989,7 +706,7 @@ struct __attribute__((aligned(16UL))) fd_versioned_bank_global {
   fd_hash_t hash;
   fd_hash_t parent_hash;
   ulong parent_slot;
-  fd_hard_forks_global_t hard_forks;
+  fd_hard_forks_t hard_forks;
   ulong transaction_count;
   ulong tick_height;
   ulong signature_count;
@@ -1013,7 +730,7 @@ struct __attribute__((aligned(16UL))) fd_versioned_bank_global {
   fd_epoch_schedule_t epoch_schedule;
   fd_inflation_t inflation;
   fd_stakes_global_t stakes;
-  fd_unused_accounts_global_t unused_accounts;
+  fd_unused_accounts_t unused_accounts;
   ulong epoch_stakes_len;
   ulong epoch_stakes_gaddr;
   uchar is_delta;
@@ -1034,17 +751,6 @@ typedef struct fd_bank_hash_stats fd_bank_hash_stats_t;
 #define FD_BANK_HASH_STATS_FOOTPRINT sizeof(fd_bank_hash_stats_t)
 #define FD_BANK_HASH_STATS_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_bank_hash_stats_global {
-  ulong num_updated_accounts;
-  ulong num_removed_accounts;
-  ulong num_lamports_stored;
-  ulong total_data_len;
-  ulong num_executable_accounts;
-};
-typedef struct fd_bank_hash_stats_global fd_bank_hash_stats_global_t;
-#define FD_BANK_HASH_STATS_GLOBAL_FOOTPRINT sizeof(fd_bank_hash_stats_global_t)
-#define FD_BANK_HASH_STATS_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (104 bytes) */
 struct __attribute__((aligned(8UL))) fd_bank_hash_info {
   fd_hash_t accounts_delta_hash;
@@ -1055,15 +761,6 @@ typedef struct fd_bank_hash_info fd_bank_hash_info_t;
 #define FD_BANK_HASH_INFO_FOOTPRINT sizeof(fd_bank_hash_info_t)
 #define FD_BANK_HASH_INFO_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_bank_hash_info_global {
-  fd_hash_t accounts_delta_hash;
-  fd_hash_t accounts_hash;
-  fd_bank_hash_stats_t stats;
-};
-typedef struct fd_bank_hash_info_global fd_bank_hash_info_global_t;
-#define FD_BANK_HASH_INFO_GLOBAL_FOOTPRINT sizeof(fd_bank_hash_info_global_t)
-#define FD_BANK_HASH_INFO_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (40 bytes) */
 struct __attribute__((aligned(8UL))) fd_slot_map_pair {
   ulong slot;
@@ -1073,14 +770,6 @@ typedef struct fd_slot_map_pair fd_slot_map_pair_t;
 #define FD_SLOT_MAP_PAIR_FOOTPRINT sizeof(fd_slot_map_pair_t)
 #define FD_SLOT_MAP_PAIR_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_slot_map_pair_global {
-  ulong slot;
-  fd_hash_t hash;
-};
-typedef struct fd_slot_map_pair_global fd_slot_map_pair_global_t;
-#define FD_SLOT_MAP_PAIR_GLOBAL_FOOTPRINT sizeof(fd_slot_map_pair_global_t)
-#define FD_SLOT_MAP_PAIR_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (16 bytes) */
 struct __attribute__((aligned(8UL))) fd_snapshot_acc_vec {
   ulong id;
@@ -1089,14 +778,6 @@ struct __attribute__((aligned(8UL))) fd_snapshot_acc_vec {
 typedef struct fd_snapshot_acc_vec fd_snapshot_acc_vec_t;
 #define FD_SNAPSHOT_ACC_VEC_FOOTPRINT sizeof(fd_snapshot_acc_vec_t)
 #define FD_SNAPSHOT_ACC_VEC_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_snapshot_acc_vec_global {
-  ulong id;
-  ulong file_sz;
-};
-typedef struct fd_snapshot_acc_vec_global fd_snapshot_acc_vec_global_t;
-#define FD_SNAPSHOT_ACC_VEC_GLOBAL_FOOTPRINT sizeof(fd_snapshot_acc_vec_global_t)
-#define FD_SNAPSHOT_ACC_VEC_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_snapshot_slot_acc_vecs {
@@ -1108,24 +789,10 @@ typedef struct fd_snapshot_slot_acc_vecs fd_snapshot_slot_acc_vecs_t;
 #define FD_SNAPSHOT_SLOT_ACC_VECS_FOOTPRINT sizeof(fd_snapshot_slot_acc_vecs_t)
 #define FD_SNAPSHOT_SLOT_ACC_VECS_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_snapshot_slot_acc_vecs_global {
-  ulong slot;
-  ulong account_vecs_len;
-  ulong account_vecs_gaddr;
-};
-typedef struct fd_snapshot_slot_acc_vecs_global fd_snapshot_slot_acc_vecs_global_t;
-#define FD_SNAPSHOT_SLOT_ACC_VECS_GLOBAL_FOOTPRINT sizeof(fd_snapshot_slot_acc_vecs_global_t)
-#define FD_SNAPSHOT_SLOT_ACC_VECS_GLOBAL_ALIGN (8UL)
-
 union fd_reward_type_inner {
   uchar nonempty; /* Hack to support enums with no inner structures */
 };
 typedef union fd_reward_type_inner fd_reward_type_inner_t;
-
-union fd_reward_type_inner_global {
-  uchar nonempty; /* Hack to support enums with no inner structures */
-};
-typedef union fd_reward_type_inner_global fd_reward_type_inner_global_t;
 
 /* https://github.com/anza-xyz/agave/blob/7117ed9653ce19e8b2dea108eff1f3eb6a3378a7/sdk/src/reward_type.rs#L7 */
 struct fd_reward_type {
@@ -1135,11 +802,6 @@ struct fd_reward_type {
 typedef struct fd_reward_type fd_reward_type_t;
 #define FD_REWARD_TYPE_FOOTPRINT sizeof(fd_reward_type_t)
 #define FD_REWARD_TYPE_ALIGN (8UL)
-struct fd_reward_type_global {
-  uint discriminant;
-  fd_reward_type_inner_global_t inner;
-};
-typedef struct fd_reward_type_global fd_reward_type_global_t;
 #define FD_REWARD_TYPE_GLOBAL_FOOTPRINT sizeof(fd_reward_type_global_t)
 #define FD_REWARD_TYPE_GLOBAL_ALIGN (8UL)
 
@@ -1159,21 +821,6 @@ struct __attribute__((aligned(8UL))) fd_solana_accounts_db_fields {
 typedef struct fd_solana_accounts_db_fields fd_solana_accounts_db_fields_t;
 #define FD_SOLANA_ACCOUNTS_DB_FIELDS_FOOTPRINT sizeof(fd_solana_accounts_db_fields_t)
 #define FD_SOLANA_ACCOUNTS_DB_FIELDS_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_solana_accounts_db_fields_global {
-  ulong storages_len;
-  ulong storages_gaddr;
-  ulong version;
-  ulong slot;
-  fd_bank_hash_info_t bank_hash_info;
-  ulong historical_roots_len;
-  ulong historical_roots_gaddr;
-  ulong historical_roots_with_hash_len;
-  ulong historical_roots_with_hash_gaddr;
-};
-typedef struct fd_solana_accounts_db_fields_global fd_solana_accounts_db_fields_global_t;
-#define FD_SOLANA_ACCOUNTS_DB_FIELDS_GLOBAL_FOOTPRINT sizeof(fd_solana_accounts_db_fields_global_t)
-#define FD_SOLANA_ACCOUNTS_DB_FIELDS_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_versioned_epoch_stakes_current {
@@ -1254,16 +901,6 @@ typedef struct fd_reward_info fd_reward_info_t;
 #define FD_REWARD_INFO_FOOTPRINT sizeof(fd_reward_info_t)
 #define FD_REWARD_INFO_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_reward_info_global {
-  fd_reward_type_t reward_type;
-  ulong lamports;
-  ulong post_balance;
-  ulong commission;
-};
-typedef struct fd_reward_info_global fd_reward_info_global_t;
-#define FD_REWARD_INFO_GLOBAL_FOOTPRINT sizeof(fd_reward_info_global_t)
-#define FD_REWARD_INFO_GLOBAL_ALIGN (8UL)
-
 /* You can cast this to a (fd_lthash_value_t *) and use it directly since the alignment is preserved */
 /* Encoded Size: Fixed (2048 bytes) */
 struct __attribute__((aligned(128UL))) fd_slot_lthash {
@@ -1272,13 +909,6 @@ struct __attribute__((aligned(128UL))) fd_slot_lthash {
 typedef struct fd_slot_lthash fd_slot_lthash_t;
 #define FD_SLOT_LTHASH_FOOTPRINT sizeof(fd_slot_lthash_t)
 #define FD_SLOT_LTHASH_ALIGN (128UL)
-
-struct __attribute__((aligned(128UL))) fd_slot_lthash_global {
-  uchar lthash[2048];
-};
-typedef struct fd_slot_lthash_global fd_slot_lthash_global_t;
-#define FD_SLOT_LTHASH_GLOBAL_FOOTPRINT sizeof(fd_slot_lthash_global_t)
-#define FD_SLOT_LTHASH_GLOBAL_ALIGN (128UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(16UL))) fd_solana_manifest {
@@ -1297,7 +927,7 @@ typedef struct fd_solana_manifest fd_solana_manifest_t;
 
 struct __attribute__((aligned(16UL))) fd_solana_manifest_global {
   fd_versioned_bank_global_t bank;
-  fd_solana_accounts_db_fields_global_t accounts_db;
+  fd_solana_accounts_db_fields_t accounts_db;
   ulong lamports_per_signature;
   ulong bank_incremental_snapshot_persistence_gaddr;
   ulong epoch_account_hash_gaddr;
@@ -1317,14 +947,6 @@ struct __attribute__((aligned(8UL))) fd_rust_duration {
 typedef struct fd_rust_duration fd_rust_duration_t;
 #define FD_RUST_DURATION_FOOTPRINT sizeof(fd_rust_duration_t)
 #define FD_RUST_DURATION_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_rust_duration_global {
-  ulong seconds;
-  uint nanoseconds;
-};
-typedef struct fd_rust_duration_global fd_rust_duration_global_t;
-#define FD_RUST_DURATION_GLOBAL_FOOTPRINT sizeof(fd_rust_duration_global_t)
-#define FD_RUST_DURATION_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_poh_config {
@@ -1374,14 +996,6 @@ struct __attribute__((aligned(8UL))) fd_pubkey_account_pair {
 typedef struct fd_pubkey_account_pair fd_pubkey_account_pair_t;
 #define FD_PUBKEY_ACCOUNT_PAIR_FOOTPRINT sizeof(fd_pubkey_account_pair_t)
 #define FD_PUBKEY_ACCOUNT_PAIR_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_pubkey_account_pair_global {
-  fd_pubkey_t key;
-  fd_solana_account_global_t account;
-};
-typedef struct fd_pubkey_account_pair_global fd_pubkey_account_pair_global_t;
-#define FD_PUBKEY_ACCOUNT_PAIR_GLOBAL_FOOTPRINT sizeof(fd_pubkey_account_pair_global_t)
-#define FD_PUBKEY_ACCOUNT_PAIR_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_genesis_solana {
@@ -1441,17 +1055,6 @@ typedef struct fd_sol_sysvar_clock fd_sol_sysvar_clock_t;
 #define FD_SOL_SYSVAR_CLOCK_FOOTPRINT sizeof(fd_sol_sysvar_clock_t)
 #define FD_SOL_SYSVAR_CLOCK_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_sol_sysvar_clock_global {
-  ulong slot;
-  long epoch_start_timestamp;
-  ulong epoch;
-  ulong leader_schedule_epoch;
-  long unix_timestamp;
-};
-typedef struct fd_sol_sysvar_clock_global fd_sol_sysvar_clock_global_t;
-#define FD_SOL_SYSVAR_CLOCK_GLOBAL_FOOTPRINT sizeof(fd_sol_sysvar_clock_global_t)
-#define FD_SOL_SYSVAR_CLOCK_GLOBAL_ALIGN (8UL)
-
 /* https://github.com/solana-labs/solana/blob/30531d7a5b74f914dde53bfbb0bc2144f2ac92bb/sdk/program/src/last_restart_slot.rs#L7 */
 /* Encoded Size: Fixed (8 bytes) */
 struct __attribute__((aligned(8UL))) fd_sol_sysvar_last_restart_slot {
@@ -1460,13 +1063,6 @@ struct __attribute__((aligned(8UL))) fd_sol_sysvar_last_restart_slot {
 typedef struct fd_sol_sysvar_last_restart_slot fd_sol_sysvar_last_restart_slot_t;
 #define FD_SOL_SYSVAR_LAST_RESTART_SLOT_FOOTPRINT sizeof(fd_sol_sysvar_last_restart_slot_t)
 #define FD_SOL_SYSVAR_LAST_RESTART_SLOT_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_sol_sysvar_last_restart_slot_global {
-  ulong slot;
-};
-typedef struct fd_sol_sysvar_last_restart_slot_global fd_sol_sysvar_last_restart_slot_global_t;
-#define FD_SOL_SYSVAR_LAST_RESTART_SLOT_GLOBAL_FOOTPRINT sizeof(fd_sol_sysvar_last_restart_slot_global_t)
-#define FD_SOL_SYSVAR_LAST_RESTART_SLOT_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Fixed (12 bytes) */
 struct __attribute__((aligned(8UL))) fd_vote_lockout {
@@ -1477,14 +1073,6 @@ typedef struct fd_vote_lockout fd_vote_lockout_t;
 #define FD_VOTE_LOCKOUT_FOOTPRINT sizeof(fd_vote_lockout_t)
 #define FD_VOTE_LOCKOUT_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_vote_lockout_global {
-  ulong slot;
-  uint confirmation_count;
-};
-typedef struct fd_vote_lockout_global fd_vote_lockout_global_t;
-#define FD_VOTE_LOCKOUT_GLOBAL_FOOTPRINT sizeof(fd_vote_lockout_global_t)
-#define FD_VOTE_LOCKOUT_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_lockout_offset {
   ulong offset;
@@ -1493,14 +1081,6 @@ struct __attribute__((aligned(8UL))) fd_lockout_offset {
 typedef struct fd_lockout_offset fd_lockout_offset_t;
 #define FD_LOCKOUT_OFFSET_FOOTPRINT sizeof(fd_lockout_offset_t)
 #define FD_LOCKOUT_OFFSET_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_lockout_offset_global {
-  ulong offset;
-  uchar confirmation_count;
-};
-typedef struct fd_lockout_offset_global fd_lockout_offset_global_t;
-#define FD_LOCKOUT_OFFSET_GLOBAL_FOOTPRINT sizeof(fd_lockout_offset_global_t)
-#define FD_LOCKOUT_OFFSET_GLOBAL_ALIGN (8UL)
 
 /* https://github.com/firedancer-io/solana/blob/da470eef4652b3b22598a1f379cacfe82bd5928d/sdk/program/src/vote/authorized_voters.rs#L9 */
 /* Encoded Size: Fixed (40 bytes) */
@@ -1516,18 +1096,6 @@ typedef struct fd_vote_authorized_voter fd_vote_authorized_voter_t;
 #define FD_VOTE_AUTHORIZED_VOTER_FOOTPRINT sizeof(fd_vote_authorized_voter_t)
 #define FD_VOTE_AUTHORIZED_VOTER_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_vote_authorized_voter_global {
-  ulong epoch;
-  fd_pubkey_t pubkey;
-  ulong parent;
-  ulong left;
-  ulong right;
-  ulong prio;
-};
-typedef struct fd_vote_authorized_voter_global fd_vote_authorized_voter_global_t;
-#define FD_VOTE_AUTHORIZED_VOTER_GLOBAL_FOOTPRINT sizeof(fd_vote_authorized_voter_global_t)
-#define FD_VOTE_AUTHORIZED_VOTER_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (48 bytes) */
 struct __attribute__((aligned(8UL))) fd_vote_prior_voter {
   fd_pubkey_t pubkey;
@@ -1537,15 +1105,6 @@ struct __attribute__((aligned(8UL))) fd_vote_prior_voter {
 typedef struct fd_vote_prior_voter fd_vote_prior_voter_t;
 #define FD_VOTE_PRIOR_VOTER_FOOTPRINT sizeof(fd_vote_prior_voter_t)
 #define FD_VOTE_PRIOR_VOTER_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_vote_prior_voter_global {
-  fd_pubkey_t pubkey;
-  ulong epoch_start;
-  ulong epoch_end;
-};
-typedef struct fd_vote_prior_voter_global fd_vote_prior_voter_global_t;
-#define FD_VOTE_PRIOR_VOTER_GLOBAL_FOOTPRINT sizeof(fd_vote_prior_voter_global_t)
-#define FD_VOTE_PRIOR_VOTER_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Fixed (56 bytes) */
 struct __attribute__((aligned(8UL))) fd_vote_prior_voter_0_23_5 {
@@ -1558,16 +1117,6 @@ typedef struct fd_vote_prior_voter_0_23_5 fd_vote_prior_voter_0_23_5_t;
 #define FD_VOTE_PRIOR_VOTER_0_23_5_FOOTPRINT sizeof(fd_vote_prior_voter_0_23_5_t)
 #define FD_VOTE_PRIOR_VOTER_0_23_5_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_vote_prior_voter_0_23_5_global {
-  fd_pubkey_t pubkey;
-  ulong epoch_start;
-  ulong epoch_end;
-  ulong slot;
-};
-typedef struct fd_vote_prior_voter_0_23_5_global fd_vote_prior_voter_0_23_5_global_t;
-#define FD_VOTE_PRIOR_VOTER_0_23_5_GLOBAL_FOOTPRINT sizeof(fd_vote_prior_voter_0_23_5_global_t)
-#define FD_VOTE_PRIOR_VOTER_0_23_5_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (24 bytes) */
 struct __attribute__((aligned(8UL))) fd_vote_epoch_credits {
   ulong epoch;
@@ -1578,15 +1127,6 @@ typedef struct fd_vote_epoch_credits fd_vote_epoch_credits_t;
 #define FD_VOTE_EPOCH_CREDITS_FOOTPRINT sizeof(fd_vote_epoch_credits_t)
 #define FD_VOTE_EPOCH_CREDITS_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_vote_epoch_credits_global {
-  ulong epoch;
-  ulong credits;
-  ulong prev_credits;
-};
-typedef struct fd_vote_epoch_credits_global fd_vote_epoch_credits_global_t;
-#define FD_VOTE_EPOCH_CREDITS_GLOBAL_FOOTPRINT sizeof(fd_vote_epoch_credits_global_t)
-#define FD_VOTE_EPOCH_CREDITS_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (16 bytes) */
 struct __attribute__((aligned(8UL))) fd_vote_block_timestamp {
   ulong slot;
@@ -1595,14 +1135,6 @@ struct __attribute__((aligned(8UL))) fd_vote_block_timestamp {
 typedef struct fd_vote_block_timestamp fd_vote_block_timestamp_t;
 #define FD_VOTE_BLOCK_TIMESTAMP_FOOTPRINT sizeof(fd_vote_block_timestamp_t)
 #define FD_VOTE_BLOCK_TIMESTAMP_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_vote_block_timestamp_global {
-  ulong slot;
-  long timestamp;
-};
-typedef struct fd_vote_block_timestamp_global fd_vote_block_timestamp_global_t;
-#define FD_VOTE_BLOCK_TIMESTAMP_GLOBAL_FOOTPRINT sizeof(fd_vote_block_timestamp_global_t)
-#define FD_VOTE_BLOCK_TIMESTAMP_GLOBAL_ALIGN (8UL)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L268 */
 /* Encoded Size: Fixed (1545 bytes) */
@@ -1615,15 +1147,6 @@ typedef struct fd_vote_prior_voters fd_vote_prior_voters_t;
 #define FD_VOTE_PRIOR_VOTERS_FOOTPRINT sizeof(fd_vote_prior_voters_t)
 #define FD_VOTE_PRIOR_VOTERS_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_vote_prior_voters_global {
-  fd_vote_prior_voter_t buf[32];
-  ulong idx;
-  uchar is_empty;
-};
-typedef struct fd_vote_prior_voters_global fd_vote_prior_voters_global_t;
-#define FD_VOTE_PRIOR_VOTERS_GLOBAL_FOOTPRINT sizeof(fd_vote_prior_voters_global_t)
-#define FD_VOTE_PRIOR_VOTERS_GLOBAL_ALIGN (8UL)
-
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L268 */
 /* Encoded Size: Fixed (1800 bytes) */
 struct __attribute__((aligned(8UL))) fd_vote_prior_voters_0_23_5 {
@@ -1634,14 +1157,6 @@ typedef struct fd_vote_prior_voters_0_23_5 fd_vote_prior_voters_0_23_5_t;
 #define FD_VOTE_PRIOR_VOTERS_0_23_5_FOOTPRINT sizeof(fd_vote_prior_voters_0_23_5_t)
 #define FD_VOTE_PRIOR_VOTERS_0_23_5_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_vote_prior_voters_0_23_5_global {
-  fd_vote_prior_voter_0_23_5_t buf[32];
-  ulong idx;
-};
-typedef struct fd_vote_prior_voters_0_23_5_global fd_vote_prior_voters_0_23_5_global_t;
-#define FD_VOTE_PRIOR_VOTERS_0_23_5_GLOBAL_FOOTPRINT sizeof(fd_vote_prior_voters_0_23_5_global_t)
-#define FD_VOTE_PRIOR_VOTERS_0_23_5_GLOBAL_ALIGN (8UL)
-
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L268 */
 /* Encoded Size: Fixed (13 bytes) */
 struct __attribute__((aligned(8UL))) fd_landed_vote {
@@ -1651,14 +1166,6 @@ struct __attribute__((aligned(8UL))) fd_landed_vote {
 typedef struct fd_landed_vote fd_landed_vote_t;
 #define FD_LANDED_VOTE_FOOTPRINT sizeof(fd_landed_vote_t)
 #define FD_LANDED_VOTE_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_landed_vote_global {
-  uchar latency;
-  fd_vote_lockout_t lockout;
-};
-typedef struct fd_landed_vote_global fd_landed_vote_global_t;
-#define FD_LANDED_VOTE_GLOBAL_FOOTPRINT sizeof(fd_landed_vote_global_t)
-#define FD_LANDED_VOTE_GLOBAL_ALIGN (8UL)
 
 #define DEQUE_NAME deq_fd_vote_lockout_t
 #define DEQUE_T fd_vote_lockout_t
@@ -1674,6 +1181,7 @@ deq_fd_vote_lockout_t_join_new( void * * alloc_mem, ulong max ) {
   *alloc_mem = (uchar *)*alloc_mem + deq_fd_vote_lockout_t_footprint( max );
   return deq_fd_vote_lockout_t_join( deq_fd_vote_lockout_t_new( deque_mem, max ) );
 }
+
 #define DEQUE_NAME deq_fd_vote_epoch_credits_t
 #define DEQUE_T fd_vote_epoch_credits_t
 #include "../../util/tmpl/fd_deque_dynamic.c"
@@ -1688,6 +1196,7 @@ deq_fd_vote_epoch_credits_t_join_new( void * * alloc_mem, ulong max ) {
   *alloc_mem = (uchar *)*alloc_mem + deq_fd_vote_epoch_credits_t_footprint( max );
   return deq_fd_vote_epoch_credits_t_join( deq_fd_vote_epoch_credits_t_new( deque_mem, max ) );
 }
+
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/vote_state_0_23_5.rs#L6 */
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_vote_state_0_23_5 {
@@ -1817,6 +1326,7 @@ deq_fd_landed_vote_t_join_new( void * * alloc_mem, ulong max ) {
   *alloc_mem = (uchar *)*alloc_mem + deq_fd_landed_vote_t_footprint( max );
   return deq_fd_landed_vote_t_join( deq_fd_landed_vote_t_new( deque_mem, max ) );
 }
+
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L310 */
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_vote_state {
@@ -1964,6 +1474,7 @@ deq_fd_lockout_offset_t_join_new( void * * alloc_mem, ulong max ) {
   *alloc_mem = (uchar *)*alloc_mem + deq_fd_lockout_offset_t_footprint( max );
   return deq_fd_lockout_offset_t_join( deq_fd_lockout_offset_t_new( deque_mem, max ) );
 }
+
 /* https://github.com/anza-xyz/agave/blob/20ee70cd1829cd414d09040460defecf9792a370/sdk/program/src/vote/state/mod.rs#L990 */
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_compact_tower_sync {
@@ -2047,14 +1558,6 @@ typedef struct fd_slot_history_inner fd_slot_history_inner_t;
 #define FD_SLOT_HISTORY_INNER_FOOTPRINT sizeof(fd_slot_history_inner_t)
 #define FD_SLOT_HISTORY_INNER_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_slot_history_inner_global {
-  ulong blocks_len;
-  ulong blocks_gaddr;
-};
-typedef struct fd_slot_history_inner_global fd_slot_history_inner_global_t;
-#define FD_SLOT_HISTORY_INNER_GLOBAL_FOOTPRINT sizeof(fd_slot_history_inner_global_t)
-#define FD_SLOT_HISTORY_INNER_GLOBAL_ALIGN (8UL)
-
 /* https://github.com/tov/bv-rs/blob/107be3e9c45324e55844befa4c4239d4d3d092c6/src/bit_vec/inner.rs#L8 */
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_slot_history_bitvec {
@@ -2100,14 +1603,6 @@ typedef struct fd_slot_hash fd_slot_hash_t;
 #define FD_SLOT_HASH_FOOTPRINT sizeof(fd_slot_hash_t)
 #define FD_SLOT_HASH_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_slot_hash_global {
-  ulong slot;
-  fd_hash_t hash;
-};
-typedef struct fd_slot_hash_global fd_slot_hash_global_t;
-#define FD_SLOT_HASH_GLOBAL_FOOTPRINT sizeof(fd_slot_hash_global_t)
-#define FD_SLOT_HASH_GLOBAL_ALIGN (8UL)
-
 #define DEQUE_NAME deq_fd_slot_hash_t
 #define DEQUE_T fd_slot_hash_t
 #include "../../util/tmpl/fd_deque_dynamic.c"
@@ -2122,6 +1617,7 @@ deq_fd_slot_hash_t_join_new( void * * alloc_mem, ulong max ) {
   *alloc_mem = (uchar *)*alloc_mem + deq_fd_slot_hash_t_footprint( max );
   return deq_fd_slot_hash_t_join( deq_fd_slot_hash_t_new( deque_mem, max ) );
 }
+
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/slot_hashes.rs#L31 */
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_slot_hashes {
@@ -2147,14 +1643,6 @@ typedef struct fd_block_block_hash_entry fd_block_block_hash_entry_t;
 #define FD_BLOCK_BLOCK_HASH_ENTRY_FOOTPRINT sizeof(fd_block_block_hash_entry_t)
 #define FD_BLOCK_BLOCK_HASH_ENTRY_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_block_block_hash_entry_global {
-  fd_hash_t blockhash;
-  fd_fee_calculator_t fee_calculator;
-};
-typedef struct fd_block_block_hash_entry_global fd_block_block_hash_entry_global_t;
-#define FD_BLOCK_BLOCK_HASH_ENTRY_GLOBAL_FOOTPRINT sizeof(fd_block_block_hash_entry_global_t)
-#define FD_BLOCK_BLOCK_HASH_ENTRY_GLOBAL_ALIGN (8UL)
-
 #define DEQUE_NAME deq_fd_block_block_hash_entry_t
 #define DEQUE_T fd_block_block_hash_entry_t
 #include "../../util/tmpl/fd_deque_dynamic.c"
@@ -2169,6 +1657,7 @@ deq_fd_block_block_hash_entry_t_join_new( void * * alloc_mem, ulong max ) {
   *alloc_mem = (uchar *)*alloc_mem + deq_fd_block_block_hash_entry_t_footprint( max );
   return deq_fd_block_block_hash_entry_t_join( deq_fd_block_block_hash_entry_t_new( deque_mem, max ) );
 }
+
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_recent_block_hashes {
   fd_block_block_hash_entry_t * hashes; /* fd_deque_dynamic (min cnt 151) */
@@ -2202,23 +1691,6 @@ typedef struct fd_slot_meta fd_slot_meta_t;
 #define FD_SLOT_META_FOOTPRINT sizeof(fd_slot_meta_t)
 #define FD_SLOT_META_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_slot_meta_global {
-  ulong slot;
-  ulong consumed;
-  ulong received;
-  long first_shred_timestamp;
-  ulong last_index;
-  ulong parent_slot;
-  ulong next_slot_len;
-  ulong next_slot_gaddr;
-  uchar is_connected;
-  ulong entry_end_indexes_len;
-  ulong entry_end_indexes_gaddr;
-};
-typedef struct fd_slot_meta_global fd_slot_meta_global_t;
-#define FD_SLOT_META_GLOBAL_FOOTPRINT sizeof(fd_slot_meta_global_t)
-#define FD_SLOT_META_GLOBAL_ALIGN (8UL)
-
 /* A validator timestamp oracle vote received from a voting node */
 /* Encoded Size: Fixed (48 bytes) */
 struct __attribute__((aligned(8UL))) fd_clock_timestamp_vote {
@@ -2229,15 +1701,6 @@ struct __attribute__((aligned(8UL))) fd_clock_timestamp_vote {
 typedef struct fd_clock_timestamp_vote fd_clock_timestamp_vote_t;
 #define FD_CLOCK_TIMESTAMP_VOTE_FOOTPRINT sizeof(fd_clock_timestamp_vote_t)
 #define FD_CLOCK_TIMESTAMP_VOTE_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_clock_timestamp_vote_global {
-  fd_pubkey_t pubkey;
-  long timestamp;
-  ulong slot;
-};
-typedef struct fd_clock_timestamp_vote_global fd_clock_timestamp_vote_global_t;
-#define FD_CLOCK_TIMESTAMP_VOTE_GLOBAL_FOOTPRINT sizeof(fd_clock_timestamp_vote_global_t)
-#define FD_CLOCK_TIMESTAMP_VOTE_GLOBAL_ALIGN (8UL)
 
 typedef struct fd_clock_timestamp_vote_t_mapnode fd_clock_timestamp_vote_t_mapnode_t;
 #define REDBLK_T fd_clock_timestamp_vote_t_mapnode_t
@@ -2286,13 +1749,6 @@ typedef struct fd_sysvar_fees fd_sysvar_fees_t;
 #define FD_SYSVAR_FEES_FOOTPRINT sizeof(fd_sysvar_fees_t)
 #define FD_SYSVAR_FEES_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_sysvar_fees_global {
-  fd_fee_calculator_t fee_calculator;
-};
-typedef struct fd_sysvar_fees_global fd_sysvar_fees_global_t;
-#define FD_SYSVAR_FEES_GLOBAL_FOOTPRINT sizeof(fd_sysvar_fees_global_t)
-#define FD_SYSVAR_FEES_GLOBAL_ALIGN (8UL)
-
 /* https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/sdk/program/src/epoch_rewards.rs#L14 */
 /* Encoded Size: Fixed (81 bytes) */
 struct __attribute__((aligned(16UL))) fd_sysvar_epoch_rewards {
@@ -2308,19 +1764,6 @@ typedef struct fd_sysvar_epoch_rewards fd_sysvar_epoch_rewards_t;
 #define FD_SYSVAR_EPOCH_REWARDS_FOOTPRINT sizeof(fd_sysvar_epoch_rewards_t)
 #define FD_SYSVAR_EPOCH_REWARDS_ALIGN (16UL)
 
-struct __attribute__((aligned(16UL))) fd_sysvar_epoch_rewards_global {
-  ulong distribution_starting_block_height;
-  ulong num_partitions;
-  fd_hash_t parent_blockhash;
-  uint128 total_points;
-  ulong total_rewards;
-  ulong distributed_rewards;
-  uchar active;
-};
-typedef struct fd_sysvar_epoch_rewards_global fd_sysvar_epoch_rewards_global_t;
-#define FD_SYSVAR_EPOCH_REWARDS_GLOBAL_FOOTPRINT sizeof(fd_sysvar_epoch_rewards_global_t)
-#define FD_SYSVAR_EPOCH_REWARDS_GLOBAL_ALIGN (16UL)
-
 /* Encoded Size: Fixed (33 bytes) */
 struct __attribute__((aligned(8UL))) fd_config_keys_pair {
   fd_pubkey_t key;
@@ -2329,14 +1772,6 @@ struct __attribute__((aligned(8UL))) fd_config_keys_pair {
 typedef struct fd_config_keys_pair fd_config_keys_pair_t;
 #define FD_CONFIG_KEYS_PAIR_FOOTPRINT sizeof(fd_config_keys_pair_t)
 #define FD_CONFIG_KEYS_PAIR_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_config_keys_pair_global {
-  fd_pubkey_t key;
-  uchar signer;
-};
-typedef struct fd_config_keys_pair_global fd_config_keys_pair_global_t;
-#define FD_CONFIG_KEYS_PAIR_GLOBAL_FOOTPRINT sizeof(fd_config_keys_pair_global_t)
-#define FD_CONFIG_KEYS_PAIR_GLOBAL_ALIGN (8UL)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/config.rs#L14 */
 /* Encoded Size: Dynamic */
@@ -2349,16 +1784,6 @@ struct __attribute__((aligned(8UL))) fd_stake_config {
 typedef struct fd_stake_config fd_stake_config_t;
 #define FD_STAKE_CONFIG_FOOTPRINT sizeof(fd_stake_config_t)
 #define FD_STAKE_CONFIG_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_stake_config_global {
-  ushort config_keys_len;
-  ulong config_keys_gaddr;
-  double warmup_cooldown_rate;
-  uchar slash_penalty;
-};
-typedef struct fd_stake_config_global fd_stake_config_global_t;
-#define FD_STAKE_CONFIG_GLOBAL_FOOTPRINT sizeof(fd_stake_config_global_t)
-#define FD_STAKE_CONFIG_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_feature_entry {
@@ -2447,11 +1872,6 @@ union fd_cluster_type_inner {
 };
 typedef union fd_cluster_type_inner fd_cluster_type_inner_t;
 
-union fd_cluster_type_inner_global {
-  uchar nonempty; /* Hack to support enums with no inner structures */
-};
-typedef union fd_cluster_type_inner_global fd_cluster_type_inner_global_t;
-
 struct fd_cluster_type {
   uint discriminant;
   fd_cluster_type_inner_t inner;
@@ -2459,11 +1879,6 @@ struct fd_cluster_type {
 typedef struct fd_cluster_type fd_cluster_type_t;
 #define FD_CLUSTER_TYPE_FOOTPRINT sizeof(fd_cluster_type_t)
 #define FD_CLUSTER_TYPE_ALIGN (8UL)
-struct fd_cluster_type_global {
-  uint discriminant;
-  fd_cluster_type_inner_global_t inner;
-};
-typedef struct fd_cluster_type_global fd_cluster_type_global_t;
 #define FD_CLUSTER_TYPE_GLOBAL_FOOTPRINT sizeof(fd_cluster_type_global_t)
 #define FD_CLUSTER_TYPE_GLOBAL_ALIGN (8UL)
 
@@ -2477,15 +1892,6 @@ typedef struct fd_rent_fresh_account fd_rent_fresh_account_t;
 #define FD_RENT_FRESH_ACCOUNT_FOOTPRINT sizeof(fd_rent_fresh_account_t)
 #define FD_RENT_FRESH_ACCOUNT_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_rent_fresh_account_global {
-  ulong partition;
-  fd_pubkey_t pubkey;
-  ulong present;
-};
-typedef struct fd_rent_fresh_account_global fd_rent_fresh_account_global_t;
-#define FD_RENT_FRESH_ACCOUNT_GLOBAL_FOOTPRINT sizeof(fd_rent_fresh_account_global_t)
-#define FD_RENT_FRESH_ACCOUNT_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_rent_fresh_accounts {
   ulong total_count;
@@ -2495,15 +1901,6 @@ struct __attribute__((aligned(8UL))) fd_rent_fresh_accounts {
 typedef struct fd_rent_fresh_accounts fd_rent_fresh_accounts_t;
 #define FD_RENT_FRESH_ACCOUNTS_FOOTPRINT sizeof(fd_rent_fresh_accounts_t)
 #define FD_RENT_FRESH_ACCOUNTS_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_rent_fresh_accounts_global {
-  ulong total_count;
-  ulong fresh_accounts_len;
-  ulong fresh_accounts_gaddr;
-};
-typedef struct fd_rent_fresh_accounts_global fd_rent_fresh_accounts_global_t;
-#define FD_RENT_FRESH_ACCOUNTS_GLOBAL_FOOTPRINT sizeof(fd_rent_fresh_accounts_global_t)
-#define FD_RENT_FRESH_ACCOUNTS_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(16UL))) fd_epoch_bank {
@@ -2616,8 +2013,8 @@ struct __attribute__((aligned(128UL))) fd_slot_bank_global {
   ulong tick_height;
   ulong use_preceeding_epoch_stakes;
   uchar has_use_preceeding_epoch_stakes;
-  fd_hard_forks_global_t hard_forks;
-  fd_rent_fresh_accounts_global_t rent_fresh_accounts;
+  fd_hard_forks_t hard_forks;
+  fd_rent_fresh_accounts_t rent_fresh_accounts;
 };
 typedef struct fd_slot_bank_global fd_slot_bank_global_t;
 #define FD_SLOT_BANK_GLOBAL_FOOTPRINT sizeof(fd_slot_bank_global_t)
@@ -2634,16 +2031,6 @@ typedef struct fd_prev_epoch_inflation_rewards fd_prev_epoch_inflation_rewards_t
 #define FD_PREV_EPOCH_INFLATION_REWARDS_FOOTPRINT sizeof(fd_prev_epoch_inflation_rewards_t)
 #define FD_PREV_EPOCH_INFLATION_REWARDS_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_prev_epoch_inflation_rewards_global {
-  ulong validator_rewards;
-  double prev_epoch_duration_in_years;
-  double validator_rate;
-  double foundation_rate;
-};
-typedef struct fd_prev_epoch_inflation_rewards_global fd_prev_epoch_inflation_rewards_global_t;
-#define FD_PREV_EPOCH_INFLATION_REWARDS_GLOBAL_FOOTPRINT sizeof(fd_prev_epoch_inflation_rewards_global_t)
-#define FD_PREV_EPOCH_INFLATION_REWARDS_GLOBAL_ALIGN (8UL)
-
 #define DEQUE_NAME deq_ulong
 #define DEQUE_T ulong
 #include "../../util/tmpl/fd_deque_dynamic.c"
@@ -2658,6 +2045,7 @@ deq_ulong_join_new( void * * alloc_mem, ulong max ) {
   *alloc_mem = (uchar *)*alloc_mem + deq_ulong_footprint( max );
   return deq_ulong_join( deq_ulong_new( deque_mem, max ) );
 }
+
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L133 */
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_vote {
@@ -2690,25 +2078,10 @@ typedef struct fd_vote_init fd_vote_init_t;
 #define FD_VOTE_INIT_FOOTPRINT sizeof(fd_vote_init_t)
 #define FD_VOTE_INIT_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_vote_init_global {
-  fd_pubkey_t node_pubkey;
-  fd_pubkey_t authorized_voter;
-  fd_pubkey_t authorized_withdrawer;
-  uchar commission;
-};
-typedef struct fd_vote_init_global fd_vote_init_global_t;
-#define FD_VOTE_INIT_GLOBAL_FOOTPRINT sizeof(fd_vote_init_global_t)
-#define FD_VOTE_INIT_GLOBAL_ALIGN (8UL)
-
 union fd_vote_authorize_inner {
   uchar nonempty; /* Hack to support enums with no inner structures */
 };
 typedef union fd_vote_authorize_inner fd_vote_authorize_inner_t;
-
-union fd_vote_authorize_inner_global {
-  uchar nonempty; /* Hack to support enums with no inner structures */
-};
-typedef union fd_vote_authorize_inner_global fd_vote_authorize_inner_global_t;
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L238 */
 struct fd_vote_authorize {
@@ -2718,11 +2091,6 @@ struct fd_vote_authorize {
 typedef struct fd_vote_authorize fd_vote_authorize_t;
 #define FD_VOTE_AUTHORIZE_FOOTPRINT sizeof(fd_vote_authorize_t)
 #define FD_VOTE_AUTHORIZE_ALIGN (8UL)
-struct fd_vote_authorize_global {
-  uint discriminant;
-  fd_vote_authorize_inner_global_t inner;
-};
-typedef struct fd_vote_authorize_global fd_vote_authorize_global_t;
 #define FD_VOTE_AUTHORIZE_GLOBAL_FOOTPRINT sizeof(fd_vote_authorize_global_t)
 #define FD_VOTE_AUTHORIZE_GLOBAL_ALIGN (8UL)
 
@@ -2735,14 +2103,6 @@ struct __attribute__((aligned(8UL))) fd_vote_authorize_pubkey {
 typedef struct fd_vote_authorize_pubkey fd_vote_authorize_pubkey_t;
 #define FD_VOTE_AUTHORIZE_PUBKEY_FOOTPRINT sizeof(fd_vote_authorize_pubkey_t)
 #define FD_VOTE_AUTHORIZE_PUBKEY_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_vote_authorize_pubkey_global {
-  fd_pubkey_t pubkey;
-  fd_vote_authorize_t vote_authorize;
-};
-typedef struct fd_vote_authorize_pubkey_global fd_vote_authorize_pubkey_global_t;
-#define FD_VOTE_AUTHORIZE_PUBKEY_GLOBAL_FOOTPRINT sizeof(fd_vote_authorize_pubkey_global_t)
-#define FD_VOTE_AUTHORIZE_PUBKEY_GLOBAL_ALIGN (8UL)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_instruction.rs#L78 */
 /* Encoded Size: Dynamic */
@@ -2891,15 +2251,6 @@ typedef struct fd_system_program_instruction_create_account fd_system_program_in
 #define FD_SYSTEM_PROGRAM_INSTRUCTION_CREATE_ACCOUNT_FOOTPRINT sizeof(fd_system_program_instruction_create_account_t)
 #define FD_SYSTEM_PROGRAM_INSTRUCTION_CREATE_ACCOUNT_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_system_program_instruction_create_account_global {
-  ulong lamports;
-  ulong space;
-  fd_pubkey_t owner;
-};
-typedef struct fd_system_program_instruction_create_account_global fd_system_program_instruction_create_account_global_t;
-#define FD_SYSTEM_PROGRAM_INSTRUCTION_CREATE_ACCOUNT_GLOBAL_FOOTPRINT sizeof(fd_system_program_instruction_create_account_global_t)
-#define FD_SYSTEM_PROGRAM_INSTRUCTION_CREATE_ACCOUNT_GLOBAL_ALIGN (8UL)
-
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/system_instruction.rs#L193 */
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_system_program_instruction_create_account_with_seed {
@@ -3045,11 +2396,6 @@ union fd_system_error_inner {
 };
 typedef union fd_system_error_inner fd_system_error_inner_t;
 
-union fd_system_error_inner_global {
-  uchar nonempty; /* Hack to support enums with no inner structures */
-};
-typedef union fd_system_error_inner_global fd_system_error_inner_global_t;
-
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/system_instruction.rs#L16 */
 struct fd_system_error {
   uint discriminant;
@@ -3058,11 +2404,6 @@ struct fd_system_error {
 typedef struct fd_system_error fd_system_error_t;
 #define FD_SYSTEM_ERROR_FOOTPRINT sizeof(fd_system_error_t)
 #define FD_SYSTEM_ERROR_ALIGN (8UL)
-struct fd_system_error_global {
-  uint discriminant;
-  fd_system_error_inner_global_t inner;
-};
-typedef struct fd_system_error_global fd_system_error_global_t;
 #define FD_SYSTEM_ERROR_GLOBAL_FOOTPRINT sizeof(fd_system_error_global_t)
 #define FD_SYSTEM_ERROR_GLOBAL_ALIGN (8UL)
 
@@ -3076,14 +2417,6 @@ typedef struct fd_stake_authorized fd_stake_authorized_t;
 #define FD_STAKE_AUTHORIZED_FOOTPRINT sizeof(fd_stake_authorized_t)
 #define FD_STAKE_AUTHORIZED_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_stake_authorized_global {
-  fd_pubkey_t staker;
-  fd_pubkey_t withdrawer;
-};
-typedef struct fd_stake_authorized_global fd_stake_authorized_global_t;
-#define FD_STAKE_AUTHORIZED_GLOBAL_FOOTPRINT sizeof(fd_stake_authorized_global_t)
-#define FD_STAKE_AUTHORIZED_GLOBAL_ALIGN (8UL)
-
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/state.rs#L135 */
 /* Encoded Size: Fixed (48 bytes) */
 struct __attribute__((aligned(8UL))) fd_stake_lockup {
@@ -3095,15 +2428,6 @@ typedef struct fd_stake_lockup fd_stake_lockup_t;
 #define FD_STAKE_LOCKUP_FOOTPRINT sizeof(fd_stake_lockup_t)
 #define FD_STAKE_LOCKUP_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_stake_lockup_global {
-  long unix_timestamp;
-  ulong epoch;
-  fd_pubkey_t custodian;
-};
-typedef struct fd_stake_lockup_global fd_stake_lockup_global_t;
-#define FD_STAKE_LOCKUP_GLOBAL_FOOTPRINT sizeof(fd_stake_lockup_global_t)
-#define FD_STAKE_LOCKUP_GLOBAL_ALIGN (8UL)
-
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/instruction.rs#L68 */
 /* Encoded Size: Fixed (112 bytes) */
 struct __attribute__((aligned(8UL))) fd_stake_instruction_initialize {
@@ -3113,14 +2437,6 @@ struct __attribute__((aligned(8UL))) fd_stake_instruction_initialize {
 typedef struct fd_stake_instruction_initialize fd_stake_instruction_initialize_t;
 #define FD_STAKE_INSTRUCTION_INITIALIZE_FOOTPRINT sizeof(fd_stake_instruction_initialize_t)
 #define FD_STAKE_INSTRUCTION_INITIALIZE_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_stake_instruction_initialize_global {
-  fd_stake_authorized_t authorized;
-  fd_stake_lockup_t lockup;
-};
-typedef struct fd_stake_instruction_initialize_global fd_stake_instruction_initialize_global_t;
-#define FD_STAKE_INSTRUCTION_INITIALIZE_GLOBAL_FOOTPRINT sizeof(fd_stake_instruction_initialize_global_t)
-#define FD_STAKE_INSTRUCTION_INITIALIZE_GLOBAL_ALIGN (8UL)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/instruction.rs#L78 */
 /* Encoded Size: Dynamic */
@@ -3147,11 +2463,6 @@ union fd_stake_authorize_inner {
 };
 typedef union fd_stake_authorize_inner fd_stake_authorize_inner_t;
 
-union fd_stake_authorize_inner_global {
-  uchar nonempty; /* Hack to support enums with no inner structures */
-};
-typedef union fd_stake_authorize_inner_global fd_stake_authorize_inner_global_t;
-
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/state.rs#L117 */
 struct fd_stake_authorize {
   uint discriminant;
@@ -3160,11 +2471,6 @@ struct fd_stake_authorize {
 typedef struct fd_stake_authorize fd_stake_authorize_t;
 #define FD_STAKE_AUTHORIZE_FOOTPRINT sizeof(fd_stake_authorize_t)
 #define FD_STAKE_AUTHORIZE_ALIGN (8UL)
-struct fd_stake_authorize_global {
-  uint discriminant;
-  fd_stake_authorize_inner_global_t inner;
-};
-typedef struct fd_stake_authorize_global fd_stake_authorize_global_t;
 #define FD_STAKE_AUTHORIZE_GLOBAL_FOOTPRINT sizeof(fd_stake_authorize_global_t)
 #define FD_STAKE_AUTHORIZE_GLOBAL_ALIGN (8UL)
 
@@ -3177,14 +2483,6 @@ struct __attribute__((aligned(8UL))) fd_stake_instruction_authorize {
 typedef struct fd_stake_instruction_authorize fd_stake_instruction_authorize_t;
 #define FD_STAKE_INSTRUCTION_AUTHORIZE_FOOTPRINT sizeof(fd_stake_instruction_authorize_t)
 #define FD_STAKE_INSTRUCTION_AUTHORIZE_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_stake_instruction_authorize_global {
-  fd_pubkey_t pubkey;
-  fd_stake_authorize_t stake_authorize;
-};
-typedef struct fd_stake_instruction_authorize_global fd_stake_instruction_authorize_global_t;
-#define FD_STAKE_INSTRUCTION_AUTHORIZE_GLOBAL_FOOTPRINT sizeof(fd_stake_instruction_authorize_global_t)
-#define FD_STAKE_INSTRUCTION_AUTHORIZE_GLOBAL_ALIGN (8UL)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/instruction.rs#L241 */
 /* Encoded Size: Dynamic */
@@ -3327,15 +2625,6 @@ typedef struct fd_stake_meta fd_stake_meta_t;
 #define FD_STAKE_META_FOOTPRINT sizeof(fd_stake_meta_t)
 #define FD_STAKE_META_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_stake_meta_global {
-  ulong rent_exempt_reserve;
-  fd_stake_authorized_t authorized;
-  fd_stake_lockup_t lockup;
-};
-typedef struct fd_stake_meta_global fd_stake_meta_global_t;
-#define FD_STAKE_META_GLOBAL_FOOTPRINT sizeof(fd_stake_meta_global_t)
-#define FD_STAKE_META_GLOBAL_ALIGN (8UL)
-
 /* https://github.com/firedancer-io/solana/blob/v1.17/sdk/program/src/stake/stake_flags.rs#L21 */
 /* Encoded Size: Fixed (1 bytes) */
 struct __attribute__((aligned(8UL))) fd_stake_flags {
@@ -3345,13 +2634,6 @@ typedef struct fd_stake_flags fd_stake_flags_t;
 #define FD_STAKE_FLAGS_FOOTPRINT sizeof(fd_stake_flags_t)
 #define FD_STAKE_FLAGS_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_stake_flags_global {
-  uchar bits;
-};
-typedef struct fd_stake_flags_global fd_stake_flags_global_t;
-#define FD_STAKE_FLAGS_GLOBAL_FOOTPRINT sizeof(fd_stake_flags_global_t)
-#define FD_STAKE_FLAGS_GLOBAL_ALIGN (8UL)
-
 /* https://github.com/firedancer-io/solana/blob/v1.17/sdk/program/src/stake/state.rs#L135 */
 /* Encoded Size: Fixed (120 bytes) */
 struct __attribute__((aligned(8UL))) fd_stake_state_v2_initialized {
@@ -3360,13 +2642,6 @@ struct __attribute__((aligned(8UL))) fd_stake_state_v2_initialized {
 typedef struct fd_stake_state_v2_initialized fd_stake_state_v2_initialized_t;
 #define FD_STAKE_STATE_V2_INITIALIZED_FOOTPRINT sizeof(fd_stake_state_v2_initialized_t)
 #define FD_STAKE_STATE_V2_INITIALIZED_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_stake_state_v2_initialized_global {
-  fd_stake_meta_t meta;
-};
-typedef struct fd_stake_state_v2_initialized_global fd_stake_state_v2_initialized_global_t;
-#define FD_STAKE_STATE_V2_INITIALIZED_GLOBAL_FOOTPRINT sizeof(fd_stake_state_v2_initialized_global_t)
-#define FD_STAKE_STATE_V2_INITIALIZED_GLOBAL_ALIGN (8UL)
 
 /* https://github.com/firedancer-io/solana/blob/v1.17/sdk/program/src/stake/state.rs#L136 */
 /* Encoded Size: Fixed (193 bytes) */
@@ -3379,26 +2654,11 @@ typedef struct fd_stake_state_v2_stake fd_stake_state_v2_stake_t;
 #define FD_STAKE_STATE_V2_STAKE_FOOTPRINT sizeof(fd_stake_state_v2_stake_t)
 #define FD_STAKE_STATE_V2_STAKE_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_stake_state_v2_stake_global {
-  fd_stake_meta_t meta;
-  fd_stake_t stake;
-  fd_stake_flags_t stake_flags;
-};
-typedef struct fd_stake_state_v2_stake_global fd_stake_state_v2_stake_global_t;
-#define FD_STAKE_STATE_V2_STAKE_GLOBAL_FOOTPRINT sizeof(fd_stake_state_v2_stake_global_t)
-#define FD_STAKE_STATE_V2_STAKE_GLOBAL_ALIGN (8UL)
-
 union fd_stake_state_v2_inner {
   fd_stake_state_v2_initialized_t initialized;
   fd_stake_state_v2_stake_t stake;
 };
 typedef union fd_stake_state_v2_inner fd_stake_state_v2_inner_t;
-
-union fd_stake_state_v2_inner_global {
-  fd_stake_state_v2_initialized_t initialized;
-  fd_stake_state_v2_stake_t stake;
-};
-typedef union fd_stake_state_v2_inner_global fd_stake_state_v2_inner_global_t;
 
 /* https://github.com/firedancer-io/solana/blob/v1.17/sdk/program/src/stake/state.rs#L132 */
 struct fd_stake_state_v2 {
@@ -3408,11 +2668,6 @@ struct fd_stake_state_v2 {
 typedef struct fd_stake_state_v2 fd_stake_state_v2_t;
 #define FD_STAKE_STATE_V2_FOOTPRINT sizeof(fd_stake_state_v2_t)
 #define FD_STAKE_STATE_V2_ALIGN (8UL)
-struct fd_stake_state_v2_global {
-  uint discriminant;
-  fd_stake_state_v2_inner_global_t inner;
-};
-typedef struct fd_stake_state_v2_global fd_stake_state_v2_global_t;
 #define FD_STAKE_STATE_V2_GLOBAL_FOOTPRINT sizeof(fd_stake_state_v2_global_t)
 #define FD_STAKE_STATE_V2_GLOBAL_ALIGN (8UL)
 
@@ -3427,24 +2682,10 @@ typedef struct fd_nonce_data fd_nonce_data_t;
 #define FD_NONCE_DATA_FOOTPRINT sizeof(fd_nonce_data_t)
 #define FD_NONCE_DATA_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_nonce_data_global {
-  fd_pubkey_t authority;
-  fd_hash_t durable_nonce;
-  fd_fee_calculator_t fee_calculator;
-};
-typedef struct fd_nonce_data_global fd_nonce_data_global_t;
-#define FD_NONCE_DATA_GLOBAL_FOOTPRINT sizeof(fd_nonce_data_global_t)
-#define FD_NONCE_DATA_GLOBAL_ALIGN (8UL)
-
 union fd_nonce_state_inner {
   fd_nonce_data_t initialized;
 };
 typedef union fd_nonce_state_inner fd_nonce_state_inner_t;
-
-union fd_nonce_state_inner_global {
-  fd_nonce_data_t initialized;
-};
-typedef union fd_nonce_state_inner_global fd_nonce_state_inner_global_t;
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/nonce/state/current.rs#L65 */
 struct fd_nonce_state {
@@ -3454,11 +2695,6 @@ struct fd_nonce_state {
 typedef struct fd_nonce_state fd_nonce_state_t;
 #define FD_NONCE_STATE_FOOTPRINT sizeof(fd_nonce_state_t)
 #define FD_NONCE_STATE_ALIGN (8UL)
-struct fd_nonce_state_global {
-  uint discriminant;
-  fd_nonce_state_inner_global_t inner;
-};
-typedef struct fd_nonce_state_global fd_nonce_state_global_t;
 #define FD_NONCE_STATE_GLOBAL_FOOTPRINT sizeof(fd_nonce_state_global_t)
 #define FD_NONCE_STATE_GLOBAL_ALIGN (8UL)
 
@@ -3468,12 +2704,6 @@ union fd_nonce_state_versions_inner {
 };
 typedef union fd_nonce_state_versions_inner fd_nonce_state_versions_inner_t;
 
-union fd_nonce_state_versions_inner_global {
-  fd_nonce_state_global_t legacy;
-  fd_nonce_state_global_t current;
-};
-typedef union fd_nonce_state_versions_inner_global fd_nonce_state_versions_inner_global_t;
-
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/nonce/state/mod.rs#L9 */
 struct fd_nonce_state_versions {
   uint discriminant;
@@ -3482,11 +2712,6 @@ struct fd_nonce_state_versions {
 typedef struct fd_nonce_state_versions fd_nonce_state_versions_t;
 #define FD_NONCE_STATE_VERSIONS_FOOTPRINT sizeof(fd_nonce_state_versions_t)
 #define FD_NONCE_STATE_VERSIONS_ALIGN (8UL)
-struct fd_nonce_state_versions_global {
-  uint discriminant;
-  fd_nonce_state_versions_inner_global_t inner;
-};
-typedef struct fd_nonce_state_versions_global fd_nonce_state_versions_global_t;
 #define FD_NONCE_STATE_VERSIONS_GLOBAL_FOOTPRINT sizeof(fd_nonce_state_versions_global_t)
 #define FD_NONCE_STATE_VERSIONS_GLOBAL_ALIGN (8UL)
 
@@ -3500,14 +2725,6 @@ typedef struct fd_compute_budget_program_instruction_request_units_deprecated fd
 #define FD_COMPUTE_BUDGET_PROGRAM_INSTRUCTION_REQUEST_UNITS_DEPRECATED_FOOTPRINT sizeof(fd_compute_budget_program_instruction_request_units_deprecated_t)
 #define FD_COMPUTE_BUDGET_PROGRAM_INSTRUCTION_REQUEST_UNITS_DEPRECATED_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_compute_budget_program_instruction_request_units_deprecated_global {
-  uint units;
-  uint additional_fee;
-};
-typedef struct fd_compute_budget_program_instruction_request_units_deprecated_global fd_compute_budget_program_instruction_request_units_deprecated_global_t;
-#define FD_COMPUTE_BUDGET_PROGRAM_INSTRUCTION_REQUEST_UNITS_DEPRECATED_GLOBAL_FOOTPRINT sizeof(fd_compute_budget_program_instruction_request_units_deprecated_global_t)
-#define FD_COMPUTE_BUDGET_PROGRAM_INSTRUCTION_REQUEST_UNITS_DEPRECATED_GLOBAL_ALIGN (8UL)
-
 union fd_compute_budget_program_instruction_inner {
   fd_compute_budget_program_instruction_request_units_deprecated_t request_units_deprecated;
   uint request_heap_frame;
@@ -3517,15 +2734,6 @@ union fd_compute_budget_program_instruction_inner {
 };
 typedef union fd_compute_budget_program_instruction_inner fd_compute_budget_program_instruction_inner_t;
 
-union fd_compute_budget_program_instruction_inner_global {
-  fd_compute_budget_program_instruction_request_units_deprecated_t request_units_deprecated;
-  uint request_heap_frame;
-  uint set_compute_unit_limit;
-  ulong set_compute_unit_price;
-  uint set_loaded_accounts_data_size_limit;
-};
-typedef union fd_compute_budget_program_instruction_inner_global fd_compute_budget_program_instruction_inner_global_t;
-
 /* https://github.com/solana-labs/solana/blob/6c520396cd76807f6227a7973f7373b37894251c/sdk/src/compute_budget.rs#L25 */
 struct fd_compute_budget_program_instruction {
   uint discriminant;
@@ -3534,11 +2742,6 @@ struct fd_compute_budget_program_instruction {
 typedef struct fd_compute_budget_program_instruction fd_compute_budget_program_instruction_t;
 #define FD_COMPUTE_BUDGET_PROGRAM_INSTRUCTION_FOOTPRINT sizeof(fd_compute_budget_program_instruction_t)
 #define FD_COMPUTE_BUDGET_PROGRAM_INSTRUCTION_ALIGN (8UL)
-struct fd_compute_budget_program_instruction_global {
-  uint discriminant;
-  fd_compute_budget_program_instruction_inner_global_t inner;
-};
-typedef struct fd_compute_budget_program_instruction_global fd_compute_budget_program_instruction_global_t;
 #define FD_COMPUTE_BUDGET_PROGRAM_INSTRUCTION_GLOBAL_FOOTPRINT sizeof(fd_compute_budget_program_instruction_global_t)
 #define FD_COMPUTE_BUDGET_PROGRAM_INSTRUCTION_GLOBAL_ALIGN (8UL)
 
@@ -3552,14 +2755,6 @@ typedef struct fd_config_keys fd_config_keys_t;
 #define FD_CONFIG_KEYS_FOOTPRINT sizeof(fd_config_keys_t)
 #define FD_CONFIG_KEYS_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_config_keys_global {
-  ushort keys_len;
-  ulong keys_gaddr;
-};
-typedef struct fd_config_keys_global fd_config_keys_global_t;
-#define FD_CONFIG_KEYS_GLOBAL_FOOTPRINT sizeof(fd_config_keys_global_t)
-#define FD_CONFIG_KEYS_GLOBAL_ALIGN (8UL)
-
 /*  */
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_bpf_loader_program_instruction_write {
@@ -3571,24 +2766,10 @@ typedef struct fd_bpf_loader_program_instruction_write fd_bpf_loader_program_ins
 #define FD_BPF_LOADER_PROGRAM_INSTRUCTION_WRITE_FOOTPRINT sizeof(fd_bpf_loader_program_instruction_write_t)
 #define FD_BPF_LOADER_PROGRAM_INSTRUCTION_WRITE_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_bpf_loader_program_instruction_write_global {
-  uint offset;
-  ulong bytes_len;
-  ulong bytes_gaddr;
-};
-typedef struct fd_bpf_loader_program_instruction_write_global fd_bpf_loader_program_instruction_write_global_t;
-#define FD_BPF_LOADER_PROGRAM_INSTRUCTION_WRITE_GLOBAL_FOOTPRINT sizeof(fd_bpf_loader_program_instruction_write_global_t)
-#define FD_BPF_LOADER_PROGRAM_INSTRUCTION_WRITE_GLOBAL_ALIGN (8UL)
-
 union fd_bpf_loader_program_instruction_inner {
   fd_bpf_loader_program_instruction_write_t write;
 };
 typedef union fd_bpf_loader_program_instruction_inner fd_bpf_loader_program_instruction_inner_t;
-
-union fd_bpf_loader_program_instruction_inner_global {
-  fd_bpf_loader_program_instruction_write_global_t write;
-};
-typedef union fd_bpf_loader_program_instruction_inner_global fd_bpf_loader_program_instruction_inner_global_t;
 
 /*  */
 struct fd_bpf_loader_program_instruction {
@@ -3598,11 +2779,6 @@ struct fd_bpf_loader_program_instruction {
 typedef struct fd_bpf_loader_program_instruction fd_bpf_loader_program_instruction_t;
 #define FD_BPF_LOADER_PROGRAM_INSTRUCTION_FOOTPRINT sizeof(fd_bpf_loader_program_instruction_t)
 #define FD_BPF_LOADER_PROGRAM_INSTRUCTION_ALIGN (8UL)
-struct fd_bpf_loader_program_instruction_global {
-  uint discriminant;
-  fd_bpf_loader_program_instruction_inner_global_t inner;
-};
-typedef struct fd_bpf_loader_program_instruction_global fd_bpf_loader_program_instruction_global_t;
 #define FD_BPF_LOADER_PROGRAM_INSTRUCTION_GLOBAL_FOOTPRINT sizeof(fd_bpf_loader_program_instruction_global_t)
 #define FD_BPF_LOADER_PROGRAM_INSTRUCTION_GLOBAL_ALIGN (8UL)
 
@@ -3617,15 +2793,6 @@ typedef struct fd_loader_v4_program_instruction_write fd_loader_v4_program_instr
 #define FD_LOADER_V4_PROGRAM_INSTRUCTION_WRITE_FOOTPRINT sizeof(fd_loader_v4_program_instruction_write_t)
 #define FD_LOADER_V4_PROGRAM_INSTRUCTION_WRITE_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_loader_v4_program_instruction_write_global {
-  uint offset;
-  ulong bytes_len;
-  ulong bytes_gaddr;
-};
-typedef struct fd_loader_v4_program_instruction_write_global fd_loader_v4_program_instruction_write_global_t;
-#define FD_LOADER_V4_PROGRAM_INSTRUCTION_WRITE_GLOBAL_FOOTPRINT sizeof(fd_loader_v4_program_instruction_write_global_t)
-#define FD_LOADER_V4_PROGRAM_INSTRUCTION_WRITE_GLOBAL_ALIGN (8UL)
-
 /* https://github.com/anza-xyz/agave/blob/007194391ca8313b2854d523769d0bedf040ef92/sdk/program/src/loader_v4_instruction.rs#L33-L36 */
 /* Encoded Size: Fixed (4 bytes) */
 struct __attribute__((aligned(8UL))) fd_loader_v4_program_instruction_truncate {
@@ -3635,24 +2802,11 @@ typedef struct fd_loader_v4_program_instruction_truncate fd_loader_v4_program_in
 #define FD_LOADER_V4_PROGRAM_INSTRUCTION_TRUNCATE_FOOTPRINT sizeof(fd_loader_v4_program_instruction_truncate_t)
 #define FD_LOADER_V4_PROGRAM_INSTRUCTION_TRUNCATE_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_loader_v4_program_instruction_truncate_global {
-  uint new_size;
-};
-typedef struct fd_loader_v4_program_instruction_truncate_global fd_loader_v4_program_instruction_truncate_global_t;
-#define FD_LOADER_V4_PROGRAM_INSTRUCTION_TRUNCATE_GLOBAL_FOOTPRINT sizeof(fd_loader_v4_program_instruction_truncate_global_t)
-#define FD_LOADER_V4_PROGRAM_INSTRUCTION_TRUNCATE_GLOBAL_ALIGN (8UL)
-
 union fd_loader_v4_program_instruction_inner {
   fd_loader_v4_program_instruction_write_t write;
   fd_loader_v4_program_instruction_truncate_t truncate;
 };
 typedef union fd_loader_v4_program_instruction_inner fd_loader_v4_program_instruction_inner_t;
-
-union fd_loader_v4_program_instruction_inner_global {
-  fd_loader_v4_program_instruction_write_global_t write;
-  fd_loader_v4_program_instruction_truncate_t truncate;
-};
-typedef union fd_loader_v4_program_instruction_inner_global fd_loader_v4_program_instruction_inner_global_t;
 
 /* https://github.com/anza-xyz/agave/blob/007194391ca8313b2854d523769d0bedf040ef92/sdk/program/src/loader_v4_instruction.rs#L5 */
 struct fd_loader_v4_program_instruction {
@@ -3662,11 +2816,6 @@ struct fd_loader_v4_program_instruction {
 typedef struct fd_loader_v4_program_instruction fd_loader_v4_program_instruction_t;
 #define FD_LOADER_V4_PROGRAM_INSTRUCTION_FOOTPRINT sizeof(fd_loader_v4_program_instruction_t)
 #define FD_LOADER_V4_PROGRAM_INSTRUCTION_ALIGN (8UL)
-struct fd_loader_v4_program_instruction_global {
-  uint discriminant;
-  fd_loader_v4_program_instruction_inner_global_t inner;
-};
-typedef struct fd_loader_v4_program_instruction_global fd_loader_v4_program_instruction_global_t;
 #define FD_LOADER_V4_PROGRAM_INSTRUCTION_GLOBAL_FOOTPRINT sizeof(fd_loader_v4_program_instruction_global_t)
 #define FD_LOADER_V4_PROGRAM_INSTRUCTION_GLOBAL_ALIGN (8UL)
 
@@ -3681,15 +2830,6 @@ typedef struct fd_bpf_upgradeable_loader_program_instruction_write fd_bpf_upgrad
 #define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_WRITE_FOOTPRINT sizeof(fd_bpf_upgradeable_loader_program_instruction_write_t)
 #define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_WRITE_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_bpf_upgradeable_loader_program_instruction_write_global {
-  uint offset;
-  ulong bytes_len;
-  ulong bytes_gaddr;
-};
-typedef struct fd_bpf_upgradeable_loader_program_instruction_write_global fd_bpf_upgradeable_loader_program_instruction_write_global_t;
-#define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_WRITE_GLOBAL_FOOTPRINT sizeof(fd_bpf_upgradeable_loader_program_instruction_write_global_t)
-#define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_WRITE_GLOBAL_ALIGN (8UL)
-
 /*  */
 /* Encoded Size: Fixed (8 bytes) */
 struct __attribute__((aligned(8UL))) fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len {
@@ -3698,13 +2838,6 @@ struct __attribute__((aligned(8UL))) fd_bpf_upgradeable_loader_program_instructi
 typedef struct fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t;
 #define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_DEPLOY_WITH_MAX_DATA_LEN_FOOTPRINT sizeof(fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t)
 #define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_DEPLOY_WITH_MAX_DATA_LEN_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_global {
-  ulong max_data_len;
-};
-typedef struct fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_global fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_global_t;
-#define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_DEPLOY_WITH_MAX_DATA_LEN_GLOBAL_FOOTPRINT sizeof(fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_global_t)
-#define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_DEPLOY_WITH_MAX_DATA_LEN_GLOBAL_ALIGN (8UL)
 
 /*  */
 /* Encoded Size: Fixed (4 bytes) */
@@ -3715,26 +2848,12 @@ typedef struct fd_bpf_upgradeable_loader_program_instruction_extend_program fd_b
 #define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_EXTEND_PROGRAM_FOOTPRINT sizeof(fd_bpf_upgradeable_loader_program_instruction_extend_program_t)
 #define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_EXTEND_PROGRAM_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_bpf_upgradeable_loader_program_instruction_extend_program_global {
-  uint additional_bytes;
-};
-typedef struct fd_bpf_upgradeable_loader_program_instruction_extend_program_global fd_bpf_upgradeable_loader_program_instruction_extend_program_global_t;
-#define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_EXTEND_PROGRAM_GLOBAL_FOOTPRINT sizeof(fd_bpf_upgradeable_loader_program_instruction_extend_program_global_t)
-#define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_EXTEND_PROGRAM_GLOBAL_ALIGN (8UL)
-
 union fd_bpf_upgradeable_loader_program_instruction_inner {
   fd_bpf_upgradeable_loader_program_instruction_write_t write;
   fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t deploy_with_max_data_len;
   fd_bpf_upgradeable_loader_program_instruction_extend_program_t extend_program;
 };
 typedef union fd_bpf_upgradeable_loader_program_instruction_inner fd_bpf_upgradeable_loader_program_instruction_inner_t;
-
-union fd_bpf_upgradeable_loader_program_instruction_inner_global {
-  fd_bpf_upgradeable_loader_program_instruction_write_global_t write;
-  fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t deploy_with_max_data_len;
-  fd_bpf_upgradeable_loader_program_instruction_extend_program_t extend_program;
-};
-typedef union fd_bpf_upgradeable_loader_program_instruction_inner_global fd_bpf_upgradeable_loader_program_instruction_inner_global_t;
 
 /*  */
 struct fd_bpf_upgradeable_loader_program_instruction {
@@ -3744,11 +2863,6 @@ struct fd_bpf_upgradeable_loader_program_instruction {
 typedef struct fd_bpf_upgradeable_loader_program_instruction fd_bpf_upgradeable_loader_program_instruction_t;
 #define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_FOOTPRINT sizeof(fd_bpf_upgradeable_loader_program_instruction_t)
 #define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_ALIGN (8UL)
-struct fd_bpf_upgradeable_loader_program_instruction_global {
-  uint discriminant;
-  fd_bpf_upgradeable_loader_program_instruction_inner_global_t inner;
-};
-typedef struct fd_bpf_upgradeable_loader_program_instruction_global fd_bpf_upgradeable_loader_program_instruction_global_t;
 #define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_GLOBAL_FOOTPRINT sizeof(fd_bpf_upgradeable_loader_program_instruction_global_t)
 #define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_GLOBAL_ALIGN (8UL)
 
@@ -3776,13 +2890,6 @@ struct __attribute__((aligned(8UL))) fd_bpf_upgradeable_loader_state_program {
 typedef struct fd_bpf_upgradeable_loader_state_program fd_bpf_upgradeable_loader_state_program_t;
 #define FD_BPF_UPGRADEABLE_LOADER_STATE_PROGRAM_FOOTPRINT sizeof(fd_bpf_upgradeable_loader_state_program_t)
 #define FD_BPF_UPGRADEABLE_LOADER_STATE_PROGRAM_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_bpf_upgradeable_loader_state_program_global {
-  fd_pubkey_t programdata_address;
-};
-typedef struct fd_bpf_upgradeable_loader_state_program_global fd_bpf_upgradeable_loader_state_program_global_t;
-#define FD_BPF_UPGRADEABLE_LOADER_STATE_PROGRAM_GLOBAL_FOOTPRINT sizeof(fd_bpf_upgradeable_loader_state_program_global_t)
-#define FD_BPF_UPGRADEABLE_LOADER_STATE_PROGRAM_GLOBAL_ALIGN (8UL)
 
 /*  */
 /* Encoded Size: Dynamic */
@@ -3843,15 +2950,6 @@ typedef struct fd_loader_v4_state fd_loader_v4_state_t;
 #define FD_LOADER_V4_STATE_FOOTPRINT sizeof(fd_loader_v4_state_t)
 #define FD_LOADER_V4_STATE_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_loader_v4_state_global {
-  ulong slot;
-  fd_pubkey_t authority_address_or_next_version;
-  ulong status;
-};
-typedef struct fd_loader_v4_state_global fd_loader_v4_state_global_t;
-#define FD_LOADER_V4_STATE_GLOBAL_FOOTPRINT sizeof(fd_loader_v4_state_global_t)
-#define FD_LOADER_V4_STATE_GLOBAL_ALIGN (8UL)
-
 /* https://github.com/firedancer-io/solana/blob/f4b7c54f9e021b40cfc7cbd32dc12b19dedbe791/ledger/src/blockstore_meta.rs#L178 */
 /* Encoded Size: Fixed (33 bytes) */
 struct __attribute__((aligned(8UL))) fd_frozen_hash_status {
@@ -3862,23 +2960,10 @@ typedef struct fd_frozen_hash_status fd_frozen_hash_status_t;
 #define FD_FROZEN_HASH_STATUS_FOOTPRINT sizeof(fd_frozen_hash_status_t)
 #define FD_FROZEN_HASH_STATUS_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_frozen_hash_status_global {
-  fd_hash_t frozen_hash;
-  uchar is_duplicate_confirmed;
-};
-typedef struct fd_frozen_hash_status_global fd_frozen_hash_status_global_t;
-#define FD_FROZEN_HASH_STATUS_GLOBAL_FOOTPRINT sizeof(fd_frozen_hash_status_global_t)
-#define FD_FROZEN_HASH_STATUS_GLOBAL_ALIGN (8UL)
-
 union fd_frozen_hash_versioned_inner {
   fd_frozen_hash_status_t current;
 };
 typedef union fd_frozen_hash_versioned_inner fd_frozen_hash_versioned_inner_t;
-
-union fd_frozen_hash_versioned_inner_global {
-  fd_frozen_hash_status_t current;
-};
-typedef union fd_frozen_hash_versioned_inner_global fd_frozen_hash_versioned_inner_global_t;
 
 /* https://github.com/firedancer-io/solana/blob/f4b7c54f9e021b40cfc7cbd32dc12b19dedbe791/ledger/src/blockstore_meta.rs#L157 */
 struct fd_frozen_hash_versioned {
@@ -3888,11 +2973,6 @@ struct fd_frozen_hash_versioned {
 typedef struct fd_frozen_hash_versioned fd_frozen_hash_versioned_t;
 #define FD_FROZEN_HASH_VERSIONED_FOOTPRINT sizeof(fd_frozen_hash_versioned_t)
 #define FD_FROZEN_HASH_VERSIONED_ALIGN (8UL)
-struct fd_frozen_hash_versioned_global {
-  uint discriminant;
-  fd_frozen_hash_versioned_inner_global_t inner;
-};
-typedef struct fd_frozen_hash_versioned_global fd_frozen_hash_versioned_global_t;
 #define FD_FROZEN_HASH_VERSIONED_GLOBAL_FOOTPRINT sizeof(fd_frozen_hash_versioned_global_t)
 #define FD_FROZEN_HASH_VERSIONED_GLOBAL_ALIGN (8UL)
 
@@ -3973,14 +3053,6 @@ typedef struct fd_gossip_bitvec_u8_inner fd_gossip_bitvec_u8_inner_t;
 #define FD_GOSSIP_BITVEC_U8_INNER_FOOTPRINT sizeof(fd_gossip_bitvec_u8_inner_t)
 #define FD_GOSSIP_BITVEC_U8_INNER_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_gossip_bitvec_u8_inner_global {
-  ulong vec_len;
-  ulong vec_gaddr;
-};
-typedef struct fd_gossip_bitvec_u8_inner_global fd_gossip_bitvec_u8_inner_global_t;
-#define FD_GOSSIP_BITVEC_U8_INNER_GLOBAL_FOOTPRINT sizeof(fd_gossip_bitvec_u8_inner_global_t)
-#define FD_GOSSIP_BITVEC_U8_INNER_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_bitvec_u8 {
   fd_gossip_bitvec_u8_inner_t bits;
@@ -4008,14 +3080,6 @@ struct __attribute__((aligned(8UL))) fd_gossip_bitvec_u64_inner {
 typedef struct fd_gossip_bitvec_u64_inner fd_gossip_bitvec_u64_inner_t;
 #define FD_GOSSIP_BITVEC_U64_INNER_FOOTPRINT sizeof(fd_gossip_bitvec_u64_inner_t)
 #define FD_GOSSIP_BITVEC_U64_INNER_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_gossip_bitvec_u64_inner_global {
-  ulong vec_len;
-  ulong vec_gaddr;
-};
-typedef struct fd_gossip_bitvec_u64_inner_global fd_gossip_bitvec_u64_inner_global_t;
-#define FD_GOSSIP_BITVEC_U64_INNER_GLOBAL_FOOTPRINT sizeof(fd_gossip_bitvec_u64_inner_global_t)
-#define FD_GOSSIP_BITVEC_U64_INNER_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_bitvec_u64 {
@@ -4047,26 +3111,11 @@ typedef struct fd_gossip_ping fd_gossip_ping_t;
 #define FD_GOSSIP_PING_FOOTPRINT sizeof(fd_gossip_ping_t)
 #define FD_GOSSIP_PING_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_gossip_ping_global {
-  fd_pubkey_t from;
-  fd_hash_t token;
-  fd_signature_t signature;
-};
-typedef struct fd_gossip_ping_global fd_gossip_ping_global_t;
-#define FD_GOSSIP_PING_GLOBAL_FOOTPRINT sizeof(fd_gossip_ping_global_t)
-#define FD_GOSSIP_PING_GLOBAL_ALIGN (8UL)
-
 union fd_gossip_ip_addr_inner {
   fd_gossip_ip4_addr_t ip4;
   fd_gossip_ip6_addr_t ip6;
 };
 typedef union fd_gossip_ip_addr_inner fd_gossip_ip_addr_inner_t;
-
-union fd_gossip_ip_addr_inner_global {
-  fd_gossip_ip4_addr_global_t ip4;
-  fd_gossip_ip6_addr_global_t ip6;
-};
-typedef union fd_gossip_ip_addr_inner_global fd_gossip_ip_addr_inner_global_t;
 
 /* Unnecessary and sad wrapper type. IPv4 addresses could have been mapped to IPv6 */
 struct fd_gossip_ip_addr {
@@ -4076,11 +3125,6 @@ struct fd_gossip_ip_addr {
 typedef struct fd_gossip_ip_addr fd_gossip_ip_addr_t;
 #define FD_GOSSIP_IP_ADDR_FOOTPRINT sizeof(fd_gossip_ip_addr_t)
 #define FD_GOSSIP_IP_ADDR_ALIGN (8UL)
-struct fd_gossip_ip_addr_global {
-  uint discriminant;
-  fd_gossip_ip_addr_inner_global_t inner;
-};
-typedef struct fd_gossip_ip_addr_global fd_gossip_ip_addr_global_t;
 #define FD_GOSSIP_IP_ADDR_GLOBAL_FOOTPRINT sizeof(fd_gossip_ip_addr_global_t)
 #define FD_GOSSIP_IP_ADDR_GLOBAL_ALIGN (8UL)
 
@@ -4097,18 +3141,6 @@ typedef struct fd_gossip_prune_data fd_gossip_prune_data_t;
 #define FD_GOSSIP_PRUNE_DATA_FOOTPRINT sizeof(fd_gossip_prune_data_t)
 #define FD_GOSSIP_PRUNE_DATA_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_gossip_prune_data_global {
-  fd_pubkey_t pubkey;
-  ulong prunes_len;
-  ulong prunes_gaddr;
-  fd_signature_t signature;
-  fd_pubkey_t destination;
-  ulong wallclock;
-};
-typedef struct fd_gossip_prune_data_global fd_gossip_prune_data_global_t;
-#define FD_GOSSIP_PRUNE_DATA_GLOBAL_FOOTPRINT sizeof(fd_gossip_prune_data_global_t)
-#define FD_GOSSIP_PRUNE_DATA_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_prune_sign_data {
   fd_pubkey_t pubkey;
@@ -4120,17 +3152,6 @@ struct __attribute__((aligned(8UL))) fd_gossip_prune_sign_data {
 typedef struct fd_gossip_prune_sign_data fd_gossip_prune_sign_data_t;
 #define FD_GOSSIP_PRUNE_SIGN_DATA_FOOTPRINT sizeof(fd_gossip_prune_sign_data_t)
 #define FD_GOSSIP_PRUNE_SIGN_DATA_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_gossip_prune_sign_data_global {
-  fd_pubkey_t pubkey;
-  ulong prunes_len;
-  ulong prunes_gaddr;
-  fd_pubkey_t destination;
-  ulong wallclock;
-};
-typedef struct fd_gossip_prune_sign_data_global fd_gossip_prune_sign_data_global_t;
-#define FD_GOSSIP_PRUNE_SIGN_DATA_GLOBAL_FOOTPRINT sizeof(fd_gossip_prune_sign_data_global_t)
-#define FD_GOSSIP_PRUNE_SIGN_DATA_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_prune_sign_data_with_prefix {
@@ -4145,7 +3166,7 @@ typedef struct fd_gossip_prune_sign_data_with_prefix fd_gossip_prune_sign_data_w
 struct __attribute__((aligned(8UL))) fd_gossip_prune_sign_data_with_prefix_global {
   ulong prefix_len;
   ulong prefix_gaddr;
-  fd_gossip_prune_sign_data_global_t data;
+  fd_gossip_prune_sign_data_t data;
 };
 typedef struct fd_gossip_prune_sign_data_with_prefix_global fd_gossip_prune_sign_data_with_prefix_global_t;
 #define FD_GOSSIP_PRUNE_SIGN_DATA_WITH_PREFIX_GLOBAL_FOOTPRINT sizeof(fd_gossip_prune_sign_data_with_prefix_global_t)
@@ -4160,14 +3181,6 @@ typedef struct fd_gossip_socket_addr_old fd_gossip_socket_addr_old_t;
 #define FD_GOSSIP_SOCKET_ADDR_OLD_FOOTPRINT sizeof(fd_gossip_socket_addr_old_t)
 #define FD_GOSSIP_SOCKET_ADDR_OLD_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_gossip_socket_addr_old_global {
-  fd_gossip_ip_addr_global_t addr;
-  ushort port;
-};
-typedef struct fd_gossip_socket_addr_old_global fd_gossip_socket_addr_old_global_t;
-#define FD_GOSSIP_SOCKET_ADDR_OLD_GLOBAL_FOOTPRINT sizeof(fd_gossip_socket_addr_old_global_t)
-#define FD_GOSSIP_SOCKET_ADDR_OLD_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_socket_addr_ip4 {
   fd_gossip_ip4_addr_t addr;
@@ -4176,14 +3189,6 @@ struct __attribute__((aligned(8UL))) fd_gossip_socket_addr_ip4 {
 typedef struct fd_gossip_socket_addr_ip4 fd_gossip_socket_addr_ip4_t;
 #define FD_GOSSIP_SOCKET_ADDR_IP4_FOOTPRINT sizeof(fd_gossip_socket_addr_ip4_t)
 #define FD_GOSSIP_SOCKET_ADDR_IP4_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_gossip_socket_addr_ip4_global {
-  fd_gossip_ip4_addr_global_t addr;
-  ushort port;
-};
-typedef struct fd_gossip_socket_addr_ip4_global fd_gossip_socket_addr_ip4_global_t;
-#define FD_GOSSIP_SOCKET_ADDR_IP4_GLOBAL_FOOTPRINT sizeof(fd_gossip_socket_addr_ip4_global_t)
-#define FD_GOSSIP_SOCKET_ADDR_IP4_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_socket_addr_ip6 {
@@ -4196,27 +3201,11 @@ typedef struct fd_gossip_socket_addr_ip6 fd_gossip_socket_addr_ip6_t;
 #define FD_GOSSIP_SOCKET_ADDR_IP6_FOOTPRINT sizeof(fd_gossip_socket_addr_ip6_t)
 #define FD_GOSSIP_SOCKET_ADDR_IP6_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_gossip_socket_addr_ip6_global {
-  fd_gossip_ip6_addr_global_t addr;
-  ushort port;
-  uint flowinfo;
-  uint scope_id;
-};
-typedef struct fd_gossip_socket_addr_ip6_global fd_gossip_socket_addr_ip6_global_t;
-#define FD_GOSSIP_SOCKET_ADDR_IP6_GLOBAL_FOOTPRINT sizeof(fd_gossip_socket_addr_ip6_global_t)
-#define FD_GOSSIP_SOCKET_ADDR_IP6_GLOBAL_ALIGN (8UL)
-
 union fd_gossip_socket_addr_inner {
   fd_gossip_socket_addr_ip4_t ip4;
   fd_gossip_socket_addr_ip6_t ip6;
 };
 typedef union fd_gossip_socket_addr_inner fd_gossip_socket_addr_inner_t;
-
-union fd_gossip_socket_addr_inner_global {
-  fd_gossip_socket_addr_ip4_global_t ip4;
-  fd_gossip_socket_addr_ip6_global_t ip6;
-};
-typedef union fd_gossip_socket_addr_inner_global fd_gossip_socket_addr_inner_global_t;
 
 struct fd_gossip_socket_addr {
   uint discriminant;
@@ -4225,11 +3214,6 @@ struct fd_gossip_socket_addr {
 typedef struct fd_gossip_socket_addr fd_gossip_socket_addr_t;
 #define FD_GOSSIP_SOCKET_ADDR_FOOTPRINT sizeof(fd_gossip_socket_addr_t)
 #define FD_GOSSIP_SOCKET_ADDR_ALIGN (8UL)
-struct fd_gossip_socket_addr_global {
-  uint discriminant;
-  fd_gossip_socket_addr_inner_global_t inner;
-};
-typedef struct fd_gossip_socket_addr_global fd_gossip_socket_addr_global_t;
 #define FD_GOSSIP_SOCKET_ADDR_GLOBAL_FOOTPRINT sizeof(fd_gossip_socket_addr_global_t)
 #define FD_GOSSIP_SOCKET_ADDR_GLOBAL_ALIGN (8UL)
 
@@ -4253,25 +3237,6 @@ typedef struct fd_gossip_contact_info_v1 fd_gossip_contact_info_v1_t;
 #define FD_GOSSIP_CONTACT_INFO_V1_FOOTPRINT sizeof(fd_gossip_contact_info_v1_t)
 #define FD_GOSSIP_CONTACT_INFO_V1_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_gossip_contact_info_v1_global {
-  fd_pubkey_t id;
-  fd_gossip_socket_addr_global_t gossip;
-  fd_gossip_socket_addr_global_t tvu;
-  fd_gossip_socket_addr_global_t tvu_fwd;
-  fd_gossip_socket_addr_global_t repair;
-  fd_gossip_socket_addr_global_t tpu;
-  fd_gossip_socket_addr_global_t tpu_fwd;
-  fd_gossip_socket_addr_global_t tpu_vote;
-  fd_gossip_socket_addr_global_t rpc;
-  fd_gossip_socket_addr_global_t rpc_pubsub;
-  fd_gossip_socket_addr_global_t serve_repair;
-  ulong wallclock;
-  ushort shred_version;
-};
-typedef struct fd_gossip_contact_info_v1_global fd_gossip_contact_info_v1_global_t;
-#define FD_GOSSIP_CONTACT_INFO_V1_GLOBAL_FOOTPRINT sizeof(fd_gossip_contact_info_v1_global_t)
-#define FD_GOSSIP_CONTACT_INFO_V1_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_vote {
   uchar index;
@@ -4282,16 +3247,6 @@ struct __attribute__((aligned(8UL))) fd_gossip_vote {
 typedef struct fd_gossip_vote fd_gossip_vote_t;
 #define FD_GOSSIP_VOTE_FOOTPRINT sizeof(fd_gossip_vote_t)
 #define FD_GOSSIP_VOTE_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_gossip_vote_global {
-  uchar index;
-  fd_pubkey_t from;
-  fd_flamenco_txn_global_t txn;
-  ulong wallclock;
-};
-typedef struct fd_gossip_vote_global fd_gossip_vote_global_t;
-#define FD_GOSSIP_VOTE_GLOBAL_FOOTPRINT sizeof(fd_gossip_vote_global_t)
-#define FD_GOSSIP_VOTE_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_lowest_slot {
@@ -4308,20 +3263,6 @@ typedef struct fd_gossip_lowest_slot fd_gossip_lowest_slot_t;
 #define FD_GOSSIP_LOWEST_SLOT_FOOTPRINT sizeof(fd_gossip_lowest_slot_t)
 #define FD_GOSSIP_LOWEST_SLOT_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_gossip_lowest_slot_global {
-  uchar u8;
-  fd_pubkey_t from;
-  ulong root;
-  ulong lowest;
-  ulong slots_len;
-  ulong slots_gaddr;
-  ulong i_dont_know;
-  ulong wallclock;
-};
-typedef struct fd_gossip_lowest_slot_global fd_gossip_lowest_slot_global_t;
-#define FD_GOSSIP_LOWEST_SLOT_GLOBAL_FOOTPRINT sizeof(fd_gossip_lowest_slot_global_t)
-#define FD_GOSSIP_LOWEST_SLOT_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_slot_hashes {
   fd_pubkey_t from;
@@ -4332,16 +3273,6 @@ struct __attribute__((aligned(8UL))) fd_gossip_slot_hashes {
 typedef struct fd_gossip_slot_hashes fd_gossip_slot_hashes_t;
 #define FD_GOSSIP_SLOT_HASHES_FOOTPRINT sizeof(fd_gossip_slot_hashes_t)
 #define FD_GOSSIP_SLOT_HASHES_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_gossip_slot_hashes_global {
-  fd_pubkey_t from;
-  ulong hashes_len;
-  ulong hashes_gaddr;
-  ulong wallclock;
-};
-typedef struct fd_gossip_slot_hashes_global fd_gossip_slot_hashes_global_t;
-#define FD_GOSSIP_SLOT_HASHES_GLOBAL_FOOTPRINT sizeof(fd_gossip_slot_hashes_global_t)
-#define FD_GOSSIP_SLOT_HASHES_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_slots {
@@ -4373,16 +3304,6 @@ typedef struct fd_gossip_flate2_slots fd_gossip_flate2_slots_t;
 #define FD_GOSSIP_FLATE2_SLOTS_FOOTPRINT sizeof(fd_gossip_flate2_slots_t)
 #define FD_GOSSIP_FLATE2_SLOTS_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_gossip_flate2_slots_global {
-  ulong first_slot;
-  ulong num;
-  ulong compressed_len;
-  ulong compressed_gaddr;
-};
-typedef struct fd_gossip_flate2_slots_global fd_gossip_flate2_slots_global_t;
-#define FD_GOSSIP_FLATE2_SLOTS_GLOBAL_FOOTPRINT sizeof(fd_gossip_flate2_slots_global_t)
-#define FD_GOSSIP_FLATE2_SLOTS_GLOBAL_ALIGN (8UL)
-
 union fd_gossip_slots_enum_inner {
   fd_gossip_flate2_slots_t flate2;
   fd_gossip_slots_t uncompressed;
@@ -4390,7 +3311,7 @@ union fd_gossip_slots_enum_inner {
 typedef union fd_gossip_slots_enum_inner fd_gossip_slots_enum_inner_t;
 
 union fd_gossip_slots_enum_inner_global {
-  fd_gossip_flate2_slots_global_t flate2;
+  fd_gossip_flate2_slots_t flate2;
   fd_gossip_slots_global_t uncompressed;
 };
 typedef union fd_gossip_slots_enum_inner_global fd_gossip_slots_enum_inner_global_t;
@@ -4502,18 +3423,6 @@ typedef struct fd_gossip_version_v3 fd_gossip_version_v3_t;
 #define FD_GOSSIP_VERSION_V3_FOOTPRINT sizeof(fd_gossip_version_v3_t)
 #define FD_GOSSIP_VERSION_V3_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_gossip_version_v3_global {
-  ushort major;
-  ushort minor;
-  ushort patch;
-  uint commit;
-  uint feature_set;
-  ushort client;
-};
-typedef struct fd_gossip_version_v3_global fd_gossip_version_v3_global_t;
-#define FD_GOSSIP_VERSION_V3_GLOBAL_FOOTPRINT sizeof(fd_gossip_version_v3_global_t)
-#define FD_GOSSIP_VERSION_V3_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (56 bytes) */
 struct __attribute__((aligned(8UL))) fd_gossip_node_instance {
   fd_pubkey_t from;
@@ -4524,16 +3433,6 @@ struct __attribute__((aligned(8UL))) fd_gossip_node_instance {
 typedef struct fd_gossip_node_instance fd_gossip_node_instance_t;
 #define FD_GOSSIP_NODE_INSTANCE_FOOTPRINT sizeof(fd_gossip_node_instance_t)
 #define FD_GOSSIP_NODE_INSTANCE_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_gossip_node_instance_global {
-  fd_pubkey_t from;
-  ulong wallclock;
-  long timestamp;
-  ulong token;
-};
-typedef struct fd_gossip_node_instance_global fd_gossip_node_instance_global_t;
-#define FD_GOSSIP_NODE_INSTANCE_GLOBAL_FOOTPRINT sizeof(fd_gossip_node_instance_global_t)
-#define FD_GOSSIP_NODE_INSTANCE_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_duplicate_shred {
@@ -4552,22 +3451,6 @@ typedef struct fd_gossip_duplicate_shred fd_gossip_duplicate_shred_t;
 #define FD_GOSSIP_DUPLICATE_SHRED_FOOTPRINT sizeof(fd_gossip_duplicate_shred_t)
 #define FD_GOSSIP_DUPLICATE_SHRED_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_gossip_duplicate_shred_global {
-  ushort duplicate_shred_index;
-  fd_pubkey_t from;
-  ulong wallclock;
-  ulong slot;
-  uint _unused;
-  uchar _unused_shred_type;
-  uchar num_chunks;
-  uchar chunk_index;
-  ulong chunk_len;
-  ulong chunk_gaddr;
-};
-typedef struct fd_gossip_duplicate_shred_global fd_gossip_duplicate_shred_global_t;
-#define FD_GOSSIP_DUPLICATE_SHRED_GLOBAL_FOOTPRINT sizeof(fd_gossip_duplicate_shred_global_t)
-#define FD_GOSSIP_DUPLICATE_SHRED_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_incremental_snapshot_hashes {
   fd_pubkey_t from;
@@ -4580,17 +3463,6 @@ typedef struct fd_gossip_incremental_snapshot_hashes fd_gossip_incremental_snaps
 #define FD_GOSSIP_INCREMENTAL_SNAPSHOT_HASHES_FOOTPRINT sizeof(fd_gossip_incremental_snapshot_hashes_t)
 #define FD_GOSSIP_INCREMENTAL_SNAPSHOT_HASHES_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_gossip_incremental_snapshot_hashes_global {
-  fd_pubkey_t from;
-  fd_slot_hash_t base_hash;
-  ulong hashes_len;
-  ulong hashes_gaddr;
-  ulong wallclock;
-};
-typedef struct fd_gossip_incremental_snapshot_hashes_global fd_gossip_incremental_snapshot_hashes_global_t;
-#define FD_GOSSIP_INCREMENTAL_SNAPSHOT_HASHES_GLOBAL_FOOTPRINT sizeof(fd_gossip_incremental_snapshot_hashes_global_t)
-#define FD_GOSSIP_INCREMENTAL_SNAPSHOT_HASHES_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_socket_entry {
   uchar key;
@@ -4600,15 +3472,6 @@ struct __attribute__((aligned(8UL))) fd_gossip_socket_entry {
 typedef struct fd_gossip_socket_entry fd_gossip_socket_entry_t;
 #define FD_GOSSIP_SOCKET_ENTRY_FOOTPRINT sizeof(fd_gossip_socket_entry_t)
 #define FD_GOSSIP_SOCKET_ENTRY_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_gossip_socket_entry_global {
-  uchar key;
-  uchar index;
-  ushort offset;
-};
-typedef struct fd_gossip_socket_entry_global fd_gossip_socket_entry_global_t;
-#define FD_GOSSIP_SOCKET_ENTRY_GLOBAL_FOOTPRINT sizeof(fd_gossip_socket_entry_global_t)
-#define FD_GOSSIP_SOCKET_ENTRY_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_gossip_contact_info_v2 {
@@ -4628,23 +3491,6 @@ typedef struct fd_gossip_contact_info_v2 fd_gossip_contact_info_v2_t;
 #define FD_GOSSIP_CONTACT_INFO_V2_FOOTPRINT sizeof(fd_gossip_contact_info_v2_t)
 #define FD_GOSSIP_CONTACT_INFO_V2_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_gossip_contact_info_v2_global {
-  fd_pubkey_t from;
-  ulong wallclock;
-  ulong outset;
-  ushort shred_version;
-  fd_gossip_version_v3_global_t version;
-  ushort addrs_len;
-  ulong addrs_gaddr;
-  ushort sockets_len;
-  ulong sockets_gaddr;
-  ushort extensions_len;
-  ulong extensions_gaddr;
-};
-typedef struct fd_gossip_contact_info_v2_global fd_gossip_contact_info_v2_global_t;
-#define FD_GOSSIP_CONTACT_INFO_V2_GLOBAL_FOOTPRINT sizeof(fd_gossip_contact_info_v2_global_t)
-#define FD_GOSSIP_CONTACT_INFO_V2_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_restart_run_length_encoding_inner {
   ushort bits;
@@ -4652,13 +3498,6 @@ struct __attribute__((aligned(8UL))) fd_restart_run_length_encoding_inner {
 typedef struct fd_restart_run_length_encoding_inner fd_restart_run_length_encoding_inner_t;
 #define FD_RESTART_RUN_LENGTH_ENCODING_INNER_FOOTPRINT sizeof(fd_restart_run_length_encoding_inner_t)
 #define FD_RESTART_RUN_LENGTH_ENCODING_INNER_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_restart_run_length_encoding_inner_global {
-  ushort bits;
-};
-typedef struct fd_restart_run_length_encoding_inner_global fd_restart_run_length_encoding_inner_global_t;
-#define FD_RESTART_RUN_LENGTH_ENCODING_INNER_GLOBAL_FOOTPRINT sizeof(fd_restart_run_length_encoding_inner_global_t)
-#define FD_RESTART_RUN_LENGTH_ENCODING_INNER_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_restart_run_length_encoding {
@@ -4669,14 +3508,6 @@ typedef struct fd_restart_run_length_encoding fd_restart_run_length_encoding_t;
 #define FD_RESTART_RUN_LENGTH_ENCODING_FOOTPRINT sizeof(fd_restart_run_length_encoding_t)
 #define FD_RESTART_RUN_LENGTH_ENCODING_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_restart_run_length_encoding_global {
-  ulong offsets_len;
-  ulong offsets_gaddr;
-};
-typedef struct fd_restart_run_length_encoding_global fd_restart_run_length_encoding_global_t;
-#define FD_RESTART_RUN_LENGTH_ENCODING_GLOBAL_FOOTPRINT sizeof(fd_restart_run_length_encoding_global_t)
-#define FD_RESTART_RUN_LENGTH_ENCODING_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_restart_raw_offsets_bitvec_u8_inner {
   ulong bits_len;
@@ -4685,14 +3516,6 @@ struct __attribute__((aligned(8UL))) fd_restart_raw_offsets_bitvec_u8_inner {
 typedef struct fd_restart_raw_offsets_bitvec_u8_inner fd_restart_raw_offsets_bitvec_u8_inner_t;
 #define FD_RESTART_RAW_OFFSETS_BITVEC_U8_INNER_FOOTPRINT sizeof(fd_restart_raw_offsets_bitvec_u8_inner_t)
 #define FD_RESTART_RAW_OFFSETS_BITVEC_U8_INNER_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_restart_raw_offsets_bitvec_u8_inner_global {
-  ulong bits_len;
-  ulong bits_gaddr;
-};
-typedef struct fd_restart_raw_offsets_bitvec_u8_inner_global fd_restart_raw_offsets_bitvec_u8_inner_global_t;
-#define FD_RESTART_RAW_OFFSETS_BITVEC_U8_INNER_GLOBAL_FOOTPRINT sizeof(fd_restart_raw_offsets_bitvec_u8_inner_global_t)
-#define FD_RESTART_RAW_OFFSETS_BITVEC_U8_INNER_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_restart_raw_offsets_bitvec {
@@ -4735,7 +3558,7 @@ union fd_restart_slots_offsets_inner {
 typedef union fd_restart_slots_offsets_inner fd_restart_slots_offsets_inner_t;
 
 union fd_restart_slots_offsets_inner_global {
-  fd_restart_run_length_encoding_global_t run_length_encoding;
+  fd_restart_run_length_encoding_t run_length_encoding;
   fd_restart_raw_offsets_global_t raw_offsets;
 };
 typedef union fd_restart_slots_offsets_inner_global fd_restart_slots_offsets_inner_global_t;
@@ -4793,18 +3616,6 @@ typedef struct fd_gossip_restart_heaviest_fork fd_gossip_restart_heaviest_fork_t
 #define FD_GOSSIP_RESTART_HEAVIEST_FORK_FOOTPRINT sizeof(fd_gossip_restart_heaviest_fork_t)
 #define FD_GOSSIP_RESTART_HEAVIEST_FORK_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_gossip_restart_heaviest_fork_global {
-  fd_pubkey_t from;
-  ulong wallclock;
-  ulong last_slot;
-  fd_hash_t last_slot_hash;
-  ulong observed_stake;
-  ushort shred_version;
-};
-typedef struct fd_gossip_restart_heaviest_fork_global fd_gossip_restart_heaviest_fork_global_t;
-#define FD_GOSSIP_RESTART_HEAVIEST_FORK_GLOBAL_FOOTPRINT sizeof(fd_gossip_restart_heaviest_fork_global_t)
-#define FD_GOSSIP_RESTART_HEAVIEST_FORK_GLOBAL_ALIGN (8UL)
-
 union fd_crds_data_inner {
   fd_gossip_contact_info_v1_t contact_info_v1;
   fd_gossip_vote_t vote;
@@ -4824,18 +3635,18 @@ union fd_crds_data_inner {
 typedef union fd_crds_data_inner fd_crds_data_inner_t;
 
 union fd_crds_data_inner_global {
-  fd_gossip_contact_info_v1_global_t contact_info_v1;
-  fd_gossip_vote_global_t vote;
-  fd_gossip_lowest_slot_global_t lowest_slot;
-  fd_gossip_slot_hashes_global_t snapshot_hashes;
-  fd_gossip_slot_hashes_global_t accounts_hashes;
+  fd_gossip_contact_info_v1_t contact_info_v1;
+  fd_gossip_vote_t vote;
+  fd_gossip_lowest_slot_t lowest_slot;
+  fd_gossip_slot_hashes_t snapshot_hashes;
+  fd_gossip_slot_hashes_t accounts_hashes;
   fd_gossip_epoch_slots_global_t epoch_slots;
   fd_gossip_version_v1_global_t version_v1;
   fd_gossip_version_v2_global_t version_v2;
   fd_gossip_node_instance_t node_instance;
-  fd_gossip_duplicate_shred_global_t duplicate_shred;
-  fd_gossip_incremental_snapshot_hashes_global_t incremental_snapshot_hashes;
-  fd_gossip_contact_info_v2_global_t contact_info_v2;
+  fd_gossip_duplicate_shred_t duplicate_shred;
+  fd_gossip_incremental_snapshot_hashes_t incremental_snapshot_hashes;
+  fd_gossip_contact_info_v2_t contact_info_v2;
   fd_gossip_restart_last_voted_fork_slots_global_t restart_last_voted_fork_slots;
   fd_gossip_restart_heaviest_fork_t restart_heaviest_fork;
 };
@@ -4977,14 +3788,6 @@ typedef struct fd_gossip_prune_msg fd_gossip_prune_msg_t;
 #define FD_GOSSIP_PRUNE_MSG_FOOTPRINT sizeof(fd_gossip_prune_msg_t)
 #define FD_GOSSIP_PRUNE_MSG_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_gossip_prune_msg_global {
-  fd_pubkey_t pubkey;
-  fd_gossip_prune_data_global_t data;
-};
-typedef struct fd_gossip_prune_msg_global fd_gossip_prune_msg_global_t;
-#define FD_GOSSIP_PRUNE_MSG_GLOBAL_FOOTPRINT sizeof(fd_gossip_prune_msg_global_t)
-#define FD_GOSSIP_PRUNE_MSG_GLOBAL_ALIGN (8UL)
-
 union fd_gossip_msg_inner {
   fd_gossip_pull_req_t pull_req;
   fd_gossip_pull_resp_t pull_resp;
@@ -4999,7 +3802,7 @@ union fd_gossip_msg_inner_global {
   fd_gossip_pull_req_global_t pull_req;
   fd_gossip_pull_resp_global_t pull_resp;
   fd_gossip_push_msg_global_t push_msg;
-  fd_gossip_prune_msg_global_t prune_msg;
+  fd_gossip_prune_msg_t prune_msg;
   fd_gossip_ping_t ping;
   fd_gossip_ping_t pong;
 };
@@ -5030,14 +3833,6 @@ typedef struct fd_addrlut_create fd_addrlut_create_t;
 #define FD_ADDRLUT_CREATE_FOOTPRINT sizeof(fd_addrlut_create_t)
 #define FD_ADDRLUT_CREATE_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_addrlut_create_global {
-  ulong recent_slot;
-  uchar bump_seed;
-};
-typedef struct fd_addrlut_create_global fd_addrlut_create_global_t;
-#define FD_ADDRLUT_CREATE_GLOBAL_FOOTPRINT sizeof(fd_addrlut_create_global_t)
-#define FD_ADDRLUT_CREATE_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_addrlut_extend {
   ulong new_addrs_len;
@@ -5047,25 +3842,11 @@ typedef struct fd_addrlut_extend fd_addrlut_extend_t;
 #define FD_ADDRLUT_EXTEND_FOOTPRINT sizeof(fd_addrlut_extend_t)
 #define FD_ADDRLUT_EXTEND_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_addrlut_extend_global {
-  ulong new_addrs_len;
-  ulong new_addrs_gaddr;
-};
-typedef struct fd_addrlut_extend_global fd_addrlut_extend_global_t;
-#define FD_ADDRLUT_EXTEND_GLOBAL_FOOTPRINT sizeof(fd_addrlut_extend_global_t)
-#define FD_ADDRLUT_EXTEND_GLOBAL_ALIGN (8UL)
-
 union fd_addrlut_instruction_inner {
   fd_addrlut_create_t create_lut;
   fd_addrlut_extend_t extend_lut;
 };
 typedef union fd_addrlut_instruction_inner fd_addrlut_instruction_inner_t;
-
-union fd_addrlut_instruction_inner_global {
-  fd_addrlut_create_t create_lut;
-  fd_addrlut_extend_global_t extend_lut;
-};
-typedef union fd_addrlut_instruction_inner_global fd_addrlut_instruction_inner_global_t;
 
 /* https://github.com/solana-labs/solana/blob/fb80288f885a62bcd923f4c9579fd0edeafaff9b/sdk/program/src/address_lookup_table/instruction.rs#L13 */
 struct fd_addrlut_instruction {
@@ -5075,11 +3856,6 @@ struct fd_addrlut_instruction {
 typedef struct fd_addrlut_instruction fd_addrlut_instruction_t;
 #define FD_ADDRLUT_INSTRUCTION_FOOTPRINT sizeof(fd_addrlut_instruction_t)
 #define FD_ADDRLUT_INSTRUCTION_ALIGN (8UL)
-struct fd_addrlut_instruction_global {
-  uint discriminant;
-  fd_addrlut_instruction_inner_global_t inner;
-};
-typedef struct fd_addrlut_instruction_global fd_addrlut_instruction_global_t;
 #define FD_ADDRLUT_INSTRUCTION_GLOBAL_FOOTPRINT sizeof(fd_addrlut_instruction_global_t)
 #define FD_ADDRLUT_INSTRUCTION_GLOBAL_ALIGN (8UL)
 
@@ -5095,17 +3871,6 @@ typedef struct fd_repair_request_header fd_repair_request_header_t;
 #define FD_REPAIR_REQUEST_HEADER_FOOTPRINT sizeof(fd_repair_request_header_t)
 #define FD_REPAIR_REQUEST_HEADER_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_repair_request_header_global {
-  fd_signature_t signature;
-  fd_pubkey_t sender;
-  fd_pubkey_t recipient;
-  long timestamp;
-  uint nonce;
-};
-typedef struct fd_repair_request_header_global fd_repair_request_header_global_t;
-#define FD_REPAIR_REQUEST_HEADER_GLOBAL_FOOTPRINT sizeof(fd_repair_request_header_global_t)
-#define FD_REPAIR_REQUEST_HEADER_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (156 bytes) */
 struct __attribute__((aligned(8UL))) fd_repair_window_index {
   fd_repair_request_header_t header;
@@ -5115,15 +3880,6 @@ struct __attribute__((aligned(8UL))) fd_repair_window_index {
 typedef struct fd_repair_window_index fd_repair_window_index_t;
 #define FD_REPAIR_WINDOW_INDEX_FOOTPRINT sizeof(fd_repair_window_index_t)
 #define FD_REPAIR_WINDOW_INDEX_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_repair_window_index_global {
-  fd_repair_request_header_t header;
-  ulong slot;
-  ulong shred_index;
-};
-typedef struct fd_repair_window_index_global fd_repair_window_index_global_t;
-#define FD_REPAIR_WINDOW_INDEX_GLOBAL_FOOTPRINT sizeof(fd_repair_window_index_global_t)
-#define FD_REPAIR_WINDOW_INDEX_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Fixed (156 bytes) */
 struct __attribute__((aligned(8UL))) fd_repair_highest_window_index {
@@ -5135,15 +3891,6 @@ typedef struct fd_repair_highest_window_index fd_repair_highest_window_index_t;
 #define FD_REPAIR_HIGHEST_WINDOW_INDEX_FOOTPRINT sizeof(fd_repair_highest_window_index_t)
 #define FD_REPAIR_HIGHEST_WINDOW_INDEX_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_repair_highest_window_index_global {
-  fd_repair_request_header_t header;
-  ulong slot;
-  ulong shred_index;
-};
-typedef struct fd_repair_highest_window_index_global fd_repair_highest_window_index_global_t;
-#define FD_REPAIR_HIGHEST_WINDOW_INDEX_GLOBAL_FOOTPRINT sizeof(fd_repair_highest_window_index_global_t)
-#define FD_REPAIR_HIGHEST_WINDOW_INDEX_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (148 bytes) */
 struct __attribute__((aligned(8UL))) fd_repair_orphan {
   fd_repair_request_header_t header;
@@ -5152,14 +3899,6 @@ struct __attribute__((aligned(8UL))) fd_repair_orphan {
 typedef struct fd_repair_orphan fd_repair_orphan_t;
 #define FD_REPAIR_ORPHAN_FOOTPRINT sizeof(fd_repair_orphan_t)
 #define FD_REPAIR_ORPHAN_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_repair_orphan_global {
-  fd_repair_request_header_t header;
-  ulong slot;
-};
-typedef struct fd_repair_orphan_global fd_repair_orphan_global_t;
-#define FD_REPAIR_ORPHAN_GLOBAL_FOOTPRINT sizeof(fd_repair_orphan_global_t)
-#define FD_REPAIR_ORPHAN_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Fixed (148 bytes) */
 struct __attribute__((aligned(8UL))) fd_repair_ancestor_hashes {
@@ -5170,14 +3909,6 @@ typedef struct fd_repair_ancestor_hashes fd_repair_ancestor_hashes_t;
 #define FD_REPAIR_ANCESTOR_HASHES_FOOTPRINT sizeof(fd_repair_ancestor_hashes_t)
 #define FD_REPAIR_ANCESTOR_HASHES_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_repair_ancestor_hashes_global {
-  fd_repair_request_header_t header;
-  ulong slot;
-};
-typedef struct fd_repair_ancestor_hashes_global fd_repair_ancestor_hashes_global_t;
-#define FD_REPAIR_ANCESTOR_HASHES_GLOBAL_FOOTPRINT sizeof(fd_repair_ancestor_hashes_global_t)
-#define FD_REPAIR_ANCESTOR_HASHES_GLOBAL_ALIGN (8UL)
-
 union fd_repair_protocol_inner {
   fd_gossip_ping_t pong;
   fd_repair_window_index_t window_index;
@@ -5187,15 +3918,6 @@ union fd_repair_protocol_inner {
 };
 typedef union fd_repair_protocol_inner fd_repair_protocol_inner_t;
 
-union fd_repair_protocol_inner_global {
-  fd_gossip_ping_t pong;
-  fd_repair_window_index_t window_index;
-  fd_repair_highest_window_index_t highest_window_index;
-  fd_repair_orphan_t orphan;
-  fd_repair_ancestor_hashes_t ancestor_hashes;
-};
-typedef union fd_repair_protocol_inner_global fd_repair_protocol_inner_global_t;
-
 struct fd_repair_protocol {
   uint discriminant;
   fd_repair_protocol_inner_t inner;
@@ -5203,11 +3925,6 @@ struct fd_repair_protocol {
 typedef struct fd_repair_protocol fd_repair_protocol_t;
 #define FD_REPAIR_PROTOCOL_FOOTPRINT sizeof(fd_repair_protocol_t)
 #define FD_REPAIR_PROTOCOL_ALIGN (8UL)
-struct fd_repair_protocol_global {
-  uint discriminant;
-  fd_repair_protocol_inner_global_t inner;
-};
-typedef struct fd_repair_protocol_global fd_repair_protocol_global_t;
 #define FD_REPAIR_PROTOCOL_GLOBAL_FOOTPRINT sizeof(fd_repair_protocol_global_t)
 #define FD_REPAIR_PROTOCOL_GLOBAL_ALIGN (8UL)
 
@@ -5216,11 +3933,6 @@ union fd_repair_response_inner {
 };
 typedef union fd_repair_response_inner fd_repair_response_inner_t;
 
-union fd_repair_response_inner_global {
-  fd_gossip_ping_t ping;
-};
-typedef union fd_repair_response_inner_global fd_repair_response_inner_global_t;
-
 struct fd_repair_response {
   uint discriminant;
   fd_repair_response_inner_t inner;
@@ -5228,11 +3940,6 @@ struct fd_repair_response {
 typedef struct fd_repair_response fd_repair_response_t;
 #define FD_REPAIR_RESPONSE_FOOTPRINT sizeof(fd_repair_response_t)
 #define FD_REPAIR_RESPONSE_ALIGN (8UL)
-struct fd_repair_response_global {
-  uint discriminant;
-  fd_repair_response_inner_global_t inner;
-};
-typedef struct fd_repair_response_global fd_repair_response_global_t;
 #define FD_REPAIR_RESPONSE_GLOBAL_FOOTPRINT sizeof(fd_repair_response_global_t)
 #define FD_REPAIR_RESPONSE_GLOBAL_ALIGN (8UL)
 
@@ -5437,14 +4144,6 @@ typedef struct fd_pubkey_rewardinfo_pair fd_pubkey_rewardinfo_pair_t;
 #define FD_PUBKEY_REWARDINFO_PAIR_FOOTPRINT sizeof(fd_pubkey_rewardinfo_pair_t)
 #define FD_PUBKEY_REWARDINFO_PAIR_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_pubkey_rewardinfo_pair_global {
-  fd_pubkey_t pubkey;
-  fd_reward_info_t reward_info;
-};
-typedef struct fd_pubkey_rewardinfo_pair_global fd_pubkey_rewardinfo_pair_global_t;
-#define FD_PUBKEY_REWARDINFO_PAIR_GLOBAL_FOOTPRINT sizeof(fd_pubkey_rewardinfo_pair_global_t)
-#define FD_PUBKEY_REWARDINFO_PAIR_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_optional_account {
   fd_solana_account_t * account;
@@ -5471,15 +4170,6 @@ typedef struct fd_calculated_stake_points fd_calculated_stake_points_t;
 #define FD_CALCULATED_STAKE_POINTS_FOOTPRINT sizeof(fd_calculated_stake_points_t)
 #define FD_CALCULATED_STAKE_POINTS_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_calculated_stake_points_global {
-  uint128 points;
-  ulong new_credits_observed;
-  uchar force_credits_update_with_skipped_reward;
-};
-typedef struct fd_calculated_stake_points_global fd_calculated_stake_points_global_t;
-#define FD_CALCULATED_STAKE_POINTS_GLOBAL_FOOTPRINT sizeof(fd_calculated_stake_points_global_t)
-#define FD_CALCULATED_STAKE_POINTS_GLOBAL_ALIGN (8UL)
-
 /* https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/programs/stake/src/rewards.rs#L24 */
 /* Encoded Size: Fixed (24 bytes) */
 struct __attribute__((aligned(8UL))) fd_calculated_stake_rewards {
@@ -5490,15 +4180,6 @@ struct __attribute__((aligned(8UL))) fd_calculated_stake_rewards {
 typedef struct fd_calculated_stake_rewards fd_calculated_stake_rewards_t;
 #define FD_CALCULATED_STAKE_REWARDS_FOOTPRINT sizeof(fd_calculated_stake_rewards_t)
 #define FD_CALCULATED_STAKE_REWARDS_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_calculated_stake_rewards_global {
-  ulong staker_rewards;
-  ulong voter_rewards;
-  ulong new_credits_observed;
-};
-typedef struct fd_calculated_stake_rewards_global fd_calculated_stake_rewards_global_t;
-#define FD_CALCULATED_STAKE_REWARDS_GLOBAL_FOOTPRINT sizeof(fd_calculated_stake_rewards_global_t)
-#define FD_CALCULATED_STAKE_REWARDS_GLOBAL_ALIGN (8UL)
 
 /* https://github.com/anza-xyz/agave/blob/v2.0.3/ledger/src/blockstore_meta.rs#L150-L156 */
 /* Encoded Size: Dynamic */
@@ -5512,16 +4193,6 @@ typedef struct fd_duplicate_slot_proof fd_duplicate_slot_proof_t;
 #define FD_DUPLICATE_SLOT_PROOF_FOOTPRINT sizeof(fd_duplicate_slot_proof_t)
 #define FD_DUPLICATE_SLOT_PROOF_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_duplicate_slot_proof_global {
-  ulong shred1_len;
-  ulong shred1_gaddr;
-  ulong shred2_len;
-  ulong shred2_gaddr;
-};
-typedef struct fd_duplicate_slot_proof_global fd_duplicate_slot_proof_global_t;
-#define FD_DUPLICATE_SLOT_PROOF_GLOBAL_FOOTPRINT sizeof(fd_duplicate_slot_proof_global_t)
-#define FD_DUPLICATE_SLOT_PROOF_GLOBAL_ALIGN (8UL)
-
 /* Encoded Size: Fixed (104 bytes) */
 struct __attribute__((aligned(8UL))) fd_epoch_info_pair {
   fd_pubkey_t account;
@@ -5530,14 +4201,6 @@ struct __attribute__((aligned(8UL))) fd_epoch_info_pair {
 typedef struct fd_epoch_info_pair fd_epoch_info_pair_t;
 #define FD_EPOCH_INFO_PAIR_FOOTPRINT sizeof(fd_epoch_info_pair_t)
 #define FD_EPOCH_INFO_PAIR_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_epoch_info_pair_global {
-  fd_pubkey_t account;
-  fd_stake_t stake;
-};
-typedef struct fd_epoch_info_pair_global fd_epoch_info_pair_global_t;
-#define FD_EPOCH_INFO_PAIR_GLOBAL_FOOTPRINT sizeof(fd_epoch_info_pair_global_t)
-#define FD_EPOCH_INFO_PAIR_GLOBAL_ALIGN (8UL)
 
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_vote_info_pair {
@@ -5576,6 +4239,26 @@ fd_vote_info_pair_t_map_join_new( void * * alloc_mem, ulong len ) {
   *alloc_mem = (uchar *)*alloc_mem + fd_vote_info_pair_t_map_footprint( len );
   return fd_vote_info_pair_t_map_join( fd_vote_info_pair_t_map_new( map_mem, len ) );
 }
+typedef struct fd_vote_info_pair_global_t_mapnode fd_vote_info_pair_global_t_mapnode_t;
+#define REDBLK_T fd_vote_info_pair_global_t_mapnode_t
+#define REDBLK_NAME fd_vote_info_pair_global_t_map
+#define REDBLK_IMPL_STYLE 1
+#include "../../util/tmpl/fd_redblack.c"
+struct fd_vote_info_pair_global_t_mapnode {
+    fd_vote_info_pair_global_t elem;
+    ulong redblack_parent;
+    ulong redblack_left;
+    ulong redblack_right;
+    int redblack_color;
+};
+static inline fd_vote_info_pair_global_t_mapnode_t *
+fd_vote_info_pair_global_t_map_join_new( void * * alloc_mem, ulong len ) {
+  if( FD_UNLIKELY( 0 == len ) ) len = 1; // prevent underflow
+  *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, fd_vote_info_pair_global_t_map_align() );
+  void * map_mem = *alloc_mem;
+  *alloc_mem = (uchar *)*alloc_mem + fd_vote_info_pair_global_t_map_footprint( len );
+  return fd_vote_info_pair_global_t_map_join( fd_vote_info_pair_global_t_map_new( map_mem, len ) );
+}
 /* Encoded Size: Dynamic */
 struct __attribute__((aligned(8UL))) fd_epoch_info {
   ulong stake_infos_len;
@@ -5613,27 +4296,10 @@ typedef struct fd_usage_cost_details fd_usage_cost_details_t;
 #define FD_USAGE_COST_DETAILS_FOOTPRINT sizeof(fd_usage_cost_details_t)
 #define FD_USAGE_COST_DETAILS_ALIGN (8UL)
 
-struct __attribute__((aligned(8UL))) fd_usage_cost_details_global {
-  ulong signature_cost;
-  ulong write_lock_cost;
-  ulong data_bytes_cost;
-  ulong programs_execution_cost;
-  ulong loaded_accounts_data_size_cost;
-  ulong allocated_accounts_data_size;
-};
-typedef struct fd_usage_cost_details_global fd_usage_cost_details_global_t;
-#define FD_USAGE_COST_DETAILS_GLOBAL_FOOTPRINT sizeof(fd_usage_cost_details_global_t)
-#define FD_USAGE_COST_DETAILS_GLOBAL_ALIGN (8UL)
-
 union fd_transaction_cost_inner {
   fd_usage_cost_details_t transaction;
 };
 typedef union fd_transaction_cost_inner fd_transaction_cost_inner_t;
-
-union fd_transaction_cost_inner_global {
-  fd_usage_cost_details_t transaction;
-};
-typedef union fd_transaction_cost_inner_global fd_transaction_cost_inner_global_t;
 
 /* https://github.com/anza-xyz/agave/blob/v2.2.0/cost-model/src/transaction_cost.rs#L20-L23 */
 struct fd_transaction_cost {
@@ -5643,11 +4309,6 @@ struct fd_transaction_cost {
 typedef struct fd_transaction_cost fd_transaction_cost_t;
 #define FD_TRANSACTION_COST_FOOTPRINT sizeof(fd_transaction_cost_t)
 #define FD_TRANSACTION_COST_ALIGN (8UL)
-struct fd_transaction_cost_global {
-  uint discriminant;
-  fd_transaction_cost_inner_global_t inner;
-};
-typedef struct fd_transaction_cost_global fd_transaction_cost_global_t;
 #define FD_TRANSACTION_COST_GLOBAL_FOOTPRINT sizeof(fd_transaction_cost_global_t)
 #define FD_TRANSACTION_COST_GLOBAL_ALIGN (8UL)
 
@@ -5659,14 +4320,6 @@ struct __attribute__((aligned(8UL))) fd_account_costs_pair {
 typedef struct fd_account_costs_pair fd_account_costs_pair_t;
 #define FD_ACCOUNT_COSTS_PAIR_FOOTPRINT sizeof(fd_account_costs_pair_t)
 #define FD_ACCOUNT_COSTS_PAIR_ALIGN (8UL)
-
-struct __attribute__((aligned(8UL))) fd_account_costs_pair_global {
-  fd_pubkey_t key;
-  ulong cost;
-};
-typedef struct fd_account_costs_pair_global fd_account_costs_pair_global_t;
-#define FD_ACCOUNT_COSTS_PAIR_GLOBAL_FOOTPRINT sizeof(fd_account_costs_pair_global_t)
-#define FD_ACCOUNT_COSTS_PAIR_GLOBAL_ALIGN (8UL)
 
 typedef struct fd_account_costs_pair_t_mapnode fd_account_costs_pair_t_mapnode_t;
 #define REDBLK_T fd_account_costs_pair_t_mapnode_t
@@ -5757,9 +4410,6 @@ int fd_hash_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 int fd_hash_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_hash_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_hash_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_hash_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_hash_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_hash_convert_global_to_local( void const * global_self, fd_hash_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_signature_new( fd_signature_t * self );
 int fd_signature_encode( fd_signature_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5772,9 +4422,6 @@ int fd_signature_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_
 int fd_signature_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_signature_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_signature_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_signature_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_signature_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_signature_convert_global_to_local( void const * global_self, fd_signature_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_ip4_addr_new( fd_gossip_ip4_addr_t * self );
 int fd_gossip_ip4_addr_encode( fd_gossip_ip4_addr_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5787,9 +4434,6 @@ int fd_gossip_ip4_addr_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * 
 int fd_gossip_ip4_addr_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_ip4_addr_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_ip4_addr_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_ip4_addr_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_ip4_addr_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_ip4_addr_convert_global_to_local( void const * global_self, fd_gossip_ip4_addr_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_ip6_addr_new( fd_gossip_ip6_addr_t * self );
 int fd_gossip_ip6_addr_encode( fd_gossip_ip6_addr_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5802,9 +4446,6 @@ int fd_gossip_ip6_addr_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * 
 int fd_gossip_ip6_addr_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_ip6_addr_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_ip6_addr_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_ip6_addr_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_ip6_addr_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_ip6_addr_convert_global_to_local( void const * global_self, fd_gossip_ip6_addr_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_feature_new( fd_feature_t * self );
 int fd_feature_encode( fd_feature_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5819,7 +4460,7 @@ void * fd_feature_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_feature_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_feature_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_feature_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_feature_convert_global_to_local( void const * global_self, fd_feature_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_feature_encode_global( fd_feature_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_fee_calculator_new( fd_fee_calculator_t * self );
 int fd_fee_calculator_encode( fd_fee_calculator_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5832,9 +4473,6 @@ int fd_fee_calculator_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * t
 int fd_fee_calculator_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_fee_calculator_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_fee_calculator_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_fee_calculator_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_fee_calculator_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_fee_calculator_convert_global_to_local( void const * global_self, fd_fee_calculator_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_hash_age_new( fd_hash_age_t * self );
 int fd_hash_age_encode( fd_hash_age_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5847,9 +4485,6 @@ int fd_hash_age_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_s
 int fd_hash_age_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_hash_age_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_hash_age_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_hash_age_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_hash_age_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_hash_age_convert_global_to_local( void const * global_self, fd_hash_age_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_hash_hash_age_pair_new( fd_hash_hash_age_pair_t * self );
 int fd_hash_hash_age_pair_encode( fd_hash_hash_age_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5862,9 +4497,6 @@ int fd_hash_hash_age_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong
 int fd_hash_hash_age_pair_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_hash_hash_age_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_hash_hash_age_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_hash_hash_age_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_hash_hash_age_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_hash_hash_age_pair_convert_global_to_local( void const * global_self, fd_hash_hash_age_pair_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_block_hash_vec_new( fd_block_hash_vec_t * self );
 int fd_block_hash_vec_encode( fd_block_hash_vec_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5879,7 +4511,7 @@ void * fd_block_hash_vec_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_block_hash_vec_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_block_hash_vec_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_block_hash_vec_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_block_hash_vec_convert_global_to_local( void const * global_self, fd_block_hash_vec_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_block_hash_vec_encode_global( fd_block_hash_vec_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_block_hash_queue_new( fd_block_hash_queue_t * self );
 int fd_block_hash_queue_encode( fd_block_hash_queue_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5894,7 +4526,7 @@ void * fd_block_hash_queue_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_block_hash_queue_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_block_hash_queue_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_block_hash_queue_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_block_hash_queue_convert_global_to_local( void const * global_self, fd_block_hash_queue_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_block_hash_queue_encode_global( fd_block_hash_queue_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_fee_rate_governor_new( fd_fee_rate_governor_t * self );
 int fd_fee_rate_governor_encode( fd_fee_rate_governor_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5907,9 +4539,6 @@ int fd_fee_rate_governor_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong 
 int fd_fee_rate_governor_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_fee_rate_governor_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_fee_rate_governor_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_fee_rate_governor_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_fee_rate_governor_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_fee_rate_governor_convert_global_to_local( void const * global_self, fd_fee_rate_governor_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_slot_pair_new( fd_slot_pair_t * self );
 int fd_slot_pair_encode( fd_slot_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5922,9 +4551,6 @@ int fd_slot_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_
 int fd_slot_pair_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_slot_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_slot_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_slot_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_slot_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_slot_pair_convert_global_to_local( void const * global_self, fd_slot_pair_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_hard_forks_new( fd_hard_forks_t * self );
 int fd_hard_forks_encode( fd_hard_forks_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5937,9 +4563,6 @@ int fd_hard_forks_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total
 int fd_hard_forks_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_hard_forks_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_hard_forks_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_hard_forks_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_hard_forks_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_hard_forks_convert_global_to_local( void const * global_self, fd_hard_forks_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_inflation_new( fd_inflation_t * self );
 int fd_inflation_encode( fd_inflation_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5952,9 +4575,6 @@ int fd_inflation_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_
 int fd_inflation_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_inflation_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_inflation_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_inflation_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_inflation_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_inflation_convert_global_to_local( void const * global_self, fd_inflation_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_rent_new( fd_rent_t * self );
 int fd_rent_encode( fd_rent_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5967,9 +4587,6 @@ int fd_rent_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 int fd_rent_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_rent_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_rent_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_rent_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_rent_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_rent_convert_global_to_local( void const * global_self, fd_rent_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_epoch_schedule_new( fd_epoch_schedule_t * self );
 int fd_epoch_schedule_encode( fd_epoch_schedule_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5982,9 +4599,6 @@ int fd_epoch_schedule_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * t
 int fd_epoch_schedule_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_epoch_schedule_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_epoch_schedule_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_epoch_schedule_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_epoch_schedule_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_schedule_convert_global_to_local( void const * global_self, fd_epoch_schedule_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_rent_collector_new( fd_rent_collector_t * self );
 int fd_rent_collector_encode( fd_rent_collector_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5997,9 +4611,6 @@ int fd_rent_collector_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * t
 int fd_rent_collector_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_rent_collector_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_rent_collector_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_rent_collector_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_rent_collector_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_rent_collector_convert_global_to_local( void const * global_self, fd_rent_collector_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_stake_history_entry_new( fd_stake_history_entry_t * self );
 int fd_stake_history_entry_encode( fd_stake_history_entry_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6012,9 +4623,6 @@ int fd_stake_history_entry_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulon
 int fd_stake_history_entry_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_history_entry_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_history_entry_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_history_entry_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_stake_history_entry_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_history_entry_convert_global_to_local( void const * global_self, fd_stake_history_entry_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_stake_history_new( fd_stake_history_t * self );
 int fd_stake_history_encode( fd_stake_history_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6027,9 +4635,6 @@ int fd_stake_history_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * to
 int fd_stake_history_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_history_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_history_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_history_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_stake_history_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_history_convert_global_to_local( void const * global_self, fd_stake_history_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_solana_account_new( fd_solana_account_t * self );
 int fd_solana_account_encode( fd_solana_account_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6042,9 +4647,6 @@ int fd_solana_account_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * t
 int fd_solana_account_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_solana_account_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_solana_account_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_solana_account_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_solana_account_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_solana_account_convert_global_to_local( void const * global_self, fd_solana_account_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_vote_accounts_pair_new( fd_vote_accounts_pair_t * self );
 int fd_vote_accounts_pair_encode( fd_vote_accounts_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6057,9 +4659,6 @@ int fd_vote_accounts_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong
 int fd_vote_accounts_pair_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_accounts_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_accounts_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_accounts_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_vote_accounts_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_accounts_pair_convert_global_to_local( void const * global_self, fd_vote_accounts_pair_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_vote_accounts_new( fd_vote_accounts_t * self );
 int fd_vote_accounts_encode( fd_vote_accounts_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6074,7 +4673,7 @@ void * fd_vote_accounts_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_accounts_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_vote_accounts_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_accounts_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_accounts_convert_global_to_local( void const * global_self, fd_vote_accounts_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_vote_accounts_encode_global( fd_vote_accounts_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_account_keys_pair_new( fd_account_keys_pair_t * self );
 int fd_account_keys_pair_encode( fd_account_keys_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6087,9 +4686,6 @@ int fd_account_keys_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong 
 int fd_account_keys_pair_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_account_keys_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_account_keys_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_account_keys_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_account_keys_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_account_keys_pair_convert_global_to_local( void const * global_self, fd_account_keys_pair_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_account_keys_new( fd_account_keys_t * self );
 int fd_account_keys_encode( fd_account_keys_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6104,7 +4700,7 @@ void * fd_account_keys_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_account_keys_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_account_keys_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_account_keys_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_account_keys_convert_global_to_local( void const * global_self, fd_account_keys_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_account_keys_encode_global( fd_account_keys_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_stake_weight_new( fd_stake_weight_t * self );
 int fd_stake_weight_encode( fd_stake_weight_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6117,9 +4713,6 @@ int fd_stake_weight_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * tot
 int fd_stake_weight_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_weight_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_weight_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_weight_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_stake_weight_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_weight_convert_global_to_local( void const * global_self, fd_stake_weight_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_stake_weights_new( fd_stake_weights_t * self );
 int fd_stake_weights_encode( fd_stake_weights_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6134,7 +4727,7 @@ void * fd_stake_weights_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_weights_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_stake_weights_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_weights_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_weights_convert_global_to_local( void const * global_self, fd_stake_weights_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_stake_weights_encode_global( fd_stake_weights_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_delegation_new( fd_delegation_t * self );
 int fd_delegation_encode( fd_delegation_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6147,9 +4740,6 @@ int fd_delegation_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total
 int fd_delegation_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_delegation_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_delegation_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_delegation_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_delegation_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_delegation_convert_global_to_local( void const * global_self, fd_delegation_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_delegation_pair_new( fd_delegation_pair_t * self );
 int fd_delegation_pair_encode( fd_delegation_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6162,9 +4752,6 @@ int fd_delegation_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * 
 int fd_delegation_pair_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_delegation_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_delegation_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_delegation_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_delegation_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_delegation_pair_convert_global_to_local( void const * global_self, fd_delegation_pair_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_stake_new( fd_stake_t * self );
 int fd_stake_encode( fd_stake_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6177,9 +4764,6 @@ int fd_stake_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz )
 int fd_stake_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_stake_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_convert_global_to_local( void const * global_self, fd_stake_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_stake_pair_new( fd_stake_pair_t * self );
 int fd_stake_pair_encode( fd_stake_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6192,9 +4776,6 @@ int fd_stake_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total
 int fd_stake_pair_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_stake_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_pair_convert_global_to_local( void const * global_self, fd_stake_pair_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_stakes_new( fd_stakes_t * self );
 int fd_stakes_encode( fd_stakes_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6209,7 +4790,7 @@ void * fd_stakes_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stakes_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_stakes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stakes_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stakes_convert_global_to_local( void const * global_self, fd_stakes_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_stakes_encode_global( fd_stakes_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_stakes_stake_new( fd_stakes_stake_t * self );
 int fd_stakes_stake_encode( fd_stakes_stake_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6224,7 +4805,7 @@ void * fd_stakes_stake_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stakes_stake_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_stakes_stake_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stakes_stake_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stakes_stake_convert_global_to_local( void const * global_self, fd_stakes_stake_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_stakes_stake_encode_global( fd_stakes_stake_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_bank_incremental_snapshot_persistence_new( fd_bank_incremental_snapshot_persistence_t * self );
 int fd_bank_incremental_snapshot_persistence_encode( fd_bank_incremental_snapshot_persistence_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6237,9 +4818,6 @@ int fd_bank_incremental_snapshot_persistence_decode_footprint( fd_bincode_decode
 int fd_bank_incremental_snapshot_persistence_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bank_incremental_snapshot_persistence_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_bank_incremental_snapshot_persistence_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bank_incremental_snapshot_persistence_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_bank_incremental_snapshot_persistence_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bank_incremental_snapshot_persistence_convert_global_to_local( void const * global_self, fd_bank_incremental_snapshot_persistence_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_node_vote_accounts_new( fd_node_vote_accounts_t * self );
 int fd_node_vote_accounts_encode( fd_node_vote_accounts_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6252,9 +4830,6 @@ int fd_node_vote_accounts_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong
 int fd_node_vote_accounts_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_node_vote_accounts_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_node_vote_accounts_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_node_vote_accounts_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_node_vote_accounts_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_node_vote_accounts_convert_global_to_local( void const * global_self, fd_node_vote_accounts_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_pubkey_node_vote_accounts_pair_new( fd_pubkey_node_vote_accounts_pair_t * self );
 int fd_pubkey_node_vote_accounts_pair_encode( fd_pubkey_node_vote_accounts_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6267,9 +4842,6 @@ int fd_pubkey_node_vote_accounts_pair_decode_footprint( fd_bincode_decode_ctx_t 
 int fd_pubkey_node_vote_accounts_pair_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_pubkey_node_vote_accounts_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_pubkey_node_vote_accounts_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_pubkey_node_vote_accounts_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_pubkey_node_vote_accounts_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_pubkey_node_vote_accounts_pair_convert_global_to_local( void const * global_self, fd_pubkey_node_vote_accounts_pair_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_pubkey_pubkey_pair_new( fd_pubkey_pubkey_pair_t * self );
 int fd_pubkey_pubkey_pair_encode( fd_pubkey_pubkey_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6282,9 +4854,6 @@ int fd_pubkey_pubkey_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong
 int fd_pubkey_pubkey_pair_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_pubkey_pubkey_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_pubkey_pubkey_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_pubkey_pubkey_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_pubkey_pubkey_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_pubkey_pubkey_pair_convert_global_to_local( void const * global_self, fd_pubkey_pubkey_pair_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_epoch_stakes_new( fd_epoch_stakes_t * self );
 int fd_epoch_stakes_encode( fd_epoch_stakes_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6299,7 +4868,7 @@ void * fd_epoch_stakes_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_epoch_stakes_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_epoch_stakes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_epoch_stakes_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_stakes_convert_global_to_local( void const * global_self, fd_epoch_stakes_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_epoch_stakes_encode_global( fd_epoch_stakes_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_epoch_epoch_stakes_pair_new( fd_epoch_epoch_stakes_pair_t * self );
 int fd_epoch_epoch_stakes_pair_encode( fd_epoch_epoch_stakes_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6314,7 +4883,7 @@ void * fd_epoch_epoch_stakes_pair_decode( void * mem, fd_bincode_decode_ctx_t * 
 void fd_epoch_epoch_stakes_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_epoch_epoch_stakes_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_epoch_epoch_stakes_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_epoch_stakes_pair_convert_global_to_local( void const * global_self, fd_epoch_epoch_stakes_pair_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_epoch_epoch_stakes_pair_encode_global( fd_epoch_epoch_stakes_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_pubkey_u64_pair_new( fd_pubkey_u64_pair_t * self );
 int fd_pubkey_u64_pair_encode( fd_pubkey_u64_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6327,9 +4896,6 @@ int fd_pubkey_u64_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * 
 int fd_pubkey_u64_pair_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_pubkey_u64_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_pubkey_u64_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_pubkey_u64_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_pubkey_u64_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_pubkey_u64_pair_convert_global_to_local( void const * global_self, fd_pubkey_u64_pair_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_unused_accounts_new( fd_unused_accounts_t * self );
 int fd_unused_accounts_encode( fd_unused_accounts_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6342,9 +4908,6 @@ int fd_unused_accounts_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * 
 int fd_unused_accounts_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_unused_accounts_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_unused_accounts_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_unused_accounts_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_unused_accounts_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_unused_accounts_convert_global_to_local( void const * global_self, fd_unused_accounts_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_versioned_bank_new( fd_versioned_bank_t * self );
 int fd_versioned_bank_encode( fd_versioned_bank_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6359,7 +4922,7 @@ void * fd_versioned_bank_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_versioned_bank_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_versioned_bank_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_versioned_bank_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_versioned_bank_convert_global_to_local( void const * global_self, fd_versioned_bank_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_versioned_bank_encode_global( fd_versioned_bank_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_bank_hash_stats_new( fd_bank_hash_stats_t * self );
 int fd_bank_hash_stats_encode( fd_bank_hash_stats_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6372,9 +4935,6 @@ int fd_bank_hash_stats_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * 
 int fd_bank_hash_stats_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bank_hash_stats_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_bank_hash_stats_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bank_hash_stats_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_bank_hash_stats_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bank_hash_stats_convert_global_to_local( void const * global_self, fd_bank_hash_stats_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_bank_hash_info_new( fd_bank_hash_info_t * self );
 int fd_bank_hash_info_encode( fd_bank_hash_info_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6387,9 +4947,6 @@ int fd_bank_hash_info_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * t
 int fd_bank_hash_info_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bank_hash_info_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_bank_hash_info_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bank_hash_info_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_bank_hash_info_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bank_hash_info_convert_global_to_local( void const * global_self, fd_bank_hash_info_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_slot_map_pair_new( fd_slot_map_pair_t * self );
 int fd_slot_map_pair_encode( fd_slot_map_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6402,9 +4959,6 @@ int fd_slot_map_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * to
 int fd_slot_map_pair_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_slot_map_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_slot_map_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_slot_map_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_slot_map_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_slot_map_pair_convert_global_to_local( void const * global_self, fd_slot_map_pair_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_snapshot_acc_vec_new( fd_snapshot_acc_vec_t * self );
 int fd_snapshot_acc_vec_encode( fd_snapshot_acc_vec_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6417,9 +4971,6 @@ int fd_snapshot_acc_vec_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong *
 int fd_snapshot_acc_vec_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_snapshot_acc_vec_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_snapshot_acc_vec_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_snapshot_acc_vec_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_snapshot_acc_vec_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_snapshot_acc_vec_convert_global_to_local( void const * global_self, fd_snapshot_acc_vec_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_snapshot_slot_acc_vecs_new( fd_snapshot_slot_acc_vecs_t * self );
 int fd_snapshot_slot_acc_vecs_encode( fd_snapshot_slot_acc_vecs_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6432,9 +4983,6 @@ int fd_snapshot_slot_acc_vecs_decode_footprint( fd_bincode_decode_ctx_t * ctx, u
 int fd_snapshot_slot_acc_vecs_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_snapshot_slot_acc_vecs_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_snapshot_slot_acc_vecs_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_snapshot_slot_acc_vecs_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_snapshot_slot_acc_vecs_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_snapshot_slot_acc_vecs_convert_global_to_local( void const * global_self, fd_snapshot_slot_acc_vecs_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_reward_type_new_disc( fd_reward_type_t * self, uint discriminant );
 void fd_reward_type_new( fd_reward_type_t * self );
@@ -6448,9 +4996,6 @@ int fd_reward_type_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * tota
 int fd_reward_type_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_reward_type_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_reward_type_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_reward_type_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_reward_type_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_reward_type_convert_global_to_local( void const * global_self, fd_reward_type_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_reward_type_is_fee( fd_reward_type_t const * self );
 FD_FN_PURE uchar fd_reward_type_is_rent( fd_reward_type_t const * self );
@@ -6473,9 +5018,6 @@ int fd_solana_accounts_db_fields_decode_footprint( fd_bincode_decode_ctx_t * ctx
 int fd_solana_accounts_db_fields_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_solana_accounts_db_fields_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_solana_accounts_db_fields_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_solana_accounts_db_fields_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_solana_accounts_db_fields_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_solana_accounts_db_fields_convert_global_to_local( void const * global_self, fd_solana_accounts_db_fields_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_versioned_epoch_stakes_current_new( fd_versioned_epoch_stakes_current_t * self );
 int fd_versioned_epoch_stakes_current_encode( fd_versioned_epoch_stakes_current_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6490,7 +5032,7 @@ void * fd_versioned_epoch_stakes_current_decode( void * mem, fd_bincode_decode_c
 void fd_versioned_epoch_stakes_current_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_versioned_epoch_stakes_current_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_versioned_epoch_stakes_current_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_versioned_epoch_stakes_current_convert_global_to_local( void const * global_self, fd_versioned_epoch_stakes_current_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_versioned_epoch_stakes_current_encode_global( fd_versioned_epoch_stakes_current_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_versioned_epoch_stakes_new_disc( fd_versioned_epoch_stakes_t * self, uint discriminant );
 void fd_versioned_epoch_stakes_new( fd_versioned_epoch_stakes_t * self );
@@ -6506,7 +5048,7 @@ void * fd_versioned_epoch_stakes_decode( void * mem, fd_bincode_decode_ctx_t * c
 void fd_versioned_epoch_stakes_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_versioned_epoch_stakes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_versioned_epoch_stakes_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_versioned_epoch_stakes_convert_global_to_local( void const * global_self, fd_versioned_epoch_stakes_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_versioned_epoch_stakes_encode_global( fd_versioned_epoch_stakes_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_versioned_epoch_stakes_is_Current( fd_versioned_epoch_stakes_t const * self );
 enum {
@@ -6525,7 +5067,7 @@ void * fd_versioned_epoch_stakes_pair_decode( void * mem, fd_bincode_decode_ctx_
 void fd_versioned_epoch_stakes_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_versioned_epoch_stakes_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_versioned_epoch_stakes_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_versioned_epoch_stakes_pair_convert_global_to_local( void const * global_self, fd_versioned_epoch_stakes_pair_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_versioned_epoch_stakes_pair_encode_global( fd_versioned_epoch_stakes_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_reward_info_new( fd_reward_info_t * self );
 int fd_reward_info_encode( fd_reward_info_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6538,9 +5080,6 @@ int fd_reward_info_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * tota
 int fd_reward_info_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_reward_info_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_reward_info_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_reward_info_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_reward_info_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_reward_info_convert_global_to_local( void const * global_self, fd_reward_info_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_slot_lthash_new( fd_slot_lthash_t * self );
 int fd_slot_lthash_encode( fd_slot_lthash_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6553,9 +5092,6 @@ int fd_slot_lthash_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * tota
 int fd_slot_lthash_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_slot_lthash_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_slot_lthash_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_slot_lthash_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_slot_lthash_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_slot_lthash_convert_global_to_local( void const * global_self, fd_slot_lthash_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_solana_manifest_new( fd_solana_manifest_t * self );
 int fd_solana_manifest_encode( fd_solana_manifest_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6570,7 +5106,7 @@ void * fd_solana_manifest_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_solana_manifest_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_solana_manifest_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_solana_manifest_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_solana_manifest_convert_global_to_local( void const * global_self, fd_solana_manifest_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_solana_manifest_encode_global( fd_solana_manifest_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_rust_duration_new( fd_rust_duration_t * self );
 int fd_rust_duration_encode( fd_rust_duration_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6583,9 +5119,6 @@ int fd_rust_duration_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * to
 int fd_rust_duration_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_rust_duration_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_rust_duration_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_rust_duration_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_rust_duration_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_rust_duration_convert_global_to_local( void const * global_self, fd_rust_duration_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_poh_config_new( fd_poh_config_t * self );
 int fd_poh_config_encode( fd_poh_config_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6600,7 +5133,7 @@ void * fd_poh_config_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_poh_config_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_poh_config_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_poh_config_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_poh_config_convert_global_to_local( void const * global_self, fd_poh_config_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_poh_config_encode_global( fd_poh_config_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_string_pubkey_pair_new( fd_string_pubkey_pair_t * self );
 int fd_string_pubkey_pair_encode( fd_string_pubkey_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6615,7 +5148,7 @@ void * fd_string_pubkey_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx )
 void fd_string_pubkey_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_string_pubkey_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_string_pubkey_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_string_pubkey_pair_convert_global_to_local( void const * global_self, fd_string_pubkey_pair_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_string_pubkey_pair_encode_global( fd_string_pubkey_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_pubkey_account_pair_new( fd_pubkey_account_pair_t * self );
 int fd_pubkey_account_pair_encode( fd_pubkey_account_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6628,9 +5161,6 @@ int fd_pubkey_account_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulon
 int fd_pubkey_account_pair_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_pubkey_account_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_pubkey_account_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_pubkey_account_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_pubkey_account_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_pubkey_account_pair_convert_global_to_local( void const * global_self, fd_pubkey_account_pair_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_genesis_solana_new( fd_genesis_solana_t * self );
 int fd_genesis_solana_encode( fd_genesis_solana_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6645,7 +5175,7 @@ void * fd_genesis_solana_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_genesis_solana_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_genesis_solana_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_genesis_solana_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_genesis_solana_convert_global_to_local( void const * global_self, fd_genesis_solana_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_genesis_solana_encode_global( fd_genesis_solana_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_sol_sysvar_clock_new( fd_sol_sysvar_clock_t * self );
 int fd_sol_sysvar_clock_encode( fd_sol_sysvar_clock_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6658,9 +5188,6 @@ int fd_sol_sysvar_clock_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong *
 int fd_sol_sysvar_clock_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_sol_sysvar_clock_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_sol_sysvar_clock_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_sol_sysvar_clock_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_sol_sysvar_clock_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_sol_sysvar_clock_convert_global_to_local( void const * global_self, fd_sol_sysvar_clock_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_sol_sysvar_last_restart_slot_new( fd_sol_sysvar_last_restart_slot_t * self );
 int fd_sol_sysvar_last_restart_slot_encode( fd_sol_sysvar_last_restart_slot_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6673,9 +5200,6 @@ int fd_sol_sysvar_last_restart_slot_decode_footprint( fd_bincode_decode_ctx_t * 
 int fd_sol_sysvar_last_restart_slot_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_sol_sysvar_last_restart_slot_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_sol_sysvar_last_restart_slot_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_sol_sysvar_last_restart_slot_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_sol_sysvar_last_restart_slot_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_sol_sysvar_last_restart_slot_convert_global_to_local( void const * global_self, fd_sol_sysvar_last_restart_slot_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_vote_lockout_new( fd_vote_lockout_t * self );
 int fd_vote_lockout_encode( fd_vote_lockout_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6688,9 +5212,6 @@ int fd_vote_lockout_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * tot
 int fd_vote_lockout_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_lockout_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_lockout_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_lockout_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_vote_lockout_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_lockout_convert_global_to_local( void const * global_self, fd_vote_lockout_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_lockout_offset_new( fd_lockout_offset_t * self );
 int fd_lockout_offset_encode( fd_lockout_offset_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6703,9 +5224,6 @@ int fd_lockout_offset_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * t
 int fd_lockout_offset_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_lockout_offset_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_lockout_offset_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_lockout_offset_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_lockout_offset_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_lockout_offset_convert_global_to_local( void const * global_self, fd_lockout_offset_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_vote_authorized_voter_new( fd_vote_authorized_voter_t * self );
 int fd_vote_authorized_voter_encode( fd_vote_authorized_voter_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6718,9 +5236,6 @@ int fd_vote_authorized_voter_decode_footprint( fd_bincode_decode_ctx_t * ctx, ul
 int fd_vote_authorized_voter_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_authorized_voter_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_authorized_voter_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_authorized_voter_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_vote_authorized_voter_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_authorized_voter_convert_global_to_local( void const * global_self, fd_vote_authorized_voter_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_vote_prior_voter_new( fd_vote_prior_voter_t * self );
 int fd_vote_prior_voter_encode( fd_vote_prior_voter_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6733,9 +5248,6 @@ int fd_vote_prior_voter_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong *
 int fd_vote_prior_voter_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_prior_voter_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_prior_voter_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_prior_voter_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_vote_prior_voter_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_prior_voter_convert_global_to_local( void const * global_self, fd_vote_prior_voter_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_vote_prior_voter_0_23_5_new( fd_vote_prior_voter_0_23_5_t * self );
 int fd_vote_prior_voter_0_23_5_encode( fd_vote_prior_voter_0_23_5_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6748,9 +5260,6 @@ int fd_vote_prior_voter_0_23_5_decode_footprint( fd_bincode_decode_ctx_t * ctx, 
 int fd_vote_prior_voter_0_23_5_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_prior_voter_0_23_5_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_prior_voter_0_23_5_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_prior_voter_0_23_5_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_vote_prior_voter_0_23_5_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_prior_voter_0_23_5_convert_global_to_local( void const * global_self, fd_vote_prior_voter_0_23_5_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_vote_epoch_credits_new( fd_vote_epoch_credits_t * self );
 int fd_vote_epoch_credits_encode( fd_vote_epoch_credits_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6763,9 +5272,6 @@ int fd_vote_epoch_credits_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong
 int fd_vote_epoch_credits_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_epoch_credits_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_epoch_credits_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_epoch_credits_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_vote_epoch_credits_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_epoch_credits_convert_global_to_local( void const * global_self, fd_vote_epoch_credits_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_vote_block_timestamp_new( fd_vote_block_timestamp_t * self );
 int fd_vote_block_timestamp_encode( fd_vote_block_timestamp_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6778,9 +5284,6 @@ int fd_vote_block_timestamp_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulo
 int fd_vote_block_timestamp_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_block_timestamp_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_block_timestamp_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_block_timestamp_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_vote_block_timestamp_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_block_timestamp_convert_global_to_local( void const * global_self, fd_vote_block_timestamp_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_vote_prior_voters_new( fd_vote_prior_voters_t * self );
 int fd_vote_prior_voters_encode( fd_vote_prior_voters_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6793,9 +5296,6 @@ int fd_vote_prior_voters_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong 
 int fd_vote_prior_voters_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_prior_voters_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_prior_voters_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_prior_voters_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_vote_prior_voters_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_prior_voters_convert_global_to_local( void const * global_self, fd_vote_prior_voters_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_vote_prior_voters_0_23_5_new( fd_vote_prior_voters_0_23_5_t * self );
 int fd_vote_prior_voters_0_23_5_encode( fd_vote_prior_voters_0_23_5_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6808,9 +5308,6 @@ int fd_vote_prior_voters_0_23_5_decode_footprint( fd_bincode_decode_ctx_t * ctx,
 int fd_vote_prior_voters_0_23_5_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_prior_voters_0_23_5_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_prior_voters_0_23_5_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_prior_voters_0_23_5_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_vote_prior_voters_0_23_5_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_prior_voters_0_23_5_convert_global_to_local( void const * global_self, fd_vote_prior_voters_0_23_5_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_landed_vote_new( fd_landed_vote_t * self );
 int fd_landed_vote_encode( fd_landed_vote_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6823,9 +5320,6 @@ int fd_landed_vote_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * tota
 int fd_landed_vote_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_landed_vote_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_landed_vote_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_landed_vote_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_landed_vote_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_landed_vote_convert_global_to_local( void const * global_self, fd_landed_vote_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_vote_state_0_23_5_new( fd_vote_state_0_23_5_t * self );
 int fd_vote_state_0_23_5_encode( fd_vote_state_0_23_5_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6840,7 +5334,7 @@ void * fd_vote_state_0_23_5_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_state_0_23_5_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_vote_state_0_23_5_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_state_0_23_5_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_state_0_23_5_convert_global_to_local( void const * global_self, fd_vote_state_0_23_5_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_vote_state_0_23_5_encode_global( fd_vote_state_0_23_5_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_authorized_voters_new( fd_vote_authorized_voters_t * self );
 int fd_vote_authorized_voters_encode( fd_vote_authorized_voters_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6855,7 +5349,7 @@ void * fd_vote_authorized_voters_decode( void * mem, fd_bincode_decode_ctx_t * c
 void fd_vote_authorized_voters_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_vote_authorized_voters_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_authorized_voters_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_authorized_voters_convert_global_to_local( void const * global_self, fd_vote_authorized_voters_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_vote_authorized_voters_encode_global( fd_vote_authorized_voters_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_state_1_14_11_new( fd_vote_state_1_14_11_t * self );
 int fd_vote_state_1_14_11_encode( fd_vote_state_1_14_11_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6870,7 +5364,7 @@ void * fd_vote_state_1_14_11_decode( void * mem, fd_bincode_decode_ctx_t * ctx )
 void fd_vote_state_1_14_11_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_vote_state_1_14_11_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_state_1_14_11_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_state_1_14_11_convert_global_to_local( void const * global_self, fd_vote_state_1_14_11_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_vote_state_1_14_11_encode_global( fd_vote_state_1_14_11_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_state_new( fd_vote_state_t * self );
 int fd_vote_state_encode( fd_vote_state_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6885,7 +5379,7 @@ void * fd_vote_state_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_state_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_vote_state_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_state_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_state_convert_global_to_local( void const * global_self, fd_vote_state_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_vote_state_encode_global( fd_vote_state_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_state_versioned_new_disc( fd_vote_state_versioned_t * self, uint discriminant );
 void fd_vote_state_versioned_new( fd_vote_state_versioned_t * self );
@@ -6901,7 +5395,7 @@ void * fd_vote_state_versioned_decode( void * mem, fd_bincode_decode_ctx_t * ctx
 void fd_vote_state_versioned_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_vote_state_versioned_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_state_versioned_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_state_versioned_convert_global_to_local( void const * global_self, fd_vote_state_versioned_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_vote_state_versioned_encode_global( fd_vote_state_versioned_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_vote_state_versioned_is_v0_23_5( fd_vote_state_versioned_t const * self );
 FD_FN_PURE uchar fd_vote_state_versioned_is_v1_14_11( fd_vote_state_versioned_t const * self );
@@ -6924,7 +5418,7 @@ void * fd_vote_state_update_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_state_update_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_vote_state_update_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_state_update_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_state_update_convert_global_to_local( void const * global_self, fd_vote_state_update_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_vote_state_update_encode_global( fd_vote_state_update_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_compact_vote_state_update_new( fd_compact_vote_state_update_t * self );
 int fd_compact_vote_state_update_encode( fd_compact_vote_state_update_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6939,7 +5433,7 @@ void * fd_compact_vote_state_update_decode( void * mem, fd_bincode_decode_ctx_t 
 void fd_compact_vote_state_update_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_compact_vote_state_update_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_compact_vote_state_update_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_compact_vote_state_update_convert_global_to_local( void const * global_self, fd_compact_vote_state_update_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_compact_vote_state_update_encode_global( fd_compact_vote_state_update_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_compact_vote_state_update_switch_new( fd_compact_vote_state_update_switch_t * self );
 int fd_compact_vote_state_update_switch_encode( fd_compact_vote_state_update_switch_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6954,7 +5448,7 @@ void * fd_compact_vote_state_update_switch_decode( void * mem, fd_bincode_decode
 void fd_compact_vote_state_update_switch_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_compact_vote_state_update_switch_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_compact_vote_state_update_switch_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_compact_vote_state_update_switch_convert_global_to_local( void const * global_self, fd_compact_vote_state_update_switch_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_compact_vote_state_update_switch_encode_global( fd_compact_vote_state_update_switch_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_compact_tower_sync_new( fd_compact_tower_sync_t * self );
 int fd_compact_tower_sync_encode( fd_compact_tower_sync_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6969,7 +5463,7 @@ void * fd_compact_tower_sync_decode( void * mem, fd_bincode_decode_ctx_t * ctx )
 void fd_compact_tower_sync_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_compact_tower_sync_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_compact_tower_sync_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_compact_tower_sync_convert_global_to_local( void const * global_self, fd_compact_tower_sync_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_compact_tower_sync_encode_global( fd_compact_tower_sync_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_tower_sync_new( fd_tower_sync_t * self );
 int fd_tower_sync_encode( fd_tower_sync_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6984,7 +5478,7 @@ void * fd_tower_sync_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_tower_sync_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_tower_sync_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_tower_sync_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_tower_sync_convert_global_to_local( void const * global_self, fd_tower_sync_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_tower_sync_encode_global( fd_tower_sync_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_tower_sync_switch_new( fd_tower_sync_switch_t * self );
 int fd_tower_sync_switch_encode( fd_tower_sync_switch_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6999,7 +5493,7 @@ void * fd_tower_sync_switch_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_tower_sync_switch_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_tower_sync_switch_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_tower_sync_switch_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_tower_sync_switch_convert_global_to_local( void const * global_self, fd_tower_sync_switch_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_tower_sync_switch_encode_global( fd_tower_sync_switch_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_slot_history_inner_new( fd_slot_history_inner_t * self );
 int fd_slot_history_inner_encode( fd_slot_history_inner_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7012,9 +5506,6 @@ int fd_slot_history_inner_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong
 int fd_slot_history_inner_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_slot_history_inner_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_slot_history_inner_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_slot_history_inner_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_slot_history_inner_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_slot_history_inner_convert_global_to_local( void const * global_self, fd_slot_history_inner_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_slot_history_bitvec_new( fd_slot_history_bitvec_t * self );
 int fd_slot_history_bitvec_encode( fd_slot_history_bitvec_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7029,7 +5520,7 @@ void * fd_slot_history_bitvec_decode( void * mem, fd_bincode_decode_ctx_t * ctx 
 void fd_slot_history_bitvec_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_slot_history_bitvec_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_slot_history_bitvec_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_slot_history_bitvec_convert_global_to_local( void const * global_self, fd_slot_history_bitvec_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_slot_history_bitvec_encode_global( fd_slot_history_bitvec_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_slot_history_new( fd_slot_history_t * self );
 int fd_slot_history_encode( fd_slot_history_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7044,7 +5535,7 @@ void * fd_slot_history_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_slot_history_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_slot_history_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_slot_history_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_slot_history_convert_global_to_local( void const * global_self, fd_slot_history_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_slot_history_encode_global( fd_slot_history_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_slot_hash_new( fd_slot_hash_t * self );
 int fd_slot_hash_encode( fd_slot_hash_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7057,9 +5548,6 @@ int fd_slot_hash_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_
 int fd_slot_hash_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_slot_hash_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_slot_hash_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_slot_hash_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_slot_hash_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_slot_hash_convert_global_to_local( void const * global_self, fd_slot_hash_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_slot_hashes_new( fd_slot_hashes_t * self );
 int fd_slot_hashes_encode( fd_slot_hashes_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7074,7 +5562,7 @@ void * fd_slot_hashes_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_slot_hashes_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_slot_hashes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_slot_hashes_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_slot_hashes_convert_global_to_local( void const * global_self, fd_slot_hashes_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_slot_hashes_encode_global( fd_slot_hashes_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_block_block_hash_entry_new( fd_block_block_hash_entry_t * self );
 int fd_block_block_hash_entry_encode( fd_block_block_hash_entry_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7087,9 +5575,6 @@ int fd_block_block_hash_entry_decode_footprint( fd_bincode_decode_ctx_t * ctx, u
 int fd_block_block_hash_entry_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_block_block_hash_entry_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_block_block_hash_entry_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_block_block_hash_entry_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_block_block_hash_entry_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_block_block_hash_entry_convert_global_to_local( void const * global_self, fd_block_block_hash_entry_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_recent_block_hashes_new( fd_recent_block_hashes_t * self );
 int fd_recent_block_hashes_encode( fd_recent_block_hashes_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7104,7 +5589,7 @@ void * fd_recent_block_hashes_decode( void * mem, fd_bincode_decode_ctx_t * ctx 
 void fd_recent_block_hashes_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_recent_block_hashes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_recent_block_hashes_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_recent_block_hashes_convert_global_to_local( void const * global_self, fd_recent_block_hashes_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_recent_block_hashes_encode_global( fd_recent_block_hashes_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_slot_meta_new( fd_slot_meta_t * self );
 int fd_slot_meta_encode( fd_slot_meta_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7117,9 +5602,6 @@ int fd_slot_meta_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_
 int fd_slot_meta_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_slot_meta_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_slot_meta_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_slot_meta_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_slot_meta_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_slot_meta_convert_global_to_local( void const * global_self, fd_slot_meta_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_clock_timestamp_vote_new( fd_clock_timestamp_vote_t * self );
 int fd_clock_timestamp_vote_encode( fd_clock_timestamp_vote_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7132,9 +5614,6 @@ int fd_clock_timestamp_vote_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulo
 int fd_clock_timestamp_vote_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_clock_timestamp_vote_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_clock_timestamp_vote_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_clock_timestamp_vote_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_clock_timestamp_vote_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_clock_timestamp_vote_convert_global_to_local( void const * global_self, fd_clock_timestamp_vote_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_clock_timestamp_votes_new( fd_clock_timestamp_votes_t * self );
 int fd_clock_timestamp_votes_encode( fd_clock_timestamp_votes_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7149,7 +5628,7 @@ void * fd_clock_timestamp_votes_decode( void * mem, fd_bincode_decode_ctx_t * ct
 void fd_clock_timestamp_votes_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_clock_timestamp_votes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_clock_timestamp_votes_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_clock_timestamp_votes_convert_global_to_local( void const * global_self, fd_clock_timestamp_votes_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_clock_timestamp_votes_encode_global( fd_clock_timestamp_votes_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_sysvar_fees_new( fd_sysvar_fees_t * self );
 int fd_sysvar_fees_encode( fd_sysvar_fees_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7162,9 +5641,6 @@ int fd_sysvar_fees_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * tota
 int fd_sysvar_fees_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_sysvar_fees_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_sysvar_fees_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_sysvar_fees_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_sysvar_fees_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_sysvar_fees_convert_global_to_local( void const * global_self, fd_sysvar_fees_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_sysvar_epoch_rewards_new( fd_sysvar_epoch_rewards_t * self );
 int fd_sysvar_epoch_rewards_encode( fd_sysvar_epoch_rewards_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7177,9 +5653,6 @@ int fd_sysvar_epoch_rewards_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulo
 int fd_sysvar_epoch_rewards_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_sysvar_epoch_rewards_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_sysvar_epoch_rewards_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_sysvar_epoch_rewards_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_sysvar_epoch_rewards_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_sysvar_epoch_rewards_convert_global_to_local( void const * global_self, fd_sysvar_epoch_rewards_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_config_keys_pair_new( fd_config_keys_pair_t * self );
 int fd_config_keys_pair_encode( fd_config_keys_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7192,9 +5665,6 @@ int fd_config_keys_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong *
 int fd_config_keys_pair_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_config_keys_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_config_keys_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_config_keys_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_config_keys_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_config_keys_pair_convert_global_to_local( void const * global_self, fd_config_keys_pair_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_stake_config_new( fd_stake_config_t * self );
 int fd_stake_config_encode( fd_stake_config_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7207,9 +5677,6 @@ int fd_stake_config_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * tot
 int fd_stake_config_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_config_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_config_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_config_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_stake_config_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_config_convert_global_to_local( void const * global_self, fd_stake_config_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_feature_entry_new( fd_feature_entry_t * self );
 int fd_feature_entry_encode( fd_feature_entry_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7224,7 +5691,7 @@ void * fd_feature_entry_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_feature_entry_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_feature_entry_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_feature_entry_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_feature_entry_convert_global_to_local( void const * global_self, fd_feature_entry_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_feature_entry_encode_global( fd_feature_entry_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_firedancer_bank_new( fd_firedancer_bank_t * self );
 int fd_firedancer_bank_encode( fd_firedancer_bank_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7239,7 +5706,7 @@ void * fd_firedancer_bank_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_firedancer_bank_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_firedancer_bank_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_firedancer_bank_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_firedancer_bank_convert_global_to_local( void const * global_self, fd_firedancer_bank_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_firedancer_bank_encode_global( fd_firedancer_bank_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_cluster_type_new_disc( fd_cluster_type_t * self, uint discriminant );
 void fd_cluster_type_new( fd_cluster_type_t * self );
@@ -7253,9 +5720,6 @@ int fd_cluster_type_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * tot
 int fd_cluster_type_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_cluster_type_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_cluster_type_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_cluster_type_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_cluster_type_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_cluster_type_convert_global_to_local( void const * global_self, fd_cluster_type_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_cluster_type_is_Testnet( fd_cluster_type_t const * self );
 FD_FN_PURE uchar fd_cluster_type_is_MainnetBeta( fd_cluster_type_t const * self );
@@ -7278,9 +5742,6 @@ int fd_rent_fresh_account_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong
 int fd_rent_fresh_account_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_rent_fresh_account_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_rent_fresh_account_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_rent_fresh_account_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_rent_fresh_account_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_rent_fresh_account_convert_global_to_local( void const * global_self, fd_rent_fresh_account_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_rent_fresh_accounts_new( fd_rent_fresh_accounts_t * self );
 int fd_rent_fresh_accounts_encode( fd_rent_fresh_accounts_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7293,9 +5754,6 @@ int fd_rent_fresh_accounts_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulon
 int fd_rent_fresh_accounts_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_rent_fresh_accounts_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_rent_fresh_accounts_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_rent_fresh_accounts_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_rent_fresh_accounts_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_rent_fresh_accounts_convert_global_to_local( void const * global_self, fd_rent_fresh_accounts_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_epoch_bank_new( fd_epoch_bank_t * self );
 int fd_epoch_bank_encode( fd_epoch_bank_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7310,7 +5768,7 @@ void * fd_epoch_bank_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_epoch_bank_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_epoch_bank_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_epoch_bank_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_bank_convert_global_to_local( void const * global_self, fd_epoch_bank_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_epoch_bank_encode_global( fd_epoch_bank_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_slot_bank_new( fd_slot_bank_t * self );
 int fd_slot_bank_encode( fd_slot_bank_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7325,7 +5783,7 @@ void * fd_slot_bank_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_slot_bank_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_slot_bank_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_slot_bank_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_slot_bank_convert_global_to_local( void const * global_self, fd_slot_bank_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_slot_bank_encode_global( fd_slot_bank_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_prev_epoch_inflation_rewards_new( fd_prev_epoch_inflation_rewards_t * self );
 int fd_prev_epoch_inflation_rewards_encode( fd_prev_epoch_inflation_rewards_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7338,9 +5796,6 @@ int fd_prev_epoch_inflation_rewards_decode_footprint( fd_bincode_decode_ctx_t * 
 int fd_prev_epoch_inflation_rewards_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_prev_epoch_inflation_rewards_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_prev_epoch_inflation_rewards_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_prev_epoch_inflation_rewards_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_prev_epoch_inflation_rewards_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_prev_epoch_inflation_rewards_convert_global_to_local( void const * global_self, fd_prev_epoch_inflation_rewards_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_vote_new( fd_vote_t * self );
 int fd_vote_encode( fd_vote_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7355,7 +5810,7 @@ void * fd_vote_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_vote_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_convert_global_to_local( void const * global_self, fd_vote_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_vote_encode_global( fd_vote_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_init_new( fd_vote_init_t * self );
 int fd_vote_init_encode( fd_vote_init_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7368,9 +5823,6 @@ int fd_vote_init_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_
 int fd_vote_init_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_init_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_init_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_init_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_vote_init_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_init_convert_global_to_local( void const * global_self, fd_vote_init_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_vote_authorize_new_disc( fd_vote_authorize_t * self, uint discriminant );
 void fd_vote_authorize_new( fd_vote_authorize_t * self );
@@ -7384,9 +5836,6 @@ int fd_vote_authorize_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * t
 int fd_vote_authorize_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_authorize_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_authorize_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_authorize_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_vote_authorize_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_authorize_convert_global_to_local( void const * global_self, fd_vote_authorize_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_vote_authorize_is_voter( fd_vote_authorize_t const * self );
 FD_FN_PURE uchar fd_vote_authorize_is_withdrawer( fd_vote_authorize_t const * self );
@@ -7405,9 +5854,6 @@ int fd_vote_authorize_pubkey_decode_footprint( fd_bincode_decode_ctx_t * ctx, ul
 int fd_vote_authorize_pubkey_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_authorize_pubkey_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_authorize_pubkey_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_authorize_pubkey_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_vote_authorize_pubkey_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_authorize_pubkey_convert_global_to_local( void const * global_self, fd_vote_authorize_pubkey_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_vote_switch_new( fd_vote_switch_t * self );
 int fd_vote_switch_encode( fd_vote_switch_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7422,7 +5868,7 @@ void * fd_vote_switch_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_switch_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_vote_switch_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_switch_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_switch_convert_global_to_local( void const * global_self, fd_vote_switch_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_vote_switch_encode_global( fd_vote_switch_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_update_vote_state_switch_new( fd_update_vote_state_switch_t * self );
 int fd_update_vote_state_switch_encode( fd_update_vote_state_switch_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7437,7 +5883,7 @@ void * fd_update_vote_state_switch_decode( void * mem, fd_bincode_decode_ctx_t *
 void fd_update_vote_state_switch_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_update_vote_state_switch_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_update_vote_state_switch_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_update_vote_state_switch_convert_global_to_local( void const * global_self, fd_update_vote_state_switch_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_update_vote_state_switch_encode_global( fd_update_vote_state_switch_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_authorize_with_seed_args_new( fd_vote_authorize_with_seed_args_t * self );
 int fd_vote_authorize_with_seed_args_encode( fd_vote_authorize_with_seed_args_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7452,7 +5898,7 @@ void * fd_vote_authorize_with_seed_args_decode( void * mem, fd_bincode_decode_ct
 void fd_vote_authorize_with_seed_args_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_vote_authorize_with_seed_args_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_authorize_with_seed_args_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_authorize_with_seed_args_convert_global_to_local( void const * global_self, fd_vote_authorize_with_seed_args_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_vote_authorize_with_seed_args_encode_global( fd_vote_authorize_with_seed_args_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_authorize_checked_with_seed_args_new( fd_vote_authorize_checked_with_seed_args_t * self );
 int fd_vote_authorize_checked_with_seed_args_encode( fd_vote_authorize_checked_with_seed_args_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7467,7 +5913,7 @@ void * fd_vote_authorize_checked_with_seed_args_decode( void * mem, fd_bincode_d
 void fd_vote_authorize_checked_with_seed_args_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_vote_authorize_checked_with_seed_args_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_authorize_checked_with_seed_args_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_authorize_checked_with_seed_args_convert_global_to_local( void const * global_self, fd_vote_authorize_checked_with_seed_args_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_vote_authorize_checked_with_seed_args_encode_global( fd_vote_authorize_checked_with_seed_args_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_instruction_new_disc( fd_vote_instruction_t * self, uint discriminant );
 void fd_vote_instruction_new( fd_vote_instruction_t * self );
@@ -7483,7 +5929,7 @@ void * fd_vote_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_instruction_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_vote_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_instruction_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_instruction_convert_global_to_local( void const * global_self, fd_vote_instruction_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_vote_instruction_encode_global( fd_vote_instruction_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_vote_instruction_is_initialize_account( fd_vote_instruction_t const * self );
 FD_FN_PURE uchar fd_vote_instruction_is_authorize( fd_vote_instruction_t const * self );
@@ -7530,9 +5976,6 @@ int fd_system_program_instruction_create_account_decode_footprint( fd_bincode_de
 int fd_system_program_instruction_create_account_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_system_program_instruction_create_account_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_system_program_instruction_create_account_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_system_program_instruction_create_account_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_system_program_instruction_create_account_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_system_program_instruction_create_account_convert_global_to_local( void const * global_self, fd_system_program_instruction_create_account_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_system_program_instruction_create_account_with_seed_new( fd_system_program_instruction_create_account_with_seed_t * self );
 int fd_system_program_instruction_create_account_with_seed_encode( fd_system_program_instruction_create_account_with_seed_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7547,7 +5990,7 @@ void * fd_system_program_instruction_create_account_with_seed_decode( void * mem
 void fd_system_program_instruction_create_account_with_seed_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_system_program_instruction_create_account_with_seed_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_system_program_instruction_create_account_with_seed_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_system_program_instruction_create_account_with_seed_convert_global_to_local( void const * global_self, fd_system_program_instruction_create_account_with_seed_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_system_program_instruction_create_account_with_seed_encode_global( fd_system_program_instruction_create_account_with_seed_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_system_program_instruction_allocate_with_seed_new( fd_system_program_instruction_allocate_with_seed_t * self );
 int fd_system_program_instruction_allocate_with_seed_encode( fd_system_program_instruction_allocate_with_seed_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7562,7 +6005,7 @@ void * fd_system_program_instruction_allocate_with_seed_decode( void * mem, fd_b
 void fd_system_program_instruction_allocate_with_seed_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_system_program_instruction_allocate_with_seed_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_system_program_instruction_allocate_with_seed_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_system_program_instruction_allocate_with_seed_convert_global_to_local( void const * global_self, fd_system_program_instruction_allocate_with_seed_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_system_program_instruction_allocate_with_seed_encode_global( fd_system_program_instruction_allocate_with_seed_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_system_program_instruction_assign_with_seed_new( fd_system_program_instruction_assign_with_seed_t * self );
 int fd_system_program_instruction_assign_with_seed_encode( fd_system_program_instruction_assign_with_seed_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7577,7 +6020,7 @@ void * fd_system_program_instruction_assign_with_seed_decode( void * mem, fd_bin
 void fd_system_program_instruction_assign_with_seed_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_system_program_instruction_assign_with_seed_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_system_program_instruction_assign_with_seed_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_system_program_instruction_assign_with_seed_convert_global_to_local( void const * global_self, fd_system_program_instruction_assign_with_seed_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_system_program_instruction_assign_with_seed_encode_global( fd_system_program_instruction_assign_with_seed_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_system_program_instruction_transfer_with_seed_new( fd_system_program_instruction_transfer_with_seed_t * self );
 int fd_system_program_instruction_transfer_with_seed_encode( fd_system_program_instruction_transfer_with_seed_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7592,7 +6035,7 @@ void * fd_system_program_instruction_transfer_with_seed_decode( void * mem, fd_b
 void fd_system_program_instruction_transfer_with_seed_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_system_program_instruction_transfer_with_seed_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_system_program_instruction_transfer_with_seed_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_system_program_instruction_transfer_with_seed_convert_global_to_local( void const * global_self, fd_system_program_instruction_transfer_with_seed_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_system_program_instruction_transfer_with_seed_encode_global( fd_system_program_instruction_transfer_with_seed_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_system_program_instruction_new_disc( fd_system_program_instruction_t * self, uint discriminant );
 void fd_system_program_instruction_new( fd_system_program_instruction_t * self );
@@ -7608,7 +6051,7 @@ void * fd_system_program_instruction_decode( void * mem, fd_bincode_decode_ctx_t
 void fd_system_program_instruction_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_system_program_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_system_program_instruction_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_system_program_instruction_convert_global_to_local( void const * global_self, fd_system_program_instruction_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_system_program_instruction_encode_global( fd_system_program_instruction_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_system_program_instruction_is_create_account( fd_system_program_instruction_t const * self );
 FD_FN_PURE uchar fd_system_program_instruction_is_assign( fd_system_program_instruction_t const * self );
@@ -7650,9 +6093,6 @@ int fd_system_error_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * tot
 int fd_system_error_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_system_error_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_system_error_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_system_error_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_system_error_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_system_error_convert_global_to_local( void const * global_self, fd_system_error_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_system_error_is_account_already_in_use( fd_system_error_t const * self );
 FD_FN_PURE uchar fd_system_error_is_result_with_negative_lamports( fd_system_error_t const * self );
@@ -7685,9 +6125,6 @@ int fd_stake_authorized_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong *
 int fd_stake_authorized_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_authorized_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_authorized_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_authorized_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_stake_authorized_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_authorized_convert_global_to_local( void const * global_self, fd_stake_authorized_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_stake_lockup_new( fd_stake_lockup_t * self );
 int fd_stake_lockup_encode( fd_stake_lockup_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7700,9 +6137,6 @@ int fd_stake_lockup_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * tot
 int fd_stake_lockup_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_lockup_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_lockup_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_lockup_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_stake_lockup_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_lockup_convert_global_to_local( void const * global_self, fd_stake_lockup_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_stake_instruction_initialize_new( fd_stake_instruction_initialize_t * self );
 int fd_stake_instruction_initialize_encode( fd_stake_instruction_initialize_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7715,9 +6149,6 @@ int fd_stake_instruction_initialize_decode_footprint( fd_bincode_decode_ctx_t * 
 int fd_stake_instruction_initialize_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_instruction_initialize_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_instruction_initialize_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_instruction_initialize_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_stake_instruction_initialize_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_instruction_initialize_convert_global_to_local( void const * global_self, fd_stake_instruction_initialize_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_stake_lockup_custodian_args_new( fd_stake_lockup_custodian_args_t * self );
 int fd_stake_lockup_custodian_args_encode( fd_stake_lockup_custodian_args_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7732,7 +6163,7 @@ void * fd_stake_lockup_custodian_args_decode( void * mem, fd_bincode_decode_ctx_
 void fd_stake_lockup_custodian_args_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_stake_lockup_custodian_args_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_lockup_custodian_args_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_lockup_custodian_args_convert_global_to_local( void const * global_self, fd_stake_lockup_custodian_args_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_stake_lockup_custodian_args_encode_global( fd_stake_lockup_custodian_args_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_stake_authorize_new_disc( fd_stake_authorize_t * self, uint discriminant );
 void fd_stake_authorize_new( fd_stake_authorize_t * self );
@@ -7746,9 +6177,6 @@ int fd_stake_authorize_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * 
 int fd_stake_authorize_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_authorize_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_authorize_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_authorize_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_stake_authorize_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_authorize_convert_global_to_local( void const * global_self, fd_stake_authorize_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_stake_authorize_is_staker( fd_stake_authorize_t const * self );
 FD_FN_PURE uchar fd_stake_authorize_is_withdrawer( fd_stake_authorize_t const * self );
@@ -7767,9 +6195,6 @@ int fd_stake_instruction_authorize_decode_footprint( fd_bincode_decode_ctx_t * c
 int fd_stake_instruction_authorize_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_instruction_authorize_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_instruction_authorize_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_instruction_authorize_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_stake_instruction_authorize_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_instruction_authorize_convert_global_to_local( void const * global_self, fd_stake_instruction_authorize_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_authorize_with_seed_args_new( fd_authorize_with_seed_args_t * self );
 int fd_authorize_with_seed_args_encode( fd_authorize_with_seed_args_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7784,7 +6209,7 @@ void * fd_authorize_with_seed_args_decode( void * mem, fd_bincode_decode_ctx_t *
 void fd_authorize_with_seed_args_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_authorize_with_seed_args_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_authorize_with_seed_args_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_authorize_with_seed_args_convert_global_to_local( void const * global_self, fd_authorize_with_seed_args_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_authorize_with_seed_args_encode_global( fd_authorize_with_seed_args_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_authorize_checked_with_seed_args_new( fd_authorize_checked_with_seed_args_t * self );
 int fd_authorize_checked_with_seed_args_encode( fd_authorize_checked_with_seed_args_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7799,7 +6224,7 @@ void * fd_authorize_checked_with_seed_args_decode( void * mem, fd_bincode_decode
 void fd_authorize_checked_with_seed_args_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_authorize_checked_with_seed_args_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_authorize_checked_with_seed_args_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_authorize_checked_with_seed_args_convert_global_to_local( void const * global_self, fd_authorize_checked_with_seed_args_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_authorize_checked_with_seed_args_encode_global( fd_authorize_checked_with_seed_args_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_lockup_checked_args_new( fd_lockup_checked_args_t * self );
 int fd_lockup_checked_args_encode( fd_lockup_checked_args_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7814,7 +6239,7 @@ void * fd_lockup_checked_args_decode( void * mem, fd_bincode_decode_ctx_t * ctx 
 void fd_lockup_checked_args_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_lockup_checked_args_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_lockup_checked_args_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_lockup_checked_args_convert_global_to_local( void const * global_self, fd_lockup_checked_args_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_lockup_checked_args_encode_global( fd_lockup_checked_args_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_lockup_args_new( fd_lockup_args_t * self );
 int fd_lockup_args_encode( fd_lockup_args_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7829,7 +6254,7 @@ void * fd_lockup_args_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_lockup_args_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_lockup_args_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_lockup_args_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_lockup_args_convert_global_to_local( void const * global_self, fd_lockup_args_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_lockup_args_encode_global( fd_lockup_args_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_stake_instruction_new_disc( fd_stake_instruction_t * self, uint discriminant );
 void fd_stake_instruction_new( fd_stake_instruction_t * self );
@@ -7845,7 +6270,7 @@ void * fd_stake_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_instruction_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_stake_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_instruction_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_instruction_convert_global_to_local( void const * global_self, fd_stake_instruction_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_stake_instruction_encode_global( fd_stake_instruction_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_stake_instruction_is_initialize( fd_stake_instruction_t const * self );
 FD_FN_PURE uchar fd_stake_instruction_is_authorize( fd_stake_instruction_t const * self );
@@ -7896,9 +6321,6 @@ int fd_stake_meta_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total
 int fd_stake_meta_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_meta_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_meta_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_meta_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_stake_meta_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_meta_convert_global_to_local( void const * global_self, fd_stake_meta_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_stake_flags_new( fd_stake_flags_t * self );
 int fd_stake_flags_encode( fd_stake_flags_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7911,9 +6333,6 @@ int fd_stake_flags_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * tota
 int fd_stake_flags_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_flags_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_flags_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_flags_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_stake_flags_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_flags_convert_global_to_local( void const * global_self, fd_stake_flags_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_stake_state_v2_initialized_new( fd_stake_state_v2_initialized_t * self );
 int fd_stake_state_v2_initialized_encode( fd_stake_state_v2_initialized_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7926,9 +6345,6 @@ int fd_stake_state_v2_initialized_decode_footprint( fd_bincode_decode_ctx_t * ct
 int fd_stake_state_v2_initialized_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_state_v2_initialized_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_state_v2_initialized_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_state_v2_initialized_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_stake_state_v2_initialized_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_state_v2_initialized_convert_global_to_local( void const * global_self, fd_stake_state_v2_initialized_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_stake_state_v2_stake_new( fd_stake_state_v2_stake_t * self );
 int fd_stake_state_v2_stake_encode( fd_stake_state_v2_stake_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7941,9 +6357,6 @@ int fd_stake_state_v2_stake_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulo
 int fd_stake_state_v2_stake_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_state_v2_stake_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_state_v2_stake_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_state_v2_stake_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_stake_state_v2_stake_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_state_v2_stake_convert_global_to_local( void const * global_self, fd_stake_state_v2_stake_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_stake_state_v2_new_disc( fd_stake_state_v2_t * self, uint discriminant );
 void fd_stake_state_v2_new( fd_stake_state_v2_t * self );
@@ -7957,9 +6370,6 @@ int fd_stake_state_v2_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * t
 int fd_stake_state_v2_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_state_v2_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_stake_state_v2_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_state_v2_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_stake_state_v2_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_state_v2_convert_global_to_local( void const * global_self, fd_stake_state_v2_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_stake_state_v2_is_uninitialized( fd_stake_state_v2_t const * self );
 FD_FN_PURE uchar fd_stake_state_v2_is_initialized( fd_stake_state_v2_t const * self );
@@ -7982,9 +6392,6 @@ int fd_nonce_data_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total
 int fd_nonce_data_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_nonce_data_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_nonce_data_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_nonce_data_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_nonce_data_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_nonce_data_convert_global_to_local( void const * global_self, fd_nonce_data_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_nonce_state_new_disc( fd_nonce_state_t * self, uint discriminant );
 void fd_nonce_state_new( fd_nonce_state_t * self );
@@ -7998,9 +6405,6 @@ int fd_nonce_state_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * tota
 int fd_nonce_state_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_nonce_state_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_nonce_state_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_nonce_state_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_nonce_state_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_nonce_state_convert_global_to_local( void const * global_self, fd_nonce_state_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_nonce_state_is_uninitialized( fd_nonce_state_t const * self );
 FD_FN_PURE uchar fd_nonce_state_is_initialized( fd_nonce_state_t const * self );
@@ -8020,9 +6424,6 @@ int fd_nonce_state_versions_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulo
 int fd_nonce_state_versions_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_nonce_state_versions_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_nonce_state_versions_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_nonce_state_versions_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_nonce_state_versions_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_nonce_state_versions_convert_global_to_local( void const * global_self, fd_nonce_state_versions_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_nonce_state_versions_is_legacy( fd_nonce_state_versions_t const * self );
 FD_FN_PURE uchar fd_nonce_state_versions_is_current( fd_nonce_state_versions_t const * self );
@@ -8041,9 +6442,6 @@ int fd_compute_budget_program_instruction_request_units_deprecated_decode_footpr
 int fd_compute_budget_program_instruction_request_units_deprecated_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_compute_budget_program_instruction_request_units_deprecated_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_compute_budget_program_instruction_request_units_deprecated_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_compute_budget_program_instruction_request_units_deprecated_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_compute_budget_program_instruction_request_units_deprecated_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_compute_budget_program_instruction_request_units_deprecated_convert_global_to_local( void const * global_self, fd_compute_budget_program_instruction_request_units_deprecated_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_compute_budget_program_instruction_new_disc( fd_compute_budget_program_instruction_t * self, uint discriminant );
 void fd_compute_budget_program_instruction_new( fd_compute_budget_program_instruction_t * self );
@@ -8057,9 +6455,6 @@ int fd_compute_budget_program_instruction_decode_footprint( fd_bincode_decode_ct
 int fd_compute_budget_program_instruction_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_compute_budget_program_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_compute_budget_program_instruction_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_compute_budget_program_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_compute_budget_program_instruction_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_compute_budget_program_instruction_convert_global_to_local( void const * global_self, fd_compute_budget_program_instruction_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_compute_budget_program_instruction_is_request_units_deprecated( fd_compute_budget_program_instruction_t const * self );
 FD_FN_PURE uchar fd_compute_budget_program_instruction_is_request_heap_frame( fd_compute_budget_program_instruction_t const * self );
@@ -8084,9 +6479,6 @@ int fd_config_keys_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * tota
 int fd_config_keys_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_config_keys_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_config_keys_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_config_keys_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_config_keys_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_config_keys_convert_global_to_local( void const * global_self, fd_config_keys_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_bpf_loader_program_instruction_write_new( fd_bpf_loader_program_instruction_write_t * self );
 int fd_bpf_loader_program_instruction_write_encode( fd_bpf_loader_program_instruction_write_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8099,9 +6491,6 @@ int fd_bpf_loader_program_instruction_write_decode_footprint( fd_bincode_decode_
 int fd_bpf_loader_program_instruction_write_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bpf_loader_program_instruction_write_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_bpf_loader_program_instruction_write_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bpf_loader_program_instruction_write_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_bpf_loader_program_instruction_write_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_loader_program_instruction_write_convert_global_to_local( void const * global_self, fd_bpf_loader_program_instruction_write_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_bpf_loader_program_instruction_new_disc( fd_bpf_loader_program_instruction_t * self, uint discriminant );
 void fd_bpf_loader_program_instruction_new( fd_bpf_loader_program_instruction_t * self );
@@ -8115,9 +6504,6 @@ int fd_bpf_loader_program_instruction_decode_footprint( fd_bincode_decode_ctx_t 
 int fd_bpf_loader_program_instruction_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bpf_loader_program_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_bpf_loader_program_instruction_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bpf_loader_program_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_bpf_loader_program_instruction_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_loader_program_instruction_convert_global_to_local( void const * global_self, fd_bpf_loader_program_instruction_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_bpf_loader_program_instruction_is_write( fd_bpf_loader_program_instruction_t const * self );
 FD_FN_PURE uchar fd_bpf_loader_program_instruction_is_finalize( fd_bpf_loader_program_instruction_t const * self );
@@ -8136,9 +6522,6 @@ int fd_loader_v4_program_instruction_write_decode_footprint( fd_bincode_decode_c
 int fd_loader_v4_program_instruction_write_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_loader_v4_program_instruction_write_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_loader_v4_program_instruction_write_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_loader_v4_program_instruction_write_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_loader_v4_program_instruction_write_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_loader_v4_program_instruction_write_convert_global_to_local( void const * global_self, fd_loader_v4_program_instruction_write_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_loader_v4_program_instruction_truncate_new( fd_loader_v4_program_instruction_truncate_t * self );
 int fd_loader_v4_program_instruction_truncate_encode( fd_loader_v4_program_instruction_truncate_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8151,9 +6534,6 @@ int fd_loader_v4_program_instruction_truncate_decode_footprint( fd_bincode_decod
 int fd_loader_v4_program_instruction_truncate_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_loader_v4_program_instruction_truncate_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_loader_v4_program_instruction_truncate_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_loader_v4_program_instruction_truncate_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_loader_v4_program_instruction_truncate_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_loader_v4_program_instruction_truncate_convert_global_to_local( void const * global_self, fd_loader_v4_program_instruction_truncate_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_loader_v4_program_instruction_new_disc( fd_loader_v4_program_instruction_t * self, uint discriminant );
 void fd_loader_v4_program_instruction_new( fd_loader_v4_program_instruction_t * self );
@@ -8167,9 +6547,6 @@ int fd_loader_v4_program_instruction_decode_footprint( fd_bincode_decode_ctx_t *
 int fd_loader_v4_program_instruction_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_loader_v4_program_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_loader_v4_program_instruction_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_loader_v4_program_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_loader_v4_program_instruction_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_loader_v4_program_instruction_convert_global_to_local( void const * global_self, fd_loader_v4_program_instruction_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_loader_v4_program_instruction_is_write( fd_loader_v4_program_instruction_t const * self );
 FD_FN_PURE uchar fd_loader_v4_program_instruction_is_truncate( fd_loader_v4_program_instruction_t const * self );
@@ -8196,9 +6573,6 @@ int fd_bpf_upgradeable_loader_program_instruction_write_decode_footprint( fd_bin
 int fd_bpf_upgradeable_loader_program_instruction_write_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bpf_upgradeable_loader_program_instruction_write_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_bpf_upgradeable_loader_program_instruction_write_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bpf_upgradeable_loader_program_instruction_write_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_bpf_upgradeable_loader_program_instruction_write_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_upgradeable_loader_program_instruction_write_convert_global_to_local( void const * global_self, fd_bpf_upgradeable_loader_program_instruction_write_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_new( fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t * self );
 int fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_encode( fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8211,9 +6585,6 @@ int fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_decod
 int fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_convert_global_to_local( void const * global_self, fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_bpf_upgradeable_loader_program_instruction_extend_program_new( fd_bpf_upgradeable_loader_program_instruction_extend_program_t * self );
 int fd_bpf_upgradeable_loader_program_instruction_extend_program_encode( fd_bpf_upgradeable_loader_program_instruction_extend_program_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8226,9 +6597,6 @@ int fd_bpf_upgradeable_loader_program_instruction_extend_program_decode_footprin
 int fd_bpf_upgradeable_loader_program_instruction_extend_program_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bpf_upgradeable_loader_program_instruction_extend_program_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_bpf_upgradeable_loader_program_instruction_extend_program_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bpf_upgradeable_loader_program_instruction_extend_program_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_bpf_upgradeable_loader_program_instruction_extend_program_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_upgradeable_loader_program_instruction_extend_program_convert_global_to_local( void const * global_self, fd_bpf_upgradeable_loader_program_instruction_extend_program_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_bpf_upgradeable_loader_program_instruction_new_disc( fd_bpf_upgradeable_loader_program_instruction_t * self, uint discriminant );
 void fd_bpf_upgradeable_loader_program_instruction_new( fd_bpf_upgradeable_loader_program_instruction_t * self );
@@ -8242,9 +6610,6 @@ int fd_bpf_upgradeable_loader_program_instruction_decode_footprint( fd_bincode_d
 int fd_bpf_upgradeable_loader_program_instruction_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bpf_upgradeable_loader_program_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_bpf_upgradeable_loader_program_instruction_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bpf_upgradeable_loader_program_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_bpf_upgradeable_loader_program_instruction_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_upgradeable_loader_program_instruction_convert_global_to_local( void const * global_self, fd_bpf_upgradeable_loader_program_instruction_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_bpf_upgradeable_loader_program_instruction_is_initialize_buffer( fd_bpf_upgradeable_loader_program_instruction_t const * self );
 FD_FN_PURE uchar fd_bpf_upgradeable_loader_program_instruction_is_write( fd_bpf_upgradeable_loader_program_instruction_t const * self );
@@ -8277,7 +6642,7 @@ void * fd_bpf_upgradeable_loader_state_buffer_decode( void * mem, fd_bincode_dec
 void fd_bpf_upgradeable_loader_state_buffer_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_bpf_upgradeable_loader_state_buffer_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_bpf_upgradeable_loader_state_buffer_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_upgradeable_loader_state_buffer_convert_global_to_local( void const * global_self, fd_bpf_upgradeable_loader_state_buffer_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_bpf_upgradeable_loader_state_buffer_encode_global( fd_bpf_upgradeable_loader_state_buffer_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_bpf_upgradeable_loader_state_program_new( fd_bpf_upgradeable_loader_state_program_t * self );
 int fd_bpf_upgradeable_loader_state_program_encode( fd_bpf_upgradeable_loader_state_program_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8290,9 +6655,6 @@ int fd_bpf_upgradeable_loader_state_program_decode_footprint( fd_bincode_decode_
 int fd_bpf_upgradeable_loader_state_program_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bpf_upgradeable_loader_state_program_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_bpf_upgradeable_loader_state_program_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bpf_upgradeable_loader_state_program_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_bpf_upgradeable_loader_state_program_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_upgradeable_loader_state_program_convert_global_to_local( void const * global_self, fd_bpf_upgradeable_loader_state_program_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_bpf_upgradeable_loader_state_program_data_new( fd_bpf_upgradeable_loader_state_program_data_t * self );
 int fd_bpf_upgradeable_loader_state_program_data_encode( fd_bpf_upgradeable_loader_state_program_data_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8307,7 +6669,7 @@ void * fd_bpf_upgradeable_loader_state_program_data_decode( void * mem, fd_binco
 void fd_bpf_upgradeable_loader_state_program_data_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_bpf_upgradeable_loader_state_program_data_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_bpf_upgradeable_loader_state_program_data_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_upgradeable_loader_state_program_data_convert_global_to_local( void const * global_self, fd_bpf_upgradeable_loader_state_program_data_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_bpf_upgradeable_loader_state_program_data_encode_global( fd_bpf_upgradeable_loader_state_program_data_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_bpf_upgradeable_loader_state_new_disc( fd_bpf_upgradeable_loader_state_t * self, uint discriminant );
 void fd_bpf_upgradeable_loader_state_new( fd_bpf_upgradeable_loader_state_t * self );
@@ -8323,7 +6685,7 @@ void * fd_bpf_upgradeable_loader_state_decode( void * mem, fd_bincode_decode_ctx
 void fd_bpf_upgradeable_loader_state_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_bpf_upgradeable_loader_state_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_bpf_upgradeable_loader_state_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_upgradeable_loader_state_convert_global_to_local( void const * global_self, fd_bpf_upgradeable_loader_state_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_bpf_upgradeable_loader_state_encode_global( fd_bpf_upgradeable_loader_state_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_bpf_upgradeable_loader_state_is_uninitialized( fd_bpf_upgradeable_loader_state_t const * self );
 FD_FN_PURE uchar fd_bpf_upgradeable_loader_state_is_buffer( fd_bpf_upgradeable_loader_state_t const * self );
@@ -8346,9 +6708,6 @@ int fd_loader_v4_state_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * 
 int fd_loader_v4_state_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_loader_v4_state_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_loader_v4_state_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_loader_v4_state_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_loader_v4_state_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_loader_v4_state_convert_global_to_local( void const * global_self, fd_loader_v4_state_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_frozen_hash_status_new( fd_frozen_hash_status_t * self );
 int fd_frozen_hash_status_encode( fd_frozen_hash_status_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8361,9 +6720,6 @@ int fd_frozen_hash_status_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong
 int fd_frozen_hash_status_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_frozen_hash_status_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_frozen_hash_status_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_frozen_hash_status_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_frozen_hash_status_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_frozen_hash_status_convert_global_to_local( void const * global_self, fd_frozen_hash_status_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_frozen_hash_versioned_new_disc( fd_frozen_hash_versioned_t * self, uint discriminant );
 void fd_frozen_hash_versioned_new( fd_frozen_hash_versioned_t * self );
@@ -8377,9 +6733,6 @@ int fd_frozen_hash_versioned_decode_footprint( fd_bincode_decode_ctx_t * ctx, ul
 int fd_frozen_hash_versioned_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_frozen_hash_versioned_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_frozen_hash_versioned_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_frozen_hash_versioned_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_frozen_hash_versioned_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_frozen_hash_versioned_convert_global_to_local( void const * global_self, fd_frozen_hash_versioned_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_frozen_hash_versioned_is_current( fd_frozen_hash_versioned_t const * self );
 enum {
@@ -8398,7 +6751,7 @@ void * fd_lookup_table_meta_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_lookup_table_meta_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_lookup_table_meta_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_lookup_table_meta_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_lookup_table_meta_convert_global_to_local( void const * global_self, fd_lookup_table_meta_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_lookup_table_meta_encode_global( fd_lookup_table_meta_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_address_lookup_table_new( fd_address_lookup_table_t * self );
 int fd_address_lookup_table_encode( fd_address_lookup_table_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8413,7 +6766,7 @@ void * fd_address_lookup_table_decode( void * mem, fd_bincode_decode_ctx_t * ctx
 void fd_address_lookup_table_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_address_lookup_table_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_address_lookup_table_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_address_lookup_table_convert_global_to_local( void const * global_self, fd_address_lookup_table_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_address_lookup_table_encode_global( fd_address_lookup_table_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_address_lookup_table_state_new_disc( fd_address_lookup_table_state_t * self, uint discriminant );
 void fd_address_lookup_table_state_new( fd_address_lookup_table_state_t * self );
@@ -8429,7 +6782,7 @@ void * fd_address_lookup_table_state_decode( void * mem, fd_bincode_decode_ctx_t
 void fd_address_lookup_table_state_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_address_lookup_table_state_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_address_lookup_table_state_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_address_lookup_table_state_convert_global_to_local( void const * global_self, fd_address_lookup_table_state_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_address_lookup_table_state_encode_global( fd_address_lookup_table_state_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_address_lookup_table_state_is_uninitialized( fd_address_lookup_table_state_t const * self );
 FD_FN_PURE uchar fd_address_lookup_table_state_is_lookup_table( fd_address_lookup_table_state_t const * self );
@@ -8448,9 +6801,6 @@ int fd_gossip_bitvec_u8_inner_decode_footprint( fd_bincode_decode_ctx_t * ctx, u
 int fd_gossip_bitvec_u8_inner_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_bitvec_u8_inner_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_bitvec_u8_inner_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_bitvec_u8_inner_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_bitvec_u8_inner_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_bitvec_u8_inner_convert_global_to_local( void const * global_self, fd_gossip_bitvec_u8_inner_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_bitvec_u8_new( fd_gossip_bitvec_u8_t * self );
 int fd_gossip_bitvec_u8_encode( fd_gossip_bitvec_u8_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8465,7 +6815,7 @@ void * fd_gossip_bitvec_u8_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_bitvec_u8_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_gossip_bitvec_u8_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_bitvec_u8_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_bitvec_u8_convert_global_to_local( void const * global_self, fd_gossip_bitvec_u8_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_gossip_bitvec_u8_encode_global( fd_gossip_bitvec_u8_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_bitvec_u64_inner_new( fd_gossip_bitvec_u64_inner_t * self );
 int fd_gossip_bitvec_u64_inner_encode( fd_gossip_bitvec_u64_inner_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8478,9 +6828,6 @@ int fd_gossip_bitvec_u64_inner_decode_footprint( fd_bincode_decode_ctx_t * ctx, 
 int fd_gossip_bitvec_u64_inner_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_bitvec_u64_inner_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_bitvec_u64_inner_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_bitvec_u64_inner_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_bitvec_u64_inner_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_bitvec_u64_inner_convert_global_to_local( void const * global_self, fd_gossip_bitvec_u64_inner_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_bitvec_u64_new( fd_gossip_bitvec_u64_t * self );
 int fd_gossip_bitvec_u64_encode( fd_gossip_bitvec_u64_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8495,7 +6842,7 @@ void * fd_gossip_bitvec_u64_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_bitvec_u64_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_gossip_bitvec_u64_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_bitvec_u64_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_bitvec_u64_convert_global_to_local( void const * global_self, fd_gossip_bitvec_u64_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_gossip_bitvec_u64_encode_global( fd_gossip_bitvec_u64_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_ping_new( fd_gossip_ping_t * self );
 int fd_gossip_ping_encode( fd_gossip_ping_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8508,9 +6855,6 @@ int fd_gossip_ping_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * tota
 int fd_gossip_ping_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_ping_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_ping_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_ping_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_ping_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_ping_convert_global_to_local( void const * global_self, fd_gossip_ping_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_ip_addr_new_disc( fd_gossip_ip_addr_t * self, uint discriminant );
 void fd_gossip_ip_addr_new( fd_gossip_ip_addr_t * self );
@@ -8524,9 +6868,6 @@ int fd_gossip_ip_addr_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * t
 int fd_gossip_ip_addr_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_ip_addr_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_ip_addr_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_ip_addr_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_ip_addr_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_ip_addr_convert_global_to_local( void const * global_self, fd_gossip_ip_addr_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_gossip_ip_addr_is_ip4( fd_gossip_ip_addr_t const * self );
 FD_FN_PURE uchar fd_gossip_ip_addr_is_ip6( fd_gossip_ip_addr_t const * self );
@@ -8545,9 +6886,6 @@ int fd_gossip_prune_data_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong 
 int fd_gossip_prune_data_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_prune_data_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_prune_data_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_prune_data_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_prune_data_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_prune_data_convert_global_to_local( void const * global_self, fd_gossip_prune_data_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_prune_sign_data_new( fd_gossip_prune_sign_data_t * self );
 int fd_gossip_prune_sign_data_encode( fd_gossip_prune_sign_data_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8560,9 +6898,6 @@ int fd_gossip_prune_sign_data_decode_footprint( fd_bincode_decode_ctx_t * ctx, u
 int fd_gossip_prune_sign_data_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_prune_sign_data_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_prune_sign_data_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_prune_sign_data_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_prune_sign_data_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_prune_sign_data_convert_global_to_local( void const * global_self, fd_gossip_prune_sign_data_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_prune_sign_data_with_prefix_new( fd_gossip_prune_sign_data_with_prefix_t * self );
 int fd_gossip_prune_sign_data_with_prefix_encode( fd_gossip_prune_sign_data_with_prefix_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8577,7 +6912,7 @@ void * fd_gossip_prune_sign_data_with_prefix_decode( void * mem, fd_bincode_deco
 void fd_gossip_prune_sign_data_with_prefix_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_gossip_prune_sign_data_with_prefix_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_prune_sign_data_with_prefix_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_prune_sign_data_with_prefix_convert_global_to_local( void const * global_self, fd_gossip_prune_sign_data_with_prefix_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_gossip_prune_sign_data_with_prefix_encode_global( fd_gossip_prune_sign_data_with_prefix_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_socket_addr_old_new( fd_gossip_socket_addr_old_t * self );
 int fd_gossip_socket_addr_old_encode( fd_gossip_socket_addr_old_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8590,9 +6925,6 @@ int fd_gossip_socket_addr_old_decode_footprint( fd_bincode_decode_ctx_t * ctx, u
 int fd_gossip_socket_addr_old_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_socket_addr_old_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_socket_addr_old_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_socket_addr_old_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_socket_addr_old_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_socket_addr_old_convert_global_to_local( void const * global_self, fd_gossip_socket_addr_old_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_socket_addr_ip4_new( fd_gossip_socket_addr_ip4_t * self );
 int fd_gossip_socket_addr_ip4_encode( fd_gossip_socket_addr_ip4_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8605,9 +6937,6 @@ int fd_gossip_socket_addr_ip4_decode_footprint( fd_bincode_decode_ctx_t * ctx, u
 int fd_gossip_socket_addr_ip4_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_socket_addr_ip4_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_socket_addr_ip4_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_socket_addr_ip4_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_socket_addr_ip4_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_socket_addr_ip4_convert_global_to_local( void const * global_self, fd_gossip_socket_addr_ip4_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_socket_addr_ip6_new( fd_gossip_socket_addr_ip6_t * self );
 int fd_gossip_socket_addr_ip6_encode( fd_gossip_socket_addr_ip6_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8620,9 +6949,6 @@ int fd_gossip_socket_addr_ip6_decode_footprint( fd_bincode_decode_ctx_t * ctx, u
 int fd_gossip_socket_addr_ip6_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_socket_addr_ip6_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_socket_addr_ip6_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_socket_addr_ip6_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_socket_addr_ip6_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_socket_addr_ip6_convert_global_to_local( void const * global_self, fd_gossip_socket_addr_ip6_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_socket_addr_new_disc( fd_gossip_socket_addr_t * self, uint discriminant );
 void fd_gossip_socket_addr_new( fd_gossip_socket_addr_t * self );
@@ -8636,9 +6962,6 @@ int fd_gossip_socket_addr_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong
 int fd_gossip_socket_addr_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_socket_addr_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_socket_addr_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_socket_addr_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_socket_addr_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_socket_addr_convert_global_to_local( void const * global_self, fd_gossip_socket_addr_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_gossip_socket_addr_is_ip4( fd_gossip_socket_addr_t const * self );
 FD_FN_PURE uchar fd_gossip_socket_addr_is_ip6( fd_gossip_socket_addr_t const * self );
@@ -8657,9 +6980,6 @@ int fd_gossip_contact_info_v1_decode_footprint( fd_bincode_decode_ctx_t * ctx, u
 int fd_gossip_contact_info_v1_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_contact_info_v1_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_contact_info_v1_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_contact_info_v1_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_contact_info_v1_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_contact_info_v1_convert_global_to_local( void const * global_self, fd_gossip_contact_info_v1_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_vote_new( fd_gossip_vote_t * self );
 int fd_gossip_vote_encode( fd_gossip_vote_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8672,9 +6992,6 @@ int fd_gossip_vote_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * tota
 int fd_gossip_vote_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_vote_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_vote_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_vote_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_vote_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_vote_convert_global_to_local( void const * global_self, fd_gossip_vote_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_lowest_slot_new( fd_gossip_lowest_slot_t * self );
 int fd_gossip_lowest_slot_encode( fd_gossip_lowest_slot_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8687,9 +7004,6 @@ int fd_gossip_lowest_slot_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong
 int fd_gossip_lowest_slot_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_lowest_slot_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_lowest_slot_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_lowest_slot_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_lowest_slot_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_lowest_slot_convert_global_to_local( void const * global_self, fd_gossip_lowest_slot_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_slot_hashes_new( fd_gossip_slot_hashes_t * self );
 int fd_gossip_slot_hashes_encode( fd_gossip_slot_hashes_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8702,9 +7016,6 @@ int fd_gossip_slot_hashes_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong
 int fd_gossip_slot_hashes_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_slot_hashes_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_slot_hashes_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_slot_hashes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_slot_hashes_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_slot_hashes_convert_global_to_local( void const * global_self, fd_gossip_slot_hashes_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_slots_new( fd_gossip_slots_t * self );
 int fd_gossip_slots_encode( fd_gossip_slots_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8719,7 +7030,7 @@ void * fd_gossip_slots_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_slots_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_gossip_slots_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_slots_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_slots_convert_global_to_local( void const * global_self, fd_gossip_slots_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_gossip_slots_encode_global( fd_gossip_slots_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_flate2_slots_new( fd_gossip_flate2_slots_t * self );
 int fd_gossip_flate2_slots_encode( fd_gossip_flate2_slots_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8732,9 +7043,6 @@ int fd_gossip_flate2_slots_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulon
 int fd_gossip_flate2_slots_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_flate2_slots_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_flate2_slots_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_flate2_slots_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_flate2_slots_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_flate2_slots_convert_global_to_local( void const * global_self, fd_gossip_flate2_slots_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_slots_enum_new_disc( fd_gossip_slots_enum_t * self, uint discriminant );
 void fd_gossip_slots_enum_new( fd_gossip_slots_enum_t * self );
@@ -8750,7 +7058,7 @@ void * fd_gossip_slots_enum_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_slots_enum_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_gossip_slots_enum_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_slots_enum_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_slots_enum_convert_global_to_local( void const * global_self, fd_gossip_slots_enum_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_gossip_slots_enum_encode_global( fd_gossip_slots_enum_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_gossip_slots_enum_is_flate2( fd_gossip_slots_enum_t const * self );
 FD_FN_PURE uchar fd_gossip_slots_enum_is_uncompressed( fd_gossip_slots_enum_t const * self );
@@ -8771,7 +7079,7 @@ void * fd_gossip_epoch_slots_decode( void * mem, fd_bincode_decode_ctx_t * ctx )
 void fd_gossip_epoch_slots_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_gossip_epoch_slots_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_epoch_slots_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_epoch_slots_convert_global_to_local( void const * global_self, fd_gossip_epoch_slots_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_gossip_epoch_slots_encode_global( fd_gossip_epoch_slots_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_version_v1_new( fd_gossip_version_v1_t * self );
 int fd_gossip_version_v1_encode( fd_gossip_version_v1_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8786,7 +7094,7 @@ void * fd_gossip_version_v1_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_version_v1_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_gossip_version_v1_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_version_v1_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_version_v1_convert_global_to_local( void const * global_self, fd_gossip_version_v1_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_gossip_version_v1_encode_global( fd_gossip_version_v1_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_version_v2_new( fd_gossip_version_v2_t * self );
 int fd_gossip_version_v2_encode( fd_gossip_version_v2_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8801,7 +7109,7 @@ void * fd_gossip_version_v2_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_version_v2_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_gossip_version_v2_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_version_v2_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_version_v2_convert_global_to_local( void const * global_self, fd_gossip_version_v2_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_gossip_version_v2_encode_global( fd_gossip_version_v2_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_version_v3_new( fd_gossip_version_v3_t * self );
 int fd_gossip_version_v3_encode( fd_gossip_version_v3_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8814,9 +7122,6 @@ int fd_gossip_version_v3_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong 
 int fd_gossip_version_v3_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_version_v3_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_version_v3_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_version_v3_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_version_v3_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_version_v3_convert_global_to_local( void const * global_self, fd_gossip_version_v3_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_node_instance_new( fd_gossip_node_instance_t * self );
 int fd_gossip_node_instance_encode( fd_gossip_node_instance_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8829,9 +7134,6 @@ int fd_gossip_node_instance_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulo
 int fd_gossip_node_instance_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_node_instance_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_node_instance_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_node_instance_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_node_instance_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_node_instance_convert_global_to_local( void const * global_self, fd_gossip_node_instance_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_duplicate_shred_new( fd_gossip_duplicate_shred_t * self );
 int fd_gossip_duplicate_shred_encode( fd_gossip_duplicate_shred_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8844,9 +7146,6 @@ int fd_gossip_duplicate_shred_decode_footprint( fd_bincode_decode_ctx_t * ctx, u
 int fd_gossip_duplicate_shred_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_duplicate_shred_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_duplicate_shred_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_duplicate_shred_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_duplicate_shred_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_duplicate_shred_convert_global_to_local( void const * global_self, fd_gossip_duplicate_shred_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_incremental_snapshot_hashes_new( fd_gossip_incremental_snapshot_hashes_t * self );
 int fd_gossip_incremental_snapshot_hashes_encode( fd_gossip_incremental_snapshot_hashes_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8859,9 +7158,6 @@ int fd_gossip_incremental_snapshot_hashes_decode_footprint( fd_bincode_decode_ct
 int fd_gossip_incremental_snapshot_hashes_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_incremental_snapshot_hashes_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_incremental_snapshot_hashes_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_incremental_snapshot_hashes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_incremental_snapshot_hashes_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_incremental_snapshot_hashes_convert_global_to_local( void const * global_self, fd_gossip_incremental_snapshot_hashes_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_socket_entry_new( fd_gossip_socket_entry_t * self );
 int fd_gossip_socket_entry_encode( fd_gossip_socket_entry_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8874,9 +7170,6 @@ int fd_gossip_socket_entry_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulon
 int fd_gossip_socket_entry_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_socket_entry_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_socket_entry_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_socket_entry_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_socket_entry_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_socket_entry_convert_global_to_local( void const * global_self, fd_gossip_socket_entry_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_contact_info_v2_new( fd_gossip_contact_info_v2_t * self );
 int fd_gossip_contact_info_v2_encode( fd_gossip_contact_info_v2_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8889,9 +7182,6 @@ int fd_gossip_contact_info_v2_decode_footprint( fd_bincode_decode_ctx_t * ctx, u
 int fd_gossip_contact_info_v2_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_contact_info_v2_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_contact_info_v2_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_contact_info_v2_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_contact_info_v2_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_contact_info_v2_convert_global_to_local( void const * global_self, fd_gossip_contact_info_v2_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_restart_run_length_encoding_inner_new( fd_restart_run_length_encoding_inner_t * self );
 int fd_restart_run_length_encoding_inner_encode( fd_restart_run_length_encoding_inner_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8904,9 +7194,6 @@ int fd_restart_run_length_encoding_inner_decode_footprint( fd_bincode_decode_ctx
 int fd_restart_run_length_encoding_inner_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_restart_run_length_encoding_inner_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_restart_run_length_encoding_inner_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_restart_run_length_encoding_inner_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_restart_run_length_encoding_inner_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_restart_run_length_encoding_inner_convert_global_to_local( void const * global_self, fd_restart_run_length_encoding_inner_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_restart_run_length_encoding_new( fd_restart_run_length_encoding_t * self );
 int fd_restart_run_length_encoding_encode( fd_restart_run_length_encoding_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8919,9 +7206,6 @@ int fd_restart_run_length_encoding_decode_footprint( fd_bincode_decode_ctx_t * c
 int fd_restart_run_length_encoding_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_restart_run_length_encoding_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_restart_run_length_encoding_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_restart_run_length_encoding_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_restart_run_length_encoding_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_restart_run_length_encoding_convert_global_to_local( void const * global_self, fd_restart_run_length_encoding_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_restart_raw_offsets_bitvec_u8_inner_new( fd_restart_raw_offsets_bitvec_u8_inner_t * self );
 int fd_restart_raw_offsets_bitvec_u8_inner_encode( fd_restart_raw_offsets_bitvec_u8_inner_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8934,9 +7218,6 @@ int fd_restart_raw_offsets_bitvec_u8_inner_decode_footprint( fd_bincode_decode_c
 int fd_restart_raw_offsets_bitvec_u8_inner_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_restart_raw_offsets_bitvec_u8_inner_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_restart_raw_offsets_bitvec_u8_inner_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_restart_raw_offsets_bitvec_u8_inner_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_restart_raw_offsets_bitvec_u8_inner_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_restart_raw_offsets_bitvec_u8_inner_convert_global_to_local( void const * global_self, fd_restart_raw_offsets_bitvec_u8_inner_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_restart_raw_offsets_bitvec_new( fd_restart_raw_offsets_bitvec_t * self );
 int fd_restart_raw_offsets_bitvec_encode( fd_restart_raw_offsets_bitvec_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8951,7 +7232,7 @@ void * fd_restart_raw_offsets_bitvec_decode( void * mem, fd_bincode_decode_ctx_t
 void fd_restart_raw_offsets_bitvec_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_restart_raw_offsets_bitvec_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_restart_raw_offsets_bitvec_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_restart_raw_offsets_bitvec_convert_global_to_local( void const * global_self, fd_restart_raw_offsets_bitvec_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_restart_raw_offsets_bitvec_encode_global( fd_restart_raw_offsets_bitvec_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_restart_raw_offsets_new( fd_restart_raw_offsets_t * self );
 int fd_restart_raw_offsets_encode( fd_restart_raw_offsets_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8966,7 +7247,7 @@ void * fd_restart_raw_offsets_decode( void * mem, fd_bincode_decode_ctx_t * ctx 
 void fd_restart_raw_offsets_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_restart_raw_offsets_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_restart_raw_offsets_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_restart_raw_offsets_convert_global_to_local( void const * global_self, fd_restart_raw_offsets_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_restart_raw_offsets_encode_global( fd_restart_raw_offsets_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_restart_slots_offsets_new_disc( fd_restart_slots_offsets_t * self, uint discriminant );
 void fd_restart_slots_offsets_new( fd_restart_slots_offsets_t * self );
@@ -8982,7 +7263,7 @@ void * fd_restart_slots_offsets_decode( void * mem, fd_bincode_decode_ctx_t * ct
 void fd_restart_slots_offsets_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_restart_slots_offsets_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_restart_slots_offsets_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_restart_slots_offsets_convert_global_to_local( void const * global_self, fd_restart_slots_offsets_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_restart_slots_offsets_encode_global( fd_restart_slots_offsets_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_restart_slots_offsets_is_run_length_encoding( fd_restart_slots_offsets_t const * self );
 FD_FN_PURE uchar fd_restart_slots_offsets_is_raw_offsets( fd_restart_slots_offsets_t const * self );
@@ -9003,7 +7284,7 @@ void * fd_gossip_restart_last_voted_fork_slots_decode( void * mem, fd_bincode_de
 void fd_gossip_restart_last_voted_fork_slots_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_gossip_restart_last_voted_fork_slots_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_restart_last_voted_fork_slots_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_restart_last_voted_fork_slots_convert_global_to_local( void const * global_self, fd_gossip_restart_last_voted_fork_slots_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_gossip_restart_last_voted_fork_slots_encode_global( fd_gossip_restart_last_voted_fork_slots_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_restart_heaviest_fork_new( fd_gossip_restart_heaviest_fork_t * self );
 int fd_gossip_restart_heaviest_fork_encode( fd_gossip_restart_heaviest_fork_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9016,9 +7297,6 @@ int fd_gossip_restart_heaviest_fork_decode_footprint( fd_bincode_decode_ctx_t * 
 int fd_gossip_restart_heaviest_fork_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_restart_heaviest_fork_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_restart_heaviest_fork_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_restart_heaviest_fork_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_restart_heaviest_fork_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_restart_heaviest_fork_convert_global_to_local( void const * global_self, fd_gossip_restart_heaviest_fork_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_crds_data_new_disc( fd_crds_data_t * self, uint discriminant );
 void fd_crds_data_new( fd_crds_data_t * self );
@@ -9034,7 +7312,7 @@ void * fd_crds_data_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_crds_data_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_crds_data_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_crds_data_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_crds_data_convert_global_to_local( void const * global_self, fd_crds_data_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_crds_data_encode_global( fd_crds_data_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_crds_data_is_contact_info_v1( fd_crds_data_t const * self );
 FD_FN_PURE uchar fd_crds_data_is_vote( fd_crds_data_t const * self );
@@ -9079,7 +7357,7 @@ void * fd_crds_bloom_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_crds_bloom_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_crds_bloom_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_crds_bloom_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_crds_bloom_convert_global_to_local( void const * global_self, fd_crds_bloom_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_crds_bloom_encode_global( fd_crds_bloom_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_crds_filter_new( fd_crds_filter_t * self );
 int fd_crds_filter_encode( fd_crds_filter_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9094,7 +7372,7 @@ void * fd_crds_filter_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_crds_filter_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_crds_filter_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_crds_filter_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_crds_filter_convert_global_to_local( void const * global_self, fd_crds_filter_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_crds_filter_encode_global( fd_crds_filter_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_crds_value_new( fd_crds_value_t * self );
 int fd_crds_value_encode( fd_crds_value_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9109,7 +7387,7 @@ void * fd_crds_value_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_crds_value_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_crds_value_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_crds_value_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_crds_value_convert_global_to_local( void const * global_self, fd_crds_value_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_crds_value_encode_global( fd_crds_value_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_pull_req_new( fd_gossip_pull_req_t * self );
 int fd_gossip_pull_req_encode( fd_gossip_pull_req_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9124,7 +7402,7 @@ void * fd_gossip_pull_req_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_pull_req_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_gossip_pull_req_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_pull_req_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_pull_req_convert_global_to_local( void const * global_self, fd_gossip_pull_req_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_gossip_pull_req_encode_global( fd_gossip_pull_req_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_pull_resp_new( fd_gossip_pull_resp_t * self );
 int fd_gossip_pull_resp_encode( fd_gossip_pull_resp_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9139,7 +7417,7 @@ void * fd_gossip_pull_resp_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_pull_resp_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_gossip_pull_resp_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_pull_resp_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_pull_resp_convert_global_to_local( void const * global_self, fd_gossip_pull_resp_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_gossip_pull_resp_encode_global( fd_gossip_pull_resp_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_push_msg_new( fd_gossip_push_msg_t * self );
 int fd_gossip_push_msg_encode( fd_gossip_push_msg_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9154,7 +7432,7 @@ void * fd_gossip_push_msg_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_push_msg_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_gossip_push_msg_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_push_msg_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_push_msg_convert_global_to_local( void const * global_self, fd_gossip_push_msg_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_gossip_push_msg_encode_global( fd_gossip_push_msg_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_prune_msg_new( fd_gossip_prune_msg_t * self );
 int fd_gossip_prune_msg_encode( fd_gossip_prune_msg_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9167,9 +7445,6 @@ int fd_gossip_prune_msg_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong *
 int fd_gossip_prune_msg_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_prune_msg_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_prune_msg_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_prune_msg_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_gossip_prune_msg_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_prune_msg_convert_global_to_local( void const * global_self, fd_gossip_prune_msg_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_gossip_msg_new_disc( fd_gossip_msg_t * self, uint discriminant );
 void fd_gossip_msg_new( fd_gossip_msg_t * self );
@@ -9185,7 +7460,7 @@ void * fd_gossip_msg_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_msg_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_gossip_msg_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_gossip_msg_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_msg_convert_global_to_local( void const * global_self, fd_gossip_msg_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_gossip_msg_encode_global( fd_gossip_msg_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_gossip_msg_is_pull_req( fd_gossip_msg_t const * self );
 FD_FN_PURE uchar fd_gossip_msg_is_pull_resp( fd_gossip_msg_t const * self );
@@ -9212,9 +7487,6 @@ int fd_addrlut_create_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * t
 int fd_addrlut_create_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_addrlut_create_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_addrlut_create_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_addrlut_create_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_addrlut_create_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_addrlut_create_convert_global_to_local( void const * global_self, fd_addrlut_create_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_addrlut_extend_new( fd_addrlut_extend_t * self );
 int fd_addrlut_extend_encode( fd_addrlut_extend_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9227,9 +7499,6 @@ int fd_addrlut_extend_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * t
 int fd_addrlut_extend_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_addrlut_extend_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_addrlut_extend_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_addrlut_extend_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_addrlut_extend_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_addrlut_extend_convert_global_to_local( void const * global_self, fd_addrlut_extend_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_addrlut_instruction_new_disc( fd_addrlut_instruction_t * self, uint discriminant );
 void fd_addrlut_instruction_new( fd_addrlut_instruction_t * self );
@@ -9243,9 +7512,6 @@ int fd_addrlut_instruction_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulon
 int fd_addrlut_instruction_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_addrlut_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_addrlut_instruction_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_addrlut_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_addrlut_instruction_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_addrlut_instruction_convert_global_to_local( void const * global_self, fd_addrlut_instruction_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_addrlut_instruction_is_create_lut( fd_addrlut_instruction_t const * self );
 FD_FN_PURE uchar fd_addrlut_instruction_is_freeze_lut( fd_addrlut_instruction_t const * self );
@@ -9270,9 +7536,6 @@ int fd_repair_request_header_decode_footprint( fd_bincode_decode_ctx_t * ctx, ul
 int fd_repair_request_header_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_repair_request_header_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_repair_request_header_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_repair_request_header_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_repair_request_header_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_repair_request_header_convert_global_to_local( void const * global_self, fd_repair_request_header_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_repair_window_index_new( fd_repair_window_index_t * self );
 int fd_repair_window_index_encode( fd_repair_window_index_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9285,9 +7548,6 @@ int fd_repair_window_index_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulon
 int fd_repair_window_index_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_repair_window_index_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_repair_window_index_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_repair_window_index_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_repair_window_index_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_repair_window_index_convert_global_to_local( void const * global_self, fd_repair_window_index_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_repair_highest_window_index_new( fd_repair_highest_window_index_t * self );
 int fd_repair_highest_window_index_encode( fd_repair_highest_window_index_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9300,9 +7560,6 @@ int fd_repair_highest_window_index_decode_footprint( fd_bincode_decode_ctx_t * c
 int fd_repair_highest_window_index_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_repair_highest_window_index_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_repair_highest_window_index_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_repair_highest_window_index_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_repair_highest_window_index_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_repair_highest_window_index_convert_global_to_local( void const * global_self, fd_repair_highest_window_index_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_repair_orphan_new( fd_repair_orphan_t * self );
 int fd_repair_orphan_encode( fd_repair_orphan_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9315,9 +7572,6 @@ int fd_repair_orphan_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * to
 int fd_repair_orphan_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_repair_orphan_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_repair_orphan_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_repair_orphan_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_repair_orphan_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_repair_orphan_convert_global_to_local( void const * global_self, fd_repair_orphan_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_repair_ancestor_hashes_new( fd_repair_ancestor_hashes_t * self );
 int fd_repair_ancestor_hashes_encode( fd_repair_ancestor_hashes_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9330,9 +7584,6 @@ int fd_repair_ancestor_hashes_decode_footprint( fd_bincode_decode_ctx_t * ctx, u
 int fd_repair_ancestor_hashes_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_repair_ancestor_hashes_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_repair_ancestor_hashes_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_repair_ancestor_hashes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_repair_ancestor_hashes_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_repair_ancestor_hashes_convert_global_to_local( void const * global_self, fd_repair_ancestor_hashes_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_repair_protocol_new_disc( fd_repair_protocol_t * self, uint discriminant );
 void fd_repair_protocol_new( fd_repair_protocol_t * self );
@@ -9346,9 +7597,6 @@ int fd_repair_protocol_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * 
 int fd_repair_protocol_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_repair_protocol_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_repair_protocol_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_repair_protocol_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_repair_protocol_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_repair_protocol_convert_global_to_local( void const * global_self, fd_repair_protocol_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_repair_protocol_is_LegacyWindowIndex( fd_repair_protocol_t const * self );
 FD_FN_PURE uchar fd_repair_protocol_is_LegacyHighestWindowIndex( fd_repair_protocol_t const * self );
@@ -9388,9 +7636,6 @@ int fd_repair_response_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * 
 int fd_repair_response_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_repair_response_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_repair_response_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_repair_response_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_repair_response_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_repair_response_convert_global_to_local( void const * global_self, fd_repair_response_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_repair_response_is_ping( fd_repair_response_t const * self );
 enum {
@@ -9410,7 +7655,7 @@ void * fd_instr_error_enum_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_instr_error_enum_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_instr_error_enum_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_instr_error_enum_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_instr_error_enum_convert_global_to_local( void const * global_self, fd_instr_error_enum_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_instr_error_enum_encode_global( fd_instr_error_enum_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_instr_error_enum_is_generic_error( fd_instr_error_enum_t const * self );
 FD_FN_PURE uchar fd_instr_error_enum_is_invalid_argument( fd_instr_error_enum_t const * self );
@@ -9535,7 +7780,7 @@ void * fd_txn_instr_error_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_txn_instr_error_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_txn_instr_error_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_txn_instr_error_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_txn_instr_error_convert_global_to_local( void const * global_self, fd_txn_instr_error_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_txn_instr_error_encode_global( fd_txn_instr_error_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_txn_error_enum_new_disc( fd_txn_error_enum_t * self, uint discriminant );
 void fd_txn_error_enum_new( fd_txn_error_enum_t * self );
@@ -9551,7 +7796,7 @@ void * fd_txn_error_enum_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_txn_error_enum_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_txn_error_enum_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_txn_error_enum_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_txn_error_enum_convert_global_to_local( void const * global_self, fd_txn_error_enum_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_txn_error_enum_encode_global( fd_txn_error_enum_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_txn_error_enum_is_account_in_use( fd_txn_error_enum_t const * self );
 FD_FN_PURE uchar fd_txn_error_enum_is_account_loaded_twice( fd_txn_error_enum_t const * self );
@@ -9643,7 +7888,7 @@ void * fd_txn_result_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_txn_result_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_txn_result_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_txn_result_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_txn_result_convert_global_to_local( void const * global_self, fd_txn_result_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_txn_result_encode_global( fd_txn_result_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_txn_result_is_ok( fd_txn_result_t const * self );
 FD_FN_PURE uchar fd_txn_result_is_error( fd_txn_result_t const * self );
@@ -9664,7 +7909,7 @@ void * fd_cache_status_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_cache_status_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_cache_status_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_cache_status_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_cache_status_convert_global_to_local( void const * global_self, fd_cache_status_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_cache_status_encode_global( fd_cache_status_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_status_value_new( fd_status_value_t * self );
 int fd_status_value_encode( fd_status_value_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9679,7 +7924,7 @@ void * fd_status_value_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_status_value_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_status_value_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_status_value_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_status_value_convert_global_to_local( void const * global_self, fd_status_value_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_status_value_encode_global( fd_status_value_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_status_pair_new( fd_status_pair_t * self );
 int fd_status_pair_encode( fd_status_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9694,7 +7939,7 @@ void * fd_status_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_status_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_status_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_status_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_status_pair_convert_global_to_local( void const * global_self, fd_status_pair_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_status_pair_encode_global( fd_status_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_slot_delta_new( fd_slot_delta_t * self );
 int fd_slot_delta_encode( fd_slot_delta_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9709,7 +7954,7 @@ void * fd_slot_delta_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_slot_delta_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_slot_delta_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_slot_delta_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_slot_delta_convert_global_to_local( void const * global_self, fd_slot_delta_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_slot_delta_encode_global( fd_slot_delta_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_bank_slot_deltas_new( fd_bank_slot_deltas_t * self );
 int fd_bank_slot_deltas_encode( fd_bank_slot_deltas_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9724,7 +7969,7 @@ void * fd_bank_slot_deltas_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_bank_slot_deltas_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_bank_slot_deltas_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_bank_slot_deltas_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bank_slot_deltas_convert_global_to_local( void const * global_self, fd_bank_slot_deltas_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_bank_slot_deltas_encode_global( fd_bank_slot_deltas_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_pubkey_rewardinfo_pair_new( fd_pubkey_rewardinfo_pair_t * self );
 int fd_pubkey_rewardinfo_pair_encode( fd_pubkey_rewardinfo_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9737,9 +7982,6 @@ int fd_pubkey_rewardinfo_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, u
 int fd_pubkey_rewardinfo_pair_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_pubkey_rewardinfo_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_pubkey_rewardinfo_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_pubkey_rewardinfo_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_pubkey_rewardinfo_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_pubkey_rewardinfo_pair_convert_global_to_local( void const * global_self, fd_pubkey_rewardinfo_pair_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_optional_account_new( fd_optional_account_t * self );
 int fd_optional_account_encode( fd_optional_account_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9754,7 +7996,7 @@ void * fd_optional_account_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_optional_account_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_optional_account_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_optional_account_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_optional_account_convert_global_to_local( void const * global_self, fd_optional_account_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_optional_account_encode_global( fd_optional_account_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_calculated_stake_points_new( fd_calculated_stake_points_t * self );
 int fd_calculated_stake_points_encode( fd_calculated_stake_points_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9767,9 +8009,6 @@ int fd_calculated_stake_points_decode_footprint( fd_bincode_decode_ctx_t * ctx, 
 int fd_calculated_stake_points_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_calculated_stake_points_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_calculated_stake_points_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_calculated_stake_points_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_calculated_stake_points_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_calculated_stake_points_convert_global_to_local( void const * global_self, fd_calculated_stake_points_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_calculated_stake_rewards_new( fd_calculated_stake_rewards_t * self );
 int fd_calculated_stake_rewards_encode( fd_calculated_stake_rewards_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9782,9 +8021,6 @@ int fd_calculated_stake_rewards_decode_footprint( fd_bincode_decode_ctx_t * ctx,
 int fd_calculated_stake_rewards_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_calculated_stake_rewards_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_calculated_stake_rewards_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_calculated_stake_rewards_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_calculated_stake_rewards_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_calculated_stake_rewards_convert_global_to_local( void const * global_self, fd_calculated_stake_rewards_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_duplicate_slot_proof_new( fd_duplicate_slot_proof_t * self );
 int fd_duplicate_slot_proof_encode( fd_duplicate_slot_proof_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9797,9 +8033,6 @@ int fd_duplicate_slot_proof_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulo
 int fd_duplicate_slot_proof_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_duplicate_slot_proof_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_duplicate_slot_proof_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_duplicate_slot_proof_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_duplicate_slot_proof_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_duplicate_slot_proof_convert_global_to_local( void const * global_self, fd_duplicate_slot_proof_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_epoch_info_pair_new( fd_epoch_info_pair_t * self );
 int fd_epoch_info_pair_encode( fd_epoch_info_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9812,9 +8045,6 @@ int fd_epoch_info_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * 
 int fd_epoch_info_pair_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_epoch_info_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_epoch_info_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_epoch_info_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_epoch_info_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_info_pair_convert_global_to_local( void const * global_self, fd_epoch_info_pair_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_vote_info_pair_new( fd_vote_info_pair_t * self );
 int fd_vote_info_pair_encode( fd_vote_info_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9829,7 +8059,7 @@ void * fd_vote_info_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_info_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_vote_info_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_vote_info_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_info_pair_convert_global_to_local( void const * global_self, fd_vote_info_pair_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_vote_info_pair_encode_global( fd_vote_info_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_epoch_info_new( fd_epoch_info_t * self );
 int fd_epoch_info_encode( fd_epoch_info_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9844,7 +8074,7 @@ void * fd_epoch_info_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_epoch_info_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_epoch_info_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_epoch_info_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_info_convert_global_to_local( void const * global_self, fd_epoch_info_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_epoch_info_encode_global( fd_epoch_info_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_usage_cost_details_new( fd_usage_cost_details_t * self );
 int fd_usage_cost_details_encode( fd_usage_cost_details_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9857,9 +8087,6 @@ int fd_usage_cost_details_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong
 int fd_usage_cost_details_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_usage_cost_details_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_usage_cost_details_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_usage_cost_details_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_usage_cost_details_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_usage_cost_details_convert_global_to_local( void const * global_self, fd_usage_cost_details_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_transaction_cost_new_disc( fd_transaction_cost_t * self, uint discriminant );
 void fd_transaction_cost_new( fd_transaction_cost_t * self );
@@ -9873,9 +8100,6 @@ int fd_transaction_cost_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong *
 int fd_transaction_cost_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_transaction_cost_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_transaction_cost_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_transaction_cost_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_transaction_cost_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_transaction_cost_convert_global_to_local( void const * global_self, fd_transaction_cost_t * self, fd_bincode_decode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_transaction_cost_is_simple_vote( fd_transaction_cost_t const * self );
 FD_FN_PURE uchar fd_transaction_cost_is_transaction( fd_transaction_cost_t const * self );
@@ -9894,9 +8118,6 @@ int fd_account_costs_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong
 int fd_account_costs_pair_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_account_costs_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_account_costs_pair_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_account_costs_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-void fd_account_costs_pair_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_account_costs_pair_convert_global_to_local( void const * global_self, fd_account_costs_pair_t * self, fd_bincode_decode_ctx_t * ctx );
 
 void fd_account_costs_new( fd_account_costs_t * self );
 int fd_account_costs_encode( fd_account_costs_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9911,7 +8132,7 @@ void * fd_account_costs_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_account_costs_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_account_costs_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_account_costs_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_account_costs_convert_global_to_local( void const * global_self, fd_account_costs_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_account_costs_encode_global( fd_account_costs_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_cost_tracker_new( fd_cost_tracker_t * self );
 int fd_cost_tracker_encode( fd_cost_tracker_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -9926,7 +8147,7 @@ void * fd_cost_tracker_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_cost_tracker_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 void * fd_cost_tracker_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
 void fd_cost_tracker_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-int fd_cost_tracker_convert_global_to_local( void const * global_self, fd_cost_tracker_t * self, fd_bincode_decode_ctx_t * ctx );
+int fd_cost_tracker_encode_global( fd_cost_tracker_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/types/fd_types.json
+++ b/src/flamenco/types/fd_types.json
@@ -768,7 +768,14 @@
       "name": "vote_authorized_voters",
       "type": "struct",
       "fields": [
-          { "name": "fd_vote_authorized_voters", "type": "treap", "treap_t": "fd_vote_authorized_voter_t", "treap_query_t": "ulong", "treap_cmp": "( (q == (e)->epoch) ? 0 : ( (q < (e)->epoch) ? -1 : 1 ) )", "treap_lt": "((e0)->epoch<(e1)->epoch)", "min": 64, "upsert": true }
+          { "name": "fd_vote_authorized_voters",
+            "type": "treap",
+            "treap_t": "fd_vote_authorized_voter_t",
+            "treap_query_t": "ulong",
+            "treap_cmp": "( (q == (e)->epoch) ? 0 : ( (q < (e)->epoch) ? -1 : 1 ) )",
+            "treap_lt": "((e0)->epoch<(e1)->epoch)",
+            "min": 64,
+            "upsert": true }
       ],
       "comment": "https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L310"
     },

--- a/src/flamenco/types/fd_types_custom.c
+++ b/src/flamenco/types/fd_types_custom.c
@@ -35,6 +35,22 @@ fd_flamenco_txn_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * t
   return 0;
 }
 
+int FD_FN_UNUSED
+fd_flamenco_txn_encode_global( fd_flamenco_txn_t const * self,
+                               fd_bincode_encode_ctx_t * ctx ) {
+  (void)self;
+  (void)ctx;
+  FD_LOG_ERR(( "only exists for testing" ));
+}
+
+void * FD_FN_UNUSED
+fd_flamenco_txn_decode_global( void *                    mem,
+                               fd_bincode_decode_ctx_t * ctx ) {
+  (void)mem;
+  (void)ctx;
+  FD_LOG_ERR(( "only exists for testing" ));
+}
+
 void *
 fd_flamenco_txn_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
   fd_flamenco_txn_t * self = (fd_flamenco_txn_t *)mem;
@@ -66,27 +82,6 @@ fd_flamenco_txn_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_
   ctx->data = (void *)( (ulong)ctx->data + sz );
 }
 
-void *
-fd_flamenco_txn_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_flamenco_txn_t * self = (fd_flamenco_txn_t *)mem;
-  fd_flamenco_txn_new( self );
-  void *   alloc_region = (uchar *)mem + sizeof(fd_flamenco_txn_t);
-  void * * alloc_mem    = &alloc_region;
-  fd_flamenco_txn_decode_inner_global( mem, alloc_mem, ctx );
-  return self;
-}
-
-int
-fd_flamenco_txn_convert_global_to_local( void const * global_self, fd_flamenco_txn_t * self, fd_bincode_decode_ctx_t * ctx ) {
-  FD_LOG_ERR(("TODO: Implement"));
-}
-
-void
-fd_flamenco_txn_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  FD_LOG_ERR(("TODO: Implement"));
-}
-
-
 void
 fd_gossip_ip4_addr_walk( void *                       w,
                          fd_gossip_ip4_addr_t const * self,
@@ -114,6 +109,10 @@ fd_gossip_ip6_addr_walk( void *                       w,
 }
 
 int fd_tower_sync_encode( fd_tower_sync_t const * self, fd_bincode_encode_ctx_t * ctx ) {
+  FD_LOG_ERR(( "todo"));
+}
+
+int fd_tower_sync_encode_global( fd_tower_sync_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   FD_LOG_ERR(( "todo"));
 }
 

--- a/src/flamenco/types/fd_types_custom.h
+++ b/src/flamenco/types/fd_types_custom.h
@@ -77,9 +77,6 @@ typedef struct fd_txnstatusidx fd_txnstatusidx_t;
 typedef uint fd_gossip_ip4_addr_t;
 typedef uint fd_gossip_ip4_addr_t;
 
-typedef uint fd_gossip_ip4_addr_global_t;
-typedef uint fd_gossip_ip4_addr_global_t;
-
 /* IPv6 ***************************************************************/
 
 union fd_gossip_ip6_addr {
@@ -125,7 +122,6 @@ struct fd_flamenco_txn {
 };
 
 typedef struct fd_flamenco_txn fd_flamenco_txn_t;
-typedef struct fd_flamenco_txn fd_flamenco_txn_global_t;
 
 
 static inline void
@@ -144,6 +140,15 @@ fd_flamenco_txn_encode( fd_flamenco_txn_t const * self,
                         fd_bincode_encode_ctx_t * ctx ) {
   return fd_bincode_bytes_encode( self->raw, self->raw_sz, ctx );
 }
+
+
+int FD_FN_UNUSED
+fd_flamenco_txn_encode_global( fd_flamenco_txn_t const * self,
+                               fd_bincode_encode_ctx_t * ctx );
+
+void * FD_FN_UNUSED
+fd_flamenco_txn_decode_global( void *                    mem,
+                               fd_bincode_decode_ctx_t * ctx );
 
 static inline void
 fd_flamenco_txn_walk( void *                    w,
@@ -184,15 +189,6 @@ fd_flamenco_txn_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 
 void
 fd_flamenco_txn_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-
-void
-fd_flamenco_txn_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
-
-void *
-fd_flamenco_txn_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-
-int
-fd_flamenco_txn_convert_global_to_local( void const * global_self, fd_flamenco_txn_t * self, fd_bincode_decode_ctx_t * ctx );
 
 /* Represents the lamport balance associated with an account. */
 typedef ulong fd_acc_lamports_t;


### PR DESCRIPTION
1. make it so global types decode supports nested local pointers
2. remove global types that don't need to be global
3. add global encodes