### PR TITLE
firedancer: removing runtime spad in favor of runtime stack

### DIFF
--- a/contrib/offline-replay/offline_replay.toml
+++ b/contrib/offline-replay/offline_replay.toml
@@ -8,7 +8,6 @@
         rocksdb_path = "{ledger}/rocksdb"
     [tiles.replay]
         cluster_version = "{cluster_version}"
-        heap_size_gib = {heap_size}
     [tiles.gui]
         enabled = false
 [funk]

--- a/src/app/firedancer-dev/config/minimal.toml
+++ b/src/app/firedancer-dev/config/minimal.toml
@@ -6,9 +6,6 @@ max_account_records = 1048576
 heap_size_gib = 20
 max_database_transactions = 1024
 
-[runtime]
-heap_size_gib = 4
-
 [runtime.limits]
 max_live_slots = 512
 max_vote_accounts = 32

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -1375,25 +1375,6 @@ user = ""
         # TODO: What is this ... needs to be deleted
         cluster_version =  "1.18.0"
 
-        # Specifies the size in gigibytes of the replay heap allocator.
-        #
-        # Persistent usages of the replay heap include:
-        # - Epoch state (scales with number of vote and stake accounts)
-        # - Slot state (scale with number of vote accounts)
-        # - Sysvar cache (tiny)
-        #
-        # Notable temporary usages of the replay heap include:
-        # - In-memory allocations
-        # - Distributing stake rewards
-        #
-        # Full Firedancer still lacks an ability to robustly scale above
-        # runtime heap allocations dynamically.  Thus, a conservative
-        # default is chosen below.
-        #
-        # TODO: These will be replaced in favor of more granular
-        # per object allocations in the replay tile's context
-        heap_size_gib = 50
-
     [tiles.send]
         # The port the send tile uses for QUIC, to send votes and other
         # transactions. It also uses this as the UDP src port.

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -976,7 +976,6 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
 
     strncpy( tile->replay.cluster_version, config->tiles.replay.cluster_version, sizeof(tile->replay.cluster_version) );
 
