### PR TITLE
flamenco, vm: implement increase_cpi_account_info_limit

### DIFF
--- a/src/flamenco/features/fd_features_generated.c
+++ b/src/flamenco/features/fd_features_generated.c
@@ -1709,6 +1709,12 @@ fd_feature_id_t const ids[] = {
     .name                      = "enforce_fixed_fec_set",
     .cleaned_up                = {UINT_MAX, UINT_MAX, UINT_MAX} },
 
+  { .index                     = offsetof(fd_features_t, increase_cpi_account_info_limit)>>3,
+    .id                        = {"\xef\x31\xcf\xa8\x88\x28\x79\x55\xd9\xb1\x72\x19\xda\x33\x5d\x8e\x8b\x8f\x5e\x3f\x41\x49\xe5\x9a\x94\x65\xa6\x44\xef\x9c\xa2\xf6"},
+                                 /* H6iVbVaDZgDphcPbcZwc5LoznMPWQfnJ1AM7L1xzqvt5 */
+    .name                      = "increase_cpi_account_info_limit",
+    .cleaned_up                = {UINT_MAX, UINT_MAX, UINT_MAX} },
+
   { .index = ULONG_MAX }
 };
 /* TODO replace this with fd_map_perfect */
@@ -1965,6 +1971,7 @@ fd_feature_id_query( ulong prefix ) {
   case 0x866094bbfe00a7c6: return &ids[ 247 ];
   case 0x7c4802b8ba3fa849: return &ids[ 248 ];
   case 0xab2a2311ca83eb09: return &ids[ 249 ];
+  case 0x55792888a8cf31ef: return &ids[ 250 ];
   default: break;
   }
   return NULL;
