### PR TITLE
quic_trace: full client support

### DIFF
--- a/src/app/shared/fd_action.h
+++ b/src/app/shared/fd_action.h
@@ -94,6 +94,7 @@ union fdctl_args {
     int dump; /* whether the user requested --dump */
     int dump_config; /* whether the user requested to dump the quic config */
     int dump_conns;  /* whether the user requested to dump the quic connections */
+    int trace_send;  /* whether the user requested tracing send tile (1) or quic tile (0) */
   } quic_trace;
 
   struct {

--- a/src/app/shared_dev/commands/quic_trace/fd_quic_trace.h
+++ b/src/app/shared_dev/commands/quic_trace/fd_quic_trace.h
@@ -3,6 +3,7 @@
 
 #include "../../../shared/fd_config.h"
 #include "../../../shared/fd_action.h"
+#include "../../../../disco/net/fd_net_tile.h"
 #include "../../../../disco/quic/fd_quic_tile.h"
 #include "../../../../waltz/quic/fd_quic_private.h"
 
@@ -24,15 +25,12 @@ typedef struct peer_conn_id_map peer_conn_id_map_t;
 #define MAP_LG_SLOT_CNT       PEER_MAP_LG_SLOT_CNT
 #include "../../../../util/tmpl/fd_map.c"
 
-/* fd_quic_trace_ctx is the relocated fd_quic_ctx_t of the target quic
-   tile.  fd_quic_trace_ctx_remote is the original fd_quic_ctx_t, but
-   the pointer itself is in the local address space. */
-
-extern fd_quic_ctx_t         fd_quic_trace_ctx;
-extern fd_quic_ctx_t const * fd_quic_trace_ctx_remote;
-extern ulong                 fd_quic_trace_ctx_raddr;
-extern ulong volatile *      fd_quic_trace_link_metrics;
-extern void const *          fd_quic_trace_log_base;
+/* fd_quic_trace_ctx_remote is the original fd_quic_ctx_t, but the
+   pointer itself is in the local address space. */
+extern void const         *  fd_quic_trace_tile_ctx_remote; /* local ptr to remote ctx */
+extern ulong                 fd_quic_trace_tile_ctx_raddr;  /* remote addr of remote ctx */
+extern ulong volatile     *  fd_quic_trace_link_metrics;
+extern void const         *  fd_quic_trace_log_base;
 extern peer_conn_id_map_t    _fd_quic_trace_peer_map[1UL<<PEER_MAP_LG_SLOT_CNT];
 extern peer_conn_id_map_t *  fd_quic_trace_peer_map;
 
@@ -45,8 +43,12 @@ struct fd_quic_trace_ctx {
   int   dump;         /* whether the user requested --dump */
   int   dump_config;  /* whether the user requested --dump-config */
   int   dump_conns;   /* whether the user requested --dump-conns */
-  int   net_out;      /* whether to include tx (net-out) packets */
+  int   trace_send;   /* whether the user requested tracing send tile (1) or quic tile (0) */
   ulong net_out_base; /* base address of net-out chunks in local addr space */
+
+  fd_quic_t * quic;  /* local join to remote quic */
+  fd_net_rx_bounds_t net_in_bounds[1]; /* bounds of net-in chunks in local addr space */
+  uchar buffer[ FD_NET_MTU ];
 };
 
 typedef struct fd_quic_trace_ctx fd_quic_trace_ctx_t;
@@ -61,29 +63,41 @@ struct fd_quic_trace_frame_ctx {
 
 typedef struct fd_quic_trace_frame_ctx fd_quic_trace_frame_ctx_t;
 
+#define translate_ptr( ptr ) __extension__({                   \
+  ulong rel   = (ulong)(ptr) - fd_quic_trace_tile_ctx_raddr; \
+  ulong laddr = (ulong)fd_quic_trace_tile_ctx_remote + rel;  \
+  (__typeof__(ptr))(laddr);                                  \
+})
+
+#define tile_member( ctx_ptr, field, is_send ) \
+*fd_ptr_if( is_send, &(((fd_send_tile_ctx_t*)(ctx_ptr))->field), &(((fd_quic_ctx_t*)(ctx_ptr))->field))
+
+
 FD_PROTOTYPES_BEGIN
 
 void
 fd_quic_trace_frames( fd_quic_trace_frame_ctx_t * context,
-                      uchar const * data,
-                      ulong         data_sz );
+                      uchar               const * data,
+                      ulong                       data_sz );
 
 void
