### PR TITLE
vm: fix epoch rewards padding

### DIFF
--- a/src/flamenco/vm/syscall/fd_vm_syscall_runtime.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_runtime.c
@@ -606,7 +606,7 @@ fd_vm_syscall_sol_get_epoch_rewards_sysvar( /**/            void *  _vm,
     return FD_VM_ERR_INVAL;
   }
   memcpy( out, &epoch_rewards, sizeof(fd_sysvar_epoch_rewards_t) );
-  memset( out+81, 0, 7 ); /* padding */
+  memset( out+81, 0, 15 ); /* padding */
 
   *_ret = 0UL;
   return FD_VM_SUCCESS;


### PR DESCRIPTION
The epoch rewards struct has 16 byte alignment so
it has 15 bytes of padding at the end.
(81 bytes that are actually used, but 96 bytes in total)
(This issue was also rediscovered by @Nicola-Osec after I forgot to PR this)