### PR TITLE
snapshot-load: accounts size histogram

### DIFF
--- a/src/app/firedancer-dev/commands/snapshot_load.c
+++ b/src/app/firedancer-dev/commands/snapshot_load.c
@@ -150,6 +150,7 @@ snapshot_load_args( int *    pargc,
                     char *** pargv,
                     args_t * args ) {
   args->snapshot_load.fsck = !!fd_env_strip_cmdline_contains( pargc, pargv, "--fsck" );
+  args->snapshot_load.accounts_hist = !!fd_env_strip_cmdline_contains( pargc, pargv, "--accounts-hist" );
   char const * snap_path = fd_env_strip_cmdline_cstr( pargc, pargv, "--snapshot-dir", NULL, NULL );
   if( snap_path ) {
     ulong snap_path_len = strlen( snap_path ); FD_TEST( snap_path_len<sizeof(args->snapshot_load.snapshot_path) );
@@ -214,6 +215,164 @@ fsck_vinyl( config_t * config ) {
   fd_io_mmio_fini( mmio, mmio_sz );
   fd_vinyl_meta_leave( meta );
   return fsck_err;
+}
+
+/* ACCOUNTS_HIST_N (32) is chosen to make the histogram lightweight.
+   And because accounts can have a data size in the range [0, 10MiB],
+   the width of the bins increments in powers of 2.  In the future, it
+   should be possible to pass this as a configuration parameter. */
+#define ACCOUNTS_HIST_N (32)
+
+struct accounts_hist {
+  ulong total_cnt;
+  ulong total_acc;
+  ulong bin_thi[ ACCOUNTS_HIST_N ];
+  ulong bin_cnt[ ACCOUNTS_HIST_N ];
+  ulong bin_acc[ ACCOUNTS_HIST_N ];
+  ulong bin_min[ ACCOUNTS_HIST_N ];
+  ulong bin_max[ ACCOUNTS_HIST_N ];
+  ulong token_cnt;
+};
+typedef struct accounts_hist accounts_hist_t;
+
+static inline void
+accounts_hist_reset( accounts_hist_t * hist ) {
+  hist->total_cnt = 0UL;
+  hist->total_acc = 0UL;
+  for( int i=0; i < ACCOUNTS_HIST_N; i++ ) {
+    hist->bin_thi[ i ] = fd_ulong_if( i > 0, fd_pow2( ulong, i-1 ), 0UL );
+    hist->bin_cnt[ i ] = 0UL;
+    hist->bin_acc[ i ] = 0UL;
+    hist->bin_min[ i ] = ULONG_MAX;
+    hist->bin_max[ i ] = 0UL;
+  }
+  hist->token_cnt = 0UL;
+}
+
+static inline void
+accounts_hist_update( accounts_hist_t * hist,
+                      ulong             account_sz ) {
+  hist->total_cnt += 1UL;
+  hist->total_acc += account_sz;
+  int i=0;
+  /* This allows for arbitrary thresholds - not optimized for pow2
+     bins. */
+  for( ; i < ACCOUNTS_HIST_N; i++ ) {
+    if( FD_UNLIKELY( account_sz <= hist->bin_thi[ i ] )) {
+      hist->bin_cnt[ i ] += 1;
+      hist->bin_acc[ i ] += account_sz;
+      hist->bin_min[ i ] = fd_ulong_min( hist->bin_min[ i ], account_sz );
+      hist->bin_max[ i ] = fd_ulong_max( hist->bin_max[ i ], account_sz );
+      break;
+    }
+  }
+  FD_TEST( i < ACCOUNTS_HIST_N );
+}
+
+static inline int
+accounts_hist_check( accounts_hist_t const * hist ) {
+  ulong cnt = 0UL;
+  ulong acc = 0UL;
+  for( int i=0; i < ACCOUNTS_HIST_N; i++ ) {
+    cnt += hist->bin_cnt[ i ];
+    acc += hist->bin_acc[ i ];
+  }
+  if( cnt != hist->total_cnt ) return -1;
+  if( acc != hist->total_acc ) return -2;
+  return 0;
+}
+
+static void
+accounts_hist_print( accounts_hist_t const * hist,
+                     char const            * description ) {
+  double hist_total_cnt_M   = (double)hist->total_cnt / (double)1.0e6;
+  double hist_total_cnt_GiB = (double)hist->total_acc / (double)1073741824;
+  printf( "\n" );
+  printf( "Accounts sizes histogram %s\n", description );
+  printf( "hist_total_cnt %16lu ( %6.1f M   )\n", hist->total_cnt, hist_total_cnt_M   );
+  printf( "hist_total_acc %16lu ( %6.1f GiB )\n", hist->total_acc, hist_total_cnt_GiB );
+  printf( "   bin_th_lo <  sz <=    bin_th_hi |    bin_cnt (run_sum%%) |      bin_acc (run_sum%%) |    bin_min B |    bin_max B |    bin_avg B |\n" );
+  ulong sum_cnt = 0UL;
+  ulong sum_acc = 0UL;
+  for( int i=0; i < ACCOUNTS_HIST_N; i++ ) {
+    /* bin thresholds */
+    ulong hist_bin_tlo      = hist->bin_thi[ fd_int_if( i>0, i-1, i ) ];
+    ulong hist_bin_thi      = hist->bin_thi[ i ];
+    /* bin cnt */
+    ulong hist_bin_cnt      = hist->bin_cnt[ i ];
+    sum_cnt                += hist->bin_cnt[ i ];
+    double sum_cnt_p        = (double)(sum_cnt * 100) / (double)hist->total_cnt;
+    double hist_bin_cnt_K   = (double)(hist_bin_cnt) / (double)1.0e3;
+    /* bin acc */
+    ulong hist_bin_acc      = hist->bin_acc[ i ];
+    sum_acc                += hist->bin_acc[ i ];
+    double sum_acc_p        = (double)(sum_acc * 100) / (double)hist->total_acc;
+    double hist_bin_acc_MiB = (double)(hist_bin_acc) / (double)1048576.0f;
+    /* bin min, max, avg */
+    ulong hist_bin_min      = fd_ulong_if( hist->bin_cnt[ i ] > 0, hist->bin_min[ i ], 0UL );
+    ulong hist_bin_max      = hist->bin_max[ i ];
+    ulong hist_bin_avg      = fd_ulong_if( hist->bin_cnt[ i ] > 0, hist->bin_acc[ i ] / hist->bin_cnt[ i ], 0UL );
+    /* log */
+    char buf[256];
+    char * p = fd_cstr_init( buf );
+    p = fd_cstr_append_printf( p, "%12lu %s sz <= %12lu |", hist_bin_tlo, i==0? "<=" : "< ", hist_bin_thi );
+    p = fd_cstr_append_printf( p, " %8.1f K (%6.1f %%) |", hist_bin_cnt_K, sum_cnt_p );
+    p = fd_cstr_append_printf( p, " %8.1f MiB (%6.1f %%) |", hist_bin_acc_MiB, sum_acc_p );
+    p = fd_cstr_append_printf( p, " %12lu | %12lu | %12lu |", hist_bin_min, hist_bin_max, hist_bin_avg );
+    p = fd_cstr_append_printf( p, "\n" );
+    printf( "%s", buf );
+  }
+  printf( "\n" );
+}
+
+static void
+accounts_hist_vinyl( accounts_hist_t * hist,
+                     config_t *        config ) {
+  fd_topo_t * topo = &config->topo;
+  ulong meta_map_id  = fd_pod_query_ulong( topo->props, "vinyl.meta_map",  ULONG_MAX );
+  ulong meta_pool_id = fd_pod_query_ulong( topo->props, "vinyl.meta_pool", ULONG_MAX );
+  FD_TEST( meta_map_id!=ULONG_MAX && meta_pool_id!=ULONG_MAX );
+  void * shmap = fd_topo_obj_laddr( topo, meta_map_id  );
+  void * shele = fd_topo_obj_laddr( topo, meta_pool_id );
+  fd_vinyl_meta_t meta[1];
+  FD_TEST( fd_vinyl_meta_join( meta, shmap, shele ) );
+
+  for( ulong ele_i=0; ele_i < fd_vinyl_meta_ele_max( meta ); ele_i++ ) {
+    fd_vinyl_meta_ele_t const * ele = meta->ele + ele_i;
+    if( FD_UNLIKELY( fd_vinyl_meta_private_ele_is_free( meta->ctx, ele ) ) ) continue;
+    accounts_hist_update( hist, (ulong)ele->phdr.info._val_sz );
+  }
+}
+
+static void
+accounts_hist_funk( accounts_hist_t * hist,
+                    config_t *        config ) {
+  fd_topo_t * topo = &config->topo;
+  ulong funk_obj_id = fd_pod_query_ulong( topo->props, "funk", ULONG_MAX );
+  FD_TEST( funk_obj_id!=ULONG_MAX );
+  void * funk_shmem = fd_topo_obj_laddr( topo, funk_obj_id );
+  fd_funk_t funk[1];
+  FD_TEST( fd_funk_join( funk, funk_shmem ) );
+
+  fd_funk_rec_map_t const * rec_map = funk->rec_map;
+  fd_funk_rec_t const * ele = rec_map->ele;
+  fd_funk_rec_map_shmem_private_chain_t const * chain = fd_funk_rec_map_shmem_private_chain_const( rec_map->map, 0UL );
+  ulong chain_cnt = fd_funk_rec_map_chain_cnt( rec_map );
+  for( ulong chain_i=0UL; chain_i < chain_cnt; chain_i++ ) {
+    ulong ver_cnt = chain[ chain_i ].ver_cnt;
+    ulong ele_cnt = fd_funk_rec_map_private_vcnt_cnt( ver_cnt );
+    ulong head_i  = fd_funk_rec_map_private_idx( chain[ chain_i ].head_cidx );
+    ulong ele_i   = head_i;
+    for( ulong ele_rem=ele_cnt; ele_rem; ele_rem-- ) {
+      fd_funk_xid_key_pair_t const * pair = &ele[ ele_i ].pair;
+      fd_funk_rec_query_t query[1];
+      fd_funk_rec_t * rec = fd_funk_rec_query_try( funk, pair->xid, pair->key, query );
+      FD_TEST( !!rec );
+      fd_account_meta_t * meta = fd_funk_val( rec, funk->wksp );
+      FD_TEST( !!meta );
+      accounts_hist_update( hist, sizeof(fd_account_meta_t) + meta->dlen );
+    }
+  }
 }
 
 static void
@@ -381,6 +540,16 @@ snapshot_load_cmd_fn( args_t *   args,
     } else {
       FD_LOG_ERR(( "FSCK: errors detected" ));
     }
+  }
+
+  if( args->snapshot_load.accounts_hist ) {
+    accounts_hist_t hist[1];
+    accounts_hist_reset( hist );
+    FD_LOG_NOTICE(( "Accounts histogram: starting" ));
+    if( snapwr_tile ) accounts_hist_vinyl( hist, config );
+    else              accounts_hist_funk ( hist, config );
+    FD_TEST( !accounts_hist_check( hist ) );
+    accounts_hist_print( hist, args->snapshot_load.snapshot_path );
   }
 }
 

--- a/src/app/shared/fd_action.h
+++ b/src/app/shared/fd_action.h
@@ -117,6 +117,7 @@ union fdctl_args {
 
   struct {
     uint fsck;
+    uint accounts_hist;
     char snapshot_path[ PATH_MAX ];
   } snapshot_load;
 


### PR DESCRIPTION
snapshot-load now creates (optionally, passing `--accounts-hist`) the account sizes histogram.