### PR TITLE
Add missing agave checks in decode_u64_varint

### DIFF
--- a/src/flamenco/gossip/fd_gossip_msg_parse.c
+++ b/src/flamenco/gossip/fd_gossip_msg_parse.c
@@ -79,6 +79,8 @@ decode_u64_varint( uchar const * payload,
     uchar byte = FD_LOAD( uchar, CURSOR ); INC( 1U );
     value |= (ulong)(byte & 0x7F) << shift;
     if( !(byte & 0x80) ) {
+      CHECK( (uchar)(value>>shift)==byte );
+      CHECK( byte || ( shift==0 && value==0 ) );
       *out_value = value;
       return BYTES_CONSUMED;
     }


### PR DESCRIPTION
Adds 2 missing checks in `decode_u64_varint`, relevant agave code: https://github.com/anza-xyz/solana-sdk/blob/0da89f297a7450c1129c40c064ced83a04903f74/serde-varint/src/lib.rs#L81-L90