### PR TITLE
gui: new boot screen

### DIFF
--- a/src/ballet/shred/test_shred.c
+++ b/src/ballet/shred/test_shred.c
@@ -1,19 +1,21 @@
 #include "fd_shred.h"
 
-FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, signature       )==0x00, unit_test );
-FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, variant         )==0x40, unit_test );
-FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, slot            )==0x41, unit_test );
-FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, idx             )==0x49, unit_test );
-FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, version         )==0x4d, unit_test );
-FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, fec_set_idx     )==0x4f, unit_test );
+#include <stddef.h> // offsetof
 
-FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, code.data_cnt   )==0x53, unit_test );
-FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, code.code_cnt   )==0x55, unit_test );
-FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, code.idx        )==0x57, unit_test );
+FD_STATIC_ASSERT( offsetof( fd_shred_t, signature       )==0x00, unit_test );
+FD_STATIC_ASSERT( offsetof( fd_shred_t, variant         )==0x40, unit_test );
+FD_STATIC_ASSERT( offsetof( fd_shred_t, slot            )==0x41, unit_test );
+FD_STATIC_ASSERT( offsetof( fd_shred_t, idx             )==0x49, unit_test );
+FD_STATIC_ASSERT( offsetof( fd_shred_t, version         )==0x4d, unit_test );
+FD_STATIC_ASSERT( offsetof( fd_shred_t, fec_set_idx     )==0x4f, unit_test );
 
-FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, data.parent_off )==0x53, unit_test );
-FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, data.flags      )==0x55, unit_test );
-FD_STATIC_ASSERT( __builtin_offsetof( fd_shred_t, data.size       )==0x56, unit_test );
+FD_STATIC_ASSERT( offsetof( fd_shred_t, code.data_cnt   )==0x53, unit_test );
+FD_STATIC_ASSERT( offsetof( fd_shred_t, code.code_cnt   )==0x55, unit_test );
+FD_STATIC_ASSERT( offsetof( fd_shred_t, code.idx        )==0x57, unit_test );
+
+FD_STATIC_ASSERT( offsetof( fd_shred_t, data.parent_off )==0x53, unit_test );
+FD_STATIC_ASSERT( offsetof( fd_shred_t, data.flags      )==0x55, unit_test );
+FD_STATIC_ASSERT( offsetof( fd_shred_t, data.size       )==0x56, unit_test );
 
 static uchar const fixture_legacy_coding_shred[FD_SHRED_MAX_SZ] = {
   0x12,0x5f,0x43,0x31,0xbe,0x64,0x52,0x07,0x88,0xc8,0x2b,0x22,0x71,0x4a,0xb9,0x2c,

--- a/src/disco/gui/Local.mk
+++ b/src/disco/gui/Local.mk
@@ -1,6 +1,6 @@
 ifdef FD_HAS_INT128
-$(call add-hdrs,fd_gui.h fd_gui_printf.h)
-$(call add-objs,fd_gui fd_gui_printf fd_gui_tile generated/http_import_dist,fd_disco)
+$(call add-hdrs,fd_gui.h fd_gui_printf.h fd_gui_peers.h)
+$(call add-objs,fd_gui fd_gui_printf fd_gui_peers fd_gui_tile generated/http_import_dist,fd_disco)
 $(OBJDIR)/obj/disco/gui/fd_gui_tile.o: book/public/fire.svg
 $(call make-unit-test,test_live_table,test_live_table,fd_disco fd_util)
 endif

--- a/src/disco/gui/fd_gui_peers.c
+++ b/src/disco/gui/fd_gui_peers.c
@@ -1,0 +1,956 @@
+#include "fd_gui_peers.h"
+#include "fd_gui_printf.h"
+
+#include "../../ballet/json/cJSON.h"
+#include "../../flamenco/gossip/fd_gossip_private.h"
+#include "../../flamenco/gossip/fd_gossip_types.h"
+
+#define LOGGING 0
+
+FD_FN_CONST ulong
+fd_gui_peers_align( void ) {
+  ulong a = 128UL;
+  a = fd_ulong_max( a, alignof(fd_gui_peers_ctx_t)              );
+  a = fd_ulong_max( a, fd_gui_peers_live_table_align()          );
+  a = fd_ulong_max( a, fd_gui_peers_bandwidth_tracking_align()  );
+  a = fd_ulong_max( a, fd_gui_peers_node_pubkey_map_align()     );
+  a = fd_ulong_max( a, fd_gui_peers_node_sock_map_align()       );
+  a = fd_ulong_max( a, alignof(fd_gui_peers_ws_conn_t)          );
+  FD_TEST( fd_ulong_pow2_up( a )==a );
+  return a;
+}
+
+FD_FN_CONST ulong
+fd_gui_peers_footprint( ulong max_ws_conn_cnt ) {
+  ulong pubkey_chain_cnt = fd_gui_peers_node_pubkey_map_chain_cnt_est( FD_CONTACT_INFO_TABLE_SIZE );
+  ulong sock_chain_cnt   = fd_gui_peers_node_sock_map_chain_cnt_est  ( FD_CONTACT_INFO_TABLE_SIZE );
+
+  ulong l = FD_LAYOUT_INIT;
+  l = FD_LAYOUT_APPEND( l, alignof(fd_gui_peers_ctx_t),             sizeof(fd_gui_peers_ctx_t)                                              );
+  l = FD_LAYOUT_APPEND( l, fd_gui_peers_live_table_align(),         fd_gui_peers_live_table_footprint        ( FD_CONTACT_INFO_TABLE_SIZE ) );
+  l = FD_LAYOUT_APPEND( l, fd_gui_peers_bandwidth_tracking_align(), fd_gui_peers_bandwidth_tracking_footprint( FD_CONTACT_INFO_TABLE_SIZE ) );
+  l = FD_LAYOUT_APPEND( l, fd_gui_peers_node_pubkey_map_align(),    fd_gui_peers_node_pubkey_map_footprint   ( pubkey_chain_cnt )           );
+  l = FD_LAYOUT_APPEND( l, fd_gui_peers_node_sock_map_align(),      fd_gui_peers_node_sock_map_footprint     ( sock_chain_cnt )             );
+  l = FD_LAYOUT_APPEND( l, alignof(fd_gui_peers_ws_conn_t),         max_ws_conn_cnt*sizeof(fd_gui_peers_ws_conn_t)                          );
+
+  return FD_LAYOUT_FINI( l, fd_gui_peers_align() );
+}
+
+void *
+fd_gui_peers_new( void *             shmem,
+                  fd_http_server_t * http,
+                  fd_topo_t *        topo,
+                  ulong              max_ws_conn_cnt,
+                  long               now ) {
+    if( FD_UNLIKELY( !shmem ) ) {
+      FD_LOG_WARNING(( "NULL shmem" ));
+      return NULL;
+    }
+
+    if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, fd_gui_peers_align() ) ) ) {
+      FD_LOG_WARNING(( "misaligned shmem" ));
+      return NULL;
+    }
+
+    ulong pubkey_chain_cnt = fd_gui_peers_node_pubkey_map_chain_cnt_est( FD_CONTACT_INFO_TABLE_SIZE );
+    ulong sock_chain_cnt   = fd_gui_peers_node_sock_map_chain_cnt_est  ( FD_CONTACT_INFO_TABLE_SIZE );
+
+    FD_SCRATCH_ALLOC_INIT( l, shmem );
+    fd_gui_peers_ctx_t * ctx = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_gui_peers_ctx_t),             sizeof(fd_gui_peers_ctx_t)                                              );
+    void * _live_table       = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_peers_live_table_align(),         fd_gui_peers_live_table_footprint        ( FD_CONTACT_INFO_TABLE_SIZE ) );
+    void * _bw_tracking      = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_peers_bandwidth_tracking_align(), fd_gui_peers_bandwidth_tracking_footprint( FD_CONTACT_INFO_TABLE_SIZE ) );
+    void * _pubkey_map       = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_peers_node_pubkey_map_align(),    fd_gui_peers_node_pubkey_map_footprint   ( pubkey_chain_cnt )           );
+    void * _sock_map         = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_peers_node_sock_map_align(),      fd_gui_peers_node_sock_map_footprint     ( sock_chain_cnt )             );
+    ctx->client_viewports    = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_gui_peers_ws_conn_t),         max_ws_conn_cnt*sizeof(fd_gui_peers_ws_conn_t)                          );
+
+    for( ulong i = 0UL; i<max_ws_conn_cnt; i++ ) ctx->client_viewports[ i ].connected = 0;
+
+    ctx->http = http;
+    ctx->topo = topo;
+
+    ctx->max_ws_conn_cnt   = max_ws_conn_cnt;
+    ctx->open_ws_conn_cnt  = 0UL;
+    ctx->active_ws_conn_id = ULONG_MAX;
+
+    ctx->next_client_nanos              = now;
+    ctx->next_metric_rate_update_nanos  = now;
+    ctx->next_gossip_stats_update_nanos = now;
+    memset( &ctx->gossip_stats, 0, sizeof(ctx->gossip_stats) );
+
+    for( ulong i = 0; i<FD_CONTACT_INFO_TABLE_SIZE; i++) ctx->contact_info_table[ i ].valid = 0;
+
+    ctx->live_table      = fd_gui_peers_live_table_join( fd_gui_peers_live_table_new( _live_table, FD_CONTACT_INFO_TABLE_SIZE ) );
+    fd_gui_peers_live_table_seed( ctx->contact_info_table, FD_CONTACT_INFO_TABLE_SIZE, 42UL );
+
+    ctx->bw_tracking     = fd_gui_peers_bandwidth_tracking_join( fd_gui_peers_bandwidth_tracking_new( _bw_tracking, FD_CONTACT_INFO_TABLE_SIZE ) );
+    fd_gui_peers_bandwidth_tracking_seed( ctx->contact_info_table, FD_CONTACT_INFO_TABLE_SIZE, 42UL );
+
+    ctx->node_pubkey_map = fd_gui_peers_node_pubkey_map_join( fd_gui_peers_node_pubkey_map_new( _pubkey_map, fd_gui_peers_node_pubkey_map_chain_cnt_est( FD_CONTACT_INFO_TABLE_SIZE ), 42UL ) );
+    ctx->node_sock_map   = fd_gui_peers_node_sock_map_join  ( fd_gui_peers_node_sock_map_new  ( _sock_map,   fd_gui_peers_node_sock_map_chain_cnt_est  ( FD_CONTACT_INFO_TABLE_SIZE ), 42UL ) );
+
+    return shmem;
+}
+
+fd_gui_peers_ctx_t *
+fd_gui_peers_join( void * shmem ) {
+  if( FD_UNLIKELY( !shmem ) ) {
+    FD_LOG_WARNING(( "NULL shmem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, fd_gui_peers_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned shmem" ));
+    return NULL;
+  }
+
+  fd_gui_peers_ctx_t * ctx = (fd_gui_peers_ctx_t *)shmem;
+
+  return ctx;
+}
+
+static ulong
+fd_gui_sum_tiles_counter( fd_gui_peers_ctx_t * peers,
+                          char const *         name,
+                          ulong                tile_cnt,
+                          ulong                metric_idx ) {
+  ulong total = 0UL;
+  for( ulong i = 0UL; i < peers->topo->tile_cnt; i++ ) {
+    if( FD_UNLIKELY( !strcmp( peers->topo->tiles[ i ].name, name ) ) ) {
+      FD_TEST( peers->topo->tiles[ i ].kind_id < tile_cnt );
+      fd_topo_tile_t const * tile = &peers->topo->tiles[ i ];
+      volatile ulong const * tile_metrics = fd_metrics_tile( tile->metrics );
+      total += tile_metrics[ metric_idx ];
+    }
+  }
+  return total;
+}
+
+static void
+fd_gui_peers_gossip_stats_snap( fd_gui_peers_ctx_t *          peers,
+                                fd_gui_peers_gossip_stats_t * gossip_stats,
+                                long                          now ) {
+  gossip_stats->sample_time = now;
+  ulong gossvf_tile_cnt = fd_topo_tile_name_cnt( peers->topo, "gossvf"  );
+  ulong gossip_tile_cnt = 1UL;
+
+  gossip_stats->network_health_pull_response_msg_rx_success =
+      fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_SUCCESS_PULL_RESPONSE ) );
+  gossip_stats->network_health_pull_response_msg_rx_failure =
+      fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PULL_RESPONSE_NO_VALID_CRDS ) );
+  gossip_stats->network_health_push_msg_rx_success =
+      fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_SUCCESS_PUSH ) );
+  gossip_stats->network_health_push_msg_rx_failure =
+      fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PUSH_NO_VALID_CRDS ) );
+  gossip_stats->network_health_push_crds_rx_success =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_RX_COUNT_UPSERTED_PUSH ) );
+  gossip_stats->network_health_push_crds_rx_failure =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_RX_COUNT_DROPPED_PUSH_STALE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_RX_COUNT_DROPPED_PUSH_DUPLICATE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, CRDS_RX_COUNT_DROPPED_PUSH_SIGNATURE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, CRDS_RX_COUNT_DROPPED_PUSH_RELAYER_NO_CONTACT_INFO ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, CRDS_RX_COUNT_DROPPED_PUSH_RELAYER_SHRED_VERSION ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, CRDS_RX_COUNT_DROPPED_PUSH_ORIGIN_NO_CONTACT_INFO ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, CRDS_RX_COUNT_DROPPED_PUSH_ORIGIN_SHRED_VERSION ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, CRDS_RX_COUNT_DROPPED_PUSH_INACTIVE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, CRDS_RX_COUNT_DROPPED_PUSH_WALLCLOCK ) );
+  gossip_stats->network_health_pull_response_crds_rx_success =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_RX_COUNT_UPSERTED_PULL_RESPONSE ) );
+  gossip_stats->network_health_pull_response_crds_rx_failure =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_RX_COUNT_DROPPED_PULL_RESPONSE_STALE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_RX_COUNT_DROPPED_PULL_RESPONSE_WALLCLOCK ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_RX_COUNT_DROPPED_PULL_RESPONSE_DUPLICATE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, CRDS_RX_COUNT_DROPPED_PULL_RESPONSE_DUPLICATE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, CRDS_RX_COUNT_DROPPED_PULL_RESPONSE_SIGNATURE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, CRDS_RX_COUNT_DROPPED_PULL_RESPONSE_RELAYER_SHRED_VERSION ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, CRDS_RX_COUNT_DROPPED_PULL_RESPONSE_ORIGIN_NO_CONTACT_INFO ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, CRDS_RX_COUNT_DROPPED_PULL_RESPONSE_ORIGIN_SHRED_VERSION ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, CRDS_RX_COUNT_DROPPED_PULL_RESPONSE_INACTIVE ) );
+  gossip_stats->network_health_push_crds_rx_duplicate =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_RX_COUNT_DROPPED_PUSH_DUPLICATE ) );
+  gossip_stats->network_health_pull_response_crds_rx_duplicate =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_RX_COUNT_DROPPED_PULL_RESPONSE_DUPLICATE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, CRDS_RX_COUNT_DROPPED_PULL_RESPONSE_DUPLICATE ) );
+
+  gossip_stats->network_health_total_stake = 0UL; /* todo ... fetch from RPC */
+  gossip_stats->network_health_total_peers = 0UL; /* todo ... fetch from RPC */
+
+  gossip_stats->network_health_connected_stake          = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_PEER_TOTAL_STAKE ) );
+  gossip_stats->network_health_connected_staked_peers   = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_PEER_STAKED_COUNT ) );
+  gossip_stats->network_health_connected_unstaked_peers = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_PEER_UNSTAKED_COUNT ) );
+
+  gossip_stats->network_ingress_peer_sz = fd_ulong_min( fd_gui_peers_bandwidth_tracking_ele_cnt( peers->bw_tracking ), FD_GUI_PEERS_GOSSIP_TOP_PEERS_CNT );
+  gossip_stats->network_ingress_total_bytes_per_sec = 0UL;
+
+  for( fd_gui_peers_bandwidth_tracking_fwd_iter_t iter = fd_gui_peers_bandwidth_tracking_fwd_iter_init( peers->bw_tracking, &FD_GUI_PEERS_BW_TRACKING_INGRESS_SORT_KEY, peers->contact_info_table ), j = 0UL;
+       !fd_gui_peers_bandwidth_tracking_fwd_iter_done( iter );
+       iter = fd_gui_peers_bandwidth_tracking_fwd_iter_next( iter, peers->contact_info_table ), j++ ) {
+    fd_gui_peers_node_t * cur = fd_gui_peers_bandwidth_tracking_fwd_iter_ele( iter, peers->contact_info_table );
+
+    if( FD_UNLIKELY( j<gossip_stats->network_ingress_peer_sz ) ) {
+      if( FD_LIKELY( cur->has_node_info ) ) FD_TEST( fd_cstr_printf_check( gossip_stats->network_ingress_peer_names[ j ], sizeof(gossip_stats->network_ingress_peer_names[ j ]), NULL, "%s", cur->name ) );
+      else                                  gossip_stats->network_ingress_peer_names[ j ][ 0 ] = '\0';
+      gossip_stats->network_ingress_peer_bytes_per_sec[ j ] = cur->gossvf_rx_sum.rate;
+      fd_memcpy( &gossip_stats->network_ingress_peer_identities[ j ], cur->contact_info.pubkey.uc, 32UL );
+    }
+
+    gossip_stats->network_ingress_total_bytes_per_sec += cur->gossvf_rx_sum.rate;
+  }
+
+  gossip_stats->network_ingress_total_bytes =
+      fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_SUCCESS_PULL_REQUEST) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_SUCCESS_PULL_RESPONSE) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_SUCCESS_PUSH) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_SUCCESS_PRUNE) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_SUCCESS_PING) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_SUCCESS_PONG) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_DROPPED_UNPARSEABLE) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_DROPPED_PULL_REQUEST_NOT_CONTACT_INFO) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_DROPPED_PULL_REQUEST_LOOPBACK) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_DROPPED_PULL_REQUEST_INACTIVE) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_DROPPED_PULL_REQUEST_WALLCLOCK) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_DROPPED_PULL_REQUEST_SIGNATURE) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_DROPPED_PULL_REQUEST_SHRED_VERSION) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_DROPPED_PRUNE_DESTINATION) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_DROPPED_PRUNE_WALLCLOCK) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_DROPPED_PRUNE_SIGNATURE) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_DROPPED_PUSH_NO_VALID_CRDS) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_DROPPED_PULL_RESPONSE_NO_VALID_CRDS) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_DROPPED_PING_SIGNATURE) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_DROPPED_PONG_SIGNATURE) );
+
+  gossip_stats->network_egress_peer_sz = fd_ulong_min( fd_gui_peers_bandwidth_tracking_ele_cnt( peers->bw_tracking ), FD_GUI_PEERS_GOSSIP_TOP_PEERS_CNT );
+
+  FD_TEST( gossip_stats->network_egress_peer_sz==gossip_stats->network_ingress_peer_sz );
+
+  gossip_stats->network_egress_peer_sz = fd_ulong_min( fd_gui_peers_bandwidth_tracking_ele_cnt( peers->bw_tracking ), FD_GUI_PEERS_GOSSIP_TOP_PEERS_CNT );
+  gossip_stats->network_egress_total_bytes_per_sec = 0UL;
+
+  for( fd_gui_peers_bandwidth_tracking_fwd_iter_t iter = fd_gui_peers_bandwidth_tracking_fwd_iter_init( peers->bw_tracking, &FD_GUI_PEERS_BW_TRACKING_EGRESS_SORT_KEY, peers->contact_info_table ), j = 0UL;
+       !fd_gui_peers_bandwidth_tracking_fwd_iter_done( iter );
+       iter = fd_gui_peers_bandwidth_tracking_fwd_iter_next( iter, peers->contact_info_table ), j++ ) {
+    fd_gui_peers_node_t * cur = fd_gui_peers_bandwidth_tracking_fwd_iter_ele( iter, peers->contact_info_table );
+
+    if( FD_UNLIKELY( j<gossip_stats->network_egress_peer_sz ) ) {
+      if( FD_LIKELY( cur->has_node_info ) ) FD_TEST( fd_cstr_printf_check( gossip_stats->network_egress_peer_names[ j ], sizeof(gossip_stats->network_egress_peer_names[ j ]), NULL, "%s", cur->name ) );
+      else                                  gossip_stats->network_egress_peer_names[ j ][ 0 ] = '\0';
+      gossip_stats->network_egress_peer_bytes_per_sec[ j ] = cur->gossip_tx_sum.rate;
+      fd_memcpy( &gossip_stats->network_egress_peer_identities[ j ], cur->contact_info.pubkey.uc, 32UL );
+    }
+
+    gossip_stats->network_egress_total_bytes_per_sec += cur->gossip_tx_sum.rate;
+  }
+
+  gossip_stats->network_egress_total_bytes =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_BYTES_PING ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_BYTES_PONG ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_BYTES_PRUNE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_BYTES_PULL_REQUEST ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_BYTES_PULL_RESPONSE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_BYTES_PUSH ) );
+
+  gossip_stats->storage_capacity = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_CAPACITY ) );
+  gossip_stats->storage_expired_cnt = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_EXPIRED_COUNT ) );
+  gossip_stats->storage_evicted_cnt = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_EVICTED_COUNT ) );
+
+  gossip_stats->storage_active_cnt[ FD_METRICS_ENUM_CRDS_VALUE_V_CONTACT_INFO_V1_IDX               ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_COUNT_CONTACT_INFO_V1 )               );
+  gossip_stats->storage_active_cnt[ FD_METRICS_ENUM_CRDS_VALUE_V_VOTE_IDX                          ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_COUNT_VOTE )                          );
+  gossip_stats->storage_active_cnt[ FD_METRICS_ENUM_CRDS_VALUE_V_LOWEST_SLOT_IDX                   ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_COUNT_LOWEST_SLOT )                   );
+  gossip_stats->storage_active_cnt[ FD_METRICS_ENUM_CRDS_VALUE_V_SNAPSHOT_HASHES_IDX               ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_COUNT_SNAPSHOT_HASHES )               );
+  gossip_stats->storage_active_cnt[ FD_METRICS_ENUM_CRDS_VALUE_V_ACCOUNTS_HASHES_IDX               ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_COUNT_ACCOUNTS_HASHES )               );
+  gossip_stats->storage_active_cnt[ FD_METRICS_ENUM_CRDS_VALUE_V_EPOCH_SLOTS_IDX                   ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_COUNT_EPOCH_SLOTS )                   );
+  gossip_stats->storage_active_cnt[ FD_METRICS_ENUM_CRDS_VALUE_V_VERSION_V1_IDX                    ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_COUNT_VERSION_V1 )                    );
+  gossip_stats->storage_active_cnt[ FD_METRICS_ENUM_CRDS_VALUE_V_VERSION_V2_IDX                    ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_COUNT_VERSION_V2 )                    );
+  gossip_stats->storage_active_cnt[ FD_METRICS_ENUM_CRDS_VALUE_V_NODE_INSTANCE_IDX                 ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_COUNT_NODE_INSTANCE )                 );
+  gossip_stats->storage_active_cnt[ FD_METRICS_ENUM_CRDS_VALUE_V_DUPLICATE_SHRED_IDX               ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_COUNT_DUPLICATE_SHRED )               );
+  gossip_stats->storage_active_cnt[ FD_METRICS_ENUM_CRDS_VALUE_V_INCREMENTAL_SNAPSHOT_HASHES_IDX   ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_COUNT_INCREMENTAL_SNAPSHOT_HASHES )   );
+  gossip_stats->storage_active_cnt[ FD_METRICS_ENUM_CRDS_VALUE_V_CONTACT_INFO_V2_IDX               ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_COUNT_CONTACT_INFO_V2 )               );
+  gossip_stats->storage_active_cnt[ FD_METRICS_ENUM_CRDS_VALUE_V_RESTART_LAST_VOTED_FORK_SLOTS_IDX ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_COUNT_RESTART_LAST_VOTED_FORK_SLOTS ) );
+  gossip_stats->storage_active_cnt[ FD_METRICS_ENUM_CRDS_VALUE_V_RESTART_HEAVIEST_FORK_IDX         ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( GAUGE, GOSSIP, CRDS_COUNT_RESTART_HEAVIEST_FORK )         );
+
+  gossip_stats->storage_cnt_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_CONTACT_INFO_V1_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_COUNT_CONTACT_INFO_V1 ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_COUNT_CONTACT_INFO_V1 ) );
+  gossip_stats->storage_cnt_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_VOTE_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_COUNT_VOTE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_COUNT_VOTE ) );
+  gossip_stats->storage_cnt_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_LOWEST_SLOT_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_COUNT_LOWEST_SLOT ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_COUNT_LOWEST_SLOT ) );
+  gossip_stats->storage_cnt_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_SNAPSHOT_HASHES_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_COUNT_SNAPSHOT_HASHES ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_COUNT_SNAPSHOT_HASHES ) );
+  gossip_stats->storage_cnt_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_ACCOUNTS_HASHES_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_COUNT_ACCOUNTS_HASHES ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_COUNT_ACCOUNTS_HASHES ) );
+  gossip_stats->storage_cnt_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_EPOCH_SLOTS_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_COUNT_EPOCH_SLOTS ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_COUNT_EPOCH_SLOTS ) );
+  gossip_stats->storage_cnt_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_VERSION_V1_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_COUNT_VERSION_V1 ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_COUNT_VERSION_V1 ) );
+  gossip_stats->storage_cnt_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_VERSION_V2_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_COUNT_VERSION_V2 ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_COUNT_VERSION_V2 ) );
+  gossip_stats->storage_cnt_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_NODE_INSTANCE_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_COUNT_NODE_INSTANCE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_COUNT_NODE_INSTANCE ) );
+  gossip_stats->storage_cnt_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_DUPLICATE_SHRED_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_COUNT_DUPLICATE_SHRED ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_COUNT_DUPLICATE_SHRED ) );
+  gossip_stats->storage_cnt_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_INCREMENTAL_SNAPSHOT_HASHES_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_COUNT_INCREMENTAL_SNAPSHOT_HASHES ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_COUNT_INCREMENTAL_SNAPSHOT_HASHES ) );
+  gossip_stats->storage_cnt_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_CONTACT_INFO_V2_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_COUNT_CONTACT_INFO_V2 ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_COUNT_CONTACT_INFO_V2 ) );
+  gossip_stats->storage_cnt_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_RESTART_LAST_VOTED_FORK_SLOTS_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_COUNT_RESTART_LAST_VOTED_FORK_SLOTS ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_COUNT_RESTART_LAST_VOTED_FORK_SLOTS ) );
+  gossip_stats->storage_cnt_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_RESTART_HEAVIEST_FORK_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_COUNT_RESTART_HEAVIEST_FORK ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_COUNT_RESTART_HEAVIEST_FORK ) );
+
+  gossip_stats->storage_bytes_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_CONTACT_INFO_V1_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_BYTES_CONTACT_INFO_V1 ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_BYTES_CONTACT_INFO_V1 ) );
+  gossip_stats->storage_bytes_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_VOTE_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_BYTES_VOTE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_BYTES_VOTE ) );
+  gossip_stats->storage_bytes_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_LOWEST_SLOT_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_BYTES_LOWEST_SLOT ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_BYTES_LOWEST_SLOT ) );
+  gossip_stats->storage_bytes_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_SNAPSHOT_HASHES_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_BYTES_SNAPSHOT_HASHES ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_BYTES_SNAPSHOT_HASHES ) );
+  gossip_stats->storage_bytes_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_ACCOUNTS_HASHES_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_BYTES_ACCOUNTS_HASHES ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_BYTES_ACCOUNTS_HASHES ) );
+  gossip_stats->storage_bytes_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_EPOCH_SLOTS_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_BYTES_EPOCH_SLOTS ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_BYTES_EPOCH_SLOTS ) );
+  gossip_stats->storage_bytes_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_VERSION_V1_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_BYTES_VERSION_V1 ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_BYTES_VERSION_V1 ) );
+  gossip_stats->storage_bytes_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_VERSION_V2_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_BYTES_VERSION_V2 ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_BYTES_VERSION_V2 ) );
+  gossip_stats->storage_bytes_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_NODE_INSTANCE_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_BYTES_NODE_INSTANCE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_BYTES_NODE_INSTANCE ) );
+  gossip_stats->storage_bytes_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_DUPLICATE_SHRED_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_BYTES_DUPLICATE_SHRED ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_BYTES_DUPLICATE_SHRED ) );
+  gossip_stats->storage_bytes_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_INCREMENTAL_SNAPSHOT_HASHES_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_BYTES_INCREMENTAL_SNAPSHOT_HASHES ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_BYTES_INCREMENTAL_SNAPSHOT_HASHES ) );
+  gossip_stats->storage_bytes_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_CONTACT_INFO_V2_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_BYTES_CONTACT_INFO_V2 ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_BYTES_CONTACT_INFO_V2 ) );
+  gossip_stats->storage_bytes_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_RESTART_LAST_VOTED_FORK_SLOTS_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_BYTES_RESTART_LAST_VOTED_FORK_SLOTS ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_BYTES_RESTART_LAST_VOTED_FORK_SLOTS ) );
+  gossip_stats->storage_bytes_tx[ FD_METRICS_ENUM_CRDS_VALUE_V_RESTART_HEAVIEST_FORK_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PUSH_BYTES_RESTART_HEAVIEST_FORK ) )
+    + fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, CRDS_TX_PULL_RESPONSE_BYTES_RESTART_HEAVIEST_FORK ) );
+
+  gossip_stats->messages_bytes_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PULL_REQUEST_IDX  ] = fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_SUCCESS_PULL_REQUEST ) );
+  gossip_stats->messages_bytes_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PULL_RESPONSE_IDX ] = fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_SUCCESS_PULL_RESPONSE ) );
+  gossip_stats->messages_bytes_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PUSH_IDX          ] = fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_SUCCESS_PUSH ) );
+  gossip_stats->messages_bytes_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PING_IDX          ] = fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_SUCCESS_PING ) );
+  gossip_stats->messages_bytes_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PONG_IDX          ] = fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_SUCCESS_PONG ) );
+  gossip_stats->messages_bytes_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PRUNE_IDX         ] = fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_BYTES_SUCCESS_PRUNE ) );
+
+  gossip_stats->messages_count_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PULL_REQUEST_IDX  ] =
+      fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_SUCCESS_PULL_REQUEST ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PULL_REQUEST_NOT_CONTACT_INFO ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PULL_REQUEST_LOOPBACK ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PULL_REQUEST_INACTIVE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PULL_REQUEST_WALLCLOCK ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PULL_REQUEST_SIGNATURE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PULL_REQUEST_SHRED_VERSION ) );
+  gossip_stats->messages_count_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PULL_RESPONSE_IDX ] =
+      fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_SUCCESS_PULL_RESPONSE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PULL_RESPONSE_NO_VALID_CRDS ) );
+  gossip_stats->messages_count_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PUSH_IDX          ] =
+      fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_SUCCESS_PUSH ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PUSH_NO_VALID_CRDS ) );
+  gossip_stats->messages_count_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PING_IDX          ] =
+      fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_SUCCESS_PING ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PING_SIGNATURE ) );
+  gossip_stats->messages_count_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PONG_IDX          ] =
+      fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_SUCCESS_PONG ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PONG_SIGNATURE ) );
+  gossip_stats->messages_count_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PRUNE_IDX         ] =
+      fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_SUCCESS_PRUNE ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PRUNE_DESTINATION ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PRUNE_WALLCLOCK ) )
+    + fd_gui_sum_tiles_counter( peers, "gossvf", gossvf_tile_cnt, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PRUNE_SIGNATURE ) );
+
+  gossip_stats->messages_bytes_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PULL_REQUEST_IDX  ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_BYTES_PULL_REQUEST ) );
+  gossip_stats->messages_bytes_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PULL_RESPONSE_IDX ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_BYTES_PULL_RESPONSE ) );
+  gossip_stats->messages_bytes_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PUSH_IDX          ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_BYTES_PUSH ) );
+  gossip_stats->messages_bytes_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PING_IDX          ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_BYTES_PING ) );
+  gossip_stats->messages_bytes_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PONG_IDX          ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_BYTES_PONG ) );
+  gossip_stats->messages_bytes_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PRUNE_IDX         ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_BYTES_PRUNE ) );
+
+  gossip_stats->messages_count_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PULL_REQUEST_IDX  ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_COUNT_PULL_REQUEST ) );
+  gossip_stats->messages_count_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PULL_RESPONSE_IDX ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_COUNT_PULL_RESPONSE ) );
+  gossip_stats->messages_count_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PUSH_IDX          ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_COUNT_PUSH ) );
+  gossip_stats->messages_count_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PING_IDX          ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_COUNT_PING ) );
+  gossip_stats->messages_count_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PONG_IDX          ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_COUNT_PONG ) );
+  gossip_stats->messages_count_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PRUNE_IDX         ] = fd_gui_sum_tiles_counter( peers, "gossip", gossip_tile_cnt, MIDX( COUNTER, GOSSIP, MESSAGE_TX_COUNT_PRUNE ) );
+}
+
+static int
+fd_gui_peers_contact_info_eq( fd_contact_info_t const * ci1,
+                              fd_contact_info_t const * ci2 ) {
+  int ci_eq =
+       ci1->shred_version                    == ci2->shred_version
+    && ci1->instance_creation_wallclock_nanos== ci2->instance_creation_wallclock_nanos
+ // && ci1->wallclock_nanos                  == ci2->wallclock_nanos
+    && ci1->version.client                   == ci2->version.client
+    && ci1->version.major                    == ci2->version.major
+    && ci1->version.minor                    == ci2->version.minor
+    && ci1->version.patch                    == ci2->version.patch
+    && ci1->version.commit                   == ci2->version.commit
+    && ci1->version.feature_set              == ci2->version.feature_set;
+
+    if( FD_LIKELY( !ci_eq ) ) return 0;
+    for( ulong j=0UL; j<(FD_CONTACT_INFO_SOCKET_CNT); j++ ) {
+      if( FD_LIKELY( !(ci1->sockets[ j ].addr==ci2->sockets[ j ].addr && ci1->sockets[ j ].port==ci2->sockets[ j ].port) ) ) return 0;
+    }
+    return 1;
+}
+
+void
+fd_gui_peers_handle_gossip_message( fd_gui_peers_ctx_t *  peers,
+                                    uchar const *         payload,
+                                    ulong                 payload_sz,
+                                    fd_ip4_port_t const * peer_sock,
+                                    int                   is_rx ) {
+  fd_gui_peers_node_t * peer = fd_gui_peers_node_sock_map_ele_query( peers->node_sock_map, peer_sock, NULL, peers->contact_info_table );
+
+  /* We set MAP_MULTI=1 since there are not guarantees that duplicates
+     sockets wont exist. In cases where we see multiple sockets the
+     update timestamp in fd_gui_peers_node_t is the tiebreaker */
+  for( fd_gui_peers_node_t * p = peer; p!=NULL; p=(fd_gui_peers_node_t *)fd_gui_peers_node_sock_map_ele_next_const( p, NULL, peers->contact_info_table ) ) {
+    if( peer->update_time_nanos>p->update_time_nanos ) peer = p;
+  }
+
+  if( FD_UNLIKELY( !peer ) ) return; /* NOP, peer not known yet */
+
+  fd_gossip_view_t view[ 1 ];
+  ulong decode_sz = fd_gossip_msg_parse( view, payload, payload_sz );
+  if( FD_UNLIKELY( !decode_sz ) ) return; /* NOP, msg unparsable */
+
+  FD_TEST( view->tag < FD_METRICS_ENUM_GOSSIP_MESSAGE_CNT );
+  fd_ptr_if( is_rx, &peer->gossvf_rx[ view->tag ], &peer->gossip_tx[ view->tag ] )->cur += payload_sz;
+  fd_ptr_if( is_rx, (fd_gui_peers_metric_rate_t *)&peer->gossvf_rx_sum, (fd_gui_peers_metric_rate_t *)&peer->gossip_tx_sum )->cur += payload_sz;
+#if LOGGING
+  if( is_rx ) FD_LOG_WARNING(("payload rx=%lu", payload_sz ));
+  else FD_LOG_WARNING(("payload tx=%lu", payload_sz ));
+#endif
+}
+
+int
+fd_gui_peers_handle_gossip_update( fd_gui_peers_ctx_t *               peers,
+                                   fd_gossip_update_message_t const * update,
+                                   long                               now ) {
+    switch( update->tag ) {
+      case FD_GOSSIP_UPDATE_TAG_CONTACT_INFO: {
+        /* origin_pubkey should be the same as the contact info pubkey */
+        if( FD_UNLIKELY( memcmp( update->contact_info.contact_info->pubkey.uc, update->origin_pubkey, 32UL ) ) ) {
+          char ci_pk[ FD_BASE58_ENCODED_32_SZ ];
+          char og_pk[ FD_BASE58_ENCODED_32_SZ ];
+          fd_base58_encode_32( update->contact_info.contact_info->pubkey.uc, NULL, ci_pk );
+          fd_base58_encode_32( update->origin_pubkey, NULL, og_pk );
+
+          FD_LOG_ERR(( "invariant violation: update->contact_info.contact_info->pubkey.uc=%s != update->origin_pubkey=%s ", ci_pk, og_pk ));
+        }
+        if( FD_UNLIKELY( update->contact_info.idx>=FD_CONTACT_INFO_TABLE_SIZE ) ) FD_LOG_ERR(( "unexpected contact_info_idx %lu >= %lu", update->contact_info.idx, FD_CONTACT_INFO_TABLE_SIZE ));
+        fd_gui_peers_node_t * peer = &peers->contact_info_table[ update->contact_info.idx ];
+
+        if( FD_LIKELY( peer->valid ) ) {
+#if LOGGING
+          char _pk[ FD_BASE58_ENCODED_32_SZ ];
+          fd_base58_encode_32( update->origin_pubkey, NULL, _pk );
+          FD_LOG_WARNING(("UPDATE %lu pk=%s", update->contact_info.idx, _pk ));
+#endif
+          /* invariant checks */
+          if( FD_UNLIKELY( memcmp( peer->contact_info.pubkey.uc, update->origin_pubkey, 32UL ) ) ) {
+            char ci_pk[ FD_BASE58_ENCODED_32_SZ ];
+            char og_pk[ FD_BASE58_ENCODED_32_SZ ];
+            fd_base58_encode_32( peer->contact_info.pubkey.uc, NULL, ci_pk );
+            fd_base58_encode_32( update->origin_pubkey, NULL, og_pk );
+
+            /* A new pubkey is not allowed to overwrite an existing valid index */
+            FD_LOG_ERR(( "invariant violation: peer->contact_info.pubkey.uc=%s != update->origin_pubkey=%s ", ci_pk, og_pk ));
+          }
+          FD_TEST( peer==fd_gui_peers_node_pubkey_map_ele_query_const( peers->node_pubkey_map, (fd_pubkey_t * )update->origin_pubkey, NULL, peers->contact_info_table ) );
+          fd_gui_peers_node_t * peer_sock = fd_gui_peers_node_sock_map_ele_query( peers->node_sock_map, &peer->contact_info.sockets[ FD_CONTACT_INFO_SOCKET_GOSSIP ], NULL, peers->contact_info_table );
+          int found = 0;
+          for( fd_gui_peers_node_t * p = peer_sock; !!p; p=(fd_gui_peers_node_t *)fd_gui_peers_node_sock_map_ele_next_const( p, NULL, peers->contact_info_table ) ) {
+            if( peer==p ) {
+              found = 1;
+              break;
+            }
+          }
+          FD_TEST( found );
+
+          /* update does nothing */
+          if( FD_UNLIKELY( fd_gui_peers_contact_info_eq( &peer->contact_info, update->contact_info.contact_info ) ) ) {
+            peer->contact_info.wallclock_nanos = update->contact_info.contact_info->wallclock_nanos;
+            return FD_GUI_PEERS_NODE_NOP;
+          }
+
+          fd_gui_peers_node_sock_map_idx_remove_fast( peers->node_sock_map, update->contact_info.idx, peers->contact_info_table );
+          fd_gui_peers_live_table_idx_remove        ( peers->live_table,    update->contact_info.idx, peers->contact_info_table );
+          fd_gui_peers_bandwidth_tracking_idx_remove( peers->bw_tracking,   update->contact_info.idx, peers->contact_info_table );
+
+          fd_memcpy( &peer->contact_info, update->contact_info.contact_info, sizeof(peer->contact_info) );
+          peer->update_time_nanos = now;
+
+          fd_gui_peers_bandwidth_tracking_idx_insert( peers->bw_tracking,   update->contact_info.idx, peers->contact_info_table );
+          fd_gui_peers_live_table_idx_insert        ( peers->live_table,    update->contact_info.idx, peers->contact_info_table );
+          fd_gui_peers_node_sock_map_idx_insert     ( peers->node_sock_map, update->contact_info.idx, peers->contact_info_table );
+
+          return FD_GUI_PEERS_NODE_UPDATE;
+        } else {
+          FD_TEST( !fd_gui_peers_node_pubkey_map_ele_query_const( peers->node_pubkey_map, &update->contact_info.contact_info->pubkey, NULL, peers->contact_info_table ) );
+#if LOGGING
+          char _pk[ FD_BASE58_ENCODED_32_SZ ];
+          fd_base58_encode_32( update->origin_pubkey, NULL, _pk );
+          FD_LOG_WARNING(( "ADD %lu pk=%s", update->contact_info.idx, _pk ));
+#endif
+          memset( &peer->gossvf_rx,     0, sizeof(peer->gossvf_rx) );
+          memset( &peer->gossip_tx,     0, sizeof(peer->gossip_tx) );
+          memset( &peer->gossvf_rx_sum, 0, sizeof(peer->gossvf_rx_sum) );
+          memset( &peer->gossip_tx_sum, 0, sizeof(peer->gossip_tx_sum) );
+          peer->has_node_info = 0;
+          peer->valid = 1;
+          peer->update_time_nanos = now;
+          fd_memcpy( &peer->contact_info, update->contact_info.contact_info, sizeof(peer->contact_info) );
+
+          /* update pubkey_map, sock_map */
+          fd_gui_peers_node_sock_map_idx_insert  ( peers->node_sock_map,   update->contact_info.idx, peers->contact_info_table );
+          fd_gui_peers_node_pubkey_map_idx_insert( peers->node_pubkey_map, update->contact_info.idx, peers->contact_info_table );
+
+          /* update live tables */
+          fd_gui_peers_live_table_idx_insert        ( peers->live_table,  update->contact_info.idx, peers->contact_info_table );
+          fd_gui_peers_bandwidth_tracking_idx_insert( peers->bw_tracking, update->contact_info.idx, peers->contact_info_table );
+
+          fd_gui_printf_peers_view_resize( peers, fd_gui_peers_live_table_ele_cnt( peers->live_table ) );
+          FD_TEST( !fd_http_server_ws_broadcast( peers->http ) );
+
+          return FD_GUI_PEERS_NODE_ADD;
+        }
+
+        break;
+      }
+      case FD_GOSSIP_UPDATE_TAG_CONTACT_INFO_REMOVE: {
+        if( FD_UNLIKELY( update->contact_info_remove.idx>=FD_CONTACT_INFO_TABLE_SIZE ) ) FD_LOG_ERR(( "unexpected remove_contact_info_idx %lu >= %lu", update->contact_info_remove.idx, FD_CONTACT_INFO_TABLE_SIZE ));
+#if LOGGING
+        char _pk[ FD_BASE58_ENCODED_32_SZ ];
+        fd_base58_encode_32( update->origin_pubkey, NULL, _pk );
+        FD_LOG_WARNING(( "REMOVE %lu pk=%s",update->contact_info.idx, _pk ));
+#endif
+
+        fd_gui_peers_node_t * peer = &peers->contact_info_table[ update->contact_info_remove.idx ];
+
+        /* invariant checks */
+        FD_TEST( peer->valid ); /* Should have already been in the table */
+        FD_TEST( peer==fd_gui_peers_node_pubkey_map_ele_query_const( peers->node_pubkey_map, (fd_pubkey_t * )update->origin_pubkey, NULL, peers->contact_info_table ) );
+        fd_gui_peers_node_t * peer_sock = fd_gui_peers_node_sock_map_ele_query( peers->node_sock_map, &peer->contact_info.sockets[ FD_CONTACT_INFO_SOCKET_GOSSIP ], NULL, peers->contact_info_table );
+        int found = 0;
+        for( fd_gui_peers_node_t const * p = peer_sock; !!p; p=(fd_gui_peers_node_t const *)fd_gui_peers_node_sock_map_ele_next_const( p, NULL, peers->contact_info_table ) ) {
+          if( peer==p ) {
+            found = 1;
+            break;
+          }
+        }
+        FD_TEST( found );
+
+        fd_gui_peers_live_table_idx_remove          ( peers->live_table,      update->contact_info_remove.idx, peers->contact_info_table );
+        fd_gui_peers_bandwidth_tracking_idx_remove  ( peers->bw_tracking,     update->contact_info_remove.idx, peers->contact_info_table );
+        fd_gui_peers_node_sock_map_idx_remove_fast  ( peers->node_sock_map,   update->contact_info_remove.idx, peers->contact_info_table );
+        fd_gui_peers_node_pubkey_map_idx_remove_fast( peers->node_pubkey_map, update->contact_info_remove.idx, peers->contact_info_table );
+        peer->valid = 0;
+
+        fd_gui_printf_peers_view_resize( peers, fd_gui_peers_live_table_ele_cnt( peers->live_table ) );
+        FD_TEST( !fd_http_server_ws_broadcast( peers->http ) );
+        break;
+      }
+      default: break;
+    }
+
+    return FD_GUI_PEERS_NODE_NOP;
+}
+
+static void
+fd_gui_peers_viewport_snap( fd_gui_peers_ctx_t * peers, ulong ws_conn_id ) {
+  FD_TEST( peers->client_viewports[ ws_conn_id ].connected );
+  if( !(peers->client_viewports[ ws_conn_id ].row_cnt && peers->client_viewports[ ws_conn_id ].row_cnt<FD_GUI_PEERS_WS_VIEWPORT_MAX_SZ) ) FD_LOG_ERR(("row_cnt=%lu", peers->client_viewports[ ws_conn_id ].row_cnt ));
+
+  if( FD_UNLIKELY( fd_gui_peers_live_table_active_sort_key_cnt( peers->live_table )==FD_GUI_PEERS_CI_TABLE_SORT_KEY_CNT ) ) {
+    /* we're out of cached sort keys. disconnect the oldest client */
+    ulong oldest_ws_conn_id    = ULONG_MAX;
+    long oldest_connected_time = LONG_MAX;
+    for( ulong i=0UL; i<peers->max_ws_conn_cnt; i++ ) {
+      if( FD_UNLIKELY( peers->client_viewports[ i ].connected && peers->client_viewports[ i ].connected_time < oldest_connected_time ) ) {
+        oldest_ws_conn_id = i;
+        oldest_connected_time = peers->client_viewports[ i ].connected_time;
+      }
+    }
+    FD_TEST( oldest_ws_conn_id!=ULONG_MAX );
+    fd_gui_peers_live_table_sort_key_remove( peers->live_table, peers->client_viewports[ oldest_ws_conn_id ].sort_key );
+    FD_TEST( fd_gui_peers_live_table_active_sort_key_cnt( peers->live_table )==FD_GUI_PEERS_CI_TABLE_SORT_KEY_CNT-1UL );
+  }
+
+  for( fd_gui_peers_live_table_fwd_iter_t iter = fd_gui_peers_live_table_fwd_iter_init( peers->live_table, peers->client_viewports[ ws_conn_id ].sort_key, peers->contact_info_table ), j = 0;
+       !fd_gui_peers_live_table_fwd_iter_done( iter ) && j<peers->client_viewports[ ws_conn_id ].start_row+peers->client_viewports[ ws_conn_id ].row_cnt;
+       iter = fd_gui_peers_live_table_fwd_iter_next( iter, peers->contact_info_table ), j++ ) {
+    if( FD_LIKELY( j<peers->client_viewports[ ws_conn_id ].start_row ) ) continue;
+    fd_gui_peers_node_t const * cur = fd_gui_peers_live_table_fwd_iter_ele_const( iter, peers->contact_info_table );
+    fd_gui_peers_node_t * ref = &peers->client_viewports[ ws_conn_id ].viewport[ j ];
+
+    fd_memcpy( ref, cur, sizeof(fd_gui_peers_node_t) );
+  }
+}
+
+static int
+fd_gui_peers_request_scroll( fd_gui_peers_ctx_t * peers,
+                             ulong                ws_conn_id,
+                             ulong                request_id,
+                             cJSON const *        params ) {
+  if( FD_UNLIKELY( !peers->client_viewports[ ws_conn_id ].connected ) ) return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
+
+  const cJSON * start_row_param = cJSON_GetObjectItemCaseSensitive( params, "start_row" );
+  if( FD_UNLIKELY( !cJSON_IsNumber( start_row_param ) ) ) return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
+  ulong _start_row = start_row_param->valueulong;
+
+  const cJSON * row_cnt_param = cJSON_GetObjectItemCaseSensitive( params, "row_cnt" );
+  if( FD_UNLIKELY( !cJSON_IsNumber( row_cnt_param ) ) ) return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
+  ulong _row_cnt = row_cnt_param->valueulong;
+
+  if( FD_UNLIKELY( _row_cnt==0 || _row_cnt > FD_GUI_PEERS_WS_VIEWPORT_MAX_SZ ) ) {
+    fd_gui_printf_null_query_response( peers->http, "gossip", "query_scroll", request_id );
+    FD_TEST( !fd_http_server_ws_send( peers->http, ws_conn_id ) );
+    return 0;
+  }
+
+  if( FD_UNLIKELY( peers->client_viewports[ ws_conn_id ].start_row==_start_row && peers->client_viewports[ ws_conn_id ].row_cnt==_row_cnt ) ) {
+    return 0; /* NOP, scroll window hasn't changed */
+  }
+
+  /* update the client's viewport */
+  peers->client_viewports[ ws_conn_id ].start_row = _start_row;
+  peers->client_viewports[ ws_conn_id ].row_cnt   = _row_cnt;
+
+  fd_gui_printf_peers_viewport_request( peers, "query_scroll", ws_conn_id, request_id );
+  FD_TEST( !fd_http_server_ws_send( peers->http, ws_conn_id ) );
+  return 0;
+}
+
+static int
+fd_gui_peers_request_sort( fd_gui_peers_ctx_t * peers,
+                           ulong                ws_conn_id,
+                           ulong                request_id,
+                           cJSON const *        params ) {
+  if( FD_UNLIKELY( !peers->client_viewports[ ws_conn_id ].connected ) ) return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
+
+  const cJSON * col_id_param = cJSON_GetObjectItemCaseSensitive( params, "col_id" );
+  if( FD_UNLIKELY( !cJSON_IsString( col_id_param ) ) ) return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
+  char * _col_name = col_id_param->valuestring;
+
+  ulong _col_idx = fd_gui_peers_live_table_col_name_to_idx( peers->live_table, _col_name );
+  if( FD_UNLIKELY( _col_idx==ULONG_MAX) ) return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
+  ulong sort_idx = ULONG_MAX;
+  for( ulong i=0UL; i<FD_GUI_PEERS_CI_TABLE_SORT_KEY_CNT; i++ ) {
+    if( FD_UNLIKELY( _col_idx==peers->client_viewports[ ws_conn_id ].sort_key->col[ i ] ) ) {
+      sort_idx = i;
+      break;
+    }
+  }
+  FD_TEST( sort_idx!=ULONG_MAX );
+
+  const cJSON * dir_param = cJSON_GetObjectItemCaseSensitive( params, "dir" );
+  if( FD_UNLIKELY( !cJSON_IsNumber( dir_param ) ) ) return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
+  int _dir = dir_param->valueint;
+
+  if( FD_UNLIKELY( _dir > 1 || _dir < -1 ) ) return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
+
+  if( FD_UNLIKELY( peers->client_viewports[ ws_conn_id ].sort_key->dir[ sort_idx ]==_dir ) ) return 0; /* NOP, sort_key hasn't changed */
+
+  /* shift the column to the front of the sort key */
+  for( ulong i=sort_idx; i>0; i-- ) {
+    peers->client_viewports[ ws_conn_id ].sort_key->col[ i ] = peers->client_viewports[ ws_conn_id ].sort_key->col[ i-1UL ];
+    peers->client_viewports[ ws_conn_id ].sort_key->dir[ i ] = peers->client_viewports[ ws_conn_id ].sort_key->dir[ i-1UL ];
+  }
+  peers->client_viewports[ ws_conn_id ].sort_key->col[ 0 ] = _col_idx;
+  peers->client_viewports[ ws_conn_id ].sort_key->dir[ 0 ] = _dir;
+
+  if( FD_UNLIKELY( peers->client_viewports[ ws_conn_id ].row_cnt==0 )) return 0; /* NOP */
+
+  fd_gui_printf_peers_viewport_request( peers, "query_sort_col", ws_conn_id, request_id );
+  FD_TEST( !fd_http_server_ws_send( peers->http, ws_conn_id ) );
+  return 0;
+}
+
+int
+fd_gui_peers_ws_message( fd_gui_peers_ctx_t * peers,
+                         ulong                ws_conn_id,
+                         uchar const *        data,
+                         ulong                data_len ) {
+  /* TODO: cJSON allocates, might fail SIGSYS due to brk(2)...
+     switch off this (or use wksp allocator) */
+  const char * parse_end;
+  cJSON * json = cJSON_ParseWithLengthOpts( (char *)data, data_len, &parse_end, 0 );
+  if( FD_UNLIKELY( !json ) ) {
+    return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
+  }
+
+  const cJSON * node = cJSON_GetObjectItemCaseSensitive( json, "id" );
+  if( FD_UNLIKELY( !cJSON_IsNumber( node ) ) ) {
+    cJSON_Delete( json );
+    return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
+  }
+  ulong id = node->valueulong;
+
+  const cJSON * topic = cJSON_GetObjectItemCaseSensitive( json, "topic" );
+  if( FD_UNLIKELY( !cJSON_IsString( topic ) || topic->valuestring==NULL ) ) {
+    cJSON_Delete( json );
+    return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
+  }
+
+  const cJSON * key = cJSON_GetObjectItemCaseSensitive( json, "key" );
+  if( FD_UNLIKELY( !cJSON_IsString( key ) || key->valuestring==NULL ) ) {
+    cJSON_Delete( json );
+    return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
+  }
+
+  if( FD_LIKELY( !strcmp( topic->valuestring, "gossip" ) && !strcmp( key->valuestring, "query_sort_col" ) ) ) {
+    const cJSON * params = cJSON_GetObjectItemCaseSensitive( json, "params" );
+    if( FD_UNLIKELY( !cJSON_IsObject( params ) ) ) {
+      cJSON_Delete( json );
+      return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
+    }
+
+    int result = fd_gui_peers_request_sort( peers, ws_conn_id, id, params );
+    cJSON_Delete( json );
+    return result;
+  } else if( FD_LIKELY( !strcmp( topic->valuestring, "gossip" ) && !strcmp( key->valuestring, "query_scroll" ) ) ) {
+    const cJSON * params = cJSON_GetObjectItemCaseSensitive( json, "params" );
+    if( FD_UNLIKELY( !cJSON_IsObject( params ) ) ) {
+      cJSON_Delete( json );
+      return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
+    }
+
+    int result = fd_gui_peers_request_scroll( peers, ws_conn_id, id, params );
+    cJSON_Delete( json );
+    return result;
+  }
+
+  cJSON_Delete( json );
+  return FD_HTTP_SERVER_CONNECTION_CLOSE_UNKNOWN_METHOD;
+}
+
+static void
+fd_gui_peers_viewport_log( fd_gui_peers_ctx_t *  peers,
+                           ulong                 ws_conn_id) {
+
+  FD_TEST( peers->client_viewports[ ws_conn_id ].row_cnt && peers->client_viewports[ ws_conn_id ].row_cnt < FD_GUI_PEERS_WS_VIEWPORT_MAX_SZ );
+
+  char out[ 1<<14 ];
+  char * p = fd_cstr_init( out );
+
+  p = fd_cstr_append_printf( p,
+    "\n[Viewport] table_size=%lu max_viewport_size=%lu\n"
+    "+-------+----------------+----------------+----------------+----------------+----------------------------------------------------+-----------------+\n"
+    "| Row # | RX Push (bps)  | RX Pull (bps)  | TX Push (bps)  | TX Pull (bps)  | Pubkey                                             | IP Address      |\n"
+    "+-------+----------------+----------------+----------------+----------------+----------------------------------------------------+-----------------+\n",
+    fd_gui_peers_live_table_ele_cnt( peers->live_table ), peers->client_viewports[ ws_conn_id ].row_cnt );
+
+  FD_TEST( peers->client_viewports[ ws_conn_id ].connected );
+  for( fd_gui_peers_live_table_fwd_iter_t iter = fd_gui_peers_live_table_fwd_iter_init( peers->live_table, peers->client_viewports[ ws_conn_id ].sort_key, peers->contact_info_table ), j = 0UL;
+       !fd_gui_peers_live_table_fwd_iter_done(iter) && j < peers->client_viewports[ ws_conn_id ].start_row + peers->client_viewports[ ws_conn_id ].row_cnt;
+       iter = fd_gui_peers_live_table_fwd_iter_next(iter, peers->contact_info_table), j++ ) {
+    if( FD_LIKELY( j < peers->client_viewports[ ws_conn_id ].start_row ) ) continue;
+
+    fd_gui_peers_node_t const * cur = fd_gui_peers_live_table_fwd_iter_ele_const( iter, peers->contact_info_table );
+
+    char pubkey_base58[ FD_BASE58_ENCODED_32_SZ ];
+    fd_base58_encode_32( cur->contact_info.pubkey.uc, NULL, pubkey_base58 );
+
+    char peer_addr[ 16 ]; /* 255.255.255.255 + '\0' */
+    FD_TEST(fd_cstr_printf_check( peer_addr, sizeof(peer_addr), NULL, FD_IP4_ADDR_FMT,
+                                  FD_IP4_ADDR_FMT_ARGS( cur->contact_info.sockets[FD_CONTACT_INFO_SOCKET_GOSSIP].addr ) ) );
+
+    long cur_egress_push_bps           = cur->gossip_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PUSH_IDX ].rate;
+    long cur_ingress_push_bps          = cur->gossvf_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PUSH_IDX ].rate;
+    long cur_egress_pull_response_bps  = cur->gossip_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PULL_RESPONSE_IDX ].rate;
+    long cur_ingress_pull_response_bps = cur->gossvf_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PULL_RESPONSE_IDX ].rate;
+
+    p = fd_cstr_append_printf( p,
+                               "| %5lu | %14ld | %14ld | %14ld | %14ld | %-50s | %-15s |\n",
+                               peers->client_viewports[ ws_conn_id ].start_row + j,
+                               cur_ingress_push_bps,
+                               cur_ingress_pull_response_bps,
+                               cur_egress_push_bps,
+                               cur_egress_pull_response_bps,
+                               pubkey_base58,
+                               peer_addr );
+  }
+  p = fd_cstr_append_printf(p, "+-------+----------------+----------------+----------------+----------------+----------------------------------------------------+-----------------+" );
+  fd_cstr_fini( p );
+  FD_LOG_NOTICE(( "%s", out ));
+}
+
+static void
+fd_gui_peers_ws_conn_rr_grow( fd_gui_peers_ctx_t * peers, ulong ws_conn_id ) {
+  if( FD_UNLIKELY( !peers->open_ws_conn_cnt ) ) peers->active_ws_conn_id = ws_conn_id;
+  peers->open_ws_conn_cnt++;
+}
+
+static void
+fd_gui_peers_ws_conn_rr_shrink( fd_gui_peers_ctx_t * peers, ulong ws_conn_id ) {
+  peers->open_ws_conn_cnt--;
+
+  if( FD_UNLIKELY( peers->open_ws_conn_cnt && peers->active_ws_conn_id==ws_conn_id ) ) {
+    for( ulong i=0UL; i<peers->max_ws_conn_cnt; i++ ) {
+      ulong next_ws_conn_id = (ws_conn_id + i) % peers->max_ws_conn_cnt;
+      if( FD_UNLIKELY( peers->client_viewports[ next_ws_conn_id ].connected ) ) {
+        peers->active_ws_conn_id = next_ws_conn_id;
+        break;
+      }
+    }
+  }
+}
+
+static int
+fd_gui_peers_ws_conn_rr_advance( fd_gui_peers_ctx_t * peers, long now ) {
+  if( FD_LIKELY( !peers->open_ws_conn_cnt || now <= peers->next_client_nanos ) ) return 0;
+
+  for( ulong i=1UL; i<peers->max_ws_conn_cnt; i++ ) {
+    ulong next_ws_conn_id = (peers->active_ws_conn_id + i) % peers->max_ws_conn_cnt;
+    if( FD_UNLIKELY( peers->client_viewports[ next_ws_conn_id ].connected ) ) {
+      peers->active_ws_conn_id = next_ws_conn_id;
+      break;
+    }
+  }
+  return 1;
+}
+
+int
+fd_gui_peers_poll( fd_gui_peers_ctx_t * peers, long now ) {
+  int did_work = 0;
+
+  /* update client viewports in a round-robin */
+  if( FD_UNLIKELY( fd_gui_peers_ws_conn_rr_advance( peers, now ) ) ) {
+    FD_TEST( peers->client_viewports[ peers->active_ws_conn_id ].connected );
+    if( FD_LIKELY( peers->client_viewports[ peers->active_ws_conn_id ].row_cnt ) ) {
+      /* broadcast the diff as cell updates */
+      fd_gui_printf_peers_viewport_update( peers, peers->active_ws_conn_id );
+      FD_TEST( !fd_http_server_ws_send( peers->http, peers->active_ws_conn_id ) );
+
+      /* log the diff */
+      fd_gui_peers_viewport_log( peers, peers->active_ws_conn_id );
+      (void)fd_gui_peers_viewport_log;
+
+      /* update client state to the latest viewport */
+      fd_gui_peers_viewport_snap( peers, peers->active_ws_conn_id );
+    }
+
+    peers->next_client_nanos = now + ((FD_GUI_PEERS_WS_VIEWPORT_UPDATE_INTERVAL_MILLIS * 1000000L) / (long)peers->open_ws_conn_cnt);
+    did_work = 1;
+  }
+
+  if( FD_UNLIKELY( now >= peers->next_metric_rate_update_nanos ) ) {
+    for( fd_gui_peers_node_pubkey_map_iter_t iter = fd_gui_peers_node_pubkey_map_iter_init( peers->node_pubkey_map, peers->contact_info_table );
+         !fd_gui_peers_node_pubkey_map_iter_done( iter, peers->node_pubkey_map, peers->contact_info_table );
+         iter = fd_gui_peers_node_pubkey_map_iter_next( iter, peers->node_pubkey_map, peers->contact_info_table ) ) {
+      fd_gui_peers_node_t * peer = fd_gui_peers_node_pubkey_map_iter_ele( iter, peers->node_pubkey_map, peers->contact_info_table );
+
+      double window = (double)(now - (peers->next_metric_rate_update_nanos - (FD_GUI_PEERS_METRIC_RATE_UPDATE_INTERVAL_MILLIS * 1000000L)));
+
+      /* optimization: no need to remove / re-insert if the rates haven't changed */
+      int change = 0;
+      for( ulong i=0UL; i<FD_METRICS_ENUM_GOSSIP_MESSAGE_CNT; i++ ) {
+        fd_gui_peers_metric_rate_t * metric = &peer->gossvf_rx[ i ];
+        long new_rate = (long)(((double)((long)metric->cur - (long)metric->ref) * 1e9 / window));
+        if( FD_LIKELY( metric->rate == new_rate ) ) continue;
+        change = 1;
+        break;
+      }
+
+      if( !change) {
+        for( ulong i=0UL; i<FD_METRICS_ENUM_GOSSIP_MESSAGE_CNT; i++ ) {
+          fd_gui_peers_metric_rate_t * metric = &peer->gossip_tx[ i ];
+          long new_rate = (long)(((double)((long)metric->cur - (long)metric->ref) * 1e9 / window));
+          if( FD_LIKELY( metric->rate == new_rate ) ) continue;
+          change = 1;
+          break;
+        }
+      }
+
+      if( !change ) continue;
+
+      /* live_table */
+      fd_gui_peers_live_table_ele_remove( peers->live_table, peer, peers->contact_info_table );
+      for( ulong i=0UL; i<FD_METRICS_ENUM_GOSSIP_MESSAGE_CNT; i++ ) {
+        fd_gui_peers_metric_rate_t * metric = &peer->gossvf_rx[ i ];
+        metric->rate = (long)(((double)((long)metric->cur - (long)metric->ref) * 1e9 / window));
+        metric->ref  = metric->cur;
+      }
+
+      for( ulong i=0UL; i<FD_METRICS_ENUM_GOSSIP_MESSAGE_CNT; i++ ) {
+        fd_gui_peers_metric_rate_t * metric = &peer->gossip_tx[ i ];
+        metric->rate = (long)(((double)((long)metric->cur - (long)metric->ref) * 1e9 / window));
+        metric->ref  = metric->cur;
+      }
+      fd_gui_peers_live_table_ele_insert( peers->live_table, peer, peers->contact_info_table );
+
+      /* bandwidth_tracking */
+      fd_gui_peers_bandwidth_tracking_ele_remove( peers->bw_tracking, peer, peers->contact_info_table );
+      peer->gossvf_rx_sum.rate = (long)(((double)((long)peer->gossvf_rx_sum.cur - (long)peer->gossvf_rx_sum.ref) * 1e9 / window));
+      peer->gossvf_rx_sum.ref  = peer->gossvf_rx_sum.cur;
+
+      peer->gossip_tx_sum.rate = (long)(((double)((long)peer->gossip_tx_sum.cur - (long)peer->gossip_tx_sum.ref) * 1e9 / window));
+      peer->gossip_tx_sum.ref  = peer->gossip_tx_sum.cur;
+      fd_gui_peers_bandwidth_tracking_ele_insert( peers->bw_tracking, peer, peers->contact_info_table );
+    }
+
+    peers->next_metric_rate_update_nanos = now + (FD_GUI_PEERS_METRIC_RATE_UPDATE_INTERVAL_MILLIS * 1000000L);
+    did_work = 1;
+    fd_gui_peers_live_table_verify( peers->live_table, peers->contact_info_table ); /* todo ... remove */
+  }
+
+  if( FD_LIKELY( now >= peers->next_gossip_stats_update_nanos ) ) {
+    fd_gui_peers_gossip_stats_snap( peers, peers->gossip_stats, now );
+    fd_gui_peers_printf_gossip_stats( peers );
+    fd_http_server_ws_broadcast( peers->http );
+
+    peers->next_gossip_stats_update_nanos = now + (FD_GUI_PEERS_GOSSIP_STATS_UPDATE_INTERVAL_MILLIS * 1000000L);
+    did_work = 1;
+  }
+
+  return did_work;
+}
+
+void
+fd_gui_peers_ws_open( fd_gui_peers_ctx_t * peers, ulong ws_conn_id, long now ) {
+  fd_gui_peers_ws_conn_rr_grow( peers, ws_conn_id );
+  peers->client_viewports[ ws_conn_id ].connected = 1;
+  peers->client_viewports[ ws_conn_id ].connected_time = now;
+  peers->client_viewports[ ws_conn_id ].start_row = 0;
+  peers->client_viewports[ ws_conn_id ].row_cnt = 0;
+  fd_memcpy( peers->client_viewports[ ws_conn_id ].sort_key, &FD_GUI_PEERS_LIVE_TABLE_DEFAULT_SORT_KEY, sizeof(fd_gui_peers_live_table_sort_key_t) );
+}
+
+void
+fd_gui_peers_ws_close( fd_gui_peers_ctx_t * peers, ulong ws_conn_id ) {
+  fd_gui_peers_live_table_sort_key_remove( peers->live_table, peers->client_viewports[ ws_conn_id ].sort_key );
+  peers->client_viewports[ ws_conn_id ].connected = 0;
+  fd_gui_peers_ws_conn_rr_shrink( peers, ws_conn_id );
+}
+
+#undef LOGGING

