### PR TITLE
rocksdb: remove entry_end_indexes

### DIFF
--- a/src/flamenco/runtime/tests/run_backtest_all.sh
+++ b/src/flamenco/runtime/tests/run_backtest_all.sh
@@ -77,7 +77,7 @@ src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-378683870-v2.3.0 -y 
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-380592002-v2.3.0 -y 3 -m 2000000 -e 380592006
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-336218682-v2.3.0 -y 5 -m 2000000 -e 336218683
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-340269866-v2.3.0 -y 5 -m 2000000 -e 340269872
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-340272018-v2.3.0 -y 5 -m 2000000 -e 340272024 -c 2.3.0
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-340272018-v2.3.0 -y 5 -m 2000000 -e 340272023
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-390056400-v2.3.0 -y 10 -m 2000000 -e 390056406
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-346556000 -y 3 -m 2000000 -e 346556337
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-346179946 -y 30 -m 90000000 -e 346179950

--- a/src/flamenco/types/fd_fuzz_types.h
+++ b/src/flamenco/types/fd_fuzz_types.h
@@ -817,14 +817,6 @@ void *fd_slot_meta_generate( void *mem, void **alloc_mem, fd_rng_t * rng ) {
     self->next_slot = NULL;
   }
   self->is_connected = fd_rng_uchar( rng );
-  self->entry_end_indexes_len = fd_rng_ulong( rng ) % 8;
-  if( self->entry_end_indexes_len ) {
-    self->entry_end_indexes = (uint *) *alloc_mem;
-    *alloc_mem = (uchar *) *alloc_mem + sizeof(uint)*self->entry_end_indexes_len;
-    LLVMFuzzerMutate( (uchar *) self->entry_end_indexes, sizeof(uint)*self->entry_end_indexes_len, sizeof(uint)*self->entry_end_indexes_len );
-  } else {
-    self->entry_end_indexes = NULL;
-  }
   return mem;
 }
 

--- a/src/flamenco/types/fd_types.h
+++ b/src/flamenco/types/fd_types.h
@@ -823,8 +823,6 @@ struct fd_slot_meta {
   ulong next_slot_len;
   ulong* next_slot;
   uchar is_connected;
-  ulong entry_end_indexes_len;
-  uint* entry_end_indexes;
 };
 typedef struct fd_slot_meta fd_slot_meta_t;
 #define FD_SLOT_META_ALIGN alignof(fd_slot_meta_t)

--- a/src/flamenco/types/fd_types.json
+++ b/src/flamenco/types/fd_types.json
@@ -595,8 +595,7 @@
           { "name": "last_index", "type": "ulong" },
           { "name": "parent_slot", "type": "ulong" },
           { "name": "next_slot", "type": "vector", "element": "ulong"},
-          { "name": "is_connected", "type": "uchar" },
-          { "name": "entry_end_indexes", "type": "vector", "element": "uint" }
+          { "name": "is_connected", "type": "uchar" }
       ]
     },
     {


### PR DESCRIPTION
testnet is using a different version of `CompletedDataIndexes` while devnet and mainnet are using the original version. making this PR so that we can get offline replay up on all three clusters. will update once all three clusters are on the same version

```
/// Legacy completed data indexes type; de/serialization is inefficient for a BTreeSet.
///
/// Replaced by [`CompletedDataIndexesV2`].
pub type CompletedDataIndexesV1 = BTreeSet<u32>;
/// A fixed size BitVec offers fast lookup and fast de/serialization.
///
/// Supersedes [`CompletedDataIndexesV1`].
#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
#[serde(transparent)]
pub struct CompletedDataIndexesV2 {
    index: BitVec<MAX_DATA_SHREDS_PER_SLOT>,
}
```