### PR TITLE
runtime: fix txn_account perf issue

### DIFF
--- a/src/flamenco/runtime/fd_txn_account.h
+++ b/src/flamenco/runtime/fd_txn_account.h
@@ -36,9 +36,7 @@ struct __attribute__((aligned(8UL))) fd_txn_account {
   uchar *                         data;
 
   int                             is_mutable;
-
-  ulong                           meta_gaddr;
-  ulong                           data_gaddr;
+  long                            meta_soff;
 
   ulong                           starting_dlen;
   ulong                           starting_lamports;


### PR DESCRIPTION
fd_wksp_containing is expensive.  txn_account needs to be
rewritten entirely at some point, but this is good enough for now.
