### PR TITLE
config: fix bzip2 feature

### DIFF
--- a/config/extra/with-arm.mk
+++ b/config/extra/with-arm.mk
@@ -30,6 +30,7 @@ else # CROSS=0
 include config/extra/with-ucontext.mk
 include config/extra/with-secp256k1.mk
 include config/extra/with-zstd.mk
+include config/extra/with-bzip2.mk
 include config/extra/with-lz4.mk
 include config/extra/with-openssl.mk
 include config/extra/with-rocksdb.mk

--- a/config/extra/with-bzip2.mk
+++ b/config/extra/with-bzip2.mk
@@ -1,0 +1,8 @@
+ifeq ($(wildcard $(OPT)/git/bzip2/bzlib.c),)
+$(warning "bzip2 not installed, skipping")
+else
+
+FD_HAS_BZIP2:=1
+CFLAGS+=-DFD_HAS_BZIP2=1
+
+endif

--- a/config/extra/with-x86-64.mk
+++ b/config/extra/with-x86-64.mk
@@ -16,6 +16,7 @@ include config/extra/with-ucontext.mk
 include config/extra/with-secp256k1.mk
 include config/extra/with-s2nbignum.mk
 include config/extra/with-zstd.mk
+include config/extra/with-bzip2.mk
 include config/extra/with-lz4.mk
 include config/extra/with-openssl.mk
 include config/extra/with-rocksdb.mk

--- a/src/ballet/bzip2/Local.mk
+++ b/src/ballet/bzip2/Local.mk
@@ -1,10 +1,4 @@
-ifeq ($(wildcard $(OPT)/git/bzip2/bzlib.c),)
-$(warning "bzip2 not installed, skipping")
-else
-
-FD_HAS_BZIP2:=1
-CFLAGS+=-DFD_HAS_BZIP2=1
-
+ifdef FD_HAS_BZIP2
 BZ2_OBJS:=blocksort compress crctable decompress huffman randtable bzlib
 $(OBJDIR)/lib/libfd_ballet.a: $(patsubst %,$(OBJDIR)/obj/ballet/bzip2/%.o,$(BZ2_OBJS))
 


### PR DESCRIPTION
Fixes build system mess that results in failure to cleanly signal bzip2 availability to compile units.
