### PR TITLE
keys: remove extraneous word in help text

### DIFF
--- a/src/app/shared/commands/keys.c
+++ b/src/app/shared/commands/keys.c
@@ -44,7 +44,7 @@ keys_cmd_args( int *    pargc,
 
 err:
     FD_LOG_ERR(( "unrecognized subcommand `%s`\nusage:\n"
-                 "  keys new key <path-to-keyfile>\n"
+                 "  keys new <path-to-keyfile>\n"
                  "  keys pubkey <path-to-keyfile>\n",
                  *pargv[0] ));
 }

--- a/src/app/shared/commands/run/run.c
+++ b/src/app/shared/commands/run/run.c
@@ -768,7 +768,7 @@ run_firedancer_init( config_t * config,
                      int        check_configure ) {
   struct stat st;
   int err = stat( config->paths.identity_key, &st );
-  if( FD_UNLIKELY( -1==err && errno==ENOENT ) ) FD_LOG_ERR(( "[consensus.identity_path] key does not exist `%s`. You can generate an identity key at this path by running `fdctl keys new identity --config <toml>`", config->paths.identity_key ));
+  if( FD_UNLIKELY( -1==err && errno==ENOENT ) ) FD_LOG_ERR(( "[consensus.identity_path] key does not exist `%s`. You can generate an identity key at this path by running `fdctl keys new %s --config <toml>`", config->paths.identity_key, config->paths.identity_key ));
   else if( FD_UNLIKELY( -1==err ) )             FD_LOG_ERR(( "could not stat [consensus.identity_path] `%s` (%i-%s)", config->paths.identity_key, errno, fd_io_strerror( errno ) ));
 
   if( FD_UNLIKELY( !config->is_firedancer ) ) {

--- a/src/disco/keyguard/fd_keyload.c
+++ b/src/disco/keyguard/fd_keyload.c
@@ -71,7 +71,7 @@ read_key( char const * key_path,
           "keyfile at `%s` but there is no such file. Either update the "
           "configuration file to point to your validator identity "
           "keypair, or generate a new validator identity key by running "
-          "`fdctl keys new identity`", key_path ));
+          "`fdctl keys new %s`", key_path, key_path ));
     } else
       FD_LOG_ERR(( "Opening key file (%s) failed (%i-%s)", key_path,  errno, fd_io_strerror( errno ) ));
   }


### PR DESCRIPTION
The distinction between "identity" and "vote" key has been removed in https://github.com/firedancer-io/firedancer/pull/5216
The command only accepts "new <path-to-file>" instead of "new key <path-to-file>"