### PR TITLE
chore: Fix typos

### DIFF
--- a/contrib/lint/check_include_guards.py
+++ b/contrib/lint/check_include_guards.py
@@ -10,7 +10,7 @@ import os
 def check_file(path):
     guard_name = "HEADER_fd_" + str(path).replace(".", "_").replace("/", "_")
     with open(path, "r") as f:
-        # Skip whitepsace lines
+        # Skip whitespace lines
         while True:
             line0 = f.readline()
             if not line0.startswith("/* ") and not line0.startswith("// ") and line0.strip():

--- a/contrib/quic/agave_compat/src/main.rs
+++ b/contrib/quic/agave_compat/src/main.rs
@@ -118,7 +118,7 @@ unsafe fn agave_to_fdquic() {
 
     // Rust's type system prevents us from passing raw pointers to a
     // thread even with appropriate synchronization barriers and unsafe.
-    // To escape this hostage situation, we indrect via usize ... sigh
+    // To escape this hostage situation, we indirect via usize ... sigh
     let udpsock2 = udpsock as usize;
     let quic2 = quic as usize;
     let stop_ptr = Box::leak(Box::new(AtomicU32::new(0))) as *mut AtomicU32 as usize;
@@ -192,7 +192,7 @@ unsafe fn agave_to_fdquic_bench() {
 
     // Rust's type system prevents us from passing raw pointers to a
     // thread even with appropriate synchronization barriers and unsafe.
-    // To escape this hostage situation, we indrect via usize ... sigh
+    // To escape this hostage situation, we indirect via usize ... sigh
     let quic2 = quic as usize;
     std::thread::spawn(move || {
         let quic3: *mut fd_quic_t = quic2 as *mut fd_quic_t;


### PR DESCRIPTION
### Summary

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details
  - `whitepsace` → `whitespace`
  - `indrect` → `indirect`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.
