### PR TITLE
[v0.4 backport] topo: fix workspace NUMA affinity

### DIFF
--- a/src/app/fdctl/main1.c
+++ b/src/app/fdctl/main1.c
@@ -103,7 +103,7 @@ initialize_numa_assignments( fd_topo_t * topo ) {
     if( FD_UNLIKELY( max_obj==ULONG_MAX ) ) FD_LOG_ERR(( "no object found for workspace %s", topo->workspaces[ i ].name ));
 
     int found_strict = 0;
-    int found_lazy   = 1;
+    int found_lazy   = 0;
     for( ulong j=0UL; j<topo->tile_cnt; j++ ) {
       fd_topo_tile_t * tile = &topo->tiles[ j ];
       if( FD_UNLIKELY( tile->tile_obj_id==max_obj && tile->cpu_idx!=ULONG_MAX ) ) {


### PR DESCRIPTION
Fixes an issue that results in workspace affinity to NUMA node 0
even if all user tiles are on a different NUMA node.

Backport of 0b8aa0e86d03ca23cb21384cb096a7151b56712b #4903 

Closes #4986