### PR TITLE
Safe version of strncpy

### DIFF
--- a/src/util/cstr/fd_cstr.c
+++ b/src/util/cstr/fd_cstr.c
@@ -105,6 +105,24 @@ fd_cstr_nlen( char const * s,
 }
 
 char *
+fd_cstr_ncpy( char *       d,
+              char const * s,
+              ulong        m ) {
+  if( FD_LIKELY( m ) ){
+    ulong i = 0UL;
+    if( FD_LIKELY( s ) ) {
+      for( ; i<m-1UL; i++ ) {
+        char c = s[i];
+        if( !c ) break;
+        d[i] = c;
+      }
+    }
+    memset( d+i, 0, m-i );
+  }
+  return d;
+}
+
+char *
 fd_cstr_printf( char *       buf,
                 ulong        sz,
                 ulong *      opt_len,

--- a/src/util/cstr/fd_cstr.h
+++ b/src/util/cstr/fd_cstr.h
@@ -115,6 +115,23 @@ FD_FN_PURE ulong
 fd_cstr_nlen( char const * s,
               ulong        m );
 
+/* fd_cstr_ncpy is a safe version of strncpy.  d is the destination cstr
+   and s is the source cstr.  d and s should not overlap.  Assumes d has
+   space for up to m bytes.  Always returns d.  All bytes of d will be
+   initialized.  Further, if m is not zero, d will _always_ be properly
+   '\0' terminated.
+
+   Specifically, if m is 0 (i.e. d has zero bytes of storage), this
+   returns d.  Otherwise, if s is NULL, this will zero out all m bytes
+   of d and return d.  Otherwise, this will copy up to m-1 of the
+   leading non-zero bytes in s into d.  All remaining bytes of d (there
+   will be at least 1) will be initialized to zero. */
+
+char *
+fd_cstr_ncpy( char *       d,
+              char const * s,
+              ulong        m );
+
 /* cstr output ********************************************************/
 
 /* fd_cstr_printf printf a cstr into the sz byte memory region pointed

--- a/src/util/cstr/test_cstr.c
+++ b/src/util/cstr/test_cstr.c
@@ -32,6 +32,32 @@ main( int     argc,
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
+  char const * ref_empty = "";
+  char const * ref_short = "0";                ulong len_short =  1UL;
+  char const * ref_long  = "0123456789abcdef"; ulong len_long  = 16UL;
+
+  FD_TEST( fd_cstr_ncpy( NULL, NULL,      0UL )==NULL );
+  FD_TEST( fd_cstr_ncpy( NULL, ref_empty, 0UL )==NULL );
+  FD_TEST( fd_cstr_ncpy( NULL, ref_short, 0UL )==NULL );
+  FD_TEST( fd_cstr_ncpy( NULL, ref_long,  0UL )==NULL );
+
+  char dst[8];
+  for( ulong sz=0UL; sz<9UL; sz++ ) {
+
+    FD_TEST( fd_cstr_ncpy( dst, NULL, sz )==dst );
+    for( ulong i=0UL; i<sz; i++ ) FD_TEST( dst[i]=='\0' );
+
+    FD_TEST( fd_cstr_ncpy( dst, ref_empty, sz )==dst );
+    for( ulong i=0UL; i<sz; i++ ) FD_TEST( dst[i]=='\0' );
+
+    FD_TEST( fd_cstr_ncpy( dst, ref_short, sz )==dst );
+    for( ulong i=0UL; i<sz; i++ ) FD_TEST( dst[i]==((i<fd_ulong_min(sz-1UL,len_short)) ? ref_short[i] : '\0') );
+
+    FD_TEST( fd_cstr_ncpy( dst, ref_long, sz )==dst );
+    for( ulong i=0UL; i<sz; i++ ) FD_TEST( dst[i]==((i<fd_ulong_min(sz-1UL,len_long )) ? ref_long[i]  : '\0') );
+
+  }
+
   do {
     ulong len;
     len=1UL; FD_TEST( fd_cstr_printf      ( NULL,      128UL, &len, "dummy" )==NULL      && len==0UL ); /* NULL cstr */


### PR DESCRIPTION
Submitting a patch from @kbowers-jump 

----------------

By popular demand.  See header comments for details.  Probably should
replace any current usages of strncpy with fd_cstr_ncpy at some point in
the near future.

(Just checking in a couple of minor cleanups made while writing vinyl.)
