### PR TITLE
gui, topo: allow_crash tile flag

### DIFF
--- a/book/api/metrics-generated.md
+++ b/book/api/metrics-generated.md
@@ -31,7 +31,7 @@
 | <span class="metrics-name">tile_&#8203;context_&#8203;switch_&#8203;voluntary_&#8203;count</span> | counter | The number of voluntary context switches |
 | <span class="metrics-name">tile_&#8203;page_&#8203;fault_&#8203;major_&#8203;count</span> | counter | The number of major page faults |
 | <span class="metrics-name">tile_&#8203;page_&#8203;fault_&#8203;minor_&#8203;count</span> | counter | The number of minor page faults |
-| <span class="metrics-name">tile_&#8203;status</span> | gauge | The current status of the tile. 0 is booting, 1 is running. 2 is shutdown |
+| <span class="metrics-name">tile_&#8203;status</span> | gauge | The current status of the tile. 0 is booting, 1 is running. 2 is shutdown. 3 is crashed. |
 | <span class="metrics-name">tile_&#8203;heartbeat</span> | gauge | The last UNIX timestamp in nanoseconds that the tile heartbeated |
 | <span class="metrics-name">tile_&#8203;in_&#8203;backpressure</span> | gauge | Whether the tile is currently backpressured or not, either 1 or 0 |
 | <span class="metrics-name">tile_&#8203;backpressure_&#8203;count</span> | counter | Number of times the tile has had to wait for one of more consumers to catch up to resume publishing |

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -1290,7 +1290,7 @@ fd_topo_initialize( config_t * config ) {
   if( FD_LIKELY( config->tiles.gui.enabled ) ) {
     fd_topob_wksp( topo, "gui"        );
 
-    /**/                 fd_topob_tile(     topo, "gui",     "gui",     "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0, 1, 0 );
+    /**/                 fd_topob_tile(     topo, "gui",     "gui",     "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0, 1, 0 )->allow_crash = 1;
 
     /*                                        topo, tile_name, tile_kind_id, fseq_wksp,   link_name,       link_kind_id, reliable,            polled */
     FOR(net_tile_cnt)      fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "net_gossvf",    i,            FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED ); /* No reliable consumers of networking fragments, may be dropped or overrun */

--- a/src/app/shared/commands/ready.c
+++ b/src/app/shared/commands/ready.c
@@ -34,6 +34,7 @@ ready_cmd_fn( args_t *   args,
 
       if( FD_LIKELY( status==1UL ) ) break;
       else if( FD_UNLIKELY( tile->allow_shutdown && status==2UL ) ) break;
+      else if( FD_UNLIKELY( tile->allow_crash && status==3UL ) ) break;
       else if( FD_UNLIKELY( status ) )
         FD_LOG_ERR(( "status for tile %s:%lu is in bad state %lu", tile->name, tile->kind_id, status ));
 

--- a/src/app/shared/commands/run/run.c
+++ b/src/app/shared/commands/run/run.c
@@ -11,8 +11,9 @@
 
 #include "../../../platform/fd_sys_util.h"
 #include "../../../platform/fd_file_util.h"
-#include "../../../platform/fd_net_util.h"
 #include "../../../../disco/net/fd_net_tile.h"
+#include "../../../../disco/metrics/fd_metrics.h"
+#include "../../../../disco/stem/fd_stem.h"
 
 #include "../configure/configure.h"
 
@@ -326,6 +327,25 @@ main_pid_namespace( void * _args ) {
     FD_TEST( 8UL==read( fds[ i ].fd, &actual_pids[ i ], 8UL ) );
   }
 
+  /* Remap fseq and metrics workspaces for tiles with allow_crash=1 so
+     we can demote reliable links to unreliable and update tile status
+     metrics when a crashable tile dies.  These workspaces were left
+     unmapped in initialize_workspaces to avoid leaking mappings
+     into child processes, but need to be rejoined before seccomp
+     filters take effect. */
+  for( ulong i=0UL; i<config->topo.wksp_cnt; i++ ) {
+    int need_join = 0;
+    for( ulong j=0UL; j<config->topo.tile_cnt; j++ ) {
+      fd_topo_tile_t const * tile = &config->topo.tiles[ j ];
+      if( FD_LIKELY( !tile->allow_crash ) ) continue;
+      need_join |= i==config->topo.objs[ tile->metrics_obj_id ].wksp_id;
+      for( ulong k=0UL; k<tile->in_cnt; k++ ) need_join |= tile->in_link_poll[ k ] && tile->in_link_reliable[ k ] && i==config->topo.objs[ tile->in_link_fseq_obj_id[ k ] ].wksp_id;
+    }
+    if( FD_UNLIKELY( need_join ) ) {
+      fd_topo_join_workspace( (fd_topo_t *)&config->topo, &((fd_topo_t *)&config->topo)->workspaces[ i ], FD_SHMEM_JOIN_MODE_READ_WRITE, 0 );
+    }
+  }
+
   if( FD_UNLIKELY( -1==setpriority( PRIO_PROCESS, 0, save_priority ) ) ) FD_LOG_ERR(( "setpriority() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
   if( FD_UNLIKELY( fd_cpuset_setaffinity( 0, floating_cpu_set ) ) )
     FD_LOG_ERR(( "fd_cpuset_setaffinity failed (%i-%s)", errno, fd_io_strerror( errno ) ));
@@ -441,18 +461,56 @@ main_pid_namespace( void * _args ) {
 
       char * tile_name = child_names[ i ];
       ulong  tile_idx = child_idxs[ i ];
-      ulong  tile_id = config->topo.tiles[ tile_idx ].kind_id;
+
+      /* Non-topology child (e.g. agave) has no tile entry */
+      if( FD_UNLIKELY( tile_idx==ULONG_MAX ) ) {
+        if( FD_UNLIKELY( !WIFEXITED( wstatus ) ) ) {
+          FD_LOG_ERR_NOEXIT(( "child %s crashed with signal %d (%s)", tile_name, WTERMSIG( wstatus ), fd_io_strsignal( WTERMSIG( wstatus ) ) ));
+          fd_sys_util_exit_group( WTERMSIG( wstatus ) ? WTERMSIG( wstatus ) : 1 );
+        } else {
+          int exit_code = WEXITSTATUS( wstatus );
+          FD_LOG_ERR_NOEXIT(( "child %s exited unexpectedly with code %d", tile_name, exit_code ));
+          fd_sys_util_exit_group( exit_code ? exit_code : 1 );
+        }
+      }
+
+      fd_topo_tile_t const * tile = &config->topo.tiles[ tile_idx ];
 
       if( FD_UNLIKELY( !WIFEXITED( wstatus ) ) ) {
-        FD_LOG_ERR_NOEXIT(( "tile %s:%lu exited with signal %d (%s)", tile_name, tile_id, WTERMSIG( wstatus ), fd_io_strsignal( WTERMSIG( wstatus ) ) ));
-        fd_sys_util_exit_group( WTERMSIG( wstatus ) ? WTERMSIG( wstatus ) : 1 );
+        if( FD_UNLIKELY( tile->allow_crash ) ) {
+          FD_LOG_WARNING(( "expendable tile %s:%lu crashed with signal %d (%s)", tile_name, tile->kind_id, WTERMSIG( wstatus ), fd_io_strsignal( WTERMSIG( wstatus ) ) ));
+
+          /* We need to make all reliable links unreliable to prevent
+             the application from stalling. */
+          for( ulong j=0UL; j<tile->in_cnt; j++ ) {
+            if( FD_UNLIKELY( !tile->in_link_poll[ j ] || !tile->in_link_reliable[ j ] ) ) continue;
+
+            ulong * fseq = fd_fseq_join( fd_topo_obj_laddr( &config->topo, tile->in_link_fseq_obj_id[ j ] ) );
+            if( FD_UNLIKELY( !fseq ) ) {
+              FD_LOG_ERR_NOEXIT(( "failed to join fseq" ));
+              fd_sys_util_exit_group( 1 );
+            }
+            fd_fseq_update( fseq, STEM_SHUTDOWN_SEQ );
+            fd_fseq_leave( fseq );
+
+            fd_topo_link_t const * in_link = &config->topo.links[ tile->in_link_id[ j ] ];
+            FD_LOG_NOTICE(( "demoted reliable in-link %s(%lu)->%s to unreliable", in_link->name, in_link->kind_id, tile->name ));
+          }
+
+          /* Update tile status metric */
+          ulong * metrics = fd_metrics_join( fd_topo_obj_laddr( &config->topo, tile->metrics_obj_id ) );
+          fd_metrics_tile( metrics )[ FD_METRICS_GAUGE_TILE_STATUS_OFF ] = 3UL;
+          fd_metrics_leave( metrics );
+        } else {
+          FD_LOG_ERR_NOEXIT(( "tile %s:%lu crashed with signal %d (%s)", tile_name, tile->kind_id, WTERMSIG( wstatus ), fd_io_strsignal( WTERMSIG( wstatus ) ) ));
+          fd_sys_util_exit_group( WTERMSIG( wstatus ) ? WTERMSIG( wstatus ) : 1 );
+        }
       } else {
         int exit_code = WEXITSTATUS( wstatus );
-        if( FD_LIKELY( !exit_code && tile_idx!=ULONG_MAX && config->topo.tiles[ tile_idx ].allow_shutdown ) ) {
-          found = 1;
-          FD_LOG_INFO(( "tile %s:%lu exited gracefully with code %d", tile_name, tile_id, exit_code ));
+        if( FD_LIKELY( !exit_code && tile->allow_shutdown ) ) {
+          FD_LOG_INFO(( "tile %s:%lu exited gracefully with code %d", tile_name, tile->kind_id, exit_code ));
         } else {
-          FD_LOG_ERR_NOEXIT(( "tile %s:%lu exited with code %d", tile_name, tile_id, exit_code ));
+          FD_LOG_ERR_NOEXIT(( "tile %s:%lu exited unexpectedly with code %d", tile_name, tile->kind_id, exit_code ));
           fd_sys_util_exit_group( exit_code ? exit_code : 1 );
         }
       }

--- a/src/app/shared/commands/watch/watch.c
+++ b/src/app/shared/commands/watch/watch.c
@@ -630,10 +630,14 @@ static uint
 write_gui( config_t const * config,
            ulong const *    cur_tile,
            ulong const *    prev_tile ) {
-  (void)cur_tile;
-
   ulong gui_tile_idx = fd_topo_find_tile( &config->topo, "gui", 0UL );
   if( gui_tile_idx==ULONG_MAX ) return 0U;
+
+  ulong gui_status = cur_tile[ gui_tile_idx*FD_METRICS_TOTAL_SZ+MIDX( GAUGE, TILE, STATUS ) ];
+  if( FD_UNLIKELY( gui_status==3UL /* crashed */ ) ) {
+    PRINT( "👁  " BOLD RED "GUI........." RESET UNBOLD " DEAD" CLEARLN "\n" );
+    return 1U;
+  }
 
   ulong connection_count = cur_tile[ gui_tile_idx*FD_METRICS_TOTAL_SZ+MIDX( GAUGE, GUI, CONNECTION_COUNT ) ]+
                            cur_tile[ gui_tile_idx*FD_METRICS_TOTAL_SZ+MIDX( GAUGE, GUI, WEBSOCKET_CONNECTION_COUNT ) ];

--- a/src/disco/diag/fd_diag_tile.c
+++ b/src/disco/diag/fd_diag_tile.c
@@ -243,9 +243,10 @@ before_credit( fd_diag_tile_t *    ctx,
   for( ulong i=0UL; i<ctx->tile_cnt; i++ ) {
     if( FD_LIKELY( -1!=ctx->stat_fds[ i ] ) ) continue;
 
-    /* The tile died, but it's a tile which is allowed to shutdown, so
-       just stop updating metrics for it. */
+    /* The tile died, but it's a tile which is allowed to crash or
+       shutdown, so just stop updating metrics for it. */
     if( FD_LIKELY( 2UL==ctx->metrics[ i ][ FD_METRICS_GAUGE_TILE_STATUS_OFF ] ) ) continue;
+    if( FD_LIKELY( 3UL==ctx->metrics[ i ][ FD_METRICS_GAUGE_TILE_STATUS_OFF ] ) ) continue;
 
     /* Supervisor is going to bring the whole process tree down if any
        of the target PIDs died, so we can ignore this and wait. */
@@ -303,18 +304,18 @@ privileged_init( fd_topo_t *      topo,
       FD_TEST( fd_cstr_printf_check( path, sizeof( path ), NULL, "/proc/%lu/task/%lu/stat", pid, tid ) );
       ctx->stat_fds[ i ] = open( path, O_RDONLY );
       if( FD_UNLIKELY( -1==ctx->stat_fds[ i ] ) ) {
-        /* Might be a tile that's allowed to shutdown already did so
-           before we got to here, due to a race condition.  Just
-           proceed, we will not be able to get metrics for the shut
-           down process. */
-        if( FD_LIKELY( 2UL!=ctx->metrics[ i ][ FD_METRICS_GAUGE_TILE_STATUS_OFF ] ) ) FD_LOG_ERR(( "open stat failed (%i-%s)", errno, strerror( errno ) ));
+        /* Might be a tile that's allowed to shutdown or crash that
+           already exited before we got here, due to a race
+           condition.  Just proceed; we will not be able to get
+           metrics for the dead process. */
+        if( FD_LIKELY( 2UL!=ctx->metrics[ i ][ FD_METRICS_GAUGE_TILE_STATUS_OFF ] && 3UL!=ctx->metrics[ i ][ FD_METRICS_GAUGE_TILE_STATUS_OFF ] ) ) FD_LOG_ERR(( "open stat failed (%i-%s)", errno, strerror( errno ) ));
         break;
       }
 
       FD_TEST( fd_cstr_printf_check( path, sizeof( path ), NULL, "/proc/%lu/task/%lu/sched", pid, tid ) );
       ctx->sched_fds[ i ] = open( path, O_RDONLY );
       if( FD_UNLIKELY( -1==ctx->sched_fds[ i ] ) ) {
-        if( FD_LIKELY( 2UL!=ctx->metrics[ i ][ FD_METRICS_GAUGE_TILE_STATUS_OFF ] ) ) FD_LOG_ERR(( "open sched failed (%i-%s)", errno, strerror( errno ) ));
+        if( FD_LIKELY( 2UL!=ctx->metrics[ i ][ FD_METRICS_GAUGE_TILE_STATUS_OFF ] && 3UL!=ctx->metrics[ i ][ FD_METRICS_GAUGE_TILE_STATUS_OFF ] ) ) FD_LOG_ERR(( "open sched failed (%i-%s)", errno, strerror( errno ) ));
         ctx->stat_fds[ i ] = -1;
       }
       break;

--- a/src/disco/metrics/generated/fd_metrics_all.h
+++ b/src/disco/metrics/generated/fd_metrics_all.h
@@ -181,7 +181,7 @@ enum {
 
 #define FD_METRICS_GAUGE_TILE_STATUS_NAME "tile_status"
 #define FD_METRICS_GAUGE_TILE_STATUS_TYPE (FD_METRICS_TYPE_GAUGE)
-#define FD_METRICS_GAUGE_TILE_STATUS_DESC "The current status of the tile. 0 is booting, 1 is running. 2 is shutdown"
+#define FD_METRICS_GAUGE_TILE_STATUS_DESC "The current status of the tile. 0 is booting, 1 is running. 2 is shutdown. 3 is crashed."
 #define FD_METRICS_GAUGE_TILE_STATUS_CVT  (FD_METRICS_CONVERTER_NONE)
 
 #define FD_METRICS_GAUGE_TILE_HEARTBEAT_NAME "tile_heartbeat"

--- a/src/disco/metrics/metrics.xml
+++ b/src/disco/metrics/metrics.xml
@@ -51,7 +51,7 @@ metric introduced.
     <counter name="ContextSwitchVoluntaryCount" summary="The number of voluntary context switches" />
     <counter name="PageFaultMajorCount" summary="The number of major page faults" />
     <counter name="PageFaultMinorCount" summary="The number of minor page faults" />
-    <gauge name="Status" summary="The current status of the tile. 0 is booting, 1 is running. 2 is shutdown" />
+    <gauge name="Status" summary="The current status of the tile. 0 is booting, 1 is running. 2 is shutdown. 3 is crashed." />
     <gauge name="Heartbeat" summary="The last UNIX timestamp in nanoseconds that the tile heartbeated" />
     <gauge name="InBackpressure" summary="Whether the tile is currently backpressured or not, either 1 or 0" />
     <counter name="BackpressureCount" summary="Number of times the tile has had to wait for one of more consumers to catch up to resume publishing" />

--- a/src/disco/stem/fd_stem.c
+++ b/src/disco/stem/fd_stem.c
@@ -195,8 +195,6 @@
 #define STEM_LAZY (0L)
 #endif
 
-#define STEM_SHUTDOWN_SEQ (ULONG_MAX-1UL)
-
 static inline void
 STEM_(in_update)( fd_stem_tile_in_t * in ) {
   fd_fseq_update( in->fseq, in->seq );

--- a/src/disco/stem/fd_stem.h
+++ b/src/disco/stem/fd_stem.h
@@ -5,6 +5,8 @@
 
 #define FD_STEM_SCRATCH_ALIGN (128UL)
 
+#define STEM_SHUTDOWN_SEQ (ULONG_MAX-1UL)
+
 struct fd_stem_context {
    fd_frag_meta_t ** mcaches;
    ulong *           seqs;

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -129,6 +129,7 @@ struct fd_topo_tile {
   ulong kind_id;                /* The ID of this tile within its name.  If there are n tile of a particular name, they have IDs [0, N).  The pair (name, kind_id) uniquely identifies a tile, as does "id" on its own. */
   int   is_agave;               /* If the tile needs to run in the Agave (Anza) address space or not. */
   int   allow_shutdown;         /* If the tile is allowed to shutdown gracefully.  If false, when the tile exits it will tear down the entire application. */
+  int   allow_crash;            /* If the tile is allowed to crash.  If false, when the tile crashes it will tear down the entire application. */
 
   ulong cpu_idx;                /* The CPU index to pin the tile on.  A value of ULONG_MAX or more indicates the tile should be floating and not pinned to a core. */
 

--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -169,6 +169,8 @@ fd_topob_tile( fd_topo_t *    topo,
   tile->in_cnt              = 0UL;
   tile->out_cnt             = 0UL;
   tile->uses_obj_cnt        = 0UL;
+  tile->allow_shutdown      = 0;
+  tile->allow_crash         = 0;
 
   fd_topo_obj_t * tile_obj = fd_topob_obj( topo, "tile", tile_wksp );
   tile->tile_obj_id = tile_obj->id;
@@ -663,6 +665,14 @@ fd_topob_finish( fd_topo_t *                topo,
                  fd_topo_obj_callbacks_t ** callbacks ) {
   for( ulong z=0UL; z<topo->tile_cnt; z++ ) {
     fd_topo_tile_t * tile = &topo->tiles[ z ];
+
+    /* Expendable tiles must not have reliable downstream consumers,
+       since crashing would stall them in the typical case.  Any
+       exceptions should explicitly be made here (e.g. for links with
+       one-shot messages). */
+    if( FD_UNLIKELY( tile->allow_crash && fd_topo_tile_reliable_consumer_cnt( topo, tile )>0UL ) ) {
+      FD_LOG_ERR(( "tile %s:%lu has allow_crash==1 but has reliable downstream consumers.", tile->name, tile->kind_id ));
+    }
 
     ulong in_cnt = 0UL;
     for( ulong i=0UL; i<tile->in_cnt; i++ ) {


### PR DESCRIPTION
allow expendable tiles to crash without taking down the rest of the client

example logs after a crash

```bash
ERR     03-11 17:42:17.583849 1266234 f0   pidns src/app/shared/commands/run/run.c(449): expendable tile gui:0 crashed with signal 9 (SIGKILL-Killed)
NOTICE  03-11 17:42:17.584239 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link shred_out(0)->gui to unreliable
NOTICE  03-11 17:42:17.584250 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link gossip_out(0)->gui to unreliable
NOTICE  03-11 17:42:17.584256 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link tower_out(0)->gui to unreliable
NOTICE  03-11 17:42:17.584260 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link replay_out(0)->gui to unreliable
NOTICE  03-11 17:42:17.584264 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link replay_epoch(0)->gui to unreliable
NOTICE  03-11 17:42:17.584269 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link genesi_out(0)->gui to unreliable
NOTICE  03-11 17:42:17.584273 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link pack_poh(0)->gui to unreliable
NOTICE  03-11 17:42:17.584277 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link pack_execle(0)->gui to unreliable
NOTICE  03-11 17:42:17.584281 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link execle_poh(0)->gui to unreliable
NOTICE  03-11 17:42:17.584285 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link execle_poh(1)->gui to unreliable
NOTICE  03-11 17:42:17.584289 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link execrp_replay(0)->gui to unreliable
NOTICE  03-11 17:42:17.584298 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link execrp_replay(1)->gui to unreliable
NOTICE  03-11 17:42:17.584303 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link execrp_replay(2)->gui to unreliable
NOTICE  03-11 17:42:17.584307 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link execrp_replay(3)->gui to unreliable
NOTICE  03-11 17:42:17.584311 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link execrp_replay(4)->gui to unreliable
NOTICE  03-11 17:42:17.584319 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link execrp_replay(5)->gui to unreliable
NOTICE  03-11 17:42:17.584323 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link execrp_replay(6)->gui to unreliable
NOTICE  03-11 17:42:17.584327 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link execrp_replay(7)->gui to unreliable
NOTICE  03-11 17:42:17.584332 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link execrp_replay(8)->gui to unreliable
NOTICE  03-11 17:42:17.584336 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link execrp_replay(9)->gui to unreliable
NOTICE  03-11 17:42:17.584340 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link snapct_gui(0)->gui to unreliable
NOTICE  03-11 17:42:17.584344 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link snapin_gui(0)->gui to unreliable
NOTICE  03-11 17:42:17.584348 1266234 f0   pidns src/app/shared/commands/run/run.c(469): demoted reliable in-link bundle_status(0)->gui to unreliable
WARNING 03-11 17:42:27.746680 1266279 f0   diag:0 src/disco/diag/fd_diag_tile.c(259): cannot get metrics for dead tile idx 56
```