### PR TITLE
Remove dependencies on funk

### DIFF
--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -39,7 +39,7 @@ $(call add-objs,commands/run_agave,fd_fdctl)
 $(call make-lib,fdctl_version)
 $(call add-objs,version,fdctl_version)
 
-$(call make-bin-rust,fdctl,main,fd_fdctl fdctl_shared fd_discoh fd_disco agave_validator firedancer_plugin_bundle fd_flamenco fd_funk fd_quic fd_tls fd_reedsol fd_ballet fd_waltz fd_tango fd_util fdctl_version)
+$(call make-bin-rust,fdctl,main,fd_fdctl fdctl_shared fd_discoh fd_disco agave_validator firedancer_plugin_bundle fd_flamenco fd_quic fd_tls fd_reedsol fd_ballet fd_waltz fd_tango fd_util fdctl_version)
 
 check-agave-hash:
 	@$(eval AGAVE_COMMIT_LS_TREE=$(shell git ls-tree HEAD | grep agave | awk '{print $$3}'))

--- a/src/app/fddev/Local.mk
+++ b/src/app/fddev/Local.mk
@@ -12,7 +12,7 @@ $(call add-objs,commands/configure/blockstore,fd_fddev)
 $(call add-objs,commands/bench,fd_fddev)
 $(call add-objs,commands/dev,fd_fddev)
 
-$(call make-bin-rust,fddev,main,fd_fddev fd_fdctl fddev_shared fdctl_shared fd_discoh fd_disco agave_validator firedancer_plugin_bundle fd_flamenco fd_funk fd_quic fd_tls fd_reedsol fd_ballet fd_waltz fd_tango fd_util fdctl_version)
+$(call make-bin-rust,fddev,main,fd_fddev fd_fdctl fddev_shared fdctl_shared fd_discoh fd_disco agave_validator firedancer_plugin_bundle fd_flamenco fd_quic fd_tls fd_reedsol fd_ballet fd_waltz fd_tango fd_util fdctl_version)
 
 ifeq (run,$(firstword $(MAKECMDGOALS)))
   RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
@@ -38,7 +38,7 @@ endif
 monitor: bin
 	$(OBJDIR)/bin/fddev monitor $(MONITOR_ARGS)
 
-$(call make-integration-test,test_fddev,tests/test_fddev,fd_fddev fd_fdctl fddev_shared fdctl_shared fd_discoh fd_disco agave_validator firedancer_plugin_bundle fd_flamenco fd_funk fd_quic fd_tls fd_reedsol fd_ballet fd_waltz fd_tango fd_util fdctl_version)
+$(call make-integration-test,test_fddev,tests/test_fddev,fd_fddev fd_fdctl fddev_shared fdctl_shared fd_discoh fd_disco agave_validator firedancer_plugin_bundle fd_flamenco fd_quic fd_tls fd_reedsol fd_ballet fd_waltz fd_tango fd_util fdctl_version)
 $(call run-integration-test,test_fddev)
 
 endif

--- a/src/app/shredcap/Local.mk
+++ b/src/app/shredcap/Local.mk
@@ -1,5 +1,5 @@
 ifdef FD_HAS_ROCKSDB
-$(call make-bin,fd_shred_cap,main,fd_flamenco fd_ballet fd_funk fd_util,$(ROCKSDB_LIBS))
+$(call make-bin,fd_shred_cap,main,fd_flamenco fd_ballet fd_util,$(ROCKSDB_LIBS))
 else
 $(warning shredcap capture tool build disabled due to lack of rocksdb)
 endif

--- a/src/choreo/voter/Local.mk
+++ b/src/choreo/voter/Local.mk
@@ -2,7 +2,7 @@ ifdef FD_HAS_INT128
 $(call add-hdrs,fd_voter.h)
 $(call add-objs,fd_voter,fd_choreo)
 ifdef FD_HAS_HOSTED
-$(call make-bin,fd_voter_ctl,fd_voter_ctl,fd_choreo fd_flamenco fd_funk fd_ballet fd_util)
-$(call make-unit-test,test_voter,test_voter,fd_choreo fd_flamenco fd_funk fd_ballet fd_util)
+$(call make-bin,fd_voter_ctl,fd_voter_ctl,fd_choreo fd_flamenco fd_ballet fd_util)
+$(call make-unit-test,test_voter,test_voter,fd_choreo fd_flamenco fd_ballet fd_util)
 endif
 endif

