### PR TITLE
ci: clear out stale git index within flock

### DIFF
--- a/contrib/test/run_test_vectors.sh
+++ b/contrib/test/run_test_vectors.sh
@@ -36,6 +36,9 @@ mkdir -p "$(dirname "$CACHE")"
 exec {lockfd}>"$CACHE.lock"
 flock -x "$lockfd"
 
+# Clean up stale git lock files left by killed processes
+rm -f "$CACHE/.git/index.lock"
+
 if [ ! -d "$CACHE" ]; then
     git clone -q "$REPO_URL" "$CACHE"
 fi


### PR DESCRIPTION
If a previous run was killed mid-git-operation (SIGKILL, OOM, CI timeout, etc...), the git index lock file remains and is stale. Subsequent runs will necessarily fail even though our flock already correctly prevents concurrent access. Since we hold the exclusive flock, any existing .git/index.lock should be safe to remove before proceeding with subsequent git operations.

example run: https://github.com/firedancer-io/firedancer/actions/runs/21677752458/job/62504375003