### PR TITLE
util: move map flags to a common header

### DIFF
--- a/src/flamenco/runtime/fd_blockstore.h
+++ b/src/flamenco/runtime/fd_blockstore.h
@@ -320,13 +320,6 @@ struct fd_block_info {
 };
 typedef struct fd_block_info fd_block_info_t;
 
-/* Needed due to redefinition of err codes in slot_para */
-#undef FD_MAP_SUCCESS
-#undef FD_MAP_ERR_INVAL
-#undef FD_MAP_ERR_AGAIN
-#undef FD_MAP_ERR_KEY
-#undef FD_MAP_FLAG_BLOCKING
-
 #define MAP_NAME                  fd_block_map
 #define MAP_ELE_T                 fd_block_info_t
 #define MAP_KEY                   slot

--- a/src/util/tmpl/fd_map.h
+++ b/src/util/tmpl/fd_map.h
@@ -1,0 +1,35 @@
+#ifndef HEADER_fd_src_util_tmpl_fd_map_h
+#define HEADER_fd_src_util_tmpl_fd_map_h
+
+/* Common map error codes (FIXME: probably should get around to making
+   unified error codes, error strings and/or flags across util at least
+   so we don't have to do this in the generator itself) */
+
+#define FD_MAP_SUCCESS     (0)
+#define FD_MAP_ERR_INVAL   (-1)
+#define FD_MAP_ERR_AGAIN   (-2)
+#define FD_MAP_ERR_CORRUPT (-3)
+//#define FD_MAP_ERR_EMPTY   (-4)
+#define FD_MAP_ERR_FULL    (-5)
+#define FD_MAP_ERR_KEY     (-6)
+
+/* common map flags */
+
+#define FD_MAP_FLAG_BLOCKING      (1<<0)
+
+/* map_slot_para flags */
+
+//#define FD_MAP_FLAG_BLOCKING      (1<<0)
+#define FD_MAP_FLAG_USE_HINT      (1<<2)
+#define FD_MAP_FLAG_PREFETCH_NONE (0<<3)
+#define FD_MAP_FLAG_PREFETCH_META (1<<3)
+#define FD_MAP_FLAG_PREFETCH_DATA (2<<3)
+#define FD_MAP_FLAG_PREFETCH      (3<<3)
+#define FD_MAP_FLAG_RDONLY        (1<<5)
+
+/* map_chain_para flags */
+
+//#define FD_MAP_FLAG_BLOCKING      (1)
+#define FD_MAP_FLAG_ADAPTIVE      (2)
+
+#endif /* HEADER_fd_src_util_tmpl_fd_map_h */

--- a/src/util/tmpl/fd_map_chain_para.c
+++ b/src/util/tmpl/fd_map_chain_para.c
@@ -1071,6 +1071,8 @@
      ... free lock_seq here
 */
 
+#include "fd_map.h"
+
 /* FIXME: consider adding a parallel verify that operates on a
    locked/idle subset of the chains. */
 
@@ -1192,26 +1194,6 @@
 #ifndef MAP_IMPL_STYLE
 #define MAP_IMPL_STYLE 0
 #endif
-
-/* Common map error codes (FIXME: probably should get around to making
-   unified error codes, error strings and/or flags across util at least
-   so we don't have to do this in the generator itself) */
-
-#define FD_MAP_SUCCESS     (0)
-#define FD_MAP_ERR_INVAL   (-1)
-#define FD_MAP_ERR_AGAIN   (-2)
-#define FD_MAP_ERR_CORRUPT (-3)
-//#define FD_MAP_ERR_EMPTY   (-4)
-//#define FD_MAP_ERR_FULL    (-5)
-#define FD_MAP_ERR_KEY     (-6)
-
-#define FD_MAP_FLAG_BLOCKING      (1<<0)
-#define FD_MAP_FLAG_ADAPTIVE      (1<<1)
-#define FD_MAP_FLAG_USE_HINT      (1<<2)
-#define FD_MAP_FLAG_PREFETCH_NONE (0<<3)
-#define FD_MAP_FLAG_PREFETCH_META (1<<3)
-#define FD_MAP_FLAG_PREFETCH_DATA (2<<3)
-#define FD_MAP_FLAG_PREFETCH      (3<<3)
 
 /* Implementation *****************************************************/
 

--- a/src/util/tmpl/fd_map_slot_para.c
+++ b/src/util/tmpl/fd_map_slot_para.c
@@ -862,6 +862,8 @@
      are nice compact streaming access patterns.  And similarly for the
      element store access patterns. */
 
+#include "fd_map.h"
+
 /* MAP_NAME gives the API prefix to use for map */
 
 #ifndef MAP_NAME
@@ -1046,26 +1048,6 @@
 #ifndef MAP_IMPL_STYLE
 #define MAP_IMPL_STYLE 0
 #endif
-
-/* Common map error codes (FIXME: probably should get around to making
-   unified error codes, error strings and/or flags across util at least
-   so we don't have to do this in the generator itself) */
-
-#define FD_MAP_SUCCESS     (0)
-#define FD_MAP_ERR_INVAL   (-1)
-#define FD_MAP_ERR_AGAIN   (-2)
-//#define FD_MAP_ERR_CORRUPT (-3)
-//#define FD_MAP_ERR_EMPTY   (-4)
-#define FD_MAP_ERR_FULL    (-5)
-#define FD_MAP_ERR_KEY     (-6)
-
-#define FD_MAP_FLAG_BLOCKING      (1<<0)
-#define FD_MAP_FLAG_USE_HINT      (1<<2)
-#define FD_MAP_FLAG_PREFETCH_NONE (0<<3)
-#define FD_MAP_FLAG_PREFETCH_META (1<<3)
-#define FD_MAP_FLAG_PREFETCH_DATA (2<<3)
-#define FD_MAP_FLAG_PREFETCH      (3<<3)
-#define FD_MAP_FLAG_RDONLY        (1<<5)
 
 /* Implementation *****************************************************/
 


### PR DESCRIPTION
Fixes build issues when including different map types into the same compile unit.
