### PR TITLE
restore: snapwm txn_commit upon fini msg

### DIFF
--- a/src/discof/restore/fd_snapwm_tile.c
+++ b/src/discof/restore/fd_snapwm_tile.c
@@ -242,9 +242,6 @@ handle_control_frag( fd_snapwm_tile_t *  ctx,
         forward_msg = 0;
         break;
       }
-
-      /* FIXME re-enable fd_snapwm_vinyl_txn_commit here once recovery
-         is fully implemented. */
       break;
     }
 


### PR DESCRIPTION
Removing deprecated FIXME, following this PR sequence: https://github.com/firedancer-io/firedancer/pull/8178, https://github.com/firedancer-io/firedancer/pull/8206, https://github.com/firedancer-io/firedancer/pull/8276, and https://github.com/firedancer-io/firedancer/pull/8322.

In summary, `fd_snapwm_vinyl_txn_commit` is invoked upon a `fini` msg when `tx->vinyl.txn_active` is true. And the latter is only true when lthash verification is disabled, so there is no overlap with `snaplv` operation.