### PR TITLE
Fix broken link to getting-started.md in system-xdp documentation

### DIFF
--- a/doc/system-xdp.md
+++ b/doc/system-xdp.md
@@ -6,7 +6,7 @@ Installation guide for `XDP`/`AF_XDP` based networking.
 Prerequisites
 -------------
 
-This guide assumes the steps in [getting-started.md](./getting-started.md)
+This guide assumes the steps in [getting-started.md](../book/guide/getting-started.md)
 have been completed.
 
 Requires recent Linux kernel and headers (version >=4.18). `XDP` and related


### PR DESCRIPTION
Updated the link to the getting-started guide in doc/system-xdp.md to point to the correct location at ../book/guide/getting-started.md. This resolves a broken link error and ensures users can access the required setup instructions.