### PR TITLE
banks: rekeying root banks instead of cloning on manifest load

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -1701,6 +1701,7 @@ unprivileged_init( fd_topo_t *      topo,
   if( FD_UNLIKELY( !ctx->banks ) ) {
     FD_LOG_ERR(( "failed to join banks" ));
   }
+
   fd_bank_t * bank = fd_banks_init_bank( ctx->banks, 0UL );
   if( FD_UNLIKELY( !bank ) ) {
     FD_LOG_ERR(( "failed to init bank" ));

--- a/src/flamenco/runtime/context/fd_exec_slot_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_slot_ctx.c
@@ -169,7 +169,7 @@ fd_exec_slot_ctx_recover( fd_exec_slot_ctx_t *                slot_ctx,
                           fd_solana_manifest_global_t const * manifest,
                           fd_spad_t *                         runtime_spad ) {
 
-  slot_ctx->bank = fd_banks_clone_from_parent( slot_ctx->banks, manifest->bank.slot, 0UL );
+  slot_ctx->bank = fd_banks_rekey_root_bank( slot_ctx->banks, manifest->bank.slot );
   if( FD_UNLIKELY( !slot_ctx->bank ) ) {
     FD_LOG_CRIT(( "fd_banks_clone_from_parent failed" ));
   }

--- a/src/flamenco/runtime/fd_bank.c
+++ b/src/flamenco/runtime/fd_bank.c
@@ -720,3 +720,40 @@ fd_banks_clear_bank( fd_banks_t * banks, fd_bank_t * bank ) {
   #undef HAS_COW_0
   #undef HAS_COW_1
 }
+
+fd_bank_t *
+fd_banks_rekey_root_bank( fd_banks_t * banks, ulong slot ) {
+
+  if( FD_UNLIKELY( !banks ) ) {
+    FD_LOG_WARNING(( "Banks is NULL" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( banks->root_idx==fd_banks_pool_idx_null( fd_banks_get_bank_pool( banks ) ) ) ) {
+    FD_LOG_WARNING(( "Root bank does not exist" ));
+    return NULL;
+  }
+
+  fd_bank_t * bank = fd_banks_pool_ele( fd_banks_get_bank_pool( banks ), banks->root_idx );
+  if( FD_UNLIKELY( !bank ) ) {
+    FD_LOG_WARNING(( "Failed to get root bank" ));
+    return NULL;
+  }
+
+  /* Once we validated that there is a valid root bank, we can remove
+     the bank from the map and insert it with the new key. */
+  bank = fd_banks_map_ele_remove( fd_banks_get_bank_map( banks ), &bank->slot_, NULL, fd_banks_get_bank_pool( banks ) );
+  if( FD_UNLIKELY( !bank ) ) {
+    FD_LOG_WARNING(( "Failed to remove root bank" ));
+    return NULL;
+  }
+
+  bank->slot_ = slot;
+
+  if( FD_UNLIKELY( !fd_banks_map_ele_insert( fd_banks_get_bank_map( banks ), bank, fd_banks_get_bank_pool( banks ) ) ) ) {
+    FD_LOG_WARNING(( "Failed to insert root bank" ));
+    return NULL;
+  }
+
+  return bank;
+}

--- a/src/flamenco/runtime/fd_bank.h
+++ b/src/flamenco/runtime/fd_bank.h
@@ -622,6 +622,19 @@ fd_banks_publish( fd_banks_t * banks, ulong slot );
 void
 fd_banks_clear_bank( fd_banks_t * banks, fd_bank_t * bank );
 
+/* fd_banks_rekey_root_bank() will change the key of the current root
+   bank to a caller-specified slot. This function returns the root bank
+   with the new key.
+
+   This should NOT be called once the root bank has child banks.
+
+   This is useful for snapshot loading where there are an unknown amount
+   of banks to load and the latest snapshot is the root slot. This
+   effectively lowers the memory used by snapshot loading. */
+
+fd_bank_t *
+fd_banks_rekey_root_bank( fd_banks_t * banks, ulong slot );
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_flamenco_runtime_fd_bank_h */

--- a/src/flamenco/runtime/test_bank.c
+++ b/src/flamenco/runtime/test_bank.c
@@ -24,10 +24,29 @@ main( int argc, char ** argv ) {
   fd_banks_t * banks = fd_banks_join( mem );
   FD_TEST( banks );
 
-  fd_bank_t * bank = fd_banks_init_bank( banks, 1UL );
+  /* Rekeying the root bank should fail because there is no root bank */
+
+  FD_TEST( !fd_banks_rekey_root_bank( banks, 1UL ) );
+
+  fd_bank_t * bank = fd_banks_init_bank( banks, 999UL );
   FD_TEST( bank );
 
+  /* Rekey the root bank to the same slot */
+
+  fd_bank_t * rekeyed_root = fd_banks_rekey_root_bank( banks, 999UL );
+  FD_TEST( rekeyed_root );
+  FD_TEST( fd_bank_slot_get( rekeyed_root ) == 999UL );
+  FD_TEST( rekeyed_root == bank );
+
+  /* Rekey the root bank to a different slot*/
+
+  rekeyed_root = fd_banks_rekey_root_bank( banks, 1UL );
+  FD_TEST( rekeyed_root );
+  FD_TEST( fd_bank_slot_get( rekeyed_root ) == 1UL );
+  FD_TEST( rekeyed_root == bank );
+
   /* Set some fields */
+
   fd_bank_capitalization_set( bank, 1000UL );
   FD_TEST( fd_bank_capitalization_get( bank ) == 1000UL );
 
@@ -78,6 +97,7 @@ main( int argc, char ** argv ) {
   FD_TEST( fd_bank_capitalization_get( bank9 ) == 2100UL );
 
   /* Set some CoW fields. */
+
   fd_account_keys_global_t * keys = fd_bank_vote_account_keys_locking_modify( bank9 );
   keys->account_keys_pool_offset = 100UL;
   keys->account_keys_root_offset = 100UL;
@@ -93,9 +113,26 @@ main( int argc, char ** argv ) {
   fd_bank_t const * new_root = fd_banks_publish( banks, 7UL );
   FD_TEST( new_root );
   FD_TEST( fd_bank_slot_get( new_root )==7UL );
-  FD_TEST( new_root == bank7);
+  FD_TEST( new_root == bank7 );
 
-  fd_bank_t * bank10 = fd_banks_clone_from_parent( banks, 10UL, 7UL );
+  /* Rekey the new root to a different slot and make sure that
+     bank7 is still the root and that its children are still valid */
+
+  rekeyed_root = fd_banks_rekey_root_bank( banks, 1234UL );
+  FD_TEST( rekeyed_root );
+  FD_TEST( fd_bank_slot_get( rekeyed_root ) == 1234UL );
+  FD_TEST( rekeyed_root == bank7 );
+
+  FD_TEST( rekeyed_root == fd_banks_root( banks ) );
+
+  fd_bank_t const * parent = fd_banks_pool_ele_const( fd_banks_get_bank_pool( banks ), bank8->parent_idx );
+  FD_TEST( parent );
+  FD_TEST( fd_bank_slot_get( parent ) == 1234UL );
+  FD_TEST( parent == rekeyed_root );
+
+  /* Create some new children*/
+
+  fd_bank_t * bank10 = fd_banks_clone_from_parent( banks, 10UL, 1234UL );
   FD_TEST( bank10 );
   FD_TEST( fd_bank_capitalization_get( bank10 ) == 2100UL );
 
@@ -128,9 +165,9 @@ main( int argc, char ** argv ) {
   fd_bank_clock_timestamp_votes_end_locking_modify( bank11 );
 
   /* Now there should be 3 forks:
-     1. 7 -> 8
-     2. 7 -> 9 -> 11
-     3  7 -> 10 */
+     1. 7 (1234) -> 8
+     2. 7 (1234) -> 9 -> 11
+     3  7 (1234) -> 10 */
 
   /* Verify that direct and competing forks are pruned off */
   FD_TEST( !fd_banks_get_bank( banks, 6UL ) );
@@ -139,11 +176,13 @@ main( int argc, char ** argv ) {
   /* At this point, bank7 is the root and it has 3 children: bank8, bank9, and bank10 */
 
   /* Verify that children slots are not pruned off */
+
   FD_TEST( !!fd_banks_get_bank( banks, 8UL ) );
   FD_TEST( !!fd_banks_get_bank( banks, 9UL ) );
   FD_TEST( !!fd_banks_get_bank( banks, 10UL ) );
 
   /* Verify that the CoW fields are properly set for bank11 */
+
   keys3 = fd_bank_vote_account_keys_locking_query( bank11 );
   FD_TEST( keys3->account_keys_pool_offset == 200UL );
   FD_TEST( keys3->account_keys_root_offset == 200UL );
@@ -167,6 +206,7 @@ main( int argc, char ** argv ) {
      2. Pool was not made dirty and had a null parent pool idx.
      3. Pool was made dirty and had a non-null parent pool idx.
      4. Pool was made dirty and had a null parent pool idx. */
+
   fd_banks_clear_bank( banks, bank11 );
   FD_TEST( fd_bank_slot_get( bank11 ) == 11UL );
   FD_TEST( fd_bank_capitalization_get( bank11 ) == 0UL );


### PR DESCRIPTION
1. adding fd_banks_rekey_root() impl and tests
2. updating snapshot load to use rekey_root() instead of clone_from_parent()