### PR TITLE
Fix OOB shifts in fd_vm_interp_core (#3872)

### DIFF
--- a/src/flamenco/vm/fd_vm_interp_core.c
+++ b/src/flamenco/vm/fd_vm_interp_core.c
@@ -976,7 +976,7 @@ interp_exec:
   /* 0xc0 - 0xcf ******************************************************/
 
   FD_VM_INTERP_INSTR_BEGIN(0xc4) /* FD_SBPF_OP_ARSH_IMM */
-    reg[ dst ] = (ulong)(uint)( (int)reg_dst >> imm ); /* FIXME: WIDE SHIFTS, STRICT SIGN EXTENSION */
+    reg[ dst ] = (ulong)(uint)fd_int_shift_right( (int)reg_dst, (int)imm );
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_BRANCH_BEGIN(0xc5) /* FD_SBPF_OP_JSLT_IMM */ /* FIXME: CHECK IMM SIGN EXTENSION */
@@ -989,11 +989,11 @@ interp_exec:
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0xc7) /* FD_SBPF_OP_ARSH64_IMM */
-    reg[ dst ] = (ulong)( (long)reg_dst >> imm ); /* FIXME: WIDE SHIFTS, STRICT SIGN EXTENSION */
+    reg[ dst ] = (ulong)fd_long_shift_right( (long)reg_dst, (int)imm );
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0xcc) /* FD_SBPF_OP_ARSH_REG */
-    reg[ dst ] = (ulong)(uint)( (int)reg_dst >> (uint)reg_src ); /* FIXME: WIDE SHIFTS, STRICT SIGN EXTENSION */
+    reg[ dst ] = (ulong)(uint)fd_int_shift_right( (int)reg_dst, (int)reg_src );
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_BRANCH_BEGIN(0xcd) /* FD_SBPF_OP_JSLT_REG */
@@ -1007,7 +1007,7 @@ interp_exec:
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0xcf) /* FD_SBPF_OP_ARSH64_REG */
-    reg[ dst ] = (ulong)( (long)reg_dst >> reg_src ); /* FIXME: WIDE SHIFTS, STRICT SIGN EXTENSION */
+    reg[ dst ] = (ulong)fd_long_shift_right( (long)reg_dst, (int)reg_src );
   FD_VM_INTERP_INSTR_END;
 
   /* 0xd0 - 0xdf ******************************************************/


### PR DESCRIPTION
## Summary
Fixes out-of-bounds (OOB) shift operations in the VM interpreter that were causing UBSan errors.

Closes #3872

## Problem
The VM interpreter had 4 arithmetic right shift (ARSH) operations using raw C shift operators without bounds checking:

- `0xc4` (ARSH_IMM): `(int)reg_dst >> imm` 
- `0xc7` (ARSH64_IMM): `(long)reg_dst >> imm`
- `0xcc` (ARSH_REG): `(int)reg_dst >> (uint)reg_src`
- `0xcf` (ARSH64_REG): `(long)reg_dst >> reg_src`

When shift amounts ≥ bit width (32 for int, 64 for long), this caused undefined behavior and UBSan errors:


## Solution
Replaced raw shift operators with safe helper functions from `fd_bits.h`:

- `fd_int_shift_right()` for 32-bit shifts
- `fd_long_shift_right()` for 64-bit shifts

These functions cap shift amounts to prevent UB while preserving arithmetic right shift semantics.

## Changes
- `src/flamenco/vm/fd_vm_interp_core.c`: Fixed 4 ARSH operations (lines 972, 985, 989, 1003)

## Testing
- No compilation errors
- UBSan errors eliminated  
- Existing ARSH tests pass
- Performance impact minimal (uses cmov instructions)