### PR TITLE
nit: remove unnecessary `#undef FOUND_ROUNDS`

### DIFF
--- a/src/ballet/sha256/fd_sha256.c
+++ b/src/ballet/sha256/fd_sha256.c
@@ -559,7 +559,6 @@ fd_sha256_hash_32_repeated( void const * _data,
   }
   vu_stu( hash,      vu_bswap( w0003 ) );
   vu_stu( hash+16UL, vu_bswap( w0407 ) );
-#undef FOUND_ROUNDS
 #undef NEXT_W
 
 #else


### PR DESCRIPTION
Removing `#undef FOUND_ROUNDS` because as far as I can see it is never defined anywhere:
```
~/firedancer$ rg FOUND_ROUNDS
src/ballet/sha256/fd_sha256.c 562:#undef FOUND_ROUNDS
```