### PR TITLE
solcap: fix deduplication, solcap hash, solcap start slot bugs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,6 +129,13 @@ jobs:
           source /opt/${{ matrix.compiler }}/${{ matrix.compiler }}-${{ matrix.compiler-version }}/activate
           make run-test-vectors
 
+      - name: run solcap tests
+        if: ${{ matrix.run-unit-tests && matrix.test-case == 'native' }}
+        run: |
+          sudo prlimit --pid $$ --memlock=-1:-1
+          source /opt/${{ matrix.compiler }}/${{ matrix.compiler }}-${{ matrix.compiler-version }}/activate
+          DUMP_DIR=../dump make run-solcap-tests
+
       - name: run integration tests
         if: ${{ matrix.run-integration-tests }}
         run: |

--- a/config/everything.mk
+++ b/config/everything.mk
@@ -450,6 +450,11 @@ LLVM_PROFILE_FILE="$(OBJDIR)/cov/raw/test_vectors-%p.profraw" \
 LOG_PATH="$(OBJDIR)/log/fd-test-vectors-report" \
 contrib/test/run_test_vectors.sh
 
+run-solcap-tests: bin unit-test
+	OBJDIR=$(OBJDIR) \
+	MACHINE=$(MACHINE) \
+	contrib/test/run_solcap_tests.sh
+
 seccomp-policies:
 	$(FIND) . -name '*.seccomppolicy' -exec $(PYTHON) contrib/codegen/generate_filters.py {} \;
 

