### PR TITLE
runtime: migrate txn account setup to accdb

### DIFF
--- a/src/flamenco/accdb/fd_accdb_ref.h
+++ b/src/flamenco/accdb/fd_accdb_ref.h
@@ -161,6 +161,9 @@ fd_accdb_ref_slot_set( fd_accdb_rw_t * rw,
 
 FD_PROTOTYPES_END
 
+FD_STATIC_ASSERT( sizeof(fd_accdb_ref_t)==sizeof(fd_accdb_ro_t), layout );
+FD_STATIC_ASSERT( sizeof(fd_accdb_ref_t)==sizeof(fd_accdb_rw_t), layout );
+
 /* fd_accdb_spec_t tracks a speculative access to a shared resource.
    Destroying this guard object marks the end of a speculative access. */
 

--- a/src/flamenco/runtime/context/fd_exec_instr_ctx.c
+++ b/src/flamenco/runtime/context/fd_exec_instr_ctx.c
@@ -57,7 +57,7 @@ fd_exec_instr_ctx_try_borrow_account( fd_exec_instr_ctx_t const * ctx,
     return FD_EXECUTOR_INSTR_ERR_MISSING_ACC;
   }
 
-  fd_account_meta_t * meta = ctx->txn_out->accounts.metas[idx_in_txn];
+  fd_account_meta_t * meta = ctx->txn_out->accounts.account[idx_in_txn].meta;
 
   /* Return an AccountBorrowFailed error if the write is not acquirable.
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L605 */

--- a/src/flamenco/runtime/fd_acc_mgr.h
+++ b/src/flamenco/runtime/fd_acc_mgr.h
@@ -32,9 +32,10 @@ FD_PROTOTYPES_BEGIN
 /* The following account management APIs are helpers for fd_account_meta_t creation,
    existence, and retrieval from funk */
 
-static inline void
+static inline fd_account_meta_t *
 fd_account_meta_init( fd_account_meta_t * m ) {
   fd_memset( m, 0, sizeof(fd_account_meta_t) );
+  return m;
 }
 
 /* fd_account_meta_exists checks if the account in a funk record exists or was

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -218,9 +218,9 @@ struct fd_txn_in {
   fd_txn_p_t const * txn;
 
   struct {
-    int                  is_bundle;
-    fd_txn_out_t const * prev_txn_outs[ FD_PACK_MAX_TXN_PER_BUNDLE ];
-    ulong                prev_txn_cnt;
+    int            is_bundle;
+    fd_txn_out_t * prev_txn_outs[ FD_PACK_MAX_TXN_PER_BUNDLE ];
+    ulong          prev_txn_cnt;
   } bundle;
 };
 typedef struct fd_txn_in fd_txn_in_t;
@@ -280,11 +280,11 @@ struct fd_txn_out {
     /* is_setup is set to 1 if account data buffer resources have been
        acquired for the transaction and 0 if they have not.  If the flag
        has been set, memory resources must be released. */
-    int                 is_setup;
-    ulong               cnt;
-    fd_pubkey_t         keys       [ MAX_TX_ACCOUNT_LOCKS ];
-    fd_account_meta_t * metas      [ MAX_TX_ACCOUNT_LOCKS ];
-    uchar               is_writable[ MAX_TX_ACCOUNT_LOCKS ];
+    int           is_setup;
+    ulong         cnt;
+    fd_pubkey_t   keys       [ MAX_TX_ACCOUNT_LOCKS ];
+    fd_accdb_rw_t account    [ MAX_TX_ACCOUNT_LOCKS ]; /* FIXME use accdb_ref_t here for safety - some accounts are readonly */
+    uchar         is_writable[ MAX_TX_ACCOUNT_LOCKS ];
 
     /* The fee payer and nonce accounts are treated differently than
        other accounts: if an on-transaction fails they are still

--- a/src/flamenco/runtime/sysvar/fd_sysvar_cache.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_cache.h
@@ -22,7 +22,7 @@
 
 #include "fd_sysvar_base.h"
 #include "../../types/fd_types.h"
-#include "../../accdb/fd_accdb_base.h"
+#include "../../accdb/fd_accdb_ref.h"
 
 #define FD_SYSVAR_CACHE_ENTRY_CNT 9
 
@@ -141,19 +141,9 @@ fd_sysvar_cache_restore_fuzz( fd_bank_t *               bank,
                               fd_accdb_user_t *         accdb,
                               fd_funk_txn_xid_t const * xid );
 
-/* fd_sysvar_cache_restore_from_metas is a version of the above
-   (fd_sysvar_cache_restore_fuzz) for use with solfuzz/protosol
-   conformance tooling.  This version works around the aforementioned
-   tooling bugs but also breaks a dependency on the accounts database to
-   refresh the sysvar cache.  Instead of reading sysvar state from the
-   accounts database, it searches for the sysvar accounts from the list
-   of pubkeys and metas that are passed in. */
-
 void
-fd_sysvar_cache_restore_from_metas( fd_bank_t *                 bank,
-                                    fd_pubkey_t const *         pubkeys,
-                                    fd_account_meta_t * const * metas,
-                                    ulong                       acc_cnt );
+fd_sysvar_cache_restore_from_ref( fd_sysvar_cache_t *   cache,
+                                  fd_accdb_ro_t const * ro );
 
 /* Generic accessors for serialized sysvar account data. */
 

--- a/src/flamenco/runtime/sysvar/fd_sysvar_instructions.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_instructions.c
@@ -53,7 +53,7 @@ fd_sysvar_instructions_serialize_account( fd_runtime_t *      runtime,
     FD_LOG_ERR(( "Failed to view sysvar instructions borrowed account. It may not be included in the txn account keys." ));
   }
 
-  fd_account_meta_t * meta = txn_out->accounts.metas[ txn_idx ];
+  fd_account_meta_t * meta = txn_out->accounts.account[ txn_idx ].meta;
   /* Agave sets up the borrowed account for the instructions sysvar to contain
      default values except for the data which is serialized into the account. */
 

--- a/src/flamenco/runtime/tests/fd_dump_pb.c
+++ b/src/flamenco/runtime/tests/fd_dump_pb.c
@@ -915,7 +915,7 @@ create_instr_context_protobuf_from_instructions( fd_exec_test_instr_context_t * 
   instr_context->accounts = fd_spad_alloc( spad, alignof(fd_exec_test_acct_state_t), (instr_context->accounts_count + num_sysvar_entries + runtime->accounts.executable_cnt) * sizeof(fd_exec_test_acct_state_t));
   for( ulong i = 0; i < txn_out->accounts.cnt; i++ ) {
     // Copy account information over
-    fd_account_meta_t * account_meta = txn_out->accounts.metas[i];
+    fd_account_meta_t * account_meta = txn_out->accounts.account[i].meta;
     fd_exec_test_acct_state_t * output_account = &instr_context->accounts[i];
     dump_account_state( &txn_out->accounts.keys[i], account_meta, output_account, spad );
   }

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -540,10 +540,10 @@ fd_solfuzz_pb_txn_run( fd_solfuzz_runner_t * runner,
          accounts */
       for( ulong j=0UL; j<txn_out->accounts.cnt; j++ ) {
         fd_pubkey_t *       pubkey   = &txn_out->accounts.keys[j];
-        fd_account_meta_t * meta     = txn_out->accounts.metas[j];
+        fd_account_meta_t * meta     = txn_out->accounts.account[j].meta;
 
         if( !( fd_runtime_account_is_writable_idx( txn_in, txn_out, runner->bank, (ushort)j ) || /* Capture writable accounts */
-               j==FD_FEE_PAYER_TXN_IDX ) ) {                                                               /* Capture the fee payer account */
+               j==FD_FEE_PAYER_TXN_IDX ) ) {                                                     /* Capture the fee payer account */
           continue;
         }
 

--- a/src/flamenco/runtime/tests/fd_vm_harness.c
+++ b/src/flamenco/runtime/tests/fd_vm_harness.c
@@ -158,7 +158,7 @@ do{
 
   uchar *                   input_ptr      = NULL;
   uchar                     program_id_idx = instr_ctx->instr->program_id;
-  fd_account_meta_t const * program_acc    = instr_ctx->txn_out->accounts.metas[program_id_idx];
+  fd_account_meta_t const * program_acc    = instr_ctx->txn_out->accounts.account[program_id_idx].meta;
   uchar                     is_deprecated  = ( program_id_idx < instr_ctx->txn_out->accounts.cnt ) &&
                                             ( !memcmp( program_acc->owner, fd_solana_bpf_loader_deprecated_program_id.key, sizeof(fd_pubkey_t) ) );
 
@@ -471,7 +471,7 @@ fd_solfuzz_pb_syscall_run( fd_solfuzz_runner_t * runner,
 
   uchar *             input_ptr      = NULL;
   uchar               program_id_idx = ctx->instr->program_id;
-  fd_account_meta_t * program_acc    = ctx->txn_out->accounts.metas[program_id_idx];
+  fd_account_meta_t * program_acc    = ctx->txn_out->accounts.account[program_id_idx].meta;
   uchar               is_deprecated  = ( program_id_idx < ctx->txn_out->accounts.cnt ) &&
                                       ( !memcmp( program_acc->owner, fd_solana_bpf_loader_deprecated_program_id.key, sizeof(fd_pubkey_t) ) );
 

--- a/src/flamenco/vm/syscall/test_vm_increase_cpi_account_info_limit.c
+++ b/src/flamenco/vm/syscall/test_vm_increase_cpi_account_info_limit.c
@@ -191,21 +191,21 @@ test_env_create( test_env_t * env,
   memset( env->sysprog_meta, 0, sizeof(fd_account_meta_t) );
   memcpy( env->sysprog_meta->owner, &fd_solana_native_loader_id, sizeof(fd_pubkey_t) );
   env->sysprog_meta->executable = 1;
-  env->txn_out->accounts.metas[0] = env->sysprog_meta;
+  env->txn_out->accounts.account[0].meta = env->sysprog_meta;
 
   memcpy( &env->txn_out->accounts.keys[1], &test_transfer_from_pubkey, sizeof(fd_pubkey_t) );
   env->source_meta = fd_wksp_alloc_laddr( wksp, alignof(fd_account_meta_t), sizeof(fd_account_meta_t), TEST_WKSP_TAG );
   memset( env->source_meta, 0, sizeof(fd_account_meta_t) );
   memcpy( env->source_meta->owner, &fd_solana_system_program_id, sizeof(fd_pubkey_t) );
   env->source_meta->lamports = 1000000UL;
-  env->txn_out->accounts.metas[1] = env->source_meta;
+  env->txn_out->accounts.account[1].meta = env->source_meta;
 
   memcpy( &env->txn_out->accounts.keys[2], &test_transfer_to_pubkey, sizeof(fd_pubkey_t) );
   env->dest_meta = fd_wksp_alloc_laddr( wksp, alignof(fd_account_meta_t), sizeof(fd_account_meta_t), TEST_WKSP_TAG );
   memset( env->dest_meta, 0, sizeof(fd_account_meta_t) );
   memcpy( env->dest_meta->owner, &fd_solana_system_program_id, sizeof(fd_pubkey_t) );
   env->dest_meta->lamports = 0UL;
-  env->txn_out->accounts.metas[2] = env->dest_meta;
+  env->txn_out->accounts.account[2].meta = env->dest_meta;
 
   env->runtime->accounts.refcnt[0] = 0UL;
   env->runtime->accounts.refcnt[1] = 0UL;


### PR DESCRIPTION
Fixes legacy behavior where the transaction executor directly
queried the funk database engine, instead of using the new accdb
abstraction.

Also improves solfuzz sysvar cache restoring from raw account
buffers.
