### PR TITLE
runtime: make BPF Loader v3 structs zero-alloc

### DIFF
--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -2365,8 +2365,8 @@ fd_new_target_program_data_account( fd_exec_slot_ctx_t * slot_ctx,
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank/builtins/core_bpf_migration/mod.rs#L118-L125 */
   if( config_upgrade_authority_address!=NULL ) {
-    if( FD_UNLIKELY( state->inner.buffer.authority_address==NULL ||
-                     memcmp( config_upgrade_authority_address, state->inner.buffer.authority_address, sizeof(fd_pubkey_t) ) ) ) {
+    if( FD_UNLIKELY( !state->inner.buffer.has_authority_address ||
+                     !fd_pubkey_eq( config_upgrade_authority_address, &state->inner.buffer.authority_address ) ) ) {
       return -1;
     }
   }
@@ -2386,11 +2386,13 @@ fd_new_target_program_data_account( fd_exec_slot_ctx_t * slot_ctx,
     .discriminant = fd_bpf_upgradeable_loader_state_enum_program_data,
     .inner = {
       .program_data = {
-        .slot = slot_ctx->slot_bank.slot,
-        .upgrade_authority_address = config_upgrade_authority_address
+        .slot = slot_ctx->slot_bank.slot
       }
     }
   };
+  fd_types_option_flat_from_nullable(
+      programdata_metadata.inner.program_data, upgrade_authority_address,
+      config_upgrade_authority_address );
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank/builtins/core_bpf_migration/mod.rs#L139-L144 */
   new_target_program_data_account->vt->set_lamports( new_target_program_data_account, lamports );

--- a/src/flamenco/runtime/program/fd_bpf_program_util.c
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.c
@@ -82,17 +82,17 @@ static int
 fd_bpf_get_executable_program_content_for_upgradeable_loader( fd_exec_slot_ctx_t *    slot_ctx,
                                                               fd_txn_account_t *      program_acc,
                                                               uchar const **          program_data,
-                                                              ulong *                 program_data_len,
-                                                              fd_spad_t *             runtime_spad ) {
+                                                              ulong *                 program_data_len ) {
   FD_TXN_ACCOUNT_DECL( programdata_acc );
 
-  fd_bpf_upgradeable_loader_state_t * program_account_state =
-    fd_bincode_decode_spad(
-      bpf_upgradeable_loader_state, runtime_spad,
+  fd_bpf_upgradeable_loader_state_t program_account_state[1];
+  if( FD_UNLIKELY( !fd_bincode_decode_flat(
+      program_account_state,
+      bpf_upgradeable_loader_state,
       program_acc->vt->get_data( program_acc ),
       program_acc->vt->get_data_len( program_acc ),
-      NULL );
-  if( FD_UNLIKELY( !program_account_state ) ) {
+      NULL
+  ) ) ) {
     return -1;
   }
   if( !fd_bpf_upgradeable_loader_state_is_program( program_account_state ) ) {
@@ -182,7 +182,7 @@ fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t *    slot_ctx,
 
     int res;
     if( !memcmp( program_acc->vt->get_owner( program_acc ), fd_solana_bpf_loader_upgradeable_program_id.key, sizeof(fd_pubkey_t) ) ) {
-      res = fd_bpf_get_executable_program_content_for_upgradeable_loader( slot_ctx, program_acc, &program_data, &program_data_len, runtime_spad );
+      res = fd_bpf_get_executable_program_content_for_upgradeable_loader( slot_ctx, program_acc, &program_data, &program_data_len );
     } else if( !memcmp( program_acc->vt->get_owner( program_acc ), fd_solana_bpf_loader_v4_program_id.key, sizeof(fd_pubkey_t) ) ) {
       res = fd_bpf_get_executable_program_content_for_v4_loader( program_acc, &program_data, &program_data_len );
     } else {

--- a/src/flamenco/runtime/program/fd_builtin_programs.h
+++ b/src/flamenco/runtime/program/fd_builtin_programs.h
@@ -3,9 +3,6 @@
 
 #include "../../fd_flamenco_base.h"
 #include "../../runtime/fd_system_ids.h"
-#include "../../features/fd_features.h"
-#include "../context/fd_exec_epoch_ctx.h"
-#include "../context/fd_exec_slot_ctx.h"
 #include "../fd_system_ids.h"
 #include "../fd_system_ids_pp.h"
 

--- a/src/flamenco/types/fd_fuzz_types.h
+++ b/src/flamenco/types/fd_fuzz_types.h
@@ -2748,15 +2748,9 @@ void *fd_bpf_upgradeable_loader_state_buffer_generate( void *mem, void **alloc_m
   *alloc_mem = (uchar *) *alloc_mem + sizeof(fd_bpf_upgradeable_loader_state_buffer_t);
   fd_bpf_upgradeable_loader_state_buffer_new(mem);
   {
-    uchar is_null = fd_rng_uchar( rng ) % 2;
-    if( !is_null ) {
-      self->authority_address = (fd_pubkey_t *) *alloc_mem;
-      *alloc_mem = (uchar *) *alloc_mem + sizeof(fd_pubkey_t);
-      fd_pubkey_new( self->authority_address );
-      fd_pubkey_generate( self->authority_address, alloc_mem, rng );
-    }
-    else {
-    self->authority_address = NULL;
+    self->has_authority_address = fd_rng_uchar( rng ) % 2;
+    if( self->has_authority_address ) {
+      fd_pubkey_generate( &self->authority_address, alloc_mem, rng );
     }
   }
   return mem;
@@ -2776,15 +2770,9 @@ void *fd_bpf_upgradeable_loader_state_program_data_generate( void *mem, void **a
   fd_bpf_upgradeable_loader_state_program_data_new(mem);
   self->slot = fd_rng_ulong( rng );
   {
-    uchar is_null = fd_rng_uchar( rng ) % 2;
-    if( !is_null ) {
-      self->upgrade_authority_address = (fd_pubkey_t *) *alloc_mem;
-      *alloc_mem = (uchar *) *alloc_mem + sizeof(fd_pubkey_t);
-      fd_pubkey_new( self->upgrade_authority_address );
-      fd_pubkey_generate( self->upgrade_authority_address, alloc_mem, rng );
-    }
-    else {
-    self->upgrade_authority_address = NULL;
+    self->has_upgrade_authority_address = fd_rng_uchar( rng ) % 2;
+    if( self->has_upgrade_authority_address ) {
+      fd_pubkey_generate( &self->upgrade_authority_address, alloc_mem, rng );
     }
   }
   return mem;

--- a/src/flamenco/types/fd_types.c
+++ b/src/flamenco/types/fd_types.c
@@ -15651,13 +15651,10 @@ int fd_bpf_upgradeable_loader_program_instruction_encode( fd_bpf_upgradeable_loa
 
 int fd_bpf_upgradeable_loader_state_buffer_encode( fd_bpf_upgradeable_loader_state_buffer_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
-  if( self->authority_address != NULL ) {
-    err = fd_bincode_bool_encode( 1, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    err = fd_pubkey_encode( self->authority_address, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-  } else {
-    err = fd_bincode_bool_encode( 0, ctx );
+  err = fd_bincode_bool_encode( self->has_authority_address, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_authority_address ) {
+    err = fd_pubkey_encode( &self->authority_address, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   return FD_BINCODE_SUCCESS;
@@ -15670,7 +15667,6 @@ static int fd_bpf_upgradeable_loader_state_buffer_decode_footprint_inner( fd_bin
     err = fd_bincode_bool_decode( &o, ctx );
     if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
     if( o ) {
-    *total_sz += FD_PUBKEY_ALIGN + sizeof(fd_pubkey_t);
       err = fd_pubkey_decode_footprint_inner( ctx, total_sz );
       if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
     }
@@ -15690,14 +15686,10 @@ static void fd_bpf_upgradeable_loader_state_buffer_decode_inner( void * struct_m
   {
     uchar o;
     fd_bincode_bool_decode_unsafe( &o, ctx );
+    self->has_authority_address = !!o;
     if( o ) {
-      *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, FD_PUBKEY_ALIGN );
-      self->authority_address = *alloc_mem;
-      *alloc_mem = (uchar *)*alloc_mem + sizeof(fd_pubkey_t);
-      fd_pubkey_new( self->authority_address );
-      fd_pubkey_decode_inner( self->authority_address, alloc_mem, ctx );
-    } else {
-      self->authority_address = NULL;
+      fd_pubkey_new( &self->authority_address );
+      fd_pubkey_decode_inner( &self->authority_address, alloc_mem, ctx );
     }
   }
 }
@@ -15714,18 +15706,18 @@ void fd_bpf_upgradeable_loader_state_buffer_new(fd_bpf_upgradeable_loader_state_
 }
 void fd_bpf_upgradeable_loader_state_buffer_walk( void * w, fd_bpf_upgradeable_loader_state_buffer_t const * self, fd_types_walk_fn_t fun, const char *name, uint level ) {
   fun( w, self, name, FD_FLAMENCO_TYPE_MAP, "fd_bpf_upgradeable_loader_state_buffer", level++ );
-  if( !self->authority_address ) {
+  if( !self->has_authority_address ) {
     fun( w, NULL, "authority_address", FD_FLAMENCO_TYPE_NULL, "pubkey", level );
   } else {
-    fd_pubkey_walk( w, self->authority_address, fun, "authority_address", level );
+    fd_pubkey_walk( w, &self->authority_address, fun, "authority_address", level );
   }
   fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_bpf_upgradeable_loader_state_buffer", level-- );
 }
 ulong fd_bpf_upgradeable_loader_state_buffer_size( fd_bpf_upgradeable_loader_state_buffer_t const * self ) {
   ulong size = 0;
   size += sizeof(char);
-  if( NULL != self->authority_address ) {
-    size += fd_pubkey_size( self->authority_address );
+  if( self->has_authority_address ) {
+    size += fd_pubkey_size( &self->authority_address );
   }
   return size;
 }
@@ -15768,13 +15760,10 @@ int fd_bpf_upgradeable_loader_state_program_data_encode( fd_bpf_upgradeable_load
   int err;
   err = fd_bincode_uint64_encode( self->slot, ctx );
   if( FD_UNLIKELY( err ) ) return err;
-  if( self->upgrade_authority_address != NULL ) {
-    err = fd_bincode_bool_encode( 1, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-    err = fd_pubkey_encode( self->upgrade_authority_address, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-  } else {
-    err = fd_bincode_bool_encode( 0, ctx );
+  err = fd_bincode_bool_encode( self->has_upgrade_authority_address, ctx );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( self->has_upgrade_authority_address ) {
+    err = fd_pubkey_encode( &self->upgrade_authority_address, ctx );
     if( FD_UNLIKELY( err ) ) return err;
   }
   return FD_BINCODE_SUCCESS;
@@ -15789,7 +15778,6 @@ static int fd_bpf_upgradeable_loader_state_program_data_decode_footprint_inner( 
     err = fd_bincode_bool_decode( &o, ctx );
     if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
     if( o ) {
-    *total_sz += FD_PUBKEY_ALIGN + sizeof(fd_pubkey_t);
       err = fd_pubkey_decode_footprint_inner( ctx, total_sz );
       if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
     }
@@ -15810,14 +15798,10 @@ static void fd_bpf_upgradeable_loader_state_program_data_decode_inner( void * st
   {
     uchar o;
     fd_bincode_bool_decode_unsafe( &o, ctx );
+    self->has_upgrade_authority_address = !!o;
     if( o ) {
-      *alloc_mem = (void*)fd_ulong_align_up( (ulong)*alloc_mem, FD_PUBKEY_ALIGN );
-      self->upgrade_authority_address = *alloc_mem;
-      *alloc_mem = (uchar *)*alloc_mem + sizeof(fd_pubkey_t);
-      fd_pubkey_new( self->upgrade_authority_address );
-      fd_pubkey_decode_inner( self->upgrade_authority_address, alloc_mem, ctx );
-    } else {
-      self->upgrade_authority_address = NULL;
+      fd_pubkey_new( &self->upgrade_authority_address );
+      fd_pubkey_decode_inner( &self->upgrade_authority_address, alloc_mem, ctx );
     }
   }
 }
@@ -15835,10 +15819,10 @@ void fd_bpf_upgradeable_loader_state_program_data_new(fd_bpf_upgradeable_loader_
 void fd_bpf_upgradeable_loader_state_program_data_walk( void * w, fd_bpf_upgradeable_loader_state_program_data_t const * self, fd_types_walk_fn_t fun, const char *name, uint level ) {
   fun( w, self, name, FD_FLAMENCO_TYPE_MAP, "fd_bpf_upgradeable_loader_state_program_data", level++ );
   fun( w, &self->slot, "slot", FD_FLAMENCO_TYPE_ULONG, "ulong", level );
-  if( !self->upgrade_authority_address ) {
+  if( !self->has_upgrade_authority_address ) {
     fun( w, NULL, "upgrade_authority_address", FD_FLAMENCO_TYPE_NULL, "pubkey", level );
   } else {
-    fd_pubkey_walk( w, self->upgrade_authority_address, fun, "upgrade_authority_address", level );
+    fd_pubkey_walk( w, &self->upgrade_authority_address, fun, "upgrade_authority_address", level );
   }
   fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_bpf_upgradeable_loader_state_program_data", level-- );
 }
@@ -15846,8 +15830,8 @@ ulong fd_bpf_upgradeable_loader_state_program_data_size( fd_bpf_upgradeable_load
   ulong size = 0;
   size += sizeof(ulong);
   size += sizeof(char);
-  if( NULL != self->upgrade_authority_address ) {
-    size += fd_pubkey_size( self->upgrade_authority_address );
+  if( self->has_upgrade_authority_address ) {
+    size += fd_pubkey_size( &self->upgrade_authority_address );
   }
   return size;
 }

--- a/src/flamenco/types/fd_types.h
+++ b/src/flamenco/types/fd_types.h
@@ -2262,7 +2262,8 @@ typedef struct fd_bpf_upgradeable_loader_program_instruction fd_bpf_upgradeable_
 
 /* Encoded Size: Dynamic */
 struct fd_bpf_upgradeable_loader_state_buffer {
-  fd_pubkey_t * authority_address;
+  fd_pubkey_t authority_address;
+  uchar has_authority_address;
 };
 typedef struct fd_bpf_upgradeable_loader_state_buffer fd_bpf_upgradeable_loader_state_buffer_t;
 #define FD_BPF_UPGRADEABLE_LOADER_STATE_BUFFER_ALIGN alignof(fd_bpf_upgradeable_loader_state_buffer_t)
@@ -2277,7 +2278,8 @@ typedef struct fd_bpf_upgradeable_loader_state_program fd_bpf_upgradeable_loader
 /* Encoded Size: Dynamic */
 struct fd_bpf_upgradeable_loader_state_program_data {
   ulong slot;
-  fd_pubkey_t * upgrade_authority_address;
+  fd_pubkey_t upgrade_authority_address;
+  uchar has_upgrade_authority_address;
 };
 typedef struct fd_bpf_upgradeable_loader_state_program_data fd_bpf_upgradeable_loader_state_program_data_t;
 #define FD_BPF_UPGRADEABLE_LOADER_STATE_PROGRAM_DATA_ALIGN alignof(fd_bpf_upgradeable_loader_state_program_data_t)

--- a/src/flamenco/types/fd_types.json
+++ b/src/flamenco/types/fd_types.json
@@ -1785,7 +1785,7 @@
       "name": "bpf_upgradeable_loader_state_buffer",
       "type": "struct",
       "fields": [
-        { "name": "authority_address", "type": "option", "element": "pubkey" }
+        { "name": "authority_address", "type": "option", "element": "pubkey", "flat": true }
       ]
     },
     {
@@ -1800,7 +1800,7 @@
       "type": "struct",
       "fields": [
         { "name": "slot", "type": "ulong" },
-        { "name": "upgrade_authority_address", "type": "option", "element": "pubkey" }
+        { "name": "upgrade_authority_address", "type": "option", "element": "pubkey", "flat": true }
       ]
     },
     {


### PR DESCRIPTION
**types: add APIs for zero alloc decoding**

- Add helper for converting between pointer and flat option
  representation
- Add decode_flat helper

**runtime: make BPF Loader v3 structs zero-alloc**

Removes dynamic allocations in BPF Loader v3 by turning pointer
option types into flat option types.