### PR TITLE
New banks hash issue because the hash field in the meta is no longer generated under lthash

### DIFF
--- a/src/flamenco/runtime/fd_hashes.c
+++ b/src/flamenco/runtime/fd_hashes.c
@@ -328,11 +328,9 @@ fd_account_hash( fd_funk_t *                    funk,
         iterator.  Instead, we will store away the record and erase
         it later where appropriate.  */
     task_info->should_erase = 1;
-    /* In the exceedingly unlikely event that the account's old hash is
-       actually 0, this would cause the account not to be included in
-       the bank hash. */
-    if( memcmp( task_info->acc_hash->hash, acc_meta->hash, sizeof(fd_hash_t) ) != 0 ) {
-      task_info->hash_changed = 1;
+    if( FD_UNLIKELY( NULL != acc_meta_parent) ){
+      if( FD_UNLIKELY( acc_meta->info.lamports != acc_meta_parent->info.lamports ) )
+        task_info->hash_changed = 1;
     }
   } else {
     uchar *             acc_data = fd_account_meta_get_data((fd_account_meta_t *) acc_meta);

--- a/src/flamenco/runtime/tests/run_backtest_ci.sh
+++ b/src/flamenco/runtime/tests/run_backtest_ci.sh
@@ -14,3 +14,4 @@ src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-378683870 -s snapsho
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-330219081 -s snapshot-330219080-2QzJWhxjNohZR2xeeFDkxt2UcdvSKZ8HhXaFdRXwg8iC.tar.zst -p 60 -y 16 -m 2000000 -e 330219086 -c 2.1.14
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-372721907 -s snapshot-372721906-FtUjok2JfLPwJCRVcioV12M8FWbbJaC91XEJzm4eZy53.tar.zst -p 60 -y 16 -m 2000000 -e 372721910 -c 2.1.14
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-331691646 -s snapshot-331691639-3NmZ4rd7nHfn6tuS4E5gUfAwWMoBAQ6K1yntNkyhPbrb.tar.zst -p 60 -y 20 -m 2000000 -e 331691650  -c 2.1.14
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-336218682 -s snapshot-336218681-BDsErdHkqa5iQGCNkSvQpeon8GLFsgeNEkckrMKboJ4N.tar.zst -p 60 -y 1 -m 2000000 -e 336218683  -c 2.2.14

--- a/src/flamenco/runtime/tests/run_backtest_tests_all.sh
+++ b/src/flamenco/runtime/tests/run_backtest_tests_all.sh
@@ -82,3 +82,4 @@ src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-331691646 -s snapsh
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-378683870 -s snapshot-378683869-7iuK12gAgSaB97WbmiTb4QPVbnqfFWCtq9F6CvfSgBj5.tar.zst -p 60 -y 16 -m 5000000 -e 378683872 -c 2.1.14
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l slashing-ledger -s snapshot-1-3pPnJsADcbDoFaCJr8Fcvb6UHf2jDUdAtbJ3G2JtevDK.tar.zst -p 60 -y 16 -m 5000000 -e 44 -c 2.3.0
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-380592002-per -s snapshot-380592001-A1J5DPRy9sr9y3GjV3wHvxPt77RDQLjBpdVc63WhTbmV.tar.zst -p 60 -y 16 -m 5000000 -e 380592006 -c 2.2.14
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-336218682 -s snapshot-336218681-BDsErdHkqa5iQGCNkSvQpeon8GLFsgeNEkckrMKboJ4N.tar.zst -p 60 -y 16 -m 2000000 -e 336218683  -c 2.2.14


### PR DESCRIPTION
the hash field is now always null