### PR TITLE
gossip: fix prune message processing

### DIFF
--- a/src/discof/gossip/fd_gossvf_tile.c
+++ b/src/discof/gossip/fd_gossvf_tile.c
@@ -349,16 +349,16 @@ verify_prune( fd_gossip_view_prune_t const * view,
               uchar const *                  payload,
               fd_sha512_t *                  sha ) {
   uchar sign_data[ FD_NET_MTU ];
-  fd_memcpy(       sign_data,                            "\xffSOLANA_PRUNE_DATA",       18UL );
-  fd_memcpy(       sign_data+18UL,                       payload+view->origin_off,      32UL );
-  FD_STORE( ulong, sign_data+50UL,                       view->prunes_len );
-  fd_memcpy(       sign_data+58UL,                       payload+view->prunes_off,      view->prunes_len*32UL );
-  fd_memcpy(       sign_data+58UL+view->prunes_len*32UL, payload+view->destination_off, 32UL );
-  FD_STORE( ulong, sign_data+90UL+view->prunes_len*32UL, view->wallclock );
+  fd_memcpy(       sign_data,                             "\xffSOLANA_PRUNE_DATA",       18UL );
+  fd_memcpy(       sign_data+18UL,                        payload+view->pubkey_off,      32UL );
+  FD_STORE( ulong, sign_data+50UL,                        view->origins_len );
+  fd_memcpy(       sign_data+58UL,                        payload+view->origins_off,     view->origins_len*32UL );
+  fd_memcpy(       sign_data+58UL+view->origins_len*32UL, payload+view->destination_off, 32UL );
+  FD_STORE( ulong, sign_data+90UL+view->origins_len*32UL, view->wallclock );
 
-  ulong sign_data_len = 98UL+view->prunes_len*32UL;
-  int err_prefix    = fd_ed25519_verify( sign_data,      sign_data_len,      payload+view->signature_off, payload+view->origin_off, sha );
-  int err_no_prefix = fd_ed25519_verify( sign_data+18UL, sign_data_len-18UL, payload+view->signature_off, payload+view->origin_off, sha );
+  ulong sign_data_len = 98UL+view->origins_len*32UL;
+  int err_prefix    = fd_ed25519_verify( sign_data,      sign_data_len,      payload+view->signature_off, payload+view->pubkey_off, sha );
+  int err_no_prefix = fd_ed25519_verify( sign_data+18UL, sign_data_len-18UL, payload+view->signature_off, payload+view->pubkey_off, sha );
 
   if( FD_LIKELY( err_prefix==FD_ED25519_SUCCESS || err_no_prefix==FD_ED25519_SUCCESS ) ) return 0;
   else                                                                                   return FD_METRICS_ENUM_GOSSVF_MESSAGE_OUTCOME_V_DROPPED_PRUNE_SIGNATURE_IDX;

--- a/src/flamenco/gossip/fd_active_set.c
+++ b/src/flamenco/gossip/fd_active_set.c
@@ -121,25 +121,18 @@ fd_active_set_node_pubkey( fd_active_set_t * active_set,
 }
 
 void
-fd_active_set_prunes( fd_active_set_t * active_set,
-                      uchar const *     identity_pubkey,
-                      ulong             identity_stake,
-                      uchar const *     peers,
-                      ulong             peers_len,
-                      uchar const *     origin,
-                      ulong             origin_stake,
-                      ulong *           opt_out_node_idx ) {
+fd_active_set_prune( fd_active_set_t * active_set,
+                     uchar const *     push_dest,
+                     uchar const *     origin,
+                     ulong             origin_stake,
+                     uchar const *     identity_pubkey,
+                     ulong             identity_stake ) {
   if( FD_UNLIKELY( !memcmp( identity_pubkey, origin, 32UL ) ) ) return;
 
   ulong bucket = fd_active_set_stake_bucket( fd_ulong_min( identity_stake, origin_stake ) );
   for( ulong i=0UL; i<12UL; i++ ) {
-    if( FD_UNLIKELY( !memcmp( active_set->entries[ bucket ]->nodes[ i ]->pubkey, origin, 32UL ) ) ) {
-      for( ulong j=0UL; j<peers_len; j++ ) {
-        fd_bloom_insert( active_set->entries[ bucket ]->nodes[ i ]->bloom, &peers[j*32UL], 32UL );
-      }
-      if( opt_out_node_idx ) {
-        *opt_out_node_idx = bucket*12UL + i;
-      }
+    if( FD_UNLIKELY( !memcmp( active_set->entries[ bucket ]->nodes[ i ]->pubkey, push_dest, 32UL ) ) ) {
+      fd_bloom_insert( active_set->entries[ bucket ]->nodes[ i ]->bloom, origin, 32UL );
       return;
     }
   }
@@ -156,7 +149,8 @@ fd_active_set_rotate( fd_active_set_t * active_set,
   ulong replace_idx;
 
   if( FD_LIKELY( entry->nodes_len==12UL ) ) {
-    replace_idx = fd_rng_ulong_roll( active_set->rng, entry->nodes_len );
+    replace_idx      = entry->nodes_idx;
+    entry->nodes_idx = (entry->nodes_idx+1UL) % 12UL;
     fd_crds_bucket_add( crds, bucket, entry->nodes[ replace_idx ]->pubkey );
   } else {
     replace_idx = entry->nodes_len;

--- a/src/flamenco/gossip/fd_active_set.h
+++ b/src/flamenco/gossip/fd_active_set.h
@@ -43,7 +43,7 @@ struct fd_active_set_peer {
 typedef struct fd_active_set_peer fd_active_set_peer_t;
 
 struct fd_active_set_entry {
-  ulong                nodes_idx;
+  ulong                nodes_idx; /* points to oldest entry in set */
   ulong                nodes_len;
   fd_active_set_peer_t nodes[ FD_ACTIVE_SET_PEERS_PER_ENTRY ][ 1UL ];
 };
@@ -108,14 +108,12 @@ fd_active_set_node_pubkey( fd_active_set_t * active_set,
                            ulong             peer_idx );
 
 void
-fd_active_set_prunes( fd_active_set_t * active_set,
-                      uchar const *     identity_pubkey,
-                      ulong             identity_stake,
-                      uchar const *     peers,
-                      ulong             peers_len,
-                      uchar const *     origin,
-                      ulong             origin_stake,
-                      ulong *           opt_out_node_idx );
+fd_active_set_prune( fd_active_set_t * active_set,
+                     uchar const *     push_dest,
+                     uchar const *     origin,
+                     ulong             origin_stake,
+                     uchar const *     identity_pubkey,
+                     ulong             identity_stake );
 
 /* fd_active_set_rotate chooses a random active set entry to swap/introduce
    a peer into. The peer is sampled from a distribution

--- a/src/flamenco/gossip/fd_gossip.c
+++ b/src/flamenco/gossip/fd_gossip.c
@@ -613,14 +613,18 @@ static void
 rx_prune( fd_gossip_t *                  gossip,
           uchar const *                  payload,
           fd_gossip_view_prune_t const * prune ) {
-  fd_active_set_prunes( gossip->active_set,
-                        gossip->identity_pubkey,
-                        gossip->identity_stake,
-                        payload+prune->prunes_off,
-                        prune->prunes_len,
-                        payload+prune->origin_off,
-                        get_stake( gossip, payload+prune->origin_off ),
-                        NULL /* TODO: use out_node_idx to update push states */ );
+  uchar const * push_dest_pubkey = payload+prune->pubkey_off;
+  uchar const * origins          = payload+prune->origins_off;
+  for( ulong i=0UL; i<prune->origins_len; i++ ) {
+    uchar const * origin_pubkey = &origins[ i*32UL ];
+    ulong         origin_stake  = get_stake( gossip, origin_pubkey );
+    fd_active_set_prune( gossip->active_set,
+                         push_dest_pubkey,
+                         origin_pubkey,
+                         origin_stake,
+                         gossip->identity_pubkey,
+                         gossip->identity_stake );
+  }
 }
 
 

--- a/src/flamenco/gossip/fd_gossip_msg_parse.c
+++ b/src/flamenco/gossip/fd_gossip_msg_parse.c
@@ -543,10 +543,10 @@ fd_gossip_msg_prune_parse( fd_gossip_view_t * view,
   CHECK_INIT( payload, payload_sz, start_offset );
   fd_gossip_view_prune_t * prune = view->prune;
   CHECKED_INC( 32U ); /* pubkey is sent twice */
-  CHECK_LEFT(                   32U ); prune->origin_off      = CUR_OFFSET               ; INC( 32U );
-  CHECK_LEFT(                    8U ); prune->prunes_len      = FD_LOAD( ulong, CURSOR ) ; INC(  8U );
-  CHECK( prune->prunes_len<=((ULONG_MAX-31U)/32U) );
-  CHECK_LEFT( prune->prunes_len*32U ); prune->prunes_off      = CUR_OFFSET               ; INC( prune->prunes_len*32U );
+  CHECK_LEFT(                   32U ); prune->pubkey_off      = CUR_OFFSET               ; INC( 32U );
+  CHECK_LEFT(                    8U ); prune->origins_len     = FD_LOAD( ulong, CURSOR ) ; INC(  8U );
+  CHECK( prune->origins_len<=((ULONG_MAX-31U)/32U) );
+  CHECK_LEFT( prune->origins_len*32U ); prune->origins_off    = CUR_OFFSET               ; INC( prune->origins_len*32U );
   CHECK_LEFT(                   64U ); prune->signature_off   = CUR_OFFSET               ; INC( 64U );
   CHECK_LEFT(                   32U ); prune->destination_off = CUR_OFFSET               ; INC( 32U );
   CHECK_LEFT(                    8U ); prune->wallclock       = FD_LOAD( ulong, CURSOR ) ; INC(  8U );

--- a/src/flamenco/gossip/fd_gossip_private.h
+++ b/src/flamenco/gossip/fd_gossip_private.h
@@ -276,9 +276,9 @@ struct fd_gossip_view_pull_request {
 typedef struct fd_gossip_view_pull_request fd_gossip_view_pull_request_t;
 
 struct fd_gossip_view_prune {
-  ushort origin_off;
-  ulong  prunes_len;
-  ushort prunes_off;
+  ushort pubkey_off;
+  ulong  origins_len;
+  ushort origins_off;
   ushort destination_off;
   ulong  wallclock;
   ushort signature_off;


### PR DESCRIPTION
Poor field name choices in `fd_gossip_view_prunes_t` led to some confusion on what node needs its push tree pruned. We previously thought the sender of a prune message was the origin that needed to be pruned (because the field name was confusingly named `origin_off`). This resulted in incorrect pruning behavior. This PR disambiguates the field names in the struct definition and fixes the incorrect processing of a prune message.