### PR TITLE
Allow the fd_log timesource to be runtime configured

### DIFF
--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -1075,6 +1075,22 @@ fd_type_pun_const( void const * p ) {
 
 #endif
 
+/* An ideal fd_clock_func_t is a function such that:
+
+     long dx = clock( args );
+     ... stuff ...
+     dx = clock( args ) - dx;
+
+   yields a strictly positive dx where dx approximates the amount of
+   wallclock time elapsed on the caller in some clock specific unit
+   (e.g. nanoseconds, CPU ticks, etc) for a reasonable amount of "stuff"
+   (including no "stuff").  args allows arbitrary clock specific context
+   to be passed to the clock implication.  (clocks that need a non-const
+   args can cast away the const in the implementation or cast the
+   function pointer as necessary.) */
+
+typedef long (*fd_clock_func_t)( void const * args );
+
 FD_PROTOTYPES_BEGIN
 
 /* fd_memcpy(d,s,sz):  On modern x86 in some circumstances, rep mov will

--- a/src/util/log/fd_log.h
+++ b/src/util/log/fd_log.h
@@ -502,14 +502,29 @@ extern ulong const fd_log_build_info_sz; /* == strlen( fd_log_build_info ) + 1UL
 
 /* Logging helper APIs ************************************************/
 
-/* fd_log_wallclock() reads the host's wallclock as ns since the UNIX
-   epoch GMT.  On x86, this uses clock_gettime/CLOCK_REALTIME under the
-   hood and is reasonably cheap (~25-50 ns nowadays).  But it still may
-   involve system calls under the hood and is much slower than, say,
-   RTSDC. */
+/* fd_log_wallclock_host( NULL ) reads the host's wallclock as ns since
+   the UNIX epoch GMT.  On x86, this uses clock_gettime/CLOCK_REALTIME
+   under the hood and is reasonably cheap (~25-50 ns nowadays).  But it
+   still may involve system calls under the hood and is much slower
+   than, say, RTSDC. */
 
-long fd_log_wallclock( void );
-long _fd_log_wallclock( void const * _ ); /* fd_clock_func_t compat */
+long fd_log_wallclock_host( void const * _ ); /* fd_clock_func_t compat */
+
+/* fd_log_wallclock reads the log's timesource to get the ns since the
+   UNIX epoch GMT.  By default, this is fd_log_wallclock_host but the
+   thread group can be configures this to use an alternative time source
+   if desired. */
+
+long fd_log_wallclock( void ); /* FIXME: Make fd_clock_func_t compat */
+
+/* fd_log_wallclock_set configures the log to use "clock( args )" as its
+   time source.  This time source should report ns since the UNIX epoch
+   GMT.  There should be no concurrent users of the log when this is
+   called. */
+
+void
+fd_log_wallclock_set( fd_clock_func_t clock,
+                      void const *    args );
 
 /* fd_log_wallclock_cstr( t, buf ) pretty prints the wallclock
    measurement t as:

--- a/src/util/log/test_log.c
+++ b/src/util/log/test_log.c
@@ -59,6 +59,8 @@ main( int     argc,
   FD_TEST( !fd_log_build_info[ fd_log_build_info_sz-1UL ]        );
   FD_TEST( (strlen(fd_log_build_info)+1UL)==fd_log_build_info_sz );
 
+  fd_log_wallclock_set( fd_log_wallclock_host, NULL );
+
   if( FD_LIKELY( fd_log_build_info_sz>1UL ) ) FD_LOG_NOTICE(( "fd_log_build_info:\n%s", fd_log_build_info ));
   else                                        FD_LOG_NOTICE(( "fd_log_build_info not available" ));
 


### PR DESCRIPTION
By popular demand.  Requires no changes to existing code (including Rust code that calls fd_log_wallclock).

This involved moving fd_clock_func_t definition to to fd_util_base.h, exposing the host system clock explicitly as fd_clock_func_t (fd_log_wallclock_host), having fd_log_wallclock call a fd_clock_func_t that by default is the fd_log_wallclock_host, and adding an API to allow the change which fd_clock_func_t fd_log_wallclock will call in a process.

Updated the test_clock and test_log accordingly.

In the process, cleaned up a bunch of comments in fd_clock and made some minor tweaks to advanced fd_clock APIs names to better match conventions in other FD APIs.