### PR TITLE
config: fix FD_HAS_BZIP2 detection

### DIFF
--- a/config/extra/with-bzip2.mk
+++ b/config/extra/with-bzip2.mk
@@ -1,4 +1,4 @@
-ifeq ($(wildcard $(OPT)/git/bzip2/bzlib.c),)
+ifeq ($(wildcard $(OPT)/include/bzlib.h),)
 $(warning "bzip2 not installed, skipping")
 else
 


### PR DESCRIPTION
Fixes a compile error when the user runs `./deps.sh +dev fetch`
and then `./deps.sh install` (without +dev).  This would make the
bzip2 source available (thus activating FD_HAS_BZIP2) without
installing the header.
