### PR TITLE
Chore: fix typos in comment

### DIFF
--- a/src/waltz/h2/fd_h2_conn.h
+++ b/src/waltz/h2/fd_h2_conn.h
@@ -217,7 +217,7 @@ fd_h2_tx_commit( fd_h2_conn_t *       conn,
 }
 
 /* fd_h2_tx is a slow streamlined variant of fd_h2_tx_{prepare,commit}.
-   This variant assumes that the frame paylaod is already available in
+   This variant assumes that the frame payload is already available in
    a separate buffer. */
 
 static inline void

--- a/src/waltz/h2/fd_h2_hdr_match.h
+++ b/src/waltz/h2/fd_h2_hdr_match.h
@@ -72,7 +72,7 @@ extern FD_TL ulong fd_h2_hdr_match_seed;
 #include "../../util/tmpl/fd_map.c"
 
 /* A h2_hdr_matcher is used to build a hash table for common header
-   names.  It is primarly designed for compile-time static lists of
+   names.  It is primarily designed for compile-time static lists of
    headers that a user might be interested in.  The user should not
    insert arbitrary entries into the map. */
 

--- a/src/waltz/http/fd_http_server.h
+++ b/src/waltz/http/fd_http_server.h
@@ -11,10 +11,10 @@
 
    The server does not allocate and has a built in allocation strategy
    and memory region for outgoing messages which the caller should use.
-   HTTP repsonse bodies and WebSocket frames are placed into an outgoing
+   HTTP response bodies and WebSocket frames are placed into an outgoing
    ring buffer, wrapping around when reaching the end, and the server
    will automatically evict slow clients that do not read their messages
-   in time and would be overwriten when the buffer has wrapped fully
+   in time and would be overwritten when the buffer has wrapped fully
    around.
 
    Using the outgoing ring has two steps,
@@ -304,7 +304,7 @@ fd_http_server_close( fd_http_server_t * http,
                       ulong              conn_id,
                       int                reason );
 
-/* Close an active WebSocket conection.  The connection ID must be an
+/* Close an active WebSocket connection.  The connection ID must be an
    open WebSocket connection ID in [0, max_ws_connection_cnt).  The
    connection will be forcibly (ungracefully) terminated.  The
    connection ID is released and should not be used again, as it may be

--- a/src/waltz/xdp/fd_xdp1.c
+++ b/src/waltz/xdp/fd_xdp1.c
@@ -146,7 +146,7 @@ fd_xdp_gen_program( ulong          code_buf[ 512 ],
   *(code++) = FD_EBPF( ldxh, r5, r2, 0                          );  // r5 = gre_hdr->flags/version
   *(code++) = FD_EBPF( jne_imm, r5, 0x0000, LBL_PASS            );  // if gre_hdr->flags/version != 0, goto LBL_PASS
   *(code++) = FD_EBPF( ldxh, r5, r2, 2                          );  // r5 = gre_hdr->protocol
-  *(code++) = FD_EBPF( jne_imm, r5, 0x0008, LBL_PASS            );  // if gre_hdr->protocl != IP, goto LBL_PASS
+  *(code++) = FD_EBPF( jne_imm, r5, 0x0008, LBL_PASS            );  // if gre_hdr->protocol != IP, goto LBL_PASS
 
 
   /* Advance r2 to start of inner ip4_hdr */

--- a/src/wiredancer/platform/f1/design/cl_dram_dma.sv
+++ b/src/wiredancer/platform/f1/design/cl_dram_dma.sv
@@ -30,7 +30,7 @@ module cl_dram_dma #(parameter NUM_DDR=4)
 // TIE OFF ALL UNUSED INTERFACES
 // Including all the unused interface to tie off
 // This list is put in the top of the fie to remind
-// developers to remve the specific interfaces
+// developers to remove the specific interfaces
 // that the CL will use
 
 `include "unused_flr_template.inc"

--- a/src/wiredancer/rtl/schl_cpu.sv
+++ b/src/wiredancer/rtl/schl_cpu.sv
@@ -93,7 +93,7 @@ package schl_pkg;
     ST_IDLE  = 4'd1, // Wait for new hash
     ST_FETCH = 4'd2, // Read data from memory
     ST_EXEC0 = 4'd3, // Start send data to primitive
-    ST_EXEC1 = 4'd4, // Propegate send data to primitive
+    ST_EXEC1 = 4'd4, // Propagate send data to primitive
     ST_BLOCK = 4'd5, // Wait for result from primitive
     ST_JMP   = 4'd6  // Jump to another instr (unused for now)
   } ssm_state_t; 
@@ -639,7 +639,7 @@ module shcl_cpu
           mem_t_wr_en   <= '0;
         end
       end
-      // Prioritize writes from ALU over input as we don't want to backpress the pipline...
+      // Prioritize writes from ALU over input as we don't want to backpress the pipeline...
       else if (mem_man_valid) begin 
         mem_d_wr_data <= mem_man_data;
         mem_d_wr_addr <= mem_man_addr;
@@ -990,7 +990,7 @@ module schl #
   input var logic              i_valid,
   output    logic              i_ready,
 
-  // Result Ouput 
+  // Result Output 
   output logic [W_HASH-1:0] o_hash,
   output logic              o_valid,
   output logic              o_correct 


### PR DESCRIPTION
Fixed a few small spelling typos across files :
 paylaod → payload,
 primarly → primarily,
 repsonse → response,
 overwriten → overwritten,
 conection → connection, 
 protocl → protocol,
 remve → remove,
 pipline → pipeline,
 Propegate → Propagate,
Ouput  → Output
