### PR TITLE
tpu_reasm: don't cancel reasm if stream reordered

### DIFF
--- a/src/disco/quic/fd_tpu_reasm.c
+++ b/src/disco/quic/fd_tpu_reasm.c
@@ -199,7 +199,6 @@ fd_tpu_reasm_frag( fd_tpu_reasm_t *      reasm,
   ulong sz0      = slot->k.sz;
 
   if( FD_UNLIKELY( data_off>sz0 ) ) {
-    fd_tpu_reasm_cancel( reasm, slot );
     return FD_TPU_REASM_ERR_SKIP;
   }
 


### PR DESCRIPTION
After this PR, we will no longer cancel reassembly if we receive stream data out of order (on a given stream).