### PR TITLE
flamenco, vote: fix UAF in vote program

### DIFF
--- a/src/flamenco/runtime/program/vote/fd_authorized_voters.c
+++ b/src/flamenco/runtime/program/vote/fd_authorized_voters.c
@@ -134,6 +134,7 @@ fd_authorized_voters_get_and_cache_authorized_voter_for_epoch( fd_vote_authorize
     ele->prio                        = (ulong)&res->pubkey;
     // https://github.com/anza-xyz/agave/blob/v2.0.1/sdk/program/src/vote/authorized_voters.rs#L33
     fd_vote_authorized_voters_treap_ele_insert( self->treap, ele, self->pool );
+    return ele;
   }
   return res;
 }


### PR DESCRIPTION
Fixes a use-after-free in the vote program, where:

- We try and retrieve the authorized voters element for an epoch, but they don't exist, so we insert the authorized voters for the current epoch, but return the cached authorized voters from the previous epoch!
- We copy a pointer to the pubkey we retrieved, for use later in the vote program
- However before using it, we purge the previous authorized voter entries, releasing the element from the pool to which we still hold a pointer
- This leads to a use-after-free when we try and use this stale pubkey pointer in `fd_vote_signature_verify`