### PR TITLE
restore: fix snapshot-load with vinyl

### DIFF
--- a/src/app/shared/fd_action.h
+++ b/src/app/shared/fd_action.h
@@ -118,6 +118,7 @@ union fdctl_args {
 
   struct {
     uint fsck : 1;
+    uint fsck_lthash : 1;
     uint lthash : 1;
     uint accounts_hist : 1;
     uint offline : 1;


### PR DESCRIPTION
- Increase snapin_manif link depth to 4 to work around stem
  flow control limitations
- Add snapshot-load --lthash flag to test new streaming lthash
  verify feature

Closes #7193