### PR TITLE
fix(seccomp): remove trailing colon in readlink policy to allow readlink calls

### DIFF
--- a/src/discof/batch/fd_batch_tile.seccomppolicy
+++ b/src/discof/batch/fd_batch_tile.seccomppolicy
@@ -72,4 +72,4 @@ read: (or (eq (arg 0) tmp_fd)
           (eq (arg 0) tmp_inc_fd))
 
 # snapshot
-readlink:
+readlink


### PR DESCRIPTION
In fd_batch_tile.seccomppolicy, the readlink: entry is incorrectly configured with a trailing colon and no follow-up expression. This causes generate_filters.py to treat the line as having an empty expression, ultimately denying readlink system calls rather than allowing them.
```
# Original (incorrect)
readlink:

# Correct (remove or properly define the policy)
readlink
# or
readlink: (conditional expressions if needed)
```
As a result, any function—such as produce_snapshot—that relies on readlink("/proc/self/fd/...") will fail, causing the snapshot process to abort with a “Failed to readlink the snapshot file” error.


