### PR TITLE
fdctl: hack around broken configure checks

### DIFF
--- a/src/app/fddev/dev1.c
+++ b/src/app/fddev/dev1.c
@@ -84,7 +84,7 @@ dev1_cmd_fn( args_t *   args,
   }
 
   update_config_for_dev( config );
-  run_firedancer_init( config, 1 );
+  run_firedancer_init( config, 1, 0 );
 
   install_parent_signals();
 

--- a/src/app/firedancer-dev/commands/backtest.c
+++ b/src/app/firedancer-dev/commands/backtest.c
@@ -380,7 +380,7 @@ backtest_cmd_fn( args_t *   args FD_PARAM_UNUSED,
   args_t c_args = configure_args();
   configure_cmd_fn( &c_args, config );
 
-  run_firedancer_init( config, 1 );
+  run_firedancer_init( config, 1, 0 );
 
   fd_log_private_shared_lock[ 1 ] = 0;
   fd_topo_join_workspaces( &config->topo, FD_SHMEM_JOIN_MODE_READ_WRITE );

--- a/src/app/firedancer-dev/commands/ipecho_server.c
+++ b/src/app/firedancer-dev/commands/ipecho_server.c
@@ -72,7 +72,7 @@ ipecho_server_cmd_fn( args_t *   args,
   args_t c_args = configure_args();
   configure_cmd_fn( &c_args, config );
 
-  run_firedancer_init( config, 1 );
+  run_firedancer_init( config, 1, 0 );
 
   fd_log_private_shared_lock[ 1 ] = 0;
   fd_topo_join_workspaces( &config->topo, FD_SHMEM_JOIN_MODE_READ_WRITE );

--- a/src/app/firedancer-dev/commands/repair.c
+++ b/src/app/firedancer-dev/commands/repair.c
@@ -427,7 +427,7 @@ repair_cmd_fn( args_t *   args,
     (void)fds;
   }
 
-  run_firedancer_init( config, 1 );
+  run_firedancer_init( config, 1, 0 );
 
   fd_log_private_shared_lock[ 1 ] = 0;
   fd_topo_join_workspaces( &config->topo, FD_SHMEM_JOIN_MODE_READ_WRITE );

--- a/src/app/firedancer-dev/commands/send_test/send_test.c
+++ b/src/app/firedancer-dev/commands/send_test/send_test.c
@@ -237,7 +237,7 @@ send_test_cmd_fn( args_t *   args ,
 
   fd_topo_print_log( 0, &config->topo );
 
-  run_firedancer_init( config, !args->dev.no_init_workspaces );
+  run_firedancer_init( config, !args->dev.no_init_workspaces, 1 );
   fdctl_setup_netns( config, 1 );
 
   if( 0==strcmp( config->net.provider, "xdp" ) ) fd_topo_install_xdp( &config->topo, config->net.bind_address_parsed );

--- a/src/app/firedancer-dev/commands/snapshot_load.c
+++ b/src/app/firedancer-dev/commands/snapshot_load.c
@@ -142,7 +142,7 @@ snapshot_load_cmd_fn( args_t *   args,
     configure_args.configure.stages[ i ] = STAGES[ i ];
   configure_cmd_fn( &configure_args, config );
 
-  run_firedancer_init( config, 1 );
+  run_firedancer_init( config, 1, 0 );
 
   fd_log_private_shared_lock[ 1 ] = 0;
   fd_topo_join_workspaces( topo, FD_SHMEM_JOIN_MODE_READ_WRITE );

--- a/src/app/shared/commands/run/run.c
+++ b/src/app/shared/commands/run/run.c
@@ -734,7 +734,8 @@ fdctl_check_configure( config_t const * config ) {
 
 void
 run_firedancer_init( config_t * config,
-                     int        init_workspaces ) {
+                     int        init_workspaces,
+                     int        check_configure ) {
   struct stat st;
   int err = stat( config->paths.identity_key, &st );
   if( FD_UNLIKELY( -1==err && errno==ENOENT ) ) FD_LOG_ERR(( "[consensus.identity_path] key does not exist `%s`. You can generate an identity key at this path by running `fdctl keys new identity --config <toml>`", config->paths.identity_key ));
@@ -748,7 +749,10 @@ run_firedancer_init( config_t * config,
     }
   }
 
-  fdctl_check_configure( config );
+  /* FIXME: fdctl_check_configure unconditionally checks for network
+            stack prerequisites even if the command being run does not
+            require networking.  Hack around that here for now. */
+  if( check_configure ) fdctl_check_configure( config );
   if( FD_LIKELY( init_workspaces ) ) initialize_workspaces( config );
   initialize_stacks( config );
 }
@@ -815,7 +819,7 @@ run_firedancer( config_t * config,
   /* dump the topology we are using to the output log */
   fd_topo_print_log( 0, &config->topo );
 
-  run_firedancer_init( config, init_workspaces );
+  run_firedancer_init( config, init_workspaces, 1 );
 
 #if defined(__x86_64__) || defined(__aarch64__)
 

--- a/src/app/shared/commands/run/run.h
+++ b/src/app/shared/commands/run/run.h
@@ -25,7 +25,8 @@ initialize_stacks( config_t const * config );
 
 void
 run_firedancer_init( config_t * config,
-                     int        init_workspaces );
+                     int        init_workspaces,
+                     int        check_configure );
 
 void
 fdctl_setup_netns( config_t * config,

--- a/src/app/shared_dev/commands/bench/bench.c
+++ b/src/app/shared_dev/commands/bench/bench.c
@@ -173,7 +173,7 @@ bench_cmd_fn( args_t *   args,
 
   update_config_for_dev( config );
 
-  run_firedancer_init( config, 1 );
+  run_firedancer_init( config, 1, 1 );
   fdctl_setup_netns( config, 1 );
 
   if( 0==strcmp( config->net.provider, "xdp" ) ) {

--- a/src/app/shared_dev/commands/dev.c
+++ b/src/app/shared_dev/commands/dev.c
@@ -119,7 +119,7 @@ run_firedancer_threaded( config_t * config,
 
   fd_topo_print_log( 0, &config->topo );
 
-  run_firedancer_init( config, init_workspaces );
+  run_firedancer_init( config, init_workspaces, 1 );
   fdctl_setup_netns( config, 1 );
 
   if( FD_UNLIKELY( config->development.debug_tile ) ) {


### PR DESCRIPTION
fdctl has poor support for custom topologies, leading to network
stack configure checks being run, even when the selected action
does not do networking.

Adds a temporary hack around that.
