### PR TITLE
funk: fix last publish semantics

### DIFF
--- a/src/discof/genesis/fd_genesi_tile.c
+++ b/src/discof/genesis/fd_genesi_tile.c
@@ -16,7 +16,6 @@ struct fd_genesi_tile {
   int fd;
 
   fd_funk_t funk[1];
-  fd_funk_txn_t * funk_txn;
 
   ushort shred_version;
   uchar  genesis_hash[ 32UL ];
@@ -59,6 +58,12 @@ should_shutdown( fd_genesi_tile_t * ctx ) {
 
 static void
 initialize_accdb( fd_genesi_tile_t * ctx ) {
+  /* Change 'last published' XID to 0 */
+  fd_funk_txn_xid_t root_xid; fd_funk_txn_xid_set_root( &root_xid );
+  fd_funk_txn_xid_t target_xid = { .ul = { 0UL, 0UL } };
+  fd_funk_txn_prepare( ctx->funk, &root_xid, &target_xid, 0 );
+  fd_funk_txn_publish( ctx->funk, &target_xid );
+
   fd_genesis_solana_global_t * genesis = fd_type_pun( ctx->genesis );
 
   fd_pubkey_account_pair_global_t const * accounts = fd_genesis_solana_accounts_join( genesis );
@@ -72,7 +77,7 @@ initialize_accdb( fd_genesi_tile_t * ctx ) {
     int err = fd_txn_account_init_from_funk_mutable( rec,
                                                      &account->key,
                                                      ctx->funk,
-                                                     ctx->funk_txn,
+                                                     NULL, /* last published XID */
                                                      1, /* do_create */
                                                      account->account.data_len,
                                                      &prepare );
@@ -82,7 +87,7 @@ initialize_accdb( fd_genesi_tile_t * ctx ) {
     fd_txn_account_set_lamports( rec, account->account.lamports );
     fd_txn_account_set_executable( rec, account->account.executable );
     fd_txn_account_set_owner( rec, &account->account.owner );
-    fd_txn_account_mutable_fini( rec, ctx->funk, ctx->funk_txn, &prepare );
+    fd_txn_account_mutable_fini( rec, ctx->funk, NULL, &prepare );
 
     fd_lthash_value_t new_hash[1];
     fd_hashes_account_lthash( rec->pubkey, fd_txn_account_get_meta( rec ), fd_txn_account_get_data( rec ), new_hash );
@@ -218,7 +223,6 @@ unprivileged_init( fd_topo_t *      topo,
   fd_genesi_tile_t * ctx = FD_SCRATCH_ALLOC_APPEND( l, alignof( fd_genesi_tile_t ), sizeof( fd_genesi_tile_t ) );
 
   FD_TEST( fd_funk_join( ctx->funk, fd_topo_obj_laddr( topo, tile->genesi.funk_obj_id ) ) );
-  ctx->funk_txn = fd_funk_txn_query( fd_funk_root( ctx->funk ), ctx->funk->txn_map );
 
   fd_lthash_zero( ctx->lthash );
 

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -585,11 +585,6 @@ replay_block_start( fd_replay_tile_t *  ctx,
 
   fd_funk_txn_xid_t xid        = { .ul = { fd_eslot_slot( eslot ), fd_eslot_slot( eslot ) } };
   fd_funk_txn_xid_t parent_xid = { .ul = { fd_eslot_slot( parent_eslot ), fd_eslot_slot( parent_eslot ) } };
-  if( FD_UNLIKELY( !fd_funk_txn_query( &parent_xid, fd_funk_txn_map( ctx->funk ) ) ) ) {
-    /* HACKY: If the parent transaction doesn't exist, assume we are
-              restoring from a snapshot or genesis. */
-    fd_funk_txn_xid_set_root( &parent_xid );
-  }
   fd_funk_txn_t * funk_txn = fd_funk_txn_prepare( ctx->funk, &parent_xid, &xid, 1 );
   if( FD_UNLIKELY( !funk_txn ) ) {
     FD_LOG_CRIT(( "invariant violation: can't prepare funk_txn for (slot %lu, prime %u)", fd_eslot_slot( eslot ), fd_eslot_prime( eslot ) ));
@@ -824,11 +819,6 @@ prepare_leader_bank( fd_replay_tile_t *  ctx,
   /* prepare the funk transaction for the leader bank */
   fd_funk_txn_xid_t xid        = { .ul = { slot, slot } };
   fd_funk_txn_xid_t parent_xid = { .ul = { parent_slot, parent_slot } };
-  if( FD_UNLIKELY( !fd_funk_txn_query( &parent_xid, fd_funk_txn_map( ctx->funk ) ) ) ) {
-    /* HACKY: If the parent transaction doesn't exist, assume we are
-              restoring from a snapshot or genesis. */
-    fd_funk_txn_xid_set_root( &parent_xid );
-  }
   fd_funk_txn_t * funk_txn = fd_funk_txn_prepare( ctx->funk, &parent_xid, &xid, 1 );
   if( FD_UNLIKELY( !funk_txn ) ) {
     FD_LOG_CRIT(( "invariant violation: funk_txn is NULL for slot %lu", slot ));

--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -70,12 +70,15 @@ struct fd_snapin_tile {
   long boot_timestamp;
 
   fd_funk_t       funk[1];
-  fd_funk_txn_t * funk_txn;
   fd_txncache_t * txncache;
   uchar *         acc_data;
 
+  fd_funk_txn_xid_t xid;
+  fd_funk_txn_t *   funk_txn;  /* tracks xid, may be NULL */
+
   fd_stem_context_t *    stem;
   fd_snapshot_parser_t * ssparse;
+  ulong                  bank_slot;
 
   ulong                   txncache_entries_len;
   fd_sstxncache_entry_t * txncache_entries;
@@ -208,7 +211,7 @@ manifest_cb( void * _ctx ) {
   fd_snapin_tile_t * ctx = (fd_snapin_tile_t*)_ctx;
 
   fd_snapshot_manifest_t const * manifest = fd_chunk_to_laddr_const( ctx->manifest_out.wksp, ctx->manifest_out.chunk );
-  ulong bank_slot = manifest->slot;
+  ulong bank_slot = ctx->bank_slot = manifest->slot;
   if( FD_UNLIKELY( verify_slot_deltas_with_bank_slot( ctx, bank_slot ) ) ) {
     FD_LOG_WARNING(( "slot deltas verification failed" ));
     transition_malformed( ctx, ctx->stem );
@@ -241,10 +244,13 @@ account_cb( void *                          _ctx,
 
   fd_funk_rec_key_t id = fd_funk_acc_key( (fd_pubkey_t*)hdr->meta.pubkey );
   fd_funk_rec_query_t query[1];
-  fd_funk_txn_xid_t txn_xid;
-  if( ctx->funk_txn ) txn_xid = ctx->funk_txn->xid;
-  else                fd_funk_txn_xid_set_root( &txn_xid );
-  fd_funk_rec_t const * rec = fd_funk_rec_query_try( ctx->funk, &txn_xid, &id, query );
+
+  /* Published records are indexed with the 'root' XID, even though they
+     might have been published in a newer XID. */
+  fd_funk_txn_xid_t xid;
+  if( ctx->funk_txn ) xid = ctx->funk_txn->xid;
+  else                fd_funk_txn_xid_set_root( &xid );
+  fd_funk_rec_t const * rec = fd_funk_rec_query_try( ctx->funk, &xid, &id, query );
 
   int should_publish = 0;
   fd_funk_rec_prepare_t prepare[1];
@@ -342,14 +348,13 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
     case FD_SNAPSHOT_MSG_CTRL_RESET_FULL:
       ctx->full = 1;
       fd_snapshot_parser_reset( ctx->ssparse, fd_chunk_to_laddr( ctx->manifest_out.wksp, ctx->manifest_out.chunk ), ctx->manifest_out.mtu );
-      fd_funk_txn_cancel_root( ctx->funk );
+      fd_funk_txn_remove_published( ctx->funk );
       ctx->state = FD_SNAPIN_STATE_LOADING;
       break;
     case FD_SNAPSHOT_MSG_CTRL_RESET_INCREMENTAL:
       ctx->full = 0;
       fd_snapshot_parser_reset( ctx->ssparse, fd_chunk_to_laddr( ctx->manifest_out.wksp, ctx->manifest_out.chunk ), ctx->manifest_out.mtu );
-      if( FD_UNLIKELY( !ctx->funk_txn ) ) fd_funk_txn_cancel_root( ctx->funk );
-      else                                fd_funk_txn_cancel( ctx->funk, &ctx->funk_txn->xid );
+      fd_funk_txn_cancel( ctx->funk, &ctx->xid );
       ctx->state = FD_SNAPIN_STATE_LOADING;
       break;
     case FD_SNAPSHOT_MSG_CTRL_EOF_FULL:
@@ -363,16 +368,14 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
       fd_snapshot_parser_reset( ctx->ssparse, fd_chunk_to_laddr( ctx->manifest_out.wksp, ctx->manifest_out.chunk ), ctx->manifest_out.mtu );
 
       fd_funk_txn_xid_t incremental_xid = fd_funk_generate_xid();
-      fd_funk_txn_xid_t parent_xid;
-      if( ctx->funk_txn )  parent_xid = ctx->funk_txn->xid;
-      else                 fd_funk_txn_xid_set_root( &parent_xid );
-      ctx->funk_txn = fd_funk_txn_prepare( ctx->funk, &parent_xid, &incremental_xid, 0 );
+      ctx->funk_txn = fd_funk_txn_prepare( ctx->funk, &ctx->xid, &incremental_xid, 0 );
       FD_TEST( ctx->funk_txn );
+      ctx->xid = incremental_xid;
 
       ctx->full     = 0;
       ctx->state    = FD_SNAPIN_STATE_LOADING;
       break;
-    case FD_SNAPSHOT_MSG_CTRL_DONE:
+    case FD_SNAPSHOT_MSG_CTRL_DONE: {
       if( FD_UNLIKELY( ctx->state!=FD_SNAPIN_STATE_DONE ) ) {
         FD_LOG_WARNING(( "unexpected end of snapshot when not done parsing" ));
         transition_malformed( ctx, stem );
@@ -387,9 +390,21 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
         break;
       }
 
-      if( FD_LIKELY( ctx->funk_txn ) ) fd_funk_txn_publish_into_parent( ctx->funk, &ctx->funk_txn->xid );
+      /* Publish any remaining funk txn */
+      if( FD_LIKELY( ctx->funk_txn ) ) {
+        fd_funk_txn_publish_into_parent( ctx->funk, &ctx->xid );
+        ctx->funk_txn = NULL;
+      }
+
+      /* Make 'Last published' XID equal the restored slot number */
+      fd_funk_txn_xid_t target_xid = { .ul = { ctx->bank_slot, ctx->bank_slot } };
+      fd_funk_txn_prepare( ctx->funk, &ctx->xid, &target_xid, 0 );
+      fd_funk_txn_publish_into_parent( ctx->funk, &target_xid );
+      ctx->xid = target_xid;
+
       fd_stem_publish( stem, 0UL, fd_ssmsg_sig( FD_SSMSG_DONE ), 0UL, 0UL, 0UL, 0UL, 0UL );
       break;
+    }
     case FD_SNAPSHOT_MSG_CTRL_SHUTDOWN:
       ctx->state = FD_SNAPIN_STATE_SHUTDOWN;
       metrics_write( ctx ); /* ensures that shutdown state is written to metrics workspace before the tile actually shuts down */
@@ -461,7 +476,8 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->boot_timestamp = fd_log_wallclock();
 
   FD_TEST( fd_funk_join( ctx->funk, fd_topo_obj_laddr( topo, tile->snapin.funk_obj_id ) ) );
-  ctx->funk_txn = fd_funk_txn_query( fd_funk_root( ctx->funk ), ctx->funk->txn_map );
+  ctx->funk_txn = NULL;
+  fd_funk_txn_xid_set_root( &ctx->xid );
 
   if( FD_LIKELY( tile->snapin.txncache_obj_id!=ULONG_MAX ) ) {
     ctx->txncache = fd_txncache_join( fd_topo_obj_laddr( topo, tile->snapin.txncache_obj_id ) );

--- a/src/funk/fd_funk.c
+++ b/src/funk/fd_funk.c
@@ -80,7 +80,7 @@ fd_funk_new( void * shmem,
   void * txn_map = FD_SCRATCH_ALLOC_APPEND( l, fd_funk_txn_map_align(), fd_funk_txn_map_footprint( txn_chain_cnt ) );
   void * txn_pool = FD_SCRATCH_ALLOC_APPEND( l, fd_funk_txn_pool_align(), fd_funk_txn_pool_footprint() );
   fd_funk_txn_t * txn_ele = (fd_funk_txn_t *)FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_funk_txn_t), sizeof(fd_funk_txn_t) * txn_max );
-  for( ulong j=0UL; j<txn_max; j++ ) txn_ele[ j ].state = FD_FUNK_TXN_STATE_INVALID;
+  for( ulong j=0UL; j<txn_max; j++ ) txn_ele[ j ].state = FD_FUNK_TXN_STATE_FREE;
 
   ulong rec_chain_cnt = fd_funk_rec_map_chain_cnt_est( rec_max );
   void * rec_map = FD_SCRATCH_ALLOC_APPEND( l, fd_funk_rec_map_align(), fd_funk_rec_map_footprint( rec_chain_cnt ) );

--- a/src/funk/test_funk_common.hpp
+++ b/src/funk/test_funk_common.hpp
@@ -227,7 +227,7 @@ struct fake_funk {
       auto xid = txn->real_id();
       fd_funk_txn_xid_t parent_xid;
       if( parent2 ) parent_xid = parent2->xid;
-      else          fd_funk_txn_xid_set_root( &parent_xid );
+      else          fd_funk_txn_xid_copy( &parent_xid, fd_funk_last_publish( _real ) );
       assert(fd_funk_txn_prepare(_real, &parent_xid, &xid, 1) != NULL);
     }
 

--- a/src/funk/test_funk_rec.c
+++ b/src/funk/test_funk_rec.c
@@ -364,7 +364,7 @@ main( int     argc,
         tparent = (fd_funk_txn_xid_t){ .ul={ rparent->xid, rparent->xid } };
       } else { /* Branch off last published */
         rparent = NULL;
-        fd_funk_txn_xid_set_root( &tparent );
+        fd_funk_txn_xid_copy( &tparent, fd_funk_last_publish( tst ) );
       }
 
       ulong rxid = xid_unique();

--- a/src/funk/test_funk_txn.c
+++ b/src/funk/test_funk_txn.c
@@ -125,8 +125,7 @@ main( int     argc,
       uint idx; RANDOM_SET_BIT_IDX( ~live_pmap );
       int is_full = fd_funk_txn_is_full( funk );
       if( FD_UNLIKELY( fd_funk_txn_xid_eq( &recent_xid[idx], last_publish ) ) ) break;
-      fd_funk_txn_xid_t root; fd_funk_txn_xid_set_root( &root );
-      fd_funk_txn_t * txn = fd_funk_txn_prepare( funk, &root, &recent_xid[idx], verbose );
+      fd_funk_txn_t * txn = fd_funk_txn_prepare( funk, fd_funk_last_publish( funk ), &recent_xid[idx], verbose );
       if( is_full ) FD_TEST( !txn );
       else          FD_TEST( txn && fd_funk_txn_xid_eq( fd_funk_txn_xid( txn ), &recent_xid[idx] ) );
       break;
@@ -137,8 +136,7 @@ main( int     argc,
       *xid = fd_funk_generate_xid();
       recent_cursor = (recent_cursor+1UL) & 63UL;
       int is_full = fd_funk_txn_is_full( funk );
-      fd_funk_txn_xid_t root; fd_funk_txn_xid_set_root( &root );
-      fd_funk_txn_t * txn = fd_funk_txn_prepare( funk, &root, xid, verbose );
+      fd_funk_txn_t * txn = fd_funk_txn_prepare( funk, fd_funk_last_publish( funk ), xid, verbose );
       if( is_full ) FD_TEST( !txn );
       else          FD_TEST( txn && fd_funk_txn_xid_eq( fd_funk_txn_xid( txn ), xid ) );
       break;
@@ -216,7 +214,7 @@ main( int     argc,
       fd_funk_txn_t * txn = fd_funk_txn_query( &recent_xid[idx], map );
       FD_TEST( txn && fd_funk_txn_xid_eq( fd_funk_txn_xid( txn ), &recent_xid[idx] ) );
       FD_TEST( fd_funk_txn_publish( funk, &recent_xid[idx] )>0UL );
-      FD_TEST( txn->state==FD_FUNK_TXN_STATE_INVALID );
+      FD_TEST( txn->state==FD_FUNK_TXN_STATE_FREE );
       FD_TEST( fd_funk_txn_xid_eq( last_publish, &recent_xid[idx] ) );
       break;
     }

--- a/src/funk/test_funk_val.c
+++ b/src/funk/test_funk_val.c
@@ -187,7 +187,7 @@ main( int     argc,
         tparent = (fd_funk_txn_xid_t){ .ul={ rparent->xid, rparent->xid } };
       } else { /* Branch off last published */
         rparent = NULL;
-        fd_funk_txn_xid_set_root( &tparent );
+        fd_funk_txn_xid_copy( &tparent, fd_funk_last_publish( tst ) );
       }
 
       ulong rxid = xid_unique();


### PR DESCRIPTION
Fixes an issue in funk transaction management where the 'last
published' transaction is keyed by (ULONG_MAX,ULONG_MAX).

This txn is now instead keyed by its original in-preparation XID.

Removes a few special cases from callers, so they will no longer
need to know whether they are preparing a txn on top of a rooted
slot or not.

Also renames the txn 'invalid' state to 'free'.

Relates to https://github.com/firedancer-io/firedancer/issues/6471