### PR TITLE
gui: slot rankings

### DIFF
--- a/book/api/websocket.md
+++ b/book/api/websocket.md
@@ -1054,6 +1054,84 @@ new validator identity.
 | waterfall           | `TxnWaterfall\|null`      | If the slot is not `mine`, will be `null`. Otherwise, a waterfall showing reasons transactions were acquired since the end of the prior leader slot |
 | tile_primary_metric | `TilePrimaryMetric\|null` | If the slot is not `mine`, will be `null`. Otherwise, max value of per-tile-type primary metrics since the end of the prior leader slot |
 
+#### `slot.query_rankings`
+| frequency   | type           | example |
+|-------------|----------------|---------|
+| *Request*   | `SlotRankings` | below   |
+
+| param | type   | description |
+|-------|--------|-------------|
+| mine  | `bool` | If `mine` is true, only include slots produced by this validator in the result.  Otherwise, any slot from the current epoch may be included |
+
+::: details Example
+
+```json
+{
+    "topic": "slot",
+    "key": "query_rankings",
+    "id": 32,
+    "params": {
+        "mine": false
+    }
+}
+```
+
+```json
+{
+    "topic": "slot",
+    "key": "query_rankings",
+    "id": 32,
+    "value": {
+      "slots_largest_tips": [1, 2, 3],
+      "vals_largest_tips": [12345678, 1234567, 123456],
+      "slots_largest_fees": [1, 2, 3],
+      "vals_largest_fees": [12345678, 1234567, 123456],
+      "slots_largest_rewards": [1, 2, 3],
+      "vals_largest_rewards": [12345678, 1234567, 123456],
+      "slots_largest_duration": [1, 2, 3],
+      "vals_largest_duration": [450000000, 440000000, 430000000],
+      "slots_largest_compute_units": [1, 2, 3],
+      "vals_largest_compute_units": [47000000, 46000000, 45000000],
+      "slots_largest_skipped": [7, 8, 9],
+      "vals_largest_skipped": [7, 8, 9],
+      "slots_smallest_tips": [1, 2, 3],
+      "vals_smallest_tips": [0, 0, 0],
+      "slots_smallest_fees": [1, 2, 3],
+      "vals_smallest_fees": [0, 0, 0],
+      "slots_smallest_rewards": [1, 2, 3],
+      "vals_smallest_rewards": [0, 0, 0],
+      "slots_smallest_duration": [1, 2, 3],
+      "vals_smallest_duration": [100000000, 120000000, 160000000],
+      "slots_smallest_compute_units": [1, 2, 3],
+      "vals_smallest_compute_units": [15000000, 16000000, 17000000],
+      "slots_smallest_skipped": [4, 5, 6],
+      "vals_smallest_skipped": [4, 5, 6]
+    }
+}
+```
+
+:::
+
+**`SlotRankings`**
+| Field                                         | Type       | Description |
+|-----------------------------------------------|------------|-------------|
+| {slots|vals}_{smallest|largest}_tips          | `number[]` | Rankings for the {smallest|largest} tips this epoch |
+| {slots|vals}_{smallest|largest}_fees          | `number[]` | Rankings for the {smallest|largest} fees this epoch |
+| {slots|vals}_{smallest|largest}_rewards       | `number[]` | Rankings for the {smallest|largest} rewards this epoch |
+| {slots|vals}_{smallest|largest}_duration      | `number[]` | Rankings for the {smallest|largest} slot durations this epoch |
+| {slots|vals}_{smallest|largest}_compute_units | `number[]` | Rankings for the {smallest|largest} compute units this epoch |
+| {slots|vals}_{smallest|largest}_skipped       | `number[]` | Rankings for the {earliest|latest} skipped slots this epoch |
+
+Each metric in this message will have four associated arrays.
+
+- vals_smallest_metric: Metric value for the lowest ranked slots (sorted ascending)
+- slots_smallest_metric: Slot numbers for vals_smallest_metric source slots
+- slots_largest_metric: Metric value for the highest ranked slots (sorted descending)
+- vals_largest_metric: Slot numbers for vals_largest_metric source slots
+
+Slots before boot time are not included in these rankings. Unless
+explicitly mentioned, skipped slots are not included.
+
 #### `slot.query`
 | frequency   | type           | example |
 |-------------|----------------|---------|
