### PR TITLE
notar: add supermajority confirmation level

### DIFF
--- a/src/choreo/notar/fd_notar.c
+++ b/src/choreo/notar/fd_notar.c
@@ -143,6 +143,7 @@ fd_notar_count_vote( fd_notar_t *        notar,
     notar_blk->stake     = 0;
     notar_blk->dup_conf  = 0;
     notar_blk->opt_conf  = 0;
+    notar_blk->sup_conf  = 0;
     notar_blk->dup_notif = 0;
     notar_blk->opt_notif = 0;
     notar_slot->block_ids[notar_slot->block_ids_cnt++] = *vote_block_id;
@@ -150,6 +151,7 @@ fd_notar_count_vote( fd_notar_t *        notar,
   notar_blk->stake   += vtr->stake;
   notar_blk->dup_conf = ((double)notar_blk->stake / (double)total_stake) > 0.52;
   notar_blk->opt_conf = ((double)notar_blk->stake / (double)total_stake) > (2.0/3.0);
+  notar_blk->sup_conf = ((double)notar_blk->stake / (double)total_stake) > (4.0/5.0);
   return notar_blk;
 }
 

--- a/src/choreo/notar/fd_notar.h
+++ b/src/choreo/notar/fd_notar.h
@@ -116,6 +116,7 @@ struct fd_notar_blk {
   ulong     stake;     /* sum of stake that has voted for this block_id */
   int       dup_conf;  /* whether this block has reached 52% of stake */
   int       opt_conf;  /* whether this block has reached 2/3 of stake */
+  int       sup_conf;  /* whether this block has reached 4/5 of stake */
   int       dup_notif; /* set by caller, whether we've notified consumers this is duplicate confirmed */
   int       opt_notif; /* set by caller, whether we've notified consumers this is optimistically confirmed */
 };

--- a/src/choreo/notar/test_notar.c
+++ b/src/choreo/notar/test_notar.c
@@ -41,6 +41,7 @@ test_advance_epoch( fd_wksp_t * wksp ) {
   // blk->pro_conf        = 0;
   // blk->dup_conf        = 0;
   // blk->opt_conf        = 0;
+  // blk->sup_conf        = 0;
 
   // fd_pubkey_t pubkeys[4] = { { .key = { 1 } },
   //                            { .key = { 2 } },

--- a/src/discof/tower/fd_tower_tile.h
+++ b/src/discof/tower/fd_tower_tile.h
@@ -94,18 +94,22 @@ typedef struct fd_tower_slot_done fd_tower_slot_done_t;
    - cluster: same as optimistic, but may not have replayed / can be
      delivered out of order.
 
+   - super: same as optimistic, but the stake threshold is 4/5
+     of stake.
+
    - rooted: a block is rooted if it or any of its descendants reach max
      lockout per TowerBFT rules.
 
-   For optimistic and rooted confirmations, the tower tile guarantees
-   that we have already replayed the block.  This is not the case for
-   duplicate and cluster confirmations (a block can get duplicate or
-   cluster confirmed before it has been replayed).  Optimistic and
-   rooted confirmations are also guaranteed to be delivered in-order
-   with no gaps from tower.  That is, if we receive a rooted frag for
-   slot N, we will have already received rooted frags for any ancestor
-   slots N - 1, N - 2, ... (if they are not skipped / on a different
-   fork) and likewise for optimistic.
+   For optimistic, super, and rooted confirmations, the tower tile
+   guarantees that we have already replayed the block.  This is not the
+   case for duplicate and cluster confirmations (a block can get
+   duplicate or cluster confirmed before it has been replayed).
+   Optimistic, super, and rooted confirmations are also
+   guaranteed to be delivered in-order with no gaps from tower.  That
+   is, if we receive a rooted frag for slot N, we will have already
+   received rooted frags for any ancestor slots N - 1, N - 2, ... (if
+   they are not skipped / on a different fork) and likewise for
+   optimistic.
 
    Note even if tower never actually voted on a slot (and therefore the
    slot never became a tower root), tower will still send a rooted
@@ -120,7 +124,8 @@ typedef struct fd_tower_slot_done fd_tower_slot_done_t;
 #define FD_TOWER_SLOT_CONFIRMED_DUPLICATE  0
 #define FD_TOWER_SLOT_CONFIRMED_OPTIMISTIC 1
 #define FD_TOWER_SLOT_CONFIRMED_CLUSTER    2
-#define FD_TOWER_SLOT_CONFIRMED_ROOTED     3
+#define FD_TOWER_SLOT_CONFIRMED_SUPER      3
+#define FD_TOWER_SLOT_CONFIRMED_ROOTED     4
 
 struct fd_tower_slot_confirmed {
   ulong     slot;


### PR DESCRIPTION
This will help with implementing `--wait-for-supermajority` to join cluster restarts.