### PR TITLE
quic: simplify stream buffer and handling

### DIFF
--- a/src/discof/send/fd_send_tile.c
+++ b/src/discof/send/fd_send_tile.c
@@ -45,7 +45,7 @@ fd_quic_limits_t quic_limits = {
   .inflight_frame_cnt          = 16UL * MAX_STAKED_LEADERS,
   .min_inflight_frame_cnt_conn = 4UL,
   .stream_id_cnt               = 64UL,
-  .tx_buf_sz                   = 1UL<<11,
+  .tx_buf_sz                   = FD_TXN_MTU,
   .stream_pool_cnt             = 1UL<<13
 };
 

--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -300,8 +300,8 @@ static void
 fd_quic_stream_init( fd_quic_stream_t * stream ) {
   stream->context            = NULL;
 
+  stream->unacked_low        = 0;
   stream->tx_buf.head        = 0;
-  stream->tx_buf.tail        = 0;
   stream->tx_sent            = 0;
 
   stream->stream_flags       = 0;
@@ -1146,12 +1146,8 @@ fd_quic_stream_send( fd_quic_stream_t *  stream,
     return FD_QUIC_SEND_ERR_FLOW;
   }
 
-  /* store data from data into tx_buf
-      this stores, but does not move the head offset */
+  /* store data from data into tx_buf */
   fd_quic_buffer_store( tx_buf, data, data_sz );
-
-  /* advance head */
-  tx_buf->head += data_sz;
 
   /* adjust flow control limits on stream and connection */
   stream->tx_tot_data += data_sz;
@@ -4460,26 +4456,23 @@ fd_quic_pkt_meta_retry( fd_quic_t      *  quic,
             stream = stream_entry->stream;
 
             /* do not try sending data that has been acked */
-            ulong offset = fd_ulong_max( pkt_meta->val.range.offset_lo, stream->tx_buf.tail );
+            ulong offset = fd_ulong_max( pkt_meta->val.range.offset_lo, stream->unacked_low );
 
             /* any data left to retry? */
             stream->tx_sent = fd_ulong_min( stream->tx_sent, offset );
 
-            /* do we have anything to send? */
-            /* TODO may need to send fin, also */
-            if( FD_LIKELY( stream->tx_sent < stream->tx_buf.head ) ) {
-
-              /* insert into send list */
-              FD_QUIC_STREAM_LIST_REMOVE( stream );
-              FD_QUIC_STREAM_LIST_INSERT_BEFORE( conn->send_streams, stream );
-
-              /* set the data to go out on the next packet */
-              stream->stream_flags   |= FD_QUIC_STREAM_FLAGS_UNSENT; /* we have unsent data */
-              stream->upd_pkt_number  = FD_QUIC_PKT_NUM_PENDING;
-            } else {
-              /* fd_quic_tx_stream_free also notifies the user */
-              fd_quic_tx_stream_free( conn->quic, conn, stream, FD_QUIC_STREAM_NOTIFY_END );
+            /* We must have something to send if the stream was found */
+            if( !( (stream->tx_sent < stream->tx_buf.head) | (stream->state & FD_QUIC_STREAM_STATE_TX_FIN) ) ) {
+              FD_LOG_CRIT(( "unexpected retry for completed stream %lu", stream_id ));
             }
+
+            /* insert into send list */
+            FD_QUIC_STREAM_LIST_REMOVE( stream );
+            FD_QUIC_STREAM_LIST_INSERT_BEFORE( conn->send_streams, stream );
+
+            /* set the data to go out on the next packet */
+            stream->stream_flags   |= FD_QUIC_STREAM_FLAGS_UNSENT; /* we have unsent data */
+            stream->upd_pkt_number  = FD_QUIC_PKT_NUM_PENDING;
           }
         } while(0);
         break;
@@ -4650,13 +4643,11 @@ fd_quic_reclaim_pkt_meta( fd_quic_conn_t *     conn,
               ( stream_entry->stream->stream_flags & FD_QUIC_STREAM_FLAGS_DEAD ) == 0 ) ) {
           stream = stream_entry->stream;
 
-          /* do not try sending data that has been acked */
-
-          ulong tx_tail = stream->tx_buf.tail;
+          ulong tx_tail = stream->unacked_low;
           ulong tx_sent = stream->tx_sent;
 
           /* ignore bytes which were already acked */
-          if( range.offset_lo < tx_tail ) range.offset_lo = tx_tail;
+          range.offset_lo = fd_ulong_max( range.offset_lo, tx_tail );
 
           /* verify offset_hi */
           if( FD_UNLIKELY( range.offset_hi > stream->tx_buf.head ) ) {
@@ -4665,104 +4656,53 @@ fd_quic_reclaim_pkt_meta( fd_quic_conn_t *     conn,
             /* stream */
             fd_quic_conn_error( conn, FD_QUIC_CONN_REASON_INTERNAL_ERROR, __LINE__ );
             return;
-          } else {
-            /* did they ack the first byte in the range? */
-            if( FD_LIKELY( range.offset_lo == tx_tail ) ) {
+          }
 
-              /* then simply move the tail up */
-              tx_tail = range.offset_hi;
-
-              /* need to clear the acks */
-              ulong   tx_mask  = stream->tx_buf.cap - 1ul;
-              uchar * tx_ack   = stream->tx_ack;
-              for( ulong j = range.offset_lo; j < range.offset_hi; ) {
-                ulong k = j & tx_mask;
-                if( ( k & 7ul ) == 0ul && j + 8ul <= range.offset_hi ) {
-                  /* process 8 bits */
-                  tx_ack[k>>3ul] = 0;
-                  j+=8;
-                } else {
-                  /* process 1 bit */
-                  tx_ack[k>>3ul] &= (uchar)(0xff ^ ( 1ul << ( k & 7ul ) ) );
-                  j++;
-                }
-              }
-            } else {
-              /* set appropriate bits in tx_ack */
-              /* TODO optimize this */
-              ulong   tx_mask  = stream->tx_buf.cap - 1ul;
-              ulong   cnt      = range.offset_hi - range.offset_lo;
-              uchar * tx_ack   = stream->tx_ack;
-              for( ulong j = 0ul; j < cnt; ) {
-                ulong k = ( j + range.offset_lo ) & tx_mask;
-                if( ( k & 7ul ) == 0ul && j + 8ul <= cnt ) {
-                  /* set whole byte */
-                  tx_ack[k>>3ul] = 0xffu;
-
-                  j += 8ul;
-                } else {
-                  /* compiler is not smart enough to know ( 1u << ( k & 7u ) ) fits in a uchar */
-                  tx_ack[k>>3ul] |= (uchar)( 1ul << ( k & 7ul ) );
-                  j++;
-                }
-              }
-
-              /* determine whether tx_tail may be moved up */
-              for( ulong j = tx_tail; j < tx_sent; ) {
-                ulong k = j & tx_mask;
-
-                /* can we skip a whole byte? */
-                if( ( k & 7ul ) == 0ul && j + 8ul <= tx_sent && tx_ack[k>>3ul] == 0xffu ) {
-                  tx_ack[k>>3ul] = 0u;
-                  tx_tail       += 8ul;
-
-                  j += 8ul;
-                } else {
-                  if( tx_ack[k>>3ul] & ( 1u << ( k & 7u ) ) ) {
-                    tx_ack[k>>3ul] = (uchar)( tx_ack[k>>3ul] & ~( 1u << ( k & 7u ) ) );
-                    tx_tail++;
-                    j++;
-                  } else {
-                    break;
-                  }
-                }
-              }
-            }
-
-            /* For convenience */
-            uint fin_state_mask = FD_QUIC_STREAM_STATE_TX_FIN | FD_QUIC_STREAM_STATE_RX_FIN;
-
-            /* move up tail, and adjust to maintain circular queue invariants, and send
-                max_data and max_stream_data, if necessary */
-            if( tx_tail > stream->tx_buf.tail ) {
-              stream->tx_buf.tail = tx_tail;
-
-              /* if we have data to send, reschedule */
-              if( fd_quic_buffer_used( &stream->tx_buf ) ) {
-                stream->upd_pkt_number = FD_QUIC_PKT_NUM_PENDING;
-                if( !FD_QUIC_STREAM_ACTION( stream ) ) {
-                  /* going from 0 to nonzero, so insert into action list */
-                  FD_QUIC_STREAM_LIST_REMOVE( stream );
-                  FD_QUIC_STREAM_LIST_INSERT_BEFORE( conn->send_streams, stream );
-                }
-
-                stream->stream_flags |= FD_QUIC_STREAM_FLAGS_UNSENT;
-
-                fd_quic_svc_prep_schedule_now( conn );
+          uchar * tx_ack = stream->tx_ack;
+          /* did they ack the first unacked byte? */
+          if( FD_LIKELY( range.offset_lo == tx_tail ) ) {
+            /* move tail to first unacked byte */
+            tx_tail = range.offset_hi;
+            while( tx_tail < tx_sent ) {
+              /* TODO - optimize this for larger strides */
+              /* can we skip a whole byte? */
+              if( ( tx_tail & 7ul ) == 0ul && tx_tail + 8ul <= tx_sent && tx_ack[tx_tail>>3ul] == 0xffu ) {
+                tx_tail += 8ul;
               } else {
-                /* if no data to send, check whether fin bits are set */
-                if( ( stream->state & fin_state_mask ) == fin_state_mask ) {
-                  /* fd_quic_tx_stream_free also notifies the user */
-                  fd_quic_tx_stream_free( conn->quic, conn, stream, FD_QUIC_STREAM_NOTIFY_END );
+                if( tx_ack[tx_tail>>3ul] & ( 1u << ( tx_tail & 7u ) ) ) {
+                  tx_tail++;
+                } else {
+                  break;
                 }
               }
-            } else if( tx_tail == stream->tx_buf.tail &&
-                ( stream->state & fin_state_mask ) == fin_state_mask ) {
-              /* fd_quic_tx_stream_free also notifies the user */
-              fd_quic_tx_stream_free( conn->quic, conn, stream, FD_QUIC_STREAM_NOTIFY_END );
             }
+            stream->unacked_low = tx_tail;
+          } else {
+            /* mark this range as acked in tx_ack, so we can skip it later */
+            /* TODO optimize this for larger strides */
+            for( ulong k = range.offset_lo; k < range.offset_hi; ) {
+              if( ( k & 7ul ) == 0ul && k + 8ul <= range.offset_hi ) {
+                /* set whole byte */
+                tx_ack[k>>3ul] = 0xffu;
+                k += 8ul;
+              } else {
+                /* compiler is not smart enough to know ( 1u << ( k & 7u ) ) fits in a uchar */
+                tx_ack[k>>3ul] |= (uchar)( 1ul << ( k & 7ul ) );
+                k++;
+              }
+            }
+          }
 
-            /* we could retransmit (timeout) the bytes which have not been acked (by implication) */
+          /* For convenience */
+          uint fin_state_mask = FD_QUIC_STREAM_STATE_TX_FIN | FD_QUIC_STREAM_STATE_RX_FIN;
+
+          /* Free stream if it's done:
+              1. peer has acked every data byte user has tried to send
+              2. peer has acked the fin --> user has fin'd */
+          if( tx_tail == stream->tx_buf.head &&
+              ( stream->state & fin_state_mask ) == fin_state_mask ) {
+            /* fd_quic_tx_stream_free also notifies the user */
+            fd_quic_tx_stream_free( conn->quic, conn, stream, FD_QUIC_STREAM_NOTIFY_END );
           }
         }
       } while(0);
@@ -5020,9 +4960,9 @@ fd_quic_tx_stream_free( fd_quic_t *        quic,
                         int                code ) {
 
   /* TODO rename FD_QUIC_NOTIFY_END to FD_QUIC_STREAM_NOTIFY_END et al */
-  if( FD_LIKELY( stream->state != FD_QUIC_STREAM_STATE_UNUSED ) ) {
+  if( FD_LIKELY( stream->state != FD_QUIC_STREAM_STATE_DEAD ) ) {
     fd_quic_cb_stream_notify( quic, stream, stream->context, code );
-    stream->state = FD_QUIC_STREAM_STATE_UNUSED;
+    stream->state = FD_QUIC_STREAM_STATE_DEAD;
   }
 
   ulong stream_id = stream->stream_id;

--- a/src/waltz/quic/fd_quic_stream_pool.c
+++ b/src/waltz/quic/fd_quic_stream_pool.c
@@ -13,7 +13,6 @@ fd_quic_stream_pool_footprint( ulong count, ulong tx_buf_sz ) {
       FD_QUIC_STREAM_POOL_ALIGN );
 
   ulong stream_foot = fd_quic_stream_footprint( tx_buf_sz );
-  if( FD_UNLIKELY( !stream_foot ) ) return 0UL;
 
   return foot + stream_foot * count;
 }
@@ -39,7 +38,6 @@ fd_quic_stream_pool_new( void * mem, ulong count, ulong tx_buf_sz ) {
   offs += fd_ulong_align_up( sizeof( fd_quic_stream_pool_t ), FD_QUIC_STREAM_POOL_ALIGN );
 
   ulong stream_foot = fd_quic_stream_footprint( tx_buf_sz );
-  if( FD_UNLIKELY( !stream_foot ) ) { FD_LOG_WARNING(( "stream footprint is 0: Confirm tx_buf_sz is pow2!" )); return NULL; }
 
   FD_QUIC_STREAM_LIST_SENTINEL( pool->head );
 

--- a/src/waltz/quic/tests/test_quic_streams.c
+++ b/src/waltz/quic/tests/test_quic_streams.c
@@ -72,22 +72,6 @@ my_handshake_complete( fd_quic_conn_t * conn,
 /* global "clock" */
 long now = 123;
 
-static void
-test_invalid_tx_buf_sz( fd_wksp_t * wksp ) {
-  FD_LOG_NOTICE(( "Testing invalid tx_buf_sz" ));
-  FD_TEST( !fd_ulong_pow2( FD_TXN_MTU ) );
-
-  fd_quic_limits_t const bad_limits = {
-    .conn_cnt           = 2,
-    .conn_id_cnt        = 4,
-    .handshake_cnt      = 10,
-    .inflight_frame_cnt = 100 * 2,
-    .tx_buf_sz          = FD_TXN_MTU,
-    .stream_pool_cnt    = 512
-  };
-  FD_TEST( !fd_quic_new( wksp, &bad_limits ) );
-}
-
 int
 main( int     argc,
       char ** argv ) {
@@ -110,8 +94,6 @@ main( int     argc,
   FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
   fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
-
-  test_invalid_tx_buf_sz( wksp );
 
   FD_LOG_NOTICE(( "Creating server QUIC" ));
 


### PR DESCRIPTION
This PR simplifies stream buffer handling. It flattens the stream buffer, which is no longer required to be sized to PoW2. It accelerates stream ack processing in the common case where the acks for a given stream are not reordered. However, tx_buf capacity must now be set to the max total stream length. For the Solana use-case, which doesn't quite require actual streaming, this is worth the tradeoff. 