### PR TITLE
pktgen: set Ethertype to IP

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -1756,8 +1756,8 @@ dynamic_port_range = "8900-9000"
         #
         # The net tile queries the route and neighbor tables as part of the
         # benchmark.  In short, these resolve the dst MAC address of the
-        # outgoing Ethernet packets.  Since pktgen does not produce IPv4
-        # packets, no traffic actually gets sent to this IP.
+        # outgoing Ethernet packets.  Since pktgen does not produce
+        # valid IPv4 packets, no traffic actually gets sent to this IP.
         #
         # The IP address should fulfill these requirements:
         # - 'ip route get <IP>' resolves to the XDP interface

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -1762,7 +1762,7 @@ user = ""
         # The net tile queries the route and neighbor tables as part of
         # the benchmark.  In short, these resolve the dst MAC address of
         # the outgoing Ethernet packets.  Since pktgen does not produce
-        # IPv4 packets, no traffic actually gets sent to this IP.
+        # valid IPv4 packets, no traffic actually gets sent to this IP.
         #
         # The IP address should fulfill these requirements:
         # - 'ip route get <IP>' resolves to the XDP interface


### PR DESCRIPTION
This PR sets the pktgen ethertype to IP and the ip header version to 4 to avoid crashing the net tile and dropping tx packets. The revert backs out the previous attempt to do this, with its partial docs updates.