### PR TITLE
deps.sh: add a space for msan flags

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -665,7 +665,7 @@ while [[ $# -gt 0 ]]; do
       PREFIX="$(pwd)/opt-msan"
       _CC=clang
       _CXX=clang++
-      EXTRA_CFLAGS+="-fsanitize=memory"
+      EXTRA_CFLAGS+=" -fsanitize=memory"
       EXTRA_CXXFLAGS+="$EXTRA_CFLAGS -nostdinc++ -nostdlib++ -isystem $PREFIX/include/c++/v1"
       EXTRA_LDFLAGS+="$PREFIX/lib/libc++.a $PREFIX/lib/libc++abi.a"
       ;;


### PR DESCRIPTION
Needs a space when doing `./deps.sh +msan` otherwise we get:

<img width="2286" height="1314" alt="image" src="https://github.com/user-attachments/assets/1e379208-f9c0-4c8c-b615-6f4470b11587" />
