### PR TITLE
quic: improve keep-alive impact on client svc schedule

### DIFF
--- a/src/discof/send/fd_send_tile.c
+++ b/src/discof/send/fd_send_tile.c
@@ -275,7 +275,8 @@ ensure_conn_for_slot( fd_send_tile_ctx_t * ctx,
     } else {
       /* Connection already exists */
       ctx->metrics.ensure_conn_result[i][FD_METRICS_ENUM_SEND_ENSURE_CONN_RESULT_V_CONNECTED_IDX]++;
-      fd_quic_conn_let_die( entry->conn[i], lifespan );
+      fd_quic_conn_let_die( entry->conn[i], lifespan, ctx->now );
+      fd_quic_service( ctx->quic, ctx->now );
     }
   }
 }

--- a/src/waltz/quic/fd_quic.h
+++ b/src/waltz/quic/fd_quic.h
@@ -542,7 +542,8 @@ fd_quic_conn_close( fd_quic_conn_t * conn,
 
 FD_QUIC_API void
 fd_quic_conn_let_die( fd_quic_conn_t * conn,
-                      long             keep_alive_duration_ns );
+                      long             keep_alive_duration_ns,
+                      long             now );
 
 /* Service API ********************************************************/
 


### PR DESCRIPTION
1. After servicing a client conn to send the keep-alive ping, we continue to default schedule for last_activity+idle_timeout/2. But that's in the past! So we end up in an INSTANT scheduling loop until the peer responds to reset last_activity.... bad. This PR fixes that. 

2. Suppose at time _t_, the user calls fd_quic_conn_let_die() to _prolong_ the lifetime, providing a new keep_alive_duration longer than the currently implicit one. The connection is still alive, but _t_ is _after_ when we'd have sent the keep-alive (last_activity+idle_timeout/2). The next service for this conn is scheduled for last_activity+idle_timeout (after change 1 in this PR), so we'd just timeout the conn isntead of ever sending the keep-alive. This PR changes let_die() to check if we're in this particular situation, and if so, schedules the conn immediately in an attempt to save the connection.

3. minor: This PR also expands the conn_close frame debug log.