### PR TITLE
Support fd_stem without x86 SSE

### DIFF
--- a/src/tango/fd_tango_base.h
+++ b/src/tango/fd_tango_base.h
@@ -283,7 +283,7 @@ fd_frag_meta_seq_query( fd_frag_meta_t const * meta ) { /* Assumed non-NULL */
 static inline __m128i
 fd_frag_meta_seq_sig_query( fd_frag_meta_t const * meta ) { /* Assumed non-NULL */
   FD_COMPILER_MFENCE();
-  __m128i sse0 = _mm_load_si128( &meta->sse0 );
+  __m128i sse0 = FD_VOLATILE_CONST( meta->sse0 );
   FD_COMPILER_MFENCE();
   return sse0;
 }


### PR DESCRIPTION
- Make fd_frag_meta_seq_sig_query atomic
  (replace _mm_load_si128 with a volatile load)
- Add a seq_sig_query fallback for architectures
  without 128-bit atomic loads
