### PR TITLE
tmpl: detect iter_next misuse

### DIFF
--- a/src/util/tmpl/fd_bplus.c
+++ b/src/util/tmpl/fd_bplus.c
@@ -953,6 +953,7 @@ BPLUS_(iter_eq_nul)( BPLUS_(t) const * join,
   return !iter.leaf_off;
 }
 
+__attribute__((warn_unused_result))
 static inline BPLUS_(iter_t)
 BPLUS_(iter_next)( BPLUS_(t) const * join,
                    BPLUS_(iter_t)    iter ) {
@@ -974,6 +975,7 @@ BPLUS_(iter_next)( BPLUS_(t) const * join,
   return iter;
 }
 
+__attribute__((warn_unused_result))
 static inline BPLUS_(iter_t)
 BPLUS_(iter_prev)( BPLUS_(t) const * join,
                    BPLUS_(iter_t)    iter ) {

--- a/src/util/tmpl/fd_deque.c
+++ b/src/util/tmpl/fd_deque.c
@@ -502,13 +502,13 @@ DEQUE_(iter_done_rev)( DEQUE_T const * deque, DEQUE_(iter_t) iter ) {
   return iter == hdr->start - 1;
 }
 
-static inline DEQUE_(iter_t)
+__attribute__((warn_unused_result)) static inline DEQUE_(iter_t)
 DEQUE_(iter_next)( DEQUE_T const * deque, DEQUE_(iter_t) iter ) {
   (void)deque;
   return iter+1;
 }
 
-static inline DEQUE_(iter_t)
+__attribute__((warn_unused_result)) static inline DEQUE_(iter_t)
 DEQUE_(iter_prev)( DEQUE_T const * deque, DEQUE_(iter_t) iter ) {
   (void)deque;
   return iter-1;

--- a/src/util/tmpl/fd_deque_dynamic.c
+++ b/src/util/tmpl/fd_deque_dynamic.c
@@ -598,7 +598,7 @@ DEQUE_(iter_done_rev)( DEQUE_T const * deque, DEQUE_(iter_t) iter ) {
   return !iter.rem;
 }
 
-static inline DEQUE_(iter_t)
+__attribute__((warn_unused_result)) static inline DEQUE_(iter_t)
 DEQUE_(iter_next)( DEQUE_T const * deque, DEQUE_(iter_t) iter ) {
   DEQUE_(private_t) const * hdr = DEQUE_(private_const_hdr_from_deque)( deque );
   iter.rem--;
@@ -606,7 +606,7 @@ DEQUE_(iter_next)( DEQUE_T const * deque, DEQUE_(iter_t) iter ) {
   return iter;
 }
 
-static inline DEQUE_(iter_t)
+__attribute__((warn_unused_result)) static inline DEQUE_(iter_t)
 DEQUE_(iter_prev)( DEQUE_T const * deque, DEQUE_(iter_t) iter ) {
   DEQUE_(private_t) const * hdr = DEQUE_(private_const_hdr_from_deque)( deque );
   iter.rem--;

--- a/src/util/tmpl/fd_map_chain.c
+++ b/src/util/tmpl/fd_map_chain.c
@@ -529,7 +529,7 @@ MAP_(iter_done)( MAP_(iter_t)      iter,
   return !iter.chain_rem;
 }
 
-FD_FN_PURE static inline MAP_(iter_t)
+__attribute__((warn_unused_result)) FD_FN_PURE static inline MAP_(iter_t)
 MAP_(iter_next)( MAP_(iter_t)      iter,
                  MAP_(t) const *   join,
                  MAP_ELE_T const * pool ) {

--- a/src/util/tmpl/fd_map_chain_para.c
+++ b/src/util/tmpl/fd_map_chain_para.c
@@ -1525,6 +1525,7 @@ MAP_(iter)( MAP_(t) const * join,
 
 FD_FN_CONST static inline int MAP_(iter_done)( MAP_(iter_t) iter ) { return MAP_(private_idx_is_null)( iter.ele_idx ); }
 
+__attribute__((warn_unused_result))
 FD_FN_PURE static inline MAP_(iter_t)
 MAP_(iter_next)( MAP_(iter_t) iter ) {
   MAP_ELE_T const * ele = iter.ele + iter.ele_idx;

--- a/src/util/tmpl/fd_map_giant.c
+++ b/src/util/tmpl/fd_map_giant.c
@@ -475,6 +475,7 @@ MAP_(iter_done)( MAP_T const * join,
   return !ele_rem;
 }
 
+__attribute__((warn_unused_result))
 FD_FN_PURE static inline MAP_(iter_t)
 MAP_(iter_next)( MAP_T const * join,
                  MAP_(iter_t)  ele_rem ) {

--- a/src/util/tmpl/fd_map_slot.c
+++ b/src/util/tmpl/fd_map_slot.c
@@ -805,7 +805,7 @@ MAP_(iter_done)( MAP_(t) const * join,
   return iter > join->probe_rem;
 }
 
-FD_FN_PURE static inline MAP_(iter_t)
+__attribute__((warn_unused_result)) FD_FN_PURE static inline MAP_(iter_t)
 MAP_(iter_next)( MAP_(t) const * join,
                  ulong           memo,
                  MAP_(iter_t)    iter ) {

--- a/src/util/tmpl/fd_map_slot_para.c
+++ b/src/util/tmpl/fd_map_slot_para.c
@@ -2284,7 +2284,7 @@ MAP_(iter_init)( MAP_(t) *      join,
   /* never get here */
 }
 
-MAP_(iter_t) *
+__attribute__((warn_unused_result)) MAP_(iter_t) *
 MAP_(iter_next)( MAP_(iter_t) * iter ) {
   ulong ele_idx = iter->ele_idx;
   ulong ele_rem = iter->ele_rem - 1UL;

--- a/src/util/tmpl/fd_set.c
+++ b/src/util/tmpl/fd_set.c
@@ -290,7 +290,7 @@ SET_(last)( SET_(t) const * set ) {
   return ~0UL;
 }
 
-FD_FN_UNUSED static ulong /* Work around -Winline */
+__attribute__((warn_unused_result)) FD_FN_UNUSED static ulong /* Work around -Winline */
 SET_(iter_next)( SET_(t) * set,
                  ulong     j ) {                     /* We've considered all bits up to and including j */
   j++;                                               /* Lowest bit we haven't considered */
@@ -307,7 +307,7 @@ SET_(iter_next)( SET_(t) * set,
 static inline ulong SET_(iter_init)( SET_(t) * set ) { return SET_(iter_next)( set, ~0UL ); }
 FD_FN_CONST static inline ulong SET_(iter_done)( ulong j ) { return !~j; }
 
-FD_FN_PURE FD_FN_UNUSED static ulong /* Work around -Winline */
+__attribute__((warn_unused_result)) FD_FN_PURE FD_FN_UNUSED static ulong /* Work around -Winline */
 SET_(const_iter_next)( SET_(t) const * set,
                        ulong           j ) {               /* We've considered all bits up to and including j */
   j++;                                                     /* Lowest bit we haven't considered */

--- a/src/util/tmpl/fd_set_dynamic.c
+++ b/src/util/tmpl/fd_set_dynamic.c
@@ -321,7 +321,7 @@ SET_(first)( SET_(t) const * set ) {
   return ~0UL;
 }
 
-FD_FN_UNUSED static ulong /* Work around -Winline */
+__attribute__((warn_unused_result)) FD_FN_UNUSED static ulong /* Work around -Winline */
 SET_(iter_next)( SET_(t) * set,
                  ulong     j ) {                     /* We've considered all bits up to and including j */
   j++;                                               /* Lowest bit we haven't considered */
@@ -338,7 +338,7 @@ SET_(iter_next)( SET_(t) * set,
 static inline ulong SET_(iter_init)( SET_(t) * set ) { return SET_(iter_next)( set, ~0UL ); }
 FD_FN_CONST static inline ulong SET_(iter_done)( ulong j ) { return !~j; }
 
-FD_FN_PURE FD_FN_UNUSED static ulong /* Work around -Winline */
+__attribute__((warn_unused_result)) FD_FN_PURE FD_FN_UNUSED static ulong /* Work around -Winline */
 SET_(const_iter_next)( SET_(t) const * set,
                        ulong           j ) {               /* We've considered all bits up to and including j */
   j++;                                                     /* Lowest bit we haven't considered */

--- a/src/util/tmpl/fd_slist.c
+++ b/src/util/tmpl/fd_slist.c
@@ -406,7 +406,7 @@ SLIST_(iter_done)( SLIST_(iter_t)      iter,
   return SLIST_(private_idx_is_null)( iter );
 }
 
-FD_FN_PURE static inline SLIST_(iter_t)
+__attribute__((warn_unused_result)) FD_FN_PURE static inline SLIST_(iter_t)
 SLIST_(iter_next)( SLIST_(iter_t)      iter,
                        SLIST_(t) const *   join,
                        SLIST_ELE_T const * pool ) {

--- a/src/util/tmpl/fd_smallset.c
+++ b/src/util/tmpl/fd_smallset.c
@@ -214,6 +214,7 @@ FD_FN_CONST static inline SET_(t) SET_(if)( int c, SET_(t) t, SET_(t) f ) { retu
 
 FD_FN_CONST static inline SET_(iter_t) SET_(iter_init)( SET_(t)      set  ) { return set;                             }
 FD_FN_CONST static inline SET_(iter_t) SET_(iter_done)( SET_(iter_t) iter ) { return !iter;                           }
+__attribute__((warn_unused_result))
 FD_FN_CONST static inline SET_(iter_t) SET_(iter_next)( SET_(iter_t) iter ) { return SET_POP_LSB(  iter );            }
 FD_FN_CONST static inline SET_IDX_T    SET_(iter_idx) ( SET_(iter_t) iter ) { return (SET_IDX_T)SET_FIND_LSB( iter ); }
 

--- a/src/util/tmpl/fd_treap.c
+++ b/src/util/tmpl/fd_treap.c
@@ -511,8 +511,8 @@ TREAP_STATIC TREAP_(t) * TREAP_(idx_remove)( TREAP_(t) * treap, ulong d, TREAP_T
 TREAP_STATIC FD_FN_PURE TREAP_(fwd_iter_t) TREAP_(fwd_iter_init)( TREAP_(t) const * treap, TREAP_T const * pool );
 TREAP_STATIC FD_FN_PURE TREAP_(rev_iter_t) TREAP_(rev_iter_init)( TREAP_(t) const * treap, TREAP_T const * pool );
 
-TREAP_STATIC FD_FN_PURE TREAP_(fwd_iter_t) TREAP_(fwd_iter_next)( TREAP_(fwd_iter_t) i, TREAP_T const * pool );
-TREAP_STATIC FD_FN_PURE TREAP_(rev_iter_t) TREAP_(rev_iter_next)( TREAP_(rev_iter_t) i, TREAP_T const * pool );
+__attribute__((warn_unused_result)) TREAP_STATIC FD_FN_PURE TREAP_(fwd_iter_t) TREAP_(fwd_iter_next)( TREAP_(fwd_iter_t) i, TREAP_T const * pool );
+__attribute__((warn_unused_result)) TREAP_STATIC FD_FN_PURE TREAP_(rev_iter_t) TREAP_(rev_iter_next)( TREAP_(rev_iter_t) i, TREAP_T const * pool );
 
 TREAP_STATIC TREAP_(t) * TREAP_(merge)( TREAP_(t) * treap_a, TREAP_(t) * treap_b, TREAP_T * pool );
 
@@ -1387,7 +1387,7 @@ TREAP_(rev_iter_init)( TREAP_(t) const * treap,
 # endif
 }
 
-TREAP_STATIC TREAP_(fwd_iter_t)
+__attribute__((warn_unused_result)) TREAP_STATIC TREAP_(fwd_iter_t)
 TREAP_(fwd_iter_next)( TREAP_(fwd_iter_t) i,
                        TREAP_T const *    pool ) {
 # if TREAP_OPTIMIZE_ITERATION
@@ -1416,7 +1416,7 @@ TREAP_(fwd_iter_next)( TREAP_(fwd_iter_t) i,
 # endif
 }
 
-TREAP_STATIC TREAP_(rev_iter_t)
+__attribute__((warn_unused_result)) TREAP_STATIC TREAP_(rev_iter_t)
 TREAP_(rev_iter_next)( TREAP_(rev_iter_t) i,
                        TREAP_T const *    pool ) {
 # if TREAP_OPTIMIZE_ITERATION


### PR DESCRIPTION
Detects the following buggy code pattern:

    for( iter_t iter = iter_init( ... );
         !iter_done( iter );
         iter_next( iter ) ) {
      ...
    }

(iter_next is typically a pure-ish function, so ignoring the
return value is a programmer error.)
