### PR TITLE
Parallel merge sorts

### DIFF
--- a/src/util/tpool/fd_tpool.h
+++ b/src/util/tpool/fd_tpool.h
@@ -1100,8 +1100,7 @@ op( void * _tpool,                                                              
 #define FD_FOR_ALL(...) FD_EXPAND_THEN_CONCAT2(FD_FOR_ALL_PRIVATE_,FD_VA_ARGS_SELECT(__VA_ARGS__,M,M,M,M,M,M,M,M,M,M,M,M,M,M,M,M,M,M,M,7,6,5,4,3,2,1,0,F,F,F,F,F))(__VA_ARGS__)
 
 /* FD_MAP_REDUCE extends to FD_FOR_ALL to reduce results back to thread
-   tpool_t0.  IMPORTANT SAFETY TIP!  Adequate scratch memory must be
-   configured for threads used by a MAP_REDUCE.
+   tpool_t0.
 
    Example usage:
 
@@ -1109,7 +1108,7 @@ op( void * _tpool,                                                              
 
        // my_hist_op uses tpool threads [tpool_t0,tpool_t1) to compute:
        //
-       //   long h[4] __attribute__((aligned(128)));
+       //   long h[4];
        //   for( long j=0L; j<4L; j++ ) h[j] = 0L;
        //   for( long i=i0; i<i1; i++ ) {
        //     long j = my_map_op( x[i] );
@@ -1118,19 +1117,19 @@ op( void * _tpool,                                                              
        //
        // where x is a pointer to a my_ele_t array.  The caller is
        // assumed to be thread tpool_t0 and threads (tpool_t0,tpool_t1)
-       // are assumed to be idle.  Requires thread local scratch space
-       // per tpool thread of ~4 ceil lg (tpool_t1-tpool_t0) ulong.
+       // are assumed to be idle.  Required stack
+       // is ~ O(1) + (8+REDUCE_FOOTPRINT) ceil lg (tpool_t1-tpool_t0)
 
        FD_MAP_REDUCE_PROTO( my_hist_op );
 
      In the source file that uses my_hist_op:
 
-       long h[4] __attribute__((aligned(128)));
-       FD_MAP_REDUCE( my_hist_op, tpool, t0,t1, i0,i1, x, h );
+       long h[4];
+       FD_MAP_REDUCE( my_hist_op, tpool,t0,t1, i0,i1, x, h );
 
      In the source file that implements my_hist_op:
 
-       FD_MAP_REDUCE_BEGIN( my_hist_op, 1L, 128UL, 4UL*sizeof(long) ) {
+       FD_MAP_REDUCE_BEGIN( my_hist_op, 1L, alignof(long), 4UL*sizeof(long) ) {
 
          ... At this point:
 
@@ -1145,11 +1144,9 @@ op( void * _tpool,                                                              
 
              - ulong reduce_align and reduce_footprint give the alignment
                and footprint of this region.  In this example, these are
-               given by the 128UL and 4UL*sizeof(long) above.  Like
-               block_thresh, these can be run-time evaluated
-               expressions.  This assumes that the region passed by the
-               caller for the final results has a compatible alignment
-               and footprint.
+               alignof(long) and 4UL*sizeof(long).  This assumes that
+               the region passed by the caller for the final results has
+               a compatible alignment and footprint.
 
              IMPORTANT SAFETY TIP!  DO NOT RETURN FROM THIS BLOCK.  (IF
              ENDING A BLOCK EARLY, USE BREAK.)
@@ -1158,6 +1155,7 @@ op( void * _tpool,                                                              
          long           * restrict h = (long           *)_r0;
 
          for( long j=0L; j<4L; j++ ) h[j] = 0UL;
+
          for( long i=block_i0; i<block_i1; i++ ) {
            long j = my_map_op( x[i] );
            h[j]++;
@@ -1165,30 +1163,33 @@ op( void * _tpool,                                                              
 
        } FD_MAP_END {
 
-         ... At this point, the environment is as described above with the
-             following differences:
+         ... At this point, the environment is as described above with
+             the following differences:
 
-             - There are at least two threads in [tpool_t0,tpool_t1).
+             - There is at least one thread in [tpool_t0,tpool_ts) and
+               one thread in [tpool_ts,tpool_t1).
 
-             - On entry, ulongs _r0 and _r1 point the partials to reduce
-               (cast to ulongs).  These will have an alignment and
-               footprint compatible with the above.
+             - On entry, _r0 points to the partial reduction (cast to a
+               ulong) of [block_i0,block_is).  This was computed by
+               threads [tpool_t0,tpool_ts).  Similarly, _r1 points to
+               the partial reduction (cast to a ulong) of
+               [block_is,block_i1).  This was computed by threads
+               [tpool_ts,tpool_t1).  These regions have the alignment
+               and footprint specified for the FD_MAP_REDUCE.
 
-             - On exit, _r1 has been reduced into _r0.  It is okay if
-               _r1 is clobbered in this process.
-
-             - [block_i0,block_i1) give the range of elements covered by
-               the output of this reduction (though this is not typically
-               used).
+             - On exit, _r1 has been reduced into _r0 such that _r0
+               points to the partial reduction of [block_i0,block_i1).
+               Threads [tpool_t0,tpool_t1) are available to compute this
+               reduction.  It is okay if _r1 is clobbered in this
+               process as _r1 will be discarded after this block exits.
 
              IMPORTANT SAFETY TIP!  While this reduction is often
              theoretically parallelizable and threads
-             [tpool_t0,tpool_t1) are available here for such,
-             parallelization of this can often be counterproductive
-             (especially if the amount to reduce is small, the reduction
-             operation is cheap and the arrays to reduce have poor
-             spatial locality for reduction here due to the mapping
-             phase above).
+             [tpool_t0,tpool_t1) are available here for this,
+             parallelization of this can often be counterproductive when
+             the amount to reduce is small, the reduction operation is
+             cheap and/or the arrays to reduce have poor spatial
+             locality due to the mapping phase above.
 
              IMPORTANT SAFETY TIP!  DO NOT RETURN FROM THIS BLOCK.  (IF
              ENDING A BLOCK EARLY, USE BREAK.)
@@ -1223,8 +1224,8 @@ op( void * _tpool,                                                              
     ulong  _r0 ) {                                                                                  \
   FD_COMPILER_MFENCE(); /* guarantees memory fence even if tpool_cnt==1 */                          \
   long            block_thresh     = (BLOCK_THRESH);                                                \
-  ulong           reduce_align     = (REDUCE_ALIGN);                                                \
-  ulong           reduce_footprint = (REDUCE_FOOTPRINT);                                            \
+  ulong           reduce_align     = (REDUCE_ALIGN);     (void)reduce_align;                        \
+  ulong           reduce_footprint = (REDUCE_FOOTPRINT); (void)reduce_footprint;                    \
   fd_tpool_t *    tpool            = (fd_tpool_t *)_tpool;                                          \
   long            block_i0         = (long)_block_i0;                                               \
   long            block_i1         = (long)_block_i1;                                               \
@@ -1233,10 +1234,9 @@ op( void * _tpool,                                                              
   struct {                                                                                          \
     uint  ts; /* ts is thread that needs to complete before reduction can proceed */                \
     uint  t1; /* [t0,t1) is range of threads available for reduction */                             \
-    ulong r1; /* r1 is the scratch memory used for the reduction */                                 \
     long  i1; /* [i0,i1) is range the reduction output covers */                                    \
+    uchar r1[ (REDUCE_FOOTPRINT) ] __attribute__((aligned((REDUCE_ALIGN))));                        \
   } _reduce_stack[ 16 ]; /* Assumes TILE_MAX<65536 (yes strictly less) */                           \
-  fd_scratch_push();                                                                                \
   for(;;) {                                                                                         \
     ulong tpool_cnt = tpool_t1 - tpool_t0;                                                          \
     /**/  block_cnt = block_i1 - block_i0;                                                          \
@@ -1245,35 +1245,33 @@ op( void * _tpool,                                                              
     ulong tpool_right = tpool_cnt - tpool_left;                                                     \
     ulong tpool_ts    = tpool_t0 + tpool_left;                                                      \
     long  block_is    = block_i1 - (long)((tpool_right*(ulong)block_cnt)/tpool_cnt); /* No ovfl */  \
-    ulong _r1 = (ulong)fd_scratch_alloc( reduce_align, reduce_footprint );                          \
     fd_tpool_exec( tpool, tpool_ts, op, tpool,tpool_ts,tpool_t1, (void *)block_is,(void *)block_i1, \
-                   _a0,_a1,_a2,_a3,_a4,_a5,_r1 );                                                   \
+                   _a0,_a1,_a2,_a3,_a4,_a5, (ulong)_reduce_stack[ _reduce_cnt ].r1 );               \
     _reduce_stack[ _reduce_cnt ].ts = (uint)tpool_ts;                                               \
     _reduce_stack[ _reduce_cnt ].t1 = (uint)tpool_t1;                                               \
     _reduce_stack[ _reduce_cnt ].i1 = block_i1;                                                     \
-    _reduce_stack[ _reduce_cnt ].r1 = _r1;                                                          \
     _reduce_cnt++;                                                                                  \
     tpool_t1 = tpool_ts;                                                                            \
     block_i1 = block_is;                                                                            \
   }                                                                                                 \
   do
 
-#define FD_MAP_END                                                  \
-  while(0);                                                         \
-  while( _reduce_cnt ) {                                            \
-    --_reduce_cnt;                                                  \
-    ulong _r1 =        _reduce_stack[ _reduce_cnt ].r1;             \
-    block_i1  =        _reduce_stack[ _reduce_cnt ].i1;             \
-    tpool_t1  = (ulong)_reduce_stack[ _reduce_cnt ].t1;             \
-    block_cnt = block_i1 - block_i0;                                \
-    fd_tpool_wait( tpool, (ulong)_reduce_stack[ _reduce_cnt ].ts ); \
-    (void)_r0; (void)_r1;                                           \
+#define FD_MAP_END                                                                  \
+  while(0);                                                                         \
+  while( _reduce_cnt ) {                                                            \
+    long  block_is  = block_i1;                               (void)block_is;       \
+    --_reduce_cnt;                                                                  \
+    ulong tpool_ts  = (ulong)_reduce_stack[ _reduce_cnt ].ts;                       \
+    /**/  tpool_t1  = (ulong)_reduce_stack[ _reduce_cnt ].t1;                       \
+    /**/  block_i1  =        _reduce_stack[ _reduce_cnt ].i1;                       \
+    ulong _r1       = (ulong)_reduce_stack[ _reduce_cnt ].r1; (void)_r0; (void)_r1; \
+    /**/  block_cnt = block_i1 - block_i0;                                          \
+    fd_tpool_wait( tpool, tpool_ts );                                               \
     do
 
 #define FD_REDUCE_END \
     while(0);         \
   }                   \
-  fd_scratch_pop();   \
 }
 
 #define FD_MAP_REDUCE_PRIVATE_F(...)                                        too_few_arguments_passed_to_FD_MAP_REDUCE

--- a/src/util/tpool/test_tpool.c
+++ b/src/util/tpool/test_tpool.c
@@ -228,13 +228,14 @@ static FD_MAP_REDUCE_BEGIN( test_map_reduce_0, 1L, 2UL, 4UL ) {
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
   FD_TEST( _a0==0UL     ); FD_TEST( _a1==0UL     ); FD_TEST( _a2==0UL     );
-  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     );
+  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 2UL ) );
 } FD_MAP_END {
   FD_TEST( block_thresh==1L ); FD_TEST( reduce_align==2UL ); FD_TEST( reduce_footprint==4UL );
-  FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
-  FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
+  FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_ts) & (tpool_ts< tpool_t1) & (tpool_t1<=test_t1) );
+  FD_TEST( (test_i0<=block_i0) & (block_i0<=block_is) & (block_is<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
   FD_TEST( _a0==0UL     ); FD_TEST( _a1==0UL     ); FD_TEST( _a2==0UL     );
-  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     );
+  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 2UL ) );
+  FD_TEST( _r0!=_r1 ); FD_TEST( fd_ulong_is_aligned( _r1, 2UL ) );
 } FD_REDUCE_END
 
 static FD_MAP_REDUCE_PROTO( test_map_reduce_1 );
