### PR TITLE
runtime: fix dead write to exec_start_timestamp

### DIFF
--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -1344,8 +1344,6 @@ fd_runtime_prepare_and_execute_txn( fd_runtime_t *       runtime,
      fees-only, we return early. */
   txn_out->err.txn_err = fd_runtime_pre_execute_check( runtime, bank, txn_in, txn_out );
 
-  txn_out->details.exec_start_timestamp = fd_tickcount();
-
   /* Execute the transaction if eligible to do so. */
   if( FD_LIKELY( txn_out->err.is_committable ) ) {
     if( FD_LIKELY( !txn_out->err.is_fees_only ) ) {


### PR DESCRIPTION
the write in fd_runtime_pre_execute_check makes more sense, also given early returns