### PR TITLE
gossip: filter crds without a contact info in pull requests

### DIFF
--- a/src/app/firedancer-dev/commands/gossip.c
+++ b/src/app/firedancer-dev/commands/gossip.c
@@ -141,7 +141,7 @@ fd_gossip_subtopo( config_t * config, ulong tile_to_cpu[ FD_TILE_MAX ] FD_PARAM_
   fd_topob_link( topo, "gossip_out", "gossip_out", 65536UL*4, sizeof(fd_gossip_update_message_t), 1UL );
   fd_topob_tile_out( topo, "gossip", 0UL, "gossip_out", 0UL );
   for( ulong i=0UL; i<gossvf_tile_count; i++ ) {
-    fd_topob_link(     topo, "gossvf_gossip", "gossvf_gossip", 65536UL*4, sizeof(fd_gossip_message_t)+FD_NET_MTU, 1UL );
+    fd_topob_link(     topo, "gossvf_gossip", "gossvf_gossip", 65536UL*4, sizeof(fd_gossip_message_t)+FD_GOSSIP_MESSAGE_MAX_CRDS+FD_NET_MTU, 1UL );
     fd_topob_tile_out( topo, "gossvf", i, "gossvf_gossip", i );
     fd_topob_tile_in(  topo, "gossip", 0UL, "metric_in", "gossvf_gossip", i, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
 
@@ -904,7 +904,7 @@ gossip_cmd_fn( args_t *   args,
 
   ulong pull_response_drops = aggregate_gossvf_counter( &gossvf_tiles, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_DROPPED_PULL_RESPONSE_NO_VALID_CRDS ) );
   ulong pull_response_success = aggregate_gossvf_counter( &gossvf_tiles, MIDX( COUNTER, GOSSVF, MESSAGE_RX_COUNT_SUCCESS_PULL_RESPONSE ) );
-  printf(" Pull response drops: %lu/%lu\n", pull_response_drops, pull_response_drops + pull_response_success);
+  printf(" Pull response drops (no valid CRDS): %lu/%lu\n", pull_response_drops, pull_response_drops + pull_response_success);
 
   ulong crds_success = aggregate_gossvf_counter( &gossvf_tiles, MIDX( COUNTER, GOSSVF, CRDS_RX_COUNT_SUCCESS_PULL_RESPONSE ) );
   ulong crds_duplicate = aggregate_gossvf_counter( &gossvf_tiles, MIDX( COUNTER, GOSSVF, CRDS_RX_COUNT_DROPPED_PULL_RESPONSE_DUPLICATE ) );

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -575,7 +575,7 @@ fd_topo_initialize( config_t * config ) {
 
   /**/                 fd_topob_link( topo, "genesi_out",    "genesi_out",    2UL,                                      10UL*1024UL*1024UL+32UL+sizeof(fd_lthash_value_t), 1UL );
   /**/                 fd_topob_link( topo, "ipecho_out",    "ipecho_out",    2UL,                                      0UL,                           1UL );
-  FOR(gossvf_tile_cnt) fd_topob_link( topo, "gossvf_gossip", "gossvf_gossip", config->net.ingress_buffer_size,          sizeof(fd_gossip_message_t)+FD_NET_MTU, 1UL );
+  FOR(gossvf_tile_cnt) fd_topob_link( topo, "gossvf_gossip", "gossvf_gossip", config->net.ingress_buffer_size,          sizeof(fd_gossip_message_t)+FD_GOSSIP_MESSAGE_MAX_CRDS+FD_NET_MTU, 1UL );
   /**/                 fd_topob_link( topo, "gossip_gossvf", "gossip_gossvf", 65536UL*4UL,                              sizeof(fd_gossip_ping_update_t), 1UL ); /* TODO: Unclear where this depth comes from ... fix */
   /**/                 fd_topob_link( topo, "gossip_out",    "gossip_out",    65536UL*4UL,                              sizeof(fd_gossip_update_message_t), 1UL ); /* TODO: Unclear where this depth comes from ... fix */
 

--- a/src/discof/gossip/fd_gossip_tile.c
+++ b/src/discof/gossip/fd_gossip_tile.c
@@ -506,7 +506,7 @@ populate_allowed_fds( fd_topo_t const *      topo,
 
    */
 
-FD_STATIC_ASSERT( CRDS_MAX_CONTACT_INFO+17UL/*FD_GOSSIP_MSG_MAX_CRDS*/*2UL<=FD_PING_TRACKER_MAX+1UL,
+FD_STATIC_ASSERT( CRDS_MAX_CONTACT_INFO+FD_GOSSIP_MESSAGE_MAX_CRDS*2UL<=FD_PING_TRACKER_MAX+1UL,
                   "Gossip stem burst needs recalculating" );
 #define STEM_BURST ( FD_PING_TRACKER_MAX+1UL )
 

--- a/src/discof/gossip/fd_gossvf_tile.c
+++ b/src/discof/gossip/fd_gossvf_tile.c
@@ -444,7 +444,8 @@ static void
 filter_shred_version_crds( fd_gossvf_tile_ctx_t * ctx,
                            uint                   tag,
                            fd_gossip_value_t *    values,
-                           ulong *                values_len ) {
+                           ulong *                values_len,
+                           uchar *                failed ) {
   ulong i = 0UL;
   while( i<*values_len ) {
     int keep      = 0;
@@ -475,9 +476,7 @@ filter_shred_version_crds( fd_gossvf_tile_ctx_t * ctx,
           ctx->metrics.crds_rx_bytes[ FD_METRICS_ENUM_GOSSVF_CRDS_OUTCOME_V_DROPPED_PUSH_ORIGIN_SHRED_VERSION_IDX ] += values[ i ].length;
         }
       }
-      values[ i ] = values[ *values_len-1UL ];
-      (*values_len)--;
-      continue;
+      failed[ i ] = 1;
     }
 
     i++;
@@ -486,14 +485,15 @@ filter_shred_version_crds( fd_gossvf_tile_ctx_t * ctx,
 
 static int
 filter_shred_version( fd_gossvf_tile_ctx_t * ctx,
-                      fd_gossip_message_t *  view ) {
+                      fd_gossip_message_t *  view,
+                      uchar *                failed ) {
   switch( view->tag ) {
     case FD_GOSSIP_MESSAGE_PING:
     case FD_GOSSIP_MESSAGE_PONG:
     case FD_GOSSIP_MESSAGE_PRUNE:
       return 0;
     case FD_GOSSIP_MESSAGE_PUSH: {
-      filter_shred_version_crds( ctx, view->tag, view->push->values, &view->push->values_len );
+      filter_shred_version_crds( ctx, view->tag, view->push->values, &view->push->values_len, failed );
       if( FD_UNLIKELY( !view->push->values_len ) ) {
         return FD_METRICS_ENUM_GOSSVF_MESSAGE_OUTCOME_V_DROPPED_PUSH_NO_VALID_CRDS_IDX;
       } else {
@@ -501,7 +501,7 @@ filter_shred_version( fd_gossvf_tile_ctx_t * ctx,
       }
     }
     case FD_GOSSIP_MESSAGE_PULL_RESPONSE: {
-      filter_shred_version_crds( ctx, view->tag, view->pull_response->values, &view->pull_response->values_len );
+      filter_shred_version_crds( ctx, view->tag, view->pull_response->values, &view->pull_response->values_len, failed );
       if( FD_UNLIKELY( !view->pull_response->values_len ) ) {
         return FD_METRICS_ENUM_GOSSVF_MESSAGE_OUTCOME_V_DROPPED_PULL_RESPONSE_NO_VALID_CRDS_IDX;
       } else {
@@ -603,6 +603,7 @@ check_addr( fd_ip4_port_t addr,
 static int
 verify_addresses( fd_gossvf_tile_ctx_t * ctx,
                   fd_gossip_message_t *  view,
+                  uchar *                failed,
                   fd_stem_context_t *    stem ) {
   ulong * values_len;
   fd_gossip_value_t * values;
@@ -613,7 +614,7 @@ verify_addresses( fd_gossvf_tile_ctx_t * ctx,
       return 0;
     case FD_GOSSIP_MESSAGE_PULL_REQUEST:
       if( FD_UNLIKELY( !check_addr( ctx->peer, ctx->allow_private_address ) ) ) return FD_METRICS_ENUM_GOSSVF_MESSAGE_OUTCOME_V_DROPPED_PULL_REQUEST_INACTIVE_IDX;
-      if( FD_UNLIKELY( ping_if_unponged( ctx, ctx->peer, view->pull_request->contact_info->origin, stem ) ) ) return FD_METRICS_ENUM_GOSSVF_MESSAGE_OUTCOME_V_DROPPED_PULL_REQUEST_INACTIVE_IDX;
+      // if( FD_UNLIKELY( ping_if_unponged( ctx, ctx->peer, view->pull_request->contact_info->origin, stem ) ) ) return FD_METRICS_ENUM_GOSSVF_MESSAGE_OUTCOME_V_DROPPED_PULL_REQUEST_INACTIVE_IDX;
       return 0;
     case FD_GOSSIP_MESSAGE_PUSH:
       values_len = &view->push->values_len;
@@ -651,25 +652,15 @@ verify_addresses( fd_gossvf_tile_ctx_t * ctx,
         ctx->metrics.crds_rx[ FD_METRICS_ENUM_GOSSVF_CRDS_OUTCOME_V_DROPPED_PULL_RESPONSE_INACTIVE_IDX ]++;
         ctx->metrics.crds_rx_bytes[ FD_METRICS_ENUM_GOSSVF_CRDS_OUTCOME_V_DROPPED_PULL_RESPONSE_INACTIVE_IDX ] += value->length;
       }
-      values[ i ] = values[ *values_len-1UL ];
-      (*values_len)--;
-      continue;
+      /* Mark as failed instead of removing so gossip tile can
+         track the hash in the purged set. */
+      failed[ i ] = 1;
     }
 
     i++;
   }
 
-  if( FD_UNLIKELY( !*values_len ) ) {
-    if( view->tag==FD_GOSSIP_MESSAGE_PUSH ) {
-      return FD_METRICS_ENUM_GOSSVF_MESSAGE_OUTCOME_V_DROPPED_PUSH_NO_VALID_CRDS_IDX;
-    } else if( view->tag==FD_GOSSIP_MESSAGE_PULL_RESPONSE ) {
-      return FD_METRICS_ENUM_GOSSVF_MESSAGE_OUTCOME_V_DROPPED_PULL_RESPONSE_NO_VALID_CRDS_IDX;
-    } else {
-      __builtin_unreachable();
-    }
-  } else {
-    return 0;
-  }
+  return 0;
 }
 
 static void
@@ -809,10 +800,12 @@ handle_net( fd_gossvf_tile_ctx_t * ctx,
     if( FD_UNLIKELY( !message->push->values_len ) ) return FD_METRICS_ENUM_GOSSVF_MESSAGE_OUTCOME_V_DROPPED_PUSH_NO_VALID_CRDS_IDX;
   }
 
-  int result = filter_shred_version( ctx, message );
+  uchar failed[ FD_GOSSIP_MESSAGE_MAX_CRDS ] = {0};
+
+  int result = filter_shred_version( ctx, message, failed );
   if( FD_UNLIKELY( result ) ) return result;
 
-  result = verify_addresses( ctx, message, stem );
+  result = verify_addresses( ctx, message, failed, stem );
   if( FD_UNLIKELY( result ) ) return result;
 
   result = verify_signatures( ctx, message, payload, ctx->sha );
@@ -823,6 +816,7 @@ handle_net( fd_gossvf_tile_ctx_t * ctx,
   switch( message->tag ) {
     case FD_GOSSIP_MESSAGE_PULL_RESPONSE: {
       for( ulong i=0UL; i<message->pull_response->values_len; i++ ) {
+        if( FD_UNLIKELY( failed[ i ] ) ) continue; /* Don't add to tcache so we can re-receive after learning contact info */
         ulong dedup_tag = ctx->seed ^ fd_ulong_load_8_fast( message->pull_response->values[ i ].signature );
         int ha_dup = 0;
         FD_TCACHE_INSERT( ha_dup, *ctx->tcache.sync, ctx->tcache.ring, ctx->tcache.depth, ctx->tcache.map, ctx->tcache.map_cnt, dedup_tag );
@@ -832,6 +826,7 @@ handle_net( fd_gossvf_tile_ctx_t * ctx,
     }
     case FD_GOSSIP_MESSAGE_PUSH: {
       for( ulong i=0UL; i<message->push->values_len; i++ ) {
+        if( FD_UNLIKELY( failed[ i ] ) ) continue; /* Don't add to tcache so we can re-receive after learning contact info */
         ulong dedup_tag = ctx->seed ^ fd_ulong_load_8_fast( message->push->values[ i ].signature );
         int ha_dup = 0;
         FD_TCACHE_INSERT( ha_dup, *ctx->tcache.sync, ctx->tcache.ring, ctx->tcache.depth, ctx->tcache.map, ctx->tcache.map_cnt, dedup_tag );
@@ -872,11 +867,13 @@ handle_net( fd_gossvf_tile_ctx_t * ctx,
 
   uchar * dst = fd_chunk_to_laddr( ctx->out->mem, ctx->out->chunk );
   fd_memcpy( dst, message, sizeof(fd_gossip_message_t ) );
-  fd_memcpy( dst+sizeof(fd_gossip_message_t), payload, payload_sz );
+  fd_memcpy( dst+sizeof(fd_gossip_message_t), failed, FD_GOSSIP_MESSAGE_MAX_CRDS );
+  fd_memcpy( dst+sizeof(fd_gossip_message_t)+FD_GOSSIP_MESSAGE_MAX_CRDS, payload, payload_sz );
 
   ulong tspub = (ulong)fd_frag_meta_ts_comp( fd_tickcount() );
-  fd_stem_publish( stem, 0UL, fd_gossvf_sig( ctx->peer.addr, ctx->peer.port, 0 ), ctx->out->chunk, sizeof(fd_gossip_message_t)+payload_sz, 0UL, tsorig, tspub );
-  ctx->out->chunk = fd_dcache_compact_next( ctx->out->chunk, sizeof(fd_gossip_message_t)+payload_sz, ctx->out->chunk0, ctx->out->wmark );
+  ulong out_sz = sizeof(fd_gossip_message_t)+FD_GOSSIP_MESSAGE_MAX_CRDS+payload_sz;
+  fd_stem_publish( stem, 0UL, fd_gossvf_sig( ctx->peer.addr, ctx->peer.port, 0 ), ctx->out->chunk, out_sz, 0UL, tsorig, tspub );
+  ctx->out->chunk = fd_dcache_compact_next( ctx->out->chunk, out_sz, ctx->out->chunk0, ctx->out->wmark );
 
   return result;
 }

--- a/src/flamenco/gossip/crds/fd_crds.c
+++ b/src/flamenco/gossip/crds/fd_crds.c
@@ -294,14 +294,25 @@ struct fd_crds_purged {
   /* Similar to fd_crds_entry, we keep a linked list of purged values sorted
      by insertion time. The time used here is our node's wallclock.
 
-     There are actually two (mutually exclusive) lists that reuse the same
-     pointers here: one for "purged" entries that expire in 60s and one for
-     "failed_inserts" that expire after 20s. */
+     There are actually three (mutually exclusive) lists that reuse the same
+     pointers here: one for "purged" entries that expire in 60s, one for
+     "failed_inserts" that expire after 20s, and one for
+     "no_contact_info" entries that expire after 2 days. */
   struct {
     long  wallclock_nanos;
     ulong next;
     ulong prev;
   } expire;
+
+  /* For no_contact_info entries, we also track the origin pubkey and
+     chain entries by origin so they can all be drained when we learn
+     the contact info for that pubkey.  Entries with the same origin
+     are chained together in the nci_origin_map (MAP_MULTI). */
+  fd_pubkey_t origin;
+  struct {
+    ulong next;
+    ulong prev;
+  } nci_map;
 };
 typedef struct fd_crds_purged fd_crds_purged_t;
 
@@ -340,6 +351,30 @@ typedef struct fd_crds_purged fd_crds_purged_t;
 
 #include "../../../util/tmpl/fd_dlist.c"
 
+#define DLIST_NAME  no_contact_info_dlist
+#define DLIST_ELE_T fd_crds_purged_t
+#define DLIST_PREV  expire.prev
+#define DLIST_NEXT  expire.next
+
+#include "../../../util/tmpl/fd_dlist.c"
+
+/* MAP_MULTI map_chain keyed on the origin pubkey of purged entries.
+   Multiple entries can share the same origin, so we use MAP_MULTI to
+   chain them together.  This lets us drain all entries for a given
+   origin when we learn their contact info. */
+
+#define MAP_NAME               nci_origin_map
+#define MAP_KEY                origin
+#define MAP_ELE_T              fd_crds_purged_t
+#define MAP_KEY_T              fd_pubkey_t
+#define MAP_PREV               nci_map.prev
+#define MAP_NEXT               nci_map.next
+#define MAP_KEY_EQ(k0,k1)      fd_pubkey_eq( k0, k1 )
+#define MAP_KEY_HASH(key,seed) (seed^fd_ulong_load_8( (key)->uc ))
+#define MAP_MULTI              1
+#define MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL 1
+#include "../../../util/tmpl/fd_map_chain.c"
+
 struct fd_crds_private {
   fd_gossip_out_ctx_t * gossip_update;
 
@@ -356,10 +391,17 @@ struct fd_crds_private {
   lookup_map_t *            lookup_map;
 
   struct {
-    fd_crds_purged_t *       pool;
-    purged_treap_t *         treap;
-    purged_dlist_t *         purged_dlist;
-    failed_inserts_dlist_t * failed_inserts_dlist;
+    fd_crds_purged_t *            pool;
+    purged_treap_t *              treap;
+    purged_dlist_t *              purged_dlist;
+    failed_inserts_dlist_t *      failed_inserts_dlist;
+    no_contact_info_dlist_t *     no_contact_info_dlist;
+
+    /* Per-origin-pubkey map (MAP_MULTI) for no_contact_info entries.
+       When we learn a contact info for a pubkey, we drain all
+       associated hashes from the purged treap so peers re-send them.
+       Elements live in the purged pool above. */
+    nci_origin_map_t *            nci_origin_map;
   } purged;
 
   struct {
@@ -383,6 +425,7 @@ fd_crds_align( void ) {
 FD_FN_CONST ulong
 fd_crds_footprint( ulong ele_max,
                    ulong purged_max ) {
+  ulong nci_origin_max = fd_ulong_pow2_up( purged_max/4UL );
   ulong l;
   l = FD_LAYOUT_INIT;
   l = FD_LAYOUT_APPEND( l, FD_CRDS_ALIGN,                         sizeof(fd_crds_t) );
@@ -396,6 +439,8 @@ fd_crds_footprint( ulong ele_max,
   l = FD_LAYOUT_APPEND( l, purged_treap_align(),                  purged_treap_footprint( purged_max ) );
   l = FD_LAYOUT_APPEND( l, purged_dlist_align(),                  purged_dlist_footprint() );
   l = FD_LAYOUT_APPEND( l, failed_inserts_dlist_align(),          failed_inserts_dlist_footprint() );
+  l = FD_LAYOUT_APPEND( l, no_contact_info_dlist_align(),         no_contact_info_dlist_footprint() );
+  l = FD_LAYOUT_APPEND( l, nci_origin_map_align(),                nci_origin_map_footprint( nci_origin_max ) );
   l = FD_LAYOUT_APPEND( l, crds_contact_info_pool_align(),        crds_contact_info_pool_footprint( CRDS_MAX_CONTACT_INFO ) );
   l = FD_LAYOUT_APPEND( l, crds_contact_info_fresh_list_align(),  crds_contact_info_fresh_list_footprint() );
   l = FD_LAYOUT_APPEND( l, crds_contact_info_evict_dlist_align(), crds_contact_info_evict_dlist_footprint() );
@@ -450,6 +495,9 @@ fd_crds_new( void *                    shmem,
   void * _purged_treap          = FD_SCRATCH_ALLOC_APPEND( l, purged_treap_align(),                  purged_treap_footprint( purged_max ) );
   void * _purged_dlist          = FD_SCRATCH_ALLOC_APPEND( l, purged_dlist_align(),                  purged_dlist_footprint() );
   void * _failed_inserts_dlist  = FD_SCRATCH_ALLOC_APPEND( l, failed_inserts_dlist_align(),          failed_inserts_dlist_footprint() );
+  ulong nci_origin_max          = fd_ulong_pow2_up( purged_max/4UL );
+  void * _nci_dlist             = FD_SCRATCH_ALLOC_APPEND( l, no_contact_info_dlist_align(),         no_contact_info_dlist_footprint() );
+  void * _nci_origin_map        = FD_SCRATCH_ALLOC_APPEND( l, nci_origin_map_align(),                nci_origin_map_footprint( nci_origin_max ) );
   void * _ci_pool               = FD_SCRATCH_ALLOC_APPEND( l, crds_contact_info_pool_align(),        crds_contact_info_pool_footprint( CRDS_MAX_CONTACT_INFO ) );
   void * _ci_dlist              = FD_SCRATCH_ALLOC_APPEND( l, crds_contact_info_fresh_list_align(),  crds_contact_info_fresh_list_footprint() );
   void * _ci_evict_dlist        = FD_SCRATCH_ALLOC_APPEND( l, crds_contact_info_evict_dlist_align(), crds_contact_info_evict_dlist_footprint() );
@@ -487,6 +535,12 @@ fd_crds_new( void *                    shmem,
 
   crds->purged.failed_inserts_dlist = failed_inserts_dlist_join( failed_inserts_dlist_new( _failed_inserts_dlist ) );
   FD_TEST( crds->purged.failed_inserts_dlist );
+
+  crds->purged.no_contact_info_dlist = no_contact_info_dlist_join( no_contact_info_dlist_new( _nci_dlist ) );
+  FD_TEST( crds->purged.no_contact_info_dlist );
+
+  crds->purged.nci_origin_map = nci_origin_map_join( nci_origin_map_new( _nci_origin_map, nci_origin_max, fd_rng_ulong( rng ) ) );
+  FD_TEST( crds->purged.nci_origin_map );
 
   crds->contact_info.pool = crds_contact_info_pool_join( crds_contact_info_pool_new( _ci_pool, CRDS_MAX_CONTACT_INFO ) );
   FD_TEST( crds->contact_info.pool );
@@ -656,6 +710,25 @@ expire( fd_crds_t *         crds,
 
     failed_inserts_dlist_ele_pop_head( crds->purged.failed_inserts_dlist, crds->purged.pool );
     purged_treap_ele_remove( crds->purged.treap, head, crds->purged.pool );
+    purged_pool_ele_release( crds->purged.pool, head );
+
+    crds->metrics->purged_cnt--;
+    crds->metrics->purged_expired_cnt++;
+  }
+
+  while( !no_contact_info_dlist_is_empty( crds->purged.no_contact_info_dlist, crds->purged.pool ) ) {
+    fd_crds_purged_t * head = no_contact_info_dlist_ele_peek_head( crds->purged.no_contact_info_dlist, crds->purged.pool );
+
+    /* Super long expiry time ... these don't get expired from peer
+       tables since they can last up to ~2 days, so we would otherwise
+       keep re-requesting these.  Reasonable to just fill the LRU with
+       them and let them cycle off then, or of course once we learn the
+       contact info of whoever the origin was. */
+    if( FD_LIKELY( head->expire.wallclock_nanos>now-STAKED_EXPIRE_DURATION_NANOS ) ) break;
+
+    no_contact_info_dlist_ele_pop_head( crds->purged.no_contact_info_dlist, crds->purged.pool );
+    purged_treap_ele_remove( crds->purged.treap, head, crds->purged.pool );
+    nci_origin_map_ele_remove_fast( crds->purged.nci_origin_map, head, crds->purged.pool );
     purged_pool_ele_release( crds->purged.pool, head );
 
     crds->metrics->purged_cnt--;
@@ -867,6 +940,63 @@ fd_crds_insert_failed_insert( fd_crds_t *   crds,
   purged_init( failed, hash, hash_prefix, now );
   purged_treap_ele_insert( crds->purged.treap, failed, crds->purged.pool );
   failed_inserts_dlist_ele_push_tail( crds->purged.failed_inserts_dlist, failed, crds->purged.pool );
+}
+
+void
+fd_crds_insert_no_contact_info( fd_crds_t *   crds,
+                                uchar const * origin,
+                                uchar const * hash,
+                                long          now ) {
+  ulong hash_prefix = fd_ulong_load_8( hash );
+  if( FD_UNLIKELY( purged_treap_ele_query( crds->purged.treap, hash_prefix, crds->purged.pool ) ) ) return;
+
+  fd_crds_purged_t * nci;
+  if( FD_UNLIKELY( !purged_pool_free( crds->purged.pool ) ) ) {
+    /* Evict oldest no_contact_info entry.  If the no_contact_info dlist
+       is empty, fall back to evicting from failed_inserts. */
+    if( FD_LIKELY( !no_contact_info_dlist_is_empty( crds->purged.no_contact_info_dlist, crds->purged.pool ) ) ) {
+      nci = no_contact_info_dlist_ele_pop_head( crds->purged.no_contact_info_dlist, crds->purged.pool );
+      purged_treap_ele_remove( crds->purged.treap, nci, crds->purged.pool );
+      nci_origin_map_ele_remove_fast( crds->purged.nci_origin_map, nci, crds->purged.pool );
+    } else {
+      nci = failed_inserts_dlist_ele_pop_head( crds->purged.failed_inserts_dlist, crds->purged.pool );
+      purged_treap_ele_remove( crds->purged.treap, nci, crds->purged.pool );
+    }
+    crds->metrics->purged_evicted_cnt++;
+  } else {
+    nci = purged_pool_ele_acquire( crds->purged.pool );
+    crds->metrics->purged_cnt++;
+  }
+
+  purged_init( nci, hash, hash_prefix, now );
+  fd_memcpy( nci->origin.uc, origin, 32UL );
+  purged_treap_ele_insert( crds->purged.treap, nci, crds->purged.pool );
+  no_contact_info_dlist_ele_push_tail( crds->purged.no_contact_info_dlist, nci, crds->purged.pool );
+
+  nci_origin_map_ele_insert( crds->purged.nci_origin_map, nci, crds->purged.pool );
+}
+
+void
+fd_crds_drain_no_contact_info( fd_crds_t *   crds,
+                               uchar const * origin ) {
+  /* Iterate all entries in the MAP_MULTI chain for this origin,
+     removing each one.  We use idx-based iteration so we can
+     capture the next index before removing the current element
+     (which clobbers its chain pointers). */
+  fd_pubkey_t const * key = (fd_pubkey_t const *)origin;
+  ulong idx = nci_origin_map_idx_query_const( crds->purged.nci_origin_map, key, ULONG_MAX, crds->purged.pool );
+  while( idx!=ULONG_MAX ) {
+    ulong next_idx = nci_origin_map_idx_next_const( idx, ULONG_MAX, crds->purged.pool );
+    fd_crds_purged_t * entry = &crds->purged.pool[ idx ];
+
+    nci_origin_map_ele_remove_fast( crds->purged.nci_origin_map, entry, crds->purged.pool );
+    no_contact_info_dlist_ele_remove( crds->purged.no_contact_info_dlist, entry, crds->purged.pool );
+    purged_treap_ele_remove( crds->purged.treap, entry, crds->purged.pool );
+    purged_pool_ele_release( crds->purged.pool, entry );
+
+    crds->metrics->purged_cnt--;
+    idx = next_idx;
+  }
 }
 
 int

--- a/src/flamenco/gossip/crds/fd_crds.h
+++ b/src/flamenco/gossip/crds/fd_crds.h
@@ -128,6 +128,36 @@ fd_crds_insert_failed_insert( fd_crds_t *   crds,
                               uchar const * hash,
                               long          now );
 
+/* fd_crds_insert_no_contact_info records a CRDS value hash that was
+   dropped because the origin pubkey has no known contact info.  The
+   hash is inserted into the shared purged treap (so it appears in
+   bloom filters) and into a per-pubkey chain so all entries for a
+   given origin can be drained when we learn their contact info.
+
+   origin points to the 32-byte origin pubkey of the CRDS value.
+   hash points to the 32-byte SHA-256 hash of the serialized value.
+   now is the current wallclock time in nanoseconds. */
+
+void
+fd_crds_insert_no_contact_info( fd_crds_t *   crds,
+                                uchar const * origin,
+                                uchar const * hash,
+                                long          now );
+
+/* fd_crds_drain_no_contact_info removes all no_contact_info entries
+   associated with the given origin pubkey from the purged treap,
+   no_contact_info dlist, and per-pubkey chain.  This causes those
+   hashes to disappear from bloom filters, so peers will re-send the
+   corresponding CRDS values in future pull responses.
+
+   This should be called when we successfully learn a peer's contact
+   info (i.e., a ContactInfo CRDS value is inserted for the first
+   time for that pubkey). */
+
+void
+fd_crds_drain_no_contact_info( fd_crds_t *   crds,
+                               uchar const * origin );
+
 /* fd_crds_checks_fast checks if inserting a CRDS value would fail on
    specific conditions. Updates the CRDS purged table depending on the checks
    that failed.

--- a/src/flamenco/gossip/fd_gossip_message.h
+++ b/src/flamenco/gossip/fd_gossip_message.h
@@ -33,6 +33,23 @@
 
 #define FD_GOSSIP_VALUE_MAX_SZ (1188UL)
 
+/* Tightest bound for values[] in a Push / PullResponse given network
+   constraints.
+
+     IPv6 minimum MTU             = 1280
+     IPv6 header                  =   40
+     UDP header                   =    8
+     PACKET_DATA_SIZE             = 1232   (= 1280 - 40 - 8)
+
+     Minimum bytes consumed before values loop:
+       Protocol tag(4) + from(32) + values_len(8)             =  44
+
+     Remaining: 1232 - 44 = 1188
+     Each CrdsValue: signature(64) + CrdsData tag(4) = 68 bytes minimum
+     Max values = floor(1188/68) = 17  */
+
+#define FD_GOSSIP_MESSAGE_MAX_CRDS (17UL)
+
 #define FD_GOSSIP_UPDATE_SZ_CONTACT_INFO        (offsetof(fd_gossip_update_message_t, contact_info)        + sizeof((fd_gossip_update_message_t *)0)->contact_info)
 #define FD_GOSSIP_UPDATE_SZ_CONTACT_INFO_REMOVE (offsetof(fd_gossip_update_message_t, contact_info_remove) + sizeof((fd_gossip_update_message_t *)0)->contact_info_remove)
 #define FD_GOSSIP_UPDATE_SZ_VOTE                (offsetof(fd_gossip_update_message_t, vote)                + sizeof((fd_gossip_update_message_t *)0)->vote)
@@ -299,24 +316,10 @@ struct fd_gossip_pull_request {
 
 typedef struct fd_gossip_pull_request fd_gossip_pull_request_t;
 
-/* Tightest bound for values[] given network constraints.
-
-     IPv6 minimum MTU             = 1280
-     IPv6 header                  =   40
-     UDP header                   =    8
-     PACKET_DATA_SIZE             = 1232   (= 1280 - 40 - 8)
-
-     Minimum bytes consumed before values loop:
-       Protocol tag(4) + from(32) + values_len(8)             =  44
-
-     Remaining: 1232 - 44 = 1188
-     Each CrdsValue: signature(64) + CrdsData tag(4) = 68 bytes minimum
-     Max values = floor(1188/68) = 17  */
-
 struct fd_gossip_pull_response {
   uchar from[ 32UL ];
   ulong values_len;
-  fd_gossip_value_t values[ 17UL ];
+  fd_gossip_value_t values[ FD_GOSSIP_MESSAGE_MAX_CRDS ];
 };
 
 typedef struct fd_gossip_pull_response fd_gossip_pull_response_t;
@@ -324,7 +327,7 @@ typedef struct fd_gossip_pull_response fd_gossip_pull_response_t;
 struct fd_gossip_push {
   uchar from[ 32UL ];
   ulong values_len;
-  fd_gossip_value_t values[ 17UL ];
+  fd_gossip_value_t values[ FD_GOSSIP_MESSAGE_MAX_CRDS ];
 };
 
 typedef struct fd_gossip_push fd_gossip_push_t;

--- a/src/flamenco/gossip/fd_gossip_txbuild.h
+++ b/src/flamenco/gossip/fd_gossip_txbuild.h
@@ -1,7 +1,7 @@
 #ifndef HEADER_fd_src_flamenco_gossip_fd_gossip_txbuild_h
 #define HEADER_fd_src_flamenco_gossip_fd_gossip_txbuild_h
 
-#include "../../util/fd_util_base.h"
+#include "fd_gossip_message.h"
 
 /* fd_gossip_txbuild_t provides a set of APIs to incrementally build a
    push or pull response message from CRDS values.  The caller is
@@ -19,7 +19,7 @@ struct fd_gossip_txbuild {
    ulong tag;
    ulong off;
    ulong sz;
-  } crds[ 17UL ];
+  } crds[ FD_GOSSIP_MESSAGE_MAX_CRDS ];
 };
 
 typedef struct fd_gossip_txbuild fd_gossip_txbuild_t;

--- a/src/util/tmpl/fd_map_chain.c
+++ b/src/util/tmpl/fd_map_chain.c
@@ -639,7 +639,7 @@ MAP_(ele_remove_fast)( MAP_(t) *   join,
                        MAP_ELE_T * pool  );
 #endif
 
-FD_FN_PURE ulong
+ulong
 MAP_(idx_query)( MAP_(t) *         join,
                  MAP_KEY_T const * key,
                  ulong             sentinel,
@@ -792,7 +792,7 @@ MAP_(reset)( MAP_(t) * join ) {
   for( ulong chain_idx=0UL; chain_idx<map->chain_cnt; chain_idx++ ) chain[ chain_idx ] = MAP_(private_box)( MAP_(private_idx_null)() );
 }
 
-FD_FN_PURE MAP_IMPL_STATIC ulong
+MAP_IMPL_STATIC ulong
 MAP_(idx_query)( MAP_(t) *         join,
                  MAP_KEY_T const * key,
                  ulong             sentinel,


### PR DESCRIPTION
The CRDS in Agave stores values for staked nodes for two days.  It's not entirely clear why, but sometimes Agave happens to be storing many CRDS entries for nodes that have no contact info anymore.  The protocol requires us to filter these CRDS out on arrival (we don't know the contact info, and nobody has it to send to us, so we don't know the shred version, and therefore it can't enter the table).

This is a bit of a problem: if we filter all of these out naively, they don't make it into the bloom filter for our pull requests, and so we end up getting these values back repeatedly in a loop (this issue seems to impact Agave although they are not aware).

This change makes it so we "filter" the CRDS out, but also add them to a special structure so they get incorporated into our outgoing bloom filters.  If we do learn of the node later on, we have a fast index where we can remove all of their entries from the "filtered" structure.