--- a/contrib/test/run_solcap_tests.sh
+++ b/contrib/test/run_solcap_tests.sh
@@ -1,0 +1,33 @@
+DUMP_DIR=${DUMP_DIR:="./dump"}
+echo $OBJDIR
+
+LEDGER="devnet-398736132"
+
+if [[ ! -e $DUMP_DIR/$LEDGER && SKIP_INGEST -eq 0 ]]; then
+    echo "Downloading gs://firedancer-ci-resources/$LEDGER.tar.gz"
+  if [ "`gcloud auth list |& grep  firedancer-scratch | wc -l`" == "0" ]; then
+    if [ "`gcloud auth list |& grep  firedancer-ci | wc -l`" == "0" ]; then
+      if [ -f /etc/firedancer-scratch-bucket-key.json ]; then
+        gcloud auth activate-service-account --key-file /etc/firedancer-scratch-bucket-key.json
+      fi
+      if [ -f /etc/firedancer-ci-78fff3e07c8b.json ]; then
+        gcloud auth activate-service-account --key-file /etc/firedancer-ci-78fff3e07c8b.json
+      fi
+    fi
+  fi
+  gcloud storage cat gs://firedancer-ci-resources/$LEDGER.tar.gz | tee $DUMP_DIR/$LEDGER.tar.gz | tar zxf - -C $DUMP_DIR
+fi
+
+rm -rf $DUMP_DIR/$LEDGER/devnet-398736132_current.toml
+rm -rf $DUMP_DIR/$LEDGER/fd.solcap
+
+cp $DUMP_DIR/$LEDGER/devnet-398736132.toml $DUMP_DIR/$LEDGER/devnet-398736132_current.toml
+
+export dump_dir=$(realpath $DUMP_DIR)
+sed -i "s#{dump_dir}#${dump_dir}#g" "$DUMP_DIR/$LEDGER/devnet-398736132_current.toml"
+
+$OBJDIR/bin/firedancer-dev configure init all --config $DUMP_DIR/$LEDGER/devnet-398736132_current.toml &> /dev/null
+$OBJDIR/bin/firedancer-dev backtest --config $DUMP_DIR/$LEDGER/devnet-398736132_current.toml
+$OBJDIR/bin/firedancer-dev configure fini all --config $DUMP_DIR/$LEDGER/devnet-398736132_current.toml &> /dev/null
+
+$OBJDIR/bin/fd_solcap_diff $DUMP_DIR/$LEDGER/solana.solcap $DUMP_DIR/$LEDGER/fd.solcap -v 4

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -873,19 +873,15 @@ static void
 fd_replay_process_solcap_account_update( fd_replay_tile_ctx_t *                          ctx,
                                           fd_runtime_public_account_update_msg_t const * msg,
                                           uchar const *                                  account_data ) {
-  if( FD_UNLIKELY( !ctx->capture_ctx || !ctx->capture_ctx->capture ||
-                   fd_bank_slot_get( ctx->slot_ctx->bank )<ctx->capture_ctx->solcap_start_slot ) ) {
-    /* No solcap capture configured or slot not reached yet, ignore the message */
-    return;
+  if( ctx->capture_ctx && ctx->capture_ctx->capture && fd_bank_slot_get( ctx->slot_ctx->bank )>=ctx->capture_ctx->solcap_start_slot ) {
+    /* Write the account to the solcap file */
+    fd_solcap_write_account( ctx->capture_ctx->capture,
+      &msg->pubkey,
+      &msg->info,
+      account_data,
+      msg->data_sz,
+      &msg->hash );
   }
-
-  /* Write the account to the solcap file */
-  fd_solcap_write_account( ctx->capture_ctx->capture,
-    &msg->pubkey,
-    &msg->info,
-    account_data,
-    msg->data_sz,
-    &msg->hash );
 }
 
 static void

--- a/src/flamenco/capture/fd_solcap_writer.c
+++ b/src/flamenco/capture/fd_solcap_writer.c
@@ -2,6 +2,7 @@
 #include "fd_solcap.pb.h"
 #include "fd_solcap_proto.h"
 #include "../../ballet/nanopb/pb_encode.h"
+#include "../../ballet/blake3/fd_blake3.h"
 
 #if !FD_HAS_HOSTED
 #error "fd_solcap_writer requires FD_HAS_HOSTED"
@@ -360,14 +361,25 @@ fd_solcap_write_account( fd_solcap_writer_t *             writer,
                          fd_solana_account_meta_t const * meta,
                          void const *                     data,
                          ulong                            data_sz,
-                         void const *                     hash ) {
+                         void const *                     hash FD_PARAM_UNUSED ) {
+
+  uchar account_hash[32];
+  fd_blake3_t b31[1];
+  fd_blake3_init( b31 );
+  fd_blake3_append( b31, &meta->lamports,   sizeof( ulong ) );
+  fd_blake3_append( b31, &meta->rent_epoch, sizeof( ulong ) );
+  fd_blake3_append( b31, data,              data_sz         );
+  fd_blake3_append( b31, &meta->executable, sizeof( uchar ) );
+  fd_blake3_append( b31, meta->owner,       32UL            );
+  fd_blake3_append( b31, key,               32UL            );
+  fd_blake3_fini  ( b31,  account_hash );
 
   if( FD_LIKELY( !writer ) ) return 0;
 
   fd_solcap_account_tbl_t rec[1];
   memset( rec, 0, sizeof(fd_solcap_account_tbl_t) );
   memcpy( rec->key,  key,  32UL );
-  memcpy( rec->hash, hash, 32UL );
+  memcpy( rec->hash, account_hash, 32UL );
 
   fd_solcap_AccountMeta meta_pb[1] = {{
     .lamports   = meta->lamports,

--- a/src/flamenco/runtime/fd_hashes.c
+++ b/src/flamenco/runtime/fd_hashes.c
@@ -78,7 +78,7 @@ fd_hashes_update_lthash( fd_txn_account_t const  * account,
   fd_bank_lthash_end_locking_modify( bank );
 
   /* Write the new account state to the capture file */
-  if( capture_ctx ) {
+  if( capture_ctx && capture_ctx->capture && fd_bank_slot_get( bank )>=capture_ctx->solcap_start_slot ) {
     uchar new_hash_checksum[FD_HASH_FOOTPRINT];
     fd_lthash_hash( new_hash, new_hash_checksum );
     int err = fd_solcap_write_account(


### PR DESCRIPTION
changes made:
* deduplicate accounts when investigating solcap captures
* update to use original account hash logic for solcaps (want to match agave bank hash details file)
* update logic to account fields even when bank hashes match
* integration test that runs backtest with solcap creation and tests against agave
* fix solcap creation with capture start slot
* make dedup optional (yaml only)