### PR TITLE
util: inhibit unsafe FD_CRIT optimization

### DIFF
--- a/src/util/log/fd_log.h
+++ b/src/util/log/fd_log.h
@@ -294,8 +294,8 @@
 #define FD_CRIT( c,m) do { if( FD_UNLIKELY( !(c) ) ) FD_LOG_CRIT (( "FAIL: %s (%s)", #c, (m) )); } while(0)
 #define FD_ALERT(c,m) do { if( FD_UNLIKELY( !(c) ) ) FD_LOG_ALERT(( "FAIL: %s (%s)", #c, (m) )); } while(0)
 #else
-#define FD_CRIT( c,m) do { if( FD_UNLIKELY( !(c) ) ) __builtin_unreachable(); } while(0)
-#define FD_ALERT(c,m) do {                                                    } while(0)
+#define FD_CRIT( c,m) do { (void)(c); } while(0)
+#define FD_ALERT(c,m) do {            } while(0)
 #endif
 
 /* Macros for doing hexedit / tcpdump-like logging of memory regions.


### PR DESCRIPTION
The use of __builtin_unreachable in FD_CRIT (FD_PARANOID==0) acts
like a compiler optimizer hint that assertion failures are never
possible.

This results in much more aggressive/unsafe code optimizations
than if the debug assertion was omitted.  Therefore the use of
__builtin_unreachable be removed for security.
