### PR TITLE
FiredancerOS kernel build target

### DIFF
--- a/.github/workflows/fdos.yml
+++ b/.github/workflows/fdos.yml
@@ -1,0 +1,27 @@
+
+name: FiredancerOS
+on:
+  workflow_call:
+  workflow_dispatch:
+concurrency:
+  group: tests_${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  build_fdos:
+    timeout-minutes: 10
+    runs-on:
+      labels: ${{ matrix.label }}
+      group: fd-public-repo
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+      - run: pip install meson
+
+      - uses: ./.github/actions/deps
+        with:
+          extras: "+embedded"
+
+      - name: build
+        run: |
+          make -j MACHINE=fdos_kern_x86 -Otarget lib

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -58,3 +58,6 @@ jobs:
       machine: linux_gcc_icelake,linux_gcc_x86_64
       build_arm: false
       check_run: true
+  fdos:
+    if: github.event.pull_request.draft == false
+    uses: ./.github/workflows/fdos.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,13 +51,6 @@ jobs:
             compiler-version: 12.4.0
             run-unit-tests: true
             run-integration-tests: true
-          - test-case: non-hosted
-            machine: bare_clang_x86_64
-            label: X64
-            extras: "no-deps"
-            targets: "lib"
-            compiler: clang
-            compiler-version: 19.1.7
     runs-on:
       labels: ${{ matrix.label }}
       group: fd-public-repo

--- a/config/machine/fdos_kern_x86.mk
+++ b/config/machine/fdos_kern_x86.mk
@@ -1,0 +1,16 @@
+# Self-hosted x86 environment, for use as an operating system kernel
+
+BUILDDIR:=fdos/kern/x86_64
+include config/machine/bare_clang_x86_64.mk
+
+ifeq ($(wildcard opt/cross/x86/include/stdlib.h),)
+$(error Embedded libc not found. Run ./deps.sh +embedded)
+endif
+
+CPPFLAGS+=\
+  -isystem opt/cross/x86/include \
+  -isystem "$(shell $(CC) -print-resource-dir)/include" \
+  -nostdinc
+
+FD_FDOS_KERN:=1
+CPPFLAGS+=-DFD_FDOS_KERN=1

--- a/deps.sh
+++ b/deps.sh
@@ -35,6 +35,7 @@ PREFIX="$(pwd)/opt"
 
 DEVMODE=0
 MSAN=0
+EMBEDDED=0
 _CC="${CC:=gcc}"
 _CXX="${CXX:=g++}"
 EXTRA_CFLAGS="-g3 -fno-omit-frame-pointer"
@@ -143,7 +144,10 @@ fetch () {
     checkout_repo bzip2   https://gitlab.com/bzip2/bzip2              "bzip2-1.0.8"
     checkout_repo rocksdb https://github.com/facebook/rocksdb         "v10.5.1"
     checkout_repo snappy  https://github.com/google/snappy            "1.2.2"
-    checkout_repo flatcc    https://github.com/dvidelabs/flatcc.git     "" "3ae5eda"
+    checkout_repo flatcc  https://github.com/dvidelabs/flatcc         "" "3ae5eda"
+  fi
+  if [[ $EMBEDDED == 1 ]]; then
+    checkout_repo picolibc https://github.com/picolibc/picolibc       "1.8.11"
   fi
 }
 
@@ -644,6 +648,53 @@ install_flatcc () {
   echo "[+] Successfully installed flatcc"
 }
 
+install_picolibc () {
+  echo "[+] Installing picolibc"
+  cd "$PREFIX/git/picolibc"
+  cat <<EOF > x86_64-unknown-elf.txt
+[binaries]
+c = 'clang'
+
+[host_machine]
+system = 'unknown'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+
+[properties]
+c_args = [
+  '--target=x86_64-unknown-elf',
+  '--no-default-config',
+  '-ffreestanding',
+  '-fno-plt',
+  '-fno-pie',
+  '-fno-pic',
+  '-static',
+  '-fno-common',
+  '-nostdlib',
+  '-nostartfiles',
+  '-nodefaultlibs',
+  '-mcmodel=medium',
+  '-mno-red-zone'
+  ]
+needs_exe_wrapper = true
+skip_sanity_check = true
+EOF
+  meson setup \
+    --wipe \
+    --cross-file x86_64-unknown-elf.txt \
+    build-x86 \
+    -Dmultilib=false \
+    -Dpicocrt=false \
+    -Dinitfini-array=false \
+    -Dthread-local-storage=false \
+    -Dsingle-thread=true \
+    -Dsemihost=false \
+    -Dprefix="$PREFIX/cross/x86"
+  meson compile -C build-x86
+  meson install -C build-x86
+}
+
 install () {
   CC="$(command -v $_CC)"
   cc="$CC"
@@ -674,6 +725,9 @@ install () {
     ( install_snappy    )
     ( install_rocksdb   )
     ( install_flatcc    )
+  fi
+  if [[ $EMBEDDED == 1 ]]; then
+    ( install_picolibc  )
   fi
 
   # Merge lib64 with lib
@@ -708,6 +762,10 @@ while [[ $# -gt 0 ]]; do
     "+dev")
       shift
       DEVMODE=1
+      ;;
+    "+embedded")
+      shift
+      EMBEDDED=1
       ;;
     nuke)
       shift


### PR DESCRIPTION
This patch provides C language support for the FiredancerOS para-virtualized kernel. 
Uses picolibc with minimal configuration as libc, and Clang as the cross-compiler.

The new machine target `fdos_kern_x86_64` produces compile objects suitable for running in an x86 ring 0 environment. 