### PR TITLE
gui: move index bounds check outside the conditional compilation flag

### DIFF
--- a/src/disco/gui/fd_gui_peers.c
+++ b/src/disco/gui/fd_gui_peers.c
@@ -476,8 +476,8 @@ fd_gui_peers_handle_gossip_update( fd_gui_peers_ctx_t *               peers,
 
           FD_LOG_ERR(( "invariant violation: update->contact_info.contact_info->pubkey.uc=%s != update->origin_pubkey=%s ", ci_pk, og_pk ));
         }
-        if( FD_UNLIKELY( update->contact_info.idx>=FD_CONTACT_INFO_TABLE_SIZE ) ) FD_LOG_ERR(( "unexpected contact_info_idx %lu >= %lu", update->contact_info.idx, FD_CONTACT_INFO_TABLE_SIZE ));
 #endif
+        if( FD_UNLIKELY( update->contact_info.idx>=FD_CONTACT_INFO_TABLE_SIZE ) ) FD_LOG_ERR(( "unexpected contact_info_idx %lu >= %lu", update->contact_info.idx, FD_CONTACT_INFO_TABLE_SIZE ));
         fd_gui_peers_node_t * peer = &peers->contact_info_table[ update->contact_info.idx ];
         if( FD_LIKELY( peer->valid ) ) {
 #if LOGGING


### PR DESCRIPTION
Given that this index is used to get the address of `peer` from `peers->contact_info_table`, it could have been used for out-of-bounds writes [here](https://github.com/firedancer-io/firedancer/blob/b45d6d52fce0f6ccd4412c5dbffd67ad03196538/src/disco/gui/fd_gui_peers.c#L526) or [here](https://github.com/firedancer-io/firedancer/blob/b45d6d52fce0f6ccd4412c5dbffd67ad03196538/src/disco/gui/fd_gui_peers.c#L550)