### PR TITLE
runtime: migrate tests to accdb

### DIFF
--- a/src/flamenco/runtime/test_runtime_alut.c
+++ b/src/flamenco/runtime/test_runtime_alut.c
@@ -4,6 +4,7 @@
 #include "fd_runtime_err.h"
 #include "fd_txn_account.h"
 #include "../accdb/fd_accdb_impl_v1.h"
+#include "../accdb/fd_accdb_sync.h"
 #include "program/fd_address_lookup_table_program.h"
 #include "fd_system_ids.h"
 #include "../../ballet/txn/fd_txn.h"
@@ -89,35 +90,19 @@ test_teardown( test_ctx_t * ctx ) {
 static void
 create_test_account( test_ctx_t *              ctx,
                      fd_funk_txn_xid_t const * xid,
-                     void const *              pubkey_,
-                     void const *              owner_,
+                     void const *              pubkey,
+                     void const *              owner,
                      void const *              data,
                      ulong                     data_len,
                      ulong                     lamports,
                      uchar                     executable ) {
-  fd_pubkey_t pubkey = FD_LOAD( fd_pubkey_t, pubkey_ );
-  fd_pubkey_t owner  = FD_LOAD( fd_pubkey_t, owner_ );
-
-  fd_txn_account_t      acc[1];
-  fd_funk_rec_prepare_t prepare = {0};
-  int ok = !!fd_txn_account_init_from_funk_mutable( /* acc          */ acc,
-                                                     /* pubkey      */ &pubkey,
-                                                     /* funk        */ ctx->accdb,
-                                                     /* xid         */ xid,
-                                                     /* do_create   */ 1,
-                                                     /* min_data_sz */ data_len,
-                                                     /* prepare     */ &prepare );
-  FD_TEST( ok );
-
-  if( data ) {
-    fd_txn_account_set_data( acc, data, data_len );
-  }
-
-  fd_txn_account_set_lamports( acc, lamports );
-  fd_txn_account_set_executable( acc, executable );
-  fd_txn_account_set_owner( acc, &owner );
-
-  fd_txn_account_mutable_fini( acc, ctx->accdb, &prepare );
+  fd_accdb_rw_t rw[1];
+  fd_accdb_open_rw( ctx->accdb, rw, xid, pubkey, data_len, FD_ACCDB_FLAG_CREATE|FD_ACCDB_FLAG_TRUNCATE );
+  fd_accdb_ref_data_set( ctx->accdb, rw, data, data_len );
+  fd_accdb_ref_lamports_set( rw, lamports );
+  fd_accdb_ref_exec_bit_set( rw, executable );
+  fd_accdb_ref_owner_set   ( rw, owner );
+  fd_accdb_close_rw( ctx->accdb, rw );
 }
 
 /* Helper to allocate transaction with flexible array member */

--- a/src/flamenco/runtime/tests/fd_block_harness.c
+++ b/src/flamenco/runtime/tests/fd_block_harness.c
@@ -315,7 +315,7 @@ fd_solfuzz_pb_block_ctx_create( fd_solfuzz_runner_t *                runner,
   /* Load in all accounts with > 0 lamports provided in the context. The input expects unique account pubkeys. */
   fd_vote_states_t * vote_states = fd_bank_vote_states_locking_modify( bank );
   for( ushort i=0; i<test_ctx->acct_states_count; i++ ) {
-    fd_solfuzz_pb_load_account( runner->runtime, accdb, xid, &test_ctx->acct_states[i], 1, i, NULL );
+    fd_solfuzz_pb_load_account( runner->runtime, accdb, xid, &test_ctx->acct_states[i], i );
 
     /* Update vote accounts cache for epoch T */
     fd_pubkey_t pubkey;

--- a/src/flamenco/runtime/tests/fd_solfuzz_private.h
+++ b/src/flamenco/runtime/tests/fd_solfuzz_private.h
@@ -31,9 +31,7 @@ fd_solfuzz_pb_load_account( fd_runtime_t *                    runtime,
                             fd_accdb_user_t *                 accdb,
                             fd_funk_txn_xid_t const *         xid,
                             fd_exec_test_acct_state_t const * state,
-                            uchar                             reject_zero_lamports,
-                            ulong                             acc_idx,
-                            fd_account_meta_t * *             meta_out );
+                            ulong                             acc_idx );
 
 /* Activates features in the runtime given an input feature set.  Fails
    if a passed-in feature is unknown / not supported. */

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -112,7 +112,7 @@ fd_solfuzz_pb_txn_ctx_create( fd_solfuzz_runner_t *              runner,
   for( ulong i = 0; i < test_ctx->account_shared_data_count; i++ ) {
     /* Load the accounts into the account manager
        Borrowed accounts get reset anyways - we just need to load the account somewhere */
-    fd_solfuzz_pb_load_account( runner->runtime, accdb, &xid, &test_ctx->account_shared_data[i], 1, i, NULL );
+    fd_solfuzz_pb_load_account( runner->runtime, accdb, &xid, &test_ctx->account_shared_data[i], i );
   }
 
   /* Setup Bank manager */


### PR DESCRIPTION
Migrates the last remaining users of fd_txn_account_init_from_funk_mutable
to accdb
