### PR TITLE
ci: clean up all hugetlbfs mounts before running CI tests

### DIFF
--- a/.github/actions/hugepages/action.yml
+++ b/.github/actions/hugepages/action.yml
@@ -17,6 +17,7 @@ runs:
       run: |
         set -x
         sudo src/util/shmem/fd_shmem_cfg fini || true
+        findmnt -t hugetlbfs -n -o TARGET | xargs -r sudo umount || true
         sudo src/util/shmem/fd_shmem_cfg reset || true
         sudo src/util/shmem/fd_shmem_cfg init 0775 $USER "" || true
         [ $(cat /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages) -lt '${{ inputs.count_gigantic }}' ] && \

--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -47,4 +47,4 @@ jobs:
       - name: fini
         if: always()
         run: |
-          sudo $OBJDIR/bin/firedancer-dev configure fini all --config ../dump/mainnet-308392063-v2.3.0_backtest.toml
+          sudo $OBJDIR/bin/firedancer-dev configure fini all --config ../dump/mainnet-308392063-v2.3.0_backtest.toml || true


### PR DESCRIPTION
Ensures all other hugetlbfs mounts are cleaned up before running CI tests.