### PR TITLE
restore: vinyl admin obj (status and wr_seq)

### DIFF
--- a/src/app/firedancer-dev/commands/backtest.c
+++ b/src/app/firedancer-dev/commands/backtest.c
@@ -150,6 +150,7 @@ backtest_topo( config_t * config ) {
         fd_topob_wksp( topo, "snaplv"    );
         FOR(snaplh_tile_cnt) fd_topob_tile( topo, "snaplh", "snaplh", "metric_in", ULONG_MAX, 0, 0 )->allow_shutdown = 1;
         /**/                 fd_topob_tile( topo, "snaplv", "snaplv", "metric_in", ULONG_MAX, 0, 0 )->allow_shutdown = 1;
+        fd_topob_wksp( topo, "vinyl_admin" );
       } else {
         fd_topob_wksp( topo, "snapla" );
         fd_topob_wksp( topo, "snapls" );
@@ -205,7 +206,6 @@ backtest_topo( config_t * config ) {
         fd_topob_wksp( topo, "snaplh_lv" );
         fd_topob_wksp( topo, "snapwm_lv" );
         fd_topob_wksp( topo, "snaplv_ct" );
-        fd_topob_wksp( topo, "snaplv_wr" );
       } else {
         fd_topob_wksp( topo, "snapla_ls" );
         fd_topob_wksp( topo, "snapin_ls" );
@@ -250,7 +250,6 @@ backtest_topo( config_t * config ) {
         /**/                 fd_topob_link( topo, "snapwm_lv",  "snapwm_lv",  32768UL, FD_SNAPWM_DUP_META_BATCH_SZ,     1UL );
         /**/                 fd_topob_link( topo, "snaplv_lh",  "snaplv_lh", 262144UL,       FD_SNAPLV_DUP_META_SZ, FD_SNAPLV_STEM_BURST ); /* FD_SNAPWM_DUP_META_BATCH_CNT_MAX times the depth of snapwm_lv */
         /**/                 fd_topob_link( topo, "snaplv_ct",  "snaplv_ct",    128UL,                         0UL,     1UL );
-        /**/                 fd_topob_link( topo, "snaplv_wr",  "snaplv_wr",    128UL,                         0UL,     1UL ); /* no dcache, only mcache fseq is used on this link. */
       } else {
         FOR(lta_tile_cnt) fd_topob_link( topo, "snapla_ls",  "snapla_ls",   128UL,  sizeof(fd_lthash_value_t),          1UL );
         /**/              fd_topob_link( topo, "snapin_ls",  "snapin_ls",   256UL,  sizeof(fd_snapshot_full_account_t), 1UL );
@@ -313,11 +312,15 @@ backtest_topo( config_t * config ) {
         FOR(snaplh_tile_cnt) fd_topob_tile_out( topo, "snaplh", i,                "snaplh_lv",  i                                         );
         /**/                 fd_topob_tile_in ( topo, "snaplv", 0UL, "metric_in", "snapwm_lv",  0UL, FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
         FOR(snaplh_tile_cnt) fd_topob_tile_in ( topo, "snaplv", 0UL, "metric_in", "snaplh_lv",  i,   FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-        /**/                 fd_topob_tile_out( topo, "snaplv", 0UL,              "snaplv_wr",  0UL                                       );
-        FOR(snapwr_tile_cnt) fd_topob_tile_in ( topo, "snapwr", i,   "metric_in", "snaplv_wr",  0UL, FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
         /**/                 fd_topob_tile_out( topo, "snaplv", 0UL,              "snaplv_ct",  0UL                                       );
         /**/                 fd_topob_tile_out( topo, "snapwm", 0UL,              "snapwm_lv",  0UL                                       );
-        FOR(snapwr_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snapwr", i ) ], &topo->objs[ topo->links[ fd_topo_find_link( topo, "snaplv_wr", 0UL ) ].mcache_obj_id ], FD_SHMEM_JOIN_MODE_READ_WRITE );
+
+        fd_topo_obj_t * vinyl_admin_obj = setup_topo_vinyl_admin( topo, "vinyl_admin" );
+        /**/                 fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snapwm", 0UL ) ], vinyl_admin_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+        FOR(snapwr_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snapwr", i   ) ], vinyl_admin_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+        /**/                 fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snaplv", 0UL ) ], vinyl_admin_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+        FOR(snaplh_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snaplh", i   ) ], vinyl_admin_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+        FD_TEST( fd_pod_insertf_ulong( topo->props, vinyl_admin_obj->id, "vinyl_admin" ) );
       } else {
         FOR(lta_tile_cnt)    fd_topob_tile_in ( topo, "snapla", i,   "metric_in", "snapdc_in",  0UL, FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
         FOR(lta_tile_cnt)    fd_topob_tile_out( topo, "snapla", i,                "snapla_ls",  i                                         );

--- a/src/app/firedancer-dev/commands/snapshot_load.c
+++ b/src/app/firedancer-dev/commands/snapshot_load.c
@@ -126,11 +126,11 @@ snapshot_load_topo( config_t * config ) {
       fd_topob_wksp( topo, "snaplv"    );
       FOR(snaplh_tile_cnt) fd_topob_tile( topo, "snaplh", "snaplh", "metric_in", ULONG_MAX, 0, 0 )->allow_shutdown = 1;
       /**/                 fd_topob_tile( topo, "snaplv", "snaplv", "metric_in", ULONG_MAX, 0, 0 )->allow_shutdown = 1;
+      fd_topob_wksp( topo, "vinyl_admin" );
       fd_topob_wksp( topo, "snaplv_lh" );
       fd_topob_wksp( topo, "snaplh_lv" );
       fd_topob_wksp( topo, "snapwm_lv" );
       fd_topob_wksp( topo, "snaplv_ct" );
-      fd_topob_wksp( topo, "snaplv_wr" );
     } else {
       fd_topob_wksp( topo, "snapla"    );
       fd_topob_wksp( topo, "snapls"    );
@@ -179,7 +179,6 @@ snapshot_load_topo( config_t * config ) {
       /**/                 fd_topob_link( topo, "snapwm_lv",  "snapwm_lv",  32768UL, FD_SNAPWM_DUP_META_BATCH_SZ,     1UL );
       /**/                 fd_topob_link( topo, "snaplv_lh",  "snaplv_lh", 262144UL,       FD_SNAPLV_DUP_META_SZ, FD_SNAPLV_STEM_BURST ); /* FD_SNAPWM_DUP_META_BATCH_CNT_MAX times the depth of snapwm_lv */
       /**/                 fd_topob_link( topo, "snaplv_ct",  "snaplv_ct",    128UL,                         0UL,     1UL );
-      /**/                 fd_topob_link( topo, "snaplv_wr",  "snaplv_wr",    128UL,                         0UL,     1UL ); /* no dcache, only mcache fseq is used on this link. */
     } else {
       FOR(lta_tile_cnt) fd_topob_link( topo, "snapla_ls",  "snapla_ls",   128UL,  sizeof(fd_lthash_value_t),          1UL );
       /**/              fd_topob_link( topo, "snapin_ls",  "snapin_ls",   256UL,  sizeof(fd_snapshot_full_account_t), 1UL );
@@ -241,11 +240,15 @@ snapshot_load_topo( config_t * config ) {
       FOR(snaplh_tile_cnt) fd_topob_tile_out( topo, "snaplh", i,                "snaplh_lv",  i                                         );
       /**/                 fd_topob_tile_in ( topo, "snaplv", 0UL, "metric_in", "snapwm_lv",  0UL, FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
       FOR(snaplh_tile_cnt) fd_topob_tile_in ( topo, "snaplv", 0UL, "metric_in", "snaplh_lv",  i,   FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-      /**/                 fd_topob_tile_out( topo, "snaplv", 0UL,              "snaplv_wr",  0UL                                       );
-      FOR(snapwr_tile_cnt) fd_topob_tile_in ( topo, "snapwr", i,   "metric_in", "snaplv_wr",  0UL, FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
       /**/                 fd_topob_tile_out( topo, "snaplv", 0UL,              "snaplv_ct",  0UL                                       );
       /**/                 fd_topob_tile_out( topo, "snapwm", 0UL,              "snapwm_lv",  0UL                                       );
-      FOR(snapwr_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snapwr", i ) ], &topo->objs[ topo->links[ fd_topo_find_link( topo, "snaplv_wr", 0UL ) ].mcache_obj_id ], FD_SHMEM_JOIN_MODE_READ_WRITE );
+
+      fd_topo_obj_t * vinyl_admin_obj = setup_topo_vinyl_admin( topo, "vinyl_admin" );
+      /**/                 fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snapwm", 0UL ) ], vinyl_admin_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+      FOR(snapwr_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snapwr", i   ) ], vinyl_admin_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+      /**/                 fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snaplv", 0UL ) ], vinyl_admin_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+      FOR(snaplh_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snaplh", i   ) ], vinyl_admin_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+      FD_TEST( fd_pod_insertf_ulong( topo->props, vinyl_admin_obj->id, "vinyl_admin" ) );
     } else {
       FOR(lta_tile_cnt) fd_topob_tile_in ( topo, "snapla", i,   "metric_in", "snapdc_in",  0UL, FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
       FOR(lta_tile_cnt) fd_topob_tile_out( topo, "snapla", i,                "snapla_ls",  i                                         );

--- a/src/app/firedancer-dev/main.c
+++ b/src/app/firedancer-dev/main.c
@@ -32,6 +32,7 @@ extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_data;
 extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_req_pool;
 extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_rq;
 extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_cq;
+extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_admin;
 
 fd_topo_obj_callbacks_t * CALLBACKS[] = {
   &fd_obj_cb_mcache,
@@ -57,6 +58,7 @@ fd_topo_obj_callbacks_t * CALLBACKS[] = {
   &fd_obj_cb_vinyl_req_pool,
   &fd_obj_cb_vinyl_rq,
   &fd_obj_cb_vinyl_cq,
+  &fd_obj_cb_vinyl_admin,
   NULL,
 };
 

--- a/src/app/firedancer/callbacks_vinyl.c
+++ b/src/app/firedancer/callbacks_vinyl.c
@@ -1,5 +1,6 @@
 #include "../../vinyl/fd_vinyl.h"
 #include "../../disco/topo/fd_topo.h"
+#include "../../discof/restore/utils/fd_vinyl_admin.h"
 #include "../../flamenco/accdb/fd_vinyl_req_pool.h"
 #include "../../util/pod/fd_pod_format.h"
 
@@ -196,3 +197,30 @@ fd_topo_obj_callbacks_t fd_obj_cb_vinyl_cq = {
   .align     = vinyl_cq_align,
   .new       = vinyl_cq_new,
 };
+
+static ulong
+vinyl_admin_footprint( fd_topo_t const *     topo FD_PARAM_UNUSED,
+                       fd_topo_obj_t const * obj FD_PARAM_UNUSED ) {
+  return sizeof(fd_vinyl_admin_t);
+}
+
+static ulong
+vinyl_admin_align( fd_topo_t const *     topo FD_PARAM_UNUSED,
+                   fd_topo_obj_t const * obj FD_PARAM_UNUSED ) {
+  return alignof(fd_vinyl_admin_t);
+}
+
+static void
+vinyl_admin_new( fd_topo_t const *     topo,
+                 fd_topo_obj_t const * obj ) {
+  fd_vinyl_admin_new( fd_topo_obj_laddr( topo, obj->id ) );
+}
+
+fd_topo_obj_callbacks_t fd_obj_cb_vinyl_admin = {
+  .name      = "vinyl_admin",
+  .footprint = vinyl_admin_footprint,
+  .align     = vinyl_admin_align,
+  .new       = vinyl_admin_new,
+};
+
+#undef VAL

--- a/src/app/firedancer/main.c
+++ b/src/app/firedancer/main.c
@@ -29,6 +29,7 @@ extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_data;
 extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_req_pool;
 extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_rq;
 extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_cq;
+extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_admin;
 
 fd_topo_obj_callbacks_t * CALLBACKS[] = {
   &fd_obj_cb_mcache,
@@ -54,6 +55,7 @@ fd_topo_obj_callbacks_t * CALLBACKS[] = {
   &fd_obj_cb_vinyl_req_pool,
   &fd_obj_cb_vinyl_rq,
   &fd_obj_cb_vinyl_cq,
+  &fd_obj_cb_vinyl_admin,
   NULL,
 };
 

--- a/src/app/firedancer/topology.h
+++ b/src/app/firedancer/topology.h
@@ -62,6 +62,10 @@ fd_topo_obj_t *
 setup_topo_accdb_cache( fd_topo_t *    topo,
                         fd_configf_t * config );
 
+fd_topo_obj_t *
+setup_topo_vinyl_admin( fd_topo_t *  topo,
+                        char const * wksp_name );
+
 void
 fd_topo_configure_tile( fd_topo_tile_t * tile,
                         fd_config_t *    config );

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -580,16 +580,17 @@ struct fd_topo_tile {
     } snapin;
 
     struct {
-      uint  lthash_disabled : 1;
       ulong vinyl_meta_map_obj_id;
       ulong vinyl_meta_pool_obj_id;
       ulong snapwr_depth;
       char  vinyl_path[ PATH_MAX ];
+      uint  lthash_disabled : 1;
     } snapwm;
 
     struct {
       ulong dcache_obj_id;
       char  vinyl_path[ PATH_MAX ];
+      uint  lthash_disabled : 1;
     } snapwr;
 
     struct {

--- a/src/discof/restore/Local.mk
+++ b/src/discof/restore/Local.mk
@@ -47,6 +47,8 @@ endif
 $(call add-objs,utils/fd_ssarchive,fd_discof)
 $(call add-objs,utils/fd_sspeer_selector,fd_discof)
 $(call add-objs,utils/fd_vinyl_io_wd,fd_discof)
+$(call add-objs,utils/fd_vinyl_admin,fd_discof)
+$(call make-unit-test,test_vinyl_admin,utils/test_vinyl_admin,fd_discof fd_flamenco fd_ballet fd_util)
 
 ifdef FD_HAS_HOSTED
 ifdef FD_HAS_ZSTD

--- a/src/discof/restore/fd_snaplh_tile.seccomppolicy
+++ b/src/discof/restore/fd_snaplh_tile.seccomppolicy
@@ -30,3 +30,9 @@ io_uring_enter: (eq (arg 0) ring_fd)
 
 # io: bd pread (when io_uring is unavailable or disabled).
 pread64: (eq (arg 0) bstream_fd)
+lseek: (eq (arg 0) bstream_fd)
+
+# fd_log_sleep: it requires a combination of these three syscalls.
+sched_yield:
+clock_nanosleep: (eq (arg 0) 0)
+nanosleep:

--- a/src/discof/restore/fd_snapwm_tile.c
+++ b/src/discof/restore/fd_snapwm_tile.c
@@ -170,6 +170,14 @@ handle_control_frag( fd_snapwm_tile_t *  ctx,
       }
       fd_snapwm_vinyl_wd_init( ctx );
 
+      /* There is a way to avoid a lock here: every other writer, in
+         particular the write tiles that update wr_seq, have already
+         finished processing all standing writes and are idle.  And
+         even though any read tile may see partial updates as they
+         occur, this all happens while they are idle waiting for the
+         init full/incr command. */
+      if( !!ctx->vinyl.admin ) fd_snapwm_vinyl_update_admin( ctx, 0/*do_rwlock*/ );
+
       /* Rewind metric counters (no-op unless recovering from a fail) */
       if( sig==FD_SNAPSHOT_MSG_CTRL_INIT_FULL ) {
         ctx->metrics.accounts_loaded   = ctx->metrics.full_accounts_loaded   = 0;

--- a/src/discof/restore/fd_snapwm_tile_private.h
+++ b/src/discof/restore/fd_snapwm_tile_private.h
@@ -6,6 +6,7 @@
 
 #include "utils/fd_slot_delta_parser.h"
 #include "utils/fd_ssparse.h"
+#include "utils/fd_vinyl_admin.h"
 #include "../../ballet/lthash/fd_lthash.h"
 #include "../../ballet/lthash/fd_lthash_adder.h"
 #include "../../disco/stem/fd_stem.h"
@@ -93,6 +94,9 @@ struct fd_snapwm_tile {
 
     fd_lthash_adder_t adder;
     fd_lthash_value_t running_lthash;
+
+    ulong              wr_cnt;
+    fd_vinyl_admin_t * admin;
   } vinyl;
 };
 
@@ -258,6 +262,18 @@ fd_snapwm_vinyl_duplicate_accounts_lthash_append( fd_snapwm_tile_t * ctx,
 int
 fd_snapwm_vinyl_duplicate_accounts_lthash_fini( fd_snapwm_tile_t *  ctx,
                                                 fd_stem_context_t * stem );
+
+/* fd_snapwm_vinyl_{init,update}_admin provide init and update helper
+   functions on the vinyl admin object.  do_rwlock is a flag indicating
+   whether the lock is required or not.  They return 1 on success and
+   0 otherwise. */
+int
+fd_snapwm_vinyl_init_admin( fd_snapwm_tile_t * ctx,
+                            int                do_rwlock );
+
+int
+fd_snapwm_vinyl_update_admin( fd_snapwm_tile_t * ctx,
+                              int                do_rwlock );
 
 FD_PROTOTYPES_END
 

--- a/src/discof/restore/generated/fd_snaplh_tile_seccomp.h
+++ b/src/discof/restore/generated/fd_snaplh_tile_seccomp.h
@@ -24,52 +24,70 @@
 #else
 # error "Target architecture is unsupported by seccomp."
 #endif
-static const unsigned int sock_filter_policy_fd_snaplh_tile_instr_cnt = 23;
+static const unsigned int sock_filter_policy_fd_snaplh_tile_instr_cnt = 31;
 
 static void populate_sock_filter_policy_fd_snaplh_tile( ulong out_cnt, struct sock_filter * out, unsigned int logfile_fd, unsigned int bstream_fd, unsigned int ring_fd ) {
-  FD_TEST( out_cnt >= 23 );
-  struct sock_filter filter[23] = {
+  FD_TEST( out_cnt >= 31 );
+  struct sock_filter filter[31] = {
     /* Check: Jump to RET_KILL_PROCESS if the script's arch != the runtime arch */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, ( offsetof( struct seccomp_data, arch ) ) ),
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, ARCH_NR, 0, /* RET_KILL_PROCESS */ 19 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, ARCH_NR, 0, /* RET_KILL_PROCESS */ 27 ),
     /* loading syscall number in accumulator */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, ( offsetof( struct seccomp_data, nr ) ) ),
     /* allow write based on expression */
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_write, /* check_write */ 5, 0 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_write, /* check_write */ 9, 0 ),
     /* allow fsync based on expression */
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_fsync, /* check_fsync */ 8, 0 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_fsync, /* check_fsync */ 12, 0 ),
     /* allow exit based on expression */
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_exit, /* check_exit */ 9, 0 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_exit, /* check_exit */ 13, 0 ),
     /* allow io_uring_enter based on expression */
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_io_uring_enter, /* check_io_uring_enter */ 10, 0 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_io_uring_enter, /* check_io_uring_enter */ 14, 0 ),
     /* allow pread64 based on expression */
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_pread64, /* check_pread64 */ 11, 0 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_pread64, /* check_pread64 */ 15, 0 ),
+    /* allow lseek based on expression */
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_lseek, /* check_lseek */ 16, 0 ),
+    /* allow sched_yield based on expression */
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_sched_yield, /* check_sched_yield */ 17, 0 ),
+    /* allow clock_nanosleep based on expression */
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_clock_nanosleep, /* check_clock_nanosleep */ 16, 0 ),
+    /* allow nanosleep based on expression */
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_nanosleep, /* check_nanosleep */ 17, 0 ),
     /* none of the syscalls matched */
-    { BPF_JMP | BPF_JA, 0, 0, /* RET_KILL_PROCESS */ 12 },
+    { BPF_JMP | BPF_JA, 0, 0, /* RET_KILL_PROCESS */ 16 },
 //  check_write:
     /* load syscall argument 0 in accumulator */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, 2, /* RET_ALLOW */ 11, /* lbl_1 */ 0 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, 2, /* RET_ALLOW */ 15, /* lbl_1 */ 0 ),
 //  lbl_1:
     /* load syscall argument 0 in accumulator */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, logfile_fd, /* RET_ALLOW */ 9, /* RET_KILL_PROCESS */ 8 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, logfile_fd, /* RET_ALLOW */ 13, /* RET_KILL_PROCESS */ 12 ),
 //  check_fsync:
     /* load syscall argument 0 in accumulator */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, logfile_fd, /* RET_ALLOW */ 7, /* RET_KILL_PROCESS */ 6 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, logfile_fd, /* RET_ALLOW */ 11, /* RET_KILL_PROCESS */ 10 ),
 //  check_exit:
     /* load syscall argument 0 in accumulator */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, 0, /* RET_ALLOW */ 5, /* RET_KILL_PROCESS */ 4 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, 0, /* RET_ALLOW */ 9, /* RET_KILL_PROCESS */ 8 ),
 //  check_io_uring_enter:
     /* load syscall argument 0 in accumulator */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, ring_fd, /* RET_ALLOW */ 3, /* RET_KILL_PROCESS */ 2 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, ring_fd, /* RET_ALLOW */ 7, /* RET_KILL_PROCESS */ 6 ),
 //  check_pread64:
     /* load syscall argument 0 in accumulator */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, bstream_fd, /* RET_ALLOW */ 1, /* RET_KILL_PROCESS */ 0 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, bstream_fd, /* RET_ALLOW */ 5, /* RET_KILL_PROCESS */ 4 ),
