### PR TITLE
gui: overview tile stats

### DIFF
--- a/src/disco/gui/fd_gui.h
+++ b/src/disco/gui/fd_gui.h
@@ -233,16 +233,12 @@ struct fd_gui_validator_info {
 #define FD_GUI_SLOT_RANKING_TYPE_DESC (1)
 
 struct fd_gui_tile_timers {
-  ulong caughtup_housekeeping_ticks;
-  ulong processing_housekeeping_ticks;
-  ulong backpressure_housekeeping_ticks;
-
-  ulong caughtup_prefrag_ticks;
-  ulong processing_prefrag_ticks;
-  ulong backpressure_prefrag_ticks;
-
-  ulong caughtup_postfrag_ticks;
-  ulong processing_postfrag_ticks;
+  ulong timers[ FD_METRICS_ENUM_TILE_REGIME_CNT ];
+  int   in_backp;
+  ulong heartbeat;
+  ulong backp_cnt;
+  ulong nvcsw;
+  ulong nivcsw;
 };
 
 typedef struct fd_gui_tile_timers fd_gui_tile_timers_t;

--- a/src/disco/gui/fd_gui_printf.h
+++ b/src/disco/gui/fd_gui_printf.h
@@ -134,6 +134,9 @@ fd_gui_printf_live_network_metrics( fd_gui_t *                     gui,
                                     fd_gui_network_stats_t const * cur );
 
 void
+fd_gui_printf_live_tile_metrics( fd_gui_t * gui );
+
+void
 fd_gui_printf_live_txn_waterfall( fd_gui_t *                     gui,
                                   fd_gui_txn_waterfall_t const * prev,
                                   fd_gui_txn_waterfall_t const * cur,


### PR DESCRIPTION
With websocket compression enabled, this message is about 0.5Mbps per client, which is about 5x more than the current tile timers.