### PR TITLE
Build firedancer-dev even when deps are missing

### DIFF
--- a/src/app/fddev/main.c
+++ b/src/app/fddev/main.c
@@ -14,5 +14,5 @@ main( int     argc,
     NULL
   };
 
-  return fd_dev_main( argc, argv, 0, configs, fd_topo_initialize );
+  return fd_dev_main( argc, argv, 0, configs );
 }

--- a/src/app/fddev/tests/test_fddev.c
+++ b/src/app/fddev/tests/test_fddev.c
@@ -206,7 +206,7 @@ fddev_test_run( int     argc,
       NULL
     };
 
-    return fd_dev_main( argc, argv, 0, configs, fd_topo_initialize );
+    return fd_dev_main( argc, argv, 0, configs );
   }
 
   return 0;

--- a/src/app/firedancer-dev/Local.mk
+++ b/src/app/firedancer-dev/Local.mk
@@ -3,8 +3,6 @@ ifdef FD_HAS_LINUX
 ifdef FD_HAS_ALLOCA
 ifdef FD_HAS_DOUBLE
 ifdef FD_HAS_INT128
-ifdef FD_HAS_ZSTD
-ifdef FD_HAS_SECP256K1
 
 .PHONY: firedancer-dev
 
@@ -25,8 +23,6 @@ firedancer-dev: $(OBJDIR)/bin/firedancer-dev
 # $(call run-integration-test,test_fddev)
 else
 $(warning firedancer-dev build disabled due to lack of zstd)
-endif
-endif
 endif
 endif
 endif

--- a/src/app/firedancer-dev/main.c
+++ b/src/app/firedancer-dev/main.c
@@ -128,29 +128,33 @@ fd_topo_run_tile_t * TILES[] = {
   &fd_tile_bundle,
   &fd_tile_gossip,
   &fd_tile_repair,
-  &fd_tile_replay,
-  &fd_tile_execor,
-  &fd_tile_writer,
   &fd_tile_poh,
   &fd_tile_send,
-  &fd_tile_tower,
   &fd_tile_rpcserv,
   &fd_tile_archiver_feeder,
   &fd_tile_archiver_writer,
   &fd_tile_archiver_playback,
   &fd_tile_shredcap,
-#if FD_HAS_ROCKSDB
-  &fd_tile_backtest,
-#endif
   &fd_tile_bencho,
   &fd_tile_benchg,
   &fd_tile_benchs,
   &fd_tile_pktgen,
   &fd_tile_udpecho,
   &fd_tile_snaprd,
+#if FD_HAS_ZSTD
   &fd_tile_snapdc,
+#endif
   &fd_tile_snapin,
   &fd_tile_ipecho,
+#if FD_HAS_SECP256k1
+  &fd_tile_replay,
+  &fd_tile_execor,
+  &fd_tile_writer,
+  &fd_tile_tower,
+#if FD_HAS_ROCKSDB
+  &fd_tile_backtest,
+#endif
+#endif
   NULL,
 };
 
@@ -237,5 +241,5 @@ main( int     argc,
     NULL
   };
 
-  return fd_dev_main( argc, argv, 1, configs, fd_topo_initialize );
+  return fd_dev_main( argc, argv, 1, configs );
 }

--- a/src/app/firedancer/Local.mk
+++ b/src/app/firedancer/Local.mk
@@ -20,8 +20,6 @@ ifdef FD_HAS_THREADS
 ifdef FD_HAS_ALLOCA
 ifdef FD_HAS_DOUBLE
 ifdef FD_HAS_INT128
-ifdef FD_HAS_SECP256K1
-ifdef FD_HAS_ZSTD
 
 $(OBJDIR)/obj/app/firedancer/config.o: src/app/firedancer/config/default.toml
 $(OBJDIR)/obj/app/firedancer/config.o: src/app/firedancer/config/testnet.toml
@@ -43,15 +41,23 @@ $(call add-objs,commands/shred_version,fd_firedancer)
 $(call make-lib,firedancer_version)
 $(call add-objs,version,firedancer_version)
 
