### PR TITLE
affinity: add ability to exclude cores

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -696,6 +696,26 @@ dynamic_port_range = "8900-9000"
     # determined automatically as well.
     agave_affinity = "auto"
 
+    # Logical CPU cores to blocklist from being used by Firedancer, when
+    # using auto affinity.  If not using auto affinity, this option is
+    # ignored.
+    #
+    # Blocklisting cores is useful if there are specific cores that are
+    # used by other processes on the system, and you do not want
+    # Firedancer running there and competing for the core.
+    #
+    # Cores are specified as a comma separated list of single cores like
+    # "0", ranges like "0-10", or ranges with stride like "0-10/2".
+    # Cores can also be specified with an 'h' suffix to indicate both
+    # the core and its hyperthread sibling should be blocklisted.  For
+    # example, "2h" blocklists core 2 and its hyperthread sibling (if
+    # any, if there is no hyperthread sibling the program will proceed).
+    #
+    # By default, both core 0 and its hyperthread sibling are
+    # blocklisted to prevent interference with OS kernel threads that
+    # often run on these cores.
+    blocklist_cores = "0h"
+
     # The number of threads to spawn per-fork for the unified scheduler.
     # The replay stage, which is a part of the Agave subprocess, uses
     # these threads for transaction execution.  The threads stay within

--- a/src/app/fdctl/topology.c
+++ b/src/app/fdctl/topology.c
@@ -350,10 +350,28 @@ fd_topo_initialize( config_t * config ) {
 
         if( FD_UNLIKELY( topo->agave_affinity_cnt>FD_TILE_MAX ) ) {
           FD_LOG_ERR(( "The CPU affinity string in the configuration file under [layout.agave_affinity] specifies more CPUs than Firedancer can use. "
-                        "You should either reduce the number of CPUs in the affinity string." ));
+                        "You should reduce the number of CPUs in the affinity string." ));
         }
         topo->agave_affinity_cpu_idx[ topo->agave_affinity_cnt++ ] = agave_cpu[ i ];
       }
+    }
+  } else {
+    ushort blocklist_cores[ FD_TILE_MAX ];
+    topo->blocklist_cores_cnt = fd_tile_private_cpus_parse( config->layout.blocklist_cores, blocklist_cores );
+    if( FD_UNLIKELY( topo->blocklist_cores_cnt>FD_TILE_MAX ) ) {
+      FD_LOG_ERR(( "The CPU string in the configuration file under [layout.blocklist_cores] specifies more CPUs than Firedancer can use. "
+                    "You should reduce the number of CPUs in the excluded cores string." ));
+    }
+
+    for( ulong i=0UL; i<topo->blocklist_cores_cnt; i++ ) {
+      /* Since we use fd_tile_private_cpus_parse() like for affinity, the user
+         may input a string containing `f`. That's parsed correctly, but it's
+         meaningless for blocklisted cores, so we reject it here.  */
+      if( FD_UNLIKELY( blocklist_cores[ i ]==USHORT_MAX ) ) {
+        FD_LOG_ERR(( "The CPU string in the configuration file under [layout.blocklist_cores] contains invalid values: `f`. "
+                      "You should fix the excluded cores string." ));
+      }
+      topo->blocklist_cores_cpu_idx[ i ] = blocklist_cores[ i ];
     }
   }
 

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -689,6 +689,26 @@ user = ""
     # the layout manually.
     affinity = "auto"
 
+    # Logical CPU cores to blocklist from being used by Firedancer, when
+    # using auto affinity.  If not using auto affinity, this option is
+    # ignored.
+    #
+    # Blocklisting cores is useful if there are specific cores that are
+    # used by other processes on the system, and you do not want
+    # Firedancer running there and competing for the core.
+    #
+    # Cores are specified as a comma separated list of single cores like
+    # "0", ranges like "0-10", or ranges with stride like "0-10/2".
+    # Cores can also be specified with an 'h' suffix to indicate both
+    # the core and its hyperthread sibling should be blocklisted.  For
+    # example, "2h" blocklists core 2 and its hyperthread sibling (if
+    # any, if there is no hyperthread sibling the program will proceed).
+    #
+    # By default, both core 0 and its hyperthread sibling are
+    # blocklisted to prevent interference with OS kernel threads that
+    # often run on these cores.
+    blocklist_cores = "0h"
+
     # How many net tiles to run.  This is configurable and designed to
     # scale out for future network conditions, but there is no need to
     # run more than 2 net tiles given current `mainnet-beta` conditions.

