### PR TITLE
restore: prefetch map chain

### DIFF
--- a/src/discof/restore/utils/fd_ssparse.h
+++ b/src/discof/restore/utils/fd_ssparse.h
@@ -11,7 +11,8 @@
 #define FD_SSPARSE_ADVANCE_STATUS_CACHE   ( 2)
 #define FD_SSPARSE_ADVANCE_ACCOUNT_HEADER ( 3)
 #define FD_SSPARSE_ADVANCE_ACCOUNT_DATA   ( 4)
-#define FD_SSPARSE_ADVANCE_DONE           ( 5)
+#define FD_SSPARSE_ADVANCE_ACCOUNT_BATCH  ( 5)
+#define FD_SSPARSE_ADVANCE_DONE           ( 6)
 
 /* fd_ssparse_t is a solana snapshot parser.  It is designed to parse a
    snapshot in streaming fasion, chunk by chunk. */
@@ -56,6 +57,10 @@ typedef struct acc_vec acc_vec_t;
 
 #include "../../../util/tmpl/fd_map_chain.c"
 
+/* FD_SSPARSE_ACC_BATCH_MAX controls the max number of accounts in a
+   batch. */
+#define FD_SSPARSE_ACC_BATCH_MAX (16UL)
+
 struct fd_ssparse_advance_result {
   ulong bytes_consumed;
 
@@ -87,6 +92,15 @@ struct fd_ssparse_advance_result {
       uchar const * data;
       ulong         data_sz;
     } account_data;
+
+    struct {
+      /* Points to first byte of each account entry
+         Each account entry is guaranteed unfragmented
+         Useful for fast path processing */
+      uchar const * batch[ FD_SSPARSE_ACC_BATCH_MAX ];
+      ulong         batch_cnt;
+      ulong         slot;
+    } account_batch;
   };
 };
 
@@ -124,6 +138,14 @@ fd_ssparse_advance( fd_ssparse_t *                ssparse,
                     uchar const *                 data,
                     ulong                         data_sz,
                     fd_ssparse_advance_result_t * result );
+
+/* fd_ssparse_batch_enable toggles whether batch processing is enabled.
+   If enabled, ssparse will deliver FD_SSPARSE_ADVANCE_ACCOUNT_BATCH
+   messages.  (These may help the caller processing accounts in batches
+   to amortize per-account overhead, such as slow DRAM/disk fetches.) */
+void
+fd_ssparse_batch_enable( fd_ssparse_t * ssparse,
+                         int            enabled );
 
 /* Test/Fuzz APIs */
 

--- a/src/funk/fd_funk_base.h
+++ b/src/funk/fd_funk_base.h
@@ -192,9 +192,7 @@ fd_funk_rec_key_hash1( uchar const key[ 32 ],
 FD_FN_PURE static inline ulong
 fd_funk_rec_key_hash( fd_funk_rec_key_t const * k,
                       ulong                     seed ) {
-  /* tons of ILP */
-  return (fd_ulong_hash( seed ^ (1UL<<0) ^ k->ul[0] ) ^ fd_ulong_hash( seed ^ (1UL<<1) ^ k->ul[1] ) ) ^
-         (fd_ulong_hash( seed ^ (1UL<<2) ^ k->ul[2] ) ^ fd_ulong_hash( seed ^ (1UL<<3) ^ k->ul[3] ) );
+  return fd_funk_rec_key_hash1( k->uc, 0UL, seed );
 }
 
 #else


### PR DESCRIPTION
Optimize snapshot loading by prefetching the index in 16-wide
batches.  Also fix a bug in funk_base that selected a worse hash
function than xxh128.
