### PR TITLE
Revert test vectors script git workflow changes

### DIFF
--- a/contrib/test/run_test_vectors.sh
+++ b/contrib/test/run_test_vectors.sh
@@ -37,55 +37,9 @@ else
   cd dump/test-vectors
 fi
 
-safe_checkout() {
-  local ref="$1"
-
-  # Remove stale git lock if present
-  [ -f .git/index.lock ] && rm -f .git/index.lock
-
-  # Ensure remote URL is correct
-  if git remote get-url origin >/dev/null 2>&1; then
-    git remote set-url origin "$REPO_URL"
-  else
-    git remote add origin "$REPO_URL"
-  fi
-
-  # Clean any outstanding changes or spurious files
-  git reset -q --hard || true
-  git clean -q -fdx || true
-
-  # Fetch the exact commit (shallow first, fallback to full)
-  if ! git fetch -q --no-tags --depth=1 origin "$ref"; then
-    git fetch -q --no-tags origin "$ref"
-  fi
-
-  # Force detached checkout to the commit
-  git config advice.detachedHead false || true
-  if ! git checkout --detach -f -q "$ref"; then
-    git fetch -q --no-tags --prune origin || true
-    git checkout --detach -f -q "$ref"
-  fi
-
-  # Verify HEAD matches the requested commit
-  local head
-  head="$(git rev-parse HEAD 2>/dev/null || echo "")"
-  if [ "$head" != "$ref" ]; then
-    echo "Failed to checkout exact commit (HEAD=$head, expected $ref)"
-    return 1
-  fi
-  return 0
-}
-
-# Only perform checkout if not already at the desired commit
-current="$(git rev-parse HEAD || echo '')"
-if [ "$current" != "$GIT_REF" ]; then
-  tries=3
-  while ! safe_checkout "$GIT_REF"; do
-    tries=$((tries-1))
-    [ $tries -le 0 ] && { echo "Failed to checkout $GIT_REF"; exit 128; }
-    echo "Retrying checkout ($tries retries left)…"
-    sleep 1
-  done
+if ! git checkout -q $GIT_REF; then
+  git remote update
+  git checkout -q $GIT_REF
 fi
 cd ../..
 


### PR DESCRIPTION
This reverts the earlier changes to the test-vectors workflow after discovering they could overwrite files in the main repository when running in a git workflow. Working directory assumptions in the script led to unintentional impact outside its intended scope. This rollback restores a safe state while we redesign the test vectors to run out-of-repo.