### PR TITLE
flamenco, runtime: set original_data_len for non-DM CPI

### DIFF
--- a/src/flamenco/runtime/program/fd_bpf_loader_serialization.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_serialization.c
@@ -82,6 +82,7 @@ write_account( fd_borrowed_account_t *   account,
   uchar const * data = account ? fd_borrowed_account_get_data( account )     : NULL;
   ulong         dlen = account ? fd_borrowed_account_get_data_len( account ) : 0UL;
 
+  acc_region_metas[instr_acc_idx].original_data_len = dlen;
   if( copy_account_data ) {
     /* Copy the account data into input region buffer */
     fd_memcpy( *serialized_params, data, dlen );
@@ -93,6 +94,11 @@ write_account( fd_borrowed_account_t *   account,
       fd_memset( *serialized_params, 0, MAX_PERMITTED_DATA_INCREASE + align_offset );
       *serialized_params += MAX_PERMITTED_DATA_INCREASE + align_offset;
     }
+    /* In the non-DM case, we don't bother with setting up mem regions.
+       So has_data_region and has_resizing_region are set to 0. */
+    acc_region_metas[instr_acc_idx].region_idx          = UINT_MAX;
+    acc_region_metas[instr_acc_idx].has_data_region     = 0U;
+    acc_region_metas[instr_acc_idx].has_resizing_region = 0U;
   } else { /* direct_mapping == true */
     /* First, push on the region for the metadata that has just been serialized.
        This function will push the metadata in the serialized_params from

--- a/src/flamenco/runtime/tests/run_backtest_ci.sh
+++ b/src/flamenco/runtime/tests/run_backtest_ci.sh
@@ -17,3 +17,4 @@ src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-331691646-v2.2.16 -
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-257039990-v2.2.16 -s snapshot-257039990-BSgErEc6ppN4p91meqPvUiXPiEhbakBNHMQQ4wKmceYv.tar.zst -y 5 -m 10000000 -e 257040003 -c 2.2.16
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-336218682-v2.2.16 -s snapshot-336218681-BDsErdHkqa5iQGCNkSvQpeon8GLFsgeNEkckrMKboJ4N.tar.zst -y 5 -m 2000000 -e 336218683 -c 2.2.16
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-340269866 -s snapshot-340269865-7kiU4fCQMuf97vs3827n1vn1oScnkYYvvQ1sGGa1QKVE.tar.zst -y 5 -m 2000000 -e 340269872 -c 2.2.16
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-390056400 -s snapshot-390056399-6JQvYEDzQqcrjF4EoxkWUMuskm9aGoGRG94twEqXuuri.tar.zst -y 10 -m 2000000 -e 390056406 -c 2.2.16

--- a/src/flamenco/runtime/tests/run_backtest_tests_all.sh
+++ b/src/flamenco/runtime/tests/run_backtest_tests_all.sh
@@ -83,3 +83,4 @@ src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-380592002-v2.2.16 -s
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-336218682-v2.2.16 -s snapshot-336218681-BDsErdHkqa5iQGCNkSvQpeon8GLFsgeNEkckrMKboJ4N.tar.zst -y 5 -m 2000000 -e 336218683 -c 2.2.16
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-340269866 -s snapshot-340269865-7kiU4fCQMuf97vs3827n1vn1oScnkYYvvQ1sGGa1QKVE.tar.zst -y 5 -m 2000000 -e 340269872 -c 2.2.16
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-340272018 -s snapshot-340272017-SoJMtGKERj3xMB6jB7bumiHe96q4xVjHVN4kz2MGbqn.tar.zst -y 5 -m 2000000 -e 340272024 -c 2.2.16
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-390056400 -s snapshot-390056399-6JQvYEDzQqcrjF4EoxkWUMuskm9aGoGRG94twEqXuuri.tar.zst -y 10 -m 2000000 -e 390056406 -c 2.2.16

--- a/src/flamenco/vm/fd_vm.h
+++ b/src/flamenco/vm/fd_vm.h
@@ -41,6 +41,11 @@ struct __attribute((aligned(8UL))) fd_vm_acc_region_meta {
    /* offset of the accounts metadata region, relative to the start of the input region.
       importantly, this excludes any duplicate account markers at the beginning of the "full" metadata region. */
    ulong                               metadata_region_offset;
+   /* FIXME: We can get rid of this field once DM is activated.  This is
+      only a hack to make the non-DM code path happy.  When DM is
+      activated, we could query the input_mem_region array for the
+      original data len. */
+   ulong                               original_data_len;
 };
 typedef struct fd_vm_acc_region_meta fd_vm_acc_region_meta_t;
 


### PR DESCRIPTION
Also a minor drive-by fix for update_caller_account() in the CPI return edge. Use the correct source for prev_len.