### PR TITLE
repair: improvements

### DIFF
--- a/src/flamenco/repair/Local.mk
+++ b/src/flamenco/repair/Local.mk
@@ -2,6 +2,6 @@ ifdef FD_HAS_INT128
 $(call add-hdrs,fd_repair.h)
 $(call add-objs,fd_repair,fd_flamenco)
 ifdef FD_HAS_HOSTED
-$(call make-bin,fd_repair_tool,fd_repair_tool,fd_flamenco fd_ballet fd_util)
+#$(call make-bin,fd_repair_tool,fd_repair_tool,fd_flamenco fd_ballet fd_util)
 endif
 endif

--- a/src/flamenco/repair/fd_repair.c
+++ b/src/flamenco/repair/fd_repair.c
@@ -21,22 +21,20 @@ fd_repair_new ( void * shmem, ulong seed ) {
   void * shm = FD_SCRATCH_ALLOC_APPEND( l, fd_active_table_align(), fd_active_table_footprint(FD_ACTIVE_KEY_MAX) );
   glob->actives = fd_active_table_join(fd_active_table_new(shm, FD_ACTIVE_KEY_MAX, seed));
   glob->seed = seed;
-  shm = FD_SCRATCH_ALLOC_APPEND( l, fd_needed_table_align(), fd_needed_table_footprint(FD_NEEDED_KEY_MAX) );
-  glob->needed = fd_needed_table_join(fd_needed_table_new(shm, FD_NEEDED_KEY_MAX, seed));
-  shm = FD_SCRATCH_ALLOC_APPEND( l, fd_dupdetect_table_align(), fd_dupdetect_table_footprint(FD_NEEDED_KEY_MAX) );
-  glob->dupdetect = fd_dupdetect_table_join(fd_dupdetect_table_new(shm, FD_NEEDED_KEY_MAX, seed));
+  shm = FD_SCRATCH_ALLOC_APPEND( l, fd_inflight_table_align(), fd_inflight_table_footprint(FD_NEEDED_KEY_MAX) );
+  glob->dupdetect = fd_inflight_table_join(fd_inflight_table_new(shm, FD_NEEDED_KEY_MAX, seed));
   shm = FD_SCRATCH_ALLOC_APPEND( l, fd_pinged_table_align(), fd_pinged_table_footprint(FD_REPAIR_PINGED_MAX) );
   glob->pinged = fd_pinged_table_join(fd_pinged_table_new(shm, FD_REPAIR_PINGED_MAX, seed));
   glob->stake_weights = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_stake_weight_t), FD_STAKE_WEIGHTS_MAX * sizeof(fd_stake_weight_t) );
   glob->stake_weights_cnt = 0;
-  glob->last_sends = 0;
   glob->last_decay = 0;
   glob->last_print = 0;
   glob->last_good_peer_cache_file_write = 0;
   glob->oldest_nonce = glob->current_nonce = glob->next_nonce = 0;
   fd_rng_new(glob->rng, (uint)seed, 0UL);
 
-  glob->actives_sticky_cnt   = 0;
+  glob->peer_cnt   = 0;
+  glob->peer_idx   = 0;
   glob->actives_random_seed  = 0;
 
   ulong scratch_top = FD_SCRATCH_ALLOC_FINI(l, 1UL);
@@ -57,8 +55,7 @@ void *
 fd_repair_delete ( void * shmap ) {
   fd_repair_t * glob = (fd_repair_t *)shmap;
   fd_active_table_delete( fd_active_table_leave( glob->actives ) );
-  fd_needed_table_delete( fd_needed_table_leave( glob->needed ) );
-  fd_dupdetect_table_delete( fd_dupdetect_table_leave( glob->dupdetect ) );
+  fd_inflight_table_delete( fd_inflight_table_leave( glob->dupdetect ) );
   fd_pinged_table_delete( fd_pinged_table_leave( glob->pinged ) );
   return glob;
 }
