### PR TITLE
disco: make builder info updates atomic in bundle client

### DIFF
--- a/src/disco/bundle/fd_bundle_client.c
+++ b/src/disco/bundle/fd_bundle_client.c
@@ -776,11 +776,14 @@ fd_bundle_client_handle_builder_fee_info(
     return;
   }
 
-  ctx->builder_commission = (uchar)res.commission;
-  if( FD_UNLIKELY( !fd_base58_decode_32( res.pubkey, ctx->builder_pubkey ) ) ) {
+  uchar decoded_builder_pubkey[ 32 ];
+  if( FD_UNLIKELY( !fd_base58_decode_32( res.pubkey, decoded_builder_pubkey ) ) ) {
     FD_LOG_HEXDUMP_WARNING(( "Invalid pubkey in BlockBuilderFeeInfoResponse", res.pubkey, strnlen( res.pubkey, sizeof(res.pubkey) ) ));
     return;
   }
+
+  ctx->builder_commission = (uchar)res.commission; /* Apply update atomically */
+  fd_memcpy( ctx->builder_pubkey, decoded_builder_pubkey, sizeof(ctx->builder_pubkey) );
 
   long validity_duration_ns = (long)( 60e9 * 5. ); /* 5 minutes */
   ctx->builder_info_avail = 1;


### PR DESCRIPTION
The block_engine_config update handling should be "atomic", otherwise the context could end up containing an invalid state. 

For example if resp.has_block_engine_config is true, and cfg->builder_commission is invalid but cfg->builder_pubkey is valid, the ctx will contain the old stale builder_commission but a new builder_pubkey