### PR TITLE
topo: repair tile uses root_slot_obj

### DIFF
--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -595,6 +595,7 @@ fd_topo_initialize( config_t * config ) {
 
   fd_topo_obj_t * root_slot_obj = fd_topob_obj( topo, "fseq", "slot_fseqs" );
   fd_topob_tile_uses( topo, replay_tile, root_slot_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+  fd_topob_tile_uses( topo, repair_tile, root_slot_obj, FD_SHMEM_JOIN_MODE_READ_ONLY );
   FD_TEST( fd_pod_insertf_ulong( topo->props, root_slot_obj->id, "root_slot" ) );
 
   /* turbine_slot0 is an fseq marking the slot number of the first shred


### PR DESCRIPTION
currently works because repair uses another object from the slot_fseqs workspace with >= mode, but for consistency and maintainability we should declare this explicitly