--- a/src/app/shared/fd_config.c
+++ b/src/app/shared/fd_config.c
@@ -535,6 +535,7 @@ fd_config_validate( fd_config_t const * config ) {
   CFG_HAS_NON_EMPTY( log.level_flush );
 
   CFG_HAS_NON_EMPTY( layout.affinity );
+  CFG_HAS_NON_EMPTY( layout.blocklist_cores );
   CFG_HAS_NON_ZERO ( layout.net_tile_count );
   CFG_HAS_NON_ZERO ( layout.quic_tile_count );
   CFG_HAS_NON_ZERO ( layout.resolv_tile_count );

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -274,6 +274,7 @@ struct fd_config {
 
   struct {
     char affinity[ AFFINITY_SZ ];
+    char blocklist_cores[ AFFINITY_SZ ];
 
     uint net_tile_count;
     uint quic_tile_count;

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -158,6 +158,7 @@ fd_config_extract_pod( uchar *       pod,
   CFG_POP      ( bool,   consensus.wait_for_vote_to_start_leader          );
 
   CFG_POP      ( cstr,   layout.affinity                                  );
+  CFG_POP      ( cstr,   layout.blocklist_cores                           );
   CFG_POP      ( uint,   layout.net_tile_count                            );
   CFG_POP      ( uint,   layout.quic_tile_count                           );
   CFG_POP      ( uint,   layout.resolv_tile_count                         );

--- a/src/disco/topo/fd_cpu_topo.c
+++ b/src/disco/topo/fd_cpu_topo.c
@@ -1,6 +1,7 @@
 #include "fd_cpu_topo.h"
 
 #include "../../util/shmem/fd_shmem_private.h"
+#include "../../util/tile/fd_tile_private.h"
 
 #include <errno.h>
 #include <unistd.h>
@@ -47,42 +48,6 @@ fd_topo_cpu_cnt( void ) {
   return end+1UL;
 }
 
-/* Return the sibling CPU (hyperthreaded pair) of the provided CPU, if
-   there is one, otherwise return ULONG_MAX.  On error, logs an error
-   and exits the process. */
-
-ulong
-fd_topob_sibling_idx( ulong cpu_idx ) {
-  char path[ PATH_MAX ];
-  FD_TEST( fd_cstr_printf_check( path, PATH_MAX, NULL, "/sys/devices/system/cpu/cpu%lu/topology/thread_siblings_list", cpu_idx ) );
-
-  int fd = open( path, O_RDONLY );
-  if( FD_UNLIKELY( -1==fd ) ) FD_LOG_ERR(( "open( \"%s\" ) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
-
-  char line[ 1024 ] = {0};
-  long bytes_read = read( fd, line, sizeof( line ) );
-  if( FD_UNLIKELY( -1==bytes_read ) ) FD_LOG_ERR(( "read( \"%s\" ) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
-  else if ( FD_UNLIKELY( (ulong)bytes_read>=sizeof( line ) ) ) FD_LOG_ERR(( "read( \"%s\" ) failed: buffer too small", path ));
-
-  if( FD_UNLIKELY( close( fd ) ) ) FD_LOG_ERR(( "close( \"%s\" ) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
-
-  char * sep = strchr( line, ',' );
-  if( FD_UNLIKELY( !sep ) ) return ULONG_MAX;
-
-  *sep = '\0';
-  errno = 0;
-  char * endptr;
-  ulong pair1 = strtoul( line, &endptr, 10 );
-  if( FD_UNLIKELY( *endptr!='\0' || errno==ERANGE || errno==EINVAL ) ) FD_LOG_ERR(( "failed to parse cpu siblings list of cpu%lu `%s`", cpu_idx, line ));
-
-  ulong pair2 = strtoul( sep+1UL, &endptr, 10 );
-  if( FD_UNLIKELY( *endptr!='\n' || errno==ERANGE || errno==EINVAL ) ) FD_LOG_ERR(( "failed to parse cpu siblings list of cpu%lu `%s`", pair1, sep+1UL ));
-
-  if( FD_LIKELY( pair1==cpu_idx ) )      return pair2;
-  else if( FD_LIKELY( pair2==cpu_idx ) ) return pair1;
-  else FD_LOG_ERR(( "failed to find sibling of cpu%lu", cpu_idx ));
-}
-
 static int
 fd_topo_cpus_online( ulong cpu_idx ) {
   if( FD_UNLIKELY( cpu_idx==0UL ) ) return 1; /* Cannot set cpu0 to offline */
@@ -101,7 +66,7 @@ fd_topo_cpus_init( fd_topo_cpus_t * cpus ) {
     cpus->cpu[ i ].idx = i;
     cpus->cpu[ i ].online = fd_topo_cpus_online( i );
     cpus->cpu[ i ].numa_node = fd_numa_node_idx( i );
-    if( FD_LIKELY( cpus->cpu[ i ].online ) ) cpus->cpu[ i ].sibling = fd_topob_sibling_idx( i );
+    if( FD_LIKELY( cpus->cpu[ i ].online ) ) cpus->cpu[ i ].sibling = fd_tile_private_sibling_idx( i );
     else                                     cpus->cpu[ i ].sibling = ULONG_MAX;
   }
 }

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -671,6 +671,8 @@ struct fd_topo {
 
   ulong          agave_affinity_cnt;
   ulong          agave_affinity_cpu_idx[ FD_TILE_MAX ];
+  ulong          blocklist_cores_cnt;
+  ulong          blocklist_cores_cpu_idx[ FD_TILE_MAX ];
 
   ulong          max_page_size; /* 2^21 or 2^30 */
   ulong          gigantic_page_threshold; /* see [hugetlbfs.gigantic_page_threshold_mib]*/

--- a/src/util/tile/fd_tile.c
+++ b/src/util/tile/fd_tile.c
@@ -2,6 +2,11 @@
 #include <errno.h>
 #include <sched.h>
 
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "fd_tile_private.h"
 
 int
@@ -25,5 +30,42 @@ fd_cpuset_setaffinity( ulong               pid,
   (void)pid; (void)mask;
   errno = ENOTSUP;
   return -1;
+# endif
+}
+
+ulong
+fd_tile_private_sibling_idx( ulong cpu_idx ) {
+# if defined(__linux__)
+  char path[ PATH_MAX ];
+  FD_TEST( fd_cstr_printf_check( path, PATH_MAX, NULL, "/sys/devices/system/cpu/cpu%lu/topology/thread_siblings_list", cpu_idx ) );
+
+  int fd = open( path, O_RDONLY );
+  if( FD_UNLIKELY( -1==fd ) ) FD_LOG_ERR(( "open( \"%s\" ) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
+
+  char line[ 1024 ] = {0};
+  long bytes_read = read( fd, line, sizeof( line ) );
+  if( FD_UNLIKELY( -1==bytes_read ) ) FD_LOG_ERR(( "read( \"%s\" ) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
+  else if ( FD_UNLIKELY( (ulong)bytes_read>=sizeof( line ) ) ) FD_LOG_ERR(( "read( \"%s\" ) failed: buffer too small", path ));
+
+  if( FD_UNLIKELY( close( fd ) ) ) FD_LOG_ERR(( "close( \"%s\" ) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
+
+  char * sep = strchr( line, ',' );
+  if( FD_UNLIKELY( !sep ) ) return ULONG_MAX;
+
+  *sep = '\0';
+  errno = 0;
+  char * endptr;
+  ulong pair1 = strtoul( line, &endptr, 10 );
+  if( FD_UNLIKELY( *endptr!='\0' || errno==ERANGE || errno==EINVAL ) ) FD_LOG_ERR(( "failed to parse cpu siblings list of cpu%lu `%s`", cpu_idx, line ));
+
+  ulong pair2 = strtoul( sep+1UL, &endptr, 10 );
+  if( FD_UNLIKELY( *endptr!='\n' || errno==ERANGE || errno==EINVAL ) ) FD_LOG_ERR(( "failed to parse cpu siblings list of cpu%lu `%s`", pair1, sep+1UL ));
+
+  if( FD_LIKELY( pair1==cpu_idx ) )      return pair2;
+  else if( FD_LIKELY( pair2==cpu_idx ) ) return pair1;
+  else FD_LOG_ERR(( "failed to find sibling of cpu%lu", cpu_idx ));
+# else
+  (void)cpu_idx;
+  return ULONG_MAX;
 # endif
 }

--- a/src/util/tile/fd_tile_private.h
+++ b/src/util/tile/fd_tile_private.h
@@ -52,6 +52,13 @@ int
 fd_cpuset_setaffinity( ulong               tid,
                        fd_cpuset_t const * mask );
 
+/* fd_tile_private_sibling_idx returns the sibling CPU (hyperthreaded
+   pair) of the provided CPU, if there is one, otherwise return ULONG_MAX.
+   On error, logs an error and exits the process. */
+
+ulong
+fd_tile_private_sibling_idx( ulong cpu_idx );
+
 /* These functions are for fd_tile internal use only. */
 
 void *

--- a/src/util/tile/fd_tile_threads.cxx
+++ b/src/util/tile/fd_tile_threads.cxx
@@ -516,6 +516,18 @@ fd_tile_private_cpus_parse( char const * cstr,
         p++; while( fd_isdigit( (int)p[0] ) ) p++; /* FIXME: USE STRTOUL ENDPTR FOR CORRECT HANDLING OF NON-BASE-10 */
       }
     }
+    else if( p[0]=='h' ) {
+      /* `Nh` is a shorthand for "core N and its hyperthread sibling".
+         If M is the sibling id and S = N-M, it translates as "N,M" or
+         equivalently "N-M/S", i.e. a range from N to M with stride S.
+         If core N doesn't have a sibling, the `h` suffix is ignored.
+         This way an expression like "0h" also works on systems where
+         hyperthread is not available. */
+      p++;
+      ulong sibling = fd_tile_private_sibling_idx( cpu0 );
+      cpu1 =   fd_ulong_if( sibling==ULONG_MAX, cpu0, sibling );
+      stride = fd_ulong_if( sibling==ULONG_MAX, 1,    sibling-cpu0 );
+    }
     while( fd_isspace( (int)p[0] ) ) p++;
     if( FD_UNLIKELY( !( p[0]==',' || p[0]=='\0' ) ) ) FD_LOG_ERR(( "fd_tile: malformed --tile-cpus (bad range delimiter)" ));
     if( p[0]==',' ) p++;


### PR DESCRIPTION
Addresses 1 and 5 in: https://github.com/firedancer-io/firedancer/issues/7278
- added `excluded_cores` config value, default to "0+"
- added ability to parse "N+" in affinity (currently undocumented except for `excluded_cores`)