### PR TITLE
[WIP] firedancer: clean up identity keyed leader schedule

### DIFF
--- a/src/app/firedancer-dev/commands/send_test/send_test_helpers.c
+++ b/src/app/firedancer-dev/commands/send_test/send_test_helpers.c
@@ -145,7 +145,6 @@ send_test_stake( send_test_ctx_t * ctx, send_test_out_t * out ) {
   msg->start_slot = ctx->epoch*MAX_SLOTS_PER_EPOCH;
   msg->slot_cnt = MAX_SLOTS_PER_EPOCH;
   msg->excluded_stake = 0;
-  msg->vote_keyed_lsched = 0;
 
   fd_vote_stake_weight_t * stake_weights = msg->weights;
   ulong stake_count = 0;

--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -1704,8 +1704,7 @@ fd_gui_handle_leader_schedule( fd_gui_t *                    gui,
                                                                                leader_schedule->slot_cnt,
                                                                                leader_schedule->staked_cnt,
                                                                                gui->epoch.epochs[ idx ].stakes,
-                                                                               leader_schedule->excluded_stake,
-                                                                               leader_schedule->vote_keyed_lsched ) );
+                                                                               leader_schedule->excluded_stake ) );
 
   if( FD_UNLIKELY( leader_schedule->start_slot==0UL ) ) {
     gui->epoch.epochs[ 0 ].start_time = now;
@@ -1758,8 +1757,7 @@ fd_gui_handle_epoch_info( fd_gui_t *                  gui,
                                                                                epoch_info->slot_cnt,
                                                                                epoch_info->staked_cnt,
                                                                                gui->epoch.epochs[ idx ].stakes,
-                                                                               epoch_info->excluded_stake,
-                                                                               epoch_info->vote_keyed_lsched ) );
+                                                                               epoch_info->excluded_stake ) );
 
   if( FD_UNLIKELY( epoch_info->start_slot==0UL ) ) {
     gui->epoch.epochs[ 0 ].start_time = now;
@@ -2950,7 +2948,7 @@ fd_gui_plugin_message( fd_gui_t *   gui,
       break;
     }
     case FD_PLUGIN_MSG_LEADER_SCHEDULE: {
-      FD_STATIC_ASSERT( sizeof(fd_stake_weight_msg_t)==6*sizeof(ulong), "new fields breaks things" );
+      FD_STATIC_ASSERT( sizeof(fd_stake_weight_msg_t)==5*sizeof(ulong), "new fields breaks things" );
       fd_gui_handle_leader_schedule( gui, (fd_stake_weight_msg_t *)msg, now );
       break;
     }

--- a/src/disco/shred/fd_stake_ci.c
+++ b/src/disco/shred/fd_stake_ci.c
@@ -39,9 +39,8 @@ fd_stake_ci_new( void             * mem,
     ei->start_slot     = 0UL;
     ei->slot_cnt       = 0UL;
     ei->excluded_stake = 0UL;
-    ei->vote_keyed_lsched = 0UL;
 
-    ei->lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( ei->_lsched, 0UL, 0UL, 1UL, 1UL,    info->vote_stake_weight,  0UL, ei->vote_keyed_lsched ) );
+    ei->lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( ei->_lsched, 0UL, 0UL, 1UL, 1UL, info->vote_stake_weight, 0UL ) );
     ei->sdest  = fd_shred_dest_join   ( fd_shred_dest_new   ( ei->_sdest,  info->shred_dest, 1UL, ei->lsched, identity_key, 0UL ) );
   }
   info->identity_key[ 0 ] = *identity_key;
@@ -67,7 +66,6 @@ fd_stake_ci_stake_msg_init( fd_stake_ci_t               * info,
   info->scratch->slot_cnt       = msg->slot_cnt;
   info->scratch->staked_cnt     = msg->staked_cnt;
   info->scratch->excluded_stake = msg->excluded_stake;
-  info->scratch->vote_keyed_lsched = msg->vote_keyed_lsched;
 
   fd_memcpy( info->vote_stake_weight, msg->weights, msg->staked_cnt*sizeof(fd_vote_stake_weight_t) );
 }
@@ -79,12 +77,11 @@ fd_stake_ci_epoch_msg_init( fd_stake_ci_t *             info,
     FD_LOG_ERR(( "The stakes -> Firedancer splice sent a malformed update with %lu stakes in it,"
                  " but the maximum allowed is %lu", msg->staked_cnt, MAX_SHRED_DESTS ));
 
-  info->scratch->epoch             = msg->epoch;
-  info->scratch->start_slot        = msg->start_slot;
-  info->scratch->slot_cnt          = msg->slot_cnt;
-  info->scratch->staked_cnt        = msg->staked_cnt;
-  info->scratch->excluded_stake    = msg->excluded_stake;
-  info->scratch->vote_keyed_lsched = msg->vote_keyed_lsched;
+  info->scratch->epoch          = msg->epoch;
+  info->scratch->start_slot     = msg->start_slot;
+  info->scratch->slot_cnt       = msg->slot_cnt;
+  info->scratch->staked_cnt     = msg->staked_cnt;
+  info->scratch->excluded_stake = msg->excluded_stake;
 
   fd_memcpy( info->vote_stake_weight, msg->weights, msg->staked_cnt*sizeof(fd_vote_stake_weight_t) );
 }
