### PR TITLE
http: do not search outside the header value

### DIFF
--- a/src/waltz/http/fd_http_server.c
+++ b/src/waltz/http/fd_http_server.c
@@ -575,13 +575,14 @@ read_conn_http( fd_http_server_t * http,
 
   conn->upgrade_websocket = 0;
   int compress_websocket = 0;
-  if( FD_UNLIKELY( upgrade_key && !strncmp( upgrade_key, "websocket", 9UL ) ) ) {
+  if( FD_UNLIKELY( upgrade_key && !strncasecmp( upgrade_key, "websocket", 9UL ) ) ) {
     conn->request_bytes_len = (ulong)result;
     conn->upgrade_websocket = 1;
 
 #if FD_HAS_ZSTD
     for( ulong i=0UL; i<num_headers; i++ ) {
-      if( FD_LIKELY( headers[ i ].name_len==22UL && !strncasecmp( headers[ i ].name, "Sec-WebSocket-Protocol", 22UL ) && strstr( headers[ i ].value, "compress-zstd" ) ) ) {
+      if( FD_LIKELY( headers[ i ].name_len==22UL && !strncasecmp( headers[ i ].name, "Sec-WebSocket-Protocol", 22UL ) &&
+                     headers[ i ].value_len==13UL && !strncmp( headers[ i ].value, "compress-zstd", 13UL ) ) ) {
         compress_websocket = 1;
       }
     }


### PR DESCRIPTION
Header values in picohttp are not null-terminated so `strstr` would happily search outside the header value and exceed the length of the header value.
This could lead to _DoS in artifical circumstances_ **which don't apply to fd in practice**. There is always a null byte in memory _somewhere_ after the header value even if it is not actually part of the header value. This is because `fd_http_server_ws_frame`s are allocated after the request buffer that contains the headers and the ws_frames contain four bytes of padding that is zero, because the whole memory we're operating on, has been allocated with `mmap` anonymously which zeroes the memory QED.

Drive-by fix: the `Upgrade` header field's token has to contain the value "websocket", but should be treated as an ASCII case-insensitive value: https://datatracker.ietf.org/doc/html/rfc6455#section-4.2.1