### PR TITLE
Standardize Dcache Bounds

### DIFF
--- a/src/disco/archiver/fd_archiver_feeder.c
+++ b/src/disco/archiver/fd_archiver_feeder.c
@@ -125,9 +125,6 @@ during_frag( fd_archiver_feeder_tile_ctx_t * ctx,
              ulong                           sz,
              ulong                           ctl FD_PARAM_UNUSED ) {
   /* TODO: filter by signature in before_credit */
-  if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark ) ) {
-    FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
-  }
 
   uchar * src = (uchar *)fd_chunk_to_laddr( ctx->in[in_idx].mem, chunk );
   uchar * dst = (uchar *)fd_chunk_to_laddr( ctx->out_mem, ctx->out_chunk );

--- a/src/disco/archiver/fd_archiver_writer.c
+++ b/src/disco/archiver/fd_archiver_writer.c
@@ -191,9 +191,6 @@ during_frag( fd_archiver_writer_tile_ctx_t * ctx,
              ulong                           chunk,
              ulong                           sz,
              ulong                           ctl FD_PARAM_UNUSED ) {
-  if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark || sz<FD_ARCHIVER_FRAG_HEADER_FOOTPRINT ) ) {
-    FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
-  }
 
   /* Write the incoming fragment to the ostream */
   char * src = (char *)fd_chunk_to_laddr( ctx->in[in_idx].mem, chunk );

--- a/src/disco/dedup/fd_dedup_tile.c
+++ b/src/disco/dedup/fd_dedup_tile.c
@@ -108,9 +108,6 @@ during_frag( fd_dedup_ctx_t * ctx,
              ulong            sz,
              ulong            ctl FD_PARAM_UNUSED ) {
 
-  if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark || sz>ctx->in[ in_idx ].mtu ) )
-    FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
-
   uchar * src = (uchar *)fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk );
   uchar * dst = (uchar *)fd_chunk_to_laddr( ctx->out_mem, ctx->out_chunk );
 

--- a/src/disco/gui/fd_gui_tile.c
+++ b/src/disco/gui/fd_gui_tile.c
@@ -188,15 +188,12 @@ during_frag( fd_gui_ctx_t * ctx,
       sz = 40UL + staked_cnt*40UL;
     }
 
-    if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark || sz>sizeof( ctx->buf ) ) )
-      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
+    if( FD_UNLIKELY( sz>sizeof( ctx->buf ) ) )
+      FD_LOG_ERR(( "gui: plugin message size %lu > buf %lu", sz, (ulong)sizeof(ctx->buf) ));
 
     fd_memcpy( ctx->buf, src, sz );
     return;
   }
-
-  if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark || sz>ctx->in[ in_idx ].mtu ) )
-    FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
 
   fd_memcpy( ctx->buf, src, sz );
 }

--- a/src/disco/net/sock/fd_sock_tile.c
+++ b/src/disco/net/sock/fd_sock_tile.c
@@ -518,9 +518,6 @@ during_frag( fd_sock_tile_t * ctx,
              ulong            chunk,
              ulong            sz,
              ulong            ctl FD_PARAM_UNUSED ) {
-  if( FD_UNLIKELY( chunk<ctx->link_tx[ in_idx ].chunk0 || chunk>ctx->link_tx[ in_idx ].wmark || sz>FD_NET_MTU ) ) {
-    FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->link_tx[ in_idx ].chunk0, ctx->link_tx[ in_idx ].wmark ));
-  }
 
   ulong const hdr_min = sizeof(fd_eth_hdr_t)+sizeof(fd_ip4_hdr_t)+sizeof(fd_udp_hdr_t);
   if( FD_UNLIKELY( sz<hdr_min ) ) {

--- a/src/disco/net/xdp/fd_xdp_tile.c
+++ b/src/disco/net/xdp/fd_xdp_tile.c
@@ -601,9 +601,6 @@ during_frag( fd_net_ctx_t * ctx,
              ulong          chunk,
              ulong          sz,
              ulong          ctl FD_PARAM_UNUSED ) {
-  if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark || sz>FD_NET_MTU ) )
-    FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
-
   if( FD_UNLIKELY( sz<34UL ) )
     FD_LOG_ERR(( "packet too small %lu (in_idx=%lu)", sz, in_idx ));
 

