### PR TITLE
fix: stray legacy skip_cnt update

### DIFF
--- a/src/disco/pack/fd_pack_tile.c
+++ b/src/disco/pack/fd_pack_tile.c
@@ -737,7 +737,6 @@ after_credit( fd_pack_ctx_t *     ctx,
       ctx->pack_txn_cnt += schedule_cnt;
 
       ctx->bank_idle_bitset = fd_ulong_pop_lsb( ctx->bank_idle_bitset );
-      ctx->skip_cnt         = (long)schedule_cnt * fd_long_if( ctx->use_consumed_cus, (long)bank_cnt/2L, 1L );
       fd_pack_pacing_update_consumed_cus( ctx->pacer, fd_pack_current_block_cost( ctx->pack ), now2 );
 
       memcpy( ctx->last_sched_metrics->all, (ulong const *)fd_metrics_tl, sizeof(ctx->last_sched_metrics->all) );


### PR DESCRIPTION
forgot to remove one... see ≈4 active LOC down