### PR TITLE
fix wrong fd_pool acquire usage

### DIFF
--- a/src/discof/restore/utils/fd_http_resolver.c
+++ b/src/discof/restore/utils/fd_http_resolver.c
@@ -185,8 +185,10 @@ fd_http_resolver_join( void * shresolver ) {
 void
 fd_http_resolver_add( fd_http_resolver_t * resolver,
                       fd_ip4_port_t        addr ) {
+  if( !peer_pool_free( resolver->pool ) ) {
+    FD_LOG_ERR(( "peer pool exhausted" ));
+  }
   fd_ssresolve_peer_t * peer = peer_pool_ele_acquire( resolver->pool );
-  FD_TEST( peer );
   peer->state                        = PEER_STATE_UNRESOLVED;
   peer->addr                         = addr;
   peer->fd.idx                       = ULONG_MAX;

--- a/src/flamenco/rewards/fd_rewards.c
+++ b/src/flamenco/rewards/fd_rewards.c
@@ -501,10 +501,10 @@ calculate_stake_vote_rewards_account( fd_bank_t *                               
       / written to once among all threads. */
 
 
-    fd_stake_reward_t * stake_reward = fd_stake_reward_calculation_pool_ele_acquire( result->stake_reward_calculation.pool );
-    if( FD_UNLIKELY( !stake_reward ) ) {
+    if( FD_UNLIKELY( !fd_stake_reward_calculation_pool_free( result->stake_reward_calculation.pool ) ) ) {
       FD_LOG_CRIT(( "insufficient space allocated for stake reward calculation pool" ));
     }
+    fd_stake_reward_t * stake_reward = fd_stake_reward_calculation_pool_ele_acquire( result->stake_reward_calculation.pool );
 
     fd_memcpy( stake_reward->stake_pubkey.uc, &stake_delegation->stake_account, sizeof(fd_pubkey_t) );
     stake_reward->lamports         = calculated_stake_rewards->staker_rewards;

--- a/src/flamenco/runtime/fd_bank.c
+++ b/src/flamenco/runtime/fd_bank.c
@@ -461,12 +461,12 @@ fd_banks_init_bank( fd_banks_t * banks ) {
 
   fd_rwlock_write( &banks->rwlock );
 
-  fd_bank_t * bank = fd_banks_pool_ele_acquire( bank_pool );
-  if( FD_UNLIKELY( bank==NULL ) ) {
+  if( FD_UNLIKELY( !fd_banks_pool_free( bank_pool ) ) ) {
     FD_LOG_WARNING(( "Failed to acquire bank" ));
     fd_rwlock_unwrite( &banks->rwlock );
     return NULL;
   }
+  fd_bank_t * bank = fd_banks_pool_ele_acquire( bank_pool );
 
   #define HAS_COW_1(type, name, footprint) \
     bank->name##_dirty    = 0;             \


### PR DESCRIPTION
calling acquire on a pool with no space left is UB and cannot be assumed to return NULL