### PR TITLE
vm: use ristretto255 type for ristretto op

### DIFF
--- a/src/flamenco/vm/syscall/fd_vm_syscall_curve.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_curve.c
@@ -487,7 +487,7 @@ multi_scalar_mul_edwards( fd_ed25519_point_t * r,
 /* multi_scalar_mul_ristretto computes a MSM on ristretto255.
    See multi_scalar_mul_edwards for details. */
 
-static fd_ed25519_point_t *
+static fd_ristretto255_point_t *
 multi_scalar_mul_ristretto( fd_ristretto255_point_t * r,
                             uchar const *             scalars,
                             uchar const *             points,


### PR DESCRIPTION
not a functional bug, since they are typedefed to the same type