### PR TITLE
Fix typos in comments and error messages

### DIFF
--- a/src/wiredancer/rtl/ed25519_sigverify_0.sv
+++ b/src/wiredancer/rtl/ed25519_sigverify_0.sv
@@ -20,7 +20,7 @@
 
     Dispatch and merge of sigverify-split-0 jobs to processors.
 
-    Dispatch serializes the three inputs of each invokation
+    Dispatch serializes the three inputs of each invocation
     into the same processor.  Job distribution logic is a 
     simple round-robin policy.  Pointer moves when a job
     is completely taken by a processor.

--- a/src/wiredancer/rtl/schl_cpu.sv
+++ b/src/wiredancer/rtl/schl_cpu.sv
@@ -616,7 +616,7 @@ module shcl_cpu
       mem_d_wr_en    <= '0; 
     end
     else begin
-      if (curr_state[0] == ST_INIT) begin // Write in constants (intialization only happens at startup)
+      if (curr_state[0] == ST_INIT) begin // Write in constants (initialization only happens at startup)
         init_done <= (init_addr == NUM_CONSTS && next_instr_ready == '1); // Consts written into memory and initial instr read for all tags
       
         if( init_addr < NUM_CONSTS) begin

--- a/src/wiredancer/test/test_wiredancer_demo.c
+++ b/src/wiredancer/test/test_wiredancer_demo.c
@@ -1005,7 +1005,7 @@ main( int     argc,
 
   ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
   if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz"  ));
-  if( FD_UNLIKELY( !replay_pcap ) ) FD_LOG_ERR(( "--replay-pcap not specifed" ));
+  if( FD_UNLIKELY( !replay_pcap ) ) FD_LOG_ERR(( "--replay-pcap not specified" ));
 
   /* Check minimum number of tiles */
   ulong req_tile_cnt = 1 /* main */ + (( !!replay_enabled )? 1UL : 0UL) +


### PR DESCRIPTION
This PR fixes several minor typos:

- Corrects "invokation" to "invocation" in sigverify_0 comments
- Fixes "intialization" to "initialization" in schcl_cpu comments 
- Corrects "specifed" to "specified" in error message

These changes improve code readability and consistency without affecting functionality.