### PR TITLE
runtime: add RBH to sysvar cache

### DIFF
--- a/src/flamenco/runtime/program/fd_system_program_nonce.c
+++ b/src/flamenco/runtime/program/fd_system_program_nonce.c
@@ -39,21 +39,14 @@ require_acct_rent( fd_exec_instr_ctx_t * ctx,
 }
 
 static int
-require_acct_recent_blockhashes( fd_exec_instr_ctx_t *        ctx,
-                                 ushort                       idx,
-                                 fd_recent_block_hashes_t * * out ) {
+require_acct_recent_blockhashes( fd_exec_instr_ctx_t * ctx,
+                                 ushort                idx ) {
+  int err = require_acct( ctx, idx, &fd_sysvar_recent_block_hashes_id );
+  if( FD_UNLIKELY( err ) ) return err;
 
-  do {
-    int err = require_acct( ctx, idx, &fd_sysvar_recent_block_hashes_id );
-    if( FD_UNLIKELY( err ) ) return err;
-  } while(0);
-
-  fd_recent_block_hashes_t const * rbh = fd_sysvar_recent_hashes_read( ctx->txn_ctx->funk, ctx->txn_ctx->funk_txn, ctx->txn_ctx->spad );
-  if( FD_UNLIKELY( !rbh ) ) {
+  if( FD_UNLIKELY( !fd_sysvar_cache_recent_hashes_is_valid( ctx->sysvar_cache ) ) ) {
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_SYSVAR;
   }
-
-  (*out)->hashes = rbh->hashes;
 
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
@@ -264,18 +257,19 @@ fd_system_program_exec_advance_nonce_account( fd_exec_instr_ctx_t * ctx ) {
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L427-L432 */
 
-  fd_recent_block_hashes_t   recent_blockhashes_obj;
-  fd_recent_block_hashes_t * recent_blockhashes = &recent_blockhashes_obj;
-  do {
-    err = require_acct_recent_blockhashes( ctx, 1UL, &recent_blockhashes );
-    if( FD_UNLIKELY( err ) ) return err;
-  } while(0);
-
-  fd_block_block_hash_entry_t const * hashes = recent_blockhashes->hashes;
+  err = require_acct_recent_blockhashes( ctx, 1UL );
+  if( FD_UNLIKELY( err ) ) return err;
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L433-L439 */
 
-  if( FD_UNLIKELY( deq_fd_block_block_hash_entry_t_empty( hashes ) ) ) {
+  int bhq_empty;
+  do {
+    fd_block_block_hash_entry_t const * hashes = fd_sysvar_cache_recent_hashes_join_const( ctx->sysvar_cache );
+    if( FD_UNLIKELY( !hashes ) ) __builtin_unreachable(); /* validated above */
+    bhq_empty = deq_fd_block_block_hash_entry_t_empty( hashes );
+    fd_sysvar_cache_recent_hashes_leave_const( ctx->sysvar_cache, hashes );
+  } while(0);
+  if( FD_UNLIKELY( bhq_empty ) ) {
     fd_log_collector_msg_literal( ctx, "Advance nonce account: recent blockhash list is empty" );
     ctx->txn_ctx->custom_err = FD_SYSTEM_PROGRAM_ERR_NONCE_NO_RECENT_BLOCKHASHES;
     return FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR;
@@ -476,10 +470,8 @@ fd_system_program_exec_withdraw_nonce_account( fd_exec_instr_ctx_t * ctx,
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L445-L449 */
 
-  fd_recent_block_hashes_t   recent_blockhashes_obj;
-  fd_recent_block_hashes_t * recent_blockhashes = &recent_blockhashes_obj;
   do {
-    int err = require_acct_recent_blockhashes( ctx, 2UL, &recent_blockhashes );
+    int err = require_acct_recent_blockhashes( ctx, 2UL );
     if( FD_UNLIKELY( err ) ) return err;
   } while(0);
 
@@ -629,18 +621,21 @@ fd_system_program_exec_initialize_nonce_account( fd_exec_instr_ctx_t * ctx,
 
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L466-L471 */
 
-  fd_recent_block_hashes_t   recent_blockhashes_obj;
-  fd_recent_block_hashes_t * recent_blockhashes = &recent_blockhashes_obj;
   do {
-    err = require_acct_recent_blockhashes( ctx, 1UL, &recent_blockhashes );
+    err = require_acct_recent_blockhashes( ctx, 1UL );
     if( FD_UNLIKELY( err ) ) return err;
   } while(0);
 
-  fd_block_block_hash_entry_t const * hashes = recent_blockhashes->hashes;
-
   /* https://github.com/solana-labs/solana/blob/v1.17.23/programs/system/src/system_processor.rs#L472-L478 */
 
-  if( FD_UNLIKELY( deq_fd_block_block_hash_entry_t_empty( hashes ) ) ) {
+  int bhq_empty;
+  do {
+    fd_block_block_hash_entry_t const * hashes = fd_sysvar_cache_recent_hashes_join_const( ctx->sysvar_cache );
+    if( FD_UNLIKELY( !hashes ) ) __builtin_unreachable(); /* validated above */
+    bhq_empty = deq_fd_block_block_hash_entry_t_empty( hashes );
+    fd_sysvar_cache_recent_hashes_leave_const( ctx->sysvar_cache, hashes );
+  } while(0);
+  if( FD_UNLIKELY( bhq_empty ) ) {
     fd_log_collector_msg_literal( ctx, "Initialize nonce account: recent blockhash list is empty" );
     ctx->txn_ctx->custom_err = FD_SYSTEM_PROGRAM_ERR_NONCE_NO_RECENT_BLOCKHASHES;
     return FD_EXECUTOR_INSTR_ERR_CUSTOM_ERR;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_cache.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_cache.c
@@ -117,6 +117,25 @@ FD_SYSVAR_SIMPLE_ITER( SIMPLE_SYSVAR )
 #undef SIMPLE_SYSVAR
 #undef SIMPLE_SYSVAR_READ
 
+fd_block_block_hash_entry_t const * /* deque */
+fd_sysvar_cache_recent_hashes_join_const(
+    fd_sysvar_cache_t const * cache
+) {
+  if( FD_UNLIKELY( !fd_sysvar_cache_recent_hashes_is_valid( cache ) ) ) return NULL;
+  fd_recent_block_hashes_global_t * var = (void *)cache->obj_recent_hashes;
+  fd_block_block_hash_entry_t * deq = deq_fd_block_block_hash_entry_t_join( (uchar *)var+var->hashes_offset );
+  if( FD_UNLIKELY( !deq ) ) FD_LOG_CRIT(( "recent blockhashes sysvar corruption detected" ));
+  return deq; /* demote to const ptr */
+}
+
+void
+fd_sysvar_cache_recent_hashes_leave_const(
+    fd_sysvar_cache_t const *           sysvar_cache,
+    fd_block_block_hash_entry_t const * hashes_deque
+) {
+  (void)sysvar_cache; (void)hashes_deque;
+}
+
 fd_slot_hash_t const *
 fd_sysvar_cache_slot_hashes_join_const(
     fd_sysvar_cache_t const * cache
@@ -172,8 +191,7 @@ fd_sysvar_cache_stake_history_leave_const(
 int
 fd_sysvar_obj_restore( fd_sysvar_cache_t *     cache,
                        fd_sysvar_desc_t *      desc,
-                       fd_sysvar_pos_t const * pos,
-                       int                     log_fails ) {
+                       fd_sysvar_pos_t const * pos ) {
   desc->flags &= ~FD_SYSVAR_FLAG_VALID;
 
   uchar const * data    = (uchar const *)cache + pos->data_off;
@@ -189,17 +207,13 @@ fd_sysvar_obj_restore( fd_sysvar_cache_t *     cache,
   fd_bincode_decode_ctx_t ctx = { .data=data, .dataend=data+data_sz };
   ulong obj_sz = 0UL;
   if( FD_UNLIKELY( pos->decode_footprint( &ctx, &obj_sz )!=FD_BINCODE_SUCCESS ) ) {
-    if( log_fails ) {
-      FD_LOG_DEBUG(( "Failed to decode sysvar %s with data_sz=%lu: decode failed",
-                     pos->name, data_sz ));
-    }
+    FD_LOG_DEBUG(( "Failed to decode sysvar %s with data_sz=%lu: decode failed",
+                   pos->name, data_sz ));
     return EINVAL;
   }
   if( FD_UNLIKELY( obj_sz > pos->obj_max ) ) {
-    if( log_fails ) {
-      FD_LOG_WARNING(( "Failed to restore sysvar %s: obj_sz=%lu exceeds max=%u",
-                       pos->name, obj_sz, pos->obj_max ));
-    }
+    FD_LOG_WARNING(( "Failed to restore sysvar %s: obj_sz=%lu exceeds max=%u",
+                     pos->name, obj_sz, pos->obj_max ));
     return ENOMEM;
   }
   pos->decode( (uchar *)cache+pos->obj_off, &ctx );

--- a/src/flamenco/runtime/sysvar/fd_sysvar_cache.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_cache.h
@@ -57,6 +57,7 @@ struct fd_sysvar_cache {
   uchar bin_last_restart_slot [ FD_SYSVAR_LAST_RESTART_SLOT_BINCODE_SZ ] __attribute__((aligned(FD_SYSVAR_ALIGN_MAX)));
   uchar obj_last_restart_slot [ FD_SYSVAR_LAST_RESTART_SLOT_FOOTPRINT  ] __attribute__((aligned(FD_SYSVAR_ALIGN_MAX)));
   uchar bin_recent_hashes     [ FD_SYSVAR_RECENT_HASHES_BINCODE_SZ     ] __attribute__((aligned(FD_SYSVAR_ALIGN_MAX)));
+  uchar obj_recent_hashes     [ FD_SYSVAR_RECENT_HASHES_FOOTPRINT      ] __attribute__((aligned(FD_SYSVAR_ALIGN_MAX)));
   uchar bin_rent              [ FD_SYSVAR_RENT_BINCODE_SZ              ] __attribute__((aligned(FD_SYSVAR_ALIGN_MAX)));
   uchar obj_rent              [ FD_SYSVAR_RENT_FOOTPRINT               ] __attribute__((aligned(FD_SYSVAR_ALIGN_MAX)));
   uchar bin_slot_hashes       [ FD_SYSVAR_SLOT_HASHES_BINCODE_SZ       ] __attribute__((aligned(FD_SYSVAR_ALIGN_MAX)));
@@ -257,6 +258,17 @@ static inline int
 fd_sysvar_cache_recent_hashes_is_valid( fd_sysvar_cache_t const * sysvar_cache ) {
   return FD_SYSVAR_IS_VALID( sysvar_cache, recent_hashes );
 }
+
+fd_block_block_hash_entry_t const * /* deque */
+fd_sysvar_cache_recent_hashes_join_const(
+    fd_sysvar_cache_t const * sysvar_cache
+);
+
+void
+fd_sysvar_cache_recent_hashes_leave_const(
+    fd_sysvar_cache_t const *           sysvar_cache,
+    fd_block_block_hash_entry_t const * hashes_deque
+);
 
 /* fd_sysvar_cache_slot_hashes_{join,leave}_const {attach,detach} the
    caller {from,to} the slot hashes deque contained in the slot hashes

--- a/src/flamenco/runtime/sysvar/fd_sysvar_cache_db.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_cache_db.c
@@ -45,7 +45,7 @@ sysvar_data_fill( fd_sysvar_cache_t *  cache,
   desc->data_sz = (uint)data_sz;
 
   /* Recover object cache entry from data cache entry */
-  return fd_sysvar_obj_restore( cache, desc, pos, log_fails );
+  return fd_sysvar_obj_restore( cache, desc, pos );
 }
 
 static int

--- a/src/flamenco/runtime/sysvar/fd_sysvar_cache_private.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_cache_private.h
@@ -95,9 +95,9 @@ static fd_sysvar_pos_t const fd_sysvar_pos_tbl[ FD_SYSVAR_CACHE_ENTRY_CNT ] = {
       TYPES_CALLBACKS( sol_sysvar_last_restart_slot, ) },
   [FD_SYSVAR_recent_hashes_IDX] =
     { .name="recent blockhashes",
-      .data_off=offsetof(fd_sysvar_cache_t, bin_recent_hashes    ), .data_max=FD_SYSVAR_RECENT_HASHES_BINCODE_SZ
-      /* No typed representation for RBH, since this sysvar account is
-         write-only (not read back by production runtime code) */ },
+      .data_off=offsetof(fd_sysvar_cache_t, bin_recent_hashes    ), .data_max=FD_SYSVAR_RECENT_HASHES_BINCODE_SZ,
+      .obj_off =offsetof(fd_sysvar_cache_t, obj_recent_hashes    ), .obj_max =FD_SYSVAR_RECENT_HASHES_FOOTPRINT,
+      TYPES_CALLBACKS( recent_block_hashes, _global ) },
   [FD_SYSVAR_rent_IDX] =
     { .name="rent",
       .data_off=offsetof(fd_sysvar_cache_t, bin_rent             ), .data_max=FD_SYSVAR_RENT_BINCODE_SZ,
@@ -141,7 +141,6 @@ static fd_pubkey_t const fd_sysvar_key_tbl[ FD_SYSVAR_CACHE_ENTRY_CNT ] = {
 int
 fd_sysvar_obj_restore( fd_sysvar_cache_t *     cache,
                        fd_sysvar_desc_t *      desc,
-                       fd_sysvar_pos_t const * pos,
-                       int                     log_fails );
+                       fd_sysvar_pos_t const * pos );
 
 #endif /* HEADER_fd_src_flamenco_runtime_sysvar_fd_sysvar_cache_private_h */

--- a/src/flamenco/runtime/sysvar/fd_sysvar_recent_hashes.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_recent_hashes.h
@@ -1,6 +1,9 @@
 #ifndef HEADER_fd_src_flamenco_runtime_sysvar_fd_recent_hashes_h
 #define HEADER_fd_src_flamenco_runtime_sysvar_fd_recent_hashes_h
 
+/* fd_sysvar_recent_hashes.h manages the "recent block hashes" sysvar
+   account (address SysvarRecentB1ockHashes11111111111111111111).  */
+
 #include "../../types/fd_types.h"
 #include "../../fd_flamenco_base.h"
 #include "../../../funk/fd_funk.h"

--- a/src/flamenco/runtime/sysvar/test_sysvar_cache.c
+++ b/src/flamenco/runtime/sysvar/test_sysvar_cache.c
@@ -172,7 +172,7 @@ sysvar_inject( fd_sysvar_cache_t * cache,
   fd_memcpy( (uchar *)cache+pos->data_off, data, data_sz );
   desc->data_sz = (uint)data_sz;
   desc->flags   = 0;
-  return fd_sysvar_obj_restore( cache, desc, pos, 1 );
+  return fd_sysvar_obj_restore( cache, desc, pos );
 }
 
 static void

--- a/src/flamenco/runtime/sysvar/test_sysvar_recent_hashes.c
+++ b/src/flamenco/runtime/sysvar/test_sysvar_recent_hashes.c
@@ -1,7 +1,6 @@
 #include "fd_sysvar_base.h"
 #include "fd_sysvar_recent_hashes.h"
-#include "test_sysvar_cache_util.h"
-#include "../fd_system_ids.h"
+#include "../../types/fd_types.h"
 
 FD_IMPORT_BINARY( example_recent_hashes, "src/flamenco/runtime/sysvar/test_sysvar_recent_hashes.bin" );
 
@@ -17,7 +16,15 @@ fd_mem_iszero8( uchar const * mem,
 
 static void
 test_sysvar_recent_hashes_bounds( void ) {
-  FD_TEST( FD_SYSVAR_RECENT_HASHES_BINCODE_SZ==6008 );
+  FD_TEST( example_recent_hashes_sz==FD_SYSVAR_RECENT_HASHES_BINCODE_SZ );
+  fd_bincode_decode_ctx_t ctx = {
+    .data    = example_recent_hashes,
+    .dataend = example_recent_hashes + example_recent_hashes_sz
+  };
+  ulong obj_sz = 0UL;
+  FD_TEST( fd_recent_block_hashes_decode_footprint( &ctx, &obj_sz )==FD_BINCODE_SUCCESS );
+  FD_TEST( obj_sz==FD_SYSVAR_RECENT_HASHES_FOOTPRINT );
+  FD_TEST( fd_recent_block_hashes_align()==FD_SYSVAR_RECENT_HASHES_ALIGN );
 }
 
 static void


### PR DESCRIPTION
Adds back the 'recent blockhashes' sysvar to the sysvar cache.
Used by nonce instruction processors in the system program.
