### PR TITLE
flamenco: remove dead check

### DIFF
--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -1670,9 +1670,7 @@ fd_executor_txn_check( fd_runtime_t * runtime,
         }
       }
 
-      if( starting_lamports != ULONG_MAX ) {
-        fd_uwide_inc( &starting_lamports_h, &starting_lamports_l, starting_lamports_h, starting_lamports_l, starting_lamports );
-      }
+      fd_uwide_inc( &starting_lamports_h, &starting_lamports_l, starting_lamports_h, starting_lamports_l, starting_lamports );
     }
   }
 


### PR DESCRIPTION
non existing accounts should have the value 0 in the newer accountsdb implementation.