### PR TITLE
Fix MSan build

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -137,8 +137,8 @@ fetch () {
   checkout_repo lz4       https://github.com/lz4/lz4                "v1.10.0"
   checkout_repo s2n       https://github.com/awslabs/s2n-bignum     "" "efa579c"
   #checkout_repo openssl   https://github.com/openssl/openssl        "openssl-3.3.1"
+  checkout_repo secp256k1 https://github.com/bitcoin-core/secp256k1 "v0.5.0"
   if [[ $DEVMODE == 1 ]]; then
-    checkout_repo secp256k1 https://github.com/bitcoin-core/secp256k1 "v0.5.0"
     checkout_repo rocksdb   https://github.com/facebook/rocksdb       "v9.7.4"
     checkout_repo snappy    https://github.com/google/snappy          "1.2.1"
   fi
@@ -351,9 +351,13 @@ install_libcxx () {
     -DCMAKE_INSTALL_PREFIX:PATH="$PREFIX" \
     -DCMAKE_INSTALL_LIBDIR="lib" \
     -DCMAKE_BUILD_TYPE=Release \
-    -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
+    -DLLVM_DIR=".." \
+    -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \
     -DLLVM_USE_SANITIZER=Memory \
-    -DLLVM_ENABLE_PIC=ON
+    -DLLVM_ENABLE_PIC=ON \
+    -DLLVM_INCLUDE_TESTS=OFF \
+    -DLIBCXX_INCLUDE_BENCHMARKS=OFF \
+    -DLIBCXXABI_USE_LLVM_UNWINDER=OFF
 
   echo "[+] Building libcxx"
   "${MAKE[@]}" cxx cxxabi
@@ -570,8 +574,8 @@ install () {
   ( install_lz4       )
   ( install_s2n       )
   #( install_openssl   )
+  ( install_secp256k1 )
   if [[ $DEVMODE == 1 ]]; then
-    ( install_secp256k1 )
     ( install_snappy    )
     ( install_rocksdb   )
   fi

--- a/src/app/firedancer-dev/Local.mk
+++ b/src/app/firedancer-dev/Local.mk
@@ -5,6 +5,7 @@ ifdef FD_HAS_DOUBLE
 ifdef FD_HAS_INT128
 ifdef FD_HAS_SSE
 ifdef FD_HAS_ZSTD
+ifdef FD_HAS_SECP256K1
 
 .PHONY: firedancer-dev
 
@@ -22,6 +23,7 @@ firedancer-dev: $(OBJDIR)/bin/firedancer-dev
 # $(call run-integration-test,test_fddev)
 else
 $(warning firedancer-dev build disabled due to lack of zstd)
+endif
 endif
 endif
 endif

--- a/src/disco/archiver/Local.mk
+++ b/src/disco/archiver/Local.mk
@@ -3,7 +3,5 @@ ifdef FD_HAS_SSE
 $(call add-objs,fd_archiver_feeder,fd_disco)
 $(call add-objs,fd_archiver_writer,fd_disco)
 $(call add-objs,fd_archiver_playback,fd_disco)
-ifdef FD_HAS_ROCKSDB
 $(call add-objs,fd_archiver_backtest,fd_disco)
-endif
 endif

--- a/src/disco/archiver/fd_archiver_backtest.c
+++ b/src/disco/archiver/fd_archiver_backtest.c
@@ -1,9 +1,7 @@
+#if FD_HAS_ROCKSDB
+
 #define _GNU_SOURCE  /* Enable GNU and POSIX extensions */
-
-#include "../tiles.h"
-
 #include "fd_archiver.h"
-#include <errno.h>
 #include <fcntl.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -290,3 +288,22 @@ fd_topo_run_tile_t fd_tile_archiver_backtest = {
   .unprivileged_init        = unprivileged_init,
   .run                      = stem_run,
 };
+
+#else /* RocksDB not supported */
+
+#include "../topo/fd_topo.h"
+
+static void
+unprivileged_init( fd_topo_t *      topo,
+                   fd_topo_tile_t * tile ) {
+  (void)topo; (void)tile;
+  FD_LOG_ERR(( "backtest functionality is unavailable: Build does not include RocksDB support.\n"
+               "To fix, run ./deps.sh +dev and do a clean rebuild." ));
+}
+
+fd_topo_run_tile_t fd_tile_archiver_backtest = {
+  .name              = "arch_b",
+  .unprivileged_init = unprivileged_init,
+};
+
+#endif /* FD_HAS_ROCKSDB */


### PR DESCRIPTION
- Remove exception/unwind support from MSan build
- Allow full Firedancer to build without dev dependencies
- Promote libsecp256k1 to a default dependency (see above)
- Fix firedancer-dev link failure if RocksDB is missing
