### PR TITLE
tls: server-side support for client auth

### DIFF
--- a/src/waltz/quic/tls/fd_quic_tls.c
+++ b/src/waltz/quic/tls/fd_quic_tls.c
@@ -62,7 +62,8 @@ fd_quic_tls_tp_peer( void *        handshake,
 static void
 fd_quic_tls_init( fd_tls_t *    tls,
                   fd_tls_sign_t signer,
-                  uchar const   cert_public_key[ static 32 ] );
+                  uchar const   cert_public_key[ static 32 ],
+                  int           authenticate_client );
 
 fd_quic_tls_t *
 fd_quic_tls_new( fd_quic_tls_t *     self,
@@ -88,7 +89,7 @@ fd_quic_tls_new( fd_quic_tls_t *     self,
   self->peer_params_cb        = cfg->peer_params_cb;
 
   /* Initialize fd_tls */
-  fd_quic_tls_init( &self->tls, cfg->signer, cfg->cert_public_key );
+  fd_quic_tls_init( &self->tls, cfg->signer, cfg->cert_public_key, cfg->authenticate_client );
 
   return self;
 }
@@ -99,10 +100,12 @@ fd_quic_tls_new( fd_quic_tls_t *     self,
 static void
 fd_quic_tls_init( fd_tls_t *    tls,
                   fd_tls_sign_t signer,
-                  uchar const   cert_public_key[ static 32 ] ) {
+                  uchar const   cert_public_key[ static 32 ],
+                  int           authenticate_client ) {
   tls = fd_tls_new( tls );
   *tls = (fd_tls_t) {
     .quic = 1,
+    .auth_client = (ulong)(authenticate_client&0x1),
     .rand = {
       .ctx     = NULL,
       .rand_fn = fd_quic_tls_rand

--- a/src/waltz/quic/tls/fd_quic_tls.h
+++ b/src/waltz/quic/tls/fd_quic_tls.h
@@ -88,6 +88,8 @@ struct fd_quic_tls_cfg {
 
   /* Ed25519 public key */
   uchar const * cert_public_key;
+
+  int authenticate_client; /* 1 if client auth is required */
 };
 
 /* structure for organising handshake data */

--- a/src/waltz/tls/fd_tls.c
+++ b/src/waltz/tls/fd_tls.c
@@ -744,7 +744,7 @@ fd_tls_server_hs_start( fd_tls_t const *      const server,
   fd_sha256_append( &transcript, msg_buf, server_ee_sz );
 
   /* Send Client Certificate Request **********************************/
-  if( handshake->client_cert ) {
+  if( server->auth_client ) {
 
     ulong cr_sz;
 
@@ -879,7 +879,7 @@ fd_tls_server_hs_start( fd_tls_t const *      const server,
 
   fd_tls_transcript_store( &handshake->transcript, &transcript );
 
-  handshake->base.state = handshake->client_cert ? FD_TLS_HS_WAIT_CERT : FD_TLS_HS_WAIT_FINISHED;
+  handshake->base.state = server->auth_client ? FD_TLS_HS_WAIT_CERT : FD_TLS_HS_WAIT_FINISHED;
 
 # undef MSG_BUFSZ
   return (long)read_sz;
@@ -1082,6 +1082,8 @@ fd_tls_server_hs_wait_cert_verify( fd_tls_t const *      const  server FD_PARAM_
   /* Finish up ********************************************************/
 
   fd_tls_transcript_store( &handshake->transcript, &transcript );
+
+  handshake->client_cert = 1; /* mark that client was authenticated */
 
   handshake->base.state = FD_TLS_HS_WAIT_FINISHED;
   return res;

--- a/src/waltz/tls/fd_tls.h
+++ b/src/waltz/tls/fd_tls.h
@@ -332,6 +332,7 @@ typedef struct fd_tls fd_tls_t;
 
 #define FD_TLS_REASON_CERT_CR_EXPECTED (501)  /* wanted Certificate or CertificateRequest, got another msg type */
 #define FD_TLS_REASON_CERT_CR_PARSE    (503)  /* failed to parse Certificate or CertificateRequest */
+#define FD_TLS_REASON_CERT_CR_ENCODE   (504)  /* failed to encode Certificate or CertificateRequest */
 
 #define FD_TLS_REASON_CERT_TYPE      (601)  /* unsupported certificate type */
 #define FD_TLS_REASON_CERT_EXPECTED  (602)  /* wanted Certificate, got another msg type */

--- a/src/waltz/tls/fd_tls.h
+++ b/src/waltz/tls/fd_tls.h
@@ -282,7 +282,8 @@ struct fd_tls {
 
   /* Flags */
   ulong quic            :  1;
-  ulong _flags_reserved : 63;
+  ulong auth_client     :  1; /* 1 if client auth is required */
+  ulong _flags_reserved : 62;
 };
 
 typedef struct fd_tls fd_tls_t;

--- a/src/waltz/tls/fd_tls_estate.h
+++ b/src/waltz/tls/fd_tls_estate.h
@@ -107,13 +107,19 @@ FD_PROTOTYPES_END
    TLS handshake state machine.  It is first instantiated when the
    client sent its ClientHello, the first message of a TLS handshake.
 
-   Currently, only one external state exists:
+   Currently, there are three external states:
 
-     FD_TLS_HS_WAIT_FINISHED:  Processed ClientHello.
+    FD_TLS_HS_WAIT_CERT:  Processed ClientHello.
+      The server has responded with all messages up to and including
+      Finished, and is now waiting for the client to respond with a
+      Certificate.
 
-       At this point, the server has responded with all messages up to
-       server Finished and is waiting for the client to respond with
-       client Finished (and optionally, a certificate).
+    FD_TLS_HS_WAIT_CV:  Processed Certificate.
+      The server is now waiting for the client's CertificateVerify.
+
+    FD_TLS_HS_WAIT_FINISHED:
+       The server is waiting for the client's Finished. Client auth,
+       if requested by the server, is complete.
 
    State data contains:
 

--- a/src/waltz/tls/fd_tls_estate.h
+++ b/src/waltz/tls/fd_tls_estate.h
@@ -138,7 +138,7 @@ struct fd_tls_estate_srv {
   fd_tls_estate_base_t base;
 
   uchar  server_cert_rpk : 1;  /* 0: X.509  1: raw public key */
-  uchar  client_cert     : 1;  /* 0: no client auth  1: client cert */
+  uchar  client_cert     : 1;  /* 0: no client auth  1: client cert completed */
   uchar  client_cert_rpk : 1;  /* 0: X.509  1: raw public key */
   uchar  hello_retry     : 1;
 

--- a/src/waltz/tls/fd_tls_proto.h
+++ b/src/waltz/tls/fd_tls_proto.h
@@ -188,6 +188,17 @@ struct fd_tls_cert_verify {
 
 typedef struct fd_tls_cert_verify fd_tls_cert_verify_t;
 
+/* fd_tls_cert_req_t describes a CertificateRequest (RFC 8446, Section
+   4.3.2). The only extension this implementation currently supports is
+   signature_algorithms. */
+
+struct fd_tls_cert_request {
+  fd_tls_ext_opaque_t certificate_request_context;
+  fd_tls_ext_signature_algorithms_t signature_algorithms;
+};
+
+typedef struct fd_tls_cert_request fd_tls_cert_request_t;
+
 /* fd_tls_finished_t matches the wire representation of Finished (RFC
    8446, Section 4.4.4).  Only supports TLS cipher suites with 32 byte
    hash output size. */
@@ -279,7 +290,7 @@ typedef struct fd_tls_finished fd_tls_finished_t;
 #define FD_TLS_MSG_NEW_SESSION_TICKET ((uchar)  4)
 #define FD_TLS_MSG_ENCRYPTED_EXT      ((uchar)  8)
 #define FD_TLS_MSG_CERT               ((uchar) 11)
-#define FD_TLS_MSG_CERT_REQ           ((uchar) 13)
+#define FD_TLS_MSG_CERT_REQUEST       ((uchar) 13)
 #define FD_TLS_MSG_CERT_VERIFY        ((uchar) 15)
 #define FD_TLS_MSG_FINISHED           ((uchar) 20)
 
@@ -460,6 +471,11 @@ fd_tls_encode_cert_verify( fd_tls_cert_verify_t const * in,
                            uchar *                      wire,
                            ulong                        wire_sz );
 
+long
+fd_tls_encode_cert_request( fd_tls_cert_request_t const *   in,
+                            uchar *                     wire,
+                            ulong                       wire_sz );
+
 static inline void
 fd_tls_cert_verify_bswap( fd_tls_cert_verify_t * x ) {
   x->sig_alg = fd_ushort_bswap( x->sig_alg );
@@ -484,6 +500,11 @@ long
 fd_tls_decode_ext_signature_algorithms( fd_tls_ext_signature_algorithms_t * out,
                                         uchar const *                       wire,
                                         ulong                               wire_sz );
+
+long
+fd_tls_encode_ext_signature_algorithms( fd_tls_ext_signature_algorithms_t const * in,
+                                        uchar *                                   wire,
+                                        ulong                                     wire_sz );
 
 long
 fd_tls_decode_key_share( fd_tls_key_share_t * out,
@@ -523,6 +544,11 @@ fd_tls_encode_ext_cert_type( fd_tls_ext_cert_type_t in,
 long
 fd_tls_decode_ext_opaque( fd_tls_ext_opaque_t * const out,
                           uchar const *         const wire,
+                          ulong                       wire_sz );
+
+long
+fd_tls_encode_ext_opaque( fd_tls_ext_opaque_t const * in,
+                          uchar *                     wire,
                           ulong                       wire_sz );
 
 static inline long

--- a/src/waltz/tls/test_tls.c
+++ b/src/waltz/tls/test_tls.c
@@ -183,6 +183,7 @@ prepare_tls_pair( fd_rng_t * rng,
     .sign       = fd_tls_test_sign( &server_sign_ctx ),
     .secrets_fn = test_tls_secrets,
     .sendmsg_fn = test_tls_sendmsg,
+    .auth_client = 1,
   };
 
   /* Generate keys */

--- a/src/waltz/tls/test_tls.c
+++ b/src/waltz/tls/test_tls.c
@@ -214,6 +214,7 @@ test_tls_pair( fd_rng_t * rng ) {
 
   fd_tls_estate_srv_t srv_hs[1]; FD_TEST( fd_tls_estate_srv_new( srv_hs ) );
   test_server_hs = srv_hs;
+  srv_hs->client_cert = 1;
 
   fd_tls_estate_cli_t cli_hs[1];
   FD_TEST( fd_tls_estate_cli_new( cli_hs ) );
@@ -223,7 +224,7 @@ test_tls_pair( fd_rng_t * rng ) {
 
   /* ClientHello */
   fd_tls_client_handshake( client, cli_hs, NULL, 0UL, FD_TLS_LEVEL_INITIAL );
-  /* ServerHello, EncryptedExtensions, Certificate, CertificateVerify, Finished */
+  /* ServerHello, EncryptedExtensions, CertificateRequest, Certificate, CertificateVerify, Finished */
   test_tls_server_respond( server, srv_hs );
   /* Finished */
   test_tls_client_respond( client, cli_hs );
@@ -233,6 +234,9 @@ test_tls_pair( fd_rng_t * rng ) {
   /* Check if connected */
   FD_TEST( srv_hs->base.state==FD_TLS_HS_CONNECTED );
   FD_TEST( cli_hs->base.state==FD_TLS_HS_CONNECTED );
+
+  FD_TEST( 0==memcmp( cli_hs->server_pubkey, server->cert_public_key, 32UL ) );
+  FD_TEST( 0==memcmp( srv_hs->client_pubkey, client->cert_public_key, 32UL ) ); /* requires srv_hs->client_cert*/
 
   test_server_hs = NULL;
   fd_tls_estate_srv_delete( srv_hs );

--- a/src/waltz/tls/test_tls_helper.h
+++ b/src/waltz/tls/test_tls_helper.h
@@ -130,7 +130,7 @@ test_record_log( uchar const * record,
   case FD_TLS_MSG_ENCRYPTED_EXT:      type = "EncryptedExtensions"; break;
   case FD_TLS_MSG_CERT:               type = "Certificate";         break;
   case FD_TLS_MSG_CERT_VERIFY:        type = "CertificateVerify";   break;
-  case FD_TLS_MSG_CERT_REQ:           type = "CertificateRequest";  break;
+  case FD_TLS_MSG_CERT_REQUEST:       type = "CertificateRequest";  break;
   case FD_TLS_MSG_FINISHED:           type = "Finished";            break;
   case FD_TLS_MSG_NEW_SESSION_TICKET: type = "NewSessionTicket";    break;
   default:


### PR DESCRIPTION
This PR brings back server-side support for client authentication in fd_tls, fd_quic_tls, and therefore fd_quic. 
It also refactors tls to reduce code duplication.