### PR TITLE
Fix accidentally negated bool check for block builder in bundle tile

### DIFF
--- a/src/disco/bundle/fd_bundle_client.c
+++ b/src/disco/bundle/fd_bundle_client.c
@@ -278,7 +278,7 @@ fd_bundle_client_step_reconnect( fd_bundle_tile_t * ctx,
   /* Request block builder info */
   int const builder_info_expired = ( ctx->builder_info_valid_until - now )<0;
   if( FD_UNLIKELY( ( ( !ctx->builder_info_avail ) |
-                     ( !builder_info_expired    ) ) &
+                     ( builder_info_expired     ) ) &
                    ( !ctx->builder_info_wait      ) ) ) {
     fd_bundle_client_request_builder_info( ctx );
     return 1;

--- a/src/disco/bundle/test_bundle_common.c
+++ b/src/disco/bundle/test_bundle_common.c
@@ -114,6 +114,7 @@ test_bundle_env_mock_h2_hs( fd_bundle_tile_t * ctx ) {
 FD_FN_UNUSED static void
 test_bundle_env_mock_builder_info( fd_bundle_tile_t * ctx ) {
   ctx->builder_info_avail = 1;
+  ctx->builder_info_valid_until = fd_bundle_now() + (long)( 60e9 * 5. );
   /* FIXME actually fill it in ... */
 }
 


### PR DESCRIPTION
We should fetch when we don't have the builder info **OR** its expired. Reduces number of network requests to the block engine