+//  check_lseek:
+    /* load syscall argument 0 in accumulator */
+    BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, bstream_fd, /* RET_ALLOW */ 3, /* RET_KILL_PROCESS */ 2 ),
+//  check_sched_yield:
+//  check_clock_nanosleep:
+    /* load syscall argument 0 in accumulator */
+    BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, 0, /* RET_ALLOW */ 1, /* RET_KILL_PROCESS */ 0 ),
+//  check_nanosleep:
 //  RET_KILL_PROCESS:
     /* KILL_PROCESS is placed before ALLOW since it's the fallthrough case. */
     BPF_STMT( BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS ),

--- a/src/discof/restore/utils/fd_vinyl_admin.c
+++ b/src/discof/restore/utils/fd_vinyl_admin.c
@@ -1,0 +1,60 @@
+#include "fd_vinyl_admin.h"
+
+ulong
+fd_vinyl_admin_align( void ) {
+  return alignof(fd_vinyl_admin_t);
+}
+
+ulong
+fd_vinyl_admin_footprint( void ){
+  return sizeof(fd_vinyl_admin_t);
+}
+
+void *
+fd_vinyl_admin_new( void * mem ) {
+  fd_vinyl_admin_t * admin = (fd_vinyl_admin_t *)mem;
+
+  memset( admin, 0UL, sizeof(fd_vinyl_admin_t) );
+
+  admin->magic = FD_VINYL_ADMIN_MAGIC;
+
+  fd_rwlock_new( &admin->lock );
+
+  /* verbose initialization */
+  admin->status = FD_VINYL_ADMIN_STATUS_INIT_PENDING;
+
+  return (void *)admin;
+}
+
+fd_vinyl_admin_t *
+fd_vinyl_admin_join( void * _admin ) {
+  fd_vinyl_admin_t * admin = (fd_vinyl_admin_t *)_admin;
+  if( FD_UNLIKELY( admin->magic!=FD_VINYL_ADMIN_MAGIC ) ) return NULL;
+  return admin;
+}
+
+void *
+fd_vinyl_admin_leave( fd_vinyl_admin_t * _admin ) {
+  return (void *)_admin;
+}
+
+void *
+fd_vinyl_admin_delete( void * _admin ) {
+  return (void *)_admin;
+}
+
+ulong
+fd_vinyl_admin_ulong_query( ulong const * _field ) {
+  FD_COMPILER_MFENCE();
+  ulong field = FD_VOLATILE_CONST( *_field );
+  FD_COMPILER_MFENCE();
+  return field;
+}
+
+void
+fd_vinyl_admin_ulong_update( ulong * _field,
+                             ulong   value ) {
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( *_field ) = value;
+  FD_COMPILER_MFENCE();
+}