@@ -159,7 +156,6 @@ fd_stake_ci_stake_msg_fini( fd_stake_ci_t * info ) {
   ulong epoch                  = info->scratch->epoch;
   ulong staked_cnt             = info->scratch->staked_cnt;
   ulong unchanged_staked_cnt   = info->scratch->staked_cnt;
-  ulong vote_keyed_lsched      = info->scratch->vote_keyed_lsched;
 
   /* Just take the first one arbitrarily because they both have the same
      contact info, other than possibly some staked nodes with no contact
@@ -231,10 +227,9 @@ fd_stake_ci_stake_msg_fini( fd_stake_ci_t * info ) {
   new_ei->start_slot     = info->scratch->start_slot;
   new_ei->slot_cnt       = info->scratch->slot_cnt;
   new_ei->excluded_stake = excluded_stake;
-  new_ei->vote_keyed_lsched = vote_keyed_lsched;
 
   new_ei->lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( new_ei->_lsched, epoch, new_ei->start_slot, new_ei->slot_cnt,
-                                                                unchanged_staked_cnt, info->vote_stake_weight, excluded_stake, vote_keyed_lsched ) );
+                                                                unchanged_staked_cnt, info->vote_stake_weight, excluded_stake ) );
   new_ei->sdest  = fd_shred_dest_join   ( fd_shred_dest_new   ( new_ei->_sdest, info->shred_dest, j,
                                                                 new_ei->lsched, info->identity_key,  excluded_stake ) );
   log_summary( "stake update", info );

--- a/src/disco/shred/fd_stake_ci.h
+++ b/src/disco/shred/fd_stake_ci.h
@@ -33,7 +33,6 @@ struct fd_per_epoch_info_private {
   ulong start_slot;
   ulong slot_cnt;
   ulong excluded_stake;
-  ulong vote_keyed_lsched;
 
   /* Invariant: These are always joined and use the memory below for
      their footprint. */
@@ -57,7 +56,6 @@ struct fd_stake_ci {
     ulong slot_cnt;
     ulong staked_cnt;
     ulong excluded_stake;
-    ulong vote_keyed_lsched;
   } scratch[1];
 
   fd_vote_stake_weight_t   vote_stake_weight[ MAX_SHRED_DESTS ];

--- a/src/disco/shred/test_shred_dest.c
+++ b/src/disco/shred/test_shred_dest.c
@@ -16,8 +16,6 @@ FD_STATIC_ASSERT( FD_SHRED_DEST_ALIGN==alignof(fd_shred_dest_t), shred_dest_alig
 
 FD_STATIC_ASSERT( sizeof(fd_shred_dest_weighted_t)==48UL, dest_info_construction );
 
-const ulong vote_keyed_lsched = 0UL;
-
 static void
 test_compute_first_matches_agave( void ) {
   ulong cnt = t1_dest_info_sz / sizeof(fd_shred_dest_weighted_t);
@@ -35,7 +33,7 @@ test_compute_first_matches_agave( void ) {
   FD_TEST( fd_shred_dest_footprint   ( staked, staked-cnt ) <= TEST_MAX_FOOTPRINT );
   FD_TEST( fd_epoch_leaders_footprint( cnt, 10000UL       ) <= TEST_MAX_FOOTPRINT );
 
-  fd_epoch_leaders_t * lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( _l_footprint, 0UL, 0UL, 10000UL, staked, stakes, 0UL, vote_keyed_lsched ) );
+  fd_epoch_leaders_t * lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( _l_footprint, 0UL, 0UL, 10000UL, staked, stakes, 0UL ) );
   FD_TEST( lsched );
 
   fd_shred_dest_t * sdest = fd_shred_dest_join( fd_shred_dest_new( _sd_footprint, info, cnt, lsched, src_key, 0UL ) );
@@ -88,7 +86,7 @@ test_compute_children_matches_agave( void ) {
   FD_TEST( fd_shred_dest_footprint   ( staked, cnt-staked ) <= TEST_MAX_FOOTPRINT );
   FD_TEST( fd_epoch_leaders_footprint( cnt,        2000UL ) <= TEST_MAX_FOOTPRINT );
 
-  fd_epoch_leaders_t * lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( _l_footprint, 0UL, 0UL, 4000UL, staked, stakes, 0UL, vote_keyed_lsched ) );
+  fd_epoch_leaders_t * lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( _l_footprint, 0UL, 0UL, 4000UL, staked, stakes, 0UL ) );
 
   fd_shred_dest_t * sdest = fd_shred_dest_join( fd_shred_dest_new( _sd_footprint, info, cnt, lsched, src_key, 0UL ) );
 
@@ -192,7 +190,7 @@ test_batching( void ) {
       info[i].ip4 = (uint)i;
     }
     fd_pubkey_t * src_key = &(info[0].pubkey);
-    fd_epoch_leaders_t * lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( _l_footprint, 0UL, 0UL, 100UL, cnt, stakes, 0UL, vote_keyed_lsched ) );
+    fd_epoch_leaders_t * lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( _l_footprint, 0UL, 0UL, 100UL, cnt, stakes, 0UL ) );
     fd_shred_dest_t * sdest = fd_shred_dest_join( fd_shred_dest_new( _sd_footprint, info, cnt, lsched, src_key, 0UL ) );
 
 #define BATCH_CNT 5
@@ -268,7 +266,7 @@ test_vary_stake( void ) {
     stakes[31].vote_key.uc[0] = 0;
     stakes[30].stake = stakes[31].stake = prev-1UL;
 
-    fd_epoch_leaders_t * lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( _l_footprint, 0UL, 0UL, 100UL, cnt, stakes, 0UL, vote_keyed_lsched ) );
+    fd_epoch_leaders_t * lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( _l_footprint, 0UL, 0UL, 100UL, cnt, stakes, 0UL ) );
     test_distribution_is_tree( info, 32UL, lsched, 6+fd_rng_ulong_roll(r, 25UL ), fd_rng_ulong_roll( r, 100UL ), fd_rng_int_roll( r, 2 ), fd_rng_ulong_roll( r, 100UL ) );
     fd_epoch_leaders_delete( fd_epoch_leaders_leave( lsched ) );
   }
@@ -289,7 +287,7 @@ test_t1_vary_radix( void ) {
     staked += (info[i].stake_lamports>0UL);
   }
 
