### PR TITLE
replay, bpf_loader_program: support un-setting upgrade authority address

### DIFF
--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -1446,7 +1446,12 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
 
         /* copy in the authority public key into the upgrade authority address.
            https://github.com/anza-xyz/agave/blob/v2.1.14/programs/bpf_loader/src/lib.rs#L946-L949 */
-        memcpy( account_state->inner.program_data.upgrade_authority_address, new_authority, sizeof(fd_pubkey_t) );
+        if( new_authority ) {
+          memcpy( account_state->inner.program_data.upgrade_authority_address, new_authority, sizeof(fd_pubkey_t) );
+        } else {
+          account_state->inner.program_data.upgrade_authority_address = NULL;
+        }
+
         err = fd_bpf_loader_v3_program_set_state( &account, account_state );
         if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
           return err;

--- a/src/flamenco/runtime/tests/run_ledger_tests_all.txt
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.txt
@@ -76,3 +76,4 @@ src/flamenco/runtime/tests/run_ledger_test.sh -l v208-zk-sdk-ledger-no-rent -s s
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-327324660 -s snapshot-327324659-85G1Hp5JsY1EiixLgFk1VRacP9bu1EGczBunvuJWgMDw.tar.zst -p 60 -y 16 -m 2000000 -e 327324660 -c 2.1.14
 src/flamenco/runtime/tests/run_ledger_test.sh -l devnet-370199634 -s snapshot-370199633-D8mrtzcNV8iNVarHs4mi55QHrCfmzDScYL8BBYXUHAwW.tar.zst -p 60 -y 16 -m 500000 -e 370199634 -c 2.1.14
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-330219081 -s snapshot-330219080-2QzJWhxjNohZR2xeeFDkxt2UcdvSKZ8HhXaFdRXwg8iC.tar.zst -p 60 -y 16 -m 2000000 -e 330219086 -c 2.1.14
+src/flamenco/runtime/tests/run_ledger_test.sh -l devnet-372721907 -s snapshot-372721906-FtUjok2JfLPwJCRVcioV12M8FWbbJaC91XEJzm4eZy53.tar.zst -p 60 -y 16 -m 2000000 -e 372721910 -c 2.1.14


### PR DESCRIPTION
If the upgrade authority address is None, we should update this correctly.