### PR TITLE
ethtool: disable RX-UDP-GRO-FWD instead of GRO

### DIFF
--- a/book/api/cli.md
+++ b/book/api/cli.md
@@ -68,8 +68,7 @@ following stages to each configure command:
  - `hyperthreads` Disables hyperthreaded pair for critical CPU cores.
  - `ethtool-channels` Configures the number of channels on the network
     device.
- - `ethtool-offloads` Disables generic receive offload (GRO) and GRE
-    segmentation offload on the network device.
+ - `ethtool-offloads` Modify offload feature flags on the network device.
  - `ethtool-loopback` Disables UDP segmentation on the loopback device.
 
 | Arguments         | Description |

--- a/book/guide/initializing.md
+++ b/book/guide/initializing.md
@@ -9,8 +9,7 @@ so Firedancer can run correctly. It does the following:
 * **hyperthreads** Checks hyperthreaded pair for critical CPU cores.
 * **ethtool-channels** Configures the number of channels on the network
 device.
-* **ethtool-offloads** Disable generic-receive-offload (GRO) and GRE
-segmentation offload on the network device.
+* **ethtool-offloads** Modify offload feature flags on the network device.
 * **ethtool-loopback** Disable tx-udp-segmentation on the loopback
 device.
 
@@ -188,7 +187,7 @@ privileges, and cannot be performed with capabilities.
 
 ## ethtool-offloads
 XDP is incompatible with a feature of network devices called
-`generic-receive-offload`. This feature must be disabled for Firedancer
+`rx-udp-gro-forwarding`. This feature must be disabled for Firedancer
 to work. GRE segmentation offload is also disabled.
 
 The command run by the stage is similar to running

--- a/src/app/fddev/commands/configure/blockstore.c
+++ b/src/app/fddev/commands/configure/blockstore.c
@@ -173,7 +173,8 @@ fini( config_t const * config,
 }
 
 static configure_result_t
