### PR TITLE
Fix spelling errors

### DIFF
--- a/book/api/websocket.md
+++ b/book/api/websocket.md
@@ -1900,7 +1900,7 @@ and is broadcast to all WebSocket clients.
 | slot_delta      | `number[]`         | `reference_slot + slot_delta[i]` is the slot to which shred event `i` belongs |
 | shred_idxs      | `(number\|null)[]` | `shred_idxs[i]` is the slot shred index of the shred for shred event `i`.  If null, then shred event `i` applies to all shreds in the slot (i.e. this is used for `slot_complete`) |
 | events          | `number[]`         | `events[i]` is the enum value for shred event `i`. Possible values are `repair_request` (0), `shred_received_turbine` (1), `shred_received_repair` (2), `shred_replay_exec_done` (3), `shred_replay_exec_start` (4), and `slot_complete` (5) |
-| events_ts_delta | `string[]`         | `reference_ts + events_ts_delta[i]` is the UNIX nanosecond timestamp when shred event `i` occured |
+| events_ts_delta | `string[]`         | `reference_ts + events_ts_delta[i]` is the UNIX nanosecond timestamp when shred event `i` occurred |
 
 #### `slot.query_shreds`
 | frequency   | type          | example |
@@ -2431,7 +2431,7 @@ explicitly mentioned, skipped slots are not included.
 | timestamp_nanos | `string` | A UNIX nanosecond timestamp representing the time when these counts were sampled by the gui tile. |
 | regular         | `number` | The number of transactions stored in the "regular" treap (i.e. the primary buffer) at `timestamp_nanos` |
 | votes           | `number` | The number of transactions stored in the "votes" treap (i.e. the buffer dedicated for vote transactions) at `timestamp_nanos` |
-| conflicting     | `number` | The number of transactions stored in the "conflicting" treap (i.e. the buffer for transations with percieved account write conflicts, which recieve slightly less priority) at `timestamp_nanos` |
+| conflicting     | `number` | The number of transactions stored in the "conflicting" treap (i.e. the buffer for transactions with perceived account write conflicts, which receive slightly less priority) at `timestamp_nanos` |
 | bundles         | `number` | The number of transactions stored in the "bundles" treap (i.e. the buffer dedicated for bundle transactions) at `timestamp_nanos` |
 
 **`TsTileTimers`**

--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -2101,7 +2101,7 @@ fd_gui_handle_completed_slot( fd_gui_t * gui,
                               long       now ) {
 
   /* This is the slot used by frontend clients as the "startup slot". In
-     certain boot conditions, we don't recieve this slot from Agave, so
+     certain boot conditions, we don't receive this slot from Agave, so
      we include a bit of a hacky assignment here to make sure it is
      always present. */
   if( FD_UNLIKELY( gui->summary.startup_progress.startup_ledger_max_slot==ULONG_MAX ) ) {
@@ -2466,7 +2466,7 @@ fd_gui_handle_reset_slot( fd_gui_t * gui, ulong reset_slot, long now ) {
   /* ensure a history exists */
   if( FD_UNLIKELY( prev_slot_completed==ULONG_MAX || gui->summary.slot_rooted==ULONG_MAX ) ) return;
 
-  /* slot complete recieved out of order on the same fork? */
+  /* slot complete received out of order on the same fork? */
   FD_TEST( fd_gui_slot_is_ancestor( gui, prev_slot_completed, gui->summary.slot_completed ) || !fd_gui_slot_is_ancestor( gui, gui->summary.slot_completed, prev_slot_completed ) );
 
   /* fork switch: we need to "undo" the previous fork */

--- a/src/discof/exec/fd_exec_tile.c
+++ b/src/discof/exec/fd_exec_tile.c
@@ -13,7 +13,7 @@
 #include "../../disco/metrics/fd_metrics.h"
 
 /* The exec tile is responsible for executing single transactions. The
-   tile recieves a parsed transaction (fd_txn_p_t) and an identifier to
+   tile receives a parsed transaction (fd_txn_p_t) and an identifier to
    which bank to execute against (index into the bank pool). With this,
    the exec tile is able to identify the correct bank and accounts db
    handle (funk_txn) to execute the transaction against.  The exec tile

--- a/src/discof/replay/fd_sched.c
+++ b/src/discof/replay/fd_sched.c
@@ -1564,7 +1564,7 @@ try_activate_block( fd_sched_t * sched ) {
   /* ... No, promote unstaged blocks. */
   ulong root_idx = sched->root_idx;
   if( FD_UNLIKELY( root_idx==ULONG_MAX ) ) {
-    FD_LOG_CRIT(( "invariant violation: root_idx==ULONG_MAX indicating fd_sched is unintialized" ));
+    FD_LOG_CRIT(( "invariant violation: root_idx==ULONG_MAX indicating fd_sched is uninitialized" ));
   }
   /* Find and stage the longest stageable unstaged fork.  This is a
      policy decision. */
@@ -1779,7 +1779,7 @@ find_and_stage_longest_unstaged_fork( fd_sched_t * sched, int lane_idx ) {
   ulong root_idx = sched->root_idx;
 
   if( FD_UNLIKELY( root_idx==ULONG_MAX ) ) {
-    FD_LOG_CRIT(( "invariant violation: root_idx==ULONG_MAX indicating fd_sched is unintialized" ));
+    FD_LOG_CRIT(( "invariant violation: root_idx==ULONG_MAX indicating fd_sched is uninitialized" ));
   }
 
   /* First pass: compute the longest unstaged fork depth for each node


### PR DESCRIPTION
Corrects common spelling mistakes in comments and API documentation:

  - `occured` → `occurred`
  - `recieve/recieves/recieved` → `receive/receives/received` (4 instances)
  - `unintialized` → `uninitialized` (2 instances)
  - `transations` → `transactions`
  - `percieved` → `perceived`