### PR TITLE
stem: reduce max lazy to 10ms

### DIFF
--- a/src/disco/quic/fd_quic_tile.c
+++ b/src/disco/quic/fd_quic_tile.c
@@ -612,7 +612,6 @@ populate_allowed_fds( fd_topo_t const *      topo,
 }
 
 #define STEM_BURST (1UL)
-#define STEM_LAZY  ((long)10e6) /* 10ms */
 
 #define STEM_CALLBACK_CONTEXT_TYPE  fd_quic_ctx_t
 #define STEM_CALLBACK_CONTEXT_ALIGN alignof(fd_quic_ctx_t)

--- a/src/disco/stem/fd_stem.c
+++ b/src/disco/stem/fd_stem.c
@@ -321,6 +321,7 @@ STEM_(run1)( ulong                        in_cnt,
   /* housekeeping init */
 
   if( lazy<=0L ) lazy = fd_tempo_lazy_default( cr_max );
+  lazy = fd_long_min( lazy, (long)10e6 ); /* report metrics ~100 times a second */
   FD_LOG_INFO(( "Configuring housekeeping (lazy %li ns)", lazy ));
 
   /* Initialize the initial event sequence to immediately update


### PR DESCRIPTION
The default max housekeeping interval is 2 seconds, which is too
large for our metrics system.
