### PR TITLE
deps: add auto install flag support for default case

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -542,9 +542,9 @@ index d7c8a12..8cfff9b 100644
 --- a/db/blob/blob_file_meta.h
 +++ b/db/blob/blob_file_meta.h
 @@ -5,6 +5,7 @@
- 
+
  #pragma once
- 
+
 +#include <cstdint>
  #include <cassert>
  #include <iosfwd>
@@ -688,7 +688,11 @@ if [[ $ACTION == 0 ]]; then
   echo
   echo "[~] Running $0 fetch check install"
 
-  read -r -p "[?] Continue? (y/N) " choice
+  if [[ "${FD_AUTO_INSTALL_PACKAGES:-}" == "1" ]]; then
+    choice=y
+  else
+    read -r -p "[?] Continue? (y/N) " choice
+  fi
   case "$choice" in
     y|Y)
       echo


### PR DESCRIPTION
# Description
This PR is pretty minor, it makes running `./deps.sh` respect `FD_AUTO_INSTALL_PACKAGES` flag, so that it doesn't ask for user confirmation.

Before: 
```sh
$ FD_AUTO_INSTALL_PACKAGES=1 ./deps.sh 
[~] This will fetch, build, and install Firedancer's dependencies into /opt/firedancer/opt
[~] For help, run: ./deps.sh help

[~] Running ./deps.sh fetch check install
[?] Continue? (y/N)
```

After: 
```sh
$ FD_AUTO_INSTALL_PACKAGES=1 ./deps.sh 
[~] This will fetch, build, and install Firedancer's dependencies into /opt/firedancer/opt
[~] For help, run: ./deps.sh help

[~] Running ./deps.sh fetch check install
Submodule 'agave' (https://github.com/firedancer-io/agave.git) registered for path 'agave'
Cloning into '/home/echo/repo/firedancer/agave'...
    ^silently cotinues deps setup
```

This is particularly useful for unattended Firedancer deployment with automation tools like Ansible.