### PR TITLE
ci: remove rocksdb from previous runs during clean-up

### DIFF
--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -25,6 +25,7 @@ jobs:
         if: always()
         run: |
           sudo killall firedancer-dev || true
+          find ../dump -type d -name rocksdb -exec rm {} + || true
 
       - uses: actions/checkout@v5
         with:
@@ -58,4 +59,5 @@ jobs:
         if: always()
         run: |
           sudo killall firedancer-dev || true
+          find ../dump -type d -name rocksdb -exec rm {} + || true
           sudo $OBJDIR/bin/firedancer-dev configure fini all --config ../dump/mainnet-308392063-v2.3.0_backtest.toml || true


### PR DESCRIPTION
Addressing CI flakiness:
https://github.com/firedancer-io/firedancer/actions/runs/18538823831

```2025-10-15 18:58:04.740716328 GMT+00 3467787:3467802 svc_firedancer:emam-ossdev-firedancer-ci4:10   fd1:[group]:snaprd:0 src/discof/restore/utils/fd_ssarchive.c(183)[fd_ssarchive_remove_old_snapshots]: unrecognized snapshot file `/data/svc_firedancer/actions-runner/_work/firedancer/dump/testnet-362107883-direct-mapping-2/rocksdb` in snapshots directory
 2025-10-15 18:58:04.740741116 GMT+00 3467787:3467802 svc_firedancer:emam-ossdev-firedancer-ci4:10   fd1:[group]:snaprd:0 src/discof/restore/utils/fd_ssarchive.c(112)[fd_ssarchive_latest_pair]: unrecognized snapshot file `/data/svc_firedancer/actions-runner/_work/firedancer/dump/testnet-362107883-direct-mapping-2/rocksdb` in snapshots directory
 2025-10-15 18:58:04.740750794 GMT+00 3467787:3467802 svc_firedancer:emam-ossdev-firedancer-ci4:10   fd1:[group]:snaprd:0 src/discof/restore/fd_snaprd_tile.c(1157)[privileged_init]: No snapshots found in `/data/svc_firedancer/actions-runner/_work/firedancer/dump/testnet-362107883-direct-mapping-2` and downloading is disabled. Please enable downloading via [snapshots.download] and restart.```