### PR TITLE
replay: better locks around banks

### DIFF
--- a/src/flamenco/runtime/fd_bank.c
+++ b/src/flamenco/runtime/fd_bank.c
@@ -442,8 +442,6 @@ fd_banks_get_bank( fd_banks_t * banks, ulong slot ) {
 
   fd_bank_t * bank = NULL;
 
-  fd_rwlock_read( &banks->rwlock );
-
   fd_bank_t *      bank_pool = fd_banks_get_bank_pool( banks );
   fd_banks_map_t * bank_map  = fd_banks_get_bank_map( banks );
 
@@ -452,8 +450,6 @@ fd_banks_get_bank( fd_banks_t * banks, ulong slot ) {
     FD_LOG_WARNING(( "Failed to get bank" ));
     return NULL;
   }
-
-  fd_rwlock_unread( &banks->rwlock );
 
   return bank;
 }

--- a/src/flamenco/runtime/fd_bank.h
+++ b/src/flamenco/runtime/fd_bank.h
@@ -509,6 +509,26 @@ FD_BANKS_ITER(X)
 #undef HAS_COW_0
 #undef HAS_COW_1
 
+/* fd_banks_lock() and fd_banks_unlock() are locks to be acquired and
+   freed around accessing or modifying a specific bank. This is only
+   required if there is concurrent access to a bank while operations on
+   its underlying map are being performed.
+
+   Under the hood, this is a wrapper around fd_banks_t's rwlock.
+   This is done so a caller can safely read/write a specific bank.
+   Otherwise, we run the risk of accessing/modifying a bank that may be
+   freed. This is acquiring and freeing a read lock around fd_banks_t. */
+
+static inline void
+fd_banks_lock( fd_banks_t * banks ) {
+  fd_rwlock_read( &banks->rwlock );
+}
+
+static inline void
+fd_banks_unlock( fd_banks_t * banks ) {
+  fd_rwlock_unread( &banks->rwlock );
+}
+
 /* fd_banks_root returns the current root slot for the bank. */
 
 FD_FN_PURE static inline fd_bank_t const *


### PR DESCRIPTION
we need locks in the exec and writer tiles around uses of the bank. This is to avoid the replay tile releasing a bank that is currently being used in the exec and writer tiles. This is not needed in the replay tile because we have an invariant that the current slot that's being executed will not be rooted