### PR TITLE
funk: default config use correct key

### DIFF
--- a/contrib/offline-replay/offline_replay.toml
+++ b/contrib/offline-replay/offline_replay.toml
@@ -15,7 +15,7 @@
     [tiles.gui]
         enabled = false
 [funk]
-    heap_size_gb = {funk_pages}
+    heap_size_gib = {funk_pages}
     max_account_records = {index_max}
     max_database_transactions = 64
 [runtime]

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -305,7 +305,7 @@ user = ""
 
     # The size of the funk heap in gigabytes.  This value must be large
     # enough to store all Solana accounts uncompressed.
-    heap_size_gb = 32
+    heap_size_gib = 32
 
     # The max amount of concurrent database transactions.  These are
     # used to track conflicting versions of accounts until such

--- a/src/flamenco/runtime/tests/run_nightly_backtest.sh
+++ b/src/flamenco/runtime/tests/run_nightly_backtest.sh
@@ -100,7 +100,7 @@ echo "
     [tiles.gui]
         enabled = false
 [funk]
-    heap_size_gb = $FUNK_PAGES
+    heap_size_gib = $FUNK_PAGES
     max_account_records = $INDEX_MAX
     max_database_transactions = 1024
 [runtime]


### PR DESCRIPTION
The parser will otherwise just set heap_size_gib to 0.