### PR TITLE
chore: remove redundant null checks

### DIFF
--- a/src/app/shared_dev/commands/quic_trace/fd_quic_trace_rx_tile.c
+++ b/src/app/shared_dev/commands/quic_trace/fd_quic_trace_rx_tile.c
@@ -106,7 +106,7 @@ fd_quic_trace_initial( fd_quic_trace_ctx_t * ctx,
 
 #       define EMPTY ((uchar[16]){0})
         /* assume this is a new connection, since this is an Initial packet */
-        if( keys && memcmp( keys->pkt_key, EMPTY, sizeof( keys->pkt_key ) ) != 0 ) {
+        if( memcmp( keys->pkt_key, EMPTY, sizeof( keys->pkt_key ) ) != 0 ) {
           /* load the appropriate cid into peer_conn_id */
           ulong peer_conn_id = key_idx == 0 ? fd_ulong_load_8( initial->src_conn_id )
                                             : fd_ulong_load_8( initial->dst_conn_id );

--- a/src/discof/execrp/fd_execrp_tile.c
+++ b/src/discof/execrp/fd_execrp_tile.c
@@ -304,7 +304,6 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->replay_in->idx = fd_topo_find_tile_in_link( topo, tile, "replay_execrp", 0UL );
   FD_TEST( ctx->replay_in->idx!=ULONG_MAX );
   fd_topo_link_t * replay_in_link = &topo->links[ tile->in_link_id[ ctx->replay_in->idx ] ];
-  FD_TEST( replay_in_link!=NULL );
   ctx->replay_in->mem    = topo->workspaces[ topo->objs[ replay_in_link->dcache_obj_id ].wksp_id ].wksp;
   ctx->replay_in->chunk0 = fd_dcache_compact_chunk0( ctx->replay_in->mem, replay_in_link->dcache );
   ctx->replay_in->wmark  = fd_dcache_compact_wmark( ctx->replay_in->mem, replay_in_link->dcache, replay_in_link->mtu );

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -1381,7 +1381,6 @@ boot_genesis( fd_replay_tile_t *  ctx,
 
 
   fd_block_id_ele_t * block_id_ele = &ctx->block_id_arr[ 0 ];
-  FD_TEST( block_id_ele );
   block_id_ele->block_id = initial_block_id;
   block_id_ele->slot     = 0UL;
 
@@ -1488,7 +1487,6 @@ on_snapshot_message( fd_replay_tile_t *  ctx,
     fd_runtime_update_leaders( bank, &ctx->runtime_stack );
 
     fd_block_id_ele_t * block_id_ele = &ctx->block_id_arr[ 0 ];
-    FD_TEST( block_id_ele );
     block_id_ele->block_id = manifest_block_id;
     block_id_ele->slot     = snapshot_slot;
     FD_TEST( fd_block_id_map_ele_insert( ctx->block_id_map, block_id_ele, ctx->block_id_arr ) );
@@ -1776,7 +1774,6 @@ process_fec_set( fd_replay_tile_t *  ctx,
 
   if( FD_UNLIKELY( reasm_fec->slot_complete ) ) {
     fd_block_id_ele_t * block_id_ele = &ctx->block_id_arr[ reasm_fec->bank_idx ];
-    FD_TEST( block_id_ele );
 
     block_id_ele->block_id_seen = 1;
     block_id_ele->block_id      = reasm_fec->key;
@@ -1894,10 +1891,10 @@ advance_published_root( fd_replay_tile_t * ctx ) {
   fd_bank_t bank[1];
   FD_TEST( fd_banks_bank_query( bank, ctx->banks, advanceable_root_idx ) );
 
-  fd_block_id_ele_t * advanceable_root_ele = &ctx->block_id_arr[ advanceable_root_idx ];
-  if( FD_UNLIKELY( !advanceable_root_ele ) ) {
-    FD_LOG_CRIT(( "invariant violation: advanceable root ele not found for bank index %lu", advanceable_root_idx ));
+  if( FD_UNLIKELY( advanceable_root_idx >= ctx->block_id_len ) ) {
+    FD_LOG_CRIT(( "invariant violation: advanceable root ele out of bounds [0, %lu) index %lu", ctx->block_id_len, advanceable_root_idx ));
   }
+  fd_block_id_ele_t * advanceable_root_ele = &ctx->block_id_arr[ advanceable_root_idx ];
 
   long exacq_start, exacq_end, exrel_end;
   FD_STORE_EXCLUSIVE_LOCK( ctx->store, exacq_start, exacq_end, exrel_end ) {

--- a/src/flamenco/runtime/fd_txncache.c
+++ b/src/flamenco/runtime/fd_txncache.c
@@ -244,7 +244,6 @@ fd_txncache_attach_child( fd_txncache_t *       tc,
     root_slist_ele_push_tail( tc->shmem->root_ll, fork->shmem, tc->blockcache_shmem_pool );
   } else {
     blockcache_t * parent = &tc->blockcache_pool[ parent_fork_id.val ];
-    FD_TEST( parent );
     /* We might be tempted to freeze the parent here, and it's valid to
        do this ordinarily, but not when loading from a snapshot, when
        we need to load many transactions into a root parent chain at
@@ -326,7 +325,6 @@ remove_children( fd_txncache_t *      tc,
   fd_txncache_fork_id_t sibling_idx = fork->shmem->child_id;
   while( sibling_idx.val!=USHORT_MAX ) {
     blockcache_t * sibling = &tc->blockcache_pool[ sibling_idx.val ];
-    FD_TEST( sibling );
 
     sibling_idx = sibling->shmem->sibling_id;
     if( FD_UNLIKELY( sibling==except ) ) continue;
@@ -342,7 +340,6 @@ fd_txncache_advance_root( fd_txncache_t *       tc,
   fd_rwlock_write( tc->shmem->lock );
 
   blockcache_t * fork = &tc->blockcache_pool[ fork_id.val ];
-  FD_TEST( fork );
 
   blockcache_t * parent_fork = &tc->blockcache_pool[ fork->shmem->parent_id.val ];
   if( FD_UNLIKELY( root_slist_ele_peek_tail( tc->shmem->root_ll, tc->blockcache_shmem_pool )!=parent_fork->shmem ) ) {


### PR DESCRIPTION
These null checks are redundant as taking the address of something should never evaluate to a NULL pointer.
I tried to replace them with equivalent checks where possible, but please double check.