### PR TITLE
ballet: fix out-of-bounds read in sbpf loader

### DIFF
--- a/src/ballet/sbpf/fd_sbpf_loader.c
+++ b/src/ballet/sbpf/fd_sbpf_loader.c
@@ -608,7 +608,7 @@ fd_sbpf_r_bpf_64_relative( fd_sbpf_elf_t const *      elf,
     ulong refd_addr = 0UL;
 
     /* https://github.com/anza-xyz/sbpf/blob/v0.12.2/src/elf.rs#L1230-L1239 */
-    if( FD_UNLIKELY( fd_ulong_sat_add( r_offset, 4UL /* BYTE_LENGTH_IMMEDIATE */ )>elf_sz ) ) {
+    if( FD_UNLIKELY( fd_ulong_sat_add( imm_offset, 4UL /* BYTE_LENGTH_IMMEDIATE */ )>elf_sz ) ) {
       return FD_SBPF_ELF_ERR_VALUE_OUT_OF_BOUNDS;
     }
     refd_addr = FD_LOAD( uint, rodata+imm_offset );


### PR DESCRIPTION
The bounds check should be on `imm_offset`, not `r_offset`: https://github.com/anza-xyz/sbpf/blob/69a2dbbc28bd5b131f26f8c852853defb10b736e/src/elf.rs#L1062-L1064