### PR TITLE
tower: fix a minor issue after refactor

### DIFF
--- a/src/choreo/tower/fd_tower.c
+++ b/src/choreo/tower/fd_tower.c
@@ -472,8 +472,8 @@ fd_tower_from_vote_acc( fd_tower_t *              tower,
       } else {
         FD_LOG_ERR(( "[%s] unknown state->discriminant %u", __func__, state->discriminant ));
       }
+      fd_tower_votes_push_tail( tower, vote );
     }
-    fd_tower_votes_push_tail( tower, vote );
 
     if( FD_LIKELY( fd_funk_rec_query_test( &query ) == FD_FUNK_SUCCESS ) ) return 0;
     else fd_tower_votes_remove_all( tower ); /* reset the tower and try again  */


### PR DESCRIPTION
When loading tower from funk record, we should push the `vote` to `tower` within the for loop.