### PR TITLE
backtest: remove genesis init stage

### DIFF
--- a/src/app/firedancer-dev/commands/backtest.c
+++ b/src/app/firedancer-dev/commands/backtest.c
@@ -347,7 +347,6 @@ backtest_cmd_fn( args_t *   args FD_PARAM_UNUSED,
   configure_args.configure.stages[ stage_idx++ ] = &fd_cfg_stage_ethtool_channels;
   configure_args.configure.stages[ stage_idx++ ] = &fd_cfg_stage_ethtool_gro;
   configure_args.configure.stages[ stage_idx++ ] = &fd_cfg_stage_ethtool_loopback;
-  configure_args.configure.stages[ stage_idx++ ] = &fd_cfg_stage_genesis;
   configure_args.configure.stages[ stage_idx++ ] = &fd_cfg_stage_snapshots;
   configure_cmd_fn( &configure_args, config );
 


### PR DESCRIPTION
The genesis stage fails if we don't have the keys directory created on the box. We don't need genesis for backtest so we should just remove this.