### PR TITLE
stakes: fix bug in fd_stake_delegations_refresh

### DIFF
--- a/src/flamenco/accdb/fd_accdb_pipe.c
+++ b/src/flamenco/accdb/fd_accdb_pipe.c
@@ -65,6 +65,7 @@ fd_accdb_ro_pipe_enqueue( fd_accdb_ro_pipe_t * pipe,
 
 void
 fd_accdb_ro_pipe_flush( fd_accdb_ro_pipe_t * pipe ) {
+  if( pipe->state!=RO_PIPE_STATE_BATCH ) return;
   fd_accdb_open_ro_multi( pipe->accdb, pipe->ro, &pipe->xid, pipe->addr, pipe->req_cnt );
   pipe->state    = RO_PIPE_STATE_DRAIN;
   pipe->req_comp = 0U;

--- a/src/flamenco/stakes/fd_stake_delegations.c
+++ b/src/flamenco/stakes/fd_stake_delegations.c
@@ -349,7 +349,7 @@ fd_stake_delegations_refresh( fd_stake_delegations_t *  stake_delegations,
 
   fd_accdb_ro_pipe_t ro_pipe[1];
   fd_accdb_ro_pipe_init( ro_pipe, accdb, xid );
-  ulong const job_cnt = stake_delegations->max_stake_accounts_;
+  ulong const job_cnt = fd_stake_delegations_cnt( stake_delegations );
   for( ulong i=0UL; i<job_cnt; i++ ) {
 
     /* stream out read requests */


### PR DESCRIPTION
Fixes a bug that results in millions of unnecessary accdb queries.
