### PR TITLE
tower: consume vote txns unreliably to prevent catchup stall

### DIFF
--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -748,8 +748,8 @@ fd_topo_initialize( config_t * config ) {
   /**/                 fd_topob_tile_in (   topo, "replay",  0UL,          "metric_in", "poh_replay",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   FOR(exec_tile_cnt)   fd_topob_tile_in (   topo, "exec",    i,            "metric_in", "replay_exec",  0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
 
-  /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "dedup_resolv", 0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED ); /* txns can be dropped because confirmations are already unreliable, as they depend on gossip votes. */
-  /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "replay_exec",  0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED ); /* In practice only gets overrun during boot, and should be changed back to RELIABLE after a fix is made. */
+  /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "dedup_resolv", 0UL,          FD_TOPOB_UNRELIABLE,   FD_TOPOB_POLLED ); /* txns can be dropped because confirmations are already unreliable, as they depend on gossip votes. */
+  /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "replay_exec",  0UL,          FD_TOPOB_UNRELIABLE,   FD_TOPOB_POLLED ); /* In practice only gets overrun during boot, and should be changed back to RELIABLE after a fix is made. */
   /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "replay_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_out(   topo, "tower",   0UL,                       "tower_out",    0UL                                                );
 

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -748,8 +748,8 @@ fd_topo_initialize( config_t * config ) {
   /**/                 fd_topob_tile_in (   topo, "replay",  0UL,          "metric_in", "poh_replay",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   FOR(exec_tile_cnt)   fd_topob_tile_in (   topo, "exec",    i,            "metric_in", "replay_exec",  0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
 
-  /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "dedup_resolv", 0UL,          FD_TOPOB_UNRELIABLE,   FD_TOPOB_POLLED ); /* txns can be dropped because confirmations are already unreliable, as they depend on gossip votes. */
-  /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "replay_exec",  0UL,          FD_TOPOB_UNRELIABLE,   FD_TOPOB_POLLED ); /* In practice only gets overrun during boot, and should be changed back to RELIABLE after a fix is made. */
+  /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "dedup_resolv", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED ); /* txns can be dropped because confirmations are already unreliable, as they depend on gossip votes. */
+  /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "replay_exec",  0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED ); /* In practice only gets overrun during boot, and should be changed back to RELIABLE after a fix is made. */
   /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "replay_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_out(   topo, "tower",   0UL,                       "tower_out",    0UL                                                );
 

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -748,8 +748,8 @@ fd_topo_initialize( config_t * config ) {
   /**/                 fd_topob_tile_in (   topo, "replay",  0UL,          "metric_in", "poh_replay",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   FOR(exec_tile_cnt)   fd_topob_tile_in (   topo, "exec",    i,            "metric_in", "replay_exec",  0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
 
-  /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "dedup_resolv", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-  /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "replay_exec",  0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+  /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "dedup_resolv", 0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED ); /* txns can be dropped because confirmations are already unreliable, as they depend on gossip votes. */
+  /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "replay_exec",  0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED ); /* In practice only gets overrun during boot, and should be changed back to RELIABLE after a fix is made. */
   /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "replay_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_out(   topo, "tower",   0UL,                       "tower_out",    0UL                                                );
 

--- a/src/choreo/tower/fd_tower_forks.h
+++ b/src/choreo/tower/fd_tower_forks.h
@@ -91,6 +91,8 @@ typedef struct fd_tower_leaf fd_tower_leaf_t;
    it is stored like:
    vote+lockout -> (vote, validator A) -> (2, validator B) -> (any other vote, any other validator)
 
+   tower switch check only cares for intervals where the interval end is >= the last vote slot, so we can skip intervals where the interval end is < the last vote slot.
+
    Since a validator can have up to 31 entries in the tower, and we have
    a max_vote_accounts, we can pool the interval objects to be
    31*max_vote_accounts entries PER bank / executed slot. We can also
@@ -264,7 +266,8 @@ void
 fd_forks_lockouts_add( fd_forks_t * forks,
                        ulong fork_slot,
                        fd_hash_t const * vote_account_pubkey,
-                       fd_tower_accts_t * acct );
+                       fd_tower_accts_t * acct,
+                       ulong our_last_vote_slot );
 
 void
 fd_forks_lockouts_clear( fd_forks_t * forks, ulong fork_slot );

--- a/src/discof/tower/fd_tower_tile.c
+++ b/src/discof/tower/fd_tower_tile.c
@@ -508,6 +508,9 @@ replay_slot_completed( ctx_t *                      ctx,
     FD_TEST( !last_vote || fd_forks_query( ctx->forks, last_vote->slot ) );
   }
 
+  fd_tower_vote_t const * last_vote = fd_tower_peek_tail_const( ctx->tower );
+  ulong our_last_vote_slot = last_vote ? last_vote->slot : 0;
+
   /* Insert the vote acct addrs and stakes from the bank into accts. */
 
   fd_tower_accts_remove_all( ctx->tower_accts );
@@ -571,7 +574,7 @@ replay_slot_completed( ctx_t *                      ctx,
 
     /* 1. Update forks with lockouts. */
 
-    fd_forks_lockouts_add( ctx->forks, slot_completed->slot, &acct->addr, acct );
+    fd_forks_lockouts_add( ctx->forks, slot_completed->slot, &acct->addr, acct, our_last_vote_slot );
 
     /* 2. Count the last vote slot in the vote state towards ghost. */
 


### PR DESCRIPTION
`link_overrun_polling_count{kind="tower",kind_id="0",link_kind="dedup_resolv",link_kind_id="0"} 1
link_overrun_polling_count{kind="tower",kind_id="0",link_kind="replay_exec",link_kind_id="0"} 57
link_overrun_polling_frag_count{kind="tower",kind_id="0",link_kind="dedup_resolv",link_kind_id="0"} 65536
link_overrun_polling_frag_count{kind="tower",kind_id="0",link_kind="replay_exec",link_kind_id="0"} 983040
link_overrun_reading_count{kind="tower",kind_id="0",link_kind="dedup_resolv",link_kind_id="0"} 0
link_overrun_reading_count{kind="tower",kind_id="0",link_kind="replay_exec",link_kind_id="0"} 0
link_overrun_reading_frag_count{kind="tower",kind_id="0",link_kind="dedup_resolv",link_kind_id="0"} 0
link_overrun_reading_frag_count{kind="tower",kind_id="0",link_kind="replay_exec",link_kind_id="0"} 0`