### PR TITLE
funk, contrib: use locked pages for funk by default

### DIFF
--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           sudo prlimit --pid=$$ --nofile=1048576
           sudo prlimit --pid=$$ --memlock=unlimited
-          DUMP_DIR=../dump make run-runtime-backtest
+          DUMP_DIR=../dump HUGE_TLBFS_MOUNT_PATH=/data/svc_firedancer/mnt/.fd make run-runtime-backtest
 
       - name: fini
         if: always()

--- a/contrib/offline-replay/offline_replay.toml
+++ b/contrib/offline-replay/offline_replay.toml
@@ -18,6 +18,7 @@
     heap_size_gib = {funk_pages}
     max_account_records = {index_max}
     max_database_transactions = 64
+    lock_pages = false
 [runtime]
     heap_size_gib = {heap_size}
     [runtime.limits]

--- a/src/app/firedancer-dev/commands/backtest.c
+++ b/src/app/firedancer-dev/commands/backtest.c
@@ -68,7 +68,8 @@ backtest_topo( config_t * config ) {
   fd_topo_obj_t * funk_obj = setup_topo_funk( topo, "funk",
       config->firedancer.funk.max_account_records,
       config->firedancer.funk.max_database_transactions,
-      config->firedancer.funk.heap_size_gib );
+      config->firedancer.funk.heap_size_gib,
+      config->firedancer.funk.lock_pages );
 
   fd_topob_tile_uses( topo, replay_tile, funk_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
 

--- a/src/app/firedancer-dev/commands/snapshot_load.c
+++ b/src/app/firedancer-dev/commands/snapshot_load.c
@@ -29,7 +29,8 @@ snapshot_load_topo( config_t *     config,
   fd_topo_obj_t * funk_obj = setup_topo_funk( topo, "funk",
       config->firedancer.funk.max_account_records,
       config->firedancer.funk.max_database_transactions,
-      config->firedancer.funk.heap_size_gib );
+      config->firedancer.funk.heap_size_gib,
+      config->firedancer.funk.lock_pages );
 
   static ushort tile_to_cpu[ FD_TILE_MAX ] = {0};
   if( args->snapshot_load.tile_cpus[0] ) {

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -374,6 +374,19 @@ user = ""
     # setting.
     max_database_transactions = 2048
 
+    # Whether to lock the memory pages backing the database to physical
+    # memory pages, which cannot be paged out.
+    #
+    # If this option is false, then the database will be backed by normal
+    # pages which will be paged out to an on-disk file if the host comes
+    # under memory pressure. This is useful for when your machine doesn't
+    # have enough physical memory to run against clusters with a large
+    # number of accounts (e.g. mainnet).
+    #
+    # WARNING: disabling this option can cause performance degradation, as
+    # the database pages may be paged out.
+    lock_pages = true
+
 [runtime]
     # Specifies the size in gigibytes of the runtime heap allocator.
     #

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -74,7 +74,8 @@ setup_topo_funk( fd_topo_t *  topo,
                  char const * wksp_name,
                  ulong        max_account_records,
                  ulong        max_database_transactions,
-                 ulong        heap_size_gib ) {
+                 ulong        heap_size_gib,
+                 int          lock_pages ) {
   fd_topo_obj_t * obj = fd_topob_obj( topo, "funk", wksp_name );
   FD_TEST( fd_pod_insert_ulong(  topo->props, "funk", obj->id ) );
   FD_TEST( fd_pod_insertf_ulong( topo->props, max_account_records,       "obj.%lu.rec_max",  obj->id ) );
@@ -90,7 +91,7 @@ setup_topo_funk( fd_topo_t *  topo,
   ulong part_max = fd_wksp_part_max_est( funk_footprint+(heap_size_gib*(1UL<<30)), 1U<<14U );
   if( FD_UNLIKELY( !part_max ) ) FD_LOG_ERR(( "fd_wksp_part_max_est(%lu,16KiB) failed", funk_footprint ));
   wksp->part_max += part_max;
-  wksp->is_locked = 0;
+  wksp->is_locked = lock_pages;
 
   return obj;
 }
@@ -466,7 +467,8 @@ fd_topo_initialize( config_t * config ) {
   fd_topo_obj_t * funk_obj = setup_topo_funk( topo, "funk",
       config->firedancer.funk.max_account_records,
       config->firedancer.funk.max_database_transactions,
-      config->firedancer.funk.heap_size_gib );
+      config->firedancer.funk.heap_size_gib,
+      config->firedancer.funk.lock_pages );
 
   FOR(exec_tile_cnt)   fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "exec", i ) ], funk_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   /*                */ fd_topob_tile_uses( topo, replay_tile,  funk_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );

--- a/src/app/firedancer/topology.h
+++ b/src/app/firedancer/topology.h
@@ -38,7 +38,8 @@ setup_topo_funk( fd_topo_t *  topo,
                  char const * wksp_name,
                  ulong        max_account_records,
                  ulong        max_database_transactions,
-                 ulong        heap_size_gib );
+                 ulong        heap_size_gib,
+                 int          lock_pages );
 
 fd_topo_obj_t *
 setup_topo_banks( fd_topo_t *  topo,

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -107,6 +107,7 @@ struct fd_configf {
     ulong max_account_records;
     ulong heap_size_gib;
     ulong max_database_transactions;
+    int   lock_pages;
   } funk;
 
   struct {

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -91,6 +91,7 @@ fd_config_extract_podf( uchar *        pod,
   CFG_POP      ( ulong,  funk.max_account_records                         );
   CFG_POP      ( ulong,  funk.heap_size_gib                               );
   CFG_POP      ( ulong,  funk.max_database_transactions                   );
+  CFG_POP      ( bool,   funk.lock_pages                                  );
 
   CFG_POP      ( ulong,  runtime.heap_size_gib                            );
   CFG_POP      ( ulong,  runtime.limits.max_rooted_slots                  );

--- a/src/flamenco/runtime/tests/run_backtest_ci.sh
+++ b/src/flamenco/runtime/tests/run_backtest_ci.sh
@@ -1,21 +1,20 @@
 #!/bin/bash
 set -e
-HUGE_TLBFS_MOUNT_PATH="/data/svc_firedancer/mnt/.fd"
 
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-308392063-v2.3.0 -s snapshot-308392062-FDuB6CFKod14xGRGmdiRpQx2uaKyp3GDkyai2Ba7eH8d.tar.zst -y 5 -m 2000000 -e 308392090 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-350814254-v2.3.0 -s snapshot-350814253-G5P3eNtkWUGkZ8b871wvf6d78wYxBJp637PCWJuQByZa.tar.zst -y 3 -m 2000000 -e 350814284 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-281546597-v2.3.0 -s snapshot-281546592-EbVCTHZzWyya8tJ4CaSvgMgZVpzDVzmifaWxp4Aiet5A.tar.zst -y 3 -m 2000000 -e 281546597 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-324823213-v2.3.0 -s snapshot-324823212-sk3zF16dk7gEsgLf1mGDhj6qRp87kFjJdEWZmhr4Kju.tar.zst -y 4 -m 2000000 -e 324823214 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-325467935-v2.3.0 -s snapshot-325467934-7VZstGKYwU8Y7A952RQjfCKD5Qdbu9t8D84e5h1mHXA6.tar.zst -y 4 -m 2000000 -e 325467936 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-283927487-v2.3.0 -s snapshot-283927486-7gCbg5g4BnD9SkQUjpHvhepWsQTpo2WaZaA5bhcNBMhG.tar.zst -y 3 -m 2000000 -e 283927497 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-321168308-v2.3.0 -s snapshot-321168307-DecxjCHDsiQgbqZPHptgz1tystKi3QmV3Rd3QEgcxs2W.tar.zst -y 3 -m 2000000 -e 321168308 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-327324660-v2.3.0 -s snapshot-327324659-RFg6ep2QLa8uzAkZku6xMnZQYVaUN9jwkVEfsnWYB25.tar.zst -y 4 -m 2000000 -e 327324660 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-370199634-v2.3.0 -s snapshot-370199633-D8mrtzcNV8iNVarHs4mi55QHrCfmzDScYL8BBYXUHAwW.tar.zst -y 3 -m 200000 -e 370199634 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-378683870-v2.3.0 -s snapshot-378683869-8tgAVwwBiDFETa2pWJPgzJZg5csvpwj51t1EFfrnVKCh.tar.zst -y 3 -m 2000000 -e 378683872 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-330219081-v2.3.0 -s snapshot-330219080-6fafBFhTgbHxNiE7wtJTF1ERUyVyTCJz2d52tMtrfG2Z.tar.zst -y 4 -m 2000000 -e 330219082 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-372721907-v2.3.0 -s snapshot-372721906-FtUjok2JfLPwJCRVcioV12M8FWbbJaC91XEJzm4eZy53.tar.zst -y 3 -m 2000000 -e 372721910 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-331691646-v2.3.0 -s snapshot-331691639-3NmZ4rd7nHfn6tuS4E5gUfAwWMoBAQ6K1yntNkyhPbrb.tar.zst -y 4 -m 2000000 -e 331691647 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-336218682-v2.3.0 -s snapshot-336218681-BDsErdHkqa5iQGCNkSvQpeon8GLFsgeNEkckrMKboJ4N.tar.zst -y 5 -m 2000000 -e 336218683 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-340269866-v2.3.0 -s snapshot-340269865-7kiU4fCQMuf97vs3827n1vn1oScnkYYvvQ1sGGa1QKVE.tar.zst -y 5 -m 2000000 -e 340269872 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-390056400-v2.3.0 -s snapshot-390056399-6JQvYEDzQqcrjF4EoxkWUMuskm9aGoGRG94twEqXuuri.tar.zst -y 10 -m 2000000 -e 390056406 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-254462437-v2.3.0 -s snapshot-254462437-9HqBi19BJJRZfHeBS3ZpkeP9B5SAxBxz6Kwug29yLHac.tar.zst -y 16 -m 10000000 -e 254462598 -c 2.3.0 -h $HUGE_TLBFS_MOUNT_PATH
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-308392063-v2.3.0 -s snapshot-308392062-FDuB6CFKod14xGRGmdiRpQx2uaKyp3GDkyai2Ba7eH8d.tar.zst -y 5 -m 2000000 -e 308392090 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-350814254-v2.3.0 -s snapshot-350814253-G5P3eNtkWUGkZ8b871wvf6d78wYxBJp637PCWJuQByZa.tar.zst -y 3 -m 2000000 -e 350814284 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-281546597-v2.3.0 -s snapshot-281546592-EbVCTHZzWyya8tJ4CaSvgMgZVpzDVzmifaWxp4Aiet5A.tar.zst -y 3 -m 2000000 -e 281546597 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-324823213-v2.3.0 -s snapshot-324823212-sk3zF16dk7gEsgLf1mGDhj6qRp87kFjJdEWZmhr4Kju.tar.zst -y 4 -m 2000000 -e 324823214 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-325467935-v2.3.0 -s snapshot-325467934-7VZstGKYwU8Y7A952RQjfCKD5Qdbu9t8D84e5h1mHXA6.tar.zst -y 4 -m 2000000 -e 325467936 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-283927487-v2.3.0 -s snapshot-283927486-7gCbg5g4BnD9SkQUjpHvhepWsQTpo2WaZaA5bhcNBMhG.tar.zst -y 3 -m 2000000 -e 283927497 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-321168308-v2.3.0 -s snapshot-321168307-DecxjCHDsiQgbqZPHptgz1tystKi3QmV3Rd3QEgcxs2W.tar.zst -y 3 -m 2000000 -e 321168308 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-327324660-v2.3.0 -s snapshot-327324659-RFg6ep2QLa8uzAkZku6xMnZQYVaUN9jwkVEfsnWYB25.tar.zst -y 4 -m 2000000 -e 327324660 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-370199634-v2.3.0 -s snapshot-370199633-D8mrtzcNV8iNVarHs4mi55QHrCfmzDScYL8BBYXUHAwW.tar.zst -y 3 -m 200000 -e 370199634 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-378683870-v2.3.0 -s snapshot-378683869-8tgAVwwBiDFETa2pWJPgzJZg5csvpwj51t1EFfrnVKCh.tar.zst -y 3 -m 2000000 -e 378683872 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-330219081-v2.3.0 -s snapshot-330219080-6fafBFhTgbHxNiE7wtJTF1ERUyVyTCJz2d52tMtrfG2Z.tar.zst -y 4 -m 2000000 -e 330219082 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-372721907-v2.3.0 -s snapshot-372721906-FtUjok2JfLPwJCRVcioV12M8FWbbJaC91XEJzm4eZy53.tar.zst -y 3 -m 2000000 -e 372721910 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-331691646-v2.3.0 -s snapshot-331691639-3NmZ4rd7nHfn6tuS4E5gUfAwWMoBAQ6K1yntNkyhPbrb.tar.zst -y 4 -m 2000000 -e 331691647 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-336218682-v2.3.0 -s snapshot-336218681-BDsErdHkqa5iQGCNkSvQpeon8GLFsgeNEkckrMKboJ4N.tar.zst -y 5 -m 2000000 -e 336218683 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-340269866-v2.3.0 -s snapshot-340269865-7kiU4fCQMuf97vs3827n1vn1oScnkYYvvQ1sGGa1QKVE.tar.zst -y 5 -m 2000000 -e 340269872 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-390056400-v2.3.0 -s snapshot-390056399-6JQvYEDzQqcrjF4EoxkWUMuskm9aGoGRG94twEqXuuri.tar.zst -y 10 -m 2000000 -e 390056406 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-254462437-v2.3.0 -s snapshot-254462437-9HqBi19BJJRZfHeBS3ZpkeP9B5SAxBxz6Kwug29yLHac.tar.zst -y 16 -m 10000000 -e 254462598 -c 2.3.0

--- a/src/flamenco/runtime/tests/run_ledger_backtest.sh
+++ b/src/flamenco/runtime/tests/run_ledger_backtest.sh
@@ -24,7 +24,7 @@ THREAD_MEM_BOUND="--thread-mem-bound 0"
 CLUSTER_VERSION=""
 DUMP_DIR=${DUMP_DIR:="./dump"}
 ONE_OFFS="2B2SBNbUcr438LtGXNcJNBP2GBSxjx81F945SdSkUSfC,LTHasHQX6661DaDD4S6A2TFi6QBuiwXKv66fB1obfHq,LTdLt9Ycbyoipz5fLysCi1NnDnASsZfmJLJXts5ZxZz,LTsNAP8h1voEVVToMNBNqoiNQex4aqfUrbFhRH3mSQ2"
-HUGE_TLBFS_MOUNT_PATH="/mnt/.fd"
+HUGE_TLBFS_MOUNT_PATH=${HUGE_TLBFS_MOUNT_PATH:="/mnt/.fd"}
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -177,6 +177,7 @@ echo "
     heap_size_gib = $FUNK_PAGES
     max_account_records = $INDEX_MAX
     max_database_transactions = 64
+    lock_pages = false
 [runtime]
     heap_size_gib = 100
     [runtime.limits]

--- a/src/flamenco/runtime/tests/run_nightly_backtest.sh
+++ b/src/flamenco/runtime/tests/run_nightly_backtest.sh
@@ -103,6 +103,7 @@ echo "
     heap_size_gib = $FUNK_PAGES
     max_account_records = $INDEX_MAX
     max_database_transactions = 1024
+    lock_pages = true
 [runtime]
     heap_size_gib = 200
     [runtime.limits]


### PR DESCRIPTION
We don't need to use unlocked pages for Funk in a lot of cases, so it makes sense to disable this by default.