### PR TITLE
tsa: base support

### DIFF
--- a/config/extra/with-tsa.mk
+++ b/config/extra/with-tsa.mk
@@ -1,0 +1,10 @@
+ifdef FD_USING_CLANG
+# Older versions have no TSA support or false positives.
+ifeq ($(shell test $(CC_MAJOR_VERSION) -ge 18 && echo yes),yes)
+CPPFLAGS+=-Wthread-safety
+else
+$(error EXTRAS=tsa requires clang >= 18 (detected CC=$(CC), version $(CC_MAJOR_VERSION)))
+endif
+else
+$(error EXTRAS=tsa requires clang >= 18 (detected CC=$(CC)); GCC/other compilers are unsupported)
+endif

--- a/contrib/thread-safety-analysis/check.py
+++ b/contrib/thread-safety-analysis/check.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Run Thread Safety Analysis (TSA) and print the result to stdout
+as bullet points or as SARIF v2 JSON.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import OrderedDict
+from pathlib import Path
+from typing import Dict, List
+
+
+WARNING_LINE_RE = re.compile(
+    r"^(?P<path>[^:\n]+):(?P<line>\d+):(?P<col>\d+): (?P<level>warning|error): (?P<msg>.*)$"
+)
+WARNING_OPTS_RE = re.compile(r"\[(?P<opts>[^\]]+)\]\s*$")
+
+
+def run_tsa_check(repo_root: Path) -> subprocess.CompletedProcess:
+    cmd = ["make", "-k", "-j", "--output-sync=line", "check"]
+    env = os.environ.copy()
+    extras = env.get("EXTRAS", "").split()
+    if "tsa" not in extras:
+        extras.append("tsa")
+    env["EXTRAS"] = " ".join(extras)
+    env["CC"] = "clang"
+
+    return subprocess.run(
+        cmd,
+        cwd=str(repo_root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        check=False,
+    )
+
+
+def parse_tsa_warnings(log: str) -> List[Dict[str, object]]:
+    warnings: List[Dict[str, object]] = []
+    seen = set()
+
+    for raw_line in log.splitlines():
+        if "Wthread-safety" not in raw_line:
+            continue
+
+        match = WARNING_LINE_RE.match(raw_line)
+        if not match:
+            continue
+
+        path = os.path.normpath(match.group("path"))
+        line = int(match.group("line"))
+        col = int(match.group("col"))
+        level = match.group("level")
+        msg = match.group("msg").strip()
+
+        opt_match = WARNING_OPTS_RE.search(msg)
+        if not opt_match:
+            continue
+
+        options = [opt.strip() for opt in opt_match.group("opts").split(",")]
+        option = next(
+            (opt for opt in options if opt.startswith("-Wthread-safety")),
+            None,
+        )
+        if option is None:
+            continue
+
+        message = msg[: opt_match.start()].rstrip()
+
+        dedup_key = (path, line, col, message, option)
+        if dedup_key in seen:
+            continue
+        seen.add(dedup_key)
+
+        warnings.append(
+            {
+                "path": path,
+                "line": line,
+                "col": col,
+                "message": message,
+                "option": option,
+                "level": level,
+            }
+        )
+
+    return warnings
+
+
+def emit_bullets(warnings: List[Dict[str, object]]) -> None:
+    grouped: "OrderedDict[str, List[Dict[str, object]]]" = OrderedDict()
+
+    for warning in warnings:
+        path = str(warning["path"])
+        if path not in grouped:
+            grouped[path] = []
+        grouped[path].append(warning)
+
+    for path, file_warnings in grouped.items():
+        print(f"- {path}")
+        for warning in file_warnings:
+            line = int(warning["line"])
+            col = int(warning["col"])
+            message = str(warning["message"])
+            option = str(warning["option"])
+            print(f"  - {line}:{col}: {message} [{option}]")
+
+
+def emit_sarif(warnings: List[Dict[str, object]]) -> None:
+    rules: "OrderedDict[str, Dict[str, object]]" = OrderedDict()
+    results: List[Dict[str, object]] = []
+
+    for warning in warnings:
+        option = str(warning["option"])
+        rule_id = option.lstrip("-")
+
+        if rule_id not in rules:
+            rules[rule_id] = {
+                "id": rule_id,
+                "name": option,
+                "shortDescription": {
+                    "text": f"Clang thread safety warning ({option})"
+                },
+                "defaultConfiguration": {"level": "warning"},
+            }
+
+        results.append(
+            {
+                "ruleId": rule_id,
+                "level": str(warning["level"]),
+                "message": {"text": str(warning["message"])},
+                "locations": [
+                    {
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": str(warning["path"])},
+                            "region": {
+                                "startLine": int(warning["line"]),
+                                "startColumn": int(warning["col"]),
+                            },
+                        }
+                    }
+                ],
+            }
+        )
+
+    sarif_doc = {
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "firedancer-thread-safety-analysis",
+                        "informationUri": "https://clang.llvm.org/docs/ThreadSafetyAnalysis.html",
+                        "rules": list(rules.values()),
+                    }
+                },
+                "results": results,
+            }
+        ],
+    }
+
+    print(json.dumps(sarif_doc, sort_keys=False, separators=(",", ":")))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run TSA checks and emit per-file bullets or SARIF v2."
+    )
+    parser.add_argument(
+        "--sarif-2",
+        action="store_true",
+        help="Emit findings as SARIF 2.1.0 JSON.",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    result = run_tsa_check(repo_root)
+    warnings = parse_tsa_warnings(result.stdout)
+
+    if args.sarif_2:
+        emit_sarif(warnings)
+    else:
+        emit_bullets(warnings)
+
+    if result.returncode != 0 and not warnings:
+        sys.stderr.write(result.stdout)
+        if result.stdout and not result.stdout.endswith("\n"):
+            sys.stderr.write("\n")
+
+    return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/flamenco/fd_rwlock.h
+++ b/src/flamenco/fd_rwlock.h
@@ -4,8 +4,9 @@
 /* A very simple read-write spin lock. */
 
 #include "../util/fd_util_base.h"
+#include "../util/sanitize/fd_tsa.h"
 
-struct fd_rwlock {
+struct FD_CAPABILITY("fd_rwlock") fd_rwlock {
   ushort value; /* Bits 0..16 are
 
                     0: Unlocked
@@ -15,6 +16,7 @@ struct fd_rwlock {
 
 typedef struct fd_rwlock fd_rwlock_t;
 
+
 static inline fd_rwlock_t *
 fd_rwlock_new( fd_rwlock_t * lock ) {
   lock->value = 0;
@@ -22,7 +24,7 @@ fd_rwlock_new( fd_rwlock_t * lock ) {
 }
 
 static inline void
-fd_rwlock_write( fd_rwlock_t * lock ) {
+fd_rwlock_write( fd_rwlock_t * lock ) FD_ACQUIRE( lock ) FD_NO_THREAD_SAFETY_ANALYSIS  {
 # if FD_HAS_THREADS
   for(;;) {
     ushort value = lock->value;
@@ -38,20 +40,18 @@ fd_rwlock_write( fd_rwlock_t * lock ) {
 }
 
 static inline void
-fd_rwlock_unwrite( fd_rwlock_t * lock ) {
+fd_rwlock_unwrite( fd_rwlock_t * lock ) FD_RELEASE( lock ) FD_NO_THREAD_SAFETY_ANALYSIS {
   FD_COMPILER_MFENCE();
   lock->value = 0;
 }
 
 static inline void
-fd_rwlock_read( fd_rwlock_t * lock ) {
+fd_rwlock_read( fd_rwlock_t * lock ) FD_ACQUIRE_SHARED( lock ) FD_NO_THREAD_SAFETY_ANALYSIS  {
 # if FD_HAS_THREADS
   for(;;) {
     ushort value = lock->value;
     if( FD_UNLIKELY( value<0xFFFE ) ) {
-      if( FD_LIKELY( FD_ATOMIC_CAS( &lock->value, value, value+1 )==value ) ) {
-        return;
-      }
+      if( FD_LIKELY( FD_ATOMIC_CAS( &lock->value, value, value+1 )==value ) ) return;
     }
     FD_SPIN_PAUSE();
   }
@@ -62,7 +62,7 @@ fd_rwlock_read( fd_rwlock_t * lock ) {
 }
 
 static inline void
-fd_rwlock_unread( fd_rwlock_t * lock ) {
+fd_rwlock_unread( fd_rwlock_t * lock ) FD_RELEASE_SHARED( lock ) FD_NO_THREAD_SAFETY_ANALYSIS {
   FD_COMPILER_MFENCE();
 # if FD_HAS_THREADS
   FD_ATOMIC_FETCH_AND_SUB( &lock->value, 1 );

--- a/src/util/sanitize/Local.mk
+++ b/src/util/sanitize/Local.mk
@@ -1,4 +1,4 @@
-$(call add-hdrs,fd_asan.h fd_msan.h fd_sanitize.h)
+$(call add-hdrs,fd_asan.h fd_msan.h fd_tsa.h fd_sanitize.h)
 ifdef FD_HAS_HOSTED
 $(call make-lib,fd_fuzz_stub)
 $(call add-objs,fd_fuzz_stub,fd_fuzz_stub)

--- a/src/util/sanitize/fd_sanitize.h
+++ b/src/util/sanitize/fd_sanitize.h
@@ -13,5 +13,6 @@
 
 #include "fd_asan.h"
 #include "fd_msan.h"
+#include "fd_tsa.h"
 
 #endif /* HEADER_fd_src_util_sanitize_fd_sanitize_h */

--- a/src/util/sanitize/fd_tsa.h
+++ b/src/util/sanitize/fd_tsa.h
@@ -1,0 +1,68 @@
+#ifndef HEADER_fd_src_util_sanitize_fd_tsa_h
+#define HEADER_fd_src_util_sanitize_fd_tsa_h
+
+/* Adopted from
+   https://github.com/llvm/llvm-project/blob/5e4f17714259361ca3b355085ff61288aad6f30f/compiler-rt/lib/scudo/standalone/thread_annotations.h
+ */
+
+#if FD_USING_CLANG
+#  define THREAD_ANNOTATION_ATTRIBUTE_(x) __attribute__((x))
+#else
+#  define THREAD_ANNOTATION_ATTRIBUTE_(x)
+#endif
+
+
+#define FD_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE_(capability(x))
+
+#define FD_SCOPED_CAPABILITY THREAD_ANNOTATION_ATTRIBUTE_(scoped_lockable)
+
+#define FD_GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE_(guarded_by(x))
+
+#define FD_PT_GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE_(pt_guarded_by(x))
+
+#define FD_ACQUIRED_BEFORE(...)                                                   \
+  THREAD_ANNOTATION_ATTRIBUTE_(acquired_before(__VA_ARGS__))
+
+#define FD_ACQUIRED_AFTER(...)                                                    \
+  THREAD_ANNOTATION_ATTRIBUTE_(acquired_after(__VA_ARGS__))
+
+#define FD_REQUIRES(...)                                                          \
+  THREAD_ANNOTATION_ATTRIBUTE_(requires_capability(__VA_ARGS__))
+
+#define FD_REQUIRES_SHARED(...)                                                   \
+  THREAD_ANNOTATION_ATTRIBUTE_(requires_shared_capability(__VA_ARGS__))
+
+#define FD_ACQUIRE(...)                                                           \
+  THREAD_ANNOTATION_ATTRIBUTE_(acquire_capability(__VA_ARGS__))
+
+#define FD_ACQUIRE_SHARED(...)                                                    \
+  THREAD_ANNOTATION_ATTRIBUTE_(acquire_shared_capability(__VA_ARGS__))
+
+#define FD_RELEASE(...)                                                           \
+  THREAD_ANNOTATION_ATTRIBUTE_(release_capability(__VA_ARGS__))
+
+#define FD_RELEASE_SHARED(...)                                                    \
+  THREAD_ANNOTATION_ATTRIBUTE_(release_shared_capability(__VA_ARGS__))
+
+#define FD_RELEASE_GENERIC(...)                                                   \
+  THREAD_ANNOTATION_ATTRIBUTE_(release_generic_capability(__VA_ARGS__))
+
+#define FD_TRY_ACQUIRE(...)                                                       \
+  THREAD_ANNOTATION_ATTRIBUTE_(try_acquire_capability(__VA_ARGS__))
+
+#define FD_TRY_ACQUIRE_SHARED(...)                                                \
+  THREAD_ANNOTATION_ATTRIBUTE_(try_acquire_shared_capability(__VA_ARGS__))
+
+#define FD_EXCLUDES(...) THREAD_ANNOTATION_ATTRIBUTE_(locks_excluded(__VA_ARGS__))
+
+#define FD_ASSERT_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE_(assert_capability(x))
+
+#define FD_ASSERT_SHARED_CAPABILITY(x)                                            \
+  THREAD_ANNOTATION_ATTRIBUTE_(assert_shared_capability(x))
+
+#define FD_RETURN_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE_(lock_returned(x))
+
+#define FD_NO_THREAD_SAFETY_ANALYSIS                                              \
+  THREAD_ANNOTATION_ATTRIBUTE_(no_thread_safety_analysis)
+
+#endif /* HEADER_fd_src_util_sanitize_fd_tsa_h */


### PR DESCRIPTION
Introduces basic Thread Safety Analyser support. In contrast to #7189, this does only adds support + a script to see the TSA warnings. As discussed offline with @ripatel-fd, follow up PRs will add annotations support to individual components. Later with the follow-up PRs merged we can decide if we want to run TSA on every PR, or if we want to use the sarif v2 output from the checker script and feed it into GitHub code scanning in nightly.