### PR TITLE
progcache: fix dedup logic

### DIFF
--- a/src/flamenco/progcache/test_progcache.c
+++ b/src/flamenco/progcache/test_progcache.c
@@ -518,6 +518,7 @@ test_invalidate_dup( fd_wksp_t * wksp ) {
   FD_TEST( !rec2->executable );
   FD_TEST( fd_progcache_peek( env->progcache, &fork_b, &key, 0UL )==rec2 );
   FD_TEST( fd_progcache_peek( env->progcache, &fork_a, &key, 0UL )==rec );
+  FD_TEST( fd_progcache_invalidate( env->progcache, &fork_b, &key, fork_b.ul[0] )==rec2 );
 
   /* Create cache invalidation entry */
   fd_funk_txn_xid_t fork_c = { .ul = { 3UL, 2UL } };


### PR DESCRIPTION
Fixes a bug where the progcache user APIs did not cooperatively dedup insertions of the same records.

Closes #7185