### PR TITLE
Remove x86intrin.h dependency from fd_util.h

### DIFF
--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -1,4 +1,5 @@
 #include "fd_config_private.h"
+#include "../../util/pod/fd_pod.h"
 
 /* Pod query utils ****************************************************/
 

--- a/src/ballet/bigint/fd_uint256_mul.h
+++ b/src/ballet/bigint/fd_uint256_mul.h
@@ -25,6 +25,10 @@
 #define OPTIMIZE
 #endif
 
+#if FD_HAS_X86
+#include <x86intrin.h>
+#endif
+
 /* Utility functions for fd_uint256_mul_mod_p.
    Implementation is based on uint128.
    The implementations WITHOUT uint128 are just for completeness, we

--- a/src/ballet/toml/fd_toml.c
+++ b/src/ballet/toml/fd_toml.c
@@ -2,6 +2,7 @@
 #include "fd_toml.h"
 #include "../../util/fd_util.h"
 #include <ctype.h>
+#include <math.h>
 #include <time.h>
 
 /* Implementation note:

--- a/src/disco/metrics/fd_metrics.h
+++ b/src/disco/metrics/fd_metrics.h
@@ -6,6 +6,7 @@
 #include "generated/fd_metrics_all.h"
 
 #include "../../tango/tempo/fd_tempo.h"
+#include "../../util/hist/fd_histf.h"
 
 /* fd_metrics mostly defines way of laying out metrics in shared
    memory so that a producer and consumer can agree on where they

--- a/src/disco/pack/fd_chkdup.h
+++ b/src/disco/pack/fd_chkdup.h
@@ -23,6 +23,7 @@
 
 #ifndef FD_CHKDUP_IMPL
 # if FD_HAS_AVX512
+#   include "../../util/simd/fd_avx.h"
 #   define FD_CHKDUP_IMPL 2
 # elif FD_HAS_AVX
 #   define FD_CHKDUP_IMPL 1

--- a/src/disco/pack/fd_pack_rebate_sum.c
+++ b/src/disco/pack/fd_pack_rebate_sum.c
@@ -1,5 +1,8 @@
 #include "fd_pack_rebate_sum.h"
 #include "fd_pack.h"
+#if FD_HAS_AVX
+#include "../../util/simd/fd_avx.h"
+#endif
 
 static const fd_acct_addr_t null_addr = { 0 };
 

--- a/src/disco/pack/test_chkdup.c
+++ b/src/disco/pack/test_chkdup.c
@@ -1,5 +1,6 @@
 #define FD_UNALIGNED_ACCESS_STYLE 0
 #include "fd_chkdup.h"
+#include <math.h>
 
 #define P 4294967291UL /* A prime that fits in a uint with 2 as a primitive root */
 

--- a/src/discof/gossip/fd_gossip_tile.c
+++ b/src/discof/gossip/fd_gossip_tile.c
@@ -14,6 +14,7 @@
 #include "../../flamenco/gossip/fd_gossip.h"
 #include "../../flamenco/runtime/fd_system_ids.h"
 #include "../../flamenco/runtime/fd_runtime.h"
+#include "../../util/pod/fd_pod.h"
 #include "../../util/net/fd_ip4.h"
 #include "../../util/net/fd_udp.h"
 #include "../../util/net/fd_net_headers.h"

--- a/src/discof/poh/fd_poh.h
+++ b/src/discof/poh/fd_poh.h
@@ -3,6 +3,7 @@
 
 #include "../../disco/tiles.h"
 #include "../../disco/shred/fd_stake_ci.h"
+#include "../../util/hist/fd_histf.h"
 
 /* Common library functions for the Proof of History tile. */
 

--- a/src/discoh/resolv/fd_resolv_tile.c
+++ b/src/discoh/resolv/fd_resolv_tile.c
@@ -6,6 +6,10 @@
 #include "../../flamenco/runtime/fd_system_ids.h"
 #include "../../flamenco/runtime/fd_system_ids_pp.h"
 
