### PR TITLE
accdb: remove funk_rec pub flag

### DIFF
--- a/src/discof/restore/fd_snapin_tile_funk.c
+++ b/src/discof/restore/fd_snapin_tile_funk.c
@@ -199,7 +199,6 @@ fd_snapin_process_account_batch_funk( fd_snapin_tile_t *            ctx,
       fd_funk_rec_key_copy( r->pair.key, &key );
       r->prev_idx = UINT_MAX;
       r->next_idx = UINT_MAX;
-      r->pub      = 1;
 
       /* Insert to hash map.  In theory, a key could appear twice in the
          same batch.  All accounts in a batch are guaranteed to be from

--- a/src/flamenco/accdb/fd_accdb_impl_v1.h
+++ b/src/flamenco/accdb/fd_accdb_impl_v1.h
@@ -89,13 +89,13 @@ fd_accdb_user_v1_rw_data_sz_set( fd_accdb_user_t * accdb,
 /* Private methods */
 
 fd_accdb_rw_t *
-fd_accdb_v1_prep_create( fd_accdb_rw_t *           rw,
-                         fd_accdb_user_v1_t *      accdb,
-                         fd_funk_txn_xid_t const * xid,
-                         void const *              address,
-                         void *                    val,
-                         ulong                     val_sz,
-                         ulong                     val_max );
+fd_accdb_v1_prep_create( fd_accdb_rw_t *       rw,
+                         fd_accdb_user_v1_t *  accdb,
+                         fd_funk_txn_t const * txn,
+                         void const *          address,
+                         void *                val,
+                         ulong                 val_sz,
+                         ulong                 val_max );
 
 void
 fd_accdb_v1_copy_account( fd_account_meta_t *       out_meta,

--- a/src/flamenco/accdb/fd_accdb_impl_v2.c
+++ b/src/flamenco/accdb/fd_accdb_impl_v2.c
@@ -282,7 +282,9 @@ not_found:
       fd_memset( tail, 0, tail_sz );
     }
 
-    fd_accdb_v1_prep_create( rw, v1, xid, addr_i, val, val_sz, val_max );
+    ulong txn_idx = v1->tip_txn_idx;
+    fd_funk_txn_t * txn = &v1->funk->txn_pool->ele[ txn_idx ];
+    fd_accdb_v1_prep_create( rw, v1, txn, addr_i, val, val_sz, val_max );
 
     req_cnt++;
   }

--- a/src/flamenco/accdb/fd_accdb_ref.h
+++ b/src/flamenco/accdb/fd_accdb_ref.h
@@ -22,6 +22,7 @@
 struct fd_accdb_ref {
   ulong meta_laddr;
   ulong user_data;
+  ulong user_data2;
   uchar address[32];
   uint  accdb_type;  /* FD_ACCDB_TYPE_* */
   uchar ref_type;    /* FD_ACCDB_REF_* */
@@ -49,7 +50,8 @@ fd_accdb_ro_init_nodb( fd_accdb_ro_t *           ro,
                        void const *              address,
                        fd_account_meta_t const * meta ) {
   ro->meta = meta;
-  ro->ref->user_data = 0UL;
+  ro->ref->user_data  = 0UL;
+  ro->ref->user_data2 = 0UL;
   memcpy( ro->ref->address, address, 32UL );
   ro->ref->accdb_type = FD_ACCDB_TYPE_NONE;
   ro->ref->ref_type   = FD_ACCDB_REF_RO;
@@ -65,7 +67,8 @@ static inline fd_accdb_ro_t *
 fd_accdb_ro_init_empty( fd_accdb_ro_t * ro,
                         void const *    address ) {
   ro->meta = &fd_accdb_meta_empty;
-  ro->ref->user_data = 0UL;
+  ro->ref->user_data  = 0UL;
+  ro->ref->user_data2 = 0UL;
   memcpy( ro->ref->address, address, 32UL );
   ro->ref->accdb_type = FD_ACCDB_TYPE_NONE;
   ro->ref->ref_type   = FD_ACCDB_REF_RO;

--- a/src/flamenco/progcache/fd_progcache_admin.c
+++ b/src/flamenco/progcache/fd_progcache_admin.c
@@ -556,7 +556,6 @@ fd_progcache_inject_rec( fd_progcache_admin_t *    cache,
   fd_funk_val_init( funk_rec );
 
   funk_rec->tag = 0;
-  funk_rec->pub = 1;
   funk_rec->prev_idx = FD_FUNK_REC_IDX_NULL;
   funk_rec->next_idx = FD_FUNK_REC_IDX_NULL;
   memcpy( funk_rec->pair.key, prog_addr, 32UL );

--- a/src/flamenco/progcache/fd_progcache_user.c
+++ b/src/flamenco/progcache/fd_progcache_user.c
@@ -600,7 +600,6 @@ fd_progcache_insert( fd_progcache_t *           cache,
                  fd_funk_rec_pool_ele_max( funk->rec_pool ) ));
   }
   memset( funk_rec, 0, sizeof(fd_funk_rec_t) );
-  funk_rec->pub = 1;
   fd_funk_val_init( funk_rec );
 
   /* Pick and lock a txn in which cache entry is created at */
@@ -762,7 +761,6 @@ fd_progcache_invalidate( fd_progcache_t *          cache,
   }
   memset( funk_rec, 0, sizeof(fd_funk_rec_t) );
   fd_funk_val_init( funk_rec );
-  funk_rec->pub = 1;
 
   /* Create a tombstone */
 

--- a/src/funk/fd_funk_rec.c
+++ b/src/funk/fd_funk_rec.c
@@ -138,7 +138,6 @@ fd_funk_rec_prepare( fd_funk_t *               funk,
   }
   fd_funk_rec_key_copy( rec->pair.key, key );
   rec->tag      = 0;
-  rec->pub      = 0;
   rec->prev_idx = FD_FUNK_REC_IDX_NULL;
   rec->next_idx = FD_FUNK_REC_IDX_NULL;
   fd_funk_rec_txn_release( txn_query );
@@ -221,7 +220,6 @@ fd_funk_rec_publish( fd_funk_t *             funk,
   fd_funk_rec_t * rec = prepare->rec;
   rec->prev_idx = FD_FUNK_REC_IDX_NULL;
   rec->next_idx = FD_FUNK_REC_IDX_NULL;
-  rec->pub      = 1;
 
   if( prepare->rec_head_idx ) {
     fd_funk_rec_push_tail( funk, prepare );

--- a/src/funk/fd_funk_rec.h
+++ b/src/funk/fd_funk_rec.h
@@ -42,7 +42,6 @@ struct __attribute__((aligned(FD_FUNK_REC_ALIGN))) fd_funk_rec {
   ulong val_sz  : 28;  /* Num bytes in record value, in [0,val_max] */
   ulong val_max : 28;  /* Max byte  in record value, in [0,FD_FUNK_REC_VAL_MAX], 0 if val_gaddr is 0 */
   ulong tag     :  1;  /* Used for internal validation */
-  ulong pub     :  1;  /* pub==0 if record is in use, but still pending insertion into record map */
   ulong val_gaddr; /* Wksp gaddr on record value if any, 0 if val_max is 0
                       If non-zero, the region [val_gaddr,val_gaddr+val_max) will be a current fd_alloc allocation (such that it is
                       has tag wksp_tag) and the owner of the region will be the record. The allocator is


### PR DESCRIPTION
Removes a redundant bit from the funk record descriptor.
The 'pub' flag used to indicate whether a record is still
"in preparation", i.e. pending insertion into the record index.

This flag was moved into fd_accdb_rw.
