### PR TITLE
Disable spammy logs

### DIFF
--- a/src/discof/replay/fd_exec.c
+++ b/src/discof/replay/fd_exec.c
@@ -31,7 +31,7 @@ fd_slice_exec_txn_parse( fd_slice_exec_t * slice_exec_ctx,
 void
 fd_slice_exec_microblock_parse( fd_slice_exec_t * slice_exec_ctx ) {
   fd_microblock_hdr_t * hdr = (fd_microblock_hdr_t *)fd_type_pun( slice_exec_ctx->buf + slice_exec_ctx->wmark );
-  FD_LOG_DEBUG(( "[%s] reading microblock with %lu txns", __func__, hdr->txn_cnt ));
+  //FD_LOG_DEBUG(( "[%s] reading microblock with %lu txns", __func__, hdr->txn_cnt ));
   slice_exec_ctx->txns_rem      = hdr->txn_cnt;
   slice_exec_ctx->last_mblk_off = slice_exec_ctx->wmark;
   slice_exec_ctx->wmark        += sizeof(fd_microblock_hdr_t);

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -1060,7 +1060,7 @@ handle_writer_state_updates( fd_replay_tile_ctx_t * ctx ) {
         uint  txn_id       = fd_writer_fseq_get_txn_id( res );
         ulong exec_tile_id = fd_writer_fseq_get_exec_tile_id( res );
         if( ctx->exec_ready[ exec_tile_id ]==EXEC_TXN_BUSY && ctx->prev_ids[ exec_tile_id ]!=txn_id ) {
-          FD_LOG_DEBUG(( "Ack that exec tile idx=%lu txn id=%u has been finalized by writer tile %lu", exec_tile_id, txn_id, i ));
+          //FD_LOG_DEBUG(( "Ack that exec tile idx=%lu txn id=%u has been finalized by writer tile %lu", exec_tile_id, txn_id, i ));
           ctx->exec_ready[ exec_tile_id ] = EXEC_TXN_READY;
           ctx->prev_ids[ exec_tile_id ]   = txn_id;
           fd_fseq_update( ctx->writer_fseq[ i ], FD_WRITER_STATE_READY );

--- a/src/flamenco/runtime/fd_blockstore.c
+++ b/src/flamenco/runtime/fd_blockstore.c
@@ -606,12 +606,12 @@ fd_blockstore_shred_insert( fd_blockstore_t * blockstore, fd_shred_t const * shr
 
   ulong parent_slot       = block_info->parent_slot;
 
-  FD_LOG_DEBUG(( "shred: (%lu, %u). consumed: %u, received: %u, complete: %u",
-               slot,
-               shred->idx,
-               block_info->buffered_idx,
-               block_info->received_idx,
-               block_info->slot_complete_idx ));
+  // FD_LOG_DEBUG(( "shred: (%lu, %u). consumed: %u, received: %u, complete: %u",
+  //              slot,
+  //              shred->idx,
+  //              block_info->buffered_idx,
+  //              block_info->received_idx,
+  //              block_info->slot_complete_idx ));
   fd_block_map_publish( query );
 
   /* Update ancestry metadata: parent_slot, is_connected, next_slot.


### PR DESCRIPTION
These print millions of lines to debug, which has a prod performance impact