### PR TITLE
ci: make jobs cleanup after themselves

### DIFF
--- a/.github/actions/hugepages/action.yml
+++ b/.github/actions/hugepages/action.yml
@@ -9,19 +9,42 @@ inputs:
     description: 'Number of gigantic pages'
     required: true
     default: '64'
+  shmem_path:
+    description: 'Base path for shmem mount'
+    required: false
+    default: '/mnt/.fd'
+  action:
+    description: 'Operation to perform'
+    required: true
+    choice:
+    - allocate
+    - cleanup
+
 outputs: {}
 runs:
   using: composite
   steps:
+
     - shell: bash
+      env:
+        FD_SHMEM_PATH: "${{ inputs.shmem_path }}"
       run: |
         set -x
-        sudo src/util/shmem/fd_shmem_cfg fini || true
-        findmnt -t hugetlbfs -n -o TARGET | xargs -r sudo umount || true
         sudo src/util/shmem/fd_shmem_cfg reset || true
+        sudo src/util/shmem/fd_shmem_cfg fini  || true
+
+    - if: "${{ inputs.action == 'allocate' }}"
+      shell: bash
+      env:
+        FD_SHMEM_PATH: "${{ inputs.shmem_path }}"
+      run: |
+        set -x
+        HUGE_PAGES=$(cat /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages)
+        GIGA_PAGES=$(cat /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages)
         sudo src/util/shmem/fd_shmem_cfg init 0775 $USER "" || true
-        [ $(cat /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages) -lt '${{ inputs.count_gigantic }}' ] && \
-          sudo src/util/shmem/fd_shmem_cfg alloc '${{ inputs.count_gigantic }}' gigantic 0
-        [ $(cat /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages) -lt '${{ inputs.count_huge }}' ] && \
+        if [[ $HUGE_PAGES -lt '${{ inputs.count_huge }}' ]]; then
           sudo src/util/shmem/fd_shmem_cfg alloc '${{ inputs.count_huge }}' huge 0
-        sudo chown -R $USER:$USER /mnt/.fd
+        fi
+        if [[ $GIGA_PAGES -lt '${{ inputs.count_gigantic }}' ]]; then
+          sudo src/util/shmem/fd_shmem_cfg alloc '${{ inputs.count_gigantic }}' gigantic 0
+        fi

--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -2,12 +2,9 @@ name: Replay Ledgers
 on:
   workflow_call:
     inputs:
-      coverage:
-        type: boolean
-        default: false
       machine:
         type: string
-        default: linux_gcc_zen2
+        default: "linux_gcc_zen2"
       extras:
         type: string
         default: "handholding"
@@ -28,11 +25,13 @@ jobs:
       - uses: ./.github/actions/deps
         with:
           extras: +dev
+
       - uses: ./.github/actions/hugepages
         with:
           # DO NOT CHANGE THESE VALUES - increasing the hugetlbfs reservations on the CI runners too high causes other jobs to be OOM-killed
           count_gigantic: 398
           count_huge: 535
+
       - uses: ./.github/actions/cpusonline
 
       - name: build
@@ -53,3 +52,9 @@ jobs:
         if: always()
         run: |
           sudo $OBJDIR/bin/firedancer-dev configure fini all --config ../dump/mainnet-308392063-v2.3.0_backtest.toml || true
+
+      - name: cleanup shmem pages
+        if: always()
+        uses: ./.github/actions/hugepages
+        with:
+          action: cleanup

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -22,11 +22,14 @@ jobs:
       - uses: ./.github/actions/deps
         with:
           extras: +dev
+
       - uses: ./.github/actions/cpusonline
+
       - uses: ./.github/actions/hugepages
         with:
           count_gigantic: 60
           count_huge: 100 # TODO: this is required until we can handle anonymous workspaces and loose huge pages in fddev
+          action: allocate
 
       - uses: dtolnay/rust-toolchain@1.73.0
 
@@ -61,3 +64,9 @@ jobs:
           functionalities: search
           flags: ci
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: cleanup shmem pages
+        if: always()
+        uses: ./.github/actions/hugepages
+        with:
+          action: cleanup

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -15,12 +15,3 @@ jobs:
     if: github.event.pull_request.draft == false
     uses: ./.github/workflows/backtest.yml
     secrets: inherit
-
-  # firedancer:
-  #   if: github.event.pull_request.draft == false
-  #   uses: ./.github/workflows/test_firedancer_localnet.yml
-  #   secrets: inherit
-  # firedancer-shredcap:
-  #   if: github.event.pull_request.draft == false
-  #   uses: ./.github/workflows/test_firedancer_testnet_shredcap.yml
-  #   secrets: inherit

--- a/.github/workflows/test_firedancer_localnet.yml
+++ b/.github/workflows/test_firedancer_localnet.yml
@@ -22,11 +22,14 @@ jobs:
       - uses: ./.github/actions/deps
         with:
           extras: +dev
+
       - uses: ./.github/actions/cpusonline
+
       - uses: ./.github/actions/hugepages
         with:
           count_gigantic: 200
           count_huge: 1000 # TODO: this is required until we can handle anonymous workspaces and loose huge pages in fddev
+          action: allocate
 
       - name: build
         run: |

--- a/.github/workflows/test_firedancer_testnet.yml
+++ b/.github/workflows/test_firedancer_testnet.yml
@@ -18,11 +18,14 @@ jobs:
       - uses: ./.github/actions/deps
         with:
           extras: +dev
+
       - uses: ./.github/actions/cpusonline
+
       - uses: ./.github/actions/hugepages
         with:
           count_gigantic: 128
           count_huge: 1000 # TODO: this is required until we can handle anonymous workspaces and loose huge pages in fddev
+          action: allocate
 
       - name: build
         run: |

--- a/.github/workflows/test_firedancer_testnet_shredcap.yml
+++ b/.github/workflows/test_firedancer_testnet_shredcap.yml
@@ -22,11 +22,14 @@ jobs:
       - uses: ./.github/actions/deps
         with:
           extras: +dev
+
       - uses: ./.github/actions/cpusonline
+
       - uses: ./.github/actions/hugepages
         with:
           count_gigantic: 250
           count_huge: 1000 # TODO: this is required until we can handle anonymous workspaces and loose huge pages in fddev
+          action: allocate
 
       - name: build
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,6 +106,8 @@ jobs:
         if: ${{ !contains(matrix.extras, 'no-deps') }}
 
       - uses: ./.github/actions/hugepages
+        with:
+          action: allocate
         if: ${{ matrix.targets != 'check' }}
 
       - uses: ./.github/actions/cpusonline
@@ -163,3 +165,9 @@ jobs:
           sudo prlimit --pid $$ --memlock=-1:-1
           source /opt/${{ matrix.compiler }}/${{ matrix.compiler }}-${{ matrix.compiler-version }}/activate
           make run-integration-test
+
+      - name: cleanup shmem pages
+        if: always()
+        uses: ./.github/actions/hugepages
+        with:
+          action: cleanup


### PR DESCRIPTION
This splits up the hugepage action so that jobs can cleanup after themselves. This also adds the ability to use different shmem paths if that ever becomes necessary. There is no change in the `allocate` behaviour as it still cleans up as before.