### PR TITLE
flamenco, vm: simplify cpi account info checks

### DIFF
--- a/src/flamenco/runtime/program/fd_bpf_loader_serialization.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_serialization.c
@@ -381,16 +381,19 @@ fd_bpf_loader_input_serialize_aligned( fd_exec_instr_ctx_t *     ctx,
       /* https://github.com/anza-xyz/agave/blob/v3.0.0/program-runtime/src/serialization.rs#L532 */
       fd_pubkey_t key = *acc;
       FD_STORE( fd_pubkey_t, serialized_params, key );
+      acc_region_metas[i].expected_pubkey_offset = (uint)(serialized_params - serialized_params_start);
       serialized_params += sizeof(fd_pubkey_t);
 
       /* https://github.com/anza-xyz/agave/blob/v3.0.0/program-runtime/src/serialization.rs#L533 */
       fd_pubkey_t owner = *(fd_pubkey_t *)&metadata->owner;
       FD_STORE( fd_pubkey_t, serialized_params, owner );
+      acc_region_metas[i].expected_owner_offset = (uint)(serialized_params - serialized_params_start);
       serialized_params += sizeof(fd_pubkey_t);
 
       /* https://github.com/anza-xyz/agave/blob/v3.0.0/program-runtime/src/serialization.rs#L534 */
       ulong lamports = metadata->lamports;
       FD_STORE( ulong, serialized_params, lamports );
+      acc_region_metas[i].expected_lamports_offset = (uint)(serialized_params - serialized_params_start);
       serialized_params += sizeof(ulong);
 
       ulong acc_data_len = metadata->dlen;
@@ -671,10 +674,12 @@ fd_bpf_loader_input_serialize_unaligned( fd_exec_instr_ctx_t *     ctx,
 
       fd_pubkey_t key = *acc;
       FD_STORE( fd_pubkey_t, serialized_params, key );
+      acc_region_metas[i].expected_pubkey_offset = (uint)(serialized_params - serialized_params_start);
       serialized_params += sizeof(fd_pubkey_t);
 
       ulong lamports = metadata->lamports;
       FD_STORE( ulong, serialized_params, lamports );
+      acc_region_metas[i].expected_lamports_offset = (uint)(serialized_params - serialized_params_start);
       serialized_params += sizeof(ulong);
 
       ulong acc_data_len = metadata->dlen;
@@ -687,6 +692,7 @@ fd_bpf_loader_input_serialize_unaligned( fd_exec_instr_ctx_t *     ctx,
 
       fd_pubkey_t owner = *(fd_pubkey_t *)&metadata->owner;
       FD_STORE( fd_pubkey_t, serialized_params, owner );
+      acc_region_metas[i].expected_owner_offset = (uint)(serialized_params - serialized_params_start);
       serialized_params += sizeof(fd_pubkey_t);
 
       uchar is_executable = (uchar)metadata->executable;

--- a/src/flamenco/vm/fd_vm.h
+++ b/src/flamenco/vm/fd_vm.h
@@ -44,7 +44,14 @@ struct __attribute((aligned(8UL))) fd_vm_acc_region_meta {
       activated, we could query the input_mem_region array for the
       original data len. */
    ulong              original_data_len;
-   fd_txn_account_t * acct; /* The transaction account corresponding to this account. */
+   /* The transaction account corresponding to this account. */
+   fd_txn_account_t * acct;
+   /* The expected virtual offsets of the serialized pubkey, lamports and owner
+      for the account corresponding to this region.
+      Used for CPI security checks. */
+   uint               expected_pubkey_offset;
+   uint               expected_lamports_offset;
+   uint               expected_owner_offset;
 };
 typedef struct fd_vm_acc_region_meta fd_vm_acc_region_meta_t;
 

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
@@ -343,12 +343,12 @@ VM_SYSCALL_CPI_TRANSLATE_AND_UPDATE_ACCOUNTS_FUNC(
       /* https://github.com/anza-xyz/agave/blob/v3.0.4/syscalls/src/cpi.rs#L138 */
       if( FD_LIKELY( vm->stricter_abi_and_runtime_constraints ) ) {
         /* https://github.com/anza-xyz/agave/blob/v3.0.4/syscalls/src/cpi.rs#L139-L144 */
-        ulong expected_pubkey_vaddr = serialized_pubkey_vaddr( vm, acc_region_meta->region_idx );
+        ulong expected_pubkey_vaddr = FD_VM_MEM_MAP_INPUT_REGION_START + acc_region_meta->expected_pubkey_offset;
         /* Max msg_sz: 40 + 18 + 18 = 76 < 127 */
         VM_SYSCALL_CPI_CHECK_ACCOUNT_INFO_POINTER_FIELD_MAX_54(vm, account_infos[j].pubkey_addr, expected_pubkey_vaddr, "key");
 
         /* https://github.com/anza-xyz/agave/blob/v3.0.4/syscalls/src/cpi.rs#L145-L150 */
-        ulong expected_owner_vaddr = serialized_owner_vaddr( vm, acc_region_meta->region_idx );
+        ulong expected_owner_vaddr = FD_VM_MEM_MAP_INPUT_REGION_START + acc_region_meta->expected_owner_offset;
         /* Max msg_sz: 42 + 18 + 18 = 78 < 127 */
         VM_SYSCALL_CPI_CHECK_ACCOUNT_INFO_POINTER_FIELD_MAX_54(vm, account_infos[j].owner_addr, expected_owner_vaddr, "owner");
       }
@@ -370,7 +370,7 @@ VM_SYSCALL_CPI_TRANSLATE_AND_UPDATE_ACCOUNTS_FUNC(
         #endif
 
         /* https://github.com/anza-xyz/agave/blob/v3.0.4/syscalls/src/cpi.rs#L167-L172 */
-        ulong expected_lamports_vaddr = serialized_lamports_vaddr( vm, acc_region_meta->region_idx );
+        ulong expected_lamports_vaddr = FD_VM_MEM_MAP_INPUT_REGION_START + acc_region_meta->expected_lamports_offset;
         /* Max msg_sz: 45 + 18 + 18 = 81 < 127 */
         VM_SYSCALL_CPI_CHECK_ACCOUNT_INFO_POINTER_FIELD_MAX_54(vm, lamports_vaddr, expected_lamports_vaddr, "lamports");
       }


### PR DESCRIPTION
The current CPI account info checks are structured in a way that is fragile and overcomplicated. This PR simplifies these in a way that is robust for both the unaligned and aligned serializers. 