### PR TITLE
net: fix IPv6 packet drops

### DIFF
--- a/src/disco/net/xdp/fd_xdp_tile.c
+++ b/src/disco/net/xdp/fd_xdp_tile.c
@@ -918,13 +918,15 @@ net_rx_packet( fd_net_ctx_t * ctx,
       ctx->metrics.rx_gre_ignored_cnt++; // drop. No gre interface in netdev table
       return;
     }
-    if( FD_UNLIKELY( FD_IP4_GET_VERSION( *iphdr )!=0x4 ) ) {
-      ctx->metrics.rx_gre_inv_pkt_cnt++; // drop. IP version!=IPv4
+    ulong gre_ipver = FD_IP4_GET_VERSION( *iphdr );
+    ulong gre_iplen = FD_IP4_GET_LEN( *iphdr );
+    if( FD_UNLIKELY( gre_ipver!=0x4 || gre_iplen<20 ) ) {
+      FD_DTRACE_PROBE( net_tile_err_rx_noip );
+      ctx->metrics.rx_gre_inv_pkt_cnt++; /* drop IPv6 packets */
       return;
     }
 
-    ulong overhead = FD_IP4_GET_LEN( *iphdr ) + sizeof(fd_gre_hdr_t);
-
+    ulong overhead = gre_iplen + sizeof(fd_gre_hdr_t);
     if( FD_UNLIKELY( (uchar *)iphdr+overhead+sizeof(fd_ip4_hdr_t)>packet_end ) ) {
       FD_DTRACE_PROBE( net_tile_err_rx_undersz );
       ctx->metrics.rx_undersz_cnt++;  // inner ip4 header invalid
@@ -946,13 +948,16 @@ net_rx_packet( fd_net_ctx_t * ctx,
   ulong ctl         = umem_off & 0x3fUL;
 
   /* Filter for UDP/IPv4 packets. */
-  if( FD_UNLIKELY( ( FD_IP4_GET_VERSION( *iphdr )!=0x4 ) ||
-                   ( iphdr->protocol!=FD_IP4_HDR_PROTOCOL_UDP ) ) ) return;
+  ulong ipver = FD_IP4_GET_VERSION( *iphdr );
+  ulong iplen = FD_IP4_GET_LEN    ( *iphdr );
+  if( FD_UNLIKELY( ipver!=0x4 || iplen<20 ||
+                   iphdr->protocol!=FD_IP4_HDR_PROTOCOL_UDP ) ) {
+    FD_DTRACE_PROBE( net_tile_err_rx_noip );
+    ctx->metrics.rx_undersz_cnt++; /* drop IPv6 packets */
+    return;
+  }
 
-  /* IPv4 is variable-length, so lookup IHL to find start of UDP */
-  uint iplen        = FD_IP4_GET_LEN( *iphdr );
   uchar const * udp = (uchar *)iphdr + iplen;
-
   if( FD_UNLIKELY( udp+sizeof(fd_udp_hdr_t) > packet_end ) ) {
     FD_DTRACE_PROBE( net_tile_err_rx_undersz );
     ctx->metrics.rx_undersz_cnt++;

--- a/src/waltz/ebpf/fd_ebpf_asm.h
+++ b/src/waltz/ebpf/fd_ebpf_asm.h
@@ -29,6 +29,7 @@
 #define FD_EBPF_ASM_jeq_imm( dst, imm, off ) FD_EBPF_ASM_JUMP_COND_IMM( 0x15, dst, imm, off )
 #define FD_EBPF_ASM_jne_imm( dst, imm, off ) FD_EBPF_ASM_JUMP_COND_IMM( 0x55, dst, imm, off )
 #define FD_EBPF_ASM_jgt_reg( dst, src, off ) FD_EBPF_ASM_JUMP_COND_REG( 0x2d, dst, src, off )
+#define FD_EBPF_ASM_jlt_imm( dst, imm, off ) FD_EBPF_ASM_JUMP_COND_IMM( 0xa5, dst, imm, off )
 
 #define FD_EBPF_ASM_call( off ) (0x85 | ((off&0xFFFFFFFFUL)<<32))
 

--- a/src/waltz/xdp/fd_xdp1.c
+++ b/src/waltz/xdp/fd_xdp1.c
@@ -108,6 +108,7 @@ fd_xdp_gen_program( ulong          code_buf[ 512 ],
   *(code++) = FD_EBPF( ldxb, r4, r2, 0                          );  // r4 = ip4_hdr->verihl
   *(code++) = FD_EBPF( and64_imm, r4, 0x0f                      );  // r4 = ip4_hdr->ihl (lsb of ip4_hrd->verihl)
   *(code++) = FD_EBPF( lsh64_imm, r4, 2                         );  // r4 = ip4_hdr->ihl*4 (length of ipv4 header)
+  *(code++) = FD_EBPF( jlt_imm, r4, 20, LBL_PASS                );  // if r4<20 goto LBL_PASS
   *(code++) = FD_EBPF( add64_reg, r4, r2                        );  // r4 = &ip4_hdr + length of ip4_hdr = start of next hdr
 
   /* Check if the next hdr is udp or gre */
@@ -160,6 +161,7 @@ fd_xdp_gen_program( ulong          code_buf[ 512 ],
   *(code++) = FD_EBPF( ldxb, r4, r2, 0                          );  // r4 = inner ip4_hdr->verihl
   *(code++) = FD_EBPF( and64_imm, r4, 0x0f                      );  // r4 = inner ip4_hdr->ihl
   *(code++) = FD_EBPF( lsh64_imm, r4, 2                         );  // r4 = ip4_hdr->ihl*4 (length of ipv4 header)
+  *(code++) = FD_EBPF( jlt_imm, r4, 20, LBL_PASS                );  // if r4<20 goto LBL_PASS
   *(code++) = FD_EBPF( add64_reg, r4, r2                        );  // r4 = start of udp_hdr
 
   /*


### PR DESCRIPTION
Fixes an issue where IPv6 traffic unrelated to Firedancer is dropped by the BPF program.