### PR TITLE
restore: snapshot load error propagation upgrades

### DIFF
--- a/src/discof/restore/fd_snapct_tile.h
+++ b/src/discof/restore/fd_snapct_tile.h
@@ -12,32 +12,34 @@
    it goes through the process of discovering and selecting elegible
    peers from gossip to download from. */
 
-#define FD_SNAPCT_STATE_WAITING_FOR_PEERS               ( 0) /* Waiting for first peer to arrive from gossip to download from */
-#define FD_SNAPCT_STATE_WAITING_FOR_PEERS_INCREMENTAL   ( 1) /* Waiting for peers when attempting to download an incremental snapshot */
-#define FD_SNAPCT_STATE_COLLECTING_PEERS                ( 2) /* First peer arrived, wait a little longer to see if a better one arrives */
-#define FD_SNAPCT_STATE_COLLECTING_PEERS_INCREMENTAL    ( 3) /* Collecting peers to download an incremental snapshot */
+#define FD_SNAPCT_STATE_INIT                            ( 0) /* Initialization step, it determines whether to start loading from file or to download */
 
-#define FD_SNAPCT_STATE_READING_FULL_FILE               ( 4) /* Full file looks better than peer, reading it from disk */
-#define FD_SNAPCT_STATE_FLUSHING_FULL_FILE_FINI         ( 5) /* Full file was read ok, signal downstream to finish all pending operations */
-#define FD_SNAPCT_STATE_FLUSHING_FULL_FILE_DONE         ( 6) /* Full file was read ok, and all other tiles have finished processing it */
-#define FD_SNAPCT_STATE_FLUSHING_FULL_FILE_RESET        ( 7) /* Resetting to load full snapshot from file again, confirm decompress and inserter are reset too */
+#define FD_SNAPCT_STATE_WAITING_FOR_PEERS               ( 1) /* Waiting for first peer to arrive from gossip to download from */
+#define FD_SNAPCT_STATE_WAITING_FOR_PEERS_INCREMENTAL   ( 2) /* Waiting for peers when attempting to download an incremental snapshot */
+#define FD_SNAPCT_STATE_COLLECTING_PEERS                ( 3) /* First peer arrived, wait a little longer to see if a better one arrives */
+#define FD_SNAPCT_STATE_COLLECTING_PEERS_INCREMENTAL    ( 4) /* Collecting peers to download an incremental snapshot */
 
-#define FD_SNAPCT_STATE_READING_INCREMENTAL_FILE        ( 8) /* Incremental file looks better than peer, reading it from disk */
-#define FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_FILE_DONE  ( 9) /* Incremental file was read ok, signal downstream to finish all pending operations */
+#define FD_SNAPCT_STATE_READING_FULL_FILE               ( 5) /* Full file looks better than peer, reading it from disk */
+#define FD_SNAPCT_STATE_FLUSHING_FULL_FILE_FINI         ( 6) /* Full file was read ok, signal downstream to finish all pending operations */
+#define FD_SNAPCT_STATE_FLUSHING_FULL_FILE_DONE         ( 7) /* Full file was read ok, and all other tiles have finished processing it */
+#define FD_SNAPCT_STATE_FLUSHING_FULL_FILE_RESET        ( 8) /* Resetting to load full snapshot from file again, confirm decompress and inserter are reset too */
+
+#define FD_SNAPCT_STATE_READING_INCREMENTAL_FILE        ( 9) /* Incremental file looks better than peer, reading it from disk */
 #define FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_FILE_FINI  (10) /* Incremental file was read ok, and all other tiles have finished processing it */
-#define FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_FILE_RESET (11) /* Resetting to load incremental snapshot from file again, confirm decompress and inserter are reset too */
+#define FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_FILE_DONE  (11) /* Incremental file was read ok, signal downstream to finish all pending operations */
+#define FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_FILE_RESET (12) /* Resetting to load incremental snapshot from file again, confirm decompress and inserter are reset too */
 
-#define FD_SNAPCT_STATE_READING_FULL_HTTP               (12) /* Peer was selected, reading full snapshot from HTTP */
-#define FD_SNAPCT_STATE_FLUSHING_FULL_HTTP_DONE         (13) /* Full snapshot was downloaded ok, signal downstream to finish all pending operations */
+#define FD_SNAPCT_STATE_READING_FULL_HTTP               (13) /* Peer was selected, reading full snapshot from HTTP */
 #define FD_SNAPCT_STATE_FLUSHING_FULL_HTTP_FINI         (14) /* Full snapshot was downloaded ok, and all other tiles have finished processing it */
