### PR TITLE
Fix 'fddev flame' for full Firedancer

### DIFF
--- a/src/app/shared_dev/commands/flame.c
+++ b/src/app/shared_dev/commands/flame.c
@@ -99,11 +99,6 @@ flame_cmd_fn( args_t *   args,
   char threads[ 4096 ] = {0};
   ulong len = 0UL;
   for( ulong i=0UL; i<tile_cnt; i++ ) {
-    if( FD_LIKELY( i!=0UL ) ) {
-      FD_TEST( fd_cstr_printf_check( threads+len, sizeof(threads)-len, NULL, "," ) );
-      len += 1UL;
-    }
-
     ulong tid = fd_metrics_tile( config->topo.tiles[ tile_idxs[ i ] ].metrics )[ FD_METRICS_GAUGE_TILE_TID_OFF ];
     ulong pid = fd_metrics_tile( config->topo.tiles[ tile_idxs[ i ] ].metrics )[ FD_METRICS_GAUGE_TILE_PID_OFF ];
 
@@ -118,6 +113,11 @@ flame_cmd_fn( args_t *   args,
     ulong arg_len;
     FD_TEST( fd_cstr_printf_check( threads+len, sizeof(threads)-len, &arg_len, "%lu", fd_ulong_if( whole_process, pid, tid ) ) );
     len += arg_len;
+
+    if( FD_LIKELY( i!=tile_cnt-1UL ) ) {
+      FD_TEST( fd_cstr_printf_check( threads+len, sizeof(threads)-len, NULL, "," ) );
+      len += 1UL;
+    }
   }
   FD_TEST( len<sizeof(threads) );
 


### PR DESCRIPTION
Fixes a bug with 'allow_shutdown' tiles that causes 'fddev flame'
to generate an invalid perf command.