--- a/src/disco/gui/fd_gui_peers.h
+++ b/src/disco/gui/fd_gui_peers.h
@@ -1,0 +1,327 @@
+#ifndef HEADER_fd_src_disco_gui_fd_gui_peers_h
+#define HEADER_fd_src_disco_gui_fd_gui_peers_h
+
+/* fd_gui_peers defines methods that maintain metrics and metadata about
+   Solana cluster peers that are active on the Gossip network.
+
+   Peer identifiers are added and removed by incoming update messages
+   from the gossip tile. Additional information about the peer is
+   obtained from other places and merged into the a large peers table
+   with live updates.
+
+   fd_gui_peers also defines methods for handling messages from a
+   WebSocket client. These messages contain peer related information,
+   including a live view of the peer table with the option to order the
+   table a custom sort key. */
+
+#include "../../util/net/fd_net_headers.h"
+#include "../../disco/metrics/fd_metrics.h"
+#include "../../flamenco/gossip/fd_gossip_types.h"
+#include "../../waltz/http/fd_http_server.h"
+#include "../topo/fd_topo.h"
+
+#define FD_GUI_PEERS_VALIDATOR_INFO_NAME_SZ     ( 64UL)
+#define FD_GUI_PEERS_VALIDATOR_INFO_WEBSITE_SZ  (128UL)
+#define FD_GUI_PEERS_VALIDATOR_INFO_DETAILS_SZ  (256UL)
+#define FD_GUI_PEERS_VALIDATOR_INFO_ICON_URI_SZ (128UL)
+
+#define FD_GUI_PEERS_NODE_NOP    (0)
+#define FD_GUI_PEERS_NODE_ADD    (1)
+#define FD_GUI_PEERS_NODE_UPDATE (2)
+#define FD_GUI_PEERS_NODE_DELETE (3)
+
+#define FD_GUI_PEERS_CI_TABLE_SORT_KEY_CNT                 (256UL) /* maximum number of maintained active sort keys */
+#define FD_GUI_PEERS_WS_VIEWPORT_MAX_SZ                    (200UL) /* the maximum number of rows a client can request for a table viewport */
+#define FD_GUI_PEERS_WS_VIEWPORT_UPDATE_INTERVAL_MILLIS    ( 100L)
+#define FD_GUI_PEERS_METRIC_RATE_UPDATE_INTERVAL_MILLIS    ( 100L)
+#define FD_GUI_PEERS_GOSSIP_STATS_UPDATE_INTERVAL_MILLIS   ( 100L)
+
+#define FD_GUI_PEERS_GOSSIP_TOP_PEERS_CNT (64UL)
+
+/* Some table columns are rates of change, which require keeping a
+   historical value / timestamp. */
+struct fd_gui_peers_metric_rate {
+  ulong cur;
+  ulong ref;
+  long rate; /* units per sec. live_table treaps use this field to sort table entries */
+};
+typedef struct fd_gui_peers_metric_rate fd_gui_peers_metric_rate_t;
+
+struct fd_gui_peers_node {
+  int valid;
+  long update_time_nanos;
+  fd_contact_info_t contact_info;
+
+  fd_gui_peers_metric_rate_t gossvf_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_CNT ];
+  fd_gui_peers_metric_rate_t gossip_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_CNT ];
+  fd_gui_peers_metric_rate_t gossvf_rx_sum; /* sum of gossvf_rx */
+  fd_gui_peers_metric_rate_t gossip_tx_sum; /* sum of gossip_tx */
+
+  int         has_node_info;
+  char name    [ FD_GUI_PEERS_VALIDATOR_INFO_NAME_SZ     ];
+  char website [ FD_GUI_PEERS_VALIDATOR_INFO_WEBSITE_SZ  ];
+  char details [ FD_GUI_PEERS_VALIDATOR_INFO_DETAILS_SZ  ];
+  char icon_uri[ FD_GUI_PEERS_VALIDATOR_INFO_ICON_URI_SZ ];
+
+  struct {
+    ulong next;
+    ulong prev;
+  } pubkey_map;
+
+  struct {
+    ulong next;
+    ulong prev;
+  } sock_map;
+
+  struct {
+    ulong parent;
+    ulong left;
+    ulong right;
+    ulong prio;
+    ulong next;
+    ulong prev;
+  } treaps_live_table[ FD_GUI_PEERS_CI_TABLE_SORT_KEY_CNT ];
+  struct {
+    ulong next;
+    ulong prev;
+  } dlist_live_table;
+  ulong sort_keys_live_table;
+
+  struct {
+    ulong parent;
+    ulong left;
+    ulong right;
+    ulong prio;
+    ulong next;
+    ulong prev;
+  } treaps_bandwidth_tracking[ 2UL ];
+    struct {
+    ulong next;
+    ulong prev;
+  } dlist_bandwidth_tracking;
+  ulong sort_keys_bandwidth_tracking;
+};
+typedef struct fd_gui_peers_node fd_gui_peers_node_t;
+
+struct fd_gui_peers_gossip_stats {
+  long  sample_time;
+  ulong network_health_pull_response_msg_rx_success;
+  ulong network_health_pull_response_msg_rx_failure;
+  ulong network_health_push_msg_rx_success;
+  ulong network_health_push_msg_rx_failure;
+  ulong network_health_push_crds_rx_duplicate;
+  ulong network_health_pull_response_crds_rx_duplicate;
+  ulong network_health_push_crds_rx_success;
+  ulong network_health_push_crds_rx_failure;
+  ulong network_health_pull_response_crds_rx_success;
+  ulong network_health_pull_response_crds_rx_failure;
+  ulong network_health_push_msg_tx;
+  ulong network_health_pull_response_msg_tx;
+  ulong network_health_total_stake; /* lamports */
+  ulong network_health_total_peers;
+  ulong network_health_connected_stake; /* lamports */
+  ulong network_health_connected_staked_peers;
+  ulong network_health_connected_unstaked_peers;
+  ulong network_ingress_total_bytes;
+  ulong network_ingress_peer_sz;
+  long  network_ingress_peer_bytes_per_sec   [ FD_GUI_PEERS_GOSSIP_TOP_PEERS_CNT ];
+  char  network_ingress_peer_names           [ FD_GUI_PEERS_GOSSIP_TOP_PEERS_CNT ][ FD_GUI_PEERS_VALIDATOR_INFO_NAME_SZ ];
+  fd_pubkey_t network_ingress_peer_identities[ FD_GUI_PEERS_GOSSIP_TOP_PEERS_CNT ];
+  long  network_ingress_total_bytes_per_sec;
+  ulong network_egress_total_bytes;
+  ulong network_egress_peer_sz;
+  long  network_egress_peer_bytes_per_sec   [ FD_GUI_PEERS_GOSSIP_TOP_PEERS_CNT ];
+  char  network_egress_peer_names           [ FD_GUI_PEERS_GOSSIP_TOP_PEERS_CNT ][ FD_GUI_PEERS_VALIDATOR_INFO_NAME_SZ ];
+  fd_pubkey_t network_egress_peer_identities[ FD_GUI_PEERS_GOSSIP_TOP_PEERS_CNT ];
+  long  network_egress_total_bytes_per_sec;
+  ulong storage_capacity;
+  ulong storage_expired_cnt;
+  ulong storage_evicted_cnt;
+  ulong storage_active_cnt[ FD_METRICS_ENUM_CRDS_VALUE_CNT ];
+  ulong storage_cnt_tx    [ FD_METRICS_ENUM_CRDS_VALUE_CNT ];
+  ulong storage_bytes_tx  [ FD_METRICS_ENUM_CRDS_VALUE_CNT ];
+  ulong messages_push_rx_cnt;
+  ulong messages_push_tx_cnt;
+  ulong messages_pull_response_rx_cnt;
+  ulong messages_pull_response_tx_cnt;
+  ulong messages_bytes_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_CNT ];
+  ulong messages_count_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_CNT ];
+  ulong messages_bytes_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_CNT ];
+  ulong messages_count_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_CNT ];
+};
+typedef struct fd_gui_peers_gossip_stats fd_gui_peers_gossip_stats_t;
+
+#define MAP_NAME  fd_gui_peers_node_pubkey_map
+#define MAP_ELE_T fd_gui_peers_node_t
+#define MAP_KEY_T fd_pubkey_t
+#define MAP_KEY   contact_info.pubkey
+#define MAP_IDX_T ulong
+#define MAP_NEXT  pubkey_map.next
+#define MAP_PREV  pubkey_map.prev
+#define MAP_KEY_HASH(k,s) ((s) ^ fd_ulong_hash( (k)->ul[ 0 ] ))
+#define MAP_KEY_EQ(k0,k1) (!memcmp((k0)->uc, (k1)->uc, 32UL))
+#define MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL 1
+#include "../../util/tmpl/fd_map_chain.c"
+
+#define MAP_NAME  fd_gui_peers_node_sock_map
+#define MAP_ELE_T fd_gui_peers_node_t
+#define MAP_KEY_T fd_ip4_port_t
+#define MAP_KEY   contact_info.sockets[ FD_CONTACT_INFO_SOCKET_GOSSIP ]
+#define MAP_IDX_T ulong
+#define MAP_NEXT  sock_map.next
+#define MAP_PREV  sock_map.prev
+#define MAP_KEY_HASH(k,s) ( fd_hash( (s), (k), sizeof(uint) + sizeof(ushort) ) )
+#define MAP_KEY_EQ(k0,k1) ((k0)->l==(k1)->l )
+#define MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL 1
+#define MAP_MULTI 1
+#include "../../util/tmpl/fd_map_chain.c"
+
+static int live_table_col_pubkey_lt( void const * a, void const * b ) { return memcmp( ((fd_pubkey_t *)a)->uc, ((fd_pubkey_t *)b)->uc, 32UL ) < 0; }
+static int live_table_col_long_lt  ( void const * a, void const * b ) { return *(long *)a < *(long *)b;                                            }
+static int live_table_col_ipv4_lt  ( void const * a, void const * b ) { return fd_uint_bswap(*(uint *)a) < fd_uint_bswap(*(uint *)b);              }
+
+#define LIVE_TABLE_NAME fd_gui_peers_live_table
+#define LIVE_TABLE_TREAP treaps_live_table
+#define LIVE_TABLE_SORT_KEYS sort_keys_live_table
+#define LIVE_TABLE_DLIST dlist_live_table
+#define LIVE_TABLE_COLUMN_CNT (6UL)
+#define LIVE_TABLE_MAX_SORT_KEY_CNT FD_GUI_PEERS_CI_TABLE_SORT_KEY_CNT
+#define LIVE_TABLE_ROW_T fd_gui_peers_node_t
+#define LIVE_TABLE_COLUMNS LIVE_TABLE_COL_ARRAY( \
+  LIVE_TABLE_COL_ENTRY( "Ingress Push", gossvf_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PUSH_IDX ].rate,          live_table_col_long_lt   ), \
+  LIVE_TABLE_COL_ENTRY( "Ingress Pull", gossvf_rx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PULL_RESPONSE_IDX ].rate, live_table_col_long_lt   ), \
+  LIVE_TABLE_COL_ENTRY( "Egress Push",  gossip_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PUSH_IDX ].rate,          live_table_col_long_lt   ), \
+  LIVE_TABLE_COL_ENTRY( "Egress Pull",  gossip_tx[ FD_METRICS_ENUM_GOSSIP_MESSAGE_V_PULL_RESPONSE_IDX ].rate, live_table_col_long_lt   ), \
+  LIVE_TABLE_COL_ENTRY( "Pubkey",       contact_info.pubkey,                                                  live_table_col_pubkey_lt ), \
+  LIVE_TABLE_COL_ENTRY( "IP Addr",      contact_info.sockets[ FD_CONTACT_INFO_SOCKET_GOSSIP ].addr,           live_table_col_ipv4_lt   )  )
+#include "fd_gui_live_table_tmpl.c"
+
+#define FD_GUI_PEERS_LIVE_TABLE_DEFAULT_SORT_KEY ((fd_gui_peers_live_table_sort_key_t){ .col = { 0, 1, 2, 3, 4, 5 }, .dir = { -1, -1, -1, -1, -1, -1 } })
+
+#define LIVE_TABLE_NAME fd_gui_peers_bandwidth_tracking
+#define LIVE_TABLE_TREAP treaps_bandwidth_tracking
+#define LIVE_TABLE_SORT_KEYS sort_keys_bandwidth_tracking
+#define LIVE_TABLE_DLIST dlist_bandwidth_tracking
+#define LIVE_TABLE_COLUMN_CNT (2UL)
+#define LIVE_TABLE_MAX_SORT_KEY_CNT (2UL)
+#define LIVE_TABLE_ROW_T fd_gui_peers_node_t
+#define LIVE_TABLE_COLUMNS LIVE_TABLE_COL_ARRAY( \
+  LIVE_TABLE_COL_ENTRY( "Ingress Total", gossvf_rx_sum.rate, live_table_col_long_lt ), \
+  LIVE_TABLE_COL_ENTRY( "Egress Total",  gossip_tx_sum.rate, live_table_col_long_lt )  )
+#include "fd_gui_live_table_tmpl.c"
+
+#define FD_GUI_PEERS_BW_TRACKING_INGRESS_SORT_KEY ((fd_gui_peers_bandwidth_tracking_sort_key_t){ .col = { 0, 1 }, .dir = { -1, 0 } })
+#define FD_GUI_PEERS_BW_TRACKING_EGRESS_SORT_KEY  ((fd_gui_peers_bandwidth_tracking_sort_key_t){ .col = { 0, 1 }, .dir = { 0, -1 } })
+
+struct fd_gui_peers_ws_conn {
+  int connected;
+  long connected_time;
+
+  ulong start_row;
+  ulong row_cnt;
+  fd_gui_peers_node_t viewport[ FD_GUI_PEERS_WS_VIEWPORT_MAX_SZ ];
+  fd_gui_peers_live_table_sort_key_t sort_key[ 1 ];
+};
+typedef struct fd_gui_peers_ws_conn fd_gui_peers_ws_conn_t;
+struct fd_gui_peers_ctx {
+  long next_client_nanos; /* ns timestamp when we'll service the next ws client */
+  long next_metric_rate_update_nanos; /* ns timestamp when we'll next update rate-of-change metrics */
+  long next_gossip_stats_update_nanos; /* ns timestamp when we'll next broadcast out gossip stats message */
+
+  fd_gui_peers_node_pubkey_map_t * node_pubkey_map;
+  fd_gui_peers_node_sock_map_t  * node_sock_map;
+  fd_gui_peers_live_table_t * live_table;
+  fd_gui_peers_bandwidth_tracking_t * bw_tracking;
+
+  fd_http_server_t * http;
+  fd_topo_t * topo;
+
+  ulong max_ws_conn_cnt;
+  ulong open_ws_conn_cnt;
+  ulong active_ws_conn_id;
+  fd_gui_peers_ws_conn_t * client_viewports; /* points to 2D array with max_ws_conn_cnt rows and FD_GUI_PEERS_WS_VIEWPORT_MAX_SZ columns */
+
+  fd_gui_peers_gossip_stats_t gossip_stats  [ 1 ];
+  fd_gui_peers_node_t contact_info_table[ FD_CONTACT_INFO_TABLE_SIZE ];
+};
+typedef struct fd_gui_peers_ctx fd_gui_peers_ctx_t;
+
+FD_PROTOTYPES_BEGIN
+
+FD_FN_CONST ulong
+fd_gui_peers_align( void );
+
+FD_FN_CONST ulong
+fd_gui_peers_footprint( ulong max_ws_conn_cnt );
+
+void *
+fd_gui_peers_new( void *             shmem,
+                  fd_http_server_t * http,
+                  fd_topo_t *        topo,
+                  ulong              max_ws_conn_cnt,
+                  long               now );
+
+fd_gui_peers_ctx_t *
+fd_gui_peers_join( void * shmem );
+
+/* fd_gui_peers_handle_gossip_message_rx parses gossip messages from the
+   net_gossvf link for ingress messages and the gossip_net link for
+   egress messages and tracks per-peer, per-message bytes.  payload and
+   payload_sz corresponds to the frag data after the network headers
+   have been stripped. is_rx is true if the frag is an incoming message
+   from the net_gossvf link. Otherwise, the frag is assumed to be an
+   outgoing message from the gossip_net link. peer_sock is the ipv4
+   address and port from the stripped net headers, which identifies the
+   peers that sent or will receive the message.
+
+   Note that gossip_net frags are unverified gossip messages from the
+   network.  Messages that cannot be parsed are ignored. */
+void
+fd_gui_peers_handle_gossip_message( fd_gui_peers_ctx_t *  peers,
+                                    uchar const *         payload,
+                                    ulong                 payload_sz,
+                                    fd_ip4_port_t const * peer_sock,
+                                    int                   is_rx );
+
+/* fd_gui_peers_handle_gossip_message_tx parses frags on the gossip_out
+   link and uses the contact info update to build up the peer table.
+   */
+int
+fd_gui_peers_handle_gossip_update( fd_gui_peers_ctx_t *               peers,
+                                   fd_gossip_update_message_t const * update,
+                                   long                               now );
+
+/* fd_gui_peers_ws_message handles incoming websocket request payloads
+   requesting peer-related responses.  ws_conn_id is the connection id
+   of the requester.  data is a pointer to the start of the
+   json-formatted request payload.  data_len is the length of the
+   request payload. */
+int
+fd_gui_peers_ws_message( fd_gui_peers_ctx_t * peers,
+                         ulong                ws_conn_id,
+                         uchar const *        data,
+                         ulong                data_len );
+
+/* fd_gui_peers_ws_open is a callback which should be triggered when a
+   new client opens a WebSocket connection.  ws_conn_id is the
+   connection id of the new client.  now is a UNIX nanosecond timestamp
+   for the current time. */
+void
+fd_gui_peers_ws_open( fd_gui_peers_ctx_t * peers, ulong ws_conn_id, long now );
+
+/* fd_gui_peers_ws_close is a callback which should be triggered when an
+   existing client closes their WebSocket connection.  ws_conn_id is the
+   connection id of the client.*/
+void
+fd_gui_peers_ws_close( fd_gui_peers_ctx_t * peers, ulong ws_conn_id );
+
+/* fd_gui_peers_poll should be called in a the tile's main spin loop to
+   periodically update peers internal state as well as publish new
+   Websocket messages to clients. now is a UNIX nanosecond timestamp for
+   the current time. */
+int
+fd_gui_peers_poll( fd_gui_peers_ctx_t * peers, long now  );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_disco_gui_fd_gui_peers_h */

