### PR TITLE
runtime: fix instruction stack leak on native program lookup failure

### DIFF
--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -1338,7 +1338,7 @@ fd_execute_instr( fd_runtime_t *      runtime,
   if( FD_UNLIKELY( err ) ) {
     FD_TXN_PREPARE_ERR_OVERWRITE( txn_out );
     FD_TXN_ERR_FOR_LOG_INSTR( txn_out, err, txn_out->err.exec_err_idx );
-    return err;
+    return fd_execute_instr_end( ctx, instr, err );
   }
 
   if( FD_LIKELY( native_prog_fn!=NULL ) ) {


### PR DESCRIPTION
fd_execute_instr() pushes the instruction stack via fd_instr_stack_push but returns directly when fd_executor_lookup_native_program() fails, bypassing fd_execute_instr_end() which is responsible for popping the stack. This permanently leaks one stack entry per failed lookup for the remainder of the transaction, diverging from Agave which always pops via .and(self.pop()).

Route the error return through fd_execute_instr_end() to ensure the stack is popped, matching the two other return paths in the function.