### PR TITLE
vinyl: start polling rq at seq 0

### DIFF
--- a/src/vinyl/fd_vinyl_exec.c
+++ b/src/vinyl/fd_vinyl_exec.c
@@ -325,7 +325,7 @@ fd_vinyl_exec( fd_vinyl_t * vinyl ) {
           _client[ client_cnt ].rq        = rq;
           _client[ client_cnt ].cq        = cq;
           _client[ client_cnt ].burst_max = burst_max;
-          _client[ client_cnt ].seq       = fd_vinyl_rq_seq( rq );
+          _client[ client_cnt ].seq       = 0UL;
           _client[ client_cnt ].link_id   = link_id;
           _client[ client_cnt ].laddr0    = (ulong)wksp;
           _client[ client_cnt ].laddr1    = ULONG_MAX; //wksp->gaddr_hi; /* FIXME: HOW TO GET THIS CLEANLY */


### PR DESCRIPTION
Always let the vinyl tile start receiving requests at sequence
number zero instead of starting at the last published seq.

This hardens vinyl bootstrap against various forms of startup race
conditions, as has happened with the vinyl/exec tiles in full
Firedancer.

Chat logs:

> <@ripatel-fd>: <@kbowers-jump>: I'd like to make a patch to Vinyl- Can you sanity check?
> In Firedancer's topology, the vinyl tile issues CNC CLIENT_JOIN requests to itself while starting up (instead of clients registering themselves).
> This was necessary for sandboxing, otherwise exec tiles could get the vinyl tile to mmap() new arbitrary memory via fd_wksp_map.
> But this resulted in a race condition where clients publish to rq before CLIENT_JOIN succeeds.
> Which results in vinyl dropping the first few requests.
> Do you mind if I change CLIENT_JOIN to always start at rq sequence number zero instead of a recently published message?
>
> <@kbowers-jump>: I don't feel strongly about the change.  The motivations sound a little gross but we've discussed the tradeoffs and at worst this sounds like something we could clean up if necessary at some point after Vinyl is integrated.