### PR TITLE
vinyl: drop IO config to INFO log

### DIFF
--- a/src/vinyl/io/fd_vinyl_io_bd.c
+++ b/src/vinyl/io/fd_vinyl_io_bd.c
@@ -650,16 +650,16 @@ fd_vinyl_io_bd_init( void *       mem,
 
   }
 
-  FD_LOG_NOTICE(( "IO config"
-                  "\n\ttype     bd"
-                  "\n\tspad_max %lu bytes"
-                  "\n\tdev_sz   %lu bytes"
-                  "\n\treset    %i"
-                  "\n\tinfo     \"%s\" (info_sz %lu%s)"
-                  "\n\tio_seed  0x%016lx%s",
-                  spad_max, dev_sz, reset,
-                  info ? (char const *)info : "", info_sz, reset ? "" : ", discovered",
-                  io_seed, reset ? "" : " (discovered)" ));
+  FD_LOG_INFO(( "IO config"
+                "\n\ttype     bd"
+                "\n\tspad_max %lu bytes"
+                "\n\tdev_sz   %lu bytes"
+                "\n\treset    %i"
+                "\n\tinfo     \"%s\" (info_sz %lu%s)"
+                "\n\tio_seed  0x%016lx%s",
+                spad_max, dev_sz, reset,
+                info ? (char const *)info : "", info_sz, reset ? "" : ", discovered",
+                io_seed, reset ? "" : " (discovered)" ));
 
   return bd->base;
 }

--- a/src/vinyl/io/fd_vinyl_io_mm.c
+++ b/src/vinyl/io/fd_vinyl_io_mm.c
@@ -623,16 +623,16 @@ fd_vinyl_io_mm_init( void *       mem,
 
   }
 
-  FD_LOG_NOTICE(( "IO config"
-                  "\n\ttype     mm"
-                  "\n\tspad_max %lu bytes"
-                  "\n\tdev_sz   %lu bytes"
-                  "\n\treset    %i"
-                  "\n\tinfo     \"%s\" (info_sz %lu%s)"
-                  "\n\tio_seed  0x%016lx%s",
-                  spad_max, dev_sz, reset,
-                  info ? (char const *)info : "", info_sz, reset ? "" : ", discovered",
-                  io_seed, reset ? "" : " (discovered)" ));
+  FD_LOG_INFO(( "IO config"
+                "\n\ttype     mm"
+                "\n\tspad_max %lu bytes"
+                "\n\tdev_sz   %lu bytes"
+                "\n\treset    %i"
+                "\n\tinfo     \"%s\" (info_sz %lu%s)"
+                "\n\tio_seed  0x%016lx%s",
+                spad_max, dev_sz, reset,
+                info ? (char const *)info : "", info_sz, reset ? "" : ", discovered",
+                io_seed, reset ? "" : " (discovered)" ));
 
   return mm->base;
 }

--- a/src/vinyl/io/fd_vinyl_io_ur.c
+++ b/src/vinyl/io/fd_vinyl_io_ur.c
@@ -768,15 +768,17 @@ fd_vinyl_io_ur_init( void *            mem,
   ur->base->seq_present = seq_present;
   ur->base->seq_future  = seq_present;
 
-  FD_LOG_NOTICE(( "IO config"
-                  "\n\ttype     ur"
-                  "\n\tspad_max %lu bytes"
-                  "\n\tdev_sz   %lu bytes"
-                  "\n\tinfo     \"%s\" (info_sz %lu, discovered)"
-                  "\n\tio_seed  0x%016lx (discovered)",
-                  spad_max, dev_sz,
-                  (char const *)info, info_sz,
-                  io_seed ));
+  FD_LOG_INFO(( "IO config"
+                "\n\ttype     ur"
+                "\n\tspad_max %lu bytes"
+                "\n\tdev_sz   %lu bytes"
+                "\n\tinfo     \"%s\" (info_sz %lu, discovered)"
+                "\n\tio_seed  0x%016lx (discovered)"
+                "\n\tsq depth %u entries",
+                spad_max, dev_sz,
+                (char const *)info, info_sz,
+                io_seed,
+                ring->sq.ring_entries ));
 
   return ur->base;
 }


### PR DESCRIPTION
Reduces stderr log clutter on validator startup by logging vinyl
I/O information to INFO log (log file only by default).

Also adds the io_uring submission queue depth to log.
