### PR TITLE
Fix typos in comment

### DIFF
--- a/src/vinyl/line/fd_vinyl_line.h
+++ b/src/vinyl/line/fd_vinyl_line.h
@@ -2,7 +2,7 @@
 #define HEADER_fd_src_vinyl_line_fd_vinyl_line_h
 
 /* A vinyl tile caches key-val pairs in DRAM for performance reasons
-   and to faciliate operations like creating a new pair or asynchronous
+   and to facilitate operations like creating a new pair or asynchronous
    I/O.  This cache can be _completely_ lost without impacting the
    recoverabilty exactly key-val state at the time the bstream was most
    recently sync'd.
@@ -30,7 +30,7 @@
 #include "../meta/fd_vinyl_meta.h"
 #include "../data/fd_vinyl_data.h"
 
-/* FD_VINYL_LINE_EVICT_PRIO_* specify eviction priorties.  These should
+/* FD_VINYL_LINE_EVICT_PRIO_* specify eviction priorities.  These should
    be compatible with fd_vinyl_req_evict_prio and FD_VINYL_REQ_FLAG_* */
 
 #define FD_VINYL_LINE_EVICT_PRIO_MRU (0) /* <0 also treated as MRU */
@@ -124,7 +124,7 @@ fd_vinyl_line_evict_prio( uint *            _line_idx_lru, /* Pointer to the LRU
 
 /* fd_vinyl_line_evict_lru finds the least recently used evictable line
    and evicts it.  Returns the line_idx of that line (will be free to
-   use).  Cannot fail from the caller's perspecitve (will FD_LOG_CRIT if
+   use).  Cannot fail from the caller's perspective (will FD_LOG_CRIT if
    corruption was detected or quotas were misconfigured). */
 
 ulong

--- a/src/vinyl/meta/fd_vinyl_meta.h
+++ b/src/vinyl/meta/fd_vinyl_meta.h
@@ -25,7 +25,7 @@
    used persistent.  But, as it can be exactly reconstructed during
    recovery from the bstream's past and there are no provisions for
    "syncing" the meta cache with the bstream in the face of unexpected
-   processs interruptions, persistence should only be used for post
+   process interruptions, persistence should only be used for post
    mortem debugging. */
 
 #include "../bstream/fd_vinyl_bstream.h"
@@ -174,7 +174,7 @@ fd_vinyl_meta_query_fast( fd_vinyl_meta_ele_t const * ele0,       /* indexed [0,
                           ulong *                     _ele_idx ); /* will be in [0,ele_max) on return */
 
 /* fd_vinyl_meta_remove_fast removes the key<>metadata mapping at meta
-   element ele_idx from the meta under the asumption the caller is the
+   element ele_idx from the meta under the assumption the caller is the
    only active writer to the meta and there are no meta prepares in
    progress.  This cannot fail from the caller's perspective
    (FD_LOG_CRIT if meta or line is corruption detected during removal). */

--- a/src/vinyl/rq/fd_vinyl_rq.h
+++ b/src/vinyl/rq/fd_vinyl_rq.h
@@ -25,7 +25,7 @@
    complete as they happen.  Specifically, except for "move", individual
    items in a batch complete atomically in whatever order they were
    processed.  (During the move of an individual item for the current
-   implementation, there is a brief momment where a concurrent meta
+   implementation, there is a brief moment where a concurrent meta
    reader could observe both key_src and key_dst as not present.)
    Similarly clients doing speculative processing will see individual
    batch items complete atomically (including move) in whatever order

--- a/src/waltz/grpc/fd_grpc_client.h
+++ b/src/waltz/grpc/fd_grpc_client.h
@@ -24,7 +24,7 @@ typedef struct fd_grpc_h2_stream fd_grpc_h2_stream_t;
 
 /* FD_GRPC_DEADLINE_* identify different types of request deadlines. */
 
-#define FD_GRPC_DEADLINE_HEADER 1 /* deadline by which Response-Headers are recevied */
+#define FD_GRPC_DEADLINE_HEADER 1 /* deadline by which Response-Headers are received */
 #define FD_GRPC_DEADLINE_RX_END 2 /* deadline by which 'end of stream' must have been reached */
 
 /* fd_grpc_client_metrics_t hold counters that are incremented by a


### PR DESCRIPTION
Corrected misspellings:
- faciliate -> facilitate (`src/vinyl/line/fd_vinyl_line.h`)
- priorites -> priorities (`src/vinyl/line/fd_vinyl_line.h`)
- processs -> process (`src/vinyl/meta/fd_vinyl_meta.h`)
- assumtion -> assumption (`src/vinyl/meta/fd_vinyl_meta.h`)
- momment -> moment (`src/vinyl/rq/fd_vinyl_rq.h`)
- recieved -> received (`src/waltz/grpc/fd_grpc_client.h`)