-    tile->replay.heap_size_gib  = config->tiles.replay.heap_size_gib;
     tile->replay.max_live_slots = config->firedancer.runtime.max_live_slots;
 
     tile->replay.expected_shred_version = config->consensus.expected_shred_version;

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -449,7 +449,6 @@ struct fd_config {
       char  cluster_version[ 32 ];
       ulong enable_features_cnt;
       char  enable_features[ 16 ][ FD_BASE58_ENCODED_32_SZ ];
-      ulong heap_size_gib;
     } replay;
 
     struct {

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -248,7 +248,6 @@ fd_config_extract_pod( uchar *       pod,
 
   CFG_POP      ( cstr,   tiles.replay.cluster_version                     );
   CFG_POP_ARRAY( cstr,   tiles.replay.enable_features                     );
-  CFG_POP      ( ulong,  tiles.replay.heap_size_gib                       );
 
   CFG_POP      ( cstr,   tiles.store_int.slots_pending                    );
   CFG_POP      ( cstr,   tiles.store_int.shred_cap_archive                );

--- a/src/discof/replay/fd_sched.h
+++ b/src/discof/replay/fd_sched.h
@@ -58,7 +58,6 @@ struct fd_sched_alut_ctx {
   fd_accdb_user_t   accdb[1];
   fd_funk_txn_xid_t xid[1];
   ulong             els; /* Effective lookup slot. */
-  fd_spad_t *       runtime_spad;
 };
 typedef struct fd_sched_alut_ctx fd_sched_alut_ctx_t;
 

--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -163,7 +163,7 @@ verify_slot_deltas_with_slot_history( fd_snapin_tile_t *         ctx,
 
   for( ulong i=0UL; i<ctx->txncache_entries_len; i++ ) {
     fd_sstxncache_entry_t const * entry = &ctx->txncache_entries[i];
-    if( FD_UNLIKELY( fd_sysvar_slot_history_find_slot( slot_history, entry->slot, NULL )!=FD_SLOT_HISTORY_SLOT_FOUND ) ) return -1;
+    if( FD_UNLIKELY( fd_sysvar_slot_history_find_slot( slot_history, entry->slot )!=FD_SLOT_HISTORY_SLOT_FOUND ) ) return -1;
   }
   return 0;
 }

--- a/src/flamenco/fd_flamenco_base.h
+++ b/src/flamenco/fd_flamenco_base.h
@@ -99,6 +99,9 @@ typedef union fd_features fd_features_t;
 struct fd_progcache;
 typedef struct fd_progcache fd_progcache_t;
 
+union fd_runtime_stack;
+typedef union fd_runtime_stack fd_runtime_stack_t;
+
 struct fd_account_meta {
   uchar owner[32];
   ulong lamports;

--- a/src/flamenco/rewards/fd_rewards.h
+++ b/src/flamenco/rewards/fd_rewards.h
@@ -32,6 +32,7 @@ void
 fd_begin_partitioned_rewards( fd_bank_t *                    bank,
                               fd_accdb_user_t *              accdb,
                               fd_funk_txn_xid_t const *      xid,
+                              fd_runtime_stack_t *           runtime_stack,
                               fd_capture_ctx_t *             capture_ctx,
                               fd_stake_delegations_t const * stake_delegations,
                               fd_hash_t const *              parent_blockhash,
@@ -53,7 +54,7 @@ fd_rewards_recalculate_partitioned_rewards( fd_banks_t *              banks,
                                             fd_bank_t *               bank,
                                             fd_funk_t *               funk,
                                             fd_funk_txn_xid_t const * xid,
-                                            fd_vote_state_credits_t * vote_state_credits,
+                                            fd_runtime_stack_t *      runtime_stack,
                                             fd_capture_ctx_t *        capture_ctx );
 
 /* fd_distribute_partitioned_epoch_rewards pays out rewards to stake

--- a/src/flamenco/runtime/Local.mk
+++ b/src/flamenco/runtime/Local.mk
@@ -55,7 +55,7 @@ $(call run-unit-test,test_txn_rw_conflicts)
 endif
 
 ifdef FD_HAS_ATOMIC
-$(call add-hdrs,fd_runtime.h fd_runtime_init.h fd_runtime_err.h fd_runtime_const.h)
+$(call add-hdrs,fd_runtime.h fd_runtime_init.h fd_runtime_err.h fd_runtime_const.h fd_runtime_stack.h)
 $(call add-objs,fd_runtime fd_runtime_init ,fd_flamenco)
 endif
 

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -1268,7 +1268,7 @@ int
 fd_execute_instr( fd_exec_txn_ctx_t * txn_ctx,
                   fd_instr_info_t *   instr ) {
   fd_sysvar_cache_t const * sysvar_cache = fd_bank_sysvar_cache_query( txn_ctx->bank );
-  FD_RUNTIME_TXN_SPAD_FRAME_BEGIN( txn_ctx->spad, txn_ctx ) {
+  FD_SPAD_FRAME_BEGIN( txn_ctx->spad ) {
     int instr_exec_result = fd_instr_stack_push( txn_ctx, instr );
     if( FD_UNLIKELY( instr_exec_result ) ) {
       FD_TXN_PREPARE_ERR_OVERWRITE( txn_ctx );
@@ -1351,7 +1351,7 @@ fd_execute_instr( fd_exec_txn_ctx_t * txn_ctx,
     }
 
     return fd_execute_instr_end( ctx, instr, instr_exec_result );
-  } FD_RUNTIME_TXN_SPAD_FRAME_END;
+  } FD_SPAD_FRAME_END;
 }
 
 void

--- a/src/flamenco/runtime/fd_runtime_stack.h
+++ b/src/flamenco/runtime/fd_runtime_stack.h
@@ -1,0 +1,51 @@
+#ifndef HEADER_fd_src_flamenco_runtime_fd_runtime_stack_h
+#define HEADER_fd_src_flamenco_runtime_fd_runtime_stack_h
+
+#include "../types/fd_types_custom.h"
+#include "../stakes/fd_vote_states.h"
+#include "sysvar/fd_sysvar_clock.h"
+#include "program/fd_builtin_programs.h"
+#include "fd_runtime_const.h"
+
+/* fd_runtime_stack_t serves as stack memory to store temporary data
+   for the runtime.  This object should only be used and owned by the
+   replay tile and is used for short-lived allocations for the runtime,
+   more specifically, for slot level calculations. */
+union fd_runtime_stack {
+
+  struct {
+    /* Staging memory to sort vote accounts by last vote timestamp for
+       clock sysvar calculation. */
+    ts_est_ele_t staked_ts[ FD_RUNTIME_MAX_VOTE_ACCOUNTS ];
+  } clock_ts;
+
+  struct {
+    /* Staging memory for bpf migration.  This is used to store and
+       stage various accounts which is required for deploying a new BPF
+       program at the epoch boundary. */
+    fd_tmp_account_t source;
+    fd_tmp_account_t program_account;
+    fd_tmp_account_t new_target_program;
+    fd_tmp_account_t new_target_program_data;
+    fd_tmp_account_t empty;
+  } bpf_migration;
+
+  struct {
+
+    /* Vote state credits as of the end of the previous epoch.  This
+       only used at boot to recalculate partitioned epoch rewards if
+       needed and is not updated after. */
+    int                     prev_vote_credits_used;
+    fd_vote_state_credits_t vote_credits[ FD_RUNTIME_MAX_VOTE_ACCOUNTS ];
+
+    /* Staging memory for vote rewards as they are accumulated. */
+    ulong                   vote_rewards[ FD_RUNTIME_MAX_VOTE_ACCOUNTS ];
+
+    /* Staging memory used for calculating and sorting vote account
+       stake weights for the leader schedule calculation. */
+    fd_vote_stake_weight_t  stake_weights[ FD_RUNTIME_MAX_VOTE_ACCOUNTS ];
+  } stakes;
+};
+typedef union fd_runtime_stack fd_runtime_stack_t;
+
+#endif /* HEADER_fd_src_flamenco_runtime_fd_runtime_stack_h */

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -2618,10 +2618,13 @@ fd_directly_invoke_loader_v3_deploy( fd_bank_t *               bank,
                                      fd_funk_txn_xid_t const * xid,
                                      fd_pubkey_t const *       program_key,
                                      uchar const *             elf,
-                                     ulong                     elf_sz,
-                                     fd_spad_t *               runtime_spad ) {
+                                     ulong                     elf_sz ) {
+  /* FIXME: Breaking this until exec spad is replaced. */
+  FD_LOG_ERR(( "fd_directly_invoke_loader_v3_deploy is not implemented" ));
+  return 0;
+
   /* Set up a dummy instr and txn context */
-  fd_exec_txn_ctx_t * txn_ctx = fd_exec_txn_ctx_join( fd_exec_txn_ctx_new( fd_spad_alloc( runtime_spad, FD_EXEC_TXN_CTX_ALIGN, FD_EXEC_TXN_CTX_FOOTPRINT ) ), runtime_spad, fd_wksp_containing( runtime_spad ) );
+  fd_exec_txn_ctx_t * txn_ctx = fd_exec_txn_ctx_join( fd_exec_txn_ctx_new( NULL ), NULL, NULL );
 
   fd_exec_txn_ctx_setup( bank,
                          accdb_shfunk,
@@ -2649,5 +2652,5 @@ fd_directly_invoke_loader_v3_deploy( fd_bank_t *               bank,
      needed because the next time the program is invoked, the program
      cache updating logic will see that the cache entry is missing and
      will insert it then. */
-  return fd_deploy_program( instr_ctx, program_key, elf, elf_sz, runtime_spad );
+  return fd_deploy_program( instr_ctx, program_key, elf, elf_sz, NULL );
 }

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.h
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.h
@@ -83,12 +83,15 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * instr_ctx );
 
 /* Public APIs */
 
-/* This function is called from `fd_runtime.c` and only performs the ELF and VM validation checks necessary
-   to deploy a program, specifically for the core native program BPF migration. Since this call is done at
-   the epoch boundary every time a new BPF core migration feature is activated, we need to mock up a transaction
-   and instruction context for execution. We do not do any funk operations here - instead, the BPF cache entry
-   will be created at the end of the block. Because of this, our logic is slightly different than Agave's.
-   See the documentation for our `fd_deploy_program` for more information.
+/* This function is called from `fd_runtime.c` and only performs the ELF
+   and VM validation checks necessary to deploy a program, specifically
+   for the core native program BPF migration. Since this call is done at
+   the epoch boundary every time a new BPF core migration feature is
+   activated, we need to mock up a transaction and instruction context
+   for execution.  We do not do any funk operations here - instead, the
+   BPF cache entry will be created at the end of the block.  Because of
+   this, our logic is slightly different than Agave's.  See the
+   documentation for our `fd_deploy_program` for more information.
 
    https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank/builtins/core_bpf_migration/mod.rs#L155-L233 */
 int
@@ -97,8 +100,7 @@ fd_directly_invoke_loader_v3_deploy( fd_bank_t *               bank,
                                      fd_funk_txn_xid_t const * xid,
                                      fd_pubkey_t const *       program_key,
                                      uchar const *             elf,
-                                     ulong                     elf_sz,
-                                     fd_spad_t *               runtime_spad );
+                                     ulong                     elf_sz );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/program/fd_builtin_programs.h
+++ b/src/flamenco/runtime/program/fd_builtin_programs.h
@@ -48,6 +48,14 @@ struct fd_precompile_program {
 };
 typedef struct fd_precompile_program fd_precompile_program_t;
 
+struct fd_tmp_account {
+  fd_pubkey_t       addr;
+  fd_account_meta_t meta;
+  uchar             data[FD_RUNTIME_ACC_SZ_MAX]__attribute__((aligned(8UL)));
+  ulong             data_sz;
+};
+typedef struct fd_tmp_account fd_tmp_account_t;
+
 FD_PROTOTYPES_BEGIN
 
 /* Initialize the builtin program accounts */
@@ -104,8 +112,8 @@ void
 fd_migrate_builtin_to_core_bpf( fd_bank_t *                            bank,
                                 fd_accdb_user_t *                      accdb,
                                 fd_funk_txn_xid_t const *              xid,
+                                fd_runtime_stack_t *                   runtime_stack,
                                 fd_core_bpf_migration_config_t const * config,
-                                fd_spad_t *                            runtime_spad,
                                 fd_capture_ctx_t *                     capture_ctx );
 
 FD_PROTOTYPES_END

--- a/src/flamenco/runtime/sysvar/fd_sysvar_clock.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_clock.h
@@ -17,6 +17,14 @@
 
 FD_PROTOTYPES_BEGIN
 
+/* ts_est_ele_t is a temporary struct used for sorting vote accounts by
+   last vote timestamp for clock sysvar calculation. */
+struct ts_est_ele {
+  long    timestamp;
+  uint128 stake; /* should really be fine as ulong, but we match Agave */
+};
+typedef struct ts_est_ele ts_est_ele_t;
+
 /* The clock sysvar provides an approximate measure of network time. */
 
 /* fd_sysvar_clock_init initializes the sysvar account to genesis state. */
@@ -39,6 +47,7 @@ fd_sysvar_clock_update( fd_bank_t *               bank,
                         fd_accdb_user_t *         accdb,
                         fd_funk_txn_xid_t const * xid,
                         fd_capture_ctx_t *        capture_ctx,
+                        fd_runtime_stack_t *      runtime_stack,
                         ulong const *             parent_epoch );
 
 /* Writes the current value of the clock sysvar to funk. */

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
@@ -4,28 +4,21 @@
 #include "../fd_system_ids.h"
 /* FIXME These constants should be header defines */
 
-/* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/slot_hashes.rs#L11 */
-FD_FN_UNUSED static const ulong slot_hashes_max_entries = 512;
-
-/* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/sysvar/slot_hashes.rs#L12 */
-static const ulong slot_hashes_account_size = 20488;
-
 void
 fd_sysvar_slot_hashes_write( fd_bank_t *               bank,
                              fd_accdb_user_t *         accdb,
                              fd_funk_txn_xid_t const * xid,
                              fd_capture_ctx_t *        capture_ctx,
                              fd_slot_hashes_global_t * slot_hashes_global ) {
-  uchar enc[slot_hashes_account_size];
-  fd_memset( enc, 0, slot_hashes_account_size );
+  uchar __attribute__((aligned(FD_SYSVAR_SLOT_HASHES_ALIGN))) enc[ FD_SYSVAR_SLOT_HASHES_BINCODE_SZ ] = {0};
   fd_bincode_encode_ctx_t ctx = {
     .data    = enc,
-    .dataend = enc + slot_hashes_account_size,
+    .dataend = enc + FD_SYSVAR_SLOT_HASHES_BINCODE_SZ,
   };
   if( fd_slot_hashes_encode_global( slot_hashes_global, &ctx ) ) {
     FD_LOG_ERR(("fd_slot_hashes_encode failed"));
   }
-  fd_sysvar_account_update( bank, accdb, xid, capture_ctx, &fd_sysvar_slot_hashes_id, enc, slot_hashes_account_size );
+  fd_sysvar_account_update( bank, accdb, xid, capture_ctx, &fd_sysvar_slot_hashes_id, enc, FD_SYSVAR_SLOT_HASHES_BINCODE_SZ );
 }
 
 ulong
@@ -78,73 +71,54 @@ fd_sysvar_slot_hashes_delete( void * mem ) {
   return mem;
 }
 
-void
-fd_sysvar_slot_hashes_init( fd_bank_t *               bank,
-                            fd_accdb_user_t *         accdb,
-                            fd_funk_txn_xid_t const * xid,
-                            fd_capture_ctx_t *        capture_ctx,
-                            fd_spad_t *               runtime_spad ) {
-  FD_SPAD_FRAME_BEGIN( runtime_spad ) {
-    void * mem                                   = fd_spad_alloc( runtime_spad, FD_SYSVAR_SLOT_HASHES_ALIGN, fd_sysvar_slot_hashes_footprint( FD_SYSVAR_SLOT_HASHES_CAP ) );
-    fd_slot_hash_t * shnull                      = NULL;
-    fd_slot_hashes_global_t * slot_hashes_global = fd_sysvar_slot_hashes_join( fd_sysvar_slot_hashes_new( mem, FD_SYSVAR_SLOT_HASHES_CAP ), &shnull );
-
-    fd_sysvar_slot_hashes_write( bank, accdb, xid, capture_ctx, slot_hashes_global );
-    fd_sysvar_slot_hashes_delete( fd_sysvar_slot_hashes_leave( slot_hashes_global, shnull ) );
-  } FD_SPAD_FRAME_END;
-}
-
 /* https://github.com/anza-xyz/agave/blob/b11ca828cfc658b93cb86a6c5c70561875abe237/runtime/src/bank.rs#L2283-L2294 */
 void
 fd_sysvar_slot_hashes_update( fd_bank_t *               bank,
                               fd_accdb_user_t *         accdb,
                               fd_funk_txn_xid_t const * xid,
-                              fd_capture_ctx_t *        capture_ctx,
-                              fd_spad_t *               runtime_spad ) {
-  FD_SPAD_FRAME_BEGIN( runtime_spad ) {
-    fd_slot_hashes_global_t * slot_hashes_global = fd_sysvar_slot_hashes_read( accdb->funk, xid, runtime_spad );
-    fd_slot_hash_t *          hashes             = NULL;
-    if( FD_UNLIKELY( !slot_hashes_global ) ) {
-      /* Note: Agave's implementation initializes a new slot_hashes if it doesn't already exist (refer to above URL). */
-      void * mem = fd_spad_alloc( runtime_spad, FD_SYSVAR_SLOT_HASHES_ALIGN, fd_sysvar_slot_hashes_footprint( FD_SYSVAR_SLOT_HASHES_CAP ) );
-      slot_hashes_global = fd_sysvar_slot_hashes_new( mem, FD_SYSVAR_SLOT_HASHES_CAP );
+                              fd_capture_ctx_t *        capture_ctx ) {
+  uchar __attribute__((aligned(FD_SYSVAR_SLOT_HASHES_ALIGN))) slot_hashes_mem[FD_SYSVAR_SLOT_HASHES_FOOTPRINT];
+  fd_slot_hashes_global_t * slot_hashes_global = fd_sysvar_slot_hashes_read( accdb->funk, xid, slot_hashes_mem );
+  fd_slot_hash_t *          hashes             = NULL;
+  if( FD_UNLIKELY( !slot_hashes_global ) ) {
+    /* Note: Agave's implementation initializes a new slot_hashes if it doesn't already exist (refer to above URL). */
+    slot_hashes_global = fd_sysvar_slot_hashes_new( slot_hashes_mem, FD_SYSVAR_SLOT_HASHES_CAP );
+  }
+  slot_hashes_global = fd_sysvar_slot_hashes_join( slot_hashes_global, &hashes );
+
+  uchar found = 0;
+  for( deq_fd_slot_hash_t_iter_t iter = deq_fd_slot_hash_t_iter_init( hashes );
+        !deq_fd_slot_hash_t_iter_done( hashes, iter );
+        iter = deq_fd_slot_hash_t_iter_next( hashes, iter ) ) {
+    fd_slot_hash_t * ele = deq_fd_slot_hash_t_iter_ele( hashes, iter );
+    if( ele->slot == fd_bank_parent_slot_get( bank ) ) {
+      fd_hash_t const * bank_hash = fd_bank_bank_hash_query( bank );
+      memcpy( &ele->hash, bank_hash, sizeof(fd_hash_t) );
+      found = 1;
     }
-    slot_hashes_global = fd_sysvar_slot_hashes_join( slot_hashes_global, &hashes );
+  }
 
-    uchar found = 0;
-    for( deq_fd_slot_hash_t_iter_t iter = deq_fd_slot_hash_t_iter_init( hashes );
-         !deq_fd_slot_hash_t_iter_done( hashes, iter );
-         iter = deq_fd_slot_hash_t_iter_next( hashes, iter ) ) {
-      fd_slot_hash_t * ele = deq_fd_slot_hash_t_iter_ele( hashes, iter );
-      if( ele->slot == fd_bank_parent_slot_get( bank ) ) {
-        fd_hash_t const * bank_hash = fd_bank_bank_hash_query( bank );
-        memcpy( &ele->hash, bank_hash, sizeof(fd_hash_t) );
-        found = 1;
-      }
-    }
+  if( !found ) {
+    // https://github.com/firedancer-io/solana/blob/08a1ef5d785fe58af442b791df6c4e83fe2e7c74/runtime/src/bank.rs#L2371
+    fd_slot_hash_t slot_hash = {
+      .hash = fd_bank_bank_hash_get( bank ), // parent hash?
+      .slot = fd_bank_parent_slot_get( bank ),   // parent_slot
+    };
 
-    if( !found ) {
-      // https://github.com/firedancer-io/solana/blob/08a1ef5d785fe58af442b791df6c4e83fe2e7c74/runtime/src/bank.rs#L2371
-      fd_slot_hash_t slot_hash = {
-        .hash = fd_bank_bank_hash_get( bank ), // parent hash?
-        .slot = fd_bank_parent_slot_get( bank ),   // parent_slot
-      };
+    if( deq_fd_slot_hash_t_full( hashes ) )
+      memset( deq_fd_slot_hash_t_pop_tail_nocopy( hashes ), 0, sizeof(fd_slot_hash_t) );
 
-      if( deq_fd_slot_hash_t_full( hashes ) )
-        memset( deq_fd_slot_hash_t_pop_tail_nocopy( hashes ), 0, sizeof(fd_slot_hash_t) );
+    deq_fd_slot_hash_t_push_head( hashes, slot_hash );
+  }
 
-      deq_fd_slot_hash_t_push_head( hashes, slot_hash );
-    }
-
-    fd_sysvar_slot_hashes_write( bank, accdb, xid, capture_ctx, slot_hashes_global );
-    fd_sysvar_slot_hashes_leave( slot_hashes_global, hashes );
-  } FD_SPAD_FRAME_END;
+  fd_sysvar_slot_hashes_write( bank, accdb, xid, capture_ctx, slot_hashes_global );
+  fd_sysvar_slot_hashes_leave( slot_hashes_global, hashes );
 }
 
 fd_slot_hashes_global_t *
 fd_sysvar_slot_hashes_read( fd_funk_t *               funk,
                             fd_funk_txn_xid_t const * xid,
-                            fd_spad_t *               spad ) {
+                            uchar *                   slot_hashes_mem ) {
   fd_txn_account_t rec[1];
   int err = fd_txn_account_init_from_funk_readonly( rec, (fd_pubkey_t const *)&fd_sysvar_slot_hashes_id, funk, xid );
   if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
@@ -155,7 +129,7 @@ fd_sysvar_slot_hashes_read( fd_funk_t *               funk,
      exists in the accounts database, but doesn't have any lamports,
      this means that the account does not exist. This wouldn't happen
      in a real execution environment. */
-  if( FD_UNLIKELY( fd_txn_account_get_lamports( rec )==0 ) ) {
+  if( FD_UNLIKELY( fd_txn_account_get_lamports( rec )==0UL ) ) {
     return NULL;
   }
 
@@ -164,17 +138,5 @@ fd_sysvar_slot_hashes_read( fd_funk_t *               funk,
     .dataend = fd_txn_account_get_data( rec ) + fd_txn_account_get_data_len( rec )
   };
 
-  ulong total_sz = 0UL;
-  err = fd_slot_hashes_decode_footprint( &decode, &total_sz );
-  if( FD_UNLIKELY( err ) ) {
-    return NULL;
-  }
-
-  uchar * mem = fd_spad_alloc( spad, fd_slot_hashes_align(), total_sz );
-
-  if( FD_UNLIKELY( !mem ) ) {
-    FD_LOG_ERR(( "Unable to allocate memory for slot hashes" ));
-  }
-
-  return fd_slot_hashes_decode_global( mem, &decode );
+  return fd_slot_hashes_decode_global( slot_hashes_mem, &decode );
 }

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.h
@@ -12,7 +12,7 @@
 
    https://github.com/anza-xyz/agave/blob/6398ddf6ab8a8f81017bf675ab315a70067f0bf0/sdk/program/src/slot_hashes.rs#L19 */
 
-#define FD_SYSVAR_SLOT_HASHES_CAP   (512UL)
+#define FD_SYSVAR_SLOT_HASHES_CAP (512UL)
 
 FD_PROTOTYPES_BEGIN
 
@@ -42,20 +42,12 @@ fd_sysvar_slot_hashes_write( fd_bank_t *               bank,
                              fd_capture_ctx_t *        capture_ctx,
                              fd_slot_hashes_global_t * slot_hashes_global );
 
-void
-fd_sysvar_slot_hashes_init( fd_bank_t *               bank,
-                            fd_accdb_user_t *         accdb,
-                            fd_funk_txn_xid_t const * xid,
-                            fd_capture_ctx_t *        capture_ctx,
-                            fd_spad_t *               runtime_spad );
-
 /* Update the slot hashes sysvar account. This should be called at the end of every slot, before execution commences. */
 void
 fd_sysvar_slot_hashes_update( fd_bank_t *               bank,
                               fd_accdb_user_t *         accdb,
                               fd_funk_txn_xid_t const * xid,
-                              fd_capture_ctx_t *        capture_ctx,
-                              fd_spad_t *               runtime_spad );
+                              fd_capture_ctx_t *        capture_ctx );
 
 /* fd_sysvar_slot_hashes_read reads the slot hashes sysvar from funk.
    If the account doesn't exist in funk or if the account has zero
@@ -63,7 +55,7 @@ fd_sysvar_slot_hashes_update( fd_bank_t *               bank,
 fd_slot_hashes_global_t *
 fd_sysvar_slot_hashes_read( fd_funk_t *               funk,
                             fd_funk_txn_xid_t const * xid,
-                            fd_spad_t *               spad );
+                            uchar *                   slot_hashes_mem );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
@@ -7,18 +7,22 @@
 
 /* FIXME These constants should be header defines */
 
-static const ulong slot_history_min_account_size = 131097;
+#define FD_SLOT_HISTORY_MIN_ACCOUNT_SIZE (131097UL)
+
+#define FD_SLOT_HISTORY_DECODED_SIZE (sizeof(fd_slot_history_global_t) + ((sizeof(ulong) * FD_SLOT_HISTORY_BLOCKS_LEN)) )
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/slot_history.rs#L37 */
-static const ulong slot_history_max_entries = 1024 * 1024;
+#define FD_SLOT_HISTORY_MAX_ENTRIES (1024UL * 1024UL)
 
 /* TODO: move into separate bitvec library */
-static const ulong bits_per_block = 8 * sizeof(ulong);
+#define FD_SLOT_HISTORY_BITS_PER_BLOCK (8UL * sizeof(ulong))
+
+#define FD_SLOT_HISTORY_BLOCKS_LEN (FD_SLOT_HISTORY_MAX_ENTRIES / FD_SLOT_HISTORY_BITS_PER_BLOCK)
 
 void
 fd_sysvar_slot_history_set( fd_slot_history_global_t * history,
                             ulong                      i ) {
-  if( FD_UNLIKELY( i > history->next_slot && i - history->next_slot >= slot_history_max_entries ) ) {
+  if( FD_UNLIKELY( i > history->next_slot && i - history->next_slot >= FD_SLOT_HISTORY_MAX_ENTRIES ) ) {
     FD_LOG_WARNING(( "Ignoring out of bounds (i=%lu next_slot=%lu)", i, history->next_slot ));
     return;
   }
@@ -29,14 +33,13 @@ fd_sysvar_slot_history_set( fd_slot_history_global_t * history,
   // Skipped slots, delete them from history
   if( FD_UNLIKELY( blocks_len == 0 ) ) return;
   for( ulong j = history->next_slot; j < i; j++ ) {
-    ulong block_idx = (j / bits_per_block) % (blocks_len);
-    blocks[ block_idx ] &= ~( 1UL << ( j % bits_per_block ) );
+    ulong block_idx = (j / FD_SLOT_HISTORY_BITS_PER_BLOCK) % (blocks_len);
+    blocks[ block_idx ] &= ~( 1UL << ( j % FD_SLOT_HISTORY_BITS_PER_BLOCK ) );
   }
-  ulong block_idx = (i / bits_per_block) % (blocks_len);
-  blocks[ block_idx ] |= ( 1UL << ( i % bits_per_block ) );
+  ulong block_idx = (i / FD_SLOT_HISTORY_BITS_PER_BLOCK) % (blocks_len);
+  blocks[ block_idx ] |= ( 1UL << ( i % FD_SLOT_HISTORY_BITS_PER_BLOCK ) );
 }
 
-FD_FN_UNUSED static const ulong blocks_len = slot_history_max_entries / bits_per_block;
 
 void
 fd_sysvar_slot_history_write_history( fd_bank_t *                bank,
@@ -44,15 +47,14 @@ fd_sysvar_slot_history_write_history( fd_bank_t *                bank,
                                       fd_funk_txn_xid_t const *  xid,
                                       fd_capture_ctx_t *         capture_ctx,
                                       fd_slot_history_global_t * history ) {
-  ulong sz = slot_history_min_account_size;
-  uchar enc[ sz ];
-  fd_memset( enc, 0, sz );
-  fd_bincode_encode_ctx_t ctx;
-  ctx.data    = enc;
-  ctx.dataend = enc + sz;
+  uchar __attribute__((aligned(FD_SLOT_HISTORY_GLOBAL_ALIGN))) slot_history_mem[ FD_SLOT_HISTORY_MIN_ACCOUNT_SIZE ] = {0};
+  fd_bincode_encode_ctx_t ctx = {
+    .data    = slot_history_mem,
+    .dataend = slot_history_mem + FD_SLOT_HISTORY_MIN_ACCOUNT_SIZE
+  };
   int err = fd_slot_history_encode_global( history, &ctx );
   if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) FD_LOG_ERR(( "fd_slot_history_encode_global failed" ));
-  fd_sysvar_account_update( bank, accdb, xid, capture_ctx, &fd_sysvar_slot_history_id, enc, sz );
+  fd_sysvar_account_update( bank, accdb, xid, capture_ctx, &fd_sysvar_slot_history_id, slot_history_mem, FD_SLOT_HISTORY_MIN_ACCOUNT_SIZE );
 }
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/slot_history.rs#L16 */
@@ -61,30 +63,23 @@ void
 fd_sysvar_slot_history_init( fd_bank_t *               bank,
                              fd_accdb_user_t *         accdb,
                              fd_funk_txn_xid_t const * xid,
-                             fd_capture_ctx_t *        capture_ctx,
-                             fd_spad_t *               runtime_spad ) {
-  FD_SPAD_FRAME_BEGIN( runtime_spad ) {
+                             fd_capture_ctx_t *        capture_ctx ) {
   /* Create a new slot history instance */
 
   /* We need to construct the gaddr-aware slot history object */
-  ulong total_sz = sizeof(fd_slot_history_global_t) + alignof(fd_slot_history_global_t) +
-                   (sizeof(ulong) + alignof(ulong)) * blocks_len;
-
-  uchar * mem = fd_spad_alloc( runtime_spad, alignof(fd_slot_history_global_t), total_sz );
-  fd_slot_history_global_t * history = (fd_slot_history_global_t *)mem;
+  uchar __attribute__((aligned(FD_SLOT_HISTORY_GLOBAL_ALIGN))) slot_history_mem[ FD_SLOT_HISTORY_DECODED_SIZE ] = {0};
+  fd_slot_history_global_t * history = (fd_slot_history_global_t *)slot_history_mem;
   ulong *                    blocks  = (ulong *)fd_ulong_align_up( (ulong)((uchar*)history + sizeof(fd_slot_history_global_t)), alignof(ulong) );
 
   history->next_slot          = fd_bank_slot_get( bank ) + 1UL;
   history->bits_bitvec_offset = (ulong)((uchar*)blocks - (uchar*)history);
-  history->bits_len           = slot_history_max_entries;
-  history->bits_bitvec_len    = blocks_len;
+  history->bits_len           = FD_SLOT_HISTORY_MAX_ENTRIES;
+  history->bits_bitvec_len    = FD_SLOT_HISTORY_BLOCKS_LEN;
   history->has_bits           = 1;
-  memset( blocks, 0, sizeof(ulong) * blocks_len );
 
   /* TODO: handle slot != 0 init case */
   fd_sysvar_slot_history_set( history, fd_bank_slot_get( bank ) );
   fd_sysvar_slot_history_write_history( bank, accdb, xid, capture_ctx, history );
-  } FD_SPAD_FRAME_END;
 }
 
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/runtime/src/bank.rs#L2345 */
@@ -98,22 +93,15 @@ fd_sysvar_slot_history_update( fd_bank_t *               bank,
 
   fd_txn_account_t rec[1];
   int err = fd_txn_account_init_from_funk_readonly( rec, key, accdb->funk, xid );
-  if (err)
-    FD_LOG_CRIT(( "fd_txn_account_init_from_funk_readonly(slot_history) failed: %d", err ));
+  if( FD_UNLIKELY( err ) ) FD_LOG_CRIT(( "fd_txn_account_init_from_funk_readonly(slot_history) failed: %d", err ));
 
   fd_bincode_decode_ctx_t ctx = {
     .data    = fd_txn_account_get_data( rec ),
     .dataend = fd_txn_account_get_data( rec ) + fd_txn_account_get_data_len( rec )
   };
 
-  ulong total_sz = 0UL;
-  err = fd_slot_history_decode_footprint( &ctx, &total_sz );
-  if( FD_UNLIKELY( err ) ) {
-    FD_LOG_CRIT(( "fd_slot_history_decode_footprint failed %d", err ));
-  }
-
-  uchar mem[ total_sz ];
-  fd_slot_history_global_t * history = fd_slot_history_decode_global( mem, &ctx );
+  uchar __attribute__((aligned(FD_SLOT_HISTORY_GLOBAL_ALIGN))) slot_history_mem[ FD_SLOT_HISTORY_MIN_ACCOUNT_SIZE ] = {0};
+  fd_slot_history_global_t * history = fd_slot_history_decode_global( slot_history_mem, &ctx );
 
   /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/slot_history.rs#L48 */
   fd_sysvar_slot_history_set( history, fd_bank_slot_get( bank ) );
@@ -161,23 +149,21 @@ fd_sysvar_slot_history_read( fd_funk_t *               funk,
 
 int
 fd_sysvar_slot_history_find_slot( fd_slot_history_global_t const * history,
-                                  ulong                            slot,
-                                  fd_wksp_t *                      wksp ) {
-  (void)wksp;
+                                  ulong                            slot ) {
+
   ulong * blocks = (ulong *)((uchar*)history + history->bits_bitvec_offset);
   if( FD_UNLIKELY( !blocks ) ) {
     FD_LOG_ERR(( "Unable to find slot history blocks" ));
   }
   ulong blocks_len = history->bits_bitvec_len;
 
-
   if( slot > history->next_slot - 1UL ) {
     return FD_SLOT_HISTORY_SLOT_FUTURE;
-  } else if ( slot < fd_ulong_sat_sub( history->next_slot, slot_history_max_entries ) ) {
+  } else if ( slot < fd_ulong_sat_sub( history->next_slot, FD_SLOT_HISTORY_MAX_ENTRIES ) ) {
     return FD_SLOT_HISTORY_SLOT_TOO_OLD;
   } else {
-    ulong block_idx = (slot / bits_per_block) % blocks_len;
-    if( blocks[ block_idx ] & ( 1UL << ( slot % bits_per_block ) ) ) {
+    ulong block_idx = (slot / FD_SLOT_HISTORY_BITS_PER_BLOCK) % blocks_len;
+    if( blocks[ block_idx ] & ( 1UL << ( slot % FD_SLOT_HISTORY_BITS_PER_BLOCK ) ) ) {
       return FD_SLOT_HISTORY_SLOT_FOUND;
     } else {
       return FD_SLOT_HISTORY_SLOT_NOT_FOUND;

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.h
@@ -18,8 +18,7 @@ void
 fd_sysvar_slot_history_init( fd_bank_t *               bank,
                              fd_accdb_user_t *         accdb,
                              fd_funk_txn_xid_t const * xid,
-                             fd_capture_ctx_t *        capture_ctx,
-                             fd_spad_t *               runtime_spad );
+                             fd_capture_ctx_t *        capture_ctx );
 
 /* Update the slot history sysvar account. This should be called at the
    end of every slot, after execution has concluded. */
@@ -40,7 +39,6 @@ fd_sysvar_slot_history_read( fd_funk_t *               funk,
 
 int
 fd_sysvar_slot_history_find_slot( fd_slot_history_global_t const * history,
-                                  ulong                            slot,
-                                  fd_wksp_t *                      wksp );
+                                  ulong                            slot );
 
 #endif /* HEADER_fd_src_flamenco_runtime_sysvar_fd_sysvar_slot_history_h */

--- a/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.c
@@ -14,8 +14,7 @@ write_stake_history( fd_bank_t *               bank,
                      fd_capture_ctx_t *        capture_ctx,
                      fd_stake_history_t *      stake_history ) {
   /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/sysvar/stake_history.rs#L12 */
-  uchar enc[FD_SYSVAR_STAKE_HISTORY_BINCODE_SZ] = {0};
-
+  uchar __attribute__((aligned(FD_STAKE_HISTORY_ALIGN))) enc[ FD_SYSVAR_STAKE_HISTORY_BINCODE_SZ ] = {0};
   fd_bincode_encode_ctx_t encode =
     { .data    = enc,
       .dataend = enc + sizeof(enc) };

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -112,7 +112,8 @@ fd_runtime_fuzz_txn_ctx_create( fd_solfuzz_runner_t *              runner,
   FD_TEST( rent );
   fd_bank_rent_set( runner->bank, *rent );
 
-  fd_slot_hashes_global_t * slot_hashes = fd_sysvar_slot_hashes_read( funk, &xid, runner->spad );
+  uchar __attribute__((aligned(FD_SLOT_HASHES_GLOBAL_ALIGN))) slot_hashes_mem[ FD_SYSVAR_SLOT_HASHES_FOOTPRINT ];
+  fd_slot_hashes_global_t * slot_hashes = fd_sysvar_slot_hashes_read( funk, &xid, slot_hashes_mem );
   FD_TEST( slot_hashes );
 
   fd_stake_history_t stake_history_[1];
@@ -124,7 +125,7 @@ fd_runtime_fuzz_txn_ctx_create( fd_solfuzz_runner_t *              runner,
   FD_TEST( clock );
 
   /* Setup vote states dummy account */
-  fd_vote_states_t * vote_states = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_locking_modify( runner->bank ), FD_RUNTIME_MAX_WRITABLE_ACCOUNTS_PER_TRANSACTION, 999UL ) );
+  fd_vote_states_t * vote_states = fd_vote_states_join( fd_vote_states_new( fd_bank_vote_states_locking_modify( runner->bank ), 64UL, 999UL ) );
   if( FD_UNLIKELY( !vote_states ) ) {
     fd_bank_vote_states_end_locking_modify( runner->bank );
     return NULL;

--- a/src/flamenco/runtime/tests/run_ledger_backtest.sh
+++ b/src/flamenco/runtime/tests/run_ledger_backtest.sh
@@ -231,7 +231,6 @@ echo "
         ingest_mode = \"$INGEST_MODE\"
     [tiles.replay]
         cluster_version = \"$CLUSTER_VERSION\"
-        heap_size_gib = 50
         enable_features = [ $FORMATTED_ONE_OFFS ]
     [tiles.gui]
         enabled = false

--- a/src/flamenco/runtime/tests/run_nightly_backtest.sh
+++ b/src/flamenco/runtime/tests/run_nightly_backtest.sh
@@ -97,7 +97,6 @@ echo "
         snapshot = \"$SNAPSHOT\"
         cluster_version = \"$CLUSTER_VERSION\"
         enable_features = [ \"$ONE_OFFS\" ]
-        heap_size_gib = 50
     [tiles.gui]
         enabled = false
 [funk]

--- a/src/flamenco/stakes/fd_vote_states.c
+++ b/src/flamenco/stakes/fd_vote_states.c
@@ -331,7 +331,6 @@ fd_vote_states_reset_stakes( fd_vote_states_t * vote_states ) {
 
     vote_state->stake     = 0UL;
     vote_state->stake_t_2 = 0UL;
-    vote_state->rewards   = 0UL;
   }
 }
 

--- a/src/flamenco/stakes/fd_vote_states.h
+++ b/src/flamenco/stakes/fd_vote_states.h
@@ -87,10 +87,6 @@ struct fd_vote_state_ele {
   ulong       last_vote_slot;
   long        last_vote_timestamp;
   uchar       commission;
-
-  /* This field is only used at the epoch boundary to stage rewards for
-     each vote account. */
-  ulong       rewards;
 };
 typedef struct fd_vote_state_ele fd_vote_state_ele_t;
 


### PR DESCRIPTION
saves ~30 gb to run live