--- a/src/flamenco/features/fd_features.h
+++ b/src/flamenco/features/fd_features.h
@@ -14,6 +14,19 @@
 
 #define FD_FEATURE_DISABLED (ULONG_MAX)
 
+/* Convenience macros for checking features */
+
+#define FD_FEATURE_ACTIVE_(_slot, _features, _feature_name)               (_slot >= (_features). _feature_name)
+#define FD_FEATURE_JUST_ACTIVATED_(_slot, _features, _feature_name)       (_slot == (_features). _feature_name)
+#define FD_FEATURE_ACTIVE_OFFSET_(_slot, _features, _offset)              (_slot >= (_features).f[_offset>>3])
+#define FD_FEATURE_JUST_ACTIVATED_OFFSET_(_slot, _features, _offset)      (_slot == (_features).f[_offset>>3] )
+
+#define FD_FEATURE_SET_ACTIVE(_features, _feature_name, _slot)           ((_features). _feature_name = _slot)
+#define FD_FEATURE_ACTIVE(_slot,_features,_feature_name)                  FD_FEATURE_ACTIVE_( _slot,_features,_feature_name )
+#define FD_FEATURE_JUST_ACTIVATED(_slot_ctx, _feature_name)               FD_FEATURE_JUST_ACTIVATED_( _slot_ctx->slot_bank.slot, _slot_ctx->epoch_ctx->features, _feature_name )
+#define FD_FEATURE_ACTIVE_OFFSET(_slot, _features, _offset)               FD_FEATURE_ACTIVE_OFFSET_( _slot, _features, _offset )
+#define FD_FEATURE_JUST_ACTIVATED_OFFSET(_slot_ctx, _offset)              FD_FEATURE_JUST_ACTIVATED_OFFSET_( _slot_ctx->slot_bank.slot, _slot_ctx->epoch_ctx->features, _offset )
+
 /* fd_features_t is the current set of enabled feature flags.
 
    Each feature has a corresponding account in the account database,

--- a/src/flamenco/gossip/Local.mk
+++ b/src/flamenco/gossip/Local.mk
@@ -2,6 +2,6 @@ ifdef FD_HAS_HOSTED
 ifdef FD_HAS_INT128
 $(call add-hdrs,fd_gossip.h)
 $(call add-objs,fd_gossip,fd_flamenco)
-$(call make-bin,fd_gossip_spy,fd_gossip_spy,fd_flamenco fd_ballet fd_funk fd_util)
+$(call make-bin,fd_gossip_spy,fd_gossip_spy,fd_flamenco fd_ballet fd_util)
 endif
 endif

--- a/src/flamenco/repair/Local.mk
+++ b/src/flamenco/repair/Local.mk
@@ -2,6 +2,6 @@ ifdef FD_HAS_INT128
 $(call add-hdrs,fd_repair.h)
 $(call add-objs,fd_repair,fd_flamenco)
 ifdef FD_HAS_HOSTED
-$(call make-bin,fd_repair_tool,fd_repair_tool,fd_flamenco fd_ballet fd_funk fd_util)
+$(call make-bin,fd_repair_tool,fd_repair_tool,fd_flamenco fd_ballet fd_util)
 endif
 endif

--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.c
@@ -225,52 +225,6 @@ fd_exec_txn_ctx_teardown( fd_exec_txn_ctx_t * ctx ) {
 }
 
 void
-fd_exec_txn_ctx_from_exec_slot_ctx( fd_exec_slot_ctx_t const * slot_ctx,
-                                    fd_exec_txn_ctx_t *        ctx,
-                                    fd_wksp_t const *          funk_wksp,
-                                    fd_wksp_t const *          runtime_pub_wksp,
-                                    ulong                      funk_txn_gaddr,
-                                    ulong                      sysvar_cache_gaddr,
-                                    ulong                      funk_gaddr ) {
-
-  ctx->runtime_pub_wksp = (fd_wksp_t *)runtime_pub_wksp;
-
-  ctx->funk_txn = fd_wksp_laddr( funk_wksp, funk_txn_gaddr );
-  if( FD_UNLIKELY( !ctx->funk_txn ) ) {
-    FD_LOG_ERR(( "Could not find valid funk transaction" ));
-  }
-
-  if( FD_UNLIKELY( !fd_funk_join( ctx->funk, fd_wksp_laddr( funk_wksp, funk_gaddr ) ) ) ) {
-    FD_LOG_ERR(( "Could not find valid funk %lu", funk_gaddr ));
-  }
-
-  ctx->sysvar_cache = fd_wksp_laddr( runtime_pub_wksp, sysvar_cache_gaddr );
-  if( FD_UNLIKELY( !ctx->sysvar_cache ) ) {
-    FD_LOG_ERR(( "Could not find valid sysvar cache" ));
-  }
-
-  ctx->features     = slot_ctx->epoch_ctx->features;
-  ctx->status_cache = slot_ctx->status_cache;
-
-  ctx->bank_hash_cmp = slot_ctx->epoch_ctx->bank_hash_cmp;
-
-  ctx->prev_lamports_per_signature = slot_ctx->prev_lamports_per_signature;
-  ctx->enable_exec_recording       = slot_ctx->enable_exec_recording;
-  ctx->total_epoch_stake           = slot_ctx->epoch_ctx->total_epoch_stake;
-
-  ctx->slot                        = slot_ctx->slot_bank.slot;
-  ctx->fee_rate_governor           = slot_ctx->slot_bank.fee_rate_governor;
-  ctx->block_hash_queue            = slot_ctx->slot_bank.block_hash_queue; /* MAKE GLOBAL */
-
-  fd_epoch_bank_t const * epoch_bank = fd_exec_epoch_ctx_epoch_bank_const( slot_ctx->epoch_ctx );
-  ctx->schedule                    = epoch_bank->epoch_schedule;
-  ctx->rent                        = epoch_bank->rent;
-  ctx->slots_per_year              = epoch_bank->slots_per_year;
-  ctx->stakes                      = epoch_bank->stakes;
-
-}
-
-void
 fd_exec_txn_ctx_reset_return_data( fd_exec_txn_ctx_t * txn_ctx ) {
   txn_ctx->return_data.len = 0;
 }

