### PR TITLE
fdos: add KVM based hypervisor

### DIFF
--- a/config/extra/with-libllvm.mk
+++ b/config/extra/with-libllvm.mk
@@ -1,0 +1,6 @@
+FD_HAS_LIBLLVM:=1
+CPPFLAGS+=-DFD_HAS_LIBLLVM=1
+
+CXXFLAGS+=$(shell llvm-config --cxxflags)
+LDFLAGS+=$(shell llvm-config --ldflags)
+LDFLAGS+=$(shell llvm-config --libs mcdisassembler x86)

--- a/src/fdos/Local.mk
+++ b/src/fdos/Local.mk
@@ -1,0 +1,17 @@
+ifdef FD_HAS_LINUX
+ifneq ($(wildcard $(BASEDIR)/fdos/kern/x86_64/bin/fdos_kern.elf),)
+
+$(call make-lib,fdos_host)
+$(call add-objs,host/fdos_env host/fdos_kern_img host/fdos_kvm,fdos_host)
+ifdef FD_HAS_LIBLLVM
+$(call add-objs,x86/fd_x86_disasm,fdos_host)
+endif
+$(call make-bin,test_fdos,test_fdos,fdos_host fd_util)
+
+$(OBJDIR)/obj/fdos/test_fdos.o: $(BASEDIR)/fdos/kern/x86_64/bin/fdos_kern.elf
+.PHONY: $(BASEDIR)/fdos/kern/x86_64/bin/fdos_kern.elf
+$(BASEDIR)/fdos/kern/x86_64/bin/fdos_kern.elf:
+	$(MAKE) MACHINE=fdos_kern_x86 $@
+
+endif
+endif

