### PR TITLE
ethtool: support multiple XDP tiles with rss_queue_mode=dedicated

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -1005,9 +1005,10 @@ dynamic_port_range = "8900-9000"
         #   traffic.
         #
         # "dedicated"
-        #   Reserves a dedicated hardware queue for each net tile.  For
-        #   now, only supports net_tile_count = 1.  Uses ethtool 'ntuple'
-        #   to route interesting packets based on UDP dst port.  This mode
+        #   Reserves a dedicated hardware queue for each net tile.  Uses
+        #   ethtool 'ntuple' rules to route incoming packets based on
+        #   UDP dst port.  Packets are load balanced across the dedicated
+        #   queues based on lowest bits of source address.  This mode
         #   may not work with some network device setups.
         #
         # "auto"

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -683,11 +683,7 @@ user = ""
     #
     # See the comments for the [tiles.net] section below for more
     # information.
-    #
-    # TODO: This should defaulted to 2 for Firedancer, but cannot be for
-    # now because changing it to 2 switches the networking rx_queue_mode
-    # to "simple" which decreases snapshot performance materially.
-    net_tile_count = 1
+    net_tile_count = 2
 
     # How many QUIC tiles to run.  Should be set to 1.  This is
     # configurable and designed to scale out for future network
@@ -1001,9 +997,10 @@ user = ""
         #   traffic.
         #
         # "dedicated"
-        #   Reserves a dedicated hardware queue for each net tile.  For
-        #   now, only supports net_tile_count = 1.  Uses ethtool 'ntuple'
-        #   to route interesting packets based on UDP dst port.  This mode
+        #   Reserves a dedicated hardware queue for each net tile.  Uses
+        #   ethtool 'ntuple' rules to route incoming packets based on
+        #   UDP dst port.  Packets are load balanced across the dedicated
+        #   queues based on lowest bits of source address.  This mode
         #   may not work with some network device setups.
         #
         # "auto" (default)

--- a/src/app/shared/commands/configure/fd_ethtool_ioctl.h
+++ b/src/app/shared/commands/configure/fd_ethtool_ioctl.h
@@ -172,28 +172,40 @@ fd_ethtool_ioctl_ntuple_clear( fd_ethtool_ioctl_t * ioc );
 /* fd_ethtool_ioctl_ntuple_set_udp_dport installs a flow steering rule
    at the given rule_idx to route all UDP/IPv4 packets with the given
    destination port to the given queue_idx.  Note that if a rule already
-   exists at rule_idx, it will be overwritten.  Returns nonzero on failure. */
+   exists at rule_idx, it will be overwritten.
+
+   In order to facilitate load balancing flows across multiple queues,
+   a nonzero rule_group_idx can be given.  rule_group_cnt must be a
+   nonzero power of 2.  This forms a mask of the lowest N bits of the
+   IPv4 source address and masked addresses matching rule_group_idx
+   are steered to the given queue_idx.  For example, we can create a
+   group of rules for queue 0 where the lowest bit of the address is 0
+   and a second set of rules for queue 1 where the lowest bit is 1.
+
+   Returns nonzero on failure. */
 
 int
 fd_ethtool_ioctl_ntuple_set_udp_dport( fd_ethtool_ioctl_t * ioc,
                                        uint                 rule_idx,
                                        ushort               dport,
+                                       uint                 rule_group_idx,
+                                       uint                 rule_group_cnt,
                                        uint                 queue_idx );
 
 /* fd_ethtool_ioctl_ntuple_validate_udp_dport queries all ntuple
    rules and then sets valid to 1 if they match the expected set of
-   rules for the given UDP destination ports.  In other words,
-   this makes sure the existing rules are correct and that no other
-   rules are active.  If num_dports is zero, then this effectively
-   checks whether any rules exist.  dports is left in an
-   indeterminate state after this function returns.  Returns
+   rules for the given UDP destination ports and the given number of
+   queues (each queue should have a group of rules, one for each port
+   in dports).  In other words, this makes sure the existing rules are
+   correct and that no other rules are active.  If dports_cnt is zero,
+   then this effectively checks whether any rules exist.  Returns
    nonzero on failure (uncertain if valid or not). */
 
 int
 fd_ethtool_ioctl_ntuple_validate_udp_dport( fd_ethtool_ioctl_t * ioc,
-                                            ushort *             dports,
-                                            uint                 num_dports,
-                                            uint                 queue_idx,
+                                            ushort const *       dports,
+                                            uint                 dports_cnt,
+                                            uint                 queue_cnt,
                                             int *                valid );
 
 

--- a/src/app/shared/fd_config.c
+++ b/src/app/shared/fd_config.c
@@ -537,11 +537,9 @@ fd_config_validate( fd_config_t const * config ) {
     CFG_HAS_NON_EMPTY( net.xdp.xdp_mode );
     CFG_HAS_POW2     ( net.xdp.xdp_rx_queue_size );
     CFG_HAS_POW2     ( net.xdp.xdp_tx_queue_size );
-    if( 0==strcmp( config->net.xdp.rss_queue_mode, "dedicated" ) ) {
-      if( FD_UNLIKELY( config->layout.net_tile_count != 1 ) )
-        FD_LOG_ERR(( "`layout.net_tile_count` must be 1 when `net.xdp.rss_queue_mode` is \"dedicated\"" ));
-    } else if( 0!=strcmp( config->net.xdp.rss_queue_mode, "simple" ) &&
-               0!=strcmp( config->net.xdp.rss_queue_mode, "auto" ) ) {
+    if( 0!=strcmp( config->net.xdp.rss_queue_mode, "dedicated" ) &&
+        0!=strcmp( config->net.xdp.rss_queue_mode, "simple" ) &&
+        0!=strcmp( config->net.xdp.rss_queue_mode, "auto" ) ) {
       FD_LOG_ERR(( "invalid `net.xdp.rss_queue_mode`: \"%s\"; must be \"simple\", \"dedicated\", or \"auto\"",
                    config->net.xdp.rss_queue_mode  ));
     }

--- a/src/disco/net/xdp/test_xdp_tile1.c
+++ b/src/disco/net/xdp/test_xdp_tile1.c
@@ -766,6 +766,8 @@ int main( int     argc,
   /* [tile-unit-test] unprivileged_init and priviledged_init. */
   mock_privileged_init( &config->topo, test_tile );
   unprivileged_init(    &config->topo, test_tile );
+  ctx->net_tile_id  = 0U;
+  ctx->net_tile_cnt = 1U;
 
   /* Ensure initial device table is valid */
   FD_TEST( net_check_gre_interface_exists( ctx )==0 );


### PR DESCRIPTION
Also:
- Dedup ntuple ports and ignore zero
- Fini device before simple fallback after failed dedicated init
- Fix some minor init failures on various devices