### PR TITLE
Add clang 20 patch for rocksdb

### DIFF
--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -71,6 +71,13 @@ RUST_CXXFLAGS=-include cstdint
 endif
 endif
 
+# Clang 20 hits the same missing <cstdint> include in RocksDB.
+ifeq ($(CC),clang)
+ifeq ($(CC_MAJOR_VERSION),20)
+RUST_CXXFLAGS=-include cstdint
+endif
+endif
+
 # Cargo build cannot cache the prior build if the command line changes,
 # for example if we did,
 #


### PR DESCRIPTION
Fixes https://github.com/firedancer-io/firedancer/issues/6844

```
➜  firedancer git:(main) clang --version
clang version 20.1.8
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```

Otherwise fails with:
```
#######################################################################
mkdir -pv build/native/clang/unit-test/ && clang++ -Lbuild/native/clang/lib build/native/clang/obj/disco/shred/test_fec_resolver.o -lfd_flamenco -lfd_disco -lfd_ballet -lfd_util -lfd_tango -lfd_reedsol  -pie -lm -ldl -L./opt/lib -lstdc++ -rdynamic -Wl,-z,relro,-z,now -fstack-protector-strong -z noexecstack -lrt -pthread opt/lib/libsecp256k1.a opt/lib/libs2nbignum.a opt/lib/libzstd.a opt/lib/liblz4.a -fsanitize=address,leak -fsanitize=undefined -o build/native/clang/unit-test/test_fec_resolver
mkdir -pv build/native/clang/unit-test/ && clang++ -Lbuild/native/clang/lib build/native/clang/obj/disco/shred/test_stake_ci.o -lfd_disco -lfd_flamenco -lfd_ballet -lfd_util -lfd_tango -lfd_reedsol  -pie -lm -ldl -L./opt/lib -lstdc++ -rdynamic -Wl,-z,relro,-z,now -fstack-protector-strong -z noexecstack -lrt -pthread opt/lib/libsecp256k1.a opt/lib/libs2nbignum.a opt/lib/libzstd.a opt/lib/liblz4.a -fsanitize=address,leak -fsanitize=undefined -o build/native/clang/unit-test/test_stake_ci
mkdir -pv build/native/clang/unit-test/ && clang++ -Lbuild/native/clang/lib build/native/clang/obj/disco/shred/test_shredder.o -lfd_disco -lfd_flamenco -lfd_ballet -lfd_util -lfd_reedsol  -pie -lm -ldl -L./opt/lib -lstdc++ -rdynamic -Wl,-z,relro,-z,now -fstack-protector-strong -z noexecstack -lrt -pthread opt/lib/libsecp256k1.a opt/lib/libs2nbignum.a opt/lib/libzstd.a opt/lib/liblz4.a -fsanitize=address,leak -fsanitize=undefined -o build/native/clang/unit-test/test_shredder
mkdir -pv build/native/clang/fuzz-test/ && clang++ -Lbuild/native/clang/lib build/native/clang/obj/ballet/reedsol/fuzz_reedsol.o -lfd_reedsol -lfd_util  build/native/clang/lib/libfd_fuzz_stub.a  -pie -lm -ldl -L./opt/lib -lstdc++ -rdynamic -Wl,-z,relro,-z,now -fstack-protector-strong -z noexecstack -lrt -pthread opt/lib/libsecp256k1.a opt/lib/libs2nbignum.a opt/lib/libzstd.a opt/lib/liblz4.a -fsanitize=address,leak -fsanitize=undefined -o build/native/clang/fuzz-test/fuzz_reedsol
/usr/bin/ld: opt/lib/librocksdb.a(fs_posix.o): in function `rocksdb::(anonymous namespace)::PosixFileSystem::PosixFileSystem()':
fs_posix.cc:(.text+0x420): undefined reference to `io_uring_queue_init'
/usr/bin/ld: opt/lib/librocksdb.a(fs_posix.o): in function `rocksdb::(anonymous namespace)::PosixFileSystem::Poll(std::vector<void*, std::allocator<void*> >&, unsigned long)':
fs_posix.cc:(.text+0x3bd3): undefined reference to `__io_uring_get_cqe'
/usr/bin/ld: opt/lib/librocksdb.a(fs_posix.o): in function `rocksdb::(anonymous namespace)::PosixFileSystem::AbortIO(std::vector<void*, std::allocator<void*> >&)':
fs_posix.cc:(.text+0x433f): undefined reference to `io_uring_submit'
/usr/bin/ld: fs_posix.cc:(.text+0x44d5): undefined reference to `__io_uring_get_cqe'
/usr/bin/ld: opt/lib/librocksdb.a(io_posix.o): in function `rocksdb::PosixRandomAccessFile::ReadAsync(rocksdb::FSReadRequest&, rocksdb::IOOptions const&, std::function<void (rocksdb::FSReadRequest&, void*)>, void*, void**, std::function<void (void*)>*, rocksdb::IODebugContext*)':
io_posix.cc:(.text+0x4c06): undefined reference to `io_uring_submit'
/usr/bin/ld: io_posix.cc:(.text+0x4c98): undefined reference to `io_uring_queue_init'
/usr/bin/ld: opt/lib/librocksdb.a(io_posix.o): in function `rocksdb::PosixRandomAccessFile::MultiRead(rocksdb::FSReadRequest*, unsigned long, rocksdb::IOOptions const&, rocksdb::IODebugContext*)':
io_posix.cc:(.text+0xa21e): undefined reference to `io_uring_submit_and_wait'
/usr/bin/ld: io_posix.cc:(.text+0xa2de): undefined reference to `__io_uring_get_cqe'
/usr/bin/ld: io_posix.cc:(.text+0xb452): undefined reference to `io_uring_queue_init'
/usr/bin/ld: io_posix.cc:(.text+0xb782): undefined reference to `__io_uring_get_cqe'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [src/app/ledger/Local.mk:7: build/native/clang/bin/fd_ledger] Error 1
make: *** Waiting for unfinished jobs....
/usr/bin/ld: opt/lib/librocksdb.a(fs_posix.o): in function `rocksdb::(anonymous namespace)::PosixFileSystem::PosixFileSystem()':
fs_posix.cc:(.text+0x420): undefined reference to `io_uring_queue_init'
/usr/bin/ld: opt/lib/librocksdb.a(fs_posix.o): in function `rocksdb::(anonymous namespace)::PosixFileSystem::Poll(std::vector<void*, std::allocator<void*> >&, unsigned long)':
fs_posix.cc:(.text+0x3bd3): undefined reference to `__io_uring_get_cqe'
/usr/bin/ld: opt/lib/librocksdb.a(fs_posix.o): in function `rocksdb::(anonymous namespace)::PosixFileSystem::AbortIO(std::vector<void*, std::allocator<void*> >&)':
fs_posix.cc:(.text+0x433f): undefined reference to `io_uring_submit'
/usr/bin/ld: fs_posix.cc:(.text+0x44d5): undefined reference to `__io_uring_get_cqe'
/usr/bin/ld: opt/lib/librocksdb.a(io_posix.o): in function `rocksdb::PosixRandomAccessFile::ReadAsync(rocksdb::FSReadRequest&, rocksdb::IOOptions const&, std::function<void (rocksdb::FSReadRequest&, void*)>, void*, void**, std::function<void (void*)>*, rocksdb::IODebugContext*)':
io_posix.cc:(.text+0x4c06): undefined reference to `io_uring_submit'
/usr/bin/ld: io_posix.cc:(.text+0x4c98): undefined reference to `io_uring_queue_init'
/usr/bin/ld: opt/lib/librocksdb.a(io_posix.o): in function `rocksdb::PosixRandomAccessFile::MultiRead(rocksdb::FSReadRequest*, unsigned long, rocksdb::IOOptions const&, rocksdb::IODebugContext*)':
io_posix.cc:(.text+0xa21e): undefined reference to `io_uring_submit_and_wait'
/usr/bin/ld: io_posix.cc:(.text+0xa2de): undefined reference to `__io_uring_get_cqe'
/usr/bin/ld: io_posix.cc:(.text+0xb452): undefined reference to `io_uring_queue_init'
/usr/bin/ld: io_posix.cc:(.text+0xb782): undefined reference to `__io_uring_get_cqe'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [src/app/firedancer-dev/Local.mk:24: build/native/clang/bin/firedancer-dev] Error 1
```