### PR TITLE
quic: fix pkt_meta remove and abandon_enc_level

### DIFF
--- a/src/waltz/quic/fd_quic_pkt_meta.c
+++ b/src/waltz/quic/fd_quic_pkt_meta.c
@@ -59,6 +59,14 @@ fd_quic_pkt_meta_remove_range( fd_quic_pkt_meta_ds_t * ds,
   return cnt_removed;
 }
 
+void
+fd_quic_pkt_meta_remove( fd_quic_pkt_meta_ds_t * ds,
+                         fd_quic_pkt_meta_t    * pool,
+                         fd_quic_pkt_meta_t    * pkt_meta ) {
+  fd_quic_pkt_meta_treap_ele_remove( ds, pkt_meta, pool );
+  fd_quic_pkt_meta_pool_ele_release( pool, pkt_meta );
+}
+
 fd_quic_pkt_meta_t *
 fd_quic_pkt_meta_min( fd_quic_pkt_meta_ds_t * ds,
                       fd_quic_pkt_meta_t    * pool ) {

--- a/src/waltz/quic/fd_quic_pkt_meta.h
+++ b/src/waltz/quic/fd_quic_pkt_meta.h
@@ -258,6 +258,16 @@ fd_quic_pkt_meta_remove_range( fd_quic_pkt_meta_ds_t * ds,
                                ulong                   pkt_number_lo,
                                ulong                   pkt_number_hi );
 
+/* fd_quic_pkt_meta_remove removes a single pkt_meta from the ds and returns it to the pool.
+@arguments:
+- ds: pointer to the ds
+- pool: pointer to the backing pool
+- pkt_meta: pointer to the pkt_meta to remove. Assumed non-null */
+void
+fd_quic_pkt_meta_remove( fd_quic_pkt_meta_ds_t * ds,
+                       fd_quic_pkt_meta_t    * pool,
+                       fd_quic_pkt_meta_t    * pkt_meta );
+
 /* fd_quic_pkt_meta_min returns pointer to pkt_meta with smallest pkt_number in the ds
   @arguments:
   - ds: pointer to the ds
@@ -268,10 +278,10 @@ fd_quic_pkt_meta_t *
 fd_quic_pkt_meta_min( fd_quic_pkt_meta_ds_t * ds,
                       fd_quic_pkt_meta_t    * pool );
 
-/* fd_quic_pkt_meta_ds_clear clears all pkt_meta tracking for a given encoding level
+/* fd_quic_pkt_meta_ds_clear clears all pkt_meta tracking for a given encryption level
   @arguments:
   - tracker: pointer to the pkt_meta tracker
-  - enc_level: encoding level to clear */
+  - enc_level: encryption level to clear */
 void
 fd_quic_pkt_meta_ds_clear( fd_quic_pkt_meta_tracker_t * tracker,
                            uint                         enc_level );


### PR DESCRIPTION
This PR: 
1. Fixes a bug in pkt_meta_retry where we were abandoning the old enc level rather than the new one
2. Switches the same call site as 1) to just reclaim the pkt meta, rather than clear out the keys for the enc level --> 'no-key' drops for initial and appdata encryption levels dropped significantly. 
3. Fixes a bug where we'd retry only one frame from each packet (incorrect usage of pkt_meta_remove_range)
4. Refactors to reclaim and free all pkt_meta at a given enc level, supporting the above

[ad9da7db](https://github.com/firedancer-io/firedancer/commit/ad9da7db43870a0511d2a41477ce70012467b3e3) started running on val4 on 2025-10-13 at 16:55:21 CST. 