### PR TITLE
flamenco: point permalink to correct function

### DIFF
--- a/src/flamenco/runtime/info/fd_instr_info.h
+++ b/src/flamenco/runtime/info/fd_instr_info.h
@@ -125,7 +125,7 @@ fd_instr_acc_is_writable_idx( fd_instr_info_t const * instr,
     - 0 if the query was successful. Check the return value to see
       if the account is a signer.
 
-  https://github.com/anza-xyz/agave/blob/v3.0.3/transaction-context/src/lib.rs#L782-L791    */
+  https://github.com/anza-xyz/agave/blob/v3.0.3/transaction-context/src/lib.rs#L770-L779    */
 FD_FN_PURE static inline int
 fd_instr_acc_is_signer_idx( fd_instr_info_t const * instr,
                             ushort                  idx,


### PR DESCRIPTION
Previously the link would point to `is_instruction_account_writable` instead of `is_instruction_account_signer`.