### PR TITLE
fuzz, precompiles: missing feature flag check for secp256r1 precompile

### DIFF
--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -148,7 +148,7 @@ fd_executor_lookup_native_program( fd_txn_account_t const * prog_acc,
     }
   }
 
-  fd_pubkey_t const *         lookup_pubkey = is_native_program ? pubkey : owner;
+  fd_pubkey_t const * lookup_pubkey = is_native_program ? pubkey : owner;
 
   /* Migrated programs must be executed via the corresponding BPF
      loader(s), not natively. This check is performed at the transaction

--- a/src/flamenco/runtime/program/fd_precompiles.c
+++ b/src/flamenco/runtime/program/fd_precompiles.c
@@ -333,6 +333,9 @@ fd_precompile_secp256k1_verify( fd_exec_instr_ctx_t * ctx ) {
 #ifdef FD_HAS_S2NBIGNUM
 int
 fd_precompile_secp256r1_verify( fd_exec_instr_ctx_t * ctx ) {
+  if( FD_UNLIKELY( !FD_FEATURE_ACTIVE_BANK( ctx->txn_ctx->bank, enable_secp256r1_precompile ) ) ) {
+    return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
+  }
 
   uchar const * data    = ctx->instr->data;
   ulong         data_sz = ctx->instr->data_sz;


### PR DESCRIPTION
Already activated on all clusters but this is just to please the fuzzers for now