### PR TITLE
SIMD-0359: Poseidon Syscall - Enforce Input Length

### DIFF
--- a/src/ballet/bn254/fd_poseidon.c
+++ b/src/ballet/bn254/fd_poseidon.c
@@ -91,11 +91,15 @@ fd_poseidon_init( fd_poseidon_t * pos,
 fd_poseidon_t *
 fd_poseidon_append( fd_poseidon_t * pos,
                     uchar const *   data,
-                    ulong           sz ) {
+                    ulong           sz,
+                    int             enforce_padding ) {
   if( FD_UNLIKELY( pos==NULL ) ) {
     return NULL;
   }
   if( FD_UNLIKELY( pos->cnt >= FD_POSEIDON_MAX_WIDTH ) ) {
+    return NULL;
+  }
+  if( FD_UNLIKELY( enforce_padding && sz!=32UL ) ) {
     return NULL;
   }
   /* Empty input and non-field are errors. Short element is extended with 0s. */

--- a/src/ballet/bn254/fd_poseidon.h
+++ b/src/ballet/bn254/fd_poseidon.h
@@ -73,7 +73,8 @@ fd_poseidon_init( fd_poseidon_t * pos,
 fd_poseidon_t *
 fd_poseidon_append( fd_poseidon_t * pos,
                     uchar const *   data,
-                    ulong           sz );
+                    ulong           sz,
+                    int             enforce_padding );
 
 /* fd_poseidon_fini finishes a Poseidon calculation.
    out is assumed to be valid (i.e. is a current local join to a Poseidon
@@ -99,7 +100,7 @@ fd_poseidon_hash( fd_poseidon_hash_result_t * result,
   fd_poseidon_t pos[1];
   fd_poseidon_init( pos, big_endian );
   for( ulong i=0; i<bytes_len/32; i++ ) {
-    fd_poseidon_append( pos, &bytes[i*32], 32 );
+    fd_poseidon_append( pos, &bytes[i*32], 32, 1 );
   }
   return !fd_poseidon_fini( pos, fd_type_pun(result) );
 }

--- a/src/flamenco/features/fd_features_generated.c
+++ b/src/flamenco/features/fd_features_generated.c
@@ -1686,6 +1686,12 @@ fd_feature_id_t const ids[] = {
     .name                      = "fix_alt_bn128_pairing_length_check",
     .cleaned_up                = {UINT_MAX, UINT_MAX, UINT_MAX} },
 
+  { .index                     = offsetof(fd_features_t, poseidon_enforce_padding)>>3,
+    .id                        = {"\x0c\x3e\xd9\x52\x45\xee\x7b\x8c\x8a\xaf\x88\xa2\x5e\x37\x29\x76\x1d\xa5\xfb\xfa\x47\x48\xfd\xd4\x5a\xff\x2b\xb8\xfa\xd3\x1c\x98"},
+                                 /* poUdAqRXXsNmfqAZ6UqpjbeYgwBygbfQLEvWSqVhSnb */
+    .name                      = "poseidon_enforce_padding",
+    .cleaned_up                = {UINT_MAX, UINT_MAX, UINT_MAX} },
+
   { .index = ULONG_MAX }
 };
 /* TODO replace this with fd_map_perfect */
@@ -1938,6 +1944,7 @@ fd_feature_id_query( ulong prefix ) {
   case 0x5004d84d60aadc0c: return &ids[ 243 ];
   case 0x520c5e674243fab5: return &ids[ 244 ];
   case 0xf08a42c3c040e908: return &ids[ 245 ];
+  case 0x8c7bee4552d93e0c: return &ids[ 246 ];
   default: break;
   }
   return NULL;
