### PR TITLE
flamenco, runtime: fix deprecate_rent_exemption_threshold testnet bug

### DIFF
--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -517,19 +517,20 @@ deprecate_rent_exemption_threshold( fd_bank_t *               bank,
                                     fd_accdb_user_t *         accdb,
                                     fd_funk_txn_xid_t const * xid,
                                     fd_capture_ctx_t *        capture_ctx ) {
-  fd_rent_t rent[1] = {0};
-  if( FD_UNLIKELY( !fd_sysvar_rent_read( accdb, xid, rent ) ) ) {
-    FD_LOG_CRIT(( "fd_sysvar_rent_read failed" ));
-  }
-  rent->lamports_per_uint8_year = fd_rust_cast_double_to_ulong(
-    (double)rent->lamports_per_uint8_year * rent->exemption_threshold );
-  rent->exemption_threshold     = FD_SIMD_0194_NEW_RENT_EXEMPTION_THRESHOLD;
+  /* We use the bank fields here to mirror Agave - in mainnet, devnet
+     and testnet Agave's bank rent.burn_percent field is different to
+     the value in the sysvar. When this feature is activated in Agave,
+     the sysvar inherits the value from the bank. */
+  fd_rent_t rent               = fd_bank_rent_get( bank );
+  rent.lamports_per_uint8_year = fd_rust_cast_double_to_ulong(
+    (double)rent.lamports_per_uint8_year * rent.exemption_threshold );
+  rent.exemption_threshold     = FD_SIMD_0194_NEW_RENT_EXEMPTION_THRESHOLD;
 
   /* We don't refresh the sysvar cache here. The cache is refreshed in
-     fd_sysvar_cache_restore, which is called at the start of every block
-     in fd_runtime_block_execute_prepare, after this function. */
-  fd_sysvar_rent_write( bank, accdb, xid, capture_ctx, rent );
-  fd_bank_rent_set( bank, *rent );
+     fd_sysvar_cache_restore, which is called at the start of every
+     block in fd_runtime_block_execute_prepare, after this function. */
+  fd_sysvar_rent_write( bank, accdb, xid, capture_ctx, &rent );
+  fd_bank_rent_set( bank, rent );
 }
 
 /* Starting a new epoch.

--- a/src/flamenco/runtime/tests/run_backtest_all.sh
+++ b/src/flamenco/runtime/tests/run_backtest_all.sh
@@ -107,3 +107,4 @@ src/flamenco/runtime/tests/run_ledger_backtest.sh -l breakpoint-385786458 -y 1 -
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l localnet-deprecate-rent-exemption-threshold -y 1 -m 1000 -e 260 -lt
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l localnet-static-instruction-limit -y 1 -m 1000 -e 191 -lt
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l vote-states-v4-local -y 1 -m 3000 -e 1000 -lt
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l testnet-386300256 -y 1 -m 2000000 -e 386300289 -lt


### PR DESCRIPTION
In some live clusters (including mainnet, devnet and testnet) the value of `rent.burn_percent` in the snapshot manifest (bank) and sysvar account are different.

```
rent from bank:        lamports_per_uint8_year=3480, exemption_threshold=2.000000, burn_percent=50
rent from accounts db: lamports_per_uint8_year=3480, exemption_threshold=2.000000, burn_percent=100
```

This means that when we update the rent sysvar at the epoch boundary in `deprecate_rent_exemption_threshold`, we should overwrite the value in the sysvar with the value from the bank, to match Agave's behaviour.

This doesn't show up in local clusters/ledgers generated from local clusters because the values are consistent in fresh clusters.

After this feature is activated the values are consistent between the bank and the sysvar account, but this causes a mismatch at the epoch boundary in clusters where they are inconsistent before.