### PR TITLE
backtest: disable RPC server in ledger backtest script

### DIFF
--- a/contrib/offline-replay/offline_replay.toml
+++ b/contrib/offline-replay/offline_replay.toml
@@ -10,6 +10,8 @@
         cluster_version = "{cluster_version}"
     [tiles.gui]
         enabled = false
+    [tiles.rpc]
+        enabled = false
 [funk]
     heap_size_gib = {funk_pages}
     max_account_records = {index_max}

--- a/src/flamenco/runtime/tests/run_ledger_backtest.sh
+++ b/src/flamenco/runtime/tests/run_ledger_backtest.sh
@@ -235,6 +235,8 @@ echo "
         enable_features = [ $FORMATTED_ONE_OFFS ]
     [tiles.gui]
         enabled = false
+    [tiles.rpc]
+        enabled = false
 [store]
     max_completed_shred_sets = 32768
 [funk]


### PR DESCRIPTION
This is not needed for backtest