### PR TITLE
ci: check generated seccomp files match

### DIFF
--- a/.github/workflows/check_seccomp.yml
+++ b/.github/workflows/check_seccomp.yml
@@ -1,0 +1,33 @@
+name: Check Generated Seccomp Files
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  check-seccomp:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Checkout current commit
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python environment
+        run: |
+          python -m venv venv && venv/bin/pip install edn_format
+
+      - name: Check generated seccomp files
+        run: |
+          set -e
+          source venv/bin/activate
+          make seccomp-policies
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Generated seccomp files are out of date. Please run 'make seccomp-policies' and commit the changes."
+            git --no-pager diff
+            exit 1
+          else
+            echo "All generated seccomp files are up to date."
+          fi


### PR DESCRIPTION
Check that the *.seccomppolicy and *_seccomp.h files match.

This would have highlighted that https://github.com/firedancer-io/firedancer/pull/6580  committed a `watch_seccomp.h` file that did not match the `watch.seccomppolicy` file.
This mismatch has been fixed in https://github.com/firedancer-io/firedancer/pull/6732