### PR TITLE
backtest: script improvements

### DIFF
--- a/src/app/firedancer-dev/config/private.toml
+++ b/src/app/firedancer-dev/config/private.toml
@@ -25,7 +25,7 @@
         prometheus_listen_port = 7999
 [consensus]
     vote = false
-    expected_shred_version = ${SHRED_VERSION}
+    expected_shred_version = 27972
 [paths]
     identity_key = "${KEYS}/fd-identity-keypair.json"
     vote_account = "${KEYS}/fd-vote-keypair.json"

--- a/src/flamenco/runtime/tests/run_backtest_tests_all.sh
+++ b/src/flamenco/runtime/tests/run_backtest_tests_all.sh
@@ -80,4 +80,4 @@ src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-330219081 -s snapsh
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-372721907 -s snapshot-372721906-FtUjok2JfLPwJCRVcioV12M8FWbbJaC91XEJzm4eZy53.tar.zst -p 60 -y 16 -m 2000000 -e 372721910 -c 2.1.14
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-331691646 -s snapshot-331691639-3NmZ4rd7nHfn6tuS4E5gUfAwWMoBAQ6K1yntNkyhPbrb.tar.zst -p 60 -y 20 -m 2000000 -e 331691650  -c 2.1.14
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-378683870 -s snapshot-378683869-7iuK12gAgSaB97WbmiTb4QPVbnqfFWCtq9F6CvfSgBj5.tar.zst -p 60 -y 16 -m 5000000 -e 378683872 -c 2.1.14
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l slashing-ledger -s snapshot-1-3pPnJsADcbDoFaCJr8Fcvb6UHf2jDUdAtbJ3G2JtevDK.tar.zst -p 80 -y 16 -m 5000000 -e 75 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l slashing-ledger -s snapshot-1-3pPnJsADcbDoFaCJr8Fcvb6UHf2jDUdAtbJ3G2JtevDK.tar.zst -p 60 -y 16 -m 5000000 -e 44 -c 2.3.0

--- a/src/flamenco/runtime/tests/run_ledger_backtest.sh
+++ b/src/flamenco/runtime/tests/run_ledger_backtest.sh
@@ -181,17 +181,18 @@ echo "
  [paths]
      identity_key = \"$DUMP_DIR/identity.json\"
      vote_account = \"$DUMP_DIR/vote.json\"
-" > $DUMP_DIR/rocksdb.toml
+" > $DUMP_DIR/${LEDGER}_backtest.toml
 
 if [ ! -f $DUMP_DIR/identity.json ]; then
-$OBJDIR/bin/firedancer-dev keys new identity --config $DUMP_DIR/rocksdb.toml
+$OBJDIR/bin/firedancer-dev keys new identity --config ${DUMP_DIR}/${LEDGER}_backtest.toml
 fi
 if [ ! -f $DUMP_DIR/vote.json ]; then
-$OBJDIR/bin/firedancer-dev keys new vote --config $DUMP_DIR/rocksdb.toml
+$OBJDIR/bin/firedancer-dev keys new vote --config ${DUMP_DIR}/${LEDGER}_backtest.toml
 fi
 
-# run the `backtest` command
-$OBJDIR/bin/firedancer-dev backtest --config $DUMP_DIR/rocksdb.toml
+echo "Running backtest for $LEDGER"
+set -x
+  $OBJDIR/bin/firedancer-dev backtest --config ${DUMP_DIR}/${LEDGER}_backtest.toml &> /dev/null
 
 { set +x; } &> /dev/null
 echo_notice "Finished on-demand ingest and replay\n"
@@ -200,8 +201,8 @@ echo "Log for ledger $LEDGER at $LOG"
 
 if grep -q "Rocksdb playback done." $LOG && ! grep -q "Bank hash mismatch!" $LOG;
 then
-  echo "rocksdb test passes"
-#   rm $LOG
+  :
+  #   rm $LOG
 else
   if [ -n "$TRASH_HASH" ]; then
     echo "inverted test passed"
@@ -210,6 +211,6 @@ else
   fi
 
   tail -40 $LOG
-  echo_error "ledger test failed: $*"
+  echo_error "backtest test failed: $*"
   echo $LOG
 fi

--- a/src/flamenco/runtime/tests/run_ledger_tests_all.txt
+++ b/src/flamenco/runtime/tests/run_ledger_tests_all.txt
@@ -80,4 +80,4 @@ src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-330219081 -s snapshot-3
 src/flamenco/runtime/tests/run_ledger_test.sh -l devnet-372721907 -s snapshot-372721906-FtUjok2JfLPwJCRVcioV12M8FWbbJaC91XEJzm4eZy53.tar.zst -p 60 -y 16 -m 2000000 -e 372721910 -c 2.1.14
 src/flamenco/runtime/tests/run_ledger_test.sh -l mainnet-331691646 -s snapshot-331691639-3NmZ4rd7nHfn6tuS4E5gUfAwWMoBAQ6K1yntNkyhPbrb.tar.zst -p 60 -y 20 -m 2000000 -e 331691650  -c 2.1.14
 src/flamenco/runtime/tests/run_ledger_test.sh -l devnet-378683870 -s snapshot-378683869-7iuK12gAgSaB97WbmiTb4QPVbnqfFWCtq9F6CvfSgBj5.tar.zst -p 60 -y 16 -m 5000000 -e 378683872 -c 2.1.14
-src/flamenco/runtime/tests/run_ledger_test.sh -l slashing-ledger -s snapshot-1-3pPnJsADcbDoFaCJr8Fcvb6UHf2jDUdAtbJ3G2JtevDK.tar.zst -p 80 -y 16 -m 5000000 -e 75 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_test.sh -l slashing-ledger -s snapshot-1-3pPnJsADcbDoFaCJr8Fcvb6UHf2jDUdAtbJ3G2JtevDK.tar.zst -p 60 -y 16 -m 5000000 -e 75 -c 2.3.0


### PR DESCRIPTION
example run:
```
(test_suite_env) [kbhargava@emch-ossdev-firedancer7 firedancer]$ src/flamenco/runtime/tests/run_ledger_backtest.sh -l slashing-ledger -s snapshot-1-3pPnJsADcbDoFaCJr8Fcvb6UHf2jDUdAtbJ3G2JtevDK.tar.zst -p 60 -y 16 -m 5000000 -e 44 -c 2.3.0
Starting on-demand ingest and replay
Running backtest for slashing-ledger
+ build/native/gcc/bin/firedancer-dev backtest --config ./dump/slashing-ledger_backtest.toml
Finished on-demand ingest and replay

Log for ledger slashing-ledger at /tmp/ledger_log3854442
```