### PR TITLE
Fix XDP loopback packet loss

### DIFF
--- a/src/app/shared/commands/configure/sysctl.c
+++ b/src/app/shared/commands/configure/sysctl.c
@@ -72,6 +72,12 @@ static const sysctl_param_t xdp_params[] = {
     WARN_MINIMUM,
     0,
   },
+  {
+    "/proc/sys/net/ipv4/conf/lo/route_localnet",
+    1,
+    ENFORCE_MINIMUM,
+    1,
+  },
   {0}
 };
 


### PR DESCRIPTION
When sending packets from/to localhost via the lo interface, the
sysctl net.ipv4.conf.lo.route_localnet must be set to 1 on newer
kernels, to avoid a drop at the following check:

https://elixir.bootlin.com/linux/v6.11/source/net/ipv4/route.c#L2255

This is presumably a kernel bug ...

Reported-by: TheDude <mark@temporal.xyz>

Closes https://github.com/firedancer-io/firedancer/issues/5651