### PR TITLE
sock: fix wrong variable and off-by-one

### DIFF
--- a/src/disco/net/sock/fd_sock_tile.c
+++ b/src/disco/net/sock/fd_sock_tile.c
@@ -215,7 +215,7 @@ privileged_init( fd_topo_t *      topo,
   for( uint candidate_idx=0U; candidate_idx<7; candidate_idx++ ) {
     if( !udp_port_candidates[ candidate_idx ] ) continue;
     uint sock_idx = ctx->sock_cnt;
-    if( candidate_idx>FD_SOCK_TILE_MAX_SOCKETS ) FD_LOG_ERR(( "too many sockets" ));
+    if( sock_idx>=FD_SOCK_TILE_MAX_SOCKETS ) FD_LOG_ERR(( "too many sockets" ));
     ushort port = (ushort)udp_port_candidates[ candidate_idx ];
 
     /* Validate value of REPAIR_SHRED_SOCKET_ID */


### PR DESCRIPTION
1. `FD_SOCK_TILE_MAX_SOCKETS` is `8` so `candidate_idx > 8` would always be false, because the loop condition is `candidate_idx<7`.
2. Therefore, I assume that `candidate_idx > 8` should read `sock_idx > 8` instead.
3. `candidate_idx > 8` is an off-by-one and should have been `candidate_idx>=8`.

Found while running https://codeql.github.com/codeql-query-help/cpp/cpp-constant-comparison/