### PR TITLE
flamenco: nonce program use previous blockhash entry lamports-per-sig instead of current

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -755,7 +755,7 @@ publish_slot_completed( fd_replay_tile_t *  ctx,
   }
 
   fd_hash_t const * bank_hash  = fd_bank_bank_hash_query( bank );
-  fd_hash_t const * block_hash = fd_blockhashes_peek_last( fd_bank_block_hash_queue_query( bank ) );
+  fd_hash_t const * block_hash = fd_blockhashes_peek_last_hash( fd_bank_block_hash_queue_query( bank ) );
   FD_TEST( bank_hash  );
   FD_TEST( block_hash );
 
@@ -1379,7 +1379,7 @@ publish_reset( fd_replay_tile_t *  ctx,
                fd_bank_t *         bank ) {
   if( FD_UNLIKELY( ctx->replay_out->idx==ULONG_MAX ) ) return;
 
-  fd_hash_t const * block_hash = fd_blockhashes_peek_last( fd_bank_block_hash_queue_query( bank ) );
+  fd_hash_t const * block_hash = fd_blockhashes_peek_last_hash( fd_bank_block_hash_queue_query( bank ) );
   FD_TEST( block_hash );
 
   fd_poh_reset_t * reset = fd_chunk_to_laddr( ctx->replay_out->mem, ctx->replay_out->chunk );
@@ -1439,7 +1439,7 @@ boot_genesis( fd_replay_tile_t *  ctx,
   static const fd_txncache_fork_id_t txncache_root = { .val = USHORT_MAX };
   bank->txncache_fork_id = fd_txncache_attach_child( ctx->txncache, txncache_root );
 
-  fd_hash_t const * block_hash = fd_blockhashes_peek_last( fd_bank_block_hash_queue_query( bank ) );
+  fd_hash_t const * block_hash = fd_blockhashes_peek_last_hash( fd_bank_block_hash_queue_query( bank ) );
   fd_txncache_finalize_fork( ctx->txncache, bank->txncache_fork_id, 0UL, block_hash->uc );
 
   publish_stake_weights( ctx, stem, bank, 0 );
@@ -2180,7 +2180,7 @@ process_tower_slot_done( fd_replay_tile_t *           ctx,
     fd_memcpy( reset->completed_block_id, &block_id_ele->block_id, sizeof(fd_hash_t) );
 
     fd_blockhashes_t const * block_hash_queue = fd_bank_block_hash_queue_query( bank );
-    fd_hash_t const * last_hash = fd_blockhashes_peek_last( block_hash_queue );
+    fd_hash_t const * last_hash = fd_blockhashes_peek_last_hash( block_hash_queue );
     FD_TEST( last_hash );
     fd_memcpy( reset->completed_blockhash, last_hash->uc, sizeof(fd_hash_t) );
 

--- a/src/discof/restore/utils/fd_ssload.c
+++ b/src/discof/restore/utils/fd_ssload.c
@@ -126,7 +126,7 @@ fd_ssload_recover( fd_snapshot_manifest_t *  manifest,
 
   /* PoH */
   fd_blockhashes_t const * bhq = fd_bank_block_hash_queue_query( bank );
-  fd_hash_t const * last_hash = fd_blockhashes_peek_last( bhq );
+  fd_hash_t const * last_hash = fd_blockhashes_peek_last_hash( bhq );
   if( FD_LIKELY( last_hash ) ) fd_bank_poh_set( bank, *last_hash );
 
   fd_bank_capitalization_set( bank, manifest->capitalization );

--- a/src/flamenco/runtime/fd_blockhashes.h
+++ b/src/flamenco/runtime/fd_blockhashes.h
@@ -106,9 +106,16 @@ fd_blockhashes_check_age( fd_blockhashes_t const * blockhashes,
                           ulong                    max_age );
 
 FD_FN_PURE static inline fd_hash_t const *
-fd_blockhashes_peek_last( fd_blockhashes_t const * blockhashes ) {
+fd_blockhashes_peek_last_hash( fd_blockhashes_t const * blockhashes ) {
   if( FD_UNLIKELY( fd_blockhash_deq_empty( blockhashes->d.deque ) ) ) return 0;
   return &fd_blockhash_deq_peek_tail_const( blockhashes->d.deque )->hash;
+}
+
+
+FD_FN_PURE static inline fd_blockhash_info_t const *
+fd_blockhashes_peek_last( fd_blockhashes_t const * blockhashes ) {
+  if( FD_UNLIKELY( fd_blockhash_deq_empty( blockhashes->d.deque ) ) ) return 0;
+  return fd_blockhash_deq_peek_tail_const( blockhashes->d.deque );
 }
 
 FD_PROTOTYPES_END

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -1332,7 +1332,7 @@ fd_runtime_process_new_epoch( fd_banks_t *              banks,
   /* Distribute rewards.  This involves calculating the rewards for
      every vote and stake account. */
 
-  fd_hash_t const * parent_blockhash = fd_blockhashes_peek_last( fd_bank_block_hash_queue_query( bank ) );
+  fd_hash_t const * parent_blockhash = fd_blockhashes_peek_last_hash( fd_bank_block_hash_queue_query( bank ) );
   fd_begin_partitioned_rewards( bank,
                                 accdb,
                                 xid,


### PR DESCRIPTION
- Rename existing `fd_blockhashes_peek_last` to `fd_blockhashes_peek_last_hash` to reflect that we only return the hash portion of the blockhash_info_t
- New `fd_blockhashes_peek_last` to return full blockhash_info_t of most recent blockhash 
- Use most recent inserted blockhash to intiailize nonce account instead of current derived blockhash lps