### PR TITLE
accdb: use virtual methods

### DIFF
--- a/src/app/firedancer/callbacks.c
+++ b/src/app/firedancer/callbacks.c
@@ -3,8 +3,8 @@
 #include "../../disco/topo/fd_topo.h"
 #include "../../disco/store/fd_store.h"
 #include "../../flamenco/runtime/fd_bank.h"
-#include "../../flamenco/runtime/fd_runtime.h"
 #include "../../flamenco/runtime/fd_txncache_shmem.h"
+#include "../../funk/fd_funk.h"
 
 #define VAL(name) (__extension__({                                                             \
   ulong __x = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "obj.%lu.%s", obj->id, name );      \

--- a/src/discof/resolv/fd_resolv_tile.c
+++ b/src/discof/resolv/fd_resolv_tile.c
@@ -5,6 +5,7 @@
 #include "generated/fd_resolv_tile_seccomp.h"
 #include "../../disco/metrics/fd_metrics.h"
 #include "../../flamenco/accdb/fd_accdb_sync.h"
+#include "../../flamenco/accdb/fd_accdb_impl_v1.h"
 #include "../../flamenco/runtime/fd_alut_interp.h"
 #include "../../flamenco/runtime/fd_system_ids_pp.h"
 #include "../../flamenco/runtime/fd_bank.h"
@@ -631,7 +632,7 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->out_replay->wmark  = fd_dcache_compact_wmark ( ctx->out_replay->mem, topo->links[ tile->out_link_id[ 1 ] ].dcache, topo->links[ tile->out_link_id[ 1 ] ].mtu );
   ctx->out_replay->chunk  = ctx->out_replay->chunk0;
 
-  FD_TEST( fd_accdb_user_join( ctx->accdb, fd_topo_obj_laddr( topo, tile->resolv.funk_obj_id ) ) );
+  FD_TEST( fd_accdb_user_v1_init( ctx->accdb, fd_topo_obj_laddr( topo, tile->resolv.funk_obj_id ) ) );
 
   ulong banks_obj_id = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "banks" );
   FD_TEST( banks_obj_id!=ULONG_MAX );

--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -6,6 +6,7 @@
 #include "../../disco/topo/fd_topo.h"
 #include "../../disco/metrics/fd_metrics.h"
 #include "../../disco/gui/fd_gui_config_parse.h"
+#include "../../flamenco/accdb/fd_accdb_impl_v1.h"
 #include "../../flamenco/runtime/fd_txncache.h"
 #include "../../flamenco/runtime/fd_system_ids.h"
 #include "../../flamenco/runtime/sysvar/fd_sysvar_slot_history.h"
