### PR TITLE
shred: fix wrong ip addr byte order comment

### DIFF
--- a/src/disco/shred/fd_shred_dest.h
+++ b/src/disco/shred/fd_shred_dest.h
@@ -30,9 +30,9 @@ typedef uint fd_shred_dest_idx_t;
 struct fd_shred_dest_weighted {
   fd_pubkey_t  pubkey;   /* The validator's identity key */
   ulong  stake_lamports; /* Stake, measured in lamports, or 0 for an unstaked validator */
-  uint   ip4;            /* The validator's IP address, in host byte order */
+  uint   ip4;            /* The validator's IP address, in network byte order */
   ushort port;           /* The TVU port, in host byte order */
-};
+}; /* be careful ip and host are in different byte order */
 typedef struct fd_shred_dest_weighted fd_shred_dest_weighted_t;
 
 /* Internal type, forward declared to be able to declare the struct

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -234,9 +234,9 @@ typedef struct {
       int    larger_shred_limits_per_block;
       ulong  expected_shred_version;
       struct {
-        uint   ip;
-        ushort port;
-      } adtl_dest;
+        uint   ip;   /* in network byte order */
+        ushort port; /* in host byte order */
+      } adtl_dest; /* be careful ip and host are in different byte order */
     } shred;
 
     struct {


### PR DESCRIPTION
the code, while having different byte order for ip and port is actually correct, since send_shred accounts for it. Instead of changing what is working in prod, let's instead add a warning to the docs

<details>
<summary>Code paths that set it</summary>

```

(1)

The firedancer/topology is not yet setting it. This is fdctl/topology code:

/* fd_cstr_to_ip4_addr parses an IPv4 address matching format
   %u.%u.%u.%u  On success stores address to out and returns 1. On fail
   returns 0.  The given address is returned in network byte order such
   that "1.0.0.0" => 0x00000001. */

int
fd_cstr_to_ip4_addr( char const * s,
                     uint *       addr );

if( FD_UNLIKELY( !fd_cstr_to_ip4_addr( adtl_dest, &(tile->shred.adtl_dest.ip) ) ) ) {

send_shred( ctx, *out_shred, ctx->adtl_dest, ctx->tsorig ); <--- (1) adtl_dest

(2)

memory[offset+32..offset+36].copy_from_slice(&ip); <-- network byte order
memory[offset+36..offset+38].copy_from_slice(&port.to_le_bytes()); <-- le so host byte order

struct __attribute__((packed)) fd_shred_dest_wire {
  fd_pubkey_t pubkey[1];
  /* The Agave splice writes this as octets, which means when we read
     this, it's essentially network byte order */
  uint   ip4_addr;
  ushort udp_port;
};
typedef struct fd_shred_dest_wire fd_shred_dest_wire_t;


  fd_shred_dest_wire_t const * in_dests = fd_type_pun_const( header+1UL );
  fd_shred_dest_weighted_t * dests = fd_stake_ci_dest_add_init( ctx->stake_ci );

  ctx->new_dest_ptr = dests;
  ctx->new_dest_cnt = dest_cnt;

  for( ulong i=0UL; i<dest_cnt; i++ ) {
    memcpy( dests[i].pubkey.uc, in_dests[i].pubkey, 32UL );
    dests[i].ip4  = in_dests[i].ip4_addr;
    dests[i].port = in_dests[i].udp_port;
  }

for( ulong j=0UL; j<*max_dest_cnt; j++ ) send_shred( ctx, *out_shred, fd_shred_dest_idx_to_dest( sdest, dests[ j ]), ctx->tsorig ); <--- (2) to_dest

---

send_shred( fd_shred_ctx_t                 * ctx,
        fd_shred_t const               * shred,
        fd_shred_dest_weighted_t const * dest,  <--- HERE
        ulong                            tsorig ) {

---

fd_ip4_hdr_t * ip4 = hdr->ip4;
ip4->daddr  = dest->ip4; <--- not swapped
ip4->net_id = fd_ushort_bswap( ctx->net_id++ );
ip4->check  = 0U;
ip4->check  = fd_ip4_hdr_check_fast( ip4 );

hdr->udp->net_dport = fd_ushort_bswap( dest->port );  <--- swapped

```
</details>