### PR TITLE
txncache: fix SHMEM_MAGIC vs MAGIC usage

### DIFF
--- a/src/flamenco/runtime/fd_txncache.h
+++ b/src/flamenco/runtime/fd_txncache.h
@@ -111,8 +111,6 @@
 
 #define FD_TXNCACHE_ALIGN (128UL)
 
-#define FD_TXNCACHE_MAGIC (0xF17EDA2CE5CAC4E0) /* FIREDANCE SCACHE V0 */
-
 struct fd_txncache_private;
 typedef struct fd_txncache_private fd_txncache_t;
 

--- a/src/flamenco/runtime/fd_txncache_private.h
+++ b/src/flamenco/runtime/fd_txncache_private.h
@@ -141,7 +141,7 @@ struct __attribute__((aligned(FD_TXNCACHE_SHMEM_ALIGN))) fd_txncache_shmem_priva
                               most recently added root, the head is the oldest root.  This is used to identify
                               which forks can be pruned when a new root is added. */
 
-  ulong magic; /* ==FD_TXNCACHE_MAGIC */
+  ulong magic; /* ==FD_TXNCACHE_SHMEM_MAGIC */
 };
 
 FD_PROTOTYPES_BEGIN

--- a/src/flamenco/runtime/fd_txncache_shmem.h
+++ b/src/flamenco/runtime/fd_txncache_shmem.h
@@ -5,7 +5,7 @@
 
 #define FD_TXNCACHE_SHMEM_ALIGN (128UL)
 
-#define FD_TXNCACHE_SHMEM_MAGIC (0xF17EDA2CE58CC4E0) /* FIREDANCE SMCCHE V0 */
+#define FD_TXNCACHE_SHMEM_MAGIC (0xF17EDA2CE58CC4E0UL) /* FIREDANCE SMCCHE V0 */
 
 typedef struct { ushort val; } fd_txncache_fork_id_t;
 


### PR DESCRIPTION
Not a bug, just a documentation/naming fix