+#if FD_HAS_AVX
+#include "../../util/simd/fd_avx.h"
+#endif
+
 #define FD_RESOLV_IN_KIND_FRAGMENT (0)
 #define FD_RESOLV_IN_KIND_BANK     (1)
 

--- a/src/flamenco/fd_flamenco_base.h
+++ b/src/flamenco/fd_flamenco_base.h
@@ -119,30 +119,6 @@ fd_acct_addr_cstr( char        cstr[ static FD_BASE58_ENCODED_32_SZ ],
   return fd_base58_encode_32( addr, NULL, cstr );
 }
 
-/* fd_pod utils */
-
-FD_FN_UNUSED static fd_pubkey_t *
-fd_pod_query_pubkey( uchar const * pod,
-                     char const *  path,
-                     fd_pubkey_t * val ) {
-
-  ulong        bufsz = 0UL;
-  void const * buf   = fd_pod_query_buf( pod, path, &bufsz );
-
-  if( FD_UNLIKELY( (!buf) | (bufsz!=sizeof(fd_pubkey_t)) ) )
-    return NULL;
-
-  memcpy( val->uc, buf, sizeof(fd_pubkey_t) );
-  return val;
-}
-
-static inline ulong
-fd_pod_insert_pubkey( uchar *             pod,
-                      char const *        path,
-                      fd_pubkey_t const * val ) {
-  return fd_pod_insert_buf( pod, path, val->uc, sizeof(fd_pubkey_t) );
-}
-
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_flamenco_fd_flamenco_base_h */

--- a/src/flamenco/gossip/fd_gossip.c
+++ b/src/flamenco/gossip/fd_gossip.c
@@ -1,6 +1,7 @@
 #include "fd_gossip.h"
 #include "../../ballet/base58/fd_base58.h"
 #include "../../disco/keyguard/fd_keyguard.h"
+#include <math.h>
 
 /* Maximum size of a network packet */
 #define PACKET_DATA_SIZE 1232

--- a/src/flamenco/runtime/fd_acc_mgr.h
+++ b/src/flamenco/runtime/fd_acc_mgr.h
@@ -6,6 +6,7 @@
 #include "../fd_flamenco_base.h"
 #include "../../ballet/txn/fd_txn.h"
 #include "fd_txn_account.h"
+#include "../../util/simd/fd_avx.h"
 
 /* FD_ACC_MGR_{SUCCESS,ERR{...}} are account management specific error codes.
    To be stored in an int. */

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -31,12 +31,11 @@
 #include "../../ballet/base58/fd_base58.h"
 #include "../../disco/pack/fd_pack.h"
 #include "../../disco/pack/fd_pack_cost.h"
-#include "../../ballet/sbpf/fd_sbpf_loader.h"
 
 #include "../../util/bits/fd_uwide.h"
 
 #include <assert.h>
-#include <errno.h>
+#include <math.h>
 #include <stdio.h>   /* snprintf(3) */
 #include <fcntl.h>   /* openat(2) */
 #include <unistd.h>  /* write(3) */

--- a/src/funk/bench_funk_index.c
+++ b/src/funk/bench_funk_index.c
@@ -1,5 +1,6 @@
 #include "fd_funk.h"
 #include "fd_funk_base.h"
+#include <math.h>
 
 #define FUNK_TAG 1UL
 

--- a/src/tango/tempo/fd_tempo.c
+++ b/src/tango/tempo/fd_tempo.c
@@ -1,4 +1,5 @@
 #include "../fd_tango.h"
+#include "../../util/math/fd_stat.h"
 
 #if FD_HAS_DOUBLE
 