--- a/src/discof/restore/utils/fd_vinyl_admin.h
+++ b/src/discof/restore/utils/fd_vinyl_admin.h
@@ -1,0 +1,88 @@
+#ifndef HEADER_fd_src_discof_restore_utils_fd_vinyl_admin_h
+#define HEADER_fd_src_discof_restore_utils_fd_vinyl_admin_h
+
+#include "../../../flamenco/fd_rwlock.h"
+
+#define FD_VINYL_ADMIN_MAGIC (0XF17EDA2C7E412AD8) /* FIREDANCER VINYL ADMIN */
+
+/* Vinyl admin synchronization object. */
+#define FD_VINYL_ADMIN_WR_SEQ_CNT_MAX       (8UL)
+
+#define FD_VINYL_ADMIN_STATUS_INIT_PENDING  (0UL)
+#define FD_VINYL_ADMIN_STATUS_INIT_DONE     (1UL)
+#define FD_VINYL_ADMIN_STATUS_UPDATING      (2UL)
+#define FD_VINYL_ADMIN_STATUS_SNAPSHOT_FULL (3UL)
+#define FD_VINYL_ADMIN_STATUS_SNAPSHOT_INCR (4UL)
+#define FD_VINYL_ADMIN_STATUS_ERROR         (ULONG_MAX)
+
+struct fd_vinyl_admin {
+  ulong       magic; /* ==FD_VINYL_ADMIN_MAGIC */
+
+  ulong       status;
+
+  struct {
+    ulong     past;
+    ulong     present;
+  } bstream_seq;
+
+  ulong       wr_seq[FD_VINYL_ADMIN_WR_SEQ_CNT_MAX];
+  ulong       wr_cnt;
+
+  fd_rwlock_t lock;
+};
+typedef struct fd_vinyl_admin fd_vinyl_admin_t;
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_vinyl_admin_{align, footprint} return align and footprint */
+
+ulong
+fd_vinyl_admin_align( void );
+
+ulong
+fd_vinyl_admin_footprint( void );
+
+/* fd_vinyl_admin_new initializes a new vinyl admin object.  It returns
+   a void pointer to the base of the fd_vinyl_admin_t in memory.  On
+   return, it does not retain ownership of the memory. */
+
+void *
+fd_vinyl_admin_new( void * mem );
+
+/* fd_vinyl_admin_join return a fd_vinyl_admin_t pointer on success,
+   NULL otherwise.  A condition for failure is e.g. an incorrect
+   magic value (meaning the memory region does not correspond to a
+   properly initialized vinyl admin object).  On return, it does not
+   retain ownership of the memory.*/
+
+fd_vinyl_admin_t *
+fd_vinyl_admin_join( void * _admin );
+
+/* fd_vinyl_admin_leave leaves the vinyl admin object, returning a void
+   pointer to the memory region. */
+
+void *
+fd_vinyl_admin_leave( fd_vinyl_admin_t * _admin );
+
+/* fd_vinyl_admin_delete leaves the memory region, returning a void
+   pointer to the memory region. */
+
+void *
+fd_vinyl_admin_delete( void * _admin );
+
+/* fd_vinyl_admin_query does a volatile read of the vinyl admin object
+   field.  It does not handle the rwlock. */
+
+ulong
+fd_vinyl_admin_ulong_query( ulong const * _field );
+
+/* fd_vinyl_admin_update modifies the given field of a vinyl admin
+   object.  It does not handle the rwlock. */
+
+void
+fd_vinyl_admin_ulong_update( ulong * _field,
+                             ulong   value );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_discof_restore_utils_fd_vinyl_admin_h */

