### PR TITLE
runtime: fix uninitialized read in fd_feature_activate on decode failure

### DIFF
--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -456,6 +456,8 @@ fd_feature_activate( fd_bank_t *               bank,
   if( FD_UNLIKELY( !fd_feature_decode( &feature, fd_accdb_ref_data_const( ro ), fd_accdb_ref_data_sz( ro ) ) ) ) {
     FD_LOG_WARNING(( "cannot activate feature %s, corrupt account data", addr_b58 ));
     FD_LOG_HEXDUMP_NOTICE(( "corrupt feature account", fd_accdb_ref_data_const( ro ), fd_accdb_ref_data_sz( ro ) ));
+    fd_accdb_close_ro( accdb, ro );
+    return;
   }
   fd_accdb_close_ro( accdb, ro );
 


### PR DESCRIPTION
fd_feature_decode() failure logged a warning but did not return, falling through to read the uninitialized fd_feature_t on the stack. If is_active was falsy (likely for zeroed stack memory), the else branch would open the account for write and activate the feature with the current slot -- incorrectly activating a feature from corrupt account data.

Add early return on decode failure to skip activation, matching Agave which returns None from get_feature_state() on decode error.

https://github.com/firedancer-io/auditor-internal/issues/391