### PR TITLE
restore: remove redundant memset during snap load

### DIFF
--- a/src/flamenco/runtime/fd_acc_mgr.c
+++ b/src/flamenco/runtime/fd_acc_mgr.c
@@ -54,7 +54,7 @@ fd_funk_get_acc_meta_mutable( fd_funk_t *               funk,
   fd_funk_rec_key_t id   = fd_funk_acc_key( pubkey );
 
   fd_funk_rec_query_t query[1];
-  fd_funk_rec_t * rec = (fd_funk_rec_t *)fd_funk_rec_query_try( funk, xid, &id, query );
+  fd_funk_rec_t * rec = fd_funk_rec_query_try( funk, xid, &id, query );
 
   int funk_err = 0;
 

--- a/src/funk/fd_funk_rec.c
+++ b/src/funk/fd_funk_rec.c
@@ -66,7 +66,7 @@ fd_funk_rec_key_set_pair( fd_funk_xid_key_pair_t *  key_pair,
   fd_funk_rec_key_copy( key_pair->key, key );
 }
 
-fd_funk_rec_t const *
+fd_funk_rec_t *
 fd_funk_rec_query_try( fd_funk_t *               funk,
                        fd_funk_txn_xid_t const * xid,
                        fd_funk_rec_key_t const * key,
@@ -91,7 +91,7 @@ fd_funk_rec_query_try( fd_funk_t *               funk,
     if( err == FD_MAP_ERR_AGAIN ) continue;
     FD_LOG_CRIT(( "query returned err %d", err ));
   }
-  return fd_funk_rec_map_query_ele_const( query );
+  return fd_funk_rec_map_query_ele( query );
 }
 
 

--- a/src/funk/fd_funk_rec.h
+++ b/src/funk/fd_funk_rec.h
@@ -179,7 +179,7 @@ fd_funk_rec_modify_publish( fd_funk_rec_query_t * query );
    records). fd_funk_rec_query_try will still return the record in this
    case, and the application should check for the flag. */
 
-fd_funk_rec_t const *
+fd_funk_rec_t *
 fd_funk_rec_query_try( fd_funk_t *               funk,
                        fd_funk_txn_xid_t const * xid,
                        fd_funk_rec_key_t const * key,


### PR DESCRIPTION
The snapshot loader currently zero-initializes account buffers it
allocates, which is about 15% of snapin CPU time when loading a
mainnet snapshot.

Remove this memset, since the snap tile will always fully init the
buffer when copying in account data.
