### PR TITLE
accdb: fix missing logic in v2 open_rw

### DIFF
--- a/src/flamenco/accdb/fd_accdb_impl_v1.h
+++ b/src/flamenco/accdb/fd_accdb_impl_v1.h
@@ -76,6 +76,26 @@ fd_accdb_user_v1_rw_data_sz_set( fd_accdb_user_t * accdb,
                                  ulong             data_sz,
                                  int               flags );
 
+/* Private methods */
+
+fd_accdb_rw_t *
+fd_accdb_v1_prep_create( fd_accdb_rw_t *           rw,
+                         fd_accdb_user_v1_t *      accdb,
+                         fd_funk_txn_xid_t const * xid,
+                         void const *              address,
+                         void *                    val,
+                         ulong                     val_sz,
+                         ulong                     val_max );
+
+void
+fd_accdb_v1_copy_account( fd_account_meta_t *   out_meta,
+                          void *                out_data,
+                          fd_accdb_ro_t const * acc );
+
+void
+fd_accdb_v1_copy_truncated( fd_account_meta_t *   out_meta,
+                            fd_accdb_ro_t const * acc );
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_flamenco_accdb_fd_accdb_impl_v1_h */


### PR DESCRIPTION
Fixes open_rw behavior for accounts that are present in vinyl but
not in funk.  In this case, the account first has to be queried
from vinyl, then copied over to funk.
