### PR TITLE
runtime: remove FD_PURE on func writing out params

### DIFF
--- a/src/flamenco/runtime/info/fd_instr_info.h
+++ b/src/flamenco/runtime/info/fd_instr_info.h
@@ -125,7 +125,7 @@ fd_instr_acc_is_writable_idx( fd_instr_info_t const * instr,
       if the account is a signer.
 
   https://github.com/anza-xyz/agave/blob/v3.0.3/transaction-context/src/lib.rs#L770-L779    */
-FD_FN_PURE static inline int
+static inline int
 fd_instr_acc_is_signer_idx( fd_instr_info_t const * instr,
                             ushort                  idx,
                             int *                   out_opt_err ) {


### PR DESCRIPTION
https://github.com/firedancer-io/firedancer/blob/e83d7465918c0d58e9e14c134b8fc226f5d61b5b/src/util/fd_util_base.h#L596-L605 documents that these functions should not be pure