### PR TITLE
fix: use UNIX nanoseconds for tile_heartbeat gauge

### DIFF
--- a/src/app/shared/fd_action.h
+++ b/src/app/shared/fd_action.h
@@ -15,7 +15,6 @@ union fdctl_args {
     long dt_max;
     long duration;
     uint seed;
-    double ns_per_tic;
     int drain_output_fd;
     int with_bench;
     int with_sankey;

--- a/src/disco/stem/fd_stem.c
+++ b/src/disco/stem/fd_stem.c
@@ -169,6 +169,7 @@
 #error "fd_stem requires alloca"
 #endif
 
+#include "../../util/log/fd_log.h"
 #include "../topo/fd_topo.h"
 #include "../metrics/fd_metrics.h"
 #include "../../tango/fd_tango.h"
@@ -422,7 +423,7 @@ STEM_(run1)( ulong                        in_cnt,
 
         /* Update metrics counters to external viewers */
         FD_COMPILER_MFENCE();
-        FD_MGAUGE_SET( TILE, HEARTBEAT,                 (ulong)now );
+        FD_MGAUGE_SET( TILE, HEARTBEAT,                 (ulong)fd_log_wallclock() );
         FD_MGAUGE_SET( TILE, IN_BACKPRESSURE,           metric_in_backp );
         FD_MCNT_INC  ( TILE, BACKPRESSURE_COUNT,        metric_backp_cnt );
         FD_MCNT_ENUM_COPY( TILE, REGIME_DURATION_NANOS, metric_regime_ticks );


### PR DESCRIPTION
Fixes [Issue #6848](https://github.com/firedancer-io/firedancer/issues/6848)

Changed `tile_heartbeat` to report UNIX nanoseconds using `fd_log_wallclock()` instead of raw ticks.

I'm still learning the tribal knowledge of the project, but my assessment is that `fd_log_wallclock` is performant enough for the housekeeping path. It maps to `clock_gettime(CLOCK_REALTIME)`, which typically utilizes the vDSO path.