### PR TITLE
chore: fix wrong fd_pool acquire usage

### DIFF
--- a/src/discof/forest/fd_forest.c
+++ b/src/discof/forest/fd_forest.c
@@ -175,7 +175,6 @@ fd_forest_init( fd_forest_t * forest, ulong root_slot ) {
 
   /* Sanity checks. */
 
-  FD_TEST( root_ele );
   FD_TEST( root_ele == fd_forest_frontier_ele_query( frontier, &root_slot, NULL, pool ));
   FD_TEST( root_ele->slot == root_slot );
 

--- a/src/discof/restore/utils/fd_sspeer_selector.c
+++ b/src/discof/restore/utils/fd_sspeer_selector.c
@@ -275,7 +275,6 @@ fd_sspeer_selector_add( fd_sspeer_selector_t * selector,
     if( FD_UNLIKELY( !peer_pool_free( selector->pool ) ) ) return ULONG_MAX;
 
     peer = peer_pool_ele_acquire( selector->pool );
-    FD_TEST( peer );
     if( FD_LIKELY( ssinfo ) ) {
       peer->ssinfo  = *ssinfo;
     } else {

--- a/src/discof/restore/utils/fd_ssping.c
+++ b/src/discof/restore/utils/fd_ssping.c
@@ -225,7 +225,6 @@ fd_ssping_add( fd_ssping_t * ssping,
   if( FD_LIKELY( !peer ) ) {
     if( FD_UNLIKELY( !peer_pool_free( ssping->pool ) ) ) return;
     peer = peer_pool_ele_acquire( ssping->pool );
-    FD_TEST( peer );
     memset( peer, 0, sizeof(fd_ssping_peer_t) );
     peer->refcnt        = 0UL;
     peer->state         = PEER_STATE_UNPINGED;

--- a/src/flamenco/runtime/fd_bank.c
+++ b/src/flamenco/runtime/fd_bank.c
@@ -53,9 +53,6 @@ fd_bank_footprint( void ) {
       FD_LOG_CRIT(( "Failed to acquire " #name " pool element: pool is full" ));                                   \
     }                                                                                                              \
     fd_bank_##name##_t * child_##name = fd_bank_##name##_pool_ele_acquire( name##_pool );                          \
-    if( FD_UNLIKELY( !child_##name ) ) {                                                                           \
-      FD_LOG_CRIT(( "Failed to acquire " #name " pool element" ));                                                 \
-    }                                                                                                              \
     fd_rwlock_unwrite( fd_bank_get_##name##_pool_lock( bank ) );                                                   \
     /* If the dirty flag has not been set yet, we need to allocated a */                                           \
     /* new pool element and copy over the data from the parent idx.   */                                           \

--- a/src/flamenco/stakes/fd_stake_delegations.c
+++ b/src/flamenco/stakes/fd_stake_delegations.c
@@ -246,9 +246,6 @@ fd_stake_delegations_update( fd_stake_delegations_t * stake_delegations,
   }
 
   fd_stake_delegation_t * stake_delegation = fd_stake_delegation_pool_ele_acquire( stake_delegation_pool );
-  if( FD_UNLIKELY( !stake_delegation ) ) {
-    FD_LOG_CRIT(( "unable to acquire stake delegation" ));
-  }
 
   stake_delegation->stake_account        = *stake_account;
   stake_delegation->vote_account         = *vote_account;

--- a/src/flamenco/stakes/fd_vote_states.c
+++ b/src/flamenco/stakes/fd_vote_states.c
@@ -193,9 +193,6 @@ fd_vote_states_update( fd_vote_states_t *  vote_states,
   }
 
   fd_vote_state_ele_t * vote_state = fd_vote_state_pool_ele_acquire( vote_state_pool );
-  if( FD_UNLIKELY( !vote_state ) ) {
-    FD_LOG_CRIT(( "unable to acquire vote state" ));
-  }
 
   vote_state->vote_account = *vote_account;
   vote_state->stake        = 0UL;


### PR DESCRIPTION
calling acquire on a pool with no space left is UB and cannot be assumed to return NULL
Fixes all the results that https://github.com/firedancer-io/firedancer/pull/7056 finds.