### PR TITLE
make test_bundle_client only if FD_HAS_SSE

### DIFF
--- a/src/disco/bundle/Local.mk
+++ b/src/disco/bundle/Local.mk
@@ -8,7 +8,9 @@ endif
 $(call add-hdrs,fd_bundle_tile.h)
 $(call add-objs,fd_bundle_auth fd_bundle_client,fd_disco)
 ifdef FD_HAS_HOSTED
+ifdef FD_HAS_SSE
 $(call make-unit-test,test_bundle_client,test_bundle_client,fd_disco fd_waltz fd_flamenco fd_tango fd_ballet fd_util,$(OPENSSL_LIBS))
+endif
 $(call make-fuzz-test,fuzz_bundle_auth_resp,fuzz_bundle_auth_resp,fd_disco fd_waltz fd_flamenco fd_tango fd_ballet fd_util,$(OPENSSL_LIBS))
 endif
 


### PR DESCRIPTION
Otherwise, it can't link the `fd_bundle_tile_housekeeping` function.