### PR TITLE
Make flatcc dep optional

### DIFF
--- a/config/extra/with-flatcc.mk
+++ b/config/extra/with-flatcc.mk
@@ -1,5 +1,7 @@
 ifneq (,$(wildcard $(OPT)/lib/libflatccrt.a))
 FLATCC_LIBS:=$(OPT)/lib/libflatccrt.a
+FD_HAS_FLATCC:=1
+CPPFLAGS+=-DFD_HAS_FLATCC=1
 else
 $(info "flatcc not installed, skipping")
 endif

--- a/src/flamenco/runtime/Local.mk
+++ b/src/flamenco/runtime/Local.mk
@@ -43,9 +43,6 @@ $(call add-objs,fd_compute_budget_details,fd_flamenco)
 $(call add-hdrs,fd_borrowed_account.h)
 $(call add-objs,fd_borrowed_account,fd_flamenco)
 
-$(call add-hdrs, tests/fd_dump_pb.h)
-$(call add-objs, tests/fd_dump_pb,fd_flamenco)
-
 $(call add-hdrs,fd_txn_account.h)
 $(call add-objs,fd_txn_account,fd_flamenco)
 ifdef FD_HAS_INT128

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -598,12 +598,14 @@ fd_runtime_pre_execute_check( fd_exec_txn_ctx_t * txn_ctx ) {
 
   */
 
+# if FD_HAS_FLATCC
   uchar dump_txn = !!( txn_ctx->log.capture_ctx &&
                        fd_bank_slot_get( txn_ctx->bank ) >= txn_ctx->log.capture_ctx->dump_proto_start_slot &&
                        txn_ctx->log.capture_ctx->dump_txn_to_pb );
   if( FD_UNLIKELY( dump_txn ) ) {
     fd_dump_txn_to_protobuf( txn_ctx );
   }
+# endif
 
   /* Verify the transaction. For now, this step only involves processing
      the compute budget instructions. */

--- a/src/flamenco/runtime/tests/Local.mk
+++ b/src/flamenco/runtime/tests/Local.mk
@@ -1,7 +1,11 @@
 ifdef FD_HAS_SECP256K1
 
+ifdef FD_HAS_FLATCC
 $(call add-hdrs,fd_solfuzz.h)
 $(call add-objs,fd_solfuzz fd_solfuzz_exec,fd_flamenco_test)
+
+$(call add-hdrs,fd_dump_pb.h)
+$(call add-objs,fd_dump_pb,fd_flamenco)
 
 $(call add-hdrs,fd_instr_harness.h fd_txn_harness.h)
 $(call add-objs,fd_elf_harness fd_instr_harness fd_txn_harness fd_block_harness fd_harness_common fd_vm_harness,fd_flamenco_test)
@@ -18,6 +22,7 @@ $(call make-shared,libfd_exec_sol_compat.so,fd_sol_compat,fd_flamenco_test fd_fl
 $(call make-unit-test,test_sol_compat_so,test_sol_compat_so,fd_util)
 
 $(call make-unit-test,test_dump_block,test_dump_block,fd_flamenco_test fd_flamenco fd_funk fd_ballet fd_util fd_disco,$(SECP256K1_LIBS) $(FLATCC_LIBS))
+endif
 
 run-runtime-backtest: $(OBJDIR)/bin/fd_ledger $(OBJDIR)/bin/firedancer-dev
 	OBJDIR=$(OBJDIR) src/flamenco/runtime/tests/run_backtest_ci.sh $(BACKTEST_ARGS)

--- a/src/flamenco/runtime/tests/fd_dump_pb.h
+++ b/src/flamenco/runtime/tests/fd_dump_pb.h
@@ -1,6 +1,8 @@
 #ifndef HEADER_fd_src_flamenco_runtime_tests_fd_dump_pb_h
 #define HEADER_fd_src_flamenco_runtime_tests_fd_dump_pb_h
 
+#if FD_HAS_FLATCC
+
 /* fd_dump_pb.h provides APIs for dumping syscalls, instructions, transactions, and blocks
    into a digestable and replayable Protobuf message. This is useful for debugging
    ledger test mismatches, collecting seed corpora, and gathering real data to test
@@ -208,5 +210,7 @@ fd_dump_elf_to_protobuf( fd_exec_txn_ctx_t * txn_ctx,
                          fd_txn_account_t *  program_acc );
 
 FD_PROTOTYPES_END
+
+#endif /* FD_HAS_FLATCC */
 
 #endif /* HEADER_fd_src_flamenco_runtime_tests_fd_dump_pb_h */

--- a/src/flamenco/vm/fd_vm_interp_core.c
+++ b/src/flamenco/vm/fd_vm_interp_core.c
@@ -142,16 +142,23 @@
    Exit
    At this point, cu is positive and err is clear.
 */
+
+# if FD_HAS_FLATCC
+# define FD_VM_INTERP_SYSCALL_EXEC_DUMP                                       \
+  /* Dumping for debugging purposes */                                        \
+  if( FD_UNLIKELY( vm->dump_syscall_to_pb ) ) {                               \
+    fd_dump_vm_syscall_to_protobuf( vm, syscall->name );                      \
+  }
+# else
+# define FD_VM_INTERP_SYSCALL_EXEC_DUMP
+# endif
 # define FD_VM_INTERP_SYSCALL_EXEC                                            \
   /* Setup */                                                                 \
   vm->pc        = pc;                                                         \
   vm->ic        = ic;                                                         \
   vm->cu        = cu;                                                         \
   vm->frame_cnt = frame_cnt;                                                  \
-  /* Dumping for debugging purposes */                                        \
-  if( FD_UNLIKELY( vm->dump_syscall_to_pb ) ) {                               \
-    fd_dump_vm_syscall_to_protobuf( vm, syscall->name );                      \
-  }                                                                           \
+  FD_VM_INTERP_SYSCALL_EXEC_DUMP                                              \
   /* Execution */                                                             \
   ulong ret[1];                                                               \
   err = syscall->func( vm, reg[1], reg[2], reg[3], reg[4], reg[5], ret );     \


### PR DESCRIPTION
flatcc is a dev dependency by nature.  Allow building full
Firedancer without it.
