### PR TITLE
gui: fix default slot_voted for unmodified vote accounts

### DIFF
--- a/book/api/websocket.md
+++ b/book/api/websocket.md
@@ -257,8 +257,10 @@ or more slots behind that fork.
 
 A number showing the distance between the highest slot the validator has
 landed a vote for, and the current highest replayed slot on the
-validators fork choice. A distance of more than 150 means the validator
-is considered delinquent.
+validators fork choice. This value excludes skipped slots, unless the
+distance is larger than 2 epochs worth of slots (NOTE: skipped slots are
+not excluded on Frankendancer). A distance of more than 150 means the
+validator is considered delinquent.
 
 #### `summary.turbine_slot`
 | frequency       | type           | example |

--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -2630,9 +2630,11 @@ try_publish_vote_status( fd_gui_t * gui, ulong _slot ) {
   if( FD_UNLIKELY( !slot || slot->vote_slot==ULONG_MAX || slot->reset_slot==ULONG_MAX ) ) return;
 
   ulong vote_distance = slot->reset_slot-slot->vote_slot;
-  for( ulong s=slot->vote_slot; s<slot->reset_slot; s++ ) {
-    fd_gui_slot_t * cur = fd_gui_get_slot( gui, s );
-    if( FD_UNLIKELY( cur && cur->skipped ) ) vote_distance--;
+  if( FD_LIKELY( vote_distance<FD_GUI_SLOTS_CNT ) ) {
+    for( ulong s=slot->vote_slot; s<slot->reset_slot; s++ ) {
+      fd_gui_slot_t * cur = fd_gui_get_slot( gui, s );
+      if( FD_UNLIKELY( cur && cur->skipped ) ) vote_distance--;
+    }
   }
 
   if( FD_UNLIKELY( gui->summary.vote_distance!=vote_distance ) ) {

--- a/src/disco/gui/fd_gui_peers.c
+++ b/src/disco/gui/fd_gui_peers.c
@@ -694,7 +694,7 @@ fd_gui_peers_handle_vote_update( fd_gui_peers_ctx_t *  peers,
        bank, even if that slot didn't have landed votes for some of
        those accounts. */
     if( FD_UNLIKELY( !memcmp( &votes_sorted[ i ].node_account, identity->uc, sizeof(fd_pubkey_t) ) && peers->slot_voted!=votes_sorted[ i ].last_vote_slot ) ) {
-      peers->slot_voted = votes_sorted[ i ].last_vote_slot;
+      peers->slot_voted = fd_ulong_if( votes_sorted[ i ].last_vote_slot==0UL, ULONG_MAX, votes_sorted[ i ].last_vote_slot );
       fd_gui_peers_printf_vote_slot( peers );
       fd_http_server_ws_broadcast( peers->http );
     }


### PR DESCRIPTION
Initalized-but-never-updated vote accounts use a last_vote_slot of `0`, but the gui uses `ULONG_MAX` for this. Fixes bug that causes unstaked nodes to get stuck in a loop.