@@ -806,8 +807,8 @@ unprivileged_init( fd_topo_t *      topo,
 
   ctx->boot_timestamp = fd_log_wallclock();
 
-  FD_TEST( fd_accdb_admin_join( ctx->accdb_admin, fd_topo_obj_laddr( topo, tile->snapin.funk_obj_id ) ) );
-  FD_TEST( fd_accdb_user_join ( ctx->accdb,       fd_topo_obj_laddr( topo, tile->snapin.funk_obj_id ) ) );
+  FD_TEST( fd_accdb_admin_join  ( ctx->accdb_admin, fd_topo_obj_laddr( topo, tile->snapin.funk_obj_id ) ) );
+  FD_TEST( fd_accdb_user_v1_init( ctx->accdb,       fd_topo_obj_laddr( topo, tile->snapin.funk_obj_id ) ) );
   fd_funk_txn_xid_copy( ctx->xid, fd_funk_root( ctx->accdb_admin->funk ) );
 
   void * _txncache_shmem = fd_topo_obj_laddr( topo, tile->snapin.txncache_obj_id );

--- a/src/discof/tower/fd_tower_tile.c
+++ b/src/discof/tower/fd_tower_tile.c
@@ -17,7 +17,7 @@
 #include "../../discof/restore/utils/fd_ssmsg.h"
 #include "../../discof/replay/fd_exec.h"
 #include "../../discof/replay/fd_replay_tile.h"
-#include "../../flamenco/fd_flamenco_base.h"
+#include "../../flamenco/accdb/fd_accdb_impl_v1.h"
 #include "../../flamenco/runtime/fd_bank.h"
 #include "../../util/pod/fd_pod.h"
 
@@ -825,7 +825,7 @@ unprivileged_init( fd_topo_t *      topo,
 
   ulong funk_obj_id = fd_pod_query_ulong( topo->props, "funk", ULONG_MAX );
   FD_TEST( funk_obj_id!=ULONG_MAX );
-  FD_TEST( fd_accdb_user_join( ctx->accdb, fd_topo_obj_laddr( topo, funk_obj_id ) ) );
+  FD_TEST( fd_accdb_user_v1_init( ctx->accdb, fd_topo_obj_laddr( topo, funk_obj_id ) ) );
 
   FD_TEST( tile->in_cnt<sizeof(ctx->in_kind)/sizeof(ctx->in_kind[0]) );
   for( ulong i=0UL; i<tile->in_cnt; i++ ) {

--- a/src/flamenco/accdb/Local.mk
+++ b/src/flamenco/accdb/Local.mk
@@ -4,7 +4,7 @@ $(call add-objs,fd_accdb_admin,fd_flamenco)
 
 # User API
 $(call add-hdrs,fd_accdb_user.h fd_accdb_sync.h)
-$(call add-objs,fd_accdb_user,fd_flamenco)
+$(call add-objs,fd_accdb_impl_v1,fd_flamenco)
 
 # Debug APIs
 $(call add-hdrs,fd_accdb_fsck.h)

--- a/src/flamenco/accdb/fd_accdb_base.h
+++ b/src/flamenco/accdb/fd_accdb_base.h
@@ -1,0 +1,10 @@
+#ifndef HEADER_fd_src_flamenco_accdb_fd_accdb_base_h
+#define HEADER_fd_src_flamenco_accdb_fd_accdb_base_h
+
+struct fd_accdb_user;
+typedef struct fd_accdb_user fd_accdb_user_t;
+
+#define FD_ACCDB_TYPE_V1 (1U) /* funk */
+#define FD_ACCDB_TYPE_v2 (2U) /* read-only vinyl + read-write funk */
+
+#endif /* HEADER_fd_src_flamenco_accdb_fd_accdb_base_h */

--- a/src/flamenco/accdb/fd_accdb_impl_v1.h
+++ b/src/flamenco/accdb/fd_accdb_impl_v1.h
@@ -1,0 +1,39 @@
+#ifndef HEADER_fd_src_flamenco_accdb_fd_accdb_impl_v1_h
+#define HEADER_fd_src_flamenco_accdb_fd_accdb_impl_v1_h
+
+/* fd_accdb_impl_v1.h implements "v1" of Firedancer's account database,
+   which is in-memory (funk) only. */
+
+#include "fd_accdb_user.h"
+#include "../../funk/fd_funk.h"
+
+struct fd_accdb_user_v1 {
+  fd_accdb_user_base_t base;
+
+  /* Funk client */
+  fd_funk_t funk[1];
+
+  /* Current fork cache */
+  fd_funk_txn_xid_t fork[ FD_ACCDB_DEPTH_MAX ];
+  ulong             fork_depth;
+
+  /* Current funk txn cache */
+  ulong tip_txn_idx; /* ==ULONG_MAX if tip is root */
+};
+
+typedef struct fd_accdb_user_v1 fd_accdb_user_v1_t;
+
+FD_PROTOTYPES_BEGIN
+
+extern fd_accdb_user_vt_t const fd_accdb_user_v1_vt;
+
+fd_accdb_user_t *
+fd_accdb_user_v1_init( fd_accdb_user_t * ljoin,
+                       void *            shfunk );
+
+fd_funk_t *
+fd_accdb_user_v1_funk( fd_accdb_user_t * accdb );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_flamenco_accdb_fd_accdb_impl_v1_h */

--- a/src/flamenco/accdb/fd_accdb_ref.h
+++ b/src/flamenco/accdb/fd_accdb_ref.h
@@ -219,4 +219,14 @@ fd_accdb_spec_drop( fd_accdb_spec_t * spec ) {
   (void)spec;
 }
 
+/* fd_accdb_peek_t is an ephemeral lock-free read-only pointer to an
+   account in database cache. */
+
+struct fd_accdb_peek {
+  fd_accdb_ro_t   acc[1];
+  fd_accdb_spec_t spec[1];
+};
+
+typedef struct fd_accdb_peek fd_accdb_peek_t;
+
 #endif /* HEADER_fd_src_flamenco_accdb_fd_accdb_ref_h */

--- a/src/flamenco/progcache/fd_prog_load.h
+++ b/src/flamenco/progcache/fd_prog_load.h
@@ -4,8 +4,8 @@
 /* fd_prog_load.h provides high-level APIs for loading Solana programs
    from the account database. */
 
-#include "../../funk/fd_funk_rec.h"
 #include "../fd_flamenco_base.h"
+#include "../accdb/fd_accdb_user.h"
 
 FD_PROTOTYPES_BEGIN
 
@@ -19,7 +19,7 @@ FD_PROTOTYPES_BEGIN
    program not deployed, program data account not found, etc */
 
 uchar const *
-fd_prog_load_elf( fd_funk_t const *         accdb,
+fd_prog_load_elf( fd_accdb_user_t *         accdb,
                   fd_funk_txn_xid_t const * xid,
                   void const *              prog_addr,
                   ulong *                   out_sz,

--- a/src/flamenco/progcache/fd_progcache_user.c
+++ b/src/flamenco/progcache/fd_progcache_user.c
@@ -501,7 +501,7 @@ fd_progcache_lock_best_txn( fd_progcache_t * cache,
 
 static fd_progcache_rec_t const *
 fd_progcache_insert( fd_progcache_t *           cache,
-                     fd_funk_t *                accdb,
+                     fd_accdb_user_t *          accdb,
                      fd_funk_txn_xid_t const *  load_xid,
                      void const *               prog_addr,
                      fd_prog_load_env_t const * env,
@@ -617,7 +617,7 @@ fd_progcache_insert( fd_progcache_t *           cache,
 
 fd_progcache_rec_t const *
 fd_progcache_pull( fd_progcache_t *           cache,
-                   fd_funk_t *                accdb,
+                   fd_accdb_user_t *          accdb,
                    fd_funk_txn_xid_t const *  xid,
                    void const *               prog_addr,
                    fd_prog_load_env_t const * env ) {

--- a/src/flamenco/progcache/fd_progcache_user.h
+++ b/src/flamenco/progcache/fd_progcache_user.h
@@ -52,8 +52,9 @@
 
 #include "fd_progcache_rec.h"
 #include "fd_prog_load.h"
-#include "../../funk/fd_funk.h"
+#include "../accdb/fd_accdb_base.h"
 #include "../runtime/fd_runtime_const.h"
+#include "../../funk/fd_funk.h"
 
 #define FD_PROGCACHE_DEPTH_MAX (128UL)
 
@@ -165,7 +166,7 @@ fd_progcache_peek( fd_progcache_t *          cache,
 
 fd_progcache_rec_t const *
 fd_progcache_pull( fd_progcache_t *           cache,
-                   fd_funk_t *                accdb,
+                   fd_accdb_user_t *          accdb,
                    fd_funk_txn_xid_t const *  xid,
                    void const *               prog_addr,
                    fd_prog_load_env_t const * env );

--- a/src/flamenco/rewards/fd_rewards.c
+++ b/src/flamenco/rewards/fd_rewards.c
@@ -2,8 +2,6 @@
 #include <math.h>
 
 #include "../runtime/fd_acc_mgr.h"
-#include "../runtime/fd_executor_err.h"
-#include "../runtime/program/fd_vote_program.h"
 #include "../runtime/sysvar/fd_sysvar_epoch_rewards.h"
 #include "../runtime/sysvar/fd_sysvar_epoch_schedule.h"
 #include "../stakes/fd_stakes.h"
@@ -13,6 +11,7 @@
 #include "../runtime/fd_runtime_stack.h"
 #include "../runtime/fd_runtime.h"
 #include "fd_epoch_rewards.h"
+#include "../accdb/fd_accdb_impl_v1.h"
 
 /* https://github.com/anza-xyz/agave/blob/7117ed9653ce19e8b2dea108eff1f3eb6a3378a7/sdk/src/inflation.rs#L85 */
 static double
@@ -763,9 +762,10 @@ calculate_rewards_and_distribute_vote_rewards( fd_bank_t *                    ba
      completed epoch.  We store the stake account rewards and vote
      states rewards in the bank */
 
+  fd_funk_t * funk = fd_accdb_user_v1_funk( accdb );
   fd_partitioned_rewards_calculation_t rewards_calc_result[1] = {0};
   calculate_rewards_for_partitioning( bank,
-                                      accdb->funk,
+                                      funk,
                                       xid,
                                       runtime_stack,
                                       stake_delegations,

--- a/src/flamenco/runtime/fd_core_bpf_migration.c
+++ b/src/flamenco/runtime/fd_core_bpf_migration.c
@@ -6,6 +6,7 @@
 #include "fd_system_ids.h"
 #include "fd_acc_mgr.h"
 #include "fd_hashes.h"
+#include "../accdb/fd_accdb_impl_v1.h"
 #include <assert.h>
 
 static fd_pubkey_t
@@ -316,13 +317,14 @@ migrate_builtin_to_core_bpf1( fd_core_bpf_migration_config_t const * config,
                               fd_runtime_stack_t *                   runtime_stack,
                               fd_pubkey_t const *                    builtin_program_id,
                               fd_capture_ctx_t *                     capture_ctx ) {
+  fd_funk_t * funk = fd_accdb_user_v1_funk( accdb );
 
   target_builtin_t target[1];
   if( FD_UNLIKELY( !target_builtin_new_checked(
       target,
       builtin_program_id,
       config->migration_target,
-      accdb->funk,
+      funk,
       xid,
       runtime_stack ) ) )
     return;
@@ -330,7 +332,7 @@ migrate_builtin_to_core_bpf1( fd_core_bpf_migration_config_t const * config,
   fd_tmp_account_t * source = &runtime_stack->bpf_migration.source;
   if( FD_UNLIKELY( !source_buffer_new_checked(
       source,
-      accdb->funk,
+      funk,
       xid,
       config->source_buffer_address ) ) )
     return;
@@ -372,8 +374,8 @@ migrate_builtin_to_core_bpf1( fd_core_bpf_migration_config_t const * config,
   assert( new_target_program_data->data_sz>=PROGRAMDATA_METADATA_SIZE );
   if( FD_UNLIKELY( !fd_directly_invoke_loader_v3_deploy(
       bank,
-      accdb->funk,
-      accdb->funk->shmem,
+      funk,
+      funk->shmem,
       &target->program_account->addr,
       new_target_program_data->data   +PROGRAMDATA_METADATA_SIZE,
       new_target_program_data->data_sz-PROGRAMDATA_METADATA_SIZE ) ) ) {

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -4,9 +4,10 @@
 #include "fd_runtime_helpers.h"
 
 struct fd_runtime {
-  fd_funk_t *      funk;
-  fd_txncache_t *  status_cache;
-  fd_progcache_t * progcache;
+  fd_accdb_user_t * accdb;
+  fd_funk_t *       funk;
+  fd_txncache_t *   status_cache;
+  fd_progcache_t *  progcache;
 
   struct {
     uchar                       stack_sz;                                /* Current depth of the instruction execution stack. */

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -2576,7 +2576,7 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
   fd_funk_txn_xid_t xid = { .ul = { fd_bank_slot_get( ctx->bank ), ctx->bank->idx } };
   fd_progcache_rec_t const * cache_entry =
       fd_progcache_pull( ctx->runtime->progcache,
-                         ctx->runtime->funk,
+                         ctx->runtime->accdb,
                          &xid,
                          program_id,
                          load_env );

--- a/src/flamenco/runtime/program/fd_builtin_programs.c
+++ b/src/flamenco/runtime/program/fd_builtin_programs.c
@@ -1,9 +1,8 @@
 #include "fd_builtin_programs.h"
 #include "fd_precompiles.h"
-#include "../fd_runtime.h"
-#include "../fd_acc_mgr.h"
 #include "../fd_system_ids.h"
 #include "../fd_system_ids_pp.h"
+#include "../../accdb/fd_accdb_impl_v1.h"
 
 #define BUILTIN_PROGRAM(program_id, name, feature_offset, migration_config) \
     {                                                                       \
@@ -281,9 +280,10 @@ fd_builtin_programs_init( fd_bank_t *               bank,
   /* https://github.com/anza-xyz/agave/blob/v2.3.7/builtins/src/lib.rs#L52 */
   fd_builtin_program_t const * builtins = fd_builtins();
 
+  fd_funk_t * funk = fd_accdb_user_v1_funk( accdb );
   for( ulong i=0UL; i<fd_num_builtins(); i++ ) {
     /** https://github.com/anza-xyz/agave/blob/v2.3.7/runtime/src/bank.rs#L4949 */
-    if( fd_bank_slot_get( bank )==0UL && builtins[i].enable_feature_offset==NO_ENABLE_FEATURE_ID && !fd_builtin_is_bpf( accdb->funk, xid, builtins[i].pubkey ) ) {
+    if( fd_bank_slot_get( bank )==0UL && builtins[i].enable_feature_offset==NO_ENABLE_FEATURE_ID && !fd_builtin_is_bpf( funk, xid, builtins[i].pubkey ) ) {
       fd_write_builtin_account( bank, accdb, xid, capture_ctx, *builtins[i].pubkey, builtins[i].data, strlen( builtins[i].data ) );
     } else if( builtins[i].core_bpf_migration_config && FD_FEATURE_ACTIVE_OFFSET( fd_bank_slot_get( bank ), fd_bank_features_query( bank ), builtins[i].core_bpf_migration_config->enable_feature_offset ) ) {
       continue;

--- a/src/flamenco/runtime/program/fd_loader_v4_program.c
+++ b/src/flamenco/runtime/program/fd_loader_v4_program.c
@@ -911,7 +911,7 @@ fd_loader_v4_program_execute( fd_exec_instr_ctx_t * instr_ctx ) {
     fd_funk_txn_xid_t xid = { .ul = { fd_bank_slot_get( instr_ctx->bank ), instr_ctx->bank->idx } };
     fd_prog_load_env_t load_env[1]; fd_prog_load_env_from_bank( load_env, instr_ctx->bank );
     fd_progcache_rec_t const * cache_entry = fd_progcache_pull( instr_ctx->runtime->progcache,
-                                                                instr_ctx->runtime->funk,
+                                                                instr_ctx->runtime->accdb,
                                                                 &xid,
                                                                 program_id,
                                                                 load_env );

--- a/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
@@ -5,6 +5,7 @@
 #include "../fd_acc_mgr.h"
 #include "../fd_system_ids.h"
 #include "../program/fd_program_util.h"
+#include "../../accdb/fd_accdb_impl_v1.h"
 
 /* Syvar Clock Possible Values:
   slot:
@@ -267,8 +268,9 @@ fd_sysvar_clock_update( fd_bank_t *               bank,
                         fd_capture_ctx_t *        capture_ctx,
                         fd_runtime_stack_t *      runtime_stack,
                         ulong const *             parent_epoch ) {
+  fd_funk_t * funk = fd_accdb_user_v1_funk( accdb );
   fd_sol_sysvar_clock_t clock_[1];
-  fd_sol_sysvar_clock_t * clock = fd_sysvar_clock_read( accdb->funk, xid, clock_ );
+  fd_sol_sysvar_clock_t * clock = fd_sysvar_clock_read( funk, xid, clock_ );
   if( FD_UNLIKELY( !clock ) ) FD_LOG_ERR(( "fd_sysvar_clock_read failed" ));
 
   fd_epoch_schedule_t const * epoch_schedule = fd_bank_epoch_schedule_query( bank );

--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_rewards.c
@@ -3,6 +3,7 @@
 #include "../fd_acc_mgr.h"
 #include "../fd_txn_account.h"
 #include "../fd_system_ids.h"
+#include "../../accdb/fd_accdb_impl_v1.h"
 
 static void
 write_epoch_rewards( fd_bank_t *                 bank,
@@ -58,8 +59,9 @@ fd_sysvar_epoch_rewards_distribute( fd_bank_t *               bank,
                                     fd_funk_txn_xid_t const * xid,
                                     fd_capture_ctx_t *        capture_ctx,
                                     ulong                     distributed ) {
+  fd_funk_t * funk = fd_accdb_user_v1_funk( accdb );
   fd_sysvar_epoch_rewards_t epoch_rewards[1];
-  if( FD_UNLIKELY( !fd_sysvar_epoch_rewards_read( accdb->funk, xid, epoch_rewards ) ) ) {
+  if( FD_UNLIKELY( !fd_sysvar_epoch_rewards_read( funk, xid, epoch_rewards ) ) ) {
     FD_LOG_ERR(( "failed to read sysvar epoch rewards" ));
   }
 
@@ -81,8 +83,9 @@ fd_sysvar_epoch_rewards_set_inactive( fd_bank_t *               bank,
                                       fd_accdb_user_t *         accdb,
                                       fd_funk_txn_xid_t const * xid,
                                       fd_capture_ctx_t *        capture_ctx ) {
+  fd_funk_t * funk = fd_accdb_user_v1_funk( accdb );
   fd_sysvar_epoch_rewards_t epoch_rewards[1];
-  if( FD_UNLIKELY( !fd_sysvar_epoch_rewards_read( accdb->funk, xid, epoch_rewards ) ) ) {
+  if( FD_UNLIKELY( !fd_sysvar_epoch_rewards_read( funk, xid, epoch_rewards ) ) ) {
     FD_LOG_ERR(( "failed to read sysvar epoch rewards" ));
   }
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.c
@@ -2,6 +2,7 @@
 #include "fd_sysvar.h"
 #include "../fd_system_ids.h"
 #include "../fd_acc_mgr.h"
+#include "../../accdb/fd_accdb_impl_v1.h"
 
 void
 fd_sysvar_last_restart_slot_write(
@@ -96,8 +97,9 @@ fd_sysvar_last_restart_slot_update(
 
   /* https://github.com/solana-labs/solana/blob/v1.18.18/runtime/src/bank.rs#L2098-L2106 */
   ulong last_restart_slot_have = ULONG_MAX;
+  fd_funk_t * funk = fd_accdb_user_v1_funk( accdb );
   fd_sol_sysvar_last_restart_slot_t sysvar;
-  if( FD_LIKELY( fd_sysvar_last_restart_slot_read( accdb->funk, xid, &sysvar ) ) ) {
+  if( FD_LIKELY( fd_sysvar_last_restart_slot_read( funk, xid, &sysvar ) ) ) {
     last_restart_slot_have = sysvar.slot;
   }
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_hashes.c
@@ -2,6 +2,8 @@
 #include "fd_sysvar.h"
 #include "../fd_acc_mgr.h"
 #include "../fd_system_ids.h"
+#include "../../accdb/fd_accdb_impl_v1.h"
+
 /* FIXME These constants should be header defines */
 
 void
@@ -77,8 +79,9 @@ fd_sysvar_slot_hashes_update( fd_bank_t *               bank,
                               fd_accdb_user_t *         accdb,
                               fd_funk_txn_xid_t const * xid,
                               fd_capture_ctx_t *        capture_ctx ) {
+  fd_funk_t * funk = fd_accdb_user_v1_funk( accdb );
   uchar __attribute__((aligned(FD_SYSVAR_SLOT_HASHES_ALIGN))) slot_hashes_mem[FD_SYSVAR_SLOT_HASHES_FOOTPRINT];
-  fd_slot_hashes_global_t * slot_hashes_global = fd_sysvar_slot_hashes_read( accdb->funk, xid, slot_hashes_mem );
+  fd_slot_hashes_global_t * slot_hashes_global = fd_sysvar_slot_hashes_read( funk, xid, slot_hashes_mem );
   fd_slot_hash_t *          hashes             = NULL;
   if( FD_UNLIKELY( !slot_hashes_global ) ) {
     /* Note: Agave's implementation initializes a new slot_hashes if it doesn't already exist (refer to above URL). */

--- a/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_slot_history.c
@@ -1,9 +1,8 @@
 #include "fd_sysvar_slot_history.h"
 #include "fd_sysvar.h"
-#include "fd_sysvar_rent.h"
 #include "../fd_system_ids.h"
 #include "../fd_txn_account.h"
-#include "../../../funk/fd_funk_txn.h"
+#include "../../accdb/fd_accdb_impl_v1.h"
 
 /* FIXME These constants should be header defines */
 
@@ -87,8 +86,9 @@ fd_sysvar_slot_history_update( fd_bank_t *               bank,
   /* Set current_slot, and update next_slot */
   fd_pubkey_t const * key = &fd_sysvar_slot_history_id;
 
+  fd_funk_t * funk = fd_accdb_user_v1_funk( accdb );
   fd_txn_account_t rec[1];
-  int err = fd_txn_account_init_from_funk_readonly( rec, key, accdb->funk, xid );
+  int err = fd_txn_account_init_from_funk_readonly( rec, key, funk, xid );
   if( FD_UNLIKELY( err ) ) FD_LOG_CRIT(( "fd_txn_account_init_from_funk_readonly(slot_history) failed: %d", err ));
 
   fd_bincode_decode_ctx_t ctx = {

--- a/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_stake_history.c
@@ -3,6 +3,7 @@
 #include "../fd_system_ids.h"
 #include "../fd_txn_account.h"
 #include "../fd_acc_mgr.h"
+#include "../../accdb/fd_accdb_impl_v1.h"
 
 /* Ensure that the size declared by our header matches the minimum size
    of the corresponding fd_types entry. */
@@ -66,8 +67,9 @@ fd_sysvar_stake_history_update( fd_bank_t *                                 bank
                                 fd_capture_ctx_t *                          capture_ctx,
                                 fd_epoch_stake_history_entry_pair_t const * pair ) {
 
+  fd_funk_t * funk = fd_accdb_user_v1_funk( accdb );
   fd_stake_history_t stake_history[1];
-  if( FD_UNLIKELY( !fd_sysvar_stake_history_read( accdb->funk, xid, stake_history ) ) ) {
+  if( FD_UNLIKELY( !fd_sysvar_stake_history_read( funk, xid, stake_history ) ) ) {
     FD_LOG_CRIT(( "Failed to read stake history sysvar" ));
   }
 

--- a/src/flamenco/runtime/sysvar/test_sysvar_recent_hashes.c
+++ b/src/flamenco/runtime/sysvar/test_sysvar_recent_hashes.c
@@ -4,6 +4,7 @@
 #include "../fd_bank.h"
 #include "../fd_system_ids.h"
 #include "../../types/fd_types.h"
+#include "../../accdb/fd_accdb_impl_v1.h"
 
 FD_IMPORT_BINARY( example_recent_hashes, "src/flamenco/runtime/sysvar/test_sysvar_recent_hashes.bin" );
 
@@ -45,8 +46,9 @@ test_sysvar_recent_hashes_init( fd_wksp_t * wksp ) {
   fd_bank_rent_set( env->bank, rent );
 
   /* Create an empty recent hashes sysvar */
+  fd_funk_t * funk = fd_accdb_user_v1_funk( env->accdb );
   fd_sysvar_recent_hashes_init( env->bank, env->accdb, &env->xid, NULL );
-  fd_sysvar_cache_restore( env->bank, env->accdb->funk, &env->xid );
+  fd_sysvar_cache_restore( env->bank, funk, &env->xid );
   FD_TEST( fd_sysvar_cache_recent_hashes_is_valid( env->sysvar_cache )==1 );
   {
     fd_bank_poh_set( env->bank, (fd_hash_t){0} );
@@ -65,6 +67,7 @@ test_sysvar_recent_hashes_update( fd_wksp_t * wksp ) {
   test_sysvar_cache_env_t env[1];
   FD_TEST( test_sysvar_cache_env_create( env, wksp ) );
   FD_TEST( fd_sysvar_cache_recent_hashes_is_valid( env->sysvar_cache )==0 );
+  fd_funk_t * funk = fd_accdb_user_v1_funk( env->accdb );
 
   /* Cannot create any sysvar without the rent sysvar */
   fd_rent_t const rent = {
@@ -84,7 +87,7 @@ test_sysvar_recent_hashes_update( fd_wksp_t * wksp ) {
   fd_bank_poh_set( env->bank, poh );
   fd_bank_rbh_lamports_per_sig_set( env->bank, 1000UL );
   fd_sysvar_recent_hashes_update( env->bank, env->accdb, &env->xid, NULL );
-  fd_sysvar_cache_restore( env->bank, env->accdb->funk, &env->xid );
+  fd_sysvar_cache_restore( env->bank, funk, &env->xid );
   FD_TEST( fd_sysvar_cache_recent_hashes_is_valid( env->sysvar_cache )==1 );
   {
     ulong sz = 0UL;
@@ -102,7 +105,7 @@ test_sysvar_recent_hashes_update( fd_wksp_t * wksp ) {
     fd_bank_poh_set( env->bank, poh );
     fd_bank_rbh_lamports_per_sig_set( env->bank, 1001UL+i );
     fd_sysvar_recent_hashes_update( env->bank, env->accdb, &env->xid, NULL );
-    fd_sysvar_cache_restore( env->bank, env->accdb->funk, &env->xid );
+    fd_sysvar_cache_restore( env->bank, funk, &env->xid );
 
     ulong sz = 0UL;
     uchar const * data = fd_sysvar_cache_data_query( env->sysvar_cache, &fd_sysvar_recent_block_hashes_id, &sz );

--- a/src/flamenco/runtime/sysvar/test_sysvar_stake_history.c
+++ b/src/flamenco/runtime/sysvar/test_sysvar_stake_history.c
@@ -3,6 +3,7 @@
 #include "test_sysvar_cache_util.h"
 #include "../fd_bank.h"
 #include "../fd_system_ids.h"
+#include "../../accdb/fd_accdb_impl_v1.h"
 
 FD_IMPORT_BINARY( example_stake_history, "src/flamenco/runtime/sysvar/test_sysvar_stake_history.bin" );
 
@@ -24,6 +25,7 @@ test_sysvar_stake_history_update( fd_wksp_t * wksp ) {
   test_sysvar_cache_env_t env[1];
   FD_TEST( test_sysvar_cache_env_create( env, wksp ) );
   FD_TEST( fd_sysvar_cache_stake_history_is_valid( env->sysvar_cache )==0 );
+  fd_funk_t * funk = fd_accdb_user_v1_funk( env->accdb );
 
   /* Cannot create any sysvar without the rent sysvar */
   fd_rent_t const rent = {
@@ -55,13 +57,13 @@ test_sysvar_stake_history_update( fd_wksp_t * wksp ) {
   };
   fd_sysvar_stake_history_init( env->bank, env->accdb, &env->xid, NULL );
   fd_sysvar_stake_history_update( env->bank, env->accdb, &env->xid, NULL, &entry0 );
-  fd_sysvar_cache_restore( env->bank, env->accdb->funk, &env->xid );
+  fd_sysvar_cache_restore( env->bank, funk, &env->xid );
   FD_TEST( fd_sysvar_cache_stake_history_is_valid( env->sysvar_cache )==1 );
 
   fd_bank_slot_set( env->bank, 432000UL );
   fd_bank_parent_slot_set( env->bank, 431999UL );
   fd_sysvar_stake_history_update( env->bank, env->accdb, &env->xid, NULL, &entry0 );
-  fd_sysvar_cache_restore( env->bank, env->accdb->funk, &env->xid );
+  fd_sysvar_cache_restore( env->bank, funk, &env->xid );
   FD_TEST( fd_sysvar_cache_stake_history_is_valid( env->sysvar_cache )==1 );
 
   {

--- a/src/flamenco/runtime/test_runtime_alut.c
+++ b/src/flamenco/runtime/test_runtime_alut.c
@@ -2,10 +2,8 @@
 
 #include "fd_runtime.h"
 #include "fd_runtime_err.h"
-#include "fd_alut_interp.h"
-#include "fd_acc_mgr.h"
 #include "fd_txn_account.h"
-#include "../accdb/fd_accdb_user.h"
+#include "../accdb/fd_accdb_impl_v1.h"
 #include "program/fd_address_lookup_table_program.h"
 #include "fd_system_ids.h"
 #include "../../ballet/txn/fd_txn.h"
@@ -28,8 +26,7 @@ typedef struct {
   void *              funk_shmem;
   fd_funk_t           funk_join[1];
   fd_funk_t *         funk;
-  fd_accdb_user_t     accdb_user[1];
-  fd_accdb_user_t *   accdb;
+  fd_accdb_user_t     accdb[1];
   fd_funk_txn_xid_t   xid;
   fd_funk_txn_t *     funk_txn;
 } test_ctx_t;
@@ -60,8 +57,7 @@ test_setup( fd_wksp_t * wksp ) {
   FD_TEST( ctx->funk );
 
   /* Set up accdb interface */
-  ctx->accdb = fd_accdb_user_join( fd_accdb_user_new( ctx->accdb_user ), ctx->funk_shmem );
-  FD_TEST( ctx->accdb );
+  FD_TEST( fd_accdb_user_v1_init( ctx->accdb, ctx->funk_shmem ) );
 
   /* Set up root transaction and target transaction ID */
   fd_funk_txn_xid_t root_xid;

--- a/src/flamenco/runtime/tests/fd_dump_pb.c
+++ b/src/flamenco/runtime/tests/fd_dump_pb.c
@@ -1254,7 +1254,7 @@ FD_SPAD_FRAME_BEGIN( spad ) {
   /* Get the programdata for the account */
   ulong         program_data_len = 0UL;
   uchar const * program_data     =
-      fd_prog_load_elf( runtime->funk, &xid, program_acc, &program_data_len, NULL );
+      fd_prog_load_elf( runtime->accdb, &xid, program_acc, &program_data_len, NULL );
   if( program_data==NULL ) {
     return;
   }

--- a/src/flamenco/runtime/tests/fd_harness_common.c
+++ b/src/flamenco/runtime/tests/fd_harness_common.c
@@ -2,6 +2,7 @@
 #include "generated/context.pb.h"
 #include "../fd_acc_mgr.h"
 #include "../../features/fd_features.h"
+#include "../../accdb/fd_accdb_impl_v1.h"
 #include <assert.h>
 
 int
@@ -20,7 +21,8 @@ fd_solfuzz_pb_load_account( fd_txn_account_t *                acc,
   fd_pubkey_t pubkey[1];  memcpy( pubkey, state->address, sizeof(fd_pubkey_t) );
 
   /* Account must not yet exist */
-  if( FD_UNLIKELY( fd_funk_get_acc_meta_readonly( accdb->funk, xid, pubkey, NULL, NULL, NULL) ) ) {
+  fd_funk_t * funk = fd_accdb_user_v1_funk( accdb );
+  if( FD_UNLIKELY( fd_funk_get_acc_meta_readonly( funk, xid, pubkey, NULL, NULL, NULL) ) ) {
     return 0;
   }
 

--- a/src/flamenco/runtime/tests/fd_solfuzz.c
+++ b/src/flamenco/runtime/tests/fd_solfuzz.c
@@ -5,6 +5,7 @@
 #include "../fd_bank.h"
 #include "../fd_runtime_stack.h"
 #include "../fd_runtime.h"
+#include "../../accdb/fd_accdb_impl_v1.h"
 #include <errno.h>
 #include <sys/mman.h>
 #include "../../../util/shmem/fd_shmem_private.h"
@@ -105,8 +106,8 @@ fd_solfuzz_runner_new( fd_wksp_t *                         wksp,
   if( FD_UNLIKELY( !shfunk   ) ) goto bail1;
   if( FD_UNLIKELY( !shpcache ) ) goto bail1;
 
-  if( FD_UNLIKELY( !fd_accdb_admin_join( runner->accdb_admin, funk_mem ) ) ) goto bail2;
-  if( FD_UNLIKELY( !fd_accdb_user_join ( runner->accdb,       funk_mem ) ) ) goto bail2;
+  if( FD_UNLIKELY( !fd_accdb_admin_join  ( runner->accdb_admin, funk_mem ) ) ) goto bail2;
+  if( FD_UNLIKELY( !fd_accdb_user_v1_init( runner->accdb,       funk_mem ) ) ) goto bail2;
   if( FD_UNLIKELY( !fd_progcache_join( runner->progcache, pcache_mem, scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) ) ) goto bail2;
   if( FD_UNLIKELY( !fd_progcache_admin_join( runner->progcache_admin, pcache_mem ) ) ) goto bail2;
 
@@ -158,7 +159,7 @@ bail1:
 void
 fd_solfuzz_runner_delete( fd_solfuzz_runner_t * runner ) {
 
-  fd_accdb_user_leave( runner->accdb, NULL );
+  fd_accdb_user_fini( runner->accdb );
   void * shfunk = NULL;
   fd_accdb_admin_leave( runner->accdb_admin, &shfunk );
   if( shfunk ) fd_wksp_free_laddr( fd_funk_delete( shfunk ) );
@@ -183,7 +184,7 @@ fd_solfuzz_runner_leak_check( fd_solfuzz_runner_t * runner ) {
     FD_LOG_CRIT(( "solfuzz leaked a spad frame (bump allocator)" ));
   }
 
-  if( FD_UNLIKELY( !fd_funk_txn_idx_is_null( fd_funk_txn_idx( runner->accdb->funk->shmem->child_head_cidx ) ) ) ) {
+  if( FD_UNLIKELY( !fd_funk_txn_idx_is_null( fd_funk_txn_idx( runner->accdb_admin->funk->shmem->child_head_cidx ) ) ) ) {
     FD_LOG_CRIT(( "solfuzz leaked a funk txn" ));
   }
 }

--- a/src/flamenco/runtime/tests/fd_solfuzz.h
+++ b/src/flamenco/runtime/tests/fd_solfuzz.h
@@ -33,8 +33,6 @@ struct fd_solfuzz_runner {
   fd_bank_t *    bank;
   fd_runtime_t * runtime;
 
-  fd_funk_t funk[1];
-
   fd_progcache_t       progcache[1];
   fd_progcache_admin_t progcache_admin[1];
 

--- a/src/flamenco/stakes/fd_stakes.c
+++ b/src/flamenco/stakes/fd_stakes.c
@@ -1,10 +1,10 @@
 #include "fd_stakes.h"
 #include "../runtime/fd_bank.h"
-#include "../runtime/fd_system_ids.h"
 #include "../runtime/program/fd_stake_program.h"
 #include "../runtime/program/fd_vote_program.h"
 #include "../runtime/sysvar/fd_sysvar_stake_history.h"
 #include "fd_stake_delegations.h"
+#include "../accdb/fd_accdb_impl_v1.h"
 
 ulong
 fd_stake_weights_by_node( fd_vote_states_t const * vote_states,
@@ -97,8 +97,9 @@ fd_stakes_activate_epoch( fd_bank_t *                    bank,
      sysvar.  Afterward, we can refresh the stake values for the vote
      accounts for the new epoch. */
 
+  fd_funk_t * funk = fd_accdb_user_v1_funk( accdb );
   fd_stake_history_t stake_history[1];
-  if( FD_UNLIKELY( !fd_sysvar_stake_history_read( accdb->funk, xid, stake_history ) ) ) {
+  if( FD_UNLIKELY( !fd_sysvar_stake_history_read( funk, xid, stake_history ) ) ) {
     FD_LOG_ERR(( "StakeHistory sysvar is missing from sysvar cache" ));
   }
 
@@ -137,7 +138,7 @@ fd_stakes_activate_epoch( fd_bank_t *                    bank,
 
   fd_sysvar_stake_history_update( bank, accdb, xid, capture_ctx, &new_elem );
 
-  if( FD_UNLIKELY( !fd_sysvar_stake_history_read( accdb->funk, xid, stake_history ) ) ) {
+  if( FD_UNLIKELY( !fd_sysvar_stake_history_read( funk, xid, stake_history ) ) ) {
     FD_LOG_ERR(( "StakeHistory sysvar is missing from sysvar cache" ));
   }
 


### PR DESCRIPTION
Introduce a 'accdb_user' virtual class in preparation for
additional database engines.

Add read API and rename accessors to {open,close}_{ro,rw}.
