### PR TITLE
runtime: custom constructors for banks [wip, don't review]

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -1619,9 +1619,9 @@ after_frag( fd_replay_tile_ctx_t *   ctx,
       }
     }
 
-    FD_LOG_NOTICE(( "fec %lu %lu %u %s %s", fec->slot, fec->slot - (ulong)fec->parent_off, fec->fec_set_idx, FD_BASE58_ENC_32_ALLOCA( &fec->key ), FD_BASE58_ENC_32_ALLOCA( &fec->cmr ) ));
+    // FD_LOG_NOTICE(( "fec %lu %lu %u %s %s", fec->slot, fec->slot - (ulong)fec->parent_off, fec->fec_set_idx, FD_BASE58_ENC_32_ALLOCA( &fec->key ), FD_BASE58_ENC_32_ALLOCA( &fec->cmr ) ));
     if( FD_UNLIKELY( fec->slot_complete ) ) {
-      FD_LOG_NOTICE(( "block_id %lu %lu %s", fec->slot, fec->slot - (ulong)fec->parent_off, FD_BASE58_ENC_32_ALLOCA( &fec->cmr ) ));
+      // FD_LOG_NOTICE(( "block_id %lu %lu %s", fec->slot, fec->slot - (ulong)fec->parent_off, FD_BASE58_ENC_32_ALLOCA( &fec->cmr ) ));
     }
 
     if( FD_UNLIKELY( fec->data_complete ) ) {

--- a/src/discof/restore/utils/fd_ssload.c
+++ b/src/discof/restore/utils/fd_ssload.c
@@ -62,8 +62,6 @@ void
 fd_ssload_recover( fd_snapshot_manifest_t * manifest,
                    fd_exec_slot_ctx_t *     slot_ctx ) {
 
-  fd_banks_clear_bank( slot_ctx->banks, slot_ctx->bank );
-
   /* Slot */
 
   fd_bank_slot_set( slot_ctx->bank, manifest->slot );
@@ -275,7 +273,11 @@ fd_ssload_recover( fd_snapshot_manifest_t * manifest,
   fd_bank_total_epoch_stake_set( slot_ctx->bank, manifest->epoch_stakes[1].total_stake );
 
   /* Vote stakes for the previous epoch (E-2) */
-  fd_vote_states_t * vote_stakes_prev_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_prev_modify( slot_ctx->bank ), FD_RUNTIME_MAX_VOTE_ACCOUNTS, 999UL ) );
+  fd_bank_vote_states_prev_prev_reset( slot_ctx->bank );
+  fd_vote_states_t * vote_stakes_prev_prev = fd_bank_vote_states_prev_prev_modify( slot_ctx->bank );
+  if( FD_UNLIKELY( !vote_stakes_prev_prev ) ) {
+    FD_LOG_CRIT(( "invariant violation: vote_stakes_prev_prev in bank not found" ));
+  }
   for( ulong i=0UL; i<manifest->epoch_stakes[0].vote_stakes_len; i++ ) {
     fd_snapshot_manifest_vote_stakes_t const * elem = &manifest->epoch_stakes[0].vote_stakes[i];
     /* First convert the epoch credits to the format expected by the

--- a/src/discof/restore/utils/fd_ssload.c
+++ b/src/discof/restore/utils/fd_ssload.c
@@ -62,6 +62,8 @@ void
 fd_ssload_recover( fd_snapshot_manifest_t * manifest,
                    fd_exec_slot_ctx_t *     slot_ctx ) {
 
+  fd_banks_clear_bank( slot_ctx->banks, slot_ctx->bank );
+
   /* Slot */
 
   fd_bank_slot_set( slot_ctx->bank, manifest->slot );
@@ -273,7 +275,7 @@ fd_ssload_recover( fd_snapshot_manifest_t * manifest,
   fd_bank_total_epoch_stake_set( slot_ctx->bank, manifest->epoch_stakes[1].total_stake );
 
   /* Vote stakes for the previous epoch (E-2) */
-  fd_vote_states_t * vote_stakes_prev_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_prev_locking_modify( slot_ctx->bank ), FD_RUNTIME_MAX_VOTE_ACCOUNTS, 999UL ) );
+  fd_vote_states_t * vote_stakes_prev_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_prev_modify( slot_ctx->bank ), FD_RUNTIME_MAX_VOTE_ACCOUNTS, 999UL ) );
   for( ulong i=0UL; i<manifest->epoch_stakes[0].vote_stakes_len; i++ ) {
     fd_snapshot_manifest_vote_stakes_t const * elem = &manifest->epoch_stakes[0].vote_stakes[i];
     /* First convert the epoch credits to the format expected by the
@@ -303,6 +305,5 @@ fd_ssload_recover( fd_snapshot_manifest_t * manifest,
       fd_vote_states_remove( vote_stakes_prev_prev, (fd_pubkey_t *)elem->vote );
     }
   }
-  fd_bank_vote_states_prev_prev_end_locking_modify( slot_ctx->bank );
 
 }

--- a/src/flamenco/runtime/fd_bank.h
+++ b/src/flamenco/runtime/fd_bank.h
@@ -621,6 +621,14 @@ fd_bank_vote_states_prev_prev_query( fd_bank_t const * bank ) {
   return vote_states;
 }
 
+static inline void
+fd_bank_vote_states_prev_prev_reset( fd_bank_t * bank ) {
+  if( bank->vote_states_prev_prev_dirty ) {
+    fd_bank_vote_states_prev_prev_t * bank_vote_states_prev_prev = fd_bank_vote_states_prev_prev_pool_ele( fd_bank_get_vote_states_prev_prev_pool( bank ), bank->vote_states_prev_prev_pool_idx );
+    fd_vote_states_new( bank_vote_states_prev_prev->data, FD_RUNTIME_MAX_VOTE_ACCOUNTS, 999UL );
+  }
+}
+
 /* Cost tracker.  The cost tracker is reset on each block and does not
    hold state across blocks. */
 

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -128,11 +128,10 @@ fd_runtime_update_leaders( fd_bank_t * bank,
   ulong slot0    = fd_epoch_slot0   ( epoch_schedule, epoch );
   ulong slot_cnt = fd_epoch_slot_cnt( epoch_schedule, epoch );
 
-  fd_vote_states_t const * vote_states_prev_prev = fd_bank_vote_states_prev_prev_locking_query( bank );
+  fd_vote_states_t const * vote_states_prev_prev = fd_bank_vote_states_prev_prev_query( bank );
   ulong                    vote_acc_cnt          = fd_vote_states_cnt( vote_states_prev_prev ) ;
   fd_vote_stake_weight_t * epoch_weights         = fd_spad_alloc_check( runtime_spad, alignof(fd_vote_stake_weight_t), vote_acc_cnt * sizeof(fd_vote_stake_weight_t) );
   ulong                    stake_weight_cnt      = fd_stake_weights_by_node( vote_states_prev_prev, epoch_weights );
-  fd_bank_vote_states_prev_prev_end_locking_query( bank );
 
   /* Derive leader schedule */
 
@@ -1386,10 +1385,9 @@ fd_runtime_prepare_and_execute_txn( fd_banks_t *        banks,
 static void
 fd_update_vote_states_prev_prev( fd_exec_slot_ctx_t * slot_ctx ) {
 
-  fd_vote_states_t *       vote_states_prev_prev = fd_bank_vote_states_prev_prev_locking_modify( slot_ctx->bank );
+  fd_vote_states_t *       vote_states_prev_prev = fd_bank_vote_states_prev_prev_modify( slot_ctx->bank );
   fd_vote_states_t const * vote_states_prev      = fd_bank_vote_states_prev_locking_query( slot_ctx->bank );
   fd_memcpy( vote_states_prev_prev, vote_states_prev, fd_bank_vote_states_footprint );
-  fd_bank_vote_states_prev_prev_end_locking_modify( slot_ctx->bank );
   fd_bank_vote_states_prev_end_locking_query( slot_ctx->bank );
 }
 
@@ -2405,7 +2403,7 @@ fd_runtime_init_bank_from_genesis( fd_exec_slot_ctx_t *        slot_ctx,
 
   fd_vote_states_t const * vote_states_curr = fd_bank_vote_states_locking_query( slot_ctx->bank );
 
-  fd_vote_states_t * vote_states_prev_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_prev_locking_modify( slot_ctx->bank ), FD_RUNTIME_MAX_VOTE_ACCOUNTS, 999UL ) );
+  fd_vote_states_t * vote_states_prev_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_prev_modify( slot_ctx->bank ), FD_RUNTIME_MAX_VOTE_ACCOUNTS, 999UL ) );
   fd_vote_states_t * vote_states_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_locking_modify( slot_ctx->bank ), FD_RUNTIME_MAX_VOTE_ACCOUNTS, 999UL ) );
 
   for( ulong i=0UL; i<genesis_block->accounts_len; i++ ) {
@@ -2420,7 +2418,6 @@ fd_runtime_init_bank_from_genesis( fd_exec_slot_ctx_t *        slot_ctx,
     }
   }
 