@@ -2189,4 +2196,5 @@ FD_STATIC_ASSERT( offsetof( fd_features_t, raise_account_cu_limit               
 FD_STATIC_ASSERT( offsetof( fd_features_t, stricter_abi_and_runtime_constraints                    )>>3==243UL, layout );
 FD_STATIC_ASSERT( offsetof( fd_features_t, account_data_direct_mapping                             )>>3==244UL, layout );
 FD_STATIC_ASSERT( offsetof( fd_features_t, fix_alt_bn128_pairing_length_check                      )>>3==245UL, layout );
+FD_STATIC_ASSERT( offsetof( fd_features_t, poseidon_enforce_padding                                )>>3==246UL, layout );
 FD_STATIC_ASSERT( sizeof( fd_features_t )>>3==FD_FEATURE_ID_CNT, layout );

--- a/src/flamenco/features/fd_features_generated.h
+++ b/src/flamenco/features/fd_features_generated.h
@@ -8,10 +8,10 @@
 #endif
 
 /* FEATURE_ID_CNT is the number of features in ids */
-#define FD_FEATURE_ID_CNT (246UL)
+#define FD_FEATURE_ID_CNT (247UL)
 
 /* Feature set ID calculated from all feature names */
-#define FD_FEATURE_SET_ID (2363000211U)
+#define FD_FEATURE_SET_ID (2146234083U)
 
 union fd_features {
   ulong f[ FD_FEATURE_ID_CNT ];
@@ -262,5 +262,6 @@ union fd_features {
     /* 0x5004d84d60aadc0c */ ulong stricter_abi_and_runtime_constraints;
     /* 0x520c5e674243fab5 */ ulong account_data_direct_mapping;
     /* 0xf08a42c3c040e908 */ ulong fix_alt_bn128_pairing_length_check;
+    /* 0x8c7bee4552d93e0c */ ulong poseidon_enforce_padding;
   };
 };

--- a/src/flamenco/features/feature_map.json
+++ b/src/flamenco/features/feature_map.json
@@ -244,5 +244,6 @@
   {"name":"raise_account_cu_limit","pubkey":"htsptAwi2yRoZH83SKaUXykeZGtZHgxkS2QwW1pssR8"},
   {"name":"stricter_abi_and_runtime_constraints","pubkey":"sD3uVpaavUXQRvDXrMFCQ2CqLqnbz5mK8ttWNXbtD3r","old":"CxeBn9PVeeXbmjbNwLv6U4C6svNxnC4JX6mfkvgeMocM"},
   {"name":"account_data_direct_mapping","pubkey":"DFN8MyKpQqFW31qczcahgnnxcAHQc6P94wtTEX5EP1RA","old":"9s3RKimHWS44rJcJ9P1rwCmn2TvMqtZQBmz815ZUUHqJ"},
-  {"name":"fix_alt_bn128_pairing_length_check","pubkey":"bnYzodLwmybj7e1HAe98yZrdJTd7we69eMMLgCXqKZm"}
+  {"name":"fix_alt_bn128_pairing_length_check","pubkey":"bnYzodLwmybj7e1HAe98yZrdJTd7we69eMMLgCXqKZm"},
+  {"name":"poseidon_enforce_padding","pubkey":"poUdAqRXXsNmfqAZ6UqpjbeYgwBygbfQLEvWSqVhSnb"}
 ]

--- a/src/flamenco/vm/syscall/fd_vm_syscall_crypto.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_crypto.c
@@ -317,11 +317,12 @@ fd_vm_syscall_sol_poseidon( void *  _vm,
 
   /* Second loop to computed Poseidon. This can return a soft error. */
   int big_endian = endianness==0;
+  int enforce_padding = FD_FEATURE_ACTIVE_BANK( vm->instr_ctx->txn_ctx->bank, poseidon_enforce_padding );
   fd_poseidon_t pos[1];
   fd_poseidon_init( pos, big_endian );
 
   for( ulong i=0UL; i<vals_len; i++ ) {
-    if( FD_UNLIKELY( fd_poseidon_append( pos, inputs_haddr[ i ], input_vec_haddr[i].len )==NULL ) ) {
+    if( FD_UNLIKELY( fd_poseidon_append( pos, inputs_haddr[ i ], input_vec_haddr[i].len, enforce_padding )==NULL ) ) {
       goto soft_error;
     }
   }


### PR DESCRIPTION
tldr: if enforce_padding==1, we should enforce that sz==32 (before we had sz<=32).

I left 1 test with enforce_padding==0, all other tests already are with enforce_padding==1 (easier to remove the feature gate later).

Context
- SIMD: https://github.com/solana-foundation/solana-improvement-documents/pull/367
- Agave impl: https://github.com/anza-xyz/agave/pull/8534/files
- Lib impl: https://github.com/Lightprotocol/light-poseidon/pull/50/files