### PR TITLE
gui: refactor late votes history

### DIFF
--- a/book/api/websocket.md
+++ b/book/api/websocket.md
@@ -1940,7 +1940,7 @@ immediately prior epoch.  Recent non-rooted slots may be included, and
 included skipped slots will not become unskipped as a later slot has
 rooted.
 
-#### `slot.vote_latency_history`
+#### `slot.late_votes_history`
 | frequency | type       | example |
 |-----------|------------|---------|
 | *Once*    | `number[]` | below   |
@@ -1950,7 +1950,7 @@ late or not at all. Specifically, the following slots are included
 - rooted slots with a vote latency > 1
 - rooted slots that were never voted for that were not skipped
 
-The slot and latency arrays are run-length encoded. For example
+The slot array is run-length encoded. For example
 
 ```
 [ a, b, c, d, e, f ]
@@ -1959,13 +1959,19 @@ The slot and latency arrays are run-length encoded. For example
 means that slots `[a, b]`, slots `[c, d]`, and slots `[e, f]` all
 recieved late or non-existent votes.
 
+The latency array is not run-length encoded. That means if the decoded
+slots array has `n` slots, then the length of `latency` will be `n`.
+
 :::details Example
 
 ```json
 {
 	"topic": "slot",
-	"key": "vote_latency_history",
-	"value": [286576808, 286576808, 286576810, 286576811, 286625025, 286625026]
+	"key": "late_votes_history",
+	"value": {
+        "slot": [286576808, 286576808, 286576810, 286576811, 286625025, 286625026],
+        "latency": [2, 3, null, 2, 2]
+    }
 }
 ```
 

--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -248,6 +248,8 @@ fd_gui_ws_open( fd_gui_t * gui,
     fd_gui_printf_live_tile_timers,
     fd_gui_printf_live_tile_metrics,
     fd_gui_printf_catch_up_history,
+    fd_gui_printf_vote_latency_history,
+    fd_gui_printf_late_votes_history
   };
 
   ulong printers_len = sizeof(printers) / sizeof(printers[0]);
@@ -255,9 +257,6 @@ fd_gui_ws_open( fd_gui_t * gui,
     printers[ i ]( gui );
     FD_TEST( !fd_http_server_ws_send( gui->http, ws_conn_id ) );
   }
-
-  fd_gui_printf_vote_latency_history( gui );
-  FD_TEST( !fd_http_server_ws_send( gui->http, ws_conn_id ) );
 
   if( FD_LIKELY( gui->block_engine.has_block_engine ) ) {
     fd_gui_printf_block_engine( gui );

--- a/src/disco/gui/fd_gui_printf.c
+++ b/src/disco/gui/fd_gui_printf.c
@@ -453,6 +453,7 @@ fd_gui_printf_skipped_history_cluster( fd_gui_t * gui ) {
   jsonp_close_envelope( gui->http );
 }
 
+/* TODO: deprecated */
 void
 fd_gui_printf_vote_latency_history( fd_gui_t * gui ) {
   jsonp_open_envelope( gui->http, "slot", "vote_latency_history" );
@@ -460,6 +461,29 @@ fd_gui_printf_vote_latency_history( fd_gui_t * gui ) {
         FD_TEST( gui->summary.late_votes_sz % 2UL == 0UL );
         for( ulong i=0UL; i<gui->summary.late_votes_sz; i++ ) jsonp_ulong( gui->http, NULL, gui->summary.late_votes[ i ] );
       jsonp_close_array( gui->http );
+  jsonp_close_envelope( gui->http );
+}
+
+void
+fd_gui_printf_late_votes_history( fd_gui_t * gui ) {
+  jsonp_open_envelope( gui->http, "slot", "late_votes_history" );
+      jsonp_open_object( gui->http, "value" );
+        jsonp_open_array( gui->http, "slot" );
+          for( ulong i=0UL; i<gui->summary.late_votes_sz; i++ ) jsonp_ulong( gui->http, NULL, gui->summary.late_votes[ i ] );
+        jsonp_close_array( gui->http );
+        jsonp_open_array( gui->http, "latency" );
+          for( long i=0UL; i<(long)gui->summary.late_votes_sz-1L; i++ ) {
+            FD_TEST( (ulong)i+1<gui->summary.late_votes_sz );
+            ulong s = gui->summary.late_votes[ i ];
+            ulong s2 = gui->summary.late_votes[ i + 1 ];
+            for( ulong j=s; j<=fd_ulong_min( s2, s+FD_GUI_SLOTS_CNT ); j++ ) {
+              fd_gui_slot_t * slot = fd_gui_get_slot( gui, j );
+              if( FD_UNLIKELY( slot && slot->vote_latency!=UCHAR_MAX ) ) jsonp_ulong( gui->http, NULL, slot->vote_latency );
+              else                                                       jsonp_null( gui->http, NULL );
+            }
+          }
+        jsonp_close_array( gui->http );
+      jsonp_close_object( gui->http );
   jsonp_close_envelope( gui->http );
 }
 

--- a/src/disco/gui/fd_gui_printf.h
+++ b/src/disco/gui/fd_gui_printf.h
@@ -22,6 +22,7 @@ void fd_gui_printf_slot_caught_up( fd_gui_t * gui );
 void fd_gui_printf_skipped_history( fd_gui_t * gui );
 void fd_gui_printf_skipped_history_cluster( fd_gui_t * gui );
 void fd_gui_printf_vote_latency_history( fd_gui_t * gui );
+void fd_gui_printf_late_votes_history( fd_gui_t * gui );
 void fd_gui_printf_tps_history( fd_gui_t * gui );
 void fd_gui_printf_startup_progress( fd_gui_t * gui );
 void fd_gui_printf_boot_progress( fd_gui_t * gui );


### PR DESCRIPTION
At the moment, vote latencies in the frontend count skipped slots towards the latency calculation.

This PR will help the frontend discount those skipped slots so we show the true latency.

Eventually, we will do this discounting in the backend. This requires a not huge but not small amount of work to track latencies in a fork-aware manner (since a single fork event will potentially change many historical vote latencies). Since this discounting would be trivial to support in the frontend at render time, we'll just fix it there in the meantime.