### PR TITLE
runtime: remove unused acc_mgr fields

### DIFF
--- a/src/choreo/voter/fd_voter.c
+++ b/src/choreo/voter/fd_voter.c
@@ -14,12 +14,12 @@ fd_voter_state( fd_funk_t * funk,
       return NULL;
     }
     fd_account_meta_t const * meta = fd_funk_val_const( rec, fd_funk_wksp(funk) );
-    if( FD_UNLIKELY( meta == NULL || meta->magic != FD_ACCOUNT_META_MAGIC ) ) {
+    if( FD_UNLIKELY( meta == NULL ) ) {
       FD_LOG_WARNING(( "bad account meta" ));
       continue;
     }
 
-    fd_voter_state_t const * state = fd_type_pun_const( (uchar const *)meta + meta->hlen );
+    fd_voter_state_t const * state = fd_type_pun_const( (uchar const *)( meta+1 ) );
     if( FD_UNLIKELY( state == NULL || state->discriminant > fd_vote_state_versioned_enum_current ) ) {
       FD_LOG_WARNING(( "bad account state" ));
       continue;

--- a/src/discof/geyser/fd_geyser.c
+++ b/src/discof/geyser/fd_geyser.c
@@ -241,8 +241,8 @@ replay_sham_link_after_frag(fd_geyser_t * ctx, fd_replay_notif_msg_t * msg) {
           const void * data = read_account_with_xid( ctx, &key, &msg->accts.funk_xid, &datalen );
           if( data ) {
             fd_account_meta_t const * meta = fd_type_pun_const( data );
-            if( datalen >= meta->hlen + meta->dlen ) {
-              (*ctx->acct_fun)( msg->accts.funk_xid.ul[0], msg->accts.sig, &addr, meta, (uchar*)data + meta->hlen, meta->dlen, ctx->fun_arg );
+            if( datalen >= sizeof(fd_account_meta_t) + meta->dlen ) {
+              (*ctx->acct_fun)( msg->accts.funk_xid.ul[0], msg->accts.sig, &addr, meta, (uchar*)data + sizeof(fd_account_meta_t), meta->dlen, ctx->fun_arg );
             }
           }
         } FD_SCRATCH_SCOPE_END;

--- a/src/discof/rpcserver/fd_block_to_json.c
+++ b/src/discof/rpcserver/fd_block_to_json.c
@@ -839,11 +839,12 @@ fd_account_to_json( fd_webserver_t * ws,
   fd_web_reply_sprintf(ws, "{\"data\":[\"");
 
   fd_account_meta_t * metadata = (fd_account_meta_t *)val;
-  if (val_sz < sizeof(fd_account_meta_t) && val_sz < metadata->hlen) {
+  if( val_sz < sizeof(fd_account_meta_t) ) {
     return "failed to load account data";
   }
-  val = (uchar*)val + metadata->hlen;
-  val_sz = val_sz - metadata->hlen;
+  /* FIXME clean up this code */
+  val = val + sizeof(fd_account_meta_t);
+  val_sz = val_sz - sizeof(fd_account_meta_t);
   if (val_sz > metadata->dlen)
     val_sz = metadata->dlen;
 

--- a/src/flamenco/runtime/fd_acc_mgr.h
+++ b/src/flamenco/runtime/fd_acc_mgr.h
@@ -18,7 +18,6 @@
 #define FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT (-1)
 #define FD_ACC_MGR_ERR_WRITE_FAILED    (-2)
 #define FD_ACC_MGR_ERR_READ_FAILED     (-3)
-#define FD_ACC_MGR_ERR_WRONG_MAGIC     (-4)
 
 /* FD_ACC_SZ_MAX is the hardcoded size limit of a Solana account. */
 
@@ -44,8 +43,6 @@ FD_PROTOTYPES_BEGIN
 static inline void
 fd_account_meta_init( fd_account_meta_t * m ) {
   fd_memset( m, 0, sizeof(fd_account_meta_t) );
-  m->magic = FD_ACCOUNT_META_MAGIC;
-  m->hlen  = sizeof(fd_account_meta_t);
 }
 
 /* fd_account_meta_exists checks if the account in a funk record exists or was
@@ -121,7 +118,6 @@ fd_funk_key_is_acc( fd_funk_rec_key_t const * id ) {
    - notably, leaves *opt_err untouched, even if opt_err!=NULL
 
    First byte of returned pointer is first byte of fd_account_meta_t.
-   To find data region of account, add (fd_account_meta_t)->hlen.
 
    Lifetime of returned fd_funk_rec_t and account record pointers ends
    when user calls modify_data for same account, or tranasction ends.

--- a/src/flamenco/runtime/fd_hashes.c
+++ b/src/flamenco/runtime/fd_hashes.c
@@ -18,12 +18,12 @@
 /* Internal helper for extracting data from account_meta */
 static inline void *
 fd_account_meta_get_data( fd_account_meta_t * m ) {
-  return ((uchar *) m) + m->hlen;
+  return m+1;
 }
 
 static inline void const *
 fd_account_meta_get_data_const( fd_account_meta_t const * m ) {
-  return ((uchar const *) m) + m->hlen;
+  return m+1;
 }
 
 #define SORT_NAME sort_pubkey_hash_pair
@@ -545,7 +545,7 @@ fd_update_hash_bank_exec_hash( fd_exec_slot_ctx_t *           slot_ctx,
           continue;
         }
 
-        uchar const * acc_data = (uchar *)acc_meta + acc_meta->hlen;
+        uchar const * acc_data = (uchar const *)( acc_meta+1 );
 
         err = fd_solcap_write_account( capture_ctx->capture,
                                       acc_key->uc,

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -103,7 +103,7 @@ typedef struct fd_poh_verifier fd_poh_verifier_t;
    the account's data. This struct encodes that layout and asserts that
    the alignment requirements of the constituents are satisfied. */
 // TODO: Use this struct at allocation sites so it's clear we use this layout
-struct __attribute__((packed)) fd_account_rec {
+struct fd_account_rec {
   fd_account_meta_t meta;
   uchar data[];
 };

--- a/src/flamenco/snapshot/fd_snapshot_main.c
+++ b/src/flamenco/snapshot/fd_snapshot_main.c
@@ -178,7 +178,6 @@ fd_snapshot_dumper_record( fd_snapshot_dumper_t * d,
 
   uchar const *             rec_val = fd_funk_val_const( rec, wksp );
   fd_account_meta_t const * meta    = (fd_account_meta_t const *)rec_val;
-  //uchar const *             data    = rec_val + meta->hlen;
 
   if( d->csv_fd>=0 ) {
     fd_snapshot_csv_rec_t csv_rec;

--- a/src/flamenco/snapshot/test_snapshot_restore.c
+++ b/src/flamenco/snapshot/test_snapshot_restore.c
@@ -509,7 +509,7 @@ main( int     argc,
       meta->slot          =  9UL;
       fd_funk_rec_publish( funk, prepare );
       FD_TEST( fd_account_meta_exists( meta ) );
-      memcpy( (uchar *)meta + meta->hlen, "ABCD", 4UL );
+      memcpy( (uchar *)( meta+1 ), "ABCD", 4UL );
     } while(0);
 
     /* Restore the snapshot */
@@ -547,7 +547,7 @@ main( int     argc,
       FD_TEST( acc1->info.lamports   == 90UL );
       FD_TEST( acc1->info.rent_epoch ==  0UL );
       FD_TEST( acc1->info.executable ==  0   );
-      FD_TEST( 0==memcmp( (uchar const *)acc1 + acc1->hlen, "ABCD", 4UL ) );
+      FD_TEST( 0==memcmp( acc1+1, "ABCD", 4UL ) );
 
       /* Verify key 10 */
       fd_pubkey_t pubkey2[1]; memcpy( pubkey2, hdr2.meta.pubkey, 32 );
@@ -559,7 +559,7 @@ main( int     argc,
       FD_TEST( acc2->info.lamports   == hdr2.info.lamports   );
       FD_TEST( acc2->info.rent_epoch == hdr2.info.rent_epoch );
       FD_TEST( acc2->info.executable == hdr2.info.executable );
-      FD_TEST( 0==memcmp( (uchar const *)acc2 + acc2->hlen, "Hi :)", 4UL ) );
+      FD_TEST( 0==memcmp( acc2+1, "Hi :)", 4UL ) );
     } while(0);
 
     fd_funk_txn_cancel( funk, restore->funk_txn, 0 );
@@ -665,7 +665,7 @@ main( int     argc,
       FD_TEST( 0==memcmp( acc->info.owner, hdr.info.owner, 32UL ) );
       FD_TEST( 0==memcmp( acc->hash,       hdr.hash.uc,    32UL ) );
 
-      uchar const * acc_data = (uchar const *)acc + acc->hlen;
+      uchar const * acc_data = (uchar const *)( acc+1 );
       FD_TEST( 0==memcmp( acc_data, "AB", 2UL ) );
     } while(0);
 

--- a/src/flamenco/types/fd_types.h
+++ b/src/flamenco/types/fd_types.h
@@ -5,7 +5,6 @@
 #include "fd_bincode.h"
 #include "../../ballet/utf8/fd_utf8.h"
 #include "fd_types_custom.h"
-#define FD_ACCOUNT_META_MAGIC 9823
 
 /* sdk/program/src/feature.rs#L22 */
 /* Encoded Size: Dynamic */
@@ -239,10 +238,8 @@ struct __attribute__((packed)) fd_solana_account_hdr {
 typedef struct fd_solana_account_hdr fd_solana_account_hdr_t;
 #define FD_SOLANA_ACCOUNT_HDR_ALIGN (8UL)
 
-/* Encoded Size: Fixed (104 bytes) */
-struct __attribute__((packed)) fd_account_meta {
-  ushort magic;
-  ushort hlen;
+/* Encoded Size: Fixed (100 bytes) */
+struct __attribute__((aligned(8))) fd_account_meta {
   ulong dlen;
   uchar hash[32];
   ulong slot;

--- a/src/flamenco/types/fd_types.json
+++ b/src/flamenco/types/fd_types.json
@@ -4,8 +4,7 @@
   "extra_header": [
       "#include \"fd_bincode.h\"",
       "#include \"../../ballet/utf8/fd_utf8.h\"",
-      "#include \"fd_types_custom.h\"",
-      "#define FD_ACCOUNT_META_MAGIC 9823"
+      "#include \"fd_types_custom.h\""
   ],
   "entries": [
     {
@@ -232,10 +231,8 @@
     {
       "name": "account_meta",
       "type": "struct",
-      "attribute": "((packed))",
+      "attribute": "((aligned(8)))",
       "fields": [
-        { "name": "magic", "type": "ushort" },
-        { "name": "hlen",  "type": "ushort" },
         { "name": "dlen",  "type": "ulong" },
         { "name": "hash",  "type": "uchar[32]" },
         { "name": "slot",  "type": "ulong" },


### PR DESCRIPTION
Remove 'magic' and 'hlen' fields from acc_mgr.
