### PR TITLE
runtime: fix UAF from spad lifetime mismatch in prepare_and_execute_txn

### DIFF
--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -1213,10 +1213,8 @@ fd_runtime_prepare_and_execute_txn( fd_banks_t *        banks,
                                     ulong               bank_idx,
                                     fd_exec_txn_ctx_t * txn_ctx,
                                     fd_txn_p_t *        txn,
-                                    fd_spad_t *         exec_spad,
                                     fd_capture_ctx_t *  capture_ctx,
                                     uchar               do_sigverify ) {
-  FD_SPAD_FRAME_BEGIN( exec_spad ) {
   int exec_res = 0;
 
   fd_bank_t * bank = fd_banks_bank_query( banks, bank_idx );
@@ -1268,7 +1266,6 @@ fd_runtime_prepare_and_execute_txn( fd_banks_t *        banks,
 
   return exec_res;
 
-  } FD_SPAD_FRAME_END;
 }
 
 /* fd_executor_txn_verify and fd_runtime_pre_execute_check are responisble

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -461,7 +461,6 @@ fd_runtime_prepare_and_execute_txn( fd_banks_t *        banks,
                                     ulong               bank_idx,
                                     fd_exec_txn_ctx_t * txn_ctx,
                                     fd_txn_p_t *        txn,
-                                    fd_spad_t *         exec_spad,
                                     fd_capture_ctx_t *  capture_ctx,
                                     uchar               do_sigverify );
 

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -353,7 +353,6 @@ fd_runtime_fuzz_txn_ctx_exec( fd_solfuzz_runner_t *     runner,
       0UL,
       txn_ctx,
       txn,
-      runner->spad,
       NULL,
       0 );
 


### PR DESCRIPTION
fd_runtime_prepare_and_execute_txn wrapped allocations in an internal FD_SPAD_FRAME, so allocations like rollback fee payer were freed before fd_runtime_finalize_txn consumed them