### PR TITLE
remove legacy wait duration ticks

### DIFF
--- a/src/disco/pack/fd_pack_tile.c
+++ b/src/disco/pack/fd_pack_tile.c
@@ -60,22 +60,6 @@ const float VOTE_FRACTION = 0.75f; /* TODO: Is this the right value? */
 #define EFFECTIVE_TXN_PER_MICROBLOCK MAX_TXN_PER_MICROBLOCK
 #endif
 
-/* There's overhead associated with each microblock the bank tile tries
-   to execute it, so the optimal strategy is not to produce a microblock
-   with a single transaction as soon as we receive it.  Basically, if we
-   have less than 31 transactions, we want to wait a little to see if we
-   receive additional transactions before we schedule a microblock.  We
-   can model the optimum amount of time to wait, but the equation is
-   complicated enough that we want to compute it before compile time.
-   wait_duration[i] for i in [0, 31] gives the time in nanoseconds pack
-   should wait after receiving its most recent transaction before
-   scheduling if it has i transactions available.  Unsurprisingly,
-   wait_duration[31] is 0.  wait_duration[0] is ULONG_MAX, so we'll
-   always wait if we have 0 transactions. */
-FD_IMPORT( wait_duration, "src/disco/pack/pack_delay.bin", ulong, 6, "" );
-
-
-
 #if FD_PACK_USE_EXTRA_STORAGE
 /* When we are done being leader for a slot and we are leader in the
    very next slot, it can still take some time to transition.  This is
@@ -215,10 +199,9 @@ typedef struct {
      increases, we expire old transactions. */
   ulong highest_observed_slot;
 
-  /* microblock_duration_ns, and wait_duration
-     respectively scaled to be in ticks instead of nanoseconds */
+  /* microblock_duration_ns, scaled to be in ticks instead of
+     nanoseconds */
   ulong microblock_duration_ticks;
-  ulong wait_duration_ticks[ MAX_TXN_PER_MICROBLOCK+1UL ];
 
 #if FD_PACK_USE_EXTRA_STORAGE
   /* In addition to the available transactions that pack knows about, we
@@ -581,13 +564,6 @@ after_credit( fd_pack_ctx_t *     ctx,
 
   /* Have I sent the max allowed microblocks? Nothing to do. */
   if( FD_UNLIKELY( ctx->slot_microblock_cnt>=ctx->slot_max_microblocks ) ) return;
-
-  /* Do I have enough transactions and/or have I waited enough time? */
-  if( FD_UNLIKELY( (ulong)(now-ctx->last_successful_insert) <
-        ctx->wait_duration_ticks[ fd_ulong_min( fd_pack_avail_txn_cnt( ctx->pack ), MAX_TXN_PER_MICROBLOCK ) ] ) ) {
-    update_metric_state( ctx, now, FD_PACK_METRIC_STATE_TRANSACTIONS, 0 );
-    return;
-  }
 
   int any_ready     = 0;
   int any_scheduled = 0;
@@ -1211,11 +1187,6 @@ unprivileged_init( fd_topo_t *      topo,
 #endif
   ctx->use_consumed_cus              = tile->pack.use_consumed_cus;
   ctx->crank->enabled                = tile->pack.bundle.enabled;
-
-  ctx->wait_duration_ticks[ 0 ] = ULONG_MAX;
-  for( ulong i=1UL; i<MAX_TXN_PER_MICROBLOCK+1UL; i++ ) {
-    ctx->wait_duration_ticks[ i ]=(ulong)(fd_tempo_tick_per_ns( NULL )*(double)wait_duration[ i ] + 0.5);
-  }
 
   ctx->limits.slot_max_cost                = limits_lower->max_cost_per_block;
   ctx->limits.slot_max_vote_cost           = limits_lower->max_vote_cost_per_block;


### PR DESCRIPTION
`wait_duration`/`wait_duration_ticks` and its use in this particular branch

```c
/* Do I have enough transactions and/or have I waited enough time? */
  if( FD_UNLIKELY( (ulong)(now-ctx->last_successful_insert) <
  ctx->wait_duration_ticks[ fd_ulong_min( fd_pack_avail_txn_cnt( ctx->pack ), MAX_TXN_PER_MICROBLOCK ) ] ) ) {
  update_metric_state( ctx, now, FD_PACK_METRIC_STATE_TRANSACTIONS, 0 );
  return;
}
```
in the pack tile's `after_credit` routine is a sort of legacy pacing strategy that is both ineffective and interferes with existing strategies. Consider the following for each of the following strategies:

1. `FD_PACK_STRATEGY_PERF`: In this strategy, we are trying to pack transaction as fast as possible and should not wait for transactions in any case
2. `FD_PACK_STRATEGY_BALANCED`: in this strategy, we already have `fd_pacer` that is limiting scheduling and do not want to wait more time if we are below are target cus when we have a few transactions buffered.
3. `FD_PACK_STRATEGY_BUNDLE`: in this strategy, we should not wait around votes, we always schedule bundles in FIFO, and have extremely limited time to pack nonvote nonbundle transactions and do not want to wait in the case we have few transactions in the buffer.