@@ -243,13 +244,14 @@ static FD_MAP_REDUCE_BEGIN( test_map_reduce_1, 2L, 4UL, 8UL ) {
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
   FD_TEST( _a0==test_a0 ); FD_TEST( _a1==0UL     ); FD_TEST( _a2==0UL     );
-  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     );
+  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 4UL ) );
 } FD_MAP_END {
   FD_TEST( block_thresh==2L ); FD_TEST( reduce_align==4UL ); FD_TEST( reduce_footprint==8UL );
-  FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
-  FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
+  FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_ts) & (tpool_ts< tpool_t1) & (tpool_t1<=test_t1) );
+  FD_TEST( (test_i0<=block_i0) & (block_i0<=block_is) & (block_is<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
   FD_TEST( _a0==test_a0 ); FD_TEST( _a1==0UL     ); FD_TEST( _a2==0UL     );
-  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     );
+  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 4UL ) );
+  FD_TEST( _r0!=_r1 ); FD_TEST( fd_ulong_is_aligned( _r1, 4UL ) );
 } FD_REDUCE_END
 
 static FD_MAP_REDUCE_PROTO( test_map_reduce_2 );
@@ -258,13 +260,14 @@ static FD_MAP_REDUCE_BEGIN( test_map_reduce_2, 3L, 8UL, 16UL ) {
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
   FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==0UL     );
