### PR TITLE
backtest, offline-replay: mock tower tile

### DIFF
--- a/contrib/offline-replay/offline_replay.toml
+++ b/contrib/offline-replay/offline_replay.toml
@@ -12,7 +12,7 @@
     [tiles.replay]
         snapshot = "{snapshot}"
         funk_sz_gb = {funk_pages}
-        funk_txn_max = 1024
+        funk_txn_max = 64
         funk_rec_max = {index_max}
         cluster_version = "{cluster_version}"
         funk_file = "{ledger}/backtest.funk"

--- a/src/flamenco/runtime/tests/run_ledger_backtest.sh
+++ b/src/flamenco/runtime/tests/run_ledger_backtest.sh
@@ -152,7 +152,7 @@ echo "
      [tiles.replay]
          snapshot = \"$SNAPSHOT\"
          funk_sz_gb = $FUNK_PAGES
-         funk_txn_max = 1024
+         funk_txn_max = 64
          funk_rec_max = $INDEX_MAX
          cluster_version = \"$CLUSTER_VERSION\"
          enable_features = [ \"$ONE_OFFS\" ]


### PR DESCRIPTION
Minimally, the replay tile needs to be notified of new roots, in order to advance its watermark and publish various structures.

Also reduce the max number of funk_txn available in backtest config TOMLs. This increases the likelihood of catching failures to publish in the replay tile.