### PR TITLE
topo: only mark sibling as assigned if it exists

### DIFF
--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -447,8 +447,11 @@ fd_topob_auto_layout( fd_topo_t * topo,
               if( FD_UNLIKELY( try_assign>=cpus->cpu_cnt ) ) FD_LOG_ERR(( "auto layout cannot set affinity for tile `%s:%lu` because all the CPUs are already assigned or have a HT pair assigned", tile->name, tile->kind_id ));
             }
 
+            ulong sibling = cpus->cpu[ cpu_ordering[ try_assign ] ].sibling;
             cpu_assigned[ cpu_ordering[ try_assign ] ] = 1;
-            cpu_assigned[ cpus->cpu[ cpu_ordering[ try_assign ] ].sibling ] = 1;
+            if( sibling!=ULONG_MAX ) {
+              cpu_assigned[ sibling ] = 1;
+            }
             tile->cpu_idx = cpu_ordering[ try_assign ];
             while( cpu_assigned[ cpu_ordering[ cpu_idx ] ] ) cpu_idx++;
           } else {


### PR DESCRIPTION
`fd_topob_sibling_idx` can return ULONG_MAX if a CPU does not have a sibling, this can happen in practice.
https://github.com/firedancer-io/firedancer/blob/d21c84994003ec8960f0c6cf1b502a3900e1f744/src/disco/topo/fd_cpu_topo.c#L69-L70
Some compilers will subsequently wrap around and overwrite a stack variable, which either segfaults the process or worse. I observed it overwriting the `topo` stack address.