-  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     );
+  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 8UL ) );
 } FD_MAP_END {
   FD_TEST( block_thresh==3L ); FD_TEST( reduce_align==8UL ); FD_TEST( reduce_footprint==16UL );
-  FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
-  FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
+  FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_ts) & (tpool_ts< tpool_t1) & (tpool_t1<=test_t1) );
+  FD_TEST( (test_i0<=block_i0) & (block_i0<=block_is) & (block_is<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
   FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==0UL     );
-  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     );
+  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 8UL ) );
+  FD_TEST( _r0!=_r1 ); FD_TEST( fd_ulong_is_aligned( _r1, 8UL ) );
 } FD_REDUCE_END
 
 static FD_MAP_REDUCE_PROTO( test_map_reduce_3 );
@@ -273,13 +276,14 @@ static FD_MAP_REDUCE_BEGIN( test_map_reduce_3, 4L, 16UL, 32UL ) {
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
   FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 );
-  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     );
+  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 16UL ) );
 } FD_MAP_END {
   FD_TEST( block_thresh==4L ); FD_TEST( reduce_align==16UL ); FD_TEST( reduce_footprint==32UL );
-  FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
-  FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
+  FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_ts) & (tpool_ts< tpool_t1) & (tpool_t1<=test_t1) );
+  FD_TEST( (test_i0<=block_i0) & (block_i0<=block_is) & (block_is<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
   FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 );
-  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     );
+  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 16UL ) );
+  FD_TEST( _r0!=_r1 ); FD_TEST( fd_ulong_is_aligned( _r1, 16UL ) );
 } FD_REDUCE_END
 
 static FD_MAP_REDUCE_PROTO( test_map_reduce_4 );
