### PR TITLE
resolv: fix IPv6 fallback nameserver index

### DIFF
--- a/src/waltz/resolv/fd_res_msend.c
+++ b/src/waltz/resolv/fd_res_msend.c
@@ -136,7 +136,7 @@ fd_res_msend_rc( int                     nqueries,
 
   /* Handle case where system lacks IPv6 support */
   if( fd < 0 && family == AF_INET6 && errno == EAFNOSUPPORT ) {
-    for( i=0; i<nns && conf->ns[nns].family == AF_INET6; i++ );
+    for( i=0; i<nns && conf->ns[i].family == AF_INET6; i++ );
     if( i==nns ) {
       return -1;
     }


### PR DESCRIPTION
Use conf->ns[i] instead of conf->ns[nns] in the EAFNOSUPPORT path to avoid an OOB read and allow correct IPv4 fallback when available.