### PR TITLE
restore: introduce io_wd_alloc_fast

### DIFF
--- a/src/discof/restore/fd_snapin_tile_vinyl.c
+++ b/src/discof/restore/fd_snapin_tile_vinyl.c
@@ -567,7 +567,7 @@ fd_snapin_process_account_batch_vinyl( fd_snapin_tile_t *            ctx,
     uchar const *  frame  = result->account_batch.batch[ i ];
     uchar const *  pubkey = frame+0x10UL;
     fd_vinyl_key_t key[1];  fd_vinyl_key_init( key, pubkey, 32UL );
-    memo[ i ] = fd_vinyl_meta_key_hash( key, map->seed );;
+    memo[ i ] = fd_vinyl_key_memo( map->seed, key );
   }
 
   /* Prefetch slots */
@@ -633,7 +633,10 @@ fd_snapin_process_account_batch_vinyl( fd_snapin_tile_t *            ctx,
     FD_CRIT( val_sz<=FD_VINYL_VAL_MAX, "corruption detected" );
 
     ulong   pair_sz = fd_vinyl_bstream_pair_sz( val_sz );
-    uchar * pair    = bstream_alloc( io, pair_sz, FD_VINYL_IO_FLAG_BLOCKING );
+    uchar * pair    = fd_vinyl_io_wd_alloc_fast( io, pair_sz );
+    if( FD_UNLIKELY( !pair ) ) {
+      pair = fd_vinyl_io_wd_alloc( io, pair_sz, FD_VINYL_IO_FLAG_BLOCKING );
+    }
 
     uchar * dst     = pair;
     ulong   dst_rem = pair_sz;

--- a/src/discof/restore/utils/fd_vinyl_io_wd.c
+++ b/src/discof/restore/utils/fd_vinyl_io_wd.c
@@ -13,53 +13,6 @@
 
 ***********************************************************************/
 
-/* wd_buf describes an O_DIRECT append buf */
-
-struct wd_buf;
-typedef struct wd_buf wd_buf_t;
-
-struct wd_buf {
-  uchar *    buf;          /* pointer into dcache */
-  uint       state;        /* WD_BUF_* */
-  wd_buf_t * next;         /* next ele in linked list */
-  ulong      io_seq;       /* mcache request sequence number */
-  ulong      bstream_seq;  /* APPEND=bstream seq of first block */
-                           /* IOWAIT=bstream seq after buffer is fully written */
-};
-
-/* WD_BUF_* give append buf states */
-
-#define WD_BUF_IDLE   1U
-#define WD_BUF_APPEND 2U
-#define WD_BUF_IOWAIT 3U
-
-/* fd_vinyl_io_wd implements the fd_vinyl_io_t interface */
-
-struct fd_vinyl_io_wd {
-  fd_vinyl_io_t base[1];
-  ulong         dev_base;
-  ulong         dev_sz;        /* Block store byte size (BLOCK_SZ multiple) */
-
-  /* Buffer linked lists by state */
-  wd_buf_t * buf_idle;         /* free stack */
-  wd_buf_t * buf_append;       /* current wip block */
-  wd_buf_t * buf_iowait_head;  /* least recently enqueued (seq increasing) */
-  wd_buf_t * buf_iowait_tail;  /* most  recently enqueued */
-
-  /* Work queue (snapwr) */
-  fd_frag_meta_t * wr_mcache;  /* metadata ring */
-  ulong            wr_seq;     /* next metadata seq no */
-  ulong            wr_seqack;  /* next expected ACK seq */
-  ulong            wr_depth;   /* metadata ring depth */
-  uchar *          wr_base;    /* base pointer for data cache */
-  uchar *          wr_chunk0;  /* [wr_chunk0,wr_chunk1) is the data cache data region */
-  uchar *          wr_chunk1;
-  ulong const *    wr_fseq;    /* completion notifications */
-  ulong            wr_mtu;     /* max block byte size */
-};
-
-typedef struct fd_vinyl_io_wd fd_vinyl_io_wd_t;
-
 /* wd_block_used returns the number of bytes already committed in an
    APPEND buffer. */
 


### PR DESCRIPTION
fd_vinyl_io_wd_alloc is slow (causes frontend stalls and was ~8.7%
of snapin wallclock time).  Introduce an inlined tiny optimistic
fast alloc API, which practically reduces vinyl append-log alloc
time to zero while loading a snapshot.
