### PR TITLE
config: revert default XDP mode to skb

### DIFF
--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -954,7 +954,7 @@ user = ""
         # If the kernel/hardware does not support driver mode, then
         # `firedancer run` will fail to start up with "operation not
         # supported".
-        xdp_mode = "default"
+        xdp_mode = "skb"
 
         # This option helps reduce CPU usage when receiving packets.
         # If enabled, the net tile instructs the network device to copy


### PR DESCRIPTION
Reverts a short-lived experiment to use DRV as the default XDP
mode.  Driver XDP mode has crashed 3 hosts about 12 times today,
so it is not yet ready to be a default.
