### PR TITLE
build: fix clang and gcc minimal builds

### DIFF
--- a/src/disco/bundle/Local.mk
+++ b/src/disco/bundle/Local.mk
@@ -7,7 +7,9 @@ endif
 
 $(call add-hdrs,fd_bundle_tile.h)
 $(call add-objs,fd_bundle_auth fd_bundle_client,fd_disco)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_bundle_client,test_bundle_client,fd_disco fd_waltz fd_flamenco fd_tango fd_ballet fd_util,-lssl -lcrypto)
+endif
 
 ifdef FD_HAS_SSE # implies FD_HAS_DOUBLE
 $(call add-objs,fd_bundle_tile,fd_disco)

--- a/src/waltz/http/Local.mk
+++ b/src/waltz/http/Local.mk
@@ -23,4 +23,6 @@ endif
 
 $(call add-hdrs,fd_url.h)
 $(call add-objs,fd_url,fd_waltz)
+ifdef FD_HAS_HOSTED
 $(call make-fuzz-test,fuzz_url_parse,fuzz_url_parse,fd_waltz fd_util)
+endif


### PR DESCRIPTION
All the `fd_shmem` stuff used in `test_bundle_client.c` needs FD_HAS_HOSTED.