### PR TITLE
gui: fix compute units on slot details

### DIFF
--- a/src/disco/gui/fd_gui_tile.c
+++ b/src/disco/gui/fd_gui_tile.c
@@ -334,11 +334,11 @@ after_frag( fd_gui_ctx_t *      ctx,
         slot_completed.slot              = fd_bank_slot_get( bank );
         slot_completed.completed_time    = replay->completion_time_nanos;
         slot_completed.parent_slot       = fd_bank_parent_slot_get( bank );
-        slot_completed.max_compute_units = (uint)replay->cost_tracker.block_cost_limit;
+        slot_completed.max_compute_units = fd_uint_if( replay->cost_tracker.block_cost_limit==0UL, UINT_MAX, (uint)replay->cost_tracker.block_cost_limit );
         slot_completed.transaction_fee   = fd_bank_execution_fees_get( bank );
         slot_completed.priority_fee      = fd_bank_priority_fees_get( bank );
         slot_completed.tips              = fd_bank_tips_get( bank );
-        slot_completed.compute_units     = (uint)fd_bank_total_compute_units_used_get( bank );
+        slot_completed.compute_units     = fd_uint_if( replay->cost_tracker.block_cost==0UL, UINT_MAX, (uint)replay->cost_tracker.block_cost );
         slot_completed.shred_cnt         = (uint)fd_bank_shred_cnt_get( bank );
 
         /* release shared ownership of bank and parent_bank */


### PR DESCRIPTION
fetch CUs from cost tracker so that we aren't only displaying execution cus