### PR TITLE
restore: ILP hashmap walk

### DIFF
--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -538,6 +538,7 @@ process_account_batch( fd_snapin_tile_t *            ctx,
                        fd_ssparse_advance_result_t * result ) {
   fd_funk_t *         funk    = ctx->accdb->funk;
   fd_funk_rec_map_t * rec_map = funk->rec_map;
+  fd_funk_rec_t *     rec_tbl = funk->rec_pool->ele;
   fd_funk_rec_map_shmem_private_chain_t * chain_tbl = fd_funk_rec_map_shmem_private_chain( rec_map->map, 0UL );
 
   /* Derive map chains */
@@ -550,43 +551,72 @@ process_account_batch( fd_snapin_tile_t *            ctx,
     chain_idx[ i ] = (uint)( memo&chain_mask );
   }
 
-  /* Prefetch map chains */
+  /* Parallel load hash chain heads */
+  uint map_node [ FD_SSPARSE_ACC_BATCH_MAX ];
+  uint chain_cnt[ FD_SSPARSE_ACC_BATCH_MAX ];
   for( ulong i=0UL; i<FD_SSPARSE_ACC_BATCH_MAX; i++ ) {
-    __builtin_prefetch( chain_tbl+chain_idx[ i ] );
+    map_node [ i ] =       chain_tbl[ chain_idx[ i ] ].head_cidx;
+    chain_cnt[ i ] = (uint)chain_tbl[ chain_idx[ i ] ].ver_cnt;
+  }
+  uint chain_max = 0U;
+  for( ulong i=0UL; i<FD_SSPARSE_ACC_BATCH_MAX; i++ ) {
+    chain_max = fd_uint_max( chain_max, chain_cnt[ i ] );
+  }
+
+  /* Parallel walk hash chains */
+  static fd_funk_rec_t dummy_rec = { .map_next = UINT_MAX };
+  fd_funk_rec_t * rec[ FD_SSPARSE_ACC_BATCH_MAX ] = {0};
+  for( ulong j=0UL; j<chain_max; j++ ) {
+    for( ulong i=0UL; i<FD_SSPARSE_ACC_BATCH_MAX; i++ ) {
+      uchar const *   frame     = result->account_batch.batch[ i ];
+      uchar const *   pubkey    = frame+0x10UL;
+      int const       has_node  = j<chain_cnt[ i ];
+      fd_funk_rec_t * node      = has_node ? rec_tbl+map_node[ i ] : &dummy_rec;
+      int const       key_match = 0==memcmp( node->pair.key, pubkey, sizeof(fd_funk_rec_key_t) );
+      if( has_node && key_match ) rec[ i ] = node;
+      map_node[ i ] = node->map_next;
+    }
   }
 
   /* Create map entries */
-  fd_funk_rec_t * recs[ FD_SSPARSE_ACC_BATCH_MAX ];
   for( ulong i=0UL; i<FD_SSPARSE_ACC_BATCH_MAX; i++ ) {
     uchar const * frame  = result->account_batch.batch[ i ];
     uchar const * pubkey = frame+0x10UL;
     fd_funk_rec_key_t key = FD_LOAD( fd_funk_rec_key_t, pubkey );
 
-    fd_funk_rec_query_t query[1];
-    fd_funk_rec_t * rec = fd_funk_rec_query_try( funk, ctx->xid, &key, query );
-    if( FD_LIKELY( !rec ) ) {  /* optimize for new account */
-      rec = fd_funk_rec_pool_acquire( funk->rec_pool, NULL, 0, NULL );
-      FD_TEST( rec );
-      memset( rec, 0, sizeof(fd_funk_rec_t) );
-      fd_funk_txn_xid_copy( rec->pair.xid, ctx->xid );
-      fd_funk_rec_key_copy( rec->pair.key, &key );
-      FD_TEST( fd_funk_rec_map_insert( funk->rec_map, rec, 0 )==FD_MAP_SUCCESS );
-      recs[ i ] = rec;
+    fd_funk_rec_t * r = rec[ i ];
+    if( FD_LIKELY( !r ) ) {  /* optimize for new account */
+      r = fd_funk_rec_pool_acquire( funk->rec_pool, NULL, 0, NULL );
+      FD_TEST( r );
+      memset( r, 0, sizeof(fd_funk_rec_t) );
+      fd_funk_txn_xid_copy( r->pair.xid, ctx->xid );
+      fd_funk_rec_key_copy( r->pair.key, &key );
+
+      /* Insert to hash map.  In theory, a key could appear twice in the
+         same batch.  All accounts in a batch are guaranteed to be from
+         the same slot though, so this is fine, assuming that accdb code
+         gracefully handles duplicate hash map entries. */
+      fd_funk_rec_map_shmem_private_chain_t * chain = &chain_tbl[ chain_idx[ i ] ];
+      ulong ver_cnt    = chain->ver_cnt;
+      uint  head_cidx  = chain->head_cidx;
+      chain->ver_cnt   = fd_funk_rec_map_private_vcnt( fd_funk_rec_map_private_vcnt_ver( ver_cnt ), fd_funk_rec_map_private_vcnt_cnt( ver_cnt )+1UL );
+      chain->head_cidx = (uint)( r-rec_tbl );
+      r->map_next      = head_cidx;
+      rec[ i ]         = r;
     } else {  /* existing record for key found */
-      fd_account_meta_t const * existing = fd_funk_val( rec, funk->wksp );
+      fd_account_meta_t const * existing = fd_funk_val( r, funk->wksp );
+      if( FD_UNLIKELY( !existing ) ) FD_LOG_HEXDUMP_NOTICE(( "r", r, sizeof(fd_funk_rec_t) ));
       FD_TEST( existing );
-      if( existing->slot <= result->account_batch.slot ) {
-        recs[ i ] = rec;
-      } else {
-        recs[ i ] = NULL;  /* skip record if existing value is newer */
+      if( existing->slot > result->account_batch.slot ) {
+        rec[ i ] = NULL;  /* skip record if existing value is newer */
       }
     }
   }
 
   /* Actually insert accounts */
   for( ulong i=0UL; i<FD_SSPARSE_ACC_BATCH_MAX; i++ ) {
-    if( recs[ i ] ) {
-      streamlined_insert( ctx, recs[ i ], result->account_batch.batch[ i ], result->account_batch.slot );
+    if( rec[ i ] ) {
+      streamlined_insert( ctx, rec[ i ], result->account_batch.batch[ i ], result->account_batch.slot );
     }
   }
 }


### PR DESCRIPTION
Uses instruction-level parallelism to parallel-query a hashmap.
Slightly improves over just prefetching the chain heads during
later stages of loading a snapshot.

Also improves stat rendering in 'firedancer-dev snapshot-load'.
