### PR TITLE
restore: snapct timeouts not configurable via toml

### DIFF
--- a/src/discof/restore/fd_snapct_tile.c
+++ b/src/discof/restore/fd_snapct_tile.c
@@ -23,7 +23,6 @@
 #define NAME "snapct"
 
 /* FIXME: Implement full_effective_age_cancel_threshold */
-/* FIXME: Add more timeout config options and have consistent behavior */
 /* FIXME: Do a finishing pass over the default.toml config options / comments */
 /* FIXME: Handle cases where no explicitly allowed peers advertise RPC */
 /* FIXME: Make the code more strict about duplicate IP:port's */


### PR DESCRIPTION
Removing deprecated FIXME in `snapct`: timeouts will not be configurable from toml.