### PR TITLE
rename solcap ctx

### DIFF
--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -1499,10 +1499,10 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
 
   } else if( FD_UNLIKELY( !strcmp( tile->name, "solcap" ) ) ) {
 
-    tile->capctx.capture_start_slot = config->capture.capture_start_slot;
-    strncpy( tile->capctx.solcap_capture, config->capture.solcap_capture, sizeof(tile->capctx.solcap_capture) );
-    tile->capctx.recent_only = config->capture.recent_only;
-    tile->capctx.recent_slots_per_file = config->capture.recent_slots_per_file;
+    tile->solcap.capture_start_slot = config->capture.capture_start_slot;
+    strncpy( tile->solcap.solcap_capture, config->capture.solcap_capture, sizeof(tile->solcap.solcap_capture) );
+    tile->solcap.recent_only = config->capture.recent_only;
+    tile->solcap.recent_slots_per_file = config->capture.recent_slots_per_file;
 
   } else {
     FD_LOG_ERR(( "unknown tile name `%s`", tile->name ));

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -634,7 +634,7 @@ struct fd_topo_tile {
       char  solcap_capture[ PATH_MAX ];
       int   recent_only;
       ulong recent_slots_per_file;
-    } capctx;
+    } solcap;
   };
 };
 

--- a/src/discof/capture/fd_solcap_tile.c
+++ b/src/discof/capture/fd_solcap_tile.c
@@ -390,21 +390,21 @@ privileged_init( fd_topo_t *      topo,
   ctx->capture_ctx = fd_capture_ctx_join( fd_capture_ctx_new( _capture_ctx ) );
   FD_TEST( ctx->capture_ctx );
 
-  ctx->recent_only = tile->capctx.recent_only;
-  ctx->recent_slots_per_file = tile->capctx.recent_slots_per_file ? tile->capctx.recent_slots_per_file : 128UL;
+  ctx->recent_only = tile->solcap.recent_only;
+  ctx->recent_slots_per_file = tile->solcap.recent_slots_per_file ? tile->solcap.recent_slots_per_file : 128UL;
 
   struct stat path_stat;
-  int stat_result = stat( tile->capctx.solcap_capture, &path_stat );
+  int stat_result = stat( tile->solcap.solcap_capture, &path_stat );
 
   if( ctx->recent_only ) {
     /* recent_only=1: Ensure path is a directory, create if not exists */
     if( stat_result != 0 ) {
-      if( FD_UNLIKELY( mkdir(tile->capctx.solcap_capture, 0755) != 0 ) ) {
+      if( FD_UNLIKELY( mkdir(tile->solcap.solcap_capture, 0755) != 0 ) ) {
         FD_LOG_ERR(( "solcap_recent_only=1 but could not create directory: %s (%i-%s)",
-                   tile->capctx.solcap_capture, errno, strerror(errno) ));
+                   tile->solcap.solcap_capture, errno, strerror(errno) ));
       }
     } else if( FD_UNLIKELY( !S_ISDIR(path_stat.st_mode) ) ) {
-      FD_LOG_ERR(( "solcap_recent_only=1 but path is not a directory: %s", tile->capctx.solcap_capture ));
+      FD_LOG_ERR(( "solcap_recent_only=1 but path is not a directory: %s", tile->solcap.solcap_capture ));
     }
 
     ctx->recent_current_idx = 0;
@@ -412,7 +412,7 @@ privileged_init( fd_topo_t *      topo,
 
     for( ulong i = 0; i < 2; i++ ) {
       char filepath[PATH_MAX];
-      int ret = snprintf( filepath, PATH_MAX, "%s/recent_%lu.solcap", tile->capctx.solcap_capture, i );
+      int ret = snprintf( filepath, PATH_MAX, "%s/recent_%lu.solcap", tile->solcap.solcap_capture, i );
       if( FD_UNLIKELY( ret<0 || ret>=PATH_MAX ) ) {
         FD_LOG_ERR(( "snprintf failed or path too long for recent file %lu", i ));
       }
@@ -429,19 +429,19 @@ privileged_init( fd_topo_t *      topo,
   } else {
     /* recent_only=0: Validate that path is a file*/
     if( FD_UNLIKELY( stat_result == 0 && S_ISDIR(path_stat.st_mode) ) ) {
-      FD_LOG_ERR(( "solcap_recent_only=0 but path is a directory: %s (should be a file path)", tile->capctx.solcap_capture ));
+      FD_LOG_ERR(( "solcap_recent_only=0 but path is a directory: %s (should be a file path)", tile->solcap.solcap_capture ));
     }
 
-    ctx->fd = open( tile->capctx.solcap_capture, O_RDWR | O_CREAT | O_TRUNC, 0644 );
+    ctx->fd = open( tile->solcap.solcap_capture, O_RDWR | O_CREAT | O_TRUNC, 0644 );
     if( FD_UNLIKELY( ctx->fd == -1 ) ) {
       FD_LOG_ERR(( "failed to open or create solcap capture file %s (%i-%s)",
-                   tile->capctx.solcap_capture, errno, strerror(errno) ));
+                   tile->solcap.solcap_capture, errno, strerror(errno) ));
     }
   }
 
   FD_TEST( ctx->capture_ctx->capture );
 
-  ctx->capture_ctx->solcap_start_slot = tile->capctx.capture_start_slot;
+  ctx->capture_ctx->solcap_start_slot = tile->solcap.capture_start_slot;
   fd_solcap_writer_init( ctx->capture_ctx->capture, ctx->fd );
 
   ctx->current_in_idx = ULONG_MAX;  /* No active message initially */


### PR DESCRIPTION
union members of fd_topo_tile should be called like the tile. This also avoids false positives from the tile-union-mismatch CodeQL query