### PR TITLE
quic_tls_hs:  simplify data buf

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -3834,14 +3834,7 @@ fd_quic_conn_service( fd_quic_t * quic, fd_quic_conn_t * conn, ulong now ) {
             fd_quic_cb_conn_new( quic, conn );
 
             /* clear out hs_data here, as we don't need it anymore */
-            fd_quic_tls_hs_data_t * hs_data = NULL;
-
-            uint enc_level = (uint)fd_quic_enc_level_appdata_id;
-            hs_data = fd_quic_tls_get_hs_data( conn->tls_hs, enc_level );
-            while( hs_data ) {
-              fd_quic_tls_pop_hs_data( conn->tls_hs, enc_level );
-              hs_data = fd_quic_tls_get_hs_data( conn->tls_hs, enc_level );
-            }
+            fd_quic_tls_clear_hs_data( conn->tls_hs, fd_quic_enc_level_appdata_id );
           }
 
           /* if we're the client, fd_quic_conn_tx will flush the hs
@@ -5444,16 +5437,7 @@ fd_quic_handle_handshake_done_frame(
   }
 
   /* eliminate any remaining hs_data at application level */
-  fd_quic_tls_hs_data_t * hs_data = NULL;
-
-  uint hs_enc_level = fd_quic_enc_level_appdata_id;
-  hs_data = fd_quic_tls_get_hs_data( conn->tls_hs, hs_enc_level );
-  /* skip packets we've sent */
-  while( hs_data ) {
-    fd_quic_tls_pop_hs_data( conn->tls_hs, hs_enc_level );
-
-    hs_data = fd_quic_tls_get_hs_data( conn->tls_hs, hs_enc_level );
-  }
+  fd_quic_tls_clear_hs_data( conn->tls_hs, fd_quic_enc_level_appdata_id );
 
   /* we shouldn't be receiving this unless handshake is complete */
   conn->state = FD_QUIC_CONN_STATE_ACTIVE;

--- a/src/waltz/quic/tls/fd_quic_tls.h
+++ b/src/waltz/quic/tls/fd_quic_tls.h
@@ -140,30 +140,18 @@ struct fd_quic_tls_hs {
      these will be encapsulated and sent in order */
   fd_quic_tls_hs_data_t hs_data[ FD_QUIC_TLS_HS_DATA_CNT ];
 
-  /* head of handshake data free list */
+  /* head of hs_data_t free list */
   ushort hs_data_free_idx;
 
-  /* head of handshake data pending (to be sent) */
+  /* head/tail of hs_data_t pending (to be sent) */
   ushort hs_data_pend_idx[4];
   ushort hs_data_pend_end_idx[4];
 
   /* handshake data buffer
-     allocated in arbitrary chunks in a circular queue manner */
-  uchar  hs_data_buf[ FD_QUIC_TLS_HS_DATA_SZ ];
-
-  /* head and tail of unused hs_data_buf data
-       head % buf_sz is first used byte
-       tail % buf_sz is first unused byte
-       invariants
-         0 <= head < 2 * buf_sz
-         0 <= tail <     buf_sz
-         head >= tail
-         head <  tail + buf_sz
-         head -  tail == unused size */
-
-  /* buffer space is shared between encryption levels */
-  uint  hs_data_buf_head;
-  uint  hs_data_buf_tail;
+      allocated in arbitrary chunks
+      and shared between encryption levels */
+  uchar hs_data_buf[ FD_QUIC_TLS_HS_DATA_SZ ];
+  uint  hs_data_buf_ptr;     /* ptr is first unused byte in hs_data_buf */
   uint  hs_data_offset[ 4 ]; /* one offset per encoding level */
 
   /* Handshake message receive buffer
@@ -257,6 +245,13 @@ fd_quic_tls_get_next_hs_data( fd_quic_tls_hs_t * self, fd_quic_tls_hs_data_t * h
    remove handshake data from head of queue and free associated resources */
 void
 fd_quic_tls_pop_hs_data( fd_quic_tls_hs_t * self, uint enc_level );
+
+
+/* fd_quic_tls_clear_hs_data
+
+   clear all handshake data from a given encryption level. */
+void
+fd_quic_tls_clear_hs_data( fd_quic_tls_hs_t * self, uint enc_level );
 
 
 #endif /* HEADER_fd_src_waltz_quic_tls_fd_quic_tls_h */


### PR DESCRIPTION
Currently, the data buffer to manage outgoing tls hs data is circular. However, 