### PR TITLE
metrics, stem: right-size metric_regime_ticks array

### DIFF
--- a/src/disco/stem/fd_stem.c
+++ b/src/disco/stem/fd_stem.c
@@ -278,7 +278,7 @@ STEM_(run1)( ulong                        in_cnt,
   ulong metric_in_backp;  /* is the run loop currently backpressured by one or more of the outs, in [0,1] */
   ulong metric_backp_cnt; /* Accumulates number of transitions of tile to backpressured between housekeeping events */
 
-  ulong metric_regime_ticks[9];    /* How many ticks the tile has spent in each regime */
+  ulong metric_regime_ticks[ FD_METRICS_ENUM_TILE_REGIME_CNT ]; /* How many ticks the tile has spent in each regime */
 
   if( FD_UNLIKELY( !scratch ) ) FD_LOG_ERR(( "NULL scratch" ));
   if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)scratch, STEM_(scratch_align)() ) ) ) FD_LOG_ERR(( "misaligned scratch" ));


### PR DESCRIPTION
prev 9, actually 8