### PR TITLE
vinyl: improve startup procedure

### DIFF
--- a/src/app/firedancer-dev/commands/backtest.c
+++ b/src/app/firedancer-dev/commands/backtest.c
@@ -268,7 +268,6 @@ backtest_topo( config_t * config ) {
     }
 
     fd_topob_wksp( topo, "vinyl_replay" );
-    fd_topob_tile_in( topo, "vinyl", 0UL, "metric_in", "snapin_manif", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
   }
 
   /**********************************************************************/

--- a/src/app/firedancer-dev/commands/snapshot_load.c
+++ b/src/app/firedancer-dev/commands/snapshot_load.c
@@ -218,8 +218,6 @@ snapshot_load_topo( config_t * config,
 
     fd_topob_tile_uses( topo, vinyl_tile, vinyl_cnc,  FD_SHMEM_JOIN_MODE_READ_WRITE );
     fd_topob_tile_uses( topo, vinyl_tile, vinyl_data, FD_SHMEM_JOIN_MODE_READ_WRITE );
-
-    fd_topob_tile_in( topo, "vinyl", 0UL, "metric_in", "snapin_manif", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
   }
 
   for( ulong i=0UL; i<topo->tile_cnt; i++ ) {


### PR DESCRIPTION
Fixes a race condition where the vinyl tile starts up before the
snapin tile finishes updating the sync block.  (This happened
because the vinyl tile used the snapshot manifest as a startup
signal, but the snapshot loader broadcasted the manifest before
syncing DB to disk.)

Rewires the vinyl tile to wait until the snapin tile exits before
starting up.
