### PR TITLE
gossip: fix gossip publishing invalid UDP datagrams

### DIFF
--- a/src/app/firedancer-dev/commands/gossip.c
+++ b/src/app/firedancer-dev/commands/gossip.c
@@ -762,6 +762,7 @@ gossip_cmd_fn( args_t *   args,
   printf("Found %lu gossvf tiles\n", gossvf_tiles.tile_count);
 
   ulong net_tile_idx = fd_topo_find_tile( &config->topo, "net", 0UL );
+  if ( net_tile_idx==ULONG_MAX ) net_tile_idx = fd_topo_find_tile( &config->topo, "sock", 0UL );
   FD_TEST( net_tile_idx!=ULONG_MAX );
   fd_topo_tile_t * net_tile = &config->topo.tiles[ net_tile_idx ];
 

--- a/src/discof/gossip/fd_gossip_tile.c
+++ b/src/discof/gossip/fd_gossip_tile.c
@@ -62,7 +62,7 @@ gossip_send_fn( void *                ctx,
   fd_memcpy( packet+sizeof(fd_ip4_udp_hdrs_t), payload, payload_sz );
 
   ulong tspub     = fd_frag_meta_ts_comp( fd_tickcount() );
-  ulong sig       = fd_disco_netmux_sig( peer_address->addr, peer_address->port, peer_address->addr, DST_PROTO_OUTGOING, 0UL /* ignored */ );
+  ulong sig       = fd_disco_netmux_sig( peer_address->addr, peer_address->port, peer_address->addr, DST_PROTO_OUTGOING, sizeof(fd_ip4_udp_hdrs_t) );
   ulong packet_sz = payload_sz + sizeof(fd_ip4_udp_hdrs_t);
 
   fd_stem_publish( stem, gossip_ctx->net_out->idx, sig, gossip_ctx->net_out->chunk, packet_sz, 0UL, tspub, tsorig );


### PR DESCRIPTION
While the header_sz mcache sig is ignored by the XDP tile it is used by the socket tile. This commit also fixes consistently getting the socket tile in the standalone gossip topology.