### PR TITLE
Improve genesis handling

### DIFF
--- a/src/app/firedancer-dev/commands/backtest.c
+++ b/src/app/firedancer-dev/commands/backtest.c
@@ -22,6 +22,7 @@
 #include "../../../disco/topo/fd_topob.h"
 #include "../../../disco/topo/fd_topob_vinyl.h"
 #include "../../../util/pod/fd_pod_format.h"
+#include "../../../discof/genesis/fd_genesi_tile.h"
 #include "../../../discof/replay/fd_replay_tile.h"
 #include "../../../discof/restore/fd_snapin_tile_private.h"
 #include "../../../discof/restore/fd_snaplv_tile_private.h"
@@ -330,7 +331,7 @@ backtest_topo( config_t * config ) {
     }
   } else {
     fd_topob_wksp( topo, "genesi_out" );
-    fd_topob_link( topo, "genesi_out", "genesi_out", 2UL, 10UL*1024UL*1024UL+32UL+sizeof(fd_lthash_value_t), 1UL );
+    fd_topob_link( topo, "genesi_out", "genesi_out", 1UL, FD_GENESIS_TILE_MTU, 0UL );
     fd_topob_tile_out( topo, "genesi", 0UL, "genesi_out", 0UL );
     fd_topob_tile_in ( topo, "replay", 0UL, "metric_in", "genesi_out", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
   }

--- a/src/app/firedancer-dev/commands/repair.c
+++ b/src/app/firedancer-dev/commands/repair.c
@@ -161,9 +161,9 @@ repair_topo( config_t * config ) {
 
   /**/                 fd_topob_link( topo, "txsend_out",   "txsend_out",   128UL,                                    FD_TXN_MTU,                    1UL );
 
-  /**/                 fd_topob_link( topo, "snapin_manif", "snapin_manif", 2UL,                                      sizeof(fd_snapshot_manifest_t), 1UL );
+  /**/                 fd_topob_link( topo, "snapin_manif", "snapin_manif", 2UL,                                      sizeof(fd_snapshot_manifest_t),1UL );
 
-  /**/                 fd_topob_link( topo, "genesi_out",  "genesi_out",    2UL,                                        128,     1UL );
+  /**/                 fd_topob_link( topo, "genesi_out",  "genesi_out",    1UL,                                      FD_GENESIS_TILE_MTU,           1UL );
 
   FOR(net_tile_cnt) fd_topos_net_rx_link( topo, "net_repair", i, config->net.ingress_buffer_size );
   FOR(net_tile_cnt) fd_topos_net_rx_link( topo, "net_quic",   i, config->net.ingress_buffer_size );

--- a/src/disco/events/fd_event_client.c
+++ b/src/disco/events/fd_event_client.c
@@ -38,8 +38,8 @@ struct fd_event_client {
   char client_version[ 10UL ];
   uchar identity_pubkey[ 32UL ];
 
-  int has_genesis_hash;
-  uchar genesis_hash[ 32UL ];
+  int       has_genesis_hash;
+  fd_hash_t genesis_hash[1];
 
   ushort has_shred_version;
   ushort shred_version;
@@ -266,9 +266,9 @@ fd_event_client_id_reserve( fd_event_client_t * client ) {
 }
 
 void
-fd_event_client_init_genesis_hash( fd_event_client_t * client,
-                                   uchar const *       genesis_hash ) {
-  fd_memcpy( client->genesis_hash, genesis_hash, 32UL );
+fd_event_client_init_genesis( fd_event_client_t *       client,
+                              fd_genesis_meta_t const * meta ) {
+  *client->genesis_hash = meta->genesis_hash;
   client->has_genesis_hash = 1;
 }
 

--- a/src/disco/events/fd_event_client.h
+++ b/src/disco/events/fd_event_client.h
@@ -3,6 +3,7 @@
 
 #include "fd_circq.h"
 #include "../keyguard/fd_keyguard_client.h"
+#include "../../discof/genesis/fd_genesi_tile.h"
 
 #if FD_HAS_OPENSSL
 #include <openssl/ssl.h>
@@ -63,8 +64,8 @@ ulong
 fd_event_client_id_reserve( fd_event_client_t * client );
 
 void
-fd_event_client_init_genesis_hash( fd_event_client_t * client,
-                                   uchar const *       genesis_hash );
+fd_event_client_init_genesis( fd_event_client_t *       client,
+                              fd_genesis_meta_t const * genesis_meta );
 
 void
 fd_event_client_init_shred_version( fd_event_client_t * client,

--- a/src/disco/events/fd_event_tile.c
+++ b/src/disco/events/fd_event_tile.c
@@ -282,12 +282,8 @@ after_frag( fd_event_tile_t *   ctx,
 
       break;
     case IN_KIND_GENESI: {
-      uchar const * src = fd_chunk_to_laddr( ctx->in[ in_idx ].mem, ctx->chunk );
-      if( FD_LIKELY( sig==GENESI_SIG_BOOTSTRAP_COMPLETED ) ) {
-        fd_event_client_init_genesis_hash( ctx->client, src+sizeof(fd_lthash_value_t) );
-      } else {
-        fd_event_client_init_genesis_hash( ctx->client, src );
-      }
+      fd_genesis_meta_t const * genesis_meta = fd_chunk_to_laddr( ctx->in[ in_idx ].mem, ctx->chunk );
+      fd_event_client_init_genesis( ctx->client, genesis_meta );
       break;
     }
     case IN_KIND_IPECHO:

--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -2427,9 +2427,9 @@ fd_gui_handle_start_progress( fd_gui_t *    gui,
 }
 
 void
-fd_gui_handle_genesis_hash( fd_gui_t *    gui,
-                            uchar const * msg ) {
-  FD_BASE58_ENCODE_32_BYTES(msg, hash_cstr);
+fd_gui_handle_genesis_hash( fd_gui_t *        gui,
+                            fd_hash_t const * msg ) {
+  FD_BASE58_ENCODE_32_BYTES( msg->uc, hash_cstr );
   ulong cluster = fd_genesis_cluster_identify(hash_cstr);
   char const * cluster_name = fd_genesis_cluster_name(cluster);
 
@@ -2964,10 +2964,10 @@ fd_gui_handle_replay_update( fd_gui_t *                gui,
 }
 
 void
-fd_gui_plugin_message( fd_gui_t *    gui,
-                       ulong         plugin_msg,
-                       uchar const * msg,
-                       long          now ) {
+fd_gui_plugin_message( fd_gui_t *   gui,
+                       ulong        plugin_msg,
+                       void const * msg,
+                       long         now ) {
 
   switch( plugin_msg ) {
     case FD_PLUGIN_MSG_SLOT_ROOTED:

--- a/src/disco/gui/fd_gui.h
+++ b/src/disco/gui/fd_gui.h
@@ -822,10 +822,10 @@ fd_gui_ws_message( fd_gui_t *    gui,
                    ulong         data_len );
 
 void
-fd_gui_plugin_message( fd_gui_t *    gui,
-                       ulong         plugin_msg,
-                       uchar const * msg,
-                       long          now );
+fd_gui_plugin_message( fd_gui_t *   gui,
+                       ulong        plugin_msg,
+                       void const * msg,
+                       long         now );
 
 void
 fd_gui_became_leader( fd_gui_t * gui,
@@ -933,8 +933,8 @@ fd_gui_handle_replay_update( fd_gui_t *                gui,
                              long                      now );
 
 void
-fd_gui_handle_genesis_hash( fd_gui_t *    gui,
-                            uchar const * msg );
+fd_gui_handle_genesis_hash( fd_gui_t *        gui,
+                            fd_hash_t const * msg );
 
 static inline ulong
 fd_gui_current_epoch_idx( fd_gui_t * gui ) {

--- a/src/disco/gui/fd_gui_tile.c
+++ b/src/disco/gui/fd_gui_tile.c
@@ -243,7 +243,7 @@ before_frag( fd_gui_ctx_t * ctx,
 static inline void
 during_frag( fd_gui_ctx_t * ctx,
              ulong          in_idx,
-             ulong          seq    FD_PARAM_UNUSED,
+             ulong          seq FD_PARAM_UNUSED,
              ulong          sig,
              ulong          chunk,
              ulong          sz,
@@ -274,7 +274,7 @@ during_frag( fd_gui_ctx_t * ctx,
   }
 
   if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_GENESI_OUT ) ) {
-    if( FD_LIKELY( sig==GENESI_SIG_BOOTSTRAP_COMPLETED ) ) sz = sizeof(fd_lthash_value_t)+sizeof(fd_hash_t);
+    sz = sig;
   }
 
   if( FD_LIKELY( ctx->in_kind[ in_idx ]==IN_KIND_REPLAY_OUT ) ) {
@@ -444,12 +444,8 @@ after_frag( fd_gui_ctx_t *      ctx,
     }
     case IN_KIND_GENESI_OUT: {
       FD_TEST( ctx->is_full_client );
-
-      if( FD_LIKELY( sig==GENESI_SIG_BOOTSTRAP_COMPLETED ) ) {
-        fd_gui_handle_genesis_hash( ctx->gui, src+sizeof(fd_lthash_value_t) );
-      } else {
-        fd_gui_handle_genesis_hash( ctx->gui, src );
-      }
+      fd_genesis_meta_t const * meta = (fd_genesis_meta_t const *)src;
+      fd_gui_handle_genesis_hash( ctx->gui, &meta->genesis_hash );
       break;
     }
     case IN_KIND_TOWER_OUT: {

--- a/src/discof/genesis/fd_genesi_tile.c
+++ b/src/discof/genesis/fd_genesi_tile.c
@@ -50,21 +50,11 @@ bz2_free( void * opaque,
 }
 #endif
 
-struct fd_rpc_out_link {
-  ulong       idx;
-  fd_wksp_t * mem;
-  ulong       chunk0;
-  ulong       wmark;
-  ulong       chunk;
-};
-
-typedef struct fd_rpc_out_link fd_rpc_out_link_t;
-
 struct fd_genesi_tile {
   fd_accdb_admin_t accdb_admin[1];
   fd_accdb_user_t  accdb[1];
 
-  uchar genesis_hash[ 32UL ];
+  fd_hash_t genesis_hash[1];
 
   fd_genesis_client_t * client;
 
@@ -78,20 +68,22 @@ struct fd_genesi_tile {
   uchar expected_genesis_hash[ 32UL ];
   ushort expected_shred_version;
 
-  uchar genesis[ FD_GENESIS_MAX_MESSAGE_SIZE ] __attribute__((aligned(alignof(fd_genesis_t)))); /* 10 MiB buffer for decoded genesis */
-  uchar buffer[ FD_GENESIS_MAX_MESSAGE_SIZE + 5UL*512UL ]; /* 10 MiB buffer for reading genesis file */
-  ulong buffer_sz;
-
   char genesis_path[ PATH_MAX ];
 
   int in_fd;
   int out_fd;
   int out_dir_fd;
 
-  fd_rpc_out_link_t out_genesi;
-  fd_rpc_out_link_t out_rpc;
+  struct {
+    fd_wksp_t * mem;
+    ulong       chunk0;
+  } out;
 
   fd_alloc_t * bz2_alloc;
+
+  fd_genesis_t genesis[1];
+  uchar        genesis_blob[ FD_GENESIS_MAX_MESSAGE_SIZE ];
+  ulong        genesis_blob_sz;
 };
 
 typedef struct fd_genesi_tile fd_genesi_tile_t;
@@ -125,68 +117,69 @@ should_shutdown( fd_genesi_tile_t * ctx ) {
 }
 
 static void
-initialize_accdb( fd_genesi_tile_t * ctx ) {
-  /* Insert accounts at root */
-  fd_genesis_t *    genesis = fd_type_pun( ctx->genesis );
-  fd_accdb_user_t * accdb   = ctx->accdb;
-
+initialize_accdb( fd_accdb_admin_t *   accdb_admin,
+                  fd_accdb_user_t *    accdb,
+                  fd_genesis_t const * genesis,
+                  uchar const *        genesis_blob,
+                  fd_lthash_value_t *  lthash ) {
   fd_funk_txn_xid_t root_xid; fd_funk_txn_xid_set_root( &root_xid );
   fd_funk_txn_xid_t xid = { .ul={ LONG_MAX, LONG_MAX } };
-  fd_accdb_attach_child( ctx->accdb_admin, &root_xid, &xid );
+  fd_accdb_attach_child( accdb_admin, &root_xid, &xid );
 
-  for( ulong i=0UL; i<genesis->accounts_len; i++ ) {
-    fd_genesis_account_t * account = fd_type_pun( (uchar *)genesis + genesis->accounts_off[ i ] );
+  for( ulong i=0UL; i<genesis->account_cnt; i++ ) {
+    fd_genesis_account_t account[1];
+    fd_genesis_account( genesis, genesis_blob, account, i );
 
     fd_accdb_rw_t rw[1];
-    fd_accdb_open_rw( ctx->accdb, rw, &xid, account->pubkey, account->meta.dlen, FD_ACCDB_FLAG_CREATE|FD_ACCDB_FLAG_DONTZERO );
+    fd_accdb_open_rw( accdb, rw, &xid, account->pubkey.key, account->meta.dlen, FD_ACCDB_FLAG_CREATE|FD_ACCDB_FLAG_DONTZERO );
     fd_accdb_ref_owner_set   ( rw, account->meta.owner        );
     fd_accdb_ref_lamports_set( rw, account->meta.lamports     );
     fd_accdb_ref_exec_bit_set( rw, !!account->meta.executable );
     fd_accdb_ref_data_set    ( accdb, rw, account->data, account->meta.dlen );
 
     fd_lthash_value_t new_hash[1];
-    fd_hashes_account_lthash( fd_type_pun( account->pubkey ), rw->meta, account->data, new_hash );
-    fd_lthash_add( ctx->lthash, new_hash );
-    fd_accdb_close_rw( ctx->accdb, rw );
+    fd_hashes_account_lthash( &account->pubkey, rw->meta, account->data, new_hash );
+    fd_lthash_add( lthash, new_hash );
+    fd_accdb_close_rw( accdb, rw );
   }
 
-  fd_accdb_advance_root( ctx->accdb_admin, &xid );
+  fd_accdb_advance_root( accdb_admin, &xid );
 }
 
 static inline void
 verify_cluster_type( fd_genesis_t const * genesis,
-                     uchar const *        genesis_hash,
+                     fd_hash_t const *    genesis_hash,
                      char const *         genesis_path ) {
 
-  uchar mainnet_hash[ 32 ];
-  FD_TEST( fd_base58_decode_32( "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d", mainnet_hash ) );
+  fd_hash_t mainnet_hash[1];
+  FD_TEST( fd_base58_decode_32( "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d", mainnet_hash->uc ) );
 
-  uchar testnet_hash[ 32 ];
-  FD_TEST( fd_base58_decode_32( "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY", testnet_hash ) );
+  fd_hash_t testnet_hash[1];
+  FD_TEST( fd_base58_decode_32( "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY", testnet_hash->uc ) );
 
-  uchar devnet_hash[ 32 ];
-  FD_TEST( fd_base58_decode_32( "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG", devnet_hash ) );
+  fd_hash_t devnet_hash[1];
+  FD_TEST( fd_base58_decode_32( "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG", devnet_hash->uc ) );
 
   switch( genesis->cluster_type ) {
     case FD_GENESIS_TYPE_MAINNET: {
-      if( FD_UNLIKELY( memcmp( genesis_hash, mainnet_hash, 32UL ) ) ) {
-        FD_BASE58_ENCODE_32_BYTES( genesis_hash, genesis_hash_b58 );
+      if( FD_UNLIKELY( !fd_hash_eq( genesis_hash, mainnet_hash ) ) ) {
+        FD_BASE58_ENCODE_32_BYTES( genesis_hash->uc, genesis_hash_b58 );
         FD_LOG_ERR(( "genesis file `%s` has cluster type MAINNET but unexpected genesis hash `%s`",
                      genesis_path, genesis_hash_b58 ));
       }
       break;
     }
     case FD_GENESIS_TYPE_TESTNET: {
-      if( FD_UNLIKELY( memcmp( genesis_hash, testnet_hash, 32UL ) ) ) {
-        FD_BASE58_ENCODE_32_BYTES( genesis_hash, genesis_hash_b58 );
+      if( FD_UNLIKELY( !fd_hash_eq( genesis_hash, testnet_hash ) ) ) {
+        FD_BASE58_ENCODE_32_BYTES( genesis_hash->uc, genesis_hash_b58 );
         FD_LOG_ERR(( "genesis file `%s` has cluster type TESTNET but unexpected genesis hash `%s`",
                      genesis_path, genesis_hash_b58 ));
       }
       break;
     }
     case FD_GENESIS_TYPE_DEVNET: {
-      if( FD_UNLIKELY( memcmp( genesis_hash, devnet_hash, 32UL ) ) ) {
-        FD_BASE58_ENCODE_32_BYTES( genesis_hash, genesis_hash_b58 );
+      if( FD_UNLIKELY( !fd_hash_eq( genesis_hash, devnet_hash ) ) ) {
+        FD_BASE58_ENCODE_32_BYTES( genesis_hash->uc, genesis_hash_b58 );
         FD_LOG_ERR(( "genesis file `%s` has cluster type DEVNET but unexpected genesis hash `%s`",
                      genesis_path, genesis_hash_b58 ));
       }
@@ -209,30 +202,28 @@ after_credit( fd_genesi_tile_t *  ctx,
   if( FD_LIKELY( ctx->local_genesis ) ) {
     FD_TEST( -1!=ctx->in_fd );
 
-    fd_genesis_t * genesis = fd_type_pun( ctx->genesis );
+    ulong msg_sz = sizeof(fd_genesis_meta_t) + ctx->genesis_blob_sz;
+    if( FD_UNLIKELY( msg_sz>FD_GENESIS_TILE_MTU ) ) {
+      FD_LOG_ERR(( "The genesis file `%s` is too large for this Firedancer build (msg_sz=%lu exceeds FD_GENESIS_TILE_MTU=%lu).\n"
+                   "Cannot start Firedancer. Please use a different genesis config or increase FD_GENESIS_TILE_MTU.",
+                   ctx->genesis_path, msg_sz, (ulong)FD_GENESIS_TILE_MTU ));
+    }
 
-    uchar * dst = fd_chunk_to_laddr( ctx->out_genesi.mem, ctx->out_genesi.chunk );
+    fd_genesis_meta_t * dst = fd_chunk_to_laddr( ctx->out.mem, ctx->out.chunk0 );
+    memset( dst, 0, sizeof(fd_genesis_meta_t) );
+    dst->genesis_hash = *ctx->genesis_hash;
+
     if( FD_UNLIKELY( ctx->bootstrap ) ) {
-      fd_memcpy( dst, &ctx->lthash->bytes, sizeof(fd_lthash_value_t) );
-      fd_memcpy( dst+sizeof(fd_lthash_value_t), &ctx->genesis_hash, sizeof(fd_hash_t) );
-      fd_memcpy( dst+sizeof(fd_lthash_value_t)+sizeof(fd_hash_t), ctx->genesis, genesis->total_sz );
-
-      fd_stem_publish( stem, ctx->out_genesi.idx, GENESI_SIG_BOOTSTRAP_COMPLETED, ctx->out_genesi.chunk, 0UL, 0UL, 0UL, 0UL );
-      ctx->out_genesi.chunk = fd_dcache_compact_next( ctx->out_genesi.chunk, genesis->total_sz+sizeof(fd_hash_t)+sizeof(fd_lthash_value_t), ctx->out_genesi.chunk0, ctx->out_genesi.wmark );
-    } else {
-      fd_memcpy( dst, ctx->genesis_hash, sizeof(fd_hash_t) );
-      fd_stem_publish( stem, ctx->out_genesi.idx, GENESI_SIG_GENESIS_HASH, ctx->out_genesi.chunk, sizeof(fd_hash_t), 0UL, 0UL, 0UL );
-      ctx->out_genesi.chunk = fd_dcache_compact_next( ctx->out_genesi.chunk, sizeof(fd_hash_t), ctx->out_genesi.chunk0, ctx->out_genesi.wmark );
+      dst->bootstrap  = 1;
+      dst->has_lthash = 1;
+      dst->lthash     = *ctx->lthash;
     }
 
-    if( FD_LIKELY( ctx->out_rpc.idx!=ULONG_MAX ) ) {
-      uchar * dst = fd_chunk_to_laddr( ctx->out_rpc.mem, ctx->out_rpc.chunk );
-      FD_TEST( ctx->buffer_sz<=FD_GENESIS_MAX_MESSAGE_SIZE );
-      fd_memcpy( dst, ctx->buffer, ctx->buffer_sz );
-      fd_stem_publish( stem, ctx->out_rpc.idx, GENESI_SIG_GENESIS_FILE, ctx->out_rpc.chunk, ctx->buffer_sz, 0UL, 0UL, 0UL );
-      ctx->out_rpc.chunk = fd_dcache_compact_next( ctx->out_rpc.chunk, sizeof(fd_hash_t), ctx->out_rpc.chunk0, ctx->out_rpc.wmark );
-    }
+    uchar * dst_blob = (uchar *)( dst+1 );
+    dst->blob_sz = ctx->genesis_blob_sz;
+    fd_memcpy( dst_blob, ctx->genesis_blob, ctx->genesis_blob_sz );
 
+    fd_stem_publish( stem, 0UL, msg_sz, ctx->out.chunk0, 0UL, 0UL, 0UL, 0UL );
     *charge_busy = 1;
     FD_LOG_NOTICE(( "loaded local genesis.bin from file `%s`", ctx->genesis_path ));
 
@@ -245,7 +236,7 @@ after_credit( fd_genesi_tile_t *  ctx,
     if( FD_UNLIKELY( -1==result ) ) FD_LOG_ERR(( "failed to retrieve genesis.bin from any configured gossip entrypoints" ));
     if( FD_LIKELY( 1==result ) ) return;
 
-    uchar * decompressed = ctx->buffer;
+    uchar * decompressed = ctx->genesis_blob;
     ulong   actual_decompressed_sz = 0UL;
 #   if FD_HAS_BZIP2
     bz_stream bzstrm = {0};
@@ -278,18 +269,12 @@ after_credit( fd_genesi_tile_t *  ctx,
 
     fd_tar_meta_t const * meta = (fd_tar_meta_t const *)decompressed;
     FD_TEST( !strcmp( meta->name, "genesis.bin" ) );
-    FD_TEST( actual_decompressed_sz>=512UL+fd_tar_meta_get_size( meta ) );
+    uchar const * blob    = decompressed+512UL;
+    ulong         blob_sz = fd_tar_meta_get_size( meta );
+    FD_TEST( actual_decompressed_sz>=512UL+blob_sz );
 
-    if( FD_LIKELY( ctx->out_rpc.idx!=ULONG_MAX ) ) {
-      uchar * dst = fd_chunk_to_laddr( ctx->out_rpc.mem, ctx->out_rpc.chunk );
-      FD_TEST( actual_decompressed_sz<=FD_GENESIS_MAX_MESSAGE_SIZE );
-      fd_memcpy( dst, decompressed, actual_decompressed_sz );
-      fd_stem_publish( stem, ctx->out_rpc.idx, GENESI_SIG_GENESIS_FILE, ctx->out_rpc.chunk, actual_decompressed_sz, 0UL, 0UL, 0UL );
-      ctx->out_rpc.chunk = fd_dcache_compact_next( ctx->out_rpc.chunk, sizeof(fd_hash_t), ctx->out_rpc.chunk0, ctx->out_rpc.wmark );
-    }
-
-    uchar hash[ 32UL ];
-    fd_sha256_hash( decompressed+512UL, fd_tar_meta_get_size( meta ), hash );
+    fd_hash_t hash[1];
+    fd_sha256_hash( blob, blob_sz, hash->uc );
 
     /* Can't verify expected_shred_version here because it needs to be
        mixed in with hard_forks from the snapshot.  Replay tile will
@@ -297,30 +282,41 @@ after_credit( fd_genesi_tile_t *  ctx,
 
     if( FD_LIKELY( ctx->has_expected_genesis_hash && memcmp( hash, ctx->expected_genesis_hash, 32UL ) ) ) {
       FD_BASE58_ENCODE_32_BYTES( ctx->expected_genesis_hash, expected_genesis_hash_b58 );
-      FD_BASE58_ENCODE_32_BYTES( hash, hash_b58 );
+      FD_BASE58_ENCODE_32_BYTES( hash->uc, hash_b58 );
       FD_LOG_ERR(( "An expected genesis hash of `%s` has been set in your configuration file at [consensus.expected_genesis_hash] "
                    "but the genesis hash derived from the peer at `http://" FD_IP4_ADDR_FMT ":%hu` has unexpected hash `%s`",
                    expected_genesis_hash_b58, FD_IP4_ADDR_FMT_ARGS( peer.addr ), fd_ushort_bswap( peer.port ), hash_b58 ));
     }
 
     FD_TEST( !ctx->bootstrap );
-    ulong size = fd_tar_meta_get_size( meta );
 
-    fd_genesis_t * genesis = fd_genesis_parse( ctx->genesis, decompressed+512UL, size );
+    fd_genesis_t * genesis = fd_genesis_parse( ctx->genesis, blob, blob_sz );
     if( FD_UNLIKELY( !genesis ) ) {
       FD_LOG_ERR(( "unable to decode downloaded solana genesis file due to violated hardcoded limits" ));
     }
 
     verify_cluster_type( genesis, hash, ctx->genesis_path );
 
-    uchar * dst = fd_chunk_to_laddr( ctx->out_genesi.mem, ctx->out_genesi.chunk );
-    fd_memcpy( dst, hash, sizeof(fd_hash_t) );
-    fd_stem_publish( stem, ctx->out_genesi.idx, GENESI_SIG_GENESIS_HASH, ctx->out_genesi.chunk, 32UL, 0UL, 0UL, 0UL );
-    ctx->out_genesi.chunk = fd_dcache_compact_next( ctx->out_genesi.chunk, sizeof(fd_hash_t), ctx->out_genesi.chunk0, ctx->out_genesi.wmark );
+    ulong msg_sz; FD_TEST( !__builtin_uaddl_overflow( sizeof(fd_genesis_meta_t), blob_sz, &msg_sz ) );
+    if( FD_UNLIKELY( msg_sz>FD_GENESIS_TILE_MTU ) ) {
+      FD_LOG_ERR(( "The genesis blob downloaded from peer at `http://" FD_IP4_ADDR_FMT ":%hu` is too large for this Firedancer build (msg_sz=%lu exceeds FD_GENESIS_TILE_MTU=%lu).\n"
+                   "Cannot start Firedancer. Please use a different genesis config or increase FD_GENESIS_TILE_MTU.",
+                   FD_IP4_ADDR_FMT_ARGS( peer.addr ), fd_ushort_bswap( peer.port ), msg_sz, (ulong)FD_GENESIS_TILE_MTU ));
+    }
+
+    fd_genesis_meta_t * dst = fd_chunk_to_laddr( ctx->out.mem, ctx->out.chunk0 );
+    memset( dst, 0, sizeof(fd_genesis_meta_t) );
+    dst->genesis_hash = *hash;
+
+    uchar * dst_blob = (uchar *)( dst+1 );
+    dst->blob_sz = blob_sz;
+    fd_memcpy( dst_blob, blob, blob_sz );
+
+    fd_stem_publish( stem, 0UL, msg_sz, ctx->out.chunk0, 0UL, 0UL, 0UL, 0UL );
 
     ulong bytes_written = 0UL;
-    while( bytes_written<fd_tar_meta_get_size( meta ) ) {
-      long result = write( ctx->out_fd, decompressed+512UL+bytes_written, fd_tar_meta_get_size( meta )-bytes_written );
+    while( bytes_written<blob_sz ) {
+      long result = write( ctx->out_fd, blob+bytes_written, blob_sz-bytes_written );
       if( FD_UNLIKELY( -1==result ) ) FD_LOG_ERR(( "write() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
       bytes_written += (ulong)result;
     }
@@ -346,45 +342,32 @@ after_credit( fd_genesi_tile_t *  ctx,
 static void
 process_local_genesis( fd_genesi_tile_t * ctx,
                        char const *       genesis_path ) {
-  struct stat st;
-  int err = fstat( ctx->in_fd, &st );
-  if( FD_UNLIKELY( -1==err ) ) FD_LOG_ERR(( "stat() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
-
-  ulong size = (ulong)st.st_size;
-
-  if( FD_UNLIKELY( size>sizeof(ctx->buffer) ) ) FD_LOG_ERR(( "genesis file `%s` too large (%lu bytes, max %lu)", genesis_path, size, (ulong)sizeof(ctx->buffer) ));
-
-  ulong bytes_read = 0UL;
-  while( bytes_read<size ) {
-    long result = read( ctx->in_fd, ctx->buffer+bytes_read, size-bytes_read );
+  ctx->genesis_blob_sz = 0UL;
+  for(;;) {
+    if( FD_UNLIKELY( ctx->genesis_blob_sz>=FD_GENESIS_MAX_MESSAGE_SIZE ) ) {
+      FD_LOG_ERR(( "The genesis file at `%s` is too large for this Firedancer build.\n"
+                   "Cannot start Firedancer. Please use a different genesis config or increase FD_GENESIS_MAX_MESSAGE_SIZE.",
+                   genesis_path ));
+    }
+    long result = read( ctx->in_fd, ctx->genesis_blob+ctx->genesis_blob_sz, FD_GENESIS_MAX_MESSAGE_SIZE-ctx->genesis_blob_sz );
     if( FD_UNLIKELY( -1==result ) ) FD_LOG_ERR(( "read() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
-    if( FD_UNLIKELY( !result ) )  FD_LOG_ERR(( "read() returned 0 before reading full file" ));
-    bytes_read += (ulong)result;
+    if( FD_UNLIKELY( !result ) ) break;
+    ctx->genesis_blob_sz += (ulong)result;
   }
-
-  FD_TEST( bytes_read==size );
-  ctx->buffer_sz = bytes_read;
 
   if( FD_UNLIKELY( -1==close( ctx->in_fd ) ) ) FD_LOG_ERR(( "close() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
 
-  fd_genesis_t * genesis = fd_genesis_parse( ctx->genesis, ctx->buffer, size );
+  fd_genesis_t * genesis = fd_genesis_parse( ctx->genesis, ctx->genesis_blob, ctx->genesis_blob_sz );
   if( FD_UNLIKELY( !genesis ) ) {
     FD_LOG_ERR(( "unable to decode solana genesis from local file due to violated hardcoded limits" ));
   }
 
-  union {
-    uchar  c[ 32 ];
-    ushort s[ 16 ];
-  } hash;
-  fd_sha256_hash( ctx->buffer, size, hash.c );
-
-  verify_cluster_type( genesis, hash.c, genesis_path );
-
-  fd_memcpy( ctx->genesis_hash, hash.c, 32UL );
+  fd_sha256_hash( ctx->genesis_blob, ctx->genesis_blob_sz, ctx->genesis_hash );
+  verify_cluster_type( genesis, ctx->genesis_hash, genesis_path );
 
   if( FD_UNLIKELY( ctx->bootstrap && ctx->expected_shred_version ) ) {
     ushort xor = 0;
-    for( ulong i=0UL; i<16UL; i++ ) xor ^= hash.s[ i ];
+    for( ulong i=0UL; i<16UL; i++ ) xor ^= ctx->genesis_hash->us[ i ];
 
     xor = fd_ushort_bswap( xor );
     xor = fd_ushort_if( xor<USHORT_MAX, (ushort)(xor + 1), USHORT_MAX );
@@ -401,7 +384,7 @@ process_local_genesis( fd_genesi_tile_t * ctx,
 
   if( FD_LIKELY( ctx->has_expected_genesis_hash && memcmp( ctx->genesis_hash, ctx->expected_genesis_hash, 32UL ) ) ) {
     FD_BASE58_ENCODE_32_BYTES( ctx->expected_genesis_hash, expected_genesis_hash_b58 );
-    FD_BASE58_ENCODE_32_BYTES( ctx->genesis_hash,          genesis_hash_b58          );
+    FD_BASE58_ENCODE_32_BYTES( ctx->genesis_hash->uc,      genesis_hash_b58          );
     FD_LOG_ERR(( "An expected genesis hash of `%s` has been set in your configuration file at [consensus.expected_genesis_hash] "
                  "but the genesis hash derived from the genesis file at `%s` has unexpected hash `%s`", expected_genesis_hash_b58, genesis_path, genesis_hash_b58 ));
   }
@@ -469,29 +452,6 @@ privileged_init( fd_topo_t *      topo,
   }
 }
 
-static inline fd_rpc_out_link_t
-out1( fd_topo_t const *      topo,
-      fd_topo_tile_t const * tile,
-      char const *           name ) {
-  ulong idx = ULONG_MAX;
-
-  for( ulong i=0UL; i<tile->out_cnt; i++ ) {
-    fd_topo_link_t const * link = &topo->links[ tile->out_link_id[ i ] ];
-    if( !strcmp( link->name, name ) ) {
-      if( FD_UNLIKELY( idx!=ULONG_MAX ) ) FD_LOG_ERR(( "tile %s:%lu had multiple output links named %s but expected one", tile->name, tile->kind_id, name ));
-      idx = i;
-    }
-  }
-
-  if( FD_UNLIKELY( idx==ULONG_MAX ) ) return (fd_rpc_out_link_t){ .idx = ULONG_MAX, .mem = NULL, .chunk0 = 0, .wmark = 0, .chunk = 0 };
-
-  void * mem = topo->workspaces[ topo->objs[ topo->links[ tile->out_link_id[ idx ] ].dcache_obj_id ].wksp_id ].wksp;
-  ulong chunk0 = fd_dcache_compact_chunk0( mem, topo->links[ tile->out_link_id[ idx ] ].dcache );
-  ulong wmark  = fd_dcache_compact_wmark ( mem, topo->links[ tile->out_link_id[ idx ] ].dcache, topo->links[ tile->out_link_id[ idx ] ].mtu );
-
-  return (fd_rpc_out_link_t){ .idx = idx, .mem = mem, .chunk0 = chunk0, .wmark = wmark, .chunk = chunk0 };
-}
-
 static void
 unprivileged_init( fd_topo_t *      topo,
                    fd_topo_tile_t * tile ) {
@@ -516,13 +476,19 @@ unprivileged_init( fd_topo_t *      topo,
   fd_memcpy( ctx->expected_genesis_hash, tile->genesi.expected_genesis_hash, 32UL );
   if( FD_LIKELY( -1!=ctx->in_fd ) ) {
     process_local_genesis( ctx, tile->genesi.genesis_path );
-    if( FD_UNLIKELY( ctx->bootstrap ) ) initialize_accdb( ctx );
+    if( FD_UNLIKELY( ctx->bootstrap ) ) {
+      initialize_accdb( ctx->accdb_admin, ctx->accdb, ctx->genesis, ctx->genesis_blob, ctx->lthash );
+    }
   }
 
   FD_TEST( fd_cstr_printf_check( ctx->genesis_path, PATH_MAX, NULL, "%s", tile->genesi.genesis_path ) );
 
-  ctx->out_genesi = out1( topo, tile, "genesi_out" );
-  ctx->out_rpc    = out1( topo, tile, "genesi_rpc" );
+  FD_TEST( tile->out_cnt==1UL );
+  fd_topo_link_t const * out_link = &topo->links[ tile->out_link_id[ 0 ] ];
+  FD_TEST( out_link->depth==1UL );  /* buffer holds a single message (dcache not a ring buffer) */
+  FD_TEST( out_link->mtu>=FD_GENESIS_TILE_MTU );
+  ctx->out.mem    = fd_wksp_containing( out_link->dcache );
+  ctx->out.chunk0 = fd_dcache_compact_chunk0( ctx->out.mem, out_link->dcache );
 
   ctx->bz2_alloc = fd_alloc_join( fd_alloc_new( _alloc, 1UL ), 1UL );
   FD_TEST( ctx->bz2_alloc );
@@ -610,6 +576,7 @@ populate_allowed_fds( fd_topo_t const *      topo,
 
 #define STEM_CALLBACK_AFTER_CREDIT    after_credit
 #define STEM_CALLBACK_SHOULD_SHUTDOWN should_shutdown
+#define STEM_LAZY                     ((long)1e5) /* 0.1ms */
 
 #include "../../disco/stem/fd_stem.c"
 

--- a/src/discof/genesis/fd_genesi_tile.h
+++ b/src/discof/genesis/fd_genesi_tile.h
@@ -1,8 +1,27 @@
 #ifndef HEADER_fd_src_discof_genesis_fd_genesi_tile_h
 #define HEADER_fd_src_discof_genesis_fd_genesi_tile_h
 
-#define GENESI_SIG_GENESIS_HASH        (0) /* This is not a bootstrapping node, just publishing learned genesis hash*/
-#define GENESI_SIG_BOOTSTRAP_COMPLETED (1) /* This node is bootstrapping the chain, publish genesis hash along with genesis info */
-#define GENESI_SIG_GENESIS_FILE        (2) /* This frag contains the contents of the compressed genesis archive. Used by RPC to serve to clients. */
+/* The genesis tile publishes a single message type:
+
+   A 'fd_genesis_meta_t' struct, followed by a Bincode-encoded genesis
+   blob. */
+
+#include "../../ballet/lthash/fd_lthash.h"
+#include "../../flamenco/runtime/fd_genesis_parse.h"
+
+#define FD_GENESIS_TILE_MTU (sizeof(fd_genesis_meta_t) + FD_GENESIS_MAX_MESSAGE_SIZE)
+
+struct fd_genesis_meta {
+  ulong bootstrap  : 1;
+  ulong has_lthash : 1;
+
+  fd_hash_t         genesis_hash;
+  fd_lthash_value_t lthash;
+
+  ulong blob_sz;
+  /* uchar[ blob_sz ] follows immediately after this struct */
+};
+
+typedef struct fd_genesis_meta fd_genesis_meta_t;
 
 #endif /* HEADER_fd_src_discof_genesis_fd_genesi_tile_h */

--- a/src/discof/ipecho/fd_ipecho_tile.c
+++ b/src/discof/ipecho/fd_ipecho_tile.c
@@ -111,20 +111,12 @@ returnable_frag( fd_ipecho_tile_ctx_t * ctx,
                  ulong                  tsorig,
                  ulong                  tspub,
                  fd_stem_context_t *    stem ) {
-  (void)in_idx; (void)seq; (void)sig; (void)chunk; (void)sz; (void)ctl; (void)tsorig; (void)tspub;
+  (void)in_idx; (void)seq; (void)sig; (void)sz; (void)ctl; (void)tspub;
+  fd_genesis_meta_t const * genesis_meta = fd_chunk_to_laddr( ctx->genesi_in_mem, chunk );
 
-  if( FD_UNLIKELY( sig==GENESI_SIG_BOOTSTRAP_COMPLETED ) ) {
-    uchar const * src = fd_chunk_to_laddr_const( ctx->genesi_in_mem, chunk );
-
-    union {
-      uchar  c[ 32 ];
-      ushort s[ 16 ];
-    } hash;
-
-    fd_memcpy( hash.c, src+sizeof(fd_lthash_value_t), sizeof(fd_hash_t) );
-
+  if( genesis_meta->bootstrap ) {
     ushort xor = 0;
-    for( ulong i=0UL; i<16UL; i++ ) xor ^= hash.s[ i ];
+    for( ulong i=0UL; i<16UL; i++ ) xor ^= genesis_meta->genesis_hash.us[ i ];
 
     xor = fd_ushort_bswap( xor );
     xor = fd_ushort_if( xor<USHORT_MAX, (ushort)(xor + 1), USHORT_MAX );

--- a/src/flamenco/runtime/fd_genesis_parse.c
+++ b/src/flamenco/runtime/fd_genesis_parse.c
@@ -2,152 +2,159 @@
 #include "fd_runtime_const.h"
 #include "../../util/bits/fd_bits.h"
 
-/* Adapted from fd_txn_parse.c */
-#define CHECK_INIT( payload, payload_sz, offset )   \
-  uchar const * _payload        = (payload);        \
-  ulong const   _payload_sz     = (payload_sz);     \
-  ulong const   _offset         = (offset);         \
-  ulong         _i              = (offset);         \
-  (void)        _payload;                           \
-  (void)        _offset;                            \
-
-#define CHECK( cond ) do {              \
-  if( FD_UNLIKELY( !(cond) ) ) {        \
-    return 0;                           \
-  }                                     \
-} while( 0 )
-
-#define CHECK_LEFT( n ) CHECK( (n)<=(_payload_sz-_i) )
-
-#define INC( n )   (_i += (ulong)(n))
-#define CUR_OFFSET ((ushort)_i)
-#define CURSOR     (_payload+_i)
-
-
 fd_genesis_t *
-fd_genesis_parse( void *        genesis_mem,
-                  uchar const * bin,
-                  ulong         bin_sz ) {
-  FD_SCRATCH_ALLOC_INIT( l, genesis_mem );
-  fd_genesis_t * genesis = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_genesis_t), sizeof(fd_genesis_t) );
+fd_genesis_parse( fd_genesis_t * genesis,
+                  uchar const *  bin,
+                  ulong          bin_sz ) {
+  /* Zero out top part of descriptor which is sufficient to fully
+     initialize fd_genesis_t (assuming no struct reordering). */
+  memset( genesis, 0, offsetof(fd_genesis_t, builtin) );
 
-  CHECK_INIT( bin, bin_sz, 0U );
+  uchar const * _payload    = bin;
+  ulong const   _payload_sz = bin_sz;
+  ulong         _i          = 0UL;
 
-  CHECK_LEFT( 8U ); genesis->creation_time = FD_LOAD( ulong, CURSOR ); INC( 8U );
+# define CHECK( cond )   { if( FD_UNLIKELY( !(cond) ) ) { return NULL; } }
+# define CHECK_LEFT( n ) CHECK( (n)<=(_payload_sz-_i) )
+# define INC( n )        (_i += (ulong)(n))
+# define CUR_OFFSET      ((ushort)_i)
+# define CURSOR          (_payload+_i)
 
-  CHECK_LEFT( 8U ); genesis->accounts_len  = FD_LOAD( ulong, CURSOR ); INC( 8U );
-  if( FD_UNLIKELY( genesis->accounts_len>FD_GENESIS_ACCOUNT_MAX_COUNT ) ) {
-    FD_LOG_WARNING(( "genesis accounts length %lu exceeds supported max count %lu", genesis->accounts_len, FD_GENESIS_ACCOUNT_MAX_COUNT ));
+  CHECK_LEFT( 8UL ); genesis->creation_time = FD_LOAD( ulong, CURSOR ); INC( 8UL );
+
+  CHECK_LEFT( 8UL ); genesis->account_cnt = FD_LOAD( ulong, CURSOR ); INC( 8UL );
+  if( FD_UNLIKELY( genesis->account_cnt>FD_GENESIS_ACCOUNT_MAX_COUNT ) ) {
+    FD_LOG_WARNING(( "genesis account count %lu exceeds max %lu (increase FD_GENESIS_ACCOUNT_MAX_COUNT?)", genesis->account_cnt, FD_GENESIS_ACCOUNT_MAX_COUNT ));
     return NULL;
   }
-  for( ulong i=0UL; i<genesis->accounts_len; i++ ) {
-    fd_genesis_account_t * account = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_genesis_account_t), sizeof(fd_genesis_account_t) );
-    genesis->accounts_off[ i ] = (uint)((ulong)account-(ulong)genesis);
-    if( FD_UNLIKELY( genesis->accounts_off[ i ] + sizeof(fd_genesis_account_t) > FD_GENESIS_MAX_MESSAGE_SIZE ) ) {
-      FD_LOG_WARNING(( "genesis accounts offset %u exceeds supported max size %lu", genesis->accounts_off[ i ], FD_GENESIS_MAX_MESSAGE_SIZE ));
+  for( ulong i=0UL; i<genesis->account_cnt; i++ ) {
+    fd_genesis_account_off_t * account = &genesis->account[ i ];
+
+    account->pubkey_off = _i;
+    CHECK_LEFT( 32UL );                                            INC( 32UL ); /* pubkey */
+    CHECK_LEFT(  8UL );                                            INC(  8UL ); /* lamports */
+    CHECK_LEFT(  8UL ); ulong data_len = FD_LOAD( ulong, CURSOR ); INC(  8UL );
+    if( FD_UNLIKELY( data_len>FD_RUNTIME_ACC_SZ_MAX ) ) {
+      FD_LOG_WARNING(( "genesis builtin account data length %lu exceeds max size %lu", data_len, FD_RUNTIME_ACC_SZ_MAX ));
       return NULL;
     }
-    CHECK_LEFT( 32U ); fd_memcpy( account->pubkey, CURSOR, 32U );           INC( 32U );
-    CHECK_LEFT( 8U );  account->meta.lamports = FD_LOAD( ulong, CURSOR );   INC( 8U );
-    CHECK_LEFT( 8U );  account->meta.dlen = (uint)FD_LOAD( ulong, CURSOR ); INC( 8U );
-    if( FD_UNLIKELY( account->meta.dlen>FD_RUNTIME_ACC_SZ_MAX ) ) {
-      FD_LOG_WARNING(( "genesis builtin account data length %u exceeds supported max size %lu", account->meta.dlen, FD_RUNTIME_ACC_SZ_MAX ));
-      return NULL;
-    }
-    if( FD_UNLIKELY( genesis->accounts_off[ i ] + sizeof(fd_genesis_account_t) + account->meta.dlen > FD_GENESIS_MAX_MESSAGE_SIZE ) ) {
-      FD_LOG_WARNING(( "genesis builtin account data length %lu exceeds supported max size %lu", genesis->accounts_off[ i ] + sizeof(fd_genesis_account_t) + account->meta.dlen, FD_GENESIS_MAX_MESSAGE_SIZE ));
-      return NULL;
-    }
-    CHECK_LEFT( account->meta.dlen );
-    uchar * data = FD_SCRATCH_ALLOC_APPEND( l, alignof(uchar), account->meta.dlen );
-    fd_memcpy( data, CURSOR, account->meta.dlen );                          INC( account->meta.dlen );
-    CHECK_LEFT( 32U ); fd_memcpy( account->meta.owner, CURSOR, 32U );       INC( 32U );
-    CHECK_LEFT( 1U );  account->meta.executable = FD_LOAD( uchar, CURSOR ); INC( 1U );
-    CHECK_LEFT( 8U );                                                       INC( 8U ); /* don't care about rent epoch */
+    CHECK_LEFT( data_len ); INC( data_len ); /* data */
+
+    account->owner_off = _i;
+    CHECK_LEFT( 32UL ); INC( 32UL ); /* owner */
+    CHECK_LEFT(  1UL ); INC(  1UL ); /* executable */
+    CHECK_LEFT(  8UL ); INC(  8UL ); /* rent epoch */
   }
 
-  CHECK_LEFT( 8U ); genesis->builtin_len  = FD_LOAD( ulong, CURSOR ); INC( 8U );
-  if( FD_UNLIKELY( genesis->builtin_len>FD_GENESIS_BUILTIN_MAX_COUNT ) ) {
-    FD_LOG_WARNING(( "genesis builtin length %lu exceeds supported max count %lu", genesis->builtin_len, FD_GENESIS_BUILTIN_MAX_COUNT ));
+  CHECK_LEFT( 8UL ); genesis->builtin_cnt = FD_LOAD( ulong, CURSOR ); INC( 8UL );
+  if( FD_UNLIKELY( genesis->builtin_cnt>FD_GENESIS_BUILTIN_MAX_COUNT ) ) {
+    FD_LOG_WARNING(( "genesis builtin count %lu exceeds max %lu", genesis->builtin_cnt, FD_GENESIS_BUILTIN_MAX_COUNT ));
     return NULL;
   }
-  for( ulong i=0UL; i<genesis->builtin_len; i++ ) {
-    /* The built in accounts are laid out with the data first followed
-       by the pubkey. */
-    fd_genesis_builtin_t * account = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_genesis_builtin_t), sizeof(fd_genesis_builtin_t) );
-    genesis->builtin_off[ i ] = (uint)((ulong)account-(ulong)genesis);
-    if( FD_UNLIKELY( genesis->builtin_off[ i ] + sizeof(fd_genesis_builtin_t) > FD_GENESIS_MAX_MESSAGE_SIZE ) ) {
-      FD_LOG_WARNING(( "genesis builtin offset %lu exceeds supported max size %lu", genesis->builtin_off[ i ] + sizeof(fd_genesis_builtin_t), FD_GENESIS_MAX_MESSAGE_SIZE ));
-      return NULL;
-    }
-    CHECK_LEFT( 8U );  account->data_len = FD_LOAD( ulong, CURSOR ); INC( 8U );
-    if( FD_UNLIKELY( account->data_len>FD_RUNTIME_ACC_SZ_MAX ) ) {
-      FD_LOG_WARNING(( "genesis builtin account data length %lu exceeds supported max size %lu", account->data_len, FD_RUNTIME_ACC_SZ_MAX ));
-      return NULL;
-    }
-    if( FD_UNLIKELY( genesis->builtin_off[ i ] + sizeof(fd_genesis_builtin_t) + account->data_len > FD_GENESIS_MAX_MESSAGE_SIZE ) ) {
-      FD_LOG_WARNING(( "genesis builtin account data length %lu exceeds supported max size %lu", genesis->builtin_off[ i ] + sizeof(fd_genesis_builtin_t) + account->data_len, FD_GENESIS_MAX_MESSAGE_SIZE ));
-      return NULL;
-    }
-    CHECK_LEFT( account->data_len );
-    uchar * data = FD_SCRATCH_ALLOC_APPEND( l, alignof(uchar), account->data_len );
-    fd_memcpy( data, CURSOR, account->data_len ); INC( account->data_len );
+  for( ulong i=0UL; i<genesis->builtin_cnt; i++ ) {
+    fd_genesis_builtin_off_t * account = &genesis->builtin[ i ];
 
-    CHECK_LEFT( 32U ); fd_memcpy( account->pubkey, CURSOR, 32U ); INC( 32U );
+    account->data_len_off = _i;
+    CHECK_LEFT( 8UL ); ulong data_len = FD_LOAD( ulong, CURSOR ); INC( 8UL );
+    if( FD_UNLIKELY( data_len>FD_RUNTIME_ACC_SZ_MAX ) ) {
+      FD_LOG_WARNING(( "genesis builtin account data length %lu exceeds supported max size %lu", data_len, FD_RUNTIME_ACC_SZ_MAX ));
+      return NULL;
+    }
+    CHECK_LEFT( data_len ); INC( data_len ); /* data */
+
+    account->pubkey_off = _i;
+    CHECK_LEFT( 32UL ); INC( 32UL ); /* pubkey */
   }
 
-  genesis->total_sz = (ulong)(FD_SCRATCH_ALLOC_FINI( l, alignof(fd_genesis_t) )) - (ulong)genesis_mem;
-
-  CHECK_LEFT( 8U ); ulong rewards_len = FD_LOAD( ulong, CURSOR ); INC( 8U );
+  CHECK_LEFT( 8UL ); ulong rewards_len = FD_LOAD( ulong, CURSOR ); INC( 8UL );
   for( ulong i=0UL; i<rewards_len; i++ ) {
-    CHECK_LEFT( 32U );                                       INC( 32U ); /* pubkey */
-    CHECK_LEFT( 8U );                                        INC( 8U ); /* lamports */
-    CHECK_LEFT( 8U ); ulong dlen = FD_LOAD( ulong, CURSOR ); INC( 8U ); /* dlen */
-    CHECK_LEFT( dlen );                                      INC( dlen ); /* data */
-    CHECK_LEFT( 32U );                                       INC( 32U ); /* owner */
-    CHECK_LEFT( 1U );                                        INC( 1U ); /* executable */
-    CHECK_LEFT( 8U );                                        INC( 8U ); /* rent epoch */
+    CHECK_LEFT( 32UL );                                        INC( 32UL ); /* pubkey */
+    CHECK_LEFT(  8UL );                                        INC(  8UL ); /* lamports */
+    CHECK_LEFT(  8UL ); ulong dlen = FD_LOAD( ulong, CURSOR ); INC(  8UL ); /* dlen */
+    CHECK_LEFT( dlen );                                        INC( dlen ); /* data */
+    CHECK_LEFT( 32UL );                                        INC( 32UL ); /* owner */
+    CHECK_LEFT(  1UL );                                        INC(  1UL ); /* executable */
+    CHECK_LEFT(  8UL );                                        INC(  8UL ); /* rent epoch */
   }
 
-  CHECK_LEFT( 8U ); genesis->poh.ticks_per_slot = FD_LOAD( ulong, CURSOR ); INC( 8U );
+  CHECK_LEFT( 8UL ); genesis->poh.ticks_per_slot = FD_LOAD( ulong, CURSOR ); INC( 8UL );
 
   CHECK_LEFT( sizeof(ulong) ); INC( sizeof(ulong) ); /* unused */
 
-  CHECK_LEFT( 8U ); genesis->poh.tick_duration_secs = FD_LOAD( ulong, CURSOR ); INC( 8U );
-  CHECK_LEFT( 4U ); genesis->poh.tick_duration_ns   = FD_LOAD( uint,  CURSOR ); INC( 4U );
-  CHECK_LEFT( 1U ); int has_target_tick_count       = FD_LOAD( uchar, CURSOR ); INC( 1U );
-  if( has_target_tick_count ) { CHECK_LEFT( 8U ); genesis->poh.target_tick_count = FD_LOAD( ulong, CURSOR ); INC( 8U ); }
+  CHECK_LEFT( 8UL ); genesis->poh.tick_duration_secs = FD_LOAD( ulong, CURSOR ); INC( 8UL );
+  CHECK_LEFT( 4UL ); genesis->poh.tick_duration_ns   = FD_LOAD( uint,  CURSOR ); INC( 4UL );
+  CHECK_LEFT( 1UL ); int has_target_tick_count       = FD_LOAD( uchar, CURSOR ); INC( 1UL );
+  if( has_target_tick_count ) { CHECK_LEFT( 8UL ); genesis->poh.target_tick_count = FD_LOAD( ulong, CURSOR ); INC( 8UL ); }
   else                                            genesis->poh.target_tick_count = 0UL;
-  CHECK_LEFT( 1U ); int has_hashes_per_tick       = FD_LOAD( uchar, CURSOR ); INC( 1U );
-  if( has_hashes_per_tick ) { CHECK_LEFT( 8U ); genesis->poh.hashes_per_tick = FD_LOAD( ulong, CURSOR ); INC( 8U ); }
+  CHECK_LEFT( 1UL ); int has_hashes_per_tick       = FD_LOAD( uchar, CURSOR ); INC( 1UL );
+  if( has_hashes_per_tick ) { CHECK_LEFT( 8UL ); genesis->poh.hashes_per_tick = FD_LOAD( ulong, CURSOR ); INC( 8UL ); }
   else                                          genesis->poh.hashes_per_tick = 0UL;
 
-  CHECK_LEFT( sizeof(ulong) ); INC( sizeof(ulong) ); /* bakcward compat v23 */
+  CHECK_LEFT( sizeof(ulong) ); INC( sizeof(ulong) ); /* backward compat v23 */
 
-  CHECK_LEFT( 8U ); genesis->fee_rate_governor.target_lamports_per_signature = FD_LOAD( ulong, CURSOR ); INC( 8U );
-  CHECK_LEFT( 8U ); genesis->fee_rate_governor.target_signatures_per_slot    = FD_LOAD( ulong, CURSOR ); INC( 8U );
-  CHECK_LEFT( 8U ); genesis->fee_rate_governor.min_lamports_per_signature    = FD_LOAD( ulong, CURSOR ); INC( 8U );
-  CHECK_LEFT( 8U ); genesis->fee_rate_governor.max_lamports_per_signature    = FD_LOAD( ulong, CURSOR ); INC( 8U );
-  CHECK_LEFT( 1U ); genesis->fee_rate_governor.burn_percent                  = FD_LOAD( uchar, CURSOR ); INC( 1U );
+  CHECK_LEFT( 8UL ); genesis->fee_rate_governor.target_lamports_per_signature = FD_LOAD( ulong, CURSOR ); INC( 8UL );
+  CHECK_LEFT( 8UL ); genesis->fee_rate_governor.target_signatures_per_slot    = FD_LOAD( ulong, CURSOR ); INC( 8UL );
+  CHECK_LEFT( 8UL ); genesis->fee_rate_governor.min_lamports_per_signature    = FD_LOAD( ulong, CURSOR ); INC( 8UL );
+  CHECK_LEFT( 8UL ); genesis->fee_rate_governor.max_lamports_per_signature    = FD_LOAD( ulong, CURSOR ); INC( 8UL );
+  CHECK_LEFT( 1UL ); genesis->fee_rate_governor.burn_percent                  = FD_LOAD( uchar, CURSOR ); INC( 1UL );
 
-  CHECK_LEFT( 8U ); genesis->rent.lamports_per_uint8_year = FD_LOAD( ulong, CURSOR );  INC( 8U );
-  CHECK_LEFT( 8U ); genesis->rent.exemption_threshold     = FD_LOAD( double, CURSOR ); INC( 8U );
-  CHECK_LEFT( 1U ); genesis->rent.burn_percent            = FD_LOAD( uchar, CURSOR );  INC( 1U );
+  CHECK_LEFT( 8UL ); genesis->rent.lamports_per_uint8_year = FD_LOAD( ulong, CURSOR );  INC( 8UL );
+  CHECK_LEFT( 8UL ); genesis->rent.exemption_threshold     = FD_LOAD( double, CURSOR ); INC( 8UL );
+  CHECK_LEFT( 1UL ); genesis->rent.burn_percent            = FD_LOAD( uchar, CURSOR );  INC( 1UL );
 
-  CHECK_LEFT( 8U ); genesis->inflation.initial         = FD_LOAD( double, CURSOR ); INC( 8U );
-  CHECK_LEFT( 8U ); genesis->inflation.terminal        = FD_LOAD( double, CURSOR ); INC( 8U );
-  CHECK_LEFT( 8U ); genesis->inflation.taper           = FD_LOAD( double, CURSOR ); INC( 8U );
-  CHECK_LEFT( 8U ); genesis->inflation.foundation      = FD_LOAD( double, CURSOR ); INC( 8U );
-  CHECK_LEFT( 8U ); genesis->inflation.foundation_term = FD_LOAD( double, CURSOR ); INC( 8U );
-  CHECK_LEFT( 8U );                                                                 INC( 8U ); /* unused */
+  CHECK_LEFT( 8UL ); genesis->inflation.initial         = FD_LOAD( double, CURSOR ); INC( 8UL );
+  CHECK_LEFT( 8UL ); genesis->inflation.terminal        = FD_LOAD( double, CURSOR ); INC( 8UL );
+  CHECK_LEFT( 8UL ); genesis->inflation.taper           = FD_LOAD( double, CURSOR ); INC( 8UL );
+  CHECK_LEFT( 8UL ); genesis->inflation.foundation      = FD_LOAD( double, CURSOR ); INC( 8UL );
+  CHECK_LEFT( 8UL ); genesis->inflation.foundation_term = FD_LOAD( double, CURSOR ); INC( 8UL );
+  CHECK_LEFT( 8UL );                                                                 INC( 8UL ); /* unused */
 
-  CHECK_LEFT( 8U ); genesis->epoch_schedule.slots_per_epoch             = FD_LOAD( ulong, CURSOR ); INC( 8U );
-  CHECK_LEFT( 8U ); genesis->epoch_schedule.leader_schedule_slot_offset = FD_LOAD( ulong, CURSOR ); INC( 8U );
-  CHECK_LEFT( 1U ); genesis->epoch_schedule.warmup                      = FD_LOAD( uchar, CURSOR ); INC( 1U );
-  CHECK_LEFT( 8U ); genesis->epoch_schedule.first_normal_epoch          = FD_LOAD( ulong, CURSOR ); INC( 8U );
-  CHECK_LEFT( 8U ); genesis->epoch_schedule.first_normal_slot           = FD_LOAD( ulong, CURSOR ); INC( 8U );
+  CHECK_LEFT( 8UL ); genesis->epoch_schedule.slots_per_epoch             = FD_LOAD( ulong, CURSOR ); INC( 8UL );
+  CHECK_LEFT( 8UL ); genesis->epoch_schedule.leader_schedule_slot_offset = FD_LOAD( ulong, CURSOR ); INC( 8UL );
+  CHECK_LEFT( 1UL ); genesis->epoch_schedule.warmup                      = FD_LOAD( uchar, CURSOR ); INC( 1UL );
+  CHECK_LEFT( 8UL ); genesis->epoch_schedule.first_normal_epoch          = FD_LOAD( ulong, CURSOR ); INC( 8UL );
+  CHECK_LEFT( 8UL ); genesis->epoch_schedule.first_normal_slot           = FD_LOAD( ulong, CURSOR ); INC( 8UL );
 
-  CHECK_LEFT( 4U ); genesis->cluster_type = FD_LOAD( uint, CURSOR ); INC( 4U );
+  CHECK_LEFT( 4UL ); genesis->cluster_type = FD_LOAD( uint, CURSOR ); INC( 4UL );
+
+# undef CHECK
+# undef CHECK_LEFT
+# undef INC
+# undef CUR_OFFSET
+# undef CURSOR
+
+  if( _i!=_payload_sz ) {
+    FD_LOG_WARNING(( "genesis blob has %lu trailing unrecognized bytes. Perhaps this Firedancer build is too old?", _payload_sz-_i ));
+    return NULL;
+  }
 
   return genesis;
+}
+
+fd_genesis_account_t *
+fd_genesis_account( fd_genesis_t const *   genesis,
+                    uchar const *          bin,
+                    fd_genesis_account_t * out,
+                    ulong                  idx ) {
+  fd_genesis_account_off_t const * off = &genesis->account[ idx ];
+  out->pubkey        = FD_LOAD( fd_pubkey_t, bin+off->pubkey_off      );
+  out->meta.lamports = FD_LOAD( ulong,       bin+off->pubkey_off+32UL );
+  out->meta.dlen     = (uint)FD_LOAD( ulong, bin+off->pubkey_off+40UL );
+  out->data          = bin+off->pubkey_off+48UL;
+  memcpy( out->meta.owner, bin+off->owner_off, sizeof(fd_pubkey_t) );
+  out->meta.executable = !!bin[ off->owner_off+32UL ];
+  out->meta.slot       = 0UL;
+  return out;
+}
+
+fd_genesis_builtin_t *
+fd_genesis_builtin( fd_genesis_t const *   genesis,
+                    uchar const *          bin,
+                    fd_genesis_builtin_t * out,
+                    ulong                  idx ) {
+  fd_genesis_builtin_off_t const * off = &genesis->builtin[ idx ];
+  out->pubkey = FD_LOAD( fd_pubkey_t, bin+off->pubkey_off   );
+  out->dlen   = FD_LOAD( ulong,       bin+off->data_len_off );
+  out->data   = bin+off->data_len_off+8UL;
+  return out;
 }

--- a/src/flamenco/runtime/fd_runtime_helpers.h
+++ b/src/flamenco/runtime/fd_runtime_helpers.h
@@ -81,7 +81,8 @@ fd_runtime_read_genesis( fd_banks_t *              banks,
                          fd_capture_ctx_t *        capture_ctx,
                          fd_hash_t const *         genesis_hash,
                          fd_lthash_value_t const * genesis_lthash,
-                         fd_genesis_t const *      genesis_block,
+                         fd_genesis_t const *      genesis,
+                         uchar const *             genesis_blob,
                          fd_runtime_stack_t *      runtime_stack );
 
 /* Error logging handholding assertions */

--- a/src/flamenco/runtime/program/fd_builtin_programs.c
+++ b/src/flamenco/runtime/program/fd_builtin_programs.c
@@ -207,7 +207,7 @@ fd_write_builtin_account( fd_bank_t  *              bank,
                           fd_funk_txn_xid_t const * xid,
                           fd_capture_ctx_t *        capture_ctx,
                           fd_pubkey_t const         pubkey,
-                          char const *              data,
+                          void const *              data,
                           ulong                     sz ) {
 
   fd_accdb_rw_t rw[1];

--- a/src/flamenco/runtime/program/fd_builtin_programs.h
+++ b/src/flamenco/runtime/program/fd_builtin_programs.h
@@ -71,7 +71,7 @@ fd_write_builtin_account( fd_bank_t  *              bank,
                           fd_funk_txn_xid_t const * xid,
                           fd_capture_ctx_t *        capture_ctx,
                           fd_pubkey_t const         pubkey,
-                          char const *              data,
+                          void const *              data,
                           ulong                     sz );
 
 fd_builtin_program_t const *

--- a/src/flamenco/types/fd_types_custom.h
+++ b/src/flamenco/types/fd_types_custom.h
@@ -18,9 +18,10 @@ union __attribute__((packed)) fd_hash {
   uchar key [ FD_HASH_FOOTPRINT ]; // Making fd_hash and fd_pubkey interchangeable
 
   // Generic type specific accessors
-  ulong ul  [ FD_HASH_FOOTPRINT / sizeof(ulong) ];
-  uint  ui  [ FD_HASH_FOOTPRINT / sizeof(uint)  ];
-  uchar uc  [ FD_HASH_FOOTPRINT ];
+  ulong  ul  [ FD_HASH_FOOTPRINT / sizeof(ulong)  ];
+  uint   ui  [ FD_HASH_FOOTPRINT / sizeof(uint)   ];
+  ushort us  [ FD_HASH_FOOTPRINT / sizeof(ushort) ];
+  uchar  uc  [ FD_HASH_FOOTPRINT                  ];
 };
 typedef union fd_hash fd_hash_t;
 typedef union fd_hash fd_pubkey_t;


### PR DESCRIPTION
- Simplify genesi_out link and make it type-safe
- Remove redundant genesi_rpc link
- Greatly increase genesis_parse limits and efficiency by using
  a descriptor-based deserializer
- Various type safety fixes (fd_hash_t instead of uchar[32], etc)
