### PR TITLE
config: fix flatcc linking

### DIFF
--- a/config/extra/with-flatcc.mk
+++ b/config/extra/with-flatcc.mk
@@ -1,5 +1,5 @@
-ifneq (,$(wildcard $(OPT)/lib/libflatcc.a))
-FLATCC_LIBS:=$(OPT)/lib/libflatcc.a $(OPT)/lib/libflatccrt.a
+ifneq (,$(wildcard $(OPT)/lib/libflatccrt.a))
+FLATCC_LIBS:=$(OPT)/lib/libflatccrt.a
 else
 $(info "flatcc not installed, skipping")
 endif


### PR DESCRIPTION
Docs say "Make sure to link with libflatccrt (rt for runtime) and
not libflatcc (the schema compiler)"
