### PR TITLE
ci: fix test-vectors checkout flake

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,9 +122,15 @@ jobs:
       - name: check out test-vectors (persistent)
         if: ${{ matrix.run-unit-tests && matrix.test-case == 'native' }}
         run: |
-          if [[ ! -d /data/svc_firedancer/test-vectors ]]; then git -C /data/svc_firedancer clone https://github.com/firedancer-io/test-vectors.git; fi
-          mkdir dump
-          ln -s /data/svc_firedancer/test-vectors dump/test-vectors
+          COMMIT_SHA=$(cat contrib/test/test-vectors-commit-sha.txt)
+          TEST_VECTORS_PATH="/data/svc_firedancer/test-vectors/${COMMIT_SHA}"
+          if [[ ! -d "${TEST_VECTORS_PATH}" ]]; then
+            mkdir -p /data/svc_firedancer/test-vectors
+            git clone https://github.com/firedancer-io/test-vectors.git "${TEST_VECTORS_PATH}"
+            git -C "${TEST_VECTORS_PATH}" checkout "${COMMIT_SHA}"
+          fi
+          mkdir -p dump
+          ln -sf "${TEST_VECTORS_PATH}" dump/test-vectors
 
       - name: run test-vector tests
         if: ${{ matrix.run-unit-tests && matrix.test-case == 'native' }}


### PR DESCRIPTION
Previously all runs of test-vectors in CI would share the same directory. This is broken for runs that need to use different test-vectors commit shas, and causes races and non-deterministic failures in CI.

This checks out each commit sha of test vectors into a separate directory, keyed by the commit sha. Checkouts are still persistent between CI runs, but runs that use different commit shas won't step on each others toes. 