### PR TITLE
Fix duplicate link_slow_count metric

### DIFF
--- a/src/disco/metrics/fd_prometheus.c
+++ b/src/disco/metrics/fd_prometheus.c
@@ -152,7 +152,7 @@ render_links_out( fd_prom_render_t *        r,
             if( FD_UNLIKELY( consumer_tile->in_link_id[ l ]==tile->out_link_id[ m ] && consumer_tile->in_link_reliable[ l ] ) ) {
               fd_topo_link_t const * link = &topo->links[ consumer_tile->in_link_id[ l ] ];
               ulong value = *(fd_metrics_link_out( tile->metrics, reliable_conns_idx ) + metric->offset );
-              render_link( r, metric, tile, link, value );
+              render_link( r, metric, consumer_tile, link, value );
               reliable_conns_idx++;
             }
           }


### PR DESCRIPTION
Fixes a bug where the Prometheus server rendered duplicate metric
descriptors for the link_slow_count metric.

This metric counts the number of times a consumer tile caused
backpressure.  However, it was keyed by the producer tile only.
This caused duplicate metrics for a reliable link that has multiple
consumers.

link_slow_cnt is now keyed by both the consumer tile (kind, kind_id)
and the producer tile (link_kind, link_kind_id).

Fixes https://github.com/firedancer-io/firedancer/issues/5580

Reported-by: @HGuillemet
