### PR TITLE
netlink: Support ifindex > 255

### DIFF
--- a/src/disco/net/xdp/fd_xdp_tile.c
+++ b/src/disco/net/xdp/fd_xdp_tile.c
@@ -385,9 +385,7 @@ interface specified by if_idx. Null if the if_idx is invalid */
 static fd_netdev_t *
 net_query_netdev_tbl( fd_net_ctx_t * ctx,
                       uint           if_idx ) {
-  /* dev_tbl is one-indexed */
-  if( if_idx>ctx->netdev_tbl.hdr->dev_cnt ) return NULL;
-  return &ctx->netdev_tbl.dev_tbl[ if_idx ];
+  return fd_netdev_tbl_query( &ctx->netdev_tbl, if_idx );
 }
 
 /* Iterates the netdev table and returns 1 if a GRE interface exists, 0 otherwise.
@@ -1374,7 +1372,7 @@ init_device_table( fd_net_ctx_t * ctx,
   ctx->netdev_buf_sz  = fd_netdev_tbl_footprint( NETDEV_MAX, BOND_MASTER_MAX );
 
   /* Create temporary empty device table during startup */
-  FD_TEST( fd_netdev_tbl_join( &ctx->netdev_tbl, fd_netdev_tbl_new( ctx->netdev_buf, 1, 1 ) ) );
+  FD_TEST( fd_netdev_tbl_join( &ctx->netdev_tbl, fd_netdev_tbl_new( ctx->netdev_buf, NETDEV_MAX, BOND_MASTER_MAX ) ) );
 
 }
 

--- a/src/disco/net/xdp/test_xdp_tile.c
+++ b/src/disco/net/xdp/test_xdp_tile.c
@@ -138,37 +138,50 @@ setup_routing_table( fd_net_ctx_t * ctx,
 }
 
 static void
+append_netdev( fd_net_ctx_t * ctx,
+               fd_netdev_t     netdev ) {
+  ushort idx = ctx->netdev_tbl.hdr->dev_cnt;
+  FD_TEST( idx < ctx->netdev_tbl.hdr->dev_max );
+  ctx->netdev_tbl.dev_tbl[ idx ] = netdev;
+  ctx->netdev_tbl.hdr->dev_cnt   = (ushort)(idx + (ushort)1);
+}
+
+static void
 setup_netdev_table( fd_net_ctx_t * ctx ) {
-  /* GRE interfaces */
-  ctx->netdev_tbl.dev_tbl[IF_IDX_GRE0] = (fd_netdev_t) {
+  ctx->netdev_tbl.hdr->dev_cnt = 0;
+
+  append_netdev( ctx, (fd_netdev_t) {
     .if_idx = IF_IDX_GRE0,
     .dev_type = ARPHRD_IPGRE,
     .gre_dst_ip = gre0_outer_dst_ip,
     .gre_src_ip = gre0_outer_src_ip
-  };
-  ctx->netdev_tbl.dev_tbl[IF_IDX_GRE1] = (fd_netdev_t) {
+  } );
+
+  append_netdev( ctx, (fd_netdev_t) {
     .if_idx = IF_IDX_GRE1,
     .dev_type = ARPHRD_IPGRE,
     .gre_dst_ip = gre1_outer_dst_ip,
-  };
+  } );
   /* Eth0 interface */
-  ctx->netdev_tbl.dev_tbl[IF_IDX_ETH0] = (fd_netdev_t) {
+  append_netdev( ctx, (fd_netdev_t) {
     .if_idx = IF_IDX_ETH0,
     .dev_type = ARPHRD_ETHER,
-  };
+  } );
   /* Eth1 interface */
-  ctx->netdev_tbl.dev_tbl[IF_IDX_ETH1] = (fd_netdev_t) {
+  append_netdev( ctx, (fd_netdev_t) {
     .if_idx = IF_IDX_ETH1,
     .dev_type = ARPHRD_ETHER,
-  };
+  } );
   /* Lo interface */
-  ctx->netdev_tbl.dev_tbl[IF_IDX_LO] = (fd_netdev_t) {
+  append_netdev( ctx, (fd_netdev_t) {
     .if_idx = IF_IDX_LO,
     .dev_type = ARPHRD_LOOPBACK,
-  };
-  fd_memcpy( (fd_netdev_t *)ctx->netdev_tbl.dev_tbl[IF_IDX_ETH0].mac_addr, eth0_src_mac_addr, 6 );
-  fd_memcpy( (fd_netdev_t *)ctx->netdev_tbl.dev_tbl[IF_IDX_ETH1].mac_addr, eth1_src_mac_addr, 6 );
-  ctx->netdev_tbl.hdr->dev_cnt = IF_IDX_GRE1 + 1;
+  } );
+  fd_netdev_t * eth0 = fd_netdev_tbl_query( &ctx->netdev_tbl, IF_IDX_ETH0 );
+  fd_netdev_t * eth1 = fd_netdev_tbl_query( &ctx->netdev_tbl, IF_IDX_ETH1 );
+  FD_TEST( eth0 && eth1 );
+  fd_memcpy( eth0->mac_addr, eth0_src_mac_addr, 6 );
+  fd_memcpy( eth1->mac_addr, eth1_src_mac_addr, 6 );
 }
 
 

