### PR TITLE
quic: tx_buf_sz pow2

### DIFF
--- a/src/app/shared_dev/commands/bench/fd_benchs.c
+++ b/src/app/shared_dev/commands/bench/fd_benchs.c
@@ -176,7 +176,7 @@ populate_quic_limits( fd_quic_limits_t * limits ) {
   limits->handshake_cnt = limits->conn_cnt;
   limits->conn_id_cnt = 16;
   limits->inflight_frame_cnt = 1500;
-  limits->tx_buf_sz = FD_TXN_MTU;
+  limits->tx_buf_sz = 1UL<<11;
   limits->stream_pool_cnt = 1UL<<16;
   limits->stream_id_cnt = 1UL<<16;
 }

--- a/src/discof/send/fd_send_tile.c
+++ b/src/discof/send/fd_send_tile.c
@@ -48,7 +48,7 @@ fd_quic_limits_t quic_limits = {
   .inflight_frame_cnt          = 16UL * MAX_STAKED_LEADERS,
   .min_inflight_frame_cnt_conn = 4UL,
   .stream_id_cnt               = 16UL,
-  .tx_buf_sz                   = FD_TXN_MTU,
+  .tx_buf_sz                   = 1UL<<11,
   .stream_pool_cnt             = 2048UL
 };
 

--- a/src/waltz/quic/fd_quic_stream.c
+++ b/src/waltz/quic/fd_quic_stream.c
@@ -75,7 +75,7 @@ fd_quic_buffer_load( fd_quic_buffer_t * buf,
 
   if( mtail >= mhead ) {
     /* free space split */
-    ulong end_sz = cap - mhead;
+    ulong end_sz = cap - mtail;
     if( data_sz <= end_sz ) {
       /* consists entirely of space at end of buffer */
       fd_memcpy( data, raw + mtail, data_sz );
@@ -97,6 +97,8 @@ fd_quic_stream_align( void );
 
 ulong
 fd_quic_stream_footprint( ulong tx_buf_sz ) {
+  if( FD_UNLIKELY( !fd_ulong_is_pow2( tx_buf_sz ) ) ) return 0UL;
+
   ulong align           = fd_quic_stream_align();
   ulong offs            = 0ul;
 

--- a/src/waltz/quic/fd_quic_stream_pool.c
+++ b/src/waltz/quic/fd_quic_stream_pool.c
@@ -13,6 +13,7 @@ fd_quic_stream_pool_footprint( ulong count, ulong tx_buf_sz ) {
       FD_QUIC_STREAM_POOL_ALIGN );
 
   ulong stream_foot = fd_quic_stream_footprint( tx_buf_sz );
+  if( FD_UNLIKELY( !stream_foot ) ) return 0UL;
 
   return foot + stream_foot * count;
 }
@@ -38,6 +39,7 @@ fd_quic_stream_pool_new( void * mem, ulong count, ulong tx_buf_sz ) {
   offs += fd_ulong_align_up( sizeof( fd_quic_stream_pool_t ), FD_QUIC_STREAM_POOL_ALIGN );
 
   ulong stream_foot = fd_quic_stream_footprint( tx_buf_sz );
+  if( FD_UNLIKELY( !stream_foot ) ) { FD_LOG_WARNING(( "stream footprint is 0: Confirm tx_buf_sz is pow2!" )); return NULL; }
 
   FD_QUIC_STREAM_LIST_SENTINEL( pool->head );
 

--- a/src/waltz/quic/tests/fd_quic_test_helpers.c
+++ b/src/waltz/quic/tests/fd_quic_test_helpers.c
@@ -8,8 +8,6 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
-#include "../../../ballet/txn/fd_txn.h" /* FD_TXN_MTU */
-#include "../../../util/net/fd_eth.h"
 #include "../../../util/net/fd_ip4.h"
 
 #if defined(__linux__)

--- a/src/waltz/quic/tests/fd_quic_test_helpers.h
+++ b/src/waltz/quic/tests/fd_quic_test_helpers.h
@@ -5,7 +5,8 @@
 #include "../../aio/fd_aio_pcapng.h"
 #include "../../udpsock/fd_udpsock.h"
 #include "../../tls/test_tls_helper.h"
-#include "../../../util/net/fd_eth.h"
+#include "../../../ballet/txn/fd_txn.h" /* FD_TXN_MTU */
+
 #include <stdio.h>
 
 /* Common helpers for QUIC tests.  The tests using these gain the

--- a/src/waltz/quic/tests/test_quic_bw.c
+++ b/src/waltz/quic/tests/test_quic_bw.c
@@ -94,7 +94,7 @@ main( int     argc,
   float        loss     = fd_env_strip_cmdline_float ( &argc, &argv, "--loss",      NULL, 0.0f                         );
   float        reorder  = fd_env_strip_cmdline_float ( &argc, &argv, "--reorder",   NULL, 0.0f                         );
   float        duration = fd_env_strip_cmdline_float ( &argc, &argv, "--duration",  NULL, 10.0f                        );
-  ushort       sz       = fd_env_strip_cmdline_ushort( &argc, &argv, "--sz",        NULL, FRAG_SZ                      );
+  ushort       sz       = fd_env_strip_cmdline_ushort( &argc, &argv, "--sz",        NULL, 1UL<<10                      );
   FD_TEST( sz<=FRAG_SZ );
 
   ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );

--- a/src/waltz/quic/tests/test_quic_streams.c
+++ b/src/waltz/quic/tests/test_quic_streams.c
@@ -77,6 +77,22 @@ ulong test_clock( void * ctx ) {
   return now;
 }
 
+static void
+test_invalid_tx_buf_sz( fd_wksp_t * wksp ) {
+  FD_LOG_NOTICE(( "Testing invalid tx_buf_sz" ));
+  FD_TEST( !fd_ulong_pow2( FD_TXN_MTU ) );
+
+  fd_quic_limits_t const bad_limits = {
+    .conn_cnt           = 2,
+    .conn_id_cnt        = 4,
+    .handshake_cnt      = 10,
+    .inflight_frame_cnt = 100 * 2,
+    .tx_buf_sz          = FD_TXN_MTU,
+    .stream_pool_cnt    = 512
+  };
+  FD_TEST( !fd_quic_new( wksp, &bad_limits ) );
+}
+
 int
 main( int     argc,
       char ** argv ) {
@@ -99,6 +115,8 @@ main( int     argc,
   FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
   fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
+
+  test_invalid_tx_buf_sz( wksp );
 
   FD_LOG_NOTICE(( "Creating server QUIC" ));
 


### PR DESCRIPTION
Requires tx_buf_sz for quic streams to be a pow2, so masking works correctly. 
And fixes circular buf OOB bug
found by @two-heart 