### PR TITLE
quic: simplify time handling

### DIFF
--- a/src/app/shared_dev/commands/bench/fd_benchs.c
+++ b/src/app/shared_dev/commands/bench/fd_benchs.c
@@ -30,15 +30,6 @@ quic_tx_aio_send( void *                    _ctx,
                   ulong *                   opt_batch_idx,
                   int                       flush );
 
-/* quic_now is called by the QUIC engine to get the current timestamp in
-   UNIX time.  */
-
-static ulong
-quic_now( void * ctx ) {
-  (void)ctx;
-  return (ulong)fd_log_wallclock();
-}
-
 typedef struct {
   ulong round_robin_cnt;
   ulong round_robin_id;
@@ -58,7 +49,11 @@ typedef struct {
   uint             service_ratio_idx;
   fd_aio_t         tx_aio;
 
-  // vector receive members
+  long         now;        /* current time in ns    */
+  fd_clock_t   clock[1];   /* memory for fd_clock_t */
+  long         recal_next; /* next recalibration time (ns) */
+
+  /* vector receive members */
   struct mmsghdr rx_msgs[IO_VEC_CNT];
   struct mmsghdr tx_msgs[IO_VEC_CNT];
   struct iovec   rx_iovecs[IO_VEC_CNT];
@@ -69,10 +64,13 @@ typedef struct {
   ulong tx_idx;
 
   fd_wksp_t * mem;
+
+  uchar __attribute__((aligned(FD_CLOCK_ALIGN))) clock_mem[ FD_CLOCK_FOOTPRINT ];
 } fd_benchs_ctx_t;
 
 static void
-service_quic( fd_benchs_ctx_t * ctx ) {
+service_quic( fd_benchs_ctx_t * ctx,
+              long              now ) {
 
   if( !ctx->no_quic ) {
     /* Publishes to mcache via callbacks */
@@ -119,7 +117,7 @@ service_quic( fd_benchs_ctx_t * ctx ) {
           buf[2] = (uchar)( ip_len >> 8 );
           buf[3] = (uchar)( ip_len      );
 
-          fd_quic_process_packet( ctx->quic, buf, ip_len );
+          fd_quic_process_packet( ctx->quic, buf, ip_len, now );
         }
       } else if( FD_UNLIKELY( revents & POLLERR ) ) {
         int error = 0;
@@ -210,6 +208,8 @@ before_frag( fd_benchs_ctx_t * ctx,
   (void)in_idx;
   (void)sig;
 
+  ctx->now = fd_clock_now( ctx->clock );
+
   return (int)( (seq%ctx->round_robin_cnt)!=ctx->round_robin_id );
 }
 
@@ -232,8 +232,8 @@ during_frag( fd_benchs_ctx_t * ctx,
     /* make this configurable */
     if( FD_UNLIKELY( ctx->service_ratio_idx++ == 8 ) ) {
       ctx->service_ratio_idx = 0;
-      service_quic( ctx );
-      fd_quic_service( ctx->quic );
+      service_quic( ctx, ctx->now );
+      fd_quic_service( ctx->quic, ctx->now );
     }
 
     if( FD_UNLIKELY( !ctx->quic_conn ) ) {
@@ -243,12 +243,12 @@ during_frag( fd_benchs_ctx_t * ctx,
       uint   dest_ip   = 0;
       ushort dest_port = fd_ushort_bswap( ctx->quic_port );
 
-      ctx->quic_conn = fd_quic_connect( ctx->quic, dest_ip, dest_port, 0U, 12000 );
+      ctx->quic_conn = fd_quic_connect( ctx->quic, dest_ip, dest_port, 0U, 12000, ctx->now );
 
       /* failed? try later */
       if( FD_UNLIKELY( !ctx->quic_conn ) ) {
-        service_quic( ctx );
-        fd_quic_service( ctx->quic );
+        service_quic( ctx, ctx->now );
+        fd_quic_service( ctx->quic, ctx->now );
         return;
       }
 
@@ -260,8 +260,8 @@ during_frag( fd_benchs_ctx_t * ctx,
          a connection dies */
       fd_quic_conn_set_context( ctx->quic_conn, ctx );
 
-      service_quic( ctx );
-      fd_quic_service( ctx->quic );
+      service_quic( ctx, ctx->now );
+      fd_quic_service( ctx->quic, ctx->now );
 
       /* conn and streams may be invalidated by fd_quic_service */
 
@@ -271,8 +271,8 @@ during_frag( fd_benchs_ctx_t * ctx,
     fd_quic_stream_t * stream = fd_quic_conn_new_stream( ctx->quic_conn );
     if( FD_UNLIKELY( !stream ) ) {
       ctx->no_stream++;
-      service_quic( ctx );
-      fd_quic_service( ctx->quic );
+      service_quic( ctx, ctx->now );
+      fd_quic_service( ctx->quic, ctx->now );
 
       /* conn and streams may be invalidated by fd_quic_service */
 
@@ -400,15 +400,13 @@ unprivileged_init( fd_topo_t *      topo,
 
     ulong quic_idle_timeout_millis = 10000;  /* idle timeout in milliseconds */
     quic->config.role                       = FD_QUIC_ROLE_CLIENT;
-    quic->config.idle_timeout               = quic_idle_timeout_millis * 1000000UL;
+    quic->config.idle_timeout               = (long)( quic_idle_timeout_millis * 1000000L );
     quic->config.initial_rx_max_stream_data = 0;
     quic->config.retry                      = 0; /* unused on clients */
 
     quic->cb.conn_new         = quic_conn_new;
     quic->cb.conn_hs_complete = handshake_complete;
     quic->cb.conn_final       = conn_final;
-    quic->cb.now              = quic_now;
-    quic->cb.now_ctx          = NULL;
     quic->cb.quic_ctx         = ctx;
 
     fd_quic_set_aio_net_tx( quic, quic_tx_aio );
@@ -434,6 +432,10 @@ unprivileged_init( fd_topo_t *      topo,
   if( FD_UNLIKELY( scratch_top > (ulong)scratch + scratch_footprint( tile ) ) )
     FD_LOG_ERR(( "scratch overflow %lu %lu %lu", scratch_top - (ulong)scratch - scratch_footprint( tile ), scratch_top, (ulong)scratch + scratch_footprint( tile ) ));
 
+  fd_clock_t * clock = ctx->clock;
+  fd_clock_default_init( clock, ctx->clock_mem );
+  ctx->recal_next = fd_clock_recal_next( clock );
+  ctx->now        = fd_clock_now( clock );
 }
 
 static void
@@ -511,13 +513,21 @@ quic_tx_aio_send( void *                    _ctx,
   return 0;
 }
 
+static void
+during_housekeeping( fd_benchs_ctx_t * ctx ) {
+  if( FD_UNLIKELY( ctx->recal_next <= ctx->now ) ) {
+    ctx->recal_next = fd_clock_default_recal( ctx->clock );
+  }
+}
+
 #define STEM_BURST (1UL)
 
 #define STEM_CALLBACK_CONTEXT_TYPE  fd_benchs_ctx_t
 #define STEM_CALLBACK_CONTEXT_ALIGN alignof(fd_benchs_ctx_t)
 
-#define STEM_CALLBACK_BEFORE_FRAG before_frag
-#define STEM_CALLBACK_DURING_FRAG during_frag
+#define STEM_CALLBACK_BEFORE_FRAG         before_frag
+#define STEM_CALLBACK_DURING_FRAG         during_frag
+#define STEM_CALLBACK_DURING_HOUSEKEEPING during_housekeeping
 
 #include "../../../../disco/stem/fd_stem.c"
 

--- a/src/app/shared_dev/commands/quic_trace/fd_quic_trace_main.c
+++ b/src/app/shared_dev/commands/quic_trace/fd_quic_trace_main.c
@@ -167,9 +167,9 @@ dump_connection( fd_quic_conn_t const * conn ) {
   X( last_pkt_number[0],     "%lu",        ( (CONN).last_pkt_number[0]     ), __VA_ARGS__ ) \
   X( last_pkt_number[1],     "%lu",        ( (CONN).last_pkt_number[1]     ), __VA_ARGS__ ) \
   X( last_pkt_number[2],     "%lu",        ( (CONN).last_pkt_number[2]     ), __VA_ARGS__ ) \
-  X( idle_timeout_ticks,     "%lu",        ( (CONN).idle_timeout_ticks     ), __VA_ARGS__ ) \
-  X( last_activity,          "%lu",        ( (CONN).last_activity          ), __VA_ARGS__ ) \
-  X( last_ack,               "%lu",        ( (CONN).last_ack               ), __VA_ARGS__ ) \
+  X( idle_timeout_ns,        "%ld",        ( (CONN).idle_timeout_ns        ), __VA_ARGS__ ) \
+  X( last_activity,          "%ld",        ( (CONN).last_activity          ), __VA_ARGS__ ) \
+  X( last_ack,               "%ld",        ( (CONN).last_ack               ), __VA_ARGS__ ) \
   X( used_pkt_meta,          "%lu",        ( (CONN).used_pkt_meta          ), __VA_ARGS__ ) \
   X( peer_cid,               "%s",         ( peer_cid_str(&(CONN))         ), __VA_ARGS__ )
 

--- a/src/app/shared_dev/commands/quic_trace/fd_quic_trace_rx_tile.c
+++ b/src/app/shared_dev/commands/quic_trace/fd_quic_trace_rx_tile.c
@@ -182,7 +182,7 @@ fd_quic_trace_initial( fd_quic_trace_ctx_t * trace_ctx,
       .flow      = key_idx,
       .conn_idx  = conn_idx };
     fd_quic_pretty_print_quic_pkt( &quic_pkt_ctx,
-                                   state->now,
+                                   fd_quic_get_state( quic )->now,
                                    data,
                                    data_sz );
     fflush( stdout );
@@ -283,7 +283,7 @@ fd_quic_trace_handshake( fd_quic_trace_ctx_t * trace_ctx,
       .flow      = key_idx,
       .conn_idx  = conn_idx };
     fd_quic_pretty_print_quic_pkt( &quic_pkt_ctx,
-                                   state->now,
+                                   fd_quic_get_state( quic )->now,
                                    data,
                                    data_sz );
     fflush( stdout );
@@ -406,7 +406,7 @@ fd_quic_trace_1rtt( fd_quic_trace_ctx_t * trace_ctx,
       .flow      = key_idx,
       .conn_idx  = conn->conn_idx };
     fd_quic_pretty_print_quic_pkt( &quic_pkt_ctx,
-                                   state->now,
+                                   fd_quic_get_state( quic )->now,
                                    data,
                                    data_sz );
     fflush( stdout );

--- a/src/app/shared_dev/commands/txn.c
+++ b/src/app/shared_dev/commands/txn.c
@@ -43,12 +43,6 @@ txn_cmd_args( int *    pargc,
   args->txn.dst_port = fd_env_strip_cmdline_ushort( pargc, pargv, "--dst-port", NULL, 0 );
 }
 
-static ulong
-cb_now( void * context ) {
-  (void)context;
-  return (ulong)fd_log_wallclock();
-}
-
 static void
 cb_conn_hs_complete( fd_quic_conn_t * conn,
                      void *           quic_ctx ) {
@@ -85,14 +79,13 @@ send_quic_transactions( fd_quic_t *         quic,
   fd_quic_set_aio_net_tx( quic, udpsock->aio );
   FD_TEST( fd_quic_init( quic ) );
 
-  quic->cb.now              = cb_now;
   quic->cb.conn_final       = cb_conn_final;
   quic->cb.conn_hs_complete = cb_conn_hs_complete;
   quic->cb.stream_notify    = cb_stream_notify;
 
-  fd_quic_conn_t * conn = fd_quic_connect( quic, dst_ip, dst_port, 0U, (ushort)udpsock->listen_port );
-  while ( FD_LIKELY( !( g_conn_hs_complete || g_conn_final ) ) ) {
-    fd_quic_service( quic );
+  fd_quic_conn_t * conn = fd_quic_connect( quic, dst_ip, dst_port, 0U, (ushort)udpsock->listen_port, fd_log_wallclock() );
+  while( FD_LIKELY( !( g_conn_hs_complete || g_conn_final ) ) ) {
+    fd_quic_service( quic, fd_log_wallclock() );
     fd_quic_udpsock_service( udpsock );
   }
   FD_TEST( conn );
@@ -101,9 +94,10 @@ send_quic_transactions( fd_quic_t *         quic,
 
   ulong sent = 0;
   while( sent < count && !g_conn_final ) {
+    long now = fd_log_wallclock();
     fd_quic_stream_t * stream = fd_quic_conn_new_stream( conn );
     if( FD_UNLIKELY( !stream ) ) {
-      fd_quic_service( quic );
+      fd_quic_service( quic, now );
       fd_quic_udpsock_service( udpsock );
       continue;
     }
@@ -113,12 +107,12 @@ send_quic_transactions( fd_quic_t *         quic,
     if( FD_UNLIKELY( res != FD_QUIC_SUCCESS ) ) FD_LOG_ERR(( "fd_quic_stream_send failed (%d)", res ));
     sent += 1UL;
 
-    fd_quic_service( quic );
+    fd_quic_service( quic, now );
     fd_quic_udpsock_service( udpsock );
   }
 
   while( FD_LIKELY( g_stream_notify!=count && !g_conn_final ) ) {
-    fd_quic_service( quic );
+    fd_quic_service( quic, fd_log_wallclock() );
     fd_quic_udpsock_service( udpsock );
   }
 
@@ -126,7 +120,7 @@ send_quic_transactions( fd_quic_t *         quic,
   if( !g_conn_final ) {
     fd_quic_conn_close( conn, 0 );
     while( !g_conn_final ) {
-      fd_quic_service( quic );
+      fd_quic_service( quic, fd_log_wallclock() );
       fd_quic_udpsock_service( udpsock );
     }
   }

--- a/src/disco/quic/fd_quic_tile.c
+++ b/src/disco/quic/fd_quic_tile.c
@@ -83,7 +83,7 @@ legacy_stream_notify( fd_quic_ctx_t * ctx,
                       ulong           packet_sz,
                       uint            ipv4 ) {
 
-  long                tspub    = fd_tickcount();
+  long                tspub    = ctx->now;
   fd_tpu_reasm_t *    reasm    = ctx->reasm;
   fd_stem_context_t * stem     = ctx->stem;
   fd_frag_meta_t *    mcache   = stem->mcaches[0];
@@ -110,7 +110,9 @@ before_credit( fd_quic_ctx_t *     ctx,
   ctx->stem = stem;
 
   /* Publishes to mcache via callbacks */
-  *charge_busy = fd_quic_service( ctx->quic );
+  long now = fd_clock_now( ctx->clock );
+  ctx->now = now;
+  *charge_busy = fd_quic_service( ctx->quic, now );
 }
 
 static inline void
@@ -230,7 +232,7 @@ after_frag( fd_quic_ctx_t *     ctx,
     ulong   ip_sz  = sz - sizeof(fd_eth_hdr_t);
 
     fd_quic_t * quic = ctx->quic;
-    fd_quic_process_packet( quic, ip_pkt, ip_sz );
+    fd_quic_process_packet( quic, ip_pkt, ip_sz, ctx->now );
   } else if( FD_LIKELY( proto==DST_PROTO_TPU_UDP ) ) {
     ulong network_hdr_sz = fd_disco_netmux_sig_hdr_sz( sig );
     if( FD_UNLIKELY( sz<=network_hdr_sz ) ) {
@@ -259,11 +261,6 @@ after_frag( fd_quic_ctx_t *     ctx,
   }
 }
 
-static ulong
-quic_now( void * ctx FD_PARAM_UNUSED ) {
-  return (ulong)fd_tickcount();
-}
-
 static void
 quic_conn_final( fd_quic_conn_t * conn,
                  void *           quic_ctx ) {
@@ -281,10 +278,10 @@ quic_stream_rx( fd_quic_conn_t * conn,
                 ulong            data_sz,
                 int              fin ) {
 
-  long                tspub    = fd_tickcount();
   fd_quic_t *         quic     = conn->quic;
   fd_quic_state_t *   state    = fd_quic_get_state( quic );  /* ugly */
   fd_quic_ctx_t *     ctx      = quic->cb.quic_ctx;
+  long                tspub    = ctx->now;
   fd_tpu_reasm_t *    reasm    = ctx->reasm;
   ulong               conn_uid = fd_quic_conn_uid( conn );
   fd_stem_context_t * stem     = ctx->stem;
@@ -449,8 +446,12 @@ quic_tls_keylog( void *       _ctx,
 
 static void
 during_housekeeping( fd_quic_ctx_t * ctx ) {
+  if( FD_UNLIKELY( ctx->recal_next <= ctx->now ) ) {
+    ctx->recal_next = fd_clock_default_recal( ctx->clock );
+  }
+
   if( FD_UNLIKELY( ctx->keylog_stream.wbuf ) ) {
-    long now = fd_log_wallclock();
+    long now = ctx->now = fd_clock_now( ctx->clock );
     if( FD_UNLIKELY( now > ctx->keylog_next_flush ) ) {
       int err = fd_io_buffered_ostream_flush( &ctx->keylog_stream );
       if( FD_UNLIKELY( err ) ) {
@@ -542,6 +543,11 @@ unprivileged_init( fd_topo_t *      topo,
     fd_net_rx_bounds_init( &ctx->net_in_bounds[ i ], link->dcache );
   }
 
+  fd_clock_t * clock = ctx->clock;
+  fd_clock_default_init( clock, ctx->clock_mem );
+  ctx->recal_next = fd_clock_recal_next( clock );
+  ctx->now        = fd_clock_now( clock );
+
   if( FD_UNLIKELY( getrandom( ctx->tls_priv_key, ED25519_PRIV_KEY_SZ, 0 )!=ED25519_PRIV_KEY_SZ ) ) {
     FD_LOG_ERR(( "getrandom failed (%i-%s)", errno, fd_io_strerror( errno ) ));
   }
@@ -570,8 +576,8 @@ unprivileged_init( fd_topo_t *      topo,
   }
 
   quic->config.role                       = FD_QUIC_ROLE_SERVER;
-  quic->config.idle_timeout               = tile->quic.idle_timeout_millis * (ulong)1e6;
-  quic->config.ack_delay                  = tile->quic.ack_delay_millis * (ulong)1e6;
+  quic->config.idle_timeout               = tile->quic.idle_timeout_millis * (long)1e6;
+  quic->config.ack_delay                  = tile->quic.ack_delay_millis    * (long)1e6;
   quic->config.initial_rx_max_stream_data = FD_TXN_MTU;
   quic->config.retry                      = tile->quic.retry;
   fd_memcpy( quic->config.identity_public_key, ctx->tls_pub_key, ED25519_PUB_KEY_SZ );
@@ -581,8 +587,6 @@ unprivileged_init( fd_topo_t *      topo,
 
   quic->cb.conn_final       = quic_conn_final;
   quic->cb.stream_rx        = quic_stream_rx;
-  quic->cb.now              = quic_now;
-  quic->cb.now_ctx          = ctx;
   quic->cb.quic_ctx         = ctx;
   if( ctx->keylog_fd>=0 ) {
     quic->cb.tls_keylog = quic_tls_keylog;
@@ -590,7 +594,6 @@ unprivileged_init( fd_topo_t *      topo,
   }
 
   fd_quic_set_aio_net_tx( quic, quic_tx_aio );
-  fd_quic_set_clock_tickcount( quic );
   if( FD_UNLIKELY( !fd_quic_init( quic ) ) ) FD_LOG_ERR(( "fd_quic_init failed" ));
 
   fd_topo_link_t * net_out = &topo->links[ tile->out_link_id[ 1 ] ];

--- a/src/disco/quic/fd_quic_tile.h
+++ b/src/disco/quic/fd_quic_tile.h
@@ -17,6 +17,10 @@ typedef struct {
 
   fd_stem_context_t * stem;
 
+  long       now;        /* current time in ns     */
+  fd_clock_t clock[1];   /* memory for fd_clock_t   */
+  long       recal_next; /* next recalibration time (ns) */
+
   fd_quic_t * quic;
   fd_aio_t    quic_tx_aio[1];
 
@@ -61,6 +65,8 @@ typedef struct {
     ulong quic_txn_too_small;
     ulong quic_txn_too_large;
   } metrics;
+
+  uchar __attribute__((aligned(FD_CLOCK_ALIGN))) clock_mem[ FD_CLOCK_FOOTPRINT ];
 } fd_quic_ctx_t;
 
 #endif /* HEADER_fd_src_app_fdctl_run_tiles_fd_quic_tile_h */

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -241,7 +241,7 @@ struct fd_topo_tile {
       ulong  max_concurrent_connections;
       ulong  max_concurrent_handshakes;
       ushort quic_transaction_listen_port;
-      ulong  idle_timeout_millis;
+      long   idle_timeout_millis;
       uint   ack_delay_millis;
       int    retry;
       char   key_log_path[ PATH_MAX ];

--- a/src/discof/send/fd_send_tile.h
+++ b/src/discof/send/fd_send_tile.h
@@ -15,6 +15,7 @@
 #include "../../disco/keyguard/fd_keyguard_client.h"
 #include "../../flamenco/leaders/fd_multi_epoch_leaders.h"
 #include "../../waltz/quic/fd_quic.h"
+#include "../../util/clock/fd_clock.h"
 
 #define IN_KIND_SIGN   (0UL)
 #define IN_KIND_GOSSIP (1UL)
@@ -32,13 +33,13 @@
 #define FD_AGAVE_MAX_CONNS_PER_MINUTE (8UL)
 /* so each of our connections must survive at least 60/8 = 7.5 seconds
    Let's conservatively go to 10 */
-#define FD_SEND_QUIC_MIN_CONN_LIFETIME_SECONDS (10UL)
+#define FD_SEND_QUIC_MIN_CONN_LIFETIME_SECONDS (10L)
 
 /* the 1M lets this be integer math */
 FD_STATIC_ASSERT((60*1000000)/FD_SEND_QUIC_MIN_CONN_LIFETIME_SECONDS <= 1000000*FD_AGAVE_MAX_CONNS_PER_MINUTE, "QUIC conn lifetime too low for rate limit");
 
-#define FD_SEND_QUIC_IDLE_TIMEOUT_NS (2e9)  /*  2 s  */
-#define FD_SEND_QUIC_ACK_DELAY_NS    (25e6) /* 25 ms */
+#define FD_SEND_QUIC_IDLE_TIMEOUT_NS (2e9L)  /*  2 s  */
+#define FD_SEND_QUIC_ACK_DELAY_NS    (25e6L) /* 25 ms */
 
 /* quic ports first, so we can re-use idx to select conn ptr
    Don't rearrange, lots of stuff depends on this order. */
@@ -76,7 +77,7 @@ struct fd_send_conn_entry {
   uint             hash;
 
   fd_quic_conn_t * conn[ FD_SEND_PORT_UDP_VOTE_IDX ]; /* first non-quic port */
-  long             last_ci_ticks;
+  long             last_ci_ns;
   uint             ip4s [ FD_SEND_PORT_CNT ]; /* net order */
   ushort           ports[ FD_SEND_PORT_CNT ]; /* host order */
   int              got_ci_msg;
@@ -131,9 +132,10 @@ struct fd_send_tile_ctx {
   fd_send_conn_entry_t * conn_map;
 
   /* timekeeping */
-  long                now;
-  ulong               ticks_per_sec;
-  ulong               housekeeping_ctr;
+  long             now;            /* current time in ns!     */
+  fd_clock_t       clock[1];       /* memory for fd_clock_t   */
+  long             recal_next;     /* next recalibration time (ns) */
+  ulong            housekeeping_ctr;
 
   struct {
     ulong leader_not_found;
@@ -159,6 +161,7 @@ struct fd_send_tile_ctx {
   } metrics;
 
   uchar __attribute__((aligned(FD_MULTI_EPOCH_LEADERS_ALIGN))) mleaders_mem[ FD_MULTI_EPOCH_LEADERS_FOOTPRINT ];
+  uchar __attribute__((aligned(FD_CLOCK_ALIGN))) clock_mem[ FD_CLOCK_FOOTPRINT ];
 };
 typedef struct fd_send_tile_ctx fd_send_tile_ctx_t;
 

--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -157,16 +157,6 @@ fd_quic_footprint( fd_quic_limits_t const * limits ) {
   return fd_quic_footprint_ext( limits, &layout );
 }
 
-static ulong
-fd_quic_clock_wallclock( void * ctx FD_PARAM_UNUSED ) {
-  return (ulong)fd_log_wallclock();
-}
-
-static ulong
-fd_quic_clock_tickcount( void * ctx FD_PARAM_UNUSED ) {
-  return (ulong)fd_tickcount();
-}
-
 FD_QUIC_API void *
 fd_quic_new( void * mem,
              fd_quic_limits_t const * limits ) {
@@ -215,11 +205,6 @@ fd_quic_new( void * mem,
   quic->config.retry_ttl    = FD_QUIC_DEFAULT_RETRY_TTL;
   quic->config.tls_hs_ttl   = FD_QUIC_DEFAULT_TLS_HS_TTL;
 
-  /* Default clock source */
-  quic->cb.now             = fd_quic_clock_wallclock;
-  quic->cb.now_ctx         = NULL;
-  quic->config.tick_per_us = 1000.0;
-
   /* Copy layout descriptors */
   quic->limits = *limits;
   quic->layout = layout;
@@ -261,8 +246,8 @@ fd_quic_config_from_env( int  *             pargc,
 
   if( FD_UNLIKELY( !cfg ) ) return NULL;
 
-  char const * keylog_file     = fd_env_strip_cmdline_cstr ( pargc, pargv, NULL,             "SSLKEYLOGFILE", NULL   );
-  ulong        idle_timeout_ms = fd_env_strip_cmdline_ulong( pargc, pargv, "--idle-timeout", NULL,            3000UL );
+  char const * keylog_file     = fd_env_strip_cmdline_cstr( pargc, pargv, NULL,             "SSLKEYLOGFILE", NULL   );
+  long         idle_timeout_ms = fd_env_strip_cmdline_long( pargc, pargv, "--idle-timeout", NULL,            3000UL );
   ulong        initial_rx_max_stream_data = fd_env_strip_cmdline_ulong(
       pargc,
       pargv,
@@ -278,7 +263,7 @@ fd_quic_config_from_env( int  *             pargc,
     cfg->keylog_file[0]='\0';
   }
 
-  cfg->idle_timeout = idle_timeout_ms * (ulong)1e6;
+  cfg->idle_timeout = idle_timeout_ms * (long)1e6;
   cfg->initial_rx_max_stream_data = initial_rx_max_stream_data;
 
   return cfg;
@@ -299,47 +284,6 @@ fd_quic_set_aio_net_tx( fd_quic_t *      quic,
   } else {
     memset( &quic->aio_tx, 0, sizeof(fd_aio_t) );
   }
-}
-
-/* fd_quic_ticks_to_us converts ticks to microseconds
-   fd_quic_us_to_ticks converts microseconds to ticks
-   These should only be used after clock has been set
-   Relies on conversion rate in config */
-FD_FN_UNUSED static ulong fd_quic_ticks_to_us( fd_quic_t * quic, ulong ticks ) {
-  double ratio = quic->config.tick_per_us;
-  return (ulong)( (double)ticks / ratio );
-}
-
-static ulong fd_quic_us_to_ticks( fd_quic_t * quic, ulong us ) {
-  double ratio = quic->config.tick_per_us;
-  return (ulong)( (double)us * ratio );
-}
-
-FD_QUIC_API void
-fd_quic_set_clock( fd_quic_t *   quic,
-                   fd_quic_now_t now_fn,
-                   void *        now_ctx,
-                   double        tick_per_us ) {
-  fd_quic_config_t *    config = &quic->config;
-  fd_quic_callbacks_t * cb     = &quic->cb;
-
-  double ratio = tick_per_us / config->tick_per_us;
-
-  config->idle_timeout = (ulong)( ratio * (double)config->idle_timeout );
-  config->ack_delay    = (ulong)( ratio * (double)config->ack_delay    );
-  config->retry_ttl    = (ulong)( ratio * (double)config->retry_ttl    );
-  /* Add more timing config here */
-
-  config->tick_per_us = tick_per_us;
-  cb->now             = now_fn;
-  cb->now_ctx         = now_ctx;
-}
-
-FD_QUIC_API void
-fd_quic_set_clock_tickcount( fd_quic_t * quic ) {
-  /* FIXME log warning and return error if tickcount ticks too slow or fluctuates too much */
-  double tick_per_us = fd_tempo_tick_per_ns( NULL ) * 1000.0;
-  fd_quic_set_clock( quic, fd_quic_clock_tickcount, NULL, tick_per_us );
 }
 
 /* initialize everything that mutates during runtime */
@@ -400,8 +344,6 @@ fd_quic_init( fd_quic_t * quic ) {
   if( FD_UNLIKELY( !config->idle_timeout  ) ) { FD_LOG_WARNING(( "zero cfg.idle_timeout" )); return NULL; }
   if( FD_UNLIKELY( !config->ack_delay     ) ) { FD_LOG_WARNING(( "zero cfg.ack_delay"    )); return NULL; }
   if( FD_UNLIKELY( !config->retry_ttl     ) ) { FD_LOG_WARNING(( "zero cfg.retry_ttl"    )); return NULL; }
-  if( FD_UNLIKELY( !quic->cb.now          ) ) { FD_LOG_WARNING(( "NULL cb.now"           )); return NULL; }
-  if( FD_UNLIKELY( config->tick_per_us==0 ) ) { FD_LOG_WARNING(( "zero cfg.tick_per_us"  )); return NULL; }
 
   do {
     ulong x = 0U;
@@ -585,27 +527,22 @@ fd_quic_init( fd_quic_t * quic ) {
   ulong initial_max_streams_uni = quic->config.role==FD_QUIC_ROLE_SERVER ? 1UL<<60 : 0;
   ulong initial_max_stream_data = config->initial_rx_max_stream_data;
 
-  double tick_per_ns = (double)quic->config.tick_per_us / 1e3;
+  long max_ack_delay_ns = config->ack_delay * 2L;
+  long max_ack_delay_ms = max_ack_delay_ns / (long)1e6;
 
-  double max_ack_delay_ticks = (double)(config->ack_delay * 2UL);
-  double max_ack_delay_ns    = max_ack_delay_ticks / tick_per_ns;
-  double max_ack_delay_ms    = max_ack_delay_ns / 1e6;
-  ulong  max_ack_delay_ms_u  = (ulong)round( max_ack_delay_ms );
-
-  double idle_timeout_ns   = (double)config->idle_timeout / tick_per_ns;
-  double idle_timeout_ms   = idle_timeout_ns / 1e6;
-  ulong  idle_timeout_ms_u = (ulong)round( idle_timeout_ms );
+  long idle_timeout_ns  = config->idle_timeout;
+  long idle_timeout_ms  = idle_timeout_ns / (long)1e6;
 
   memset( tp, 0, sizeof(fd_quic_transport_params_t) );
-  FD_QUIC_TRANSPORT_PARAM_SET( tp, max_idle_timeout_ms,                 idle_timeout_ms_u        );
-  FD_QUIC_TRANSPORT_PARAM_SET( tp, max_udp_payload_size,                FD_QUIC_MAX_PAYLOAD_SZ   ); /* TODO */
-  FD_QUIC_TRANSPORT_PARAM_SET( tp, initial_max_data,                    (1UL<<62)-1UL            );
-  FD_QUIC_TRANSPORT_PARAM_SET( tp, initial_max_stream_data_uni,         initial_max_stream_data  );
-  FD_QUIC_TRANSPORT_PARAM_SET( tp, initial_max_streams_bidi,            0                        );
-  FD_QUIC_TRANSPORT_PARAM_SET( tp, initial_max_streams_uni,             initial_max_streams_uni  );
-  FD_QUIC_TRANSPORT_PARAM_SET( tp, ack_delay_exponent,                  0                        );
-  FD_QUIC_TRANSPORT_PARAM_SET( tp, max_ack_delay,                       max_ack_delay_ms_u       );
-  /*                         */tp->disable_active_migration_present =   1;
+  FD_QUIC_TRANSPORT_PARAM_SET( tp, max_idle_timeout_ms,               (ulong)idle_timeout_ms  );
+  FD_QUIC_TRANSPORT_PARAM_SET( tp, max_udp_payload_size,              FD_QUIC_MAX_PAYLOAD_SZ  ); /* TODO */
+  FD_QUIC_TRANSPORT_PARAM_SET( tp, initial_max_data,                  (1UL<<62)-1UL           );
+  FD_QUIC_TRANSPORT_PARAM_SET( tp, initial_max_stream_data_uni,       initial_max_stream_data );
+  FD_QUIC_TRANSPORT_PARAM_SET( tp, initial_max_streams_bidi,          0                       );
+  FD_QUIC_TRANSPORT_PARAM_SET( tp, initial_max_streams_uni,           initial_max_streams_uni );
+  FD_QUIC_TRANSPORT_PARAM_SET( tp, ack_delay_exponent,                0                       );
+  FD_QUIC_TRANSPORT_PARAM_SET( tp, max_ack_delay,                     (ulong)max_ack_delay_ms );
+  /*                         */tp->disable_active_migration_present = 1;
 
   /* Compute max inflight pkt cnt per conn */
   state->max_inflight_frame_cnt_conn = limits->inflight_frame_cnt - limits->min_inflight_frame_cnt_conn * (limits->conn_cnt-1);
@@ -687,8 +624,8 @@ fd_quic_svc_schedule( fd_quic_state_t * state,
   }
 
   int  is_queued = conn->svc_type < FD_QUIC_SVC_CNT;
-  long cur_delay = (long)conn->svc_time - (long)state->now;
-  long tgt_delay = (long)state->svc_delay[ svc_type ];
+  long cur_delay = conn->svc_time - state->now;
+  long tgt_delay = state->svc_delay[ svc_type ];
 
   /* Don't reschedule if already scheduled sooner */
   if( is_queued && cur_delay<=tgt_delay ) return;
@@ -704,7 +641,7 @@ fd_quic_svc_schedule( fd_quic_state_t * state,
   uint                  old_tail_idx = queue->tail;
   fd_quic_conn_t *      old_tail_ele = fd_quic_conn_at_idx( state, old_tail_idx );
   conn->svc_type = svc_type;
-  conn->svc_time = state->now + (ulong)tgt_delay;
+  conn->svc_time = state->now + tgt_delay;
   conn->svc_prev = UINT_MAX;
   conn->svc_next = old_tail_idx;
   *fd_ptr_if( old_tail_idx!=UINT_MAX, &old_tail_ele->svc_prev, &queue->head ) = (uint)conn->conn_idx;
@@ -723,7 +660,7 @@ fd_quic_svc_queue_validate( fd_quic_t * quic,
                             uint        svc_type ) {
   FD_TEST( svc_type < FD_QUIC_SVC_CNT );
   fd_quic_state_t * state = fd_quic_get_state( quic );
-  ulong now = state->now;
+  long now = state->now;
 
   ulong cnt  = 0UL;
   uint  prev = UINT_MAX;
@@ -899,7 +836,7 @@ fd_quic_frame_error( fd_quic_frame_ctx_t const * ctx,
     .src_file = "fd_quic.c",
     .src_line = error_line,
   };
-  fd_quic_log_tx_submit( state->log_tx, sizeof(fd_quic_log_error_t), sig, (long)state->now );
+  fd_quic_log_tx_submit( state->log_tx, sizeof(fd_quic_log_error_t), sig, state->now );
 }
 
 /* returns the encoding level we should use for the next tx quic packet
@@ -1418,7 +1355,7 @@ fd_quic_send_retry( fd_quic_t *               quic,
 
   fd_quic_state_t * state = fd_quic_get_state( quic );
 
-  ulong expire_at = state->now + quic->config.retry_ttl;
+  long  expire_at = state->now + quic->config.retry_ttl;
   uchar retry_pkt[ FD_QUIC_RETRY_LOCAL_SZ ];
   ulong retry_pkt_sz = fd_quic_retry_create( retry_pkt, pkt, state->_rng, state->retry_secret, state->retry_iv, odcid, scid, new_conn_id, expire_at );
 
@@ -2434,10 +2371,11 @@ is_version_invalid( fd_quic_t * quic, uint version ) {
 static inline void
 fd_quic_process_packet_impl( fd_quic_t * quic,
                              uchar *     data,
-                             ulong       data_sz ) {
-
-  fd_quic_state_t * state = fd_quic_get_state( quic );
-  state->now = fd_quic_now( quic );
+                             ulong       data_sz,
+                             long        now ) {
+  fd_quic_get_state( quic )->now = now;
+  quic->metrics.net_rx_byte_cnt += data_sz;
+  quic->metrics.net_rx_pkt_cnt++;
 
   ulong rc = 0;
 
@@ -2453,7 +2391,7 @@ fd_quic_process_packet_impl( fd_quic_t * quic,
 
   fd_quic_pkt_t pkt = { .datagram_sz = (uint)data_sz };
 
-  pkt.rcv_time       = state->now;
+  pkt.rcv_time       = now;
   pkt.rtt_pkt_number = 0;
   pkt.rtt_ack_time   = 0;
 
@@ -2602,16 +2540,14 @@ fd_quic_process_packet_impl( fd_quic_t * quic,
 }
 
 void
-fd_quic_process_packet( fd_quic_t * quic,
-                        uchar *     data,
-                        ulong       data_sz ) {
-  long dt = -fd_tickcount();
-  fd_quic_process_packet_impl( quic, data, data_sz );
-  dt += fd_tickcount();
-  fd_histf_sample( quic->metrics.receive_duration, (ulong)dt );
-
-  quic->metrics.net_rx_byte_cnt += data_sz;
-  quic->metrics.net_rx_pkt_cnt++;
+fd_quic_process_packet( fd_quic_t  *  quic,
+                        uchar      *  data,
+                        ulong         data_sz,
+                        long          now ) {
+  long now_ticks = fd_tickcount();
+  fd_quic_process_packet_impl( quic, data, data_sz, now );
+  long delta_ticks = fd_tickcount() - now_ticks;
+  fd_histf_sample( quic->metrics.receive_duration, (ulong)delta_ticks );
 }
 
 /* main receive-side entry point */
@@ -2624,19 +2560,13 @@ fd_quic_aio_cb_receive( void *                    context,
   (void)flush;
 
   fd_quic_t * quic = context;
-
-  FD_DEBUG(
-    fd_quic_state_t * state = fd_quic_get_state( quic );
-    static ulong t0 = 0;
-    static ulong t1 = 0;
-    t0 = state->now;
-  )
+  long now = fd_quic_get_state( quic )->now;
 
   /* this aio interface is configured as one-packet per buffer
      so batch[0] refers to one buffer
      as such, we simply forward each individual packet to a handling function */
   for( ulong j = 0; j < batch_cnt; ++j ) {
-    fd_quic_process_packet( quic, batch[ j ].buf, batch[ j ].buf_sz );
+    fd_quic_process_packet( quic, batch[ j ].buf, batch[ j ].buf_sz, now );
   }
 
   /* the assumption here at present is that any packet that could not be processed
@@ -2645,14 +2575,6 @@ fd_quic_aio_cb_receive( void *                    context,
   if( FD_LIKELY( opt_batch_idx ) ) {
     *opt_batch_idx = batch_cnt;
   }
-
-  FD_DEBUG(
-    t1 = fd_quic_now( quic );
-    ulong delta = t1 - t0;
-    if( delta > (ulong)500e3 ) {
-      FD_LOG_WARNING(( "CALLBACK - took %lu  t0: %lu  t1: %lu  batch_cnt: %lu", delta, t0, t1, (ulong)batch_cnt ));
-    }
-  )
 
   return FD_AIO_SUCCESS;
 }
@@ -2806,9 +2728,8 @@ fd_quic_apply_peer_params( fd_quic_conn_t *                   conn,
 
   /* set the max_idle_timeout to the min of our and peer max_idle_timeout */
   if( peer_tp->max_idle_timeout_ms ) {
-    double peer_max_idle_timeout_us    = (double)peer_tp->max_idle_timeout_ms * 1e3;
-    ulong  peer_max_idle_timeout_ticks = fd_quic_us_to_ticks( conn->quic, (ulong)peer_max_idle_timeout_us );
-    conn->idle_timeout_ticks = fd_ulong_min( peer_max_idle_timeout_ticks, conn->idle_timeout_ticks );
+    long peer_max_idle_timeout_ns = (long)peer_tp->max_idle_timeout_ms * (long)1e6;
+    conn->idle_timeout_ns         = fd_long_min( peer_max_idle_timeout_ns, conn->idle_timeout_ns );
   }
 
   /* set ack_delay_exponent so we can properly interpret peer's ack_delays
@@ -2818,8 +2739,7 @@ fd_quic_apply_peer_params( fd_quic_conn_t *                   conn,
                                     peer_tp->ack_delay_exponent,
                                     3UL );
 
-  float tick_per_us = (float)conn->quic->config.tick_per_us;
-  conn->peer_ack_delay_scale = (float)( 1UL << peer_ack_delay_exponent ) * tick_per_us;
+  conn->peer_ack_delay_scale = (float)( 1UL << peer_ack_delay_exponent ) * 1e3f;
 
   /* peer max ack delay in microseconds
      peer_tp->max_ack_delay is milliseconds */
@@ -2827,7 +2747,7 @@ fd_quic_apply_peer_params( fd_quic_conn_t *                   conn,
                                     peer_tp->max_ack_delay_present,
                                     peer_tp->max_ack_delay * 1000UL,
                                     25000UL );
-  conn->peer_max_ack_delay_ticks = peer_max_ack_delay_us * tick_per_us;
+  conn->peer_max_ack_delay_ns = peer_max_ack_delay_us * 1e3f;
 
   conn->transport_params_set = 1;
 }
@@ -2964,7 +2884,7 @@ fd_quic_handle_crypto_frame( fd_quic_frame_ctx_t *    context,
 static int
 fd_quic_svc_poll( fd_quic_t *      quic,
                   fd_quic_conn_t * conn,
-                  ulong            now ) {
+                  long             now ) {
   fd_quic_state_t * state = fd_quic_get_state( quic );
   if( FD_UNLIKELY( conn->state == FD_QUIC_CONN_STATE_INVALID ) ) {
     /* connection shouldn't have been scheduled,
@@ -2977,21 +2897,25 @@ fd_quic_svc_poll( fd_quic_t *      quic,
   conn->svc_type = UINT_MAX;
   conn->svc_time = LONG_MAX;
 
-  if( FD_UNLIKELY( now >= conn->last_activity + ( conn->idle_timeout_ticks / 2 ) ) ) {
-    if( FD_UNLIKELY( now >= conn->last_activity + conn->idle_timeout_ticks ) ) {
+  if( FD_UNLIKELY( now >= conn->last_activity + ( conn->idle_timeout_ns / 2 ) ) ) {
+    if( FD_UNLIKELY( now >= conn->last_activity + conn->idle_timeout_ns ) ) {
       if( FD_LIKELY( conn->state != FD_QUIC_CONN_STATE_DEAD ) ) {
         /* rfc9000 10.1 Idle Timeout
             "... the connection is silently closed and its state is discarded
             when it remains idle for longer than the minimum of the
             max_idle_timeout value advertised by both endpoints." */
-        FD_DEBUG( FD_LOG_WARNING(("%s  conn %p  conn_idx: %u  closing due to idle timeout (%g ms)",
+        FD_DEBUG( FD_LOG_WARNING(("%s  conn %p  conn_idx: %u  closing due to idle timeout=%gms last_activity=%ld now=%ld",
             conn->server?"SERVER":"CLIENT",
-            (void *)conn, conn->conn_idx, (double)fd_quic_ticks_to_us(conn->idle_timeout_ticks) / 1e3 )); )
+            (void *)conn, conn->conn_idx,
+            (double)conn->idle_timeout_ns / 1e6,
+            conn->last_activity,
+            now
+        )); )
 
         fd_quic_set_conn_state( conn, FD_QUIC_CONN_STATE_DEAD );
         quic->metrics.conn_timeout_cnt++;
       }
-    } else if( quic->config.keep_alive & !!(conn->let_die_ticks > now) ) {
+    } else if( quic->config.keep_alive & !!(conn->let_die_time_ns > now) ) {
       /* send PING */
       if( !( conn->flags & FD_QUIC_CONN_FLAGS_PING ) ) {
         conn->flags         |= FD_QUIC_CONN_FLAGS_PING;
@@ -3029,7 +2953,7 @@ fd_quic_svc_poll( fd_quic_t *      quic,
 static int
 fd_quic_svc_poll_head( fd_quic_t * quic,
                        uint        svc_type,
-                       ulong       now ) {
+                       long        now ) {
   fd_quic_state_t * state = fd_quic_get_state( quic );
 
   /* Peek head of queue */
@@ -3050,7 +2974,7 @@ fd_quic_svc_poll_head( fd_quic_t * quic,
 static int
 fd_quic_svc_poll_tail( fd_quic_t * quic,
                        uint        svc_type,
-                       ulong       now ) {
+                       long        now ) {
   fd_quic_state_t * state = fd_quic_get_state( quic );
 
   /* Peek tail of queue */
@@ -3069,10 +2993,10 @@ fd_quic_svc_poll_tail( fd_quic_t * quic,
 }
 
 int
-fd_quic_service( fd_quic_t * quic ) {
+fd_quic_service( fd_quic_t * quic,
+                 long        now ) {
   fd_quic_state_t * state = fd_quic_get_state( quic );
 
-  ulong now = fd_quic_now( quic );
   state->now = now;
 
   long now_ticks = fd_tickcount();
@@ -3629,7 +3553,7 @@ fd_quic_gen_frames( fd_quic_conn_t           * conn,
                     uchar                    * payload_ptr,
                     uchar                    * payload_end,
                     fd_quic_pkt_meta_t       * pkt_meta_tmpl,
-                    ulong                      now ) {
+                    long                       now ) {
 
   uint closing = 0U;
   switch( conn->state ) {
@@ -3641,7 +3565,7 @@ fd_quic_gen_frames( fd_quic_conn_t           * conn,
 
   fd_quic_pkt_meta_tracker_t * tracker = &conn->pkt_meta_tracker;
 
-  payload_ptr = fd_quic_gen_ack_frames( conn->ack_gen, payload_ptr, payload_end, pkt_meta_tmpl->enc_level, now, (float)conn->quic->config.tick_per_us );
+  payload_ptr = fd_quic_gen_ack_frames( conn->ack_gen, payload_ptr, payload_end, pkt_meta_tmpl->enc_level, now );
   if( conn->ack_gen->head == conn->ack_gen->tail ) conn->unacked_sz = 0UL;
 
   if( FD_UNLIKELY( closing ) ) {
@@ -3721,10 +3645,10 @@ fd_quic_conn_tx( fd_quic_t      * quic,
   int key_phase_tx  = (int)key_phase ^ key_phase_upd;
 
   /* get time, and set reschedule time for at most the idle timeout */
-  ulong now = fd_quic_get_state( quic )->now;
+  long now = state->now;
 
   /* initialize expiry and tx_time */
-  fd_quic_pkt_meta_t pkt_meta_tmpl[1] = {{.expiry = now+500000000UL, .tx_time = now}};
+  fd_quic_pkt_meta_t pkt_meta_tmpl[1] = {{.expiry = now+500000000L, .tx_time = now}};
   // pkt_meta_tmpl->expiry = fd_quic_calc_expiry( conn, now );
   //ulong margin = (ulong)(conn->rtt->smoothed_rtt) + (ulong)(3 * conn->rtt->var_rtt);
   //if( margin < pkt_meta->expiry ) {
@@ -4003,11 +3927,11 @@ fd_quic_conn_tx( fd_quic_t      * quic,
 }
 
 void
-fd_quic_conn_service( fd_quic_t * quic, fd_quic_conn_t * conn, ulong now ) {
+fd_quic_conn_service( fd_quic_t * quic, fd_quic_conn_t * conn, long now ) {
   (void)now;
 
   /* Send new rtt measurement probe? */
-  if( FD_UNLIKELY(now > conn->last_ack + (ulong)conn->rtt_period_ticks) ) {
+  if( FD_UNLIKELY( now > conn->last_ack + (long)conn->rtt_period_ns ) ) {
     /* send PING */
     if( !( conn->flags & ( FD_QUIC_CONN_FLAGS_PING | FD_QUIC_CONN_FLAGS_PING_SENT ) )
         && conn->state == FD_QUIC_CONN_STATE_ACTIVE ) {
@@ -4209,13 +4133,14 @@ fd_quic_conn_free( fd_quic_t *      quic,
 }
 
 fd_quic_conn_t *
-fd_quic_connect( fd_quic_t *  quic,
-                 uint         dst_ip_addr,
-                 ushort       dst_udp_port,
-                 uint         src_ip_addr,
-                 ushort       src_udp_port ) {
+fd_quic_connect( fd_quic_t * quic,
+                 uint        dst_ip_addr,
+                 ushort      dst_udp_port,
+                 uint        src_ip_addr,
+                 ushort      src_udp_port,
+                 long        now ) {
   fd_quic_state_t * state = fd_quic_get_state( quic );
-  state->now              = fd_quic_now( quic );
+  state->now              = now;
 
   if( FD_UNLIKELY( !fd_quic_tls_hs_pool_free( state->hs_pool ) ) ) {
     /* try evicting, 0 if oldest is too young so fail */
@@ -4277,7 +4202,7 @@ fd_quic_connect( fd_quic_t *  quic,
       (void*)conn,
       0 /*is_server*/,
       tp,
-      state->now );
+      now );
   if( FD_UNLIKELY( tls_hs->alert ) ) {
     FD_LOG_WARNING(( "fd_quic_tls_hs_client_new failed" ));
     /* shut down tls_hs */
@@ -4432,21 +4357,21 @@ fd_quic_conn_create( fd_quic_t *               quic,
   fd_rtt_estimate_t * rtt = conn->rtt;
 
   ulong peer_ack_delay_exponent  = 3UL; /* by spec, default is 3 */
-  conn->peer_ack_delay_scale     = (float)( 1UL << peer_ack_delay_exponent )
-                                         * (float)quic->config.tick_per_us;
-  conn->peer_max_ack_delay_ticks = 0.0f;       /* starts at zero, since peers respond immediately to */
+  conn->peer_ack_delay_scale     = (float)( 1UL << peer_ack_delay_exponent ) * 1e3f;
+  conn->peer_max_ack_delay_ns    = 0.0f;       /* starts at zero, since peers respond immediately to */
                                                /* INITIAL and HANDSHAKE */
                                                /* updated when we get transport parameters */
-  rtt->smoothed_rtt              = FD_QUIC_INITIAL_RTT_US * (float)quic->config.tick_per_us;
-  rtt->latest_rtt                = FD_QUIC_INITIAL_RTT_US * (float)quic->config.tick_per_us;
-  rtt->min_rtt                   = FD_QUIC_INITIAL_RTT_US * (float)quic->config.tick_per_us;
-  rtt->var_rtt                   = FD_QUIC_INITIAL_RTT_US * (float)quic->config.tick_per_us * 0.5f;
-  conn->rtt_period_ticks         = FD_QUIC_RTT_PERIOD_US  * (float)quic->config.tick_per_us;
+  rtt->smoothed_rtt              = FD_QUIC_INITIAL_RTT_US * 1e3f;
+  rtt->latest_rtt                = FD_QUIC_INITIAL_RTT_US * 1e3f;
+  rtt->min_rtt                   = FD_QUIC_INITIAL_RTT_US * 1e3f;
+  rtt->var_rtt                   = FD_QUIC_INITIAL_RTT_US * 1e3f * 0.5f;
+  conn->rtt_period_ns            = FD_QUIC_RTT_PERIOD_US  * 1e3f;
 
   /* idle timeout */
-  conn->idle_timeout_ticks  = config->idle_timeout;
-  conn->last_activity       = state->now;
-  conn->let_die_ticks       = ULONG_MAX;
+  conn->idle_timeout_ns      = config->idle_timeout;
+  conn->last_activity        = state->now;
+  if( !conn->last_activity )   FD_LOG_CRIT(( "last activity: %ld", conn->last_activity ));
+  conn->let_die_time_ns      = LONG_MAX;
 
   /* update metrics */
   quic->metrics.conn_alloc_cnt++;
@@ -4459,7 +4384,7 @@ fd_quic_conn_create( fd_quic_t *               quic,
   return conn;
 }
 
-ulong
+long
 fd_quic_get_next_wakeup( fd_quic_t * quic ) {
   /* FIXME not optimized for performance */
   fd_quic_state_t * state = fd_quic_get_state( quic );
@@ -4469,14 +4394,14 @@ fd_quic_get_next_wakeup( fd_quic_t * quic ) {
   long wait_wakeup = LONG_MAX;
   if( state->svc_queue[ FD_QUIC_SVC_ACK_TX ].head != UINT_MAX ) {
     fd_quic_conn_t * conn = fd_quic_conn_at_idx( state, state->svc_queue[ FD_QUIC_SVC_ACK_TX ].head );
-    ack_wakeup = (long)conn->svc_time;
+    ack_wakeup = conn->svc_time;
   }
   if( state->svc_queue[ FD_QUIC_SVC_WAIT ].head != UINT_MAX ) {
     fd_quic_conn_t * conn = fd_quic_conn_at_idx( state, state->svc_queue[ FD_QUIC_SVC_WAIT ].head );
-    wait_wakeup = (long)conn->svc_time;
+    wait_wakeup = conn->svc_time;
   }
 
-  return (ulong)fd_long_max( fd_long_min( ack_wakeup, wait_wakeup ), 0L );
+  return fd_long_max( fd_long_min( ack_wakeup, wait_wakeup ), 0L );
 }
 
 /* frame handling function default definitions */
@@ -4520,7 +4445,7 @@ fd_quic_pkt_meta_retry( fd_quic_t *          quic,
                         uint                 arg_enc_level ) {
   fd_quic_conn_stream_rx_t * srx = conn->srx;
 
-  ulong now = fd_quic_get_state( quic )->now;
+  long now = fd_quic_get_state( quic )->now;
 
   /* minimum pkt_meta required to be freed
      If not forcing, 0 is applicable
@@ -4545,7 +4470,7 @@ fd_quic_pkt_meta_retry( fd_quic_t *          quic,
     /* find earliest expiring pkt_meta, over smallest pkt number at each enc_level */
     uint  enc_level      = arg_enc_level;
     uint  peer_enc_level = conn->peer_enc_level;
-    ulong expiry         = ~0ul;
+    long  expiry         = LONG_MAX;
     if( arg_enc_level == ~0u ) {
       for( uint j = 0u; j < 4u; ++j ) {
         /* TODO this only checks smallest pkt number,
@@ -4595,7 +4520,7 @@ fd_quic_pkt_meta_retry( fd_quic_t *          quic,
     }
 
     if( exit ) {
-      if( expiry != ~0ul ) fd_quic_svc_schedule1( conn, FD_QUIC_SVC_WAIT );
+      if( expiry!=LONG_MAX ) fd_quic_svc_schedule1( conn, FD_QUIC_SVC_WAIT );
       return;
     };
 
@@ -4987,7 +4912,7 @@ fd_quic_process_ack_range( fd_quic_conn_t      * conn,
                            ulong                 largest_ack,
                            ulong                 ack_range,
                            int                   is_largest,
-                           ulong                 now,
+                           long                  now,
                            ulong                 ack_delay ) {
   /* FIXME: Close connection if peer ACKed a higher packet number than we sent */
 
@@ -5010,8 +4935,8 @@ fd_quic_process_ack_range( fd_quic_conn_t      * conn,
     if( FD_UNLIKELY( e->key.pkt_num > hi ) ) break;
     if( is_largest && e->key.pkt_num == hi && hi >= pkt->rtt_pkt_number ) {
       pkt->rtt_pkt_number = hi;
-      pkt->rtt_ack_time   = now - e->tx_time; /* in ticks */
-      pkt->rtt_ack_delay  = ack_delay;               /* in peer units */
+      pkt->rtt_ack_time   = now - e->tx_time; /* in ns */
+      pkt->rtt_ack_delay  = ack_delay;        /* in peer units */
     }
     fd_quic_reclaim_pkt_meta( conn, e, enc_level );
   }
@@ -5033,7 +4958,7 @@ fd_quic_handle_ack_frame( fd_quic_frame_ctx_t * context,
     return FD_QUIC_PARSE_FAIL;
   }
 
-  fd_quic_state_t * state = fd_quic_get_state( context->quic );
+  fd_quic_state_t * state = fd_quic_get_state( conn->quic );
   conn->last_ack = state->now;
 
   /* track lowest packet acked */
@@ -5640,7 +5565,7 @@ fd_quic_conn_close( fd_quic_conn_t * conn,
 
 void
 fd_quic_conn_let_die( fd_quic_conn_t * conn,
-                      ulong            keep_alive_duration_ticks ) {
-  ulong const now = fd_quic_get_state( conn->quic )->now;
-  conn->let_die_ticks = fd_ulong_sat_add( now, keep_alive_duration_ticks );
+                      long             keep_alive_duration ) {
+  long const now = fd_quic_get_state( conn->quic )->now;
+  conn->let_die_time_ns = fd_long_sat_add( now, keep_alive_duration );
 }

--- a/src/waltz/quic/fd_quic.h
+++ b/src/waltz/quic/fd_quic.h
@@ -86,6 +86,7 @@
 
 #include "../aio/fd_aio.h"
 #include "../tls/fd_tls.h"
+#include "../../util/clock/fd_clock.h"
 #include "../../util/hist/fd_histf.h"
 
 /* FD_QUIC_API marks public API declarations.  No-op for now. */
@@ -140,13 +141,6 @@ struct fd_quic_layout {
 
 typedef struct fd_quic_layout fd_quic_layout_t;
 
-/* fd_quic_now_t is the clock source used internally by quic for
-   scheduling events.  context is an arbitrary pointer earlier provided
-   by the caller during config. */
-
-typedef ulong
-(*fd_quic_now_t)( void * context );
-
 /* fd_quic_config_t defines mutable config of an fd_quic_t.  The config is
    immutable during an active join. */
 
@@ -159,13 +153,12 @@ struct __attribute__((aligned(16UL))) fd_quic_config {
 #define FD_QUIC_CONFIG_LIST(X,...) \
   X( role,                        "%d",     enum,  "enum",         __VA_ARGS__ ) \
   X( retry,                       "%d",     bool,  "bool",         __VA_ARGS__ ) \
-  X( tick_per_us,                 "%f",     units, "ticks per us", __VA_ARGS__ ) \
-  X( idle_timeout,                "%lu",    units, "ns",           __VA_ARGS__ ) \
+  X( idle_timeout,                "%ld",    units, "ns",           __VA_ARGS__ ) \
   X( keep_alive,                  "%d",     bool,  "bool",         __VA_ARGS__ ) \
-  X( ack_delay,                   "%lu",    units, "ns",           __VA_ARGS__ ) \
+  X( ack_delay,                   "%ld",    units, "ns",           __VA_ARGS__ ) \
   X( ack_threshold,               "%lu",    units, "bytes",        __VA_ARGS__ ) \
-  X( retry_ttl,                   "%lu",    units, "ns",           __VA_ARGS__ ) \
-  X( tls_hs_ttl,                  "%lu",    units, "ns",           __VA_ARGS__ ) \
+  X( retry_ttl,                   "%ld",    units, "ns",           __VA_ARGS__ ) \
+  X( tls_hs_ttl,                  "%ld",    units, "ns",           __VA_ARGS__ ) \
   X( identity_public_key,         "%x",     hex32, "",             __VA_ARGS__ ) \
   X( sign,                        "%p",     ptr,   "",             __VA_ARGS__ ) \
   X( sign_ctx,                    "%p",     ptr,   "",             __VA_ARGS__ ) \
@@ -181,13 +174,10 @@ struct __attribute__((aligned(16UL))) fd_quic_config {
   /* retry: whether address validation using retry packets is enabled (RFC 9000, Section 8.1.2) */
   int retry;
 
-  /* tick_per_us: clock ticks per microsecond */
-  double tick_per_us;
-
   /* idle_timeout: Upper bound on conn idle timeout.
      Also sent to peer via max_idle_timeout transport param.
      If the peer specifies a lower idle timeout, that is used instead. */
-  ulong idle_timeout;
+  long idle_timeout;
 # define FD_QUIC_DEFAULT_IDLE_TIMEOUT (ulong)(1e9) /* 1s */
 
 /* keep_alive
@@ -199,8 +189,8 @@ struct __attribute__((aligned(16UL))) fd_quic_config {
 
   /* ack_delay: median delay on outgoing ACKs.  Greater delays allow
      fd_quic to coalesce packet ACKs. */
-  ulong ack_delay;
-# define FD_QUIC_DEFAULT_ACK_DELAY (ulong)(50e6) /* 50ms */
+  long ack_delay;
+# define FD_QUIC_DEFAULT_ACK_DELAY (long)(50e6) /* 50ms */
 
   /* ack_threshold: immediately send an ACK when the number of
      unacknowledged stream bytes exceeds this value. */
@@ -208,12 +198,12 @@ struct __attribute__((aligned(16UL))) fd_quic_config {
 # define FD_QUIC_DEFAULT_ACK_THRESHOLD (65536UL) /* 64 KiB */
 
   /* retry_ttl: time-to-live for retry tokens */
-  ulong retry_ttl;
-# define FD_QUIC_DEFAULT_RETRY_TTL (ulong)(1e9) /* 1s */
+  long retry_ttl;
+# define FD_QUIC_DEFAULT_RETRY_TTL (long)(1e9) /* 1s */
 
   /* hs_ttl: time-to-live for tls_hs */
-  ulong tls_hs_ttl;
-# define FD_QUIC_DEFAULT_TLS_HS_TTL (ulong)(3e9) /* 3s */
+  long tls_hs_ttl;
+# define FD_QUIC_DEFAULT_TLS_HS_TTL (long)(3e9) /* 3s */
 
   /* TLS config ********************************************/
 
@@ -307,11 +297,6 @@ struct fd_quic_callbacks {
   fd_quic_cb_stream_notify_t           stream_notify;     /* non-NULL, with stream_ctx */
   fd_quic_cb_stream_rx_t               stream_rx;         /* non-NULL, with stream_ctx */
   fd_quic_cb_tls_keylog_t              tls_keylog;        /* nullable, with quic_ctx   */
-
-  /* Clock source */
-
-  fd_quic_now_t now;     /* non-NULL */
-  void *        now_ctx; /* user-provided context pointer for now_fn calls */
 
 };
 typedef struct fd_quic_callbacks fd_quic_callbacks_t;
@@ -489,20 +474,6 @@ FD_QUIC_API void
 fd_quic_set_aio_net_tx( fd_quic_t *      quic,
                         fd_aio_t const * aio_tx );
 
-/* fd_quic_set_clock sets the clock source.  Converts all timing values
-   in the config to the new time scale. */
-
-FD_QUIC_API void
-fd_quic_set_clock( fd_quic_t *   quic,
-                   fd_quic_now_t now_fn,
-                   void *        now_ctx,
-                   double        tick_per_us );
-
-/* fd_quic_set_clock_tickcount sets fd_tickcount as the clock source. */
-
-FD_QUIC_API void
-fd_quic_set_clock_tickcount( fd_quic_t * quic );
-
 /* Initialization *****************************************************/
 
 /* fd_quic_init initializes the QUIC such that it is ready to serve.
@@ -546,7 +517,8 @@ fd_quic_connect( fd_quic_t *  quic,  /* requires exclusive access */
                  uint         dst_ip_addr,
                  ushort       dst_udp_port,
                  uint         src_ip_addr,
-                 ushort       src_udp_port );
+                 ushort       src_udp_port,
+                 long         now );
 
 /* fd_quic_conn_close asynchronously initiates a shutdown of the conn.
    The given reason code is returned to the peer via a CONNECTION_CLOSE
@@ -558,7 +530,7 @@ fd_quic_conn_close( fd_quic_conn_t * conn,
                     uint             reason );
 
 /* fd_quic_conn_let_die stops keeping a conn alive after
-   'keep_alive_duration_ticks'. No-op if keep-alive is not configured.
+   'keep_alive_duration_ns'. No-op if keep-alive is not configured.
    Safe to call on a connection in any state.
 
    If called multiple times on the same connection, only the latest
@@ -572,14 +544,14 @@ fd_quic_conn_close( fd_quic_conn_t * conn,
 
 FD_QUIC_API void
 fd_quic_conn_let_die( fd_quic_conn_t * conn,
-                      ulong            keep_alive_duration_ticks );
+                      long             keep_alive_duration_ns );
 
 /* Service API ********************************************************/
 
 /* fd_quic_get_next_wakeup returns the next requested service time.
    This is only intended for unit tests. */
 
-FD_QUIC_API ulong
+FD_QUIC_API long
 fd_quic_get_next_wakeup( fd_quic_t * quic );
 
 /* fd_quic_service services the next QUIC connection at each service
@@ -589,7 +561,8 @@ fd_quic_get_next_wakeup( fd_quic_t * quic );
    did no work. */
 
 FD_QUIC_API int
-fd_quic_service( fd_quic_t * quic );
+fd_quic_service( fd_quic_t * quic,
+                 long        now );
 
 /* fd_quic_svc_validate checks for violations of service queue and free
    list invariants, such as cycles in linked lists.  Prints to warning/
@@ -649,7 +622,9 @@ fd_quic_stream_fin( fd_quic_stream_t * stream );
 FD_QUIC_API void
 fd_quic_process_packet( fd_quic_t * quic,
                         uchar *     data,
-                        ulong       data_sz );
+                        ulong       data_sz,
+                        long        now );
+
 
 uint
 fd_quic_tx_buffered_raw( fd_quic_t * quic,

--- a/src/waltz/quic/fd_quic_ack_tx.h
+++ b/src/waltz/quic/fd_quic_ack_tx.h
@@ -29,7 +29,7 @@
 
 struct __attribute__((aligned(16))) fd_quic_ack {
   fd_quic_range_t pkt_number;  /* Range of packet numbers being ACKed */
-  ulong           ts;          /* timestamp of highest packet number */
+  long            ts;          /* timestamp of highest packet number */
   uchar           enc_level;   /* in [0,4) */
   /* FIXME enc_level should technically be pn_space instead */
   uchar           _pad[7];
@@ -86,7 +86,7 @@ int
 fd_quic_ack_pkt( fd_quic_ack_gen_t * gen,
                  ulong               pkt_number,
                  uint                enc_level,
-                 ulong               now );
+                 long                now );
 
 #define FD_QUIC_ACK_TX_NOOP   (0)
 #define FD_QUIC_ACK_TX_NEW    (1)
@@ -120,8 +120,7 @@ fd_quic_gen_ack_frames( fd_quic_ack_gen_t * gen,
                         uchar *             payload_ptr,
                         uchar *             payload_end,
                         uint                enc_level,
-                        ulong               tickcount,
-                        float               tick_per_us );
+                        long                now );
 
 FD_PROTOTYPES_END
 

--- a/src/waltz/quic/fd_quic_conn.h
+++ b/src/waltz/quic/fd_quic_conn.h
@@ -99,7 +99,7 @@ struct fd_quic_conn {
   uint               svc_type;  /* FD_QUIC_SVC_{...} or UINT_MAX */
   uint               svc_prev;
   uint               svc_next;
-  ulong              svc_time;  /* service may be delayed until this timestamp */
+  long               svc_time;  /* service may be delayed until this timestamp */
 
   ulong              our_conn_id;
 
@@ -214,16 +214,16 @@ struct fd_quic_conn {
   uchar                peer_enc_level;
 
   /* idle timeout arguments */
-  ulong                idle_timeout_ticks;
-  ulong                last_activity;
-  ulong                last_ack;
-  ulong                let_die_ticks; /* stop keep-alive after this time */
+  long                 idle_timeout_ns;
+  long                 last_activity;
+  long                 last_ack;
+  long                 let_die_time_ns; /* stop keep-alive after this time */
 
   /* round trip time related members */
   fd_rtt_estimate_t rtt[1];
-  float rtt_period_ticks;         /* bound on time between RTT measurements */
-  float peer_ack_delay_scale;     /* convert ACK delay units to ticks */
-  float peer_max_ack_delay_ticks; /* peer max ack delay in ticks */
+  float rtt_period_ns;         /* bound on time between RTT measurements */
+  float peer_ack_delay_scale;  /* convert ACK delay units to nanoseconds */
+  float peer_max_ack_delay_ns; /* peer max ack delay in nanoseconds */
 
   ulong token_len;
   uchar token[ FD_QUIC_RETRY_MAX_TOKEN_SZ ];

--- a/src/waltz/quic/fd_quic_pkt_meta.c
+++ b/src/waltz/quic/fd_quic_pkt_meta.c
@@ -18,7 +18,7 @@ fd_quic_pkt_meta_tracker_init( fd_quic_pkt_meta_tracker_t * tracker,
 void
 fd_quic_pkt_meta_ds_init_pool( fd_quic_pkt_meta_t * pool,
                                ulong                total_meta_cnt ) {
-  fd_quic_pkt_meta_treap_seed( pool, total_meta_cnt, (ulong)fd_log_wallclock() );
+  fd_quic_pkt_meta_treap_seed( pool, total_meta_cnt, (ulong)fd_tickcount() );
 }
 
 void

--- a/src/waltz/quic/fd_quic_pkt_meta.h
+++ b/src/waltz/quic/fd_quic_pkt_meta.h
@@ -66,8 +66,8 @@ struct fd_quic_pkt_meta {
   fd_quic_pkt_meta_value_t val;
   uchar                    enc_level: 2;
   uchar                    pn_space;    /* packet number space (derived from enc_level) */
-  ulong                    tx_time;     /* transmit time */
-  ulong                    expiry;      /* time pkt_meta expires... this is the time the
+  long                     tx_time;     /* transmit time */
+  long                     expiry;      /* time pkt_meta expires... this is the time the
                                          ack is expected by */
 
   /* treap fields */

--- a/src/waltz/quic/fd_quic_pretty_print.c
+++ b/src/waltz/quic/fd_quic_pretty_print.c
@@ -531,7 +531,7 @@ ip4_to_str( char buf[IP4_TO_STR_BUF_SZ], uint ip4_addr ) {
 
 ulong
 fd_quic_pretty_print_quic_pkt( fd_quic_pretty_print_t * pkt_ctx,
-                               ulong                    now,
+                               long                     now,
                                uchar const *            buf,
                                ulong                    buf_sz ) {
   (void)now;

--- a/src/waltz/quic/fd_quic_pretty_print.h
+++ b/src/waltz/quic/fd_quic_pretty_print.h
@@ -13,7 +13,7 @@ typedef struct fd_quic_pretty_print fd_quic_pretty_print_t;
 
 ulong
 fd_quic_pretty_print_quic_pkt( fd_quic_pretty_print_t * pkt_ctx,
-                               ulong                    now,
+                               long                     now,
                                uchar const *            buf,
                                ulong                    buf_sz );
 

--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -66,7 +66,7 @@ struct __attribute__((aligned(16UL))) fd_quic_state_private {
   /* Flags */
   ulong flags;
 
-  ulong now; /* the time we entered into fd_quic_service, or fd_quic_aio_cb_receive */
+  long now; /* recent timestamp, assumed in ns */
 
   /* transport_params: Template for QUIC-TLS transport params extension.
      Contains a mix of mutable and immutable fields.  Immutable fields
@@ -97,7 +97,7 @@ struct __attribute__((aligned(16UL))) fd_quic_state_private {
   fd_quic_pkt_meta_t    * pkt_meta_pool;
   fd_rng_t                _rng[1];        /* random number generator */
   fd_quic_svc_queue_t     svc_queue[ FD_QUIC_SVC_CNT ]; /* dlists */
-  ulong                   svc_delay[ FD_QUIC_SVC_CNT ]; /* target service delay */
+  long                    svc_delay[ FD_QUIC_SVC_CNT ]; /* target service delay */
 
   /* need to be able to access connections by index */
   ulong                   conn_base;      /* address of array of all connections */
@@ -130,7 +130,7 @@ struct fd_quic_pkt {
   /* the following are the "current" values only. There may be more QUIC packets
      in a UDP datagram */
   ulong              pkt_number;  /* quic packet number currently being decoded/parsed */
-  ulong              rcv_time;    /* time packet was received */
+  long               rcv_time;    /* time packet was received */
   uint               enc_level;   /* encryption level */
   uint               datagram_sz; /* length of the original datagram */
   uint               ack_flag;    /* ORed together: 0-don't ack  1-ack  2-cancel ack */
@@ -138,7 +138,7 @@ struct fd_quic_pkt {
 # define ACK_FLAG_CANCEL  2
 
   ulong              rtt_pkt_number; /* packet number used for rtt */
-  ulong              rtt_ack_time;
+  long               rtt_ack_time;
   ulong              rtt_ack_delay;
 };
 
@@ -192,7 +192,7 @@ fd_quic_conn_query( fd_quic_conn_map_t * map,
 void
 fd_quic_conn_service( fd_quic_t *      quic,
                       fd_quic_conn_t * conn,
-                      ulong            now );
+                      long             now );
 
 /* fd_quic_svc_schedule installs a connection timer.  svc_type is in
    [0,FD_QUIC_SVC_CNT) and specifies the timer delay.  Lower timers
@@ -280,11 +280,6 @@ fd_quic_apply_peer_params( fd_quic_conn_t *                   conn,
                            fd_quic_transport_params_t const * peer_tp );
 
 /* Helpers for calling callbacks **************************************/
-
-static inline ulong
-fd_quic_now( fd_quic_t * quic ) {
-  return quic->cb.now( quic->cb.now_ctx );
-}
 
 static inline void
 fd_quic_cb_conn_new( fd_quic_t *      quic,
@@ -426,36 +421,34 @@ fd_quic_conn_at_idx( fd_quic_state_t * quic_state, ulong idx ) {
 /* called with round-trip-time (rtt) and the ack delay (from the spec)
    to sample the round trip times. */
 static inline void
-fd_quic_sample_rtt( fd_quic_conn_t * conn, long rtt_ticks, long ack_delay ) {
+fd_quic_sample_rtt( fd_quic_conn_t * conn, long rtt_ns, long ack_delay ) {
   /* for convenience */
   fd_rtt_estimate_t * rtt = conn->rtt;
 
-  /* ack_delay is in peer units, so scale to put in ticks */
-  float ack_delay_ticks = (float)ack_delay * conn->peer_ack_delay_scale;
+  /* scale ack delay using peer exponent - rfc9000 19.3 */
+  float ack_delay_ns = (float)ack_delay * conn->peer_ack_delay_scale;
 
   /* bound ack_delay by peer_max_ack_delay */
-  ack_delay_ticks = fminf( ack_delay_ticks, conn->peer_max_ack_delay_ticks );
+  ack_delay_ns = fminf( ack_delay_ns, conn->peer_max_ack_delay_ns );
 
-  fd_rtt_sample( rtt, (float)rtt_ticks, ack_delay_ticks );
+  fd_rtt_sample( rtt, (float)rtt_ns, ack_delay_ns );
 
   FD_DEBUG({
-    double us_per_tick = 1.0 / (double)conn->quic->config.tick_per_us;
-    FD_LOG_NOTICE(( "conn_idx: %u  min_rtt: %f  smoothed_rtt: %f  var_rtt: %f  adj_rtt: %f  rtt_ticks: %f  ack_delay_ticks: %f  diff: %f",
-                      (uint)conn->conn_idx,
-                      us_per_tick * (double)rtt->min_rtt,
-                      us_per_tick * (double)rtt->smoothed_rtt,
-                      us_per_tick * (double)rtt->var_rtt,
-                      us_per_tick * (double)adj_rtt,
-                      us_per_tick * (double)rtt_ticks,
-                      us_per_tick * (double)ack_delay_ticks,
-                      us_per_tick * ( (double)rtt_ticks - (double)ack_delay_ticks ) ));
+    FD_LOG_NOTICE(( "conn_idx: %u  min_rtt: %f  smoothed_rtt: %f  var_rtt: %f  rtt_ns: %f  ack_delay_ns: %f  diff: %f",
+                    (uint)conn->conn_idx,
+                    (double)rtt->min_rtt,
+                    (double)rtt->smoothed_rtt,
+                    (double)rtt->var_rtt,
+                    (double)rtt_ns,
+                    (double)ack_delay_ns,
+                    ( (double)rtt_ns - (double)ack_delay_ns ) ));
   })
 }
 
 /* fd_quic_calc_expiry returns the timestamp of the next expiry event. */
 
-static inline ulong
-fd_quic_calc_expiry( fd_quic_conn_t * conn, ulong now ) {
+static inline long
+fd_quic_calc_expiry( fd_quic_conn_t * conn, long now ) {
   /* Instead of a full implementation of PTO, we're setting an expiry
      time per sent QUIC packet
      This calculates the expiry time according to the PTO spec
@@ -466,14 +459,14 @@ fd_quic_calc_expiry( fd_quic_conn_t * conn, ulong now ) {
 
   fd_rtt_estimate_t * rtt = conn->rtt;
 
-  ulong duration = (ulong)
+  long duration = (long)
     ( rtt->smoothed_rtt
         + (4.0f * rtt->var_rtt)
-        + conn->peer_max_ack_delay_ticks );
+        + conn->peer_max_ack_delay_ns );
 
   FD_DTRACE_PROBE_2( quic_calc_expiry, conn->our_conn_id, duration );
 
-  return now + (ulong)500e6; /* 500ms */
+  return now + (long)500e6; /* 500ms */
 }
 
 uchar *
@@ -490,7 +483,7 @@ fd_quic_process_ack_range( fd_quic_conn_t      *      conn,
                            ulong                      largest_ack,
                            ulong                      ack_range,
                            int                        is_largest,
-                           ulong                      now,
+                           long                       now,
                            ulong                      ack_delay );
 
 FD_PROTOTYPES_END

--- a/src/waltz/quic/fd_quic_retry.c
+++ b/src/waltz/quic/fd_quic_retry.c
@@ -65,7 +65,7 @@ fd_quic_retry_create(
     fd_quic_conn_id_t const * orig_dst_conn_id,
     fd_quic_conn_id_t const * src_conn_id,
     ulong                     new_conn_id,
-    ulong                     expire_at
+    long                      expire_at
 ) {
 
   uchar * out_ptr  = retry;
@@ -99,8 +99,8 @@ fd_quic_retry_create(
 
   fd_quic_retry_data_new( &retry_token->data, rng );
   fd_quic_retry_data_set_ip4( &retry_token->data, src_ip4_addr );
-  retry_token->data.udp_port   = (ushort)src_udp_port;
-  retry_token->data.expire_comp = expire_at >> FD_QUIC_RETRY_EXPIRE_SHIFT;
+  retry_token->data.udp_port    = (ushort)src_udp_port;
+  retry_token->data.expire_comp = (ulong)( expire_at >> FD_QUIC_RETRY_EXPIRE_SHIFT );
 
   retry_token->data.rscid    = new_conn_id;
   retry_token->data.odcid_sz = orig_dst_conn_id->sz;
@@ -149,8 +149,8 @@ fd_quic_retry_server_verify(
     ulong *                   retry_src_conn_id, /* out */
     uchar const               retry_secret[ FD_QUIC_RETRY_SECRET_SZ ],
     uchar const               retry_iv[ FD_QUIC_RETRY_IV_SZ ],
-    ulong                     now,
-    ulong                     ttl
+    long                      now,
+    long                      ttl
 ) {
 
   /* We told the client to retry with a DCID chosen by us, and we
@@ -181,8 +181,8 @@ fd_quic_retry_server_verify(
   int   is_ip4        = 0==memcmp( retry_token->data.ip6_addr, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff", 12 );
   uint  pkt_port      = fd_ushort_bswap( (ushort)pkt->udp->net_sport );
   uint  retry_port    = retry_token->data.udp_port;
-  ulong expire_at     = retry_token->data.expire_comp << FD_QUIC_RETRY_EXPIRE_SHIFT;
-  ulong expire_before = now + ttl;
+  long  expire_at     = (long)retry_token->data.expire_comp << FD_QUIC_RETRY_EXPIRE_SHIFT;
+  long  expire_before = now + ttl;
 
   int is_match =
     vfy_res == FD_QUIC_SUCCESS &&

--- a/src/waltz/quic/fd_quic_retry.h
+++ b/src/waltz/quic/fd_quic_retry.h
@@ -214,7 +214,7 @@ fd_quic_retry_create(
     fd_quic_conn_id_t const * orig_dst_conn_id,
     fd_quic_conn_id_t const * src_conn_id,
     ulong                     retry_src_conn_id,
-    ulong                     expire_at
+    long                      expire_at
 );
 
 int
@@ -225,8 +225,8 @@ fd_quic_retry_server_verify(
     ulong *                   retry_src_conn_id, /* out */
     uchar const               retry_secret[ FD_QUIC_RETRY_SECRET_SZ ],
     uchar const               retry_iv[ FD_QUIC_RETRY_IV_SZ ],
-    ulong                     now,
-    ulong                     ttl
+    long                      now,
+    long                      ttl
 );
 
 int

--- a/src/waltz/quic/fd_quic_svc_q.c
+++ b/src/waltz/quic/fd_quic_svc_q.c
@@ -132,7 +132,7 @@ fd_quic_svc_timers_validate( fd_quic_svc_timers_t * timers,
 
 fd_quic_svc_event_t
 fd_quic_svc_timers_next( fd_quic_svc_timers_t * timers,
-                         ulong                  now,
+                         long                   now,
                          int                    pop ) {
   fd_quic_svc_event_t next = { .timeout = ULONG_MAX, .conn = NULL };
 

--- a/src/waltz/quic/fd_quic_svc_q.h
+++ b/src/waltz/quic/fd_quic_svc_q.h
@@ -8,7 +8,7 @@
 
 struct fd_quic_svc_timers_conn_meta {
   ulong idx;           /* points to idx in heap, caller should not modify */
-  ulong next_timeout;  /* next timeout for this connection */
+  long  next_timeout;  /* next timeout for this connection */
 };
 typedef struct fd_quic_svc_timers_conn_meta fd_quic_svc_timers_conn_meta_t;
 
@@ -80,7 +80,7 @@ fd_quic_svc_cancel( fd_quic_svc_timers_t * timers,
    Returns NULL conn if queue empty. */
 fd_quic_svc_event_t
 fd_quic_svc_timers_next( fd_quic_svc_timers_t * timers,
-                         ulong                  now,
+                         long                   now,
                          int                    pop );
 
 

--- a/src/waltz/quic/log/fd_quic_log_tx.h
+++ b/src/waltz/quic/log/fd_quic_log_tx.h
@@ -165,7 +165,7 @@ static inline void
 fd_quic_log_tx_submit( fd_quic_log_tx_t * tx,
                        ulong              sz,     /* in [0,FD_QUIC_LOG_BUF_MTU) */
                        ulong              sig,    /* see fd_quic_log_sig() */
-                       long               ts ) {  /* usually fd_tickcount() */
+                       long               ts ) {
   fd_frag_meta_t * mcache  = tx->mcache;
   ulong            chunk   = tx->chunk;
   ulong            depth   = tx->depth;

--- a/src/waltz/quic/tests/fd_quic_sandbox.h
+++ b/src/waltz/quic/tests/fd_quic_sandbox.h
@@ -33,7 +33,7 @@ struct fd_quic_sandbox {
   ulong  pkt_seq_r;   /* seq no of next packet not yet read */
   ulong  pkt_seq_w;   /* seq no of next packet to publish */
   ulong  pkt_chunk;   /* publisher chunk index */
-  ulong  wallclock;   /* time as seen by fd_quic (ns) */
+  long   wallclock;   /* time as seen by fd_quic (ns) */
 };
 
 typedef struct fd_quic_sandbox fd_quic_sandbox_t;

--- a/src/waltz/quic/tests/fd_quic_test_helpers.c
+++ b/src/waltz/quic/tests/fd_quic_test_helpers.c
@@ -123,7 +123,6 @@ fd_quic_config_anonymous( fd_quic_t * quic,
   quic->cb.stream_notify    = fd_quic_test_cb_stream_notify;
   quic->cb.stream_rx        = fd_quic_test_cb_stream_rx;
   quic->cb.tls_keylog       = fd_quic_test_cb_tls_keylog;
-  quic->cb.now_ctx          = NULL;
 }
 
 void
@@ -147,6 +146,7 @@ fd_quic_new_anonymous( fd_wksp_t *              wksp,
   FD_TEST( quic );
 
   fd_quic_config_anonymous( quic, role );
+  fd_quic_get_state( quic )->now = 1L;
 
   fd_tls_test_sign_ctx_t * sign_ctx = fd_wksp_alloc_laddr( wksp, alignof(fd_tls_test_sign_ctx_t), sizeof(fd_tls_test_sign_ctx_t), 1UL );
   fd_tls_test_sign_ctx( sign_ctx, rng );

--- a/src/waltz/quic/tests/fd_quic_test_helpers.h
+++ b/src/waltz/quic/tests/fd_quic_test_helpers.h
@@ -2,6 +2,7 @@
 #define HEADER_fd_src_waltz_quic_tests_fd_quic_helpers_h
 
 #include "../fd_quic.h"
+#include "../fd_quic_private.h"
 #include "../../aio/fd_aio_pcapng.h"
 #include "../../udpsock/fd_udpsock.h"
 #include "../../tls/test_tls_helper.h"

--- a/src/waltz/quic/tests/fuzz_quic.c
+++ b/src/waltz/quic/tests/fuzz_quic.c
@@ -86,7 +86,7 @@ uint send_packet(uchar const *payload, size_t payload_sz) {
   cur_ptr += (ulong)payload_sz;
   cur_sz -= (ulong)payload_sz;
 
-  fd_quic_process_packet( server_quic, scratch, scratch_sz - cur_sz );
+  fd_quic_process_packet( server_quic, scratch, scratch_sz - cur_sz, 1L );
 
   return FD_QUIC_SUCCESS; /* success */
 }

--- a/src/waltz/quic/tests/test_quic_ack_tx.c
+++ b/src/waltz/quic/tests/test_quic_ack_tx.c
@@ -9,7 +9,6 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
-  float tick_per_us = 1000.0f;
 
   fd_quic_ack_gen_t gen[1];
 
@@ -79,19 +78,19 @@ main( int     argc,
   gen->is_elicited = 1;
 
   /* requested wrong encryption level */
-  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+sizeof(buf), 1U, 2009UL, tick_per_us )==buf );
+  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+sizeof(buf), 1U, 2009UL )==buf );
   FD_TEST( gen->tail==0UL && gen->head==FD_QUIC_ACK_QUEUE_CNT );
   FD_TEST( gen->is_elicited==1 );
 
   /* not enough buffer space */
   for( ulong j=0UL; j<=4UL; j++ ) {
-    FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+j, 0U, 2009UL, tick_per_us )==buf );
+    FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+j, 0U, 2009UL )==buf );
     FD_TEST( gen->tail==0UL && gen->head==FD_QUIC_ACK_QUEUE_CNT );
     FD_TEST( gen->is_elicited==1 );
   }
 
   /* generate one frame */
-  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+16, 0U, 2011UL, tick_per_us )==buf+5UL );
+  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+16, 0U, 2011UL )==buf+5UL );
   FD_TEST( gen->tail==1UL && gen->head==FD_QUIC_ACK_QUEUE_CNT );
   fd_quic_ack_frame_t ack_frame[2];
   FD_TEST( fd_quic_decode_ack_frame( ack_frame, buf, 5UL )==5UL );
@@ -104,7 +103,7 @@ main( int     argc,
 
   /* generate two frames */
   gen->tail = 0UL;
-  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+sizeof(buf), 0U, 2011UL, tick_per_us )==buf+10UL );
+  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+sizeof(buf), 0U, 2011UL )==buf+10UL );
   FD_TEST( gen->tail==2UL && gen->head==FD_QUIC_ACK_QUEUE_CNT );
   FD_TEST( fd_quic_decode_ack_frame( ack_frame,   buf,     128UL )==5UL );
   FD_TEST( fd_quic_decode_ack_frame( ack_frame+1, buf+5UL, 128UL )==5UL );
@@ -117,7 +116,7 @@ main( int     argc,
 
   /* generate last frame */
   gen->tail = gen->head - 1;
-  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+sizeof(buf), 2U, 1UL, tick_per_us )==buf+6UL );
+  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+sizeof(buf), 2U, 1UL )==buf+6UL );
   FD_TEST( gen->tail==gen->head );
   FD_TEST( fd_quic_decode_ack_frame( ack_frame, buf, 128UL )==6UL );
   FD_TEST( ack_frame[0].type           ==0x02 );
@@ -129,7 +128,7 @@ main( int     argc,
 
   /* refuse to generate ACK frames when no ACK eliciting frame was received */
   gen->tail = gen->head - 1;
-  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+sizeof(buf), 2U, 1UL, tick_per_us )==buf );
+  FD_TEST( fd_quic_gen_ack_frames( gen, buf, buf+sizeof(buf), 2U, 1UL )==buf );
   FD_TEST( gen->tail==gen->head-1 );
   FD_TEST( gen->is_elicited==0 );
 

--- a/src/waltz/quic/tests/test_quic_hs.c
+++ b/src/waltz/quic/tests/test_quic_hs.c
@@ -58,8 +58,8 @@ validate_quic_hs_tls_cache( fd_quic_t * quic ) {
   fd_quic_tls_hs_cache_t * hs_cache  =  &state->hs_cache;
   fd_quic_tls_hs_t       * pool      =  state->hs_pool;
 
-  ulong  cache_cnt  = 0UL;
-  ulong  prev_birth = 0UL;
+  ulong cache_cnt  = 0UL;
+  long  prev_birth = 0L;
   for( fd_quic_tls_hs_cache_iter_t iter = fd_quic_tls_hs_cache_iter_fwd_init( hs_cache, pool );
       !fd_quic_tls_hs_cache_iter_done( iter, hs_cache, pool );
       iter = fd_quic_tls_hs_cache_iter_fwd_next( iter, hs_cache, pool )
@@ -75,12 +75,7 @@ validate_quic_hs_tls_cache( fd_quic_t * quic ) {
 
 
 /* global "clock" */
-ulong now = 123;
-
-ulong test_clock( void * ctx ) {
-  (void)ctx;
-  return now;
-}
+long now = 123;
 
 int
 main( int argc, char ** argv ) {
@@ -125,11 +120,9 @@ main( int argc, char ** argv ) {
   fd_quic_t * client_quic = fd_quic_new_anonymous( wksp, &quic_limits, FD_QUIC_ROLE_CLIENT, rng );
   FD_TEST( client_quic );
 
-  server_quic->cb.now              = test_clock;
   server_quic->cb.conn_new         = my_connection_new;
   server_quic->cb.stream_rx        = my_stream_rx_cb;
 
-  client_quic->cb.now              = test_clock;
   client_quic->cb.conn_hs_complete = my_handshake_complete;
 
   server_quic->config.initial_rx_max_stream_data = 1<<16;
@@ -142,18 +135,19 @@ main( int argc, char ** argv ) {
   FD_LOG_NOTICE(( "Initializing QUICs" ));
   FD_TEST( fd_quic_init( server_quic ) );
   FD_TEST( fd_quic_init( client_quic ) );
+  fd_quic_get_state( server_quic )->now = fd_quic_get_state( client_quic )->now = now;
   fd_quic_svc_validate( server_quic );
   fd_quic_svc_validate( client_quic );
 
   FD_LOG_NOTICE(( "Creating connection" ));
-  fd_quic_conn_t * client_conn = fd_quic_connect( client_quic, 0U, 0, 0U, 0 );
+  fd_quic_conn_t * client_conn = fd_quic_connect( client_quic, 0U, 0, 0U, 0, now );
   FD_TEST( client_conn );
 
   /* do general processing */
   for( ulong j = 0; j < 20; j++ ) {
     FD_LOG_INFO(( "running services" ));
-    fd_quic_service( client_quic );
-    fd_quic_service( server_quic );
+    fd_quic_service( client_quic, now );
+    fd_quic_service( server_quic, now );
     validate_quic_hs_tls_cache( client_quic );
     validate_quic_hs_tls_cache( server_quic );
 
@@ -163,6 +157,7 @@ main( int argc, char ** argv ) {
     }
   }
 
+  fflush( fd_quic_test_pcap );
   FD_TEST( server_complete && client_complete );
 
   /* TODO detect missing QUIC transport params */
@@ -185,8 +180,8 @@ main( int argc, char ** argv ) {
   for( unsigned j = 0; j < 16; ++j ) {
     FD_LOG_INFO(( "running services" ));
 
-    fd_quic_service( client_quic );
-    fd_quic_service( server_quic );
+    fd_quic_service( client_quic, now );
+    fd_quic_service( server_quic, now );
 
     buf[12] = ' ';
     //buf[15] = (char)( ( j / 10 ) + '0' );
@@ -212,8 +207,8 @@ main( int argc, char ** argv ) {
 
   for( uint j=0; j<10U; ++j ) {
     FD_LOG_INFO(( "running services" ));
-    fd_quic_service( client_quic );
-    fd_quic_service( server_quic );
+    fd_quic_service( client_quic, now );
+    fd_quic_service( server_quic, now );
   }
 
   fd_quic_svc_validate( server_quic );
@@ -233,7 +228,7 @@ main( int argc, char ** argv ) {
 
   /* fill buffer, no eviction or failure */
   for( int i=0; i<10; ++i ) {
-    FD_TEST( fd_quic_connect( client_quic, 0U, 0, 0U, 0 ) );
+    FD_TEST( fd_quic_connect( client_quic, 0U, 0, 0U, 0, now ) );
     FD_TEST( client_quic->metrics.hs_evicted_cnt == prev_evicted );
   }
   FD_TEST( !fd_quic_tls_hs_pool_free( client_state->hs_pool ) );
@@ -242,14 +237,14 @@ main( int argc, char ** argv ) {
   now++;
   /* new connection should fail because within TTL of 5 */
   ulong prev_fail = client_quic->metrics.hs_err_alloc_fail_cnt;
-  FD_TEST( !fd_quic_connect( client_quic, 0U, 0, 0U, 0 ) );
+  FD_TEST( !fd_quic_connect( client_quic, 0U, 0, 0U, 0, now ) );
   FD_TEST( client_quic->metrics.hs_err_alloc_fail_cnt == prev_fail+1 );
   validate_quic_hs_tls_cache( client_quic );
 
   FD_LOG_NOTICE(( "Testing TLS cache - evicts if over ttl " ));
   now+=10;
   FD_TEST( !fd_quic_tls_hs_pool_free( client_state->hs_pool ) );
-  FD_TEST( fd_quic_connect( client_quic, 0U, 0, 0U, 0 ) );
+  FD_TEST( fd_quic_connect( client_quic, 0U, 0, 0U, 0, now ) );
   validate_quic_hs_tls_cache( client_quic );
   FD_TEST( client_quic->metrics.hs_evicted_cnt == prev_evicted+1 );
 

--- a/src/waltz/quic/tests/test_quic_idle_conns.c
+++ b/src/waltz/quic/tests/test_quic_idle_conns.c
@@ -76,15 +76,17 @@ run_quic_client( fd_quic_t *         quic,
   fd_quic_set_aio_net_tx( quic, udpsock->aio );
   FD_TEST( fd_quic_init( quic ) );
 
-  ulong out_time = (ulong)fd_log_wallclock() + (ulong)1e9;
+  long out_time = fd_log_wallclock() + (long)1e9;
 
   while( 1 ) {
-    fd_quic_service( quic );
+    long now = fd_log_wallclock();
+
+    fd_quic_service( quic, now );
     fd_quic_udpsock_service( udpsock );
 
     if( g_dead > 0 ) {
       /* start a new connection */
-      fd_quic_conn_t * conn = fd_quic_connect( quic, dst_ip, dst_port, 0U, 0 );
+      fd_quic_conn_t * conn = fd_quic_connect( quic, dst_ip, dst_port, 0U, 0, now );
 
       if( conn ) {
         g_conn_meta[conn->conn_idx].conn     = conn;
@@ -99,10 +101,9 @@ run_quic_client( fd_quic_t *         quic,
     /* TODO send pings */
 
     /* output stats */
-    ulong now = (ulong)fd_log_wallclock();
     if( now > out_time ) {
       FD_LOG_NOTICE(( "connections: active: %lu  initializing: %lu", (ulong)g_active, (ulong)g_init ));
-      out_time = now + (ulong)1e9;
+      out_time = now + (long)1e9;
     }
   }
 

--- a/src/waltz/quic/tests/test_quic_key_phase.c
+++ b/src/waltz/quic/tests/test_quic_key_phase.c
@@ -53,14 +53,13 @@ fd_quic_conn_t * server_conn = NULL;
 
 void
 my_cb_conn_final( fd_quic_conn_t * conn,
-                  void *           context ) {
-  (void)context;
-
+                  void *           context  FD_PARAM_UNUSED) {
   fd_quic_conn_t ** ppconn = (fd_quic_conn_t**)fd_quic_conn_get_context( conn );
   if( ppconn ) {
     FD_LOG_INFO(( "my_cb_conn_final %p SUCCESS", (void*)*ppconn ));
     *ppconn = NULL;
-  }}
+  }
+}
 
 void
 my_connection_new( fd_quic_conn_t * conn,
@@ -89,19 +88,17 @@ my_handshake_complete( fd_quic_conn_t * conn,
 }
 
 /* global "clock" */
-static ulong now = (ulong)1e18;
-
-static ulong
-test_clock( void * ctx ) {
-  (void)ctx;
-  return now;
-}
+static long now = 1e18L;
 
 static long
 test_fibre_clock(void) {
-  return (long)now;
+  return now;
 }
 
+static void
+sync_clocks( fd_quic_t * x, fd_quic_t * y ) {
+  fd_quic_get_state( x )->now = fd_quic_get_state( y )->now = now; /* keep clocks synced */
+}
 
 struct client_args {
   fd_quic_t * quic;
@@ -113,34 +110,37 @@ static void
 client_fibre_fn( void * vp_arg ) {
   client_args_t * args = (client_args_t*)vp_arg;
 
-  fd_quic_t * quic = args->quic;
+  fd_quic_t * quic        = args->quic;
+  fd_quic_t * server_quic = args->server_quic;
 
   fd_quic_conn_t *   conn   = NULL;
   fd_quic_stream_t * stream = NULL;
 
   static uchar const buf[] = "Hello World!";
 
-  ulong period_ns = (ulong)1e6;
-  ulong next_send = now;
+  long  period_ns = (long)1e6;
+  long  next_send = now;
   ulong sent      = 0;
 
   rcvd = sent = 0;
 
-  conn = fd_quic_connect( quic, 0U, 0, 0U, 0 );
+  conn = fd_quic_connect( quic, 0U, 0, 0U, 0, now );
   if( !conn ) {
-    FD_LOG_ERR(( "Client unable to obtain a connection. now: %lu", (ulong)now ));
+    FD_LOG_ERR(( "Client unable to obtain a connection. now: %ld", now ));
   }
 
   fd_quic_conn_set_context( conn, &conn );
 
   /* service client until connection is established */
   while( conn && conn->state != FD_QUIC_CONN_STATE_ACTIVE ) {
-    fd_quic_service( quic );
+    sync_clocks( quic, server_quic );
+    fd_quic_service( quic, now );
 
-    ulong next_wakeup = fd_quic_get_next_wakeup( quic );
+    long next_wakeup = fd_quic_get_next_wakeup( quic );
+    FD_TEST( next_wakeup < LONG_MAX );
 
     /* wake up at either next service or next send, whichever is sooner */
-    fd_fibre_wait_until( (long)next_wakeup );
+    fd_fibre_wait_until( next_wakeup );
   }
 
   next_send = now;
@@ -150,12 +150,14 @@ client_fibre_fn( void * vp_arg ) {
   FD_LOG_INFO(( "CLIENT - connection established - key_phase: %u", (uint)conn->key_phase ));
 
   while( !client_done ) {
-    ulong next_wakeup = fd_quic_get_next_wakeup( quic );
+    long next_wakeup = fd_quic_get_next_wakeup( quic );
+    FD_TEST( next_wakeup < LONG_MAX );
 
     /* wake up at either next service or next send, whichever is sooner */
-    fd_fibre_wait_until( (long)fd_ulong_min( next_wakeup, next_send ) );
+    fd_fibre_wait_until( fd_long_min( next_wakeup, next_send ) );
 
-    fd_quic_service( quic );
+    sync_clocks( quic, server_quic );
+    fd_quic_service( quic, now );
 
     /* in this controlled test, connections should not terminate */
     if( !conn ) {
@@ -164,10 +166,10 @@ client_fibre_fn( void * vp_arg ) {
 
     /* report key phase changes, when complete */
     if( !conn->key_update && last_key_phase != conn->key_phase ) {
-      FD_LOG_INFO(( "CLIENT - key phase changed to %u", (uint)conn->key_phase ));
+      tot_key_phase_change++;
+      FD_LOG_INFO(( "CLIENT - key phase changed to %u, %lu changes done", (uint)conn->key_phase, tot_key_phase_change ));
       last_key_phase = conn->key_phase;
 
-      tot_key_phase_change++;
       if( tot_key_phase_change == NUM_KEY_PHASE_CHANGES ) {
         client_done = 1;
       }
@@ -219,7 +221,8 @@ client_fibre_fn( void * vp_arg ) {
 
     /* keep servicing until connection closed */
     while( conn ) {
-      fd_quic_service( quic );
+      sync_clocks( quic, server_quic );
+      fd_quic_service( quic, now );
       fd_fibre_yield();
     }
   }
@@ -231,23 +234,26 @@ client_fibre_fn( void * vp_arg ) {
 
 struct server_args {
   fd_quic_t * quic;
+  fd_quic_t * client_quic;
 };
 typedef struct server_args server_args_t;
 
 
 static void
 server_fibre_fn( void * vp_arg ) {
-  server_args_t * args = (server_args_t*)vp_arg;
+  server_args_t * args = fd_type_pun( vp_arg );
 
   fd_quic_t * quic = args->quic;
+  fd_quic_t * client_quic = args->client_quic;
 
   /* track key phase changes */
   uint last_key_phase = -1u;
 
   /* wake up at least every 1ms */
-  ulong period_ns = (ulong)1e6;
+  long period_ns = (long)1e6;
   while( !server_done ) {
-    fd_quic_service( quic );
+    sync_clocks( quic, client_quic );
+    fd_quic_service( quic, now );
 
     if( server_conn ) {
       if( last_key_phase == -1u ) {
@@ -259,10 +265,10 @@ server_fibre_fn( void * vp_arg ) {
       }
     }
 
-    ulong next_wakeup = fd_quic_get_next_wakeup( quic );
-    ulong next_period = now + period_ns;
+    long next_wakeup = fd_quic_get_next_wakeup( quic );
+    long next_period = now + period_ns;
 
-    fd_fibre_wait_until( (long)fd_ulong_min( next_wakeup, next_period ) );
+    fd_fibre_wait_until( fd_long_min( next_wakeup, next_period ) );
   }
 }
 
@@ -314,18 +320,13 @@ main( int argc, char ** argv ) {
 
   client_quic->cb.conn_hs_complete = my_handshake_complete;
   client_quic->cb.conn_final       = my_cb_conn_final;
-
-  client_quic->cb.now     = test_clock;
-  client_quic->cb.now_ctx = NULL;
+  client_quic->cb.quic_ctx         = &client_quic;
 
   client_quic->config.initial_rx_max_stream_data = 1<<15;
 
   server_quic->cb.conn_new       = my_connection_new;
   server_quic->cb.stream_rx      = my_stream_rx_cb;
   server_quic->cb.conn_final     = my_cb_conn_final;
-
-  server_quic->cb.now     = test_clock;
-  server_quic->cb.now_ctx = NULL;
 
   server_quic->config.initial_rx_max_stream_data = 1<<15;
 
@@ -351,7 +352,7 @@ main( int argc, char ** argv ) {
   FD_TEST( client_fibre );
 
   void * server_mem = fd_wksp_alloc_laddr( wksp, fd_fibre_start_align(), fd_fibre_start_footprint( stack_sz ), 1UL );
-  server_args_t server_args[1] = {{ .quic = server_quic }};
+  server_args_t server_args[1] = {{ .quic = server_quic, .client_quic = client_quic }};
   server_fibre = fd_fibre_start( server_mem, stack_sz, server_fibre_fn, server_args );
   FD_TEST( server_fibre );
 
@@ -365,7 +366,7 @@ main( int argc, char ** argv ) {
     long timeout = fd_fibre_schedule_run();
     if( timeout < 0 ) break;
 
-    now = (ulong)timeout;
+    now = timeout;
   }
 
   FD_LOG_NOTICE(( "Passed %lu key updates", tot_key_phase_change ));

--- a/src/waltz/quic/tests/test_quic_pkt_meta.c
+++ b/src/waltz/quic/tests/test_quic_pkt_meta.c
@@ -64,7 +64,7 @@ test_adversarial_ack( ulong max_inflight,
     fd_quic_pkt_meta_ds_t * sent_pkt_metas = &conn.pkt_meta_tracker.sent_pkt_metas[fd_quic_enc_level_appdata_id];
 
     ulong highest_known = max_inflight - 1;
-    long start = fd_tickcount();
+    long start = fd_log_wallclock();
     ulong cnt;
     while( ( cnt = fd_quic_pkt_meta_ds_ele_cnt( sent_pkt_metas ) ) > 0) {
     /* let's send the largest range_sz values */
@@ -104,7 +104,7 @@ test_adversarial_ack( ulong max_inflight,
         0
       );
     }
-    long end = fd_tickcount();
+    long end = fd_log_wallclock();
     FD_LOG_NOTICE(( "Very adversarial: Time taken: %ld us", (end - start) / 1000 ));
   } while(0);
 
@@ -114,7 +114,7 @@ test_adversarial_ack( ulong max_inflight,
     fd_quic_pkt_meta_ds_t * sent_pkt_metas = &conn.pkt_meta_tracker.sent_pkt_metas[fd_quic_enc_level_appdata_id];
     fd_quic_pkt_meta_t    * pool           = fd_quic_get_state( quic )->pkt_meta_pool;
 
-    long start = fd_tickcount();
+    long start = fd_log_wallclock();
     ulong cnt;
     while( ( cnt = fd_quic_pkt_meta_ds_ele_cnt( sent_pkt_metas ) ) > 0 ) {
       fd_quic_pkt_meta_ds_fwd_iter_t start = fd_quic_pkt_meta_ds_fwd_iter_init( sent_pkt_metas, pool );
@@ -146,7 +146,7 @@ test_adversarial_ack( ulong max_inflight,
       );
 
     }
-    long end = fd_tickcount();
+    long end = fd_log_wallclock();
     FD_LOG_NOTICE(( "Reasonable reordering: Time taken: %ld us", (end - start) / 1000 ));
   } while(0);
 
@@ -157,7 +157,7 @@ test_adversarial_ack( ulong max_inflight,
     fd_quic_pkt_meta_ds_t * sent_pkt_metas = &conn.pkt_meta_tracker.sent_pkt_metas[fd_quic_enc_level_appdata_id];
     fd_quic_pkt_meta_t    * pool           = fd_quic_get_state( conn.quic )->pkt_meta_pool;
 
-    long start = fd_tickcount();
+    long start = fd_log_wallclock();
     ulong cnt;
     while( ( cnt = fd_quic_pkt_meta_ds_ele_cnt( sent_pkt_metas ) ) > 0 ) {
       fd_quic_pkt_meta_ds_fwd_iter_t start = fd_quic_pkt_meta_ds_fwd_iter_init( sent_pkt_metas, pool );
@@ -176,9 +176,9 @@ test_adversarial_ack( ulong max_inflight,
         0
       );
 
-      }
-      long end = fd_tickcount();
-      FD_LOG_NOTICE(( "Happy case: Time taken: %ld us", (end - start) / 1000 ));
+    }
+    long end = fd_log_wallclock();
+    FD_LOG_NOTICE(( "Happy case: Time taken: %ld us", (end - start) / 1000 ));
   } while(0);
 }
 

--- a/src/waltz/quic/tests/test_quic_retry_integration.c
+++ b/src/waltz/quic/tests/test_quic_retry_integration.c
@@ -54,16 +54,13 @@ my_handshake_complete( fd_quic_conn_t * conn,
 
 
 /* global "clock" */
-ulong now = 123;
+long now = 123;
 
-ulong test_clock( void * ctx ) {
-  (void)ctx;
-  return now;
-}
-
-/* Test that server responds with Retry packet when receiving Initial with 46-byte token */
+/* Test that server responds with Retry packet when receiving Initial
+   with a token that has a size that we couldn't have possibly emitted. */
 void
-test_initial_with_46_byte_token( fd_quic_t * server_quic, fd_quic_t * client_quic ) {
+test_initial_token_odd_sz( fd_quic_t * server_quic,
+                           fd_quic_t * client_quic ) {
   FD_LOG_NOTICE(( "Testing Initial packet with 46-byte token" ));
 
   /* Create an arbitrary 46-byte token */
@@ -78,7 +75,7 @@ test_initial_with_46_byte_token( fd_quic_t * server_quic, fd_quic_t * client_qui
   ulong conn_created_count = server_quic->metrics.conn_created_cnt;
 
   /* Create a new connection with 46-byte token */
-  fd_quic_conn_t * client_conn = fd_quic_connect( client_quic, 0U, 0, 0U, 0 );
+  fd_quic_conn_t * client_conn = fd_quic_connect( client_quic, 0U, 0, 0U, 0, now );
   FD_TEST( client_conn );
 
   /* Override the token in the connection state to be our 46-byte token */
@@ -87,8 +84,8 @@ test_initial_with_46_byte_token( fd_quic_t * server_quic, fd_quic_t * client_qui
 
   /* Process packets - should trigger retry response */
   for( ulong j = 0; j < 5; j++ ) {
-    fd_quic_service( client_quic );
-    fd_quic_service( server_quic );
+    fd_quic_service( client_quic, now );
+    fd_quic_service( server_quic, now );
   }
 
   /* Verify server sent a retry packet (difference-based check) */
@@ -105,17 +102,18 @@ test_initial_with_46_byte_token( fd_quic_t * server_quic, fd_quic_t * client_qui
 }
 
 void
-test_retry_integration( fd_quic_t * server_quic, fd_quic_t * client_quic ) {
+test_retry_integration( fd_quic_t * server_quic,
+                        fd_quic_t * client_quic ) {
 
   FD_LOG_NOTICE(( "Creating connection" ));
-  fd_quic_conn_t * client_conn = fd_quic_connect( client_quic, 0U, 0, 0U, 0 );
+  fd_quic_conn_t * client_conn = fd_quic_connect( client_quic, 0U, 0, 0U, 0, now );
   FD_TEST( client_conn );
 
   /* do general processing */
   for( ulong j = 0; j < 20; j++ ) {
     FD_LOG_INFO(( "running services" ));
-    fd_quic_service( client_quic );
-    fd_quic_service( server_quic );
+    fd_quic_service( client_quic, now );
+    fd_quic_service( server_quic, now );
 
     if( server_complete && client_complete ) {
       FD_LOG_INFO(( "***** both handshakes complete *****" ));
@@ -159,8 +157,8 @@ test_retry_integration( fd_quic_t * server_quic, fd_quic_t * client_quic ) {
   for( unsigned j = 0; j < 16; ++j ) {
     FD_LOG_INFO(( "running services" ));
 
-    fd_quic_service( client_quic );
-    fd_quic_service( server_quic );
+    fd_quic_service( client_quic, now );
+    fd_quic_service( server_quic, now );
 
     buf[12] = ' ';
     //buf[15] = (char)( ( j / 10 ) + '0' );
@@ -184,8 +182,8 @@ test_retry_integration( fd_quic_t * server_quic, fd_quic_t * client_quic ) {
 
   for( uint j=0; j<10U; ++j ) {
     FD_LOG_INFO(( "running services" ));
-    fd_quic_service( client_quic );
-    fd_quic_service( server_quic );
+    fd_quic_service( client_quic, now );
+    fd_quic_service( server_quic, now );
   }
 
   FD_TEST( client_quic->metrics.conn_created_cnt== 1 );
@@ -236,12 +234,10 @@ main( int argc, char ** argv ) {
   fd_quic_t * client_quic = fd_quic_new_anonymous( wksp, &quic_limits, FD_QUIC_ROLE_CLIENT, rng );
   FD_TEST( client_quic );
 
-  server_quic->cb.now              = test_clock;
   server_quic->cb.conn_new         = my_connection_new;
   server_quic->cb.stream_rx        = my_stream_rx_cb;
   server_quic->config.retry = 1;
 
-  client_quic->cb.now              = test_clock;
   client_quic->cb.conn_hs_complete = my_handshake_complete;
 
   server_quic->config.initial_rx_max_stream_data = 1<<16;
@@ -259,7 +255,7 @@ main( int argc, char ** argv ) {
   test_retry_integration( server_quic, client_quic );
 
   /* Run the 46-byte token test */
-  test_initial_with_46_byte_token( server_quic, client_quic );
+  test_initial_token_odd_sz( server_quic, client_quic );
 
   FD_LOG_NOTICE(( "Cleaning up" ));
   fd_quic_virtual_pair_fini( &vp );

--- a/src/waltz/quic/tests/test_quic_retry_unit.c
+++ b/src/waltz/quic/tests/test_quic_retry_unit.c
@@ -102,13 +102,13 @@ bench_retry_create( void ) {
   uchar aes_iv [16] = {2};
   ulong ttl         = (ulong)3e9;
 
-  fd_quic_retry_create( retry, &pkt, rng, aes_key, aes_iv, &orig_dst_conn_id, &peer_src_conn_id, retry_src_conn_id, 7315969UL+(ulong)ttl );
+  fd_quic_retry_create( retry, &pkt, rng, aes_key, aes_iv, &orig_dst_conn_id, &peer_src_conn_id, retry_src_conn_id, 7315969L+(long)ttl );
   FD_LOG_HEXDUMP_INFO(( "Retry Token", retry+0x1f, sizeof(fd_quic_retry_token_t) ));
 
   long dt = -fd_log_wallclock();
   ulong iter = 1000000UL;
   for( ulong j=0UL; j<iter; j++ ) {
-    fd_quic_retry_create( retry, &pkt, rng, aes_key, aes_iv, &orig_dst_conn_id, &peer_src_conn_id, retry_src_conn_id, 1UL+(ulong)ttl );
+    fd_quic_retry_create( retry, &pkt, rng, aes_key, aes_iv, &orig_dst_conn_id, &peer_src_conn_id, retry_src_conn_id, 1L+(long)ttl );
     FD_COMPILER_UNPREDICTABLE( retry[0] );
   }
   dt += fd_log_wallclock();
@@ -146,8 +146,8 @@ bench_retry_server_verify( void ) {
 
   uchar aes_key[16] = {1};
   uchar aes_iv [16] = {2};
-  ulong now         = 50UL;
-  ulong ttl         = (ulong)3e9;
+  long  now         = 50UL;
+  long  ttl         = (long)3e9;
 
   long dt = -fd_log_wallclock();
   ulong iter = 1000000UL;
@@ -247,8 +247,8 @@ test_retry_token_malleability( void ) {
   fd_quic_pkt_t const pkt = {0};
   uchar aes_key[16] = {1};
   uchar aes_iv [16] = {2};
-  ulong now         = 50UL;
-  ulong ttl         = (ulong)3e9;
+  long  now         = 50UL;
+  long  ttl         = (long)3e9;
   for( ulong j=0; j<sizeof(token); j++ ) {
     for( int i=0; i<8; i++ ) {
       retry[j] = (uchar)( initial.token[j] ^ (1<<i) );
@@ -281,7 +281,7 @@ test_retry_token_time( void ) {
   fd_quic_pkt_t const pkt = {0};
   uchar aes_key[16] = {1};
   uchar aes_iv [16] = {2};
-  ulong ttl         = (ulong)3e9;
+  long  ttl         = (long)3e9;
 
   fd_quic_conn_id_t odcid;
   ulong             rscid;
@@ -292,7 +292,7 @@ test_retry_token_time( void ) {
   TRY( 3007315967UL, FD_QUIC_SUCCESS );
   TRY( 3007315968UL, FD_QUIC_FAILED  );
   TRY( 3007315969UL, FD_QUIC_FAILED  );
-  TRY(    ULONG_MAX, FD_QUIC_FAILED  );
+  TRY(     LONG_MAX, FD_QUIC_FAILED  );
 # undef TRY
 }
 

--- a/src/waltz/quic/tests/test_quic_svc_q.c
+++ b/src/waltz/quic/tests/test_quic_svc_q.c
@@ -48,20 +48,20 @@ test_svc_schedule( fd_quic_svc_timers_t * timers,
   FD_LOG_NOTICE(( "Testing fd_quic_svc_schedule" ));
 
   /* Test basic scheduling */
-  ulong now = 1000UL;
-  conn->svc_meta.next_timeout = now + 100UL;
+  long now = 1000L;
+  conn->svc_meta.next_timeout = now + 100L;
   fd_quic_svc_schedule( timers, conn );
 
   /* Verify the connection is scheduled */
   FD_TEST( conn->svc_meta.idx != FD_QUIC_SVC_IDX_INVAL );
 
   /* Test rescheduling with earlier time */
-  conn->svc_meta.next_timeout = now + 50UL;
+  conn->svc_meta.next_timeout = now + 50L;
   fd_quic_svc_schedule( timers, conn );
   FD_TEST( conn->svc_meta.idx != FD_QUIC_SVC_IDX_INVAL );
 
   /* Test rescheduling with later time (should be ignored) */
-  conn->svc_meta.next_timeout = now + 150UL;
+  conn->svc_meta.next_timeout = now + 150L;
   fd_quic_svc_schedule( timers, conn );
 
   /* Verify we kept the earlier time */
@@ -77,7 +77,7 @@ test_svc_cancel( fd_quic_svc_timers_t * timers,
   FD_LOG_NOTICE(( "Testing fd_quic_svc_cancel" ));
 
   /* Schedule event */
-  ulong now = 1000UL;
+  long now = 1000UL;
   conn->svc_meta.next_timeout = now + 100UL;
   fd_quic_svc_schedule( timers, conn );
   FD_TEST( conn->svc_meta.idx != FD_QUIC_SVC_IDX_INVAL );
@@ -107,7 +107,7 @@ test_multiple_connections( fd_quic_svc_timers_t * timers,
     conns[i] = (fd_quic_conn_t *)(conn_base + i * conn_sz);
   }
 
-  ulong now = 1000UL;
+  long now = 1000UL;
 
   /* Schedule connections in order */
   for( int i=0; i<10; i++ ) {

--- a/src/waltz/quic/tests/test_quic_txns.c
+++ b/src/waltz/quic/tests/test_quic_txns.c
@@ -103,14 +103,15 @@ run_quic_client( fd_quic_t *         quic,
   FD_TEST( fd_quic_init( quic ) );
 
   while( 1 ) {
-    fd_quic_service( quic );
+    long now = fd_log_wallclock();
+    fd_quic_service( quic, now );
     fd_quic_udpsock_service( udpsock );
 
     if( !gbl_conn ) {
       /* if no connection, try making one */
       FD_LOG_NOTICE(( "Creating connection" ));
 
-      gbl_conn = fd_quic_connect( quic, dst_ip, dst_port, 0U, 0 );
+      gbl_conn = fd_quic_connect( quic, dst_ip, dst_port, 0U, 0, now );
 
       continue;
     }
@@ -157,7 +158,7 @@ run_quic_client( fd_quic_t *         quic,
 
   /* wait for connection to close */
   while( gbl_conn ) {
-    fd_quic_service( quic );
+    fd_quic_service( quic, fd_log_wallclock() );
     fd_quic_udpsock_service( udpsock );
   }
 

--- a/src/waltz/quic/tls/fd_quic_tls.c
+++ b/src/waltz/quic/tls/fd_quic_tls.c
@@ -150,7 +150,7 @@ fd_quic_tls_hs_new( fd_quic_tls_hs_t * self,
                     void *             context,
                     int                is_server,
                     fd_quic_transport_params_t const * self_transport_params,
-                    ulong              now ) {
+                    long               now ) {
   // clear the handshake bits
   fd_memset( self, 0, sizeof(fd_quic_tls_hs_t) );
 

--- a/src/waltz/quic/tls/fd_quic_tls.h
+++ b/src/waltz/quic/tls/fd_quic_tls.h
@@ -131,7 +131,7 @@ struct fd_quic_tls_hs {
 
   ulong           next;      /* alloc pool/cache dlist */
   ulong           prev;      /* cache dlist */
-  ulong           birthtime; /* allocation time, used for cache eviction sanity check */
+  long            birthtime; /* allocation time, used for cache eviction sanity check */
 
   /* handshake data
      this is data that must be sent to the peer
@@ -195,7 +195,7 @@ fd_quic_tls_hs_new( fd_quic_tls_hs_t * self,
                     void *             context,
                     int                is_server,
                     fd_quic_transport_params_t const * self_transport_params,
-                    ulong              now );
+                    long               now );
 
 void
 fd_quic_tls_hs_delete( fd_quic_tls_hs_t * hs );


### PR DESCRIPTION
This PR lets fd_quic forget about ticks and time domains, to avoid any further time domain conversion bugs. fd_quic now only speaks nanoseconds, and its callers are responsible for passing 'now' in ns (typically using fd_clock)

Primarily written by @ripatel-fd .