### PR TITLE
pack: pack is responsible for ending leader slots

### DIFF
--- a/src/app/fdctl/topology.c
+++ b/src/app/fdctl/topology.c
@@ -34,6 +34,7 @@ fd_topo_initialize( config_t * config ) {
   fd_topob_wksp( topo, "dedup_resolv" );
   fd_topob_wksp( topo, "resolv_pack"  );
   fd_topob_wksp( topo, "pack_bank"    );
+  fd_topob_wksp( topo, "pack_poh"     );
   fd_topob_wksp( topo, "bank_pack"    );
   fd_topob_wksp( topo, "bank_poh"     );
   fd_topob_wksp( topo, "bank_busy"    );
@@ -75,6 +76,7 @@ fd_topo_initialize( config_t * config ) {
   /* pack_bank is shared across all banks, so if one bank stalls due to complex transactions, the buffer neeeds to be large so that
      other banks can keep proceeding. */
   /**/                 fd_topob_link( topo, "pack_bank",    "pack_bank",    65536UL,                                  USHORT_MAX,             1UL );
+  /**/                 fd_topob_link( topo, "pack_poh",     "pack_poh",     128UL,                                    sizeof(fd_done_packing_t), 1UL );
   FOR(bank_tile_cnt)   fd_topob_link( topo, "bank_poh",     "bank_poh",     16384UL,                                  USHORT_MAX,             1UL );
   FOR(bank_tile_cnt)   fd_topob_link( topo, "bank_pack",    "bank_pack",    16384UL,                                  USHORT_MAX,             3UL );
   /**/                 fd_topob_link( topo, "poh_pack",     "bank_poh",     128UL,                                    sizeof(fd_became_leader_t), 1UL );
@@ -170,6 +172,7 @@ fd_topo_initialize( config_t * config ) {
   /**/                 fd_topob_tile_in(  topo, "pack",   0UL,           "metric_in", "poh_pack",     0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_in(  topo, "pack",   0UL,           "metric_in", "executed_txn", 0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
                        fd_topob_tile_out( topo, "pack",   0UL,                        "pack_bank",    0UL                                                );
+                       fd_topob_tile_out( topo, "pack",   0UL,                        "pack_poh",     0UL                                                );
   FOR(bank_tile_cnt)   fd_topob_tile_in(  topo, "bank",   i,             "metric_in", "pack_bank",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   FOR(bank_tile_cnt)   fd_topob_tile_out( topo, "bank",   i,                          "bank_poh",     i                                                  );
   FOR(bank_tile_cnt)   fd_topob_tile_out( topo, "bank",   i,                          "bank_pack",    i                                                  );
@@ -177,7 +180,7 @@ fd_topo_initialize( config_t * config ) {
   if( FD_LIKELY( config->tiles.pack.use_consumed_cus ) )
     FOR(bank_tile_cnt) fd_topob_tile_in(  topo, "pack",   0UL,           "metric_in", "bank_pack",    i,            FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_in(  topo, "poh",    0UL,           "metric_in", "stake_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-  /**/                 fd_topob_tile_in(  topo, "poh",    0UL,           "metric_in", "pack_bank",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+  /**/                 fd_topob_tile_in(  topo, "poh",    0UL,           "metric_in", "pack_poh",     0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_out( topo, "poh",    0UL,                        "poh_shred",    0UL                                                );
   /**/                 fd_topob_tile_out( topo, "poh",    0UL,                        "poh_pack",     0UL                                                );
   FOR(shred_tile_cnt) for( ulong j=0UL; j<net_tile_cnt; j++ )
@@ -250,6 +253,7 @@ fd_topo_initialize( config_t * config ) {
     /**/                 fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "plugin_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     /**/                 fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "poh_pack",     0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     /**/                 fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "pack_bank",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+    /**/                 fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "pack_poh",     0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     FOR(bank_tile_cnt)   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "bank_poh",     i,            FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   }
 

--- a/src/disco/fd_disco_base.h
+++ b/src/disco/fd_disco_base.h
@@ -17,8 +17,7 @@
 
 #define POH_PKT_TYPE_MICROBLOCK    (0UL)
 #define POH_PKT_TYPE_BECAME_LEADER (1UL)
-#define POH_PKT_TYPE_DONE_PACKING  (2UL)
-#define POH_PKT_TYPE_FEAT_ACT_SLOT (3UL)
+#define POH_PKT_TYPE_FEAT_ACT_SLOT (2UL)
 
 #define REPLAY_FLAG_FINISHED_BLOCK      (0x01UL)
 #define REPLAY_FLAG_PACKED_MICROBLOCK   (0x02UL)
@@ -119,12 +118,12 @@ FD_FN_CONST static inline ulong fd_disco_poh_sig_bank_tile( ulong sig ) { return
 
 FD_FN_CONST static inline ulong
 fd_disco_bank_sig( ulong slot,
-                   ulong microblock_idx ) {
-  return (slot << 32) | microblock_idx;
+                   ulong pack_idx ) {
+  return (slot << 32) | pack_idx;
 }
 
 FD_FN_CONST static inline ulong fd_disco_bank_sig_slot( ulong sig ) { return (sig >> 32); }
-FD_FN_CONST static inline ulong fd_disco_bank_sig_microblock_idx( ulong sig ) { return sig & 0xFFFFFFFFUL; }
+FD_FN_CONST static inline ulong fd_disco_bank_sig_pack_idx( ulong sig ) { return sig & 0xFFFFFFFFUL; }
 
 /* TODO remove with store_int */
 

--- a/src/disco/gui/fd_gui_tile.c
+++ b/src/disco/gui/fd_gui_tile.c
@@ -43,7 +43,8 @@ extern uint  const fdctl_commit_ref;
 #define IN_KIND_PLUGIN    (0UL)
 #define IN_KIND_POH_PACK  (1UL)
 #define IN_KIND_PACK_BANK (2UL)
-#define IN_KIND_BANK_POH  (3UL)
+#define IN_KIND_PACK_POH  (3UL)
+#define IN_KIND_BANK_POH  (4UL)
 
 FD_IMPORT_BINARY( firedancer_svg, "book/public/fire.svg" );
 
@@ -219,6 +220,8 @@ after_frag( fd_gui_ctx_t *      ctx,
     FD_TEST( fd_disco_poh_sig_pkt_type( sig )==POH_PKT_TYPE_BECAME_LEADER );
     fd_became_leader_t * became_leader = (fd_became_leader_t *)ctx->buf;
     fd_gui_became_leader( ctx->gui, fd_frag_meta_ts_decomp( tspub, fd_tickcount() ), fd_disco_poh_sig_slot( sig ), became_leader->slot_start_ns, became_leader->slot_end_ns, became_leader->limits.slot_max_cost, became_leader->max_microblocks_in_slot );
+  } else if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_PACK_POH ) ) {
+    fd_gui_unbecame_leader( ctx->gui, fd_frag_meta_ts_decomp( tspub, fd_tickcount() ), fd_disco_poh_sig_slot( sig ), ((fd_done_packing_t *)ctx->buf)->microblocks_in_slot );
   } else if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_PACK_BANK ) ) {
     if( FD_LIKELY( fd_disco_poh_sig_pkt_type( sig )==POH_PKT_TYPE_MICROBLOCK ) ) {
       FD_TEST( sz<ULONG_MAX );
@@ -230,8 +233,6 @@ after_frag( fd_gui_ctx_t *      ctx,
                                          (sz-sizeof( fd_microblock_bank_trailer_t ))/sizeof( fd_txn_p_t ),
                                          (uint)trailer->microblock_idx,
                                          trailer->pack_txn_idx );
-    } else if( FD_LIKELY( fd_disco_poh_sig_pkt_type( sig )==POH_PKT_TYPE_DONE_PACKING ) ) {
-      fd_gui_unbecame_leader( ctx->gui, fd_frag_meta_ts_decomp( tspub, fd_tickcount() ), fd_disco_poh_sig_slot( sig ), ((fd_done_packing_t *)ctx->buf)->microblocks_in_slot );
     } else {
       FD_LOG_ERR(( "unexpected poh packet type %lu", fd_disco_poh_sig_pkt_type( sig ) ));
     }
@@ -511,6 +512,7 @@ unprivileged_init( fd_topo_t *      topo,
     if( FD_LIKELY( !strcmp( link->name, "plugin_out"     ) ) ) ctx->in_kind[ i ] = IN_KIND_PLUGIN;
     else if( FD_LIKELY( !strcmp( link->name, "poh_pack"  ) ) ) ctx->in_kind[ i ] = IN_KIND_POH_PACK;
     else if( FD_LIKELY( !strcmp( link->name, "pack_bank" ) ) ) ctx->in_kind[ i ] = IN_KIND_PACK_BANK;
+    else if( FD_LIKELY( !strcmp( link->name, "pack_poh" ) ) )  ctx->in_kind[ i ] = IN_KIND_PACK_POH;
     else if( FD_LIKELY( !strcmp( link->name, "bank_poh"  ) ) ) ctx->in_kind[ i ] = IN_KIND_BANK_POH;
     else FD_LOG_ERR(( "gui tile has unexpected input link %lu %s", i, link->name ));
 

--- a/src/disco/tiles.h
+++ b/src/disco/tiles.h
@@ -151,6 +151,7 @@ struct fd_microblock_bank_trailer {
      banks.  This is used by PoH to ensure microblocks get committed
      in the same order they are executed. */
   ulong microblock_idx;
+  uint  pack_idx;
 
   /* A sequentially increasing index of the first transaction in the
      microblock, across all slots ever processed by pack.  This is used

--- a/src/discoh/poh/fd_poh_tile.c
+++ b/src/discoh/poh/fd_poh_tile.c
@@ -441,7 +441,7 @@ typedef struct {
      little bit over-strict, we just need to ensure that microblocks
      with conflicting accounts execute in order, but this is easiest to
      implement for now. */
-  ulong expect_microblock_idx;
+  uint expect_pack_idx;
 
   /* The PoH tile must never drop microblocks that get committed by the
      bank, so it needs to always be able to mixin a microblock hash.
@@ -1095,7 +1095,6 @@ fd_ext_poh_begin_leader( void const * bank,
   ctx->current_leader_bank     = bank;
   ctx->microblocks_lower_bound = 0UL;
   ctx->cus_used                = 0UL;
-  ctx->expect_microblock_idx   = 0UL;
 
   ctx->limits.slot_max_cost                = cus_block_limit;
   ctx->limits.slot_max_vote_cost           = cus_vote_cost_limit;
@@ -1775,16 +1774,12 @@ before_frag( fd_poh_ctx_t * ctx,
              ulong          sig ) {
   (void)seq;
 
-  if( FD_LIKELY( ctx->in_kind[ in_idx ]==IN_KIND_BANK ) ) {
-    ulong microblock_idx = fd_disco_bank_sig_microblock_idx( sig );
-    FD_TEST( microblock_idx>=ctx->expect_microblock_idx );
+  if( FD_LIKELY( ctx->in_kind[ in_idx ]!=IN_KIND_BANK && ctx->in_kind[ in_idx ]!=IN_KIND_PACK ) ) return 0;
 
-    /* Return the fragment to stem so we can process it later, if it's
-       not next in the sequence. */
-    if( FD_UNLIKELY( microblock_idx>ctx->expect_microblock_idx ) ) return -1;
-
-    ctx->expect_microblock_idx++;
-  }
+  uint pack_idx = (uint)fd_disco_bank_sig_pack_idx( sig );
+  FD_TEST( ((int)(pack_idx-ctx->expect_pack_idx))>=0L );
+  if( FD_UNLIKELY( pack_idx!=ctx->expect_pack_idx ) ) return -1;
+  ctx->expect_pack_idx++;
 
   return 0;
 }
@@ -1797,7 +1792,6 @@ during_frag( fd_poh_ctx_t * ctx,
              ulong          chunk,
              ulong          sz,
              ulong          ctl FD_PARAM_UNUSED ) {
-
   ctx->skip_frag = 0;
 
   if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_STAKE ) ) {
@@ -1810,16 +1804,13 @@ during_frag( fd_poh_ctx_t * ctx,
     return;
   }
 
-  ulong pkt_type;
   ulong slot;
   switch( ctx->in_kind[ in_idx ] ) {
     case IN_KIND_BANK: {
-      pkt_type = POH_PKT_TYPE_MICROBLOCK;
       slot = fd_disco_bank_sig_slot( sig );
       break;
     }
     case IN_KIND_PACK: {
-      pkt_type = fd_disco_poh_sig_pkt_type( sig );
       slot = fd_disco_poh_sig_slot( sig );
       break;
     }
@@ -1827,40 +1818,35 @@ during_frag( fd_poh_ctx_t * ctx,
       FD_LOG_ERR(( "unexpected in_kind %d", ctx->in_kind[ in_idx ] ));
   }
 
-  int is_frag_for_prior_leader_slot = 0;
-  if( FD_LIKELY( pkt_type==POH_PKT_TYPE_DONE_PACKING || pkt_type==POH_PKT_TYPE_MICROBLOCK ) ) {
-    /* The following sequence is possible...
+  /* The following sequence is possible...
 
-        1. We become leader in slot 10
-        2. While leader, we switch to a fork that is on slot 8, where
-            we are leader
-        3. We get the in-flight microblocks for slot 10
+      1. We become leader in slot 10
+      2. While leader, we switch to a fork that is on slot 8, where
+          we are leader
+      3. We get the in-flight microblocks for slot 10
 
-      These in-flight microblocks need to be dropped, so we check
-      against the high water mark (highwater_leader_slot) rather than
-      the current hashcnt here when determining what to drop.
+    These in-flight microblocks need to be dropped, so we check
+    against the high water mark (highwater_leader_slot) rather than
+    the current hashcnt here when determining what to drop.
 
-      We know if the slot is lower than the high water mark it's from a stale
-      leader slot, because we will not become leader for the same slot twice
-      even if we are reset back in time (to prevent duplicate blocks). */
-    is_frag_for_prior_leader_slot = slot<ctx->highwater_leader_slot;
-  }
+    We know if the slot is lower than the high water mark it's from a stale
+    leader slot, because we will not become leader for the same slot twice
+    even if we are reset back in time (to prevent duplicate blocks). */
+  int is_frag_for_prior_leader_slot = slot<ctx->highwater_leader_slot;
 
   if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_PACK ) ) {
     /* We now know the real amount of microblocks published, so set an
        exact bound for once we receive them. */
     ctx->skip_frag = 1;
-    if( pkt_type==POH_PKT_TYPE_DONE_PACKING ) {
-      if( FD_UNLIKELY( is_frag_for_prior_leader_slot ) ) return;
+    if( FD_UNLIKELY( is_frag_for_prior_leader_slot ) ) return;
 
-      FD_TEST( ctx->microblocks_lower_bound<=ctx->max_microblocks_per_slot );
-      fd_done_packing_t const * done_packing = fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk );
-      FD_LOG_INFO(( "done_packing(slot=%lu,seen_microblocks=%lu,microblocks_in_slot=%lu)",
-                    ctx->slot,
-                    ctx->microblocks_lower_bound,
-                    done_packing->microblocks_in_slot ));
-      ctx->microblocks_lower_bound += ctx->max_microblocks_per_slot - done_packing->microblocks_in_slot;
-    }
+    FD_TEST( ctx->microblocks_lower_bound<=ctx->max_microblocks_per_slot );
+    fd_done_packing_t const * done_packing = fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk );
+    FD_LOG_INFO(( "done_packing(slot=%lu,seen_microblocks=%lu,microblocks_in_slot=%lu)",
+                  ctx->slot,
+                  ctx->microblocks_lower_bound,
+                  done_packing->microblocks_in_slot ));
+    ctx->microblocks_lower_bound += ctx->max_microblocks_per_slot - done_packing->microblocks_in_slot;
     return;
   } else {
     if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark || sz>USHORT_MAX ) )
@@ -2245,6 +2231,7 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->lagged_consecutive_leader_start = tile->poh.lagged_consecutive_leader_start;
   ctx->expect_sequential_leader_slot = ULONG_MAX;
 
+  ctx->expect_pack_idx         = 0U;
   ctx->microblocks_lower_bound = 0UL;
 
   ctx->max_active_descendant = 0UL;
@@ -2328,7 +2315,7 @@ unprivileged_init( fd_topo_t *      topo,
 
     if(        !strcmp( link->name, "stake_out" ) ) {
       ctx->in_kind[ i ] = IN_KIND_STAKE;
-    } else if( !strcmp( link->name, "pack_bank" ) ) {
+    } else if( !strcmp( link->name, "pack_poh" ) ) {
       ctx->in_kind[ i ] = IN_KIND_PACK;
     } else if( !strcmp( link->name, "bank_poh"  ) ) {
       ctx->in_kind[ i ] = IN_KIND_BANK;


### PR DESCRIPTION
In full Firedancer the bank forks objects are implicitly refcounted by the leader pipeline, so they are acquired by pack and released by poh, because of this pack must "flush" the pipeline and give poh a way to guarantee the bank fork is not in use when it releases, which it can do by exactly sequencing the done packing messaage (must arrive after the bank microblocks).