### PR TITLE
flamenco, funk: remove tombstones

### DIFF
--- a/src/choreo/voter/fd_voter.c
+++ b/src/choreo/voter/fd_voter.c
@@ -10,7 +10,7 @@ fd_voter_state( fd_funk_t * funk,
                 fd_funk_rec_key_t const * key ) {
   for( ; ; ) {
     fd_funk_rec_t const * rec = fd_funk_rec_query_try_global( funk, txn, key, NULL, query );
-    if( FD_UNLIKELY( !rec || !!( rec->flags & FD_FUNK_REC_FLAG_ERASE ) ) ) {
+    if( FD_UNLIKELY( !rec ) ) {
       return NULL;
     }
     fd_account_meta_t const * meta = fd_funk_val_const( rec, fd_funk_wksp(funk) );

--- a/src/flamenco/runtime/fd_acc_mgr.c
+++ b/src/flamenco/runtime/fd_acc_mgr.c
@@ -29,7 +29,7 @@ fd_funk_get_acc_meta_readonly( fd_funk_t *            funk,
     if( !txn_out ) txn_out    = dummy_txn_out;
     fd_funk_rec_t const * rec = fd_funk_rec_query_try_global( funk, txn, &id, txn_out, query );
 
-    if( FD_UNLIKELY( !rec || !!( rec->flags & FD_FUNK_REC_FLAG_ERASE ) ) )  {
+    if( FD_UNLIKELY( !rec ) )  {
       fd_int_store_if( !!opt_err, opt_err, FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT );
       return NULL;
     }

--- a/src/flamenco/runtime/program/fd_bpf_program_util.c
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.c
@@ -430,7 +430,6 @@ fd_bpf_scan_and_create_bpf_program_cache_entry_para( fd_exec_slot_ctx_t *    slo
       /* Make a list of rec ptrs to process */
       ulong rec_cnt = 0UL;
       for( ; NULL != rec; rec = fd_funk_txn_next_rec( funk, rec ) ) {
-        if( rec->flags & FD_FUNK_REC_FLAG_ERASE ) continue;
         recs[ rec_cnt ] = rec;
 
         if( rec_cnt==65536UL ) {
@@ -503,7 +502,7 @@ fd_bpf_scan_and_create_bpf_program_cache_entry( fd_exec_slot_ctx_t * slot_ctx,
   for (fd_funk_rec_t const *rec = fd_funk_txn_first_rec( funk, funk_txn );
        NULL != rec;
        rec = fd_funk_txn_next_rec( funk, rec )) {
-    if( !fd_funk_key_is_acc( rec->pair.key ) || ( rec->flags & FD_FUNK_REC_FLAG_ERASE ) ) {
+    if( !fd_funk_key_is_acc( rec->pair.key ) ) {
       continue;
     }
 
@@ -568,7 +567,7 @@ fd_bpf_load_cache_entry( fd_funk_t *                    funk,
     fd_funk_rec_query_t query[1];
     fd_funk_rec_t const * rec = fd_funk_rec_query_try_global(funk, funk_txn, &id, NULL, query);
 
-    if( FD_UNLIKELY( !rec || !!( rec->flags & FD_FUNK_REC_FLAG_ERASE ) ) ) {
+    if( FD_UNLIKELY( !rec ) ) {
       if( fd_funk_rec_query_test( query ) == FD_FUNK_SUCCESS ) {
         return -1;
       } else {

--- a/src/funk/fd_funk_rec.c
+++ b/src/funk/fd_funk_rec.c
@@ -225,7 +225,6 @@ fd_funk_rec_prepare( fd_funk_t *               funk,
     fd_funk_rec_key_copy( rec->pair.key, key );
     fd_funk_val_init( rec );
     rec->tag = 0;
-    rec->flags = 0;
     rec->prev_idx = FD_FUNK_REC_IDX_NULL;
     rec->next_idx = FD_FUNK_REC_IDX_NULL;
   } else {

--- a/src/funk/fd_funk_rec.h
+++ b/src/funk/fd_funk_rec.h
@@ -51,7 +51,6 @@ struct __attribute__((aligned(FD_FUNK_REC_ALIGN))) fd_funk_rec {
 
   uint  txn_cidx;  /* Compressed transaction map index (or compressed FD_FUNK_TXN_IDX if this is in the last published) */
   uint  tag;       /* Internal use only */
-  ulong flags;     /* Flags that indicate how to interpret a record */
 
   /* Note: use of uint here requires FD_FUNK_REC_VAL_MAX to be at most
      UINT_MAX. */
@@ -64,6 +63,7 @@ struct __attribute__((aligned(FD_FUNK_REC_ALIGN))) fd_funk_rec {
                       fd_funk_alloc(). IMPORTANT! HAS NO GUARANTEED ALIGNMENT! */
 
   /* Padding to FD_FUNK_REC_ALIGN here */
+  ulong padding; /* Unused field. Can be repurposed for future use. */
 };
 
 typedef struct fd_funk_rec fd_funk_rec_t;

--- a/src/funk/fd_funk_val.c
+++ b/src/funk/fd_funk_val.c
@@ -10,8 +10,7 @@ fd_funk_val_truncate( fd_funk_rec_t * rec,
   /* Check input args */
 
 #ifdef FD_FUNK_HANDHOLDING
-  if( FD_UNLIKELY( (!rec) | (new_val_sz>FD_FUNK_REC_VAL_MAX) | (!alloc) | (!wksp) ) ||  /* NULL rec,too big,NULL alloc,NULL wksp */
-      FD_UNLIKELY( rec->flags & FD_FUNK_REC_FLAG_ERASE                            ) ) { /* Marked erase */
+  if( FD_UNLIKELY( (!rec) | (new_val_sz>FD_FUNK_REC_VAL_MAX) | (!alloc) | (!wksp) )  /* NULL rec,too big,NULL alloc,NULL wksp */ ) {
     fd_int_store_if( !!opt_err, opt_err, FD_FUNK_ERR_INVAL );
     return NULL;
   }
@@ -99,16 +98,11 @@ fd_funk_val_verify( fd_funk_t * funk ) {
 
     TEST( val_sz<=val_max );
 
-    if( rec->flags & FD_FUNK_REC_FLAG_ERASE ) {
-      TEST( !val_max   );
-      TEST( !val_gaddr );
-    } else {
-      TEST( val_max<=FD_FUNK_REC_VAL_MAX );
-      if( !val_gaddr ) TEST( !val_max );
-      else {
-        TEST( (0UL<val_max) & (val_max<=FD_FUNK_REC_VAL_MAX) );
-        TEST( fd_wksp_tag( wksp, val_gaddr )==wksp_tag );
-      }
+    TEST( val_max<=FD_FUNK_REC_VAL_MAX );
+    if( !val_gaddr ) TEST( !val_max );
+    else {
+      TEST( (0UL<val_max) & (val_max<=FD_FUNK_REC_VAL_MAX) );
+      TEST( fd_wksp_tag( wksp, val_gaddr )==wksp_tag );
     }
   }
 

--- a/src/funk/test_funk_common.hpp
+++ b/src/funk/test_funk_common.hpp
@@ -188,7 +188,7 @@ struct fake_funk {
 
       fd_funk_txn_t * txn2 = get_real_txn(txn);
       auto key = rec->real_id();
-      assert(fd_funk_rec_remove(_real, txn2, &key, NULL, 0UL) == FD_FUNK_SUCCESS);
+      assert(fd_funk_rec_remove(_real, txn2, &key, NULL) == FD_FUNK_SUCCESS);
 
       rec->_erased = true;
       rec->_data.clear();
@@ -348,10 +348,8 @@ struct fake_funk {
         assert(j != recs.end());
         auto * rec2 = *j;
         if (rec2->_erased) {
-          assert(rec->flags & FD_FUNK_REC_FLAG_ERASE);
           assert(fd_funk_val_sz(rec) == 0);
         } else {
-          assert(!(rec->flags & FD_FUNK_REC_FLAG_ERASE));
           assert(fd_funk_val_sz(rec) == rec2->size());
           assert(memcmp(fd_funk_val(rec, _wksp), rec2->data(), rec2->size()) == 0);
         }
@@ -360,10 +358,7 @@ struct fake_funk {
         fd_funk_txn_t * txn = fd_funk_txn_query( xid, &txn_map );
         fd_funk_rec_query_t query[1];
         auto* rec3 = fd_funk_rec_query_try_global(_real, txn, rec->pair.key, NULL, query);
-        if( ( rec->flags & FD_FUNK_REC_FLAG_ERASE ) )
-          assert(rec3 == NULL);
-        else
-          assert(rec == rec3);
+        assert(rec == rec3);
         assert(!fd_funk_rec_query_test( query ));
 
         assert(!rec2->_touched);

--- a/src/funk/test_funk_rec.c
+++ b/src/funk/test_funk_rec.c
@@ -4,8 +4,6 @@
 
 FD_STATIC_ASSERT( FD_FUNK_REC_ALIGN    == 64UL, unit_test );
 
-FD_STATIC_ASSERT( FD_FUNK_REC_FLAG_ERASE==1UL, unit_test );
-
 FD_STATIC_ASSERT( FD_FUNK_REC_IDX_NULL==UINT_MAX, unit_test );
 
 #include "test_funk_common.h"
@@ -112,14 +110,14 @@ main( int     argc,
       FD_TEST( !fd_funk_rec_query_test( rec_query ) );
 
 #ifdef FD_FUNK_HANDHOLDING
-      FD_TEST( fd_funk_rec_remove( NULL, NULL, NULL, NULL, 0UL )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( NULL, NULL, tkey, NULL, 0UL )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst, NULL, NULL, NULL, 0UL )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( NULL, NULL, NULL, NULL )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( NULL, NULL, tkey, NULL )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( tst, NULL, NULL, NULL )==FD_FUNK_ERR_INVAL );
 #endif
 
       if( trec ) {
         if( is_frozen ) {
-          FD_TEST( fd_funk_rec_remove( tst, NULL, tkey, NULL, 0UL )==FD_FUNK_ERR_FROZEN );
+          FD_TEST( fd_funk_rec_remove( tst, NULL, tkey, NULL )==FD_FUNK_ERR_FROZEN );
         }
       }
 
@@ -201,13 +199,13 @@ main( int     argc,
       FD_TEST( !fd_funk_rec_query_test( rec_query ) );
 
 #ifdef FD_FUNK_HANDHOLDING
-      FD_TEST( fd_funk_rec_remove( NULL, ttxn, NULL, NULL, 0UL )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( NULL, ttxn, tkey, NULL, 0UL )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst, ttxn, NULL, NULL, 0UL )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( NULL, ttxn, NULL, NULL )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( NULL, ttxn, tkey, NULL )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( tst, ttxn, NULL, NULL )==FD_FUNK_ERR_INVAL );
 #endif
 
       if( trec && ttxn_is_frozen ) {
-        FD_TEST( fd_funk_rec_remove( tst, ttxn, tkey, NULL, 0UL )==FD_FUNK_ERR_FROZEN );
+        FD_TEST( fd_funk_rec_remove( tst, ttxn, tkey, NULL )==FD_FUNK_ERR_FROZEN );
       }
 
       fd_funk_rec_prepare_t rec_prepare[1];
@@ -343,7 +341,7 @@ main( int     argc,
       FD_TEST( !fd_funk_rec_query_test( query ) );
 
       fd_funk_rec_t * trec2;
-      FD_TEST( !fd_funk_rec_remove( tst, ttxn, key_set( tkey, rkey ), &trec2, 0UL ) );
+      FD_TEST( !fd_funk_rec_remove( tst, ttxn, key_set( tkey, rkey ), &trec2 ) );
       FD_TEST( trec == trec2 );
 
     } else if( op>=2 ) { /* Prepare 8x as publish and cancel combined */

--- a/src/funk/test_funk_val.c
+++ b/src/funk/test_funk_val.c
@@ -170,7 +170,7 @@ main( int     argc,
       rec_remove( ref, rrec );
 
       fd_funk_txn_t * ttxn = rxid ? fd_funk_txn_query( xid_set( txid, rxid ), &txn_map ) : NULL;
-      FD_TEST( !fd_funk_rec_remove( tst, ttxn, key_set( tkey, rkey ), NULL, 0UL ) );
+      FD_TEST( !fd_funk_rec_remove( tst, ttxn, key_set( tkey, rkey ), NULL ) );
 
     } else if( op>=2 ) { /* Prepare 8x as publish and cancel combined */
 


### PR DESCRIPTION
Now that we do not support snapshots, we can remove tombstones from Funk. This has several benefits: simplifying the LRU logic, saving space and simplifying the Funk logic.