### PR TITLE
fdctl: allow generating keys at any path

### DIFF
--- a/book/api/cli.md
+++ b/book/api/cli.md
@@ -204,20 +204,20 @@ $ fdctl keys pubkey ~/.firedancer/fd1/identity.json
 Fe4StcZSQ228dKK2hni7aCP7ZprNhj8QKWzFe5usGFYF
 ```
 
-### `keys new <identity|vote>`
+### `keys new <PATH>`
 Creates a new keypair from the kernel random number generator and writes
-it to the identity key path, or vote key path. The key path is retrieved
-from the configuration TOML file
+it to the file specified at `<PATH>`. The default user for the operation
+is the user running the command and should have write access to `<PATH>`.
+The user can be changed by specifying it in the TOML configuration file.
 
 | Arguments  | Description |
 |------------|-------------|
-| `--config` | Path to a configuration TOML file which determines where the key is written. Either `[consensus.identity_path]` or `[consensus.vote_account_path]` for `identity` or `vote` arguments respectively
+| `--config` | Path to a configuration TOML file which determines the user creating the file.
 
 ::: code-group
 
 ```toml [config.toml]
-[consensus]
-    identity_path = "/home/{user}/.fd/keys/identity.json"
+user = "firedancer"
 ```
 
 :::

--- a/book/guide/getting-started.md
+++ b/book/guide/getting-started.md
@@ -142,7 +142,7 @@ check out a newer version, update dependencies, and rebuild binaries.
 
 ```sh [bash]
 git fetch --tags
-git checkout v0.404.20113 # replace version number here
+git checkout __FD_LATEST_VERSION__
 git submodule update
 make -j fdctl solana
 ```
@@ -192,8 +192,9 @@ user = "firedancer"
 
 This configuration will cause Firedancer to run as the user `firedancer`
 on the local machine. The `identity_path` and `vote_account_path` should
-be Agave style keys, which can be generated using `solana-keygen`.
-`solana-keygen` is part of the [Solana CLI](https://docs.anza.xyz/cli/install).
+be Agave style keys, which can be generated using the [`fdctl keys`.
+subcommand](../api/cli.md#keys-new-path). The `vote_account_path` can
+also be the public key of an existing vote account.
 
 This will put the ledger in `/home/firedancer/.firedancer/fd1/ledger`.
 To customize this path, refer to the [configuration

--- a/book/snippets/commands/keys-new.ansi
+++ b/book/snippets/commands/keys-new.ansi
@@ -1,2 +1,2 @@
-$ fdctl keys new vote --config config.toml
-[32mNOTICE [0m successfully created keypair in `/home/fd/.fd/keys/identity.json`
+$ fdctl keys new ~/identity.json --config config.toml
+[32mNOTICE [0m successfully created keypair in `/home/firedancer/identity.json`

--- a/src/app/shared/commands/help.c
+++ b/src/app/shared/commands/help.c
@@ -12,7 +12,7 @@ void
 help_cmd_fn( args_t *   args   FD_PARAM_UNUSED,
              config_t * config FD_PARAM_UNUSED ) {
   FD_LOG_STDOUT(( "%s control binary\n\n", FD_APP_NAME ));
-  FD_LOG_STDOUT(( "Usage: %s [OPTIONS] <SUBCOMMAND>\n\n", FD_BINARY_NAME ));
+  FD_LOG_STDOUT(( "Usage: %s <SUBCOMMAND> [OPTIONS]\n\n", FD_BINARY_NAME ));
   FD_LOG_STDOUT(( "\nOPTIONS:\n" ));
   /* fdctl does not have many flag arguments so we hard-code the
      --config parameter. */


### PR DESCRIPTION
To setup new validators, typically you need to create more keys for staking, authorized withdrawer, etc. This lets a new operator do all that by letting `fdctl` create keys at arbitrary paths. This gets rid of the slight dependency we have on the `solana-keygen` binary which we don't compile from our repo.