-  fd_bank_vote_states_prev_prev_end_locking_modify( slot_ctx->bank );
   fd_bank_vote_states_prev_end_locking_modify( slot_ctx->bank );
   fd_bank_vote_states_end_locking_query( slot_ctx->bank );
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
@@ -159,7 +159,7 @@ get_timestamp_estimate( fd_bank_t *             bank,
      if we are currently in epoch E. We do not count vote accounts that
      have not voted in an epoch's worth of slots (432k). */
   fd_vote_states_t const * vote_states           = fd_bank_vote_states_locking_query( bank );
-  fd_vote_states_t const * vote_states_prev_prev = fd_bank_vote_states_prev_prev_locking_query( bank );
+  fd_vote_states_t const * vote_states_prev_prev = fd_bank_vote_states_prev_prev_query( bank );
 
   fd_vote_states_iter_t iter_[1];
   for( fd_vote_states_iter_t * iter = fd_vote_states_iter_init( iter_, vote_states );
@@ -214,7 +214,6 @@ get_timestamp_estimate( fd_bank_t *             bank,
     total_stake += vote_stake;
   }
   fd_bank_vote_states_end_locking_query( bank );
-  fd_bank_vote_states_prev_prev_end_locking_query( bank );
 
   /* https://github.com/anza-xyz/agave/blob/v2.3.7/runtime/src/stake_weighted_timestamp.rs#L56-L58 */
   if( FD_UNLIKELY( total_stake==0UL ) ) {

--- a/src/flamenco/runtime/tests/fd_block_harness.c
+++ b/src/flamenco/runtime/tests/fd_block_harness.c
@@ -259,9 +259,8 @@ fd_runtime_fuzz_block_ctx_create( fd_solfuzz_runner_t *                runner,
   vote_states_prev = fd_vote_states_join( fd_vote_states_new( vote_states_prev, FD_RUNTIME_MAX_VOTE_ACCOUNTS, 999UL ) );
   fd_bank_vote_states_prev_end_locking_modify( slot_ctx->bank );
 
-  fd_vote_states_t * vote_states_prev_prev = fd_bank_vote_states_prev_prev_locking_modify( slot_ctx->bank );
+  fd_vote_states_t * vote_states_prev_prev = fd_bank_vote_states_prev_prev_modify( slot_ctx->bank );
   vote_states_prev_prev = fd_vote_states_join( fd_vote_states_new( vote_states_prev_prev, FD_RUNTIME_MAX_VOTE_ACCOUNTS, 999UL ) );
-  fd_bank_vote_states_prev_prev_end_locking_modify( slot_ctx->bank );
 
   fd_stake_delegations_t * stake_delegations = fd_banks_stake_delegations_root_query( slot_ctx->banks );
   stake_delegations = fd_stake_delegations_join( fd_stake_delegations_new( stake_delegations, FD_RUNTIME_MAX_STAKE_ACCOUNTS, 0 ) );
@@ -314,12 +313,11 @@ fd_runtime_fuzz_block_ctx_create( fd_solfuzz_runner_t *                runner,
   fd_bank_vote_states_prev_end_locking_modify( slot_ctx->bank );
 
   /* Update vote cache for epoch T-2 */
-  vote_states_prev_prev = fd_bank_vote_states_prev_prev_locking_modify( slot_ctx->bank );
+  vote_states_prev_prev = fd_bank_vote_states_prev_prev_modify( slot_ctx->bank );
   fd_runtime_fuzz_block_update_prev_epoch_votes_cache( vote_states_prev_prev,
                                                        test_ctx->epoch_ctx.vote_accounts_t_2,
                                                        test_ctx->epoch_ctx.vote_accounts_t_2_count,
                                                        runner->spad );
-  fd_bank_vote_states_prev_prev_end_locking_modify( slot_ctx->bank );
 
   /* Update leader schedule */
   fd_runtime_update_leaders( slot_ctx->bank, fd_bank_slot_get( slot_ctx->bank ), runner->spad );

--- a/src/flamenco/runtime/tests/fd_dump_pb.c
+++ b/src/flamenco/runtime/tests/fd_dump_pb.c
@@ -400,9 +400,8 @@ create_block_context_protobuf_from_block( fd_exec_test_block_context_t * block_c
   ulong vote_account_t_1_cnt  = fd_vote_states_cnt( vote_states_prev );
   fd_bank_vote_states_prev_end_locking_query( slot_ctx->bank );
 
-  fd_vote_states_t const * vote_states_prev_prev = fd_bank_vote_states_prev_prev_locking_query( slot_ctx->bank );
+  fd_vote_states_t const * vote_states_prev_prev = fd_bank_vote_states_prev_prev_query( slot_ctx->bank );
   ulong vote_account_t_2_cnt = fd_vote_states_cnt( vote_states_prev_prev );
-  fd_bank_vote_states_prev_prev_end_locking_query( slot_ctx->bank );
 
   ulong total_num_accounts    = num_sysvar_entries +
                                 num_loaded_builtins +
@@ -495,13 +494,12 @@ create_block_context_protobuf_from_block( fd_exec_test_block_context_t * block_c
   fd_bank_vote_states_prev_end_locking_query( slot_ctx->bank );
 
   // BlockContext -> EpochContext -> vote_accounts_t_2 (vote accounts at epoch T-2)
-  vote_states_prev_prev = fd_bank_vote_states_prev_prev_locking_query( slot_ctx->bank );
+  vote_states_prev_prev = fd_bank_vote_states_prev_prev_query( slot_ctx->bank );
   dump_vote_accounts( slot_ctx,
                       vote_states,
                       spad,
                       block_context->acct_states,
                       &block_context->acct_states_count );
-  fd_bank_vote_states_prev_prev_end_locking_query( slot_ctx->bank );
 }
 
 static void

--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -78,12 +78,10 @@ fd_runtime_fuzz_instr_ctx_create( fd_solfuzz_runner_t *                runner,
   }
   fd_bank_vote_states_prev_end_locking_modify( slot_ctx->bank );
 
-  fd_vote_states_t * vote_states_prev_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_prev_locking_modify( slot_ctx->bank ), MAX_TX_ACCOUNT_LOCKS, 999UL ) );
+  fd_vote_states_t * vote_states_prev_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_prev_modify( slot_ctx->bank ), MAX_TX_ACCOUNT_LOCKS, 999UL ) );
   if( FD_UNLIKELY( !vote_states_prev_prev ) ) {
-    fd_bank_vote_states_prev_prev_end_locking_modify( slot_ctx->bank );
     return 0;
   }
-  fd_bank_vote_states_prev_prev_end_locking_modify( slot_ctx->bank );
 
   /* Set up epoch context. Defaults obtained from GenesisConfig::Default() */
 

--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -65,20 +65,20 @@ fd_runtime_fuzz_instr_ctx_create( fd_solfuzz_runner_t *                runner,
   }
 
   /* Setup vote states accounts */
-  fd_vote_states_t * vote_states = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_locking_modify( slot_ctx->bank ), FD_RUNTIME_MAX_VOTE_ACCOUNTS, 999UL ) );
+  fd_vote_states_t * vote_states = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_locking_modify( slot_ctx->bank ), MAX_TX_ACCOUNT_LOCKS, 999UL ) );
   if( FD_UNLIKELY( !vote_states ) ) {
     return 0;
   }
   fd_bank_vote_states_end_locking_modify( slot_ctx->bank );
 
