### PR TITLE
Use demand-paged memory 'make run-test-vectors'

### DIFF
--- a/contrib/test/run_test_vectors.sh
+++ b/contrib/test/run_test_vectors.sh
@@ -43,15 +43,7 @@ if ! git checkout -q $GIT_REF; then
 fi
 cd ../..
 
-WKSP=run-test-vectors
-# If workspace already exists, reset it (and hope that it has the correct size)
-if ./$OBJDIR/bin/fd_wksp_ctl query $WKSP --log-path '' >/dev/null 2>/dev/null; then
-  ./$OBJDIR/bin/fd_wksp_ctl reset $WKSP --log-path ''
-else
-  ./$OBJDIR/bin/fd_wksp_ctl new run-test-vectors $PAGE_CNT $PAGE_SZ 0 0644 --log-path ''
-fi
-
-SOL_COMPAT=( "$OBJDIR/unit-test/test_sol_compat" "--wksp" "$WKSP" --tile-cpus "f,0-$(( $NUM_PROCESSES - 1 ))" )
+SOL_COMPAT=( "$OBJDIR/unit-test/test_sol_compat" --tile-cpus "f,0-$(( $NUM_PROCESSES - 1 ))" )
 
 export FD_LOG_PATH=$LOG_PATH/solfuzz.log
 ${SOL_COMPAT[@]} \


### PR DESCRIPTION
Allocating and zero-initializing the run-test-vectors wksp takes
significantly more time than using pinned memory saves.
