### PR TITLE
restore: narrow account batching to 8-wide

### DIFF
--- a/src/discof/restore/utils/fd_ssparse.h
+++ b/src/discof/restore/utils/fd_ssparse.h
@@ -59,7 +59,7 @@ typedef struct acc_vec acc_vec_t;
 
 /* FD_SSPARSE_ACC_BATCH_MAX controls the max number of accounts in a
    batch. */
-#define FD_SSPARSE_ACC_BATCH_MAX (16UL)
+#define FD_SSPARSE_ACC_BATCH_MAX (8UL)
 
 struct fd_ssparse_advance_result {
   ulong bytes_consumed;


### PR DESCRIPTION
Improves snapshot loading throughput by nearly 2x when disabling
bstream integrity hashes, on Zen 4.  It is unclear why 16-wide
batching was that slow.  Presumably due to more frequent batching
failures, bigger code footprint, and more frequent data cache
misses.
