### PR TITLE
repair: fix fd_forest_new parameter mismatch

### DIFF
--- a/src/discof/forest/fd_forest.h
+++ b/src/discof/forest/fd_forest.h
@@ -153,7 +153,7 @@ fd_forest_footprint( ulong ele_max ) {
    address space with the required footprint and alignment. */
 
 void *
-fd_forest_new( void * shmem, ulong seed, ulong ele_max );
+fd_forest_new( void * shmem, ulong ele_max, ulong seed );
 
 /* fd_forest_join joins the caller to the forest.  forest
    points to the first byte of the memory region backing the forest


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/af3f20b7-12f5-4b46-97d4-73fe72c0ec1e)
The header and the implementation do not agree on the order of the arguments, because the swaped arguments are of the same type the compiler does not catch this. Currently, everything is using it as the .c file expects it, so no usage fixes needed.