--- a/src/fdos/host/fdos_env.c
+++ b/src/fdos/host/fdos_env.c
@@ -1,0 +1,334 @@
+/* fdos_env.c sets up kernel data structures.
+
+   Conventionally, an operating system would set up its own data
+   structures in a bootloader.  In fdos, we instead opt to let the host
+   set up the kernel's data structures.  This allows the virtualized
+   kernel to instantly boot in a ready environment, and also saves
+   complex legacy setup (e.g. manually bringing up the CPU from real to
+   long mode, or switching between different address spaces). */
+
+#include "fdos_env.h"
+#include "../kern/fdos_kern_def.h"
+#include "../x86/fd_x86_mmu.h"
+
+/* fdos_env_map_range sets up an identity mapping between physical and
+   virtual ranges [addr,addr+sz).  addr and sz must be 4K aligned.
+
+   FIXME Defend against host corruption from an invalid guest kernel */
+
+static void
+fdos_env_map_range( ulong *     pml4,
+                    fd_wksp_t * wksp_kern_meta,
+                    ulong       addr,
+                    ulong       sz,
+                    int         user ) {
+  ulong us = user ? 0x4UL : 0UL;
+
+  ulong       addr0 = addr;
+  ulong const addr1 = addr+sz;
+  FD_LOG_INFO(( "Creating identity mapping for range [%#lx,%#lx)", addr0, addr1 ));
+  FD_CRIT( fd_ulong_is_aligned( addr0, FD_SHMEM_HUGE_PAGE_SZ ), "invalid argument" );
+  FD_CRIT( fd_ulong_is_aligned( addr1, FD_SHMEM_HUGE_PAGE_SZ ), "invalid argument" );
+  FD_CRIT( addr0<=addr1, "invalid argument" );
+
+  while( addr0<addr1 ) { /* each PML4E */
+    ulong pml4e_base = fd_ulong_align_dn( addr0, FD_X86_PML4E_RANGE );
+    ulong pml4e_idx  = fd_ulong_extract( addr0, 39, 47 );
+    if( !pml4[ pml4e_idx ] ) {
+      FD_LOG_DEBUG(( "Creating PDPT at PML4E[%lu] spanning [%#lx,%#lx)", pml4e_idx, pml4e_base, pml4e_base+FD_X86_PML4E_RANGE ));
+      ulong table_gaddr = fd_wksp_alloc( wksp_kern_meta, FD_SHMEM_NORMAL_PAGE_SZ, FD_SHMEM_NORMAL_PAGE_SZ, 1UL );
+      FD_TEST( table_gaddr );
+      ulong table_gpaddr = FDOS_GPADDR_KERN_META + table_gaddr;
+      pml4[ pml4e_idx ] = table_gpaddr | 0x7UL;
+    }
+    ulong * pdpt = (ulong *)fd_wksp_laddr_fast( wksp_kern_meta, (pml4[ pml4e_idx ] & ~0xfffUL)-FDOS_GPADDR_KERN_META );
+
+    while( addr0<addr1 ) { /* each PDPTE */
+      ulong pdpte_base = fd_ulong_align_dn( addr0, FD_X86_PDPTE_RANGE );
+      ulong pdpte_idx  = fd_ulong_extract( addr0, 30, 38 );
+      if( !pdpt[ pdpte_idx ] ) {
+        FD_LOG_DEBUG(( "Creating PD at PDPTE[%lu,%lu] spanning [%#lx,%#lx)", pml4e_idx, pdpte_idx, pdpte_base, pdpte_base+FD_X86_PDPTE_RANGE ));
+        ulong table_gaddr = fd_wksp_alloc( wksp_kern_meta, FD_SHMEM_NORMAL_PAGE_SZ, FD_SHMEM_NORMAL_PAGE_SZ, 1UL );
+        FD_TEST( table_gaddr );
+        ulong table_gpaddr = FDOS_GPADDR_KERN_META + table_gaddr;
+        pdpt[ pdpte_idx ] = table_gpaddr | 0x7UL;
+      }
+      ulong * pd = (ulong *)fd_wksp_laddr_fast( wksp_kern_meta, (pdpt[ pdpte_idx ] & ~0xfffUL)-FDOS_GPADDR_KERN_META );
+
+      while( addr0<addr1 ) { /* each PDE */
+        /* Create huge page */
+        ulong pde_idx = fd_ulong_extract( addr0, 21, 29 );
+        FD_LOG_DEBUG(( "Creating huge page at PDE[%lu,%lu,%lu] spanning [%#lx,%#lx)", pml4e_idx, pdpte_idx, pde_idx, addr0, addr0+FD_X86_PDE_RANGE ));
+        pd[ pde_idx ] = addr0 | 0x83UL | us;
+        addr0 += FD_X86_PDE_RANGE;
+        if( FD_UNLIKELY( !fd_ulong_extract( addr0, 21, 29 ) ) ) break;
+      }
+      if( FD_UNLIKELY( !fd_ulong_extract( addr0, 30, 38 ) ) ) break;
+    }
+  }
+}
+
+/* fdos_env_tss sets up a dummy Task State Segment */
+
+static void
+fdos_env_tss( fdos_env_t * env ) {
+  ulong tss_kern_gaddr = fd_wksp_alloc( env->wksp_kern_meta, 16UL, sizeof(fd_x86_tss64_t), 1UL );
+  ulong tss_user_gaddr = fd_wksp_alloc( env->wksp_kern_meta, 16UL, sizeof(fd_x86_tss64_t), 1UL );
+  FD_TEST( tss_kern_gaddr ); FD_TEST( tss_user_gaddr );
+
+  fd_x86_tss64_t * tss_kern = fd_wksp_laddr_fast( env->wksp_kern_meta, tss_kern_gaddr );
+  fd_x86_tss64_t * tss_user = fd_wksp_laddr_fast( env->wksp_kern_meta, tss_user_gaddr );
+
+  memset( tss_kern, 0, sizeof(fd_x86_tss64_t) );
+  memset( tss_user, 0, sizeof(fd_x86_tss64_t) );
+
+  tss_kern->rsp0       = env->stack_kern_top_gvaddr;
+  tss_kern->iomap_base = 0x1000; /* exceeds tss_limit -> no IO map */
+
+  tss_user->rsp0       = env->stack_user_top_gvaddr;
+  tss_user->iomap_base = 0x1000; /* exceeds tss_limit -> no IO map */
+
+  env->tss_kern_gpaddr = FDOS_GPADDR_KERN_META + tss_kern_gaddr;
+  env->tss_user_gpaddr = FDOS_GPADDR_KERN_META + tss_user_gaddr;
+}
+
+/* fdos_env_gdt sets up the global descriptor table */
+
+static void
+fdos_env_gdt( fdos_env_t * env ) {
+
+  ulong gdt_gaddr = fd_wksp_alloc( env->wksp_kern_meta, 16UL, FDOS_GDT_CNT*sizeof(fd_x86_gdt_t), 1UL );
+  FD_TEST( gdt_gaddr );
+  env->gdt_gpaddr = FDOS_GPADDR_KERN_META + gdt_gaddr;
+  fd_x86_gdt_t * gdt = fd_wksp_laddr_fast( env->wksp_kern_meta, gdt_gaddr );
+  gdt[ FDOS_GDT_IDX_NULL ] = (fd_x86_gdt_t) {0};
+  gdt[ FDOS_GDT_IDX_KERN_CODE ] = (fd_x86_gdt_t) {
+    .limit0 = 0xffff,
+    .base0  = 0,
+    .base1  = 0,
+    .type   = 11,
+    .s      = 1,
+    .dpl    = 0,
+    .p      = 1,
+    .limit1 = 15,
+    .avl    = 0,
+    .l      = 1,
+    .d      = 0,
+    .g      = 1,
+    .base2  = 0
+  };
+  gdt[ FDOS_GDT_IDX_KERN_DATA ] = (fd_x86_gdt_t) {
+    .limit0 = 0xffff,
+    .base0  = 0,
+    .base1  = 0,
+    .type   = 3,
+    .s      = 1,
+    .dpl    = 0,
+    .p      = 1,
+    .limit1 = 15,
+    .avl    = 0,
+    .l      = 0,
+    .d      = 1,
+    .g      = 1,
+    .base2  = 0
+  };
+  gdt[ FDOS_GDT_IDX_USER_DATA ] = (fd_x86_gdt_t) {
+    .limit0 = 0xffff,
+    .base0  = 0,
+    .base1  = 0,
+    .type   = 11,
+    .s      = 1,
+    .dpl    = 3,
+    .p      = 1,
+    .limit1 = 15,
+    .avl    = 0,
+    .l      = 1,
+    .d      = 0,
+    .g      = 1,
+    .base2  = 0
+  };
+  gdt[ FDOS_GDT_IDX_USER_CODE ] = (fd_x86_gdt_t) {
+    .limit0 = 0xffff,
+    .base0  = 0,
+    .base1  = 0,
+    .type   = 3,
+    .s      = 1,
+    .dpl    = 3,
+    .p      = 1,
+    .limit1 = 15,
+    .avl    = 0,
+    .l      = 0,
+    .d      = 1,
+    .g      = 1,
+    .base2  = 0
+  };
+  /* TSS */
+  ulong tss_base  = env->tss_kern_gpaddr;
+  uint  tss_limit = sizeof(fd_x86_tss64_t)-1UL;
+  gdt[ FDOS_GDT_IDX_TSS ] = (fd_x86_gdt_t) {
+    .limit0 = tss_limit & 0xffffUL,
+    .base0  = (ushort)( tss_base & 0xffffUL ),
+    .base1  = (tss_base>>16) & 0xffUL,
+    .type   = 11,
+    .s      = 0,
+    .dpl    = 0,
+    .p      = 1,
+    .limit1 = 0,
+    .avl    = 0,
+    .l      = 0,
+    .d      = 0,
+    .g      = 0,
+    .base2  = 0
+  };
+  gdt[ FDOS_GDT_IDX_TSS_HIGH ] = (fd_x86_gdt_t) {
+    .base3    = (uint)( tss_base>>32 ),
+    .reserved = 0
+  };
+}
+
+/* fdos_env_idt sets up the interrupt descriptor table */
+
+static void
+fdos_env_idt( fdos_env_t * env ) {
+  /* Interrupt handler */
+  ulong   interrupt_handler_gaddr  = fd_wksp_alloc( env->wksp_kern_code, 256UL, 256UL, 1UL );
+  FD_TEST( interrupt_handler_gaddr );
+  ulong   interrupt_handler_gvaddr = FDOS_GPADDR_KERN_CODE + interrupt_handler_gaddr;
+  uchar * interrupt_handler        = fd_wksp_laddr_fast( env->wksp_kern_code, interrupt_handler_gaddr );
+  memset( interrupt_handler, 0xf4, 256UL );
+  env->int_handler_gvaddr = interrupt_handler_gvaddr;
+
+  /* IDT */
+  ulong               idt_gaddr  = fd_wksp_alloc( env->wksp_kern_meta, 16UL, 256*sizeof(fd_x86_idt_gate_t), 1UL );
+  FD_TEST( idt_gaddr );
+  ulong               idt_gpaddr = FDOS_GPADDR_KERN_META + idt_gaddr;
+  fd_x86_idt_gate_t * idt        = fd_wksp_alloc_laddr( env->wksp_kern_meta, 16UL, 256*sizeof(fd_x86_idt_gate_t), 1UL );
+  FD_TEST( idt );
+  memset( idt, 0, 256*sizeof(fd_x86_idt_gate_t) );
+  for( ulong i=0UL; i<256UL; i++ ) {
+    ulong gvaddr = interrupt_handler_gvaddr+i;
+    idt[ i ] = (fd_x86_idt_gate_t) {
+      .offset_low   = (ushort)( gvaddr & 0xffff ),
+      .selector     = 0x08, /* ring 0, GDT, entry 1 (code) */
+      .ist          = 0,
+      .type_attr    = 0x8e, /* interrupt gate, ring 0, present */
+      .offset_mid   = (ushort)((gvaddr >> 16) & 0xffff),
+      .offset_high  = (uint)((gvaddr >> 32) & 0xffffffff),
+      .reserved     = 0
+    };
+  }
+  env->idt_gpaddr = idt_gpaddr;
+  env->idt        = idt;
+}
+
+/* fdos_env_shared sets up interop shared data structures between the
+   host and the guest kernel. */
+
+static void
+fdos_env_shared( fdos_env_t * env ) {
+
+  /* Hypercall shared memory area */
+  ulong hyper_args_gaddr = fd_wksp_alloc( env->wksp_kern_data, alignof(fd_hypercall_args_t), sizeof(fd_hypercall_args_t), 1UL );
+  FD_TEST( hyper_args_gaddr );
+  env->hyper_args_gvaddr = FDOS_GPADDR_KERN_DATA + hyper_args_gaddr;
+  env->hyper_args        = fd_wksp_laddr_fast( env->wksp_kern_data, hyper_args_gaddr );
+  memset( env->hyper_args, 0, sizeof(fd_hypercall_args_t) );
+
+  /* Entry args */
+  ulong entry_args_gaddr = fd_wksp_alloc( env->wksp_kern_data, alignof(fdos_kern_args_t), sizeof(fdos_kern_args_t), 1UL );
+  FD_TEST( entry_args_gaddr );
+  env->entry_args_gvaddr = FDOS_GPADDR_KERN_DATA + entry_args_gaddr;
+  env->entry_args        = fd_wksp_laddr_fast( env->wksp_kern_data, entry_args_gaddr );
+  memset( env->entry_args, 0, sizeof(fdos_kern_args_t) );
+  fdos_kern_args_t * entry_args = env->entry_args;
+
+  entry_args->hyper_args_gvaddr     = env->hyper_args_gvaddr;
+  entry_args->stack_user_top_gvaddr = env->stack_user_top_gvaddr;
+}
+
+/* fdos_env_ring0_setup sets up various dynamic x86 data structures and
+   hypervisor interop logic */
+
+static void
+fdos_env_ring0_setup( fdos_env_t * env ) {
+  fdos_env_tss   ( env );
+  fdos_env_gdt   ( env );
+  fdos_env_idt   ( env );
+  fdos_env_shared( env );
+}
+
+fdos_env_t *
+fdos_env_create( fdos_env_t *  env,
+                 uchar const * kern_bin,
+                 ulong         kern_bin_sz ) {
+  ulong guest_cpu = fd_log_cpu_id();
+  ulong part_max  = 61UL; /* 4096 headroom */
+
+  /* Allocate guest physical memory regions */
+  fd_wksp_t * wksp_kern_meta   = fd_wksp_new_anonymous( FD_SHMEM_HUGE_PAGE_SZ, 2UL, guest_cpu, "guest_meta",   part_max ); FD_TEST( wksp_kern_meta   );
+  fd_wksp_t * wksp_kern_code   = fd_wksp_new_anonymous( FD_SHMEM_HUGE_PAGE_SZ, 2UL, guest_cpu, "guest_code",   part_max ); FD_TEST( wksp_kern_code   );
+  fd_wksp_t * wksp_kern_rodata = fd_wksp_new_anonymous( FD_SHMEM_HUGE_PAGE_SZ, 2UL, guest_cpu, "guest_rodata", part_max ); FD_TEST( wksp_kern_rodata );
+  fd_wksp_t * wksp_kern_data   = fd_wksp_new_anonymous( FD_SHMEM_HUGE_PAGE_SZ, 2UL, guest_cpu, "guest_data",   part_max ); FD_TEST( wksp_kern_data   );
+  fd_wksp_t * wksp_kern_stack  = fd_wksp_new_anonymous( FD_SHMEM_HUGE_PAGE_SZ, 2UL, guest_cpu, "guest_stack",  part_max ); FD_TEST( wksp_kern_stack  );
+  fd_wksp_t * wksp_user_stack  = fd_wksp_new_anonymous( FD_SHMEM_HUGE_PAGE_SZ, 2UL, guest_cpu, "user_stack",   part_max ); FD_TEST( wksp_user_stack  );
+
+  /* Root page */
+  ulong   pml4_gaddr  = fd_wksp_alloc( wksp_kern_meta, FD_SHMEM_NORMAL_PAGE_SZ, FD_SHMEM_NORMAL_PAGE_SZ, 1UL ); FD_TEST( pml4_gaddr );
+  ulong   pml4_gpaddr = FDOS_GPADDR_KERN_META + pml4_gaddr;
+  ulong * pml4        = fd_wksp_laddr_fast( wksp_kern_meta, pml4_gaddr );
+  memset( pml4, 0, FD_SHMEM_NORMAL_PAGE_SZ );
+
+  /* Create page table */
+  fdos_env_map_range( pml4, wksp_kern_meta, FDOS_GPADDR_KERN_META,   2UL*FD_SHMEM_HUGE_PAGE_SZ, 0 );
+  fdos_env_map_range( pml4, wksp_kern_meta, FDOS_GPADDR_KERN_CODE,   2UL*FD_SHMEM_HUGE_PAGE_SZ, 1 );
+  fdos_env_map_range( pml4, wksp_kern_meta, FDOS_GPADDR_KERN_RODATA, 2UL*FD_SHMEM_HUGE_PAGE_SZ, 1 );
+  fdos_env_map_range( pml4, wksp_kern_meta, FDOS_GPADDR_KERN_DATA,   2UL*FD_SHMEM_HUGE_PAGE_SZ, 1 );
+  fdos_env_map_range( pml4, wksp_kern_meta, FDOS_GPADDR_KERN_STACK,  2UL*FD_SHMEM_HUGE_PAGE_SZ, 0 );
+  fdos_env_map_range( pml4, wksp_kern_meta, FDOS_GPADDR_USER_STACK,  2UL*FD_SHMEM_HUGE_PAGE_SZ, 1 );
+
+  /* Guest kernel stack */
+  ulong stack_kern_gaddr  = fd_wksp_alloc( wksp_kern_stack, 16UL, 2*FD_SHMEM_HUGE_PAGE_SZ-FD_SHMEM_NORMAL_PAGE_SZ, 1UL );
+  FD_TEST( stack_kern_gaddr );
+  ulong stack_kern_gpaddr = FDOS_GPADDR_KERN_STACK + 2*FD_SHMEM_HUGE_PAGE_SZ;
+
+  /* Guest user stack */
+  ulong stack_user_gaddr  = fd_wksp_alloc( wksp_user_stack, 16UL, 2*FD_SHMEM_HUGE_PAGE_SZ-FD_SHMEM_NORMAL_PAGE_SZ, 1UL );
+  FD_TEST( stack_user_gaddr );
+  ulong stack_user_gpaddr = FDOS_GPADDR_USER_STACK + 2*FD_SHMEM_HUGE_PAGE_SZ;
+
+  *env = (fdos_env_t) {
+    .wksp_kern_meta   = wksp_kern_meta,
+    .wksp_kern_code   = wksp_kern_code,
+    .wksp_kern_rodata = wksp_kern_rodata,
+    .wksp_kern_data   = wksp_kern_data,
+    .wksp_kern_stack  = wksp_kern_stack,
+    .wksp_user_stack  = wksp_user_stack,
+
+    .pml4        = pml4,
+    .pml4_gpaddr = pml4_gpaddr,
+
+    .stack_kern_top_gvaddr = stack_kern_gpaddr,
+    .stack_kern_sz         = stack_kern_gpaddr-FDOS_GPADDR_KERN_STACK-stack_kern_gaddr,
+
+    .stack_user_top_gvaddr = stack_user_gpaddr,
+    .stack_user_sz         = stack_user_gpaddr-FDOS_GPADDR_USER_STACK-stack_user_gaddr
+  };
+
+  /* Load kernel image into memory */
+  fdos_env_img_load( env, kern_bin, kern_bin_sz );
+
+  /* Set up kernel data structures */
+  fdos_env_ring0_setup( env );
+
+  return env;
+}
+
+void
+fdos_env_destroy( fdos_env_t * env ) {
+  fd_wksp_delete_anonymous( env->wksp_kern_meta   );
+  fd_wksp_delete_anonymous( env->wksp_kern_code   );
+  fd_wksp_delete_anonymous( env->wksp_kern_rodata );
+  fd_wksp_delete_anonymous( env->wksp_kern_data   );
+  fd_wksp_delete_anonymous( env->wksp_kern_stack  );
+  memset( env, 0, sizeof(fdos_env_t) );
+}

