### PR TITLE
Fix idle timeout units

### DIFF
--- a/src/waltz/quic/fd_quic_conn.h
+++ b/src/waltz/quic/fd_quic_conn.h
@@ -232,7 +232,7 @@ struct fd_quic_conn {
   uchar                peer_enc_level;
 
   /* idle timeout arguments */
-  ulong                idle_timeout;
+  ulong                idle_timeout_ticks;
   ulong                last_activity;
   ulong                last_ack;
 

--- a/src/waltz/quic/templ/fd_quic_transport_params.h
+++ b/src/waltz/quic/templ/fd_quic_transport_params.h
@@ -18,7 +18,7 @@ X( original_destination_connection_id,                                          
   "first Initial packet sent by the client; see Section 7.3. This transport "          \
   "parameter is only sent by a server.",                                               \
   __VA_ARGS__ )                                                                        \
-X( max_idle_timeout,                                                                   \
+X( max_idle_timeout_ms,                                                                   \
   0x01,                                                                                \
   VARINT,                                                                              \
   DFT_UNKNOWN,                                                                         \

--- a/src/waltz/quic/templ/test_quic_transport_params.c
+++ b/src/waltz/quic/templ/test_quic_transport_params.c
@@ -103,8 +103,8 @@ test_max_size( void ) {
     .original_destination_connection_id_len     = FD_QUIC_MAX_CONN_ID_SZ,
 
     /* 0x01 */
-    .max_idle_timeout_present = 1,
-    .max_idle_timeout         = (1UL<<62)-1,
+    .max_idle_timeout_ms_present = 1,
+    .max_idle_timeout_ms         = (1UL<<62)-1,
 
     /* 0x02 */
     .stateless_reset_token_present = 1,

--- a/src/waltz/quic/tests/fd_quic_sandbox.c
+++ b/src/waltz/quic/tests/fd_quic_sandbox.c
@@ -304,8 +304,8 @@ fd_quic_sandbox_new_conn_established( fd_quic_sandbox_t * sandbox,
   conn->peer_enc_level     = fd_quic_enc_level_appdata_id;
   conn->keys_avail         = 1U<<fd_quic_enc_level_appdata_id;
 
-  conn->idle_timeout  = FD_QUIC_SANDBOX_IDLE_TIMEOUT;
-  conn->last_activity = sandbox->wallclock;
+  conn->idle_timeout_ticks  = FD_QUIC_SANDBOX_IDLE_TIMEOUT;
+  conn->last_activity       = sandbox->wallclock;
 
   /* Reset flow control limits */
   conn->tx_max_data           = 0UL;

--- a/src/waltz/quic/tests/test_quic_concurrency.c
+++ b/src/waltz/quic/tests/test_quic_concurrency.c
@@ -80,7 +80,7 @@ main( int     argc,
     fd_quic_conn_t * conn = fd_quic_sandbox_new_conn_established( sandbox, rng );
     conn->srx->rx_sup_stream_id = (1UL<<62)-1;
     conn->last_activity         = state->now;
-    conn->idle_timeout          = (ulong)100000e9;
+    conn->idle_timeout_ticks    = (ulong)100000e9;
     conn_list[ j ] = conn;
   }
 


### PR DESCRIPTION
We currently don't convert the incoming peer_tp max_idle_timeout from ms to ticks when we take the min. So we probably timeout ticks_per_ns too fast. Opening this PR for now if folks want to take a look. Testing on val4 first. 