### PR TITLE
fix(seccomp): remove the narrower read rule to keep the broader intent

### DIFF
--- a/src/discof/rpc/fd_rpcserv_tile.seccomppolicy
+++ b/src/discof/rpc/fd_rpcserv_tile.seccomppolicy
@@ -68,8 +68,5 @@ close: (not (or (eq (arg 0) 2)
 # arg 2 is the timeout.
 poll: (eq (arg 2) 0)
 
-# blockstore: read archival file
-read: (eq (arg 0) blockstore_fd)
-
 # blockstore: lseek archival file
 lseek: (eq (arg 0) blockstore_fd)


### PR DESCRIPTION
**Description**  

**What’s the issue?**  
- In `fd_rpcserv_tile.seccomppolicy`, two `read` rules were defined:
  1. A broader rule allowing reads for all file descriptors except `2`, `logfile_fd`, and `rpcserv_socket_fd`.
  2. A narrower rule permitting reads only from `blockstore_fd`.
- Because `generate_filters.py` overwrites earlier rules with later ones, the second rule effectively replaced the first, causing all `read` operations on other FDs to be denied.

**Why it matters**  
- The first rule was meant to allow a wide range of valid `read` operations and only restrict a few specific descriptors.  
- Overwriting it with the second rule severely limited allowed `read` calls, breaking the intended security boundary and potentially hindering functionality.

**What changed?**  
- Removed the second `read` rule (that only allows `blockstore_fd`), ensuring the broader first rule remains effective.

**Impact**  
- With the narrower rule removed, the security policy reverts to allowing reads on all file descriptors except `2`, `logfile_fd`, and `rpcserv_socket_fd`.  
- This aligns with the original intent and should resolve issues where valid reads were previously denied.