--- a/src/fdos/host/fdos_env.h
+++ b/src/fdos/host/fdos_env.h
@@ -1,0 +1,84 @@
+#ifndef HEADER_fd_src_fdos_host_fdos_host_h
+#define HEADER_fd_src_fdos_host_fdos_host_h
+
+#include "../kern/fdos_hypercall.h"
+#include "../x86/fd_x86_gdt.h"
+#include "../x86/fd_x86_idt.h"
+#include "../x86/fd_x86_tss.h"
+#include "../../util/wksp/fd_wksp.h"
+
+struct fdos_env {
+  fd_wksp_t * wksp_kern_meta;
+  fd_wksp_t * wksp_kern_code;
+  fd_wksp_t * wksp_kern_rodata;
+  fd_wksp_t * wksp_kern_data;
+  fd_wksp_t * wksp_kern_stack;
+  fd_wksp_t * wksp_user_stack;
+
+  /* Page table */
+  ulong * pml4; /* in meta_wksp */
+  ulong   pml4_gpaddr;
+
+  /* Stack (kernel, user) */
+  ulong   stack_kern_top_gvaddr;
+  ulong   stack_kern_sz;
+  ulong   stack_user_top_gvaddr;
+  ulong   stack_user_sz;
+
+  /* Kernel image */
+  uchar * rodata;
+  uchar * text;
+  uchar * data;
+  ulong   rodata_gvaddr;
+  ulong   rodata_sz;
+  ulong   text_gvaddr;
+  ulong   text_sz;
+  ulong   entry_gvaddr;
+  ulong   data_gvaddr;
+  ulong   data_sz;
+
+  /* TSS (kernel, user) */
+  fd_x86_tss64_t * tss_kern;
+  fd_x86_tss64_t * tss_user;
+  ulong            tss_kern_gpaddr;
+  ulong            tss_user_gpaddr;
+
+  /* GDT */
+  ulong          gdt_gpaddr;
+  fd_x86_gdt_t * gdt;
+
+  /* Default interrupt handler */
+  ulong int_handler_gvaddr; /* 256 bytes, 1 byte for each interrupt descriptor */
+
+  /* IDT */
+  ulong               idt_gpaddr;
+  fd_x86_idt_gate_t * idt;
+
+  /* Startup args */
+  ulong              entry_args_gvaddr;
+  fdos_kern_args_t * entry_args;
+
+  /* Hypercalls */
+  ulong                 hyper_args_gvaddr;
+  fd_hypercall_args_t * hyper_args;
+};
+
+typedef struct fdos_env fdos_env_t;
+
+void
+fdos_env_img_load( fdos_env_t *  env,
+                   uchar const * bin,
+                   ulong         bin_sz );
+
+/* fdos_env_create sets up all fdos kernel data structures
+   needed to bootstrap a KVM ring 0 guest environment. */
+
+fdos_env_t *
+fdos_env_create( fdos_env_t *  env,
+                 uchar const * kern_bin,
+                 ulong         kern_bin_sz );
+
+void
+fdos_env_destroy( fdos_env_t * env );
+
+#endif /* HEADER_fd_src_fdos_host_fdos_host_h */

