### PR TITLE
bundle: improve keepalive logic

### DIFF
--- a/src/disco/bundle/fd_bundle_client.c
+++ b/src/disco/bundle/fd_bundle_client.c
@@ -26,8 +26,8 @@
 #define FD_BUNDLE_CLIENT_REQUEST_TIMEOUT ((long)8e9) /* 8 seconds */
 
 __attribute__((weak)) long
-fd_bundle_tickcount( void ) {
-  return fd_tickcount();
+fd_bundle_now( void ) {
+  return fd_log_wallclock();
 }
 
 void
@@ -48,7 +48,7 @@ fd_bundle_client_reset( fd_bundle_tile_t * ctx ) {
   ctx->bundle_subscription_live = 0;
   ctx->bundle_subscription_wait = 0;
 
-  ctx->rtt->is_rtt_valid = 0;
+  memset( ctx->rtt, 0, sizeof(fd_rtt_estimate_t) );
 
 # if FD_HAS_OPENSSL
   if( FD_UNLIKELY( ctx->ssl ) ) {
@@ -57,7 +57,7 @@ fd_bundle_client_reset( fd_bundle_tile_t * ctx ) {
   }
 # endif
 
-  fd_bundle_tile_backoff( ctx, fd_bundle_tickcount() );
+  fd_bundle_tile_backoff( ctx, fd_bundle_now() );
 
   fd_bundle_auther_reset( &ctx->auther );
   fd_grpc_client_reset( ctx->grpc_client );
@@ -167,8 +167,7 @@ fd_bundle_client_create_conn( fd_bundle_tile_t * ctx ) {
 # endif /* FD_HAS_OPENSSL */
 
   fd_grpc_client_reset( ctx->grpc_client );
-  ctx->last_ping_tx_ticks = fd_bundle_tickcount();
-  ctx->last_ping_tx_nanos = fd_log_wallclock();
+  fd_keepalive_init( ctx->keepalive, ctx->rng, ctx->keepalive_interval, ctx->keepalive_interval, fd_bundle_now() );
 }
 
 static int
@@ -258,25 +257,15 @@ fd_bundle_client_send_ping( fd_bundle_tile_t * ctx ) {
   fd_h2_rbuf_t * rbuf_tx = fd_grpc_client_rbuf_tx( ctx->grpc_client );
 
   if( FD_LIKELY( fd_h2_tx_ping( conn, rbuf_tx ) ) ) {
-    ctx->last_ping_tx_ticks = fd_bundle_tickcount();
-    ctx->last_ping_tx_nanos = fd_log_wallclock();
-    ctx->ping_randomize     = fd_rng_ulong( ctx->rng );
+    long now = fd_bundle_now();
+    fd_keepalive_tx( ctx->keepalive, ctx->rng, now );
+    FD_LOG_DEBUG(( "Keepalive TX (deadline=+%gs)", (double)( ctx->keepalive->ts_deadline-now )/1e9 ));
   }
-}
-
-FD_FN_PURE int
-fd_bundle_client_ping_is_due( fd_bundle_tile_t const * ctx,
-                              long                     now_ticks ) {
-  ulong delay_min = ctx->ping_threshold_ticks>>1;
-  ulong delay_rng = ctx->ping_threshold_ticks & ctx->ping_randomize;
-  ulong delay     = delay_min + delay_rng;
-  long  deadline  = ctx->last_ping_tx_ticks + (long)delay;
-  return now_ticks >= deadline;
 }
 
 int
 fd_bundle_client_step_reconnect( fd_bundle_tile_t * ctx,
-                                 long               io_ticks ) {
+                                 long               now ) {
   /* Drive auth */
   if( FD_UNLIKELY( ctx->auther.needs_poll ) ) {
     fd_bundle_auther_poll( &ctx->auther, ctx->grpc_client, ctx->keyguard_client );
@@ -285,7 +274,7 @@ fd_bundle_client_step_reconnect( fd_bundle_tile_t * ctx,
   if( FD_UNLIKELY( ctx->auther.state!=FD_BUNDLE_AUTH_STATE_DONE_WAIT ) ) return 0;
 
   /* Request block builder info */
-  int const builder_info_expired = ( ctx->builder_info_valid_until_ticks - io_ticks )<0;
+  int const builder_info_expired = ( ctx->builder_info_valid_until - now )<0;
   if( FD_UNLIKELY( ( ( !ctx->builder_info_avail ) |
                      ( !builder_info_expired    ) ) &
                    ( !ctx->builder_info_wait      ) ) ) {
@@ -306,7 +295,7 @@ fd_bundle_client_step_reconnect( fd_bundle_tile_t * ctx,
   }
 
   /* Send a PING */
-  if( FD_UNLIKELY( fd_bundle_client_ping_is_due( ctx, io_ticks ) ) ) {
+  if( FD_UNLIKELY( fd_keepalive_should_tx( ctx->keepalive, now ) ) ) {
     fd_bundle_client_send_ping( ctx );
     return 1;
   }
@@ -351,7 +340,7 @@ fd_bundle_client_step1( fd_bundle_tile_t * ctx,
   /* gRPC conn died? */
   if( FD_UNLIKELY( !ctx->grpc_client ) ) {
   reconnect:
-    if( FD_UNLIKELY( fd_bundle_tile_should_stall( ctx, fd_bundle_tickcount() ) ) ) {
+    if( FD_UNLIKELY( fd_bundle_tile_should_stall( ctx, fd_bundle_now() ) ) ) {
       return;
     }
     fd_bundle_client_create_conn( ctx );
@@ -360,10 +349,11 @@ fd_bundle_client_step1( fd_bundle_tile_t * ctx,
   }
 
   /* Did a HTTP/2 PING time out */
-  long check_ts = fd_bundle_tickcount();
-  if( FD_UNLIKELY( fd_bundle_client_ping_is_timeout( ctx, check_ts ) ) ) {
+  long check_ts = fd_bundle_now();
+  if( FD_UNLIKELY( fd_keepalive_is_timeout( ctx->keepalive, check_ts ) ) ) {
     FD_LOG_WARNING(( "Bundle gRPC timed out (HTTP/2 PING went unanswered for %.2f seconds)",
-                    ( (double)ctx->ping_deadline_ticks / fd_tempo_tick_per_ns( NULL ) )*1e-9 ));
+                     (double)( check_ts - ctx->keepalive->ts_last_tx )/1e9 ));
+    ctx->keepalive->inflight = 0;
     ctx->defer_reset = 1;
     *charge_busy = 1;
     return;
@@ -380,7 +370,7 @@ fd_bundle_client_step1( fd_bundle_tile_t * ctx,
 
   /* Are we ready to issue a new request? */
   if( FD_UNLIKELY( fd_grpc_client_request_is_blocked( ctx->grpc_client ) ) ) return;
-  long io_ts = fd_bundle_tickcount();
+  long io_ts = fd_bundle_now();
   if( FD_UNLIKELY( fd_bundle_tile_should_stall( ctx, io_ts ) ) ) return;
 
   *charge_busy |= fd_bundle_client_step_reconnect( ctx, io_ts );
@@ -417,17 +407,17 @@ fd_bundle_client_step( fd_bundle_tile_t * ctx,
 
 void
 fd_bundle_tile_backoff( fd_bundle_tile_t * ctx,
-                        long               ts_ticks ) {
+                        long               now ) {
   uint iter = ctx->backoff_iter;
-  if( ts_ticks < ctx->backoff_reset ) iter = 0U;
+  if( now < ctx->backoff_reset ) iter = 0U;
   iter++;
 
   /* FIXME proper backoff */
-  long wait_ticks = (long)( 2e9 * fd_tempo_tick_per_ns( NULL ) );
-  wait_ticks = (long)( fd_rng_ulong( ctx->rng ) & ( (1UL<<fd_ulong_find_msb_w_default( (ulong)wait_ticks, 0 ))-1UL ) );
+  long wait_ns = (long)2e9;
+  wait_ns = (long)( fd_rng_ulong( ctx->rng ) & ( (1UL<<fd_ulong_find_msb_w_default( (ulong)wait_ns, 0 ))-1UL ) );
 
-  ctx->backoff_until = ts_ticks +   wait_ticks;
-  ctx->backoff_reset = ts_ticks + 2*wait_ticks;
+  ctx->backoff_until = now +   wait_ns;
+  ctx->backoff_reset = now + 2*wait_ns;
 
   ctx->backoff_iter = iter;
 }
@@ -484,7 +474,7 @@ fd_bundle_tile_publish_bundle_txn(
     FD_LOG_CRIT(( "ctx->stem not set. This is a bug." ));
   }
 
-  ulong tspub = (ulong)fd_frag_meta_ts_comp( fd_bundle_tickcount() );
+  ulong tspub = (ulong)fd_frag_meta_ts_comp( fd_bundle_now() );
   fd_stem_publish( ctx->stem, ctx->verify_out.idx, sig, ctx->verify_out.chunk, sz, 0UL, 0UL, tspub );
   ctx->verify_out.chunk = fd_dcache_compact_next( ctx->verify_out.chunk, sz, ctx->verify_out.chunk0, ctx->verify_out.wmark );
   ctx->metrics.txn_received_cnt++;
@@ -519,7 +509,7 @@ fd_bundle_tile_publish_txn(
     FD_LOG_CRIT(( "ctx->stem not set. This is a bug." ));
   }
 
-  ulong tspub = (ulong)fd_frag_meta_ts_comp( fd_bundle_tickcount() );
+  ulong tspub = (ulong)fd_frag_meta_ts_comp( fd_bundle_now() );
   fd_stem_publish( ctx->stem, ctx->verify_out.idx, sig, ctx->verify_out.chunk, sz, 0UL, 0UL, tspub );
   ctx->verify_out.chunk = fd_dcache_compact_next( ctx->verify_out.chunk, sz, ctx->verify_out.chunk0, ctx->verify_out.wmark );
   ctx->metrics.txn_received_cnt++;
@@ -727,9 +717,9 @@ fd_bundle_client_handle_builder_fee_info(
     return;
   }
 
-  long validity_duration_ticks = (long)( fd_tempo_tick_per_ns( NULL ) * (60e9 * 5.) ); /* 5 minutes */
+  long validity_duration_ns = (long)( 60e9 * 5. ); /* 5 minutes */
   ctx->builder_info_avail = 1;
-  ctx->builder_info_valid_until_ticks = fd_bundle_tickcount() + validity_duration_ticks;
+  ctx->builder_info_valid_until = fd_bundle_now() + validity_duration_ns;
 }
 
 static void
@@ -771,13 +761,13 @@ fd_bundle_client_grpc_rx_msg(
   case FD_BUNDLE_CLIENT_REQ_Auth_GenerateAuthChallenge:
     if( FD_UNLIKELY( !fd_bundle_auther_handle_challenge_resp( &ctx->auther, protobuf, protobuf_sz ) ) ) {
       ctx->metrics.decode_fail_cnt++;
-      fd_bundle_tile_backoff( ctx, fd_bundle_tickcount() );
+      fd_bundle_tile_backoff( ctx, fd_bundle_now() );
     }
     break;
   case FD_BUNDLE_CLIENT_REQ_Auth_GenerateAuthTokens:
     if( FD_UNLIKELY( !fd_bundle_auther_handle_tokens_resp( &ctx->auther, protobuf, protobuf_sz ) ) ) {
       ctx->metrics.decode_fail_cnt++;
-      fd_bundle_tile_backoff( ctx, fd_bundle_tickcount() );
+      fd_bundle_tile_backoff( ctx, fd_bundle_now() );
     }
     break;
   case FD_BUNDLE_CLIENT_REQ_Bundle_SubscribeBundles:
@@ -797,7 +787,7 @@ fd_bundle_client_grpc_rx_msg(
 static void
 fd_bundle_client_request_failed( fd_bundle_tile_t * ctx,
                                  ulong              request_ctx ) {
-  fd_bundle_tile_backoff( ctx, fd_bundle_tickcount() );
+  fd_bundle_tile_backoff( ctx, fd_bundle_now() );
   switch( request_ctx ) {
   case FD_BUNDLE_CLIENT_REQ_Auth_GenerateAuthChallenge:
   case FD_BUNDLE_CLIENT_REQ_Auth_GenerateAuthTokens:
@@ -829,7 +819,7 @@ fd_bundle_client_grpc_rx_end(
   case FD_BUNDLE_CLIENT_REQ_Bundle_SubscribePackets:
     ctx->packet_subscription_live = 0;
     ctx->packet_subscription_wait = 0;
-    fd_bundle_tile_backoff( ctx, fd_bundle_tickcount() );
+    fd_bundle_tile_backoff( ctx, fd_bundle_now() );
     ctx->defer_reset = 1;
     FD_LOG_INFO(( "SubscribePackets stream failed (gRPC status %u-%s). Reconnecting ...",
                   resp->grpc_status, fd_grpc_status_cstr( resp->grpc_status ) ));
@@ -837,7 +827,7 @@ fd_bundle_client_grpc_rx_end(
   case FD_BUNDLE_CLIENT_REQ_Bundle_SubscribeBundles:
     ctx->bundle_subscription_live = 0;
     ctx->bundle_subscription_wait = 0;
-    fd_bundle_tile_backoff( ctx, fd_bundle_tickcount() );
+    fd_bundle_tile_backoff( ctx, fd_bundle_now() );
     ctx->defer_reset = 1;
     FD_LOG_INFO(( "SubscribeBundles stream failed (gRPC status %u-%s). Reconnecting ...",
                   resp->grpc_status, fd_grpc_status_cstr( resp->grpc_status ) ));
@@ -877,10 +867,12 @@ fd_bundle_client_grpc_rx_timeout(
 static void
 fd_bundle_client_grpc_ping_ack( void * app_ctx ) {
   fd_bundle_tile_t * ctx = app_ctx;
-  ctx->last_ping_rx_ticks = fd_bundle_tickcount();
+  long rtt_sample = fd_keepalive_rx( ctx->keepalive, fd_bundle_now() );
+  if( FD_LIKELY( rtt_sample ) ) {
+    fd_rtt_sample( ctx->rtt, (float)rtt_sample, 0 );
+    FD_LOG_DEBUG(( "Keepalive ACK" ));
+  }
   ctx->metrics.ping_ack_cnt++;
-  long rtt_sample = fd_log_wallclock() - ctx->last_ping_tx_nanos;
-  fd_rtt_sample( ctx->rtt, (float)rtt_sample, 0 );
 }
 
 fd_grpc_client_callbacks_t fd_bundle_client_grpc_callbacks = {
@@ -934,7 +926,7 @@ fd_bundle_client_status( fd_bundle_tile_t const * ctx ) {
     return CONNECTING; /* not fully connected */
   }
 
-  if( FD_UNLIKELY( fd_bundle_client_ping_is_timeout( ctx, fd_bundle_tickcount() ) ) ) {
+  if( FD_UNLIKELY( fd_keepalive_is_timeout( ctx->keepalive, fd_bundle_now() ) ) ) {
     return DISCONNECTED; /* possible timeout */
   }
 
@@ -966,13 +958,4 @@ fd_bundle_request_ctx_cstr( ulong request_ctx ) {
   default:
     return "unknown";
   }
-}
-
-void
-fd_bundle_client_set_ping_interval( fd_bundle_tile_t * ctx,
-                                    long               ping_interval_ns ) {
-  ctx->ping_threshold_ticks = fd_ulong_pow2_up( (ulong)
-      ( (double)ping_interval_ns * fd_tempo_tick_per_ns( NULL ) ) );
-  ctx->ping_randomize = fd_rng_ulong( ctx->rng );
-  ctx->ping_deadline_ticks = 4UL * ctx->ping_threshold_ticks;
 }

--- a/src/disco/bundle/fd_bundle_tile.c
+++ b/src/disco/bundle/fd_bundle_tile.c
@@ -116,7 +116,7 @@ fd_bundle_tile_publish_block_engine_update(
 
   update->status = (uchar)ctx->bundle_status_recent;
 
-  ulong tspub = (ulong)fd_frag_meta_ts_comp( fd_bundle_tickcount() );
+  ulong tspub = (ulong)fd_frag_meta_ts_comp( fd_bundle_now() );
   fd_stem_publish(
       stem,
       ctx->plugin_out.idx,
@@ -547,7 +547,7 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->so_rcvbuf = (int)so_rcvbuf;
 
   /* Set idle ping timer */
-  // fd_bundle_client_set_ping_interval( ctx, (long)tile->bundle.keepalive_interval_nanos );
+  ctx->keepalive_interval = (long)tile->bundle.keepalive_interval_nanos;
 
   ctx->bundle_status_plugin = 127;
   ctx->bundle_status_recent = FD_PLUGIN_MSG_BLOCK_ENGINE_UPDATE_STATUS_DISCONNECTED;
@@ -601,6 +601,7 @@ populate_allowed_fds( fd_topo_t const *      topo,
 }
 
 #define STEM_BURST (5UL)
+#define STEM_LAZY ((long)10e6)
 
 #define STEM_CALLBACK_CONTEXT_TYPE  fd_bundle_tile_t
 #define STEM_CALLBACK_CONTEXT_ALIGN alignof(fd_bundle_tile_t)

--- a/src/disco/bundle/fd_keepalive.h
+++ b/src/disco/bundle/fd_keepalive.h
@@ -1,0 +1,94 @@
+#ifndef HEADER_fd_src_disco_bundle_fd_keepalive_h
+#define HEADER_fd_src_disco_bundle_fd_keepalive_h
+
+/* fd_keepalive.h provides an API to periodically generate keepalive
+   events.  The general usage is as follows:
+   - Configure a target keepalive interval and timeout
+   - Periodically check back whether a keepalive is due, or whether a
+     keepalive timed out
+   - Notify the object whenever a keepalive was sent or a keepalive ACK
+     was received. */
+
+#include "../../util/rng/fd_rng.h"
+
+struct fd_keepalive {
+  long ts_next_tx;   /* Timestamp when to send next ping */
+  long ts_deadline;  /* Timestamp by which ping ACK is expected to be received */
+  long interval;
+  long timeout;
+
+  long ts_last_tx;   /* Timestamp of last ping sent */
+  long ts_last_rx;   /* Timestamp of last ping ACK received */
+
+  uint inflight : 1;
+};
+
+typedef struct fd_keepalive fd_keepalive_t;
+
+FD_PROTOTYPES_BEGIN
+
+static inline long
+fd_keepalive_interval_reload( fd_rng_t * rng,
+                              long       interval ) {
+  long i2 = interval>>1;
+  return i2 + (long)fd_rng_ulong_roll( rng, (ulong)i2 );
+}
+
+static inline fd_keepalive_t *
+fd_keepalive_init( fd_keepalive_t * ka,
+                   fd_rng_t *       rng,
+                   long             interval,
+                   long             timeout,
+                   long             now ) {
+  memset( ka, 0, sizeof(fd_keepalive_t) );
+  if( FD_UNLIKELY( interval<2L || !timeout ) ) return NULL;
+  ka->interval = interval;
+  ka->timeout  = timeout;
+  ka->ts_next_tx = now + (long)fd_keepalive_interval_reload( rng, ka->interval );
+  return ka;
+}
+
+/* fd_keepalive_should_tx returns 1 if the caller should send out a new
+   keepalive probe.  Otherwise, returns 0.  Always returns 0 if interval
+   is zero (thus has no-op behavior for a zeroed keepalive struct). */
+
+static inline int
+fd_keepalive_should_tx( fd_keepalive_t const * ka,
+                        long                   now ) {
+  return (!!ka->interval) & (ka->ts_next_tx <= now) & (!ka->inflight);
+}
+
+static inline void
+fd_keepalive_tx( fd_keepalive_t * ka,
+                 fd_rng_t *       rng,
+                 long             now ) {
+  long delay = (long)fd_keepalive_interval_reload( rng, ka->interval );
+  ka->ts_last_tx  = now;
+  ka->ts_next_tx += delay;
+  if( FD_UNLIKELY( ka->ts_next_tx < now ) ) {
+    ka->ts_next_tx = now + delay;
+  }
+  ka->ts_deadline = ka->ts_last_tx + ka->timeout;
+  ka->inflight    = 1;
+}
+
+static inline int
+fd_keepalive_is_timeout( fd_keepalive_t const * ka,
+                         long                   now ) {
+  return (!!ka->inflight) & (ka->ts_deadline <= now);
+}
+
+static inline long
+fd_keepalive_rx( fd_keepalive_t * ka,
+                 long             now ) {
+  long rtt = now - ka->ts_last_tx;
+  if( !ka->inflight ) rtt = 0L;
+  ka->ts_deadline = 0L;
+  ka->ts_last_rx  = now;
+  ka->inflight    = 0;
+  return rtt;
+}
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_disco_bundle_fd_keepalive_h */

--- a/src/disco/bundle/fuzz_bundle_client.c
+++ b/src/disco/bundle/fuzz_bundle_client.c
@@ -9,7 +9,7 @@
    For now, this fuzzer does not support timeouts. */
 
 long
-fd_bundle_tickcount( void ) {
+fd_bundle_now( void ) {
   return 2UL;
 }
 


### PR DESCRIPTION
- Moves keepalive logic to a separate API
- Fixes a HTTP/2 PING flood bug
- Clears RTT Prometheus metrics when the connection breaks
- Switch bundle tile from fd_tickcount to fd_log_wallclock