### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/src/disco/shred/fd_fec_resolver.h
+++ b/src/disco/shred/fd_fec_resolver.h
@@ -199,7 +199,7 @@ int fd_fec_resolver_add_shred( fd_fec_resolver_t    * resolver,
                                fd_bmtree_node_t     * out_merkle_root );
 
 
-/* fd_fec_resolver_done_contains returns 1 if the the FEC with signature
+/* fd_fec_resolver_done_contains returns 1 if the FEC with signature
    lives in the done_map, and thus means it has been completed. Returns
    0 otherwise. */
 int

--- a/src/flamenco/runtime/context/fd_exec_instr_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_instr_ctx.h
@@ -83,7 +83,7 @@ fd_exec_instr_ctx_check_num_insn_accounts( fd_exec_instr_ctx_t const * ctx,
 
 /* Mirrors Agave function solana_sdk::transaction_context::InstructionContext::find_index_of_instruction_account.
 
-   Returns the index of the the instruction account given the account pubkey
+   Returns the index of the instruction account given the account pubkey
    or -1 if the account is not found.
 
    https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L524-L538 */

--- a/src/flamenco/runtime/fd_blockstore.h
+++ b/src/flamenco/runtime/fd_blockstore.h
@@ -528,7 +528,7 @@ fd_blockstore_footprint( ulong shred_max, ulong block_max, ulong idx_max, ulong 
 }
 
 /* fd_blockstore_new formats a memory region with the appropriate
-   alignment and footprint into a blockstore.  shmem points in the the
+   alignment and footprint into a blockstore.  shmem points in the
    caller's address space of the memory region to format.  Returns shmem
    on success (blockstore has ownership of the memory region) and NULL
    on failure (no changes, logs details).  Caller is not joined on

--- a/src/util/alloc/fd_alloc_cfg.h
+++ b/src/util/alloc/fd_alloc_cfg.h
@@ -33,7 +33,7 @@
    
    Specifically, we pick a "large" superblock size that will nest as
    tightly inside a block of a "huge" superblock when the huge
-   superblock is divided into the minimum 8 blocks.  Noting that the the
+   superblock is divided into the minimum 8 blocks.  Noting that the
    large superblock will have the same 19B overhead and the huge huge
    superblock has a 16B header, we have L=floor((H-16B)/8)-19B=65512B.
 


### PR DESCRIPTION
remove redundant word in comment