### PR TITLE
ethtool: support additional drivers for dedicated mode

### DIFF
--- a/src/app/fddev/commands/configure/blockstore.c
+++ b/src/app/fddev/commands/configure/blockstore.c
@@ -129,12 +129,12 @@ init( config_t const * config ) {
 
 }
 
-static void
+static int
 fini( config_t const * config,
       int              pre_init FD_PARAM_UNUSED ) {
   DIR * dir = opendir( config->paths.ledger );
   if( FD_UNLIKELY( !dir ) ) {
-    if( errno == ENOENT ) return;
+    if( errno == ENOENT ) return 0;
     FD_LOG_ERR(( "opendir `%s` failed (%i-%s)", config->paths.ledger, errno, fd_io_strerror( errno ) ));
   }
 
@@ -165,6 +165,8 @@ fini( config_t const * config,
 
   if( FD_UNLIKELY( errno && errno!=ENOENT ) ) FD_LOG_ERR(( "readdir `%s` failed (%i-%s)", config->paths.ledger, errno, fd_io_strerror( errno ) ));
   if( FD_UNLIKELY( closedir( dir ) ) ) FD_LOG_ERR(( "closedir `%s` failed (%i-%s)", config->paths.ledger, errno, fd_io_strerror( errno ) ));
+
+  return 1;
 }
 
 static configure_result_t

--- a/src/app/shared/commands/configure/configure.c
+++ b/src/app/shared/commands/configure/configure.c
@@ -137,11 +137,12 @@ configure_stage( configure_stage_t * stage,
       }
 
       FD_LOG_NOTICE(( "%s ... finishing", stage->name ));
-      if( FD_LIKELY( stage->fini ) ) stage->fini( config, 0 );
+      int fini_done = 0;
+      if( FD_LIKELY( stage->fini ) ) fini_done = stage->fini( config, 0 );
 
       result = stage->check( config );
-      if( FD_UNLIKELY( result.result == CONFIGURE_OK && stage->init && stage->fini ) ) {
-        /* if the step does nothing, it's fine if it's fully configured
+      if( FD_UNLIKELY( result.result == CONFIGURE_OK && stage->init && fini_done ) ) {
+        /* if the fini step does nothing, it's fine if it's fully configured
             after being undone */
         FD_LOG_ERR(( "%s ... not undone", stage->name ));
       } else if( FD_UNLIKELY( result.result == CONFIGURE_PARTIALLY_CONFIGURED && !stage->always_recreate ) ) {

--- a/src/app/shared/commands/configure/configure.h
+++ b/src/app/shared/commands/configure/configure.h
@@ -54,6 +54,8 @@ typedef struct {
     return result;                \
   } while( 0 )
 
+/* fini() returns whether or not it took any actions. */
+
 typedef struct configure_stage {
   const char *       name;
   int                always_recreate;
@@ -61,7 +63,7 @@ typedef struct configure_stage {
   void               (*init_perm)( fd_cap_chk_t * chk, config_t const * config );
   void               (*fini_perm)( fd_cap_chk_t * chk, config_t const * config );
   void               (*init)     ( config_t const * config );
-  void               (*fini)     ( config_t const * config, int pre_init );
+  int                (*fini)     ( config_t const * config, int pre_init );
   configure_result_t (*check)    ( config_t const * config );
 } configure_stage_t;
 

--- a/src/app/shared/commands/configure/fd_ethtool_ioctl.h
+++ b/src/app/shared/commands/configure/fd_ethtool_ioctl.h
@@ -30,7 +30,7 @@
 
 #include "../../../../util/fd_util_base.h"
 
-#define FD_ETHTOOL_MAX_RXFH_TABLE_SIZE (2048)
+#define FD_ETHTOOL_MAX_RXFH_TABLE_SIZE (32768)
 
 #define FD_ETHTOOL_FEATURE_NTUPLE "rx-ntuple-filter"
 

--- a/src/app/shared/commands/configure/hugetlbfs.c
+++ b/src/app/shared/commands/configure/hugetlbfs.c
@@ -231,7 +231,7 @@ warn_mount_users( char const * mount_path ) {
   if( FD_UNLIKELY( -1==closedir( dir ) ) ) FD_LOG_ERR(( "closedir (%i-%s)", errno, fd_io_strerror( errno ) ));
 }
 
-static void
+static int
 fini( config_t const * config,
       int              pre_init ) {
   (void)pre_init;
@@ -285,6 +285,8 @@ fini( config_t const * config,
   FD_LOG_NOTICE(( "RUN: `rmdir %s`", config->hugetlbfs.mount_path ));
   if( FD_UNLIKELY( rmdir( config->hugetlbfs.mount_path ) && errno!=ENOENT ) )
     FD_LOG_ERR(( "error removing hugetlbfs directory at `%s` (%i-%s)", config->hugetlbfs.mount_path, errno, fd_io_strerror( errno ) ));
+
+  return 1;
 }
 
 static configure_result_t

--- a/src/app/shared_dev/commands/configure/genesis.c
+++ b/src/app/shared_dev/commands/configure/genesis.c
@@ -263,7 +263,7 @@ init( config_t const * config ) {
   FD_LOG_INFO(( "Shred version: %hu", shred_version ));
 }
 
-static void
+static int
 fini( config_t const * config,
       int              pre_init ) {
   (void)pre_init;
@@ -272,6 +272,7 @@ fini( config_t const * config,
   FD_TEST( fd_cstr_printf_check( genesis_path, PATH_MAX, NULL, "%s/genesis.bin", config->paths.ledger ) );
   if( FD_UNLIKELY( unlink( genesis_path ) && errno!=ENOENT ) )
     FD_LOG_ERR(( "could not remove genesis.bin file `%s` (%i-%s)", genesis_path, errno, fd_io_strerror( errno ) ));
+  return 1;
 }
 
 static configure_result_t

--- a/src/app/shared_dev/commands/configure/netns.c
+++ b/src/app/shared_dev/commands/configure/netns.c
@@ -94,7 +94,7 @@ init( config_t const * config ) {
        interface1, interface1 );
 }
 
-static void
+static int
 fini( config_t const * config,
       int              pre_init FD_PARAM_UNUSED ) {
   const char * interface0 = config->development.netns.interface0;
@@ -113,6 +113,8 @@ fini( config_t const * config,
   /* if neither of them was present, we wouldn't get to the undo step so make sure we were
      able to delete whatever is there */
   if( FD_UNLIKELY( status1 && status2 ) ) FD_LOG_ERR(( "failed to delete network namespaces" ));
+
+  return 1;
 }
 
 static configure_result_t

--- a/src/app/shared_dev/commands/configure/normalpage.c
+++ b/src/app/shared_dev/commands/configure/normalpage.c
@@ -50,7 +50,7 @@ is_mountpoint( char const * directory ) {
   return st_parent.st_dev!=st.st_dev;
 }
 
-static void
+static int
 fini( config_t const * config,
       int              pre_init ) {
   (void)pre_init;
@@ -71,6 +71,8 @@ fini( config_t const * config,
 
   FD_LOG_NOTICE(( "RUN: `rm -rf %s`", path ));
   if( FD_UNLIKELY( -1==fd_file_util_rmtree( path, 1 ) ) ) FD_LOG_ERR(( "error removing normal pages directory at `%s` (%i-%s)", path, errno, fd_io_strerror( errno ) ));
+
+  return 1;
 }
 
 


### PR DESCRIPTION
- Fix rxfh_get_table on ice devices (simpler ioctl bugged)
- Fix a minor bug in fini() on i40e devices
- Fix a minor bug in creating ntuple rules on bnxt devices.
- Also prevent a "not undone" error log in simple-mode fini()