### PR TITLE
runtime: remove FD_PUBKEY_SUCCESS

### DIFF
--- a/src/disco/bundle/fd_bundle_crank.c
+++ b/src/disco/bundle/fd_bundle_crank.c
@@ -206,7 +206,7 @@ fd_bundle_crank_gen_init( void                 * mem,
     for( ulong i=0UL; i<8UL; i++ ) {
       seed[12] = (char)((ulong)'0' + i);
       uchar out_bump[1];
-      FD_TEST( FD_PUBKEY_SUCCESS==fd_pubkey_find_program_address( (fd_pubkey_t const *)tip_payment_program_addr,
+      FD_TEST( FD_EXECUTOR_INSTR_SUCCESS==fd_pubkey_find_program_address( (fd_pubkey_t const *)tip_payment_program_addr,
                                                                   1UL, seed_ptr, &seed_len,
                                                                   (fd_pubkey_t *)g->crank3->tip_payment_accounts[i], out_bump, cerr ) );
     }
@@ -217,11 +217,11 @@ fd_bundle_crank_gen_init( void                 * mem,
     ulong seed_len = 14;
     uchar out_bump[1];
     uchar * seed_ptr[1] = { (uchar *)seed };
-    FD_TEST( FD_PUBKEY_SUCCESS==fd_pubkey_find_program_address( (fd_pubkey_t const *)tip_payment_program_addr,
+    FD_TEST( FD_EXECUTOR_INSTR_SUCCESS==fd_pubkey_find_program_address( (fd_pubkey_t const *)tip_payment_program_addr,
                                                                 1UL, seed_ptr, &seed_len,
                                                                 (fd_pubkey_t *)g->crank3->tip_payment_program_config, out_bump, cerr ) );
     /* Same seed used for tip distribution config account too */
-    FD_TEST( FD_PUBKEY_SUCCESS==fd_pubkey_find_program_address( (fd_pubkey_t const *)tip_distribution_program_addr,
+    FD_TEST( FD_EXECUTOR_INSTR_SUCCESS==fd_pubkey_find_program_address( (fd_pubkey_t const *)tip_distribution_program_addr,
                                                                 1UL, seed_ptr, &seed_len,
                                                                 (fd_pubkey_t *)g->crank3->tip_distribution_program_config, out_bump, cerr ) );
   } while( 0 );
@@ -275,7 +275,7 @@ fd_bundle_crank_update_epoch( fd_bundle_crank_gen_t * g,
 
   uchar * _seeds[1] = { (uchar *)seeds };
 
-  FD_TEST( FD_PUBKEY_SUCCESS==fd_pubkey_find_program_address( (fd_pubkey_t const *)g->crank3->tip_distribution_program,
+  FD_TEST( FD_EXECUTOR_INSTR_SUCCESS==fd_pubkey_find_program_address( (fd_pubkey_t const *)g->crank3->tip_distribution_program,
                                                               1UL, _seeds, &seed_len,
                                                               (fd_pubkey_t *)g->crank3->new_tip_receiver,
                                                               &(g->crank3->init_tip_distribution_acct.bump), custom_err ) );

--- a/src/flamenco/runtime/fd_pubkey_utils.c
+++ b/src/flamenco/runtime/fd_pubkey_utils.c
@@ -37,11 +37,11 @@ fd_pubkey_create_with_seed( fd_exec_instr_ctx_t const * ctx,
 
 /* https://github.com/anza-xyz/agave/blob/77daab497df191ef485a7ad36ed291c1874596e5/sdk/program/src/pubkey.rs#L578-L625 */
 int
-fd_pubkey_derive_pda( fd_pubkey_t const * program_id, 
-                      ulong               seeds_cnt, 
-                      uchar **            seeds, 
+fd_pubkey_derive_pda( fd_pubkey_t const * program_id,
+                      ulong               seeds_cnt,
+                      uchar **            seeds,
                       ulong *             seed_szs,
-                      uchar *             bump_seed, 
+                      uchar *             bump_seed,
                       fd_pubkey_t *       out,
                       uint *              custom_err ) {
   /* https://github.com/anza-xyz/agave/blob/6ac4fe32e28d8ceb4085072b61fa0c6cb09baac1/sdk/program/src/pubkey.rs#L579-L581 */
@@ -51,7 +51,7 @@ fd_pubkey_derive_pda( fd_pubkey_t const * program_id,
   }
   /* TODO: This does not contain size checks for the seed as checked in
      https://github.com/anza-xyz/agave/blob/77daab497df191ef485a7ad36ed291c1874596e5/sdk/program/src/pubkey.rs#L586-L588 */
-                      
+
   fd_sha256_t sha = {0};
   fd_sha256_init( &sha );
   for ( ulong i=0UL; i<seeds_cnt; i++ ) {
@@ -61,7 +61,7 @@ fd_pubkey_derive_pda( fd_pubkey_t const * program_id,
     }
     fd_sha256_append( &sha, seed, seed_szs[i] );
   }
-    
+
   if( bump_seed ) {
     fd_sha256_append( &sha, bump_seed, 1UL );
   }
@@ -71,22 +71,22 @@ fd_pubkey_derive_pda( fd_pubkey_t const * program_id,
   fd_sha256_fini( &sha, out );
 
   /* A PDA is valid if it is not a valid ed25519 curve point.
-     In most cases the user will have derived the PDA off-chain, 
-     or the PDA is a known signer. 
+     In most cases the user will have derived the PDA off-chain,
+     or the PDA is a known signer.
      https://github.com/anza-xyz/agave/blob/6ac4fe32e28d8ceb4085072b61fa0c6cb09baac1/sdk/program/src/pubkey.rs#L599-L601 */
   if( FD_UNLIKELY( fd_ed25519_point_validate( out->key ) ) ) {
     *custom_err = FD_PUBKEY_ERR_INVALID_SEEDS;
     return FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR;
   }
 
-  return FD_PUBKEY_SUCCESS;
+  return FD_EXECUTOR_INSTR_SUCCESS;
 }
 
 /* https://github.com/anza-xyz/agave/blob/77daab497df191ef485a7ad36ed291c1874596e5/sdk/program/src/pubkey.rs#L477-L534 */
 int
-fd_pubkey_find_program_address( fd_pubkey_t const * program_id, 
-                                ulong               seeds_cnt, 
-                                uchar **            seeds, 
+fd_pubkey_find_program_address( fd_pubkey_t const * program_id,
+                                ulong               seeds_cnt,
+                                uchar **            seeds,
                                 ulong *             seed_szs,
                                 fd_pubkey_t *       out,
                                 uchar *             out_bump_seed,
@@ -97,17 +97,17 @@ fd_pubkey_find_program_address( fd_pubkey_t const * program_id,
 
     fd_pubkey_t derived[ 1UL ];
     int err = fd_pubkey_derive_pda( program_id, seeds_cnt, seeds, seed_szs, bump_seed, derived, custom_err );
-    if( err==FD_PUBKEY_SUCCESS ) {
+    if( err==FD_EXECUTOR_INSTR_SUCCESS ) {
       /* Stop looking if we have found a valid PDA */
       fd_memcpy( out, derived, sizeof(fd_pubkey_t) );
       fd_memcpy( out_bump_seed, bump_seed, 1UL );
       break;
-    } else if( err==FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR && *custom_err!=FD_PUBKEY_ERR_INVALID_SEEDS ) { 
+    } else if( err==FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR && *custom_err!=FD_PUBKEY_ERR_INVALID_SEEDS ) {
       return err;
     }
   }
 
   // Custom error may get set in fd_pubkey_derive_pda call
   *custom_err = UINT_MAX;
-  return FD_PUBKEY_SUCCESS;
+  return FD_EXECUTOR_INSTR_SUCCESS;
 }

--- a/src/flamenco/runtime/fd_pubkey_utils.h
+++ b/src/flamenco/runtime/fd_pubkey_utils.h
@@ -7,9 +7,6 @@
 #define MAX_SEEDS    (16UL)
 #define MAX_SEED_LEN (32UL)
 
-/* TODO: firedancer pubkey errors don't map to agave's implementation */
-#define FD_PUBKEY_SUCCESS                   (0)
-
 /* Custom error codes */
 #define FD_PUBKEY_ERR_MAX_SEED_LEN_EXCEEDED (0U)
 #define FD_PUBKEY_ERR_INVALID_SEEDS         (1U)
@@ -30,15 +27,15 @@ fd_pubkey_create_with_seed( fd_exec_instr_ctx_t const * ctx,
    TODO: Potentially replace with shared function in fd_vm_syscall_pda.c */
 
 int
-fd_pubkey_derive_pda( fd_pubkey_t const * program_id, 
-                      ulong               seeds_cnt, 
-                      uchar **            seeds, 
+fd_pubkey_derive_pda( fd_pubkey_t const * program_id,
+                      ulong               seeds_cnt,
+                      uchar **            seeds,
                       ulong *             seed_szs,
-                      uchar *             bump_seed, 
+                      uchar *             bump_seed,
                       fd_pubkey_t *       out,
                       uint *              custom_err );
 
-/* fd_pubkey_find_program_address mirrors the vm syscall function 
+/* fd_pubkey_find_program_address mirrors the vm syscall function
    fd_vm_syscall_sol_try_find_program_address and creates a valid
    program derived address searching for a valid ed25519 curve point by
    iterating through 255 possible bump seeds. If any of the possible addresses
@@ -47,8 +44,8 @@ fd_pubkey_derive_pda( fd_pubkey_t const * program_id,
    TODO: Potentially replace with shared function in fd_vm_syscall_pda.c */
 
 int
-fd_pubkey_find_program_address( fd_pubkey_t const * program_id, 
-                                ulong               seeds_cnt, 
+fd_pubkey_find_program_address( fd_pubkey_t const * program_id,
+                                ulong               seeds_cnt,
                                 uchar **            seeds,
                                 ulong *             seed_szs,
                                 fd_pubkey_t *       out,


### PR DESCRIPTION
previously, FD_PUBKEY_SUCCESS was mixed with FD_EXECUTOR_INSTR_ERR_* for failiure cases. Furthermore, it runs the risk of confusion with #define FD_PUBKEY_ERR_* codes, that have a semantically different meaning (custom_err vs return code).