### PR TITLE
funk: refer to txns by XID (pt. 3)

### DIFF
--- a/src/flamenco/runtime/fd_acc_mgr.c
+++ b/src/flamenco/runtime/fd_acc_mgr.c
@@ -8,7 +8,7 @@ fd_funk_get_acc_meta_readonly( fd_funk_t const *         funk,
                                fd_pubkey_t const *       pubkey,
                                fd_funk_rec_t const **    orec,
                                int *                     opt_err,
-                               fd_funk_txn_t const **    txn_out ) {
+                               fd_funk_txn_xid_t *       out_xid ) {
   fd_funk_rec_key_t id = fd_funk_acc_key( pubkey );
 
   /* When we access this pointer later on in the execution pipeline, we assume that
@@ -18,9 +18,7 @@ fd_funk_get_acc_meta_readonly( fd_funk_t const *         funk,
   for( ; ; ) {
 
     fd_funk_rec_query_t   query[1];
-    fd_funk_txn_t const * dummy_txn_out[1];
-    if( !txn_out ) txn_out    = dummy_txn_out;
-    fd_funk_rec_t const * rec = fd_funk_rec_query_try_global( funk, xid, &id, txn_out, query );
+    fd_funk_rec_t const * rec = fd_funk_rec_query_try_global( funk, xid, &id, out_xid, query );
 
     if( FD_UNLIKELY( !rec ) )  {
       fd_int_store_if( !!opt_err, opt_err, FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT );

--- a/src/flamenco/runtime/fd_acc_mgr.h
+++ b/src/flamenco/runtime/fd_acc_mgr.h
@@ -144,9 +144,8 @@ fd_funk_key_is_acc( fd_funk_rec_key_t const * id ) {
    It is always wrong to cast return value to a non-const pointer.
    Instead, use fd_funk_get_acc_meta_mutable to acquire a mutable handle.
 
-   if txn_out is supplied (non-null), the txn the key was found in
-   is returned. If *txn_out == NULL, the key was found in the root
-   context.
+   If xid_out is supplied (non-null), sets *xid_out to the xid in which
+   the found record was created.
 
    IMPORTANT: fd_funk_get_acc_meta_readonly is only safe if it
    is guaranteed there are no other modifying accesses to the account. */
@@ -157,7 +156,7 @@ fd_funk_get_acc_meta_readonly( fd_funk_t const *         funk,
                                fd_pubkey_t const *       pubkey,
                                fd_funk_rec_t const **    orec,
                                int *                     opt_err,
-                               fd_funk_txn_t const **    txn_out ) ;
+                               fd_funk_txn_xid_t *       xid_out ) ;
 
 /* fd_funk_get_acc_meta_mutable requests a writable handle to an account.
    Follows interface of fd_funk_get_account_meta_readonly with the following

--- a/src/flamenco/stakes/fd_stake_delegations.h
+++ b/src/flamenco/stakes/fd_stake_delegations.h
@@ -176,11 +176,6 @@ struct fd_stake_delegations_iter {
 };
 typedef struct fd_stake_delegations_iter fd_stake_delegations_iter_t;
 
-struct fd_funk_private;
-typedef struct fd_funk_private fd_funk_t;
-struct fd_funk_txn_private;
-typedef struct fd_funk_txn_private fd_funk_txn_t;
-
 FD_PROTOTYPES_BEGIN
 
 /* fd_stake_delegations_align returns the alignment of the stake

--- a/src/funk/fd_funk.h
+++ b/src/funk/fd_funk.h
@@ -421,7 +421,7 @@ fd_funk_last_publish_child_tail( fd_funk_t *          funk,
    current local join.  The value at this pointer will always be the
    root transaction id. */
 
