### PR TITLE
accdb: add RAII-style read API

### DIFF
--- a/src/flamenco/accdb/fd_accdb_impl_v1.c
+++ b/src/flamenco/accdb/fd_accdb_impl_v1.c
@@ -488,7 +488,8 @@ fd_accdb_user_v1_init( fd_accdb_user_t * accdb,
 fd_funk_t *
 fd_accdb_user_v1_funk( fd_accdb_user_t * accdb ) {
   fd_accdb_user_v1_t * v1 = (fd_accdb_user_v1_t *)accdb;
-  if( FD_UNLIKELY( accdb->base.accdb_type!=FD_ACCDB_TYPE_V1 ) ) {
+  uint accdb_type = accdb->base.accdb_type;
+  if( FD_UNLIKELY( accdb_type!=FD_ACCDB_TYPE_V1 && accdb_type!=FD_ACCDB_TYPE_V2 ) ) {
     FD_LOG_CRIT(( "fd_accdb_user_v1_funk called on non-v1 accdb_user (type %u)", accdb->base.accdb_type ));
   }
   return v1->funk;

--- a/src/flamenco/accdb/fd_accdb_sync.h
+++ b/src/flamenco/accdb/fd_accdb_sync.h
@@ -71,6 +71,51 @@ fd_accdb_close_ro( fd_accdb_user_t * accdb,
   accdb->base.vt->close_ro( accdb, ro );
 }
 
+/* FD_ACDB_RO_{BEGIN,END} provides RAII-style safe macros for
+   fd_accdb_{open,close}_ro.
+
+   Typical usage like:
+
+     FD_ACCDB_RO_BEGIN( accdb, ro, xid, address ) {
+       FD_LOG_NOTICE(( "Account has %lu lamports", fd_accdb_ref_lamports( ro ) ));
+     }
+     FD_ACCDB_RO_NOT_FOUND {
+       FD_LOG_NOTICE(( "Account does not exist" ));
+     }
+     FD_ACCDB_RO_END; */
+
+struct fd_accdb_ro_scope_guard {
+  fd_accdb_user_t * accdb;
+  fd_accdb_ro_t *   ro;
+};
+typedef struct fd_accdb_ro_scope_guard fd_accdb_ro_scope_guard_t;
+
+FD_FN_UNUSED static inline void
+fd_accdb_ro_scope_exit( fd_accdb_ro_scope_guard_t * guard ) {
+  fd_accdb_close_ro( guard->accdb, guard->ro );
+}
+
+#define FD_ACCDB_RO_BEGIN( accdb__, handle, xid, address)              \
+  {                                                                    \
+    fd_accdb_ro_t     handle[1];                                       \
+    fd_accdb_user_t * accdb_ = (accdb__);                              \
+    void const *      addr_ = (address);                               \
+    if( fd_accdb_open_ro( accdb, handle, (xid), addr_ ) ) {            \
+      fd_accdb_ro_scope_guard_t __attribute__((cleanup(fd_accdb_ro_scope_exit))) guard_ = \
+        { .accdb=accdb_, .ro=handle };                                 \
+      (void)guard_;                                                    \
+      {                                                                \
+        /* User-provided account found snippet */
+#define FD_ACCDB_RO_NOT_FOUND                                          \
+      }                                                                \
+    } else {                                                           \
+      {                                                                \
+        /* User-provided account not found snippet */
+#define FD_ACCDB_RO_END                                                \
+      }                                                                \
+    }                                                                  \
+  }
+
 /* In-place transactional write APIs **********************************/
 
 FD_PROTOTYPES_BEGIN

--- a/src/flamenco/runtime/sysvar/fd_sysvar_clock.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_clock.h
@@ -64,7 +64,7 @@ fd_sysvar_clock_write( fd_bank_t *               bank,
    has zero lamports, this function returns NULL. */
 
 fd_sol_sysvar_clock_t *
-fd_sysvar_clock_read( fd_funk_t *               funk,
+fd_sysvar_clock_read( fd_accdb_user_t *         accdb,
                       fd_funk_txn_xid_t const * xid,
                       fd_sol_sysvar_clock_t *   clock );
 

--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -246,7 +246,7 @@ fd_solfuzz_pb_instr_ctx_create( fd_solfuzz_runner_t *                runner,
   FD_TEST( fd_sysvar_last_restart_slot_read( funk, xid, last_restart_slot_ ) );
 
   fd_sol_sysvar_clock_t clock_[1];
-  fd_sol_sysvar_clock_t * clock = fd_sysvar_clock_read( funk, xid, clock_ );
+  fd_sol_sysvar_clock_t * clock = fd_sysvar_clock_read( runner->accdb, xid, clock_ );
   FD_TEST( clock );
   fd_bank_slot_set( runner->bank, clock->slot );
 

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -119,7 +119,7 @@ fd_solfuzz_pb_txn_ctx_create( fd_solfuzz_runner_t *              runner,
   FD_TEST( stake_history );
 
   fd_sol_sysvar_clock_t clock_[1];
-  fd_sol_sysvar_clock_t const * clock = fd_sysvar_clock_read( funk, &xid, clock_ );
+  fd_sol_sysvar_clock_t const * clock = fd_sysvar_clock_read( runner->accdb, &xid, clock_ );
   FD_TEST( clock );
 
   /* Setup vote states dummy account */


### PR DESCRIPTION
Provides syntax sugar for acquiring an account read-only handle
that automatically releases resources when exiting scope.
