### PR TITLE
quic: allocate conn after decrypt in handle_initial

### DIFF
--- a/src/waltz/quic/tests/test_quic_hs.c
+++ b/src/waltz/quic/tests/test_quic_hs.c
@@ -163,6 +163,8 @@ main( int argc, char ** argv ) {
     }
   }
 
+  FD_TEST( server_complete && client_complete );
+
   /* TODO detect missing QUIC transport params */
 
   /* TODO we get callback before the call to fd_quic_conn_new_stream can complete


### PR DESCRIPTION
This PR primarily addresses https://github.com/firedancer-io/firedancer/issues/5248 .  It refactors handle_v1_initial so that we don't allocate a connection too early, where it might need to be torn down anyway due to a decryption failure. It also closes a very low-sev attack vector that is currently open: If client A has an open connection that is still handshaking (server retains the initial enc keys), client B can tear down that connection by sending a malformed initial with the same destination connection ID. 

It also cleans up handle_initial. Should be soaked in mainnet for a while before merging. 