### PR TITLE
funk: move global iter API to private header

### DIFF
--- a/src/flamenco/runtime/program/test_program_cache_concur.cxx
+++ b/src/flamenco/runtime/program/test_program_cache_concur.cxx
@@ -1,6 +1,6 @@
 #include "../../../funk/fd_funk_rec.h"
 #include "../../../funk/fd_funk_txn.h"
-#include "../../../funk/test_funk_common.hpp"
+#include "../../../funk/test_funk_common.hxx"
 #include "fd_program_cache.h"
 #include <cstdio>
 #include <pthread.h>

--- a/src/flamenco/runtime/tests/fd_solfuzz.c
+++ b/src/flamenco/runtime/tests/fd_solfuzz.c
@@ -140,8 +140,7 @@ fd_solfuzz_runner_leak_check( fd_solfuzz_runner_t * runner ) {
     FD_LOG_CRIT(( "solfuzz leaked a spad frame (bump allocator)" ));
   }
 
-  fd_funk_txn_all_iter_t iter[1];
-  for( fd_funk_txn_all_iter_new( runner->funk, iter ); !fd_funk_txn_all_iter_done( iter ); fd_funk_txn_all_iter_next( iter ) ) {
+  if( FD_UNLIKELY( !fd_funk_txn_idx_is_null( fd_funk_txn_idx( runner->funk->shmem->child_head_cidx ) ) ) ) {
     FD_LOG_CRIT(( "solfuzz leaked a funk txn" ));
   }
 }

