### PR TITLE
fd_pool_para: fix atomic emulation logic in POOL_(private_cas)

### DIFF
--- a/src/util/tmpl/fd_pool_para.c
+++ b/src/util/tmpl/fd_pool_para.c
@@ -408,7 +408,7 @@ POOL_(private_cas)( ulong volatile * p,
   o = FD_ATOMIC_CAS( p, c, s );
 # else
   o = *p;
-  *p = fd_ulong_if( o==c, s, c );
+  *p = fd_ulong_if( o==c, s, o );
 # endif
   FD_COMPILER_MFENCE();
   return o;


### PR DESCRIPTION
Compare against comment:
https://github.com/firedancer-io/firedancer/blob/a11b37fcc81cea10a3b601ddc33b77b96ff6415e/src/util/fd_util_base.h#L830-L836

Issue, is easy to see with a simple PoC:

```c
#include "../fd_util.h"
#include "../log/fd_log.h"

struct myele {
  uint mynext;
  uint val;
};
typedef struct myele myele_t;

#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wmacro-redefined"


#define FD_HAS_ATOMIC 1

static inline ulong
mypool_private_cas( ulong volatile * p,
                    ulong            c,
                    ulong            s ) {
  ulong o;
  FD_COMPILER_MFENCE();
# if FD_HAS_ATOMIC
  o = FD_ATOMIC_CAS( p, c, s );
# else
  o = *p;
  *p = fd_ulong_if( o==c, s, c );
# endif
  FD_COMPILER_MFENCE();
  return o;
}

#define FD_HAS_ATOMIC 0

static inline ulong
mypool2_private_cas( ulong volatile * p,
                    ulong            c,
                    ulong            s ) {
  ulong o;
  FD_COMPILER_MFENCE();
# if FD_HAS_ATOMIC
  o = FD_ATOMIC_CAS( p, c, s );
# else
  o = *p;
  *p = fd_ulong_if( o==c, s, c );
# endif
  FD_COMPILER_MFENCE();
  return o;
}


int main( int argc,
          char **argv ) {
  (void)argc; (void)argv;
  ulong p = 0;
  ulong c = 1;
  ulong s = 2;
  mypool_private_cas( &p, c, s);
  FD_LOG_NOTICE(( "p %lu c %lu s %lu", p, c, s ));

  p = 0;
  c = 1;
  s = 2;
  mypool2_private_cas( &p, c, s);
  FD_LOG_NOTICE(( "p %lu c %lu s %lu", p, c, s ));
}


NOTICE  04-09 12:10:59.509442 42476  f0   0    src/util/tmpl/test_private_cas.c(56): p 0 c 1 s 2
NOTICE  04-09 12:10:59.509516 42476  f0   0    src/util/tmpl/test_private_cas.c(62): p 1 c 1 s 2
```
