### PR TITLE
flamenco, replay: lazy program cache insertion / reverification

### DIFF
--- a/src/app/ledger/main.c
+++ b/src/app/ledger/main.c
@@ -523,14 +523,6 @@ fd_ledger_main_setup( fd_ledger_args_t * args ) {
   fd_runtime_update_leaders( args->slot_ctx->bank, args->slot_ctx->slot, args->runtime_spad );
   fd_calculate_epoch_accounts_hash_values( args->slot_ctx );
 
-  fd_exec_para_cb_ctx_t exec_para_ctx = {
-    .func       = bpf_tpool_wrapper,
-    .para_arg_1 = args->tpool
-  };
-  fd_bpf_scan_and_create_bpf_program_cache_entry_para( args->slot_ctx,
-                                                       args->runtime_spad,
-                                                       &exec_para_ctx );
-
   /* After both snapshots have been loaded in, we can determine if we should
       start distributing rewards. */
 

--- a/src/discof/replay/fd_exec.h
+++ b/src/discof/replay/fd_exec.h
@@ -49,18 +49,6 @@ generate_hash_bank_msg( ulong                               task_infos_gaddr,
   hash_msg_out->slot             = curr_slot;
 }
 
-static inline void
-generate_bpf_scan_msg( ulong start_idx,
-                       ulong end_idx,
-                       ulong recs_gaddr,
-                       ulong is_bpf_gaddr,
-                       fd_runtime_public_bpf_scan_msg_t * scan_msg_out ) {
-  scan_msg_out->start_idx       = start_idx;
-  scan_msg_out->end_idx         = end_idx;
-  scan_msg_out->recs_gaddr      = recs_gaddr;
-  scan_msg_out->is_bpf_gaddr    = is_bpf_gaddr;
-}
-
 /* Execution tracking helpers */
 
 struct fd_slice_exec {

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -44,6 +44,11 @@ typedef int (* fd_exec_instr_fn_t)( fd_exec_instr_ctx_t * ctx );
 fd_exec_instr_fn_t
 fd_executor_lookup_native_precompile_program( fd_txn_account_t const * prog_acc );
 
+/* Returns 1 if the given pubkey matches one of the BPF loader v1/v2/v3/v4
+   program IDs, and 0 otherwise. */
+uchar
+fd_executor_pubkey_is_bpf_loader( fd_pubkey_t const * pubkey );
+
 int
 fd_executor_check_transactions( fd_exec_txn_ctx_t * txn_ctx );
 

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -596,6 +596,26 @@ fd_runtime_block_pre_execute_process_new_epoch( fd_exec_slot_ctx_t * slot_ctx,
                                                 fd_spad_t *          runtime_spad,
                                                 int *                is_epoch_boundary );
 
+/* This function is responsible for inserting fresh entries or updating existing entries in the program cache.
+   When the client boots up, the program cache is empty. As programs get invoked, this function is responsible
+   for verifying and inserting these programs into the cache. Additionally, this function performs reverification
+   checks for every existing program that is invoked after an epoch boundary once per program per epoch, and invalidates
+   any programs that fail reverification.
+
+   When the cluster's feature set changes at an epoch, there is a possibility that existing programs
+   fail new SBPF / ELF header checks. Therefore, after every epoch, we should reverify all programs
+   and update our program cache so that users cannot invoke those old programs. Since iterating through
+   all programs every single epoch is expensive, we adopt a lazy approach where we reverify programs as they
+   are referenced in transactions, since only a small subset of all programs are actually referenced at any
+   time. We also make sure each program is only verified once per epoch, so repeated executions of a
+   program within the same epoch will only trigger verification once at the very first invocation.
+
+   Note that ALUTs must be resolved because programs referenced in ALUTs can be invoked via CPI. */
+void
+fd_runtime_update_program_cache( fd_exec_slot_ctx_t * slot_ctx,
+                                 fd_txn_p_t const *   txn_p,
+                                 fd_spad_t *          runtime_spad );
+
 /* Debugging Tools ************************************************************/
 
 void

--- a/src/flamenco/runtime/fd_runtime_public.h
+++ b/src/flamenco/runtime/fd_runtime_public.h
@@ -13,7 +13,6 @@
 
 #define EXEC_NEW_TXN_SIG               (0x777777UL)
 #define EXEC_HASH_ACCS_SIG             (0x888888UL)
-#define EXEC_BPF_SCAN_SIG              (0x999991UL)
 #define EXEC_SNAP_HASH_ACCS_CNT_SIG    (0x191992UL)
 #define EXEC_SNAP_HASH_ACCS_GATHER_SIG (0x193992UL)
 
@@ -24,7 +23,6 @@
 #define FD_EXEC_STATE_NOT_BOOTED       (0xFFFFFFFFUL)
 #define FD_EXEC_STATE_BOOTED           (1<<1UL      )
 #define FD_EXEC_STATE_HASH_DONE        (1<<6UL      )
-#define FD_EXEC_STATE_BPF_SCAN_DONE    (1<<7UL      )
 #define FD_EXEC_STATE_SNAP_CNT_DONE    (1<<8UL      )
 #define FD_EXEC_STATE_SNAP_GATHER_DONE (1<<9UL      )
 
@@ -116,13 +114,6 @@ fd_exec_fseq_get_slot( ulong fseq ) {
   return (uint)(fseq >> 32UL);
 }
 
-static ulong FD_FN_UNUSED
-fd_exec_fseq_set_bpf_scan_done( ulong id ) {
-  ulong state = ((ulong)id << 32UL);
-  state      |= FD_EXEC_STATE_BPF_SCAN_DONE;
-  return state;
-}
-
 static uint FD_FN_UNUSED
 fd_exec_fseq_get_bpf_id( ulong fseq ) {
   return (uint)(fseq >> 32UL);
@@ -202,15 +193,6 @@ struct fd_runtime_public_hash_bank_msg {
   ulong slot;
 };
 typedef struct fd_runtime_public_hash_bank_msg fd_runtime_public_hash_bank_msg_t;
-
-struct fd_runtime_public_bpf_scan_msg {
-  ulong recs_gaddr;
-  ulong is_bpf_gaddr;
-  ulong cache_txn_gaddr;
-  ulong start_idx;
-  ulong end_idx;
-};
-typedef struct fd_runtime_public_bpf_scan_msg fd_runtime_public_bpf_scan_msg_t;
 
 struct fd_runtime_public_snap_hash_msg {
   ulong num_pairs_out_gaddr;

--- a/src/flamenco/runtime/program/Local.mk
+++ b/src/flamenco/runtime/program/Local.mk
@@ -47,4 +47,11 @@ $(call add-objs,fd_zk_elgamal_proof_program,fd_flamenco)
 
 $(call add-hdrs,fd_native_cpi.h)
 $(call add-objs,fd_native_cpi,fd_flamenco)
+
+### Tests
+ifdef FD_HAS_HOSTED
+$(call make-unit-test,test_program_cache,test_program_cache,fd_flamenco fd_ballet fd_util fd_funk)
+$(call run-unit-test,test_program_cache)
+endif
+
 endif

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.h
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.h
@@ -70,7 +70,7 @@ fd_deploy_program( fd_exec_instr_ctx_t * instr_ctx,
                    fd_spad_t *           spad );
 
 int
-fd_bpf_execute( fd_exec_instr_ctx_t * instr_ctx, fd_sbpf_validated_program_t * prog, uchar is_deprecated );
+fd_bpf_execute( fd_exec_instr_ctx_t * instr_ctx, fd_sbpf_validated_program_t const * prog, uchar is_deprecated );
 
 int
 fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * instr_ctx );

--- a/src/flamenco/runtime/program/fd_bpf_program_util.c
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.c
@@ -1,15 +1,19 @@
 #include "fd_bpf_program_util.h"
 #include "fd_bpf_loader_program.h"
 #include "fd_loader_v4_program.h"
-#include "../fd_acc_mgr.h"
-#include "../context/fd_exec_slot_ctx.h"
-#include "../../vm/syscall/fd_vm_syscall.h"
+#include "../sysvar/fd_sysvar_epoch_schedule.h"
 
 #include <assert.h>
 
 fd_sbpf_validated_program_t *
 fd_sbpf_validated_program_new( void * mem, fd_sbpf_elf_info_t const * elf_info ) {
   fd_sbpf_validated_program_t * validated_prog = (fd_sbpf_validated_program_t *)mem;
+
+  /* Last verified epoch */
+  validated_prog->last_epoch_verification_ran = ULONG_MAX;
+
+  /* Failed verification flag */
+  validated_prog->failed_verification = 0;
 
   ulong l = FD_LAYOUT_INIT;
 
@@ -56,35 +60,44 @@ fd_acc_mgr_cache_key( fd_pubkey_t const * pubkey ) {
 
 /* Similar to the below function, but gets the executable program content for the v4 loader.
    Unlike the v3 loader, the programdata is stored in a single program account. The program must
-   NOT be retracted to be added to the cache. */
-static int
-fd_bpf_get_executable_program_content_for_v4_loader( fd_txn_account_t      * program_acc,
-                                                     uchar const          ** program_data,
-                                                     ulong                 * program_data_len ) {
+   NOT be retracted to be added to the cache. Returns a pointer to the programdata on success,
+   and NULL on failure.
+
+   Reasons for failure include:
+   - The program state cannot be read from the account data or is in the `retracted` state. */
+static uchar const *
+fd_bpf_get_executable_program_content_for_v4_loader( fd_txn_account_t const * program_acc,
+                                                     ulong *                  program_data_len ) {
   int err;
 
   /* Get the current loader v4 state. This implicitly also checks the dlen. */
   fd_loader_v4_state_t const * state = fd_loader_v4_get_state( program_acc, &err );
   if( FD_UNLIKELY( err ) ) {
-    return -1;
+    return NULL;
   }
 
   /* The program must be deployed or finalized. */
   if( FD_UNLIKELY( fd_loader_v4_status_is_retracted( state ) ) ) {
-    return -1;
+    return NULL;
   }
 
-  *program_data     = program_acc->vt->get_data( program_acc ) + LOADER_V4_PROGRAM_DATA_OFFSET;
   *program_data_len = program_acc->vt->get_data_len( program_acc ) - LOADER_V4_PROGRAM_DATA_OFFSET;
-  return 0;
+  return program_acc->vt->get_data( program_acc ) + LOADER_V4_PROGRAM_DATA_OFFSET;
 }
 
-static int
-fd_bpf_get_executable_program_content_for_upgradeable_loader( fd_exec_slot_ctx_t *    slot_ctx,
-                                                              fd_txn_account_t *      program_acc,
-                                                              uchar const **          program_data,
-                                                              ulong *                 program_data_len,
-                                                              fd_spad_t *             runtime_spad ) {
+/* Gets the programdata for a v3 loader-owned account by decoding the account data
+   as well as the programdata account. Returns a pointer to the programdata on success,
+   and NULL on failure.
+
+   Reasons for failure include:
+   - The program account data cannot be decoded or is not in the `program` state.
+   - The programdata account is not large enough to hold at least `PROGRAMDATA_METADATA_SIZE` bytes. */
+static uchar const *
+fd_bpf_get_executable_program_content_for_upgradeable_loader( fd_funk_t const *        funk,
+                                                              fd_funk_txn_t const *    funk_txn,
+                                                              fd_txn_account_t const * program_acc,
+                                                              ulong *                  program_data_len,
+                                                              fd_spad_t *              runtime_spad ) {
   FD_TXN_ACCOUNT_DECL( programdata_acc );
 
   fd_bpf_upgradeable_loader_state_t * program_account_state =
@@ -94,19 +107,16 @@ fd_bpf_get_executable_program_content_for_upgradeable_loader( fd_exec_slot_ctx_t
       program_acc->vt->get_data_len( program_acc ),
       NULL );
   if( FD_UNLIKELY( !program_account_state ) ) {
-    return -1;
+    return NULL;
   }
   if( !fd_bpf_upgradeable_loader_state_is_program( program_account_state ) ) {
-    return -1;
+    return NULL;
   }
 
   fd_pubkey_t * programdata_address = &program_account_state->inner.program.programdata_address;
 
-  if( fd_txn_account_init_from_funk_readonly( programdata_acc,
-                                              programdata_address,
-                                              slot_ctx->funk,
-                                              slot_ctx->funk_txn ) != FD_ACC_MGR_SUCCESS ) {
-    return -1;
+  if( fd_txn_account_init_from_funk_readonly( programdata_acc, programdata_address, funk, funk_txn )!=FD_ACC_MGR_SUCCESS ) {
+    return NULL;
   }
 
   /* We don't actually need to decode here, just make sure that the account
@@ -118,25 +128,26 @@ fd_bpf_get_executable_program_content_for_upgradeable_loader( fd_exec_slot_ctx_t
 
   ulong total_sz = 0UL;
   if( FD_UNLIKELY( fd_bpf_upgradeable_loader_state_decode_footprint( &ctx_programdata, &total_sz ) ) ) {
-    return -1;
+    return NULL;
   }
 
   if( FD_UNLIKELY( programdata_acc->vt->get_data_len( programdata_acc )<PROGRAMDATA_METADATA_SIZE ) ) {
-    return -1;
+    return NULL;
   }
 
-  *program_data     = programdata_acc->vt->get_data( programdata_acc ) + PROGRAMDATA_METADATA_SIZE;
   *program_data_len = programdata_acc->vt->get_data_len( programdata_acc ) - PROGRAMDATA_METADATA_SIZE;
-  return 0;
+  return programdata_acc->vt->get_data( programdata_acc ) + PROGRAMDATA_METADATA_SIZE;
 }
 
-static int
-fd_bpf_get_executable_program_content_for_v1_v2_loaders( fd_txn_account_t * program_acc,
-                                                         uchar const     ** program_data,
-                                                         ulong            * program_data_len ) {
-  *program_data     = program_acc->vt->get_data( program_acc );
+/* Gets the programdata for a v1/v2 loader-owned account by returning a pointer to the account data.
+   Returns a pointer to the programdata on success. Given the txn account API always returns a handle
+   to the account data, this function should NEVER return NULL (since the programdata of v1 and v2 loader)
+   accounts start at the beginning of the data. */
+static uchar const *
+fd_bpf_get_executable_program_content_for_v1_v2_loaders( fd_txn_account_t const * program_acc,
+                                                         ulong *                  program_data_len ) {
   *program_data_len = program_acc->vt->get_data_len( program_acc );
-  return 0;
+  return program_acc->vt->get_data( program_acc );
 }
 
 void
@@ -163,53 +174,220 @@ fd_bpf_get_sbpf_versions( uint *                sbpf_min_version,
   }
 }
 
+uchar const *
+fd_bpf_get_programdata_from_account( fd_funk_t const *        funk,
+                                     fd_funk_txn_t const *    funk_txn,
+                                     fd_txn_account_t const * program_acc,
+                                     ulong *                  out_program_data_len,
+                                     fd_spad_t *              runtime_spad ) {
+  /* v1/v2 loaders: Programdata is just the account data.
+     v3 loader: Programdata lives in a separate account. Deserialize the program account
+                and lookup the programdata account. Deserialize the programdata account.
+     v4 loader: Programdata lives in the program account, offset by LOADER_V4_PROGRAM_DATA_OFFSET. */
+  if( !memcmp( program_acc->vt->get_owner( program_acc ), fd_solana_bpf_loader_upgradeable_program_id.key, sizeof(fd_pubkey_t) ) ) {
+    return fd_bpf_get_executable_program_content_for_upgradeable_loader( funk, funk_txn, program_acc, out_program_data_len, runtime_spad );
+  } else if( !memcmp( program_acc->vt->get_owner( program_acc ), fd_solana_bpf_loader_v4_program_id.key, sizeof(fd_pubkey_t) ) ) {
+    return fd_bpf_get_executable_program_content_for_v4_loader( program_acc, out_program_data_len );
+  } else if( !memcmp( program_acc->vt->get_owner( program_acc ), fd_solana_bpf_loader_program_id.key, sizeof(fd_pubkey_t) ) ||
+             !memcmp( program_acc->vt->get_owner( program_acc ), fd_solana_bpf_loader_deprecated_program_id.key, sizeof(fd_pubkey_t) ) ) {
+    return fd_bpf_get_executable_program_content_for_v1_v2_loaders( program_acc, out_program_data_len );
+  }
+  return NULL;
+}
+
+/* Parse ELF info from programdata. */
 static int
-fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t *    slot_ctx,
-                                       fd_txn_account_t *      program_acc,
-                                       fd_spad_t *             runtime_spad ) {
+fd_bpf_parse_elf_info( fd_sbpf_elf_info_t *       elf_info,
+                       uchar const *              program_data,
+                       ulong                      program_data_len,
+                       fd_exec_slot_ctx_t const * slot_ctx ) {
+  uint min_sbpf_version, max_sbpf_version;
+  fd_bpf_get_sbpf_versions( &min_sbpf_version,
+                            &max_sbpf_version,
+                            slot_ctx->slot,
+                            fd_bank_features_query( slot_ctx->bank ) );
+  if( FD_UNLIKELY( !fd_sbpf_elf_peek( elf_info, program_data, program_data_len, /* deploy checks */ 0, min_sbpf_version, max_sbpf_version ) ) ) {
+    FD_LOG_DEBUG(( "fd_sbpf_elf_peek() failed: %s", fd_sbpf_strerror() ));
+    return -1;
+  }
+  return 0;
+}
+
+/* This function is used to validate an sBPF program and set the program's flags accordingly. The return
+   code only signifies whether the program was successfully validated or not. Regardless of the return code,
+   the program should still be added to the cache. `validated_prog` is expected to be a pre-allocated struct with
+   enough space to hold its field members + calldests info.
+
+   Reasons for failure include:
+   - Insufficient memory in the spad to allocate memory for local objects.
+   - The sBPF program fails to be loaded or validated validated.
+
+   On a failure that doesn't kill the client, the `failed_verification` flag for the record is set to 1.
+
+   On success, `validated_prog` is updated with the loaded sBPF program metadata, as well as the `last_verified_epoch`
+   and `failed_verification` flags. */
+static int
+fd_bpf_validate_sbpf_program( fd_exec_slot_ctx_t const *    slot_ctx,
+                              fd_sbpf_elf_info_t const *    elf_info,
+                              uchar const *                 program_data,
+                              ulong                         program_data_len,
+                              fd_spad_t *                   runtime_spad,
+                              fd_sbpf_validated_program_t * validated_prog /* out */ ) {
+  /* Mark the program as validated for this epoch. */
+
+  fd_epoch_schedule_t const * epoch_schedule = fd_bank_epoch_schedule_query( slot_ctx->bank );
+  validated_prog->last_epoch_verification_ran = fd_slot_to_epoch( epoch_schedule,
+                                                                  slot_ctx->slot,
+                                                                  NULL );
+
+  ulong               prog_align     = fd_sbpf_program_align();
+  ulong               prog_footprint = fd_sbpf_program_footprint( elf_info );
+  fd_sbpf_program_t * prog           = fd_sbpf_program_new(  fd_spad_alloc( runtime_spad, prog_align, prog_footprint ), elf_info, validated_prog->rodata );
+  if( FD_UNLIKELY( !prog ) ) {
+    validated_prog->failed_verification = 1;
+    return -1;
+  }
+
+  /* Allocate syscalls */
+
+  fd_sbpf_syscalls_t * syscalls = fd_sbpf_syscalls_new( fd_spad_alloc( runtime_spad, fd_sbpf_syscalls_align(), fd_sbpf_syscalls_footprint() ) );
+  if( FD_UNLIKELY( !syscalls ) ) {
+    FD_LOG_CRIT(( "Call to fd_sbpf_syscalls_new() failed" ));
+  }
+
+  fd_vm_syscall_register_slot( syscalls,
+                               slot_ctx->slot,
+                               fd_bank_features_query( slot_ctx->bank ),
+                               0 );
+
+  /* Load program. */
+
+  if( FD_UNLIKELY( 0!=fd_sbpf_program_load( prog, program_data, program_data_len, syscalls, false ) ) ) {
+    FD_LOG_DEBUG(( "fd_sbpf_program_load() failed: %s", fd_sbpf_strerror() ));
+    validated_prog->failed_verification = 1;
+    return -1;
+  }
+
+  /* Validate the program. */
+
+  fd_vm_t _vm[ 1UL ];
+  fd_vm_t * vm = fd_vm_join( fd_vm_new( _vm ) );
+  if( FD_UNLIKELY( !vm ) ) {
+    FD_LOG_CRIT(( "fd_vm_new() or fd_vm_join() failed" ));
+  }
+
+  int direct_mapping = FD_FEATURE_ACTIVE( slot_ctx->slot, fd_bank_features_query( slot_ctx->bank ), bpf_account_data_direct_mapping );
+
+  vm = fd_vm_init( vm,
+                   NULL, /* OK since unused in `fd_vm_validate()` */
+                   0UL,
+                   0UL,
+                   prog->rodata,
+                   prog->rodata_sz,
+                   prog->text,
+                   prog->text_cnt,
+                   prog->text_off,
+                   prog->text_sz,
+                   prog->entry_pc,
+                   prog->calldests,
+                   elf_info->sbpf_version,
+                   syscalls,
+                   NULL,
+                   NULL,
+                   NULL,
+                   0U,
+                   NULL,
+                   0,
+                   direct_mapping,
+                   0 );
+
+  if( FD_UNLIKELY( !vm ) ) {
+    FD_LOG_CRIT(( "fd_vm_init() failed" ));
+  }
+
+  int res = fd_vm_validate( vm );
+  if( FD_UNLIKELY( res ) ) {
+    FD_LOG_DEBUG(( "fd_vm_validate() failed" ));
+    validated_prog->failed_verification = 1;
+    return -1;
+  }
+
+  /* FIXME: Super expensive memcpy. */
+  fd_memcpy( validated_prog->calldests_shmem, prog->calldests_shmem, fd_sbpf_calldests_footprint( prog->rodata_sz/8UL ) );
+
+  validated_prog->calldests           = fd_sbpf_calldests_join( validated_prog->calldests_shmem );
+  validated_prog->entry_pc            = prog->entry_pc;
+  validated_prog->text_off            = prog->text_off;
+  validated_prog->text_cnt            = prog->text_cnt;
+  validated_prog->text_sz             = prog->text_sz;
+  validated_prog->rodata_sz           = prog->rodata_sz;
+  validated_prog->failed_verification = 0;
+
+  return 0;
+}
+
+/* Publishes an in-prepare funk record for a program that failed verification. Creates a default
+   sBPF validated program with the `failed_verification` flag set to 1. The passed-in funk record
+   is expected to be in a prepare. */
+static void
+fd_publish_failed_verification_rec( fd_funk_t *             funk,
+                                    fd_funk_rec_prepare_t * prepare,
+                                    fd_funk_rec_t *         rec ) {
+  /* Truncate the record to have a minimal footprint */
+  fd_sbpf_elf_info_t elf_info = {0};
+  ulong record_sz = fd_sbpf_validated_program_footprint( &elf_info );
+  void * data = fd_funk_val_truncate( rec, fd_funk_alloc( funk ), fd_funk_wksp( funk ), 0UL, record_sz, NULL );
+  if( FD_UNLIKELY( data==NULL ) ) {
+    FD_LOG_ERR(( "fd_funk_val_truncate() failed to truncate record to size %lu", record_sz ));
+  }
+
+  /* Initialize the validated program to default values. This is fine because the `failed_verification` flag indicates
+     that the should not be executed. */
+  fd_sbpf_validated_program_t * validated_prog = fd_sbpf_validated_program_new( data, &elf_info );
+  validated_prog->failed_verification = 1;
+
+  fd_funk_rec_publish( funk, prepare );
+}
+
+/* Validates an SBPF program and adds it to the program cache. Verification failure reasons include:
+   - The programdata cannot be read from the account or programdata account
+   - The ELF info cannot be parsed from the programdata.
+   - The sBPF program fails to be validated.
+
+   The program will still be added to the cache even if verifications fail. This is to prevent a DOS
+   vector where an attacker could spam invocations to programs that failed verification. */
+static void
+fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t *     slot_ctx,
+                                       fd_txn_account_t const * program_acc,
+                                       fd_spad_t *              runtime_spad ) {
   FD_SPAD_FRAME_BEGIN( runtime_spad ) {
 
-    fd_pubkey_t * program_pubkey = program_acc->pubkey;
-
-    fd_funk_t     *   funk             = slot_ctx->funk;
+    /* Prepare the funk record for the program cache. */
+    fd_pubkey_t const * program_pubkey = program_acc->pubkey;
+    fd_funk_t *       funk             = slot_ctx->funk;
     fd_funk_txn_t *   funk_txn         = slot_ctx->funk_txn;
     fd_funk_rec_key_t id               = fd_acc_mgr_cache_key( program_pubkey );
 
-    uchar const *     program_data     = NULL;
-    ulong             program_data_len = 0UL;
-
-    /* For v3 loaders, deserialize the program account and lookup the
-       programdata account. Deserialize the programdata account. */
-
-    int res;
-    if( !memcmp( program_acc->vt->get_owner( program_acc ), fd_solana_bpf_loader_upgradeable_program_id.key, sizeof(fd_pubkey_t) ) ) {
-      res = fd_bpf_get_executable_program_content_for_upgradeable_loader( slot_ctx, program_acc, &program_data, &program_data_len, runtime_spad );
-    } else if( !memcmp( program_acc->vt->get_owner( program_acc ), fd_solana_bpf_loader_v4_program_id.key, sizeof(fd_pubkey_t) ) ) {
-      res = fd_bpf_get_executable_program_content_for_v4_loader( program_acc, &program_data, &program_data_len );
-    } else {
-      res = fd_bpf_get_executable_program_content_for_v1_v2_loaders( program_acc, &program_data, &program_data_len );
+    /* This prepare should never fail. */
+    int funk_err = FD_FUNK_SUCCESS;
+    fd_funk_rec_prepare_t prepare[1];
+    fd_funk_rec_t * rec = fd_funk_rec_prepare( funk, funk_txn, &id, prepare, &funk_err );
+    if( rec == NULL || funk_err != FD_FUNK_SUCCESS ) {
+      FD_LOG_CRIT(( "fd_funk_rec_prepare() failed: %i-%s", funk_err, fd_funk_strerror( funk_err ) ));
     }
 
-    if( res ) {
-      return -1;
+    ulong         program_data_len = 0UL;
+    uchar const * program_data     = fd_bpf_get_programdata_from_account( funk, funk_txn, program_acc, &program_data_len, runtime_spad );
+
+    if( FD_UNLIKELY( program_data==NULL ) ) {
+      fd_publish_failed_verification_rec( funk, prepare, rec );
+      return;
     }
 
     fd_sbpf_elf_info_t elf_info = {0};
-    uint min_sbpf_version, max_sbpf_version;
-    fd_bpf_get_sbpf_versions( &min_sbpf_version,
-                              &max_sbpf_version,
-                              slot_ctx->slot,
-                              fd_bank_features_query( slot_ctx->bank ) );
-    if( fd_sbpf_elf_peek( &elf_info, program_data, program_data_len, /* deploy checks */ 0, min_sbpf_version, max_sbpf_version ) == NULL ) {
-      FD_LOG_DEBUG(( "fd_sbpf_elf_peek() failed: %s", fd_sbpf_strerror() ));
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
-    }
-
-    int funk_err = FD_FUNK_SUCCESS;
-    fd_funk_rec_prepare_t prepare[1];
-    fd_funk_rec_t * rec = fd_funk_rec_prepare( funk, funk_txn, &id, prepare, NULL );
-    if( rec == NULL || funk_err != FD_FUNK_SUCCESS ) {
-      return -1;
+    if( FD_UNLIKELY( fd_bpf_parse_elf_info( &elf_info, program_data, program_data_len, slot_ctx ) ) ) {
+      fd_publish_failed_verification_rec( funk, prepare, rec );
+      return;
     }
 
     ulong val_sz = fd_sbpf_validated_program_footprint( &elf_info );
@@ -224,103 +402,15 @@ fd_bpf_create_bpf_program_cache_entry( fd_exec_slot_ctx_t *    slot_ctx,
       FD_LOG_ERR(( "fd_funk_val_truncate(sz=%lu) for account failed (%i-%s)", val_sz, funk_err, fd_funk_strerror( funk_err ) ));
     }
 
+    /* Note that the validated program points to the funk record data and writes into the record directly to avoid an expensive memcpy. */
     fd_sbpf_validated_program_t * validated_prog = fd_sbpf_validated_program_new( val, &elf_info );
-
-    ulong  prog_align     = fd_sbpf_program_align();
-    ulong  prog_footprint = fd_sbpf_program_footprint( &elf_info );
-    fd_sbpf_program_t * prog = fd_sbpf_program_new(  fd_spad_alloc( runtime_spad, prog_align, prog_footprint ), &elf_info, validated_prog->rodata );
-    if( FD_UNLIKELY( !prog ) ) {
-      fd_funk_rec_cancel( funk, prepare );
-      return -1;
-    }
-
-    /* Allocate syscalls */
-
-    fd_sbpf_syscalls_t * syscalls = fd_sbpf_syscalls_new( fd_spad_alloc( runtime_spad, fd_sbpf_syscalls_align(), fd_sbpf_syscalls_footprint() ) );
-    if( FD_UNLIKELY( !syscalls ) ) {
-      FD_LOG_ERR(( "Call to fd_sbpf_syscalls_new() failed" ));
-    }
-
-    fd_vm_syscall_register_slot( syscalls,
-                                 slot_ctx->slot,
-                                 fd_bank_features_query( slot_ctx->bank ),
-                                 0 );
-
-    /* Load program. */
-
-    if( FD_UNLIKELY( 0!=fd_sbpf_program_load( prog, program_data, program_data_len, syscalls, false ) ) ) {
-      /* Remove pending funk record */
-      FD_LOG_DEBUG(( "fd_sbpf_program_load() failed: %s", fd_sbpf_strerror() ));
-      fd_funk_rec_cancel( funk, prepare );
-      return -1;
-    }
-
-    /* Validate the program. */
-
-    fd_vm_t _vm[ 1UL ];
-    fd_vm_t * vm = fd_vm_join( fd_vm_new( _vm ) );
-    if( FD_UNLIKELY( !vm ) ) {
-      FD_LOG_ERR(( "fd_vm_new() or fd_vm_join() failed" ));
-    }
-    fd_exec_instr_ctx_t dummy_instr_ctx = {0};
-    fd_exec_txn_ctx_t   dummy_txn_ctx   = {0};
-    dummy_txn_ctx.slot = slot_ctx->slot;
-
-    if( FD_UNLIKELY( !slot_ctx->bank ) ) {
-      /* We only handle this case for some unit tests. */
-      dummy_txn_ctx.features = (fd_features_t){0};
-    } else {
-      dummy_txn_ctx.features = fd_bank_features_get( slot_ctx->bank );
-    }
-    dummy_instr_ctx.txn_ctx  = &dummy_txn_ctx;
-    vm = fd_vm_init( vm,
-                     &dummy_instr_ctx,
-                     0UL,
-                     0UL,
-                     prog->rodata,
-                     prog->rodata_sz,
-                     prog->text,
-                     prog->text_cnt,
-                     prog->text_off,
-                     prog->text_sz,
-                     prog->entry_pc,
-                     prog->calldests,
-                     elf_info.sbpf_version,
-                     syscalls,
-                     NULL,
-                     NULL,
-                     NULL,
-                     0U,
-                     NULL,
-                     0,
-                     FD_FEATURE_ACTIVE( slot_ctx->slot, &dummy_txn_ctx.features, bpf_account_data_direct_mapping ),
-                     0 );
-
-    if( FD_UNLIKELY( !vm ) ) {
-      FD_LOG_ERR(( "fd_vm_init() failed" ));
-    }
-
-    res = fd_vm_validate( vm );
+    int res = fd_bpf_validate_sbpf_program( slot_ctx, &elf_info, program_data, program_data_len, runtime_spad, validated_prog );
     if( FD_UNLIKELY( res ) ) {
-      /* Remove pending funk record */
-      FD_LOG_DEBUG(( "fd_vm_validate() failed" ));
-      fd_funk_rec_cancel( funk, prepare );
-      return -1;
+      fd_publish_failed_verification_rec( funk, prepare, rec );
+      return;
     }
-
-    fd_memcpy( validated_prog->calldests_shmem, prog->calldests_shmem, fd_sbpf_calldests_footprint( prog->rodata_sz/8UL ) );
-    validated_prog->calldests = fd_sbpf_calldests_join( validated_prog->calldests_shmem );
-
-    validated_prog->entry_pc          = prog->entry_pc;
-    validated_prog->last_updated_slot = slot_ctx->slot;
-    validated_prog->text_off          = prog->text_off;
-    validated_prog->text_cnt          = prog->text_cnt;
-    validated_prog->text_sz           = prog->text_sz;
-    validated_prog->rodata_sz         = prog->rodata_sz;
 
     fd_funk_rec_publish( funk, prepare );
-
-    return 0;
   } FD_SPAD_FRAME_END;
 }
 
@@ -329,183 +419,15 @@ fd_bpf_check_and_create_bpf_program_cache_entry( fd_exec_slot_ctx_t * slot_ctx,
                                                  fd_pubkey_t const *  pubkey,
                                                  fd_spad_t *          runtime_spad ) {
   FD_TXN_ACCOUNT_DECL( exec_rec );
-  if( fd_txn_account_init_from_funk_readonly( exec_rec, pubkey, slot_ctx->funk, slot_ctx->funk_txn ) != FD_ACC_MGR_SUCCESS ) {
+  if( FD_UNLIKELY( fd_txn_account_init_from_funk_readonly( exec_rec, pubkey, slot_ctx->funk, slot_ctx->funk_txn ) != FD_ACC_MGR_SUCCESS ) ) {
     return -1;
   }
 
-  if( memcmp( exec_rec->vt->get_owner( exec_rec ), fd_solana_bpf_loader_deprecated_program_id.key,  sizeof(fd_pubkey_t) ) &&
-      memcmp( exec_rec->vt->get_owner( exec_rec ), fd_solana_bpf_loader_program_id.key,             sizeof(fd_pubkey_t) ) &&
-      memcmp( exec_rec->vt->get_owner( exec_rec ), fd_solana_bpf_loader_upgradeable_program_id.key, sizeof(fd_pubkey_t) ) &&
-      memcmp( exec_rec->vt->get_owner( exec_rec ), fd_solana_bpf_loader_v4_program_id.key,          sizeof(fd_pubkey_t) ) ) {
+  if( !fd_executor_pubkey_is_bpf_loader( exec_rec->vt->get_owner( exec_rec ) ) ) {
     return -1;
   }
 
-  if( fd_bpf_create_bpf_program_cache_entry( slot_ctx, exec_rec, runtime_spad ) != 0 ) {
-    return -1;
-  }
-
-  return 0;
-}
-
-void
-fd_bpf_is_bpf_program( fd_funk_rec_t const * rec,
-                       fd_wksp_t *           funk_wksp,
-                       uchar *               is_bpf_program ) {
-
-  if( !fd_funk_key_is_acc( rec->pair.key ) ) {
-    *is_bpf_program = 0;
-    return;
-  }
-
-  void const * raw = fd_funk_val( rec, funk_wksp );
-
-  fd_account_meta_t const * metadata = fd_type_pun_const( raw );
-
-  if( metadata &&
-      memcmp( metadata->info.owner, fd_solana_bpf_loader_deprecated_program_id.key,  sizeof(fd_pubkey_t) ) &&
-      memcmp( metadata->info.owner, fd_solana_bpf_loader_program_id.key,             sizeof(fd_pubkey_t) ) &&
-      memcmp( metadata->info.owner, fd_solana_bpf_loader_upgradeable_program_id.key, sizeof(fd_pubkey_t) ) &&
-      memcmp( metadata->info.owner, fd_solana_bpf_loader_v4_program_id.key,          sizeof(fd_pubkey_t) ) ) {
-    *is_bpf_program = 0;
-  } else {
-    *is_bpf_program = 1;
-  }
-}
-
-static void FD_FN_UNUSED
-fd_bpf_scan_task( void * tpool, ulong t0, ulong t1,
-                  void * args, void * reduce, ulong stride FD_PARAM_UNUSED,
-                  ulong l0 FD_PARAM_UNUSED, ulong l1 FD_PARAM_UNUSED,
-                  ulong m0 FD_PARAM_UNUSED, ulong m1 FD_PARAM_UNUSED,
-                  ulong n0 FD_PARAM_UNUSED, ulong n1 FD_PARAM_UNUSED  ) {
-  fd_funk_rec_t const * * recs           = (fd_funk_rec_t const * *)tpool;
-  ulong                   start_idx      = t0;
-  ulong                   end_idx        = t1;
-  uchar *                 is_bpf_program = (uchar *)args;
-  fd_exec_slot_ctx_t *    slot_ctx       = (fd_exec_slot_ctx_t *)reduce;
-
-  for( ulong i=start_idx; i<=end_idx; i++ ) {
-    fd_funk_rec_t const * rec = recs[ i ];
-    fd_bpf_is_bpf_program( rec, fd_funk_wksp( slot_ctx->funk ), &is_bpf_program[ i ] );
-  }
-}
-
-static void
-fd_bpf_scan_and_create_program_cache_entry_tpool_helper( fd_tpool_t *            tpool,
-                                                         fd_funk_rec_t const * * recs,
-                                                         uchar *                 is_bpf_program,
-                                                         ulong                   rec_cnt,
-                                                         fd_exec_slot_ctx_t *    slot_ctx ) {
-
-  ulong wcnt           = fd_tpool_worker_cnt( tpool );
-  ulong cnt_per_worker = rec_cnt / wcnt;
-  for( ulong worker_idx=1UL; worker_idx<wcnt; worker_idx++ ) {
-    ulong start_idx = (worker_idx-1UL) * cnt_per_worker;
-    ulong end_idx   = worker_idx!=wcnt-1UL ? fd_ulong_sat_sub( start_idx + cnt_per_worker, 1UL ) :
-                                            fd_ulong_sat_sub( rec_cnt, 1UL );
-
-    fd_tpool_exec( tpool, worker_idx, fd_bpf_scan_task,
-                   recs, start_idx, end_idx,
-                   is_bpf_program, slot_ctx, 0UL,
-                   0UL, 0UL, worker_idx, 0UL, 0UL, 0UL );
-  }
-
-  for( ulong worker_idx=1UL; worker_idx<wcnt; worker_idx++ ) {
-    fd_tpool_wait( tpool, worker_idx );
-  }
-}
-
-void
-bpf_tpool_wrapper( void * para_arg_1,
-                   void * para_arg_2 FD_PARAM_UNUSED,
-                   void * fn_arg_1,
-                   void * fn_arg_2,
-                   void * fn_arg_3,
-                   void * fn_arg_4 ) {
-
-  (void)para_arg_2; /* unused */
-
-  fd_tpool_t *            tpool          = (fd_tpool_t *)para_arg_1;
-  fd_funk_rec_t const * * recs           = (fd_funk_rec_t const **)fn_arg_1;
-  uchar *                 is_bpf_program = (uchar *)fn_arg_2;
-  ulong                   rec_cnt        = (ulong)fn_arg_3;
-  fd_exec_slot_ctx_t *    slot_ctx       = (fd_exec_slot_ctx_t *)fn_arg_4;
-
-  fd_bpf_scan_and_create_program_cache_entry_tpool_helper( tpool, recs, is_bpf_program, rec_cnt, slot_ctx );
-}
-
-int
-fd_bpf_scan_and_create_bpf_program_cache_entry_para( fd_exec_slot_ctx_t *    slot_ctx,
-                                                     fd_spad_t *             runtime_spad,
-                                                     fd_exec_para_cb_ctx_t * exec_para_ctx ) {
-  long        elapsed_ns = -fd_log_wallclock();
-  fd_funk_t * funk       = slot_ctx->funk;
-  ulong       cached_cnt = 0UL;
-
-  /* Use random-ish xid to avoid concurrency issues */
-  fd_funk_txn_xid_t cache_xid = fd_funk_generate_xid();
-
-  fd_funk_txn_start_write( funk );
-  fd_funk_txn_t * cache_txn = fd_funk_txn_prepare( funk, slot_ctx->funk_txn, &cache_xid, 1 );
-  if( !cache_txn ) {
-    FD_LOG_ERR(( "fd_funk_txn_prepare() failed" ));
-    return -1;
-  }
-  fd_funk_txn_end_write( funk );
-
-  fd_funk_txn_t * funk_txn = slot_ctx->funk_txn;
-  slot_ctx->funk_txn = cache_txn;
-
-  fd_funk_txn_start_read( funk );
-  fd_funk_rec_t const * rec = fd_funk_txn_first_rec( funk, funk_txn );
-  while( rec!=NULL ) {
-    FD_SPAD_FRAME_BEGIN( runtime_spad ) {
-      fd_funk_rec_t const * * recs           = fd_spad_alloc( runtime_spad, alignof(fd_funk_rec_t*), 65536UL * sizeof(fd_funk_rec_t const *) );
-      uchar *                 is_bpf_program = fd_spad_alloc( runtime_spad, 8UL, 65536UL * sizeof(uchar) );
-
-      /* Make a list of rec ptrs to process */
-      ulong rec_cnt = 0UL;
-      for( ; NULL != rec; rec = fd_funk_txn_next_rec( funk, rec ) ) {
-        if( rec->flags & FD_FUNK_REC_FLAG_ERASE ) continue;
-        recs[ rec_cnt ] = rec;
-        rec_cnt++;
-        if( FD_UNLIKELY( rec_cnt==65536UL ) ) break;
-      }
-
-      /* Pass in args */
-      exec_para_ctx->fn_arg_1 = (void*)recs;
-      exec_para_ctx->fn_arg_2 = (void*)is_bpf_program;
-      exec_para_ctx->fn_arg_3 = (void*)rec_cnt;
-      exec_para_ctx->fn_arg_4 = (void*)slot_ctx;
-      fd_exec_para_call_func( exec_para_ctx );
-
-      for( ulong i=0UL; i<rec_cnt; i++ ) {
-        if( !is_bpf_program[ i ] ) {
-          continue;
-        }
-
-        fd_pubkey_t const * pubkey = fd_type_pun_const( recs[i]->pair.key[0].uc );
-        int res = fd_bpf_check_and_create_bpf_program_cache_entry( slot_ctx, pubkey, runtime_spad );
-        if( res==0 ) {
-          cached_cnt++;
-        }
-      }
-
-    } FD_SPAD_FRAME_END;
-  }
-  fd_funk_txn_end_read( funk );
-
-  fd_funk_txn_start_write( funk );
-  if( fd_funk_txn_publish_into_parent( funk, cache_txn, 1 ) != FD_FUNK_SUCCESS ) {
-    FD_LOG_ERR(( "fd_funk_txn_publish_into_parent() failed" ));
-  }
-  fd_funk_txn_end_write( funk );
-
-  slot_ctx->funk_txn = funk_txn;
-
-  elapsed_ns += fd_log_wallclock();
-
-  FD_LOG_NOTICE(( "loaded program cache - entries: %lu, elapsed_seconds: %ld", cached_cnt, elapsed_ns/(long)1e9 ));
+  fd_bpf_create_bpf_program_cache_entry( slot_ctx, exec_rec, runtime_spad );
 
   return 0;
 }
@@ -562,10 +484,10 @@ fd_bpf_scan_and_create_bpf_program_cache_entry( fd_exec_slot_ctx_t * slot_ctx,
 }
 
 int
-fd_bpf_load_cache_entry( fd_funk_t *                    funk,
-                         fd_funk_txn_t *                funk_txn,
-                         fd_pubkey_t const *            program_pubkey,
-                         fd_sbpf_validated_program_t ** valid_prog ) {
+fd_bpf_load_cache_entry( fd_funk_t const *                    funk,
+                         fd_funk_txn_t const *                funk_txn,
+                         fd_pubkey_t const *                  program_pubkey,
+                         fd_sbpf_validated_program_t const ** valid_prog ) {
   fd_funk_rec_key_t id   = fd_acc_mgr_cache_key( program_pubkey );
 
   for(;;) {
@@ -582,7 +504,7 @@ fd_bpf_load_cache_entry( fd_funk_t *                    funk,
 
     void const * data = fd_funk_val_const( rec, fd_funk_wksp(funk) );
 
-    *valid_prog = (fd_sbpf_validated_program_t *)data;
+    *valid_prog = (fd_sbpf_validated_program_t const *)data;
 
     /* This test is actually too early. It should happen after the
        data is actually consumed.
@@ -596,4 +518,98 @@ fd_bpf_load_cache_entry( fd_funk_t *                    funk,
 
     /* Try again */
   }
+}
+
+void
+fd_bpf_program_update_program_cache( fd_exec_slot_ctx_t * slot_ctx,
+                                     fd_pubkey_t const *  program_pubkey,
+                                     fd_spad_t *          runtime_spad ) {
+FD_SPAD_FRAME_BEGIN( runtime_spad ) {
+  FD_TXN_ACCOUNT_DECL( exec_rec );
+  fd_funk_rec_key_t id = fd_acc_mgr_cache_key( program_pubkey );
+
+  /* No need to touch the cache if the account no longer exists. */
+  if( FD_UNLIKELY( fd_txn_account_init_from_funk_readonly( exec_rec,
+                                                           program_pubkey,
+                                                           slot_ctx->funk,
+                                                           slot_ctx->funk_txn ) ) ) {
+    return;
+  }
+
+  /* The account owner must be a BPF loader to even be considered. */
+  if( FD_UNLIKELY( !fd_executor_pubkey_is_bpf_loader( exec_rec->vt->get_owner( exec_rec ) ) ) ) {
+    return;
+  }
+
+  /* If the program is not present in the cache yet, then we should run verifications and add it to the cache.
+     `fd_bpf_create_bpf_program_cache_entry()` will insert the program into the cache and update the entry's flags
+     accordingly if it fails verification. */
+  fd_sbpf_validated_program_t const * prog = NULL;
+  int err = fd_bpf_load_cache_entry( slot_ctx->funk, slot_ctx->funk_txn, program_pubkey, &prog );
+  if( FD_UNLIKELY( err ) ) {
+    fd_bpf_create_bpf_program_cache_entry( slot_ctx, exec_rec, runtime_spad );
+    return;
+  }
+
+  /* At this point, the program is in the cache. We need to check the last verified epoch now to determine if it needs to be reverified.
+     If it has already been reverified for the current epoch, then there is no need to do anything. */
+  fd_epoch_schedule_t const * epoch_schedule = fd_bank_epoch_schedule_query( slot_ctx->bank );
+  ulong current_epoch = fd_slot_to_epoch( epoch_schedule, slot_ctx->slot, NULL );
+  if( FD_LIKELY( prog->last_epoch_verification_ran==current_epoch ) ) {
+    return;
+  }
+
+  /* At this point, the program is in the cache but has not been reverified for the current epoch.
+     We need to run verifications and update the cache if it passes. */
+
+  /* Copy the record (if needed) down into the current funk txn from one of its ancestors. It is safe to
+     pass in min_sz=0 because the record is known to exist in the cache already, and the record size will not change */
+  fd_funk_rec_try_clone_safe( slot_ctx->funk, slot_ctx->funk_txn, &id, 0UL, 0UL );
+
+  /* Modify the record within the current funk txn */
+  fd_funk_rec_query_t query[1];
+  fd_funk_rec_t * rec = fd_funk_rec_modify( slot_ctx->funk, slot_ctx->funk_txn, &id, query );
+
+  if( FD_UNLIKELY( !rec ) ) {
+    /* The record does not exist (somehow). Ideally this should never happen since this function is called in a single-threaded context. */
+    FD_LOG_CRIT(( "Failed to modify the BPF program cache record. Perhaps there is a race condition?" ));
+  }
+
+  void *                        data          = fd_funk_val( rec, fd_funk_wksp( slot_ctx->funk ) );
+  fd_sbpf_elf_info_t            elf_info      = {0};
+  fd_sbpf_validated_program_t * modified_prog = (fd_sbpf_validated_program_t *)data;
+
+  /* Get the program data from the account */
+  ulong         program_data_len = 0UL;
+  uchar const * program_data     = fd_bpf_get_programdata_from_account( slot_ctx->funk,
+                                                                        slot_ctx->funk_txn,
+                                                                        exec_rec,
+                                                                        &program_data_len,
+                                                                        runtime_spad );
+  if( FD_UNLIKELY( program_data==NULL ) ) {
+    modified_prog->failed_verification = 1;
+    fd_funk_rec_modify_publish( query );
+    return;
+  }
+
+  /* Parse the ELF info */
+  if( FD_UNLIKELY( fd_bpf_parse_elf_info( &elf_info, program_data, program_data_len, slot_ctx ) ) ) {
+    modified_prog->failed_verification = 1;
+    fd_funk_rec_modify_publish( query );
+    return;
+  }
+
+  /* Validate the sBPF program. This will set the program's flags accordingly. The return code does not matter here because we publish
+     regardless of the return code. */
+  modified_prog = fd_sbpf_validated_program_new( data, &elf_info );
+  fd_bpf_validate_sbpf_program( slot_ctx, &elf_info, program_data, program_data_len, runtime_spad, modified_prog );
+
+  if( modified_prog->failed_verification ) {
+    FD_LOG_ERR(("program fialed veriifecation;"));
+  }
+
+  /* Finish modifying and release lock */
+  fd_funk_rec_modify_publish( query );
+
+} FD_SPAD_FRAME_END;
 }

--- a/src/flamenco/runtime/program/fd_bpf_program_util.h
+++ b/src/flamenco/runtime/program/fd_bpf_program_util.h
@@ -2,35 +2,42 @@
 #define HEADER_fd_src_flamenco_runtime_program_fd_bpf_program_util_h
 
 #include "../../fd_flamenco_base.h"
-#include "../fd_runtime_public.h"
 #include "../fd_acc_mgr.h"
 #include "../context/fd_exec_slot_ctx.h"
 #include "../../vm/syscall/fd_vm_syscall.h"
+#include "../fd_system_ids.h"
 
 struct fd_sbpf_validated_program {
   ulong magic;
 
-  ulong last_updated_slot;
-  ulong entry_pc;
-  ulong text_cnt;
-  ulong text_off;
-  ulong text_sz;
+   /* For any programs that fail verification, we retain this flag for the current epoch to
+      prevent any reverification attempts for the remainder of the epoch (instead of
+      removing them from the cache). When `failed_verification` is set, the value of all other
+      fields in this struct are undefined. */
+   uchar failed_verification;
 
-  ulong rodata_sz;
+   /* Stores the last epoch verification checks were ran for a program. Programs are reverified
+      the first time they are mentioned in a transaction in an epoch, and then never again
+      until the next epoch. This is because feature set changes across the epoch boundary can
+      make existing deployed programs invalid. If `last_epoch_verification_ran` != current epoch,
+      then we run the verification and update `failed_verification` if it fails. */
+   ulong last_epoch_verification_ran;
+
+   ulong entry_pc;
+   ulong text_cnt;
+   ulong text_off;
+   ulong text_sz;
+
+   ulong rodata_sz;
 
   /* We keep the pointer to the calldests raw memory around, so that we can easily copy the entire
      data structures (including the private header) later. */
-  void * calldests_shmem;
-  fd_sbpf_calldests_t * calldests;
+   void *                calldests_shmem;
+   fd_sbpf_calldests_t * calldests;
+   uchar *               rodata;
 
-  uchar * rodata;
-
-  /* Backing memory for calldests and rodata */
-  // uchar calldests_shmem[];
-  // uchar rodata[];
-
-  /* SBPF version, SIMD-0161 */
-  ulong sbpf_version;
+   /* SBPF version, SIMD-0161 */
+   ulong sbpf_version;
 };
 typedef struct fd_sbpf_validated_program fd_sbpf_validated_program_t;
 
@@ -39,14 +46,6 @@ typedef struct fd_sbpf_validated_program fd_sbpf_validated_program_t;
 #define FD_SBPF_VALIDATED_PROGRAM_MAGIC 0xfd5540ddc5a33496
 
 FD_PROTOTYPES_BEGIN
-
-void
-bpf_tpool_wrapper( void * para_arg_1,
-                   void * para_arg_2,
-                   void * fn_arg_1,
-                   void * fn_arg_2,
-                   void * fn_arg_3,
-                   void * fn_arg_4 );
 
 fd_sbpf_validated_program_t *
 fd_sbpf_validated_program_new( void * mem, fd_sbpf_elf_info_t const * elf_info );
@@ -66,27 +65,52 @@ int
 fd_bpf_scan_and_create_bpf_program_cache_entry( fd_exec_slot_ctx_t * slot_ctx,
                                                 fd_spad_t *          runtime_spad );
 
-void
-fd_bpf_is_bpf_program( fd_funk_rec_t const * rec,
-                       fd_wksp_t *           funk_wksp,
-                       uchar *               is_bpf_program );
-
 int
 fd_bpf_scan_and_create_bpf_program_cache_entry_para( fd_exec_slot_ctx_t *    slot_ctx,
                                                      fd_spad_t *             runtime_spad,
                                                      fd_exec_para_cb_ctx_t * exec_para_ctx );
 
 int
-fd_bpf_load_cache_entry( fd_funk_t *                    funk,
-                         fd_funk_txn_t *                funk_txn,
-                         fd_pubkey_t const *            program_pubkey,
-                         fd_sbpf_validated_program_t ** valid_prog );
+fd_bpf_load_cache_entry( fd_funk_t const *                    funk,
+                         fd_funk_txn_t const *                funk_txn,
+                         fd_pubkey_t const *                  program_pubkey,
+                         fd_sbpf_validated_program_t const ** valid_prog );
 
 void
 fd_bpf_get_sbpf_versions( uint *                sbpf_min_version,
                           uint *                sbpf_max_version,
                           ulong                 slot,
                           fd_features_t const * features );
+
+/* Parses the programdata from a program account. Returns a pointer to the program data
+   and sets `out_program_data_len` on success. Returns NULL on failure or if the program
+   account is not owned by a BPF loader program ID, and leaves `out_program_data_len`
+   in an undefined state. Reasons for failure vary on the loader version. See the respective
+   functions in this file for more details. */
+uchar const *
+fd_bpf_get_programdata_from_account( fd_funk_t const *        funk,
+                                     fd_funk_txn_t const *    funk_txn,
+                                     fd_txn_account_t const * program_acc,
+                                     ulong *                  out_program_data_len,
+                                     fd_spad_t *              runtime_spad );
+
+/* Updates the program cache for a single program. This function is called for every program
+   that is referenced in a transaction, plus every single account in a lookup table referenced
+   in the transaction. This function...
+   - Reads the programdata from an account, given the pubkey
+   - Creates a program cache entry for the program if it doesn't exist in the cache already
+   - Reverifies programs every epoch
+      - Lazily reverifies programs as they are invoked in a transaction (only once per program per epoch)
+      - Invalidates programs that fail verification until the next epoch
+      - Updates the program cache entry for the program after reverification (syscalls, calldests, etc)
+
+   With this design, the program cache is designed to only grow as new programs are deployed / invoked. If a program fails
+   verification, it stays in the cache so that repeated calls won't DOS the validator by forcing reverifications (since we
+   won't be able to distinguish failed verifications from new deployments). */
+void
+fd_bpf_program_update_program_cache( fd_exec_slot_ctx_t * slot_ctx,
+                                     fd_pubkey_t const *  program_pubkey,
+                                     fd_spad_t *          runtime_spad );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/program/test_program_cache.c
+++ b/src/flamenco/runtime/program/test_program_cache.c
@@ -1,0 +1,340 @@
+#include "fd_bpf_program_util.h"
+#include "../../../util/fd_util.h"
+
+#if FD_HAS_HOSTED
+
+#define TEST_WKSP_TAG 1234UL
+
+/* Load in programdata for tests */
+FD_IMPORT_BINARY( valid_program_data, "src/ballet/sbpf/fixtures/hello_solana_program.so" );
+
+static uchar const invalid_program_data[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
+
+/* Test program pubkeys */
+static fd_pubkey_t const test_program_pubkey = {
+  .uc = { 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+          0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99 }
+};
+
+static ulong const SPAD_MEM_MAX = 100UL << 20; /* 100MB */
+
+/* Test setup and teardown helpers */
+static fd_wksp_t * test_wksp = NULL;
+static fd_funk_t * test_funk = NULL;
+static fd_spad_t * test_spad = NULL;
+static fd_exec_slot_ctx_t * test_slot_ctx = NULL;
+
+static void
+test_teardown( void ) {
+  if( test_slot_ctx ) {
+    fd_exec_slot_ctx_leave( test_slot_ctx );
+    test_slot_ctx = NULL;
+  }
+
+  if( test_spad ) {
+    fd_spad_leave( test_spad );
+    test_spad = NULL;
+  }
+
+  if( test_funk ) {
+    fd_funk_leave( test_funk, NULL );
+    test_funk = NULL;
+  }
+
+  if( test_wksp ) {
+    fd_wksp_delete_anonymous( test_wksp );
+    test_wksp = NULL;
+  }
+}
+
+/* Helper to create a funk transaction */
+static fd_funk_txn_t *
+create_test_funk_txn( void ) {
+  fd_funk_txn_xid_t xid = fd_funk_generate_xid();
+  fd_funk_txn_start_write( test_funk );
+  fd_funk_txn_t * funk_txn = fd_funk_txn_prepare( test_funk, NULL, &xid, 1 );
+  fd_funk_txn_end_write( test_funk );
+  FD_TEST( funk_txn );
+  return funk_txn;
+}
+
+/* Helper to create a test account */
+static void
+create_test_account( fd_pubkey_t const * pubkey,
+                     fd_pubkey_t const * owner,
+                     uchar const *       data,
+                     ulong               data_len,
+                     uchar               executable ) {
+  FD_TXN_ACCOUNT_DECL( acc );
+  int err = fd_txn_account_init_from_funk_mutable( /* acc         */ acc,
+                                                   /* pubkey      */ pubkey,
+                                                   /* funk        */ test_funk,
+                                                   /* txn         */ test_slot_ctx->funk_txn,
+                                                   /* do_create   */ 1,
+                                                   /* min_data_sz */ data_len );
+  FD_TEST( !err );
+
+  if( data ) {
+    acc->vt->set_data( acc, data, data_len );
+  }
+
+  acc->starting_lamports = 1UL;
+  acc->starting_dlen     = data_len;
+  acc->vt->set_lamports( acc, 1UL );
+  acc->vt->set_executable( acc, executable );
+  acc->vt->set_rent_epoch( acc, ULONG_MAX );
+  acc->vt->set_owner( acc, owner );
+
+  /* make the account read-only by default */
+  acc->vt->set_readonly( acc );
+
+  fd_txn_account_mutable_fini( acc, test_funk, test_slot_ctx->funk_txn );
+}
+
+/* Test 1: Account doesn't exist */
+static void
+test_account_does_not_exist( void ) {
+  FD_LOG_NOTICE(( "Testing: Account doesn't exist" ));
+
+  fd_funk_txn_t * funk_txn = create_test_funk_txn();
+  test_slot_ctx->funk_txn = funk_txn;
+
+  /* Call with a non-existent pubkey */
+  fd_pubkey_t const non_existent_pubkey = {0};
+
+  /* This should return early without doing anything */
+  fd_bpf_program_update_program_cache( test_slot_ctx, &non_existent_pubkey, test_spad );
+
+  /* Verify no cache entry was created */
+  fd_sbpf_validated_program_t const * valid_prog = NULL;
+  int err = fd_bpf_load_cache_entry( test_funk, funk_txn, &non_existent_pubkey, &valid_prog );
+  FD_TEST( err==-1 ); /* Should not exist */
+
+  fd_funk_txn_cancel( test_funk, funk_txn, 0 );
+}
+
+/* Test 2: Account exists but is not owned by a BPF loader */
+static void
+test_account_not_bpf_loader_owner( void ) {
+  FD_LOG_NOTICE(( "Testing: Account exists but is not owned by a BPF loader" ));
+
+  fd_funk_txn_t * funk_txn = create_test_funk_txn();
+  test_slot_ctx->funk_txn = funk_txn;
+
+  /* Create an account owned by a non-BPF loader */
+  create_test_account( &test_program_pubkey,
+                       &fd_solana_system_program_id,
+                       invalid_program_data,
+                       sizeof(invalid_program_data),
+                       1 );
+
+  /* This should return early without doing anything */
+  fd_bpf_program_update_program_cache( test_slot_ctx, &test_program_pubkey, test_spad );
+
+  /* Verify no cache entry was created */
+  fd_sbpf_validated_program_t const * valid_prog = NULL;
+  int err = fd_bpf_load_cache_entry( test_funk, funk_txn, &test_program_pubkey, &valid_prog );
+  FD_TEST( err==-1 ); /* Should not exist */
+
+  fd_funk_txn_cancel( test_funk, funk_txn, 0 );
+}
+
+/* Test 3: Program is not in cache yet (first time), but program fails validations */
+static void
+test_invalid_program_not_in_cache_first_time( void ) {
+  FD_LOG_NOTICE(( "Testing: Program is not in cache yet (first time), but program fails validations" ));
+
+  fd_funk_txn_t * funk_txn = create_test_funk_txn();
+  test_slot_ctx->funk_txn = funk_txn;
+
+  /* Create a BPF loader account */
+  create_test_account( &test_program_pubkey,
+                       &fd_solana_bpf_loader_program_id,
+                       invalid_program_data,
+                       sizeof(invalid_program_data),
+                       1 );
+
+  /* This should create a cache entry */
+  fd_bpf_program_update_program_cache( test_slot_ctx, &test_program_pubkey, test_spad );
+
+  /* Verify cache entry was created */
+  fd_sbpf_validated_program_t const * valid_prog = NULL;
+  int err = fd_bpf_load_cache_entry( test_funk, funk_txn, &test_program_pubkey, &valid_prog );
+  FD_TEST( !err ); /* Should exist */
+  FD_TEST( valid_prog );
+  FD_TEST( valid_prog->magic==FD_SBPF_VALIDATED_PROGRAM_MAGIC );
+  FD_TEST( valid_prog->failed_verification );
+
+  fd_funk_txn_cancel( test_funk, funk_txn, 0 );
+}
+
+/* Test 4: Program is not in cache yet (first time), but program passes validations */
+static void
+test_valid_program_not_in_cache_first_time( void ) {
+  FD_LOG_NOTICE(( "Testing: Program is not in cache yet (first time), but program passes validations" ));
+
+  fd_funk_txn_t * funk_txn = create_test_funk_txn();
+  test_slot_ctx->funk_txn = funk_txn;
+
+  /* Create a BPF loader account */
+  create_test_account( &test_program_pubkey,
+                       &fd_solana_bpf_loader_program_id,
+                       valid_program_data,
+                       valid_program_data_sz,
+                       1 );
+
+  /* This should create a cache entry */
+  fd_bpf_program_update_program_cache( test_slot_ctx, &test_program_pubkey, test_spad );
+
+  /* Verify cache entry was created */
+  fd_sbpf_validated_program_t const * valid_prog = NULL;
+  int err = fd_bpf_load_cache_entry( test_funk, funk_txn, &test_program_pubkey, &valid_prog );
+  FD_TEST( !err ); /* Should exist */
+  FD_TEST( valid_prog );
+  FD_TEST( valid_prog->magic==FD_SBPF_VALIDATED_PROGRAM_MAGIC );
+  FD_TEST( !valid_prog->failed_verification );
+  FD_TEST( valid_prog->last_epoch_verification_ran==1UL );
+
+  fd_funk_txn_cancel( test_funk, funk_txn, 0 );
+}
+
+/* Test 5: Program is in cache but needs reverification (different epoch) */
+static void
+test_program_in_cache_needs_reverification( void ) {
+  FD_LOG_NOTICE(( "Testing: Program is in cache but needs reverification (different epoch)" ));
+
+  fd_funk_txn_t * funk_txn = create_test_funk_txn();
+  test_slot_ctx->funk_txn = funk_txn;
+
+  /* Create a BPF loader account */
+  create_test_account( &test_program_pubkey,
+                       &fd_solana_bpf_loader_program_id,
+                       valid_program_data,
+                       valid_program_data_sz,
+                       1 );
+
+  /* First call to create cache entry */
+  fd_bpf_program_update_program_cache( test_slot_ctx, &test_program_pubkey, test_spad );
+
+  /* Verify cache entry was created */
+  fd_sbpf_validated_program_t const * valid_prog = NULL;
+  int err = fd_bpf_load_cache_entry( test_funk, funk_txn, &test_program_pubkey, &valid_prog );
+  FD_TEST( !err );
+  FD_TEST( valid_prog );
+  FD_TEST( valid_prog->magic==FD_SBPF_VALIDATED_PROGRAM_MAGIC );
+  FD_TEST( !valid_prog->failed_verification );
+  FD_TEST( valid_prog->last_epoch_verification_ran==1UL );
+
+  /* Fast forward to next epoch */
+  test_slot_ctx->slot += 432000UL;
+
+  /* This should trigger reverification */
+  fd_bpf_program_update_program_cache( test_slot_ctx, &test_program_pubkey, test_spad );
+
+  /* Verify the cache entry was updated */
+  err = fd_bpf_load_cache_entry( test_funk, funk_txn, &test_program_pubkey, &valid_prog );
+  FD_TEST( !err );
+  FD_TEST( valid_prog );
+  FD_TEST( valid_prog->magic==FD_SBPF_VALIDATED_PROGRAM_MAGIC );
+  FD_TEST( !valid_prog->failed_verification );
+  FD_TEST( valid_prog->last_epoch_verification_ran==2UL );
+
+  fd_funk_txn_cancel( test_funk, funk_txn, 0 );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  FD_LOG_NOTICE(( "Starting BPF program cache tests" ));
+
+    /* Create workspace */
+  test_wksp = fd_wksp_new_anonymous( FD_SHMEM_GIGANTIC_PAGE_SZ, 2UL, fd_log_cpu_id(), "test_wksp", 0UL );
+  FD_TEST( test_wksp );
+
+  /* Create funk */
+  ulong funk_align = fd_funk_align();
+  ulong funk_footprint = fd_funk_footprint( 1024UL, 1024UL );
+  void * funk_mem = fd_wksp_alloc_laddr( test_wksp, funk_align, funk_footprint, TEST_WKSP_TAG );
+  FD_TEST( funk_mem );
+
+  void * shfunk = fd_funk_new( funk_mem, 1234UL, 5678UL, 1024UL, 1024UL );
+  FD_TEST( shfunk );
+
+  fd_funk_t funk_[1];
+  test_funk = fd_funk_join( funk_, shfunk );
+  FD_TEST( test_funk );
+
+  /* Create spad */
+  ulong spad_align = fd_spad_align();
+  ulong spad_footprint = fd_spad_footprint( SPAD_MEM_MAX );
+  void * spad_mem = fd_wksp_alloc_laddr( test_wksp, spad_align, spad_footprint, TEST_WKSP_TAG );
+  FD_TEST( spad_mem );
+
+  test_spad = fd_spad_join( fd_spad_new( spad_mem, SPAD_MEM_MAX ) );
+  FD_TEST( test_spad );
+
+  FD_SPAD_FRAME_BEGIN( test_spad ) {
+
+    /* Create slot context */
+    ulong slot_align = FD_EXEC_SLOT_CTX_ALIGN;
+    ulong slot_footprint = FD_EXEC_SLOT_CTX_FOOTPRINT;
+    uchar * slot_mem = fd_spad_alloc( test_spad, slot_align, slot_footprint );
+    test_slot_ctx = fd_exec_slot_ctx_join( fd_exec_slot_ctx_new( slot_mem ) );
+    FD_TEST( test_slot_ctx );
+
+    /* Set up slot context */
+    test_slot_ctx->funk = test_funk;
+    test_slot_ctx->slot = 433000UL; // Epoch 1
+
+    /* Set up bank */
+    ulong        banks_footprint = fd_banks_footprint( 1UL );
+    uchar *      banks_mem       = fd_wksp_alloc_laddr( test_wksp, fd_banks_align(), banks_footprint, TEST_WKSP_TAG );
+    FD_TEST( banks_mem );
+
+    fd_banks_t * banks = fd_banks_join( fd_banks_new( banks_mem, 1UL ) );
+    FD_TEST( banks );
+    fd_bank_t * bank = fd_banks_init_bank( banks, 433000UL );
+    FD_TEST( bank );
+
+    test_slot_ctx->bank  = bank;
+    test_slot_ctx->banks = banks;
+
+    fd_epoch_schedule_t epoch_schedule = {
+        .slots_per_epoch             = 432000UL,
+        .leader_schedule_slot_offset = 432000UL,
+        .warmup                      = 0,
+        .first_normal_epoch          = 0UL,
+        .first_normal_slot           = 0UL
+    };
+    fd_bank_epoch_schedule_set( bank, epoch_schedule );
+
+    test_account_does_not_exist();
+    test_account_not_bpf_loader_owner();
+    test_invalid_program_not_in_cache_first_time();
+    test_valid_program_not_in_cache_first_time();
+    test_program_in_cache_needs_reverification();
+  } FD_SPAD_FRAME_END;
+
+  test_teardown();
+
+  FD_LOG_NOTICE(( "All BPF program cache tests passed" ));
+  fd_halt();
+  return 0;
+}
+
+#undef TEST_WKSP_TAG
+
+#else
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+  FD_LOG_WARNING(( "skip: unit test requires FD_HAS_HOSTED capabilities" ));
+  fd_halt();
+  return 0;
+}
+
+#endif

--- a/src/flamenco/runtime/tests/fd_dump_pb.h
+++ b/src/flamenco/runtime/tests/fd_dump_pb.h
@@ -104,7 +104,7 @@ fd_dump_vm_syscall_to_protobuf( fd_vm_t const * vm,
 
 void
 fd_dump_elf_to_protobuf( fd_exec_txn_ctx_t * txn_ctx,
-                         fd_pubkey_t const * program_id );
+                         fd_txn_account_t *  program_acc );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/tests/harness/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/harness/fd_instr_harness.c
@@ -179,11 +179,7 @@ fd_runtime_fuzz_instr_ctx_create( fd_runtime_fuzz_runner_t *           runner,
   /* Load in executable accounts */
   for( ulong i = 0; i < txn_ctx->accounts_cnt; i++ ) {
     fd_txn_account_t * acc = &accts[i];
-    if ( memcmp( acc->vt->get_owner( acc ), fd_solana_bpf_loader_deprecated_program_id.key, sizeof(fd_pubkey_t) ) != 0 &&
-         memcmp( acc->vt->get_owner( acc ), fd_solana_bpf_loader_program_id.key, sizeof(fd_pubkey_t) ) != 0 &&
-         memcmp( acc->vt->get_owner( acc ), fd_solana_bpf_loader_upgradeable_program_id.key, sizeof(fd_pubkey_t) ) != 0 &&
-         memcmp( acc->vt->get_owner( acc ), fd_solana_bpf_loader_v4_program_id.key, sizeof(fd_pubkey_t) ) != 0
-    ) {
+    if ( !fd_executor_pubkey_is_bpf_loader( acc->vt->get_owner( acc ) ) ) {
       continue;
     }
 

--- a/src/flamenco/vm/fd_vm.c
+++ b/src/flamenco/vm/fd_vm.c
@@ -621,11 +621,6 @@ fd_vm_init(
     return NULL;
   }
 
-  if ( FD_UNLIKELY( instr_ctx == NULL ) ) {
-    FD_LOG_WARNING(( "NULL instr_ctx" ));
-    return NULL;
-  }
-
   if ( FD_UNLIKELY( heap_max > FD_VM_HEAP_MAX ) ) {
     FD_LOG_WARNING(( "heap_max > FD_VM_HEAP_MAX" ));
     return NULL;

--- a/src/flamenco/vm/fd_vm_private.h
+++ b/src/flamenco/vm/fd_vm_private.h
@@ -206,7 +206,7 @@ fd_vm_mem_cfg( fd_vm_t * vm ) {
   vm->region_haddr[FD_VM_STACK_REGION] = (ulong)vm->stack;  vm->region_ld_sz[FD_VM_STACK_REGION] = (uint)FD_VM_STACK_MAX; vm->region_st_sz[FD_VM_STACK_REGION] = (uint)FD_VM_STACK_MAX;
   vm->region_haddr[FD_VM_HEAP_REGION]  = (ulong)vm->heap;   vm->region_ld_sz[FD_VM_HEAP_REGION]  = (uint)vm->heap_max;    vm->region_st_sz[FD_VM_HEAP_REGION]  = (uint)vm->heap_max;
   vm->region_haddr[5]                  = 0UL;               vm->region_ld_sz[5]                  = (uint)0UL;             vm->region_st_sz[5]                  = (uint)0UL;
-  if( FD_FEATURE_ACTIVE( vm->instr_ctx->txn_ctx->slot, &vm->instr_ctx->txn_ctx->features, bpf_account_data_direct_mapping ) || !vm->input_mem_regions_cnt ) {
+  if( vm->direct_mapping || !vm->input_mem_regions_cnt ) {
     /* When direct mapping is enabled, we don't use these fields because
        the load and stores are fragmented. */
     vm->region_haddr[FD_VM_INPUT_REGION] = 0UL;


### PR DESCRIPTION
This PR is the first of 3, in an effort to make the program cache correct, properly specified, and moved out of Funk:
1. (This PR)  Make the program cache ~~great again~~ by...
    a. Getting rid of snapshot full account iteration by lazily populating the program cache as programs are referenced within transactions.
    b. Adding support for reverifying programs across epoch boundaries where updated active feature sets may invalidate existing programs.
2. Move program cache updates to happen per transaction instead of at the end of a slot to remove any dependency on funk iteration APIs.
3. Moving the program cache to a new fork-aware data structure similar to but separate from Funk.