### PR TITLE
runtime, replay: refactor replay execution state management

### DIFF
--- a/src/choreo/forks/fd_forks.h
+++ b/src/choreo/forks/fd_forks.h
@@ -24,7 +24,7 @@ struct fd_fork {
                  be read or written to by downstream consumers (eg.
                  consensus, publishing) and should definitely not be
                  removed. */
-  uint  end_idx; /* the end_idx of the last batch executed on this fork */
+  uint  end_idx; /* the end_idx (inclusive) of the last shred of the last batch executed on this fork */
 };
 
 typedef struct fd_fork fd_fork_t;

--- a/src/disco/fd_disco_base.h
+++ b/src/disco/fd_disco_base.h
@@ -25,10 +25,6 @@
 #define REPLAY_FLAG_CATCHING_UP         (0x08UL)
 #define REPLAY_FLAG_INIT                (0x10UL)
 
-#define EXEC_FLAG_READY_NEW             (0x20UL)
-#define EXEC_FLAG_EXECUTING_SLICE       (0x40UL)
-#define EXEC_FLAG_FINISHED_SLOT         (0x80UL)
-
 /* FD_NET_MTU is the max full packet size, with ethernet, IP, and UDP
    headers that can go in or out of the net tile.  2048 is the maximum
    XSK entry size, so this value follows naturally. */

--- a/src/discof/exec/fd_exec_tile.c
+++ b/src/discof/exec/fd_exec_tile.c
@@ -177,7 +177,6 @@ static void
 hash_accounts( fd_exec_tile_ctx_t *                ctx,
                fd_runtime_public_hash_bank_msg_t * msg ) {
 
-  ctx->slot = msg->slot;
   fd_funk_txn_map_t * txn_map = fd_funk_txn_map( ctx->funk );
   if( FD_UNLIKELY( !txn_map->map ) ) {
     FD_LOG_ERR(( "Could not find valid funk transaction map" ));
@@ -280,6 +279,7 @@ during_frag( fd_exec_tile_ctx_t * ctx,
     } else if( sig==EXEC_HASH_ACCS_SIG ) {
       fd_runtime_public_hash_bank_msg_t * msg = fd_chunk_to_laddr( ctx->replay_in_mem, chunk );
       FD_LOG_DEBUG(( "hash accs=%lu msg recvd", msg->end_idx - msg->start_idx ));
+      ctx->slot = msg->slot;
       hash_accounts( ctx, msg );
       return;
     } else if( sig==EXEC_SNAP_HASH_ACCS_CNT_SIG ) {

--- a/src/discof/replay/fd_exec.c
+++ b/src/discof/replay/fd_exec.c
@@ -39,19 +39,9 @@ fd_slice_exec_microblock_parse( fd_slice_exec_t * slice_exec_ctx ) {
 }
 
 void
-fd_slice_exec_reset( fd_slice_exec_t * slice_exec_ctx ) {
-  slice_exec_ctx->last_batch    = 0;
-  slice_exec_ctx->txns_rem      = 0;
-  slice_exec_ctx->mblks_rem     = 0;
-  slice_exec_ctx->sz            = 0;
-  slice_exec_ctx->wmark         = 0;
-  slice_exec_ctx->last_mblk_off = 0;
-}
-
-void
 fd_slice_exec_begin( fd_slice_exec_t * slice_exec_ctx,
-                     ulong slice_sz,
-                     int   last_batch ) {
+                     ulong             slice_sz,
+                     int               last_batch ) {
   slice_exec_ctx->sz         = slice_sz;
   slice_exec_ctx->last_batch = last_batch;
   slice_exec_ctx->txns_rem   = 0;

--- a/src/flamenco/runtime/fd_runtime_public.h
+++ b/src/flamenco/runtime/fd_runtime_public.h
@@ -17,8 +17,7 @@
 #define EXEC_SNAP_HASH_ACCS_GATHER_SIG (0x193992UL)
 
 #define FD_WRITER_BOOT_SIG             (0xAABB0011UL)
-#define FD_WRITER_SLOT_SIG             (0xBBBB1122UL)
-#define FD_WRITER_TXN_SIG              (0xBBCC2233UL)
+#define FD_WRITER_TXN_SIG              (0xBBCC1122UL)
 
 #define FD_EXEC_STATE_NOT_BOOTED       (0xFFFFFFFFUL)
 #define FD_EXEC_STATE_BOOTED           (1<<1UL      )


### PR DESCRIPTION
- Fix a bug which caused exec tiles to be stranded in certain states forever on fork switches.
- Fix a race condition which caused potentially conflicting transactions to be dispatched for parallel execution.
- Documentation.