### PR TITLE
bundle: fix set-identity

### DIFF
--- a/src/disco/bundle/fd_bundle_client.c
+++ b/src/disco/bundle/fd_bundle_client.c
@@ -32,6 +32,7 @@ fd_bundle_client_reset( fd_bundle_tile_t * ctx ) {
   }
   ctx->defer_reset = 0;
 
+  ctx->builder_info_avail       = 0;
   ctx->builder_info_wait        = 0;
   ctx->packet_subscription_live = 0;
   ctx->packet_subscription_wait = 0;

--- a/src/disco/bundle/fd_bundle_tile_private.h
+++ b/src/disco/bundle/fd_bundle_tile_private.h
@@ -47,7 +47,6 @@ typedef struct fd_bundle_metrics fd_bundle_metrics_t;
 struct fd_bundle_tile {
   /* Key switch */
   fd_keyswitch_t * keyswitch;
-  uint             identity_switched : 1;
 
   /* Key guard */
   fd_keyguard_client_t keyguard_client[1];
@@ -182,6 +181,11 @@ fd_bundle_tile_should_stall( fd_bundle_tile_t const * ctx,
                              long                     tickcount ) {
   return tickcount < ctx->backoff_until;
 }
+
+/* fd_bundle_tile_housekeeping runs periodically at a low frequency. */
+
+void
+fd_bundle_tile_housekeeping( fd_bundle_tile_t * ctx );
 
 /* fd_bundle_client_grpc_rx_msg is called by grpc_client when a gRPC
    message arrives (unary or server-streaming response). */


### PR DESCRIPTION
Fixes a bug where the bundle tile keeps an old session after running set-identity.
