### PR TITLE
gui: add bounds check to peer messages

### DIFF
--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -546,19 +546,23 @@ fd_gui_poll( fd_gui_t * gui ) {
 static void
 fd_gui_handle_gossip_update( fd_gui_t *    gui,
                              uchar const * msg ) {
+  if( FD_UNLIKELY( gui->gossip.peer_cnt == FD_GUI_MAX_PEER_CNT ) ) {
+    FD_LOG_DEBUG(("gossip peer cnt exceeds 40200 %lu, ignoring additional entries", gui->gossip.peer_cnt ));
+    return;
+  }
   ulong const * header = (ulong const *)fd_type_pun_const( msg );
   ulong peer_cnt = header[ 0 ];
 
-  FD_TEST( peer_cnt<=40200UL );
+  FD_TEST( peer_cnt<=FD_GUI_MAX_PEER_CNT );
 
   ulong added_cnt = 0UL;
-  ulong added[ 40200 ] = {0};
+  ulong added[ FD_GUI_MAX_PEER_CNT ] = {0};
 
   ulong update_cnt = 0UL;
-  ulong updated[ 40200 ] = {0};
+  ulong updated[ FD_GUI_MAX_PEER_CNT ] = {0};
 
   ulong removed_cnt = 0UL;
-  fd_pubkey_t removed[ 40200 ] = {0};
+  fd_pubkey_t removed[ FD_GUI_MAX_PEER_CNT ] = {0};
 
   uchar const * data = (uchar const *)(header+1UL);
   for( ulong i=0UL; i<gui->gossip.peer_cnt; i++ ) {
@@ -670,19 +674,23 @@ fd_gui_handle_gossip_update( fd_gui_t *    gui,
 static void
 fd_gui_handle_vote_account_update( fd_gui_t *    gui,
                                    uchar const * msg ) {
+  if( FD_UNLIKELY( gui->vote_account.vote_account_cnt==FD_GUI_MAX_PEER_CNT ) ) {
+    FD_LOG_DEBUG(("vote account cnt exceeds 40200 %lu, ignoring additional entries", gui->vote_account.vote_account_cnt ));
+    return;
+  }
   ulong const * header = (ulong const *)fd_type_pun_const( msg );
   ulong peer_cnt = header[ 0 ];
 
-  FD_TEST( peer_cnt<=40200UL );
+  FD_TEST( peer_cnt<=FD_GUI_MAX_PEER_CNT );
 
   ulong added_cnt = 0UL;
-  ulong added[ 40200 ] = {0};
+  ulong added[ FD_GUI_MAX_PEER_CNT ] = {0};
 
   ulong update_cnt = 0UL;
-  ulong updated[ 40200 ] = {0};
+  ulong updated[ FD_GUI_MAX_PEER_CNT ] = {0};
 
   ulong removed_cnt = 0UL;
-  fd_pubkey_t removed[ 40200 ] = {0};
+  fd_pubkey_t removed[ FD_GUI_MAX_PEER_CNT ] = {0};
 
   uchar const * data = (uchar const *)(header+1UL);
   for( ulong i=0UL; i<gui->vote_account.vote_account_cnt; i++ ) {
@@ -762,6 +770,10 @@ fd_gui_handle_vote_account_update( fd_gui_t *    gui,
 static void
 fd_gui_handle_validator_info_update( fd_gui_t *    gui,
                                      uchar const * msg ) {
+  if( FD_UNLIKELY( gui->validator_info.info_cnt == FD_GUI_MAX_PEER_CNT ) ) {
+    FD_LOG_DEBUG(("validator info cnt exceeds 40200 %lu, ignoring additional entries", gui->validator_info.info_cnt ));
+    return;
+  }
   uchar const * data = (uchar const *)fd_type_pun_const( msg );
 
   ulong added_cnt = 0UL;

--- a/src/disco/gui/fd_gui.h
+++ b/src/disco/gui/fd_gui.h
@@ -16,6 +16,7 @@
 #define FD_GUI_TILE_TIMER_LEADER_CNT               (4096UL)
 #define FD_GUI_TILE_TIMER_LEADER_DOWNSAMPLE_CNT    (50UL)
 #define FD_GUI_TILE_TIMER_TILE_CNT                 (128UL)
+#define FD_GUI_MAX_PEER_CNT                        (40200UL)
 
 #define FD_GUI_SLOT_LEVEL_INCOMPLETE               (0)
 #define FD_GUI_SLOT_LEVEL_COMPLETED                (1)
@@ -390,17 +391,17 @@ struct fd_gui {
 
   struct {
     ulong                     peer_cnt;
-    struct fd_gui_gossip_peer peers[ 40200 ];
+    struct fd_gui_gossip_peer peers[ FD_GUI_MAX_PEER_CNT ];
   } gossip;
 
   struct {
     ulong                      vote_account_cnt;
-    struct fd_gui_vote_account vote_accounts[ 40200 ];
+    struct fd_gui_vote_account vote_accounts[ FD_GUI_MAX_PEER_CNT ];
   } vote_account;
 
   struct {
     ulong                        info_cnt;
-    struct fd_gui_validator_info info[ 40200 ];
+    struct fd_gui_validator_info info[ FD_GUI_MAX_PEER_CNT ];
   } validator_info;
 };
 

--- a/src/disco/gui/fd_gui_printf.c
+++ b/src/disco/gui/fd_gui_printf.c
@@ -741,7 +741,7 @@ fd_gui_printf_peer( fd_gui_t *    gui,
                     uchar const * identity_pubkey ) {
   ulong gossip_idx = ULONG_MAX;
   ulong info_idx = ULONG_MAX;
-  ulong vote_idxs[ 40200 ] = {0};
+  ulong vote_idxs[ FD_GUI_MAX_PEER_CNT ] = {0};
   ulong vote_idx_cnt = 0UL;
 
   for( ulong i=0UL; i<gui->gossip.peer_cnt; i++ ) {

--- a/src/disco/gui/fd_gui_tile.c
+++ b/src/disco/gui/fd_gui_tile.c
@@ -80,7 +80,7 @@ typedef struct {
   /* This needs to be max(plugin_msg) across all kinds of messages.
      Currently this is just figured out manually, it's a gossip update
      message assuming the table is completely full (40200) of peers. */
-  uchar      buf[ 8UL+40200UL*(58UL+12UL*34UL) ] __attribute__((aligned(8)));
+  uchar      buf[ 8UL+FD_GUI_MAX_PEER_CNT*(58UL+12UL*34UL) ] __attribute__((aligned(8)));
 
   fd_http_server_t * gui_server;
 
@@ -176,11 +176,11 @@ during_frag( fd_gui_ctx_t * ctx,
     /* ... todo... sigh, sz is not correct since it's too big */
     if( FD_LIKELY( sig==FD_PLUGIN_MSG_GOSSIP_UPDATE ) ) {
       ulong peer_cnt = ((ulong *)src)[ 0 ];
-      FD_TEST( peer_cnt<=40200 );
+      FD_TEST( peer_cnt<=FD_GUI_MAX_PEER_CNT );
       sz = 8UL + peer_cnt*FD_GOSSIP_LINK_MSG_SIZE;
     } else if( FD_LIKELY( sig==FD_PLUGIN_MSG_VOTE_ACCOUNT_UPDATE ) ) {
       ulong peer_cnt = ((ulong *)src)[ 0 ];
-      FD_TEST( peer_cnt<=40200 );
+      FD_TEST( peer_cnt<=FD_GUI_MAX_PEER_CNT );
       sz = 8UL + peer_cnt*112UL;
     } else if( FD_UNLIKELY( sig==FD_PLUGIN_MSG_LEADER_SCHEDULE ) ) {
       ulong staked_cnt = ((ulong *)src)[ 1 ];


### PR DESCRIPTION
waiting for testnet to realive to test this
 
resolves https://github.com/firedancer-io/auditor-internal/issues/303

agave [diff](https://github.com/firedancer-io/agave/compare/04b8dfe993b358194cf77ccaee1c69aad7dc74fb..jherrera/gui-valinfo-bounds-check)