-  fd_epoch_leaders_t * lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( _l_footprint, 0UL, 0UL, 4000UL, staked, stakes, 0UL, vote_keyed_lsched ) );
+  fd_epoch_leaders_t * lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( _l_footprint, 0UL, 0UL, 4000UL, staked, stakes, 0UL ) );
   for( ulong fanout=35UL; fanout<650UL; fanout+=11UL ) {
     FD_LOG_NOTICE(( "Fanout: %lu", fanout ));
     test_distribution_is_tree( info, cnt, lsched, fanout, fd_rng_ulong_roll( r, 4000UL ), fd_rng_int_roll( r, 2 ), fd_rng_ulong_roll( r, 100UL ) );
@@ -312,7 +310,7 @@ test_change_contact( void ) {
     staked += (info[i].stake_lamports>0UL);
   }
 
-  fd_epoch_leaders_t * lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( _l_footprint, 0UL, 0UL, 10000UL, staked, stakes, 0UL, vote_keyed_lsched ) );
+  fd_epoch_leaders_t * lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( _l_footprint, 0UL, 0UL, 10000UL, staked, stakes, 0UL ) );
 
   fd_shred_dest_t * sdest = fd_shred_dest_join( fd_shred_dest_new( _sd_footprint, info, cnt, lsched, src_key, 0UL ) );
   fd_shred_dest_idx_to_dest( sdest, (ushort)0 )->ip4 = 12U;
@@ -333,7 +331,7 @@ test_errors( void ) {
   memset( &(stakes[0].vote_key), 1, 32UL );
   stakes[0].stake = 100UL;
   fd_pubkey_t const * src_key = (fd_pubkey_t const *)t1_pubkey;
-  fd_epoch_leaders_t * lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( _l_footprint, 0UL, 0UL, 10000UL, 1UL, stakes, 0UL, vote_keyed_lsched ) );
+  fd_epoch_leaders_t * lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( _l_footprint, 0UL, 0UL, 10000UL, 1UL, stakes, 0UL ) );
 
   fd_shred_dest_t * sdest = fd_shred_dest_join( fd_shred_dest_new( _sd_footprint, NULL, 0UL, lsched, src_key, 0UL ) );
   FD_TEST( sdest==NULL );
@@ -364,9 +362,9 @@ test_indeterminate( void ) {
   FD_TEST( lf_trunc + fd_epoch_leaders_footprint( truncated_cnt, 4000UL ) < _l_footprint + TEST_MAX_FOOTPRINT );
 
   fd_epoch_leaders_t * lsched_full  = fd_epoch_leaders_join( fd_epoch_leaders_new( lf_full,  0UL, 0UL, 4000UL, staked_cnt,
-                                                                                   stakes, 0UL,            vote_keyed_lsched ) );
+                                                                                   stakes, 0UL            ) );
   fd_epoch_leaders_t * lsched_trunc = fd_epoch_leaders_join( fd_epoch_leaders_new( lf_trunc, 0UL, 0UL, 4000UL, truncated_cnt,
-                                                                                   stakes, excluded_stake, vote_keyed_lsched ) );
+                                                                                   stakes, excluded_stake ) );
 
   uchar * sf_full  = _sd_footprint;
   uchar * sf_trunc = _sd_footprint + fd_shred_dest_footprint( staked_cnt, 0UL );
@@ -462,7 +460,7 @@ test_performance( void ) {
   FD_TEST( fd_epoch_leaders_footprint( cnt,       10000UL ) <= TEST_MAX_FOOTPRINT  );
 
   long dt = -fd_log_wallclock();
-  fd_epoch_leaders_t * lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( _l_footprint, 0UL, 0UL, 10000UL, staked, stakes, 0UL, vote_keyed_lsched ) );
+  fd_epoch_leaders_t * lsched = fd_epoch_leaders_join( fd_epoch_leaders_new( _l_footprint, 0UL, 0UL, 10000UL, staked, stakes, 0UL ) );
   fd_shred_dest_t    * sdest  = fd_shred_dest_join   ( fd_shred_dest_new   ( _sd_footprint, info, cnt, lsched, src_key, 0UL ) );
   dt += fd_log_wallclock();
 