--- a/src/disco/pack/fd_pack_tile.c
+++ b/src/disco/pack/fd_pack_tile.c
@@ -774,10 +774,6 @@ during_frag( fd_pack_ctx_t * ctx,
       /* Not interested in stamped microblocks, only leader updates. */
     if( fd_disco_poh_sig_pkt_type( sig )!=POH_PKT_TYPE_BECAME_LEADER ) return;
 
-    /* There was a leader transition.  Handle it. */
-    if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark || sz!=sizeof(fd_became_leader_t) ) )
-      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
-
     long now_ticks = fd_tickcount();
     long now_ns    = fd_log_wallclock();
 

--- a/src/disco/plugin/fd_plugin_tile.c
+++ b/src/disco/plugin/fd_plugin_tile.c
@@ -70,10 +70,7 @@ during_frag( fd_plugin_ctx_t * ctx,
     FD_TEST( staked_cnt<=50000UL );
     sz = 40UL + staked_cnt*40UL;
   }
-
-  if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark || sz>ctx->in[ in_idx ].mtu ) )
-    FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
-
+  
   fd_memcpy( dst, src, sz );
 }
 

--- a/src/disco/shred/fd_shred_tile.c
+++ b/src/disco/shred/fd_shred_tile.c
@@ -349,19 +349,12 @@ during_frag( fd_shred_ctx_t * ctx,
   ctx->tsorig = fd_frag_meta_ts_comp( fd_tickcount() );
 
   if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_REPAIR ) ) {
-    if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark ) )
-    FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz,
-                ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
-
     uchar const * dcache_entry = fd_chunk_to_laddr_const( ctx->in[ in_idx ].mem, chunk );
     fd_memcpy( ctx->shred_buffer, dcache_entry, sz );
     return;
   }
 
   if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_CONTACT ) ) {
-    if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark ) )
-      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz,
-                   ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
 
     uchar const * dcache_entry = fd_chunk_to_laddr_const( ctx->in[ in_idx ].mem, chunk );
     handle_new_cluster_contact_info( ctx, dcache_entry );

--- a/src/disco/sign/fd_sign_tile.c
+++ b/src/disco/sign/fd_sign_tile.c
@@ -108,12 +108,6 @@ during_frag_sensitive( void * _ctx,
   fd_sign_ctx_t * ctx = (fd_sign_ctx_t *)_ctx;
   FD_TEST( in_idx<MAX_IN );
 
-  int  role = ctx->in_role[ in_idx ];
-  uint mtu  = ctx->in_mtu [ in_idx ];
-
-  if( sz>mtu ) {
-    FD_LOG_EMERG(( "oversz signing request (role=%d sz=%lu mtu=%u)", role, sz, mtu ));
-  }
   fd_memcpy( ctx->_data, ctx->in_data[ in_idx ], sz );
 }
 

