### PR TITLE
gui: remove useless memcpy

### DIFF
--- a/src/disco/gui/fd_gui_peers.c
+++ b/src/disco/gui/fd_gui_peers.c
@@ -727,7 +727,6 @@ fd_gui_peers_handle_vote_update( fd_gui_peers_ctx_t *  peers,
   (void)now;
   fd_gui_peers_vote_t * votes_sorted  = votes;
   fd_gui_peers_vote_t * votes_scratch = peers->votes_scratch;
-  fd_memcpy( votes_sorted, votes, vote_cnt*sizeof(fd_gui_peers_vote_t) );
 
   /* deduplicate node accounts, keeping the vote accounts with largest stake */
   fd_gui_peers_votes_stake_sort_inplace( votes_sorted, vote_cnt );


### PR DESCRIPTION
This memcpy is useless, because dest and src are the same.

@jherrera-jump you added the code in https://github.com/firedancer-io/firedancer/commit/36a7627596804339894a7bafc7d6296aab6e9631#diff-a762854841573ceab3ec0b0ce132378b8feab159c519ab1c2d499b2ddff636d8.
Right now the memcpy is useless, but maybe it was intended to do something else?