### PR TITLE
Fix full Firedancer log spam

### DIFF
--- a/src/discof/exec/fd_exec_tile.c
+++ b/src/discof/exec/fd_exec_tile.c
@@ -132,7 +132,7 @@ after_frag( fd_exec_tile_ctx_t * ctx,
             fd_stem_context_t *  stem ) {
 
   if( sig==EXEC_NEW_TXN_SIG ) {
-    FD_LOG_DEBUG(( "Sending ack for new txn msg" ));
+    //FD_LOG_DEBUG(( "Sending ack for new txn msg" ));
     /* At this point we can assume that the transaction is done
        executing. A writer tile will be repsonsible for commiting
        the transaction back to funk. */

--- a/src/discof/send/fd_send_tile.c
+++ b/src/discof/send/fd_send_tile.c
@@ -354,7 +354,7 @@ handle_contact_info_update( fd_send_tile_ctx_t *               ctx,
   fd_send_conn_entry_t * entry  = fd_send_conn_map_query( ctx->conn_map, *(fd_pubkey_t *)(msg->origin_pubkey), NULL );
   if( FD_UNLIKELY( !entry ) ) {
     /* Skip if UNSTAKED */
-    FD_LOG_DEBUG(("send_tile: Skipping unstaked pubkey %s", FD_BASE58_ENC_32_ALLOCA( msg->origin_pubkey )));
+    // FD_LOG_DEBUG(("send_tile: Skipping unstaked pubkey %s", FD_BASE58_ENC_32_ALLOCA( msg->origin_pubkey )));
     ctx->metrics.unstaked_ci_rcvd++;
     return;
   }
@@ -434,7 +434,7 @@ finalize_stake_msg( fd_send_tile_ctx_t * ctx ) {
     fd_send_conn_entry_t * entry = fd_send_conn_map_query( ctx->conn_map, pubkey, NULL );
     /* UNSTAKED -> NO_CONN: create new entry in NO_CONN state */
     if( FD_UNLIKELY( !entry ) ) {
-      FD_LOG_DEBUG(("send_tile: creating new entry for pubkey %s", FD_BASE58_ENC_32_ALLOCA( pubkey.key )));
+      // FD_LOG_DEBUG(("send_tile: creating new entry for pubkey %s", FD_BASE58_ENC_32_ALLOCA( pubkey.key )));
       /* insert and initialize entry */
       entry = fd_send_conn_map_insert( ctx->conn_map, pubkey );
       *entry = (fd_send_conn_entry_t){.pubkey = entry->pubkey, .hash = entry->hash };


### PR DESCRIPTION
These lines make up >70% of DEBUG log
