### PR TITLE
xdp: fix netlnk updates

### DIFF
--- a/src/disco/net/xdp/fd_xdp_tile.c
+++ b/src/disco/net/xdp/fd_xdp_tile.c
@@ -376,7 +376,7 @@ net_load_netdev_tbl( fd_net_ctx_t * ctx ) {
   if( FD_UNLIKELY( !fd_dbl_buf_read( ctx->netdev_dbl_buf, ctx->netdev_buf_sz, ctx->netdev_buf, NULL ) ) ) return;
 
   /* Join local copy */
-  if( FD_UNLIKELY( !fd_netdev_tbl_join( &ctx->netdev_dbl_buf, ctx->netdev_buf ) ) ) FD_LOG_ERR(("netdev table join failed"));
+  if( FD_UNLIKELY( !fd_netdev_tbl_join( &ctx->netdev_tbl, ctx->netdev_buf ) ) ) FD_LOG_ERR(("netdev table join failed"));
 }
 
 /* Query the netdev table. Return a fd_netdev_t pointer to the net device of the


### PR DESCRIPTION
Every housekeeping, the xdp tile loads the netdev table from the netlnk tile. Loading involves 1) copying the remote table into a local buffer and 2) populating a netdev_tbl_join with metadata about the newly copied data. Then, when looking up routes, we use this local join. 

The xdp tile currently populates the correct join during init, and uses the correct join during query time.... however, the ongoing updates mistake the remote buffer for the join. This 1) clobbers the remote buffer, causing subsequent reads to exit early; and 2) does not update the header in the local join, causing us to miss devices that were added after starting the validator.

This PR fixes this claudian bug 😄 