--- a/src/disco/stem/fd_stem.c
+++ b/src/disco/stem/fd_stem.c
@@ -618,7 +618,17 @@ STEM_(run1)( ulong                        in_cnt,
     ulong tspub    = (ulong)this_in_mline->tspub;  (void)tspub;
 
 #ifdef STEM_CALLBACK_DURING_FRAG
-    STEM_CALLBACK_DURING_FRAG( ctx, (ulong)this_in->idx, seq_found, sig, chunk, sz, ctl );
+    if ( FD_UNLIKELY ( !fd_dcache_bounds_check( this_in->shmem_base,
+                                                this_in->dcache,
+                                                this_in->mtu,
+                                                this_in->depth,
+                                                this_in->burst,
+                                                this_in->compact ) ) ) {
+      FD_LOG_WARNING(( "stem: fragment %lu failed dcache bounds check", chunk ));
+    }
+    else {
+      STEM_CALLBACK_DURING_FRAG ( ctx, (ulong)this_in->idx, seq_found, sig, chunk, sz, ctl);
+    }
 #endif
 
     FD_COMPILER_MFENCE();

--- a/src/disco/verify/fd_verify_tile.c
+++ b/src/disco/verify/fd_verify_tile.c
@@ -71,9 +71,6 @@ during_frag( fd_verify_ctx_t * ctx,
 
   ulong in_kind = ctx->in_kind[ in_idx ];
   if( FD_UNLIKELY( in_kind==IN_KIND_QUIC || in_kind==IN_KIND_GOSSIP || in_kind==IN_KIND_SEND ) ) {
-    if( FD_UNLIKELY( chunk<ctx->in[in_idx].chunk0 || chunk>ctx->in[in_idx].wmark || sz>FD_TPU_MTU ) )
-      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->in[in_idx].chunk0, ctx->in[in_idx].wmark ));
-
     uchar * src = (uchar *)fd_chunk_to_laddr( ctx->in[in_idx].mem, chunk );
     fd_txn_m_t * dst = (fd_txn_m_t *)fd_chunk_to_laddr( ctx->out_mem, ctx->out_chunk );
 
@@ -81,9 +78,6 @@ during_frag( fd_verify_ctx_t * ctx,
     dst->block_engine.bundle_id = 0UL;
     fd_memcpy( fd_txn_m_payload( dst ), src, sz );
   } else if( FD_UNLIKELY( in_kind==IN_KIND_BUNDLE ) ) {
-    if( FD_UNLIKELY( chunk<ctx->in[in_idx].chunk0 || chunk>ctx->in[in_idx].wmark || sz>FD_TPU_RAW_MTU ) )
-      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu,%lu]", chunk, sz, ctx->in[in_idx].chunk0, ctx->in[in_idx].wmark, FD_TPU_RAW_MTU ));
-
     uchar * src = (uchar *)fd_chunk_to_laddr( ctx->in[in_idx].mem, chunk );
     uchar * dst = (uchar *)fd_chunk_to_laddr( ctx->out_mem, ctx->out_chunk );
     fd_memcpy( dst, src, sz );

--- a/src/discof/exec/fd_exec_tile.c
+++ b/src/discof/exec/fd_exec_tile.c
@@ -266,14 +266,6 @@ during_frag( fd_exec_tile_ctx_t * ctx,
              ulong                ctl FD_PARAM_UNUSED ) {
 
   if( FD_LIKELY( in_idx == ctx->replay_exec_in_idx ) ) {
-    if( FD_UNLIKELY( chunk < ctx->replay_in_chunk0 || chunk > ctx->replay_in_wmark ) ) {
-      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]",
-                    chunk,
-                    sz,
-                    ctx->replay_in_chunk0,
-                    ctx->replay_in_wmark ));
-    }
-
     if( FD_LIKELY( sig==EXEC_NEW_TXN_SIG ) ) {
       fd_runtime_public_txn_msg_t * txn = (fd_runtime_public_txn_msg_t *)fd_chunk_to_laddr( ctx->replay_in_mem, chunk );
       ctx->txn  = txn->txn;

--- a/src/discof/gossip/fd_gossip_tile.c
+++ b/src/discof/gossip/fd_gossip_tile.c
@@ -320,9 +320,6 @@ during_frag( fd_gossip_tile_ctx_t * ctx,
   fd_gossip_in_ctx_t const * in_ctx = &ctx->in_links[ in_idx ];
 
   if( in_kind == IN_KIND_SEND ) {
-    if( FD_UNLIKELY( chunk<in_ctx->chunk0 || chunk>in_ctx->wmark || sz>FD_TXN_MTU ) ) {
-      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, in_ctx->chunk0, in_ctx->wmark ));
-    }
 
     ctx->replay_vote_txn_sz = sz;
     memcpy( ctx->replay_vote_txn, fd_chunk_to_laddr( in_ctx->mem, chunk ), sz );

--- a/src/discof/poh/fd_poh_tile.c
+++ b/src/discof/poh/fd_poh_tile.c
@@ -1800,9 +1800,6 @@ during_frag( fd_poh_ctx_t * ctx,
   ctx->skip_frag = 0;
 
   if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_STAKE ) ) {
-    if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark ) )
-      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz,
-            ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
 
     uchar const * dcache_entry = fd_chunk_to_laddr_const( ctx->in[ in_idx ].mem, chunk );
     fd_multi_epoch_leaders_stake_msg_init( ctx->mleaders, fd_type_pun_const( dcache_entry ) );