--- a/src/disco/gui/fd_gui_printf.h
+++ b/src/disco/gui/fd_gui_printf.h
@@ -15,12 +15,14 @@ void fd_gui_printf_vote_key( fd_gui_t * gui );
 void fd_gui_printf_startup_time_nanos( fd_gui_t * gui );
 void fd_gui_printf_vote_state( fd_gui_t * gui );
 void fd_gui_printf_vote_distance( fd_gui_t * gui );
-void fd_gui_printf_slot_max_known( fd_gui_t * gui );
+void fd_gui_printf_turbine_slot( fd_gui_t * gui );
+void fd_gui_printf_repair_slot( fd_gui_t * gui );
 void fd_gui_printf_slot_caught_up( fd_gui_t * gui );
 void fd_gui_printf_skipped_history( fd_gui_t * gui );
 void fd_gui_printf_skipped_history_cluster( fd_gui_t * gui );
 void fd_gui_printf_tps_history( fd_gui_t * gui );
 void fd_gui_printf_startup_progress( fd_gui_t * gui );
+void fd_gui_printf_boot_progress( fd_gui_t * gui );
 void fd_gui_printf_block_engine( fd_gui_t * gui );
 void fd_gui_printf_tiles( fd_gui_t * gui );
 void fd_gui_printf_schedule_strategy( fd_gui_t * gui );
