### PR TITLE
funk: remove 'rec_remove' API

### DIFF
--- a/src/flamenco/runtime/fd_acc_mgr.c
+++ b/src/flamenco/runtime/fd_acc_mgr.c
@@ -22,7 +22,7 @@ fd_funk_get_acc_meta_readonly( fd_funk_t const *         funk,
     if( !txn_out ) txn_out    = dummy_txn_out;
     fd_funk_rec_t const * rec = fd_funk_rec_query_try_global( funk, xid, &id, txn_out, query );
 
-    if( FD_UNLIKELY( !rec || rec->erase ) )  {
+    if( FD_UNLIKELY( !rec ) )  {
       fd_int_store_if( !!opt_err, opt_err, FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT );
       return NULL;
     }

--- a/src/flamenco/runtime/program/fd_program_cache.c
+++ b/src/flamenco/runtime/program/fd_program_cache.c
@@ -468,14 +468,6 @@ fd_program_cache_load_entry( fd_funk_t const *                 funk,
       return -1;
     }
 
-    if( FD_UNLIKELY( rec->erase ) ) {
-      if( fd_funk_rec_query_test( query ) == FD_FUNK_SUCCESS ) {
-        return -1;
-      } else {
-        continue;
-      }
-    }
-
     void const * data = fd_funk_val_const( rec, fd_funk_wksp(funk) );
 
     *cache_entry = (fd_program_cache_entry_t const *)data;

--- a/src/funk/fd_funk.h
+++ b/src/funk/fd_funk.h
@@ -141,7 +141,6 @@
      fd_funk_rec_prepare
      fd_funk_rec_publish
      fd_funk_rec_cancel
-     fd_funk_rec_remove
 */
 
 //#include "fd_funk_base.h" /* Includes ../util/fd_util.h */

--- a/src/funk/fd_funk_rec.h
+++ b/src/funk/fd_funk_rec.h
@@ -40,10 +40,9 @@ struct __attribute__((aligned(FD_FUNK_REC_ALIGN))) fd_funk_rec {
      (1UL<<28)-1. */
 
   ulong val_sz  : 28;  /* Num bytes in record value, in [0,val_max] */
-  ulong val_max : 28;  /* Max byte  in record value, in [0,FD_FUNK_REC_VAL_MAX], 0 if erase flag set or val_gaddr is 0 */
-  ulong erase   :  1;  /* Indicates a tombstone */
+  ulong val_max : 28;  /* Max byte  in record value, in [0,FD_FUNK_REC_VAL_MAX], 0 if val_gaddr is 0 */
   ulong tag     :  1;  /* Used for internal validation */
-  ulong val_gaddr; /* Wksp gaddr on record value if any, 0 if erase flag set or val_max is 0
+  ulong val_gaddr; /* Wksp gaddr on record value if any, 0 if val_max is 0
                       If non-zero, the region [val_gaddr,val_gaddr+val_max) will be a current fd_alloc allocation (such that it is
                       has tag wksp_tag) and the owner of the region will be the record. The allocator is
                       fd_funk_alloc(). IMPORTANT! HAS NO GUARANTEED ALIGNMENT! */
@@ -295,35 +294,6 @@ fd_funk_rec_clone( fd_funk_t *               funk,
                    fd_funk_rec_key_t const * key,
                    fd_funk_rec_prepare_t *   prepare,
                    int *                     opt_err );
-
-/* fd_funk_rec_remove removes the live record with the
-   given (xid,key) from funk. Returns FD_FUNK_SUCCESS (0) on
-   success and an FD_FUNK_ERR_* (negative) on failure.  Reasons for
-   failure include:
-
-     FD_FUNK_ERR_INVAL - bad inputs (NULL funk, NULL xid)
-
-     FD_FUNK_ERR_KEY - the record did not appear to be a live record.
-       Specifically, a record query of funk for rec's (xid,key) pair did
-       not return rec.
-
-   The record will cease to exist in that transaction and any of
-   transaction's subsequently created descendants (again, assuming no
-   subsequent insert of key).  This type of remove can be done on a
-   published record (assuming the last published transaction is
-   unfrozen). A tombstone is left in funk to track removals as they
-   are published or cancelled.
-
-   Any information in an erased record is lost.
-
-   This is a reasonably fast O(1) and fortified against memory
-   corruption. */
-
-int
-fd_funk_rec_remove( fd_funk_t *               funk,
-                    fd_funk_txn_xid_t const * xid,
-                    fd_funk_rec_key_t const * key,
-                    fd_funk_rec_t **          rec_out );
 
 /* Misc */
 

--- a/src/funk/fd_funk_txn.c
+++ b/src/funk/fd_funk_txn.c
@@ -485,16 +485,13 @@ fd_funk_txn_cancel_all( fd_funk_t * funk ) {
    Transaction txn_idx will have an _empty_ record list.
 
    Updates in the transaction txn_idx are processed from oldest to
-   youngest.  If an update erases an existing record in dest, the record
-   to erase is removed from the destination records without perturbing
-   the order of remaining destination records.  If an update is to
-   update an existing record, the destination record value is updated
-   and the order of the destination records is unchanged.  If an update
-   is to create a new record, the record is appended to the list of
-   existing values as youngest without changing the order of existing
-   values.  If an update erases a record in an in-prep parent, the
-   erasure will be moved into the parent as the youngest without
-   changing the order of existing values. */
+   youngest.  If an update is to update an existing record, the
+   destination record value is updated and the order of the destination
+   records is unchanged.  If an update is to create a new record, the
+   record is appended to the list of existing values as youngest without
+   changing the order of existing values.  If an update erases a record
+   in an in-prep parent, the erasure will be moved into the parent as
+   the youngest without changing the order of existing values. */
 
 static void
 fd_funk_txn_update( fd_funk_t *               funk,

--- a/src/funk/fd_funk_val.c
+++ b/src/funk/fd_funk_val.c
@@ -12,7 +12,6 @@ fd_funk_val_truncate( fd_funk_rec_t * rec,
 
 #ifdef FD_FUNK_HANDHOLDING
   if( FD_UNLIKELY( (!rec) | (sz>FD_FUNK_REC_VAL_MAX) | (!alloc) | (!wksp) ) ||  /* NULL rec,too big,NULL alloc,NULL wksp */
-      FD_UNLIKELY( rec->erase                                             ) ||  /* Marked erase */
       FD_UNLIKELY( !fd_ulong_is_pow2( align ) & (align != 0UL)            ) ) { /* Align is not a power of 2 or == 0 */
     fd_int_store_if( !!opt_err, opt_err, FD_FUNK_ERR_INVAL );
     return NULL;
@@ -102,16 +101,11 @@ fd_funk_val_verify( fd_funk_t * funk ) {
 
     TEST( val_sz<=val_max );
 
-    if( rec->erase ) {
-      TEST( !val_max   );
-      TEST( !val_gaddr );
-    } else {
-      TEST( val_max<=FD_FUNK_REC_VAL_MAX );
-      if( !val_gaddr ) TEST( !val_max );
-      else {
-        TEST( (0UL<val_max) & (val_max<=FD_FUNK_REC_VAL_MAX) );
-        TEST( fd_wksp_tag( wksp, val_gaddr )==wksp_tag );
-      }
+    TEST( val_max<=FD_FUNK_REC_VAL_MAX );
+    if( !val_gaddr ) TEST( !val_max );
+    else {
+      TEST( (0UL<val_max) & (val_max<=FD_FUNK_REC_VAL_MAX) );
+      TEST( fd_wksp_tag( wksp, val_gaddr )==wksp_tag );
     }
   }
 

--- a/src/funk/test_funk_common.c
+++ b/src/funk/test_funk_common.c
@@ -253,10 +253,6 @@ rec_insert( funk_t * funk,
 
   rec_t * rec = rec_query( funk, txn, key );
   if( rec ) {
-    if( rec->erase ) { /* Undo any previous erase */
-      rec->erase = 0;
-      return rec;
-    }
     FD_LOG_ERR(( "never get here unless user error" ));
   }
 
@@ -266,7 +262,6 @@ rec_insert( funk_t * funk,
   /* Push into the map */
 
   rec->key   = key;
-  rec->erase = 0;
   rec->val   = 0U;
 
   rec_t * prev = funk->rec_map_tail;
@@ -297,16 +292,6 @@ rec_insert( funk_t * funk,
   *_tail = rec;
 
   return rec;
-}
-
-void
-rec_remove( funk_t * funk,
-            rec_t *  rec ) {
-  (void)funk;
-
-//FD_LOG_NOTICE(( "remove (%lu,%lu) erase=%i", rec->txn ? rec->txn->xid : 0UL, rec->key, erase ));
-
-  rec->erase = 1;
 }
 
 /* Mini funk implementation *******************************************/

--- a/src/funk/test_funk_common.h
+++ b/src/funk/test_funk_common.h
@@ -140,10 +140,6 @@ rec_insert( funk_t * funk,
             txn_t *  txn,
             ulong    key );
 
-void
-rec_remove( funk_t * funk,
-            rec_t *  rec );
-
 /* Mini funk API */
 
 funk_t *

--- a/src/funk/test_funk_rec.c
+++ b/src/funk/test_funk_rec.c
@@ -105,21 +105,9 @@ main( int     argc,
 
       rec_t *               rrec = rec_query_global( ref, NULL, rkey );
       fd_funk_rec_t const * trec = fd_funk_rec_query_try_global( tst, fd_funk_last_publish( tst ), tkey, NULL, rec_query );
-      if( !rrec || rrec->erase ) FD_TEST( !trec );
-      else                       FD_TEST( trec && xid_eq( fd_funk_rec_xid( trec ), rrec->txn ? rrec->txn->xid : ULONG_MAX ) );
+      if( !rrec ) FD_TEST( !trec );
+      else        FD_TEST( trec && xid_eq( fd_funk_rec_xid( trec ), rrec->txn ? rrec->txn->xid : ULONG_MAX ) );
       FD_TEST( !fd_funk_rec_query_test( rec_query ) );
-
-// #ifdef FD_FUNK_HANDHOLDING
-//       FD_TEST( fd_funk_rec_remove( NULL, NULL, NULL, NULL )==FD_FUNK_ERR_INVAL );
-//       FD_TEST( fd_funk_rec_remove( NULL, NULL, tkey, NULL )==FD_FUNK_ERR_INVAL );
-//       FD_TEST( fd_funk_rec_remove( tst, NULL, NULL, NULL )==FD_FUNK_ERR_INVAL );
-// #endif
-
-      // if( trec ) {
-      //   if( is_frozen ) {
-      //     FD_TEST( fd_funk_rec_remove( tst, fd_funk_last_publish( tst ), tkey, NULL )==FD_FUNK_ERR_FROZEN );
-      //   }
-      // }
 
 //       fd_funk_rec_prepare_t rec_prepare[1];
 //       int err;
@@ -190,21 +178,11 @@ main( int     argc,
 
       rec_t *               rrec = rec_query_global( ref, rtxn, rkey );
       fd_funk_rec_t const * trec = fd_funk_rec_query_try_global( tst, &ttxn->xid, tkey, NULL, rec_query );
-      if( !rrec || rrec->erase ) FD_TEST( !trec );
+      if( !rrec ) FD_TEST( !trec );
       else {
         FD_TEST( trec && xid_eq( fd_funk_rec_xid( trec ), rrec->txn ? rrec->txn->xid : ULONG_MAX ) );
       }
       FD_TEST( !fd_funk_rec_query_test( rec_query ) );
-
-// #ifdef FD_FUNK_HANDHOLDING
-//       FD_TEST( fd_funk_rec_remove( NULL, ttxn, NULL, NULL )==FD_FUNK_ERR_INVAL );
-//       FD_TEST( fd_funk_rec_remove( NULL, ttxn, tkey, NULL )==FD_FUNK_ERR_INVAL );
-//       FD_TEST( fd_funk_rec_remove( tst, ttxn, NULL, NULL )==FD_FUNK_ERR_INVAL );
-// #endif
-
-      // if( trec && ttxn_is_frozen ) {
-      //   FD_TEST( fd_funk_rec_remove( tst, &ttxn->xid, tkey, NULL )==FD_FUNK_ERR_FROZEN );
-      // }
 
 //       fd_funk_rec_prepare_t rec_prepare[1];
 //       int err;
@@ -333,18 +311,12 @@ main( int     argc,
       }
       ulong rkey = rrec->key;
 
-      rec_remove( ref, rrec );
-
       if( rxid ) xid_set( txid, rxid );
       else       fd_funk_txn_xid_copy( txid, fd_funk_last_publish( tst ) );
       fd_funk_rec_query_t query[1];
       fd_funk_rec_t const * trec = fd_funk_rec_query_try( tst, txid, key_set( tkey, rkey ), query );
       FD_TEST( trec );
       FD_TEST( !fd_funk_rec_query_test( query ) );
-
-      fd_funk_rec_t * trec2;
-      FD_TEST( !fd_funk_rec_remove( tst, txid, key_set( tkey, rkey ), &trec2 ) );
-      FD_TEST( trec == trec2 );
 
     } else if( op>=2 ) { /* Prepare 8x as publish and cancel combined */
 

--- a/src/funk/test_funk_txn2.cxx
+++ b/src/funk/test_funk_txn2.cxx
@@ -16,9 +16,6 @@ int main(int argc, char** argv) {
     for (uint i = 0; i < 50; ++i)
       ff.random_insert();
     ff.verify();
-    for (uint i = 0; i < 20; ++i)
-      ff.random_remove();
-    ff.verify();
     ff.random_publish();
     ff.verify();
     for (uint i = 0; i < 10; ++i)
@@ -26,9 +23,6 @@ int main(int argc, char** argv) {
     ff.verify();
     for (uint i = 0; i < 50; ++i)
       ff.random_insert();
-    ff.verify();
-    for (uint i = 0; i < 10; ++i)
-      ff.random_remove();
     ff.verify();
     ff.random_publish_into_parent();
     ff.verify();
@@ -38,9 +32,6 @@ int main(int argc, char** argv) {
     for (uint i = 0; i < 50; ++i)
       ff.random_insert();
     ff.verify();
-    for (uint i = 0; i < 10; ++i)
-      ff.random_remove();
-    ff.verify();
     ff.random_cancel();
     ff.verify();
     for (uint i = 0; i < 10; ++i)
@@ -48,9 +39,6 @@ int main(int argc, char** argv) {
     ff.verify();
     for (uint i = 0; i < 50; ++i)
       ff.random_insert();
-    ff.verify();
-    for (uint i = 0; i < 10; ++i)
-      ff.random_remove();
     ff.verify();
     ff.random_publish_into_parent();
     ff.verify();

--- a/src/funk/test_funk_val.c
+++ b/src/funk/test_funk_val.c
@@ -88,22 +88,11 @@ main( int     argc,
 
       FD_TEST( !fd_funk_rec_query_test( rec_query ) );
 
-      if( rrec->erase ) {
+      FD_TEST( _val && FD_LOAD( uint, _val )==rrec->val );
 
-        FD_TEST( !_val );
-
-        FD_TEST( !fd_funk_val_sz   ( trec ) );
-        FD_TEST( !fd_funk_val_max  ( trec ) );
-        FD_TEST( !fd_funk_val_const( trec, wksp ) );
-
-      } else {
-
-        FD_TEST( _val && FD_LOAD( uint, _val )==rrec->val );
-
-        FD_TEST( fd_funk_val_sz   ( trec       )==sizeof(uint)       );
-        FD_TEST( fd_funk_val_max  ( trec       )>=sizeof(uint)       );
-        FD_TEST( fd_funk_val_const( trec, wksp )==(void const *)_val );
-      }
+      FD_TEST( fd_funk_val_sz   ( trec       )==sizeof(uint)       );
+      FD_TEST( fd_funk_val_max  ( trec       )>=sizeof(uint)       );
+      FD_TEST( fd_funk_val_const( trec, wksp )==(void const *)_val );
 
       rrec = rrec->map_next;
     }
@@ -151,25 +140,6 @@ main( int     argc,
       TEST_TAIL_PADDING( 4UL );
 
     } else if( op>=18UL ) { /* Remove and insert at same rate */
-
-      if( FD_UNLIKELY( !ref->rec_cnt ) ) continue;
-
-      ulong   idx = fd_rng_ulong_roll( rng, ref->rec_cnt );
-      rec_t * rrec = ref->rec_map_head; for( ulong rem=idx; rem; rem-- ) rrec = rrec->map_next;
-
-      ulong rxid;
-      if( rrec->txn ) {
-        if( txn_is_frozen( rrec->txn ) ) continue;
-        rxid = rrec->txn->xid;
-      } else {
-        if( funk_is_frozen( ref ) ) continue;
-        rxid = ref->last_publish;
-      }
-      ulong rkey = rrec->key;
-
-      rec_remove( ref, rrec );
-
-      FD_TEST( !fd_funk_rec_remove( tst, xid_set( txid, rxid ), key_set( tkey, rkey ), NULL ) );
 
     } else if( op>=2 ) { /* Prepare 8x as publish and cancel combined */
 


### PR DESCRIPTION
Removes the concept of tombstones from funk, which are a rarely
exercised edge case.
