### PR TITLE
use ppoll for getaddrinfo

### DIFF
--- a/src/waltz/resolv/fd_res_msend.c
+++ b/src/waltz/resolv/fd_res_msend.c
@@ -13,6 +13,7 @@
 #include <pthread.h>
 #include "syscall.h"
 #include "fd_lookup.h"
+#include "../../util/fd_util.h"
 
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wsign-compare"
@@ -199,7 +200,7 @@ fd_res_msend_rc( int                     nqueries,
     }
 
     /* Wait for a response, or until time to retry */
-    if( poll( pfd, nqueries+1, t1+retry_interval-t2 ) <= 0 ) continue;
+    if( fd_syscall_poll( pfd, nqueries+1, t1+retry_interval-t2 ) <= 0 ) continue;
 
     while( next < nqueries ) {
       struct msghdr mh = {


### PR DESCRIPTION
The bundle tile uses `fd_getaddrinfo` which in turn (eventually) calls `poll` which is why `fdctl` was crashing without the `poll` in the bundle tile seccomppolicy (only when bundles are enabled). We either do this (does not look like anything other than bundle tile uses this call path) or we add `poll` back into the bundle tile seccomppolicy.