--- a/src/funk/fd_funk_private.h
+++ b/src/funk/fd_funk_private.h
@@ -1,0 +1,145 @@
+#ifndef HEADER_fd_src_funk_fd_funk_private_h
+#define HEADER_fd_src_funk_fd_funk_private_h
+
+/* fd_funk_private.h contains internal APIs deemed unsafe for public
+   consumption. */
+
+#include "fd_funk.h"
+
+/* fd_funk_all_iter_t iterators over all funk record objects in all funk
+   transactions.  This API is not optimized for performance and has a
+   high fixed cost (slow even for empty DBs).
+
+   Assumes no concurrent write accesses to the entire funk instance
+   during the lifetime of this iterator.
+
+   Usage is:
+
+   fd_funk_all_iter_t iter[1];
+   for( fd_funk_all_iter_new( funk, iter ); !fd_funk_all_iter_done( iter ); fd_funk_all_iter_next( iter ) ) {
+     fd_funk_rec_t const * rec = fd_funk_all_iter_ele_const( iter );
+     ...
+   } */
+
+struct fd_funk_all_iter {
+  fd_funk_rec_map_t      rec_map;
+  ulong                  chain_cnt;
+  ulong                  chain_idx;
+  fd_funk_rec_map_iter_t rec_map_iter;
+};
+
+typedef struct fd_funk_all_iter fd_funk_all_iter_t;
+
+FD_PROTOTYPES_BEGIN
+
+FD_FN_UNUSED static void
+fd_funk_all_iter_skip_nulls( fd_funk_all_iter_t * iter ) {
+  if( iter->chain_idx == iter->chain_cnt ) return;
+  while( fd_funk_rec_map_iter_done( iter->rec_map_iter ) ) {
+    if( ++(iter->chain_idx) == iter->chain_cnt ) break;
+    iter->rec_map_iter = fd_funk_rec_map_iter( &iter->rec_map, iter->chain_idx );
+  }
+}
+
+FD_FN_UNUSED static void
+fd_funk_all_iter_new( fd_funk_t const *    funk,
+                      fd_funk_all_iter_t * iter ) {
+  iter->rec_map      = *funk->rec_map;
+  iter->chain_cnt    = fd_funk_rec_map_chain_cnt( &iter->rec_map );
+  iter->chain_idx    = 0;
+  iter->rec_map_iter = fd_funk_rec_map_iter( &iter->rec_map, 0 );
+  fd_funk_all_iter_skip_nulls( iter );
+}
+
+static inline int
+fd_funk_all_iter_done( fd_funk_all_iter_t const * iter ) {
+  return ( iter->chain_idx == iter->chain_cnt );
+}
+
+FD_FN_UNUSED static void
+fd_funk_all_iter_next( fd_funk_all_iter_t * iter ) {
+  iter->rec_map_iter = fd_funk_rec_map_iter_next( iter->rec_map_iter );
+  fd_funk_all_iter_skip_nulls( iter );
+}
+
+static inline fd_funk_rec_t const *
+fd_funk_all_iter_ele_const( fd_funk_all_iter_t * iter ) {
+  return fd_funk_rec_map_iter_ele_const( iter->rec_map_iter );
+}
+
+static inline fd_funk_rec_t *
+fd_funk_all_iter_ele( fd_funk_all_iter_t * iter ) {
+  return fd_funk_rec_map_iter_ele( iter->rec_map_iter );
+}
+
+FD_PROTOTYPES_END
+
+/* fd_funk_txn_all_iter_t iterators over all funk transaction objects.
+
+   Assumes no concurrent write accesses to the entire funk instance
+   during the lifetime of this iterator.
+
+   Usage is:
+
+   fd_funk_txn_all_iter_t txn_iter[1];
+   for( fd_funk_txn_all_iter_new( funk, txn_iter ); !fd_funk_txn_all_iter_done( txn_iter ); fd_funk_txn_all_iter_next( txn_iter ) ) {
+     fd_funk_txn_t const * txn = fd_funk_txn_all_iter_ele_const( txn_iter );
+     ...
+   }
+
+   FIXME depth-first search transaction tree instead */
+
+struct fd_funk_txn_all_iter {
+  fd_funk_txn_map_t txn_map;
+  ulong chain_cnt;
+  ulong chain_idx;
+  fd_funk_txn_map_iter_t txn_map_iter;
+};
+
+typedef struct fd_funk_txn_all_iter fd_funk_txn_all_iter_t;
+
+FD_PROTOTYPES_BEGIN
+
+FD_FN_UNUSED static void
+fd_funk_txn_all_iter_skip_nulls( fd_funk_txn_all_iter_t * iter ) {
+  if( iter->chain_idx == iter->chain_cnt ) return;
+  while( fd_funk_txn_map_iter_done( iter->txn_map_iter ) ) {
+    if( ++(iter->chain_idx) == iter->chain_cnt ) break;
+    iter->txn_map_iter = fd_funk_txn_map_iter( &iter->txn_map, iter->chain_idx );
+  }
+}
+
+FD_FN_UNUSED static void
+fd_funk_txn_all_iter_new( fd_funk_t const *        funk,
+                          fd_funk_txn_all_iter_t * iter ) {
+  iter->txn_map = *funk->txn_map;
+  iter->chain_cnt = fd_funk_txn_map_chain_cnt( funk->txn_map );
+  iter->chain_idx = 0;
+  iter->txn_map_iter = fd_funk_txn_map_iter( funk->txn_map, 0 );
+  fd_funk_txn_all_iter_skip_nulls( iter );
+}
+
+static inline int
+fd_funk_txn_all_iter_done( fd_funk_txn_all_iter_t const * iter ) {
+  return iter->chain_idx == iter->chain_cnt;
+}
+
+FD_FN_UNUSED static void
+fd_funk_txn_all_iter_next( fd_funk_txn_all_iter_t * iter ) {
+  iter->txn_map_iter = fd_funk_txn_map_iter_next( iter->txn_map_iter );
+  fd_funk_txn_all_iter_skip_nulls( iter );
+}
+
+static inline fd_funk_txn_t const *
+fd_funk_txn_all_iter_ele_const( fd_funk_txn_all_iter_t * iter ) {
+  return fd_funk_txn_map_iter_ele_const( iter->txn_map_iter );
+}
+
+static inline fd_funk_txn_t *
+fd_funk_txn_all_iter_ele( fd_funk_txn_all_iter_t * iter ) {
+  return fd_funk_txn_map_iter_ele( iter->txn_map_iter );
+}
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_funk_fd_funk_private_h */

--- a/src/funk/fd_funk_rec.c
+++ b/src/funk/fd_funk_rec.c
@@ -1,6 +1,4 @@
-#include "fd_funk.h"
-#include "fd_funk_base.h"
-#include "fd_funk_txn.h"
+#include "fd_funk_private.h"
 #include "../util/racesan/fd_racesan_target.h"
 
 /* Provide the actual record map implementation */
