### PR TITLE
flamenco, vm: forbid precompiles from accessing CPI instruction datas

### DIFF
--- a/src/flamenco/runtime/program/fd_precompiles.c
+++ b/src/flamenco/runtime/program/fd_precompiles.c
@@ -97,7 +97,7 @@ fd_precompile_get_instr_data( fd_exec_instr_ctx_t * ctx,
 
   } else {
 
-    if( FD_UNLIKELY( index>=ctx->runtime->instr.info_cnt ) )
+    if( FD_UNLIKELY( index>=TXN( ctx->txn_in->txn )->instr_cnt ) )
       return FD_EXECUTOR_PRECOMPILE_ERR_DATA_OFFSET;
 
     fd_instr_info_t const * instr = &ctx->runtime->instr.infos[ index ];


### PR DESCRIPTION
Fixing `fd_precompile_get_instr_data` to make precompiles access only top-level ixs data.