### PR TITLE
ctype.h considered harmful and other cleanups

### DIFF
--- a/src/ballet/toml/fd_toml.c
+++ b/src/ballet/toml/fd_toml.c
@@ -315,7 +315,7 @@ fd_toml_parse_escaped( fd_toml_parser_t * parser ) {
     return 1;
   case 'u':
     if( FD_UNLIKELY( fd_toml_avail( parser ) < 4UL ) ) return 0;
-    for( ulong j=0; j<4; j++ ) valid &= ( !!isxdigit( parser->c.data[j] ) );
+    for( ulong j=0; j<4; j++ ) valid &= fd_isxdigit( parser->c.data[j] );
     if( FD_UNLIKELY( !valid ) ) return 0;
     rune  = ( fd_toml_xdigit( parser->c.data[0] )<<12 );
     rune |= ( fd_toml_xdigit( parser->c.data[1] )<< 8 );
@@ -326,7 +326,7 @@ fd_toml_parse_escaped( fd_toml_parser_t * parser ) {
     return 1;
   case 'U':
     if( FD_UNLIKELY( fd_toml_avail( parser ) < 8UL ) ) return 0;
-    for( ulong j=0; j<8; j++ ) valid &= ( !!isxdigit( parser->c.data[j] ) );
+    for( ulong j=0; j<8; j++ ) valid &= fd_isxdigit( parser->c.data[j] );
     if( FD_UNLIKELY( !valid ) ) return 0;
     rune  = ( fd_toml_xdigit( parser->c.data[0] )<<28 );
     rune |= ( fd_toml_xdigit( parser->c.data[1] )<<24 );
@@ -971,8 +971,8 @@ fd_toml_parse_zero_prefixable_int( fd_toml_parser_t * parser,
     if( FD_UNLIKELY( allow_underscore && parser->c.data[0] == '_' ) ) {
       allow_underscore = 0;
       fd_toml_advance_inline( parser, 1UL );
-      if( FD_UNLIKELY( !fd_toml_avail( parser )      ) ) return 0;
-      if( FD_UNLIKELY( !isdigit( parser->c.data[0] ) ) ) return 0;
+      if( FD_UNLIKELY( !fd_toml_avail( parser )         ) ) return 0;
+      if( FD_UNLIKELY( !fd_isdigit( parser->c.data[0] ) ) ) return 0;
     } else {
       int digit = (uchar)parser->c.data[0];
       if( FD_UNLIKELY(
@@ -983,7 +983,7 @@ fd_toml_parse_zero_prefixable_int( fd_toml_parser_t * parser,
       }
       fd_toml_advance_inline( parser, 1UL );
       if( !fd_toml_avail( parser ) ) break;
-      if( !isdigit( parser->c.data[0] ) && parser->c.data[0] != '_' ) break;
+      if( !fd_isdigit( parser->c.data[0] ) && parser->c.data[0] != '_' ) break;
       allow_underscore = 1;
     }
   }
@@ -1041,10 +1041,10 @@ fd_toml_parse_dec_int( fd_toml_parser_t * parser ) {
 
 static int
 fd_toml_parse_hex_int( fd_toml_parser_t * parser ) {
-  if( FD_UNLIKELY( fd_toml_avail( parser ) < 3    ) ) return 0;
-  if( FD_UNLIKELY( parser->c.data[0] != '0'       ) ) return 0;
-  if( FD_UNLIKELY( parser->c.data[1] != 'x'       ) ) return 0;
-  if( FD_UNLIKELY( !isxdigit( parser->c.data[2] ) ) ) return 0;  /* at least one digit */
+  if( FD_UNLIKELY( fd_toml_avail( parser ) < 3       ) ) return 0;
+  if( FD_UNLIKELY( parser->c.data[0] != '0'          ) ) return 0;
+  if( FD_UNLIKELY( parser->c.data[1] != 'x'          ) ) return 0;
+  if( FD_UNLIKELY( !fd_isxdigit( parser->c.data[2] ) ) ) return 0;  /* at least one digit */
   fd_toml_advance_inline( parser, 2UL );
 
   ulong res = 0UL;
@@ -1054,10 +1054,10 @@ fd_toml_parse_hex_int( fd_toml_parser_t * parser ) {
     if( FD_UNLIKELY( allow_underscore && digit == '_' ) ) {
       allow_underscore = 0;
       fd_toml_advance_inline( parser, 1UL );
-      if( FD_UNLIKELY( !fd_toml_avail( parser )       ) ) return 0;
-      if( FD_UNLIKELY( !isxdigit( parser->c.data[0] ) ) ) return 0;
+      if( FD_UNLIKELY( !fd_toml_avail( parser )          ) ) return 0;
+      if( FD_UNLIKELY( !fd_isxdigit( parser->c.data[0] ) ) ) return 0;
     } else {
-      if( !isxdigit( digit ) ) break;
+      if( !fd_isxdigit( digit ) ) break;
       if( FD_UNLIKELY( res>>60 ) ) {
         parser->error = FD_TOML_ERR_RANGE;
         return 0;
@@ -1319,16 +1319,16 @@ fd_toml_parse_full_date( fd_toml_parser_t * parser,
                          struct tm *        time ) {
   if( FD_UNLIKELY( fd_toml_avail( parser ) < 10 ) ) return 0;
 
-  if( ( !isdigit( parser->c.data[0] ) )      |
-      ( !isdigit( parser->c.data[1] ) )      |
-      ( !isdigit( parser->c.data[2] ) )      |
-      ( !isdigit( parser->c.data[3] ) )      |
-                ( parser->c.data[4] != '-' ) |
-      ( !isdigit( parser->c.data[5] ) )      |
-      ( !isdigit( parser->c.data[6] ) )      |
-                ( parser->c.data[7] != '-' ) |
-      ( !isdigit( parser->c.data[8] ) ) |
-      ( !isdigit( parser->c.data[9] ) ) ) {
+  if( ( !fd_isdigit( parser->c.data[0] ) )      |
+      ( !fd_isdigit( parser->c.data[1] ) )      |
+      ( !fd_isdigit( parser->c.data[2] ) )      |
+      ( !fd_isdigit( parser->c.data[3] ) )      |
+                   ( parser->c.data[4] != '-' ) |
+      ( !fd_isdigit( parser->c.data[5] ) )      |
+      ( !fd_isdigit( parser->c.data[6] ) )      |
+                   ( parser->c.data[7] != '-' ) |
+      ( !fd_isdigit( parser->c.data[8] ) ) |
+      ( !fd_isdigit( parser->c.data[9] ) ) ) {
     return 0;
   }
 
@@ -1362,9 +1362,9 @@ fd_toml_parse_time_delim( fd_toml_parser_t * parser ) {
 static int
 fd_toml_parse_time_secfrac( fd_toml_parser_t * parser,
                             ulong *            pnanos ) {
-  if( fd_toml_avail( parser ) < 2                  ) return 0;
-  if( parser->c.data[0] != '.'                     ) return 0;
-  if( FD_UNLIKELY( !isdigit( parser->c.data[1] ) ) ) return 0;
+  if( fd_toml_avail( parser ) < 2                     ) return 0;
+  if( parser->c.data[0] != '.'                        ) return 0;
+  if( FD_UNLIKELY( !fd_isdigit( parser->c.data[1] ) ) ) return 0;
   fd_toml_advance_inline( parser, 1UL );
 
   ulong secfrac = 0UL;
@@ -1374,7 +1374,7 @@ fd_toml_parse_time_secfrac( fd_toml_parser_t * parser,
     secfrac = secfrac * 10UL + (ulong)( digit - '0' );
     fd_toml_advance_inline( parser, 1UL );
     len++;
-  } while( fd_toml_avail( parser ) && isdigit( parser->c.data[0] ) );
+  } while( fd_toml_avail( parser ) && fd_isdigit( parser->c.data[0] ) );
   if( FD_UNLIKELY( len > 9 ) ) {
     FD_LOG_WARNING(( "TOML parse error: invalid time fraction format" ));
     return 0;
@@ -1395,14 +1395,14 @@ fd_toml_parse_partial_time( fd_toml_parser_t * parser,
                             ulong *            pnanos ) {
 
   if( FD_UNLIKELY( fd_toml_avail( parser ) < 8 ) ) return 0;
-  if( ( !isdigit( parser->c.data[0] ) )      |
-      ( !isdigit( parser->c.data[1] ) )      |
-                ( parser->c.data[2] != ':' ) |
-      ( !isdigit( parser->c.data[3] ) )      |
-      ( !isdigit( parser->c.data[4] ) )      |
-                ( parser->c.data[5] != ':' ) |
-      ( !isdigit( parser->c.data[6] ) )      |
-      ( !isdigit( parser->c.data[7] ) ) ) {
+  if( ( !fd_isdigit( parser->c.data[0] ) )      |
+      ( !fd_isdigit( parser->c.data[1] ) )      |
+                   ( parser->c.data[2] != ':' ) |
+      ( !fd_isdigit( parser->c.data[3] ) )      |
+      ( !fd_isdigit( parser->c.data[4] ) )      |
+                   ( parser->c.data[5] != ':' ) |
+      ( !fd_isdigit( parser->c.data[6] ) )      |
+      ( !fd_isdigit( parser->c.data[7] ) ) ) {
     return 0;
   }
 
@@ -1446,11 +1446,11 @@ fd_toml_parse_time_numoffset( fd_toml_parser_t * parser,
   fd_toml_advance_inline( parser, 1UL );
 
   if( FD_UNLIKELY( fd_toml_avail( parser ) < 5   ) ) return 0;
-  if( ( !isdigit( parser->c.data[0] ) ) |
-      ( !isdigit( parser->c.data[1] ) ) |
-                ( parser->c.data[2] != ':' ) |
-      ( !isdigit( parser->c.data[3] ) ) |
-      ( !isdigit( parser->c.data[4] ) ) ) {
+  if( ( !fd_isdigit( parser->c.data[0] ) ) |
+      ( !fd_isdigit( parser->c.data[1] ) ) |
+                   ( parser->c.data[2] != ':' ) |
+      ( !fd_isdigit( parser->c.data[3] ) ) |
+      ( !fd_isdigit( parser->c.data[4] ) ) ) {
     FD_LOG_WARNING(( "TOML parse error: invalid time offset format" ));
     return 0;
   }
@@ -1768,7 +1768,6 @@ fd_toml_parse( void const *         toml,
     .scratch_cur = scratch,
     .scratch_end = scratch + scratch_sz
   }};
-
 
   int ok = fd_toml_parse_toml( parser );
   opt_err->line = parser->c.lineno;

--- a/src/flamenco/runtime/fd_blockstore.h
+++ b/src/flamenco/runtime/fd_blockstore.h
@@ -118,8 +118,6 @@ static const fd_shred_key_t     fd_shred_key_null = { 0 };
 #define FD_SHRED_KEY_EQ(k0,k1)  (!(((k0).slot) ^ ((k1).slot))) & !(((k0).idx) ^ (((k1).idx)))
 #define FD_SHRED_KEY_HASH(key)  ((uint)(((key).slot)<<15UL) | (((key).idx))) /* current max shred idx is 32KB = 2 << 15*/
 
-
-
 /* fd_buf_shred is a thin wrapper around fd_shred_t that facilitates
    buffering data shreds before all the shreds for a slot have been
    received. After all shreds are received, these buffered shreds are
@@ -166,7 +164,7 @@ typedef struct fd_buf_shred fd_buf_shred_t;
 #define MAP_KEY_EQ(k0,k1)      (FD_SHRED_KEY_EQ(*k0,*k1))
 #define MAP_KEY_EQ_IS_SLOW     1
 #define MAP_KEY_HASH(key,seed) (FD_SHRED_KEY_HASH(*key)^seed)
-#include "../../util/tmpl/fd_map_para.c"
+#include "../../util/tmpl/fd_map_chain_para.c"
 
 #define DEQUE_NAME fd_slot_deque
 #define DEQUE_T    ulong

--- a/src/flamenco/vm/test_vm_instr.c
+++ b/src/flamenco/vm/test_vm_instr.c
@@ -100,14 +100,14 @@ parse_advance( test_parser_t * p,
 
 static void
 parse_assign_sep( test_parser_t * p ) {
-  while( p->cur != p->end && isspace( p->cur[0] ) ) {
+  while( p->cur != p->end && fd_isspace( p->cur[0] ) ) {
     parse_advance( p, 1UL );
   }
   if( p->cur == p->end || p->cur[0] != '=' ) {
     FD_LOG_ERR(( "Expected '=' at %s(%lu)", p->path, p->line ));
   }
   parse_advance( p, 1UL );
-  while( p->cur != p->end && isspace( p->cur[0] ) ) {
+  while( p->cur != p->end && fd_isspace( p->cur[0] ) ) {
     parse_advance( p, 1UL );
   }
 }
@@ -127,7 +127,7 @@ parse_hex_buf( test_parser_t * p,
   while( peek + 1 < p->end ) {
     int c0 = peek[0];
     int c1 = peek[1];
-    if( !isxdigit( c0 ) || !isxdigit( c1 ) ) break;
+    if( !fd_isxdigit( c0 ) || !fd_isxdigit( c1 ) ) break;
     peek += 2;
     sz   += 1;
   }
@@ -141,9 +141,9 @@ parse_hex_buf( test_parser_t * p,
   while( p->cur + 1 < p->end ) {
     int c0 = p->cur[0];
     int c1 = p->cur[1];
-    if( !isxdigit( c0 ) || !isxdigit( c1 ) ) break;
-    int hi = isdigit( c0 ) ? c0 - '0' : tolower( c0 ) - 'a' + 10;
-    int lo = isdigit( c1 ) ? c1 - '0' : tolower( c1 ) - 'a' + 10;
+    if( !fd_isxdigit( c0 ) || !fd_isxdigit( c1 ) ) break;
+    int hi = fd_isdigit( c0 ) ? c0 - '0' : tolower( c0 ) - 'a' + 10;
+    int lo = fd_isdigit( c1 ) ? c1 - '0' : tolower( c1 ) - 'a' + 10;
     *(cur++) = (uchar)( ( hi << 4 ) | lo );
     parse_advance( p, 2UL );
   }
@@ -160,8 +160,8 @@ parse_hex_int( test_parser_t * p ) {
   int   empty = 1;
   while( p->cur != p->end ) {
     int c = p->cur[0];
-    if( !isxdigit( c ) ) break;
-    int digit = isdigit( c ) ? c - '0' : tolower( c ) - 'a' + 10;
+    if( !fd_isxdigit( c ) ) break;
+    int digit = fd_isdigit( c ) ? c - '0' : tolower( c ) - 'a' + 10;
     val <<= 4;
     val  |= (ulong)digit;
     empty = 0;
@@ -187,7 +187,7 @@ static test_fixture_t *
 parse_token( test_parser_t *  p,
              test_fixture_t * out ) {
 
-  while( p->cur != p->end && isspace( p->cur[0] ) ) {
+  while( p->cur != p->end && fd_isspace( p->cur[0] ) ) {
     parse_advance( p, 1UL );
   }
 
@@ -250,7 +250,7 @@ parse_token( test_parser_t *  p,
   char const * word = p->cur;
   while( p->cur != p->end ) {
     int c = p->cur[0];
-    if( isalnum( c ) || c == '_' ) {
+    if( fd_isalnum( c ) || c == '_' ) {
       parse_advance( p, 1UL );
     } else {
       break;
@@ -321,7 +321,7 @@ parse_token( test_parser_t *  p,
     p->effects.status = STATUS_VERIFY_FAIL;
     p->effects.force_exec = 0;
 
-  } else if( word_len >= 2 && word[0] == 'r' && isdigit( word[1] ) ) {
+  } else if( word_len >= 2 && word[0] == 'r' && fd_isdigit( word[1] ) ) {
 
     ulong reg = fd_cstr_to_uchar( word+1 );
     assert( reg < REG_CNT );

--- a/src/funk/fd_funk.c
+++ b/src/funk/fd_funk.c
@@ -204,7 +204,7 @@ fd_funk_delete( void * shfunk ) {
   /* Free all the records */
   fd_alloc_t * alloc = fd_funk_alloc( funk, wksp);
 
-  /* Thread-safe iteration as described in the documentation of fd_map_para.c */
+  /* Thread-safe iteration as described in the documentation of fd_map_chain_para.c */
   fd_funk_rec_map_t rec_map = fd_funk_rec_map( funk, wksp );
   ulong lock_cnt               = fd_funk_rec_map_chain_cnt( &rec_map );
   ulong * lock_seq             = (ulong *)fd_alloc_malloc( alloc, alignof(ulong), sizeof(ulong) * lock_cnt );

--- a/src/funk/fd_funk.h
+++ b/src/funk/fd_funk.h
@@ -172,7 +172,8 @@ struct __attribute__((aligned(FD_FUNK_ALIGN))) fd_funk_private {
 
   /* The funk transaction map stores the details about transactions
      in preparation and their relationships to each other.  This is a
-     fd_map_para/fd_pool_para and more details are given in fd_funk_txn.h
+     fd_map_chain_para/fd_pool_para and more details are given in
+     fd_funk_txn.h
 
      txn_max is the maximum number of transactions that can be in
      preparation.  Due to the use of compressed map indices to reduce
@@ -223,7 +224,8 @@ struct __attribute__((aligned(FD_FUNK_ALIGN))) fd_funk_private {
   /* The funk record map stores the details about all the records in
      the funk, including all those in the last published transaction and
      all those getting updated in an in-preparation translation.  This
-     is a fd_map_para/fd_pool_para and more details are given in fd_funk_rec.h
+     is a fd_map_chain_para/fd_pool_para and more details are given in
+     fd_funk_rec.h
 
      rec_max is the maximum number of records that can exist in this
      funk.

--- a/src/funk/fd_funk_rec.c
+++ b/src/funk/fd_funk_rec.c
@@ -20,7 +20,7 @@
 #define MAP_MAGIC             (0xf173da2ce77ecdb0UL) /* Firedancer rec db version 0 */
 #define MAP_MEMOIZE           1
 #define MAP_IMPL_STYLE        2
-#include "../util/tmpl/fd_map_para.c"
+#include "../util/tmpl/fd_map_chain_para.c"
 
 fd_funk_rec_t const *
 fd_funk_rec_query_try( fd_funk_t *               funk,
@@ -302,8 +302,6 @@ fd_funk_rec_clone( fd_funk_t *               funk,
     }
   }
 }
-
-
 
 int
 fd_funk_rec_is_full( fd_funk_t * funk ) {

--- a/src/funk/fd_funk_rec.h
+++ b/src/funk/fd_funk_rec.h
@@ -69,7 +69,6 @@ struct __attribute__((aligned(FD_FUNK_REC_ALIGN))) fd_funk_rec {
                       has tag wksp_tag) and the owner of the region will be the record. The allocator is
                       fd_funk_alloc(). IMPORTANT! HAS NO GUARANTEED ALIGNMENT! */
 
-
   /* Padding to FD_FUNK_REC_ALIGN here */
 };
 
@@ -103,7 +102,7 @@ FD_STATIC_ASSERT( sizeof(fd_funk_rec_t) == 2U*FD_FUNK_REC_ALIGN, record size is 
 #define MAP_MAGIC             (0xf173da2ce77ecdb0UL) /* Firedancer rec db version 0 */
 #define MAP_MEMOIZE           1
 #define MAP_IMPL_STYLE        1
-#include "../util/tmpl/fd_map_para.c"
+#include "../util/tmpl/fd_map_chain_para.c"
 #undef  MAP_MEMOIZE
 #undef  MAP_HASH
 
@@ -312,7 +311,6 @@ void
 fd_funk_rec_hard_remove( fd_funk_t *               funk,
                          fd_funk_txn_t *           txn,
                          fd_funk_rec_key_t const * key );
-
 
 /* When a record is erased there is metadata stored in the five most
    significant bytes of record flags.  These are helpers to make setting

--- a/src/funk/fd_funk_txn.c
+++ b/src/funk/fd_funk_txn.c
@@ -19,7 +19,7 @@
 #define MAP_HASH              map_hash
 #define MAP_MAGIC             (0xf173da2ce7172db0UL) /* Firedancer txn db version 0 */
 #define MAP_IMPL_STYLE        2
-#include "../util/tmpl/fd_map_para.c"
+#include "../util/tmpl/fd_map_chain_para.c"
 
 /* TODO: remove this lock */
 #include "../flamenco/fd_rwlock.h"

--- a/src/funk/fd_funk_txn.h
+++ b/src/funk/fd_funk_txn.h
@@ -71,7 +71,7 @@ typedef struct fd_funk_txn_private fd_funk_txn_t;
 #define MAP_HASH              map_hash
 #define MAP_MAGIC             (0xf173da2ce7172db0UL) /* Firedancer txn db version 0 */
 #define MAP_IMPL_STYLE        1
-#include "../util/tmpl/fd_map_para.c"
+#include "../util/tmpl/fd_map_chain_para.c"
 #undef  MAP_HASH
 
 FD_PROTOTYPES_BEGIN

--- a/src/util/cstr/fd_cstr.c
+++ b/src/util/cstr/fd_cstr.c
@@ -39,7 +39,7 @@ fd_cstr_to_ulong_seq( char const * cstr,
     char   c;
     char * q;
 
-    c = *p; while( isspace( (int)c ) ) c = *(++p); /* Move and peek at next non-white-space character */
+    c = *p; while( fd_isspace( (int)c ) ) c = *(++p); /* Move and peek at next non-white-space character */
     if( c=='\0' ) break; /* end of sequence */
 
     ulong seq_ele_0 = strtoul( p, &q, 0 );
@@ -49,7 +49,7 @@ fd_cstr_to_ulong_seq( char const * cstr,
     ulong seq_ele_1  = seq_ele_0;
     ulong seq_stride = 1UL;
 
-    c = *p; while( isspace( (int)c ) ) c = *(++p); /* Move and peek at next non-white-space character */
+    c = *p; while( fd_isspace( (int)c ) ) c = *(++p); /* Move and peek at next non-white-space character */
     if( c=='-' ) {
       p++;
 
@@ -57,7 +57,7 @@ fd_cstr_to_ulong_seq( char const * cstr,
       if( FD_UNLIKELY( p==(char const *)q ) ) return 0UL; /* Malformed sequence, seq_ele_1 is not a ulong */
       p = (char const *)q;
 
-      c = *p; while( isspace( (int)c ) ) c = *(++p); /* Move and peek at next non-white-space character */
+      c = *p; while( fd_isspace( (int)c ) ) c = *(++p); /* Move and peek at next non-white-space character */
       if( c=='/' || c==':' ) {
         p++;
 
@@ -67,7 +67,7 @@ fd_cstr_to_ulong_seq( char const * cstr,
       }
     }
 
-    c = *p; while( isspace( (int)c ) ) c = *(++p); /* Move and peek at next non-white-space character */
+    c = *p; while( fd_isspace( (int)c ) ) c = *(++p); /* Move and peek at next non-white-space character */
     if( !(c==',' || c=='\0' ) ) return 0UL; /* Malformed sequence, delimiter */
     if( c==',' ) p++;
 
@@ -76,7 +76,6 @@ fd_cstr_to_ulong_seq( char const * cstr,
        near or equal to ULONG_MAX */
 
     if( FD_UNLIKELY( (seq_ele_1<seq_ele_0) | (!seq_stride) )) return 0UL; /* Malformed sequence, bad range */
-
 
     ulong seq_ele = seq_ele_0;
     while( ((seq_ele_0<=seq_ele) & (seq_ele<seq_ele_1)) ) {
@@ -165,7 +164,7 @@ fd_cstr_tokenize( char ** tok,
   for(;;) {
 
     /* Find token start and record it (if possible) */
-    while( isspace( (int)p[0] ) ) p++;
+    while( fd_isspace( (int)p[0] ) ) p++;
     if( p[0]=='\0' ) break;
     if( tok_cnt<tok_max ) tok[ tok_cnt ] = p;
     tok_cnt++;
@@ -179,4 +178,3 @@ fd_cstr_tokenize( char ** tok,
 
   return tok_cnt;
 }
-

--- a/src/util/cstr/test_cstr.c
+++ b/src/util/cstr/test_cstr.c
@@ -1,4 +1,5 @@
 #include "../fd_util.h"
+#include <ctype.h>
 
 /* FIXME: COVERAGE FOR FD_CSTR_CASECMP, FD_CSTR_TO_ULONG_OCTAL,
    FD_CSTR_APPEND_PRINTF, FD_CSTR_APPEND_CSTR, FD_CSTR_APPEND_CSTR_SAFE,
@@ -253,10 +254,33 @@ main( int     argc,
     strcpy( buf2, "a; b c ;d" ); FD_TEST( fd_cstr_tokenize( tok, 1UL, buf2, ';' )==3UL ); FD_TEST( !strcmp( buf, buf2 ) ); FD_TEST( !strcmp( tok[0], "a" ) );
   } while(0);
 
+  for( ulong i=0UL; i<256UL; i++ ) {
+    char c = (char)i;
+
+    /* Note the compiler will warn (promoted to error) without the
+       volatile because it will detect the result of the macros is
+       always 0 or 1 (which is the whole point of the test). */
+
+    int volatile b;
+
+    b = fd_isalnum (c); FD_TEST( (0<=b) & (b<=1) );
+    b = fd_isalpha (c); FD_TEST( (0<=b) & (b<=1) );
+    b = fd_iscntrl (c); FD_TEST( (0<=b) & (b<=1) );
+    b = fd_isdigit (c); FD_TEST( (0<=b) & (b<=1) );
+    b = fd_isgraph (c); FD_TEST( (0<=b) & (b<=1) );
+    b = fd_islower (c); FD_TEST( (0<=b) & (b<=1) );
+    b = fd_isprint (c); FD_TEST( (0<=b) & (b<=1) );
+    b = fd_ispunct (c); FD_TEST( (0<=b) & (b<=1) );
+    b = fd_isspace (c); FD_TEST( (0<=b) & (b<=1) );
+    b = fd_isupper (c); FD_TEST( (0<=b) & (b<=1) );
+    b = fd_isxdigit(c); FD_TEST( (0<=b) & (b<=1) );
+    b = fd_isascii (c); FD_TEST( (0<=b) & (b<=1) );
+    b = fd_isblank (c); FD_TEST( (0<=b) & (b<=1) );
+  }
+
   fd_rng_delete( fd_rng_leave( rng ) );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();
   return 0;
 }
-

--- a/src/util/log/fd_log.c
+++ b/src/util/log/fd_log.c
@@ -696,7 +696,7 @@ fd_log_private_hexdump_msg( char const * descr,
     FD_LOG_HEXDUMP_ADD_TO_LOG_BUF( " %02x", (uint)(uchar)c );
 
     /* If not a printable ASCII character, output a dot. */
-    line_buf[ col_idx     ] = fd_char_if( isalnum( (int)c ) | ispunct( (int)c ) | (c==' '), c, '.' );
+    line_buf[ col_idx     ] = fd_char_if( fd_isalnum( (int)c ) | fd_ispunct( (int)c ) | (c==' '), c, '.' );
     line_buf[ col_idx+1UL ] = '\0';
   }
 

--- a/src/util/pod/fd_pod_ctl.c
+++ b/src/util/pod/fd_pod_ctl.c
@@ -54,7 +54,7 @@ insert_val( uchar *      pod,
 
 static inline int
 issingleprint( int c ) {
-  return isalnum( c ) | ispunct( c ) | (c==' ');
+  return fd_isalnum( c ) | fd_ispunct( c ) | (c==' ');
 }
 
 static void
@@ -141,7 +141,7 @@ printf_val( fd_pod_info_t const * info ) {
 
   case FD_POD_VAL_TYPE_SCHAR:  { int   i = (int) *(schar *)info->val; printf( "%i", i ); break; }
   case FD_POD_VAL_TYPE_SHORT:
-  case FD_POD_VAL_TYPE_INT: 
+  case FD_POD_VAL_TYPE_INT:
   case FD_POD_VAL_TYPE_LONG:   { ulong u; fd_ulong_svw_dec( info->val, &u ); printf( "%li", fd_long_zz_dec( u ) ); break; }
 
 # if FD_HAS_INT128
@@ -179,7 +179,7 @@ main( int     argc,
 
   if( FD_UNLIKELY( argc<1 ) ) FD_LOG_ERR(( "no arguments" ));
   char const * bin = argv[0];
-  SHIFT(1); 
+  SHIFT(1);
 
   ulong tag = 1UL;
 
@@ -317,7 +317,7 @@ main( int     argc,
       fd_pod_info_t * info;
       ulong info_cnt = fd_pod_cnt_recursive( pod );
       if( FD_UNLIKELY( !info_cnt ) ) info = NULL;
-      else { 
+      else {
         info = (fd_pod_info_t *)aligned_alloc( alignof(fd_pod_info_t), info_cnt*sizeof(fd_pod_info_t) );
         if( FD_UNLIKELY( !info ) ) {
           fd_wksp_unmap( fd_pod_leave( pod ) );
@@ -576,7 +576,6 @@ main( int     argc,
       FD_LOG_NOTICE(( "%i: %s %s %s %s %s: success", cnt, cmd, cstr, type, path, val ));
       SHIFT(4);
 
-
     } else if( !strcmp( cmd, "compact" ) ) {
 
       if( FD_UNLIKELY( argc<2 ) ) FD_LOG_ERR(( "%i: %s: too few arguments\n\tDo %s help for help", cnt, cmd, bin ));
@@ -729,4 +728,3 @@ main( int     argc,
 }
 
 #endif
-

--- a/src/util/shmem/fd_shmem_admin.c
+++ b/src/util/shmem/fd_shmem_admin.c
@@ -666,7 +666,7 @@ fd_shmem_name_len( char const * name ) {
   while( FD_LIKELY( len<FD_SHMEM_NAME_MAX ) ) {
     char c = name[len];
     if( FD_UNLIKELY( !c ) ) break;
-    if( FD_UNLIKELY( !( (!!isalnum( c )) | ((len>0UL) & ((c=='_') | (c=='-') | (c=='.'))) ) ) ) return 0UL; /* Bad character */
+    if( FD_UNLIKELY( !( fd_isalnum( c ) | ((len>0UL) & ((c=='_') | (c=='-') | (c=='.'))) ) ) ) return 0UL; /* Bad character */
     len++;
   }
 

--- a/src/util/shmem/test_shmem.c
+++ b/src/util/shmem/test_shmem.c
@@ -33,7 +33,7 @@ main( int     argc,
   fd_boot( &argc, &argv );
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
-  
+
   ulong numa_cnt = fd_shmem_numa_cnt(); FD_TEST( (1UL<=numa_cnt) & (numa_cnt<=FD_SHMEM_NUMA_MAX) );
   ulong cpu_cnt  = fd_shmem_cpu_cnt (); FD_TEST( (1UL<=cpu_cnt ) & (cpu_cnt <=FD_SHMEM_CPU_MAX ) );
   FD_TEST( numa_cnt<=cpu_cnt );
@@ -76,11 +76,11 @@ main( int     argc,
     ulong expected = len;
     if     ( len< 1UL               ) expected = 0UL; /* too short */
     else if( len>=FD_SHMEM_NAME_MAX ) expected = 0UL; /* too long */
-    else if( !isalnum( name[0] )    ) expected = 0UL; /* invalid first character */
+    else if( !fd_isalnum( name[0] ) ) expected = 0UL; /* invalid first character */
     else
       for( ulong b=1UL; b<len; b++ ) {
         char c = name[b];
-        if( !( isalnum( c ) || (c=='_') || (c=='-') || (c=='.') ) ) { expected = 0UL; break; } /* invalid suffix character */
+        if( !( fd_isalnum( c ) || (c=='_') || (c=='-') || (c=='.') ) ) { expected = 0UL; break; } /* invalid suffix character */
       }
 
     FD_TEST( fd_shmem_name_len( name )==expected );
@@ -435,4 +435,3 @@ main( int     argc,
 }
 
 #endif
-

--- a/src/util/tile/fd_tile_threads.cxx
+++ b/src/util/tile/fd_tile_threads.cxx
@@ -457,22 +457,22 @@ fd_tile_private_cpus_parse( char const * cstr,
   char const * p = cstr;
   for(;;) {
 
-    while( isspace( (int)p[0] ) ) p++; /* Munch whitespace */
+    while( fd_isspace( (int)p[0] ) ) p++; /* Munch whitespace */
 
     if( p[0]=='f' ) { /* These tiles have been requested to float on the original core set */
       p++;
 
       ulong float_cnt;
 
-      while( isspace( (int)p[0] ) ) p++; /* Munch whitespace */
+      while( fd_isspace( (int)p[0] ) ) p++; /* Munch whitespace */
       if     ( p[0]==','             ) float_cnt = 1UL, p++;
       else if( p[0]=='\0'            ) float_cnt = 1UL;
-      else if( !isdigit( (int)p[0] ) ) FD_LOG_ERR(( "fd_tile: malformed --tile-cpus (malformed count)" ));
+      else if( !fd_isdigit( (int)p[0] ) ) FD_LOG_ERR(( "fd_tile: malformed --tile-cpus (malformed count)" ));
       else {
         float_cnt = fd_cstr_to_ulong( p );
         if( FD_UNLIKELY( !float_cnt ) ) FD_LOG_ERR(( "fd_tile: malformed --tile-cpus (bad count)" ));
-        p++; while( isdigit( (int)p[0] ) ) p++; /* FIXME: USE STRTOUL ENDPTR FOR CORRECT HANDLING OF NON-BASE-10 */
-        while( isspace( (int)p[0] ) ) p++; /* Munch whitespace */
+        p++; while( fd_isdigit( (int)p[0] ) ) p++; /* FIXME: USE STRTOUL ENDPTR FOR CORRECT HANDLING OF NON-BASE-10 */
+        while( fd_isspace( (int)p[0] ) ) p++; /* Munch whitespace */
         if( FD_UNLIKELY( !( p[0]==',' || p[0]=='\0' ) ) ) FD_LOG_ERR(( "fd_tile: malformed --tile-cpus (bad count delimiter)" ));
         if( p[0]==',' ) p++;
       }
@@ -486,31 +486,31 @@ fd_tile_private_cpus_parse( char const * cstr,
       continue;
     }
 
-    if( !isdigit( (int)p[0] ) ) {
+    if( !fd_isdigit( (int)p[0] ) ) {
       if( FD_UNLIKELY( p[0]!='\0' ) ) FD_LOG_ERR(( "fd_tile: malformed --tile-cpus (range lo not a cpu)" ));
       break;
     }
     ulong cpu0   = fd_cstr_to_ulong( p );
     ulong cpu1   = cpu0;
     ulong stride = 1UL;
-    p++; while( isdigit( (int)p[0] ) ) p++; /* FIXME: USE STRTOUL ENDPTR FOR CORRECT HANDLING OF NON-BASE-10 */
-    while( isspace( (int)p[0] ) ) p++;
+    p++; while( fd_isdigit( (int)p[0] ) ) p++; /* FIXME: USE STRTOUL ENDPTR FOR CORRECT HANDLING OF NON-BASE-10 */
+    while( fd_isspace( (int)p[0] ) ) p++;
     if( p[0]=='-' ) {
       p++;
-      while( isspace( (int)p[0] ) ) p++;
-      if( FD_UNLIKELY( !isdigit( (int)p[0] ) ) ) FD_LOG_ERR(( "fd_tile: malformed --tile-cpus (range hi not a cpu)" ));
+      while( fd_isspace( (int)p[0] ) ) p++;
+      if( FD_UNLIKELY( !fd_isdigit( (int)p[0] ) ) ) FD_LOG_ERR(( "fd_tile: malformed --tile-cpus (range hi not a cpu)" ));
       cpu1 = fd_cstr_to_ulong( p );
-      p++; while( isdigit( (int)p[0] ) ) p++; /* FIXME: USE STRTOUL ENDPTR FOR CORRECT HANDLING OF NON-BASE-10 */
-      while( isspace( (int)p[0] ) ) p++;
+      p++; while( fd_isdigit( (int)p[0] ) ) p++; /* FIXME: USE STRTOUL ENDPTR FOR CORRECT HANDLING OF NON-BASE-10 */
+      while( fd_isspace( (int)p[0] ) ) p++;
       if( p[0]=='/' || p[0]==':' ) {
         p++;
-        while( isspace( (int)p[0] ) ) p++;
-        if( FD_UNLIKELY( !isdigit( (int)p[0] ) ) ) FD_LOG_ERR(( "fd_tile: malformed --tile-cpus (stride not an int)" ));
+        while( fd_isspace( (int)p[0] ) ) p++;
+        if( FD_UNLIKELY( !fd_isdigit( (int)p[0] ) ) ) FD_LOG_ERR(( "fd_tile: malformed --tile-cpus (stride not an int)" ));
         stride = fd_cstr_to_ulong( p );
-        p++; while( isdigit( (int)p[0] ) ) p++; /* FIXME: USE STRTOUL ENDPTR FOR CORRECT HANDLING OF NON-BASE-10 */
+        p++; while( fd_isdigit( (int)p[0] ) ) p++; /* FIXME: USE STRTOUL ENDPTR FOR CORRECT HANDLING OF NON-BASE-10 */
       }
     }
-    while( isspace( (int)p[0] ) ) p++;
+    while( fd_isspace( (int)p[0] ) ) p++;
     if( FD_UNLIKELY( !( p[0]==',' || p[0]=='\0' ) ) ) FD_LOG_ERR(( "fd_tile: malformed --tile-cpus (bad range delimiter)" ));
     if( p[0]==',' ) p++;
     cpu1++;

--- a/src/util/tmpl/Local.mk
+++ b/src/util/tmpl/Local.mk
@@ -1,4 +1,4 @@
-$(call add-hdrs,fd_bplus.c fd_deque.c fd_deque_dynamic.c fd_dlist.c fd_heap.c fd_map.c fd_map_chain.c fd_map_dynamic.c fd_map_giant.c fd_map_para.c fd_map_slot_para.c fd_pool.c fd_pool_para.c fd_prq.c fd_queue.c fd_queue_dynamic.c fd_redblack.c fd_set.c fd_set_dynamic.c fd_smallset.c fd_sort.c fd_stack.c fd_treap.c fd_vec.c fd_voff.c)
+$(call add-hdrs,fd_bplus.c fd_deque.c fd_deque_dynamic.c fd_dlist.c fd_heap.c fd_map.c fd_map_chain.c fd_map_dynamic.c fd_map_giant.c fd_map_chain_para.c fd_map_slot_para.c fd_pool.c fd_pool_para.c fd_prq.c fd_queue.c fd_queue_dynamic.c fd_redblack.c fd_set.c fd_set_dynamic.c fd_smallset.c fd_sort.c fd_stack.c fd_treap.c fd_vec.c fd_voff.c)
 $(call make-unit-test,test_bplus,test_bplus,fd_util)
 $(call make-unit-test,test_deque,test_deque,fd_util)
 $(call make-unit-test,test_deque_dynamic,test_deque_dynamic,fd_util)
@@ -14,7 +14,7 @@ ifdef FD_HAS_HOSTED # FIXME: HMMM ....
 $(call make-unit-test,test_map_giant_concur,test_map_giant_concur,fd_util)
 endif
 $(call make-unit-test,test_map_perfect,test_map_perfect,fd_util)
-$(call make-unit-test,test_map_para,test_map_para,fd_util) # FIXME: rename to map_chain_para?
+$(call make-unit-test,test_map_chain_para,test_map_chain_para,fd_util)
 $(call make-unit-test,test_map_slot_para,test_map_slot_para,fd_util)
 $(call make-unit-test,test_pool,test_pool,fd_util)
 $(call make-unit-test,test_pool_para,test_pool_para,fd_util)
@@ -42,7 +42,7 @@ $(call run-unit-test,test_map_chain_multi,)
 $(call run-unit-test,test_map_dynamic,)
 $(call run-unit-test,test_map_giant,)
 $(call run-unit-test,test_map_giant_mem,)
-$(call run-unit-test,test_map_para,)
+$(call run-unit-test,test_map_chain_para,)
 $(call run-unit-test,test_map_slot_para,)
 # FIXME: MAP_PERFECT?
 $(call run-unit-test,test_pool,)

--- a/src/util/tmpl/fd_map_chain_para.c
+++ b/src/util/tmpl/fd_map_chain_para.c
@@ -90,7 +90,7 @@
 
      #define MAP_NAME  mymap
      #define MAP_ELE_T myele_t
-     #include "tmpl/fd_map_para.c"
+     #include "tmpl/fd_map_chain_para.c"
 
    will declare the following APIs as a header only style library in the
    compilation unit:

--- a/src/util/tmpl/fd_map_slot_para.c
+++ b/src/util/tmpl/fd_map_slot_para.c
@@ -66,9 +66,9 @@
    concurrency, high algorithmic and implementation performance for
    normal usage and friendly cache / file system streaming access
    patterns for heavily loaded / heavily concurrent usage are
-   prioritized.  In particular, unlike fd_map_para, this takes ownership
-   of the underlying element store for the lifetime of the map in order
-   to speed up operations and increase concurrency.
+   prioritized.  In particular, unlike fd_map_chain_para, this takes
+   ownership of the underlying element store for the lifetime of the map
+   in order to speed up operations and increase concurrency.
 
    Typical usage:
 
@@ -735,7 +735,7 @@
        ... will be to an element compatible memory region that will
        ... continue to exist regardless and we shouldn't be trusting any
        ... query reads yet (the query test will detect if these can be
-       ... trusted).  See rant in fd_map_para.c for more details.
+       ... trusted).  See rant in fd_map_chain_para.c for more details.
 
        ... At this point, we are done with speculative processing (or we
        ... don't want to do any more speculative processing if the try

--- a/src/util/tmpl/test_map_chain_para.c
+++ b/src/util/tmpl/test_map_chain_para.c
@@ -28,7 +28,7 @@ typedef struct myele myele_t;
 #define MAP_MEMOIZE        1
 #define MAP_MEMO           mymemo
 #define MAP_KEY_EQ_IS_SLOW 1
-#include "fd_map_para.c"
+#include "fd_map_chain_para.c"
 
 FD_STATIC_ASSERT( FD_MAP_SUCCESS    == 0, unit_test );
 FD_STATIC_ASSERT( FD_MAP_ERR_INVAL  ==-1, unit_test );


### PR DESCRIPTION
Hmmm ...
```
  $ cat ctype_considered_harmful.c
  #include <stdio.h>
  #include <ctype.h>

  int
  main( int     argc,
        char ** argv ) {
    int bad_standards_make_babies_cry = isspace( '\n' );
    printf( "isspace( '\\n' ) = %i\n", bad_standards_make_babies_cry );
    return 0;
  }
  $ gcc ctype_considered_harmful.c
  $ ./a.out
  isspace( '\n' ) = 8192
```
... see code for more discussions.

Also, by popular demand, renamed fd_map_para to fd_map_chain_para.