### PR TITLE
Parallel snapshot decompress experiment

### DIFF
--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -1778,12 +1778,18 @@ user = ""
     [development.udpecho]
         affinity = "auto"
 
-    # Set to true to disable verification of the lthash in the
-    # snapshot loader.  This is not safe or supported in production
-    # and should only be used for development and testing purposes.
-    #
-    # If lthash verification is disabled, the validator will not
-    # start any lthash tiles and the value of `snapla_tile_count`
-    # in the layout will be ignored.
+    # Experimental snapshot loading options
     [development.snapshots]
+        # Set to true to disable verification of the lthash in the
+        # snapshot loader.  This is not safe or supported in production
+        # and should only be used for development and testing purposes.
+        #
+        # If lthash verification is disabled, the validator will not
+        # start any lthash tiles and the value of `snapla_tile_count`
+        # in the layout will be ignored.
         disable_lthash_verification = true
+
+        # Set numebr of decompression threads.  Values other than 1 only
+        # have an effect with snapshot files with an experimental
+        # compression format.  See src/discof/restore/fd_snapmk_para.c
+        decompress_tile_count = 1

--- a/src/app/shared/fd_action.h
+++ b/src/app/shared/fd_action.h
@@ -140,6 +140,7 @@ union fdctl_args {
     ulong db_rec_max;
     ulong cache_sz;
     ulong cache_rec_max;
+    uint  dc_tile_cnt;
   } snapshot_load;
 
   struct {

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -348,6 +348,7 @@ struct fd_config {
 
     struct {
       int disable_lthash_verification;
+      uint decompress_tile_count;
     } snapshots;
 
     struct {

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -315,6 +315,7 @@ fd_config_extract_pod( uchar *       pod,
 
   CFG_POP      ( cstr,   development.udpecho.affinity                     );
   CFG_POP      ( bool,   development.snapshots.disable_lthash_verification );
+  CFG_POP      ( uint,   development.snapshots.decompress_tile_count      );
 
   if( FD_UNLIKELY( !config->is_firedancer ) ) {
     CFG_POP    ( bool,   development.gui.websocket_compression            );

--- a/src/disco/stem/fd_stem.h
+++ b/src/disco/stem/fd_stem.h
@@ -13,6 +13,8 @@ struct fd_stem_context {
    ulong *           cr_avail;
    ulong *           min_cr_avail;
    ulong             cr_decrement_amount;
+
+   ulong             next_in_idx;
 };
 
 typedef struct fd_stem_context fd_stem_context_t;

--- a/src/discof/restore/Local.mk
+++ b/src/discof/restore/Local.mk
@@ -28,6 +28,12 @@ $(call make-unit-test,test_sspeer_selector,utils/test_sspeer_selector,fd_discof 
 $(call run-unit-test,test_slot_delta_parser)
 $(call run-unit-test,test_sspeer_selector)
 endif
+ifdef FD_HAS_ZSTD
+$(call add-objs,utils/fd_zstd_dskip,fd_discof)
+ifdef FD_HAS_HOSTED
+$(call make-unit-test,test_zstd_dskip,utils/test_zstd_dskip,fd_discof fd_flamenco fd_ballet fd_util)
+endif
+endif
 
 ifdef FD_HAS_HOSTED
 $(call make-fuzz-test,fuzz_snapshot_parser,utils/fuzz_snapshot_parser,fd_discof fd_flamenco fd_ballet fd_util)

--- a/src/discof/restore/Local.mk
+++ b/src/discof/restore/Local.mk
@@ -32,6 +32,7 @@ ifdef FD_HAS_ZSTD
 $(call add-objs,utils/fd_zstd_dskip,fd_discof)
 ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_zstd_dskip,utils/test_zstd_dskip,fd_discof fd_flamenco fd_ballet fd_util)
+$(call make-fuzz-test,fuzz_zstd_dskip,utils/fuzz_zstd_dskip,fd_discof fd_flamenco fd_ballet fd_util)
 endif
 endif
 

--- a/src/discof/restore/Local.mk
+++ b/src/discof/restore/Local.mk
@@ -33,6 +33,7 @@ $(call add-objs,utils/fd_zstd_dskip,fd_discof)
 ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_zstd_dskip,utils/test_zstd_dskip,fd_discof fd_flamenco fd_ballet fd_util)
 $(call make-fuzz-test,fuzz_zstd_dskip,utils/fuzz_zstd_dskip,fd_discof fd_flamenco fd_ballet fd_util)
+$(call make-fuzz-test,fuzz_zstd_dskip_diff,utils/fuzz_zstd_dskip_diff,fd_discof fd_flamenco fd_ballet fd_util)
 endif
 endif
 

--- a/src/discof/restore/utils/fd_ssctrl.h
+++ b/src/discof/restore/utils/fd_ssctrl.h
@@ -70,6 +70,7 @@
 #define FD_SNAPSHOT_MSG_CTRL_DONE              (6UL) /* Current snapshot succeeded, commit work, go idle, and expect shutdown */
 #define FD_SNAPSHOT_MSG_CTRL_SHUTDOWN          (7UL) /* No work left to do, perform final cleanup and shut down */
 #define FD_SNAPSHOT_MSG_CTRL_ERROR             (8UL) /* Some tile encountered an error with the current stream */
+#define FD_SNAPSHOT_MSG_CTRL_BARRIER           (9UL) /* Synchronize all tiles up to this point in the pipeline */
 
 /* snapla -> snapls */
 #define FD_SNAPSHOT_HASH_MSG_RESULT_ADD        (9UL) /* Hash result sent from snapla to snapls */

--- a/src/discof/restore/utils/fd_zstd_dskip.c
+++ b/src/discof/restore/utils/fd_zstd_dskip.c
@@ -1,0 +1,306 @@
+#include "fd_zstd_dskip.h"
+#include "../../../util/fd_util.h"
+#include <string.h>
+
+/* Zstandard format constants */
+#define FD_ZSTD_MAGICNUMBER            0xFD2FB528U
+#define FD_ZSTD_MAGIC_SKIPPABLE_START  0x184D2A50U
+#define FD_ZSTD_MAGIC_SKIPPABLE_MASK   0xFFFFFFF0U
+#define FD_ZSTD_FRAMEIDSIZE            4
+#define FD_ZSTD_SKIPPABLEHEADERSIZE    8
+#define FD_ZSTD_BLOCKHEADERSIZE        3
+#define FD_ZSTD_FRAMEHEADERSIZE_PREFIX 5  /* min bytes to determine frame header size */
+#define FD_ZSTD_FRAMECHECKSUMSIZE      4
+
+/* Parser states */
+#define FD_ZSTD_DSKIP_STATE_MAGIC      0  /* Reading magic number */
+#define FD_ZSTD_DSKIP_STATE_SKIP_SIZE  1  /* Reading skippable frame size */
+#define FD_ZSTD_DSKIP_STATE_SKIP_DATA  2  /* Skipping skippable frame data */
+#define FD_ZSTD_DSKIP_STATE_FRAME_HDR  3  /* Reading frame header */
+#define FD_ZSTD_DSKIP_STATE_BLOCK_HDR  4  /* Reading block header */
+#define FD_ZSTD_DSKIP_STATE_BLOCK_DATA 5  /* Skipping block data */
+#define FD_ZSTD_DSKIP_STATE_CHECKSUM   6  /* Skipping frame checksum */
+
+fd_zstd_dskip_t *
+fd_zstd_dskip_init( fd_zstd_dskip_t * dskip ) {
+  memset( dskip, 0, sizeof( fd_zstd_dskip_t ) );
+  dskip->state = FD_ZSTD_DSKIP_STATE_MAGIC;
+  return dskip;
+}
+
+/* Helper to read little-endian integers */
+static inline uint
+fd_zstd_read_le32( uchar const * buf ) {
+  return (uint)buf[0] | ((uint)buf[1]<<8) | ((uint)buf[2]<<16) | ((uint)buf[3]<<24);
+}
+
+static inline uint
+fd_zstd_read_le24( uchar const * buf ) {
+  return (uint)buf[0] | ((uint)buf[1]<<8) | ((uint)buf[2]<<16);
+}
+
+/* Helper to calculate frame header size from frame header descriptor byte
+   Based on ZSTD_frameHeaderSize_internal */
+static inline ulong
+fd_zstd_frame_header_size( uchar fhd ) {
+  static uchar const did_field_size[4] = { 0, 1, 2, 4 };
+  static uchar const fcs_field_size[4] = { 0, 2, 4, 8 };
+
+  uint dict_id       = fhd & 3;
+  uint single_seg    = (fhd >> 5) & 1;
+  uint fcs_id        = fhd >> 6;
+
+  return (ulong)FD_ZSTD_FRAMEHEADERSIZE_PREFIX + (ulong)(!single_seg) +
+         (ulong)did_field_size[dict_id] + (ulong)fcs_field_size[fcs_id] +
+         (ulong)(single_seg && !fcs_id);
+}
+
+ulong
+fd_zstd_dskip_advance( fd_zstd_dskip_t * dskip,
+                       void const *      src,
+                       ulong             src_sz,
+                       ulong *           src_consumed ) {
+
+  uchar const * src_ptr = (uchar const *)src;
+  ulong consumed = 0UL;
+
+  while( consumed < src_sz ) {
+    ulong avail = src_sz - consumed;
+
+    switch( dskip->state ) {
+
+    case FD_ZSTD_DSKIP_STATE_MAGIC: {
+      /* Need to buffer the 4-byte magic number */
+      ulong need = FD_ZSTD_FRAMEIDSIZE - dskip->buf_sz;
+      ulong copy = (avail < need) ? avail : need;
+      memcpy( dskip->buf + dskip->buf_sz, src_ptr + consumed, copy );
+      dskip->buf_sz += copy;
+      consumed += copy;
+
+      if( dskip->buf_sz < FD_ZSTD_FRAMEIDSIZE ) {
+        /* Need more data */
+        *src_consumed = consumed;
+        return 1UL;
+      }
+
+      /* Parse magic number */
+      uint magic = fd_zstd_read_le32( dskip->buf );
+
+      if( (magic & FD_ZSTD_MAGIC_SKIPPABLE_MASK) == FD_ZSTD_MAGIC_SKIPPABLE_START ) {
+        /* Skippable frame */
+        dskip->state = FD_ZSTD_DSKIP_STATE_SKIP_SIZE;
+        dskip->buf_sz = 0;
+      } else if( magic == FD_ZSTD_MAGICNUMBER ) {
+        /* Regular Zstandard frame - keep magic in buffer for FRAME_HDR */
+        dskip->state = FD_ZSTD_DSKIP_STATE_FRAME_HDR;
+        /* buf_sz = 4, keep the magic bytes in buffer */
+      } else {
+        /* Invalid magic number */
+        *src_consumed = consumed;
+        return ULONG_MAX;
+      }
+      break;
+    }
+
+    case FD_ZSTD_DSKIP_STATE_SKIP_SIZE: {
+      /* Read 4-byte size field for skippable frame */
+      ulong need = FD_ZSTD_FRAMEIDSIZE - dskip->buf_sz;
+      ulong copy = (avail < need) ? avail : need;
+      memcpy( dskip->buf + dskip->buf_sz, src_ptr + consumed, copy );
+      dskip->buf_sz += copy;
+      consumed += copy;
+
+      if( dskip->buf_sz < FD_ZSTD_FRAMEIDSIZE ) {
+        *src_consumed = consumed;
+        return 1UL;
+      }
+
+      uint size = fd_zstd_read_le32( dskip->buf );
+      dskip->skip_rem = (ulong)size;
+      dskip->buf_sz = 0;
+
+      if( dskip->skip_rem == 0 ) {
+        /* Empty skippable frame - done with this frame */
+        dskip->state = FD_ZSTD_DSKIP_STATE_MAGIC;
+        *src_consumed = consumed;
+        return 0UL;
+      }
+
+      dskip->state = FD_ZSTD_DSKIP_STATE_SKIP_DATA;
+      break;
+    }
+
+    case FD_ZSTD_DSKIP_STATE_SKIP_DATA: {
+      /* Skip over skippable frame data */
+      ulong skip = (avail < dskip->skip_rem) ? avail : dskip->skip_rem;
+      consumed += skip;
+      dskip->skip_rem -= skip;
+
+      if( dskip->skip_rem == 0 ) {
+        /* Done with skippable frame */
+        dskip->state = FD_ZSTD_DSKIP_STATE_MAGIC;
+        *src_consumed = consumed;
+        return 0UL;
+      }
+
+      *src_consumed = consumed;
+      return 1UL;
+    }
+
+    case FD_ZSTD_DSKIP_STATE_FRAME_HDR: {
+      /* Need to read enough to determine frame header size */
+      if( dskip->buf_sz < FD_ZSTD_FRAMEHEADERSIZE_PREFIX ) {
+        ulong need = FD_ZSTD_FRAMEHEADERSIZE_PREFIX - dskip->buf_sz;
+        ulong copy = (avail < need) ? avail : need;
+        memcpy( dskip->buf + dskip->buf_sz, src_ptr + consumed, copy );
+        dskip->buf_sz += copy;
+        consumed += copy;
+
+        if( dskip->buf_sz < FD_ZSTD_FRAMEHEADERSIZE_PREFIX ) {
+          *src_consumed = consumed;
+          return 1UL;
+        }
+      }
+
+      /* Calculate full frame header size */
+      uchar fhd = dskip->buf[ FD_ZSTD_FRAMEHEADERSIZE_PREFIX - 1 ];
+      ulong hdr_size = fd_zstd_frame_header_size( fhd );
+
+      /* Read the rest of the header */
+      ulong need = hdr_size - dskip->buf_sz;
+      avail = src_sz - consumed;  /* Recalculate avail after consuming bytes above */
+      ulong copy = (avail < need) ? avail : need;
+      memcpy( dskip->buf + dskip->buf_sz, src_ptr + consumed, copy );
+      dskip->buf_sz += copy;
+      consumed += copy;
+
+      if( dskip->buf_sz < hdr_size ) {
+        *src_consumed = consumed;
+        return 1UL;
+      }
+
+      /* Parse frame header descriptor for checksum flag */
+      dskip->has_checksum = (fhd >> 2) & 1;
+      dskip->buf_sz = 0;
+      dskip->state = FD_ZSTD_DSKIP_STATE_BLOCK_HDR;
+      break;
+    }
+
+    case FD_ZSTD_DSKIP_STATE_BLOCK_HDR: {
+      /* Read 3-byte block header */
+      ulong need = FD_ZSTD_BLOCKHEADERSIZE - dskip->buf_sz;
+      ulong copy = (avail < need) ? avail : need;
+      memcpy( dskip->buf + dskip->buf_sz, src_ptr + consumed, copy );
+      dskip->buf_sz += copy;
+      consumed += copy;
+
+      if( dskip->buf_sz < FD_ZSTD_BLOCKHEADERSIZE ) {
+        *src_consumed = consumed;
+        return 1UL;
+      }
+
+      /* Parse block header */
+      uint block_hdr = fd_zstd_read_le24( dskip->buf );
+      uint last_block = block_hdr & 1;
+      uint block_type = (block_hdr >> 1) & 3;
+      uint block_size = block_hdr >> 3;
+
+      /* Block types: 0=raw, 1=rle, 2=compressed, 3=reserved */
+
+      /* Check for reserved block type */
+      if( block_type == 3 ) {
+        *src_consumed = consumed;
+        return ULONG_MAX;
+      }
+
+      /* RLE blocks store only 1 byte (the byte to repeat) */
+      if( block_type == 1 ) {
+        block_size = 1;
+      }
+
+      dskip->skip_rem = (ulong)block_size;
+      dskip->last_block = last_block;
+      dskip->buf_sz = 0;
+
+      if( dskip->skip_rem == 0 ) {
+        /* Empty block */
+        if( last_block ) {
+          /* Last block and empty, check for checksum */
+          if( dskip->has_checksum ) {
+            dskip->skip_rem = FD_ZSTD_FRAMECHECKSUMSIZE;
+            dskip->state = FD_ZSTD_DSKIP_STATE_CHECKSUM;
+          } else {
+            /* Frame complete */
+            dskip->state = FD_ZSTD_DSKIP_STATE_MAGIC;
+            *src_consumed = consumed;
+            return 0UL;
+          }
+        } else {
+          /* Not last block and empty, go to next block */
+          dskip->state = FD_ZSTD_DSKIP_STATE_BLOCK_HDR;
+        }
+      } else {
+        /* Block has data to skip */
+        dskip->state = FD_ZSTD_DSKIP_STATE_BLOCK_DATA;
+      }
+      break;
+    }
+
+    case FD_ZSTD_DSKIP_STATE_BLOCK_DATA: {
+      /* Skip over block data */
+      ulong skip = (avail < dskip->skip_rem) ? avail : dskip->skip_rem;
+      consumed += skip;
+      dskip->skip_rem -= skip;
+
+      if( dskip->skip_rem > 0 ) {
+        *src_consumed = consumed;
+        return 1UL;
+      }
+
+      /* Block data consumed, check if this was the last block */
+      if( dskip->last_block ) {
+        /* Last block completed, check for checksum */
+        if( dskip->has_checksum ) {
+          dskip->skip_rem = FD_ZSTD_FRAMECHECKSUMSIZE;
+          dskip->state = FD_ZSTD_DSKIP_STATE_CHECKSUM;
+        } else {
+          /* Frame complete */
+          dskip->state = FD_ZSTD_DSKIP_STATE_MAGIC;
+          *src_consumed = consumed;
+          return 0UL;
+        }
+      } else {
+        /* More blocks to read */
+        dskip->buf_sz = 0;
+        dskip->state = FD_ZSTD_DSKIP_STATE_BLOCK_HDR;
+      }
+      break;
+    }
+
+    case FD_ZSTD_DSKIP_STATE_CHECKSUM: {
+      /* Skip 4-byte checksum */
+      ulong skip = (avail < dskip->skip_rem) ? avail : dskip->skip_rem;
+      consumed += skip;
+      dskip->skip_rem -= skip;
+
+      if( dskip->skip_rem > 0 ) {
+        *src_consumed = consumed;
+        return 1UL;
+      }
+
+      /* Frame complete */
+      dskip->state = FD_ZSTD_DSKIP_STATE_MAGIC;
+      *src_consumed = consumed;
+      return 0UL;
+    }
+
+    default:
+      *src_consumed = consumed;
+      return ULONG_MAX;
+    }
+  }
+
+  /* Consumed all input but haven't finished the frame yet */
+  *src_consumed = consumed;
+  return 1UL;
+}

--- a/src/discof/restore/utils/fd_zstd_dskip.h
+++ b/src/discof/restore/utils/fd_zstd_dskip.h
@@ -1,0 +1,40 @@
+#ifndef HEADER_fd_discof_restore_utils_fd_zstd_dskip_h
+#define HEADER_fd_discof_restore_utils_fd_zstd_dskip_h
+
+/* fd_zstd_dskip.h provides an API to skip through Zstandard compressed
+   frames.  This is useful for when multiple threads take turns
+   decompressing frames from the same compressed byte stream. */
+
+#include "../../../util/fd_util_base.h"
+
+struct fd_zstd_dskip {
+  uchar buf[ 32 ];      /* Buffer for partial headers */
+  ulong buf_sz;         /* Number of bytes in buffer */
+  ulong skip_rem;       /* Bytes remaining to skip in current element */
+  uint  state;          /* Current parser state */
+  uint  has_checksum;   /* Whether current frame has checksum */
+  uint  last_block;     /* Whether current block is the last in frame */
+};
+
+typedef struct fd_zstd_dskip fd_zstd_dskip_t;
+
+FD_PROTOTYPES_BEGIN
+
+fd_zstd_dskip_t *
+fd_zstd_dskip_init( fd_zstd_dskip_t * dskip );
+
+/* fd_zstd_dskip_advance skips through Zstandard compressed data.
+   *src_consumed is set to the number of bytes consumed.  Returns
+   ULONG_MAX on decompress error.  Returns 1UL if everything was
+   skipped, but the current frame has not yet ended.  Returns 0UL on end
+   of Zstandard frame. */
+
+ulong
+fd_zstd_dskip_advance( fd_zstd_dskip_t * dskip,
+                       void const *      src,
+                       ulong             src_sz,
+                       ulong *           src_consumed );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_discof_restore_utils_fd_zstd_dskip_h */

--- a/src/discof/restore/utils/fuzz_zstd_dskip.c
+++ b/src/discof/restore/utils/fuzz_zstd_dskip.c
@@ -1,0 +1,69 @@
+#include "fd_zstd_dskip.h"
+
+#include "../../../util/fd_util.h"
+#include "../../../util/sanitize/fd_fuzz.h"
+
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <assert.h>
+#include <stdlib.h>
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  putenv( "FD_LOG_BACKTRACE=0" );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+  //fd_log_level_stderr_set(4);
+  //fd_log_level_logfile_set(4);
+  //fd_log_level_core_set(4);
+  return 0;
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * const data,
+                        ulong         const size ) {
+  if( FD_UNLIKELY( size<8UL ) ) return -1;
+  uint rng_seed = (uint)fd_ulong_hash( FD_LOAD( ulong, data+size-8 ) );
+  fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, (uint)rng_seed, 0UL ) );
+
+  fd_zstd_dskip_t dskip0, dskip1;
+  fd_zstd_dskip_init( &dskip0 );
+  fd_zstd_dskip_init( &dskip1 );
+
+  ulong off = 0UL;
+  while( off<size ) {
+    ulong rem = size-off;
+    /* One-shot parse */
+
+    ulong actual0_sz;
+    ulong actual0_res = fd_zstd_dskip_advance( &dskip0, data+off, rem, &actual0_sz );
+
+    /* Streaming parse */
+
+    ulong actual1_sz  = 0UL;
+    ulong actual1_res = ULONG_MAX;
+    ulong off1 = off;
+    do {
+      ulong rem1 = size-off1;
+      ulong frag_sz = fd_ulong_min( fd_rng_uint( rng )&15UL, rem1 );
+      ulong actual2_sz = 0UL;
+      actual1_res = fd_zstd_dskip_advance( &dskip1, data+off1, frag_sz, &actual2_sz );
+      actual1_sz += actual2_sz;
+      if( actual1_res!=1UL ) break;
+      off1 += frag_sz;
+    } while( off1<size );
+
+    assert( actual0_res==actual1_res );
+    if( actual0_res!=0UL ) break;
+    assert( actual0_sz==actual1_sz );
+    off += actual0_sz;
+  }
+  assert( off<=size );
+
+  fd_rng_delete( fd_rng_leave( rng ) );
+  FD_FUZZ_MUST_BE_COVERED;
+  return 0;
+}

--- a/src/discof/restore/utils/fuzz_zstd_dskip_diff.c
+++ b/src/discof/restore/utils/fuzz_zstd_dskip_diff.c
@@ -1,0 +1,108 @@
+#include "fd_zstd_dskip.h"
+
+#include "../../../util/fd_util.h"
+#include "../../../util/sanitize/fd_fuzz.h"
+
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <zstd.h>
+#include <zstd_errors.h>
+
+/* fuzz_zstd_dskip_diff compares the behavior of fd_zstd_dskip against
+   libzstd's ZSTD_findFrameCompressedSize.  The fuzzer chunks the input
+   data randomly to test streaming behavior. */
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  putenv( "FD_LOG_BACKTRACE=0" );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+
+  /* Disable parsing error logging but allow printf */
+  fd_log_level_stderr_set(4);
+  fd_log_level_logfile_set(4);
+  fd_log_level_core_set(4);
+  return 0;
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * const data,
+                        ulong         const size ) {
+  if( FD_UNLIKELY( size<8UL ) ) return -1;
+  uint rng_seed = (uint)fd_ulong_hash( FD_LOAD( ulong, data+size-8 ) );
+  fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, (uint)rng_seed, 0UL ) );
+
+  fd_zstd_dskip_t dskip0, dskip1;
+  fd_zstd_dskip_init( &dskip0 );
+  fd_zstd_dskip_init( &dskip1 );
+
+  ulong off = 0UL;
+  while( off<size ) {
+    ulong rem = size-off;
+    ulong expected_res = ZSTD_findFrameCompressedSize( data+off, rem );
+
+    /* One-shot parse */
+
+    ulong actual0_sz;
+    ulong actual0_res = fd_zstd_dskip_advance( &dskip0, data+off, rem, &actual0_sz );
+
+    /* Streaming parse */
+
+    ulong actual1_sz  = 0UL;
+    ulong actual1_res = ULONG_MAX;
+    ulong off1 = off;
+    do {
+      ulong rem1 = size-off1;
+      ulong frag_sz = fd_ulong_min( fd_rng_uint( rng )&15UL, rem1 );
+      ulong actual2_sz = 0UL;
+      actual1_res = fd_zstd_dskip_advance( &dskip1, data+off1, frag_sz, &actual1_sz );
+      actual1_sz += actual2_sz;
+      if( actual1_res!=1UL ) break;
+      off1 += frag_sz;
+    } while( off1<size );
+
+    /* Verify result */
+
+    if( ZSTD_isError( expected_res ) ) {
+      if( ZSTD_getErrorCode( expected_res )==ZSTD_error_srcSize_wrong ) {
+        if( actual0_res!=1UL ) {
+          fprintf( stderr, "FAIL: off=%lu rem=%lu expected_res=ZSTD_error_srcSize_wrong actual0_res=%lu actual0_sz=%lu\n",
+                   off, rem, actual0_res, actual0_sz );
+          fprintf( stderr, "dskip0 state: state=%u buf_sz=%lu skip_rem=%lu has_checksum=%u last_block=%u\n",
+                   dskip0.state, dskip0.buf_sz, dskip0.skip_rem, dskip0.has_checksum, dskip0.last_block );
+          fflush( stderr );
+        }
+        assert( actual0_res==1UL );
+        assert( actual1_res==1UL );
+      } else {
+        if( actual0_res!=ULONG_MAX ) {
+          fprintf( stderr, "FAIL: off=%lu rem=%lu expected_res=error_%s actual0_res=%lu actual0_sz=%lu\n",
+                   off, rem, ZSTD_getErrorName(expected_res), actual0_res, actual0_sz );
+          fprintf( stderr, "dskip0 state: state=%u buf_sz=%lu skip_rem=%lu has_checksum=%u last_block=%u\n",
+                   dskip0.state, dskip0.buf_sz, dskip0.skip_rem, dskip0.has_checksum, dskip0.last_block );
+          fflush( stderr );
+        }
+        assert( actual0_res==ULONG_MAX );
+        assert( actual1_res==ULONG_MAX );
+      }
+      break;
+    } else {
+      assert( actual0_res==0UL );
+      assert( actual1_res==0UL );
+      assert( actual0_sz==expected_res );
+      assert( actual1_sz==expected_res );
+      off += expected_res;
+    }
+  }
+  assert( off<=size );
+
+  fd_rng_delete( fd_rng_leave( rng ) );
+  FD_FUZZ_MUST_BE_COVERED;
+  return 0;
+}

