### PR TITLE
Fix additional shred destinations

### DIFF
--- a/src/app/fdctl/topology.c
+++ b/src/app/fdctl/topology.c
@@ -478,11 +478,13 @@ fd_topo_initialize( config_t * config ) {
                        config->tiles.shred.additional_shred_destinations_retransmit[ i ],
                        &tile->shred.adtl_dests_retransmit[ i ] );
       }
+      tile->shred.adtl_dests_retransmit_cnt = config->tiles.shred.additional_shred_destinations_retransmit_cnt;
       for( ulong i=0UL; i<config->tiles.shred.additional_shred_destinations_leader_cnt; i++ ) {
         parse_ip_port( "tiles.shred.additional_shred_destinations_leader",
                        config->tiles.shred.additional_shred_destinations_leader[ i ],
                        &tile->shred.adtl_dests_leader[ i ] );
       }
+      tile->shred.adtl_dests_leader_cnt = config->tiles.shred.additional_shred_destinations_leader_cnt;
 
     } else if( FD_UNLIKELY( !strcmp( tile->name, "store" ) ) ) {
       tile->store.disable_blockstore_from_slot = config->development.bench.disable_blockstore_from_slot;

--- a/src/disco/shred/fd_shred_tile.c
+++ b/src/disco/shred/fd_shred_tile.c
@@ -1052,24 +1052,26 @@ after_frag( fd_shred_ctx_t *    ctx,
     ulong max_dest_cnt[1];
     fd_shred_dest_idx_t * dests;
     if( FD_LIKELY( ctx->in_kind[ in_idx ]==IN_KIND_NET ) ) {
+      for( ulong i=0UL; i<k; i++ ) {
+        for( ulong j=0UL; j<ctx->adtl_dests_retransmit_cnt; j++ ) send_shred( ctx, stem, new_shreds[ i ], ctx->adtl_dests_retransmit+j, ctx->tsorig );
+      }
       out_stride = k;
       /* In the case of feature activation, the fanout used below is
           the same as the one calculated/modified previously at the
-          begining of after_frag() for IN_KIND_NET in this slot. */
+          beginning of after_frag() for IN_KIND_NET in this slot. */
       dests = fd_shred_dest_compute_children( sdest, new_shreds, k, ctx->scratchpad_dests, k, fanout, fanout, max_dest_cnt );
     } else {
-      out_stride = 1UL;
-      *max_dest_cnt = 1UL;
-      dests = fd_shred_dest_compute_first   ( sdest, new_shreds, k, ctx->scratchpad_dests );
       for( ulong i=0UL; i<k; i++ ) {
         for( ulong j=0UL; j<ctx->adtl_dests_leader_cnt; j++ ) send_shred( ctx, stem, new_shreds[ i ], ctx->adtl_dests_leader+j, ctx->tsorig );
       }
+      out_stride = 1UL;
+      *max_dest_cnt = 1UL;
+      dests = fd_shred_dest_compute_first   ( sdest, new_shreds, k, ctx->scratchpad_dests );
     }
     if( FD_UNLIKELY( !dests ) ) return;
 
     /* Send only the ones we didn't receive. */
     for( ulong i=0UL; i<k; i++ ) {
-      for( ulong j=0UL; j<ctx->adtl_dests_retransmit_cnt; j++ ) send_shred( ctx, stem, new_shreds[ i ], ctx->adtl_dests_retransmit+j, ctx->tsorig );
       for( ulong j=0UL; j<*max_dest_cnt; j++ ) send_shred( ctx, stem, new_shreds[ i ], fd_shred_dest_idx_to_dest( sdest, dests[ j*out_stride+i ]), ctx->tsorig );
     }
   }


### PR DESCRIPTION
The last commit of PR #5801 was incomplete, causing the new config directives to be ignored. Sorry about this.

Also both leader and received shreds were sent to `additional_shred_destinations_retransmit`. I believe it's better to keep both streams disjoint and only send received shreds to these destinations.
