### PR TITLE
fdctl: physically pre-allocate when creating vinyl

### DIFF
--- a/src/app/firedancer/commands/configure/vinyl.c
+++ b/src/app/firedancer/commands/configure/vinyl.c
@@ -36,8 +36,8 @@ init( config_t const * config ) {
 
   ulong bstream_sz = config->firedancer.vinyl.file_size_gib<<30;
   if( (ulong)st.st_size < bstream_sz ) {
-    if( FD_UNLIKELY( 0!=ftruncate( vinyl_fd, (long)bstream_sz ) ) ) {
-      FD_LOG_ERR(( "ftruncate(`%s`,%lu bytes) failed (%i-%s)", config->paths.accounts, bstream_sz, errno, fd_io_strerror( errno ) ));
+    if( FD_UNLIKELY( 0!=posix_fallocate( vinyl_fd, 0L, (long)bstream_sz ) ) ) {
+      FD_LOG_ERR(( "posix_fallocate(`%s`,%lu bytes) failed (%i-%s)", config->paths.accounts, bstream_sz, errno, fd_io_strerror( errno ) ));
     }
   }
 


### PR DESCRIPTION
Fixes a bug where the vinyl configure stage used sparse allocation
on XFS when creating a bstream, which can lead to unexpected ENOSPC
at runtime.  posix_fallocate claims it does physical allocation.
