### PR TITLE
snapshots: send highest manifest slot

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -792,7 +792,9 @@ on_snapshot_message( fd_replay_tile_ctx_t * ctx,
                      fd_stem_context_t *    stem,
                      ulong                  in_idx,
                      ulong                  chunk,
-                     ulong                  sig ) {
+                     ulong                  sig,
+                     ulong                  tsorig FD_PARAM_UNUSED,
+                     ulong                  tspub  FD_PARAM_UNUSED) {
   ulong msg = fd_ssmsg_sig_message( sig );
   if( FD_LIKELY( msg==FD_SSMSG_DONE ) ) {
     /* An end of message notification indicates the snapshot is loaded.
@@ -801,19 +803,6 @@ on_snapshot_message( fd_replay_tile_ctx_t * ctx,
        state machine and set the state here accordingly. */
     FD_LOG_INFO(("Snapshot loaded, replay can start executing"));
     ctx->snapshot_init_done = 1;
-    /* Kickoff repair orphans after the snapshots are done loading. If
-       we kickoff repair after we receive a full manifest, we might try
-       to repair a slot that is potentially huge amount of slots behind
-       turbine causing our repair buffers to fill up. Instead, we should
-       wait until we are done receiving all the snapshots.
-
-       TODO: Eventually, this logic should be cased out more:
-       1. If we just have a full snapshot, load in the slot_ctx for the
-          slot ctx and kickoff repair as soon as the manifest is
-          received.
-       2. If we are loading a full and incremental snapshot, we should
-          only load in the slot_ctx and kickoff repair for the
-          incremental snapshot. */
     kickoff_repair_orphans( ctx, stem );
     init_from_snapshot( ctx, stem );
     ulong curr_slot = fd_bank_slot_get( ctx->slot_ctx->bank );
@@ -824,6 +813,16 @@ on_snapshot_message( fd_replay_tile_ctx_t * ctx,
   }
 
   switch( msg ) {
+    case FD_SSMSG_HIGHEST_MANIFEST_SLOT: {
+      /* snapin sends the highest manifest slot so far to notify any
+         listeners of the highest rooted slot that will be loaded
+         by the snapshot tiles.  The highest manifest slot may change
+         if the snapshot tiles retry snapshot loading, but it is
+         guaranteed to be monotonically increasing. */
+      /* TODO: currently a no-op.  Repair cannot handle an receiving an
+         incrementally changing rooted slot and stake weights yet. */
+      break;
+    }
     case FD_SSMSG_MANIFEST_FULL:
     case FD_SSMSG_MANIFEST_INCREMENTAL: {
       /* We may either receive a full snapshot manifest or an
@@ -944,8 +943,8 @@ after_frag( fd_replay_tile_ctx_t *   ctx,
             ulong                    seq FD_PARAM_UNUSED,
             ulong                    sig,
             ulong                    sz FD_PARAM_UNUSED,
-            ulong                    tsorig FD_PARAM_UNUSED,
-            ulong                    tspub FD_PARAM_UNUSED,
+            ulong                    tsorig,
+            ulong                    tspub,
             fd_stem_context_t *      stem FD_PARAM_UNUSED ) {
   if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_ROOT ) ) {
     ulong root = sig;
@@ -974,7 +973,7 @@ after_frag( fd_replay_tile_ctx_t *   ctx,
 
     fd_fseq_update( ctx->published_wmark, root );
   } else if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_SNAP ) ) {
-    on_snapshot_message( ctx, stem, in_idx, ctx->_snap_out_chunk, sig );
+    on_snapshot_message( ctx, stem, in_idx, ctx->_snap_out_chunk, sig, tsorig, tspub );
   } else if( FD_LIKELY( ctx->in_kind[ in_idx ]==IN_KIND_REPAIR ) ) {
 
     /* Forks form a partial ordering over FEC sets. The Repair tile

--- a/src/discof/restore/Local.mk
+++ b/src/discof/restore/Local.mk
@@ -23,3 +23,4 @@ endif
 $(call add-objs,utils/fd_ssping,fd_discof)
 $(call add-objs,utils/fd_sshttp,fd_discof)
 $(call add-objs,utils/fd_ssarchive,fd_discof)
+$(call add-objs,utils/fd_ssresolve,fd_discof)

--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -214,7 +214,9 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
 static void
 handle_control_frag( fd_snapin_tile_t *  ctx,
                      fd_stem_context_t * stem,
-                     ulong               sig ) {
+                     ulong               sig,
+                     ulong               tsorig,
+                     ulong               tspub ) {
   switch( sig ) {
     case FD_SNAPSHOT_MSG_CTRL_RESET_FULL:
       ctx->full = 1;
@@ -257,6 +259,11 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
     case FD_SNAPSHOT_MSG_CTRL_SHUTDOWN:
       ctx->state = FD_SNAPIN_STATE_SHUTDOWN;
       break;
+    case FD_SNAPSHOT_MSG_HIGHEST_MANIFEST_SLOT:
+      /* Informational control message forwarded to snap_out */
+      fd_stem_publish( stem, 0UL, FD_SSMSG_HIGHEST_MANIFEST_SLOT, 0UL, 0UL, 0UL, tsorig, tspub );
+      /* No need to send an ack for an informational control message */
+      return;
     default:
       FD_LOG_ERR(( "unexpected control sig %lu", sig ));
       return;
@@ -288,7 +295,7 @@ returnable_frag( fd_snapin_tile_t *  ctx,
   FD_TEST( ctx->state!=FD_SNAPIN_STATE_SHUTDOWN );
 
   if( FD_UNLIKELY( sig==FD_SNAPSHOT_MSG_DATA ) ) handle_data_frag( ctx, chunk, sz, stem );
-  else                                           handle_control_frag( ctx, stem, sig  );
+  else                                           handle_control_frag( ctx, stem, sig, tsorig, tspub  );
 
   return 0;
 }

--- a/src/discof/restore/utils/fd_ssctrl.h
+++ b/src/discof/restore/utils/fd_ssctrl.h
@@ -40,13 +40,23 @@
 
 #define FD_SNAPSHOT_MSG_DATA                   (0UL) /* Fragment represents some snapshot data */
 
-#define FD_SNAPSHOT_MSG_CTRL_RESET_FULL        (1UL) /* Reset to start loading a fresh full snapshot */
-#define FD_SNAPSHOT_MSG_CTRL_EOF_FULL          (2UL) /* Full snapshot data is done, incremental data starting now */
-#define FD_SNAPSHOT_MSG_CTRL_RESET_INCREMENTAL (3UL) /* Incremental data being retried, start incremental over */
-#define FD_SNAPSHOT_MSG_CTRL_DONE              (4UL) /* Snapshot load is over, data is finished for this tile */
-#define FD_SNAPSHOT_MSG_CTRL_SHUTDOWN          (5UL) /* All tiles have acknowledged snapshot load is done, can now shutdown */
+/* The HIGHEST_MANIFEST_SLOT message is an informational control message
+   that is forwarded from the snaprd tile to the snapin tile, which
+   forwards the message to the snap_out link.  The HIGHEST_MANIFEST_SLOT
+   message contains the highest manifest slot so far.  It is typically
+   the incremental snapshot slot but can be the full snapshot slot if
+   incremental snapshots are disabled.  It is guaranteed to be
+   monotonically increasing and is forwarded regardless of any snapshot
+   loading error / retry. */
+#define FD_SNAPSHOT_MSG_HIGHEST_MANIFEST_SLOT  (1UL) /* Fragment contains the highest manifest slot so far, guaranteed to be monotonically increasing */
 
-#define FD_SNAPSHOT_MSG_CTRL_ACK               (6UL) /* Sent from tiles back to snaprd, meaning they ACK whatever control message was pending */
-#define FD_SNAPSHOT_MSG_CTRL_MALFORMED         (7UL) /* Sent from tiles back to snaprd, meaning they consider the current snapshot malformed */
+#define FD_SNAPSHOT_MSG_CTRL_RESET_FULL        (2UL) /* Reset to start loading a fresh full snapshot */
+#define FD_SNAPSHOT_MSG_CTRL_EOF_FULL          (3UL) /* Full snapshot data is done, incremental data starting now */
+#define FD_SNAPSHOT_MSG_CTRL_RESET_INCREMENTAL (4UL) /* Incremental data being retried, start incremental over */
+#define FD_SNAPSHOT_MSG_CTRL_DONE              (5UL) /* Snapshot load is over, data is finished for this tile */
+#define FD_SNAPSHOT_MSG_CTRL_SHUTDOWN          (6UL) /* All tiles have acknowledged snapshot load is done, can now shutdown */
+
+#define FD_SNAPSHOT_MSG_CTRL_ACK               (7UL) /* Sent from tiles back to snaprd, meaning they ACK whatever control message was pending */
+#define FD_SNAPSHOT_MSG_CTRL_MALFORMED         (8UL) /* Sent from tiles back to snaprd, meaning they consider the current snapshot malformed */
 
 #endif /* HEADER_fd_src_discof_restore_utils_fd_ssctrl_h */

--- a/src/discof/restore/utils/fd_sshttp.c
+++ b/src/discof/restore/utils/fd_sshttp.c
@@ -36,9 +36,6 @@ struct fd_sshttp_private {
   ulong response_len;
   char  response[ USHORT_MAX ];
 
-  char full_snapshot_name[ PATH_MAX ];
-  char incremental_snapshot_name[ PATH_MAX ];
-
   ulong content_len;
 
   ulong magic;
@@ -290,14 +287,6 @@ read_body( fd_sshttp_t * http,
   http->content_len -= (ulong)read;
 
   return FD_SSHTTP_ADVANCE_DATA;
-}
-
-void
-fd_sshttp_snapshot_names( fd_sshttp_t * http,
-                         char const **  full_snapshot_name,
-                         char const **  incremental_snapshot_name ) {
-  *full_snapshot_name        = http->full_snapshot_name;
-  *incremental_snapshot_name = http->incremental_snapshot_name;
 }
 
 int

--- a/src/discof/restore/utils/fd_sshttp.c
+++ b/src/discof/restore/utils/fd_sshttp.c
@@ -53,7 +53,7 @@ FD_FN_CONST ulong
 fd_sshttp_footprint( void ) {
   ulong l;
   l = FD_LAYOUT_INIT;
-  l = FD_LAYOUT_APPEND( l, FD_SSHTTP_ALIGN,       sizeof(fd_sshttp_t) );
+  l = FD_LAYOUT_APPEND( l, FD_SSHTTP_ALIGN, sizeof(fd_sshttp_t) );
   return FD_LAYOUT_FINI( l, FD_SSHTTP_ALIGN );
 }
 

--- a/src/discof/restore/utils/fd_sshttp.h
+++ b/src/discof/restore/utils/fd_sshttp.h
@@ -24,12 +24,6 @@ fd_sshttp_new( void * shmem );
 fd_sshttp_t *
 fd_sshttp_join( void * sshttp );
 
-/* Sets points to snapshot names */
-void
-fd_sshttp_snapshot_names( fd_sshttp_t * http,
-                         char const **  full_snapshot_name,
-                         char const **  incremental_snapshot_name );
-
 void
 fd_sshttp_init( fd_sshttp_t * http,
                 fd_ip4_port_t addr,

--- a/src/discof/restore/utils/fd_ssping.h
+++ b/src/discof/restore/utils/fd_ssping.h
@@ -17,6 +17,7 @@
 
 #include "../../../util/fd_util_base.h"
 #include "../../../util/net/fd_net_headers.h"
+#include "../../../flamenco/types/fd_types_custom.h"
 
 #define FD_SSPING_ALIGN (8UL)
 
@@ -24,6 +25,29 @@
 
 struct fd_ssping_private;
 typedef struct fd_ssping_private fd_ssping_t;
+
+/* fd_ssinfo stores the resolved snapshot information from a peer. */
+struct fd_ssinfo {
+   struct {
+      ulong slot;                      /* slot of the full snapshot */
+      uchar hash[ FD_HASH_FOOTPRINT ]; /* base58 decoded hash of the full snapshot */
+      ulong slots_behind;              /* number of slots behind the latest full cluster slot */
+    } full;
+
+    struct {
+      ulong base_slot;
+      ulong slot;
+      uchar hash[ FD_HASH_FOOTPRINT ];
+      ulong slots_behind;
+    } incremental;
+};
+typedef struct fd_ssinfo fd_ssinfo_t;
+
+struct fd_sspeer {
+  fd_ip4_port_t       addr;
+  fd_ssinfo_t const * snapshot_info;
+};
+typedef struct fd_sspeer fd_sspeer_t;
 
 FD_PROTOTYPES_BEGIN
 
@@ -83,7 +107,7 @@ fd_ssping_advance( fd_ssping_t * ssping,
 /* Retrieve the best "active" peer right now, by lowest ping.  If no
    peer is active or pingable, this returns 0.0.0.0:0. */
 
-fd_ip4_port_t
+fd_sspeer_t
 fd_ssping_best( fd_ssping_t const * ssping );
 
 FD_PROTOTYPES_END

--- a/src/discof/restore/utils/fd_ssping.h
+++ b/src/discof/restore/utils/fd_ssping.h
@@ -35,14 +35,15 @@ struct fd_ssinfo {
     } full;
 
     struct {
-      ulong base_slot;
-      ulong slot;
-      uchar hash[ FD_HASH_FOOTPRINT ];
-      ulong slots_behind;
+      ulong base_slot;                 /* slot of the full snapshot */
+      ulong slot;                      /* slot of the incremental snapshot */
+      uchar hash[ FD_HASH_FOOTPRINT ]; /* base58 decoded hash of the incremental snapshot */
+      ulong slots_behind;              /* number of slots behind latest incremental cluster slot */
     } incremental;
 };
 typedef struct fd_ssinfo fd_ssinfo_t;
 
+/* fd_sspeer stores a peer's address and its resolved snapshot info. */
 struct fd_sspeer {
   fd_ip4_port_t       addr;
   fd_ssinfo_t const * snapshot_info;
@@ -104,11 +105,13 @@ void
 fd_ssping_advance( fd_ssping_t * ssping,
                    long          now );
 
-/* Retrieve the best "active" peer right now, by lowest ping.  If no
-   peer is active or pingable, this returns 0.0.0.0:0. */
+/* Retrieve the best "active" peer right now, by lowest ping.  Peer's
+   resolved snapshot slot must be greater than the highest slot
+   parameter. If no peer is active or pingable, this returns an empty
+   peer with address 0.0.0.0:0. */
 
 fd_sspeer_t
-fd_ssping_best( fd_ssping_t const * ssping );
+fd_ssping_best( fd_ssping_t * ssping );
 
 FD_PROTOTYPES_END
 

--- a/src/discof/restore/utils/fd_ssresolve.c
+++ b/src/discof/restore/utils/fd_ssresolve.c
@@ -76,18 +76,18 @@ fd_ssresolve_new( void * shmem ) {
 }
 
 fd_ssresolve_t *
-fd_ssresolve_join( void * _ssresolve ) {
-  if( FD_UNLIKELY( !_ssresolve ) ) {
+fd_ssresolve_join( void * shresolve ) {
+  if( FD_UNLIKELY( !shresolve ) ) {
     FD_LOG_WARNING(( "NULL ssresolve" ));
     return NULL;
   }
 
-  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)_ssresolve, fd_ssresolve_align() ) ) ) {
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shresolve, fd_ssresolve_align() ) ) ) {
     FD_LOG_WARNING(( "misaligned ssresolve" ));
     return NULL;
   }
 
-  fd_ssresolve_t * ssresolve = (fd_ssresolve_t *)_ssresolve;
+  fd_ssresolve_t * ssresolve = (fd_ssresolve_t *)shresolve;
 
   if( FD_UNLIKELY( ssresolve->magic!=FD_SSRESOLVE_MAGIC ) ) {
     FD_LOG_WARNING(( "bad magic" ));
@@ -95,6 +95,52 @@ fd_ssresolve_join( void * _ssresolve ) {
   }
 
   return ssresolve;
+}
+
+void *
+fd_ssresolve_leave( fd_ssresolve_t * ssresolve ) {
+  if( FD_UNLIKELY( !ssresolve ) ) {
+    FD_LOG_WARNING(( "NULL ssresolve" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)ssresolve, fd_ssresolve_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned ssresolve" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( ssresolve->magic!=FD_SSRESOLVE_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+    return NULL;
+  }
+
+  return (void *)ssresolve;
+}
+
+void *
+fd_ssresolve_delete( void * shresolve ) {
+  if( FD_UNLIKELY( !shresolve ) ) {
+    FD_LOG_WARNING(( "NULL ssresolve" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shresolve, fd_ssresolve_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned ssresolve" ));
+    return NULL;
+  }
+
+  fd_ssresolve_t * ssresolve = (fd_ssresolve_t *)shresolve;
+
+  if( FD_UNLIKELY( ssresolve->magic!=FD_SSRESOLVE_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+    return NULL;
+  }
+
+  FD_COMPILER_MFENCE();
+  ssresolve->magic = 0UL;
+  FD_COMPILER_MFENCE();
+
+  return shresolve;
 }
 
 void

--- a/src/discof/restore/utils/fd_ssresolve.c
+++ b/src/discof/restore/utils/fd_ssresolve.c
@@ -1,0 +1,302 @@
+#include "fd_ssresolve.h"
+#include "fd_ssarchive.h"
+
+#include "../../../waltz/http/picohttpparser.h"
+#include "../../../util/log/fd_log.h"
+
+#include <unistd.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <strings.h>
+
+#include <sys/socket.h>
+#include <netinet/tcp.h>
+#include <netinet/in.h>
+
+#define FD_SSRESOLVE_STATE_REQ  (0) /* sending request for snapshot */
+#define FD_SSRESOLVE_STATE_RESP (1) /* receiving snapshot response */
+#define FD_SSRESOLVE_STATE_DONE (2) /* done */
+
+struct fd_ssresolve_private {
+  int  state;
+  long deadline;
+
+  fd_ip4_port_t addr;
+  int           sockfd;
+  int           full;
+
+  char  request[ 4096UL ];
+  ulong request_sent;
+  ulong request_len;
+
+  ulong response_len;
+  char  response[ USHORT_MAX ];
+
+  ulong magic;
+};
+
+FD_FN_CONST ulong
+fd_ssresolve_align( void ) {
+  return FD_SSRESOLVE_ALIGN;
+}
+
+FD_FN_CONST ulong
+fd_ssresolve_footprint( void ) {
+  ulong l;
+  l = FD_LAYOUT_INIT;
+  l = FD_LAYOUT_APPEND( l, FD_SSRESOLVE_ALIGN, sizeof(fd_ssresolve_t) );
+  return FD_LAYOUT_FINI( l, FD_SSRESOLVE_ALIGN );
+}
+
+void *
+fd_ssresolve_new( void * shmem ) {
+  if( FD_UNLIKELY( !shmem ) ) {
+    FD_LOG_WARNING(( "NULL shmem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, fd_ssresolve_align() ) ) ) {
+    FD_LOG_WARNING(( "unaligned shmem" ));
+    return NULL;
+  }
+
+  FD_SCRATCH_ALLOC_INIT( l, shmem );
+  fd_ssresolve_t * ssresolve = FD_SCRATCH_ALLOC_APPEND( l, FD_SSRESOLVE_ALIGN, sizeof(fd_ssresolve_t) );
+
+  ssresolve->state        = FD_SSRESOLVE_STATE_REQ;
+  ssresolve->request_sent = 0UL;
+  ssresolve->request_len  = 0UL;
+  ssresolve->response_len = 0UL;
+
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( ssresolve->magic ) = FD_SSRESOLVE_MAGIC;
+  FD_COMPILER_MFENCE();
+
+  return (void *)ssresolve;
+}
+
+fd_ssresolve_t *
+fd_ssresolve_join( void * _ssresolve ) {
+  if( FD_UNLIKELY( !_ssresolve ) ) {
+    FD_LOG_WARNING(( "NULL ssresolve" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)_ssresolve, fd_ssresolve_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned ssresolve" ));
+    return NULL;
+  }
+
+  fd_ssresolve_t * ssresolve = (fd_ssresolve_t *)_ssresolve;
+
+  if( FD_UNLIKELY( ssresolve->magic!=FD_SSRESOLVE_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+    return NULL;
+  }
+
+  return ssresolve;
+}
+
+void
+fd_ssresolve_init( fd_ssresolve_t * ssresolve,
+                   fd_ip4_port_t    addr,
+                   int              sockfd,
+                   int              full ) {
+  ssresolve->addr   = addr;
+  ssresolve->sockfd = sockfd;
+  ssresolve->full   = full;
+
+  ssresolve->state        = FD_SSRESOLVE_STATE_REQ;
+  ssresolve->request_sent = 0UL;
+  ssresolve->request_len  = 0UL;
+  ssresolve->response_len = 0UL;
+}
+
+static void
+fd_ssresolve_render_req( fd_ssresolve_t * ssresolve,
+                         fd_ip4_port_t    addr ) {
+  if( FD_LIKELY( ssresolve->full ) ) {
+    FD_TEST( fd_cstr_printf_check( ssresolve->request, sizeof(ssresolve->request), &ssresolve->request_len,
+           "GET %.*s HTTP/1.1\r\n"
+           "User-Agent: Firedancer\r\n"
+           "Accept: */*\r\n"
+           "Accept-Encoding: identity\r\n"
+           "Host: " FD_IP4_ADDR_FMT "\r\n\r\n",
+           17, "/snapshot.tar.bz2", FD_IP4_ADDR_FMT_ARGS( addr.addr ) ) );
+  } else {
+    FD_TEST( fd_cstr_printf_check( ssresolve->request, sizeof(ssresolve->request), &ssresolve->request_len,
+           "GET %.*s HTTP/1.1\r\n"
+           "User-Agent: Firedancer\r\n"
+           "Accept: */*\r\n"
+           "Accept-Encoding: identity\r\n"
+           "Host: " FD_IP4_ADDR_FMT "\r\n\r\n",
+           29, "/incremental-snapshot.tar.bz2", FD_IP4_ADDR_FMT_ARGS( addr.addr ) ) );
+  }
+}
+
+static int
+fd_ssresolve_send_request( fd_ssresolve_t * ssresolve ) {
+  FD_TEST( ssresolve->state==FD_SSRESOLVE_STATE_REQ );
+
+  if( FD_UNLIKELY( !ssresolve->request_len ) ) {
+    fd_ssresolve_render_req( ssresolve, ssresolve->addr );
+  }
+
+  long sent = send( ssresolve->sockfd, ssresolve->request+ssresolve->request_sent, ssresolve->request_len-ssresolve->request_sent, 0 );
+  if( FD_UNLIKELY( -1==sent && errno==EAGAIN ) ) return FD_SSRESOLVE_ADVANCE_AGAIN;
+  else if( FD_UNLIKELY( -1==sent ) ) {
+    return FD_SSRESOLVE_ADVANCE_ERROR;
+  }
+
+  ssresolve->request_sent += (ulong)sent;
+  if( FD_UNLIKELY( ssresolve->request_sent==ssresolve->request_len ) ) {
+    ssresolve->state = FD_SSRESOLVE_STATE_RESP;
+    return FD_SSRESOLVE_ADVANCE_SUCCESS;
+  }
+
+  return FD_SSRESOLVE_ADVANCE_AGAIN;
+}
+
+static int
+fd_ssresolve_parse_redirect( fd_ssresolve_t *        ssresolve,
+                             struct phr_header *     headers,
+                             ulong                   header_cnt,
+                             fd_ssresolve_result_t * result ) {
+  ulong        location_len = 0UL;
+  char const * location     = NULL;
+
+  for( ulong i=0UL; i<header_cnt; i++ ) {
+    if( FD_UNLIKELY( !strncasecmp( headers[ i ].name, "location", headers[ i ].name_len ) ) ) {
+      if( FD_UNLIKELY( !headers [ i ].value_len || headers[ i ].value[ 0 ]!='/' ) ) {
+        FD_LOG_WARNING(( "invalid location header `%.*s`", (int)headers[ i ].value_len, headers[ i ].value ));
+        return FD_SSRESOLVE_ADVANCE_ERROR;
+      }
+
+      location_len = headers[ i ].value_len;
+      location = headers[ i ].value;
+      break;
+    }
+  }
+
+  if( FD_UNLIKELY( location_len>=PATH_MAX-1UL ) ) return FD_SSRESOLVE_ADVANCE_ERROR;
+
+  char snapshot_name[ PATH_MAX ];
+  fd_memcpy( snapshot_name, location+1UL, location_len-1UL );
+  snapshot_name[ location_len-1UL ] = '\0';
+
+  ulong full_entry_slot, incremental_entry_slot;
+  uchar decoded_hash[ FD_HASH_FOOTPRINT ];
+  int err = fd_ssarchive_parse_filename( snapshot_name, &full_entry_slot, &incremental_entry_slot, decoded_hash );
+
+  if( FD_UNLIKELY( err ) ) {
+    FD_LOG_WARNING(( "unrecognized snapshot file `%s` in redirect location header", snapshot_name ));
+    return FD_SSRESOLVE_ADVANCE_ERROR;
+  }
+
+  if( FD_LIKELY( incremental_entry_slot==ULONG_MAX ) ) {
+    result->slot      = full_entry_slot;
+    result->base_slot = ULONG_MAX;
+  } else {
+    result->slot      = incremental_entry_slot;
+    result->base_slot = full_entry_slot;
+  }
+  fd_memcpy( result->hash.hash, decoded_hash, FD_HASH_FOOTPRINT );
+
+  ssresolve->state = FD_SSRESOLVE_STATE_DONE;
+  return FD_SSRESOLVE_ADVANCE_SUCCESS;
+}
+
+static int
+fd_ssresolve_read_response( fd_ssresolve_t *        ssresolve,
+                            fd_ssresolve_result_t * result ) {
+  FD_TEST( ssresolve->state==FD_SSRESOLVE_STATE_RESP );
+  long read = recv( ssresolve->sockfd, ssresolve->response+ssresolve->response_len, sizeof(ssresolve->response)-ssresolve->response_len, 0 );
+  if( FD_UNLIKELY( -1==read && errno==EAGAIN ) ) return FD_SSRESOLVE_ADVANCE_AGAIN;
+  else if( FD_UNLIKELY( -1==read ) ) {
+    FD_LOG_WARNING(( "recv() failed (%d-%s)", errno, fd_io_strerror( errno ) ));
+    return FD_SSRESOLVE_ADVANCE_ERROR;
+  }
+
+  ssresolve->response_len += (ulong)read;
+
+  int               minor_version;
+  int               status;
+  const char *      message;
+  ulong             message_len;
+  struct phr_header headers[ 128UL ];
+  ulong             header_cnt = 128UL;
+  int parsed = phr_parse_response( ssresolve->response,
+                                    ssresolve->response_len,
+                                    &minor_version,
+                                    &status,
+                                    &message,
+                                    &message_len,
+                                    headers,
+                                    &header_cnt,
+                                    ssresolve->response_len - (ulong)read );
+  if( FD_UNLIKELY( parsed==-1 ) ) {
+    FD_LOG_WARNING(( "malformed response body" ));
+    return FD_SSRESOLVE_ADVANCE_ERROR;
+  } else if( parsed==-2 ) {
+    return FD_SSRESOLVE_ADVANCE_ERROR;
+  }
+
+  int is_redirect = (status==301) | (status==303) | (status==304) | (status==307) | (status==308);
+  if( FD_UNLIKELY( is_redirect ) ) {
+    return fd_ssresolve_parse_redirect( ssresolve, headers, header_cnt, result );
+  }
+
+  if( FD_UNLIKELY( status!=200 ) ) {
+    FD_LOG_WARNING(( "unexpected response status %d", status ));
+    return FD_SSRESOLVE_ADVANCE_ERROR;
+  }
+
+  return FD_SSRESOLVE_ADVANCE_ERROR;
+}
+
+int
+fd_ssresolve_advance_poll_out( fd_ssresolve_t *        ssresolve ) {
+  int res;
+  switch( ssresolve->state ) {
+    case FD_SSRESOLVE_STATE_REQ: {
+      res = fd_ssresolve_send_request( ssresolve );
+      break;
+    }
+    case FD_SSRESOLVE_STATE_RESP: {
+      res = FD_SSRESOLVE_ADVANCE_AGAIN;
+      break;
+    }
+    default: {
+      FD_LOG_ERR(( "unexpected state %d", ssresolve->state ));
+      return FD_SSRESOLVE_ADVANCE_ERROR;
+    }
+  }
+  return res;
+}
+
+int
+fd_ssresolve_advance_poll_in( fd_ssresolve_t *        ssresolve,
+                              fd_ssresolve_result_t * result ) {
+  int res;
+  switch( ssresolve->state ) {
+    case FD_SSRESOLVE_STATE_RESP: {
+      res = fd_ssresolve_read_response( ssresolve, result );
+      break;
+    }
+    case FD_SSRESOLVE_STATE_REQ: {
+      res = FD_SSRESOLVE_ADVANCE_AGAIN;
+      break;
+    }
+    default: {
+      FD_LOG_ERR(( "unexpected state %d", ssresolve->state ));
+      return FD_SSRESOLVE_ADVANCE_ERROR;
+    }
+  }
+
+  return res;
+}
+
+int
+fd_ssresolve_is_done( fd_ssresolve_t * ssresolve ) {
+  return ssresolve->state==FD_SSRESOLVE_STATE_DONE;
+}

--- a/src/discof/restore/utils/fd_ssresolve.h
+++ b/src/discof/restore/utils/fd_ssresolve.h
@@ -9,9 +9,9 @@
 #define FD_SSRESOLVE_ALIGN (8UL)
 
 struct fd_ssresolve_result {
-  ulong     slot;       /* slot of the snapshot */
-  ulong     base_slot;  /* base slot of incremental snapshot or ULONG_MAX */
-  fd_hash_t hash;       /* base58 decoded hash of the snapshot */
+  ulong     slot;             /* slot of the snapshot */
+  ulong     base_slot;        /* base slot of incremental snapshot or ULONG_MAX */
+  fd_hash_t hash;             /* base58 decoded hash of the snapshot */
 };
 
 typedef struct fd_ssresolve_result fd_ssresolve_result_t;

--- a/src/discof/restore/utils/fd_ssresolve.h
+++ b/src/discof/restore/utils/fd_ssresolve.h
@@ -1,0 +1,67 @@
+#ifndef HEADER_fd_src_discof_restore_utils_fd_ssresolve_h
+#define HEADER_fd_src_discof_restore_utils_fd_ssresolve_h
+
+#include "../../../util/fd_util_base.h"
+#include "../../../flamenco/types/fd_types_custom.h"
+#include "../../../util/net/fd_net_headers.h"
+
+#define FD_SSRESOLVE_MAGIC (0xF17EDA2CE55E510) /* FIREDANCER HTTP RESOLVE V0 */
+#define FD_SSRESOLVE_ALIGN (8UL)
+
+struct fd_ssresolve_result {
+  ulong     slot;       /* slot of the snapshot */
+  ulong     base_slot;  /* base slot of incremental snapshot or ULONG_MAX */
+  fd_hash_t hash;       /* base58 decoded hash of the snapshot */
+};
+
+typedef struct fd_ssresolve_result fd_ssresolve_result_t;
+
+/* fd_ssresolve is responsible for resolving snapshots from a given
+   peer by sending http requests and parsing http redirect responses.
+
+   It is used by fd_ssping_t to ping and resolve snapshots for each
+   peer. */
+struct fd_ssresolve_private;
+typedef struct fd_ssresolve_private fd_ssresolve_t;
+
+FD_PROTOTYPES_BEGIN
+
+FD_FN_CONST ulong
+fd_ssresolve_align( void );
+
+FD_FN_CONST ulong
+fd_ssresolve_footprint( void );
+
+void *
+fd_ssresolve_new( void * shmem );
+
+fd_ssresolve_t *
+fd_ssresolve_join( void * ssresolve );
+
+void
+fd_ssresolve_init( fd_ssresolve_t * ssresolve,
+                   fd_ip4_port_t    addr,
+                   int              sockfd,
+                   int              full );
+
+#define FD_SSRESOLVE_ADVANCE_ERROR   (-1) /* fatal error */
+#define FD_SSRESOLVE_ADVANCE_AGAIN   ( 0) /* try again */
+#define FD_SSRESOLVE_ADVANCE_SUCCESS ( 1) /* success */
+
+/* fd_ssresolve_advance_poll_out advances the ssresolve state machine
+   when its socket file descriptor is ready for sending data. */
+int
+fd_ssresolve_advance_poll_out( fd_ssresolve_t * ssresolve );
+
+/* fd_ssresolve_advance_poll_in advances the ssresolve state machine
+   when its socket file descriptor is ready for receiving data. */
+int
+fd_ssresolve_advance_poll_in( fd_ssresolve_t *        ssresolve,
+                              fd_ssresolve_result_t * result );
+
+int
+fd_ssresolve_is_done( fd_ssresolve_t * ssresolve );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_discof_restore_utils_fd_ssresolve_h */

--- a/src/discof/restore/utils/fd_ssresolve.h
+++ b/src/discof/restore/utils/fd_ssresolve.h
@@ -8,16 +8,18 @@
 #define FD_SSRESOLVE_MAGIC (0xF17EDA2CE55E510) /* FIREDANCER HTTP RESOLVE V0 */
 #define FD_SSRESOLVE_ALIGN (8UL)
 
+/* fd_ssresolve_result contains the resolved snapshot info from
+   making an http request to a snapshot peer. */
 struct fd_ssresolve_result {
-  ulong     slot;             /* slot of the snapshot */
-  ulong     base_slot;        /* base slot of incremental snapshot or ULONG_MAX */
-  fd_hash_t hash;             /* base58 decoded hash of the snapshot */
+  ulong     slot;      /* slot of the snapshot */
+  ulong     base_slot; /* base slot of incremental snapshot or ULONG_MAX */
+  fd_hash_t hash;      /* base58 decoded hash of the snapshot */
 };
 
 typedef struct fd_ssresolve_result fd_ssresolve_result_t;
 
 /* fd_ssresolve is responsible for resolving snapshots from a given
-   peer by sending http requests and parsing http redirect responses.
+   peer by sending a http request and parsing a http redirect response.
 
    It is used by fd_ssping_t to ping and resolve snapshots for each
    peer. */
@@ -36,8 +38,17 @@ void *
 fd_ssresolve_new( void * shmem );
 
 fd_ssresolve_t *
-fd_ssresolve_join( void * ssresolve );
+fd_ssresolve_join( void * shresolve );
 
+void *
+fd_ssresolve_leave( fd_ssresolve_t * ssresolve );
+
+void *
+fd_ssresolve_delete( void * shresolve );
+
+/* fd_ssresolve_init initializes a fd_ssresolve_t object with a peer's
+   address, a socket file descriptor, and whether the resolve request
+   is for a full or incremental snapshot. */
 void
 fd_ssresolve_init( fd_ssresolve_t * ssresolve,
                    fd_ip4_port_t    addr,
@@ -59,6 +70,9 @@ int
 fd_ssresolve_advance_poll_in( fd_ssresolve_t *        ssresolve,
                               fd_ssresolve_result_t * result );
 
+/* fd_ssresolve_is_done returns whether the ssresolve state machine
+   is done.  The ssresolve object must be reset via fd_ssresolve_init
+   to restart the state machine. */
 int
 fd_ssresolve_is_done( fd_ssresolve_t * ssresolve );
 


### PR DESCRIPTION
Repair can start before the snapshot is fully loaded if the snapshot tiles send the highest manifest slot seen so far. The highest manifest slot is typically the incremental snapshot slot, but can be the full snapshot slot if incremental snapshots are disabled. The highest manifest slot is guaranteed to be monotonically increasing. It is sent by the snaprd tile when a snapshot peer is selected.

Makes use of https://github.com/firedancer-io/firedancer/pull/5777 to resolve snapshots for each peer.