### PR TITLE
Update tuning.md

### DIFF
--- a/book/guide/tuning.md
+++ b/book/guide/tuning.md
@@ -78,7 +78,7 @@ recommendations for `mainnet-beta`,
 | `net`    | 1               | Handles >1M TPS per tile. Designed to scale out for future network conditions, but there is no need to run more than 1 net tile at the moment on `mainnet-beta` |
 | `quic`   | 1               | Handles >1M TPS per tile. Designed to scale out for future network conditions, but there is no need to run more than 1 QUIC tile at the moment on `mainnet-beta` |
 | `verify` | 4               | Handles 20-40k TPS per tile. Recommend running many verify tiles, as signature verification is the primary bottleneck of the application |
-| `bank`   | 2               | Handles 20-40k TPS per tile, with diminishing returns from adding more tiles. Designed to scale out for future network conditions, but 2 tiles is enough to handle current `mainnet-beta` conditions. Can be increased further when benchmarking to test future network performance |
+| `bank`   | 4               | Handles 20-40k TPS per tile, with diminishing returns from adding more tiles. Designed to scale out for future network conditions, but 4 tiles is enough to handle current `mainnet-beta` conditions. Can be increased further when benchmarking to test future network performance |
 | `shred`  | 1               | Throughput is mainly dependent on cluster size, 1 tile is enough to handle current `mainnet-beta` conditions. In benchmarking, if the cluster size is small, 1 tile can handle >1M TPS |
 
 ## Testing


### PR DESCRIPTION
Hi,

I have seen a small discrepancy between the default.toml file provided in docs.firedancer.io that says :  How many bank tiles to run.  Should be set to 4 for perf and balanced scheduling modes. 

And the tuning part that says about bank tiles : 
Handles 20-40k TPS per tile, with diminishing returns from adding more tiles. Designed to scale out for future network conditions, but 2 tiles is enough to handle current mainnet-beta conditions.

One source says that 4 is best and the other one 2 with a diminishing returns from adding more tiles.

Hope I understand it well and it can help others. 

<img width="769" alt="Capture d’écran 2025-06-20 à 17 51 47" src="https://github.com/user-attachments/assets/b006a673-7d77-471a-a95b-5f64e365f259" />
<img width="733" alt="Capture d’écran 2025-06-20 à 17 51 38" src="https://github.com/user-attachments/assets/1b409f0c-4fcd-4627-9fd8-ff2a52ace4ec" />


Best,

Léo