### PR TITLE
Remove unused 'wksp' argument from decode_ctx

### DIFF
--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -314,8 +314,7 @@ status_check_tower( ulong slot, void * _ctx ) {
 
   fd_slot_history_global_t * slot_history = fd_sysvar_slot_history_read( ctx->funk,
                                                                          ctx->funk_txn,
-                                                                         ctx->spad,
-                                                                         ctx->spad_wksp );
+                                                                         ctx->spad );
 
   if( fd_sysvar_slot_history_find_slot( slot_history,
                                         slot,

--- a/src/flamenco/runtime/sysvar/fd_sysvar_cache.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_cache.c
@@ -122,8 +122,7 @@ fd_sysvar_cache_restore_##name(                                                 
       type##_decode() does not do heap allocations on failure */                          \
     fd_bincode_decode_ctx_t decode = {                                                    \
       .data    = account->vt->get_data( account ),                                        \
-      .dataend = account->vt->get_data( account ) + account->vt->get_data_len( account ), \
-      .wksp    = wksp                                                                     \
+      .dataend = account->vt->get_data( account ) + account->vt->get_data_len( account )  \
     };                                                                                    \
     ulong total_sz    = 0UL;                                                              \
     int   err         = type##_decode_footprint( &decode, &total_sz );                    \

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
@@ -146,8 +146,7 @@ fd_sysvar_slot_hashes_read( fd_exec_slot_ctx_t *  slot_ctx,
 
   fd_bincode_decode_ctx_t decode = {
     .data    = rec->vt->get_data( rec ),
-    .dataend = rec->vt->get_data( rec ) + rec->vt->get_data_len( rec ),
-    .wksp    = slot_ctx->runtime_wksp
+    .dataend = rec->vt->get_data( rec ) + rec->vt->get_data_len( rec )
   };
 
   ulong total_sz = 0UL;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
@@ -92,8 +92,7 @@ fd_sysvar_slot_history_update( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtim
 
   fd_bincode_decode_ctx_t ctx = {
     .data    = rec->vt->get_data( rec ),
-    .dataend = rec->vt->get_data( rec ) + rec->vt->get_data_len( rec ),
-    .wksp    = slot_ctx->runtime_wksp
+    .dataend = rec->vt->get_data( rec ) + rec->vt->get_data_len( rec )
   };
 
   ulong total_sz = 0UL;
@@ -143,8 +142,7 @@ fd_sysvar_slot_history_update( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtim
 fd_slot_history_global_t *
 fd_sysvar_slot_history_read( fd_funk_t *     funk,
                              fd_funk_txn_t * funk_txn,
-                             fd_spad_t *     spad,
-                             fd_wksp_t *     wksp ) {
+                             fd_spad_t *     spad ) {
 
   /* Set current_slot, and update next_slot */
 
@@ -158,8 +156,7 @@ fd_sysvar_slot_history_read( fd_funk_t *     funk,
 
   fd_bincode_decode_ctx_t ctx = {
     .data    = rec->vt->get_data( rec ),
-    .dataend = rec->vt->get_data( rec ) + rec->vt->get_data_len( rec ),
-    .wksp    = wksp
+    .dataend = rec->vt->get_data( rec ) + rec->vt->get_data_len( rec )
   };
 
   ulong total_sz = 0UL;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.h
@@ -28,8 +28,7 @@ fd_sysvar_slot_history_update( fd_exec_slot_ctx_t * slot_ctx,
 fd_slot_history_global_t *
 fd_sysvar_slot_history_read( fd_funk_t *     funk,
                              fd_funk_txn_t * funk_txn,
-                             fd_spad_t *     spad,
-                             fd_wksp_t *     wksp );
+                             fd_spad_t *     spad );
 
 int
 fd_sysvar_slot_history_find_slot( fd_slot_history_global_t const * history,

--- a/src/flamenco/types/fd_bincode.h
+++ b/src/flamenco/types/fd_bincode.h
@@ -36,9 +36,6 @@ struct fd_bincode_decode_ctx {
   void const * data;
   /* End of buffer */
   void const * dataend;
-  /* Wksp for laddr to gaddr conversions */
-  /* TODO: This could be split out into a fd_bincode_global_decode_ctx */
-  fd_wksp_t * wksp;
 };
 typedef struct fd_bincode_decode_ctx fd_bincode_decode_ctx_t;
 


### PR DESCRIPTION
Not sure if this is going to have a purpose in the future, but for now it's dead weight.