### PR TITLE
tango: minor fixes

### DIFF
--- a/src/tango/cnc/fd_cnc.c
+++ b/src/tango/cnc/fd_cnc.c
@@ -264,7 +264,7 @@ fd_cnc_open( fd_cnc_t * cnc ) {
        running it is live.  Assume it is and tell the user to try again
        later. */
 
-    FD_LOG_WARNING(( "pid %lu currently command session and unable to diagnose pid's state (%i-%s); try again later?",
+    FD_LOG_WARNING(( "pid %lu currently has command session and unable to diagnose pid's state (%i-%s); try again later?",
                      cnc_pid, err, fd_io_strerror( err ) ));
     return FD_CNC_ERR_AGAIN;
   }

--- a/src/tango/dcache/fd_dcache.h
+++ b/src/tango/dcache/fd_dcache.h
@@ -93,10 +93,10 @@ fd_dcache_footprint( ulong data_sz,
    region is app_sz bytes.  Zero is valid for data_sz and/or app_sz.
 
    Returns shmem (and the memory region it points to will be formatted
-   as a dcache with the data and application regions initialized to
-   zero, caller is not joined) on success and NULL on failure (logs
-   details).  Reasons for failure include obviously bad shmem, bad
-   data_sz or bad app_sz. */
+   as a dcache with the application region initialized to zero, caller
+   is not joined) on success and NULL on failure (logs details).
+   Reasons for failure include obviously bad shmem, bad data_sz or bad
+   app_sz. */
 
 void *
 fd_dcache_new( void * shmem,

--- a/src/tango/fseq/fd_fseq.c
+++ b/src/tango/fseq/fd_fseq.c
@@ -38,7 +38,7 @@ fd_fseq_new( void * shmem,
   if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, fd_fseq_align() ) ) ) {
     FD_LOG_WARNING(( "misaligned shmem" ));
     return NULL;
-  } 
+  }
 
   fd_fseq_shmem_t * fseq = (fd_fseq_shmem_t *)shmem;
 

--- a/src/tango/fseq/fd_fseq.h
+++ b/src/tango/fseq/fd_fseq.h
@@ -78,10 +78,10 @@ fd_fseq_leave( ulong const * fseq );
 void *
 fd_fseq_delete( void * shfseq );
 
-/* fd_fctl_app_laddr returns local address of the fctl's application
-   region.  This will have FD_FCTL_APP_ALIGN alignment and room for at
-   least FD_FCTL_APP_FOOTPRINT bytes.  Assumes fseq is a current local
-   join.  fd_cnc_app_laddr_const is for const correctness.  The return
+/* fd_fseq_app_laddr returns local address of the fseq's application
+   region.  This will have FD_FSEQ_APP_ALIGN alignment and room for at
+   least FD_FSEQ_APP_FOOTPRINT bytes.  Assumes fseq is a current local
+   join.  fd_fseq_app_laddr_const is for const correctness.  The return
    values are valid for the lifetime of the local join. */
 
 FD_FN_CONST static inline void *       fd_fseq_app_laddr      ( ulong *       fseq ) { return (void       *)(fseq+2); }

--- a/src/tango/test_ipc_full
+++ b/src/tango/test_ipc_full
@@ -45,13 +45,13 @@ CORE_NEXT=$CORE_FIRST
 # Start up the receivers
 
 for((rx_idx=0;rx_idx<rx_cnt;rx_idx++)); do
-  taskset -c "$CORE_NEXT" "$UNIT_TEST"/test_frag_rx --tile-cpus "$CORE_NEXT" --cnc "${RX_CNC[rx_idx]}" --mcache "${TX_MCACHE[0]}" --dcache "${TX_DCACHE[0]}" --fseq "${RX_FSEQ[rx_idx]}" &
+  timeout 15 taskset -c "$CORE_NEXT" "$UNIT_TEST"/test_frag_rx --tile-cpus "$CORE_NEXT" --cnc "${RX_CNC[rx_idx]}" --mcache "${TX_MCACHE[0]}" --dcache "${TX_DCACHE[0]}" --fseq "${RX_FSEQ[rx_idx]}" &
   CORE_NEXT=$((CORE_NEXT+NUMA_STRIDE))
 done
 
 # Start up the transmitter
 
-taskset -c "$CORE_NEXT" "$UNIT_TEST"/test_frag_tx --tile-cpus "$CORE_NEXT" --cnc "${TX_CNC[0]}" --mcache "${TX_MCACHE[0]}" --dcache "${TX_DCACHE[0]}" --fseqs "${RX_FSEQS}" "$@" &
+timeout 15 taskset -c "$CORE_NEXT" "$UNIT_TEST"/test_frag_tx --tile-cpus "$CORE_NEXT" --cnc "${TX_CNC[0]}" --mcache "${TX_MCACHE[0]}" --dcache "${TX_DCACHE[0]}" --fseqs "${RX_FSEQS}" "$@" &
 CORE_NEXT=$((CORE_NEXT+NUMA_STRIDE))
 
 # Let run for a while

--- a/src/tango/test_ipc_meta
+++ b/src/tango/test_ipc_meta
@@ -47,13 +47,13 @@ CORE_NEXT=$CORE_FIRST
 # Start up the receivers
 
 for((rx_idx=0;rx_idx<rx_cnt;rx_idx++)); do
-  taskset -c "$CORE_NEXT" "$UNIT_TEST"/test_meta_rx --tile-cpus "$CORE_NEXT" --cnc "${RX_CNC[rx_idx]}" --mcache "${TX_MCACHE[0]}" --fseq "${RX_FSEQ[rx_idx]}" &
+  timeout 15 taskset -c "$CORE_NEXT" "$UNIT_TEST"/test_meta_rx --tile-cpus "$CORE_NEXT" --cnc "${RX_CNC[rx_idx]}" --mcache "${TX_MCACHE[0]}" --fseq "${RX_FSEQ[rx_idx]}" &
   CORE_NEXT=$((CORE_NEXT+NUMA_STRIDE))
 done
 
 # Start up the transmitter
 
-taskset -c "$CORE_NEXT" "$UNIT_TEST"/test_meta_tx --tile-cpus "$CORE_NEXT" --cnc "${TX_CNC[0]}" --mcache "${TX_MCACHE[0]}" --fseqs "${RX_FSEQS}" "$@" &
+timeout 15 taskset -c "$CORE_NEXT" "$UNIT_TEST"/test_meta_tx --tile-cpus "$CORE_NEXT" --cnc "${TX_CNC[0]}" --mcache "${TX_MCACHE[0]}" --fseqs "${RX_FSEQS}" "$@" &
 CORE_NEXT=$((CORE_NEXT+NUMA_STRIDE))
 
 # Let run for a while


### PR DESCRIPTION
Things found by AI

- Fix log in cnc
- Fix doc for fd_dcache_new, which incorrectly stated that the
  data region is zerod (Regression from commit 5bfe27beb322f4b5abba7b1f8e085b495debd3ec)
- Fix copy-paste error in fseq doc
- Harden test_ipc to prevent runaway subprocesses
