### PR TITLE
codeql: ignore magic numbers in metrics query

### DIFF
--- a/contrib/codeql/nightly/MetricsEnumAccess.ql
+++ b/contrib/codeql/nightly/MetricsEnumAccess.ql
@@ -218,15 +218,15 @@ predicate isArrayAccessOob(ArrayExpr access) {
 
 /**
  * Holds if the index used in `a` (which is either an IDX macro or a value bounded by a CNT macro)
- * does not match any metric array definition's associated enum name (if any).
+ * does not match any metric array definition's associated enum name.
  * E.g., if `a` uses `FD_METRICS_ENUM_FOO_IDX`, but the array size is defined using
- * the literal `9` (instead of `FD_METRICS_ENUM_FOO_CNT`), then this predicate holds.
+ * `FD_METRICS_ENUM_BLABLA_CNT`), then this predicate holds.
  */
 predicate isMismatchedEnumName(MetricsEnumAccess a) {
   exists(int dimension | dimension = getDimension(a) |
-    not exists(MetricsArray e |
+    exists(MetricsArray e |
       e.getAUsage(dimension) = a and
-      e.getMacro(dimension).getAnEnumName() = a.getMacro().getAnEnumName()
+      e.getMacro(dimension).getAnEnumName() != a.getMacro().getAnEnumName()
     )
   )
 }
@@ -247,5 +247,5 @@ where
   or
   isMismatchedEnumName(access) and
   des =
-    "The enum name in the IDX macro does not match the one associated with the CNT macro (if any) in the array definition."
+    "The enum name in the IDX macro does not match the one associated with the CNT macro in the array definition."
 select access, des

--- a/contrib/codeql/test/query-tests/MetricsEnumAccess/MetricsEnumAccess.expected
+++ b/contrib/codeql/test/query-tests/MetricsEnumAccess/MetricsEnumAccess.expected
@@ -1,9 +1,7 @@
 | MetricsEnumAccess.c:94:5:94:17 | access to array | The IDX value (3) is greater than the arrays size (3). |
 | MetricsEnumAccess.c:101:9:101:33 | access to array | The CNT value (3) associated with the IDX macro and the array size (4) do not match and could result in under/over reads/writes. |
-| MetricsEnumAccess.c:101:9:101:33 | access to array | The enum name in the IDX macro does not match the one associated with the CNT macro (if any) in the array definition. |
 | MetricsEnumAccess.c:107:5:107:61 | access to array | The CNT value (5) associated with the IDX macro and the array size (3) do not match and could result in under/over reads/writes. |
-| MetricsEnumAccess.c:107:5:107:61 | access to array | The enum name in the IDX macro does not match the one associated with the CNT macro (if any) in the array definition. |
+| MetricsEnumAccess.c:107:5:107:61 | access to array | The enum name in the IDX macro does not match the one associated with the CNT macro in the array definition. |
 | MetricsEnumAccess.c:114:5:114:51 | access to array | The CNT value (3) associated with the IDX macro and the array size (4) do not match and could result in under/over reads/writes. |
-| MetricsEnumAccess.c:114:5:114:51 | access to array | The enum name in the IDX macro does not match the one associated with the CNT macro (if any) in the array definition. |
+| MetricsEnumAccess.c:114:5:114:51 | access to array | The enum name in the IDX macro does not match the one associated with the CNT macro in the array definition. |
 | MetricsEnumAccess.c:124:49:124:59 | access to array | The CNT value ((4UL)) associated with the IDX macro and the array size (2) do not match and could result in under/over reads/writes. |
-| MetricsEnumAccess.c:124:49:124:59 | access to array | The enum name in the IDX macro does not match the one associated with the CNT macro (if any) in the array definition. |


### PR DESCRIPTION
Reduces the amount of alerts that clutter the security overview. If/after https://github.com/firedancer-io/firedancer/pull/6543 is merged, one could consider reverting this commit.