### PR TITLE
runtime: fix uninitialized read in bank manager

### DIFF
--- a/src/flamenco/runtime/fd_bank.c
+++ b/src/flamenco/runtime/fd_bank.c
@@ -498,7 +498,7 @@ fd_banks_init_bank( fd_banks_t * banks ) {
   #define HAS_COW_0(name)
 
   #define HAS_LOCK_1(name) \
-    fd_rwlock_unwrite(&bank->name##_lock);
+    fd_rwlock_new( &bank->name##_lock );
   #define HAS_LOCK_0(name)
 
   #define X(type, name, footprint, align, cow, limit_fork_width, has_lock) \
@@ -513,12 +513,16 @@ fd_banks_init_bank( fd_banks_t * banks ) {
 
   fd_bank_set_cost_tracker_pool( bank, fd_banks_get_cost_tracker_pool( banks ) );
   bank->cost_tracker_pool_idx = fd_bank_cost_tracker_pool_idx_null( fd_bank_get_cost_tracker_pool( bank ) );
-  fd_rwlock_unwrite( &bank->cost_tracker_lock );
+  fd_rwlock_new( &bank->cost_tracker_lock );
+
+  bank->stake_delegations_delta_dirty = 0;
+  fd_rwlock_new( &bank->stake_delegations_delta_lock );
 
   bank->flags |= FD_BANK_FLAGS_INIT | FD_BANK_FLAGS_REPLAYABLE | FD_BANK_FLAGS_FROZEN;
   bank->refcnt = 0UL;
 
   bank->first_fec_set_received_nanos      = fd_log_wallclock();
+  bank->preparation_begin_nanos           = 0L;
   bank->first_transaction_scheduled_nanos = 0L;
   bank->last_transaction_finished_nanos   = 0L;
 


### PR DESCRIPTION
Also reduce memory requirements of test_bank

```
==2354302==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x55555565c8b6 in fd_rwlock_write /data/r/firedancer/src/flamenco/runtime/../stakes/../runtime/info/../../accdb/../../funk/../flamenco/fd_rwlock.h:29:9
    #1 0x55555565c8b6 in fd_bank_stake_delegations_delta_locking_modify /data/r/firedancer/src/flamenco/runtime/fd_bank.h:645:3
    #2 0x55555565c8b6 in main /data/r/firedancer/src/flamenco/runtime/test_bank.c:302:48
    #3 0x7ffff78295cf in __libc_start_call_main (/lib64/libc.so.6+0x295cf) (BuildId: d09a919a085d10d01109d735dd5c5b710cae4b2c)
    #4 0x7ffff782967f in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x2967f) (BuildId: d09a919a085d10d01109d735dd5c5b710cae4b2c)
    #5 0x5555555bb5b4 in _start (/data/r/firedancer/build/clang-msan/unit-test/test_bank+0x675b4) (BuildId: ccda77ee26e17e6cb72978f8dbabc501a6d8effd)
```