### PR TITLE
net: set multicast TTL to 64 on tx socket in socket mode

### DIFF
--- a/src/disco/net/sock/fd_sock_tile.c
+++ b/src/disco/net/sock/fd_sock_tile.c
@@ -258,6 +258,11 @@ privileged_init( fd_topo_t *      topo,
     FD_LOG_ERR(( "setsockopt(SOL_SOCKET,SO_SNDBUF,%i) failed (%i-%s)", tile->sock.so_sndbuf, errno, fd_io_strerror( errno ) ));
   }
 
+  uchar mcast_ttl = 64;
+  if( FD_UNLIKELY( 0!=setsockopt( tx_sock, IPPROTO_IP, IP_MULTICAST_TTL, &mcast_ttl, sizeof(mcast_ttl) ) ) ) {
+    FD_LOG_ERR(( "setsockopt(IPPROTO_IP,IP_MULTICAST_TTL,%u) failed (%i-%s)", (uint)mcast_ttl, errno, fd_io_strerror( errno ) ));
+  }
+
   ctx->tx_sock      = tx_sock;
   ctx->bind_address = tile->sock.net.bind_address;
 


### PR DESCRIPTION
Linux defaults IP_MULTICAST_TTL to 1, which prevents multicast packets from being routed beyond the local subnet. Since the sock tile strips the IP header and the kernel rebuilds it, the TTL=64 set in fd_ip4_udp_hdr_init has no effect for outgoing packets. Set IP_MULTICAST_TTL on the raw tx socket so that shred packets sent to multicast destinations have a TTL of 64, matching the rest of the codebase.