### PR TITLE
config: use default XDP mode

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -953,9 +953,8 @@ dynamic_port_range = "8900-9000"
         #   Full list of network drivers supporting XDP:
         #   https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md#xdp
         #
-        # "generic"
-        #   Selects "skb" or "drv" automatically.  It is not recommended
-        #   to use this mode in production.
+        # "default"
+        #   Selects "skb" or "drv" automatically.
         #
         # If the kernel/hardware does not support driver mode, then
         # `fdctl run` will fail to start up with "operation not

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -948,14 +948,13 @@ user = ""
         #   Full list of network drivers supporting XDP:
         #   https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md#xdp
         #
-        # "generic"
-        #   Selects "skb" or "drv" automatically.  It is not recommended
-        #   to use this mode in production.
+        # "default"
+        #   Selects "skb" or "drv" automatically.
         #
         # If the kernel/hardware does not support driver mode, then
         # `firedancer run` will fail to start up with "operation not
         # supported".
-        xdp_mode = "skb"
+        xdp_mode = "default"
 
         # This option helps reduce CPU usage when receiving packets.
         # If enabled, the net tile instructs the network device to copy

--- a/src/waltz/xdp/fd_xdp1.c
+++ b/src/waltz/xdp/fd_xdp1.c
@@ -253,7 +253,7 @@ fd_xdp_install( uint           if_idx,
   if(      !strcmp( xdp_mode, "skb"     ) ) uxdp_mode = XDP_FLAGS_SKB_MODE;
   else if( !strcmp( xdp_mode, "drv"     ) ) uxdp_mode = XDP_FLAGS_DRV_MODE;
   else if( !strcmp( xdp_mode, "hw"      ) ) uxdp_mode = XDP_FLAGS_HW_MODE;
-  else if( !strcmp( xdp_mode, "generic" ) ) uxdp_mode = 0U;
+  else if( !strcmp( xdp_mode, "default" ) ) uxdp_mode = 0U;
   else FD_LOG_ERR(( "unknown XDP mode `%s`", xdp_mode ));
 
   uint true_port_cnt = 0U;


### PR DESCRIPTION
Allow the kernel to select driver XDP when available instead of
always using SKB mode.
