### PR TITLE
replay, writer: remove writer->replay fseq

### DIFF
--- a/src/app/firedancer-dev/commands/backtest.c
+++ b/src/app/firedancer-dev/commands/backtest.c
@@ -205,16 +205,13 @@ backtest_topo( config_t * config ) {
 
   /**********************************************************************/
   /* Setup writer->replay links in topo, to send solcap account updates
-     so that they are serialized.
-
-     TODO: remove this when solcap v2 is here. */
+     so that they are serialized, and to notify replay tile that a txn
+     has been finalized by the writer tile. */
   /**********************************************************************/
-  if( strlen( config->capture.solcap_capture ) ) {
-    fd_topob_wksp( topo, "writ_repl" );
-    FOR(writer_tile_cnt) fd_topob_link( topo, "writ_repl", "writ_repl", 1UL, FD_RUNTIME_PUBLIC_ACCOUNT_UPDATE_MSG_FOOTPRINT, 1UL );
-    FOR(writer_tile_cnt) fd_topob_tile_out( topo, "writer", i, "writ_repl", i );
-    FOR(writer_tile_cnt) fd_topob_tile_in( topo, "replay", 0UL, "metric_in", "writ_repl", i, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
-  }
+  fd_topob_wksp( topo, "writ_repl" );
+  FOR(writer_tile_cnt) fd_topob_link( topo, "writ_repl", "writ_repl", 1UL, FD_RUNTIME_PUBLIC_ACCOUNT_UPDATE_MSG_FOOTPRINT, 1UL );
+  FOR(writer_tile_cnt) fd_topob_tile_out( topo, "writer", i, "writ_repl", i );
+  FOR(writer_tile_cnt) fd_topob_tile_in( topo, "replay", 0UL, "metric_in", "writ_repl", i, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
 
   /**********************************************************************/
   /* Setup the shared objs used by replay and exec tiles                */

--- a/src/flamenco/runtime/fd_hashes.c
+++ b/src/flamenco/runtime/fd_hashes.c
@@ -84,7 +84,7 @@ fd_hashes_update_lthash( fd_txn_account_t const  * account,
     int err = fd_solcap_write_account(
       capture_ctx->capture,
       account->pubkey,
-      fd_txn_account_get_info( account ),
+      &meta->info,
       fd_txn_account_get_data( account ),
       fd_txn_account_get_data_len( account ),
       new_hash_checksum );

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -1042,9 +1042,9 @@ fd_runtime_finalize_account( fd_funk_t *        funk,
 
    TODO: remove this when solcap v2 is here. */
 static void
-fd_runtime_buffer_solcap_account_update( fd_txn_account_t * account,
-                                         fd_bank_t *        bank,
-                                         fd_capture_ctx_t * capture_ctx ) {
+fd_runtime_buffer_solcap_account_update( fd_txn_account_t *        account,
+                                         fd_bank_t *               bank,
+                                         fd_capture_ctx_t *        capture_ctx ) {
 
   /* Check if we should publish the update */
   if( FD_UNLIKELY( !capture_ctx || fd_bank_slot_get( bank )<capture_ctx->solcap_start_slot ) ) {
@@ -1052,9 +1052,8 @@ fd_runtime_buffer_solcap_account_update( fd_txn_account_t * account,
   }
 
   /* Get account data */
-  fd_solana_account_meta_t const * info = fd_txn_account_get_info( account );
-  fd_account_meta_t const * meta        = fd_txn_account_get_meta( account );
-  void const * data                     = fd_txn_account_get_data( account );
+  fd_account_meta_t const * meta = fd_txn_account_get_meta( account );
+  void const * data              = fd_txn_account_get_data( account );
 
   /* Calculate account hash using lthash */
   fd_lthash_value_t lthash[1];
@@ -1071,7 +1070,7 @@ fd_runtime_buffer_solcap_account_update( fd_txn_account_t * account,
   /* Write the message to the buffer */
   fd_runtime_public_account_update_msg_t * account_update_msg = (fd_runtime_public_account_update_msg_t *)(capture_ctx->account_updates_buffer_ptr);
   account_update_msg->pubkey                                  = *account->pubkey;
-  account_update_msg->info                                    = *info;
+  account_update_msg->info                                    = meta->info;
   account_update_msg->data_sz                                 = meta->dlen;
   account_update_msg->hash                                    = hash;
   capture_ctx->account_updates_buffer_ptr                    += sizeof(fd_runtime_public_account_update_msg_t);


### PR DESCRIPTION
Removes the writer->replay fseq in favour of a frag-based model.

Fixes a race condition where the solcap account updates would not get fully flushed before backtest shut down.

This PR also fixes an related bug where some solcap account sysvar account updates were getting lost.