### PR TITLE
topo: allow tiles without sandbox

### DIFF
--- a/src/app/shared/commands/run/run1.c
+++ b/src/app/shared/commands/run/run1.c
@@ -56,7 +56,11 @@ tile_main( void * _args ) {
   }
 
   fd_topo_run_tile_t run_tile = fdctl_tile_run( args->tile );
-  fd_topo_run_tile( &args->config->topo, args->tile, args->config->development.sandbox, 0, args->config->development.core_dump, args->config->uid, args->config->gid, args->pipefd, wait, debug, &run_tile );
+
+  int sandbox_enabled = !!args->config->development.sandbox;
+  if( run_tile.disable_sandbox ) sandbox_enabled = 0;
+
+  fd_topo_run_tile( &args->config->topo, args->tile, sandbox_enabled, 0, args->config->development.core_dump, args->config->uid, args->config->gid, args->pipefd, wait, debug, &run_tile );
   return 0;
 }
 

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -481,6 +481,7 @@ typedef struct {
   ulong        rlimit_address_space;
   ulong        rlimit_data;
   int          for_tpool;
+  int          disable_sandbox;
 
   ulong (*populate_allowed_seccomp)( fd_topo_t const * topo, fd_topo_tile_t const * tile, ulong out_cnt, struct sock_filter * out );
   ulong (*populate_allowed_fds    )( fd_topo_t const * topo, fd_topo_tile_t const * tile, ulong out_fds_sz, int * out_fds );


### PR DESCRIPTION
This should not actually be merged. I'm just leaving this functionality here in case we need it in the future.

----------

Some tiles use system libraries that do unpredictable file system
accesses and system calls.  For example, getaddrinfo / nsswitch.
Running such tiles in a sandbox is not practical.  Therefore,
introduce a mechanism to add sandbox exceptions.

Of course, such tiles must not be exposed to any untrusted data.
