### PR TITLE
flamenco: fix stack out-of-bounds when using the precompile feature offset

### DIFF
--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -2129,7 +2129,7 @@ fd_apply_builtin_program_feature_transitions( fd_exec_slot_ctx_t * slot_ctx,
   /* https://github.com/anza-xyz/agave/blob/c1080de464cfb578c301e975f498964b5d5313db/runtime/src/bank.rs#L6795-L6805 */
   fd_precompile_program_t const * precompiles = fd_precompiles();
   for( ulong i=0UL; i<fd_num_precompiles(); i++ ) {
-    if( FD_FEATURE_JUST_ACTIVATED_OFFSET( slot_ctx, precompiles[i].feature_offset ) ) {
+    if( precompiles[i].feature_offset != NO_ENABLE_FEATURE_ID && FD_FEATURE_JUST_ACTIVATED_OFFSET( slot_ctx, precompiles[i].feature_offset ) ) {
       fd_write_builtin_account( slot_ctx, *precompiles[i].pubkey, "", 0 );
     }
   }


### PR DESCRIPTION
Fixing ASAN crash report when replaying ledgers:

```
=================================================================
==252449==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fbb5e3057b8 at pc 0x5565fb8a2dc8 bp 0x7ffd0db75930 sp 0x7ffd0db75920
READ of size 8 at 0x7fbb5e3057b8 thread T0
    #0 0x5565fb8a2dc7 in fd_apply_builtin_program_feature_transitions src/flamenco/runtime/fd_runtime.c:2133
    #1 0x5565fb8b7743 in fd_runtime_process_new_epoch src/flamenco/runtime/fd_runtime.c:2258
    #2 0x5565fb8b7743 in fd_runtime_block_pre_execute_process_new_epoch src/flamenco/runtime/fd_runtime.c:3662
    #3 0x5565fb8ba607 in fd_runtime_block_eval_tpool src/flamenco/runtime/fd_runtime.c:3729
    #4 0x5565fb844350 in runtime_replay src/app/ledger/main.c:287
    #5 0x5565fb84db4d in replay src/app/ledger/main.c:1115
    #6 0x5565fb7e0407 in main src/app/ledger/main.c:1325
    #7 0x7fbb602ce082 in __libc_start_main ../csu/libc-start.c:308
    #8 0x5565fb841b8d in _start (/home/.../firedancer/build/native/gcc/bin/fd_ledger+0x398b8d) (BuildId: 91fca3cc9d99473f923ba0f859357f8b8d8334e5)
```