### PR TITLE
restore: fix funk record linked list corruption

### DIFF
--- a/src/discof/restore/fd_snapin_tile_funk.c
+++ b/src/discof/restore/fd_snapin_tile_funk.c
@@ -168,6 +168,8 @@ fd_snapin_process_account_batch_funk( fd_snapin_tile_t *            ctx,
       memset( r, 0, sizeof(fd_funk_rec_t) );
       fd_funk_txn_xid_copy( r->pair.xid, ctx->xid );
       fd_funk_rec_key_copy( r->pair.key, &key );
+      r->prev_idx = UINT_MAX;
+      r->next_idx = UINT_MAX;
 
       /* Insert to hash map.  In theory, a key could appear twice in the
          same batch.  All accounts in a batch are guaranteed to be from


### PR DESCRIPTION
Fixes a bug found by snapshot-load --fsck
