### PR TITLE
chore(forest): remove deprecated root warning

### DIFF
--- a/src/discof/forest/fd_forest.c
+++ b/src/discof/forest/fd_forest.c
@@ -799,13 +799,6 @@ fd_forest_publish( fd_forest_t * forest, ulong new_root_slot ) {
   fd_forest_blk_t * old_root_ele = fd_forest_pool_ele( pool, forest->root );
   fd_forest_blk_t * new_root_ele = query( forest, new_root_slot );
 
-# if FD_FOREST_USE_HANDHOLDING
-  if( FD_UNLIKELY( new_root_ele && new_root_ele->slot <= old_root_ele->slot ) ) {
-    FD_LOG_WARNING(( "tower sent us a root %lu older than forest root %lu", new_root_ele->slot, old_root_ele->slot ));
-    return NULL;
-  }
-# endif
-
   /* As an unfortunate side effect of maintaining forest slots in such
      a fine-grained way, and also the possibility we can publish forwards
      and backwards non-monotically, we have to consider every possible case of

--- a/src/discof/repair/fd_repair_tile.c
+++ b/src/discof/repair/fd_repair_tile.c
@@ -768,7 +768,7 @@ after_frag( ctx_t * ctx,
   if( FD_UNLIKELY( in_kind==IN_KIND_TOWER ) ) {
     if( FD_LIKELY( sig==FD_TOWER_SIG_SLOT_DONE ) ) {
       fd_tower_slot_done_t const * msg = (fd_tower_slot_done_t const *)fd_type_pun_const( ctx->buffer );
-      if( FD_LIKELY( msg->root_slot!=ULONG_MAX ) ) fd_forest_publish( ctx->forest, msg->root_slot );
+      if( FD_LIKELY( msg->root_slot!=ULONG_MAX && msg->root_slot > fd_forest_root_slot( ctx->forest ) ) ) fd_forest_publish( ctx->forest, msg->root_slot );
     }
     return;
   }


### PR DESCRIPTION
tower tile now guarantees contiguous monotonically increasing root publishes