### PR TITLE
funk: reduce rec footprint to 84 bytes

### DIFF
--- a/src/flamenco/runtime/fd_acc_mgr.c
+++ b/src/flamenco/runtime/fd_acc_mgr.c
@@ -22,7 +22,7 @@ fd_funk_get_acc_meta_readonly( fd_funk_t const *         funk,
     if( !txn_out ) txn_out    = dummy_txn_out;
     fd_funk_rec_t const * rec = fd_funk_rec_query_try_global( funk, xid, &id, txn_out, query );
 
-    if( FD_UNLIKELY( !rec || !!( rec->flags & FD_FUNK_REC_FLAG_ERASE ) ) )  {
+    if( FD_UNLIKELY( !rec || rec->erase ) )  {
       fd_int_store_if( !!opt_err, opt_err, FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT );
       return NULL;
     }

--- a/src/flamenco/runtime/program/fd_program_cache.c
+++ b/src/flamenco/runtime/program/fd_program_cache.c
@@ -468,7 +468,7 @@ fd_program_cache_load_entry( fd_funk_t const *                 funk,
       return -1;
     }
 
-    if( FD_UNLIKELY( !!( rec->flags & FD_FUNK_REC_FLAG_ERASE ) ) ) {
+    if( FD_UNLIKELY( rec->erase ) ) {
       if( fd_funk_rec_query_test( query ) == FD_FUNK_SUCCESS ) {
         return -1;
       } else {

--- a/src/funk/fd_funk_val.c
+++ b/src/funk/fd_funk_val.c
@@ -12,7 +12,7 @@ fd_funk_val_truncate( fd_funk_rec_t * rec,
 
 #ifdef FD_FUNK_HANDHOLDING
   if( FD_UNLIKELY( (!rec) | (sz>FD_FUNK_REC_VAL_MAX) | (!alloc) | (!wksp) ) ||  /* NULL rec,too big,NULL alloc,NULL wksp */
-      FD_UNLIKELY( rec->flags & FD_FUNK_REC_FLAG_ERASE                    ) ||  /* Marked erase */
+      FD_UNLIKELY( rec->erase                                             ) ||  /* Marked erase */
       FD_UNLIKELY( !fd_ulong_is_pow2( align ) & (align != 0UL)            ) ) { /* Align is not a power of 2 or == 0 */
     fd_int_store_if( !!opt_err, opt_err, FD_FUNK_ERR_INVAL );
     return NULL;
@@ -55,8 +55,8 @@ fd_funk_val_truncate( fd_funk_rec_t * rec,
     fd_memset( new_val + val_sz, 0, new_val_max - val_sz ); /* Clear out trailing padding to be on the safe side */
 
     rec->val_gaddr = fd_wksp_gaddr_fast( wksp, new_val );
-    rec->val_sz    = (uint)sz;
-    rec->val_max   = (uint)fd_ulong_min( new_val_max, FD_FUNK_REC_VAL_MAX );
+    rec->val_sz    = (uint)( sz & FD_FUNK_REC_VAL_MAX );
+    rec->val_max   = (uint)( fd_ulong_min( new_val_max, FD_FUNK_REC_VAL_MAX ) & FD_FUNK_REC_VAL_MAX );
 
     if( val ) fd_alloc_free( alloc, val ); /* Free the old value (if any) */
 
@@ -67,7 +67,7 @@ fd_funk_val_truncate( fd_funk_rec_t * rec,
 
     /* Just set the new size */
 
-    rec->val_sz = (uint)sz;
+    rec->val_sz = (uint)( sz & FD_FUNK_REC_VAL_MAX );
 
     fd_int_store_if( !!opt_err, opt_err, FD_FUNK_SUCCESS );
     return (uchar *)fd_wksp_laddr_fast( wksp, rec->val_gaddr );
@@ -102,7 +102,7 @@ fd_funk_val_verify( fd_funk_t * funk ) {
 
     TEST( val_sz<=val_max );
 
-    if( rec->flags & FD_FUNK_REC_FLAG_ERASE ) {
+    if( rec->erase ) {
       TEST( !val_max   );
       TEST( !val_gaddr );
     } else {

--- a/src/funk/fd_funk_val.h
+++ b/src/funk/fd_funk_val.h
@@ -8,7 +8,7 @@
 
 /* FD_FUNK_REC_VAL_MAX is the maximum size of a record value. */
 
-#define FD_FUNK_REC_VAL_MAX (UINT_MAX)
+#define FD_FUNK_REC_VAL_MAX ((1UL<<28)-1UL)
 #define FD_FUNK_VAL_ALIGN   (8UL)
 
 FD_PROTOTYPES_BEGIN

--- a/src/funk/test_funk_common.hxx
+++ b/src/funk/test_funk_common.hxx
@@ -323,10 +323,10 @@ struct fake_funk {
         assert(j != recs.end());
         auto * rec2 = *j;
         if (rec2->_erased) {
-          assert(rec->flags & FD_FUNK_REC_FLAG_ERASE);
+          assert(rec->erase);
           assert(fd_funk_val_sz(rec) == 0);
         } else {
-          assert(!(rec->flags & FD_FUNK_REC_FLAG_ERASE));
+          assert(!rec->erase);
           assert(fd_funk_val_sz(rec) == rec2->size());
           assert(memcmp(fd_funk_val(rec, _wksp), rec2->data(), rec2->size()) == 0);
         }
@@ -336,7 +336,7 @@ struct fake_funk {
         if( !txn ) xid = fd_funk_last_publish( _real );
         fd_funk_rec_query_t query[1];
         auto* rec3 = fd_funk_rec_query_try_global(_real, xid, rec->pair.key, NULL, query);
-        if( ( rec->flags & FD_FUNK_REC_FLAG_ERASE ) )
+        if( rec->erase )
           assert(rec3 == NULL);
         else
           assert(rec == rec3);

--- a/src/funk/test_funk_rec.c
+++ b/src/funk/test_funk_rec.c
@@ -4,8 +4,6 @@
 
 FD_STATIC_ASSERT( FD_FUNK_REC_ALIGN    == 32UL, unit_test );
 
-FD_STATIC_ASSERT( FD_FUNK_REC_FLAG_ERASE==1UL, unit_test );
-
 FD_STATIC_ASSERT( FD_FUNK_REC_IDX_NULL==UINT_MAX, unit_test );
 
 #include "test_funk_common.h"

--- a/src/funk/test_funk_val.c
+++ b/src/funk/test_funk_val.c
@@ -4,7 +4,7 @@
 
 #include "test_funk_common.h"
 
-FD_STATIC_ASSERT( FD_FUNK_REC_VAL_MAX==UINT_MAX, unit_test );
+FD_STATIC_ASSERT( FD_FUNK_REC_VAL_MAX==268435455UL, unit_test );
 
 int
 main( int     argc,


### PR DESCRIPTION
Carves out 12 bytes for user data embedding