--- a/src/discof/restore/utils/test_zstd_dskip.c
+++ b/src/discof/restore/utils/test_zstd_dskip.c
@@ -1,0 +1,64 @@
+#include "fd_zstd_dskip.h"
+#include "../../../util/fd_util.h"
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+  if( argc!=2 ) {
+    fprintf( stderr, "Usage: %s file.zst\n", argv[0] );
+    return EXIT_FAILURE;
+  }
+
+  FILE * file = fopen( argv[1], "rb" );
+  if( FD_UNLIKELY( !file ) ) FD_LOG_ERR(( "fopen(%s,\"rb\") failed (%i-%s)", argv[1], errno, fd_io_strerror( errno ) ));
+
+  fd_zstd_dskip_t dskip[1];
+  fd_zstd_dskip_init( dskip );
+
+  ulong frame_idx = 0UL;
+  ulong frame_start = 0UL;
+  ulong total_offset = 0UL;
+
+  for(;;) {
+    uchar buf[ 2 ];
+    size_t nread = fread( buf, 1, sizeof(buf), file );
+    if( nread==0 ) {
+      if( feof( file ) ) break;
+      FD_LOG_ERR(( "fread(%s) failed (%i-%s)", argv[1], errno, fd_io_strerror( errno ) ));
+    }
+    ulong offset = 0UL;
+    while( offset<nread ) {
+      ulong src_consumed;
+      ulong res = fd_zstd_dskip_advance( dskip, buf+offset, nread-offset, &src_consumed );
+      if( FD_UNLIKELY( res==ULONG_MAX ) ) {
+        FD_LOG_ERR(( "fd_zstd_dskip_advance failed at offset %lu (state=%u, buf_sz=%lu, skip_rem=%lu)",
+                     total_offset+offset, dskip->state, dskip->buf_sz, dskip->skip_rem ));
+      }
+      if( FD_UNLIKELY( src_consumed>(nread-offset) ) ) {
+        FD_LOG_ERR(( "src_consumed=%lu > avail=%lu (state=%u, buf_sz=%lu)",
+                     src_consumed, nread-offset, dskip->state, dskip->buf_sz ));
+      }
+      FD_TEST( src_consumed<=(nread-offset) );
+      offset += src_consumed;
+      total_offset += src_consumed;
+      if( res==0UL ) {
+        FD_LOG_NOTICE(( "Frame %lu at [%lu,%lu) bytes", frame_idx, frame_start, total_offset ));
+        frame_idx++;
+        frame_start = total_offset;
+      }
+    }
+    FD_TEST( offset==nread );
+  }
+
+  if( FD_UNLIKELY( 0!=fclose( file ) ) ) {
+    FD_LOG_ERR(( "fclose(%s) failed (%i-%s)", argv[1], errno, fd_io_strerror( errno ) ));
+  }
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Updates Firedancer's snapshot load topology to run multiple Zstandard decompressor tiles in parallel, taking turns compressing frames produced by the writer in #7401.

This entirely eliminates the Zstandard bottleneck, decompressing a mainnet snapshot in 22 seconds with 16 threads on Zen 4.