### PR TITLE
bundle: connect() call should only return errno if connection error

### DIFF
--- a/src/disco/bundle/fd_bundle_client.c
+++ b/src/disco/bundle/fd_bundle_client.c
@@ -74,7 +74,8 @@ fd_bundle_client_do_connect( fd_bundle_tile_t const * ctx,
     .sin_port        = fd_ushort_bswap( ctx->server_tcp_port )
   };
   errno = 0;
-  connect( ctx->tcp_sock, fd_type_pun_const( &addr ), sizeof(struct sockaddr_in) );
+  if( FD_LIKELY( 0==connect( ctx->tcp_sock, fd_type_pun_const( &addr ), sizeof(struct sockaddr_in) ) ) ) return 0;
+  if( errno == EISCONN ) return 0;
   return errno;
 }
 


### PR DESCRIPTION
`errno` should only be returned if connect indicated failure, the man page says: `The value in errno is significant only when the return value of the call indicated an error; a function that succeeds is allowed to change errno.` . This means that connect may indicate success but also modify errno (which should be ignored) while the caller would wrongly detect an error.

ID 3