@@ -99,29 +96,22 @@ fd_repair_update_addr( fd_repair_t * glob, const fd_repair_peer_addr_t * intake_
 /* Initiate connection to a peer */
 int
 fd_repair_add_active_peer( fd_repair_t * glob, fd_repair_peer_addr_t const * addr, fd_pubkey_t const * id ) {
-  char tmp[100];
-  char keystr[ FD_BASE58_ENCODED_32_SZ ];
-  fd_base58_encode_32( id->uc, NULL, keystr );
-  FD_LOG_DEBUG(("adding active peer address %s key %s", fd_repair_addr_str(tmp, sizeof(tmp), addr), keystr));
-
   fd_active_elem_t * val = fd_active_table_query(glob->actives, id, NULL);
   if (val == NULL) {
-    if (fd_active_table_is_full(glob->actives)) {
-      FD_LOG_WARNING(("too many active repair peers, discarding new peer"));
-      return -1;
-    }
     val = fd_active_table_insert(glob->actives, id);
     fd_repair_peer_addr_copy(&val->addr, addr);
     val->avg_reqs = 0;
     val->avg_reps = 0;
     val->avg_lat = 0;
-    val->sticky = 0;
-    val->first_request_time = 0;
     val->stake = 0UL;
-    FD_LOG_DEBUG(( "adding repair peer %s", FD_BASE58_ENC_32_ALLOCA( val->key.uc ) ));
-  }
 
-  return 0;
+    glob->peers[ glob->peer_cnt++ ] = (fd_peer_t){
+      .key = *id,
+      .ip4 = *addr
+    };
+    return 0;
+  }
+  return 1;
 }
 
 /* Set the current protocol time in nanosecs */
@@ -239,7 +229,6 @@ fd_read_in_good_peer_cache_file( fd_repair_t * repair ) {
       FD_LOG_WARNING(( "Invalid IPv4 address '%s', skipping", ip_str ));
       continue;
     }
-    uint ip_addr = (uint)addr_parsed.s_addr;
 
     /* Convert the port */
     char * endptr = NULL;
@@ -250,14 +239,14 @@ fd_read_in_good_peer_cache_file( fd_repair_t * repair ) {
     }
 
     /* Create the peer address struct (byte-swap the port to network order). */
-    fd_repair_peer_addr_t peer_addr;
+    //fd_repair_peer_addr_t peer_addr;
     /* already in network byte order from inet_aton */
-    peer_addr.addr = ip_addr;
+    //peer_addr.addr = ip_addr;
     /* Flip to big-endian for network order */
-    peer_addr.port = fd_ushort_bswap( (ushort)port );
+    //peer_addr.port = fd_ushort_bswap( (ushort)port );
 
     /* Add to active peers in the repair tile. */
-    fd_repair_add_active_peer( repair, &peer_addr, &pubkey );
+   // fd_repair_add_active_peer( repair, &peer_addr, &pubkey );
 
     loaded_peers++;
   }
@@ -276,7 +265,6 @@ fd_repair_start( fd_repair_t * glob ) {
 }
 
 static void fd_repair_print_all_stats( fd_repair_t * glob );
-static void fd_actives_shuffle( fd_repair_t * repair );
 static int fd_write_good_peer_cache_file( fd_repair_t * repair );
 
 /* Dispatch timed events and other protocol behavior. This should be
@@ -286,11 +274,9 @@ fd_repair_continue( fd_repair_t * glob ) {
   if ( glob->now - glob->last_print > (long)30e9 ) { /* 30 seconds */
     fd_repair_print_all_stats( glob );
     glob->last_print = glob->now;
