### PR TITLE
funk: remove unused APIs

### DIFF
--- a/src/funk/fd_funk_rec.h
+++ b/src/funk/fd_funk_rec.h
@@ -389,53 +389,7 @@ int
 fd_funk_rec_remove( fd_funk_t *               funk,
                     fd_funk_txn_t *           txn,
                     fd_funk_rec_key_t const * key,
-                    fd_funk_rec_t **          rec_out,
-                    ulong                     erase_data );
-
-/*
-  fd_funk_rec_hard_remove completely removes the record from Funk,
-  and leaves no tombstone behind.
-
-  This is a dangerous API. An older version of the record in a
-  parent transaction might be exposed. In other words, the record may
-  appear to go backwards in time. We are effectively reverting an
-  update. Any information in an removed record is lost.
-
-  Always succeeds.
-*/
-void
-fd_funk_rec_hard_remove( fd_funk_t *               funk,
-                         fd_funk_txn_t *           txn,
-                         fd_funk_rec_key_t const * key );
-
-/* When a record is erased there is metadata stored in the five most
-   significant bytes of record flags.  These are helpers to make setting
-   and getting these values simple. The caller is responsible for doing
-   a check on the flag of the record before using the value of the erase
-   data. The 5 least significant bytes of the erase data parameter will
-   be used and set into the erase flag. */
-
-void
-fd_funk_rec_set_erase_data( fd_funk_rec_t * rec, ulong erase_data );
-
-ulong
-fd_funk_rec_get_erase_data( fd_funk_rec_t const * rec );
-
-/* Remove a list of tombstones from funk, thereby freeing up space in
-   the main index. All the records must be removed and published
-   beforehand. Reasons for failure include:
-
-     FD_FUNK_ERR_INVAL - bad inputs (NULL funk, NULL rec, rec is
-       obviously not from funk, etc)
-
-     FD_FUNK_ERR_KEY - the record did not appear to be a removed record.
-       Specifically, a record query of funk for rec's (xid,key) pair did
-       not return rec. Also, the record was never published.
-*/
-int
-fd_funk_rec_forget( fd_funk_t *      funk,
-                    fd_funk_rec_t ** recs,
-                    ulong            recs_cnt );
+                    fd_funk_rec_t **          rec_out );
 
 /* fd_funk_all_iter_t iterators over all funk record objects in all funk
    transactions.

--- a/src/funk/test_funk_common.hpp
+++ b/src/funk/test_funk_common.hpp
@@ -201,7 +201,7 @@ struct fake_funk {
 
       fd_funk_txn_t * txn2 = get_real_txn(txn);
       auto key = rec->real_id();
-      assert(fd_funk_rec_remove(_real, txn2, &key, NULL, 0UL) == FD_FUNK_SUCCESS);
+      assert(fd_funk_rec_remove(_real, txn2, &key, NULL) == FD_FUNK_SUCCESS);
 
       rec->_erased = true;
       rec->_data.clear();

--- a/src/funk/test_funk_rec.c
+++ b/src/funk/test_funk_rec.c
@@ -115,14 +115,14 @@ main( int     argc,
       FD_TEST( !fd_funk_rec_query_test( rec_query ) );
 
 #ifdef FD_FUNK_HANDHOLDING
-      FD_TEST( fd_funk_rec_remove( NULL, NULL, NULL, NULL, 0UL )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( NULL, NULL, tkey, NULL, 0UL )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst, NULL, NULL, NULL, 0UL )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( NULL, NULL, NULL, NULL )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( NULL, NULL, tkey, NULL )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( tst, NULL, NULL, NULL )==FD_FUNK_ERR_INVAL );
 #endif
 
       if( trec ) {
         if( is_frozen ) {
-          FD_TEST( fd_funk_rec_remove( tst, NULL, tkey, NULL, 0UL )==FD_FUNK_ERR_FROZEN );
+          FD_TEST( fd_funk_rec_remove( tst, NULL, tkey, NULL )==FD_FUNK_ERR_FROZEN );
         }
       }
 
@@ -204,13 +204,13 @@ main( int     argc,
       FD_TEST( !fd_funk_rec_query_test( rec_query ) );
 
 #ifdef FD_FUNK_HANDHOLDING
-      FD_TEST( fd_funk_rec_remove( NULL, ttxn, NULL, NULL, 0UL )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( NULL, ttxn, tkey, NULL, 0UL )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst, ttxn, NULL, NULL, 0UL )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( NULL, ttxn, NULL, NULL )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( NULL, ttxn, tkey, NULL )==FD_FUNK_ERR_INVAL );
+      FD_TEST( fd_funk_rec_remove( tst, ttxn, NULL, NULL )==FD_FUNK_ERR_INVAL );
 #endif
 
       if( trec && ttxn_is_frozen ) {
-        FD_TEST( fd_funk_rec_remove( tst, ttxn, tkey, NULL, 0UL )==FD_FUNK_ERR_FROZEN );
+        FD_TEST( fd_funk_rec_remove( tst, ttxn, tkey, NULL )==FD_FUNK_ERR_FROZEN );
       }
 
       fd_funk_rec_prepare_t rec_prepare[1];
@@ -346,7 +346,7 @@ main( int     argc,
       FD_TEST( !fd_funk_rec_query_test( query ) );
 
       fd_funk_rec_t * trec2;
-      FD_TEST( !fd_funk_rec_remove( tst, ttxn, key_set( tkey, rkey ), &trec2, 0UL ) );
+      FD_TEST( !fd_funk_rec_remove( tst, ttxn, key_set( tkey, rkey ), &trec2 ) );
       FD_TEST( trec == trec2 );
 
     } else if( op>=2 ) { /* Prepare 8x as publish and cancel combined */

--- a/src/funk/test_funk_val.c
+++ b/src/funk/test_funk_val.c
@@ -173,7 +173,7 @@ main( int     argc,
       rec_remove( ref, rrec );
 
       fd_funk_txn_t * ttxn = rxid ? fd_funk_txn_query( xid_set( txid, rxid ), txn_map ) : NULL;
-      FD_TEST( !fd_funk_rec_remove( tst, ttxn, key_set( tkey, rkey ), NULL, 0UL ) );
+      FD_TEST( !fd_funk_rec_remove( tst, ttxn, key_set( tkey, rkey ), NULL ) );
 
     } else if( op>=2 ) { /* Prepare 8x as publish and cancel combined */
 


### PR DESCRIPTION
- Remove rec_hard_remove
  Previously used to track hashing work, obsolete after
  https://github.com/firedancer-io/firedancer/pull/5581

- Remove erase_data tagging
  Previously planned to be used for LRU / garbage collection
  logic, currently unused

- Remove rec_forget
  Unused and untested

Closes #4856 