### PR TITLE
bundle: increase buffer sizes

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -1657,7 +1657,7 @@ dynamic_port_range = "8900-9000"
         # This affects the size of various gRPC-related buffers,
         # including socket buffer sizes, the TLS buffer, the HTTP/2
         # frame buffer, and a Protobuf encode buffer.
-        buffer_size_kib = 1024
+        buffer_size_kib = 2048
 
         # SSL library heap size in MiB.
         #

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -1378,7 +1378,7 @@ user = ""
         # This affects the size of various gRPC-related buffers,
         # including socket buffer sizes, the TLS buffer, the HTTP/2
         # frame buffer, and a Protobuf encode buffer.
-        buffer_size_kib = 1024
+        buffer_size_kib = 2048
 
         # SSL library heap size in MiB.
         #

--- a/src/disco/bundle/fd_bundle_client.c
+++ b/src/disco/bundle/fd_bundle_client.c
@@ -152,7 +152,7 @@ fd_bundle_client_create_conn( fd_bundle_tile_t * ctx ) {
   }
 # endif /* FD_HAS_OPENSSL */
 
-  ctx->grpc_client = fd_grpc_client_new( ctx->grpc_client_mem, &fd_bundle_client_grpc_callbacks, ctx->grpc_metrics, ctx, ctx->map_seed );
+  ctx->grpc_client = fd_grpc_client_new( ctx->grpc_client_mem, &fd_bundle_client_grpc_callbacks, ctx->grpc_metrics, ctx, ctx->grpc_buf_max, ctx->map_seed );
   if( FD_UNLIKELY( !ctx->grpc_client ) ) {
     FD_LOG_CRIT(( "fd_grpc_client_new failed" )); /* unreachable */
   }

--- a/src/disco/bundle/fd_bundle_tile.c
+++ b/src/disco/bundle/fd_bundle_tile.c
@@ -25,9 +25,9 @@ FD_FN_CONST static ulong
 scratch_footprint( fd_topo_tile_t const * tile ) {
   (void)tile;
   ulong l = FD_LAYOUT_INIT;
-  l = FD_LAYOUT_APPEND( l, alignof(fd_bundle_tile_t), sizeof(fd_bundle_tile_t)   );
-  l = FD_LAYOUT_APPEND( l, fd_grpc_client_align(),    fd_grpc_client_footprint() );
-  l = FD_LAYOUT_APPEND( l, fd_alloc_align(),          fd_alloc_footprint()       );
+  l = FD_LAYOUT_APPEND( l, alignof(fd_bundle_tile_t), sizeof(fd_bundle_tile_t)                        );
+  l = FD_LAYOUT_APPEND( l, fd_grpc_client_align(),    fd_grpc_client_footprint( tile->bundle.buf_sz ) );
+  l = FD_LAYOUT_APPEND( l, fd_alloc_align(),          fd_alloc_footprint()                            );
   return FD_LAYOUT_FINI( l, 32 );
 }
 
@@ -359,9 +359,9 @@ privileged_init( fd_topo_t *      topo,
   void * scratch = fd_topo_obj_laddr( topo, tile->tile_obj_id );
 
   FD_SCRATCH_ALLOC_INIT( l, scratch );
-  fd_bundle_tile_t * ctx         = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_bundle_tile_t), sizeof(fd_bundle_tile_t)   );
-  void *             grpc_mem    = FD_SCRATCH_ALLOC_APPEND( l, fd_grpc_client_align(),    fd_grpc_client_footprint() );
-  void *             alloc_mem   = FD_SCRATCH_ALLOC_APPEND( l, fd_alloc_align(),          fd_alloc_footprint()       );
+  fd_bundle_tile_t * ctx         = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_bundle_tile_t), sizeof(fd_bundle_tile_t)                        );
+  void *             grpc_mem    = FD_SCRATCH_ALLOC_APPEND( l, fd_grpc_client_align(),    fd_grpc_client_footprint( tile->bundle.buf_sz ) );
+  void *             alloc_mem   = FD_SCRATCH_ALLOC_APPEND( l, fd_alloc_align(),          fd_alloc_footprint()                            );
   ulong              scratch_end = FD_SCRATCH_ALLOC_FINI( l, scratch_align() );
   (void)alloc_mem; /* potentially unused */
 
