### PR TITLE
snapshot: add support for custom http header

### DIFF
--- a/src/app/firedancer-dev/config/default.toml
+++ b/src/app/firedancer-dev/config/default.toml
@@ -28,6 +28,7 @@
     [tiles.replay]
         snapshot_url = "http://{validator_ip}:8899/snapshot.tar.bz2"
         incremental_url = "http://{validator_ip}:8899/incremental-snapshot.tar.bz2"
+        snapshot_additional_http_header = ""
     [tiles.metric]
         prometheus_listen_address = "0.0.0.0"
         prometheus_listen_port = 7999

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -1081,6 +1081,22 @@ user = ""
         snapshot = ""
         snapshot_url = ""
 
+        # Snapshots are downloaded over HTTP.  In some cases, private
+        # snapshot providers may require a custom header to be set to
+        # authenticate the request.
+        #
+        # The header key and value are unique to each provider and
+        # client, and should both be provided in the format
+        #
+        #  "Header-Name: Header-Value"
+        #
+        # For example,
+        #
+        #  "X-token: jdkiejugb-96f55e-122e-b5s6-22e33te66ee5s22e"
+        #
+        # If the value is empty, no custom header will be set.
+        snapshot_additional_http_header = ""
+
         # Where to obtain the incremental snapshot.
         #
         # If you have an incremental snapshot pre-downloaded somewhere,

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -226,6 +226,9 @@ setup_snapshots( config_t *       config,
 
   strncpy( tile->replay.snapshot_dir, config->tiles.replay.snapshot_dir, sizeof(tile->replay.snapshot_dir) );
   tile->replay.snapshot_dir[ sizeof(tile->replay.snapshot_dir)-1UL ] = '\0';
+
+  strncpy( tile->replay.snapshot_additional_http_header, config->tiles.replay.snapshot_additional_http_header, sizeof(tile->replay.snapshot_additional_http_header) );
+  tile->replay.snapshot_additional_http_header[ sizeof(tile->replay.snapshot_additional_http_header)-1UL ] = '\0';
 }
 
 void

--- a/src/app/ledger/main.c
+++ b/src/app/ledger/main.c
@@ -1124,7 +1124,8 @@ ingest( fd_ledger_args_t * args ) {
                           FD_SNAPSHOT_TYPE_FULL,
                           args->exec_spads,
                           args->exec_spad_cnt,
-                          args->runtime_spad );
+                          args->runtime_spad,
+                          NULL );
     FD_LOG_NOTICE(( "imported records from snapshot" ));
   }
   if( args->incremental ) {
@@ -1139,7 +1140,8 @@ ingest( fd_ledger_args_t * args ) {
                           FD_SNAPSHOT_TYPE_INCREMENTAL,
                           args->exec_spads,
                           args->exec_spad_cnt,
-                          args->runtime_spad );
+                          args->runtime_spad,
+                          NULL );
     FD_LOG_NOTICE(( "imported records from incremental snapshot" ));
   }
 
