### PR TITLE
agave, snapshot: add download-abort param, delay download speed check

### DIFF
--- a/src/app/fdctl/commands/run_agave.c
+++ b/src/app/fdctl/commands/run_agave.c
@@ -167,6 +167,7 @@ agave_boot( config_t const * config ) {
   if( strcmp( "", config->frankendancer.snapshots.incremental_path ) ) ADD( "--incremental-snapshot-archive-path", config->frankendancer.snapshots.incremental_path );
   ADDU( "--maximum-snapshots-to-retain", config->frankendancer.snapshots.maximum_full_snapshots_to_retain );
   ADDU( "--maximum-incremental-snapshots-to-retain", config->frankendancer.snapshots.maximum_incremental_snapshots_to_retain );
+  ADDU( "--maximum-snapshot-download-abort", config->frankendancer.snapshots.maximum_snapshot_download_abort );
   ADDU( "--minimal-snapshot-download-speed", config->frankendancer.snapshots.minimum_snapshot_download_speed );
 
   if( config->frankendancer.layout.agave_unified_scheduler_handler_threads ) {

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -398,6 +398,14 @@ dynamic_port_range = "8900-9000"
     # client with the `--minimum-snapshot-download-speed` argument.
     minimum_snapshot_download_speed = 10485760
 
+    # The maximum number of times to abort and retry when encountering a
+    # slow snapshot download.
+    #
+    # The default value is 5 retries.  This option is passed to the
+    # Agave client with the `--maximum-snapshot-download-abort`
+    # argument.
+    maximum_snapshot_download_abort = 5
+
     # Absolute directory path for storing snapshots.  If no path is
     # provided, it defaults to the [ledger.path] option from above.
     #

--- a/src/app/shared/fd_config.c
+++ b/src/app/shared/fd_config.c
@@ -445,6 +445,7 @@ fd_config_validateh( fd_configh_t const * config ) {
   CFG_HAS_NON_ZERO( snapshots.full_snapshot_interval_slots );
   CFG_HAS_NON_ZERO( snapshots.incremental_snapshot_interval_slots );
   CFG_HAS_NON_ZERO( snapshots.minimum_snapshot_download_speed );
+  CFG_HAS_NON_ZERO( snapshots.maximum_snapshot_download_abort );
 
   CFG_HAS_NON_EMPTY( layout.agave_affinity );
 }

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -76,6 +76,7 @@ struct fd_configh {
     uint full_snapshot_interval_slots;
     uint incremental_snapshot_interval_slots;
     uint minimum_snapshot_download_speed;
+    uint maximum_snapshot_download_abort;
     uint maximum_full_snapshots_to_retain;
     uint maximum_incremental_snapshots_to_retain;
     char path[ PATH_MAX ];

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -298,6 +298,7 @@ fd_config_extract_podh( uchar *        pod,
   CFG_POP      ( uint,   snapshots.full_snapshot_interval_slots           );
   CFG_POP      ( uint,   snapshots.incremental_snapshot_interval_slots    );
   CFG_POP      ( uint,   snapshots.minimum_snapshot_download_speed        );
+  CFG_POP      ( uint,   snapshots.maximum_snapshot_download_abort        );
   CFG_POP      ( uint,   snapshots.maximum_full_snapshots_to_retain       );
   CFG_POP      ( uint,   snapshots.maximum_incremental_snapshots_to_retain);
   CFG_POP      ( cstr,   snapshots.path                                   );


### PR DESCRIPTION
- delay the throughput check to after 5 seconds
- add maximum_snapshot_download_abort config option with a default value of 5 retries

Once merged, I will also backport to v0.5 branch

agave [diff](https://github.com/firedancer-io/agave/compare/dbe432c3ce23df..jherrera/inc-speed-test_duration)