### PR TITLE
progcache: fix invalidation GC

### DIFF
--- a/contrib/offline-replay/offline_replay.toml
+++ b/contrib/offline-replay/offline_replay.toml
@@ -18,7 +18,7 @@
     max_live_slots = 4
     max_fork_width = 4
     [runtime.program_cache]
-        heap_size_mib = 131072
+        heap_size_mib = 4096
 [consensus]
     vote = false
 [development]

--- a/src/flamenco/progcache/fd_progcache_user.c
+++ b/src/flamenco/progcache/fd_progcache_user.c
@@ -649,6 +649,11 @@ fd_progcache_invalidate( fd_progcache_t *          cache,
 
   if( FD_UNLIKELY( !cache || !funk->shmem ) ) FD_LOG_CRIT(( "NULL progcache" ));
 
+  /* Select a fork node to create invalidate record in
+     Do not create invalidation records at the funk root */
+
+  if( fd_funk_txn_xid_eq( xid, cache->funk->shmem->last_publish ) ) return NULL;
+
   fd_funk_txn_t * txn = fd_funk_txn_query( xid, funk->txn_map );
   if( FD_UNLIKELY( !fd_progcache_txn_try_lock( txn ) ) ) {
     FD_LOG_CRIT(( "fd_progcache_invalidate(xid=%lu,...) failed: txn is write-locked", xid->ul[0] ));


### PR DESCRIPTION
fd_progcache must maintain an invariant that no cache invalidation
records exist at the root.  Adds missing garbage collection for
this case.  Fixes a bug that results in invalidations incorrectly
being reordered with newly rooted records.
