### PR TITLE
flamenco: is_owned_by_current_program conformance in err case

### DIFF
--- a/src/flamenco/runtime/fd_borrowed_account.h
+++ b/src/flamenco/runtime/fd_borrowed_account.h
@@ -358,7 +358,7 @@ fd_borrowed_account_is_owned_by_current_program( fd_borrowed_account_t const * b
   fd_pubkey_t const * program_id_pubkey = NULL;
   int err = fd_exec_instr_ctx_get_last_program_key( borrowed_acct->instr_ctx, &program_id_pubkey );
   if( FD_UNLIKELY( err ) ) {
-    return err;
+    return 0;
   }
 
   return memcmp( program_id_pubkey->key,


### PR DESCRIPTION
Agave calls unwrap_or_default, which would return false/0 in this case.
```rust
            .get_last_program_key(self.transaction_context)
            .map(|key| key == self.get_owner())
            .unwrap_or_default()
```