### PR TITLE
sock - log & continue in the event of error returned from sendmmsg

### DIFF
--- a/src/disco/net/sock/fd_sock_tile.c
+++ b/src/disco/net/sock/fd_sock_tile.c
@@ -453,7 +453,8 @@ flush_tx_batch( fd_sock_tile_t * ctx ) {
             break;
 
           default:
-            FD_LOG_ERR(( "sendmmsg failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+            /* log with NOTICE, since flushing has a significant negative performance impact */
+            FD_LOG_NOTICE(( "sendmmsg failed (%i-%s)", errno, fd_io_strerror( errno ) ));
         }
 
         /* first message failed, so skip failing message and continue */


### PR DESCRIPTION
sendmmsg has a hard-to-determine list of transient errors that should not terminate the validator.
As such, this PR logs the errors and continues.