-#define FD_SNAPCT_STATE_FLUSHING_FULL_HTTP_RESET        (15) /* Resetting to load full snapshot from HTTP again, confirm decompress and inserter are reset too */
+#define FD_SNAPCT_STATE_FLUSHING_FULL_HTTP_DONE         (15) /* Full snapshot was downloaded ok, signal downstream to finish all pending operations */
+#define FD_SNAPCT_STATE_FLUSHING_FULL_HTTP_RESET        (16) /* Resetting to load full snapshot from HTTP again, confirm decompress and inserter are reset too */
 
-#define FD_SNAPCT_STATE_READING_INCREMENTAL_HTTP        (16) /* Peer was selected, reading incremental snapshot from HTTP */
-#define FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_HTTP_DONE  (17) /* Incremental snapshot was downloaded ok, signal downstream to finish all pending operations */
+#define FD_SNAPCT_STATE_READING_INCREMENTAL_HTTP        (17) /* Peer was selected, reading incremental snapshot from HTTP */
 #define FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_HTTP_FINI  (18) /* Incremental snapshot was downloaded ok, and all other tiles have finished processing it */
-#define FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_HTTP_RESET (19) /* Resetting to load incremental snapshot from HTTP again, confirm decompress and inserter are reset too */
+#define FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_HTTP_DONE  (19) /* Incremental snapshot was downloaded ok, signal downstream to finish all pending operations */
+#define FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_HTTP_RESET (20) /* Resetting to load incremental snapshot from HTTP again, confirm decompress and inserter are reset too */
 
-#define FD_SNAPCT_STATE_SHUTDOWN                        (20) /* The tile is done, and has likely already exited */
+#define FD_SNAPCT_STATE_SHUTDOWN                        (21) /* The tile is done, and has likely already exited */
 
 
 
@@ -45,6 +47,7 @@
 static inline const char *
 fd_snapct_state_str( ulong state ) {
   switch( state ) {
+    case FD_SNAPCT_STATE_INIT:                            return "init";
     case FD_SNAPCT_STATE_WAITING_FOR_PEERS:               return "waiting_for_peers";
     case FD_SNAPCT_STATE_WAITING_FOR_PEERS_INCREMENTAL:   return "waiting_for_peers_incremental";
     case FD_SNAPCT_STATE_COLLECTING_PEERS:                return "collecting_peers";

--- a/src/discof/restore/fd_snapla_tile.c
+++ b/src/discof/restore/fd_snapla_tile.c
@@ -250,7 +250,7 @@ handle_control_frag( fd_snapla_tile_t *  ctx,
        error conditions can be triggered by any tile in the pipeline,
        it is possible to be in error state and still receive otherwise
        valid messages.  Only a fail message can revert this. */
-    goto forward_msg;
+    return;
   };
 
   switch( sig ) {
@@ -317,7 +317,6 @@ handle_control_frag( fd_snapla_tile_t *  ctx,
     }
   }
 
-forward_msg:
   /* Forward the control message down the pipeline */
   fd_stem_publish( stem, FD_SNAPLA_OUT_CTRL, sig, 0UL, 0UL, 0UL, 0UL, 0UL );
 }

--- a/src/discof/restore/fd_snapwm_tile_private.h
+++ b/src/discof/restore/fd_snapwm_tile_private.h
@@ -88,6 +88,7 @@ struct fd_snapwm_tile {
 
     ulong txn_seq;  /* bstream seq of first txn record (in [seq_past,seq_present]) */
     uint  txn_active : 1;
+    uint  txn_commit : 1;
 
     ulong   duplicate_accounts_batch_sz;
     ulong   duplicate_accounts_batch_cnt;
@@ -274,6 +275,14 @@ fd_snapwm_vinyl_init_admin( fd_snapwm_tile_t * ctx,
 int
 fd_snapwm_vinyl_update_admin( fd_snapwm_tile_t * ctx,
                               int                do_rwlock );
+
+/* fd_snapwm_vinyl_meta_clean_all frees all elements of the vinyl meta
+   map, invoking fd_vinyl_meta_private_ele_free on each of them.  This
+   is typically needed when recovering from an error during a full
+   snapshot loading process. */
+
+void
+fd_snapwm_vinyl_meta_clean_all( fd_vinyl_meta_t * join );
 
 FD_PROTOTYPES_END
 


### PR DESCRIPTION
Dependent on https://github.com/firedancer-io/firedancer/pull/8178.
Introduces error propagation upgraded to the snapshot load pipeline.