### PR TITLE
funk: remove rec pool global lock in rec_publish

### DIFF
--- a/src/funk/fd_funk.h
+++ b/src/funk/fd_funk.h
@@ -253,6 +253,7 @@ struct __attribute__((aligned(FD_FUNK_ALIGN))) fd_funk_private {
      that and allocating exclusively from that? */
 
   ulong alloc_gaddr; /* Non-zero wksp gaddr with tag wksp tag */
+  uchar lock;        /* lock for synchronizing modifications to funk object */
 
   /* Padding to FD_FUNK_ALIGN here */
 };

--- a/src/funk/fd_funk_rec.h
+++ b/src/funk/fd_funk_rec.h
@@ -124,6 +124,7 @@ struct _fd_funk_rec_prepare {
   fd_funk_rec_t * rec;
   uint *          rec_head_idx;
   uint *          rec_tail_idx;
+  uchar *         txn_lock;
 };
 
 typedef struct _fd_funk_rec_prepare fd_funk_rec_prepare_t;

--- a/src/funk/fd_funk_txn.c
+++ b/src/funk/fd_funk_txn.c
@@ -47,9 +47,9 @@ fd_funk_txn_end_write( fd_funk_t * funk FD_PARAM_UNUSED ) {
 
 fd_funk_txn_t *
 fd_funk_txn_prepare( fd_funk_t *               funk,
-                        fd_funk_txn_t *           parent,
-                        fd_funk_txn_xid_t const * xid,
-                        int                          verbose ) {
+                     fd_funk_txn_t *           parent,
+                     fd_funk_txn_xid_t const * xid,
+                     int                       verbose ) {
 
 #ifdef FD_FUNK_HANDHOLDING
   if( FD_UNLIKELY( !funk ) ) {

--- a/src/funk/fd_funk_txn.h
+++ b/src/funk/fd_funk_txn.h
@@ -48,6 +48,7 @@ struct __attribute__((aligned(FD_FUNK_TXN_ALIGN))) fd_funk_txn_private {
 
   uint  rec_head_idx;      /* Record map index of the first record, FD_FUNK_REC_IDX_NULL if none (from oldest to youngest) */
   uint  rec_tail_idx;      /* "                       last          " */
+  uchar lock;              /* Internal use by funk for sychronizing modifications to txn object */
 };
 
 typedef struct fd_funk_txn_private fd_funk_txn_t;


### PR DESCRIPTION
Multi-threaded tpool perf
```
with global lock and 4 threads: Inserted 1000000 accounts in 0.57s (rate=1.8e+06 per_item=567ns)
with CAS on the txn object and 4 threads: Inserted 1000000 accounts in 0.34s (rate=2.9e+06 per_item=340ns)
```

single threaded perf:
```
With glocal rec pool lock: Inserted 1000000 accounts in 0.28s (rate=3.5e+06 per_item=284ns)
With CAS: Inserted 1000000 accounts in 0.29s (rate=3.5e+06 per_item=286ns)
```

Closes #4823 