### PR TITLE
store: fix under allocation due to rounding-up after footprint calcul…

### DIFF
--- a/src/disco/store/fd_store.c
+++ b/src/disco/store/fd_store.c
@@ -25,11 +25,8 @@ fd_store_new( void * shmem, ulong fec_max, ulong part_cnt ) {
     return NULL;
   }
 
+  fec_max = fd_ulong_pow2_up( fec_max ); /* required by map_chain */
   ulong footprint = fd_store_footprint( fec_max );
-  if( FD_UNLIKELY( !footprint ) ) {
-    FD_LOG_WARNING(( "bad fec_max (%lu)", fec_max ));
-    return NULL;
-  }
 
   fd_wksp_t * wksp = fd_wksp_containing( shmem );
   if( FD_UNLIKELY( !wksp ) ) {
@@ -38,7 +35,6 @@ fd_store_new( void * shmem, ulong fec_max, ulong part_cnt ) {
   }
 
   fd_memset( shmem, 0, footprint );
-  fec_max = fd_ulong_pow2_up( fec_max ); /* required by map_chain */
 
   /* This seed value is very important. We have fec_max chains in the
      map, which means the size of each partition of buckets should be

--- a/src/disco/store/fd_store.h
+++ b/src/disco/store/fd_store.h
@@ -242,6 +242,10 @@ fd_store_align( void ) {
 
 FD_FN_CONST static inline ulong
 fd_store_footprint( ulong fec_max ) {
+  /* Despite fd_store_new already calling us with fec_max pow2 up,
+     we still need to do it for the footprint calculation in the
+     topology. */
+  fec_max = fd_ulong_pow2_up( fec_max );
   return FD_LAYOUT_FINI(
     FD_LAYOUT_APPEND(
     FD_LAYOUT_APPEND(


### PR DESCRIPTION
…ation

otherwise for a non power of two fec_max, store_map will be zero, because it is used unchecked in fd_store_footprint. Also shele will be under-allocated.