--- a/src/discof/repair/fd_repair_tile.c
+++ b/src/discof/repair/fd_repair_tile.c
@@ -453,9 +453,6 @@ during_frag( fd_repair_tile_ctx_t * ctx,
     dcache_entry_sz = sz;
 
   } else if( FD_UNLIKELY( in_kind==IN_KIND_CONTACT ) ) {
-    if( FD_UNLIKELY( chunk<in_ctx->chunk0 || chunk>in_ctx->wmark ) ) {
-      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, in_ctx->chunk0, in_ctx->wmark ));
-    }
     dcache_entry = fd_chunk_to_laddr_const( in_ctx->mem, chunk );
     dcache_entry_sz = sz * sizeof(fd_shred_dest_wire_t);
 

--- a/src/discof/restart/fd_restart_tile.c
+++ b/src/discof/restart/fd_restart_tile.c
@@ -187,8 +187,8 @@ during_frag( fd_restart_tile_ctx_t * ctx,
              ulong                   sz,
              ulong                   ctl FD_PARAM_UNUSED ) {
   if( FD_LIKELY( in_idx==GOSSIP_IN_IDX ) ) {
-    if( FD_UNLIKELY( chunk<ctx->gossip_in_chunk0 || chunk>ctx->gossip_in_wmark || sz>FD_RESTART_LINK_BYTES_MAX+sizeof(uint) ) ) {
-      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->gossip_in_chunk0, ctx->gossip_in_wmark ));
+    if( FD_UNLIKELY( sz>FD_RESTART_LINK_BYTES_MAX+sizeof(uint) ) ) {
+      FD_LOG_ERR(( "restart: gossip msg size %lu > max %lu", sz, (ulong)(FD_RESTART_LINK_BYTES_MAX + sizeof(uint)) ));
     }
 
     fd_memcpy( ctx->restart_gossip_msg, fd_chunk_to_laddr( ctx->gossip_in_mem, chunk ), sz );
@@ -196,8 +196,8 @@ during_frag( fd_restart_tile_ctx_t * ctx,
   }
 
   if( FD_UNLIKELY( in_idx==STORE_IN_IDX ) ) {
-    if( FD_UNLIKELY( chunk<ctx->store_in_chunk0 || chunk>ctx->store_in_wmark || sz!=sizeof(fd_funk_txn_xid_t) ) ) {
-      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->store_in_chunk0, ctx->store_in_wmark ));
+    if( FD_UNLIKELY( sz!=sizeof(fd_funk_txn_xid_t) ) ) {
+      FD_LOG_ERR(( "restart: store-XID msg size %lu != expected %lu", sz, (ulong)sizeof(fd_funk_txn_xid_t) ));
     }
 
     fd_memcpy( &ctx->store_xid_msg, fd_chunk_to_laddr( ctx->store_in_mem, chunk), sz );

--- a/src/discof/rpcserver/fd_rpcserv_tile.c
+++ b/src/discof/rpcserver/fd_rpcserv_tile.c
@@ -92,17 +92,9 @@ during_frag( fd_rpcserv_tile_ctx_t * ctx,
              ulong                   ctl FD_PARAM_UNUSED ) {
 
   if( FD_UNLIKELY( in_idx==REPLAY_NOTIF_IDX ) ) {
-    if( FD_UNLIKELY( chunk<ctx->replay_notif_in_chunk0 || chunk>ctx->replay_notif_in_wmark ) ) {
-      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz,
-                   ctx->replay_notif_in_chunk0, ctx->replay_notif_in_wmark ));
-    }
     fd_rpc_replay_during_frag( ctx->ctx, &ctx->replay_notif_in_state, fd_chunk_to_laddr_const( ctx->replay_notif_in_mem, chunk ), (int)sz );
 
   } else if( FD_UNLIKELY( in_idx==STAKE_IN_IDX ) ) {
-    if( FD_UNLIKELY( chunk<ctx->stake_in_chunk0 || chunk>ctx->stake_in_wmark ) ) {
-      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz,
-                   ctx->stake_in_chunk0, ctx->stake_in_wmark ));
-    }
     fd_rpc_stake_during_frag( ctx->ctx, ctx->args.leaders, fd_chunk_to_laddr_const( ctx->stake_in_mem, chunk ), (int)sz );
 
   } else {

--- a/src/discof/send/fd_send_tile.c
+++ b/src/discof/send/fd_send_tile.c
@@ -325,9 +325,6 @@ during_frag( fd_send_tile_ctx_t * ctx,
              ulong                  ctl ) {
 
   fd_send_link_in_t * in_link = &ctx->in_links[ in_idx ];
-  if( FD_UNLIKELY( chunk<in_link->chunk0 || chunk>in_link->wmark ) ) {
-    FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu] on link %lu", chunk, sz, in_link->chunk0, in_link->wmark, in_idx ));
-  }
 
   uchar const * dcache_entry = fd_chunk_to_laddr_const( in_link->mem, chunk );
   ulong         kind         = in_link->kind;

--- a/src/discof/shredcap/fd_shredcap_tile.c
+++ b/src/discof/shredcap/fd_shredcap_tile.c
@@ -209,10 +209,6 @@ during_frag( fd_capture_tile_ctx_t * ctx,
     ctx->repair_buffer_sz = sz;
   } else {
     // contact infos can be copied into a buffer
-    if( FD_UNLIKELY( chunk<ctx->in_links[ in_idx ].chunk0 || chunk>ctx->in_links[ in_idx ].wmark ) ) {
-      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz,
-                   ctx->in_links[ in_idx ].chunk0, ctx->in_links[ in_idx ].wmark ));
-    }
     uchar const * dcache_entry = fd_chunk_to_laddr_const( ctx->in_links[ in_idx ].mem, chunk );
     fd_memcpy( ctx->contact_info_buffer, dcache_entry, sz );
   }

