### PR TITLE
codeql: drop used-unused-param severity to none

### DIFF
--- a/contrib/codeql/nightly/TrivialMemcpy.ql
+++ b/contrib/codeql/nightly/TrivialMemcpy.ql
@@ -6,7 +6,7 @@
                 to weaker typing.
  * @kind problem
  * @id firedancer-io/trivial-memcpy
- * @problem.severity warning
+ * @problem.severity none
  * @precision high
  * @tags maintainability
  *       readability

--- a/contrib/codeql/nightly/WrongUnused.ql
+++ b/contrib/codeql/nightly/WrongUnused.ql
@@ -4,7 +4,7 @@
  * @id asymmetric-research/used-unused-param
  * @kind problem
  * @precision high
- * @problem.severity warning
+ * @problem.severity none
  */
 
 import cpp


### PR DESCRIPTION
This alert is quite spammy and not security relevant
