### PR TITLE
enable PC table map for fuzz targets for additional fuzzing feedback

### DIFF
--- a/config/extra/with-fuzz.mk
+++ b/config/extra/with-fuzz.mk
@@ -4,7 +4,7 @@ FD_HAS_FUZZ:=1
 
 CPPFLAGS+=-fno-omit-frame-pointer
 CPPFLAGS+=-fsanitize=fuzzer-no-link
-CPPFLAGS+=-fsanitize-coverage=inline-8bit-counters
+CPPFLAGS+=-fsanitize-coverage=inline-8bit-counters,pc-table
 
-LDFLAGS+=-fsanitize-coverage=inline-8bit-counters
+LDFLAGS+=-fsanitize-coverage=inline-8bit-counters,pc-table
 LDFLAGS_FUZZ+=-fsanitize=fuzzer


### PR DESCRIPTION
The `pc-table` minimal-overhead instrumentation emits a table mapping coverage counters to program counter (PC) values, improving coverage analysis and feedback quality for honggfuzz.