### PR TITLE
gossip: fix pull request bugs

### DIFF
--- a/src/app/firedancer-dev/commands/gossip.c
+++ b/src/app/firedancer-dev/commands/gossip.c
@@ -899,6 +899,9 @@ gossip_cmd_fn( args_t *   args,
   printf(" Single Tile RX bw %s\n\n", fmt_bytes( buf1, net0_link[ MIDX( COUNTER, LINK, CONSUMED_SIZE_BYTES ) ] - prev_net0_rx_bytes ) );
   prev_net0_rx_bytes = net0_link[ MIDX( COUNTER, LINK, CONSUMED_SIZE_BYTES ) ];
 
+  printf( " Message unparseable: %lu/??\n",
+          gossip_metrics[ MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_UNPARSEABLE ) ] );
+
   ulong pull_response_drops = aggregate_gossvf_counter( &gossvf_tiles, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PULL_RESPONSE_NO_VALID_CRDS ) );
   ulong pull_response_success = aggregate_gossvf_counter( &gossvf_tiles, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_SUCCESS_PULL_RESPONSE ) );
   printf(" Pull response drops: %lu/%lu\n", pull_response_drops, pull_response_drops + pull_response_success);

--- a/src/flamenco/gossip/crds/fd_crds.c
+++ b/src/flamenco/gossip/crds/fd_crds.c
@@ -757,7 +757,7 @@ crds_entry_init( fd_gossip_value_t const * value,
   out_value->stake           = stake;
 
   fd_crds_generate_hash( sha, value_bytes, value_bytes_len, out_value->value_hash );
-  out_value->hash.hash_prefix = fd_ulong_bswap( fd_ulong_load_8( out_value->value_hash ) );
+  out_value->hash.hash_prefix = fd_ulong_load_8( out_value->value_hash );
 
   if( FD_UNLIKELY( value->tag==FD_GOSSIP_VALUE_NODE_INSTANCE ) ) {
     out_value->node_instance.token = value->node_instance->token;
@@ -782,7 +782,7 @@ void
 insert_purged( fd_crds_t *   crds,
                uchar const * hash,
                long          now ) {
-  ulong hash_prefix = fd_ulong_bswap( fd_ulong_load_8( hash ) );
+  ulong hash_prefix = fd_ulong_load_8( hash );
   if( purged_treap_ele_query( crds->purged.treap, hash_prefix, crds->purged.pool ) ) {
     return;
   }
@@ -844,7 +844,7 @@ void
 fd_crds_insert_failed_insert( fd_crds_t *   crds,
                               uchar const * hash,
                               long          now ) {
-  ulong hash_prefix = fd_ulong_bswap( fd_ulong_load_8( hash ) );
+  ulong hash_prefix = fd_ulong_load_8( hash );
   if( purged_treap_ele_query( crds->purged.treap, hash_prefix, crds->purged.pool ) ) {
     return;
   }

--- a/src/flamenco/gossip/fd_gossip.c
+++ b/src/flamenco/gossip/fd_gossip.c
@@ -488,7 +488,7 @@ rx_pull_request( fd_gossip_t *                    gossip,
     /* TODO: Add jitter here? */
     // if( FD_UNLIKELY( fd_crds_value_wallclock( candidate )>contact_info->wallclock_nanos ) ) continue;
 
-    if( FD_UNLIKELY( !fd_bloom_contains( filter, fd_crds_entry_hash( candidate ), 32UL ) ) ) continue;
+    if( FD_UNLIKELY( fd_bloom_contains( filter, fd_crds_entry_hash( candidate ), 32UL ) ) ) continue;
 
     uchar const * crds_val;
     ulong         crds_size;


### PR DESCRIPTION
 (1) There was an endianness mismatch in the
     hash_prefix computation for pull requests,
     so they were just wrong and we could get
     almost entirely duplicates back.

 (2) The bloom filter check in rx_pull_request was
     inverted, so we were always sending back
     exactly the values a requesting node already
     had.