--- a/src/disco/shred/test_stake_ci.c
+++ b/src/disco/shred/test_stake_ci.c
@@ -19,11 +19,10 @@ generate_stake_msg( uchar *      _buf,
   buf->slot_cnt       = SLOTS_PER_EPOCH;
   buf->staked_cnt     = strlen(stakers);
   buf->excluded_stake = 0UL;
-  buf->vote_keyed_lsched = 0UL;
 
   ulong i = 0UL;
   for(; *stakers; stakers++, i++ ) {
-    /* for simplicity use vote==id, but see test_stake_msg_staked_by_vote()
+    /* for simplicity use vote==id, but see test_stake_msg_multi_vote_per_identity()
        where we test cases in which id is repeated.
        (vote is not used, so it doesn't matter if it's repeated or not) */
     memset( buf->weights[i].vote_key.uc, *stakers, sizeof(fd_pubkey_t) );
@@ -44,7 +43,6 @@ generate_epoch_msg( uchar *      _buf,
   buf->slot_cnt       = SLOTS_PER_EPOCH;
   buf->staked_cnt     = strlen(stakers);
   buf->excluded_stake = 0UL;
-  buf->vote_keyed_lsched = 0UL;
   memset( &buf->features, 0, sizeof(fd_features_t) );
 
   ulong i = 0UL;
@@ -327,17 +325,15 @@ test_stake_msg_destaking( void ) {
 }
 
 static void
-test_stake_msg_staked_by_vote( void ) {
+test_stake_msg_multi_vote_per_identity( void ) {
   fd_stake_ci_t * info = fd_stake_ci_join( fd_stake_ci_new( _info, identity_key ) );
   fd_stake_weight_msg_t * msg;
 
   msg = generate_stake_msg( stake_msg, 0UL, "I"   );
-  msg->vote_keyed_lsched = 1;
   fd_stake_ci_stake_msg_init( info, msg );  fd_stake_ci_stake_msg_fini( info );
   check_destinations( info, 0UL, "I",   "" );
 
   msg = generate_stake_msg( stake_msg, 0UL, "ABC"   );
-  msg->vote_keyed_lsched = 1;
   fd_stake_ci_stake_msg_init( info, msg );  fd_stake_ci_stake_msg_fini( info );
   check_destinations( info, 0UL, "ABC",   "I" );
 
@@ -363,7 +359,7 @@ test_stake_msg( void ) {
   test_stake_msg_cancel();
   test_stake_msg_ordering();
   test_stake_msg_destaking();
-  test_stake_msg_staked_by_vote();
+  test_stake_msg_multi_vote_per_identity();
 }
 
 static void
@@ -552,17 +548,15 @@ test_epoch_msg_destaking( void ) {
 }
 
 static void
-test_epoch_msg_staked_by_vote( void ) {
+test_epoch_msg_multi_vote_per_identity( void ) {
   fd_stake_ci_t * info = fd_stake_ci_join( fd_stake_ci_new( _info, identity_key ) );
   fd_epoch_info_msg_t * msg;
 
   msg = generate_epoch_msg( epoch_msg, 0UL, "I"   );
-  msg->vote_keyed_lsched = 1;
   fd_stake_ci_epoch_msg_init( info, msg );  fd_stake_ci_epoch_msg_fini( info );
   check_destinations( info, 0UL, "I",   "" );
 
   msg = generate_epoch_msg( epoch_msg, 0UL, "ABC"   );
-  msg->vote_keyed_lsched = 1;
   fd_stake_ci_epoch_msg_init( info, msg );  fd_stake_ci_epoch_msg_fini( info );
   check_destinations( info, 0UL, "ABC",   "I" );
 
@@ -588,7 +582,7 @@ test_epoch_msg( void ) {
   test_epoch_msg_cancel();
   test_epoch_msg_ordering();
   test_epoch_msg_destaking();
-  test_epoch_msg_staked_by_vote();
+  test_epoch_msg_multi_vote_per_identity();
 }
 
 static void
@@ -633,12 +627,11 @@ test_limits( void ) {
 
   for( ulong stake_weight_cnt=40198UL; stake_weight_cnt<=40201UL; stake_weight_cnt++ ) {
     fd_stake_weight_msg_t * buf = fd_type_pun( stake_msg );
-    buf->epoch                  = stake_weight_cnt;
-    buf->start_slot             = stake_weight_cnt * SLOTS_PER_EPOCH;
-    buf->slot_cnt               = SLOTS_PER_EPOCH;
-    buf->staked_cnt             = 0UL;
-    buf->excluded_stake         = 0UL;
-    buf->vote_keyed_lsched      = 0UL;
+    buf->epoch          = stake_weight_cnt;
+    buf->start_slot     = stake_weight_cnt * SLOTS_PER_EPOCH;
+    buf->slot_cnt       = SLOTS_PER_EPOCH;
+    buf->staked_cnt     = 0UL;
+    buf->excluded_stake = 0UL;
 
     for( ulong i=0UL; i<stake_weight_cnt; i++ ) {
       ulong stake = 2000000000UL/(i+1UL);
@@ -832,7 +825,6 @@ test_dest_update_overflow( void ) {
   buf->slot_cnt       = SLOTS_PER_EPOCH;
   buf->staked_cnt     = MAX_SHRED_DESTS - 2UL;
   buf->excluded_stake = 0UL;
-  buf->vote_keyed_lsched = 0UL;
   memset( &buf->features, 0, sizeof(fd_features_t) );
 
   for(ulong i = 0UL; i<buf->staked_cnt; i++ ) {

--- a/src/discof/replay/fd_execrp.h
+++ b/src/discof/replay/fd_execrp.h
@@ -4,10 +4,6 @@
 #include "../../disco/fd_txn_p.h"
 #include "../../flamenco/types/fd_types_custom.h"
 
-/* FIXME: SIMD-0180 - set the correct epochs */
-#define FD_SIMD0180_ACTIVE_EPOCH_TESTNET (829)
-#define FD_SIMD0180_ACTIVE_EPOCH_MAINNET (841)
-
 /* Exec tile task types. */
 #define FD_EXECRP_TT_TXN_EXEC      (1UL) /* Transaction execution. */
 #define FD_EXECRP_TT_TXN_SIGVERIFY (2UL) /* Transaction sigverify. */

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -574,18 +574,10 @@ generate_epoch_info_msg( ulong                       slot,
                          int                         current_epoch ) {
   fd_vote_stake_weight_t * stake_weights = epoch_info_msg->weights;
 
-  epoch_info_msg->epoch             = epoch;
-  epoch_info_msg->start_slot        = fd_epoch_slot0( epoch_schedule, epoch );
-  epoch_info_msg->slot_cnt          = fd_epoch_slot_cnt( epoch_schedule, epoch );
-  epoch_info_msg->excluded_stake    = 0UL;
-  epoch_info_msg->vote_keyed_lsched = 1UL;
-
-  /* FIXME: SIMD-0180 - hack to (de)activate in testnet vs mainnet.
-     This code can be removed once the feature is active. */
-  if( (1==epoch_schedule->warmup && epoch<FD_SIMD0180_ACTIVE_EPOCH_TESTNET) ||
-      (0==epoch_schedule->warmup && epoch<FD_SIMD0180_ACTIVE_EPOCH_MAINNET) ) {
-    epoch_info_msg->vote_keyed_lsched = 0UL;
-  }
+  epoch_info_msg->epoch          = epoch;
+  epoch_info_msg->start_slot     = fd_epoch_slot0( epoch_schedule, epoch );
+  epoch_info_msg->slot_cnt       = fd_epoch_slot_cnt( epoch_schedule, epoch );
+  epoch_info_msg->excluded_stake = 0UL;
 
   ulong idx = 0UL;
 

--- a/src/discof/shredcap/fd_shredcap_tile.c
+++ b/src/discof/shredcap/fd_shredcap_tile.c
@@ -221,18 +221,11 @@ generate_epoch_info_msg_manifest( ulong                                       ep
   fd_epoch_info_msg_t *    epoch_info_msg = (fd_epoch_info_msg_t *)fd_type_pun( epoch_info_msg_out );
   fd_vote_stake_weight_t * stake_weights  = epoch_info_msg->weights;
 
-  epoch_info_msg->epoch             = epoch;
-  epoch_info_msg->start_slot        = fd_epoch_slot0( epoch_schedule, epoch );
-  epoch_info_msg->slot_cnt          = fd_epoch_slot_cnt( epoch_schedule, epoch );
-  epoch_info_msg->excluded_stake    = 0UL;
-  epoch_info_msg->vote_keyed_lsched = 1UL;
-
-  /* FIXME: SIMD-0180 - hack to (de)activate in testnet vs mainnet.
-     This code can be removed once the feature is active. */
-  if( (1==epoch_schedule->warmup && epoch<FD_SIMD0180_ACTIVE_EPOCH_TESTNET) ||
-      (0==epoch_schedule->warmup && epoch<FD_SIMD0180_ACTIVE_EPOCH_MAINNET) ) {
-    epoch_info_msg->vote_keyed_lsched = 0UL;
-  }
+  epoch_info_msg->epoch          = epoch;
+  epoch_info_msg->staked_cnt     = epoch_stakes->vote_stakes_len;
+  epoch_info_msg->start_slot     = fd_epoch_slot0( epoch_schedule, epoch );
+  epoch_info_msg->slot_cnt       = fd_epoch_slot_cnt( epoch_schedule, epoch );
+  epoch_info_msg->excluded_stake = 0UL;
 
   /* Set all features as deactivated as we don't have available feature info from manifest. */
   fd_memset( &epoch_info_msg->features, 0xFF, sizeof(fd_features_t) );

--- a/src/flamenco/leaders/fd_leaders.c
+++ b/src/flamenco/leaders/fd_leaders.c
@@ -2,16 +2,6 @@
 #include "../../ballet/chacha/fd_chacha_rng.h"
 #include "../../ballet/wsample/fd_wsample.h"
 
-#define SORT_NAME sort_vote_weights_by_stake_id
-#define SORT_KEY_T fd_vote_stake_weight_t
-#define SORT_BEFORE(a,b) ((a).stake > (b).stake ? 1 : ((a).stake < (b).stake ? 0 : memcmp( (a).id_key.uc, (b).id_key.uc, 32UL )>0))
-#include "../../util/tmpl/fd_sort.c"
-
-#define SORT_NAME sort_vote_weights_by_id
-#define SORT_KEY_T fd_vote_stake_weight_t
-#define SORT_BEFORE(a,b) (memcmp( (a).id_key.uc, (b).id_key.uc, 32UL )>0)
-#include "../../util/tmpl/fd_sort.c"
-
 ulong
 fd_epoch_leaders_align( void ) {
   return FD_EPOCH_LEADERS_ALIGN;
@@ -28,14 +18,13 @@ fd_epoch_leaders_footprint( ulong pub_cnt,
 }
 
 void *
-fd_epoch_leaders_new( void  *                  shmem,
-                      ulong                    epoch,
-                      ulong                    slot0,
-                      ulong                    slot_cnt,
-                      ulong                    pub_cnt,
-                      fd_vote_stake_weight_t * stakes,
-                      ulong                    excluded_stake,
-                      ulong                    vote_keyed_lsched ) {
+fd_epoch_leaders_new( void  *                        shmem,
+                      ulong                          epoch,
+                      ulong                          slot0,
+                      ulong                          slot_cnt,
+                      ulong                          pub_cnt,
+                      fd_vote_stake_weight_t const * stakes,
+                      ulong                          excluded_stake ) {
   if( FD_UNLIKELY( !shmem ) ) {
     FD_LOG_WARNING(( "NULL shmem" ));
     return NULL;
@@ -45,38 +34,6 @@ fd_epoch_leaders_new( void  *                  shmem,
   if( FD_UNLIKELY( !fd_ulong_is_aligned( laddr, FD_EPOCH_LEADERS_ALIGN ) ) ) {
     FD_LOG_WARNING(( "misaligned shmem" ));
     return NULL;
-  }
-
-  if( FD_UNLIKELY( !pub_cnt ) ) {
-    FD_LOG_WARNING(( "pub_cnt is 0" ));
-    return NULL;
-  }
-
-  /* This code can be be removed when enable_vote_address_leader_schedule is
-     enabled and cleared.
-     And, as a consequence, stakes can be made const. */
-  if( FD_LIKELY( vote_keyed_lsched==0 ) ) {
-    /* Sort [(vote, id, stake)] by id, so we can dedup */
-    sort_vote_weights_by_id_inplace( stakes, pub_cnt );
-
-    /* Dedup entries, aggregating stake */
-    ulong j=0UL;
-    for( ulong i=1UL; i<pub_cnt; i++ ) {
-      fd_pubkey_t * pre = &stakes[ j ].id_key;
-      fd_pubkey_t * cur = &stakes[ i ].id_key;
-      if( 0==memcmp( pre, cur, sizeof(fd_pubkey_t) ) ) {
-        stakes[ j ].stake += stakes[ i ].stake;
-      } else {
-        ++j;
-        stakes[ j ].stake = stakes[ i ].stake;
-        memcpy( stakes[ j ].id_key.uc, stakes[ i ].id_key.uc, sizeof(fd_pubkey_t) );
-        /* vote doesn't matter */
-      }
-    }
-    pub_cnt = fd_ulong_min( pub_cnt, j+1 );
-
-    /* Sort [(vote, id, stake)] by stake then id, as expected */
-    sort_vote_weights_by_stake_id_inplace( stakes, pub_cnt );
   }
 
   /* The eventual layout that we want is:

--- a/src/flamenco/leaders/fd_leaders.h
+++ b/src/flamenco/leaders/fd_leaders.h
@@ -101,8 +101,6 @@ fd_epoch_leaders_footprint( ulong pub_cnt,
    pub_cnt is the number of unique public keys in this schedule.
    `stakes` points to the first entry of pub_cnt entries of stake
    weights sorted by tuple (stake, pubkey) in descending order.
-   `vote_keyed_lsched` is either 0 or 1, when 1 the leader schedule
-   is computed by vote accounts (see SIMD-0180).
 
    If `stakes` does not include all staked nodes, e.g. in the case of an
    attack that swamps the network with fake validators, `stakes` should
@@ -113,14 +111,13 @@ fd_epoch_leaders_footprint( ulong pub_cnt,
    Does NOT retain a read interest in stakes upon return.
    The caller is not joined to the object on return. */
 void *
-fd_epoch_leaders_new( void  *                  shmem,
-                      ulong                    epoch,
-                      ulong                    slot0,
-                      ulong                    slot_cnt,
-                      ulong                    pub_cnt,
-                      fd_vote_stake_weight_t * stakes, /* indexed [0, pub_cnt) */
-                      ulong                    excluded_stake,
-                      ulong                    vote_keyed_lsched );
+fd_epoch_leaders_new( void  *                        shmem,
+                      ulong                          epoch,
+                      ulong                          slot0,
+                      ulong                          slot_cnt,
+                      ulong                          pub_cnt,
+                      fd_vote_stake_weight_t const * stakes, /* indexed [0, pub_cnt) */
+                      ulong                          excluded_stake );
 
 /* fd_epoch_leaders_join joins the caller to the leader schedule object.
    fd_epoch_leaders_leave undoes an existing join. */

--- a/src/flamenco/leaders/fd_leaders_base.h
+++ b/src/flamenco/leaders/fd_leaders_base.h
@@ -11,12 +11,11 @@
 /* Follows message structure in fd_stake_ci_stake_msg_init.
    Frankendancer only */
 struct fd_stake_weight_msg_t {
-  ulong             epoch;          /* Epoch for which the stake weights are valid */
-  ulong             staked_cnt;     /* Number of staked nodes */
-  ulong             start_slot;     /* Start slot of the epoch */
-  ulong             slot_cnt;       /* Number of slots in the epoch */
-  ulong             excluded_stake; /* Total stake that is excluded from leader selection */
-  ulong             vote_keyed_lsched; /* 1=use vote-keyed leader schedule, 0=use old leader schedule */
+  ulong                  epoch;          /* Epoch for which the stake weights are valid */
+  ulong                  staked_cnt;     /* Number of staked nodes */
+  ulong                  start_slot;     /* Start slot of the epoch */
+  ulong                  slot_cnt;       /* Number of slots in the epoch */
+  ulong                  excluded_stake; /* Total stake that is excluded from leader selection */
   fd_vote_stake_weight_t weights[]; /* Stake weights for each staked node */
 };
 typedef struct fd_stake_weight_msg_t fd_stake_weight_msg_t;
@@ -38,7 +37,6 @@ struct fd_epoch_info_msg_t {
   ulong                  start_slot;        /* Start slot of the epoch */
   ulong                  slot_cnt;          /* Number of slots in the epoch */
   ulong                  excluded_stake;    /* Total stake that is excluded from leader selection */
-  ulong                  vote_keyed_lsched; /* Whether vote account keyed leader schedule is active */
   fd_epoch_schedule_t    epoch_schedule;    /* Epoch schedule */
   fd_features_t          features;          /* Feature activation slots */
   fd_vote_stake_weight_t weights[];         /* Flexible array member (must be last) */

--- a/src/flamenco/leaders/fd_multi_epoch_leaders.c
+++ b/src/flamenco/leaders/fd_multi_epoch_leaders.c
@@ -13,12 +13,11 @@ fd_multi_epoch_leaders_new( void * shmem ) {
   }
 
   fd_multi_epoch_leaders_t * leaders = (fd_multi_epoch_leaders_t *)shmem;
-  leaders->scratch->vote_keyed_lsched = 0;
 
   /* Initialize all epochs to satisfy invariants */
   fd_vote_stake_weight_t dummy_stakes[ 1 ] = {{ .vote_key = {{0}}, .id_key = {{0}}, .stake = 1UL }};
   for( ulong i=0UL; i<MULTI_EPOCH_LEADERS_EPOCH_CNT; i++ ) {
-    leaders->lsched[i] = fd_epoch_leaders_join( fd_epoch_leaders_new( leaders->_lsched[i], i, 0UL, 1UL, 1UL, dummy_stakes, 0UL, leaders->scratch->vote_keyed_lsched ) );
+    leaders->lsched[i] = fd_epoch_leaders_join( fd_epoch_leaders_new( leaders->_lsched[i], i, 0UL, 1UL, 1UL, dummy_stakes, 0UL ) );
     FD_TEST( leaders->lsched[i] );
     leaders->init_done[i] = 0;
   }
@@ -105,7 +104,6 @@ fd_multi_epoch_leaders_stake_msg_init( fd_multi_epoch_leaders_t   * mleaders,
   mleaders->scratch->slot_cnt       = msg->slot_cnt;
   mleaders->scratch->staked_cnt     = msg->staked_cnt;
   mleaders->scratch->excluded_stake = msg->excluded_stake;
-  mleaders->scratch->vote_keyed_lsched = msg->vote_keyed_lsched;
 
   fd_memcpy( mleaders->vote_stake_weight, msg->weights, msg->staked_cnt*sizeof(fd_vote_stake_weight_t) );
 }
@@ -122,22 +120,20 @@ fd_multi_epoch_leaders_epoch_msg_init( fd_multi_epoch_leaders_t   * mleaders,
   mleaders->scratch->slot_cnt       = msg->slot_cnt;
   mleaders->scratch->staked_cnt     = msg->staked_cnt;
   mleaders->scratch->excluded_stake = msg->excluded_stake;
-  mleaders->scratch->vote_keyed_lsched = msg->vote_keyed_lsched;
 
   fd_memcpy( mleaders->vote_stake_weight, msg->weights, msg->staked_cnt*sizeof(fd_vote_stake_weight_t) );
 }
 
 void
 fd_multi_epoch_leaders_stake_msg_fini( fd_multi_epoch_leaders_t * mleaders ) {
-  const ulong epoch          = mleaders->scratch->epoch;
-  const ulong slot0          = mleaders->scratch->start_slot;
-  const ulong slot_cnt       = mleaders->scratch->slot_cnt;
-  const ulong pub_cnt        = mleaders->scratch->staked_cnt;
-  const ulong excluded_stake = mleaders->scratch->excluded_stake;
-  const ulong vote_keyed_lsched = mleaders->scratch->vote_keyed_lsched;
-  const ulong epoch_idx      = epoch % MULTI_EPOCH_LEADERS_EPOCH_CNT;
+  ulong const epoch          = mleaders->scratch->epoch;
+  ulong const slot0          = mleaders->scratch->start_slot;
+  ulong const slot_cnt       = mleaders->scratch->slot_cnt;
+  ulong const pub_cnt        = mleaders->scratch->staked_cnt;
+  ulong const excluded_stake = mleaders->scratch->excluded_stake;
+  ulong const epoch_idx      = epoch % MULTI_EPOCH_LEADERS_EPOCH_CNT;
 
-  fd_vote_stake_weight_t * stakes = mleaders->vote_stake_weight;
+  fd_vote_stake_weight_t const * stakes = mleaders->vote_stake_weight;
 
   /* Clear old data */
   fd_epoch_leaders_delete( fd_epoch_leaders_leave( mleaders->lsched[epoch_idx] ) );
@@ -146,7 +142,7 @@ fd_multi_epoch_leaders_stake_msg_fini( fd_multi_epoch_leaders_t * mleaders ) {
   uchar *  lsched_mem        = mleaders->_lsched[epoch_idx];
   mleaders->lsched[epoch_idx] = fd_epoch_leaders_join( fd_epoch_leaders_new(
                                     lsched_mem, epoch, slot0, slot_cnt,
-                                    pub_cnt, stakes, excluded_stake, vote_keyed_lsched ) );
+                                    pub_cnt, stakes, excluded_stake ) );
   mleaders->init_done[epoch_idx] = 1;
 }
 

--- a/src/flamenco/leaders/fd_multi_epoch_leaders.h
+++ b/src/flamenco/leaders/fd_multi_epoch_leaders.h
@@ -28,7 +28,6 @@ struct fd_multi_epoch_leaders_priv {
     ulong slot_cnt;
     ulong staked_cnt;
     ulong excluded_stake;
-    ulong vote_keyed_lsched;
   } scratch[1];
 
   _lsched_t _lsched[MULTI_EPOCH_LEADERS_EPOCH_CNT];

--- a/src/flamenco/leaders/test_leaders.c
+++ b/src/flamenco/leaders/test_leaders.c
@@ -15,8 +15,6 @@ static uchar leaders_buf[
   FD_EPOCH_LEADERS_FOOTPRINT( 3373UL, 432000UL )
 ] __attribute__((aligned(FD_EPOCH_LEADERS_ALIGN)));
 
-const ulong vote_keyed_lsched = 0UL;
-
 int
 main( int     argc,
       char ** argv ) {
@@ -40,7 +38,7 @@ main( int     argc,
   fd_pubkey_t       const * leaders_pubkeys = (fd_pubkey_t       const *)e454_leaders_pubkeys;
   uint              const * leaders_idx     = (uint              const *)e454_leaders_idx;
 
-  FD_TEST( leaders_buf == fd_epoch_leaders_new( leaders_buf, 454UL, slot0, 432000UL, pub_cnt, stakes, 0UL, vote_keyed_lsched ) );
+  FD_TEST( leaders_buf == fd_epoch_leaders_new( leaders_buf, 454UL, slot0, 432000UL, pub_cnt, stakes, 0UL ) );
   fd_epoch_leaders_t * leaders = fd_epoch_leaders_join( leaders_buf );
   FD_TEST( leaders );
 
@@ -60,7 +58,7 @@ main( int     argc,
   ulong shortlist_cnt = pub_cnt/2UL;
   ulong excluded_stake = 0UL;
   for( ulong i=shortlist_cnt; i<pub_cnt; i++ ) excluded_stake += stakes[ i ].stake;
-  FD_TEST( leaders_buf == fd_epoch_leaders_new( leaders_buf, 454UL, slot0, 432000UL, shortlist_cnt, stakes, excluded_stake, vote_keyed_lsched ) );
+  FD_TEST( leaders_buf == fd_epoch_leaders_new( leaders_buf, 454UL, slot0, 432000UL, shortlist_cnt, stakes, excluded_stake ) );
   leaders = fd_epoch_leaders_join( leaders_buf );
   FD_TEST( leaders );
 

--- a/src/flamenco/leaders/test_multi_leaders.c
+++ b/src/flamenco/leaders/test_multi_leaders.c
@@ -20,7 +20,6 @@ generate_stake_msg( uchar *      _buf,
   buf->slot_cnt       = SLOTS_PER_EPOCH;
   buf->staked_cnt     = strlen(stakers);
   buf->excluded_stake = 0UL;
-  buf->vote_keyed_lsched = 0UL;
 
   ulong i = 0UL;
   for(; *stakers; stakers++, i++ ) {
@@ -232,12 +231,11 @@ test_limits( void ) {
 
   for( ulong stake_weight_cnt=MAX_STAKED_LEADERS-2; stake_weight_cnt<=MAX_STAKED_LEADERS+2; stake_weight_cnt++ ) {
     fd_stake_weight_msg_t * buf = fd_type_pun( stake_msg );
-    buf->epoch                  = stake_weight_cnt;
-    buf->start_slot             = stake_weight_cnt * SLOTS_PER_EPOCH;
-    buf->slot_cnt               = SLOTS_PER_EPOCH;
-    buf->staked_cnt             = 0UL;
-    buf->excluded_stake         = 0UL;
-    buf->vote_keyed_lsched      = 0UL;
+    buf->epoch          = stake_weight_cnt;
+    buf->start_slot     = stake_weight_cnt * SLOTS_PER_EPOCH;
+    buf->slot_cnt       = SLOTS_PER_EPOCH;
+    buf->staked_cnt     = 0UL;
+    buf->excluded_stake = 0UL;
 
     for( ulong i=0UL; i<stake_weight_cnt; i++ ) {
       ulong stake = 2000000000UL/(i+1UL);

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -76,43 +76,6 @@ fd_runtime_compute_max_tick_height( ulong   ticks_per_slot,
   return FD_RUNTIME_EXECUTE_SUCCESS;
 }
 
-/* Returns whether the specified epoch should use the new vote account
-   keyed leader schedule (returns 1) or the old validator identity keyed
-   leader schedule (returns 0). See SIMD-0180.  This is the analogous to
-   Agave's Bank::should_use_vote_keyed_leader_schedule():
-   https://github.com/anza-xyz/agave/blob/v2.3.1/runtime/src/bank.rs#L6148 */
-
-static int
-fd_runtime_should_use_vote_keyed_leader_schedule( fd_bank_t * bank ) {
-  /* Agave uses an option type for their effective_epoch value. We
-     represent None as ULONG_MAX and Some(value) as the value.
-     https://github.com/anza-xyz/agave/blob/v2.3.1/runtime/src/bank.rs#L6149-L6165 */
-  if( FD_FEATURE_ACTIVE_BANK( bank, enable_vote_address_leader_schedule ) ) {
-    /* Return the first epoch if activated at genesis
-       https://github.com/anza-xyz/agave/blob/v2.3.1/runtime/src/bank.rs#L6153-L6157 */
-    ulong activation_slot = fd_bank_features_query( bank )->enable_vote_address_leader_schedule;
-    if( activation_slot==0UL ) return 1; /* effective_epoch=0, current_epoch >= effective_epoch always true */
-
-    /* Calculate the epoch that the feature became activated in
-       https://github.com/anza-xyz/agave/blob/v2.3.1/runtime/src/bank.rs#L6159-L6160 */
-    fd_epoch_schedule_t const * epoch_schedule = fd_bank_epoch_schedule_query( bank );
-    ulong activation_epoch = fd_slot_to_epoch( epoch_schedule, activation_slot, NULL );
-
-    /* The effective epoch is the epoch immediately after the activation
-       epoch.
-       https://github.com/anza-xyz/agave/blob/v2.3.1/runtime/src/bank.rs#L6162-L6164 */
-    ulong effective_epoch = activation_epoch + 1UL;
-    ulong current_epoch   = fd_bank_epoch_get( bank );
-
-    /* https://github.com/anza-xyz/agave/blob/v2.3.1/runtime/src/bank.rs#L6167-L6170 */
-    return !!( current_epoch >= effective_epoch );
-  }
-
-  /* ...The rest of the logic in this function either returns None or
-     Some(false) so we will just return 0 by default. */
-  return 0;
-}
-
 void
 fd_runtime_update_leaders( fd_bank_t *          bank,
                            fd_runtime_stack_t * runtime_stack ) {
@@ -130,18 +93,29 @@ fd_runtime_update_leaders( fd_bank_t *          bank,
 
   /* TODO: Can optimize by avoiding recomputing if another fork has
      already computed them for this epoch. */
-  void * epoch_leaders_mem = fd_bank_epoch_leaders_modify( bank );
-  fd_epoch_leaders_t * leaders = fd_epoch_leaders_join( fd_epoch_leaders_new(
-      epoch_leaders_mem,
-      epoch,
-      slot0,
-      slot_cnt,
-      stake_weight_cnt,
-      epoch_weights,
-      0UL,
-      (ulong)fd_runtime_should_use_vote_keyed_leader_schedule( bank ) ) );
-  if( FD_UNLIKELY( !leaders ) ) {
-    FD_LOG_ERR(( "Unable to init and join fd_epoch_leaders" ));
+
+  /* Derive leader schedule */
+  ulong epoch_leaders_footprint = fd_epoch_leaders_footprint( stake_weight_cnt, slot_cnt );
+  if( FD_LIKELY( epoch_leaders_footprint ) ) {
+    if( FD_UNLIKELY( stake_weight_cnt>MAX_PUB_CNT ) ) {
+      FD_LOG_ERR(( "Stake weight count exceeded max" ));
+    }
+    if( FD_UNLIKELY( slot_cnt>MAX_SLOTS_PER_EPOCH ) ) {
+      FD_LOG_ERR(( "Slot count exceeeded max" ));
+    }
+
+    void * epoch_leaders_mem = fd_bank_epoch_leaders_modify( bank );
+    fd_epoch_leaders_t * leaders = fd_epoch_leaders_join( fd_epoch_leaders_new(
+        epoch_leaders_mem,
+        epoch,
+        slot0,
+        slot_cnt,
+        stake_weight_cnt,
+        epoch_weights,
+        0UL ) );
+    if( FD_UNLIKELY( !leaders ) ) {
+      FD_LOG_ERR(( "Unable to init and join fd_epoch_leaders" ));
+    }
   }
 }
 


### PR DESCRIPTION
Now that `enable_vote_address_leader_schedule` is active on all clusters we don't need this logic anymore. Corresponding Agave 4.0 PR: https://github.com/anza-xyz/agave/pull/10150