@@ -374,6 +374,7 @@ privileged_init( fd_topo_t *      topo,
 
   memset( ctx, 0, sizeof(fd_bundle_tile_t) );
   ctx->grpc_client_mem = grpc_mem;
+  ctx->grpc_buf_max    = tile->bundle.buf_sz;
   ctx->tcp_sock        = -1;
 
   fd_bundle_auther_init( &ctx->auther );

--- a/src/disco/bundle/fd_bundle_tile_private.h
+++ b/src/disco/bundle/fd_bundle_tile_private.h
@@ -86,6 +86,7 @@ struct fd_bundle_tile {
 
   /* gRPC client */
   void *                   grpc_client_mem;
+  ulong                    grpc_buf_max;
   fd_grpc_client_t *       grpc_client;
   fd_grpc_client_metrics_t grpc_metrics[1];
   ulong                    map_seed;

--- a/src/waltz/grpc/fd_grpc_client.h
+++ b/src/waltz/grpc/fd_grpc_client.h
@@ -13,21 +13,6 @@
 struct fd_grpc_client_private;
 typedef struct fd_grpc_client_private fd_grpc_client_t;
 
-/* FIXME don't hardcode these limits */
-
-/* FD_GRPC_CLIENT_MSG_SZ_MAX is the largest serialized Protobuf
-   message that grpc_client can handle.
-
-   FD_GRPC_CLIENT_BUFSZ, which sets the size of frame buffers wrapping
-   messages, is at least FD_GRPC_CLIENT_REQUEST_SZ_MAX bytes large,
-   plus FD_GRPC_CLIENT_BUFFER_SLACK bytes of "slack" for headers.
-
-   FIXME consider making these dynamic, and move them to the config file */
-
-#define FD_GRPC_CLIENT_MSG_SZ_MAX (1<<16) /* 64 KiB */
-#define FD_GRPC_CLIENT_BUFFER_SLACK (1<<12) /* 4 KiB */
-#define FD_GRPC_CLIENT_BUFSZ (FD_GRPC_CLIENT_MSG_SZ_MAX+FD_GRPC_CLIENT_BUFFER_SLACK)
-
 /* FD_GRPC_CLIENT_MAX_STREAMS specifies the max number of inflight
    unary and server-streaming requests.  Note that grpc_client does
    not scale well to large numbers due to O(n) algorithms. */
@@ -162,13 +147,14 @@ ulong
 fd_grpc_client_align( void );
 
 ulong
-fd_grpc_client_footprint( void );
+fd_grpc_client_footprint( ulong buf_max );
 
 fd_grpc_client_t *
 fd_grpc_client_new( void *                             mem,
                     fd_grpc_client_callbacks_t const * callbacks,
                     fd_grpc_client_metrics_t *         metrics,
                     void *                             app_ctx,
+                    ulong                              buf_max,
                     ulong                              rng_seed );
 
 void *

--- a/src/waltz/grpc/fd_grpc_client_private.h
+++ b/src/waltz/grpc/fd_grpc_client_private.h
@@ -17,10 +17,11 @@ struct fd_grpc_h2_stream {
   fd_grpc_resp_hdrs_t hdrs;
 
   /* Buffer an incoming gRPC message */
-  uchar msg_buf[ sizeof(fd_grpc_hdr_t)+FD_GRPC_CLIENT_MSG_SZ_MAX ];
-  uint  hdrs_received : 1;
-  ulong msg_buf_used; /* including header */
-  ulong msg_sz;       /* size of next message */
+  uchar * msg_buf;
+  ulong   msg_buf_max;
+  uint    hdrs_received : 1;
+  ulong   msg_buf_used; /* including header */
+  ulong   msg_sz;       /* size of next message */
 };
 
 typedef struct fd_grpc_h2_stream fd_grpc_h2_stream_t;
@@ -110,6 +111,7 @@ struct fd_grpc_client_private {
 
   /* Stream pool */
   fd_grpc_h2_stream_t * stream_pool;
+  uchar *               stream_bufs;
 
   /* Stream map */
   /* FIXME pull this into a fd_map_tiny.c? */
@@ -119,7 +121,15 @@ struct fd_grpc_client_private {
 
   /* Buffers */
   uchar * nanopb_tx;
+  ulong   nanopb_tx_max;
   uchar * frame_scratch;
+  ulong   frame_scratch_max;
+
+  /* Frame buffers */
+  uchar * frame_rx_buf;
+  ulong   frame_rx_buf_max;
+  uchar * frame_tx_buf;
+  ulong   frame_tx_buf_max;
 
   /* Version string */
   uchar version_len;
@@ -127,17 +137,5 @@ struct fd_grpc_client_private {
 
   fd_grpc_client_metrics_t * metrics;
 };
-
-struct fd_grpc_client_bufs {
-  /* Nanopb serialize buffer */
-  uchar nanopb_tx[ FD_GRPC_CLIENT_MSG_SZ_MAX ];
-
-  /* Frame buffers */
-  uchar frame_rx_buf[ FD_GRPC_CLIENT_BUFSZ ];
-  uchar frame_tx_buf[ FD_GRPC_CLIENT_BUFSZ ];
-  uchar frame_scratch[ FD_GRPC_CLIENT_BUFSZ ];
-};
-
-typedef struct fd_grpc_client_bufs fd_grpc_client_bufs_t;
 
 #endif /* HEADER_fd_src_waltz_grpc_fd_grpc_client_private_h */


### PR DESCRIPTION
Occasionally, Jito sends us a gRPC message about 800 kB large.

- Plumb through [development.bundle.buffer_size_kib] to every buffer
- Increase default to 2048 KiB

Thank you to Italo Casas for reporting this bug