### PR TITLE
repair: forest and chainer max as configurable in toml

### DIFF
--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -235,6 +235,13 @@ user = ""
     # in the historical transaction info stored.
     extended_tx_metadata_storage = false
 
+# TODO: DOCS
+[repair]
+    client_port = 8701
+    serve_port  = 8702
+    forest_max  = 4096
+    chainer_max = 32768
+
 # Snapshots are a periodic view of the ledger at a point in time.  They
 # are used to enable validators to join the network quickly, as they do
 # not need to replay all transactions since genesis, just those since a
@@ -901,10 +908,6 @@ user = ""
         # slots.
         additional_shred_destination = ""
 
-    # TODO: DOCS
-    [tiles.repair]
-        repair_intake_listen_port = 8701
-        repair_serve_listen_port = 8702
 
     [tiles.replay]
         # Where to obtain the full snapshot.

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -752,8 +752,8 @@ fd_topo_initialize( config_t * config ) {
       tile->net.quic_transaction_listen_port   = config->tiles.quic.quic_transaction_listen_port;
       tile->net.legacy_transaction_listen_port = config->tiles.quic.regular_transaction_listen_port;
       tile->net.gossip_listen_port             = config->gossip.port;
-      tile->net.repair_intake_listen_port      = config->tiles.repair.repair_intake_listen_port;
-      tile->net.repair_serve_listen_port       = config->tiles.repair.repair_serve_listen_port;
+      tile->net.repair_intake_listen_port      = config->firedancer.repair.client_port;
+      tile->net.repair_serve_listen_port       = config->firedancer.repair.serve_port;
 
     } else if( FD_UNLIKELY( !strcmp( tile->name, "netlnk" ) ) ) {
 
@@ -806,16 +806,18 @@ fd_topo_initialize( config_t * config ) {
       tile->gossip.tpu_port             = config->tiles.quic.regular_transaction_listen_port;
       tile->gossip.tpu_quic_port        = config->tiles.quic.quic_transaction_listen_port;
       tile->gossip.tpu_vote_port        = config->tiles.quic.regular_transaction_listen_port; /* TODO: support separate port for tpu vote */
-      tile->gossip.repair_serve_port    = config->tiles.repair.repair_serve_listen_port;
+      tile->gossip.repair_serve_port    = config->firedancer.repair.serve_port;
       tile->gossip.entrypoints_cnt      = fd_ulong_min( config->gossip.resolved_entrypoints_cnt, FD_TOPO_GOSSIP_ENTRYPOINTS_MAX );
       fd_memcpy( tile->gossip.entrypoints, config->gossip.resolved_entrypoints, tile->gossip.entrypoints_cnt * sizeof(fd_ip4_port_t) );
 
     } else if( FD_UNLIKELY( !strcmp( tile->name, "repair" ) ) ) {
       tile->repair.max_pending_shred_sets    = config->tiles.shred.max_pending_shred_sets;
       tile->repair.shred_tile_cnt            = config->layout.shred_tile_count;
-      tile->repair.repair_intake_listen_port = config->tiles.repair.repair_intake_listen_port;
-      tile->repair.repair_serve_listen_port  = config->tiles.repair.repair_serve_listen_port;
-      strncpy( tile->repair.good_peer_cache_file, config->tiles.repair.good_peer_cache_file, sizeof(tile->repair.good_peer_cache_file) );
+      tile->repair.repair_intake_listen_port = config->firedancer.repair.client_port;
+      tile->repair.repair_serve_listen_port  = config->firedancer.repair.serve_port;
+      tile->repair.forest_max                = config->firedancer.repair.forest_max;
+      tile->repair.chainer_max               = config->firedancer.repair.chainer_max;
+      strncpy( tile->repair.good_peer_cache_file, config->firedancer.repair.good_peer_cache_file, sizeof(tile->repair.good_peer_cache_file) );
 
       strncpy( tile->repair.identity_key_path, config->paths.identity_key, sizeof(tile->repair.identity_key_path) );
 

--- a/src/app/shared/fd_config.c
+++ b/src/app/shared/fd_config.c
@@ -432,7 +432,11 @@ fd_config_fill( fd_config_t * config,
 
 static void
 fd_config_validatef( fd_configf_t const * config ) {
-  (void)config;
+  CFG_HAS_NON_ZERO( repair.chainer_max );
+  CFG_HAS_NON_ZERO( repair.forest_max );
+  CFG_HAS_NON_ZERO( repair.client_port );
+  CFG_HAS_NON_ZERO( repair.serve_port );
+
 }
 
 static void

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -96,6 +96,14 @@ struct fd_configf {
   } consensus;
 
   struct {
+    ushort client_port;
+    ushort serve_port;
+    ulong  forest_max;
+    ulong  chainer_max;
+    char   good_peer_cache_file[ PATH_MAX ];
+  } repair;
+
+  struct {
     ulong shred_max;
     ulong block_max;
     ulong idx_max;
@@ -336,12 +344,6 @@ struct fd_config {
       ulong  max_http_request_length;
       ulong  send_buffer_size_mb;
     } gui;
-
-    struct {
-      ushort repair_intake_listen_port;
-      ushort repair_serve_listen_port;
-      char   good_peer_cache_file[ PATH_MAX ];
-    } repair;
 
     struct {
       char  capture[ PATH_MAX ];

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -310,6 +310,12 @@ fd_config_extract_podf( uchar *        pod,
 
   CFG_POP      ( bool,   consensus.vote                                   );
 
+  CFG_POP      ( ushort, repair.client_port                               );
+  CFG_POP      ( ushort, repair.serve_port                               );
+  CFG_POP      ( ulong,  repair.forest_max                                );
+  CFG_POP      ( ulong,  repair.chainer_max                               );
+  CFG_POP      ( cstr,   repair.good_peer_cache_file                      );
+
   return config;
 }
 
@@ -411,10 +417,6 @@ fd_config_extract_pod( uchar *       pod,
   CFG_POP      ( ulong,  tiles.gui.max_websocket_connections              );
   CFG_POP      ( ulong,  tiles.gui.max_http_request_length                );
   CFG_POP      ( ulong,  tiles.gui.send_buffer_size_mb                    );
-
-  CFG_POP      ( ushort, tiles.repair.repair_intake_listen_port           );
-  CFG_POP      ( ushort, tiles.repair.repair_serve_listen_port            );
-  CFG_POP      ( cstr,   tiles.repair.good_peer_cache_file                );
 
   CFG_POP      ( cstr,   tiles.replay.capture                             );
   CFG_POP      ( cstr,   tiles.replay.funk_checkpt                        );

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -359,6 +359,8 @@ typedef struct {
       ushort  repair_intake_listen_port;
       ushort  repair_serve_listen_port;
       char    good_peer_cache_file[ PATH_MAX ];
+      ulong   forest_max;
+      ulong   chainer_max;
 
       /* non-config */
 

--- a/src/discof/forest/fd_forest.c
+++ b/src/discof/forest/fd_forest.c
@@ -696,8 +696,8 @@ fd_forest_frontier_print( fd_forest_t const * forest ) {
        !fd_forest_frontier_iter_done( iter, frontier, pool );
        iter = fd_forest_frontier_iter_next( iter, frontier, pool ) ) {
     fd_forest_ele_t const * ele = fd_forest_frontier_iter_ele_const( iter, frontier, pool );
-    printf("%lu (%u/%u)\n", ele->slot, ele->buffered_idx + 1, ele->complete_idx + 1 );
-   //ancestry_print( forest, fd_forest_pool_ele_const( fd_forest_pool_const( forest ), fd_forest_pool_idx( pool, ele ) ), 0, "" );
+    //printf("%lu (%u/%u)\n", ele->slot, ele->buffered_idx + 1, ele->complete_idx + 1 );
+    ancestry_print( forest, fd_forest_pool_ele_const( fd_forest_pool_const( forest ), fd_forest_pool_idx( pool, ele ) ), 0, "" );
   }
 }
 


### PR DESCRIPTION
making a toml config change, replace:
```
[tiles.repair]
        repair_intake_listen_port = x
        repair_serve_listen_port = y
        good_peer_cache_file = something
```
with 
```
[repair]
    client_port = x
    serve_port = y
    good_peer_cache_file = something
```
with repair now at top level

note there are also 2 new configurable variables `forest_max` and `chainer_max`  under repair , but they are covered by `default.toml`


