### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/src/flamenco/runtime/tests/fd_dump_pb.h
+++ b/src/flamenco/runtime/tests/fd_dump_pb.h
@@ -78,7 +78,7 @@ fd_dump_txn_to_protobuf( fd_exec_txn_ctx_t *txn_ctx, fd_spad_t * spad );
    will create an initial BlockContext type that saves some fields from the slot and epoch context, as well as any current
    builtins and sysvar accounts.
 
-   `fd_dump_block_to_protobuf_tx_only` takes an existing block context message and a runtime block and and dumps
+   `fd_dump_block_to_protobuf_tx_only` takes an existing block context message and a runtime block and dumps
    the transactions within the block to be replayed.
 
    CAVEATS: Currently, due to how spad frames are handled in the runtime, there is an edge case where block dumping will

--- a/src/groove/fd_groove_data.h
+++ b/src/groove/fd_groove_data.h
@@ -204,7 +204,7 @@ FD_PROTOTYPES_BEGIN
    fd_groove_data.  Assumes shdata points in the caller's address space
    to the memory region containing the fd_groove_data and that there are
    no current joins globally.  Returns shdata on success (caller has
-   ownership of the memory region, any volumes in the groove and and any
+   ownership of the memory region, any volumes in the groove and any
    groove data objects in these volumes) and NULL on failure (no
    ownership changes, logs details). */
 
@@ -495,7 +495,7 @@ fd_groove_data_verify( fd_groove_data_t const * data );
 
 /* fd_groove_data_volume_verify returns FD_GROOVE_SUCCESS if the
    groove volume mapped into the caller's address at _volume is appears
-   to be a valid groove volume and and FD_GROOVE_ERR_CORRUPT
+   to be a valid groove volume and FD_GROOVE_ERR_CORRUPT
    otherwise (logs details).  Assumes join is a current local join and
    the groove data is idle.  It is fine to verify volumes in parallel
    (e.g. use hundreds of cores to verify petabytes of groove data). */

--- a/src/util/alloc/fd_alloc_cfg.h
+++ b/src/util/alloc/fd_alloc_cfg.h
@@ -53,7 +53,7 @@
    allocation.)
    
    block_footprints are directly computed from these superblock
-   footprints and and the block counts are recomputed to squeeze some
+   footprints and the block counts are recomputed to squeeze some
    extra blocks into the superblocks that various integer roundings
    might have exposed.  We discard any sizeclasses that are redundant
    and any sizeclasses that are too small to be useful (blocks need to

--- a/src/util/tmpl/fd_sort.c
+++ b/src/util/tmpl/fd_sort.c
@@ -1193,7 +1193,7 @@ SORT_(fast_para)( fd_tpool_t * tpool, ulong t0, ulong t1,
      where thresh is an empirical minimum amount of sorting work to
      justify starting / stopping a thread.  (As written below, the gamma
      term is more like gamma T^2, which makes the other limit more like
-     the cube root of N ln N but doesn't change the the overall
+     the cube root of N ln N but doesn't change the overall
      conclusion.) */
 
   ulong thresh = (4096UL + sizeof(SORT_KEY_T)-1UL) / sizeof(SORT_KEY_T);


### PR DESCRIPTION
remove redundant word in comment