### PR TITLE
quic: fix quic_conformance reliance on conn scheduling

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -771,6 +771,7 @@ fd_quic_conn_error1( fd_quic_conn_t * conn,
 
   /* set connection to be serviced ASAP */
   fd_quic_svc_prep_schedule_now( conn );
+  fd_quic_svc_schedule1( conn );
 }
 
 static void

--- a/src/waltz/quic/tests/test_quic_conformance.c
+++ b/src/waltz/quic/tests/test_quic_conformance.c
@@ -119,13 +119,12 @@ test_quic_ping_frame( fd_quic_sandbox_t * sandbox,
   fd_quic_sandbox_init( sandbox, FD_QUIC_ROLE_SERVER );
   fd_quic_conn_t * conn = fd_quic_sandbox_new_conn_established( sandbox, rng );
   conn->ack_gen->is_elicited = 0;
-  FD_TEST( conn->svc_meta.idx != FD_QUIC_SVC_IDX_INVAL );
+  FD_TEST( conn->svc_meta.idx == FD_QUIC_SVC_IDX_INVAL );
 
   uchar buf[1] = {0x01};
   fd_quic_sandbox_send_lone_frame( sandbox, conn, buf, sizeof(buf) );
   FD_TEST( conn->state == FD_QUIC_CONN_STATE_ACTIVE );
   FD_TEST( conn->ack_gen->is_elicited == 1 );
-  FD_TEST( conn->svc_meta.idx != FD_QUIC_SVC_IDX_INVAL );
 }
 
 /* Test an ALPN failure when acting as a server */


### PR DESCRIPTION
We used to directly call schedule everywhere, then switched to prepare/schedule API.  But the tests still assume that some internal functions directly schedule. In particular, fd_quic_conn_error1, fd_quic_conn_create, and fd_quic_handle_v1_frame (ping handler) 

This PR mostly fixes that reliance, although adds the actual scheduling call back to conn_error1 (should be infrequent enough)