--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.h
@@ -230,15 +230,6 @@ fd_exec_txn_ctx_setup( fd_exec_txn_ctx_t * ctx,
                        fd_rawtxn_b_t const * txn_raw );
 
 void
-fd_exec_txn_ctx_from_exec_slot_ctx( fd_exec_slot_ctx_t const * slot_ctx,
-                                    fd_exec_txn_ctx_t *        ctx,
-                                    fd_wksp_t const *          funk_wksp,
-                                    fd_wksp_t const *          runtime_pub_wksp,
-                                    ulong                      funk_txn_gaddr,
-                                    ulong                      sysvar_cache_gaddr,
-                                    ulong                      funk_gaddr );
-
-void
 fd_exec_txn_ctx_teardown( fd_exec_txn_ctx_t * txn_ctx );
 
 /* Mirrors Agave function solana_sdk::transaction_context::find_index_of_account

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -1174,6 +1174,52 @@ fd_executor_is_blockhash_valid_for_age( fd_block_hash_queue_t const * block_hash
   return ( age<=max_age );
 }
 
+void
+fd_exec_txn_ctx_from_exec_slot_ctx( fd_exec_slot_ctx_t const * slot_ctx,
+                                    fd_exec_txn_ctx_t *        ctx,
+                                    fd_wksp_t const *          funk_wksp,
+                                    fd_wksp_t const *          runtime_pub_wksp,
+                                    ulong                      funk_txn_gaddr,
+                                    ulong                      sysvar_cache_gaddr,
+                                    ulong                      funk_gaddr ) {
+
+  ctx->runtime_pub_wksp = (fd_wksp_t *)runtime_pub_wksp;
+
+  ctx->funk_txn = fd_wksp_laddr( funk_wksp, funk_txn_gaddr );
+  if( FD_UNLIKELY( !ctx->funk_txn ) ) {
+    FD_LOG_ERR(( "Could not find valid funk transaction" ));
+  }
+
+  if( FD_UNLIKELY( !fd_funk_join( ctx->funk, fd_wksp_laddr( funk_wksp, funk_gaddr ) ) ) ) {
+    FD_LOG_ERR(( "Could not find valid funk %lu", funk_gaddr ));
+  }
+
+  ctx->sysvar_cache = fd_wksp_laddr( runtime_pub_wksp, sysvar_cache_gaddr );
+  if( FD_UNLIKELY( !ctx->sysvar_cache ) ) {
+    FD_LOG_ERR(( "Could not find valid sysvar cache" ));
+  }
+
+  ctx->features     = slot_ctx->epoch_ctx->features;
+  ctx->status_cache = slot_ctx->status_cache;
+
+  ctx->bank_hash_cmp = slot_ctx->epoch_ctx->bank_hash_cmp;
+
+  ctx->prev_lamports_per_signature = slot_ctx->prev_lamports_per_signature;
+  ctx->enable_exec_recording       = slot_ctx->enable_exec_recording;
+  ctx->total_epoch_stake           = slot_ctx->epoch_ctx->total_epoch_stake;
+
+  ctx->slot                        = slot_ctx->slot_bank.slot;
+  ctx->fee_rate_governor           = slot_ctx->slot_bank.fee_rate_governor;
+  ctx->block_hash_queue            = slot_ctx->slot_bank.block_hash_queue; /* MAKE GLOBAL */
+
+  fd_epoch_bank_t const * epoch_bank = fd_exec_epoch_ctx_epoch_bank_const( slot_ctx->epoch_ctx );
+  ctx->schedule                    = epoch_bank->epoch_schedule;
+  ctx->rent                        = epoch_bank->rent;
+  ctx->slots_per_year              = epoch_bank->slots_per_year;
+  ctx->stakes                      = epoch_bank->stakes;
+
+}
+
 fd_txn_account_t *
 fd_executor_setup_txn_account( fd_exec_txn_ctx_t * txn_ctx,
                                ushort              idx ) {

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -141,6 +141,15 @@ int
 fd_instr_stack_pop( fd_exec_txn_ctx_t *       txn_ctx,
                     fd_instr_info_t const *   instr );
 
+void
+fd_exec_txn_ctx_from_exec_slot_ctx( fd_exec_slot_ctx_t const * slot_ctx,
+                                    fd_exec_txn_ctx_t *        ctx,
+                                    fd_wksp_t const *          funk_wksp,
+                                    fd_wksp_t const *          runtime_pub_wksp,
+                                    ulong                      funk_txn_gaddr,
+                                    ulong                      sysvar_cache_gaddr,
+                                    ulong                      funk_gaddr );
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_flamenco_runtime_fd_executor_h */

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -44,17 +44,6 @@
 
 #define FD_RUNTIME_NUM_ROOT_BLOCKS (32UL)
 
-#define FD_FEATURE_ACTIVE_(_slot, _features, _feature_name)               (_slot >= (_features). _feature_name)
-#define FD_FEATURE_JUST_ACTIVATED_(_slot, _features, _feature_name)       (_slot == (_features). _feature_name)
-#define FD_FEATURE_ACTIVE_OFFSET_(_slot, _features, _offset)              (_slot >= (_features).f[_offset>>3])
-#define FD_FEATURE_JUST_ACTIVATED_OFFSET_(_slot, _features, _offset)      (_slot == (_features).f[_offset>>3] )
-
-#define FD_FEATURE_SET_ACTIVE(_features, _feature_name, _slot)           ((_features). _feature_name = _slot)
-#define FD_FEATURE_ACTIVE(_slot,_features,_feature_name)                  FD_FEATURE_ACTIVE_( _slot,_features,_feature_name )
-#define FD_FEATURE_JUST_ACTIVATED(_slot_ctx, _feature_name)               FD_FEATURE_JUST_ACTIVATED_( _slot_ctx->slot_bank.slot, _slot_ctx->epoch_ctx->features, _feature_name )
-#define FD_FEATURE_ACTIVE_OFFSET(_slot, _features, _offset)               FD_FEATURE_ACTIVE_OFFSET_( _slot, _features, _offset )
-#define FD_FEATURE_JUST_ACTIVATED_OFFSET(_slot_ctx, _offset)              FD_FEATURE_JUST_ACTIVATED_OFFSET_( _slot_ctx->slot_bank.slot, _slot_ctx->epoch_ctx->features, _offset )
-
 #define FD_BLOCKHASH_QUEUE_MAX_ENTRIES    (300UL)
 #define FD_RECENT_BLOCKHASHES_MAX_ENTRIES (150UL)
 

--- a/src/flamenco/runtime/program/zksdk/Local.mk
+++ b/src/flamenco/runtime/program/zksdk/Local.mk
@@ -2,6 +2,6 @@ ifdef FD_HAS_INT128
 $(call add-hdrs,fd_zksdk.h)
 $(call add-objs,fd_zksdk,fd_flamenco)
 ifdef FD_HAS_HOSTED
-$(call make-unit-test,test_zksdk,test_zksdk,fd_flamenco fd_funk fd_ballet fd_util)
+$(call make-unit-test,test_zksdk,test_zksdk,fd_flamenco fd_ballet fd_util)
 endif
 endif

--- a/src/flamenco/runtime/sysvar/Local.mk
+++ b/src/flamenco/runtime/sysvar/Local.mk
@@ -31,9 +31,9 @@ $(call add-hdrs,fd_sysvar_recent_hashes.h)
 $(call add-objs,fd_sysvar_recent_hashes,fd_flamenco)
 
 $(call add-hdrs,fd_sysvar_rent.h)
-$(call add-objs,fd_sysvar_rent,fd_flamenco)
+$(call add-objs,fd_sysvar_rent fd_sysvar_rent1,fd_flamenco)
 ifdef FD_HAS_HOSTED
-$(call make-unit-test,test_sysvar_rent,test_sysvar_rent,fd_flamenco fd_funk fd_ballet fd_util)
+$(call make-unit-test,test_sysvar_rent,test_sysvar_rent,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_sysvar_rent)
 endif
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
@@ -1,37 +1,9 @@
 #include "fd_sysvar_rent.h"
 #include "fd_sysvar.h"
-#include "../fd_acc_mgr.h"
 #include "../fd_system_ids.h"
 #include "../context/fd_exec_epoch_ctx.h"
+#include "../context/fd_exec_slot_ctx.h"
 #include <assert.h>
-
-/* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/rent.rs#L36 */
-#define ACCOUNT_STORAGE_OVERHEAD (128)
-
-fd_rent_t *
-fd_sysvar_rent_read( fd_funk_t *     funk,
-                     fd_funk_txn_t * funk_txn,
-                     fd_spad_t *     spad ) {
-
-  FD_TXN_ACCOUNT_DECL( rent_rec );
-
-  int err = fd_txn_account_init_from_funk_readonly( rent_rec, &fd_sysvar_rent_id, funk, funk_txn );
-  if( FD_UNLIKELY( err != FD_ACC_MGR_SUCCESS ) ) {
-    FD_LOG_WARNING(( "failed to read rent sysvar: %d", err ));
-    return NULL;
-  }
-
-  fd_rent_t * rent = fd_bincode_decode_spad(
-      rent, spad,
-      rent_rec->vt->get_data( rent_rec ),
-      rent_rec->vt->get_data_len( rent_rec ),
-      &err );
-  if( FD_UNLIKELY( err ) ) {
-    FD_LOG_WARNING(( "fd_rent_decode failed" ));
-    return NULL;
-  }
-  return rent;
-}
 
 static void
 write_rent( fd_exec_slot_ctx_t * slot_ctx,
@@ -56,11 +28,4 @@ void
 fd_sysvar_rent_init( fd_exec_slot_ctx_t * slot_ctx ) {
   fd_epoch_bank_t * epoch_bank = fd_exec_epoch_ctx_epoch_bank( slot_ctx->epoch_ctx );
   write_rent( slot_ctx, &epoch_bank->rent );
-}
-
-ulong
-fd_rent_exempt_minimum_balance( fd_rent_t const * rent,
-                                ulong             data_len ) {
-  /* https://github.com/anza-xyz/agave/blob/d2124a995f89e33c54f41da76bfd5b0bd5820898/sdk/program/src/rent.rs#L74 */
-  return fd_rust_cast_double_to_ulong( (double)((data_len + ACCOUNT_STORAGE_OVERHEAD) * rent->lamports_per_uint8_year) * rent->exemption_threshold );
 }

--- a/src/flamenco/runtime/sysvar/fd_sysvar_rent.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_rent.h
@@ -2,7 +2,6 @@
 #define HEADER_fd_src_flamenco_runtime_fd_sysvar_rent_h
 
 #include "../../fd_flamenco_base.h"
-#include "../context/fd_exec_slot_ctx.h"
 #include "../../types/fd_types.h"
 
 FD_PROTOTYPES_BEGIN
@@ -13,15 +12,6 @@ FD_PROTOTYPES_BEGIN
 
 void
 fd_sysvar_rent_init( fd_exec_slot_ctx_t * slot_ctx );
-
-/* fd_sysvar_rent_read queries the rent sysvar from the given slot
-   context.  Rent sysvar is written into *result (may be uninitialized).
-   Returns result on success, NULL otherwise. */
-
-fd_rent_t *
-fd_sysvar_rent_read( fd_funk_t *     funk,
-                     fd_funk_txn_t * funk_txn,
-                     fd_spad_t *     spad );
 
 /* fd_rent_exempt_minimum_balance returns the minimum balance needed
    for an account with the given data_len to be rent exempt.  rent

--- a/src/flamenco/runtime/sysvar/fd_sysvar_rent1.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_rent1.c
@@ -1,0 +1,13 @@
+#include "fd_sysvar_rent.h"
+
+/* Moved into a separate compile unit to minimize dependencies on fd_funk */
+
+/* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/rent.rs#L36 */
+#define ACCOUNT_STORAGE_OVERHEAD (128)
+
+ulong
+fd_rent_exempt_minimum_balance( fd_rent_t const * rent,
+                                ulong             data_len ) {
+  /* https://github.com/anza-xyz/agave/blob/d2124a995f89e33c54f41da76bfd5b0bd5820898/sdk/program/src/rent.rs#L74 */
+  return fd_rust_cast_double_to_ulong( (double)((data_len + ACCOUNT_STORAGE_OVERHEAD) * rent->lamports_per_uint8_year) * rent->exemption_threshold );
+}

--- a/src/flamenco/snapshot/Local.mk
+++ b/src/flamenco/snapshot/Local.mk
@@ -5,10 +5,10 @@ ifdef FD_HAS_INT128
 ifdef FD_HAS_HOSTED
 $(call add-hdrs,fd_snapshot_http.h)
 $(call add-objs,fd_snapshot_http,fd_flamenco)
-$(call make-unit-test,test_snapshot_http,test_snapshot_http,fd_flamenco fd_disco fd_funk fd_ballet fd_util)
+$(call make-unit-test,test_snapshot_http,test_snapshot_http,fd_flamenco fd_disco fd_ballet fd_util)
 $(call run-unit-test,test_snapshot_http)
 ifdef FD_HAS_THREADS
-$(call make-fuzz-test,fuzz_snapshot_http,fuzz_snapshot_http,fd_flamenco fd_disco fd_funk fd_ballet fd_util)
+$(call make-fuzz-test,fuzz_snapshot_http,fuzz_snapshot_http,fd_flamenco fd_disco fd_ballet fd_util)
 endif
 endif
 

--- a/src/flamenco/snapshot/fd_snapshot_restore.c
+++ b/src/flamenco/snapshot/fd_snapshot_restore.c
@@ -2,7 +2,7 @@
 #include "fd_snapshot_restore_private.h"
 #include "../../util/archive/fd_tar.h"
 #include "../runtime/fd_acc_mgr.h"
-#include "../runtime/fd_borrowed_account.h"
+#include "../runtime/fd_runtime.h"
 
 #include <assert.h>
 #include <errno.h>

--- a/src/flamenco/vm/Local.mk
+++ b/src/flamenco/vm/Local.mk
@@ -10,11 +10,12 @@ $(call add-objs,test_vm_util,fd_flamenco)
 
 $(call make-bin,fd_vm_tool,fd_vm_tool,fd_flamenco fd_funk fd_ballet fd_util fd_disco,$(SECP256K1_LIBS))
 
+# Unfortunately, the get_sysvar syscall handler depends on the funk database
 $(call make-unit-test,test_vm_interp,test_vm_interp,fd_flamenco fd_funk fd_ballet fd_util fd_disco,$(SECP256K1_LIBS))
 
-$(call make-unit-test,test_vm_base,test_vm_base,fd_flamenco fd_funk fd_ballet fd_util)
+$(call make-unit-test,test_vm_base,test_vm_base,fd_flamenco fd_ballet fd_util)
 
-$(call make-unit-test,test_vm_instr,test_vm_instr,fd_flamenco fd_funk fd_ballet fd_util)
+$(call make-unit-test,test_vm_instr,test_vm_instr,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_vm_instr)
 
 $(call run-unit-test,test_vm_base)

--- a/src/flamenco/vm/fd_vm_private.h
+++ b/src/flamenco/vm/fd_vm_private.h
@@ -7,7 +7,6 @@
 #include "../../ballet/sbpf/fd_sbpf_opcodes.h"
 #include "../../ballet/murmur3/fd_murmur3.h"
 #include "../runtime/context/fd_exec_txn_ctx.h"
-#include "../runtime/fd_runtime.h"
 #include "../features/fd_features.h"
 #include "fd_vm_base.h"
 

--- a/src/flamenco/vm/syscall/Local.mk
+++ b/src/flamenco/vm/syscall/Local.mk
@@ -4,9 +4,9 @@ ifdef FD_HAS_SECP256K1
 $(call add-hdrs,fd_vm_syscall.h fd_vm_syscall_macros.h fd_vm_cpi.h)
 $(call add-objs,fd_vm_syscall fd_vm_syscall_cpi fd_vm_syscall_hash fd_vm_syscall_crypto fd_vm_syscall_curve fd_vm_syscall_pda fd_vm_syscall_runtime fd_vm_syscall_util,fd_flamenco)
 
-$(call make-unit-test,test_vm_syscall_cpi,test_vm_syscall_cpi,fd_flamenco fd_funk fd_ballet fd_util)
-$(call make-unit-test,test_vm_syscall_curve,test_vm_syscall_curve,fd_flamenco fd_funk fd_ballet fd_util)
-$(call make-unit-test,test_vm_syscalls,test_vm_syscalls,fd_flamenco fd_funk fd_ballet fd_util)
+$(call make-unit-test,test_vm_syscall_cpi,test_vm_syscall_cpi,fd_flamenco fd_ballet fd_util)
+$(call make-unit-test,test_vm_syscall_curve,test_vm_syscall_curve,fd_flamenco fd_ballet fd_util)
+$(call make-unit-test,test_vm_syscalls,test_vm_syscalls,fd_flamenco fd_ballet fd_util)
 
 $(call run-unit-test,test_vm_syscalls)
 $(call run-unit-test,test_vm_syscall_cpi)

--- a/src/flamenco/vm/test_vm_instr.c
+++ b/src/flamenco/vm/test_vm_instr.c
@@ -5,6 +5,8 @@
 #include "fd_vm_base.h"
 #include "fd_vm_private.h"
 #include "test_vm_util.h"
+#include "../runtime/context/fd_exec_epoch_ctx.h"
+#include "../runtime/context/fd_exec_slot_ctx.h"
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>

--- a/src/flamenco/vm/test_vm_interp.c
+++ b/src/flamenco/vm/test_vm_interp.c
@@ -2,6 +2,8 @@
 #include "fd_vm_base.h"
 #include "fd_vm_private.h"
 #include "test_vm_util.h"
+#include "../runtime/context/fd_exec_epoch_ctx.h"
+#include "../runtime/context/fd_exec_slot_ctx.h"
 #include <stdlib.h>  /* malloc */
 
 static int


### PR DESCRIPTION
- Removes the funk library from 14 executables
- Does some light restructuring to relax dependencies between compile units

This change will block future attempts to access the database directly from the VM. That would cause link failures all over the place with this PR, since a lot of tests no longer link in database code.