### PR TITLE
dockerfiles for gcc-8, gcc-9 and gcc-10

### DIFF
--- a/contrib/containers/README.md
+++ b/contrib/containers/README.md
@@ -1,0 +1,51 @@
+# GCC Containers
+
+These dockerfiles can be used to build containers with GCC 8, GCC 9 and GCC 10.
+
+## Build the container
+
+This assumes you are currently in the top directory of the repository.
+
+```bash
+podman build -t gcc:8 -f ./contrib/containers/gcc-8.dockerfile
+```
+
+## Run the container
+
+If SELinux is enabled, run the following command once:
+
+```bash
+chcon -R -t container_file_t ./
+```
+
+When running the container, mount the top directory of the repository at `/data/firedancer`:
+
+```bash
+podman run -ti -v ./:/data/firedancer gcc:8 bash
+```
+
+## Build the binaries
+
+When building with different compilers, you should cleanup any existing files.
+
+> [!WARNING]
+> Since we mount the files from the host, this cleanup, even though running inside
+> the container, will cleanup the files on the host as well. If you want to avoid
+> that, make a fresh clone of the repository on the host and mount that directory
+> while running the container.
+
+```bash
+./deps.sh nuke && make -j distclean
+```
+
+Install and compile the dependencies:
+
+```bash
+FD_AUTO_INSTALL_PACKAGES=1 ./deps.sh +dev fetch check install
+```
+
+Compile desired targets:
+
+```bash
+make -j all fdctl fddev
+```

--- a/contrib/containers/gcc-10.dockerfile
+++ b/contrib/containers/gcc-10.dockerfile
@@ -1,0 +1,30 @@
+FROM rockylinux:8
+
+# Install GCC Toolset 10
+RUN yum install -qy gcc-toolset-10 wget git && \
+    yum clean all
+
+# Enable GCC Toolset 10 by default
+ENV PATH=/opt/rh/gcc-toolset-10/root/usr/bin:${PATH}
+ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-10/root/usr/lib64:${LD_LIBRARY_PATH}
+
+# Download and install pre-built CMake 3.26.5 binary
+RUN cd /tmp && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.26.5/cmake-3.26.5-linux-x86_64.tar.gz && \
+    tar -xzf cmake-3.26.5-linux-x86_64.tar.gz -C /opt && \
+    ln -s /opt/cmake-3.26.5-linux-x86_64/bin/cmake /usr/local/bin/cmake && \
+    ln -s /opt/cmake-3.26.5-linux-x86_64/bin/ctest /usr/local/bin/ctest && \
+    ln -s /opt/cmake-3.26.5-linux-x86_64/bin/cpack /usr/local/bin/cpack && \
+    rm -f /tmp/cmake-3.26.5-linux-x86_64.tar.gz
+
+# Install Rust using rustup
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+
+# Enable Rust by default
+ENV PATH=/root/.cargo/bin:${PATH}
+ENV RUSTUP_HOME=/root/.rustup
+ENV CARGO_HOME=/root/.cargo
+
+WORKDIR /data/firedancer
+
+CMD ["/bin/bash"]

--- a/contrib/containers/gcc-8.dockerfile
+++ b/contrib/containers/gcc-8.dockerfile
@@ -1,0 +1,27 @@
+FROM rockylinux:8
+
+# Install GCC 8 and development tools (Rocky Linux 8 ships with GCC 8.5.0 by default)
+RUN yum groupinstall -qy "Development Tools" && \
+    yum install -qy wget git && \
+    yum clean all
+
+# Download and install pre-built CMake 3.26.5 binary
+RUN cd /tmp && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.26.5/cmake-3.26.5-linux-x86_64.tar.gz && \
+    tar -xzf cmake-3.26.5-linux-x86_64.tar.gz -C /opt && \
+    ln -s /opt/cmake-3.26.5-linux-x86_64/bin/cmake /usr/local/bin/cmake && \
+    ln -s /opt/cmake-3.26.5-linux-x86_64/bin/ctest /usr/local/bin/ctest && \
+    ln -s /opt/cmake-3.26.5-linux-x86_64/bin/cpack /usr/local/bin/cpack && \
+    rm -f /tmp/cmake-3.26.5-linux-x86_64.tar.gz
+
+# Install Rust using rustup
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+
+# Enable Rust by default
+ENV PATH=/root/.cargo/bin:${PATH}
+ENV RUSTUP_HOME=/root/.rustup
+ENV CARGO_HOME=/root/.cargo
+
+WORKDIR /data/firedancer
+
+CMD ["/bin/bash"]

--- a/contrib/containers/gcc-9.dockerfile
+++ b/contrib/containers/gcc-9.dockerfile
@@ -1,0 +1,30 @@
+FROM rockylinux:8
+
+# Install GCC Toolset 9
+RUN yum install -qy gcc-toolset-9 wget git && \
+    yum clean all
+
+# Enable GCC Toolset 9 by default
+ENV PATH=/opt/rh/gcc-toolset-9/root/usr/bin:${PATH}
+ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-9/root/usr/lib64:${LD_LIBRARY_PATH}
+
+# Download and install pre-built CMake 3.26.5 binary
+RUN cd /tmp && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.26.5/cmake-3.26.5-linux-x86_64.tar.gz && \
+    tar -xzf cmake-3.26.5-linux-x86_64.tar.gz -C /opt && \
+    ln -s /opt/cmake-3.26.5-linux-x86_64/bin/cmake /usr/local/bin/cmake && \
+    ln -s /opt/cmake-3.26.5-linux-x86_64/bin/ctest /usr/local/bin/ctest && \
+    ln -s /opt/cmake-3.26.5-linux-x86_64/bin/cpack /usr/local/bin/cpack && \
+    rm -f /tmp/cmake-3.26.5-linux-x86_64.tar.gz
+
+# Install Rust using rustup
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+
+# Enable Rust by default
+ENV PATH=/root/.cargo/bin:${PATH}
+ENV RUSTUP_HOME=/root/.rustup
+ENV CARGO_HOME=/root/.cargo
+
+WORKDIR /data/firedancer
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
The next step would be to update `build.sh` to use these and perform builds for gcc-8, gcc-9 and gcc-10 in containers, which would be do-able even on RHEL/Rocky 9 hosts.