### PR TITLE
gui: publish vote pubkey

### DIFF
--- a/src/app/fdctl/topology.c
+++ b/src/app/fdctl/topology.c
@@ -492,6 +492,7 @@ fd_topo_initialize( config_t * config ) {
       tile->gui.is_voting = strcmp( config->paths.vote_account, "" );
       strncpy( tile->gui.cluster, config->cluster, sizeof(tile->gui.cluster) );
       strncpy( tile->gui.identity_key_path, config->paths.identity_key, sizeof(tile->gui.identity_key_path) );
+      strncpy( tile->gui.vote_key_path, config->paths.vote_account, sizeof(tile->gui.vote_key_path) );
       tile->gui.max_http_connections      = config->tiles.gui.max_http_connections;
       tile->gui.max_websocket_connections = config->tiles.gui.max_websocket_connections;
       tile->gui.max_http_request_length   = config->tiles.gui.max_http_request_length;

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -1051,6 +1051,7 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
       tile->gui.is_voting = strcmp( config->paths.vote_account, "" );
       strncpy( tile->gui.cluster, config->cluster, sizeof(tile->gui.cluster) );
       strncpy( tile->gui.identity_key_path, config->paths.identity_key, sizeof(tile->gui.identity_key_path) );
+      strncpy( tile->gui.vote_key_path, config->paths.vote_account, sizeof(tile->gui.vote_key_path) );
       tile->gui.max_http_connections      = config->tiles.gui.max_http_connections;
       tile->gui.max_websocket_connections = config->tiles.gui.max_websocket_connections;
       tile->gui.max_http_request_length   = config->tiles.gui.max_http_request_length;

--- a/src/disco/gui/fd_gui.h
+++ b/src/disco/gui/fd_gui.h
@@ -282,6 +282,9 @@ struct fd_gui {
 
   struct {
     fd_pubkey_t identity_key[ 1 ];
+    int         has_vote_key;
+    fd_pubkey_t vote_key[ 1 ];
+    char vote_key_base58[ FD_BASE58_ENCODED_32_SZ ];
     char identity_key_base58[ FD_BASE58_ENCODED_32_SZ ];
 
     char const * version;
@@ -421,6 +424,8 @@ fd_gui_new( void *             shmem,
             char const *       version,
             char const *       cluster,
             uchar const *      identity_key,
+            int                has_vote_key,
+            uchar const *      vote_key,
             int                is_voting,
             int                schedule_strategy,
             fd_topo_t *        topo );

--- a/src/disco/gui/fd_gui_printf.c
+++ b/src/disco/gui/fd_gui_printf.c
@@ -214,6 +214,14 @@ fd_gui_printf_identity_key( fd_gui_t * gui ) {
 }
 
 void
+fd_gui_printf_vote_key( fd_gui_t * gui ) {
+  jsonp_open_envelope( gui, "summary", "vote_key" );
+    if( FD_LIKELY( gui->summary.has_vote_key ) ) jsonp_string( gui, "value", gui->summary.vote_key_base58 );
+    else                                         jsonp_null( gui, "value" );
+  jsonp_close_envelope( gui );
+}
+
+void
 fd_gui_printf_startup_time_nanos( fd_gui_t * gui ) {
   jsonp_open_envelope( gui, "summary", "startup_time_nanos" );
     jsonp_long_as_str( gui, "value", gui->summary.startup_time_nanos );

--- a/src/disco/gui/fd_gui_printf.h
+++ b/src/disco/gui/fd_gui_printf.h
@@ -11,6 +11,7 @@ void fd_gui_printf_version( fd_gui_t * gui );
 void fd_gui_printf_cluster( fd_gui_t * gui );
 void fd_gui_printf_commit_hash( fd_gui_t * gui );
 void fd_gui_printf_identity_key( fd_gui_t * gui );
+void fd_gui_printf_vote_key( fd_gui_t * gui );
 void fd_gui_printf_startup_time_nanos( fd_gui_t * gui );
 void fd_gui_printf_vote_state( fd_gui_t * gui );
 void fd_gui_printf_vote_distance( fd_gui_t * gui );

--- a/src/disco/gui/fd_gui_tile.c
+++ b/src/disco/gui/fd_gui_tile.c
@@ -95,6 +95,9 @@ typedef struct {
   fd_keyswitch_t * keyswitch;
   uchar const *    identity_key;
 
+  int              has_vote_key;
+  uchar const *    vote_key;
+
   ulong           in_kind[ 64UL ];
   ulong           in_bank_idx[ 64UL ];
   fd_gui_in_ctx_t in[ 64UL ];
@@ -380,6 +383,13 @@ privileged_init( fd_topo_t *      topo,
     FD_LOG_ERR(( "identity_key_path not set" ));
 
   ctx->identity_key = fd_keyload_load( tile->gui.identity_key_path, /* pubkey only: */ 1 );
+
+  if( FD_UNLIKELY( !strcmp( tile->gui.vote_key_path, "" ) ) ) {
+    ctx->has_vote_key = 0;
+  } else {
+    ctx->has_vote_key = 1;
+    ctx->vote_key = fd_keyload_load( tile->gui.vote_key_path, /* pubkey only: */ 1 );
+  }
 }
 
 #if FD_HAS_ZSTD
@@ -491,7 +501,7 @@ unprivileged_init( fd_topo_t *      topo,
   FD_TEST( fd_cstr_printf_check( ctx->version_string, sizeof( ctx->version_string ), NULL, "%s", fdctl_version_string ) );
 
   ctx->topo = topo;
-  ctx->gui  = fd_gui_join( fd_gui_new( _gui, ctx->gui_server, ctx->version_string, tile->gui.cluster, ctx->identity_key, tile->gui.is_voting, tile->gui.schedule_strategy, ctx->topo ) );
+  ctx->gui  = fd_gui_join( fd_gui_new( _gui, ctx->gui_server, ctx->version_string, tile->gui.cluster, ctx->identity_key, ctx->has_vote_key, ctx->vote_key, tile->gui.is_voting, tile->gui.schedule_strategy, ctx->topo ) );
   FD_TEST( ctx->gui );
 
   ctx->keyswitch = fd_keyswitch_join( fd_topo_obj_laddr( topo, tile->keyswitch_obj_id ) );

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -276,6 +276,7 @@ struct fd_topo_tile {
 
       char   cluster[ 32 ];
       char   identity_key_path[ PATH_MAX ];
+      char   vote_key_path[ PATH_MAX ];
 
       ulong  max_http_connections;
       ulong  max_websocket_connections;


### PR DESCRIPTION
right now the gui gets the validator vote account using on-chain data. Though rare, there might be more than one on-chain vote account associated with a given identity pubkey. the right way to do this is to pass the vote pubkey from the config directly into the gui tile