### PR TITLE
Add "--public-rpc-address" option

### DIFF
--- a/src/app/fdctl/commands/run_agave.c
+++ b/src/app/fdctl/commands/run_agave.c
@@ -145,6 +145,7 @@ agave_boot( config_t const * config ) {
   if( config->rpc.port ) ADDH( "--rpc-port", config->rpc.port );
   if( config->frankendancer.rpc.full_api ) ADD1( "--full-rpc-api" );
   if( config->frankendancer.rpc.private ) ADD1( "--private-rpc" );
+  if( strcmp( config->frankendancer.rpc.public_address, "" ) ) ADD( "--public-rpc-address", config->frankendancer.rpc.public_address );
   if( strcmp( config->frankendancer.rpc.bind_address, "" ) ) ADD( "--rpc-bind-address", config->frankendancer.rpc.bind_address );
   if( config->frankendancer.rpc.transaction_history ) ADD1( "--enable-rpc-transaction-history" );
   if( config->rpc.extended_tx_metadata_storage ) ADD1( "--enable-extended-tx-metadata-storage" );

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -323,6 +323,12 @@ dynamic_port_range = "8900-9000"
     # with the `--rpc-bind-address` argument.
     bind_address = ""
 
+    # RPC address for the validator to advertise publicly in gossip.
+    # Useful for validators running behind a load balancer or proxy.
+    # This option is passed to the Agave client
+    # with the `--public-rpc-address` argument.
+    public_address = ""
+
     # Enable historical transaction info over JSON RPC, including the
     # `getConfirmedBlock` API.  This will cause an increase in disk
     # usage and IOPS.  This option is passed to the Agave client

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -11,6 +11,8 @@
 #define AFFINITY_SZ                      (256UL)
 #define CONFIGURE_STAGE_COUNT            ( 12UL)
 #define GOSSIP_TILE_ENTRYPOINTS_MAX      ( 16UL)
+#define FD_CONFIG_GOSSIP_ENTRYPOINTS_MAX ( 16UL)
+#define FD_IP4_PORT_STR_MAX              ( 22UL)
 
 struct fd_configh {
   char dynamic_port_range[ 32 ];
@@ -63,6 +65,7 @@ struct fd_configh {
     int    full_api;
     int    private;
     char   bind_address[ 16 ];
+    char   public_address[ FD_IP4_PORT_STR_MAX ];
     int    transaction_history;
     int    only_known;
     int    pubsub_enable_block_subscription;

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -53,6 +53,7 @@ fd_config_extract_podh( uchar *        pod,
   CFG_POP      ( bool,   rpc.full_api                                     );
   CFG_POP      ( bool,   rpc.private                                      );
   CFG_POP      ( cstr,   rpc.bind_address                                 );
+  CFG_POP      ( cstr,   rpc.public_address                               );
   CFG_POP      ( bool,   rpc.transaction_history                          );
   CFG_POP      ( bool,   rpc.only_known                                   );
   CFG_POP      ( bool,   rpc.pubsub_enable_block_subscription             );


### PR DESCRIPTION
- Adds option to specify a `public_address` which can be useful for proxy/load balancer.

Note:
I believe this flag will be deprecated eventually in the underlying Agave client.