### PR TITLE
chore: Fix Typos

### DIFF
--- a/src/wiredancer/platform/f1/design/cl_dram_dma.sv
+++ b/src/wiredancer/platform/f1/design/cl_dram_dma.sv
@@ -30,7 +30,7 @@ module cl_dram_dma #(parameter NUM_DDR=4)
 // TIE OFF ALL UNUSED INTERFACES
 // Including all the unused interface to tie off
 // This list is put in the top of the fie to remind
-// developers to remve the specific interfaces
+// developers to remove the specific interfaces
 // that the CL will use
 
 `include "unused_flr_template.inc"

--- a/src/wiredancer/rtl/schl_cpu.sv
+++ b/src/wiredancer/rtl/schl_cpu.sv
@@ -639,7 +639,7 @@ module shcl_cpu
           mem_t_wr_en   <= '0;
         end
       end
-      // Prioritize writes from ALU over input as we don't want to backpress the pipline...
+      // Prioritize writes from ALU over input as we don't want to backpress the pipeline...
       else if (mem_man_valid) begin 
         mem_d_wr_data <= mem_man_data;
         mem_d_wr_addr <= mem_man_addr;


### PR DESCRIPTION
### Summary

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `remve` → `remove`
  - `pipline` → `pipeline`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.