### PR TITLE
deps.sh: also make EXTRA_{CXXFLAGS|LDFLAGS} robust

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -666,8 +666,8 @@ while [[ $# -gt 0 ]]; do
       _CC=clang
       _CXX=clang++
       EXTRA_CFLAGS+=" -fsanitize=memory"
-      EXTRA_CXXFLAGS+="$EXTRA_CFLAGS -nostdinc++ -nostdlib++ -isystem $PREFIX/include/c++/v1"
-      EXTRA_LDFLAGS+="$PREFIX/lib/libc++.a $PREFIX/lib/libc++abi.a"
+      EXTRA_CXXFLAGS+=" $EXTRA_CFLAGS -nostdinc++ -nostdlib++ -isystem $PREFIX/include/c++/v1"
+      EXTRA_LDFLAGS+=" $PREFIX/lib/libc++.a $PREFIX/lib/libc++abi.a"
       ;;
     "+dev")
       shift


### PR DESCRIPTION
Similar to https://github.com/firedancer-io/firedancer/pull/7156 but also fixes EXTRA_{CXXFLAGS|LDFLAGS}
So future code isn't affected once someone starts to use those. (Currently only EXTRA_FLAGS is used: https://github.com/firedancer-io/firedancer/blob/554a075c72deebfc83f8507089100fe0d0d57588/deps.sh#L40-L42)