### PR TITLE
gossip: add scratch regression checks

### DIFF
--- a/src/flamenco/gossip/Local.mk
+++ b/src/flamenco/gossip/Local.mk
@@ -14,6 +14,9 @@ $(call run-unit-test,test_active_set)
 $(call make-unit-test,test_ping_tracker,test_ping_tracker,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_ping_tracker)
 
+$(call make-unit-test,test_gossip,test_gossip,fd_flamenco fd_ballet fd_util)
+$(call run-unit-test,test_gossip)
+
 ifdef FD_HAS_HOSTED
 $(call make-fuzz-test,fuzz_gossip_msg_parse,fuzz_gossip_msg_parse,fd_flamenco fd_ballet fd_util)
 endif

--- a/src/flamenco/gossip/crds/Local.mk
+++ b/src/flamenco/gossip/crds/Local.mk
@@ -1,2 +1,5 @@
 $(call add-hdrs,fd_crds.h)
 $(call add-objs,fd_crds,fd_flamenco)
+
+$(call make-unit-test,test_crds,test_crds,fd_flamenco fd_ballet fd_util)
+$(call run-unit-test,test_crds)

--- a/src/flamenco/gossip/crds/fd_crds.c
+++ b/src/flamenco/gossip/crds/fd_crds.c
@@ -416,12 +416,12 @@ fd_crds_new( void *                    shmem,
     return NULL;
   }
 
