### PR TITLE
Fix Clangd linting for C headers

### DIFF
--- a/src/.clangd
+++ b/src/.clangd
@@ -23,3 +23,9 @@ CompileFlags:
   - -Wdouble-promotion
   - -Wformat-security
   - -Wimplicit-fallthrough
+---
+If:
+  PathMatch: .*\.h
+CompileFlags:
+  Add:
+  - -xc-header


### PR DESCRIPTION
Clangd incorrectly recognized .h files as Objective-C headers.
Fixes that.
