### PR TITLE
Allow systems without NUMA support to start up

### DIFF
--- a/src/disco/topo/fd_cpu_topo.c
+++ b/src/disco/topo/fd_cpu_topo.c
@@ -59,13 +59,13 @@ fd_topo_cpus_online( ulong cpu_idx ) {
 
 void
 fd_topo_cpus_init( fd_topo_cpus_t * cpus ) {
-  cpus->numa_node_cnt = fd_numa_node_cnt();
+  cpus->numa_node_cnt = fd_numa_node_cnt( 0 );
   cpus->cpu_cnt = fd_topo_cpu_cnt();
 
   for( ulong i=0UL; i<cpus->cpu_cnt; i++ ) {
     cpus->cpu[ i ].idx = i;
     cpus->cpu[ i ].online = fd_topo_cpus_online( i );
-    cpus->cpu[ i ].numa_node = fd_numa_node_idx( i );
+    cpus->cpu[ i ].numa_node = fd_numa_node_idx( i, 0 );
     if( FD_LIKELY( cpus->cpu[ i ].online ) ) cpus->cpu[ i ].sibling = fd_tile_private_sibling_idx( i );
     else                                     cpus->cpu[ i ].sibling = ULONG_MAX;
   }

--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -587,7 +587,8 @@ fd_topob_auto_layout( fd_topo_t * topo,
 }
 
 ulong
-fd_numa_node_idx( ulong cpu_idx );
+fd_numa_node_idx( ulong cpu_idx,
+                  int   numa_enabled );
 
 static void
 initialize_numa_assignments( fd_topo_t * topo ) {
@@ -618,7 +619,7 @@ initialize_numa_assignments( fd_topo_t * topo ) {
     for( ulong j=0UL; j<topo->tile_cnt; j++ ) {
       fd_topo_tile_t * tile = &topo->tiles[ j ];
       if( FD_UNLIKELY( tile->tile_obj_id==max_obj && tile->cpu_idx<FD_TILE_MAX ) ) {
-        topo->workspaces[ i ].numa_idx = fd_numa_node_idx( tile->cpu_idx );
+        topo->workspaces[ i ].numa_idx = fd_numa_node_idx( tile->cpu_idx, 0 );
         FD_TEST( topo->workspaces[ i ].numa_idx!=ULONG_MAX );
         found_strict   = 1;
         found_lazy     = 1;
@@ -636,7 +637,7 @@ initialize_numa_assignments( fd_topo_t * topo ) {
         fd_topo_tile_t * tile = &topo->tiles[ j ];
         for( ulong k=0UL; k<tile->uses_obj_cnt; k++ ) {
           if( FD_LIKELY( tile->uses_obj_id[ k ]==max_obj && tile->cpu_idx<FD_TILE_MAX ) ) {
-            topo->workspaces[ i ].numa_idx = fd_numa_node_idx( tile->cpu_idx );
+            topo->workspaces[ i ].numa_idx = fd_numa_node_idx( tile->cpu_idx, 0 );
             FD_TEST( topo->workspaces[ i ].numa_idx!=ULONG_MAX );
             found_lazy     = 1;
             found_assigned = 1;

--- a/src/util/shmem/fd_numa_linux.c
+++ b/src/util/shmem/fd_numa_linux.c
@@ -40,17 +40,18 @@ fd_numa_private_parse_node_idx( char const * s ) {
 }
 
 ulong
-fd_numa_node_cnt( void ) {
+fd_numa_node_cnt( int numa_enabled ) {
 
-  /* Open sysfs dir containing NUMA config.  Abort if this fails. */
+  /* Open sysfs dir containing NUMA config.  On systems confirmed to
+     lack NUMA support (numa_enabled==0, detected via ENOSYS from NUMA
+     policy syscalls), a missing directory is expected; treat it as a
+     single NUMA node.  When NUMA syscalls are available, ENOENT is
+     ambiguous and is treated as an error. */
 
   char const * path = "/sys/devices/system/node";
   DIR *        dir  = opendir( path );
   if( FD_UNLIKELY( !dir ) ) {
-    // On some systems (such as a Linux container running in Docker on a Mac), parts of the file system
-    // are not set up the way we expect it to be on Linux. E.g., `/sys/devices/system/node` does not
-    // exist - if we are in such a system, assume that we only have a single NUMA node and continue
-    if ( errno == ENOENT ) return 1UL;
+    if( errno==ENOENT && !numa_enabled ) return 1UL;
     FD_LOG_WARNING(( "opendir( \"%s\" ) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
     return 0UL;
   }
@@ -95,7 +96,8 @@ fd_numa_cpu_cnt( void ) {
 }
 
 ulong
-fd_numa_node_idx( ulong cpu_idx ) {
+fd_numa_node_idx( ulong cpu_idx,
+                  int   numa_enabled ) {
 
   /* Open sysfs dir containing CPU config.  Abort if this fails. */
 
@@ -122,7 +124,10 @@ fd_numa_node_idx( ulong cpu_idx ) {
     FD_LOG_WARNING(( "closedir( \"%s\" ) failed (%i-%s); attempting to continue", path, errno, fd_io_strerror( errno ) ));
 
   if( FD_UNLIKELY( node_idx<0 ) ) {
-    FD_LOG_WARNING(( "No numa node found in \"%s\" - assuming NUMA node 0", path ));
+    if( numa_enabled ) {
+      FD_LOG_WARNING(( "No numa node found in \"%s\"", path ));
+      return ULONG_MAX;
+    }
     return 0UL;
   }
 
@@ -180,9 +185,10 @@ fd_numa_get_mempolicy( int *   mode,
                        ulong * nodemask,
                        ulong   maxnode,
                        void *  addr,
-                       uint    flags ) {
+                       uint    flags,
+                       int     numa_enabled ) {
   long rc = syscall( SYS_get_mempolicy, mode, nodemask, maxnode, addr, flags );
-  if ( rc && errno == ENOSYS ) {
+  if( rc && errno==ENOSYS && !numa_enabled ) {
     FD_LOG_WARNING(( "System appears to not support NUMA - unable to get mempolicy. Attempting to continue..." ));
     return 0L;
   }
@@ -196,9 +202,10 @@ fd_numa_get_mempolicy( int *   mode,
 long
 fd_numa_set_mempolicy( int           mode,
                        ulong const * nodemask,
-                       ulong         maxnode ) {
+                       ulong         maxnode,
+                       int           numa_enabled ) {
   long rc = syscall( SYS_set_mempolicy, mode, nodemask, maxnode );
-  if ( rc && errno == ENOSYS ) {
+  if( rc && errno==ENOSYS && !numa_enabled ) {
     FD_LOG_WARNING(( "System appears to not support NUMA - unable to set mempolicy. Attempting to continue..." ));
     return 0L;
   }
@@ -211,9 +218,10 @@ fd_numa_mbind( void *        addr,
                int           mode,
                ulong const * nodemask,
                ulong         maxnode,
-               uint          flags ) {
+               uint          flags,
+               int           numa_enabled ) {
   long rc = syscall( SYS_mbind, addr, len, mode, nodemask, maxnode, flags );
-  if ( rc && errno == ENOSYS ) {
+  if( rc && errno==ENOSYS && !numa_enabled ) {
     FD_LOG_WARNING(( "System appears to not support NUMA - unable to bind memory. Attempting to continue..." ));
     return 0L;
   }

--- a/src/util/shmem/fd_numa_stub.c
+++ b/src/util/shmem/fd_numa_stub.c
@@ -1,7 +1,8 @@
 #include "fd_shmem_private.h"
 
 ulong
-fd_numa_node_cnt( void ) {
+fd_numa_node_cnt( int numa_enabled ) {
+  (void)numa_enabled;
   FD_LOG_WARNING(( "no numa support for this build target" ));
   return 0UL;
 }
@@ -13,8 +14,9 @@ fd_numa_cpu_cnt ( void ) {
 }
 
 ulong
-fd_numa_node_idx( ulong cpu_idx ) {
-  (void)cpu_idx;
+fd_numa_node_idx( ulong cpu_idx,
+                  int   numa_enabled ) {
+  (void)cpu_idx; (void)numa_enabled;
   FD_LOG_WARNING(( "no numa support for this build target" ));
   return ULONG_MAX;
 }
@@ -44,8 +46,9 @@ fd_numa_get_mempolicy( int *   mode,
                        ulong * nodemask,
                        ulong   maxnode,
                        void *  addr,
-                       uint    flags ) {
-  (void)mode; (void)nodemask; (void)maxnode; (void)addr; (void)flags;
+                       uint    flags,
+                       int     numa_enabled ) {
+  (void)mode; (void)nodemask; (void)maxnode; (void)addr; (void)flags; (void)numa_enabled;
   FD_LOG_WARNING(( "no numa support for this build target" ));
   errno = EINVAL;
   return -1L;
@@ -54,8 +57,9 @@ fd_numa_get_mempolicy( int *   mode,
 long
 fd_numa_set_mempolicy( int           mode,
                        ulong const * nodemask,
-                       ulong         maxnode ) {
-  (void)mode; (void)nodemask; (void)maxnode;
+                       ulong         maxnode,
+                       int           numa_enabled ) {
+  (void)mode; (void)nodemask; (void)maxnode; (void)numa_enabled;
   FD_LOG_WARNING(( "no numa support for this build target" ));
   errno = EINVAL;
   return -1L;
@@ -67,8 +71,9 @@ fd_numa_mbind( void *        addr,
                int           mode,
                ulong const * nodemask,
                ulong         maxnode,
-               uint          flags ) {
-  (void)addr; (void)len; (void)mode; (void)nodemask; (void)maxnode; (void)flags;
+               uint          flags,
+               int           numa_enabled ) {
+  (void)addr; (void)len; (void)mode; (void)nodemask; (void)maxnode; (void)flags; (void)numa_enabled;
   FD_LOG_WARNING(( "no numa support for this build target" ));
   errno = EINVAL;
   return -1L;

--- a/src/util/shmem/fd_shmem_admin.c
+++ b/src/util/shmem/fd_shmem_admin.c
@@ -84,6 +84,7 @@ static ulong  fd_shmem_private_numa_cnt;                      /* 0UL at thread g
 static ulong  fd_shmem_private_cpu_cnt;                       /* " */
 static ushort fd_shmem_private_numa_idx[ FD_SHMEM_CPU_MAX  ]; /* " */
 static ushort fd_shmem_private_cpu_idx [ FD_SHMEM_NUMA_MAX ]; /* " */
+static int    fd_shmem_private_numa_avail;                    /* 0   at thread group start, initialized at boot */
 
 ulong fd_shmem_numa_cnt( void ) { return fd_shmem_private_numa_cnt; }
 ulong fd_shmem_cpu_cnt ( void ) { return fd_shmem_private_cpu_cnt;  }
@@ -232,7 +233,7 @@ fd_shmem_create_multi_flags( char const *  name,
 
   /* Save this thread's numa node mempolicy */
 
-  if( FD_UNLIKELY( fd_numa_get_mempolicy( &orig_mempolicy, orig_nodemask, FD_SHMEM_NUMA_MAX, NULL, 0UL ) ) ) {
+  if( FD_UNLIKELY( fd_numa_get_mempolicy( &orig_mempolicy, orig_nodemask, FD_SHMEM_NUMA_MAX, NULL, 0UL, fd_shmem_private_numa_avail ) ) ) {
     FD_LOG_WARNING(( "fd_numa_get_mempolicy failed (%i-%s)", errno, fd_io_strerror( errno ) ));
     ERROR( done );
   }
@@ -300,7 +301,7 @@ fd_shmem_create_multi_flags( char const *  name,
     fd_memset( nodemask, 0, 8UL*((FD_SHMEM_NUMA_MAX+63UL)/64UL) );
     nodemask[ sub_numa_idx >> 6 ] = 1UL << (sub_numa_idx & 63UL);
 
-    if( FD_UNLIKELY( fd_numa_set_mempolicy( MPOL_BIND | MPOL_F_STATIC_NODES, nodemask, FD_SHMEM_NUMA_MAX ) ) ) {
+    if( FD_UNLIKELY( fd_numa_set_mempolicy( MPOL_BIND | MPOL_F_STATIC_NODES, nodemask, FD_SHMEM_NUMA_MAX, fd_shmem_private_numa_avail ) ) ) {
       FD_LOG_WARNING(( "fd_numa_set_mempolicy failed (%i-%s)", errno, fd_io_strerror( errno ) ));
       ERROR( unmap );
     }
@@ -346,7 +347,7 @@ fd_shmem_create_multi_flags( char const *  name,
     fd_memset( nodemask, 0, 8UL*((FD_SHMEM_NUMA_MAX+63UL)/64UL) );
     nodemask[ sub_numa_idx >> 6 ] = 1UL << (sub_numa_idx & 63UL);
 
-    if( FD_UNLIKELY( fd_numa_mbind( sub_shmem, sub_sz, MPOL_BIND, nodemask, FD_SHMEM_NUMA_MAX, MPOL_MF_MOVE|MPOL_MF_STRICT ) ) ) {
+    if( FD_UNLIKELY( fd_numa_mbind( sub_shmem, sub_sz, MPOL_BIND, nodemask, FD_SHMEM_NUMA_MAX, MPOL_MF_MOVE|MPOL_MF_STRICT, fd_shmem_private_numa_avail ) ) ) {
       FD_LOG_WARNING(( "sub[%lu]: fd_numa_mbind(\"%s\",%lu KiB,MPOL_BIND,1UL<<%lu,MPOL_MF_MOVE|MPOL_MF_STRICT) failed (%i-%s)",
                        sub_idx, path, sub_sz>>10, sub_numa_idx, errno, fd_io_strerror( errno ) ));
       ERROR( unmap );
@@ -379,7 +380,7 @@ close:
     FD_LOG_ERR(( "close(\"%s\") failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
 
 restore:
-  if( FD_UNLIKELY( fd_numa_set_mempolicy( orig_mempolicy, orig_nodemask, FD_SHMEM_NUMA_MAX ) ) )
+  if( FD_UNLIKELY( fd_numa_set_mempolicy( orig_mempolicy, orig_nodemask, FD_SHMEM_NUMA_MAX, fd_shmem_private_numa_avail ) ) )
     FD_LOG_ERR(( "fd_numa_set_mempolicy failed (%i-%s)", errno, fd_io_strerror( errno ) ));
 
 done:
@@ -542,7 +543,7 @@ fd_shmem_acquire_multi( ulong         page_sz,
 
   ulong  sz = page_cnt*page_sz;
 
-  if( FD_UNLIKELY( fd_numa_get_mempolicy( &orig_mempolicy, orig_nodemask, FD_SHMEM_NUMA_MAX, NULL, 0UL ) ) ) {
+  if( FD_UNLIKELY( fd_numa_get_mempolicy( &orig_mempolicy, orig_nodemask, FD_SHMEM_NUMA_MAX, NULL, 0UL, fd_shmem_private_numa_avail ) ) ) {
     FD_LOG_WARNING(( "fd_numa_get_mempolicy failed (%i-%s)", errno, fd_io_strerror( errno ) ));
     ERROR( done );
   }
@@ -574,7 +575,7 @@ fd_shmem_acquire_multi( ulong         page_sz,
     fd_memset( nodemask, 0, 8UL*((FD_SHMEM_NUMA_MAX+63UL)/64UL) );
     nodemask[ sub_numa_idx >> 6 ] = 1UL << (sub_numa_idx & 63UL);
 
-    if( FD_UNLIKELY( fd_numa_set_mempolicy( MPOL_BIND | MPOL_F_STATIC_NODES, nodemask, FD_SHMEM_NUMA_MAX ) ) ) {
+    if( FD_UNLIKELY( fd_numa_set_mempolicy( MPOL_BIND | MPOL_F_STATIC_NODES, nodemask, FD_SHMEM_NUMA_MAX, fd_shmem_private_numa_avail ) ) ) {
       FD_LOG_WARNING(( "fd_numa_set_mempolicy failed (%i-%s)", errno, fd_io_strerror( errno ) ));
       ERROR( unmap );
     }
@@ -591,7 +592,7 @@ fd_shmem_acquire_multi( ulong         page_sz,
     fd_memset( nodemask, 0, 8UL*((FD_SHMEM_NUMA_MAX+63UL)/64UL) );
     nodemask[ sub_numa_idx >> 6 ] = 1UL << (sub_numa_idx & 63UL);
 
-    if( FD_UNLIKELY( fd_numa_mbind( sub_mem, sub_sz, MPOL_BIND, nodemask, FD_SHMEM_NUMA_MAX, MPOL_MF_MOVE|MPOL_MF_STRICT ) ) ) {
+    if( FD_UNLIKELY( fd_numa_mbind( sub_mem, sub_sz, MPOL_BIND, nodemask, FD_SHMEM_NUMA_MAX, MPOL_MF_MOVE|MPOL_MF_STRICT, fd_shmem_private_numa_avail ) ) ) {
       FD_LOG_WARNING(( "sub[%lu]: fd_numa_mbind(anon,%lu KiB,MPOL_BIND,1UL<<%lu,MPOL_MF_MOVE|MPOL_MF_STRICT) failed (%i-%s)",
                        sub_idx, sub_sz>>10, sub_numa_idx, errno, fd_io_strerror( errno ) ));
       ERROR( unmap );
@@ -615,7 +616,7 @@ unmap:
                      sz>>10, errno, fd_io_strerror( errno ) ));
 
 restore:
-  if( FD_UNLIKELY( fd_numa_set_mempolicy( orig_mempolicy, orig_nodemask, FD_SHMEM_NUMA_MAX ) ) )
+  if( FD_UNLIKELY( fd_numa_set_mempolicy( orig_mempolicy, orig_nodemask, FD_SHMEM_NUMA_MAX, fd_shmem_private_numa_avail ) ) )
     FD_LOG_WARNING(( "fd_numa_set_mempolicy failed (%i-%s); attempting to continue", errno, fd_io_strerror( errno ) ));
 
 done:
@@ -700,10 +701,25 @@ fd_shmem_private_boot( int *    pargc,
     FD_LOG_WARNING(( "fd_shmem: pthread_mutexattr_destroy failed; attempting to continue" ));
 # endif /* FD_HAS_THREADS */
 
+  /* Detect whether NUMA policy syscalls are available by probing
+     get_mempolicy.  ENOSYS is an unambiguous signal that the kernel
+     has no NUMA support (e.g. Linux containers in Docker on macOS).
+     This result gates subsequent sysfs queries: ENOENT on the node
+     directory is only treated as "single NUMA node" when NUMA syscalls
+     are confirmed unavailable; otherwise it is an error. */
+
+  int probe_mode;
+  ulong probe_nodemask[ (FD_SHMEM_NUMA_MAX+63UL)/64UL ];
+  long probe_rc = fd_numa_get_mempolicy( &probe_mode, probe_nodemask, FD_SHMEM_NUMA_MAX, NULL, 0UL, 1 );
+  int numa_avail = !(probe_rc && errno==ENOSYS);
+  if( FD_UNLIKELY( !numa_avail ) )
+    FD_LOG_WARNING(( "fd_shmem: NUMA policy syscalls not available; running without NUMA memory binding" ));
+  fd_shmem_private_numa_avail = numa_avail;
+
   /* Cache the numa topology for this thread group's host for
      subsequent fast use by the application. */
 
-  ulong numa_cnt = fd_numa_node_cnt();
+  ulong numa_cnt = fd_numa_node_cnt( numa_avail );
   if( FD_UNLIKELY( !((1UL<=numa_cnt) & (numa_cnt<=FD_SHMEM_NUMA_MAX)) ) )
     FD_LOG_ERR(( "fd_shmem: unexpected numa_cnt %lu (expected in [1,%lu])", numa_cnt, FD_SHMEM_NUMA_MAX ));
   fd_shmem_private_numa_cnt = numa_cnt;
@@ -715,7 +731,7 @@ fd_shmem_private_boot( int *    pargc,
 
   for( ulong cpu_rem=cpu_cnt; cpu_rem; cpu_rem-- ) {
     ulong cpu_idx  = cpu_rem-1UL;
-    ulong numa_idx = fd_numa_node_idx( cpu_idx );
+    ulong numa_idx = fd_numa_node_idx( cpu_idx, numa_avail );
     if( FD_UNLIKELY( numa_idx>=FD_SHMEM_NUMA_MAX) )
       FD_LOG_ERR(( "fd_shmem: unexpected numa idx (%lu) for cpu idx %lu", numa_idx, cpu_idx ));
     fd_shmem_private_numa_idx[ cpu_idx  ] = (ushort)numa_idx;
@@ -746,8 +762,9 @@ fd_shmem_private_halt( void ) {
 
   /* At this point, shared memory is offline */
 
-  fd_shmem_private_numa_cnt = 0;
-  fd_shmem_private_cpu_cnt  = 0;
+  fd_shmem_private_numa_cnt  = 0;
+  fd_shmem_private_cpu_cnt   = 0;
+  fd_shmem_private_numa_avail = 0;
   fd_memset( fd_shmem_private_numa_idx, 0, FD_SHMEM_CPU_MAX );
 
   fd_shmem_private_base[0] = '\0';

--- a/src/util/shmem/fd_shmem_private.h
+++ b/src/util/shmem/fd_shmem_private.h
@@ -30,23 +30,36 @@ FD_PROTOTYPES_BEGIN
    configured numa nodes / cpus (roughly equivalent to libnuma's
    numa_num_configured_nodes / numa_num_configured_cpus).  Returns 0 if
    this could not be determined (logs details on failure).  These
-   function are only used during shmem initialization as part of
-   topology discovery so should not do any fancy caching under the hood. */
+   functions are only used during shmem initialization as part of
+   topology discovery so should not do any fancy caching under the hood.
+
+   numa_enabled should be non-zero when NUMA policy syscalls are known
+   to be available (detected via ENOSYS probe), zero otherwise.
+   When zero, ENOENT on the sysfs NUMA node directory is treated as
+   "single NUMA node" rather than an error, since on systems without
+   NUMA the directory is expected to be absent. */
 
 ulong
-fd_numa_node_cnt( void );
+fd_numa_node_cnt( int numa_enabled );
 
 ulong
 fd_numa_cpu_cnt( void );
 
 /* fd_numa_node_idx determines the numa node closest to the given
-   cpu_idx (roughly equivalent to libnuma's numa_node_of_cpu).  Returns
-   ULONG_MAX if this could not be determined (logs details on failure).
+   cpu_idx (roughly equivalent to libnuma's numa_node_of_cpu).
+
+   When numa_enabled is non-zero (NUMA policy syscalls are available),
+   returns ULONG_MAX if the node could not be determined (logs details
+   on failure).  When numa_enabled is zero, returns 0 so that all CPUs
+   map to the single assumed NUMA node.
+
    This function is only used during shmem initialization as part of
-   topology discovery so should not do any fancy caching under the hood. */
+   topology discovery so should not do any fancy caching under the
+   hood. */
 
 ulong
-fd_numa_node_idx( ulong cpu_idx );
+fd_numa_node_idx( ulong cpu_idx,
+                  int   numa_enabled );
 
 /* FIXME: probably should clean up the below APIs to get something
    that allows for cleaner integration with fd_shmem_admin.c (e.g. if we
@@ -74,30 +87,40 @@ fd_numa_munlock( void const * addr,
 /* fd_numa_get_mempolicy retrieves the NUMA memory policy of the
    current thread.  Wraps the `get_mempolicy(2)` Linux syscall.  See:
 
-     https://man7.org/linux/man-pages/man2/get_mempolicy.2.html */
+     https://man7.org/linux/man-pages/man2/get_mempolicy.2.html
+
+   numa_enabled should be non-zero when NUMA policy syscalls are known
+   to be available, zero otherwise.  When zero, ENOSYS is treated as a
+   non-fatal condition and the call returns 0. */
 
 long
 fd_numa_get_mempolicy( int *   mode,
                        ulong * nodemask,
                        ulong   maxnode,
                        void *  addr,
-                       uint    flags );
+                       uint    flags,
+                       int     numa_enabled );
 
 /* fd_numa_set_mempolicy sets the default NUMA memory policy of the
    current thread and its children.  Wraps the `set_mempolicy(2)` Linux
    syscall.  See:
 
-     https://man7.org/linux/man-pages/man2/set_mempolicy.2.html */
+     https://man7.org/linux/man-pages/man2/set_mempolicy.2.html
+
+   See fd_numa_get_mempolicy for the numa_enabled semantics. */
 
 long
 fd_numa_set_mempolicy( int           mode,
                        ulong const * nodemask,
-                       ulong         maxnode );
+                       ulong         maxnode,
+                       int           numa_enabled );
 
 /* fd_numa_mbind sets the NUMA memory policy for a range of memory.
    Wraps the `mbind(2)` Linux syscall.  See:
 
-     https://man7.org/linux/man-pages/man2/mbind.2.html */
+     https://man7.org/linux/man-pages/man2/mbind.2.html
+
+   See fd_numa_get_mempolicy for the numa_enabled semantics. */
 
 long
 fd_numa_mbind( void *        addr,
@@ -105,7 +128,8 @@ fd_numa_mbind( void *        addr,
                int           mode,
                ulong const * nodemask,
                ulong         maxnode,
-               uint          flags );
+               uint          flags,
+               int           numa_enabled );
 
 /* fd_numa_move_page moves pages of a process to another node.  Wraps
    the `move_pages(2)` Linux syscall.  See:


### PR DESCRIPTION
Each of the changes below changes something that would have otherwise crashed right at startup to _not_ crash. I.e., it should not affect anyone running Firedancer today (unless they are unable to start, in which case, it might help them...).