-  if( FD_UNLIKELY( !ele_max || !fd_ulong_is_pow2( ele_max ) ) ) {
+  if( FD_UNLIKELY( !fd_ulong_is_pow2( ele_max ) ) ) {
     FD_LOG_WARNING(( "ele_max must be a power of 2" ));
     return NULL;
   }
 
-  if( FD_UNLIKELY( !purged_max || !fd_ulong_is_pow2( purged_max ) ) ) {
+  if( FD_UNLIKELY( !fd_ulong_is_pow2( purged_max ) ) ) {
     FD_LOG_WARNING(( "purged_max must be a power of 2" ));
     return NULL;
   }
@@ -451,6 +451,7 @@ fd_crds_new( void *                    shmem,
   void * _ci_pool               = FD_SCRATCH_ALLOC_APPEND( l, crds_contact_info_pool_align(),        crds_contact_info_pool_footprint( CRDS_MAX_CONTACT_INFO ) );
   void * _ci_dlist              = FD_SCRATCH_ALLOC_APPEND( l, crds_contact_info_fresh_list_align(),  crds_contact_info_fresh_list_footprint() );
   void * _ci_evict_dlist        = FD_SCRATCH_ALLOC_APPEND( l, crds_contact_info_evict_dlist_align(), crds_contact_info_evict_dlist_footprint() );
+  FD_TEST( FD_SCRATCH_ALLOC_FINI( l, FD_CRDS_ALIGN ) == (ulong)shmem + fd_crds_footprint( ele_max, purged_max ) );
 
   crds->pool = crds_pool_join( crds_pool_new( _pool, ele_max ) );
   FD_TEST( crds->pool );

--- a/src/flamenco/gossip/crds/test_crds.c
+++ b/src/flamenco/gossip/crds/test_crds.c
@@ -1,0 +1,39 @@
+#include "../../../util/fd_util.h"
+#include "fd_crds.h"
+
+#include <stdlib.h>
+
+static void
+test_crds_new_basic( void ) {
+  ulong ele_max    = 1024UL;
+  ulong purged_max =  512UL;
+
+  void * mem = aligned_alloc( fd_crds_align(), fd_crds_footprint( ele_max, purged_max ) );
+  FD_TEST( mem );
+
+  fd_rng_t _rng[1];
+  fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
+  FD_TEST( rng );
+
+  static fd_gossip_out_ctx_t gossip_out = {0};
+
+  void * shcrds = fd_crds_new( mem, rng, ele_max, purged_max, &gossip_out );
+  FD_TEST( shcrds );
+
+  fd_crds_t * crds = fd_crds_join( shcrds );
+  FD_TEST( crds );
+
+  free( mem );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  test_crds_new_basic();
+  FD_LOG_NOTICE(( "test_crds_new_basic() passed" ));
+  fd_halt();
+  return 0;
+}
+

--- a/src/flamenco/gossip/fd_active_set.c
+++ b/src/flamenco/gossip/fd_active_set.c
@@ -33,6 +33,7 @@ fd_active_set_new( void *     shmem,
   FD_SCRATCH_ALLOC_INIT( l, shmem );
   fd_active_set_t * as = FD_SCRATCH_ALLOC_APPEND( l, FD_ACTIVE_SET_ALIGN, sizeof(fd_active_set_t) );
   uchar * _blooms = FD_SCRATCH_ALLOC_APPEND( l, FD_BLOOM_ALIGN, 25UL*12UL*bloom_footprint );
+  FD_TEST( FD_SCRATCH_ALLOC_FINI( l, FD_ACTIVE_SET_ALIGN ) == (ulong)shmem + fd_active_set_footprint() );
 
   as->rng = rng;
   for( ulong i=0UL; i<25UL; i++ ) {

--- a/src/flamenco/gossip/fd_bloom.c
+++ b/src/flamenco/gossip/fd_bloom.c
@@ -68,6 +68,7 @@ fd_bloom_new( void *     shmem,
   fd_bloom_t * bloom = FD_SCRATCH_ALLOC_APPEND( l, FD_BLOOM_ALIGN, sizeof(fd_bloom_t) );
   void * _keys       = FD_SCRATCH_ALLOC_APPEND( l, 8UL, num_keys*sizeof(ulong) );
   void * _bits       = FD_SCRATCH_ALLOC_APPEND( l, 8UL, (max_bits+7UL)/8UL );
+  FD_TEST( FD_SCRATCH_ALLOC_FINI( l, FD_BLOOM_ALIGN ) == (ulong)shmem + fd_bloom_footprint( false_positive_rate, max_bits ) );
 
   bloom->keys      = (ulong *)_keys;
   bloom->keys_len  = 0UL;

--- a/src/flamenco/gossip/fd_gossip.c
+++ b/src/flamenco/gossip/fd_gossip.c
@@ -157,7 +157,7 @@ void *
 fd_gossip_new( void *                    shmem,
                fd_rng_t *                rng,
                ulong                     max_values,
-               ulong                     entrypoints_cnt,
+               ulong                     entrypoints_len,
                fd_ip4_port_t const *     entrypoints,
                fd_contact_info_t const * my_contact_info,
                long                      now,
@@ -179,12 +179,12 @@ fd_gossip_new( void *                    shmem,
     return NULL;
   }
 
-  if( FD_UNLIKELY( (entrypoints_cnt<1) | (entrypoints_cnt>16UL) ) ) {
+  if( FD_UNLIKELY( (entrypoints_len<1) | (entrypoints_len>16UL) ) ) {
     FD_LOG_WARNING(( "entrypoints_cnt must in (0, 16]" ));
     return NULL;
   }
 
-  if( FD_UNLIKELY( !max_values || !fd_ulong_is_pow2( max_values ) ) ) {
+  if( FD_UNLIKELY( !fd_ulong_is_pow2( max_values ) ) ) {
     FD_LOG_WARNING(( "max_values must be a power of 2" ));
     return NULL;
   }
@@ -194,15 +194,16 @@ fd_gossip_new( void *                    shmem,
   fd_gossip_t * gossip  = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_gossip_t),    sizeof(fd_gossip_t)                           );
   void * crds           = FD_SCRATCH_ALLOC_APPEND( l, fd_crds_align(),         fd_crds_footprint( max_values, max_values )   );
   void * active_set     = FD_SCRATCH_ALLOC_APPEND( l, fd_active_set_align(),   fd_active_set_footprint()                     );
-  void * ping_tracker   = FD_SCRATCH_ALLOC_APPEND( l, fd_ping_tracker_align(), fd_ping_tracker_footprint( entrypoints_cnt )  );
+  void * ping_tracker   = FD_SCRATCH_ALLOC_APPEND( l, fd_ping_tracker_align(), fd_ping_tracker_footprint( entrypoints_len )  );
   void * stake_pool     = FD_SCRATCH_ALLOC_APPEND( l, stake_pool_align(),      stake_pool_footprint( CRDS_MAX_CONTACT_INFO ) );
   void * stake_weights  = FD_SCRATCH_ALLOC_APPEND( l, stake_map_align(),       stake_map_footprint( stake_map_chain_cnt )    );
   void * active_ps      = FD_SCRATCH_ALLOC_APPEND( l, push_set_align(),        push_set_footprint( FD_ACTIVE_SET_MAX_PEERS ) );
+  FD_TEST( FD_SCRATCH_ALLOC_FINI( l, fd_gossip_align() ) == (ulong)shmem + fd_gossip_footprint( max_values, entrypoints_len  ) );
 
   gossip->gossip_net_out  = gossip_net_out;
 
-  gossip->entrypoints_cnt = entrypoints_cnt;
-  fd_memcpy( gossip->entrypoints, entrypoints, entrypoints_cnt*sizeof(fd_ip4_port_t) );
+  gossip->entrypoints_cnt = entrypoints_len;
+  fd_memcpy( gossip->entrypoints, entrypoints, entrypoints_len*sizeof(fd_ip4_port_t) );
 
   gossip->crds = fd_crds_join( fd_crds_new( crds, rng, max_values, max_values, gossip_update_out ) );
   FD_TEST( gossip->crds );

--- a/src/flamenco/gossip/fd_gossip.h
+++ b/src/flamenco/gossip/fd_gossip.h
@@ -98,7 +98,7 @@ void *
 fd_gossip_new( void *                    shmem,
                fd_rng_t *                rng,
                ulong                     max_values,
-               ulong                     entrypoints_cnt,
+               ulong                     entrypoints_len,
                fd_ip4_port_t const *     entrypoints,
                fd_contact_info_t const * my_contact_info,
                long                      now,

--- a/src/flamenco/gossip/test_gossip.c
+++ b/src/flamenco/gossip/test_gossip.c
@@ -1,0 +1,100 @@
+#include "../../util/fd_util.h"
+#include "fd_gossip.h"
+
+#include <stdlib.h>
+
+static void
+send_stub( void *               ctx,
+           fd_stem_context_t *  stem,
+           uchar const *        data,
+           ulong                sz,
+           fd_ip4_port_t const *peer_address,
+           ulong                now ) {
+  (void)ctx; (void)stem; (void)data; (void)sz; (void)peer_address; (void)now;
+}
+
+static void
+sign_stub( void *        ctx,
+           uchar const * data,
+           ulong         sz,
+           int           sign_type,
+           uchar *       out_signature ) {
+  (void)ctx; (void)data; (void)sz; (void)sign_type;
+  /* Produce a deterministic dummy signature */
+  for( ulong i=0UL; i<64UL; i++ ) out_signature[i] = (uchar)i;
+}
+
+static void
+ping_change_stub( void *        ctx,
+                  uchar const * peer_pubkey,
+                  fd_ip4_port_t peer_address,
+                  long          now,
+                  int           change_type ) {
+  (void)ctx; (void)peer_pubkey; (void)peer_address; (void)now; (void)change_type;
+}
+
+static void
+test_gossip_new_basic( void ) {
+  ulong max_values      = 1024UL;
+
+  ulong               entrypoints_len = 1UL;
+  fd_ip4_port_t const entrypoints[1]  = { { .addr = 0x7f000001U, /* 127.0.0.1 */
+                                           .port = fd_ushort_bswap( (ushort)8001 ) } };
+
+  fd_contact_info_t my_ci = {0};
+  for( ulong i=0UL; i<32UL; i++ ) my_ci.pubkey.uc[i] = (uchar)i;
+  my_ci.shred_version                        = 0U;
+  my_ci.instance_creation_wallclock_nanos    = fd_log_wallclock();
+  my_ci.wallclock_nanos                      = my_ci.instance_creation_wallclock_nanos;
+  my_ci.sockets[ FD_CONTACT_INFO_SOCKET_GOSSIP ].addr = entrypoints[0].addr;
+  my_ci.sockets[ FD_CONTACT_INFO_SOCKET_GOSSIP ].port = entrypoints[0].port;
+  my_ci.version.client                       = FD_CONTACT_INFO_VERSION_CLIENT_FIREDANCER;
+  my_ci.version.major                        = 0U;
+  my_ci.version.minor                        = 0U;
+  my_ci.version.patch                        = 0U;
+  my_ci.version.commit                       = 0U;
+  my_ci.version.feature_set                  = 0U;
+
+  void * mem = aligned_alloc( fd_gossip_align(), fd_gossip_footprint( max_values, entrypoints_len ) );
+  FD_TEST( mem );
+
+  fd_rng_t _rng[1];
+  fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
+  FD_TEST( rng );
+
+  static fd_gossip_out_ctx_t gossip_update_out = {0};
+  static fd_gossip_out_ctx_t gossip_net_out    = {0};
+
+  void * shgossip = fd_gossip_new( mem,
+                                   rng,
+                                   max_values,
+                                   entrypoints_len,
+                                   entrypoints,
+                                   &my_ci,
+                                   fd_log_wallclock(),
+                                   send_stub,
+                                   NULL,
+                                   sign_stub,
+                                   NULL,
+                                   ping_change_stub,
+                                   NULL,
+                                   &gossip_update_out,
+                                   &gossip_net_out );
+  FD_TEST( shgossip );
+
+  fd_gossip_t * gossip = fd_gossip_join( shgossip );
+  FD_TEST( gossip );
+
+  free( mem );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  test_gossip_new_basic();
+  FD_LOG_NOTICE(( "test_gossip_new_basic() passed" ));
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
For more complex scratch allocations it is common practice to add assert checks, to test that a change doesn't lead to a regression

* add basic unit tests calling _new, that can be expanded later
* consistent parameter naming
* remove 0 checks, since fd_ulong_is_pow2(n) is correctly defined for n=0