### PR TITLE
firedancer: pass features through from replay to shred tile

### DIFF
--- a/src/app/firedancer-dev/commands/backtest.c
+++ b/src/app/firedancer-dev/commands/backtest.c
@@ -369,17 +369,17 @@ backtest_topo( config_t * config ) {
   /**********************************************************************/
   /* Setup replay->stake/send/poh links in topo w/o consumers         */
   /**********************************************************************/
-  fd_topob_wksp( topo, "replay_stake"    );
+  fd_topob_wksp( topo, "replay_epoch"    );
   fd_topob_wksp( topo, "replay_poh"   );
 
-  fd_topob_link( topo, "replay_stake",   "replay_stake",   128UL, 40UL + 40200UL * 40UL, 1UL );
+  fd_topob_link( topo, "replay_epoch", "replay_epoch", 128UL, FD_EPOCH_OUT_MTU, 1UL );
   ulong bank_tile_cnt   = config->layout.bank_tile_count;
   FOR(bank_tile_cnt) fd_topob_link( topo, "replay_poh", "replay_poh", 128UL, (4096UL*sizeof(fd_txn_p_t))+sizeof(fd_microblock_trailer_t), 1UL );
 
-  fd_topob_tile_out( topo, "replay", 0UL, "replay_stake",   0UL );
+  fd_topob_tile_out( topo, "replay", 0UL, "replay_epoch",   0UL );
   FOR(bank_tile_cnt) fd_topob_tile_out( topo, "replay", 0UL, "replay_poh", i );
 
-  topo->links[ replay_tile->out_link_id[ fd_topo_find_tile_out_link( topo, replay_tile, "replay_stake",   0 ) ] ].permit_no_consumers = 1;
+  topo->links[ replay_tile->out_link_id[ fd_topo_find_tile_out_link( topo, replay_tile, "replay_epoch",   0 ) ] ].permit_no_consumers = 1;
   FOR(bank_tile_cnt) topo->links[ replay_tile->out_link_id[ fd_topo_find_tile_out_link( topo, replay_tile, "replay_poh", i ) ] ].permit_no_consumers = 1;
 
   /**********************************************************************/

--- a/src/app/firedancer-dev/commands/repair.c
+++ b/src/app/firedancer-dev/commands/repair.c
@@ -115,7 +115,7 @@ repair_topo( config_t * config ) {
   fd_topob_wksp( topo, "net_quic"     );
 
   fd_topob_wksp( topo, "shred_out"    );
-  fd_topob_wksp( topo, "replay_stake" );
+  fd_topob_wksp( topo, "replay_epoch" );
 
   fd_topob_wksp( topo, "poh_shred"    );
 
@@ -143,7 +143,7 @@ repair_topo( config_t * config ) {
   FOR(quic_tile_cnt)   fd_topob_link( topo, "quic_net",     "net_quic",     config->net.ingress_buffer_size,          FD_NET_MTU,                    1UL );
   FOR(shred_tile_cnt)  fd_topob_link( topo, "shred_net",    "net_shred",    config->net.ingress_buffer_size,          FD_NET_MTU,                    1UL );
 
-  /**/                 fd_topob_link( topo, "replay_stake", "replay_stake", 128UL,                                    40UL + 40200UL * 40UL,         1UL );
+  /**/                 fd_topob_link( topo, "replay_epoch", "replay_epoch", 128UL,                                    FD_EPOCH_OUT_MTU,              1UL );
 
   FOR(shred_tile_cnt)  fd_topob_link( topo, "shred_sign",   "shred_sign",   128UL,                                    32UL,                          1UL );
   FOR(shred_tile_cnt)  fd_topob_link( topo, "sign_shred",   "sign_shred",   128UL,                                    64UL,                          1UL );
@@ -229,7 +229,7 @@ repair_topo( config_t * config ) {
   FOR(shred_tile_cnt) for( ulong j=0UL; j<net_tile_cnt; j++ )
                        fd_topob_tile_in(  topo, "shred",  i,             "metric_in", "net_shred",     j,            FD_TOPOB_UNRELIABLE,   FD_TOPOB_POLLED ); /* No reliable consumers of networking fragments, may be dropped or overrun */
   FOR(shred_tile_cnt)  fd_topob_tile_in(  topo, "shred",  i,             "metric_in", "poh_shred",     0UL,          FD_TOPOB_RELIABLE,     FD_TOPOB_POLLED );
-  FOR(shred_tile_cnt)  fd_topob_tile_in(  topo, "shred",  i,             "metric_in", "replay_stake",  0UL,          FD_TOPOB_RELIABLE,     FD_TOPOB_POLLED );
+  FOR(shred_tile_cnt)  fd_topob_tile_in(  topo, "shred",  i,             "metric_in", "replay_epoch",  0UL,          FD_TOPOB_RELIABLE,     FD_TOPOB_POLLED );
   FOR(shred_tile_cnt)  fd_topob_tile_in(  topo, "shred",  i,             "metric_in", "gossip_out",    0UL,          FD_TOPOB_RELIABLE,     FD_TOPOB_POLLED );
   FOR(shred_tile_cnt)  fd_topob_tile_out( topo, "shred",  i,                          "shred_out",     i                                                    );
   FOR(shred_tile_cnt)  fd_topob_tile_out( topo, "shred",  i,                          "shred_net",     i                                                    );
@@ -248,13 +248,13 @@ repair_topo( config_t * config ) {
     /**/               fd_topob_tile_in(  topo, "shred",  i,             "metric_in", "sign_shred",    i,            FD_TOPOB_UNRELIABLE, FD_TOPOB_UNPOLLED );
     /**/               fd_topob_tile_out( topo, "sign",   0UL,                        "sign_shred",    i                                                    );
   }
-  FOR(gossvf_tile_cnt) fd_topob_tile_in ( topo, "gossvf",   i,            "metric_in", "replay_stake", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED   );
+  FOR(gossvf_tile_cnt) fd_topob_tile_in ( topo, "gossvf",   i,            "metric_in", "replay_epoch", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED   );
 
-  /**/                 fd_topob_tile_in ( topo, "gossip",   0UL,          "metric_in", "replay_stake", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED   );
+  /**/                 fd_topob_tile_in ( topo, "gossip",   0UL,          "metric_in", "replay_epoch", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED   );
 
   FOR(net_tile_cnt)    fd_topob_tile_in(  topo, "repair",  0UL,          "metric_in", "net_repair",    i,            FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED   ); /* No reliable consumers of networking fragments, may be dropped or overrun */
   /**/                 fd_topob_tile_in(  topo, "repair",  0UL,          "metric_in", "gossip_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED   );
-  /**/                 fd_topob_tile_in(  topo, "repair",  0UL,          "metric_in", "replay_stake",  0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED   );
+  /**/                 fd_topob_tile_in(  topo, "repair",  0UL,          "metric_in", "replay_epoch",  0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED   );
                        fd_topob_tile_in(  topo, "repair",  0UL,          "metric_in", "snapin_manif",  0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED   );
   FOR(shred_tile_cnt)  fd_topob_tile_in(  topo, "repair",  0UL,          "metric_in", "shred_out",     i,            FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED   );
   FOR(shred_tile_cnt)  fd_topob_tile_out( topo, "repair", 0UL,                        "repair_shred",  i                                                    );
@@ -281,7 +281,7 @@ repair_topo( config_t * config ) {
     fd_topob_tile_in( topo, "scap", 0UL, "metric_in", "gossip_out", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
 
     fd_topob_tile_uses( topo, scap_tile, root_slot_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
-    fd_topob_tile_out( topo, "scap", 0UL, "replay_stake", 0UL );
+    fd_topob_tile_out( topo, "scap", 0UL, "replay_epoch", 0UL );
     fd_topob_tile_out( topo, "scap", 0UL, "snapin_manif", 0UL );
   }
 

--- a/src/app/firedancer-dev/commands/send_test/send_test.c
+++ b/src/app/firedancer-dev/commands/send_test/send_test.c
@@ -99,18 +99,18 @@ send_test_topo( config_t * config ) {
   /* mock links */
   /* braces shut up clang's 'misleading identation' warning */
   if( !use_live_gossip ) {fd_topob_wksp( topo, "gossip_out" ); }
-  /**/                    fd_topob_wksp( topo, "replay_stake"  );
+  /**/                    fd_topob_wksp( topo, "replay_epoch"  );
   /**/                    fd_topob_wksp( topo, "tower_out" );
   /**/                    fd_topob_wksp( topo, "send_out"  );
 
   if( !use_live_gossip ) {fd_topob_link( topo, "gossip_out",   "gossip_out",   65536UL*4UL, sizeof(fd_gossip_update_message_t), 1UL ); }
-  /**/                    fd_topob_link( topo, "replay_stake", "replay_stake", 128UL,       FD_STAKE_OUT_MTU,                   1UL );
+  /**/                    fd_topob_link( topo, "replay_epoch", "replay_epoch", 128UL,       FD_STAKE_OUT_MTU,                   1UL );
   /**/                    fd_topob_link( topo, "tower_out",    "tower_out",    1024UL,      sizeof(fd_tower_slot_done_t),       1UL );
   /**/                    fd_topob_link( topo, "send_out",     "send_out",     128UL,       40200UL * 38UL,                     1UL );
 
   if( !use_live_gossip ) {fd_link_permit_no_producers( topo, "gossip_out" ); }
   if( !use_live_gossip ) {fd_link_permit_no_consumers( topo, "send_out"   ); }
-  /**/                    fd_link_permit_no_producers( topo, "replay_stake"  );
+  /**/                    fd_link_permit_no_producers( topo, "replay_epoch"  );
   /**/                    fd_link_permit_no_producers( topo, "tower_out" );
 
   if( use_live_gossip ) {
@@ -124,7 +124,7 @@ send_test_topo( config_t * config ) {
   fd_topob_tile_in (    topo, "send", 0UL, "metric_in", "net_send",     0UL, FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
 
   fd_topob_tile_in(     topo, "send", 0UL, "metric_in", "gossip_out",   0UL, FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-  fd_topob_tile_in(     topo, "send", 0UL, "metric_in", "replay_stake", 0UL, FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+  fd_topob_tile_in(     topo, "send", 0UL, "metric_in", "replay_epoch", 0UL, FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   fd_topob_tile_in(     topo, "send", 0UL, "metric_in", "tower_out",    0UL, FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
 
   /* attach out links */
@@ -202,7 +202,7 @@ init( send_test_ctx_t * ctx, config_t * config ) {
   ctx->vote_acct_addr[ 0 ] = *(fd_pubkey_t const *)(fd_keyload_load( config->paths.vote_account, /* pubkey only: */ 1 ) );
 
   ctx->out_links[    MOCK_CI_IDX   ] = setup_test_out_link( topo, "gossip_out" );
-  ctx->out_links[  MOCK_STAKE_IDX  ] = setup_test_out_link( topo, "replay_stake" );
+  ctx->out_links[  MOCK_STAKE_IDX  ] = setup_test_out_link( topo, "replay_epoch" );
   ctx->out_links[ MOCK_TRIGGER_IDX ] = setup_test_out_link( topo, "tower_out" );
 
   ctx->out_fns  [    MOCK_CI_IDX   ] = send_test_ci;

--- a/src/app/firedancer-dev/commands/sim.c
+++ b/src/app/firedancer-dev/commands/sim.c
@@ -72,13 +72,13 @@ sim_topo( config_t * config ) {
   fd_topob_wksp( topo, "shred_storei" );
   fd_topob_wksp( topo, "repair_store" );
   fd_topob_wksp( topo, "storei_notif" );
-  fd_topob_wksp( topo, "replay_stake" );
+  fd_topob_wksp( topo, "replay_epoch" );
   fd_topob_wksp( topo, "store_replay" );
   /*             topo,  link_name,      wksp_name,     depth,         mtu,                    burst */
   fd_topob_link( topo, "shred_storei", "shred_storei", 65536UL,       4UL*FD_SHRED_STORE_MTU, 4UL+config->tiles.shred.max_pending_shred_sets );
   fd_topob_link( topo, "repair_store", "repair_store", 1024UL*1024UL, FD_SHRED_MAX_SZ,        128UL                                          );
   fd_topob_link( topo, "storei_notif", "storei_notif", 65536UL,       4UL*FD_SHRED_STORE_MTU, 4UL+config->tiles.shred.max_pending_shred_sets );
-  fd_topob_link( topo, "replay_stake", "replay_stake", 128UL,         40UL + 40200UL * 40UL,  1UL                                            );
+  fd_topob_link( topo, "replay_epoch", "replay_epoch", 128UL,         40UL + 40200UL * 40UL,  1UL                                            );
   fd_topob_link( topo, "store_replay", "store_replay", 32768UL,       sizeof(ulong),          64UL                                           );
 
   /*                 topo, tile_name, tile_kind_id, link_name,      link_kind_id */
@@ -87,7 +87,7 @@ sim_topo( config_t * config ) {
   fd_topob_tile_in(  topo, "arch_p",  0UL,          "metric_in", "storei_notif",       0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
 
   /*                 topo, tile_name, tile_kind_id, fseq_wksp,   link_name,            link_kind_id, reliable,            polled */
-  fd_topob_tile_in(  topo, "storei",  0UL,          "metric_in", "replay_stake",       0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
+  fd_topob_tile_in(  topo, "storei",  0UL,          "metric_in", "replay_epoch",       0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
   fd_topob_tile_in(  topo, "storei",  0UL,          "metric_in", "repair_store",       0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   fd_topob_tile_in(  topo, "storei",  0UL,          "metric_in", "shred_storei",       0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
 
@@ -99,7 +99,7 @@ sim_topo( config_t * config ) {
   fd_topob_tile_in(  topo, "replay",  0UL,          "metric_in", "store_replay",       0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED   );
 
   /*                 topo, tile_name, tile_kind_id, link_name,          link_kind_id */
-  fd_topob_tile_out( topo, "replay",  0UL,          "replay_stake",     0UL );
+  fd_topob_tile_out( topo, "replay",  0UL,          "replay_epoch",     0UL );
 
   /**********************************************************************/
   /* Setup replay-->exec links in topo                                  */

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -412,7 +412,7 @@ fd_topo_initialize( config_t * config ) {
 
   fd_topob_wksp( topo, "shred_out"    );
   fd_topob_wksp( topo, "repair_shred" );
-  fd_topob_wksp( topo, "replay_stake" );
+  fd_topob_wksp( topo, "replay_epoch" );
   fd_topob_wksp( topo, "replay_exec"  );
   fd_topob_wksp( topo, "replay_out"   );
   fd_topob_wksp( topo, "tower_out"    );
@@ -581,7 +581,7 @@ fd_topo_initialize( config_t * config ) {
   FOR(verify_tile_cnt) fd_topob_link( topo, "verify_dedup", "verify_dedup", config->tiles.verify.receive_buffer_size, FD_TPU_PARSED_MTU,             1UL );
   /**/                 fd_topob_link( topo, "dedup_resolv", "dedup_resolv", 65536UL,                                  FD_TPU_PARSED_MTU,             1UL );
   FOR(resolv_tile_cnt) fd_topob_link( topo, "resolv_pack",  "resolv_pack",  65536UL,                                  FD_TPU_RESOLVED_MTU,           1UL );
-  /**/                 fd_topob_link( topo, "replay_stake", "replay_stake", 128UL,                                    FD_STAKE_OUT_MTU,              1UL ); /* TODO: This should be 2 but requires fixing STEM_BURST */
+  /**/                 fd_topob_link( topo, "replay_epoch", "replay_epoch", 128UL,                                    FD_EPOCH_OUT_MTU,              1UL ); /* TODO: This should be 2 but requires fixing STEM_BURST */
   /**/                 fd_topob_link( topo, "replay_out",   "replay_out",   8192UL,                                   sizeof(fd_replay_message_t),   1UL );
   /**/                 fd_topob_link( topo, "pack_poh",     "pack_poh",     4096UL,                                   sizeof(fd_done_packing_t),     1UL );
   /* pack_bank is shared across all banks, so if one bank stalls due to complex transactions, the buffer needs to be large so that
@@ -786,8 +786,8 @@ fd_topo_initialize( config_t * config ) {
   FOR(gossvf_tile_cnt) fd_topob_tile_in (   topo, "gossvf", i,             "metric_in", "gossip_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   FOR(gossvf_tile_cnt) fd_topob_tile_in (   topo, "gossvf", i,             "metric_in", "gossip_gossv", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   FOR(gossvf_tile_cnt) fd_topob_tile_in (   topo, "gossvf", i,             "metric_in", "ipecho_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-  FOR(gossvf_tile_cnt) fd_topob_tile_in (   topo, "gossvf", i,             "metric_in", "replay_stake", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-  /**/                 fd_topob_tile_in (   topo, "gossip", 0UL,           "metric_in", "replay_stake", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+  FOR(gossvf_tile_cnt) fd_topob_tile_in (   topo, "gossvf", i,             "metric_in", "replay_epoch", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+  /**/                 fd_topob_tile_in (   topo, "gossip", 0UL,           "metric_in", "replay_epoch", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_out(   topo, "gossip", 0UL,                        "gossip_out",   0UL                                                );
   /**/                 fd_topob_tile_out(   topo, "gossip", 0UL,                        "gossip_net",   0UL                                                );
   /**/                 fd_topob_tile_in (   topo, "gossip", 0UL,           "metric_in", "ipecho_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
@@ -872,7 +872,7 @@ fd_topo_initialize( config_t * config ) {
   /**/                 fd_topob_tile_in(    topo, "repair",  0UL,          "metric_in", "genesi_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_in(    topo, "repair",  0UL,          "metric_in", "gossip_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_in(    topo, "repair",  0UL,          "metric_in", "tower_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-  /**/                 fd_topob_tile_in(    topo, "repair",  0UL,          "metric_in", "replay_stake", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+  /**/                 fd_topob_tile_in(    topo, "repair",  0UL,          "metric_in", "replay_epoch", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   if( snapshots_enabled ) {
                        fd_topob_tile_in(    topo, "repair",  0UL,          "metric_in", "snapin_manif", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   }
@@ -881,7 +881,7 @@ fd_topo_initialize( config_t * config ) {
   FOR(shred_tile_cnt)  fd_topob_tile_out(   topo, "repair",  0UL,                       "repair_shred", i                                                  );
   /**/                 fd_topob_tile_in (   topo, "replay",  0UL,          "metric_in", "genesi_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_out(   topo, "replay",  0UL,                       "replay_out",   0UL                                                );
-  /**/                 fd_topob_tile_out(   topo, "replay",  0UL,                       "replay_stake", 0UL                                                );
+  /**/                 fd_topob_tile_out(   topo, "replay",  0UL,                       "replay_epoch", 0UL                                                );
   /**/                 fd_topob_tile_out(   topo, "replay",  0UL,                       "executed_txn", 0UL                                                );
   /**/                 fd_topob_tile_out(   topo, "replay",  0UL,                       "replay_exec",  0UL                                                );
   /**/                 fd_topob_tile_in (   topo, "replay",  0UL,          "metric_in", "tower_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
@@ -899,7 +899,7 @@ fd_topo_initialize( config_t * config ) {
   /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "replay_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_out(   topo, "tower",   0UL,                       "tower_out",    0UL                                                );
 
-  /**/                 fd_topob_tile_in (   topo, "send",    0UL,          "metric_in", "replay_stake", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+  /**/                 fd_topob_tile_in (   topo, "send",    0UL,          "metric_in", "replay_epoch", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_in (   topo, "send",    0UL,          "metric_in", "gossip_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_in (   topo, "send",    0UL,          "metric_in", "tower_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_out(   topo, "send",    0UL,                       "send_net",     0UL                                                );
@@ -938,7 +938,7 @@ fd_topo_initialize( config_t * config ) {
   /**/                 fd_topob_tile_in(    topo, "poh",     0UL,          "metric_in", "replay_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_out(   topo, "poh",     0UL,                       "poh_shred",    0UL                                                );
   /**/                 fd_topob_tile_out(   topo, "poh",     0UL,                       "poh_replay",   0UL                                                );
-  FOR(shred_tile_cnt)  fd_topob_tile_in (   topo, "shred",   i,            "metric_in", "replay_stake", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+  FOR(shred_tile_cnt)  fd_topob_tile_in (   topo, "shred",   i,            "metric_in", "replay_epoch", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   FOR(shred_tile_cnt)  fd_topob_tile_in (   topo, "shred",   i,            "metric_in", "gossip_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   FOR(shred_tile_cnt)  fd_topob_tile_out(   topo, "shred",   i,                         "shred_out",    i                                                  );
   FOR(shred_tile_cnt)  fd_topob_tile_in (   topo, "shred",   i,            "metric_in", "repair_shred", i,            FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
@@ -1172,7 +1172,7 @@ fd_topo_initialize( config_t * config ) {
     /**/                 fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "gossip_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     /**/                 fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "tower_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     /**/                 fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "replay_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-    /**/                 fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "replay_stake", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+    /**/                 fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "replay_epoch", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     /**/                 fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "genesi_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     /**/                 fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "pack_poh",     0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     /**/                 fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "pack_bank",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );

--- a/src/disco/gui/fd_gui.h
+++ b/src/disco/gui/fd_gui.h
@@ -897,6 +897,11 @@ fd_gui_handle_leader_schedule( fd_gui_t *                    gui,
                                long                          now );
 
 void
+fd_gui_handle_epoch_info( fd_gui_t *                  gui,
+                          fd_epoch_info_msg_t const * epoch_info,
+                          long                        now );
+
+void
 fd_gui_handle_notarization_update( fd_gui_t *                        gui,
                                    fd_tower_slot_confirmed_t const * notar );
 

--- a/src/disco/gui/fd_gui_tile.c
+++ b/src/disco/gui/fd_gui_tile.c
@@ -52,7 +52,7 @@ static fd_http_static_file_t * STATIC_FILES;
 #define IN_KIND_REPAIR_NET   (10UL) /* firedancer only */
 #define IN_KIND_TOWER_OUT    (11UL) /* firedancer only */
 #define IN_KIND_REPLAY_OUT   (12UL) /* firedancer only */
-#define IN_KIND_REPLAY_STAKE (13UL) /* firedancer only */
+#define IN_KIND_EPOCH        (13UL) /* firedancer only */
 #define IN_KIND_GENESI_OUT   (14UL) /* firedancer only */
 #define IN_KIND_SNAPIN       (15UL) /* firedancer only */
 #define IN_KIND_EXEC_REPLAY  (16UL) /* firedancer only */
@@ -268,10 +268,9 @@ during_frag( fd_gui_ctx_t * ctx,
     }
   }
 
-  if( FD_LIKELY( ctx->in_kind[ in_idx ]==IN_KIND_REPLAY_STAKE ) ) {
-    fd_stake_weight_msg_t * leader_schedule = (fd_stake_weight_msg_t *)src;
-    FD_TEST( sz==(ushort)(sizeof(fd_stake_weight_msg_t)+(leader_schedule->staked_cnt*sizeof(fd_vote_stake_weight_t))) );
-    sz = fd_stake_weight_msg_sz( leader_schedule->staked_cnt );
+  if( FD_LIKELY( ctx->in_kind[ in_idx ]==IN_KIND_EPOCH ) ) {
+    fd_epoch_info_msg_t * epoch_info = (fd_epoch_info_msg_t *)src;
+    sz = fd_epoch_info_msg_sz( epoch_info->staked_cnt );
   }
 
   if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_GENESI_OUT ) ) {
@@ -431,11 +430,11 @@ after_frag( fd_gui_ctx_t *      ctx,
       }
       break;
     }
-    case IN_KIND_REPLAY_STAKE: {
+    case IN_KIND_EPOCH: {
       FD_TEST( ctx->is_full_client );
 
-      fd_stake_weight_msg_t * leader_schedule = (fd_stake_weight_msg_t *)src;
-      fd_gui_handle_leader_schedule( ctx->gui, leader_schedule, fd_clock_now( ctx->clock ) );
+      fd_epoch_info_msg_t * epoch_info = (fd_epoch_info_msg_t *)src;
+      fd_gui_handle_epoch_info( ctx->gui, epoch_info, fd_clock_now( ctx->clock ) );
       break;
     }
     case IN_KIND_SNAPIN: {
@@ -819,7 +818,7 @@ unprivileged_init( fd_topo_t *      topo,
     else if( FD_LIKELY( !strcmp( link->name, "repair_net"   ) ) ) ctx->in_kind[ i ] = IN_KIND_REPAIR_NET;   /* full client only */
     else if( FD_LIKELY( !strcmp( link->name, "tower_out"    ) ) ) ctx->in_kind[ i ] = IN_KIND_TOWER_OUT;    /* full client only */
     else if( FD_LIKELY( !strcmp( link->name, "replay_out"   ) ) ) ctx->in_kind[ i ] = IN_KIND_REPLAY_OUT;   /* full client only */
-    else if( FD_LIKELY( !strcmp( link->name, "replay_stake" ) ) ) ctx->in_kind[ i ] = IN_KIND_REPLAY_STAKE; /* full client only */
+    else if( FD_LIKELY( !strcmp( link->name, "replay_epoch" ) ) ) ctx->in_kind[ i ] = IN_KIND_EPOCH; /* full client only */
     else if( FD_LIKELY( !strcmp( link->name, "genesi_out"   ) ) ) ctx->in_kind[ i ] = IN_KIND_GENESI_OUT; /* full client only */
     else if( FD_LIKELY( !strcmp( link->name, "snapin_gui"   ) ) ) ctx->in_kind[ i ] = IN_KIND_SNAPIN; /* full client only */
     else if( FD_LIKELY( !strcmp( link->name, "exec_replay"  ) ) ) ctx->in_kind[ i ] = IN_KIND_EXEC_REPLAY;  /* full client only */

--- a/src/disco/plugin/fd_plugin_tile.c
+++ b/src/disco/plugin/fd_plugin_tile.c
@@ -160,7 +160,6 @@ unprivileged_init( fd_topo_t *      topo,
     if(      !strcmp( link->name, "replay_plugi" ) ) ctx->in_kind[ i ] = IN_KIND_REPLAY;
     else if( !strcmp( link->name, "gossip_plugi" ) ) ctx->in_kind[ i ] = IN_KIND_GOSSIP;
     else if( !strcmp( link->name, "stake_out"    ) ) ctx->in_kind[ i ] = IN_KIND_STAKE;
-    else if( !strcmp( link->name, "replay_stake" ) ) ctx->in_kind[ i ] = IN_KIND_STAKE;
     else if( !strcmp( link->name, "poh_plugin"   ) ) ctx->in_kind[ i ] = IN_KIND_POH;
     else if( !strcmp( link->name, "votes_plugin" ) ) ctx->in_kind[ i ] = IN_KIND_VOTE;
     else if( !strcmp( link->name, "startp_plugi" ) ) ctx->in_kind[ i ] = IN_KIND_STARTP;

--- a/src/disco/shred/fd_stake_ci.c
+++ b/src/disco/shred/fd_stake_ci.c
@@ -72,6 +72,23 @@ fd_stake_ci_stake_msg_init( fd_stake_ci_t               * info,
   fd_memcpy( info->vote_stake_weight, msg->weights, msg->staked_cnt*sizeof(fd_vote_stake_weight_t) );
 }
 
+void
+fd_stake_ci_epoch_msg_init( fd_stake_ci_t *             info,
+                            fd_epoch_info_msg_t const * msg ) {
+  if( FD_UNLIKELY( msg->staked_cnt > MAX_SHRED_DESTS ) )
+    FD_LOG_ERR(( "The stakes -> Firedancer splice sent a malformed update with %lu stakes in it,"
+                 " but the maximum allowed is %lu", msg->staked_cnt, MAX_SHRED_DESTS ));
+
+  info->scratch->epoch             = msg->epoch;
+  info->scratch->start_slot        = msg->start_slot;
+  info->scratch->slot_cnt          = msg->slot_cnt;
+  info->scratch->staked_cnt        = msg->staked_cnt;
+  info->scratch->excluded_stake    = msg->excluded_stake;
+  info->scratch->vote_keyed_lsched = msg->vote_keyed_lsched;
+
+  fd_memcpy( info->vote_stake_weight, msg->weights, msg->staked_cnt*sizeof(fd_vote_stake_weight_t) );
+}
+
 static inline void
 log_summary( char const * msg, fd_stake_ci_t * info ) {
 #if 0
@@ -217,6 +234,11 @@ fd_stake_ci_stake_msg_fini( fd_stake_ci_t * info ) {
   new_ei->sdest  = fd_shred_dest_join   ( fd_shred_dest_new   ( new_ei->_sdest, info->shred_dest, j,
                                                                 new_ei->lsched, info->identity_key,  excluded_stake ) );
   log_summary( "stake update", info );
+}
+
+void
+fd_stake_ci_epoch_msg_fini( fd_stake_ci_t * info ) {
+  fd_stake_ci_stake_msg_fini( info );
 }
 
 fd_shred_dest_weighted_t * fd_stake_ci_dest_add_init( fd_stake_ci_t * info ) { return info->shred_dest; }

--- a/src/disco/shred/fd_stake_ci.h
+++ b/src/disco/shred/fd_stake_ci.h
@@ -161,6 +161,13 @@ fd_shred_dest_weighted_t * fd_stake_ci_dest_add_init ( fd_stake_ci_t * info     
 void                       fd_stake_ci_dest_add_fini ( fd_stake_ci_t * info, ulong                         cnt );
 
 /* Firedancer only:
+   fd_stake_ci_epoch_msg_{init, fini} are the Firedancer equivalents of
+   fd_stake_ci_stake_msg_{init, fini}. They take a different input message
+   structure (fd_epoch_info_msg_t vs fd_stake_weight_msg_t). */
+void                       fd_stake_ci_epoch_msg_init( fd_stake_ci_t * info, fd_epoch_info_msg_t const * msg );
+void                       fd_stake_ci_epoch_msg_fini( fd_stake_ci_t * info );
+
+/* Firedancer only:
    The full client's Gossip update model publishes individual contact
    info updates (update/insert or remove), which requires a different
    set of dest_ APIs.

--- a/src/discof/gossip/fd_gossip_tile.c
+++ b/src/discof/gossip/fd_gossip_tile.c
@@ -13,7 +13,7 @@
 #define IN_KIND_SHRED_VERSION (1)
 #define IN_KIND_SIGN          (2)
 #define IN_KIND_SEND          (3)
-#define IN_KIND_STAKE         (4)
+#define IN_KIND_EPOCH         (4)
 
 /* Symbols exported by version.c */
 extern ulong const firedancer_major_version;
@@ -196,8 +196,8 @@ handle_local_vote( fd_gossip_tile_ctx_t * ctx,
 }
 
 static void
-handle_stakes( fd_gossip_tile_ctx_t *        ctx,
-               fd_stake_weight_msg_t const * msg ) {
+handle_epoch( fd_gossip_tile_ctx_t *      ctx,
+              fd_epoch_info_msg_t const * msg ) {
   ulong stakes_cnt = compute_id_weights_from_vote_weights( ctx->stake_weights_converted, msg->weights, msg->staked_cnt );
   fd_gossip_stakes_update( ctx->gossip, ctx->stake_weights_converted, stakes_cnt );
 }
@@ -252,7 +252,7 @@ returnable_frag( fd_gossip_tile_ctx_t * ctx,
   switch( ctx->in[ in_idx ].kind ) {
     case IN_KIND_SHRED_VERSION: handle_shred_version( ctx, sig ); break;
     case IN_KIND_SEND:          handle_local_vote( ctx, fd_chunk_to_laddr_const( ctx->in[ in_idx ].mem, chunk ), stem ); break;
-    case IN_KIND_STAKE:         handle_stakes( ctx, fd_chunk_to_laddr_const( ctx->in[ in_idx ].mem, chunk ) ); break;
+    case IN_KIND_EPOCH:         handle_epoch( ctx, fd_chunk_to_laddr_const( ctx->in[ in_idx ].mem, chunk ) ); break;
     case IN_KIND_GOSSVF:        handle_packet( ctx, sig, fd_chunk_to_laddr_const( ctx->in[ in_idx ].mem, chunk ), sz, stem ); break;
   }
 
@@ -337,8 +337,8 @@ unprivileged_init( fd_topo_t *      topo,
       sign_in_tile_idx = i;
     } else if( FD_UNLIKELY( !strcmp( link->name, "send_out" ) ) ) {
       ctx->in[ i ].kind = IN_KIND_SEND;
-    } else if( FD_UNLIKELY( !strcmp( link->name, "replay_stake" ) ) ) {
-      ctx->in[ i ].kind = IN_KIND_STAKE;
+    } else if( FD_UNLIKELY( !strcmp( link->name, "replay_epoch" ) ) ) {
+      ctx->in[ i ].kind = IN_KIND_EPOCH;
     } else {
       FD_LOG_ERR(( "unexpected input link name %s", link->name ));
     }

--- a/src/discof/repair/fd_repair_tile.c
+++ b/src/discof/repair/fd_repair_tile.c
@@ -44,7 +44,7 @@
 #define IN_KIND_SHRED   (3)
 #define IN_KIND_SIGN    (4)
 #define IN_KIND_SNAP    (5)
-#define IN_KIND_STAKE   (6)
+#define IN_KIND_EPOCH   (6)
 #define IN_KIND_GOSSIP  (7)
 #define IN_KIND_GENESIS (8)
 
@@ -498,7 +498,7 @@ during_frag( ctx_t * ctx,
     return;
   }
 
-  if( FD_UNLIKELY( in_kind==IN_KIND_STAKE ) ) {
+  if( FD_UNLIKELY( in_kind==IN_KIND_EPOCH ) ) {
     return;
   }
 
@@ -882,7 +882,7 @@ after_frag( ctx_t * ctx,
     return;
   }
 
-  if( FD_UNLIKELY( in_kind==IN_KIND_STAKE ) ) {
+  if( FD_UNLIKELY( in_kind==IN_KIND_EPOCH ) ) {
     return;
   }
 
@@ -1024,7 +1024,7 @@ unprivileged_init( fd_topo_t *      topo,
     else if( 0==strcmp( link->name, "tower_out"    ) ) ctx->in_kind[ in_idx ] = IN_KIND_TOWER;
     else if( 0==strcmp( link->name, "shred_out"    ) ) ctx->in_kind[ in_idx ] = IN_KIND_SHRED;
     else if( 0==strcmp( link->name, "snapin_manif" ) ) ctx->in_kind[ in_idx ] = IN_KIND_SNAP;
-    else if( 0==strcmp( link->name, "replay_stake" ) ) ctx->in_kind[ in_idx ] = IN_KIND_STAKE;
+    else if( 0==strcmp( link->name, "replay_epoch" ) ) ctx->in_kind[ in_idx ] = IN_KIND_EPOCH;
     else if( 0==strcmp( link->name, "genesi_out"   ) ) ctx->in_kind[ in_idx ] = IN_KIND_GENESIS;
     else FD_LOG_ERR(( "repair tile has unexpected input link %s", link->name ));
 

--- a/src/discof/send/fd_send_tile.c
+++ b/src/discof/send/fd_send_tile.c
@@ -531,11 +531,11 @@ during_frag( fd_send_tile_ctx_t * ctx,
     fd_memcpy( ctx->quic_buf, src, sz );
   }
 
-  if( FD_UNLIKELY( kind==IN_KIND_STAKE ) ) {
-    if( sz>sizeof(fd_stake_weight_t)*(MAX_STAKED_LEADERS+1UL) ) {
-      FD_LOG_ERR(( "sz %lu >= max expected stake update size %lu", sz, sizeof(fd_stake_weight_t) * (MAX_STAKED_LEADERS+1UL) ));
+  if( FD_UNLIKELY( kind==IN_KIND_EPOCH ) ) {
+    if( sz>FD_EPOCH_INFO_MAX_MSG_SZ ) {
+      FD_LOG_ERR(( "sz %lu >= max expected epoch update size %lu", sz, FD_EPOCH_INFO_MAX_MSG_SZ ));
     }
-    fd_multi_epoch_leaders_stake_msg_init( ctx->mleaders, fd_type_pun_const( dcache_entry ) );
+    fd_multi_epoch_leaders_epoch_msg_init( ctx->mleaders, fd_type_pun_const( dcache_entry ) );
   }
 
   if( FD_LIKELY( kind==IN_KIND_GOSSIP ) ) {
@@ -592,7 +592,7 @@ after_frag( fd_send_tile_ctx_t * ctx,
     }
   }
 
-  if( FD_UNLIKELY( kind==IN_KIND_STAKE ) ) {
+  if( FD_UNLIKELY( kind==IN_KIND_EPOCH ) ) {
     finalize_stake_msg( ctx );
   }
 }
@@ -703,8 +703,8 @@ unprivileged_init( fd_topo_t *      topo,
       fd_net_rx_bounds_init( &ctx->net_in_bounds[ i ], link->dcache );
     } else if( 0==strcmp( link->name, "gossip_out" ) ) {
       setup_input_link( ctx, topo, tile, IN_KIND_GOSSIP, i );
-    } else if( 0==strcmp( link->name, "replay_stake" ) ) {
-      setup_input_link( ctx, topo, tile, IN_KIND_STAKE, i );
+    } else if( 0==strcmp( link->name, "replay_epoch" ) ) {
+      setup_input_link( ctx, topo, tile, IN_KIND_EPOCH, i );
     } else if( 0==strcmp( link->name, "tower_out" ) ) {
       setup_input_link( ctx, topo, tile, IN_KIND_TOWER, i );
     }

--- a/src/discof/send/fd_send_tile.h
+++ b/src/discof/send/fd_send_tile.h
@@ -18,7 +18,7 @@
 
 #define IN_KIND_SIGN   (0UL)
 #define IN_KIND_GOSSIP (1UL)
-#define IN_KIND_STAKE  (2UL)
+#define IN_KIND_EPOCH  (2UL)
 #define IN_KIND_TOWER  (3UL)
 #define IN_KIND_NET    (4UL)
 

--- a/src/discof/sender/fd_sender_tile.c
+++ b/src/discof/sender/fd_sender_tile.c
@@ -234,7 +234,7 @@ during_frag( fd_sender_tile_ctx_t * ctx,
       FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz,
             ctx->stake_in_chunk0, ctx->stake_in_wmark ));
     uchar const * dcache_entry = fd_chunk_to_laddr_const( ctx->stake_in_mem, chunk );
-    fd_stake_ci_stake_msg_init( ctx->stake_ci, dcache_entry );
+    fd_stake_ci_epoch_msg_init( ctx->stake_ci, fd_type_pun_const( dcache_entry ) );
   }
 
   if( FD_UNLIKELY( in_idx==ctx->contact_in_idx ) ) {
@@ -363,7 +363,7 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->poh_slot = fd_fseq_join( fd_topo_obj_laddr( topo, poh_slot_obj_id ) );
 
   /* Set up stake input */
-  ctx->stake_in_idx = fd_topo_find_tile_in_link( topo, tile, "replay_stake", 0 );
+  ctx->stake_in_idx = fd_topo_find_tile_in_link( topo, tile, "replay_epoch", 0 );
   FD_TEST( ctx->stake_in_idx!=ULONG_MAX );
   fd_topo_link_t * stake_in_link = &topo->links[ tile->in_link_id[ ctx->stake_in_idx ] ];
   ctx->stake_in_mem    = topo->workspaces[ topo->objs[ stake_in_link->dcache_obj_id ].wksp_id ].wksp;

--- a/src/discoh/poh/fd_poh_tile.c
+++ b/src/discoh/poh/fd_poh_tile.c
@@ -353,7 +353,7 @@
 
 #define IN_KIND_BANK  (0)
 #define IN_KIND_PACK  (1)
-#define IN_KIND_STAKE (2)
+#define IN_KIND_EPOCH (2)
 
 
 typedef struct {
@@ -1833,7 +1833,7 @@ during_frag( fd_poh_ctx_t * ctx,
              ulong          ctl FD_PARAM_UNUSED ) {
   ctx->skip_frag = 0;
 
-  if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_STAKE ) ) {
+  if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_EPOCH ) ) {
     if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark ) )
       FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz,
             ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
@@ -1964,7 +1964,7 @@ after_frag( fd_poh_ctx_t *      ctx,
 
   if( FD_UNLIKELY( ctx->skip_frag ) ) return;
 
-  if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_STAKE ) ) {
+  if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_EPOCH ) ) {
     fd_multi_epoch_leaders_stake_msg_fini( ctx->mleaders );
     /* It might seem like we do not need to do state transitions in and
        out of being the leader here, since leader schedule updates are
@@ -2363,7 +2363,7 @@ unprivileged_init( fd_topo_t *      topo,
     ctx->in[ i ].wmark  = fd_dcache_compact_wmark ( ctx->in[ i ].mem, link->dcache, link->mtu );
 
     if(        !strcmp( link->name, "stake_out" ) ) {
-      ctx->in_kind[ i ] = IN_KIND_STAKE;
+      ctx->in_kind[ i ] = IN_KIND_EPOCH;
     } else if( !strcmp( link->name, "pack_poh" ) ) {
       ctx->in_kind[ i ] = IN_KIND_PACK;
     } else if( !strcmp( link->name, "bank_poh"  ) ) {

--- a/src/flamenco/features/fd_features_generated.c
+++ b/src/flamenco/features/fd_features_generated.c
@@ -1751,6 +1751,12 @@ fd_feature_id_t const ids[] = {
     .name                      = "enable_alt_bn128_g2_syscalls",
     .cleaned_up                = {UINT_MAX, UINT_MAX, UINT_MAX} },
 
+  { .index                     = offsetof(fd_features_t, switch_to_chacha8_turbine)>>3,
+    .id                        = {"\xa7\xaf\x63\xf3\xce\xb1\x12\xfc\xc9\xd8\x71\xc1\x4e\x8f\x17\x9e\xd0\x6f\x9b\x70\xf8\x41\x1a\x92\x9e\x48\x46\xb5\x2a\x0e\x98\x0c"},
+                                 /* CHaChatUnR3s6cPyPMMGNJa3VdQQ8PNH2JqdD4LpCKnB */
+    .name                      = "switch_to_chacha8_turbine",
+    .cleaned_up                = {UINT_MAX, UINT_MAX, UINT_MAX} },
+
   { .index = ULONG_MAX }
 };
 /* TODO replace this with fd_map_perfect */
@@ -2014,6 +2020,7 @@ fd_feature_id_query( ulong prefix ) {
   case 0x640dddd90caae808: return &ids[ 254 ];
   case 0x6a9db4aa29bdb608: return &ids[ 255 ];
   case 0x010f656d89a4e808: return &ids[ 256 ];
+  case 0xfc12b1cef363afa7: return &ids[ 257 ];
   default: break;
   }
   return NULL;
@@ -2276,4 +2283,5 @@ FD_STATIC_ASSERT( offsetof( fd_features_t, vote_state_v4                        
 FD_STATIC_ASSERT( offsetof( fd_features_t, alt_bn128_little_endian                                 )>>3==254UL, layout );
 FD_STATIC_ASSERT( offsetof( fd_features_t, enable_bls12_381_syscall                                )>>3==255UL, layout );
 FD_STATIC_ASSERT( offsetof( fd_features_t, enable_alt_bn128_g2_syscalls                            )>>3==256UL, layout );
+FD_STATIC_ASSERT( offsetof( fd_features_t, switch_to_chacha8_turbine                               )>>3==257UL, layout );
 FD_STATIC_ASSERT( sizeof( fd_features_t )>>3==FD_FEATURE_ID_CNT, layout );

--- a/src/flamenco/features/fd_features_generated.h
+++ b/src/flamenco/features/fd_features_generated.h
@@ -8,10 +8,10 @@
 #endif
 
 /* FEATURE_ID_CNT is the number of features in ids */
-#define FD_FEATURE_ID_CNT (257UL)
+#define FD_FEATURE_ID_CNT (258UL)
 
 /* Feature set ID calculated from all feature names */
-#define FD_FEATURE_SET_ID (1293382763U)
+#define FD_FEATURE_SET_ID (1996934138U)
 
 union fd_features {
   ulong f[ FD_FEATURE_ID_CNT ];
@@ -273,5 +273,6 @@ union fd_features {
     /* 0x640dddd90caae808 */ ulong alt_bn128_little_endian;
     /* 0x6a9db4aa29bdb608 */ ulong enable_bls12_381_syscall;
     /* 0x010f656d89a4e808 */ ulong enable_alt_bn128_g2_syscalls;
+    /* 0xfc12b1cef363afa7 */ ulong switch_to_chacha8_turbine;
   };
 };

--- a/src/flamenco/features/feature_map.json
+++ b/src/flamenco/features/feature_map.json
@@ -255,5 +255,6 @@
   {"name":"vote_state_v4","pubkey":"Gx4XFcrVMt4HUvPzTpTSVkdDVgcDSjKhDN1RqRS6KDuZ"},
   {"name":"alt_bn128_little_endian","pubkey":"bn2oPgpkzQPT3tohMaAsMVGjhDmmDa4jCaVPqCFmtxM"},
   {"name":"enable_bls12_381_syscall","pubkey":"b1sraWPVFdcUizB2LV5wQTeMuK8M313bi5bHjco5eVU"},
-  {"name":"enable_alt_bn128_g2_syscalls","pubkey":"bn1hKNURMGQaQoEVxahcEAcqiX3NwRs6hgKKNSLeKxH"}
+  {"name":"enable_alt_bn128_g2_syscalls","pubkey":"bn1hKNURMGQaQoEVxahcEAcqiX3NwRs6hgKKNSLeKxH"},
+  {"name":"switch_to_chacha8_turbine","pubkey":"CHaChatUnR3s6cPyPMMGNJa3VdQQ8PNH2JqdD4LpCKnB"}
 ]

--- a/src/flamenco/leaders/fd_leaders_base.h
+++ b/src/flamenco/leaders/fd_leaders_base.h
@@ -2,12 +2,14 @@
 #define HEADER_fd_src_flamenco_leaders_fd_leaders_base_h
 
 #include "../types/fd_types_custom.h"
+#include "../features/fd_features.h"
 
 #define MAX_SLOTS_PER_EPOCH   432000UL
 #define MAX_PUB_CNT           50000UL
 #define MAX_STAKED_LEADERS    40200UL
 
-/* Follows message structure in fd_stake_ci_stake_msg_init */
+/* Follows message structure in fd_stake_ci_stake_msg_init.
+   Frankendancer only */
 struct fd_stake_weight_msg_t {
   ulong             epoch;          /* Epoch for which the stake weights are valid */
   ulong             staked_cnt;     /* Number of staked nodes */
@@ -27,6 +29,27 @@ typedef struct fd_stake_weight_msg_t fd_stake_weight_msg_t;
 
 static inline ulong fd_stake_weight_msg_sz( ulong cnt ) {
   return FD_STAKE_CI_STAKE_MSG_HEADER_SZ + cnt * FD_STAKE_CI_STAKE_MSG_RECORD_SZ;
+}
+
+/* Firedancer only */
+struct fd_epoch_info_msg_t {
+  ulong                  epoch;             /* Epoch for which the info is valid */
+  ulong                  staked_cnt;        /* Number of staked nodes */
+  ulong                  start_slot;        /* Start slot of the epoch */
+  ulong                  slot_cnt;          /* Number of slots in the epoch */
+  ulong                  excluded_stake;    /* Total stake that is excluded from leader selection */
+  ulong                  vote_keyed_lsched; /* Whether vote account keyed leader schedule is active */
+  fd_features_t          features;          /* Feature activation slots */
+  fd_vote_stake_weight_t weights[];         /* Flexible array member (must be last) */
+};
+typedef struct fd_epoch_info_msg_t fd_epoch_info_msg_t;
+
+#define FD_EPOCH_INFO_MSG_HEADER_SZ (sizeof(fd_epoch_info_msg_t))
+#define FD_EPOCH_INFO_MAX_MSG_SZ    (FD_EPOCH_INFO_MSG_HEADER_SZ + MAX_STAKED_LEADERS * sizeof(fd_vote_stake_weight_t))
+#define FD_EPOCH_OUT_MTU            FD_EPOCH_INFO_MAX_MSG_SZ
+
+static inline ulong fd_epoch_info_msg_sz( ulong cnt ) {
+  return FD_EPOCH_INFO_MSG_HEADER_SZ + ( cnt * sizeof(fd_vote_stake_weight_t) );
 }
 
 #endif /* HEADER_fd_src_flamenco_leaders_fd_leaders_base_h */

--- a/src/flamenco/leaders/fd_multi_epoch_leaders.h
+++ b/src/flamenco/leaders/fd_multi_epoch_leaders.h
@@ -179,6 +179,18 @@ void
 fd_multi_epoch_leaders_stake_msg_fini( fd_multi_epoch_leaders_t * mleaders );
 
 
+/* fd_multi_epoch_leaders_epoch_msg_{init, fini} are the Firedancer
+   equivalents to the Frankendancer fd_multi_epoch_leaders_stake_msg_{init, fini}.
+   They take a different input message structure (fd_epoch_info_msg_t
+   vs fd_stake_weight_msg_t). */
+
+void
+fd_multi_epoch_leaders_epoch_msg_init( fd_multi_epoch_leaders_t   * mleaders,
+                                       fd_epoch_info_msg_t const  * msg );
+
+void
+fd_multi_epoch_leaders_epoch_msg_fini( fd_multi_epoch_leaders_t * mleaders );
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_flamenco_leaders_fd_multi_epoch_leaders_h */


### PR DESCRIPTION
- Adds the feature set to the message published by replay on the `replay_stake` link
- Rename `replay_stake` link to `replay_epoch`
- Consume the relevant features the shred tile needs in the shred tile
- Keep Frankendancer messages as they were so that we don't have to keep the feature sets in sync when we do upgrades