### PR TITLE
flamenco, runtime, vm: clean up remove_accounts_executable_flag_checks

### DIFF
--- a/src/flamenco/features/fd_features_generated.c
+++ b/src/flamenco/features/fd_features_generated.c
@@ -1496,7 +1496,7 @@ fd_feature_id_t const ids[] = {
     .id                        = {"\xd7\xeb\x98\x87\x27\xcf\x64\x78\xbe\x0d\x81\x84\x03\x96\x2b\x10\x77\xb6\xc9\xcb\x3b\xfd\x6c\x3b\x95\xf6\xa4\x79\xee\x74\xde\xb8"},
                                  /* FXs1zh47QbNnhXcnB6YiAQoJ4sGB91tKF3UFHLcKT7PM */
     .name                      = "remove_accounts_executable_flag_checks",
-    .cleaned_up                = {UINT_MAX, UINT_MAX, UINT_MAX},
+    .cleaned_up                = {3, 0, 0},
     .hardcode_for_fuzzing = 1 },
 
   { .index                     = offsetof(fd_features_t, fix_alt_bn128_multiplication_input_length)>>3,

--- a/src/flamenco/features/feature_map.json
+++ b/src/flamenco/features/feature_map.json
@@ -215,7 +215,7 @@
   {"name":"migrate_stake_program_to_core_bpf","pubkey":"6M4oQ6eXneVhtLoiAr4yRYQY43eVLjrKbiDZDJc892yk","hardcode_for_fuzzing":1},
   {"name":"enable_get_epoch_stake_syscall","pubkey":"FKe75t4LXxGaQnVHdUKM6DSFifVVraGZ8LyNo7oPwy1Z","old":"7mScTYkJXsbdrcwTQRs7oeCSXoJm4WjzBsRyf8bCU3Np"},
   {"name":"disable_account_loader_special_case","pubkey":"EQUMpNFr7Nacb1sva56xn1aLfBxppEoSBH8RRVdkcD1x","cleaned_up":[2,2,0],"hardcode_for_fuzzing":1},
-  {"name":"remove_accounts_executable_flag_checks","pubkey":"FXs1zh47QbNnhXcnB6YiAQoJ4sGB91tKF3UFHLcKT7PM","old":"FfgtauHUWKeXTzjXkua9Px4tNGBFHKZ9WaigM5VbbzFx","hardcode_for_fuzzing":1},
+  {"name":"remove_accounts_executable_flag_checks","pubkey":"FXs1zh47QbNnhXcnB6YiAQoJ4sGB91tKF3UFHLcKT7PM","old":"FfgtauHUWKeXTzjXkua9Px4tNGBFHKZ9WaigM5VbbzFx","hardcode_for_fuzzing":1,"cleaned_up":[3,0,0]},
   {"name":"fix_alt_bn128_multiplication_input_length","pubkey":"bn2puAyxUx6JUabAxYdKdJ5QHbNNmKw8dCGuGCyRrFN","cleaned_up":[3,1,0],"hardcode_for_fuzzing":1},
   {"name":"lift_cpi_caller_restriction","pubkey":"HcW8ZjBezYYgvcbxNJwqv1t484Y2556qJsfNDWvJGZRH","reverted":1},
   {"name":"accounts_lt_hash","pubkey":"LTHasHQX6661DaDD4S6A2TFi6QBuiwXKv66fB1obfHq","old":"LtHaSHHsUge7EWTPVrmpuexKz6uVHZXZL6cgJa7W7Zn","cleaned_up":[3,0,0],"hardcode_for_fuzzing":1},

--- a/src/flamenco/runtime/fd_borrowed_account.c
+++ b/src/flamenco/runtime/fd_borrowed_account.c
@@ -38,12 +38,6 @@ fd_borrowed_account_set_owner( fd_borrowed_account_t * borrowed_acct,
     return FD_EXECUTOR_INSTR_ERR_MODIFIED_PROGRAM_ID;
   }
 
-  /* And only if the account is not executable
-     https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L749 */
-  if( FD_UNLIKELY( fd_borrowed_account_is_executable_internal( borrowed_acct ) ) ) {
-    return FD_EXECUTOR_INSTR_ERR_MODIFIED_PROGRAM_ID;
-  }
-
   /* And only if the data is zero-initialized or empty
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L753 */
   if( FD_UNLIKELY( !fd_borrowed_account_is_zeroed( borrowed_acct ) ) ) {
@@ -82,12 +76,6 @@ fd_borrowed_account_set_lamports( fd_borrowed_account_t * borrowed_acct,
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L779 */
   if( FD_UNLIKELY( !fd_borrowed_account_is_writable( borrowed_acct ) ) ) {
     return FD_EXECUTOR_INSTR_ERR_READONLY_LAMPORT_CHANGE;
-  }
-
-  /* The balance of executable accounts may not change
-     https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L783 */
-  if( FD_UNLIKELY( fd_borrowed_account_is_executable_internal( borrowed_acct ) ) ) {
-    return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_LAMPORT_CHANGE;
   }
 
   /* Don't copy the account if the lamports do not change
@@ -190,12 +178,6 @@ fd_borrowed_account_set_executable( fd_borrowed_account_t * borrowed_acct,
   /* And only if the account is writable
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L1015 */
   if( FD_UNLIKELY( !fd_borrowed_account_is_writable( borrowed_acct ) ) ) {
-    return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_MODIFIED;
-  }
-
-  /* One can not clear the executable flag
-     https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L1019 */
-  if( FD_UNLIKELY( fd_borrowed_account_is_executable_internal( borrowed_acct ) && !is_executable ) ) {
     return FD_EXECUTOR_INSTR_ERR_EXECUTABLE_MODIFIED;
   }
 

--- a/src/flamenco/runtime/fd_borrowed_account.h
+++ b/src/flamenco/runtime/fd_borrowed_account.h
@@ -287,19 +287,6 @@ fd_borrowed_account_is_executable( fd_borrowed_account_t const * borrowed_acct )
   return fd_txn_account_is_executable( borrowed_acct->acct );
 }
 
-/* fd_borrowed_account_is_executable_internal is a private function for deprecating the `is_executable` flag.
-   It returns true if the `remove_accounts_executable_flag_checks` feature is inactive AND fd_account_is_executable
-   return true. This is newly used in account modification logic to eventually allow "executable" accounts to be
-   modified.
-
-   https://github.com/anza-xyz/agave/blob/89872fdb074e6658646b2b57a299984f0059cc84/sdk/transaction-context/src/lib.rs#L1052-L1060 */
-
-FD_FN_PURE static inline int
-fd_borrowed_account_is_executable_internal( fd_borrowed_account_t const * borrowed_acct ) {
-  return !FD_FEATURE_ACTIVE_BANK( borrowed_acct->instr_ctx->bank, remove_accounts_executable_flag_checks ) &&
-          fd_borrowed_account_is_executable( borrowed_acct );
-}
-
 FD_FN_PURE static inline int
 fd_borrowed_account_is_mutable( fd_borrowed_account_t const * borrowed_acct ) {
   return fd_txn_account_is_mutable( borrowed_acct->acct );
@@ -370,14 +357,7 @@ fd_borrowed_account_is_owned_by_current_program( fd_borrowed_account_t const * b
 static inline int
 fd_borrowed_account_can_data_be_changed( fd_borrowed_account_t const * borrowed_acct,
                                          int *                       err ) {
-  /* Only non-executable accounts data can be changed
-     https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L1076 */
-  if( FD_UNLIKELY( fd_borrowed_account_is_executable_internal( borrowed_acct ) ) ) {
-    *err = FD_EXECUTOR_INSTR_ERR_EXECUTABLE_DATA_MODIFIED;
-    return 0;
-  }
-
-  /* And only if the account is writable
+  /* Only writable accounts can be changed
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L1080 */
   if( FD_UNLIKELY( !fd_borrowed_account_is_writable( borrowed_acct ) ) ) {
     *err = FD_EXECUTOR_INSTR_ERR_READONLY_DATA_MODIFIED;

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -147,7 +147,7 @@ fd_executor_lookup_native_program( fd_txn_account_t const * prog_acc,
      This will not be the case though once core programs are migrated to BPF. */
   int is_native_program = !memcmp( owner, fd_solana_native_loader_id.key, sizeof(fd_pubkey_t) );
 
-  if( !is_native_program && FD_FEATURE_ACTIVE_BANK( bank, remove_accounts_executable_flag_checks ) ) {
+  if( !is_native_program ) {
     if( FD_UNLIKELY( !fd_executor_pubkey_is_bpf_loader( owner ) ) ) {
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
     }
@@ -587,12 +587,6 @@ fd_executor_load_transaction_accounts_old( fd_runtime_t *      runtime,
       return FD_RUNTIME_TXN_ERR_PROGRAM_ACCOUNT_NOT_FOUND;
     }
 
-    /* https://github.com/anza-xyz/agave/blob/v2.2.0/svm/src/account_loader.rs#L464-L471 */
-    if( FD_UNLIKELY( !FD_FEATURE_ACTIVE_BANK( bank, remove_accounts_executable_flag_checks ) &&
-                     !fd_txn_account_is_executable( program_account ) ) ) {
-      return FD_RUNTIME_TXN_ERR_INVALID_PROGRAM_FOR_EXECUTION;
-    }
-
     /* https://github.com/anza-xyz/agave/blob/v2.2.0/svm/src/account_loader.rs#L474-L477 */
     if( !memcmp( fd_txn_account_get_owner( program_account ), fd_solana_native_loader_id.key, sizeof(fd_pubkey_t) ) ) {
       continue;
@@ -627,9 +621,7 @@ fd_executor_load_transaction_accounts_old( fd_runtime_t *      runtime,
 
 
     /* https://github.com/anza-xyz/agave/blob/v2.2.0/svm/src/account_loader.rs#L502-L510 */
-    if( FD_UNLIKELY( memcmp( fd_txn_account_get_owner( owner_account ), fd_solana_native_loader_id.key, sizeof(fd_pubkey_t) ) ||
-                     ( !FD_FEATURE_ACTIVE_BANK( bank, remove_accounts_executable_flag_checks ) &&
-                       !fd_txn_account_is_executable( owner_account ) ) ) ) {
+    if( FD_UNLIKELY( memcmp( fd_txn_account_get_owner( owner_account ), fd_solana_native_loader_id.key, sizeof(fd_pubkey_t) ) ) ) {
       return FD_RUNTIME_TXN_ERR_INVALID_PROGRAM_FOR_EXECUTION;
     }
 
@@ -853,12 +845,6 @@ fd_executor_load_transaction_accounts_simd_186( fd_runtime_t *      runtime,
                                                fd_runtime_account_check_exists );
     if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS || fd_txn_account_get_lamports( program_account )==0UL ) ) {
       return FD_RUNTIME_TXN_ERR_PROGRAM_ACCOUNT_NOT_FOUND;
-    }
-
-    /* https://github.com/anza-xyz/agave/blob/v2.3.1/svm/src/account_loader.rs#L668-L675 */
-    if( FD_UNLIKELY( !FD_FEATURE_ACTIVE_BANK( bank, remove_accounts_executable_flag_checks ) &&
-                     !fd_txn_account_is_executable( program_account ) ) ) {
-      return FD_RUNTIME_TXN_ERR_INVALID_PROGRAM_FOR_EXECUTION;
     }
 
     /* https://github.com/anza-xyz/agave/blob/v2.3.1/svm/src/account_loader.rs#L677-L681 */

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -1412,12 +1412,6 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
       fd_guarded_borrowed_account_t program = {0};
       FD_TRY_BORROW_INSTR_ACCOUNT_DEFAULT_ERR_CHECK( instr_ctx, 1UL, &program );
 
-      /* https://github.com/anza-xyz/agave/blob/89872fdb074e6658646b2b57a299984f0059cc84/programs/bpf_loader/src/lib.rs#L758-L765 */
-      if( FD_UNLIKELY( !FD_FEATURE_ACTIVE_BANK( instr_ctx->bank, remove_accounts_executable_flag_checks ) &&
-                       !fd_borrowed_account_is_executable( &program ) ) ) {
-        fd_log_collector_msg_literal( instr_ctx, "Program account not executable" );
-        return FD_EXECUTOR_INSTR_ERR_ACC_NOT_EXECUTABLE;
-      }
       if( FD_UNLIKELY( !fd_borrowed_account_is_writable( &program ) ) ) {
         fd_log_collector_msg_literal( instr_ctx, "Program account not writeable" );
         return FD_EXECUTOR_INSTR_ERR_INVALID_ARG;
@@ -2451,20 +2445,8 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
       return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
     } else {
       fd_log_collector_msg_literal( ctx, "Invalid BPF loader id" );
-      /* https://github.com/anza-xyz/agave/blob/89872fdb074e6658646b2b57a299984f0059cc84/programs/bpf_loader/src/lib.rs#L429-L436 */
-      if( FD_FEATURE_ACTIVE_BANK( ctx->bank, remove_accounts_executable_flag_checks ) ) {
-        return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
-      }
-      return FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID;
+      return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
     }
-  }
-
-  /* https://github.com/anza-xyz/agave/blob/89872fdb074e6658646b2b57a299984f0059cc84/programs/bpf_loader/src/lib.rs#L445-L452 */
-  /* Program invocation. Any invalid programs will be caught here or at the program load. */
-  if( FD_UNLIKELY( !FD_FEATURE_ACTIVE_BANK( ctx->bank, remove_accounts_executable_flag_checks ) &&
-                    !fd_borrowed_account_is_executable( &program_account ) ) ) {
-    fd_log_collector_msg_literal( ctx, "Program is not executable" );
-    return FD_EXECUTOR_INSTR_ERR_INCORRECT_PROGRAM_ID;
   }
 
   /* https://github.com/anza-xyz/agave/blob/77daab497df191ef485a7ad36ed291c1874596e5/programs/bpf_loader/src/lib.rs#L551-L563 */
@@ -2499,10 +2481,7 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
     err = fd_bpf_loader_program_get_state( program_account.acct, program_account_state );
     if( FD_UNLIKELY( err!=FD_EXECUTOR_INSTR_SUCCESS ) ) {
       fd_log_collector_msg_literal( ctx, "Program is not deployed" );
-      if( FD_FEATURE_ACTIVE_BANK( ctx->bank, remove_accounts_executable_flag_checks ) ) {
-        return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
-      }
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+      return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
     }
 
     /* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/program_loader.rs#L96-L98
@@ -2517,10 +2496,7 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
       if( !fd_is_non_migrating_builtin_program( program_id ) ) {
         fd_log_collector_msg_literal( ctx, "Program is not deployed" );
       }
-      if( FD_FEATURE_ACTIVE_BANK( ctx->bank, remove_accounts_executable_flag_checks ) ) {
-        return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
-      }
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+      return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
     }
 
     fd_txn_account_t * program_data_account = NULL;
@@ -2533,28 +2509,19 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
                                              fd_runtime_account_check_exists );
     if( FD_UNLIKELY( err!=FD_ACC_MGR_SUCCESS ) ) {
       fd_log_collector_msg_literal( ctx, "Program is not deployed" );
-      if( FD_FEATURE_ACTIVE_BANK( ctx->bank, remove_accounts_executable_flag_checks ) ) {
-        return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
-      }
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+      return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
     }
 
     if( FD_UNLIKELY( fd_txn_account_get_data_len( program_data_account )<PROGRAMDATA_METADATA_SIZE ) ) {
       fd_log_collector_msg_literal( ctx, "Program is not deployed" );
-      if( FD_FEATURE_ACTIVE_BANK( ctx->bank, remove_accounts_executable_flag_checks ) ) {
-        return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
-      }
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+      return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
     }
 
     fd_bpf_upgradeable_loader_state_t program_data_account_state[1];
     err = fd_bpf_loader_program_get_state( program_data_account, program_data_account_state );
     if( FD_UNLIKELY( err!=FD_EXECUTOR_INSTR_SUCCESS ) ) {
       fd_log_collector_msg_literal( ctx, "Program is not deployed" );
-      if( FD_FEATURE_ACTIVE_BANK( ctx->bank, remove_accounts_executable_flag_checks ) ) {
-        return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
-      }
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+      return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
     }
 
     /* https://github.com/anza-xyz/agave/blob/v2.0.9/svm/src/program_loader.rs#L100-L104
@@ -2562,10 +2529,7 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
     if( FD_UNLIKELY( !fd_bpf_upgradeable_loader_state_is_program_data( program_data_account_state ) ) ) {
       /* The account is closed. */
       fd_log_collector_msg_literal( ctx, "Program is not deployed" );
-      if( FD_FEATURE_ACTIVE_BANK( ctx->bank, remove_accounts_executable_flag_checks ) ) {
-        return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
-      }
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+      return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
     }
 
     ulong program_data_slot = program_data_account_state->inner.program_data.slot;
@@ -2573,10 +2537,7 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
       /* The account was likely just deployed or upgraded. Corresponds to
          'LoadedProgramType::DelayVisibility' */
       fd_log_collector_msg_literal( ctx, "Program is not deployed" );
-      if( FD_FEATURE_ACTIVE_BANK( ctx->bank, remove_accounts_executable_flag_checks ) ) {
-        return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
-      }
-      return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+      return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
     }
   }
 
@@ -2590,21 +2551,13 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
                          load_env );
   if( FD_UNLIKELY( !cache_entry ) ) {
     fd_log_collector_msg_literal( ctx, "Program is not cached" );
-
-    /* https://github.com/anza-xyz/agave/blob/89872fdb074e6658646b2b57a299984f0059cc84/programs/bpf_loader/src/lib.rs#L460-L467 */
-    if( FD_FEATURE_ACTIVE_BANK( ctx->bank, remove_accounts_executable_flag_checks ) ) {
-      return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
-    }
-    return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+    return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
   }
 
   /* The program may be in the cache but could have failed verification in the current epoch. */
   if( FD_UNLIKELY( cache_entry->executable==0 ) ) {
     fd_log_collector_msg_literal( ctx, "Program is not deployed" );
-    if( FD_FEATURE_ACTIVE_BANK( ctx->bank, remove_accounts_executable_flag_checks ) ) {
-      return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
-    }
-    return FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA;
+    return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;
   }
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.14/programs/bpf_loader/src/lib.rs#L446 */

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
@@ -202,17 +202,6 @@ fd_vm_prepare_instruction( fd_instr_info_t *        callee_instr,
     FD_TXN_ERR_FOR_LOG_INSTR( instr_ctx->txn_out, FD_EXECUTOR_INSTR_ERR_MISSING_ACC, instr_ctx->txn_out->err.exec_err_idx );
     return FD_EXECUTOR_INSTR_ERR_MISSING_ACC;
   }
-  /* Check that the program account is executable. We need to ensure that the
-    program account is a valid instruction account.
-    https://github.com/anza-xyz/agave/blob/v2.1.14/program-runtime/src/invoke_context.rs#L438 */
-  if( !FD_FEATURE_ACTIVE_BANK( instr_ctx->bank, remove_accounts_executable_flag_checks ) ) {
-    if( FD_UNLIKELY( !fd_borrowed_account_is_executable( &borrowed_program_account ) ) ) {
-      FD_BASE58_ENCODE_32_BYTES( callee_program_id_pubkey->uc, id_b58 );
-      fd_log_collector_msg_many( instr_ctx, 3, "Account ", 8UL, id_b58, id_b58_len, " is not executable", 18UL );
-      FD_TXN_ERR_FOR_LOG_INSTR( instr_ctx->txn_out, FD_EXECUTOR_INSTR_ERR_ACC_NOT_EXECUTABLE, instr_ctx->txn_out->err.exec_err_idx );
-      return FD_EXECUTOR_INSTR_ERR_ACC_NOT_EXECUTABLE;
-    }
-  }
 
   *instruction_accounts_cnt = duplicate_indicies_cnt;
 


### PR DESCRIPTION
Agave cleanup PR: https://github.com/anza-xyz/agave/pull/6847

This means the borrowed account API can be tested without a dependency on the banks!