### PR TITLE
snapshots: remove entrypoints config option

### DIFF
--- a/src/app/firedancer-dev/commands/snapshot_load.c
+++ b/src/app/firedancer-dev/commands/snapshot_load.c
@@ -137,8 +137,8 @@ extern int * fd_log_private_shared_lock;
 static void
 snapshot_load_cmd_fn( args_t *   args,
                       config_t * config ) {
-  if( FD_UNLIKELY( config->firedancer.snapshots.sources.gossip.enabled || config->firedancer.snapshots.sources.entrypoints.enabled ) ) {
-    FD_LOG_ERR(( "snapshot-load command is incompatible with gossip or entrypoint snapshot sources" ));
+  if( FD_UNLIKELY( config->firedancer.snapshots.sources.gossip.enabled ) ) {
+    FD_LOG_ERR(( "snapshot-load command is incompatible with gossip snapshot sources" ));
   }
   snapshot_load_topo( config, args );
   fd_topo_t * topo = &config->topo;

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -400,12 +400,6 @@ user = ""
     # you highly trust, and this is the default behavior of the
     # configuration.
     [snapshots.sources]
-        # Allow fetching of snapshots from peers specified in the gossip
-        # entrypoints.  Gossip entrypoints must be peers that are highly
-        # trusted as they are used to bootstrap your node.
-        [snapshots.sources.entrypoints]
-            enabled = false
-
         # Allow fetching of snapshots from arbitrary gossip peers that
         # are hosting a snapshot server.  This may allow faster snapshot
         # download if a peer in a local data-center is serving a good
@@ -424,7 +418,7 @@ user = ""
         #
         # If these peers have snapshots at the given paths, they will be
         # considered as additional sources for downloading snapshots
-        # when enabled alongside gossip and entrypoint sources.
+        # when enabled alongside gossip sources.
         [[snapshots.sources.http]]
             # Whether to enable fetching snapshots from a list of
             # HTTP peers.

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -915,12 +915,7 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
     tile->snapct.maximum_download_retry_abort      = config->firedancer.snapshots.maximum_download_retry_abort;
     tile->snapct.max_full_snapshots_to_keep        = config->firedancer.snapshots.max_full_snapshots_to_keep;
     tile->snapct.max_incremental_snapshots_to_keep = config->firedancer.snapshots.max_incremental_snapshots_to_keep;
-
-    tile->snapct.entrypoints_enabled               = config->firedancer.snapshots.sources.entrypoints.enabled;
     tile->snapct.gossip_peers_enabled              = config->firedancer.snapshots.sources.gossip.enabled;
-    tile->snapct.gossip_entrypoints_cnt            = config->gossip.entrypoints_cnt;
-
-    for( ulong i=0UL; i<tile->snapct.gossip_entrypoints_cnt; i++ ) tile->snapct.gossip_entrypoints[ i ] = config->gossip.resolved_entrypoints[ i ];
 
     ulong peers_cnt          = config->firedancer.snapshots.sources.http.peers_cnt;
     ulong resolved_peers_cnt = 0UL;

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -128,10 +128,6 @@ struct fd_configf {
 
       struct {
         int enabled;
-      } entrypoints;
-
-      struct {
-        int enabled;
       } gossip;
 
       struct {

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -104,7 +104,6 @@ fd_config_extract_podf( uchar *        pod,
   CFG_POP      ( uint,   snapshots.maximum_download_retry_abort              );
   CFG_POP      ( uint,   snapshots.max_full_snapshots_to_keep                );
   CFG_POP      ( uint,   snapshots.max_incremental_snapshots_to_keep         );
-  CFG_POP      ( bool,   snapshots.sources.entrypoints.enabled               );
   CFG_POP      ( bool,   snapshots.sources.gossip.enabled                    );
   CFG_POP_TABLE( bool,   snapshots.sources.http, snapshots.sources.http.peers, enabled, 0 );
   CFG_POP_TABLE( cstr,   snapshots.sources.http, snapshots.sources.http.peers, url,     1 );

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -512,11 +512,7 @@ struct fd_topo_tile {
       uint max_full_snapshots_to_keep;
       uint max_incremental_snapshots_to_keep;
 
-      int entrypoints_enabled;
       int gossip_peers_enabled;
-
-      ulong         gossip_entrypoints_cnt;
-      fd_ip4_port_t gossip_entrypoints[ FD_TOPO_GOSSIP_ENTRYPOINTS_MAX ];
 
       struct {
         ulong         peers_cnt;


### PR DESCRIPTION
This is redundant with the upcoming list of allowed gossip peers (similar to known_validators) so removing for simplicity and to make the next PR(s) smaller to review.