### PR TITLE
runtime: harden feature activation logic

### DIFF
--- a/src/flamenco/features/fd_features.h
+++ b/src/flamenco/features/fd_features.h
@@ -31,6 +31,12 @@
 #define FD_FEATURE_ACTIVE_BANK_OFFSET(_bank, _offset)                     FD_FEATURE_ACTIVE_OFFSET_( fd_bank_slot_get( _bank ), fd_bank_features_query( _bank ), _offset )
 #define FD_FEATURE_JUST_ACTIVATED_BANK(_bank, _feature_name)              FD_FEATURE_JUST_ACTIVATED_( fd_bank_slot_get( _bank ), fd_bank_features_query( _bank ), _feature_name )
 
+struct __attribute__((packed)) fd_feature {
+  uchar is_active;  /* 0 or 1 */
+  ulong activation_slot;
+};
+
+typedef struct fd_feature fd_feature_t;
 
 /* fd_features_t is the current set of enabled feature flags.
 
@@ -69,6 +75,11 @@ struct fd_feature_id {
 typedef struct fd_feature_id fd_feature_id_t;
 
 FD_PROTOTYPES_BEGIN
+
+fd_feature_t *
+fd_feature_decode( fd_feature_t * feature,
+                   uchar const *  data,
+                   ulong          data_sz );
 
 /* fd_feature_ids is the list of known feature IDs.
    The last element has offset==ULONG_MAX. */

--- a/src/flamenco/types/fd_types.c
+++ b/src/flamenco/types/fd_types.c
@@ -8,69 +8,6 @@
 #endif
 #define SOURCE_fd_src_flamenco_types_fd_types_c
 #include "fd_types_custom.h"
-int fd_feature_encode( fd_feature_t const * self, fd_bincode_encode_ctx_t * ctx ) {
-  int err;
-  err = fd_bincode_bool_encode( self->has_activated_at, ctx );
-  if( FD_UNLIKELY( err ) ) return err;
-  if( self->has_activated_at ) {
-    err = fd_bincode_uint64_encode( self->activated_at, ctx );
-    if( FD_UNLIKELY( err ) ) return err;
-  }
-  return FD_BINCODE_SUCCESS;
-}
-static int fd_feature_decode_footprint_inner( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
-  if( ctx->data>=ctx->dataend ) { return FD_BINCODE_ERR_OVERFLOW; };
-  int err = 0;
-  {
-    uchar o;
-    err = fd_bincode_bool_decode( &o, ctx );
-    if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
-    if( o ) {
-      err = fd_bincode_uint64_decode_footprint( ctx );
-      if( FD_UNLIKELY( err!=FD_BINCODE_SUCCESS ) ) return err;
-    }
-  }
-  return 0;
-}
-int fd_feature_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz ) {
-  *total_sz += sizeof(fd_feature_t);
-  void const * start_data = ctx->data;
-  int err = fd_feature_decode_footprint_inner( ctx, total_sz );
-  if( ctx->data>ctx->dataend ) { return FD_BINCODE_ERR_OVERFLOW; };
-  ctx->data = start_data;
-  return err;
-}
-static void fd_feature_decode_inner( void * struct_mem, void * * alloc_mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_feature_t * self = (fd_feature_t *)struct_mem;
-  {
-    uchar o;
-    fd_bincode_bool_decode_unsafe( &o, ctx );
-    self->has_activated_at = !!o;
-    if( o ) {
-      fd_bincode_uint64_decode_unsafe( &self->activated_at, ctx );
-    }
-  }
-}
-void * fd_feature_decode( void * mem, fd_bincode_decode_ctx_t * ctx ) {
-  fd_feature_t * self = (fd_feature_t *)mem;
-  fd_feature_new( self );
-  void * alloc_region = (uchar *)mem + sizeof(fd_feature_t);
-  void * * alloc_mem = &alloc_region;
-  fd_feature_decode_inner( mem, alloc_mem, ctx );
-  return self;
-}
-void fd_feature_new(fd_feature_t * self) {
-  fd_memset( self, 0, sizeof(fd_feature_t) );
-}
-ulong fd_feature_size( fd_feature_t const * self ) {
-  ulong size = 0;
-  size += sizeof(char);
-  if( self->has_activated_at ) {
-    size += sizeof(ulong);
-  }
-  return size;
-}
-
 int fd_fee_calculator_encode( fd_fee_calculator_t const * self, fd_bincode_encode_ctx_t * ctx ) {
   int err;
   err = fd_bincode_uint64_encode( self->lamports_per_signature, ctx );

--- a/src/flamenco/types/fd_types.h
+++ b/src/flamenco/types/fd_types.h
@@ -6,15 +6,6 @@
 #include "../../ballet/utf8/fd_utf8.h"
 #include "fd_types_custom.h"
 
-/* sdk/program/src/feature.rs#L22 */
-/* Encoded Size: Dynamic */
-struct fd_feature {
-  ulong activated_at;
-  uchar has_activated_at;
-};
-typedef struct fd_feature fd_feature_t;
-#define FD_FEATURE_ALIGN alignof(fd_feature_t)
-
 /* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/fee_calculator.rs#L9 */
 /* Encoded Size: Fixed (8 bytes) */
 struct fd_fee_calculator {
@@ -1540,13 +1531,6 @@ typedef struct fd_addrlut_instruction fd_addrlut_instruction_t;
 
 
 FD_PROTOTYPES_BEGIN
-
-void fd_feature_new( fd_feature_t * self );
-int fd_feature_encode( fd_feature_t const * self, fd_bincode_encode_ctx_t * ctx );
-ulong fd_feature_size( fd_feature_t const * self );
-static inline ulong fd_feature_align( void ) { return FD_FEATURE_ALIGN; }
-int fd_feature_decode_footprint( fd_bincode_decode_ctx_t * ctx, ulong * total_sz );
-void * fd_feature_decode( void * mem, fd_bincode_decode_ctx_t * ctx );
 
 static inline void fd_fee_calculator_new( fd_fee_calculator_t * self ) { fd_memset( self, 0, sizeof(fd_fee_calculator_t) ); }
 int fd_fee_calculator_encode( fd_fee_calculator_t const * self, fd_bincode_encode_ctx_t * ctx );

--- a/src/flamenco/types/fd_types.json
+++ b/src/flamenco/types/fd_types.json
@@ -21,14 +21,6 @@
       "agave": "solana_pubkey::Pubkey"
     },
     {
-      "name": "feature",
-      "type": "struct",
-      "fields": [
-        { "name": "activated_at", "type": "option", "element": "ulong", "flat": true }
-      ],
-      "comment": "sdk/program/src/feature.rs#L22"
-    },
-    {
       "name": "fee_calculator",
       "type": "struct",
       "fields": [


### PR DESCRIPTION
- Only consider accounts owned by the feature program for
  activation (fixes a stray FD_LOG_WARNING for account
  9LZdXeKGeBV6hRLdxS1rHbHoEUsKqesCC2ZAPTPKJAbK, which was
  initialized a year ago, but is still owned by the system
  program)
- Do not crash with FD_LOG_CRIT if the feature account is too
  small to activate, log a warning instead
- Simplify serialization logic