### PR TITLE
Fix incorrect parameter in `eval_bit_and` function when calling `eval_` in generate_filters.py

### DIFF
--- a/contrib/codegen/generate_filters.py
+++ b/contrib/codegen/generate_filters.py
@@ -240,7 +240,7 @@ def eval_bit_and(filt, op1, op2, label_t, label_f):
 
     elif op2_type is tuple and op1_type is not tuple:
         # eval op2 and do operation with op1 imm
-        eval_(op2, 0, 0)
+        eval_(op2, filt, 0, 0)
         # accu now contains the eval res of op2
         filt.append("{ BPF_ALU | BPF_AND | BPF_K, 0, 0, %s }" % str(op1))
     else:


### PR DESCRIPTION
**Description**  
In the `eval_bit_and` function within `generate_filters.py`, the second parameter for `eval_` was mistakenly set to `0` instead of `filt` in the branch where `op2` is a tuple but `op1` is not. This caused incorrect behavior (or a potential error) when generating BPF instructions, as `eval_` was not receiving the correct list reference to append instructions to.

```python
# Original (incorrect)
elif op2_type is tuple and op1_type is not tuple:
    eval_(op2, 0, 0)

# Fixed
elif op2_type is tuple and op1_type is not tuple:
    eval_(op2, filt, 0, 0)
```