--- a/src/discof/writer/fd_writer_tile.c
+++ b/src/discof/writer/fd_writer_tile.c
@@ -131,14 +131,6 @@ during_frag( fd_writer_tile_ctx_t * ctx,
 
   fd_writer_tile_in_ctx_t * in_ctx = &(ctx->exec_writer_in[ in_idx ]);
 
-  if( FD_UNLIKELY( chunk < in_ctx->chunk0 || chunk > in_ctx->wmark ) ) {
-    FD_LOG_CRIT(( "chunk %lu %lu corrupt, not in range [%lu,%lu]",
-                  chunk,
-                  sz,
-                  in_ctx->chunk0,
-                  in_ctx->wmark ));
-  }
-
   /* Process messages from exec tiles. */
 
   if( FD_UNLIKELY( sig == FD_WRITER_BOOT_SIG ) ) {

--- a/src/discoh/bank/fd_bank_tile.c
+++ b/src/discoh/bank/fd_bank_tile.c
@@ -124,9 +124,6 @@ during_frag( fd_bank_ctx_t * ctx,
   uchar * src = (uchar *)fd_chunk_to_laddr( ctx->pack_in_mem, chunk );
   uchar * dst = (uchar *)fd_chunk_to_laddr( ctx->out_mem, ctx->out_chunk );
 
-  if( FD_UNLIKELY( chunk<ctx->pack_in_chunk0 || chunk>ctx->pack_in_wmark || sz>USHORT_MAX ) )
-    FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->pack_in_chunk0, ctx->pack_in_wmark ));
-
   fd_memcpy( dst, src, sz-sizeof(fd_microblock_bank_trailer_t) );
   fd_microblock_bank_trailer_t * trailer = (fd_microblock_bank_trailer_t *)( src+sz-sizeof(fd_microblock_bank_trailer_t) );
   ctx->_bank = trailer->bank;

--- a/src/discoh/poh/fd_poh_tile.c
+++ b/src/discoh/poh/fd_poh_tile.c
@@ -1801,10 +1801,6 @@ during_frag( fd_poh_ctx_t * ctx,
   ctx->skip_frag = 0;
 
   if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_STAKE ) ) {
-    if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark ) )
-      FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz,
-            ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
-
     uchar const * dcache_entry = fd_chunk_to_laddr_const( ctx->in[ in_idx ].mem, chunk );
     fd_multi_epoch_leaders_stake_msg_init( ctx->mleaders, fd_type_pun_const( dcache_entry ) );
     return;

