### PR TITLE
fdctl: MSan fixes

### DIFF
--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -402,7 +402,7 @@ fd_topo_initialize( config_t * config ) {
   ulong affinity_tile_cnt = 0UL;
   if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_tile_private_cpus_parse( config->layout.affinity, parsed_tile_to_cpu );
 
-  ulong tile_to_cpu[ FD_TILE_MAX ];
+  ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
     if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && parsed_tile_to_cpu[ i ]>=cpus->cpu_cnt ) )
       FD_LOG_ERR(( "The CPU affinity string in the configuration file under [layout.affinity] specifies a CPU index of %hu, but the system "

--- a/src/app/shared/commands/configure/ethtool-loopback.c
+++ b/src/app/shared/commands/configure/ethtool-loopback.c
@@ -72,6 +72,7 @@ find_feature_index( int          sock,
     FD_LOG_ERR(( "error configuring network device, ioctl(SIOCETHTOOL,ETHTOOL_GSSET_INFO) failed (%i-%s)",
                  errno, fd_io_strerror( errno ) ));
   }
+  fd_msan_unpoison( set_info.r.data, sizeof(uint) );
   uint const feature_cnt = fd_uint_min( set_info.r.data[0], MAX_FEATURES );
 
   static union {
@@ -87,6 +88,7 @@ find_feature_index( int          sock,
     FD_LOG_ERR(( "error configuring network device, ioctl(SIOCETHTOOL,ETHTOOL_GSTRINGS) failed (%i-%s)",
                  errno, fd_io_strerror( errno ) ));
   }
+  fd_msan_unpoison( get_strings.r.data, ETH_GSTRING_LEN*feature_cnt );
 
   for( uint j=0UL; j<feature_cnt; j++ ) {
     uchar const * str = get_strings.r.data + (j*ETH_GSTRING_LEN);
@@ -115,6 +117,7 @@ get_feature_state( int sock,
     FD_LOG_ERR(( "error configuring network device, ioctl(SIOCETHTOOL,ETHTOOL_GFEATURES) failed (%i-%s)",
                  errno, fd_io_strerror( errno ) ));
   }
+  fd_msan_unpoison( get_features.r.features, get_features.r.size*sizeof(struct ethtool_get_features_block) );
 
   uint bucket = (uint)index / 32u;
   uint offset = (uint)index % 32u;

--- a/src/app/shared/fd_cap_chk.c
+++ b/src/app/shared/fd_cap_chk.c
@@ -64,6 +64,7 @@ has_capability( uint capability ) {
   };
 
   if( FD_UNLIKELY( syscall( SYS_capget, &capheader, capdata ) ) ) FD_LOG_ERR(( "capget syscall failed (%i-%s)", errno, fd_io_strerror( errno ) ) );
+  fd_msan_unpoison( capdata, sizeof(capdata) );
   return !!(capdata[ 0 ].effective & (1U << capability));
 }
 


### PR DESCRIPTION
- Fix uninitialized read in topology.c
- Add MSan annotations for cap_chk and ethtool syscalls