@@ -1312,7 +1314,8 @@ replay( fd_ledger_args_t * args ) {
                           FD_SNAPSHOT_TYPE_FULL,
                           args->exec_spads,
                           args->exec_spad_cnt,
-                          args->runtime_spad );
+                          args->runtime_spad,
+                          NULL );
     FD_LOG_NOTICE(( "imported from snapshot" ));
     if( args->incremental ) {
       fd_snapshot_load_all( args->incremental,
@@ -1326,7 +1329,8 @@ replay( fd_ledger_args_t * args ) {
                             FD_SNAPSHOT_TYPE_INCREMENTAL,
                             args->exec_spads,
                             args->exec_spad_cnt,
-                            args->runtime_spad );
+                            args->runtime_spad,
+                            NULL );
       FD_LOG_NOTICE(( "imported from snapshot" ));
     }
   }

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -389,6 +389,7 @@ struct fd_config {
       char  snapshot[ PATH_MAX ];
       char  snapshot_url[ PATH_MAX ];
       char  snapshot_dir[ PATH_MAX ];
+      char  snapshot_additional_http_header[ PATH_MAX ];
       char  status_cache[ PATH_MAX ];
       char  cluster_version[ 32 ];
       char  tower_checkpt[ PATH_MAX ];

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -227,6 +227,7 @@ fd_config_extract_pod( uchar *       pod,
   CFG_POP      ( cstr,   tiles.replay.snapshot                            );
   CFG_POP      ( cstr,   tiles.replay.snapshot_url                        );
   CFG_POP      ( cstr,   tiles.replay.snapshot_dir                        );
+  CFG_POP      ( cstr,   tiles.replay.snapshot_additional_http_header         );
   CFG_POP      ( cstr,   tiles.replay.status_cache                        );
   CFG_POP      ( cstr,   tiles.replay.cluster_version                     );
   CFG_POP      ( cstr,   tiles.replay.tower_checkpt                       );

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -289,6 +289,7 @@ struct fd_topo_tile {
       char  shred_cap[ PATH_MAX ];
       char  snapshot[ PATH_MAX ];
       char  snapshot_dir[ PATH_MAX ];
+      char  snapshot_additional_http_header[ PATH_MAX ];
       char  status_cache[ PATH_MAX ];
       char  cluster_version[ 32 ];
       char  tower_checkpt[ PATH_MAX ];

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -138,6 +138,7 @@ struct fd_replay_tile_ctx {
   char const * incremental;
   char const * snapshot;
   char const * snapshot_dir;
+  char const * snapshot_additional_http_header;
   int          incremental_src_type;
   int          snapshot_src_type;
 
@@ -1622,7 +1623,8 @@ read_snapshot( void *              _ctx,
                fd_stem_context_t * stem,
                char const *        snapshot,
                char const *        incremental,
-               char const *        snapshot_dir ) {
+               char const *        snapshot_dir,
+               char const *        snapshot_additional_http_header ) {
   fd_replay_tile_ctx_t * ctx = (fd_replay_tile_ctx_t *)_ctx;
 
   fd_exec_para_cb_ctx_t exec_para_ctx_snap = {
@@ -1669,7 +1671,8 @@ read_snapshot( void *              _ctx,
                                                                     ctx->exec_spads,
                                                                     ctx->exec_spad_cnt,
                                                                     ctx->runtime_spad,
-                                                                    &exec_para_ctx_snap );
+                                                                    &exec_para_ctx_snap,
+                                                                    snapshot_additional_http_header );
       /* Load the prefetch manifest, and initialize the status cache and slot context,
          so that we can use these to kick off repair. */
       fd_snapshot_load_prefetch_manifest( tmp_snap_ctx );
@@ -1689,7 +1692,8 @@ read_snapshot( void *              _ctx,
                                                               ctx->exec_spads,
                                                               ctx->exec_spad_cnt,
                                                               ctx->runtime_spad,
-                                                              &exec_para_ctx_snap );
+                                                              &exec_para_ctx_snap,
+                                                              snapshot_additional_http_header );
 
     fd_snapshot_load_init( snap_ctx );
 
@@ -1728,7 +1732,8 @@ read_snapshot( void *              _ctx,
                           FD_SNAPSHOT_TYPE_INCREMENTAL,
                           ctx->exec_spads,
                           ctx->exec_spad_cnt,
-                          ctx->runtime_spad );
+                          ctx->runtime_spad,
+                          snapshot_additional_http_header );
   }
 
   fd_runtime_update_leaders( ctx->slot_ctx,
@@ -1912,7 +1917,13 @@ init_snapshot( fd_replay_tile_ctx_t * ctx,
 
   uchar is_snapshot = strlen( ctx->snapshot ) > 0;
   if( is_snapshot ) {
-    read_snapshot( ctx, stem, ctx->snapshot, ctx->incremental, ctx->snapshot_dir );
+    read_snapshot(
+      ctx,
+      stem,
+      ctx->snapshot,
+      ctx->incremental,
+      ctx->snapshot_dir,
+      ctx->snapshot_additional_http_header );
   }
 
   if( ctx->plugin_out->mem ) {
@@ -2535,13 +2546,14 @@ unprivileged_init( fd_topo_t *      topo,
   /* TOML paths                                                         */
   /**********************************************************************/
 
-  ctx->blockstore_checkpt  = tile->replay.blockstore_checkpt;
-  ctx->tx_metadata_storage = tile->replay.tx_metadata_storage;
-  ctx->funk_checkpt        = tile->replay.funk_checkpt;
-  ctx->genesis             = tile->replay.genesis;
-  ctx->incremental         = tile->replay.incremental;
-  ctx->snapshot            = tile->replay.snapshot;
-  ctx->snapshot_dir        = tile->replay.snapshot_dir;
+  ctx->blockstore_checkpt          = tile->replay.blockstore_checkpt;
+  ctx->tx_metadata_storage         = tile->replay.tx_metadata_storage;
+  ctx->funk_checkpt                = tile->replay.funk_checkpt;
+  ctx->genesis                     = tile->replay.genesis;
+  ctx->incremental                 = tile->replay.incremental;
+  ctx->snapshot                    = tile->replay.snapshot;
+  ctx->snapshot_dir                = tile->replay.snapshot_dir;
+  ctx->snapshot_additional_http_header = tile->replay.snapshot_additional_http_header;
 
   ctx->incremental_src_type = tile->replay.incremental_src_type;
   ctx->snapshot_src_type    = tile->replay.snapshot_src_type;

--- a/src/flamenco/snapshot/fd_snapshot.h
+++ b/src/flamenco/snapshot/fd_snapshot.h
@@ -77,7 +77,8 @@ fd_snapshot_load_new( uchar *                 mem,
                       fd_spad_t * *           exec_spads,
                       ulong                   spad_cnt,
                       fd_spad_t *             runtime_spad,
-                      fd_exec_para_cb_ctx_t * exec_para_ctx );
+                      fd_exec_para_cb_ctx_t * exec_para_ctx,
+                      const char *            additional_http_header );
 
 void
 fd_snapshot_load_init( fd_snapshot_load_ctx_t * ctx );
@@ -106,7 +107,8 @@ fd_snapshot_load_all( const char *         source_cstr,
                       int                  snapshot_type,
                       fd_spad_t * *        exec_spads,
                       ulong                exec_spad_cnt,
-                      fd_spad_t *          runtime_spad );
+                      fd_spad_t *          runtime_spad,
+                      const char *         additional_http_header );
 
 void
 fd_snapshot_load_prefetch_manifest( fd_snapshot_load_ctx_t * ctx );

--- a/src/flamenco/snapshot/fd_snapshot_http.c
+++ b/src/flamenco/snapshot/fd_snapshot_http.c
@@ -60,7 +60,8 @@ fd_snapshot_http_new( void *               mem,
                       uint                 dst_ipv4,
                       ushort               dst_port,
                       const char *         snapshot_dir,
-                      fd_snapshot_name_t * name_out ) {
+                      fd_snapshot_name_t * name_out,
+                      const char *         additional_http_header ) {
 
   fd_snapshot_http_t * this = (fd_snapshot_http_t *)mem;
   if( FD_UNLIKELY( !this ) ) {
@@ -113,9 +114,19 @@ fd_snapshot_http_new( void *               mem,
   p = fd_cstr_append_text( p, dst_str, strlen(dst_str) );
 
   static char const hdr_part2[] =
-    "\r\n"
     "\r\n";
   p = fd_cstr_append_text( p, hdr_part2, sizeof(hdr_part2)-1 );
+
+  if( FD_UNLIKELY( additional_http_header && strlen(additional_http_header) > 0 ) ) {
+    p = fd_cstr_append_text( p, additional_http_header, strlen(additional_http_header) );
+    static char const hdr_part3[] =
+      "\r\n";
+    p = fd_cstr_append_text( p, hdr_part3, sizeof(hdr_part3)-1 );
+  }
+
+  static char const hdr_part4[] =
+    "\r\n";
+  p = fd_cstr_append_text( p, hdr_part4, sizeof(hdr_part4)-1 );
 
   this->req_head = (ushort)( p - this->req_buf );
 

--- a/src/flamenco/snapshot/fd_snapshot_http.h
+++ b/src/flamenco/snapshot/fd_snapshot_http.h
@@ -104,7 +104,8 @@ fd_snapshot_http_new( void *               mem,
                       uint                 dst_ipv4,
                       ushort               dst_port,
                       const char *         snapshot_dir,
-                      fd_snapshot_name_t * name_out );
+                      fd_snapshot_name_t * name_out,
+                      const char *         additional_http_header );
 
 void *
 fd_snapshot_http_delete( fd_snapshot_http_t * this );

--- a/src/flamenco/snapshot/fd_snapshot_loader.c
+++ b/src/flamenco/snapshot/fd_snapshot_loader.c
@@ -133,7 +133,8 @@ fd_snapshot_loader_init( fd_snapshot_loader_t *    d,
                          fd_snapshot_restore_t *   restore,
                          fd_snapshot_src_t const * src,
                          ulong                     base_slot,
-                         int                       validate_slot ) {
+                         int                       validate_slot,
+                         const char *              additional_http_header ) {
 
   d->restore = restore;
 
@@ -162,7 +163,14 @@ fd_snapshot_loader_init( fd_snapshot_loader_t *    d,
     d->vsrc = fd_io_istream_file_virtual( d->vfile );
     break;
   case FD_SNAPSHOT_SRC_HTTP:
-    d->http = fd_snapshot_http_new( d->http_mem, src->http.dest, src->http.ip4, src->http.port, src->snapshot_dir, &d->name );
+    d->http = fd_snapshot_http_new(
+      d->http_mem,
+      src->http.dest,
+      src->http.ip4,
+      src->http.port,
+      src->snapshot_dir,
+      &d->name,
+      additional_http_header );
     if( FD_UNLIKELY( !d->http ) ) {
       FD_LOG_WARNING(( "Failed to create fd_snapshot_http_t" ));
       return NULL;

--- a/src/flamenco/snapshot/fd_snapshot_loader.h
+++ b/src/flamenco/snapshot/fd_snapshot_loader.h
@@ -73,7 +73,8 @@ fd_snapshot_loader_init( fd_snapshot_loader_t *    loader,
                          fd_snapshot_restore_t *   restore,
                          fd_snapshot_src_t const * src,
                          ulong                     base_slot,
-                         int                       validate_slot );
+                         int                       validate_slot,
+                         const char *              additional_http_header );
 
 /* fd_snapshot_loader_advance polls the tar reader for data.  This data
    is synchronously passed down the pipeline (ending in a manifest

--- a/src/flamenco/snapshot/fd_snapshot_main.c
+++ b/src/flamenco/snapshot/fd_snapshot_main.c
@@ -358,7 +358,7 @@ do_dump( fd_snapshot_dumper_t *    d,
 
   /* Set up the snapshot loader */
 
-  if( FD_UNLIKELY( !fd_snapshot_loader_init( d->loader, d->restore, src, 0UL, 0 ) ) ) {
+  if( FD_UNLIKELY( !fd_snapshot_loader_init( d->loader, d->restore, src, 0UL, 0, NULL ) ) ) {
     FD_LOG_WARNING(( "fd_snapshot_loader_init failed" ));
     return EXIT_FAILURE;
   }

--- a/src/flamenco/snapshot/fuzz_snapshot_http.c
+++ b/src/flamenco/snapshot/fuzz_snapshot_http.c
@@ -46,7 +46,8 @@ target_task( void * ctx ) {
 
   fd_snapshot_name_t name[1] = {{0}};
   fd_snapshot_http_t  _http[1];
-  fd_snapshot_http_t * http = fd_snapshot_http_new( _http, "localhost:80", FD_IP4_ADDR( 127, 0, 0, 1 ), 80, NULL, name );
+  fd_snapshot_http_t * http = fd_snapshot_http_new(
+    _http, "localhost:80", FD_IP4_ADDR( 127, 0, 0, 1 ), 80, NULL, name, NULL );
 
   /* Hijack the HTTP state and make it think there is a successful connection */
   assert( http->socket_fd == -1 );

--- a/src/flamenco/snapshot/test_snapshot_http.c
+++ b/src/flamenco/snapshot/test_snapshot_http.c
@@ -7,7 +7,14 @@ main( int     argc,
 
   fd_snapshot_name_t name[1] = {{0}};
   fd_snapshot_http_t _http[1];
-  fd_snapshot_http_t * http = fd_snapshot_http_new( _http, "1.1.1.1:80", 0x01010101, 80, NULL, name );
+  fd_snapshot_http_t * http = fd_snapshot_http_new(
+    _http,
+    "1.1.1.1:80",
+    0x01010101,
+    80,
+    NULL,
+    name,
+    "X-custom-header: some_custom_header" );
   FD_TEST( http );
   FD_TEST( 0==memcmp( http->req_buf + http->req_tail,
       "GET /snapshot.tar.bz2 HTTP/1.1\r\n"
@@ -15,6 +22,7 @@ main( int     argc,
       "accept: */*\r\n"
       "accept-encoding: identity\r\n"
       "host: 1.1.1.1:80\r\n"
+      "X-custom-header: some_custom_header\r\n"
       "\r\n",
       (ulong)( http->req_head - http->req_tail ) ) );
   FD_TEST( fd_snapshot_http_delete( http )==_http );


### PR DESCRIPTION
Some private RPC nodes require an extra non-standard HTTP header for token authentication. Unfortunately, this is not a standard API bearer token format, but a custom http header.