### PR TITLE
flamenco, feature: 2.3 feature cleanups

### DIFF
--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.c
@@ -287,8 +287,7 @@ fd_exec_txn_account_is_writable_idx_flat( const ulong           slot,
   /* See comments in fd_system_ids.h.
      https://github.com/anza-xyz/agave/blob/v2.1.11/sdk/program/src/message/sanitized.rs#L44 */
   if( fd_pubkey_is_active_reserved_key( addr_at_idx ) ||
-      ( FD_FEATURE_ACTIVE( slot, features, add_new_reserved_account_keys ) &&
-                           fd_pubkey_is_pending_reserved_key( addr_at_idx ) ) ||
+      fd_pubkey_is_pending_reserved_key( addr_at_idx ) ||
       ( FD_FEATURE_ACTIVE( slot, features, enable_secp256r1_precompile ) &&
                            fd_pubkey_is_secp256r1_key( addr_at_idx ) ) ) {
 

--- a/src/flamenco/runtime/fd_cost_tracker.c
+++ b/src/flamenco/runtime/fd_cost_tracker.c
@@ -319,11 +319,10 @@ add_transaction_cost( fd_cost_tracker_t *           self,
 
 void
 fd_cost_tracker_init( fd_cost_tracker_t *        self,
-                      fd_exec_slot_ctx_t const * slot_ctx,
                       fd_spad_t *                spad ) {
   // Set limits appropriately
   self->account_cost_limit = FD_MAX_WRITABLE_ACCOUNT_UNITS;
-  self->block_cost_limit   = FD_FEATURE_ACTIVE_BANK( slot_ctx->bank, raise_block_limits_to_50m ) ? FD_MAX_BLOCK_UNITS_SIMD_0207 : FD_MAX_BLOCK_UNITS;
+  self->block_cost_limit   = FD_MAX_BLOCK_UNITS_SIMD_0207;
   self->vote_cost_limit    = FD_MAX_VOTE_UNITS;
 
   /* Init cost tracker map

--- a/src/flamenco/runtime/fd_cost_tracker.h
+++ b/src/flamenco/runtime/fd_cost_tracker.h
@@ -49,7 +49,6 @@ FD_PROTOTYPES_BEGIN
 /* Initializes the cost tracker and allocates enough memory for the map */
 void
 fd_cost_tracker_init( fd_cost_tracker_t *        self,
-                      fd_exec_slot_ctx_t const * slot_ctx,
                       fd_spad_t *                spad );
 
 /* Modeled after `CostModel::calculate_cost_for_executed_transaction()`.

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -255,22 +255,12 @@ fd_runtime_freeze( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_spad ) {
 
   fd_sysvar_recent_hashes_update( slot_ctx, runtime_spad );
 
-  ulong fees = 0UL;
-  ulong burn = 0UL;
-
   ulong execution_fees = fd_bank_execution_fees_get( slot_ctx->bank );
   ulong priority_fees  = fd_bank_priority_fees_get( slot_ctx->bank );
 
-  if( FD_FEATURE_ACTIVE_BANK( slot_ctx->bank, reward_full_priority_fee ) ) {
-    ulong half_fee = execution_fees / 2;
-    fees = fd_ulong_sat_add( priority_fees, execution_fees - half_fee );
-    burn = half_fee;
-  } else {
-    ulong total_fees = fd_ulong_sat_add( execution_fees, priority_fees );
-    ulong half_fee = total_fees / 2;
-    fees = total_fees - half_fee;
-    burn = half_fee;
-  }
+  ulong burn = execution_fees / 2;
+  ulong fees = fd_ulong_sat_add( priority_fees, execution_fees - burn );
+
   if( FD_LIKELY( fees ) ) {
     // Look at collect_fees... I think this was where I saw the fee payout..
     FD_TXN_ACCOUNT_DECL( rec );
@@ -1211,8 +1201,8 @@ fd_runtime_pre_execute_check( fd_execute_txn_task_info_t * task_info ) {
     fd_dump_txn_to_protobuf( task_info->txn_ctx, task_info->txn_ctx->spad );
   }
 
-  /* Verify the transaction. This step involves processing the compute budget instructions and
-     precompiles (for now, until `move_precompile_verification_to_svm` is cleaned up). */
+  /* Verify the transaction. For now, this step only involves processing
+     the compute budget instructions. */
   err = fd_executor_verify_transaction( task_info->txn_ctx );
   if( FD_UNLIKELY( err!=FD_RUNTIME_EXECUTE_SUCCESS ) ) {
     task_info->txn->flags = 0U;
@@ -1619,7 +1609,7 @@ fd_runtime_process_txns_in_microblock_stream( fd_exec_slot_ctx_t * slot_ctx,
 
     /* Verify cost tracker limits (only for offline replay)
        https://github.com/anza-xyz/agave/blob/v2.2.0/ledger/src/blockstore_processor.rs#L284-L299 */
-    if( cost_tracker_opt!=NULL && FD_FEATURE_ACTIVE_BANK( slot_ctx->bank, apply_cost_tracker_during_replay ) ) {
+    if( cost_tracker_opt!=NULL ) {
       for( ulong i=exec_idx_start; i<curr_exec_idx; i++ ) {
 
         /* Skip any transactions that were not processed */
@@ -2272,21 +2262,6 @@ fd_runtime_process_new_epoch( fd_exec_slot_ctx_t * slot_ctx,
   /* Apply builtin program feature transitions
      https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank.rs#L6621-L6624 */
   fd_apply_builtin_program_feature_transitions( slot_ctx, runtime_spad );
-
-  /* Change the speed of the poh clock
-     https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank.rs#L6627-L6649 */
-
-  if( FD_FEATURE_JUST_ACTIVATED( slot_ctx, update_hashes_per_tick6 ) ) {
-    fd_bank_hashes_per_tick_set( slot_ctx->bank, UPDATED_HASHES_PER_TICK6 );
-  } else if( FD_FEATURE_JUST_ACTIVATED( slot_ctx, update_hashes_per_tick5 ) ) {
-    fd_bank_hashes_per_tick_set( slot_ctx->bank, UPDATED_HASHES_PER_TICK5 );
-  } else if( FD_FEATURE_JUST_ACTIVATED( slot_ctx, update_hashes_per_tick4 ) ) {
-    fd_bank_hashes_per_tick_set( slot_ctx->bank, UPDATED_HASHES_PER_TICK4 );
-  } else if( FD_FEATURE_JUST_ACTIVATED( slot_ctx, update_hashes_per_tick3 ) ) {
-    fd_bank_hashes_per_tick_set( slot_ctx->bank, UPDATED_HASHES_PER_TICK3 );
-  } else if( FD_FEATURE_JUST_ACTIVATED( slot_ctx, update_hashes_per_tick2 ) ) {
-    fd_bank_hashes_per_tick_set( slot_ctx->bank, UPDATED_HASHES_PER_TICK2 );
-  }
 
   /* Get the new rate activation epoch */
   int _err[1];
@@ -3611,9 +3586,7 @@ fd_runtime_block_execute_tpool( fd_exec_slot_ctx_t *            slot_ctx,
 
   /* Initialize the cost tracker when the feature is active */
   fd_cost_tracker_t * cost_tracker = fd_spad_alloc( runtime_spad, FD_COST_TRACKER_ALIGN, sizeof(fd_cost_tracker_t) );
-  if( FD_FEATURE_ACTIVE_BANK( slot_ctx->bank, apply_cost_tracker_during_replay ) ) {
-    fd_cost_tracker_init( cost_tracker, slot_ctx, runtime_spad );
-  }
+  fd_cost_tracker_init( cost_tracker, runtime_spad );
 
   /* We want to emulate microblock-by-microblock execution */
   ulong to_exec_idx = 0UL;

--- a/src/flamenco/runtime/fd_system_ids.h
+++ b/src/flamenco/runtime/fd_system_ids.h
@@ -60,7 +60,7 @@ extern const fd_pubkey_t fd_solana_migration_authority;
 
    To verify that the pubkey is a reserved key, the caller will need to check that either:
      1. The pubkey is in the set of active reserved keys
-     2. The pubkey is in the set of pending reserved keys, AND the `add_new_reserved_account_keys` feature is active.
+     2. The pubkey is in the set of pending reserved keys.
      3. The pubkey is the secp256r1 program id, AND the `enable_secp256r1_precompile` feature is active.
 
    If a pubkey is a reserved key, it will not be added to Agave's message writable accounts cache and thus

--- a/src/flamenco/runtime/program/fd_stake_program.c
+++ b/src/flamenco/runtime/program/fd_stake_program.c
@@ -3166,24 +3166,19 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
    * https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L356
    */
   case fd_stake_instruction_enum_move_stake: {
-    // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L359
-    if( FD_LIKELY( FD_FEATURE_ACTIVE_BANK( ctx->txn_ctx->bank, move_stake_and_move_lamports_ixs ) ) ) {
-      // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L361
-      if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) )
-        return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+    // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L361
+    if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) )
+      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
 
-      ulong lamports = instruction->inner.move_stake;
-      // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L362
-      rc = move_stake( ctx,
-                       0UL,
-                       lamports,
-                       1UL,
-                       2UL,
-                       &ctx->txn_ctx->custom_err );
-    } else {
-      // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L372
-      return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
-    }
+    ulong lamports = instruction->inner.move_stake;
+    // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L362
+    rc = move_stake( ctx,
+                     0UL,
+                     lamports,
+                     1UL,
+                     2UL,
+                     &ctx->txn_ctx->custom_err );
+
     break;
   }
   /* MoveLamports
@@ -3195,25 +3190,20 @@ fd_stake_program_execute( fd_exec_instr_ctx_t * ctx ) {
    * https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L375
    */
   case fd_stake_instruction_enum_move_lamports: {
-    // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L378
-    if( FD_LIKELY( FD_FEATURE_ACTIVE_BANK( ctx->txn_ctx->bank, move_stake_and_move_lamports_ixs ) ) ) {
-      // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L380
-      if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) )
-        return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
+    // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L380
+    if( FD_UNLIKELY( ctx->instr->acct_cnt<3 ) )
+      return FD_EXECUTOR_INSTR_ERR_NOT_ENOUGH_ACC_KEYS;
 
-      // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L381
-      ulong lamports = instruction->inner.move_lamports;
+    // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L381
+    ulong lamports = instruction->inner.move_lamports;
 
-      // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L381
-      rc = move_lamports( ctx,
-                       0UL,
-                       lamports,
-                       1UL,
-                       2UL );
-    } else {
-      // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L391
-      return FD_EXECUTOR_INSTR_ERR_INVALID_INSTR_DATA;
-    }
+    // https://github.com/anza-xyz/agave/blob/cdff19c7807b006dd63429114fb1d9573bf74172/programs/stake/src/stake_instruction.rs#L381
+    rc = move_lamports( ctx,
+                        0UL,
+                        lamports,
+                        1UL,
+                        2UL );
+
     break;
   }
   default:


### PR DESCRIPTION
These features are now cleaned up in the codebase:
* `add_new_reserved_account_keys`
* `raise_block_limits_to_50m`
* `move_precompile_verification_to_svm`
* `reward_full_priority_fee`
* `apply_cost_tracker_during_replay`
* `update_hashes_per_tick{2,3,4,5,6}`
* `reserve_minimal_cus_for_builtin_instructions`
* `move_stake_and_move_lamports_ixs`
* `allow_commission_decrease_at_any_time`
* `commission_updates_only_allowed_in_first_half_of_epoch`
* `enable_tower_sync_ix`