### PR TITLE
recorder: added new peer selection and request tracking to repair tile

### DIFF
--- a/src/flamenco/repair/Local.mk
+++ b/src/flamenco/repair/Local.mk
@@ -1,7 +1,8 @@
 ifdef FD_HAS_INT128
-$(call add-hdrs,fd_repair.h)
-$(call add-objs,fd_repair,fd_flamenco)
+$(call add-hdrs,fd_repair.h fd_recorder.h)
+$(call add-objs,fd_repair fd_recorder,fd_flamenco)
 ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_repair,test_repair,fd_flamenco fd_ballet fd_util)
+$(call make-unit-test,test_recorder,test_recorder,fd_flamenco fd_ballet fd_util)
 endif
 endif

--- a/src/flamenco/repair/fd_recorder.c
+++ b/src/flamenco/repair/fd_recorder.c
@@ -1,0 +1,732 @@
+#include "fd_recorder.h"
+#include "../../flamenco/fd_flamenco_base.h"
+#include "../../util/net/fd_net_headers.h"
+#include "../../flamenco/fd_rwlock.h"
+#include <stdbool.h>
+#include <stdlib.h>
+
+/* fd_recorder implementation
+
+   IMPORTANT: All functions in this file assume that the caller has
+   acquired the appropriate lock (read or write) as documented in the
+   header file. This implementation does NOT acquire or release locks
+   internally. View locking requirements in header file.
+  */
+
+void *
+fd_recorder_new( void * shmem, ulong seed, ulong timeout_ns ) {
+
+  if( FD_UNLIKELY( !shmem ) ) {
+    FD_LOG_WARNING(( "NULL mem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, fd_recorder_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned mem" ));
+    return NULL;
+  }
+
+  ulong footprint = fd_recorder_footprint();
+  if( FD_UNLIKELY( !footprint ) ) {
+    FD_LOG_WARNING(( "bad footprint" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !timeout_ns ) ) {
+    FD_LOG_WARNING(( "zero timeout_ns" ));
+    return NULL;
+  }
+
+  fd_wksp_t * wksp = fd_wksp_containing( shmem );
+  if( FD_UNLIKELY( !wksp ) ) {
+    FD_LOG_WARNING(( "shmem must be part of a workspace" ));
+    return NULL;
+  }
+
+  fd_memset( shmem, 0, footprint );
+
+  FD_SCRATCH_ALLOC_INIT( l, shmem );
+  fd_recorder_t * recorder = FD_SCRATCH_ALLOC_APPEND( l, fd_recorder_align(), sizeof( fd_recorder_t ) );
+  void *        req_pool   = FD_SCRATCH_ALLOC_APPEND( l, fd_recorder_req_pool_align(),  fd_recorder_req_pool_footprint ( MAX_REQUESTS )                                       );
+  void *        req_map    = FD_SCRATCH_ALLOC_APPEND( l, fd_recorder_req_map_align(),   fd_recorder_req_map_footprint  ( fd_recorder_req_map_chain_cnt_est( MAX_REQUESTS ) )  );
+  void *        req_dlist  = FD_SCRATCH_ALLOC_APPEND( l, fd_recorder_req_dlist_align(), fd_recorder_req_dlist_footprint()                                                     );
+  void *        peer_pool  = FD_SCRATCH_ALLOC_APPEND( l, fd_recorder_peer_pool_align(), fd_recorder_peer_pool_footprint( FD_MAX_PEERS )                                       );
+  void *        peer_map   = FD_SCRATCH_ALLOC_APPEND( l, fd_recorder_peer_map_align(),  fd_recorder_peer_map_footprint ( fd_recorder_peer_map_chain_cnt_est( FD_MAX_PEERS ) ) );
+
+  recorder->req_pool_gaddr  = fd_wksp_gaddr_fast( wksp, fd_recorder_req_pool_join ( fd_recorder_req_pool_new ( req_pool, MAX_REQUESTS ) )                                             );
+  recorder->req_map_gaddr   = fd_wksp_gaddr_fast( wksp, fd_recorder_req_map_join  ( fd_recorder_req_map_new  ( req_map, fd_recorder_req_map_chain_cnt_est( MAX_REQUESTS ), seed ) )   );
+  recorder->req_dlist_gaddr = fd_wksp_gaddr_fast( wksp, fd_recorder_req_dlist_join( fd_recorder_req_dlist_new( req_dlist ) )                                                          );
+  recorder->peer_pool_gaddr = fd_wksp_gaddr_fast( wksp, fd_recorder_peer_pool_join( fd_recorder_peer_pool_new( peer_pool, FD_MAX_PEERS ) )                                            );
+  recorder->peer_map_gaddr  = fd_wksp_gaddr_fast( wksp, fd_recorder_peer_map_join ( fd_recorder_peer_map_new ( peer_map, fd_recorder_peer_map_chain_cnt_est( FD_MAX_PEERS ), seed ) ) );
+
+  recorder->recorder_gaddr = fd_wksp_gaddr_fast( wksp, recorder );
+  recorder->seed                   = seed;
+  recorder->timeout_ns             = timeout_ns;
+  recorder->total_active_requests  = 0UL;
+  recorder->total_expired_requests = 0UL;
+  recorder->total_handled_requests = 0UL;
+  recorder->peer_cnt               = 0UL;
+
+  /* Initialize priority counts and indices */
+  recorder->high_priority_cnt   = 0UL;
+  recorder->medium_priority_cnt = 0UL;
+  recorder->low_priority_cnt    = 0UL;
+  recorder->zero_hr_cnt         = 0UL;
+
+  recorder->high_priority_idx   = 0UL;
+  recorder->medium_priority_idx = 0UL;
+  recorder->low_priority_idx    = 0UL;
+  recorder->zero_hr_idx         = 0UL;
+
+  recorder->cycle_position = 0UL;
+  recorder->cycle_count    = 0UL;
+
+  /* Initialize the read-write lock */
+  recorder->rw_lock = (fd_rwlock_t){0};
+
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( recorder->magic ) = FD_RECORDER_MAGIC;
+  FD_COMPILER_MFENCE();
+
+  return shmem;
+}
+
+fd_recorder_t *
+fd_recorder_join( void * shrecorder ) {
+  fd_recorder_t * recorder = (fd_recorder_t *)shrecorder;
+
+  if( FD_UNLIKELY( !recorder ) ) {
+    FD_LOG_ERR(( "NULL recorder" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned((ulong)recorder, fd_recorder_align() ) ) ) {
+    FD_LOG_ERR(( "misaligned recorder" ));
+    return NULL;
+  }
+
+  fd_wksp_t * wksp = fd_wksp_containing( recorder );
+  if( FD_UNLIKELY( !wksp ) ) {
+    FD_LOG_ERR(( "recorder must be part of a workspace" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( recorder->magic!=FD_RECORDER_MAGIC ) ) {
+    FD_LOG_ERR(( "bad magic" ));
+    return NULL;
+  }
+
+  return recorder;
+}
+
+void *
+fd_recorder_leave( fd_recorder_t const * recorder ) {
+
+  if( FD_UNLIKELY( !recorder ) ) {
+    FD_LOG_WARNING(( "NULL recorder" ));
+    return NULL;
+  }
+
+  return (void *)recorder;
+}
+
+void *
+fd_recorder_delete( void * recorder ) {
+
+  if( FD_UNLIKELY( !recorder ) ) {
+    FD_LOG_ERR(( "NULL recorder" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned((ulong)recorder, fd_recorder_align() ) ) ) {
+    FD_LOG_ERR(( "misaligned recorder" ));
+    return NULL;
+  }
+
+  return recorder;
+}
+
+fd_recorder_req_t *
+fd_recorder_req_insert( fd_recorder_t *             recorder,
+                        ulong                       nonce,
+                        ulong                       timestamp_ns,
+                        fd_pubkey_t const *         pubkey,
+                        fd_ip4_port_t               ip4,
+                        ulong                       slot,
+                        ulong                       shred_idx ) {
+
+  /* Note: Caller must hold write lock on recorder->rw_lock */
+
+  if( FD_UNLIKELY( !recorder ) ) {
+    FD_LOG_WARNING(( "NULL recorder" ));
+    return NULL;
+  }
+
+  #if FD_RECORDER_USE_HANDHOLDING
+  if( FD_UNLIKELY( recorder->magic != FD_RECORDER_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+    return NULL;
+  }
+  #endif
+
+  fd_recorder_req_map_t * req_map  = fd_recorder_req_map( recorder );
+  fd_recorder_req_t *     req_pool = fd_recorder_req_pool( recorder );
+
+  /* Check if nonce already exists */
+  if( FD_UNLIKELY( fd_recorder_req_query( recorder, nonce ) ) ) {
+    FD_LOG_WARNING(( "nonce %lu already exists", nonce ));
+    return NULL;
+  }
+
+  /* Check if pool has space */
+  #if FD_RECORDER_USE_HANDHOLDING
+  if( FD_UNLIKELY( !fd_recorder_req_pool_free( req_pool ) ) ) {
+    FD_LOG_WARNING(( "request pool full" ));
+    return NULL;
+  }
+  #endif
+
+
+  /* Allocate new request from pool */
+  if (fd_recorder_req_pool_free(req_pool) == 0) {
+    FD_LOG_WARNING(( "request pool full" ));
+    return NULL;
+  }
+
+  fd_recorder_req_t * req = fd_recorder_req_pool_ele_acquire( req_pool );
+  memset( req, 0, sizeof(fd_recorder_req_t) );
+
+  if( FD_UNLIKELY( !req ) ) {
+    FD_LOG_WARNING(( "failed to acquire request from pool" ));
+    return NULL;
+  }
+
+  fd_recorder_peer_t * peer = fd_recorder_peer_query( recorder, pubkey );
+  if( FD_UNLIKELY( !peer ) ) {
+    FD_LOG_ERR(( "peer not found" ));
+    return NULL;
+  }
+  if( FD_UNLIKELY( peer->ip4.addr != ip4.addr ) ) {
+    FD_LOG_WARNING(( "IP mismatch" ));
+    return NULL;
+  }
+
+  /* Initialize request fields */
+  req->nonce        = nonce;
+  req->timestamp_ns = timestamp_ns;
+  req->pubkey       = *pubkey;
+  req->slot         = slot;
+  req->shred_idx    = shred_idx;
+
+  /* Update or add peer */
+  peer->inflight_to_peer_cnt++;
+
+  fd_recorder_req_map_ele_insert( req_map, req, req_pool );
+
+#if FD_RECORDER_USE_HANDHOLDING
+  FD_TEST( !fd_recorder_req_map_verify( req_map, fd_recorder_req_pool_max( req_pool ), req_pool ) );
+#endif
+
+  /* Get the pool index of this request */
+
+  /* Insert at tail of doubly linked list */
+  fd_recorder_req_dlist_t * dlist = fd_recorder_req_dlist( recorder );
+  fd_recorder_req_dlist_ele_push_tail( dlist, req, req_pool );
+
+  recorder->total_active_requests++;
+  return req;
+}
+
+int
+fd_recorder_req_remove( fd_recorder_t * recorder, ulong nonce, int is_recv ) {
+
+  if( FD_UNLIKELY( !recorder ) ) {
+    FD_LOG_WARNING(( "NULL recorder" ));
+    return -1;
+  }
+
+  #if FD_RECORDER_USE_HANDHOLDING
+  if( FD_UNLIKELY( recorder->magic != FD_RECORDER_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+    return -1;
+  }
+  #endif
+
+  fd_recorder_req_map_t * req_map  = fd_recorder_req_map( recorder );
+  fd_recorder_req_t *     req_pool = fd_recorder_req_pool( recorder );
+
+  fd_recorder_req_t * req = fd_recorder_req_map_ele_query( req_map, &nonce, NULL, req_pool );
+  if( FD_UNLIKELY( !req ) ) {
+    return -1;
+  }
+
+  fd_recorder_peer_t * peer = fd_recorder_peer_query( recorder, &req->pubkey );
+  if( FD_UNLIKELY( !peer ) ) {
+    FD_LOG_WARNING(( "peer not found" ));
+    return -1;
+  }
+
+  /* Update peer stats with the request information */
+  fd_recorder_peer_update( recorder, &peer->key, peer->ip4, is_recv, req->timestamp_ns, (ulong)fd_log_wallclock());
+
+  fd_recorder_req_dlist_t * dlist = fd_recorder_req_dlist( recorder );
+  fd_recorder_req_dlist_ele_remove( dlist, req, req_pool );
+
+  fd_recorder_req_map_ele_remove( req_map, &nonce, NULL, req_pool );
+  fd_recorder_req_pool_ele_release( req_pool, req );
+
+#if FD_RECORDER_USE_HANDHOLDING
+  FD_TEST( !fd_recorder_req_map_verify( req_map, fd_recorder_req_pool_max( req_pool ), req_pool ) );
+#endif
+
+  if( FD_LIKELY(is_recv) ) recorder->total_handled_requests++;
+  else                     recorder->total_expired_requests++;
+
+  recorder->total_active_requests--;
+
+  return 0;
+}
+
+ulong
+fd_recorder_req_expire( fd_recorder_t * recorder, ulong current_ns, int is_recv ) {
+
+  if( FD_UNLIKELY( !recorder ) ) {
+    FD_LOG_WARNING(( "NULL recorder" ));
+    return 0UL;
+  }
+
+  #if FD_RECORDER_USE_HANDHOLDING
+  if( FD_UNLIKELY( recorder->magic != FD_RECORDER_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+    return 0UL;
+  }
+  #endif
+
+  fd_recorder_req_dlist_t * dlist    = fd_recorder_req_dlist( recorder );
+  fd_recorder_req_t *       req_pool = fd_recorder_req_pool( recorder );
+  ulong                     expired_cnt = 0UL;
+
+  /* Traverse from head (oldest) and remove expired requests */
+  fd_recorder_req_dlist_iter_t iter = fd_recorder_req_dlist_iter_fwd_init( dlist, req_pool );
+  while( !fd_recorder_req_dlist_iter_done( iter, dlist, req_pool ) ) {
+    fd_recorder_req_t * req = fd_recorder_req_dlist_iter_ele( iter, dlist, req_pool );
+
+    /* Check if request has expired */
+    if( FD_UNLIKELY( req->timestamp_ns + recorder->timeout_ns > current_ns ) ) break;
+
+    iter = fd_recorder_req_dlist_iter_fwd_next( iter, dlist, req_pool );
+
+    /* Remove request from list and map */
+    fd_recorder_req_remove( recorder, req->nonce, is_recv );
+
+    expired_cnt++;
+  }
+
+  return expired_cnt;
+}
+
+fd_recorder_peer_t *
+fd_recorder_peer_add( fd_recorder_t *             recorder,
+                      fd_pubkey_t const *         pubkey,
+                      fd_ip4_port_t               ip4 ) {
+
+  if( FD_UNLIKELY( !recorder) ) {
+    FD_LOG_WARNING(( "NULL recorder" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !pubkey ) ) {
+    FD_LOG_WARNING(( "NULL pubkey" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( recorder->peer_cnt > FD_MAX_PEERS) ) {
+    FD_LOG_WARNING(( "peer list full" ));
+    return NULL;
+  }
+
+  fd_recorder_peer_map_t * peer_map  = fd_recorder_peer_map( recorder );
+  fd_recorder_peer_t *     peer_pool = fd_recorder_peer_pool( recorder );
+
+  /* Check if peer already exists */
+  fd_recorder_peer_t * existing = fd_recorder_peer_map_ele_query( peer_map, pubkey, NULL, peer_pool );
+  if( FD_UNLIKELY( existing ) ) { // will be unlikley after gossip delta push outs are implemented
+    /* Update existing peer info */
+    existing->ip4 = ip4;
+    return existing;
+  }
+
+  /* Allocate new peer */
+  fd_recorder_peer_t * peer = fd_recorder_peer_pool_ele_acquire( peer_pool );
+  if( FD_UNLIKELY( !peer ) ) {
+    FD_LOG_WARNING(( "failed to acquire peer from pool" ));
+    return NULL;
+  }
+
+  /* Initialize peer */
+  peer->key               = *pubkey;
+  peer->ip4               = ip4;
+  peer->ewma_hr           = -1;
+  peer->ewma_rtt          = 0UL;
+  peer->inflight_to_peer_cnt  = 0UL;
+
+  /* Insert into map */
+  if( FD_UNLIKELY( !fd_recorder_peer_map_ele_insert( peer_map, peer, peer_pool ) ) ) {
+    FD_LOG_WARNING(( "failed to insert peer into map" ));
+    return NULL;
+  }
+
+#if FD_RECORDER_USE_HANDHOLDING
+  FD_TEST( !fd_recorder_peer_map_verify( peer_map, fd_recorder_peer_pool_max( peer_pool ), peer_pool ) );
+#endif
+
+  recorder->peer_cnt++;
+
+  return peer;
+}
+
+fd_recorder_peer_t *
+fd_recorder_peer_update( fd_recorder_t *             recorder,
+                         fd_pubkey_t const *         pubkey,
+                         fd_ip4_port_t               ip4  FD_PARAM_UNUSED,
+                         int                         is_recv,
+                         ulong                       req_timestamp_ns,
+                         ulong                       current_time ) {
+  if( FD_UNLIKELY( !recorder || !pubkey ) ) {
+    FD_LOG_WARNING(( "NULL recorder or pubkey" ));
+    return NULL;
+  }
+
+  fd_recorder_peer_map_t * peer_map  = fd_recorder_peer_map( recorder );
+  fd_recorder_peer_t *     peer_pool = fd_recorder_peer_pool( recorder );
+
+  /* Check if peer already exists */
+  fd_recorder_peer_t * existing = fd_recorder_peer_map_ele_query( peer_map, pubkey, NULL, peer_pool );
+  if( FD_LIKELY( existing ) ) {
+    /* Regardless of whether the request was received or expired, update
+       the peer's hit rate and RTT */
+    double hr_sample = is_recv ? 1.0 : 0.0;
+    if (existing->ewma_hr == -1) {
+        existing->ewma_hr = hr_sample;
+    } else {
+        existing->ewma_hr = existing->ewma_hr * 0.9 + hr_sample * 0.1;
+    }
+
+    /* Only update RTT if the request was received */
+    if (FD_LIKELY(is_recv)) {
+      double rtt_sample = (double)(current_time - req_timestamp_ns);
+      existing->ewma_rtt = (existing->ewma_rtt == 0) ? rtt_sample : existing->ewma_rtt * 0.9 + rtt_sample * 0.1;
+    }
+
+    existing->inflight_to_peer_cnt--;
+    return existing;
+  }
+  return NULL;
+}
+
+fd_recorder_peer_t *
+fd_recorder_peer_remove( fd_recorder_t * recorder, fd_pubkey_t const * pubkey ) {
+  fd_recorder_peer_map_t * peer_map  = fd_recorder_peer_map( recorder );
+  fd_recorder_peer_t *     peer_pool = fd_recorder_peer_pool( recorder );
+  fd_recorder_peer_t *     peer = fd_recorder_peer_map_ele_remove( peer_map, (void *)pubkey, NULL, peer_pool );
+  if( peer ) {
+    #if FD_RECORDER_USE_HANDHOLDING
+        FD_TEST( !fd_recorder_peer_map_verify( peer_map, fd_recorder_peer_pool_max( peer_pool ), peer_pool ) );
+    #endif
+
+    recorder->peer_cnt--;
+  }
+  return peer;
+}
+
+/* Helper function to reshuffle peers into categories based on RTT and HR */
+void FD_FN_UNUSED
+fd_recorder_reshuffle_peers_boundaries( fd_recorder_t * recorder ) {
+  recorder->high_priority_cnt = 0;
+  recorder->medium_priority_cnt = 0;
+  recorder->low_priority_cnt = 0;
+  recorder->zero_hr_cnt = 0;
+
+  recorder->high_priority_idx = 0;
+  recorder->medium_priority_idx = 0;
+  recorder->low_priority_idx = 0;
+  recorder->zero_hr_idx = 0;
+
+  fd_recorder_peer_map_t * peer_map = fd_recorder_peer_map( recorder );
+  fd_recorder_peer_t * peer_pool = fd_recorder_peer_pool( recorder );
+
+  for( fd_recorder_peer_map_iter_t iter = fd_recorder_peer_map_iter_init( peer_map, peer_pool );
+       !fd_recorder_peer_map_iter_done( iter, peer_map, peer_pool );
+       iter = fd_recorder_peer_map_iter_next( iter, peer_map, peer_pool ) ) {
+
+      fd_recorder_peer_t * peer = fd_recorder_peer_map_iter_ele( iter, peer_map, peer_pool );
+
+      /* Check if peer has zero hit rate */
+      if( peer->ewma_hr <= 0.0 ) {
+        recorder->zero_hr_peers[recorder->zero_hr_cnt++] = &peer->key;
+      }
+      else if( peer->ewma_rtt < 50000000UL ) { /* < 50ms */
+        recorder->high_priority_peers[recorder->high_priority_cnt++] = &peer->key;
+      }
+      else if( peer->ewma_rtt < 100000000UL ) { /* 50-100ms */
+        recorder->medium_priority_peers[recorder->medium_priority_cnt++] = &peer->key;
+      }
+      else { /* >= 100ms */
+        recorder->low_priority_peers[recorder->low_priority_cnt++] = &peer->key;
+      }
+
+    }
+}
+
+/* Helper structure for sorting peers by RTT */
+struct peer_rtt_pair {
+  fd_pubkey_t * key;
+  double        rtt;
+};
+
+/* Comparison function for qsort - sorts by RTT ascending (quickest first) */
+static int
+peer_rtt_compare( const void * a, const void * b ) {
+  const struct peer_rtt_pair * pair_a = (const struct peer_rtt_pair *)a;
+  const struct peer_rtt_pair * pair_b = (const struct peer_rtt_pair *)b;
+
+  if( pair_a->rtt < pair_b->rtt ) return -1;
+  if( pair_a->rtt > pair_b->rtt ) return 1;
+  return 0;
+}
+
+/* Helper function to reshuffle peers into categories based on count.
+   First 500 quickest -> high priority
+   Next 500 quickest -> medium priority
+   Remaining -> low priority
+   Zero hit rate peers stay separate */
+void
+fd_recorder_reshuffle_peers_cnt( fd_recorder_t * recorder ) {
+  recorder->high_priority_cnt = 0;
+  recorder->medium_priority_cnt = 0;
+  recorder->low_priority_cnt = 0;
+  recorder->zero_hr_cnt = 0;
+
+  recorder->high_priority_idx = 0;
+  recorder->medium_priority_idx = 0;
+  recorder->low_priority_idx = 0;
+  recorder->zero_hr_idx = 0;
+
+  fd_recorder_peer_map_t * peer_map = fd_recorder_peer_map( recorder );
+  fd_recorder_peer_t * peer_pool = fd_recorder_peer_pool( recorder );
+
+  /* First pass: count total peers and separate zero HR peers */
+  ulong non_zero_hr_peers = 0;
+
+  for( fd_recorder_peer_map_iter_t iter = fd_recorder_peer_map_iter_init( peer_map, peer_pool );
+       !fd_recorder_peer_map_iter_done( iter, peer_map, peer_pool );
+       iter = fd_recorder_peer_map_iter_next( iter, peer_map, peer_pool ) ) {
+
+    fd_recorder_peer_t * peer = fd_recorder_peer_map_iter_ele( iter, peer_map, peer_pool );
+
+    /* Separate zero hit rate peers immediately */
+    if( peer->ewma_hr <= 0.0 ) recorder->zero_hr_peers[recorder->zero_hr_cnt++] = &peer->key;
+    else                       non_zero_hr_peers++;
+  }
+
+  /* If no non-zero HR peers, we're done */
+  if( FD_UNLIKELY( non_zero_hr_peers == 0 ) ) return;
+
+  /* Allocate temporary array for sorting non-zero HR peers */
+  struct peer_rtt_pair sorted_peers[FD_MAX_PEERS];
+  ulong sorted_count = 0;
+
+  /* Second pass: collect non-zero HR peers for sorting */
+  for( fd_recorder_peer_map_iter_t iter = fd_recorder_peer_map_iter_init( peer_map, peer_pool );
+       !fd_recorder_peer_map_iter_done( iter, peer_map, peer_pool );
+       iter = fd_recorder_peer_map_iter_next( iter, peer_map, peer_pool ) ) {
+
+    fd_recorder_peer_t * peer = fd_recorder_peer_map_iter_ele( iter, peer_map, peer_pool );
+
+    /* Skip zero HR peers (already handled) */
+    if( FD_UNLIKELY( peer->ewma_hr <= 0.0 ) ) continue;
+
+    /* Add to sorting array */
+    sorted_peers[sorted_count].key = &peer->key;
+    sorted_peers[sorted_count].rtt = peer->ewma_rtt;
+    sorted_count++;
+  }
+
+  /* Sort peers by RTT (quickest first) */
+  qsort( sorted_peers, sorted_count, sizeof(struct peer_rtt_pair), peer_rtt_compare );
+
+  /* Distribute sorted peers into buckets:
+     - First 500: high priority
+     - Next 500: medium priority
+     - Remaining: low priority */
+
+  for( ulong i = 0; i < sorted_count; i++ ) {
+    if( i < 500 ) {
+      /* First 500 quickest -> high priority */
+      recorder->high_priority_peers[recorder->high_priority_cnt++] = sorted_peers[i].key;
+    } else if( i < 1000 ) {
+      /* Next 500 quickest -> medium priority */
+      recorder->medium_priority_peers[recorder->medium_priority_cnt++] = sorted_peers[i].key;
+    } else {
+      /* Remaining -> low priority */
+      recorder->low_priority_peers[recorder->low_priority_cnt++] = sorted_peers[i].key;
+    }
+  }
+}
+
+fd_pubkey_t *
+fd_recorder_select_peer(fd_recorder_t * recorder) {
+  if( FD_UNLIKELY( !recorder ) ) {
+    FD_LOG_WARNING(( "NULL recorder" ));
+    return NULL;
+  }
+
+  /* Check if we need to reshuffle */
+  if( FD_UNLIKELY( recorder->cycle_position == 0 && (recorder->cycle_count % 10000) == 0 ) ) {
+    fd_recorder_reshuffle_peers_cnt( recorder );
+  }
+
+  /* Define the weighted round-robin pattern:
+     - High priority (<50ms): 10 polls per cycle
+     - Medium priority (50-100ms): 5 polls per cycle
+     - Low priority (>=100ms): 1 poll per cycle
+     - Zero HR: 1 poll per cycle (handled separately)
+
+     Pattern: H,H,H,M,H,H,H,M,H,H,H,M,H,H,H,M,H,H,M,L,Z (21 total positions) */
+
+  static const int pattern[] = {
+    0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 2, 3
+  };
+  static const ulong pattern_len = sizeof(pattern) / sizeof(pattern[0]);
+
+  /* Try to find a peer following the pattern */
+  for( ulong attempts = 0; attempts < pattern_len; attempts++ ) {
+    int category = pattern[recorder->cycle_position];
+
+    fd_pubkey_t * selected = NULL;
+
+    switch( category ) {
+      case 0: /* High priority */
+        if( recorder->high_priority_cnt > 0 ) {
+          selected = recorder->high_priority_peers[recorder->high_priority_idx];
+          recorder->high_priority_idx = (recorder->high_priority_idx + 1) % recorder->high_priority_cnt;
+        }
+        break;
+
+      case 1: /* Medium priority */
+        if( recorder->medium_priority_cnt > 0 ) {
+          selected = recorder->medium_priority_peers[recorder->medium_priority_idx];
+          recorder->medium_priority_idx = (recorder->medium_priority_idx + 1) % recorder->medium_priority_cnt;
+        }
+        break;
+
+      case 2: /* Low priority */
+        if( recorder->low_priority_cnt > 0 ) {
+          selected = recorder->low_priority_peers[recorder->low_priority_idx];
+          recorder->low_priority_idx = (recorder->low_priority_idx + 1) % recorder->low_priority_cnt;
+        }
+        break;
+
+      case 3: /* Zero HR */
+        if( recorder->zero_hr_cnt > 0 ) {
+          selected = recorder->zero_hr_peers[recorder->zero_hr_idx];
+          recorder->zero_hr_idx = (recorder->zero_hr_idx + 1) % recorder->zero_hr_cnt;
+        }
+        break;
+    }
+
+    /* Move to next position in pattern */
+    recorder->cycle_position = (recorder->cycle_position + 1) % pattern_len;
+    if( FD_UNLIKELY( recorder->cycle_position == 0 ) ) recorder->cycle_count++;
+
+    /* If we found a peer, return it */
+    if( FD_LIKELY( selected ) ) {
+      return selected;
+    }
+
+    /* If no peers available in any category, break to avoid infinite loop */
+    if( FD_UNLIKELY( recorder->high_priority_cnt == 0 &&
+                     recorder->medium_priority_cnt == 0 &&
+                     recorder->low_priority_cnt == 0 &&
+                     recorder->zero_hr_cnt == 0 ) ) {
+      FD_LOG_WARNING(( "No peers available for selection" ));
+      break;
+    }
+  }
+
+  return NULL; /* No peer selected */
+}
+
+
+/* helpers */
+
+int
+fd_recorder_verify( fd_recorder_t const * recorder ) {
+  if( FD_UNLIKELY( !recorder ) ) {
+    FD_LOG_WARNING(( "NULL recorder" ));
+    return -1;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)recorder, fd_recorder_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned recorder" ));
+    return -1;
+  }
+
+  fd_wksp_t * wksp = fd_wksp_containing( recorder );
+  if( FD_UNLIKELY( !wksp ) ) {
+    FD_LOG_WARNING(( "recorder must be part of a workspace" ));
+    return -1;
+  }
+
+  if( FD_UNLIKELY( recorder->magic!=FD_RECORDER_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+    return -1;
+  }
+
+  fd_recorder_req_t const *     req_pool = fd_recorder_req_pool_const( recorder );
+  fd_recorder_req_map_t const * req_map  = fd_recorder_req_map_const( recorder );
+  fd_recorder_req_dlist_t const * req_dlist  = fd_recorder_req_dlist_const( recorder );
+  fd_recorder_peer_t const *     peer_pool = fd_recorder_peer_pool_const( recorder );
+  fd_recorder_peer_map_t const * peer_map  = fd_recorder_peer_map_const( recorder );
+
+  /* Verify map consistency */
+  if( fd_recorder_req_map_verify( req_map, fd_recorder_req_pool_max( req_pool ), req_pool ) ) {
+    FD_LOG_WARNING(( "map verification failed" ));
+    return -1;
+  }
+
+  if( fd_recorder_peer_map_verify( peer_map, fd_recorder_peer_pool_max( peer_pool ), peer_pool ) ) {
+    FD_LOG_WARNING(( "peer map verification failed" ));
+    return -1;
+  }
+
+  if( fd_recorder_req_dlist_verify( req_dlist, fd_recorder_req_pool_max( req_pool ), req_pool ) ) {
+    FD_LOG_WARNING(( "dlist verification failed" ));
+    return -1;
+  }
+
+  return 0;
+}
+
+void
+fd_recorder_peer_print( fd_recorder_peer_t * peer ) {
+  FD_LOG_NOTICE(("Peer: %s, IP: "FD_IP4_ADDR_FMT", ewma_hr: %f, ewma_rtt: %f, inflight_to_peer_cnt: %lu",
+                 FD_BASE58_ENC_32_ALLOCA(&peer->key), FD_IP4_ADDR_FMT_ARGS(peer->ip4.addr), peer->ewma_hr, peer->ewma_rtt, peer->inflight_to_peer_cnt));
+}
+
+void
+fd_recorder_print_first_nonce( fd_recorder_t * recorder ) {
+  fd_recorder_req_dlist_t * dlist = fd_recorder_req_dlist( recorder );
+  fd_recorder_req_t * req = fd_recorder_req_dlist_iter_ele( fd_recorder_req_dlist_iter_fwd_init( dlist, fd_recorder_req_pool( recorder ) ), dlist, fd_recorder_req_pool( recorder ) );
+  FD_LOG_NOTICE(("First nonce: %lu", req->nonce));
+}
+
+void
+fd_recorder_print_summary( fd_recorder_t const * recorder ) {
+  if( FD_UNLIKELY( !recorder ) ) {
+    FD_LOG_WARNING(( "NULL recorder" ));
+    return;
+  }
+
+  FD_LOG_NOTICE(("Peer active_requests: %lu, expired_requests: %lu, handled_requests: %lu", recorder->total_active_requests, recorder->total_expired_requests, recorder->total_handled_requests));
+}

--- a/src/flamenco/repair/fd_recorder.h
+++ b/src/flamenco/repair/fd_recorder.h
@@ -1,0 +1,489 @@
+#ifndef HEADER_fd_src_discof_repair_fd_recorder_h
+#define HEADER_fd_src_discof_repair_fd_recorder_h
+
+/*
+Recorder:
+
+The recorder tracks peers and outstanding repair requests for the Solana
+repair protocol. It maintains two hash maps: one for peers and one for
+requests, with automatic expiration handling.
+
+   The recorder manages:
+   - Peer tracking with IP addresses and timestamps
+   - Outstanding repair requests with nonces, timeouts, and target peers
+   - Peer selection for new repair requests
+   - Automatic cleanup of expired requests
+
+   The recorder is designed for concurrent access from multiple tiles:
+   - Allocated in a dedicated workspace for shared memory access
+   - Protected by a read-write lock for thread-safe operations
+   - Joinable by multiple tiles (e.g., repair tile, shredcap tile)
+
+   Typical usage:
+
+     // Create in workspace
+     void * mem = fd_wksp_alloc_laddr( wksp, fd_recorder_align(),
+                                       fd_recorder_footprint(), 1UL );
+     fd_recorder_t * recorder = fd_recorder_join(
+    fd_recorder_new( mem, seed, timeout_ns ) );
+
+     // Access with appropriate locking
+     fd_rwlock_write( &recorder->rw_lock );
+     fd_recorder_peer_add( recorder, pubkey, ip4_port );
+     fd_rwlock_unwrite( &recorder->rw_lock );
+
+     // Query with read lock
+     fd_rwlock_read( &recorder->rw_lock );
+     fd_recorder_req_t * req = fd_recorder_req_query( recorder, nonce );
+     // Use req...
+     fd_rwlock_unread( &recorder->rw_lock );
+
+   IMPORTANT: Pointers returned by query functions are only valid while the lock is held.
+   Do not use returned pointers after releasing the lock. */
+
+
+/* IMPORTANT NOTE ON LOCKING:
+   Currently, the recorder does not implement locking given that it's
+   only accessed by the repair tile. Initial implementation was to use
+   locking in order to allow multiple tiles to access the recorder.
+   However, this is no longer needed. Locking functionality remains in
+   the library for future use, if needed, but is currently unused.
+*/
+
+#include "../../flamenco/types/fd_types.h"
+#include "../../util/net/fd_net_headers.h"
+#include "../../flamenco/fd_rwlock.h"
+#include <stdbool.h>
+
+#define FD_MAX_PEERS (1<<12)
+#define MAX_REQUESTS (1000000UL)
+
+
+
+/* FD_RECORDER_USE_HANDHOLDING: Define this to non-zero at compile time
+   to turn on additional runtime checks and logging. */
+#define FD_RECORDER_USE_HANDHOLDING 0
+
+
+#define FD_RECORDER_MAGIC (0xf17eda2ce7940570UL) /* firedancer recorder version 0 */
+
+/* fd_recorder_req_t represents a single peer request in the system.
+   Each request is tracked by a unique nonce and contains metadata
+   about the request including timestamp, peer pubkey, and request data. */
+
+struct __attribute__((aligned(128UL))) fd_recorder_req {
+  ulong         nonce;         /* unique identifier for the request */
+  ulong         next;          /* reserved for internal use by fd_pool and fd_map_chain */
+  ulong         timestamp_ns;  /* timestamp when request was created (nanoseconds) */
+  fd_pubkey_t   pubkey;        /* public key of the peer */
+
+  /* Doubly linked list pointers for timeout management */
+  ulong         prev_idx;      /* pool index of previous element in timeout list */
+  ulong         next_idx;      /* pool index of next element in timeout list */
+
+  /* Request-specific data (can be extended based on needs) */
+  ulong         slot;          /* slot number for the request */
+  ulong         shred_idx;     /* shred index within the slot */
+};
+typedef struct fd_recorder_req fd_recorder_req_t;
+
+/* Define the memory pool for recorder requests */
+#define POOL_NAME       fd_recorder_req_pool
+#define POOL_T          fd_recorder_req_t
+#include "../../util/tmpl/fd_pool.c"
+
+/* Define the hash map for nonce -> request mapping */
+#define MAP_NAME        fd_recorder_req_map
+#define MAP_ELE_T       fd_recorder_req_t
+#define MAP_KEY         nonce
+#include "../../util/tmpl/fd_map_chain.c"
+
+#define DLIST_NAME      fd_recorder_req_dlist
+#define DLIST_ELE_T     fd_recorder_req_t
+#define DLIST_PREV      prev_idx
+#define DLIST_NEXT      next_idx
+#include "../../util/tmpl/fd_dlist.c"
+
+struct __attribute__((aligned(64UL))) fd_recorder_peer {
+  fd_pubkey_t   key;                  /* peer's public key */
+  ulong         next;                 /* reserved for internal use by fd_map_chain */
+  fd_ip4_port_t ip4;                  /* peer's IP */
+  double        ewma_hr;              /* exponentially weighted moving average hit rate */
+  double        ewma_rtt;             /* exponentially weighted moving average RTT */
+  ulong         inflight_to_peer_cnt; /* number of inflight requests to this peer */
+};
+typedef struct fd_recorder_peer fd_recorder_peer_t;
+
+/* Define the memory pool for recorder peers */
+#define POOL_NAME fd_recorder_peer_pool
+#define POOL_T    fd_recorder_peer_t
+#include "../../util/tmpl/fd_pool.c"
+
+/* Define the hash map for pubkey -> peer mapping */
+#define MAP_NAME  fd_recorder_peer_map
+#define MAP_ELE_T fd_recorder_peer_t
+#define MAP_KEY   key
+#define MAP_KEY_T fd_pubkey_t
+#define MAP_KEY_EQ(k0,k1) (!memcmp( (k0), (k1), 32UL ))
+#define MAP_KEY_HASH(key,seed) fd_hash((seed),(key),32UL)
+#include "../../util/tmpl/fd_map_chain.c"
+
+#define FD_RECORDER_MAGIC_INTERNAL (0xf17eda2ce7940570UL)
+
+struct __attribute__((aligned(128UL))) fd_recorder {
+  /* Metadata */
+  ulong magic;
+  ulong recorder_gaddr;        /* wksp gaddr of this in the backing wksp */
+  ulong seed;                  /* seed for hash functions */
+  ulong timeout_ns;            /* global timeout duration for requests in nanoseconds */
+  fd_rwlock_t rw_lock;         /* read-write lock for the recorder */
+
+  /* Memory pool, hash map, and dlist for reqs and peers */
+  ulong req_pool_gaddr;
+  ulong req_map_gaddr;
+  ulong req_dlist_gaddr;
+  ulong peer_pool_gaddr;
+  ulong peer_map_gaddr;
+
+  /* Stats */
+  ulong total_active_requests;     /* current number of active requests */
+  ulong total_expired_requests;    /* total number of expired requests */
+  ulong total_handled_requests;    /* total number of handled requests */
+
+  ulong peer_cnt;        /* current number of active peers */
+  /* Peer arrays used for weighted round-robin selection */
+  fd_pubkey_t * high_priority_peers[FD_MAX_PEERS];
+  fd_pubkey_t * medium_priority_peers[FD_MAX_PEERS];
+  fd_pubkey_t * low_priority_peers[FD_MAX_PEERS];
+  fd_pubkey_t * zero_hr_peers[FD_MAX_PEERS];
+
+  ulong high_priority_cnt;    /* number of high priority peers */
+  ulong medium_priority_cnt;  /* number of medium priority peers */
+  ulong low_priority_cnt;     /* number of low priority peers */
+  ulong zero_hr_cnt;          /* number of zero HR peers */
+
+  ulong high_priority_idx;    /* current index in high priority list */
+  ulong medium_priority_idx;  /* current index in medium priority list */
+  ulong low_priority_idx;     /* current index in low priority list */
+  ulong zero_hr_idx;          /* current index in zero HR list */
+
+  ulong cycle_position;       /* position in the weighted round-robin cycle */
+  ulong cycle_count;          /* number of complete cycles */
+
+};
+typedef struct fd_recorder fd_recorder_t;
+
+FD_PROTOTYPES_BEGIN
+
+/* ================= CONSTRUCTORS ================= */
+
+/* fd_recorder_{align,footprint} return the required alignment and
+   footprint of memory suitable for use as recorder. */
+
+FD_FN_CONST static inline ulong
+fd_recorder_align( void ) {
+  return alignof(fd_recorder_t);
+}
+
+FD_FN_CONST static inline ulong
+fd_recorder_footprint( void ) {
+  ulong req_chain_cnt = fd_recorder_req_map_chain_cnt_est( MAX_REQUESTS );
+  ulong peer_chain_cnt = fd_recorder_peer_map_chain_cnt_est( FD_MAX_PEERS );
+
+  return FD_LAYOUT_FINI(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_INIT,
+      alignof(fd_recorder_t),                sizeof(fd_recorder_t) ),
+      fd_recorder_req_pool_align(),          fd_recorder_req_pool_footprint( MAX_REQUESTS ) ),
+      fd_recorder_req_map_align(),           fd_recorder_req_map_footprint( req_chain_cnt ) ),
+      fd_recorder_req_dlist_align(),         fd_recorder_req_dlist_footprint() ),
+      fd_recorder_peer_pool_align(),         fd_recorder_peer_pool_footprint( FD_MAX_PEERS ) ),
+      fd_recorder_peer_map_align(),          fd_recorder_peer_map_footprint( peer_chain_cnt ) ),
+    fd_recorder_align() );
+}
+
+/* fd_recorder_new formats an unused memory region for use as a recorder.
+   shmem is a non-NULL pointer to this region in the local address space
+   with the required footprint and alignment.  seed is an arbitrary
+   value used for hash functions.  timeout_ns is the timeout duration in
+   nanoseconds. */
+
+void * fd_recorder_new( void * shmem, ulong seed, ulong timeout_ns );
+
+/* fd_recorder_join joins the caller to the recorder. */
+
+fd_recorder_t * fd_recorder_join( void * shrecorder );
+
+/* fd_recorder_leave leaves a current local join. */
+
+void * fd_recorder_leave( fd_recorder_t const * recorder );
+
+/* fd_recorder_delete unformats a memory region used as a recorder. */
+
+void * fd_recorder_delete( void * recorder );
+
+/* ================= ACCESSORS ================= */
+
+/* fd_recorder_wksp returns the local join to the wksp backing the
+   recorder. The lifetime of the returned pointer is at least as long as
+   the lifetime of the local join.  Assumes recorder is a current local
+   join. */
+
+FD_FN_PURE static inline fd_wksp_t * fd_recorder_wksp( fd_recorder_t const * recorder ) { return (fd_wksp_t *)( ( (ulong)recorder ) - recorder->recorder_gaddr ); }
+
+/* fd_recorder_{req_pool,req_map,req_dlist,peer_pool,peer_map} returns a
+   pointer in the caller's address space to the corresponding recorder
+   field. const versions for each are also provided. */
+
+FD_FN_PURE static inline fd_recorder_req_t             * fd_recorder_req_pool        ( fd_recorder_t       * recorder ) { return fd_wksp_laddr_fast( fd_recorder_wksp( recorder ), recorder->req_pool_gaddr  ); }
+FD_FN_PURE static inline fd_recorder_req_t       const * fd_recorder_req_pool_const  ( fd_recorder_t const * recorder ) { return fd_wksp_laddr_fast( fd_recorder_wksp( recorder ), recorder->req_pool_gaddr  ); }
+FD_FN_PURE static inline fd_recorder_req_map_t         * fd_recorder_req_map         ( fd_recorder_t       * recorder ) { return fd_wksp_laddr_fast( fd_recorder_wksp( recorder ), recorder->req_map_gaddr   ); }
+FD_FN_PURE static inline fd_recorder_req_map_t   const * fd_recorder_req_map_const   ( fd_recorder_t const * recorder ) { return fd_wksp_laddr_fast( fd_recorder_wksp( recorder ), recorder->req_map_gaddr   ); }
+FD_FN_PURE static inline fd_recorder_req_dlist_t       * fd_recorder_req_dlist       ( fd_recorder_t       * recorder ) { return fd_wksp_laddr_fast( fd_recorder_wksp( recorder ), recorder->req_dlist_gaddr ); }
+FD_FN_PURE static inline fd_recorder_req_dlist_t const * fd_recorder_req_dlist_const ( fd_recorder_t const * recorder ) { return fd_wksp_laddr_fast( fd_recorder_wksp( recorder ), recorder->req_dlist_gaddr ); }
+FD_FN_PURE static inline fd_recorder_peer_t            * fd_recorder_peer_pool       ( fd_recorder_t       * recorder ) { return fd_wksp_laddr_fast( fd_recorder_wksp( recorder ), recorder->peer_pool_gaddr ); }
+FD_FN_PURE static inline fd_recorder_peer_t      const * fd_recorder_peer_pool_const ( fd_recorder_t const * recorder ) { return fd_wksp_laddr_fast( fd_recorder_wksp( recorder ), recorder->peer_pool_gaddr ); }
+FD_FN_PURE static inline fd_recorder_peer_map_t        * fd_recorder_peer_map        ( fd_recorder_t       * recorder ) { return fd_wksp_laddr_fast( fd_recorder_wksp( recorder ), recorder->peer_map_gaddr  ); }
+FD_FN_PURE static inline fd_recorder_peer_map_t  const * fd_recorder_peer_map_const  ( fd_recorder_t const * recorder ) { return fd_wksp_laddr_fast( fd_recorder_wksp( recorder ), recorder->peer_map_gaddr  ); }
+
+
+/* fd_recorder_{timeout_ns,req_cnt,peer_cnt} return recorder statistics and configuration. */
+FD_FN_PURE static inline ulong fd_recorder_timeout_ns ( fd_recorder_t const * recorder ) { return recorder->timeout_ns;             }
+FD_FN_PURE static inline ulong fd_recorder_req_cnt    ( fd_recorder_t const * recorder ) { return recorder->total_active_requests;  }
+FD_FN_PURE static inline ulong fd_recorder_peer_cnt   ( fd_recorder_t const * recorder ) { return recorder->peer_cnt;               }
+
+/* ================== ALL HANDLING OPERATIONS ================== */
+
+/* LOCKING PROTOCOL:
+
+   The recorder uses a read-write lock (rw_lock) for thread-safe
+   concurrent access. All operations on the recorder require appropriate
+   locking:
+
+   - READ LOCK: Required for operations that only query/read data
+     without modifying state
+     - req_query, peer_query
+     - req_oldest, req_newest
+     - verify, print operations
+
+   - WRITE LOCK: Required for operations that modify the data structure
+     - req_insert, req_remove, req_expire
+     - peer_add, peer_remove, peer_update
+     - select_peers (modifies internal indices)
+
+   Lock acquisition/release is the CALLER'S responsibility. The recorder
+   functions do NOT acquire or release locks internally. Typical usage:
+
+     fd_rwlock_read( &recorder->rw_lock );
+     fd_recorder_req_t * req = fd_recorder_req_query( recorder, nonce );
+     // Use req while lock is held...
+     fd_rwlock_unread( &recorder->rw_lock );
+
+   IMPORTANT: Pointers returned by query functions are only valid while
+   the lock is held. Do not use returned pointers after releasing the
+   lock. */
+
+/* ================== REQUEST HANDLING ================== */
+
+/* fd_recorder_req_insert inserts a new request into the recorder.
+   Returns a pointer to the inserted request on success, NULL on
+   failure. Failures can occur if the recorder is full or if the nonce
+   already exists.
+
+   Requires caller to hold WRITE LOCK on recorder->rw_lock */
+
+fd_recorder_req_t *
+fd_recorder_req_insert( fd_recorder_t *             recorder,
+                        ulong                       nonce,
+                        ulong                       timestamp_ns,
+                        fd_pubkey_t const *         pubkey,
+                        fd_ip4_port_t               ip4,
+                        ulong                       slot,
+                        ulong                       shred_idx );
+
+/* fd_recorder_req_query looks up a request by its nonce.
+   Returns a pointer to the request if found, NULL otherwise.
+
+   Requires caller to hold READ LOCK on recorder->rw_lock
+   The returned pointer is only valid while the lock is held. */
+
+FD_FN_PURE static inline fd_recorder_req_t const *
+fd_recorder_req_query_const( fd_recorder_t const * recorder, ulong nonce ) {
+  fd_recorder_req_map_t const * req_map  = fd_recorder_req_map_const( recorder );
+  fd_recorder_req_t const *     req_pool = fd_recorder_req_pool_const( recorder );
+  return fd_recorder_req_map_ele_query_const( req_map, &nonce, NULL, req_pool );
+}
+
+FD_FN_PURE static inline fd_recorder_req_t *
+fd_recorder_req_query( fd_recorder_t * recorder, ulong nonce ) {
+  fd_recorder_req_map_t * req_map  = fd_recorder_req_map( recorder );
+  fd_recorder_req_t *     req_pool = fd_recorder_req_pool( recorder );
+  return fd_recorder_req_map_ele_query( req_map, &nonce, NULL, req_pool );
+}
+
+/* fd_recorder_req_remove removes a request by its nonce.
+   Returns 0 on success, -1 if the request was not found.
+
+   CONCURRENCY: Requires caller to hold WRITE LOCK on recorder->rw_lock */
+
+int
+fd_recorder_req_remove( fd_recorder_t * recorder, ulong nonce, int is_recv );
+
+/* fd_recorder_req_expire removes all requests that have timed out based
+   on the provided current timestamp.  Returns the number of expired
+   requests.
+
+   CONCURRENCY: Requires caller to hold WRITE LOCK on recorder->rw_lock */
+
+ulong
+fd_recorder_req_expire( fd_recorder_t * recorder, ulong current_ns, int is_recv );
+
+/* fd_recorder_req_oldest returns the oldest request in the recorder
+   (front of list). Returns NULL if the recorder is empty.
+
+   CONCURRENCY: Requires caller to hold READ LOCK on recorder->rw_lock
+   The returned pointer is only valid while the lock is held. */
+
+FD_FN_PURE static inline fd_recorder_req_t const *
+fd_recorder_req_oldest( fd_recorder_t const * recorder ) {
+  fd_recorder_req_dlist_t const * dlist = fd_recorder_req_dlist_const( recorder );
+  fd_recorder_req_t const * pool = fd_recorder_req_pool_const( recorder );
+  if( FD_UNLIKELY( fd_recorder_req_dlist_is_empty( dlist, pool ) ) ) return NULL;
+  return fd_recorder_req_dlist_ele_peek_head_const( dlist, pool );
+}
+
+/* fd_recorder_req_newest returns the newest request in the recorder
+   (back of list). Returns NULL if the recorder is empty.
+
+   CONCURRENCY: Requires caller to hold READ LOCK on recorder->rw_lock
+   The returned pointer is only valid while the lock is held. */
+
+FD_FN_PURE static inline fd_recorder_req_t const *
+fd_recorder_req_newest( fd_recorder_t const * recorder ) {
+  fd_recorder_req_dlist_t const * dlist = fd_recorder_req_dlist_const( recorder );
+  fd_recorder_req_t const * pool = fd_recorder_req_pool_const( recorder );
+  if( FD_UNLIKELY( fd_recorder_req_dlist_is_empty( dlist, pool ) ) ) return NULL;
+  return fd_recorder_req_dlist_ele_peek_tail_const( dlist, pool );
+}
+
+/* ================== PEER HANDLING ================== */
+
+/* fd_recorder_peer_add adds a new peer to the recorder.
+   Returns a pointer to the peer on success, NULL on failure.
+
+   CONCURRENCY: Requires caller to hold WRITE LOCK on recorder->rw_lock */
+fd_recorder_peer_t *
+fd_recorder_peer_add( fd_recorder_t *             recorder,
+                      fd_pubkey_t const *         pubkey,
+                      fd_ip4_port_t               ip4 );
+
+/* fd_recorder_peer_query looks up a peer by its pubkey.
+   Returns a pointer to the peer if found, NULL otherwise.
+
+   CONCURRENCY: Requires caller to hold READ LOCK on recorder->rw_lock
+   The returned pointer is only valid while the lock is held. */
+FD_FN_PURE static inline fd_recorder_peer_t const *
+fd_recorder_peer_query_const( fd_recorder_t const * recorder, fd_pubkey_t const * pubkey ) {
+  fd_recorder_peer_map_t const * peer_map  = fd_recorder_peer_map_const( recorder );
+  fd_recorder_peer_t const *     peer_pool = fd_recorder_peer_pool_const( recorder );
+  return fd_recorder_peer_map_ele_query_const( peer_map, pubkey, NULL, peer_pool );
+}
+
+FD_FN_PURE static inline fd_recorder_peer_t *
+fd_recorder_peer_query( fd_recorder_t * recorder, fd_pubkey_t const * pubkey ) {
+  fd_recorder_peer_map_t * peer_map  = fd_recorder_peer_map( recorder );
+  fd_recorder_peer_t *     peer_pool = fd_recorder_peer_pool( recorder );
+  return fd_recorder_peer_map_ele_query( peer_map, pubkey, NULL, peer_pool );
+}
+
+/* fd_recorder_peer_remove removes a peer by its pubkey.
+   Returns a pointer to the removed peer on success, NULL if the peer
+   was not found.
+
+   CONCURRENCY: Requires caller to hold WRITE LOCK on recorder->rw_lock */
+fd_recorder_peer_t *
+fd_recorder_peer_remove( fd_recorder_t *     recorder,
+                         fd_pubkey_t const * pubkey );
+
+/* fd_recorder_peer_update updates a peer by its pubkey.
+   Returns a pointer to the peer on success, NULL on failure.
+
+   CONCURRENCY: Requires caller to hold WRITE LOCK on recorder->rw_lock */
+fd_recorder_peer_t *
+fd_recorder_peer_update( fd_recorder_t *             recorder,
+                         fd_pubkey_t const *         pubkey,
+                         fd_ip4_port_t               ip4,
+                         int                         is_recv,
+                         ulong                       req_timestamp_ns,
+                         ulong                       current_time );
+
+
+/* ================== PEER SELECTION ================== */
+
+/* fd_recorder_select_peer selects a single peer for repair, using a
+   weighted round-robin algorithm. Returns a pointer to the pubkey of
+   the selected peer, or NULL if no peers are available.
+
+   CONCURRENCY: Requires caller to hold WRITE LOCK on recorder->rw_lock
+   as this may modify internal state (peer selection indices) */
+fd_pubkey_t *
+fd_recorder_select_peer(fd_recorder_t * recorder);
+
+/* fd_recorder_reshuffle_peers reshuffles peers into categories based on
+   hit rate. Peers under 50ms RTT go to high priority, under 100ms to
+   medium priority, remaining to low priority. Zero hit rate peers
+   remain separate.
+
+   CONCURRENCY: Requires caller to hold WRITE LOCK on recorder->rw_lock */
+void
+fd_recorder_reshuffle_peers_boundaries(fd_recorder_t * recorder);
+
+/* fd_recorder_reshuffle_peers_cnt reshuffles peers into categories
+   based on count. The quickest 500 peers go to high priority, next 500
+   to medium priority, remaining to low priority. Zero hit rate peers
+   remain separate.
+
+   CONCURRENCY: Requires caller to hold WRITE LOCK on recorder->rw_lock */
+void
+fd_recorder_reshuffle_peers_cnt( fd_recorder_t * recorder );
+
+
+
+/* ================== PRINT & VERIFY HELPERS ================== */
+
+/* fd_recorder_print prints peer count
+
+   CONCURRENCY: Requires caller to hold READ LOCK on recorder->rw_lock */
+
+void
+fd_recorder_print_summary( fd_recorder_t const * recorder );
+
+/* fd_recorder_peer_print prints a peer.
+
+   CONCURRENCY: Requires caller to hold READ LOCK on recorder->rw_lock */
+void
+fd_recorder_peer_print( fd_recorder_peer_t * peer );
+
+/* fd_recorder_print_first_nonce prints the first nonce in the dlist.
+
+   CONCURRENCY: Requires caller to hold READ LOCK on recorder->rw_lock */
+void
+fd_recorder_print_first_nonce( fd_recorder_t * recorder );
+
+
+/* fd_recorder_verify checks that the recorder data structure is
+   internally consistent. Returns 0 on success, -1 on failure.
+
+   CONCURRENCY: Requires caller to hold READ LOCK on recorder->rw_lock */
+
+int
+fd_recorder_verify( fd_recorder_t const * recorder );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_discof_repair_fd_recorder_h */

--- a/src/flamenco/repair/test_recorder.c
+++ b/src/flamenco/repair/test_recorder.c
@@ -1,0 +1,606 @@
+#include "fd_recorder.h"
+#include "../../flamenco/fd_flamenco_base.h"
+#include "../../util/net/fd_net_headers.h"
+
+#include <stdarg.h>
+
+fd_recorder_t *
+setup_recorder( fd_wksp_t * wksp, ulong seed, ulong timeout_ns ) {
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_recorder_align(), fd_recorder_footprint(), 1UL );
+  FD_TEST( mem );
+  fd_recorder_t * ledger = fd_recorder_join( fd_recorder_new( mem, seed, timeout_ns ) );
+  FD_TEST( ledger );
+  return ledger;
+}
+
+/* create pubkeys */
+fd_pubkey_t
+make_pubkey( uchar val ) {
+  fd_pubkey_t key;
+  memset( &key, 0, sizeof(key) );
+  key.key[0] = val;
+  return key;
+}
+
+/*  create IP addresses */
+fd_ip4_port_t
+make_ip4_port( uint ip, ushort port ) {
+  fd_ip4_port_t ip4;
+  ip4.addr = ip;
+  ip4.port = port;
+  return ip4;
+}
+
+void test_recorder_cleanup( fd_recorder_t * ledger ) {
+  fd_wksp_free_laddr( fd_recorder_delete( fd_recorder_leave( ledger ) ) );
+  FD_LOG_NOTICE(( "Test passed" ));
+}
+
+/* basic peer operations: add, query, remove */
+void
+test_recorder_peer_basic( fd_wksp_t * wksp ) {
+  FD_LOG_NOTICE(( "Testing basic peer operations" ));
+
+  fd_recorder_t * ledger = setup_recorder( wksp, 42UL, 1000000000UL );
+
+  FD_TEST( fd_recorder_peer_cnt( ledger ) == 0UL );
+
+  fd_pubkey_t peer1_key = make_pubkey( 1 );
+  fd_pubkey_t peer2_key = make_pubkey( 2 );
+  fd_ip4_port_t peer1_ip = make_ip4_port( 0x7F000001, 8080 );
+  fd_ip4_port_t peer2_ip = make_ip4_port( 0x7F000002, 8081 );
+
+  /* adding peers */
+  fd_recorder_peer_t * peer1 = fd_recorder_peer_add( ledger, &peer1_key, peer1_ip );
+  FD_TEST( peer1 );
+  FD_TEST( fd_recorder_peer_cnt( ledger ) == 1UL );
+  FD_TEST( peer1->ip4.addr == peer1_ip.addr );
+  FD_TEST( peer1->ip4.port == peer1_ip.port );
+  FD_TEST( peer1->inflight_to_peer_cnt == 0UL );
+
+  fd_recorder_peer_t * peer2 = fd_recorder_peer_add( ledger, &peer2_key, peer2_ip );
+  FD_TEST( peer2 );
+  FD_TEST( fd_recorder_peer_cnt( ledger ) == 2UL );
+
+  /* querying peers */
+  fd_recorder_peer_t * found1 = fd_recorder_peer_query( ledger, &peer1_key );
+  FD_TEST( found1 );
+  FD_TEST( found1 == peer1 );
+  FD_TEST( !memcmp( &found1->key, &peer1_key, sizeof(fd_pubkey_t) ) );
+
+  fd_recorder_peer_t * found2 = fd_recorder_peer_query( ledger, &peer2_key );
+  FD_TEST( found2 );
+  FD_TEST( found2 == peer2 );
+
+  /* non-added peer */
+  fd_pubkey_t nonexistent_key = make_pubkey( 99 );
+  fd_recorder_peer_t * nonexistent_peer = fd_recorder_peer_query( ledger, &nonexistent_key );
+  FD_TEST( !nonexistent_peer );
+
+  fd_recorder_peer_t * test = fd_recorder_peer_query( ledger, &peer1_key );
+  FD_TEST( test );
+  FD_TEST( test == peer1 );
+  FD_TEST( test->inflight_to_peer_cnt == 0UL );
+
+  /* adding duplicate peer (should update existing) */
+  fd_ip4_port_t peer1_new_ip = make_ip4_port( 0x7F000003, 9090 );
+  fd_recorder_peer_t * peer1_updated = fd_recorder_peer_add( ledger, &peer1_key, peer1_new_ip );
+  FD_TEST( peer1_updated );
+  FD_TEST( peer1_updated == peer1 );
+  FD_TEST( fd_recorder_peer_cnt( ledger ) == 2UL );
+
+  FD_TEST( peer1_updated->ip4.addr == peer1_new_ip.addr );
+
+  test = fd_recorder_peer_query( ledger, &peer1_key );
+  FD_TEST( test );
+  FD_TEST( test == peer1 );
+  FD_TEST( test->inflight_to_peer_cnt == 0UL );
+
+  /* removing peers */
+  fd_recorder_peer_t * remove_result = fd_recorder_peer_remove( ledger, &peer1_key);
+  FD_TEST( remove_result != NULL );
+  FD_TEST( fd_recorder_peer_cnt( ledger ) == 1UL );
+
+  /* querying removed peer */
+  fd_recorder_peer_t * removed = fd_recorder_peer_query( ledger, &peer1_key );
+  FD_TEST( !removed );
+
+  /* removing non-existent peer */
+  fd_recorder_peer_t * remove_result2 = fd_recorder_peer_remove( ledger, &nonexistent_key);
+  FD_TEST( remove_result2 == NULL );
+
+  test_recorder_cleanup( ledger );
+}
+
+/* Basic request operations: insert, query, remove */
+void
+test_recorder_req_basic( fd_wksp_t * wksp ) {
+  FD_LOG_NOTICE(( "Testing basic request operations" ));
+
+  fd_recorder_t * ledger = setup_recorder( wksp, 42UL, 1000000000UL );
+
+  /* initial state */
+  FD_TEST( fd_recorder_req_cnt( ledger ) == 0UL );
+
+  fd_pubkey_t peer_key = make_pubkey( 1 );
+  fd_ip4_port_t peer_ip = make_ip4_port( 0x7F000001, 8080 );
+  fd_recorder_peer_t * peer = fd_recorder_peer_add( ledger, &peer_key, peer_ip );
+  FD_TEST( peer );
+
+  /* inserting requests */
+  ulong nonce1 = 12345UL;
+  ulong nonce2 = 67890UL;
+  ulong timestamp = 1000000000UL;
+  ulong slot = 100UL;
+  ulong shred_idx = 5UL;
+  fd_recorder_req_t * req1 = fd_recorder_req_insert( ledger, nonce1, timestamp, &peer_key, peer_ip, slot, shred_idx );
+
+  FD_TEST( req1 );
+  FD_TEST( fd_recorder_req_cnt( ledger ) == 1UL );
+  FD_TEST( req1->nonce == nonce1 );
+  FD_TEST( req1->timestamp_ns == timestamp );
+  FD_TEST( req1->slot == slot );
+  FD_TEST( req1->shred_idx == shred_idx );
+  FD_TEST( !memcmp( &req1->pubkey, &peer_key, sizeof(fd_pubkey_t) ) );
+
+  fd_recorder_req_t * req2 = fd_recorder_req_insert( ledger, nonce2, timestamp + 1000000UL, &peer_key, peer_ip, slot + 1, shred_idx + 1 );
+  FD_TEST( req2 );
+  FD_TEST( fd_recorder_req_cnt( ledger ) == 2UL );
+
+  /* querying requests */
+  fd_recorder_req_t * found1 = fd_recorder_req_query( ledger, nonce1 );
+  FD_TEST( found1 );
+  FD_TEST( found1 == req1 );
+  FD_TEST( found1->nonce == nonce1 );
+
+  fd_recorder_req_t * found2 = fd_recorder_req_query( ledger, nonce2 );
+  FD_TEST( found2 );
+  FD_TEST( found2 == req2 );
+
+  /* querying non-existent request */
+  fd_recorder_req_t * not_found = fd_recorder_req_query( ledger, 99999UL );
+  FD_TEST( !not_found );
+
+  /* inserting another request with different nonce */
+  ulong nonce3 = 54321UL;
+  fd_recorder_req_t * req3 = fd_recorder_req_insert( ledger, nonce3, timestamp + 2000000UL, &peer_key, peer_ip, slot + 2, shred_idx + 2 );
+
+  FD_TEST( req3 );
+  FD_TEST( fd_recorder_req_cnt( ledger ) == 3UL );
+
+  /* oldest/newest requests */
+  fd_recorder_req_t const * oldest = fd_recorder_req_oldest( ledger );
+  FD_TEST( oldest );
+  FD_TEST( oldest->nonce == nonce1 );
+
+  fd_recorder_req_t const * newest = fd_recorder_req_newest( ledger );
+  FD_TEST( newest );
+  FD_TEST( newest->nonce == nonce3 );
+
+  int remove_result = fd_recorder_req_remove( ledger, nonce1, 1);
+  FD_TEST( remove_result == 0 );
+  FD_TEST( fd_recorder_req_cnt( ledger ) == 2UL );
+
+  /* querying removed request */
+  fd_recorder_req_t * removed = fd_recorder_req_query( ledger, nonce1 );
+  FD_TEST( !removed );
+
+  int remove_result2 = fd_recorder_req_remove( ledger, 99999UL, 1);
+  FD_TEST( remove_result2 == -1 );
+
+  test_recorder_cleanup( ledger );
+}
+
+/* Request expiration functionality */
+void
+test_recorder_req_expire( fd_wksp_t * wksp ) {
+  FD_LOG_NOTICE(( "Testing request expiration" ));
+
+  ulong timeout_ns = 1000000000UL; /* 1 second timeout */
+  fd_recorder_t * ledger = setup_recorder( wksp, 42UL, timeout_ns );
+
+  fd_pubkey_t peer_key = make_pubkey( 1 );
+  fd_ip4_port_t peer_ip = make_ip4_port( 0x7F000001, 8080 );
+  fd_recorder_peer_t * peer = fd_recorder_peer_add( ledger, &peer_key, peer_ip );
+  FD_TEST( peer );
+
+  ulong base_time = 1000000000UL;
+  ulong nonce1 = 1UL;
+  ulong nonce2 = 2UL;
+  ulong nonce3 = 3UL;
+
+  /* Request 1: expire */
+  fd_recorder_req_t * req1 = fd_recorder_req_insert( ledger, nonce1, base_time,
+                                                               &peer_key, peer_ip, 100UL, 0UL );
+  FD_TEST( req1 );
+
+  /* Request 2: expire */
+  fd_recorder_req_t * req2 = fd_recorder_req_insert( ledger, nonce2, base_time + 500000000UL,
+                                                               &peer_key, peer_ip, 101UL, 0UL );
+  FD_TEST( req2 );
+
+  /* Request 3: not expire */
+  fd_recorder_req_t * req3 = fd_recorder_req_insert( ledger, nonce3, base_time + 1500000000UL,
+                                                               &peer_key, peer_ip, 102UL, 0UL );
+  FD_TEST( req3 );
+
+  FD_TEST( fd_recorder_req_cnt( ledger ) == 3UL );
+
+  /* Test expiration at a time that should expire first two requests */
+  ulong expire_time = base_time + 2000000000UL; /* 2 seconds after base_time */
+  ulong expired_count = fd_recorder_req_expire( ledger, expire_time, 1);
+
+  FD_TEST( expired_count == 2UL );
+  FD_TEST( fd_recorder_req_cnt( ledger ) == 1UL );
+
+  FD_TEST( !fd_recorder_req_query( ledger, nonce1 ) );
+  FD_TEST( !fd_recorder_req_query( ledger, nonce2 ) );
+  FD_TEST( fd_recorder_req_query( ledger, nonce3 ) );
+
+  /* Test expiration when no requests should expire */
+  ulong no_expire_count = fd_recorder_req_expire( ledger, expire_time, 1);
+  FD_TEST( no_expire_count == 0UL );
+  FD_TEST( fd_recorder_req_cnt( ledger ) == 1UL );
+
+  /* Test expiration that removes all remaining requests */
+  ulong expire_all_time = base_time + 3000000000UL; /* 3 seconds after base_time */
+  ulong all_expired_count = fd_recorder_req_expire( ledger, expire_all_time, 1);
+  FD_TEST( all_expired_count == 1UL );
+  FD_TEST( fd_recorder_req_cnt( ledger ) == 0UL );
+
+  ulong empty_expire_count = fd_recorder_req_expire( ledger, expire_all_time, 1);
+  FD_TEST( empty_expire_count == 0UL );
+
+  test_recorder_cleanup( ledger );
+}
+
+/* Test peer selection functionality */
+void
+test_recorder_peer_selection( fd_wksp_t * wksp ) {
+  FD_LOG_NOTICE(( "Testing peer selection" ));
+
+  fd_recorder_t * ledger = setup_recorder( wksp, 42UL, 1000000000UL );
+
+  fd_pubkey_t peer_keys[5];
+  for( uint i = 0; i < 5; i++ ) {
+    peer_keys[i] = make_pubkey( (uchar)(i + 1) );
+    fd_ip4_port_t peer_ip = make_ip4_port( 0x7F000001 + i, (ushort)(8080UL + i) );
+    fd_recorder_peer_t * peer = fd_recorder_peer_add( ledger, &peer_keys[i], peer_ip );
+    FD_TEST( peer );
+  }
+
+  FD_TEST( fd_recorder_peer_cnt( ledger ) == 5UL );
+
+  /* Test selecting peers */
+  fd_pubkey_t * selected_peers[3];
+  for( uint i=0; i<3; i++ ) {
+    selected_peers[i] = fd_recorder_select_peer( ledger );
+  }
+
+  /* Verify we got 3 different peers */
+  FD_TEST( selected_peers[0] != selected_peers[1] );
+  FD_TEST( selected_peers[1] != selected_peers[2] );
+  FD_TEST( selected_peers[0] != selected_peers[2] );
+
+  fd_pubkey_t * more_selected[3];
+  for( uint i=0; i<3; i++ ) {
+    more_selected[i] = fd_recorder_select_peer( ledger );
+    FD_TEST( more_selected[i] );
+  }
+
+  test_recorder_cleanup( ledger );
+}
+
+/* Test peer update functionality */
+void
+test_recorder_peer_update( fd_wksp_t * wksp ) {
+  FD_LOG_NOTICE(( "Testing peer update" ));
+
+  fd_recorder_t * ledger = setup_recorder( wksp, 42UL, 1000000000UL );
+
+  fd_pubkey_t peer_key = make_pubkey( 1 );
+  fd_ip4_port_t peer_ip = make_ip4_port( 0x7F000001, 8080 );
+  long current_time = 1000000000L;
+  fd_recorder_peer_t * peer = fd_recorder_peer_add( ledger, &peer_key, peer_ip );
+  FD_TEST( peer );
+
+  /* Add a request first so we have inflight requests to track */
+  fd_recorder_req_t * req = fd_recorder_req_insert( ledger, 12345UL, (ulong)current_time, &peer_key, peer_ip, 100UL, 0UL );
+  FD_TEST( req );
+  FD_TEST( peer->inflight_to_peer_cnt == 1UL );
+
+  long update_time = current_time + 1000000L;
+  fd_recorder_peer_t * updated_peer = fd_recorder_peer_update( ledger, &peer_key, peer_ip, 1, (ulong)current_time, (ulong)update_time );
+  FD_TEST( updated_peer );
+  FD_TEST( updated_peer == peer );
+  FD_TEST( updated_peer->ewma_hr == 1.0 );
+  FD_TEST( updated_peer->inflight_to_peer_cnt == 0UL );
+
+  fd_recorder_req_t * req2 = fd_recorder_req_insert( ledger, 12346UL, (ulong)current_time, &peer_key, peer_ip, 101UL, 1UL );
+  FD_TEST( req2 );
+  FD_TEST( peer->inflight_to_peer_cnt == 1UL );
+
+  /* Test updating peer send */
+  long send_time = update_time + 1000000L;
+  fd_recorder_peer_t * sent_peer = fd_recorder_peer_update( ledger, &peer_key, peer_ip, 0, (ulong)current_time, (ulong)send_time );
+  FD_TEST( sent_peer );
+  FD_TEST( sent_peer == peer );
+  FD_TEST( sent_peer->ewma_hr > 0.89 && sent_peer->ewma_hr < 0.91 );
+  FD_TEST( sent_peer->inflight_to_peer_cnt == 0UL );
+
+  /* Test updating on onon-existent peer */
+  fd_pubkey_t nonexistent_key = make_pubkey( 99 );
+  fd_recorder_peer_t * not_found = fd_recorder_peer_update( ledger, &nonexistent_key, peer_ip, 1, (ulong)send_time, (ulong)current_time );
+  FD_TEST( !not_found );
+
+  test_recorder_cleanup( ledger );
+}
+
+/* Test repair ledger verification */
+void
+test_recorder_verify( fd_wksp_t * wksp ) {
+  FD_LOG_NOTICE(( "Testing repair ledger verification" ));
+
+  fd_recorder_t * ledger = setup_recorder( wksp, 42UL, 1000000000UL );
+
+  int verify_result = fd_recorder_verify( ledger );
+  FD_TEST( verify_result == 0 );
+
+  fd_pubkey_t peer_key = make_pubkey( 1 );
+  fd_ip4_port_t peer_ip = make_ip4_port( 0x7F000001, 8080 );
+  fd_recorder_peer_t * peer = fd_recorder_peer_add( ledger, &peer_key, peer_ip );
+  FD_TEST( peer );
+
+  fd_recorder_req_t * req = fd_recorder_req_insert( ledger, 12345UL, 1000000000UL,
+                                                             &peer_key, peer_ip, 100UL, 0UL );
+  FD_TEST( req );
+
+  verify_result = fd_recorder_verify( ledger );
+  FD_TEST( verify_result == 0 );
+
+  verify_result = fd_recorder_verify( NULL );
+  FD_TEST( verify_result == -1 );
+
+  test_recorder_cleanup( ledger );
+}
+
+/* Test filling up the request map/deque with many requests */
+void
+test_recorder_many_requests( fd_wksp_t * wksp ) {
+  FD_LOG_NOTICE(( "Testing many requests (fill map/deque)" ));
+
+  fd_recorder_t * ledger = setup_recorder( wksp, 42UL, 10000000000UL ); /* 10 second timeout */
+
+  ulong num_peers = 10;
+  fd_pubkey_t peer_keys[10];
+
+  for( ulong i = 0; i < num_peers; i++ ) {
+    peer_keys[i] = make_pubkey( (uchar)(i + 1) );
+    fd_ip4_port_t peer_ip = make_ip4_port( (uint)(0x7F000001 + i), (ushort)(8080 + i) );
+    fd_recorder_peer_t * peer = fd_recorder_peer_add( ledger, &peer_keys[i], peer_ip );
+    FD_TEST( peer );
+  }
+
+  FD_TEST( fd_recorder_peer_cnt( ledger ) == num_peers );
+
+  /* Insert many requests */
+  ulong num_requests = 1000; /* Test with 1000 requests */
+  ulong base_time = 1000000000UL;
+
+  for( ulong i = 0; i < num_requests; i++ ) {
+    ulong nonce = i + 1000;
+    ulong peer_idx = i % num_peers;
+    fd_ip4_port_t peer_ip = make_ip4_port( (uint)(0x7F000001 + peer_idx), (ushort)(8080 + peer_idx) );
+
+    fd_recorder_req_t * req = fd_recorder_req_insert(
+      ledger, nonce, base_time + i * 1000000UL, /* Spread timestamps */
+      &peer_keys[peer_idx], peer_ip,
+      100UL + i, /* Different slots */
+      i % 10     /* Different shred indices */
+    );
+    FD_TEST( req );
+    FD_TEST( req->nonce == nonce );
+  }
+
+  FD_TEST( fd_recorder_req_cnt( ledger ) == num_requests );
+  FD_LOG_NOTICE(( "Successfully inserted %lu requests", num_requests ));
+
+  /* Verify we can query all requests */
+  for( ulong i = 0; i < num_requests; i++ ) {
+    ulong nonce = i + 1000;
+    fd_recorder_req_t * req = fd_recorder_req_query( ledger, nonce );
+    FD_TEST( req );
+    FD_TEST( req->nonce == nonce );
+  }
+
+  fd_recorder_req_t const * oldest = fd_recorder_req_oldest( ledger );
+  fd_recorder_req_t const * newest = fd_recorder_req_newest( ledger );
+  FD_TEST( oldest );
+  FD_TEST( newest );
+  FD_TEST( oldest->nonce == 1000 );
+  FD_TEST( newest->nonce == 1000 + num_requests - 1 );
+
+  /* Remove all requests */
+  for( ulong i = 0; i < num_requests; i++ ) {
+    ulong nonce = i + 1000;
+    int result = fd_recorder_req_remove( ledger, nonce, 1 );
+    FD_TEST( result == 0 );
+  }
+
+  FD_TEST( fd_recorder_req_cnt( ledger ) == 0UL );
+  FD_LOG_NOTICE(( "Successfully removed all %lu requests", num_requests ));
+
+  test_recorder_cleanup( ledger );
+}
+
+/* Test out of order response handling */
+void
+test_recorder_out_of_order_response( fd_wksp_t * wksp ) {
+  FD_LOG_NOTICE(( "Testing out of order response handling" ));
+
+  fd_recorder_t * ledger = setup_recorder( wksp, 42UL, 5000000000UL ); /* 5 second timeout */
+
+  /* Add peers */
+  ulong num_peers = 3;
+  fd_pubkey_t peer_keys[3];
+
+  for( ulong i = 0; i < num_peers; i++ ) {
+    peer_keys[i] = make_pubkey( (uchar)(i + 1) );
+    fd_ip4_port_t peer_ip = make_ip4_port( (uint)(0x7F000001 + i), (ushort)(8080 + i) );
+    fd_recorder_peer_t * peer = fd_recorder_peer_add( ledger, &peer_keys[i], peer_ip );
+    FD_TEST( peer );
+  }
+
+  /* Insert requests in order: nonce 100, 101, 102, 103, 104 */
+  ulong base_time = 1000000000UL;
+  ulong nonces[5] = {100, 101, 102, 103, 104};
+
+  for( ulong i = 0; i < 5; i++ ) {
+    ulong peer_idx = i % num_peers;
+    fd_ip4_port_t peer_ip = make_ip4_port( (uint)(0x7F000001 + peer_idx), (ushort)(8080 + peer_idx) );
+
+    fd_recorder_req_t * req = fd_recorder_req_insert(
+      ledger, nonces[i], base_time + i * 100000000UL, /* 100ms apart */
+      &peer_keys[peer_idx], peer_ip,
+      200UL + i, i
+    );
+    FD_TEST( req );
+  }
+
+  FD_TEST( fd_recorder_req_cnt( ledger ) == 5UL );
+
+  fd_recorder_req_t const * oldest = fd_recorder_req_oldest( ledger );
+  FD_TEST( oldest );
+  FD_TEST( oldest->nonce == 100 );
+
+  /* Remove responses out of order: 102, 100, 104, 101, 103 */
+  ulong remove_order[5] = {102, 100, 104, 101, 103};
+
+  for( ulong i = 0; i < 5; i++ ) {
+    ulong nonce_to_remove = remove_order[i];
+
+    fd_recorder_req_t * req = fd_recorder_req_query( ledger, nonce_to_remove );
+    FD_TEST( req );
+
+    int result = fd_recorder_req_remove( ledger, nonce_to_remove, 1 );
+    FD_TEST( result == 0 );
+    FD_TEST( fd_recorder_req_cnt( ledger ) == (5 - i - 1) );
+
+    fd_recorder_req_t * removed_req = fd_recorder_req_query( ledger, nonce_to_remove );
+    FD_TEST( !removed_req );
+
+    FD_LOG_NOTICE(( "Removed request %lu out of order (step %lu/5)", nonce_to_remove, i + 1 ));
+  }
+
+  FD_TEST( fd_recorder_req_cnt( ledger ) == 0UL );
+
+  /* Test that we can still add new requests after out-of-order removal */
+  fd_ip4_port_t peer_ip = make_ip4_port( 0x7F000001, 8080 );
+  fd_recorder_req_t * new_req = fd_recorder_req_insert(
+    ledger, 999UL, base_time + 1000000000UL,
+    &peer_keys[0], peer_ip, 300UL, 0UL
+  );
+  FD_TEST( new_req );
+  FD_TEST( fd_recorder_req_cnt( ledger ) == 1UL );
+
+  test_recorder_cleanup( ledger );
+}
+
+/* Test that removed requests don't get expired later */
+void
+test_recorder_removal_vs_expiration( fd_wksp_t * wksp ) {
+  FD_LOG_NOTICE(( "Testing removal vs expiration interaction" ));
+
+  ulong timeout_ns = 1000000000UL; /* 1 second timeout */
+  fd_recorder_t * ledger = setup_recorder( wksp, 42UL, timeout_ns );
+
+  fd_pubkey_t peer_key = make_pubkey( 1 );
+  fd_ip4_port_t peer_ip = make_ip4_port( 0x7F000001, 8080 );
+  fd_recorder_peer_t * peer = fd_recorder_peer_add( ledger, &peer_key, peer_ip );
+  FD_TEST( peer );
+
+  /* Insert 4 requests with old timestamps (all should be expirable) */
+  ulong base_time = 1000000000UL;
+  ulong nonce1 = 1UL, nonce2 = 2UL, nonce3 = 3UL, nonce4 = 4UL;
+
+  fd_recorder_req_t * req1 = fd_recorder_req_insert( ledger, nonce1, base_time, &peer_key, peer_ip, 100UL, 1UL );
+  fd_recorder_req_t * req2 = fd_recorder_req_insert( ledger, nonce2, base_time + 100000000UL, &peer_key, peer_ip, 101UL, 2UL );
+  fd_recorder_req_t * req3 = fd_recorder_req_insert( ledger, nonce3, base_time + 200000000UL, &peer_key, peer_ip, 102UL, 3UL );
+  fd_recorder_req_t * req4 = fd_recorder_req_insert( ledger, nonce4, base_time + 300000000UL, &peer_key, peer_ip, 103UL, 4UL );
+
+  FD_TEST( req1 && req2 && req3 && req4 );
+  FD_TEST( fd_recorder_req_cnt( ledger ) == 4UL );
+
+  ulong initial_handled = ledger->total_handled_requests;
+  ulong initial_expired = ledger->total_expired_requests;
+
+  // Remove two requests manually and check that only two remain
+  int remove_result1 = fd_recorder_req_remove( ledger, nonce1, 1 );
+  int remove_result2 = fd_recorder_req_remove( ledger, nonce3, 1 );
+  FD_TEST( remove_result1 == 0 && remove_result2 == 0 );
+  FD_TEST( fd_recorder_req_cnt( ledger ) == 2UL );
+
+  FD_TEST( !fd_recorder_req_query( ledger, nonce1 ) );
+  FD_TEST( !fd_recorder_req_query( ledger, nonce3 ) );
+  FD_TEST( fd_recorder_req_query( ledger, nonce2 ) );
+  FD_TEST( fd_recorder_req_query( ledger, nonce4 ) );
+
+  FD_TEST( ledger->total_handled_requests == initial_handled + 2 );
+  FD_TEST( ledger->total_expired_requests == initial_expired );
+
+  // expire the remaining requests and check that both are expired
+  ulong expire_time = base_time + 2000000000UL;
+  ulong expired_count = fd_recorder_req_expire( ledger, expire_time, 0 );
+
+  FD_TEST( expired_count == 2UL );
+  FD_TEST( fd_recorder_req_cnt( ledger ) == 0UL );
+
+  // handled unchanged, expired increased by 2
+  FD_TEST( ledger->total_handled_requests == initial_handled + 2 );
+  FD_TEST( ledger->total_expired_requests == initial_expired + 2 );
+
+  FD_TEST( !fd_recorder_req_query( ledger, nonce1 ) );
+  FD_TEST( !fd_recorder_req_query( ledger, nonce2 ) );
+  FD_TEST( !fd_recorder_req_query( ledger, nonce3 ) );
+  FD_TEST( !fd_recorder_req_query( ledger, nonce4 ) );
+
+  FD_LOG_NOTICE(( "Verified: manually removed requests don't get double-counted as expired" ));
+
+  test_recorder_cleanup( ledger );
+}
+
+int
+main( int argc, char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  ulong  page_cnt = 1;
+  char * _page_sz = "gigantic";
+  ulong  numa_idx = fd_shmem_numa_idx( 0 );
+  FD_LOG_NOTICE( ( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)",
+                   page_cnt,
+                   _page_sz,
+                   numa_idx ) );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ),
+                                            page_cnt,
+                                            fd_shmem_cpu_idx( numa_idx ),
+                                            "wksp",
+                                            0UL );
+  FD_TEST( wksp );
+
+  /* Run all tests */
+  test_recorder_peer_basic( wksp );
+  test_recorder_req_basic( wksp );
+  test_recorder_req_expire( wksp );
+  test_recorder_peer_selection( wksp );
+  test_recorder_peer_update( wksp );
+  test_recorder_verify( wksp );
+  test_recorder_many_requests( wksp );
+  test_recorder_out_of_order_response( wksp );
+  test_recorder_removal_vs_expiration( wksp );
+
+  FD_LOG_NOTICE(( "All repair ledger tests passed!" ));
+
+  fd_wksp_delete_anonymous( wksp );
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
## Add recorder library for repair request performance tracking

This PR introduces a comprehensive recorder library that tracks repair request performance and implements intelligent peer selection for the repair tile.

- **Peer performance tracking**: Maintains EWMA hit rates and RTT metrics for all repair peers
- **Request lifecycle management**: Tracks outgoing repair requests with automatic timeout/expiration
- **Intelligent peer selection**: Weighted round-robin algorithm prioritizing high-performance peers
- **Performance-based categorization**: Automatically sorts peers into high/medium/low priority buckets based on RTT and success rates for peer selection

This enhancement significantly improve repair speed on boot by ~34% on testnet