@@ -288,13 +292,14 @@ static FD_MAP_REDUCE_BEGIN( test_map_reduce_4, 5L, 32UL, 64UL ) {
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
   FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 );
-  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     );
+  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 32UL ) );
 } FD_MAP_END {
   FD_TEST( block_thresh==5L ); FD_TEST( reduce_align==32UL ); FD_TEST( reduce_footprint==64UL );
-  FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
-  FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
+  FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_ts) & (tpool_ts< tpool_t1) & (tpool_t1<=test_t1) );
+  FD_TEST( (test_i0<=block_i0) & (block_i0<=block_is) & (block_is<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
   FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 );
-  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     );
+  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 32UL ) );
+  FD_TEST( _r0!=_r1 ); FD_TEST( fd_ulong_is_aligned( _r1, 32UL ) );
 } FD_REDUCE_END
 
 static FD_MAP_REDUCE_PROTO( test_map_reduce_5 );
@@ -303,13 +308,14 @@ static FD_MAP_REDUCE_BEGIN( test_map_reduce_5, 6L, 64UL, 128UL ) {
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
   FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 );
-  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==test_a4 ); FD_TEST( _a5==0UL     );
+  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==test_a4 ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 64UL ) );
 } FD_MAP_END {
   FD_TEST( block_thresh==6L ); FD_TEST( reduce_align==64UL ); FD_TEST( reduce_footprint==128UL );
-  FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
-  FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
+  FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_ts) & (tpool_ts< tpool_t1) & (tpool_t1<=test_t1) );
+  FD_TEST( (test_i0<=block_i0) & (block_i0<=block_is) & (block_is<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
   FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 );
-  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==test_a4 ); FD_TEST( _a5==0UL     );
+  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==test_a4 ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 64UL ) );
+  FD_TEST( _r0!=_r1 ); FD_TEST( fd_ulong_is_aligned( _r1, 64UL ) );
 } FD_REDUCE_END
 
 static FD_MAP_REDUCE_PROTO( test_map_reduce_6 );