@@ -502,45 +500,6 @@ fd_funk_rec_remove( fd_funk_t *               funk,
   fd_funk_val_flush( rec, funk->alloc, funk->wksp );
   fd_funk_rec_txn_release( txn_query );
   return FD_FUNK_SUCCESS;
-}
-
-static void
-fd_funk_all_iter_skip_nulls( fd_funk_all_iter_t * iter ) {
-  if( iter->chain_idx == iter->chain_cnt ) return;
-  while( fd_funk_rec_map_iter_done( iter->rec_map_iter ) ) {
-    if( ++(iter->chain_idx) == iter->chain_cnt ) break;
-    iter->rec_map_iter = fd_funk_rec_map_iter( &iter->rec_map, iter->chain_idx );
-  }
-}
-
-void
-fd_funk_all_iter_new( fd_funk_t * funk, fd_funk_all_iter_t * iter ) {
-  iter->rec_map      = *funk->rec_map;
-  iter->chain_cnt    = fd_funk_rec_map_chain_cnt( &iter->rec_map );
-  iter->chain_idx    = 0;
-  iter->rec_map_iter = fd_funk_rec_map_iter( &iter->rec_map, 0 );
-  fd_funk_all_iter_skip_nulls( iter );
-}
-
-int
-fd_funk_all_iter_done( fd_funk_all_iter_t * iter ) {
-  return ( iter->chain_idx == iter->chain_cnt );
-}
-
-void
-fd_funk_all_iter_next( fd_funk_all_iter_t * iter ) {
-  iter->rec_map_iter = fd_funk_rec_map_iter_next( iter->rec_map_iter );
-  fd_funk_all_iter_skip_nulls( iter );
-}
-
-fd_funk_rec_t const *
-fd_funk_all_iter_ele_const( fd_funk_all_iter_t * iter ) {
-  return fd_funk_rec_map_iter_ele_const( iter->rec_map_iter );
-}
-
-fd_funk_rec_t *
-fd_funk_all_iter_ele( fd_funk_all_iter_t * iter ) {
-  return fd_funk_rec_map_iter_ele( iter->rec_map_iter );
 }
 
 int

--- a/src/funk/fd_funk_rec.h
+++ b/src/funk/fd_funk_rec.h
@@ -352,40 +352,6 @@ fd_funk_rec_remove( fd_funk_t *               funk,
                     fd_funk_rec_key_t const * key,
                     fd_funk_rec_t **          rec_out );
 
