### PR TITLE
send: fix network ordering

### DIFF
--- a/src/app/firedancer-dev/commands/send_test/send_test.c
+++ b/src/app/firedancer-dev/commands/send_test/send_test.c
@@ -1,7 +1,7 @@
 /*
 send_test is a firedancer-dev command that tests the send tile.
 It uses the net, send, metrics, and sign tiles, just like in prod.
-The main test function writes contact info to the gossip_send link,
+The main test function writes contact info to the gossip_out link,
 stake info to the stake_out link, and triggers mock votes on the
 tower_send link.
 
@@ -53,10 +53,10 @@ send_test_topo( config_t * config ) {
   fd_topob_wksp( topo, "send_sign" );
 
   /* wksps for mock links */
-  fd_topob_wksp( topo, "gossip_send" );
-  fd_topob_wksp( topo, "stake_out"   );
-  fd_topob_wksp( topo, "tower_send"  );
-  fd_topob_wksp( topo, "send_txns"   );
+  fd_topob_wksp( topo, "gossip_out" );
+  fd_topob_wksp( topo, "stake_out"  );
+  fd_topob_wksp( topo, "tower_send" );
+  fd_topob_wksp( topo, "send_txns"  );
 
   ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
   ushort parsed_tile_to_cpu[ FD_TILE_MAX ];
@@ -93,7 +93,7 @@ send_test_topo( config_t * config ) {
   /**/              fd_topob_link( topo, "sign_send", "sign_send", 128UL,          64UL,       1UL  );
 
   /* mock links */
-  fd_topob_link( topo, "gossip_send", "gossip_send", 128UL,   40200UL * 38UL,     1UL  )
+  fd_topob_link( topo, "gossip_out", "gossip_out", 65536UL*4UL, sizeof(fd_gossip_update_message_t), 1UL )
                  ->permit_no_producers = 1;
   fd_topob_link( topo, "stake_out",   "stake_out",   128UL,   FD_STAKE_OUT_MTU,   1UL  )
                  ->permit_no_producers = 1;
@@ -103,7 +103,7 @@ send_test_topo( config_t * config ) {
                  ->permit_no_consumers = 1;
 
   /* attach mock links */
-  fd_topob_tile_in( topo, "send", 0UL, "metric_in", "gossip_send", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
+  fd_topob_tile_in( topo, "send", 0UL, "metric_in", "gossip_out", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
   fd_topob_tile_in( topo, "send", 0UL, "metric_in", "stake_out",   0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
   fd_topob_tile_in( topo, "send", 0UL, "metric_in", "tower_send",  0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
 
@@ -189,7 +189,7 @@ init( send_test_ctx_t * ctx, config_t * config ) {
   ctx->identity_key  [ 0 ] = *(fd_pubkey_t const *)(fd_keyload_load( config->paths.identity_key, /* pubkey only: */ 1 ) );
   ctx->vote_acct_addr[ 0 ] = *(fd_pubkey_t const *)(fd_keyload_load( config->paths.vote_account, /* pubkey only: */ 1 ) );
 
-  ctx->out_links[    MOCK_CI_IDX   ] = setup_test_out_link( topo, "gossip_send" );
+  ctx->out_links[    MOCK_CI_IDX   ] = setup_test_out_link( topo, "gossip_out" );
   ctx->out_links[  MOCK_STAKE_IDX  ] = setup_test_out_link( topo, "stake_out" );
   ctx->out_links[ MOCK_TRIGGER_IDX ] = setup_test_out_link( topo, "tower_send" );
 

--- a/src/discof/send/fd_send_tile.h
+++ b/src/discof/send/fd_send_tile.h
@@ -14,7 +14,6 @@
 #include "../../disco/net/fd_net_tile.h"
 #include "../../disco/keyguard/fd_keyguard_client.h"
 #include "../../flamenco/leaders/fd_multi_epoch_leaders.h"
-#include "../../flamenco/gossip/fd_gossip.h"
 #include "../../waltz/quic/fd_quic.h"
 
 #define IN_KIND_SIGN   (0UL)
@@ -56,8 +55,8 @@ struct fd_send_conn_entry {
   uint             hash;
   fd_quic_conn_t * conn;
   long             last_ci_ticks;
-  uint             ip4_addr;
-  ushort           udp_port;
+  uint             ip4_addr;  /* net order */
+  ushort           udp_port;  /* host order */
   int              got_ci_msg;
 };
 typedef struct fd_send_conn_entry fd_send_conn_entry_t;

--- a/src/util/net/fd_ip4.c
+++ b/src/util/net/fd_ip4.c
@@ -13,7 +13,6 @@ __fd_cstr_to_uchar( char const * cstr ) {
   return (int)value;
 }
 
-
 int
 fd_cstr_to_ip4_addr( char const * s,
                      uint *       out ) {

--- a/src/waltz/quic/fd_quic.h
+++ b/src/waltz/quic/fd_quic.h
@@ -547,8 +547,8 @@ fd_quic_fini( fd_quic_t * quic );
    until conn_final callback.
 
    args
-     dst_ip_addr   destination ip address
-     dst_udp_port  destination port number */
+     dst_ip_addr   destination ip address, in net order
+     dst_udp_port  destination port number, in host order */
 
 FD_QUIC_API fd_quic_conn_t *
 fd_quic_connect( fd_quic_t *  quic,  /* requires exclusive access */

--- a/src/waltz/quic/fd_quic_conn_id.h
+++ b/src/waltz/quic/fd_quic_conn_id.h
@@ -78,11 +78,11 @@ FD_PROTOTYPES_END
   (memcmp(&(LHS),&(RHS),sizeof(fd_quic_conn_id_t))==0)
 
 /* fd_quic_net_endpoint_t identifies a UDP/IP network endpoint.
-   Stored in host endian.  May change during the lifetime of the conn. */
+    May change during the lifetime of the conn. */
 
 struct fd_quic_net_endpoint {
-  uint   ip_addr;
-  ushort udp_port;
+  uint   ip_addr;  /* net */
+  ushort udp_port; /* host */
 };
 typedef struct fd_quic_net_endpoint fd_quic_net_endpoint_t;
 


### PR DESCRIPTION
This PR fixes host/network order confusion in send, send_test, and corrects some comments in fd_quic. 

It also fixes send_test breaks due to gossip changes. 