@@ -1393,8 +1471,8 @@ new validator identity.
 | txn_bank_idx                      | `number[]`  | `txn_bank_idx[i]` is the index of the bank tile that executed the `i`-th transaction in the slot |
 | txn_microblock_id                 | `string[]`  | `txn_microblock_id[i]` is the index of the microblock for the `i`-th transaction in the slot.  Microblocks are collections of 1+ transactions.  All of the transactions from a bundle share the same microblock. Microblock ids are monotonically increasing in the order they appear in the block and start at 0 for each slot |
 | txn_signature                     | `string[]`  | `txn_signature[i]` is the base58 signature of the `i`-th transaction in the slot |
-| txn_source_ipv4                   | `number[]`  | `txn_signature[i]` is the source ipv4 address for the `i`-th transaction in the slot |
-| txn_source_tpu                    | `string[]`  | `txn_signature[i]` is the transaction processing unit (TPU) which handled the `i`-th transaction in the slot |
+| txn_source_ipv4                   | `string[]`  | `txn_source_ipv4[i]` is the source ipv4 address for the `i`-th transaction in the slot |
+| txn_source_tpu                    | `string[]`  | `txn_source_tpu[i]` is the transaction processing unit (TPU) which handled the `i`-th transaction in the slot |
 
 The source tpu for a transaction can be one of the following
 

