### PR TITLE
fix(fd_http_server): unsigned difference expression compared to zero

### DIFF
--- a/src/waltz/http/fd_http_server.c
+++ b/src/waltz/http/fd_http_server.c
@@ -939,12 +939,12 @@ write_conn_http( fd_http_server_t * http,
           http->ws_conns[ ws_conn_id ].send_frame_bytes_written = 0UL;
 
           FD_TEST( conn->request_bytes_read>=conn->request_bytes_len );
-          if( FD_UNLIKELY( conn->request_bytes_read-conn->request_bytes_len>0UL ) ) {
+          if( FD_UNLIKELY( conn->request_bytes_read > conn->request_bytes_len ) ) {
             /* Client might have already started sending data prior to
                response, so make sure to move it to the recv buffer. */
-            FD_TEST( conn->request_bytes_read-conn->request_bytes_len<=http->max_ws_recv_frame_len );
-            fd_memcpy( http->ws_conns[ ws_conn_id ].recv_bytes, conn->request_bytes+conn->request_bytes_len, conn->request_bytes_read-conn->request_bytes_len );
-            http->ws_conns[ ws_conn_id ].recv_bytes_read = conn->request_bytes_read-conn->request_bytes_len;
+            FD_TEST( conn->request_bytes_read - conn->request_bytes_len <= http->max_ws_recv_frame_len );
+            fd_memcpy( http->ws_conns[ ws_conn_id ].recv_bytes, conn->request_bytes + conn->request_bytes_len, conn->request_bytes_read - conn->request_bytes_len );
+            http->ws_conns[ ws_conn_id ].recv_bytes_read = conn->request_bytes_read - conn->request_bytes_len;
           }
 
 #if FD_HTTP_SERVER_DEBUG


### PR DESCRIPTION
https://github.com/firedancer-io/firedancer/blob/3515f7b462c3157e84b9a878617dd56d138dc0d0/src/waltz/http/fd_http_server.c#L942-L947

Fix the issue the comparison should be rewritten to avoid unsigned subtraction. Instead, directly compare the two unsigned integers using `>=` or `<` as appropriate. This ensures the logic is clear and avoids potential underflow issues.

The specific change is to replace the condition `conn->request_bytes_read - conn->request_bytes_len > 0UL` with `conn->request_bytes_read > conn->request_bytes_len`. This achieves the same logical result without relying on unsigned subtraction.


This rule finds relational comparisons between the result of an unsigned subtraction and the value 0. Such comparisons are likely to be wrong as the value of an unsigned subtraction can never be negative. So the relational comparison ends up checking whether the result of the subtraction is equal to 0. This is probably not what the programmer intended.

[INT02-C. Understand integer conversion rules](https://wiki.sei.cmu.edu/confluence/display/c/INT02-C.+Understand+integer+conversion+rules)
