### PR TITLE
flamenco, vm: Fix inverted error code in CPI

### DIFF
--- a/contrib/offline-replay/offline_replay_template.sh
+++ b/contrib/offline-replay/offline_replay_template.sh
@@ -6,7 +6,6 @@ export FD_BRANCH="main"
 
 # Agave Repo
 export AGAVE_REPO="/path/to/agave"
-export AGAVE_LEDGER_TOOL="${AGAVE_REPO}/target/release/agave-ledger-tool"
 
 # Network Specific Parameters
 export NETWORK="mainnet"

--- a/contrib/offline-replay/run_offline_replay_backtest.sh
+++ b/contrib/offline-replay/run_offline_replay_backtest.sh
@@ -59,7 +59,17 @@ while true; do
         cd $AGAVE_REPO
         git pull
         git checkout $AGAVE_TAG
-        cargo build --release
+
+        AGAVE_VERSION=$(echo "$AGAVE_TAG" | sed 's/^v//')
+        if [ "$(printf '%s\n' "$AGAVE_VERSION" "3.1.0" | sort -V | head -n1)" = "3.1.0" ]; then
+            cargo clean
+            cargo build --manifest-path dev-bins/Cargo.toml -p agave-ledger-tool --release
+            AGAVE_LEDGER_TOOL="${AGAVE_REPO}/dev-bins/target/release/agave-ledger-tool"
+        else
+            cargo clean
+            cargo build --release
+            AGAVE_LEDGER_TOOL="${AGAVE_REPO}/target/release/agave-ledger-tool"
+        fi
 
         send_slack_message "Bucket Slot \`$NEWEST_BUCKET_SLOT\` is greater than the last run bucket slot \`$LATEST_RUN_BUCKET_SLOT\`"
 


### PR DESCRIPTION
Note for posterity that this is updating the checks to match the order which was changed in https://github.com/anza-xyz/agave/pull/7554

(originally posted by @topointon-jump in https://github.com/firedancer-io/firedancer/pull/7275)