### PR TITLE
accdb: fix bug in ro_pipe_fini

### DIFF
--- a/src/flamenco/accdb/fd_accdb_pipe.c
+++ b/src/flamenco/accdb/fd_accdb_pipe.c
@@ -36,8 +36,12 @@ fd_accdb_ro_pipe_init( fd_accdb_ro_pipe_t *      pipe,
 
 void
 fd_accdb_ro_pipe_fini( fd_accdb_ro_pipe_t * pipe ) {
-  fd_accdb_ro_pipe_flush( pipe );
-  while( fd_accdb_ro_pipe_poll( pipe ) ) {}
+  if( pipe->state==RO_PIPE_STATE_DRAIN ) {
+    fd_accdb_close_ro_multi( pipe->accdb, pipe->ro, pipe->req_cnt );
+  }
+  pipe->state    = RO_PIPE_STATE_BATCH;
+  pipe->req_cnt  = 0U;
+  pipe->req_comp = 0U;
 }
 
 void

--- a/src/flamenco/accdb/fd_accdb_pipe.h
+++ b/src/flamenco/accdb/fd_accdb_pipe.h
@@ -97,8 +97,7 @@ fd_accdb_ro_pipe_flush( fd_accdb_ro_pipe_t * pipe );
    ro_pipe_{enqueue,flush,poll} is made on this pipe object, or when the
    pipe object is destroyed.
 
-   Results are delivered in arbitrary order (not necessarily same as
-   enqueued).
+   Results are delivered in enqueued order.
 
    NOTE: If an account was not found, returns a non-NULL ro (to a dummy
    account with zero lamports), which differs from fd_accdb_open_ro. */


### PR DESCRIPTION
Fixes a bug where ro_pipe_fini fires off an unnecessary read
request if ro_pipe was in the middle of receiving completions.
