### PR TITLE
restore: snapshot load vinyl recovery

### DIFF
--- a/src/discof/restore/fd_snapin_tile_vinyl.c
+++ b/src/discof/restore/fd_snapin_tile_vinyl.c
@@ -56,8 +56,9 @@ fd_snapin_process_account_header_vinyl( fd_snapin_tile_t *            ctx,
 
   phdr->ctl = fd_vinyl_bstream_ctl( FD_VINYL_BSTREAM_CTL_TYPE_PAIR, FD_VINYL_BSTREAM_CTL_STYLE_RAW, val_sz );
   fd_vinyl_key_init( &phdr->key, result->account_header.pubkey, 32UL );
-  phdr->info.val_sz = (uint)val_sz;
-  phdr->info.ul[1]  = result->account_header.slot;
+  phdr->info.val_sz  = (uint)val_sz; /* info.ui[ 0 ] */
+  phdr->info.ui[ 1 ] = 0U;
+  phdr->info.ul[ 1 ] = result->account_header.slot;
 
   dst     += sizeof(fd_vinyl_bstream_phdr_t);
   dst_rem -= sizeof(fd_vinyl_bstream_phdr_t);
@@ -147,10 +148,11 @@ fd_snapin_process_account_batch_vinyl( fd_snapin_tile_t *            ctx,
     FD_CRIT( dst_rem >= sizeof(fd_vinyl_bstream_phdr_t), "corruption detected" );
     fd_vinyl_bstream_phdr_t * phdr = (fd_vinyl_bstream_phdr_t *)dst;
     memset( phdr, 0, sizeof(fd_vinyl_bstream_phdr_t) );
-    phdr->ctl         = fd_vinyl_bstream_ctl( FD_VINYL_BSTREAM_CTL_TYPE_PAIR, FD_VINYL_BSTREAM_CTL_STYLE_RAW, val_sz );
-    phdr->key         = *key;
-    phdr->info.val_sz = (uint)val_sz;
-    phdr->info.ul[1]  = result->account_batch.slot;
+    phdr->ctl          = fd_vinyl_bstream_ctl( FD_VINYL_BSTREAM_CTL_TYPE_PAIR, FD_VINYL_BSTREAM_CTL_STYLE_RAW, val_sz );
+    phdr->key          = *key;
+    phdr->info.val_sz  = (uint)val_sz; /* info.ui[ 0 ] */
+    phdr->info.ui[ 1 ] = 0U;
+    phdr->info.ul[ 1 ] = result->account_batch.slot;
 
     dst     += sizeof(fd_vinyl_bstream_phdr_t);
     dst_rem -= sizeof(fd_vinyl_bstream_phdr_t);

--- a/src/discof/restore/fd_snapwm_tile.c
+++ b/src/discof/restore/fd_snapwm_tile.c
@@ -174,10 +174,24 @@ handle_control_frag( fd_snapwm_tile_t *  ctx,
       FD_TEST( ctx->state==FD_SNAPSHOT_STATE_IDLE );
       ctx->state = FD_SNAPSHOT_STATE_PROCESSING;
       ctx->full = sig==FD_SNAPSHOT_MSG_CTRL_INIT_FULL;
-      if( sig==FD_SNAPSHOT_MSG_CTRL_INIT_INCR ) {
+      /* When lthash verification is disabled, vinyl txn operation can
+         be used, providing a fast revert mechanism when the incr
+         snapshot is cancelled.  However, when the lthash verification
+         is enabled, the meta map needs to be updated as the accounts
+         are processed, in order to detemine which duplicates are new
+         and which are old.  This prevents us from using txn_commit
+         when lthash is enabled.  (In more detail: the need of having
+         recovery_seq in the pair's phdr info makes an update on the
+         bstream during txn_commit not feasible, since it would require
+         recomputing the pair's integrity hashes).  For the case when
+         lthash verification is enabled, there is a recovery mechanism
+         in place. */
+      if( sig==FD_SNAPSHOT_MSG_CTRL_INIT_INCR && ctx->lthash_disabled ) {
         fd_snapwm_vinyl_txn_begin( ctx );
       }
       fd_snapwm_vinyl_wd_init( ctx );
+      /* backup bstream seq, independent of whether full or incr. */
+      fd_snapwm_vinyl_recovery_seq_backup( ctx );
 
       /* There is a way to avoid a lock here: every other writer, in
          particular the write tiles that update wr_seq, have already
@@ -204,12 +218,7 @@ handle_control_frag( fd_snapwm_tile_t *  ctx,
     case FD_SNAPSHOT_MSG_CTRL_FINI: {
       FD_TEST( ctx->state==FD_SNAPSHOT_STATE_PROCESSING );
       ctx->state = FD_SNAPSHOT_STATE_FINISHING;
-
       fd_snapwm_vinyl_wd_fini( ctx );
-
-      /* FIXME vinyl_txn_commit should not happen in fini (it should
-         happen either in NEXT or DONE).  This is a temporary patch,
-         it will be corrected in an upcoming PR.  TODO. */
       if( ctx->vinyl.txn_active ) {
         fd_snapwm_vinyl_txn_commit( ctx, stem );
       }
@@ -241,9 +250,6 @@ handle_control_frag( fd_snapwm_tile_t *  ctx,
       FD_TEST( ctx->state==FD_SNAPSHOT_STATE_FINISHING );
       ctx->state = FD_SNAPSHOT_STATE_IDLE;
 
-      /* FIXME re-enable fd_snapwm_vinyl_txn_commit here once recovery
-         is fully implemented. */
-
       if( FD_UNLIKELY( verify_slot_deltas_with_slot_history( ctx ) ) ) {
         if( ctx->full ) FD_LOG_WARNING(( "slot deltas verification failed for full snapshot" ));
         else            FD_LOG_WARNING(( "slot deltas verification failed for incremental snapshot" ));
@@ -264,11 +270,14 @@ handle_control_frag( fd_snapwm_tile_t *  ctx,
       FD_TEST( ctx->state!=FD_SNAPSHOT_STATE_SHUTDOWN );
       ctx->state = FD_SNAPSHOT_STATE_IDLE;
       fd_snapwm_vinyl_wd_fini( ctx );
-      if( ctx->vinyl.txn_active ) {
-        fd_snapwm_vinyl_txn_cancel( ctx );
-      }
       if( ctx->full ) {
-        fd_snapwm_vinyl_meta_clean_all( ctx->vinyl.map );
+        fd_snapwm_vinyl_revert_full( ctx );
+      } else {
+        if( ctx->vinyl.txn_active ) {
+          fd_snapwm_vinyl_txn_cancel( ctx );
+        } else {
+          fd_snapwm_vinyl_revert_incr( ctx );
+        }
       }
       break;
     }

--- a/src/discof/restore/fd_snapwm_tile_private.h
+++ b/src/discof/restore/fd_snapwm_tile_private.h
@@ -98,6 +98,13 @@ struct fd_snapwm_tile {
 
     ulong              wr_cnt;
     fd_vinyl_admin_t * admin;
+
+   struct {
+      ulong seq_ancient;
+      ulong seq_past;
+      ulong seq_present;
+      ulong seq_future;
+   } recovery;
   } vinyl;
 };
 
@@ -276,13 +283,83 @@ int
 fd_snapwm_vinyl_update_admin( fd_snapwm_tile_t * ctx,
                               int                do_rwlock );
 
-/* fd_snapwm_vinyl_meta_clean_all frees all elements of the vinyl meta
-   map, invoking fd_vinyl_meta_private_ele_free on each of them.  This
-   is typically needed when recovering from an error during a full
-   snapshot loading process. */
+/* fd_snapwm_vinyl_recovery_seq_{backup,apply} are helper functions
+   that handle vinyl io bstream seq backup and apply (for recovery).
+   Both operate on vinyl io_mm seq values, since this is the io that
+   keeps track of those values.  That means that backup must happen
+   after io init, and apply must happen before io sync.  */
 
 void
-fd_snapwm_vinyl_meta_clean_all( fd_vinyl_meta_t * join );
+fd_snapwm_vinyl_recovery_seq_backup( fd_snapwm_tile_t * ctx );
+
+void
+fd_snapwm_vinyl_recovery_seq_apply( fd_snapwm_tile_t * ctx );
+
+/* fd_snapwm_vinyl_revert_full provides the mechanism to revert any
+   changes that happened during a full snapshot load that has been
+   cancelled.  It frees all elements of the vinyl meta map.  Finally,
+   it reverts the bstream seq(s) in vinyl io and syncs the bstream. */
+
+void
+fd_snapwm_vinyl_revert_full( fd_snapwm_tile_t * ctx );
+
+/* fd_snapwm_vinyl_revert_incr provides the mechanism to revert any
+   changes that happened during an incr snapshot load that has been
+   cancelled.  To do this, every bstream pair's phdr info, as well
+   as the corresponding meta map element's phdr info, is modified to
+   include val_sz (32 bits), recovery_seq (48 bits) and slot (48 bits)
+   in the info length of 16 bytes (128 bits).  When a new account is
+   written to the bstream, recovery_seq=0UL is assigned (which works
+   as a sentinel value).  When an account is a duplicate update of an
+   existing account, the update's recovery_seq corresponds to the seq
+   value of the existing account in the bstream.  This is essentially
+   a reference to the account that is being superseded.
+
+      bstream:  [     full     |  incr  |   free  )
+      revert:                 (*)->......)
+
+   To revert the incremental snapshot, the function walks the bstream
+   from recovery seq_present (*) towards the future, until all pairs
+   are processed.  If the recovery_seq (in the pair's phdr info) is
+   0UL (the sentinel) this account was a new account, and the meta map
+   entry needs to be freed.  If the recovery_seq is less than the
+   recovery seq_present, the phdr of the pair at recovery_seq is read,
+   and used to update the meta map element.  If the recovery_seq is
+   greater or equal to the recovery seq_present, this means that the
+   update was a duplicate on the incr snapshot itself, and it can
+   be discarded altogether.
+   Note that as the recovery process moves forward, the meta map entry
+   and an account update on the incr side of the bstream may see
+   different revovery_seq values (e.g. consider what happens with
+   chained duplicate updates).  This means that the true recovery_seq
+   is the one in the phdr info of the bstream pair.
+   Finally, it reverts the bstream seq(s) in vinyl io and syncs the
+   bstream. */
+
+void
+fd_snapwm_vinyl_revert_incr( fd_snapwm_tile_t * ctx );
+
+/* fd_snapin_vinyl_pair_info_{from_parts,update_recovery_seq} are
+   helper functions to update the pair's info.
+   fd_snapin_vinyl_pair_info_{val_sz,recovery_seq,slot} are helper
+   functions to retrieve the corresponding values.
+   In order to facilitate a recovery process, in particular when an
+   incr snapshot is cancelled, every bstream pair's phdr info, as well
+   as the corresponding meta map element's phdr info, is modified to
+   include val_sz (32 bits), recovery_seq (48 bits) and slot (48 bits)
+   in the info length of 16 bytes (128 bits). */
+
+void
+fd_snapin_vinyl_pair_info_from_parts( fd_vinyl_info_t * info,
+                                      ulong             val_sz,
+                                      ulong             recovery_seq,
+                                      ulong             slot );
+void
+fd_snapin_vinyl_pair_info_update_recovery_seq( fd_vinyl_info_t * info,
+                                               ulong             recovery_seq );
+ulong fd_snapin_vinyl_pair_info_val_sz      ( fd_vinyl_info_t const * info );
+ulong fd_snapin_vinyl_pair_info_recovery_seq( fd_vinyl_info_t const * info );
+ulong fd_snapin_vinyl_pair_info_slot        ( fd_vinyl_info_t const * info );
 
 FD_PROTOTYPES_END
 


### PR DESCRIPTION
Provides recovery mechanisms in the snapshot load pipeline under vinyl when either snapshot (full or incr) is cancelled.
