### PR TITLE
restore: snapwh shutdown when lthash enabled

### DIFF
--- a/src/discof/restore/fd_snapwh_tile.c
+++ b/src/discof/restore/fd_snapwh_tile.c
@@ -119,7 +119,7 @@ populate_allowed_seccomp( fd_topo_t const *      topo,
 
 static int
 should_shutdown( fd_snapwh_t const * ctx ) {
-  return ctx->state==FD_SNAPSHOT_STATE_SHUTDOWN && ctx->last_fseq==ctx->next_seq;
+  return ctx->state==FD_SNAPSHOT_STATE_SHUTDOWN;
 }
 
 static void


### PR DESCRIPTION
`snapwh`'s shutdown should not depend on `ctx->last_fseq==ctx->next_seq` when lthash verification is enabled under vinyl. This is because, in that configuration, `ctx->last_fseq` depends on `snapwr` and `snaplh`. Since the latter is controlled by `snaplv`, the shutdown message (and hence the last fseq) from `snapwh` may not be received and acked by `snaplh` if it has already proceeded to shutdown. Broadly speaking: `snapwh`, `snapwr` and `snaplh` are outside the snapshot-load state machine loop (even if they still follow it).
Making the code of `snaplh` more verbose as well.

Closes https://github.com/firedancer-io/firedancer/issues/7914