@@ -24,10 +25,10 @@ fd_tempo_wallclock_model( double * opt_tau ) {
        jitter. */
 
     ulong iter = 0UL;
-    for(;;) { 
+    for(;;) {
 #     define TRIAL_CNT 512UL
 #     define TRIM_CNT  64UL
-      double trial[ TRIAL_CNT ]; 
+      double trial[ TRIAL_CNT ];
       for( ulong trial_idx=0UL; trial_idx<TRIAL_CNT; trial_idx++ ) {
         FD_COMPILER_MFENCE();
         long tic = fd_log_wallclock();
@@ -67,10 +68,10 @@ fd_tempo_tickcount_model( double * opt_tau ) {
     /* Same as the above but for fd_tickcount(). */
 
     ulong iter = 0UL;
-    for(;;) { 
+    for(;;) {
 #     define TRIAL_CNT 512UL
 #     define TRIM_CNT  64UL
-      double trial[ TRIAL_CNT ]; 
+      double trial[ TRIAL_CNT ];
       for( ulong trial_idx=0UL; trial_idx<TRIAL_CNT; trial_idx++ ) {
         FD_COMPILER_MFENCE();
         long tic = fd_tickcount();
@@ -131,10 +132,10 @@ fd_tempo_tick_per_ns( double * opt_sigma ) {
          well modeled as normal. */
 
       ulong iter = 0UL;
-      for(;;) { 
+      for(;;) {
   #     define TRIAL_CNT 32UL
   #     define TRIM_CNT   4UL
-        double trial[ TRIAL_CNT ]; 
+        double trial[ TRIAL_CNT ];
         for( ulong trial_idx=0UL; trial_idx<TRIAL_CNT; trial_idx++ ) {
           long then; long toc; fd_tempo_observe_pair( &then, &toc );
           fd_log_sleep( 16777216L ); /* ~16.8 ms */
@@ -199,7 +200,7 @@ fd_tempo_observe_pair( long * opt_now,
        tickcount because that is typically the lower overhead, more
        deterministic one and less likely to get jerked around behind our
        back.
-       
+
        Theoretically, this exploits how the minimum of a shifted
        exponential random variable converges.  Since the time to read
        the various clocks is expected to be reasonably modeled as a

--- a/src/util/fd_util.h
+++ b/src/util/fd_util.h
@@ -18,13 +18,13 @@
 //#include "tile/fd_tile.h"         /* includes shmem/fd_shmem.h */
 //#include "scratch/fd_scratch.h"   /* includes tile/fd_tile.h sanitize/fd_sanitize.h valloc/fd_valloc.h */
 //#include "tpool/fd_tpool.h"       /* includes tile/fd_tile.h scratch/fd_scratch.h */
-//#include "wksp/fd_wksp.h"         /* includes pod/fd_pod.h tpool/fd_tpool.h checkpt/fd_checkpt.h sanitize/fd_sanitize.h */
+//#include "wksp/fd_wksp.h"         /* tpool/fd_tpool.h checkpt/fd_checkpt.h sanitize/fd_sanitize.h */
 #include "alloc/fd_alloc.h"         /* includes wksp/fd_wksp.h valloc/fd_valloc.h */
 #include "rng/fd_rng.h"             /* includes bits/fd_bits.h */
 
 /* FIXME: Should these be optional APIs? */
 #include "sandbox/fd_sandbox.h"     /* includes fd_util_base.h */
-#include "math/fd_stat.h"           /* includes bits/fd_bits.h */
+//#include "math/fd_stat.h"         /* includes bits/fd_bits.h */
 #include "bits/fd_sat.h"            /* includes bits/fd_bits.h */
 //#include "hist/fd_histf.h"        /* includes log/fd_log.h */
 

--- a/src/util/fd_util.h
+++ b/src/util/fd_util.h
@@ -26,7 +26,7 @@
 #include "sandbox/fd_sandbox.h"     /* includes fd_util_base.h */
 #include "math/fd_stat.h"           /* includes bits/fd_bits.h */
 #include "bits/fd_sat.h"            /* includes bits/fd_bits.h */
-#include "hist/fd_histf.h"          /* includes log/fd_log.h */
+//#include "hist/fd_histf.h"        /* includes log/fd_log.h */
 
 /* Additional fd_util APIs that are not included by default */
 

--- a/src/util/math/test_stat.c
+++ b/src/util/math/test_stat.c
@@ -1,4 +1,5 @@
 #include "../fd_util.h"
+#include "../../util/math/fd_stat.h"
 
 /* This are uniform in [-0.5,+0.5] */
 

--- a/src/util/pod/fd_pod_ctl.c
+++ b/src/util/pod/fd_pod_ctl.c
@@ -1,4 +1,5 @@
 #include "../fd_util.h"
+#include "../../util/pod/fd_pod.h"
 
 #if FD_HAS_HOSTED
 

--- a/src/util/pod/test_pod.c
+++ b/src/util/pod/test_pod.c
@@ -1,4 +1,5 @@
 #include "../fd_util.h"
+#include "../../util/pod/fd_pod.h"
 
 uchar mem[ 16384 ];
 

--- a/src/util/rng/test_rng.c
+++ b/src/util/rng/test_rng.c
@@ -289,37 +289,6 @@ main( int     argc,
 
   FD_TEST( fd_rng_delete( shrng )==_rng );
 
-# if FD_HAS_X86
-
-  FD_LOG_NOTICE(( "Testing RDRAND" ));
-
-  sum_pop  = 0L;
-  sum_pop2 = 0L;
-  min_pop  = INT_MAX;
-  max_pop  = INT_MIN;
-
-  long iter = (1L<<22);
-  ctr = 0;
-  for( long i=0; i<iter; i++ ) {
-    if( !ctr ) { FD_LOG_NOTICE(( "Completed %li iterations", i )); ctr = 1000000; }
-    ctr--;
-
-    uchar seq[8];
-    for(;;)
-      if( FD_LIKELY( fd_rdrand( seq, 8UL ) ) )
-        break;
-    int pop  = fd_ulong_popcnt( FD_LOAD( ulong, seq ) );
-    sum_pop  += (long) pop;
-    sum_pop2 += (long)(pop*pop);
-    min_pop  = pop<min_pop ? pop : min_pop;
-    max_pop  = pop>max_pop ? pop : max_pop;
-  }
-  avg_pop = ((float)sum_pop ) / ((float)iter);
-  rms_pop = sqrtf( (((float)sum_pop2) / ((float)iter)) - avg_pop*avg_pop );
-  FD_LOG_NOTICE(( "rdrand popcount stats: %.3f +/- %.3f [%i,%i]", (double)avg_pop, (double)rms_pop, min_pop, max_pop ));
-
-# endif /* FD_HAS_X86 */
-
 # if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
   test_rng_secure();
 # endif /* defined(...) */

--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -1,7 +1,6 @@
 #ifndef HEADER_fd_src_util_wksp_fd_wksp_h
 #define HEADER_fd_src_util_wksp_fd_wksp_h
 
-#include "../pod/fd_pod.h"
 #include "../tpool/fd_tpool.h"
 #include "../checkpt/fd_checkpt.h"
 #include "../sanitize/fd_sanitize.h"

--- a/src/util/wksp/fd_wksp_helper.c
+++ b/src/util/wksp/fd_wksp_helper.c
@@ -1,4 +1,5 @@
 #include "fd_wksp_private.h"
+#include "../pod/fd_pod.h"
 
 /* fd_wksp_private_{join,leave}_func are used to automagically handle
    the first join / last leave by the fd_wksp_attach / fd_wksp_detach. */

--- a/src/waltz/quic/fd_quic.h
+++ b/src/waltz/quic/fd_quic.h
@@ -86,6 +86,7 @@
 
 #include "../aio/fd_aio.h"
 #include "../tls/fd_tls.h"
+#include "../../util/hist/fd_histf.h"
 
 /* FD_QUIC_API marks public API declarations.  No-op for now. */
 #define FD_QUIC_API

--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -11,6 +11,7 @@
 #include "fd_quic_stream_pool.h"
 #include "fd_quic_pretty_print.h"
 #include "fd_quic_svc_q.h"
+#include <math.h>
 
 #include "../../util/log/fd_dtrace.h"
 #include "../../util/net/fd_ip4.h"


### PR DESCRIPTION
Changes code so that including `fd_util.h` no longer includes `<x86intrin.h>` and friends.

The x86 intrinsics are about 70k lines of headers, which makes up the majority of compile-time for small compile units.

`make -j lib CC=gcc-14`:
Before: 0m28.815s
After: 0m26.495s

`make -j lib=CC=clang`:
Before: 0m21.672s
After: 0m19.811s