### PR TITLE
flamenco: remove unused code when pushing instr stack

### DIFF
--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -958,8 +958,7 @@ fd_instr_stack_push( fd_exec_txn_ctx_t *     txn_ctx,
   int err = fd_exec_txn_ctx_get_key_of_account_at_index( txn_ctx,
                                                          instr->program_id,
                                                          &program_id_pubkey );
-  if( FD_UNLIKELY( err ||
-                   !memcmp( program_id_pubkey->key, fd_solana_native_loader_id.key, sizeof(fd_pubkey_t) ) ) ) {
+  if( FD_UNLIKELY( err ) ) {
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
   }
 


### PR DESCRIPTION
 if the vector of account indices is empty then `fd_exec_txn_ctx_get_key_of_account_at_index` should fail first.

Ran a pass of local fuzzing didn't seem to trigger a mismatch.