### PR TITLE
funk: clean up join API

### DIFF
--- a/src/app/rpcserver/main.c
+++ b/src/app/rpcserver/main.c
@@ -32,9 +32,9 @@ init_args( int * argc, char *** argv, fd_rpcserver_args_t * args ) {
   char const * funk_file = fd_env_strip_cmdline_cstr( argc, argv, "--funk-file", NULL, NULL );
   if( FD_UNLIKELY( !funk_file ))
     FD_LOG_ERR(( "--funk-file argument is required" ));
-  args->funk = fd_funk_open_file( funk_file, 1, 0, 0, 0, 0, FD_FUNK_READONLY, NULL );
-  if( args->funk == NULL ) {
-    FD_LOG_ERR(( "failed to join a funky" ));
+  fd_funk_t * funk = fd_funk_open_file( args->funk, funk_file, 1, 0, 0, 0, 0, FD_FUNK_READONLY, NULL );
+  if( !funk ) {
+    FD_LOG_ERR(( "failed to join funk" ));
   }
 
   char const * blockstore_file = fd_env_strip_cmdline_cstr( argc, argv, "--blockstore-file", NULL, NULL );
@@ -107,10 +107,13 @@ init_args_offline( int * argc, char *** argv, fd_rpcserver_args_t * args ) {
   if( FD_UNLIKELY( !funk_file ))
     FD_LOG_ERR(( "--funk-file argument is required" ));
   char const * restore = fd_env_strip_cmdline_cstr ( argc, argv, "--restore-funk", NULL, NULL );
-  if( restore != NULL )
-    args->funk = fd_funk_recover_checkpoint( funk_file, 1, restore, NULL );
-  else
-    args->funk = fd_funk_open_file( funk_file, 1, 0, 0, 0, 0, FD_FUNK_READONLY, NULL );
+  fd_funk_t * funk = NULL;
+  if( restore != NULL ) {
+    funk = fd_funk_recover_checkpoint( args->funk, funk_file, 1, restore, NULL );
+  } else {
+    funk = fd_funk_open_file( args->funk, funk_file, 1, 0, 0, 0, 0, FD_FUNK_READONLY, NULL );
+  }
+  if( FD_UNLIKELY( !funk ) ) FD_LOG_ERR(( "Failed to join funk database" ));
 
   fd_wksp_t * wksp;
   const char * wksp_name = fd_env_strip_cmdline_cstr ( argc, argv, "--wksp-name-blockstore", NULL, NULL );

--- a/src/choreo/forks/fd_forks.c
+++ b/src/choreo/forks/fd_forks.c
@@ -193,7 +193,7 @@ slot_ctx_restore( ulong                 slot,
                   fd_exec_epoch_ctx_t * epoch_ctx,
                   fd_spad_t *           runtime_spad,
                   fd_exec_slot_ctx_t *  slot_ctx_out ) {
-  fd_funk_txn_map_t txn_map = fd_funk_txn_map( funk, fd_funk_wksp( funk ) );
+  fd_funk_txn_map_t * txn_map = fd_funk_txn_map( funk );
   bool block_exists = fd_blockstore_shreds_complete( blockstore, slot );
 
   FD_LOG_DEBUG( ( "Current slot %lu", slot ) );
@@ -204,11 +204,11 @@ slot_ctx_restore( ulong                 slot,
   fd_funk_rec_key_t id  = fd_runtime_slot_bank_key();
   for( ; ; ) {
     fd_funk_txn_start_read( funk );
-    fd_funk_txn_t *   txn = fd_funk_txn_query( &xid, &txn_map );
+    fd_funk_txn_t * txn = fd_funk_txn_query( &xid, txn_map );
     if( !txn ) {
       memset( xid.uc, 0, sizeof( fd_funk_txn_xid_t ) );
       xid.ul[0] = slot;
-      txn       = fd_funk_txn_query( &xid, &txn_map );
+      txn       = fd_funk_txn_query( &xid, txn_map );
       if( !txn ) {
         FD_LOG_ERR( ( "missing txn, parent slot %lu", slot ) );
       }

--- a/src/discof/batch/fd_batch_tile.c
+++ b/src/discof/batch/fd_batch_tile.c
@@ -28,7 +28,7 @@ struct fd_snapshot_tile_ctx {
   /* Shared data structures. */
   fd_txncache_t * status_cache;
   ulong         * is_constipated;
-  fd_funk_t     * funk;
+  fd_funk_t       funk[1];
 
   /* File descriptors used for snapshot generation. */
   int             tmp_fd;
@@ -442,20 +442,15 @@ after_credit( fd_snapshot_tile_ctx_t * ctx,
   if( FD_UNLIKELY( !ctx->is_funk_active ) ) {
     /* Setting these parameters are not required because we are joining the
        funk that was setup in the replay tile. */
-    ctx->funk = fd_funk_open_file( ctx->funk_file,
-                                   1UL,
-                                   0UL,
-                                   0UL,
-                                   0UL,
-                                   0UL,
-                                   FD_FUNK_READ_WRITE,
-                                   NULL );
-    if( FD_UNLIKELY( !ctx->funk ) ) {
-      FD_LOG_ERR(( "failed to join a funky" ));
+    fd_funk_t * funk = fd_funk_open_file(
+        ctx->funk, ctx->funk_file,
+        1UL, 0UL, 0UL, 0UL, 0UL, FD_FUNK_READ_WRITE, NULL );
+    if( FD_UNLIKELY( !funk ) ) {
+      FD_LOG_ERR(( "Failed to join a funk database" ));
     }
     ctx->is_funk_active = 1;
 
-    FD_LOG_WARNING(( "Just joined funk at file=%s", ctx->funk_file ));
+    FD_LOG_WARNING(( "Joined funk database at file=%s", ctx->funk_file ));
   }
 
   if( fd_batch_fseq_is_snapshot( batch_fseq ) ) {

--- a/src/discof/consensus/test_consensus.c
+++ b/src/discof/consensus/test_consensus.c
@@ -444,13 +444,14 @@ main( void ) {
 //   /**********************************************************************/
 
 //   fd_wksp_tag_query_info_t funk_info;
-//   fd_funk_t *              funk     = NULL;
+//   fd_funk_t                funk_[1];
+//   fd_funk_t *              funk = NULL;
 //   ulong                    funk_tag = FD_FUNK_MAGIC;
 //   if( fd_wksp_tag_query( wksp, &funk_tag, 1, &funk_info, 1 ) > 0 ) {
 //     void * shmem = fd_wksp_laddr_fast( wksp, funk_info.gaddr_lo );
-//     funk         = fd_funk_join( shmem );
+//     funk         = fd_funk_join( funk_, shmem );
 //   }
-//   if( funk == NULL ) FD_LOG_ERR( ( "failed to join a funky" ) );
+//   if( !funk ) FD_LOG_ERR( ( "failed to join a funky" ) );
 
 //   /**********************************************************************/
 //   /* blockstore                                                         */

--- a/src/discof/exec/fd_exec_tile.c
+++ b/src/discof/exec/fd_exec_tile.c
@@ -119,7 +119,7 @@ struct fd_exec_tile_ctx {
   int                   pending_epoch_pop;
 
   /* Funk-specific setup.  */
-  fd_funk_t *           funk;
+  fd_funk_t             funk[1];
   fd_wksp_t *           funk_wksp;
 
   /* Data structures related to managing and executing the transaction.
@@ -241,13 +241,13 @@ prepare_new_slot_execution( fd_exec_tile_ctx_t *           ctx,
   fd_spad_push( ctx->exec_spad );
   ctx->pending_slot_pop = 1;
 
-  fd_funk_txn_map_t txn_map = fd_funk_txn_map( ctx->funk, ctx->funk_wksp );
-  if( FD_UNLIKELY( !txn_map.map ) ) {
+  fd_funk_txn_map_t * txn_map = fd_funk_txn_map( ctx->funk );
+  if( FD_UNLIKELY( !txn_map->map ) ) {
     FD_LOG_ERR(( "Could not find valid funk transaction map" ));
   }
   fd_funk_txn_xid_t xid = { .ul = { slot_msg->slot, slot_msg->slot } };
   fd_funk_txn_start_read( ctx->funk );
-  fd_funk_txn_t * funk_txn = fd_funk_txn_query( &xid, &txn_map );
+  fd_funk_txn_t * funk_txn = fd_funk_txn_query( &xid, txn_map );
   if( FD_UNLIKELY( !funk_txn ) ) {
     FD_LOG_ERR(( "Could not find valid funk transaction" ));
   }
@@ -664,19 +664,13 @@ unprivileged_init( fd_topo_t *      topo,
      the funk that was setup in the replay tile. */
   FD_LOG_NOTICE(( "Trying to join funk at file=%s", tile->exec.funk_file ));
   fd_funk_txn_start_write( NULL );
-  ctx->funk = fd_funk_open_file( tile->exec.funk_file,
-                                  1UL,
-                                  0UL,
-                                  0UL,
-                                  0UL,
-                                  0UL,
-                                  FD_FUNK_READONLY,
-                                  NULL );
+  if( FD_UNLIKELY( !fd_funk_open_file(
+      ctx->funk, tile->exec.funk_file,
+      1UL, 0UL, 0UL, 0UL, 0UL, FD_FUNK_READONLY, NULL ) ) ) {
+    FD_LOG_ERR(( "fd_funk_open_file(%s) failed", tile->exec.funk_file ));
+  }
   fd_funk_txn_end_write( NULL );
   ctx->funk_wksp = fd_funk_wksp( ctx->funk );
-  if( FD_UNLIKELY( !ctx->funk ) ) {
-    FD_LOG_ERR(( "failed to join a funk" ));
-  }
 
   FD_LOG_NOTICE(( "Just joined funk at file=%s", tile->exec.funk_file ));
 
@@ -693,7 +687,7 @@ unprivileged_init( fd_topo_t *      topo,
   // FIXME account for this in exec spad footprint
   uchar * txn_ctx_mem   = fd_spad_alloc( ctx->exec_spad, FD_EXEC_TXN_CTX_ALIGN, FD_EXEC_TXN_CTX_FOOTPRINT );
   ctx->txn_ctx          = fd_exec_txn_ctx_join( fd_exec_txn_ctx_new( txn_ctx_mem ), ctx->exec_spad, ctx->exec_spad_wksp );
-  ctx->txn_ctx->funk    = ctx->funk;
+  *ctx->txn_ctx->funk   = *ctx->funk;
 
   ctx->txn_ctx->runtime_pub_wksp = ctx->runtime_public_wksp;
   if( FD_UNLIKELY( !ctx->txn_ctx->runtime_pub_wksp ) ) {

--- a/src/discof/geyser/fd_geyser.c
+++ b/src/discof/geyser/fd_geyser.c
@@ -29,7 +29,7 @@
 #include "sham_link.h"
 
 struct fd_geyser {
-  fd_funk_t *          funk;
+  fd_funk_t            funk[1];
   fd_blockstore_t      blockstore_ljoin;
   fd_blockstore_t *    blockstore;
   int                  blockstore_fd;
@@ -72,9 +72,9 @@ fd_geyser_new( void * mem, fd_geyser_args_t * args ) {
   ulong scratch_top = FD_SCRATCH_ALLOC_FINI( l, 1UL );
   FD_TEST( scratch_top <= (ulong)mem + fd_geyser_footprint() );
 
-  self->funk = fd_funk_open_file( args->funk_file, 1, 0, 0, 0, 0, FD_FUNK_READONLY, NULL );
-  if( self->funk == NULL ) {
-    FD_LOG_ERR(( "failed to join a funky" ));
+  fd_funk_t * funk = fd_funk_open_file( self->funk, args->funk_file, 1, 0, 0, 0, 0, FD_FUNK_READONLY, NULL );
+  if( !funk ) {
+    FD_LOG_ERR(( "fd_funk_open_file(%s) failed", args->funk_file ));
   }
 
   fd_wksp_t * wksp = fd_wksp_attach( args->blockstore_wksp );
@@ -216,8 +216,8 @@ replay_sham_link_during_frag( fd_geyser_t * ctx, fd_replay_notif_msg_t * state, 
 
 static const void *
 read_account_with_xid( fd_geyser_t * ctx, fd_funk_rec_key_t * recid, fd_funk_txn_xid_t * xid, ulong * result_len ) {
-  fd_funk_txn_map_t txn_map = fd_funk_txn_map( ctx->funk, fd_funk_wksp( ctx->funk ) );
-  fd_funk_txn_t *   txn     = fd_funk_txn_query( xid, &txn_map );
+  fd_funk_txn_map_t * txn_map = fd_funk_txn_map( ctx->funk );
+  fd_funk_txn_t *     txn     = fd_funk_txn_query( xid, txn_map );
   return fd_funk_rec_query_copy( ctx->funk, txn, recid, fd_scratch_virtual(), result_len );
 }
 

--- a/src/discof/rpc/fd_rpcserv_tile.c
+++ b/src/discof/rpc/fd_rpcserv_tile.c
@@ -26,6 +26,7 @@
 
 struct fd_rpcserv_tile_ctx {
   fd_rpcserver_args_t args;
+  fd_funk_t funk[1];
   char funk_file[ PATH_MAX ];
 
   int activated;
@@ -140,9 +141,9 @@ after_frag( fd_rpcserv_tile_ctx_t * ctx,
   if( FD_LIKELY( in_idx==REPLAY_NOTIF_IDX ) ) {
     if( FD_UNLIKELY( !ctx->activated ) ) {
       fd_rpcserver_args_t * args = &ctx->args;
-      args->funk = fd_funk_open_file(
-        ctx->funk_file, 1, 0, 0, 0, 0, FD_FUNK_READ_WRITE, NULL );
-      if( FD_UNLIKELY( args->funk == NULL ) ) {
+      fd_funk_t * funk = fd_funk_open_file(
+        ctx->funk, ctx->funk_file, 1, 0, 0, 0, 0, FD_FUNK_READ_WRITE, NULL );
+      if( FD_UNLIKELY( !funk ) ) {
         FD_LOG_ERR(( "failed to join a funky" ));
       }
 

--- a/src/discof/rpcserver/fd_rpc_service.c
+++ b/src/discof/rpcserver/fd_rpc_service.c
@@ -142,8 +142,8 @@ fd_method_error( fd_rpc_ctx_t * ctx, int errcode, const char* format, ... ) {
 
 static const void *
 read_account_with_xid( fd_rpc_ctx_t * ctx, fd_funk_rec_key_t * recid, fd_funk_txn_xid_t * xid, ulong * result_len ) {
-  fd_funk_txn_map_t txn_map = fd_funk_txn_map( ctx->global->funk, fd_funk_wksp( ctx->global->funk ) );
-  fd_funk_txn_t *   txn     = fd_funk_txn_query( xid, &txn_map );
+  fd_funk_txn_map_t * txn_map = fd_funk_txn_map( ctx->global->funk );
+  fd_funk_txn_t *     txn     = fd_funk_txn_query( xid, txn_map );
   return fd_funk_rec_query_copy( ctx->global->funk, txn, recid, fd_scratch_virtual(), result_len );
 }
 

--- a/src/discof/rpcserver/fd_rpc_service.h
+++ b/src/discof/rpcserver/fd_rpc_service.h
@@ -6,12 +6,8 @@
 
 #include "../../disco/topo/fd_topo.h"
 #include "../../disco/shred/fd_stake_ci.h"
-#include "../../util/fd_util.h"
-#include "../../funk/fd_funk.h"
 #include "../../flamenco/runtime/fd_blockstore.h"
-#include "../../tango/mcache/fd_mcache.h"
 #include "../../ballet/http/fd_http_server.h"
-#include "../../util/wksp/fd_wksp_private.h"
 
 #include <netinet/in.h>
 
@@ -20,7 +16,7 @@ typedef struct fd_rpc_ctx fd_rpc_ctx_t;
 struct fd_rpcserver_args {
   fd_valloc_t          valloc;
   int                  offline;
-  fd_funk_t *          funk;
+  fd_funk_t            funk[1];
   fd_blockstore_t      blockstore_ljoin;
   fd_blockstore_t *    blockstore;
   int                  blockstore_fd;

--- a/src/discof/writer/fd_writer_tile.c
+++ b/src/discof/writer/fd_writer_tile.c
@@ -30,7 +30,7 @@ struct fd_writer_tile_ctx {
   ulong *                     fseq;
 
   /* Local join of Funk.  R/W. */
-  fd_funk_t *                 funk;
+  fd_funk_t                   funk[1];
   fd_wksp_t *                 funk_wksp;
 
   /* Link management. */
@@ -341,17 +341,18 @@ unprivileged_init( fd_topo_t *      topo,
 
   FD_LOG_DEBUG(( "Trying to join funk at file=%s", tile->writer.funk_file ));
   fd_funk_txn_start_write( NULL );
-  ctx->funk = fd_funk_open_file( tile->writer.funk_file,
-                                 1UL,
-                                 0UL,
-                                 0UL,
-                                 0UL,
-                                 0UL,
-                                 FD_FUNK_READ_WRITE,
-                                 NULL );
+  int funk_join_ok = !!fd_funk_open_file( ctx->funk,
+      tile->writer.funk_file,
+      1UL,
+      0UL,
+      0UL,
+      0UL,
+      0UL,
+      FD_FUNK_READ_WRITE,
+      NULL );
   fd_funk_txn_end_write( NULL );
   ctx->funk_wksp = fd_funk_wksp( ctx->funk );
-  if( FD_UNLIKELY( !ctx->funk ) ) {
+  if( FD_UNLIKELY( !funk_join_ok ) ) {
     FD_LOG_CRIT(( "Failed to join funk" ));
   }
   FD_LOG_DEBUG(( "Just joined funk at file=%s", tile->exec.funk_file ));

--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.c
@@ -240,8 +240,7 @@ fd_exec_txn_ctx_from_exec_slot_ctx( fd_exec_slot_ctx_t const * slot_ctx,
     FD_LOG_ERR(( "Could not find valid funk transaction" ));
   }
 
-  ctx->funk = fd_wksp_laddr( funk_wksp, funk_gaddr );
-  if( FD_UNLIKELY( !ctx->funk ) ) {
+  if( FD_UNLIKELY( !fd_funk_join( ctx->funk, fd_wksp_laddr( funk_wksp, funk_gaddr ) ) ) ) {
     FD_LOG_ERR(( "Could not find valid funk %lu", funk_gaddr ));
   }
 

--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.h
@@ -75,7 +75,7 @@ struct __attribute__((aligned(8UL))) fd_exec_txn_ctx {
   ulong                           total_epoch_stake;
   fd_bank_hash_cmp_t *            bank_hash_cmp;
   fd_funk_txn_t *                 funk_txn;
-  fd_funk_t *                     funk;
+  fd_funk_t                       funk[1];
   fd_wksp_t *                     runtime_pub_wksp;
   ulong                           slot;
   fd_fee_rate_governor_t          fee_rate_governor;

--- a/src/flamenco/runtime/fd_acc_mgr.c
+++ b/src/flamenco/runtime/fd_acc_mgr.c
@@ -1,16 +1,9 @@
 #include "fd_acc_mgr.h"
-#include "fd_runtime.h"
 #include "../../ballet/base58/fd_base58.h"
-#include "context/fd_exec_epoch_ctx.h"
-#include "context/fd_exec_slot_ctx.h"
-#include "fd_rent_lists.h"
-#include "fd_rocksdb.h"
-#include "sysvar/fd_sysvar_rent.h"
-#include "fd_system_ids.h"
-#include <assert.h>
+#include "../../funk/fd_funk.h"
 
 fd_account_meta_t const *
-fd_funk_get_acc_meta_readonly( fd_funk_t *            funk,
+fd_funk_get_acc_meta_readonly( fd_funk_t const *      funk,
                                fd_funk_txn_t const *  txn,
                                fd_pubkey_t const *    pubkey,
                                fd_funk_rec_t const ** orec,
@@ -100,7 +93,7 @@ fd_funk_get_acc_meta_mutable( fd_funk_t *             funk,
   ulong sz = sizeof(fd_account_meta_t)+min_data_sz;
   void * val;
   if( fd_funk_val_sz( rec ) < sz )
-    val = fd_funk_val_truncate( rec, sz, fd_funk_alloc( funk, wksp ), wksp, &funk_err );
+    val = fd_funk_val_truncate( rec, sz, fd_funk_alloc( funk ), wksp, &funk_err );
   else
     val = fd_funk_val( rec, wksp );
 

--- a/src/flamenco/runtime/fd_acc_mgr.h
+++ b/src/flamenco/runtime/fd_acc_mgr.h
@@ -5,7 +5,6 @@
 
 #include "../fd_flamenco_base.h"
 #include "../../ballet/txn/fd_txn.h"
-#include "../../funk/fd_funk.h"
 #include "fd_txn_account.h"
 
 /* FD_ACC_MGR_{SUCCESS,ERR{...}} are account management specific error codes.
@@ -140,7 +139,7 @@ fd_funk_key_is_acc( fd_funk_rec_key_t const * id ) {
    is guaranteed there are no other modifying accesses to the account. */
 
 fd_account_meta_t const *
-fd_funk_get_acc_meta_readonly( fd_funk_t *            funk,
+fd_funk_get_acc_meta_readonly( fd_funk_t const *      funk,
                                fd_funk_txn_t const *  txn,
                                fd_pubkey_t const *    pubkey,
                                fd_funk_rec_t const ** opt_out_rec,

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -1302,7 +1302,7 @@ fd_execute_txn_prepare_start( fd_exec_slot_ctx_t const * slot_ctx,
   /* FIXME: just pass in the runtime workspace, instead of getting it from fd_wksp_containing */
   fd_wksp_t * runtime_pub_wksp   = fd_wksp_containing( slot_ctx );
   ulong       funk_txn_gaddr     = fd_wksp_gaddr( funk_wksp, slot_ctx->funk_txn );
-  ulong       funk_gaddr         = fd_wksp_gaddr( funk_wksp, slot_ctx->funk );
+  ulong       funk_gaddr         = fd_wksp_gaddr( funk_wksp, slot_ctx->funk->shmem );
   ulong       sysvar_cache_gaddr = fd_wksp_gaddr( runtime_pub_wksp, slot_ctx->sysvar_cache );
 
   /* Init txn ctx */

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -3986,9 +3986,9 @@ fd_runtime_publish_old_txns( fd_exec_slot_ctx_t * slot_ctx,
                              fd_spad_t *          runtime_spad ) {
   /* Publish any transaction older than 31 slots */
   fd_funk_txn_start_write( slot_ctx->funk );
-  fd_funk_t *        funk      = slot_ctx->funk;
-  fd_funk_txn_pool_t txnpool   = fd_funk_txn_pool( funk, fd_funk_wksp( funk ) );
-  fd_epoch_bank_t * epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
+  fd_funk_t *          funk       = slot_ctx->funk;
+  fd_funk_txn_pool_t * txnpool    = fd_funk_txn_pool( funk );
+  fd_epoch_bank_t *    epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
 
   if( capture_ctx != NULL ) {
     fd_runtime_checkpt( capture_ctx, slot_ctx, slot_ctx->slot_bank.slot );
@@ -3997,7 +3997,7 @@ fd_runtime_publish_old_txns( fd_exec_slot_ctx_t * slot_ctx,
   int do_eah = 0;
 
   uint depth = 0;
-  for( fd_funk_txn_t * txn = slot_ctx->funk_txn; txn; txn = fd_funk_txn_parent(txn, &txnpool) ) {
+  for( fd_funk_txn_t * txn = slot_ctx->funk_txn; txn; txn = fd_funk_txn_parent(txn, txnpool) ) {
     if( ++depth == (FD_RUNTIME_NUM_ROOT_BLOCKS - 1 ) ) {
       FD_LOG_DEBUG(("publishing %s (slot %lu)", FD_BASE58_ENC_32_ALLOCA( &txn->xid ), txn->xid.ul[0]));
 
@@ -4008,7 +4008,7 @@ fd_runtime_publish_old_txns( fd_exec_slot_ctx_t * slot_ctx,
       }
 
       if( slot_ctx->epoch_ctx->constipate_root ) {
-        fd_funk_txn_t * parent = fd_funk_txn_parent( txn, &txnpool );
+        fd_funk_txn_t * parent = fd_funk_txn_parent( txn, txnpool );
         if( parent != NULL ) {
           slot_ctx->root_slot = txn->xid.ul[0];
 

--- a/src/flamenco/runtime/fd_runtime_init.c
+++ b/src/flamenco/runtime/fd_runtime_init.c
@@ -24,7 +24,7 @@ fd_runtime_save_epoch_bank( fd_exec_slot_ctx_t * slot_ctx ) {
     return opt_err;
   }
 
-  uchar *buf = fd_funk_val_truncate(rec, sz, fd_funk_alloc( funk, fd_funk_wksp(funk) ), fd_funk_wksp(funk), NULL);
+  uchar *buf = fd_funk_val_truncate(rec, sz, fd_funk_alloc( funk ), fd_funk_wksp(funk), NULL);
   *(uint*)buf = FD_RUNTIME_ENC_BINCODE;
   fd_bincode_encode_ctx_t ctx = {
       .data = buf + sizeof(uint),
@@ -34,12 +34,12 @@ fd_runtime_save_epoch_bank( fd_exec_slot_ctx_t * slot_ctx ) {
   if (FD_UNLIKELY(fd_epoch_bank_encode(epoch_bank, &ctx) != FD_BINCODE_SUCCESS))
   {
     FD_LOG_WARNING(("fd_runtime_save_banks: fd_firedancer_banks_encode failed"));
-    fd_funk_rec_cancel( prepare );
+    fd_funk_rec_cancel( funk, prepare );
     return -1;
   }
   FD_TEST(ctx.data == ctx.dataend);
 
-  fd_funk_rec_publish( prepare );
+  fd_funk_rec_publish( funk, prepare );
 
   FD_LOG_DEBUG(( "epoch frozen, slot=%lu bank_hash=%s poh_hash=%s", slot_ctx->slot_bank.slot, FD_BASE58_ENC_32_ALLOCA( slot_ctx->slot_bank.banks_hash.hash ), FD_BASE58_ENC_32_ALLOCA( slot_ctx->slot_bank.poh.hash ) ));
 
@@ -63,7 +63,7 @@ int fd_runtime_save_slot_bank( fd_exec_slot_ctx_t * slot_ctx ) {
     return opt_err;
   }
 
-  uchar * buf = fd_funk_val_truncate(rec, sz, fd_funk_alloc( funk, fd_funk_wksp(funk) ), fd_funk_wksp(funk), NULL);
+  uchar * buf = fd_funk_val_truncate(rec, sz, fd_funk_alloc( funk ), fd_funk_wksp( funk ), NULL);
   *(uint*)buf = FD_RUNTIME_ENC_BINCODE;
   fd_bincode_encode_ctx_t ctx = {
       .data    = buf + sizeof(uint),
@@ -72,7 +72,7 @@ int fd_runtime_save_slot_bank( fd_exec_slot_ctx_t * slot_ctx ) {
 
   if( FD_UNLIKELY( fd_slot_bank_encode( &slot_ctx->slot_bank, &ctx ) != FD_BINCODE_SUCCESS ) ) {
     FD_LOG_WARNING(( "fd_runtime_save_banks: fd_firedancer_banks_encode failed" ));
-    fd_funk_rec_cancel( prepare );
+    fd_funk_rec_cancel( funk, prepare );
     return -1;
   }
 
@@ -80,7 +80,7 @@ int fd_runtime_save_slot_bank( fd_exec_slot_ctx_t * slot_ctx ) {
     FD_LOG_ERR(( "Data does not equal to end of buffer" ));
   }
 
-  fd_funk_rec_publish( prepare );
+  fd_funk_rec_publish( funk, prepare );
 
   FD_LOG_DEBUG(( "slot frozen, slot=%lu bank_hash=%s poh_hash=%s",
                  slot_ctx->slot_bank.slot,

--- a/src/flamenco/runtime/fd_txn_account.c
+++ b/src/flamenco/runtime/fd_txn_account.c
@@ -178,7 +178,7 @@ fd_txn_account_make_mutable( fd_txn_account_t * acct,
 int
 fd_txn_account_init_from_funk_readonly( fd_txn_account_t *    acct,
                                         fd_pubkey_t const *   pubkey,
-                                        fd_funk_t *           funk,
+                                        fd_funk_t const *     funk,
                                         fd_funk_txn_t const * funk_txn ) {
   fd_txn_account_init( acct );
 
@@ -300,12 +300,12 @@ fd_txn_account_save( fd_txn_account_t * acct,
   acct->private_state.rec = rec;
   ulong reclen = sizeof(fd_account_meta_t)+acct->private_state.const_meta->dlen;
   fd_wksp_t * wksp = fd_funk_wksp( funk );
-  if( fd_funk_val_truncate( rec, reclen, fd_funk_alloc( funk, wksp ), wksp, &err ) == NULL ) {
+  if( fd_funk_val_truncate( rec, reclen, fd_funk_alloc( funk ), wksp, &err ) == NULL ) {
     FD_LOG_ERR(( "unable to allocate account value, err %d", err ));
   }
   err = fd_txn_account_save_internal( acct, funk );
 
-  fd_funk_rec_publish( prepare );
+  fd_funk_rec_publish( funk, prepare );
 
   return err;
 }
@@ -344,7 +344,7 @@ fd_txn_account_mutable_fini( fd_txn_account_t * acct,
   /* Publish the record if the record is not in the current funk transaction
      and there exists a record in preparation in the fd_txn_account_t object */
   if( rec==NULL && acct->prepared_rec.rec!=NULL ) {
-    fd_funk_rec_publish( &acct->prepared_rec );
+    fd_funk_rec_publish( funk, &acct->prepared_rec );
   }
 }
 

--- a/src/flamenco/runtime/fd_txn_account.h
+++ b/src/flamenco/runtime/fd_txn_account.h
@@ -90,7 +90,7 @@ fd_txn_account_make_mutable( fd_txn_account_t * acct,
 int
 fd_txn_account_init_from_funk_readonly( fd_txn_account_t *    acct,
                                         fd_pubkey_t const *   pubkey,
-                                        fd_funk_t *           funk,
+                                        fd_funk_t const *     funk,
                                         fd_funk_txn_t const * funk_txn );
 
 /* Initializes a fd_txn_account_t object with a mutable handle into

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -2521,7 +2521,7 @@ fd_directly_invoke_loader_v3_deploy( fd_exec_slot_ctx_t * slot_ctx,
   fd_wksp_t *         runtime_wksp       = fd_wksp_containing( slot_ctx );
   ulong               funk_txn_gaddr     = fd_wksp_gaddr( funk_wksp, slot_ctx->funk_txn );
   ulong               sysvar_cache_gaddr = fd_wksp_gaddr( runtime_wksp, txn_ctx->sysvar_cache );
-  ulong               funk_gaddr         = fd_wksp_gaddr( funk_wksp, funk );
+  ulong               funk_gaddr         = fd_wksp_gaddr( funk_wksp, funk->shmem );
 
   fd_exec_txn_ctx_from_exec_slot_ctx( slot_ctx,
                                       txn_ctx,

--- a/src/flamenco/runtime/program/fd_bpf_program_util.c
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.c
@@ -216,14 +216,14 @@ fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t *    slot_ctx,
     }
 
     fd_wksp_t * wksp = fd_funk_wksp( funk );
-    void * val = fd_funk_val_truncate( rec, fd_sbpf_validated_program_footprint( &elf_info ), fd_funk_alloc( funk, wksp ), wksp, NULL );;
+    void * val = fd_funk_val_truncate( rec, fd_sbpf_validated_program_footprint( &elf_info ), fd_funk_alloc( funk ), wksp, NULL );;
     fd_sbpf_validated_program_t * validated_prog = fd_sbpf_validated_program_new( val, &elf_info );
 
     ulong  prog_align     = fd_sbpf_program_align();
     ulong  prog_footprint = fd_sbpf_program_footprint( &elf_info );
     fd_sbpf_program_t * prog = fd_sbpf_program_new(  fd_spad_alloc( runtime_spad, prog_align, prog_footprint ), &elf_info, validated_prog->rodata );
     if( FD_UNLIKELY( !prog ) ) {
-      fd_funk_rec_cancel( prepare );
+      fd_funk_rec_cancel( funk, prepare );
       return -1;
     }
 
@@ -244,7 +244,7 @@ fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t *    slot_ctx,
     if( FD_UNLIKELY( 0!=fd_sbpf_program_load( prog, program_data, program_data_len, syscalls, false ) ) ) {
       /* Remove pending funk record */
       FD_LOG_DEBUG(( "fd_sbpf_program_load() failed: %s", fd_sbpf_strerror() ));
-      fd_funk_rec_cancel( prepare );
+      fd_funk_rec_cancel( funk, prepare );
       return -1;
     }
 
@@ -290,7 +290,7 @@ fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t *    slot_ctx,
     if( FD_UNLIKELY( res ) ) {
       /* Remove pending funk record */
       FD_LOG_DEBUG(( "fd_vm_validate() failed" ));
-      fd_funk_rec_cancel( prepare );
+      fd_funk_rec_cancel( funk, prepare );
       return -1;
     }
 
@@ -304,7 +304,7 @@ fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t *    slot_ctx,
     validated_prog->text_sz = prog->text_sz;
     validated_prog->rodata_sz = prog->rodata_sz;
 
-    fd_funk_rec_publish( prepare );
+    fd_funk_rec_publish( funk, prepare );
 
     return 0;
   } FD_SPAD_FRAME_END;

--- a/src/flamenco/runtime/test_txn_rw_conflicts.c
+++ b/src/flamenco/runtime/test_txn_rw_conflicts.c
@@ -338,8 +338,8 @@ main( int     argc,
 
   fd_funk_txn_xid_t xid = {.ul={ slot+1, slot+1 }};
   fd_funk_txn_xid_t const * last_publish_xid = fd_funk_last_publish( funk );
-  fd_funk_txn_map_t txn_map = fd_funk_txn_map( funk, wksp );
-  fd_funk_txn_t * last_publish = fd_funk_txn_query( last_publish_xid, &txn_map );
+  fd_funk_txn_map_t * txn_map = fd_funk_txn_map( funk );
+  fd_funk_txn_t * last_publish = fd_funk_txn_query( last_publish_xid, txn_map );
   fd_funk_txn_t * funk_txn = fd_funk_txn_prepare( funk, last_publish, &xid, 1 );
   FD_TEST( funk_txn );
 

--- a/src/flamenco/runtime/tests/harness/fd_harness_common.h
+++ b/src/flamenco/runtime/tests/harness/fd_harness_common.h
@@ -10,9 +10,9 @@
    for all harnesses. */
 
 struct fd_runtime_fuzz_runner {
-    fd_funk_t * funk;
-    fd_spad_t * spad;
-    fd_wksp_t * wksp;
+  fd_funk_t   funk[1];
+  fd_wksp_t * wksp;
+  fd_spad_t * spad;
 };
 typedef struct fd_runtime_fuzz_runner fd_runtime_fuzz_runner_t;
 

--- a/src/flamenco/runtime/tests/harness/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/harness/fd_instr_harness.c
@@ -75,7 +75,7 @@ fd_runtime_fuzz_instr_ctx_create( fd_runtime_fuzz_runner_t *           runner,
   fd_wksp_t * funk_wksp          = fd_funk_wksp( funk );
   fd_wksp_t * runtime_wksp       = fd_wksp_containing( slot_ctx );
   ulong       funk_txn_gaddr     = fd_wksp_gaddr( funk_wksp, funk_txn );
-  ulong       funk_gaddr         = fd_wksp_gaddr( funk_wksp, funk );
+  ulong       funk_gaddr         = fd_wksp_gaddr( funk_wksp, funk->shmem );
   ulong       sysvar_cache_gaddr = fd_wksp_gaddr( runtime_wksp, slot_ctx->sysvar_cache );
 
   /* Set up mock txn descriptor */

--- a/src/flamenco/snapshot/fd_snapshot_create.h
+++ b/src/flamenco/snapshot/fd_snapshot_create.h
@@ -5,7 +5,7 @@
    snapshot from a slot execution context. */
 
 #include "fd_snapshot_base.h"
-#include "../runtime/fd_runtime_init.h"
+#include "../../funk/fd_funk_base.h"
 #include "../runtime/fd_txncache.h"
 #include "../../util/archive/fd_tar.h"
 #include "../types/fd_types.h"

--- a/src/funk/fd_funk.c
+++ b/src/funk/fd_funk.c
@@ -1,4 +1,5 @@
 #include "fd_funk.h"
+#include "fd_funk_base.h"
 #include <stdio.h>
 
 ulong
@@ -8,18 +9,19 @@ fd_funk_align( void ) {
 
 ulong
 fd_funk_footprint( ulong txn_max,
-                   uint  rec_max ) {
+                   ulong rec_max ) {
+  if( FD_UNLIKELY( rec_max>UINT_MAX ) ) return 0UL;
 
   ulong l = FD_LAYOUT_INIT;
 
-  l = FD_LAYOUT_APPEND( l, alignof(fd_funk_t), sizeof(fd_funk_t) );
+  l = FD_LAYOUT_APPEND( l, alignof(fd_funk_shmem_t), sizeof(fd_funk_shmem_t) );
 
   ulong txn_chain_cnt = fd_funk_txn_map_chain_cnt_est( txn_max );
   l = FD_LAYOUT_APPEND( l, fd_funk_txn_map_align(), fd_funk_txn_map_footprint( txn_chain_cnt ) );
   l = FD_LAYOUT_APPEND( l, fd_funk_txn_pool_align(), fd_funk_txn_pool_footprint() );
   l = FD_LAYOUT_APPEND( l, alignof(fd_funk_txn_t), sizeof(fd_funk_txn_t) * txn_max );
 
-  ulong rec_chain_cnt = fd_funk_rec_map_chain_cnt_est( (ulong)rec_max );
+  ulong rec_chain_cnt = fd_funk_rec_map_chain_cnt_est( rec_max );
   l = FD_LAYOUT_APPEND( l, fd_funk_rec_map_align(), fd_funk_rec_map_footprint( rec_chain_cnt ) );
   l = FD_LAYOUT_APPEND( l, fd_funk_rec_pool_align(), fd_funk_rec_pool_footprint() );
   l = FD_LAYOUT_APPEND( l, alignof(fd_funk_rec_t), sizeof(fd_funk_rec_t) * rec_max );
@@ -38,11 +40,10 @@ fd_funk_new( void * shmem,
              ulong  wksp_tag,
              ulong  seed,
              ulong  txn_max,
-             uint   rec_max ) {
-  fd_funk_t * funk = (fd_funk_t *)shmem;
-  fd_wksp_t * wksp = fd_wksp_containing( funk );
+             ulong  rec_max ) {
+  fd_funk_shmem_t * funk = shmem;
+  fd_wksp_t *       wksp = fd_wksp_containing( funk );
 
-#ifdef FD_FUNK_HANDHOLDING
   if( FD_UNLIKELY( !funk ) ) {
     FD_LOG_WARNING(( "NULL funk" ));
     return NULL;
@@ -63,11 +64,15 @@ fd_funk_new( void * shmem,
     return NULL;
   }
 
-  if( txn_max>FD_FUNK_TXN_IDX_NULL ) { /* See note in fd_funk.h about this limit */
+  if( FD_UNLIKELY( txn_max>FD_FUNK_TXN_IDX_NULL ) ) { /* See note in fd_funk.h about this limit */
     FD_LOG_WARNING(( "txn_max too large for index compression" ));
     return NULL;
   }
-#endif
+
+  if( FD_UNLIKELY( rec_max>UINT_MAX ) ) {
+    FD_LOG_WARNING(( "invalid rec_max" ));
+    return NULL;
+  }
 
   FD_SCRATCH_ALLOC_INIT( l, funk+1 );
 
@@ -113,7 +118,7 @@ fd_funk_new( void * shmem,
   fd_funk_rec_pool_join( rec_join, rec_pool2, rec_ele, rec_max );
   fd_funk_rec_pool_reset( rec_join, 0UL );
   funk->rec_ele_gaddr = fd_wksp_gaddr_fast( wksp, rec_ele );
-  funk->rec_max = rec_max;
+  funk->rec_max = (uint)rec_max;
   funk->rec_head_idx  = FD_FUNK_REC_IDX_NULL;
   funk->rec_tail_idx  = FD_FUNK_REC_IDX_NULL;
 
@@ -127,101 +132,177 @@ fd_funk_new( void * shmem,
 }
 
 fd_funk_t *
-fd_funk_join( void * shfunk ) {
-  fd_funk_t * funk = (fd_funk_t *)shfunk;
-
-#ifdef FD_FUNK_HANDHOLDING
-  if( FD_UNLIKELY( !funk ) ) {
+fd_funk_join( void * ljoin,
+              void * shfunk ) {
+  if( FD_UNLIKELY( !shfunk ) ) {
     FD_LOG_WARNING(( "NULL shfunk" ));
     return NULL;
   }
 
-  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)funk, fd_funk_align() ) ) ) {
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shfunk, fd_funk_align() ) ) ) {
     FD_LOG_WARNING(( "misaligned shfunk" ));
     return NULL;
   }
 
-  fd_wksp_t * wksp = fd_wksp_containing( funk );
+  fd_wksp_t * wksp = fd_wksp_containing( shfunk );
   if( FD_UNLIKELY( !wksp ) ) {
     FD_LOG_WARNING(( "shfunk must be part of a workspace" ));
     return NULL;
   }
 
-  if( FD_UNLIKELY( funk->magic!=FD_FUNK_MAGIC ) ) {
+  fd_funk_shmem_t * shmem = shfunk;
+  if( FD_UNLIKELY( shmem->magic!=FD_FUNK_MAGIC ) ) {
     FD_LOG_WARNING(( "bad magic" ));
     return NULL;
   }
-#endif
+
+  if( FD_UNLIKELY( !ljoin ) ) {
+    FD_LOG_WARNING(( "NULL ljoin" ));
+    return NULL;
+  }
 
 #ifdef FD_FUNK_WKSP_PROTECT
-#ifndef FD_FUNK_HANDHOLDING
-  fd_wksp_t * wksp = fd_wksp_containing( funk );
-#endif
   fd_wksp_mprotect( wksp, 1 );
 #endif
+
+  fd_funk_t * funk = ljoin;
+  memset( funk, 0, sizeof(fd_funk_t) );
+
+  funk->shmem = shfunk;
+  funk->wksp  = wksp;
+
+  if( FD_UNLIKELY( !fd_funk_txn_pool_join( funk->txn_pool, fd_wksp_laddr( wksp, shmem->txn_pool_gaddr ), fd_wksp_laddr( wksp, shmem->txn_ele_gaddr ), shmem->txn_max ) ) ) {
+    FD_LOG_WARNING(( "failed to join txn_pool" ));
+    return NULL;
+  }
+  if( FD_UNLIKELY( !fd_funk_txn_map_join( funk->txn_map, fd_wksp_laddr( wksp, shmem->txn_map_gaddr ), fd_wksp_laddr_fast( wksp, shmem->txn_ele_gaddr ), shmem->txn_max ) ) ) {
+    FD_LOG_WARNING(( "failed to join txn_map" ));
+    return NULL;
+  }
+  if( FD_UNLIKELY( !fd_funk_rec_map_join( funk->rec_map, fd_wksp_laddr( wksp, shmem->rec_map_gaddr ), fd_wksp_laddr( wksp, shmem->rec_ele_gaddr ), shmem->rec_max ) ) ) {
+    FD_LOG_WARNING(( "failed to join rec_map" ));
+    return NULL;
+  }
+  if( FD_UNLIKELY( !fd_funk_rec_pool_join( funk->rec_pool, fd_wksp_laddr( wksp, shmem->rec_pool_gaddr ), fd_wksp_laddr_fast( wksp, shmem->rec_ele_gaddr ), shmem->rec_max ) ) ) {
+    FD_LOG_WARNING(( "failed to join rec_pool" ));
+    return NULL;
+  }
+  funk->alloc = fd_wksp_laddr( wksp, shmem->alloc_gaddr );
+  if( FD_UNLIKELY( !fd_alloc_join( funk->alloc, fd_tile_idx() ) ) ) {
+    FD_LOG_WARNING(( "failed to join funk alloc" ));
+    return NULL;
+  }
 
   return funk;
 }
 
 void *
-fd_funk_leave( fd_funk_t * funk ) {
+fd_funk_leave( fd_funk_t * funk,
+               void **     opt_shfunk ) {
 
   if( FD_UNLIKELY( !funk ) ) {
     FD_LOG_WARNING(( "NULL funk" ));
+    if( opt_shfunk ) *opt_shfunk = NULL;
     return NULL;
   }
+  void * shfunk = funk->shmem;
 
+  memset( funk, 0, sizeof(fd_funk_t) );
+
+  if( opt_shfunk ) *opt_shfunk = shfunk;
   return (void *)funk;
 }
 
 void *
 fd_funk_delete( void * shfunk ) {
-  fd_funk_t * funk = (fd_funk_t *)shfunk;
 
-#ifdef FD_FUNK_HANDHOLDING
-  if( FD_UNLIKELY( !funk ) ) {
+  if( FD_UNLIKELY( !shfunk ) ) {
     FD_LOG_WARNING(( "NULL shfunk" ));
     return NULL;
   }
 
-  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)funk, fd_funk_align() ) ) ) {
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shfunk, fd_funk_align() ) ) ) {
     FD_LOG_WARNING(( "misaligned shfunk" ));
     return NULL;
   }
 
-  if( FD_UNLIKELY( funk->magic!=FD_FUNK_MAGIC ) ) {
-    FD_LOG_WARNING(( "bad magic" ));
-    return NULL;
-  }
-#endif
-
-  fd_wksp_t * wksp = fd_wksp_containing( funk );
+  fd_wksp_t * wksp = fd_wksp_containing( shfunk );
   if( FD_UNLIKELY( !wksp ) ) {
     FD_LOG_WARNING(( "shfunk must be part of a workspace" ));
     return NULL;
   }
 
-  /* Free all the records */
-  fd_alloc_t * alloc = fd_funk_alloc( funk, wksp);
-  fd_funk_all_iter_t iter[1];
-  for( fd_funk_all_iter_new( funk, iter ); !fd_funk_all_iter_done( iter ); fd_funk_all_iter_next( iter ) ) {
-    fd_funk_rec_t * rec = fd_funk_all_iter_ele( iter );
-    fd_funk_val_flush( rec, alloc, wksp );
+  fd_funk_shmem_t * shmem = shfunk;
+  if( FD_UNLIKELY( shmem->magic!=FD_FUNK_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+    return NULL;
   }
 
-  /* Free the allocator */
+  /* Free all fd_alloc allocations made, individually
+     (FIXME consider walking the element pool instead of the map?) */
+
+  fd_alloc_t * alloc = fd_alloc_join( fd_wksp_laddr_fast( wksp, shmem->alloc_gaddr ), fd_tile_idx() );
+
+  void * shmap = fd_wksp_laddr_fast( wksp, shmem->rec_map_gaddr );
+  void * shele = fd_wksp_laddr_fast( wksp, shmem->rec_ele_gaddr );
+  fd_funk_rec_map_t rec_map[1];
+  if( FD_UNLIKELY( !fd_funk_rec_map_join( rec_map, shmap, shele, 0UL ) ) ) {
+    FD_LOG_ERR(( "failed to join rec_map (corrupt funk?)" ));
+    return NULL;
+  }
+  ulong chain_cnt = fd_funk_rec_map_chain_cnt( rec_map );
+  for( ulong chain_idx=0UL; chain_idx<chain_cnt; chain_idx++ ) {
+    for(
+        fd_funk_rec_map_iter_t iter = fd_funk_rec_map_iter( rec_map, chain_idx );
+        !fd_funk_rec_map_iter_done( iter );
+        iter = fd_funk_rec_map_iter_next( iter )
+    ) {
+      fd_funk_val_flush( fd_funk_rec_map_iter_ele( iter ), alloc, wksp );
+    }
+  }
+
+  fd_funk_rec_map_leave( rec_map );
+
+  /* Free the fd_alloc instance */
+
   fd_wksp_free_laddr( fd_alloc_delete( fd_alloc_leave( alloc ) ) );
 
   FD_COMPILER_MFENCE();
-  FD_VOLATILE( funk->magic ) = 0UL;
+  FD_VOLATILE( shmem->magic ) = 0UL;
   FD_COMPILER_MFENCE();
 
-  return funk;
+  return shmem;
 }
 
-#ifdef FD_FUNK_HANDHOLDING
+void
+fd_funk_delete_fast( void * shfunk ) {
+
+  if( FD_UNLIKELY( !shfunk ) ) {
+    FD_LOG_WARNING(( "NULL shfunk" ));
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shfunk, fd_funk_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned shfunk" ));
+  }
+
+  fd_funk_shmem_t * shmem = shfunk;
+  if( FD_UNLIKELY( shmem->magic!=FD_FUNK_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+  }
+
+  fd_wksp_t * wksp = fd_wksp_containing( shmem );
+  if( FD_UNLIKELY( !wksp ) ) {
+    FD_LOG_WARNING(( "shfunk must be part of a workspace" ));
+  }
+
+  ulong const tags[1] = { shmem->wksp_tag };
+  fd_wksp_tag_free( wksp, tags, 1UL );
+
+}
+
 int
-fd_funk_verify( fd_funk_t * funk ) {
+fd_funk_verify( fd_funk_t * join ) {
+  fd_funk_shmem_t * funk = join->shmem;
 
 # define TEST(c) do {                                                                           \
     if( FD_UNLIKELY( !(c) ) ) { FD_LOG_WARNING(( "FAIL: %s", #c )); return FD_FUNK_ERR_INVAL; } \
@@ -235,12 +316,12 @@ fd_funk_verify( fd_funk_t * funk ) {
 
   ulong funk_gaddr = funk->funk_gaddr;
   TEST( funk_gaddr );
-  fd_wksp_t * wksp = fd_funk_wksp( funk );
+  fd_wksp_t * wksp = fd_funk_wksp( join );
   TEST( wksp );
   TEST( fd_wksp_laddr_fast( wksp, funk_gaddr )==(void *)funk );
   TEST( fd_wksp_gaddr_fast( wksp, funk       )==funk_gaddr   );
 
-  ulong wksp_tag = fd_funk_wksp_tag( funk );
+  ulong wksp_tag = fd_funk_wksp_tag( join );
   TEST( !!wksp_tag );
 
   ulong seed = funk->seed; /* seed can be anything */
@@ -249,15 +330,15 @@ fd_funk_verify( fd_funk_t * funk ) {
 
   /* Test transaction map */
 
-  ulong txn_max = funk->txn_max;
+  ulong txn_max = fd_funk_txn_pool_ele_max( join->txn_pool );
   TEST( txn_max<=FD_FUNK_TXN_IDX_NULL );
 
   ulong txn_map_gaddr = funk->txn_map_gaddr;
   TEST( txn_map_gaddr );
-  fd_funk_txn_map_t txn_map = fd_funk_txn_map( funk, wksp );
+  fd_funk_txn_map_t * txn_map = fd_funk_txn_map( join );
   ulong txn_chain_cnt = fd_funk_txn_map_chain_cnt_est( txn_max );
-  TEST( txn_chain_cnt==fd_funk_txn_map_chain_cnt( &txn_map ) );
-  TEST( seed==fd_funk_txn_map_seed( &txn_map ) );
+  TEST( txn_chain_cnt==fd_funk_txn_map_chain_cnt( txn_map ) );
+  TEST( seed==fd_funk_txn_map_seed( txn_map ) );
 
   ulong child_head_idx = fd_funk_txn_idx( funk->child_head_cidx );
   ulong child_tail_idx = fd_funk_txn_idx( funk->child_tail_cidx );
@@ -276,7 +357,7 @@ fd_funk_verify( fd_funk_t * funk ) {
 
   if( !txn_max ) TEST( fd_funk_txn_idx_is_null( child_tail_idx ) );
 
-  fd_funk_txn_xid_t const * root = fd_funk_root( funk );
+  fd_funk_txn_xid_t const * root = fd_funk_root( join );
   TEST( root ); /* Practically guaranteed */
   TEST( fd_funk_txn_xid_eq_root( root ) );
 
@@ -286,19 +367,19 @@ fd_funk_verify( fd_funk_t * funk ) {
      creation.  But we don't know which situation applies here so this
      could be anything. */
 
-  TEST( !fd_funk_txn_verify( funk ) );
+  TEST( !fd_funk_txn_verify( join ) );
 
   /* Test record map */
 
-  ulong rec_max = funk->rec_max;
+  ulong rec_max = fd_funk_rec_pool_ele_max( join->rec_pool );
   TEST( rec_max<=FD_FUNK_TXN_IDX_NULL );
 
   ulong rec_map_gaddr = funk->rec_map_gaddr;
   TEST( rec_map_gaddr );
-  fd_funk_rec_map_t rec_map = fd_funk_rec_map( funk, wksp );
+  fd_funk_rec_map_t * rec_map = fd_funk_rec_map( join );
   ulong rec_chain_cnt = fd_funk_rec_map_chain_cnt_est( rec_max );
-  TEST( rec_chain_cnt==fd_funk_rec_map_chain_cnt( &rec_map ) );
-  TEST( seed==fd_funk_rec_map_seed( &rec_map ) );
+  TEST( rec_chain_cnt==fd_funk_rec_map_chain_cnt( rec_map ) );
+  TEST( seed==fd_funk_rec_map_seed( rec_map ) );
 
   uint rec_head_idx = funk->rec_head_idx;
   uint rec_tail_idx = funk->rec_tail_idx;
@@ -317,19 +398,18 @@ fd_funk_verify( fd_funk_t * funk ) {
 
   if( !rec_max ) TEST( fd_funk_rec_idx_is_null( rec_tail_idx ) );
 
-  TEST( !fd_funk_rec_verify( funk ) );
+  TEST( !fd_funk_rec_verify( join ) );
 
   /* Test values */
 
   ulong alloc_gaddr = funk->alloc_gaddr;
   TEST( alloc_gaddr );
-  fd_alloc_t * alloc = fd_funk_alloc( funk, wksp );
+  fd_alloc_t * alloc = fd_funk_alloc( join );
   TEST( alloc );
 
-  TEST( !fd_funk_val_verify( funk ) );
+  TEST( !fd_funk_val_verify( join ) );
 
 # undef TEST
 
   return FD_FUNK_SUCCESS;
 }
-#endif

--- a/src/funk/fd_funk_base.h
+++ b/src/funk/fd_funk_base.h
@@ -125,7 +125,12 @@ struct fd_funk_xid_key_pair {
 
 typedef struct fd_funk_xid_key_pair fd_funk_xid_key_pair_t;
 
-/* A fd_funk_t * is an opaque handle of a local join to a funk instance */
+/* A fd_funk_shmem_t is the top part of a funk object in shared memory. */
+
+struct fd_funk_shmem_private;
+typedef struct fd_funk_shmem_private fd_funk_shmem_t;
+
+/* A fd_funk_t * is local join handle to a funk instance */
 
 struct fd_funk_private;
 typedef struct fd_funk_private fd_funk_t;

--- a/src/funk/fd_funk_filemap.c
+++ b/src/funk/fd_funk_filemap.c
@@ -11,14 +11,15 @@
 #define PAGESIZE (1UL<<12)  /* 4 KiB */
 
 fd_funk_t *
-fd_funk_open_file( const char * filename,
-                      ulong        wksp_tag,
-                      ulong        seed,
-                      ulong        txn_max,
-                      uint         rec_max,
-                      ulong        total_sz,
-                      fd_funk_file_mode_t mode,
-                      fd_funk_close_file_args_t * close_args_out ) {
+fd_funk_open_file( void *       ljoin,
+                   const char * filename,
+                   ulong        wksp_tag,
+                   ulong        seed,
+                   ulong        txn_max,
+                   ulong        rec_max,
+                   ulong        total_sz,
+                   fd_funk_file_mode_t mode,
+                   fd_funk_close_file_args_t * close_args_out ) {
 
   /* See if we already have the file open */
 
@@ -34,14 +35,14 @@ fd_funk_open_file( const char * filename,
 
       fd_wksp_tag_query_info_t info2;
       if( FD_UNLIKELY( !fd_wksp_tag_query( wksp, &wksp_tag, 1, &info2, 1 ) ) ) {
-        FD_LOG_WARNING(( "%s does not contain a funky", filename ));
+        FD_LOG_WARNING(( "%s does not contain a funk database", filename ));
         return NULL;
       }
 
       void * funk_shmem = fd_wksp_laddr_fast( wksp, info2.gaddr_lo );
-      fd_funk_t * funk = fd_funk_join( funk_shmem );
+      fd_funk_t * funk = fd_funk_join( ljoin, funk_shmem );
       if( FD_UNLIKELY( funk == NULL ) ) {
-        FD_LOG_WARNING(( "failed to join a funky" ));
+        FD_LOG_WARNING(( "Failed to join funk database at %s:0x%lx", fd_wksp_name( wksp ), info2.gaddr_lo ));
         return NULL;
       }
 
@@ -226,7 +227,7 @@ fd_funk_open_file( const char * filename,
       return NULL;
     }
 
-    fd_funk_t * funk = fd_funk_join( fd_funk_new( funk_shmem, wksp_tag, seed, txn_max, rec_max ) );
+    fd_funk_t * funk = fd_funk_join( ljoin, fd_funk_new( funk_shmem, wksp_tag, seed, txn_max, rec_max ) );
     if( FD_UNLIKELY( funk == NULL ) ) {
       FD_LOG_WARNING(( "failed to allocate a funky" ));
       munmap( shmem, total_sz );
@@ -271,7 +272,7 @@ fd_funk_open_file( const char * filename,
     }
 
     void * funk_shmem = fd_wksp_laddr_fast( wksp, info.gaddr_lo );
-    fd_funk_t * funk = fd_funk_join( funk_shmem );
+    fd_funk_t * funk = fd_funk_join( ljoin, funk_shmem );
     if( FD_UNLIKELY( funk == NULL ) ) {
       FD_LOG_WARNING(( "failed to join a funky" ));
       munmap( shmem, total_sz );
@@ -297,10 +298,11 @@ fd_funk_open_file( const char * filename,
 }
 
 fd_funk_t *
-fd_funk_recover_checkpoint( const char * funk_filename,
-                               ulong        wksp_tag,
-                               const char * checkpt_filename,
-                               fd_funk_close_file_args_t * close_args_out ) {
+fd_funk_recover_checkpoint( void *       ljoin,
+                            const char * funk_filename,
+                            ulong        wksp_tag,
+                            const char * checkpt_filename,
+                            fd_funk_close_file_args_t * close_args_out ) {
   /* Make the funk workspace match the parameters used to create the
      checkpoint. */
 
@@ -421,7 +423,7 @@ fd_funk_recover_checkpoint( const char * funk_filename,
   }
 
   void * funk_shmem = fd_wksp_laddr_fast( wksp, info.gaddr_lo );
-  fd_funk_t * funk = fd_funk_join( funk_shmem );
+  fd_funk_t * funk = fd_funk_join( ljoin, funk_shmem );
   if( FD_UNLIKELY( funk == NULL ) ) {
     FD_LOG_WARNING(( "failed to join a funky" ));
     munmap( shmem, total_sz );

--- a/src/funk/fd_funk_filemap.h
+++ b/src/funk/fd_funk_filemap.h
@@ -35,14 +35,15 @@ typedef struct fd_funk_close_file_args fd_funk_close_file_args_t;
    an existing file is opened without being overwritten. */
 
 fd_funk_t *
-fd_funk_open_file( const char * filename,
-                      ulong        wksp_tag,
-                      ulong        seed,
-                      ulong        txn_max,
-                      uint         rec_max,
-                      ulong        total_sz,
-                      fd_funk_file_mode_t mode,
-                      fd_funk_close_file_args_t * close_args_out );
+fd_funk_open_file( void *       ljoin,
+                   const char * filename,
+                   ulong        wksp_tag,
+                   ulong        seed,
+                   ulong        txn_max,
+                   ulong        rec_max,
+                   ulong        total_sz,
+                   fd_funk_file_mode_t mode,
+                   fd_funk_close_file_args_t * close_args_out );
 
 /* Load a workspace checkpoint containing a funk
    instance. funk_filename is the backing file, or NULL for a
@@ -52,10 +53,11 @@ fd_funk_open_file( const char * filename,
    filled in. This is needed for fd_funk_close_file. */
 
 fd_funk_t *
-fd_funk_recover_checkpoint( const char * funk_filename,
-                               ulong        wksp_tag,
-                               const char * checkpt_filename,
-                               fd_funk_close_file_args_t * close_args_out );
+fd_funk_recover_checkpoint( void *       ljoin,
+                            const char * funk_filename,
+                            ulong        wksp_tag,
+                            const char * checkpt_filename,
+                            fd_funk_close_file_args_t * close_args_out );
 
 /* Release the resources associated with a funk file map. The funk
    pointer is invalid after this is called. */

--- a/src/funk/fd_funk_rec.c
+++ b/src/funk/fd_funk_rec.c
@@ -37,8 +37,6 @@ fd_funk_rec_query_try( fd_funk_t *               funk,
   }
 #endif
 
-  fd_wksp_t * wksp          = fd_funk_wksp( funk );
-  fd_funk_rec_map_t rec_map = fd_funk_rec_map( funk, wksp );
   fd_funk_xid_key_pair_t pair[1];
   if( txn == NULL ) {
     fd_funk_txn_xid_set_root( pair->xid );
@@ -47,7 +45,7 @@ fd_funk_rec_query_try( fd_funk_t *               funk,
   }
   fd_funk_rec_key_copy( pair->key, key );
   for(;;) {
-    int err = fd_funk_rec_map_query_try( &rec_map, pair, NULL, query, 0 );
+    int err = fd_funk_rec_map_query_try( funk->rec_map, pair, NULL, query, 0 );
     if( err == FD_MAP_SUCCESS )   break;
     if( err == FD_MAP_ERR_KEY )   return NULL;
     if( err == FD_MAP_ERR_AGAIN ) continue;
@@ -57,7 +55,7 @@ fd_funk_rec_query_try( fd_funk_t *               funk,
 }
 
 fd_funk_rec_t const *
-fd_funk_rec_query_try_global( fd_funk_t *               funk,
+fd_funk_rec_query_try_global( fd_funk_t const *         funk,
                               fd_funk_txn_t const *     txn,
                               fd_funk_rec_key_t const * key,
                               fd_funk_txn_t const **    txn_out,
@@ -76,10 +74,6 @@ fd_funk_rec_query_try_global( fd_funk_t *               funk,
      the same record key appear on the same hash chain in order of
      newest to oldest. */
 
-  fd_wksp_t * wksp            = fd_funk_wksp( funk );
-  fd_funk_rec_map_t rec_map   = fd_funk_rec_map( funk, wksp );
-  fd_funk_txn_pool_t txn_pool = fd_funk_txn_pool( funk, wksp );
-
   fd_funk_xid_key_pair_t pair[1];
   if( txn == NULL ) {
     fd_funk_txn_xid_set_root( pair->xid );
@@ -87,15 +81,17 @@ fd_funk_rec_query_try_global( fd_funk_t *               funk,
     fd_funk_txn_xid_copy( pair->xid, &txn->xid );
   }
   fd_funk_rec_key_copy( pair->key, key );
-  ulong hash  = fd_funk_rec_map_key_hash( pair, rec_map.map->seed );
-  ulong chain_idx = (hash & (rec_map.map->chain_cnt-1UL) );
 
-  fd_funk_rec_map_shmem_private_chain_t * chain = (fd_funk_rec_map_shmem_private_chain_t *)(rec_map.map+1) + chain_idx;
+  fd_funk_rec_map_shmem_t * rec_map = funk->rec_map->map;
+  ulong hash = fd_funk_rec_map_key_hash( pair, rec_map->seed );
+  ulong chain_idx = (hash & (rec_map->chain_cnt-1UL) );
+
+  fd_funk_rec_map_shmem_private_chain_t * chain = fd_funk_rec_map_shmem_private_chain( rec_map, hash );
   query->ele     = NULL;
   query->chain   = chain;
   query->ver_cnt = chain->ver_cnt; /* After unlock */
 
-  for( fd_funk_rec_map_iter_t iter = fd_funk_rec_map_iter( &rec_map, chain_idx );
+  for( fd_funk_rec_map_iter_t iter = fd_funk_rec_map_iter( funk->rec_map, chain_idx );
        !fd_funk_rec_map_iter_done( iter );
        iter = fd_funk_rec_map_iter_next( iter ) ) {
     fd_funk_rec_t const * ele = fd_funk_rec_map_iter_ele_const( iter );
@@ -103,7 +99,7 @@ fd_funk_rec_query_try_global( fd_funk_t *               funk,
 
       /* For cur_txn in path from [txn] to [root] where root is NULL */
 
-      for( fd_funk_txn_t const * cur_txn = txn; ; cur_txn = fd_funk_txn_parent( cur_txn, &txn_pool ) ) {
+      for( fd_funk_txn_t const * cur_txn = txn; ; cur_txn = fd_funk_txn_parent( cur_txn, funk->txn_pool ) ) {
         /* If record ele is part of transaction cur_txn, we have a
            match. According to the property above, this will be the
            youngest descendent in the transaction stack. */
@@ -133,7 +129,6 @@ fd_funk_rec_query_copy( fd_funk_t *               funk,
                         fd_valloc_t               valloc,
                         ulong *                   sz_out ) {
   *sz_out = ULONG_MAX;
-  fd_funk_rec_map_t rec_map = fd_funk_rec_map( funk, fd_funk_wksp( funk ) );
   fd_funk_xid_key_pair_t pair[1];
   if( txn == NULL ) {
     fd_funk_txn_xid_set_root( pair->xid );
@@ -145,7 +140,7 @@ fd_funk_rec_query_copy( fd_funk_t *               funk,
   ulong last_copy_sz = 0;
   for(;;) {
     fd_funk_rec_query_t query[1];
-    int err = fd_funk_rec_map_query_try( &rec_map, pair, NULL, query, 0 );
+    int err = fd_funk_rec_map_query_try( funk->rec_map, pair, NULL, query, 0 );
     if( err == FD_MAP_ERR_KEY )   {
       if( last_copy ) fd_valloc_free( valloc, last_copy );
       return NULL;
@@ -201,10 +196,7 @@ fd_funk_rec_prepare( fd_funk_t *               funk,
     }
   }
 
-  prepare->funk = funk;
-  prepare->wksp = fd_funk_wksp( funk );
-  fd_funk_rec_pool_t rec_pool = fd_funk_rec_pool( funk, prepare->wksp );
-  fd_funk_rec_t * rec = prepare->rec = fd_funk_rec_pool_acquire( &rec_pool, NULL, 1, opt_err );
+  fd_funk_rec_t * rec = prepare->rec = fd_funk_rec_pool_acquire( funk->rec_pool, NULL, 1, opt_err );
   if( opt_err && *opt_err == FD_POOL_ERR_CORRUPT ) {
     FD_LOG_ERR(( "corrupt element returned from funk rec pool" ));
   }
@@ -213,13 +205,12 @@ fd_funk_rec_prepare( fd_funk_t *               funk,
     if( txn == NULL ) {
       fd_funk_txn_xid_set_root( rec->pair.xid );
       rec->txn_cidx = fd_funk_txn_cidx( FD_FUNK_TXN_IDX_NULL );
-      prepare->rec_head_idx = &funk->rec_head_idx;
-      prepare->rec_tail_idx = &funk->rec_tail_idx;
-      prepare->txn_lock     = &funk->lock;
+      prepare->rec_head_idx = &funk->shmem->rec_head_idx;
+      prepare->rec_tail_idx = &funk->shmem->rec_tail_idx;
+      prepare->txn_lock     = &funk->shmem->lock;
     } else {
       fd_funk_txn_xid_copy( rec->pair.xid, &txn->xid );
-      fd_funk_txn_pool_t txn_pool = fd_funk_txn_pool( funk, prepare->wksp );
-      rec->txn_cidx = fd_funk_txn_cidx( (ulong)( txn - txn_pool.ele ) );
+      rec->txn_cidx = fd_funk_txn_cidx( (ulong)( txn - funk->txn_pool->ele ) );
       prepare->rec_head_idx = &txn->rec_head_idx;
       prepare->rec_tail_idx = &txn->rec_tail_idx;
       prepare->txn_lock     = &txn->lock;
@@ -237,29 +228,28 @@ fd_funk_rec_prepare( fd_funk_t *               funk,
 }
 
 void
-fd_funk_rec_publish( fd_funk_rec_prepare_t * prepare ) {
+fd_funk_rec_publish( fd_funk_t *             funk,
+                     fd_funk_rec_prepare_t * prepare ) {
   fd_funk_rec_t * rec = prepare->rec;
   uint * rec_head_idx = prepare->rec_head_idx;
   uint * rec_tail_idx = prepare->rec_tail_idx;
-  fd_funk_rec_map_t rec_map = fd_funk_rec_map( prepare->funk, prepare->wksp );
-  fd_funk_rec_pool_t rec_pool = fd_funk_rec_pool( prepare->funk, prepare->wksp );
 
   /* Lock the txn */
   while( FD_ATOMIC_CAS( prepare->txn_lock, 0, 1 ) ) FD_SPIN_PAUSE();
 
   uint rec_prev_idx;
-  uint rec_idx  = (uint)( rec - rec_pool.ele );
-  rec_prev_idx  = *rec_tail_idx;
+  uint rec_idx = (uint)( rec - funk->rec_pool->ele );
+  rec_prev_idx = *rec_tail_idx;
   *rec_tail_idx = rec_idx;
   rec->prev_idx = rec_prev_idx;
   rec->next_idx = FD_FUNK_REC_IDX_NULL;
   if( fd_funk_rec_idx_is_null( rec_prev_idx ) ) {
     *rec_head_idx = rec_idx;
   } else {
-    rec_pool.ele[ rec_prev_idx ].next_idx = rec_idx;
+    funk->rec_pool->ele[ rec_prev_idx ].next_idx = rec_idx;
   }
 
-  if( fd_funk_rec_map_insert( &rec_map, rec, FD_MAP_FLAG_BLOCKING ) ) {
+  if( fd_funk_rec_map_insert( funk->rec_map, rec, FD_MAP_FLAG_BLOCKING ) ) {
     FD_LOG_CRIT(( "fd_funk_rec_map_insert failed" ));
   }
 
@@ -267,10 +257,10 @@ fd_funk_rec_publish( fd_funk_rec_prepare_t * prepare ) {
 }
 
 void
-fd_funk_rec_cancel( fd_funk_rec_prepare_t * prepare ) {
-  fd_funk_val_flush( prepare->rec, fd_funk_alloc( prepare->funk, prepare->wksp ), prepare->wksp );
-  fd_funk_rec_pool_t rec_pool = fd_funk_rec_pool( prepare->funk, prepare->wksp );
-  fd_funk_rec_pool_release( &rec_pool, prepare->rec, 1 );
+fd_funk_rec_cancel( fd_funk_t *             funk,
+                    fd_funk_rec_prepare_t * prepare ) {
+  fd_funk_val_flush( prepare->rec, funk->alloc, funk->wksp );
+  fd_funk_rec_pool_release( funk->rec_pool, prepare->rec, 1 );
 }
 
 fd_funk_rec_t *
@@ -287,15 +277,15 @@ fd_funk_rec_clone( fd_funk_t *               funk,
     fd_funk_rec_t const * old_rec = fd_funk_rec_query_try_global( funk, txn, key, NULL, query );
     if( !old_rec ) {
       fd_int_store_if( !!opt_err, opt_err, FD_FUNK_ERR_KEY );
-      fd_funk_rec_cancel( prepare );
+      fd_funk_rec_cancel( funk, prepare );
       return NULL;
     }
 
     fd_wksp_t * wksp = fd_funk_wksp( funk );
     ulong val_sz     = old_rec->val_sz;
-    void * buf = fd_funk_val_truncate( new_rec, val_sz, fd_funk_alloc( funk, wksp ), wksp, opt_err );
+    void * buf = fd_funk_val_truncate( new_rec, val_sz, funk->alloc, wksp, opt_err );
     if( !buf ) {
-      fd_funk_rec_cancel( prepare );
+      fd_funk_rec_cancel( funk, prepare );
       return NULL;
     }
     memcpy( buf, fd_funk_val( old_rec, wksp ), val_sz );
@@ -306,23 +296,10 @@ fd_funk_rec_clone( fd_funk_t *               funk,
   }
 }
 
-int
-fd_funk_rec_is_full( fd_funk_t * funk ) {
-  fd_wksp_t * wksp            = fd_funk_wksp( funk );
-  fd_funk_rec_pool_t rec_pool = fd_funk_rec_pool( funk, wksp );
-  return fd_funk_rec_pool_is_empty( &rec_pool );
-}
-
 void
 fd_funk_rec_hard_remove( fd_funk_t *               funk,
                          fd_funk_txn_t *           txn,
                          fd_funk_rec_key_t const * key ) {
-
-  fd_wksp_t * wksp            = fd_funk_wksp( funk );
-  fd_alloc_t * alloc          = fd_funk_alloc( funk, wksp );
-  fd_funk_rec_map_t rec_map   = fd_funk_rec_map( funk, wksp );
-  fd_funk_rec_pool_t rec_pool = fd_funk_rec_pool( funk, wksp );
-
   fd_funk_xid_key_pair_t pair[1];
   if( txn == NULL ) {
     fd_funk_txn_xid_set_root( pair->xid );
@@ -333,7 +310,7 @@ fd_funk_rec_hard_remove( fd_funk_t *               funk,
 
   uchar * lock = NULL;
   if( txn==NULL ) {
-    lock = &funk->lock;
+    lock = &funk->shmem->lock;
   } else {
     lock = &txn->lock;
   }
@@ -343,7 +320,7 @@ fd_funk_rec_hard_remove( fd_funk_t *               funk,
   fd_funk_rec_t * rec = NULL;
   for(;;) {
     fd_funk_rec_map_query_t rec_query[1];
-    int err = fd_funk_rec_map_remove( &rec_map, pair, NULL, rec_query, FD_MAP_FLAG_BLOCKING );
+    int err = fd_funk_rec_map_remove( funk->rec_map, pair, NULL, rec_query, FD_MAP_FLAG_BLOCKING );
     if( FD_UNLIKELY( err == FD_MAP_ERR_AGAIN ) ) continue;
     if( err == FD_MAP_ERR_KEY ) {
       FD_VOLATILE( *lock ) = 0;
@@ -357,21 +334,21 @@ fd_funk_rec_hard_remove( fd_funk_t *               funk,
   uint prev_idx = rec->prev_idx;
   uint next_idx = rec->next_idx;
   if( txn == NULL ) {
-    if( fd_funk_rec_idx_is_null( prev_idx ) ) funk->rec_head_idx                = next_idx;
-    else                                      rec_pool.ele[ prev_idx ].next_idx = next_idx;
-    if( fd_funk_rec_idx_is_null( next_idx ) ) funk->rec_tail_idx                = prev_idx;
-    else                                      rec_pool.ele[ next_idx ].prev_idx = prev_idx;
+    if( fd_funk_rec_idx_is_null( prev_idx ) ) funk->shmem->rec_head_idx                = next_idx;
+    else                                      funk->rec_pool->ele[ prev_idx ].next_idx = next_idx;
+    if( fd_funk_rec_idx_is_null( next_idx ) ) funk->shmem->rec_tail_idx                = prev_idx;
+    else                                      funk->rec_pool->ele[ next_idx ].prev_idx = prev_idx;
   } else {
-    if( fd_funk_rec_idx_is_null( prev_idx ) ) txn->rec_head_idx                 = next_idx;
-    else                                      rec_pool.ele[ prev_idx ].next_idx = next_idx;
-    if( fd_funk_rec_idx_is_null( next_idx ) ) txn->rec_tail_idx                 = prev_idx;
-    else                                      rec_pool.ele[ next_idx ].prev_idx = prev_idx;
+    if( fd_funk_rec_idx_is_null( prev_idx ) ) txn->rec_head_idx                        = next_idx;
+    else                                      funk->rec_pool->ele[ prev_idx ].next_idx = next_idx;
+    if( fd_funk_rec_idx_is_null( next_idx ) ) txn->rec_tail_idx                        = prev_idx;
+    else                                      funk->rec_pool->ele[ next_idx ].prev_idx = prev_idx;
   }
 
   FD_VOLATILE( *lock ) = 0;
 
-  fd_funk_val_flush( rec, alloc, wksp );
-  fd_funk_rec_pool_release( &rec_pool, rec, 1 );
+  fd_funk_val_flush( rec, funk->alloc, funk->wksp );
+  fd_funk_rec_pool_release( funk->rec_pool, rec, 1 );
 }
 
 int
@@ -399,8 +376,6 @@ fd_funk_rec_remove( fd_funk_t *               funk,
     }
   }
 
-  fd_wksp_t * wksp          = fd_funk_wksp( funk );
-  fd_funk_rec_map_t rec_map = fd_funk_rec_map( funk, wksp );
   fd_funk_xid_key_pair_t pair[1];
   if( txn == NULL ) {
     fd_funk_txn_xid_set_root( pair->xid );
@@ -410,7 +385,7 @@ fd_funk_rec_remove( fd_funk_t *               funk,
   fd_funk_rec_key_copy( pair->key, key );
   fd_funk_rec_query_t query[ 1 ];
   for(;;) {
-    int err = fd_funk_rec_map_query_try( &rec_map, pair, NULL, query, 0 );
+    int err = fd_funk_rec_map_query_try( funk->rec_map, pair, NULL, query, 0 );
     if( err == FD_MAP_SUCCESS )   break;
     if( err == FD_MAP_ERR_KEY )   return FD_FUNK_SUCCESS;
     if( err == FD_MAP_ERR_AGAIN ) continue;
@@ -432,7 +407,7 @@ fd_funk_rec_remove( fd_funk_t *               funk,
      lead to an unbounded number of records, but for application
      reasons, we need to remember what was deleted. */
 
-  fd_funk_val_flush( rec, fd_funk_alloc( funk, wksp ), wksp );
+  fd_funk_val_flush( rec, funk->alloc, funk->wksp );
 
   /* At this point, the 5 most significant bytes should store data about the
      transaction that the record was updated in. */
@@ -460,21 +435,16 @@ fd_funk_rec_forget( fd_funk_t *      funk,
   if( FD_UNLIKELY( !funk ) ) return FD_FUNK_ERR_INVAL;
 #endif
 
-  fd_wksp_t * wksp            = fd_funk_wksp( funk );
-  fd_alloc_t * alloc          = fd_funk_alloc( funk, wksp );
-  fd_funk_rec_map_t rec_map   = fd_funk_rec_map( funk, wksp );
-  fd_funk_rec_pool_t rec_pool = fd_funk_rec_pool( funk, wksp );
-
 #ifdef FD_FUNK_HANDHOLDING
-  ulong rec_max = funk->rec_max;
+  ulong rec_max = funk->shmem->rec_max;
 #endif
 
   for( ulong i = 0; i < recs_cnt; ++i ) {
     fd_funk_rec_t * rec = recs[i];
 
 #ifdef FD_FUNK_HANDHOLDING
-    ulong rec_idx = (ulong)(rec - rec_pool.ele);
-    if( FD_UNLIKELY( (rec_idx>=rec_max) /* Out of map (incl NULL) */ | (rec!=(rec_pool.ele+rec_idx)) /* Bad alignment */ ) )
+    ulong rec_idx = (ulong)(rec - funk->rec_pool->ele);
+    if( FD_UNLIKELY( (rec_idx>=rec_max) /* Out of map (incl NULL) */ | (rec!=(funk->rec_pool->ele+rec_idx)) /* Bad alignment */ ) )
       return FD_FUNK_ERR_INVAL;
 #endif
 
@@ -486,7 +456,7 @@ fd_funk_rec_forget( fd_funk_t *      funk,
 
     for(;;) {
       fd_funk_rec_map_query_t rec_query[1];
-      int err = fd_funk_rec_map_remove( &rec_map, fd_funk_rec_pair( rec ), NULL, rec_query, FD_MAP_FLAG_BLOCKING );
+      int err = fd_funk_rec_map_remove( funk->rec_map, fd_funk_rec_pair( rec ), NULL, rec_query, FD_MAP_FLAG_BLOCKING );
       if( FD_UNLIKELY( err == FD_MAP_ERR_AGAIN ) ) continue;
       if( err == FD_MAP_ERR_KEY ) return FD_FUNK_ERR_KEY;
       if( FD_UNLIKELY( err != FD_MAP_SUCCESS ) ) FD_LOG_CRIT(( "map corruption" ));
@@ -496,13 +466,13 @@ fd_funk_rec_forget( fd_funk_t *      funk,
 
     uint prev_idx = rec->prev_idx;
     uint next_idx = rec->next_idx;
-    if( fd_funk_rec_idx_is_null( prev_idx ) ) funk->rec_head_idx =                next_idx;
-    else                                         rec_pool.ele[ prev_idx ].next_idx = next_idx;
-    if( fd_funk_rec_idx_is_null( next_idx ) ) funk->rec_tail_idx =                prev_idx;
-    else                                         rec_pool.ele[ next_idx ].prev_idx = prev_idx;
+    if( fd_funk_rec_idx_is_null( prev_idx ) ) funk->shmem->rec_head_idx =                next_idx;
+    else                                      funk->rec_pool->ele[ prev_idx ].next_idx = next_idx;
+    if( fd_funk_rec_idx_is_null( next_idx ) ) funk->shmem->rec_tail_idx =                prev_idx;
+    else                                      funk->rec_pool->ele[ next_idx ].prev_idx = prev_idx;
 
-    fd_funk_val_flush( rec, alloc, wksp );
-    fd_funk_rec_pool_release( &rec_pool, rec, 1 );
+    fd_funk_val_flush( rec, funk->alloc, funk->wksp );
+    fd_funk_rec_pool_release( funk->rec_pool, rec, 1 );
   }
 
   return FD_FUNK_SUCCESS;
@@ -519,8 +489,7 @@ fd_funk_all_iter_skip_nulls( fd_funk_all_iter_t * iter ) {
 
 void
 fd_funk_all_iter_new( fd_funk_t * funk, fd_funk_all_iter_t * iter ) {
-  fd_wksp_t * wksp   = fd_funk_wksp( funk );
-  iter->rec_map      = fd_funk_rec_map( funk, wksp );
+  iter->rec_map      = *funk->rec_map;
   iter->chain_cnt    = fd_funk_rec_map_chain_cnt( &iter->rec_map );
   iter->chain_idx    = 0;
   iter->rec_map_iter = fd_funk_rec_map_iter( &iter->rec_map, 0 );
@@ -548,89 +517,88 @@ fd_funk_all_iter_ele( fd_funk_all_iter_t * iter ) {
   return fd_funk_rec_map_iter_ele( iter->rec_map_iter );
 }
 
-#ifdef FD_FUNK_HANDHOLDING
 int
 fd_funk_rec_verify( fd_funk_t * funk ) {
-  fd_wksp_t *           wksp     = fd_funk_wksp( funk );          /* Previously verified */
-  fd_funk_txn_map_t  txn_map  = fd_funk_txn_map( funk, wksp ); /* Previously verified */
-  fd_funk_rec_map_t  rec_map  = fd_funk_rec_map( funk, wksp ); /* Previously verified */
-  fd_funk_txn_pool_t txn_pool = fd_funk_txn_pool( funk, wksp ); /* Previously verified */
-  fd_funk_rec_pool_t rec_pool = fd_funk_rec_pool( funk, wksp ); /* Previously verified */
-  ulong                 txn_max  = funk->txn_max;                 /* Previously verified */
-  ulong                 rec_max  = funk->rec_max;                 /* Previously verified */
-
-  /* At this point, txn_map has been extensively verified */
+  fd_funk_rec_map_t *  rec_map  = funk->rec_map;
+  fd_funk_rec_pool_t * rec_pool = funk->rec_pool;
+  fd_funk_txn_pool_t * txn_pool = funk->txn_pool;
+  ulong txn_max = fd_funk_txn_pool_ele_max( txn_pool );
+  ulong rec_max = fd_funk_rec_pool_ele_max( rec_pool );
 
 # define TEST(c) do {                                                                           \
     if( FD_UNLIKELY( !(c) ) ) { FD_LOG_WARNING(( "FAIL: %s", #c )); return FD_FUNK_ERR_INVAL; } \
   } while(0)
 
-  TEST( !fd_funk_rec_map_verify( &rec_map ) );
-  TEST( !fd_funk_rec_pool_verify( &rec_pool ) );
+  TEST( !fd_funk_rec_map_verify( rec_map ) );
+  TEST( !fd_funk_rec_pool_verify( rec_pool ) );
 
-  /* Iterate over all records in use */
+  /* Iterate (again) over all records in use */
 
-  fd_funk_all_iter_t iter[1];
-  for( fd_funk_all_iter_new( funk, iter ); !fd_funk_all_iter_done( iter ); fd_funk_all_iter_next( iter ) ) {
-    fd_funk_rec_t const * rec = fd_funk_all_iter_ele_const( iter );
+  ulong chain_cnt = fd_funk_rec_map_chain_cnt( rec_map );
+  for( ulong chain_idx=0UL; chain_idx<chain_cnt; chain_idx++ ) {
+    for( fd_funk_rec_map_iter_t iter = fd_funk_rec_map_iter( rec_map, chain_idx );
+         !fd_funk_rec_map_iter_done( iter );
+         iter = fd_funk_rec_map_iter_next( iter ) ) {
+      fd_funk_rec_t const * rec = fd_funk_rec_map_iter_ele_const( iter );
 
-    /* Make sure every record either links up with the last published
-       transaction or an in-prep transaction and the flags are sane. */
+      /* Make sure every record either links up with the last published
+         transaction or an in-prep transaction and the flags are sane. */
 
-    fd_funk_txn_xid_t const * txn_xid = fd_funk_rec_xid( rec );
-    ulong                        txn_idx = fd_funk_txn_idx( rec->txn_cidx );
+      fd_funk_txn_xid_t const * txn_xid = fd_funk_rec_xid( rec );
+      ulong                     txn_idx = fd_funk_txn_idx( rec->txn_cidx );
 
-    if( fd_funk_txn_idx_is_null( txn_idx ) ) { /* This is a record from the last published transaction */
+      if( fd_funk_txn_idx_is_null( txn_idx ) ) { /* This is a record from the last published transaction */
 
-      TEST( fd_funk_txn_xid_eq_root( txn_xid ) );
+        TEST( fd_funk_txn_xid_eq_root( txn_xid ) );
 
-    } else { /* This is a record from an in-prep transaction */
+      } else { /* This is a record from an in-prep transaction */
 
-      TEST( txn_idx<txn_max );
-      fd_funk_txn_t const * txn = fd_funk_txn_query( txn_xid, &txn_map );
-      TEST( txn );
-      TEST( txn==(txn_pool.ele+txn_idx) );
+        TEST( txn_idx<txn_max );
+        fd_funk_txn_t const * txn = fd_funk_txn_query( txn_xid, funk->txn_map );
+        TEST( txn );
+        TEST( txn==(funk->txn_pool->ele+txn_idx) );
 
+      }
     }
   }
 
   /* Clear record tags and then verify the forward and reverse linkage */
 
-  for( ulong rec_idx=0UL; rec_idx<rec_max; rec_idx++ ) rec_pool.ele[ rec_idx ].tag = 0U;
+  for( ulong rec_idx=0UL; rec_idx<rec_max; rec_idx++ ) rec_pool->ele[ rec_idx ].tag = 0U;
 
   do {
     ulong txn_idx = FD_FUNK_TXN_IDX_NULL;
-    uint rec_idx = funk->rec_head_idx;
+    uint  rec_idx = funk->shmem->rec_head_idx;
     while( !fd_funk_rec_idx_is_null( rec_idx ) ) {
-      TEST( (rec_idx<rec_max) && (fd_funk_txn_idx( rec_pool.ele[ rec_idx ].txn_cidx )==txn_idx) && rec_pool.ele[ rec_idx ].tag==0U );
-      rec_pool.ele[ rec_idx ].tag = 1U;
+      TEST( (rec_idx<rec_max) && (fd_funk_txn_idx( rec_pool->ele[ rec_idx ].txn_cidx )==txn_idx) && rec_pool->ele[ rec_idx ].tag==0U );
+      rec_pool->ele[ rec_idx ].tag = 1U;
       fd_funk_rec_query_t query[1];
-      fd_funk_rec_t const * rec2 = fd_funk_rec_query_try_global( funk, NULL, rec_pool.ele[ rec_idx ].pair.key, NULL, query );
-      if( FD_UNLIKELY( rec_pool.ele[ rec_idx ].flags & FD_FUNK_REC_FLAG_ERASE ) )
+      fd_funk_rec_t const * rec2 = fd_funk_rec_query_try_global( funk, NULL, rec_pool->ele[ rec_idx ].pair.key, NULL, query );
+      if( FD_UNLIKELY( rec_pool->ele[ rec_idx ].flags & FD_FUNK_REC_FLAG_ERASE ) )
         TEST( rec2 == NULL );
       else
-        TEST( rec2 = rec_pool.ele + rec_idx );
-      uint next_idx = rec_pool.ele[ rec_idx ].next_idx;
-      if( !fd_funk_rec_idx_is_null( next_idx ) ) TEST( rec_pool.ele[ next_idx ].prev_idx==rec_idx );
+        TEST( rec2 = rec_pool->ele + rec_idx );
+      uint next_idx = rec_pool->ele[ rec_idx ].next_idx;
+      if( !fd_funk_rec_idx_is_null( next_idx ) ) TEST( rec_pool->ele[ next_idx ].prev_idx==rec_idx );
       rec_idx = next_idx;
     }
     fd_funk_txn_all_iter_t txn_iter[1];
     for( fd_funk_txn_all_iter_new( funk, txn_iter ); !fd_funk_txn_all_iter_done( txn_iter ); fd_funk_txn_all_iter_next( txn_iter ) ) {
       fd_funk_txn_t const * txn = fd_funk_txn_all_iter_ele_const( txn_iter );
 
-      ulong txn_idx = (ulong)(txn-txn_pool.ele);
-      uint rec_idx = txn->rec_head_idx;
+      ulong txn_idx = (ulong)(txn-txn_pool->ele);
+      uint  rec_idx = txn->rec_head_idx;
       while( !fd_funk_rec_idx_is_null( rec_idx ) ) {
-        TEST( (rec_idx<rec_max) && (fd_funk_txn_idx( rec_pool.ele[ rec_idx ].txn_cidx )==txn_idx) && rec_pool.ele[ rec_idx ].tag==0U );
-        rec_pool.ele[ rec_idx ].tag = 1U;
+        TEST( (rec_idx<rec_max) && (fd_funk_txn_idx( rec_pool->ele[ rec_idx ].txn_cidx )==txn_idx) && rec_pool->ele[ rec_idx ].tag==0U );
+        rec_pool->ele[ rec_idx ].tag = 1U;
         fd_funk_rec_query_t query[1];
-        fd_funk_rec_t const * rec2 = fd_funk_rec_query_try_global( funk, txn, rec_pool.ele[ rec_idx ].pair.key, NULL, query );
-        if( FD_UNLIKELY( rec_pool.ele[ rec_idx ].flags & FD_FUNK_REC_FLAG_ERASE ) )
+        fd_funk_rec_t const * rec2 = fd_funk_rec_query_try_global( funk, txn, rec_pool->ele[ rec_idx ].pair.key, NULL, query );
+        if( FD_UNLIKELY( rec_pool->ele[ rec_idx ].flags & FD_FUNK_REC_FLAG_ERASE ) )
           TEST( rec2 == NULL );
         else
-          TEST( rec2 = rec_pool.ele + rec_idx );
-        uint next_idx = rec_pool.ele[ rec_idx ].next_idx;
-        if( !fd_funk_rec_idx_is_null( next_idx ) ) TEST( rec_pool.ele[ next_idx ].prev_idx==rec_idx );
+          TEST( rec2 = rec_pool->ele + rec_idx );
+        uint next_idx = rec_pool->ele[ rec_idx ].next_idx;
+        if( !fd_funk_rec_idx_is_null( next_idx ) ) TEST( rec_pool->ele[ next_idx ].prev_idx==rec_idx );
         rec_idx = next_idx;
       }
     }
@@ -638,12 +606,12 @@ fd_funk_rec_verify( fd_funk_t * funk ) {
 
   do {
     ulong txn_idx = FD_FUNK_TXN_IDX_NULL;
-    uint rec_idx = funk->rec_tail_idx;
+    uint  rec_idx = funk->shmem->rec_tail_idx;
     while( !fd_funk_rec_idx_is_null( rec_idx ) ) {
-      TEST( (rec_idx<rec_max) && (fd_funk_txn_idx( rec_pool.ele[ rec_idx ].txn_cidx )==txn_idx) && rec_pool.ele[ rec_idx ].tag==1U );
-      rec_pool.ele[ rec_idx ].tag = 2U;
-      uint prev_idx = rec_pool.ele[ rec_idx ].prev_idx;
-      if( !fd_funk_rec_idx_is_null( prev_idx ) ) TEST( rec_pool.ele[ prev_idx ].next_idx==rec_idx );
+      TEST( (rec_idx<rec_max) && (fd_funk_txn_idx( rec_pool->ele[ rec_idx ].txn_cidx )==txn_idx) && rec_pool->ele[ rec_idx ].tag==1U );
+      rec_pool->ele[ rec_idx ].tag = 2U;
+      uint prev_idx = rec_pool->ele[ rec_idx ].prev_idx;
+      if( !fd_funk_rec_idx_is_null( prev_idx ) ) TEST( rec_pool->ele[ prev_idx ].next_idx==rec_idx );
       rec_idx = prev_idx;
     }
 
@@ -651,13 +619,13 @@ fd_funk_rec_verify( fd_funk_t * funk ) {
     for( fd_funk_txn_all_iter_new( funk, txn_iter ); !fd_funk_txn_all_iter_done( txn_iter ); fd_funk_txn_all_iter_next( txn_iter ) ) {
       fd_funk_txn_t const * txn = fd_funk_txn_all_iter_ele_const( txn_iter );
 
-      uint txn_idx = (uint)(txn-txn_pool.ele);
-      uint rec_idx = txn->rec_tail_idx;
+      ulong txn_idx = (ulong)(txn-txn_pool->ele);
+      uint  rec_idx = txn->rec_tail_idx;
       while( !fd_funk_rec_idx_is_null( rec_idx ) ) {
-        TEST( (rec_idx<rec_max) && (fd_funk_txn_idx( rec_pool.ele[ rec_idx ].txn_cidx )==txn_idx) && rec_pool.ele[ rec_idx ].tag==1U );
-        rec_pool.ele[ rec_idx ].tag = 2U;
-        uint prev_idx = rec_pool.ele[ rec_idx ].prev_idx;
-        if( !fd_funk_rec_idx_is_null( prev_idx ) ) TEST( rec_pool.ele[ prev_idx ].next_idx==rec_idx );
+        TEST( (rec_idx<rec_max) && (fd_funk_txn_idx( rec_pool->ele[ rec_idx ].txn_cidx )==txn_idx) && rec_pool->ele[ rec_idx ].tag==1U );
+        rec_pool->ele[ rec_idx ].tag = 2U;
+        uint prev_idx = rec_pool->ele[ rec_idx ].prev_idx;
+        if( !fd_funk_rec_idx_is_null( prev_idx ) ) TEST( rec_pool->ele[ prev_idx ].next_idx==rec_idx );
         rec_idx = prev_idx;
       }
     }
@@ -667,4 +635,3 @@ fd_funk_rec_verify( fd_funk_t * funk ) {
 
   return FD_FUNK_SUCCESS;
 }
-#endif

--- a/src/funk/fd_funk_txn.h
+++ b/src/funk/fd_funk_txn.h
@@ -142,7 +142,7 @@ fd_funk_txn_end_write( fd_funk_t * funk );
 
 FD_FN_PURE static inline fd_funk_txn_t *
 fd_funk_txn_query( fd_funk_txn_xid_t const * xid,
-                   fd_funk_txn_map_t * map ) {
+                   fd_funk_txn_map_t *       map ) {
   do {
     fd_funk_txn_map_query_t query[1];
     if( FD_UNLIKELY( fd_funk_txn_map_query_try( map, xid, NULL, query, 0 ) ) ) return NULL;
@@ -184,13 +184,13 @@ FD_FN_CONST static inline fd_funk_txn_xid_t const * fd_funk_txn_xid( fd_funk_txn
    no siblings, there are no transaction histories competing with txn
    globally. */
 
-#define FD_FUNK_ACCESSOR(field)                     \
-FD_FN_PURE static inline fd_funk_txn_t *            \
-fd_funk_txn_##field( fd_funk_txn_t const * txn,     \
-                     fd_funk_txn_pool_t * pool ) {  \
-  ulong idx = fd_funk_txn_idx( txn->field##_cidx ); \
-  if( idx==FD_FUNK_TXN_IDX_NULL ) return NULL;      \
-  return pool->ele + idx;                           \
+#define FD_FUNK_ACCESSOR(field)                          \
+FD_FN_PURE static inline fd_funk_txn_t *                 \
+fd_funk_txn_##field( fd_funk_txn_t const *      txn,     \
+                     fd_funk_txn_pool_t const * pool ) { \
+  ulong idx = fd_funk_txn_idx( txn->field##_cidx );      \
+  if( idx==FD_FUNK_TXN_IDX_NULL ) return NULL;           \
+  return pool->ele + idx;                                \
 }
 
 FD_FUNK_ACCESSOR( parent       )
@@ -364,12 +364,6 @@ fd_funk_txn_prepare( fd_funk_t *               funk,
                      fd_funk_txn_xid_t const * xid,
                      int                       verbose );
 
-/* fd_funk_txn_is_full returns true if the transaction map is
-   full. No more in-preparation transactions are allowed. */
-
-int
-fd_funk_txn_is_full( fd_funk_t * funk );
-
 /* fd_funk_txn_cancel cancels in-preparation transaction txn and any of
    its in-preparation descendants.  On success, returns the number of
    transactions cancelled and 0 on failure.  The state of records in the
@@ -454,13 +448,14 @@ fd_funk_txn_publish_into_parent( fd_funk_t *     funk,
                                  fd_funk_txn_t * txn,
                                  int             verbose );
 
-/* Iterator which walks all in-preparation transactions. Usage is:
+/* fd_funk_txn_all_iter_t iterators over all funk transaction objects.
+   Usage is:
 
-     fd_funk_txn_all_iter_t txn_iter[1];
-     for( fd_funk_txn_all_iter_new( funk, txn_iter ); !fd_funk_txn_all_iter_done( txn_iter ); fd_funk_txn_all_iter_next( txn_iter ) ) {
-       fd_funk_txn_t const * txn = fd_funk_txn_all_iter_ele_const( txn_iter );
-       ...
-     }
+   fd_funk_txn_all_iter_t txn_iter[1];
+   for( fd_funk_txn_all_iter_new( funk, txn_iter ); !fd_funk_txn_all_iter_done( txn_iter ); fd_funk_txn_all_iter_next( txn_iter ) ) {
+     fd_funk_txn_t const * txn = fd_funk_txn_all_iter_ele_const( txn_iter );
+     ...
+   }
 */
 
 struct fd_funk_txn_all_iter {
@@ -483,8 +478,6 @@ fd_funk_txn_t * fd_funk_txn_all_iter_ele( fd_funk_txn_all_iter_t * iter );
 
 /* Misc */
 
-#ifdef FD_FUNK_HANDHOLDING
-
 /* fd_funk_txn_verify verifies a transaction map.  Returns
    FD_FUNK_SUCCESS if the transaction map appears intact and
    FD_FUNK_ERR_INVAL if not (logs details).  Meant to be called as part
@@ -497,9 +490,7 @@ fd_funk_txn_verify( fd_funk_t * funk );
    a valid in-prep transaction. */
 
 int
-fd_funk_txn_valid( fd_funk_t * funk, fd_funk_txn_t const * txn );
-
-#endif
+fd_funk_txn_valid( fd_funk_t const * funk, fd_funk_txn_t const * txn );
 
 FD_PROTOTYPES_END
 

--- a/src/funk/fd_funk_val.c
+++ b/src/funk/fd_funk_val.c
@@ -2,10 +2,10 @@
 
 void *
 fd_funk_val_truncate( fd_funk_rec_t * rec,
-                         ulong           new_val_sz,
-                         fd_alloc_t *    alloc,
-                         fd_wksp_t *     wksp,
-                         int *           opt_err ) {
+                      ulong           new_val_sz,
+                      fd_alloc_t *    alloc,
+                      fd_wksp_t *     wksp,
+                      int *           opt_err ) {
 
   /* Check input args */
 
@@ -71,11 +71,10 @@ fd_funk_val_truncate( fd_funk_rec_t * rec,
   }
 }
 
-#ifdef FD_FUNK_HANDHOLDING
 int
 fd_funk_val_verify( fd_funk_t * funk ) {
   fd_wksp_t * wksp = fd_funk_wksp( funk );
-  ulong wksp_tag = funk->wksp_tag;
+  ulong wksp_tag = funk->shmem->wksp_tag;
 
   /* At this point, rec_map has been extensively verified */
 
@@ -116,4 +115,3 @@ fd_funk_val_verify( fd_funk_t * funk ) {
 
   return FD_FUNK_SUCCESS;
 }
-#endif

--- a/src/funk/fd_funk_val.h
+++ b/src/funk/fd_funk_val.h
@@ -100,17 +100,15 @@ fd_funk_val_init( fd_funk_rec_t * rec ) { /* Assumed record in caller's address 
 /* fd_funk_val_flush sets a record to the NULL value, discarding the
    current value if any.  Meant for internal use. */
 
-static inline fd_funk_rec_t *                  /* Returns rec */
+static inline fd_funk_rec_t *               /* Returns rec */
 fd_funk_val_flush( fd_funk_rec_t * rec,     /* Assumed live funk record in caller's address space */
-                      fd_alloc_t *       alloc,   /* ==fd_funk_alloc( funk, wksp ) */
-                      fd_wksp_t *        wksp ) { /* ==fd_funk_wksp( funk ) where funk is a current local join */
+                   fd_alloc_t *    alloc,   /* ==fd_funk_alloc( funk, wksp ) */
+                   fd_wksp_t *     wksp ) { /* ==fd_funk_wksp( funk ) where funk is a current local join */
   ulong val_gaddr = rec->val_gaddr;
   fd_funk_val_init( rec );
   if( val_gaddr ) fd_alloc_free( alloc, fd_wksp_laddr_fast( wksp, val_gaddr ) );
   return rec;
 }
-
-#ifdef FD_FUNK_HANDHOLDING
 
 /* fd_funk_val_verify verifies the record values.  Returns
    FD_FUNK_SUCCESS if the values appear intact and FD_FUNK_ERR_INVAL if
@@ -120,8 +118,6 @@ fd_funk_val_flush( fd_funk_rec_t * rec,     /* Assumed live funk record in calle
 
 int
 fd_funk_val_verify( fd_funk_t * funk );
-
-#endif
 
 FD_PROTOTYPES_END
 

--- a/src/funk/test_funk_common.hpp
+++ b/src/funk/test_funk_common.hpp
@@ -1,6 +1,4 @@
-extern "C" {
-  #include "fd_funk.h"
-}
+#include "fd_funk.h"
 #include <map>
 #include <vector>
 #include <set>
@@ -94,7 +92,7 @@ struct fake_txn {
 
 struct fake_funk {
     fd_wksp_t * _wksp;
-    fd_funk_t * _real;
+    fd_funk_t _real[1];
     std::map<ulong,fake_txn*> _txns;
     ulong _lastxid = 0;
 #ifdef TEST_FUNK_FILE
@@ -107,14 +105,14 @@ struct fake_funk {
       uint  rec_max = 1<<16;
 
 #ifdef TEST_FUNK_FILE
-      _real = fd_funk_open_file( "funk_test_file", 1, 1234U, txn_max, rec_max, FD_SHMEM_GIGANTIC_PAGE_SZ, FD_FUNK_OVERWRITE, &close_args );
+      FD_TEST( fd_funk_open_file( _real, "funk_test_file", 1, 1234U, txn_max, rec_max, FD_SHMEM_GIGANTIC_PAGE_SZ, FD_FUNK_OVERWRITE, &close_args ) );
       _wksp = fd_funk_wksp( _real );
 
 #else
       ulong  numa_idx = fd_shmem_numa_idx( 0 );
       _wksp = fd_wksp_new_anonymous( FD_SHMEM_GIGANTIC_PAGE_SZ, 1U, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
       void * mem = fd_wksp_alloc_laddr( _wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), FD_FUNK_MAGIC );
-      _real = fd_funk_join( fd_funk_new( mem, 1, 1234U, txn_max, rec_max ) );
+      FD_TEST( fd_funk_join( _real, fd_funk_new( mem, 1, 1234U, txn_max, rec_max ) ) );
 #endif
 
       _txns[ROOT_KEY] = new fake_txn(ROOT_KEY);
@@ -134,7 +132,7 @@ struct fake_funk {
 #ifdef TEST_FUNK_FILE
     void reopen_file() {
       fd_funk_close_file( &close_args );
-      _real = fd_funk_open_file( "funk_test_file", 1, 0, 0, 0, 0, FD_FUNK_READ_WRITE, &close_args );
+      FD_TEST( fd_funk_open_file( _real, "funk_test_file", 1, 0, 0, 0, 0, FD_FUNK_READ_WRITE, &close_args ) );
       _wksp = fd_funk_wksp( _real );
     }
 #endif
@@ -151,9 +149,9 @@ struct fake_funk {
     fd_funk_txn_t * get_real_txn(fake_txn * txn) {
       if (txn->_key == ROOT_KEY)
         return NULL;
-      fd_funk_txn_map_t txn_map = fd_funk_txn_map( _real, _wksp );
+      fd_funk_txn_map_t * txn_map = fd_funk_txn_map( _real );
       auto xid = txn->real_id();
-      return fd_funk_txn_query(&xid, &txn_map);
+      return fd_funk_txn_query(&xid, txn_map);
     }
 
     void random_insert() {
@@ -169,9 +167,9 @@ struct fake_funk {
       auto key = rec->real_id();
       fd_funk_rec_prepare_t prepare[1];
       fd_funk_rec_t * rec2 = fd_funk_rec_prepare(_real, txn2, &key, prepare, NULL);
-      void * val = fd_funk_val_truncate(rec2, rec->size(), fd_funk_alloc(_real, _wksp), _wksp, NULL);
+      void * val = fd_funk_val_truncate(rec2, rec->size(), fd_funk_alloc( _real ), _wksp, NULL);
       memcpy(val, rec->data(), rec->size());
-      fd_funk_rec_publish( prepare );
+      fd_funk_rec_publish( _real, prepare );
       assert(fd_funk_val_sz(rec2) == rec->size());
     }
 
@@ -356,8 +354,8 @@ struct fake_funk {
           assert(memcmp(fd_funk_val(rec, _wksp), rec2->data(), rec2->size()) == 0);
         }
 
-        fd_funk_txn_map_t txn_map = fd_funk_txn_map( _real, fd_funk_wksp( _real ) );
-        fd_funk_txn_t * txn = fd_funk_txn_query( xid, &txn_map );
+        fd_funk_txn_map_t * txn_map = fd_funk_txn_map( _real );
+        fd_funk_txn_t * txn = fd_funk_txn_query( xid, txn_map );
         fd_funk_rec_query_t query[1];
         auto* rec3 = fd_funk_rec_query_try_global(_real, txn, rec->pair.key, NULL, query);
         if( ( rec->flags & FD_FUNK_REC_FLAG_ERASE ) )
@@ -403,7 +401,7 @@ struct fake_funk {
         }
       }
 
-      fd_funk_txn_pool_t txn_pool = fd_funk_txn_pool( _real, _wksp );
+      fd_funk_txn_pool_t * txn_pool = fd_funk_txn_pool( _real );
 
       fd_funk_txn_all_iter_t txn_iter[1];
       for( fd_funk_txn_all_iter_new( _real, txn_iter ); !fd_funk_txn_all_iter_done( txn_iter ); fd_funk_txn_all_iter_next( txn_iter ) ) {
@@ -415,7 +413,7 @@ struct fake_funk {
         assert(!txn2->_touched);
         txn2->_touched = true;
 
-        auto * parent = fd_funk_txn_parent(txn, &txn_pool);
+        auto * parent = fd_funk_txn_parent(txn, txn_pool);
         if (parent == NULL)
           assert(ROOT_KEY == txn2->_parent->_key);
         else

--- a/src/funk/test_funk_rec.c
+++ b/src/funk/test_funk_rec.c
@@ -43,12 +43,15 @@ main( int     argc,
   FD_LOG_NOTICE(( "Testing with --wksp-tag %lu --seed %lu --txn-max %lu --rxn-max %u --iter-max %lu --verbose %i",
                   wksp_tag, seed, txn_max, rec_max, iter_max, verbose ));
 
-  fd_funk_t * tst = fd_funk_join( fd_funk_new( fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint(txn_max, rec_max), wksp_tag ),
-                                               wksp_tag, seed, txn_max, rec_max ) );
+  void * shfunk = fd_funk_new( fd_wksp_alloc_laddr(
+      wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), wksp_tag ),
+      wksp_tag, seed, txn_max, rec_max );
+  fd_funk_t tst_[1];
+  fd_funk_t * tst = fd_funk_join( tst_, shfunk );
   if( FD_UNLIKELY( !tst ) ) FD_LOG_ERR(( "Unable to create tst" ));
 
-  fd_funk_txn_map_t txn_map = fd_funk_txn_map( tst, wksp );
-  fd_funk_txn_pool_t txn_pool = fd_funk_txn_pool( tst, wksp );
+  fd_funk_txn_map_t *  txn_map  = fd_funk_txn_map( tst );
+  fd_funk_txn_pool_t * txn_pool = fd_funk_txn_pool( tst );
 
   funk_t * ref = funk_new();
 
@@ -145,13 +148,13 @@ main( int     argc,
     txn_t * rtxn = ref->txn_map_head;
     while( rtxn ) {
 
-      fd_funk_txn_t * ttxn = fd_funk_txn_query( xid_set( txid, rtxn->xid ), &txn_map );
+      fd_funk_txn_t * ttxn = fd_funk_txn_query( xid_set( txid, rtxn->xid ), txn_map );
       FD_TEST( ttxn && xid_eq( fd_funk_txn_xid( ttxn ), rtxn->xid ) );
 
-#     define TEST_RELATIVE(rel) do {                                    \
-        txn_t *         r##rel = rtxn->rel;                             \
-        fd_funk_txn_t * t##rel = fd_funk_txn_##rel( ttxn, &txn_pool ); \
-        if( !r##rel ) FD_TEST( !t##rel );                               \
+#     define TEST_RELATIVE(rel) do {                                  \
+        txn_t *         r##rel = rtxn->rel;                           \
+        fd_funk_txn_t * t##rel = fd_funk_txn_##rel( ttxn, txn_pool ); \
+        if( !r##rel ) FD_TEST( !t##rel );                             \
         else          FD_TEST( t##rel && xid_eq( fd_funk_txn_xid( t##rel ), r##rel->xid ) ); \
       } while(0)
       TEST_RELATIVE( parent       );
@@ -167,12 +170,12 @@ main( int     argc,
       FD_TEST( txn_is_only_child( rtxn )==fd_funk_txn_is_only_child( ttxn ) );
 
       txn_t *         rancestor = txn_ancestor( rtxn );
-      fd_funk_txn_t * tancestor = fd_funk_txn_ancestor( ttxn, &txn_pool );
+      fd_funk_txn_t * tancestor = fd_funk_txn_ancestor( ttxn, txn_pool );
       if( rancestor ) FD_TEST( tancestor && xid_eq( fd_funk_txn_xid( tancestor ), rancestor->xid ) );
       else            FD_TEST( !tancestor );
 
       txn_t *         rdescendant = txn_descendant( rtxn );
-      fd_funk_txn_t * tdescendant = fd_funk_txn_descendant( ttxn, &txn_pool );
+      fd_funk_txn_t * tdescendant = fd_funk_txn_descendant( ttxn, txn_pool );
       if( rdescendant ) FD_TEST( tdescendant && xid_eq( fd_funk_txn_xid( tdescendant ), rdescendant->xid ) );
       else              FD_TEST( !tdescendant );
 
@@ -259,7 +262,7 @@ main( int     argc,
       xid_set( txid, rxid );
       key_set( tkey, rkey );
 
-      fd_funk_txn_t const * ttxn = rxid ? fd_funk_txn_query( txid, &txn_map ) : NULL;
+      fd_funk_txn_t const * ttxn = rxid ? fd_funk_txn_query( txid, txn_map ) : NULL;
       fd_funk_rec_query_t rec_query[1];
       fd_funk_rec_t const * trec = fd_funk_rec_query_try( tst, ttxn, tkey, rec_query );
       FD_TEST( trec && xid_eq( fd_funk_rec_xid( trec ), rxid ) && key_eq( fd_funk_rec_key( trec ), rkey ) );
@@ -310,12 +313,12 @@ main( int     argc,
       rec_insert( ref, rtxn, rkey );
 
       int err;
-      fd_funk_txn_t * ttxn = fd_funk_txn_query( xid_set( txid, rxid ), &txn_map );
+      fd_funk_txn_t * ttxn = fd_funk_txn_query( xid_set( txid, rxid ), txn_map );
       fd_funk_rec_prepare_t prepare[1];
       fd_funk_rec_t const * trec = fd_funk_rec_prepare( tst, ttxn, key_set( tkey, rkey ), prepare, &err );
       FD_TEST( trec );
       FD_TEST( !err );
-      fd_funk_rec_publish( prepare );
+      fd_funk_rec_publish( tst, prepare );
 
     } else if( op>=18UL ) { /* Remove and insert at same rate */
 
@@ -336,7 +339,7 @@ main( int     argc,
 
       rec_remove( ref, rrec );
 
-      fd_funk_txn_t * ttxn = rxid ? fd_funk_txn_query( xid_set( txid, rxid ), &txn_map ) : NULL;
+      fd_funk_txn_t * ttxn = rxid ? fd_funk_txn_query( xid_set( txid, rxid ), txn_map ) : NULL;
       fd_funk_rec_query_t query[1];
       fd_funk_rec_t const * trec = fd_funk_rec_query_try( tst, ttxn, key_set( tkey, rkey ), query );
       FD_TEST( trec );
@@ -356,7 +359,7 @@ main( int     argc,
       ulong idx = fd_rng_ulong_roll( rng, ref->txn_cnt+1UL );
       if( idx<ref->txn_cnt ) { /* Branch off in-prep */
         rparent = ref->txn_map_head; for( ulong rem=idx; rem; rem-- ) rparent = rparent->map_next;
-        tparent = fd_funk_txn_query( xid_set( txid, rparent->xid ), &txn_map );
+        tparent = fd_funk_txn_query( xid_set( txid, rparent->xid ), txn_map );
       } else { /* Branch off last published */
         rparent = NULL;
         tparent = NULL;
@@ -373,7 +376,7 @@ main( int     argc,
       ulong idx = fd_rng_ulong_roll( rng, ref->txn_cnt );
 
       txn_t *         rtxn = ref->txn_map_head; for( ulong rem=idx; rem; rem-- ) rtxn = rtxn->map_next;
-      fd_funk_txn_t * ttxn = fd_funk_txn_query( xid_set( txid, rtxn->xid ), &txn_map );
+      fd_funk_txn_t * ttxn = fd_funk_txn_query( xid_set( txid, rtxn->xid ), txn_map );
 
       ulong cnt = ref->txn_cnt; txn_cancel( ref, rtxn ); cnt -= ref->txn_cnt;
       FD_TEST( fd_funk_txn_cancel( tst, ttxn, verbose )==cnt );
@@ -384,7 +387,7 @@ main( int     argc,
 
       ulong idx = fd_rng_ulong_roll( rng, ref->txn_cnt );
       txn_t *         rtxn = ref->txn_map_head; for( ulong rem=idx; rem; rem-- ) rtxn = rtxn->map_next;
-      fd_funk_txn_t * ttxn = fd_funk_txn_query( xid_set( txid, rtxn->xid ), &txn_map );
+      fd_funk_txn_t * ttxn = fd_funk_txn_query( xid_set( txid, rtxn->xid ), txn_map );
 
       ulong cnt = txn_publish( ref, rtxn, 0UL );
       FD_TEST( fd_funk_txn_publish( tst, ttxn, verbose )==cnt );
@@ -394,7 +397,8 @@ main( int     argc,
 
   funk_delete( ref );
 
-  fd_wksp_free_laddr( fd_funk_delete( fd_funk_leave( tst ) ) );
+  fd_funk_leave( tst, NULL );
+  fd_wksp_free_laddr( fd_funk_delete( shfunk ) );
   if( name ) fd_wksp_detach( wksp );
   else       fd_wksp_delete_anonymous( wksp );
 

--- a/src/funk/test_funk_txn.c
+++ b/src/funk/test_funk_txn.c
@@ -47,12 +47,15 @@ main( int     argc,
   FD_LOG_NOTICE(( "Testing with --wksp-tag %lu --seed %lu --txn-max %lu --rxn-max %u --iter-max %lu --verbose %i",
                   wksp_tag, seed, txn_max, rec_max, iter_max, verbose ));
 
-  fd_funk_t * funk = fd_funk_join( fd_funk_new( fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), wksp_tag ),
-                                                wksp_tag, seed, txn_max, rec_max ) );
+  void * shfunk = fd_funk_new( fd_wksp_alloc_laddr(
+      wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), wksp_tag ),
+      wksp_tag, seed, txn_max, rec_max );
+  fd_funk_t funk_[1];
+  fd_funk_t * funk = fd_funk_join( funk_, shfunk );
   if( FD_UNLIKELY( !funk ) ) FD_LOG_ERR(( "Unable to create funk" ));
 
-  fd_funk_txn_map_t map = fd_funk_txn_map( funk, wksp );
-  fd_funk_txn_pool_t pool = fd_funk_txn_pool( funk, wksp );
+  fd_funk_txn_map_t *  map  = fd_funk_txn_map( funk );
+  fd_funk_txn_pool_t * pool = fd_funk_txn_pool( funk );
 
   for( ulong rem=1000000UL; rem; rem-- ) {
     ulong idx = (ulong)fd_rng_uint( rng );
@@ -72,7 +75,7 @@ main( int     argc,
   for( ulong iter=0UL; iter<iter_max; iter++ ) {
 
     ulong live_pmap = 0UL;
-    for( ulong idx=0UL; idx<64UL; idx++ ) if( fd_funk_txn_query( &recent_xid[ idx ], &map ) ) live_pmap |= (1UL<<idx);
+    for( ulong idx=0UL; idx<64UL; idx++ ) if( fd_funk_txn_query( &recent_xid[ idx ], map ) ) live_pmap |= (1UL<<idx);
 
 #   define RANDOM_SET_BIT_IDX(pmap) do {                                                       \
       idx = (r&63U);                                                                           \
@@ -87,7 +90,7 @@ main( int     argc,
     case 0: { /* look up a live xid (always succeed) */
       if( FD_UNLIKELY( !live_pmap ) ) break;
       uint idx; RANDOM_SET_BIT_IDX( live_pmap );
-      fd_funk_txn_t * txn = fd_funk_txn_query( &recent_xid[idx], &map );
+      fd_funk_txn_t * txn = fd_funk_txn_query( &recent_xid[idx], map );
       FD_TEST( txn && fd_funk_txn_xid_eq( fd_funk_txn_xid( txn ), &recent_xid[idx] ) );
       break;
     }
@@ -95,7 +98,7 @@ main( int     argc,
     case 1: { /* look up a dead xid (always fail) */
       if( FD_UNLIKELY( !~live_pmap ) ) break;
       uint idx; RANDOM_SET_BIT_IDX( ~live_pmap );
-      fd_funk_txn_t * txn = fd_funk_txn_query( &recent_xid[idx], &map );
+      fd_funk_txn_t * txn = fd_funk_txn_query( &recent_xid[idx], map );
       FD_TEST( !txn );
       break;
     }
@@ -103,7 +106,7 @@ main( int     argc,
     case 2: { /* look up never seen xid (always fail) */
       fd_funk_txn_xid_t xid[1];
       xid[0] = fd_funk_generate_xid();
-      fd_funk_txn_t * txn = fd_funk_txn_query( xid, &map );
+      fd_funk_txn_t * txn = fd_funk_txn_query( xid, map );
       FD_TEST( !txn );
       break;
     }
@@ -140,7 +143,7 @@ main( int     argc,
     case 6: { /* prepare from live xid with a live xid (always fail) */
       if( FD_UNLIKELY( !live_pmap ) ) break;
       uint idx; uint idx1; RANDOM_SET_BIT_IDX( live_pmap ); idx1 = idx; RANDOM_SET_BIT_IDX( live_pmap );
-      fd_funk_txn_t * parent = fd_funk_txn_query( &recent_xid[idx], &map );
+      fd_funk_txn_t * parent = fd_funk_txn_query( &recent_xid[idx], map );
       FD_TEST( parent && fd_funk_txn_xid_eq( fd_funk_txn_xid( parent ), &recent_xid[idx] ) );
       FD_TEST( !fd_funk_txn_prepare( funk, parent, &recent_xid[idx1], verbose ) );
       break;
@@ -150,7 +153,7 @@ main( int     argc,
       if( FD_UNLIKELY( !live_pmap || !~live_pmap ) ) break;
       uint idx; uint idx1; RANDOM_SET_BIT_IDX( ~live_pmap ); idx1 = idx; RANDOM_SET_BIT_IDX( live_pmap );
       if( FD_UNLIKELY( fd_funk_txn_xid_eq( &recent_xid[idx1], last_publish ) ) ) break;
-      fd_funk_txn_t * parent = fd_funk_txn_query( &recent_xid[idx], &map );
+      fd_funk_txn_t * parent = fd_funk_txn_query( &recent_xid[idx], map );
       FD_TEST( parent && fd_funk_txn_xid_eq( fd_funk_txn_xid( parent ), &recent_xid[idx] ) );
       int is_full = fd_funk_txn_is_full( funk );
       fd_funk_txn_t * txn = fd_funk_txn_prepare( funk, parent, &recent_xid[idx1], verbose );
@@ -162,7 +165,7 @@ main( int     argc,
     case 8: { /* prepare from live xid with a never seen xid (succeed if not full) */
       if( FD_UNLIKELY( !live_pmap ) ) break;
       uint idx; RANDOM_SET_BIT_IDX( live_pmap );
-      fd_funk_txn_t * parent = fd_funk_txn_query( &recent_xid[idx], &map );
+      fd_funk_txn_t * parent = fd_funk_txn_query( &recent_xid[idx], map );
       FD_TEST( parent && fd_funk_txn_xid_eq( fd_funk_txn_xid( parent ), &recent_xid[idx] ) );
       fd_funk_txn_xid_t * xid = &recent_xid[ recent_cursor ];
       *xid = fd_funk_generate_xid();
@@ -177,7 +180,7 @@ main( int     argc,
     case 9: { /* cancel a live xid (should always be at least 1) */
       if( FD_UNLIKELY( !live_pmap ) ) break;
       uint idx; RANDOM_SET_BIT_IDX( live_pmap );
-      fd_funk_txn_t * txn = fd_funk_txn_query( &recent_xid[idx], &map );
+      fd_funk_txn_t * txn = fd_funk_txn_query( &recent_xid[idx], map );
       FD_TEST( txn && fd_funk_txn_xid_eq( fd_funk_txn_xid( txn ), &recent_xid[idx] ) );
       FD_TEST( fd_funk_txn_cancel( funk, txn, verbose )>0UL );
       break;
@@ -186,7 +189,7 @@ main( int     argc,
     case 10: { /* cancel a dead xid (should always be 0) */
       if( FD_UNLIKELY( !~live_pmap ) ) break;
       uint idx; RANDOM_SET_BIT_IDX( ~live_pmap );
-      fd_funk_txn_t * txn = fd_funk_txn_query( &recent_xid[idx], &map );
+      fd_funk_txn_t * txn = fd_funk_txn_query( &recent_xid[idx], map );
       FD_TEST( !txn );
 #ifdef FD_FUNK_HANDHOLDING
       FD_TEST( fd_funk_txn_cancel( funk, txn, verbose )==0UL );
@@ -197,7 +200,7 @@ main( int     argc,
     case 11: { /* cancel a never seen xid (should always be 0) */
       fd_funk_txn_xid_t xid[1];
       xid[0] = fd_funk_generate_xid();
-      fd_funk_txn_t * txn = fd_funk_txn_query( xid, &map );
+      fd_funk_txn_t * txn = fd_funk_txn_query( xid, map );
       FD_TEST( !txn );
 #ifdef FD_FUNK_HANDHOLDING
       FD_TEST( fd_funk_txn_cancel( funk, txn, verbose )==0UL );
@@ -208,7 +211,7 @@ main( int     argc,
     case 12: { /* publish a live xid (should always be at least 1) */
       if( FD_UNLIKELY( !live_pmap ) ) break;
       uint idx; RANDOM_SET_BIT_IDX( live_pmap );
-      fd_funk_txn_t * txn = fd_funk_txn_query( &recent_xid[idx], &map );
+      fd_funk_txn_t * txn = fd_funk_txn_query( &recent_xid[idx], map );
       FD_TEST( txn && fd_funk_txn_xid_eq( fd_funk_txn_xid( txn ), &recent_xid[idx] ) );
       FD_TEST( fd_funk_txn_publish( funk, txn, verbose )>0UL );
       FD_TEST( fd_funk_txn_xid_eq( last_publish, &recent_xid[idx] ) );
@@ -218,7 +221,7 @@ main( int     argc,
     case 13: { /* publish a dead xid (should always be 0) */
       if( FD_UNLIKELY( !~live_pmap ) ) break;
       uint idx; RANDOM_SET_BIT_IDX( ~live_pmap );
-      fd_funk_txn_t * txn = fd_funk_txn_query( &recent_xid[idx], &map );
+      fd_funk_txn_t * txn = fd_funk_txn_query( &recent_xid[idx], map );
       FD_TEST( !txn );
 #ifdef FD_FUNK_HANDHOLDING
       FD_TEST( fd_funk_txn_publish( funk, txn, verbose )==0UL );
@@ -229,7 +232,7 @@ main( int     argc,
     case 14: { /* publish a never seen xid (should always be 0) */
       fd_funk_txn_xid_t xid[1];
       xid[0] = fd_funk_generate_xid();
-      fd_funk_txn_t * txn = fd_funk_txn_query( xid, &map );
+      fd_funk_txn_t * txn = fd_funk_txn_query( xid, map );
       FD_TEST( !txn );
 #ifdef FD_FUNK_HANDHOLDING
       FD_TEST( fd_funk_txn_publish( funk, txn, verbose )==0UL );
@@ -239,13 +242,13 @@ main( int     argc,
 
     default: { /* various sanity checks */
       uint idx = r & 63U; r >>= 6;
-      fd_funk_txn_t * txn = fd_funk_txn_query( &recent_xid[idx], &map );
+      fd_funk_txn_t * txn = fd_funk_txn_query( &recent_xid[idx], map );
 #ifdef FD_FUNK_HANDHOLDING
       fd_funk_txn_xid_t xid[1];
       xid[0] = fd_funk_generate_xid();
 
       fd_funk_txn_t * dead = NULL;
-      if( txn_max && !fd_funk_txn_query( fd_funk_txn_xid( &pool.ele[0] ), &map ) ) dead = &pool.ele[0];
+      if( txn_max && !fd_funk_txn_query( fd_funk_txn_xid( &pool->ele[0] ), map ) ) dead = &pool->ele[0];
 
       fd_funk_txn_t bad[1]; fd_funk_txn_xid_copy( &bad->xid, xid );
 
@@ -272,11 +275,11 @@ main( int     argc,
       if( txn ) {
         FD_TEST( fd_funk_txn_xid_eq( fd_funk_txn_xid( txn ), &recent_xid[idx] ) );
 
-        fd_funk_txn_t * parent      = fd_funk_txn_parent      ( txn, &pool );
-        fd_funk_txn_t * first_born  = fd_funk_txn_child_head  ( txn, &pool );
-        fd_funk_txn_t * last_born   = fd_funk_txn_child_tail  ( txn, &pool );
-        fd_funk_txn_t * older_sib   = fd_funk_txn_sibling_prev( txn, &pool );
-        fd_funk_txn_t * younger_sib = fd_funk_txn_sibling_next( txn, &pool );
+        fd_funk_txn_t * parent      = fd_funk_txn_parent      ( txn, pool );
+        fd_funk_txn_t * first_born  = fd_funk_txn_child_head  ( txn, pool );
+        fd_funk_txn_t * last_born   = fd_funk_txn_child_tail  ( txn, pool );
+        fd_funk_txn_t * older_sib   = fd_funk_txn_sibling_prev( txn, pool );
+        fd_funk_txn_t * younger_sib = fd_funk_txn_sibling_next( txn, pool );
 
         /* Make sure transaction suitable marked as frozen */
 
@@ -292,20 +295,20 @@ main( int     argc,
         /* Make sure txn's children know that txn is the parent (in both
            directions) */
 
-        for( cur = first_born; cur; cur = fd_funk_txn_sibling_next( cur, &pool ) ) FD_TEST( fd_funk_txn_parent( cur, &pool )==txn );
-        for( cur = last_born;  cur; cur = fd_funk_txn_sibling_prev( cur, &pool ) ) FD_TEST( fd_funk_txn_parent( cur, &pool )==txn );
+        for( cur = first_born; cur; cur = fd_funk_txn_sibling_next( cur, pool ) ) FD_TEST( fd_funk_txn_parent( cur, pool )==txn );
+        for( cur = last_born;  cur; cur = fd_funk_txn_sibling_prev( cur, pool ) ) FD_TEST( fd_funk_txn_parent( cur, pool )==txn );
 
         /* Make sure txn's parent knows this txn is a child (in both
            directions) */
 
-        if( !parent ) cur = fd_funk_last_publish_child_head( funk, &pool );
-        else          cur = fd_funk_txn_child_head( parent, &pool );
-        for( ; cur; cur = fd_funk_txn_sibling_next( cur, &pool ) ) if( cur==txn ) break;
+        if( !parent ) cur = fd_funk_last_publish_child_head( funk, pool );
+        else          cur = fd_funk_txn_child_head( parent, pool );
+        for( ; cur; cur = fd_funk_txn_sibling_next( cur, pool ) ) if( cur==txn ) break;
         FD_TEST( cur );
 
-        if( !parent ) cur = fd_funk_last_publish_child_tail( funk, &pool );
-        else          cur = fd_funk_txn_child_tail( parent, &pool );
-        for( ; cur; cur = fd_funk_txn_sibling_prev( cur, &pool ) ) if( cur==txn ) break;
+        if( !parent ) cur = fd_funk_last_publish_child_tail( funk, pool );
+        else          cur = fd_funk_txn_child_tail( parent, pool );
+        for( ; cur; cur = fd_funk_txn_sibling_prev( cur, pool ) ) if( cur==txn ) break;
         FD_TEST( cur );
       }
 
@@ -318,7 +321,8 @@ main( int     argc,
 #endif
   }
 
-  fd_wksp_free_laddr( fd_funk_delete( fd_funk_leave( funk ) ) );
+  fd_funk_leave( funk, NULL );
+  fd_wksp_free_laddr( fd_funk_delete( shfunk ) );
   if( name ) fd_wksp_detach( wksp );
   else       fd_wksp_delete_anonymous( wksp );
 

--- a/src/funk/test_funk_val.c
+++ b/src/funk/test_funk_val.c
@@ -39,12 +39,15 @@ main( int     argc,
   FD_LOG_NOTICE(( "Testing with --wksp-tag %lu --seed %lu --txn-max %lu --rxn-max %u --iter-max %lu --verbose %i",
                   wksp_tag, seed, txn_max, rec_max, iter_max, verbose ));
 
-  fd_funk_t * tst = fd_funk_join( fd_funk_new( fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), wksp_tag ),
-                                               wksp_tag, seed, txn_max, rec_max ) );
+  void * shfunk = fd_funk_new( fd_wksp_alloc_laddr(
+      wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), wksp_tag ),
+      wksp_tag, seed, txn_max, rec_max );
+  fd_funk_t tst_[1];
+  fd_funk_t * tst = fd_funk_join( tst_, shfunk );
   if( FD_UNLIKELY( !tst ) ) FD_LOG_ERR(( "Unable to create tst" ));
 
-  fd_funk_txn_map_t txn_map = fd_funk_txn_map( tst, wksp );
-  fd_alloc_t *    alloc   = fd_funk_alloc  ( tst, wksp );
+  fd_funk_txn_map_t * txn_map = fd_funk_txn_map( tst );
+  fd_alloc_t *        alloc   = fd_funk_alloc  ( tst );
 
   funk_t * ref = funk_new();
 
@@ -81,7 +84,7 @@ main( int     argc,
       key_set( tkey, rkey );
 
       fd_funk_rec_query_t rec_query[1];
-      fd_funk_txn_t const * ttxn = rxid ? fd_funk_txn_query( txid, &txn_map ) : NULL;
+      fd_funk_txn_t const * ttxn = rxid ? fd_funk_txn_query( txid, txn_map ) : NULL;
       fd_funk_rec_t const * trec = fd_funk_rec_query_try( tst, ttxn, tkey, rec_query );
 
       void const * _val = (void const *)fd_funk_val( trec, wksp );
@@ -137,7 +140,7 @@ main( int     argc,
       int err = 1;
       fd_funk_rec_prepare_t prepare[1];
       fd_funk_rec_t * trec =
-        fd_funk_rec_prepare( tst, fd_funk_txn_query( xid_set( txid, rxid ), &txn_map ), key_set( tkey, rkey ), prepare, &err );
+        fd_funk_rec_prepare( tst, fd_funk_txn_query( xid_set( txid, rxid ), txn_map ), key_set( tkey, rkey ), prepare, &err );
       FD_TEST( trec && !err );
 
       uint val = (fd_rng_uint( rng )<<2) | 1U;
@@ -145,7 +148,7 @@ main( int     argc,
 
       memcpy( fd_funk_val_truncate( trec, sizeof(val), alloc, wksp, NULL ), &val, sizeof(val) );
 
-      fd_funk_rec_publish( prepare );
+      fd_funk_rec_publish( tst, prepare );
 
       FD_TEST( FD_LOAD( uint, fd_funk_val( trec, wksp ) )==val );
       TEST_TAIL_PADDING( 4UL );
@@ -169,7 +172,7 @@ main( int     argc,
 
       rec_remove( ref, rrec );
 
-      fd_funk_txn_t * ttxn = rxid ? fd_funk_txn_query( xid_set( txid, rxid ), &txn_map ) : NULL;
+      fd_funk_txn_t * ttxn = rxid ? fd_funk_txn_query( xid_set( txid, rxid ), txn_map ) : NULL;
       FD_TEST( !fd_funk_rec_remove( tst, ttxn, key_set( tkey, rkey ), NULL, 0UL ) );
 
     } else if( op>=2 ) { /* Prepare 8x as publish and cancel combined */
@@ -182,7 +185,7 @@ main( int     argc,
       ulong idx = fd_rng_ulong_roll( rng, ref->txn_cnt+1UL );
       if( idx<ref->txn_cnt ) { /* Branch off in-prep */
         rparent = ref->txn_map_head; for( ulong rem=idx; rem; rem-- ) rparent = rparent->map_next;
-        tparent = fd_funk_txn_query( xid_set( txid, rparent->xid ), &txn_map );
+        tparent = fd_funk_txn_query( xid_set( txid, rparent->xid ), txn_map );
       } else { /* Branch off last published */
         rparent = NULL;
         tparent = NULL;
@@ -199,7 +202,7 @@ main( int     argc,
       ulong idx = fd_rng_ulong_roll( rng, ref->txn_cnt );
 
       txn_t *         rtxn = ref->txn_map_head; for( ulong rem=idx; rem; rem-- ) rtxn = rtxn->map_next;
-      fd_funk_txn_t * ttxn = fd_funk_txn_query( xid_set( txid, rtxn->xid ), &txn_map );
+      fd_funk_txn_t * ttxn = fd_funk_txn_query( xid_set( txid, rtxn->xid ), txn_map );
 
       ulong cnt = ref->txn_cnt; txn_cancel( ref, rtxn ); cnt -= ref->txn_cnt;
       FD_TEST( fd_funk_txn_cancel( tst, ttxn, verbose )==cnt );
@@ -211,7 +214,7 @@ main( int     argc,
       ulong idx = fd_rng_ulong_roll( rng, ref->txn_cnt );
 
       txn_t *         rtxn = ref->txn_map_head; for( ulong rem=idx; rem; rem-- ) rtxn = rtxn->map_next;
-      fd_funk_txn_t * ttxn = fd_funk_txn_query( xid_set( txid, rtxn->xid ), &txn_map );
+      fd_funk_txn_t * ttxn = fd_funk_txn_query( xid_set( txid, rtxn->xid ), txn_map );
 
       ulong cnt = txn_publish( ref, rtxn, 0UL );
       FD_TEST( fd_funk_txn_publish( tst, ttxn, verbose )==cnt );
@@ -221,7 +224,8 @@ main( int     argc,
 
   funk_delete( ref );
 
-  fd_wksp_free_laddr( fd_funk_delete( fd_funk_leave( tst ) ) );
+  fd_funk_leave( tst, NULL );
+  fd_wksp_free_laddr( fd_funk_delete( shfunk ) );
   if( name ) fd_wksp_detach( wksp );
   else       fd_wksp_delete_anonymous( wksp );
 


### PR DESCRIPTION
Adds a 'join' struct containing local address space pointers to
sub objects.  Improves insert performance by about 20ns per record.

Reverts 'ele_max' to ulong to avoid integer truncation issues.

Closes #4847 