### PR TITLE
runtime: remove unused txn_account funk read API

### DIFF
--- a/src/discof/bank/fd_bank_tile.c
+++ b/src/discof/bank/fd_bank_tile.c
@@ -609,7 +609,6 @@ unprivileged_init( fd_topo_t *      topo,
   }
 
   ctx->runtime->accdb                    = accdb;
-  ctx->runtime->funk                     = fd_accdb_user_v1_funk( accdb );
   ctx->runtime->progcache                = progcache;
   ctx->runtime->status_cache             = txncache;
   ctx->runtime->acc_pool                 = acc_pool;

--- a/src/discof/exec/fd_exec_tile.c
+++ b/src/discof/exec/fd_exec_tile.c
@@ -430,7 +430,6 @@ unprivileged_init( fd_topo_t *      topo,
   /********************************************************************/
 
   ctx->runtime->accdb                    = ctx->accdb;
-  ctx->runtime->funk                     = fd_accdb_user_v1_funk( ctx->accdb );
   ctx->runtime->progcache                = ctx->progcache;
   ctx->runtime->status_cache             = ctx->txncache;
   ctx->runtime->acc_pool                 = ctx->acc_pool;

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -41,7 +41,6 @@
 
 struct fd_runtime {
   fd_accdb_user_t * accdb;
-  fd_funk_t *       funk;
   fd_txncache_t *   status_cache;
   fd_progcache_t *  progcache;
   fd_acc_pool_t *   acc_pool;

--- a/src/flamenco/runtime/fd_txn_account.c
+++ b/src/flamenco/runtime/fd_txn_account.c
@@ -115,37 +115,6 @@ fd_txn_account_delete( void * mem ) {
   return mem;
 }
 
-/* Factory constructors from funk */
-
-int
-fd_txn_account_init_from_funk_readonly( fd_txn_account_t *        acct,
-                                        fd_pubkey_t const *       pubkey,
-                                        fd_funk_t const *         funk,
-                                        fd_funk_txn_xid_t const * xid ) {
-  fd_accdb_user_t accdb[1];
-  fd_accdb_user_v1_init( accdb, funk->shmem );
-
-  fd_accdb_ro_t ro[1];
-  if( FD_UNLIKELY( !fd_accdb_open_ro( accdb, ro, xid, pubkey ) ) ) {
-    fd_accdb_user_fini( accdb );
-    return FD_ACC_MGR_ERR_UNKNOWN_ACCOUNT;
-  }
-
-  /* HACKY: Convert accdb_rw writable reference into txn_account.
-     In the future, use fd_accdb_modify_publish instead */
-  accdb->base.ro_active--;
-  if( FD_UNLIKELY( !fd_txn_account_new(
-        acct,
-        pubkey,
-        (fd_account_meta_t *)ro->meta,
-        0 ) ) ) {
-    FD_LOG_CRIT(( "Failed to join txn account" ));
-  }
-  fd_accdb_user_fini( accdb );
-
-  return FD_ACC_MGR_SUCCESS;
-}
-
 fd_account_meta_t *
 fd_txn_account_init_from_funk_mutable( fd_txn_account_t *        acct,
                                        fd_pubkey_t const *       pubkey,

--- a/src/flamenco/runtime/fd_txn_account.h
+++ b/src/flamenco/runtime/fd_txn_account.h
@@ -88,22 +88,6 @@ fd_txn_account_delete( void * mem );
    replaced with a new factory constructor or removed entirely in favor
    of the generic constructors defined above. */
 
-/* fd_txn_account_init_from_funk_readonly initializes a fd_txn_account_t
-   object with a readonly handle into its funk record.
-
-   IMPORTANT: When we access the account metadata and data pointer later
-   on in the execution pipeline, we assume that nothing else will change
-   these.
-
-   This is safe because we assume that we hold a read lock on the
-   account, since we are inside a Solana transaction. */
-
-int
-fd_txn_account_init_from_funk_readonly( fd_txn_account_t *        acct,
-                                        fd_pubkey_t const *       pubkey,
-                                        fd_funk_t const *         funk,
-                                        fd_funk_txn_xid_t const * xid );
-
 /* fd_txn_account_init_from_funk_mutable initializes a fd_txn_account_t
    object with a mutable handle into its funk record.
 

--- a/src/flamenco/runtime/test_instr_acct_bounds.c
+++ b/src/flamenco/runtime/test_instr_acct_bounds.c
@@ -150,7 +150,6 @@ test_env_create( test_env_t * env, fd_wksp_t * wksp ) {
   fd_bank_epoch_set( env->bank, 0UL );
 
   env->runtime->accdb        = env->accdb;
-  env->runtime->funk         = fd_accdb_user_v1_funk( env->accdb );
   env->runtime->status_cache = NULL;
   env->runtime->progcache    = env->progcache;
   env->runtime->acc_pool     = env->acc_pool;

--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -8,7 +8,6 @@
 #include "../program/fd_bpf_loader_program.h"
 #include "../program/fd_loader_v4_program.h"
 #include "../fd_system_ids.h"
-#include "../../accdb/fd_accdb_impl_v1.h"
 #include "../../log_collector/fd_log_collector.h"
 #include <assert.h>
 
@@ -19,8 +18,6 @@ fd_solfuzz_pb_instr_ctx_create( fd_solfuzz_runner_t *                runner,
                                 bool                                 is_syscall ) {
 
   memset( ctx, 0, sizeof(fd_exec_instr_ctx_t) );
-
-  fd_funk_t * funk = fd_accdb_user_v1_funk( runner->accdb );
 
   /* Generate unique ID for funk txn */
 
@@ -84,7 +81,6 @@ fd_solfuzz_pb_instr_ctx_create( fd_solfuzz_runner_t *                runner,
     .data_sz  = (ushort)txn->payload_sz,
   };
 
-  runtime->funk                     = funk;
   runtime->log.enable_log_collector = 0;
 
   fd_compute_budget_details_new( &txn_out->details.compute_budget );

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -352,7 +352,6 @@ fd_solfuzz_txn_ctx_exec( fd_solfuzz_runner_t * runner,
   }
 
   runtime->accdb           = runner->accdb;
-  runtime->funk            = fd_accdb_user_v1_funk( runner->accdb );
   runtime->progcache       = runner->progcache;
   runtime->status_cache    = NULL;
   runtime->log.tracing_mem = tracing_mem;


### PR DESCRIPTION
All account reads in the Firedancer SVM now use the new accdb API.
Start removing legacy funk code.
