### PR TITLE
fix arm builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -220,6 +220,6 @@ jobs:
           if [ "${{ matrix.gcc_version }}" != "8" ]; then
             source /opt/rh/gcc-toolset-${{ matrix.gcc_version }}/enable
           fi
-          ./deps.sh +dev fetch install
+          ./deps.sh fetch install
           make -j clean
           make -j all

--- a/deps.sh
+++ b/deps.sh
@@ -140,11 +140,11 @@ fetch () {
   checkout_repo s2n       https://github.com/awslabs/s2n-bignum       "" "4d2e22a"
   checkout_repo openssl   https://github.com/openssl/openssl          "openssl-3.6.0"
   checkout_repo secp256k1 https://github.com/bitcoin-core/secp256k1   "v0.7.0"
-  checkout_repo flatcc    https://github.com/dvidelabs/flatcc.git     "" "3ae5eda"
   if [[ $DEVMODE == 1 ]]; then
     checkout_repo bzip2   https://gitlab.com/bzip2/bzip2              "bzip2-1.0.8"
     checkout_repo rocksdb https://github.com/facebook/rocksdb         "v10.5.1"
     checkout_repo snappy  https://github.com/google/snappy            "1.2.2"
+    checkout_repo flatcc    https://github.com/dvidelabs/flatcc.git     "" "3ae5eda"
   fi
 }
 

--- a/src/discof/restore/fd_snapmk_para.c
+++ b/src/discof/restore/fd_snapmk_para.c
@@ -3,6 +3,7 @@
 #include "../../util/archive/fd_tar.h"
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <zstd.h>
 
 #define SNAPMK_MAGIC        (0xf212f209fd944ba2UL)


### PR DESCRIPTION
We do not install flatcc if `DEVMODE` isn't enabled, so might as well not check it out. Also `flatcc` does not compile (as-is) on arm64.