### PR TITLE
ci: bump hugepages reservation

### DIFF
--- a/.github/actions/hugepages/action.yml
+++ b/.github/actions/hugepages/action.yml
@@ -4,7 +4,7 @@ inputs:
   count_huge:
     description: 'Number of huge pages'
     required: true
-    default: '128'
+    default: '160'
   count_gigantic:
     description: 'Number of gigantic pages'
     required: true


### PR DESCRIPTION
We were not reserving enough hugepages for the test vectors CI step.