### PR TITLE
restore: fix stake_delegations_len bounds check in manifest parser

### DIFF
--- a/src/discof/restore/utils/fd_ssmanifest_parser.c
+++ b/src/discof/restore/utils/fd_ssmanifest_parser.c
@@ -1422,7 +1422,7 @@ state_validate( fd_ssmanifest_parser_t * parser ) {
       break;
     }
     case STATE_STAKES_STAKE_DELEGATIONS_LENGTH: {
-      if( FD_UNLIKELY( manifest->stake_delegations_len>( 1UL<<22UL ) ) ) { /* 2^21 needed, arbitrarily put 2^22 to have some margin */
+      if( FD_UNLIKELY( manifest->stake_delegations_len>sizeof(manifest->stake_delegations)/sizeof(manifest->stake_delegations[0]) ) ) {
         FD_LOG_WARNING(( "invalid stakes_stake_delegations length %lu", manifest->stake_delegations_len ));
         return -1;
       }


### PR DESCRIPTION
The validation for stake_delegations_len used a hardcoded (1UL<<22UL) (4,194,304) as the upper bound, but the backing array is only FD_RUNTIME_MAX_STAKE_ACCOUNTS (3,000,000) entries. A crafted snapshot with stake_delegations_len between 3,000,001 and 4,194,304 would pass validation and cause out-of-bounds writes into epoch_stakes memory during parsing, followed by a potential validator crash when the downstream stake delegation pool (capacity 3M) is exhausted.

```bash
python3 ~/poc_snapshot_manifest_oob.py > /tmp/crafted_manifest.bin; ./build/native/gcc/unit-test/test_ssmanifest_parser /tmp/crafted_manifest.bin

  Prefix size: 582 bytes
  Delegation entries: 3000001
  Delegation data: 288000096 bytes (274.7 MB)
  Total: 288000678 bytes (274.7 MB)

  FD_RUNTIME_MAX_STAKE_ACCOUNTS = 3000000
  Parser validation bound        = 4194304 (1<<22)
  Entries in payload              = 3000001
  OOB entries                     = 1
  --log-path not specified; using autogenerated path
  Log at "/tmp/fd-0.101.30108_3705245_nick_[host]_2026_02_23_16_59_38_325863414_GMT+00"
  NOTICE  02-23 16:59:38.432246 3705245 f0   0    src/discof/restore/utils/test_ssmanifest_parser.c(55): Parsing 288000678 bytes from /tmp/crafted_manifest.bin
  NOTICE  02-23 16:59:38.826215 3705245 f0   0    src/discof/restore/utils/test_ssmanifest_parser.c(68): fd_ssmanifest_parser decoded 288000678 bytes in 393 ms
  Log at "/tmp/fd-0.101.30108_3705245_nick_[host]_2026_02_23_16_59_38_325863414_GMT+00"
  ```

Use sizeof()/sizeof() against the actual array, matching the pattern already used for vote_accounts_len on the preceding line.