### PR TITLE
fix: check for nonzero consumers

### DIFF
--- a/src/disco/stem/fd_stem.c
+++ b/src/disco/stem/fd_stem.c
@@ -328,7 +328,7 @@ STEM_(run1)( ulong                        in_cnt,
   out_depth  = (ulong *)FD_SCRATCH_ALLOC_APPEND( l, alignof(ulong), out_cnt*sizeof(ulong) );
   out_seq    = (ulong *)FD_SCRATCH_ALLOC_APPEND( l, alignof(ulong), out_cnt*sizeof(ulong) );
 
-  ulong cr_max = fd_ulong_if( !out_cnt, 128UL, ULONG_MAX );
+  ulong cr_max = fd_ulong_if( !(out_cnt && cons_cnt), 128UL, ULONG_MAX );
 
   for( ulong out_idx=0UL; out_idx<out_cnt; out_idx++ ) {
 


### PR DESCRIPTION
### Background
We have a setup which uses some links with no producers, and some links with no consumers (there are a separate rust based tiles). These links have `link->permit_no_consumers = 1` or `link->permit_no_producers=1`.  Consequently, the consumer count for those with no consumers is 0.

### Problem
This `cr_max` is set to `ULONG_MAX` as some dummy value when out_cnt is nonzero, with the implicit assumption that `cons_cnt` is also nonzero. This is because there is a block of code right below this that then iterates through all the consumers to find the appropriate cr_max. However, when `out_cnt>0` and `cons_cnt=0` the dummy value remains and an "excessive lazy" `LOG_ERR` which was introduced recently is hit. 

In my culture we'd say this is "no bueno".

### Solution
Use default value of 128 when both `out_cnt` AND `cons_cnt` are nonzero.

acceleretardibrlio