### PR TITLE
topo: fix workspace NUMA affinity

### DIFF
--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -510,7 +510,7 @@ initialize_numa_assignments( fd_topo_t * topo ) {
     if( FD_UNLIKELY( max_obj==ULONG_MAX ) ) FD_LOG_ERR(( "no object found for workspace %s", topo->workspaces[ i ].name ));
 
     int found_strict = 0;
-    int found_lazy   = 1;
+    int found_lazy   = 0;
     for( ulong j=0UL; j<topo->tile_cnt; j++ ) {
       fd_topo_tile_t * tile = &topo->tiles[ j ];
       if( FD_UNLIKELY( tile->tile_obj_id==max_obj && tile->cpu_idx!=ULONG_MAX ) ) {
@@ -555,8 +555,6 @@ initialize_numa_assignments( fd_topo_t * topo ) {
 void
 fd_topob_finish( fd_topo_t *                topo,
                  fd_topo_obj_callbacks_t ** callbacks ) {
-  initialize_numa_assignments( topo );
-
   for( ulong z=0UL; z<topo->tile_cnt; z++ ) {
     fd_topo_tile_t * tile = &topo->tiles[ z ];
 
@@ -649,6 +647,8 @@ fd_topob_finish( fd_topo_t *                topo,
     wksp->page_sz = page_sz;
     wksp->page_cnt = wksp_aligned_footprint / page_sz;
   }
+
+  initialize_numa_assignments( topo );
 
   validate( topo );
 }


### PR DESCRIPTION
Fixes two bugs that result in workspace affinity to NUMA node 0
even if all user tiles are on a different NUMA node.