+ifdef FD_HAS_SECP256K1
+ifdef FD_HAS_ZSTD
+FD_HAS_FIREDANCER_DEPS:=1
+endif
+endif
+
+endif
+endif
+endif
+endif
+endif
+
+
+ifdef FD_HAS_FIREDANCER_DEPS
 $(call make-bin,firedancer,main,fd_firedancer fdctl_shared fdctl_platform fd_discof fd_disco fd_choreo fd_flamenco fd_funk fd_quic fd_tls fd_reedsol fd_waltz fd_tango fd_ballet fd_util firedancer_version,$(SECP256K1_LIBS) $(OPENSSL_LIBS))
 
 firedancer: $(OBJDIR)/bin/firedancer
 else
-$(warning firedancer build disabled due to lack of zstd)
-endif
-endif
-endif
-endif
-endif
-endif
+$(warning firedancer build not supported on this platform, missing deps?)
 endif

--- a/src/app/shared/boot/fd_boot.c
+++ b/src/app/shared/boot/fd_boot.c
@@ -175,7 +175,7 @@ fd_main_init( int *                      pargc,
                                &override_config, &override_config_path, &override_config_sz );
 
     fd_config_load( is_firedancer, netns, is_local_cluster, default_config, default_config_sz, override_config, override_config_path, override_config_sz, user_config, user_config_sz, opt_user_config_path, config );
-    topo_init( config );
+    if( topo_init ) topo_init( config );
 
     if( FD_UNLIKELY( user_config && -1==munmap( user_config, user_config_sz ) ) ) FD_LOG_ERR(( "munmap() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
 

--- a/src/app/shared_dev/boot/fd_dev_boot.c
+++ b/src/app/shared_dev/boot/fd_dev_boot.c
@@ -60,8 +60,7 @@ int
 fd_dev_main( int                        argc,
              char **                    _argv,
              int                        is_firedancer,
-             fd_config_file_t * const * configs,
-             void (* topo_init )( config_t * config ) ) {
+             fd_config_file_t * const * configs ) {
   /* save original arguments list in case we need to respawn the process
      as privileged */
   int    orig_argc = argc;
@@ -115,7 +114,7 @@ fd_dev_main( int                        argc,
     exit( 1 );
   }
 
-  fd_main_init( &argc, &argv, &config, opt_user_config_path, is_firedancer, action->is_local_cluster, log_path, configs, topo_init );
+  fd_main_init( &argc, &argv, &config, opt_user_config_path, is_firedancer, action->is_local_cluster, log_path, configs, NULL );
 
   config.development.no_clone = config.development.no_clone || no_clone;
   config.development.sandbox = config.development.sandbox && !no_sandbox && !no_clone;

--- a/src/app/shared_dev/boot/fd_dev_boot.h
+++ b/src/app/shared_dev/boot/fd_dev_boot.h
@@ -10,8 +10,7 @@ int
 fd_dev_main( int                        argc,
              char **                    _argv,
              int                        is_firedancer,
-             fd_config_file_t * const * configs,
-             void (* topo_init )( config_t * config ) );
+             fd_config_file_t * const * configs );
 
 FD_PROTOTYPES_END
 

--- a/src/app/shared_dev/commands/dev.c
+++ b/src/app/shared_dev/commands/dev.c
@@ -14,7 +14,10 @@
 #include <pthread.h>
 #include <sys/wait.h>
 
-fd_topo_run_tile_t
+extern void
+fd_topo_initialize( fd_config_t * config );
+
+extern fd_topo_run_tile_t
 fdctl_tile_run( fd_topo_tile_t const * tile );
 
 void
@@ -151,6 +154,8 @@ void
 dev_cmd_fn( args_t *   args,
             config_t * config,
             void ( * agave_main )( config_t const * ) ) {
+  fd_topo_initialize( config );
+
   if( FD_LIKELY( !args->dev.no_configure ) ) {
     args_t configure_args = {
       .configure.command = CONFIGURE_CMD_INIT,

--- a/src/choreo/tower/Local.mk
+++ b/src/choreo/tower/Local.mk
@@ -1,10 +1,8 @@
 ifdef FD_HAS_INT128
-ifdef FD_HAS_SECP256K1
 $(call add-hdrs,fd_tower.h)
 $(call add-objs,fd_tower,fd_choreo)
 ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_tower,test_tower,fd_choreo fd_flamenco fd_funk fd_tango fd_ballet fd_util,$(SECP256K1_LIBS))
 $(call run-unit-test,test_tower)
-endif
 endif
 endif


### PR DESCRIPTION
Improves portability of firedancer-dev, allowing us to run dev
commands (like pktgen) on exotic hosts.
