### PR TITLE
sbpf: clarify padding check

### DIFF
--- a/src/ballet/sbpf/fd_sbpf_loader.c
+++ b/src/ballet/sbpf/fd_sbpf_loader.c
@@ -742,6 +742,7 @@ fd_sbpf_elf_peek_strict( fd_sbpf_elf_info_t * info,
     | ( ehdr.e_ident[ FD_ELF_EI_DATA    ] != FD_ELF_DATA_LE        )
     | ( ehdr.e_ident[ FD_ELF_EI_VERSION ] != 1                     )
     | ( ehdr.e_ident[ FD_ELF_EI_OSABI   ] != FD_ELF_OSABI_NONE     )
+    // The 7 padding bytes [9, 16) must be 0. Byte 8 (EI_OSABI) is 0 due to above check, so check [8, 16).
     | ( fd_ulong_load_8( ehdr.e_ident+8 ) != 0UL                   )
     | ( ehdr.e_type                       != FD_ELF_ET_DYN         )
     | ( ehdr.e_machine                    != FD_ELF_EM_SBPF        )


### PR DESCRIPTION
The SIMD specifies to check
> `e_ident.ei_pad` must be `[0x00; 7]`

Because EI_OSABI is the immediately preceding byte of ei_pad - and guaranteed to be zero due to the previous check - we can just check that the 8 bytes starting at EI_OSABI are zero.

Maybe it saves someone else time to check why we're doing the same as agave in a slightly different way :)