### PR TITLE
codeql: add filter for non-binary is function

### DIFF
--- a/contrib/codeql/nightly/NonBinaryIsFunction.ql
+++ b/contrib/codeql/nightly/NonBinaryIsFunction.ql
@@ -12,6 +12,7 @@
 
 import cpp
 import semmle.code.cpp.rangeanalysis.new.SimpleRangeAnalysis
+import filter
 
 /**
  * A function whose name suggests it returns a boolean value (0 or 1).
@@ -33,7 +34,8 @@ where
   (
     lowerBound < 0 or
     upperBound > 1
-  )
+  ) and
+  included(rs.getLocation())
 select rs,
   "The function $@ is named like an `is` function but returns a value with bounds [" + lowerBound +
     ", " + upperBound + "].", f, f.getName()


### PR DESCRIPTION
Filters out all the results from agave's dependencies we don't care about.

When initially testing this query, the downloaded database from GitHub didn't include the `agave/` directory so I didn't notice that we need filtering.