### PR TITLE
Fix tower tile seccomp policy

### DIFF
--- a/src/discof/tower/fd_tower_tile.c
+++ b/src/discof/tower/fd_tower_tile.c
@@ -1,7 +1,5 @@
 #define _GNU_SOURCE
 
-#include "generated/fd_tower_tile_seccomp.h"
-
 #include "../../choreo/fd_choreo.h"
 #include "../../disco/fd_disco.h"
 #include "../../disco/keyguard/fd_keyload.h"
@@ -10,6 +8,7 @@
 #include "../../flamenco/runtime/fd_runtime.h"
 #include "../../funk/fd_funk.h"
 #include "../../funk/fd_funk_val.h"
+#include "generated/fd_tower_tile_seccomp.h"
 
 #define IN_KIND_GOSSIP ( 0)
 #define IN_KIND_REPLAY ( 1)

--- a/src/discof/tower/generated/fd_tower_tile_seccomp.h
+++ b/src/discof/tower/generated/fd_tower_tile_seccomp.h
@@ -3,7 +3,6 @@
 #define HEADER_fd_src_discof_tower_generated_fd_tower_tile_seccomp_h
 
 #include "../../../../src/util/fd_util_base.h"
-#include "../../../../src/util/log/fd_log.h"
 #include <linux/audit.h>
 #include <linux/capability.h>
 #include <linux/filter.h>


### PR DESCRIPTION
Reverts handmade changes to an autogenerated seccomp policy
