### PR TITLE
Parallelization tune up and other cleanups

### DIFF
--- a/src/discof/consensus/test_consensus.c
+++ b/src/discof/consensus/test_consensus.c
@@ -892,7 +892,7 @@ main( void ) {
 //   uchar tpool_mem[FD_TPOOL_FOOTPRINT( FD_TILE_MAX )]__attribute__((aligned(FD_TPOOL_ALIGN))) = { 0 };
 //   /* clang-format on */
 //   if( tile_cnt > 4 ) {
-//     tpool = fd_tpool_init( tpool_mem, tile_cnt );
+//     tpool = fd_tpool_init( tpool_mem, tile_cnt, 0UL );
 //     FD_TEST( tpool );
 //     if( tpool == NULL ) FD_LOG_ERR( ( "failed to create thread pool" ) );
 //     ulong   scratch_sz = fd_scratch_smem_footprint( 256 << 20 );

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -281,7 +281,6 @@ fd_runtime_validate_fee_collector( fd_exec_slot_ctx_t const * slot_ctx,
   return 0UL;
 }
 
-
 static int
 fd_runtime_run_incinerator( fd_exec_slot_ctx_t * slot_ctx ) {
   FD_TXN_ACCOUNT_DECL( rec );
@@ -657,7 +656,6 @@ fd_runtime_collect_from_existing_account( ulong                       slot,
   #undef EXEMPT
   #undef COLLECT_RENT
 }
-
 
 /* fd_runtime_collect_rent_from_account performs rent collection duties.
    Although the Solana runtime prevents the creation of new accounts
@@ -1664,7 +1662,6 @@ fd_runtime_prepare_txns_start( fd_exec_slot_ctx_t *         slot_ctx,
 
     fd_rawtxn_b_t raw_txn = { .raw = txn->payload, .txn_sz = (ushort)txn->payload_sz };
 
-
     task_info[txn_idx].txn_ctx->spad      = runtime_spad;
     task_info[txn_idx].txn_ctx->spad_wksp = fd_wksp_containing( runtime_spad );
     int err = fd_execute_txn_prepare_start( slot_ctx,
@@ -2115,8 +2112,7 @@ fd_runtime_process_txns_in_microblock_stream( fd_exec_slot_ctx_t * slot_ctx,
       if( curr_exec_idx>=txn_cnt ) {
         break;
       }
-      int state = fd_tpool_worker_state( tpool, worker_idx );
-      if( state!=FD_TPOOL_WORKER_STATE_IDLE ) {
+      if( !fd_tpool_worker_idle( tpool, worker_idx ) ) {
         continue;
       }
 

--- a/src/flamenco/runtime/tests/harness/fd_block_harness.c
+++ b/src/flamenco/runtime/tests/harness/fd_block_harness.c
@@ -374,8 +374,8 @@ fd_runtime_fuzz_block_ctx_exec( fd_runtime_fuzz_runner_t * runner,
   /* Initialize tpool and spad(s) */
   ulong        worker_max = FD_BLOCK_HARNESS_TPOOL_WORKER_CNT;
   void *       tpool_mem  = fd_spad_alloc( runner->spad, FD_TPOOL_ALIGN, FD_TPOOL_FOOTPRINT( worker_max ) );
-  fd_tpool_t * tpool      = fd_tpool_init( tpool_mem, worker_max );
-  fd_tpool_worker_push( tpool, 1UL, NULL, 0UL );
+  fd_tpool_t * tpool      = fd_tpool_init( tpool_mem, worker_max, 0UL );
+  fd_tpool_worker_push( tpool, 1UL );
 
   fd_spad_t * runtime_spad = runner->spad;
 

--- a/src/util/alloc/fd_alloc.h
+++ b/src/util/alloc/fd_alloc.h
@@ -120,7 +120,6 @@
    time to try to bound the amount of pre-allocation for small requests. */
 
 #include "../wksp/fd_wksp.h"
-#include "../valloc/fd_valloc.h"
 
 /* FD_ALLOC_{ALIGN,FOOTPRINT} give the required alignment and footprint
    needed for a wksp allocation to be suitable as a fd_alloc.  ALIGN is
@@ -633,4 +632,3 @@ fd_alloc_virtual( fd_alloc_t * alloc ) {
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_util_alloc_fd_alloc_h */
-

--- a/src/util/archive/fd_tar.h
+++ b/src/util/archive/fd_tar.h
@@ -5,7 +5,6 @@
    format. This is not a general-purpose TAR implementation.  It is
    currently only intended for loading and writing Solana snapshots. */
 
-#include "../fd_util_base.h"
 #include "../io/fd_io.h"
 
 /* File Format ********************************************************/
@@ -84,7 +83,7 @@ fd_tar_set_octal( char  buf[ static 12 ],
                   ulong val );
 
 /* fd_tar_meta_set_size sets the size field.  Returns 1 on success, 0
-   if sz is too large to be represented in TAR header. Set size using the 
+   if sz is too large to be represented in TAR header. Set size using the
    OLDGNU size extension to allow for unlimited file sizes. The first byte
    must be 0x80 followed by 0s and then the size in binary. */
 
@@ -240,30 +239,30 @@ fd_tar_read( void *        reader,
     2. Write out file data with fd_tar_writer_write_file_data( writer, data, data_sz ).
        This can be done as many times as you want.
     3. Finish the current file with fd_tar_writer_fini_file( writer ).
-  
-   When you are done, call fd_tar_writer_delete( writer ) to write out the 
+
+   When you are done, call fd_tar_writer_delete( writer ) to write out the
    tar archive trailer and close otu the file descriptor.
 
-   If you want to reserve space for an existing file and write back to it 
+   If you want to reserve space for an existing file and write back to it
    at some point in the future see the below comments for
    fd_tar_writer_{make,fill}_space().
-   
+
    */
 
 struct fd_tar_writer {
   int                      fd;         /* The file descriptor for the tar archive. */
   ulong                    header_pos; /* The position in the file for the current files header.
-                                          If there is no current file that is being streamed out, 
+                                          If there is no current file that is being streamed out,
                                           the header_pos will be equal to ULONG_MAX. */
   ulong                    data_sz;    /* The size of the current files data. If there is no
                                           current file that is being streamed out, the data_sz
                                           will be equal to ULONG_MAX. */
   ulong                    wb_pos;     /* If this value is not equal to ULONG_MAX that means that
-                                          this is the position at which to write back to with a 
+                                          this is the position at which to write back to with a
                                           call to fd_tar_writer_fill_space. */
-  /* TODO: Right now, the stream to the tar writer just uses fd_io_write. 
+  /* TODO: Right now, the stream to the tar writer just uses fd_io_write.
      This can eventually be abstracted to use write callbacks that use
-     fd_io streaming under the hood. This adds some additional complexity 
+     fd_io streaming under the hood. This adds some additional complexity
      that's related to writing back into the header: if the header is still
      in the ostream buf, modify the buffer. Otherwise, read the header
      directly from the file. */
@@ -333,15 +332,15 @@ fd_tar_writer_fini_file( fd_tar_writer_t * writer );
 /* fd_tar_writer_make_space and fd_tar_writer_fill_space, allow for writing
    back to a specific place in the tar stream. This can be used by first
    making a call to fd_tar_write_new_file, fd_tar_writer_make_space, and
-   fd_tar_writer_fini_file. This will populate the header and write out 
+   fd_tar_writer_fini_file. This will populate the header and write out
    random bytes. The start of this data file will be saved by the tar writer.
-   Up to n data files can be appended to the tar archive before a call to 
+   Up to n data files can be appended to the tar archive before a call to
    fd_tar_writer_fill_space. fd_tar_writer_fill_space should only be called
    after an unpaired call to fd_tar_writer_make_space and it requires a valid
    fd_tar_writer_t handle. It allows the user to write back to the point at
    which they made space. _make_space and _fill_space should be paired together.
    There can only be one oustanding call to make_space at a time.
-   
+
    TODO: This can be extended to support multiple write backs. */
 
 int

--- a/src/util/bits/fd_bits.h
+++ b/src/util/bits/fd_bits.h
@@ -3,7 +3,7 @@
 
 /* Bit manipulation APIs */
 
-#include "../sanitize/fd_msan.h"
+#include "../sanitize/fd_sanitize.h"
 
 FD_PROTOTYPES_BEGIN
 

--- a/src/util/fd_util.h
+++ b/src/util/fd_util.h
@@ -1,50 +1,50 @@
 #ifndef HEADER_fd_src_util_fd_util_h
 #define HEADER_fd_src_util_fd_util_h
 
-//#include "fd_util_base.h"         /* includes stdalign.h, string.h, limits.h, float.h */
-//#include "sanitize/fd_msan.h"     /* includes fd_util_base.h */
-//#include "bits/fd_bits.h"         /* includes sanitize/fd_msan.h */
-//#include "sanitize/fd_asan.h"     /* includes fd_util_base.h" */
-//#include "sanitize/fd_msan.h"     /* includes fd_util_base.h" */
-//#include "sanitize/fd_sanitize.h" /* includes sanitize/fd_asan.h sanitize/fd_msan.h */
-//#include "io/fd_io.h"             /* includes bits/fd_bits.h */
-#include "spad/fd_spad.h"           /* includes bits/fd_bits.h */
-//#include "cstr/fd_cstr.h"         /* includes bits/fd_bits.h */
-//#include "pod/fd_pod.h"           /* includes cstr/fd_cstr.h */
-//#include "env/fd_env.h"           /* includes cstr/fd_cstr.h */
-//#include "log/fd_log.h"           /* includes env/fd_env.h io/fd_io.h */
-//#include "checkpt/fd_checkpt.h"   /* includes log/fd_log.h */
-//#include "shmem/fd_shmem.h"       /* includes log/fd_log.h */
-//#include "tile/fd_tile.h"         /* includes shmem/fd_shmem.h */
-//#include "scratch/fd_scratch.h"   /* includes tile/fd_tile.h sanitize/fd_sanitize.h valloc/fd_valloc.h */
-//#include "tpool/fd_tpool.h"       /* includes tile/fd_tile.h scratch/fd_scratch.h */
-//#include "wksp/fd_wksp.h"         /* tpool/fd_tpool.h checkpt/fd_checkpt.h sanitize/fd_sanitize.h */
-#include "alloc/fd_alloc.h"         /* includes wksp/fd_wksp.h valloc/fd_valloc.h */
-#include "rng/fd_rng.h"             /* includes bits/fd_bits.h */
+//#include "fd_util_base.h"          /* includes stdalign.h string.h limits.h float.h */
+//#include "sanitize/fd_sanitize.h"  /* includes fd_util_base.h (fd_asan.h fd_msan.h) */
+//#include "valloc/fd_valloc.h"      /* includes fd_util_base.h */ /* FIXME: deprecate? */
+//#include "bits/fd_bits.h"          /* includes sanitize/fd_sanitize.h (fd_bits_find_lsb.h fd_bits_find_msb.h fd_bits_tg.h) */
+//#include "io/fd_io.h"              /* includes bits/fd_bits.h */
+//#include "cstr/fd_cstr.h"          /* includes bits/fd_bits.h */
+#include "rng/fd_rng.h"              /* includes bits/fd_bits.h */
+#include "spad/fd_spad.h"            /* includes bits/fd_bits.h valloc/fd_valloc.h */
+//#include "env/fd_env.h"            /* includes cstr/fd_cstr.h */
+//#include "log/fd_log.h"            /* includes env/fd_env.h io/fd_io.h */
+//#include "checkpt/fd_checkpt.h"    /* includes log/fd_log.h */
+//#include "shmem/fd_shmem.h"        /* includes log/fd_log.h */
+//#include "tile/fd_tile.h"          /* includes shmem/fd_shmem.h */
+//#include "scratch/fd_scratch.h"    /* includes tile/fd_tile.h valloc/fd_valloc.h */ /* FIXME: deprecate non alloca parts? */
+//#include "tpool/fd_tpool.h"        /* includes scratch/fd_scratch.h */
+//#include "wksp/fd_wksp.h"          /* includes tpool/fd_tpool.h checkpt/fd_checkpt.h */
+#include "alloc/fd_alloc.h"          /* includes wksp/fd_wksp.h */
 
-/* FIXME: Should these be optional APIs? */
-#include "sandbox/fd_sandbox.h"     /* includes fd_util_base.h */
-//#include "math/fd_stat.h"         /* includes bits/fd_bits.h */
-#include "bits/fd_sat.h"            /* includes bits/fd_bits.h */
-//#include "hist/fd_histf.h"        /* includes log/fd_log.h */
+#include "sandbox/fd_sandbox.h"      /* includes fd_util_base.h */ /* FIXME: should this be included by default? */
+#include "bits/fd_sat.h"             /* includes bits/fd_bits.h */ /* FIXME: should this be incldued by default? */
 
 /* Additional fd_util APIs that are not included by default */
 
-//#include "archive/fd_ar.h"        /* includes fd_util_base.h */
-//#include "net/fd_pcapng.h"        /* includes fd_util_base.h */
-//#include "net/fd_eth.h"           /* includes bits/fd_bits.h */
-//#include "net/fd_ip4.h"           /* includes bits/fd_bits.h */
-//#include "net/fd_igmp.h"          /* includes net/fd_ip4.h */
-//#include "net/fd_udp.h"           /* includes net/fd_ip4.h */
-//#include "net/fd_net_headers.h */ /* includes net/fd_udp.h net/fd_eth.h */
-//#include "net/fd_pcap.h"          /* includes net/fd_eth.h log/fd_log.h */
-//#include "bits/fd_float.h"        /* includes bits/fd_bits.h */
-//#include "bits/fd_uwide.h"        /* includes bits/fd_bits.h */
-//#include "math/fd_sqrt.h"         /* includes bits/fd_bits.h */
-//#include "math/fd_fxp.h"          /* includes math/fd_sqrt.h, (!FD_HAS_INT128) bits/fd_uwide.h */
-//#include "simd/fd_sse.h"          /* includes bits/fd_bits.h, requires FD_HAS_SSE */
-//#include "simd/fd_avx.h"          /* includes bits/fd_bits.h, requires FD_HAS_AVX */
-//#include "simd/fd_avx512.h"       /* includes bits/fd_bits.h, requires FD_HAS_AVX512 */
+//#include "archive/fd_ar.h"         /* includes fd_util_base.h */
+//#include "archive/fd_tar.h"        /* includes fd_io.h */
+//#include "bits/fd_float.h"         /* includes bits/fd_bits.h */
+//#include "bits/fd_uwide.h"         /* includes bits/fd_bits.h */
+//#include "hist/fd_histf.h"         /* includes log/fd_log.h math.h (FD_HAS_AVX) fd_avx.h */
+//#include "math/fd_stat.h"          /* includes bits/fd_bits.h */
+//#include "math/fd_sqrt.h"          /* includes bits/fd_bits.h */
+//#include "math/fd_fxp.h"           /* includes math/fd_sqrt.h, (!FD_HAS_INT128) bits/fd_uwide.h */
+//#include "net/fd_pcapng.h"         /* includes fd_util_base.h */
+//#include "net/fd_eth.h"            /* includes bits/fd_bits.h */
+//#include "net/fd_ip4.h"            /* includes bits/fd_bits.h */
+//#include "net/fd_igmp.h"           /* includes net/fd_ip4.h */
+//#include "net/fd_udp.h"            /* includes net/fd_ip4.h */
+//#include "net/fd_net_headers.h */  /* includes net/fd_udp.h net/fd_eth.h */
+//#include "net/fd_pcap.h"           /* includes net/fd_eth.h log/fd_log.h */
+//#include "pod/fd_pod.h"            /* includes cstr/fd_cstr.h */
+//#include "sanitize/fd_fuzz.h"      /* includes fd_util_base.h */
+//#include "sanitize/fd_backtrace.h" /* FIXME: this probably should be merged with another header */
+//#include "simd/fd_sse.h"           /* includes bits/fd_bits.h, requires FD_HAS_SSE */
+//#include "simd/fd_avx.h"           /* includes bits/fd_bits.h, requires FD_HAS_AVX */
+//#include "simd/fd_avx512.h"        /* includes bits/fd_bits.h, requires FD_HAS_AVX512 */
 
 FD_PROTOTYPES_BEGIN
 

--- a/src/util/scratch/fd_scratch.h
+++ b/src/util/scratch/fd_scratch.h
@@ -9,7 +9,6 @@
    It is meant for use in situations that have very complex and large
    temporary memory usage. */
 
-#include "../sanitize/fd_sanitize.h"
 #include "../tile/fd_tile.h"
 #include "../valloc/fd_valloc.h"
 

--- a/src/util/spad/fd_spad.h
+++ b/src/util/spad/fd_spad.h
@@ -1,8 +1,6 @@
 #ifndef HEADER_fd_src_util_spad_fd_spad_h
 #define HEADER_fd_src_util_spad_fd_spad_h
 
-#include "../sanitize/fd_sanitize.h"
-
 /* APIs for high performance persistent inter-process shared scratch pad
    memories.  A spad as a scratch pad that behaves very much like a
    thread's stack:
@@ -296,7 +294,6 @@ FD_FN_PURE static inline ulong fd_spad_mem_wmark( fd_spad_t const * spad ) { ret
 
 FD_FN_PURE static inline int fd_spad_in_frame( fd_spad_t const * spad ) { return spad->frame_free<FD_SPAD_FRAME_MAX; }
 
-
 /* operations */
 /* fd_spad_alloc_max returns the maximum number of bytes with initial
    byte alignment of align that can currently be allocated / prepared
@@ -531,7 +528,6 @@ fd_spad_virtual( fd_spad_t * spad ) {
   fd_valloc_t valloc = { spad, &fd_spad_vtable };
   return valloc;
 }
-
 
 /* fn implementations */
 static inline void

--- a/src/util/tmpl/test_sort_para.c
+++ b/src/util/tmpl/test_sort_para.c
@@ -45,11 +45,11 @@ main( int     argc,
 
   static uchar _tpool[ FD_TPOOL_FOOTPRINT( FD_TILE_MAX ) ] __attribute__((aligned(FD_TPOOL_ALIGN)));
 
-  fd_tpool_t * tpool = fd_tpool_init( _tpool, thread_cnt ); /* logs details */
+  fd_tpool_t * tpool = fd_tpool_init( _tpool, thread_cnt, 0UL ); /* logs details */
   if( FD_UNLIKELY( !tpool ) ) FD_LOG_ERR(( "fd_tpool_init failed" ));
 
   for( ulong thread_idx=1UL; thread_idx<thread_cnt; thread_idx++ )
-    if( FD_UNLIKELY( !fd_tpool_worker_push( tpool, thread_idx, NULL, 0UL ) ) ) FD_LOG_ERR(( "fd_tpool_worker_push failed" ));
+    if( FD_UNLIKELY( !fd_tpool_worker_push( tpool, thread_idx ) ) ) FD_LOG_ERR(( "fd_tpool_worker_push failed" ));
 
   FD_LOG_NOTICE(( "Running (--iter-max %lu --diag-int %lu)", iter_max, diag_int ));
 

--- a/src/util/tpool/fd_map_reduce.h
+++ b/src/util/tpool/fd_map_reduce.h
@@ -1,0 +1,496 @@
+/* DO NOT INCLUDE DIRECTLY, USE fd_tpool.h */
+
+/* FD_MAP_REDUCE supports writing CUDA-ish kernels.  These have faster
+   dispatch than CUDA (or other threading libraries) and they don't
+   require any data choreography to shuffle data between the CPU and
+   GPU.  An ultra high performance deterministic parallelized tree
+   dispatch is used for good scaling, cache temporal locality and cache
+   spatial locality.  Example usage:
+
+     In a header file:
+
+       // my_hist_op uses the caller and tpool threads
+       // (tpool_t0,tpool_t1) to compute:
+       //
+       //   long h[4];
+       //   for( long j=0L; j<4L; j++ ) h[j] = 0L;
+       //   for( long i=i0; i<i1; i++ ) {
+       //     long j = my_map_op( x[i] );
+       //     h[j]++;
+       //   }
+       //
+       // where x is a pointer to a my_ele_t array.  Tpool threads
+       // (tpool_t0,tpool_t1) are assumed to be idle and i1-i0 is
+       // assumed to be in [0,LONG_MAX/FD_TILE_MAX]
+
+       FD_MAP_REDUCE_PROTO( my_hist_op );
+
+     In a source file that uses my_hist_op:
+
+       long h[4]; // should have appropriate alignment
+
+       FD_MAP_REDUCE( my_hist_op, tpool,t0,t1, i0,i1, h, x );
+
+     In the source file that implements my_hist_op:
+
+       FD_MAP_REDUCE_BEGIN( my_hist_op, 1L, 0UL, sizeof(long), 4L ) {
+
+         ... At this point:
+
+             - The long range [block_i0,block_i1) give the elements for
+               this thread to process.  Other threads will process other
+               approximately equally sized disjoint ranges in parallel.
+               The long block_cnt gives block_i1 - block_i0.  The long
+               block_thresh gives the parameter used to optimize thread
+               dispatch (1L in this example).  Element ranges with more
+               than this number of elements are considered worth
+               processing with more than one thread if available.
+               block_thresh should be at least 1 and can be a run time
+               evaluated expression.  This can also be used to make sure
+               different kernel dispatches consistently partition
+               elements such that there is good cache reuse between
+               different thread parallel kernels.
+
+             - tpool is a handle of this thread's tpool and ulong
+               range [tpool_t0,tpool_t1) give the threads available to
+               process this block.  This thread should be considered
+               tpool_t0 and threads (tpool_t0,tpool_t1) are idle.  Even
+               if (tpool_t0,tpool_t1) is not empty, it is almost
+               certainly optimal to just have this thread process all
+               elements in the block single threaded.  That is, when
+               processing many elements (i.e. >> block_thresh*(t1-t0)),
+               (tpool_t0,tpool_t1) will be empty but, when processing a
+               small numbers of elements, FD_MAP_REDUCE already
+               concluded there were too few elements to dispatch to
+               (tpool_t0,tpool_t1).
+
+             - The ulong arg_cnt gives the number of arguments passed by
+               the caller (2 in this example).  arg_cnt is in [0,26].
+
+             - ulongs arg[i] for i in [1,arg_cnt) give all but the first
+               user arguments passed to FD_MAP_REDUCE (cast to a ulong)
+               in order.  If reduce_cnt==0 and arg_cnt>0, arg[0] gives
+               the initial user argument passed to FD_MAP_REDUCE (cast
+               to a ulong).
+
+             - If reduce_cnt>0 (as it is in this example), arg[0] gives
+               the unique uninitialized scratch region where this thread
+               should save its local reduction.  This region will have
+               an alignment of reduce_align byte where reduce_align is
+               an integer power of 2.  In this example, the ulong
+               reduce_align / ulong reduce_sz / long reduce_cnt were
+               specified via the 0UL / sizeof(long) / 4L above.  A zero
+               value for reduce_align indicates to use a HPC thread
+               friendly default of 128.  Note that the combination of
+               arg_cnt==0 and reduce_cnt>0 is a little silly but will
+               still work.
+
+             - The names _reduce_top, _reduce_footprint, _reduce_stack,
+               _r1 are reserved.
+
+             IMPORTANT SAFETY TIP!  REDUCE_ALIGN / REDUCE_CNT /
+             REDUCE_SZ SHOULD BE ALLOCA FRIENDLY AMOUNTS (<<~1 MIB
+             TYPICALLY).  DO NOT ASSUME THE REDUCTION REGION HAS A SIZE
+             OF _REDUCE_FOOTPRINT (THE OUTPUT REGION PASSED BY THE USER
+             MIGHT ONLY HAVE A SIZE OF REDUCE_CNT*REDUCE_SZ EVEN IF IT
+             HAS THE CORRECT ALIGNMENT).
+
+             IMPORTANT SAFETY TIP!  DO NOT RETURN FROM THIS BLOCK.  IF
+             ENDING A BLOCK EARLY, USE BREAK.
+
+             IMPORTANT SAFETY TIP!  DO NOT MODIFY BLOCK_I1 OR TPOOL_T1,
+             IN THIS BLOCK.  IT WILL CONFUSE THE REDUCTION.
+
+         long           * restrict h = (long           *)arg[0];
+         my_ele_t const * restrict x = (my_ele_t const *)arg[1];
+
+         for( long j=0L; j<4L; j++ ) h[j] = 0UL;
+
+         for( long i=block_i0; i<block_i1; i++ ) {
+           long j = my_map_op( x[i] );
+           h[j]++;
+         }
+
+       } FD_MAP_END {
+
+         ... At this point, the environment is as described above with
+             the following differences:
+
+             - There is at least one thread in the ulong range
+               [tpool_t0,tpool_ts) and one thread in the ulong range
+               [tpool_ts,tpool_t1).  This should be considered thread t0
+               and threads (tpool_t0,tpool_t1) are idle.
+
+             - On entry, arg[0] points to the partial reduction (cast to
+               a ulong) computed for elements in the long range
+               [block_i0,block_is).  This was computed by threads
+               [tpool_t0,tpool_ts).  Similarly, _r1 points to the
+               partial reduction (cast to a ulong) for elements in the
+               long range [block_is,block_i1).  This was computed by
+               threads [tpool_ts,tpool_t1).  These regions have the
+               alignment and footprint specified for the FD_MAP_REDUCE.
+
+             - On exit, the contents in _r1 should have been reduced
+               into the contents of arg[0] such that arg[0] contains to
+               the partial reduction of the elements in
+               [block_i0,block_i1).  Threads [tpool_t0,tpool_t1) are
+               available to compute this reduction.  _r1 should not be
+               modified but the contents in _r1 are free to clobber.
+
+             IMPORTANT SAFETY TIP!  While this reduction is often
+             theoretically parallelizable and threads
+             (tpool_t0,tpool_t1) are available here for this,
+             parallelization of this is usually counterproductive if the
+             amount to reduce is small, the reduction operation is cheap
+             and/or the arrays to reduce have poor spatial locality due
+             to the mapping phase above.
+
+         long       * restrict h0 = (long       *)arg[0];
+         long const * restrict h1 = (long const *)_r1;
+
+         for( long j=0L; j<4L; j++ ) h0[j] += h1[j];
+
+       } FD_REDUCE_END
+
+  FD_MAP_REDUCE operations act as a compiler memory fence. */
+
+#define FD_MAP_REDUCE_PROTO(op) \
+void                            \
+op( fd_tpool_t *  tpool,        \
+    ulong         tpool_t0,     \
+    ulong         arg_cnt,      \
+    ulong const * arg )
+
+/* Note: we don't use fd_alloca here because of current compiler
+   limitations where gcc doesn't recognize reduce_align is a compile
+   time constant (fd_alloc turns into __built_alloca_with_align under
+   the hood and that builtin requires align to be compile time ... which
+   is fine ... when the compiler can recognize it.  Use of dynamic
+   allocation on the stack does imply this requires FD_HAS_ALLOCA. */
+
+#define FD_MAP_REDUCE_BEGIN(op,BLOCK_THRESH,REDUCE_ALIGN,REDUCE_SZ,REDUCE_CNT)                                 \
+void                                                                                                           \
+op( fd_tpool_t *  tpool,                                                                                       \
+    ulong         tpool_t0,                                                                                    \
+    ulong         arg_cnt,  /* at least 3 */                                                                   \
+    ulong const * arg ) {                                                                                      \
+  FD_COMPILER_MFENCE(); /* guarantees memory fence even if tpool_cnt==1 */                                     \
+  long  block_thresh      = (BLOCK_THRESH);                                                                    \
+  ulong reduce_align      = (REDUCE_ALIGN); reduce_align = fd_ulong_if( !!reduce_align, reduce_align, 128UL ); \
+  ulong reduce_sz         = (REDUCE_SZ);                                                                       \
+  long  reduce_cnt        = (REDUCE_CNT);                                                                      \
+  ulong tpool_t1          =       arg[0];                                                                      \
+  long  block_i0          = (long)arg[1];                                                                      \
+  long  block_i1          = (long)arg[2];                                                                      \
+  long  block_cnt;                                                                                             \
+  ulong _reduce_top       = 0UL;                                                                               \
+  ulong _reduce_footprint = fd_ulong_align_up( reduce_sz*(ulong)reduce_cnt, reduce_align );                    \
+  struct { ulong t1; long i1; } _reduce_stack[ 11 ]; /* Assumes TILE_MAX<2048 (yes strictly less) */           \
+  ulong _r1 = !reduce_cnt ? 0UL :                                                                              \
+    fd_ulong_align_up( (ulong)__builtin_alloca( _reduce_footprint*11UL + reduce_align-1UL ), reduce_align );   \
+  for(;;) {                                                                                                    \
+    ulong tpool_cnt   = tpool_t1 - tpool_t0;                                                                   \
+    /**/  block_cnt   = block_i1 - block_i0;                                                                   \
+    if( FD_LIKELY( (tpool_cnt<=1UL) | (block_cnt<=block_thresh) ) ) break;                                     \
+    ulong tpool_left  = fd_tpool_private_split( tpool_cnt );                                                   \
+    ulong tpool_right = tpool_cnt - tpool_left;                                                                \
+    ulong tpool_ts    = tpool_t0 + tpool_left;                                                                 \
+    long  block_is    = block_i1 - (long)((tpool_right*(ulong)block_cnt)/tpool_cnt); /* No overfl */           \
+    fd_tpool_private_worker_t * worker = fd_tpool_private_worker( tpool )[ tpool_ts ];                         \
+    uint  seq0        = worker->seq0 + 1U;                                                                     \
+    worker->arg_cnt   = (uint)arg_cnt;                                                                         \
+    worker->task      = (ulong)(op);                                                                           \
+    worker->arg[0]    =        tpool_t1;                                                                       \
+    worker->arg[1]    = (ulong)block_is;                                                                       \
+    worker->arg[2]    = (ulong)block_i1;                                                                       \
+    if( reduce_cnt ) worker->arg[3] = _r1;                                                                     \
+    for( ulong idx=reduce_cnt ? 4UL : 3UL; idx<arg_cnt; idx++ ) worker->arg[idx] = arg[idx];                   \
+    FD_COMPILER_MFENCE();                                                                                      \
+    worker->seq0      = seq0;                                                                                  \
+    FD_COMPILER_MFENCE();                                                                                      \
+    if( FD_UNLIKELY( tpool->opt & FD_TPOOL_OPT_SLEEP ) ) fd_tpool_private_wake( worker );                      \
+    _reduce_stack[ _reduce_top ].t1 = tpool_t1;                                                                \
+    _reduce_stack[ _reduce_top ].i1 = block_i1;                                                                \
+    _reduce_top++;                                                                                             \
+    _r1 += _reduce_footprint;                                                                                  \
+    tpool_t1 = tpool_ts;                                                                                       \
+    block_i1 = block_is;                                                                                       \
+  }                                                                                                            \
+  arg_cnt -= 3UL;                                                                                              \
+  arg     += 3UL;                                                                                              \
+  do
+
+#define FD_MAP_END                                            \
+  while(0);                                                   \
+  while( _reduce_top ) {                                      \
+    long  block_is  = block_i1; (void)block_is;               \
+    ulong tpool_ts  = tpool_t1;                               \
+    /**/  _r1      -= _reduce_footprint;                      \
+    /**/  _reduce_top--;                                      \
+    /**/  tpool_t1  = (ulong)_reduce_stack[ _reduce_top ].t1; \
+    /**/  block_i1  =        _reduce_stack[ _reduce_top ].i1; \
+    /**/  block_cnt = block_i1 - block_i0;                    \
+    fd_tpool_wait( tpool, tpool_ts );                         \
+    do
+
+#define FD_REDUCE_END   \
+    while(0);           \
+  }                     \
+  FD_COMPILER_MFENCE(); \
+}
+
+/* FD_FOR_ALL is a special case of FD_MAP_REDUCE when no reduction is
+   required (i.e. reduce_align=1, reduce_sz=0, reduce_cnt=0).  Example:
+
+       // my_vec_op uses the caller and tpool threads
+       // (tpool_t0,tpool_t1) to compute:
+       //
+       //   for( long i=i0; i<i1; i++ ) z[i] = my_scalar_op( x[i], y[i] );
+       //
+       // where x, y and z are pointers to non-overlapping my_ele_t
+       // arrays.  Threads (tpool_t0,tpool_t1) are assumed to be idle
+       // and (block_i1-block_i0) in [0,LONG_MAX / FD_TILE_MAX].
+
+       FD_FOR_ALL_PROTO( my_vec_op );
+
+     In a source file that uses my_vec_op:
+
+       FD_FOR_ALL( my_vec_op, tpool, t0,t1, i0,i1, x,y,z );
+
+     In the source file that implements my_vec_op:
+
+       FD_FOR_ALL_BEGIN( my_vec_op, 1024L ) {
+
+         my_ele_t const * restrict x = (my_ele_t const *)arg[0];
+         my_ele_t const * restrict y = (my_ele_t const *)arg[1];
+         my_ele_t       * restrict z = (my_ele_t       *)arg[2];
+
+         for( long i=block_i0; i<block_i1; i++ ) z[i] = my_scalar_op( x[i], y[i] );
+
+       } FD_FOR_ALL_END */
+
+#define FD_FOR_ALL_PROTO                  FD_MAP_REDUCE_PROTO
+#define FD_FOR_ALL_BEGIN(op,BLOCK_THRESH) FD_MAP_REDUCE_BEGIN((op),(BLOCK_THRESH),1UL,0UL,0L)
+#define FD_FOR_ALL_END                    FD_MAP_END {} FD_REDUCE_END
+#define FD_FOR_ALL                        FD_MAP_REDUCE
+
+/* THIS CODE IS AUTOGENERATED; DO NOT INCLUDE DIRECTLY */
+
+static inline void
+fd_map_reduce_private_0( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1 ) {
+  ulong arg[3]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1;
+  task( tpool, t0, 3UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_0(task,tpool,t0,t1,i0,i1) fd_map_reduce_private_0( (task), (tpool), (t0), (t1), (i0), (i1) )
+
+static inline void
+fd_map_reduce_private_1( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0 ) {
+  ulong arg[4]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0;
+  task( tpool, t0, 4UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_1(task,tpool,t0,t1,i0,i1,a0) fd_map_reduce_private_1( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0) )
+
+static inline void
+fd_map_reduce_private_2( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1 ) {
+  ulong arg[5]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1;
+  task( tpool, t0, 5UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_2(task,tpool,t0,t1,i0,i1,a0,a1) fd_map_reduce_private_2( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1) )
+
+static inline void
+fd_map_reduce_private_3( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2 ) {
+  ulong arg[6]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2;
+  task( tpool, t0, 6UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_3(task,tpool,t0,t1,i0,i1,a0,a1,a2) fd_map_reduce_private_3( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2) )
+
+static inline void
+fd_map_reduce_private_4( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3 ) {
+  ulong arg[7]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3;
+  task( tpool, t0, 7UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_4(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3) fd_map_reduce_private_4( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3) )
+
+static inline void
+fd_map_reduce_private_5( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4 ) {
+  ulong arg[8]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4;
+  task( tpool, t0, 8UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_5(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4) fd_map_reduce_private_5( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4) )
+
+static inline void
+fd_map_reduce_private_6( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5 ) {
+  ulong arg[9]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5;
+  task( tpool, t0, 9UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_6(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5) fd_map_reduce_private_6( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5) )
+
+static inline void
+fd_map_reduce_private_7( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6 ) {
+  ulong arg[10]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6;
+  task( tpool, t0, 10UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_7(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6) fd_map_reduce_private_7( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6) )
+
+static inline void
+fd_map_reduce_private_8( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7 ) {
+  ulong arg[11]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7;
+  task( tpool, t0, 11UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_8(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7) fd_map_reduce_private_8( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7) )
+
+static inline void
+fd_map_reduce_private_9( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8 ) {
+  ulong arg[12]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8;
+  task( tpool, t0, 12UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_9(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8) fd_map_reduce_private_9( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8) )
+
+static inline void
+fd_map_reduce_private_10( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9 ) {
+  ulong arg[13]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9;
+  task( tpool, t0, 13UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_10(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9) fd_map_reduce_private_10( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9) )
+
+static inline void
+fd_map_reduce_private_11( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9, ulong a10 ) {
+  ulong arg[14]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9; arg[13] = a10;
+  task( tpool, t0, 14UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_11(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10) fd_map_reduce_private_11( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9), (ulong)(a10) )
+
+static inline void
+fd_map_reduce_private_12( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9, ulong a10, ulong a11 ) {
+  ulong arg[15]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9; arg[13] = a10; arg[14] = a11;
+  task( tpool, t0, 15UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_12(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) fd_map_reduce_private_12( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9), (ulong)(a10), (ulong)(a11) )
+
+static inline void
+fd_map_reduce_private_13( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9, ulong a10, ulong a11, ulong a12 ) {
+  ulong arg[16]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9; arg[13] = a10; arg[14] = a11; arg[15] = a12;
+  task( tpool, t0, 16UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_13(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12) fd_map_reduce_private_13( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9), (ulong)(a10), (ulong)(a11), (ulong)(a12) )
+
+static inline void
+fd_map_reduce_private_14( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9, ulong a10, ulong a11, ulong a12, ulong a13 ) {
+  ulong arg[17]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9; arg[13] = a10; arg[14] = a11; arg[15] = a12; arg[16] = a13;
+  task( tpool, t0, 17UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_14(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13) fd_map_reduce_private_14( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9), (ulong)(a10), (ulong)(a11), (ulong)(a12), (ulong)(a13) )
+
+static inline void
+fd_map_reduce_private_15( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9, ulong a10, ulong a11, ulong a12, ulong a13, ulong a14 ) {
+  ulong arg[18]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9; arg[13] = a10; arg[14] = a11; arg[15] = a12; arg[16] = a13; arg[17] = a14;
+  task( tpool, t0, 18UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_15(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14) fd_map_reduce_private_15( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9), (ulong)(a10), (ulong)(a11), (ulong)(a12), (ulong)(a13), (ulong)(a14) )
+
+static inline void
+fd_map_reduce_private_16( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9, ulong a10, ulong a11, ulong a12, ulong a13, ulong a14, ulong a15 ) {
+  ulong arg[19]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9; arg[13] = a10; arg[14] = a11; arg[15] = a12; arg[16] = a13; arg[17] = a14; arg[18] = a15;
+  task( tpool, t0, 19UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_16(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15) fd_map_reduce_private_16( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9), (ulong)(a10), (ulong)(a11), (ulong)(a12), (ulong)(a13), (ulong)(a14), (ulong)(a15) )
+
+static inline void
+fd_map_reduce_private_17( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9, ulong a10, ulong a11, ulong a12, ulong a13, ulong a14, ulong a15, ulong a16 ) {
+  ulong arg[20]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9; arg[13] = a10; arg[14] = a11; arg[15] = a12; arg[16] = a13; arg[17] = a14; arg[18] = a15; arg[19] = a16;
+  task( tpool, t0, 20UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_17(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16) fd_map_reduce_private_17( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9), (ulong)(a10), (ulong)(a11), (ulong)(a12), (ulong)(a13), (ulong)(a14), (ulong)(a15), (ulong)(a16) )
+
+static inline void
+fd_map_reduce_private_18( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9, ulong a10, ulong a11, ulong a12, ulong a13, ulong a14, ulong a15, ulong a16, ulong a17 ) {
+  ulong arg[21]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9; arg[13] = a10; arg[14] = a11; arg[15] = a12; arg[16] = a13; arg[17] = a14; arg[18] = a15; arg[19] = a16; arg[20] = a17;
+  task( tpool, t0, 21UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_18(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17) fd_map_reduce_private_18( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9), (ulong)(a10), (ulong)(a11), (ulong)(a12), (ulong)(a13), (ulong)(a14), (ulong)(a15), (ulong)(a16), (ulong)(a17) )
+
+static inline void
+fd_map_reduce_private_19( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9, ulong a10, ulong a11, ulong a12, ulong a13, ulong a14, ulong a15, ulong a16, ulong a17, ulong a18 ) {
+  ulong arg[22]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9; arg[13] = a10; arg[14] = a11; arg[15] = a12; arg[16] = a13; arg[17] = a14; arg[18] = a15; arg[19] = a16; arg[20] = a17; arg[21] = a18;
+  task( tpool, t0, 22UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_19(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18) fd_map_reduce_private_19( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9), (ulong)(a10), (ulong)(a11), (ulong)(a12), (ulong)(a13), (ulong)(a14), (ulong)(a15), (ulong)(a16), (ulong)(a17), (ulong)(a18) )
+
+static inline void
+fd_map_reduce_private_20( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9, ulong a10, ulong a11, ulong a12, ulong a13, ulong a14, ulong a15, ulong a16, ulong a17, ulong a18, ulong a19 ) {
+  ulong arg[23]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9; arg[13] = a10; arg[14] = a11; arg[15] = a12; arg[16] = a13; arg[17] = a14; arg[18] = a15; arg[19] = a16; arg[20] = a17; arg[21] = a18; arg[22] = a19;
+  task( tpool, t0, 23UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_20(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19) fd_map_reduce_private_20( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9), (ulong)(a10), (ulong)(a11), (ulong)(a12), (ulong)(a13), (ulong)(a14), (ulong)(a15), (ulong)(a16), (ulong)(a17), (ulong)(a18), (ulong)(a19) )
+
+static inline void
+fd_map_reduce_private_21( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9, ulong a10, ulong a11, ulong a12, ulong a13, ulong a14, ulong a15, ulong a16, ulong a17, ulong a18, ulong a19, ulong a20 ) {
+  ulong arg[24]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9; arg[13] = a10; arg[14] = a11; arg[15] = a12; arg[16] = a13; arg[17] = a14; arg[18] = a15; arg[19] = a16; arg[20] = a17; arg[21] = a18; arg[22] = a19; arg[23] = a20;
+  task( tpool, t0, 24UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_21(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20) fd_map_reduce_private_21( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9), (ulong)(a10), (ulong)(a11), (ulong)(a12), (ulong)(a13), (ulong)(a14), (ulong)(a15), (ulong)(a16), (ulong)(a17), (ulong)(a18), (ulong)(a19), (ulong)(a20) )
+
+static inline void
+fd_map_reduce_private_22( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9, ulong a10, ulong a11, ulong a12, ulong a13, ulong a14, ulong a15, ulong a16, ulong a17, ulong a18, ulong a19, ulong a20, ulong a21 ) {
+  ulong arg[25]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9; arg[13] = a10; arg[14] = a11; arg[15] = a12; arg[16] = a13; arg[17] = a14; arg[18] = a15; arg[19] = a16; arg[20] = a17; arg[21] = a18; arg[22] = a19; arg[23] = a20; arg[24] = a21;
+  task( tpool, t0, 25UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_22(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21) fd_map_reduce_private_22( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9), (ulong)(a10), (ulong)(a11), (ulong)(a12), (ulong)(a13), (ulong)(a14), (ulong)(a15), (ulong)(a16), (ulong)(a17), (ulong)(a18), (ulong)(a19), (ulong)(a20), (ulong)(a21) )
+
+static inline void
+fd_map_reduce_private_23( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9, ulong a10, ulong a11, ulong a12, ulong a13, ulong a14, ulong a15, ulong a16, ulong a17, ulong a18, ulong a19, ulong a20, ulong a21, ulong a22 ) {
+  ulong arg[26]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9; arg[13] = a10; arg[14] = a11; arg[15] = a12; arg[16] = a13; arg[17] = a14; arg[18] = a15; arg[19] = a16; arg[20] = a17; arg[21] = a18; arg[22] = a19; arg[23] = a20; arg[24] = a21; arg[25] = a22;
+  task( tpool, t0, 26UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_23(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22) fd_map_reduce_private_23( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9), (ulong)(a10), (ulong)(a11), (ulong)(a12), (ulong)(a13), (ulong)(a14), (ulong)(a15), (ulong)(a16), (ulong)(a17), (ulong)(a18), (ulong)(a19), (ulong)(a20), (ulong)(a21), (ulong)(a22) )
+
+static inline void
+fd_map_reduce_private_24( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9, ulong a10, ulong a11, ulong a12, ulong a13, ulong a14, ulong a15, ulong a16, ulong a17, ulong a18, ulong a19, ulong a20, ulong a21, ulong a22, ulong a23 ) {
+  ulong arg[27]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9; arg[13] = a10; arg[14] = a11; arg[15] = a12; arg[16] = a13; arg[17] = a14; arg[18] = a15; arg[19] = a16; arg[20] = a17; arg[21] = a18; arg[22] = a19; arg[23] = a20; arg[24] = a21; arg[25] = a22; arg[26] = a23;
+  task( tpool, t0, 27UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_24(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23) fd_map_reduce_private_24( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9), (ulong)(a10), (ulong)(a11), (ulong)(a12), (ulong)(a13), (ulong)(a14), (ulong)(a15), (ulong)(a16), (ulong)(a17), (ulong)(a18), (ulong)(a19), (ulong)(a20), (ulong)(a21), (ulong)(a22), (ulong)(a23) )
+
+static inline void
+fd_map_reduce_private_25( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9, ulong a10, ulong a11, ulong a12, ulong a13, ulong a14, ulong a15, ulong a16, ulong a17, ulong a18, ulong a19, ulong a20, ulong a21, ulong a22, ulong a23, ulong a24 ) {
+  ulong arg[28]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9; arg[13] = a10; arg[14] = a11; arg[15] = a12; arg[16] = a13; arg[17] = a14; arg[18] = a15; arg[19] = a16; arg[20] = a17; arg[21] = a18; arg[22] = a19; arg[23] = a20; arg[24] = a21; arg[25] = a22; arg[26] = a23; arg[27] = a24;
+  task( tpool, t0, 28UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_25(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24) fd_map_reduce_private_25( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9), (ulong)(a10), (ulong)(a11), (ulong)(a12), (ulong)(a13), (ulong)(a14), (ulong)(a15), (ulong)(a16), (ulong)(a17), (ulong)(a18), (ulong)(a19), (ulong)(a20), (ulong)(a21), (ulong)(a22), (ulong)(a23), (ulong)(a24) )
+
+static inline void
+fd_map_reduce_private_26( fd_tpool_task_v2_t task, fd_tpool_t * tpool, ulong t0, ulong t1, long i0, long i1, ulong a0, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6, ulong a7, ulong a8, ulong a9, ulong a10, ulong a11, ulong a12, ulong a13, ulong a14, ulong a15, ulong a16, ulong a17, ulong a18, ulong a19, ulong a20, ulong a21, ulong a22, ulong a23, ulong a24, ulong a25 ) {
+  ulong arg[29]; arg[0] = t1; arg[1] = (ulong)i0; arg[2] = (ulong)i1; arg[3] = a0; arg[4] = a1; arg[5] = a2; arg[6] = a3; arg[7] = a4; arg[8] = a5; arg[9] = a6; arg[10] = a7; arg[11] = a8; arg[12] = a9; arg[13] = a10; arg[14] = a11; arg[15] = a12; arg[16] = a13; arg[17] = a14; arg[18] = a15; arg[19] = a16; arg[20] = a17; arg[21] = a18; arg[22] = a19; arg[23] = a20; arg[24] = a21; arg[25] = a22; arg[26] = a23; arg[27] = a24; arg[28] = a25;
+  task( tpool, t0, 29UL, arg );
+}
+
+#define FD_MAP_REDUCE_PRIVATE_26(task,tpool,t0,t1,i0,i1,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25) fd_map_reduce_private_26( (task), (tpool), (t0), (t1), (i0), (i1), (ulong)(a0), (ulong)(a1), (ulong)(a2), (ulong)(a3), (ulong)(a4), (ulong)(a5), (ulong)(a6), (ulong)(a7), (ulong)(a8), (ulong)(a9), (ulong)(a10), (ulong)(a11), (ulong)(a12), (ulong)(a13), (ulong)(a14), (ulong)(a15), (ulong)(a16), (ulong)(a17), (ulong)(a18), (ulong)(a19), (ulong)(a20), (ulong)(a21), (ulong)(a22), (ulong)(a23), (ulong)(a24), (ulong)(a25) )
+
+#define FD_MAP_REDUCE_PRIVATE_F(...) too_few_arguments_passed_to_FD_MAP_REDUCE
+#define FD_MAP_REDUCE(...)          FD_EXPAND_THEN_CONCAT2(FD_MAP_REDUCE_PRIVATE_,FD_VA_ARGS_SELECT(__VA_ARGS__,26,25,24,23,22,21,20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0,F,F,F,F,F))(__VA_ARGS__)

--- a/src/util/tpool/test_tpool.c
+++ b/src/util/tpool/test_tpool.c
@@ -1,20 +1,18 @@
 #include "../fd_util.h"
 
-FD_STATIC_ASSERT( FD_TPOOL_ALIGN            == 128UL, unit_test );
-FD_STATIC_ASSERT( FD_TPOOL_FOOTPRINT(1UL)   == 256UL, unit_test );
-FD_STATIC_ASSERT( FD_TPOOL_FOOTPRINT(1024UL)==8448UL, unit_test );
+FD_STATIC_ASSERT( FD_TPOOL_OPT_SLEEP   == 1UL, unit_test );
+FD_STATIC_ASSERT( FD_TPOOL_TASK_ARG_MAX==43UL, unit_test );
 
-FD_STATIC_ASSERT( FD_TPOOL_WORKER_STATE_BOOT==0, unit_test );
-FD_STATIC_ASSERT( FD_TPOOL_WORKER_STATE_IDLE==1, unit_test );
-FD_STATIC_ASSERT( FD_TPOOL_WORKER_STATE_EXEC==2, unit_test );
-FD_STATIC_ASSERT( FD_TPOOL_WORKER_STATE_HALT==3, unit_test );
+FD_STATIC_ASSERT( FD_TPOOL_ALIGN            == 128UL, unit_test );
+FD_STATIC_ASSERT( FD_TPOOL_FOOTPRINT(1UL)   == 512UL, unit_test );
+FD_STATIC_ASSERT( FD_TPOOL_FOOTPRINT(1024UL)==8704UL, unit_test );
 
 static int
 tile_self_push_main( int     argc,
                      char ** argv ) {
   (void)argc;
   fd_tpool_t * tpool = (fd_tpool_t *)argv;
-  FD_TEST( !fd_tpool_worker_push( tpool, fd_tile_idx(), NULL, 0UL ) ); /* self push */
+  FD_TEST( !fd_tpool_worker_push( tpool, fd_tile_idx() ) ); /* self push */
   return 0;
 }
 
@@ -127,221 +125,184 @@ worker_bench( void * tpool,
 
 static ulong test_t0; static ulong test_t1;
 static  long test_i0; static  long test_i1;
-static ulong test_a0; static ulong test_a1; static ulong test_a2; static ulong test_a3;
-static ulong test_a4; static ulong test_a5; static ulong test_a6;
+static ulong test_a[ FD_TPOOL_TASK_ARG_MAX ];
 
 /* FIXME: test load balance and reduce range correctness too */
 
 static FD_FOR_ALL_PROTO( test_for_all_0 );
 static FD_FOR_ALL_BEGIN( test_for_all_0, 1L ) {
-  FD_TEST( block_thresh==1L  );
+  FD_TEST( block_thresh==1L ); FD_TEST( reduce_align==1UL ); FD_TEST( reduce_sz==0UL ); FD_TEST( reduce_cnt==0L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==0UL     ); FD_TEST( _a1==0UL     ); FD_TEST( _a2==0UL     ); FD_TEST( _a3==0UL     );
-  FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( _a6==0UL     );
+  FD_TEST( arg_cnt==0UL );
 } FD_FOR_ALL_END
 
 static FD_FOR_ALL_PROTO( test_for_all_1 );
 static FD_FOR_ALL_BEGIN( test_for_all_1, 2L ) {
-  FD_TEST( block_thresh==2L  );
+  FD_TEST( block_thresh==2L ); FD_TEST( reduce_align==1UL ); FD_TEST( reduce_sz==0UL ); FD_TEST( reduce_cnt==0L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==0UL     ); FD_TEST( _a2==0UL     ); FD_TEST( _a3==0UL     );
-  FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( _a6==0UL     );
+  FD_TEST( arg_cnt==1UL ); FD_TEST( !memcmp( arg, test_a, arg_cnt*sizeof(ulong) ) );
 } FD_FOR_ALL_END
 
 static FD_FOR_ALL_PROTO( test_for_all_2 );
 static FD_FOR_ALL_BEGIN( test_for_all_2, 3L ) {
-  FD_TEST( block_thresh==3L  );
+  FD_TEST( block_thresh==3L ); FD_TEST( reduce_align==1UL ); FD_TEST( reduce_sz==0UL ); FD_TEST( reduce_cnt==0L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==0UL     ); FD_TEST( _a3==0UL     );
-  FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( _a6==0UL     );
+  FD_TEST( arg_cnt==2UL ); FD_TEST( !memcmp( arg, test_a, arg_cnt*sizeof(ulong) ) );
 } FD_FOR_ALL_END
 
 static FD_FOR_ALL_PROTO( test_for_all_3 );
 static FD_FOR_ALL_BEGIN( test_for_all_3, 4L ) {
-  FD_TEST( block_thresh==4L  );
+  FD_TEST( block_thresh==4L ); FD_TEST( reduce_align==1UL ); FD_TEST( reduce_sz==0UL ); FD_TEST( reduce_cnt==0L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 ); FD_TEST( _a3==0UL     );
-  FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( _a6==0UL     );
+  FD_TEST( arg_cnt==3UL ); FD_TEST( !memcmp( arg, test_a, arg_cnt*sizeof(ulong) ) );
 } FD_FOR_ALL_END
 
 static FD_FOR_ALL_PROTO( test_for_all_4 );
 static FD_FOR_ALL_BEGIN( test_for_all_4, 5L ) {
-  FD_TEST( block_thresh==5L  );
+  FD_TEST( block_thresh==5L ); FD_TEST( reduce_align==1UL ); FD_TEST( reduce_sz==0UL ); FD_TEST( reduce_cnt==0L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 ); FD_TEST( _a3==test_a3 );
-  FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( _a6==0UL     );
+  FD_TEST( arg_cnt==4UL ); FD_TEST( !memcmp( arg, test_a, arg_cnt*sizeof(ulong) ) );
 } FD_FOR_ALL_END
 
 static FD_FOR_ALL_PROTO( test_for_all_5 );
 static FD_FOR_ALL_BEGIN( test_for_all_5, 6L ) {
-  FD_TEST( block_thresh==6L  );
+  FD_TEST( block_thresh==6L ); FD_TEST( reduce_align==1UL ); FD_TEST( reduce_sz==0UL ); FD_TEST( reduce_cnt==0L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 ); FD_TEST( _a3==test_a3 );
-  FD_TEST( _a4==test_a4 ); FD_TEST( _a5==0UL     ); FD_TEST( _a6==0UL     );
+  FD_TEST( arg_cnt==5UL ); FD_TEST( !memcmp( arg, test_a, arg_cnt*sizeof(ulong) ) );
 } FD_FOR_ALL_END
 
 static FD_FOR_ALL_PROTO( test_for_all_6 );
 static FD_FOR_ALL_BEGIN( test_for_all_6, 7L ) {
-  FD_TEST( block_thresh==7L  );
+  FD_TEST( block_thresh==7L ); FD_TEST( reduce_align==1UL ); FD_TEST( reduce_sz==0UL ); FD_TEST( reduce_cnt==0L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 ); FD_TEST( _a3==test_a3 );
-  FD_TEST( _a4==test_a4 ); FD_TEST( _a5==test_a5 ); FD_TEST( _a6==0UL     );
-} FD_FOR_ALL_END
-
-static FD_FOR_ALL_PROTO( test_for_all_7 );
-static FD_FOR_ALL_BEGIN( test_for_all_7, 8L ) {
-  FD_TEST( block_thresh==8L  );
-  FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
-  FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 ); FD_TEST( _a3==test_a3 );
-  FD_TEST( _a4==test_a4 ); FD_TEST( _a5==test_a5 ); FD_TEST( _a6==test_a6 );
-} FD_FOR_ALL_END
-
-#define TEST_SPAD_ALIGN     (4096UL)
-#define TEST_SPAD_FOOTPRINT (4096UL)
-#define TEST_SPAD_DEPTH     (128UL)
-#define TEST_SPAD_SZ        (TEST_SPAD_FOOTPRINT - TEST_SPAD_DEPTH*sizeof(ulong))
-
-struct __attribute__((aligned(TEST_SPAD_ALIGN))) {
-  ulong fmem[ TEST_SPAD_DEPTH ];
-  uchar smem[ TEST_SPAD_SZ    ];
-} test_spad[ FD_TILE_MAX ];
-
-static FD_FOR_ALL_BEGIN( test_scratch_attach, 1L ) {
-  fd_scratch_attach( test_spad[tpool_t0].smem, test_spad[tpool_t0].fmem, TEST_SPAD_SZ, TEST_SPAD_DEPTH );
-} FD_FOR_ALL_END
-
-static FD_FOR_ALL_BEGIN( test_scratch_detach, 1L ) {
-  fd_scratch_detach( NULL );
+  FD_TEST( arg_cnt==6UL ); FD_TEST( !memcmp( arg, test_a, arg_cnt*sizeof(ulong) ) );
 } FD_FOR_ALL_END
 
 static FD_MAP_REDUCE_PROTO( test_map_reduce_0 );
-static FD_MAP_REDUCE_BEGIN( test_map_reduce_0, 1L, 2UL, 4UL ) {
-  FD_TEST( block_thresh==1L ); FD_TEST( reduce_align==2UL ); FD_TEST( reduce_footprint==4UL );
+static FD_MAP_REDUCE_BEGIN( test_map_reduce_0, 1L, 2UL, 4UL, 0L ) {
+  FD_TEST( block_thresh==1L ); FD_TEST( reduce_align==2UL ); FD_TEST( reduce_sz==4UL ); FD_TEST( reduce_cnt==0L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==0UL     ); FD_TEST( _a1==0UL     ); FD_TEST( _a2==0UL     );
-  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 2UL ) );
+  FD_TEST( arg_cnt==0UL );
 } FD_MAP_END {
-  FD_TEST( block_thresh==1L ); FD_TEST( reduce_align==2UL ); FD_TEST( reduce_footprint==4UL );
+  FD_TEST( block_thresh==1L ); FD_TEST( reduce_align==2UL ); FD_TEST( reduce_sz==4UL ); FD_TEST( reduce_cnt==0L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_ts) & (tpool_ts< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_is) & (block_is<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==0UL     ); FD_TEST( _a1==0UL     ); FD_TEST( _a2==0UL     );
-  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 2UL ) );
-  FD_TEST( _r0!=_r1 ); FD_TEST( fd_ulong_is_aligned( _r1, 2UL ) );
+  FD_TEST( arg_cnt==0UL );
+  FD_TEST( !_r1 );
 } FD_REDUCE_END
 
 static FD_MAP_REDUCE_PROTO( test_map_reduce_1 );
-static FD_MAP_REDUCE_BEGIN( test_map_reduce_1, 2L, 4UL, 8UL ) {
-  FD_TEST( block_thresh==2L ); FD_TEST( reduce_align==4UL ); FD_TEST( reduce_footprint==8UL );
+static FD_MAP_REDUCE_BEGIN( test_map_reduce_1, 2L, 4UL, 8UL, 1L ) {
+  FD_TEST( block_thresh==2L ); FD_TEST( reduce_align==4UL ); FD_TEST( reduce_sz==8UL ); FD_TEST( reduce_cnt==1L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==0UL     ); FD_TEST( _a2==0UL     );
-  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 4UL ) );
+  FD_TEST( arg_cnt==1UL ); FD_TEST( fd_ulong_is_aligned( arg[0], reduce_align ) );
 } FD_MAP_END {
-  FD_TEST( block_thresh==2L ); FD_TEST( reduce_align==4UL ); FD_TEST( reduce_footprint==8UL );
+  FD_TEST( block_thresh==2L ); FD_TEST( reduce_align==4UL ); FD_TEST( reduce_sz==8UL ); FD_TEST( reduce_cnt==1L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_ts) & (tpool_ts< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_is) & (block_is<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==0UL     ); FD_TEST( _a2==0UL     );
-  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 4UL ) );
-  FD_TEST( _r0!=_r1 ); FD_TEST( fd_ulong_is_aligned( _r1, 4UL ) );
+  FD_TEST( arg_cnt==1UL ); FD_TEST( fd_ulong_is_aligned( arg[0], reduce_align ) );
+  FD_TEST( arg[0]!=_r1 );  FD_TEST( fd_ulong_is_aligned( _r1,    reduce_align ) );
 } FD_REDUCE_END
 
 static FD_MAP_REDUCE_PROTO( test_map_reduce_2 );
-static FD_MAP_REDUCE_BEGIN( test_map_reduce_2, 3L, 8UL, 16UL ) {
-  FD_TEST( block_thresh==3L ); FD_TEST( reduce_align==8UL ); FD_TEST( reduce_footprint==16UL );
+static FD_MAP_REDUCE_BEGIN( test_map_reduce_2, 3L, 8UL, 16UL, 2L ) {
+  FD_TEST( block_thresh==3L ); FD_TEST( reduce_align==8UL ); FD_TEST( reduce_sz==16UL ); FD_TEST( reduce_cnt==2L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==0UL     );
-  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 8UL ) );
+  FD_TEST( arg_cnt==2UL ); FD_TEST( fd_ulong_is_aligned( arg[0], reduce_align ) );
+  FD_TEST( !memcmp( arg+1, test_a+1, (arg_cnt-1UL)*sizeof(ulong) ) );
 } FD_MAP_END {
-  FD_TEST( block_thresh==3L ); FD_TEST( reduce_align==8UL ); FD_TEST( reduce_footprint==16UL );
+  FD_TEST( block_thresh==3L ); FD_TEST( reduce_align==8UL ); FD_TEST( reduce_sz==16UL ); FD_TEST( reduce_cnt==2L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_ts) & (tpool_ts< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_is) & (block_is<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==0UL     );
-  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 8UL ) );
-  FD_TEST( _r0!=_r1 ); FD_TEST( fd_ulong_is_aligned( _r1, 8UL ) );
+  FD_TEST( arg_cnt==2UL ); FD_TEST( fd_ulong_is_aligned( arg[0], reduce_align ) );
+  FD_TEST( arg[0]!=_r1 );  FD_TEST( fd_ulong_is_aligned( _r1,    reduce_align ) );
+  FD_TEST( !memcmp( arg+1, test_a+1, (arg_cnt-1UL)*sizeof(ulong) ) );
 } FD_REDUCE_END
 
 static FD_MAP_REDUCE_PROTO( test_map_reduce_3 );
-static FD_MAP_REDUCE_BEGIN( test_map_reduce_3, 4L, 16UL, 32UL ) {
-  FD_TEST( block_thresh==4L ); FD_TEST( reduce_align==16UL ); FD_TEST( reduce_footprint==32UL );
+static FD_MAP_REDUCE_BEGIN( test_map_reduce_3, 4L, 16UL, 32UL, 3L ) {
+  FD_TEST( block_thresh==4L ); FD_TEST( reduce_align==16UL ); FD_TEST( reduce_sz==32UL ); FD_TEST( reduce_cnt==3L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 );
-  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 16UL ) );
+  FD_TEST( arg_cnt==3UL ); FD_TEST( fd_ulong_is_aligned( arg[0], reduce_align ) );
+  FD_TEST( !memcmp( arg+1, test_a+1, (arg_cnt-1UL)*sizeof(ulong) ) );
 } FD_MAP_END {
-  FD_TEST( block_thresh==4L ); FD_TEST( reduce_align==16UL ); FD_TEST( reduce_footprint==32UL );
+  FD_TEST( block_thresh==4L ); FD_TEST( reduce_align==16UL ); FD_TEST( reduce_sz==32UL ); FD_TEST( reduce_cnt==3L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_ts) & (tpool_ts< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_is) & (block_is<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 );
-  FD_TEST( _a3==0UL     ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 16UL ) );
-  FD_TEST( _r0!=_r1 ); FD_TEST( fd_ulong_is_aligned( _r1, 16UL ) );
+  FD_TEST( arg_cnt==3UL ); FD_TEST( fd_ulong_is_aligned( arg[0], reduce_align ) );
+  FD_TEST( arg[0]!=_r1 );  FD_TEST( fd_ulong_is_aligned( _r1,    reduce_align ) );
+  FD_TEST( !memcmp( arg+1, test_a+1, (arg_cnt-1UL)*sizeof(ulong) ) );
 } FD_REDUCE_END
 
 static FD_MAP_REDUCE_PROTO( test_map_reduce_4 );
-static FD_MAP_REDUCE_BEGIN( test_map_reduce_4, 5L, 32UL, 64UL ) {
-  FD_TEST( block_thresh==5L ); FD_TEST( reduce_align==32UL ); FD_TEST( reduce_footprint==64UL );
+static FD_MAP_REDUCE_BEGIN( test_map_reduce_4, 5L, 32UL, 64UL, 4L ) {
+  FD_TEST( block_thresh==5L ); FD_TEST( reduce_align==32UL ); FD_TEST( reduce_sz==64UL ); FD_TEST( reduce_cnt==4L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 );
-  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 32UL ) );
+  FD_TEST( arg_cnt==4UL ); FD_TEST( fd_ulong_is_aligned( arg[0], reduce_align ) );
+  FD_TEST( !memcmp( arg+1, test_a+1, (arg_cnt-1UL)*sizeof(ulong) ) );
 } FD_MAP_END {
-  FD_TEST( block_thresh==5L ); FD_TEST( reduce_align==32UL ); FD_TEST( reduce_footprint==64UL );
+  FD_TEST( block_thresh==5L ); FD_TEST( reduce_align==32UL ); FD_TEST( reduce_sz==64UL ); FD_TEST( reduce_cnt==4L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_ts) & (tpool_ts< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_is) & (block_is<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 );
-  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==0UL     ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 32UL ) );
-  FD_TEST( _r0!=_r1 ); FD_TEST( fd_ulong_is_aligned( _r1, 32UL ) );
+  FD_TEST( arg_cnt==4UL ); FD_TEST( fd_ulong_is_aligned( arg[0], reduce_align ) );
+  FD_TEST( arg[0]!=_r1 );  FD_TEST( fd_ulong_is_aligned( _r1,    reduce_align ) );
+  FD_TEST( !memcmp( arg+1, test_a+1, (arg_cnt-1UL)*sizeof(ulong) ) );
 } FD_REDUCE_END
 
 static FD_MAP_REDUCE_PROTO( test_map_reduce_5 );
-static FD_MAP_REDUCE_BEGIN( test_map_reduce_5, 6L, 64UL, 128UL ) {
-  FD_TEST( block_thresh==6L ); FD_TEST( reduce_align==64UL ); FD_TEST( reduce_footprint==128UL );
+static FD_MAP_REDUCE_BEGIN( test_map_reduce_5, 6L, 64UL, 128UL, 5L ) {
+  FD_TEST( block_thresh==6L ); FD_TEST( reduce_align==64UL ); FD_TEST( reduce_sz==128UL ); FD_TEST( reduce_cnt==5L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 );
-  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==test_a4 ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 64UL ) );
+  FD_TEST( arg_cnt==5UL ); FD_TEST( fd_ulong_is_aligned( arg[0], reduce_align ) );
+  FD_TEST( !memcmp( arg+1, test_a+1, (arg_cnt-1UL)*sizeof(ulong) ) );
 } FD_MAP_END {
-  FD_TEST( block_thresh==6L ); FD_TEST( reduce_align==64UL ); FD_TEST( reduce_footprint==128UL );
+  FD_TEST( block_thresh==6L ); FD_TEST( reduce_align==64UL ); FD_TEST( reduce_sz==128UL ); FD_TEST( reduce_cnt==5L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_ts) & (tpool_ts< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_is) & (block_is<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 );
-  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==test_a4 ); FD_TEST( _a5==0UL     ); FD_TEST( fd_ulong_is_aligned( _r0, 64UL ) );
-  FD_TEST( _r0!=_r1 ); FD_TEST( fd_ulong_is_aligned( _r1, 64UL ) );
+  FD_TEST( arg_cnt==5UL ); FD_TEST( fd_ulong_is_aligned( arg[0], reduce_align ) );
+  FD_TEST( arg[0]!=_r1 );  FD_TEST( fd_ulong_is_aligned( _r1,    reduce_align ) );
+  FD_TEST( !memcmp( arg+1, test_a+1, (arg_cnt-1UL)*sizeof(ulong) ) );
 } FD_REDUCE_END
 
 static FD_MAP_REDUCE_PROTO( test_map_reduce_6 );
-static FD_MAP_REDUCE_BEGIN( test_map_reduce_6, 7L, 128UL, 256UL ) {
-  FD_TEST( block_thresh==7L ); FD_TEST( reduce_align==128UL ); FD_TEST( reduce_footprint==256UL );
+static FD_MAP_REDUCE_BEGIN( test_map_reduce_6, 7L, 128UL, 256UL, 6L ) {
+  FD_TEST( block_thresh==7L ); FD_TEST( reduce_align==128UL ); FD_TEST( reduce_sz==256UL ); FD_TEST( reduce_cnt==6L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 );
-  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==test_a4 ); FD_TEST( _a5==test_a5 ); FD_TEST( fd_ulong_is_aligned( _r0, 128UL ) );
+  FD_TEST( arg_cnt==6UL ); FD_TEST( fd_ulong_is_aligned( arg[0], reduce_align ) );
+  FD_TEST( !memcmp( arg+1, test_a+1, (arg_cnt-1UL)*sizeof(ulong) ) );
 } FD_MAP_END {
-  FD_TEST( block_thresh==7L ); FD_TEST( reduce_align==128UL ); FD_TEST( reduce_footprint==256UL );
+  FD_TEST( block_thresh==7L ); FD_TEST( reduce_align==128UL ); FD_TEST( reduce_sz==256UL ); FD_TEST( reduce_cnt==6L );
   FD_TEST( (test_t0<=tpool_t0) & (tpool_t0< tpool_ts) & (tpool_ts< tpool_t1) & (tpool_t1<=test_t1) );
   FD_TEST( (test_i0<=block_i0) & (block_i0<=block_is) & (block_is<=block_i1) & (block_i1<=test_i1) & (block_cnt==(block_i1-block_i0)) );
-  FD_TEST( _a0==test_a0 ); FD_TEST( _a1==test_a1 ); FD_TEST( _a2==test_a2 );
-  FD_TEST( _a3==test_a3 ); FD_TEST( _a4==test_a4 ); FD_TEST( _a5==test_a5 ); FD_TEST( fd_ulong_is_aligned( _r0, 128UL ) );
-  FD_TEST( _r0!=_r1 ); FD_TEST( fd_ulong_is_aligned( _r1, 128UL ) );
+  FD_TEST( arg_cnt==6UL ); FD_TEST( fd_ulong_is_aligned( arg[0], reduce_align ) );
+  FD_TEST( arg[0]!=_r1 );  FD_TEST( fd_ulong_is_aligned( _r1,    reduce_align ) );
+  FD_TEST( !memcmp( arg+1, test_a+1, (arg_cnt-1UL)*sizeof(ulong) ) );
 } FD_REDUCE_END
 
 static FD_FOR_ALL_BEGIN( bench_for_all, 1L ) {} FD_FOR_ALL_END
 
-static FD_MAP_REDUCE_BEGIN( bench_map_reduce, 1L, 128UL, 128UL ) {} FD_MAP_END {} FD_REDUCE_END
+static FD_MAP_REDUCE_BEGIN( bench_map_reduce, 1L, 0UL, 8UL, 1L ) {} FD_MAP_END {} FD_REDUCE_END
 
 int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
+
+  ulong opt = fd_env_strip_cmdline_ulong( &argc, &argv, "--opt", NULL, 0UL );
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
@@ -381,53 +342,46 @@ main( int     argc,
 
   uchar tpool_mem[ FD_TPOOL_FOOTPRINT(FD_TILE_MAX) ] __attribute__((aligned(FD_TPOOL_ALIGN)));
 
-  FD_LOG_NOTICE(( "Testing init and fini" ));
+  FD_LOG_NOTICE(( "Testing init and fini (--opt %lx)", opt ));
 
   fd_tpool_t * tpool;
-  FD_TEST( !fd_tpool_init( NULL,        1UL             ) ); /* NULL mem */
-  FD_TEST( !fd_tpool_init( (void *)1UL, 1UL             ) ); /* misaligned mem */
-  FD_TEST( !fd_tpool_init( tpool_mem,   0UL             ) ); /* bad worker_max */
-  FD_TEST( !fd_tpool_init( tpool_mem,   FD_TILE_MAX+1UL ) ); /* bad worker_max */
+  FD_TEST( !fd_tpool_init( NULL,        1UL,             opt ) ); /* NULL mem */
+  FD_TEST( !fd_tpool_init( (void *)1UL, 1UL,             opt ) ); /* misaligned mem */
+  FD_TEST( !fd_tpool_init( tpool_mem,   0UL,             opt ) ); /* bad worker_max */
+  FD_TEST( !fd_tpool_init( tpool_mem,   FD_TILE_MAX+1UL, opt ) ); /* bad worker_max */
   FD_TEST( !fd_tpool_fini( NULL ) );                         /* NULL tpool */
   for( ulong worker_max=1UL; worker_max<=FD_TILE_MAX; worker_max++ ) {
-    tpool = fd_tpool_init( tpool_mem, worker_max ); FD_TEST( tpool );
-    FD_TEST( fd_tpool_worker_cnt       ( tpool      )==1UL                        );
-    FD_TEST( fd_tpool_worker_max       ( tpool      )==worker_max                 );
-    FD_TEST( fd_tpool_worker_tile_idx  ( tpool, 0UL )==0UL                        );
-    FD_TEST( fd_tpool_worker_scratch   ( tpool, 0UL )==NULL                       );
-    FD_TEST( fd_tpool_worker_scratch_sz( tpool, 0UL )==0UL                        );
-    FD_TEST( fd_tpool_worker_state     ( tpool, 0UL )==FD_TPOOL_WORKER_STATE_EXEC );
+    tpool = fd_tpool_init( tpool_mem, worker_max, opt ); FD_TEST( tpool );
+    FD_TEST( fd_tpool_opt              ( tpool      )==opt        );
+    FD_TEST( fd_tpool_worker_cnt       ( tpool      )==1UL        );
+    FD_TEST( fd_tpool_worker_max       ( tpool      )==worker_max );
+    FD_TEST( fd_tpool_worker_tile_idx  ( tpool, 0UL )==0UL        );
+    FD_TEST( fd_tpool_worker_idle      ( tpool, 0UL )==0          );
     FD_TEST( fd_tpool_fini( tpool )==(void *)tpool_mem );
   }
 
   FD_LOG_NOTICE(( "Testing push" ));
 
   ulong tile_cnt = fd_tile_cnt();
-  tpool = fd_tpool_init( tpool_mem, tile_cnt ); FD_TEST( tpool );
+  tpool = fd_tpool_init( tpool_mem, tile_cnt, opt ); FD_TEST( tpool );
 
-  FD_TEST( !fd_tpool_worker_push( NULL,  1UL,      NULL, 0UL ) ); /* NULL tpool */
-  FD_TEST( !fd_tpool_worker_push( tpool, 0UL,      NULL, 0UL ) ); /* cant push to tile idx 0 */
-  FD_TEST( !fd_tpool_worker_push( tpool, tile_cnt, NULL, 0UL ) ); /* cant push non-existent tile */
-  if( tile_cnt>1L ) {
-    FD_TEST( !fd_tpool_worker_push( tpool, 1UL, NULL,        1UL ) ); /* NULL scratch */
-    FD_TEST( !fd_tpool_worker_push( tpool, 1UL, (void *)1UL, 1UL ) ); /* misaligned scratch */
-  }
+  FD_TEST( !fd_tpool_worker_push( NULL,  1UL      ) ); /* NULL tpool */
+  FD_TEST( !fd_tpool_worker_push( tpool, 0UL      ) ); /* cant push to tile idx 0 */
+  FD_TEST( !fd_tpool_worker_push( tpool, tile_cnt ) ); /* cant push non-existent tile */
   for( ulong worker_idx=1UL; worker_idx<tile_cnt; worker_idx++ ) {
-    ulong tile_idx = tile_cnt-worker_idx;
-    FD_TEST( fd_tpool_worker_push( tpool, tile_idx, (void *)tile_idx, 0UL )==tpool );
-    FD_TEST( fd_tpool_worker_cnt       ( tpool )            ==worker_idx+1UL             );
-    FD_TEST( fd_tpool_worker_max       ( tpool )            ==tile_cnt                   );
-    FD_TEST( fd_tpool_worker_tile_idx  ( tpool, worker_idx )==tile_idx                   );
-    FD_TEST( fd_tpool_worker_scratch   ( tpool, worker_idx )==(void *)tile_idx           );
-    FD_TEST( fd_tpool_worker_scratch_sz( tpool, worker_idx )==0UL                        );
-    FD_TEST( fd_tpool_worker_state     ( tpool, worker_idx )==FD_TPOOL_WORKER_STATE_IDLE );
-    FD_TEST( !fd_tpool_worker_push( tpool, tile_idx, NULL, 0UL ) ); /* Already added and/or too many */
+    ulong tile_idx = tile_cnt - worker_idx;
+    FD_TEST( fd_tpool_worker_push( tpool, tile_idx )==tpool );
+    FD_TEST( fd_tpool_worker_cnt     ( tpool )            ==worker_idx+1UL   );
+    FD_TEST( fd_tpool_worker_max     ( tpool )            ==tile_cnt         );
+    FD_TEST( fd_tpool_worker_tile_idx( tpool, worker_idx )==tile_idx         );
+    FD_TEST( fd_tpool_worker_idle    ( tpool, worker_idx )==1                );
+    FD_TEST( !fd_tpool_worker_push( tpool, tile_idx ) ); /* Already added and/or too many */
   }
 
   FD_TEST( fd_tpool_fini( tpool )==(void *)tpool_mem );
 
   if( tile_cnt>1L ) {
-    tpool = fd_tpool_init( tpool_mem, 2UL ); FD_TEST( tpool );
+    tpool = fd_tpool_init( tpool_mem, 2UL, opt ); FD_TEST( tpool );
 
     fd_tile_exec_delete( fd_tile_exec_new( 1UL, tile_self_push_main, 0, (char **)tpool ), NULL );
 
@@ -435,7 +389,7 @@ main( int     argc,
     FD_COMPILER_MFENCE(); /* FIXME: give fd_tile_exec_new stronger fencing semantics */
     fd_tile_exec_t * exec = fd_tile_exec_new( 1UL, tile_spin_main, 0, &spin_done ); FD_TEST( exec );
 
-    FD_TEST( !fd_tpool_worker_push( tpool, 1UL, NULL, 0UL ) ); /* Already in use */
+    FD_TEST( !fd_tpool_worker_push( tpool, 1UL ) ); /* Already in use */
 
     spin_done = (char *)1UL;
     fd_tile_exec_delete( exec, NULL );
@@ -445,21 +399,21 @@ main( int     argc,
 
   FD_LOG_NOTICE(( "Testing pop, exec and wait" ));
 
-  tpool = fd_tpool_init( tpool_mem, tile_cnt ); FD_TEST( tpool );
+  tpool = fd_tpool_init( tpool_mem, tile_cnt, opt ); FD_TEST( tpool );
 
   FD_TEST( !fd_tpool_worker_pop( NULL  ) ); /* NULL tpool */
   FD_TEST( !fd_tpool_worker_pop( tpool ) ); /* no workers */
-  for( ulong tile_idx=1UL; tile_idx<tile_cnt; tile_idx++ ) FD_TEST( fd_tpool_worker_push( tpool, tile_idx, NULL, 0UL )==tpool );
+  for( ulong tile_idx=1UL; tile_idx<tile_cnt; tile_idx++ ) FD_TEST( fd_tpool_worker_push( tpool, tile_idx )==tpool );
 
   if( tile_cnt>1L ) {
     ulong worker_idx = tile_cnt-1UL;
     ulong spin_done = 0UL;
     fd_tpool_exec( tpool,worker_idx, worker_spin, &spin_done, 1UL,2UL,(void *)3UL,(void *)4UL,5UL,6UL,7UL,8UL,9UL,10UL,11UL );
-    FD_TEST( fd_tpool_worker_state( tpool, worker_idx )==FD_TPOOL_WORKER_STATE_EXEC );
+    FD_TEST( !fd_tpool_worker_idle( tpool, worker_idx ) );
     FD_TEST( !fd_tpool_worker_pop( tpool ) ); /* already in use */
     spin_done = 1UL;
     fd_tpool_wait( tpool,worker_idx );
-    FD_TEST( fd_tpool_worker_state( tpool, worker_idx )==FD_TPOOL_WORKER_STATE_IDLE );
+    FD_TEST( fd_tpool_worker_idle( tpool, worker_idx ) );
   }
 
   for( ulong worker_idx=tile_cnt-1UL; worker_idx; worker_idx-- ) {
@@ -472,8 +426,8 @@ main( int     argc,
 
   FD_LOG_NOTICE(( "Testing fd_tpool_exec_all_raw" ));
 
-  tpool = fd_tpool_init( tpool_mem, tile_cnt ); FD_TEST( tpool );
-  for( ulong tile_idx=1UL; tile_idx<tile_cnt; tile_idx++ ) FD_TEST( fd_tpool_worker_push( tpool, tile_idx, NULL, 0UL )==tpool );
+  tpool = fd_tpool_init( tpool_mem, tile_cnt, opt ); FD_TEST( tpool );
+  for( ulong tile_idx=1UL; tile_idx<tile_cnt; tile_idx++ ) FD_TEST( fd_tpool_worker_push( tpool, tile_idx )==tpool );
 
   for( ulong rem=100000UL; rem; rem-- ) {
     ulong  tmp0       = fd_rng_ulong_roll( rng, tile_cnt );
@@ -642,53 +596,38 @@ main( int     argc,
     test_t1 = fd_rng_ulong_roll( rng, tile_cnt ); fd_swap_if( test_t1<test_t0, test_t0, test_t1 ); test_t1++;
     test_i0 = (long)fd_rng_int( rng );
     test_i1 = (long)fd_rng_int( rng ); fd_swap_if( test_i1<test_i0, test_i0, test_i1 );
-    test_a0 = fd_rng_ulong( rng ); test_a1 = fd_rng_ulong( rng ); test_a2 = fd_rng_ulong( rng ); test_a3 = fd_rng_ulong( rng );
-    test_a4 = fd_rng_ulong( rng ); test_a5 = fd_rng_ulong( rng ); test_a6 = fd_rng_ulong( rng );
+    for( ulong i=0UL; i<7UL; i++ ) test_a[i] = fd_rng_ulong( rng );
     FD_FOR_ALL( test_for_all_0, tpool,test_t0,test_t1, test_i0,test_i1 );
-    FD_FOR_ALL( test_for_all_1, tpool,test_t0,test_t1, test_i0,test_i1, test_a0 );
-    FD_FOR_ALL( test_for_all_2, tpool,test_t0,test_t1, test_i0,test_i1, test_a0,test_a1 );
-    FD_FOR_ALL( test_for_all_3, tpool,test_t0,test_t1, test_i0,test_i1, test_a0,test_a1,test_a2 );
-    FD_FOR_ALL( test_for_all_4, tpool,test_t0,test_t1, test_i0,test_i1, test_a0,test_a1,test_a2,test_a3 );
-    FD_FOR_ALL( test_for_all_5, tpool,test_t0,test_t1, test_i0,test_i1, test_a0,test_a1,test_a2,test_a3,test_a4 );
-    FD_FOR_ALL( test_for_all_6, tpool,test_t0,test_t1, test_i0,test_i1, test_a0,test_a1,test_a2,test_a3,test_a4,test_a5 );
-    FD_FOR_ALL( test_for_all_7, tpool,test_t0,test_t1, test_i0,test_i1, test_a0,test_a1,test_a2,test_a3,test_a4,test_a5,test_a6 );
+    FD_FOR_ALL( test_for_all_1, tpool,test_t0,test_t1, test_i0,test_i1, test_a[0] );
+    FD_FOR_ALL( test_for_all_2, tpool,test_t0,test_t1, test_i0,test_i1, test_a[0], test_a[1] );
+    FD_FOR_ALL( test_for_all_3, tpool,test_t0,test_t1, test_i0,test_i1, test_a[0], test_a[1], test_a[2] );
+    FD_FOR_ALL( test_for_all_4, tpool,test_t0,test_t1, test_i0,test_i1, test_a[0], test_a[1], test_a[2], test_a[3] );
+    FD_FOR_ALL( test_for_all_5, tpool,test_t0,test_t1, test_i0,test_i1, test_a[0], test_a[1], test_a[2], test_a[3], test_a[4] );
+    FD_FOR_ALL( test_for_all_6, tpool,test_t0,test_t1, test_i0,test_i1, test_a[0], test_a[1], test_a[2], test_a[3], test_a[4], test_a[5] );
   }
 
   FD_LOG_NOTICE(( "Testing FD_MAP_REDUCE" ));
-
-  FD_FOR_ALL( test_scratch_attach, tpool,0UL,tile_cnt, 0L,(long)tile_cnt );
 
   for( ulong rem=100000UL; rem; rem-- ) {
     test_t0 = fd_rng_ulong_roll( rng, tile_cnt );
     test_t1 = fd_rng_ulong_roll( rng, tile_cnt ); fd_swap_if( test_t1<test_t0, test_t0, test_t1 ); test_t1++;
     test_i0 = (long)fd_rng_int( rng );
     test_i1 = (long)fd_rng_int( rng ); fd_swap_if( test_i1<test_i0, test_i0, test_i1 );
-    test_a0 = fd_rng_ulong( rng ); test_a1 = fd_rng_ulong( rng ); test_a2 = fd_rng_ulong( rng ); test_a3 = fd_rng_ulong( rng );
-    test_a4 = fd_rng_ulong( rng ); test_a5 = fd_rng_ulong( rng ); test_a6 = fd_rng_ulong( rng ) & ~127UL;
-    FD_MAP_REDUCE( test_map_reduce_0, tpool,test_t0,test_t1, test_i0,test_i1,                                                  test_a6 );
-    FD_MAP_REDUCE( test_map_reduce_1, tpool,test_t0,test_t1, test_i0,test_i1, test_a0,                                         test_a6 );
-    FD_MAP_REDUCE( test_map_reduce_2, tpool,test_t0,test_t1, test_i0,test_i1, test_a0,test_a1,                                 test_a6 );
-    FD_MAP_REDUCE( test_map_reduce_3, tpool,test_t0,test_t1, test_i0,test_i1, test_a0,test_a1,test_a2,                         test_a6 );
-    FD_MAP_REDUCE( test_map_reduce_4, tpool,test_t0,test_t1, test_i0,test_i1, test_a0,test_a1,test_a2,test_a3,                 test_a6 );
-    FD_MAP_REDUCE( test_map_reduce_5, tpool,test_t0,test_t1, test_i0,test_i1, test_a0,test_a1,test_a2,test_a3,test_a4,         test_a6 );
-    FD_MAP_REDUCE( test_map_reduce_6, tpool,test_t0,test_t1, test_i0,test_i1, test_a0,test_a1,test_a2,test_a3,test_a4,test_a5, test_a6 );
+    for( ulong i=0UL; i<7UL; i++ ) test_a[i] = fd_rng_ulong( rng );
+    test_a[0] &= ~127UL;
+    FD_FOR_ALL( test_map_reduce_0, tpool,test_t0,test_t1, test_i0,test_i1 );
+    FD_FOR_ALL( test_map_reduce_1, tpool,test_t0,test_t1, test_i0,test_i1, test_a[0] );
+    FD_FOR_ALL( test_map_reduce_2, tpool,test_t0,test_t1, test_i0,test_i1, test_a[0], test_a[1] );
+    FD_FOR_ALL( test_map_reduce_3, tpool,test_t0,test_t1, test_i0,test_i1, test_a[0], test_a[1], test_a[2] );
+    FD_FOR_ALL( test_map_reduce_4, tpool,test_t0,test_t1, test_i0,test_i1, test_a[0], test_a[1], test_a[2], test_a[3] );
+    FD_FOR_ALL( test_map_reduce_5, tpool,test_t0,test_t1, test_i0,test_i1, test_a[0], test_a[1], test_a[2], test_a[3], test_a[4] );
+    FD_FOR_ALL( test_map_reduce_6, tpool,test_t0,test_t1, test_i0,test_i1, test_a[0], test_a[1], test_a[2], test_a[3], test_a[4], test_a[5] );
   }
-
-  FD_FOR_ALL( test_scratch_detach, tpool,0UL,tile_cnt, 0L,(long)tile_cnt );
 
   FD_TEST( fd_tpool_fini( tpool )==(void *)tpool_mem );
 
-  FD_LOG_NOTICE(( "Testing fd_tpool_worker_state_cstr" ));
-
-  char const * cstr;
-  cstr = fd_tpool_worker_state_cstr( FD_TPOOL_WORKER_STATE_BOOT ); FD_TEST( cstr && !strcmp( cstr, "boot"    ) );
-  cstr = fd_tpool_worker_state_cstr( FD_TPOOL_WORKER_STATE_IDLE ); FD_TEST( cstr && !strcmp( cstr, "idle"    ) );
-  cstr = fd_tpool_worker_state_cstr( FD_TPOOL_WORKER_STATE_EXEC ); FD_TEST( cstr && !strcmp( cstr, "exec"    ) );
-  cstr = fd_tpool_worker_state_cstr( FD_TPOOL_WORKER_STATE_HALT ); FD_TEST( cstr && !strcmp( cstr, "halt"    ) );
-  cstr = fd_tpool_worker_state_cstr( -1 );                         FD_TEST( cstr && !strcmp( cstr, "unknown" ) );
-
-  tpool = fd_tpool_init( tpool_mem, tile_cnt ); FD_TEST( tpool );
-  for( ulong tile_idx=1UL; tile_idx<tile_cnt; tile_idx++ ) FD_TEST( fd_tpool_worker_push( tpool, tile_idx, NULL, 0UL )==tpool );
+  tpool = fd_tpool_init( tpool_mem, tile_cnt, opt ); FD_TEST( tpool );
+  for( ulong tile_idx=1UL; tile_idx<tile_cnt; tile_idx++ ) FD_TEST( fd_tpool_worker_push( tpool, tile_idx )==tpool );
 
   ulong iter_cnt = 65536UL;
   float overhead;
@@ -710,21 +649,21 @@ main( int     argc,
       overhead = dt;
       FD_LOG_NOTICE(( "%4lu workers %9.3f ns (%9.3f overhead)", worker_cnt, (double)dt, (double)overhead ));
     } else {
-      float dt_per_level = (dt-overhead) / (float)fd_ulong_find_msb( worker_cnt );
+      float dt_per_level = (dt-overhead) / (float)fd_ulong_find_msb( fd_ulong_pow2_up( worker_cnt ) );
       FD_LOG_NOTICE(( "%4lu workers %9.3f ns (%9.3f dt_per_level)", worker_cnt, (double)dt, (double)dt_per_level ));
     }
   }
 
-  FD_LOG_NOTICE(( "Benchmarking FOR_ALL" ));
+  FD_LOG_NOTICE(( "Benchmarking FD_FOR_ALL" ));
 
   for( ulong worker_cnt=1UL; worker_cnt<=tile_cnt; worker_cnt++ ) {
 
     /* warmup */
-    for( ulong rem=1024UL; rem; rem-- ) FD_FOR_ALL( bench_for_all, tpool, 0L,worker_cnt, 0L,worker_cnt );
+    for( ulong rem=1024UL; rem; rem-- ) FD_FOR_ALL( bench_for_all, tpool, 0UL,worker_cnt, 0L,(long)worker_cnt );
 
     /* for real */
     long elapsed = -fd_log_wallclock();
-    for( ulong rem=iter_cnt; rem; rem-- ) FD_FOR_ALL( bench_for_all, tpool, 0L,worker_cnt, 0L,worker_cnt );
+    for( ulong rem=iter_cnt; rem; rem-- ) FD_FOR_ALL( bench_for_all, tpool, 0UL,worker_cnt, 0L,(long)worker_cnt );
     elapsed += fd_log_wallclock();
 
     float dt = ((float)elapsed) / ((float)iter_cnt);
@@ -732,23 +671,21 @@ main( int     argc,
       overhead = dt;
       FD_LOG_NOTICE(( "%4lu workers %9.3f ns (%9.3f overhead)", worker_cnt, (double)dt, (double)overhead ));
     } else {
-      float dt_per_level = (dt-overhead) / (float)fd_ulong_find_msb( worker_cnt );
+      float dt_per_level = (dt-overhead) / (float)fd_ulong_find_msb( fd_ulong_pow2_up( worker_cnt ) );
       FD_LOG_NOTICE(( "%4lu workers %9.3f ns (%9.3f dt_per_level)", worker_cnt, (double)dt, (double)dt_per_level ));
     }
   }
 
-  FD_LOG_NOTICE(( "Benchmarking MAP_REDUCE" ));
-
-  FD_FOR_ALL( test_scratch_attach, tpool,0UL,tile_cnt, 0L,(long)tile_cnt );
+  FD_LOG_NOTICE(( "Benchmarking FD_MAP_REDUCE" ));
 
   for( ulong worker_cnt=1UL; worker_cnt<=tile_cnt; worker_cnt++ ) {
 
     /* warmup */
-    for( ulong rem=1024UL; rem; rem-- ) FD_MAP_REDUCE( bench_map_reduce, tpool, 0L,worker_cnt, 0L,worker_cnt, NULL );
+    for( ulong rem=1024UL; rem; rem-- ) FD_MAP_REDUCE( bench_map_reduce, tpool, 0UL,worker_cnt, 0L,(long)worker_cnt, NULL );
 
     /* for real */
     long elapsed = -fd_log_wallclock();
-    for( ulong rem=iter_cnt; rem; rem-- ) FD_MAP_REDUCE( bench_map_reduce, tpool, 0L,worker_cnt, 0L,worker_cnt, NULL );
+    for( ulong rem=iter_cnt; rem; rem-- ) FD_MAP_REDUCE( bench_map_reduce, tpool, 0UL,worker_cnt, 0L,(long)worker_cnt, NULL );
     elapsed += fd_log_wallclock();
 
     float dt = ((float)elapsed) / ((float)iter_cnt);
@@ -756,13 +693,11 @@ main( int     argc,
       overhead = dt;
       FD_LOG_NOTICE(( "%4lu workers %9.3f ns (%9.3f overhead)", worker_cnt, (double)dt, (double)overhead ));
     } else {
-      float dt_per_level = (dt-overhead) / (float)fd_ulong_find_msb( worker_cnt );
+      float dt_per_level = (dt-overhead) / (float)fd_ulong_find_msb( fd_ulong_pow2_up( worker_cnt ) );
       FD_LOG_NOTICE(( "%4lu workers %9.3f ns (%9.3f dt_per_level)", worker_cnt, (double)dt, (double)dt_per_level ));
     }
 
   }
-
-  FD_FOR_ALL( test_scratch_detach, tpool,0UL,tile_cnt, 0L,(long)tile_cnt );
 
   FD_TEST( fd_tpool_fini( tpool )==(void *)tpool_mem );
 

--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -3,7 +3,6 @@
 
 #include "../tpool/fd_tpool.h"
 #include "../checkpt/fd_checkpt.h"
-#include "../sanitize/fd_sanitize.h"
 
 /* API for creating NUMA-aware and TLB-efficient workspaces used for
    complex inter-thread and inter-process shared memory communication

--- a/src/util/wksp/test_wksp_tpool.c
+++ b/src/util/wksp/test_wksp_tpool.c
@@ -8,12 +8,12 @@
 static FD_TL fd_rng_t rng_mem[1];
 
 static FD_FOR_ALL_BEGIN( rng_init, 1L ) {
-  fd_rng_t ** _rng = (fd_rng_t **)_a0;
+  fd_rng_t ** _rng = (fd_rng_t **)arg[0];
   _rng[ tpool_t0 ] = fd_rng_join( fd_rng_new( rng_mem, (uint)tpool_t0, 0UL ) );
 } FD_FOR_ALL_END
 
 static FD_FOR_ALL_BEGIN( rng_fini, 1L ) {
-  fd_rng_t ** _rng = (fd_rng_t **)_a0;
+  fd_rng_t ** _rng = (fd_rng_t **)arg[0];
   fd_rng_delete( fd_rng_leave( _rng[ tpool_t0 ] ) );
 } FD_FOR_ALL_END
 
@@ -23,8 +23,8 @@ typedef struct {
 } alloc_info_t;
 
 static FD_FOR_ALL_BEGIN( alloc_init, 1L ) {
-  fd_wksp_t *          wksp = (fd_wksp_t *)         _a0;
-  alloc_info_t const * info = (alloc_info_t const *)_a1;
+  fd_wksp_t *          wksp = (fd_wksp_t *)         arg[0];
+  alloc_info_t const * info = (alloc_info_t const *)arg[1];
 
   for( long idx=block_i0; idx<block_i1; idx++ ) {
     ulong gaddr0 = info[ idx ].gaddr0;   /* !=0 */
@@ -37,8 +37,8 @@ static FD_FOR_ALL_BEGIN( alloc_init, 1L ) {
 } FD_FOR_ALL_END
 
 static FD_FOR_ALL_BEGIN( alloc_zero, 1L ) {
-  fd_wksp_t *          wksp = (fd_wksp_t *)         _a0;
-  alloc_info_t const * info = (alloc_info_t const *)_a1;
+  fd_wksp_t *          wksp = (fd_wksp_t *)         arg[0];
+  alloc_info_t const * info = (alloc_info_t const *)arg[1];
 
   for( long idx=block_i0; idx<block_i1; idx++ ) {
     ulong gaddr0 = info[ idx ].gaddr0; /* !=0 */
@@ -49,10 +49,10 @@ static FD_FOR_ALL_BEGIN( alloc_zero, 1L ) {
 } FD_FOR_ALL_END
 
 static FD_FOR_ALL_BEGIN( alloc_test, 1L ) {
-  fd_wksp_t *          wksp = (fd_wksp_t *)         _a0;
-  alloc_info_t const * info = (alloc_info_t const *)_a1;
+  fd_wksp_t *          wksp = (fd_wksp_t *)         arg[0];
+  alloc_info_t const * info = (alloc_info_t const *)arg[1];
 
-  fd_rng_t * rng  = ((fd_rng_t **)_a2)[ tpool_t0 ];
+  fd_rng_t * rng  = ((fd_rng_t **)arg[2])[ tpool_t0 ];
 
   for( long idx=block_i0; idx<block_i1; idx++ ) {
     ulong gaddr0 = info[ idx ].gaddr0;   /* !=0 */
@@ -99,13 +99,13 @@ main( int     argc,
 
   FD_LOG_NOTICE(( "Creating thread pool (--worker-cnt %lu)", worker_cnt ));
   static uchar _tpool[ FD_TPOOL_FOOTPRINT(FD_TILE_MAX) ] __attribute__((aligned(FD_TPOOL_ALIGN)));
-  fd_tpool_t * tpool = fd_tpool_init( _tpool, worker_cnt ); /* logs details */
+  fd_tpool_t * tpool = fd_tpool_init( _tpool, worker_cnt, 0UL ); /* logs details */
   if( FD_UNLIKELY( !tpool ) ) FD_LOG_ERR(( "fd_tpool_init failed" ));
 
   FD_LOG_NOTICE(( "Adding tiles as workers to thread pool" ));
 
   for( ulong worker_idx=1UL; worker_idx<worker_cnt; worker_idx++ )
-    if( FD_UNLIKELY( !fd_tpool_worker_push( tpool, worker_idx, NULL, 0UL ) ) ) FD_LOG_ERR(( "fd_tpool_worker_push failed" ));
+    if( FD_UNLIKELY( !fd_tpool_worker_push( tpool, worker_idx ) ) ) FD_LOG_ERR(( "fd_tpool_worker_push failed" ));
 
   FD_LOG_NOTICE(( "Creating random number generators" ));
 


### PR DESCRIPTION
Polished up some thread parallelism rough edges noted in the recent parallel thread sorting API installation.  Significant performance improvement for thread parallelism strong scaling (not that it wasn't already very fast) and some low impact tpool API changes from user point of view for existing usages (that make it easier to use and more flexible to deploy):

- Improved cache traffic between dispatch and worker threads in tpool. Thread dispatch / sync is low tens of percent faster (from ~400 ns per level to ~300 ns per level by reducing cache contention).  A side effect of this is that the tpool state variable was split into two sequence number variables.  This eliminated the FD_TPOOL_WORKER_STATE_* defines and corresponding fd_tpool_state_cstr APIs.  It also replaced the fd_tpool_worker_state with a simpler to use fd_tpool_worker_idle API.

- Added an run-time option for tpool threads to sleep when idle instead of spinning when idle.  This option slows down thread dispatch by over an order of magnitude (e.g.  ~28 us vs ~1.8 us to dispatch and synchronize 64 threads instead of ~1.8 us on typical x86 server ... the OS does a _terrible_ job at parallelism, especially at high core count).  But this is helpful for various kinds of testing and for situations where low latency / strong scaling is not a concern (especially with floating threads, low priority background processing, etc).  This added a new opt argument to fd_tool_init.

- Polished up FD_MAP_REDUCE / FD_FOR_ALL.  These now support passing more arguments, more flexibily and more simply than previously.  This tweaked how arguments are presented to implementation (simplifying practically, no more LOC than required for writing a normal function input argument list).  The dispatch logic was similarly tuned to take advantage of the above.

- Removed dependence on fd_scratch APIs from tpool.  This simplifies API usage and removes the scratch / scratch_sz argument from fd_tpool_worker_push.  At this point, suspect the fd_scratch API can be fully eliminated in favor of spad.

- Gave test_tpool the ability to select spin or sleeping style from command line and made minor improvement to the accuracy of the dispatch performance model in the various benchmarks.

- Did a linting pass on fd_util.h and related includes to reflect current util API organization.