### PR TITLE
shred: change fec resolver to not spill to done map

### DIFF
--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -1244,7 +1244,7 @@ user = ""
         # To compute an appropriate value, multiply the expected Turbine
         # worst-case latency (tenths of seconds) by the expected
         # transaction rate, and divide by approx 25.
-        max_pending_shred_sets = 16384
+        max_pending_shred_sets = 1024
 
         # The shred tile listens on a specific port for shreds to
         # forward.  This argument controls which port that is.  The port

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -355,7 +355,7 @@ fd_topo_initialize( config_t * config ) {
 
   /**/                 fd_topob_link( topo, "repair_net",   "net_repair",   config->net.ingress_buffer_size,          FD_NET_MTU,                    1UL );
   /**/                 fd_topob_link( topo, "ping_sign",    "repair_sign",  128UL,                                    2048UL,                        1UL );
-  FOR(shred_tile_cnt)  fd_topob_link( topo, "shred_repair", "shred_repair", pending_fec_shreds_depth,                 FD_SHRED_REPAIR_MTU,           2UL /* at most 2 msgs per after_frag */ );
+  FOR(shred_tile_cnt)  fd_topob_link( topo, "shred_repair", "shred_repair", pending_fec_shreds_depth,                 FD_SHRED_REPAIR_MTU,           3UL );
 
 
   FOR(shred_tile_cnt)  fd_topob_link( topo, "repair_shred", "shred_repair", pending_fec_shreds_depth,                 sizeof(fd_ed25519_sig_t),      1UL );

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -508,6 +508,7 @@ fd_topo_initialize( config_t * config ) {
   fd_topo_obj_t * store_obj = setup_topo_store( topo, "store", config->firedancer.store.max_completed_shred_sets, (uint)shred_tile_cnt );
   FOR(shred_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "shred", i ) ], store_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   fd_topob_tile_uses( topo, replay_tile, store_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+  fd_topob_tile_uses( topo, repair_tile, store_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   FD_TEST( fd_pod_insertf_ulong( topo->props, store_obj->id, "store" ) );
 
   /* Create a txncache to be used by replay. */
@@ -763,7 +764,7 @@ fd_topo_initialize( config_t * config ) {
     for( ulong j=0UL; j<shred_tile_cnt; j++ ) {
       fd_topob_tile_in(  topo, "scap", 0UL, "metric_in", "shred_repair", j, FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
     }
-    fd_topob_tile_in( topo, "shrdcp", 0UL, "metric_in", "gossip_out", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
+    fd_topob_tile_in( topo, "scap", 0UL, "metric_in", "gossip_out", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
 
     fd_topob_tile_in( topo, "scap", 0UL, "metric_in", "repair_scap", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
     fd_topob_tile_in( topo, "scap", 0UL, "metric_in", "replay_scap", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );

--- a/src/disco/shred/fd_fec_resolver.c
+++ b/src/disco/shred/fd_fec_resolver.c
@@ -309,13 +309,19 @@ ctx_ll_insert( set_ctx_t * p, set_ctx_t * c ) {
   return c;
 }
 
-int fd_fec_resolver_add_shred( fd_fec_resolver_t    * resolver,
-                               fd_shred_t const     * shred,
-                               ulong                  shred_sz,
-                               uchar const          * leader_pubkey,
-                               fd_fec_set_t const * * out_fec_set,
-                               fd_shred_t const   * * out_shred,
-                               fd_bmtree_node_t     * out_merkle_root ) {
+
+int
+fd_fec_resolver_add_shred( fd_fec_resolver_t    * resolver,
+                           fd_shred_t const     * shred,
+                           ulong                  shred_sz,
+                           uchar const          * leader_pubkey,
+                           fd_fec_set_t const * * out_fec_set,
+                           fd_shred_t const   * * out_shred,
+                           fd_bmtree_node_t     * out_merkle_root,
+                           ulong                * out_spilled_slot,
+                           uint                 * out_spilled_fec_set_idx,
+                           uint                 * out_max_dshred_idx ) {
+
   /* Unpack variables */
   ulong partial_depth = resolver->partial_depth;
   ulong done_depth    = resolver->done_depth;
@@ -406,7 +412,7 @@ int fd_fec_resolver_add_shred( fd_fec_resolver_t    * resolver,
   /* This, combined with the check on shred->code.data_cnt implies that
      shred_idx is in [0, DATA_SHREDS_MAX+PARITY_SHREDS_MAX). */
 
-  if( FD_UNLIKELY( tree_depth>FD_SHRED_MERKLE_LAYER_CNT-1UL             ) ) return FD_FEC_RESOLVER_SHRED_REJECTED;
+  if( FD_UNLIKELY( tree_depth>FD_SHRED_MERKLE_LAYER_CNT-1UL          ) ) return FD_FEC_RESOLVER_SHRED_REJECTED;
   if( FD_UNLIKELY( fd_bmtree_depth( shred_idx+1UL ) > tree_depth+1UL ) ) return FD_FEC_RESOLVER_SHRED_REJECTED;
 
   if( FD_UNLIKELY( !ctx ) ) { /* This is the first shred in the FEC set */
@@ -418,10 +424,27 @@ int fd_fec_resolver_add_shred( fd_fec_resolver_t    * resolver,
          set to the back of the free list. */
       set_ctx_t * victim_ctx = resolver->curr_ll_sentinel->prev;
 
-      /* Add this one that we're sacrificing to the done map to
-         prevent the possibility of thrashing. */
-      ctx_ll_insert( done_ll_sentinel, ctx_map_insert( done_map, victim_ctx->sig ) );
-      if( FD_UNLIKELY( ctx_map_key_cnt( done_map ) > done_depth ) ) ctx_map_remove( done_map, ctx_ll_remove( done_ll_sentinel->prev ) );
+
+      if( FD_LIKELY( out_spilled_slot || out_spilled_fec_set_idx || out_max_dshred_idx ) ) {
+        fd_fec_set_t * set = victim_ctx->set;
+
+        /* Find the highest data shred received in the FEC set */
+
+        ulong max_rcvd_dshred_idx = d_rcvd_last( set->data_shred_rcvd );
+        fd_shred_t const * max_shred;
+        if( max_rcvd_dshred_idx == ~0UL ) {
+          max_rcvd_dshred_idx = FD_SHRED_BLK_MAX; /* No data shreds received. Use a parity shred to determine the spilled slot and fec_set_idx */
+          max_shred = fd_shred_parse( set->parity_shreds[ p_rcvd_first( set->parity_shred_rcvd ) ], FD_SHRED_MAX_SZ );
+        } else {
+          max_shred = fd_shred_parse( set->data_shreds  [ max_rcvd_dshred_idx ],                    FD_SHRED_MIN_SZ );
+        }
+
+        if( FD_LIKELY( out_spilled_slot        ) ) *out_spilled_slot        = max_shred->slot;
+        if( FD_LIKELY( out_spilled_fec_set_idx ) ) *out_spilled_fec_set_idx = max_shred->fec_set_idx;
+        if( FD_LIKELY( out_max_dshred_idx      ) ) *out_max_dshred_idx      = (uint)max_rcvd_dshred_idx;
+
+        FD_LOG_INFO(("Thrashed from fec_resolver in-progress map %lu %u, data_shreds_rcvd %lu, parity_shreds_rcvd %lu, max_d_rcvd_shred_idx %lu", max_shred->slot, max_shred->fec_set_idx, d_rcvd_cnt( set->data_shred_rcvd ), p_rcvd_cnt( set->parity_shred_rcvd ), max_rcvd_dshred_idx ));
+      }
 
       freelist_push_tail( free_list,        victim_ctx->set  );
       bmtrlist_push_tail( bmtree_free_list, victim_ctx->tree );
@@ -813,10 +836,15 @@ fd_fec_resolver_force_complete( fd_fec_resolver_t  *  resolver,
   ctx->set->parity_shred_cnt = 0UL;
 
   /* Reject FEC set if it didn't validate and return mem to the pools */
+  set_ctx_t * done_ll_sentinel = resolver->done_ll_sentinel;
+  set_ctx_t * curr_map         = resolver->curr_map;
+  set_ctx_t * done_map         = resolver->done_map;
+  ulong       done_depth       = resolver->done_depth;
 
   if( FD_UNLIKELY( reject ) ) {
     freelist_push_tail( resolver->free_list,        ctx->set  );
     bmtrlist_push_tail( resolver->bmtree_free_list, ctx->tree );
+    ctx_map_remove( curr_map, ctx_ll_remove( ctx ));
     FD_MCNT_INC( SHRED, FEC_REJECTED_FATAL, 1UL );
     return FD_FEC_RESOLVER_SHRED_REJECTED;
   }
@@ -827,11 +855,6 @@ fd_fec_resolver_force_complete( fd_fec_resolver_t  *  resolver,
 
   /* Don't need to populate merkle proofs or retransmitter signatures
      because it is by definition the full set of rcvd data shreds. */
-
-  set_ctx_t * done_ll_sentinel = resolver->done_ll_sentinel;
-  set_ctx_t * curr_map         = resolver->curr_map;
-  set_ctx_t * done_map         = resolver->done_map;
-  ulong       done_depth       = resolver->done_depth;
 
   fd_fec_set_t        * set  = ctx->set;
   fd_bmtree_commit_t  * tree = ctx->tree;

--- a/src/disco/shred/fd_fec_resolver.h
+++ b/src/disco/shred/fd_fec_resolver.h
@@ -193,14 +193,27 @@ fd_fec_resolver_set_shred_version( fd_fec_resolver_t * resolver,
 
    This function returns SHRED_COMPLETES when the received shred is the
    last one and completes the FEC set.  In this case, the function
-   populates any missing shreds in the FEC set stored in out_fec_set. */
-int fd_fec_resolver_add_shred( fd_fec_resolver_t    * resolver,
-                               fd_shred_t const     * shred,
-                               ulong                  shred_sz,
-                               uchar const          * leader_pubkey,
-                               fd_fec_set_t const * * out_fec_set,
-                               fd_shred_t const   * * out_shred,
-                               fd_bmtree_node_t     * out_merkle_root );
+   populates any missing shreds in the FEC set stored in out_fec_set.
+
+   Along with the return err code, if adding this shred caused an
+   incomplete FEC set to be evicted from the current map, the slot and
+   FEC set idx of the evicted FEC set will be written to spilled_slot
+   and spilled_fec_set_idx.  The max data shred idx received thus far
+   of the evicted FEC set will be written to max_shred_idx.  If no FEC
+   set was evicted, spilled_slot and max_shred_idx will be 0, and
+   spilled_fec_set_idx will be FD_SHRED_BLK_MAX. */
+
+int
+fd_fec_resolver_add_shred( fd_fec_resolver_t    * resolver,
+                           fd_shred_t const     * shred,
+                           ulong                  shred_sz,
+                           uchar const          * leader_pubkey,
+                           fd_fec_set_t const * * out_fec_set,
+                           fd_shred_t const   * * out_shred,
+                           fd_bmtree_node_t     * out_merkle_root,
+                           ulong                * out_spilled_slot,
+                           uint                 * out_spilled_fec_set_idx,
+                           uint                 * out_max_dshred_idx );
 
 
 /* fd_fec_resolver_done_contains returns 1 if the FEC with signature

--- a/src/disco/shred/fd_fec_resolver.h
+++ b/src/disco/shred/fd_fec_resolver.h
@@ -160,7 +160,12 @@ fd_fec_resolver_set_shred_version( fd_fec_resolver_t * resolver,
 #define FD_FEC_RESOLVER_ADD_SHRED_RETVAL_CNT 4
 #define FD_FEC_RESOLVER_ADD_SHRED_RETVAL_OFF 2
 
-
+struct fd_fec_resolver_spilled {
+  ulong slot;
+  uint  fec_set_idx;
+  uint  max_dshred_idx; /* position in FEC set, in [0, FD_REEDSOL_DATA_SHREDS_MAX) */
+};
+typedef struct fd_fec_resolver_spilled fd_fec_resolver_spilled_t;
 
 /* fd_fec_resolver_add_shred notifies the FEC resolver of a newly
    received shred.  The FEC resolver validates the shred and copies it
@@ -195,25 +200,29 @@ fd_fec_resolver_set_shred_version( fd_fec_resolver_t * resolver,
    last one and completes the FEC set.  In this case, the function
    populates any missing shreds in the FEC set stored in out_fec_set.
 
-   Along with the return err code, if adding this shred caused an
-   incomplete FEC set to be evicted from the current map, the slot and
-   FEC set idx of the evicted FEC set will be written to spilled_slot
-   and spilled_fec_set_idx.  The max data shred idx received thus far
-   of the evicted FEC set will be written to max_shred_idx.  If no FEC
-   set was evicted, spilled_slot and max_shred_idx will be 0, and
-   spilled_fec_set_idx will be FD_SHRED_BLK_MAX. */
+   Regardless of success/failure, if an incomplete FEC set was evicted
+   from the current map during this add_shred call, the metadata of the
+   evicted FEC set will be written to out_spilled_fec_set.  The FEC set
+   metadata includes slot, fec_set_idx, and also highest data shred
+   index received thus far in this FEC set, in the range
+   [0, FD_REEDSOL_DATA_SHREDS_MAX).  If no data shreds have been
+   received yet (i.e., only parity shreds have been received),
+   max_dshred_idx will be FD_SHRED_BLK_MAX.  If no FEC set was evicted,
+   out_spilled_fec_set will remain unmodified.  Similar to
+   out_merkle_root, the caller owns and provides the memory for
+   out_spilled_fec_set.  If the out_spilled_fec_set pointer is NULL, the
+   argument will be ignored and the evicted FEC set metadata will not be
+   written. */
 
 int
-fd_fec_resolver_add_shred( fd_fec_resolver_t    * resolver,
-                           fd_shred_t const     * shred,
-                           ulong                  shred_sz,
-                           uchar const          * leader_pubkey,
-                           fd_fec_set_t const * * out_fec_set,
-                           fd_shred_t const   * * out_shred,
-                           fd_bmtree_node_t     * out_merkle_root,
-                           ulong                * out_spilled_slot,
-                           uint                 * out_spilled_fec_set_idx,
-                           uint                 * out_max_dshred_idx );
+fd_fec_resolver_add_shred( fd_fec_resolver_t         * resolver,
+                           fd_shred_t const          * shred,
+                           ulong                       shred_sz,
+                           uchar const               * leader_pubkey,
+                           fd_fec_set_t const      * * out_fec_set,
+                           fd_shred_t const        * * out_shred,
+                           fd_bmtree_node_t          * out_merkle_root,
+                           fd_fec_resolver_spilled_t * out_spilled_fec_set );
 
 
 /* fd_fec_resolver_done_contains returns 1 if the FEC with signature

--- a/src/disco/shred/fd_shred_tile.c
+++ b/src/disco/shred/fd_shred_tile.c
@@ -873,12 +873,10 @@ after_frag( fd_shred_ctx_t *    ctx,
 
     fd_fec_set_t const * out_fec_set[1];
     fd_shred_t const   * out_shred[1];
-    ulong spilled_slot           = ULONG_MAX;
-    uint  spilled_fec_set_idx    = FD_SHRED_BLK_MAX;
-    uint  spilled_max_dshred_idx = FD_SHRED_BLK_MAX;
+    fd_fec_resolver_spilled_t spilled_fec = { 0 };
 
     long add_shred_timing  = -fd_tickcount();
-    int rv = fd_fec_resolver_add_shred( ctx->resolver, shred, shred_buffer_sz, slot_leader->uc, out_fec_set, out_shred, &out_merkle_root, &spilled_slot, &spilled_fec_set_idx, &spilled_max_dshred_idx );
+    int rv = fd_fec_resolver_add_shred( ctx->resolver, shred, shred_buffer_sz, slot_leader->uc, out_fec_set, out_shred, &out_merkle_root, &spilled_fec );
     add_shred_timing      +=  fd_tickcount();
 
     fd_histf_sample( ctx->metrics->add_shred_timing, (ulong)add_shred_timing );
@@ -917,13 +915,12 @@ after_frag( fd_shred_ctx_t *    ctx,
       }
     }
 
-    if( FD_UNLIKELY( spilled_slot < ULONG_MAX && spilled_fec_set_idx < FD_SHRED_BLK_MAX && spilled_max_dshred_idx < FD_SHRED_BLK_MAX ) ) {
-      /* We've spilled an in-progress FEC set in the fec_resolver. We need to let
-         repair know to clear out it's cached info for that fec set and
-         re-repair those shreds. */
-      ulong sig_ = fd_disco_shred_repair_shred_sig( 0, spilled_slot, spilled_fec_set_idx, 0, spilled_max_dshred_idx );
+    if( FD_UNLIKELY( spilled_fec.slot!=0 && spilled_fec.max_dshred_idx!=FD_SHRED_BLK_MAX ) ) {
+      /* We've spilled an in-progress FEC set in the fec_resolver. We
+         need to let repair know to clear out it's cached info for that
+         fec set and re-repair those shreds. */
+      ulong sig_ = fd_disco_shred_repair_shred_sig( 0, spilled_fec.slot, spilled_fec.fec_set_idx, 0, spilled_fec.max_dshred_idx );
       fd_stem_publish( stem, ctx->repair_out_idx, sig_, ctx->repair_out_chunk, 0, 0, ctx->tsorig, ctx->tsorig );
-      ctx->repair_out_chunk = fd_dcache_compact_next( ctx->repair_out_chunk, 0, ctx->repair_out_chunk0, ctx->repair_out_wmark );
     }
 
     if( (rv==FD_FEC_RESOLVER_SHRED_OKAY) | (rv==FD_FEC_RESOLVER_SHRED_COMPLETES) ) {
@@ -1071,7 +1068,16 @@ after_frag( fd_shred_ctx_t *    ctx,
          we don't know whether shred will finish inserting into store
          first or repair will finish validating the FEC set first. The
          header and merkle root of the last shred in the FEC set are
-         sent as part of this frag. */
+         sent as part of this frag.
+
+         This message, the shred msg, and the FEC evict msg constitute
+         the max 3 possible messages to repair per after_frag.  In
+         reality, it is only possible to publish all 3 in the case where
+         we receive a coding shred first for a FEC set where (N=1,K=18),
+         which allows for the FEC set to be instantly completed by the
+         singular coding shred, and that also happens to evict a FEC set
+         from the curr_map. When fix-32 arrives, the link burst value
+         can be lowered to 2. */
 
       ulong   sig   = fd_disco_shred_repair_fec_sig( last->slot, last->fec_set_idx, (uint)set->data_shred_cnt, last->data.flags & FD_SHRED_DATA_FLAG_SLOT_COMPLETE, last->data.flags & FD_SHRED_DATA_FLAG_DATA_COMPLETE );
       uchar * chunk = fd_chunk_to_laddr( ctx->repair_out_mem, ctx->repair_out_chunk );

--- a/src/discof/forest/fd_forest.c
+++ b/src/discof/forest/fd_forest.c
@@ -389,7 +389,7 @@ advance_consumed_frontier( fd_forest_t * forest, ulong slot, ulong parent_slot )
 # endif
 
   /* BFS elements as pool idxs.
-     Invariant: whatever is in the queue, must be on the frontier. */
+     Invariant: whatever is in the queue, must be in the consumed map. */
   fd_forest_deque_push_tail( queue, ele->forest_pool_idx );
   while( FD_LIKELY( fd_forest_deque_cnt( queue ) ) ) {
     fd_forest_blk_t * head  = fd_forest_pool_ele( pool, fd_forest_deque_pop_head( queue ) );
@@ -451,6 +451,30 @@ fd_forest_query( fd_forest_t * forest, ulong slot ) {
   return query( forest, slot );
 }
 
+static void
+ensure_consumed_reachable( fd_forest_t * forest, fd_forest_blk_t * ele ) {
+  fd_forest_blk_t *      pool     = fd_forest_pool( forest );
+  fd_forest_ancestry_t * ancestry = fd_forest_ancestry( forest );
+  fd_forest_frontier_t * frontier = fd_forest_frontier( forest );
+  fd_forest_consumed_t * consumed = fd_forest_consumed( forest );
+  fd_forest_cns_t *      conspool = fd_forest_conspool( forest );
+
+  if( FD_LIKELY( fd_forest_ancestry_ele_query( ancestry, &ele->slot, NULL, pool ) ||
+                 fd_forest_frontier_ele_query( frontier, &ele->slot, NULL, pool ) ) ) {
+    /* There is a chance that we connected this ele to the main tree.
+       If this ele doesn't have a parent in the consumed map, add it
+       to the consumed map. */
+    fd_forest_blk_t * ancestor = ele;
+    while( FD_UNLIKELY( ancestor && !fd_forest_consumed_ele_query( consumed, &ancestor->slot, NULL, conspool ) ) ) {
+      ancestor = fd_forest_pool_ele( pool, ancestor->parent );
+    }
+    if( FD_UNLIKELY( !ancestor ) ) {
+      FD_LOG_NOTICE(( "fd_forest: ensure_consumed_reachable: ele %lu is not reachable from consumed frontier, adding myself", ele->slot ));
+      consumed_map_insert( forest, ele->slot, fd_forest_pool_idx( pool, ele ) );
+    }
+  }
+}
+
 fd_forest_blk_t *
 fd_forest_blk_insert( fd_forest_t * forest, ulong slot, ulong parent_slot ) {
 # if FD_FOREST_USE_HANDHOLDING
@@ -463,8 +487,6 @@ fd_forest_blk_insert( fd_forest_t * forest, ulong slot, ulong parent_slot ) {
   fd_forest_frontier_t * frontier = fd_forest_frontier( forest );
   fd_forest_subtrees_t * subtrees = fd_forest_subtrees( forest );
   fd_forest_orphaned_t * orphaned = fd_forest_orphaned( forest );
-  fd_forest_consumed_t * consumed = fd_forest_consumed( forest );
-  fd_forest_cns_t *      conspool = fd_forest_conspool( forest );
   fd_forest_blk_t *      pool     = fd_forest_pool ( forest );
   ulong *                bfs      = fd_forest_deque( forest );
 
@@ -531,20 +553,7 @@ fd_forest_blk_insert( fd_forest_t * forest, ulong slot, ulong parent_slot ) {
   }
 
   FD_TEST( fd_forest_deque_empty( bfs ) );
-
-  if( FD_LIKELY( fd_forest_ancestry_ele_query( ancestry, &ele->slot, NULL, pool ) ||
-                 fd_forest_frontier_ele_query( frontier, &ele->slot, NULL, pool ) ) ) {
-    /* There is a chance that we connected this ele to the main tree.
-       If this ele doesn't have a parent in the consumed map, add it
-       to the consumed map. */
-    fd_forest_blk_t * ancestor = ele;
-    while( FD_UNLIKELY( ancestor && !fd_forest_consumed_ele_query( consumed, &ancestor->slot, NULL, conspool ) ) ) {
-      ancestor = fd_forest_pool_ele( pool, ancestor->parent );
-    }
-    if( FD_UNLIKELY( !ancestor ) ) {
-      consumed_map_insert( forest, ele->slot, fd_forest_pool_idx( pool, ele ) );
-    }
-  }
+  ensure_consumed_reachable( forest, ele );
   return ele;
 }
 
@@ -559,6 +568,51 @@ fd_forest_data_shred_insert( fd_forest_t * forest, ulong slot, ulong parent_slot
   while( fd_forest_blk_idxs_test( ele->idxs, ele->buffered_idx + 1U ) ) ele->buffered_idx++;
   advance_consumed_frontier( forest, slot, parent_slot );
   return ele;
+}
+
+void
+fd_forest_fec_clear( fd_forest_t * forest, ulong slot, uint fec_set_idx, uint max_shred_idx ) {
+  VER_INC;
+
+  if( FD_UNLIKELY( slot <= fd_forest_root_slot( forest ) ) ) {
+    FD_LOG_NOTICE(( "fd_forest: fd_forest_fec_clear: slot %lu is <= root slot %lu, ignoring", slot, fd_forest_root_slot( forest ) ));
+    return;
+  }
+
+  fd_forest_blk_t * ele = query( forest, slot );
+  if( FD_UNLIKELY( !ele ) ) return;
+  for( uint i=fec_set_idx; i<=fec_set_idx+max_shred_idx; i++ ) {
+    fd_forest_blk_idxs_remove( ele->idxs, i );
+  }
+  if( FD_UNLIKELY( fec_set_idx == 0 ) ) ele->buffered_idx = UINT_MAX;
+  else                                  ele->buffered_idx = fd_uint_if( ele->buffered_idx != UINT_MAX, fd_uint_min( ele->buffered_idx, fec_set_idx - 1 ), UINT_MAX );
+
+  ensure_consumed_reachable( forest, ele );
+
+  /* Remove any children of this ele that are in consumed */
+
+  fd_forest_consumed_t * consumed = fd_forest_consumed( forest );
+  fd_forest_cns_t *      conspool = fd_forest_conspool( forest );
+  fd_forest_blk_t *      pool     = fd_forest_pool( forest );
+  ulong *                queue    = fd_forest_deque( forest );
+  FD_TEST( fd_forest_deque_cnt( queue ) == 0 );
+
+  fd_forest_deque_push_tail( queue, fd_forest_pool_idx( pool, ele ) );
+  while( FD_LIKELY( fd_forest_deque_cnt( queue ) ) ) {
+    fd_forest_blk_t * head = fd_forest_pool_ele( pool, fd_forest_deque_pop_head( queue ) );
+    if( FD_LIKELY( head!=ele ) ) {
+      fd_forest_cns_t * consumed_ele = fd_forest_consumed_ele_remove( consumed, &head->slot, NULL, conspool );
+      if( FD_UNLIKELY( consumed_ele ) ) {
+        fd_forest_conspool_ele_release( conspool, consumed_ele );
+        FD_LOG_NOTICE(( "fd_forest: fd_forest_fec_clear: removed %lu from consumed frontier", head->slot ));
+      }
+    }
+    fd_forest_blk_t * child = fd_forest_pool_ele( pool, head->child );
+    while( FD_LIKELY( child ) ) {
+      fd_forest_deque_push_tail( queue, fd_forest_pool_idx( pool, child ) );
+      child = fd_forest_pool_ele( pool, child->sibling );
+    }
+  }
 }
 
 fd_forest_blk_t const *

--- a/src/discof/forest/fd_forest.h
+++ b/src/discof/forest/fd_forest.h
@@ -391,6 +391,12 @@ fd_forest_blk_insert( fd_forest_t * forest, ulong slot, ulong parent_slot );
 fd_forest_blk_t *
 fd_forest_data_shred_insert( fd_forest_t * forest, ulong slot, ulong parent_slot, uint shred_idx, uint fec_set_idx, int slot_complete );
 
+/* fd_forest_fec_clear clears the FEC set at the given slot and
+   fec_set_idx. */
+
+void
+fd_forest_fec_clear( fd_forest_t * forest, ulong slot, uint fec_set_idx, uint max_shred_idx );
+
 /* fd_forest_publish publishes slot as the new forest root, setting
    the subtree beginning from slot as the new forest tree (ie. slot
    and all its descendants).  Prunes all eles not in slot's forest.

--- a/src/discof/repair/fd_repair_tile.c
+++ b/src/discof/repair/fd_repair_tile.c
@@ -856,7 +856,6 @@ after_frag( fd_repair_tile_ctx_t * ctx,
     fd_fec_sig_t * fec_sig = fd_fec_sig_query( ctx->fec_sigs, (shred->slot << 32) | shred->fec_set_idx, NULL );
     if( FD_UNLIKELY( !fec_sig && !fec_completes ) ) {
       fec_sig = fd_fec_sig_insert( ctx->fec_sigs, (shred->slot << 32) | shred->fec_set_idx );
-      FD_TEST( fec_sig );
       memcpy( fec_sig->sig, shred->signature, sizeof(fd_ed25519_sig_t) );
     }
 
@@ -867,9 +866,7 @@ after_frag( fd_repair_tile_ctx_t * ctx,
 
     if( FD_UNLIKELY( fec_completes ) ) {
       fd_forest_blk_t * ele = fd_forest_blk_insert( ctx->forest, shred->slot, shred->slot - shred->data.parent_off );
-      for( uint idx = shred->fec_set_idx; idx <= shred->idx; idx++ ) {
-        ele = fd_forest_data_shred_insert( ctx->forest, shred->slot, shred->slot - shred->data.parent_off, idx, shred->fec_set_idx, 0 );
-      }
+      fd_forest_fec_insert( ctx->forest, shred->slot, shred->slot - shred->data.parent_off, shred->idx, shred->fec_set_idx, 0 );
       FD_TEST( ele ); /* must be non-empty */
 
       fd_hash_t const * merkle_root         = (fd_hash_t const *)fd_type_pun_const( ctx->buffer + FD_SHRED_DATA_HEADER_SZ );

--- a/src/discof/repair/fd_repair_tile.c
+++ b/src/discof/repair/fd_repair_tile.c
@@ -593,11 +593,9 @@ handle_contact_info_update( fd_repair_tile_ctx_t *             ctx,
        this, we proactively send a placeholder Repair request as soon as we
        receive a peer's contact information for the first time, effectively
        prepaying the RTT cost. */
-      if( FD_LIKELY( ctx->repair_sign_cnt>0 ) ) {
-        fd_repair_send_request( ctx, ctx->stem, ctx->repair, fd_needed_window_index, 0, 0, &contact_info->pubkey, fd_log_wallclock() );
-      }
-    ulong hash_src = 0xfffffUL & fd_ulong_hash( (ulong)repair_peer.addr | ((ulong)repair_peer.port<<32) );
-    FD_LOG_INFO(( "Added repair peer: pubkey %s hash_src %lu", FD_BASE58_ENC_32_ALLOCA( msg->origin_pubkey ), hash_src ));
+    if( FD_LIKELY( ctx->repair_sign_cnt>0 ) ) {
+      fd_repair_send_request( ctx, ctx->stem, ctx->repair, fd_needed_window_index, 0, 0, &contact_info->pubkey, fd_log_wallclock() );
+    }
   }
 }
 
@@ -673,7 +671,7 @@ during_frag( fd_repair_tile_ctx_t * ctx,
     FD_LOG_ERR(( "Frag from unknown link (kind=%u in_idx=%lu)", in_kind, in_idx ));
   }
 
-  fd_memcpy( ctx->buffer, dcache_entry, dcache_entry_sz );
+  if( FD_LIKELY( dcache_entry_sz > 0 ) ) fd_memcpy( ctx->buffer, dcache_entry, dcache_entry_sz );
 }
 
 static inline void
@@ -823,6 +821,17 @@ after_frag( fd_repair_tile_ctx_t * ctx,
   }
 
   if( FD_UNLIKELY( in_kind==IN_KIND_SHRED ) ) {
+    int resolver_evicted = sz == 0;
+    int fec_completes    = sz == FD_SHRED_DATA_HEADER_SZ + sizeof(fd_hash_t) + sizeof(fd_hash_t);
+    if( FD_UNLIKELY( resolver_evicted ) ) {
+      ulong spilled_slot        = fd_disco_shred_repair_shred_sig_slot       ( sig );
+      uint  spilled_fec_set_idx = fd_disco_shred_repair_shred_sig_fec_set_idx( sig );
+      uint  spilled_max_idx     = fd_disco_shred_repair_shred_sig_data_cnt   ( sig );
+
+      fd_forest_fec_clear( ctx->forest, spilled_slot, spilled_fec_set_idx, spilled_max_idx );
+      return;
+    }
+
     fd_shred_t * shred = (fd_shred_t *)fd_type_pun( ctx->buffer );
     if( FD_UNLIKELY( shred->slot <= fd_forest_root_slot( ctx->forest ) ) ) {
       FD_LOG_WARNING(( "shred %lu %u %u too old, ignoring", shred->slot, shred->idx, shred->fec_set_idx ));
@@ -844,11 +853,10 @@ after_frag( fd_repair_tile_ctx_t * ctx,
     /* Insert the shred sig (shared by all shred members in the FEC set)
        into the map. */
 
-    int fec_completes = sz == FD_SHRED_DATA_HEADER_SZ + sizeof(fd_hash_t) + sizeof(fd_hash_t);
-
     fd_fec_sig_t * fec_sig = fd_fec_sig_query( ctx->fec_sigs, (shred->slot << 32) | shred->fec_set_idx, NULL );
     if( FD_UNLIKELY( !fec_sig && !fec_completes ) ) {
       fec_sig = fd_fec_sig_insert( ctx->fec_sigs, (shred->slot << 32) | shred->fec_set_idx );
+      FD_TEST( fec_sig );
       memcpy( fec_sig->sig, shred->signature, sizeof(fd_ed25519_sig_t) );
     }
 
@@ -1085,7 +1093,7 @@ during_housekeeping( fd_repair_tile_ctx_t * ctx ) {
 
 # if DEBUG_LOGGING
   long now = fd_log_wallclock();
-  if( FD_UNLIKELY( now - ctx->tsprint > (long)30e9 ) ) {
+  if( FD_UNLIKELY( now - ctx->tsprint > (long)10e9 ) ) {
     fd_forest_print( ctx->forest );
     fd_reasm_print( ctx->reasm );
     ctx->tsprint = fd_log_wallclock();

--- a/src/flamenco/repair/fd_repair.c
+++ b/src/flamenco/repair/fd_repair.c
@@ -364,13 +364,11 @@ fd_repair_create_inflight_request( fd_repair_t * glob, int type, ulong slot, uin
   fd_inflight_elem_t * dupelem = fd_inflight_table_query( glob->dupdetect, &dupkey, NULL );
 
   if( dupelem == NULL ) {
-    dupelem = fd_inflight_table_insert( glob->dupdetect, &dupkey );
-
-    if ( FD_UNLIKELY( dupelem == NULL ) ) {
-      FD_LOG_ERR(( "Eviction unimplemented. Failed to insert duplicate detection element for slot %lu, shred_index %u", slot, shred_index ));
+    if( FD_UNLIKELY( fd_inflight_table_is_full( glob->dupdetect ) ) ) {
+      FD_LOG_WARNING(( "Failed to insert duplicate detection element for slot %lu, shred_index %u. Eviction unimplemented.", slot, shred_index ));
       return 0;
     }
-
+    dupelem = fd_inflight_table_insert( glob->dupdetect, &dupkey );
     dupelem->last_send_time = 0L;
   }
 

--- a/src/flamenco/repair/fd_repair.c
+++ b/src/flamenco/repair/fd_repair.c
@@ -275,7 +275,6 @@ fd_repair_start( fd_repair_t * glob ) {
   return fd_read_in_good_peer_cache_file( glob );
 }
 
-static void fd_repair_print_all_stats( fd_repair_t * glob );
 static int fd_write_good_peer_cache_file( fd_repair_t * repair );
 
 /* Dispatch timed events and other protocol behavior. This should be
@@ -283,7 +282,6 @@ static int fd_write_good_peer_cache_file( fd_repair_t * repair );
 int
 fd_repair_continue( fd_repair_t * glob ) {
   if ( glob->now - glob->last_print > (long)30e9 ) { /* 30 seconds */
-    fd_repair_print_all_stats( glob );
     glob->last_print = glob->now;
     fd_repair_decay_stats( glob );
     glob->last_decay = glob->now;
@@ -470,34 +468,6 @@ int
 fd_repair_need_orphan( fd_repair_t * glob, ulong slot ) {
   // FD_LOG_NOTICE( ( "[repair] need orphan %lu", slot ) );
   return fd_repair_create_inflight_request( glob, fd_needed_orphan, slot, UINT_MAX, glob->now );
-}
-
-static void
-print_stats( fd_active_elem_t * val ) {
-  fd_pubkey_t const * id = &val->key;
-  if( FD_UNLIKELY( NULL == val ) ) return;
-  if( val->avg_reqs == 0 )
-    FD_LOG_INFO(( "repair peer %s: no requests sent, stake=%lu", FD_BASE58_ENC_32_ALLOCA( id ), val->stake / (ulong)1e9 ));
-  else if( val->avg_reps == 0 )
-    FD_LOG_INFO(( "repair peer %s: avg_requests=%lu, no responses received, stake=%lu", FD_BASE58_ENC_32_ALLOCA( id ), val->avg_reqs, val->stake / (ulong)1e9 ));
-  else
-    FD_LOG_INFO(( "repair peer %s: avg_requests=%lu, response_rate=%f, latency=%f, stake=%lu",
-                    FD_BASE58_ENC_32_ALLOCA( id ),
-                    val->avg_reqs,
-                    ((double)val->avg_reps)/((double)val->avg_reqs),
-                    1.0e-9*((double)val->avg_lat)/((double)val->avg_reps),
-                    val->stake / (ulong)1e9 ));
-}
-
-static void
-fd_repair_print_all_stats( fd_repair_t * glob ) {
-  for( fd_active_table_iter_t iter = fd_active_table_iter_init( glob->actives );
-       !fd_active_table_iter_done( glob->actives, iter );
-       iter = fd_active_table_iter_next( glob->actives, iter ) ) {
-    fd_active_elem_t * val = fd_active_table_iter_ele( glob->actives, iter );
-    print_stats( val );
-  }
-  FD_LOG_INFO( ( "peer count: %lu", fd_active_table_key_cnt( glob->actives ) ) );
 }
 
 void fd_repair_add_sticky( fd_repair_t * glob, fd_pubkey_t const * id ) {

--- a/src/util/tmpl/fd_map_giant.c
+++ b/src/util/tmpl/fd_map_giant.c
@@ -99,7 +99,7 @@
 
     // mymap_insert inserts the key pointed to by key into the map.
     // Returns the location in the caller's address space of the element
-    // for key in the map or NULL if there was no space in the map.
+    // for key in the map.
     //
     // Assumes map is a current local join, key points to a valid key in
     // the caller's address space, there are no concurrent operations on

--- a/src/util/tmpl/fd_set.c
+++ b/src/util/tmpl/fd_set.c
@@ -62,6 +62,10 @@
 
      ulong my_set_first( my_set_t const * set ); // Return in [0,max) on success, >=max if empty set
 
+     // Return the highest indexed element in the set
+
+     ulong my_set_last( my_set_t const * set );  // Return in [0,max) on success, >=max if empty set
+
      // Two pair of functions for writing efficient iterators over all
      // members of sparse sets.  The first pair is a destructive
      // iterator:
@@ -272,6 +276,16 @@ SET_(first)( SET_(t) const * set ) {
   for( ulong i=0UL; i<word_cnt; i++ ) {
     ulong w = set[i];
     if( w ) return (i<<6) + (ulong)fd_ulong_find_lsb( w );
+  }
+  return ~0UL;
+}
+
+FD_FN_PURE static inline ulong
+SET_(last)( SET_(t) const * set ) {
+  ulong word_cnt = (ulong)SET_(word_cnt);
+  for( ulong i=word_cnt; i>0UL; i-- ) {
+    ulong w = set[i-1];
+    if( w ) return ((i-1)<<6) + (ulong)fd_ulong_find_msb( w );
   }
   return ~0UL;
 }

--- a/src/util/tmpl/test_set.c
+++ b/src/util/tmpl/test_set.c
@@ -75,6 +75,11 @@ main( int     argc,
     FD_TEST( set_first( ebar )==(idx ? 0UL : 1UL) );
     FD_TEST( set_first( full )==0UL               );
 
+    FD_TEST( set_last( null )>=max                    );
+    FD_TEST( set_last( e    )==idx                    );
+    FD_TEST( set_last( ebar )==max-1UL-(idx==max-1UL) );
+    FD_TEST( set_last( full )==max-1UL                );
+
     FD_TEST( set_copy( t, null )==t && set_eq( set_insert( t, idx ), e    ) );
     FD_TEST( set_copy( t, e    )==t && set_eq( set_insert( t, idx ), e    ) );
     FD_TEST( set_copy( t, ebar )==t && set_eq( set_insert( t, idx ), full ) );


### PR DESCRIPTION
so many bugs discovered 🐛 🐛  🐛  
 🐛  `force_complete` didn't remove from curr_map , but it would release the memory back to freelist, so we could see things in the curr_map that were weird af
 🐛  no pool_release in consumed_map in forest (in both publish and in advance_consumed 💀 )
 🐛  repair.c inflight table insert doesn't return NULL on no space, and would eventually overwrite the map_private_t fields
 🐛  store lock not released in replay
 
burst value: burst for the tile is already large enough due to the max burst publishing to store in frankendancer path; link burst remains <= 2 bc if an eviction happens that means there is no fec complete msg
