### PR TITLE
Fix spelling errors in comments and field names

### DIFF
--- a/contrib/tango.lua
+++ b/contrib/tango.lua
@@ -98,7 +98,7 @@ local tpu_simple_vote = ProtoField.uint32("fd_tpu.flags.simple_vote", "Simple Vo
 local tpu_bundle = ProtoField.uint32("fd_tpu.flags.bundle", "Bundle", base.DEC, yesno_types, 0x2)
 local tpu_initializer = ProtoField.uint32("fd_tpu.flags.initializer_bundle", "Initializer Bundle", base.DEC, yesno_types, 0x4)
 local tpu_sanitized = ProtoField.uint32("fd_tpu.flags.sanitized", "Sanitize Success", base.DEC, yesno_types, 0x8)
-local tpu_executed = ProtoField.uint32("fd_tpu.flags.excuted", "Execute Success", base.DEC, yesno_types, 0x10)
+local tpu_executed = ProtoField.uint32("fd_tpu.flags.executed", "Execute Success", base.DEC, yesno_types, 0x10)
 local tpu_nonce = ProtoField.uint32("fd_tpu.flags.is_nonce", "Durable Nonce", base.DEC, yesno_types, 0x20)
 local tpu_status   = ProtoField.uint32("fd_tpu.flags.status", "Status", base.DEC, status_codes, 0xFF000000)
 

--- a/src/ballet/sbpf/fd_sbpf_loader.c
+++ b/src/ballet/sbpf/fd_sbpf_loader.c
@@ -130,7 +130,7 @@ fd_sbpf_program_align( void ) {
 
 ulong
 fd_sbpf_program_footprint( fd_sbpf_elf_info_t const * info ) {
-  FD_COMPILER_UNPREDICTABLE( info ); /* Make this appear as FD_FN_PURE (e.g. footprint might depened on info contents in future) */
+  FD_COMPILER_UNPREDICTABLE( info ); /* Make this appear as FD_FN_PURE (e.g. footprint might depend on info contents in future) */
   if( FD_UNLIKELY( fd_sbpf_enable_stricter_elf_headers_enabled( info->sbpf_version ) ) ) {
     /* SBPF v3+ no longer needs calldests bitmap */
     return FD_LAYOUT_FINI( FD_LAYOUT_APPEND( FD_LAYOUT_INIT,

--- a/src/util/shmem/fd_shmem_admin.c
+++ b/src/util/shmem/fd_shmem_admin.c
@@ -682,7 +682,7 @@ fd_shmem_private_boot( int *    pargc,
                        char *** pargv ) {
   FD_LOG_INFO(( "fd_shmem: booting" ));
 
-  /* Initialize the phtread mutex */
+  /* Initialize the pthread mutex */
 
 # if FD_HAS_THREADS
   pthread_mutexattr_t lockattr[1];


### PR DESCRIPTION
 Fixes three typos across the codebase:

  - `contrib/tango.lua`: "excuted" → "executed" in ProtoField name
  - `src/ballet/sbpf/fd_sbpf_loader.c`: "depened" → "depend" in comment
  - `src/util/shmem/fd_shmem_admin.c`: "phtread" → "pthread" in comment