### PR TITLE
Fix: update fd_log.c filename behavior

### DIFF
--- a/src/util/log/fd_log.c
+++ b/src/util/log/fd_log.c
@@ -21,6 +21,7 @@
 #define _GNU_SOURCE
 
 #include "fd_log.h"
+#include "../../app/fdctl/version.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -1027,7 +1028,7 @@ fd_log_private_open_path( int          cmdline,
     fd_log_wallclock_cstr( fd_log_wallclock(), tag );
     for( ulong b=0UL; tag[b]; b++ ) if( tag[b]==' ' || tag[b]=='-' || tag[b]=='.' || tag[b]==':' ) tag[b] = '_';
     ulong len; fd_cstr_printf( fd_log_private_path, 1024UL, &len, "/tmp/fd-%i.%i.%i_%lu_%s_%s_%s",
-                              FD_VERSION_MAJOR, FD_VERSION_MINOR, FD_VERSION_PATCH,
+                              FIREDANCER_VERSION_MAJOR, FIREDANCER_VERSION_MINOR, FIREDANCER_VERSION_PATCH,
                               fd_log_group_id(), fd_log_user(), fd_log_host(), tag );
     if( len==1023UL ) { fd_log_private_fprintf_0( STDERR_FILENO, "default log path too long; unable to boot\n" ); exit(1); }
   }


### PR DESCRIPTION
Match the version to ensured consistency with other logging components

Fix #4705 