### PR TITLE
rpc-client: fix uninit field

### DIFF
--- a/src/app/shared_dev/rpc_client/fd_rpc_client.c
+++ b/src/app/shared_dev/rpc_client/fd_rpc_client.c
@@ -28,6 +28,7 @@ fd_rpc_client_new( void * mem,
     rpc->requests[ i ].state = FD_RPC_CLIENT_STATE_NONE;
     rpc->fds[ i ].fd = -1;
     rpc->fds[ i ].events = POLLIN | POLLOUT;
+    rpc->fds[ i ].revents = 0;
   }
   return (void *)rpc;
 }


### PR DESCRIPTION
Fixes an MSAN violation when running test_rpc_client.

```
test_rpc_client      ==1275203==WARNING: MemorySanitizer: use-of-uninitialized-value
 test_rpc_client          #0 0x565010096cf5 in fd_rpc_client_service /home/sg/firedancer/src/app/shared_dev/rpc_client/fd_rpc_client.c:294:9
test_rpc_client          #1 0x5650100973db in fd_rpc_client_status /home/sg/firedancer/src/app/shared_dev/rpc_client/fd_rpc_client.c:358:5
test_rpc_client          #2 0x5650100943b9 in main /home/sg/firedancer/src/app/shared_dev/rpc_client/test_rpc_client.c:180:41
test_rpc_client          #3 0x7f2bc3607ca7 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
test_rpc_client          #4 0x7f2bc3607d64 in __libc_start_main csu/../csu/libc-start.c:360:3
test_rpc_client          #5 0x56500fff6690 in _start (/home/sg/firedancer/build/msan/unit-test/test_rpc_client+0x38690)
test_rpc_client      
test_rpc_client      SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/sg/firedancer/src/app/shared_dev/rpc_client/fd_rpc_client.c:294:9 in fd_rpc_client_service
```