### PR TITLE
Add {timestamp} substitution to log.path config item

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -110,10 +110,11 @@ dynamic_port_range = "8900-9000"
     # appended to, or created if it does not already exist. The
     # shortened ephemeral log will always be written to stderr.
     #
-    # Two substitutions will be performed on this string.  If "{user}"
+    # Three substitutions will be performed on this string.  If "{user}"
     # is present it will be replaced with the user running Firedancer,
-    # as above, and "{name}" will be replaced with the name of the
-    # Firedancer instance.
+    # as above, "{name}" will be replaced with the name of the
+    # Firedancer instance, and "{timestamp}" will be replaced with the
+    # current time as a RFC 3339 format string (millisecond resolution).
     #
     # If no path is provided, the default is to place the log file in
     # /tmp with a name that will be unique.  If specified as "-", the

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -178,10 +178,11 @@ user = ""
     # appended to, or created if it does not already exist. The
     # shortened ephemeral log will always be written to stderr.
     #
-    # Two substitutions will be performed on this string.  If "{user}"
+    # Three substitutions will be performed on this string.  If "{user}"
     # is present it will be replaced with the user running Firedancer,
-    # as above, and "{name}" will be replaced with the name of the
-    # Firedancer instance.
+    # as above, "{name}" will be replaced with the name of the
+    # Firedancer instance, and "{timestamp}" will be replaced with the
+    # current time as a RFC 3339 format string (millisecond resolution).
     #
     # If no path is provided, the default is to place the log file in
     # /tmp with a name that will be unique.  If specified as "-", the

--- a/src/app/shared/fd_config.c
+++ b/src/app/shared/fd_config.c
@@ -13,6 +13,7 @@
 #include <stdlib.h> /* strtoul */
 #include <sys/utsname.h>
 #include <sys/mman.h>
+#include <time.h>
 
 /* TODO: Rewrite this ... */
 
@@ -241,6 +242,22 @@ fd_config_fill_net( fd_config_t * config ) {
   }
 }
 
+/* rfc3339_timestamp returns a RFC 3339 timestamp, millisecond resolution,
+   per https://datatracker.ietf.org/doc/html/rfc3339#section-5. */
+
+const char *
+rfc3339_timestamp( long nanos ) {
+    static char ts[26];
+    char        buf[20];
+    long        seconds = nanos / (long) 1e9;
+    long        millis = (long) ( nanos / (long) 1e6 ) % (long) 1e3;
+
+    strftime( buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S", gmtime( &seconds ) );
+    snprintf( ts, sizeof(ts), "%s.%03ldZ", buf, millis );
+
+    return ts;
+}
+
 void
 fd_config_fill( fd_config_t * config,
                 int           netns,
@@ -299,6 +316,8 @@ fd_config_fill( fd_config_t * config,
 
   replace( config->log.path, "{user}", config->user );
   replace( config->log.path, "{name}", config->name );
+  /* Useful for per-invocation logfiles (not useful for other items). */
+  replace( config->log.path, "{timestamp}", rfc3339_timestamp( config->boot_timestamp_nanos ) );
 
   if( FD_LIKELY( !strcmp( "auto", config->log.colorize ) ) )       config->log.colorize1 = 2;
   else if( FD_LIKELY( !strcmp( "true", config->log.colorize ) ) )  config->log.colorize1 = 1;


### PR DESCRIPTION
This substitution is intended to make it a lot easier for operators to achive "one log per invocation".  As the substitution's value is not easily predictable, it's only implemented for `log.path` where is it useful, and not for the other config items.

I've tested by editing `src/app/fdctl/config/default.toml` to set `log.path = "/tmp/foo-{timestamp}.log"`, then doing `make run` to confirm we get the expected result:

```
$ make run
[ ... ]

ERR     09-03 02:18:28.225454 2706686 f0   main src/app/shared_dev/commands/dev.c(67): Received signal SIGINT-Interrupt
Log at "/tmp/foo-2025-09-03T02:18:20.214Z.log"
make: *** [src/app/fddev/Local.mk:25: run] Error 130

$ ls -l /tmp/foo-2025-09-03T02\:18\:20.214Z.log
-rw-r--r--. 1 msuter msuter 381914 Sep  3 02:18 /tmp/foo-2025-09-03T02:18:20.214Z.log
```