### PR TITLE
fix: filter out cloned routes when loading routing table

### DIFF
--- a/src/waltz/ip/fd_fib4_netlink.c
+++ b/src/waltz/ip/fd_fib4_netlink.c
@@ -71,6 +71,15 @@ fd_fib4_netlink_translate( fd_fib4_t *             fib,
   struct rtattr * rat    = RTM_RTA( msg );
   long            rat_sz = (long)(int)RTM_PAYLOAD( msg_hdr );
 
+  if( FD_UNLIKELY(msg->rtm_flags & RTM_F_CLONED) ) {
+    return 0;
+  }
+
+  if( FD_UNLIKELY(msg->rtm_table != RT_TABLE_UNSPEC &&
+       msg->rtm_table != table_id ) ) {
+    return 0;
+  }
+
   switch( msg->rtm_type ) {
   case RTN_UNICAST:
     hop->rtype = FD_FIB4_RTYPE_UNICAST;


### PR DESCRIPTION
- Filter out routes with `RTM_F_CLONED` flag
- Immediately filter out routes with non target `table_id` before reading `RTA_TABLE` if `rtm_table` is not `RT_TABLE_UNSPEC`

This fixes the `netlnk:0 src/waltz/ip/fd_fib4_netlink.c(227): Routing table is too small! `ip route show table 254` returned 2815 entries, which exceeds the configured maximum of 128` bug.