### PR TITLE
runtime: bump number of accounts a txn can input

### DIFF
--- a/src/flamenco/runtime/fd_runtime_helpers.h
+++ b/src/flamenco/runtime/fd_runtime_helpers.h
@@ -15,9 +15,9 @@
 #define HEADER_fd_src_flamenco_runtime_fd_runtime_helpers_h
 
 struct fd_exec_accounts {
-  uchar rollback_nonce_account_mem[ FD_ACC_TOT_SZ_MAX ]                       __attribute__((aligned(FD_ACCOUNT_REC_ALIGN)));
-  uchar rollback_fee_payer_mem[ FD_ACC_TOT_SZ_MAX ]                           __attribute__((aligned(FD_ACCOUNT_REC_ALIGN)));
-  uchar accounts_mem[ FD_RUNTIME_WRITABLE_ACCOUNTS_MAX ][ FD_ACC_TOT_SZ_MAX ] __attribute__((aligned(FD_ACCOUNT_REC_ALIGN)));
+  uchar rollback_nonce_account_mem[ FD_ACC_TOT_SZ_MAX ]           __attribute__((aligned(FD_ACCOUNT_REC_ALIGN)));
+  uchar rollback_fee_payer_mem[ FD_ACC_TOT_SZ_MAX ]               __attribute__((aligned(FD_ACCOUNT_REC_ALIGN)));
+  uchar accounts_mem[ MAX_TX_ACCOUNT_LOCKS ][ FD_ACC_TOT_SZ_MAX ] __attribute__((aligned(FD_ACCOUNT_REC_ALIGN)));
 };
 typedef struct fd_exec_accounts fd_exec_accounts_t;
 


### PR DESCRIPTION
this is a temporary fix, and will be undone when account memory is pooled