### PR TITLE
firedancer-dev: read gossvf config parameters

### DIFF
--- a/src/app/firedancer-dev/commands/gossip.c
+++ b/src/app/firedancer-dev/commands/gossip.c
@@ -86,8 +86,8 @@ fd_gossip_subtopo( config_t * config, ulong tile_to_cpu[ FD_TILE_MAX ] FD_PARAM_
     fd_topo_tile_t * gossvf_tile = fd_topob_tile( topo, "gossvf", "gossvf", "metric_in", 0UL, 0, 1 );
     strncpy( gossvf_tile->gossvf.identity_key_path, config->paths.identity_key, sizeof(gossvf_tile->gossvf.identity_key_path) );
     gossvf_tile->gossvf.tcache_depth = 1UL<<22UL;
-    gossvf_tile->gossvf.shred_version = 0;
-    gossvf_tile->gossvf.allow_private_address = 0;
+    gossvf_tile->gossvf.shred_version = config->consensus.expected_shred_version;
+    gossvf_tile->gossvf.allow_private_address = config->development.gossip.allow_private_address;
     gossvf_tile->gossvf.entrypoints_cnt = config->gossip.entrypoints_cnt;
     gossvf_tile->gossvf.boot_timestamp_nanos = config->boot_timestamp_nanos;
     for( ulong i=0UL; i<config->gossip.entrypoints_cnt; i++ ) {


### PR DESCRIPTION
Currently, firedancer-dev hardcodes `shred_version` and `allow_private_address` both to 0. This prevents use on local deployments without a source of shreds.

This PR sets both parameters to the values from the config.