### PR TITLE
fuzz: types fuzzer compatibility changes

### DIFF
--- a/src/flamenco/runtime/tests/harness/fd_types_harness.c
+++ b/src/flamenco/runtime/tests/harness/fd_types_harness.c
@@ -28,7 +28,11 @@ custom_serializer_walk( void *       _self,
   switch( type ) {
     case FD_FLAMENCO_TYPE_MAP:
     case FD_FLAMENCO_TYPE_MAP_END:
+      break;
     case FD_FLAMENCO_TYPE_ENUM:
+      // print the enum discriminant
+      fprintf( file, "%u,", *(uint const*) arg );
+      break;
     case FD_FLAMENCO_TYPE_ENUM_END:
     case FD_FLAMENCO_TYPE_ARR:
     case FD_FLAMENCO_TYPE_ARR_END:
@@ -131,16 +135,8 @@ custom_serializer_walk( void *       _self,
         fprintf( file, "'%s',", (char const *)arg );
       }
       break;
-    case FD_FLAMENCO_TYPE_ENUM_DISC: {
-      char lowercase_variant[128];
-      memset(lowercase_variant, 0, 128);
-
-      for( ulong i=0; name[i]; ++i ) {
-        lowercase_variant[i] = (char) tolower(name[i]);
-      }
-      fprintf( file, "'%s',", lowercase_variant );
+    case FD_FLAMENCO_TYPE_ENUM_DISC:
       break;
-    }
     default:
       FD_LOG_CRIT(( "unknown type %#x", (uint)type ));
       break;

--- a/src/flamenco/types/fd_types_custom.c
+++ b/src/flamenco/types/fd_types_custom.c
@@ -89,9 +89,15 @@ fd_gossip_ip4_addr_walk( void *                       w,
                          char const *                 name,
                          uint                         level ) {
 
-  char buf[ 16 ];
-  sprintf( buf, FD_IP4_ADDR_FMT, FD_IP4_ADDR_FMT_ARGS( *self ) );
-  fun( w, buf, name, FD_FLAMENCO_TYPE_CSTR, "ip4_addr", level );
+  uchar * octet = (uchar *)self;
+  for( uchar i = 0; i < 4; ++i ) {
+    fun( w, &octet[i], name, FD_FLAMENCO_TYPE_UCHAR, "uchar", level );
+  }
+  /* TODO: Add support for optional pretty-printing like serde?
+     Saving this in the meantime */
+  // char buf[ 16 ];
+  // sprintf( buf, FD_IP4_ADDR_FMT, FD_IP4_ADDR_FMT_ARGS( *self ) );
+  // fun( w, buf, name, FD_FLAMENCO_TYPE_CSTR, "ip4_addr", level );
 }
 
 void
@@ -100,12 +106,16 @@ fd_gossip_ip6_addr_walk( void *                       w,
                          fd_types_walk_fn_t           fun,
                          char const *                 name,
                          uint                         level ) {
-
-  char buf[ 40 ];
-  sprintf( buf,
-           "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
-           FD_LOG_HEX16_FMT_ARGS( self->us ) );
-  fun( w, buf, name, FD_FLAMENCO_TYPE_CSTR, "ip6_addr", level );
+  uchar * octet = (uchar *)self;
+  for( uchar i = 0; i < 16; ++i ) {
+    fun( w, &octet[i], name, FD_FLAMENCO_TYPE_UCHAR, "uchar", level );
+  }
+  /* Saving this for when we support configurable pretty-printing mode */
+  // char buf[ 40 ];
+  // sprintf( buf,
+  //          "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
+  //          FD_LOG_HEX16_FMT_ARGS( self->us ) );
+  // fun( w, buf, name, FD_FLAMENCO_TYPE_CSTR, "ip6_addr", level );
 }
 
 int fd_tower_sync_encode( fd_tower_sync_t const * self, fd_bincode_encode_ctx_t * ctx ) {

--- a/src/flamenco/types/fixtures/gossip_pull_req.yml
+++ b/src/flamenco/types/fixtures/gossip_pull_req.yml
@@ -114,43 +114,73 @@ pull_req:
         id: 'FtxH6Na6AJk8hM21DzsHtmGCuwgm4qWdUTosAdN9fmTD'
         gossip: 
           ip4: 
-            addr: '0.0.0.0'
+            addr: 0
+            addr: 0
+            addr: 0
+            addr: 0
             port: 0
         tvu: 
           ip4: 
-            addr: '0.0.0.0'
+            addr: 0
+            addr: 0
+            addr: 0
+            addr: 0
             port: 0
         tvu_fwd: 
           ip4: 
-            addr: '0.0.0.0'
+            addr: 0
+            addr: 0
+            addr: 0
+            addr: 0
             port: 0
         repair: 
           ip4: 
-            addr: '0.0.0.0'
+            addr: 0
+            addr: 0
+            addr: 0
+            addr: 0
             port: 0
         tpu: 
           ip4: 
-            addr: '0.0.0.0'
+            addr: 0
+            addr: 0
+            addr: 0
+            addr: 0
             port: 0
         tpu_fwd: 
           ip4: 
-            addr: '0.0.0.0'
+            addr: 0
+            addr: 0
+            addr: 0
+            addr: 0
             port: 0
         tpu_vote: 
           ip4: 
-            addr: '0.0.0.0'
+            addr: 0
+            addr: 0
+            addr: 0
+            addr: 0
             port: 0
         rpc: 
           ip4: 
-            addr: '0.0.0.0'
+            addr: 0
+            addr: 0
+            addr: 0
+            addr: 0
             port: 0
         rpc_pubsub: 
           ip4: 
-            addr: '0.0.0.0'
+            addr: 0
+            addr: 0
+            addr: 0
+            addr: 0
             port: 0
         serve_repair: 
           ip4: 
-            addr: '0.0.0.0'
+            addr: 0
+            addr: 0
+            addr: 0
+            addr: 0
             port: 0
         wallclock: 1660627129489
         shred_version: 0

--- a/src/flamenco/types/fixtures/gossip_pull_resp_contact_info.yml
+++ b/src/flamenco/types/fixtures/gossip_pull_resp_contact_info.yml
@@ -7,43 +7,73 @@ pull_resp:
           id: '9Diwct7c6braQnne86jutswAW4iZmPfcg6VHVp4FBrLn'
           gossip: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 1024
           tvu: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 1025
           tvu_fwd: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 1026
           repair: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 1031
           tpu: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 1027
           tpu_fwd: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 1028
           tpu_vote: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 1029
           rpc: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 8899
           rpc_pubsub: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 8900
           serve_repair: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 1032
           wallclock: 1660658416429
           shred_version: 25514

--- a/src/flamenco/types/fixtures/gossip_pull_resp_contact_info_v2.yml
+++ b/src/flamenco/types/fixtures/gossip_pull_resp_contact_info_v2.yml
@@ -7,43 +7,73 @@ push_msg:
           id: 'Hm5NNNZpBgAo5j3gRwJtkHXihpLzdCyP3WRWHLzcPSup'
           gossip: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 1024
           tvu: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 1025
           tvu_fwd: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 1026
           repair: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 1035
           tpu: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 1027
           tpu_fwd: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 1028
           tpu_vote: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 1029
           rpc: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 8899
           rpc_pubsub: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 8900
           serve_repair: 
             ip4: 
-              addr: '127.0.0.1'
+              addr: 127
+              addr: 0
+              addr: 0
+              addr: 1
               port: 1032
           wallclock: 1702312087747
           shred_version: 22793
@@ -62,7 +92,10 @@ push_msg:
             feature_set: 367846227
             client: 0
           addrs: 
-            - ip4: '127.0.0.1'
+            - ip4: 127
+              ip4: 0
+              ip4: 0
+              ip4: 1
           sockets: 
             - key: 0
               index: 0


### PR DESCRIPTION
1. Encode enum discriminants instead of names in in-memory representation (corresponding solfuzz-ag PR here https://github.com/firedancer-io/solfuzz-agave/pull/267)
2. Do not pretty print gossip ipaddrs (for now) 