--- a/src/fdos/host/fdos_kern_img.c
+++ b/src/fdos/host/fdos_kern_img.c
@@ -1,0 +1,83 @@
+#include "fdos_env.h"
+#include "../kern/fdos_kern_def.h"
+#include "../../ballet/elf/fd_elf64.h"
+
+/* Kernel loader */
+
+struct fdos_kern_img_off {
+  fd_elf64_ehdr ehdr;
+  fd_elf64_phdr phdr_rom;
+  fd_elf64_phdr phdr_code;
+  fd_elf64_phdr phdr_ram;
+};
+
+typedef struct fdos_kern_img_off fdos_kern_img_off_t;
+
+static fdos_kern_img_off_t *
+fdos_kern_img_off_load( fdos_kern_img_off_t * img_off,
+                        uchar const *         bin,
+                        ulong                 bin_sz ) {
+  memset( img_off, 0, sizeof(fdos_kern_img_off_t) );
+
+  img_off->ehdr = FD_LOAD( fd_elf64_ehdr, bin );
+  FD_TEST( FD_LOAD( uint, img_off->ehdr.e_ident )==fd_uint_bswap( 0x7f454c46 ) );
+  /* FIXME More validation */
+  FD_TEST( img_off->ehdr.e_phnum==3 );
+  FD_TEST( img_off->ehdr.e_phentsize==sizeof(fd_elf64_phdr) );
+
+  ulong phdr_off0 = img_off->ehdr.e_phoff;
+  ulong phdr_off1 = img_off->ehdr.e_phoff + img_off->ehdr.e_phnum*sizeof(fd_elf64_phdr);
+  FD_TEST( phdr_off1<=bin_sz );
+
+  uchar const * phdr_i = bin + phdr_off0;
+  img_off->phdr_rom  = FD_LOAD( fd_elf64_phdr, phdr_i ); phdr_i += sizeof(fd_elf64_phdr);
+  img_off->phdr_code = FD_LOAD( fd_elf64_phdr, phdr_i ); phdr_i += sizeof(fd_elf64_phdr);
+  img_off->phdr_ram  = FD_LOAD( fd_elf64_phdr, phdr_i ); phdr_i += sizeof(fd_elf64_phdr);
+
+  FD_TEST( img_off->phdr_rom.p_type   == FD_ELF_PT_LOAD );
+  FD_TEST( img_off->phdr_rom.p_flags  == 4 );
+  FD_TEST( img_off->phdr_code.p_type  == FD_ELF_PT_LOAD );
+  FD_TEST( img_off->phdr_code.p_flags == 5 );
+  FD_TEST( img_off->phdr_ram.p_type   == FD_ELF_PT_LOAD );
+  FD_TEST( img_off->phdr_ram.p_flags  == 6 );
+
+  ulong off1;
+  FD_TEST( !__builtin_uaddl_overflow( img_off->phdr_rom.p_offset,  img_off->phdr_rom.p_filesz,  &off1 ) && off1<=bin_sz );
+  FD_TEST( !__builtin_uaddl_overflow( img_off->phdr_code.p_offset, img_off->phdr_code.p_filesz, &off1 ) && off1<=bin_sz );
+  FD_TEST( !__builtin_uaddl_overflow( img_off->phdr_ram.p_offset,  img_off->phdr_ram.p_filesz,  &off1 ) && off1<=bin_sz );
+
+  return img_off;
+}
+
+void
+fdos_env_img_load( fdos_env_t *  env,
+                   uchar const * bin,
+                   ulong         bin_sz ) {
+  fdos_kern_img_off_t img_off[1];
+  FD_TEST( fdos_kern_img_off_load( img_off, bin, bin_sz ) );
+
+  ulong rodata_gaddr = fd_wksp_alloc( env->wksp_kern_rodata, FD_SHMEM_NORMAL_PAGE_SZ, img_off->phdr_rom.p_memsz, 1UL );
+  FD_TEST( rodata_gaddr==FD_SHMEM_NORMAL_PAGE_SZ );
+  uchar * rodata = fd_wksp_laddr_fast( env->wksp_kern_rodata, rodata_gaddr );
+  fd_memcpy( rodata, bin + img_off->phdr_rom.p_offset, img_off->phdr_rom.p_filesz );
+  env->rodata        = rodata;
+  env->rodata_gvaddr = FDOS_GPADDR_KERN_RODATA + rodata_gaddr;
+  env->rodata_sz     = img_off->phdr_rom.p_filesz;
+
+  ulong text_gaddr = fd_wksp_alloc( env->wksp_kern_code, FD_SHMEM_NORMAL_PAGE_SZ, img_off->phdr_code.p_memsz, 1UL );
+  FD_TEST( text_gaddr==FD_SHMEM_NORMAL_PAGE_SZ );
+  uchar * text = fd_wksp_laddr_fast( env->wksp_kern_code, text_gaddr );
+  fd_memcpy( text, bin + img_off->phdr_code.p_offset, img_off->phdr_code.p_filesz );
+  env->text         = text;
+  env->text_gvaddr  = FDOS_GPADDR_KERN_CODE + text_gaddr;
+  env->text_sz      = img_off->phdr_code.p_filesz;
+  env->entry_gvaddr = img_off->ehdr.e_entry;
+
+  ulong data_gaddr = fd_wksp_alloc( env->wksp_kern_data, FD_SHMEM_NORMAL_PAGE_SZ, img_off->phdr_ram.p_memsz, 1UL );
+  FD_TEST( data_gaddr==FD_SHMEM_NORMAL_PAGE_SZ );
+  uchar * data = fd_wksp_laddr_fast( env->wksp_kern_data, data_gaddr );
+  fd_memcpy( data, bin + img_off->phdr_ram.p_offset, img_off->phdr_ram.p_filesz );
+  env->data        = data;
+  env->data_gvaddr = FDOS_GPADDR_KERN_DATA + data_gaddr;
+  env->data_sz     = img_off->phdr_ram.p_filesz;
+}

