### PR TITLE
vote ts in seconds

### DIFF
--- a/src/choreo/tower/fd_tower.c
+++ b/src/choreo/tower/fd_tower.c
@@ -502,7 +502,7 @@ fd_tower_to_vote_txn( fd_tower_t const *    tower,
   tower_sync.root          = root;
   tower_sync.lockouts_len  = (ushort)fd_tower_votes_cnt( tower );
   tower_sync.lockouts      = lockouts_scratch;
-  tower_sync.timestamp     = fd_log_wallclock();
+  tower_sync.timestamp     = (long)(fd_log_wallclock() / 1e9L); /* seconds */
   tower_sync.has_timestamp = 1;
 
   ulong prev = tower_sync.root;


### PR DESCRIPTION
This PR timestamps votes in seconds, rather than ns, to match agave's behavior. The current impl means any vote account used on full firedancer is impossible to use with frank/agave. 😅 