### PR TITLE
multi_epoch_leaders: get_next_slot check across epochs

### DIFF
--- a/src/flamenco/leaders/fd_multi_epoch_leaders.h
+++ b/src/flamenco/leaders/fd_multi_epoch_leaders.h
@@ -123,14 +123,13 @@ fd_multi_epoch_leaders_get_sorted_lscheds( fd_multi_epoch_leaders_t const * mlea
 
 
 /* fd_multi_epoch_leaders_get_next_slot returns the first slot on or after
-   start_slot that 'leader' will be leader. It only checks the epoch containing
-   start_slot. If it can't find one, returns ULONG_MAX.
+   start_slot that 'leader' will be leader. If it can't find one, returns ULONG_MAX.
 
    Failures cases include:
       - mleaders does not track the epoch containing start_slot
         - It was either never initialized with that epoch information, or
         - It was overwritten by another epoch with the same parity
-      - leader_q does not have a leader slot in the epoch containing start_slot
+      - leader_q does not have a leader slot in the epochs tracked
       - leader_q was part of the excluded_stake for that epoch, and the lsched
         returns FD_INDETERMINATE_LEADER as the leader for leader_q's slots.
 */

--- a/src/flamenco/leaders/test_multi_leaders.c
+++ b/src/flamenco/leaders/test_multi_leaders.c
@@ -187,6 +187,9 @@ test_next_slot( void ) {
   fd_multi_epoch_leaders_stake_msg_init( mleaders, generate_stake_msg( stake_msg, 0UL, "ABC" ) );
   fd_multi_epoch_leaders_stake_msg_fini( mleaders );
 
+  fd_multi_epoch_leaders_stake_msg_init( mleaders, generate_stake_msg( stake_msg, 1UL, "D" ) );
+  fd_multi_epoch_leaders_stake_msg_fini( mleaders );
+
   fd_epoch_leaders_t const * lsched = fd_multi_epoch_leaders_get_lsched_for_epoch( mleaders, 0UL );
   FD_TEST( lsched );
   FD_TEST( lsched->slot0 == 0UL );
@@ -194,12 +197,22 @@ test_next_slot( void ) {
 
   /* Test finding next slot for each leader */
   fd_pubkey_t test_key;
-  for( char leader='A'; leader<'D'; leader++ ) {
-    memset( test_key.uc, leader, sizeof(fd_pubkey_t) );
+  for( char leader='A'; leader<='C'; leader++ ) {
+    fd_memset( test_key.uc, leader, sizeof(fd_pubkey_t) );
     ulong next_slot = fd_multi_epoch_leaders_get_next_slot( mleaders, 0UL, &test_key );
     FD_TEST( next_slot >= lsched->slot0 );
     FD_TEST( next_slot < lsched->slot0 + lsched->slot_cnt );
     FD_TEST( fd_multi_epoch_leaders_get_leader_for_slot( mleaders, next_slot )->uc[0] == leader );
+  }
+
+  /* test crossing epoch boundary */
+  {
+    fd_memset( test_key.uc, 'D', sizeof(fd_pubkey_t) );
+    fd_epoch_leaders_t const * lsched = fd_multi_epoch_leaders_get_lsched_for_epoch( mleaders, 1UL );
+    ulong next_slot = fd_multi_epoch_leaders_get_next_slot( mleaders, 0UL, &test_key );
+    FD_TEST( next_slot >= lsched->slot0 );
+    FD_TEST( next_slot < lsched->slot0 + lsched->slot_cnt );
+    FD_TEST( fd_multi_epoch_leaders_get_leader_for_slot( mleaders, next_slot )->uc[0] == 'D' );
   }
 
   /* Test with non-existent leader */


### PR DESCRIPTION
This PR modifies multi_epoch_leaders_get_next_slot to search for the next leader slot across epoch boundaries, to better mirror the original behavior of poh_tile.  