-FD_FN_CONST static inline fd_funk_txn_xid_t const * fd_funk_root( fd_funk_t * funk ) { return funk->shmem->root; }
+FD_FN_CONST static inline fd_funk_txn_xid_t const * fd_funk_root( fd_funk_t const * funk ) { return funk->shmem->root; }
 
 /* fd_funk_last_publish returns a pointer in the caller's address space
    to transaction id of the last published transaction.  Assumes funk is
@@ -429,7 +429,7 @@ FD_FN_CONST static inline fd_funk_txn_xid_t const * fd_funk_root( fd_funk_t * fu
    lifetime of the current local join.  The value at this pointer will
    be constant until the next transaction is published. */
 
-FD_FN_CONST static inline fd_funk_txn_xid_t const * fd_funk_last_publish( fd_funk_t * funk ) { return funk->shmem->last_publish; }
+FD_FN_CONST static inline fd_funk_txn_xid_t const * fd_funk_last_publish( fd_funk_t const * funk ) { return funk->shmem->last_publish; }
 
 /* fd_funk_is_frozen returns 1 if the records of the last published
    transaction are frozen (i.e. the funk has children) and 0 otherwise

--- a/src/funk/fd_funk_base.h
+++ b/src/funk/fd_funk_base.h
@@ -135,9 +135,6 @@ typedef struct fd_funk_shmem_private fd_funk_shmem_t;
 struct fd_funk_private;
 typedef struct fd_funk_private fd_funk_t;
 
-struct fd_funk_txn_private;
-typedef struct fd_funk_txn_private fd_funk_txn_t;
-
 FD_PROTOTYPES_BEGIN
 
 /* fd_funk_rec_key_hash provides a family of hashes that hash the key

--- a/src/funk/fd_funk_rec.c
+++ b/src/funk/fd_funk_rec.c
@@ -121,7 +121,7 @@ fd_funk_rec_t const *
 fd_funk_rec_query_try_global( fd_funk_t const *         funk,
                               fd_funk_txn_xid_t const * xid,
                               fd_funk_rec_key_t const * key,
-                              fd_funk_txn_t const **    txn_out,
+                              fd_funk_txn_xid_t *       txn_out,
                               fd_funk_rec_query_t *     query ) {
   if( FD_UNLIKELY( !funk  ) ) FD_LOG_CRIT(( "NULL funk"  ));
   if( FD_UNLIKELY( !key   ) ) FD_LOG_CRIT(( "NULL key"   ));
@@ -186,7 +186,9 @@ retry:
           fd_funk_txn_xid_eq_root( ele->pair.xid );
 
         if( FD_LIKELY( match ) ) {
-          if( txn_out ) *txn_out = cur_txn;
+          if( txn_out ) {
+            *txn_out = *( cur_txn ? &cur_txn->xid : fd_funk_last_publish( funk ) );
+          }
           query->ele = (fd_funk_rec_t *)ele;
           res = query->ele;
           goto found;

--- a/src/funk/fd_funk_rec.h
+++ b/src/funk/fd_funk_rec.h
@@ -203,8 +203,8 @@ int fd_funk_rec_query_test( fd_funk_rec_query_t * query );
    will query txn's ancestors for key from youngest to oldest if key is
    not part of txn.  As such, the txn of the returned record may not
    match txn but will be the txn of most recent ancestor with the key
-   otherwise. *txn_out is set to the transaction where the record was
-   found.
+   otherwise.   If xid_out!=NULLL, *xid_out is set to the XID in which
+   the record was created.
 
    This is reasonably fast O(in_prep_ancestor_cnt).
 
@@ -217,7 +217,7 @@ fd_funk_rec_t const *
 fd_funk_rec_query_try_global( fd_funk_t const *         funk,
                               fd_funk_txn_xid_t const * xid,
                               fd_funk_rec_key_t const * key,
-                              fd_funk_txn_t const **    txn_out,
+                              fd_funk_txn_xid_t *       xid_out,
                               fd_funk_rec_query_t *     query );
 
 /* fd_funk_rec_query_copy queries the in-preparation transaction pointed to


### PR DESCRIPTION
Updates last public funk API to use opaque XIDs instead of raw txn
pointers.
