### PR TITLE
Return errno only when connect() indicates failure

### DIFF
--- a/src/disco/bundle/fd_bundle_client.c
+++ b/src/disco/bundle/fd_bundle_client.c
@@ -76,7 +76,7 @@ fd_bundle_client_do_connect( fd_bundle_tile_t const * ctx,
   int err = connect( ctx->tcp_sock, fd_type_pun_const( &addr ), sizeof(struct sockaddr_in) );
   /* FD_LIKELY is used here as EINPROGRESS is expected even to local tcp ports */
   if( FD_LIKELY( err==-1 ) ) {
-      return errno;
+    return errno;
   }
   return 0;
 }


### PR DESCRIPTION
Only return `errno` on failure, the man page says:
> The value in errno is significant only when the return value of the call indicated an error; a function that succeeds is allowed to change errno.

So the `connect()` call may succeed but set `errno` (which should be ignored) while the caller would wrongly detect an error.

Also changed `FD_UNLIKELY` to `FD_LIKELY` as from local testing `connect()` generally returns `EINPROGRESS` to non-blocking tcp sockets even to local ports.