### PR TITLE
replay, leader pipeline: implement remove_simple_vote_from_cost_model

### DIFF
--- a/src/disco/pack/test_pack.c
+++ b/src/disco/pack/test_pack.c
@@ -1101,14 +1101,16 @@ test_limits( void ) {
       insert( i, pack );
     }
 
-    /* Test that as we gradually increase the CU limit, the correct number of votes get scheduled */
-    for( ulong cu_limit=0UL; cu_limit<45UL*FD_PACK_SIMPLE_VOTE_COST; cu_limit += FD_PACK_SIMPLE_VOTE_COST ) {
-      /* FIXME: CU limit for votes is done based on the typical cost,
-         which is slightly different from the sample vote cost. */
+    /* Test that as we gradually increase the CU limit, the correct number of votes get scheduled.
+       After 33 iterations we start hitting FD_PACK_TEST_MAX_VOTE_COST_PER_BLOCK. */
+    for( ulong cu_limit=0UL; cu_limit<33UL*FD_PACK_SIMPLE_VOTE_COST; cu_limit += FD_PACK_SIMPLE_VOTE_COST ) {
+      /* FIXME: Before remove_simple_vote_from_cost_model, CU limit for
+                votes is done based on the typical cost, which is
+                slightly different from the sample vote cost. */
       schedule_validate_microblock( pack, cu_limit, 1.0f, cu_limit/FD_PACK_SIMPLE_VOTE_COST, 0UL, 0UL, &outcome );
     }
-    /* sum_{x=0}^44 x = 990, so there should be 34 transactions left */
-    FD_TEST( fd_pack_avail_txn_cnt( pack )==34UL );
+    /* sum_{x=0}^32 x = 528, so there should be 496 transactions left */
+    FD_TEST( fd_pack_avail_txn_cnt( pack )==496UL );
   }
 
 

