### PR TITLE
funk: add placeholder accounts_lru_prev_idx/accounts_lru_next_idx rec fields

### DIFF
--- a/src/app/ledger/main.c
+++ b/src/app/ledger/main.c
@@ -37,7 +37,7 @@ struct fd_ledger_args {
   ulong                 shred_max;               /* maximum number of shreds*/
   ulong                 slot_history_max;        /* number of slots stored by blockstore*/
   ulong                 txns_max;                /* txns_max*/
-  ulong                 index_max;               /* size of funk index (same as rec max) */
+  uint                  index_max;               /* size of funk index (same as rec max) */
   char const *          funk_file;               /* path to funk backing store */
   ulong                 funk_page_cnt;
   fd_funk_close_file_args_t funk_close_args;
@@ -1358,7 +1358,7 @@ initial_setup( int argc, char ** argv, fd_ledger_args_t * args ) {
   ulong        page_cnt              = fd_env_strip_cmdline_ulong ( &argc, &argv, "--page-cnt",              NULL, 5                                                  );
   int          reset                 = fd_env_strip_cmdline_int   ( &argc, &argv, "--reset",                 NULL, 0                                                  );
   char const * cmd                   = fd_env_strip_cmdline_cstr  ( &argc, &argv, "--cmd",                   NULL, NULL                                               );
-  ulong        index_max             = fd_env_strip_cmdline_ulong ( &argc, &argv, "--index-max",             NULL, 450000000                                          );
+  uint        index_max              = fd_env_strip_cmdline_uint  ( &argc, &argv, "--index-max",             NULL, 450000000                                          );
   ulong        txns_max              = fd_env_strip_cmdline_ulong ( &argc, &argv, "--txn-max",               NULL,      1000                                          );
   char const * funk_file             = fd_env_strip_cmdline_cstr  ( &argc, &argv, "--funk-file",             NULL, NULL                                               );
   int          verify_funk           = fd_env_strip_cmdline_int   ( &argc, &argv, "--verify-funky",          NULL, 0                                                  );

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -400,7 +400,7 @@ struct fd_config {
     struct {
       char  capture[ PATH_MAX ];
       char  funk_checkpt[ PATH_MAX ];
-      ulong funk_rec_max;
+      uint  funk_rec_max;
       ulong funk_sz_gb;
       ulong funk_txn_max;
       char  funk_file[ PATH_MAX ];

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -398,7 +398,7 @@ fdctl_pod_to_cfg( config_t * config,
 
   CFG_POP      ( cstr,   tiles.replay.capture                             );
   CFG_POP      ( cstr,   tiles.replay.funk_checkpt                        );
-  CFG_POP      ( ulong,  tiles.replay.funk_rec_max                        );
+  CFG_POP      ( uint,   tiles.replay.funk_rec_max                        );
   CFG_POP      ( ulong,  tiles.replay.funk_sz_gb                          );
   CFG_POP      ( ulong,  tiles.replay.funk_txn_max                        );
   CFG_POP      ( cstr,   tiles.replay.funk_file                           );

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -271,7 +271,7 @@ typedef struct {
       int   tx_metadata_storage;
       char  capture[ PATH_MAX ];
       char  funk_checkpt[ PATH_MAX ];
-      ulong funk_rec_max;
+      uint  funk_rec_max;
       ulong funk_sz_gb;
       ulong funk_txn_max;
       char  funk_file[ PATH_MAX ];

--- a/src/flamenco/runtime/test_txn_rw_conflicts.c
+++ b/src/flamenco/runtime/test_txn_rw_conflicts.c
@@ -324,7 +324,8 @@ main( int     argc,
   int lg_max_naccts   = fd_ulong_find_msb( fd_ulong_pow2_up( FD_TXN_CONFLICT_MAP_MAX_NACCT ) );
   void * acct_map_mem = fd_wksp_alloc_laddr( wksp, fd_conflict_detect_map_align(), fd_conflict_detect_map_footprint( lg_max_naccts ), 1234UL );
   void * acct_arr_mem = fd_wksp_alloc_laddr( wksp, 32UL, sizeof(fd_acct_addr_t)*FD_TXN_CONFLICT_MAP_MAX_NACCT, 1235UL );
-  ulong tag=2345UL, seed=5678UL, txn_max=1024, rec_max=1024;
+  ulong tag=2345UL, seed=5678UL, txn_max=1024;
+  uint rec_max=1024;
   void * funk_mem     = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), tag );
   FD_TEST( funk_mem );
   FD_TEST( acct_arr_mem );

--- a/src/flamenco/runtime/tests/harness/fd_harness_common.c
+++ b/src/flamenco/runtime/tests/harness/fd_harness_common.c
@@ -8,7 +8,7 @@ fd_runtime_fuzz_runner_align( void ) {
 ulong
 fd_runtime_fuzz_runner_footprint( void ) {
   ulong txn_max = 4+fd_tile_cnt();
-  ulong rec_max = 1024UL;
+  uint rec_max  = 1024;
 
   ulong l = FD_LAYOUT_INIT;
   l = FD_LAYOUT_APPEND( l, fd_runtime_fuzz_runner_align(), sizeof(fd_runtime_fuzz_runner_t) );
@@ -22,7 +22,7 @@ fd_runtime_fuzz_runner_new( void * mem,
                             void * spad_mem,
                             ulong  wksp_tag ) {
   ulong txn_max = 4+fd_tile_cnt();
-  ulong rec_max = 1024UL;
+  uint rec_max  = 1024;
 
   FD_SCRATCH_ALLOC_INIT( l, mem );
   void * runner_mem = FD_SCRATCH_ALLOC_APPEND( l, fd_runtime_fuzz_runner_align(), sizeof(fd_runtime_fuzz_runner_t) );

--- a/src/funk/fd_funk.c
+++ b/src/funk/fd_funk.c
@@ -8,7 +8,7 @@ fd_funk_align( void ) {
 
 ulong
 fd_funk_footprint( ulong txn_max,
-                      ulong rec_max ) {
+                   uint  rec_max ) {
 
   ulong l = FD_LAYOUT_INIT;
 
@@ -19,7 +19,7 @@ fd_funk_footprint( ulong txn_max,
   l = FD_LAYOUT_APPEND( l, fd_funk_txn_pool_align(), fd_funk_txn_pool_footprint() );
   l = FD_LAYOUT_APPEND( l, alignof(fd_funk_txn_t), sizeof(fd_funk_txn_t) * txn_max );
 
-  ulong rec_chain_cnt = fd_funk_rec_map_chain_cnt_est( rec_max );
+  ulong rec_chain_cnt = fd_funk_rec_map_chain_cnt_est( (ulong)rec_max );
   l = FD_LAYOUT_APPEND( l, fd_funk_rec_map_align(), fd_funk_rec_map_footprint( rec_chain_cnt ) );
   l = FD_LAYOUT_APPEND( l, fd_funk_rec_pool_align(), fd_funk_rec_pool_footprint() );
   l = FD_LAYOUT_APPEND( l, alignof(fd_funk_rec_t), sizeof(fd_funk_rec_t) * rec_max );
@@ -38,7 +38,7 @@ fd_funk_new( void * shmem,
              ulong  wksp_tag,
              ulong  seed,
              ulong  txn_max,
-             ulong  rec_max ) {
+             uint   rec_max ) {
   fd_funk_t * funk = (fd_funk_t *)shmem;
   fd_wksp_t * wksp = fd_wksp_containing( funk );
 
@@ -300,8 +300,8 @@ fd_funk_verify( fd_funk_t * funk ) {
   TEST( rec_chain_cnt==fd_funk_rec_map_chain_cnt( &rec_map ) );
   TEST( seed==fd_funk_rec_map_seed( &rec_map ) );
 
-  ulong rec_head_idx = funk->rec_head_idx;
-  ulong rec_tail_idx = funk->rec_tail_idx;
+  uint rec_head_idx = funk->rec_head_idx;
+  uint rec_tail_idx = funk->rec_tail_idx;
 
   int null_rec_head = fd_funk_rec_idx_is_null( rec_head_idx );
   int null_rec_tail = fd_funk_rec_idx_is_null( rec_tail_idx );

--- a/src/funk/fd_funk.h
+++ b/src/funk/fd_funk.h
@@ -233,14 +233,14 @@ struct __attribute__((aligned(FD_FUNK_ALIGN))) fd_funk_private {
      rec_map_gaddr is the wksp gaddr of the fd_funk_rec_map_t used by
      this funk. */
 
-  ulong rec_max;
+  uint rec_max;
   ulong rec_map_gaddr; /* Non-zero wksp gaddr with tag wksp_tag
                           seed   ==fd_funk_rec_map_seed   (rec_map)
                           rec_max==fd_funk_rec_map_key_max(rec_map) */
   ulong rec_pool_gaddr;
   ulong rec_ele_gaddr;
-  ulong rec_head_idx;  /* Record map index of the first record, FD_FUNK_REC_IDX_NULL if none (from oldest to youngest) */
-  ulong rec_tail_idx;  /* "                       last          " */
+  uint rec_head_idx;  /* Record map index of the first record, FD_FUNK_REC_IDX_NULL if none (from oldest to youngest) */
+  uint rec_tail_idx;  /* "                       last          " */
 
   /* The funk alloc is used for allocating wksp resources for record
      values.  This is a fd_alloc and more details are given in
@@ -272,7 +272,7 @@ fd_funk_align( void );
 
 FD_FN_CONST ulong
 fd_funk_footprint( ulong txn_max,
-                   ulong rec_max );
+                   uint  rec_max );
 
 /* fd_wksp_new formats an unused wksp allocation with the appropriate
    alignment and footprint as a funk.  Caller is not joined on return.
@@ -292,7 +292,7 @@ fd_funk_new( void * shmem,
              ulong  wksp_tag,
              ulong  seed,
              ulong  txn_max,
-             ulong  rec_max );
+             uint   rec_max );
 
 /* fd_funk_join joins the caller to a funk instance.  shfunk points to
    the first byte of the memory region backing the funk in the caller's
@@ -436,7 +436,7 @@ fd_funk_last_publish_is_frozen( fd_funk_t const * funk ) {
    in the funk.  This includes both records of the last published
    transaction and records for transactions that are in-flight. */
 
-FD_FN_PURE static inline ulong fd_funk_rec_max( fd_funk_t * funk ) { return funk->rec_max; }
+FD_FN_PURE static inline uint fd_funk_rec_max( fd_funk_t * funk ) { return funk->rec_max; }
 
 /* fd_funk_rec_map returns the funk's record map join. This
    join can copied by value and is generally stored as a stack variable. */

--- a/src/funk/fd_funk_filemap.c
+++ b/src/funk/fd_funk_filemap.c
@@ -15,7 +15,7 @@ fd_funk_open_file( const char * filename,
                       ulong        wksp_tag,
                       ulong        seed,
                       ulong        txn_max,
-                      ulong        rec_max,
+                      uint         rec_max,
                       ulong        total_sz,
                       fd_funk_file_mode_t mode,
                       fd_funk_close_file_args_t * close_args_out ) {

--- a/src/funk/fd_funk_filemap.h
+++ b/src/funk/fd_funk_filemap.h
@@ -39,7 +39,7 @@ fd_funk_open_file( const char * filename,
                       ulong        wksp_tag,
                       ulong        seed,
                       ulong        txn_max,
-                      ulong        rec_max,
+                      uint         rec_max,
                       ulong        total_sz,
                       fd_funk_file_mode_t mode,
                       fd_funk_close_file_args_t * close_args_out );

--- a/src/funk/fd_funk_txn.c
+++ b/src/funk/fd_funk_txn.c
@@ -165,16 +165,16 @@ fd_funk_txn_cancel_childless( fd_funk_t * funk,
      idx with NULL though we can detect cycles as soon as possible
      and abort. */
 
-  fd_wksp_t * wksp = fd_funk_wksp( funk );
-  fd_alloc_t * alloc = fd_funk_alloc( funk, wksp );
-  fd_funk_rec_map_t rec_map = fd_funk_rec_map( funk, wksp );
+  fd_wksp_t *        wksp     = fd_funk_wksp( funk );
+  fd_alloc_t *       alloc    = fd_funk_alloc( funk, wksp );
+  fd_funk_rec_map_t  rec_map  = fd_funk_rec_map( funk, wksp );
   fd_funk_rec_pool_t rec_pool = fd_funk_rec_pool( funk, wksp );
-  ulong           rec_max = funk->rec_max;
-  fd_funk_txn_map_t txn_map = fd_funk_txn_map( funk, wksp );
+  uint               rec_max  = funk->rec_max;
+  fd_funk_txn_map_t  txn_map  = fd_funk_txn_map( funk, wksp );
   fd_funk_txn_pool_t txn_pool = fd_funk_txn_pool( funk, wksp );
 
   fd_funk_txn_t * txn = &txn_pool.ele[ txn_idx ];
-  ulong rec_idx = txn->rec_head_idx;
+  uint rec_idx = txn->rec_head_idx;
   while( !fd_funk_rec_idx_is_null( rec_idx ) ) {
 
     if( FD_UNLIKELY( rec_idx>=rec_max ) ) FD_LOG_CRIT(( "memory corruption detected (bad idx)" ));
@@ -182,7 +182,7 @@ fd_funk_txn_cancel_childless( fd_funk_t * funk,
       FD_LOG_CRIT(( "memory corruption detected (cycle or bad idx)" ));
 
     fd_funk_rec_t * rec = &rec_pool.ele[ rec_idx ];
-    ulong next_idx = rec->next_idx;
+    uint next_idx = rec->next_idx;
     rec->txn_cidx = fd_funk_txn_cidx( FD_FUNK_TXN_IDX_NULL );
 
     for(;;) {
@@ -476,8 +476,8 @@ fd_funk_txn_cancel_all( fd_funk_t *     funk,
 
 static void
 fd_funk_txn_update( fd_funk_t *                  funk,
-                       ulong *                   _dst_rec_head_idx, /* Pointer to the dst list head */
-                       ulong *                   _dst_rec_tail_idx, /* Pointer to the dst list tail */
+                       uint *                   _dst_rec_head_idx, /* Pointer to the dst list head */
+                       uint *                   _dst_rec_tail_idx, /* Pointer to the dst list tail */
                        ulong                     dst_txn_idx,       /* Transaction index of the merge destination */
                        fd_funk_txn_xid_t const * dst_xid,        /* dst xid */
                        ulong                     txn_idx ) {        /* Transaction index of the records to merge */
@@ -488,10 +488,10 @@ fd_funk_txn_update( fd_funk_t *                  funk,
   fd_funk_txn_pool_t txn_pool = fd_funk_txn_pool( funk, wksp );
 
   fd_funk_txn_t * txn = &txn_pool.ele[ txn_idx ];
-  ulong rec_idx = txn->rec_head_idx;
+  uint rec_idx = txn->rec_head_idx;
   while( !fd_funk_rec_idx_is_null( rec_idx ) ) {
     fd_funk_rec_t * rec = &rec_pool.ele[ rec_idx ];
-    ulong next_rec_idx = rec->next_idx;
+    uint next_rec_idx   = rec->next_idx;
 
     /* See if (dst_xid,key) already exists.  */
     fd_funk_xid_key_pair_t pair[1];
@@ -505,8 +505,8 @@ fd_funk_txn_update( fd_funk_t *                  funk,
 
       /* Remove from the transaction */
       fd_funk_rec_t * rec2 = fd_funk_rec_map_query_ele( rec_query );
-      ulong prev_idx = rec2->prev_idx;
-      ulong next_idx = rec2->next_idx;
+      uint prev_idx = rec2->prev_idx;
+      uint next_idx = rec2->next_idx;
       if( fd_funk_rec_idx_is_null( prev_idx ) ) {
         *_dst_rec_head_idx = next_idx;
       } else {
@@ -731,7 +731,7 @@ fd_funk_txn_publish_into_parent( fd_funk_t *     funk,
 fd_funk_rec_t const *
 fd_funk_txn_first_rec( fd_funk_t *           funk,
                        fd_funk_txn_t const * txn ) {
-  ulong rec_idx;
+  uint rec_idx;
   if( FD_UNLIKELY( NULL == txn ))
     rec_idx = funk->rec_head_idx;
   else
@@ -745,7 +745,7 @@ fd_funk_txn_first_rec( fd_funk_t *           funk,
 fd_funk_rec_t const *
 fd_funk_txn_last_rec( fd_funk_t *           funk,
                       fd_funk_txn_t const * txn ) {
-  ulong rec_idx;
+  uint rec_idx;
   if( FD_UNLIKELY( NULL == txn ))
     rec_idx = funk->rec_tail_idx;
   else
@@ -762,7 +762,7 @@ fd_funk_txn_last_rec( fd_funk_t *           funk,
 fd_funk_rec_t const *
 fd_funk_txn_next_rec( fd_funk_t *           funk,
                       fd_funk_rec_t const * rec ) {
-  ulong rec_idx = rec->next_idx;
+  uint rec_idx = rec->next_idx;
   if( fd_funk_rec_idx_is_null( rec_idx ) ) return NULL;
   fd_wksp_t * wksp = fd_funk_wksp( funk );
   fd_funk_rec_pool_t rec_pool = fd_funk_rec_pool( funk, wksp );
@@ -772,7 +772,7 @@ fd_funk_txn_next_rec( fd_funk_t *           funk,
 fd_funk_rec_t const *
 fd_funk_txn_prev_rec( fd_funk_t *           funk,
                       fd_funk_rec_t const * rec ) {
-  ulong rec_idx = rec->prev_idx;
+  uint rec_idx = rec->prev_idx;
   if( fd_funk_rec_idx_is_null( rec_idx ) ) return NULL;
   fd_wksp_t * wksp = fd_funk_wksp( funk );
   fd_funk_rec_pool_t rec_pool = fd_funk_rec_pool( funk, wksp );

--- a/src/funk/fd_funk_txn.h
+++ b/src/funk/fd_funk_txn.h
@@ -46,8 +46,8 @@ struct __attribute__((aligned(FD_FUNK_TXN_ALIGN))) fd_funk_txn_private {
   uint   stack_cidx;        /* Internal use by funk */
   ulong  tag;               /* Internal use by funk */
 
-  ulong  rec_head_idx;      /* Record map index of the first record, FD_FUNK_REC_IDX_NULL if none (from oldest to youngest) */
-  ulong  rec_tail_idx;      /* "                       last          " */
+  uint  rec_head_idx;      /* Record map index of the first record, FD_FUNK_REC_IDX_NULL if none (from oldest to youngest) */
+  uint  rec_tail_idx;      /* "                       last          " */
 };
 
 typedef struct fd_funk_txn_private fd_funk_txn_t;

--- a/src/funk/test_funk.c
+++ b/src/funk/test_funk.c
@@ -20,7 +20,7 @@ main( int     argc,
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL,          1234UL );
   ulong        seed     = fd_env_strip_cmdline_ulong( &argc, &argv, "--seed",      NULL,          5678UL );
   ulong        txn_max  = fd_env_strip_cmdline_ulong( &argc, &argv, "--txn-max",   NULL,        262144UL );
-  ulong        rec_max  = fd_env_strip_cmdline_ulong( &argc, &argv, "--rec-max",   NULL,        262144UL );
+  uint         rec_max  = fd_env_strip_cmdline_uint(  &argc, &argv, "--rec-max",   NULL,          262144 );
 
   fd_wksp_t * wksp;
   if( name ) {
@@ -34,7 +34,7 @@ main( int     argc,
 
   if( FD_UNLIKELY( !wksp ) ) FD_LOG_ERR(( "Unable to attach to wksp" ));
 
-  FD_LOG_NOTICE(( "Testing with --wksp-tag %lu --seed %lu --txn-max %lu --rec-max %lu", wksp_tag, seed, txn_max, rec_max ));
+  FD_LOG_NOTICE(( "Testing with --wksp-tag %lu --seed %lu --txn-max %lu --rec-max %u", wksp_tag, seed, txn_max, rec_max ));
 
   ulong align     = fd_funk_align();     FD_TEST( align    ==FD_FUNK_ALIGN     );
   ulong footprint = fd_funk_footprint(txn_max, rec_max);

--- a/src/funk/test_funk_common.hpp
+++ b/src/funk/test_funk_common.hpp
@@ -104,7 +104,7 @@ struct fake_funk {
     fake_funk(int * argc, char *** argv) {
       fd_boot( argc, argv );
       ulong txn_max = 128;
-      ulong rec_max = 1<<16;
+      uint  rec_max = 1<<16;
 
 #ifdef TEST_FUNK_FILE
       _real = fd_funk_open_file( "funk_test_file", 1, 1234U, txn_max, rec_max, FD_SHMEM_GIGANTIC_PAGE_SZ, FD_FUNK_OVERWRITE, &close_args );

--- a/src/funk/test_funk_concur.cxx
+++ b/src/funk/test_funk_concur.cxx
@@ -100,7 +100,7 @@ int main(int argc, char** argv) {
   fd_boot( &argc, &argv );
 
   ulong txn_max = MAX_TXN_CNT;
-  ulong rec_max = 1<<20;
+  uint  rec_max = 1<<20;
   ulong  numa_idx = fd_shmem_numa_idx( 0 );
   fd_wksp_t * wksp = fd_wksp_new_anonymous( FD_SHMEM_GIGANTIC_PAGE_SZ, 1U, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   void * mem = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), FD_FUNK_MAGIC );

--- a/src/funk/test_funk_rec.c
+++ b/src/funk/test_funk_rec.c
@@ -6,7 +6,7 @@ FD_STATIC_ASSERT( FD_FUNK_REC_ALIGN    == 64UL, unit_test );
 
 FD_STATIC_ASSERT( FD_FUNK_REC_FLAG_ERASE==1UL, unit_test );
 
-FD_STATIC_ASSERT( FD_FUNK_REC_IDX_NULL==ULONG_MAX, unit_test );
+FD_STATIC_ASSERT( FD_FUNK_REC_IDX_NULL==UINT_MAX, unit_test );
 
 #include "test_funk_common.h"
 
@@ -22,7 +22,7 @@ main( int     argc,
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL,          1234UL );
   ulong        seed     = fd_env_strip_cmdline_ulong( &argc, &argv, "--seed",      NULL,          5678UL );
   ulong        txn_max  = fd_env_strip_cmdline_ulong( &argc, &argv, "--txn-max",   NULL,            32UL );
-  ulong        rec_max  = fd_env_strip_cmdline_ulong( &argc, &argv, "--rec-max",   NULL,           128UL );
+  uint         rec_max  = fd_env_strip_cmdline_uint(  &argc, &argv, "--rec-max",   NULL,             128 );
   ulong        iter_max = fd_env_strip_cmdline_ulong( &argc, &argv, "--iter-max",  NULL,       1048576UL );
   int          verbose  = fd_env_strip_cmdline_int  ( &argc, &argv, "--verbose",   NULL,               0 );
 
@@ -40,7 +40,7 @@ main( int     argc,
 
   if( FD_UNLIKELY( !wksp ) ) FD_LOG_ERR(( "Unable to attach to wksp" ));
 
-  FD_LOG_NOTICE(( "Testing with --wksp-tag %lu --seed %lu --txn-max %lu --rxn-max %lu --iter-max %lu --verbose %i",
+  FD_LOG_NOTICE(( "Testing with --wksp-tag %lu --seed %lu --txn-max %lu --rxn-max %u --iter-max %lu --verbose %i",
                   wksp_tag, seed, txn_max, rec_max, iter_max, verbose ));
 
   fd_funk_t * tst = fd_funk_join( fd_funk_new( fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint(txn_max, rec_max), wksp_tag ),

--- a/src/funk/test_funk_txn.c
+++ b/src/funk/test_funk_txn.c
@@ -26,7 +26,7 @@ main( int     argc,
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL,          1234UL );
   ulong        seed     = fd_env_strip_cmdline_ulong( &argc, &argv, "--seed",      NULL,          5678UL );
   ulong        txn_max  = fd_env_strip_cmdline_ulong( &argc, &argv, "--txn-max",   NULL,            32UL );
-  ulong        rec_max  = fd_env_strip_cmdline_ulong( &argc, &argv, "--rec-max",   NULL,            32UL );
+  uint         rec_max  = fd_env_strip_cmdline_uint(  &argc, &argv, "--rec-max",   NULL,              32 );
   ulong        iter_max = fd_env_strip_cmdline_ulong( &argc, &argv, "--iter-max",  NULL,       1048576UL );
   int          verbose  = fd_env_strip_cmdline_int  ( &argc, &argv, "--verbose",   NULL,               0 );
 
@@ -44,7 +44,7 @@ main( int     argc,
 
   if( FD_UNLIKELY( !wksp ) ) FD_LOG_ERR(( "Unable to attach to wksp" ));
 
-  FD_LOG_NOTICE(( "Testing with --wksp-tag %lu --seed %lu --txn-max %lu --rxn-max %lu --iter-max %lu --verbose %i",
+  FD_LOG_NOTICE(( "Testing with --wksp-tag %lu --seed %lu --txn-max %lu --rxn-max %u --iter-max %lu --verbose %i",
                   wksp_tag, seed, txn_max, rec_max, iter_max, verbose ));
 
   fd_funk_t * funk = fd_funk_join( fd_funk_new( fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), wksp_tag ),

--- a/src/funk/test_funk_val.c
+++ b/src/funk/test_funk_val.c
@@ -18,7 +18,7 @@ main( int     argc,
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL,          1234UL );
   ulong        seed     = fd_env_strip_cmdline_ulong( &argc, &argv, "--seed",      NULL,          5678UL );
   ulong        txn_max  = fd_env_strip_cmdline_ulong( &argc, &argv, "--txn-max",   NULL,            32UL );
-  ulong        rec_max  = fd_env_strip_cmdline_ulong( &argc, &argv, "--rec-max",   NULL,           128UL );
+  uint         rec_max  = fd_env_strip_cmdline_uint(  &argc, &argv, "--rec-max",   NULL,             128 );
   ulong        iter_max = fd_env_strip_cmdline_ulong( &argc, &argv, "--iter-max",  NULL,       1048576UL );
   int          verbose  = fd_env_strip_cmdline_int  ( &argc, &argv, "--verbose",   NULL,               0 );
 
@@ -36,7 +36,7 @@ main( int     argc,
 
   if( FD_UNLIKELY( !wksp ) ) FD_LOG_ERR(( "Unable to attach to wksp" ));
 
-  FD_LOG_NOTICE(( "Testing with --wksp-tag %lu --seed %lu --txn-max %lu --rxn-max %lu --iter-max %lu --verbose %i",
+  FD_LOG_NOTICE(( "Testing with --wksp-tag %lu --seed %lu --txn-max %lu --rxn-max %u --iter-max %lu --verbose %i",
                   wksp_tag, seed, txn_max, rec_max, iter_max, verbose ));
 
   fd_funk_t * tst = fd_funk_join( fd_funk_new( fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), wksp_tag ),


### PR DESCRIPTION
This PR adds placeholder fields inside `fd_funk_rec_t` which will be used for the LRU cache. To fit them into `fd_funk_rec_t` whilst maintaining alignment I changed `prev_idx`/`next_idx` to be uint.

 I'm just merging this PR in before these fields are used because the changes touch a lot of files.