--- a/src/discoh/resolv/fd_resolv_tile.c
+++ b/src/discoh/resolv/fd_resolv_tile.c
@@ -208,9 +208,6 @@ during_frag( fd_resolv_ctx_t * ctx,
              ulong             sz,
              ulong             ctl FD_PARAM_UNUSED ) {
 
-  if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark || sz>ctx->in[ in_idx ].mtu ) )
-    FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
-
   switch( ctx->in[in_idx].kind ) {
     case FD_RESOLV_IN_KIND_BANK:
       fd_memcpy( ctx->_bank_msg, fd_chunk_to_laddr_const( ctx->in[in_idx].mem, chunk ), sz );

--- a/src/discoh/store/fd_store_tile.c
+++ b/src/discoh/store/fd_store_tile.c
@@ -45,9 +45,6 @@ during_frag( fd_store_ctx_t * ctx,
              ulong            sz,
              ulong            ctl FD_PARAM_UNUSED ) {
 
-  if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark || sz>FD_SHRED_STORE_MTU || sz<32UL ) )
-    FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
-
   uchar * src = (uchar *)fd_chunk_to_laddr( ctx->in[in_idx].mem, chunk );
 
   fd_memcpy( ctx->mem, src, sz );

--- a/src/tango/dcache/fd_dcache.c
+++ b/src/tango/dcache/fd_dcache.c
@@ -259,3 +259,15 @@ fd_dcache_compact_is_safe( void const * base,
   return 1;
 }
 
+int fd_dcache_bounds_check(void const * base,
+                           void const * dcache,
+                           uint64_t mtu,
+                           uint64_t depth,
+                           uint64_t burst,
+                           int32_t compact) {
+  
+  if( FD_UNLIKELY( compact ) ) return fd_dcache_compact_is_safe( base, dcache, mtu, depth );
+
+  return fd_dcache_req_data_sz( mtu, depth, burst, 0 ) ? 1 : 0;
+}
+

--- a/src/tango/dcache/test_dcache.c
+++ b/src/tango/dcache/test_dcache.c
@@ -212,6 +212,27 @@ main( int     argc,
 
   fd_rng_delete( fd_rng_leave( rng ) );
 
+  // FD_TEST( fd_dcache_bounds_check( NULL, NULL, 1UL, 1UL, 1UL, 0 ) == 0 );
+  
+  // ulong bounds_mtu = 64UL;
+  // ulong bounds_depth = 2UL;
+  // ulong bounds_burst = 1UL;
+
+  // fd_wksp_t * wksp;
+  // ulong shmem_gaddr = fd_wksp_alloc( wksp, FD_DCACHE_ALIGN, FD_DCACHE_FOOTPRINT ( FD_DCACHE_SLOT_FOOTPRINT( bounds_mtu ) * ( bounds_depth + bounds_burst ), 0UL ), 1UL );
+  // void *bounds_shdcache = fd_wksp_laddr( wksp, shmem_gaddr );
+  // uchar * bounds_dcache = fd_dcache_join( bounds_shdcache );
+
+  // FD_TEST( fd_dcache_bounds_check( bounds_shdcache, bounds_dcache, 0UL, bounds_depth, bounds_burst, 0 ) == 0 );
+  // FD_TEST( fd_dcache_bounds_check( bounds_shdcache, bounds_dcache, bounds_mtu, 0UL, bounds_burst, 0 ) == 0 );
+  // FD_TEST( fd_dcache_bounds_check( bounds_shdcache, bounds_dcache, bounds_mtu, bounds_depth, 0UL, 0 ) == 0 );
+  // FD_TEST( fd_dcache_bounds_check( bounds_shdcache, bounds_dcache, 0UL, bounds_depth, bounds_burst, 0 ) == 1 );
+  // FD_TEST( fd_dcache_bounds_check( bounds_shdcache, bounds_dcache, 0UL, bounds_depth, 0UL, 1 ) == 
+  //          fd_dcache_compact_is_safe(bounds_shdcache, bounds_dcache, bounds_mtu, bounds_depth) );
+  
+  // fd_wksp_unmap( fd_dcache_leave( bounds_dcache ) );
+  // fd_wksp_delete( bounds_shdcache );
+
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();
   return 0;


### PR DESCRIPTION
Added dcache bounds checking to src/tango/dcache:fd_dcache_bounds_check. Added this bounds check to fd_stem STEM_CALLBACK_DURING_FRAG macro, and since that is the touchpoint for all demux and dispatching of tiles, I removed the bounds check from all other during_frag occurrences. Unit tests included.