### PR TITLE
do not build genesis tile if bzip2 not present

### DIFF
--- a/src/discof/genesis/Local.mk
+++ b/src/discof/genesis/Local.mk
@@ -1,5 +1,7 @@
 ifdef FD_HAS_ALLOCA
 ifdef FD_HAS_INT128
+ifdef FD_HAS_BZIP2
 $(call add-objs,fd_genesi_tile fd_genesis_client,fd_discof)
+endif
 endif
 endif


### PR DESCRIPTION
Currently on `main`, if `./deps.sh` is run without `+dev` and then we run `make -j fdctl solana` as we say in our docs, compilation fails with:
```
src/discof/genesis/fd_genesi_tile.c:22:10: fatal error: bzlib.h: No such file or directory
   22 | #include <bzlib.h>
      |          ^~~~~~~~~
compilation terminated.
```