### PR TITLE
backtest, firedancer: fix solcap race

### DIFF
--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -212,7 +212,6 @@ fd_topo_initialize( config_t * config ) {
   ulong sign_tile_cnt   = config->firedancer.layout.sign_tile_count;
 
   int snapshots_enabled = !!config->gossip.entrypoints_cnt;
-  int solcap_enabled = strcmp( "", config->capture.solcap_capture );
 
   fd_topo_t * topo = fd_topob_new( &config->topo, config->name );
 
@@ -646,15 +645,6 @@ fd_topo_initialize( config_t * config ) {
   FOR(exec_tile_cnt) fd_topob_tile_out( topo, "exec",      i,                               "exec_replay", i );
   FOR(exec_tile_cnt) fd_topob_tile_in(  topo, "replay",    0UL,    "metric_in", "exec_replay", i, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
   FOR(exec_tile_cnt) fd_topob_tile_in(  topo, "exec",      i,      "metric_in", "send_txns", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
-
-  if( FD_UNLIKELY( solcap_enabled ) ) {
-    /* Capture account updates, whose updates must be centralized in the replay tile as solcap is currently not thread-safe.
-      TODO: remove this when solcap v2 is here. */
-    fd_topob_wksp( topo, "capt_replay" );
-    FOR(exec_tile_cnt) fd_topob_link(     topo, "capt_replay", "capt_replay", FD_CAPTURE_CTX_MAX_ACCOUNT_UPDATES, FD_CAPTURE_CTX_ACCOUNT_UPDATE_MSG_FOOTPRINT, 1UL );
-    FOR(exec_tile_cnt) fd_topob_tile_out( topo, "exec",      i,                               "capt_replay", i );
-    FOR(exec_tile_cnt) fd_topob_tile_in(  topo, "replay",    0UL,         "metric_in",        "capt_replay", i, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
-  }
 
   if( FD_LIKELY( config->tiles.gui.enabled ) ) {
     fd_topob_wksp( topo, "gui" );

--- a/src/discof/replay/fd_exec.h
+++ b/src/discof/replay/fd_exec.h
@@ -151,7 +151,9 @@ fd_slice_exec_slot_complete( fd_slice_exec_t const * slice_exec_ctx ) {
 
 /**********************************************************************/
 
-#define EXEC_NEW_TXN_SIG (0x777777UL)
+#define FD_REPLAY_EXEC_NEW_TXN_SIG       (0x777777UL)
+#define FD_EXEC_REPLAY_TXN_FINALIZED_SIG (0x888888UL)
+#define FD_EXEC_REPLAY_SOLCAP_UPDATE_SIG (0x999999UL)
 
 /* fd_exec_txn_msg_t is the message that is sent from the replay tile to
    the exec tiles.  This represents all of the information that is needed


### PR DESCRIPTION
Using a separate exec->replay link for solcap account updates introduces a race. Solcap is being re-written, but in the meantime this PR:

- Removes the ability to capture solcaps from the full client, as this was unuused.
- Consolidates the solcap account updates and the txn finalization messages from exec->replay into a single `exec_replay` link, to avoid the race.
- Adjusts the depth and MTU of the `exec_replay` link if solcap is enabled, so that normal backtest runs do not have excessive memory requirements.