-fd_quic_trace_rx_tile( fd_quic_trace_ctx_t *  trace_ctx,
+fd_quic_trace_rx_tile( fd_quic_trace_ctx_t  * trace_ctx,
                        fd_frag_meta_t const * rx_mcache,
                        fd_frag_meta_t const * tx_mcache );
 
 void
-fd_quic_trace_log_tile( fd_frag_meta_t const * in_mcache );
+fd_quic_trace_log_tile( fd_quic_trace_ctx_t  * ctx,
+                        fd_frag_meta_t const * in_mcache );
+
+static inline fd_quic_conn_t const *
+fd_quic_trace_conn_at_idx( fd_quic_t const * quic, ulong idx ) {
+  fd_quic_state_t const * state = fd_quic_get_state_const( quic );
+  ulong const local_conn_base   = translate_ptr( state->conn_base );
+  return (fd_quic_conn_t *)( local_conn_base + idx * state->conn_sz );
+}
 
 FD_PROTOTYPES_END
 
-
-#define translate_ptr( ptr ) __extension__({              \
-    ulong rel   = (ulong)(ptr) - fd_quic_trace_ctx_raddr; \
-    ulong laddr = (ulong)fd_quic_trace_ctx_remote + rel;  \
-    (__typeof__(ptr))(laddr);                             \
-  })
 
 extern action_t fd_action_quic_trace;
 

--- a/src/app/shared_dev/commands/quic_trace/fd_quic_trace_log_tile.c
+++ b/src/app/shared_dev/commands/quic_trace/fd_quic_trace_log_tile.c
@@ -13,27 +13,25 @@ before_frag( void * _ctx   FD_FN_UNUSED,
 }
 
 static void
