### PR TITLE
restore: snapwm and vinyl firedancer main.c

### DIFF
--- a/src/app/firedancer/main.c
+++ b/src/app/firedancer/main.c
@@ -23,6 +23,13 @@ extern fd_topo_obj_callbacks_t fd_obj_cb_banks_locks;
 extern fd_topo_obj_callbacks_t fd_obj_cb_funk;
 extern fd_topo_obj_callbacks_t fd_obj_cb_acc_pool;
 
+extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_meta;
+extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_meta_ele;
+extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_data;
+extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_req_pool;
+extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_rq;
+extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_cq;
+
 fd_topo_obj_callbacks_t * CALLBACKS[] = {
   &fd_obj_cb_mcache,
   &fd_obj_cb_dcache,
@@ -40,6 +47,13 @@ fd_topo_obj_callbacks_t * CALLBACKS[] = {
   &fd_obj_cb_banks_locks,
   &fd_obj_cb_funk,
   &fd_obj_cb_acc_pool,
+  &fd_obj_cb_vinyl_meta,
+  &fd_obj_cb_vinyl_meta_ele,
+  &fd_obj_cb_vinyl_data,
+  &fd_obj_cb_acc_pool,
+  &fd_obj_cb_vinyl_req_pool,
+  &fd_obj_cb_vinyl_rq,
+  &fd_obj_cb_vinyl_cq,
   NULL,
 };
 
@@ -88,12 +102,14 @@ extern fd_topo_run_tile_t fd_tile_replay;
 extern fd_topo_run_tile_t fd_tile_execor;
 extern fd_topo_run_tile_t fd_tile_send;
 extern fd_topo_run_tile_t fd_tile_tower;
+extern fd_topo_run_tile_t fd_tile_vinyl;
 extern fd_topo_run_tile_t fd_tile_solcap;
 
 extern fd_topo_run_tile_t fd_tile_snapct;
 extern fd_topo_run_tile_t fd_tile_snapld;
 extern fd_topo_run_tile_t fd_tile_snapdc;
 extern fd_topo_run_tile_t fd_tile_snapin;
+extern fd_topo_run_tile_t fd_tile_snapwm;
 extern fd_topo_run_tile_t fd_tile_snapwh;
 extern fd_topo_run_tile_t fd_tile_snapwr;
 extern fd_topo_run_tile_t fd_tile_snapla;
@@ -131,6 +147,7 @@ fd_topo_run_tile_t * TILES[] = {
   &fd_tile_snapld,
   &fd_tile_snapdc,
   &fd_tile_snapin,
+  &fd_tile_snapwm,
   &fd_tile_snapwh,
   &fd_tile_snapwr,
   &fd_tile_snapla,
@@ -141,6 +158,7 @@ fd_topo_run_tile_t * TILES[] = {
   &fd_tile_genesi,
 # endif
   &fd_tile_ipecho,
+  &fd_tile_vinyl,
   &fd_tile_solcap,
   NULL,
 };

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -735,8 +735,8 @@ fd_topo_initialize( config_t * config ) {
       fd_topo_obj_t * vinyl_map_obj  = &topo->objs[ vinyl_map_obj_id ];
       fd_topo_obj_t * vinyl_pool_obj = &topo->objs[ vinyl_pool_obj_id ];
 
-      fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snapin", 0UL ) ], vinyl_map_obj,  FD_SHMEM_JOIN_MODE_READ_WRITE );
-      fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snapin", 0UL ) ], vinyl_pool_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+      fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snapwm", 0UL ) ], vinyl_map_obj,  FD_SHMEM_JOIN_MODE_READ_WRITE );
+      fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snapwm", 0UL ) ], vinyl_pool_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
     }
   }
 


### PR DESCRIPTION
`snapwm`, `vinyl` and `vinyl callbacks` missing in firedancer `main.c`