### PR TITLE
bank: fix agave 2.2 ABI

### DIFF
--- a/src/discoh/bank/fd_bank_abi.c
+++ b/src/discoh/bank/fd_bank_abi.c
@@ -279,6 +279,7 @@ struct ABI_ALIGN(8UL) fd_bank_abi_txn_private {
   }; /* parts of the SanitizedTransaction */
 };
 
+FD_STATIC_ASSERT( sizeof (struct fd_bank_abi_txn_private)==FD_BANK_ABI_TXN_FOOTPRINT, bank_abi );
 FD_STATIC_ASSERT( sizeof (struct fd_bank_abi_txn_private)==392UL, bank_abi );
 FD_STATIC_ASSERT( alignof(struct fd_bank_abi_txn_private)==8UL,   bank_abi );
 

--- a/src/discoh/bank/fd_bank_abi.h
+++ b/src/discoh/bank/fd_bank_abi.h
@@ -5,9 +5,9 @@
 #include "../../ballet/blake3/fd_blake3.h"
 
 #define FD_BANK_ABI_TXN_ALIGN     (8UL)
-#define FD_BANK_ABI_TXN_FOOTPRINT (248UL)
+#define FD_BANK_ABI_TXN_FOOTPRINT (392UL)
 
-/* A SanitizedTransaction is not just a 248 byte struct but also a bunch
+/* A SanitizedTransaction is not just a 392 byte struct but also a bunch
    of sidecar data that's pointed to by the struct.  All of this sidecar
    data is in the form of Vec<T>'s.  Note that we only store the actual
    vector contents in the sidecar, the metadata like capacity and length


### PR DESCRIPTION
This was causing transactions to stomp on each other. Since we normally run with 1 transaction per microblock except in the bundle case, this was only triggering with bundles, which is why we didn't catch it immediately.