-check( config_t const * config ) {
+check( config_t const * config,
+       int              check_type FD_PARAM_UNUSED ) {
   int has_non_genesis = 0;
 
   DIR * dir = opendir( config->paths.ledger );

--- a/src/app/firedancer-dev/commands/send_test/send_test.c
+++ b/src/app/firedancer-dev/commands/send_test/send_test.c
@@ -271,7 +271,7 @@ configure_stage_perm( configure_stage_t const * stage,
                       fd_cap_chk_t *            chk,
                       config_t const *          config ) {
   int enabled = !stage->enabled || stage->enabled( config );
-  if( enabled && stage->check( config ).result != CONFIGURE_OK )
+  if( enabled && stage->check( config, FD_CONFIGURE_CHECK_TYPE_INIT_PERM ).result != CONFIGURE_OK )
     if( stage->init_perm ) stage->init_perm( chk, config );
 }
 

--- a/src/app/firedancer/commands/configure/vinyl.c
+++ b/src/app/firedancer/commands/configure/vinyl.c
@@ -51,7 +51,8 @@ fini( config_t const * config,
 }
 
 static configure_result_t
-check( config_t const * config ) {
+check( config_t const * config,
+       int              check_type FD_PARAM_UNUSED ) {
   struct stat st;
   if( FD_UNLIKELY( 0!=stat( config->paths.accounts, &st ) ) ) {
     if( errno==ENOENT ) NOT_CONFIGURED( "`%s` does not exist", config->paths.accounts );

--- a/src/app/shared/commands/configure/configure.h
+++ b/src/app/shared/commands/configure/configure.h
@@ -54,6 +54,16 @@ typedef struct {
     return result;                \
   } while( 0 )
 
+#define FD_CONFIGURE_CHECK_TYPE_INIT_PERM (0)
+#define FD_CONFIGURE_CHECK_TYPE_FINI_PERM (1)
+#define FD_CONFIGURE_CHECK_TYPE_PRE_INIT  (2)
+#define FD_CONFIGURE_CHECK_TYPE_UNDO_INIT (3)
+#define FD_CONFIGURE_CHECK_TYPE_POST_INIT (4)
+#define FD_CONFIGURE_CHECK_TYPE_CHECK     (5)
+#define FD_CONFIGURE_CHECK_TYPE_PRE_FINI  (6)
+#define FD_CONFIGURE_CHECK_TYPE_POST_FINI (7)
+#define FD_CONFIGURE_CHECK_TYPE_RUN       (8)
+
 /* fini() returns whether or not it took any actions. */
 
 typedef struct configure_stage {
@@ -64,7 +74,7 @@ typedef struct configure_stage {
   void               (*fini_perm)( fd_cap_chk_t * chk, config_t const * config );
   void               (*init)     ( config_t const * config );
   int                (*fini)     ( config_t const * config, int pre_init );
-  configure_result_t (*check)    ( config_t const * config );
+  configure_result_t (*check)    ( config_t const * config, int check_type );
 } configure_stage_t;
 
 extern configure_stage_t fd_cfg_stage_hugetlbfs;

--- a/src/app/shared/commands/configure/ethtool-channels.c
+++ b/src/app/shared/commands/configure/ethtool-channels.c
@@ -277,7 +277,8 @@ check_device_is_configured( char const *        device,
 }
 
 static configure_result_t
-check( fd_config_t const * config ) {
+check( fd_config_t const * config,
+       int                 check_type FD_PARAM_UNUSED ) {
   int only_dedicated =
     (0==strcmp( config->net.xdp.rss_queue_mode, "dedicated" ));
   int check_dedicated = only_dedicated ||

--- a/src/app/shared/commands/configure/ethtool-loopback.c
+++ b/src/app/shared/commands/configure/ethtool-loopback.c
@@ -42,7 +42,8 @@ init( fd_config_t const * config FD_PARAM_UNUSED ) {
 }
 
 static configure_result_t
-check( fd_config_t const * config FD_PARAM_UNUSED ) {
+check( fd_config_t const * config     FD_PARAM_UNUSED,
+       int                 check_type FD_PARAM_UNUSED ) {
   fd_ethtool_ioctl_t ioc;
   if( FD_UNLIKELY( &ioc != fd_ethtool_ioctl_init( &ioc, "lo" ) ) )
     FD_LOG_ERR(( "error configuring network device (lo), unable to init ethtool ioctl" ));

--- a/src/app/shared/commands/configure/ethtool-offloads.c
+++ b/src/app/shared/commands/configure/ethtool-offloads.c
@@ -1,12 +1,20 @@
-/* This stage disables various ethtool features on the main and
-   loopback interfaces that are known to be incompatible with AF_XDP.
+/* This stage checks and modifies various ethtool features on the main
+   and loopback interfaces.
 
-     - "Generic Receive Offload": If left enabled, GRO will mangle UDP
-     packets in a way that causes AF_XDP packets to get corrupted.
+     - "Generic Receive Offload": If enabled, may greatly increase
+     throughput for sockets-based TCP flows, such as HTTP snapshot
+     downloads.  This stage will log a warning if GRO is disabled, but
+     does not modify the flag.
+
+     - "RX UDP GRO Forwarding": If left enabled, may aggregate multiple
+     UDP packets into a single large superpacket.  This would normally
+     be split later for socket recv() calls, but AF_XDP delivers the
+     full superpacket which confuses the application layer.  Disabled
+     by this stage.
 
      - "GRE Segmentation Offload": This feature has been known to cause
      corruption of packets sent via normal sockets while XDP is in use
-     on the same system. */
+     on the same system.  Disabled by this stage. */
 
 #include "configure.h"
 
@@ -24,9 +32,6 @@ enabled( fd_config_t const * config ) {
   /* if we're running in a network namespace, we configure ethtool on
      the virtual device as part of netns setup, not here */
   if( config->development.netns.enabled ) return 0;
-
-  /* only enable if network stack is XDP */
-  if( 0!=strcmp( config->net.provider, "xdp" ) ) return 0;
 
   return 1;
 }
@@ -70,87 +75,100 @@ device_read_slaves( char const * device,
 }
 
 static void
-init_device( char const * device ) {
-  fd_ethtool_ioctl_t ioc;
+init_device( char const * device,
+             int          xdp ) {
+  if( !xdp ) return;
+
+  fd_ethtool_ioctl_t ioc __attribute__((cleanup(fd_ethtool_ioctl_fini)));
   if( FD_UNLIKELY( &ioc != fd_ethtool_ioctl_init( &ioc, device ) ) )
     FD_LOG_ERR(( "error configuring network device (%s), unable to init ethtool ioctl", device ));
 
-  /* turn off generic-receive-offload, which is entirely incompatible with
+  /* turn off rx-udp-gro-forwarding, which is entirely incompatible with
    * AF_XDP and QUIC
    * It results in multiple UDP payloads being merged into a single UDP packet,
    * with IP and UDP headers rewritten, combining the lengths and updating the
    * checksums. QUIC short packets cannot be processed reliably in this case. */
-  FD_TEST( 0==fd_ethtool_ioctl_feature_gro_set( &ioc, 0 ) );
+  FD_TEST( 0==fd_ethtool_ioctl_feature_set( &ioc, FD_ETHTOOL_FEATURE_RXUDPGROFWD,  0 ) );
 
   /* turn off tx-gre-segmentation and tx-gre-csum-segmentation.  When
      enabled, some packets sent via normal sockets can be corrupted
      while XDP is in use on the same system. */
   FD_TEST( 0==fd_ethtool_ioctl_feature_set( &ioc, FD_ETHTOOL_FEATURE_TXGRESEG,     0 ) );
   FD_TEST( 0==fd_ethtool_ioctl_feature_set( &ioc, FD_ETHTOOL_FEATURE_TXGRECSUMSEG, 0 ) );
-
-  fd_ethtool_ioctl_fini( &ioc );
 }
 
 static void
 init( fd_config_t const * config ) {
+  int const xdp = 0==strcmp( config->net.provider, "xdp" );
   if( FD_UNLIKELY( device_is_bonded( config->net.interface ) ) ) {
-    /* if using a bonded device, we need to disable gro on the
-       underlying devices.
-
-       we don't need to disable gro on the bonded device, as the packets are
-       redirected by XDP before any of the kernel bonding logic */
     char line[ 4096 ];
     device_read_slaves( config->net.interface, line );
     char * saveptr;
     for( char * token=strtok_r( line , " \t", &saveptr ); token!=NULL; token=strtok_r( NULL, " \t", &saveptr ) ) {
-      init_device( token );
+      init_device( token, xdp );
     }
   } else {
-    init_device( config->net.interface );
+    init_device( config->net.interface, xdp );
   }
-  init_device( "lo" );
+  init_device( "lo", xdp );
 }
 
 static configure_result_t
-check_device( char const * device ) {
-  fd_ethtool_ioctl_t ioc;
+check_device( char const * device,
+              int          xdp,
+              int          warn_gro ) {
+  fd_ethtool_ioctl_t ioc __attribute__((cleanup(fd_ethtool_ioctl_fini)));
   if( FD_UNLIKELY( &ioc != fd_ethtool_ioctl_init( &ioc, device ) ) )
     FD_LOG_ERR(( "error configuring network device (%s), unable to init ethtool ioctl", device ));
 
-  int gro_active;
-  FD_TEST( 0==fd_ethtool_ioctl_feature_gro_test( &ioc, &gro_active ) );
+  if( warn_gro ) {
+    int gro_active, gro_supported;
+    if( FD_LIKELY( 0==fd_ethtool_ioctl_feature_gro_test( &ioc, &gro_active, &gro_supported ) ) ) {
+      if( FD_UNLIKELY( !gro_active && gro_supported ) ) {
+        FD_LOG_WARNING(( "network device `%s` has generic-receive-offload disabled.  "
+                         "Consider enabling with `ethtool --offload %s generic-receive-offload on`.  "
+                         "Proceeding but performance may be reduced.", device, device ));
+      }
+    }
+  }
 
-  int greseg_active;
-  int grecsumseg_active;
-  FD_TEST( 0==fd_ethtool_ioctl_feature_test( &ioc, FD_ETHTOOL_FEATURE_TXGRESEG,     &greseg_active     ) );
-  FD_TEST( 0==fd_ethtool_ioctl_feature_test( &ioc, FD_ETHTOOL_FEATURE_TXGRECSUMSEG, &grecsumseg_active ) );
+  if( xdp ) {
+    int udpgrofwd_active;
+    int greseg_active;
+    int grecsumseg_active;
+    FD_TEST( 0==fd_ethtool_ioctl_feature_test( &ioc, FD_ETHTOOL_FEATURE_RXUDPGROFWD,  &udpgrofwd_active  ) );
+    FD_TEST( 0==fd_ethtool_ioctl_feature_test( &ioc, FD_ETHTOOL_FEATURE_TXGRESEG,     &greseg_active     ) );
+    FD_TEST( 0==fd_ethtool_ioctl_feature_test( &ioc, FD_ETHTOOL_FEATURE_TXGRECSUMSEG, &grecsumseg_active ) );
 
-  fd_ethtool_ioctl_fini( &ioc );
-
-  if( FD_UNLIKELY( gro_active ) )
-    NOT_CONFIGURED( "device `%s` has generic-receive-offload enabled. Should be disabled", device );
-
-  if( FD_UNLIKELY( greseg_active ) )
-    NOT_CONFIGURED( "device `%s` has tx-gre-segmentation enabled. Should be disabled", device );
-  if( FD_UNLIKELY( grecsumseg_active ) )
-    NOT_CONFIGURED( "device `%s` has tx-gre-csum-segmentation enabled. Should be disabled", device );
+    if( FD_UNLIKELY( udpgrofwd_active ) )
+      NOT_CONFIGURED( "device `%s` has rx-udp-gro-forwarding enabled. Should be disabled", device );
+    if( FD_UNLIKELY( greseg_active ) )
+      NOT_CONFIGURED( "device `%s` has tx-gre-segmentation enabled. Should be disabled", device );
+    if( FD_UNLIKELY( grecsumseg_active ) )
+      NOT_CONFIGURED( "device `%s` has tx-gre-csum-segmentation enabled. Should be disabled", device );
+  }
 
   CONFIGURE_OK();
 }
 
 static configure_result_t
-check( fd_config_t const * config ) {
+check( fd_config_t const * config,
+       int                 check_type ) {
+  int warn_gro = check_type==FD_CONFIGURE_CHECK_TYPE_PRE_INIT ||
+                 check_type==FD_CONFIGURE_CHECK_TYPE_CHECK ||
+                 check_type==FD_CONFIGURE_CHECK_TYPE_RUN;
+  int const xdp = 0==strcmp( config->net.provider, "xdp" );
   if( FD_UNLIKELY( device_is_bonded( config->net.interface ) ) ) {
     char line[ 4096 ];
     device_read_slaves( config->net.interface, line );
     char * saveptr;
     for( char * token=strtok_r( line, " \t", &saveptr ); token!=NULL; token=strtok_r( NULL, " \t", &saveptr ) ) {
-      CHECK( check_device( token ) );
+      CHECK( check_device( token, xdp, warn_gro ) );
     }
   } else {
-    CHECK( check_device( config->net.interface ) );
+    CHECK( check_device( config->net.interface, xdp, warn_gro ) );
   }
-  CHECK( check_device( "lo" ) );
+  CHECK( check_device( "lo", xdp, 0 ) );
 
   CONFIGURE_OK();
 }

--- a/src/app/shared/commands/configure/fd_ethtool_ioctl.c
+++ b/src/app/shared/commands/configure/fd_ethtool_ioctl.c
@@ -392,9 +392,11 @@ fd_ethtool_ioctl_feature_gro_set( fd_ethtool_ioctl_t * ioc,
 
 int
 fd_ethtool_ioctl_feature_gro_test( fd_ethtool_ioctl_t * ioc,
-                                   int *                enabled ) {
+                                   int *                enabled,
+                                   int *                supported ) {
   struct ethtool_value gro = { .cmd = ETHTOOL_GGRO };
   int ret = run_ioctl( ioc, "ETHTOOL_GGRO", &gro, 1, 0 );
+  *supported = (ret!=EOPNOTSUPP);
   if( FD_UNLIKELY( ret!=0 ) ) {
     if( FD_LIKELY( ret==EOPNOTSUPP ) ) {
       *enabled = 0;

--- a/src/app/shared/commands/configure/fd_ethtool_ioctl.h
+++ b/src/app/shared/commands/configure/fd_ethtool_ioctl.h
@@ -44,6 +44,7 @@
 #define FD_ETHTOOL_FEATURE_TXUDPSEG      "tx-udp-segmentation"
 #define FD_ETHTOOL_FEATURE_TXGRESEG      "tx-gre-segmentation"
 #define FD_ETHTOOL_FEATURE_TXGRECSUMSEG  "tx-gre-csum-segmentation"
+#define FD_ETHTOOL_FEATURE_RXUDPGROFWD   "rx-udp-gro-forwarding"
 
 struct fd_ethtool_ioctl {
   int          fd;
@@ -154,12 +155,13 @@ fd_ethtool_ioctl_feature_gro_set( fd_ethtool_ioctl_t * ioc,
                                   int                  enabled );
 
 /* fd_ethtool_ioctl_feature_gro_test sets enabled to 1 if the
-   generic-receive-offload feature is enabled.  Returns nonzero on
-   failure. */
+   generic-receive-offload feature is enabled.  Sets supported to 1
+   if this feature is supported.  Returns nonzero on failure. */
 
 int
 fd_ethtool_ioctl_feature_gro_test( fd_ethtool_ioctl_t * ioc,
-                                   int *                enabled );
+                                   int *                enabled,
+                                   int *                supported );
 
 /* fd_ethtool_ioctl_ntuple_clear deletes any active ntuple flow steering
    rules, which is the default state.  Returns nonzero on failure. */

--- a/src/app/shared/commands/configure/hugetlbfs.c
+++ b/src/app/shared/commands/configure/hugetlbfs.c
@@ -290,7 +290,8 @@ fini( config_t const * config,
 }
 
 static configure_result_t
-check( config_t const * config ) {
+check( config_t const * config,
+       int              check_type FD_PARAM_UNUSED ) {
   char const * mount_path[ 2 ] = {
     config->hugetlbfs.huge_page_mount_path,
     config->hugetlbfs.gigantic_page_mount_path,

--- a/src/app/shared/commands/configure/hyperthreads.c
+++ b/src/app/shared/commands/configure/hyperthreads.c
@@ -31,8 +31,11 @@ determine_cpu_used( config_t const * config,
 }
 
 static configure_result_t
-check( config_t const * config ) {
-  static int has_warned = 0;
+check( config_t const * config,
+       int              check_type ) {
+  if( !( check_type==FD_CONFIGURE_CHECK_TYPE_PRE_INIT ||
+         check_type==FD_CONFIGURE_CHECK_TYPE_CHECK ||
+         check_type==FD_CONFIGURE_CHECK_TYPE_RUN ) ) CONFIGURE_OK();
 
   fd_topo_cpus_t cpus[1];
   fd_topo_cpus_init( cpus );
@@ -56,14 +59,10 @@ check( config_t const * config ) {
     }
   }
 
-  if( FD_LIKELY( !has_warned ) ) {
-    if( FD_UNLIKELY( pack_pair_used ) )        FD_LOG_WARNING(( "pack cpu %lu has hyperthread pair cpu %lu which is used by another tile. Proceeding but performance may be reduced.", config->topo.tiles[ pack_tile_idx ].cpu_idx, pack_pair ));
-    else if( FD_UNLIKELY( pack_pair_online ) ) FD_LOG_WARNING(( "pack cpu %lu has hyperthread pair cpu %lu which should be offline. Proceeding but performance may be reduced.", config->topo.tiles[ pack_tile_idx ].cpu_idx, pack_pair ));
-    if( FD_UNLIKELY( poh_pair_used  ) )        FD_LOG_WARNING(( "poh cpu %lu has hyperthread pair cpu %lu which is used by another tile. Proceeding but performance may be reduced.", config->topo.tiles[ poh_tile_idx ].cpu_idx, poh_pair ));
-    else if( FD_UNLIKELY( poh_pair_online ) )  FD_LOG_WARNING(( "poh cpu %lu has hyperthread pair cpu %lu which should be offline. Proceeding but performance may be reduced.", config->topo.tiles[ poh_tile_idx ].cpu_idx, poh_pair ));
-  }
-
-  has_warned = 1;
+  if( FD_UNLIKELY( pack_pair_used ) )        FD_LOG_WARNING(( "pack cpu %lu has hyperthread pair cpu %lu which is used by another tile. Proceeding but performance may be reduced.", config->topo.tiles[ pack_tile_idx ].cpu_idx, pack_pair ));
+  else if( FD_UNLIKELY( pack_pair_online ) ) FD_LOG_WARNING(( "pack cpu %lu has hyperthread pair cpu %lu which should be offline. Proceeding but performance may be reduced.", config->topo.tiles[ pack_tile_idx ].cpu_idx, pack_pair ));
+  if( FD_UNLIKELY( poh_pair_used  ) )        FD_LOG_WARNING(( "poh cpu %lu has hyperthread pair cpu %lu which is used by another tile. Proceeding but performance may be reduced.", config->topo.tiles[ poh_tile_idx ].cpu_idx, poh_pair ));
+  else if( FD_UNLIKELY( poh_pair_online ) )  FD_LOG_WARNING(( "poh cpu %lu has hyperthread pair cpu %lu which should be offline. Proceeding but performance may be reduced.", config->topo.tiles[ poh_tile_idx ].cpu_idx, poh_pair ));
 
   CONFIGURE_OK();
 }

--- a/src/app/shared/commands/configure/snapshots.c
+++ b/src/app/shared/commands/configure/snapshots.c
@@ -12,7 +12,8 @@ init( config_t const * config ) {
 }
 
 static configure_result_t
-check( config_t const * config ) {
+check( config_t const * config,
+       int              check_type FD_PARAM_UNUSED ) {
   struct stat st;
   if( FD_UNLIKELY( stat( config->paths.snapshots, &st ) && errno==ENOENT ) )
     NOT_CONFIGURED( "`%s` does not exist", config->paths.snapshots );

--- a/src/app/shared/commands/configure/sysctl.c
+++ b/src/app/shared/commands/configure/sysctl.c
@@ -170,7 +170,8 @@ check_param_list( sysctl_param_t const * list ) {
 }
 
 static configure_result_t
-check( config_t const * config ) {
+check( config_t const * config,
+       int              check_type FD_PARAM_UNUSED ) {
   configure_result_t r;
 
   r = check_param_list( params );

--- a/src/app/shared/commands/run/run.c
+++ b/src/app/shared/commands/run/run.c
@@ -713,35 +713,35 @@ initialize_stacks( config_t const * config ) {
 
 void
 fdctl_check_configure( config_t const * config ) {
-  configure_result_t check = fd_cfg_stage_hugetlbfs.check( config );
+  configure_result_t check = fd_cfg_stage_hugetlbfs.check( config, FD_CONFIGURE_CHECK_TYPE_RUN );
   if( FD_UNLIKELY( check.result!=CONFIGURE_OK ) )
     FD_LOG_ERR(( "Huge pages are not configured correctly: %s. You can run `fdctl configure init hugetlbfs` "
                  "to create the mounts correctly. This must be done after every system restart before running "
                  "Firedancer.", check.message ));
 
   if( FD_LIKELY( !config->development.netns.enabled && 0==strcmp( config->net.provider, "xdp" ) ) ) {
-    check = fd_cfg_stage_ethtool_channels.check( config );
+    check = fd_cfg_stage_ethtool_channels.check( config, FD_CONFIGURE_CHECK_TYPE_RUN );
     if( FD_UNLIKELY( check.result!=CONFIGURE_OK ) )
       FD_LOG_ERR(( "Network %s. You can run `fdctl configure init ethtool-channels` to set the number of channels on the "
                   "network device correctly.", check.message ));
 
-    check = fd_cfg_stage_ethtool_offloads.check( config );
+    check = fd_cfg_stage_ethtool_offloads.check( config, FD_CONFIGURE_CHECK_TYPE_RUN );
     if( FD_UNLIKELY( check.result!=CONFIGURE_OK ) )
       FD_LOG_ERR(( "Network %s. You can run `fdctl configure init ethtool-offloads` to disable features "
                   "as required.", check.message ));
 
-    check = fd_cfg_stage_ethtool_loopback.check( config );
+    check = fd_cfg_stage_ethtool_loopback.check( config, FD_CONFIGURE_CHECK_TYPE_RUN );
     if( FD_UNLIKELY( check.result!=CONFIGURE_OK ) )
       FD_LOG_ERR(( "Network %s. You can run `fdctl configure init ethtool-loopback` to disable tx-udp-segmentation "
                   "on the loopback device.", check.message ));
   }
 
-  check = fd_cfg_stage_sysctl.check( config );
+  check = fd_cfg_stage_sysctl.check( config, FD_CONFIGURE_CHECK_TYPE_RUN );
   if( FD_UNLIKELY( check.result!=CONFIGURE_OK ) )
     FD_LOG_ERR(( "Kernel parameters are not configured correctly: %s. You can run `fdctl configure init sysctl` "
                  "to set kernel parameters correctly.", check.message ));
 
-  check = fd_cfg_stage_hyperthreads.check( config );
+  check = fd_cfg_stage_hyperthreads.check( config, FD_CONFIGURE_CHECK_TYPE_RUN );
   if( FD_UNLIKELY( check.result!=CONFIGURE_OK ) )
     FD_LOG_ERR(( "Hyperthreading is not configured correctly: %s. You can run `fdctl configure init hyperthreads` "
                  "to configure hyperthreading correctly.", check.message ));

--- a/src/app/shared_dev/commands/configure/genesis.c
+++ b/src/app/shared_dev/commands/configure/genesis.c
@@ -296,7 +296,8 @@ fini( config_t const * config,
 }
 
 static configure_result_t
-check( config_t const * config ) {
+check( config_t const * config,
+       int              check_type FD_PARAM_UNUSED ) {
   if( FD_LIKELY( config->gossip.entrypoints_cnt ) ) CONFIGURE_OK();
 
   char _genesis_path[ PATH_MAX ];

--- a/src/app/shared_dev/commands/configure/keys.c
+++ b/src/app/shared_dev/commands/configure/keys.c
@@ -74,7 +74,8 @@ init( config_t const * config ) {
 }
 
 static configure_result_t
-check( config_t const * config ) {
+check( config_t const * config,
+       int              check_type FD_PARAM_UNUSED ) {
   char faucet[ PATH_MAX ], stake[ PATH_MAX ];
 
   FD_TEST( fd_cstr_printf_check( faucet, PATH_MAX, NULL, "%s/faucet.json", config->paths.base ) );

--- a/src/app/shared_dev/commands/configure/kill.c
+++ b/src/app/shared_dev/commands/configure/kill.c
@@ -170,7 +170,8 @@ init( config_t const * config ) {
 }
 
 static configure_result_t
-check( config_t const * config FD_PARAM_UNUSED ) {
+check( config_t const * config     FD_PARAM_UNUSED,
+       int              check_type FD_PARAM_UNUSED ) {
   PARTIALLY_CONFIGURED( "kill existing instances" );
 }
 

--- a/src/app/shared_dev/commands/configure/netns.c
+++ b/src/app/shared_dev/commands/configure/netns.c
@@ -118,7 +118,8 @@ fini( config_t const * config,
 }
 
 static configure_result_t
-check( config_t const * config ) {
+check( config_t const * config,
+       int              check_type FD_PARAM_UNUSED ) {
   const char * interface0 = config->development.netns.interface0;
   const char * interface1 = config->development.netns.interface1;
 


### PR DESCRIPTION
In #2437 GRO was disabled to solve an issue with AF_XDP and GRO, namely the fact that GRO was creating "superpackets" out of aggregated small UDP packets.  AF_XDP was then delivering these to the socket which was breaking QUIC.

As it turns out, we only need to disable rx-udp-gro-forwarding to fix this, not the entire generic-receive-offload feature. This PR swaps the disable logic for the more specific feature.

Wonderfully, this means we can re-enable the overarching GRO feature, which is also done in this PR. This can have a massive impact on throughput for sockets-based TCP flows, such as the HTTP snapshot download.  An increase from ~400MBps to ~900MBps was observed. :rocket: