### PR TITLE
flamenco, vm: fix ubsan errors in the vm

### DIFF
--- a/src/flamenco/vm/fd_vm_interp_core.c
+++ b/src/flamenco/vm/fd_vm_interp_core.c
@@ -59,25 +59,37 @@
 
    https://doc.rust-lang.org/std/primitive.u64.html#method.wrapping_shl
  */
-#define FD_RUST_ULONG_WRAPPING_SHL( a, b ) (a << ( b & ( 63 ) ))
+#define FD_RUST_ULONG_WRAPPING_SHL( a, b ) ((a) << ( (b) & ( 63 ) ))
 
 /* u64::wrapping_shr: a.unchecked_shr(b & (64 - 1))
 
    https://doc.rust-lang.org/std/primitive.u64.html#method.wrapping_shr
  */
-#define FD_RUST_ULONG_WRAPPING_SHR( a, b ) (a >> ( b & ( 63 ) ))
+#define FD_RUST_ULONG_WRAPPING_SHR( a, b ) ((a) >> ( (b) & ( 63 ) ))
 
 /* u32::wrapping_shl: a.unchecked_shl(b & (32 - 1))
 
    https://doc.rust-lang.org/std/primitive.u32.html#method.wrapping_shl
  */
-#define FD_RUST_UINT_WRAPPING_SHL( a, b ) (a << ( b & ( 31 ) ))
+#define FD_RUST_UINT_WRAPPING_SHL( a, b ) ((a) << ( (b) & ( 31 ) ))
 
 /* u32::wrapping_shr: a.unchecked_shr(b & (32 - 1))
 
    https://doc.rust-lang.org/std/primitive.u32.html#method.wrapping_shr
  */
-#define FD_RUST_UINT_WRAPPING_SHR( a, b ) (a >> ( b & ( 31 ) ))
+#define FD_RUST_UINT_WRAPPING_SHR( a, b ) ((a) >> ( (b) & ( 31 ) ))
+
+/* i32::wrapping_shr: a.unchecked_shr(b & (32 - 1))
+
+   https://doc.rust-lang.org/std/primitive.i32.html#method.wrapping_shr
+ */
+#define FD_RUST_INT_WRAPPING_SHR( a, b ) ((a) >> ( (b) & ( 31 ) ))
+
+/* i64::wrapping_shr: a.unchecked_shr(b & (64 - 1))
+
+   https://doc.rust-lang.org/std/primitive.i64.html#method.wrapping_shr
+ */
+#define FD_RUST_LONG_WRAPPING_SHR( a, b ) ((a) >> ( (b) & ( 63 ) ))
 
 
 # define FD_VM_INTERP_INSTR_EXEC                                                                 \
@@ -976,7 +988,7 @@ interp_exec:
   /* 0xc0 - 0xcf ******************************************************/
 
   FD_VM_INTERP_INSTR_BEGIN(0xc4) /* FD_SBPF_OP_ARSH_IMM */
-    reg[ dst ] = (ulong)(uint)( (int)reg_dst >> imm ); /* FIXME: WIDE SHIFTS, STRICT SIGN EXTENSION */
+    reg[ dst ] = (ulong)(uint)( FD_RUST_INT_WRAPPING_SHR( (int)reg_dst, imm ) );
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_BRANCH_BEGIN(0xc5) /* FD_SBPF_OP_JSLT_IMM */ /* FIXME: CHECK IMM SIGN EXTENSION */
@@ -989,11 +1001,11 @@ interp_exec:
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0xc7) /* FD_SBPF_OP_ARSH64_IMM */
-    reg[ dst ] = (ulong)( (long)reg_dst >> imm ); /* FIXME: WIDE SHIFTS, STRICT SIGN EXTENSION */
+    reg[ dst ] = (ulong)( FD_RUST_LONG_WRAPPING_SHR( (long)reg_dst, imm ) );
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0xcc) /* FD_SBPF_OP_ARSH_REG */
-    reg[ dst ] = (ulong)(uint)( (int)reg_dst >> (uint)reg_src ); /* FIXME: WIDE SHIFTS, STRICT SIGN EXTENSION */
+    reg[ dst ] = (ulong)(uint)( FD_RUST_INT_WRAPPING_SHR( (int)reg_dst, (uint)reg_src ) );
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_BRANCH_BEGIN(0xcd) /* FD_SBPF_OP_JSLT_REG */
@@ -1007,7 +1019,7 @@ interp_exec:
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0xcf) /* FD_SBPF_OP_ARSH64_REG */
-    reg[ dst ] = (ulong)( (long)reg_dst >> reg_src ); /* FIXME: WIDE SHIFTS, STRICT SIGN EXTENSION */
+    reg[ dst ] = (ulong)( FD_RUST_LONG_WRAPPING_SHR( (long)reg_dst, reg_src ) );
   FD_VM_INTERP_INSTR_END;
 
   /* 0xd0 - 0xdf ******************************************************/

--- a/src/flamenco/vm/instr_test/v0/shift.instr
+++ b/src/flamenco/vm/instr_test/v0/shift.instr
@@ -224,3 +224,84 @@ $ op=67 dst=6 src=2 off=8000 r6=5a5a5a5a00000002 imm=ffffffff : vfy
 $ op=67 dst=9 src=b                                           : vfy # invalid src
 $ op=67 dst=a src=1                                           : vfy # invalid dst
 $ op=67 dst=b src=1                                           : vfy # invalid dst
+
+# arsh32 reg, imm
+$ op=c4 dst=0 src=a off=0000 r0=               0 imm=       0 : ok  r0=               0  # zero
+$ op=c4 dst=1 src=9 off=0000 r1=ffffffff00000000 imm=       0 : ok  r1=               0  # truncate upper, zero result
+$ op=c4 dst=2 src=8 off=0000 r2=ffffffff00000001 imm=       0 : ok  r2=               1  # positive stays positive
+$ op=c4 dst=3 src=7 off=0000 r3=        80000000 imm=       0 : ok  r3=        80000000  # negative, no shift
+$ op=c4 dst=4 src=6 off=0000 r4=        80000000 imm=       1 : ok  r4=        c0000000  # negative, sign extends
+$ op=c4 dst=5 src=5 off=0000 r5=        80000000 imm=       2 : ok  r5=        e0000000
+$ op=c4 dst=6 src=4 off=0000 r6=        80000000 imm=       3 : ok  r6=        f0000000
+$ op=c4 dst=7 src=3 off=0000 r7=        80000000 imm=       4 : ok  r7=        f8000000
+$ op=c4 dst=8 src=2 off=0000 r8=        80000000 imm=      1f : ok  r8=        ffffffff  # all 1s
+$ op=c4 dst=9 src=1 off=0000 r9=        7fffffff imm=       1 : ok  r9=        3fffffff  # positive, zero fills
+$ op=c4 dst=0 src=0 off=0000 r0=        7fffffff imm=      1e : ok  r0=               1
+$ op=c4 dst=1 src=a off=0000 r1=        7fffffff imm=      1f : ok  r1=               0  # shifted to zero
+$ op=c4 dst=2 src=9 off=0000 r2=        ffffffff imm=       1 : ok  r2=        ffffffff  # -1 stays -1
+$ op=c4 dst=3 src=8 off=0000 r3=        80000000 imm=      20 : vfy
+$ op=c4 dst=4 src=7 off=0000 r4=        80000000 imm=      21 : vfy
+$ op=c4 dst=5 src=6 off=0000 r5=        80000000 imm=      3f : vfy
+$ op=c4 dst=6 src=5 off=0000 r6=        80000000 imm=      40 : vfy
+$ op=c4 dst=7 src=4 off=0000 r7=        80000000 imm=7fffffff : vfy
+$ op=c4 dst=8 src=3 off=0000 r8=        80000000 imm=ffffffff : vfy
+$ op=c4 dst=9 src=2 off=0000 r9=        7fffffff imm=ffffffff : vfy
+$ op=c4 dst=9 src=b                                           : vfy
+$ op=c4 dst=a src=1                                           : vfy
+$ op=c4 dst=b src=1                                           : vfy
+
+# arsh32 reg, reg
+$ op=cc dst=0 src=a off=0000 r0=               0 r10=       0 : ok  r0=               0  # zero
+$ op=cc dst=1 src=9 off=0000 r1=        80000000 r9 =       0 : ok  r1=        80000000  # no shift
+$ op=cc dst=2 src=8 off=0000 r2=        80000000 r8 =       1 : ok  r2=        c0000000  # sign extends
+$ op=cc dst=3 src=7 off=0000 r3=        80000000 r7 =      1f : ok  r3=        ffffffff  # all 1s
+$ op=cc dst=4 src=6 off=0000 r4=        7fffffff r6 =       1 : ok  r4=        3fffffff  # positive
+$ op=cc dst=5 src=6 off=0000 r5=        ffffffff r6 =       1 : ok  r5=        ffffffff  # -1 stays -1
+# arsh32 reg wrapping tests (shift amount masked with 31)
+$ op=cc dst=6 src=4 off=0000 r6=        80000000 r4 =      20 : ok  r6=        80000000  # 32 & 31 = 0
+$ op=cc dst=7 src=3 off=0000 r7=        80000000 r3 =      21 : ok  r7=        c0000000  # 33 & 31 = 1
+$ op=cc dst=8 src=2 off=0000 r8=        80000000 r2 =7fffffff : ok  r8=        ffffffff  # 0x7fffffff & 31 = 31
+$ op=cc dst=9 src=1 off=0000 r9=        80000000 r1 =ffffffff : ok  r9=        ffffffff  # 0xffffffff & 31 = 31
+$ op=cc dst=0 src=a off=0000 r0=        80000000 r10=ffffffffffffffff : ok  r0=        ffffffff  # lower 32 bits used, & 31
+$ op=cc dst=9 src=b                                           : vfy
+$ op=cc dst=a src=1                                           : vfy
+$ op=cc dst=b src=1                                           : vfy
+
+# arsh64 reg, imm
+$ op=c7 dst=0 src=a off=0000 r0=               0 imm=       0 : ok  r0=               0  # zero
+$ op=c7 dst=1 src=9 off=0000 r1=8000000000000000 imm=       0 : ok  r1=8000000000000000  # negative, no shift
+$ op=c7 dst=2 src=8 off=0000 r2=8000000000000000 imm=       1 : ok  r2=c000000000000000  # sign extends
+$ op=c7 dst=3 src=7 off=0000 r3=8000000000000000 imm=       2 : ok  r3=e000000000000000
+$ op=c7 dst=4 src=6 off=0000 r4=8000000000000000 imm=       3 : ok  r4=f000000000000000
+$ op=c7 dst=5 src=5 off=0000 r5=8000000000000000 imm=       4 : ok  r5=f800000000000000
+$ op=c7 dst=6 src=4 off=0000 r6=8000000000000000 imm=      3f : ok  r6=ffffffffffffffff  # all 1s
+$ op=c7 dst=7 src=3 off=0000 r7=7fffffffffffffff imm=       1 : ok  r7=3fffffffffffffff  # positive
+$ op=c7 dst=8 src=2 off=0000 r8=7fffffffffffffff imm=      3e : ok  r8=               1
+$ op=c7 dst=9 src=1 off=0000 r9=7fffffffffffffff imm=      3f : ok  r9=               0  # shifted to zero
+$ op=c7 dst=0 src=0 off=0000 r0=ffffffffffffffff imm=       1 : ok  r0=ffffffffffffffff  # -1 stays -1
+$ op=c7 dst=1 src=a off=0000 r1=8000000000000000 imm=      40 : vfy
+$ op=c7 dst=2 src=9 off=0000 r2=8000000000000000 imm=      41 : vfy
+$ op=c7 dst=3 src=8 off=0000 r3=8000000000000000 imm=      7f : vfy
+$ op=c7 dst=4 src=7 off=0000 r4=8000000000000000 imm=      80 : vfy
+$ op=c7 dst=5 src=6 off=0000 r5=8000000000000000 imm=7fffffff : vfy
+$ op=c7 dst=6 src=5 off=0000 r6=8000000000000000 imm=ffffffff : vfy
+$ op=c7 dst=7 src=4 off=0000 r7=7fffffffffffffff imm=ffffffff : vfy
+$ op=c7 dst=9 src=b                                           : vfy
+$ op=c7 dst=a src=1                                           : vfy
+$ op=c7 dst=b src=1                                           : vfy
+
+# arsh64 reg, reg
+$ op=cf dst=0 src=a off=0000 r0=               0 r10=       0 : ok  r0=               0  # zero
+$ op=cf dst=1 src=9 off=0000 r1=8000000000000000 r9 =       0 : ok  r1=8000000000000000  # no shift
+$ op=cf dst=2 src=8 off=0000 r2=8000000000000000 r8 =       1 : ok  r2=c000000000000000  # sign extends
+$ op=cf dst=3 src=7 off=0000 r3=8000000000000000 r7 =      3f : ok  r3=ffffffffffffffff  # all 1s
+$ op=cf dst=4 src=6 off=0000 r4=7fffffffffffffff r6 =       1 : ok  r4=3fffffffffffffff  # positive
+$ op=cf dst=5 src=6 off=0000 r5=ffffffffffffffff r6 =       1 : ok  r5=ffffffffffffffff  # -1 stays -1
+$ op=cf dst=6 src=4 off=0000 r6=8000000000000000 r4 =      40 : ok  r6=8000000000000000  # 64 & 63 = 0
+$ op=cf dst=7 src=3 off=0000 r7=8000000000000000 r3 =      41 : ok  r7=c000000000000000  # 65 & 63 = 1
+$ op=cf dst=8 src=2 off=0000 r8=8000000000000000 r2 =7fffffff : ok  r8=ffffffffffffffff  # 0x7fffffff & 63 = 63
+$ op=cf dst=9 src=1 off=0000 r9=8000000000000000 r1 =ffffffff : ok  r9=ffffffffffffffff  # 0xffffffff & 63 = 63
+$ op=cf dst=0 src=a off=0000 r0=8000000000000000 r10=ffffffffffffffff : ok  r0=ffffffffffffffff  # lower bits used, & 63
+$ op=cf dst=9 src=b                                           : vfy
+$ op=cf dst=a src=1                                           : vfy
+$ op=cf dst=b src=1                                           : vfy

--- a/src/flamenco/vm/instr_test/v2/shift.instr
+++ b/src/flamenco/vm/instr_test/v2/shift.instr
@@ -224,3 +224,84 @@ $ op=67 dst=6 src=2 off=8000 r6=5a5a5a5a00000002 imm=ffffffff : vfy
 $ op=67 dst=9 src=b                                           : vfy # invalid src
 $ op=67 dst=a src=1                                           : vfy # invalid dst
 $ op=67 dst=b src=1                                           : vfy # invalid dst
+
+# arsh32 reg, imm
+$ op=c4 dst=0 src=a off=0000 r0=               0 imm=       0 : ok  r0=               0  # zero
+$ op=c4 dst=1 src=9 off=0000 r1=ffffffff00000000 imm=       0 : ok  r1=               0  # truncate upper, zero result
+$ op=c4 dst=2 src=8 off=0000 r2=ffffffff00000001 imm=       0 : ok  r2=               1  # positive stays positive
+$ op=c4 dst=3 src=7 off=0000 r3=        80000000 imm=       0 : ok  r3=        80000000  # negative, no shift
+$ op=c4 dst=4 src=6 off=0000 r4=        80000000 imm=       1 : ok  r4=        c0000000  # negative, sign extends
+$ op=c4 dst=5 src=5 off=0000 r5=        80000000 imm=       2 : ok  r5=        e0000000
+$ op=c4 dst=6 src=4 off=0000 r6=        80000000 imm=       3 : ok  r6=        f0000000
+$ op=c4 dst=7 src=3 off=0000 r7=        80000000 imm=       4 : ok  r7=        f8000000
+$ op=c4 dst=8 src=2 off=0000 r8=        80000000 imm=      1f : ok  r8=        ffffffff  # all 1s
+$ op=c4 dst=9 src=1 off=0000 r9=        7fffffff imm=       1 : ok  r9=        3fffffff  # positive, zero fills
+$ op=c4 dst=0 src=0 off=0000 r0=        7fffffff imm=      1e : ok  r0=               1
+$ op=c4 dst=1 src=a off=0000 r1=        7fffffff imm=      1f : ok  r1=               0  # shifted to zero
+$ op=c4 dst=2 src=9 off=0000 r2=        ffffffff imm=       1 : ok  r2=        ffffffff  # -1 stays -1
+$ op=c4 dst=3 src=8 off=0000 r3=        80000000 imm=      20 : vfy
+$ op=c4 dst=4 src=7 off=0000 r4=        80000000 imm=      21 : vfy
+$ op=c4 dst=5 src=6 off=0000 r5=        80000000 imm=      3f : vfy
+$ op=c4 dst=6 src=5 off=0000 r6=        80000000 imm=      40 : vfy
+$ op=c4 dst=7 src=4 off=0000 r7=        80000000 imm=7fffffff : vfy
+$ op=c4 dst=8 src=3 off=0000 r8=        80000000 imm=ffffffff : vfy
+$ op=c4 dst=9 src=2 off=0000 r9=        7fffffff imm=ffffffff : vfy
+$ op=c4 dst=9 src=b                                           : vfy
+$ op=c4 dst=a src=1                                           : vfy
+$ op=c4 dst=b src=1                                           : vfy
+
+# arsh32 reg, reg
+$ op=cc dst=0 src=a off=0000 r0=               0 r10=       0 : ok  r0=               0  # zero
+$ op=cc dst=1 src=9 off=0000 r1=        80000000 r9 =       0 : ok  r1=        80000000  # no shift
+$ op=cc dst=2 src=8 off=0000 r2=        80000000 r8 =       1 : ok  r2=        c0000000  # sign extends
+$ op=cc dst=3 src=7 off=0000 r3=        80000000 r7 =      1f : ok  r3=        ffffffff  # all 1s
+$ op=cc dst=4 src=6 off=0000 r4=        7fffffff r6 =       1 : ok  r4=        3fffffff  # positive
+$ op=cc dst=5 src=6 off=0000 r5=        ffffffff r6 =       1 : ok  r5=        ffffffff  # -1 stays -1
+# arsh32 reg wrapping tests (shift amount masked with 31)
+$ op=cc dst=6 src=4 off=0000 r6=        80000000 r4 =      20 : ok  r6=        80000000  # 32 & 31 = 0
+$ op=cc dst=7 src=3 off=0000 r7=        80000000 r3 =      21 : ok  r7=        c0000000  # 33 & 31 = 1
+$ op=cc dst=8 src=2 off=0000 r8=        80000000 r2 =7fffffff : ok  r8=        ffffffff  # 0x7fffffff & 31 = 31
+$ op=cc dst=9 src=1 off=0000 r9=        80000000 r1 =ffffffff : ok  r9=        ffffffff  # 0xffffffff & 31 = 31
+$ op=cc dst=0 src=a off=0000 r0=        80000000 r10=ffffffffffffffff : ok  r0=        ffffffff  # lower 32 bits used, & 31
+$ op=cc dst=9 src=b                                           : vfy
+$ op=cc dst=a src=1                                           : vfy
+$ op=cc dst=b src=1                                           : vfy
+
+# arsh64 reg, imm
+$ op=c7 dst=0 src=a off=0000 r0=               0 imm=       0 : ok  r0=               0  # zero
+$ op=c7 dst=1 src=9 off=0000 r1=8000000000000000 imm=       0 : ok  r1=8000000000000000  # negative, no shift
+$ op=c7 dst=2 src=8 off=0000 r2=8000000000000000 imm=       1 : ok  r2=c000000000000000  # sign extends
+$ op=c7 dst=3 src=7 off=0000 r3=8000000000000000 imm=       2 : ok  r3=e000000000000000
+$ op=c7 dst=4 src=6 off=0000 r4=8000000000000000 imm=       3 : ok  r4=f000000000000000
+$ op=c7 dst=5 src=5 off=0000 r5=8000000000000000 imm=       4 : ok  r5=f800000000000000
+$ op=c7 dst=6 src=4 off=0000 r6=8000000000000000 imm=      3f : ok  r6=ffffffffffffffff  # all 1s
+$ op=c7 dst=7 src=3 off=0000 r7=7fffffffffffffff imm=       1 : ok  r7=3fffffffffffffff  # positive
+$ op=c7 dst=8 src=2 off=0000 r8=7fffffffffffffff imm=      3e : ok  r8=               1
+$ op=c7 dst=9 src=1 off=0000 r9=7fffffffffffffff imm=      3f : ok  r9=               0  # shifted to zero
+$ op=c7 dst=0 src=0 off=0000 r0=ffffffffffffffff imm=       1 : ok  r0=ffffffffffffffff  # -1 stays -1
+$ op=c7 dst=1 src=a off=0000 r1=8000000000000000 imm=      40 : vfy
+$ op=c7 dst=2 src=9 off=0000 r2=8000000000000000 imm=      41 : vfy
+$ op=c7 dst=3 src=8 off=0000 r3=8000000000000000 imm=      7f : vfy
+$ op=c7 dst=4 src=7 off=0000 r4=8000000000000000 imm=      80 : vfy
+$ op=c7 dst=5 src=6 off=0000 r5=8000000000000000 imm=7fffffff : vfy
+$ op=c7 dst=6 src=5 off=0000 r6=8000000000000000 imm=ffffffff : vfy
+$ op=c7 dst=7 src=4 off=0000 r7=7fffffffffffffff imm=ffffffff : vfy
+$ op=c7 dst=9 src=b                                           : vfy
+$ op=c7 dst=a src=1                                           : vfy
+$ op=c7 dst=b src=1                                           : vfy
+
+# arsh64 reg, reg
+$ op=cf dst=0 src=a off=0000 r0=               0 r10=       0 : ok  r0=               0  # zero
+$ op=cf dst=1 src=9 off=0000 r1=8000000000000000 r9 =       0 : ok  r1=8000000000000000  # no shift
+$ op=cf dst=2 src=8 off=0000 r2=8000000000000000 r8 =       1 : ok  r2=c000000000000000  # sign extends
+$ op=cf dst=3 src=7 off=0000 r3=8000000000000000 r7 =      3f : ok  r3=ffffffffffffffff  # all 1s
+$ op=cf dst=4 src=6 off=0000 r4=7fffffffffffffff r6 =       1 : ok  r4=3fffffffffffffff  # positive
+$ op=cf dst=5 src=6 off=0000 r5=ffffffffffffffff r6 =       1 : ok  r5=ffffffffffffffff  # -1 stays -1
+$ op=cf dst=6 src=4 off=0000 r6=8000000000000000 r4 =      40 : ok  r6=8000000000000000  # 64 & 63 = 0
+$ op=cf dst=7 src=3 off=0000 r7=8000000000000000 r3 =      41 : ok  r7=c000000000000000  # 65 & 63 = 1
+$ op=cf dst=8 src=2 off=0000 r8=8000000000000000 r2 =7fffffff : ok  r8=ffffffffffffffff  # 0x7fffffff & 63 = 63
+$ op=cf dst=9 src=1 off=0000 r9=8000000000000000 r1 =ffffffff : ok  r9=ffffffffffffffff  # 0xffffffff & 63 = 63
+$ op=cf dst=0 src=a off=0000 r0=8000000000000000 r10=ffffffffffffffff : ok  r0=ffffffffffffffff  # lower bits used, & 63
+$ op=cf dst=9 src=b                                           : vfy
+$ op=cf dst=a src=1                                           : vfy
+$ op=cf dst=b src=1                                           : vfy


### PR DESCRIPTION
Fix ubsan errors in backtest whilst preserving the correct semantics to match Agave's vm. The resulting x86 machine code is identical - this is just to avoid the ubsan errors. Perf ledger shows no difference.