### PR TITLE
topo: remove duplicate rpc tile declaration

### DIFF
--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -403,7 +403,6 @@ fd_topob_auto_layout_cpus( fd_topo_t *      topo,
     "execrp", /* FIREDANCER only */
     "txsend", /* FIREDANCER only */
     "tower",  /* FIREDANCER only */
-    "rpc",    /* FIREDANCER only */
     "pktgen",
     "snapct", /* FIREDANCER only */
     "snapld", /* FIREDANCER only */


### PR DESCRIPTION
The duplicate caused topo to require one more core than necessary.