--- a/src/disco/net/xdp/test_xdp_tile1.c
+++ b/src/disco/net/xdp/test_xdp_tile1.c
@@ -215,37 +215,50 @@ setup_neighbor_table( fd_net_ctx_t * ctx ) {
 }
 
 static void
+append_netdev( fd_net_ctx_t * ctx,
+               fd_netdev_t     netdev ) {
+  ushort idx = ctx->netdev_tbl.hdr->dev_cnt;
+  FD_TEST( idx < ctx->netdev_tbl.hdr->dev_max );
+  ctx->netdev_tbl.dev_tbl[ idx ] = netdev;
+  ctx->netdev_tbl.hdr->dev_cnt   = (ushort)(idx + (ushort)1);
+}
+
+static void
 setup_netdev_table( fd_net_ctx_t * ctx ) {
-  /* GRE interfaces */
-  ctx->netdev_tbl.dev_tbl[IF_IDX_GRE0] = (fd_netdev_t) {
+  ctx->netdev_tbl.hdr->dev_cnt = 0;
+
+  append_netdev( ctx, (fd_netdev_t) {
     .if_idx = IF_IDX_GRE0,
     .dev_type = ARPHRD_IPGRE,
     .gre_dst_ip = gre0_outer_dst_ip,
     .gre_src_ip = gre0_outer_src_ip
-  };
-  ctx->netdev_tbl.dev_tbl[IF_IDX_GRE1] = (fd_netdev_t) {
+  } );
+
+  append_netdev( ctx, (fd_netdev_t) {
     .if_idx = IF_IDX_GRE1,
     .dev_type = ARPHRD_IPGRE,
     .gre_dst_ip = gre1_outer_dst_ip,
-  };
+  } );
   /* Eth0 interface */
-  ctx->netdev_tbl.dev_tbl[IF_IDX_ETH0] = (fd_netdev_t) {
+  append_netdev( ctx, (fd_netdev_t) {
     .if_idx = IF_IDX_ETH0,
     .dev_type = ARPHRD_ETHER,
-  };
+  } );
   /* Eth1 interface */
-  ctx->netdev_tbl.dev_tbl[IF_IDX_ETH1] = (fd_netdev_t) {
+  append_netdev( ctx, (fd_netdev_t) {
     .if_idx = IF_IDX_ETH1,
     .dev_type = ARPHRD_ETHER,
-  };
+  } );
   /* Lo interface */
-  ctx->netdev_tbl.dev_tbl[IF_IDX_LO] = (fd_netdev_t) {
+  append_netdev( ctx, (fd_netdev_t) {
     .if_idx = IF_IDX_LO,
     .dev_type = ARPHRD_LOOPBACK,
-  };
-  fd_memcpy( (fd_netdev_t *)ctx->netdev_tbl.dev_tbl[IF_IDX_ETH0].mac_addr, eth0_src_mac_addr, 6 );
-  fd_memcpy( (fd_netdev_t *)ctx->netdev_tbl.dev_tbl[IF_IDX_ETH1].mac_addr, eth1_src_mac_addr, 6 );
-  ctx->netdev_tbl.hdr->dev_cnt = IF_IDX_GRE1 + 1;
+  } );
+  fd_netdev_t * eth0 = fd_netdev_tbl_query( &ctx->netdev_tbl, IF_IDX_ETH0 );
+  fd_netdev_t * eth1 = fd_netdev_tbl_query( &ctx->netdev_tbl, IF_IDX_ETH1 );
+  FD_TEST( eth0 && eth1 );
+  fd_memcpy( eth0->mac_addr, eth0_src_mac_addr, 6 );
+  fd_memcpy( eth1->mac_addr, eth1_src_mac_addr, 6 );
 }
 
 /************************* Test Init Auxiliary Function ***********************/