--- a/src/discof/restore/utils/test_vinyl_admin.c
+++ b/src/discof/restore/utils/test_vinyl_admin.c
@@ -1,0 +1,337 @@
+#include "fd_vinyl_admin.h"
+#include "../../../util/fd_util.h"
+#include <stdlib.h>
+
+char * tile_argv[] = { NULL, NULL, NULL };
+
+char * mem_argv[FD_VINYL_ADMIN_WR_SEQ_CNT_MAX] = { NULL };
+
+#define MEM_CMD_SZ (1024)
+char   mem_cmd[MEM_CMD_SZ];
+
+#define SHMEM_MAX (131072UL)
+
+static FD_TL uchar shmem[ SHMEM_MAX ];
+
+static void *
+shmem_join( ulong a,
+            ulong s ) {
+  uchar * m  = (uchar *)fd_ulong_align_up( (ulong)shmem, a );
+  uchar * m_end = m + s;
+  FD_TEST( ((ulong)(m_end)-(ulong)shmem) <= SHMEM_MAX );
+  return (void *)m;
+}
+
+int
+tile_main( int     argc,
+           char ** argv ) {
+
+  fd_rng_t rng[1]; fd_rng_join( fd_rng_new( rng, (uint)fd_log_wallclock(), fd_tile_id() ) );
+
+  FD_TEST( fd_tile_id()==fd_log_thread_id() );
+  ulong wr_idx = fd_tile_idx();
+  FD_TEST( wr_idx<FD_VINYL_ADMIN_WR_SEQ_CNT_MAX );
+
+  FD_TEST( argc==1 );
+  fd_vinyl_admin_t * admin = (fd_vinyl_admin_t *)argv[ 0 ];
+
+  /* test_lockfree_init_sync */
+
+  FD_TEST( admin->status==FD_VINYL_ADMIN_STATUS_INIT_PENDING );
+
+  for(;;) {
+    if( fd_vinyl_admin_ulong_query( &admin->status )==FD_VINYL_ADMIN_STATUS_INIT_DONE ) break;
+    FD_SPIN_PAUSE();
+  }
+
+  fd_vinyl_admin_ulong_update( &admin->wr_seq[ wr_idx ], fd_vinyl_admin_ulong_query( &admin->bstream_seq.present ) );
+
+  /* test_lockfree_wr_seq_regression */
+
+  for(;;) {
+    if( fd_vinyl_admin_ulong_query( &admin->status )==FD_VINYL_ADMIN_STATUS_SNAPSHOT_FULL ) break;
+    FD_SPIN_PAUSE();
+  }
+
+  ulong wr_seqA = fd_vinyl_admin_ulong_query( &admin->bstream_seq.past    );
+  ulong wr_seqB = fd_vinyl_admin_ulong_query( &admin->bstream_seq.present );
+
+  for( ulong wr_seq=wr_seqA; wr_seq<=wr_seqB; wr_seq++ ) {
+    fd_vinyl_admin_ulong_update( &admin->wr_seq[ wr_idx ], wr_seq );
+    FD_SPIN_PAUSE();
+  }
+
+  for(;;) {
+    if( fd_vinyl_admin_ulong_query( &admin->wr_seq[ wr_idx ] )==wr_seqA ) break;
+    FD_SPIN_PAUSE();
+  }
+
+  fd_vinyl_admin_ulong_update( &admin->wr_seq[ wr_idx ], ULONG_MAX );
+
+  /* test_rwlock_init_and_wr_seq */
+
+  for(;;) {
+    fd_rwlock_read( &admin->lock );
+    int found = fd_vinyl_admin_ulong_query( &admin->status )==FD_VINYL_ADMIN_STATUS_SNAPSHOT_FULL;
+    fd_rwlock_unread( &admin->lock );
+    fd_log_sleep( (long)1e3 /*1us*/ );
+    if( found ) break;
+    FD_SPIN_PAUSE();
+  }
+
+  ulong wr_seqC = fd_vinyl_admin_ulong_query( &admin->bstream_seq.past    );
+  ulong wr_seqD = fd_vinyl_admin_ulong_query( &admin->bstream_seq.present );
+
+  for( ulong wr_seq=wr_seqC; wr_seq<=wr_seqD; wr_seq++ ) {
+    fd_rwlock_write( &admin->lock );
+    fd_vinyl_admin_ulong_update( &admin->wr_seq[ wr_idx ], wr_seq );
+    fd_rwlock_unwrite( &admin->lock );
+    FD_SPIN_PAUSE();
+  }
+
+  fd_log_flush();
+
+  return 0;
+}
+
+void
+test_lockfree_init_sync( fd_vinyl_admin_t * admin,
+                         fd_rng_t *         rng,
+                         ulong              tile_cnt ) {
+  (void)rng;
+  FD_LOG_NOTICE(( "testing lockfree init sync ..." ));
+
+  /* Init - the other tiles are waiting. */
+  FD_TEST( admin->status==FD_VINYL_ADMIN_STATUS_INIT_PENDING );
+  ulong past    = 0UL;
+  ulong present = ULONG_MAX-1UL;
+  fd_vinyl_admin_ulong_update( &admin->bstream_seq.past,    past    );
+  fd_vinyl_admin_ulong_update( &admin->bstream_seq.present, present );
+  for( ulong idx=1UL; idx<tile_cnt; idx++ ) {
+    FD_TEST( !fd_vinyl_admin_ulong_query( &admin->wr_seq[ idx ] ) );
+  }
+  fd_vinyl_admin_ulong_update( &admin->wr_cnt, tile_cnt );
+  fd_vinyl_admin_ulong_update( &admin->status, FD_VINYL_ADMIN_STATUS_INIT_DONE );
+
+  /* The other tiles will respond by updating wr_seq to "present". */
+  for(;;) {
+    ulong seq_min = ULONG_MAX;
+    for( ulong idx=1UL; idx<tile_cnt; idx++ ) {
+      ulong seq = fd_vinyl_admin_ulong_query( &admin->wr_seq[ idx ] );
+      seq_min = fd_ulong_min( seq_min, seq );
+    }
+    if( seq_min==present ) break;
+    FD_SPIN_PAUSE();
+  }
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+void
+test_lockfree_wr_seq_regression( fd_vinyl_admin_t * admin,
+                                 fd_rng_t *         rng,
+                                 ulong              tile_cnt ) {
+  FD_LOG_NOTICE(( "testing lockfree wr_seq regression ..." ));
+
+  ulong past    = 1UL;
+  ulong present = past + 100UL + (fd_rng_ulong( rng ) & ((1UL<<20)-1UL));
+  FD_LOG_NOTICE(( "... past     %lu", past     ));
+  FD_LOG_NOTICE(( "... present  %lu", present  ));
+
+  /* Init - the other tiles are waiting. */
+  fd_vinyl_admin_ulong_update( &admin->status, FD_VINYL_ADMIN_STATUS_UPDATING );
+  fd_vinyl_admin_ulong_update( &admin->bstream_seq.past,    past    );
+  fd_vinyl_admin_ulong_update( &admin->bstream_seq.present, present );
+  for( ulong idx=1UL; idx<tile_cnt; idx++ ) fd_vinyl_admin_ulong_update( &admin->wr_seq[ idx ], past );
+  fd_vinyl_admin_ulong_update( &admin->status, FD_VINYL_ADMIN_STATUS_SNAPSHOT_FULL );
+
+  /* The other tiles will respond by incrementing wr_seq gradually, up
+     until reaching "present". */
+  for(;;) {
+    ulong seq_min = ULONG_MAX;
+    for( ulong idx=1UL; idx<tile_cnt; idx++ ) {
+      ulong seq = fd_vinyl_admin_ulong_query( &admin->wr_seq[ idx ] );
+      seq_min = fd_ulong_min( seq_min, seq );
+    }
+    if( seq_min==present ) break;
+    FD_SPIN_PAUSE();
+  }
+
+  FD_LOG_NOTICE(( "... present has been reached" ));
+
+  /* The other tiles are waiting for a regression to "past". */
+  for( ulong idx=1UL; idx<tile_cnt; idx++ ) {
+    fd_vinyl_admin_ulong_update( &admin->wr_seq[ idx ], past );
+  }
+
+  /* The other tiles will respond by setting wr_seq to ULONG_MAX. */
+  for(;;) {
+    ulong seq_min = ULONG_MAX;
+    for( ulong idx=1UL; idx<tile_cnt; idx++ ) {
+      ulong seq = fd_vinyl_admin_ulong_query( &admin->wr_seq[ idx ] );
+      seq_min = fd_ulong_min( seq_min, seq );
+    }
+    if( seq_min==ULONG_MAX ) break;
+    FD_SPIN_PAUSE();
+  }
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+void
+test_rwlock_init_and_wr_seq( fd_vinyl_admin_t * admin,
+                             fd_rng_t *         rng,
+                             ulong              tile_cnt ) {
+  FD_LOG_NOTICE(( "testing rwlock ..." ));
+
+  ulong past     = 1UL;
+  ulong present = past + 100UL + (fd_rng_ulong( rng ) & ((1UL<<20)-1UL));
+  FD_LOG_NOTICE(( "... past     %lu", past     ));
+  FD_LOG_NOTICE(( "... present  %lu", present  ));
+
+  /* Init - the other tiles are waiting. */
+  fd_rwlock_write( &admin->lock );
+  fd_vinyl_admin_ulong_update( &admin->status, FD_VINYL_ADMIN_STATUS_UPDATING );
+  fd_vinyl_admin_ulong_update( &admin->bstream_seq.past,    past    );
+  fd_vinyl_admin_ulong_update( &admin->bstream_seq.present, present );
+  for( ulong idx=1UL; idx<tile_cnt; idx++ ) fd_vinyl_admin_ulong_update( &admin->wr_seq[ idx ], past );
+  fd_vinyl_admin_ulong_update( &admin->status, FD_VINYL_ADMIN_STATUS_SNAPSHOT_INCR );
+  fd_rwlock_unwrite( &admin->lock );
+
+  /* The other tiles will respond by updating wr_seq to "present". */
+  for(;;) {
+    ulong seq_min = ULONG_MAX;
+    fd_rwlock_read( &admin->lock );
+    for( ulong idx=1UL; idx<tile_cnt; idx++ ) {
+      ulong seq = fd_vinyl_admin_ulong_query( &admin->wr_seq[ idx ] );
+      seq_min = fd_ulong_min( seq_min, seq );
+    }
+    fd_rwlock_unread( &admin->lock );
+    fd_log_sleep( (long)1e3 /*1us*/ );
+    if( seq_min==present ) break;
+    FD_SPIN_PAUSE();
+  }
+
+  FD_LOG_NOTICE(( "... present has been reached" ));
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+
+  int     t_argc = argc;
+  char ** t_argv = argv;
+
+  /* The test needs a minimum number of tiles > 1, which is typically
+     provided either as an environment variable (FD_TILE_CPUS) or via
+     the command line (--tile-cpus).  If neither is given, the code
+     below will set this to a default value before calling fd_boot. */
+  int contains_tile_cpus = !!getenv( "FD_TILE_CPUS" );
+  for( int i=0UL; i<argc; i++ ) {
+    if( !strcmp( "--tile-cpus", t_argv[ i ] ) ) contains_tile_cpus = 1;
+  }
+  if( !contains_tile_cpus ) {
+    /* Use mem_argv as a 1-D buffer. */
+    t_argc = 0;
+    t_argv = (char**)mem_argv;
+    char * p = mem_cmd;
+    for( int i=0; i<argc; i++ ) {
+      p = fd_cstr_init( p );
+      t_argv[ t_argc++ ] = p;
+      p = fd_cstr_append_cstr( p, argv[ i ] );
+      fd_cstr_fini( p );
+      p += 1;
+    }
+    p = fd_cstr_init( p );
+    t_argv[ t_argc++ ] = p;
+    p = fd_cstr_append_cstr( p, "--tile-cpus" );
+    fd_cstr_fini( p );
+    p += 1;
+    t_argv[ t_argc++ ] = p;
+    ulong sz_used  = 0UL;
+    ulong sz_avail = ((ulong)mem_cmd)+MEM_CMD_SZ-2UL-(ulong)p;
+    fd_cstr_printf( p, sz_avail, &sz_used, "1-%lu", FD_VINYL_ADMIN_WR_SEQ_CNT_MAX );
+    FD_TEST( sz_used );
+    FD_TEST( sz_used <= sz_avail );
+    t_argv[ t_argc ] = NULL;
+    FD_LOG_WARNING(( "unspecified --tile-cpus, using default: %s %s", t_argv[ t_argc-2 ], t_argv[ t_argc-1 ] ));
+  }
+
+  /* Unit test boot. */
+  fd_boot( &t_argc, &t_argv );
+
+  FD_LOG_NOTICE(( "fd_vinyl_admin_align()     %lu", fd_vinyl_admin_align()     ));
+  FD_LOG_NOTICE(( "fd_vinyl_admin_footprint() %lu", fd_vinyl_admin_footprint() ));
+
+  ulong tile_cnt = fd_tile_cnt();
+  if( tile_cnt > FD_VINYL_ADMIN_WR_SEQ_CNT_MAX ) FD_LOG_ERR(( "tile count cannot exceed FD_VINYL_ADMIN_WR_SEQ_CNT_MAX %lu", FD_VINYL_ADMIN_WR_SEQ_CNT_MAX ));
+  if( tile_cnt <= 1UL )                          FD_LOG_ERR(( "tile count must be > 1" ));
+  FD_TEST( fd_tile_id()==fd_log_thread_id() );
+
+  FD_LOG_NOTICE(( "cnt %lu", tile_cnt      )); FD_TEST( tile_cnt>0UL ); FD_TEST( tile_cnt<=FD_TILE_MAX );
+  FD_LOG_NOTICE(( "id0 %lu", fd_tile_id0() ));
+  FD_LOG_NOTICE(( "id1 %lu", fd_tile_id1() )); FD_TEST( tile_cnt==(fd_tile_id1()-fd_tile_id0()) );
+  FD_LOG_NOTICE(( "id  %lu", fd_tile_id () )); FD_TEST( fd_tile_id()==fd_tile_id0() );
+  FD_LOG_NOTICE(( "idx %lu", fd_tile_idx() )); FD_TEST( fd_tile_idx()==0UL );
+  fd_log_flush();
+
+  /* Random number generator init. */
+  fd_rng_t rng[1]; fd_rng_join( fd_rng_new( rng, (uint)fd_log_wallclock(), 0UL ) );
+
+  /* Vinyl admin (shared memory). */
+  void * vinyl_admin_shmem = shmem_join( fd_vinyl_admin_align(), fd_vinyl_admin_footprint() );
+  tile_argv[ 0 ] = vinyl_admin_shmem;
+  fd_vinyl_admin_t * admin = fd_vinyl_admin_join( fd_vinyl_admin_new( vinyl_admin_shmem ) );
+
+  /* Other tiles's exec context. */
+  fd_tile_exec_t * exec[FD_VINYL_ADMIN_WR_SEQ_CNT_MAX] = { NULL };
+
+  /* Starting all the other tiles, running "tile_main". */
+  FD_LOG_NOTICE(( "starting %lu tiles", tile_cnt ));
+
+  for( ulong idx=1UL; idx<tile_cnt; idx++ ) {
+    int     argc = 1;
+    char ** argv = (char **)tile_argv;
+
+    exec[ idx ] = fd_tile_exec_new( idx, tile_main, argc, argv );
+    FD_TEST( !!exec[ idx ] );
+
+    FD_TEST( fd_tile_exec( idx )==exec[ idx ] );
+
+    FD_LOG_NOTICE(( "... tile idx %lu running", idx ));
+  }
+
+  fd_log_flush();
+
+  /* Main tests: note that the other tiles are running, each waiting
+     and ready to respond in accordance to each test (see tile_main). */
+  test_lockfree_init_sync( admin, rng, tile_cnt );
+
+  test_lockfree_wr_seq_regression( admin, rng, tile_cnt );
+
+  test_rwlock_init_and_wr_seq( admin, rng, tile_cnt );
+
+  /* Closing all other tiles. */
+  for( ulong idx=1UL; idx<tile_cnt; idx++ ) {
+    FD_LOG_NOTICE(( "closing tile %lu", idx ));
+
+    int done = fd_tile_exec_done( exec[ idx ] );
+    FD_TEST( 0<=done && done<=1 );
+
+    int          ret;
+    char const * fail = fd_tile_exec_delete( exec[ idx ], &ret );
+    FD_TEST( !fail );
+  }
+
+  /* Final check: wr_seq[0] must have remained unchanged (==0). */
+  FD_TEST( !fd_vinyl_admin_ulong_query( &admin->wr_seq[0] ) );
+
+  FD_LOG_NOTICE(( "pass" ));
+
+  fd_rng_delete( fd_rng_leave( rng ) );
+  fd_vinyl_admin_delete( fd_vinyl_admin_leave( admin ) );
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
Adding `vinyl admin object` to the snapshot load pipeline.

- `snaplv_wr` has been deprecated. `snapwr` updates the (bstream) write sequence directly into the new vinyl admin obj, and `snaplh` polls from it.
- `snaplv` and `snaplh` wait until `snapwm` initializes the vinyl admin object. This prevents `snaplh` from starting from an older bstream sync block.