### PR TITLE
topob: auto layout should deprioritize HT pairs

### DIFF
--- a/src/app/fdctl/topology.c
+++ b/src/app/fdctl/topology.c
@@ -389,7 +389,7 @@ fd_topo_initialize( config_t * config ) {
     fd_topo_configure_tile( tile, config );
   }
 
-  if( FD_UNLIKELY( is_auto_affinity ) ) fd_topob_auto_layout( topo, 1 );
+  if( FD_UNLIKELY( is_auto_affinity ) ) fd_topob_auto_layout( topo, 1, 0 );
 
   fd_topob_finish( topo, CALLBACKS );
   config->topo = *topo;

--- a/src/app/firedancer-dev/commands/gossip.c
+++ b/src/app/firedancer-dev/commands/gossip.c
@@ -39,7 +39,7 @@ gossip_cmd_topo( config_t * config ) {
 
   fd_topob_tile_in( topo, "gossip", 0UL, "metric_in", "sign_gossip",  0UL, FD_TOPOB_UNRELIABLE, FD_TOPOB_UNPOLLED );
   for( ulong i=0UL; i<net_tile_cnt; i++ ) fd_topos_net_tile_finish( topo, i );
-  fd_topob_auto_layout( topo, 0 );
+  fd_topob_auto_layout( topo, 0, 1 );
   fd_topob_finish( topo, CALLBACKS );
 }
 

--- a/src/app/firedancer-dev/commands/ipecho_server.c
+++ b/src/app/firedancer-dev/commands/ipecho_server.c
@@ -31,7 +31,7 @@ ipecho_topo( fd_topo_t *  topo,
   tile->ipecho.bind_port    = 12008;
   fd_topob_tile_out( topo, "ipecho", 0UL, "ipecho_out", 0UL );
 
-  fd_topob_auto_layout( topo, 0 );
+  fd_topob_auto_layout( topo, 0, 1 );
   fd_topob_finish( topo, CALLBACKS );
 }
 

--- a/src/app/firedancer-dev/commands/repair.c
+++ b/src/app/firedancer-dev/commands/repair.c
@@ -301,7 +301,7 @@ repair_topo( config_t * config ) {
     fd_topo_configure_tile( tile, config );
   }
 
-  if( FD_UNLIKELY( is_auto_affinity ) ) fd_topob_auto_layout( topo, 0 );
+  if( FD_UNLIKELY( is_auto_affinity ) ) fd_topob_auto_layout( topo, 0, 1 );
 
   fd_topob_finish( topo, CALLBACKS );
 

--- a/src/app/firedancer-dev/commands/send_test/send_test.c
+++ b/src/app/firedancer-dev/commands/send_test/send_test.c
@@ -145,7 +145,7 @@ send_test_topo( config_t * config ) {
   }
 
   /* Finish topology setup */
-  if( FD_UNLIKELY( !strcmp( config->layout.affinity, "auto" ) ) ) fd_topob_auto_layout( topo, 0 );
+  if( FD_UNLIKELY( !strcmp( config->layout.affinity, "auto" ) ) ) fd_topob_auto_layout( topo, 0, 1 );
   fd_topob_finish( topo, CALLBACKS );
 }
 

--- a/src/app/firedancer-dev/commands/snapshot_load.c
+++ b/src/app/firedancer-dev/commands/snapshot_load.c
@@ -109,7 +109,7 @@ snapshot_load_topo( config_t *     config,
   snaprd_tile->snaprd.diagnostics = 0;
 
   if( !args->snapshot_load.tile_cpus[0] ) {
-    fd_topob_auto_layout( topo, 0 );
+    fd_topob_auto_layout( topo, 0, 1 );
   }
   fd_topob_finish( topo, CALLBACKS );
 }

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -687,7 +687,7 @@ fd_topo_initialize( config_t * config ) {
   }
 
 
