### PR TITLE
restore: vinyl recovery pair_cnt

### DIFF
--- a/src/discof/restore/fd_snapwm_tile.c
+++ b/src/discof/restore/fd_snapwm_tile.c
@@ -203,14 +203,15 @@ handle_control_frag( fd_snapwm_tile_t *  ctx,
 
       /* Rewind metric counters (no-op unless recovering from a fail) */
       if( sig==FD_SNAPSHOT_MSG_CTRL_INIT_FULL ) {
-        ctx->metrics.accounts_loaded   = ctx->metrics.full_accounts_loaded   = 0;
-        ctx->metrics.accounts_replaced = ctx->metrics.full_accounts_replaced = 0;
-        ctx->metrics.accounts_ignored  = ctx->metrics.full_accounts_ignored  = 0;
-        ctx->vinyl.pair_cnt            = 0UL;
+        ctx->metrics.accounts_loaded   = ctx->metrics.full_accounts_loaded   = 0UL;
+        ctx->metrics.accounts_replaced = ctx->metrics.full_accounts_replaced = 0UL;
+        ctx->metrics.accounts_ignored  = ctx->metrics.full_accounts_ignored  = 0UL;
+        ctx->vinyl.pair_cnt            = ctx->vinyl.full_pair_cnt            = 0UL;
       } else {
         ctx->metrics.accounts_loaded   = ctx->metrics.full_accounts_loaded;
         ctx->metrics.accounts_replaced = ctx->metrics.full_accounts_replaced;
         ctx->metrics.accounts_ignored  = ctx->metrics.full_accounts_ignored;
+        ctx->vinyl.pair_cnt            = ctx->vinyl.full_pair_cnt;
       }
       break;
     }
@@ -233,6 +234,7 @@ handle_control_frag( fd_snapwm_tile_t *  ctx,
       ctx->metrics.full_accounts_loaded   = ctx->metrics.accounts_loaded;
       ctx->metrics.full_accounts_replaced = ctx->metrics.accounts_replaced;
       ctx->metrics.full_accounts_ignored  = ctx->metrics.accounts_ignored;
+      ctx->vinyl.full_pair_cnt            = ctx->vinyl.pair_cnt;
 
       if( FD_UNLIKELY( verify_slot_deltas_with_slot_history( ctx ) ) ) {
         FD_LOG_WARNING(( "slot deltas verification failed for full snapshot" ));

--- a/src/discof/restore/fd_snapwm_tile_private.h
+++ b/src/discof/restore/fd_snapwm_tile_private.h
@@ -77,6 +77,7 @@ struct fd_snapwm_tile {
     ulong   bstream_sz;
 
     ulong pair_cnt;
+    ulong full_pair_cnt;
 
     /* Vinyl in either io_wd or io_mm mode */
     fd_vinyl_io_t * io;


### PR DESCRIPTION
Vinyl recovery of `pair_cnt` during snapshot load when the incremental snapshot is cancelled (and restarted).