### PR TITLE
Add missing AMD Zen 3/4/5 machine configurations

### DIFF
--- a/config/machine/linux_clang_zen3.mk
+++ b/config/machine/linux_clang_zen3.mk
@@ -1,0 +1,31 @@
+BUILDDIR?=linux/clang/zen3
+
+include config/base.mk
+include config/extra/with-clang.mk
+include config/extra/with-x86-64.mk
+include config/extra/with-debug.mk
+include config/extra/with-security.mk
+include config/extra/with-brutality.mk
+include config/extra/with-optimization.mk
+include config/extra/with-threads.mk
+
+CPPFLAGS+=-march=znver3 -mtune=znver3
+
+CPPFLAGS+=\
+  -DFD_HAS_INT128=1 \
+  -DFD_HAS_DOUBLE=1 \
+  -DFD_HAS_ALLOCA=1 \
+  -DFD_HAS_X86=1 \
+  -DFD_HAS_SSE=1 \
+  -DFD_HAS_AVX=1 \
+  -DFD_HAS_SHANI=1 \
+  -DFD_HAS_AESNI=1
+
+FD_HAS_INT128:=1
+FD_HAS_DOUBLE:=1
+FD_HAS_ALLOCA:=1
+FD_HAS_X86:=1
+FD_HAS_SSE:=1
+FD_HAS_AVX:=1
+FD_HAS_SHANI:=1
+FD_HAS_AESNI:=1

--- a/config/machine/linux_clang_zen4.mk
+++ b/config/machine/linux_clang_zen4.mk
@@ -1,0 +1,35 @@
+BUILDDIR?=linux/clang/zen4
+
+include config/base.mk
+include config/extra/with-clang.mk
+include config/extra/with-x86-64.mk
+include config/extra/with-debug.mk
+include config/extra/with-security.mk
+include config/extra/with-brutality.mk
+include config/extra/with-optimization.mk
+include config/extra/with-threads.mk
+
+CPPFLAGS+=-march=znver4 -mtune=znver4
+
+CPPFLAGS+=\
+  -DFD_HAS_INT128=1 \
+  -DFD_HAS_DOUBLE=1 \
+  -DFD_HAS_ALLOCA=1 \
+  -DFD_HAS_X86=1 \
+  -DFD_HAS_SSE=1 \
+  -DFD_HAS_AVX=1 \
+  -DFD_HAS_SHANI=1 \
+  -DFD_HAS_AESNI=1 \
+  -DFD_HAS_AVX512=1 \
+  -DFD_HAS_GFNI=1
+
+FD_HAS_INT128:=1
+FD_HAS_DOUBLE:=1
+FD_HAS_ALLOCA:=1
+FD_HAS_X86:=1
+FD_HAS_SSE:=1
+FD_HAS_AVX:=1
+FD_HAS_SHANI:=1
+FD_HAS_AESNI:=1
+FD_HAS_AVX512:=1
+FD_HAS_GFNI:=1

--- a/config/machine/linux_clang_zen5.mk
+++ b/config/machine/linux_clang_zen5.mk
@@ -1,0 +1,35 @@
+BUILDDIR?=linux/clang/zen5
+
+include config/base.mk
+include config/extra/with-clang.mk
+include config/extra/with-x86-64.mk
+include config/extra/with-debug.mk
+include config/extra/with-security.mk
+include config/extra/with-brutality.mk
+include config/extra/with-optimization.mk
+include config/extra/with-threads.mk
+
+CPPFLAGS+=-march=znver5 -mtune=znver5
+
+CPPFLAGS+=\
+  -DFD_HAS_INT128=1 \
+  -DFD_HAS_DOUBLE=1 \
+  -DFD_HAS_ALLOCA=1 \
+  -DFD_HAS_X86=1 \
+  -DFD_HAS_SSE=1 \
+  -DFD_HAS_AVX=1 \
+  -DFD_HAS_SHANI=1 \
+  -DFD_HAS_AESNI=1 \
+  -DFD_HAS_AVX512=1 \
+  -DFD_HAS_GFNI=1
+
+FD_HAS_INT128:=1
+FD_HAS_DOUBLE:=1
+FD_HAS_ALLOCA:=1
+FD_HAS_X86:=1
+FD_HAS_SSE:=1
+FD_HAS_AVX:=1
+FD_HAS_SHANI:=1
+FD_HAS_AESNI:=1
+FD_HAS_AVX512:=1
+FD_HAS_GFNI:=1

--- a/config/machine/linux_gcc_zen3.mk
+++ b/config/machine/linux_gcc_zen3.mk
@@ -1,0 +1,36 @@
+BUILDDIR?=linux/gcc/zen3
+
+include config/base.mk
+include config/extra/with-gcc.mk
+include config/extra/with-x86-64.mk
+include config/extra/with-debug.mk
+include config/extra/with-security.mk
+include config/extra/with-brutality.mk
+include config/extra/with-optimization.mk
+include config/extra/with-threads.mk
+
+# GCC 8 (Firedancer's minimum supported GCC version) only supports znver1.
+ifeq ($(shell $(CC) -dumpversion),8)
+CPPFLAGS+=-march=znver1 -mtune=znver1
+else
+CPPFLAGS+=-march=znver3 -mtune=znver3
+endif
+
+CPPFLAGS+=\
+  -DFD_HAS_INT128=1 \
+  -DFD_HAS_DOUBLE=1 \
+  -DFD_HAS_ALLOCA=1 \
+  -DFD_HAS_X86=1 \
+  -DFD_HAS_SSE=1 \
+  -DFD_HAS_AVX=1 \
+  -DFD_HAS_SHANI=1 \
+  -DFD_HAS_AESNI=1
+
+FD_HAS_INT128:=1
+FD_HAS_DOUBLE:=1
+FD_HAS_ALLOCA:=1
+FD_HAS_X86:=1
+FD_HAS_SSE:=1
+FD_HAS_AVX:=1
+FD_HAS_SHANI:=1
+FD_HAS_AESNI:=1


### PR DESCRIPTION
## Summary
This PR adds machine configuration files for AMD Zen 3, 4, and 5 architectures, providing complete coverage of modern AMD CPU generations.

## Changes
- Add `linux_clang_zen3.mk` with znver3 target and base instruction set
- Add `linux_clang_zen4.mk` with znver4 target, AVX-512, and GFNI support  
- Add `linux_clang_zen5.mk` with znver5 target, AVX-512, and GFNI support
- Add `linux_gcc_zen3.mk` with znver3 target and GCC 8 compatibility

## Feature Flags
Configurations correctly reflect hardware capabilities for each generation:
- **Zen 3**: AVX, SHA-NI, AES-NI (no AVX-512)
- **Zen 4/5**: AVX, SHA-NI, AES-NI, AVX-512, GFNI