### PR TITLE
reedsol: explicitly make stack non-executable in asm file

### DIFF
--- a/src/ballet/reedsol/fd_reedsol_gfni_32.S
+++ b/src/ballet/reedsol/fd_reedsol_gfni_32.S
@@ -9,6 +9,11 @@ gfni_const_tbl:
 .incbin "src/ballet/reedsol/constants/gfni_constants.bin"
 .previous
 
+# Make stack non-executable
+.section .note.GNU-stack,"",@progbits
+
+.text
+
 fd_reedsol_private_encode_32_32:
 .globl fd_reedsol_private_encode_32_32
 .cfi_startproc


### PR DESCRIPTION
See https://github.com/firedancer-io/firedancer/pull/4456 and https://github.com/firedancer-io/auditor-internal/issues/290
Note that I couldn't reproduce the "missing .note.GNU-stack section implies executable stack" warning locally, but I don't see why it shouldn't apply in this case as well.