### PR TITLE
codeql: query for useless memcpy + cleanup

### DIFF
--- a/contrib/codeql/nightly/TrivialMemcpy.ql
+++ b/contrib/codeql/nightly/TrivialMemcpy.ql
@@ -14,14 +14,7 @@
 
 import cpp
 import filter
-
-class MemcpyFunction extends Function {
-  MemcpyFunction() {
-    this.hasGlobalOrStdName("memcpy")
-    or
-    this.hasGlobalName(["fd_memcpy", "__builtin_memcpy"])
-  }
-}
+import fd_memcpy
 
 predicate ignoredLocation(Location l) {
   // we don't want to change vendored code if not really necessary

--- a/contrib/codeql/nightly/TrivialMemcpyWrong.ql
+++ b/contrib/codeql/nightly/TrivialMemcpyWrong.ql
@@ -13,14 +13,7 @@
 
 import cpp
 import filter
-
-class MemcpyFunction extends Function {
-  MemcpyFunction() {
-    this.hasGlobalOrStdName("memcpy")
-    or
-    this.hasGlobalName(["fd_memcpy", "__builtin_memcpy"])
-  }
-}
+import fd_memcpy
 
 class NotVoidChar extends Type {
   NotVoidChar() {

--- a/contrib/codeql/nightly/UselessMemcpy.ql
+++ b/contrib/codeql/nightly/UselessMemcpy.ql
@@ -1,0 +1,24 @@
+/**
+ * @name Suspicious/useless `memcpy(foo, foo, ...)` call.
+ * @description `memcpy` is called with the same source and destination pointer.
+ *                This is likely a bug or at best useless code.
+ * @kind problem
+ * @id asymmetric-research/useless-memcpy
+ * @problem.severity warning
+ * @precision high
+ * @tags correctness
+ */
+
+import cpp
+import semmle.code.cpp.valuenumbering.GlobalValueNumbering
+import fd_memcpy
+
+predicate isSamePointer(Expr e1, Expr e2) { globalValueNumber(e1) = globalValueNumber(e2) }
+
+from MemcpyFunction memcpy, FunctionCall call
+where
+  call.getTarget() = memcpy and
+  isSamePointer(call.getArgument(0), call.getArgument(1))
+select call,
+  "Call to " + memcpy.getName() +
+    " has the same source and destination. This is likely a bug or useless code."

--- a/contrib/codeql/nightly/fd_memcpy.qll
+++ b/contrib/codeql/nightly/fd_memcpy.qll
@@ -1,0 +1,15 @@
+import cpp
+
+/**
+ * A memcpy function:
+ * - `memcpy` from `<string.h>`
+ * - `fd_memcpy` from `fd_util_base.h`
+ * - `__builtin_memcpy`
+ */
+class MemcpyFunction extends Function {
+  MemcpyFunction() {
+    this.hasGlobalOrStdName("memcpy")
+    or
+    this.hasGlobalName(["fd_memcpy", "__builtin_memcpy"])
+  }
+}


### PR DESCRIPTION
Add query for useless memcpy and use the same memcpy definition across all queries.

Finds exactly https://github.com/firedancer-io/firedancer/pull/7462.