### PR TITLE
funk: optimize rec memory layout

### DIFF
--- a/src/funk/test_funk_rec.c
+++ b/src/funk/test_funk_rec.c
@@ -2,7 +2,7 @@
 
 #if FD_HAS_HOSTED
 
-FD_STATIC_ASSERT( FD_FUNK_REC_ALIGN    == 64UL, unit_test );
+FD_STATIC_ASSERT( FD_FUNK_REC_ALIGN    == 32UL, unit_test );
 
 FD_STATIC_ASSERT( FD_FUNK_REC_FLAG_ERASE==1UL, unit_test );
 


### PR DESCRIPTION
Reduces fd_funk_rec_t footprint from 128 bytes to 96 bytes
