### PR TITLE
build: fix compilation when rocksdb not present

### DIFF
--- a/src/disco/archiver/Local.mk
+++ b/src/disco/archiver/Local.mk
@@ -3,5 +3,7 @@ ifdef FD_HAS_SSE
 $(call add-objs,fd_archiver_feeder,fd_disco)
 $(call add-objs,fd_archiver_writer,fd_disco)
 $(call add-objs,fd_archiver_playback,fd_disco)
+ifdef FD_HAS_ROCKSDB
 $(call add-objs,fd_archiver_backtest,fd_disco)
+endif
 endif


### PR DESCRIPTION
`main` doesn't compile without this unless `./deps.sh` was installed with `+dev` which is not default.