### PR TITLE
flamenco: initialize sysvar_slot_hashes in runtime + fix memory corruption in read genesis

### DIFF
--- a/src/discof/rpc/fd_rpcserv_tile.c
+++ b/src/discof/rpc/fd_rpcserv_tile.c
@@ -26,7 +26,6 @@
 
 struct fd_rpcserv_tile_ctx {
   fd_rpcserver_args_t args;
-  fd_funk_t funk[1];
   char funk_file[ PATH_MAX ];
 
   int activated;
@@ -142,7 +141,7 @@ after_frag( fd_rpcserv_tile_ctx_t * ctx,
     if( FD_UNLIKELY( !ctx->activated ) ) {
       fd_rpcserver_args_t * args = &ctx->args;
       fd_funk_t * funk = fd_funk_open_file(
-        ctx->funk, ctx->funk_file, 1, 0, 0, 0, 0, FD_FUNK_READ_WRITE, NULL );
+        args->funk, ctx->funk_file, 1, 0, 0, 0, 0, FD_FUNK_READ_WRITE, NULL );
       if( FD_UNLIKELY( !funk ) ) {
         FD_LOG_ERR(( "failed to join a funky" ));
       }

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -3338,6 +3338,7 @@ fd_runtime_init_program( fd_exec_slot_ctx_t * slot_ctx,
   fd_sysvar_recent_hashes_init( slot_ctx, runtime_spad );
   fd_sysvar_clock_init( slot_ctx );
   fd_sysvar_slot_history_init( slot_ctx, runtime_spad );
+  fd_sysvar_slot_hashes_init( slot_ctx, runtime_spad );
   fd_sysvar_epoch_schedule_init( slot_ctx );
   if( !FD_FEATURE_ACTIVE( slot_ctx->slot_bank.slot, slot_ctx->epoch_ctx->features, disable_fees_sysvar ) ) {
     fd_sysvar_fees_init( slot_ctx );
@@ -3659,83 +3660,94 @@ fd_runtime_read_genesis( fd_exec_slot_ctx_t * slot_ctx,
 
   fd_epoch_bank_t *   epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
 
-  FD_SPAD_FRAME_BEGIN( runtime_spad ) {
-    fd_genesis_solana_t * genesis_block;
-    fd_hash_t             genesis_hash;
-    uchar * buf = fd_spad_alloc( runtime_spad, alignof(ulong), (ulong)sbuf.st_size );
-    ssize_t n   = read( fd, buf, (ulong)sbuf.st_size );
-    FD_TEST( n>=0L );
-    close( fd );
+  fd_genesis_solana_t * genesis_block;
+  fd_hash_t             genesis_hash;
+
+  /* NOTE: These genesis decode spad allocs persist through the lifetime of fd_runtime,
+     even though they aren't used outside of this function. This is because
+     fd_runtime_init_bank_from_genesis, which depends on the genesis_block, initializes
+     a bunch of structures on spad that need to persist throughout fd_runtime. Using a bump
+     allocator does not let us free memory lower in the stack without freeing everything
+     above it (in a meaningful way).
+
+     FIXME: Use spad frames here once the fd_runtime structures initialized here are no
+     longer spad-backed. */
+
+  uchar * buf = fd_spad_alloc( runtime_spad, alignof(ulong), (ulong)sbuf.st_size );
+  ulong sz    = 0UL;
+  int res     = fd_io_read( fd, buf, (ulong)sbuf.st_size, (ulong)sbuf.st_size, &sz );
+  FD_TEST( res==0 );
+  FD_TEST( sz==(ulong)sbuf.st_size );
+  close( fd );
 
     int err;
     genesis_block = fd_bincode_decode_spad(
-        genesis_solana, runtime_spad, buf, (ulong)n, &err );
+        genesis_solana, runtime_spad, buf, sz, &err );
     if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) {
       FD_LOG_ERR(( "fd_genesis_solana_decode_footprint failed (%d)", err ));
     }
 
-    // The hash is generated from the raw data... don't mess with this..
-    fd_sha256_hash( buf, (ulong)n, genesis_hash.uc );
+  // The hash is generated from the raw data... don't mess with this..
+  fd_sha256_hash( buf, sz, genesis_hash.uc );
 
-    fd_memcpy( epoch_bank->genesis_hash.uc, genesis_hash.uc, sizeof(fd_hash_t) );
-    epoch_bank->cluster_type = genesis_block->cluster_type;
+  fd_memcpy( epoch_bank->genesis_hash.uc, genesis_hash.uc, sizeof(fd_hash_t) );
+  epoch_bank->cluster_type = genesis_block->cluster_type;
 
-    if( !is_snapshot ) {
-      fd_runtime_init_bank_from_genesis( slot_ctx,
-                                         genesis_block,
-                                         &genesis_hash,
-                                         runtime_spad );
+  if( !is_snapshot ) {
+    fd_runtime_init_bank_from_genesis( slot_ctx,
+                                        genesis_block,
+                                        &genesis_hash,
+                                        runtime_spad );
 
-      fd_runtime_init_program( slot_ctx, runtime_spad );
+    fd_runtime_init_program( slot_ctx, runtime_spad );
 
-      FD_LOG_DEBUG(( "start genesis accounts - count: %lu", genesis_block->accounts_len ));
+    FD_LOG_DEBUG(( "start genesis accounts - count: %lu", genesis_block->accounts_len ));
 
-      for( ulong i=0; i<genesis_block->accounts_len; i++ ) {
-        fd_pubkey_account_pair_t * a = &genesis_block->accounts[i];
+    for( ulong i=0; i<genesis_block->accounts_len; i++ ) {
+      fd_pubkey_account_pair_t * a = &genesis_block->accounts[i];
 
-        FD_TXN_ACCOUNT_DECL( rec );
+      FD_TXN_ACCOUNT_DECL( rec );
 
-        int err = fd_txn_account_init_from_funk_mutable( rec,
-                                                        &a->key,
-                                                        slot_ctx->funk,
-                                                        slot_ctx->funk_txn,
-                                                        1, /* do_create */
-                                                        a->account.data_len );
+      int err = fd_txn_account_init_from_funk_mutable( rec,
+                                                      &a->key,
+                                                      slot_ctx->funk,
+                                                      slot_ctx->funk_txn,
+                                                      1, /* do_create */
+                                                      a->account.data_len );
 
-        if( FD_UNLIKELY( err ) ) {
-          FD_LOG_ERR(( "fd_txn_account_init_from_funk_mutable failed (%d)", err ));
-        }
-
-        rec->vt->set_data( rec, a->account.data, a->account.data_len );
-        rec->vt->set_lamports( rec, a->account.lamports );
-        rec->vt->set_rent_epoch( rec, a->account.rent_epoch );
-        rec->vt->set_executable( rec, a->account.executable );
-        rec->vt->set_owner( rec, &a->account.owner );
-
-        fd_txn_account_mutable_fini( rec, slot_ctx->funk, slot_ctx->funk_txn );
-      }
-
-      FD_LOG_DEBUG(( "end genesis accounts" ));
-
-      FD_LOG_DEBUG(( "native instruction processors - count: %lu", genesis_block->native_instruction_processors_len ));
-
-      for( ulong i=0UL; i < genesis_block->native_instruction_processors_len; i++ ) {
-        fd_string_pubkey_pair_t * a = &genesis_block->native_instruction_processors[i];
-        fd_write_builtin_account( slot_ctx, a->pubkey, (const char *) a->string, a->string_len );
-      }
-
-      fd_features_restore( slot_ctx, runtime_spad );
-
-      slot_ctx->slot_bank.slot = 0UL;
-
-      int err = fd_runtime_process_genesis_block( slot_ctx, capture_ctx, runtime_spad );
       if( FD_UNLIKELY( err ) ) {
-        FD_LOG_ERR(( "Genesis slot 0 execute failed with error %d", err ));
+        FD_LOG_ERR(( "fd_txn_account_init_from_funk_mutable failed (%d)", err ));
       }
+
+      rec->vt->set_data( rec, a->account.data, a->account.data_len );
+      rec->vt->set_lamports( rec, a->account.lamports );
+      rec->vt->set_rent_epoch( rec, a->account.rent_epoch );
+      rec->vt->set_executable( rec, a->account.executable );
+      rec->vt->set_owner( rec, &a->account.owner );
+
+      fd_txn_account_mutable_fini( rec, slot_ctx->funk, slot_ctx->funk_txn );
     }
 
-    fd_genesis_solana_destroy( genesis_block );
-  } FD_SPAD_FRAME_END;
+    FD_LOG_DEBUG(( "end genesis accounts" ));
+
+    FD_LOG_DEBUG(( "native instruction processors - count: %lu", genesis_block->native_instruction_processors_len ));
+
+    for( ulong i=0UL; i < genesis_block->native_instruction_processors_len; i++ ) {
+      fd_string_pubkey_pair_t * a = &genesis_block->native_instruction_processors[i];
+      fd_write_builtin_account( slot_ctx, a->pubkey, (const char *) a->string, a->string_len );
+    }
+
+    fd_features_restore( slot_ctx, runtime_spad );
+
+    slot_ctx->slot_bank.slot = 0UL;
+
+    int err = fd_runtime_process_genesis_block( slot_ctx, capture_ctx, runtime_spad );
+    if( FD_UNLIKELY( err ) ) {
+      FD_LOG_ERR(( "Genesis slot 0 execute failed with error %d", err ));
+    }
+  }
+
+  fd_genesis_solana_destroy( genesis_block );
 
   slot_ctx->slot_bank.stake_account_keys.account_keys_root = NULL;
   uchar * pool_mem = fd_spad_alloc( runtime_spad, fd_account_keys_pair_t_map_align(), fd_account_keys_pair_t_map_footprint( 100000UL ) );

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
@@ -13,9 +13,9 @@ FD_FN_UNUSED static const ulong slot_hashes_max_entries = 512;
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/sysvar/slot_hashes.rs#L12 */
 static const ulong slot_hashes_account_size = 20488;
 
-static void
-write_slot_hashes( fd_exec_slot_ctx_t *      slot_ctx,
-                   fd_slot_hashes_global_t * slot_hashes_global ) {
+void
+fd_sysvar_slot_hashes_write( fd_exec_slot_ctx_t *      slot_ctx,
+                             fd_slot_hashes_global_t * slot_hashes_global ) {
   uchar enc[slot_hashes_account_size];
   fd_memset( enc, 0, slot_hashes_account_size );
   fd_bincode_encode_ctx_t ctx = {
@@ -29,25 +29,79 @@ write_slot_hashes( fd_exec_slot_ctx_t *      slot_ctx,
   fd_sysvar_set( slot_ctx, &fd_sysvar_owner_id, &fd_sysvar_slot_hashes_id, enc, slot_hashes_account_size, slot_ctx->slot_bank.slot );
 }
 
-void
-fd_sysvar_slot_hashes_init( fd_exec_slot_ctx_t *      slot_ctx,
-                            fd_slot_hashes_global_t * slot_hashes_global ) {
-  write_slot_hashes( slot_ctx, slot_hashes_global );
+ulong
+fd_sysvar_slot_hashes_footprint( ulong slot_hashes_cap ) {
+  return sizeof(fd_slot_hashes_global_t) +
+         deq_fd_slot_hash_t_footprint( slot_hashes_cap ) + deq_fd_slot_hash_t_align();
 }
 
-/* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/slot_hashes.rs#L34 */
+void *
+fd_sysvar_slot_hashes_new( void * mem,
+                           ulong  slot_hashes_cap ) {
+  if( FD_UNLIKELY( !mem ) ) {
+    FD_LOG_ERR(( "Unable to allocate memory for slot hashes" ));
+  }
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)mem, FD_SYSVAR_SLOT_HASHES_ALIGN ) ) ) {
+    FD_LOG_ERR(( "Memory for slot hashes is not aligned" ));
+  }
+
+  fd_slot_hashes_global_t * slot_hashes_global = (fd_slot_hashes_global_t *)mem;
+
+  uchar * slot_hash_mem = (uchar*)fd_ulong_align_up( (ulong)((uchar *)mem + sizeof(fd_slot_hashes_global_t)), deq_fd_slot_hash_t_align() );
+  deq_fd_slot_hash_t_new( (void*)slot_hash_mem, slot_hashes_cap );
+  slot_hashes_global->hashes_offset = (ulong)slot_hash_mem - (ulong)slot_hashes_global;
+
+  return slot_hashes_global;
+}
+
+fd_slot_hashes_global_t *
+fd_sysvar_slot_hashes_join( void *            shmem,
+                            fd_slot_hash_t ** slot_hash ) {
+  fd_slot_hashes_global_t * slot_hashes_global = (fd_slot_hashes_global_t *)shmem;
+  *slot_hash                                   = deq_fd_slot_hash_t_join( (uchar*)shmem + slot_hashes_global->hashes_offset );
+
+  return slot_hashes_global;
+}
+
+void *
+fd_sysvar_slot_hashes_leave( fd_slot_hashes_global_t * slot_hashes_global,
+                             fd_slot_hash_t *          slot_hash ) {
+  deq_fd_slot_hash_t_leave( slot_hash );
+
+  return slot_hashes_global;
+}
+
+void *
+fd_sysvar_slot_hashes_delete( void * mem ) {
+  void * slot_hash_mem = (void *)fd_ulong_align_up( (ulong)((uchar *)mem + sizeof(fd_slot_hashes_global_t)), deq_fd_slot_hash_t_align() );
+  deq_fd_slot_hash_t_delete( slot_hash_mem );
+
+  return mem;
+}
+
+void
+fd_sysvar_slot_hashes_init( fd_exec_slot_ctx_t * slot_ctx,
+                            fd_spad_t *          runtime_spad ) {
+  FD_SPAD_FRAME_BEGIN( runtime_spad ) {
+    void * mem                                    = fd_spad_alloc( runtime_spad, FD_SYSVAR_SLOT_HASHES_ALIGN, fd_sysvar_slot_hashes_footprint( FD_SYSVAR_SLOT_HASHES_CAP ) );
+    fd_slot_hash_t * shnull                       = NULL;
+    fd_slot_hashes_global_t * slot_hashes_global  = fd_sysvar_slot_hashes_join( fd_sysvar_slot_hashes_new( mem, FD_SYSVAR_SLOT_HASHES_CAP ), &shnull );
+
+    fd_sysvar_slot_hashes_write( slot_ctx, slot_hashes_global);
+    fd_sysvar_slot_hashes_delete( fd_sysvar_slot_hashes_leave( slot_hashes_global, shnull ) );
+  } FD_SPAD_FRAME_END;
+}
+
+/* https://github.com/anza-xyz/agave/blob/b11ca828cfc658b93cb86a6c5c70561875abe237/runtime/src/bank.rs#L2283-L2294 */
 void
 fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_spad ) {
+FD_SPAD_FRAME_BEGIN( runtime_spad ) {
   fd_slot_hashes_global_t * slot_hashes_global = fd_sysvar_slot_hashes_read( slot_ctx, runtime_spad );
   fd_slot_hash_t *          hashes             = NULL;
-  if( !slot_hashes_global ) {
-    uchar * deque_mem = fd_spad_alloc( runtime_spad,
-                                       deq_fd_slot_hash_t_align(),
-                                       deq_fd_slot_hash_t_footprint( FD_SYSVAR_SLOT_HASHES_CAP ) );
-    hashes = deq_fd_slot_hash_t_join( deq_fd_slot_hash_t_new( deque_mem, FD_SYSVAR_SLOT_HASHES_CAP ) );
-    if( FD_UNLIKELY( !hashes ) ) {
-      FD_LOG_ERR(( "Unable to allocate memory for slot hashes" ));
-    }
+  if( FD_UNLIKELY( !slot_hashes_global ) ) {
+    /* Note: Agave's implementation initializes a new slot_hashes if it doesn't already exist (refer to above URL). */
+    void * mem = fd_spad_alloc( runtime_spad, FD_SYSVAR_SLOT_HASHES_ALIGN, fd_sysvar_slot_hashes_footprint( FD_SYSVAR_SLOT_HASHES_CAP ) );
+    slot_hashes_global = fd_sysvar_slot_hashes_join( fd_sysvar_slot_hashes_new( mem, FD_SYSVAR_SLOT_HASHES_CAP ), &hashes );
   } else {
     hashes = deq_fd_slot_hash_t_join( (uchar*)slot_hashes_global + slot_hashes_global->hashes_offset );
   }
@@ -77,7 +131,9 @@ fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime
     deq_fd_slot_hash_t_push_head( hashes, slot_hash );
   }
 
-  write_slot_hashes( slot_ctx, slot_hashes_global );
+  fd_sysvar_slot_hashes_write( slot_ctx, slot_hashes_global );
+  fd_sysvar_slot_hashes_leave( slot_hashes_global, hashes );
+} FD_SPAD_FRAME_END;
 }
 
 fd_slot_hashes_global_t *
@@ -85,8 +141,9 @@ fd_sysvar_slot_hashes_read( fd_exec_slot_ctx_t *  slot_ctx,
                             fd_spad_t *           runtime_spad ) {
   FD_TXN_ACCOUNT_DECL( rec );
   int err = fd_txn_account_init_from_funk_readonly( rec, (fd_pubkey_t const *)&fd_sysvar_slot_hashes_id, slot_ctx->funk, slot_ctx->funk_txn );
-  if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) )
+  if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
     return NULL;
+  }
 
   fd_bincode_decode_ctx_t decode = {
     .data    = rec->vt->get_data( rec ),

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.h
@@ -11,14 +11,38 @@
 
    https://github.com/anza-xyz/agave/blob/6398ddf6ab8a8f81017bf675ab315a70067f0bf0/sdk/program/src/slot_hashes.rs#L19 */
 
-#define FD_SYSVAR_SLOT_HASHES_CAP (512UL)
+#define FD_SYSVAR_SLOT_HASHES_CAP   (512UL)
+#define FD_SYSVAR_SLOT_HASHES_ALIGN (FD_SLOT_HASHES_GLOBAL_ALIGN)
 
 FD_PROTOTYPES_BEGIN
 
-/* Initialize the slot hashes sysvar account (used for tests currently) */
+
+ulong
+fd_sysvar_slot_hashes_footprint( ulong slot_hashes_cap );
+
+void *
+fd_sysvar_slot_hashes_new( void *   mem,
+                           ulong    slot_hashes_cap );
+
+fd_slot_hashes_global_t *
+fd_sysvar_slot_hashes_join( void *            shmem,
+                            fd_slot_hash_t ** slot_hash );
+
+void *
+fd_sysvar_slot_hashes_leave( fd_slot_hashes_global_t * slot_hashes_global,
+                             fd_slot_hash_t *          slot_hash );
+
+void *
+fd_sysvar_slot_hashes_delete( void * mem );
+
+/* Write a funk entry for the slot hashes sysvar account (exposed for tests) */
 void
-fd_sysvar_slot_hashes_init( fd_exec_slot_ctx_t *      slot_ctx,
-                            fd_slot_hashes_global_t * slot_hashes_global );
+fd_sysvar_slot_hashes_write( fd_exec_slot_ctx_t *      slot_ctx,
+                             fd_slot_hashes_global_t * slot_hashes_global );
+
+void
+fd_sysvar_slot_hashes_init( fd_exec_slot_ctx_t * slot_ctx,
+                            fd_spad_t *          runtime_spad );
 
 /* Update the slot hashes sysvar account. This should be called at the end of every slot, before execution commences. */
 void

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
@@ -56,6 +56,7 @@ fd_sysvar_slot_history_write_history( fd_exec_slot_ctx_t *       slot_ctx,
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/slot_history.rs#L16 */
 void
 fd_sysvar_slot_history_init( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_spad ) {
+  FD_SPAD_FRAME_BEGIN( runtime_spad ) {
   /* Create a new slot history instance */
 
   /* We need to construct the gaddr-aware slot history object */
@@ -79,6 +80,7 @@ fd_sysvar_slot_history_init( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_
   /* TODO: handle slot != 0 init case */
   fd_sysvar_slot_history_set( history, slot_ctx->slot_bank.slot );
   fd_sysvar_slot_history_write_history( slot_ctx, history );
+  } FD_SPAD_FRAME_END;
 }
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/runtime/src/bank.rs#L2345 */

--- a/src/flamenco/runtime/tests/harness/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/harness/fd_txn_harness.c
@@ -125,21 +125,20 @@ fd_runtime_fuzz_txn_ctx_create( fd_runtime_fuzz_runner_t *         runner,
 
   /* Provide default slot hashes of size 1 if not provided */
   if( !slot_ctx->sysvar_cache->has_slot_hashes ) {
-    /* The offseted gaddr aware types need the memory for the entire
-       struct to be allocated out of a contiguous memory region. */
-    ulong default_slot_hashes_sz = sizeof(fd_slot_hashes_global_t) +
-                                   deq_fd_slot_hash_t_footprint( 1UL ) +
-                                   deq_fd_slot_hash_t_align();
-    uchar * slot_hashes_mem = fd_spad_alloc( runner->spad, alignof(fd_slot_hashes_global_t), default_slot_hashes_sz );
-    fd_slot_hashes_global_t * default_slot_hashes_global = (fd_slot_hashes_global_t *)slot_hashes_mem;
+    FD_SPAD_FRAME_BEGIN( runner->spad ) {
+      /* The offseted gaddr aware types need the memory for the entire
+         struct to be allocated out of a contiguous memory region. */
+      fd_slot_hash_t * slot_hashes                          = NULL;
+      void * mem                                            = fd_spad_alloc( runner->spad, FD_SYSVAR_SLOT_HASHES_ALIGN, fd_sysvar_slot_hashes_footprint( 1UL ) );
+      fd_slot_hashes_global_t * default_slot_hashes_global  = fd_sysvar_slot_hashes_join( fd_sysvar_slot_hashes_new( mem, 1UL ), &slot_hashes );
 
-    uchar * slot_hash_mem = (uchar*)fd_ulong_align_up( (ulong)(slot_hashes_mem + sizeof(fd_slot_hashes_global_t)), deq_fd_slot_hash_t_align() );
-    fd_slot_hash_t * slot_hashes = deq_fd_slot_hash_t_join( deq_fd_slot_hash_t_new( slot_hash_mem, 1 ) );
-    fd_slot_hash_t * dummy_elem = deq_fd_slot_hash_t_push_tail_nocopy( slot_hashes );
-    memset( dummy_elem, 0, sizeof(fd_slot_hash_t) );
+      fd_slot_hash_t * dummy_elem = deq_fd_slot_hash_t_push_tail_nocopy( slot_hashes );
+      memset( dummy_elem, 0, sizeof(fd_slot_hash_t) );
 
-    default_slot_hashes_global->hashes_offset = (ulong)deq_fd_slot_hash_t_leave( slot_hashes ) - (ulong)default_slot_hashes_global;
-    fd_sysvar_slot_hashes_init( slot_ctx, default_slot_hashes_global );
+      fd_sysvar_slot_hashes_write( slot_ctx, default_slot_hashes_global );
+
+      fd_sysvar_slot_hashes_delete( fd_sysvar_slot_hashes_leave( default_slot_hashes_global, slot_hashes ) );
+    } FD_SPAD_FRAME_END;
   }
 
   /* Provide default stake history if not provided */


### PR DESCRIPTION
highly recommend hiding whitespace diffs 