--- a/src/discof/execle/fd_execle_tile.c
+++ b/src/discof/execle/fd_execle_tile.c
@@ -269,11 +269,16 @@ handle_microblock( fd_execle_tile_t *  ctx,
 
     int is_simple_vote = 0;
     if( FD_UNLIKELY( is_simple_vote = fd_txn_is_simple_vote_transaction( TXN(txn), txn->payload ) ) ) {
-      /* Simple votes are charged fixed amounts of compute regardless of
-         the real cost they incur.  Unclear what cost is returned by
-         fd_execute txn, however, so we override it here. */
-      actual_execution_cus = FD_PACK_VOTE_DEFAULT_COMPUTE_UNITS;
-      actual_acct_data_cus = 0U;
+      if( !FD_FEATURE_ACTIVE_BANK( bank, remove_simple_vote_from_cost_model ) ) {
+        /* TODO: remove this once remove_simple_vote_from_cost_model is
+                 activated */
+
+        /* Simple votes are charged fixed amounts of compute regardless of
+           the real cost they incur.  Unclear what cost is returned by
+           fd_execute txn, however, so we override it here. */
+        actual_execution_cus = FD_PACK_VOTE_DEFAULT_COMPUTE_UNITS;
+        actual_acct_data_cus = 0U;
+      }
     }
 
     /* FeesOnly transactions are transactions that failed to load
@@ -432,18 +437,21 @@ handle_bundle( fd_execle_tile_t *  ctx,
         FD_BASE58_ENCODE_64_BYTES( signature, signature_b58 );
         FD_LOG_CRIT(( "transaction %s failed to fit into block despite pack guaranteeing it would "
                       "(res=%d) [block_cost=%lu, vote_cost=%lu, allocated_accounts_data_size=%lu, "
-                      "block_cost_limit=%lu, vote_cost_limit=%lu, account_cost_limit=%lu]",
+                      "block_cost_limit=%lu, vote_cost_limit=%lu, account_cost_limit=%lu, "
+                      "remove_simple_vote_from_cost_model=%i]",
                       signature_b58, err, cost_tracker->block_cost, cost_tracker->vote_cost,
                       cost_tracker->allocated_accounts_data_size,
                       cost_tracker->block_cost_limit, cost_tracker->vote_cost_limit,
-                      cost_tracker->account_cost_limit ));
+                      cost_tracker->account_cost_limit,
+                      cost_tracker->remove_simple_vote_from_cost_model ));
       }
 
       uint actual_execution_cus = (uint)(txn_out->details.compute_budget.compute_unit_limit - txn_out->details.compute_budget.compute_meter);
       uint actual_acct_data_cus = (uint)(txn_out->details.txn_cost.transaction.loaded_accounts_data_size_cost);
-      if( FD_UNLIKELY( fd_txn_is_simple_vote_transaction( TXN( &txns[ i ] ), txns[ i ].payload ) ) ) {
-        actual_execution_cus = FD_PACK_VOTE_DEFAULT_COMPUTE_UNITS;
-        actual_acct_data_cus = 0U;
+      if( FD_UNLIKELY( fd_txn_is_simple_vote_transaction( TXN( &txns[ i ] ), txns[ i ].payload ) &&
+                       !FD_FEATURE_ACTIVE_BANK( bank, remove_simple_vote_from_cost_model ) ) ) {
+          actual_execution_cus = FD_PACK_VOTE_DEFAULT_COMPUTE_UNITS;
+          actual_acct_data_cus = 0U;
       }
 
       uint requested_exec_plus_acct_data_cus  = txns[ i ].pack_cu.requested_exec_plus_acct_data_cus;

--- a/src/discoh/bank/fd_bank_tile.c
+++ b/src/discoh/bank/fd_bank_tile.c
@@ -250,8 +250,19 @@ handle_microblock( fd_bank_ctx_t *     ctx,
     uint actual_execution_cus = consumed_exec_cus[ sanitized_idx-1UL ];
     uint actual_acct_data_cus = consumed_acct_data_cus[ sanitized_idx-1UL ];
 
+    /* FIXME: before remove_simple_vote_from_cost_model is activated
+              we need to change fd_ext_bank_load_and_execute_txns to
+              return the real cost of the transaction and remove
+              this conditional logic.
+
+              The plan is to do this in the next version of
+              Frankendancer as remove_simple_vote_from_cost_model is
+              an Agave 4.0 feature. */
     int is_simple_vote = 0;
     if( FD_UNLIKELY( is_simple_vote = fd_txn_is_simple_vote_transaction( TXN(txn), txn->payload ) ) ) {
+      /* TODO: remove this once remove_simple_vote_from_cost_model is
+               activated */
+
       /* Simple votes are charged fixed amounts of compute regardless of
       the real cost they incur.  fd_ext_bank_load_and_execute_txns
       returns the real cost, however, so we override it here. */
@@ -439,9 +450,19 @@ handle_bundle( fd_bank_ctx_t *     ctx,
     uint requested_exec_plus_acct_data_cus = txn->pack_cu.requested_exec_plus_acct_data_cus;
     uint non_execution_cus                 = txn->pack_cu.non_execution_cus;
 
+    /* TODO: remove this once remove_simple_vote_from_cost_model is
+             activated */
     if( FD_UNLIKELY( fd_txn_is_simple_vote_transaction( TXN(txns + i), txns[ i ].payload ) ) ) {
       /* Although bundles dont typically contain simple votes, we want
         to charge them correctly anyways. */
+      /* FIXME: before remove_simple_vote_from_cost_model is activated
+                we need to change fd_ext_bank_load_and_execute_txns to
+                return the real cost of the transaction and remove
+                this conditional logic.
+
+                The plan is to do this in the next version of
+                Frankendancer as remove_simple_vote_from_cost_model is
+                an Agave 4.0 feature. */
       consumed_cus[ i ] = FD_PACK_VOTE_DEFAULT_COMPUTE_UNITS;
     } else {
       /* Note that some transactions will have 0 consumed cus because

--- a/src/flamenco/features/fd_features_generated.c
+++ b/src/flamenco/features/fd_features_generated.c
@@ -1773,6 +1773,12 @@ fd_feature_id_t const ids[] = {
     .name                      = "relax_programdata_account_check_migration",
     .cleaned_up                = 0 },
 
+  { .index                     = offsetof(fd_features_t, remove_simple_vote_from_cost_model)>>3,
+    .id                        = {"\x12\xc0\xcc\x9e\x1c\x42\x5c\xf5\xc7\xde\x6c\x39\x5e\xc1\xbf\xdc\x21\x5a\x01\x3e\x68\x94\x70\x0e\x15\xa2\x20\x46\x17\x7a\xfb\x7b"},
+                                 /* 2GCrNXbzmt4xrwdcKS2RdsLzsgu4V5zHAemW57pcHT6a */
+    .name                      = "remove_simple_vote_from_cost_model",
+    .cleaned_up                = 0 },
+
   { .index = ULONG_MAX }
 };
 
@@ -2049,6 +2055,7 @@ typedef struct fd_feature_id_lookup_entry fd_feature_id_lookup_entry_t;
 #define MAP_PERFECT_257 0xfc12b1cef363afa7UL, .val = &ids[257]
 #define MAP_PERFECT_258 0x3727b6b01b8a6c1cUL, .val = &ids[258]
 #define MAP_PERFECT_259 0xa5ce8f931961b80cUL, .val = &ids[259]
+#define MAP_PERFECT_260 0xf55c421c9eccc012UL, .val = &ids[260]
 
 #include "../../util/tmpl/fd_map_perfect.c"
 
@@ -2319,4 +2326,5 @@ FD_STATIC_ASSERT( offsetof( fd_features_t, enable_alt_bn128_g2_syscalls         
 FD_STATIC_ASSERT( offsetof( fd_features_t, switch_to_chacha8_turbine                               )>>3==257UL, layout );
 FD_STATIC_ASSERT( offsetof( fd_features_t, bls_pubkey_management_in_vote_account                   )>>3==258UL, layout );
 FD_STATIC_ASSERT( offsetof( fd_features_t, relax_programdata_account_check_migration               )>>3==259UL, layout );
+FD_STATIC_ASSERT( offsetof( fd_features_t, remove_simple_vote_from_cost_model                      )>>3==260UL, layout );
 FD_STATIC_ASSERT( sizeof( fd_features_t )>>3==FD_FEATURE_ID_CNT, layout );

--- a/src/flamenco/features/fd_features_generated.h
+++ b/src/flamenco/features/fd_features_generated.h
@@ -8,10 +8,10 @@
 #endif
 
 /* FEATURE_ID_CNT is the number of features in ids */
-#define FD_FEATURE_ID_CNT (260UL)
+#define FD_FEATURE_ID_CNT (261UL)
 
 /* Feature set ID calculated from all feature names */
-#define FD_FEATURE_SET_ID (187897177U)
+#define FD_FEATURE_SET_ID (720936894U)
 
 union fd_features {
   ulong f[ FD_FEATURE_ID_CNT ];
@@ -276,5 +276,6 @@ union fd_features {
     /* 0xfc12b1cef363afa7 */ ulong switch_to_chacha8_turbine;
     /* 0x3727b6b01b8a6c1c */ ulong bls_pubkey_management_in_vote_account;
     /* 0xa5ce8f931961b80c */ ulong relax_programdata_account_check_migration;
+    /* 0xf55c421c9eccc012 */ ulong remove_simple_vote_from_cost_model;
   };
 };

--- a/src/flamenco/features/feature_map.json
+++ b/src/flamenco/features/feature_map.json
@@ -258,5 +258,6 @@
   {"name":"enable_alt_bn128_g2_syscalls","pubkey":"bn1hKNURMGQaQoEVxahcEAcqiX3NwRs6hgKKNSLeKxH"},
   {"name":"switch_to_chacha8_turbine","pubkey":"CHaChatUnR3s6cPyPMMGNJa3VdQQ8PNH2JqdD4LpCKnB"},
   {"name":"bls_pubkey_management_in_vote_account","pubkey":"2uxQgtKa2ECHGs67Zdj7dgmzn2w9HiqhdcedwCWfYzzq"},
-  {"name":"relax_programdata_account_check_migration","pubkey":"rexav5eNTUSNT1K2N7cfRjnthwhcP5BC25v2tA4rW4h"}
+  {"name":"relax_programdata_account_check_migration","pubkey":"rexav5eNTUSNT1K2N7cfRjnthwhcP5BC25v2tA4rW4h"},
+  {"name":"remove_simple_vote_from_cost_model","pubkey":"2GCrNXbzmt4xrwdcKS2RdsLzsgu4V5zHAemW57pcHT6a"}
 ]

--- a/src/flamenco/runtime/fd_cost_tracker.h
+++ b/src/flamenco/runtime/fd_cost_tracker.h
@@ -21,6 +21,7 @@
 #define FD_MAX_BLOCK_UNITS_SIMD_0256          ( 60000000UL) /* https://github.com/anza-xyz/agave/blob/v2.3.0/cost-model/src/block_cost_limits.rs#L50-L56 */
 #define FD_MAX_BLOCK_UNITS_SIMD_0286          (100000000UL) /* https://github.com/anza-xyz/agave/blob/v3.0.0/cost-model/src/block_cost_limits.rs#L30 */
 #define FD_MAX_VOTE_UNITS                     ( 36000000UL) /* https://github.com/anza-xyz/agave/blob/v2.2.0/cost-model/src/block_cost_limits.rs#L38 */
+#define FD_SIMPLE_VOTE_USAGE_COST             (     3428UL) /* https://github.com/anza-xyz/agave/blob/v3.1.8/cost-model/src/transaction_cost.rs#L21 */
 
 /* https://github.com/anza-xyz/agave/blob/v2.2.0/cost-model/src/cost_tracker.rs#L18-L33 */
 #define FD_COST_TRACKER_SUCCESS                                     (0)
@@ -81,6 +82,7 @@ struct __attribute__((aligned(FD_COST_TRACKER_ALIGN))) fd_cost_tracker {
   ulong account_cost_limit;
 
   int larger_max_cost_per_block;
+  int remove_simple_vote_from_cost_model;
 };
 
 typedef struct fd_cost_tracker fd_cost_tracker_t;


### PR DESCRIPTION
Cost model changes needed for `remove_simple_vote_from_cost_model` and `bls_pubkey_management_in_vote_account`.

As of `remove_simple_vote_from_cost_model`, simple vote transactions no longer have a hardcoded value in the cost model.

As of `bls_pubkey_management_in_vote_account`, the vote program is no longer treated as a builtin in the cost model, and some vote instructions are more expensive (those which perform BLS proof-of-possession verification).

To avoid feature-gating pack code, we increase the estimate for simple vote transactions which pack uses. Once `remove_simple_vote_from_cost_model` has been activated everywhere, we can make the is_simple_vote classifier stricter and use a tighter estimate.