### PR TITLE
builds: update runner labels

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -91,7 +91,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build_gcc:
-    runs-on: rocky810
+    runs-on: rocky8
     if: ${{ inputs.gcc != 'none' }}
     steps:
       - uses: actions/checkout@v5
@@ -144,7 +144,7 @@ jobs:
           contrib/build.sh --no-rust --no-clang ${{ env.BUILD_ARGS }}
 
   build_clang:
-    runs-on: rocky94
+    runs-on: rocky9
     if: ${{ inputs.clang != 'none' }}
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
For our purposes, a rocky8.10 and rocky8.9 are equivalent, as are rocky9.4 and rocky9.5. I've updated the runner labels already, so this should make more hosts pickup build runs.