### PR TITLE
build: arm64 brew support, install coreutils on macos

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -266,13 +266,13 @@ check_alpine_pkgs () {
 }
 
 check_macos_pkgs () {
-  local REQUIRED_FORMULAE=( perl autoconf gettext automake flex bison protobuf )
+  local REQUIRED_FORMULAE=( perl autoconf gettext automake flex bison protobuf coreutils )
 
   echo "[~] Checking for required brew formulae"
 
   local MISSING_FORMULAE=( )
   for formula in "${REQUIRED_FORMULAE[@]}"; do
-    if [[ ! -d "/usr/local/Cellar/$formula" ]]; then
+    if ! brew ls --versions "$formula" >/dev/null 2>&1; then
       MISSING_FORMULAE+=( "$formula" )
     fi
   done


### PR DESCRIPTION
Hi, Homebrew on arm64 macos uses a different folder for Cellars. I also think that the Cellar location can be manually changed as well, so the current check would fail for these builds too. A better way to check whether a formula is installed is to directly ask Homebrew. 

Plus, `nproc` is not a thing by default on macos. It should either be installed with `coreutils`, or the usage of it should be swapped to a `sysctl -n hw.logicalcpu`. Given that it probably will be easier to maintain everything with keeping in mind that you can freely use `nproc`, the current change is just installing `coreutils`.