### PR TITLE
restore: snapct no state collapse

### DIFF
--- a/src/discof/restore/fd_snapct_tile.c
+++ b/src/discof/restore/fd_snapct_tile.c
@@ -562,9 +562,6 @@ after_credit( fd_snapct_tile_t *  ctx,
   /* Note: All state transitions should occur within this switch
      statement to make it easier to reason about the state management. */
 
-  /* FIXME: Collapse WAITING_FOR_PEERS and COLLECTING_PEERS states for
-     both full and incremental variants? */
-
   switch ( ctx->state ) {
 
     /* ============================================================== */


### PR DESCRIPTION
Deprecated FIXME on `snapct` states: waiting and collecting peers for both full and incremental left as separate states to simplify the state machine transitions.