### PR TITLE
resolv: fix stall parsing resolv.conf

### DIFF
--- a/src/waltz/resolv/Local.mk
+++ b/src/waltz/resolv/Local.mk
@@ -23,4 +23,7 @@ $(call make-fuzz-test,fuzz_dn_expand,fuzz_dn_expand,fd_waltz fd_util)
 $(call make-fuzz-test,fuzz_lookup_literal,fuzz_lookup_literal,fd_waltz fd_util)
 $(call make-fuzz-test,fuzz_dns_parse,fuzz_dns_parse,fd_waltz fd_util)
 
+$(call make-unit-test,test_resolv,test_resolv,fd_waltz fd_util)
+$(call run-unit-test,test_resolv)
+
 endif

--- a/src/waltz/resolv/fd_resolvconf.c
+++ b/src/waltz/resolv/fd_resolvconf.c
@@ -30,13 +30,15 @@ fd_get_resolv_conf( fd_resolvconf_t * conf ) {
   fd_io_buffered_istream_init( istream, fd_etc_resolv_conf_fd, rbuf, sizeof(rbuf) );
 
   char line[256];
-  int err;
-  while( fd_io_fgets( line, sizeof(line), istream, &err ) ) {
+  int fgets_err = 0;
+  while( fgets_err!=-1 &&
+         fd_io_fgets( line, sizeof(line), istream, &fgets_err ) ) {
     char * p, * z;
-    if( !strchr( line, '\n' ) && err==0 ) {
+    if( !strchr( line, '\n' ) && fgets_err==0 ) {
       /* Ignore lines that get truncated rather than
        * potentially misinterpreting them. */
       int c;
+      int err;
       do c = fd_io_fgetc( istream, &err );
       while( c!='\n' && c!=-1 );
       continue;

--- a/src/waltz/resolv/test_resolv.c
+++ b/src/waltz/resolv/test_resolv.c
@@ -1,0 +1,38 @@
+#define _GNU_SOURCE
+#include <sys/mman.h>
+#include <unistd.h>
+#include "fd_lookup.h"
+#include "../../util/fd_util.h"
+
+FD_IMPORT_BINARY( test_resolvconf, "src/waltz/resolv/test_resolvconf.txt" );
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  /* Test normal resolv.conf */
+
+  fd_etc_resolv_conf_fd = memfd_create( "resolv.conf", 0 );
+  FD_TEST( fd_etc_resolv_conf_fd>=0 );
+  ssize_t sz = write( fd_etc_resolv_conf_fd, test_resolvconf, test_resolvconf_sz );
+  FD_TEST( sz==(ssize_t)test_resolvconf_sz );
+  FD_TEST( 0==lseek( fd_etc_resolv_conf_fd, 0, SEEK_SET ) );
+  fd_resolvconf_t conf;
+  FD_TEST( 0==fd_get_resolv_conf( &conf ) );
+  FD_TEST( 0==close( fd_etc_resolv_conf_fd ) );
+
+  /* Chop off trailing newline */
+
+  fd_etc_resolv_conf_fd = memfd_create( "resolv.conf", 0 );
+  FD_TEST( fd_etc_resolv_conf_fd>=0 );
+  sz = write( fd_etc_resolv_conf_fd, test_resolvconf, test_resolvconf_sz-1UL );
+  FD_TEST( sz==(ssize_t)( test_resolvconf_sz-1UL ) );
+  FD_TEST( 0==lseek( fd_etc_resolv_conf_fd, 0, SEEK_SET ) );
+  FD_TEST( 0==fd_get_resolv_conf( &conf ) );
+  FD_TEST( 0==close( fd_etc_resolv_conf_fd ) );
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}

--- a/src/waltz/resolv/test_resolvconf.txt
+++ b/src/waltz/resolv/test_resolvconf.txt
@@ -1,0 +1,3 @@
+nameserver 127.0.0.53
+options edns0 trust-ad
+search .


### PR DESCRIPTION
Fixes an issue where fd_getaddrinfo() can infinite loop when
parsing an /etc/resolv.conf file without a trailing newline.

Caused by a difference in behavior between fgets and fd_io_fgets
when porting from musl.

Reported-by: Vadym Boronichev at Everstake
