### PR TITLE
fd_txncache_set_is_constipated switch to write lock

### DIFF
--- a/src/flamenco/runtime/fd_txncache.c
+++ b/src/flamenco/runtime/fd_txncache.c
@@ -1174,11 +1174,11 @@ fd_txncache_get_is_constipated( fd_txncache_t * tc ) {
 
 int
 fd_txncache_set_is_constipated( fd_txncache_t * tc, int is_constipated ) {
-  fd_rwlock_read( tc->lock );
+  fd_rwlock_write( tc->lock );
 
   tc->is_constipated = is_constipated;
 
-  fd_rwlock_unread( tc->lock );
+  fd_rwlock_unwrite( tc->lock );
 
   return 0;
 }


### PR DESCRIPTION
Comment seems to indicate except for queries and insertions, other state modifications need a write lock:
```Insertion and querying only take a read lock as they can be done lockless but all other operations will take a write lock internally.```