### PR TITLE
remove rustup toolchain installation from deps

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -375,11 +375,6 @@ check () {
         echo "[+] Installing rustup"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         source "$HOME/.cargo/env"
-        rust_toolchain=$(grep "channel" agave/rust-toolchain.toml | awk '{print $NF}' | tr -d '"')
-        if [[ ! $(rustup toolchain list | grep $rust_toolchain) ]]; then
-          echo "[+] Updating rustup toolchain"
-          rustup toolchain add $rust_toolchain
-        fi
         ;;
       *)
         echo "[-] Skipping rustup install"


### PR DESCRIPTION
This is already done in the makefile for the relevant rust targets. Also fixes the issue in #6174 