### PR TITLE
Fix /etc/localtime seccomp crash

### DIFF
--- a/src/disco/topo/fd_topo_run.c
+++ b/src/disco/topo/fd_topo_run.c
@@ -105,6 +105,10 @@ fd_topo_run_tile( fd_topo_t *          topo,
     rlimit_file_cnt = tile_run->rlimit_file_cnt_fn( topo, tile );
   }
 
+  /* Open /etc/localtime so it is available for fd_log later. */
+  char wallclock_cstr_dummy[ FD_LOG_WALLCLOCK_CSTR_BUF_SZ ];
+  fd_log_wallclock_cstr( 0L, wallclock_cstr_dummy );
+
   if( FD_LIKELY( sandbox ) ) {
     fd_sandbox_enter( uid,
                       gid,


### PR DESCRIPTION
Fixes an fdctl sandbox crash when logfile+stderr log levels are set
to WARNING or higher.

This is due to fd_log opening /etc/localtime on the first log
message, which has to happen _before_ entering the sandbox.

This patch always opens /etc/localtime before entering the sandbox.

Thank you to James W at Figment for reporting.
