### PR TITLE
`ci/nightly`: skip clusterfuzz nightly job if it failed

### DIFF
--- a/.github/workflows/on_nightly.yml
+++ b/.github/workflows/on_nightly.yml
@@ -9,6 +9,7 @@ jobs:
     uses: ./.github/workflows/coverage_report_clusterfuzz.yml
     secrets: inherit
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '30 11 * * *' }}
+    continue-on-error: true # I believe this should just be deprecated since ClusterFuzz is no more.
   coverage-report:
     uses: ./.github/workflows/coverage_report.yml
     secrets: inherit


### PR DESCRIPTION
ClusterFuzz is no more, not sure how useful this job is. We can hook it up to the current fuzzer corpora if that's a priority.