### PR TITLE
codeql: test frankendancer and firedancer in ci

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
           compiler: clang
           machine: linux_clang_x86_64
           compiler-version: 15.0.6
-          targets: fddev
+          targets: fddev firedancer-dev
           extras: rpath
     env:
       MACHINE: ${{ matrix.machine }}


### PR DESCRIPTION
due to the recent split of build targets this change adds firedancer-dev to the CodeQL action