### PR TITLE
quic: keep alive config parameter

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -39,14 +39,6 @@
 #define MAP_QUERY_OPT         1
 #include "../../util/tmpl/fd_map_dynamic.c"
 
-/* FD_QUIC_KEEP_ALIVE
- *
- * This compile time option specifies whether the server should use
- * QUIC PING frames to keep connections alive
- *
- * Set to 1 to keep connections alive
- * Set to 0 to allow connections to close on idle */
-# define FD_QUIC_KEEP_ALIVE 0
 
 /* FD_QUIC_MAX_STREAMS_ALWAYS_UNLESS_ACKED  */
 /* Defines whether a MAX_STREAMS frame is sent even if it was just */
@@ -2832,8 +2824,6 @@ fd_quic_svc_poll( fd_quic_t *      quic,
     return 1;
   }
 
-  //FD_DEBUG( FD_LOG_DEBUG(( "svc_poll conn=%p svc_type=%u", (void *)conn, conn->svc_type )); )
-
   if( FD_UNLIKELY( now >= conn->last_activity + ( conn->idle_timeout / 2 ) ) ) {
     if( FD_UNLIKELY( now >= conn->last_activity + conn->idle_timeout ) ) {
       if( FD_LIKELY( conn->state != FD_QUIC_CONN_STATE_DEAD ) ) {
@@ -2841,14 +2831,14 @@ fd_quic_svc_poll( fd_quic_t *      quic,
             "... the connection is silently closed and its state is discarded
             when it remains idle for longer than the minimum of the
             max_idle_timeout value advertised by both endpoints." */
-        FD_DEBUG( FD_LOG_WARNING(( "%s  conn %p  conn_idx: %u  closing due to idle timeout (%g ms)",
+        FD_DEBUG( FD_LOG_WARNING(("%s  conn %p  conn_idx: %u  closing due to idle timeout (%g ms)",
             conn->server?"SERVER":"CLIENT",
             (void *)conn, conn->conn_idx, (double)conn->idle_timeout / 1e6 )); )
 
         fd_quic_set_conn_state( conn, FD_QUIC_CONN_STATE_DEAD );
         quic->metrics.conn_timeout_cnt++;
       }
-    } else if( FD_QUIC_KEEP_ALIVE ) {
+    } else if( quic->config.keep_alive ) {
       /* send PING */
       if( !( conn->flags & FD_QUIC_CONN_FLAGS_PING ) ) {
         conn->flags         |= FD_QUIC_CONN_FLAGS_PING;
@@ -2876,7 +2866,8 @@ fd_quic_svc_poll( fd_quic_t *      quic,
     fd_quic_conn_free( quic, conn );
     break;
   default:
-    fd_quic_svc_prep_schedule( conn, state->now + quic->config.idle_timeout );
+    /* prep idle timeout or keep alive at idle timeout/2 */
+    fd_quic_svc_prep_schedule( conn, state->now + (conn->idle_timeout>>(quic->config.keep_alive)) );
     fd_quic_svc_schedule( state->svc_timers, conn );
     break;
   }
@@ -4292,8 +4283,9 @@ fd_quic_conn_create( fd_quic_t *               quic,
 
   fd_quic_svc_timers_init_conn( conn );
 
-  /* prep idle timeout */
-  fd_quic_svc_prep_schedule( conn, state->now+quic->config.idle_timeout );
+  /* prep idle timeout or keep alive at idle timeout/2 */
+  ulong delay = quic->config.idle_timeout>>(quic->config.keep_alive);
+  fd_quic_svc_prep_schedule( conn, state->now+delay );
 
   /* return connection */
   return conn;

--- a/src/waltz/quic/fd_quic.h
+++ b/src/waltz/quic/fd_quic.h
@@ -169,6 +169,13 @@ struct __attribute__((aligned(16UL))) fd_quic_config {
   ulong idle_timeout;
 # define FD_QUIC_DEFAULT_IDLE_TIMEOUT (ulong)(1e9) /* 1s */
 
+/* keep_alive
+ * whether the fd_quic should use QUIC PING frames to keep connections alive
+ * Set to 1 to keep connections alive
+ * Set to 0 to allow connections to close on idle
+ * default is 0 */
+  int keep_alive;
+
   /* ack_delay: median delay on outgoing ACKs.  Greater delays allow
      fd_quic to coalesce packet ACKs. */
   ulong ack_delay;

--- a/src/waltz/quic/tests/test_quic_hs.c
+++ b/src/waltz/quic/tests/test_quic_hs.c
@@ -199,6 +199,31 @@ main( int argc, char ** argv ) {
     FD_LOG_INFO(( "fd_quic_stream_send returned %d", rc ));
   }
 
+  /* testing keep_alive */
+  ulong const idle_timeout = fd_ulong_min(
+                                  client_quic->config.idle_timeout,
+                                  server_quic->config.idle_timeout
+                                 );
+  ulong const timestep     = idle_timeout>>3;
+
+  for( int keep_alive=1; keep_alive>=0; --keep_alive ) {
+    client_quic->config.keep_alive = keep_alive;
+    for( int i=0; i<10; ++i ) {
+      now+=timestep;
+      fd_quic_service( client_quic );
+      fd_quic_service( server_quic );
+    }
+    if( keep_alive ) {
+      FD_TEST( client_conn->state == FD_QUIC_CONN_STATE_ACTIVE );
+    } else {
+      FD_TEST( client_conn->state == FD_QUIC_CONN_STATE_DEAD ||
+              client_conn->state == FD_QUIC_CONN_STATE_INVALID );
+    }
+  }
+
+  FD_LOG_NOTICE(( "Validated idle_timeout and keep_alive" ));
+
+
   FD_LOG_NOTICE(( "Closing connections" ));
 
   fd_quic_state_validate( server_quic );


### PR DESCRIPTION
This PR makes keep_alive a quic config parameter rather than a compile time option. This is primarily to support the sender tile. 