### PR TITLE
Fix error when enabling already-enabled ntuple

### DIFF
--- a/src/app/shared/commands/configure/ethtool-channels.c
+++ b/src/app/shared/commands/configure/ethtool-channels.c
@@ -117,9 +117,17 @@ init_device( char const *        device,
       else         return 1;
     }
 
-    if( FD_UNLIKELY( 0!=fd_ethtool_ioctl_feature_set( &ioc, FD_ETHTOOL_FEATURE_NTUPLE, 1 ) ) ) {
-      if( strict ) FD_LOG_ERR(( "error configuring network device (%s), failed to enable ntuple feature. Try `net.xdp.rss_queue_mode=\"simple\"`", device ));
+    int is_set;
+    if( FD_UNLIKELY( 0!=fd_ethtool_ioctl_feature_test( &ioc, FD_ETHTOOL_FEATURE_NTUPLE, &is_set ) ) ) {
+      if( strict ) FD_LOG_ERR(( "error configuring network device (%s), failed to read ntuple feature. Try `net.xdp.rss_queue_mode=\"simple\"`", device ));
       else         return 1;
+    }
+
+    if ( !is_set ) {
+      if( FD_UNLIKELY( 0!=fd_ethtool_ioctl_feature_set( &ioc, FD_ETHTOOL_FEATURE_NTUPLE, 1 ) ) ) {
+        if( strict ) FD_LOG_ERR(( "error configuring network device (%s), failed to enable ntuple feature. Try `net.xdp.rss_queue_mode=\"simple\"`", device ));
+        else         return 1;
+      }
     }
 
     /* FIXME Centrally define listen port list to avoid this configure


### PR DESCRIPTION
On ConnectX-4, and probably other NICS, ntuple feature is activated by default and cannot be changed.
This causes `fdctl init` to fail to configure the net tile with ` rss_queue_mode = "dedicated"`.

This PR proposes 2 fixes.
* A minor one that changes the error message when the ioctl returns a positive value. Current error message printed a misleading message using an `errno` that were not set by `ioctl`.
* A test to only try to enable ntuple if it's not already enabled. Maybe a more generic fix would be make such test in `fd_ethtool_ioctl_feature_set` instead of specifically for ntuple.