### PR TITLE
Make vinyl limit config more robust

### DIFF
--- a/src/discof/vinyl/fd_vinyl_tile.c
+++ b/src/discof/vinyl/fd_vinyl_tile.c
@@ -366,7 +366,8 @@ unprivileged_init( fd_topo_t *      topo,
     }
 
     if( FD_UNLIKELY( quota_max > fd_ulong_min( quota_free, FD_VINYL_COMP_QUOTA_MAX ) ) ) {
-      FD_LOG_ERR(( "too large quota_max (increase line_cnt or decrease quota_max)" ));
+      FD_LOG_ERR(( "too large quota_max (increase line_cnt (currently %lu, free %lu) or decrease quota_max (currently %lu))",
+                   vinyl->line_cnt, quota_free, quota_max ));
     }
 
     for( ulong client_idx=0UL; client_idx<ctx->client_cnt; client_idx++ ) {

--- a/src/flamenco/runtime/tests/run_ledger_backtest.sh
+++ b/src/flamenco/runtime/tests/run_ledger_backtest.sh
@@ -264,10 +264,13 @@ if [[ "$DB" == "funk" ]]; then
     max_database_transactions = 64
 EOF
 elif [[ "$DB" == "vinyl" ]]; then
+  if [[ "$INDEX_MAX" -lt "1000000" ]]; then
+    INDEX_MAX=1000000
+  fi
   cat <<EOF >> ${CONFIG_FILE}
 [funk]
     heap_size_gib = 2
-    max_account_records = 100000
+    max_account_records = 1000000
     max_database_transactions = 64
 [vinyl]
     enabled = true


### PR DESCRIPTION
Fixes a few backtests on vinyl which fail due to too low limits.

- If the user sets max_cache_entries lower than the sum of quotas
  on all links, log a warning and increase the cache size
- run_ledger_backtest.sh: run with at least 1 million record map
  capacity
