### PR TITLE
fuzz, flamenco: agave v2.2.13 support

### DIFF
--- a/src/ballet/sbpf/fd_sbpf_loader.c
+++ b/src/ballet/sbpf/fd_sbpf_loader.c
@@ -221,7 +221,7 @@ fd_sbpf_load_phdrs( fd_sbpf_elf_info_t *  info,
     case FD_ELF_PT_LOAD:
       /* LOAD segments must be ordered */
       REQUIRE( phdr[ i ].p_vaddr >= p_load_vaddr );
-      p_load_vaddr = fd_ulong_sat_add( phdr[ i ].p_offset, phdr[ i ].p_filesz );
+      p_load_vaddr = phdr[ i ].p_vaddr;
       /* Segment must be within bounds */
       REQUIRE( ( phdr[ i ].p_offset + phdr[ i ].p_filesz >= phdr[ i ].p_offset )
              & ( phdr[ i ].p_offset + phdr[ i ].p_filesz <= elf_sz             ) );

--- a/src/flamenco/features/fd_features_generated.c
+++ b/src/flamenco/features/fd_features_generated.c
@@ -1152,8 +1152,8 @@ fd_feature_id_t const ids[] = {
     .cleaned_up                = {UINT_MAX, UINT_MAX, UINT_MAX} },
 
   { .index                     = offsetof(fd_features_t, enable_loader_v4)>>3,
-    .id                        = {"\x6a\xf9\xc2\xb7\xef\x03\x1f\xcd\x0f\x1a\x09\x23\x4e\x8a\x87\x4e\xa1\xf5\x78\x76\x05\xb9\x50\xa3\x0d\x93\x1f\xf6\x6a\x54\x99\xd6"},
-                                 /* 8Cb77yHjPWe9wuWUfXeh6iszFGCDGNCoFk3tprViYHNm */
+    .id                        = {"\xe0\xea\x16\x11\xc8\xd1\xc7\x7c\x8b\xf2\xbd\xee\x37\x3b\x8d\x17\x56\x09\x1b\x97\x83\xce\xaf\x70\xc9\xb6\xc7\x2a\xb9\x42\x22\x79"},
+                                 /* G8yMNsNUd4p3VB22ycrPEB1qRgepCFeFpAqD2Lr66s36 */
     .name                      = "enable_loader_v4",
     .cleaned_up                = {UINT_MAX, UINT_MAX, UINT_MAX},
     .activated_on_all_clusters = 1 },
@@ -1772,7 +1772,7 @@ fd_feature_id_query( ulong prefix ) {
   case 0x3cbf822ccb2eebd4: return &ids[ 163 ];
   case 0xe9d32123513c4d0d: return &ids[ 164 ];
   case 0x64205286d7935342: return &ids[ 165 ];
-  case 0xcd1f03efb7c2f96a: return &ids[ 166 ];
+  case 0x7cc7d1c81116eae0: return &ids[ 166 ];
   case 0x4b241cb4c6f3b3b2: return &ids[ 167 ];
   case 0x21746beaa849f9d9: return &ids[ 168 ];
   case 0x9bb55b5df1c396c5: return &ids[ 169 ];

--- a/src/flamenco/features/fd_features_generated.h
+++ b/src/flamenco/features/fd_features_generated.h
@@ -173,7 +173,7 @@ union fd_features {
     /* 0x3cbf822ccb2eebd4 */ ulong enable_poseidon_syscall;
     /* 0xe9d32123513c4d0d */ ulong timely_vote_credits;
     /* 0x64205286d7935342 */ ulong remaining_compute_units_syscall_enabled;
-    /* 0xcd1f03efb7c2f96a */ ulong enable_loader_v4;
+    /* 0x7cc7d1c81116eae0 */ ulong enable_loader_v4;
     /* 0x4b241cb4c6f3b3b2 */ ulong require_rent_exempt_split_destination;
     /* 0x21746beaa849f9d9 */ ulong better_error_codes_for_tx_lamport_check;
     /* 0x9bb55b5df1c396c5 */ ulong enable_alt_bn128_compression_syscall;

--- a/src/flamenco/features/feature_map.json
+++ b/src/flamenco/features/feature_map.json
@@ -165,7 +165,7 @@
   {"name":"enable_poseidon_syscall","pubkey": "FL9RsQA6TVUoh5xJQ9d936RHSebA1NLQqe3Zv9sXZRpr","activated_on_all_clusters":1},
   {"name":"timely_vote_credits","old": "2oXpeh141pPZCTCFHBsvCwG2BtaHZZAtrVhwaxSy6brS","pubkey":"tvcF6b1TRz353zKuhBjinZkKzjmihXmBAHJdjNYw1sQ","activated_on_all_clusters":1},
   {"name":"remaining_compute_units_syscall_enabled","pubkey": "5TuppMutoyzhUSfuYdhgzD47F92GL1g89KpCZQKqedxP"},
-  {"name":"enable_loader_v4","pubkey": "8Cb77yHjPWe9wuWUfXeh6iszFGCDGNCoFk3tprViYHNm","activated_on_all_clusters":1},
+  {"name":"enable_loader_v4","pubkey": "G8yMNsNUd4p3VB22ycrPEB1qRgepCFeFpAqD2Lr66s36","old": "8Cb77yHjPWe9wuWUfXeh6iszFGCDGNCoFk3tprViYHNm","activated_on_all_clusters":1},
   {"name":"require_rent_exempt_split_destination","pubkey": "D2aip4BBr8NPWtU9vLrwrBvbuaQ8w1zV38zFLxx4pfBV","cleaned_up":[2,0,0],"activated_on_all_clusters":1},
   {"name":"better_error_codes_for_tx_lamport_check","pubkey": "Ffswd3egL3tccB6Rv3XY6oqfdzn913vUcjCSnpvCKpfx","cleaned_up":[2,0,0],"activated_on_all_clusters":1},
   {"name":"enable_alt_bn128_compression_syscall","pubkey": "EJJewYSddEEtSZHiqugnvhQHiWyZKjkFDQASd7oKSagn","activated_on_all_clusters":1},

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -77,9 +77,6 @@ fd_execute_txn_prepare_start( fd_exec_slot_ctx_t const * slot_ctx,
 int
 fd_execute_txn( fd_execute_txn_task_info_t * task_info );
 
-uint
-fd_executor_txn_uses_sysvar_instructions( fd_exec_txn_ctx_t const * txn_ctx );
-
 int
 fd_executor_validate_transaction_fee_payer( fd_exec_txn_ctx_t * txn_ctx );
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_instructions.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_instructions.h
@@ -12,9 +12,10 @@ fd_sysvar_instructions_serialize_account( fd_exec_txn_ctx_t *      txn_ctx,
                                           fd_instr_info_t const *  instrs,
                                           ushort                   instrs_cnt );
 
-int
-fd_sysvar_instructions_update_current_instr_idx( fd_exec_txn_ctx_t * txn_ctx,
-                                                 ushort              current_instr_idx );
+void
+fd_sysvar_instructions_update_current_instr_idx( fd_txn_account_t * rec,
+                                                 ushort             current_instr_idx );
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_flamenco_runtime_sysvar_instructions_h */

--- a/src/flamenco/runtime/tests/harness/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/harness/fd_instr_harness.c
@@ -145,6 +145,11 @@ fd_runtime_fuzz_instr_ctx_create( fd_runtime_fuzz_runner_t *           runner,
       has_program_id = 1;
       info->program_id = (uchar)txn_ctx->accounts_cnt;
     }
+
+    /* Since the instructions sysvar is set as mutable at the txn level, we need to make it mutable here as well. */
+    if( !memcmp( accts[j].pubkey, &fd_sysvar_instructions_id, sizeof(fd_pubkey_t) ) ) {
+      acc->vt->set_mutable( acc );
+    }
   }
 
   /* If the program id is not in the set of accounts it must be added to the set of accounts. */


### PR DESCRIPTION
* Follows https://github.com/anza-xyz/sbpf/pull/39 and commit 9cba8b009a1a20955513d8270525b0b49a6d026c.
* Rekeys `enable_loader_v4` feature
* Move sysvar instructions updating to instruction level from txn level (follows https://github.com/anza-xyz/agave/pull/5698)