### PR TITLE
runtime: remove unused and buggy fd_instr_info_accumulate_starting_la…

### DIFF
--- a/src/flamenco/runtime/info/fd_instr_info.c
+++ b/src/flamenco/runtime/info/fd_instr_info.c
@@ -3,22 +3,6 @@
 #include "../../../util/bits/fd_uwide.h"
 
 void
-fd_instr_info_accumulate_starting_lamports( fd_instr_info_t * instr,
-                                            fd_txn_out_t *    txn_out,
-                                            ushort            idx_in_callee,
-                                            ushort            idx_in_txn ) {
-  if( FD_LIKELY( !instr->is_duplicate[ idx_in_callee ] ) ) {
-    fd_accdb_rw_t const * ref = &txn_out->accounts.account[ idx_in_txn ];
-    if( ref ) {
-      fd_uwide_inc(
-        &instr->starting_lamports_h, &instr->starting_lamports_l,
-        instr->starting_lamports_h, instr->starting_lamports_l,
-        fd_accdb_ref_lamports( ref->ro ) );
-    }
-  }
-}
-
-void
 fd_instr_info_init_from_txn_instr( fd_instr_info_t *      instr,
                                    fd_bank_t *            bank,
                                    fd_txn_in_t const *    txn_in,

--- a/src/flamenco/runtime/info/fd_instr_info.h
+++ b/src/flamenco/runtime/info/fd_instr_info.h
@@ -85,17 +85,6 @@ fd_instr_info_setup_instr_account( fd_instr_info_t * instr,
                                                                   is_signer );
 }
 
-/* fd_instr_info_accumulate_starting_lamports accumulates the starting lamports fields
-   when setting up an fd_instr_info_t object.
-   Note that the caller must zero out the starting lamports fields in fd_instr_info_t
-   beforehand. */
-
-void
-fd_instr_info_accumulate_starting_lamports( fd_instr_info_t * instr,
-                                            fd_txn_out_t *    txn_out,
-                                            ushort            idx_in_callee,
-                                            ushort            idx_in_txn );
-
 void
 fd_instr_info_init_from_txn_instr( fd_instr_info_t *      instr,
                                    fd_bank_t *            bank,


### PR DESCRIPTION
…mports

the function does a null check on a reference it just got with &, this can never be null