### PR TITLE
Revert "quic: lazy evict from conn ID map"

### DIFF
--- a/src/waltz/quic/fd_quic_conn_map.h
+++ b/src/waltz/quic/fd_quic_conn_map.h
@@ -1,11 +1,11 @@
 #ifndef HEADER_fd_src_waltz_quic_fd_quic_conn_map_h
 #define HEADER_fd_src_waltz_quic_fd_quic_conn_map_h
 
-#include "fd_quic_common.h"
+#include "../../util/fd_util_base.h"
 
 struct __attribute__((aligned(16))) fd_quic_conn_map {
   ulong conn_id;
-  fd_quic_conn_t * conn;
+  fd_quic_conn_t *  conn;
 };
 typedef struct fd_quic_conn_map fd_quic_conn_map_t;
 
@@ -15,6 +15,14 @@ typedef struct fd_quic_conn_map fd_quic_conn_map_t;
 #define MAP_MEMOIZE     0
 #define MAP_KEY_HASH(k) ((uint)k)
 #include "../../util/tmpl/fd_map_dynamic.c"
+
+FD_PROTOTYPES_BEGIN
+
+fd_quic_conn_t *
+fd_quic_conn_query( fd_quic_conn_map_t * map,
+                    ulong                conn_id );
+
+FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_waltz_quic_fd_quic_conn_map_h */
 

--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -149,24 +149,6 @@ fd_quic_get_state_const( fd_quic_t const * quic ) {
   return (fd_quic_state_t const *)( (ulong)quic + FD_QUIC_STATE_OFF );
 }
 
-static inline fd_quic_conn_map_t *
-fd_quic_conn_query1( fd_quic_conn_map_t * map,
-                     ulong                conn_id,
-                     fd_quic_conn_map_t * sentinel ) {
-  if( !conn_id ) return sentinel;
-  return fd_quic_conn_map_query( map, conn_id, sentinel );
-}
-
-static inline fd_quic_conn_t *
-fd_quic_conn_query( fd_quic_conn_map_t * map,
-                    ulong                conn_id ) {
-  fd_quic_conn_map_t sentinel = {0};
-  if( !conn_id ) return NULL;
-  fd_quic_conn_map_t * entry = fd_quic_conn_map_query( map, conn_id, &sentinel );
-  if( entry->conn && entry->conn->state==FD_QUIC_CONN_STATE_INVALID ) return NULL;
-  return entry->conn;
-}
-
 /* fd_quic_conn_service is called periodically to perform pending
    operations and time based operations.
 
@@ -192,9 +174,8 @@ fd_quic_conn_create( fd_quic_t *               quic,
                      ushort                    self_udp_port,
                      int                       server );
 
-/* fd_quic_conn_free frees up most resources related to the connection
-   and returns it to the connection free list.  The dead conn remains in
-   the conn_id_map to catch inflight packets by the peer. */
+/* fd_quic_conn_free frees up resources related to the connection and
+   returns it to the connection free list. */
 void
 fd_quic_conn_free( fd_quic_t *      quic,
                    fd_quic_conn_t * conn );
@@ -336,14 +317,13 @@ fd_quic_handle_v1_initial( fd_quic_t *               quic,
                            fd_quic_conn_id_t const * scid,
                            uchar *                   cur_ptr,
                            ulong                     cur_sz );
+
 ulong
-fd_quic_handle_v1_handshake(
-    fd_quic_t *      quic,
-    fd_quic_conn_t * conn,
-    fd_quic_pkt_t *  pkt,
-    uchar *          cur_ptr,
-    ulong            cur_sz
-);
+fd_quic_handle_v1_handshake( fd_quic_t *      quic,
+                             fd_quic_conn_t * conn,
+                             fd_quic_pkt_t *  pkt,
+                             uchar *          cur_ptr,
+                             ulong            cur_sz );
 
 ulong
 fd_quic_handle_v1_one_rtt( fd_quic_t *      quic,


### PR DESCRIPTION
This reverts commit 4a969bac8d3162b37348a24a9162e7371ac48079.

https://github.com/firedancer-io/firedancer/commit/b252be2b805c5db0c22630e6ca2747489bb6ac8f already defeated the main purpose of the original commit. The only remaining benefit was keeping data around for quic_trace to use. But we discovered that occasionally, a non-first Initial packet destined for a connection that had somehow become INVALID would get dropped. With this revert, we instead have a chance of reviving the connection (creating a new conn slot for it). 