### PR TITLE
flamenco, funk: remove funk_rec_hard_remove

### DIFF
--- a/src/flamenco/runtime/fd_runtime_init.c
+++ b/src/flamenco/runtime/fd_runtime_init.c
@@ -72,8 +72,6 @@ int fd_runtime_save_slot_bank( fd_exec_slot_ctx_t * slot_ctx ) {
 
   fd_funk_t * funk = slot_ctx->funk;
 
-  fd_funk_rec_hard_remove( funk, slot_ctx->funk_txn, &id );
-
   fd_funk_rec_prepare_t prepare[1];
   fd_funk_rec_t * rec = fd_funk_rec_prepare(funk, slot_ctx->funk_txn, &id, prepare, &opt_err);
   if( !rec ) {

--- a/src/flamenco/runtime/fd_txn_account.c
+++ b/src/flamenco/runtime/fd_txn_account.c
@@ -289,23 +289,46 @@ fd_txn_account_save( fd_txn_account_t * acct,
 
   fd_funk_rec_key_t key = fd_funk_acc_key( acct->pubkey );
 
-  /* Remove previous incarnation of the account's record from the transaction, so that we don't hash it twice */
-  fd_funk_rec_hard_remove( funk, txn, &key );
+  /* There are two cases to consider here:
+     1. The account that we are attempting to save exists in the current
+        funk transaction. In this case, all we need to do is acquire an
+        exclusive write on the current hash chain using fd_funk_rec_modify_prepare
+        and write into the record.
+     2. The account that we are attempting to save does NOT exist in the
+        current transaction, but it may or may not exist in some parent
+        funk transaction. In this case, we will have to prepare and
+        publish the account into the current funk transaction. */
 
-  int err;
-  fd_funk_rec_prepare_t prepare[1];
-  fd_funk_rec_t * rec = fd_funk_rec_prepare( funk, txn, &key, prepare, &err );
-  if( rec == NULL ) FD_LOG_ERR(( "unable to insert a new record, error %d", err ));
+  fd_funk_rec_query_t query[1];
+  fd_funk_rec_t *     rec         = fd_funk_rec_modify_prepare( funk, txn, &key, query );
+  fd_wksp_t *         funk_wksp   = fd_funk_wksp( funk );
 
-  acct->private_state.rec = rec;
-  ulong reclen = sizeof(fd_account_meta_t)+acct->private_state.const_meta->dlen;
-  fd_wksp_t * wksp = fd_funk_wksp( funk );
-  if( fd_funk_val_truncate( rec, reclen, fd_funk_alloc( funk, wksp ), wksp, &err ) == NULL ) {
-    FD_LOG_ERR(( "unable to allocate account value, err %d", err ));
+  int err = 0;
+  if( rec ) {
+    acct->private_state.rec = rec;
+    ulong reclen            = sizeof(fd_account_meta_t)+acct->private_state.const_meta->dlen;
+    if( FD_UNLIKELY( fd_funk_val_truncate( rec, reclen, fd_funk_alloc( funk, funk_wksp ), funk_wksp, &err ) == NULL ) ) {
+      FD_LOG_ERR(( "unable to allocate account value, err %d", err ));
+    }
+    err = fd_txn_account_save_internal( acct, funk );
+
+    fd_funk_rec_modify_publish( query );
+  } else {
+    fd_funk_rec_prepare_t prepare[1];
+    rec = fd_funk_rec_prepare( funk, txn, &key, prepare, &err );
+    if( FD_UNLIKELY( rec == NULL ) ) {
+      FD_LOG_ERR(( "unable to insert a new record, error %d", err ));
+    }
+
+    acct->private_state.rec = rec;
+    ulong reclen = sizeof(fd_account_meta_t)+acct->private_state.const_meta->dlen;
+    if( FD_UNLIKELY( fd_funk_val_truncate( rec, reclen, fd_funk_alloc( funk, funk_wksp ), funk_wksp, &err ) == NULL ) ) {
+      FD_LOG_ERR(( "unable to allocate account value, err %d", err ));
+    }
+
+    err = fd_txn_account_save_internal( acct, funk );
+    fd_funk_rec_publish( prepare );
   }
-  err = fd_txn_account_save_internal( acct, funk );
-
-  fd_funk_rec_publish( prepare );
 
   return err;
 }

--- a/src/funk/fd_funk_rec.c
+++ b/src/funk/fd_funk_rec.c
@@ -311,59 +311,6 @@ fd_funk_rec_is_full( fd_funk_t * funk ) {
   return fd_funk_rec_pool_is_empty( &rec_pool );
 }
 
-void
-fd_funk_rec_hard_remove( fd_funk_t *               funk,
-                         fd_funk_txn_t *           txn,
-                         fd_funk_rec_key_t const * key ) {
-
-  fd_wksp_t * wksp            = fd_funk_wksp( funk );
-  fd_alloc_t * alloc          = fd_funk_alloc( funk, wksp );
-  fd_funk_rec_map_t rec_map   = fd_funk_rec_map( funk, wksp );
-  fd_funk_rec_pool_t rec_pool = fd_funk_rec_pool( funk, wksp );
-
-  fd_funk_xid_key_pair_t pair[1];
-  if( txn == NULL ) {
-    fd_funk_txn_xid_set_root( pair->xid );
-  } else {
-    fd_funk_txn_xid_copy( pair->xid, &txn->xid );
-  }
-  fd_funk_rec_key_copy( pair->key, key );
-
-  fd_funk_rec_pool_lock( &rec_pool, 1 );
-
-  fd_funk_rec_t * rec = NULL;
-  for(;;) {
-    fd_funk_rec_map_query_t rec_query[1];
-    int err = fd_funk_rec_map_remove( &rec_map, pair, NULL, rec_query, FD_MAP_FLAG_BLOCKING );
-    if( FD_UNLIKELY( err == FD_MAP_ERR_AGAIN ) ) continue;
-    if( err == FD_MAP_ERR_KEY ) {
-      fd_funk_rec_pool_unlock( &rec_pool );
-      return;
-    }
-    if( FD_UNLIKELY( err != FD_MAP_SUCCESS ) ) FD_LOG_CRIT(( "map corruption" ));
-    rec = fd_funk_rec_map_query_ele( rec_query );
-    break;
-  }
-
-  uint prev_idx = rec->prev_idx;
-  uint next_idx = rec->next_idx;
-  if( txn == NULL ) {
-    if( fd_funk_rec_idx_is_null( prev_idx ) ) funk->rec_head_idx =                next_idx;
-    else                                         rec_pool.ele[ prev_idx ].next_idx = next_idx;
-    if( fd_funk_rec_idx_is_null( next_idx ) ) funk->rec_tail_idx =                prev_idx;
-    else                                         rec_pool.ele[ next_idx ].prev_idx = prev_idx;
-  } else {
-    if( fd_funk_rec_idx_is_null( prev_idx ) ) txn->rec_head_idx =                next_idx;
-    else                                         rec_pool.ele[ prev_idx ].next_idx = next_idx;
-    if( fd_funk_rec_idx_is_null( next_idx ) ) txn->rec_tail_idx =                prev_idx;
-    else                                         rec_pool.ele[ next_idx ].prev_idx = prev_idx;
-  }
-  fd_funk_rec_pool_unlock( &rec_pool );
-
-  fd_funk_val_flush( rec, alloc, wksp );
-  fd_funk_rec_pool_release( &rec_pool, rec, 1 );
-}
-
 int
 fd_funk_rec_remove( fd_funk_t *               funk,
                     fd_funk_txn_t *           txn,
@@ -496,6 +443,38 @@ fd_funk_rec_forget( fd_funk_t *      funk,
   }
 
   return FD_FUNK_SUCCESS;
+}
+
+fd_funk_rec_t *
+fd_funk_rec_modify_prepare( fd_funk_t *               funk,
+                            fd_funk_txn_t const *     txn,
+                            fd_funk_rec_key_t const * key,
+                            fd_funk_rec_query_t *     query ) {
+  fd_wksp_t * wksp          = fd_funk_wksp( funk );
+  fd_funk_rec_map_t rec_map = fd_funk_rec_map( funk, wksp );
+  fd_funk_xid_key_pair_t pair[1];
+  if( txn == NULL ) {
+    fd_funk_txn_xid_set_root( pair->xid );
+  } else {
+    fd_funk_txn_xid_copy( pair->xid, &txn->xid );
+  }
+  fd_funk_rec_key_copy( pair->key, key );
+
+  for( ;; ) {
+    int err = fd_funk_rec_map_modify_try( &rec_map, pair, NULL, query, FD_MAP_FLAG_BLOCKING );
+    if( err==FD_MAP_SUCCESS ) break;
+    if( err==FD_MAP_ERR_KEY ) return NULL;
+    if( err==FD_MAP_ERR_AGAIN ) continue;
+    FD_LOG_CRIT(( "query returned err %d", err ));
+  }
+
+  fd_funk_rec_t * rec = fd_funk_rec_map_query_ele( query );
+  return rec;
+}
+
+void
+fd_funk_rec_modify_publish( fd_funk_rec_query_t * query ) {
+  fd_funk_rec_map_modify_test( query );
 }
 
 static void

--- a/src/funk/fd_funk_rec.h
+++ b/src/funk/fd_funk_rec.h
@@ -302,21 +302,21 @@ fd_funk_rec_remove( fd_funk_t *               funk,
                     fd_funk_rec_t **          rec_out,
                     ulong                     erase_data );
 
-/*
-  fd_funk_rec_hard_remove completely removes the record from Funk,
-  and leaves no tombstone behind.
+/* fd_funk_rec_modify_prepare queries the in-prep transaction pointed to
+   by txn for the record whose key matches the key pointed to by the
+   key. If the query is successful, then we will acquire a lock on the
+   corresponding hash chain. Any updates made to the record can be
+   published into the funk transaction with a call to
+   fd_funk_rec_modify_publish. */
 
-  This is a dangerous API. An older version of the record in a
-  parent transaction might be exposed. In other words, the record may
-  appear to go backwards in time. We are effectively reverting an
-  update. Any information in an removed record is lost.
+fd_funk_rec_t *
+fd_funk_rec_modify_prepare( fd_funk_t *               funk,
+                            fd_funk_txn_t const *     txn,
+                            fd_funk_rec_key_t const * key,
+                            fd_funk_rec_query_t *     query );
 
-  Always succeeds.
-*/
 void
-fd_funk_rec_hard_remove( fd_funk_t *               funk,
-                         fd_funk_txn_t *           txn,
-                         fd_funk_rec_key_t const * key );
+fd_funk_rec_modify_publish( fd_funk_rec_query_t * query );
 
 /* When a record is erased there is metadata stored in the five most
    significant bytes of record flags.  These are helpers to make setting


### PR DESCRIPTION
This is an anti-pattern, leads to a memory leak and should be removed.

Addresses https://github.com/firedancer-io/firedancer/issues/4856