### PR TITLE
repair: queue-based repair replacement for tree-traversal

### DIFF
--- a/src/discof/forest/fd_forest.c
+++ b/src/discof/forest/fd_forest.c
@@ -969,20 +969,8 @@ fd_forest_preorder_print( fd_forest_t const * forest ) {
   printf( "\n\n" );
 }
 
-/* TODO use bit tricks / change */
-static int
-num_digits( ulong slot ) {
-  /* using log10 */
-  int digits = 0;
-  while( slot ) {
-    digits++;
-    slot /= 10;
-  }
-  return digits;
-}
-
 static void
-ancestry_print2( fd_forest_t const * forest,
+orphaned_print( fd_forest_t const * forest,
                  fd_forest_blk_t const    * ele,
                  fd_forest_blk_t const    * prev,
                  ulong        last_printed,
@@ -992,7 +980,7 @@ ancestry_print2( fd_forest_t const * forest,
   if( FD_UNLIKELY( ele == NULL ) ) return;
 
   fd_forest_blk_t const * pool = fd_forest_pool_const( forest );
-  int digits = num_digits( ele->slot );
+  int digits = (int)fd_ulong_base10_dig_cnt( ele->slot );
 
   /* If there is a prefix, this means we are on a fork,  and we need to
      indent to the correct depth. We do depth - 1 for more satisfying
@@ -1024,7 +1012,7 @@ ancestry_print2( fd_forest_t const * forest,
       depth += digits + 6;
     } else {
       printf( ", %lu] ── [%lu", prev->slot, ele->slot );
-      depth += digits + num_digits(prev->slot ) + 8;
+      depth += digits + (int)fd_ulong_base10_dig_cnt( prev->slot ) + 8;
     }
     last_printed = ele->slot;
   } else if( curr && curr->sibling != ULONG_MAX ) { // has multiple children, do not elide
@@ -1052,9 +1040,9 @@ ancestry_print2( fd_forest_t const * forest,
   new_prefix[0] = '\0'; /* first fork stays on the same line, no prefix */
   while( curr ) {
     if( fd_forest_pool_ele_const( pool, curr->sibling ) ) {
-      ancestry_print2( forest, curr, new_prev, last_printed, depth, new_prefix );
+      orphaned_print( forest, curr, new_prev, last_printed, depth, new_prefix );
     } else {
-      ancestry_print2( forest, curr, new_prev, last_printed, depth, new_prefix );
+      orphaned_print( forest, curr, new_prev, last_printed, depth, new_prefix );
     }
     curr = fd_forest_pool_ele_const( pool, curr->sibling );
 
@@ -1069,7 +1057,7 @@ ancestry_print2( fd_forest_t const * forest,
 }
 
 static void
-ancestry_print3( fd_forest_t const * forest, fd_forest_blk_t const * ele, int space, const char * prefix, fd_forest_blk_t const * prev, int elide ) {
+ancestry_print( fd_forest_t const * forest, fd_forest_blk_t const * ele, int space, const char * prefix, fd_forest_blk_t const * prev, int elide ) {
   fd_forest_blk_t const * pool = fd_forest_pool_const( forest );
 
   if( ele == NULL ) return;
@@ -1104,21 +1092,21 @@ ancestry_print3( fd_forest_t const * forest, fd_forest_blk_t const * ele, int sp
       /* current slot wasn't printed, but now that we are branching,
          we will want to print the current slot and close the bracket */
       printf( ", %lu]", ele->slot );
-      space += fd_int_max( num_digits( ele->slot ) + 2, 0 );
+      space += fd_int_max( (int)fd_ulong_base10_dig_cnt( ele->slot ) + 2, 0 );
     } else {
       printf( "]");
     }
 
     sprintf( new_prefix, "└── [" ); /* end branch */
-    ancestry_print3( forest, child, space + 5, new_prefix, prev, 0 );
+    ancestry_print( forest, child, space + 5, new_prefix, prev, 0 );
   } else if ( one_child && child->slot == ele->slot + 1 ) {
-    ancestry_print3( forest, child, space, prefix, prev, 1);
+    ancestry_print( forest, child, space, prefix, prev, 1);
   } else { /* multiple children */
     if( elide ) {
       /* current slot wasn't printed, but now that we are branching,
          we will want to print the current slot and close the bracket */
       printf( ", %lu]", ele->slot );
-      space += fd_int_max( num_digits( ele->slot ) + 2, 0 );
+      space += fd_int_max( (int)fd_ulong_base10_dig_cnt( ele->slot ) + 2, 0 );
     } else {
       printf( "]");
     }
@@ -1126,10 +1114,10 @@ ancestry_print3( fd_forest_t const * forest, fd_forest_blk_t const * ele, int sp
     while( child ) {
       if( fd_forest_pool_ele_const( pool, child->sibling ) ) {
         sprintf( new_prefix, "├── [" ); /* branch indicating more siblings follow */
-        ancestry_print3( forest, child, space + 5, new_prefix, prev, 0 );
+        ancestry_print( forest, child, space + 5, new_prefix, prev, 0 );
       } else {
         sprintf( new_prefix, "└── [" ); /* end branch */
-        ancestry_print3( forest, child, space + 5, new_prefix, prev, 0 );
+        ancestry_print( forest, child, space + 5, new_prefix, prev, 0 );
       }
       child = fd_forest_pool_ele_const( pool, child->sibling );
     }
@@ -1139,7 +1127,7 @@ ancestry_print3( fd_forest_t const * forest, fd_forest_blk_t const * ele, int sp
 void
 fd_forest_ancestry_print( fd_forest_t const * forest ) {
   printf(("\n\n[Ancestry]\n" ) );
-  ancestry_print3( forest, fd_forest_pool_ele_const( fd_forest_pool_const( forest ), forest->root ), 0, "[", NULL, 0 );
+  ancestry_print( forest, fd_forest_pool_ele_const( fd_forest_pool_const( forest ), forest->root ), 0, "[", NULL, 0 );
   fflush(stdout); /* Ensure ancestry printf output is flushed */
 }
 
@@ -1169,7 +1157,7 @@ fd_forest_orphaned_print( fd_forest_t const * forest ) {
        !fd_forest_subtrees_iter_done( iter, subtrees, pool );
        iter = fd_forest_subtrees_iter_next( iter, subtrees, pool ) ) {
     fd_forest_blk_t const * ele = fd_forest_subtrees_iter_ele_const( iter, subtrees, pool );
-    ancestry_print2( forest, fd_forest_pool_ele_const( fd_forest_pool_const( forest ), fd_forest_pool_idx( pool, ele ) ), NULL, 0, 0, "" );
+    orphaned_print( forest, fd_forest_pool_ele_const( fd_forest_pool_const( forest ), fd_forest_pool_idx( pool, ele ) ), NULL, 0, 0, "" );
   }
   fflush(stdout);
 }

--- a/src/discof/forest/fd_forest.c
+++ b/src/discof/forest/fd_forest.c
@@ -149,6 +149,10 @@ requests_remove( fd_forest_t * forest, ulong pool_idx ) {
   fd_forest_ref_t      * pool     = fd_forest_reqspool( forest );
   fd_forest_ref_t      * ele;
   if( FD_LIKELY( ele = fd_forest_requests_ele_remove( requests, &pool_idx, NULL, pool ) ) ) {
+    /* invalidate the iterator if it is on the removed slot. */
+    if( FD_UNLIKELY( forest->iter.ele_idx == pool_idx ) ) {
+      forest->iter.ele_idx = ULONG_MAX;
+    }
     fd_forest_reqslist_ele_remove( fd_forest_reqslist( forest ), ele, pool );
     fd_forest_reqspool_ele_release( pool, ele );
   }
@@ -632,8 +636,7 @@ fd_forest_blk_insert( fd_forest_t * forest, ulong slot, ulong parent_slot ) {
                  fd_forest_frontier_ele_query( frontier, &ele->slot, NULL, pool ) ) ) {
     /* There is a chance that we connected this ele to the main tree. If
        this ele doesn't have a parent in the consumed/requests map, add it to the
-       consumed/requests map. If there are no requests in the deque though
-       (common case after catchup), don't even bother iterating. */
+       consumed/requests map. */
     ulong ancestor = fd_forest_pool_idx( pool, ele );
     int   has_requests_anc = 0;
     int   has_consumed_anc = 0;
@@ -760,6 +763,7 @@ fd_forest_publish( fd_forest_t * forest, ulong new_root_slot ) {
   fd_forest_orphaned_t * orphaned = fd_forest_orphaned( forest );
   fd_forest_frontier_t * frontier = fd_forest_frontier( forest );
   fd_forest_subtrees_t * subtrees = fd_forest_subtrees( forest );
+  fd_forest_ref_t *      conspool = fd_forest_conspool( forest );
   fd_forest_blk_t *      pool     = fd_forest_pool( forest );
   ulong                  null     = fd_forest_pool_idx_null( pool );
   ulong *                queue    = fd_forest_deque( forest );
@@ -849,7 +853,7 @@ fd_forest_publish( fd_forest_t * forest, ulong new_root_slot ) {
      In that case we need to continue repairing from the new root, so
      add it to the consumed map. */
 
-  if( FD_UNLIKELY( fd_forest_conspool_used( fd_forest_conspool( forest ) ) == 0 ) ) {
+  if( FD_UNLIKELY( fd_forest_conslist_is_empty( fd_forest_conslist( forest ), conspool ) ) ) {
     consumed_insert( forest, fd_forest_pool_idx( pool, new_root_ele ) );
     requests_insert( forest, fd_forest_pool_idx( pool, new_root_ele ) );
     new_root_ele->complete_idx = 0;
@@ -956,14 +960,23 @@ fd_forest_iter_next( fd_forest_t * forest ) {
           requests_insert( forest, fd_forest_pool_idx( pool, child ) );
           child = fd_forest_pool_ele_const( pool, child->sibling );
         }
-        requests_remove( forest, iter->ele_idx );  /* remove finished slot from head of requests deque */
-        if( FD_UNLIKELY( ele->complete_idx == UINT_MAX ) ) {
-          /* if we just made a highest_window_idx request, add this slot back to the requests deque at the end */
+        /* so annoying. cant call requests_remove because itll invalidate the current iter->ele_idx,
+           so we explicitly pop the head and free the ele here. */
+        fd_forest_ref_t * head = fd_forest_reqslist_ele_pop_head( fd_forest_reqslist( forest ), reqspool );
+        fd_forest_requests_ele_remove ( fd_forest_requests( forest ), &head->idx, NULL, reqspool );
+        fd_forest_reqspool_ele_release( reqspool, head );
+
+        if( FD_UNLIKELY( iter->shred_idx == UINT_MAX && ( ele->buffered_idx == UINT_MAX || ele->buffered_idx < ele->complete_idx ) ) ) {
+          /* If we just made a highest_window_idx request, add this slot
+             back to the requests deque at the end.  Also condition on
+             whether or not this slot is still incomplete.  If the slot
+             is complete and we add it back to the loop, we will end up
+             infinite looping. */
           requests_insert( forest, iter->ele_idx );
         }
       }
 
-      /* move onto the next slot */
+      /* Move onto the next slot */
       if( FD_UNLIKELY( fd_forest_reqslist_is_empty( reqslist, reqspool ) ) ) {
         iter->ele_idx = fd_forest_pool_idx_null( pool );
         iter->shred_idx = UINT_MAX;

--- a/src/discof/forest/test_forest.c
+++ b/src/discof/forest/test_forest.c
@@ -862,6 +862,25 @@ test_iter_publish( fd_wksp_t * wksp ) {
 
 }
 
+void
+test_iter_caught_up( fd_wksp_t * wksp ) {
+  ulong ele_max = 8;
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  FD_TEST( mem );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+
+  fd_forest_init( forest, 0 );
+  fd_forest_blk_fec_insert       ( forest, 1, 0, 0, 0, 1    );
+  fd_forest_blk_fec_insert       ( forest, 2, 1, 0, 0, 1    ); /* fully caught up */
+  fd_forest_blk_data_shred_insert( forest, 3, 2, 0, 0, 0, 0 );
+
+  for( int i = 0; i < 10; i++ ) {
+    fd_forest_iter_next( forest );
+    FD_LOG_NOTICE(("iter: slot %lu, idx %u", idx_slot( forest, forest->iter.ele_idx ), forest->iter.shred_idx));
+  }
+
+}
+
 
 int
 main( int argc, char ** argv ) {
@@ -873,18 +892,19 @@ main( int argc, char ** argv ) {
   fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
-  test_invalid_frontier_insert( wksp );
-  test_publish( wksp );
-  test_publish_incremental( wksp );
-  test_out_of_order( wksp );
-  test_forks( wksp );
-  test_print_tree( wksp );
-  // test_large_print_tree( wksp);
-  test_linear_forest_iterator( wksp );
-  test_branched_forest_iterator( wksp );
-  test_frontier( wksp );
-  test_fec_clear( wksp );
-  test_iter_publish( wksp );
+  //test_invalid_frontier_insert( wksp );
+  //test_publish( wksp );
+  //test_publish_incremental( wksp );
+  //test_out_of_order( wksp );
+  //test_forks( wksp );
+  //test_print_tree( wksp );
+  //// test_large_print_tree( wksp);
+  //test_linear_forest_iterator( wksp );
+  //test_branched_forest_iterator( wksp );
+  //test_frontier( wksp );
+  //test_fec_clear( wksp );
+  //test_iter_publish( wksp );
+  test_iter_caught_up( wksp );
 
   fd_halt();
   return 0;

--- a/src/discof/forest/test_forest.c
+++ b/src/discof/forest/test_forest.c
@@ -27,6 +27,9 @@ fd_forest_blk_fec_insert( fd_forest_t * forest, ulong slot, ulong parent_slot, u
   return fd_forest_fec_insert( forest, slot, parent_slot, last_shred_idx, fec_set_idx, slot_complete, 0 );
 }
 
+#define slot_idx( forest, slot ) fd_forest_pool_idx( fd_forest_pool( forest ), fd_forest_query( forest, slot ) )
+#define idx_slot( forest, idx )  fd_forest_pool_ele_const( fd_forest_pool_const( forest ), idx )->slot
+
 fd_forest_t *
 setup_preorder( fd_forest_t * forest ) {
   fd_forest_init( forest, 0 );
@@ -105,7 +108,7 @@ test_publish_incremental( fd_wksp_t * wksp ){
   //fd_forest_orphaned_t * orphaned = fd_forest_orphaned( forest );
   fd_forest_subtrees_t * subtrees = fd_forest_subtrees( forest );
   fd_forest_consumed_t * consumed = fd_forest_consumed( forest );
-  fd_forest_cns_t *      conspool = fd_forest_conspool( forest );
+  fd_forest_ref_t *      conspool = fd_forest_conspool( forest );
   fd_forest_blk_t *      pool     = fd_forest_pool( forest );
 
   /* 1. Try publishing to a slot that doesnt exist
@@ -120,8 +123,9 @@ test_publish_incremental( fd_wksp_t * wksp ){
   ulong new_root = 1;
   ulong _11 = 11;
   fd_forest_publish( forest, new_root );
+  ulong new_root_idx = slot_idx( forest, new_root );
   FD_TEST( fd_forest_root_slot( forest ) == new_root );
-  FD_TEST( fd_forest_consumed_ele_query( consumed, &new_root, NULL, conspool ) );
+  FD_TEST( fd_forest_consumed_ele_query( consumed, &new_root_idx, NULL, conspool ) );
   FD_TEST( fd_forest_frontier_ele_query( frontier, &new_root, NULL, pool ) || fd_forest_ancestry_ele_query( ancestry, &new_root, NULL, pool ) );
   FD_TEST( fd_forest_subtrees_ele_query( subtrees, &_11, NULL, pool ) );
   FD_TEST( !fd_forest_query( forest, 0 ) );
@@ -138,12 +142,13 @@ test_publish_incremental( fd_wksp_t * wksp ){
   fd_forest_blk_fec_insert( forest, 3, 2, 0, 0, 1 );
 
   ulong front_slot = 3;
+  ulong front_slot_idx = slot_idx( forest, front_slot );
   fd_forest_print( forest );
-  FD_TEST( fd_forest_consumed_ele_query( consumed, &front_slot, NULL, conspool ) );
+  FD_TEST( fd_forest_consumed_ele_query( consumed, &front_slot_idx, NULL, conspool ) );
   FD_TEST( fd_forest_frontier_ele_query( frontier, &front_slot, NULL, pool ) );
   fd_forest_publish( forest, front_slot );
   FD_TEST( fd_forest_root_slot( forest ) == front_slot );
-  FD_TEST( fd_forest_consumed_ele_query( consumed, &front_slot, NULL, conspool ) );
+  FD_TEST( fd_forest_consumed_ele_query( consumed, &front_slot_idx, NULL, conspool ) );
   FD_TEST( !fd_forest_query( forest, 1 ) );
   FD_TEST( !fd_forest_query( forest, 2 ) );
   FD_TEST( !fd_forest_query( forest, 10 ) );
@@ -163,12 +168,15 @@ test_publish_incremental( fd_wksp_t * wksp ){
   FD_TEST( !fd_forest_verify( forest ) );
 
   front_slot = 4;
+  front_slot_idx = slot_idx( forest, front_slot );
   new_root = 6;
-  FD_TEST( fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &front_slot, NULL, fd_forest_conspool( forest ) ) );
+  FD_TEST( fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &front_slot_idx, NULL, fd_forest_conspool( forest ) ) );
+
   fd_forest_publish( forest, new_root );
   FD_TEST( fd_forest_root_slot( forest ) == new_root );
   front_slot = 7;
-  FD_TEST( fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &front_slot, NULL, fd_forest_conspool( forest ) ) );
+  front_slot_idx = slot_idx( forest, front_slot );
+  FD_TEST( fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &front_slot_idx, NULL, fd_forest_conspool( forest ) ) );
   FD_TEST( !fd_forest_query( forest, 3 ) );
   FD_TEST( !fd_forest_query( forest, 4 ) );
   FD_TEST( !fd_forest_query( forest, 5 ) );
@@ -183,11 +191,11 @@ test_publish_incremental( fd_wksp_t * wksp ){
 
   new_root = 10;
   front_slot = 11;
-
+  front_slot_idx = slot_idx( forest, front_slot );
   fd_forest_publish( forest, new_root );
   FD_TEST( !fd_forest_verify( forest ) );
   FD_TEST( fd_forest_root_slot( forest ) == new_root );
-  FD_TEST( fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &front_slot, NULL, fd_forest_conspool( forest ) ) );
+  FD_TEST( fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &front_slot_idx, NULL, fd_forest_conspool( forest ) ) );
   FD_TEST( !fd_forest_query( forest, 6 ) );
   FD_TEST( !fd_forest_query( forest, 7 ) );
   FD_TEST( !fd_forest_query( forest, 8 ) );
@@ -207,10 +215,11 @@ test_publish_incremental( fd_wksp_t * wksp ){
 
   new_root = 15;
   front_slot = 16;
+  front_slot_idx = slot_idx( forest, front_slot );
   fd_forest_publish( forest, new_root );
   FD_TEST( !fd_forest_verify( forest ) );
   FD_TEST( fd_forest_root_slot( forest ) == new_root );
-  FD_TEST( fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &front_slot, NULL, fd_forest_conspool( forest ) ) );
+  FD_TEST( fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &front_slot_idx, NULL, fd_forest_conspool( forest ) ) );
   FD_TEST( !fd_forest_query( forest, 10 ) );
   FD_TEST( !fd_forest_query( forest, 11 ) );
   FD_TEST( !fd_forest_query( forest, 14 ) );
@@ -221,7 +230,7 @@ test_publish_incremental( fd_wksp_t * wksp ){
 
 ulong * consumed_arr( fd_wksp_t * wksp, fd_forest_t * forest ) {
   fd_forest_consumed_t const * consumed = fd_forest_consumed_const( forest );
-  fd_forest_cns_t const *      conspool = fd_forest_conspool_const( forest );
+  fd_forest_ref_t const *      conspool = fd_forest_conspool_const( forest );
   fd_forest_blk_t const *      pool     = fd_forest_pool_const( forest );
   ulong                        cnt      = fd_forest_pool_used( pool );
 
@@ -232,8 +241,8 @@ ulong * consumed_arr( fd_wksp_t * wksp, fd_forest_t * forest ) {
   for( fd_forest_consumed_iter_t iter = fd_forest_consumed_iter_init( consumed, conspool );
        !fd_forest_consumed_iter_done( iter, consumed, conspool );
        iter = fd_forest_consumed_iter_next( iter, consumed, conspool ) ) {
-    fd_forest_cns_t const * ele = fd_forest_consumed_iter_ele_const( iter, consumed, conspool );
-    arr[i++] = ele->slot;
+    fd_forest_ref_t const * ele = fd_forest_consumed_iter_ele_const( iter, consumed, conspool );
+    arr[i++] = fd_forest_pool_ele_const( pool, ele->idx )->slot;
     FD_TEST( i < cnt );
   }
   for( ulong j = i; j < cnt; j++ ) arr[j] = ULONG_MAX;
@@ -352,26 +361,24 @@ test_forks( fd_wksp_t * wksp ){
   fd_forest_blk_data_shred_insert( forest, 10, 9, 1, 0, 0, 1 ); /* orphan */
 
   /* Frontier should be slot 1. */
-  ulong key = 1 ;
+  ulong key = slot_idx( forest, 1 );
   FD_TEST(  fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &key, NULL, fd_forest_conspool( forest ) ) );
 
   int cnt = 0;
   for( fd_forest_consumed_iter_t iter = fd_forest_consumed_iter_init( fd_forest_consumed( forest ), fd_forest_conspool( forest ) );
        !fd_forest_consumed_iter_done( iter, fd_forest_consumed( forest ), fd_forest_conspool( forest ) );
        iter = fd_forest_consumed_iter_next( iter, fd_forest_consumed( forest ), fd_forest_conspool( forest ) ) ) {
-    fd_forest_cns_t * ele = fd_forest_consumed_iter_ele( iter, fd_forest_consumed( forest ), fd_forest_conspool( forest ) );
+    fd_forest_ref_t * ele = fd_forest_consumed_iter_ele( iter, fd_forest_consumed( forest ), fd_forest_conspool( forest ) );
     cnt++;
     (void) ele;
   }
 
   FD_TEST( cnt == 1 );
   // advance frontier to slot 3
-  //fd_forest_blk_data_shred_insert( forest, 1, 0, 0, 0, 0, 0 );
   fd_forest_blk_fec_insert       ( forest, 1, 0, 1, 0, 1    );
-  //fd_forest_blk_data_shred_insert( forest, 2, 1, 0, 0, 0, 0 );
   fd_forest_blk_fec_insert       ( forest, 2, 1, 1, 0, 1    );
 
-  key = 3;
+  key = slot_idx( forest, 3 );
   FD_TEST( fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &key, NULL, fd_forest_conspool( forest ) ) );
 
   // add a new fork off slot 1
@@ -380,14 +387,14 @@ test_forks( fd_wksp_t * wksp ){
 
   fd_forest_print( forest );
 
-  key = 5;
+  key = slot_idx( forest, 5 );
   FD_TEST( fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &key, NULL, fd_forest_conspool( forest ) ) );
 
   cnt = 0;
   for( fd_forest_consumed_iter_t iter = fd_forest_consumed_iter_init( fd_forest_consumed( forest ), fd_forest_conspool( forest ) );
        !fd_forest_consumed_iter_done( iter, fd_forest_consumed( forest ), fd_forest_conspool( forest ) );
        iter = fd_forest_consumed_iter_next( iter, fd_forest_consumed( forest ), fd_forest_conspool( forest ) ) ) {
-    fd_forest_cns_t * ele = fd_forest_consumed_iter_ele( iter, fd_forest_consumed( forest ), fd_forest_conspool( forest ) );
+    fd_forest_ref_t * ele = fd_forest_consumed_iter_ele( iter, fd_forest_consumed( forest ), fd_forest_conspool( forest ) );
     cnt++;
     (void) ele;
   }
@@ -401,7 +408,7 @@ test_forks( fd_wksp_t * wksp ){
   for( fd_forest_consumed_iter_t iter = fd_forest_consumed_iter_init( fd_forest_consumed( forest ), fd_forest_conspool( forest ) );
        !fd_forest_consumed_iter_done( iter, fd_forest_consumed( forest ), fd_forest_conspool( forest ) );
        iter = fd_forest_consumed_iter_next( iter, fd_forest_consumed( forest ), fd_forest_conspool( forest ) ) ) {
-    fd_forest_cns_t * ele = fd_forest_consumed_iter_ele( iter, fd_forest_consumed( forest ), fd_forest_conspool( forest ) );
+    fd_forest_ref_t * ele = fd_forest_consumed_iter_ele( iter, fd_forest_consumed( forest ), fd_forest_conspool( forest ) );
     cnt++;
     (void) ele;
   }
@@ -505,18 +512,12 @@ test_linear_forest_iterator( fd_wksp_t * wksp ) {
   fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
 
   /*
-  slot  complete_idx   received
-  0          1
-  1          1            1
-  2          2            2
-  3          3            0
-  4          4            3
-  5          5            5
+     0 - 1(-/1) - 2(-/2) - 3(0/?) - 4(-/?) - 5(-/5)
 
   expected iterator order:
   (slot 1, idx 0), (slot 2, idx 0), (slot 2, idx 1), (slot 3, idx UINT_MAX), (slot 4, idx UINT_MAX),
-  (slot 5, idx 0), (slot 5, idx 1), (slot 5, idx 2), (slot 5, idx 3), (slot 5, idx 4)
-  */
+  (slot 5, idx 0), (slot 5, idx 1), (slot 5, idx 2), (slot 5, idx 3), (slot 5, idx 4) */
+
   fd_forest_init( forest, 0 );
   fd_forest_blk_data_shred_insert( forest, 1, 0, 1, 0, 1, 1 );
   fd_forest_blk_data_shred_insert( forest, 2, 1, 2, 0, 1, 1 );
@@ -526,19 +527,16 @@ test_linear_forest_iterator( fd_wksp_t * wksp ) {
 
   iter_order_t expected[10] = {
     { 1, 0 }, { 2, 0 }, { 2, 1 }, { 3, UINT_MAX }, { 4, UINT_MAX },
-    { 5, 0 }, { 5, 1 }, { 5, 2 }, { 5, 3 }, { 5, 4 }
+    { 3, UINT_MAX }, { 5, 0 }, { 5, 1 }, { 5, 2 }, { 5, 3 }
   };
 
   fd_forest_blk_t const * pool = fd_forest_pool_const( forest );
-  ulong i = 0;
-  for( fd_forest_iter_t iter = fd_forest_iter_init( forest ); !fd_forest_iter_done( iter, forest ); iter = fd_forest_iter_next( iter, forest ) ) {
+  for( ulong i = 0; i < sizeof(expected) / sizeof(iter_order_t); i++ ) {
+    fd_forest_iter_t iter = *fd_forest_iter_next( forest );
     fd_forest_blk_t const * ele = fd_forest_pool_ele_const( pool, iter.ele_idx );
-    FD_LOG_DEBUG(( "iter: slot %lu, idx %u", ele->slot, iter.shred_idx ));
-    FD_TEST( ele->slot == expected[i].slot );
-    FD_TEST( iter.shred_idx == expected[i].idx );
-    i++;
+    FD_TEST( ele->slot      == expected[i].slot );
+    FD_TEST( iter.shred_idx == expected[i].idx  );
   }
-  FD_TEST( i == sizeof(expected) / sizeof(iter_order_t) );
   FD_LOG_DEBUG(("success"));
 }
 
@@ -552,7 +550,6 @@ test_branched_forest_iterator( fd_wksp_t * wksp ) {
   fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
 
    /*
-
          slot 0
            |
          slot 1
@@ -568,12 +565,7 @@ test_branched_forest_iterator( fd_wksp_t * wksp ) {
   2          2            2
   3          3            0
   4          4            3
-  5          5            5
-
-  expected iterator order:
-  (slot 1, idx 0), (slot 2, idx 0), (slot 2, idx 1), (slot 3, idx UINT_MAX), (slot 4, idx UINT_MAX),
-  (slot 5, idx 0), (slot 5, idx 1), (slot 5, idx 2), (slot 5, idx 3), (slot 5, idx 4)
-  */
+  5          5            5  */
   fd_forest_init( forest, 0 );
   fd_forest_blk_data_shred_insert( forest, 1, 0, 1, 0, 1, 1 );
   fd_forest_blk_data_shred_insert( forest, 2, 1, 2, 0, 1, 1 );
@@ -581,22 +573,19 @@ test_branched_forest_iterator( fd_wksp_t * wksp ) {
   fd_forest_blk_data_shred_insert( forest, 4, 2, 3, 0, 0, 0 );
   fd_forest_blk_data_shred_insert( forest, 5, 3, 5, 0, 1, 1 );
 
-  /* This is deterministic. With only one frontier, we will try to DFS
-  the left most fork */
-  iter_order_t inital_expected[4] = {
-    { 1, 0 }, { 2, 0 }, { 2, 1 }, { 4, UINT_MAX },
+  /* Expected iterator order: */
+  iter_order_t inital_expected[11] = {
+    { 1, 0 }, { 2, 0 }, { 2, 1 }, { 3, UINT_MAX }, { 4, UINT_MAX },
+    { 5, 0 }, { 5, 1 }, { 5, 2 }, { 5, 3 }, { 5, 4 }, {3, UINT_MAX }
   };
-  int i = 0;
-  for( fd_forest_iter_t iter = fd_forest_iter_init( forest ); !fd_forest_iter_done( iter, forest ); iter = fd_forest_iter_next( iter, forest ) ) {
+  for( ulong i = 0; i < sizeof(inital_expected) / sizeof(iter_order_t); i++ ) {
+    fd_forest_iter_t iter = *fd_forest_iter_next( forest );
     fd_forest_blk_t const * ele = fd_forest_pool_ele_const( fd_forest_pool_const( forest ), iter.ele_idx );
     FD_LOG_DEBUG(( "iter: slot %lu, idx %u", ele->slot, iter.shred_idx ));
     FD_TEST( ele->slot == inital_expected[i].slot );
     FD_TEST( iter.shred_idx == inital_expected[i].idx );
-    i++;
   }
-  FD_TEST( i == sizeof(inital_expected) / sizeof(iter_order_t) );
 
-  FD_LOG_DEBUG(("advancing frontier"));
   /* Now frontier advances to the point where we have two things in the
      frontier */
   ulong curr_ver =  fd_fseq_query( fd_forest_ver_const( forest ) );
@@ -608,30 +597,30 @@ test_branched_forest_iterator( fd_wksp_t * wksp ) {
   curr_ver = fd_fseq_query( fd_forest_ver_const( forest ) );
 
   iter_order_t expected[9] = {
-    { 2, 0 }, { 2, 1 }, { 4, UINT_MAX }, { 3, UINT_MAX },
-    { 5, 0 }, { 5, 1 }, { 5, 2 }, { 5, 3 }, { 5, 4 }
+    { 4, UINT_MAX }, { 5, 0 }, { 5, 1 }, { 5, 2 }, { 5, 3 }, { 5, 4 }, { 3, UINT_MAX },
+    { 4, UINT_MAX }, { 5, 0 }
   };
 
-  i = 0;
-  for( fd_forest_iter_t iter = fd_forest_iter_init( forest ); !fd_forest_iter_done( iter, forest ); iter = fd_forest_iter_next( iter, forest ) ) {
+  for( ulong i = 0; i < sizeof(expected) / sizeof(iter_order_t); i++ ) {
+    fd_forest_iter_t iter = *fd_forest_iter_next( forest );
     fd_forest_blk_t const * ele = fd_forest_pool_ele_const( fd_forest_pool_const( forest ), iter.ele_idx );
-    FD_LOG_DEBUG(( "iter: slot %lu, idx %u", ele->slot, iter.shred_idx ));
     FD_TEST( ele->slot == expected[i].slot );
     FD_TEST( iter.shred_idx == expected[i].idx );
-    i++;
   }
-  FD_TEST( i == sizeof(expected) / sizeof(iter_order_t) );
-
-  FD_LOG_DEBUG(("adding data shred middle of iteration"));
 
   FD_TEST( curr_ver == fd_fseq_query( fd_forest_ver_const( forest ) ) );
 
+  iter_order_t expected2[8] = {
+    { 5, 1 }, { 5, 2 }, { 5, 3 }, { 5, 4 }, { 3, 1 },
+    { 3, 2 }, { 4, UINT_MAX }, { 5, 0 }
+  };
+
   /* Lets do a data shred insert in the middle that affects the frontier */
-  i = 0;
-  for( fd_forest_iter_t iter = fd_forest_iter_init( forest ); !fd_forest_iter_done( iter, forest ); iter = fd_forest_iter_next( iter, forest ) ) {
+  for( ulong i = 0; i < sizeof(expected2) / sizeof(iter_order_t); i++ ) {
+    fd_forest_iter_t iter = *fd_forest_iter_next( forest );
     fd_forest_blk_t const * ele = fd_forest_pool_ele_const( fd_forest_pool_const( forest ), iter.ele_idx );
-    FD_LOG_DEBUG(( "iter: slot %lu, idx %u", ele->slot, iter.shred_idx ));
-    i++;
+    FD_TEST( ele->slot == expected2[i].slot );
+    FD_TEST( iter.shred_idx == expected2[i].idx );
     if( i == 2 ) {
       /* insert a data shred in the middle of the iteration */
       fd_forest_blk_data_shred_insert( forest, 3, 1, 3, 0, 1, 1 );
@@ -640,7 +629,6 @@ test_branched_forest_iterator( fd_wksp_t * wksp ) {
     }
   }
   FD_TEST( curr_ver == fd_fseq_query( fd_forest_ver_const( forest ) ) );
-  FD_TEST( i == 2 ); // iteration gets cut off
 }
 
 void
@@ -664,9 +652,10 @@ test_frontier( fd_wksp_t * wksp ) {
 
   /* frontier chaining from slot 1 */
   fd_forest_blk_data_shred_insert( forest, 4, 1, 0, 0, 0, 0 ); /* new frontier */
-  frontier_slot = 4;
+        frontier_slot     = 4;
+  ulong frontier_slot_idx = slot_idx( forest, frontier_slot );
   FD_TEST( !fd_forest_verify( forest ) );
-  FD_TEST(  fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &frontier_slot, NULL, fd_forest_conspool( forest ) ) );
+  FD_TEST(  fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &frontier_slot_idx, NULL, fd_forest_conspool( forest ) ) );
   FD_TEST( !fd_forest_ancestry_ele_query( fd_forest_ancestry( forest ), &frontier_slot, NULL, fd_forest_pool( forest ) ) );
 }
 
@@ -716,11 +705,12 @@ test_invalid_frontier_insert( fd_wksp_t * wksp ) {
 
   fd_forest_print( forest );
   FD_TEST( !fd_forest_verify( forest ) );
-  ulong _101 = 101;
-  ulong _108 = 108;
-  FD_TEST( fd_forest_consumed_ele_query ( fd_forest_consumed( forest ), &_101, NULL, fd_forest_conspool( forest ) ) );
-  FD_TEST( fd_forest_consumed_ele_query ( fd_forest_consumed( forest ), &_108, NULL, fd_forest_conspool( forest ) ) );
-  FD_TEST( !fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &_109, NULL, fd_forest_conspool( forest ) ) );
+  ulong _101idx = slot_idx( forest, 101 );
+  ulong _108idx = slot_idx( forest, 108 );
+  ulong _109idx = slot_idx( forest, 109 );
+  FD_TEST( fd_forest_consumed_ele_query ( fd_forest_consumed( forest ), &_101idx, NULL, fd_forest_conspool( forest ) ) );
+  FD_TEST( fd_forest_consumed_ele_query ( fd_forest_consumed( forest ), &_108idx, NULL, fd_forest_conspool( forest ) ) );
+  FD_TEST( !fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &_109idx, NULL, fd_forest_conspool( forest ) ) );
 
   fd_forest_print( forest );
 
@@ -737,24 +727,23 @@ test_fec_clear( fd_wksp_t * wksp ) {
 
   /* simulate block 1 getting completed with 2 FEC sets */
 
-  ulong _1 = 1;
-  ulong _2 = 2;
-  ulong _3 = 3;
 
-  fd_forest_blk_data_shred_insert( forest, _2, _1, 0, 0, 0, 0 );
+  fd_forest_blk_data_shred_insert( forest, 2, 1, 0, 0, 0, 0 );
+  fd_forest_blk_fec_insert( forest, 1, 0, 31, 0,  0 );
+  fd_forest_blk_fec_insert( forest, 1, 0, 63, 32, 1 );
 
-  fd_forest_blk_fec_insert( forest, _1, 0, 31, 0,  0 );
-  fd_forest_blk_fec_insert( forest, _1, 0, 63, 32, 1 );
-
+  ulong _1 = slot_idx( forest, 1 );
+  ulong _2 = slot_idx( forest, 2 );
   FD_TEST( fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &_2, NULL, fd_forest_conspool( forest ) ) );
 
   /* something funky happened in fec_resolver, sending a clear msg for
      something that was completed already */
-  fd_forest_fec_clear( forest, _1, 0, 17 );
+  fd_forest_fec_clear( forest, 1, 0, 17 );
   /* but its ok because consumed should be unaffected */
   FD_TEST( fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &_2, NULL, fd_forest_conspool( forest ) ) );
 
-  fd_forest_blk_fec_insert( forest, _3, _2, 32, 0, 1 ); /* despite being completed, we are still stuck at slot 2 */
+  fd_forest_blk_fec_insert( forest, 3, 2, 32, 0, 1 ); /* despite being completed, we are still stuck at slot 2 */
+  ulong _3 = slot_idx( forest, 3 );
   FD_TEST( fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &_2, NULL, fd_forest_conspool( forest ) ) );
 
   /* receiving all the shreds for slot 2 but not the fec completes does
@@ -768,13 +757,111 @@ test_fec_clear( fd_wksp_t * wksp ) {
   FD_TEST( fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &_2, NULL, fd_forest_conspool( forest ) ) );
 
   /* receiving 1 fec for slot 2 does not complete the slot */
-  fd_forest_blk_fec_insert( forest, _2, _1, 2, 0, 0 );
+  fd_forest_blk_fec_insert( forest, 2, 1, 2, 0, 0 );
   FD_TEST( fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &_2, NULL, fd_forest_conspool( forest ) ) );
   /* finally complete */
-  fd_forest_blk_fec_insert( forest, _2, _1, 5, 3, 1 );
+  fd_forest_blk_fec_insert( forest, 2, 1, 5, 3, 1 );
   FD_TEST( fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &_3, NULL, fd_forest_conspool( forest ) ) );
   FD_TEST( !fd_forest_consumed_ele_query( fd_forest_consumed( forest ), &_2, NULL, fd_forest_conspool( forest ) ) );
 }
+
+void
+test_iter_publish( fd_wksp_t * wksp ) {
+  ulong ele_max = 8;
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  FD_TEST( mem );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+
+  fd_forest_init( forest, 0 );
+  fd_forest_blk_data_shred_insert( forest, 1, 0, 0, 0, 0, 0 );
+  fd_forest_blk_data_shred_insert( forest, 1, 0, 10,0, 1, 1 );
+  fd_forest_blk_data_shred_insert( forest, 2, 1, 0, 0, 0, 0 );
+  fd_forest_blk_fec_insert       ( forest, 2, 1, 0, 0, 0    );
+  fd_forest_blk_data_shred_insert( forest, 3, 2, 0, 0, 0, 0 );
+  fd_forest_blk_fec_insert       ( forest, 3, 2, 0, 0, 0    );
+
+  #define iter_cnt 13
+  fd_forest_iter_t iter[iter_cnt] = {
+    { 1, 1 }, { 1, 2 }, { 1, 3 }, { 1, 4 }, { 1, 5 },
+    { 1, 6 }, { 1, 7 }, { 1, 8 }, { 1, 9 }, { 2, UINT_MAX },
+    { 3, UINT_MAX },    { 2, UINT_MAX },    { 3, UINT_MAX },
+  };
+
+  int i = 0;
+  for(;;) {
+    fd_forest_iter_next( forest );
+    FD_TEST( forest->iter.ele_idx == iter[i].ele_idx );
+    FD_TEST( forest->iter.shred_idx == iter[i].shred_idx );
+    i++;
+    if( i == iter_cnt ) break;
+  }
+
+  /* check forest deque head is at slot 3 */
+  FD_TEST( fd_forest_reqslist_ele_peek_head_const( fd_forest_reqslist( forest ), fd_forest_reqspool( forest ) )->idx == 3 );
+  /* print everything in the request queue */
+  for( fd_forest_reqslist_iter_t iter = fd_forest_reqslist_iter_fwd_init( fd_forest_reqslist( forest ), fd_forest_reqspool( forest ) );
+       !fd_forest_reqslist_iter_done( iter, fd_forest_reqslist( forest ), fd_forest_reqspool( forest ) );
+       iter = fd_forest_reqslist_iter_fwd_next( iter, fd_forest_reqslist( forest ), fd_forest_reqspool( forest ) ) ) {
+    fd_forest_ref_t const * ele = fd_forest_reqslist_iter_ele_const( iter, fd_forest_reqslist( forest ), fd_forest_reqspool( forest ) );
+    FD_LOG_NOTICE(("req: slot %lu, idx %lu", fd_forest_pool_ele_const( fd_forest_pool_const( forest ), ele->idx )->slot, ele->idx));
+  }
+
+  /* add highest windows for 2, 3, and also add forks for
+     4 and 5 off of 3
+
+
+         slot 0
+           |
+         slot 1 - slot 6
+           |
+         slot 2
+           |
+         slot 3
+         /    \
+    slot 4   slot 5
+
+  */
+
+  fd_forest_blk_data_shred_insert( forest, 2, 1, 4, 0, 1, 1 );
+  fd_forest_blk_fec_insert( forest, 2, 1, 4, 0, 1 ); // slot 2 must be completed and "executed" for us to publish to it.
+
+  /* At this point iter_next should pop 3 off the top, add 3's children
+     to the end (4,5). Then add 3 itself to the end. iter_next would
+     then normally return 2, but because 2 is now completed, itll move
+     on and actually return 4 as the next slot to request.
+
+     Queue should be [4,5,3]
+     */
+  fd_forest_blk_data_shred_insert( forest, 3, 2, 4, 0, 1, 1 );
+  fd_forest_blk_data_shred_insert( forest, 4, 3, 4, 0, 1, 1 );
+  fd_forest_blk_data_shred_insert( forest, 5, 3, 4, 0, 1, 1 );
+
+  fd_forest_blk_data_shred_insert( forest, 6, 1, 4, 0, 1, 1 );
+  ulong _6 = slot_idx( forest, 6 );
+  FD_TEST( fd_forest_requests_ele_query( fd_forest_requests( forest ), &_6, NULL, fd_forest_reqspool( forest ) ) );
+
+  fd_forest_print( forest );
+  fd_forest_publish( forest, 2 );
+  FD_TEST( !fd_forest_verify( forest ) );
+  /* since the last request was for highest idx of 3, we expect to start
+     requesting for 2 */
+
+  fd_forest_iter_next( forest );
+  FD_LOG_NOTICE(("iter: slot %lu, idx %u", idx_slot( forest, forest->iter.ele_idx ), forest->iter.shred_idx));
+  FD_TEST( fd_forest_query( forest, idx_slot( forest, forest->iter.ele_idx ) ) );
+
+  ulong expected_queue[3] = { 4, 5, 3 };
+  i = 0;
+  for( fd_forest_reqslist_iter_t iter = fd_forest_reqslist_iter_fwd_init( fd_forest_reqslist( forest ), fd_forest_reqspool( forest ) );
+       !fd_forest_reqslist_iter_done( iter, fd_forest_reqslist( forest ), fd_forest_reqspool( forest ) );
+       iter = fd_forest_reqslist_iter_fwd_next( iter, fd_forest_reqslist( forest ), fd_forest_reqspool( forest ) ) ) {
+    fd_forest_ref_t const * ele = fd_forest_reqslist_iter_ele_const( iter, fd_forest_reqslist( forest ), fd_forest_reqspool( forest ) );
+    FD_TEST( idx_slot( forest, ele->idx ) == expected_queue[i] );
+    i++;
+  }
+
+}
+
 
 int
 main( int argc, char ** argv ) {
@@ -797,6 +884,7 @@ main( int argc, char ** argv ) {
   test_branched_forest_iterator( wksp );
   test_frontier( wksp );
   test_fec_clear( wksp );
+  test_iter_publish( wksp );
 
   fd_halt();
   return 0;

--- a/src/discof/repair/fd_inflight.h
+++ b/src/discof/repair/fd_inflight.h
@@ -4,13 +4,18 @@
 #include "../../flamenco/types/fd_types.h"
 
 /* fd_inflights tracks repair requests that are inflight to other
-   validators.  This module is not necessary for the repair protocol and
-   strategy, but is useful for metrics and reporting.  Incorrect updates
-   and removals from this module are non-critical.  Requests are key-ed
-   by nonce as in the current strategy (see fd_policy.h), all requests
-   have a unique nonce.  The chances that an inflight request does not
-   get a response are non-negligible due to shred tile upstream deduping
-   duplicates. */
+   validators.  This module is useful for metrics and reporting.
+   In-exact updates of orphan requests and highest window requests from
+   this module are non-critical, but exact updates of shred requests are
+   critical. Repair tile relies on this module to be able to re-request
+   any shreds that it has sent, because policy next does not request any
+   shred twice.
+   (TODO should this be rolled into policy.h?)
+
+   Requests are key-ed by nonce as in the current strategy (see
+   fd_policy.h), all requests have a unique nonce.  The chances that an
+   inflight request does not get a response are non-negligible due to
+   shred tile upstream deduping duplicates. */
 
 /* Max number of pending requests */
 #define FD_INFLIGHT_REQ_MAX (1<<20)
@@ -96,7 +101,7 @@ fd_inflights_should_drain( fd_inflights_t * table, long now ) {
   if( FD_UNLIKELY( fd_inflight_dlist_is_empty( table->dlist, table->pool ) ) ) return 0;
 
   fd_inflight_t * inflight_req = fd_inflight_dlist_ele_peek_head( table->dlist, table->pool );
-  if( FD_UNLIKELY( inflight_req->timestamp_ns + 100e6L < now ) ) return 1;
+  if( FD_UNLIKELY( inflight_req->timestamp_ns + 90e6L < now ) ) return 1;
   return 0;
 }
 

--- a/src/discof/repair/fd_inflight.h
+++ b/src/discof/repair/fd_inflight.h
@@ -21,6 +21,9 @@ struct __attribute__((aligned(128UL))) fd_inflight {
   long          timestamp_ns;  /* timestamp when request was created (nanoseconds) */
   fd_pubkey_t   pubkey;        /* public key of the peer */
 
+  ulong         slot;          /* slot of the request */
+  ulong         shred_idx;     /* shred index of the request */
+
   /* Reserved for DLL eviction */
   ulong          prevll;      /* pool index of previous element in DLL */
   ulong          nextll;      /* pool index of next element in DLL */
@@ -74,10 +77,29 @@ fd_inflights_t *
 fd_inflights_join( void * shmem );
 
 void
-fd_inflights_request_insert( fd_inflights_t * table, ulong nonce, fd_pubkey_t const * pubkey );
+fd_inflights_request_insert( fd_inflights_t * table, ulong nonce, fd_pubkey_t const * pubkey, ulong slot, ulong shred_idx );
 
 long
 fd_inflights_request_remove( fd_inflights_t * table, ulong nonce, fd_pubkey_t * peer_out );
+
+/* Important! Caller must guarantee that the request list is not empty.
+   This function cannot fail and will always try to populate the output
+   parameters. Typical use should only call this after
+   fd_inflights_should_drain returns true. */
+
+void
+fd_inflights_request_pop( fd_inflights_t * table, ulong * nonce_out, ulong * slot_out, ulong * shred_idx_out );
+
+static inline int
+fd_inflights_should_drain( fd_inflights_t * table, long now ) {
+  /* peek at head */
+  if( FD_UNLIKELY( fd_inflight_dlist_is_empty( table->dlist, table->pool ) ) ) return 0;
+
+  fd_inflight_t * inflight_req = fd_inflight_dlist_ele_peek_head( table->dlist, table->pool );
+  if( FD_UNLIKELY( inflight_req->timestamp_ns + 100e6L < now ) ) return 1;
+  return 0;
+}
+
 
 fd_inflight_t *
 fd_inflights_request_query ( fd_inflights_t * table, ulong nonce );

--- a/src/discof/repair/fd_policy.c
+++ b/src/discof/repair/fd_policy.c
@@ -164,6 +164,8 @@ fd_policy_peer_select( fd_policy_t * policy ) {
   fd_peer_dlist_t * worst_dlist = policy->peers.slow;
   fd_peer_t       * pool        = policy->peers.pool;
 
+  if( FD_UNLIKELY( fd_peer_pool_used( policy->peers.pool ) == 0 ) ) return NULL;
+
   fd_peer_dlist_t * dlist = bucket_stages[policy->peers.select.stage] == FD_POLICY_LATENCY_FAST ? best_dlist : worst_dlist;
 
   while( FD_UNLIKELY( fd_peer_dlist_iter_done( policy->peers.select.iter, dlist, pool ) ) ) {
@@ -235,10 +237,10 @@ fd_policy_next( fd_policy_t * policy, fd_forest_t * forest, fd_repair_t * repair
        means that the shred_idx of the iterf is likely to be UINT_MAX,
        which means calling fd_forest_iter_next will advance the iterf
        to the next slot. */
-    //forest->iter.shred_idx = UINT_MAX; // heinous... i'm sorry
-    //fd_forest_iter_next( forest );
-    //if( FD_UNLIKELY( fd_forest_iter_done( forest->iter, forest ) ) ) break;
-    //continue;
+    forest->iter.shred_idx = UINT_MAX;
+    /* TODO: Heinous... I'm sorry. Easiest way to ensure this slot gets added back to the requests deque.
+       but maybe there should be an explicit API for it. */
+    return NULL;
   }
 
   if( FD_UNLIKELY( forest->iter.shred_idx == UINT_MAX ) ) {
@@ -300,7 +302,7 @@ fd_policy_peer_remove( fd_policy_t * policy, fd_pubkey_t const * key ) {
 
   if( FD_UNLIKELY( policy->peers.select.iter == fd_peer_pool_idx( policy->peers.pool, peer_ele ) ) ) {
     /* In general removal during iteration is safe, except when the iterator is on the peer to be removed. */
-    fd_peer_dlist_t * dlist = policy->peers.select.stage == FD_POLICY_LATENCY_FAST ? policy->peers.fast : policy->peers.slow;
+    fd_peer_dlist_t * dlist = bucket_stages[policy->peers.select.stage] == FD_POLICY_LATENCY_FAST ? policy->peers.fast : policy->peers.slow;
     policy->peers.select.iter = fd_peer_dlist_iter_fwd_next( policy->peers.select.iter, dlist, policy->peers.pool );
   }
 

--- a/src/discof/repair/fd_policy.c
+++ b/src/discof/repair/fd_policy.c
@@ -41,7 +41,6 @@ fd_policy_new( void * shmem, ulong dedup_max, ulong peer_max, ulong seed ) {
   policy->peers.pool    = fd_peer_pool_new        ( peers_pool, peer_max        );
   policy->peers.fast    = fd_peer_dlist_new       ( peers_fast                  );
   policy->peers.slow    = fd_peer_dlist_new       ( peers_slow                  );
-  policy->iterf.ele_idx = ULONG_MAX;
   policy->turbine_slot0 = ULONG_MAX;
   policy->tsreset       = 0;
   policy->nonce         = 1;
@@ -202,18 +201,13 @@ fd_policy_next( fd_policy_t * policy, fd_forest_t * forest, fd_repair_t * repair
     }
   }
 
-  /* Every so often we'll need to reset the frontier iterator to the
-     head of frontier, because we could end up traversing down a very
-     long tree if we are far behind. */
+  /**********************/
+  /* ADVANCE ITERATOR   */
+  /**********************/
 
-  if( FD_UNLIKELY( now_ms - policy->tsreset > 100UL /* ms */ ||
-                   policy->iterf.frontier_ver != fd_fseq_query( fd_forest_ver_const( forest ) ) ) ) {
-    fd_policy_reset( policy, forest );
-  }
-
-  fd_forest_blk_t * ele = fd_forest_pool_ele( pool, policy->iterf.ele_idx );
-  if( FD_UNLIKELY( !ele ) ) {
-    // This happens when we are fully caught up i.e. we have all the shreds of every slot we know about.
+  fd_forest_iter_next( forest );
+  if( FD_UNLIKELY( fd_forest_iter_done( forest ) ) ) {
+    // This happens when we have already requested all the shreds we know about.
     return NULL;
   }
 
@@ -231,53 +225,34 @@ fd_policy_next( fd_policy_t * policy, fd_forest_t * forest, fd_repair_t * repair
      next valid requestable element. */
 
   int req_made = 0;
-  while( !req_made ) {
-    ele = fd_forest_pool_ele( pool, policy->iterf.ele_idx );
 
-    if( FD_UNLIKELY( !passes_throttle_threshold( policy, ele ) ) ) {
-      /* We are not ready to repair this slot yet.  But it's possible we
-         have another fork that we need to repair... so we just
-         should skip to the next SLOT in the consumed iterator.  The
-         likelihood that this ele is the head of turbine is high, which
-         means that the shred_idx of the iterf is likely to be UINT_MAX,
-         which means calling fd_forest_iter_next will advance the iterf
-         to the next slot. */
-      policy->iterf.shred_idx = UINT_MAX; // heinous... i'm sorry
-      policy->iterf = fd_forest_iter_next( policy->iterf, forest );
-      if( FD_UNLIKELY( fd_forest_iter_done( policy->iterf, forest ) ) ) {
-         policy->iterf = fd_forest_iter_init( forest );
-         break;
-      }
-      continue;
+  fd_forest_blk_t * ele = fd_forest_pool_ele( pool, forest->iter.ele_idx );
+  if( FD_UNLIKELY( !passes_throttle_threshold( policy, ele ) ) ) {
+    /* We are not ready to repair this slot yet.  But it's possible we
+       have another fork that we need to repair... so we just
+       should skip to the next SLOT in the consumed iterator.  The
+       likelihood that this ele is the head of turbine is high, which
+       means that the shred_idx of the iterf is likely to be UINT_MAX,
+       which means calling fd_forest_iter_next will advance the iterf
+       to the next slot. */
+    //forest->iter.shred_idx = UINT_MAX; // heinous... i'm sorry
+    //fd_forest_iter_next( forest );
+    //if( FD_UNLIKELY( fd_forest_iter_done( forest->iter, forest ) ) ) break;
+    //continue;
+  }
+
+  if( FD_UNLIKELY( forest->iter.shred_idx == UINT_MAX ) ) {
+    if( FD_UNLIKELY( ele->slot < highest_known_slot ) ) {
+      // We'll never know the the highest shred for the current turbine slot, so there's no point in requesting it.
+      out = fd_repair_highest_shred( repair, fd_policy_peer_select( policy ), now_ms, policy->nonce, ele->slot, 0 );
+      policy->nonce++;
+      req_made = 1;
     }
-
-    if( FD_UNLIKELY( policy->iterf.shred_idx == UINT_MAX ) ) {
-      ulong key = fd_policy_dedup_key( FD_REPAIR_KIND_HIGHEST_SHRED, ele->slot, 0 );
-      if( FD_UNLIKELY( ele->slot < highest_known_slot && !dedup_next( policy, key, now ) ) ) {
-        // We'll never know the the highest shred for the current turbine slot, so there's no point in requesting it.
-        out = fd_repair_highest_shred( repair, fd_policy_peer_select( policy ), now_ms, policy->nonce, ele->slot, 0 );
-        policy->nonce++;
-        req_made = 1;
-      }
-    } else {
-      ulong key = fd_policy_dedup_key( FD_REPAIR_KIND_SHRED, ele->slot, policy->iterf.shred_idx );
-      if( FD_UNLIKELY( !dedup_next( policy, key, now ) ) ) {
-        out = fd_repair_shred( repair, fd_policy_peer_select( policy ), now_ms, policy->nonce, ele->slot, policy->iterf.shred_idx );
-        policy->nonce++;
-        if( FD_UNLIKELY( ele->first_req_ts == 0 ) ) ele->first_req_ts = fd_tickcount();
-        req_made = 1;
-      }
-    }
-
-    /* Even if we have a request ready, we need to advance the iterator.
-       Otherwise on the next call of policy_next, we'll try to re-request the
-       same shred and it will get deduped. */
-
-    policy->iterf = fd_forest_iter_next( policy->iterf, forest );
-    if( FD_UNLIKELY( fd_forest_iter_done( policy->iterf, forest ) ) ) {
-      policy->iterf = fd_forest_iter_init( forest );
-      break;
-    }
+  } else {
+    out = fd_repair_shred( repair, fd_policy_peer_select( policy ), now_ms, policy->nonce, ele->slot, forest->iter.shred_idx );
+    policy->nonce++;
+    if( FD_UNLIKELY( ele->first_req_ts == 0 ) ) ele->first_req_ts = fd_tickcount();
+    req_made = 1;
   }
 
   if( FD_UNLIKELY( !req_made ) ) return NULL;
@@ -363,12 +338,6 @@ fd_policy_peer_response_update( fd_policy_t * policy, fd_pubkey_t const * to, lo
       fd_peer_dlist_ele_push_tail( new_bucket,  peer_ele, policy->peers.pool );
     }
   }
-}
-
-void
-fd_policy_reset( fd_policy_t * policy, fd_forest_t * forest ) {
-  policy->iterf   = fd_forest_iter_init( forest );
-  policy->tsreset = ts_ms( fd_log_wallclock() );
 }
 
 void

--- a/src/discof/repair/fd_policy.h
+++ b/src/discof/repair/fd_policy.h
@@ -180,7 +180,6 @@ struct fd_policy {
   long              tsmax; /* maximum time for an iteration before resetting the DFS to root */
   long              tsref; /* reference timestamp for resetting DFS */
 
-  fd_forest_iter_t  iterf; /* forest iterator */
   ulong             tsreset; /* ms timestamp of last reset of iterf */
 
   ulong turbine_slot0;
@@ -286,8 +285,5 @@ fd_policy_peer_response_update( fd_policy_t * policy, fd_pubkey_t const * to, lo
 
 void
 fd_policy_set_turbine_slot0( fd_policy_t * policy, ulong slot );
-
-void
-fd_policy_reset( fd_policy_t * policy, fd_forest_t * forest );
 
 #endif /* HEADER_fd_src_choreo_policy_fd_policy_h */

--- a/src/discof/repair/fd_repair_metrics.h
+++ b/src/discof/repair/fd_repair_metrics.h
@@ -18,7 +18,7 @@ struct fd_slot_metrics {
 };
 typedef struct fd_slot_metrics fd_slot_metrics_t;
 
-#define FD_CATCHUP_METRICS_MAX 256
+#define FD_CATCHUP_METRICS_MAX 16384
 
 struct fd_repair_metrics_t {
   fd_slot_metrics_t slots[ FD_CATCHUP_METRICS_MAX ];


### PR DESCRIPTION
10ms incremental slot completion, not including orphans (handled in follow up)