### PR TITLE
sbpf: fix calldest map for SHT_NOBITS .text

### DIFF
--- a/src/ballet/sbpf/fd_sbpf_loader.h
+++ b/src/ballet/sbpf/fd_sbpf_loader.h
@@ -165,9 +165,10 @@ typedef struct fd_sbpf_syscalls fd_sbpf_syscalls_t;
 struct fd_sbpf_elf_info {
   ulong bin_sz;   /* size of ELF binary */
 
-  uint  text_off; /* File offset of .text section (overlaps rodata segment) */
-  uint  text_cnt; /* Instruction count */
-  ulong text_sz;  /* size of text segment. Guaranteed to be <= bin_sz. */
+  ulong calldests_max;  /* Size of calldests set */
+  uint  text_off;       /* File offset of .text section (overlaps rodata segment) */
+  uint  text_cnt;       /* Instruction count */
+  ulong text_sz;        /* size of text segment. Guaranteed to be <= bin_sz. */
 
   /* Known section indices
      In [-1,USHORT_MAX) where -1 means "not found" */


### PR DESCRIPTION
Fixes a mismatch in the ELF loader for SHT_NOBITS .text sections.
If SHT_NOBITS is set and sh_size is not zero, then the instruction
count is zero, but the call destination map is scaled by sh_size.

Therefore, the size of the calldest map and text_cnt need to be
decoupled.

Note that this would not cause a bank hash mismatch, since zero
instruction ELF programs are guaranteed to fail verification (due
to entrypoint being out of bounds).

Found by solfuzz repo 9bede7116179ceb81bacac9a55e27042fc8c98f8423edae4dbac95838c952c62
