### PR TITLE
Increase vinyl reservations in run_ledger_backtest.sh

### DIFF
--- a/src/flamenco/runtime/tests/run_ledger_backtest.sh
+++ b/src/flamenco/runtime/tests/run_ledger_backtest.sh
@@ -275,7 +275,7 @@ elif [[ "$DB" == "vinyl" ]]; then
 [vinyl]
     enabled = true
     max_account_records = $INDEX_MAX
-    file_size_gib = $FUNK_PAGES
+    file_size_gib = $((FUNK_PAGES * 2))
     max_cache_entries = 100000
     cache_size_gib = 10
     [vinyl.io_uring]


### PR DESCRIPTION
Vinyl requires more raw space than funk (but on disk, not in DRAM)
