### PR TITLE
firedancer-dev: repair profiler light - update

### DIFF
--- a/src/flamenco/types/fd_types_custom.h
+++ b/src/flamenco/types/fd_types_custom.h
@@ -222,6 +222,11 @@ struct fd_vote_stake_weight {
 };
 typedef struct fd_vote_stake_weight fd_vote_stake_weight_t;
 
+#define SORT_NAME sort_vote_weights_by_stake_vote
+#define SORT_KEY_T fd_vote_stake_weight_t
+#define SORT_BEFORE(a,b) ((a).stake > (b).stake ? 1 : ((a).stake < (b).stake ? 0 : memcmp( (a).vote_key.uc, (b).vote_key.uc, 32UL )>0))
+#include "../../util/tmpl/fd_sort.c"
+
 struct fd_stake_weight {
   fd_pubkey_t key;      /* validator identity pubkey */
   ulong       stake;    /* total stake by identity */


### PR DESCRIPTION
Upgrading the repair profiler light tool.
It now uses *fd_ssmanifest_parser_t* and *fd_snapshot_manifest_t* to retrieve the required data from the manifest. 
This PR is dependent on  https://github.com/firedancer-io/firedancer/pull/5892 (which should be merged first).