### PR TITLE
Revert "flamenco, vm: clean up loosen_cpi_size_restriction"

### DIFF
--- a/src/flamenco/features/fd_features_generated.c
+++ b/src/flamenco/features/fd_features_generated.c
@@ -771,7 +771,7 @@ fd_feature_id_t const ids[] = {
     .id                        = {"\xe2\x04\x73\xa5\xa7\x6f\x1e\xe2\x8a\xb6\x64\xde\x46\xec\x20\x34\xdf\xdf\x68\xf9\xe7\x11\x5c\x2c\xe1\x6a\xa6\x27\x91\xec\x3d\xda"},
                                  /* GDH5TVdbTPUpRnXaRyQqiKUa7uZAbZ28Q2N9bhbKoMLm */
     .name                      = "loosen_cpi_size_restriction",
-    .cleaned_up                = {3, 0, 0},
+    .cleaned_up                = {UINT_MAX, UINT_MAX, UINT_MAX},
     .hardcode_for_fuzzing = 1 },
 
   { .index                     = offsetof(fd_features_t, use_default_units_in_fee_calculation)>>3,

--- a/src/flamenco/features/feature_map.json
+++ b/src/flamenco/features/feature_map.json
@@ -109,7 +109,7 @@
   {"name":"skip_rent_rewrites","pubkey": "CGB2jM8pwZkeeiXQ66kBMyBR6Np61mggL7XUsmLjVcrw","cleaned_up":[3,0,0],"hardcode_for_fuzzing":1},
   {"name":"prevent_crediting_accounts_that_end_rent_paying","pubkey": "812kqX67odAp5NFwM8D2N24cku7WTm9CHUTFUXaDkWPn","cleaned_up":[1,18,0],"hardcode_for_fuzzing":1},
   {"name":"cap_bpf_program_instruction_accounts","pubkey": "9k5ijzTbYPtjzu8wj2ErH9v45xecHzQ1x4PMYMMxFgdM","cleaned_up":[1,18,0],"hardcode_for_fuzzing":1},
-  {"name":"loosen_cpi_size_restriction","pubkey": "GDH5TVdbTPUpRnXaRyQqiKUa7uZAbZ28Q2N9bhbKoMLm","cleaned_up":[3,0,0],"hardcode_for_fuzzing":1},
+  {"name":"loosen_cpi_size_restriction","pubkey": "GDH5TVdbTPUpRnXaRyQqiKUa7uZAbZ28Q2N9bhbKoMLm","hardcode_for_fuzzing":1},
   {"name":"use_default_units_in_fee_calculation","pubkey": "8sKQrMQoUHtQSUP83SPG4ta2JDjSAiWs7t5aJ9uEd6To","cleaned_up":[1,18,0],"hardcode_for_fuzzing":1},
   {"name":"compact_vote_state_updates","pubkey": "86HpNqzutEZwLcPxS6EHDcMNYWk6ikhteg9un7Y2PBKE","cleaned_up":[1,18,0],"hardcode_for_fuzzing":1},
   {"name":"incremental_snapshot_only_incremental_hash_calculation","pubkey": "25vqsfjk7Nv1prsQJmA4Xu1bN61s8LXCBGUPp8Rfy1UF","cleaned_up":[2,3,0],"hardcode_for_fuzzing":1},

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi.c
@@ -251,17 +251,29 @@ get_cpi_max_account_infos( fd_bank_t * bank ) {
    to instruction data size. */
 
 static int
-fd_vm_syscall_cpi_check_instruction( ulong acct_cnt, ulong data_sz ) {
+fd_vm_syscall_cpi_check_instruction( fd_vm_t const * vm,
+                                     ulong           acct_cnt,
+                                     ulong           data_sz ) {
   /* https://github.com/anza-xyz/agave/blob/v3.1.2/program-runtime/src/cpi.rs#L146-L161 */
-  if( FD_UNLIKELY( acct_cnt > FD_CPI_MAX_INSTRUCTION_ACCOUNTS ) ) {
-    FD_LOG_WARNING(( "cpi: too many accounts (%#lx)", acct_cnt ));
-    // SyscallError::MaxInstructionAccountsExceeded
-    return FD_VM_SYSCALL_ERR_MAX_INSTRUCTION_ACCOUNTS_EXCEEDED;
-  }
-  if( FD_UNLIKELY( data_sz>FD_RUNTIME_CPI_MAX_INSTR_DATA_LEN ) ) {
-    FD_LOG_WARNING(( "cpi: data too long (%#lx)", data_sz ));
-    // SyscallError::MaxInstructionDataLenExceeded
-    return FD_VM_SYSCALL_ERR_MAX_INSTRUCTION_DATA_LEN_EXCEEDED;
+  if( FD_FEATURE_ACTIVE_BANK( vm->instr_ctx->bank, loosen_cpi_size_restriction ) ) {
+    if( FD_UNLIKELY( acct_cnt > FD_CPI_MAX_INSTRUCTION_ACCOUNTS ) ) {
+      FD_LOG_WARNING(( "cpi: too many accounts (%#lx)", acct_cnt ));
+      // SyscallError::MaxInstructionAccountsExceeded
+      return FD_VM_SYSCALL_ERR_MAX_INSTRUCTION_ACCOUNTS_EXCEEDED;
+    }
+    if( FD_UNLIKELY( data_sz>FD_RUNTIME_CPI_MAX_INSTR_DATA_LEN ) ) {
+      FD_LOG_WARNING(( "cpi: data too long (%#lx)", data_sz ));
+      // SyscallError::MaxInstructionDataLenExceeded
+      return FD_VM_SYSCALL_ERR_MAX_INSTRUCTION_DATA_LEN_EXCEEDED;
+    }
+  } else {
+    // https://github.com/solana-labs/solana/blob/dbf06e258ae418097049e845035d7d5502fe1327/programs/bpf_loader/src/syscalls/cpi.rs#L1114
+    ulong tot_sz = fd_ulong_sat_add( fd_ulong_sat_mul( FD_VM_RUST_ACCOUNT_META_SIZE, acct_cnt ), data_sz );
+    if ( FD_UNLIKELY( tot_sz > FD_VM_MAX_CPI_INSTRUCTION_SIZE ) ) {
+      FD_LOG_WARNING(( "cpi: instruction too long (%#lx)", tot_sz ));
+      // SyscallError::InstructionTooLarge
+      return FD_VM_SYSCALL_ERR_INSTRUCTION_TOO_LARGE;
+    }
   }
 
   return FD_VM_SUCCESS;

--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
@@ -710,16 +710,17 @@ VM_SYSCALL_CPI_ENTRYPOINT( void *  _vm,
 
   /* Instruction checks ***********************************************/
 
-  int err = fd_vm_syscall_cpi_check_instruction( VM_SYSCALL_CPI_INSTR_ACCS_LEN( cpi_instruction ), VM_SYSCALL_CPI_INSTR_DATA_LEN( cpi_instruction ) );
+  int err = fd_vm_syscall_cpi_check_instruction( vm, VM_SYSCALL_CPI_INSTR_ACCS_LEN( cpi_instruction ), VM_SYSCALL_CPI_INSTR_DATA_LEN( cpi_instruction ) );
   if( FD_UNLIKELY( err ) ) {
     FD_VM_ERR_FOR_LOG_SYSCALL( vm, err );
     return err;
   }
 
   /* Agave consumes CU in translate_instruction
-     Rust ABI: https://github.com/anza-xyz/agave/blob/v3.1.1/program-runtime/src/cpi.rs#L551-L553
-     C ABI:    https://github.com/anza-xyz/agave/blob/v3.1.1/program-runtime/src/cpi.rs#L682-L684 */
-  FD_VM_CU_UPDATE( vm, VM_SYSCALL_CPI_INSTR_DATA_LEN( cpi_instruction ) / FD_VM_CPI_BYTES_PER_UNIT );
+     https://github.com/anza-xyz/agave/blob/838c1952595809a31520ff1603a13f2c9123aa51/programs/bpf_loader/src/syscalls/cpi.rs#L445 */
+  if( FD_FEATURE_ACTIVE_BANK( vm->instr_ctx->bank, loosen_cpi_size_restriction ) ) {
+    FD_VM_CU_UPDATE( vm, VM_SYSCALL_CPI_INSTR_DATA_LEN( cpi_instruction ) / FD_VM_CPI_BYTES_PER_UNIT );
+  }
 
   /* Final checks for translate_instruction
    */


### PR DESCRIPTION
Reverts firedancer-io/firedancer#7483

Some of our backtest ledgers don't have this feature cleaned up yet