### PR TITLE
runtime: fix sysvar cache function name mismatch

### DIFF
--- a/src/flamenco/runtime/sysvar/fd_sysvar_cache.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_cache.c
@@ -146,7 +146,7 @@ fd_sysvar_cache_slot_history_join_const(
 }
 
 void
-fd_sysvar_slot_history_leave_const(
+fd_sysvar_cache_slot_history_leave_const(
     fd_sysvar_cache_t const *        sysvar_cache,
     fd_slot_history_global_t const * slot_history
 ) {


### PR DESCRIPTION
match the name to the .h declaration