### PR TITLE
fix coverage report failure

### DIFF
--- a/src/flamenco/vm/syscall/test_vm_syscalls.c
+++ b/src/flamenco/vm/syscall/test_vm_syscalls.c
@@ -196,7 +196,7 @@ test_vm_syscall_sol_log_data( char const *            test_case_name,
 
 static void
 dump_syscall_table( void ) {
-  fd_sbpf_syscalls_t _syscalls[ 1UL<<FD_SBPF_SYSCALLS_LG_SLOT_CNT ];
+  fd_sbpf_syscalls_t _syscalls[ 1UL<<FD_SBPF_SYSCALLS_LG_SLOT_CNT ] = {0};
   fd_sbpf_syscalls_t * syscalls = fd_sbpf_syscalls_join( fd_sbpf_syscalls_new( _syscalls ) );
   FD_TEST( syscalls );
 


### PR DESCRIPTION
Compiling with Clang makes the `test_vm_syscalls` unit test segfault. We did not catch it in CI as we also compile with ASAN which (somehow) prevents this from happening, as does GCC.