### PR TITLE
chore: fix unused/used static analysis lint in shred

### DIFF
--- a/src/disco/shred/fd_shred_tile.c
+++ b/src/disco/shred/fd_shred_tile.c
@@ -655,7 +655,6 @@ after_frag( fd_shred_ctx_t *    ctx,
             ulong               _tspub,
             fd_stem_context_t * stem ) {
   (void)seq;
-  (void)sig;
   (void)sz;
   (void)tsorig;
   (void)_tspub;


### PR DESCRIPTION
Just to have a clean static analysis tab (: