### PR TITLE
funk: refer to txns by XID (pt. 2)

### DIFF
--- a/src/discof/bank/fd_bank_tile.c
+++ b/src/discof/bank/fd_bank_tile.c
@@ -235,7 +235,7 @@ handle_microblock( fd_bank_ctx_t *     ctx,
        if that happens.  We cannot reject the transaction here as there
        would be no way to undo the partially applied changes to the bank
        in finalize anyway. */
-    fd_runtime_finalize_txn( ctx->txn_ctx->funk, txn_ctx->funk_txn, txn_ctx, bank, NULL );
+    fd_runtime_finalize_txn( ctx->txn_ctx->funk, txn_ctx->xid, txn_ctx, bank, NULL );
     FD_TEST( txn->flags );
   }
 

--- a/src/discof/genesis/fd_genesi_tile.c
+++ b/src/discof/genesis/fd_genesi_tile.c
@@ -61,7 +61,7 @@ initialize_accdb( fd_genesi_tile_t * ctx ) {
   /* Change 'last published' XID to 0 */
   fd_funk_txn_xid_t root_xid; fd_funk_txn_xid_set_root( &root_xid );
   fd_funk_txn_xid_t target_xid = { .ul = { 0UL, 0UL } };
-  fd_funk_txn_prepare( ctx->funk, &root_xid, &target_xid, 0 );
+  fd_funk_txn_prepare( ctx->funk, &root_xid, &target_xid );
   fd_funk_txn_publish( ctx->funk, &target_xid );
 
   fd_genesis_solana_global_t * genesis = fd_type_pun( ctx->genesis );
@@ -77,7 +77,7 @@ initialize_accdb( fd_genesi_tile_t * ctx ) {
     int err = fd_txn_account_init_from_funk_mutable( rec,
                                                      &account->key,
                                                      ctx->funk,
-                                                     NULL, /* last published XID */
+                                                     &target_xid,
                                                      1, /* do_create */
                                                      account->account.data_len,
                                                      &prepare );
@@ -87,7 +87,7 @@ initialize_accdb( fd_genesi_tile_t * ctx ) {
     fd_txn_account_set_lamports( rec, account->account.lamports );
     fd_txn_account_set_executable( rec, account->account.executable );
     fd_txn_account_set_owner( rec, &account->account.owner );
-    fd_txn_account_mutable_fini( rec, ctx->funk, NULL, &prepare );
+    fd_txn_account_mutable_fini( rec, ctx->funk, &prepare );
 
     fd_lthash_value_t new_hash[1];
     fd_hashes_account_lthash( rec->pubkey, fd_txn_account_get_meta( rec ), fd_txn_account_get_data( rec ), new_hash );

--- a/src/discof/replay/fd_sched.c
+++ b/src/discof/replay/fd_sched.c
@@ -1084,10 +1084,10 @@ fd_sched_parse_txn( fd_sched_t * sched, fd_sched_block_t * block, fd_sched_alut_
   if( has_aluts ) {
     /* FIXME: statically size out slot hashes decode footprint. */
     FD_SPAD_FRAME_BEGIN( alut_ctx->runtime_spad ) {
-    fd_slot_hashes_global_t const * slot_hashes_global = fd_sysvar_slot_hashes_read( alut_ctx->funk, alut_ctx->funk_txn, alut_ctx->runtime_spad );
+    fd_slot_hashes_global_t const * slot_hashes_global = fd_sysvar_slot_hashes_read( alut_ctx->funk, alut_ctx->xid, alut_ctx->runtime_spad );
     if( FD_LIKELY( slot_hashes_global ) ) {
       fd_slot_hash_t * slot_hash = deq_fd_slot_hash_t_join( (uchar *)slot_hashes_global + slot_hashes_global->hashes_offset );
-      serializing = !!fd_runtime_load_txn_address_lookup_tables( txn, block->fec_buf+block->fec_buf_soff, alut_ctx->funk, alut_ctx->funk_txn, alut_ctx->els, slot_hash, block->aluts );
+      serializing = !!fd_runtime_load_txn_address_lookup_tables( txn, block->fec_buf+block->fec_buf_soff, alut_ctx->funk, alut_ctx->xid, alut_ctx->els, slot_hash, block->aluts );
       sched->metrics->alut_success_cnt += (uint)!serializing;
     } else {
       serializing = 1;

--- a/src/discof/replay/fd_sched.h
+++ b/src/discof/replay/fd_sched.h
@@ -55,10 +55,10 @@ typedef struct fd_sched fd_sched_t;
 
 
 struct fd_sched_alut_ctx {
-  fd_funk_t *     funk;
-  fd_funk_txn_t * funk_txn;
-  ulong           els; /* Effective lookup slot. */
-  fd_spad_t *     runtime_spad;
+  fd_funk_t *       funk;
+  fd_funk_txn_xid_t xid[1];
+  ulong             els; /* Effective lookup slot. */
+  fd_spad_t *       runtime_spad;
 };
 typedef struct fd_sched_alut_ctx fd_sched_alut_ctx_t;
 

--- a/src/discof/rpcserver/fd_rpc_service.c
+++ b/src/discof/rpcserver/fd_rpc_service.c
@@ -125,9 +125,7 @@ fd_method_error( fd_rpc_ctx_t * ctx, int errcode, const char* format, ... ) {
 
 static const void *
 read_account_with_xid( fd_rpc_ctx_t * ctx, fd_funk_rec_key_t * recid, fd_funk_txn_xid_t * xid, ulong * result_len ) {
-  fd_funk_txn_map_t * txn_map = fd_funk_txn_map( ctx->global->funk );
-  fd_funk_txn_t *     txn     = fd_funk_txn_query( xid, txn_map );
-  return fd_funk_rec_query_copy( ctx->global->funk, txn, recid, fd_spad_virtual(ctx->global->spad), result_len );
+  return fd_funk_rec_query_copy( ctx->global->funk, xid, recid, fd_spad_virtual(ctx->global->spad), result_len );
 }
 
 static const void *
@@ -672,12 +670,10 @@ method_getEpochInfo(struct json_values* values, fd_rpc_ctx_t * ctx) {
       fd_method_error(ctx, -1, "unable to find slot info");
       return 0;
     }
-    fd_funk_txn_map_t * map = fd_funk_txn_map( ctx->global->funk );
     fd_funk_txn_xid_t xid;
     xid.ul[0] = xid.ul[1] = slot;
-    fd_funk_txn_t * txn = fd_funk_txn_query( &xid, map );
     fd_epoch_schedule_t epoch_schedule_out[1];
-    fd_epoch_schedule_t * epoch_schedule = fd_sysvar_epoch_schedule_read( ctx->global->funk, txn, epoch_schedule_out );
+    fd_epoch_schedule_t * epoch_schedule = fd_sysvar_epoch_schedule_read( ctx->global->funk, &xid, epoch_schedule_out );
     if( epoch_schedule == NULL ) {
       fd_method_error(ctx, -1, "unable to find epoch schedule");
       return 0;
@@ -701,13 +697,11 @@ static int
 method_getEpochSchedule(struct json_values* values, fd_rpc_ctx_t * ctx) {
   FD_SPAD_FRAME_BEGIN( ctx->global->spad ) {
     fd_webserver_t * ws = &ctx->global->ws;
-    fd_funk_txn_map_t * map = fd_funk_txn_map( ctx->global->funk );
     ulong slot = get_slot_from_commitment_level( values, ctx );
     fd_funk_txn_xid_t xid;
     xid.ul[0] = xid.ul[1] = slot;
-    fd_funk_txn_t * txn = fd_funk_txn_query( &xid, map );
     fd_epoch_schedule_t epoch_schedule_out[1];
-    fd_epoch_schedule_t * epoch_schedule = fd_sysvar_epoch_schedule_read( ctx->global->funk, txn, epoch_schedule_out );
+    fd_epoch_schedule_t * epoch_schedule = fd_sysvar_epoch_schedule_read( ctx->global->funk, &xid, epoch_schedule_out );
     if( epoch_schedule == NULL ) {
       fd_method_error(ctx, -1, "unable to find epoch schedule");
       return 0;

--- a/src/flamenco/rewards/fd_rewards.c
+++ b/src/flamenco/rewards/fd_rewards.c
@@ -662,7 +662,7 @@ calculate_validator_rewards( fd_exec_slot_ctx_t *                      slot_ctx,
                              fd_calculate_validator_rewards_result_t * result,
                              fd_spad_t *                               runtime_spad ) {
     /* https://github.com/firedancer-io/solana/blob/dab3da8e7b667d7527565bddbdbecf7ec1fb868e/runtime/src/bank.rs#L2759-L2786 */
-  fd_stake_history_t const * stake_history = fd_sysvar_stake_history_read( slot_ctx->funk, slot_ctx->funk_txn, runtime_spad );
+  fd_stake_history_t const * stake_history = fd_sysvar_stake_history_read( slot_ctx->funk, slot_ctx->xid, runtime_spad );
     if( FD_UNLIKELY( !stake_history ) ) {
     FD_LOG_ERR(( "Unable to read and decode stake history sysvar" ));
   }
@@ -852,7 +852,7 @@ calculate_rewards_and_distribute_vote_rewards( fd_exec_slot_ctx_t *           sl
     if( FD_UNLIKELY( fd_txn_account_init_from_funk_mutable( vote_rec,
                                                             vote_pubkey,
                                                             slot_ctx->funk,
-                                                            slot_ctx->funk_txn,
+                                                            slot_ctx->xid,
                                                             1,
                                                             0UL,
                                                             &prepare )!=FD_ACC_MGR_SUCCESS ) ) {
@@ -873,7 +873,7 @@ calculate_rewards_and_distribute_vote_rewards( fd_exec_slot_ctx_t *           sl
     }
 
     fd_hashes_update_lthash( vote_rec, prev_hash,slot_ctx->bank, capture_ctx );
-    fd_txn_account_mutable_fini( vote_rec, slot_ctx->funk, slot_ctx->funk_txn, &prepare );
+    fd_txn_account_mutable_fini( vote_rec, slot_ctx->funk, &prepare );
 
     distributed_rewards = fd_ulong_sat_add( distributed_rewards, vote_reward_node->elem.vote_rewards );
 
@@ -915,7 +915,7 @@ distribute_epoch_reward_to_stake_acc( fd_exec_slot_ctx_t * slot_ctx,
   if( FD_UNLIKELY( fd_txn_account_init_from_funk_mutable( stake_acc_rec,
                                                           stake_pubkey,
                                                           slot_ctx->funk,
-                                                          slot_ctx->funk_txn,
+                                                          slot_ctx->xid,
                                                           0,
                                                           0UL,
                                                           &prepare )!=FD_ACC_MGR_SUCCESS ) ) {
@@ -983,7 +983,7 @@ distribute_epoch_reward_to_stake_acc( fd_exec_slot_ctx_t * slot_ctx,
   }
 
   fd_hashes_update_lthash( stake_acc_rec, prev_hash, slot_ctx->bank, capture_ctx );
-  fd_txn_account_mutable_fini( stake_acc_rec, slot_ctx->funk, slot_ctx->funk_txn, &prepare );
+  fd_txn_account_mutable_fini( stake_acc_rec, slot_ctx->funk, &prepare );
 
   return 0;
 }
@@ -1158,7 +1158,7 @@ fd_rewards_recalculate_partitioned_rewards( fd_exec_slot_ctx_t * slot_ctx,
   FD_SPAD_FRAME_BEGIN( runtime_spad ) {
 
   fd_sysvar_epoch_rewards_t epoch_rewards[1];
-  if( FD_UNLIKELY( !fd_sysvar_epoch_rewards_read( slot_ctx->funk, slot_ctx->funk_txn, epoch_rewards ) ) ) {
+  if( FD_UNLIKELY( !fd_sysvar_epoch_rewards_read( slot_ctx->funk, slot_ctx->xid, epoch_rewards ) ) ) {
     FD_LOG_DEBUG(( "Failed to read or decode epoch rewards sysvar - may not have been created yet" ));
     set_epoch_reward_status_inactive( slot_ctx->bank );
     return;
@@ -1191,7 +1191,7 @@ fd_rewards_recalculate_partitioned_rewards( fd_exec_slot_ctx_t * slot_ctx,
       new_warmup_cooldown_rate_epoch = NULL;
     }
 
-    fd_stake_history_t const * stake_history = fd_sysvar_stake_history_read( slot_ctx->funk, slot_ctx->funk_txn, runtime_spad );
+    fd_stake_history_t const * stake_history = fd_sysvar_stake_history_read( slot_ctx->funk, slot_ctx->xid, runtime_spad );
     if( FD_UNLIKELY( !stake_history ) ) {
       FD_LOG_ERR(( "Unable to read and decode stake history sysvar" ));
     }

--- a/src/flamenco/runtime/context/fd_exec_slot_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_slot_ctx.h
@@ -24,8 +24,8 @@ struct fd_exec_slot_ctx {
   fd_banks_t *    banks; /* TODO: Remove fd_banks_t when fd_ledger is removed */
   fd_bank_t *     bank;
 
-  fd_funk_t *     funk;
-  fd_funk_txn_t * funk_txn;
+  fd_funk_t *       funk;
+  fd_funk_txn_xid_t xid[1];
 
   fd_txncache_t * status_cache;
 

--- a/src/flamenco/runtime/context/fd_exec_txn_ctx.h
+++ b/src/flamenco/runtime/context/fd_exec_txn_ctx.h
@@ -54,8 +54,8 @@ struct fd_exec_txn_ctx {
   fd_txncache_t *                      status_cache;
   int                                  enable_exec_recording;
   fd_bank_hash_cmp_t *                 bank_hash_cmp;
-  fd_funk_txn_t *                      funk_txn;
   fd_funk_t                            funk[1];
+  fd_funk_txn_xid_t                    xid[1];
   ulong                                slot;
   ulong                                bank_idx;
   fd_txn_p_t                           txn;

--- a/src/flamenco/runtime/fd_acc_mgr.h
+++ b/src/flamenco/runtime/fd_acc_mgr.h
@@ -152,12 +152,12 @@ fd_funk_key_is_acc( fd_funk_rec_key_t const * id ) {
    is guaranteed there are no other modifying accesses to the account. */
 
 fd_account_meta_t const *
-fd_funk_get_acc_meta_readonly( fd_funk_t const *      funk,
-                               fd_funk_txn_t const *  txn,
-                               fd_pubkey_t const *    pubkey,
-                               fd_funk_rec_t const ** opt_out_rec,
-                               int *                  opt_err,
-                               fd_funk_txn_t const ** txn_out );
+fd_funk_get_acc_meta_readonly( fd_funk_t const *         funk,
+                               fd_funk_txn_xid_t const * xid,
+                               fd_pubkey_t const *       pubkey,
+                               fd_funk_rec_t const **    orec,
+                               int *                     opt_err,
+                               fd_funk_txn_t const **    txn_out ) ;
 
 /* fd_funk_get_acc_meta_mutable requests a writable handle to an account.
    Follows interface of fd_funk_get_account_meta_readonly with the following
@@ -196,14 +196,14 @@ fd_funk_get_acc_meta_readonly( fd_funk_t const *      funk,
    that account. */
 
 fd_account_meta_t *
-fd_funk_get_acc_meta_mutable( fd_funk_t *             funk,
-                              fd_funk_txn_t *         txn,
-                              fd_pubkey_t const *     pubkey,
-                              int                     do_create,
-                              ulong                   min_data_sz,
-                              fd_funk_rec_t **        opt_out_rec,
-                              fd_funk_rec_prepare_t * out_prepare,
-                              int *                   opt_err );
+fd_funk_get_acc_meta_mutable( fd_funk_t *               funk,
+                              fd_funk_txn_xid_t const * xid,
+                              fd_pubkey_t const *       pubkey,
+                              int                       do_create,
+                              ulong                     min_data_sz,
+                              fd_funk_rec_t **          opt_out_rec,
+                              fd_funk_rec_prepare_t *   out_prepare,
+                              int *                     opt_err );
 
 /* fd_acc_mgr_strerror converts an fd_acc_mgr error code into a human
    readable cstr.  The lifetime of the returned pointer is infinite and

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -581,7 +581,7 @@ fd_executor_load_transaction_accounts_old( fd_exec_txn_ctx_t * txn_ctx ) {
     err = fd_txn_account_init_from_funk_readonly( owner_account,
                                                   fd_txn_account_get_owner( program_account ),
                                                   txn_ctx->funk,
-                                                  txn_ctx->funk_txn );
+                                                  txn_ctx->xid );
     if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
       /* https://github.com/anza-xyz/agave/blob/v2.2.0/svm/src/account_loader.rs#L520 */
       return FD_RUNTIME_TXN_ERR_PROGRAM_ACCOUNT_NOT_FOUND;
@@ -690,7 +690,7 @@ fd_collect_loaded_account( fd_exec_txn_ctx_t *      txn_ctx,
   err = fd_txn_account_init_from_funk_readonly( programdata_account,
                                                 &loader_state->inner.program.programdata_address,
                                                 txn_ctx->funk,
-                                                txn_ctx->funk_txn );
+                                                txn_ctx->xid );
   if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
     return FD_RUNTIME_EXECUTE_SUCCESS;
   }
@@ -936,7 +936,7 @@ fd_executor_create_rollback_fee_payer_account( fd_exec_txn_ctx_t * txn_ctx,
     int err = FD_ACC_MGR_SUCCESS;
     fd_account_meta_t const * meta = fd_funk_get_acc_meta_readonly(
         txn_ctx->funk,
-        txn_ctx->funk_txn,
+        txn_ctx->xid,
         fee_payer_key,
         NULL,
         &err,
@@ -1046,7 +1046,7 @@ fd_executor_setup_txn_alut_account_keys( fd_exec_txn_ctx_t * txn_ctx ) {
     int err = fd_runtime_load_txn_address_lookup_tables( TXN( &txn_ctx->txn ),
                                                          txn_ctx->txn.payload,
                                                          txn_ctx->funk,
-                                                         txn_ctx->funk_txn,
+                                                         txn_ctx->xid,
                                                          txn_ctx->slot,
                                                          slot_hashes,
                                                          accts_alt );
@@ -1364,13 +1364,9 @@ void
 fd_exec_txn_ctx_from_exec_slot_ctx( fd_exec_slot_ctx_t const * slot_ctx,
                                     fd_exec_txn_ctx_t *        ctx,
                                     fd_wksp_t const *          funk_wksp,
-                                    ulong                      funk_txn_gaddr,
                                     ulong                      funk_gaddr,
                                     fd_bank_hash_cmp_t *       bank_hash_cmp ) {
-  ctx->funk_txn = fd_wksp_laddr( funk_wksp, funk_txn_gaddr );
-  if( FD_UNLIKELY( !ctx->funk_txn ) ) {
-    FD_LOG_ERR(( "Could not find valid funk transaction" ));
-  }
+  ctx->xid[0] = slot_ctx->xid[0];
 
   if( FD_UNLIKELY( !fd_funk_join( ctx->funk, fd_wksp_laddr( funk_wksp, funk_gaddr ) ) ) ) {
     FD_LOG_ERR(( "Could not find valid funk %lu", funk_gaddr ));
@@ -1401,7 +1397,7 @@ fd_executor_setup_txn_account( fd_exec_txn_ctx_t * txn_ctx,
   int err = FD_ACC_MGR_SUCCESS;
   fd_account_meta_t const * meta = fd_funk_get_acc_meta_readonly(
       txn_ctx->funk,
-      txn_ctx->funk_txn,
+      txn_ctx->xid,
       acc,
       NULL,
       &err,
@@ -1489,7 +1485,7 @@ fd_executor_setup_executable_account( fd_exec_txn_ctx_t *      txn_ctx,
   if( FD_LIKELY( fd_txn_account_init_from_funk_readonly( &txn_ctx->executable_accounts[ *executable_idx ],
                                                             programdata_acc,
                                                             txn_ctx->funk,
-                                                            txn_ctx->funk_txn )==0 ) ) {
+                                                            txn_ctx->xid )==0 ) ) {
     (*executable_idx)++;
   }
 }

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -136,7 +136,6 @@ void
 fd_exec_txn_ctx_from_exec_slot_ctx( fd_exec_slot_ctx_t const * slot_ctx,
                                     fd_exec_txn_ctx_t *        ctx,
                                     fd_wksp_t const *          funk_wksp,
-                                    ulong                      funk_txn_gaddr,
                                     ulong                      funk_gaddr,
                                     fd_bank_hash_cmp_t *       bank_hash_cmp );
 

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -5,7 +5,6 @@
 #include "fd_hashes.h"
 #include "fd_runtime_err.h"
 #include "fd_runtime_init.h"
-#include "fd_pubkey_utils.h"
 
 #include "fd_executor.h"
 #include "sysvar/fd_sysvar_cache.h"
@@ -166,22 +165,6 @@ fd_runtime_update_leaders( fd_bank_t * bank,
   } FD_SPAD_FRAME_END;
 }
 
-fd_funk_txn_t *
-fd_runtime_funk_txn_get( fd_funk_t * funk,
-                         ulong       slot ) {
-  /* Query the funk transaction for the given slot. */
-  fd_funk_txn_map_t * txn_map = fd_funk_txn_map( funk );
-  if( FD_UNLIKELY( !txn_map->map ) ) {
-    FD_LOG_ERR(( "Could not find valid funk transaction map" ));
-  }
-  fd_funk_txn_xid_t xid = { .ul = { slot, slot } };
-  fd_funk_txn_t * funk_txn = fd_funk_txn_query( &xid, txn_map );
-  if( FD_UNLIKELY( !funk_txn ) ) {
-    FD_LOG_ERR(( "Could not find valid funk transaction for slot %lu", slot ));
-  }
-  return funk_txn;
-}
-
 /******************************************************************************/
 /* Various Private Runtime Helpers                                            */
 /******************************************************************************/
@@ -237,10 +220,10 @@ fd_runtime_validate_fee_collector( fd_bank_t *              bank,
 }
 
 static int
-fd_runtime_run_incinerator( fd_bank_t *        bank,
-                            fd_funk_t *        funk,
-                            fd_funk_txn_t *    funk_txn,
-                            fd_capture_ctx_t * capture_ctx ) {
+fd_runtime_run_incinerator( fd_bank_t *               bank,
+                            fd_funk_t *               funk,
+                            fd_funk_txn_xid_t const * xid,
+                            fd_capture_ctx_t *        capture_ctx ) {
   FD_TXN_ACCOUNT_DECL( rec );
   fd_funk_rec_prepare_t prepare = {0};
 
@@ -248,7 +231,7 @@ fd_runtime_run_incinerator( fd_bank_t *        bank,
       rec,
       &fd_sysvar_incinerator_id,
       funk,
-      funk_txn,
+      xid,
       0,
       0UL,
       &prepare );
@@ -265,7 +248,7 @@ fd_runtime_run_incinerator( fd_bank_t *        bank,
 
   fd_txn_account_set_lamports( rec, 0UL );
   fd_hashes_update_lthash( rec, prev_hash, bank, capture_ctx );
-  fd_txn_account_mutable_fini( rec, funk, funk_txn, &prepare );
+  fd_txn_account_mutable_fini( rec, funk, &prepare );
 
   return 0;
 }
@@ -312,7 +295,7 @@ fd_runtime_freeze( fd_exec_slot_ctx_t * slot_ctx ) {
           rec,
           leader,
           slot_ctx->funk,
-          slot_ctx->funk_txn,
+          slot_ctx->xid,
           1,
           0UL,
           &prepare );
@@ -345,7 +328,7 @@ fd_runtime_freeze( fd_exec_slot_ctx_t * slot_ctx ) {
       fd_txn_account_set_slot( rec, fd_bank_slot_get( slot_ctx->bank ) );
 
       fd_hashes_update_lthash( rec, prev_hash, slot_ctx->bank, slot_ctx->capture_ctx );
-      fd_txn_account_mutable_fini( rec, slot_ctx->funk, slot_ctx->funk_txn, &prepare );
+      fd_txn_account_mutable_fini( rec, slot_ctx->funk, &prepare );
 
     } while(0);
 
@@ -358,7 +341,7 @@ fd_runtime_freeze( fd_exec_slot_ctx_t * slot_ctx ) {
     fd_bank_priority_fees_set( slot_ctx->bank, 0UL );
   }
 
-  fd_runtime_run_incinerator( slot_ctx->bank, slot_ctx->funk, slot_ctx->funk_txn, slot_ctx->capture_ctx );
+  fd_runtime_run_incinerator( slot_ctx->bank, slot_ctx->funk, slot_ctx->xid, slot_ctx->capture_ctx );
 
 }
 
@@ -475,13 +458,13 @@ fd_runtime_block_sysvar_update_pre_execute( fd_exec_slot_ctx_t * slot_ctx,
 
 int
 fd_runtime_load_txn_address_lookup_tables(
-    fd_txn_t const *       txn,
-    uchar const *          payload,
-    fd_funk_t *            funk,
-    fd_funk_txn_t *        funk_txn,
-    ulong                  slot,
-    fd_slot_hash_t const * hashes, /* deque */
-    fd_acct_addr_t *       out_accts_alt
+    fd_txn_t const *          txn,
+    uchar const *             payload,
+    fd_funk_t *               funk,
+    fd_funk_txn_xid_t const * xid,
+    ulong                     slot,
+    fd_slot_hash_t const *    hashes, /* deque */
+    fd_acct_addr_t *          out_accts_alt
 ) {
 
   if( FD_LIKELY( txn->transaction_version!=FD_TXN_V0 ) ) return FD_RUNTIME_EXECUTE_SUCCESS;
@@ -499,7 +482,7 @@ fd_runtime_load_txn_address_lookup_tables(
     int err = fd_txn_account_init_from_funk_readonly( addr_lut_rec,
                                                       addr_lut_acc,
                                                       funk,
-                                                      funk_txn );
+                                                      xid );
     if( FD_UNLIKELY( err != FD_ACC_MGR_SUCCESS ) ) {
       return FD_RUNTIME_TXN_ERR_ADDRESS_LOOKUP_TABLE_NOT_FOUND;
     }
@@ -586,7 +569,7 @@ fd_runtime_microblock_verify_read_write_conflicts( fd_txn_p_t *               tx
                                                    fd_conflict_detect_ele_t * acct_map,
                                                    fd_acct_addr_t *           acct_arr,
                                                    fd_funk_t *                funk,
-                                                   fd_funk_txn_t *            funk_txn,
+                                                   fd_funk_txn_xid_t const *  xid,
                                                    ulong                      slot,
                                                    fd_slot_hash_t *           slot_hashes,
                                                    fd_features_t *            features,
@@ -619,7 +602,7 @@ if( FD_UNLIKELY( cond1 ) ) { \
     runtime_err = fd_runtime_load_txn_address_lookup_tables( TXN(txn),
                                                              txn->payload,
                                                              funk,
-                                                             funk_txn,
+                                                             xid,
                                                              slot,
                                                              slot_hashes,
                                                              txn_accts+accts_imm_cnt );
@@ -939,9 +922,9 @@ fd_runtime_pre_execute_check( fd_exec_txn_ctx_t * txn_ctx ) {
    a writable transaction account back into the accountsdb. */
 
 static void
-fd_runtime_finalize_account( fd_funk_t *        funk,
-                             fd_funk_txn_t *    funk_txn,
-                             fd_txn_account_t * acc ) {
+fd_runtime_finalize_account( fd_funk_t *               funk,
+                             fd_funk_txn_xid_t const * xid,
+                             fd_txn_account_t *        acc ) {
   if( FD_UNLIKELY( !fd_txn_account_is_mutable( acc ) ) ) {
     FD_LOG_CRIT(( "fd_runtime_finalize_account: account is not mutable" ));
   }
@@ -954,7 +937,7 @@ fd_runtime_finalize_account( fd_funk_t *        funk,
 
   fd_funk_rec_key_t     funk_key = fd_funk_acc_key( key );
   fd_funk_rec_prepare_t prepare[1];
-  fd_funk_rec_t *       rec = fd_funk_rec_prepare( funk, funk_txn, &funk_key, prepare, &err );
+  fd_funk_rec_t *       rec = fd_funk_rec_prepare( funk, xid, &funk_key, prepare, &err );
   if( FD_UNLIKELY( !rec || err!=FD_FUNK_SUCCESS ) ) {
     FD_LOG_ERR(( "fd_runtime_finalize_account: failed to prepare record (%i-%s)", err, fd_funk_strerror( err ) ));
   }
@@ -1045,12 +1028,12 @@ fd_runtime_buffer_solcap_account_update( fd_txn_account_t *        account,
    All non-optional pointers must be valid. */
 
 static void
-fd_runtime_save_account( fd_funk_t *        funk,
-                         fd_funk_txn_t *    funk_txn,
-                         fd_txn_account_t * account,
-                         fd_bank_t *        bank,
-                         fd_wksp_t *        acc_data_wksp,
-                         fd_capture_ctx_t * capture_ctx ) {
+fd_runtime_save_account( fd_funk_t *               funk,
+                         fd_funk_txn_xid_t const * xid,
+                         fd_txn_account_t *        account,
+                         fd_bank_t *               bank,
+                         fd_wksp_t *               acc_data_wksp,
+                         fd_capture_ctx_t *        capture_ctx ) {
 
   /* Join the transaction account */
   if( FD_UNLIKELY( !fd_txn_account_join( account, acc_data_wksp ) ) ) {
@@ -1059,7 +1042,7 @@ fd_runtime_save_account( fd_funk_t *        funk,
 
   /* Look up the previous version of the account from Funk */
   FD_TXN_ACCOUNT_DECL( previous_account_version );
-  int err = fd_txn_account_init_from_funk_readonly( previous_account_version, account->pubkey, funk, funk_txn );
+  int err = fd_txn_account_init_from_funk_readonly( previous_account_version, account->pubkey, funk, xid );
   if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS && err!=FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT ) ) {
     FD_LOG_CRIT(( "Failed to read old account version from Funk" ));
     return;
@@ -1084,7 +1067,7 @@ fd_runtime_save_account( fd_funk_t *        funk,
   fd_runtime_buffer_solcap_account_update( account, bank, capture_ctx );
 
   /* Save the new version of the account to Funk */
-  fd_runtime_finalize_account( funk, funk_txn, account );
+  fd_runtime_finalize_account( funk, xid, account );
 }
 
 /* fd_runtime_finalize_txn is a helper used by the non-tpool transaction
@@ -1093,11 +1076,11 @@ fd_runtime_save_account( fd_funk_t *        funk,
    TODO: This function should probably be moved to fd_executor.c. */
 
 void
-fd_runtime_finalize_txn( fd_funk_t *         funk,
-                         fd_funk_txn_t *     funk_txn,
-                         fd_exec_txn_ctx_t * txn_ctx,
-                         fd_bank_t *         bank,
-                         fd_capture_ctx_t *  capture_ctx ) {
+fd_runtime_finalize_txn( fd_funk_t *               funk,
+                         fd_funk_txn_xid_t const * xid,
+                         fd_exec_txn_ctx_t *       txn_ctx,
+                         fd_bank_t *               bank,
+                         fd_capture_ctx_t *        capture_ctx ) {
 
   /* Collect fees */
 
@@ -1123,12 +1106,12 @@ fd_runtime_finalize_txn( fd_funk_t *         funk,
 
        We should always rollback the nonce account first. Note that the nonce account may be the fee payer (case 2). */
     if( txn_ctx->nonce_account_idx_in_txn!=ULONG_MAX ) {
-      fd_runtime_save_account( funk, funk_txn, txn_ctx->rollback_nonce_account, bank, txn_ctx->spad_wksp, capture_ctx );
+      fd_runtime_save_account( funk, xid, txn_ctx->rollback_nonce_account, bank, txn_ctx->spad_wksp, capture_ctx );
     }
 
     /* Now, we must only save the fee payer if the nonce account was not the fee payer (because that was already saved above) */
     if( FD_LIKELY( txn_ctx->nonce_account_idx_in_txn!=FD_FEE_PAYER_TXN_IDX ) ) {
-      fd_runtime_save_account( funk, funk_txn, txn_ctx->rollback_fee_payer_account, bank, txn_ctx->spad_wksp, capture_ctx );
+      fd_runtime_save_account( funk, xid, txn_ctx->rollback_fee_payer_account, bank, txn_ctx->spad_wksp, capture_ctx );
     }
   } else {
 
@@ -1158,7 +1141,7 @@ fd_runtime_finalize_txn( fd_funk_t *         funk,
          cache updates have been applied. */
       fd_executor_reclaim_account( txn_ctx, &txn_ctx->accounts[i] );
 
-      fd_runtime_save_account( funk, funk_txn, &txn_ctx->accounts[i], bank, txn_ctx->spad_wksp, capture_ctx );
+      fd_runtime_save_account( funk, xid, &txn_ctx->accounts[i], bank, txn_ctx->spad_wksp, capture_ctx );
     }
 
     /* We need to queue any existing program accounts that may have
@@ -1168,7 +1151,7 @@ fd_runtime_finalize_txn( fd_funk_t *         funk,
       ulong current_slot = fd_bank_slot_get( bank );
       for( uchar i=0; i<txn_ctx->programs_to_reverify_cnt; i++ ) {
         fd_pubkey_t const * program_key = &txn_ctx->programs_to_reverify[i];
-        fd_program_cache_queue_program_for_reverification( funk, funk_txn, program_key, current_slot );
+        fd_program_cache_queue_program_for_reverification( funk, xid, program_key, current_slot );
       }
   }
 
@@ -1223,11 +1206,6 @@ fd_runtime_prepare_and_execute_txn( fd_banks_t *        banks,
 
   ulong slot = fd_bank_slot_get( bank );
 
-  fd_funk_txn_t * funk_txn = fd_runtime_funk_txn_get( txn_ctx->funk, slot );
-  if( FD_UNLIKELY( !funk_txn ) ) {
-    FD_LOG_CRIT(( "Could not get funk transaction for slot %lu", slot ));
-  }
-
   /* Setup and execute the transaction. */
   txn_ctx->bank                  = bank;
   txn_ctx->slot                  = fd_bank_slot_get( bank );
@@ -1235,7 +1213,7 @@ fd_runtime_prepare_and_execute_txn( fd_banks_t *        banks,
   txn_ctx->features              = fd_bank_features_get( bank );
   txn_ctx->status_cache          = NULL; // TODO: Make non-null once implemented
   txn_ctx->enable_exec_recording = !!( bank->flags & FD_BANK_FLAGS_EXEC_RECORDING );
-  txn_ctx->funk_txn              = funk_txn;
+  txn_ctx->xid[0]                = (fd_funk_txn_xid_t){ .ul = { slot, slot } };
   txn_ctx->capture_ctx           = capture_ctx;
   txn_ctx->txn                   = *txn;
 
@@ -1396,7 +1374,7 @@ fd_feature_activate( fd_features_t *         features,
   if( id->reverted==1 ) return;
 
   FD_TXN_ACCOUNT_DECL( acct_rec );
-  int err = fd_txn_account_init_from_funk_readonly( acct_rec, addr, slot_ctx->funk, slot_ctx->funk_txn );
+  int err = fd_txn_account_init_from_funk_readonly( acct_rec, addr, slot_ctx->funk, slot_ctx->xid );
   if( FD_UNLIKELY( err != FD_ACC_MGR_SUCCESS ) ) {
     return;
   }
@@ -1421,7 +1399,7 @@ fd_feature_activate( fd_features_t *         features,
 
     FD_TXN_ACCOUNT_DECL( modify_acct_rec );
     fd_funk_rec_prepare_t modify_acct_prepare = {0};
-    err = fd_txn_account_init_from_funk_mutable( modify_acct_rec, addr, slot_ctx->funk, slot_ctx->funk_txn, 0, 0UL, &modify_acct_prepare );
+    err = fd_txn_account_init_from_funk_mutable( modify_acct_rec, addr, slot_ctx->funk, slot_ctx->xid, 0, 0UL, &modify_acct_prepare );
     if( FD_UNLIKELY( err != FD_ACC_MGR_SUCCESS ) ) {
       return;
     }
@@ -1445,7 +1423,7 @@ fd_feature_activate( fd_features_t *         features,
     }
 
     fd_hashes_update_lthash( modify_acct_rec, prev_hash, slot_ctx->bank, slot_ctx->capture_ctx );
-    fd_txn_account_mutable_fini( modify_acct_rec, slot_ctx->funk, slot_ctx->funk_txn, &modify_acct_prepare );
+    fd_txn_account_mutable_fini( modify_acct_rec, slot_ctx->funk, &modify_acct_prepare );
   }
 }
 
@@ -1531,7 +1509,7 @@ fd_runtime_process_new_epoch( fd_exec_slot_ctx_t * slot_ctx,
 
   /* Refresh vote accounts in stakes cache using updated stake weights, and merges slot bank vote accounts with the epoch bank vote accounts.
     https://github.com/anza-xyz/agave/blob/v2.1.6/runtime/src/stakes.rs#L363-L370 */
-  fd_stake_history_t const * history = fd_sysvar_stake_history_read( slot_ctx->funk, slot_ctx->funk_txn, runtime_spad );
+  fd_stake_history_t const * history = fd_sysvar_stake_history_read( slot_ctx->funk, slot_ctx->xid, runtime_spad );
   if( FD_UNLIKELY( !history ) ) {
     FD_LOG_ERR(( "StakeHistory sysvar could not be read and decoded" ));
   }
@@ -1614,7 +1592,7 @@ fd_runtime_update_program_cache( fd_exec_slot_ctx_t * slot_ctx,
 
     /* Iterate over account keys referenced in ALUTs */
     fd_acct_addr_t alut_accounts[256];
-    fd_slot_hashes_global_t const * slot_hashes_global = fd_sysvar_slot_hashes_read( slot_ctx->funk, slot_ctx->funk_txn, runtime_spad );
+    fd_slot_hashes_global_t const * slot_hashes_global = fd_sysvar_slot_hashes_read( slot_ctx->funk, slot_ctx->xid, runtime_spad );
     if( FD_UNLIKELY( !slot_hashes_global ) ) {
       return;
     }
@@ -1630,7 +1608,7 @@ fd_runtime_update_program_cache( fd_exec_slot_ctx_t * slot_ctx,
           txn_descriptor,
           txn_p->payload,
           slot_ctx->funk,
-          slot_ctx->funk_txn,
+          slot_ctx->xid,
           fd_bank_slot_get( slot_ctx->bank ),
           slot_hash,
           alut_accounts ) ) ) {
@@ -1817,7 +1795,7 @@ fd_runtime_init_bank_from_genesis( fd_exec_slot_ctx_t *               slot_ctx,
      the amount of stake that is delegated to each vote account. */
 
   ulong new_rate_activation_epoch = 0UL;
-  fd_stake_history_t * stake_history = fd_sysvar_stake_history_read( slot_ctx->funk, slot_ctx->funk_txn, runtime_spad );
+  fd_stake_history_t * stake_history = fd_sysvar_stake_history_read( slot_ctx->funk, slot_ctx->xid, runtime_spad );
   fd_refresh_vote_accounts(
       slot_ctx,
       stake_delegations,

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -415,7 +415,7 @@ fd_runtime_microblock_verify_read_write_conflicts( fd_txn_p_t *               tx
                                                    fd_conflict_detect_ele_t * acct_map,
                                                    fd_acct_addr_t *           acct_arr,
                                                    fd_funk_t *                funk,
-                                                   fd_funk_txn_t *            funk_txn,
+                                                   fd_funk_txn_xid_t const *  xid,
                                                    ulong                      slot,
                                                    fd_slot_hash_t *           slot_hashes,
                                                    fd_features_t *            features,
@@ -424,13 +424,15 @@ fd_runtime_microblock_verify_read_write_conflicts( fd_txn_p_t *               tx
 
 /* Load the accounts in the address lookup tables of txn into out_accts_alt */
 int
-fd_runtime_load_txn_address_lookup_tables( fd_txn_t const * txn,
-                                           uchar const *    payload,
-                                           fd_funk_t *      funk,
-                                           fd_funk_txn_t *  funk_txn,
-                                           ulong            slot,
-                                           fd_slot_hash_t const * hashes,
-                                           fd_acct_addr_t * out_accts_alt );
+fd_runtime_load_txn_address_lookup_tables(
+    fd_txn_t const *          txn,
+    uchar const *             payload,
+    fd_funk_t *               funk,
+    fd_funk_txn_xid_t const * xid,
+    ulong                     slot,
+    fd_slot_hash_t const *    hashes, /* deque */
+    fd_acct_addr_t *          out_accts_alt
+);
 
 int
 fd_runtime_block_execute_prepare( fd_exec_slot_ctx_t * slot_ctx,
@@ -438,11 +440,6 @@ fd_runtime_block_execute_prepare( fd_exec_slot_ctx_t * slot_ctx,
 
 void
 fd_runtime_block_execute_finalize( fd_exec_slot_ctx_t * slot_ctx );
-
-/* Look up the funk transaction for the given slot */
-fd_funk_txn_t *
-fd_runtime_funk_txn_get( fd_funk_t * funk,
-                         ulong       slot );
 
 /* Transaction Level Execution Management *************************************/
 
@@ -463,11 +460,11 @@ fd_runtime_prepare_and_execute_txn( fd_banks_t *        banks,
                                     uchar               do_sigverify );
 
 void
-fd_runtime_finalize_txn( fd_funk_t *         funk,
-                         fd_funk_txn_t *     funk_txn,
-                         fd_exec_txn_ctx_t * txn_ctx,
-                         fd_bank_t *         bank,
-                         fd_capture_ctx_t *  capture_ctx );
+fd_runtime_finalize_txn( fd_funk_t *               funk,
+                         fd_funk_txn_xid_t const * xid,
+                         fd_exec_txn_ctx_t *       txn_ctx,
+                         fd_bank_t *               bank,
+                         fd_capture_ctx_t *        capture_ctx );
 
 /* Epoch Boundary *************************************************************/
 

--- a/src/flamenco/runtime/fd_runtime_init.c
+++ b/src/flamenco/runtime/fd_runtime_init.c
@@ -21,7 +21,7 @@ fd_feature_restore( fd_features_t *         features,
   int err = fd_txn_account_init_from_funk_readonly( acct_rec,
                                                     addr,
                                                     slot_ctx->funk,
-                                                    slot_ctx->funk_txn );
+                                                    slot_ctx->xid );
   if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
     return;
   }

--- a/src/flamenco/runtime/fd_txn_account.c
+++ b/src/flamenco/runtime/fd_txn_account.c
@@ -148,15 +148,15 @@ fd_txn_account_delete( void * mem ) {
 /* Factory constructors from funk */
 
 int
-fd_txn_account_init_from_funk_readonly( fd_txn_account_t *    acct,
-                                        fd_pubkey_t const *   pubkey,
-                                        fd_funk_t const *     funk,
-                                        fd_funk_txn_t const * funk_txn ) {
+fd_txn_account_init_from_funk_readonly( fd_txn_account_t *        acct,
+                                        fd_pubkey_t const *       pubkey,
+                                        fd_funk_t const *         funk,
+                                        fd_funk_txn_xid_t const * xid ) {
 
   int err = FD_ACC_MGR_SUCCESS;
   fd_account_meta_t const * meta = fd_funk_get_acc_meta_readonly(
       funk,
-      funk_txn,
+      xid,
       pubkey,
       NULL,
       &err,
@@ -178,18 +178,18 @@ fd_txn_account_init_from_funk_readonly( fd_txn_account_t *    acct,
 }
 
 int
-fd_txn_account_init_from_funk_mutable( fd_txn_account_t *      acct,
-                                       fd_pubkey_t const *     pubkey,
-                                       fd_funk_t *             funk,
-                                       fd_funk_txn_t *         funk_txn,
-                                       int                     do_create,
-                                       ulong                   min_data_sz,
-                                       fd_funk_rec_prepare_t * prepare_out ) {
+fd_txn_account_init_from_funk_mutable( fd_txn_account_t *        acct,
+                                       fd_pubkey_t const *       pubkey,
+                                       fd_funk_t *               funk,
+                                       fd_funk_txn_xid_t const * xid,
+                                       int                       do_create,
+                                       ulong                     min_data_sz,
+                                       fd_funk_rec_prepare_t *   prepare_out ) {
   memset( prepare_out, 0, sizeof(fd_funk_rec_prepare_t) );
   int err = FD_ACC_MGR_SUCCESS;
   fd_account_meta_t * meta = fd_funk_get_acc_meta_mutable(
       funk,
-      funk_txn,
+      xid,
       pubkey,
       do_create,
       min_data_sz,
@@ -218,11 +218,9 @@ fd_txn_account_init_from_funk_mutable( fd_txn_account_t *      acct,
 }
 
 void
-fd_txn_account_mutable_fini( fd_txn_account_t *      acct,
-                             fd_funk_t *             funk,
-                             fd_funk_txn_t *         txn,
-                             fd_funk_rec_prepare_t * prepare ) {
-  (void)txn;
+fd_txn_account_mutable_fini( fd_txn_account_t *        acct,
+                             fd_funk_t *               funk,
+                             fd_funk_rec_prepare_t *   prepare ) {
   fd_funk_rec_key_t key = fd_funk_acc_key( acct->pubkey );
 
   /* Check that the prepared record is still valid -

--- a/src/flamenco/runtime/fd_txn_account.h
+++ b/src/flamenco/runtime/fd_txn_account.h
@@ -114,10 +114,10 @@ fd_txn_account_delete( void * mem );
    account, since we are inside a Solana transaction. */
 
 int
-fd_txn_account_init_from_funk_readonly( fd_txn_account_t *    acct,
-                                        fd_pubkey_t const *   pubkey,
-                                        fd_funk_t const *     funk,
-                                        fd_funk_txn_t const * funk_txn );
+fd_txn_account_init_from_funk_readonly( fd_txn_account_t *        acct,
+                                        fd_pubkey_t const *       pubkey,
+                                        fd_funk_t const *         funk,
+                                        fd_funk_txn_xid_t const * xid );
 
 /* fd_txn_account_init_from_funk_mutable initializes a fd_txn_account_t
    object with a mutable handle into its funk record.
@@ -125,13 +125,13 @@ fd_txn_account_init_from_funk_readonly( fd_txn_account_t *    acct,
    IMPORTANT: Cannot be called in the executor tile. */
 
 int
-fd_txn_account_init_from_funk_mutable( fd_txn_account_t *      acct,
-                                       fd_pubkey_t const *     pubkey,
-                                       fd_funk_t *             funk,
-                                       fd_funk_txn_t *         funk_txn,
-                                       int                     do_create,
-                                       ulong                   min_data_sz,
-                                       fd_funk_rec_prepare_t * prepare_out );
+fd_txn_account_init_from_funk_mutable( fd_txn_account_t *        acct,
+                                       fd_pubkey_t const *       pubkey,
+                                       fd_funk_t *               funk,
+                                       fd_funk_txn_xid_t const * xid,
+                                       int                       do_create,
+                                       ulong                     min_data_sz,
+                                       fd_funk_rec_prepare_t *   prepare_out );
 
 /* Publishes the record contents of a mutable fd_txn_account_t object
    obtained from fd_txn_account_init_from_funk_mutable into funk
@@ -140,10 +140,9 @@ fd_txn_account_init_from_funk_mutable( fd_txn_account_t *      acct,
    by fd_txn_account_init_from_funk_mutable. */
 
 void
-fd_txn_account_mutable_fini( fd_txn_account_t *      acct,
-                             fd_funk_t *             funk,
-                             fd_funk_txn_t *         txn,
-                             fd_funk_rec_prepare_t * prepare );
+fd_txn_account_mutable_fini( fd_txn_account_t *        acct,
+                             fd_funk_t *               funk,
+                             fd_funk_rec_prepare_t *   prepare );
 
 /* Simple accesssors and mutators. */
 

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -2565,7 +2565,7 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
        stricter. */
     fd_program_cache_entry_t const * cache_entry = NULL;
     if( FD_UNLIKELY( fd_program_cache_load_entry( ctx->txn_ctx->funk,
-                                                  ctx->txn_ctx->funk_txn,
+                                                  ctx->txn_ctx->xid,
                                                   program_id,
                                                   &cache_entry )!=0 ) ) {
       fd_log_collector_msg_literal( ctx, "Program is not cached" );
@@ -2603,16 +2603,14 @@ fd_directly_invoke_loader_v3_deploy( fd_exec_slot_ctx_t * slot_ctx,
                                      ulong                elf_sz,
                                      fd_spad_t *          runtime_spad ) {
   /* Set up a dummy instr and txn context */
-  fd_exec_txn_ctx_t * txn_ctx        = fd_exec_txn_ctx_join( fd_exec_txn_ctx_new( fd_spad_alloc( runtime_spad, FD_EXEC_TXN_CTX_ALIGN, FD_EXEC_TXN_CTX_FOOTPRINT ) ), runtime_spad, fd_wksp_containing( runtime_spad ) );
-  fd_funk_t *         funk           = slot_ctx->funk;
-  fd_wksp_t *         funk_wksp      = fd_funk_wksp( funk );
-  ulong               funk_txn_gaddr = fd_wksp_gaddr( funk_wksp, slot_ctx->funk_txn );
-  ulong               funk_gaddr     = fd_wksp_gaddr( funk_wksp, funk->shmem );
+  fd_exec_txn_ctx_t * txn_ctx    = fd_exec_txn_ctx_join( fd_exec_txn_ctx_new( fd_spad_alloc( runtime_spad, FD_EXEC_TXN_CTX_ALIGN, FD_EXEC_TXN_CTX_FOOTPRINT ) ), runtime_spad, fd_wksp_containing( runtime_spad ) );
+  fd_funk_t *         funk       = slot_ctx->funk;
+  fd_wksp_t *         funk_wksp  = fd_funk_wksp( funk );
+  ulong               funk_gaddr = fd_wksp_gaddr( funk_wksp, funk->shmem );
 
   fd_exec_txn_ctx_from_exec_slot_ctx( slot_ctx,
                                       txn_ctx,
                                       funk_wksp,
-                                      funk_txn_gaddr,
                                       funk_gaddr,
                                       NULL );
 

--- a/src/flamenco/runtime/program/fd_loader_v4_program.c
+++ b/src/flamenco/runtime/program/fd_loader_v4_program.c
@@ -857,7 +857,7 @@ fd_loader_v4_program_execute( fd_exec_instr_ctx_t * instr_ctx ) {
          https://github.com/anza-xyz/agave/blob/v2.2.6/programs/loader-v4/src/lib.rs#L522-L528 */
       fd_program_cache_entry_t const * cache_entry = NULL;
       if( FD_UNLIKELY( fd_program_cache_load_entry( instr_ctx->txn_ctx->funk,
-                                                    instr_ctx->txn_ctx->funk_txn,
+                                                    instr_ctx->txn_ctx->xid,
                                                     program_id,
                                                     &cache_entry )!=0 ) ) {
         fd_log_collector_msg_literal( instr_ctx, "Program is not cached" );

--- a/src/flamenco/runtime/program/fd_program_cache.h
+++ b/src/flamenco/runtime/program/fd_program_cache.h
@@ -236,7 +236,7 @@ fd_program_cache_key( fd_pubkey_t const * pubkey );
    to the program cache entry. */
 int
 fd_program_cache_load_entry( fd_funk_t const *                 funk,
-                             fd_funk_txn_t const *             funk_txn,
+                             fd_funk_txn_xid_t const *         xid,
                              fd_pubkey_t const *               program_pubkey,
                              fd_program_cache_entry_t const ** cache_entry );
 
@@ -250,10 +250,10 @@ fd_program_cache_load_entry( fd_funk_t const *                 funk,
    This is essentially load_program_with_pubkey(), sans the ELF parsing
    and whatnot which is done in load_program_from_bytes(). */
 uchar const *
-fd_program_cache_get_account_programdata( fd_funk_t const *        funk,
-                                          fd_funk_txn_t const *    funk_txn,
-                                          fd_txn_account_t const * program_acc,
-                                          ulong *                  out_program_data_len );
+fd_program_cache_get_account_programdata( fd_funk_t const *         funk,
+                                          fd_funk_txn_xid_t const * xid,
+                                          fd_txn_account_t const *  program_acc,
+                                          ulong *                   out_program_data_len );
 
 /* Updates the program cache for a single program. This function is
    called for every program that is referenced in a transaction, plus
@@ -296,10 +296,10 @@ fd_program_cache_update_program( fd_exec_slot_ctx_t * slot_ctx,
    If the record exists in the program cache, this function will
    acquire a write-lock on the program cache entry. */
 void
-fd_program_cache_queue_program_for_reverification( fd_funk_t *         funk,
-                                                   fd_funk_txn_t *     funk_txn,
-                                                   fd_pubkey_t const * program_key,
-                                                   ulong               current_slot );
+fd_program_cache_queue_program_for_reverification( fd_funk_t *               funk,
+                                                   fd_funk_txn_xid_t const * xid,
+                                                   fd_pubkey_t const *       program_key,
+                                                   ulong                     current_slot );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/program/fd_stake_program.c
+++ b/src/flamenco/runtime/program/fd_stake_program.c
@@ -3243,7 +3243,7 @@ write_stake_config( fd_exec_slot_ctx_t * slot_ctx, fd_stake_config_t const * sta
 
   FD_TXN_ACCOUNT_DECL(rec);
   fd_funk_rec_prepare_t prepare = {0};
-  int err = fd_txn_account_init_from_funk_mutable( rec, acc_key, slot_ctx->funk, slot_ctx->funk_txn, 1, data_sz, &prepare );
+  int err = fd_txn_account_init_from_funk_mutable( rec, acc_key, slot_ctx->funk, slot_ctx->xid, 1, data_sz, &prepare );
   FD_TEST( !err );
 
   fd_txn_account_set_lamports( rec, 960480UL );
@@ -3257,7 +3257,7 @@ write_stake_config( fd_exec_slot_ctx_t * slot_ctx, fd_stake_config_t const * sta
 
   fd_txn_account_set_data( rec, stake_config, data_sz );
 
-  fd_txn_account_mutable_fini( rec, slot_ctx->funk, slot_ctx->funk_txn, &prepare );
+  fd_txn_account_mutable_fini( rec, slot_ctx->funk, &prepare );
 }
 
 void

--- a/src/flamenco/runtime/program/fd_system_program_nonce.c
+++ b/src/flamenco/runtime/program/fd_system_program_nonce.c
@@ -940,7 +940,7 @@ fd_check_transaction_age( fd_exec_txn_ctx_t * txn_ctx ) {
   int err = fd_txn_account_init_from_funk_readonly( durable_nonce_rec,
                                                     &txn_ctx->account_keys[ nonce_idx ],
                                                     txn_ctx->funk,
-                                                    txn_ctx->funk_txn );
+                                                    txn_ctx->xid );
   if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
     return FD_RUNTIME_TXN_ERR_BLOCKHASH_NOT_FOUND;
   }
@@ -993,7 +993,7 @@ fd_check_transaction_age( fd_exec_txn_ctx_t * txn_ctx ) {
          */
         fd_account_meta_t const * meta = fd_funk_get_acc_meta_readonly(
             txn_ctx->funk,
-            txn_ctx->funk_txn,
+            txn_ctx->xid,
             &txn_ctx->account_keys[ instr_accts[ 0UL ] ],
             NULL,
             &err,

--- a/src/flamenco/runtime/sysvar/fd_sysvar.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar.c
@@ -20,7 +20,7 @@ fd_sysvar_account_update( fd_exec_slot_ctx_t * slot_ctx,
 
   FD_TXN_ACCOUNT_DECL( rec );
   fd_funk_rec_prepare_t prepare = {0};
-  fd_txn_account_init_from_funk_mutable( rec, address, slot_ctx->funk, slot_ctx->funk_txn, 1, sz, &prepare );
+  fd_txn_account_init_from_funk_mutable( rec, address, slot_ctx->funk, slot_ctx->xid, 1, sz, &prepare );
   fd_lthash_value_t prev_hash[1];
   fd_hashes_account_lthash( address, fd_txn_account_get_meta( rec ), fd_txn_account_get_data( rec ), prev_hash );
 
@@ -49,7 +49,7 @@ fd_sysvar_account_update( fd_exec_slot_ctx_t * slot_ctx,
   }
 
   fd_hashes_update_lthash( rec, prev_hash, slot_ctx->bank, slot_ctx->capture_ctx );
-  fd_txn_account_mutable_fini( rec, slot_ctx->funk, slot_ctx->funk_txn, &prepare );
+  fd_txn_account_mutable_fini( rec, slot_ctx->funk, &prepare );
 
   FD_LOG_DEBUG(( "Updated sysvar: address=%s data_sz=%lu slot=%lu lamports=%lu lamports_minted=%lu",
                  FD_BASE58_ENC_32_ALLOCA( address ), sz, slot, lamports_after, lamports_minted ));

--- a/src/flamenco/runtime/sysvar/fd_sysvar_cache_db.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_cache_db.c
@@ -19,10 +19,8 @@ sysvar_data_fill( fd_sysvar_cache_t *  cache,
   fd_sysvar_desc_t *      desc = &cache->desc      [ idx ];
 
   /* Read account from database */
-  fd_funk_t *     funk     = slot_ctx->funk;
-  fd_funk_txn_t * funk_txn = slot_ctx->funk_txn;
   FD_TXN_ACCOUNT_DECL( rec );
-  int err = fd_txn_account_init_from_funk_readonly( rec, key, funk, funk_txn );
+  int err = fd_txn_account_init_from_funk_readonly( rec, key, slot_ctx->funk, slot_ctx->xid );
   if( err==FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT ) {
     if( log_fails ) FD_LOG_DEBUG(( "Sysvar %s not found", pos->name ));
     return 0;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
@@ -45,11 +45,11 @@ fd_sysvar_clock_write( fd_exec_slot_ctx_t *    slot_ctx,
 
 
 fd_sol_sysvar_clock_t *
-fd_sysvar_clock_read( fd_funk_t *             funk,
-                      fd_funk_txn_t *         funk_txn,
-                      fd_sol_sysvar_clock_t * clock ) {
+fd_sysvar_clock_read( fd_funk_t *               funk,
+                      fd_funk_txn_xid_t const * xid,
+                      fd_sol_sysvar_clock_t *   clock ) {
   FD_TXN_ACCOUNT_DECL( acc );
-  int rc = fd_txn_account_init_from_funk_readonly( acc, &fd_sysvar_clock_id, funk, funk_txn );
+  int rc = fd_txn_account_init_from_funk_readonly( acc, &fd_sysvar_clock_id, funk, xid );
   if( FD_UNLIKELY( rc!=FD_ACC_MGR_SUCCESS ) ) {
     return NULL;
   }
@@ -285,7 +285,7 @@ fd_sysvar_clock_update( fd_exec_slot_ctx_t * slot_ctx,
                         fd_spad_t *          spad,
                         ulong const *        parent_epoch ) {
   fd_sol_sysvar_clock_t clock_[1];
-  fd_sol_sysvar_clock_t * clock = fd_sysvar_clock_read( slot_ctx->funk, slot_ctx->funk_txn, clock_ );
+  fd_sol_sysvar_clock_t * clock = fd_sysvar_clock_read( slot_ctx->funk, slot_ctx->xid, clock_ );
   if( FD_UNLIKELY( !clock ) ) FD_LOG_ERR(( "fd_sysvar_clock_read failed" ));
 
   fd_bank_t *                 bank           = slot_ctx->bank;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_clock.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_clock.h
@@ -47,9 +47,9 @@ fd_sysvar_clock_write( fd_exec_slot_ctx_t *    slot_ctx,
    has zero lamports, this function returns NULL. */
 
 fd_sol_sysvar_clock_t *
-fd_sysvar_clock_read( fd_funk_t *             funk,
-                      fd_funk_txn_t *         funk_txn,
-                      fd_sol_sysvar_clock_t * clock );
+fd_sysvar_clock_read( fd_funk_t *               funk,
+                      fd_funk_txn_xid_t const * xid,
+                      fd_sol_sysvar_clock_t *   clock );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.c
@@ -23,10 +23,10 @@ write_epoch_rewards( fd_exec_slot_ctx_t * slot_ctx, fd_sysvar_epoch_rewards_t * 
 
 fd_sysvar_epoch_rewards_t *
 fd_sysvar_epoch_rewards_read( fd_funk_t *                 funk,
-                              fd_funk_txn_t *             funk_txn,
+                              fd_funk_txn_xid_t const *   xid,
                               fd_sysvar_epoch_rewards_t * out ) {
   FD_TXN_ACCOUNT_DECL( acc );
-  int err = fd_txn_account_init_from_funk_readonly( acc, &fd_sysvar_epoch_rewards_id, funk, funk_txn );
+  int err = fd_txn_account_init_from_funk_readonly( acc, &fd_sysvar_epoch_rewards_id, funk, xid );
   if( FD_UNLIKELY( err != FD_ACC_MGR_SUCCESS ) ) {
     return NULL;
   }
@@ -53,7 +53,7 @@ void
 fd_sysvar_epoch_rewards_distribute( fd_exec_slot_ctx_t * slot_ctx,
                                     ulong                distributed ) {
   fd_sysvar_epoch_rewards_t epoch_rewards[1];
-  if( FD_UNLIKELY( !fd_sysvar_epoch_rewards_read( slot_ctx->funk, slot_ctx->funk_txn, epoch_rewards ) ) ) {
+  if( FD_UNLIKELY( !fd_sysvar_epoch_rewards_read( slot_ctx->funk, slot_ctx->xid, epoch_rewards ) ) ) {
     FD_LOG_ERR(( "failed to read sysvar epoch rewards" ));
   }
 
@@ -73,7 +73,7 @@ fd_sysvar_epoch_rewards_distribute( fd_exec_slot_ctx_t * slot_ctx,
 void
 fd_sysvar_epoch_rewards_set_inactive( fd_exec_slot_ctx_t * slot_ctx ) {
   fd_sysvar_epoch_rewards_t epoch_rewards[1];
-  if( FD_UNLIKELY( !fd_sysvar_epoch_rewards_read( slot_ctx->funk, slot_ctx->funk_txn, epoch_rewards ) ) ) {
+  if( FD_UNLIKELY( !fd_sysvar_epoch_rewards_read( slot_ctx->funk, slot_ctx->xid, epoch_rewards ) ) ) {
     FD_LOG_ERR(( "failed to read sysvar epoch rewards" ));
   }
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.h
@@ -12,7 +12,7 @@ FD_PROTOTYPES_BEGIN
 
 fd_sysvar_epoch_rewards_t *
 fd_sysvar_epoch_rewards_read( fd_funk_t *                 funk,
-                              fd_funk_txn_t *             funk_txn,
+                              fd_funk_txn_xid_t const *   xid,
                               fd_sysvar_epoch_rewards_t * out );
 
 /* Update EpochRewards sysvar with distributed rewards

--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.c
@@ -51,12 +51,12 @@ fd_sysvar_epoch_schedule_write( fd_exec_slot_ctx_t *        slot_ctx,
 }
 
 fd_epoch_schedule_t *
-fd_sysvar_epoch_schedule_read( fd_funk_t *           funk,
-                               fd_funk_txn_t *       funk_txn,
-                               fd_epoch_schedule_t * out ) {
+fd_sysvar_epoch_schedule_read( fd_funk_t *               funk,
+                               fd_funk_txn_xid_t const * xid,
+                               fd_epoch_schedule_t *     out ) {
 
   FD_TXN_ACCOUNT_DECL( acc );
-  int err = fd_txn_account_init_from_funk_readonly( acc, &fd_sysvar_epoch_schedule_id, funk, funk_txn );
+  int err = fd_txn_account_init_from_funk_readonly( acc, &fd_sysvar_epoch_schedule_id, funk, xid );
   if( FD_UNLIKELY( err != FD_ACC_MGR_SUCCESS ) ) {
     return NULL;
   }

--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.h
@@ -65,9 +65,9 @@ fd_sysvar_epoch_schedule_init( fd_exec_slot_ctx_t * slot_ctx );
    has zero lamports, this function returns NULL. */
 
 fd_epoch_schedule_t *
-fd_sysvar_epoch_schedule_read( fd_funk_t *           funk,
-                               fd_funk_txn_t *       funk_txn,
-                               fd_epoch_schedule_t * out );
+fd_sysvar_epoch_schedule_read( fd_funk_t *               funk,
+                               fd_funk_txn_xid_t const * xid,
+                               fd_epoch_schedule_t *     out );
 
 /* fd_sysvar_epoch_schedule_write writes the current value of the epoch
    schedule sysvar to funk. */

--- a/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.c
@@ -52,13 +52,13 @@ fd_sysvar_last_restart_slot_derive(
 
 fd_sol_sysvar_last_restart_slot_t *
 fd_sysvar_last_restart_slot_read(
-    fd_funk_t *     funk,
-    fd_funk_txn_t * funk_txn,
+    fd_funk_t *               funk,
+    fd_funk_txn_xid_t const * xid,
     fd_sol_sysvar_last_restart_slot_t * out
 ) {
 
   FD_TXN_ACCOUNT_DECL( acc );
-  int err = fd_txn_account_init_from_funk_readonly( acc, &fd_sysvar_last_restart_slot_id, funk, funk_txn );
+  int err = fd_txn_account_init_from_funk_readonly( acc, &fd_sysvar_last_restart_slot_id, funk, xid );
   if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) return NULL;
 
   /* This check is needed as a quirk of the fuzzer. If a sysvar account
@@ -89,7 +89,7 @@ fd_sysvar_last_restart_slot_update(
   /* https://github.com/solana-labs/solana/blob/v1.18.18/runtime/src/bank.rs#L2098-L2106 */
   ulong last_restart_slot_have = ULONG_MAX;
   fd_sol_sysvar_last_restart_slot_t sysvar;
-  if( FD_LIKELY( fd_sysvar_last_restart_slot_read( slot_ctx->funk, slot_ctx->funk_txn, &sysvar ) ) ) {
+  if( FD_LIKELY( fd_sysvar_last_restart_slot_read( slot_ctx->funk, slot_ctx->xid, &sysvar ) ) ) {
     last_restart_slot_have = sysvar.slot;
   }
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.h
@@ -38,8 +38,8 @@ fd_sysvar_last_restart_slot_update(
 
 fd_sol_sysvar_last_restart_slot_t *
 fd_sysvar_last_restart_slot_read(
-    fd_funk_t *     funk,
-    fd_funk_txn_t * funk_txn,
+    fd_funk_t *               funk,
+    fd_funk_txn_xid_t const * xid,
     fd_sol_sysvar_last_restart_slot_t * out
 );
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_recent_hashes.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_recent_hashes.c
@@ -70,9 +70,9 @@ fd_sysvar_recent_hashes_update( fd_exec_slot_ctx_t * slot_ctx ) {
 }
 
 fd_recent_block_hashes_t *
-fd_sysvar_recent_hashes_read( fd_funk_t * funk, fd_funk_txn_t * funk_txn, fd_spad_t * spad ) {
+fd_sysvar_recent_hashes_read( fd_funk_t * funk, fd_funk_txn_xid_t const * xid, fd_spad_t * spad ) {
   FD_TXN_ACCOUNT_DECL( acc );
-  int err = fd_txn_account_init_from_funk_readonly( acc, &fd_sysvar_recent_block_hashes_id, funk, funk_txn );
+  int err = fd_txn_account_init_from_funk_readonly( acc, &fd_sysvar_recent_block_hashes_id, funk, xid );
   if( FD_UNLIKELY( err != FD_ACC_MGR_SUCCESS ) )
     return NULL;
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_recent_hashes.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_recent_hashes.h
@@ -34,7 +34,7 @@ fd_sysvar_recent_hashes_update( fd_exec_slot_ctx_t * slot_ctx );
    lamports, this function returns NULL. */
 
 fd_recent_block_hashes_t *
-fd_sysvar_recent_hashes_read( fd_funk_t * funk, fd_funk_txn_t * funk_txn, fd_spad_t * spad );
+fd_sysvar_recent_hashes_read( fd_funk_t * funk, fd_funk_txn_xid_t const * xid, fd_spad_t * spad );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
@@ -32,11 +32,11 @@ fd_sysvar_rent_init( fd_exec_slot_ctx_t * slot_ctx ) {
 }
 
 fd_rent_t const *
-fd_sysvar_rent_read( fd_funk_t *     funk,
-                     fd_funk_txn_t * funk_txn,
-                     fd_spad_t *     spad ) {
+fd_sysvar_rent_read( fd_funk_t *               funk,
+                     fd_funk_txn_xid_t const * xid,
+                     fd_spad_t *               spad ) {
   FD_TXN_ACCOUNT_DECL( acc );
-  int rc = fd_txn_account_init_from_funk_readonly( acc, &fd_sysvar_rent_id, funk, funk_txn );
+  int rc = fd_txn_account_init_from_funk_readonly( acc, &fd_sysvar_rent_id, funk, xid );
   if( FD_UNLIKELY( rc!=FD_ACC_MGR_SUCCESS ) ) {
     return NULL;
   }

--- a/src/flamenco/runtime/sysvar/fd_sysvar_rent.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_rent.h
@@ -32,9 +32,9 @@ fd_rent_exempt_minimum_balance( fd_rent_t const * rent,
    has zero lamports, this function returns NULL. */
 
 fd_rent_t const *
-fd_sysvar_rent_read( fd_funk_t *     funk,
-                     fd_funk_txn_t * funk_txn,
-                     fd_spad_t *     spad );
+fd_sysvar_rent_read( fd_funk_t *               funk,
+                     fd_funk_txn_xid_t const * xid,
+                     fd_spad_t *               spad );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
@@ -94,7 +94,7 @@ fd_sysvar_slot_hashes_init( fd_exec_slot_ctx_t * slot_ctx,
 void
 fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime_spad ) {
   FD_SPAD_FRAME_BEGIN( runtime_spad ) {
-    fd_slot_hashes_global_t * slot_hashes_global = fd_sysvar_slot_hashes_read( slot_ctx->funk, slot_ctx->funk_txn, runtime_spad );
+    fd_slot_hashes_global_t * slot_hashes_global = fd_sysvar_slot_hashes_read( slot_ctx->funk, slot_ctx->xid, runtime_spad );
     fd_slot_hash_t *          hashes             = NULL;
     if( FD_UNLIKELY( !slot_hashes_global ) ) {
       /* Note: Agave's implementation initializes a new slot_hashes if it doesn't already exist (refer to above URL). */
@@ -135,11 +135,11 @@ fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime
 }
 
 fd_slot_hashes_global_t *
-fd_sysvar_slot_hashes_read( fd_funk_t *     funk,
-                            fd_funk_txn_t * funk_txn,
-                            fd_spad_t *     spad ) {
+fd_sysvar_slot_hashes_read( fd_funk_t *               funk,
+                            fd_funk_txn_xid_t const * xid,
+                            fd_spad_t *               spad ) {
   FD_TXN_ACCOUNT_DECL( rec );
-  int err = fd_txn_account_init_from_funk_readonly( rec, (fd_pubkey_t const *)&fd_sysvar_slot_hashes_id, funk, funk_txn );
+  int err = fd_txn_account_init_from_funk_readonly( rec, (fd_pubkey_t const *)&fd_sysvar_slot_hashes_id, funk, xid );
   if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
     return NULL;
   }

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.h
@@ -51,9 +51,9 @@ fd_sysvar_slot_hashes_update( fd_exec_slot_ctx_t * slot_ctx, fd_spad_t * runtime
    If the account doesn't exist in funk or if the account has zero
    lamports, this function returns NULL. */
 fd_slot_hashes_global_t *
-fd_sysvar_slot_hashes_read( fd_funk_t *     funk,
-                            fd_funk_txn_t * funk_txn,
-                            fd_spad_t *     spad );
+fd_sysvar_slot_hashes_read( fd_funk_t *               funk,
+                            fd_funk_txn_xid_t const * xid,
+                            fd_spad_t *               spad );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
@@ -87,7 +87,7 @@ fd_sysvar_slot_history_update( fd_exec_slot_ctx_t * slot_ctx ) {
   fd_pubkey_t const * key = &fd_sysvar_slot_history_id;
 
   FD_TXN_ACCOUNT_DECL( rec );
-  int err = fd_txn_account_init_from_funk_readonly( rec, key, slot_ctx->funk, slot_ctx->funk_txn );
+  int err = fd_txn_account_init_from_funk_readonly( rec, key, slot_ctx->funk, slot_ctx->xid );
   if (err)
     FD_LOG_CRIT(( "fd_txn_account_init_from_funk_readonly(slot_history) failed: %d", err ));
 
@@ -115,15 +115,15 @@ fd_sysvar_slot_history_update( fd_exec_slot_ctx_t * slot_ctx ) {
 }
 
 fd_slot_history_global_t *
-fd_sysvar_slot_history_read( fd_funk_t *     funk,
-                             fd_funk_txn_t * funk_txn,
-                             uchar           out_mem[ static FD_SYSVAR_SLOT_HISTORY_FOOTPRINT ] ) {
+fd_sysvar_slot_history_read( fd_funk_t *               funk,
+                             fd_funk_txn_xid_t const * xid,
+                             uchar                     out_mem[ static FD_SYSVAR_SLOT_HISTORY_FOOTPRINT ] ) {
   /* Set current_slot, and update next_slot */
 
   fd_pubkey_t const * key = &fd_sysvar_slot_history_id;
 
   FD_TXN_ACCOUNT_DECL( rec );
-  int err = fd_txn_account_init_from_funk_readonly( rec, key, funk, funk_txn );
+  int err = fd_txn_account_init_from_funk_readonly( rec, key, funk, xid );
   if( err ) {
     FD_LOG_CRIT(( "fd_txn_account_init_from_funk_readonly(slot_history) failed: %d", err ));
   }

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.h
@@ -28,9 +28,9 @@ fd_sysvar_slot_history_update( fd_exec_slot_ctx_t * slot_ctx );
    lamports, this function returns NULL. */
 
 fd_slot_history_global_t *
-fd_sysvar_slot_history_read( fd_funk_t *     funk,
-                             fd_funk_txn_t * funk_txn,
-                             uchar           out_mem[ static FD_SYSVAR_SLOT_HISTORY_FOOTPRINT ] );
+fd_sysvar_slot_history_read( fd_funk_t *               funk,
+                             fd_funk_txn_xid_t const * xid,
+                             uchar                     out_mem[ static FD_SYSVAR_SLOT_HISTORY_FOOTPRINT ] );
 
 int
 fd_sysvar_slot_history_find_slot( fd_slot_history_global_t const * history,

--- a/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.c
@@ -24,11 +24,11 @@ write_stake_history( fd_exec_slot_ctx_t * slot_ctx,
 }
 
 fd_stake_history_t *
-fd_sysvar_stake_history_read( fd_funk_t *     funk,
-                              fd_funk_txn_t * funk_txn,
-                              fd_spad_t *     spad ) {
+fd_sysvar_stake_history_read( fd_funk_t *               funk,
+                              fd_funk_txn_xid_t const * xid,
+                              fd_spad_t *               spad ) {
   FD_TXN_ACCOUNT_DECL( stake_rec );
-  int err = fd_txn_account_init_from_funk_readonly( stake_rec, &fd_sysvar_stake_history_id, funk, funk_txn );
+  int err = fd_txn_account_init_from_funk_readonly( stake_rec, &fd_sysvar_stake_history_id, funk, xid );
   if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
     return NULL;
   }
@@ -62,7 +62,7 @@ fd_sysvar_stake_history_update( fd_exec_slot_ctx_t *                        slot
   FD_SPAD_FRAME_BEGIN( runtime_spad ) {
 
   // Need to make this maybe zero copies of map...
-  fd_stake_history_t * stake_history = fd_sysvar_stake_history_read( slot_ctx->funk, slot_ctx->funk_txn, runtime_spad );
+  fd_stake_history_t * stake_history = fd_sysvar_stake_history_read( slot_ctx->funk, slot_ctx->xid, runtime_spad );
 
   if( stake_history->fd_stake_history_offset == 0 ) {
     stake_history->fd_stake_history_offset = stake_history->fd_stake_history_size - 1;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.h
@@ -25,9 +25,9 @@ fd_sysvar_stake_history_init( fd_exec_slot_ctx_t * slot_ctx );
    lamports, this function returns NULL. */
 
 fd_stake_history_t *
-fd_sysvar_stake_history_read( fd_funk_t *     funk,
-                              fd_funk_txn_t * funk_txn,
-                              fd_spad_t *     spad );
+fd_sysvar_stake_history_read( fd_funk_t *               funk,
+                              fd_funk_txn_xid_t const * xid,
+                              fd_spad_t *               spad );
 
 /* Update the stake history sysvar account - called during epoch boundary */
 void

--- a/src/flamenco/runtime/sysvar/test_sysvar_cache.c
+++ b/src/flamenco/runtime/sysvar/test_sysvar_cache.c
@@ -21,6 +21,7 @@ test_sysvar_cache_env_create( test_sysvar_cache_env_t * env,
   env->slot_ctx->magic  = FD_EXEC_SLOT_CTX_MAGIC;
   env->slot_ctx->bank   = bank;
   env->slot_ctx->funk   = funk;
+  env->slot_ctx->xid[0] = *fd_funk_last_publish( funk );
   env->sysvar_cache     = fd_sysvar_cache_join( fd_sysvar_cache_new( bank->sysvar_cache ) );
   return env;
 }

--- a/src/flamenco/runtime/sysvar/test_sysvar_cache_util.h
+++ b/src/flamenco/runtime/sysvar/test_sysvar_cache_util.h
@@ -10,7 +10,6 @@
 
 struct test_sysvar_cache_env {
   fd_funk_t           funk[1];
-  fd_funk_txn_t *     funk_txn;
   fd_exec_slot_ctx_t  slot_ctx[1];
   fd_sysvar_cache_t * sysvar_cache;
 };

--- a/src/flamenco/runtime/tests/fd_harness_common.c
+++ b/src/flamenco/runtime/tests/fd_harness_common.c
@@ -5,7 +5,7 @@
 int
 fd_runtime_fuzz_load_account( fd_txn_account_t *                acc,
                               fd_funk_t *                       funk,
-                              fd_funk_txn_t *                   funk_txn,
+                              fd_funk_txn_xid_t const *         xid,
                               fd_exec_test_acct_state_t const * state,
                               uchar                             reject_zero_lamports ) {
   if( reject_zero_lamports && state->lamports==0UL ) {
@@ -18,7 +18,7 @@ fd_runtime_fuzz_load_account( fd_txn_account_t *                acc,
   fd_pubkey_t pubkey[1];  memcpy( pubkey, state->address, sizeof(fd_pubkey_t) );
 
   /* Account must not yet exist */
-  if( FD_UNLIKELY( fd_funk_get_acc_meta_readonly( funk, funk_txn, pubkey, NULL, NULL, NULL) ) ) {
+  if( FD_UNLIKELY( fd_funk_get_acc_meta_readonly( funk, xid, pubkey, NULL, NULL, NULL) ) ) {
     return 0;
   }
 
@@ -28,7 +28,7 @@ fd_runtime_fuzz_load_account( fd_txn_account_t *                acc,
   int err = fd_txn_account_init_from_funk_mutable( /* acc         */ acc,
                                                    /* pubkey      */ pubkey,
                                                    /* funk        */ funk,
-                                                   /* txn         */ funk_txn,
+                                                   /* xid         */ xid,
                                                    /* do_create   */ 1,
                                                    /* min_data_sz */ size,
                                                    /* prepare     */ &prepare );
@@ -47,7 +47,7 @@ fd_runtime_fuzz_load_account( fd_txn_account_t *                acc,
   /* make the account read-only by default */
   fd_txn_account_set_readonly( acc );
 
-  fd_txn_account_mutable_fini( acc, funk, funk_txn, &prepare );
+  fd_txn_account_mutable_fini( acc, funk, &prepare );
 
   return 1;
 }

--- a/src/flamenco/runtime/tests/fd_solfuzz_private.h
+++ b/src/flamenco/runtime/tests/fd_solfuzz_private.h
@@ -18,7 +18,7 @@ FD_PROTOTYPES_BEGIN
 int
 fd_runtime_fuzz_load_account( fd_txn_account_t *                acc,
                               fd_funk_t *                       funk,
-                              fd_funk_txn_t *                   funk_txn,
+                              fd_funk_txn_xid_t const *         xid,
                               fd_exec_test_acct_state_t const * state,
                               uchar                             reject_zero_lamports );
 

--- a/src/flamenco/stakes/fd_stake_delegations.c
+++ b/src/flamenco/stakes/fd_stake_delegations.c
@@ -331,9 +331,9 @@ fd_stake_delegations_remove( fd_stake_delegations_t * stake_delegations,
 }
 
 void
-fd_stake_delegations_refresh( fd_stake_delegations_t * stake_delegations,
-                              fd_funk_t *              funk,
-                              fd_funk_txn_t *          funk_txn ) {
+fd_stake_delegations_refresh( fd_stake_delegations_t *  stake_delegations,
+                              fd_funk_t *               funk,
+                              fd_funk_txn_xid_t const * xid ) {
 
   fd_stake_delegation_map_t * stake_delegation_map = fd_stake_delegations_get_map( stake_delegations );
   if( FD_UNLIKELY( !stake_delegation_map ) ) {
@@ -364,7 +364,7 @@ fd_stake_delegations_refresh( fd_stake_delegations_t * stake_delegations,
         acct_rec,
         &stake_delegation->stake_account,
         funk,
-        funk_txn );
+        xid );
 
     if( FD_UNLIKELY( err || fd_txn_account_get_lamports( acct_rec )==0UL ) ) {
       fd_stake_delegation_map_idx_remove( stake_delegation_map, &stake_delegation->stake_account, ULONG_MAX, stake_delegation_pool );

--- a/src/flamenco/stakes/fd_stake_delegations.h
+++ b/src/flamenco/stakes/fd_stake_delegations.h
@@ -288,9 +288,9 @@ fd_stake_delegations_query( fd_stake_delegations_t const * stake_delegations,
    No new entries are added to the struct at this point. */
 
 void
-fd_stake_delegations_refresh( fd_stake_delegations_t * stake_delegations,
-                              fd_funk_t *              funk,
-                              fd_funk_txn_t *          funk_txn );
+fd_stake_delegations_refresh( fd_stake_delegations_t *  stake_delegations,
+                              fd_funk_t *               funk,
+                              fd_funk_txn_xid_t const * xid );
 
 /* fd_stake_delegations_cnt returns the number of stake delegations
    in the stake delegations struct. fd_stake_delegations_t must be a

--- a/src/flamenco/stakes/fd_stakes.c
+++ b/src/flamenco/stakes/fd_stakes.c
@@ -171,7 +171,7 @@ fd_stakes_activate_epoch( fd_exec_slot_ctx_t *           slot_ctx,
   /* Add a new entry to the Stake History sysvar for the previous epoch
      https://github.com/solana-labs/solana/blob/88aeaa82a856fc807234e7da0b31b89f2dc0e091/runtime/src/stakes.rs#L181-L192 */
 
-  fd_stake_history_t const * history = fd_sysvar_stake_history_read( slot_ctx->funk, slot_ctx->funk_txn, runtime_spad );
+  fd_stake_history_t const * history = fd_sysvar_stake_history_read( slot_ctx->funk, slot_ctx->xid, runtime_spad );
   if( FD_UNLIKELY( !history ) ) FD_LOG_ERR(( "StakeHistory sysvar is missing from sysvar cache" ));
 
   fd_stake_history_entry_t accumulator = {

--- a/src/funk/fd_funk_rec.c
+++ b/src/funk/fd_funk_rec.c
@@ -1,4 +1,5 @@
 #include "fd_funk.h"
+#include "fd_funk_base.h"
 #include "fd_funk_txn.h"
 
 /* Provide the actual record map implementation */
@@ -40,30 +41,66 @@ static int fd_funk_rec_pool_is_in_pool( fd_funk_rec_t const * ele ) {
 #define MAP_IMPL_STYLE        2
 #include "../util/tmpl/fd_map_chain_para.c"
 
+static fd_funk_txn_t *
+fd_funk_rec_txn_borrow( fd_funk_t const *         funk,
+                        fd_funk_txn_xid_t const * xid,
+                        fd_funk_txn_map_query_t * query ) {
+  memset( query, 0, sizeof(fd_funk_txn_map_query_t) );
+  if( fd_funk_txn_xid_eq( xid, funk->shmem->last_publish ) ) return NULL;
+
+  fd_funk_txn_map_query_t txn_query[1];
+  for(;;) {
+    int txn_query_err = fd_funk_txn_map_query_try( funk->txn_map, xid, NULL, txn_query, 0 );
+    if( FD_UNLIKELY( txn_query_err==FD_MAP_ERR_AGAIN ) ) continue;
+    if( FD_UNLIKELY( txn_query_err!=FD_MAP_SUCCESS ) ) {
+      FD_LOG_ERR(( "fd_funk_rec op failed: txn_map_query_try(%lu:%lu) error %i-%s",
+                  xid->ul[0], xid->ul[1],
+                  txn_query_err, fd_map_strerror( txn_query_err ) ));
+    }
+    break;
+  }
+  fd_funk_txn_t * txn = fd_funk_txn_map_query_ele( txn_query );
+  uint txn_state = FD_VOLATILE_CONST( txn->state );
+  if( FD_UNLIKELY( txn_state!=FD_FUNK_TXN_STATE_ACTIVE ) ) {
+    FD_LOG_ERR(( "fd_funk_rec op failed: txn %p %lu:%lu state is %u-%s",
+                 (void *)txn, xid->ul[0], xid->ul[1],
+                 txn_state, fd_funk_txn_state_str( txn_state ) ));
+  }
+  return txn;
+}
+
+static void
+fd_funk_rec_txn_release( fd_funk_txn_map_query_t const * query ) {
+  if( !query->ele ) return;
+  if( FD_UNLIKELY( fd_funk_txn_map_query_test( query )!=FD_MAP_SUCCESS ) ) {
+    FD_LOG_CRIT(( "fd_funk_rec_txn_release: fd_funk_txn_map_query_test failed (data race detected?)" ));
+  }
+}
+
 static void
 fd_funk_rec_key_set_pair( fd_funk_xid_key_pair_t *  key_pair,
-                          fd_funk_txn_t const *     txn,
+                          fd_funk_txn_xid_t const * xid,
                           fd_funk_rec_key_t const * key ) {
-  if( !txn ) {
-    fd_funk_txn_xid_set_root( key_pair->xid );
-  } else {
-    fd_funk_txn_xid_copy( key_pair->xid, &txn->xid );
-  }
+  fd_funk_txn_xid_copy( key_pair->xid, xid );
   fd_funk_rec_key_copy( key_pair->key, key );
 }
 
 fd_funk_rec_t const *
 fd_funk_rec_query_try( fd_funk_t *               funk,
-                       fd_funk_txn_xid_t const * txn_xid,
+                       fd_funk_txn_xid_t const * xid,
                        fd_funk_rec_key_t const * key,
                        fd_funk_rec_query_t *     query ) {
-  if( FD_UNLIKELY( !funk    ) ) FD_LOG_CRIT(( "NULL funk"    ));
-  if( FD_UNLIKELY( !txn_xid ) ) FD_LOG_CRIT(( "NULL txn_xid" ));
-  if( FD_UNLIKELY( !key     ) ) FD_LOG_CRIT(( "NULL key"     ));
-  if( FD_UNLIKELY( !query   ) ) FD_LOG_CRIT(( "NULL query"   ));
+  if( FD_UNLIKELY( !funk  ) ) FD_LOG_CRIT(( "NULL funk"  ));
+  if( FD_UNLIKELY( !xid   ) ) FD_LOG_CRIT(( "NULL xid"   ));
+  if( FD_UNLIKELY( !key   ) ) FD_LOG_CRIT(( "NULL key"   ));
+  if( FD_UNLIKELY( !query ) ) FD_LOG_CRIT(( "NULL query" ));
 
   fd_funk_xid_key_pair_t pair[1];
-  fd_funk_txn_xid_copy( pair->xid, txn_xid );
+  if( FD_UNLIKELY( fd_funk_txn_xid_eq( xid, funk->shmem->last_publish ) ) ) {
+    fd_funk_txn_xid_set_root( pair->xid );
+  } else {
+    fd_funk_txn_xid_copy( pair->xid, xid );
+  }
   fd_funk_rec_key_copy( pair->key, key );
 
   for(;;) {
@@ -79,12 +116,12 @@ fd_funk_rec_query_try( fd_funk_t *               funk,
 
 fd_funk_rec_t *
 fd_funk_rec_modify( fd_funk_t *               funk,
-                    fd_funk_txn_t const *     txn,
+                    fd_funk_txn_xid_t const * xid,
                     fd_funk_rec_key_t const * key,
                     fd_funk_rec_query_t *     query ) {
   fd_funk_rec_map_t *    rec_map = fd_funk_rec_map( funk );
   fd_funk_xid_key_pair_t pair[1];
-  fd_funk_rec_key_set_pair( pair, txn, key );
+  fd_funk_rec_key_set_pair( pair, xid, key );
 
   int err = fd_funk_rec_map_modify_try( rec_map, pair, NULL, query, FD_MAP_FLAG_BLOCKING );
   if( err==FD_MAP_ERR_KEY ) return NULL;
@@ -101,18 +138,16 @@ fd_funk_rec_modify_publish( fd_funk_rec_query_t * query ) {
 
 fd_funk_rec_t const *
 fd_funk_rec_query_try_global( fd_funk_t const *         funk,
-                              fd_funk_txn_t const *     txn,
+                              fd_funk_txn_xid_t const * xid,
                               fd_funk_rec_key_t const * key,
                               fd_funk_txn_t const **    txn_out,
                               fd_funk_rec_query_t *     query ) {
   if( FD_UNLIKELY( !funk  ) ) FD_LOG_CRIT(( "NULL funk"  ));
   if( FD_UNLIKELY( !key   ) ) FD_LOG_CRIT(( "NULL key"   ));
   if( FD_UNLIKELY( !query ) ) FD_LOG_CRIT(( "NULL query" ));
-#ifdef FD_FUNK_HANDHOLDING
-  if( FD_UNLIKELY( txn && !fd_funk_txn_valid( funk, txn ) ) ) {
-    return NULL;
-  }
-#endif
+
+  fd_funk_txn_map_query_t txn_query[1];
+  fd_funk_txn_t * txn = fd_funk_rec_txn_borrow( funk, xid, txn_query );
 
   /* Look for the first element in the hash chain with the right
      record key. This takes advantage of the fact that elements with
@@ -120,7 +155,7 @@ fd_funk_rec_query_try_global( fd_funk_t const *         funk,
      newest to oldest. */
 
   fd_funk_xid_key_pair_t pair[1];
-  fd_funk_rec_key_set_pair( pair, txn, key );
+  fd_funk_rec_key_set_pair( pair, xid, key );
 
   fd_funk_rec_map_shmem_t * rec_map = funk->rec_map->map;
   ulong hash = fd_funk_rec_map_key_hash( pair, rec_map->seed );
@@ -130,6 +165,8 @@ fd_funk_rec_query_try_global( fd_funk_t const *         funk,
   query->ele     = NULL;
   query->chain   = chain;
   query->ver_cnt = chain->ver_cnt; /* After unlock */
+
+  fd_funk_rec_t const * res = NULL;
 
   for( fd_funk_rec_map_iter_t iter = fd_funk_rec_map_iter( funk->rec_map, chain_idx );
        !fd_funk_rec_map_iter_done( iter );
@@ -152,8 +189,8 @@ fd_funk_rec_query_try_global( fd_funk_t const *         funk,
           if( txn_out ) *txn_out = cur_txn;
           query->ele = ( FD_UNLIKELY( ele->flags & FD_FUNK_REC_FLAG_ERASE ) ? NULL :
                          (fd_funk_rec_t *)ele );
-          if( FD_LIKELY( txn ) ) fd_funk_txn_xid_assert( txn, pair->xid );
-          return query->ele;
+          res = query->ele;
+          goto found;
         }
 
         if( cur_txn == NULL ) break;
@@ -161,19 +198,21 @@ fd_funk_rec_query_try_global( fd_funk_t const *         funk,
     }
   }
 
+found:
   if( FD_LIKELY( txn ) ) fd_funk_txn_xid_assert( txn, pair->xid );
-  return NULL;
+  fd_funk_rec_txn_release( txn_query );
+  return res;
 }
 
 fd_funk_rec_t const *
 fd_funk_rec_query_copy( fd_funk_t *               funk,
-                        fd_funk_txn_t const *     txn,
+                        fd_funk_txn_xid_t const * xid,
                         fd_funk_rec_key_t const * key,
                         fd_valloc_t               valloc,
                         ulong *                   sz_out ) {
   *sz_out = ULONG_MAX;
   fd_funk_xid_key_pair_t pair[1];
-  fd_funk_rec_key_set_pair( pair, txn, key );
+  fd_funk_rec_key_set_pair( pair, xid, key );
 
   void * last_copy = NULL;
   ulong last_copy_sz = 0;
@@ -209,30 +248,29 @@ fd_funk_rec_query_test( fd_funk_rec_query_t * query ) {
 
 fd_funk_rec_t *
 fd_funk_rec_prepare( fd_funk_t *               funk,
-                     fd_funk_txn_t *           txn,
+                     fd_funk_txn_xid_t const * xid,
                      fd_funk_rec_key_t const * key,
                      fd_funk_rec_prepare_t *   prepare,
                      int *                     opt_err ) {
-#ifdef FD_FUNK_HANDHOLDING
-  if( FD_UNLIKELY( funk==NULL || key==NULL || prepare==NULL ) ) {
-    fd_int_store_if( !!opt_err, opt_err, FD_FUNK_ERR_INVAL );
-    return NULL;
-  }
-  if( FD_UNLIKELY( txn && !fd_funk_txn_valid( funk, txn ) ) ) {
-    fd_int_store_if( !!opt_err, opt_err, FD_FUNK_ERR_INVAL );
-    return NULL;
-  }
-#endif
+  if( FD_UNLIKELY( !funk    ) ) FD_LOG_ERR(( "NULL funk"    ));
+  if( FD_UNLIKELY( !xid     ) ) FD_LOG_ERR(( "NULL xid"     ));
+  if( FD_UNLIKELY( !prepare ) ) FD_LOG_ERR(( "NULL prepare" ));
+
+  fd_funk_txn_map_query_t txn_query[1];
+  fd_funk_txn_t * txn = fd_funk_rec_txn_borrow( funk, xid, txn_query );
+
   memset( prepare, 0, sizeof(fd_funk_rec_prepare_t) );
 
   if( !txn ) { /* Modifying last published */
     if( FD_UNLIKELY( fd_funk_last_publish_is_frozen( funk ) ) ) {
       fd_int_store_if( !!opt_err, opt_err, FD_FUNK_ERR_FROZEN );
+      fd_funk_rec_txn_release( txn_query );
       return NULL;
     }
   } else {
     if( FD_UNLIKELY( fd_funk_txn_is_frozen( txn ) ) ) {
       fd_int_store_if( !!opt_err, opt_err, FD_FUNK_ERR_FROZEN );
+      fd_funk_rec_txn_release( txn_query );
       return NULL;
     }
   }
@@ -243,6 +281,7 @@ fd_funk_rec_prepare( fd_funk_t *               funk,
   }
   if( FD_UNLIKELY( !rec ) ) {
     fd_int_store_if( !!opt_err, opt_err, FD_FUNK_ERR_REC );
+    fd_funk_rec_txn_release( txn_query );
     return rec;
   }
 
@@ -261,6 +300,7 @@ fd_funk_rec_prepare( fd_funk_t *               funk,
   rec->flags = 0;
   rec->prev_idx = FD_FUNK_REC_IDX_NULL;
   rec->next_idx = FD_FUNK_REC_IDX_NULL;
+  fd_funk_rec_txn_release( txn_query );
   return rec;
 }
 
@@ -382,7 +422,7 @@ fd_funk_rec_txn_publish( fd_funk_t *             funk,
 
 void
 fd_funk_rec_insert_para( fd_funk_t *               funk,
-                         fd_funk_txn_t *           txn,
+                         fd_funk_txn_xid_t const * xid,
                          fd_funk_rec_key_t const * key ) {
 
   /* TODO: There is probably a cleaner way to allocate the txn memory. */
@@ -395,20 +435,21 @@ fd_funk_rec_insert_para( fd_funk_t *               funk,
      from either the current transaction or one of its ancestors. */
 
   fd_funk_rec_t const * rec_glob = NULL;
-  fd_funk_txn_t const * txn_glob = NULL;
+  fd_funk_txn_xid_t     txn_glob[1] = {0};
 
   for(;;) {
     fd_funk_rec_query_t query_glob[1];
-    txn_glob = NULL;
-    rec_glob = fd_funk_rec_query_try_global(
-        funk, txn,key, &txn_glob, query_glob );
+    fd_funk_txn_t const * found_txn = NULL;
+    rec_glob = fd_funk_rec_query_try_global( funk, xid, key, &found_txn, query_glob );
+    if( found_txn ) fd_funk_txn_xid_copy( txn_glob, &found_txn->xid );
+    else            fd_funk_txn_xid_copy( txn_glob, fd_funk_last_publish( funk ) );
 
     /* If the record exists and already exists in the specified funk
        txn, we can return successfully.
 
        TODO: This should probably also check that the record has a large
        enough size, i.e. rec_glob >= min_sz. */
-    if( rec_glob && txn==txn_glob ) {
+    if( rec_glob && fd_funk_txn_xid_eq( txn_glob, xid ) ) {
       return;
     }
 
@@ -427,7 +468,7 @@ fd_funk_rec_insert_para( fd_funk_t *               funk,
   fd_funk_rec_map_txn_t * map_txn = fd_funk_rec_map_txn_init( txn_mem, funk->rec_map, MAX_TXN_KEY_CNT );
 
   fd_funk_xid_key_pair_t pair[1];
-  fd_funk_rec_key_set_pair( pair, txn, key );
+  fd_funk_rec_key_set_pair( pair, xid, key );
 
   fd_funk_rec_map_txn_add( map_txn, pair, 1 );
 
@@ -465,7 +506,7 @@ fd_funk_rec_insert_para( fd_funk_t *               funk,
      (if one exists). */
 
   fd_funk_rec_prepare_t prepare[1];
-  fd_funk_rec_prepare( funk, txn, key, prepare, &err );
+  fd_funk_rec_prepare( funk, xid, key, prepare, &err );
   if( FD_UNLIKELY( err ) ) {
     FD_LOG_CRIT(( "fd_funk_rec_prepare returned err=%d", err ));
   }
@@ -483,16 +524,16 @@ fd_funk_rec_insert_para( fd_funk_t *               funk,
 
 fd_funk_rec_t *
 fd_funk_rec_clone( fd_funk_t *               funk,
-                   fd_funk_txn_t *           txn,
+                   fd_funk_txn_xid_t const * xid,
                    fd_funk_rec_key_t const * key,
                    fd_funk_rec_prepare_t *   prepare,
                    int *                     opt_err ) {
-  fd_funk_rec_t * new_rec = fd_funk_rec_prepare( funk, txn, key, prepare, opt_err );
+  fd_funk_rec_t * new_rec = fd_funk_rec_prepare( funk, xid, key, prepare, opt_err );
   if( !new_rec ) return NULL;
 
   for(;;) {
     fd_funk_rec_query_t query[1];
-    fd_funk_rec_t const * old_rec = fd_funk_rec_query_try_global( funk, txn, key, NULL, query );
+    fd_funk_rec_t const * old_rec = fd_funk_rec_query_try_global( funk, xid, key, NULL, query );
     if( !old_rec ) {
       fd_int_store_if( !!opt_err, opt_err, FD_FUNK_ERR_KEY );
       fd_funk_rec_cancel( funk, prepare );
@@ -522,36 +563,38 @@ fd_funk_rec_clone( fd_funk_t *               funk,
 
 int
 fd_funk_rec_remove( fd_funk_t *               funk,
-                    fd_funk_txn_t *           txn,
+                    fd_funk_txn_xid_t const * xid,
                     fd_funk_rec_key_t const * key,
                     fd_funk_rec_t **          rec_out ) {
-#ifdef FD_FUNK_HANDHOLDING
-  if( FD_UNLIKELY( funk==NULL || key==NULL ) ) {
-    return FD_FUNK_ERR_INVAL;
-  }
-  if( FD_UNLIKELY( txn && !fd_funk_txn_valid( funk, txn ) ) ) {
-    return FD_FUNK_ERR_INVAL;
-  }
-#endif
+  if( FD_UNLIKELY( !funk ) ) FD_LOG_ERR(( "NULL funk" ));
+  if( FD_UNLIKELY( !xid  ) ) FD_LOG_ERR(( "NULL xid"  ));
+  if( FD_UNLIKELY( !key  ) ) FD_LOG_ERR(( "NULL key"  ));
+
+  fd_funk_txn_map_query_t txn_query[1];
+  fd_funk_txn_t * txn = fd_funk_rec_txn_borrow( funk, xid, txn_query );
+
+  fd_funk_xid_key_pair_t pair[1];
+  fd_funk_rec_key_set_pair( pair, xid, key );
 
   if( !txn ) { /* Modifying last published */
     if( FD_UNLIKELY( fd_funk_last_publish_is_frozen( funk ) ) ) {
-      return FD_FUNK_ERR_FROZEN;
+      FD_LOG_ERR(( "fd_funk_rec_remove failed: txn %lu:%lu (last published) is frozen", xid->ul[0], xid->ul[1] ));
     }
+    fd_funk_txn_xid_set_root( pair->xid );
   } else {
     if( FD_UNLIKELY( fd_funk_txn_is_frozen( txn ) ) ) {
-      return FD_FUNK_ERR_FROZEN;
+      FD_LOG_ERR(( "fd_funk_rec_remove failed: txn %p %lu:%lu is frozen", (void *)txn, xid->ul[0], xid->ul[1] ));
     }
   }
-
-  fd_funk_xid_key_pair_t pair[1];
-  fd_funk_rec_key_set_pair( pair, txn, key );
 
   fd_funk_rec_query_t query[ 1 ];
   for(;;) {
     int err = fd_funk_rec_map_query_try( funk->rec_map, pair, NULL, query, 0 );
-    if( err == FD_MAP_SUCCESS )   break;
-    if( err == FD_MAP_ERR_KEY )   return FD_FUNK_ERR_KEY;
+    if( err == FD_MAP_SUCCESS   ) break;
+    if( err == FD_MAP_ERR_KEY   ) {
+      fd_funk_rec_txn_release( txn_query );
+      return FD_FUNK_ERR_KEY;
+    }
     if( err == FD_MAP_ERR_AGAIN ) continue;
     FD_LOG_CRIT(( "query returned err %d", err ));
   }
@@ -563,7 +606,10 @@ fd_funk_rec_remove( fd_funk_t *               funk,
   ulong old_flags;
   for(;;) {
     old_flags = rec->flags;
-    if( FD_UNLIKELY( old_flags & FD_FUNK_REC_FLAG_ERASE ) ) return FD_FUNK_SUCCESS;
+    if( FD_UNLIKELY( old_flags & FD_FUNK_REC_FLAG_ERASE ) ) {
+      fd_funk_rec_txn_release( txn_query );
+      return FD_FUNK_SUCCESS;
+    }
     if( FD_ATOMIC_CAS( &rec->flags, old_flags, old_flags | FD_FUNK_REC_FLAG_ERASE ) == old_flags ) break;
   }
 
@@ -572,7 +618,7 @@ fd_funk_rec_remove( fd_funk_t *               funk,
      reasons, we need to remember what was deleted. */
 
   fd_funk_val_flush( rec, funk->alloc, funk->wksp );
-
+  fd_funk_rec_txn_release( txn_query );
   return FD_FUNK_SUCCESS;
 }
 
@@ -679,12 +725,12 @@ fd_funk_rec_verify( fd_funk_t * funk ) {
       /* Make sure every record either links up with the last published
          transaction or an in-prep transaction and the flags are sane. */
 
-      fd_funk_txn_xid_t const * txn_xid = fd_funk_rec_xid( rec );
+      fd_funk_txn_xid_t const * xid     = fd_funk_rec_xid( rec );
       ulong                     txn_idx = fd_funk_txn_idx( rec->txn_cidx );
 
       if( fd_funk_txn_idx_is_null( txn_idx ) ) { /* This is a record from the last published transaction */
 
-        TEST( fd_funk_txn_xid_eq_root( txn_xid ) );
+        TEST( fd_funk_txn_xid_eq_root( xid ) );
         /* No record linked list at the root txn */
         TEST( fd_funk_rec_idx_is_null( rec->prev_idx ) );
         TEST( fd_funk_rec_idx_is_null( rec->next_idx ) );
@@ -692,7 +738,7 @@ fd_funk_rec_verify( fd_funk_t * funk ) {
       } else { /* This is a record from an in-prep transaction */
 
         TEST( txn_idx<txn_max );
-        fd_funk_txn_t const * txn = fd_funk_txn_query( txn_xid, funk->txn_map );
+        fd_funk_txn_t const * txn = fd_funk_txn_query( xid, funk->txn_map );
         TEST( txn );
         TEST( txn==(funk->txn_pool->ele+txn_idx) );
 
@@ -724,7 +770,7 @@ fd_funk_rec_verify( fd_funk_t * funk ) {
         TEST( (rec_idx<rec_max) && (fd_funk_txn_idx( rec_pool->ele[ rec_idx ].txn_cidx )==txn_idx) && rec_pool->ele[ rec_idx ].tag==0U );
         rec_pool->ele[ rec_idx ].tag = 1U;
         fd_funk_rec_query_t query[1];
-        fd_funk_rec_t const * rec2 = fd_funk_rec_query_try_global( funk, txn, rec_pool->ele[ rec_idx ].pair.key, NULL, query );
+        fd_funk_rec_t const * rec2 = fd_funk_rec_query_try_global( funk, &txn->xid, rec_pool->ele[ rec_idx ].pair.key, NULL, query );
         if( FD_UNLIKELY( rec_pool->ele[ rec_idx ].flags & FD_FUNK_REC_FLAG_ERASE ) )
           TEST( rec2 == NULL );
         else

--- a/src/funk/fd_funk_rec.h
+++ b/src/funk/fd_funk_rec.h
@@ -166,7 +166,7 @@ FD_FN_CONST static inline int fd_funk_rec_idx_is_null( uint idx ) { return idx==
 
 fd_funk_rec_t *
 fd_funk_rec_modify( fd_funk_t *               funk,
-                    fd_funk_txn_t const *     txn,
+                    fd_funk_txn_xid_t const * xid,
                     fd_funk_rec_key_t const * key,
                     fd_funk_rec_query_t *     query );
 
@@ -209,7 +209,7 @@ fd_funk_rec_modify_publish( fd_funk_rec_query_t * query );
 
 fd_funk_rec_t const *
 fd_funk_rec_query_try( fd_funk_t *               funk,
-                       fd_funk_txn_xid_t const * txn,
+                       fd_funk_txn_xid_t const * xid,
                        fd_funk_rec_key_t const * key,
                        fd_funk_rec_query_t *     query );
 
@@ -247,7 +247,7 @@ int fd_funk_rec_query_test( fd_funk_rec_query_t * query );
    fd_funk_rec_query_try_strict. */
 fd_funk_rec_t const *
 fd_funk_rec_query_try_global( fd_funk_t const *         funk,
-                              fd_funk_txn_t const *     txn,
+                              fd_funk_txn_xid_t const * xid,
                               fd_funk_rec_key_t const * key,
                               fd_funk_txn_t const **    txn_out,
                               fd_funk_rec_query_t *     query );
@@ -262,7 +262,7 @@ fd_funk_rec_query_try_global( fd_funk_t const *         funk,
 
 fd_funk_rec_t const *
 fd_funk_rec_query_copy( fd_funk_t *               funk,
-                        fd_funk_txn_t const *     txn,
+                        fd_funk_txn_xid_t const * xid,
                         fd_funk_rec_key_t const * key,
                         fd_valloc_t               valloc,
                         ulong *                   sz_out );
@@ -289,7 +289,7 @@ FD_FN_CONST static inline fd_funk_rec_key_t const *      fd_funk_rec_key ( fd_fu
 
 fd_funk_rec_t *
 fd_funk_rec_prepare( fd_funk_t *               funk,
-                     fd_funk_txn_t *           txn,
+                     fd_funk_txn_xid_t const * xid,
                      fd_funk_rec_key_t const * key,
                      fd_funk_rec_prepare_t *   prepare,
                      int *                     opt_err );
@@ -322,7 +322,7 @@ fd_funk_rec_cancel( fd_funk_t *             funk,
 
 fd_funk_rec_t *
 fd_funk_rec_clone( fd_funk_t *               funk,
-                   fd_funk_txn_t *           txn,
+                   fd_funk_txn_xid_t const * xid,
                    fd_funk_rec_key_t const * key,
                    fd_funk_rec_prepare_t *   prepare,
                    int *                     opt_err );
@@ -352,7 +352,7 @@ fd_funk_rec_clone( fd_funk_t *               funk,
 
 void
 fd_funk_rec_insert_para( fd_funk_t *               funk,
-                         fd_funk_txn_t *           txn,
+                         fd_funk_txn_xid_t const * xid,
                          fd_funk_rec_key_t const * key );
 
 /* fd_funk_rec_remove removes the live record with the
@@ -380,7 +380,7 @@ fd_funk_rec_insert_para( fd_funk_t *               funk,
 
 int
 fd_funk_rec_remove( fd_funk_t *               funk,
-                    fd_funk_txn_t *           txn,
+                    fd_funk_txn_xid_t const * xid,
                     fd_funk_rec_key_t const * key,
                     fd_funk_rec_t **          rec_out );
 

--- a/src/funk/fd_funk_txn.h
+++ b/src/funk/fd_funk_txn.h
@@ -325,8 +325,7 @@ fd_funk_txn_descendant( fd_funk_txn_t * txn,
    funk is NULL, the funk's transaction map is full, the parent is
    neither NULL nor points to an in-preparation funk transaction, xid is
    NULL, the requested xid is in use (i.e. the last published or matches
-   another in-preparation transaction).  If verbose is non-zero, these
-   will FD_LOG_WARNING details about the reason for failure.
+   another in-preparation transaction).
 
    This is a reasonably fast O(1) time (theoretical minimum), reasonably
    small O(1) space (theoretical minimum), does no allocation, does no
@@ -334,11 +333,10 @@ fd_funk_txn_descendant( fd_funk_txn_t * txn,
    least).  That is, we can scalably track forks until we run out of
    resources allocated to the funk. */
 
-fd_funk_txn_t *
+void
 fd_funk_txn_prepare( fd_funk_t *               funk,
                      fd_funk_txn_xid_t const * parent,
-                     fd_funk_txn_xid_t const * xid,
-                     int                       verbose );
+                     fd_funk_txn_xid_t const * xid );
 
 /* fd_funk_txn_cancel cancels in-preparation transaction txn and any of
    its in-preparation descendants.  On success, returns the number of
@@ -364,7 +362,7 @@ fd_funk_txn_prepare( fd_funk_t *               funk,
 
 ulong
 fd_funk_txn_cancel( fd_funk_t *               funk,
-                    fd_funk_txn_xid_t const * txn );
+                    fd_funk_txn_xid_t const * xid );
 
 /* fd_funk_txn_cancel_all cancels all in-preparation
    transactions. Only the last published transaction remains. */
@@ -386,16 +384,14 @@ fd_funk_txn_cancel_all( fd_funk_t * funk );
 
 ulong
 fd_funk_txn_publish( fd_funk_t *               funk,
-                     fd_funk_txn_xid_t const * txn );
+                     fd_funk_txn_xid_t const * xid );
 
 /* This version of publish just combines the transaction with its
    immediate parent. Ancestors will remain unpublished. Any competing
-   histories (siblings of the given transaction) are still cancelled.
-
-   Returns FD_FUNK_SUCCESS on success or an error code on failure. */
-int
+   histories (siblings of the given transaction) are still cancelled. */
+void
 fd_funk_txn_publish_into_parent( fd_funk_t *               funk,
-                                 fd_funk_txn_xid_t const * txn );
+                                 fd_funk_txn_xid_t const * xid );
 
 /* fd_funk_txn_remove_published removes all published transactions.
    Funk instance must not have any funk transactions in preparation.

--- a/src/funk/test_funk_common.h
+++ b/src/funk/test_funk_common.h
@@ -164,7 +164,7 @@ funk_descendant( funk_t * funk ) {
 ulong
 xid_unique( void );
 
-static inline fd_funk_txn_xid_t *
+__attribute__((noinline)) static fd_funk_txn_xid_t *
 xid_set( fd_funk_txn_xid_t * xid,
          ulong               _xid ) {
   xid->ul[0] = _xid; xid->ul[1] = _xid;
@@ -178,7 +178,7 @@ xid_eq( fd_funk_txn_xid_t const * xid,
   return fd_funk_txn_xid_eq( xid, xid_set( tmp, _xid ) );
 }
 
-static inline fd_funk_rec_key_t *
+__attribute__((noinline)) static FD_FN_UNUSED fd_funk_rec_key_t *
 key_set( fd_funk_rec_key_t * key,
          ulong               _key ) {
   key->ul[0] = _key; key->ul[1] = _key+_key; key->ul[2] = _key*_key; key->ul[3] = -_key;

--- a/src/funk/test_funk_common.hpp
+++ b/src/funk/test_funk_common.hpp
@@ -161,12 +161,14 @@ struct fake_funk {
       return list[((uint)lrand48())%listlen];
     }
 
-    fd_funk_txn_t * get_real_txn(fake_txn * txn) {
+    fd_funk_txn_xid_t const * get_real_txn(fake_txn * txn) {
       if (txn->_key == ROOT_KEY)
-        return NULL;
+        return fd_funk_last_publish( _real );
       fd_funk_txn_map_t * txn_map = fd_funk_txn_map( _real );
       auto xid = txn->real_id();
-      return fd_funk_txn_query(&xid, txn_map);
+      fd_funk_txn_t * rtxn = fd_funk_txn_query(&xid, txn_map);
+      if( !rtxn ) return fd_funk_last_publish( _real );
+      return &rtxn->xid;
     }
 
     void random_insert() {
@@ -178,10 +180,9 @@ struct fake_funk {
         /* Prevent duplicate keys */
       } while (!txn->insert(rec));
 
-      fd_funk_txn_t * txn2 = get_real_txn(txn);
       auto key = rec->real_id();
       fd_funk_rec_prepare_t prepare[1];
-      fd_funk_rec_t * rec2 = fd_funk_rec_prepare(_real, txn2, &key, prepare, NULL);
+      fd_funk_rec_t * rec2 = fd_funk_rec_prepare(_real, get_real_txn(txn), &key, prepare, NULL);
       void * val = fd_funk_val_truncate(rec2, fd_funk_alloc( _real ), _wksp, 0UL, rec->size(), NULL);
       memcpy(val, rec->data(), rec->size());
       fd_funk_rec_publish( _real, prepare );
@@ -199,9 +200,8 @@ struct fake_funk {
       if (!listlen) return;
       auto* rec = list[((uint)lrand48())%listlen];
 
-      fd_funk_txn_t * txn2 = get_real_txn(txn);
       auto key = rec->real_id();
-      assert(fd_funk_rec_remove(_real, txn2, &key, NULL) == FD_FUNK_SUCCESS);
+      assert(fd_funk_rec_remove(_real, get_real_txn(txn), &key, NULL) == FD_FUNK_SUCCESS);
 
       rec->_erased = true;
       rec->_data.clear();
@@ -223,12 +223,8 @@ struct fake_funk {
       txn->_parent = parent;
       parent->_children[key] = txn;
 
-      fd_funk_txn_t * parent2 = get_real_txn(parent);
       auto xid = txn->real_id();
-      fd_funk_txn_xid_t parent_xid;
-      if( parent2 ) parent_xid = parent2->xid;
-      else          fd_funk_txn_xid_copy( &parent_xid, fd_funk_last_publish( _real ) );
-      assert(fd_funk_txn_prepare(_real, &parent_xid, &xid, 1) != NULL);
+      fd_funk_txn_prepare(_real, get_real_txn(parent), &xid);
     }
 
     void fake_cancel_family(fake_txn* txn) {
@@ -299,8 +295,7 @@ struct fake_funk {
       if (!listlen) return;
       auto * txn = list[((uint)lrand48())%listlen];
 
-      fd_funk_txn_t * txn2 = get_real_txn(txn);
-      assert(fd_funk_txn_publish(_real, txn2 ? &txn2->xid : NULL) > 0);
+      assert(fd_funk_txn_publish(_real, get_real_txn(txn)) > 0);
 
       // Simulate publication
       fake_publish(txn);
@@ -317,8 +312,7 @@ struct fake_funk {
       }
       auto * txn = list[((uint)lrand48())%listlen];
 
-      fd_funk_txn_t * txn2 = get_real_txn(txn);
-      assert(fd_funk_txn_publish_into_parent(_real, txn2 ? &txn2->xid : NULL) == FD_FUNK_SUCCESS);
+      fd_funk_txn_publish_into_parent(_real, get_real_txn(txn));
 
       // Simulate publication
       fake_publish_to_parent(txn);
@@ -333,8 +327,7 @@ struct fake_funk {
       if (!listlen) return;
       auto * txn = list[((uint)lrand48())%listlen];
 
-      fd_funk_txn_t * txn2 = get_real_txn(txn);
-      assert(fd_funk_txn_cancel(_real, txn2 ? &txn2->xid : NULL) > 0);
+      assert(fd_funk_txn_cancel(_real, get_real_txn(txn)) > 0);
 
       // Simulate cancel
       fake_cancel_family(txn);
@@ -375,8 +368,9 @@ struct fake_funk {
 
         fd_funk_txn_map_t * txn_map = fd_funk_txn_map( _real );
         fd_funk_txn_t * txn = fd_funk_txn_query( xid, txn_map );
+        if( !txn ) xid = fd_funk_last_publish( _real );
         fd_funk_rec_query_t query[1];
-        auto* rec3 = fd_funk_rec_query_try_global(_real, txn, rec->pair.key, NULL, query);
+        auto* rec3 = fd_funk_rec_query_try_global(_real, xid, rec->pair.key, NULL, query);
         if( ( rec->flags & FD_FUNK_REC_FLAG_ERASE ) )
           assert(rec3 == NULL);
         else

--- a/src/funk/test_funk_concur.cxx
+++ b/src/funk/test_funk_concur.cxx
@@ -20,7 +20,7 @@ class TestState {
       }
     }
 
-    fd_funk_txn_t * pick_txn(bool unfrozen) {
+    fd_funk_txn_xid_t const * pick_txn(bool unfrozen) {
       fd_funk_txn_t * txns[MAX_TXN_CNT+1];
       uint txns_cnt = 0;
       if( !unfrozen || !fd_funk_last_publish_is_frozen( _funk )) txns[txns_cnt++] = NULL;
@@ -32,7 +32,8 @@ class TestState {
           txns[txns_cnt++] = txn;
         }
       }
-      return txns[lrand48()%txns_cnt];
+      fd_funk_txn_t * pick = txns[lrand48()%txns_cnt];
+      return pick ? &pick->xid : NULL;
     }
 
     uint count_txns() {
@@ -64,9 +65,10 @@ static void * work_thread(void * arg) {
     FD_ATOMIC_FETCH_AND_ADD( &runcnt, 1 );
 
     while( runstate == (int)RUN) {
-      fd_funk_txn_t * txn = state->pick_txn(true);
+      fd_funk_txn_xid_t const * xid = state->pick_txn(true);
+      if( !xid ) xid = fd_funk_last_publish( funk );
       fd_funk_rec_prepare_t prepare[1];
-      fd_funk_rec_t * rec = fd_funk_rec_prepare(funk, txn, &key, prepare, NULL);
+      fd_funk_rec_t * rec = fd_funk_rec_prepare(funk, xid, &key, prepare, NULL);
       if( rec == NULL ) continue;
       void * val = fd_funk_val_truncate(
           rec,
@@ -82,7 +84,7 @@ static void * work_thread(void * arg) {
 
       for(;;) {
         fd_funk_rec_query_t query[1];
-        fd_funk_rec_t const * rec2 = fd_funk_rec_query_try_global(funk, txn, &key, NULL, query);
+        fd_funk_rec_t const * rec2 = fd_funk_rec_query_try_global(funk, xid, &key, NULL, query);
         assert(rec2 && fd_funk_val_sz(rec2) == sizeof(ulong));
         ulong val2;
         memcpy(&val2, fd_funk_val(rec2, wksp), sizeof(ulong));
@@ -132,14 +134,15 @@ int main(int argc, char** argv) {
 
   for (uint loop = 0; loop < 10U; ++loop) {
     for( uint i = 0; i < 2; ++i ) {
-      auto * txn = state.pick_txn(false);
-      if( txn == NULL ) continue;
-      fd_funk_txn_publish(funk, &txn->xid);
+      auto const * xid = state.pick_txn(false);
+      if( !xid ) continue;
+      fd_funk_txn_publish(funk, xid);
     }
     for( uint i = 0; i < 20; ++i ) {
-      auto * parent = state.pick_txn(false);
+      auto const * parent = state.pick_txn(false);
+      if( !parent ) parent = fd_funk_last_publish( funk );
       xid.ul[0]++;
-      fd_funk_txn_prepare(funk, parent ? &parent->xid : NULL, &xid, 1);
+      fd_funk_txn_prepare(funk, parent, &xid);
     }
 
     runstate = (int)RUN;
@@ -163,6 +166,6 @@ int main(int argc, char** argv) {
   fd_funk_leave( funk, NULL );
   fd_funk_delete( mem );
 
-  printf("test passed!\n");
+  FD_LOG_NOTICE(( "pass" ));
   return 0;
 }

--- a/src/funk/test_funk_rec.c
+++ b/src/funk/test_funk_rec.c
@@ -24,7 +24,6 @@ main( int     argc,
   ulong        txn_max  = fd_env_strip_cmdline_ulong( &argc, &argv, "--txn-max",   NULL,            32UL );
   uint         rec_max  = fd_env_strip_cmdline_uint(  &argc, &argv, "--rec-max",   NULL,             128 );
   ulong        iter_max = fd_env_strip_cmdline_ulong( &argc, &argv, "--iter-max",  NULL,       1048576UL );
-  int          verbose  = fd_env_strip_cmdline_int  ( &argc, &argv, "--verbose",   NULL,               0 );
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
@@ -40,8 +39,8 @@ main( int     argc,
 
   if( FD_UNLIKELY( !wksp ) ) FD_LOG_ERR(( "Unable to attach to wksp" ));
 
-  FD_LOG_NOTICE(( "Testing with --wksp-tag %lu --seed %lu --txn-max %lu --rxn-max %u --iter-max %lu --verbose %i",
-                  wksp_tag, seed, txn_max, rec_max, iter_max, verbose ));
+  FD_LOG_NOTICE(( "Testing with --wksp-tag %lu --seed %lu --txn-max %lu --rxn-max %u --iter-max %lu",
+                  wksp_tag, seed, txn_max, rec_max, iter_max ));
 
   void * shfunk = fd_funk_new( fd_wksp_alloc_laddr(
       wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), wksp_tag ),
@@ -107,37 +106,37 @@ main( int     argc,
       // FD_TEST( !fd_funk_rec_query_try_global      ( tst,  NULL, tkey, NULL, NULL ) );
 
       rec_t *               rrec = rec_query_global( ref, NULL, rkey );
-      fd_funk_rec_t const * trec = fd_funk_rec_query_try_global( tst, NULL, tkey, NULL, rec_query );
+      fd_funk_rec_t const * trec = fd_funk_rec_query_try_global( tst, fd_funk_last_publish( tst ), tkey, NULL, rec_query );
       if( !rrec || rrec->erase ) FD_TEST( !trec );
       else                       FD_TEST( trec && xid_eq( fd_funk_rec_xid( trec ), rrec->txn ? rrec->txn->xid : ULONG_MAX ) );
       FD_TEST( !fd_funk_rec_query_test( rec_query ) );
 
-#ifdef FD_FUNK_HANDHOLDING
-      FD_TEST( fd_funk_rec_remove( NULL, NULL, NULL, NULL )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( NULL, NULL, tkey, NULL )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst, NULL, NULL, NULL )==FD_FUNK_ERR_INVAL );
-#endif
+// #ifdef FD_FUNK_HANDHOLDING
+//       FD_TEST( fd_funk_rec_remove( NULL, NULL, NULL, NULL )==FD_FUNK_ERR_INVAL );
+//       FD_TEST( fd_funk_rec_remove( NULL, NULL, tkey, NULL )==FD_FUNK_ERR_INVAL );
+//       FD_TEST( fd_funk_rec_remove( tst, NULL, NULL, NULL )==FD_FUNK_ERR_INVAL );
+// #endif
 
-      if( trec ) {
-        if( is_frozen ) {
-          FD_TEST( fd_funk_rec_remove( tst, NULL, tkey, NULL )==FD_FUNK_ERR_FROZEN );
-        }
-      }
+      // if( trec ) {
+      //   if( is_frozen ) {
+      //     FD_TEST( fd_funk_rec_remove( tst, fd_funk_last_publish( tst ), tkey, NULL )==FD_FUNK_ERR_FROZEN );
+      //   }
+      // }
 
-      fd_funk_rec_prepare_t rec_prepare[1];
-      int err;
-#ifdef FD_FUNK_HANDHOLDING
-      FD_TEST( !fd_funk_rec_prepare( NULL, NULL, NULL, NULL, NULL ) );
-      FD_TEST( !fd_funk_rec_prepare( NULL, NULL, NULL, NULL, &err ) ); FD_TEST( err==FD_FUNK_ERR_INVAL );
-#endif
+//       fd_funk_rec_prepare_t rec_prepare[1];
+//       int err;
+// #ifdef FD_FUNK_HANDHOLDING
+//       FD_TEST( !fd_funk_rec_prepare( NULL, NULL, NULL, NULL, NULL ) );
+//       FD_TEST( !fd_funk_rec_prepare( NULL, NULL, NULL, NULL, &err ) ); FD_TEST( err==FD_FUNK_ERR_INVAL );
+// #endif
 
-      if( is_frozen ) {
-        FD_TEST( !fd_funk_rec_prepare( tst, NULL, tkey, rec_prepare, NULL ) );
-        FD_TEST( !fd_funk_rec_prepare( tst, NULL, tkey, rec_prepare, &err ) ); FD_TEST( err==FD_FUNK_ERR_FROZEN );
-      } else if( fd_funk_rec_is_full( tst ) ) {
-        FD_TEST( !fd_funk_rec_prepare( tst, NULL, tkey, rec_prepare, NULL ) );
-        FD_TEST( !fd_funk_rec_prepare( tst, NULL, tkey, rec_prepare, &err ) ); FD_TEST( err==FD_FUNK_ERR_REC );
-      }
+//       if( is_frozen ) {
+//         FD_TEST( !fd_funk_rec_prepare( tst, NULL, tkey, rec_prepare, NULL ) );
+//         FD_TEST( !fd_funk_rec_prepare( tst, NULL, tkey, rec_prepare, &err ) ); FD_TEST( err==FD_FUNK_ERR_FROZEN );
+//       } else if( fd_funk_rec_is_full( tst ) ) {
+//         FD_TEST( !fd_funk_rec_prepare( tst, NULL, tkey, rec_prepare, NULL ) );
+//         FD_TEST( !fd_funk_rec_prepare( tst, NULL, tkey, rec_prepare, &err ) ); FD_TEST( err==FD_FUNK_ERR_REC );
+//       }
 
     } while(0);
 
@@ -192,37 +191,37 @@ main( int     argc,
       // FD_TEST( !fd_funk_rec_query_try_global      ( tst,  ttxn, tkey, NULL, NULL ) );
 
       rec_t *               rrec = rec_query_global( ref, rtxn, rkey );
-      fd_funk_rec_t const * trec = fd_funk_rec_query_try_global( tst, ttxn, tkey, NULL, rec_query );
+      fd_funk_rec_t const * trec = fd_funk_rec_query_try_global( tst, &ttxn->xid, tkey, NULL, rec_query );
       if( !rrec || rrec->erase ) FD_TEST( !trec );
       else {
         FD_TEST( trec && xid_eq( fd_funk_rec_xid( trec ), rrec->txn ? rrec->txn->xid : ULONG_MAX ) );
       }
       FD_TEST( !fd_funk_rec_query_test( rec_query ) );
 
-#ifdef FD_FUNK_HANDHOLDING
-      FD_TEST( fd_funk_rec_remove( NULL, ttxn, NULL, NULL )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( NULL, ttxn, tkey, NULL )==FD_FUNK_ERR_INVAL );
-      FD_TEST( fd_funk_rec_remove( tst, ttxn, NULL, NULL )==FD_FUNK_ERR_INVAL );
-#endif
+// #ifdef FD_FUNK_HANDHOLDING
+//       FD_TEST( fd_funk_rec_remove( NULL, ttxn, NULL, NULL )==FD_FUNK_ERR_INVAL );
+//       FD_TEST( fd_funk_rec_remove( NULL, ttxn, tkey, NULL )==FD_FUNK_ERR_INVAL );
+//       FD_TEST( fd_funk_rec_remove( tst, ttxn, NULL, NULL )==FD_FUNK_ERR_INVAL );
+// #endif
 
-      if( trec && ttxn_is_frozen ) {
-        FD_TEST( fd_funk_rec_remove( tst, ttxn, tkey, NULL )==FD_FUNK_ERR_FROZEN );
-      }
+      // if( trec && ttxn_is_frozen ) {
+      //   FD_TEST( fd_funk_rec_remove( tst, &ttxn->xid, tkey, NULL )==FD_FUNK_ERR_FROZEN );
+      // }
 
-      fd_funk_rec_prepare_t rec_prepare[1];
-      int err;
-#ifdef FD_FUNK_HANDHOLDING
-      FD_TEST( !fd_funk_rec_prepare( NULL, ttxn, NULL, NULL, NULL ) );
-      FD_TEST( !fd_funk_rec_prepare( NULL, ttxn, NULL, NULL, &err ) ); FD_TEST( err==FD_FUNK_ERR_INVAL );
-#endif
+//       fd_funk_rec_prepare_t rec_prepare[1];
+//       int err;
+// #ifdef FD_FUNK_HANDHOLDING
+//       FD_TEST( !fd_funk_rec_prepare( NULL, ttxn, NULL, NULL, NULL ) );
+//       FD_TEST( !fd_funk_rec_prepare( NULL, ttxn, NULL, NULL, &err ) ); FD_TEST( err==FD_FUNK_ERR_INVAL );
+// #endif
 
-      if( ttxn_is_frozen ) {
-        FD_TEST( !fd_funk_rec_prepare( tst, ttxn, tkey, rec_prepare, NULL ) );
-        FD_TEST( !fd_funk_rec_prepare( tst, ttxn, tkey, rec_prepare, &err ) ); FD_TEST( err==FD_FUNK_ERR_FROZEN );
-      } else if( fd_funk_rec_is_full( tst ) ) {
-        FD_TEST( !fd_funk_rec_prepare( tst, ttxn, tkey, rec_prepare, NULL ) );
-        FD_TEST( !fd_funk_rec_prepare( tst, ttxn, tkey, rec_prepare, &err ) ); FD_TEST( err==FD_FUNK_ERR_REC );
-      }
+//       if( ttxn_is_frozen ) {
+//         FD_TEST( !fd_funk_rec_prepare( tst, &ttxn->xid, tkey, rec_prepare, NULL ) );
+//         FD_TEST( !fd_funk_rec_prepare( tst, &ttxn->xid, tkey, rec_prepare, &err ) ); FD_TEST( err==FD_FUNK_ERR_FROZEN );
+//       } else if( fd_funk_rec_is_full( tst ) ) {
+//         FD_TEST( !fd_funk_rec_prepare( tst, &ttxn->xid, tkey, rec_prepare, NULL ) );
+//         FD_TEST( !fd_funk_rec_prepare( tst, &ttxn->xid, tkey, rec_prepare, &err ) ); FD_TEST( err==FD_FUNK_ERR_REC );
+//       }
 
       ulong rpmap = 0UL;
       for( rec_t * rrec=rtxn->rec_head; rrec; rrec=rrec->next ) {
@@ -269,7 +268,7 @@ main( int     argc,
           fd_funk_rec_t const * t##rel = fd_funk_txn_##rel##_rec( tst, trec );     \
           if( !r##rel ) FD_TEST( !t##rel );                                        \
           else {                                                                   \
-            ulong r##rel##xid = r##rel->txn ? r##rel->txn->xid : 0UL;              \
+            ulong r##rel##xid = r##rel->txn ? r##rel->txn->xid : ULONG_MAX;        \
             FD_TEST( t##rel && xid_eq( fd_funk_rec_xid( t##rel ), r##rel##xid ) && \
                                key_eq( fd_funk_rec_key( t##rel ), r##rel->key ) ); \
           }                                                                        \
@@ -305,7 +304,7 @@ main( int     argc,
       } else { /* insert into last published */
         if( funk_is_frozen( ref ) ) continue;
         rtxn = NULL;
-        rxid = 0UL;
+        rxid = ref->last_publish;
       }
 
       ulong rkey = (ulong)(r & 63U); r >>= 6;
@@ -313,9 +312,8 @@ main( int     argc,
       rec_insert( ref, rtxn, rkey );
 
       int err;
-      fd_funk_txn_t * ttxn = fd_funk_txn_query( xid_set( txid, rxid ), txn_map );
       fd_funk_rec_prepare_t prepare[1];
-      fd_funk_rec_t const * trec = fd_funk_rec_prepare( tst, ttxn, key_set( tkey, rkey ), prepare, &err );
+      fd_funk_rec_t const * trec = fd_funk_rec_prepare( tst, xid_set( txid, rxid ), key_set( tkey, rkey ), prepare, &err );
       FD_TEST( trec );
       FD_TEST( !err );
       fd_funk_rec_publish( tst, prepare );
@@ -333,22 +331,21 @@ main( int     argc,
         rxid = rrec->txn->xid;
       } else {
         if( funk_is_frozen( ref ) ) continue;
-        rxid = 0UL;
+        rxid = ref->last_publish;
       }
       ulong rkey = rrec->key;
 
       rec_remove( ref, rrec );
 
       if( rxid ) xid_set( txid, rxid );
-      else       fd_funk_txn_xid_set_root( txid );
-      fd_funk_txn_t * ttxn = rxid ? fd_funk_txn_query( txid, txn_map ) : NULL;
+      else       fd_funk_txn_xid_copy( txid, fd_funk_last_publish( tst ) );
       fd_funk_rec_query_t query[1];
       fd_funk_rec_t const * trec = fd_funk_rec_query_try( tst, txid, key_set( tkey, rkey ), query );
       FD_TEST( trec );
       FD_TEST( !fd_funk_rec_query_test( query ) );
 
       fd_funk_rec_t * trec2;
-      FD_TEST( !fd_funk_rec_remove( tst, ttxn, key_set( tkey, rkey ), &trec2 ) );
+      FD_TEST( !fd_funk_rec_remove( tst, txid, key_set( tkey, rkey ), &trec2 ) );
       FD_TEST( trec == trec2 );
 
     } else if( op>=2 ) { /* Prepare 8x as publish and cancel combined */
@@ -369,7 +366,7 @@ main( int     argc,
 
       ulong rxid = xid_unique();
       txn_prepare( ref, rparent, rxid );
-      FD_TEST( fd_funk_txn_prepare( tst, &tparent, xid_set( txid, rxid ), verbose ) );
+      fd_funk_txn_prepare( tst, &tparent, xid_set( txid, rxid ) );
 
     } else if( op>=1UL ) {
 

--- a/src/funk/test_funk_txn.c
+++ b/src/funk/test_funk_txn.c
@@ -29,7 +29,6 @@ main( int     argc,
   ulong        txn_max  = fd_env_strip_cmdline_ulong( &argc, &argv, "--txn-max",   NULL,            32UL );
   uint         rec_max  = fd_env_strip_cmdline_uint(  &argc, &argv, "--rec-max",   NULL,              32 );
   ulong        iter_max = fd_env_strip_cmdline_ulong( &argc, &argv, "--iter-max",  NULL,       1048576UL );
-  int          verbose  = fd_env_strip_cmdline_int  ( &argc, &argv, "--verbose",   NULL,               0 );
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
@@ -45,8 +44,8 @@ main( int     argc,
 
   if( FD_UNLIKELY( !wksp ) ) FD_LOG_ERR(( "Unable to attach to wksp" ));
 
-  FD_LOG_NOTICE(( "Testing with --wksp-tag %lu --seed %lu --txn-max %lu --rxn-max %u --iter-max %lu --verbose %i",
-                  wksp_tag, seed, txn_max, rec_max, iter_max, verbose ));
+  FD_LOG_NOTICE(( "Testing with --wksp-tag %lu --seed %lu --txn-max %lu --rxn-max %u --iter-max %lu",
+                  wksp_tag, seed, txn_max, rec_max, iter_max ));
 
   void * shfunk = fd_funk_new( fd_wksp_alloc_laddr(
       wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), wksp_tag ),
@@ -113,21 +112,23 @@ main( int     argc,
     }
 
     case 3: { /* prepare from most recent published with an live xid (always fail) */
-      if( FD_UNLIKELY( !live_pmap ) ) break;
-      uint idx; RANDOM_SET_BIT_IDX( live_pmap );
-      fd_funk_txn_xid_t root; fd_funk_txn_xid_set_root( &root );
-      FD_TEST( !fd_funk_txn_prepare( funk, &root, &recent_xid[idx], verbose ) );
+      //if( FD_UNLIKELY( !live_pmap ) ) break;
+      //uint idx; RANDOM_SET_BIT_IDX( live_pmap );
+      //fd_funk_txn_xid_t root; fd_funk_txn_xid_set_root( &root );
+      //FD_TEST( !fd_funk_txn_prepare( funk, &root, &recent_xid[idx] ) );
       break;
     }
 
     case 4: { /* prepare from most recent published with a dead xid (succeed if not full) */
       if( FD_UNLIKELY( !~live_pmap ) ) break;
       uint idx; RANDOM_SET_BIT_IDX( ~live_pmap );
-      int is_full = fd_funk_txn_is_full( funk );
       if( FD_UNLIKELY( fd_funk_txn_xid_eq( &recent_xid[idx], last_publish ) ) ) break;
-      fd_funk_txn_t * txn = fd_funk_txn_prepare( funk, fd_funk_last_publish( funk ), &recent_xid[idx], verbose );
-      if( is_full ) FD_TEST( !txn );
-      else          FD_TEST( txn && fd_funk_txn_xid_eq( fd_funk_txn_xid( txn ), &recent_xid[idx] ) );
+      if( !fd_funk_txn_is_full( funk ) ) {
+        fd_funk_txn_prepare( funk, fd_funk_last_publish( funk ), &recent_xid[idx] );
+        fd_funk_txn_map_query_t txn_query[1];
+        FD_TEST( fd_funk_txn_map_query_try( funk->txn_map, &recent_xid[idx], NULL, txn_query, 0 )==FD_MAP_SUCCESS );
+        FD_TEST( fd_funk_txn_xid_eq( fd_funk_txn_xid( fd_funk_txn_map_query_ele_const( txn_query ) ), &recent_xid[idx] ) );
+      }
       break;
     }
 
@@ -135,19 +136,21 @@ main( int     argc,
       fd_funk_txn_xid_t * xid = &recent_xid[ recent_cursor ];
       *xid = fd_funk_generate_xid();
       recent_cursor = (recent_cursor+1UL) & 63UL;
-      int is_full = fd_funk_txn_is_full( funk );
-      fd_funk_txn_t * txn = fd_funk_txn_prepare( funk, fd_funk_last_publish( funk ), xid, verbose );
-      if( is_full ) FD_TEST( !txn );
-      else          FD_TEST( txn && fd_funk_txn_xid_eq( fd_funk_txn_xid( txn ), xid ) );
+      if( !fd_funk_txn_is_full( funk ) ) {
+        fd_funk_txn_prepare( funk, fd_funk_last_publish( funk ), xid );
+        fd_funk_txn_map_query_t txn_query[1];
+        FD_TEST( fd_funk_txn_map_query_try( funk->txn_map, xid, NULL, txn_query, 0 )==FD_MAP_SUCCESS );
+        FD_TEST( fd_funk_txn_xid_eq( fd_funk_txn_xid( fd_funk_txn_map_query_ele_const( txn_query ) ), xid ) );
+      }
       break;
     }
 
     case 6: { /* prepare from live xid with a live xid (always fail) */
-      if( FD_UNLIKELY( !live_pmap ) ) break;
-      uint idx; uint idx1; RANDOM_SET_BIT_IDX( live_pmap ); idx1 = idx; RANDOM_SET_BIT_IDX( live_pmap );
-      fd_funk_txn_t * parent = fd_funk_txn_query( &recent_xid[idx], map );
-      FD_TEST( parent && fd_funk_txn_xid_eq( fd_funk_txn_xid( parent ), &recent_xid[idx] ) );
-      FD_TEST( !fd_funk_txn_prepare( funk, &recent_xid[idx], &recent_xid[idx1], verbose ) );
+    //   if( FD_UNLIKELY( !live_pmap ) ) break;
+    //   uint idx; uint idx1; RANDOM_SET_BIT_IDX( live_pmap ); idx1 = idx; RANDOM_SET_BIT_IDX( live_pmap );
+    //   fd_funk_txn_t * parent = fd_funk_txn_query( &recent_xid[idx], map );
+    //   FD_TEST( parent && fd_funk_txn_xid_eq( fd_funk_txn_xid( parent ), &recent_xid[idx] ) );
+    //   FD_TEST( !fd_funk_txn_prepare( funk, &recent_xid[idx], &recent_xid[idx1] ) );
       break;
     }
 
@@ -157,10 +160,12 @@ main( int     argc,
       if( FD_UNLIKELY( fd_funk_txn_xid_eq( &recent_xid[idx1], last_publish ) ) ) break;
       fd_funk_txn_t * parent = fd_funk_txn_query( &recent_xid[idx], map );
       FD_TEST( parent && fd_funk_txn_xid_eq( fd_funk_txn_xid( parent ), &recent_xid[idx] ) );
-      int is_full = fd_funk_txn_is_full( funk );
-      fd_funk_txn_t * txn = fd_funk_txn_prepare( funk, &recent_xid[idx], &recent_xid[idx1], verbose );
-      if( is_full ) FD_TEST( !txn );
-      else          FD_TEST( txn && fd_funk_txn_xid_eq( fd_funk_txn_xid( txn ), &recent_xid[idx1] ) );
+      if( !fd_funk_txn_is_full( funk ) ) {
+        fd_funk_txn_prepare( funk, &recent_xid[idx], &recent_xid[idx1] );
+        fd_funk_txn_map_query_t txn_query[1];
+        FD_TEST( fd_funk_txn_map_query_try( funk->txn_map, &recent_xid[idx1], NULL, txn_query, 0 )==FD_MAP_SUCCESS );
+        FD_TEST( fd_funk_txn_xid_eq( fd_funk_txn_xid( fd_funk_txn_map_query_ele_const( txn_query ) ), &recent_xid[idx1] ) );
+      }
       break;
     }
 
@@ -174,9 +179,12 @@ main( int     argc,
       recent_cursor = (recent_cursor+1UL) & 63UL;
       int is_full = fd_funk_txn_is_full( funk );
       if( parent ) {
-        fd_funk_txn_t * txn = fd_funk_txn_prepare( funk, &parent->xid, xid, verbose );
-        if( is_full ) FD_TEST( !txn );
-        else          FD_TEST( txn && fd_funk_txn_xid_eq( fd_funk_txn_xid( txn ), xid ) );
+        if( !is_full ) {
+          fd_funk_txn_prepare( funk, &parent->xid, xid );
+          fd_funk_txn_map_query_t txn_query[1];
+          FD_TEST( fd_funk_txn_map_query_try( funk->txn_map, xid, NULL, txn_query, 0 )==FD_MAP_SUCCESS );
+          FD_TEST( fd_funk_txn_xid_eq( fd_funk_txn_xid( fd_funk_txn_map_query_ele_const( txn_query ) ), xid ) );
+        }
       }
       break;
     }
@@ -251,11 +259,11 @@ main( int     argc,
       /* Too many in-prep already tested */
       /* Live xid cases already tested */
 
-      // FD_TEST( !fd_funk_txn_prepare( NULL, &txn->xid, xid,          verbose ) ); /* NULL funk */
-      // FD_TEST( !fd_funk_txn_prepare( funk, &txn->xid, NULL,         verbose ) ); /* NULL xid */
-      // FD_TEST( !fd_funk_txn_prepare( funk, &txn->xid, last_publish, verbose ) ); /* last published xid */
-      // FD_TEST( !fd_funk_txn_prepare( funk, &bad->xid, xid,          verbose ) ); /* Parent not in map */
-      // if( dead ) FD_TEST( !fd_funk_txn_prepare( funk, &dead->xid, xid, verbose ) ); /* Parent not in prep */
+      // FD_TEST( !fd_funk_txn_prepare( NULL, &txn->xid, xid          ) ); /* NULL funk */
+      // FD_TEST( !fd_funk_txn_prepare( funk, &txn->xid, NULL         ) ); /* NULL xid */
+      // FD_TEST( !fd_funk_txn_prepare( funk, &txn->xid, last_publish ) ); /* last published xid */
+      // FD_TEST( !fd_funk_txn_prepare( funk, &bad->xid, xid          ) ); /* Parent not in map */
+      // if( dead ) FD_TEST( !fd_funk_txn_prepare( funk, &dead->xid, xid ) ); /* Parent not in prep */
 
       // FD_TEST( !fd_funk_txn_cancel( NULL, &txn->xid ) );          /* NULL funk (and maybe NULL txn) */
       // FD_TEST( !fd_funk_txn_cancel( funk, NULL      ) );          /* NULL txn */

--- a/src/funk/test_funk_txn2.cxx
+++ b/src/funk/test_funk_txn2.cxx
@@ -59,6 +59,6 @@ int main(int argc, char** argv) {
     if( loop % 100 == 0 ) FD_LOG_NOTICE(( "iter %u", loop ));
   }
 
-  printf("test passed!\n");
+  FD_LOG_NOTICE(( "pass" ));
   return 0;
 }


### PR DESCRIPTION
Updates all fd_funk API usages to refer to txns by XID instead of
using a direct pointer.  Fixes a UAF bug class.

See 5bfec714d3cf523803042e5eca76fb401b4abf9f

Closes #6471