--- a/src/fdos/host/fdos_kvm.c
+++ b/src/fdos/host/fdos_kvm.c
@@ -1,0 +1,154 @@
+/* fdos_kvm.c provides a KVM hypervisor environment for fdos. */
+
+#include "fdos_kvm.h"
+#include "../x86/fd_x86_disasm.h"
+#include "../kern/fdos_kern_def.h"
+#include <errno.h>
+#include <sys/ioctl.h> /* ioctl(2) */
+
+#define TEXT_NORMAL    "\033[0m"
+#define TEXT_BOLD      "\033[1m"
+#define TEXT_UNDERLINE "\033[4m"
+#define TEXT_BLINK     "\033[5m"
+
+#define TEXT_BLUE      "\033[34m"
+#define TEXT_GREEN     "\033[32m"
+#define TEXT_YELLOW    "\033[93m"
+#define TEXT_RED       "\033[31m"
+
+static void *
+gvaddr_to_haddr( fdos_env_t const * env,
+                 ulong             gvaddr ) {
+  void * base = NULL;
+  switch( gvaddr>>24 ) {
+  case 3:
+    base = env->wksp_kern_rodata;
+    break;
+  case 4:
+    base = env->wksp_kern_data;
+    break;
+  case 5:
+    base = env->wksp_kern_stack;
+    break;
+  }
+  if( FD_UNLIKELY( !base ) ) return NULL;
+  return fd_wksp_laddr_fast( base, gvaddr&0xffffffUL );
+}
+
+static void
+hypercall_log( fdos_env_t * kern,
+               int          vcpu_fd,
+               ulong        level,
+               ulong        file_gvaddr,
+               ulong        line,
+               ulong        func_gvaddr,
+               ulong        msg_gvaddr ) {
+  static char const * color_level_cstr[] = {
+    /* 0 */ TEXT_NORMAL                                  "DEBUG  ",
+    /* 1 */ TEXT_BLUE                                    "INFO   " TEXT_NORMAL,
+    /* 2 */ TEXT_GREEN                                   "NOTICE " TEXT_NORMAL,
+    /* 3 */ TEXT_YELLOW                                  "WARNING" TEXT_NORMAL,
+    /* 4 */ TEXT_RED                                     "ERR    " TEXT_NORMAL,
+    /* 5 */ TEXT_RED TEXT_BOLD                           "CRIT   " TEXT_NORMAL,
+    /* 6 */ TEXT_RED TEXT_BOLD TEXT_UNDERLINE            "ALERT  " TEXT_NORMAL,
+    /* 7 */ TEXT_RED TEXT_BOLD TEXT_UNDERLINE TEXT_BLINK "EMERG  " TEXT_NORMAL
+  };
+  char const * file = (char const *)gvaddr_to_haddr( kern, file_gvaddr );
+  char const * func = (char const *)gvaddr_to_haddr( kern, func_gvaddr );
+  char const * msg  = (char const *)gvaddr_to_haddr( kern, msg_gvaddr  );
+
+
+  struct kvm_sregs sregs;
+  if( FD_UNLIKELY( ioctl( vcpu_fd, KVM_GET_SREGS, &sregs )<0 ) ) {
+    FD_LOG_ERR(( "KVM_GET_REGS failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+
+  FD_LOG_NOTICE(( "%s ring%d  %s(%lu)[%s]: %s",
+                  color_level_cstr[ level<sizeof(color_level_cstr)/sizeof(color_level_cstr[0]) ? level : 0 ],
+                  sregs.cs.dpl,
+                  file, line, func, msg ));
+}
+
+void
+fdos_hypercall_handler( fdos_env_t *     env,
+                        int              vcpu_fd,
+                        struct kvm_run * run ) {
+  if( FD_UNLIKELY( run->io.size!=4 || run->io.count!=1 ) ) {
+    FD_LOG_CRIT(( "invalid io_out hypercall (size=%u,count=%u)", run->io.size, run->io.count ));
+  }
+  fd_hypercall_args_t const * args = env->hyper_args;
+  uint  port = run->io.port;
+  ulong arg0 = FD_VOLATILE_CONST( args->arg[0] ); (void)arg0;
+  ulong arg1 = FD_VOLATILE_CONST( args->arg[1] ); (void)arg1;
+  ulong arg2 = FD_VOLATILE_CONST( args->arg[2] ); (void)arg2;
+  ulong arg3 = FD_VOLATILE_CONST( args->arg[3] ); (void)arg3;
+  ulong arg4 = FD_VOLATILE_CONST( args->arg[4] ); (void)arg4;
+  switch( port ) {
+  case FDOS_HYPERCALL_LOG:
+    hypercall_log( env, vcpu_fd, arg0, arg1, arg2, arg3, arg4 );
+    break;
+  default:
+    FD_LOG_CRIT(( "invalid hypercall port %u", port ));
+  }
+  return;
+}
+
+static void
+trace_rip( fdos_env_t *     env,
+           struct kvm_run * run,
+           int              vcpu_fd,
+           ulong            rip ) {
+  (void)env; (void)run;
+
+  struct kvm_regs regs;
+  if( FD_UNLIKELY( ioctl( vcpu_fd, KVM_GET_REGS, &regs )<0 ) ) {
+    FD_LOG_ERR(( "KVM_GET_REGS failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+  if( !rip ) rip = regs.rip;
+
+  char const * dis = "";
+# if FD_HAS_LIBLLVM
+  char dis_buf[ FD_X86_DISASM_MAX ];
+  dis = fd_x86_disasm( dis_buf, rip, env->text, env->text_sz, FDOS_GPADDR_KERN_CODE+0x1000 );
+  if( !dis ) dis = "                                        ";
+# endif
+
+  FD_LOG_INFO(( "\033[2mrip=%#lx\033[0m %s \033[2mrsp=%8llx rax=%16llx rbx=%16llx rcx=%16llx rdx=%16llx rsi=%16llx rdi=%16llx\033[0m",
+                rip, dis,
+                regs.rsp, regs.rax, regs.rbx, regs.rcx, regs.rdx, regs.rsi, regs.rdi ));
+}
+
+int
+fdos_kvm_run( fdos_env_t *     kern,
+              struct kvm_run * kvm_run,
+              int              vcpu_fd ) {
+  if( FD_UNLIKELY( ioctl( vcpu_fd, KVM_RUN, 0 ) )<0 ) {
+    if( errno==EINTR ) return 0;
+    FD_LOG_ERR(( "KVM_RUN failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+  switch( kvm_run->exit_reason ) {
+  case KVM_EXIT_IO: /* hypercall */
+    if( kvm_run->io.direction==KVM_EXIT_IO_OUT ) {
+      fdos_hypercall_handler( kern, vcpu_fd, kvm_run );
+    } else {
+      FD_LOG_ERR(( "Unexpected INPUT hypercall" ));
+    }
+    return 0;
+  case KVM_EXIT_DEBUG: {
+    trace_rip( kern, kvm_run, vcpu_fd, kvm_run->debug.arch.pc );
+    return 0;
+  }
+  case KVM_EXIT_HLT:
+    FD_LOG_NOTICE(( "KVM guest issued HLT instruction" ));
+    return 1;
+  case KVM_EXIT_FAIL_ENTRY:
+    FD_LOG_ERR(( "KVM guest failed to enter (hardware_entry_failure_reason=%#llx)", kvm_run->fail_entry.hardware_entry_failure_reason ));
+  case KVM_EXIT_SHUTDOWN:
+    FD_LOG_WARNING(( "KVM guest shut down (hardware_exit_reason=%#llx)", kvm_run->hw.hardware_exit_reason ));
+    return 1;
+  case KVM_EXIT_INTERNAL_ERROR:
+    FD_LOG_ERR(( "KVM_EXIT_INTERNAL_ERROR (suberror %u)", kvm_run->internal.suberror ));
+  default:
+    FD_LOG_ERR(( "Unhandled KVM exit reason %u", kvm_run->exit_reason ));
+  }
+}

--- a/src/fdos/host/fdos_kvm.h
+++ b/src/fdos/host/fdos_kvm.h
@@ -1,0 +1,17 @@
+#ifndef HEADER_fd_src_fdos_host_fdos_kvm_h
+#define HEADER_fd_src_fdos_host_fdos_kvm_h
+
+#include "fdos_env.h"
+#include <linux/kvm.h>
+
+void
+fdos_hypercall_handler( fdos_env_t *     env,
+                        int              vcpu_fd,
+                        struct kvm_run * run );
+
+int
+fdos_kvm_run( fdos_env_t *     kern,
+              struct kvm_run * kvm_run,
+              int              vcpu_fd );
+
+#endif /* HEADER_fd_src_fdos_host_fdos_kvm_h */

--- a/src/fdos/kern/fdos_kern.c
+++ b/src/fdos/kern/fdos_kern.c
@@ -198,7 +198,7 @@ fdos_kern_main( fdos_kern_args_t * args ) {
   setup_lstar();
 
   FD_LOG_NOTICE(( "Entering ring 3 user stack top %#lx", args->stack_user_top_gvaddr ));
-  ulong const user_stack_top_gpaddr = args->stack_user_top_gvaddr;
+  ulong const user_stack_top_gpaddr = args->stack_user_top_gvaddr-8UL;
   if( setjmp()==0 ) {
     enter_ring3( user_stack_top_gpaddr, (ulong)hello_ring3 );
   } else {

--- a/src/fdos/kern/fdos_kern_def.h
+++ b/src/fdos/kern/fdos_kern_def.h
@@ -1,0 +1,27 @@
+#ifndef HEADER_fd_src_fdos_kern_fdos_kern_def_h
+#define HEADER_fd_src_fdos_kern_fdos_kern_def_h
+
+/* Guest physical base addresses
+   These are identity-mapped into the ring 0 virtual address space
+
+   FIXME move these above the low 4 GiB (low 4 GiB needs to be reserved for user) */
+
+#define FDOS_GPADDR_KERN_META   0x1000000UL /* page table, GDT, TSS, etc */
+#define FDOS_GPADDR_KERN_CODE   0x2000000UL /* guest kern code */
+#define FDOS_GPADDR_KERN_RODATA 0x3000000UL /* guest kern rodata */
+#define FDOS_GPADDR_KERN_DATA   0x4000000UL /* guest kern data */
+#define FDOS_GPADDR_KERN_STACK  0x5000000UL /* guest stack */
+#define FDOS_GPADDR_USER_STACK  0x6000000UL /* user stack */
+
+/* Global Descriptor Table */
+
+#define FDOS_GDT_IDX_NULL      0UL
+#define FDOS_GDT_IDX_KERN_CODE 1UL
+#define FDOS_GDT_IDX_KERN_DATA 2UL
+#define FDOS_GDT_IDX_USER_DATA 3UL
+#define FDOS_GDT_IDX_USER_CODE 4UL
+#define FDOS_GDT_IDX_TSS       5UL
+#define FDOS_GDT_IDX_TSS_HIGH  6UL
+#define FDOS_GDT_CNT           7UL
+
+#endif /* HEADER_fd_src_fdos_kern_fdos_kern_def_h */

--- a/src/fdos/test_fdos.c
+++ b/src/fdos/test_fdos.c
@@ -1,0 +1,248 @@
+#include "host/fdos_kvm.h"
+#include "kern/fdos_kern_def.h"
+#include "x86/fd_x86_msr.h"
+#include "../util/fd_util.h"
+
+#include <errno.h>
+#include <fcntl.h> /* open(2) */
+#include <unistd.h> /* close(2) */
+#include <sys/ioctl.h> /* ioctl(2) */
+#include <sys/mman.h> /* mmap(2) */
+
+FD_IMPORT_BINARY( fdos_kern_img, "build/fdos/kern/x86_64/bin/fdos_kern.elf" );
+
+static void
+wksp_map_to_guest_phys( int         vm_fd,
+                        uint        slot,
+                        fd_wksp_t * wksp,
+                        ulong       gpaddr ) {
+  fd_shmem_join_info_t info[1];
+  FD_TEST( 0==fd_shmem_join_query_by_join( wksp, info ) );
+
+  struct kvm_userspace_memory_region region = {
+    .slot            = slot,
+    .guest_phys_addr = gpaddr,
+    .memory_size     = info->page_sz * info->page_cnt,
+    .userspace_addr  = (ulong)wksp
+  };
+  if( FD_UNLIKELY( ioctl( vm_fd, KVM_SET_USER_MEMORY_REGION, &region )<0 ) ) {
+    FD_LOG_ERR(( "KVM_SET_USER_MEMORY_REGION(slot=%u,guest_phys_addr=%#llx,memory_size=%#llx,userspace_addr=%p) failed (%i-%s)",
+                 region.slot, region.guest_phys_addr, region.memory_size, (void *)region.userspace_addr, errno, fd_io_strerror( errno ) ));
+  }
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  int flag_trace = fd_env_strip_cmdline_contains( &argc, &argv, "--trace" );
+
+  /* Create a VM kernel object */
+
+  int kvm_fd = open( "/dev/kvm", O_RDWR|O_CLOEXEC );
+  if( FD_UNLIKELY( kvm_fd<0 ) ) {
+    FD_LOG_ERR(( "open(/dev/kvm) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+
+  int kvm_version = ioctl( kvm_fd, KVM_GET_API_VERSION, 0 );
+  if( FD_UNLIKELY( kvm_version!=KVM_API_VERSION ) ) {
+    FD_LOG_ERR(( "Linux KVM version mismatch (have %i, expected %i)", kvm_version, KVM_API_VERSION ));
+  }
+
+  int vm_fd = ioctl( kvm_fd, KVM_CREATE_VM, 0 );
+  if( FD_UNLIKELY( vm_fd<0 ) ) {
+    FD_LOG_ERR(( "KVM_CREATE_VM failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+
+  int vcpu_fd = ioctl( vm_fd, KVM_CREATE_VCPU, 0 );
+  if( FD_UNLIKELY( vcpu_fd<0 ) ) {
+    FD_LOG_ERR(( "KVM_CREATE_VCPU failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+
+  /* Setup guest kernel data structures */
+
+  fdos_env_t env[1];
+  FD_TEST( fdos_env_create( env, fdos_kern_img, fdos_kern_img_sz ) );
+
+  /* Interrupt handler */
+
+  /* Map memory regions into guest physical memory */
+
+  wksp_map_to_guest_phys( vm_fd, 0U, env->wksp_kern_meta,   FDOS_GPADDR_KERN_META   );
+  wksp_map_to_guest_phys( vm_fd, 1U, env->wksp_kern_code,   FDOS_GPADDR_KERN_CODE   );
+  wksp_map_to_guest_phys( vm_fd, 2U, env->wksp_kern_rodata, FDOS_GPADDR_KERN_RODATA );
+  wksp_map_to_guest_phys( vm_fd, 3U, env->wksp_kern_data,   FDOS_GPADDR_KERN_DATA   );
+  wksp_map_to_guest_phys( vm_fd, 4U, env->wksp_kern_stack,  FDOS_GPADDR_KERN_STACK  );
+  wksp_map_to_guest_phys( vm_fd, 5U, env->wksp_user_stack,  FDOS_GPADDR_USER_STACK  );
+
+  struct kvm_sregs sregs[1];
+  if( FD_UNLIKELY( ioctl( vcpu_fd, KVM_GET_SREGS, sregs )<0 ) ) {
+    FD_LOG_ERR(( "KVM_GET_SREGS failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+
+  sregs->gdt.base  = env->gdt_gpaddr;
+  sregs->gdt.limit = (FDOS_GDT_CNT * sizeof(ulong)) - 1UL;
+  memset( sregs->gdt.padding, 0, sizeof(sregs->gdt.padding) );
+
+  sregs->idt.base  = env->idt_gpaddr;
+  sregs->idt.limit = (256 * sizeof(fd_x86_idt_gate_t)) - 1UL;
+
+  /* Segment descriptors */
+
+  struct kvm_segment cs = {
+    .base     = 0,
+    .limit    = 0xffffffff,
+    .selector = 0x08, /* ring 0, GDT, entry 1 (code) */
+    .present  = 1,
+    .type     = 0xb,
+    .dpl      = 0,
+    .db       = 0,
+    .s        = 1,
+    .l        = 1,
+    .g        = 1
+  };
+  sregs->cs = cs;
+  struct kvm_segment ds = {
+    .base     = 0,
+    .limit    = 0xffffffff,
+    .selector = 0x10, /* ring 0, GDT, entry 2 (data) */
+    .type     = 0x3,
+    .present  = 1,
+    .dpl      = 0,
+    .db       = 0,
+    .s        = 1,
+    .l        = 1,
+    .g        = 1
+  };
+  sregs->ds = ds;
+  sregs->es = ds;
+  sregs->fs = ds;
+  sregs->gs = ds;
+  sregs->ss = ds;
+
+  /* Wire up TSS */
+
+  sregs->tr.base     = env->tss_kern_gpaddr;
+  sregs->tr.limit    = sizeof(fd_x86_tss64_t)-1UL;
+  sregs->tr.selector = 0x28;
+  sregs->tr.type     = 0xb;
+  sregs->tr.present  = 1;
+  sregs->tr.dpl      = 0;
+  sregs->tr.s        = 0;
+  sregs->tr.g        = 0;
+
+  sregs->ldt.unusable = 1;
+
+  /* Enable long mode */
+
+  sregs->cr3 = (ulong)env->pml4_gpaddr;
+  sregs->cr4 =
+      FD_X86_CR4_PAE |
+      FD_X86_CR4_OSFXSR;
+
+  sregs->cr0 =
+      FD_X86_CR0_PE |
+      FD_X86_CR0_MP |
+      FD_X86_CR0_ET |
+      FD_X86_CR0_NE |
+      FD_X86_CR0_WP |
+      FD_X86_CR0_AM |
+      FD_X86_CR0_PG;
+
+  sregs->efer =
+      FD_X86_EFER_SCE |
+      FD_X86_EFER_LME |
+      FD_X86_EFER_LMA;
+
+  if( FD_UNLIKELY( ioctl( vcpu_fd, KVM_SET_SREGS, sregs )<0 ) ) {
+    FD_LOG_ERR(( "KVM_SET_SREGS failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+
+  /* Setup SYSCALL MSRs */
+
+  ulong msr_star = ((ulong)0x08 << 3) | /* kernel CS */
+                   ((ulong)0x18 << 3);  /* user CS */
+
+  struct {
+    struct kvm_msrs msrs;
+    struct kvm_msr_entry entry[1];
+  } msr_req = {
+    .msrs = {
+      .nmsrs = 1
+    },
+    .entry = {
+      {
+        .index = FD_X86_MSR_STAR,
+        .data  = msr_star,
+      }
+    }
+  };
+  if( FD_UNLIKELY( ioctl( vcpu_fd, KVM_SET_MSRS, &msr_req )<0 ) ) {
+    FD_LOG_ERR(( "KVM_SET_MSRS failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+
+  /* Load initial CPU state */
+
+  struct kvm_regs regs = {
+    .rdi    = env->entry_args_gvaddr,
+    .rip    = env->entry_gvaddr,
+    .rflags = 0x2UL | (3<<12),
+    .rsp    = env->stack_kern_top_gvaddr,
+    .rbp    = env->stack_kern_top_gvaddr
+  };
+  if( FD_UNLIKELY( ioctl( vcpu_fd, KVM_SET_REGS, &regs )<0 ) ) {
+    FD_LOG_ERR(( "KVM_SET_REGS failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+
+  /* Enable guest debugging */
+
+  struct kvm_guest_debug debug = {0};
+  if( flag_trace ) {
+    debug.control = KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_SINGLESTEP;
+    if( FD_UNLIKELY( ioctl( vcpu_fd, KVM_SET_GUEST_DEBUG, &debug )<0 ) ) {
+      FD_LOG_ERR(( "KVM_SET_GUEST_DEBUG failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    }
+  }
+
+  /* Map kvm_run struct */
+
+  int mmap_size = ioctl( kvm_fd, KVM_GET_VCPU_MMAP_SIZE, 0 );
+  if( FD_UNLIKELY( mmap_size<0 ) ) {
+    FD_LOG_ERR(( "KVM_GET_VCPU_MMAP_SIZE failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+
+  struct kvm_run * kvm_run = mmap( NULL, (ulong)mmap_size, PROT_READ|PROT_WRITE, MAP_SHARED, vcpu_fd, 0 );
+  if( FD_UNLIKELY( kvm_run==MAP_FAILED ) ) {
+    FD_LOG_ERR(( "mmap(kvm_run) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+
+  FD_LOG_NOTICE(( "Running KVM guest" ));
+
+  /* Run */
+
+  for(;;) {
+    if( flag_trace ) {
+      struct kvm_guest_debug debug = {0};
+      debug.control = KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_SINGLESTEP;
+      if( FD_UNLIKELY( ioctl( vcpu_fd, KVM_SET_GUEST_DEBUG, &debug )<0 ) ) {
+        FD_LOG_ERR(( "KVM_SET_GUEST_DEBUG failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+      }
+    }
+    if( FD_UNLIKELY( 0!=fdos_kvm_run( env, kvm_run, vcpu_fd ) ) ) break;
+  }
+
+  /* Clean up */
+
+  FD_LOG_NOTICE(( "Cleaning up" ));
+
+  if( FD_UNLIKELY( munmap( kvm_run, (ulong)mmap_size ) ) ) FD_LOG_ERR(( "munmap(kvm_run) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  if( FD_UNLIKELY( close( vcpu_fd ) ) ) FD_LOG_ERR(( "close(vcpu) failed (%i-%s)",     errno, fd_io_strerror( errno ) ));
+  if( FD_UNLIKELY( close( vm_fd   ) ) ) FD_LOG_ERR(( "close(vm) failed (%i-%s)",       errno, fd_io_strerror( errno ) ));
+  if( FD_UNLIKELY( close( kvm_fd  ) ) ) FD_LOG_ERR(( "close(/dev/kvm) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+
+  fdos_env_destroy( env );
+
+  fd_halt();
+  return 0;
+}

--- a/src/fdos/x86/fd_x86_disasm.c
+++ b/src/fdos/x86/fd_x86_disasm.c
@@ -1,0 +1,62 @@
+#include "fd_x86_disasm.h"
+#include "../../util/fd_util.h"
+#include <llvm-c/Core.h>
+#include <llvm-c/TargetMachine.h>
+#include <llvm-c/Disassembler.h>
+
+char *
+fd_x86_disasm( char          str[ FD_X86_DISASM_MAX ],
+               ulong         rip,
+               uchar const * code,
+               ulong         code_sz,
+               ulong         code_base ) {
+  if( FD_UNLIKELY( rip<code_base ) ) return NULL;
+  ulong code_off = rip-code_base;
+  if( FD_UNLIKELY( code_off>=code_sz ) ) return NULL;
+  ulong code_avail = code_sz-code_off;
+
+  static LLVMDisasmContextRef disasm_ctx;
+  FD_THREAD_ONCE_BEGIN {
+    LLVMInitializeAllTargetInfos();
+    LLVMInitializeAllTargetMCs();
+    LLVMInitializeAllDisassemblers();
+
+    disasm_ctx = LLVMCreateDisasm( "x86_64-unknown-linux-gnu", NULL, 0, NULL, NULL );
+    FD_TEST( disasm_ctx );
+
+    FD_TEST( 1==LLVMSetDisasmOptions( disasm_ctx,
+        LLVMDisassembler_Option_PrintImmHex|
+        LLVMDisassembler_Option_AsmPrinterVariant|
+        LLVMDisassembler_Option_Color ) );
+  }
+  FD_THREAD_ONCE_END;
+
+  ulong cnt = LLVMDisasmInstruction( disasm_ctx, (uchar *)code+code_off, code_avail, rip, str, FD_X86_DISASM_MAX );
+  if( FD_UNLIKELY( cnt==0 ) ) return NULL;
+
+  /* Count number of chars excluding ANSI control chars.
+     Also, replace tabs with spaces. */
+  ulong visible_len = 0;
+  ulong i           = 0;
+  for( i=0; str[i]; i++ ) {
+    if( str[i]=='\x1b' ) {
+      /* Skip ANSI escape sequence */
+      i++;
+      while( str[i] && str[i]!='m' ) i++;
+      if( !str[i] ) break;
+      continue;
+    }
+    if( str[i]=='\t' ) {
+      str[i] = ' ';
+    }
+    visible_len++;
+  }
+
+  /* Pad with spaces to ensure fixed width */
+  for( ; visible_len<40 && i<FD_X86_DISASM_MAX-1; i++, visible_len++ ) {
+    str[i] = ' ';
+  }
+  str[i] = '\0';
+
+  return str;
+}

--- a/src/fdos/x86/fd_x86_disasm.h
+++ b/src/fdos/x86/fd_x86_disasm.h
@@ -1,0 +1,19 @@
+#ifndef HEADER_fd_fdos_x86_fd_x86_disasm_h
+#define HEADER_fd_fdos_x86_fd_x86_disasm_h
+
+#define FD_X86_DISASM_MAX 512
+
+#if FD_HAS_LIBLLVM
+
+#include "../../util/fd_util_base.h"
+
+char *
+fd_x86_disasm( char          str[ FD_X86_DISASM_MAX ],
+               ulong         rip,
+               uchar const * code,
+               ulong         code_sz,
+               ulong         code_base );
+
+#endif /* FD_HAS_LIBLLVM */
+
+#endif /* HEADER_fd_fdos_x86_fd_x86_disasm_h */

--- a/src/fdos/x86/fd_x86_gdt.h
+++ b/src/fdos/x86/fd_x86_gdt.h
@@ -1,0 +1,31 @@
+#ifndef HEADER_fd_src_fdos_x86_fd_x86_gdt_h
+#define HEADER_fd_src_fdos_x86_fd_x86_gdt_h
+
+#include "../../util/fd_util_base.h"
+
+union __attribute__((packed)) fd_x86_gdt {
+  struct __attribute__((packed)) {
+    ushort limit0;
+    ushort base0;
+    ushort base1 : 8;
+    ushort type : 4;
+    ushort s : 1;
+    ushort dpl : 2;
+    ushort p : 1;
+    ushort limit1 : 4;
+    ushort avl : 1;
+    ushort l : 1;
+    ushort d : 1;
+    ushort g : 1;
+    ushort base2 : 8;
+  };
+  struct __attribute__((packed)) {
+    uint base3;
+    uint reserved;
+  };
+  ulong ul;
+};
+
+typedef union fd_x86_gdt fd_x86_gdt_t;
+
+#endif /* HEADER_fd_src_fdos_x86_fd_x86_gdt_h */

--- a/src/fdos/x86/fd_x86_idt.h
+++ b/src/fdos/x86/fd_x86_idt.h
@@ -1,0 +1,18 @@
+#ifndef HEADER_fd_src_fdos_x86_fd_x86_idt_h
+#define HEADER_fd_src_fdos_x86_fd_x86_idt_h
+
+#include "../../util/fd_util_base.h"
+
+struct __attribute__((packed)) fd_x86_idt_gate {
+  ushort offset_low;
+  ushort selector;
+  uchar  ist;
+  uchar  type_attr;
+  ushort offset_mid;
+  uint   offset_high;
+  uint   reserved;
+};
+
+typedef struct fd_x86_idt_gate fd_x86_idt_gate_t;
+
+#endif /* HEADER_fd_src_fdos_x86_fd_x86_idt_h */

--- a/src/fdos/x86/fd_x86_mmu.h
+++ b/src/fdos/x86/fd_x86_mmu.h
@@ -1,0 +1,8 @@
+#ifndef HEADER_fd_src_fdos_x86_fd_x86_mmu_h
+#define HEADER_fd_src_fdos_x86_fd_x86_mmu_h
+
+#define FD_X86_PML4E_RANGE (1UL<<39)
+#define FD_X86_PDPTE_RANGE (1UL<<30)
+#define FD_X86_PDE_RANGE   (1UL<<21)
+
+#endif /* HEADER_fd_src_fdos_x86_fd_x86_mmu_h */

--- a/src/fdos/x86/fd_x86_msr.h
+++ b/src/fdos/x86/fd_x86_msr.h
@@ -1,0 +1,27 @@
+#ifndef HEADER_fd_src_fdos_x86_fd_x86_msr_h
+#define HEADER_fd_src_fdos_x86_fd_x86_msr_h
+
+#define FD_X86_CR0_PE (1U<<0)
+#define FD_X86_CR0_MP (1U<<1)
+#define FD_X86_CR0_EM (1U<<2)
+#define FD_X86_CR0_TS (1U<<3)
+#define FD_X86_CR0_ET (1U<<4)
+#define FD_X86_CR0_NE (1U<<5)
+#define FD_X86_CR0_WP (1U<<16)
+#define FD_X86_CR0_AM (1U<<18)
+#define FD_X86_CR0_NW (1U<<29)
+#define FD_X86_CR0_CD (1U<<30)
+#define FD_X86_CR0_PG (1U<<31)
+
+#define FD_X86_CR4_PAE    (1U<<5)
+#define FD_X86_CR4_OSFXSR (1U<<9)
+
+#define FD_X86_EFER_SCE (1U<< 0)
+#define FD_X86_EFER_LME (1U<< 8)
+#define FD_X86_EFER_LMA (1U<<10)
+#define FD_X86_EFER_NX  (1U<<11)
+
+#define FD_X86_MSR_STAR  0xc0000081
+#define FD_X86_MSR_LSTAR 0xc0000082
+
+#endif /* HEADER_fd_src_fdos_x86_fd_x86_msr_h */

--- a/src/fdos/x86/fd_x86_tss.h
+++ b/src/fdos/x86/fd_x86_tss.h
@@ -1,0 +1,26 @@
+#ifndef HEADER_fd_src_fdos_x86_fd_x86_tss_h
+#define HEADER_fd_src_fdos_x86_fd_x86_tss_h
+
+#include "../../util/fd_util_base.h"
+
+struct __attribute__((packed)) fd_x86_tss64 {
+  uint   reserved0;
+  ulong  rsp0;
+  ulong  rsp1;
+  ulong  rsp2;
+  ulong  reserved1;
+  ulong  ist1;
+  ulong  ist2;
+  ulong  ist3;
+  ulong  ist4;
+  ulong  ist5;
+  ulong  ist6;
+  ulong  ist7;
+  ulong  reserved2;
+  ushort reserved3;
+  ushort iomap_base;
+};
+
+typedef struct fd_x86_tss64 fd_x86_tss64_t;
+
+#endif /* HEADER_fd_src_fdos_x86_fd_x86_tss_h */


### PR DESCRIPTION
Adds a KVM-based execution environment for FiredancerOS:
- Basic physical and virtual memory maps
- ELF loader restoring kernel into an image
- Basic VM bootstrapping setting up long mode, page tables, GDT,
  TSS, stacks, and SYSCALL instruction
- libLLVM based x86 disassembler
- Linux KVM execution environment