@@ -119,5 +121,21 @@ void
 fd_gui_printf_live_tile_stats( fd_gui_t *                  gui,
                                fd_gui_tile_stats_t const * prev,
                                fd_gui_tile_stats_t const * cur );
+
+void
+fd_gui_printf_peers_viewport_update( fd_gui_peers_ctx_t *  peers,
+                                     ulong                 ws_conn_id );
+
+void
+fd_gui_printf_peers_viewport_request( fd_gui_peers_ctx_t *  peers,
+                                      char const *          key,
+                                      ulong                 ws_conn_id,
+                                      ulong                 request_id );
+
+void
+fd_gui_printf_peers_view_resize( fd_gui_peers_ctx_t *  peers, ulong sz );
+
+void
+fd_gui_peers_printf_gossip_stats( fd_gui_peers_ctx_t *  peers );
 
 #endif /* HEADER_fd_src_disco_gui_fd_gui_printf_h */

--- a/src/discof/restore/Local.mk
+++ b/src/discof/restore/Local.mk
@@ -1,4 +1,5 @@
 ifdef FD_HAS_SSE
+$(call add-hdrs,fd_snaprd_tile.h)
 $(call add-objs,fd_snaprd_tile,fd_discof)
 ifdef FD_HAS_ZSTD
 $(call add-objs,fd_snapdc_tile,fd_discof)