-/* fd_funk_all_iter_t iterators over all funk record objects in all funk
-   transactions.
-
-   Assumes that no other join is doing funk write accesses during the
-   lifetime of the iterator object.  This API is not optimized for
-   performance and has a high fixed cost (slow even for empty DBs).
-
-   Usage is:
-
-   fd_funk_all_iter_t iter[1];
-   for( fd_funk_all_iter_new( funk, iter ); !fd_funk_all_iter_done( iter ); fd_funk_all_iter_next( iter ) ) {
-     fd_funk_rec_t const * rec = fd_funk_all_iter_ele_const( iter );
-     ...
-   } */
-
-struct fd_funk_all_iter {
-  fd_funk_rec_map_t      rec_map;
-  ulong                  chain_cnt;
-  ulong                  chain_idx;
-  fd_funk_rec_map_iter_t rec_map_iter;
-};
-
-typedef struct fd_funk_all_iter fd_funk_all_iter_t;
-
-void fd_funk_all_iter_new( fd_funk_t * funk, fd_funk_all_iter_t * iter );
-
-int fd_funk_all_iter_done( fd_funk_all_iter_t * iter );
-
-void fd_funk_all_iter_next( fd_funk_all_iter_t * iter );
-
-fd_funk_rec_t const * fd_funk_all_iter_ele_const( fd_funk_all_iter_t * iter );
-
-fd_funk_rec_t * fd_funk_all_iter_ele( fd_funk_all_iter_t * iter );
-
 /* Misc */
 
 /* fd_funk_rec_verify verifies the record map.  Returns FD_FUNK_SUCCESS

--- a/src/funk/fd_funk_txn.c
+++ b/src/funk/fd_funk_txn.c
@@ -803,46 +803,6 @@ fd_funk_generate_xid(void) {
   return xid;
 }
 
-static void
-fd_funk_txn_all_iter_skip_nulls( fd_funk_txn_all_iter_t * iter ) {
-  if( iter->chain_idx == iter->chain_cnt ) return;
-  while( fd_funk_txn_map_iter_done( iter->txn_map_iter ) ) {
-    if( ++(iter->chain_idx) == iter->chain_cnt ) break;
-    iter->txn_map_iter = fd_funk_txn_map_iter( &iter->txn_map, iter->chain_idx );
-  }
-}
-
-void
-fd_funk_txn_all_iter_new( fd_funk_t *              funk,
-                          fd_funk_txn_all_iter_t * iter ) {
-  iter->txn_map = *funk->txn_map;
-  iter->chain_cnt = fd_funk_txn_map_chain_cnt( funk->txn_map );
-  iter->chain_idx = 0;
-  iter->txn_map_iter = fd_funk_txn_map_iter( funk->txn_map, 0 );
-  fd_funk_txn_all_iter_skip_nulls( iter );
-}
-
-int
-fd_funk_txn_all_iter_done( fd_funk_txn_all_iter_t * iter ) {
-  return ( iter->chain_idx == iter->chain_cnt );
-}
-
-void
-fd_funk_txn_all_iter_next( fd_funk_txn_all_iter_t * iter ) {
-  iter->txn_map_iter = fd_funk_txn_map_iter_next( iter->txn_map_iter );
-  fd_funk_txn_all_iter_skip_nulls( iter );
-}
-
-fd_funk_txn_t const *
-fd_funk_txn_all_iter_ele_const( fd_funk_txn_all_iter_t * iter ) {
-  return fd_funk_txn_map_iter_ele_const( iter->txn_map_iter );
-}
-
-fd_funk_txn_t *
-fd_funk_txn_all_iter_ele( fd_funk_txn_all_iter_t * iter ) {
-  return fd_funk_txn_map_iter_ele( iter->txn_map_iter );
-}
-
 int
 fd_funk_txn_verify( fd_funk_t * funk ) {
   fd_funk_txn_map_t *  txn_map  = funk->txn_map;

--- a/src/funk/fd_funk_txn.h
+++ b/src/funk/fd_funk_txn.h
@@ -401,34 +401,6 @@ fd_funk_txn_publish_into_parent( fd_funk_t *               funk,
 void
 fd_funk_txn_remove_published( fd_funk_t * funk );
 
-/* fd_funk_txn_all_iter_t iterators over all funk transaction objects.
-   Usage is:
-
-   fd_funk_txn_all_iter_t txn_iter[1];
-   for( fd_funk_txn_all_iter_new( funk, txn_iter ); !fd_funk_txn_all_iter_done( txn_iter ); fd_funk_txn_all_iter_next( txn_iter ) ) {
-     fd_funk_txn_t const * txn = fd_funk_txn_all_iter_ele_const( txn_iter );
-     ...
-   }
-*/
-
-struct fd_funk_txn_all_iter {
-  fd_funk_txn_map_t txn_map;
-  ulong chain_cnt;
-  ulong chain_idx;
-  fd_funk_txn_map_iter_t txn_map_iter;
-};
-
-typedef struct fd_funk_txn_all_iter fd_funk_txn_all_iter_t;
-
-void fd_funk_txn_all_iter_new( fd_funk_t * funk, fd_funk_txn_all_iter_t * iter );
-
-int fd_funk_txn_all_iter_done( fd_funk_txn_all_iter_t * iter );
-
-void fd_funk_txn_all_iter_next( fd_funk_txn_all_iter_t * iter );
-
-fd_funk_txn_t const * fd_funk_txn_all_iter_ele_const( fd_funk_txn_all_iter_t * iter );
-fd_funk_txn_t * fd_funk_txn_all_iter_ele( fd_funk_txn_all_iter_t * iter );
-
 /* Misc */
 
 /* fd_funk_txn_verify verifies a transaction map.  Returns

--- a/src/funk/fd_funk_val.c
+++ b/src/funk/fd_funk_val.c
@@ -1,4 +1,4 @@
-#include "fd_funk.h"
+#include "fd_funk_private.h"
 
 void *
 fd_funk_val_truncate( fd_funk_rec_t * rec,

--- a/src/funk/test_funk_common.hxx
+++ b/src/funk/test_funk_common.hxx
@@ -1,4 +1,4 @@
-#include "fd_funk.h"
+#include "fd_funk_private.h"
 #include <map>
 #include <vector>
 #include <set>

--- a/src/funk/test_funk_concur.cxx
+++ b/src/funk/test_funk_concur.cxx
@@ -1,4 +1,4 @@
-#include "test_funk_common.hpp"
+#include "test_funk_common.hxx"
 #include <cstdio>
 #include <pthread.h>
 

--- a/src/funk/test_funk_txn2.cxx
+++ b/src/funk/test_funk_txn2.cxx
@@ -1,4 +1,4 @@
-#include "test_funk_common.hpp"
+#include "test_funk_common.hxx"
 #include <stdio.h>
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Discourage use of global iterator, which is inherently incompatible
with concurrent usage.
