### PR TITLE
Add Archlinux support

### DIFF
--- a/config/extra/with-rocksdb.mk
+++ b/config/extra/with-rocksdb.mk
@@ -4,6 +4,12 @@ ifneq (,$(wildcard $(OPT)/lib/libzstd.a))
 FD_HAS_ROCKSDB:=1
 CFLAGS+=-DFD_HAS_ROCKSDB=1 -DROCKSDB_LITE=1
 ROCKSDB_LIBS:=$(OPT)/lib/librocksdb.a $(OPT)/lib/libsnappy.a
+
+# RocksDB enables io_uring support opportunistically; only link liburing when
+# the static archive actually references its symbols (e.g. Arch Linux builds).
+ifneq (,$(shell nm -A $(OPT)/lib/librocksdb.a 2>/dev/null | grep -F io_uring_queue_init))
+ROCKSDB_LIBS+=-luring
+endif
 else
 $(warning "zstd not installed, skipping rocksdb")
 endif

--- a/src/app/shared/commands/monitor/monitor.c
+++ b/src/app/shared/commands/monitor/monitor.c
@@ -265,7 +265,7 @@ static struct termios termios_backup;
 
 static void
 restore_terminal( void ) {
-  (void)tcsetattr( STDIN_FILENO, TCSANOW, &termios_backup );
+  (void)ioctl( STDIN_FILENO, TCSETS, &termios_backup );
 }
 
 static void
@@ -315,15 +315,15 @@ run_monitor( config_t const * config,
 
   /* Restore original terminal attributes at exit */
   atexit( restore_terminal );
-  if( FD_UNLIKELY( 0!=tcgetattr( STDIN_FILENO, &termios_backup ) ) ) {
-    FD_LOG_ERR(( "tcgetattr(STDIN_FILENO) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  if( FD_UNLIKELY( ioctl( STDIN_FILENO, TCGETS, &termios_backup ) ) ) {
+    FD_LOG_ERR(( "ioctl(STDIN_FILENO) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
   }
 
   /* Disable character echo and line buffering */
   struct termios term = termios_backup;
   term.c_lflag &= (tcflag_t)~(ICANON | ECHO);
-  if( FD_UNLIKELY( 0!=tcsetattr( STDIN_FILENO, TCSANOW, &term ) ) ) {
-    FD_LOG_WARNING(( "tcsetattr(STDIN_FILENO) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  if( FD_UNLIKELY( ioctl( STDIN_FILENO, TCSETS, &term ) ) ) {
+    FD_LOG_WARNING(( "ioctl(STDIN_FILENO) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
   }
 
   for(;;) {


### PR DESCRIPTION
Hack for enabling further progress on Arch 6.12.52-1-lts with gcc-12. Tested and working on Ubuntu 24.04.3.

Explanation:
<img width="820" height="234" alt="image" src="https://github.com/user-attachments/assets/1a3393d6-bc39-49c7-9340-9838f948a9b6" />
```
• The patch stops going through glibc’s tcgetattr/tcsetattr wrappers and issues
  the exact ioctl calls that our seccomp profile already allows. With glibc 2.39
  those wrappers now probe TCGETS2/TCSETS2 first; that request code is not on the
  allow list, so the kernel kills the monitor with SIGSYS before glibc can fall
  back to TCGETS/TCSETS. By calling ioctl(STDIN_FILENO, TCGETS/TCSETS, …) ourselves
  (src/app/shared/commands/monitor/monitor.c:268, src/app/shared/commands/monitor/
  monitor.c:318, src/app/shared/commands/monitor/monitor.c:325), the monitor only
  issues the legacy requests that are whitelisted in the seccomp filter (src/app/
  shared/commands/monitor/generated/monitor_seccomp.h:83). That keeps the startup
  terminal-setup code inside the permitted syscall set, so the monitor process no
  longer trips the seccomp guard and make run succeeds.
```