--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -84,6 +84,7 @@ fd_gui_new( void *             shmem,
   gui->summary.startup_full_snapshot_slot             = 0;
   gui->summary.startup_incremental_snapshot_slot      = 0;
   gui->summary.startup_waiting_for_supermajority_slot = ULONG_MAX;
+  gui->summary.startup_ledger_max_slot                = ULONG_MAX;
 
   gui->summary.identity_account_balance      = 0UL;
   gui->summary.vote_account_balance          = 0UL;
@@ -945,6 +946,100 @@ fd_gui_request_slot_detailed( fd_gui_t *    gui,
   return 0;
 }
 
+static inline ulong
+fd_gui_slot_duration( fd_gui_t const * gui, fd_gui_slot_t const * cur ) {
+  if( FD_UNLIKELY( cur->slot == ULONG_MAX || cur->slot == 0UL ) ) return ULONG_MAX;
+
+  fd_gui_slot_t const * prev = gui->slots[ (cur->slot - 1UL) % FD_GUI_SLOTS_CNT ];
+  if( FD_UNLIKELY( prev->slot == ULONG_MAX ||
+                   prev->skipped ||
+                   prev->completed_time == LONG_MAX ||
+                   prev->slot != (cur->slot - 1UL) ||
+                   cur->skipped ||
+                   cur->completed_time == LONG_MAX ) ) return ULONG_MAX;
+
+  return (ulong)(cur->completed_time - prev->completed_time);
+}
+
+static inline void
+fd_gui_try_insert_ranking( fd_gui_t               * gui,
+                           fd_gui_slot_rankings_t * rankings,
+                           fd_gui_slot_t const    * slot ) {
+  /* Rankings are inserted into an extra slot at the end of the ranking
+     array, then the array is sorted. */
+#define TRY_INSERT_SLOT( ranking_name, ranking_slot, ranking_value ) \
+  do { \
+    rankings->FD_CONCAT2(largest_, ranking_name) [ FD_GUI_SLOT_RANKINGS_SZ ] = (fd_gui_slot_ranking_t){ .slot = (ranking_slot), .value = (ranking_value), .type = FD_GUI_SLOT_RANKING_TYPE_DESC }; \
+    fd_gui_slot_ranking_sort_insert( rankings->FD_CONCAT2(largest_, ranking_name), FD_GUI_SLOT_RANKINGS_SZ+1UL ); \
+    rankings->FD_CONCAT2(smallest_, ranking_name)[ FD_GUI_SLOT_RANKINGS_SZ ] = (fd_gui_slot_ranking_t){ .slot = (ranking_slot), .value = (ranking_value), .type = FD_GUI_SLOT_RANKING_TYPE_ASC  }; \
+    fd_gui_slot_ranking_sort_insert( rankings->FD_CONCAT2(smallest_, ranking_name), FD_GUI_SLOT_RANKINGS_SZ+1UL ); \
+  } while (0)
+
+    if( slot->skipped ) {
+      TRY_INSERT_SLOT( skipped, slot->slot, slot->slot );
+      return;
+    }
+
+    ulong dur = fd_gui_slot_duration( gui, slot );
+    if( FD_LIKELY( dur!=ULONG_MAX ) ) TRY_INSERT_SLOT( duration, slot->slot, dur );
+    TRY_INSERT_SLOT( tips,          slot->slot, slot->tips                      );
+    TRY_INSERT_SLOT( fees,          slot->slot, slot->priority_fee              );
+    TRY_INSERT_SLOT( rewards,       slot->slot, slot->tips + slot->priority_fee );
+    TRY_INSERT_SLOT( compute_units, slot->slot, slot->compute_units             );
+#undef TRY_INSERT_SLOT
+}
+
+static void
+fd_gui_update_slot_rankings( fd_gui_t * gui ) {
+  if( FD_UNLIKELY( gui->summary.startup_ledger_max_slot==ULONG_MAX ) ) return;
+  if( FD_UNLIKELY( gui->summary.slot_rooted==0UL ) )                   return;
+
+  ulong epoch_start_slot = ULONG_MAX;
+  ulong epoch            = ULONG_MAX;
+  for( ulong i = 0UL; i<2UL; i++ ) {
+    if( FD_LIKELY( gui->epoch.has_epoch[ i ] ) ) {
+      /* the "current" epoch is the smallest */
+      epoch_start_slot = fd_ulong_min( epoch_start_slot, gui->epoch.epochs[ i ].start_slot );
+      epoch            = fd_ulong_min( epoch,            gui->epoch.epochs[ i ].epoch      );
+    }
+  }
+
+  if( FD_UNLIKELY( epoch==ULONG_MAX ) ) return;
+  ulong epoch_idx = epoch % 2UL;
+
+  /* No new slots since the last update */
+  if( FD_UNLIKELY( gui->epoch.epochs[ epoch_idx ].rankings_slot>gui->summary.slot_rooted ) ) return;
+
+  /* Slots before startup_ledger_max_slot are unavailable. */
+  gui->epoch.epochs[ epoch_idx ].rankings_slot = fd_ulong_max( gui->epoch.epochs[ epoch_idx ].rankings_slot, gui->summary.startup_ledger_max_slot+1UL );
+
+  /* Update the rankings. Only look through slots we haven't already. */
+  for( ulong s = gui->summary.slot_rooted; s>=gui->epoch.epochs[ epoch_idx ].rankings_slot; s--) {
+    fd_gui_slot_t * slot = gui->slots[ s % FD_GUI_SLOTS_CNT ];
+    if( FD_UNLIKELY( slot->slot!=s || slot->slot==ULONG_MAX ) ) break;
+
+    fd_gui_try_insert_ranking( gui, gui->epoch.epochs[ epoch_idx ].rankings, slot );
+    if( FD_UNLIKELY( slot->mine ) ) fd_gui_try_insert_ranking( gui, gui->epoch.epochs[ epoch_idx ].my_rankings, slot );
+  }
+
+  gui->epoch.epochs[ epoch_idx ].rankings_slot = gui->summary.slot_rooted + 1UL;
+}
+
+int
+fd_gui_request_slot_rankings( fd_gui_t *    gui,
+                              ulong         ws_conn_id,
+                              ulong         request_id,
+                              cJSON const * params ) {
+  const cJSON * slot_param = cJSON_GetObjectItemCaseSensitive( params, "mine" );
+  if( FD_UNLIKELY( !cJSON_IsBool( slot_param ) ) ) return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
+
+  int mine = !!(slot_param->type & cJSON_True);
+  fd_gui_update_slot_rankings( gui );
+  fd_gui_printf_slot_rankings_request( gui, request_id, mine );
+  FD_TEST( !fd_http_server_ws_send( gui->http, ws_conn_id ) );
+  return 0;
+}
+
 int
 fd_gui_ws_message( fd_gui_t *    gui,
                    ulong         ws_conn_id,
@@ -1005,6 +1100,16 @@ fd_gui_ws_message( fd_gui_t *    gui,
     }
 
     int result = fd_gui_request_slot_transactions( gui, ws_conn_id, id, params );
+    cJSON_Delete( json );
+    return result;
+  } else if( FD_LIKELY( !strcmp( topic->valuestring, "slot" ) && !strcmp( key->valuestring, "query_rankings" ) ) ) {
+    const cJSON * params = cJSON_GetObjectItemCaseSensitive( json, "params" );
+    if( FD_UNLIKELY( !cJSON_IsObject( params ) ) ) {
+      cJSON_Delete( json );
+      return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
+    }
+
+    int result = fd_gui_request_slot_rankings( gui, ws_conn_id, id, params );
     cJSON_Delete( json );
     return result;
   } else if( FD_LIKELY( !strcmp( topic->valuestring, "summary" ) && !strcmp( key->valuestring, "ping" ) ) ) {
@@ -1099,6 +1204,10 @@ fd_gui_handle_leader_schedule( fd_gui_t *    gui,
   gui->epoch.epochs[ idx ].excluded_stake   = excluded_stake;
   gui->epoch.epochs[ idx ].my_total_slots   = 0UL;
   gui->epoch.epochs[ idx ].my_skipped_slots = 0UL;
+
+  memset( gui->epoch.epochs[ idx ].rankings,    (int)(UINT_MAX), sizeof(gui->epoch.epochs[ idx ].rankings[ 0 ])    );
+  memset( gui->epoch.epochs[ idx ].my_rankings, (int)(UINT_MAX), sizeof(gui->epoch.epochs[ idx ].my_rankings[ 0 ]) );
+  gui->epoch.epochs[ idx ].rankings_slot = start_slot;
 
   fd_vote_stake_weight_t const * stake_weights = fd_type_pun_const( msg+6UL );
   memcpy( gui->epoch.epochs[ idx ].stakes, stake_weights, staked_cnt*sizeof(fd_vote_stake_weight_t) );
@@ -1304,8 +1413,8 @@ fd_gui_handle_reset_slot( fd_gui_t * gui,
     if( FD_UNLIKELY( parent_slot_idx>=parent_cnt ) ) break;
   }
 
-  ulong last_slot = _slot;
-  long last_published = gui->slots[ _slot % FD_GUI_SLOTS_CNT ]->completed_time;
+  ulong duration_sum = 0UL;
+  ulong slot_cnt = 0UL;
 
   for( ulong i=0UL; i<fd_ulong_min( _slot+1, 750UL ); i++ ) {
     ulong parent_slot = _slot - i;
@@ -1317,14 +1426,15 @@ fd_gui_handle_reset_slot( fd_gui_t * gui,
       FD_LOG_ERR(( "_slot %lu i %lu we expect _slot-i %lu got slot->slot %lu", _slot, i, _slot-i, slot->slot ));
     }
 
-    if( FD_LIKELY( !slot->skipped ) ) {
-      last_slot = parent_slot;
-      last_published = slot->completed_time;
+    ulong slot_duration = fd_gui_slot_duration( gui, slot );
+    if( FD_LIKELY( slot_duration!=ULONG_MAX ) ) {
+      duration_sum += slot_duration;
+      slot_cnt++;
     }
   }
 
-  if( FD_LIKELY( _slot!=last_slot )) {
-    gui->summary.estimated_slot_duration_nanos = (ulong)(fd_log_wallclock()-last_published)/(_slot-last_slot);
+  if( FD_LIKELY( slot_cnt>0 )) {
+    gui->summary.estimated_slot_duration_nanos = (ulong)(duration_sum / slot_cnt);
     fd_gui_printf_estimated_slot_duration_nanos( gui );
     fd_http_server_ws_broadcast( gui->http );
   }

--- a/src/disco/gui/fd_gui_printf.h
+++ b/src/disco/gui/fd_gui_printf.h
@@ -88,6 +88,12 @@ fd_gui_printf_slot_request( fd_gui_t * gui,
                             ulong      id );
 
 void
+fd_gui_printf_slot_rankings_request( fd_gui_t * gui,
+                                     ulong      id,
+                                     int        mine );
+
+
+void
 fd_gui_printf_slot_request_detailed( fd_gui_t * gui,
                                      ulong      slot,
                                      ulong      id );


### PR DESCRIPTION
add query.slot_rankings message with `mine` param
change slot duration estimate to exclude skipped slots (since historical skipping is independent from future skipping)