-    fd_actives_shuffle( glob );
     fd_repair_decay_stats( glob );
     glob->last_decay = glob->now;
   } else if ( glob->now - glob->last_decay > (long)15e9 ) { /* 15 seconds */
-    fd_actives_shuffle( glob );
     fd_repair_decay_stats( glob );
     glob->last_decay = glob->now;
   } else if ( glob->now - glob->last_good_peer_cache_file_write > (long)60e9 ) { /* 1 minute */
@@ -300,281 +286,107 @@ fd_repair_continue( fd_repair_t * glob ) {
   return 0;
 }
 
-
 int
-fd_repair_is_full( fd_repair_t * glob ) {
-  return fd_needed_table_is_full(glob->needed);
+fd_repair_construct_request_protocol( fd_repair_t          * glob,
+                                      fd_repair_protocol_t * protocol,
+                                      enum fd_needed_elem_type type,
+                                      ulong                  slot,
+                                      uint                   shred_index,
+                                      fd_pubkey_t const    * recipient,
+                                      uint                   nonce,
+                                      long                   now ) {
+  switch( type ) {
+    case fd_needed_window_index: {
+      glob->metrics.sent_pkt_types[FD_METRICS_ENUM_REPAIR_SENT_REQUEST_TYPES_V_NEEDED_WINDOW_IDX]++;
+      fd_repair_protocol_new_disc(protocol, fd_repair_protocol_enum_window_index);
+      fd_repair_window_index_t * wi = &protocol->inner.window_index;
+      wi->header.sender = *glob->public_key;
+      wi->header.recipient = *recipient;
+      wi->header.timestamp = (ulong)now/1000000L;
+      wi->header.nonce = nonce;
+      wi->slot = slot;
+      wi->shred_index = shred_index;
+        //FD_LOG_INFO(( "repair request for %lu, %lu", wi->slot, wi->shred_index ));
+      return 1;
+    }
+
+    case fd_needed_highest_window_index: {
+      glob->metrics.sent_pkt_types[FD_METRICS_ENUM_REPAIR_SENT_REQUEST_TYPES_V_NEEDED_HIGHEST_WINDOW_IDX]++;
+      fd_repair_protocol_new_disc( protocol, fd_repair_protocol_enum_highest_window_index );
+      fd_repair_highest_window_index_t * wi = &protocol->inner.highest_window_index;
+      wi->header.sender = *glob->public_key;
+      wi->header.recipient = *recipient;
+      wi->header.timestamp = (ulong)now/1000000L;
+      wi->header.nonce = nonce;
+      wi->slot = slot;
+      wi->shred_index = shred_index;
+      //FD_LOG_INFO(( "repair request for %lu, %lu", wi->slot, wi->shred_index ));
+      return 1;
+    }
+
+    case fd_needed_orphan: {
+      glob->metrics.sent_pkt_types[FD_METRICS_ENUM_REPAIR_SENT_REQUEST_TYPES_V_NEEDED_ORPHAN_IDX]++;
+      fd_repair_protocol_new_disc( protocol, fd_repair_protocol_enum_orphan );
+      fd_repair_orphan_t * wi = &protocol->inner.orphan;
+      wi->header.sender = *glob->public_key;
+      wi->header.recipient = *recipient;
+      wi->header.timestamp = (ulong)now/1000000L;
+      wi->header.nonce = nonce;
+      wi->slot = slot;
+      //FD_LOG_INFO(( "repair request for %lu", ele->dupkey.slot));
+      return 1;
+    }
+  }
+  return 0;
 }
 
-/* Test if a peer is good. Returns 1 if the peer is "great", 0 if the peer is "good", and -1 if the peer sucks */
+/* Returns 1 if its valid to send a request for the given shred. 0 if
+   it is not, i.e., there is an inflight request for it that was sent
+   within the last x ms. */
 static int
-is_good_peer( fd_active_elem_t * val ) {
-  if( FD_UNLIKELY( NULL == val ) ) return -1;                          /* Very bad */
-  if( val->avg_reqs > 10U && val->avg_reps == 0U )  return -1;         /* Bad, no response after 10 requests */
-  if( val->avg_reqs < 20U ) return 0;                                  /* Not sure yet, good enough for now */
-  if( (float)val->avg_reps < 0.01f*((float)val->avg_reqs) ) return -1; /* Very bad */
-  if( (float)val->avg_reps < 0.8f*((float)val->avg_reqs) ) return 0;   /* 80%, Good but not great */
-  if( (float)val->avg_lat > 2500e9f*((float)val->avg_reps) ) return 0;  /* 300ms, Good but not great */
-  return 1;                                                            /* Great! */
-}
-
-#define SORT_NAME        fd_latency_sort
-#define SORT_KEY_T       long
-#define SORT_BEFORE(a,b) (a)<(b)
-#include "../../util/tmpl/fd_sort.c"
-
-static void
-fd_actives_shuffle( fd_repair_t * repair ) {
-  /* Since we now have stake weights very quickly after reading the manifest, we wait
-     until we have the stake weights before we start repairing. This ensures that we always
-     sample from the available peers using stake weights. */
-  if( repair->stake_weights_cnt == 0 ) {
-    FD_LOG_NOTICE(( "repair does not have stake weights yet, not selecting any sticky peers" ));
-    return;
-  }
-
-  FD_SCRATCH_SCOPE_BEGIN {
-    ulong prev_sticky_cnt = repair->actives_sticky_cnt;
-    /* Find all the usable stake holders */
-    fd_active_elem_t ** leftovers = fd_scratch_alloc(
-        alignof( fd_active_elem_t * ),
-        sizeof( fd_active_elem_t * ) * repair->stake_weights_cnt );
-    ulong leftovers_cnt = 0;
-
-    ulong total_stake = 0UL;
-    if( repair->stake_weights_cnt==0 ) {
-      leftovers = fd_scratch_alloc(
-        alignof( fd_active_elem_t * ),
-        sizeof( fd_active_elem_t * ) * fd_active_table_key_cnt( repair->actives ) );
-
-      for( fd_active_table_iter_t iter = fd_active_table_iter_init( repair->actives );
-         !fd_active_table_iter_done( repair->actives, iter );
-         iter = fd_active_table_iter_next( repair->actives, iter ) ) {
-        fd_active_elem_t * peer = fd_active_table_iter_ele( repair->actives, iter );
-        if( peer->sticky ) continue;
-        leftovers[leftovers_cnt++] = peer;
-      }
-    } else {
-      leftovers = fd_scratch_alloc(
-        alignof( fd_active_elem_t * ),
-        sizeof( fd_active_elem_t * ) * repair->stake_weights_cnt );
-
-      for( ulong i = 0; i < repair->stake_weights_cnt; i++ ) {
-        fd_stake_weight_t const * stake_weight = &repair->stake_weights[i];
-        ulong stake = stake_weight->stake;
-        if( !stake ) continue;
-        fd_pubkey_t const * key = &stake_weight->key;
-        fd_active_elem_t * peer = fd_active_table_query( repair->actives, key, NULL );
-        if( peer!=NULL ) {
-          peer->stake = stake;
-          total_stake = fd_ulong_sat_add( total_stake, stake );
-        }
-        if( NULL == peer || peer->sticky ) continue;
-        leftovers[leftovers_cnt++] = peer;
-      }
-    }
-
-    fd_active_elem_t * best[FD_REPAIR_STICKY_MAX];
-    ulong              best_cnt = 0;
-    fd_active_elem_t * good[FD_REPAIR_STICKY_MAX];
-    ulong              good_cnt = 0;
-
-    long  latencies[ FD_REPAIR_STICKY_MAX ];
-    ulong latencies_cnt = 0UL;
-
-    long first_quartile_latency = LONG_MAX;
-
-    /* fetch all latencies */
-    for( fd_active_table_iter_t iter = fd_active_table_iter_init( repair->actives );
-            !fd_active_table_iter_done( repair->actives, iter );
-            iter = fd_active_table_iter_next( repair->actives, iter ) ) {
-            fd_active_elem_t * peer = fd_active_table_iter_ele( repair->actives, iter );
-
-      if( !peer->sticky ) {
-        continue;
-      }
-
-      if( peer->avg_lat==0L || peer->avg_reps==0UL ) {
-        continue;
-      }
-
-      latencies[ latencies_cnt++ ] = peer->avg_lat/(long)peer->avg_reps;
-    }
-
-    if( latencies_cnt >= 4 ) {
-      /* we probably want a few peers before sorting and pruning them based on
-         latency. */
-      fd_latency_sort_inplace( latencies, latencies_cnt );
-      first_quartile_latency = latencies[ latencies_cnt / 4UL ];
-      FD_LOG_NOTICE(( "repair peers first quartile latency - latency: %6.6f ms", (double)first_quartile_latency * 1e-6 ));
-    }
-
-    /* Build the new sticky peers set based on the latency and stake weight */
-
-    /* select an upper bound */
-    /* acceptable latency is 2 * first quartile latency  */
-    long acceptable_latency = first_quartile_latency != LONG_MAX ? 2L * first_quartile_latency : LONG_MAX;
-    for( fd_active_table_iter_t iter = fd_active_table_iter_init( repair->actives );
-         !fd_active_table_iter_done( repair->actives, iter );
-         iter = fd_active_table_iter_next( repair->actives, iter ) ) {
-      fd_active_elem_t * peer = fd_active_table_iter_ele( repair->actives, iter );
-      uchar sticky = peer->sticky;
-      peer->sticky = 0; /* Already clear the sticky bit */
-      if( sticky ) {
-        /* See if we still like this peer */
-        if( peer->avg_reps>0UL && ( peer->avg_lat/(long)peer->avg_reps ) >= acceptable_latency ) {
-          continue;
-        }
-        int r = is_good_peer( peer );
-        if( r == 1 ) best[best_cnt++] = peer;
-        else if( r == 0 ) good[good_cnt++] = peer;
-      }
-    }
-
-    ulong tot_cnt = 0;
-    for( ulong i = 0; i < best_cnt && tot_cnt < FD_REPAIR_STICKY_MAX - 2U; ++i ) {
-      repair->actives_sticky[tot_cnt++] = best[i]->key;
-      best[i]->sticky                       = (uchar)1;
-    }
-    for( ulong i = 0; i < good_cnt && tot_cnt < FD_REPAIR_STICKY_MAX - 2U; ++i ) {
-      repair->actives_sticky[tot_cnt++] = good[i]->key;
-      good[i]->sticky                       = (uchar)1;
-    }
-    if( leftovers_cnt ) {
-      /* Sample 64 new sticky peers using stake-weighted sampling */
-      for( ulong i = 0; i < 64 && tot_cnt < FD_REPAIR_STICKY_MAX && tot_cnt < fd_active_table_key_cnt( repair->actives ); ++i ) {
-        /* Generate a random amount of culmative stake at which to sample the peer */
-        ulong target_culm_stake = fd_rng_ulong( repair->rng ) % total_stake;
-
-        /* Iterate over the active peers until we find the randomly selected peer */
-        ulong culm_stake = 0UL;
-        fd_active_elem_t * peer = NULL;
-        for( fd_active_table_iter_t iter = fd_active_table_iter_init( repair->actives );
-          !fd_active_table_iter_done( repair->actives, iter );
-          iter = fd_active_table_iter_next( repair->actives, iter ) ) {
-            peer = fd_active_table_iter_ele( repair->actives, iter );
-            culm_stake = fd_ulong_sat_add( culm_stake, peer->stake );
-            if( FD_UNLIKELY(( culm_stake >= target_culm_stake )) ) {
-              break;
-            }
-        }
-
-        /* Select this peer as sticky */
-        if( FD_LIKELY(( peer && !peer->sticky )) ) {
-          repair->actives_sticky[tot_cnt++] = peer->key;
-          peer->sticky                      = (uchar)1;
-        }
-      }
-
-    }
-    repair->actives_sticky_cnt = tot_cnt;
-
-    FD_LOG_NOTICE(
-        ( "selected %lu (previously: %lu) peers for repair (best was %lu, good was %lu, leftovers was %lu) (nonce_diff: %u)",
-          tot_cnt,
-          prev_sticky_cnt,
-          best_cnt,
-          good_cnt,
-          leftovers_cnt,
-          repair->next_nonce - repair->current_nonce ) );
-  }
-  FD_SCRATCH_SCOPE_END;
-}
-
-static fd_active_elem_t *
-actives_sample( fd_repair_t * repair ) {
-  ulong seed = repair->actives_random_seed;
-  ulong actives_sticky_cnt = repair->actives_sticky_cnt;
-  while( actives_sticky_cnt ) {
-    seed += 774583887101UL;
-    fd_pubkey_t *      id   = &repair->actives_sticky[seed % actives_sticky_cnt];
-    fd_active_elem_t * peer = fd_active_table_query( repair->actives, id, NULL );
-    if( NULL != peer ) {
-      if( peer->first_request_time == 0U ) peer->first_request_time = repair->now;
-      /* Aggressively throw away bad peers */
-      if( repair->now - peer->first_request_time < (long)5e9 || /* Sample the peer for at least 5 seconds */
-          is_good_peer( peer ) != -1 ) {
-        repair->actives_random_seed = seed;
-        return peer;
-      }
-      peer->sticky = 0;
-    }
-    *id = repair->actives_sticky[--( actives_sticky_cnt )];
-  }
-  return NULL;
-}
-
-static int
-fd_repair_create_needed_request( fd_repair_t * glob, int type, ulong slot, uint shred_index ) {
+fd_repair_create_inflight_request( fd_repair_t * glob, int type, ulong slot, uint shred_index, long now ) {
 
   /* If there are no active sticky peers from which to send requests to, refresh the sticky peers
      selection. It may be that stake weights were not available before, and now they are. */
-  if ( glob->actives_sticky_cnt == 0 ) {
-    fd_actives_shuffle( glob );
-  }
 
-  fd_pubkey_t * ids[FD_REPAIR_NUM_NEEDED_PEERS] = {0};
-  uint found_peer = 0;
-  uint peer_cnt = fd_uint_min( (uint)glob->actives_sticky_cnt, FD_REPAIR_NUM_NEEDED_PEERS );
-  for( ulong i=0UL; i<peer_cnt; i++ ) {
-    fd_active_elem_t * peer = actives_sample( glob );
-    if(!peer) continue;
-    found_peer = 1;
+  fd_inflight_key_t    dupkey  = { .type = (enum fd_needed_elem_type)type, .slot = slot, .shred_index = shred_index };
+  fd_inflight_elem_t * dupelem = fd_inflight_table_query( glob->dupdetect, &dupkey, NULL );
 
-    ids[i] = &peer->key;
-  }
-
-  if (!found_peer) {
-    /* maybe atp we should just... send it. TODO: reevaluate wth testnet */
-
-    for( ulong i=0UL; i<peer_cnt; i++ ) {
-      fd_pubkey_t *      id   = &glob->actives_sticky[i];
-      fd_active_elem_t * peer = fd_active_table_query( glob->actives, id, NULL );
-      if( peer ){
-        peer->first_request_time = glob->now;
-      }
-    }
-
-    // Can guarantee found peers now! lol
-    for( ulong i=0UL; i<peer_cnt; i++ ) {
-      fd_active_elem_t * peer = actives_sample( glob );
-      if(!peer) continue;
-      ids[i] = &peer->key;
-    }
-    //
-    //return -1;
-  };
-
-  fd_dupdetect_key_t dupkey = { .type = (enum fd_needed_elem_type)type, .slot = slot, .shred_index = shred_index };
-  fd_dupdetect_elem_t * dupelem = fd_dupdetect_table_query( glob->dupdetect, &dupkey, NULL );
   if( dupelem == NULL ) {
-    dupelem = fd_dupdetect_table_insert( glob->dupdetect, &dupkey );
+    dupelem = fd_inflight_table_insert( glob->dupdetect, &dupkey );
+
+    if ( FD_UNLIKELY( dupelem == NULL ) ) {
+      FD_LOG_ERR(( "Eviction unimplemented. Failed to insert duplicate detection element for slot %lu, shred_index %u", slot, shred_index ));
+      return 0;
+    }
+
     dupelem->last_send_time = 0L;
-  } else if( ( dupelem->last_send_time+(long)20e6 )>glob->now ) {
-    // if last send time > now - 100ms. then we don't want to add another.
-
-    //FD_LOG_INFO(("deduped request for %lu, %u", slot, shred_index));
-    return 0;
   }
 
-  dupelem->last_send_time = glob->now;
-  dupelem->req_cnt = peer_cnt;
-
-  if (fd_needed_table_is_full(glob->needed)) {
-    FD_LOG_DEBUG(( "repair failed to get shred - slot: %lu, shred_index: %u, reason: %d", slot, shred_index, FD_REPAIR_DELIVER_FAIL_REQ_LIMIT_EXCEEDED ));
-    return -1;
+  if( FD_LIKELY( dupelem->last_send_time+(long)40e6  < now ) ) { /* 40ms */
+    dupelem->last_send_time = now;
+    dupelem->req_cnt        = FD_REPAIR_NUM_NEEDED_PEERS;
+    return 1;
   }
-  for( ulong i=0UL; i<fd_ulong_min( fd_needed_table_key_max( glob->needed ) - fd_needed_table_key_cnt( glob->needed ), peer_cnt ); i++ ) {
-    fd_repair_nonce_t key = glob->next_nonce++;
-    fd_needed_elem_t * val = fd_needed_table_insert(glob->needed, &key);
-    val->id = *ids[i];
-    val->dupkey = dupkey;
-    val->when = glob->now;
-  }
-  FD_LOG_INFO(("added request for %lu, %u", slot, shred_index));
-
   return 0;
 }
+
+int
+fd_repair_inflight_remove( fd_repair_t * glob,
+                           ulong         slot,
+                           uint          shred_index ) {
+  /* If we have a shred, we can remove it from the inflight table */
+  // FIXME: might be worth adding eviction logic here for orphan / highest window reqs
+
+  fd_inflight_key_t    dupkey  = { .type = fd_needed_window_index, .slot = slot, .shred_index = shred_index };
+  fd_inflight_elem_t * dupelem = fd_inflight_table_query( glob->dupdetect, &dupkey, NULL );
+  if( dupelem ) {
+    /* Remove the element from the inflight table */
+    fd_inflight_table_remove( glob->dupdetect, &dupkey );
+  }
+  return 0;
+}
+
 
 static int
 fd_write_good_peer_cache_file( fd_repair_t * repair ) {
@@ -636,19 +448,19 @@ fd_write_good_peer_cache_file( fd_repair_t * repair ) {
 int
 fd_repair_need_window_index( fd_repair_t * glob, ulong slot, uint shred_index ) {
   // FD_LOG_NOTICE(( "[%s] need window %lu, shred_index %u", __func__, slot, shred_index ));
-  return fd_repair_create_needed_request( glob, fd_needed_window_index, slot, shred_index );
+  return fd_repair_create_inflight_request( glob, fd_needed_window_index, slot, shred_index, glob->now );
 }
 
 int
 fd_repair_need_highest_window_index( fd_repair_t * glob, ulong slot, uint shred_index ) {
-  FD_LOG_DEBUG(( "[%s] need highest %lu", __func__, slot ));
-  return fd_repair_create_needed_request( glob, fd_needed_highest_window_index, slot, shred_index );
+  //FD_LOG_DEBUG(( "[%s] need highest %lu", __func__, slot ));
+  return fd_repair_create_inflight_request( glob, fd_needed_highest_window_index, slot, shred_index, glob->now );
 }
 
 int
 fd_repair_need_orphan( fd_repair_t * glob, ulong slot ) {
   // FD_LOG_NOTICE( ( "[repair] need orphan %lu", slot ) );
-  return fd_repair_create_needed_request( glob, fd_needed_orphan, slot, UINT_MAX );
+  return fd_repair_create_inflight_request( glob, fd_needed_orphan, slot, UINT_MAX, glob->now );
 }
 
 static void
@@ -674,7 +486,6 @@ fd_repair_print_all_stats( fd_repair_t * glob ) {
        !fd_active_table_iter_done( glob->actives, iter );
        iter = fd_active_table_iter_next( glob->actives, iter ) ) {
     fd_active_elem_t * val = fd_active_table_iter_ele( glob->actives, iter );
-    if( !val->sticky ) continue;
     print_stats( val );
   }
   FD_LOG_INFO( ( "peer count: %lu", fd_active_table_key_cnt( glob->actives ) ) );

--- a/src/flamenco/repair/fd_repair.h
+++ b/src/flamenco/repair/fd_repair.h
@@ -74,11 +74,11 @@ struct fd_active_elem {
     ulong next; /* used internally by fd_map_giant */
 
     fd_repair_peer_addr_t addr;
+    // Might be worth keeping these fields, but currently response rate is pretty high.
+    // latency could be a useful metric to keep track of.
     ulong avg_reqs; /* Moving average of the number of requests */
     ulong avg_reps; /* Moving average of the number of requests */
     long  avg_lat;  /* Moving average of response latency */
-    uchar sticky;
-    long  first_request_time;
     ulong stake;
 };
 /* Active table */
@@ -94,44 +94,44 @@ enum fd_needed_elem_type {
   fd_needed_window_index, fd_needed_highest_window_index, fd_needed_orphan
 };
 
-struct fd_dupdetect_key {
+struct fd_inflight_key {
   enum fd_needed_elem_type type;
   ulong slot;
   uint shred_index;
 };
-typedef struct fd_dupdetect_key fd_dupdetect_key_t;
+typedef struct fd_inflight_key fd_inflight_key_t;
 
-struct fd_dupdetect_elem {
-  fd_dupdetect_key_t key;
+struct fd_inflight_elem {
+  fd_inflight_key_t key;
   long               last_send_time;
   uint               req_cnt;
   ulong              next;
 };
-typedef struct fd_dupdetect_elem fd_dupdetect_elem_t;
+typedef struct fd_inflight_elem fd_inflight_elem_t;
 
 FD_FN_PURE static inline int
-fd_dupdetect_eq( const fd_dupdetect_key_t * key1, const fd_dupdetect_key_t * key2 ) {
+fd_inflight_eq( const fd_inflight_key_t * key1, const fd_inflight_key_t * key2 ) {
   return (key1->type == key2->type) &&
          (key1->slot == key2->slot) &&
          (key1->shred_index == key2->shred_index);
 }
 
 FD_FN_PURE static inline ulong
-fd_dupdetect_hash( const fd_dupdetect_key_t * key, ulong seed ) {
+fd_inflight_hash( const fd_inflight_key_t * key, ulong seed ) {
   return (key->slot + seed)*9540121337UL + key->shred_index*131U;
 }
 
 static inline void
-fd_dupdetect_copy( fd_dupdetect_key_t * keyd, const fd_dupdetect_key_t * keys ) {
+fd_inflight_copy( fd_inflight_key_t * keyd, const fd_inflight_key_t * keys ) {
   *keyd = *keys;
 }
 
-#define MAP_NAME     fd_dupdetect_table
-#define MAP_KEY_T    fd_dupdetect_key_t
-#define MAP_KEY_EQ   fd_dupdetect_eq
-#define MAP_KEY_HASH fd_dupdetect_hash
-#define MAP_KEY_COPY fd_dupdetect_copy
-#define MAP_T        fd_dupdetect_elem_t
+#define MAP_NAME     fd_inflight_table
+#define MAP_KEY_T    fd_inflight_key_t
+#define MAP_KEY_EQ   fd_inflight_eq
+#define MAP_KEY_HASH fd_inflight_hash
+#define MAP_KEY_COPY fd_inflight_copy
+#define MAP_T        fd_inflight_elem_t
 #include "../../util/tmpl/fd_map_giant.c"
 
 FD_FN_PURE static inline int
@@ -149,22 +149,6 @@ fd_repair_nonce_copy( fd_repair_nonce_t * keyd, const fd_repair_nonce_t * keys )
   *keyd = *keys;
 }
 
-struct fd_needed_elem {
-  fd_repair_nonce_t key;
-  ulong next;
-  fd_pubkey_t id;
-  fd_dupdetect_key_t dupkey;
-  long when;
-};
-typedef struct fd_needed_elem fd_needed_elem_t;
-#define MAP_NAME     fd_needed_table
-#define MAP_KEY_T    fd_repair_nonce_t
-#define MAP_KEY_EQ   fd_repair_nonce_eq
-#define MAP_KEY_HASH fd_repair_nonce_hash
-#define MAP_KEY_COPY fd_repair_nonce_copy
-#define MAP_T        fd_needed_elem_t
-#include "../../util/tmpl/fd_map_giant.c"
-
 struct fd_pinged_elem {
   fd_repair_peer_addr_t key;
   ulong next;
@@ -181,8 +165,11 @@ typedef struct fd_pinged_elem fd_pinged_elem_t;
 #define MAP_T        fd_pinged_elem_t
 #include "../../util/tmpl/fd_map_giant.c"
 
-/* Callbacks when a repair is requested. shred_idx==-1 means the last index. */
-
+struct fd_peer {
+  fd_pubkey_t   key;
+  fd_ip4_port_t ip4;
+};
+typedef struct fd_peer fd_peer_t;
 /* Repair Metrics */
 struct fd_repair_metrics {
   ulong recv_clnt_pkt;
@@ -211,13 +198,20 @@ struct fd_repair {
     void * fun_arg;
     /* Table of validators that we are actively pinging, keyed by repair address */
     fd_active_elem_t * actives;
+
+    /* TODO remove, along with good peer cache file */
     fd_pubkey_t actives_sticky[FD_REPAIR_STICKY_MAX]; /* cache of chosen repair peer samples */
     ulong       actives_sticky_cnt;
     ulong       actives_random_seed;
+
+    fd_peer_t peers[ FD_ACTIVE_KEY_MAX ];
+    ulong     peer_cnt; /* number of peers in the peers array */
+    ulong     peer_idx; /* max number of peers in the peers array */
+
     /* Duplicate request detection table */
-    fd_dupdetect_elem_t * dupdetect;
+    fd_inflight_elem_t * dupdetect;
+
     /* Table of needed shreds */
-    fd_needed_elem_t * needed;
     fd_repair_nonce_t oldest_nonce;
     fd_repair_nonce_t current_nonce;
     fd_repair_nonce_t next_nonce;
@@ -253,8 +247,7 @@ fd_repair_footprint( void ) {
   ulong l = FD_LAYOUT_INIT;
   l = FD_LAYOUT_APPEND( l, alignof(fd_repair_t), sizeof(fd_repair_t) );
   l = FD_LAYOUT_APPEND( l, fd_active_table_align(), fd_active_table_footprint(FD_ACTIVE_KEY_MAX) );
-  l = FD_LAYOUT_APPEND( l, fd_needed_table_align(), fd_needed_table_footprint(FD_NEEDED_KEY_MAX) );
-  l = FD_LAYOUT_APPEND( l, fd_dupdetect_table_align(), fd_dupdetect_table_footprint(FD_NEEDED_KEY_MAX) );
+  l = FD_LAYOUT_APPEND( l, fd_inflight_table_align(), fd_inflight_table_footprint(FD_NEEDED_KEY_MAX) );
   l = FD_LAYOUT_APPEND( l, fd_pinged_table_align(), fd_pinged_table_footprint(FD_REPAIR_PINGED_MAX) );
   l = FD_LAYOUT_APPEND( l, alignof(fd_stake_weight_t), FD_STAKE_WEIGHTS_MAX * sizeof(fd_stake_weight_t) );
   return FD_LAYOUT_FINI(l, fd_repair_align() );
@@ -299,8 +292,9 @@ int fd_repair_start( fd_repair_t * glob );
  * called inside the main spin loop. calling settime first is recommended. */
 int fd_repair_continue( fd_repair_t * glob );
 
-/* Determine if the request queue is full */
-int fd_repair_is_full( fd_repair_t * glob );
+int fd_repair_inflight_remove( fd_repair_t * glob,
+                               ulong         slot,
+                               uint          shred_index );
 
 /* Register a request for a shred */
 int fd_repair_need_window_index( fd_repair_t * glob, ulong slot, uint shred_index );
@@ -308,6 +302,16 @@ int fd_repair_need_window_index( fd_repair_t * glob, ulong slot, uint shred_inde
 int fd_repair_need_highest_window_index( fd_repair_t * glob, ulong slot, uint shred_index );
 
 int fd_repair_need_orphan( fd_repair_t * glob, ulong slot );
+
+int
+fd_repair_construct_request_protocol( fd_repair_t          * glob,
+                                      fd_repair_protocol_t * protocol,
+                                      enum fd_needed_elem_type type,
+                                      ulong                  slot,
+                                      uint                   shred_index,
+                                      fd_pubkey_t const    * recipient,
+                                      uint                   nonce,
+                                      long                   now );
 
 void fd_repair_add_sticky( fd_repair_t * glob, fd_pubkey_t const * id );
 


### PR DESCRIPTION
Series of repair improvements, mostly simplifying what we have
- takes response rate by peer from ~50% -> 95% (could later track rndtrip latency)
- benchmarked catchup handful of times::
       - pre-commit: takes > 400ms / slot to execute from snapshot to first turbine including repair stalls
       - post: takes ~200ms/slot to execute from snapshot to first turbine inclusing repair stalls
Also overall way less shred->repair backpressure