### PR TITLE
ethtool-channels: fix net packet rx distribution

### DIFF
--- a/src/app/shared/commands/configure/fd_ethtool_ioctl.c
+++ b/src/app/shared/commands/configure/fd_ethtool_ioctl.c
@@ -573,3 +573,15 @@ fd_ethtool_ioctl_ntuple_validate_udp_dport( fd_ethtool_ioctl_t * ioc,
   *valid = 1;
   return 0;
 }
+
+int
+fd_ethtool_ioctl_rxfh_set_flow_hash_udp4( fd_ethtool_ioctl_t * ioc ) {
+  FD_LOG_NOTICE(( "RUN: `ethtool --config-nfc %s rx-flow-hash udp4 sdfn`", ioc->ifr.ifr_name ));
+  struct ethtool_rxnfc nfc = {
+    .cmd       = ETHTOOL_SRXFH,
+    .flow_type = UDP_V4_FLOW,
+    .data      = RXH_IP_SRC | RXH_IP_DST | RXH_L4_B_0_1 | RXH_L4_B_2_3,
+  };
+  TRY_RUN_IOCTL( ioc, "ETHTOOL_SRXFH", &nfc );
+  return 0;
+}

--- a/src/app/shared/commands/configure/fd_ethtool_ioctl.h
+++ b/src/app/shared/commands/configure/fd_ethtool_ioctl.h
@@ -208,6 +208,17 @@ fd_ethtool_ioctl_ntuple_validate_udp_dport( fd_ethtool_ioctl_t * ioc,
                                             uint                 queue_cnt,
                                             int *                valid );
 
+/* fd_ethtool_ioctl_rxfh_set_flow_hash_udp4 configures the NIC to
+   include source and destination ports in the RSS hash for UDP/IPv4
+   flows.  By default, many NICs only hash on IP addresses for UDP,
+   which causes poor load balancing when traffic has a fixed destination
+   IP and port (e.g. gossip).  Including ports in the hash provides
+   much better entropy and queue distribution.  Returns nonzero on
+   failure. */
+
+int
+fd_ethtool_ioctl_rxfh_set_flow_hash_udp4( fd_ethtool_ioctl_t * ioc );
+
 
 FD_PROTOTYPES_END
 


### PR DESCRIPTION
Gossip was seeing extremely imbalanced inflow,
with 10-20x the RX bandwidth arriving on net tile
0 in a two net tile configuration.  This is due to most NICs defaulting to hashing only on IP
addresses for UDP/IPv4 flows, which causes severe
RX queue imbalance when all traffic targets the
same destination IP and port (e.g. gossip).