### PR TITLE
snapshots: fix alignment

### DIFF
--- a/src/discof/restore/utils/fd_snapshot_parser.h
+++ b/src/discof/restore/utils/fd_snapshot_parser.h
@@ -90,7 +90,7 @@ typedef struct fd_snapshot_parser fd_snapshot_parser_t;
 
 FD_FN_CONST static inline ulong
 fd_snapshot_parser_align( void ) {
-  return 128UL;
+  return fd_ulong_max( alignof(fd_snapshot_parser_t), fd_ulong_max( fd_ssmanifest_parser_align(), fd_ulong_max( fd_slot_delta_parser_align(), 16UL ) ) );
 }
 
 FD_FN_CONST ulong

--- a/src/discof/restore/utils/fd_ssmanifest_parser.c
+++ b/src/discof/restore/utils/fd_ssmanifest_parser.c
@@ -1596,7 +1596,7 @@ state_process( fd_ssmanifest_parser_t * parser ) {
 
 FD_FN_CONST ulong
 fd_ssmanifest_parser_align( void ) {
-  return 128UL;
+  return fd_ulong_max( alignof(fd_ssmanifest_parser_t), fd_ulong_max( acc_vec_pool_align(), acc_vec_map_align() ) );
 }
 
 FD_FN_CONST ulong
@@ -1605,7 +1605,7 @@ fd_ssmanifest_parser_footprint( ulong max_acc_vecs ) {
   l = FD_LAYOUT_APPEND( l, alignof(fd_ssmanifest_parser_t), sizeof(fd_ssmanifest_parser_t)         );
   l = FD_LAYOUT_APPEND( l, acc_vec_pool_align(),            acc_vec_pool_footprint( max_acc_vecs ) );
   l = FD_LAYOUT_APPEND( l, acc_vec_map_align(),             acc_vec_map_footprint( max_acc_vecs )  );
-  return FD_LAYOUT_FINI( l, alignof(fd_ssmanifest_parser_t) );
+  return FD_LAYOUT_FINI( l, fd_ssmanifest_parser_align() );
 }
 
 void *


### PR DESCRIPTION
fixes fuzzer asan crash:
```
==2125607==ERROR: AddressSanitizer: invalid alignment requested in aligned_alloc: 128, alignment must be a power of two and the requested size 0xe198 must be a multiple of alignment (thread T0)
```