### PR TITLE
accdb: fix ghost reads after rooting deletions

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -2533,6 +2533,7 @@ unprivileged_init( fd_topo_t *      topo,
   fd_topo_obj_t const * vinyl_data = fd_topo_find_tile_obj( topo, tile, "vinyl_data" );
   if( !vinyl_data ) {
     FD_TEST( fd_accdb_user_v1_init( ctx->accdb, fd_topo_obj_laddr( topo, tile->replay.funk_obj_id ) ) );
+    ctx->accdb_admin->enable_reclaims = 1;
   } else {
     fd_topo_obj_t const * vinyl_rq       = fd_topo_find_tile_obj( topo, tile, "vinyl_rq" );
     fd_topo_obj_t const * vinyl_req_pool = fd_topo_find_tile_obj( topo, tile, "vinyl_rpool" );

--- a/src/flamenco/accdb/fd_accdb_admin.h
+++ b/src/flamenco/accdb/fd_accdb_admin.h
@@ -6,6 +6,8 @@
 struct fd_accdb_admin {
   fd_funk_t funk[1];
 
+  uint enable_reclaims : 1;
+
   struct {
     ulong root_cnt;     /* moved to database root */
     ulong reclaim_cnt;  /* 0 lamport account removed while rooting */


### PR DESCRIPTION
Fixes a configuration issue where account tombstones were removed
from funk when rooting database transactions (aka reclaims).

This behavior is valid in accdb_v1 but not in accdb_v2, in which
funk needs to be an accurate overlay over vinyl.
