### PR TITLE
metrics, bank, pack, quic: use MACRO_CNT in def

### DIFF
--- a/src/disco/pack/fd_pack_tile.c
+++ b/src/disco/pack/fd_pack_tile.c
@@ -261,7 +261,7 @@ typedef struct {
   struct {
     uint metric_state;
     long metric_state_begin;
-    long metric_timing[ 16 ];
+    long metric_timing[ FD_METRICS_ENUM_PACK_TIMING_STATE_CNT ];
   };
 
   struct {
@@ -300,7 +300,7 @@ typedef struct {
     fd_keyswitch_t *      keyswitch;
     fd_keyguard_client_t  keyguard_client[1];
 
-    ulong                 metrics[4];
+    ulong                 metrics[FD_METRICS_ENUM_BUNDLE_CRANK_RESULT_CNT];
   } crank[1];
 
 

--- a/src/discoh/bank/fd_bank_tile.c
+++ b/src/discoh/bank/fd_bank_tile.c
@@ -46,8 +46,8 @@ typedef struct {
   fd_pack_rebate_sum_t rebater[ 1 ];
 
   struct {
-    ulong txn_load_address_lookup_tables[ 6 ];
-    ulong transaction_result[ 41 ];
+    ulong txn_load_address_lookup_tables[ FD_METRICS_COUNTER_BANK_TRANSACTION_LOAD_ADDRESS_TABLES_CNT ];
+    ulong transaction_result[ FD_METRICS_COUNTER_BANK_TRANSACTION_RESULT_CNT ];
     ulong processing_failed;
     ulong fee_only;
     ulong exec_failed;

--- a/src/waltz/quic/crypto/fd_quic_crypto_suites.h
+++ b/src/waltz/quic/crypto/fd_quic_crypto_suites.h
@@ -3,6 +3,7 @@
 
 #include "../fd_quic_enum.h"
 #include "../../../ballet/aes/fd_aes_gcm.h"
+#include "../../../disco/metrics/generated/fd_metrics_quic.h"
 
 /* Defines the crypto suites used by QUIC v1.
 
@@ -48,6 +49,8 @@ struct fd_quic_crypto_keys {
 #define fd_quic_enc_level_handshake_id  2
 #define fd_quic_enc_level_appdata_id    3
 #define FD_QUIC_NUM_ENC_LEVELS          4
+
+FD_STATIC_ASSERT( FD_METRICS_ENUM_QUIC_ENC_LEVEL_CNT==FD_QUIC_NUM_ENC_LEVELS, "quic_num_enc_level_cnt_mismatch" );
 
 /* labels defined in rfc9001 */
 #define FD_QUIC_CRYPTO_LABEL_CLIENT_IN "client in"

--- a/src/waltz/quic/fd_quic.h
+++ b/src/waltz/quic/fd_quic.h
@@ -83,6 +83,7 @@
 
 #include "fd_quic_common.h"
 #include "fd_quic_enum.h"
+#include "../../disco/metrics/generated/fd_metrics_quic.h"
 
 #include "../aio/fd_aio.h"
 #include "../tls/fd_tls.h"
@@ -313,32 +314,32 @@ union fd_quic_metrics {
     ulong retry_tx_cnt;    /* number of Retry packets sent */
 
     /* Conn metrics */
-    ulong conn_alloc_cnt;          /* number of conns currently allocated */
-    ulong conn_created_cnt;        /* number of conns created */
-    ulong conn_closed_cnt;         /* number of conns gracefully closed */
-    ulong conn_aborted_cnt;        /* number of conns aborted */
-    ulong conn_timeout_cnt;        /* number of conns timed out */
-    ulong conn_retry_cnt;          /* number of conns established with retry */
-    ulong conn_err_no_slots_cnt;   /* number of conns that failed to create due to lack of slots */
-    ulong conn_err_retry_fail_cnt; /* number of conns that failed during retry (e.g. invalid token) */
-    ulong conn_state_cnt[ 8 ];     /* current number of conns in each state */
+    ulong conn_alloc_cnt;                                        /* number of conns currently allocated */
+    ulong conn_created_cnt;                                      /* number of conns created */
+    ulong conn_closed_cnt;                                       /* number of conns gracefully closed */
+    ulong conn_aborted_cnt;                                      /* number of conns aborted */
+    ulong conn_timeout_cnt;                                      /* number of conns timed out */
+    ulong conn_retry_cnt;                                        /* number of conns established with retry */
+    ulong conn_err_no_slots_cnt;                                 /* number of conns that failed to create due to lack of slots */
+    ulong conn_err_retry_fail_cnt;                               /* number of conns that failed during retry (e.g. invalid token) */
+    ulong conn_state_cnt[ FD_METRICS_ENUM_QUIC_CONN_STATE_CNT ]; /* current number of conns in each state */
 
     /* Packet metrics */
-    ulong pkt_net_hdr_err_cnt;          /* number of packets dropped due to weird IPv4/UDP headers */
-    ulong pkt_quic_hdr_err_cnt;         /* number of packets dropped due to weird QUIC header */
-    ulong pkt_undersz_cnt;              /* number of QUIC packets dropped due to being too small */
-    ulong pkt_oversz_cnt;               /* number of QUIC packets dropped due to being too large */
-    ulong pkt_decrypt_fail_cnt[ 4 ];    /* number of packets that failed decryption due to auth tag */
-    ulong pkt_no_key_cnt[ 4 ];          /* number of packets that failed decryption due to missing key */
-    ulong pkt_no_conn_cnt[ 4 ];         /* number of packets with unknown conn ID (initial, retry, hs, 1-RTT) */
-    ulong frame_tx_alloc_cnt[ 3 ];      /* number of pkt_meta alloc successes, fails for empty pool, fails at conn max */
-    ulong pkt_verneg_cnt;               /* number of QUIC version negotiation packets or packets with wrong version */
-    ulong pkt_retransmissions_cnt[ 4 ]; /* number of pkt_meta retries */
-    ulong initial_token_len_cnt[ 3 ];   /* number of Initial packets grouped by token length */
+    ulong pkt_net_hdr_err_cnt;                                               /* number of packets dropped due to weird IPv4/UDP headers */
+    ulong pkt_quic_hdr_err_cnt;                                              /* number of packets dropped due to weird QUIC header */
+    ulong pkt_undersz_cnt;                                                   /* number of QUIC packets dropped due to being too small */
+    ulong pkt_oversz_cnt;                                                    /* number of QUIC packets dropped due to being too large */
+    ulong pkt_decrypt_fail_cnt[ FD_METRICS_ENUM_QUIC_ENC_LEVEL_CNT ];        /* number of packets that failed decryption due to auth tag */
+    ulong pkt_no_key_cnt[ FD_METRICS_ENUM_QUIC_ENC_LEVEL_CNT ];              /* number of packets that failed decryption due to missing key */
+    ulong pkt_no_conn_cnt[ FD_METRICS_ENUM_QUIC_PKT_HANDLE_CNT ];            /* number of packets with unknown conn ID (initial, retry, hs, 1-RTT) */
+    ulong frame_tx_alloc_cnt[ FD_METRICS_ENUM_FRAME_TX_ALLOC_RESULT_CNT ];   /* number of pkt_meta alloc successes, fails for empty pool, fails at conn max */
+    ulong pkt_verneg_cnt;                                                    /* number of QUIC version negotiation packets or packets with wrong version */
+    ulong pkt_retransmissions_cnt[FD_METRICS_ENUM_QUIC_ENC_LEVEL_CNT];       /* number of pkt_meta retries */
+    ulong initial_token_len_cnt[FD_METRICS_ENUM_QUIC_INITIAL_TOKEN_LEN_CNT]; /* number of Initial packets grouped by token length */
 
     /* Frame metrics */
-    ulong frame_rx_cnt[ 22 ];      /* number of frames received (indexed by implementation-defined IDs) */
-    ulong frame_rx_err_cnt;        /* number of frames failed */
+    ulong frame_rx_cnt[ FD_METRICS_ENUM_QUIC_FRAME_TYPE_CNT ];      /* number of frames received (indexed by implementation-defined IDs) */
+    ulong frame_rx_err_cnt;                                         /* number of frames failed */
 
     /* Handshake metrics */
     ulong hs_created_cnt;          /* number of handshake flows created */
@@ -353,7 +354,7 @@ union fd_quic_metrics {
     ulong stream_rx_byte_cnt;       /* total stream payload bytes received */
 
     /* ACK metrics */
-    ulong ack_tx[ 5 ];
+    ulong ack_tx[ FD_METRICS_ENUM_QUIC_ACK_TX_CNT ];
 
     /* Performance metrics */
     fd_histf_t service_duration[ 1 ]; /* time spent in service */

--- a/src/waltz/quic/fd_quic_ack_tx.h
+++ b/src/waltz/quic/fd_quic_ack_tx.h
@@ -9,6 +9,7 @@
    parameter. */
 
 #include "fd_quic_common.h"
+#include "../../disco/metrics/generated/fd_metrics_quic.h"
 
 #define FD_ACK_DEBUG(...)
 //#define FD_ACK_DEBUG(...) __VA_ARGS__
@@ -94,6 +95,8 @@ fd_quic_ack_pkt( fd_quic_ack_gen_t * gen,
 #define FD_QUIC_ACK_TX_ENOSPC (3)
 #define FD_QUIC_ACK_TX_CANCEL (4)
 #define FD_QUIC_ACK_TX_CNT    (5)
+
+FD_STATIC_ASSERT( FD_METRICS_ENUM_QUIC_ACK_TX_CNT==FD_QUIC_ACK_TX_CNT, "quic_ack_tx_cnt_mismatch" );
 
 /* fd_quic_ack_queue_ele returns the ack_queue element indexed by a
    sequence number. */

--- a/src/waltz/quic/fd_quic_conn.h
+++ b/src/waltz/quic/fd_quic_conn.h
@@ -21,8 +21,10 @@
 #define FD_QUIC_CONN_STATE_DEAD               7 /* connection about to be freed */
 #define FD_QUIC_CONN_STATE_CNT                8
 
-FD_STATIC_ASSERT( FD_QUIC_CONN_STATE_CNT == sizeof(((fd_quic_metrics_t*)0)->conn_state_cnt)/sizeof(((fd_quic_metrics_t*)0)->conn_state_cnt[0]),
+FD_STATIC_ASSERT( FD_QUIC_CONN_STATE_CNT              == sizeof(((fd_quic_metrics_t*)0)->conn_state_cnt)/sizeof(((fd_quic_metrics_t*)0)->conn_state_cnt[0]),
                   "metrics conn_state_cnt is the wrong size" );
+FD_STATIC_ASSERT( FD_METRICS_ENUM_QUIC_CONN_STATE_CNT == FD_QUIC_CONN_STATE_CNT,
+                  "quic_conn_state_cnt_mismatch"             );
 
 #define FD_QUIC_REASON_CODES(X,SEP) \
   X(NO_ERROR                     , 0x00  , "No error"                                  ) SEP \


### PR DESCRIPTION
Use the MACRO_CNT variables in the definition of the metrics arrays. 
This is to avoid drift in the future which could result in over/ under reads/writes.

(Apologies for all the review requests...)