### PR TITLE
funk: improve rec_publish concurrency

### DIFF
--- a/src/funk/fd_funk.c
+++ b/src/funk/fd_funk.c
@@ -122,8 +122,6 @@ fd_funk_new( void * shmem,
 
   funk->alloc_gaddr = fd_wksp_gaddr_fast( wksp, fd_alloc_join( fd_alloc_new( alloc, wksp_tag ), 0UL ) );
 
-  funk->lock = 0;
-
   FD_COMPILER_MFENCE();
   FD_VOLATILE( funk->magic ) = FD_FUNK_MAGIC;
   FD_COMPILER_MFENCE();

--- a/src/funk/fd_funk.h
+++ b/src/funk/fd_funk.h
@@ -251,7 +251,6 @@ struct __attribute__((aligned(FD_FUNK_ALIGN))) fd_funk_shmem_private {
      that and allocating exclusively from that? */
 
   ulong alloc_gaddr; /* Non-zero wksp gaddr with tag wksp tag */
-  uchar lock;        /* lock for synchronizing modifications to funk object */
 
   /* Padding to FD_FUNK_ALIGN here */
 };

--- a/src/funk/fd_funk_rec.h
+++ b/src/funk/fd_funk_rec.h
@@ -118,7 +118,6 @@ struct _fd_funk_rec_prepare {
   fd_funk_rec_t * rec;
   uint *          rec_head_idx;
   uint *          rec_tail_idx;
-  uchar *         txn_lock;
 };
 
 typedef struct _fd_funk_rec_prepare fd_funk_rec_prepare_t;
@@ -279,11 +278,14 @@ FD_FN_CONST static inline fd_funk_xid_key_pair_t const * fd_funk_rec_pair( fd_fu
 FD_FN_CONST static inline fd_funk_txn_xid_t const *      fd_funk_rec_xid ( fd_funk_rec_t const * rec ) { return rec->pair.xid; }
 FD_FN_CONST static inline fd_funk_rec_key_t const *      fd_funk_rec_key ( fd_funk_rec_t const * rec ) { return rec->pair.key; }
 
-/* fd_funk_rec_prepare prepares to insert a new record. This call just
-   allocates a record from the pool and initializes it.
-   The application should then fill in the new
-   value. fd_funk_rec_publish actually does the map insert and
-   should be called once the value is correct. */
+/* fd_funk_rec_prepare creates an unpublished funk record entry.  This
+   is the first step to adding a funk record to a transaction.  Record
+   entry acquisition may fail if the record object pool is exhausted
+   (FD_FUNK_ERR_REC) or the transaction is not writable
+   (FD_FUNK_ERR_FROZEN).  The returned record entry (located in funk
+   shared memory) is then either be cancelled or published by the
+   caller.  This record is invisible to funk query or record-iteration
+   operations until published.  Concurrent record preparation is fine. */
 
 fd_funk_rec_t *
 fd_funk_rec_prepare( fd_funk_t *               funk,
@@ -292,14 +294,20 @@ fd_funk_rec_prepare( fd_funk_t *               funk,
                      fd_funk_rec_prepare_t *   prepare,
                      int *                     opt_err );
 
-/* fd_funk_rec_publish inserts a prepared record into the record map. */
+/* fd_funk_rec_publish makes a prepared record globally visible.  First,
+   registers a record with the txn's record list, then inserts it into
+   the record map.  Concurrent record publishing is fine, even to the
+   same transaction.  Crashes the application with FD_LOG_CRIT if the
+   caller attempts to publish the same (txn,xid) key twice. */
 
 void
 fd_funk_rec_publish( fd_funk_t *             funk,
                      fd_funk_rec_prepare_t * prepare );
 
-/* fd_funk_rec_cancel returns a prepared record to the pool without
-   inserting it. */
+/* fd_funk_rec_cancel returns an unpublished funk record entry back to
+   the record object pool, invalidating the prepare struct.  The caller
+   cleans up any resources associated with the record (e.g. funk_val)
+   before calling this function. */
 
 void
 fd_funk_rec_cancel( fd_funk_t *             funk,

--- a/src/funk/fd_funk_txn.c
+++ b/src/funk/fd_funk_txn.c
@@ -116,7 +116,6 @@ fd_funk_txn_prepare( fd_funk_t *               funk,
   txn->stack_cidx        = fd_funk_txn_cidx( FD_FUNK_TXN_IDX_NULL );
   txn->tag               = 0UL;
 
-  txn->lock = 0;
   txn->rec_head_idx = FD_FUNK_REC_IDX_NULL;
   txn->rec_tail_idx = FD_FUNK_REC_IDX_NULL;
 

--- a/src/funk/fd_funk_txn.h
+++ b/src/funk/fd_funk_txn.h
@@ -48,7 +48,6 @@ struct __attribute__((aligned(FD_FUNK_TXN_ALIGN))) fd_funk_txn_private {
 
   uint  rec_head_idx;      /* Record map index of the first record, FD_FUNK_REC_IDX_NULL if none (from oldest to youngest) */
   uint  rec_tail_idx;      /* "                       last          " */
-  uchar lock;              /* Internal use by funk for sychronizing modifications to txn object */
 };
 
 typedef struct fd_funk_txn_private fd_funk_txn_t;


### PR DESCRIPTION
- Remove a mutex from the funk_txn and funk_shmem classes.
- Rewrite doubly linked list append in rec_publish using atomic CAS
  primitive

Aims to achieve the following:

- Concurrent / racy linked list appends to a funk transaction (rec_publish) do the correct thing
- Concurrent linked list walk over funk records (forwards or backwards) must be sound (but may skip over a record when going back-to-front due to a race between the two CAS operations)
