### PR TITLE
runtime: remove account_meta hash

### DIFF
--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -142,7 +142,6 @@ account_cb( void *                          _ctx,
 
   fd_txn_account_set_data_len( rec, hdr->meta.data_len );
   fd_txn_account_set_slot( rec, ctx->ssparse->accv_slot );
-  fd_txn_account_set_hash( rec, &hdr->hash );
   fd_txn_account_set_meta_info( rec, &hdr->info );
 
   ctx->acc_data = fd_txn_account_get_data_mut( rec );

--- a/src/flamenco/runtime/fd_txn_account.c
+++ b/src/flamenco/runtime/fd_txn_account.c
@@ -351,14 +351,6 @@ fd_txn_account_get_rent_epoch( fd_txn_account_t const * acct ) {
   return acct->meta->info.rent_epoch;
 }
 
-fd_hash_t const *
-fd_txn_account_get_hash( fd_txn_account_t const * acct ) {
-  if( FD_UNLIKELY( !acct->meta ) ) {
-    FD_LOG_CRIT(( "account is not setup" ));
-  }
-  return (fd_hash_t const *)acct->meta->hash;
-}
-
 fd_solana_account_meta_t const *
 fd_txn_account_get_info( fd_txn_account_t const * acct ) {
   if( FD_UNLIKELY( !acct->meta ) ) {
@@ -482,17 +474,6 @@ fd_txn_account_set_slot( fd_txn_account_t * acct, ulong slot ) {
     FD_LOG_CRIT(( "account is not setup" ));
   }
   acct->meta->slot = slot;
-}
-
-void
-fd_txn_account_set_hash( fd_txn_account_t * acct, fd_hash_t const *  hash ) {
-  if( FD_UNLIKELY( !acct->is_mutable ) ) {
-    FD_LOG_CRIT(( "account is not mutable" ));
-  }
-  if( FD_UNLIKELY( !acct->meta ) ) {
-    FD_LOG_CRIT(( "account is not setup" ));
-  }
-  memcpy( acct->meta->hash, hash->hash, sizeof(fd_hash_t) );
 }
 
 void

--- a/src/flamenco/runtime/fd_txn_account.h
+++ b/src/flamenco/runtime/fd_txn_account.h
@@ -171,9 +171,6 @@ fd_txn_account_get_lamports( fd_txn_account_t const * acct );
 ulong
 fd_txn_account_get_rent_epoch( fd_txn_account_t const * acct );
 
-fd_hash_t const *
-fd_txn_account_get_hash( fd_txn_account_t const * acct );
-
 fd_solana_account_meta_t const *
 fd_txn_account_get_info( fd_txn_account_t const * acct );
 
@@ -209,10 +206,6 @@ fd_txn_account_set_data_len( fd_txn_account_t * acct, ulong data_len );
 void
 fd_txn_account_set_slot( fd_txn_account_t * acct,
                          ulong              slot );
-
-void
-fd_txn_account_set_hash( fd_txn_account_t * acct,
-                         fd_hash_t const *  hash );
 
 void
 fd_txn_account_clear_owner( fd_txn_account_t * acct );

--- a/src/flamenco/runtime/test_txn_account.c
+++ b/src/flamenco/runtime/test_txn_account.c
@@ -48,7 +48,6 @@ main( int argc, char ** argv ) {
   FD_TEST( fd_txn_account_get_data_len( txn_account ) == 100UL );
   FD_TEST( fd_txn_account_get_lamports( txn_account ) == 0UL );
   FD_TEST( fd_txn_account_get_rent_epoch( txn_account ) == ULONG_MAX );
-  FD_TEST( !memcmp( fd_txn_account_get_hash( txn_account ), null_hash, sizeof(null_hash) ) );
   FD_TEST( !memcmp( fd_txn_account_get_owner( txn_account ), null_hash, sizeof(null_hash) ) );
   FD_TEST( fd_txn_account_get_meta( txn_account ) == meta );
   FD_TEST( fd_txn_account_get_data( txn_account ) == acc_data );

--- a/src/flamenco/types/fd_fuzz_types.h
+++ b/src/flamenco/types/fd_fuzz_types.h
@@ -252,7 +252,6 @@ void *fd_account_meta_generate( void *mem, void **alloc_mem, fd_rng_t * rng ) {
   self->magic = fd_rng_ushort( rng );
   self->hlen = fd_rng_ushort( rng );
   self->dlen = fd_rng_ulong( rng );
-  LLVMFuzzerMutate( &self->hash[0], sizeof(self->hash), sizeof(self->hash) );
   self->slot = fd_rng_ulong( rng );
   fd_solana_account_meta_generate( &self->info, alloc_mem, rng );
   return mem;

--- a/src/flamenco/types/fd_types.c
+++ b/src/flamenco/types/fd_types.c
@@ -1047,8 +1047,6 @@ int fd_account_meta_encode( fd_account_meta_t const * self, fd_bincode_encode_ct
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_bincode_uint64_encode( self->dlen, ctx );
   if( FD_UNLIKELY( err ) ) return err;
-  err = fd_bincode_bytes_encode( self->hash, sizeof(self->hash), ctx );
-  if( FD_UNLIKELY( err ) ) return err;
   err = fd_bincode_uint64_encode( self->slot, ctx );
   if( FD_UNLIKELY( err ) ) return err;
   err = fd_solana_account_meta_encode( &self->info, ctx );
@@ -1064,8 +1062,6 @@ static int fd_account_meta_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
   err = fd_bincode_uint64_decode_footprint( ctx );
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
-  err = fd_bincode_bytes_decode_footprint( 32, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
   err = fd_bincode_uint64_decode_footprint( ctx );
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
   err = fd_solana_account_meta_decode_footprint_inner( ctx, total_sz );
@@ -1085,7 +1081,6 @@ static void fd_account_meta_decode_inner( void * struct_mem, void * * alloc_mem,
   fd_bincode_uint16_decode_unsafe( &self->magic, ctx );
   fd_bincode_uint16_decode_unsafe( &self->hlen, ctx );
   fd_bincode_uint64_decode_unsafe( &self->dlen, ctx );
-  fd_bincode_bytes_decode_unsafe( &self->hash[0], sizeof(self->hash), ctx );
   fd_bincode_uint64_decode_unsafe( &self->slot, ctx );
   fd_solana_account_meta_decode_inner( &self->info, alloc_mem, ctx );
 }
@@ -1107,7 +1102,6 @@ void fd_account_meta_walk( void * w, fd_account_meta_t const * self, fd_types_wa
   fun( w, &self->magic, "magic", FD_FLAMENCO_TYPE_USHORT, "ushort", level, 0  );
   fun( w, &self->hlen, "hlen", FD_FLAMENCO_TYPE_USHORT, "ushort", level, 0  );
   fun( w, &self->dlen, "dlen", FD_FLAMENCO_TYPE_ULONG, "ulong", level, 0  );
-  fun( w, self->hash, "hash", FD_FLAMENCO_TYPE_HASH256, "uchar[32]", level, 0  );
   fun( w, &self->slot, "slot", FD_FLAMENCO_TYPE_ULONG, "ulong", level, 0  );
   fd_solana_account_meta_walk( w, &self->info, fun, "info", level, 0 );
   fun( w, self, name, FD_FLAMENCO_TYPE_MAP_END, "fd_account_meta", level--, 0 );

--- a/src/flamenco/types/fd_types.h
+++ b/src/flamenco/types/fd_types.h
@@ -181,12 +181,11 @@ struct __attribute__((packed)) fd_solana_account_hdr {
 typedef struct fd_solana_account_hdr fd_solana_account_hdr_t;
 #define FD_SOLANA_ACCOUNT_HDR_ALIGN (8UL)
 
-/* Encoded Size: Fixed (104 bytes) */
+/* Encoded Size: Fixed (72 bytes) */
 struct __attribute__((packed)) fd_account_meta {
   ushort magic;
   ushort hlen;
   ulong dlen;
-  uchar hash[32];
   ulong slot;
   fd_solana_account_meta_t info;
 };
@@ -2811,7 +2810,7 @@ void * fd_solana_account_hdr_decode( void * mem, fd_bincode_decode_ctx_t * ctx )
 void fd_account_meta_new( fd_account_meta_t * self );
 int fd_account_meta_encode( fd_account_meta_t const * self, fd_bincode_encode_ctx_t * ctx );
 void fd_account_meta_walk( void * w, fd_account_meta_t const * self, fd_types_walk_fn_t fun, const char *name, uint level, uint varint );
-static inline ulong fd_account_meta_size( fd_account_meta_t const * self ) { (void)self; return 104UL; }
+static inline ulong fd_account_meta_size( fd_account_meta_t const * self ) { (void)self; return 72UL; }
 static inline ulong fd_account_meta_align( void ) { return FD_ACCOUNT_META_ALIGN; }
 int fd_account_meta_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
 void * fd_account_meta_decode( void * mem, fd_bincode_decode_ctx_t * ctx );

--- a/src/flamenco/types/fd_types.json
+++ b/src/flamenco/types/fd_types.json
@@ -209,7 +209,6 @@
         { "name": "magic", "type": "ushort" },
         { "name": "hlen",  "type": "ushort" },
         { "name": "dlen",  "type": "ulong" },
-        { "name": "hash",  "type": "uchar[32]" },
         { "name": "slot",  "type": "ulong" },
         { "name": "info",  "type": "solana_account_meta" }
       ]


### PR DESCRIPTION
Saves ~32 bytes per account, which is ~30 GB at current mainnet state size.