-  if( FD_UNLIKELY( is_auto_affinity ) ) fd_topob_auto_layout( topo, 0 );
+  if( FD_UNLIKELY( is_auto_affinity ) ) fd_topob_auto_layout( topo, 0, 1 );
 
   /* There is a special fseq that sits between the pack, bank, and poh
      tiles to indicate when the bank/poh tiles are done processing a

--- a/src/app/shared_dev/commands/bench/bench.c
+++ b/src/app/shared_dev/commands/bench/bench.c
@@ -50,7 +50,7 @@ add_bench_topo( fd_topo_t  * topo,
                 ushort       rpc_port,
                 uint         rpc_ip_addr,
                 int          no_quic,
-                int          reserve_agave_cores ) {
+                int          is_firedancer ) {
 
   fd_topob_wksp( topo, "bench" );
   fd_topob_link( topo, "bencho_out", "bench", 128UL, 64UL, 1UL );
@@ -116,7 +116,7 @@ add_bench_topo( fd_topo_t  * topo,
   }
 
   /* This will blow away previous auto topology layouts and recompute an auto topology. */
-  if( FD_UNLIKELY( is_bench_auto_affinity ) ) fd_topob_auto_layout( topo, reserve_agave_cores );
+  if( FD_UNLIKELY( is_bench_auto_affinity ) ) fd_topob_auto_layout( topo, !is_firedancer, is_firedancer );
   fd_topob_finish( topo, CALLBACKS );
 }
 
@@ -161,7 +161,7 @@ bench_cmd_fn( args_t *   args,
                   config->rpc.port,
                   config->net.ip_addr,
                   args->load.no_quic,
-                  !config->is_firedancer );
+                  config->is_firedancer );
 
   args_t configure_args = {
     .configure.command = CONFIGURE_CMD_INIT,

--- a/src/app/shared_dev/commands/pktgen/pktgen.c
+++ b/src/app/shared_dev/commands/pktgen/pktgen.c
@@ -70,7 +70,7 @@ pktgen_topo( config_t * config ) {
   fd_topob_tile_in( topo, "pktgen", 0UL, "metric_in", "net_quic", 0UL, FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
 
   fd_topos_net_tile_finish( topo, 0UL );
-  if( FD_UNLIKELY( is_auto_affinity ) ) fd_topob_auto_layout( topo, 0 );
+  if( FD_UNLIKELY( is_auto_affinity ) ) fd_topob_auto_layout( topo, 0, config->is_firedancer );
   topo->agave_affinity_cnt = 0;
   fd_topob_finish( topo, CALLBACKS );
   fd_topo_print_log( /* stdout */ 1, topo );

--- a/src/app/shared_dev/commands/udpecho/udpecho.c
+++ b/src/app/shared_dev/commands/udpecho/udpecho.c
@@ -63,7 +63,7 @@ udpecho_topo( config_t * config ) {
   fd_topob_tile_in( topo, "l4swap", 0UL, "metric_in", "net_quic", 0UL, FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
 
   fd_topos_net_tile_finish( topo, 0UL );
-  if( FD_UNLIKELY( is_auto_affinity ) ) fd_topob_auto_layout( topo, 0 );
+  if( FD_UNLIKELY( is_auto_affinity ) ) fd_topob_auto_layout( topo, 0, config->is_firedancer );
   topo->agave_affinity_cnt = 0;
   fd_topob_finish( topo, CALLBACKS );
   fd_topo_print_log( /* stdout */ 1, topo );

--- a/src/disco/topo/fd_topob.h
+++ b/src/disco/topo/fd_topob.h
@@ -132,7 +132,8 @@ fd_topob_tile_out( fd_topo_t *  topo,
 
 void
 fd_topob_auto_layout( fd_topo_t * topo,
-                      int         reserve_agave_cores );
+                      int         reserve_agave_cores,
+                      int         is_firedancer );
 
 /* Finish creating the topology.  Lays out all the objects in the
    given workspaces, and sizes everything correctly.  Also validates


### PR DESCRIPTION
We keep the existing logic for Frakendancer and only use the new deprioritization for Firedancer. Both are changed to allocate core(s) for CRITICAL tiles before non-critical tiles.