### PR TITLE
gui: 10min tps history

### DIFF
--- a/book/api/websocket.md
+++ b/book/api/websocket.md
@@ -467,10 +467,10 @@ start incorporating skips for the new identity key.
 |-----------|--------------|---------|
 | *Once*    | `number[][]` | `[[5492.2,4578.841,914.24,0],[6134.44419,5149.23,985,0]]` |
 
-A list of the last 150 TPS samples taken by the validator. Currently the
+A list of the last 1500 TPS samples taken by the validator. Currently the
 spacing between samples is poorly defined, but it's roughly one sample
 per slot. Each element in the outer array represents a sample, and the
-outer array will have up to 150 samples. Each sample will have 4
+outer array will have up to 1500 samples. Each sample will have 4
 elements, which are `total_tps`, `vote_tps`, `nonvote_success_tps`, and
 `nonvote_failed_tps` as defined below. Samples are listed from oldest
 first.
@@ -482,9 +482,9 @@ first.
 
 The estimated number of transactions per second the network is running
 at. This includes total, vote, non-vote successful, and non-vote failed
-transactions. This is a moving average from the prior 150 slots, or
-around one minute. For a more precise view of transactions per second,
-the client can calculate it from the stream of new slot data.
+transactions. This is a moving average from the prior 10 seconds. For a
+more precise view of transactions per second, the client can calculate
+it from the stream of new slot data.
 
 The sum of the non-vote successful and the non-vote failed transactions
 represent the number of non-vote transactions. The sum of the estimated

--- a/src/disco/gui/fd_gui.h
+++ b/src/disco/gui/fd_gui.h
@@ -12,7 +12,7 @@
 
 #define FD_GUI_SLOTS_CNT (864000UL)
 #define FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS (10L) /* 10 second moving average */
-#define FD_GUI_TPS_HISTORY_SAMPLE_CNT              (150UL)
+#define FD_GUI_TPS_HISTORY_SAMPLE_CNT              (1500UL) /* 10min worth of slots */
 #define FD_GUI_TILE_TIMER_SNAP_CNT                 (512UL)
 #define FD_GUI_TILE_TIMER_LEADER_CNT               (4096UL)
 #define FD_GUI_TILE_TIMER_LEADER_DOWNSAMPLE_CNT    (50UL)


### PR DESCRIPTION
The frontend will handle this change gracefully (i.e. will stay at 1min for now). This will allow for eventually increasing the size of the tps window.