--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -135,8 +135,8 @@ scratch_footprint( fd_topo_tile_t const * tile ) {
 
 static void
 metrics_write( fd_snapin_tile_t * ctx ) {
-  // FD_MGAUGE_SET( SNAPIN, FULL_BYTES_READ, ctx->metrics.full_bytes_read );
-  // FD_MGAUGE_SET( SNAPIN, INCREMENTAL_BYTES_READ, ctx->metrics.incremental_bytes_read );
+  FD_MGAUGE_SET( SNAPIN, FULL_BYTES_READ, ctx->metrics.full_bytes_read );
+  FD_MGAUGE_SET( SNAPIN, INCREMENTAL_BYTES_READ, ctx->metrics.incremental_bytes_read );
 
   FD_MGAUGE_SET( SNAPIN, ACCOUNTS_INSERTED, ctx->metrics.accounts_inserted );
   FD_MGAUGE_SET( SNAPIN, STATE, (ulong)ctx->state );

--- a/src/discof/restore/fd_snaprd_tile.h
+++ b/src/discof/restore/fd_snaprd_tile.h
@@ -17,11 +17,11 @@
 #define FD_SNAPRD_STATE_READING_FULL_FILE         ( 2) /* Full file looks better than peer, reading it from disk */
 #define FD_SNAPRD_STATE_FLUSHING_FULL_FILE        ( 3) /* Full file was read ok, confirm it decompressed and inserted ok */
 #define FD_SNAPRD_STATE_FLUSHING_FULL_FILE_RESET  ( 4) /* Resetting to load full snapshot from file again, confirm decompress and inserter are reset too */
-#define FD_SNAPRD_STATE_READING_INCREMENTAL_FILE  ( 5) /* Incremental file looks better than peer, reading it from disk */
-#define FD_SNAPRD_STATE_FLUSHING_INCREMENTAL_FILE ( 6) /* Incremental file was read ok, confirm it decompressed and inserted ok */
-#define FD_SNAPRD_STATE_READING_FULL_HTTP         ( 7) /* Peer was selected, reading full snapshot from HTTP */
-#define FD_SNAPRD_STATE_FLUSHING_FULL_HTTP        ( 8) /* Full snapshot was downloaded ok, confirm it decompressed and inserted ok */
-#define FD_SNAPRD_STATE_FLUSHING_FULL_HTTP_RESET  ( 9) /* Resetting to load full snapshot from HTTP again, confirm decompress and inserter are reset too */
+#define FD_SNAPRD_STATE_READING_FULL_HTTP         ( 5) /* Peer was selected, reading full snapshot from HTTP */
+#define FD_SNAPRD_STATE_FLUSHING_FULL_HTTP        ( 6) /* Full snapshot was downloaded ok, confirm it decompressed and inserted ok */
+#define FD_SNAPRD_STATE_FLUSHING_FULL_HTTP_RESET  ( 7) /* Resetting to load full snapshot from HTTP again, confirm decompress and inserter are reset too */
+#define FD_SNAPRD_STATE_READING_INCREMENTAL_FILE  ( 8) /* Incremental file looks better than peer, reading it from disk */
+#define FD_SNAPRD_STATE_FLUSHING_INCREMENTAL_FILE ( 9) /* Incremental file was read ok, confirm it decompressed and inserted ok */
 #define FD_SNAPRD_STATE_READING_INCREMENTAL_HTTP  (10) /* Peer was selected, reading incremental snapshot from HTTP */
 #define FD_SNAPRD_STATE_FLUSHING_INCREMENTAL_HTTP (11) /* Incremental snapshot was downloaded ok, confirm it decompressed and inserted ok */
 #define FD_SNAPRD_STATE_SHUTDOWN                  (12) /* The tile is done, and has likely already exited */
@@ -45,5 +45,14 @@ fd_snaprd_state_str( ulong state ) {
     default:                                        return "unknown";
   }
 }
+
+#define FD_SNAPRD_SNAPSHOT_TYPE_FULL        (0)
+#define FD_SNAPRD_SNAPSHOT_TYPE_INCREMENTAL (1)
+
+typedef struct {
+  int type;
+  int is_download;
+  char read_path[ PATH_MAX ];
+} fd_snaprd_update_t;
 
 #endif /* HEADER_fd_src_discof_restore_fd_snaprd_tile_h */

--- a/src/discof/restore/utils/fd_sshttp.c
+++ b/src/discof/restore/utils/fd_sshttp.c
@@ -74,6 +74,8 @@ fd_sshttp_new( void * shmem ) {
   fd_sshttp_t * sshttp = FD_SCRATCH_ALLOC_APPEND( l, FD_SSHTTP_ALIGN, sizeof(fd_sshttp_t) );
 
   sshttp->state = FD_SSHTTP_STATE_INIT;
+  sshttp->full_snapshot_name[ 0 ] = '\0';
+  sshttp->incremental_snapshot_name[ 0 ] = '\0';
 
   FD_COMPILER_MFENCE();
   FD_VOLATILE( sshttp->magic ) = FD_SSHTTP_MAGIC;

--- a/src/discoh/poh/fd_poh_tile.c
+++ b/src/discoh/poh/fd_poh_tile.c
@@ -1049,7 +1049,7 @@ publish_became_leader( fd_poh_ctx_t * ctx,
     FD_LOG_ERR(( "Too many skipped ticks %lu for slot %lu, chain must halt", leader->ticks_per_slot+leader->total_skipped_ticks, slot ));
 
   ulong sig = fd_disco_poh_sig( slot, POH_PKT_TYPE_BECAME_LEADER, 0UL );
-  fd_stem_publish( ctx->stem, ctx->pack_out->idx, sig, ctx->pack_out->chunk, sizeof(fd_became_leader_t), 0UL, 0UL, 0UL );
+  fd_stem_publish( ctx->stem, ctx->pack_out->idx, sig, ctx->pack_out->chunk, sizeof(fd_became_leader_t), 0UL, 0UL, fd_frag_meta_ts_comp( fd_tickcount() ) );
   ctx->pack_out->chunk = fd_dcache_compact_next( ctx->pack_out->chunk, sizeof(fd_became_leader_t), ctx->pack_out->chunk0, ctx->pack_out->wmark );
 
   /* increment refcount for pack's reference to the current leader bank */

--- a/src/flamenco/gossip/fd_gossip_private.h
+++ b/src/flamenco/gossip/fd_gossip_private.h
@@ -6,6 +6,8 @@
 #include "../../util/fd_util.h"
 #include "../../disco/fd_disco_base.h"
 
+#include <stddef.h> // offsetof
+
 /* Constants used in deriving size bounds
    - 1232b (MTU)
    - 1188b = 1232b-4b(discriminant)-32b(pubkey)-8(crds len) max CRDS sz
@@ -74,12 +76,12 @@ FD_STATIC_ASSERT( FD_GOSSIP_SNAPSHOT_HASHES_MAX_INCREMENTAL==25UL,
                  "FD_GOSSIP_SNAPSHOT_HASHES_MAX_INCREMENTAL must be 25" );
 
 
-#define FD_GOSSIP_UPDATE_SZ_CONTACT_INFO        (__builtin_offsetof(fd_gossip_update_message_t, contact_info)        + sizeof(ulong) + sizeof(fd_contact_info_t))
-#define FD_GOSSIP_UPDATE_SZ_CONTACT_INFO_REMOVE (__builtin_offsetof(fd_gossip_update_message_t, contact_info_remove) + sizeof(ulong))
-#define FD_GOSSIP_UPDATE_SZ_LOWEST_SLOT         (__builtin_offsetof(fd_gossip_update_message_t, lowest_slot)         + sizeof(ulong))
-#define FD_GOSSIP_UPDATE_SZ_VOTE                (__builtin_offsetof(fd_gossip_update_message_t, vote)                + sizeof(fd_gossip_vote_t))
-#define FD_GOSSIP_UPDATE_SZ_DUPLICATE_SHRED     (__builtin_offsetof(fd_gossip_update_message_t, duplicate_shred)     + sizeof(fd_gossip_duplicate_shred_t))
-#define FD_GOSSIP_UPDATE_SZ_SNAPSHOT_HASHES     (__builtin_offsetof(fd_gossip_update_message_t, snapshot_hashes)     + sizeof(fd_gossip_snapshot_hashes_t))
+#define FD_GOSSIP_UPDATE_SZ_CONTACT_INFO        (offsetof(fd_gossip_update_message_t, contact_info)        + sizeof(ulong) + sizeof(fd_contact_info_t))
+#define FD_GOSSIP_UPDATE_SZ_CONTACT_INFO_REMOVE (offsetof(fd_gossip_update_message_t, contact_info_remove) + sizeof(ulong))
+#define FD_GOSSIP_UPDATE_SZ_LOWEST_SLOT         (offsetof(fd_gossip_update_message_t, lowest_slot)         + sizeof(ulong))
+#define FD_GOSSIP_UPDATE_SZ_VOTE                (offsetof(fd_gossip_update_message_t, vote)                + sizeof(fd_gossip_vote_t))
+#define FD_GOSSIP_UPDATE_SZ_DUPLICATE_SHRED     (offsetof(fd_gossip_update_message_t, duplicate_shred)     + sizeof(fd_gossip_duplicate_shred_t))
+#define FD_GOSSIP_UPDATE_SZ_SNAPSHOT_HASHES     (offsetof(fd_gossip_update_message_t, snapshot_hashes)     + sizeof(fd_gossip_snapshot_hashes_t))
 
 struct fd_gossip_view_ipaddr {
   uchar   is_ip6;

--- a/src/flamenco/gossip/test_gossip.c
+++ b/src/flamenco/gossip/test_gossip.c
@@ -39,7 +39,7 @@ test_gossip_new_basic( void ) {
 
   ulong               entrypoints_len = 1UL;
   fd_ip4_port_t const entrypoints[1]  = { { .addr = 0x7f000001U, /* 127.0.0.1 */
-                                           .port = fd_ushort_bswap( (ushort)8001 ) } };
+                                            .port = fd_ushort_bswap( (ushort)8001 ) } };
 
   fd_contact_info_t my_ci = {0};
   for( ulong i=0UL; i<32UL; i++ ) my_ci.pubkey.uc[i] = (uchar)i;

--- a/src/util/net/fd_net_headers.h
+++ b/src/util/net/fd_net_headers.h
@@ -61,7 +61,7 @@ union fd_ip4_port {
     uint   addr;  /* net order */
     ushort port;  /* net order */
   };
-  ulong l;
+  ulong l : 48;
 };
 
 typedef union fd_ip4_port fd_ip4_port_t;


### PR DESCRIPTION
Adds the following ws messages
- `summary.boot_progress`
- `gossip.network_stats`
- `gossip.query_scroll`
- `gossip.query_sort_col`
- `gossip.peers_size_update`
- `gossip.view_update`

Some fields are still missing support, but they'll be fixed in a future PR
- `gossip.network_stats.health.pull_already_known_pct`  (requires gossvf tile support)
- `gossipo.network_stats.health.total_stake` (requires RPC call at startup)
- `gossipo.network_stats.health.total_staked_peers` (requires RPC call at startup)
- `gossipo.network_stats.health.total_unstaked_peers` (requires RPC call at startup)

driveby nit fix: replaces some uses of compiler intrinsic `__builtin_offsetof` with slightly more cross-compiler compatible `offsetof`