### PR TITLE
Unmap MAP_SHARED stacks on fork()

### DIFF
--- a/src/util/tile/fd_tile_threads.cxx
+++ b/src/util/tile/fd_tile_threads.cxx
@@ -297,6 +297,12 @@ fd_tile_private_manager( void * _args ) {
   if( FD_LIKELY( stack ) ) { /* User provided stack */
     fd_tile_private_stack0 = (ulong)stack;
     fd_tile_private_stack1 = (ulong)stack + stack_sz;
+
+    /* Prevent another fork() from smashing the stack */
+    if( FD_UNLIKELY( madvise( stack, FD_TILE_PRIVATE_STACK_SZ, MADV_DONTFORK ) ) ) {
+      FD_LOG_ERR(( "madvise(stack,MADV_DONTFORK) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    }
+
   } else { /* Pthread provided stack */
     fd_log_private_stack_discover( stack_sz, &fd_tile_private_stack0, &fd_tile_private_stack1 ); /* logs details */
     if( FD_UNLIKELY( !fd_tile_private_stack0 ) )


### PR DESCRIPTION
Firedancer threads don't support fork(). If a user calls fork() regardless, wild memory corruption ensues, crashing both parent and child. This PR keeps the parent alive and crashes the child reliably.

- [x] Test regular `fddev`
- [x] Test `fddev --no-sandbox`
- [x] Test `fddev --no-sandbox --no-clone`
- [x] Test fd_tile APIs 