### PR TITLE
tls: fix test_tls_openssl with upstream OSSL

### DIFF
--- a/src/waltz/tls/Local.mk
+++ b/src/waltz/tls/Local.mk
@@ -10,9 +10,7 @@ $(call make-fuzz-test,fuzz_tls,fuzz_tls,fd_tls fd_ballet fd_util)
 $(call make-fuzz-test,fuzz_tls_msg_parser,fuzz_tls_msg_parser,fd_tls fd_ballet fd_util)
 endif
 
-# Uncomment this to test against quictls.  Upstream OpenSSL does not
-# support this test.
-#ifdef FD_HAS_OPENSSL
-#$(call make-unit-test,test_tls_openssl,test_tls_openssl,fd_quic fd_tls fd_ballet fd_util,-lssl -lcrypto)
-#$(call run-unit-test,test_tls_openssl)
-#endif
+ifdef FD_HAS_OPENSSL
+$(call make-unit-test,test_tls_openssl,test_tls_openssl,fd_quic fd_tls fd_ballet fd_util,-lssl -lcrypto)
+$(call run-unit-test,test_tls_openssl)
+endif


### PR DESCRIPTION
This PR revives test_tls_openssl with upstream OpenSSL. Most changes are because the core API switched to callback-oriented, instead of push-oriented. + some deduplication