### PR TITLE
bundle: fix scratch alignment

### DIFF
--- a/src/disco/bundle/fd_bundle_tile.c
+++ b/src/disco/bundle/fd_bundle_tile.c
@@ -25,7 +25,7 @@ extern char const fdctl_version_string[];
 
 FD_FN_CONST static ulong
 scratch_align( void ) {
-  return alignof(fd_bundle_tile_t);
+  return fd_ulong_max( fd_ulong_max( alignof(fd_bundle_tile_t), fd_grpc_client_align() ), fd_alloc_align() );
 }
 
 FD_FN_CONST static ulong
@@ -35,7 +35,7 @@ scratch_footprint( fd_topo_tile_t const * tile ) {
   l = FD_LAYOUT_APPEND( l, alignof(fd_bundle_tile_t), sizeof(fd_bundle_tile_t)                        );
   l = FD_LAYOUT_APPEND( l, fd_grpc_client_align(),    fd_grpc_client_footprint( tile->bundle.buf_sz ) );
   l = FD_LAYOUT_APPEND( l, fd_alloc_align(),          fd_alloc_footprint()                            );
-  return FD_LAYOUT_FINI( l, 32 );
+  return FD_LAYOUT_FINI( l, scratch_align() );
 }
 
 FD_FN_CONST static inline ulong


### PR DESCRIPTION
The second argument for `FD_LAYOUT_FINI` is incorrect. The usage comment of `FD_LAYOUT_*` macros says: `Correct operation requires page_sz>=max(align0,align1)` , while in this case page_sz is 32 and one of the alignN values is 4096 (`fd_alloc_align()` specifically).

ID: 2