### PR TITLE
fdos: add minimal OS kernel

### DIFF
--- a/.github/workflows/fdos.yml
+++ b/.github/workflows/fdos.yml
@@ -1,10 +1,9 @@
-
 name: FiredancerOS
 on:
   workflow_call:
   workflow_dispatch:
 concurrency:
-  group: tests_${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: fdos_${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   build_fdos:

--- a/deps.sh
+++ b/deps.sh
@@ -690,6 +690,7 @@ EOF
     -Dthread-local-storage=false \
     -Dsingle-thread=true \
     -Dsemihost=false \
+    -Dio-float-exact=false \
     -Dprefix="$PREFIX/cross/x86"
   meson compile -C build-x86
   meson install -C build-x86

--- a/src/fdos/kern/Local.mk
+++ b/src/fdos/kern/Local.mk
@@ -1,0 +1,14 @@
+ifdef FD_FDOS_KERN
+$(OBJDIR)/bin/fdos_kern.elf: src/fdos/kern/fdos_kern.ld $(OBJDIR)/obj/fdos/kern/fdos_kern.o $(OBJDIR)/lib/libfd_util.a
+	mkdir -p $(dir $@) && \
+    ld.lld \
+	--no-undefined \
+	--no-dynamic-linker \
+	--static \
+	-T src/fdos/kern/fdos_kern.ld \
+	-o $@ \
+	$(OBJDIR)/obj/fdos/kern/fdos_kern.o \
+	$(OBJDIR)/lib/libfd_util.a \
+	$(OPT)/cross/x86/lib/libc.a \
+	$(OPT)/cross/x86/lib/libnosys.a
+endif

--- a/src/fdos/kern/fdos_hypercall.h
+++ b/src/fdos/kern/fdos_hypercall.h
@@ -1,0 +1,31 @@
+#ifndef HEADER_fd_src_fdos_kern_fdos_hypercall_h
+#define HEADER_fd_src_fdos_kern_fdos_hypercall_h
+
+/* fdos_hypercall.h provides the ABI for kernel-to-host hypercalls.
+   This mechanism is used by the fdos kernel to sychronously send
+   messages to the KVM host (e.g. logging). */
+
+#include "../../util/fd_util_base.h"
+
+/* kernel boot parameters */
+
+struct fdos_kern_args {
+  ulong hyper_args_gvaddr;
+  ulong stack_user_top_gvaddr;
+};
+
+typedef struct fdos_kern_args fdos_kern_args_t;
+
+/* FDOS_HYPERCALL_* give hypercall IDs. */
+
+#define FDOS_HYPERCALL_LOG 1
+
+/* fd_hypercall_args_t holds hypercall request and reply arguments. */
+
+struct fd_hypercall_args {
+  ulong arg[5];
+};
+
+typedef struct fd_hypercall_args fd_hypercall_args_t;
+
+#endif /* HEADER_fd_src_fdos_kern_fdos_hypercall_h */

--- a/src/fdos/kern/fdos_kern.c
+++ b/src/fdos/kern/fdos_kern.c
@@ -1,0 +1,242 @@
+/* Entrypoint for FiredancerOS kernel */
+
+#include "fdos_hypercall.h"
+#include "../../util/log/fd_log.h"
+#include <stdarg.h>
+#include <stdio.h>
+
+/* fd_util system environment *****************************************/
+
+static fd_hypercall_args_t volatile * g_hyper = NULL;
+
+long
+fd_log_wallclock( void ) {
+  return (long)fd_tickcount();
+}
+
+#define FD_LOG_BUF_SZ (32UL*4096UL)
+
+static char fd_log_private_log_msg[ FD_LOG_BUF_SZ ];
+static ulong
+hypercall_log( ulong arg0,
+               ulong arg1,
+               ulong arg2,
+               ulong arg3,
+               ulong arg4 ) {
+  g_hyper->arg[0] = arg0;
+  g_hyper->arg[1] = arg1;
+  g_hyper->arg[2] = arg2;
+  g_hyper->arg[3] = arg3;
+  g_hyper->arg[4] = arg4;
+
+  __asm__ volatile (
+    "movw %[port], %%dx;\n"
+    "outsl;\n"
+    :
+    : [port] "r" ((ushort)FDOS_HYPERCALL_LOG)
+    : "rdx", "memory"
+  );
+
+  return g_hyper->arg[0];
+}
+
+char const *
+fd_log_private_0( char const * fmt, ... ) {
+  va_list ap;
+  va_start( ap, fmt );
+  int len = vsnprintf( fd_log_private_log_msg, FD_LOG_BUF_SZ, fmt, ap );
+  if( len<0                        ) len = 0;                        /* cmov */
+  if( len>(int)(FD_LOG_BUF_SZ-1UL) ) len = (int)(FD_LOG_BUF_SZ-1UL); /* cmov */
+  fd_log_private_log_msg[ len ] = '\0';
+  va_end( ap );
+  return fd_log_private_log_msg;
+}
+
+void
+fd_log_private_1( int          level,
+                  long         now,
+                  char const * file,
+                  int          line,
+                  char const * func,
+                  char const * msg ) {
+  (void)now;
+  hypercall_log(
+      /* arg0 */ (ulong)level,
+      /* arg1 */ (ulong)file,
+      /* arg2 */ (ulong)line,
+      /* arg3 */ (ulong)func,
+      /* arg4 */ (ulong)msg
+  );
+}
+
+__attribute__((noreturn)) void
+fd_log_private_2( int          level,
+                  long         now,
+                  char const * file,
+                  int          line,
+                  char const * func,
+                  char const * msg ) {
+  (void)now;
+  hypercall_log(
+      /* arg0 */ (ulong)level,
+      /* arg1 */ (ulong)file,
+      /* arg2 */ (ulong)line,
+      /* arg3 */ (ulong)func,
+      /* arg4 */ (ulong)msg
+  );
+  __asm__ volatile ("hlt");
+  for(;;) {}
+}
+
+/* Context switching **************************************************/
+
+void
+syscall_handler( void );
+
+struct fd_jmp_buf {
+  ulong rbx;
+  ulong rbp;
+  ulong r12;
+  ulong r13;
+  ulong r14;
+  ulong r15;
+  ulong rsp;
+  ulong ret;
+};
+
+typedef struct fd_jmp_buf fd_jmp_buf_t;
+
+fd_jmp_buf_t g_sysret;
+
+static void
+hello_ring3( void ) {
+  FD_LOG_NOTICE(( "Hello from ring 3!" ));
+  FD_LOG_NOTICE(( "Returning to ring 0" ));
+  __asm__ volatile (
+      "movq $1, %rax;\n"
+      "syscall;\n"
+  );
+}
+
+static void
+bounce_ring3( void ) {
+  __asm__ volatile (
+      "syscall;\n"
+  );
+}
+
+__attribute__((naked)) void
+enter_ring3( ulong user_stack_top_gpaddr,
+             ulong function ) {
+  __asm__ volatile (
+      "pushq $0x23;\n" /* segment 4 */
+      "pushq %rdi;\n"  /* user stack */
+      "pushq $0x1b;\n" /* segment 3 */
+      "pushq %rsi;\n"
+      "movl $0x23, %eax;\n"
+      "movw %ax, %ds;\n"
+      "movw %ax, %es;\n"
+      "movw %ax, %fs;\n"
+      "movw %ax, %gs;\n"
+      "lretq;\n"
+  );
+}
+
+__attribute__((naked)) uint
+setjmp( void ) {
+  __asm__ volatile (
+      "movabsq $g_sysret, %rsi;\n"
+      "movq %rbx, (%rsi);\n"
+      "movq %rbp, 8(%rsi);\n"
+      "movq %r12, 16(%rsi);\n"
+      "movq %r13, 24(%rsi);\n"
+      "movq %r14, 32(%rsi);\n"
+      "movq %r15, 40(%rsi);\n"
+      "leaq 8(%rsp), %rdx;\n"
+      "movq %rdx, 48(%rsi);\n"
+      "movq (%rsp), %rdx;\n"
+      "movq %rdx, 56(%rsi);\n"
+      "xorl %eax, %eax;\n"
+      "retq;\n"
+  );
+}
+
+__attribute__((naked)) void
+longjmp( void ) {
+  __asm__ volatile (
+      "movabsq $g_sysret, %rdi;\n"
+      "movq (%rdi), %rbx;\n"
+      "movq 8(%rdi), %rbp;\n"
+      "movq 16(%rdi), %r12;\n"
+      "movq 24(%rdi), %r13;\n"
+      "movq 32(%rdi), %r14;\n"
+      "movq 40(%rdi), %r15;\n"
+      "movq 48(%rdi), %rsp;\n"
+      "jmp *56(%rdi);\n"
+  );
+}
+
+static void
+setup_lstar( void ) {
+  __asm__ volatile (
+      "movl $0xc0000082, %%ecx;\n"
+      "movq $longjmp, %%rax;\n"
+      "movq %%rax, %%rdx;\n"
+      "shrq $32, %%rdx;\n"
+      "wrmsr;\n"
+      :
+      : : "rax", "rcx", "rdx", "memory"
+  );
+}
+
+__attribute__((noreturn)) void
+fdos_kern_main( fdos_kern_args_t * args ) {
+  g_hyper = (fd_hypercall_args_t *)args->hyper_args_gvaddr;
+
+  FD_LOG_NOTICE(( "Hello world!" ));
+
+  setup_lstar();
+
+  FD_LOG_NOTICE(( "Entering ring 3 user stack top %#lx", args->stack_user_top_gvaddr ));
+  ulong const user_stack_top_gpaddr = args->stack_user_top_gvaddr;
+  if( setjmp()==0 ) {
+    enter_ring3( user_stack_top_gpaddr, (ulong)hello_ring3 );
+  } else {
+    FD_LOG_NOTICE(( "Returned from ring 3" ));
+  }
+  FD_LOG_NOTICE(( "Doing 10 million context switches" ));
+
+  for( ulong i=0UL; i<10000000UL; i++ ) {
+    if( setjmp()==0 ) {
+      enter_ring3( user_stack_top_gpaddr, (ulong)bounce_ring3 );
+    }
+  }
+
+  FD_LOG_ERR(( "Goodbye" ));
+  __asm__ volatile ("hlt");
+  for(;;) {}
+}
+
+__attribute__((noreturn)) void
+fdos_kern_entry( fdos_kern_args_t * args ) {
+
+  /* On entry, our GDT, code, and data segment selectors were set up by
+     the host.  However, we will need to far return to make the content
+     of these structures take changes.  Otherwise, we would run in some
+     undocumented KVM guest default state. */
+
+  __asm__ volatile (
+      /* Select segment 1, privilege level 0 */
+      "pushq $8;\n"
+      /* Return address (entry1) */
+      "movabsq $fdos_kern_main, %%rax;\n"
+      "pushq %%rax;\n"
+      /* First argument to entry1 */
+      "movq %0, %%rdi;\n"
+      /* Far return */
+      "lretq;\n"
+      : : "r" (args) : "rax", "rdi", "memory"
+  );
+
+  __builtin_unreachable();
+}

--- a/src/fdos/kern/fdos_kern.ld
+++ b/src/fdos/kern/fdos_kern.ld
@@ -1,0 +1,43 @@
+ENTRY(fdos_kern_entry)
+OUTPUT_FORMAT(elf64-x86-64)
+
+PHDRS
+{
+  ROM  PT_LOAD AT(0) FLAGS(4);
+  CODE PT_LOAD FLAGS(5);
+  RAM  PT_LOAD FLAGS(6);
+}
+
+SECTIONS
+{
+  .text 0x2001000 : AT(0x1000) ALIGN(4K)
+  {
+    *(.text)
+  } :CODE
+
+  .rodata 0x3001000 : AT(LOADADDR(.text) + SIZEOF(.text)) ALIGN(4K)
+  {
+    *(.eh_frame)
+    *(.rodata)
+    *(.rodata.*)
+  } :ROM
+
+  .data 0x4001000 : AT(LOADADDR(.rodata) + SIZEOF(.rodata)) ALIGN(4K)
+  {
+    *(.data)
+  } :RAM
+
+  .bss (0x4001000 + SIZEOF(.data)) (NOLOAD) : AT(LOADADDR(.data) + SIZEOF(.data)) ALIGN(4K)
+  {
+    *(.bss)
+  } :RAM
+
+  /DISCARD/ :
+  {
+    *(.note.GNU-stack)
+    *(.comment)
+    *(.interp)
+    *(.hash)
+    *(.gnu.hash)
+  }
+}


### PR DESCRIPTION
Adds a minimal para-virtualized kernel with the following features:
- Logging via KVM I/O trap (OUT register port), using picolibc for
  the printf implementation
- Basic ring 0 context saving (setjmp, longjmp)
- Context switch to privilege level 3 via LRETQ (far return)
- Context switch to privilege level 0 via SYSCALL with LSTAR MSR
  setup
- Basic linker script producing a static ELF binary

The resulting kernel image requires a specialized execution
environment to run.  It expects the VM host to have already set up
the GDT, page table, and other data structures.

For now, all the kernel does is benchmark context switching between
the privilege levels.  Page table updates are not yet supported.
