### PR TITLE
gui: fix CU pct for replayed slots

### DIFF
--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -987,6 +987,7 @@ fd_gui_clear_slot( fd_gui_t * gui,
 
   slot->slot                   = _slot;
   slot->parent_slot            = _parent_slot;
+  slot->max_compute_units      = UINT_MAX;
   slot->mine                   = mine;
   slot->skipped                = 0;
   slot->must_republish         = 1;
@@ -1004,7 +1005,6 @@ fd_gui_clear_slot( fd_gui_t * gui,
 
   slot->txs.leader_start_time  = LONG_MAX;
   slot->txs.leader_end_time    = LONG_MAX;
-  slot->txs.max_compute_units  = UINT_MAX;
   slot->txs.microblocks_upper_bound = USHORT_MAX;
   slot->txs.begin_microblocks  = 0U;
   slot->txs.end_microblocks    = 0U;
@@ -1300,12 +1300,14 @@ fd_gui_handle_completed_slot( fd_gui_t * gui,
   ulong priority_fee             = msg[ 7 ];
   ulong tips                     = msg[ 8 ];
   ulong _parent_slot             = msg[ 9 ];
+  ulong max_compute_units        = msg[ 10 ];
 
   fd_gui_slot_t * slot = gui->slots[ _slot % FD_GUI_SLOTS_CNT ];
   if( FD_UNLIKELY( slot->slot!=_slot ) ) fd_gui_clear_slot( gui, _slot, _parent_slot );
 
   slot->completed_time = fd_log_wallclock();
   slot->parent_slot = _parent_slot;
+  slot->max_compute_units = (uint)max_compute_units;
   if( FD_LIKELY( slot->level<FD_GUI_SLOT_LEVEL_COMPLETED ) ) {
     /* Typically a slot goes from INCOMPLETE to COMPLETED but it can
        happen that it starts higher.  One such case is when we
@@ -1675,10 +1677,10 @@ fd_gui_became_leader( fd_gui_t * gui,
                       ulong      max_microblocks ) {
   fd_gui_init_slot_txns( gui, tickcount, _slot );
   fd_gui_slot_t * slot = gui->slots[ _slot % FD_GUI_SLOTS_CNT ];
+  slot->max_compute_units = (uint)max_compute_units;
 
   slot->txs.leader_start_time = start_time_nanos;
   slot->txs.leader_end_time   = end_time_nanos;
-  slot->txs.max_compute_units = (uint)max_compute_units;
   if( FD_LIKELY( slot->txs.microblocks_upper_bound==USHORT_MAX ) ) slot->txs.microblocks_upper_bound = (ushort)max_microblocks;
 }
 

--- a/src/disco/gui/fd_gui.h
+++ b/src/disco/gui/fd_gui.h
@@ -181,6 +181,7 @@ typedef struct fd_gui_tile_stats fd_gui_tile_stats_t;
 struct fd_gui_slot {
   ulong slot;
   ulong parent_slot;
+  uint max_compute_units;
   long  completed_time;
   int   mine;
   int   skipped;
@@ -216,9 +217,6 @@ struct fd_gui_slot {
     uint end_microblocks;   /* The number of microblocks we have seen be ended (sent) from banks to poh.  The
                                slot is only considered over if the begin and end microblocks seen are both equal
                                to the microblock upper bound. */
-
-    uint   max_compute_units; /* The maximum number of compute units allowed in the slot.  Currently fixed at 48M
-                                 but will increase dynamically in future according to some feature gates. */
 
     ulong   start_offset; /* The smallest pack transaction index for this slot. The first transaction for this slot will
                              be written to gui->txs[ start_offset%FD_GUI_TXN_HISTORY_SZ ]. */

--- a/src/disco/gui/fd_gui_printf.c
+++ b/src/disco/gui/fd_gui_printf.c
@@ -1053,8 +1053,8 @@ fd_gui_printf_slot( fd_gui_t * gui,
         else                                              jsonp_ulong( gui, "vote_transactions", slot->vote_txn_cnt );
         if( FD_UNLIKELY( slot->failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui, "failed_transactions" );
         else                                                jsonp_ulong( gui, "failed_transactions", slot->failed_txn_cnt );
-        if( FD_UNLIKELY( slot->txs.max_compute_units==UINT_MAX ) ) jsonp_null( gui, "max_compute_units" );
-        else                                                       jsonp_ulong( gui, "max_compute_units", slot->txs.max_compute_units );
+        if( FD_UNLIKELY( slot->max_compute_units==UINT_MAX ) ) jsonp_null( gui, "max_compute_units" );
+        else                                                       jsonp_ulong( gui, "max_compute_units", slot->max_compute_units );
         if( FD_UNLIKELY( slot->compute_units==UINT_MAX ) ) jsonp_null( gui, "compute_units" );
         else                                               jsonp_ulong( gui, "compute_units", slot->compute_units );
         if( FD_UNLIKELY( slot->transaction_fee==ULONG_MAX ) ) jsonp_null( gui, "transaction_fee" );
@@ -1120,8 +1120,8 @@ fd_gui_printf_slot_request( fd_gui_t * gui,
         else                                              jsonp_ulong( gui, "vote_transactions", slot->vote_txn_cnt );
         if( FD_UNLIKELY( slot->failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui, "failed_transactions" );
         else                                                jsonp_ulong( gui, "failed_transactions", slot->failed_txn_cnt );
-        if( FD_UNLIKELY( slot->txs.max_compute_units==UINT_MAX ) ) jsonp_null( gui, "max_compute_units" );
-        else                                                       jsonp_ulong( gui, "max_compute_units", slot->txs.max_compute_units );
+        if( FD_UNLIKELY( slot->max_compute_units==UINT_MAX ) ) jsonp_null( gui, "max_compute_units" );
+        else                                                       jsonp_ulong( gui, "max_compute_units", slot->max_compute_units );
         if( FD_UNLIKELY( slot->compute_units==UINT_MAX ) ) jsonp_null( gui, "compute_units" );
         else                                               jsonp_ulong( gui, "compute_units", slot->compute_units );
         if( FD_UNLIKELY( slot->transaction_fee==ULONG_MAX ) ) jsonp_null( gui, "transaction_fee" );
@@ -1179,8 +1179,8 @@ fd_gui_printf_slot_transactions_request( fd_gui_t * gui,
         else                                              jsonp_ulong( gui, "vote_transactions", slot->vote_txn_cnt );
         if( FD_UNLIKELY( slot->failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui, "failed_transactions" );
         else                                                jsonp_ulong( gui, "failed_transactions", slot->failed_txn_cnt );
-        if( FD_UNLIKELY( slot->txs.max_compute_units==UINT_MAX ) ) jsonp_null( gui, "max_compute_units" );
-        else                                                       jsonp_ulong( gui, "max_compute_units", slot->txs.max_compute_units );
+        if( FD_UNLIKELY( slot->max_compute_units==UINT_MAX ) ) jsonp_null( gui, "max_compute_units" );
+        else                                                       jsonp_ulong( gui, "max_compute_units", slot->max_compute_units );
         if( FD_UNLIKELY( slot->compute_units==UINT_MAX ) ) jsonp_null( gui, "compute_units" );
         else                                               jsonp_ulong( gui, "compute_units", slot->compute_units );
         if( FD_UNLIKELY( slot->transaction_fee==ULONG_MAX ) ) jsonp_null( gui, "transaction_fee" );
@@ -1322,8 +1322,8 @@ fd_gui_printf_slot_request_detailed( fd_gui_t * gui,
         else                                              jsonp_ulong( gui, "vote_transactions", slot->vote_txn_cnt );
         if( FD_UNLIKELY( slot->failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui, "failed_transactions" );
         else                                                jsonp_ulong( gui, "failed_transactions", slot->failed_txn_cnt );
-        if( FD_UNLIKELY( slot->txs.max_compute_units==UINT_MAX ) ) jsonp_null( gui, "max_compute_units" );
-        else                                                       jsonp_ulong( gui, "max_compute_units", slot->txs.max_compute_units );
+        if( FD_UNLIKELY( slot->max_compute_units==UINT_MAX ) ) jsonp_null( gui, "max_compute_units" );
+        else                                                       jsonp_ulong( gui, "max_compute_units", slot->max_compute_units );
         if( FD_UNLIKELY( slot->compute_units==UINT_MAX ) ) jsonp_null( gui, "compute_units" );
         else                                               jsonp_ulong( gui, "compute_units", slot->compute_units );
         if( FD_UNLIKELY( slot->transaction_fee==ULONG_MAX ) ) jsonp_null( gui, "transaction_fee" );

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -1305,7 +1305,7 @@ publish_slot_notifications( fd_replay_tile_ctx_t * ctx,
       .parent_slot = ctx->parent_slot,
     };
     */
-    ulong msg[10];
+    ulong msg[11];
     msg[ 0 ] = ctx->curr_slot;
     msg[ 1 ] = fork->slot_ctx->txn_count;
     msg[ 2 ] = fork->slot_ctx->nonvote_txn_count;
@@ -1316,6 +1316,7 @@ publish_slot_notifications( fd_replay_tile_ctx_t * ctx,
     msg[ 7 ] = fork->slot_ctx->slot_bank.collected_priority_fees;
     msg[ 8 ] = 0UL; /* todo ... track tips */
     msg[ 9 ] = ctx->parent_slot;
+    msg[ 10 ] = 0UL;  /* todo ... max compute units */
     replay_plugin_publish( ctx, stem, FD_PLUGIN_MSG_SLOT_COMPLETED, (uchar const *)msg, sizeof(msg) );
   }
 }


### PR DESCRIPTION
In the gui, only leader slots were aware of max cus. This sends the value from the replay pipeline so that all slots reflect the limit accurately.

agave [diff](https://github.com/firedancer-io/agave/compare/3f7623b0fe..jherrera/gui-fix-cus-pct~9)