### PR TITLE
quic - only increment pkt_number when we have committed the current packet into the tx buffer

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -3688,7 +3688,7 @@ fd_quic_conn_tx( fd_quic_t      * quic,
     /* get next packet number
        Returned to pool if not sent as gaps are harmful for ACK frame
        compression. */
-    ulong pkt_number = conn->pkt_number[pn_space]++;
+    ulong pkt_number = conn->pkt_number[pn_space];
     FD_QUIC_PKT_META_SET_PKT_NUM( pkt_meta_tmpl, pkt_number );
 
     /* are we the client initial packet? */
@@ -3895,6 +3895,9 @@ fd_quic_conn_tx( fd_quic_t      * quic,
 
     conn->tx_ptr += cipher_text_sz;
 #endif
+
+    /* we have committed the packet into the buffer, so inc pkt_number */
+    conn->pkt_number[pn_space]++;
 
     fd_quic_svc_schedule( state, conn, FD_QUIC_SVC_WAIT );
 


### PR DESCRIPTION
Current behavior causes gaps in packet numbers, leading to inefficient ack ranges, and difficulty with diagnostics.
This patch avoids most such skips.