### PR TITLE
quic: use correct alignment for stream map

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -552,9 +552,7 @@ fd_quic_init( fd_quic_t * quic ) {
   state->hs_pool = hs_pool;
 
   /* State: Initialize TLS handshake cache */
-  if( FD_LIKELY( !fd_quic_tls_hs_cache_join(
-    fd_quic_tls_hs_cache_new( &state->hs_cache )
-  ))) {
+  if( FD_UNLIKELY( !fd_quic_tls_hs_cache_join( fd_quic_tls_hs_cache_new( &state->hs_cache ) ) ) ) {
     FD_LOG_WARNING(( "fd_quic_tls_hs_cache_new failed" ));
     return NULL;
   }

--- a/src/waltz/quic/fd_quic.h
+++ b/src/waltz/quic/fd_quic.h
@@ -159,7 +159,7 @@ struct __attribute__((aligned(16UL))) fd_quic_config {
 #define FD_QUIC_CONFIG_LIST(X,...) \
   X( role,                        "%d",     enum,  "enum",         __VA_ARGS__ ) \
   X( retry,                       "%d",     bool,  "bool",         __VA_ARGS__ ) \
-  X( tick_per_us,                 "%f",     units, "ticks per ms", __VA_ARGS__ ) \
+  X( tick_per_us,                 "%f",     units, "ticks per us", __VA_ARGS__ ) \
   X( idle_timeout,                "%lu",    units, "ns",           __VA_ARGS__ ) \
   X( keep_alive,                  "%d",     bool,  "bool",         __VA_ARGS__ ) \
   X( ack_delay,                   "%lu",    units, "ns",           __VA_ARGS__ ) \
@@ -591,10 +591,11 @@ fd_quic_conn_let_die( fd_quic_conn_t * conn,
 FD_QUIC_API ulong
 fd_quic_get_next_wakeup( fd_quic_t * quic );
 
-/* fd_quic_service services the next QUIC connection, including stream
-   transmit ops, ACK transmit, loss timeout, and idle timeout.   The
-   user should call service at high frequency.  Returns 1 if the service
-   call did any work, or 0 otherwise. */
+/* fd_quic_service services the next QUIC connection at each service
+   level, including stream transmit ops, ACK transmit, loss timeout, and
+   idle timeout.  The user should call service at high frequency.
+   Returns the number of connections serviced, where 0 means the call
+   did no work. */
 
 FD_QUIC_API int
 fd_quic_service( fd_quic_t * quic );

--- a/src/waltz/quic/fd_quic_conn.c
+++ b/src/waltz/quic/fd_quic_conn.c
@@ -46,7 +46,7 @@ fd_quic_conn_footprint_ext( fd_quic_limits_t const * limits,
     }
     layout->stream_map_lg = (int)lg;
 
-    off                     = fd_ulong_align_up( off, fd_quic_stream_align() );
+    off                     = fd_ulong_align_up( off, fd_quic_stream_map_align() );
     layout->stream_map_off  = off;
     off                    += fd_quic_stream_map_footprint( (int)lg );
   } else {


### PR DESCRIPTION
+ drive-by fixes: wrong doc, wrong time unit in string, wrong branch hint