### PR TITLE
fxt: add FTF file writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ venv
 .venv
 *.pyc
 *.egg-info/
+
+# Fuchsia trace format
+*.fxt

--- a/src/disco/trace/fd_trace_export.c
+++ b/src/disco/trace/fd_trace_export.c
@@ -1,0 +1,160 @@
+#include "fd_trace_export.h"
+
+#include <errno.h>
+
+/* From generated/fd_trace_strings.c */
+extern char const * fd_trace_strtab[];
+
+static uint const fd_trace_fxt_provider_id = 0xcf380f66u;
+
+fd_trace_fxt_o_t *
+fd_trace_fxt_o_new( fd_trace_fxt_o_t * this,
+                    int                fd ) {
+  FILE * file = fdopen( fd, "w" );
+  if( FD_UNLIKELY( !file ) ) {
+    FD_LOG_WARNING(( "fdopen(fd=%d) failed (%i-%s)", fd, errno, fd_io_strerror( errno ) ));
+  }
+  *this = (fd_trace_fxt_o_t) {
+    .file = file
+  };
+  return this;
+}
+
+void *
+fd_trace_fxt_o_delete( fd_trace_fxt_o_t * this ) {
+  if( this->file ) {
+    if( FD_UNLIKELY( 0!=fclose( this->file ) ) ) {
+      FD_LOG_WARNING(( "fclose() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    }
+    this->file = NULL;
+  }
+  return this;
+}
+
+static int
+fxt_write( fd_trace_fxt_o_t * this,
+           void const *       data,
+           ulong              sz ) {
+  if( FD_UNLIKELY( !sz ) ) return 0;
+  ulong written = fwrite( data, 1, sz, this->file );
+  return written==sz ? 0 : errno;
+}
+
+static int
+fxt_write_magic( fd_trace_fxt_o_t * this ) {
+  ulong hdr = fd_fxt_rec_magic_number_hdr();
+  return fxt_write( this, &hdr, sizeof(hdr) );
+}
+
+static int
+fxt_write_padding( fd_trace_fxt_o_t * this,
+                   ulong              cur ) {
+  uchar pad[8] = {0};
+  ulong sz = fd_ulong_align_up( cur, 8UL ) - cur;
+  return fxt_write( this, pad, sz );
+}
+
+static int
+fxt_write_str( fd_trace_fxt_o_t * this,
+               char const *       str,
+               ulong              len ) {
+  int err = fxt_write( this, str, len );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fxt_write_padding( this, len );
+}
+
+static int
+fxt_write_provider_info( fd_trace_fxt_o_t * this ) {
+  static char const provider_name[] = "Firedancer";
+  ulong             provider_len    = sizeof(provider_name)-1;
+
+  ulong hdr = fd_fxt_rec_provider_info_hdr( fd_trace_fxt_provider_id, provider_len );
+  int err = fxt_write( this, &hdr, sizeof(hdr) );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fxt_write_str( this, provider_name, provider_len );
+}
+
+static int
+fxt_write_tile( fd_trace_fxt_o_t *     this,
+                fd_topo_tile_t const * tile ) {
+  ulong koid = tile->id + 1024uL;
+
+  /* Format tile name */
+  char name[ 64 ];
+  snprintf( name, sizeof(name), "%s:%lu", tile->name, tile->kind_id );
+
+  /* Write fake KOID with name */
+  ulong        name_len    = strlen( name );
+  ulong        rec_kobj_sz = fd_fxt_rec_kobj_sz( name_len );
+  ulong rec_kobj[ 2 ] = {
+    fd_fxt_rec_kobj_hdr(
+        rec_kobj_sz,
+        FD_FXT_KOBJ_TYPE_THREAD,
+        0x8000 | name_len,
+        0UL ),
+    koid
+  };
+  int err = fxt_write( this, rec_kobj, sizeof(rec_kobj) );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fxt_write_str( this, name, name_len );
+  if( FD_UNLIKELY( err ) ) return err;
+
+  /* Write thread record */
+  ulong tidx = tile->id+1UL; /* Fuchsia thread refs 1-indexed */
+  ulong rec[ 3 ] = {
+    fd_fxt_rec_thread_hdr( tidx ),
+    0UL,  /* placeholder: process KOID */
+    koid  /* placeholder: thread KOID */
+  };
+  return fxt_write( this, rec, sizeof(rec) );
+}
+
+static int
+fxt_write_tiles( fd_trace_fxt_o_t * this,
+                 fd_topo_t const *  topo ) {
+  ulong tile_cnt = fd_ulong_min( topo->tile_cnt, 254UL );
+  for( ulong i=0UL; i<tile_cnt; i++ ) {
+    int err = fxt_write_tile( this, &topo->tiles[ i ] );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return 0;
+}
+
+static int
+fxt_write_dict_str( fd_trace_fxt_o_t * this,
+                    ulong              str_id,
+                    char const *       str,
+                    ulong              len ) {
+  ulong hdr = fd_fxt_rec_string_hdr( len, str_id );
+  int err = fxt_write( this, &hdr, sizeof(hdr) );
+  if( FD_UNLIKELY( err ) ) return err;
+  return fxt_write_str( this, str, len );
+}
+
+static int
+fxt_write_dict_strs( fd_trace_fxt_o_t * this ) {
+  char const ** p = fd_trace_strtab;
+  for( ulong i=0UL; *p; i++, p++ ) {
+    char const * str = *p;
+    ulong        len = strlen( str );
+    int err = fxt_write_dict_str( this, i, str, len );
+    if( FD_UNLIKELY( err ) ) return err;
+  }
+  return 0;
+}
+
+int
+fd_trace_fxt_o_start( fd_trace_fxt_o_t * this,
+                      fd_topo_t const *  topo ) {
+  int err;
+  err = fxt_write_magic( this );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fxt_write_provider_info( this );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fxt_write_tiles( this, topo );
+  if( FD_UNLIKELY( err ) ) return err;
+  err = fxt_write_dict_strs( this );
+  if( FD_UNLIKELY( err ) ) return err;
+  if( FD_UNLIKELY( 0!=fflush( this->file ) ) ) return errno;
+  return 0;
+}

--- a/src/disco/trace/fd_trace_export.h
+++ b/src/disco/trace/fd_trace_export.h
@@ -1,0 +1,77 @@
+#ifndef HEADER_fd_src_disco_trace_fd_trace_export_h
+#define HEADER_fd_src_disco_trace_fd_trace_export_h
+
+/* fd_trace_export.h provides APIs for exporting internal fd_trace
+   events to .fxt files.
+
+   FIXME consider rewriting this using fd_io instead of stdio. */
+
+#include "../topo/fd_topo.h"
+#include "../../tango/fxt/fd_fxt_proto.h"
+#include <stdio.h>
+
+/* fd_trace_fxt_o_t writes out .fxt files. */
+
+struct fd_trace_fxt_o {
+  FILE * file;
+};
+
+typedef struct fd_trace_fxt_o fd_trace_fxt_o_t;
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_trace_fxt_o_new creates a new .fxt writer.   Assumes ownership of
+   the given file descriptor. */
+
+fd_trace_fxt_o_t *
+fd_trace_fxt_o_new( fd_trace_fxt_o_t * this,
+                    int                fd );
+
+/* fd_trace_fxt_o_delete destroys an .fxt writer.  Closes the underlying
+   file descriptor. */
+
+void *
+fd_trace_fxt_o_delete( fd_trace_fxt_o_t * this );
+
+/* fd_trace_fxt_o_start writes out the start of an .fxt file.  This
+   includes tile/thread context, and the string dictionary. */
+
+int
+fd_trace_fxt_o_start( fd_trace_fxt_o_t * this,
+                      fd_topo_t const *  topo );
+
+FD_PROTOTYPES_END
+
+/* Thread record ******************************************************/
+
+static inline ulong
+fd_fxt_rec_thread_sz( void ) { return 24UL; }
+
+static inline ulong
+fd_fxt_rec_thread_hdr( ulong thread_idx ) { /* in [0,255] */
+  ulong words = fd_fxt_rec_thread_sz()>>3;
+  return
+    ( FD_FXT_REC_THREAD<< 0 ) |
+    ( words            << 4 ) |
+    ( thread_idx       <<16 );
+}
+
+/* String record ******************************************************/
+
+static inline ulong
+fd_fxt_rec_string_sz( ulong len ) { /* in [0,32767] */
+  return 8UL + fd_ulong_align_up( len, 8UL );
+}
+
+static inline ulong
+fd_fxt_rec_string_hdr( ulong len,    /* in [0,32767] */
+                       ulong idx ) { /* in [0,32767] */
+  ulong words = fd_fxt_rec_string_sz( len )>>3;
+  return
+    ( FD_FXT_REC_STRING<< 0 ) |
+    ( words            << 4 ) |
+    ( idx              <<16 ) |
+    ( len              <<32 );
+}
+
+#endif /* HEADER_fd_src_disco_trace_fd_trace_export_h */

--- a/src/tango/fxt/fd_fxt_proto.h
+++ b/src/tango/fxt/fd_fxt_proto.h
@@ -19,6 +19,7 @@
 #define FD_FXT_REC_THREAD  3
 #define FD_FXT_REC_EVENT   4
 #define FD_FXT_REC_BLOB    5
+#define FD_FXT_REC_KOBJ    7
 #define FD_FXT_REC_LOG     9
 #define FD_FXT_REC_LARGE  15
 
@@ -60,6 +61,11 @@
 
 #define FD_FXT_META_PROVIDER_EVENT_OVERRUN 0
 
+/* FD_FXT_KOBJ_TYPE_* give ZX kernel object types */
+
+#define FD_FXT_KOBJ_TYPE_PROCESS 1
+#define FD_FXT_KOBJ_TYPE_THREAD  2
+
 FD_PROTOTYPES_BEGIN
 
 /* Event record *******************************************************/
@@ -80,6 +86,68 @@ fd_fxt_rec_event_hdr( ulong record_sz,    /* in [0,32767] */
     ( thread_ref      <<24 ) |
     ( category_ref    <<32 ) |
     ( name_ref        <<48 );
+}
+
+/* Magic number record ************************************************/
+
+static inline ulong
+fd_fxt_rec_magic_number_hdr( void ) {
+  return
+    ( FD_FXT_REC_META       << 0 ) |
+    ( 1UL                   << 4 ) |
+    ( FD_FXT_META_TRACE_INFO<<16 ) |
+    ( ((ulong)FD_FXT_MAGIC) <<24 );
+}
+
+/* Provider info metadata record **************************************/
+
+/* fd_fxt_rec_provider_info_sz gives the size of a provider info
+   metadata record in bytes (multiple of 8). */
+
+static inline ulong
+fd_fxt_rec_provider_info_sz( ulong name_sz ) {
+  return 8UL + fd_ulong_align_up( name_sz, 8UL );
+}
+
+/* fd_fxt_rec_provider_hdr constructs a provider info metadata record
+   header. */
+
+static inline ulong
+fd_fxt_rec_provider_info_hdr( ulong provider_id, /* in [0,2^32-1] */
+                              ulong name_len ) { /* in [0,255] */
+  ulong words = fd_fxt_rec_provider_info_sz( name_len )>>3;
+  return
+    ( FD_FXT_REC_META          << 0 ) |
+    ( words                    << 4 ) |
+    ( FD_FXT_META_PROVIDER_INFO<<16 ) |
+    ( provider_id              <<20 ) |
+    ( name_len                 <<52 );
+}
+
+/* Kernel object record ***********************************************/
+
+/* fd_fxt_rec_kobj_sz gives the size of a kernel object record in bytes
+   (multiple of 8). */
+
+static inline ulong
+fd_fxt_rec_kobj_sz( ulong name_sz ) {
+  return 16UL + fd_ulong_align_up( name_sz, 8UL );
+}
+
+/* fd_fxt_rec_kobj_hdr constructs a kernel object record header. */
+
+static inline ulong
+fd_fxt_rec_kobj_hdr( ulong record_sz,
+                     ulong zx_obj_type,
+                     ulong name_ref,
+                     ulong arg_cnt ) {
+  ulong words = record_sz>>3;
+  return
+    ( FD_FXT_REC_KOBJ<< 0 ) |
+    ( words          << 4 ) |
+    ( zx_obj_type    <<16 ) |
+    ( name_ref       <<24 ) |
+    ( arg_cnt        <<40 );
 }
 
 FD_PROTOTYPES_END


### PR DESCRIPTION
fd_trace_export converts events in shared-memory rings to FTF
file records.
