### PR TITLE
syscalls: code refactor to simplify

### DIFF
--- a/src/flamenco/vm/syscall/fd_vm_syscall_curve.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_curve.c
@@ -603,18 +603,8 @@ fd_vm_syscall_sol_curve_multiscalar_mul( void *  _vm,
     fd_ed25519_point_t * r = multi_scalar_mul_edwards( _r, scalars, points, points_len );
 
     if( FD_LIKELY( r ) ) {
-      /* https://github.com/anza-xyz/agave/blob/v2.3.1/programs/bpf_loader/src/syscalls/mod.rs#L1339-L1343 */
-      fd_vm_haddr_query_t result_query = {
-        .vaddr    = result_point_addr,
-        .align    = FD_VM_ALIGN_RUST_POD_U8_ARRAY,
-        .sz       = FD_VM_SYSCALL_SOL_CURVE_CURVE25519_POINT_SZ,
-        .is_slice = 0,
-      };
-
-      fd_vm_haddr_query_t * queries[] = { &result_query };
-      FD_VM_TRANSLATE_MUT( vm, queries );
-
-      fd_ed25519_point_tobytes( result_query.haddr, r );
+      uchar * result = FD_VM_HADDR_QUERY_U8_ARRAY( vm, result_point_addr, FD_VM_SYSCALL_SOL_CURVE_CURVE25519_POINT_SZ );
+      fd_ed25519_point_tobytes( result, r );
       ret = 0UL;
     }
     break;
@@ -625,18 +615,8 @@ fd_vm_syscall_sol_curve_multiscalar_mul( void *  _vm,
     fd_ristretto255_point_t * r = multi_scalar_mul_ristretto( _r, scalars, points, points_len );
 
     if( FD_LIKELY( r ) ) {
-      /* https://github.com/anza-xyz/agave/blob/v2.3.1/programs/bpf_loader/src/syscalls/mod.rs#L1380-L1384 */
-      fd_vm_haddr_query_t result_query = {
-        .vaddr    = result_point_addr,
-        .align    = FD_VM_ALIGN_RUST_POD_U8_ARRAY,
-        .sz       = FD_VM_SYSCALL_SOL_CURVE_CURVE25519_POINT_SZ,
-        .is_slice = 0,
-      };
-
-      fd_vm_haddr_query_t * queries[] = { &result_query };
-      FD_VM_TRANSLATE_MUT( vm, queries );
-
-      fd_ristretto255_point_tobytes( result_query.haddr, r );
+      uchar * result = FD_VM_HADDR_QUERY_U8_ARRAY( vm, result_point_addr, FD_VM_SYSCALL_SOL_CURVE_CURVE25519_POINT_SZ );
+      fd_ristretto255_point_tobytes( result, r );
       ret = 0UL;
     }
     break;

--- a/src/flamenco/vm/syscall/fd_vm_syscall_hash.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_hash.c
@@ -46,17 +46,7 @@ fd_vm_syscall_sol_sha256( /**/            void *  _vm,
 
   /* https://github.com/anza-xyz/agave/blob/v1.18.12/programs/bpf_loader/src/syscalls/mod.rs#L1922 */
   FD_VM_CU_UPDATE( vm, FD_VM_SHA256_BASE_COST );
-
-  /* https://github.com/anza-xyz/agave/blob/v2.3.1/programs/bpf_loader/src/syscalls/mod.rs#L2030-L2034 */
-  fd_vm_haddr_query_t hash_result_query = {
-    .vaddr    = result_addr,
-    .align    = FD_VM_ALIGN_RUST_U8,
-    .sz       = 32UL,
-    .is_slice = 1,
-  };
-
-  fd_vm_haddr_query_t * queries[] = { &hash_result_query };
-  FD_VM_TRANSLATE_MUT( vm, queries );
+  uchar * hash_result = FD_VM_HADDR_QUERY_U8_SLICE( vm, result_addr, 32UL );
 
   /* https://github.com/anza-xyz/agave/blob/v1.18.12/programs/bpf_loader/src/syscalls/mod.rs#L1930 */
   fd_sha256_t sha[1];
@@ -83,7 +73,7 @@ fd_vm_syscall_sol_sha256( /**/            void *  _vm,
   }
 
   /* https://github.com/anza-xyz/agave/blob/v1.18.12/programs/bpf_loader/src/syscalls/mod.rs#L1956-L1957 */
-  fd_sha256_fini( sha, hash_result_query.haddr );
+  fd_sha256_fini( sha, hash_result );
   *_ret = 0UL;
   return FD_VM_SUCCESS;
 }
@@ -111,17 +101,7 @@ fd_vm_syscall_sol_blake3( /**/            void *  _vm,
 
   /* https://github.com/anza-xyz/agave/blob/v1.18.12/programs/bpf_loader/src/syscalls/mod.rs#L1922 */
   FD_VM_CU_UPDATE( vm, FD_VM_SHA256_BASE_COST );
-
-  /* https://github.com/anza-xyz/agave/blob/v2.3.1/programs/bpf_loader/src/syscalls/mod.rs#L2030-L2034 */
-  fd_vm_haddr_query_t hash_result_query = {
-    .vaddr    = result_addr,
-    .align    = FD_VM_ALIGN_RUST_U8,
-    .sz       = 32UL,
-    .is_slice = 1,
-  };
-
-  fd_vm_haddr_query_t * queries[] = { &hash_result_query };
-  FD_VM_TRANSLATE_MUT( vm, queries );
+  uchar * hash_result = FD_VM_HADDR_QUERY_U8_SLICE( vm, result_addr, 32UL );
 
   /* https://github.com/anza-xyz/agave/blob/v1.18.12/programs/bpf_loader/src/syscalls/mod.rs#L1930 */
   fd_blake3_t sha[1];
@@ -148,7 +128,7 @@ fd_vm_syscall_sol_blake3( /**/            void *  _vm,
   }
 
   /* https://github.com/anza-xyz/agave/blob/v1.18.12/programs/bpf_loader/src/syscalls/mod.rs#L1956-L1957 */
-  fd_blake3_fini( sha, hash_result_query.haddr );
+  fd_blake3_fini( sha, hash_result );
   *_ret = 0UL;
   return FD_VM_SUCCESS;
 }
@@ -176,17 +156,7 @@ fd_vm_syscall_sol_keccak256( /**/            void *  _vm,
 
   /* https://github.com/anza-xyz/agave/blob/v1.18.12/programs/bpf_loader/src/syscalls/mod.rs#L1922 */
   FD_VM_CU_UPDATE( vm, FD_VM_SHA256_BASE_COST );
-
-  /* https://github.com/anza-xyz/agave/blob/v2.3.1/programs/bpf_loader/src/syscalls/mod.rs#L2030-L2034 */
-  fd_vm_haddr_query_t hash_result_query = {
-    .vaddr    = result_addr,
-    .align    = FD_VM_ALIGN_RUST_U8,
-    .sz       = 32UL,
-    .is_slice = 1,
-  };
-
-  fd_vm_haddr_query_t * queries[] = { &hash_result_query };
-  FD_VM_TRANSLATE_MUT( vm, queries );
+  uchar * hash_result = FD_VM_HADDR_QUERY_U8_SLICE( vm, result_addr, 32UL );
 
   /* https://github.com/anza-xyz/agave/blob/v1.18.12/programs/bpf_loader/src/syscalls/mod.rs#L1930 */
   fd_keccak256_t sha[1];
@@ -213,7 +183,7 @@ fd_vm_syscall_sol_keccak256( /**/            void *  _vm,
   }
 
   /* https://github.com/anza-xyz/agave/blob/v1.18.12/programs/bpf_loader/src/syscalls/mod.rs#L1956-L1957 */
-  fd_keccak256_fini( sha, hash_result_query.haddr );
+  fd_keccak256_fini( sha, hash_result );
   *_ret = 0UL;
   return FD_VM_SUCCESS;
 }

--- a/src/flamenco/vm/syscall/fd_vm_syscall_pda.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_pda.c
@@ -224,17 +224,8 @@ fd_vm_syscall_sol_create_program_address( /**/            void *  _vm,
     return err;
   }
 
-  /* https://github.com/anza-xyz/agave/blob/v2.3.1/programs/bpf_loader/src/syscalls/mod.rs#L875-L880 */
-  fd_vm_haddr_query_t address_query = {
-    .vaddr    = out_vaddr,
-    .align    = FD_VM_ALIGN_RUST_U8,
-    .sz       = FD_PUBKEY_FOOTPRINT,
-    .is_slice = 1,
-  };
-
-  fd_vm_haddr_query_t * queries[] = { &address_query };
-  FD_VM_TRANSLATE_MUT( vm, queries );
-  memcpy( address_query.haddr, derived->uc, FD_PUBKEY_FOOTPRINT );
+  uchar * address = FD_VM_HADDR_QUERY_U8_SLICE( vm, out_vaddr, FD_PUBKEY_FOOTPRINT );
+  memcpy( address, derived->uc, FD_PUBKEY_FOOTPRINT );
 
   /* Success */
   *_ret = 0UL;


### PR DESCRIPTION
1. use `FD_VM_HADDR_QUERY_U8_ARRAY` introduced in https://github.com/firedancer-io/firedancer/pull/5111
2. `fd_bn254_g1_compress` & co. are safe against unaligned input -> simplify the syscall code