### PR TITLE
gossip: remove element from eviction treap in fd_crds_acquire

### DIFF
--- a/src/flamenco/gossip/crds/fd_crds.c
+++ b/src/flamenco/gossip/crds/fd_crds.c
@@ -694,6 +694,7 @@ fd_crds_acquire( fd_crds_t *         crds,
 
     hash_treap_ele_remove( crds->hash_treap, evict, crds->pool );
     lookup_map_ele_remove( crds->lookup_map, &evict->key, NULL, crds->pool );
+    evict_treap_ele_remove( crds->evict_treap, evict, crds->pool );
     if( FD_UNLIKELY( evict->key.tag==FD_GOSSIP_VALUE_CONTACT_INFO ) ) remove_contact_info( crds, evict, now, stem );
 
     crds->metrics->evicted_cnt++;


### PR DESCRIPTION
We otherwise have a dangling entry in our evict treap, which could lead to bad/attackable eviction choices