### PR TITLE
flamenco, runtime: correctly pass instr_data_len to fd_native_cpi_native_invoke

### DIFF
--- a/src/flamenco/runtime/program/fd_address_lookup_table_program.c
+++ b/src/flamenco/runtime/program/fd_address_lookup_table_program.c
@@ -349,10 +349,11 @@ create_lookup_table( fd_exec_instr_ctx_t *       ctx,
       return FD_EXECUTOR_INSTR_ERR_FATAL;
     }
 
+    ulong instr_data_sz = (ulong)( (uchar *)encode_ctx.data - instr_data );
     err = fd_native_cpi_native_invoke( ctx,
                                        &fd_solana_system_program_id,
                                        instr_data,
-                                       FD_TXN_MTU,
+                                       instr_data_sz,
                                        acct_metas,
                                        2UL,
                                        signers,
@@ -391,10 +392,11 @@ create_lookup_table( fd_exec_instr_ctx_t *       ctx,
   }
 
   // Execute allocate instruction
+  ulong instr_data_sz = (ulong)( (uchar *)encode_ctx.data - instr_data );
   err = fd_native_cpi_native_invoke( ctx,
                                      &fd_solana_system_program_id,
                                      instr_data,
-                                     FD_TXN_MTU,
+                                     instr_data_sz,
                                      acct_metas,
                                      1UL,
                                      signers,
@@ -423,10 +425,11 @@ create_lookup_table( fd_exec_instr_ctx_t *       ctx,
   }
 
   // Execute assign instruction
+  instr_data_sz = (ulong)( (uchar *)encode_ctx.data - instr_data );
   err = fd_native_cpi_native_invoke( ctx,
                                      &fd_solana_system_program_id,
                                      instr_data,
-                                     FD_TXN_MTU,
+                                     instr_data_sz,
                                      acct_metas,
                                      1UL,
                                      signers,
@@ -772,10 +775,11 @@ extend_lookup_table( fd_exec_instr_ctx_t *       ctx,
       return FD_EXECUTOR_INSTR_ERR_FATAL;
     }
 
+    ulong instr_data_sz = (ulong)( (uchar *)encode_ctx.data - instr_data );
     err = fd_native_cpi_native_invoke( ctx,
                                        &fd_solana_system_program_id,
                                        instr_data,
-                                       FD_TXN_MTU,
+                                       instr_data_sz,
                                        acct_metas,
                                        2UL,
                                        signers,

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -832,10 +832,11 @@ common_extend_program( fd_exec_instr_ctx_t * instr_ctx,
     fd_native_cpi_create_account_meta( payer_key,       1UL, 1UL, &acct_metas[ 0UL ] );
     fd_native_cpi_create_account_meta( programdata_key, 0UL, 1UL, &acct_metas[ 1UL ] );
 
+    ulong instr_data_sz = (ulong)( (uchar *)encode_ctx.data - instr_data );
     err = fd_native_cpi_native_invoke( instr_ctx,
                                        &fd_solana_system_program_id,
                                        instr_data,
-                                       FD_TXN_MTU,
+                                       instr_data_sz,
                                        acct_metas,
                                        2UL,
                                        NULL,
@@ -1256,10 +1257,11 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
       if( FD_UNLIKELY( err ) ) {
         return err;
       }
+      ulong instr_data_sz = (ulong)( (uchar *)encode_ctx.data - instr_data );
       err = fd_native_cpi_native_invoke( instr_ctx,
                                          &fd_solana_system_program_id,
                                          instr_data,
-                                         FD_TXN_MTU,
+                                         instr_data_sz,
                                          acct_metas,
                                          3UL,
                                          signers,
@@ -2226,10 +2228,11 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
           return FD_EXECUTOR_INSTR_ERR_FATAL;
         }
 
+        ulong instr_data_sz = (ulong)( (uchar *)encode_ctx.data - instr_data );
         err = fd_native_cpi_native_invoke( instr_ctx,
                                            &fd_solana_bpf_loader_v4_program_id,
                                            instr_data,
-                                           FD_TXN_MTU,
+                                           instr_data_sz,
                                            acct_metas,
                                            3UL,
                                            NULL,
@@ -2266,10 +2269,11 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
           return FD_EXECUTOR_INSTR_ERR_FATAL;
         }
 
+        instr_data_sz = (ulong)( (uchar *)encode_ctx.data - instr_data );
         err = fd_native_cpi_native_invoke( instr_ctx,
                                            &fd_solana_bpf_loader_v4_program_id,
                                            instr_data,
-                                           FD_TXN_MTU,
+                                           instr_data_sz,
                                            acct_metas,
                                            3UL,
                                            NULL,
@@ -2298,10 +2302,11 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
           return FD_EXECUTOR_INSTR_ERR_FATAL;
         }
 
+        instr_data_sz = (ulong)( (uchar *)encode_ctx.data - instr_data );
         err = fd_native_cpi_native_invoke( instr_ctx,
                                            &fd_solana_bpf_loader_v4_program_id,
                                            instr_data,
-                                           FD_TXN_MTU,
+                                           instr_data_sz,
                                            acct_metas,
                                            2UL,
                                            NULL,
@@ -2332,10 +2337,11 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
             return FD_EXECUTOR_INSTR_ERR_FATAL;
           }
 
+          instr_data_sz = (ulong)( (uchar *)encode_ctx.data - instr_data );
           err = fd_native_cpi_native_invoke( instr_ctx,
                                              &fd_solana_bpf_loader_v4_program_id,
                                              instr_data,
-                                             FD_TXN_MTU,
+                                             instr_data_sz,
                                              acct_metas,
                                              3UL,
                                              NULL,
@@ -2366,10 +2372,11 @@ process_loader_upgradeable_instruction( fd_exec_instr_ctx_t * instr_ctx ) {
             return FD_EXECUTOR_INSTR_ERR_FATAL;
           }
 
+          instr_data_sz = (ulong)( (uchar *)encode_ctx.data - instr_data );
           err = fd_native_cpi_native_invoke( instr_ctx,
                                              &fd_solana_bpf_loader_v4_program_id,
                                              instr_data,
-                                             FD_TXN_MTU,
+                                             instr_data_sz,
                                              acct_metas,
                                              3UL,
                                              NULL,


### PR DESCRIPTION
Addresses https://github.com/firedancer-io/auditor-internal/issues/343