--- a/src/waltz/mib/fd_netdev_tbl.c
+++ b/src/waltz/mib/fd_netdev_tbl.c
@@ -133,6 +133,16 @@ fd_netdev_tbl_reset( fd_netdev_tbl_join_t * tbl ) {
   fd_memset( tbl->bond_tbl, 0, sizeof(fd_netdev_bond_t) * tbl->hdr->bond_max );
 }
 
+fd_netdev_t *
+fd_netdev_tbl_query( fd_netdev_tbl_join_t * tbl,
+                     uint                  if_idx ) {
+  fd_netdev_t * dev     = tbl->dev_tbl;
+  for( ushort j=0U; j<tbl->hdr->dev_cnt; j++, dev++ ) {
+    if( dev->if_idx==if_idx ) return dev;
+  }
+  return NULL;
+}
+
 #if FD_HAS_HOSTED
 
 #include <errno.h>

--- a/src/waltz/mib/fd_netdev_tbl.h
+++ b/src/waltz/mib/fd_netdev_tbl.h
@@ -23,9 +23,9 @@
 struct fd_netdev {
   ushort mtu;            /* Largest layer-3 payload that fits in a packet */
   uchar  mac_addr[6];    /* MAC address */
-  ushort if_idx;         /* Interface index */
+  uint   if_idx;         /* Interface index */
   short  slave_tbl_idx;  /* index to bond slave table, -1 if not a bond master */
-  short  master_idx;     /* index of bond master, -1 if not a bond slave */
+  int    master_idx;     /* index of bond master, -1 if not a bond slave */
   char   name[16];       /* cstr interface name (max 15 length) */
   uchar  oper_status;    /* one of FD_OPER_STATUS_{...} */
   ushort dev_type;       /* one of ARPHRD_ETHER/_LOOPBACK_/IPGRE*/
@@ -127,6 +127,10 @@ fd_netdev_tbl_delete( void * shtbl );
 
 void
 fd_netdev_tbl_reset( fd_netdev_tbl_join_t * tbl );
+
+FD_FN_PURE fd_netdev_t *
+fd_netdev_tbl_query( fd_netdev_tbl_join_t * tbl,
+                     uint                  if_idx );
 
 #if FD_HAS_HOSTED
 


### PR DESCRIPTION
Fixes https://github.com/firedancer-io/firedancer/issues/6821

Summary:
  - store netlink-discovered interfaces in a dense array keyed by fd_netdev_tbl_query, so high Linux ifindexes no longer exceed NETDEV_MAX
  - Update fd_netdev_tbl to use Linux native bit sizes if_idx/master_idx
  - update the netlink loader, XDP tile, and tests to use the new helpers instead of indexing by if_idx