### PR TITLE
fix: remove last cjson workaround

### DIFF
--- a/src/disco/gui/fd_gui_config_parse.c
+++ b/src/disco/gui/fd_gui_config_parse.c
@@ -66,7 +66,7 @@ fd_gui_config_parse_validator_info_check( uchar const * data,
 
   CHECK_LEFT( sizeof(ulong) ); ulong json_str_sz = FD_LOAD( ulong, data+i ); i += sizeof(ulong);
 
-  CHECK_LEFT( json_str_sz+1UL ); /* cJSON_ParseWithLengthOpts requires having byte after the JSON payload */
+  CHECK_LEFT( json_str_sz );
   cJSON * json = cJSON_ParseWithLengthOpts( (char *)(data+i), json_str_sz, NULL, 0 );
   if( FD_UNLIKELY( !json ) ) return 0;
 


### PR DESCRIPTION
Reverts the last missing piece of https://github.com/firedancer-io/firedancer/pull/7392 after https://github.com/firedancer-io/firedancer/pull/7708 and https://github.com/firedancer-io/firedancer/pull/7711