@@ -2220,4 +2227,5 @@ FD_STATIC_ASSERT( offsetof( fd_features_t, poseidon_enforce_padding             
 FD_STATIC_ASSERT( offsetof( fd_features_t, relax_intrabatch_account_locks                          )>>3==247UL, layout );
 FD_STATIC_ASSERT( offsetof( fd_features_t, provide_instruction_data_offset_in_vm_r2                )>>3==248UL, layout );
 FD_STATIC_ASSERT( offsetof( fd_features_t, enforce_fixed_fec_set                                   )>>3==249UL, layout );
+FD_STATIC_ASSERT( offsetof( fd_features_t, increase_cpi_account_info_limit                         )>>3==250UL, layout );
 FD_STATIC_ASSERT( sizeof( fd_features_t )>>3==FD_FEATURE_ID_CNT, layout );

--- a/src/flamenco/features/fd_features_generated.h
+++ b/src/flamenco/features/fd_features_generated.h
@@ -8,10 +8,10 @@
 #endif
 
 /* FEATURE_ID_CNT is the number of features in ids */
-#define FD_FEATURE_ID_CNT (250UL)
+#define FD_FEATURE_ID_CNT (251UL)
 
 /* Feature set ID calculated from all feature names */
-#define FD_FEATURE_SET_ID (3332207143U)
+#define FD_FEATURE_SET_ID (1776864602U)
 
 union fd_features {
   ulong f[ FD_FEATURE_ID_CNT ];
@@ -266,5 +266,6 @@ union fd_features {
     /* 0x866094bbfe00a7c6 */ ulong relax_intrabatch_account_locks;
     /* 0x7c4802b8ba3fa849 */ ulong provide_instruction_data_offset_in_vm_r2;
     /* 0xab2a2311ca83eb09 */ ulong enforce_fixed_fec_set;
+    /* 0x55792888a8cf31ef */ ulong increase_cpi_account_info_limit;
   };
 };

--- a/src/flamenco/features/feature_map.json
+++ b/src/flamenco/features/feature_map.json
@@ -248,5 +248,6 @@
   {"name":"poseidon_enforce_padding","pubkey":"poUdAqRXXsNmfqAZ6UqpjbeYgwBygbfQLEvWSqVhSnb"},
   {"name":"relax_intrabatch_account_locks","pubkey":"ENTRYnPAoT5Swwx73YDGzMp3XnNH1kxacyvLosRHza1i"},
   {"name":"provide_instruction_data_offset_in_vm_r2","pubkey":"5xXZc66h4UdB6Yq7FzdBxBiRAFMMScMLwHxk2QZDaNZL"},
-  {"name":"enforce_fixed_fec_set","pubkey":"fixfecLZYMfkGzwq6NJA11Yw6KYztzXiK9QcL3K78in"}
+  {"name":"enforce_fixed_fec_set","pubkey":"fixfecLZYMfkGzwq6NJA11Yw6KYztzXiK9QcL3K78in"},
+  {"name":"increase_cpi_account_info_limit","pubkey":"H6iVbVaDZgDphcPbcZwc5LoznMPWQfnJ1AM7L1xzqvt5"}
 ]

--- a/src/flamenco/runtime/tests/run_backtest_all.sh
+++ b/src/flamenco/runtime/tests/run_backtest_all.sh
@@ -92,4 +92,5 @@ src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-413869565 -y 40 -m 1
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-376969880 -y 1 -m 2000000 -e 376969900
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l devnet-422969842 -y 1 -m 2000000 -e 422969848
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-376969880-r2 -y 1 -m 2000000 -e 376969900 -o 5xXZc66h4UdB6Yq7FzdBxBiRAFMMScMLwHxk2QZDaNZL
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-376969880-simd-339 -y 1 -m 2000000 -e 376969900 -o H6iVbVaDZgDphcPbcZwc5LoznMPWQfnJ1AM7L1xzqvt5
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l breakpoint-385786458 -y 1 -m 2000000 -e 385786458

--- a/src/flamenco/vm/fd_vm_base.h
+++ b/src/flamenco/vm/fd_vm_base.h
@@ -196,9 +196,25 @@ FD_PROTOTYPES_END
 #define FD_VM_CREATE_PROGRAM_ADDRESS_UNITS              (            1500UL)
 
 /* FD_VM_INVOKE_UNITS is the number of compute units consumed by an
-   invoke call (not including the cost incurred by the called program) */
+   invoke call (not including the cost incurred by the called program)
+   https://github.com/anza-xyz/agave/blob/v3.1.2/program-runtime/src/execution_budget.rs#L20-L21 */
 
 #define FD_VM_INVOKE_UNITS                              (            1000UL)
+
+/* FD_VM_INVOKE_UNITS_SIMD_0339 is the number of compute units consumed by
+   an invoke call (not including the cost incurred by the called program)
+   with SIMD-0339 (increase_cpi_account_info_limit) active.
+   https://github.com/anza-xyz/agave/blob/v3.1.2/program-runtime/src/execution_budget.rs#L22-L23 */
+#define FD_VM_INVOKE_UNITS_SIMD_0339                    (             946UL)
+
+/* SIMD-0339 uses a fixed size (80 bytes) to bill each account info:
+   - 32 bytes for account address
+   - 32 bytes for owner address
+   - 8 bytes for lamports
+   - 8 bytes for data length
+   https://github.com/anza-xyz/agave/blob/v3.1.2/program-runtime/src/cpi.rs#L63-L68
+ */
+#define FD_VM_ACCOUNT_INFO_BYTE_SIZE                     (             80UL)
 
 /* FD_VM_MAX_INVOKE_STACK_HEIGHT is the maximum program instruction
    invocation stack height. Invocation stack height starts at 1 for

--- a/src/flamenco/vm/syscall/Local.mk
+++ b/src/flamenco/vm/syscall/Local.mk
@@ -10,5 +10,7 @@ $(call make-unit-test,test_vm_syscalls,test_vm_syscalls,fd_flamenco fd_funk fd_u
 $(call run-unit-test,test_vm_syscalls)
 $(call make-unit-test,test_vm_syscall_curve,test_vm_syscall_curve,fd_flamenco fd_funk fd_util fd_ballet)
 $(call run-unit-test,test_vm_syscall_curve)
+$(call make-unit-test,test_vm_increase_cpi_account_info_limit,test_vm_increase_cpi_account_info_limit,fd_flamenco fd_funk fd_util fd_ballet)
+$(call run-unit-test,test_vm_increase_cpi_account_info_limit)
 endif
 endif

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
@@ -228,13 +228,32 @@ fd_vm_prepare_instruction( fd_instr_info_t *        callee_instr,
    https://github.com/anza-xyz/agave/blob/838c1952595809a31520ff1603a13f2c9123aa51/programs/bpf_loader/src/syscalls/cpi.rs#L1011 */
 
 #define FD_CPI_MAX_ACCOUNT_INFOS           (128UL)
+#define FD_CPI_MAX_ACCOUNT_INFOS_SIMD_0339 (255UL)
+
 /* This is just encoding what Agave says in their code comments into a
    compile-time check, so if anyone ever inadvertently changes one of
    the limits, they will have to take a look. */
 FD_STATIC_ASSERT( FD_CPI_MAX_ACCOUNT_INFOS==MAX_TX_ACCOUNT_LOCKS, cpi_max_account_info );
+
+/* https://github.com/anza-xyz/agave/blob/v3.1.2/program-runtime/src/cpi.rs#L168-L180 */
 static inline ulong
 get_cpi_max_account_infos( fd_bank_t * bank ) {
-  return fd_ulong_if( FD_FEATURE_ACTIVE_BANK( bank, increase_tx_account_lock_limit ), FD_CPI_MAX_ACCOUNT_INFOS, 64UL );
+  if( FD_LIKELY( FD_FEATURE_ACTIVE_BANK( bank, increase_cpi_account_info_limit ) ) ) {
+    return FD_CPI_MAX_ACCOUNT_INFOS_SIMD_0339;
+  } else if( FD_LIKELY( FD_FEATURE_ACTIVE_BANK( bank, increase_tx_account_lock_limit ) ) ) {
+    return FD_CPI_MAX_ACCOUNT_INFOS;
+  } else {
+    return 64UL;
+  }
+}
+
+/* https://github.com/anza-xyz/agave/blob/v3.1.2/program-runtime/src/execution_budget.rs#L25-L31 */
+static inline ulong
+get_cpi_invoke_unit_cost( fd_bank_t * bank ) {
+  return fd_ulong_if(
+    FD_FEATURE_ACTIVE_BANK( bank, increase_cpi_account_info_limit ),
+    FD_VM_INVOKE_UNITS_SIMD_0339,
+    FD_VM_INVOKE_UNITS );
 }
 
 /* Maximum CPI instruction accounts. 255 was chosen to ensure that instruction

--- a/src/flamenco/vm/syscall/test_vm_increase_cpi_account_info_limit.c
+++ b/src/flamenco/vm/syscall/test_vm_increase_cpi_account_info_limit.c
@@ -1,0 +1,506 @@
+/* Test for SIMD-0339 increase_cpi_account_info_limit
+
+   This test makes a CPI call (a simple system program transfer) with
+   all permuatations of the increase_cpi_account_info_limit and
+   increase_tx_account_lock_limit features.
+
+   Each test asserts that the error code is correct and the correct amount
+   of CUs have been charged. */
+
+#include "fd_vm_syscall.h"
+#include "../test_vm_util.h"
+#include "../../runtime/fd_bank.h"
+#include "../../runtime/fd_runtime.h"
+#include "../../runtime/fd_system_ids.h"
+#include "../../log_collector/fd_log_collector.h"
+
+#define TEST_SYSTEM_PROGRAM_TRANSFER_DISCRIMINANT (2U)
+#define TEST_VM_ACCOUNT_INFO_BYTE_SIZE            (80UL)
+#define TEST_VM_CPI_BYTES_PER_UNIT                (250UL)
+#define TEST_SYSTEM_PROGRAM_EXECUTE_CU            (150UL)
+#define TEST_WKSP_TAG                             (1234UL)
+
+static fd_pubkey_t const test_transfer_from_pubkey = {{
+  0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+  0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+  0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+  0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11
+}};
+
+static fd_pubkey_t const test_transfer_to_pubkey = {{
+  0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+  0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+  0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+  0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22
+}};
+
+struct test_env {
+  fd_wksp_t *             wksp;
+  fd_runtime_t *          runtime;
+  fd_sha256_t             sha[1];
+  fd_vm_t                 vm[1];
+  fd_exec_instr_ctx_t     instr_ctx[1];
+  fd_bank_t               bank[1];
+  fd_txn_out_t            txn_out[1];
+  fd_instr_info_t         instr[1];
+  uchar                   rodata[100];
+  fd_account_meta_t *     source_meta;
+  fd_account_meta_t *     dest_meta;
+  fd_account_meta_t *     sysprog_meta;
+  fd_vm_acc_region_meta_t acc_region_metas[3];
+  fd_log_collector_t      log_collector[1];
+};
+typedef struct test_env test_env_t;
+
+static inline ulong
+expected_account_info_cu( ulong num_acct_infos ) {
+  return (num_acct_infos * TEST_VM_ACCOUNT_INFO_BYTE_SIZE) / TEST_VM_CPI_BYTES_PER_UNIT;
+}
+
+static void
+setup_cpi_memory( fd_vm_t * vm,
+                  ulong     num_acct_infos,
+                  ulong *   out_instr_va,
+                  ulong *   out_acct_infos_va ) {
+
+  ulong heap_offset = 0UL;
+
+  fd_vm_c_instruction_t * instr = (fd_vm_c_instruction_t *)&vm->heap[heap_offset];
+  *out_instr_va = FD_VM_MEM_MAP_HEAP_REGION_START + heap_offset;
+  heap_offset += sizeof(fd_vm_c_instruction_t);
+
+  ulong program_id_offset = heap_offset;
+  fd_pubkey_t * program_id = (fd_pubkey_t *)&vm->heap[heap_offset];
+  memcpy( program_id, &fd_solana_system_program_id, sizeof(fd_pubkey_t) );
+  heap_offset += sizeof(fd_pubkey_t);
+
+  ulong acct_metas_offset = heap_offset;
+  fd_vm_c_account_meta_t * meta0 = (fd_vm_c_account_meta_t *)&vm->heap[heap_offset];
+  heap_offset += sizeof(fd_vm_c_account_meta_t);
+  fd_vm_c_account_meta_t * meta1 = (fd_vm_c_account_meta_t *)&vm->heap[heap_offset];
+  heap_offset += sizeof(fd_vm_c_account_meta_t);
+
+  ulong meta_pubkey0_offset = heap_offset;
+  fd_pubkey_t * meta_pubkey0 = (fd_pubkey_t *)&vm->heap[heap_offset];
+  memcpy( meta_pubkey0, &test_transfer_from_pubkey, sizeof(fd_pubkey_t) );
+  heap_offset += sizeof(fd_pubkey_t);
+
+  ulong meta_pubkey1_offset = heap_offset;
+  fd_pubkey_t * meta_pubkey1 = (fd_pubkey_t *)&vm->heap[heap_offset];
+  memcpy( meta_pubkey1, &test_transfer_to_pubkey, sizeof(fd_pubkey_t) );
+  heap_offset += sizeof(fd_pubkey_t);
+
+  meta0->pubkey_addr = FD_VM_MEM_MAP_HEAP_REGION_START + meta_pubkey0_offset;
+  meta0->is_signer   = 1;
+  meta0->is_writable = 1;
+
+  meta1->pubkey_addr = FD_VM_MEM_MAP_HEAP_REGION_START + meta_pubkey1_offset;
+  meta1->is_signer   = 0;
+  meta1->is_writable = 1;
+
+  ulong instr_data_offset = heap_offset;
+  uint * discriminant = (uint *)&vm->heap[heap_offset];
+  *discriminant = TEST_SYSTEM_PROGRAM_TRANSFER_DISCRIMINANT;
+  heap_offset += sizeof(uint);
+
+  ulong * lamports = (ulong *)&vm->heap[heap_offset];
+  *lamports = 0UL;
+  heap_offset += sizeof(ulong);
+
+  heap_offset = fd_ulong_align_up( heap_offset, 8UL );
+
+  ulong acct_infos_offset = heap_offset;
+  *out_acct_infos_va = FD_VM_MEM_MAP_HEAP_REGION_START + acct_infos_offset;
+
+  ulong acc_info_data_offset = heap_offset + num_acct_infos * sizeof(fd_vm_c_account_info_t);
+
+  for( ulong i = 0; i < num_acct_infos; i++ ) {
+    fd_vm_c_account_info_t * info = (fd_vm_c_account_info_t *)&vm->heap[heap_offset];
+
+    ulong pubkey_offset   = acc_info_data_offset + i * (sizeof(fd_pubkey_t) + sizeof(ulong));
+    ulong lamports_offset = pubkey_offset + sizeof(fd_pubkey_t);
+
+    fd_pubkey_t * pubkey = (fd_pubkey_t *)&vm->heap[pubkey_offset];
+    if( i == 0 ) {
+      memcpy( pubkey, &test_transfer_from_pubkey, sizeof(fd_pubkey_t) );
+    } else if( i == 1 ) {
+      memcpy( pubkey, &test_transfer_to_pubkey, sizeof(fd_pubkey_t) );
+    } else {
+      memset( pubkey->uc, (int)(0x30 + i), sizeof(fd_pubkey_t) );
+    }
+
+    ulong * info_lamports = (ulong *)&vm->heap[lamports_offset];
+    *info_lamports = (i == 0) ? 1000000UL : 0UL;
+
+    info->pubkey_addr   = FD_VM_MEM_MAP_HEAP_REGION_START + pubkey_offset;
+    info->lamports_addr = FD_VM_MEM_MAP_HEAP_REGION_START + lamports_offset;
+    info->data_sz       = 0UL;
+    info->data_addr     = 0UL;
+    info->owner_addr    = FD_VM_MEM_MAP_HEAP_REGION_START + program_id_offset;
+    info->rent_epoch    = 0UL;
+    info->is_signer     = (i == 0) ? 1 : 0;
+    info->is_writable   = (i < 2) ? 1 : 0;
+    info->executable    = 0;
+    heap_offset += sizeof(fd_vm_c_account_info_t);
+  }
+
+  instr->program_id_addr = FD_VM_MEM_MAP_HEAP_REGION_START + program_id_offset;
+  instr->accounts_addr   = FD_VM_MEM_MAP_HEAP_REGION_START + acct_metas_offset;
+  instr->accounts_len    = 2UL;
+  instr->data_addr       = FD_VM_MEM_MAP_HEAP_REGION_START + instr_data_offset;
+  instr->data_len        = sizeof(uint) + sizeof(ulong);
+}
+
+static void
+test_env_create( test_env_t * env,
+                 fd_wksp_t *  wksp,
+                 int          enable_increase_cpi_account_info_limit,
+                 int          enable_increase_tx_account_lock_limit ) {
+
+  memset( env, 0, sizeof(test_env_t) );
+  env->wksp = wksp;
+
+  env->runtime = fd_wksp_alloc_laddr( wksp, alignof(fd_runtime_t), sizeof(fd_runtime_t), TEST_WKSP_TAG );
+  FD_TEST( env->runtime );
+
+  fd_log_collector_init( env->log_collector, 0 );
+  env->runtime->log.log_collector = env->log_collector;
+
+  fd_sha256_t * sha = fd_sha256_join( fd_sha256_new( env->sha ) );
+  FD_TEST( sha );
+
+  fd_vm_t * vm = fd_vm_join( fd_vm_new( env->vm ) );
+  FD_TEST( vm );
+
+  test_vm_minimal_exec_instr_ctx( env->instr_ctx, env->runtime, env->bank, env->txn_out );
+
+  fd_features_t * features = fd_bank_features_modify( env->bank );
+  fd_features_disable_all( features );
+  fd_bank_slot_set( env->bank, 1UL );
+
+  if( enable_increase_cpi_account_info_limit ) features->increase_cpi_account_info_limit = 0UL;
+  if( enable_increase_tx_account_lock_limit )  features->increase_tx_account_lock_limit  = 0UL;
+  features->loosen_cpi_size_restriction = 0UL;
+
+  env->txn_out->accounts.cnt = 3;
+
+  memcpy( &env->txn_out->accounts.keys[0], &fd_solana_system_program_id, sizeof(fd_pubkey_t) );
+  env->sysprog_meta = fd_wksp_alloc_laddr( wksp, alignof(fd_account_meta_t), sizeof(fd_account_meta_t), TEST_WKSP_TAG );
+  memset( env->sysprog_meta, 0, sizeof(fd_account_meta_t) );
+  memcpy( env->sysprog_meta->owner, &fd_solana_native_loader_id, sizeof(fd_pubkey_t) );
+  env->sysprog_meta->executable = 1;
+  env->txn_out->accounts.metas[0] = env->sysprog_meta;
+
+  memcpy( &env->txn_out->accounts.keys[1], &test_transfer_from_pubkey, sizeof(fd_pubkey_t) );
+  env->source_meta = fd_wksp_alloc_laddr( wksp, alignof(fd_account_meta_t), sizeof(fd_account_meta_t), TEST_WKSP_TAG );
+  memset( env->source_meta, 0, sizeof(fd_account_meta_t) );
+  memcpy( env->source_meta->owner, &fd_solana_system_program_id, sizeof(fd_pubkey_t) );
+  env->source_meta->lamports = 1000000UL;
+  env->txn_out->accounts.metas[1] = env->source_meta;
+
+  memcpy( &env->txn_out->accounts.keys[2], &test_transfer_to_pubkey, sizeof(fd_pubkey_t) );
+  env->dest_meta = fd_wksp_alloc_laddr( wksp, alignof(fd_account_meta_t), sizeof(fd_account_meta_t), TEST_WKSP_TAG );
+  memset( env->dest_meta, 0, sizeof(fd_account_meta_t) );
+  memcpy( env->dest_meta->owner, &fd_solana_system_program_id, sizeof(fd_pubkey_t) );
+  env->dest_meta->lamports = 0UL;
+  env->txn_out->accounts.metas[2] = env->dest_meta;
+
+  env->runtime->accounts.refcnt[0] = 0UL;
+  env->runtime->accounts.refcnt[1] = 0UL;
+  env->runtime->accounts.refcnt[2] = 0UL;
+
+  memset( env->instr, 0, sizeof(fd_instr_info_t) );
+  env->instr->program_id  = 0;
+  env->instr->acct_cnt    = 3;
+  env->instr->accounts[0] = fd_instruction_account_init( 0, 0, 0, 0, 0 );
+  env->instr->accounts[1] = fd_instruction_account_init( 1, 1, 1, 1, 1 );
+  env->instr->accounts[2] = fd_instruction_account_init( 2, 2, 2, 1, 0 );
+  env->instr_ctx->instr   = env->instr;
+
+  memset( env->acc_region_metas, 0, sizeof(env->acc_region_metas) );
+  env->acc_region_metas[0].region_idx        = 0;
+  env->acc_region_metas[0].original_data_len = 0UL;
+  env->acc_region_metas[0].meta              = env->sysprog_meta;
+  env->acc_region_metas[1].region_idx        = 0;
+  env->acc_region_metas[1].original_data_len = 0UL;
+  env->acc_region_metas[1].meta              = env->source_meta;
+  env->acc_region_metas[2].region_idx        = 0;
+  env->acc_region_metas[2].original_data_len = 0UL;
+  env->acc_region_metas[2].meta              = env->dest_meta;
+
+  memset( env->rodata, 0, sizeof(env->rodata) );
+  int vm_ok = !!fd_vm_init(
+      vm,
+      env->instr_ctx,
+      FD_VM_HEAP_DEFAULT,
+      FD_VM_COMPUTE_UNIT_LIMIT,
+      env->rodata,
+      sizeof(env->rodata),
+      NULL,
+      0UL,
+      0UL,
+      0UL,
+      0UL,
+      NULL,
+      TEST_VM_DEFAULT_SBPF_VERSION,
+      NULL,
+      NULL,
+      sha,
+      NULL,
+      0U,
+      env->acc_region_metas,
+      0,
+      FD_FEATURE_ACTIVE_BANK( env->bank, account_data_direct_mapping ),
+      FD_FEATURE_ACTIVE_BANK( env->bank, stricter_abi_and_runtime_constraints ),
+      0, 0UL
+  );
+  FD_TEST( vm_ok );
+}
+
+static void
+test_env_destroy( test_env_t * env ) {
+  test_vm_clear_txn_ctx_err( env->instr_ctx->txn_out );
+  fd_vm_delete( fd_vm_leave( env->vm ) );
+  fd_sha256_delete( fd_sha256_leave( env->sha ) );
+  fd_wksp_free_laddr( env->sysprog_meta );
+  fd_wksp_free_laddr( env->source_meta );
+  fd_wksp_free_laddr( env->dest_meta );
+  fd_wksp_free_laddr( env->runtime );
+
+  ulong           tag = TEST_WKSP_TAG;
+  fd_wksp_usage_t usage[1];
+  fd_wksp_usage( env->wksp, &tag, 1UL, usage );
+  FD_TEST( usage->used_cnt == 0UL );
+  FD_TEST( usage->used_sz  == 0UL );
+}
+
+static void
+run_test( fd_wksp_t * wksp,
+          int         increase_cpi_account_info_limit,
+          int         increase_tx_account_lock_limit,
+          ulong       num_infos,
+          int         expected_err,
+          ulong       expected_cus ) {
+  test_env_t env[1];
+  test_env_create( env, wksp, increase_cpi_account_info_limit, increase_tx_account_lock_limit );
+
+  ulong initial_cu = env->vm->cu;
+  ulong instr_va, acct_infos_va;
+  setup_cpi_memory( env->vm, num_infos, &instr_va, &acct_infos_va );
+
+  ulong ret = 0UL;
+  int err = fd_vm_syscall_cpi_c( env->vm, instr_va, acct_infos_va, num_infos, 0UL, 0UL, &ret );
+
+  FD_TEST( err == expected_err );
+  FD_TEST( (initial_cu - env->vm->cu) == expected_cus );
+
+  test_env_destroy( env );
+}
+
+static void
+test_both_enabled_exceeds_limit( fd_wksp_t * wksp ) {
+  int   increase_cpi_account_info_limit = 1;
+  int   increase_tx_account_lock_limit  = 1;
+  ulong num_infos                       = 256UL;
+  ulong expected_cus                    = FD_VM_INVOKE_UNITS_SIMD_0339;
+  run_test( wksp,
+            increase_cpi_account_info_limit,
+            increase_tx_account_lock_limit,
+            num_infos,
+            FD_VM_SYSCALL_ERR_MAX_INSTRUCTION_ACCOUNT_INFOS_EXCEEDED,
+            expected_cus );
+}
+
+static void
+test_increase_cpi_account_info_limit_enabled_exceeds_limit( fd_wksp_t * wksp ) {
+  int   increase_cpi_account_info_limit = 1;
+  int   increase_tx_account_lock_limit  = 0;
+  ulong num_infos                       = 256UL;
+  ulong expected_cus                    = FD_VM_INVOKE_UNITS_SIMD_0339;
+  run_test( wksp,
+            increase_cpi_account_info_limit,
+            increase_tx_account_lock_limit,
+            num_infos,
+            FD_VM_SYSCALL_ERR_MAX_INSTRUCTION_ACCOUNT_INFOS_EXCEEDED,
+            expected_cus );
+}
+
+static void
+test_increase_tx_account_lock_limit_enabled_exceeds_limit( fd_wksp_t * wksp ) {
+  int   increase_cpi_account_info_limit = 0;
+  int   increase_tx_account_lock_limit  = 1;
+  ulong num_infos                       = 129UL;
+  ulong expected_cus                    = FD_VM_INVOKE_UNITS;
+  run_test( wksp,
+            increase_cpi_account_info_limit,
+            increase_tx_account_lock_limit,
+            num_infos,
+            FD_VM_SYSCALL_ERR_MAX_INSTRUCTION_ACCOUNT_INFOS_EXCEEDED,
+            expected_cus );
+}
+
+static void
+test_neither_enabled_exceeds_limit( fd_wksp_t * wksp ) {
+  int   increase_cpi_account_info_limit = 0;
+  int   increase_tx_account_lock_limit  = 0;
+  ulong num_infos                       = 65UL;
+  ulong expected_cus                    = FD_VM_INVOKE_UNITS;
+  run_test( wksp,
+            increase_cpi_account_info_limit,
+            increase_tx_account_lock_limit,
+            num_infos,
+            FD_VM_SYSCALL_ERR_MAX_INSTRUCTION_ACCOUNT_INFOS_EXCEEDED,
+            expected_cus );
+}
+
+static void
+test_both_enabled_at_limit( fd_wksp_t * wksp ) {
+  int   increase_cpi_account_info_limit = 1;
+  int   increase_tx_account_lock_limit  = 1;
+  ulong num_infos                       = 255UL;
+  ulong expected_cus                    = FD_VM_INVOKE_UNITS_SIMD_0339
+                                        + expected_account_info_cu( num_infos )
+                                        + TEST_SYSTEM_PROGRAM_EXECUTE_CU;
+  run_test( wksp,
+            increase_cpi_account_info_limit,
+            increase_tx_account_lock_limit,
+            num_infos,
+            FD_VM_SUCCESS,
+            expected_cus );
+}
+
+static void
+test_increase_cpi_account_info_limit_enabled_at_limit( fd_wksp_t * wksp ) {
+  int   increase_cpi_account_info_limit = 1;
+  int   increase_tx_account_lock_limit  = 0;
+  ulong num_infos                       = 255UL;
+  ulong expected_cus                    = FD_VM_INVOKE_UNITS_SIMD_0339
+                                        + expected_account_info_cu( num_infos )
+                                        + TEST_SYSTEM_PROGRAM_EXECUTE_CU;
+  run_test( wksp,
+            increase_cpi_account_info_limit,
+            increase_tx_account_lock_limit,
+            num_infos,
+            FD_VM_SUCCESS,
+            expected_cus );
+}
+
+static void
+test_increase_tx_account_lock_limit_enabled_at_limit( fd_wksp_t * wksp ) {
+  int   increase_cpi_account_info_limit = 0;
+  int   increase_tx_account_lock_limit  = 1;
+  ulong num_infos                       = 128UL;
+  ulong expected_cus                    = FD_VM_INVOKE_UNITS + TEST_SYSTEM_PROGRAM_EXECUTE_CU;
+  run_test( wksp,
+            increase_cpi_account_info_limit,
+            increase_tx_account_lock_limit,
+            num_infos,
+            FD_VM_SUCCESS,
+            expected_cus );
+}
+
+static void
+test_neither_enabled_at_limit( fd_wksp_t * wksp ) {
+  int   increase_cpi_account_info_limit = 0;
+  int   increase_tx_account_lock_limit  = 0;
+  ulong num_infos                       = 64UL;
+  ulong expected_cus                    = FD_VM_INVOKE_UNITS + TEST_SYSTEM_PROGRAM_EXECUTE_CU;
+  run_test( wksp,
+            increase_cpi_account_info_limit,
+            increase_tx_account_lock_limit,
+            num_infos,
+            FD_VM_SUCCESS,
+            expected_cus );
+}
+
+static void
+test_both_enabled_below_limit( fd_wksp_t * wksp ) {
+  int   increase_cpi_account_info_limit = 1;
+  int   increase_tx_account_lock_limit  = 1;
+  ulong num_infos                       = 10UL;
+  ulong expected_cus                    = FD_VM_INVOKE_UNITS_SIMD_0339
+                                        + expected_account_info_cu( num_infos )
+                                        + TEST_SYSTEM_PROGRAM_EXECUTE_CU;
+  run_test( wksp,
+            increase_cpi_account_info_limit,
+            increase_tx_account_lock_limit,
+            num_infos,
+            FD_VM_SUCCESS,
+            expected_cus );
+}
+
+static void
+test_increase_cpi_account_info_limit_enabled_below_limit( fd_wksp_t * wksp ) {
+  int   increase_cpi_account_info_limit = 1;
+  int   increase_tx_account_lock_limit  = 0;
+  ulong num_infos                       = 10UL;
+  ulong expected_cus                    = FD_VM_INVOKE_UNITS_SIMD_0339
+                                        + expected_account_info_cu( num_infos )
+                                        + TEST_SYSTEM_PROGRAM_EXECUTE_CU;
+  run_test( wksp,
+            increase_cpi_account_info_limit,
+            increase_tx_account_lock_limit,
+            num_infos,
+            FD_VM_SUCCESS,
+            expected_cus );
+}
+
+static void
+test_increase_tx_account_lock_limit_enabled_below_limit( fd_wksp_t * wksp ) {
+  int   increase_cpi_account_info_limit = 0;
+  int   increase_tx_account_lock_limit  = 1;
+  ulong num_infos                       = 10UL;
+  ulong expected_cus                    = FD_VM_INVOKE_UNITS + TEST_SYSTEM_PROGRAM_EXECUTE_CU;
+  run_test( wksp,
+            increase_cpi_account_info_limit,
+            increase_tx_account_lock_limit,
+            num_infos,
+            FD_VM_SUCCESS,
+            expected_cus );
+}
+
+static void
+test_neither_enabled_below_limit( fd_wksp_t * wksp ) {
+  int   increase_cpi_account_info_limit = 0;
+  int   increase_tx_account_lock_limit  = 0;
+  ulong num_infos                       = 10UL;
+  ulong expected_cus                    = FD_VM_INVOKE_UNITS + TEST_SYSTEM_PROGRAM_EXECUTE_CU;
+  run_test( wksp,
+            increase_cpi_account_info_limit,
+            increase_tx_account_lock_limit,
+            num_infos,
+            FD_VM_SUCCESS,
+            expected_cus );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"      );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 4UL             );
+  ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
+
+  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
+  FD_TEST( wksp );
+
+  test_both_enabled_exceeds_limit( wksp );
+  test_increase_cpi_account_info_limit_enabled_exceeds_limit( wksp );
+  test_increase_tx_account_lock_limit_enabled_exceeds_limit( wksp );
+  test_neither_enabled_exceeds_limit( wksp );
+  test_both_enabled_at_limit( wksp );
+  test_increase_cpi_account_info_limit_enabled_at_limit( wksp );
+  test_increase_tx_account_lock_limit_enabled_at_limit( wksp );
+  test_neither_enabled_at_limit( wksp );
+  test_both_enabled_below_limit( wksp );
+  test_increase_cpi_account_info_limit_enabled_below_limit( wksp );
+  test_increase_tx_account_lock_limit_enabled_below_limit( wksp );
+  test_neither_enabled_below_limit( wksp );
+
+  fd_wksp_delete_anonymous( wksp );
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}

--- a/src/flamenco/vm/test_vm_base.c
+++ b/src/flamenco/vm/test_vm_base.c
@@ -54,6 +54,7 @@ FD_STATIC_ASSERT( FD_VM_COMPUTE_UNIT_LIMIT                       ==         1400
 FD_STATIC_ASSERT( FD_VM_LOG_64_UNITS                             ==             100UL, vm_cu );
 FD_STATIC_ASSERT( FD_VM_CREATE_PROGRAM_ADDRESS_UNITS             ==            1500UL, vm_cu );
 FD_STATIC_ASSERT( FD_VM_INVOKE_UNITS                             ==            1000UL, vm_cu );
+FD_STATIC_ASSERT( FD_VM_INVOKE_UNITS_SIMD_0339                   ==             946UL, vm_cu );
 FD_STATIC_ASSERT( FD_VM_MAX_INVOKE_STACK_HEIGHT                  ==               5UL, vm_cu );
 FD_STATIC_ASSERT( FD_VM_MAX_INSTRUCTION_TRACE_LENGTH             ==              64UL, vm_cu );
 FD_STATIC_ASSERT( FD_VM_SHA256_BASE_COST                         ==              85UL, vm_cu );
@@ -63,6 +64,7 @@ FD_STATIC_ASSERT( FD_VM_MAX_CALL_DEPTH                           ==             
 FD_STATIC_ASSERT( FD_VM_STACK_FRAME_SIZE                         ==            4096UL, vm_cu );
 FD_STATIC_ASSERT( FD_VM_LOG_PUBKEY_UNITS                         ==             100UL, vm_cu );
 FD_STATIC_ASSERT( FD_VM_MAX_CPI_INSTRUCTION_SIZE                 ==            1280UL, vm_cu );
+FD_STATIC_ASSERT( FD_VM_ACCOUNT_INFO_BYTE_SIZE                   ==              80UL, vm_cu );
 FD_STATIC_ASSERT( FD_VM_CPI_BYTES_PER_UNIT                       ==             250UL, vm_cu );
 FD_STATIC_ASSERT( FD_VM_SYSVAR_BASE_COST                         ==             100UL, vm_cu );
 FD_STATIC_ASSERT( FD_VM_SECP256K1_RECOVER_COST                   ==           25000UL, vm_cu );


### PR DESCRIPTION
Implementing `increase_cpi_account_info_limit` (https://github.com/solana-foundation/solana-improvement-documents/pull/339), which improves UX/reduces work for programs which make CPI calls that were _themselves_ invoked with more than 64 accounts - they no longer have to de-dup the list of account infos to make a CPI call.

This SIMD also starts charging for serialized account infos and instruction account metas in CPIs.

- [x] Implementation
- [x] Unit tests
- [x] Ledger tests
- [x] Fuzzing