### PR TITLE
firedancer-dev: vinyl genesis bootstrap

### DIFF
--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -758,6 +758,8 @@ fd_topo_initialize( config_t * config ) {
     fd_topob_tile_uses( topo, accdb_tile, accdb_map_obj,  FD_SHMEM_JOIN_MODE_READ_WRITE );
     fd_topob_tile_uses( topo, accdb_tile, accdb_pool_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
 
+    fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "genesi", 0UL ) ], accdb_data, FD_SHMEM_JOIN_MODE_READ_WRITE );
+
     fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "replay", 0UL ) ], accdb_data, FD_SHMEM_JOIN_MODE_READ_WRITE );
     for( ulong i=0UL; i<execrp_tile_cnt; i++ ) {
       fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "execrp", i ) ], accdb_data, FD_SHMEM_JOIN_MODE_READ_WRITE );
@@ -771,6 +773,7 @@ fd_topo_initialize( config_t * config ) {
       fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "rpc", 0UL ) ], accdb_data, FD_SHMEM_JOIN_MODE_READ_ONLY );
     }
 
+    fd_topob_wksp( topo, "accdb_genesi" );
     fd_topob_wksp( topo, "accdb_replay" );
     fd_topob_wksp( topo, "accdb_execrp" );
     if( leader_enabled ) fd_topob_wksp( topo, "accdb_execle" );
@@ -1384,6 +1387,7 @@ fd_topo_initialize( config_t * config ) {
   fd_pod_insert_int( topo->props, "sandbox", config->development.sandbox ? 1 : 0 );
 
   if( vinyl_enabled ) {
+    fd_topob_vinyl_rq( topo, "genesi", 0UL, "accdb_genesi", "genesi", 4UL, 1024UL, 1024UL );
     fd_topob_vinyl_rq( topo, "replay", 0UL, "accdb_replay", "replay", 4UL, 1024UL, 1024UL );
     for( ulong i=0UL; i<execrp_tile_cnt; i++ ) {
       fd_topob_vinyl_rq( topo, "execrp", i, "accdb_execrp", "execrp", 4UL, 1024UL, 1024UL );

--- a/src/flamenco/accdb/fd_accdb_admin_v2.c
+++ b/src/flamenco/accdb/fd_accdb_admin_v2.c
@@ -197,7 +197,10 @@ fd_accdb_v2_advance_root( fd_accdb_admin_t *        accdb_,
   }
 
   ulong delay = xid->ul[0] - oldest_xid.ul[0];
-  if( delay >= accdb->slot_delay ) {
+  /* genesis_override is necessary when bootstrapping from genesis,
+     without requiring fd_accdb_admin_v2_delay_set to accept 0. */
+  int genesis_override = !xid->ul[0];
+  if( delay >= accdb->slot_delay || genesis_override ) {
     FD_LOG_INFO(( "accdb xid %lu:%lu: pruning",
                   oldest_xid.ul[0], oldest_xid.ul[1] ));
     fd_funk_txn_t * oldest = &funk->txn_pool->ele[ funk->shmem->child_head_cidx ];


### PR DESCRIPTION
Provides vinyl support when booting from genesis in `firedancer-dev`.

Dependent on https://github.com/firedancer-io/firedancer/pull/8300 for `bench` command tests.
Closes https://github.com/firedancer-io/firedancer/issues/7911.