### PR TITLE
accdb: fix query race while rooting

### DIFF
--- a/src/flamenco/accdb/fd_accdb_admin.c
+++ b/src/flamenco/accdb/fd_accdb_admin.c
@@ -200,10 +200,15 @@ fd_accdb_cancel( fd_accdb_admin_t *        accdb,
                  fd_funk_txn_xid_t const * xid ) {
   fd_funk_t * funk = accdb->funk;
 
-  fd_funk_txn_t * txn = fd_funk_txn_query( xid, funk->txn_map );
-  if( FD_UNLIKELY( !txn ) ) {
-    FD_LOG_CRIT(( "fd_accdb_txn_cancel failed: txn with xid %lu:%lu not found", xid->ul[0], xid->ul[1] ));
+  /* Assume no concurrent access to txn_map */
+
+  fd_funk_txn_map_query_t query[1];
+  int query_err = fd_funk_txn_map_query_try( funk->txn_map, xid, NULL, query, 0 );
+  if( FD_UNLIKELY( query_err ) ) {
+    FD_LOG_CRIT(( "fd_accdb_cancel failed: fd_funk_txn_map_query_try(xid=%lu:%lu) returned (%i-%s)",
+                   xid->ul[0], xid->ul[1], query_err, fd_map_strerror( query_err ) ));
   }
+  fd_funk_txn_t * txn = fd_funk_txn_map_query_ele( query );
 
   fd_accdb_txn_cancel_next_list( accdb, txn );
   fd_accdb_txn_cancel_tree( accdb, txn );
@@ -341,10 +346,15 @@ fd_accdb_advance_root( fd_accdb_admin_t *        accdb,
                        fd_funk_txn_xid_t const * xid ) {
   fd_funk_t * funk = accdb->funk;
 
-  fd_funk_txn_t * txn = fd_funk_txn_query( xid, funk->txn_map );
-  if( FD_UNLIKELY( !txn ) ) {
-    FD_LOG_CRIT(( "fd_accdb_txn_advance_root failed: txn with xid %lu:%lu not found", xid->ul[0], xid->ul[1] ));
+  /* Assume no concurrent access to txn_map */
+
+  fd_funk_txn_map_query_t query[1];
+  int query_err = fd_funk_txn_map_query_try( funk->txn_map, xid, NULL, query, 0 );
+  if( FD_UNLIKELY( query_err ) ) {
+    FD_LOG_CRIT(( "fd_accdb_advance_root failed: fd_funk_txn_map_query_try(xid=%lu:%lu) returned (%i-%s)",
+                   xid->ul[0], xid->ul[1], query_err, fd_map_strerror( query_err ) ));
   }
+  fd_funk_txn_t * txn = fd_funk_txn_map_query_ele( query );
 
   if( FD_UNLIKELY( !fd_funk_txn_idx_is_null( fd_funk_txn_idx( txn->parent_cidx ) ) ) ) {
     FD_LOG_CRIT(( "fd_accdb_txn_advance_root: parent of txn %lu:%lu is not root", xid->ul[0], xid->ul[1] ));

--- a/src/flamenco/progcache/fd_progcache_user.c
+++ b/src/flamenco/progcache/fd_progcache_user.c
@@ -476,16 +476,36 @@ fd_progcache_lock_best_txn( fd_progcache_t * cache,
 
   /* Backtrack up to newer fork graph nodes (>= access slot)
      Very old slots could have been rooted at this point */
-  fd_funk_txn_t * txn;
   do {
     /* Locate fork */
     fd_funk_txn_xid_t const * xid = &cache->fork[ target_xid_idx ];
-    txn = fd_funk_txn_query( xid, cache->funk->txn_map );
-    if( FD_LIKELY( txn ) ) {
-      /* Attempt to read-lock transaction */
-      if( FD_LIKELY( fd_progcache_txn_try_lock( txn ) ) ) return txn;
+
+    /* Speculatively query txn_map (recovering from ongoing rooting),
+       and lock target transaction */
+    for(;;) {
+      fd_funk_txn_map_query_t query[1];
+      int query_err = fd_funk_txn_map_query_try( cache->funk->txn_map, xid, NULL, query, 0 );
+      if( FD_UNLIKELY( query_err==FD_MAP_ERR_AGAIN ) ) {
+        /* FIXME random backoff */
+        FD_SPIN_PAUSE();
+        continue;
+      }
+      if( FD_LIKELY( query_err==FD_MAP_SUCCESS ) ) {
+        /* Attempt to read-lock transaction */
+        fd_funk_txn_t * txn = fd_funk_txn_map_query_ele( query );
+        if( FD_LIKELY( fd_progcache_txn_try_lock( txn ) ) ) {
+          FD_TEST( fd_funk_txn_map_query_test( query )==FD_MAP_SUCCESS );
+          return txn;
+        }
+        /* currently being rooted */
+      } else if( FD_UNLIKELY( query_err!=FD_MAP_ERR_KEY ) ) {
+        FD_LOG_CRIT(( "fd_funk_txn_map_query_try failed (%i-%s)", query_err, fd_map_strerror( query_err ) ));
+      }
+      break;
     }
-    /* Cannot insert at this fork graph node, try one newer */
+
+    /* Cannot insert at this fork graph node (already rooted, or
+       currently being rooted), try one newer */
     target_xid_idx--;
   } while( target_xid_idx!=ULONG_MAX );
 
@@ -657,12 +677,29 @@ fd_progcache_invalidate( fd_progcache_t *          cache,
 
   if( FD_UNLIKELY( !cache || !funk->shmem ) ) FD_LOG_CRIT(( "NULL progcache" ));
 
+  /* Resolve the fork graph node at xid.  Due to (unrelated) ongoing
+     root operations, recover from temporary lock issues. */
+
+  fd_funk_txn_t * txn = NULL;
+  for(;;) {
+    fd_funk_txn_map_query_t query[1];
+    int query_err = fd_funk_txn_map_query_try( funk->txn_map, xid, NULL, query, 0 );
+    if( FD_UNLIKELY( query_err==FD_MAP_ERR_AGAIN ) ) {
+      /* FIXME random backoff */
+      FD_SPIN_PAUSE();
+      continue;
+    }
+    if( FD_UNLIKELY( query_err ) ) {
+      FD_LOG_CRIT(( "fd_progcache_invalidate(xid=%lu:%lu) failed: fd_funk_txn_map_query_try returned (%i-%s)",
+                    xid->ul[0], xid->ul[1], query_err, fd_map_strerror( query_err ) ));
+    }
+    txn = fd_funk_txn_map_query_ele( query );
+    break;
+  }
+
   /* Select a fork node to create invalidate record in
      Do not create invalidation records at the funk root */
 
-  if( fd_funk_txn_xid_eq( xid, cache->funk->shmem->last_publish ) ) return NULL;
-
-  fd_funk_txn_t * txn = fd_funk_txn_query( xid, funk->txn_map );
   if( FD_UNLIKELY( !fd_progcache_txn_try_lock( txn ) ) ) {
     FD_LOG_CRIT(( "fd_progcache_invalidate(xid=%lu,...) failed: txn is write-locked", xid->ul[0] ));
   }

--- a/src/flamenco/progcache/fd_progcache_user.h
+++ b/src/flamenco/progcache/fd_progcache_user.h
@@ -177,7 +177,10 @@ fd_progcache_pull( fd_progcache_t *           cache,
 
    After a program has been invalidated at xid, it is forbidden to pull
    the same entry at the same xid.  (Invalidations should happen after
-   replaying transactions). */
+   replaying transactions).
+
+   Assumes that xid is a valid fork graph node (not rooted) until
+   invalidate returns. */
 
 fd_progcache_rec_t const *
 fd_progcache_invalidate( fd_progcache_t *          cache,

--- a/src/funk/fd_funk_rec.c
+++ b/src/funk/fd_funk_rec.c
@@ -369,7 +369,8 @@ fd_funk_rec_verify( fd_funk_t * funk ) {
 
       } else { /* This is a record from an in-prep transaction */
 
-        TEST( fd_funk_txn_query( xid, funk->txn_map ) );
+        fd_funk_txn_map_query_t query[1];
+        TEST( fd_funk_txn_map_query_try( funk->txn_map, xid, NULL, query, 0 )==FD_MAP_SUCCESS );
 
       }
     }

--- a/src/funk/fd_funk_txn.h
+++ b/src/funk/fd_funk_txn.h
@@ -103,30 +103,6 @@ static inline int fd_funk_txn_idx_is_null( ulong idx ) { return idx==FD_FUNK_TXN
 
 /* Accessors */
 
-/* fd_funk_txn_query returns a pointer to an in-preparation transaction
-   whose id is pointed to by xid.  Returns NULL if xid is not an
-   in-preparation transaction.  Assumes funk is a current local join,
-   map==fd_funk_txn_map( funk, fd_funk_wksp( funk ) ), xid points to a
-   transaction id in the caller's address space and there are no
-   concurrent operations on funk or xid.  Retains no interest in xid.
-
-   The returned pointer is in the caller's address space and, if the
-   return is non-NULL, the lifetime of the returned pointer is the
-   lesser of the funk join or the transaction is published or canceled
-   (either directly or indirectly via publish of a descendant, publish
-   of a competing transaction history or cancel of an ancestor). */
-
-FD_FN_PURE static inline fd_funk_txn_t *
-fd_funk_txn_query( fd_funk_txn_xid_t const * xid,
-                   fd_funk_txn_map_t *       map ) {
-  do {
-    fd_funk_txn_map_query_t query[1];
-    if( FD_UNLIKELY( fd_funk_txn_map_query_try( map, xid, NULL, query, 0 ) ) ) return NULL;
-    fd_funk_txn_t * ele = fd_funk_txn_map_query_ele( query );
-    if( FD_LIKELY( !fd_funk_txn_map_query_test( query ) ) ) return ele;
-  } while( 1 );
-}
-
 /* fd_funk_txn_xid returns a pointer in the local address space of the
    ID of an in-preparation transaction.  Assumes txn points to an
    in-preparation transaction in the caller's address space.  The


### PR DESCRIPTION
Removes a broken funk API (fd_funk_txn_query), which occasionally
returns NULL when querying a funk_txn while another unrelated one
is being rooted.

Adapts all former users of this API to use the txn_map query_try
API instead.