-  fd_vote_states_t * vote_states_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_locking_modify( slot_ctx->bank ), FD_RUNTIME_MAX_VOTE_ACCOUNTS, 999UL ) );
+  fd_vote_states_t * vote_states_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_locking_modify( slot_ctx->bank ), MAX_TX_ACCOUNT_LOCKS, 999UL ) );
   if( FD_UNLIKELY( !vote_states_prev ) ) {
     fd_bank_vote_states_prev_end_locking_modify( slot_ctx->bank );
     return 0;
   }
   fd_bank_vote_states_prev_end_locking_modify( slot_ctx->bank );
 
-  fd_vote_states_t * vote_states_prev_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_prev_locking_modify( slot_ctx->bank ), FD_RUNTIME_MAX_VOTE_ACCOUNTS, 999UL ) );
+  fd_vote_states_t * vote_states_prev_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_prev_locking_modify( slot_ctx->bank ), MAX_TX_ACCOUNT_LOCKS, 999UL ) );
   if( FD_UNLIKELY( !vote_states_prev_prev ) ) {
     fd_bank_vote_states_prev_prev_end_locking_modify( slot_ctx->bank );
     return 0;

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -176,7 +176,7 @@ fd_runtime_fuzz_txn_ctx_create( fd_solfuzz_runner_t *              runner,
   }
 
   /* Setup vote states dummy account */
-  fd_vote_states_t * vote_states = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_locking_modify( slot_ctx->bank ), FD_RUNTIME_MAX_VOTE_ACCOUNTS, 999UL ) );
+  fd_vote_states_t * vote_states = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_locking_modify( slot_ctx->bank ), MAX_TX_ACCOUNT_LOCKS, 999UL ) );
   if( FD_UNLIKELY( !vote_states ) ) {
     fd_bank_vote_states_end_locking_modify( slot_ctx->bank );
     return NULL;
@@ -184,7 +184,7 @@ fd_runtime_fuzz_txn_ctx_create( fd_solfuzz_runner_t *              runner,
   fd_bank_vote_states_end_locking_modify( slot_ctx->bank );
 
   /* Setup vote states dummy account */
-  fd_vote_states_t * vote_states_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_locking_modify( slot_ctx->bank ), FD_RUNTIME_MAX_VOTE_ACCOUNTS, 999UL ) );
+  fd_vote_states_t * vote_states_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_locking_modify( slot_ctx->bank ), MAX_TX_ACCOUNT_LOCKS, 999UL ) );
   if( FD_UNLIKELY( !vote_states_prev ) ) {
     fd_bank_vote_states_prev_end_locking_modify( slot_ctx->bank );
     return NULL;
@@ -192,7 +192,7 @@ fd_runtime_fuzz_txn_ctx_create( fd_solfuzz_runner_t *              runner,
   fd_bank_vote_states_prev_end_locking_modify( slot_ctx->bank );
 
   /* Setup vote states dummy account */
-  fd_vote_states_t * vote_states_prev_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_prev_locking_modify( slot_ctx->bank ), FD_RUNTIME_MAX_VOTE_ACCOUNTS, 999UL ) );
+  fd_vote_states_t * vote_states_prev_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_prev_locking_modify( slot_ctx->bank ), MAX_TX_ACCOUNT_LOCKS, 999UL ) );
   if( FD_UNLIKELY( !vote_states_prev_prev ) ) {
     fd_bank_vote_states_prev_prev_end_locking_modify( slot_ctx->bank );
     return NULL;

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -192,12 +192,10 @@ fd_runtime_fuzz_txn_ctx_create( fd_solfuzz_runner_t *              runner,
   fd_bank_vote_states_prev_end_locking_modify( slot_ctx->bank );
 
   /* Setup vote states dummy account */
-  fd_vote_states_t * vote_states_prev_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_prev_locking_modify( slot_ctx->bank ), MAX_TX_ACCOUNT_LOCKS, 999UL ) );
+  fd_vote_states_t * vote_states_prev_prev = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_prev_prev_modify( slot_ctx->bank ), MAX_TX_ACCOUNT_LOCKS, 999UL ) );
   if( FD_UNLIKELY( !vote_states_prev_prev ) ) {
-    fd_bank_vote_states_prev_prev_end_locking_modify( slot_ctx->bank );
     return NULL;
   }
-  fd_bank_vote_states_prev_prev_end_locking_modify( slot_ctx->bank );
 
   /* Provide a default clock if not present */
   fd_sol_sysvar_clock_t clock_[1];


### PR DESCRIPTION
eliminates ~20mb of memcpy each time a bank is created