### PR TITLE
Update getting-started.md 

### DIFF
--- a/book/guide/getting-started.md
+++ b/book/guide/getting-started.md
@@ -107,7 +107,7 @@ Firedancer depends on the Agave validator, this will also build some
 Agave components.
 
 ```sh [bash]
-$ make -j fdctl solana
+$ make -j fdctl solana agave-ledger-tool
 ```
 
 You will need around 32GiB of available memory to build Firedancer.  If


### PR DESCRIPTION
Hey,
I was looking at the makefiles inside the firedancer repo to see if it was possible to build agave-ledger-tool as a binary. I checked the src/app/fdctl/Local.mk and I saw that it was possible  :  agave-ledger-tool: $(OBJDIR)/bin/agave-ledger-tool

And indeed, the make -j fdctl solana agave-ledger-tool worked. 

I used it during the testnet restart to create the correct snapshot and the command : agave-ledger-tool --ledger ledger create-snapshot was working too.

Unfortunately, when the testnet restarted, it was not working well and I suspected it come from the version of the agave-ledger-tool that was not correct one to use for snapshot generation.

But it could be useful for validators to directly build this binary easily with make, especially for future restarts. 

Maybe there is a reason this is not the case but I would like to submit the idea here (saw a message on discord that developers were more active on github than discord)

Best,

Léo