@@ -318,13 +324,14 @@ static FD_MAP_REDUCE_BEGIN( test_map_reduce_6, 7L, 128UL, 256UL ) {
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
   FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 );
-  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==test_a4 ); FD_TEST( _a5==test_a5 );
+  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==test_a4 ); FD_TEST( _a5==test_a5 ); FD_TEST( fd_ulong_is_aligned( _r0, 128UL ) );
 } FD_MAP_END {
   FD_TEST( block_thresh==7L ); FD_TEST( reduce_align==128UL ); FD_TEST( reduce_footprint==256UL );
-  FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
-  FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
+  FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_ts) & (tpool_ts< tpool_t1) & (tpool_t1<=test_t1) );
+  FD_TEST( (test_i0<=block_i0) & (block_i0<=block_is) & (block_is<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
   FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 );
-  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==test_a4 ); FD_TEST( _a5==test_a5 );
+  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==test_a4 ); FD_TEST( _a5==test_a5 ); FD_TEST( fd_ulong_is_aligned( _r0, 128UL ) );
+  FD_TEST( _r0!=_r1 ); FD_TEST( fd_ulong_is_aligned( _r1, 128UL ) );
 } FD_REDUCE_END
 
 static FD_FOR_ALL_BEGIN( bench_for_all, 1L ) {} FD_FOR_ALL_END
@@ -657,7 +664,7 @@ main( int     argc,
     test_i0 = (long)fd_rng_int( rng );
     test_i1 = (long)fd_rng_int( rng ); fd_swap_if( test_i1<test_i0, test_i0, test_i1 );
     test_a0 = fd_rng_ulong( rng ); test_a1 = fd_rng_ulong( rng ); test_a2 = fd_rng_ulong( rng ); test_a3 = fd_rng_ulong( rng );
-    test_a4 = fd_rng_ulong( rng ); test_a5 = fd_rng_ulong( rng ); test_a6 = fd_rng_ulong( rng );
+    test_a4 = fd_rng_ulong( rng ); test_a5 = fd_rng_ulong( rng ); test_a6 = fd_rng_ulong( rng ) & ~127UL;
     FD_MAP_REDUCE( test_map_reduce_0, tpool,test_t0,test_t1, test_i0,test_i1,                                                  test_a6 );
     FD_MAP_REDUCE( test_map_reduce_1, tpool,test_t0,test_t1, test_i0,test_i1, test_a0,                                         test_a6 );
     FD_MAP_REDUCE( test_map_reduce_2, tpool,test_t0,test_t1, test_i0,test_i1, test_a0,test_a1,                                 test_a6 );


### PR DESCRIPTION
By popular demand and mentioned in parallel quick sort PR, this PR adds additional styles of parallel sorting.  This provides a thread parallel, NUMA friendly, cache friendly merge sort implementation.  (As a reminder, unlike quick sorts, merge sorts are stable but out-of-place.)

This implementation has an asymptotic wallclock of O(N) in the large thread count limit (as opposed to the N log N for a serial merge sort).

test_sort_para was updated to large arrays with more heavily randomized testing to explore more threading edge cases.

Tweaked FD_TPOOL_MAP_REDUCE to make this cleaner to implement and less restrictive to use and updated the test_tpool to reflect this. Specifically:

- FD_TPOOL_MAP_REDUCE no longer requires fd_scratch to be configured on the tpool threads used for the sorting.

- The reduce section makes the thread split and element split used in the previous stage of reduction available to the user.

Plan to add one more style of parallel sort (based on statistical sampling with slightly better average asymptotics) in the near future.