### PR TITLE
types: reduce global bloat

### DIFF
--- a/src/flamenco/types/fd_types.h
+++ b/src/flamenco/types/fd_types.h
@@ -16,13 +16,6 @@ struct fd_feature {
 typedef struct fd_feature fd_feature_t;
 #define FD_FEATURE_ALIGN alignof(fd_feature_t)
 
-struct fd_feature_global {
-  ulong activated_at;
-  uchar has_activated_at;
-};
-typedef struct fd_feature_global fd_feature_global_t;
-#define FD_FEATURE_GLOBAL_ALIGN alignof(fd_feature_global_t)
-
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/fee_calculator.rs#L9 */
 /* Encoded Size: Fixed (8 bytes) */
 struct fd_fee_calculator {
@@ -59,19 +52,6 @@ struct fd_block_hash_vec {
 typedef struct fd_block_hash_vec fd_block_hash_vec_t;
 #define FD_BLOCK_HASH_VEC_ALIGN alignof(fd_block_hash_vec_t)
 
-struct fd_block_hash_vec_global {
-  ulong last_hash_index;
-  ulong last_hash_offset;
-  ulong ages_len;
-  ulong ages_offset;
-  ulong max_age;
-};
-typedef struct fd_block_hash_vec_global fd_block_hash_vec_global_t;
-#define FD_BLOCK_HASH_VEC_GLOBAL_ALIGN alignof(fd_block_hash_vec_global_t)
-
-FD_FN_UNUSED static fd_hash_hash_age_pair_t * fd_block_hash_vec_ages_join( fd_block_hash_vec_global_t * struct_mem ) { // vector
-  return (fd_hash_hash_age_pair_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->ages_offset );
-}
 typedef struct fd_hash_hash_age_pair_t_mapnode fd_hash_hash_age_pair_t_mapnode_t;
 #define REDBLK_T fd_hash_hash_age_pair_t_mapnode_t
 #define REDBLK_NAME fd_hash_hash_age_pair_t_map
@@ -103,22 +83,6 @@ struct fd_block_hash_queue {
 typedef struct fd_block_hash_queue fd_block_hash_queue_t;
 #define FD_BLOCK_HASH_QUEUE_ALIGN alignof(fd_block_hash_queue_t)
 
-struct fd_block_hash_queue_global {
-  ulong last_hash_index;
-  ulong last_hash_offset;
-  ulong ages_pool_offset;
-  ulong ages_root_offset;
-  ulong max_age;
-};
-typedef struct fd_block_hash_queue_global fd_block_hash_queue_global_t;
-#define FD_BLOCK_HASH_QUEUE_GLOBAL_ALIGN alignof(fd_block_hash_queue_global_t)
-
-static FD_FN_UNUSED fd_hash_hash_age_pair_t_mapnode_t * fd_block_hash_queue_ages_pool_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_hash_hash_age_pair_t_mapnode_t *)fd_hash_hash_age_pair_t_map_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
-static FD_FN_UNUSED fd_hash_hash_age_pair_t_mapnode_t * fd_block_hash_queue_ages_root_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_hash_hash_age_pair_t_mapnode_t *)fd_type_pun( (uchar *)struct_mem + offset );
-}
 /* Encoded Size: Fixed (33 bytes) */
 struct fd_fee_rate_governor {
   ulong target_lamports_per_signature;
@@ -146,16 +110,6 @@ struct fd_hard_forks {
 typedef struct fd_hard_forks fd_hard_forks_t;
 #define FD_HARD_FORKS_ALIGN alignof(fd_hard_forks_t)
 
-struct fd_hard_forks_global {
-  ulong hard_forks_len;
-  ulong hard_forks_offset;
-};
-typedef struct fd_hard_forks_global fd_hard_forks_global_t;
-#define FD_HARD_FORKS_GLOBAL_ALIGN alignof(fd_hard_forks_global_t)
-
-FD_FN_UNUSED static fd_slot_pair_t * fd_hard_forks_hard_forks_join( fd_hard_forks_global_t * struct_mem ) { // vector
-  return (fd_slot_pair_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->hard_forks_offset );
-}
 /* Encoded Size: Fixed (48 bytes) */
 struct fd_inflation {
   double initial;
@@ -241,20 +195,6 @@ struct fd_solana_account {
 typedef struct fd_solana_account fd_solana_account_t;
 #define FD_SOLANA_ACCOUNT_ALIGN alignof(fd_solana_account_t)
 
-struct fd_solana_account_global {
-  ulong lamports;
-  ulong data_len;
-  ulong data_offset;
-  fd_pubkey_t owner;
-  uchar executable;
-  ulong rent_epoch;
-};
-typedef struct fd_solana_account_global fd_solana_account_global_t;
-#define FD_SOLANA_ACCOUNT_GLOBAL_ALIGN alignof(fd_solana_account_global_t)
-
-FD_FN_UNUSED static uchar * fd_solana_account_data_join( fd_solana_account_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->data_offset );
-}
 /* Encoded Size: Fixed (48 bytes) */
 struct __attribute__((packed)) fd_solana_account_stored_meta {
   ulong write_version_obsolete;
@@ -306,14 +246,6 @@ struct fd_vote_accounts_pair {
 typedef struct fd_vote_accounts_pair fd_vote_accounts_pair_t;
 #define FD_VOTE_ACCOUNTS_PAIR_ALIGN alignof(fd_vote_accounts_pair_t)
 
-struct fd_vote_accounts_pair_global {
-  fd_pubkey_t key;
-  ulong stake;
-  fd_solana_account_global_t value;
-};
-typedef struct fd_vote_accounts_pair_global fd_vote_accounts_pair_global_t;
-#define FD_VOTE_ACCOUNTS_PAIR_GLOBAL_ALIGN alignof(fd_vote_accounts_pair_global_t)
-
 typedef struct fd_vote_accounts_pair_t_mapnode fd_vote_accounts_pair_t_mapnode_t;
 #define REDBLK_T fd_vote_accounts_pair_t_mapnode_t
 #define REDBLK_NAME fd_vote_accounts_pair_t_map
@@ -334,26 +266,6 @@ fd_vote_accounts_pair_t_map_join_new( void * * alloc_mem, ulong len ) {
   *alloc_mem = (uchar *)*alloc_mem + fd_vote_accounts_pair_t_map_footprint( len );
   return fd_vote_accounts_pair_t_map_join( fd_vote_accounts_pair_t_map_new( map_mem, len ) );
 }
-typedef struct fd_vote_accounts_pair_global_t_mapnode fd_vote_accounts_pair_global_t_mapnode_t;
-#define REDBLK_T fd_vote_accounts_pair_global_t_mapnode_t
-#define REDBLK_NAME fd_vote_accounts_pair_global_t_map
-#define REDBLK_IMPL_STYLE 1
-#include "../../util/tmpl/fd_redblack.c"
-struct fd_vote_accounts_pair_global_t_mapnode {
-    fd_vote_accounts_pair_global_t elem;
-    ulong redblack_parent;
-    ulong redblack_left;
-    ulong redblack_right;
-    int redblack_color;
-};
-static inline fd_vote_accounts_pair_global_t_mapnode_t *
-fd_vote_accounts_pair_global_t_map_join_new( void * * alloc_mem, ulong len ) {
-  if( FD_UNLIKELY( 0 == len ) ) len = 1; // prevent underflow
-  *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, fd_vote_accounts_pair_global_t_map_align() );
-  void * map_mem = *alloc_mem;
-  *alloc_mem = (uchar *)*alloc_mem + fd_vote_accounts_pair_global_t_map_footprint( len );
-  return fd_vote_accounts_pair_global_t_map_join( fd_vote_accounts_pair_global_t_map_new( map_mem, len ) );
-}
 /* Encoded Size: Dynamic */
 struct fd_vote_accounts {
   fd_vote_accounts_pair_t_mapnode_t * vote_accounts_pool;
@@ -362,19 +274,6 @@ struct fd_vote_accounts {
 typedef struct fd_vote_accounts fd_vote_accounts_t;
 #define FD_VOTE_ACCOUNTS_ALIGN alignof(fd_vote_accounts_t)
 
-struct fd_vote_accounts_global {
-  ulong vote_accounts_pool_offset;
-  ulong vote_accounts_root_offset;
-};
-typedef struct fd_vote_accounts_global fd_vote_accounts_global_t;
-#define FD_VOTE_ACCOUNTS_GLOBAL_ALIGN alignof(fd_vote_accounts_global_t)
-
-static FD_FN_UNUSED fd_vote_accounts_pair_global_t_mapnode_t * fd_vote_accounts_vote_accounts_pool_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_vote_accounts_pair_global_t_mapnode_t *)fd_vote_accounts_pair_global_t_map_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
-static FD_FN_UNUSED fd_vote_accounts_pair_global_t_mapnode_t * fd_vote_accounts_vote_accounts_root_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_vote_accounts_pair_global_t_mapnode_t *)fd_type_pun( (uchar *)struct_mem + offset );
-}
 /* Encoded Size: Fixed (33 bytes) */
 struct fd_account_keys_pair {
   fd_pubkey_t key;
@@ -411,19 +310,6 @@ struct fd_account_keys {
 typedef struct fd_account_keys fd_account_keys_t;
 #define FD_ACCOUNT_KEYS_ALIGN alignof(fd_account_keys_t)
 
-struct fd_account_keys_global {
-  ulong account_keys_pool_offset;
-  ulong account_keys_root_offset;
-};
-typedef struct fd_account_keys_global fd_account_keys_global_t;
-#define FD_ACCOUNT_KEYS_GLOBAL_ALIGN alignof(fd_account_keys_global_t)
-
-static FD_FN_UNUSED fd_account_keys_pair_t_mapnode_t * fd_account_keys_account_keys_pool_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_account_keys_pair_t_mapnode_t *)fd_account_keys_pair_t_map_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
-static FD_FN_UNUSED fd_account_keys_pair_t_mapnode_t * fd_account_keys_account_keys_root_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_account_keys_pair_t_mapnode_t *)fd_type_pun( (uchar *)struct_mem + offset );
-}
 /* fd_stake_weight_t assigns an Ed25519 public key (node identity) a stake weight number measured in lamports */
 /* Encoded Size: Fixed (40 bytes) */
 struct fd_stake_weight {
@@ -461,19 +347,6 @@ struct fd_stake_weights {
 typedef struct fd_stake_weights fd_stake_weights_t;
 #define FD_STAKE_WEIGHTS_ALIGN alignof(fd_stake_weights_t)
 
-struct fd_stake_weights_global {
-  ulong stake_weights_pool_offset;
-  ulong stake_weights_root_offset;
-};
-typedef struct fd_stake_weights_global fd_stake_weights_global_t;
-#define FD_STAKE_WEIGHTS_GLOBAL_ALIGN alignof(fd_stake_weights_global_t)
-
-static FD_FN_UNUSED fd_stake_weight_t_mapnode_t * fd_stake_weights_stake_weights_pool_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_stake_weight_t_mapnode_t *)fd_stake_weight_t_map_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
-static FD_FN_UNUSED fd_stake_weight_t_mapnode_t * fd_stake_weights_stake_weights_root_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_stake_weight_t_mapnode_t *)fd_type_pun( (uchar *)struct_mem + offset );
-}
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/state.rs#L303 */
 /* Encoded Size: Fixed (64 bytes) */
 struct fd_delegation {
@@ -544,23 +417,6 @@ struct fd_stakes {
 typedef struct fd_stakes fd_stakes_t;
 #define FD_STAKES_ALIGN alignof(fd_stakes_t)
 
-struct fd_stakes_global {
-  fd_vote_accounts_global_t vote_accounts;
-  ulong stake_delegations_pool_offset;
-  ulong stake_delegations_root_offset;
-  ulong unused;
-  ulong epoch;
-  fd_stake_history_t stake_history;
-};
-typedef struct fd_stakes_global fd_stakes_global_t;
-#define FD_STAKES_GLOBAL_ALIGN alignof(fd_stakes_global_t)
-
-static FD_FN_UNUSED fd_delegation_pair_t_mapnode_t * fd_stakes_stake_delegations_pool_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_delegation_pair_t_mapnode_t *)fd_delegation_pair_t_map_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
-static FD_FN_UNUSED fd_delegation_pair_t_mapnode_t * fd_stakes_stake_delegations_root_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_delegation_pair_t_mapnode_t *)fd_type_pun( (uchar *)struct_mem + offset );
-}
 typedef struct fd_stake_pair_t_mapnode fd_stake_pair_t_mapnode_t;
 #define REDBLK_T fd_stake_pair_t_mapnode_t
 #define REDBLK_NAME fd_stake_pair_t_map
@@ -594,23 +450,6 @@ struct fd_stakes_stake {
 typedef struct fd_stakes_stake fd_stakes_stake_t;
 #define FD_STAKES_STAKE_ALIGN alignof(fd_stakes_stake_t)
 
-struct fd_stakes_stake_global {
-  fd_vote_accounts_global_t vote_accounts;
-  ulong stake_delegations_pool_offset;
-  ulong stake_delegations_root_offset;
-  ulong unused;
-  ulong epoch;
-  fd_stake_history_t stake_history;
-};
-typedef struct fd_stakes_stake_global fd_stakes_stake_global_t;
-#define FD_STAKES_STAKE_GLOBAL_ALIGN alignof(fd_stakes_stake_global_t)
-
-static FD_FN_UNUSED fd_stake_pair_t_mapnode_t * fd_stakes_stake_stake_delegations_pool_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_stake_pair_t_mapnode_t *)fd_stake_pair_t_map_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
-static FD_FN_UNUSED fd_stake_pair_t_mapnode_t * fd_stakes_stake_stake_delegations_root_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_stake_pair_t_mapnode_t *)fd_type_pun( (uchar *)struct_mem + offset );
-}
 /* Encoded Size: Fixed (88 bytes) */
 struct fd_bank_incremental_snapshot_persistence {
   ulong full_slot;
@@ -631,17 +470,6 @@ struct fd_node_vote_accounts {
 typedef struct fd_node_vote_accounts fd_node_vote_accounts_t;
 #define FD_NODE_VOTE_ACCOUNTS_ALIGN alignof(fd_node_vote_accounts_t)
 
-struct fd_node_vote_accounts_global {
-  ulong vote_accounts_len;
-  ulong vote_accounts_offset;
-  ulong total_stake;
-};
-typedef struct fd_node_vote_accounts_global fd_node_vote_accounts_global_t;
-#define FD_NODE_VOTE_ACCOUNTS_GLOBAL_ALIGN alignof(fd_node_vote_accounts_global_t)
-
-FD_FN_UNUSED static fd_pubkey_t * fd_node_vote_accounts_vote_accounts_join( fd_node_vote_accounts_global_t * struct_mem ) { // vector
-  return (fd_pubkey_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->vote_accounts_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_pubkey_node_vote_accounts_pair {
   fd_pubkey_t key;
@@ -649,13 +477,6 @@ struct fd_pubkey_node_vote_accounts_pair {
 };
 typedef struct fd_pubkey_node_vote_accounts_pair fd_pubkey_node_vote_accounts_pair_t;
 #define FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_ALIGN alignof(fd_pubkey_node_vote_accounts_pair_t)
-
-struct fd_pubkey_node_vote_accounts_pair_global {
-  fd_pubkey_t key;
-  fd_node_vote_accounts_global_t value;
-};
-typedef struct fd_pubkey_node_vote_accounts_pair_global fd_pubkey_node_vote_accounts_pair_global_t;
-#define FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_GLOBAL_ALIGN alignof(fd_pubkey_node_vote_accounts_pair_global_t)
 
 /* Encoded Size: Fixed (64 bytes) */
 struct fd_pubkey_pubkey_pair {
@@ -677,23 +498,6 @@ struct fd_epoch_stakes {
 typedef struct fd_epoch_stakes fd_epoch_stakes_t;
 #define FD_EPOCH_STAKES_ALIGN alignof(fd_epoch_stakes_t)
 
-struct fd_epoch_stakes_global {
-  fd_stakes_global_t stakes;
-  ulong total_stake;
-  ulong node_id_to_vote_accounts_len;
-  ulong node_id_to_vote_accounts_offset;
-  ulong epoch_authorized_voters_len;
-  ulong epoch_authorized_voters_offset;
-};
-typedef struct fd_epoch_stakes_global fd_epoch_stakes_global_t;
-#define FD_EPOCH_STAKES_GLOBAL_ALIGN alignof(fd_epoch_stakes_global_t)
-
-FD_FN_UNUSED static fd_pubkey_node_vote_accounts_pair_global_t * fd_epoch_stakes_node_id_to_vote_accounts_join( fd_epoch_stakes_global_t * struct_mem ) { // vector
-  return (fd_pubkey_node_vote_accounts_pair_global_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->node_id_to_vote_accounts_offset );
-}
-FD_FN_UNUSED static fd_pubkey_pubkey_pair_t * fd_epoch_stakes_epoch_authorized_voters_join( fd_epoch_stakes_global_t * struct_mem ) { // vector
-  return (fd_pubkey_pubkey_pair_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->epoch_authorized_voters_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_epoch_epoch_stakes_pair {
   ulong key;
@@ -701,13 +505,6 @@ struct fd_epoch_epoch_stakes_pair {
 };
 typedef struct fd_epoch_epoch_stakes_pair fd_epoch_epoch_stakes_pair_t;
 #define FD_EPOCH_EPOCH_STAKES_PAIR_ALIGN alignof(fd_epoch_epoch_stakes_pair_t)
-
-struct fd_epoch_epoch_stakes_pair_global {
-  ulong key;
-  fd_epoch_stakes_global_t value;
-};
-typedef struct fd_epoch_epoch_stakes_pair_global fd_epoch_epoch_stakes_pair_global_t;
-#define FD_EPOCH_EPOCH_STAKES_PAIR_GLOBAL_ALIGN alignof(fd_epoch_epoch_stakes_pair_global_t)
 
 /* Encoded Size: Fixed (40 bytes) */
 struct fd_pubkey_u64_pair {
@@ -729,26 +526,6 @@ struct fd_unused_accounts {
 typedef struct fd_unused_accounts fd_unused_accounts_t;
 #define FD_UNUSED_ACCOUNTS_ALIGN alignof(fd_unused_accounts_t)
 
-struct fd_unused_accounts_global {
-  ulong unused1_len;
-  ulong unused1_offset;
-  ulong unused2_len;
-  ulong unused2_offset;
-  ulong unused3_len;
-  ulong unused3_offset;
-};
-typedef struct fd_unused_accounts_global fd_unused_accounts_global_t;
-#define FD_UNUSED_ACCOUNTS_GLOBAL_ALIGN alignof(fd_unused_accounts_global_t)
-
-FD_FN_UNUSED static fd_pubkey_t * fd_unused_accounts_unused1_join( fd_unused_accounts_global_t * struct_mem ) { // vector
-  return (fd_pubkey_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->unused1_offset );
-}
-FD_FN_UNUSED static fd_pubkey_t * fd_unused_accounts_unused2_join( fd_unused_accounts_global_t * struct_mem ) { // vector
-  return (fd_pubkey_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->unused2_offset );
-}
-FD_FN_UNUSED static fd_pubkey_u64_pair_t * fd_unused_accounts_unused3_join( fd_unused_accounts_global_t * struct_mem ) { // vector
-  return (fd_pubkey_u64_pair_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->unused3_offset );
-}
 /* https://github.com/solana-labs/solana/blob/88aeaa82a856fc807234e7da0b31b89f2dc0e091/runtime/src/bank.rs#L967 */
 /* Encoded Size: Dynamic */
 struct fd_versioned_bank {
@@ -790,51 +567,6 @@ struct fd_versioned_bank {
 typedef struct fd_versioned_bank fd_versioned_bank_t;
 #define FD_VERSIONED_BANK_ALIGN alignof(fd_versioned_bank_t)
 
-struct fd_versioned_bank_global {
-  fd_block_hash_vec_global_t blockhash_queue;
-  ulong ancestors_len;
-  ulong ancestors_offset;
-  fd_hash_t hash;
-  fd_hash_t parent_hash;
-  ulong parent_slot;
-  fd_hard_forks_global_t hard_forks;
-  ulong transaction_count;
-  ulong tick_height;
-  ulong signature_count;
-  ulong capitalization;
-  ulong max_tick_height;
-  ulong hashes_per_tick_offset;
-  ulong ticks_per_slot;
-  uint128 ns_per_slot;
-  ulong genesis_creation_time;
-  double slots_per_year;
-  ulong accounts_data_len;
-  ulong slot;
-  ulong epoch;
-  ulong block_height;
-  fd_pubkey_t collector_id;
-  ulong collector_fees;
-  fd_fee_calculator_t fee_calculator;
-  fd_fee_rate_governor_t fee_rate_governor;
-  ulong collected_rent;
-  fd_rent_collector_t rent_collector;
-  fd_epoch_schedule_t epoch_schedule;
-  fd_inflation_t inflation;
-  fd_stakes_global_t stakes;
-  fd_unused_accounts_global_t unused_accounts;
-  ulong epoch_stakes_len;
-  ulong epoch_stakes_offset;
-  uchar is_delta;
-};
-typedef struct fd_versioned_bank_global fd_versioned_bank_global_t;
-#define FD_VERSIONED_BANK_GLOBAL_ALIGN alignof(fd_versioned_bank_global_t)
-
-FD_FN_UNUSED static fd_slot_pair_t * fd_versioned_bank_ancestors_join( fd_versioned_bank_global_t * struct_mem ) { // vector
-  return (fd_slot_pair_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->ancestors_offset );
-}
-FD_FN_UNUSED static fd_epoch_epoch_stakes_pair_global_t * fd_versioned_bank_epoch_stakes_join( fd_versioned_bank_global_t * struct_mem ) { // vector
-  return (fd_epoch_epoch_stakes_pair_global_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->epoch_stakes_offset );
-}
 /* Encoded Size: Fixed (40 bytes) */
 struct fd_bank_hash_stats {
   ulong num_updated_accounts;
@@ -880,24 +612,12 @@ struct fd_snapshot_slot_acc_vecs {
 typedef struct fd_snapshot_slot_acc_vecs fd_snapshot_slot_acc_vecs_t;
 #define FD_SNAPSHOT_SLOT_ACC_VECS_ALIGN alignof(fd_snapshot_slot_acc_vecs_t)
 
-struct fd_snapshot_slot_acc_vecs_global {
-  ulong slot;
-  ulong account_vecs_len;
-  ulong account_vecs_offset;
-};
-typedef struct fd_snapshot_slot_acc_vecs_global fd_snapshot_slot_acc_vecs_global_t;
-#define FD_SNAPSHOT_SLOT_ACC_VECS_GLOBAL_ALIGN alignof(fd_snapshot_slot_acc_vecs_global_t)
-
-FD_FN_UNUSED static fd_snapshot_acc_vec_t * fd_snapshot_slot_acc_vecs_account_vecs_join( fd_snapshot_slot_acc_vecs_global_t * struct_mem ) { // vector
-  return (fd_snapshot_acc_vec_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->account_vecs_offset );
-}
 /* https://github.com/anza-xyz/agave/blob/7117ed9653ce19e8b2dea108eff1f3eb6a3378a7/sdk/src/reward_type.rs#L7 */
 struct fd_reward_type {
   uint discriminant;
 };
 typedef struct fd_reward_type fd_reward_type_t;
 #define FD_REWARD_TYPE_ALIGN alignof(fd_reward_type_t)
-#define FD_REWARD_TYPE_GLOBAL_ALIGN alignof(fd_reward_type_global_t)
 
 /* Accounts DB related fields in a snapshot */
 /* Encoded Size: Dynamic */
@@ -915,29 +635,6 @@ struct fd_solana_accounts_db_fields {
 typedef struct fd_solana_accounts_db_fields fd_solana_accounts_db_fields_t;
 #define FD_SOLANA_ACCOUNTS_DB_FIELDS_ALIGN alignof(fd_solana_accounts_db_fields_t)
 
-struct fd_solana_accounts_db_fields_global {
-  ulong storages_len;
-  ulong storages_offset;
-  ulong version;
-  ulong slot;
-  fd_bank_hash_info_t bank_hash_info;
-  ulong historical_roots_len;
-  ulong historical_roots_offset;
-  ulong historical_roots_with_hash_len;
-  ulong historical_roots_with_hash_offset;
-};
-typedef struct fd_solana_accounts_db_fields_global fd_solana_accounts_db_fields_global_t;
-#define FD_SOLANA_ACCOUNTS_DB_FIELDS_GLOBAL_ALIGN alignof(fd_solana_accounts_db_fields_global_t)
-
-FD_FN_UNUSED static fd_snapshot_slot_acc_vecs_global_t * fd_solana_accounts_db_fields_storages_join( fd_solana_accounts_db_fields_global_t * struct_mem ) { // vector
-  return (fd_snapshot_slot_acc_vecs_global_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->storages_offset );
-}
-FD_FN_UNUSED static ulong * fd_solana_accounts_db_fields_historical_roots_join( fd_solana_accounts_db_fields_global_t * struct_mem ) { // vector
-  return (ulong *)fd_type_pun( (uchar *)struct_mem + struct_mem->historical_roots_offset );
-}
-FD_FN_UNUSED static fd_slot_map_pair_t * fd_solana_accounts_db_fields_historical_roots_with_hash_join( fd_solana_accounts_db_fields_global_t * struct_mem ) { // vector
-  return (fd_slot_map_pair_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->historical_roots_with_hash_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_versioned_epoch_stakes_current {
   fd_stakes_stake_t stakes;
@@ -950,32 +647,10 @@ struct fd_versioned_epoch_stakes_current {
 typedef struct fd_versioned_epoch_stakes_current fd_versioned_epoch_stakes_current_t;
 #define FD_VERSIONED_EPOCH_STAKES_CURRENT_ALIGN alignof(fd_versioned_epoch_stakes_current_t)
 
-struct fd_versioned_epoch_stakes_current_global {
-  fd_stakes_stake_global_t stakes;
-  ulong total_stake;
-  ulong node_id_to_vote_accounts_len;
-  ulong node_id_to_vote_accounts_offset;
-  ulong epoch_authorized_voters_len;
-  ulong epoch_authorized_voters_offset;
-};
-typedef struct fd_versioned_epoch_stakes_current_global fd_versioned_epoch_stakes_current_global_t;
-#define FD_VERSIONED_EPOCH_STAKES_CURRENT_GLOBAL_ALIGN alignof(fd_versioned_epoch_stakes_current_global_t)
-
-FD_FN_UNUSED static fd_pubkey_node_vote_accounts_pair_global_t * fd_versioned_epoch_stakes_current_node_id_to_vote_accounts_join( fd_versioned_epoch_stakes_current_global_t * struct_mem ) { // vector
-  return (fd_pubkey_node_vote_accounts_pair_global_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->node_id_to_vote_accounts_offset );
-}
-FD_FN_UNUSED static fd_pubkey_pubkey_pair_t * fd_versioned_epoch_stakes_current_epoch_authorized_voters_join( fd_versioned_epoch_stakes_current_global_t * struct_mem ) { // vector
-  return (fd_pubkey_pubkey_pair_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->epoch_authorized_voters_offset );
-}
 union fd_versioned_epoch_stakes_inner {
   fd_versioned_epoch_stakes_current_t Current;
 };
 typedef union fd_versioned_epoch_stakes_inner fd_versioned_epoch_stakes_inner_t;
-
-union fd_versioned_epoch_stakes_inner_global {
-  fd_versioned_epoch_stakes_current_global_t Current;
-};
-typedef union fd_versioned_epoch_stakes_inner_global fd_versioned_epoch_stakes_inner_global_t;
 
 struct fd_versioned_epoch_stakes {
   uint discriminant;
@@ -983,12 +658,6 @@ struct fd_versioned_epoch_stakes {
 };
 typedef struct fd_versioned_epoch_stakes fd_versioned_epoch_stakes_t;
 #define FD_VERSIONED_EPOCH_STAKES_ALIGN alignof(fd_versioned_epoch_stakes_t)
-struct fd_versioned_epoch_stakes_global {
-  uint discriminant;
-  fd_versioned_epoch_stakes_inner_global_t inner;
-};
-typedef struct fd_versioned_epoch_stakes_global fd_versioned_epoch_stakes_global_t;
-#define FD_VERSIONED_EPOCH_STAKES_GLOBAL_ALIGN alignof(fd_versioned_epoch_stakes_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_versioned_epoch_stakes_pair {
@@ -997,13 +666,6 @@ struct fd_versioned_epoch_stakes_pair {
 };
 typedef struct fd_versioned_epoch_stakes_pair fd_versioned_epoch_stakes_pair_t;
 #define FD_VERSIONED_EPOCH_STAKES_PAIR_ALIGN alignof(fd_versioned_epoch_stakes_pair_t)
-
-struct fd_versioned_epoch_stakes_pair_global {
-  ulong epoch;
-  fd_versioned_epoch_stakes_global_t val;
-};
-typedef struct fd_versioned_epoch_stakes_pair_global fd_versioned_epoch_stakes_pair_global_t;
-#define FD_VERSIONED_EPOCH_STAKES_PAIR_GLOBAL_ALIGN alignof(fd_versioned_epoch_stakes_pair_global_t)
 
 /* https://github.com/anza-xyz/agave/blob/7117ed9653ce19e8b2dea108eff1f3eb6a3378a7/sdk/src/reward_info.rs#L5 */
 /* Encoded Size: Fixed (28 bytes) */
@@ -1038,22 +700,6 @@ struct fd_solana_manifest {
 typedef struct fd_solana_manifest fd_solana_manifest_t;
 #define FD_SOLANA_MANIFEST_ALIGN alignof(fd_solana_manifest_t)
 
-struct fd_solana_manifest_global {
-  fd_versioned_bank_global_t bank;
-  fd_solana_accounts_db_fields_global_t accounts_db;
-  ulong lamports_per_signature;
-  ulong bank_incremental_snapshot_persistence_offset;
-  ulong epoch_account_hash_offset;
-  ulong versioned_epoch_stakes_len;
-  ulong versioned_epoch_stakes_offset;
-  ulong lthash_offset;
-};
-typedef struct fd_solana_manifest_global fd_solana_manifest_global_t;
-#define FD_SOLANA_MANIFEST_GLOBAL_ALIGN alignof(fd_solana_manifest_global_t)
-
-FD_FN_UNUSED static fd_versioned_epoch_stakes_pair_global_t * fd_solana_manifest_versioned_epoch_stakes_join( fd_solana_manifest_global_t * struct_mem ) { // vector
-  return (fd_versioned_epoch_stakes_pair_global_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->versioned_epoch_stakes_offset );
-}
 /* Encoded Size: Fixed (12 bytes) */
 struct fd_rust_duration {
   ulong seconds;
@@ -1072,15 +718,6 @@ struct fd_poh_config {
 typedef struct fd_poh_config fd_poh_config_t;
 #define FD_POH_CONFIG_ALIGN alignof(fd_poh_config_t)
 
-struct fd_poh_config_global {
-  fd_rust_duration_t target_tick_duration;
-  ulong target_tick_count_offset;
-  ulong hashes_per_tick;
-  uchar has_hashes_per_tick;
-};
-typedef struct fd_poh_config_global fd_poh_config_global_t;
-#define FD_POH_CONFIG_GLOBAL_ALIGN alignof(fd_poh_config_global_t)
-
 /* Encoded Size: Dynamic */
 struct fd_string_pubkey_pair {
   ulong string_len;
@@ -1090,17 +727,6 @@ struct fd_string_pubkey_pair {
 typedef struct fd_string_pubkey_pair fd_string_pubkey_pair_t;
 #define FD_STRING_PUBKEY_PAIR_ALIGN alignof(fd_string_pubkey_pair_t)
 
-struct fd_string_pubkey_pair_global {
-  ulong string_len;
-  ulong string_offset;
-  fd_pubkey_t pubkey;
-};
-typedef struct fd_string_pubkey_pair_global fd_string_pubkey_pair_global_t;
-#define FD_STRING_PUBKEY_PAIR_GLOBAL_ALIGN alignof(fd_string_pubkey_pair_global_t)
-
-FD_FN_UNUSED static uchar * fd_string_pubkey_pair_string_join( fd_string_pubkey_pair_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->string_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_pubkey_account_pair {
   fd_pubkey_t key;
@@ -1108,13 +734,6 @@ struct fd_pubkey_account_pair {
 };
 typedef struct fd_pubkey_account_pair fd_pubkey_account_pair_t;
 #define FD_PUBKEY_ACCOUNT_PAIR_ALIGN alignof(fd_pubkey_account_pair_t)
-
-struct fd_pubkey_account_pair_global {
-  fd_pubkey_t key;
-  fd_solana_account_global_t account;
-};
-typedef struct fd_pubkey_account_pair_global fd_pubkey_account_pair_global_t;
-#define FD_PUBKEY_ACCOUNT_PAIR_GLOBAL_ALIGN alignof(fd_pubkey_account_pair_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_genesis_solana {
@@ -1138,36 +757,6 @@ struct fd_genesis_solana {
 typedef struct fd_genesis_solana fd_genesis_solana_t;
 #define FD_GENESIS_SOLANA_ALIGN alignof(fd_genesis_solana_t)
 
-struct fd_genesis_solana_global {
-  ulong creation_time;
-  ulong accounts_len;
-  ulong accounts_offset;
-  ulong native_instruction_processors_len;
-  ulong native_instruction_processors_offset;
-  ulong rewards_pools_len;
-  ulong rewards_pools_offset;
-  ulong ticks_per_slot;
-  ulong unused;
-  fd_poh_config_global_t poh_config;
-  ulong __backwards_compat_with_v0_23;
-  fd_fee_rate_governor_t fee_rate_governor;
-  fd_rent_t rent;
-  fd_inflation_t inflation;
-  fd_epoch_schedule_t epoch_schedule;
-  uint cluster_type;
-};
-typedef struct fd_genesis_solana_global fd_genesis_solana_global_t;
-#define FD_GENESIS_SOLANA_GLOBAL_ALIGN alignof(fd_genesis_solana_global_t)
-
-FD_FN_UNUSED static fd_pubkey_account_pair_global_t * fd_genesis_solana_accounts_join( fd_genesis_solana_global_t * struct_mem ) { // vector
-  return (fd_pubkey_account_pair_global_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->accounts_offset );
-}
-FD_FN_UNUSED static fd_string_pubkey_pair_global_t * fd_genesis_solana_native_instruction_processors_join( fd_genesis_solana_global_t * struct_mem ) { // vector
-  return (fd_string_pubkey_pair_global_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->native_instruction_processors_offset );
-}
-FD_FN_UNUSED static fd_pubkey_account_pair_global_t * fd_genesis_solana_rewards_pools_join( fd_genesis_solana_global_t * struct_mem ) { // vector
-  return (fd_pubkey_account_pair_global_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->rewards_pools_offset );
-}
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/clock.rs#L114 */
 /* Encoded Size: Fixed (40 bytes) */
 struct fd_sol_sysvar_clock {
@@ -1329,28 +918,6 @@ struct fd_vote_state_0_23_5 {
 typedef struct fd_vote_state_0_23_5 fd_vote_state_0_23_5_t;
 #define FD_VOTE_STATE_0_23_5_ALIGN alignof(fd_vote_state_0_23_5_t)
 
-struct fd_vote_state_0_23_5_global {
-  fd_pubkey_t node_pubkey;
-  fd_pubkey_t authorized_voter;
-  ulong authorized_voter_epoch;
-  fd_vote_prior_voters_0_23_5_t prior_voters;
-  fd_pubkey_t authorized_withdrawer;
-  uchar commission;
-  ulong votes_offset; /* fd_deque_dynamic (min cnt 32) */
-  ulong root_slot;
-  uchar has_root_slot;
-  ulong epoch_credits_offset; /* fd_deque_dynamic (min cnt 64) */
-  fd_vote_block_timestamp_t last_timestamp;
-};
-typedef struct fd_vote_state_0_23_5_global fd_vote_state_0_23_5_global_t;
-#define FD_VOTE_STATE_0_23_5_GLOBAL_ALIGN alignof(fd_vote_state_0_23_5_global_t)
-
-static FD_FN_UNUSED fd_vote_lockout_t * fd_vote_state_0_23_5_votes_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_vote_lockout_t *)deq_fd_vote_lockout_t_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
-static FD_FN_UNUSED fd_vote_epoch_credits_t * fd_vote_state_0_23_5_epoch_credits_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_vote_epoch_credits_t *)deq_fd_vote_epoch_credits_t_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
 #define FD_VOTE_AUTHORIZED_VOTERS_MIN 64
 #define POOL_NAME fd_vote_authorized_voters_pool
 #define POOL_T fd_vote_authorized_voter_t
@@ -1387,13 +954,6 @@ struct fd_vote_authorized_voters {
 typedef struct fd_vote_authorized_voters fd_vote_authorized_voters_t;
 #define FD_VOTE_AUTHORIZED_VOTERS_ALIGN alignof(fd_vote_authorized_voters_t)
 
-struct fd_vote_authorized_voters_global {
-  ulong pool_offset;
-  ulong treap_offset;
-};
-typedef struct fd_vote_authorized_voters_global fd_vote_authorized_voters_global_t;
-#define FD_VOTE_AUTHORIZED_VOTERS_GLOBAL_ALIGN alignof(fd_vote_authorized_voters_global_t)
-
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L310 */
 /* Encoded Size: Dynamic */
 struct fd_vote_state_1_14_11 {
@@ -1411,27 +971,6 @@ struct fd_vote_state_1_14_11 {
 typedef struct fd_vote_state_1_14_11 fd_vote_state_1_14_11_t;
 #define FD_VOTE_STATE_1_14_11_ALIGN alignof(fd_vote_state_1_14_11_t)
 
-struct fd_vote_state_1_14_11_global {
-  fd_pubkey_t node_pubkey;
-  fd_pubkey_t authorized_withdrawer;
-  uchar commission;
-  ulong votes_offset; /* fd_deque_dynamic (min cnt 32) */
-  ulong root_slot;
-  uchar has_root_slot;
-  fd_vote_authorized_voters_global_t authorized_voters;
-  fd_vote_prior_voters_t prior_voters;
-  ulong epoch_credits_offset; /* fd_deque_dynamic (min cnt 64) */
-  fd_vote_block_timestamp_t last_timestamp;
-};
-typedef struct fd_vote_state_1_14_11_global fd_vote_state_1_14_11_global_t;
-#define FD_VOTE_STATE_1_14_11_GLOBAL_ALIGN alignof(fd_vote_state_1_14_11_global_t)
-
-static FD_FN_UNUSED fd_vote_lockout_t * fd_vote_state_1_14_11_votes_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_vote_lockout_t *)deq_fd_vote_lockout_t_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
-static FD_FN_UNUSED fd_vote_epoch_credits_t * fd_vote_state_1_14_11_epoch_credits_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_vote_epoch_credits_t *)deq_fd_vote_epoch_credits_t_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
 #define DEQUE_NAME deq_fd_landed_vote_t
 #define DEQUE_T fd_landed_vote_t
 #include "../../util/tmpl/fd_deque_dynamic.c"
@@ -1464,40 +1003,12 @@ struct fd_vote_state {
 typedef struct fd_vote_state fd_vote_state_t;
 #define FD_VOTE_STATE_ALIGN alignof(fd_vote_state_t)
 
-struct fd_vote_state_global {
-  fd_pubkey_t node_pubkey;
-  fd_pubkey_t authorized_withdrawer;
-  uchar commission;
-  ulong votes_offset; /* fd_deque_dynamic (min cnt 32) */
-  ulong root_slot;
-  uchar has_root_slot;
-  fd_vote_authorized_voters_global_t authorized_voters;
-  fd_vote_prior_voters_t prior_voters;
-  ulong epoch_credits_offset; /* fd_deque_dynamic (min cnt 64) */
-  fd_vote_block_timestamp_t last_timestamp;
-};
-typedef struct fd_vote_state_global fd_vote_state_global_t;
-#define FD_VOTE_STATE_GLOBAL_ALIGN alignof(fd_vote_state_global_t)
-
-static FD_FN_UNUSED fd_landed_vote_t * fd_vote_state_votes_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_landed_vote_t *)deq_fd_landed_vote_t_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
-static FD_FN_UNUSED fd_vote_epoch_credits_t * fd_vote_state_epoch_credits_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_vote_epoch_credits_t *)deq_fd_vote_epoch_credits_t_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
 union fd_vote_state_versioned_inner {
   fd_vote_state_0_23_5_t v0_23_5;
   fd_vote_state_1_14_11_t v1_14_11;
   fd_vote_state_t current;
 };
 typedef union fd_vote_state_versioned_inner fd_vote_state_versioned_inner_t;
-
-union fd_vote_state_versioned_inner_global {
-  fd_vote_state_0_23_5_global_t v0_23_5;
-  fd_vote_state_1_14_11_global_t v1_14_11;
-  fd_vote_state_global_t current;
-};
-typedef union fd_vote_state_versioned_inner_global fd_vote_state_versioned_inner_global_t;
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/vote_state_versions.rs#L4 */
 struct fd_vote_state_versioned {
@@ -1506,12 +1017,6 @@ struct fd_vote_state_versioned {
 };
 typedef struct fd_vote_state_versioned fd_vote_state_versioned_t;
 #define FD_VOTE_STATE_VERSIONED_ALIGN alignof(fd_vote_state_versioned_t)
-struct fd_vote_state_versioned_global {
-  uint discriminant;
-  fd_vote_state_versioned_inner_global_t inner;
-};
-typedef struct fd_vote_state_versioned_global fd_vote_state_versioned_global_t;
-#define FD_VOTE_STATE_VERSIONED_GLOBAL_ALIGN alignof(fd_vote_state_versioned_global_t)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L185 */
 /* Encoded Size: Dynamic */
@@ -1526,20 +1031,6 @@ struct fd_vote_state_update {
 typedef struct fd_vote_state_update fd_vote_state_update_t;
 #define FD_VOTE_STATE_UPDATE_ALIGN alignof(fd_vote_state_update_t)
 
-struct fd_vote_state_update_global {
-  ulong lockouts_offset; /* fd_deque_dynamic (min cnt 32) */
-  ulong root;
-  uchar has_root;
-  fd_hash_t hash;
-  long timestamp;
-  uchar has_timestamp;
-};
-typedef struct fd_vote_state_update_global fd_vote_state_update_global_t;
-#define FD_VOTE_STATE_UPDATE_GLOBAL_ALIGN alignof(fd_vote_state_update_global_t)
-
-static FD_FN_UNUSED fd_vote_lockout_t * fd_vote_state_update_lockouts_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_vote_lockout_t *)deq_fd_vote_lockout_t_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
 /* Encoded Size: Dynamic */
 struct fd_compact_vote_state_update {
   ulong root;
@@ -1552,20 +1043,6 @@ struct fd_compact_vote_state_update {
 typedef struct fd_compact_vote_state_update fd_compact_vote_state_update_t;
 #define FD_COMPACT_VOTE_STATE_UPDATE_ALIGN alignof(fd_compact_vote_state_update_t)
 
-struct fd_compact_vote_state_update_global {
-  ulong root;
-  ushort lockouts_len;
-  ulong lockouts_offset;
-  fd_hash_t hash;
-  long timestamp;
-  uchar has_timestamp;
-};
-typedef struct fd_compact_vote_state_update_global fd_compact_vote_state_update_global_t;
-#define FD_COMPACT_VOTE_STATE_UPDATE_GLOBAL_ALIGN alignof(fd_compact_vote_state_update_global_t)
-
-FD_FN_UNUSED static fd_lockout_offset_t * fd_compact_vote_state_update_lockouts_join( fd_compact_vote_state_update_global_t * struct_mem ) { // vector
-  return (fd_lockout_offset_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->lockouts_offset );
-}
 /* https://github.com/solana-labs/solana/blob/252438e28fbfb2c695fe1215171b83456e4b761c/programs/vote/src/vote_instruction.rs#L143 */
 /* Encoded Size: Dynamic */
 struct fd_compact_vote_state_update_switch {
@@ -1574,13 +1051,6 @@ struct fd_compact_vote_state_update_switch {
 };
 typedef struct fd_compact_vote_state_update_switch fd_compact_vote_state_update_switch_t;
 #define FD_COMPACT_VOTE_STATE_UPDATE_SWITCH_ALIGN alignof(fd_compact_vote_state_update_switch_t)
-
-struct fd_compact_vote_state_update_switch_global {
-  fd_compact_vote_state_update_global_t compact_vote_state_update;
-  fd_hash_t hash;
-};
-typedef struct fd_compact_vote_state_update_switch_global fd_compact_vote_state_update_switch_global_t;
-#define FD_COMPACT_VOTE_STATE_UPDATE_SWITCH_GLOBAL_ALIGN alignof(fd_compact_vote_state_update_switch_global_t)
 
 #define DEQUE_NAME deq_fd_lockout_offset_t
 #define DEQUE_T fd_lockout_offset_t
@@ -1610,20 +1080,6 @@ struct fd_compact_tower_sync {
 typedef struct fd_compact_tower_sync fd_compact_tower_sync_t;
 #define FD_COMPACT_TOWER_SYNC_ALIGN alignof(fd_compact_tower_sync_t)
 
-struct fd_compact_tower_sync_global {
-  ulong root;
-  ulong lockout_offsets_offset; /* fd_deque_dynamic (min cnt 32) */
-  fd_hash_t hash;
-  long timestamp;
-  uchar has_timestamp;
-  fd_hash_t block_id;
-};
-typedef struct fd_compact_tower_sync_global fd_compact_tower_sync_global_t;
-#define FD_COMPACT_TOWER_SYNC_GLOBAL_ALIGN alignof(fd_compact_tower_sync_global_t)
-
-static FD_FN_UNUSED fd_lockout_offset_t * fd_compact_tower_sync_lockout_offsets_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_lockout_offset_t *)deq_fd_lockout_offset_t_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L185 */
 /* Encoded Size: Dynamic */
 struct fd_tower_sync {
@@ -1639,22 +1095,6 @@ struct fd_tower_sync {
 typedef struct fd_tower_sync fd_tower_sync_t;
 #define FD_TOWER_SYNC_ALIGN alignof(fd_tower_sync_t)
 
-struct fd_tower_sync_global {
-  ulong lockouts_offset; /* fd_deque_dynamic */
-  ulong lockouts_cnt;
-  ulong root;
-  uchar has_root;
-  fd_hash_t hash;
-  long timestamp;
-  uchar has_timestamp;
-  fd_hash_t block_id;
-};
-typedef struct fd_tower_sync_global fd_tower_sync_global_t;
-#define FD_TOWER_SYNC_GLOBAL_ALIGN alignof(fd_tower_sync_global_t)
-
-static FD_FN_UNUSED fd_vote_lockout_t * fd_tower_sync_lockouts_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_vote_lockout_t *)deq_fd_vote_lockout_t_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_instruction.rs#L104 */
 /* Encoded Size: Dynamic */
 struct fd_tower_sync_switch {
@@ -1663,13 +1103,6 @@ struct fd_tower_sync_switch {
 };
 typedef struct fd_tower_sync_switch fd_tower_sync_switch_t;
 #define FD_TOWER_SYNC_SWITCH_ALIGN alignof(fd_tower_sync_switch_t)
-
-struct fd_tower_sync_switch_global {
-  fd_tower_sync_global_t tower_sync;
-  fd_hash_t hash;
-};
-typedef struct fd_tower_sync_switch_global fd_tower_sync_switch_global_t;
-#define FD_TOWER_SYNC_SWITCH_GLOBAL_ALIGN alignof(fd_tower_sync_switch_global_t)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/slot_history.rs#L11 */
 /* Encoded Size: Dynamic */
@@ -1789,28 +1222,6 @@ struct fd_slot_meta {
 typedef struct fd_slot_meta fd_slot_meta_t;
 #define FD_SLOT_META_ALIGN alignof(fd_slot_meta_t)
 
-struct fd_slot_meta_global {
-  ulong slot;
-  ulong consumed;
-  ulong received;
-  long first_shred_timestamp;
-  ulong last_index;
-  ulong parent_slot;
-  ulong next_slot_len;
-  ulong next_slot_offset;
-  uchar is_connected;
-  ulong entry_end_indexes_len;
-  ulong entry_end_indexes_offset;
-};
-typedef struct fd_slot_meta_global fd_slot_meta_global_t;
-#define FD_SLOT_META_GLOBAL_ALIGN alignof(fd_slot_meta_global_t)
-
-FD_FN_UNUSED static ulong * fd_slot_meta_next_slot_join( fd_slot_meta_global_t * struct_mem ) { // vector
-  return (ulong *)fd_type_pun( (uchar *)struct_mem + struct_mem->next_slot_offset );
-}
-FD_FN_UNUSED static uint * fd_slot_meta_entry_end_indexes_join( fd_slot_meta_global_t * struct_mem ) { // vector
-  return (uint *)fd_type_pun( (uchar *)struct_mem + struct_mem->entry_end_indexes_offset );
-}
 /* A validator timestamp oracle vote received from a voting node */
 /* Encoded Size: Fixed (48 bytes) */
 struct fd_clock_timestamp_vote {
@@ -1850,19 +1261,6 @@ struct fd_clock_timestamp_votes {
 typedef struct fd_clock_timestamp_votes fd_clock_timestamp_votes_t;
 #define FD_CLOCK_TIMESTAMP_VOTES_ALIGN alignof(fd_clock_timestamp_votes_t)
 
-struct fd_clock_timestamp_votes_global {
-  ulong votes_pool_offset;
-  ulong votes_root_offset;
-};
-typedef struct fd_clock_timestamp_votes_global fd_clock_timestamp_votes_global_t;
-#define FD_CLOCK_TIMESTAMP_VOTES_GLOBAL_ALIGN alignof(fd_clock_timestamp_votes_global_t)
-
-static FD_FN_UNUSED fd_clock_timestamp_vote_t_mapnode_t * fd_clock_timestamp_votes_votes_pool_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_clock_timestamp_vote_t_mapnode_t *)fd_clock_timestamp_vote_t_map_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
-static FD_FN_UNUSED fd_clock_timestamp_vote_t_mapnode_t * fd_clock_timestamp_votes_votes_root_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_clock_timestamp_vote_t_mapnode_t *)fd_type_pun( (uchar *)struct_mem + offset );
-}
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/sysvar/fees.rs#L21 */
 /* Encoded Size: Fixed (8 bytes) */
 struct fd_sysvar_fees {
@@ -1904,18 +1302,6 @@ struct fd_stake_config {
 typedef struct fd_stake_config fd_stake_config_t;
 #define FD_STAKE_CONFIG_ALIGN alignof(fd_stake_config_t)
 
-struct fd_stake_config_global {
-  ushort config_keys_len;
-  ulong config_keys_offset;
-  double warmup_cooldown_rate;
-  uchar slash_penalty;
-};
-typedef struct fd_stake_config_global fd_stake_config_global_t;
-#define FD_STAKE_CONFIG_GLOBAL_ALIGN alignof(fd_stake_config_global_t)
-
-FD_FN_UNUSED static fd_config_keys_pair_t * fd_stake_config_config_keys_join( fd_stake_config_global_t * struct_mem ) { // vector
-  return (fd_config_keys_pair_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->config_keys_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_feature_entry {
   fd_pubkey_t pubkey;
@@ -1926,18 +1312,6 @@ struct fd_feature_entry {
 typedef struct fd_feature_entry fd_feature_entry_t;
 #define FD_FEATURE_ENTRY_ALIGN alignof(fd_feature_entry_t)
 
-struct fd_feature_entry_global {
-  fd_pubkey_t pubkey;
-  ulong description_len;
-  ulong description_offset;
-  ulong since_slot;
-};
-typedef struct fd_feature_entry_global fd_feature_entry_global_t;
-#define FD_FEATURE_ENTRY_GLOBAL_ALIGN alignof(fd_feature_entry_global_t)
-
-FD_FN_UNUSED static uchar * fd_feature_entry_description_join( fd_feature_entry_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->description_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_firedancer_bank {
   fd_stakes_t stakes;
@@ -1968,41 +1342,11 @@ struct fd_firedancer_bank {
 typedef struct fd_firedancer_bank fd_firedancer_bank_t;
 #define FD_FIREDANCER_BANK_ALIGN alignof(fd_firedancer_bank_t)
 
-struct fd_firedancer_bank_global {
-  fd_stakes_global_t stakes;
-  fd_recent_block_hashes_global_t recent_block_hashes;
-  fd_clock_timestamp_votes_global_t timestamp_votes;
-  ulong slot;
-  ulong prev_slot;
-  fd_hash_t poh;
-  fd_hash_t banks_hash;
-  fd_fee_rate_governor_t fee_rate_governor;
-  ulong capitalization;
-  ulong block_height;
-  ulong lamports_per_signature;
-  ulong hashes_per_tick;
-  ulong ticks_per_slot;
-  uint128 ns_per_slot;
-  ulong genesis_creation_time;
-  double slots_per_year;
-  ulong max_tick_height;
-  fd_inflation_t inflation;
-  fd_epoch_schedule_t epoch_schedule;
-  fd_rent_t rent;
-  ulong collected_fees;
-  ulong collected_rent;
-  fd_vote_accounts_global_t epoch_stakes;
-  fd_sol_sysvar_last_restart_slot_t last_restart_slot;
-};
-typedef struct fd_firedancer_bank_global fd_firedancer_bank_global_t;
-#define FD_FIREDANCER_BANK_GLOBAL_ALIGN alignof(fd_firedancer_bank_global_t)
-
 struct fd_cluster_type {
   uint discriminant;
 };
 typedef struct fd_cluster_type fd_cluster_type_t;
 #define FD_CLUSTER_TYPE_ALIGN alignof(fd_cluster_type_t)
-#define FD_CLUSTER_TYPE_GLOBAL_ALIGN alignof(fd_cluster_type_global_t)
 
 /* Encoded Size: Fixed (48 bytes) */
 struct fd_rent_fresh_account {
@@ -2022,17 +1366,6 @@ struct fd_rent_fresh_accounts {
 typedef struct fd_rent_fresh_accounts fd_rent_fresh_accounts_t;
 #define FD_RENT_FRESH_ACCOUNTS_ALIGN alignof(fd_rent_fresh_accounts_t)
 
-struct fd_rent_fresh_accounts_global {
-  ulong total_count;
-  ulong fresh_accounts_len;
-  ulong fresh_accounts_offset;
-};
-typedef struct fd_rent_fresh_accounts_global fd_rent_fresh_accounts_global_t;
-#define FD_RENT_FRESH_ACCOUNTS_GLOBAL_ALIGN alignof(fd_rent_fresh_accounts_global_t)
-
-FD_FN_UNUSED static fd_rent_fresh_account_t * fd_rent_fresh_accounts_fresh_accounts_join( fd_rent_fresh_accounts_global_t * struct_mem ) { // vector
-  return (fd_rent_fresh_account_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->fresh_accounts_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_epoch_bank {
   fd_stakes_t stakes;
@@ -2056,29 +1389,6 @@ struct fd_epoch_bank {
 };
 typedef struct fd_epoch_bank fd_epoch_bank_t;
 #define FD_EPOCH_BANK_ALIGN alignof(fd_epoch_bank_t)
-
-struct fd_epoch_bank_global {
-  fd_stakes_global_t stakes;
-  ulong hashes_per_tick;
-  ulong ticks_per_slot;
-  uint128 ns_per_slot;
-  ulong genesis_creation_time;
-  double slots_per_year;
-  ulong max_tick_height;
-  fd_inflation_t inflation;
-  fd_epoch_schedule_t epoch_schedule;
-  fd_rent_t rent;
-  ulong eah_start_slot;
-  ulong eah_stop_slot;
-  ulong eah_interval;
-  fd_hash_t genesis_hash;
-  uint cluster_type;
-  uint cluster_version[3];
-  fd_vote_accounts_global_t next_epoch_stakes;
-  fd_epoch_schedule_t rent_epoch_schedule;
-};
-typedef struct fd_epoch_bank_global fd_epoch_bank_global_t;
-#define FD_EPOCH_BANK_GLOBAL_ALIGN alignof(fd_epoch_bank_global_t)
 
 /* Encoded Size: Fixed (49 bytes) */
 struct fd_stake_reward {
@@ -2146,15 +1456,6 @@ struct fd_partitioned_stake_rewards {
 typedef struct fd_partitioned_stake_rewards fd_partitioned_stake_rewards_t;
 #define FD_PARTITIONED_STAKE_REWARDS_ALIGN alignof(fd_partitioned_stake_rewards_t)
 
-struct fd_partitioned_stake_rewards_global {
-  ulong partitions_len;
-  ulong partitions_lengths[4096];
-  ulong pool_offset;
-  ulong dlist_offset;
-};
-typedef struct fd_partitioned_stake_rewards_global fd_partitioned_stake_rewards_global_t;
-#define FD_PARTITIONED_STAKE_REWARDS_GLOBAL_ALIGN alignof(fd_partitioned_stake_rewards_global_t)
-
 /* https://github.com/anza-xyz/agave/blob/7117ed9653ce19e8b2dea108eff1f3eb6a3378a7/runtime/src/bank/partitioned_epoch_rewards/mod.rs#L131 */
 /* Encoded Size: Dynamic */
 struct fd_stake_reward_calculation_partitioned {
@@ -2163,13 +1464,6 @@ struct fd_stake_reward_calculation_partitioned {
 };
 typedef struct fd_stake_reward_calculation_partitioned fd_stake_reward_calculation_partitioned_t;
 #define FD_STAKE_REWARD_CALCULATION_PARTITIONED_ALIGN alignof(fd_stake_reward_calculation_partitioned_t)
-
-struct fd_stake_reward_calculation_partitioned_global {
-  fd_partitioned_stake_rewards_global_t partitioned_stake_rewards;
-  ulong total_stake_rewards_lamports;
-};
-typedef struct fd_stake_reward_calculation_partitioned_global fd_stake_reward_calculation_partitioned_global_t;
-#define FD_STAKE_REWARD_CALCULATION_PARTITIONED_GLOBAL_ALIGN alignof(fd_stake_reward_calculation_partitioned_global_t)
 
 #define POOL_NAME fd_stake_reward_calculation_pool
 #define POOL_T fd_stake_reward_t
@@ -2205,15 +1499,6 @@ struct fd_stake_reward_calculation {
 typedef struct fd_stake_reward_calculation fd_stake_reward_calculation_t;
 #define FD_STAKE_REWARD_CALCULATION_ALIGN alignof(fd_stake_reward_calculation_t)
 
-struct fd_stake_reward_calculation_global {
-  ulong stake_rewards_len;
-  ulong pool_offset;
-  ulong dlist_offset;
-  ulong total_stake_rewards_lamports;
-};
-typedef struct fd_stake_reward_calculation_global fd_stake_reward_calculation_global_t;
-#define FD_STAKE_REWARD_CALCULATION_GLOBAL_ALIGN alignof(fd_stake_reward_calculation_global_t)
-
 typedef struct fd_vote_reward_t_mapnode fd_vote_reward_t_mapnode_t;
 #define REDBLK_T fd_vote_reward_t_mapnode_t
 #define REDBLK_NAME fd_vote_reward_t_map
@@ -2243,20 +1528,6 @@ struct fd_calculate_stake_vote_rewards_result {
 typedef struct fd_calculate_stake_vote_rewards_result fd_calculate_stake_vote_rewards_result_t;
 #define FD_CALCULATE_STAKE_VOTE_REWARDS_RESULT_ALIGN alignof(fd_calculate_stake_vote_rewards_result_t)
 
-struct fd_calculate_stake_vote_rewards_result_global {
-  fd_stake_reward_calculation_global_t stake_reward_calculation;
-  ulong vote_reward_map_pool_offset;
-  ulong vote_reward_map_root_offset;
-};
-typedef struct fd_calculate_stake_vote_rewards_result_global fd_calculate_stake_vote_rewards_result_global_t;
-#define FD_CALCULATE_STAKE_VOTE_REWARDS_RESULT_GLOBAL_ALIGN alignof(fd_calculate_stake_vote_rewards_result_global_t)
-
-static FD_FN_UNUSED fd_vote_reward_t_mapnode_t * fd_calculate_stake_vote_rewards_result_vote_reward_map_pool_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_vote_reward_t_mapnode_t *)fd_vote_reward_t_map_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
-static FD_FN_UNUSED fd_vote_reward_t_mapnode_t * fd_calculate_stake_vote_rewards_result_vote_reward_map_root_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_vote_reward_t_mapnode_t *)fd_type_pun( (uchar *)struct_mem + offset );
-}
 /* https://github.com/anza-xyz/agave/blob/7117ed9653ce19e8b2dea108eff1f3eb6a3378a7/runtime/src/bank/partitioned_epoch_rewards/mod.rs#L102 */
 /* Encoded Size: Dynamic */
 struct fd_calculate_validator_rewards_result {
@@ -2265,13 +1536,6 @@ struct fd_calculate_validator_rewards_result {
 };
 typedef struct fd_calculate_validator_rewards_result fd_calculate_validator_rewards_result_t;
 #define FD_CALCULATE_VALIDATOR_REWARDS_RESULT_ALIGN alignof(fd_calculate_validator_rewards_result_t)
-
-struct fd_calculate_validator_rewards_result_global {
-  fd_calculate_stake_vote_rewards_result_global_t calculate_stake_vote_rewards_result;
-  fd_point_value_t point_value;
-};
-typedef struct fd_calculate_validator_rewards_result_global fd_calculate_validator_rewards_result_global_t;
-#define FD_CALCULATE_VALIDATOR_REWARDS_RESULT_GLOBAL_ALIGN alignof(fd_calculate_validator_rewards_result_global_t)
 
 /* https://github.com/anza-xyz/agave/blob/7117ed9653ce19e8b2dea108eff1f3eb6a3378a7/runtime/src/bank/partitioned_epoch_rewards/mod.rs#L138 */
 /* Encoded Size: Dynamic */
@@ -2283,15 +1547,6 @@ struct fd_calculate_rewards_and_distribute_vote_rewards_result {
 };
 typedef struct fd_calculate_rewards_and_distribute_vote_rewards_result fd_calculate_rewards_and_distribute_vote_rewards_result_t;
 #define FD_CALCULATE_REWARDS_AND_DISTRIBUTE_VOTE_REWARDS_RESULT_ALIGN alignof(fd_calculate_rewards_and_distribute_vote_rewards_result_t)
-
-struct fd_calculate_rewards_and_distribute_vote_rewards_result_global {
-  ulong total_rewards;
-  ulong distributed_rewards;
-  fd_point_value_t point_value;
-  fd_stake_reward_calculation_partitioned_global_t stake_rewards_by_partition;
-};
-typedef struct fd_calculate_rewards_and_distribute_vote_rewards_result_global fd_calculate_rewards_and_distribute_vote_rewards_result_global_t;
-#define FD_CALCULATE_REWARDS_AND_DISTRIBUTE_VOTE_REWARDS_RESULT_GLOBAL_ALIGN alignof(fd_calculate_rewards_and_distribute_vote_rewards_result_global_t)
 
 /* https://github.com/anza-xyz/agave/blob/7117ed9653ce19e8b2dea108eff1f3eb6a3378a7/runtime/src/bank/partitioned_epoch_rewards/mod.rs#L118 */
 /* Encoded Size: Dynamic */
@@ -2310,27 +1565,6 @@ struct fd_partitioned_rewards_calculation {
 typedef struct fd_partitioned_rewards_calculation fd_partitioned_rewards_calculation_t;
 #define FD_PARTITIONED_REWARDS_CALCULATION_ALIGN alignof(fd_partitioned_rewards_calculation_t)
 
-struct fd_partitioned_rewards_calculation_global {
-  ulong vote_reward_map_pool_offset;
-  ulong vote_reward_map_root_offset;
-  fd_stake_reward_calculation_partitioned_global_t stake_rewards_by_partition;
-  ulong old_vote_balance_and_staked;
-  ulong validator_rewards;
-  double validator_rate;
-  double foundation_rate;
-  double prev_epoch_duration_in_years;
-  ulong capitalization;
-  fd_point_value_t point_value;
-};
-typedef struct fd_partitioned_rewards_calculation_global fd_partitioned_rewards_calculation_global_t;
-#define FD_PARTITIONED_REWARDS_CALCULATION_GLOBAL_ALIGN alignof(fd_partitioned_rewards_calculation_global_t)
-
-static FD_FN_UNUSED fd_vote_reward_t_mapnode_t * fd_partitioned_rewards_calculation_vote_reward_map_pool_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_vote_reward_t_mapnode_t *)fd_vote_reward_t_map_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
-static FD_FN_UNUSED fd_vote_reward_t_mapnode_t * fd_partitioned_rewards_calculation_vote_reward_map_root_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_vote_reward_t_mapnode_t *)fd_type_pun( (uchar *)struct_mem + offset );
-}
 /* https://github.com/anza-xyz/agave/blob/7117ed9653ce19e8b2dea108eff1f3eb6a3378a7/runtime/src/bank/partitioned_epoch_rewards/mod.rs#L60 */
 /* Encoded Size: Dynamic */
 struct fd_start_block_height_and_rewards {
@@ -2340,13 +1574,6 @@ struct fd_start_block_height_and_rewards {
 typedef struct fd_start_block_height_and_rewards fd_start_block_height_and_rewards_t;
 #define FD_START_BLOCK_HEIGHT_AND_REWARDS_ALIGN alignof(fd_start_block_height_and_rewards_t)
 
-struct fd_start_block_height_and_rewards_global {
-  ulong distribution_starting_block_height;
-  fd_partitioned_stake_rewards_global_t partitioned_stake_rewards;
-};
-typedef struct fd_start_block_height_and_rewards_global fd_start_block_height_and_rewards_global_t;
-#define FD_START_BLOCK_HEIGHT_AND_REWARDS_GLOBAL_ALIGN alignof(fd_start_block_height_and_rewards_global_t)
-
 /* Encoded Size: Dynamic */
 struct fd_fd_epoch_reward_status_inner {
   fd_start_block_height_and_rewards_t Active;
@@ -2354,21 +1581,10 @@ struct fd_fd_epoch_reward_status_inner {
 typedef struct fd_fd_epoch_reward_status_inner fd_fd_epoch_reward_status_inner_t;
 #define FD_FD_EPOCH_REWARD_STATUS_INNER_ALIGN alignof(fd_fd_epoch_reward_status_inner_t)
 
-struct fd_fd_epoch_reward_status_inner_global {
-  fd_start_block_height_and_rewards_global_t Active;
-};
-typedef struct fd_fd_epoch_reward_status_inner_global fd_fd_epoch_reward_status_inner_global_t;
-#define FD_FD_EPOCH_REWARD_STATUS_INNER_GLOBAL_ALIGN alignof(fd_fd_epoch_reward_status_inner_global_t)
-
 union fd_epoch_reward_status_inner {
   fd_start_block_height_and_rewards_t Active;
 };
 typedef union fd_epoch_reward_status_inner fd_epoch_reward_status_inner_t;
-
-union fd_epoch_reward_status_inner_global {
-  fd_start_block_height_and_rewards_global_t Active;
-};
-typedef union fd_epoch_reward_status_inner_global fd_epoch_reward_status_inner_global_t;
 
 /* https://github.com/anza-xyz/agave/blob/7117ed9653ce19e8b2dea108eff1f3eb6a3378a7/runtime/src/bank/partitioned_epoch_rewards/mod.rs#L70 */
 struct fd_epoch_reward_status {
@@ -2377,12 +1593,6 @@ struct fd_epoch_reward_status {
 };
 typedef struct fd_epoch_reward_status fd_epoch_reward_status_t;
 #define FD_EPOCH_REWARD_STATUS_ALIGN alignof(fd_epoch_reward_status_t)
-struct fd_epoch_reward_status_global {
-  uint discriminant;
-  fd_epoch_reward_status_inner_global_t inner;
-};
-typedef struct fd_epoch_reward_status_global fd_epoch_reward_status_global_t;
-#define FD_EPOCH_REWARD_STATUS_GLOBAL_ALIGN alignof(fd_epoch_reward_status_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_slot_bank {
@@ -2419,40 +1629,6 @@ struct fd_slot_bank {
 typedef struct fd_slot_bank fd_slot_bank_t;
 #define FD_SLOT_BANK_ALIGN alignof(fd_slot_bank_t)
 
-struct fd_slot_bank_global {
-  fd_clock_timestamp_votes_global_t timestamp_votes;
-  ulong slot;
-  ulong prev_slot;
-  fd_hash_t poh;
-  fd_hash_t banks_hash;
-  fd_hash_t epoch_account_hash;
-  fd_fee_rate_governor_t fee_rate_governor;
-  ulong capitalization;
-  ulong block_height;
-  ulong max_tick_height;
-  ulong collected_execution_fees;
-  ulong collected_priority_fees;
-  ulong collected_rent;
-  fd_vote_accounts_global_t epoch_stakes;
-  fd_sol_sysvar_last_restart_slot_t last_restart_slot;
-  fd_account_keys_global_t stake_account_keys;
-  fd_account_keys_global_t vote_account_keys;
-  ulong lamports_per_signature;
-  ulong transaction_count;
-  fd_slot_lthash_t lthash;
-  fd_block_hash_queue_global_t block_hash_queue;
-  fd_hash_t prev_banks_hash;
-  ulong parent_signature_cnt;
-  ulong tick_height;
-  ulong use_preceeding_epoch_stakes;
-  uchar has_use_preceeding_epoch_stakes;
-  fd_hard_forks_global_t hard_forks;
-  fd_rent_fresh_accounts_global_t rent_fresh_accounts;
-  fd_epoch_reward_status_global_t epoch_reward_status;
-};
-typedef struct fd_slot_bank_global fd_slot_bank_global_t;
-#define FD_SLOT_BANK_GLOBAL_ALIGN alignof(fd_slot_bank_global_t)
-
 /* Encoded Size: Fixed (32 bytes) */
 struct fd_prev_epoch_inflation_rewards {
   ulong validator_rewards;
@@ -2488,17 +1664,6 @@ struct fd_vote {
 typedef struct fd_vote fd_vote_t;
 #define FD_VOTE_ALIGN alignof(fd_vote_t)
 
-struct fd_vote_global {
-  ulong slots_offset; /* fd_deque_dynamic */
-  fd_hash_t hash;
-  ulong timestamp_offset;
-};
-typedef struct fd_vote_global fd_vote_global_t;
-#define FD_VOTE_GLOBAL_ALIGN alignof(fd_vote_global_t)
-
-static FD_FN_UNUSED ulong * fd_vote_slots_join( void * struct_mem, ulong offset ) { // deque
-  return (ulong *)deq_ulong_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L230 */
 /* Encoded Size: Fixed (97 bytes) */
 struct fd_vote_init {
@@ -2516,7 +1681,6 @@ struct fd_vote_authorize {
 };
 typedef struct fd_vote_authorize fd_vote_authorize_t;
 #define FD_VOTE_AUTHORIZE_ALIGN alignof(fd_vote_authorize_t)
-#define FD_VOTE_AUTHORIZE_GLOBAL_ALIGN alignof(fd_vote_authorize_global_t)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_instruction.rs#L37 */
 /* Encoded Size: Fixed (36 bytes) */
@@ -2536,13 +1700,6 @@ struct fd_vote_switch {
 typedef struct fd_vote_switch fd_vote_switch_t;
 #define FD_VOTE_SWITCH_ALIGN alignof(fd_vote_switch_t)
 
-struct fd_vote_switch_global {
-  fd_vote_global_t vote;
-  fd_hash_t hash;
-};
-typedef struct fd_vote_switch_global fd_vote_switch_global_t;
-#define FD_VOTE_SWITCH_GLOBAL_ALIGN alignof(fd_vote_switch_global_t)
-
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_instruction.rs#L104 */
 /* Encoded Size: Dynamic */
 struct fd_update_vote_state_switch {
@@ -2551,13 +1708,6 @@ struct fd_update_vote_state_switch {
 };
 typedef struct fd_update_vote_state_switch fd_update_vote_state_switch_t;
 #define FD_UPDATE_VOTE_STATE_SWITCH_ALIGN alignof(fd_update_vote_state_switch_t)
-
-struct fd_update_vote_state_switch_global {
-  fd_vote_state_update_global_t vote_state_update;
-  fd_hash_t hash;
-};
-typedef struct fd_update_vote_state_switch_global fd_update_vote_state_switch_global_t;
-#define FD_UPDATE_VOTE_STATE_SWITCH_GLOBAL_ALIGN alignof(fd_update_vote_state_switch_global_t)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L244 */
 /* Encoded Size: Dynamic */
@@ -2571,19 +1721,6 @@ struct fd_vote_authorize_with_seed_args {
 typedef struct fd_vote_authorize_with_seed_args fd_vote_authorize_with_seed_args_t;
 #define FD_VOTE_AUTHORIZE_WITH_SEED_ARGS_ALIGN alignof(fd_vote_authorize_with_seed_args_t)
 
-struct fd_vote_authorize_with_seed_args_global {
-  fd_vote_authorize_t authorization_type;
-  fd_pubkey_t current_authority_derived_key_owner;
-  ulong current_authority_derived_key_seed_len;
-  ulong current_authority_derived_key_seed_offset;
-  fd_pubkey_t new_authority;
-};
-typedef struct fd_vote_authorize_with_seed_args_global fd_vote_authorize_with_seed_args_global_t;
-#define FD_VOTE_AUTHORIZE_WITH_SEED_ARGS_GLOBAL_ALIGN alignof(fd_vote_authorize_with_seed_args_global_t)
-
-FD_FN_UNUSED static uchar * fd_vote_authorize_with_seed_args_current_authority_derived_key_seed_join( fd_vote_authorize_with_seed_args_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->current_authority_derived_key_seed_offset );
-}
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/programs/vote/src/vote_state/mod.rs#L252 */
 /* Encoded Size: Dynamic */
 struct fd_vote_authorize_checked_with_seed_args {
@@ -2595,18 +1732,6 @@ struct fd_vote_authorize_checked_with_seed_args {
 typedef struct fd_vote_authorize_checked_with_seed_args fd_vote_authorize_checked_with_seed_args_t;
 #define FD_VOTE_AUTHORIZE_CHECKED_WITH_SEED_ARGS_ALIGN alignof(fd_vote_authorize_checked_with_seed_args_t)
 
-struct fd_vote_authorize_checked_with_seed_args_global {
-  fd_vote_authorize_t authorization_type;
-  fd_pubkey_t current_authority_derived_key_owner;
-  ulong current_authority_derived_key_seed_len;
-  ulong current_authority_derived_key_seed_offset;
-};
-typedef struct fd_vote_authorize_checked_with_seed_args_global fd_vote_authorize_checked_with_seed_args_global_t;
-#define FD_VOTE_AUTHORIZE_CHECKED_WITH_SEED_ARGS_GLOBAL_ALIGN alignof(fd_vote_authorize_checked_with_seed_args_global_t)
-
-FD_FN_UNUSED static uchar * fd_vote_authorize_checked_with_seed_args_current_authority_derived_key_seed_join( fd_vote_authorize_checked_with_seed_args_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->current_authority_derived_key_seed_offset );
-}
 union fd_vote_instruction_inner {
   fd_vote_init_t initialize_account;
   fd_vote_authorize_pubkey_t authorize;
@@ -2626,25 +1751,6 @@ union fd_vote_instruction_inner {
 };
 typedef union fd_vote_instruction_inner fd_vote_instruction_inner_t;
 
-union fd_vote_instruction_inner_global {
-  fd_vote_init_t initialize_account;
-  fd_vote_authorize_pubkey_t authorize;
-  fd_vote_global_t vote;
-  ulong withdraw;
-  uchar update_commission;
-  fd_vote_switch_global_t vote_switch;
-  fd_vote_authorize_t authorize_checked;
-  fd_vote_state_update_global_t update_vote_state;
-  fd_update_vote_state_switch_global_t update_vote_state_switch;
-  fd_vote_authorize_with_seed_args_global_t authorize_with_seed;
-  fd_vote_authorize_checked_with_seed_args_global_t authorize_checked_with_seed;
-  fd_compact_vote_state_update_global_t compact_update_vote_state;
-  fd_compact_vote_state_update_switch_global_t compact_update_vote_state_switch;
-  fd_tower_sync_global_t tower_sync;
-  fd_tower_sync_switch_global_t tower_sync_switch;
-};
-typedef union fd_vote_instruction_inner_global fd_vote_instruction_inner_global_t;
-
 /* https://github.com/firedancer-io/solana/blob/53a4e5d6c58b2ffe89b09304e4437f8ca198dadd/programs/vote/src/vote_instruction.rs#L21 */
 struct fd_vote_instruction {
   uint discriminant;
@@ -2652,12 +1758,6 @@ struct fd_vote_instruction {
 };
 typedef struct fd_vote_instruction fd_vote_instruction_t;
 #define FD_VOTE_INSTRUCTION_ALIGN alignof(fd_vote_instruction_t)
-struct fd_vote_instruction_global {
-  uint discriminant;
-  fd_vote_instruction_inner_global_t inner;
-};
-typedef struct fd_vote_instruction_global fd_vote_instruction_global_t;
-#define FD_VOTE_INSTRUCTION_GLOBAL_ALIGN alignof(fd_vote_instruction_global_t)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/system_instruction.rs#L158 */
 /* Encoded Size: Fixed (48 bytes) */
@@ -2682,20 +1782,6 @@ struct fd_system_program_instruction_create_account_with_seed {
 typedef struct fd_system_program_instruction_create_account_with_seed fd_system_program_instruction_create_account_with_seed_t;
 #define FD_SYSTEM_PROGRAM_INSTRUCTION_CREATE_ACCOUNT_WITH_SEED_ALIGN alignof(fd_system_program_instruction_create_account_with_seed_t)
 
-struct fd_system_program_instruction_create_account_with_seed_global {
-  fd_pubkey_t base;
-  ulong seed_len;
-  ulong seed_offset;
-  ulong lamports;
-  ulong space;
-  fd_pubkey_t owner;
-};
-typedef struct fd_system_program_instruction_create_account_with_seed_global fd_system_program_instruction_create_account_with_seed_global_t;
-#define FD_SYSTEM_PROGRAM_INSTRUCTION_CREATE_ACCOUNT_WITH_SEED_GLOBAL_ALIGN alignof(fd_system_program_instruction_create_account_with_seed_global_t)
-
-FD_FN_UNUSED static uchar * fd_system_program_instruction_create_account_with_seed_seed_join( fd_system_program_instruction_create_account_with_seed_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->seed_offset );
-}
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/system_instruction.rs#L269 */
 /* Encoded Size: Dynamic */
 struct fd_system_program_instruction_allocate_with_seed {
@@ -2708,19 +1794,6 @@ struct fd_system_program_instruction_allocate_with_seed {
 typedef struct fd_system_program_instruction_allocate_with_seed fd_system_program_instruction_allocate_with_seed_t;
 #define FD_SYSTEM_PROGRAM_INSTRUCTION_ALLOCATE_WITH_SEED_ALIGN alignof(fd_system_program_instruction_allocate_with_seed_t)
 
-struct fd_system_program_instruction_allocate_with_seed_global {
-  fd_pubkey_t base;
-  ulong seed_len;
-  ulong seed_offset;
-  ulong space;
-  fd_pubkey_t owner;
-};
-typedef struct fd_system_program_instruction_allocate_with_seed_global fd_system_program_instruction_allocate_with_seed_global_t;
-#define FD_SYSTEM_PROGRAM_INSTRUCTION_ALLOCATE_WITH_SEED_GLOBAL_ALIGN alignof(fd_system_program_instruction_allocate_with_seed_global_t)
-
-FD_FN_UNUSED static uchar * fd_system_program_instruction_allocate_with_seed_seed_join( fd_system_program_instruction_allocate_with_seed_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->seed_offset );
-}
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/system_instruction.rs#L288 */
 /* Encoded Size: Dynamic */
 struct fd_system_program_instruction_assign_with_seed {
@@ -2732,18 +1805,6 @@ struct fd_system_program_instruction_assign_with_seed {
 typedef struct fd_system_program_instruction_assign_with_seed fd_system_program_instruction_assign_with_seed_t;
 #define FD_SYSTEM_PROGRAM_INSTRUCTION_ASSIGN_WITH_SEED_ALIGN alignof(fd_system_program_instruction_assign_with_seed_t)
 
-struct fd_system_program_instruction_assign_with_seed_global {
-  fd_pubkey_t base;
-  ulong seed_len;
-  ulong seed_offset;
-  fd_pubkey_t owner;
-};
-typedef struct fd_system_program_instruction_assign_with_seed_global fd_system_program_instruction_assign_with_seed_global_t;
-#define FD_SYSTEM_PROGRAM_INSTRUCTION_ASSIGN_WITH_SEED_GLOBAL_ALIGN alignof(fd_system_program_instruction_assign_with_seed_global_t)
-
-FD_FN_UNUSED static uchar * fd_system_program_instruction_assign_with_seed_seed_join( fd_system_program_instruction_assign_with_seed_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->seed_offset );
-}
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/system_instruction.rs#L288 */
 /* Encoded Size: Dynamic */
 struct fd_system_program_instruction_transfer_with_seed {
@@ -2755,18 +1816,6 @@ struct fd_system_program_instruction_transfer_with_seed {
 typedef struct fd_system_program_instruction_transfer_with_seed fd_system_program_instruction_transfer_with_seed_t;
 #define FD_SYSTEM_PROGRAM_INSTRUCTION_TRANSFER_WITH_SEED_ALIGN alignof(fd_system_program_instruction_transfer_with_seed_t)
 
-struct fd_system_program_instruction_transfer_with_seed_global {
-  ulong lamports;
-  ulong from_seed_len;
-  ulong from_seed_offset;
-  fd_pubkey_t from_owner;
-};
-typedef struct fd_system_program_instruction_transfer_with_seed_global fd_system_program_instruction_transfer_with_seed_global_t;
-#define FD_SYSTEM_PROGRAM_INSTRUCTION_TRANSFER_WITH_SEED_GLOBAL_ALIGN alignof(fd_system_program_instruction_transfer_with_seed_global_t)
-
-FD_FN_UNUSED static uchar * fd_system_program_instruction_transfer_with_seed_from_seed_join( fd_system_program_instruction_transfer_with_seed_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->from_seed_offset );
-}
 union fd_system_program_instruction_inner {
   fd_system_program_instruction_create_account_t create_account;
   fd_pubkey_t assign;
@@ -2782,21 +1831,6 @@ union fd_system_program_instruction_inner {
 };
 typedef union fd_system_program_instruction_inner fd_system_program_instruction_inner_t;
 
-union fd_system_program_instruction_inner_global {
-  fd_system_program_instruction_create_account_t create_account;
-  fd_pubkey_t assign;
-  ulong transfer;
-  fd_system_program_instruction_create_account_with_seed_global_t create_account_with_seed;
-  ulong withdraw_nonce_account;
-  fd_pubkey_t initialize_nonce_account;
-  fd_pubkey_t authorize_nonce_account;
-  ulong allocate;
-  fd_system_program_instruction_allocate_with_seed_global_t allocate_with_seed;
-  fd_system_program_instruction_assign_with_seed_global_t assign_with_seed;
-  fd_system_program_instruction_transfer_with_seed_global_t transfer_with_seed;
-};
-typedef union fd_system_program_instruction_inner_global fd_system_program_instruction_inner_global_t;
-
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/system_instruction.rs#L152 */
 struct fd_system_program_instruction {
   uint discriminant;
@@ -2804,12 +1838,6 @@ struct fd_system_program_instruction {
 };
 typedef struct fd_system_program_instruction fd_system_program_instruction_t;
 #define FD_SYSTEM_PROGRAM_INSTRUCTION_ALIGN alignof(fd_system_program_instruction_t)
-struct fd_system_program_instruction_global {
-  uint discriminant;
-  fd_system_program_instruction_inner_global_t inner;
-};
-typedef struct fd_system_program_instruction_global fd_system_program_instruction_global_t;
-#define FD_SYSTEM_PROGRAM_INSTRUCTION_GLOBAL_ALIGN alignof(fd_system_program_instruction_global_t)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/system_instruction.rs#L16 */
 struct fd_system_error {
@@ -2817,7 +1845,6 @@ struct fd_system_error {
 };
 typedef struct fd_system_error fd_system_error_t;
 #define FD_SYSTEM_ERROR_ALIGN alignof(fd_system_error_t)
-#define FD_SYSTEM_ERROR_GLOBAL_ALIGN alignof(fd_system_error_global_t)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/state.rs#L169 */
 /* Encoded Size: Fixed (64 bytes) */
@@ -2857,21 +1884,12 @@ struct fd_stake_lockup_custodian_args {
 typedef struct fd_stake_lockup_custodian_args fd_stake_lockup_custodian_args_t;
 #define FD_STAKE_LOCKUP_CUSTODIAN_ARGS_ALIGN alignof(fd_stake_lockup_custodian_args_t)
 
-struct fd_stake_lockup_custodian_args_global {
-  fd_stake_lockup_t lockup;
-  fd_sol_sysvar_clock_t clock;
-  ulong custodian_offset;
-};
-typedef struct fd_stake_lockup_custodian_args_global fd_stake_lockup_custodian_args_global_t;
-#define FD_STAKE_LOCKUP_CUSTODIAN_ARGS_GLOBAL_ALIGN alignof(fd_stake_lockup_custodian_args_global_t)
-
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/state.rs#L117 */
 struct fd_stake_authorize {
   uint discriminant;
 };
 typedef struct fd_stake_authorize fd_stake_authorize_t;
 #define FD_STAKE_AUTHORIZE_ALIGN alignof(fd_stake_authorize_t)
-#define FD_STAKE_AUTHORIZE_GLOBAL_ALIGN alignof(fd_stake_authorize_global_t)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/instruction.rs#L78 */
 /* Encoded Size: Fixed (36 bytes) */
@@ -2894,19 +1912,6 @@ struct fd_authorize_with_seed_args {
 typedef struct fd_authorize_with_seed_args fd_authorize_with_seed_args_t;
 #define FD_AUTHORIZE_WITH_SEED_ARGS_ALIGN alignof(fd_authorize_with_seed_args_t)
 
-struct fd_authorize_with_seed_args_global {
-  fd_pubkey_t new_authorized_pubkey;
-  fd_stake_authorize_t stake_authorize;
-  ulong authority_seed_len;
-  ulong authority_seed_offset;
-  fd_pubkey_t authority_owner;
-};
-typedef struct fd_authorize_with_seed_args_global fd_authorize_with_seed_args_global_t;
-#define FD_AUTHORIZE_WITH_SEED_ARGS_GLOBAL_ALIGN alignof(fd_authorize_with_seed_args_global_t)
-
-FD_FN_UNUSED static uchar * fd_authorize_with_seed_args_authority_seed_join( fd_authorize_with_seed_args_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->authority_seed_offset );
-}
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/instruction.rs#L249 */
 /* Encoded Size: Dynamic */
 struct fd_authorize_checked_with_seed_args {
@@ -2918,18 +1923,6 @@ struct fd_authorize_checked_with_seed_args {
 typedef struct fd_authorize_checked_with_seed_args fd_authorize_checked_with_seed_args_t;
 #define FD_AUTHORIZE_CHECKED_WITH_SEED_ARGS_ALIGN alignof(fd_authorize_checked_with_seed_args_t)
 
-struct fd_authorize_checked_with_seed_args_global {
-  fd_stake_authorize_t stake_authorize;
-  ulong authority_seed_len;
-  ulong authority_seed_offset;
-  fd_pubkey_t authority_owner;
-};
-typedef struct fd_authorize_checked_with_seed_args_global fd_authorize_checked_with_seed_args_global_t;
-#define FD_AUTHORIZE_CHECKED_WITH_SEED_ARGS_GLOBAL_ALIGN alignof(fd_authorize_checked_with_seed_args_global_t)
-
-FD_FN_UNUSED static uchar * fd_authorize_checked_with_seed_args_authority_seed_join( fd_authorize_checked_with_seed_args_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->authority_seed_offset );
-}
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/instruction.rs#L235 */
 /* Encoded Size: Dynamic */
 struct fd_lockup_checked_args {
@@ -2938,13 +1931,6 @@ struct fd_lockup_checked_args {
 };
 typedef struct fd_lockup_checked_args fd_lockup_checked_args_t;
 #define FD_LOCKUP_CHECKED_ARGS_ALIGN alignof(fd_lockup_checked_args_t)
-
-struct fd_lockup_checked_args_global {
-  ulong unix_timestamp_offset;
-  ulong epoch_offset;
-};
-typedef struct fd_lockup_checked_args_global fd_lockup_checked_args_global_t;
-#define FD_LOCKUP_CHECKED_ARGS_GLOBAL_ALIGN alignof(fd_lockup_checked_args_global_t)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/instruction.rs#L228 */
 /* Encoded Size: Dynamic */
@@ -2955,14 +1941,6 @@ struct fd_lockup_args {
 };
 typedef struct fd_lockup_args fd_lockup_args_t;
 #define FD_LOCKUP_ARGS_ALIGN alignof(fd_lockup_args_t)
-
-struct fd_lockup_args_global {
-  ulong unix_timestamp_offset;
-  ulong epoch_offset;
-  ulong custodian_offset;
-};
-typedef struct fd_lockup_args_global fd_lockup_args_global_t;
-#define FD_LOCKUP_ARGS_GLOBAL_ALIGN alignof(fd_lockup_args_global_t)
 
 union fd_stake_instruction_inner {
   fd_stake_instruction_initialize_t initialize;
@@ -2979,21 +1957,6 @@ union fd_stake_instruction_inner {
 };
 typedef union fd_stake_instruction_inner fd_stake_instruction_inner_t;
 
-union fd_stake_instruction_inner_global {
-  fd_stake_instruction_initialize_t initialize;
-  fd_stake_instruction_authorize_t authorize;
-  ulong split;
-  ulong withdraw;
-  fd_lockup_args_global_t set_lockup;
-  fd_authorize_with_seed_args_global_t authorize_with_seed;
-  fd_stake_authorize_t authorize_checked;
-  fd_authorize_checked_with_seed_args_global_t authorize_checked_with_seed;
-  fd_lockup_checked_args_global_t set_lockup_checked;
-  ulong move_stake;
-  ulong move_lamports;
-};
-typedef union fd_stake_instruction_inner_global fd_stake_instruction_inner_global_t;
-
 /* https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/sdk/program/src/stake/instruction.rs#L96 */
 struct fd_stake_instruction {
   uint discriminant;
@@ -3001,12 +1964,6 @@ struct fd_stake_instruction {
 };
 typedef struct fd_stake_instruction fd_stake_instruction_t;
 #define FD_STAKE_INSTRUCTION_ALIGN alignof(fd_stake_instruction_t)
-struct fd_stake_instruction_global {
-  uint discriminant;
-  fd_stake_instruction_inner_global_t inner;
-};
-typedef struct fd_stake_instruction_global fd_stake_instruction_global_t;
-#define FD_STAKE_INSTRUCTION_GLOBAL_ALIGN alignof(fd_stake_instruction_global_t)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/stake/state.rs#L248 */
 /* Encoded Size: Fixed (120 bytes) */
@@ -3057,7 +2014,6 @@ struct fd_stake_state_v2 {
 };
 typedef struct fd_stake_state_v2 fd_stake_state_v2_t;
 #define FD_STAKE_STATE_V2_ALIGN alignof(fd_stake_state_v2_t)
-#define FD_STAKE_STATE_V2_GLOBAL_ALIGN alignof(fd_stake_state_v2_global_t)
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/nonce/state/current.rs#L17 */
 /* Encoded Size: Fixed (72 bytes) */
@@ -3081,7 +2037,6 @@ struct fd_nonce_state {
 };
 typedef struct fd_nonce_state fd_nonce_state_t;
 #define FD_NONCE_STATE_ALIGN alignof(fd_nonce_state_t)
-#define FD_NONCE_STATE_GLOBAL_ALIGN alignof(fd_nonce_state_global_t)
 
 union fd_nonce_state_versions_inner {
   fd_nonce_state_t legacy;
@@ -3096,7 +2051,6 @@ struct fd_nonce_state_versions {
 };
 typedef struct fd_nonce_state_versions fd_nonce_state_versions_t;
 #define FD_NONCE_STATE_VERSIONS_ALIGN alignof(fd_nonce_state_versions_t)
-#define FD_NONCE_STATE_VERSIONS_GLOBAL_ALIGN alignof(fd_nonce_state_versions_global_t)
 
 /* https://github.com/solana-labs/solana/blob/6c520396cd76807f6227a7973f7373b37894251c/sdk/src/compute_budget.rs#L28 */
 /* Encoded Size: Fixed (8 bytes) */
@@ -3123,7 +2077,6 @@ struct fd_compute_budget_program_instruction {
 };
 typedef struct fd_compute_budget_program_instruction fd_compute_budget_program_instruction_t;
 #define FD_COMPUTE_BUDGET_PROGRAM_INSTRUCTION_ALIGN alignof(fd_compute_budget_program_instruction_t)
-#define FD_COMPUTE_BUDGET_PROGRAM_INSTRUCTION_GLOBAL_ALIGN alignof(fd_compute_budget_program_instruction_global_t)
 
 /* https://github.com/solana-labs/solana/blob/a03ae63daff987912c48ee286eb8ee7e8a84bf01/programs/config/src/lib.rs#L32 */
 /* Encoded Size: Dynamic */
@@ -3134,16 +2087,6 @@ struct fd_config_keys {
 typedef struct fd_config_keys fd_config_keys_t;
 #define FD_CONFIG_KEYS_ALIGN alignof(fd_config_keys_t)
 
-struct fd_config_keys_global {
-  ushort keys_len;
-  ulong keys_offset;
-};
-typedef struct fd_config_keys_global fd_config_keys_global_t;
-#define FD_CONFIG_KEYS_GLOBAL_ALIGN alignof(fd_config_keys_global_t)
-
-FD_FN_UNUSED static fd_config_keys_pair_t * fd_config_keys_keys_join( fd_config_keys_global_t * struct_mem ) { // vector
-  return (fd_config_keys_pair_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->keys_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_bpf_loader_program_instruction_write {
   uint offset;
@@ -3153,26 +2096,10 @@ struct fd_bpf_loader_program_instruction_write {
 typedef struct fd_bpf_loader_program_instruction_write fd_bpf_loader_program_instruction_write_t;
 #define FD_BPF_LOADER_PROGRAM_INSTRUCTION_WRITE_ALIGN alignof(fd_bpf_loader_program_instruction_write_t)
 
-struct fd_bpf_loader_program_instruction_write_global {
-  uint offset;
-  ulong bytes_len;
-  ulong bytes_offset;
-};
-typedef struct fd_bpf_loader_program_instruction_write_global fd_bpf_loader_program_instruction_write_global_t;
-#define FD_BPF_LOADER_PROGRAM_INSTRUCTION_WRITE_GLOBAL_ALIGN alignof(fd_bpf_loader_program_instruction_write_global_t)
-
-FD_FN_UNUSED static uchar * fd_bpf_loader_program_instruction_write_bytes_join( fd_bpf_loader_program_instruction_write_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->bytes_offset );
-}
 union fd_bpf_loader_program_instruction_inner {
   fd_bpf_loader_program_instruction_write_t write;
 };
 typedef union fd_bpf_loader_program_instruction_inner fd_bpf_loader_program_instruction_inner_t;
-
-union fd_bpf_loader_program_instruction_inner_global {
-  fd_bpf_loader_program_instruction_write_global_t write;
-};
-typedef union fd_bpf_loader_program_instruction_inner_global fd_bpf_loader_program_instruction_inner_global_t;
 
 struct fd_bpf_loader_program_instruction {
   uint discriminant;
@@ -3180,12 +2107,6 @@ struct fd_bpf_loader_program_instruction {
 };
 typedef struct fd_bpf_loader_program_instruction fd_bpf_loader_program_instruction_t;
 #define FD_BPF_LOADER_PROGRAM_INSTRUCTION_ALIGN alignof(fd_bpf_loader_program_instruction_t)
-struct fd_bpf_loader_program_instruction_global {
-  uint discriminant;
-  fd_bpf_loader_program_instruction_inner_global_t inner;
-};
-typedef struct fd_bpf_loader_program_instruction_global fd_bpf_loader_program_instruction_global_t;
-#define FD_BPF_LOADER_PROGRAM_INSTRUCTION_GLOBAL_ALIGN alignof(fd_bpf_loader_program_instruction_global_t)
 
 /* https://github.com/anza-xyz/solana-sdk/blob/loader-v4-interface%40v2.2.1/loader-v4-interface/src/instruction.rs#L21-L27 */
 /* Encoded Size: Dynamic */
@@ -3197,17 +2118,6 @@ struct fd_loader_v4_program_instruction_write {
 typedef struct fd_loader_v4_program_instruction_write fd_loader_v4_program_instruction_write_t;
 #define FD_LOADER_V4_PROGRAM_INSTRUCTION_WRITE_ALIGN alignof(fd_loader_v4_program_instruction_write_t)
 
-struct fd_loader_v4_program_instruction_write_global {
-  uint offset;
-  ulong bytes_len;
-  ulong bytes_offset;
-};
-typedef struct fd_loader_v4_program_instruction_write_global fd_loader_v4_program_instruction_write_global_t;
-#define FD_LOADER_V4_PROGRAM_INSTRUCTION_WRITE_GLOBAL_ALIGN alignof(fd_loader_v4_program_instruction_write_global_t)
-
-FD_FN_UNUSED static uchar * fd_loader_v4_program_instruction_write_bytes_join( fd_loader_v4_program_instruction_write_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->bytes_offset );
-}
 /* https://github.com/anza-xyz/solana-sdk/blob/loader-v4-interface%40v2.2.1/loader-v4-interface/src/instruction.rs#L35-L42 */
 /* Encoded Size: Fixed (12 bytes) */
 struct fd_loader_v4_program_instruction_copy {
@@ -3233,13 +2143,6 @@ union fd_loader_v4_program_instruction_inner {
 };
 typedef union fd_loader_v4_program_instruction_inner fd_loader_v4_program_instruction_inner_t;
 
-union fd_loader_v4_program_instruction_inner_global {
-  fd_loader_v4_program_instruction_write_global_t write;
-  fd_loader_v4_program_instruction_copy_t copy;
-  fd_loader_v4_program_instruction_set_program_length_t set_program_length;
-};
-typedef union fd_loader_v4_program_instruction_inner_global fd_loader_v4_program_instruction_inner_global_t;
-
 /* https://github.com/anza-xyz/agave/blob/007194391ca8313b2854d523769d0bedf040ef92/sdk/program/src/loader_v4_instruction.rs#L5 */
 struct fd_loader_v4_program_instruction {
   uint discriminant;
@@ -3247,12 +2150,6 @@ struct fd_loader_v4_program_instruction {
 };
 typedef struct fd_loader_v4_program_instruction fd_loader_v4_program_instruction_t;
 #define FD_LOADER_V4_PROGRAM_INSTRUCTION_ALIGN alignof(fd_loader_v4_program_instruction_t)
-struct fd_loader_v4_program_instruction_global {
-  uint discriminant;
-  fd_loader_v4_program_instruction_inner_global_t inner;
-};
-typedef struct fd_loader_v4_program_instruction_global fd_loader_v4_program_instruction_global_t;
-#define FD_LOADER_V4_PROGRAM_INSTRUCTION_GLOBAL_ALIGN alignof(fd_loader_v4_program_instruction_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_bpf_upgradeable_loader_program_instruction_write {
@@ -3263,17 +2160,6 @@ struct fd_bpf_upgradeable_loader_program_instruction_write {
 typedef struct fd_bpf_upgradeable_loader_program_instruction_write fd_bpf_upgradeable_loader_program_instruction_write_t;
 #define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_WRITE_ALIGN alignof(fd_bpf_upgradeable_loader_program_instruction_write_t)
 
-struct fd_bpf_upgradeable_loader_program_instruction_write_global {
-  uint offset;
-  ulong bytes_len;
-  ulong bytes_offset;
-};
-typedef struct fd_bpf_upgradeable_loader_program_instruction_write_global fd_bpf_upgradeable_loader_program_instruction_write_global_t;
-#define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_WRITE_GLOBAL_ALIGN alignof(fd_bpf_upgradeable_loader_program_instruction_write_global_t)
-
-FD_FN_UNUSED static uchar * fd_bpf_upgradeable_loader_program_instruction_write_bytes_join( fd_bpf_upgradeable_loader_program_instruction_write_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->bytes_offset );
-}
 /* Encoded Size: Fixed (8 bytes) */
 struct fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len {
   ulong max_data_len;
@@ -3295,25 +2181,12 @@ union fd_bpf_upgradeable_loader_program_instruction_inner {
 };
 typedef union fd_bpf_upgradeable_loader_program_instruction_inner fd_bpf_upgradeable_loader_program_instruction_inner_t;
 
-union fd_bpf_upgradeable_loader_program_instruction_inner_global {
-  fd_bpf_upgradeable_loader_program_instruction_write_global_t write;
-  fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t deploy_with_max_data_len;
-  fd_bpf_upgradeable_loader_program_instruction_extend_program_t extend_program;
-};
-typedef union fd_bpf_upgradeable_loader_program_instruction_inner_global fd_bpf_upgradeable_loader_program_instruction_inner_global_t;
-
 struct fd_bpf_upgradeable_loader_program_instruction {
   uint discriminant;
   fd_bpf_upgradeable_loader_program_instruction_inner_t inner;
 };
 typedef struct fd_bpf_upgradeable_loader_program_instruction fd_bpf_upgradeable_loader_program_instruction_t;
 #define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_ALIGN alignof(fd_bpf_upgradeable_loader_program_instruction_t)
-struct fd_bpf_upgradeable_loader_program_instruction_global {
-  uint discriminant;
-  fd_bpf_upgradeable_loader_program_instruction_inner_global_t inner;
-};
-typedef struct fd_bpf_upgradeable_loader_program_instruction_global fd_bpf_upgradeable_loader_program_instruction_global_t;
-#define FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_GLOBAL_ALIGN alignof(fd_bpf_upgradeable_loader_program_instruction_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_bpf_upgradeable_loader_state_buffer {
@@ -3321,12 +2194,6 @@ struct fd_bpf_upgradeable_loader_state_buffer {
 };
 typedef struct fd_bpf_upgradeable_loader_state_buffer fd_bpf_upgradeable_loader_state_buffer_t;
 #define FD_BPF_UPGRADEABLE_LOADER_STATE_BUFFER_ALIGN alignof(fd_bpf_upgradeable_loader_state_buffer_t)
-
-struct fd_bpf_upgradeable_loader_state_buffer_global {
-  ulong authority_address_offset;
-};
-typedef struct fd_bpf_upgradeable_loader_state_buffer_global fd_bpf_upgradeable_loader_state_buffer_global_t;
-#define FD_BPF_UPGRADEABLE_LOADER_STATE_BUFFER_GLOBAL_ALIGN alignof(fd_bpf_upgradeable_loader_state_buffer_global_t)
 
 /* Encoded Size: Fixed (32 bytes) */
 struct fd_bpf_upgradeable_loader_state_program {
@@ -3343,13 +2210,6 @@ struct fd_bpf_upgradeable_loader_state_program_data {
 typedef struct fd_bpf_upgradeable_loader_state_program_data fd_bpf_upgradeable_loader_state_program_data_t;
 #define FD_BPF_UPGRADEABLE_LOADER_STATE_PROGRAM_DATA_ALIGN alignof(fd_bpf_upgradeable_loader_state_program_data_t)
 
-struct fd_bpf_upgradeable_loader_state_program_data_global {
-  ulong slot;
-  ulong upgrade_authority_address_offset;
-};
-typedef struct fd_bpf_upgradeable_loader_state_program_data_global fd_bpf_upgradeable_loader_state_program_data_global_t;
-#define FD_BPF_UPGRADEABLE_LOADER_STATE_PROGRAM_DATA_GLOBAL_ALIGN alignof(fd_bpf_upgradeable_loader_state_program_data_global_t)
-
 union fd_bpf_upgradeable_loader_state_inner {
   fd_bpf_upgradeable_loader_state_buffer_t buffer;
   fd_bpf_upgradeable_loader_state_program_t program;
@@ -3357,25 +2217,12 @@ union fd_bpf_upgradeable_loader_state_inner {
 };
 typedef union fd_bpf_upgradeable_loader_state_inner fd_bpf_upgradeable_loader_state_inner_t;
 
-union fd_bpf_upgradeable_loader_state_inner_global {
-  fd_bpf_upgradeable_loader_state_buffer_global_t buffer;
-  fd_bpf_upgradeable_loader_state_program_t program;
-  fd_bpf_upgradeable_loader_state_program_data_global_t program_data;
-};
-typedef union fd_bpf_upgradeable_loader_state_inner_global fd_bpf_upgradeable_loader_state_inner_global_t;
-
 struct fd_bpf_upgradeable_loader_state {
   uint discriminant;
   fd_bpf_upgradeable_loader_state_inner_t inner;
 };
 typedef struct fd_bpf_upgradeable_loader_state fd_bpf_upgradeable_loader_state_t;
 #define FD_BPF_UPGRADEABLE_LOADER_STATE_ALIGN alignof(fd_bpf_upgradeable_loader_state_t)
-struct fd_bpf_upgradeable_loader_state_global {
-  uint discriminant;
-  fd_bpf_upgradeable_loader_state_inner_global_t inner;
-};
-typedef struct fd_bpf_upgradeable_loader_state_global fd_bpf_upgradeable_loader_state_global_t;
-#define FD_BPF_UPGRADEABLE_LOADER_STATE_GLOBAL_ALIGN alignof(fd_bpf_upgradeable_loader_state_global_t)
 
 /* https://github.com/anza-xyz/agave/blob/v2.1.4/sdk/program/src/loader_v4.rs#L33-L43 */
 /* Encoded Size: Fixed (48 bytes) */
@@ -3408,7 +2255,6 @@ struct fd_frozen_hash_versioned {
 };
 typedef struct fd_frozen_hash_versioned fd_frozen_hash_versioned_t;
 #define FD_FROZEN_HASH_VERSIONED_ALIGN alignof(fd_frozen_hash_versioned_t)
-#define FD_FROZEN_HASH_VERSIONED_GLOBAL_ALIGN alignof(fd_frozen_hash_versioned_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_lookup_table_meta {
@@ -3422,17 +2268,6 @@ struct fd_lookup_table_meta {
 typedef struct fd_lookup_table_meta fd_lookup_table_meta_t;
 #define FD_LOOKUP_TABLE_META_ALIGN alignof(fd_lookup_table_meta_t)
 
-struct fd_lookup_table_meta_global {
-  ulong deactivation_slot;
-  ulong last_extended_slot;
-  uchar last_extended_slot_start_index;
-  fd_pubkey_t authority;
-  uchar has_authority;
-  ushort _padding;
-};
-typedef struct fd_lookup_table_meta_global fd_lookup_table_meta_global_t;
-#define FD_LOOKUP_TABLE_META_GLOBAL_ALIGN alignof(fd_lookup_table_meta_global_t)
-
 /* Encoded Size: Dynamic */
 struct fd_address_lookup_table {
   fd_lookup_table_meta_t meta;
@@ -3440,21 +2275,10 @@ struct fd_address_lookup_table {
 typedef struct fd_address_lookup_table fd_address_lookup_table_t;
 #define FD_ADDRESS_LOOKUP_TABLE_ALIGN alignof(fd_address_lookup_table_t)
 
-struct fd_address_lookup_table_global {
-  fd_lookup_table_meta_global_t meta;
-};
-typedef struct fd_address_lookup_table_global fd_address_lookup_table_global_t;
-#define FD_ADDRESS_LOOKUP_TABLE_GLOBAL_ALIGN alignof(fd_address_lookup_table_global_t)
-
 union fd_address_lookup_table_state_inner {
   fd_address_lookup_table_t lookup_table;
 };
 typedef union fd_address_lookup_table_state_inner fd_address_lookup_table_state_inner_t;
-
-union fd_address_lookup_table_state_inner_global {
-  fd_address_lookup_table_global_t lookup_table;
-};
-typedef union fd_address_lookup_table_state_inner_global fd_address_lookup_table_state_inner_global_t;
 
 struct fd_address_lookup_table_state {
   uint discriminant;
@@ -3462,12 +2286,6 @@ struct fd_address_lookup_table_state {
 };
 typedef struct fd_address_lookup_table_state fd_address_lookup_table_state_t;
 #define FD_ADDRESS_LOOKUP_TABLE_STATE_ALIGN alignof(fd_address_lookup_table_state_t)
-struct fd_address_lookup_table_state_global {
-  uint discriminant;
-  fd_address_lookup_table_state_inner_global_t inner;
-};
-typedef struct fd_address_lookup_table_state_global fd_address_lookup_table_state_global_t;
-#define FD_ADDRESS_LOOKUP_TABLE_STATE_GLOBAL_ALIGN alignof(fd_address_lookup_table_state_global_t)
 
 /* https://github.com/solana-labs/solana/blob/52616cf7aa424a80f770e5ec3f2cd49d1cfeb845/gossip/src/ping_pong.rs#L22 */
 /* Encoded Size: Fixed (128 bytes) */
@@ -3492,7 +2310,6 @@ struct fd_gossip_ip_addr {
 };
 typedef struct fd_gossip_ip_addr fd_gossip_ip_addr_t;
 #define FD_GOSSIP_IP_ADDR_ALIGN alignof(fd_gossip_ip_addr_t)
-#define FD_GOSSIP_IP_ADDR_GLOBAL_ALIGN alignof(fd_gossip_ip_addr_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_gossip_prune_data {
@@ -3506,20 +2323,6 @@ struct fd_gossip_prune_data {
 typedef struct fd_gossip_prune_data fd_gossip_prune_data_t;
 #define FD_GOSSIP_PRUNE_DATA_ALIGN alignof(fd_gossip_prune_data_t)
 
-struct fd_gossip_prune_data_global {
-  fd_pubkey_t pubkey;
-  ulong prunes_len;
-  ulong prunes_offset;
-  fd_signature_t signature;
-  fd_pubkey_t destination;
-  ulong wallclock;
-};
-typedef struct fd_gossip_prune_data_global fd_gossip_prune_data_global_t;
-#define FD_GOSSIP_PRUNE_DATA_GLOBAL_ALIGN alignof(fd_gossip_prune_data_global_t)
-
-FD_FN_UNUSED static fd_pubkey_t * fd_gossip_prune_data_prunes_join( fd_gossip_prune_data_global_t * struct_mem ) { // vector
-  return (fd_pubkey_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->prunes_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_gossip_prune_sign_data {
   fd_pubkey_t pubkey;
@@ -3531,19 +2334,6 @@ struct fd_gossip_prune_sign_data {
 typedef struct fd_gossip_prune_sign_data fd_gossip_prune_sign_data_t;
 #define FD_GOSSIP_PRUNE_SIGN_DATA_ALIGN alignof(fd_gossip_prune_sign_data_t)
 
-struct fd_gossip_prune_sign_data_global {
-  fd_pubkey_t pubkey;
-  ulong prunes_len;
-  ulong prunes_offset;
-  fd_pubkey_t destination;
-  ulong wallclock;
-};
-typedef struct fd_gossip_prune_sign_data_global fd_gossip_prune_sign_data_global_t;
-#define FD_GOSSIP_PRUNE_SIGN_DATA_GLOBAL_ALIGN alignof(fd_gossip_prune_sign_data_global_t)
-
-FD_FN_UNUSED static fd_pubkey_t * fd_gossip_prune_sign_data_prunes_join( fd_gossip_prune_sign_data_global_t * struct_mem ) { // vector
-  return (fd_pubkey_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->prunes_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_gossip_prune_sign_data_with_prefix {
   ulong prefix_len;
@@ -3553,17 +2343,6 @@ struct fd_gossip_prune_sign_data_with_prefix {
 typedef struct fd_gossip_prune_sign_data_with_prefix fd_gossip_prune_sign_data_with_prefix_t;
 #define FD_GOSSIP_PRUNE_SIGN_DATA_WITH_PREFIX_ALIGN alignof(fd_gossip_prune_sign_data_with_prefix_t)
 
-struct fd_gossip_prune_sign_data_with_prefix_global {
-  ulong prefix_len;
-  ulong prefix_offset;
-  fd_gossip_prune_sign_data_global_t data;
-};
-typedef struct fd_gossip_prune_sign_data_with_prefix_global fd_gossip_prune_sign_data_with_prefix_global_t;
-#define FD_GOSSIP_PRUNE_SIGN_DATA_WITH_PREFIX_GLOBAL_ALIGN alignof(fd_gossip_prune_sign_data_with_prefix_global_t)
-
-FD_FN_UNUSED static uchar * fd_gossip_prune_sign_data_with_prefix_prefix_join( fd_gossip_prune_sign_data_with_prefix_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->prefix_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_gossip_socket_addr_old {
   fd_gossip_ip_addr_t addr;
@@ -3602,7 +2381,6 @@ struct fd_gossip_socket_addr {
 };
 typedef struct fd_gossip_socket_addr fd_gossip_socket_addr_t;
 #define FD_GOSSIP_SOCKET_ADDR_ALIGN alignof(fd_gossip_socket_addr_t)
-#define FD_GOSSIP_SOCKET_ADDR_GLOBAL_ALIGN alignof(fd_gossip_socket_addr_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_gossip_contact_info_v1 {
@@ -3647,22 +2425,6 @@ struct fd_gossip_lowest_slot {
 typedef struct fd_gossip_lowest_slot fd_gossip_lowest_slot_t;
 #define FD_GOSSIP_LOWEST_SLOT_ALIGN alignof(fd_gossip_lowest_slot_t)
 
-struct fd_gossip_lowest_slot_global {
-  uchar u8;
-  fd_pubkey_t from;
-  ulong root;
-  ulong lowest;
-  ulong slots_len;
-  ulong slots_offset;
-  ulong i_dont_know;
-  ulong wallclock;
-};
-typedef struct fd_gossip_lowest_slot_global fd_gossip_lowest_slot_global_t;
-#define FD_GOSSIP_LOWEST_SLOT_GLOBAL_ALIGN alignof(fd_gossip_lowest_slot_global_t)
-
-FD_FN_UNUSED static ulong * fd_gossip_lowest_slot_slots_join( fd_gossip_lowest_slot_global_t * struct_mem ) { // vector
-  return (ulong *)fd_type_pun( (uchar *)struct_mem + struct_mem->slots_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_gossip_slot_hashes {
   fd_pubkey_t from;
@@ -3673,18 +2435,6 @@ struct fd_gossip_slot_hashes {
 typedef struct fd_gossip_slot_hashes fd_gossip_slot_hashes_t;
 #define FD_GOSSIP_SLOT_HASHES_ALIGN alignof(fd_gossip_slot_hashes_t)
 
-struct fd_gossip_slot_hashes_global {
-  fd_pubkey_t from;
-  ulong hashes_len;
-  ulong hashes_offset;
-  ulong wallclock;
-};
-typedef struct fd_gossip_slot_hashes_global fd_gossip_slot_hashes_global_t;
-#define FD_GOSSIP_SLOT_HASHES_GLOBAL_ALIGN alignof(fd_gossip_slot_hashes_global_t)
-
-FD_FN_UNUSED static fd_slot_hash_t * fd_gossip_slot_hashes_hashes_join( fd_gossip_slot_hashes_global_t * struct_mem ) { // vector
-  return (fd_slot_hash_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->hashes_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_gossip_slots {
   ulong first_slot;
@@ -3697,17 +2447,6 @@ struct fd_gossip_slots {
 typedef struct fd_gossip_slots fd_gossip_slots_t;
 #define FD_GOSSIP_SLOTS_ALIGN alignof(fd_gossip_slots_t)
 
-struct fd_gossip_slots_global {
-  ulong first_slot;
-  ulong num;
-  uchar has_slots;
-  ulong slots_bitvec_len;
-  ulong slots_bitvec_offset;
-  ulong slots_len;
-};
-typedef struct fd_gossip_slots_global fd_gossip_slots_global_t;
-#define FD_GOSSIP_SLOTS_GLOBAL_ALIGN alignof(fd_gossip_slots_global_t)
-
 /* Encoded Size: Dynamic */
 struct fd_gossip_flate2_slots {
   ulong first_slot;
@@ -3718,29 +2457,11 @@ struct fd_gossip_flate2_slots {
 typedef struct fd_gossip_flate2_slots fd_gossip_flate2_slots_t;
 #define FD_GOSSIP_FLATE2_SLOTS_ALIGN alignof(fd_gossip_flate2_slots_t)
 
-struct fd_gossip_flate2_slots_global {
-  ulong first_slot;
-  ulong num;
-  ulong compressed_len;
-  ulong compressed_offset;
-};
-typedef struct fd_gossip_flate2_slots_global fd_gossip_flate2_slots_global_t;
-#define FD_GOSSIP_FLATE2_SLOTS_GLOBAL_ALIGN alignof(fd_gossip_flate2_slots_global_t)
-
-FD_FN_UNUSED static uchar * fd_gossip_flate2_slots_compressed_join( fd_gossip_flate2_slots_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->compressed_offset );
-}
 union fd_gossip_slots_enum_inner {
   fd_gossip_flate2_slots_t flate2;
   fd_gossip_slots_t uncompressed;
 };
 typedef union fd_gossip_slots_enum_inner fd_gossip_slots_enum_inner_t;
-
-union fd_gossip_slots_enum_inner_global {
-  fd_gossip_flate2_slots_global_t flate2;
-  fd_gossip_slots_global_t uncompressed;
-};
-typedef union fd_gossip_slots_enum_inner_global fd_gossip_slots_enum_inner_global_t;
 
 struct fd_gossip_slots_enum {
   uint discriminant;
@@ -3748,12 +2469,6 @@ struct fd_gossip_slots_enum {
 };
 typedef struct fd_gossip_slots_enum fd_gossip_slots_enum_t;
 #define FD_GOSSIP_SLOTS_ENUM_ALIGN alignof(fd_gossip_slots_enum_t)
-struct fd_gossip_slots_enum_global {
-  uint discriminant;
-  fd_gossip_slots_enum_inner_global_t inner;
-};
-typedef struct fd_gossip_slots_enum_global fd_gossip_slots_enum_global_t;
-#define FD_GOSSIP_SLOTS_ENUM_GLOBAL_ALIGN alignof(fd_gossip_slots_enum_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_gossip_epoch_slots {
@@ -3766,19 +2481,6 @@ struct fd_gossip_epoch_slots {
 typedef struct fd_gossip_epoch_slots fd_gossip_epoch_slots_t;
 #define FD_GOSSIP_EPOCH_SLOTS_ALIGN alignof(fd_gossip_epoch_slots_t)
 
-struct fd_gossip_epoch_slots_global {
-  uchar u8;
-  fd_pubkey_t from;
-  ulong slots_len;
-  ulong slots_offset;
-  ulong wallclock;
-};
-typedef struct fd_gossip_epoch_slots_global fd_gossip_epoch_slots_global_t;
-#define FD_GOSSIP_EPOCH_SLOTS_GLOBAL_ALIGN alignof(fd_gossip_epoch_slots_global_t)
-
-FD_FN_UNUSED static fd_gossip_slots_enum_global_t * fd_gossip_epoch_slots_slots_join( fd_gossip_epoch_slots_global_t * struct_mem ) { // vector
-  return (fd_gossip_slots_enum_global_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->slots_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_gossip_version_v1 {
   fd_pubkey_t from;
@@ -3791,18 +2493,6 @@ struct fd_gossip_version_v1 {
 };
 typedef struct fd_gossip_version_v1 fd_gossip_version_v1_t;
 #define FD_GOSSIP_VERSION_V1_ALIGN alignof(fd_gossip_version_v1_t)
-
-struct fd_gossip_version_v1_global {
-  fd_pubkey_t from;
-  ulong wallclock;
-  ushort major;
-  ushort minor;
-  ushort patch;
-  uint commit;
-  uchar has_commit;
-};
-typedef struct fd_gossip_version_v1_global fd_gossip_version_v1_global_t;
-#define FD_GOSSIP_VERSION_V1_GLOBAL_ALIGN alignof(fd_gossip_version_v1_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_gossip_version_v2 {
@@ -3817,19 +2507,6 @@ struct fd_gossip_version_v2 {
 };
 typedef struct fd_gossip_version_v2 fd_gossip_version_v2_t;
 #define FD_GOSSIP_VERSION_V2_ALIGN alignof(fd_gossip_version_v2_t)
-
-struct fd_gossip_version_v2_global {
-  fd_pubkey_t from;
-  ulong wallclock;
-  ushort major;
-  ushort minor;
-  ushort patch;
-  uint commit;
-  uchar has_commit;
-  uint feature_set;
-};
-typedef struct fd_gossip_version_v2_global fd_gossip_version_v2_global_t;
-#define FD_GOSSIP_VERSION_V2_GLOBAL_ALIGN alignof(fd_gossip_version_v2_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_gossip_version_v3 {
@@ -3869,24 +2546,6 @@ struct fd_gossip_duplicate_shred {
 typedef struct fd_gossip_duplicate_shred fd_gossip_duplicate_shred_t;
 #define FD_GOSSIP_DUPLICATE_SHRED_ALIGN alignof(fd_gossip_duplicate_shred_t)
 
-struct fd_gossip_duplicate_shred_global {
-  ushort duplicate_shred_index;
-  fd_pubkey_t from;
-  ulong wallclock;
-  ulong slot;
-  uint _unused;
-  uchar _unused_shred_type;
-  uchar num_chunks;
-  uchar chunk_index;
-  ulong chunk_len;
-  ulong chunk_offset;
-};
-typedef struct fd_gossip_duplicate_shred_global fd_gossip_duplicate_shred_global_t;
-#define FD_GOSSIP_DUPLICATE_SHRED_GLOBAL_ALIGN alignof(fd_gossip_duplicate_shred_global_t)
-
-FD_FN_UNUSED static uchar * fd_gossip_duplicate_shred_chunk_join( fd_gossip_duplicate_shred_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->chunk_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_gossip_incremental_snapshot_hashes {
   fd_pubkey_t from;
@@ -3898,19 +2557,6 @@ struct fd_gossip_incremental_snapshot_hashes {
 typedef struct fd_gossip_incremental_snapshot_hashes fd_gossip_incremental_snapshot_hashes_t;
 #define FD_GOSSIP_INCREMENTAL_SNAPSHOT_HASHES_ALIGN alignof(fd_gossip_incremental_snapshot_hashes_t)
 
-struct fd_gossip_incremental_snapshot_hashes_global {
-  fd_pubkey_t from;
-  fd_slot_hash_t base_hash;
-  ulong hashes_len;
-  ulong hashes_offset;
-  ulong wallclock;
-};
-typedef struct fd_gossip_incremental_snapshot_hashes_global fd_gossip_incremental_snapshot_hashes_global_t;
-#define FD_GOSSIP_INCREMENTAL_SNAPSHOT_HASHES_GLOBAL_ALIGN alignof(fd_gossip_incremental_snapshot_hashes_global_t)
-
-FD_FN_UNUSED static fd_slot_hash_t * fd_gossip_incremental_snapshot_hashes_hashes_join( fd_gossip_incremental_snapshot_hashes_global_t * struct_mem ) { // vector
-  return (fd_slot_hash_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->hashes_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_gossip_socket_entry {
   uchar key;
@@ -3937,31 +2583,6 @@ struct fd_gossip_contact_info_v2 {
 typedef struct fd_gossip_contact_info_v2 fd_gossip_contact_info_v2_t;
 #define FD_GOSSIP_CONTACT_INFO_V2_ALIGN alignof(fd_gossip_contact_info_v2_t)
 
-struct fd_gossip_contact_info_v2_global {
-  fd_pubkey_t from;
-  ulong wallclock;
-  ulong outset;
-  ushort shred_version;
-  fd_gossip_version_v3_t version;
-  ushort addrs_len;
-  ulong addrs_offset;
-  ushort sockets_len;
-  ulong sockets_offset;
-  ushort extensions_len;
-  ulong extensions_offset;
-};
-typedef struct fd_gossip_contact_info_v2_global fd_gossip_contact_info_v2_global_t;
-#define FD_GOSSIP_CONTACT_INFO_V2_GLOBAL_ALIGN alignof(fd_gossip_contact_info_v2_global_t)
-
-FD_FN_UNUSED static fd_gossip_ip_addr_t * fd_gossip_contact_info_v2_addrs_join( fd_gossip_contact_info_v2_global_t * struct_mem ) { // vector
-  return (fd_gossip_ip_addr_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->addrs_offset );
-}
-FD_FN_UNUSED static fd_gossip_socket_entry_t * fd_gossip_contact_info_v2_sockets_join( fd_gossip_contact_info_v2_global_t * struct_mem ) { // vector
-  return (fd_gossip_socket_entry_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->sockets_offset );
-}
-FD_FN_UNUSED static uint * fd_gossip_contact_info_v2_extensions_join( fd_gossip_contact_info_v2_global_t * struct_mem ) { // vector
-  return (uint *)fd_type_pun( (uchar *)struct_mem + struct_mem->extensions_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_restart_run_length_encoding_inner {
   ushort bits;
@@ -3977,16 +2598,6 @@ struct fd_restart_run_length_encoding {
 typedef struct fd_restart_run_length_encoding fd_restart_run_length_encoding_t;
 #define FD_RESTART_RUN_LENGTH_ENCODING_ALIGN alignof(fd_restart_run_length_encoding_t)
 
-struct fd_restart_run_length_encoding_global {
-  ulong offsets_len;
-  ulong offsets_offset;
-};
-typedef struct fd_restart_run_length_encoding_global fd_restart_run_length_encoding_global_t;
-#define FD_RESTART_RUN_LENGTH_ENCODING_GLOBAL_ALIGN alignof(fd_restart_run_length_encoding_global_t)
-
-FD_FN_UNUSED static fd_restart_run_length_encoding_inner_t * fd_restart_run_length_encoding_offsets_join( fd_restart_run_length_encoding_global_t * struct_mem ) { // vector
-  return (fd_restart_run_length_encoding_inner_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->offsets_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_restart_raw_offsets {
   uchar has_offsets;
@@ -3997,26 +2608,11 @@ struct fd_restart_raw_offsets {
 typedef struct fd_restart_raw_offsets fd_restart_raw_offsets_t;
 #define FD_RESTART_RAW_OFFSETS_ALIGN alignof(fd_restart_raw_offsets_t)
 
-struct fd_restart_raw_offsets_global {
-  uchar has_offsets;
-  ulong offsets_bitvec_len;
-  ulong offsets_bitvec_offset;
-  ulong offsets_len;
-};
-typedef struct fd_restart_raw_offsets_global fd_restart_raw_offsets_global_t;
-#define FD_RESTART_RAW_OFFSETS_GLOBAL_ALIGN alignof(fd_restart_raw_offsets_global_t)
-
 union fd_restart_slots_offsets_inner {
   fd_restart_run_length_encoding_t run_length_encoding;
   fd_restart_raw_offsets_t raw_offsets;
 };
 typedef union fd_restart_slots_offsets_inner fd_restart_slots_offsets_inner_t;
-
-union fd_restart_slots_offsets_inner_global {
-  fd_restart_run_length_encoding_global_t run_length_encoding;
-  fd_restart_raw_offsets_global_t raw_offsets;
-};
-typedef union fd_restart_slots_offsets_inner_global fd_restart_slots_offsets_inner_global_t;
 
 struct fd_restart_slots_offsets {
   uint discriminant;
@@ -4024,12 +2620,6 @@ struct fd_restart_slots_offsets {
 };
 typedef struct fd_restart_slots_offsets fd_restart_slots_offsets_t;
 #define FD_RESTART_SLOTS_OFFSETS_ALIGN alignof(fd_restart_slots_offsets_t)
-struct fd_restart_slots_offsets_global {
-  uint discriminant;
-  fd_restart_slots_offsets_inner_global_t inner;
-};
-typedef struct fd_restart_slots_offsets_global fd_restart_slots_offsets_global_t;
-#define FD_RESTART_SLOTS_OFFSETS_GLOBAL_ALIGN alignof(fd_restart_slots_offsets_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_gossip_restart_last_voted_fork_slots {
@@ -4042,17 +2632,6 @@ struct fd_gossip_restart_last_voted_fork_slots {
 };
 typedef struct fd_gossip_restart_last_voted_fork_slots fd_gossip_restart_last_voted_fork_slots_t;
 #define FD_GOSSIP_RESTART_LAST_VOTED_FORK_SLOTS_ALIGN alignof(fd_gossip_restart_last_voted_fork_slots_t)
-
-struct fd_gossip_restart_last_voted_fork_slots_global {
-  fd_pubkey_t from;
-  ulong wallclock;
-  fd_restart_slots_offsets_global_t offsets;
-  ulong last_voted_slot;
-  fd_hash_t last_voted_hash;
-  ushort shred_version;
-};
-typedef struct fd_gossip_restart_last_voted_fork_slots_global fd_gossip_restart_last_voted_fork_slots_global_t;
-#define FD_GOSSIP_RESTART_LAST_VOTED_FORK_SLOTS_GLOBAL_ALIGN alignof(fd_gossip_restart_last_voted_fork_slots_global_t)
 
 /* Encoded Size: Fixed (90 bytes) */
 struct fd_gossip_restart_heaviest_fork {
@@ -4084,36 +2663,12 @@ union fd_crds_data_inner {
 };
 typedef union fd_crds_data_inner fd_crds_data_inner_t;
 
-union fd_crds_data_inner_global {
-  fd_gossip_contact_info_v1_t contact_info_v1;
-  fd_gossip_vote_t vote;
-  fd_gossip_lowest_slot_global_t lowest_slot;
-  fd_gossip_slot_hashes_global_t snapshot_hashes;
-  fd_gossip_slot_hashes_global_t accounts_hashes;
-  fd_gossip_epoch_slots_global_t epoch_slots;
-  fd_gossip_version_v1_global_t version_v1;
-  fd_gossip_version_v2_global_t version_v2;
-  fd_gossip_node_instance_t node_instance;
-  fd_gossip_duplicate_shred_global_t duplicate_shred;
-  fd_gossip_incremental_snapshot_hashes_global_t incremental_snapshot_hashes;
-  fd_gossip_contact_info_v2_global_t contact_info_v2;
-  fd_gossip_restart_last_voted_fork_slots_global_t restart_last_voted_fork_slots;
-  fd_gossip_restart_heaviest_fork_t restart_heaviest_fork;
-};
-typedef union fd_crds_data_inner_global fd_crds_data_inner_global_t;
-
 struct fd_crds_data {
   uint discriminant;
   fd_crds_data_inner_t inner;
 };
 typedef struct fd_crds_data fd_crds_data_t;
 #define FD_CRDS_DATA_ALIGN alignof(fd_crds_data_t)
-struct fd_crds_data_global {
-  uint discriminant;
-  fd_crds_data_inner_global_t inner;
-};
-typedef struct fd_crds_data_global fd_crds_data_global_t;
-#define FD_CRDS_DATA_GLOBAL_ALIGN alignof(fd_crds_data_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_crds_bloom {
@@ -4128,21 +2683,6 @@ struct fd_crds_bloom {
 typedef struct fd_crds_bloom fd_crds_bloom_t;
 #define FD_CRDS_BLOOM_ALIGN alignof(fd_crds_bloom_t)
 
-struct fd_crds_bloom_global {
-  ulong keys_len;
-  ulong keys_offset;
-  uchar has_bits;
-  ulong bits_bitvec_len;
-  ulong bits_bitvec_offset;
-  ulong bits_len;
-  ulong num_bits_set;
-};
-typedef struct fd_crds_bloom_global fd_crds_bloom_global_t;
-#define FD_CRDS_BLOOM_GLOBAL_ALIGN alignof(fd_crds_bloom_global_t)
-
-FD_FN_UNUSED static ulong * fd_crds_bloom_keys_join( fd_crds_bloom_global_t * struct_mem ) { // vector
-  return (ulong *)fd_type_pun( (uchar *)struct_mem + struct_mem->keys_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_crds_filter {
   fd_crds_bloom_t filter;
@@ -4152,14 +2692,6 @@ struct fd_crds_filter {
 typedef struct fd_crds_filter fd_crds_filter_t;
 #define FD_CRDS_FILTER_ALIGN alignof(fd_crds_filter_t)
 
-struct fd_crds_filter_global {
-  fd_crds_bloom_global_t filter;
-  ulong mask;
-  uint mask_bits;
-};
-typedef struct fd_crds_filter_global fd_crds_filter_global_t;
-#define FD_CRDS_FILTER_GLOBAL_ALIGN alignof(fd_crds_filter_global_t)
-
 /* Encoded Size: Dynamic */
 struct fd_crds_value {
   fd_signature_t signature;
@@ -4168,13 +2700,6 @@ struct fd_crds_value {
 typedef struct fd_crds_value fd_crds_value_t;
 #define FD_CRDS_VALUE_ALIGN alignof(fd_crds_value_t)
 
-struct fd_crds_value_global {
-  fd_signature_t signature;
-  fd_crds_data_global_t data;
-};
-typedef struct fd_crds_value_global fd_crds_value_global_t;
-#define FD_CRDS_VALUE_GLOBAL_ALIGN alignof(fd_crds_value_global_t)
-
 /* Encoded Size: Dynamic */
 struct fd_gossip_pull_req {
   fd_crds_filter_t filter;
@@ -4182,13 +2707,6 @@ struct fd_gossip_pull_req {
 };
 typedef struct fd_gossip_pull_req fd_gossip_pull_req_t;
 #define FD_GOSSIP_PULL_REQ_ALIGN alignof(fd_gossip_pull_req_t)
-
-struct fd_gossip_pull_req_global {
-  fd_crds_filter_global_t filter;
-  fd_crds_value_global_t value;
-};
-typedef struct fd_gossip_pull_req_global fd_gossip_pull_req_global_t;
-#define FD_GOSSIP_PULL_REQ_GLOBAL_ALIGN alignof(fd_gossip_pull_req_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_gossip_pull_resp {
@@ -4199,17 +2717,6 @@ struct fd_gossip_pull_resp {
 typedef struct fd_gossip_pull_resp fd_gossip_pull_resp_t;
 #define FD_GOSSIP_PULL_RESP_ALIGN alignof(fd_gossip_pull_resp_t)
 
-struct fd_gossip_pull_resp_global {
-  fd_pubkey_t pubkey;
-  ulong crds_len;
-  ulong crds_offset;
-};
-typedef struct fd_gossip_pull_resp_global fd_gossip_pull_resp_global_t;
-#define FD_GOSSIP_PULL_RESP_GLOBAL_ALIGN alignof(fd_gossip_pull_resp_global_t)
-
-FD_FN_UNUSED static fd_crds_value_global_t * fd_gossip_pull_resp_crds_join( fd_gossip_pull_resp_global_t * struct_mem ) { // vector
-  return (fd_crds_value_global_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->crds_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_gossip_push_msg {
   fd_pubkey_t pubkey;
@@ -4219,17 +2726,6 @@ struct fd_gossip_push_msg {
 typedef struct fd_gossip_push_msg fd_gossip_push_msg_t;
 #define FD_GOSSIP_PUSH_MSG_ALIGN alignof(fd_gossip_push_msg_t)
 
-struct fd_gossip_push_msg_global {
-  fd_pubkey_t pubkey;
-  ulong crds_len;
-  ulong crds_offset;
-};
-typedef struct fd_gossip_push_msg_global fd_gossip_push_msg_global_t;
-#define FD_GOSSIP_PUSH_MSG_GLOBAL_ALIGN alignof(fd_gossip_push_msg_global_t)
-
-FD_FN_UNUSED static fd_crds_value_global_t * fd_gossip_push_msg_crds_join( fd_gossip_push_msg_global_t * struct_mem ) { // vector
-  return (fd_crds_value_global_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->crds_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_gossip_prune_msg {
   fd_pubkey_t pubkey;
@@ -4237,13 +2733,6 @@ struct fd_gossip_prune_msg {
 };
 typedef struct fd_gossip_prune_msg fd_gossip_prune_msg_t;
 #define FD_GOSSIP_PRUNE_MSG_ALIGN alignof(fd_gossip_prune_msg_t)
-
-struct fd_gossip_prune_msg_global {
-  fd_pubkey_t pubkey;
-  fd_gossip_prune_data_global_t data;
-};
-typedef struct fd_gossip_prune_msg_global fd_gossip_prune_msg_global_t;
-#define FD_GOSSIP_PRUNE_MSG_GLOBAL_ALIGN alignof(fd_gossip_prune_msg_global_t)
 
 union fd_gossip_msg_inner {
   fd_gossip_pull_req_t pull_req;
@@ -4255,16 +2744,6 @@ union fd_gossip_msg_inner {
 };
 typedef union fd_gossip_msg_inner fd_gossip_msg_inner_t;
 
-union fd_gossip_msg_inner_global {
-  fd_gossip_pull_req_global_t pull_req;
-  fd_gossip_pull_resp_global_t pull_resp;
-  fd_gossip_push_msg_global_t push_msg;
-  fd_gossip_prune_msg_global_t prune_msg;
-  fd_gossip_ping_t ping;
-  fd_gossip_ping_t pong;
-};
-typedef union fd_gossip_msg_inner_global fd_gossip_msg_inner_global_t;
-
 /* UDP payloads of the Solana gossip protocol */
 struct fd_gossip_msg {
   uint discriminant;
@@ -4272,12 +2751,6 @@ struct fd_gossip_msg {
 };
 typedef struct fd_gossip_msg fd_gossip_msg_t;
 #define FD_GOSSIP_MSG_ALIGN alignof(fd_gossip_msg_t)
-struct fd_gossip_msg_global {
-  uint discriminant;
-  fd_gossip_msg_inner_global_t inner;
-};
-typedef struct fd_gossip_msg_global fd_gossip_msg_global_t;
-#define FD_GOSSIP_MSG_GLOBAL_ALIGN alignof(fd_gossip_msg_global_t)
 
 /* Encoded Size: Fixed (9 bytes) */
 struct fd_addrlut_create {
@@ -4295,27 +2768,11 @@ struct fd_addrlut_extend {
 typedef struct fd_addrlut_extend fd_addrlut_extend_t;
 #define FD_ADDRLUT_EXTEND_ALIGN alignof(fd_addrlut_extend_t)
 
-struct fd_addrlut_extend_global {
-  ulong new_addrs_len;
-  ulong new_addrs_offset;
-};
-typedef struct fd_addrlut_extend_global fd_addrlut_extend_global_t;
-#define FD_ADDRLUT_EXTEND_GLOBAL_ALIGN alignof(fd_addrlut_extend_global_t)
-
-FD_FN_UNUSED static fd_pubkey_t * fd_addrlut_extend_new_addrs_join( fd_addrlut_extend_global_t * struct_mem ) { // vector
-  return (fd_pubkey_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->new_addrs_offset );
-}
 union fd_addrlut_instruction_inner {
   fd_addrlut_create_t create_lut;
   fd_addrlut_extend_t extend_lut;
 };
 typedef union fd_addrlut_instruction_inner fd_addrlut_instruction_inner_t;
-
-union fd_addrlut_instruction_inner_global {
-  fd_addrlut_create_t create_lut;
-  fd_addrlut_extend_global_t extend_lut;
-};
-typedef union fd_addrlut_instruction_inner_global fd_addrlut_instruction_inner_global_t;
 
 /* https://github.com/solana-labs/solana/blob/fb80288f885a62bcd923f4c9579fd0edeafaff9b/sdk/program/src/address_lookup_table/instruction.rs#L13 */
 struct fd_addrlut_instruction {
@@ -4324,12 +2781,6 @@ struct fd_addrlut_instruction {
 };
 typedef struct fd_addrlut_instruction fd_addrlut_instruction_t;
 #define FD_ADDRLUT_INSTRUCTION_ALIGN alignof(fd_addrlut_instruction_t)
-struct fd_addrlut_instruction_global {
-  uint discriminant;
-  fd_addrlut_instruction_inner_global_t inner;
-};
-typedef struct fd_addrlut_instruction_global fd_addrlut_instruction_global_t;
-#define FD_ADDRLUT_INSTRUCTION_GLOBAL_ALIGN alignof(fd_addrlut_instruction_global_t)
 
 /* https://github.com/anza-xyz/agave/blob/v2.2.7/core/src/repair/serve_repair.rs#L204-L210 */
 /* Encoded Size: Fixed (140 bytes) */
@@ -4392,7 +2843,6 @@ struct fd_repair_protocol {
 };
 typedef struct fd_repair_protocol fd_repair_protocol_t;
 #define FD_REPAIR_PROTOCOL_ALIGN alignof(fd_repair_protocol_t)
-#define FD_REPAIR_PROTOCOL_GLOBAL_ALIGN alignof(fd_repair_protocol_global_t)
 
 union fd_repair_response_inner {
   fd_gossip_ping_t ping;
@@ -4405,7 +2855,6 @@ struct fd_repair_response {
 };
 typedef struct fd_repair_response fd_repair_response_t;
 #define FD_REPAIR_RESPONSE_ALIGN alignof(fd_repair_response_t)
-#define FD_REPAIR_RESPONSE_GLOBAL_ALIGN alignof(fd_repair_response_global_t)
 
 union fd_instr_error_enum_inner {
   uint custom;
@@ -4413,24 +2862,12 @@ union fd_instr_error_enum_inner {
 };
 typedef union fd_instr_error_enum_inner fd_instr_error_enum_inner_t;
 
-union fd_instr_error_enum_inner_global {
-  uint custom;
-  char* borsh_io_error;
-};
-typedef union fd_instr_error_enum_inner_global fd_instr_error_enum_inner_global_t;
-
 struct fd_instr_error_enum {
   uint discriminant;
   fd_instr_error_enum_inner_t inner;
 };
 typedef struct fd_instr_error_enum fd_instr_error_enum_t;
 #define FD_INSTR_ERROR_ENUM_ALIGN alignof(fd_instr_error_enum_t)
-struct fd_instr_error_enum_global {
-  uint discriminant;
-  fd_instr_error_enum_inner_global_t inner;
-};
-typedef struct fd_instr_error_enum_global fd_instr_error_enum_global_t;
-#define FD_INSTR_ERROR_ENUM_GLOBAL_ALIGN alignof(fd_instr_error_enum_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_txn_instr_error {
@@ -4440,13 +2877,6 @@ struct fd_txn_instr_error {
 typedef struct fd_txn_instr_error fd_txn_instr_error_t;
 #define FD_TXN_INSTR_ERROR_ALIGN alignof(fd_txn_instr_error_t)
 
-struct fd_txn_instr_error_global {
-  uchar instr_idx;
-  fd_instr_error_enum_global_t error;
-};
-typedef struct fd_txn_instr_error_global fd_txn_instr_error_global_t;
-#define FD_TXN_INSTR_ERROR_GLOBAL_ALIGN alignof(fd_txn_instr_error_global_t)
-
 union fd_txn_error_enum_inner {
   fd_txn_instr_error_t instruction_error;
   uchar duplicate_instruction;
@@ -4455,36 +2885,17 @@ union fd_txn_error_enum_inner {
 };
 typedef union fd_txn_error_enum_inner fd_txn_error_enum_inner_t;
 
-union fd_txn_error_enum_inner_global {
-  fd_txn_instr_error_global_t instruction_error;
-  uchar duplicate_instruction;
-  uchar insufficient_funds_for_rent;
-  uchar program_execution_temporarily_restricted;
-};
-typedef union fd_txn_error_enum_inner_global fd_txn_error_enum_inner_global_t;
-
 struct fd_txn_error_enum {
   uint discriminant;
   fd_txn_error_enum_inner_t inner;
 };
 typedef struct fd_txn_error_enum fd_txn_error_enum_t;
 #define FD_TXN_ERROR_ENUM_ALIGN alignof(fd_txn_error_enum_t)
-struct fd_txn_error_enum_global {
-  uint discriminant;
-  fd_txn_error_enum_inner_global_t inner;
-};
-typedef struct fd_txn_error_enum_global fd_txn_error_enum_global_t;
-#define FD_TXN_ERROR_ENUM_GLOBAL_ALIGN alignof(fd_txn_error_enum_global_t)
 
 union fd_txn_result_inner {
   fd_txn_error_enum_t error;
 };
 typedef union fd_txn_result_inner fd_txn_result_inner_t;
-
-union fd_txn_result_inner_global {
-  fd_txn_error_enum_global_t error;
-};
-typedef union fd_txn_result_inner_global fd_txn_result_inner_global_t;
 
 struct fd_txn_result {
   uint discriminant;
@@ -4492,12 +2903,6 @@ struct fd_txn_result {
 };
 typedef struct fd_txn_result fd_txn_result_t;
 #define FD_TXN_RESULT_ALIGN alignof(fd_txn_result_t)
-struct fd_txn_result_global {
-  uint discriminant;
-  fd_txn_result_inner_global_t inner;
-};
-typedef struct fd_txn_result_global fd_txn_result_global_t;
-#define FD_TXN_RESULT_GLOBAL_ALIGN alignof(fd_txn_result_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_cache_status {
@@ -4506,13 +2911,6 @@ struct fd_cache_status {
 };
 typedef struct fd_cache_status fd_cache_status_t;
 #define FD_CACHE_STATUS_ALIGN alignof(fd_cache_status_t)
-
-struct fd_cache_status_global {
-  uchar key_slice[20];
-  fd_txn_result_global_t result;
-};
-typedef struct fd_cache_status_global fd_cache_status_global_t;
-#define FD_CACHE_STATUS_GLOBAL_ALIGN alignof(fd_cache_status_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_status_value {
@@ -4523,17 +2921,6 @@ struct fd_status_value {
 typedef struct fd_status_value fd_status_value_t;
 #define FD_STATUS_VALUE_ALIGN alignof(fd_status_value_t)
 
-struct fd_status_value_global {
-  ulong txn_idx;
-  ulong statuses_len;
-  ulong statuses_offset;
-};
-typedef struct fd_status_value_global fd_status_value_global_t;
-#define FD_STATUS_VALUE_GLOBAL_ALIGN alignof(fd_status_value_global_t)
-
-FD_FN_UNUSED static fd_cache_status_global_t * fd_status_value_statuses_join( fd_status_value_global_t * struct_mem ) { // vector
-  return (fd_cache_status_global_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->statuses_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_status_pair {
   fd_hash_t hash;
@@ -4541,13 +2928,6 @@ struct fd_status_pair {
 };
 typedef struct fd_status_pair fd_status_pair_t;
 #define FD_STATUS_PAIR_ALIGN alignof(fd_status_pair_t)
-
-struct fd_status_pair_global {
-  fd_hash_t hash;
-  fd_status_value_global_t value;
-};
-typedef struct fd_status_pair_global fd_status_pair_global_t;
-#define FD_STATUS_PAIR_GLOBAL_ALIGN alignof(fd_status_pair_global_t)
 
 /* Encoded Size: Dynamic */
 struct fd_slot_delta {
@@ -4559,18 +2939,6 @@ struct fd_slot_delta {
 typedef struct fd_slot_delta fd_slot_delta_t;
 #define FD_SLOT_DELTA_ALIGN alignof(fd_slot_delta_t)
 
-struct fd_slot_delta_global {
-  ulong slot;
-  uchar is_root;
-  ulong slot_delta_vec_len;
-  ulong slot_delta_vec_offset;
-};
-typedef struct fd_slot_delta_global fd_slot_delta_global_t;
-#define FD_SLOT_DELTA_GLOBAL_ALIGN alignof(fd_slot_delta_global_t)
-
-FD_FN_UNUSED static fd_status_pair_global_t * fd_slot_delta_slot_delta_vec_join( fd_slot_delta_global_t * struct_mem ) { // vector
-  return (fd_status_pair_global_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->slot_delta_vec_offset );
-}
 /* Encoded Size: Dynamic */
 struct fd_bank_slot_deltas {
   ulong slot_deltas_len;
@@ -4579,16 +2947,6 @@ struct fd_bank_slot_deltas {
 typedef struct fd_bank_slot_deltas fd_bank_slot_deltas_t;
 #define FD_BANK_SLOT_DELTAS_ALIGN alignof(fd_bank_slot_deltas_t)
 
-struct fd_bank_slot_deltas_global {
-  ulong slot_deltas_len;
-  ulong slot_deltas_offset;
-};
-typedef struct fd_bank_slot_deltas_global fd_bank_slot_deltas_global_t;
-#define FD_BANK_SLOT_DELTAS_GLOBAL_ALIGN alignof(fd_bank_slot_deltas_global_t)
-
-FD_FN_UNUSED static fd_slot_delta_global_t * fd_bank_slot_deltas_slot_deltas_join( fd_bank_slot_deltas_global_t * struct_mem ) { // vector
-  return (fd_slot_delta_global_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->slot_deltas_offset );
-}
 /* https://github.com/anza-xyz/agave/blob/7117ed9653ce19e8b2dea108eff1f3eb6a3378a7/runtime/src/bank/partitioned_epoch_rewards/mod.rs#L85 */
 /* Encoded Size: Fixed (60 bytes) */
 struct fd_pubkey_rewardinfo_pair {
@@ -4604,12 +2962,6 @@ struct fd_optional_account {
 };
 typedef struct fd_optional_account fd_optional_account_t;
 #define FD_OPTIONAL_ACCOUNT_ALIGN alignof(fd_optional_account_t)
-
-struct fd_optional_account_global {
-  ulong account_offset;
-};
-typedef struct fd_optional_account_global fd_optional_account_global_t;
-#define FD_OPTIONAL_ACCOUNT_GLOBAL_ALIGN alignof(fd_optional_account_global_t)
 
 /* https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/programs/stake/src/points.rs#L27 */
 /* Encoded Size: Fixed (25 bytes) */
@@ -4642,21 +2994,6 @@ struct fd_duplicate_slot_proof {
 typedef struct fd_duplicate_slot_proof fd_duplicate_slot_proof_t;
 #define FD_DUPLICATE_SLOT_PROOF_ALIGN alignof(fd_duplicate_slot_proof_t)
 
-struct fd_duplicate_slot_proof_global {
-  ulong shred1_len;
-  ulong shred1_offset;
-  ulong shred2_len;
-  ulong shred2_offset;
-};
-typedef struct fd_duplicate_slot_proof_global fd_duplicate_slot_proof_global_t;
-#define FD_DUPLICATE_SLOT_PROOF_GLOBAL_ALIGN alignof(fd_duplicate_slot_proof_global_t)
-
-FD_FN_UNUSED static uchar * fd_duplicate_slot_proof_shred1_join( fd_duplicate_slot_proof_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->shred1_offset );
-}
-FD_FN_UNUSED static uchar * fd_duplicate_slot_proof_shred2_join( fd_duplicate_slot_proof_global_t * struct_mem ) { // vector
-  return (uchar *)fd_type_pun( (uchar *)struct_mem + struct_mem->shred2_offset );
-}
 /* Encoded Size: Fixed (104 bytes) */
 struct fd_epoch_info_pair {
   fd_pubkey_t account;
@@ -4672,13 +3009,6 @@ struct fd_vote_info_pair {
 };
 typedef struct fd_vote_info_pair fd_vote_info_pair_t;
 #define FD_VOTE_INFO_PAIR_ALIGN alignof(fd_vote_info_pair_t)
-
-struct fd_vote_info_pair_global {
-  fd_pubkey_t account;
-  fd_vote_state_versioned_global_t state;
-};
-typedef struct fd_vote_info_pair_global fd_vote_info_pair_global_t;
-#define FD_VOTE_INFO_PAIR_GLOBAL_ALIGN alignof(fd_vote_info_pair_global_t)
 
 typedef struct fd_vote_info_pair_t_mapnode fd_vote_info_pair_t_mapnode_t;
 #define REDBLK_T fd_vote_info_pair_t_mapnode_t
@@ -4700,26 +3030,6 @@ fd_vote_info_pair_t_map_join_new( void * * alloc_mem, ulong len ) {
   *alloc_mem = (uchar *)*alloc_mem + fd_vote_info_pair_t_map_footprint( len );
   return fd_vote_info_pair_t_map_join( fd_vote_info_pair_t_map_new( map_mem, len ) );
 }
-typedef struct fd_vote_info_pair_global_t_mapnode fd_vote_info_pair_global_t_mapnode_t;
-#define REDBLK_T fd_vote_info_pair_global_t_mapnode_t
-#define REDBLK_NAME fd_vote_info_pair_global_t_map
-#define REDBLK_IMPL_STYLE 1
-#include "../../util/tmpl/fd_redblack.c"
-struct fd_vote_info_pair_global_t_mapnode {
-    fd_vote_info_pair_global_t elem;
-    ulong redblack_parent;
-    ulong redblack_left;
-    ulong redblack_right;
-    int redblack_color;
-};
-static inline fd_vote_info_pair_global_t_mapnode_t *
-fd_vote_info_pair_global_t_map_join_new( void * * alloc_mem, ulong len ) {
-  if( FD_UNLIKELY( 0 == len ) ) len = 1; // prevent underflow
-  *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, fd_vote_info_pair_global_t_map_align() );
-  void * map_mem = *alloc_mem;
-  *alloc_mem = (uchar *)*alloc_mem + fd_vote_info_pair_global_t_map_footprint( len );
-  return fd_vote_info_pair_global_t_map_join( fd_vote_info_pair_global_t_map_new( map_mem, len ) );
-}
 /* Encoded Size: Dynamic */
 struct fd_epoch_info {
   ulong stake_infos_len;
@@ -4731,25 +3041,6 @@ struct fd_epoch_info {
 typedef struct fd_epoch_info fd_epoch_info_t;
 #define FD_EPOCH_INFO_ALIGN alignof(fd_epoch_info_t)
 
-struct fd_epoch_info_global {
-  ulong stake_infos_len;
-  ulong stake_infos_offset;
-  ulong vote_states_pool_offset;
-  ulong vote_states_root_offset;
-  ulong stake_infos_new_keys_start_idx;
-};
-typedef struct fd_epoch_info_global fd_epoch_info_global_t;
-#define FD_EPOCH_INFO_GLOBAL_ALIGN alignof(fd_epoch_info_global_t)
-
-FD_FN_UNUSED static fd_epoch_info_pair_t * fd_epoch_info_stake_infos_join( fd_epoch_info_global_t * struct_mem ) { // vector
-  return (fd_epoch_info_pair_t *)fd_type_pun( (uchar *)struct_mem + struct_mem->stake_infos_offset );
-}
-static FD_FN_UNUSED fd_vote_info_pair_global_t_mapnode_t * fd_epoch_info_vote_states_pool_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_vote_info_pair_global_t_mapnode_t *)fd_vote_info_pair_global_t_map_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
-static FD_FN_UNUSED fd_vote_info_pair_global_t_mapnode_t * fd_epoch_info_vote_states_root_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_vote_info_pair_global_t_mapnode_t *)fd_type_pun( (uchar *)struct_mem + offset );
-}
 /* https://github.com/anza-xyz/agave/blob/v2.2.0/cost-model/src/transaction_cost.rs#L153-L161 */
 /* Encoded Size: Fixed (48 bytes) */
 struct fd_usage_cost_details {
@@ -4775,7 +3066,6 @@ struct fd_transaction_cost {
 };
 typedef struct fd_transaction_cost fd_transaction_cost_t;
 #define FD_TRANSACTION_COST_ALIGN alignof(fd_transaction_cost_t)
-#define FD_TRANSACTION_COST_GLOBAL_ALIGN alignof(fd_transaction_cost_global_t)
 
 /* Encoded Size: Fixed (40 bytes) */
 struct fd_account_costs_pair {
@@ -4813,19 +3103,6 @@ struct fd_account_costs {
 typedef struct fd_account_costs fd_account_costs_t;
 #define FD_ACCOUNT_COSTS_ALIGN alignof(fd_account_costs_t)
 
-struct fd_account_costs_global {
-  ulong account_costs_pool_offset;
-  ulong account_costs_root_offset;
-};
-typedef struct fd_account_costs_global fd_account_costs_global_t;
-#define FD_ACCOUNT_COSTS_GLOBAL_ALIGN alignof(fd_account_costs_global_t)
-
-static FD_FN_UNUSED fd_account_costs_pair_t_mapnode_t * fd_account_costs_account_costs_pool_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_account_costs_pair_t_mapnode_t *)fd_account_costs_pair_t_map_join( fd_type_pun( (uchar *)struct_mem + offset ) );
-}
-static FD_FN_UNUSED fd_account_costs_pair_t_mapnode_t * fd_account_costs_account_costs_root_join( void * struct_mem, ulong offset ) { // deque
-  return (fd_account_costs_pair_t_mapnode_t *)fd_type_pun( (uchar *)struct_mem + offset );
-}
 /* https://github.com/anza-xyz/agave/blob/v2.2.0/cost-model/src/cost_tracker.rs#L62-L79 */
 /* Encoded Size: Dynamic */
 struct fd_cost_tracker {
@@ -4844,23 +3121,6 @@ struct fd_cost_tracker {
 };
 typedef struct fd_cost_tracker fd_cost_tracker_t;
 #define FD_COST_TRACKER_ALIGN alignof(fd_cost_tracker_t)
-
-struct fd_cost_tracker_global {
-  ulong account_cost_limit;
-  ulong block_cost_limit;
-  ulong vote_cost_limit;
-  fd_account_costs_global_t cost_by_writable_accounts;
-  ulong block_cost;
-  ulong vote_cost;
-  ulong transaction_count;
-  ulong allocated_accounts_data_size;
-  ulong transaction_signature_count;
-  ulong secp256k1_instruction_signature_count;
-  ulong ed25519_instruction_signature_count;
-  ulong secp256r1_instruction_signature_count;
-};
-typedef struct fd_cost_tracker_global fd_cost_tracker_global_t;
-#define FD_COST_TRACKER_GLOBAL_ALIGN alignof(fd_cost_tracker_global_t)
 
 
 FD_PROTOTYPES_BEGIN
@@ -4904,8 +3164,6 @@ ulong fd_feature_size( fd_feature_t const * self );
 static inline ulong fd_feature_align( void ) { return FD_FEATURE_ALIGN; }
 int fd_feature_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_feature_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_feature_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_feature_encode_global( fd_feature_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_fee_calculator_new( fd_fee_calculator_t * self ) { fd_memset( self, 0, sizeof(fd_fee_calculator_t) ); }
 int fd_fee_calculator_encode( fd_fee_calculator_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -4950,8 +3208,6 @@ ulong fd_block_hash_vec_size( fd_block_hash_vec_t const * self );
 static inline ulong fd_block_hash_vec_align( void ) { return FD_BLOCK_HASH_VEC_ALIGN; }
 int fd_block_hash_vec_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_block_hash_vec_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_block_hash_vec_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_block_hash_vec_encode_global( fd_block_hash_vec_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_block_hash_queue_new( fd_block_hash_queue_t * self );
 int fd_block_hash_queue_encode( fd_block_hash_queue_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -4960,8 +3216,6 @@ ulong fd_block_hash_queue_size( fd_block_hash_queue_t const * self );
 static inline ulong fd_block_hash_queue_align( void ) { return FD_BLOCK_HASH_QUEUE_ALIGN; }
 int fd_block_hash_queue_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_block_hash_queue_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_block_hash_queue_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_block_hash_queue_encode_global( fd_block_hash_queue_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_fee_rate_governor_new( fd_fee_rate_governor_t * self ) { fd_memset( self, 0, sizeof(fd_fee_rate_governor_t) ); }
 int fd_fee_rate_governor_encode( fd_fee_rate_governor_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -4994,8 +3248,6 @@ ulong fd_hard_forks_size( fd_hard_forks_t const * self );
 static inline ulong fd_hard_forks_align( void ) { return FD_HARD_FORKS_ALIGN; }
 int fd_hard_forks_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_hard_forks_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_hard_forks_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_hard_forks_encode_global( fd_hard_forks_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_inflation_new( fd_inflation_t * self ) { fd_memset( self, 0, sizeof(fd_inflation_t) ); }
 int fd_inflation_encode( fd_inflation_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5076,8 +3328,6 @@ ulong fd_solana_account_size( fd_solana_account_t const * self );
 static inline ulong fd_solana_account_align( void ) { return FD_SOLANA_ACCOUNT_ALIGN; }
 int fd_solana_account_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_solana_account_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_solana_account_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_solana_account_encode_global( fd_solana_account_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_accounts_pair_new( fd_vote_accounts_pair_t * self );
 int fd_vote_accounts_pair_encode( fd_vote_accounts_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5086,8 +3336,6 @@ ulong fd_vote_accounts_pair_size( fd_vote_accounts_pair_t const * self );
 static inline ulong fd_vote_accounts_pair_align( void ) { return FD_VOTE_ACCOUNTS_PAIR_ALIGN; }
 int fd_vote_accounts_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_accounts_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_accounts_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_accounts_pair_encode_global( fd_vote_accounts_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_accounts_new( fd_vote_accounts_t * self );
 int fd_vote_accounts_encode( fd_vote_accounts_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5096,8 +3344,6 @@ ulong fd_vote_accounts_size( fd_vote_accounts_t const * self );
 static inline ulong fd_vote_accounts_align( void ) { return FD_VOTE_ACCOUNTS_ALIGN; }
 int fd_vote_accounts_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_accounts_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_accounts_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_accounts_encode_global( fd_vote_accounts_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_account_keys_pair_new( fd_account_keys_pair_t * self ) { fd_memset( self, 0, sizeof(fd_account_keys_pair_t) ); }
 int fd_account_keys_pair_encode( fd_account_keys_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5118,8 +3364,6 @@ ulong fd_account_keys_size( fd_account_keys_t const * self );
 static inline ulong fd_account_keys_align( void ) { return FD_ACCOUNT_KEYS_ALIGN; }
 int fd_account_keys_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_account_keys_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_account_keys_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_account_keys_encode_global( fd_account_keys_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_stake_weight_new( fd_stake_weight_t * self ) { fd_memset( self, 0, sizeof(fd_stake_weight_t) ); }
 int fd_stake_weight_encode( fd_stake_weight_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5140,8 +3384,6 @@ ulong fd_stake_weights_size( fd_stake_weights_t const * self );
 static inline ulong fd_stake_weights_align( void ) { return FD_STAKE_WEIGHTS_ALIGN; }
 int fd_stake_weights_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_weights_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_weights_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_weights_encode_global( fd_stake_weights_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_delegation_new( fd_delegation_t * self ) { fd_memset( self, 0, sizeof(fd_delegation_t) ); }
 int fd_delegation_encode( fd_delegation_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5198,8 +3440,6 @@ ulong fd_stakes_size( fd_stakes_t const * self );
 static inline ulong fd_stakes_align( void ) { return FD_STAKES_ALIGN; }
 int fd_stakes_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stakes_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stakes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stakes_encode_global( fd_stakes_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_stakes_stake_new( fd_stakes_stake_t * self );
 int fd_stakes_stake_encode( fd_stakes_stake_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5208,8 +3448,6 @@ ulong fd_stakes_stake_size( fd_stakes_stake_t const * self );
 static inline ulong fd_stakes_stake_align( void ) { return FD_STAKES_STAKE_ALIGN; }
 int fd_stakes_stake_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stakes_stake_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stakes_stake_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stakes_stake_encode_global( fd_stakes_stake_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_bank_incremental_snapshot_persistence_new( fd_bank_incremental_snapshot_persistence_t * self ) { fd_memset( self, 0, sizeof(fd_bank_incremental_snapshot_persistence_t) ); }
 int fd_bank_incremental_snapshot_persistence_encode( fd_bank_incremental_snapshot_persistence_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5230,8 +3468,6 @@ ulong fd_node_vote_accounts_size( fd_node_vote_accounts_t const * self );
 static inline ulong fd_node_vote_accounts_align( void ) { return FD_NODE_VOTE_ACCOUNTS_ALIGN; }
 int fd_node_vote_accounts_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_node_vote_accounts_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_node_vote_accounts_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_node_vote_accounts_encode_global( fd_node_vote_accounts_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_pubkey_node_vote_accounts_pair_new( fd_pubkey_node_vote_accounts_pair_t * self );
 int fd_pubkey_node_vote_accounts_pair_encode( fd_pubkey_node_vote_accounts_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5240,8 +3476,6 @@ ulong fd_pubkey_node_vote_accounts_pair_size( fd_pubkey_node_vote_accounts_pair_
 static inline ulong fd_pubkey_node_vote_accounts_pair_align( void ) { return FD_PUBKEY_NODE_VOTE_ACCOUNTS_PAIR_ALIGN; }
 int fd_pubkey_node_vote_accounts_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_pubkey_node_vote_accounts_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_pubkey_node_vote_accounts_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_pubkey_node_vote_accounts_pair_encode_global( fd_pubkey_node_vote_accounts_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_pubkey_pubkey_pair_new( fd_pubkey_pubkey_pair_t * self ) { fd_memset( self, 0, sizeof(fd_pubkey_pubkey_pair_t) ); }
 int fd_pubkey_pubkey_pair_encode( fd_pubkey_pubkey_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5262,8 +3496,6 @@ ulong fd_epoch_stakes_size( fd_epoch_stakes_t const * self );
 static inline ulong fd_epoch_stakes_align( void ) { return FD_EPOCH_STAKES_ALIGN; }
 int fd_epoch_stakes_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_epoch_stakes_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_epoch_stakes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_stakes_encode_global( fd_epoch_stakes_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_epoch_epoch_stakes_pair_new( fd_epoch_epoch_stakes_pair_t * self );
 int fd_epoch_epoch_stakes_pair_encode( fd_epoch_epoch_stakes_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5272,8 +3504,6 @@ ulong fd_epoch_epoch_stakes_pair_size( fd_epoch_epoch_stakes_pair_t const * self
 static inline ulong fd_epoch_epoch_stakes_pair_align( void ) { return FD_EPOCH_EPOCH_STAKES_PAIR_ALIGN; }
 int fd_epoch_epoch_stakes_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_epoch_epoch_stakes_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_epoch_epoch_stakes_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_epoch_stakes_pair_encode_global( fd_epoch_epoch_stakes_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_pubkey_u64_pair_new( fd_pubkey_u64_pair_t * self ) { fd_memset( self, 0, sizeof(fd_pubkey_u64_pair_t) ); }
 int fd_pubkey_u64_pair_encode( fd_pubkey_u64_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5294,8 +3524,6 @@ ulong fd_unused_accounts_size( fd_unused_accounts_t const * self );
 static inline ulong fd_unused_accounts_align( void ) { return FD_UNUSED_ACCOUNTS_ALIGN; }
 int fd_unused_accounts_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_unused_accounts_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_unused_accounts_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_unused_accounts_encode_global( fd_unused_accounts_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_versioned_bank_new( fd_versioned_bank_t * self );
 int fd_versioned_bank_encode( fd_versioned_bank_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5304,8 +3532,6 @@ ulong fd_versioned_bank_size( fd_versioned_bank_t const * self );
 static inline ulong fd_versioned_bank_align( void ) { return FD_VERSIONED_BANK_ALIGN; }
 int fd_versioned_bank_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_versioned_bank_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_versioned_bank_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_versioned_bank_encode_global( fd_versioned_bank_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_bank_hash_stats_new( fd_bank_hash_stats_t * self ) { fd_memset( self, 0, sizeof(fd_bank_hash_stats_t) ); }
 int fd_bank_hash_stats_encode( fd_bank_hash_stats_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5362,8 +3588,6 @@ ulong fd_snapshot_slot_acc_vecs_size( fd_snapshot_slot_acc_vecs_t const * self )
 static inline ulong fd_snapshot_slot_acc_vecs_align( void ) { return FD_SNAPSHOT_SLOT_ACC_VECS_ALIGN; }
 int fd_snapshot_slot_acc_vecs_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_snapshot_slot_acc_vecs_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_snapshot_slot_acc_vecs_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_snapshot_slot_acc_vecs_encode_global( fd_snapshot_slot_acc_vecs_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_reward_type_new_disc( fd_reward_type_t * self, uint discriminant ) { self->discriminant = discriminant; }
 static inline void fd_reward_type_new( fd_reward_type_t * self ) { self->discriminant = (uint)ULONG_MAX; }
@@ -5391,8 +3615,6 @@ ulong fd_solana_accounts_db_fields_size( fd_solana_accounts_db_fields_t const * 
 static inline ulong fd_solana_accounts_db_fields_align( void ) { return FD_SOLANA_ACCOUNTS_DB_FIELDS_ALIGN; }
 int fd_solana_accounts_db_fields_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_solana_accounts_db_fields_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_solana_accounts_db_fields_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_solana_accounts_db_fields_encode_global( fd_solana_accounts_db_fields_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_versioned_epoch_stakes_current_new( fd_versioned_epoch_stakes_current_t * self );
 int fd_versioned_epoch_stakes_current_encode( fd_versioned_epoch_stakes_current_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5401,8 +3623,6 @@ ulong fd_versioned_epoch_stakes_current_size( fd_versioned_epoch_stakes_current_
 static inline ulong fd_versioned_epoch_stakes_current_align( void ) { return FD_VERSIONED_EPOCH_STAKES_CURRENT_ALIGN; }
 int fd_versioned_epoch_stakes_current_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_versioned_epoch_stakes_current_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_versioned_epoch_stakes_current_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_versioned_epoch_stakes_current_encode_global( fd_versioned_epoch_stakes_current_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_versioned_epoch_stakes_new_disc( fd_versioned_epoch_stakes_t * self, uint discriminant );
 void fd_versioned_epoch_stakes_new( fd_versioned_epoch_stakes_t * self );
@@ -5412,8 +3632,6 @@ ulong fd_versioned_epoch_stakes_size( fd_versioned_epoch_stakes_t const * self )
 static inline ulong fd_versioned_epoch_stakes_align( void ) { return FD_VERSIONED_EPOCH_STAKES_ALIGN; }
 int fd_versioned_epoch_stakes_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_versioned_epoch_stakes_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_versioned_epoch_stakes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_versioned_epoch_stakes_encode_global( fd_versioned_epoch_stakes_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_versioned_epoch_stakes_is_Current( fd_versioned_epoch_stakes_t const * self );
 enum {
@@ -5426,8 +3644,6 @@ ulong fd_versioned_epoch_stakes_pair_size( fd_versioned_epoch_stakes_pair_t cons
 static inline ulong fd_versioned_epoch_stakes_pair_align( void ) { return FD_VERSIONED_EPOCH_STAKES_PAIR_ALIGN; }
 int fd_versioned_epoch_stakes_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_versioned_epoch_stakes_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_versioned_epoch_stakes_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_versioned_epoch_stakes_pair_encode_global( fd_versioned_epoch_stakes_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_reward_info_new( fd_reward_info_t * self );
 int fd_reward_info_encode( fd_reward_info_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5456,8 +3672,6 @@ ulong fd_solana_manifest_size( fd_solana_manifest_t const * self );
 static inline ulong fd_solana_manifest_align( void ) { return FD_SOLANA_MANIFEST_ALIGN; }
 int fd_solana_manifest_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_solana_manifest_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_solana_manifest_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_solana_manifest_encode_global( fd_solana_manifest_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_rust_duration_new( fd_rust_duration_t * self ) { fd_memset( self, 0, sizeof(fd_rust_duration_t) ); }
 int fd_rust_duration_encode( fd_rust_duration_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5478,8 +3692,6 @@ ulong fd_poh_config_size( fd_poh_config_t const * self );
 static inline ulong fd_poh_config_align( void ) { return FD_POH_CONFIG_ALIGN; }
 int fd_poh_config_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_poh_config_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_poh_config_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_poh_config_encode_global( fd_poh_config_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_string_pubkey_pair_new( fd_string_pubkey_pair_t * self );
 int fd_string_pubkey_pair_encode( fd_string_pubkey_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5488,8 +3700,6 @@ ulong fd_string_pubkey_pair_size( fd_string_pubkey_pair_t const * self );
 static inline ulong fd_string_pubkey_pair_align( void ) { return FD_STRING_PUBKEY_PAIR_ALIGN; }
 int fd_string_pubkey_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_string_pubkey_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_string_pubkey_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_string_pubkey_pair_encode_global( fd_string_pubkey_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_pubkey_account_pair_new( fd_pubkey_account_pair_t * self );
 int fd_pubkey_account_pair_encode( fd_pubkey_account_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5498,8 +3708,6 @@ ulong fd_pubkey_account_pair_size( fd_pubkey_account_pair_t const * self );
 static inline ulong fd_pubkey_account_pair_align( void ) { return FD_PUBKEY_ACCOUNT_PAIR_ALIGN; }
 int fd_pubkey_account_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_pubkey_account_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_pubkey_account_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_pubkey_account_pair_encode_global( fd_pubkey_account_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_genesis_solana_new( fd_genesis_solana_t * self );
 int fd_genesis_solana_encode( fd_genesis_solana_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5508,8 +3716,6 @@ ulong fd_genesis_solana_size( fd_genesis_solana_t const * self );
 static inline ulong fd_genesis_solana_align( void ) { return FD_GENESIS_SOLANA_ALIGN; }
 int fd_genesis_solana_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_genesis_solana_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_genesis_solana_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_genesis_solana_encode_global( fd_genesis_solana_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_sol_sysvar_clock_new( fd_sol_sysvar_clock_t * self ) { fd_memset( self, 0, sizeof(fd_sol_sysvar_clock_t) ); }
 int fd_sol_sysvar_clock_encode( fd_sol_sysvar_clock_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5654,8 +3860,6 @@ ulong fd_vote_state_0_23_5_size( fd_vote_state_0_23_5_t const * self );
 static inline ulong fd_vote_state_0_23_5_align( void ) { return FD_VOTE_STATE_0_23_5_ALIGN; }
 int fd_vote_state_0_23_5_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_state_0_23_5_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_state_0_23_5_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_state_0_23_5_encode_global( fd_vote_state_0_23_5_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_authorized_voters_new( fd_vote_authorized_voters_t * self );
 int fd_vote_authorized_voters_encode( fd_vote_authorized_voters_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5664,8 +3868,6 @@ ulong fd_vote_authorized_voters_size( fd_vote_authorized_voters_t const * self )
 static inline ulong fd_vote_authorized_voters_align( void ) { return FD_VOTE_AUTHORIZED_VOTERS_ALIGN; }
 int fd_vote_authorized_voters_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_authorized_voters_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_authorized_voters_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_authorized_voters_encode_global( fd_vote_authorized_voters_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_state_1_14_11_new( fd_vote_state_1_14_11_t * self );
 int fd_vote_state_1_14_11_encode( fd_vote_state_1_14_11_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5674,8 +3876,6 @@ ulong fd_vote_state_1_14_11_size( fd_vote_state_1_14_11_t const * self );
 static inline ulong fd_vote_state_1_14_11_align( void ) { return FD_VOTE_STATE_1_14_11_ALIGN; }
 int fd_vote_state_1_14_11_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_state_1_14_11_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_state_1_14_11_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_state_1_14_11_encode_global( fd_vote_state_1_14_11_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_state_new( fd_vote_state_t * self );
 int fd_vote_state_encode( fd_vote_state_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5684,8 +3884,6 @@ ulong fd_vote_state_size( fd_vote_state_t const * self );
 static inline ulong fd_vote_state_align( void ) { return FD_VOTE_STATE_ALIGN; }
 int fd_vote_state_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_state_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_state_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_state_encode_global( fd_vote_state_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_state_versioned_new_disc( fd_vote_state_versioned_t * self, uint discriminant );
 void fd_vote_state_versioned_new( fd_vote_state_versioned_t * self );
@@ -5695,8 +3893,6 @@ ulong fd_vote_state_versioned_size( fd_vote_state_versioned_t const * self );
 static inline ulong fd_vote_state_versioned_align( void ) { return FD_VOTE_STATE_VERSIONED_ALIGN; }
 int fd_vote_state_versioned_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_state_versioned_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_state_versioned_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_state_versioned_encode_global( fd_vote_state_versioned_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_vote_state_versioned_is_v0_23_5( fd_vote_state_versioned_t const * self );
 FD_FN_PURE uchar fd_vote_state_versioned_is_v1_14_11( fd_vote_state_versioned_t const * self );
@@ -5713,8 +3909,6 @@ ulong fd_vote_state_update_size( fd_vote_state_update_t const * self );
 static inline ulong fd_vote_state_update_align( void ) { return FD_VOTE_STATE_UPDATE_ALIGN; }
 int fd_vote_state_update_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_state_update_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_state_update_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_state_update_encode_global( fd_vote_state_update_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_compact_vote_state_update_new( fd_compact_vote_state_update_t * self );
 int fd_compact_vote_state_update_encode( fd_compact_vote_state_update_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5723,8 +3917,6 @@ ulong fd_compact_vote_state_update_size( fd_compact_vote_state_update_t const * 
 static inline ulong fd_compact_vote_state_update_align( void ) { return FD_COMPACT_VOTE_STATE_UPDATE_ALIGN; }
 int fd_compact_vote_state_update_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_compact_vote_state_update_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_compact_vote_state_update_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_compact_vote_state_update_encode_global( fd_compact_vote_state_update_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_compact_vote_state_update_switch_new( fd_compact_vote_state_update_switch_t * self );
 int fd_compact_vote_state_update_switch_encode( fd_compact_vote_state_update_switch_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5733,8 +3925,6 @@ ulong fd_compact_vote_state_update_switch_size( fd_compact_vote_state_update_swi
 static inline ulong fd_compact_vote_state_update_switch_align( void ) { return FD_COMPACT_VOTE_STATE_UPDATE_SWITCH_ALIGN; }
 int fd_compact_vote_state_update_switch_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_compact_vote_state_update_switch_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_compact_vote_state_update_switch_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_compact_vote_state_update_switch_encode_global( fd_compact_vote_state_update_switch_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_compact_tower_sync_new( fd_compact_tower_sync_t * self );
 int fd_compact_tower_sync_encode( fd_compact_tower_sync_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5743,8 +3933,6 @@ ulong fd_compact_tower_sync_size( fd_compact_tower_sync_t const * self );
 static inline ulong fd_compact_tower_sync_align( void ) { return FD_COMPACT_TOWER_SYNC_ALIGN; }
 int fd_compact_tower_sync_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_compact_tower_sync_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_compact_tower_sync_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_compact_tower_sync_encode_global( fd_compact_tower_sync_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_tower_sync_new( fd_tower_sync_t * self );
 int fd_tower_sync_encode( fd_tower_sync_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5753,8 +3941,6 @@ ulong fd_tower_sync_size( fd_tower_sync_t const * self );
 static inline ulong fd_tower_sync_align( void ) { return FD_TOWER_SYNC_ALIGN; }
 int fd_tower_sync_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_tower_sync_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_tower_sync_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_tower_sync_encode_global( fd_tower_sync_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_tower_sync_switch_new( fd_tower_sync_switch_t * self );
 int fd_tower_sync_switch_encode( fd_tower_sync_switch_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5763,8 +3949,6 @@ ulong fd_tower_sync_switch_size( fd_tower_sync_switch_t const * self );
 static inline ulong fd_tower_sync_switch_align( void ) { return FD_TOWER_SYNC_SWITCH_ALIGN; }
 int fd_tower_sync_switch_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_tower_sync_switch_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_tower_sync_switch_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_tower_sync_switch_encode_global( fd_tower_sync_switch_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_slot_history_new( fd_slot_history_t * self );
 int fd_slot_history_encode( fd_slot_history_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5827,8 +4011,6 @@ ulong fd_slot_meta_size( fd_slot_meta_t const * self );
 static inline ulong fd_slot_meta_align( void ) { return FD_SLOT_META_ALIGN; }
 int fd_slot_meta_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_slot_meta_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_slot_meta_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_slot_meta_encode_global( fd_slot_meta_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_clock_timestamp_vote_new( fd_clock_timestamp_vote_t * self ) { fd_memset( self, 0, sizeof(fd_clock_timestamp_vote_t) ); }
 int fd_clock_timestamp_vote_encode( fd_clock_timestamp_vote_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5849,8 +4031,6 @@ ulong fd_clock_timestamp_votes_size( fd_clock_timestamp_votes_t const * self );
 static inline ulong fd_clock_timestamp_votes_align( void ) { return FD_CLOCK_TIMESTAMP_VOTES_ALIGN; }
 int fd_clock_timestamp_votes_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_clock_timestamp_votes_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_clock_timestamp_votes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_clock_timestamp_votes_encode_global( fd_clock_timestamp_votes_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_sysvar_fees_new( fd_sysvar_fees_t * self ) { fd_memset( self, 0, sizeof(fd_sysvar_fees_t) ); }
 int fd_sysvar_fees_encode( fd_sysvar_fees_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5887,8 +4067,6 @@ ulong fd_stake_config_size( fd_stake_config_t const * self );
 static inline ulong fd_stake_config_align( void ) { return FD_STAKE_CONFIG_ALIGN; }
 int fd_stake_config_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_config_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_config_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_config_encode_global( fd_stake_config_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_feature_entry_new( fd_feature_entry_t * self );
 int fd_feature_entry_encode( fd_feature_entry_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5897,8 +4075,6 @@ ulong fd_feature_entry_size( fd_feature_entry_t const * self );
 static inline ulong fd_feature_entry_align( void ) { return FD_FEATURE_ENTRY_ALIGN; }
 int fd_feature_entry_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_feature_entry_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_feature_entry_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_feature_entry_encode_global( fd_feature_entry_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_firedancer_bank_new( fd_firedancer_bank_t * self );
 int fd_firedancer_bank_encode( fd_firedancer_bank_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5907,8 +4083,6 @@ ulong fd_firedancer_bank_size( fd_firedancer_bank_t const * self );
 static inline ulong fd_firedancer_bank_align( void ) { return FD_FIREDANCER_BANK_ALIGN; }
 int fd_firedancer_bank_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_firedancer_bank_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_firedancer_bank_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_firedancer_bank_encode_global( fd_firedancer_bank_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_cluster_type_new_disc( fd_cluster_type_t * self, uint discriminant ) { self->discriminant = discriminant; }
 static inline void fd_cluster_type_new( fd_cluster_type_t * self ) { self->discriminant = (uint)ULONG_MAX; }
@@ -5948,8 +4122,6 @@ ulong fd_rent_fresh_accounts_size( fd_rent_fresh_accounts_t const * self );
 static inline ulong fd_rent_fresh_accounts_align( void ) { return FD_RENT_FRESH_ACCOUNTS_ALIGN; }
 int fd_rent_fresh_accounts_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_rent_fresh_accounts_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_rent_fresh_accounts_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_rent_fresh_accounts_encode_global( fd_rent_fresh_accounts_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_epoch_bank_new( fd_epoch_bank_t * self );
 int fd_epoch_bank_encode( fd_epoch_bank_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -5958,8 +4130,6 @@ ulong fd_epoch_bank_size( fd_epoch_bank_t const * self );
 static inline ulong fd_epoch_bank_align( void ) { return FD_EPOCH_BANK_ALIGN; }
 int fd_epoch_bank_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_epoch_bank_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_epoch_bank_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_bank_encode_global( fd_epoch_bank_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_stake_reward_new( fd_stake_reward_t * self ) { fd_memset( self, 0, sizeof(fd_stake_reward_t) ); }
 int fd_stake_reward_encode( fd_stake_reward_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6004,8 +4174,6 @@ ulong fd_partitioned_stake_rewards_size( fd_partitioned_stake_rewards_t const * 
 static inline ulong fd_partitioned_stake_rewards_align( void ) { return FD_PARTITIONED_STAKE_REWARDS_ALIGN; }
 int fd_partitioned_stake_rewards_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_partitioned_stake_rewards_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_partitioned_stake_rewards_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_partitioned_stake_rewards_encode_global( fd_partitioned_stake_rewards_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_stake_reward_calculation_partitioned_new( fd_stake_reward_calculation_partitioned_t * self );
 int fd_stake_reward_calculation_partitioned_encode( fd_stake_reward_calculation_partitioned_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6014,8 +4182,6 @@ ulong fd_stake_reward_calculation_partitioned_size( fd_stake_reward_calculation_
 static inline ulong fd_stake_reward_calculation_partitioned_align( void ) { return FD_STAKE_REWARD_CALCULATION_PARTITIONED_ALIGN; }
 int fd_stake_reward_calculation_partitioned_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_reward_calculation_partitioned_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_reward_calculation_partitioned_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_reward_calculation_partitioned_encode_global( fd_stake_reward_calculation_partitioned_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_stake_reward_calculation_new( fd_stake_reward_calculation_t * self );
 int fd_stake_reward_calculation_encode( fd_stake_reward_calculation_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6024,8 +4190,6 @@ ulong fd_stake_reward_calculation_size( fd_stake_reward_calculation_t const * se
 static inline ulong fd_stake_reward_calculation_align( void ) { return FD_STAKE_REWARD_CALCULATION_ALIGN; }
 int fd_stake_reward_calculation_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_reward_calculation_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_reward_calculation_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_reward_calculation_encode_global( fd_stake_reward_calculation_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_calculate_stake_vote_rewards_result_new( fd_calculate_stake_vote_rewards_result_t * self );
 int fd_calculate_stake_vote_rewards_result_encode( fd_calculate_stake_vote_rewards_result_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6034,8 +4198,6 @@ ulong fd_calculate_stake_vote_rewards_result_size( fd_calculate_stake_vote_rewar
 static inline ulong fd_calculate_stake_vote_rewards_result_align( void ) { return FD_CALCULATE_STAKE_VOTE_REWARDS_RESULT_ALIGN; }
 int fd_calculate_stake_vote_rewards_result_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_calculate_stake_vote_rewards_result_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_calculate_stake_vote_rewards_result_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_calculate_stake_vote_rewards_result_encode_global( fd_calculate_stake_vote_rewards_result_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_calculate_validator_rewards_result_new( fd_calculate_validator_rewards_result_t * self );
 int fd_calculate_validator_rewards_result_encode( fd_calculate_validator_rewards_result_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6044,8 +4206,6 @@ ulong fd_calculate_validator_rewards_result_size( fd_calculate_validator_rewards
 static inline ulong fd_calculate_validator_rewards_result_align( void ) { return FD_CALCULATE_VALIDATOR_REWARDS_RESULT_ALIGN; }
 int fd_calculate_validator_rewards_result_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_calculate_validator_rewards_result_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_calculate_validator_rewards_result_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_calculate_validator_rewards_result_encode_global( fd_calculate_validator_rewards_result_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_calculate_rewards_and_distribute_vote_rewards_result_new( fd_calculate_rewards_and_distribute_vote_rewards_result_t * self );
 int fd_calculate_rewards_and_distribute_vote_rewards_result_encode( fd_calculate_rewards_and_distribute_vote_rewards_result_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6054,8 +4214,6 @@ ulong fd_calculate_rewards_and_distribute_vote_rewards_result_size( fd_calculate
 static inline ulong fd_calculate_rewards_and_distribute_vote_rewards_result_align( void ) { return FD_CALCULATE_REWARDS_AND_DISTRIBUTE_VOTE_REWARDS_RESULT_ALIGN; }
 int fd_calculate_rewards_and_distribute_vote_rewards_result_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_calculate_rewards_and_distribute_vote_rewards_result_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_calculate_rewards_and_distribute_vote_rewards_result_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_calculate_rewards_and_distribute_vote_rewards_result_encode_global( fd_calculate_rewards_and_distribute_vote_rewards_result_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_partitioned_rewards_calculation_new( fd_partitioned_rewards_calculation_t * self );
 int fd_partitioned_rewards_calculation_encode( fd_partitioned_rewards_calculation_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6064,8 +4222,6 @@ ulong fd_partitioned_rewards_calculation_size( fd_partitioned_rewards_calculatio
 static inline ulong fd_partitioned_rewards_calculation_align( void ) { return FD_PARTITIONED_REWARDS_CALCULATION_ALIGN; }
 int fd_partitioned_rewards_calculation_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_partitioned_rewards_calculation_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_partitioned_rewards_calculation_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_partitioned_rewards_calculation_encode_global( fd_partitioned_rewards_calculation_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_start_block_height_and_rewards_new( fd_start_block_height_and_rewards_t * self );
 int fd_start_block_height_and_rewards_encode( fd_start_block_height_and_rewards_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6074,8 +4230,6 @@ ulong fd_start_block_height_and_rewards_size( fd_start_block_height_and_rewards_
 static inline ulong fd_start_block_height_and_rewards_align( void ) { return FD_START_BLOCK_HEIGHT_AND_REWARDS_ALIGN; }
 int fd_start_block_height_and_rewards_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_start_block_height_and_rewards_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_start_block_height_and_rewards_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_start_block_height_and_rewards_encode_global( fd_start_block_height_and_rewards_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_fd_epoch_reward_status_inner_new( fd_fd_epoch_reward_status_inner_t * self );
 int fd_fd_epoch_reward_status_inner_encode( fd_fd_epoch_reward_status_inner_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6084,8 +4238,6 @@ ulong fd_fd_epoch_reward_status_inner_size( fd_fd_epoch_reward_status_inner_t co
 static inline ulong fd_fd_epoch_reward_status_inner_align( void ) { return FD_FD_EPOCH_REWARD_STATUS_INNER_ALIGN; }
 int fd_fd_epoch_reward_status_inner_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_fd_epoch_reward_status_inner_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_fd_epoch_reward_status_inner_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_fd_epoch_reward_status_inner_encode_global( fd_fd_epoch_reward_status_inner_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_epoch_reward_status_new_disc( fd_epoch_reward_status_t * self, uint discriminant );
 void fd_epoch_reward_status_new( fd_epoch_reward_status_t * self );
@@ -6095,8 +4247,6 @@ ulong fd_epoch_reward_status_size( fd_epoch_reward_status_t const * self );
 static inline ulong fd_epoch_reward_status_align( void ) { return FD_EPOCH_REWARD_STATUS_ALIGN; }
 int fd_epoch_reward_status_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_epoch_reward_status_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_epoch_reward_status_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_reward_status_encode_global( fd_epoch_reward_status_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_epoch_reward_status_is_Active( fd_epoch_reward_status_t const * self );
 FD_FN_PURE uchar fd_epoch_reward_status_is_Inactive( fd_epoch_reward_status_t const * self );
@@ -6111,8 +4261,6 @@ ulong fd_slot_bank_size( fd_slot_bank_t const * self );
 static inline ulong fd_slot_bank_align( void ) { return FD_SLOT_BANK_ALIGN; }
 int fd_slot_bank_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_slot_bank_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_slot_bank_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_slot_bank_encode_global( fd_slot_bank_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_prev_epoch_inflation_rewards_new( fd_prev_epoch_inflation_rewards_t * self ) { fd_memset( self, 0, sizeof(fd_prev_epoch_inflation_rewards_t) ); }
 int fd_prev_epoch_inflation_rewards_encode( fd_prev_epoch_inflation_rewards_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6133,8 +4281,6 @@ ulong fd_vote_size( fd_vote_t const * self );
 static inline ulong fd_vote_align( void ) { return FD_VOTE_ALIGN; }
 int fd_vote_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_encode_global( fd_vote_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_vote_init_new( fd_vote_init_t * self ) { fd_memset( self, 0, sizeof(fd_vote_init_t) ); }
 int fd_vote_init_encode( fd_vote_init_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6178,8 +4324,6 @@ ulong fd_vote_switch_size( fd_vote_switch_t const * self );
 static inline ulong fd_vote_switch_align( void ) { return FD_VOTE_SWITCH_ALIGN; }
 int fd_vote_switch_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_switch_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_switch_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_switch_encode_global( fd_vote_switch_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_update_vote_state_switch_new( fd_update_vote_state_switch_t * self );
 int fd_update_vote_state_switch_encode( fd_update_vote_state_switch_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6188,8 +4332,6 @@ ulong fd_update_vote_state_switch_size( fd_update_vote_state_switch_t const * se
 static inline ulong fd_update_vote_state_switch_align( void ) { return FD_UPDATE_VOTE_STATE_SWITCH_ALIGN; }
 int fd_update_vote_state_switch_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_update_vote_state_switch_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_update_vote_state_switch_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_update_vote_state_switch_encode_global( fd_update_vote_state_switch_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_authorize_with_seed_args_new( fd_vote_authorize_with_seed_args_t * self );
 int fd_vote_authorize_with_seed_args_encode( fd_vote_authorize_with_seed_args_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6198,8 +4340,6 @@ ulong fd_vote_authorize_with_seed_args_size( fd_vote_authorize_with_seed_args_t 
 static inline ulong fd_vote_authorize_with_seed_args_align( void ) { return FD_VOTE_AUTHORIZE_WITH_SEED_ARGS_ALIGN; }
 int fd_vote_authorize_with_seed_args_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_authorize_with_seed_args_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_authorize_with_seed_args_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_authorize_with_seed_args_encode_global( fd_vote_authorize_with_seed_args_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_authorize_checked_with_seed_args_new( fd_vote_authorize_checked_with_seed_args_t * self );
 int fd_vote_authorize_checked_with_seed_args_encode( fd_vote_authorize_checked_with_seed_args_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6208,8 +4348,6 @@ ulong fd_vote_authorize_checked_with_seed_args_size( fd_vote_authorize_checked_w
 static inline ulong fd_vote_authorize_checked_with_seed_args_align( void ) { return FD_VOTE_AUTHORIZE_CHECKED_WITH_SEED_ARGS_ALIGN; }
 int fd_vote_authorize_checked_with_seed_args_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_authorize_checked_with_seed_args_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_authorize_checked_with_seed_args_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_authorize_checked_with_seed_args_encode_global( fd_vote_authorize_checked_with_seed_args_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_vote_instruction_new_disc( fd_vote_instruction_t * self, uint discriminant );
 void fd_vote_instruction_new( fd_vote_instruction_t * self );
@@ -6219,8 +4357,6 @@ ulong fd_vote_instruction_size( fd_vote_instruction_t const * self );
 static inline ulong fd_vote_instruction_align( void ) { return FD_VOTE_INSTRUCTION_ALIGN; }
 int fd_vote_instruction_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_instruction_encode_global( fd_vote_instruction_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_vote_instruction_is_initialize_account( fd_vote_instruction_t const * self );
 FD_FN_PURE uchar fd_vote_instruction_is_authorize( fd_vote_instruction_t const * self );
@@ -6275,8 +4411,6 @@ ulong fd_system_program_instruction_create_account_with_seed_size( fd_system_pro
 static inline ulong fd_system_program_instruction_create_account_with_seed_align( void ) { return FD_SYSTEM_PROGRAM_INSTRUCTION_CREATE_ACCOUNT_WITH_SEED_ALIGN; }
 int fd_system_program_instruction_create_account_with_seed_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_system_program_instruction_create_account_with_seed_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_system_program_instruction_create_account_with_seed_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_system_program_instruction_create_account_with_seed_encode_global( fd_system_program_instruction_create_account_with_seed_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_system_program_instruction_allocate_with_seed_new( fd_system_program_instruction_allocate_with_seed_t * self );
 int fd_system_program_instruction_allocate_with_seed_encode( fd_system_program_instruction_allocate_with_seed_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6285,8 +4419,6 @@ ulong fd_system_program_instruction_allocate_with_seed_size( fd_system_program_i
 static inline ulong fd_system_program_instruction_allocate_with_seed_align( void ) { return FD_SYSTEM_PROGRAM_INSTRUCTION_ALLOCATE_WITH_SEED_ALIGN; }
 int fd_system_program_instruction_allocate_with_seed_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_system_program_instruction_allocate_with_seed_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_system_program_instruction_allocate_with_seed_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_system_program_instruction_allocate_with_seed_encode_global( fd_system_program_instruction_allocate_with_seed_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_system_program_instruction_assign_with_seed_new( fd_system_program_instruction_assign_with_seed_t * self );
 int fd_system_program_instruction_assign_with_seed_encode( fd_system_program_instruction_assign_with_seed_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6295,8 +4427,6 @@ ulong fd_system_program_instruction_assign_with_seed_size( fd_system_program_ins
 static inline ulong fd_system_program_instruction_assign_with_seed_align( void ) { return FD_SYSTEM_PROGRAM_INSTRUCTION_ASSIGN_WITH_SEED_ALIGN; }
 int fd_system_program_instruction_assign_with_seed_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_system_program_instruction_assign_with_seed_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_system_program_instruction_assign_with_seed_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_system_program_instruction_assign_with_seed_encode_global( fd_system_program_instruction_assign_with_seed_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_system_program_instruction_transfer_with_seed_new( fd_system_program_instruction_transfer_with_seed_t * self );
 int fd_system_program_instruction_transfer_with_seed_encode( fd_system_program_instruction_transfer_with_seed_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6305,8 +4435,6 @@ ulong fd_system_program_instruction_transfer_with_seed_size( fd_system_program_i
 static inline ulong fd_system_program_instruction_transfer_with_seed_align( void ) { return FD_SYSTEM_PROGRAM_INSTRUCTION_TRANSFER_WITH_SEED_ALIGN; }
 int fd_system_program_instruction_transfer_with_seed_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_system_program_instruction_transfer_with_seed_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_system_program_instruction_transfer_with_seed_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_system_program_instruction_transfer_with_seed_encode_global( fd_system_program_instruction_transfer_with_seed_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_system_program_instruction_new_disc( fd_system_program_instruction_t * self, uint discriminant );
 void fd_system_program_instruction_new( fd_system_program_instruction_t * self );
@@ -6316,8 +4444,6 @@ ulong fd_system_program_instruction_size( fd_system_program_instruction_t const 
 static inline ulong fd_system_program_instruction_align( void ) { return FD_SYSTEM_PROGRAM_INSTRUCTION_ALIGN; }
 int fd_system_program_instruction_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_system_program_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_system_program_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_system_program_instruction_encode_global( fd_system_program_instruction_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_system_program_instruction_is_create_account( fd_system_program_instruction_t const * self );
 FD_FN_PURE uchar fd_system_program_instruction_is_assign( fd_system_program_instruction_t const * self );
@@ -6419,8 +4545,6 @@ ulong fd_stake_lockup_custodian_args_size( fd_stake_lockup_custodian_args_t cons
 static inline ulong fd_stake_lockup_custodian_args_align( void ) { return FD_STAKE_LOCKUP_CUSTODIAN_ARGS_ALIGN; }
 int fd_stake_lockup_custodian_args_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_lockup_custodian_args_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_lockup_custodian_args_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_lockup_custodian_args_encode_global( fd_stake_lockup_custodian_args_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_stake_authorize_new_disc( fd_stake_authorize_t * self, uint discriminant ) { self->discriminant = discriminant; }
 static inline void fd_stake_authorize_new( fd_stake_authorize_t * self ) { self->discriminant = (uint)ULONG_MAX; }
@@ -6452,8 +4576,6 @@ ulong fd_authorize_with_seed_args_size( fd_authorize_with_seed_args_t const * se
 static inline ulong fd_authorize_with_seed_args_align( void ) { return FD_AUTHORIZE_WITH_SEED_ARGS_ALIGN; }
 int fd_authorize_with_seed_args_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_authorize_with_seed_args_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_authorize_with_seed_args_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_authorize_with_seed_args_encode_global( fd_authorize_with_seed_args_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_authorize_checked_with_seed_args_new( fd_authorize_checked_with_seed_args_t * self );
 int fd_authorize_checked_with_seed_args_encode( fd_authorize_checked_with_seed_args_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6462,8 +4584,6 @@ ulong fd_authorize_checked_with_seed_args_size( fd_authorize_checked_with_seed_a
 static inline ulong fd_authorize_checked_with_seed_args_align( void ) { return FD_AUTHORIZE_CHECKED_WITH_SEED_ARGS_ALIGN; }
 int fd_authorize_checked_with_seed_args_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_authorize_checked_with_seed_args_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_authorize_checked_with_seed_args_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_authorize_checked_with_seed_args_encode_global( fd_authorize_checked_with_seed_args_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_lockup_checked_args_new( fd_lockup_checked_args_t * self );
 int fd_lockup_checked_args_encode( fd_lockup_checked_args_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6472,8 +4592,6 @@ ulong fd_lockup_checked_args_size( fd_lockup_checked_args_t const * self );
 static inline ulong fd_lockup_checked_args_align( void ) { return FD_LOCKUP_CHECKED_ARGS_ALIGN; }
 int fd_lockup_checked_args_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_lockup_checked_args_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_lockup_checked_args_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_lockup_checked_args_encode_global( fd_lockup_checked_args_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_lockup_args_new( fd_lockup_args_t * self );
 int fd_lockup_args_encode( fd_lockup_args_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6482,8 +4600,6 @@ ulong fd_lockup_args_size( fd_lockup_args_t const * self );
 static inline ulong fd_lockup_args_align( void ) { return FD_LOCKUP_ARGS_ALIGN; }
 int fd_lockup_args_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_lockup_args_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_lockup_args_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_lockup_args_encode_global( fd_lockup_args_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_stake_instruction_new_disc( fd_stake_instruction_t * self, uint discriminant );
 void fd_stake_instruction_new( fd_stake_instruction_t * self );
@@ -6493,8 +4609,6 @@ ulong fd_stake_instruction_size( fd_stake_instruction_t const * self );
 static inline ulong fd_stake_instruction_align( void ) { return FD_STAKE_INSTRUCTION_ALIGN; }
 int fd_stake_instruction_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_stake_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_stake_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_stake_instruction_encode_global( fd_stake_instruction_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_stake_instruction_is_initialize( fd_stake_instruction_t const * self );
 FD_FN_PURE uchar fd_stake_instruction_is_authorize( fd_stake_instruction_t const * self );
@@ -6683,8 +4797,6 @@ ulong fd_config_keys_size( fd_config_keys_t const * self );
 static inline ulong fd_config_keys_align( void ) { return FD_CONFIG_KEYS_ALIGN; }
 int fd_config_keys_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_config_keys_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_config_keys_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_config_keys_encode_global( fd_config_keys_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_bpf_loader_program_instruction_write_new( fd_bpf_loader_program_instruction_write_t * self );
 int fd_bpf_loader_program_instruction_write_encode( fd_bpf_loader_program_instruction_write_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6693,8 +4805,6 @@ ulong fd_bpf_loader_program_instruction_write_size( fd_bpf_loader_program_instru
 static inline ulong fd_bpf_loader_program_instruction_write_align( void ) { return FD_BPF_LOADER_PROGRAM_INSTRUCTION_WRITE_ALIGN; }
 int fd_bpf_loader_program_instruction_write_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bpf_loader_program_instruction_write_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bpf_loader_program_instruction_write_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_loader_program_instruction_write_encode_global( fd_bpf_loader_program_instruction_write_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_bpf_loader_program_instruction_new_disc( fd_bpf_loader_program_instruction_t * self, uint discriminant );
 void fd_bpf_loader_program_instruction_new( fd_bpf_loader_program_instruction_t * self );
@@ -6704,8 +4814,6 @@ ulong fd_bpf_loader_program_instruction_size( fd_bpf_loader_program_instruction_
 static inline ulong fd_bpf_loader_program_instruction_align( void ) { return FD_BPF_LOADER_PROGRAM_INSTRUCTION_ALIGN; }
 int fd_bpf_loader_program_instruction_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bpf_loader_program_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bpf_loader_program_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_loader_program_instruction_encode_global( fd_bpf_loader_program_instruction_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_bpf_loader_program_instruction_is_write( fd_bpf_loader_program_instruction_t const * self );
 FD_FN_PURE uchar fd_bpf_loader_program_instruction_is_finalize( fd_bpf_loader_program_instruction_t const * self );
@@ -6720,8 +4828,6 @@ ulong fd_loader_v4_program_instruction_write_size( fd_loader_v4_program_instruct
 static inline ulong fd_loader_v4_program_instruction_write_align( void ) { return FD_LOADER_V4_PROGRAM_INSTRUCTION_WRITE_ALIGN; }
 int fd_loader_v4_program_instruction_write_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_loader_v4_program_instruction_write_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_loader_v4_program_instruction_write_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_loader_v4_program_instruction_write_encode_global( fd_loader_v4_program_instruction_write_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_loader_v4_program_instruction_copy_new( fd_loader_v4_program_instruction_copy_t * self ) { fd_memset( self, 0, sizeof(fd_loader_v4_program_instruction_copy_t) ); }
 int fd_loader_v4_program_instruction_copy_encode( fd_loader_v4_program_instruction_copy_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6755,8 +4861,6 @@ ulong fd_loader_v4_program_instruction_size( fd_loader_v4_program_instruction_t 
 static inline ulong fd_loader_v4_program_instruction_align( void ) { return FD_LOADER_V4_PROGRAM_INSTRUCTION_ALIGN; }
 int fd_loader_v4_program_instruction_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_loader_v4_program_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_loader_v4_program_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_loader_v4_program_instruction_encode_global( fd_loader_v4_program_instruction_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_loader_v4_program_instruction_is_write( fd_loader_v4_program_instruction_t const * self );
 FD_FN_PURE uchar fd_loader_v4_program_instruction_is_copy( fd_loader_v4_program_instruction_t const * self );
@@ -6781,8 +4885,6 @@ ulong fd_bpf_upgradeable_loader_program_instruction_write_size( fd_bpf_upgradeab
 static inline ulong fd_bpf_upgradeable_loader_program_instruction_write_align( void ) { return FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_WRITE_ALIGN; }
 int fd_bpf_upgradeable_loader_program_instruction_write_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bpf_upgradeable_loader_program_instruction_write_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bpf_upgradeable_loader_program_instruction_write_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_upgradeable_loader_program_instruction_write_encode_global( fd_bpf_upgradeable_loader_program_instruction_write_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_new( fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t * self ) { fd_memset( self, 0, sizeof(fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t) ); }
 int fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_encode( fd_bpf_upgradeable_loader_program_instruction_deploy_with_max_data_len_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6816,8 +4918,6 @@ ulong fd_bpf_upgradeable_loader_program_instruction_size( fd_bpf_upgradeable_loa
 static inline ulong fd_bpf_upgradeable_loader_program_instruction_align( void ) { return FD_BPF_UPGRADEABLE_LOADER_PROGRAM_INSTRUCTION_ALIGN; }
 int fd_bpf_upgradeable_loader_program_instruction_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bpf_upgradeable_loader_program_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bpf_upgradeable_loader_program_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_upgradeable_loader_program_instruction_encode_global( fd_bpf_upgradeable_loader_program_instruction_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_bpf_upgradeable_loader_program_instruction_is_initialize_buffer( fd_bpf_upgradeable_loader_program_instruction_t const * self );
 FD_FN_PURE uchar fd_bpf_upgradeable_loader_program_instruction_is_write( fd_bpf_upgradeable_loader_program_instruction_t const * self );
@@ -6846,8 +4946,6 @@ ulong fd_bpf_upgradeable_loader_state_buffer_size( fd_bpf_upgradeable_loader_sta
 static inline ulong fd_bpf_upgradeable_loader_state_buffer_align( void ) { return FD_BPF_UPGRADEABLE_LOADER_STATE_BUFFER_ALIGN; }
 int fd_bpf_upgradeable_loader_state_buffer_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bpf_upgradeable_loader_state_buffer_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bpf_upgradeable_loader_state_buffer_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_upgradeable_loader_state_buffer_encode_global( fd_bpf_upgradeable_loader_state_buffer_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_bpf_upgradeable_loader_state_program_new( fd_bpf_upgradeable_loader_state_program_t * self ) { fd_memset( self, 0, sizeof(fd_bpf_upgradeable_loader_state_program_t) ); }
 int fd_bpf_upgradeable_loader_state_program_encode( fd_bpf_upgradeable_loader_state_program_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6868,8 +4966,6 @@ ulong fd_bpf_upgradeable_loader_state_program_data_size( fd_bpf_upgradeable_load
 static inline ulong fd_bpf_upgradeable_loader_state_program_data_align( void ) { return FD_BPF_UPGRADEABLE_LOADER_STATE_PROGRAM_DATA_ALIGN; }
 int fd_bpf_upgradeable_loader_state_program_data_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bpf_upgradeable_loader_state_program_data_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bpf_upgradeable_loader_state_program_data_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_upgradeable_loader_state_program_data_encode_global( fd_bpf_upgradeable_loader_state_program_data_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_bpf_upgradeable_loader_state_new_disc( fd_bpf_upgradeable_loader_state_t * self, uint discriminant );
 void fd_bpf_upgradeable_loader_state_new( fd_bpf_upgradeable_loader_state_t * self );
@@ -6879,8 +4975,6 @@ ulong fd_bpf_upgradeable_loader_state_size( fd_bpf_upgradeable_loader_state_t co
 static inline ulong fd_bpf_upgradeable_loader_state_align( void ) { return FD_BPF_UPGRADEABLE_LOADER_STATE_ALIGN; }
 int fd_bpf_upgradeable_loader_state_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bpf_upgradeable_loader_state_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bpf_upgradeable_loader_state_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bpf_upgradeable_loader_state_encode_global( fd_bpf_upgradeable_loader_state_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_bpf_upgradeable_loader_state_is_uninitialized( fd_bpf_upgradeable_loader_state_t const * self );
 FD_FN_PURE uchar fd_bpf_upgradeable_loader_state_is_buffer( fd_bpf_upgradeable_loader_state_t const * self );
@@ -6932,8 +5026,6 @@ ulong fd_lookup_table_meta_size( fd_lookup_table_meta_t const * self );
 static inline ulong fd_lookup_table_meta_align( void ) { return FD_LOOKUP_TABLE_META_ALIGN; }
 int fd_lookup_table_meta_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_lookup_table_meta_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_lookup_table_meta_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_lookup_table_meta_encode_global( fd_lookup_table_meta_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_address_lookup_table_new( fd_address_lookup_table_t * self );
 int fd_address_lookup_table_encode( fd_address_lookup_table_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -6942,8 +5034,6 @@ ulong fd_address_lookup_table_size( fd_address_lookup_table_t const * self );
 static inline ulong fd_address_lookup_table_align( void ) { return FD_ADDRESS_LOOKUP_TABLE_ALIGN; }
 int fd_address_lookup_table_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_address_lookup_table_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_address_lookup_table_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_address_lookup_table_encode_global( fd_address_lookup_table_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_address_lookup_table_state_new_disc( fd_address_lookup_table_state_t * self, uint discriminant );
 void fd_address_lookup_table_state_new( fd_address_lookup_table_state_t * self );
@@ -6953,8 +5043,6 @@ ulong fd_address_lookup_table_state_size( fd_address_lookup_table_state_t const 
 static inline ulong fd_address_lookup_table_state_align( void ) { return FD_ADDRESS_LOOKUP_TABLE_STATE_ALIGN; }
 int fd_address_lookup_table_state_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_address_lookup_table_state_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_address_lookup_table_state_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_address_lookup_table_state_encode_global( fd_address_lookup_table_state_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_address_lookup_table_state_is_uninitialized( fd_address_lookup_table_state_t const * self );
 FD_FN_PURE uchar fd_address_lookup_table_state_is_lookup_table( fd_address_lookup_table_state_t const * self );
@@ -6996,8 +5084,6 @@ ulong fd_gossip_prune_data_size( fd_gossip_prune_data_t const * self );
 static inline ulong fd_gossip_prune_data_align( void ) { return FD_GOSSIP_PRUNE_DATA_ALIGN; }
 int fd_gossip_prune_data_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_prune_data_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_prune_data_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_prune_data_encode_global( fd_gossip_prune_data_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_prune_sign_data_new( fd_gossip_prune_sign_data_t * self );
 int fd_gossip_prune_sign_data_encode( fd_gossip_prune_sign_data_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7006,8 +5092,6 @@ ulong fd_gossip_prune_sign_data_size( fd_gossip_prune_sign_data_t const * self )
 static inline ulong fd_gossip_prune_sign_data_align( void ) { return FD_GOSSIP_PRUNE_SIGN_DATA_ALIGN; }
 int fd_gossip_prune_sign_data_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_prune_sign_data_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_prune_sign_data_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_prune_sign_data_encode_global( fd_gossip_prune_sign_data_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_prune_sign_data_with_prefix_new( fd_gossip_prune_sign_data_with_prefix_t * self );
 int fd_gossip_prune_sign_data_with_prefix_encode( fd_gossip_prune_sign_data_with_prefix_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7016,8 +5100,6 @@ ulong fd_gossip_prune_sign_data_with_prefix_size( fd_gossip_prune_sign_data_with
 static inline ulong fd_gossip_prune_sign_data_with_prefix_align( void ) { return FD_GOSSIP_PRUNE_SIGN_DATA_WITH_PREFIX_ALIGN; }
 int fd_gossip_prune_sign_data_with_prefix_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_prune_sign_data_with_prefix_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_prune_sign_data_with_prefix_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_prune_sign_data_with_prefix_encode_global( fd_gossip_prune_sign_data_with_prefix_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_socket_addr_old_new( fd_gossip_socket_addr_old_t * self );
 int fd_gossip_socket_addr_old_encode( fd_gossip_socket_addr_old_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7081,8 +5163,6 @@ ulong fd_gossip_lowest_slot_size( fd_gossip_lowest_slot_t const * self );
 static inline ulong fd_gossip_lowest_slot_align( void ) { return FD_GOSSIP_LOWEST_SLOT_ALIGN; }
 int fd_gossip_lowest_slot_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_lowest_slot_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_lowest_slot_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_lowest_slot_encode_global( fd_gossip_lowest_slot_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_slot_hashes_new( fd_gossip_slot_hashes_t * self );
 int fd_gossip_slot_hashes_encode( fd_gossip_slot_hashes_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7091,8 +5171,6 @@ ulong fd_gossip_slot_hashes_size( fd_gossip_slot_hashes_t const * self );
 static inline ulong fd_gossip_slot_hashes_align( void ) { return FD_GOSSIP_SLOT_HASHES_ALIGN; }
 int fd_gossip_slot_hashes_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_slot_hashes_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_slot_hashes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_slot_hashes_encode_global( fd_gossip_slot_hashes_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_slots_new( fd_gossip_slots_t * self );
 int fd_gossip_slots_encode( fd_gossip_slots_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7101,8 +5179,6 @@ ulong fd_gossip_slots_size( fd_gossip_slots_t const * self );
 static inline ulong fd_gossip_slots_align( void ) { return FD_GOSSIP_SLOTS_ALIGN; }
 int fd_gossip_slots_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_slots_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_slots_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_slots_encode_global( fd_gossip_slots_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_flate2_slots_new( fd_gossip_flate2_slots_t * self );
 int fd_gossip_flate2_slots_encode( fd_gossip_flate2_slots_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7111,8 +5187,6 @@ ulong fd_gossip_flate2_slots_size( fd_gossip_flate2_slots_t const * self );
 static inline ulong fd_gossip_flate2_slots_align( void ) { return FD_GOSSIP_FLATE2_SLOTS_ALIGN; }
 int fd_gossip_flate2_slots_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_flate2_slots_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_flate2_slots_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_flate2_slots_encode_global( fd_gossip_flate2_slots_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_slots_enum_new_disc( fd_gossip_slots_enum_t * self, uint discriminant );
 void fd_gossip_slots_enum_new( fd_gossip_slots_enum_t * self );
@@ -7122,8 +5196,6 @@ ulong fd_gossip_slots_enum_size( fd_gossip_slots_enum_t const * self );
 static inline ulong fd_gossip_slots_enum_align( void ) { return FD_GOSSIP_SLOTS_ENUM_ALIGN; }
 int fd_gossip_slots_enum_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_slots_enum_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_slots_enum_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_slots_enum_encode_global( fd_gossip_slots_enum_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_gossip_slots_enum_is_flate2( fd_gossip_slots_enum_t const * self );
 FD_FN_PURE uchar fd_gossip_slots_enum_is_uncompressed( fd_gossip_slots_enum_t const * self );
@@ -7138,8 +5210,6 @@ ulong fd_gossip_epoch_slots_size( fd_gossip_epoch_slots_t const * self );
 static inline ulong fd_gossip_epoch_slots_align( void ) { return FD_GOSSIP_EPOCH_SLOTS_ALIGN; }
 int fd_gossip_epoch_slots_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_epoch_slots_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_epoch_slots_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_epoch_slots_encode_global( fd_gossip_epoch_slots_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_version_v1_new( fd_gossip_version_v1_t * self );
 int fd_gossip_version_v1_encode( fd_gossip_version_v1_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7148,8 +5218,6 @@ ulong fd_gossip_version_v1_size( fd_gossip_version_v1_t const * self );
 static inline ulong fd_gossip_version_v1_align( void ) { return FD_GOSSIP_VERSION_V1_ALIGN; }
 int fd_gossip_version_v1_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_version_v1_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_version_v1_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_version_v1_encode_global( fd_gossip_version_v1_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_version_v2_new( fd_gossip_version_v2_t * self );
 int fd_gossip_version_v2_encode( fd_gossip_version_v2_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7158,8 +5226,6 @@ ulong fd_gossip_version_v2_size( fd_gossip_version_v2_t const * self );
 static inline ulong fd_gossip_version_v2_align( void ) { return FD_GOSSIP_VERSION_V2_ALIGN; }
 int fd_gossip_version_v2_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_version_v2_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_version_v2_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_version_v2_encode_global( fd_gossip_version_v2_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_version_v3_new( fd_gossip_version_v3_t * self );
 int fd_gossip_version_v3_encode( fd_gossip_version_v3_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7188,8 +5254,6 @@ ulong fd_gossip_duplicate_shred_size( fd_gossip_duplicate_shred_t const * self )
 static inline ulong fd_gossip_duplicate_shred_align( void ) { return FD_GOSSIP_DUPLICATE_SHRED_ALIGN; }
 int fd_gossip_duplicate_shred_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_duplicate_shred_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_duplicate_shred_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_duplicate_shred_encode_global( fd_gossip_duplicate_shred_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_incremental_snapshot_hashes_new( fd_gossip_incremental_snapshot_hashes_t * self );
 int fd_gossip_incremental_snapshot_hashes_encode( fd_gossip_incremental_snapshot_hashes_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7198,8 +5262,6 @@ ulong fd_gossip_incremental_snapshot_hashes_size( fd_gossip_incremental_snapshot
 static inline ulong fd_gossip_incremental_snapshot_hashes_align( void ) { return FD_GOSSIP_INCREMENTAL_SNAPSHOT_HASHES_ALIGN; }
 int fd_gossip_incremental_snapshot_hashes_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_incremental_snapshot_hashes_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_incremental_snapshot_hashes_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_incremental_snapshot_hashes_encode_global( fd_gossip_incremental_snapshot_hashes_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_socket_entry_new( fd_gossip_socket_entry_t * self );
 int fd_gossip_socket_entry_encode( fd_gossip_socket_entry_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7216,8 +5278,6 @@ ulong fd_gossip_contact_info_v2_size( fd_gossip_contact_info_v2_t const * self )
 static inline ulong fd_gossip_contact_info_v2_align( void ) { return FD_GOSSIP_CONTACT_INFO_V2_ALIGN; }
 int fd_gossip_contact_info_v2_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_contact_info_v2_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_contact_info_v2_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_contact_info_v2_encode_global( fd_gossip_contact_info_v2_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_restart_run_length_encoding_inner_new( fd_restart_run_length_encoding_inner_t * self );
 int fd_restart_run_length_encoding_inner_encode( fd_restart_run_length_encoding_inner_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7234,8 +5294,6 @@ ulong fd_restart_run_length_encoding_size( fd_restart_run_length_encoding_t cons
 static inline ulong fd_restart_run_length_encoding_align( void ) { return FD_RESTART_RUN_LENGTH_ENCODING_ALIGN; }
 int fd_restart_run_length_encoding_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_restart_run_length_encoding_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_restart_run_length_encoding_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_restart_run_length_encoding_encode_global( fd_restart_run_length_encoding_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_restart_raw_offsets_new( fd_restart_raw_offsets_t * self );
 int fd_restart_raw_offsets_encode( fd_restart_raw_offsets_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7244,8 +5302,6 @@ ulong fd_restart_raw_offsets_size( fd_restart_raw_offsets_t const * self );
 static inline ulong fd_restart_raw_offsets_align( void ) { return FD_RESTART_RAW_OFFSETS_ALIGN; }
 int fd_restart_raw_offsets_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_restart_raw_offsets_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_restart_raw_offsets_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_restart_raw_offsets_encode_global( fd_restart_raw_offsets_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_restart_slots_offsets_new_disc( fd_restart_slots_offsets_t * self, uint discriminant );
 void fd_restart_slots_offsets_new( fd_restart_slots_offsets_t * self );
@@ -7255,8 +5311,6 @@ ulong fd_restart_slots_offsets_size( fd_restart_slots_offsets_t const * self );
 static inline ulong fd_restart_slots_offsets_align( void ) { return FD_RESTART_SLOTS_OFFSETS_ALIGN; }
 int fd_restart_slots_offsets_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_restart_slots_offsets_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_restart_slots_offsets_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_restart_slots_offsets_encode_global( fd_restart_slots_offsets_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_restart_slots_offsets_is_run_length_encoding( fd_restart_slots_offsets_t const * self );
 FD_FN_PURE uchar fd_restart_slots_offsets_is_raw_offsets( fd_restart_slots_offsets_t const * self );
@@ -7271,8 +5325,6 @@ ulong fd_gossip_restart_last_voted_fork_slots_size( fd_gossip_restart_last_voted
 static inline ulong fd_gossip_restart_last_voted_fork_slots_align( void ) { return FD_GOSSIP_RESTART_LAST_VOTED_FORK_SLOTS_ALIGN; }
 int fd_gossip_restart_last_voted_fork_slots_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_restart_last_voted_fork_slots_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_restart_last_voted_fork_slots_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_restart_last_voted_fork_slots_encode_global( fd_gossip_restart_last_voted_fork_slots_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_gossip_restart_heaviest_fork_new( fd_gossip_restart_heaviest_fork_t * self ) { fd_memset( self, 0, sizeof(fd_gossip_restart_heaviest_fork_t) ); }
 int fd_gossip_restart_heaviest_fork_encode( fd_gossip_restart_heaviest_fork_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7294,8 +5346,6 @@ ulong fd_crds_data_size( fd_crds_data_t const * self );
 static inline ulong fd_crds_data_align( void ) { return FD_CRDS_DATA_ALIGN; }
 int fd_crds_data_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_crds_data_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_crds_data_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_crds_data_encode_global( fd_crds_data_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_crds_data_is_contact_info_v1( fd_crds_data_t const * self );
 FD_FN_PURE uchar fd_crds_data_is_vote( fd_crds_data_t const * self );
@@ -7334,8 +5384,6 @@ ulong fd_crds_bloom_size( fd_crds_bloom_t const * self );
 static inline ulong fd_crds_bloom_align( void ) { return FD_CRDS_BLOOM_ALIGN; }
 int fd_crds_bloom_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_crds_bloom_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_crds_bloom_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_crds_bloom_encode_global( fd_crds_bloom_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_crds_filter_new( fd_crds_filter_t * self );
 int fd_crds_filter_encode( fd_crds_filter_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7344,8 +5392,6 @@ ulong fd_crds_filter_size( fd_crds_filter_t const * self );
 static inline ulong fd_crds_filter_align( void ) { return FD_CRDS_FILTER_ALIGN; }
 int fd_crds_filter_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_crds_filter_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_crds_filter_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_crds_filter_encode_global( fd_crds_filter_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_crds_value_new( fd_crds_value_t * self );
 int fd_crds_value_encode( fd_crds_value_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7354,8 +5400,6 @@ ulong fd_crds_value_size( fd_crds_value_t const * self );
 static inline ulong fd_crds_value_align( void ) { return FD_CRDS_VALUE_ALIGN; }
 int fd_crds_value_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_crds_value_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_crds_value_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_crds_value_encode_global( fd_crds_value_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_pull_req_new( fd_gossip_pull_req_t * self );
 int fd_gossip_pull_req_encode( fd_gossip_pull_req_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7364,8 +5408,6 @@ ulong fd_gossip_pull_req_size( fd_gossip_pull_req_t const * self );
 static inline ulong fd_gossip_pull_req_align( void ) { return FD_GOSSIP_PULL_REQ_ALIGN; }
 int fd_gossip_pull_req_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_pull_req_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_pull_req_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_pull_req_encode_global( fd_gossip_pull_req_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_pull_resp_new( fd_gossip_pull_resp_t * self );
 int fd_gossip_pull_resp_encode( fd_gossip_pull_resp_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7374,8 +5416,6 @@ ulong fd_gossip_pull_resp_size( fd_gossip_pull_resp_t const * self );
 static inline ulong fd_gossip_pull_resp_align( void ) { return FD_GOSSIP_PULL_RESP_ALIGN; }
 int fd_gossip_pull_resp_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_pull_resp_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_pull_resp_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_pull_resp_encode_global( fd_gossip_pull_resp_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_push_msg_new( fd_gossip_push_msg_t * self );
 int fd_gossip_push_msg_encode( fd_gossip_push_msg_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7384,8 +5424,6 @@ ulong fd_gossip_push_msg_size( fd_gossip_push_msg_t const * self );
 static inline ulong fd_gossip_push_msg_align( void ) { return FD_GOSSIP_PUSH_MSG_ALIGN; }
 int fd_gossip_push_msg_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_push_msg_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_push_msg_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_push_msg_encode_global( fd_gossip_push_msg_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_prune_msg_new( fd_gossip_prune_msg_t * self );
 int fd_gossip_prune_msg_encode( fd_gossip_prune_msg_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7394,8 +5432,6 @@ ulong fd_gossip_prune_msg_size( fd_gossip_prune_msg_t const * self );
 static inline ulong fd_gossip_prune_msg_align( void ) { return FD_GOSSIP_PRUNE_MSG_ALIGN; }
 int fd_gossip_prune_msg_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_prune_msg_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_prune_msg_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_prune_msg_encode_global( fd_gossip_prune_msg_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_gossip_msg_new_disc( fd_gossip_msg_t * self, uint discriminant );
 void fd_gossip_msg_new( fd_gossip_msg_t * self );
@@ -7405,8 +5441,6 @@ ulong fd_gossip_msg_size( fd_gossip_msg_t const * self );
 static inline ulong fd_gossip_msg_align( void ) { return FD_GOSSIP_MSG_ALIGN; }
 int fd_gossip_msg_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_gossip_msg_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_gossip_msg_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_gossip_msg_encode_global( fd_gossip_msg_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_gossip_msg_is_pull_req( fd_gossip_msg_t const * self );
 FD_FN_PURE uchar fd_gossip_msg_is_pull_resp( fd_gossip_msg_t const * self );
@@ -7441,8 +5475,6 @@ ulong fd_addrlut_extend_size( fd_addrlut_extend_t const * self );
 static inline ulong fd_addrlut_extend_align( void ) { return FD_ADDRLUT_EXTEND_ALIGN; }
 int fd_addrlut_extend_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_addrlut_extend_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_addrlut_extend_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_addrlut_extend_encode_global( fd_addrlut_extend_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_addrlut_instruction_new_disc( fd_addrlut_instruction_t * self, uint discriminant );
 void fd_addrlut_instruction_new( fd_addrlut_instruction_t * self );
@@ -7452,8 +5484,6 @@ ulong fd_addrlut_instruction_size( fd_addrlut_instruction_t const * self );
 static inline ulong fd_addrlut_instruction_align( void ) { return FD_ADDRLUT_INSTRUCTION_ALIGN; }
 int fd_addrlut_instruction_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_addrlut_instruction_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_addrlut_instruction_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_addrlut_instruction_encode_global( fd_addrlut_instruction_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_addrlut_instruction_is_create_lut( fd_addrlut_instruction_t const * self );
 FD_FN_PURE uchar fd_addrlut_instruction_is_freeze_lut( fd_addrlut_instruction_t const * self );
@@ -7583,8 +5613,6 @@ ulong fd_instr_error_enum_size( fd_instr_error_enum_t const * self );
 static inline ulong fd_instr_error_enum_align( void ) { return FD_INSTR_ERROR_ENUM_ALIGN; }
 int fd_instr_error_enum_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_instr_error_enum_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_instr_error_enum_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_instr_error_enum_encode_global( fd_instr_error_enum_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_instr_error_enum_is_generic_error( fd_instr_error_enum_t const * self );
 FD_FN_PURE uchar fd_instr_error_enum_is_invalid_argument( fd_instr_error_enum_t const * self );
@@ -7703,8 +5731,6 @@ ulong fd_txn_instr_error_size( fd_txn_instr_error_t const * self );
 static inline ulong fd_txn_instr_error_align( void ) { return FD_TXN_INSTR_ERROR_ALIGN; }
 int fd_txn_instr_error_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_txn_instr_error_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_txn_instr_error_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_txn_instr_error_encode_global( fd_txn_instr_error_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_txn_error_enum_new_disc( fd_txn_error_enum_t * self, uint discriminant );
 void fd_txn_error_enum_new( fd_txn_error_enum_t * self );
@@ -7714,8 +5740,6 @@ ulong fd_txn_error_enum_size( fd_txn_error_enum_t const * self );
 static inline ulong fd_txn_error_enum_align( void ) { return FD_TXN_ERROR_ENUM_ALIGN; }
 int fd_txn_error_enum_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_txn_error_enum_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_txn_error_enum_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_txn_error_enum_encode_global( fd_txn_error_enum_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_txn_error_enum_is_account_in_use( fd_txn_error_enum_t const * self );
 FD_FN_PURE uchar fd_txn_error_enum_is_account_loaded_twice( fd_txn_error_enum_t const * self );
@@ -7801,8 +5825,6 @@ ulong fd_txn_result_size( fd_txn_result_t const * self );
 static inline ulong fd_txn_result_align( void ) { return FD_TXN_RESULT_ALIGN; }
 int fd_txn_result_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_txn_result_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_txn_result_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_txn_result_encode_global( fd_txn_result_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_FN_PURE uchar fd_txn_result_is_ok( fd_txn_result_t const * self );
 FD_FN_PURE uchar fd_txn_result_is_error( fd_txn_result_t const * self );
@@ -7817,8 +5839,6 @@ ulong fd_cache_status_size( fd_cache_status_t const * self );
 static inline ulong fd_cache_status_align( void ) { return FD_CACHE_STATUS_ALIGN; }
 int fd_cache_status_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_cache_status_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_cache_status_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_cache_status_encode_global( fd_cache_status_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_status_value_new( fd_status_value_t * self );
 int fd_status_value_encode( fd_status_value_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7827,8 +5847,6 @@ ulong fd_status_value_size( fd_status_value_t const * self );
 static inline ulong fd_status_value_align( void ) { return FD_STATUS_VALUE_ALIGN; }
 int fd_status_value_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_status_value_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_status_value_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_status_value_encode_global( fd_status_value_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_status_pair_new( fd_status_pair_t * self );
 int fd_status_pair_encode( fd_status_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7837,8 +5855,6 @@ ulong fd_status_pair_size( fd_status_pair_t const * self );
 static inline ulong fd_status_pair_align( void ) { return FD_STATUS_PAIR_ALIGN; }
 int fd_status_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_status_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_status_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_status_pair_encode_global( fd_status_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_slot_delta_new( fd_slot_delta_t * self );
 int fd_slot_delta_encode( fd_slot_delta_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7847,8 +5863,6 @@ ulong fd_slot_delta_size( fd_slot_delta_t const * self );
 static inline ulong fd_slot_delta_align( void ) { return FD_SLOT_DELTA_ALIGN; }
 int fd_slot_delta_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_slot_delta_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_slot_delta_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_slot_delta_encode_global( fd_slot_delta_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_bank_slot_deltas_new( fd_bank_slot_deltas_t * self );
 int fd_bank_slot_deltas_encode( fd_bank_slot_deltas_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7857,8 +5871,6 @@ ulong fd_bank_slot_deltas_size( fd_bank_slot_deltas_t const * self );
 static inline ulong fd_bank_slot_deltas_align( void ) { return FD_BANK_SLOT_DELTAS_ALIGN; }
 int fd_bank_slot_deltas_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_bank_slot_deltas_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_bank_slot_deltas_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_bank_slot_deltas_encode_global( fd_bank_slot_deltas_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_pubkey_rewardinfo_pair_new( fd_pubkey_rewardinfo_pair_t * self );
 int fd_pubkey_rewardinfo_pair_encode( fd_pubkey_rewardinfo_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7875,8 +5887,6 @@ ulong fd_optional_account_size( fd_optional_account_t const * self );
 static inline ulong fd_optional_account_align( void ) { return FD_OPTIONAL_ACCOUNT_ALIGN; }
 int fd_optional_account_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_optional_account_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_optional_account_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_optional_account_encode_global( fd_optional_account_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_calculated_stake_points_new( fd_calculated_stake_points_t * self ) { fd_memset( self, 0, sizeof(fd_calculated_stake_points_t) ); }
 int fd_calculated_stake_points_encode( fd_calculated_stake_points_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7909,8 +5919,6 @@ ulong fd_duplicate_slot_proof_size( fd_duplicate_slot_proof_t const * self );
 static inline ulong fd_duplicate_slot_proof_align( void ) { return FD_DUPLICATE_SLOT_PROOF_ALIGN; }
 int fd_duplicate_slot_proof_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_duplicate_slot_proof_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_duplicate_slot_proof_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_duplicate_slot_proof_encode_global( fd_duplicate_slot_proof_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_epoch_info_pair_new( fd_epoch_info_pair_t * self ) { fd_memset( self, 0, sizeof(fd_epoch_info_pair_t) ); }
 int fd_epoch_info_pair_encode( fd_epoch_info_pair_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7931,8 +5939,6 @@ ulong fd_vote_info_pair_size( fd_vote_info_pair_t const * self );
 static inline ulong fd_vote_info_pair_align( void ) { return FD_VOTE_INFO_PAIR_ALIGN; }
 int fd_vote_info_pair_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_vote_info_pair_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_vote_info_pair_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_vote_info_pair_encode_global( fd_vote_info_pair_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_epoch_info_new( fd_epoch_info_t * self );
 int fd_epoch_info_encode( fd_epoch_info_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7941,8 +5947,6 @@ ulong fd_epoch_info_size( fd_epoch_info_t const * self );
 static inline ulong fd_epoch_info_align( void ) { return FD_EPOCH_INFO_ALIGN; }
 int fd_epoch_info_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_epoch_info_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_epoch_info_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_epoch_info_encode_global( fd_epoch_info_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 static inline void fd_usage_cost_details_new( fd_usage_cost_details_t * self ) { fd_memset( self, 0, sizeof(fd_usage_cost_details_t) ); }
 int fd_usage_cost_details_encode( fd_usage_cost_details_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -7990,8 +5994,6 @@ ulong fd_account_costs_size( fd_account_costs_t const * self );
 static inline ulong fd_account_costs_align( void ) { return FD_ACCOUNT_COSTS_ALIGN; }
 int fd_account_costs_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_account_costs_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_account_costs_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_account_costs_encode_global( fd_account_costs_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 void fd_cost_tracker_new( fd_cost_tracker_t * self );
 int fd_cost_tracker_encode( fd_cost_tracker_t const * self, fd_bincode_encode_ctx_t * ctx );
@@ -8000,8 +6002,6 @@ ulong fd_cost_tracker_size( fd_cost_tracker_t const * self );
 static inline ulong fd_cost_tracker_align( void ) { return FD_COST_TRACKER_ALIGN; }
 int fd_cost_tracker_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_cost_tracker_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
-void * fd_cost_tracker_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );
-int fd_cost_tracker_encode_global( fd_cost_tracker_global_t const * self, fd_bincode_encode_ctx_t * ctx );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/types/fd_types.json
+++ b/src/flamenco/types/fd_types.json
@@ -893,6 +893,7 @@
     {
       "name": "slot_history",
       "type": "struct",
+      "global": true,
       "fields": [
           { "name": "bits", "type": "bitvec", "element": "ulong" },
           { "name": "next_slot", "type": "ulong" }
@@ -910,6 +911,7 @@
     {
       "name": "slot_hashes",
       "type": "struct",
+      "global": true,
       "fields": [
           { "name": "hashes", "type": "deque", "element": "slot_hash", "min": 512 }
       ],
@@ -926,6 +928,7 @@
     {
       "name": "recent_block_hashes",
       "type": "struct",
+      "global": true,
       "fields": [
           { "name": "hashes", "type": "deque", "element": "block_block_hash_entry", "min": 151 }
       ]

--- a/src/flamenco/types/fd_types_custom.c
+++ b/src/flamenco/types/fd_types_custom.c
@@ -112,10 +112,6 @@ int fd_tower_sync_encode( fd_tower_sync_t const * self, fd_bincode_encode_ctx_t 
   FD_LOG_ERR(( "todo"));
 }
 
-int fd_tower_sync_encode_global( fd_tower_sync_global_t const * self, fd_bincode_encode_ctx_t * ctx ) {
-  FD_LOG_ERR(( "todo"));
-}
-
 static void fd_hash_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );
 static int fd_hash_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 static void fd_lockout_offset_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx );

--- a/src/flamenco/types/fd_types_custom.h
+++ b/src/flamenco/types/fd_types_custom.h
@@ -37,7 +37,6 @@ union fd_signature {
 };
 
 typedef union fd_signature fd_signature_t;
-typedef union fd_signature fd_signature_global_t;
 
 FD_PROTOTYPES_BEGIN
 
@@ -55,9 +54,6 @@ FD_PROTOTYPES_BEGIN
 #define fd_pubkey_decode_footprint        fd_hash_decode_footprint
 #define fd_pubkey_decode_footprint_inner  fd_hash_decode_footprint_inner
 #define fd_pubkey_decode                  fd_hash_decode
-#define fd_pubkey_decode_global           fd_hash_decode_global
-#define fd_pubkey_decode_inner_global     fd_hash_decode_inner_global
-#define fd_pubkey_convert_global_to_local fd_hash_convert_global_to_local
 
 struct __attribute__((aligned(8UL))) fd_option_slot {
   uchar is_some;
@@ -88,14 +84,6 @@ union fd_gossip_ip6_addr {
 
 typedef union fd_gossip_ip6_addr fd_gossip_ip6_addr_t;
 #define FD_GOSSIP_IP6_ADDR_ALIGN alignof(fd_gossip_ip6_addr_t)
-
-union fd_gossip_ip6_addr_global {
-  uchar  uc[ 16 ];
-  ushort us[  8 ];
-  uint   ul[  4 ];
-};
-
-typedef union fd_gossip_ip6_addr_global fd_gossip_ip6_addr_global_t;
 
 int
 fd_solana_vote_account_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );

--- a/src/flamenco/types/gen_stubs.py
+++ b/src/flamenco/types/gen_stubs.py
@@ -109,8 +109,10 @@ fuzzytypes = {
 
 class TypeNode:
     def __init__(self, json, **kwargs):
+        self.produce_global = False
         if json is not None:
             self.name = json["name"]
+            self.produce_global = bool(json["global"]) if "global" in json else None
         elif 'name' in kwargs:
             self.name = kwargs['name']
         else:
@@ -131,6 +133,9 @@ class TypeNode:
 
     def emitOffsetJoin(self, type_name):
         pass
+
+    def subTypes(self):
+        return iter(())
 
 class PrimitiveMember(TypeNode):
     def __init__(self, container, json):
@@ -1442,7 +1447,7 @@ class MapMember(TypeNode):
         print(f'  *alloc_mem = (uchar *)*alloc_mem + {mapname}_footprint( len );', file=header)
         print(f'  return {mapname}_join( {mapname}_new( map_mem, len ) );', file=header)
         print("}", file=header)
-        if self.element in flattypes:
+        if not self.produce_global or self.element in flattypes:
             return
         element_type = self.elem_type_global()
         mapname = element_type + "_map"
@@ -1491,6 +1496,8 @@ class MapMember(TypeNode):
             print(f'  return (long)( left->elem.{key} - right->elem.{key} );', file=body)
         print("}", file=body)
         if self.element in flattypes:
+            return
+        if not self.produce_global or self.element in flattypes:
             return
         element_type = self.elem_type_global()
         mapname = element_type + "_map"
@@ -2956,6 +2963,23 @@ class OpaqueType(TypeNode):
         pass
 
 
+# FIXME horrible code
+def extract_sub_type(member):
+    if isinstance(member, str):
+        return None
+    if isinstance(member, PrimitiveMember):
+        return None
+    if isinstance(member, OpaqueType):
+        return None
+    if isinstance(member, BitVectorMember):
+        return None
+    if hasattr(member, "type"):
+        return type_map[member.type]
+    if hasattr(member, "element"):
+        return type_map[member.element]
+    raise ValueError(f"Unknown type {member} in extract_sub_type")
+
+
 class StructType(TypeNode):
     def __init__(self, json):
         super().__init__(json)
@@ -2980,17 +3004,6 @@ class StructType(TypeNode):
         else:
             self.attribute = f''
             self.alignment = 0
-
-
-        # if a member is determined to be flat, then it should be
-        # added to the flattypes list.
-        self.produce_global = False
-        for f in self.fields:
-            if not f.isFlat():
-                self.produce_global = True
-
-        if not self.produce_global:
-            flattypes.add( self.name )
 
     def isFixedSize(self):
         for f in self.fields:
@@ -3017,6 +3030,12 @@ class StructType(TypeNode):
             if not f.isFuzzy():
                 return False
         return True
+
+    def subTypes(self):
+        for f in self.fields:
+            sub_type = extract_sub_type(f)
+            if sub_type is not None:
+                yield sub_type
 
     def emitHeader(self):
         for f in self.fields:
@@ -3045,9 +3064,7 @@ class StructType(TypeNode):
         print("", file=header)
 
         # Global type
-
-
-        if self.produce_global:
+        if self.produce_global and not self.isFlat():
             print(f'struct {self.attribute}{n}_global {{', file=header)
             for f in self.fields:
                 f.emitMemberGlobal()
@@ -3084,7 +3101,7 @@ class StructType(TypeNode):
         else:
             print(f'int {n}_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );', file=header)
         print(f'void * {n}_decode( void * mem, fd_bincode_decode_ctx_t * ctx );', file=header)
-        if self.produce_global:
+        if self.produce_global and not self.isFlat():
             print(f'void * {n}_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );', file=header)
             print(f"int {n}_encode_global( {n}_global_t const * self, fd_bincode_encode_ctx_t * ctx );", file=header)
         print("", file=header)
@@ -3092,7 +3109,7 @@ class StructType(TypeNode):
     def emitEncodes(self):
         n = self.fullname
         self.emitEncode(n)
-        if self.produce_global:
+        if self.produce_global and not self.isFlat():
             self.emitEncodeGlobal(n)
 
     def emitEncode(self, n):
@@ -3169,7 +3186,7 @@ class StructType(TypeNode):
             print(f'  return self;', file=body)
             print(f'}}', file=body)
 
-            if self.produce_global:
+            if self.produce_global and not self.isFlat():
                 print(f'static void {n}_decode_inner_global( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {{', file=body)
                 print(f'  {n}_global_t * self = ({n}_global_t *)struct_mem;', file=body)
                 for f in self.fields:
@@ -3249,15 +3266,11 @@ class EnumType(TypeNode):
             self.repr_codec_stem = "uint64"
             self.repr_max_val = "ULONG_MAX"
 
-        self.produce_global = False
-
+    def subTypes(self):
         for v in self.variants:
-            if not isinstance(v, str):
-                if not v.isFlat():
-                    self.produce_global = True
-
-        if not self.produce_global:
-            flattypes.add(self.name)
+            sub_type = extract_sub_type(v)
+            if sub_type is not None:
+                yield sub_type
 
     def isFlat(self):
         for v in self.variants:
@@ -3301,7 +3314,7 @@ class EnumType(TypeNode):
             print("};", file=header)
             print(f"typedef union {n}_inner {n}_inner_t;\n", file=header)
 
-            if self.produce_global:
+            if self.produce_global and not self.isFlat():
                 print(f'union {self.attribute}{n}_inner_global {{', file=header)
                 empty = True
                 for v in self.variants:
@@ -3327,17 +3340,17 @@ class EnumType(TypeNode):
         else:
             print(f"#define {n.upper()}_ALIGN alignof({n}_t)", file=header)
 
-        if self.produce_global:
+        if self.produce_global and not self.isFlat():
             print(f"struct {self.attribute}{n}_global {{", file=header)
             print(f'  {self.repr} discriminant;', file=header)
             print(f'  {n}_inner_global_t inner;', file=header)
             print("};", file=header)
             print(f"typedef struct {n}_global {n}_global_t;", file=header)
 
-        if self.alignment > 0:
-            print(f"#define {n.upper()}_GLOBAL_ALIGN ({self.alignment}UL)", file=header)
-        else:
-            print(f"#define {n.upper()}_GLOBAL_ALIGN alignof({n}_global_t)", file=header)
+            if self.alignment > 0:
+                print(f"#define {n.upper()}_GLOBAL_ALIGN ({self.alignment}UL)", file=header)
+            else:
+                print(f"#define {n.upper()}_GLOBAL_ALIGN alignof({n}_global_t)", file=header)
         print("", file=header)
 
     def emitPrototypes(self):
@@ -3354,7 +3367,7 @@ class EnumType(TypeNode):
         print(f'static inline ulong {n}_align( void ) {{ return {n.upper()}_ALIGN; }}', file=header)
         print(f'int {n}_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );', file=header)
         print(f'void * {n}_decode( void * mem, fd_bincode_decode_ctx_t * ctx );', file=header)
-        if self.produce_global:
+        if self.produce_global and not self.isFlat():
             print(f'void * {n}_decode_global( void * mem, fd_bincode_decode_ctx_t * ctx );', file=header)
             print(f"int {n}_encode_global( {n}_global_t const * self, fd_bincode_encode_ctx_t * ctx );", file=header)
         print("", file=header)
@@ -3429,7 +3442,7 @@ class EnumType(TypeNode):
             print("}", file=body)
 
 
-            if self.produce_global:
+            if self.produce_global and not self.isFlat():
                 print(f'static void {n}_inner_decode_inner_global( {n}_inner_global_t * self, void * * alloc_mem, {self.repr} discriminant, fd_bincode_decode_ctx_t * ctx ) {{', file=body)
                 print('  switch (discriminant) {', file=body)
                 for i, v in enumerate(self.variants):
@@ -3462,7 +3475,7 @@ class EnumType(TypeNode):
         print(f'  return self;', file=body)
         print(f'}}', file=body)
 
-        if self.produce_global:
+        if self.produce_global and not self.isFlat():
             print(f'static int {n}_inner_encode_global( {n}_inner_global_t const * self, {self.repr} discriminant, fd_bincode_encode_ctx_t * ctx ) {{', file=body)
             first = True
             for i, v in enumerate(self.variants):
@@ -3607,6 +3620,8 @@ class EnumType(TypeNode):
             if not isinstance(v, str):
                 v.emitPostamble()
 
+type_map = {}
+
 def main():
     alltypes = []
     for entry in entries:
@@ -3616,6 +3631,18 @@ def main():
             alltypes.append(StructType(entry))
         if entry['type'] == 'enum':
             alltypes.append(EnumType(entry))
+
+    global type_map
+    for t in alltypes:
+        type_map[t.name] = t
+
+    # Propagate 'global' attribute
+    propagate = set(alltypes)
+    while len(propagate) > 0:
+        t = propagate.pop()
+        if t.produce_global:
+            for sub in t.subTypes():
+                sub.produce_global = True
 
     nametypes = {}
     for t in alltypes:


### PR DESCRIPTION
Only produce position-independent type decoders when explicitly
requested.

Introduces a new 'global' attribute in 'types.json'.  If set on a
top-level struct, the attribute is propagated to all sub types.
