### PR TITLE
flamenco, test: ensure no workspace memory leaks during solfuzz execution

### DIFF
--- a/src/flamenco/runtime/tests/fd_block_harness.c
+++ b/src/flamenco/runtime/tests/fd_block_harness.c
@@ -238,6 +238,12 @@ static void
 fd_solfuzz_pb_block_ctx_destroy( fd_solfuzz_runner_t * runner ) {
   fd_accdb_clear( runner->accdb_admin );
   fd_progcache_clear( runner->progcache_admin );
+
+  /* In order to check for leaks in the workspace, we need to compact the
+     allocators. Without doing this, empty superblocks may be retained
+     by the fd_alloc instance, which mean we cannot check for leaks. */
+  fd_alloc_compact( runner->accdb_admin->funk->alloc );
+  fd_alloc_compact( runner->progcache_admin->funk->alloc );
 }
 
 /* Sets up block execution context from an input test case to execute

--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -351,6 +351,12 @@ fd_solfuzz_pb_instr_ctx_destroy( fd_solfuzz_runner_t * runner,
   if( !ctx ) return;
   fd_accdb_clear( runner->accdb_admin );
   fd_progcache_clear( runner->progcache_admin );
+
+  /* In order to check for leaks in the workspace, we need to compact the
+     allocators. Without doing this, empty superblocks may be retained
+     by the fd_alloc instance, which mean we cannot check for leaks. */
+  fd_alloc_compact( runner->accdb_admin->funk->alloc );
+  fd_alloc_compact( runner->progcache_admin->funk->alloc );
 }
 
 ulong

--- a/src/flamenco/runtime/tests/fd_sol_compat.c
+++ b/src/flamenco/runtime/tests/fd_sol_compat.c
@@ -160,6 +160,7 @@ sol_compat_instr_execute_v1( uchar *       out,
   fd_spad_pop( runner->spad );
 
   pb_release( &fd_exec_test_instr_context_t_msg, input );
+  fd_solfuzz_runner_leak_check( runner );
   return ok;
 }
 
@@ -182,6 +183,7 @@ sol_compat_txn_execute_v1( uchar *       out,
   fd_spad_pop( runner->spad );
 
   pb_release( &fd_exec_test_txn_context_t_msg, input );
+  fd_solfuzz_runner_leak_check( runner );
   return ok;
 }
 
@@ -204,6 +206,7 @@ sol_compat_block_execute_v1( uchar *       out,
   fd_spad_pop( runner->spad );
 
   pb_release( &fd_exec_test_block_context_t_msg, input );
+  fd_solfuzz_runner_leak_check( runner );
   return ok;
 }
 
@@ -226,6 +229,7 @@ sol_compat_elf_loader_v1( uchar *       out,
   fd_spad_pop( runner->spad );
 
   pb_release( &fd_exec_test_elf_loader_ctx_t_msg, input );
+  fd_solfuzz_runner_leak_check( runner );
   return ok;
 }
 
@@ -248,6 +252,7 @@ sol_compat_vm_syscall_execute_v1( uchar *       out,
   fd_spad_pop( runner->spad );
 
   pb_release( &fd_exec_test_syscall_context_t_msg, input );
+  fd_solfuzz_runner_leak_check( runner );
   return ok;
 }
 
@@ -270,6 +275,7 @@ sol_compat_vm_interp_v1( uchar *       out,
   fd_spad_pop( runner->spad );
 
   pb_release( &fd_exec_test_syscall_context_t_msg, input );
+  fd_solfuzz_runner_leak_check( runner );
   return ok;
 }
 

--- a/src/flamenco/runtime/tests/fd_solfuzz.h
+++ b/src/flamenco/runtime/tests/fd_solfuzz.h
@@ -28,6 +28,8 @@
 
 struct fd_solfuzz_runner {
   fd_wksp_t *    wksp;
+  ulong          wksp_tag;
+  ulong          wksp_baseline_used_sz;
   fd_spad_t *    spad;
   fd_banks_t *   banks;
   fd_bank_t *    bank;

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -37,6 +37,12 @@ static void
 fd_solfuzz_txn_ctx_destroy( fd_solfuzz_runner_t * runner ) {
   fd_accdb_clear( runner->accdb_admin );
   fd_progcache_clear( runner->progcache_admin );
+
+  /* In order to check for leaks in the workspace, we need to compact the
+     allocators. Without doing this, empty superblocks may be retained
+     by the fd_alloc instance, which mean we cannot check for leaks. */
+  fd_alloc_compact( runner->accdb_admin->funk->alloc );
+  fd_alloc_compact( runner->progcache_admin->funk->alloc );
 }
 
 /* Creates transaction execution context for a single test case.


### PR DESCRIPTION
Add a check at the end of every test execution to ensure that we do not leak memory. Note that we need to compact the fd_alloc instances before doing this, otherwise unused superblocks may be leaked.