### PR TITLE
pack: initialize skip_cnt for bundles

### DIFF
--- a/src/disco/pack/fd_pack.c
+++ b/src/disco/pack/fd_pack.c
@@ -1451,6 +1451,7 @@ fd_pack_insert_bundle_fini( fd_pack_t          * pack,
     bundle[ i ]->txnp->flags &= ~(FD_TXN_P_FLAGS_INITIALIZER_BUNDLE | FD_TXN_P_FLAGS_DURABLE_NONCE);
     bundle[ i ]->txnp->flags |= fd_uint_if( initializer_bundle, FD_TXN_P_FLAGS_INITIALIZER_BUNDLE, 0U );
     bundle[ i ]->txnp->flags |= fd_uint_if( is_durable_nonce,   FD_TXN_P_FLAGS_DURABLE_NONCE,      0U );
+    ord->skip = FD_PACK_SKIP_CNT;
     ord->expires_at = expires_at;
 
     if( FD_UNLIKELY( is_durable_nonce ) ) {


### PR DESCRIPTION
This could cause invalid bundle execution in rare circumstances