### PR TITLE
xdp: lock xsk descriptor rings and exclude from core dumps

### DIFF
--- a/src/disco/topo/fd_topo.c
+++ b/src/disco/topo/fd_topo.c
@@ -235,13 +235,12 @@ fd_topo_tile_extra_normal_pages( fd_topo_tile_t const * tile ) {
       /* tx ring */
       xsk_rings_sz_bytes += tile->xdp.xdp_tx_queue_size * xdp_desc_sz_bytes;
 
-      /* completion ring */ 
+      /* completion ring */
       xsk_rings_sz_bytes += tile->xdp.xdp_tx_queue_size * xdp_address_sz_bytes;
       /* free ring */
       xsk_rings_sz_bytes += tile->xdp.free_ring_depth   * xdp_address_sz_bytes;
 
-      /* Rounds up number of pages */
-      key_pages += ( ( xsk_rings_sz_bytes + FD_SHMEM_NORMAL_PAGE_SZ - 1UL ) / FD_SHMEM_NORMAL_PAGE_SZ );
+      key_pages += fd_ulong_align_up( xsk_rings_sz_bytes, FD_SHMEM_NORMAL_PAGE_SZ ) / FD_SHMEM_NORMAL_PAGE_SZ;
 
       /* All 4 rings must store a ring header. This is 320 bytes
          per ring as of linux v6.18.3, however could change in

--- a/src/waltz/xdp/fd_xsk.c
+++ b/src/waltz/xdp/fd_xsk.c
@@ -65,7 +65,7 @@ fd_xsk_mmap_ring( fd_xdp_ring_t * ring,
      kernel to exclude this region from core dumps for consistency
      with fd_shmem. Reimplements syscall logic of fd_numa_mlock()
      from fd_shmem_private.h to circumvent the ASan interceptor
-     and avoid private header dependencies. */ 
+     and avoid private header dependencies. */
 
   if( FD_UNLIKELY( (int)syscall( SYS_mlock, res, map_sz ) ) )
     FD_LOG_WARNING(( "syscall(SYS_mlock, %p, %lu KiB) on %s ring failed (%i-%s); attempting to continue",


### PR DESCRIPTION
Resolves TODO and brings the allocation of memory for the xsk descriptor rings up to standard with fd_shmem.

Benchmarked with fddev on AMD EPYC 9254P (24 cores, set to min 2.9GHz) with 384GB RAM (warmed for 20 mins).

Mean TPS over 300 seconds:
Before: 119,924
After: 119,737

Avoided including fd_numa_mlock() from fd_shmem_private.h (and instead reimplemented its functionality) to avoid including a private header from a separate fd component. Chose not to refactor the given shmem function into a public header to avoid heavily tweaking shmem.