### PR TITLE
ci: upgrade gcc minimum version to 11

### DIFF
--- a/.github/workflows/on_nightly.yml
+++ b/.github/workflows/on_nightly.yml
@@ -2,18 +2,15 @@ name: On Nightly
 on:
   workflow_dispatch:
   schedule:
-    - cron: 30 11 * * *
-    - cron: 0 3 * * *
+    - cron: 0 4 * * *
 jobs:
   coverage-report:
     uses: ./.github/workflows/coverage_report.yml
     secrets: inherit
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '30 11 * * *' }}
   codeql:
     uses: ./.github/workflows/codeql.yml
     permissions:
       security-events: write
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '30 11 * * *' }}
   builds:
     uses: ./.github/workflows/builds.yml
     with:
@@ -30,4 +27,3 @@ jobs:
         ALL,linux_gcc_riscv,ALL
       verbose: false
       build_arm: true
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '0 3 * * *' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
             deps-extras: "+dev"
             targets: "check"
             compiler: gcc
-            compiler-version: 8.5.0
+            compiler-version: 11.4.0
           - test-case: linux_gcc_x86_64
             machine: linux_gcc_x86_64
             label: X64
@@ -41,7 +41,7 @@ jobs:
             deps-extras: "+dev"
             targets: "all integration-test fdctl firedancer"
             compiler: gcc
-            compiler-version: 8.5.0
+            compiler-version: 11.4.0
             run-unit-tests: true
           - test-case: linux_gcc_icelake
             machine: linux_gcc_icelake


### PR DESCRIPTION
Gcc 11 is the default Ubuntu 22.04 and RHEL 9 onwards. Note that nightly builds will continue to test support for the older compilers, this just bumps it for regular CI runs.