-during_frag( void * _ctx   FD_PARAM_UNUSED,
-             ulong  in_idx FD_PARAM_UNUSED,
-             ulong  seq    FD_PARAM_UNUSED,
-             ulong  sig    FD_PARAM_UNUSED,
-             ulong  chunk,
-             ulong  sz,
-             ulong  ctl    FD_PARAM_UNUSED ) {
-  fd_quic_ctx_t * ctx = &fd_quic_trace_ctx;
+during_frag( fd_quic_trace_ctx_t * ctx,
+             ulong                 in_idx FD_PARAM_UNUSED,
+             ulong                 seq    FD_PARAM_UNUSED,
+             ulong                 sig    FD_PARAM_UNUSED,
+             ulong                 chunk,
+             ulong                 sz,
+             ulong                 ctl    FD_PARAM_UNUSED ) {
   fd_memcpy( ctx->buffer, fd_chunk_to_laddr_const( fd_quic_trace_log_base, chunk ), sz );
 }
 
 static void
-after_frag( void *              _ctx   FD_FN_UNUSED,
-            ulong               in_idx FD_FN_UNUSED,
-            ulong               seq    FD_FN_UNUSED,
-            ulong               sig    FD_FN_UNUSED,
-            ulong               sz     FD_FN_UNUSED,
-            ulong               tsorig FD_FN_UNUSED,
-            ulong               tspub  FD_FN_UNUSED,
-            fd_stem_context_t * stem   FD_FN_UNUSED ) {
-  fd_quic_ctx_t * ctx = &fd_quic_trace_ctx;
+after_frag( fd_quic_trace_ctx_t * ctx,
+            ulong                 in_idx FD_FN_UNUSED,
+            ulong                 seq    FD_FN_UNUSED,
+            ulong                 sig    FD_FN_UNUSED,
+            ulong                 sz     FD_FN_UNUSED,
+            ulong                 tsorig FD_FN_UNUSED,
+            ulong                 tspub  FD_FN_UNUSED,
+            fd_stem_context_t   * stem   FD_FN_UNUSED ) {
   fd_quic_log_error_t const * error = fd_type_pun_const( ctx->buffer );
   printf( "event=conn_close_quic conn_id=%016lx src_ip=%08x enc=%d pktnum=%8lu close_code=0x%lx loc=%.*s(%u)\n",
           error->hdr.conn_id,
@@ -49,8 +47,9 @@ after_frag( void *              _ctx   FD_FN_UNUSED,
 
 #define STEM_BURST (1UL)
 
-#define STEM_CALLBACK_CONTEXT_TYPE  void
-#define STEM_CALLBACK_CONTEXT_ALIGN 1
+#define STEM_CALLBACK_CONTEXT_TYPE  fd_quic_trace_ctx_t
+#define STEM_CALLBACK_CONTEXT_ALIGN alignof(fd_quic_trace_ctx_t)
+
 #define STEM_CALLBACK_BEFORE_FRAG   before_frag
 #define STEM_CALLBACK_DURING_FRAG   during_frag
 #define STEM_CALLBACK_AFTER_FRAG    after_frag
@@ -58,7 +57,8 @@ after_frag( void *              _ctx   FD_FN_UNUSED,
 #include "../../../../disco/stem/fd_stem.c"
 
 void
-fd_quic_trace_log_tile( fd_frag_meta_t const * in_mcache ) {
+fd_quic_trace_log_tile( fd_quic_trace_ctx_t  * ctx,
+                        fd_frag_meta_t const * in_mcache ) {
   fd_frag_meta_t const * in_mcache_tbl[1] = { in_mcache };
 
   uchar   fseq_mem[ FD_FSEQ_FOOTPRINT ] __attribute__((aligned(FD_FSEQ_ALIGN)));
@@ -82,7 +82,7 @@ fd_quic_trace_log_tile( fd_frag_meta_t const * in_mcache ) {
              /* stem_lazy  */ 0L,
              /* rng        */ rng,
              /* scratch    */ scratch,
-             /* ctx        */ NULL );
+             /* ctx        */ ctx );
 
   fd_fseq_delete( fd_fseq_leave( fseq ) );
 }

--- a/src/app/shared_dev/commands/quic_trace/fd_quic_trace_rx_tile.c
+++ b/src/app/shared_dev/commands/quic_trace/fd_quic_trace_rx_tile.c
@@ -13,16 +13,21 @@
 #include "../../../../util/net/fd_udp.h"
 
 static int
-before_frag( void * _ctx   FD_FN_UNUSED,
-             ulong  in_idx FD_FN_UNUSED,
-             ulong  seq    FD_FN_UNUSED,
-             ulong  sig ) {
-  /* Skip non-QUIC packets */
+before_frag( fd_quic_trace_ctx_t * ctx,
+             ulong                 in_idx FD_FN_UNUSED,
+             ulong                 seq    FD_FN_UNUSED,
+             ulong                 sig ) {
+  /* Skip non-QUIC packets, based on the tile we target */
   ulong proto = fd_disco_netmux_sig_proto( sig );
+  int   send  = ctx->trace_send;
+
   switch( proto ) {
     case DST_PROTO_OUTGOING:
+      return 0;
     case DST_PROTO_TPU_QUIC:
-      break;
+      return send;
+    case DST_PROTO_SEND:
+      return !send;
     default:
         return 1;
   }
@@ -31,34 +36,31 @@ before_frag( void * _ctx   FD_FN_UNUSED,
 }
 
 static void
-during_frag( void * _ctx,
-             ulong  in_idx FD_PARAM_UNUSED,
-             ulong  seq    FD_PARAM_UNUSED,
-             ulong  sig,
-             ulong  chunk,
-             ulong  sz,
-             ulong  ctl ) {
-  fd_quic_ctx_t *       ctx       = &fd_quic_trace_ctx;
-  fd_quic_trace_ctx_t * trace_ctx = (fd_quic_trace_ctx_t*)_ctx;
-
+during_frag( fd_quic_trace_ctx_t * ctx,
+             ulong                 in_idx FD_PARAM_UNUSED,
+             ulong                 seq    FD_PARAM_UNUSED,
+             ulong                 sig,
+             ulong                 chunk,
+             ulong                 sz,
+             ulong                 ctl ) {
   ulong proto = fd_disco_netmux_sig_proto( sig );
-  if( proto == DST_PROTO_TPU_QUIC ) {
+  if( (proto==DST_PROTO_TPU_QUIC) | (proto==DST_PROTO_SEND) ) {
     fd_memcpy( ctx->buffer, fd_net_rx_translate_frag( &ctx->net_in_bounds[0], chunk, ctl, sz ), sz );
   } else if( proto == DST_PROTO_OUTGOING ) {
-    ulong p = (trace_ctx->net_out_base + (chunk<<FD_CHUNK_LG_SZ));
+    ulong p = ctx->net_out_base + (chunk<<FD_CHUNK_LG_SZ);
     fd_memcpy( ctx->buffer, (void*)p, sz );
   }
 }
 
 static int
-bounds_check_conn( fd_quic_t *      quic,
-                   fd_quic_conn_t * conn ) {
+bounds_check_conn( fd_quic_t      const * quic,
+                   fd_quic_conn_t const * conn ) {
   long conn_off = (long)((ulong)conn-(ulong)quic);
   return conn_off >= (long)quic->layout.conns_off && conn_off < (long)quic->layout.conn_map_off;
 }
 
 static ulong
-fd_quic_trace_initial( fd_quic_trace_ctx_t * trace_ctx,
+fd_quic_trace_initial( fd_quic_trace_ctx_t * ctx,
                        uchar *               data,
                        ulong                 data_sz,
                        uint                  ip4_saddr,
@@ -66,9 +68,8 @@ fd_quic_trace_initial( fd_quic_trace_ctx_t * trace_ctx,
                        uint                  ip4_daddr,
                        ushort                udp_dport,
                        uint                  key_idx ) {
-  fd_quic_ctx_t *      ctx      = &fd_quic_trace_ctx;
-  fd_quic_t *          quic     = ctx->quic;
-  fd_quic_state_t *    state    = fd_quic_get_state( quic );
+  fd_quic_t          * quic     = ctx->quic;
+  fd_quic_state_t    * state    = fd_quic_get_state( quic );
   fd_quic_conn_map_t * conn_map = translate_ptr( state->conn_map );
 
   if( FD_UNLIKELY( data_sz < FD_QUIC_SHORTEST_PKT ) ) return FD_QUIC_PARSE_FAIL;
@@ -110,41 +111,36 @@ fd_quic_trace_initial( fd_quic_trace_ctx_t * trace_ctx,
           ulong peer_conn_id = key_idx == 0 ? fd_ulong_load_8( initial->src_conn_id )
                                             : fd_ulong_load_8( initial->dst_conn_id );
 
-          if( 1 ) {
-            /* insert into peer_cid map */
-            peer_conn_id_map_t * entry = peer_conn_id_map_insert( fd_quic_trace_peer_map, peer_conn_id );
+          /* insert into peer_cid map */
+          peer_conn_id_map_t * entry = peer_conn_id_map_insert( fd_quic_trace_peer_map, peer_conn_id );
 
-            /* NULL entry either implies already exists, or full */
-            if( entry ) {
-              entry->conn_idx = conn->conn_idx;
-            }
+          /* NULL entry either implies already exists, or full */
+          if( entry ) {
+            entry->conn_idx = conn->conn_idx;
           }
         }
+      } else {
+        FD_LOG_WARNING(( "conn out of bounds in fd_quic_trace_initial for conn id %lu with key idx %u", conn_id, key_idx ));
       }
+    } else {
+      FD_LOG_DEBUG(( "Failed to find conn for conn id %lu with key idx %u", conn_id, key_idx ));
     }
   }
 
   if( !keys || memcmp( keys->pkt_key, EMPTY, sizeof( keys->pkt_key ) ) == 0 ) {
-    if( key_idx == 0 ) {
-      /* on ingress, try creating the skeys */
+    int is_client = ctx->trace_send;
+    int is_egress = (int)key_idx;
 
-      /* Set secrets->initial_secret */
+    /* (server,egress) and (client,ingress) don't have the client's orig DCID avail */
+    if( is_client==is_egress ) {
       fd_quic_crypto_secrets_t secrets[1];
       fd_quic_gen_initial_secrets(
           secrets,
           initial->dst_conn_id, initial->dst_conn_id_len,
-          /* is_client */ 0 );
-
-      /* Derive secrets->secret[0][0] */
-      fd_tls_hkdf_expand_label(
-          secrets->secret[0][0], FD_QUIC_SECRET_SZ,
-          secrets->initial_secret,
-          FD_QUIC_CRYPTO_LABEL_CLIENT_IN,
-          FD_QUIC_CRYPTO_LABEL_CLIENT_IN_LEN,
-          NULL, 0UL );
+          !is_client );
 
       /* Derive decryption key */
-      fd_quic_gen_keys( _keys, secrets->secret[0][key_idx] );
+      fd_quic_gen_keys( _keys, secrets->secret[fd_quic_enc_level_initial_id][key_idx] );
       keys = _keys;
     }
   }
@@ -173,7 +169,7 @@ fd_quic_trace_initial( fd_quic_trace_ctx_t * trace_ctx,
   ulong wrap_sz = hdr_sz + FD_QUIC_CRYPTO_TAG_SZ;
   if( FD_UNLIKELY( data_sz<wrap_sz ) ) return FD_QUIC_PARSE_FAIL;
 
-  if( trace_ctx->dump ) {
+  if( ctx->dump ) {
     fd_quic_pretty_print_t quic_pkt_ctx = {
       .ip4_saddr = ip4_saddr,
       .udp_sport = udp_sport,
@@ -184,7 +180,7 @@ fd_quic_trace_initial( fd_quic_trace_ctx_t * trace_ctx,
     fd_quic_pretty_print_quic_pkt( &quic_pkt_ctx,
                                    state->now,
                                    data,
-                                   data_sz );
+                                   tot_sz );
     fflush( stdout );
   } else {
     uchar conn_id_truncated[24] = {0};
@@ -197,14 +193,14 @@ fd_quic_trace_initial( fd_quic_trace_ctx_t * trace_ctx,
       .pkt_type = FD_QUIC_PKT_TYPE_INITIAL
     };
 
-    fd_quic_trace_frames( &frame_ctx, data+hdr_sz, data_sz-wrap_sz );
+    fd_quic_trace_frames( &frame_ctx, data+hdr_sz, tot_sz-wrap_sz );
   }
 
   return tot_sz;
 }
 
 static ulong
-fd_quic_trace_handshake( fd_quic_trace_ctx_t * trace_ctx,
+fd_quic_trace_handshake( fd_quic_trace_ctx_t * ctx,
                          uchar *               data,
                          ulong                 data_sz,
                          uint                  ip4_saddr,
@@ -212,7 +208,6 @@ fd_quic_trace_handshake( fd_quic_trace_ctx_t * trace_ctx,
                          uint                  ip4_daddr,
                          ushort                udp_dport,
                          uint                  key_idx ) {
-  fd_quic_ctx_t *      ctx      = &fd_quic_trace_ctx;
   fd_quic_t *          quic     = ctx->quic;
   fd_quic_state_t *    state    = fd_quic_get_state( quic );
   fd_quic_conn_map_t * conn_map = translate_ptr( state->conn_map );
@@ -274,7 +269,7 @@ fd_quic_trace_handshake( fd_quic_trace_ctx_t * trace_ctx,
   ulong wrap_sz = hdr_sz + FD_QUIC_CRYPTO_TAG_SZ;
   if( FD_UNLIKELY( data_sz<wrap_sz ) ) return FD_QUIC_PARSE_FAIL;
 
-  if( trace_ctx->dump ) {
+  if( ctx->dump ) {
     fd_quic_pretty_print_t quic_pkt_ctx = {
       .ip4_saddr = ip4_saddr,
       .udp_sport = udp_sport,
@@ -305,7 +300,7 @@ fd_quic_trace_handshake( fd_quic_trace_ctx_t * trace_ctx,
 }
 
 static void
-fd_quic_trace_1rtt( fd_quic_trace_ctx_t * trace_ctx,
+fd_quic_trace_1rtt( fd_quic_trace_ctx_t * ctx,
                     uchar *               data,
                     ulong                 data_sz,
                     uint                  ip4_saddr,
@@ -313,15 +308,14 @@ fd_quic_trace_1rtt( fd_quic_trace_ctx_t * trace_ctx,
                     uint                  ip4_daddr,
                     ushort                udp_dport,
                     uint                  key_idx ) {
-  fd_quic_ctx_t *      ctx      = &fd_quic_trace_ctx;
   fd_quic_t *          quic     = ctx->quic;
   fd_quic_state_t *    state    = fd_quic_get_state( quic );
   fd_quic_conn_map_t * conn_map = translate_ptr( state->conn_map );
 
   if( FD_UNLIKELY( data_sz < FD_QUIC_SHORTEST_PKT ) ) return;
 
-  fd_quic_conn_t * conn        = NULL;
-  ulong            dst_conn_id = 0UL;
+  fd_quic_conn_t const * conn        = NULL;
+  ulong                  dst_conn_id = 0UL;
 
   /* key_idx 0 is ingress, key_idx 1 is egress */
   if( key_idx == 0 ) {
@@ -338,8 +332,7 @@ fd_quic_trace_1rtt( fd_quic_trace_ctx_t * trace_ctx,
     /* we use the first 8 bytes of the peer conn_id for the key
        since we don't actually know the length */
 
-    ulong peer_conn_id;
-    memcpy( &peer_conn_id, data+1, 8UL );
+    ulong peer_conn_id = fd_ulong_load_8( data+1 );
 
     /* look up connection id in peer conn_id map */
     uint                 conn_idx = 0;
@@ -355,11 +348,11 @@ fd_quic_trace_1rtt( fd_quic_trace_ctx_t * trace_ctx,
               "\"flow\": \"%s\", "
               "\"trace_time\": \"%s\", "
               "\"src_ip_addr\": \"" FD_IP4_ADDR_FMT "\", "
-              "\"src_udp_port\": %u, "
+              "\"src_udp_port\": \"%u\", "
               "\"dst_ip_addr\": \"" FD_IP4_ADDR_FMT "\", "
-              "\"dst_udp_port\": %u, "
+              "\"dst_udp_port\": \"%u\", "
               "\"hdr_type\": \"1-rtt\", "
-              "\"err\": \"no-connection\", "
+              "\"err\": \"no-trace-connection\", "
               "\"dst_conn_id\": \"%lx\" "
               "}, ] }\n",
          key_idx == 0 ? "ingress" : "egress",
@@ -373,15 +366,12 @@ fd_quic_trace_1rtt( fd_quic_trace_ctx_t * trace_ctx,
       return;
     }
 
-    long conn_loc = (long)quic + (long)quic->layout.conns_off;
-    fd_quic_conn_t * conns = (fd_quic_conn_t*)conn_loc;
-
-    conn = &conns[conn_idx];
+    conn = fd_quic_trace_conn_at_idx( quic, conn_idx );
   }
 
   if( !conn ) return;
 
-  fd_quic_crypto_keys_t * keys = &conn->keys[ fd_quic_enc_level_appdata_id ][ key_idx ];
+  fd_quic_crypto_keys_t const * keys = &conn->keys[ fd_quic_enc_level_appdata_id ][ key_idx ];
 
   ulong pktnum_off = 9UL;
   int hdr_err = fd_quic_crypto_decrypt_hdr( data, data_sz, pktnum_off, keys );
@@ -397,7 +387,7 @@ fd_quic_trace_1rtt( fd_quic_trace_ctx_t * trace_ctx,
   ulong wrap_sz = hdr_sz + FD_QUIC_CRYPTO_TAG_SZ;
   if( FD_UNLIKELY( data_sz<wrap_sz ) ) return;
 
-  if( trace_ctx->dump ) {
+  if( ctx->dump ) {
     fd_quic_pretty_print_t quic_pkt_ctx = {
       .ip4_saddr = ip4_saddr,
       .udp_sport = udp_sport,
@@ -421,19 +411,26 @@ fd_quic_trace_1rtt( fd_quic_trace_ctx_t * trace_ctx,
 
     fd_quic_trace_frames( &frame_ctx, data+hdr_sz, data_sz-wrap_sz );
   }
+}
 
-  (void)ip4_saddr; (void)conn;
+static int
+is_valid_quic_long_hdr( uchar* data ) {
+  if( data[0]>>6 != 0x3 ) return 0;
+  uint version = fd_uint_bswap( FD_LOAD( uint, data + 1 ) );
+  if( version != 1 ) return 0;
+
+  return 1;
 }
 
 static void
-fd_quic_trace_pkt( void *          ctx,
-                   uchar *         data,
-                   ulong           data_sz,
-                   uint            ip4_saddr,
-                   ushort          udp_sport,
-                   uint            ip4_daddr,
-                   ushort          udp_dport,
-                   uint            key_idx ) {
+fd_quic_trace_pkt( fd_quic_trace_ctx_t * ctx,
+                   uchar               * data,
+                   ulong                 data_sz,
+                   uint                  ip4_saddr,
+                   ushort                udp_sport,
+                   uint                  ip4_daddr,
+                   ushort                udp_dport,
+                   uint                  key_idx ) {
 
   uchar * cur_ptr = data;
   uchar * end_ptr = data + data_sz;
@@ -441,13 +438,24 @@ fd_quic_trace_pkt( void *          ctx,
     int is_long = fd_quic_h0_hdr_form( cur_ptr[0] );
     ulong sz = 0;
     if( is_long ) {
+      if( !is_valid_quic_long_hdr( cur_ptr ) ) {
+        FD_LOG_NOTICE(( "Invalid quic long hdr with key_idx %u (maybe udp)", key_idx ));
+        return;
+      };
       switch( fd_quic_h0_long_packet_type( cur_ptr[0] ) ) {
-      case FD_QUIC_PKT_TYPE_INITIAL:
-        sz = fd_quic_trace_initial( ctx, cur_ptr, (ulong)( end_ptr - cur_ptr ), ip4_saddr, udp_sport, ip4_daddr, udp_dport, key_idx );
-        break;
-      case FD_QUIC_PKT_TYPE_HANDSHAKE:
-        sz = fd_quic_trace_handshake( ctx, cur_ptr, (ulong)( end_ptr - cur_ptr ), ip4_saddr, udp_sport, ip4_daddr, udp_dport, key_idx );
-        break;
+        case FD_QUIC_PKT_TYPE_INITIAL:
+          sz = fd_quic_trace_initial( ctx, cur_ptr, (ulong)( end_ptr - cur_ptr ), ip4_saddr, udp_sport, ip4_daddr, udp_dport, key_idx );
+          break;
+        case FD_QUIC_PKT_TYPE_HANDSHAKE:
+          sz = fd_quic_trace_handshake( ctx, cur_ptr, (ulong)( end_ptr - cur_ptr ), ip4_saddr, udp_sport, ip4_daddr, udp_dport, key_idx );
+          break;
+        case FD_QUIC_PKT_TYPE_RETRY:
+          /* TODO fd_quic_trace_retry */
+          FD_LOG_NOTICE(( "%s retry packet of data_sz %lu, src: " FD_IP4_ADDR_FMT ":%u, dst: " FD_IP4_ADDR_FMT ":%u", key_idx==0 ? "Received" : "Sent", (ulong)( end_ptr - cur_ptr ), FD_IP4_ADDR_FMT_ARGS( ip4_saddr ), udp_sport, FD_IP4_ADDR_FMT_ARGS( ip4_daddr ), udp_dport ));
+          return;
+        default:
+          FD_LOG_NOTICE(( "Unknown long packet type with key_idx %u, data_sz %lu, src: " FD_IP4_ADDR_FMT ":%u, dst: " FD_IP4_ADDR_FMT ":%u", key_idx, (ulong)( end_ptr - cur_ptr ), FD_IP4_ADDR_FMT_ARGS( ip4_saddr ), udp_sport, FD_IP4_ADDR_FMT_ARGS( ip4_daddr ), udp_dport ));
+          return;
       }
 
       /* TODO TX should support FD_QUIC_PKT_TYPE_RETRY */
@@ -466,18 +474,16 @@ fd_quic_trace_pkt( void *          ctx,
 }
 
 static void
-after_frag( void * _ctx,
-            ulong  in_idx FD_PARAM_UNUSED,
-            ulong  seq FD_PARAM_UNUSED,
-            ulong  sig,
-            ulong  sz,
-            ulong  tsorig FD_PARAM_UNUSED,
-            ulong  tspub FD_PARAM_UNUSED,
-            fd_stem_context_t * stem FD_PARAM_UNUSED ) {
+after_frag( fd_quic_trace_ctx_t * ctx,
+            ulong                 in_idx FD_PARAM_UNUSED,
+            ulong                 seq    FD_PARAM_UNUSED,
+            ulong                 sig,
+            ulong                 sz,
+            ulong                 tsorig FD_PARAM_UNUSED,
+            ulong                 tspub  FD_PARAM_UNUSED,
+            fd_stem_context_t   * stem   FD_PARAM_UNUSED ) {
   ulong proto   = fd_disco_netmux_sig_proto( sig );
-  uint  key_idx = proto == DST_PROTO_TPU_QUIC ? 0 : 1;
-
-  fd_quic_ctx_t * ctx = &fd_quic_trace_ctx;
+  uint  key_idx = proto==DST_PROTO_OUTGOING ? 1 : 0;
 
   if( sz < FD_QUIC_SHORTEST_PKT ) return;
   if( sz > sizeof(ctx->buffer)  ) return;
@@ -500,20 +506,20 @@ after_frag( void * _ctx,
   if( FD_UNLIKELY( cur+sizeof(fd_udp_hdr_t) > end ) ) return;
   cur += sizeof(fd_udp_hdr_t);
   if( FD_UNLIKELY( cur>end ) ) return;
-  (void)udp_hdr;
 
   uint   ip4_saddr = fd_uint_load_4( ip4_hdr->saddr_c );
   ushort udp_sport = fd_ushort_bswap( udp_hdr->net_sport );
   uint   ip4_daddr = fd_uint_load_4( ip4_hdr->daddr_c );
   ushort udp_dport = fd_ushort_bswap( udp_hdr->net_dport );
-  fd_quic_trace_pkt( _ctx, cur, (ulong)( end-cur ), ip4_saddr, udp_sport, ip4_daddr, udp_dport, key_idx );
+  fd_quic_trace_pkt( ctx, cur, (ulong)( end-cur ), ip4_saddr, udp_sport, ip4_daddr, udp_dport, key_idx );
 }
 
 
 #define STEM_BURST (1UL)
 
 #define STEM_CALLBACK_CONTEXT_TYPE  fd_quic_trace_ctx_t
-#define STEM_CALLBACK_CONTEXT_ALIGN 1
+#define STEM_CALLBACK_CONTEXT_ALIGN alignof(fd_quic_trace_ctx_t)
+
 #define STEM_CALLBACK_BEFORE_FRAG   before_frag
 #define STEM_CALLBACK_DURING_FRAG   during_frag
 #define STEM_CALLBACK_AFTER_FRAG    after_frag
@@ -521,7 +527,7 @@ after_frag( void * _ctx,
 #include "../../../../disco/stem/fd_stem.c"
 
 void
-fd_quic_trace_rx_tile( fd_quic_trace_ctx_t *  trace_ctx,
+fd_quic_trace_rx_tile( fd_quic_trace_ctx_t  * trace_ctx,
                        fd_frag_meta_t const * rx_mcache,
                        fd_frag_meta_t const * tx_mcache ) {
 

--- a/src/discof/send/fd_send_tile.c
+++ b/src/discof/send/fd_send_tile.c
@@ -100,8 +100,7 @@ quic_hs_complete( fd_quic_conn_t * conn,
 
 inline static int
 port_idx_is_quic( ulong port_idx ) {
-  return !!(port_idx == FD_SEND_PORT_QUIC_VOTE_IDX) |
-         !!(port_idx == FD_SEND_PORT_QUIC_TPU_IDX);
+  return (port_idx==FD_SEND_PORT_QUIC_VOTE_IDX) | (port_idx==FD_SEND_PORT_QUIC_TPU_IDX);
 }
 
 /* quic_conn_final is called when the QUIC connection dies. */

--- a/src/waltz/quic/fd_quic_pretty_print.c
+++ b/src/waltz/quic/fd_quic_pretty_print.c
@@ -567,12 +567,12 @@ fd_quic_pretty_print_quic_pkt( fd_quic_pretty_print_t * pkt_ctx,
   out_buf_sz -= sz;
 
   /* */ sz = safe_snprintf( out_buf, out_buf_sz, "\"src_ip_addr\": \"%s\", \"src_udp_port\": \"%u\", ",
-                            ip4_to_str( tmp_buf, pkt_ctx->ip4_saddr ), fd_ushort_bswap( (ushort)pkt_ctx->udp_sport ) );
+                            ip4_to_str( tmp_buf, pkt_ctx->ip4_saddr ), pkt_ctx->udp_sport );
   out_buf    += sz;
   out_buf_sz -= sz;
 
   /* */ sz = safe_snprintf( out_buf, out_buf_sz, "\"dst_ip_addr\": \"%s\", \"dst_udp_port\": \"%u\", ",
-                            ip4_to_str( tmp_buf, pkt_ctx->ip4_daddr ), fd_ushort_bswap( (ushort)pkt_ctx->udp_dport ) );
+                            ip4_to_str( tmp_buf, pkt_ctx->ip4_daddr ), pkt_ctx->udp_dport );
   out_buf    += sz;
   out_buf_sz -= sz;
 


### PR DESCRIPTION
This PR extends quic_trace for the full client (particularly send_tile). It simplifies the rebasing logic and fixes various quic_trace bugs. 