### PR TITLE
runtime: validate aligned realloc against original serialized length

### DIFF
--- a/src/flamenco/runtime/program/fd_bpf_loader_serialization.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_serialization.c
@@ -485,8 +485,7 @@ fd_bpf_loader_input_deserialize_aligned( fd_exec_instr_ctx_t * ctx,
 
       uchar * post_data = buffer+start;
 
-      fd_account_meta_t const * metadata_check = fd_borrowed_account_get_acc_meta( &view_acc );
-      if( FD_UNLIKELY( fd_ulong_sat_sub( post_len, metadata_check->dlen )>MAX_PERMITTED_DATA_INCREASE ||
+      if( FD_UNLIKELY( fd_ulong_sat_sub( post_len, pre_len )>MAX_PERMITTED_DATA_INCREASE ||
                        post_len>MAX_PERMITTED_DATA_LENGTH ) ) {
         return FD_EXECUTOR_INSTR_ERR_INVALID_REALLOC;
       }


### PR DESCRIPTION
The current length can be changed with CPI