### PR TITLE
funk: reduce memory allocation in fd_funk_delete

### DIFF
--- a/src/funk/fd_funk.h
+++ b/src/funk/fd_funk.h
@@ -320,7 +320,11 @@ fd_funk_leave( fd_funk_t * funk );
    nobody is or will be joined to the funk.  Returns shmem on success
    and NULL on failure (logs details).  Reasons for failure include
    shfunk is NULL, misaligned shfunk, shfunk is not backed by a
-   workspace, etc. */
+   workspace, etc.
+
+   This function is NOT thread-safe, and should only be called be a single
+   thread. There should be no other threads using the funk at the time of
+   calling this function. */
 
 void *
 fd_funk_delete( void * shfunk );

--- a/src/funk/fd_funk_rec.c
+++ b/src/funk/fd_funk_rec.c
@@ -532,6 +532,11 @@ fd_funk_all_iter_ele_const( fd_funk_all_iter_t * iter ) {
   return fd_funk_rec_map_iter_ele_const( iter->rec_map_iter );
 }
 
+fd_funk_rec_t *
+fd_funk_all_iter_ele( fd_funk_all_iter_t * iter ) {
+  return fd_funk_rec_map_iter_ele( iter->rec_map_iter );
+}
+
 #ifdef FD_FUNK_HANDHOLDING
 int
 fd_funk_rec_verify( fd_funk_t * funk ) {

--- a/src/funk/fd_funk_rec.h
+++ b/src/funk/fd_funk_rec.h
@@ -367,6 +367,8 @@ void fd_funk_all_iter_next( fd_funk_all_iter_t * iter );
 
 fd_funk_rec_t const * fd_funk_all_iter_ele_const( fd_funk_all_iter_t * iter );
 
+fd_funk_rec_t * fd_funk_all_iter_ele( fd_funk_all_iter_t * iter );
+
 /* Misc */
 
 #ifdef FD_FUNK_HANDHOLDING


### PR DESCRIPTION
Addresses https://github.com/firedancer-io/firedancer/issues/4822

`fd_funk_delete` does not need to be thread-safe so we can remove the locking here, which removes the memory allocation.