### PR TITLE
flamenco: add owner check in fd_executor_lookup_native_program

### DIFF
--- a/contrib/test/test-vectors-fixtures/txn-fixtures/program-tests.list
+++ b/contrib/test/test-vectors-fixtures/txn-fixtures/program-tests.list
@@ -1919,6 +1919,7 @@ dump/test-vectors/txn/fixtures/programs/9d45f7478d50b40dd4883e5eb4970b075a5deb45
 dump/test-vectors/txn/fixtures/programs/9d45f7478d50b40dd4883e5eb4970b075a5deb45_3293287.fix
 dump/test-vectors/txn/fixtures/programs/9d763cea6739a560ce16ef2f9d47812c00aec14a_265678.fix
 dump/test-vectors/txn/fixtures/programs/9d98845ab80ae919a4c32b43c7ce2db8b2da2bb0_265678.fix
+dump/test-vectors/txn/fixtures/programs/9da3a0d88d15613311e43d03cb97e28961bdca77_3938735.fix
 dump/test-vectors/txn/fixtures/programs/9da4f42a875bafad9ebbdec34e463e7424101540_265678.fix
 dump/test-vectors/txn/fixtures/programs/9dacaaaf67b58eb8428385fc80972cd1f7f74260_265678.fix
 dump/test-vectors/txn/fixtures/programs/9db0d6ac727a2378226657a9b039ab9a89310ed6_265678.fix

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -45,8 +45,10 @@ typedef int (* fd_exec_instr_fn_t)( fd_exec_instr_ctx_t * ctx );
    processor for the given native program ID.  Returns NULL if given ID
    is not a recognized native program. */
 
-fd_exec_instr_fn_t
-fd_executor_lookup_native_program( fd_txn_account_t const * account );
+int
+fd_executor_lookup_native_program( fd_txn_account_t const * prog_acc,
+                                   fd_exec_txn_ctx_t *      txn_ctx,
+                                   fd_exec_instr_fn_t *     native_prog_fn );
 
 fd_exec_instr_fn_t
 fd_executor_lookup_native_precompile_program( fd_txn_account_t const * prog_acc );


### PR DESCRIPTION
https://github.com/anza-xyz/agave/pull/5207 fixed a bug in the implementation of `remove_accounts_executable_flag_checks`