### PR TITLE
funk: move record locks to separate wksp

### DIFF
--- a/src/app/firedancer-dev/main.h
+++ b/src/app/firedancer-dev/main.h
@@ -22,6 +22,7 @@ extern fd_topo_obj_callbacks_t fd_obj_cb_txncache;
 extern fd_topo_obj_callbacks_t fd_obj_cb_banks;
 extern fd_topo_obj_callbacks_t fd_obj_cb_banks_locks;
 extern fd_topo_obj_callbacks_t fd_obj_cb_funk;
+extern fd_topo_obj_callbacks_t fd_obj_cb_funk_locks;
 extern fd_topo_obj_callbacks_t fd_obj_cb_acc_pool;
 extern fd_topo_obj_callbacks_t fd_obj_cb_rnonce_ss;
 
@@ -50,6 +51,7 @@ fd_topo_obj_callbacks_t * CALLBACKS[] = {
   &fd_obj_cb_banks,
   &fd_obj_cb_banks_locks,
   &fd_obj_cb_funk,
+  &fd_obj_cb_funk_locks,
   &fd_obj_cb_vinyl_meta,
   &fd_obj_cb_vinyl_meta_ele,
   &fd_obj_cb_vinyl_data,

--- a/src/app/firedancer/callbacks.c
+++ b/src/app/firedancer/callbacks.c
@@ -75,8 +75,7 @@ funk_align( fd_topo_t const *     topo,
 static ulong
 funk_footprint( fd_topo_t const *     topo,
                 fd_topo_obj_t const * obj ) {
-  (void)topo;
-  return fd_funk_footprint( VAL("txn_max"), VAL("rec_max") );
+  return fd_funk_shmem_footprint( VAL("txn_max"), VAL("rec_max") );
 }
 
 static ulong
@@ -87,10 +86,10 @@ funk_loose( fd_topo_t const *     topo,
 
 static void
 funk_new( fd_topo_t const *     topo,
-           fd_topo_obj_t const * obj ) {
+          fd_topo_obj_t const * obj ) {
   ulong funk_seed = fd_pod_queryf_ulong( topo->props, 0UL, "obj.%lu.seed", obj->id );
   if( !funk_seed ) FD_TEST( fd_rng_secure( &funk_seed, sizeof(ulong) ) );
-  FD_TEST( fd_funk_new( fd_topo_obj_laddr( topo, obj->id ), 2UL, funk_seed, VAL("txn_max"), VAL("rec_max") ) );
+  FD_TEST( fd_funk_shmem_new( fd_topo_obj_laddr( topo, obj->id ), 2UL, funk_seed, VAL("txn_max"), VAL("rec_max") ) );
 }
 
 fd_topo_obj_callbacks_t fd_obj_cb_funk = {
@@ -99,6 +98,25 @@ fd_topo_obj_callbacks_t fd_obj_cb_funk = {
   .loose     = funk_loose,
   .align     = funk_align,
   .new       = funk_new,
+};
+
+static ulong
+funk_locks_footprint( fd_topo_t const *     topo,
+                      fd_topo_obj_t const * obj ) {
+  return fd_funk_locks_footprint( VAL("txn_max"), VAL("rec_max") );
+}
+
+static void
+funk_locks_new( fd_topo_t const *     topo,
+                fd_topo_obj_t const * obj ) {
+  FD_TEST( fd_funk_locks_new( fd_topo_obj_laddr( topo, obj->id ), VAL("txn_max"), VAL("rec_max") ) );
+}
+
+fd_topo_obj_callbacks_t fd_obj_cb_funk_locks = {
+  .name      = "funk_locks",
+  .footprint = funk_locks_footprint,
+  .align     = funk_align,
+  .new       = funk_locks_new,
 };
 
 /* cnc: a tile admin message queue */

--- a/src/app/firedancer/main.c
+++ b/src/app/firedancer/main.c
@@ -21,6 +21,7 @@ extern fd_topo_obj_callbacks_t fd_obj_cb_txncache;
 extern fd_topo_obj_callbacks_t fd_obj_cb_banks;
 extern fd_topo_obj_callbacks_t fd_obj_cb_banks_locks;
 extern fd_topo_obj_callbacks_t fd_obj_cb_funk;
+extern fd_topo_obj_callbacks_t fd_obj_cb_funk_locks;
 extern fd_topo_obj_callbacks_t fd_obj_cb_acc_pool;
 extern fd_topo_obj_callbacks_t fd_obj_cb_rnonce_ss;
 
@@ -48,6 +49,7 @@ fd_topo_obj_callbacks_t * CALLBACKS[] = {
   &fd_obj_cb_banks,
   &fd_obj_cb_banks_locks,
   &fd_obj_cb_funk,
+  &fd_obj_cb_funk_locks,
   &fd_obj_cb_acc_pool,
   &fd_obj_cb_vinyl_meta,
   &fd_obj_cb_vinyl_meta_ele,

--- a/src/app/firedancer/topology.h
+++ b/src/app/firedancer/topology.h
@@ -24,14 +24,13 @@ fd_topo_obj_t *
 setup_topo_banks_locks( fd_topo_t *  topo,
                         char const * wksp_name );
 
-fd_topo_obj_t *
+void
 setup_topo_funk( fd_topo_t *  topo,
-                 char const * wksp_name,
                  ulong        max_account_records,
                  ulong        max_database_transactions,
                  ulong        heap_size_gib );
 
-fd_topo_obj_t *
+void
 setup_topo_progcache( fd_topo_t *  topo,
                       char const * wksp_name,
                       ulong        max_cache_entries,

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -386,7 +386,6 @@ struct fd_topo_tile {
       ulong fec_max;
 
       ulong txncache_obj_id;
-      ulong progcache_obj_id;
 
       char  shred_cap[ PATH_MAX ];
 
@@ -427,7 +426,6 @@ struct fd_topo_tile {
 
     struct {
       ulong txncache_obj_id;
-      ulong progcache_obj_id;
       ulong acc_pool_obj_id;
 
       ulong max_live_slots;
@@ -581,6 +579,7 @@ struct fd_topo_tile {
       ulong max_live_slots;
       ulong accdb_max_depth;
       ulong funk_obj_id;
+      ulong funk_locks_obj_id;
       ulong txncache_obj_id;
 
       uint  lthash_disabled : 1;
@@ -621,7 +620,6 @@ struct fd_topo_tile {
       ulong max_live_slots;
       ulong accdb_max_depth;
       ulong txncache_obj_id;
-      ulong progcache_obj_id;
       ulong acc_pool_obj_id;
     } execle;
 

--- a/src/discof/execle/fd_execle_tile.c
+++ b/src/discof/execle/fd_execle_tile.c
@@ -606,10 +606,7 @@ unprivileged_init( fd_topo_t *      topo,
 
   fd_accdb_init_from_topo( ctx->accdb, topo, tile, tile->execle.accdb_max_depth );
 
-  void * shprogcache = fd_topo_obj_laddr( topo, tile->execle.progcache_obj_id );
-  FD_TEST( shprogcache );
-  fd_progcache_t * progcache = fd_progcache_join( ctx->progcache, shprogcache, pc_scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT );
-  FD_TEST( progcache );
+  fd_progcache_init_from_topo( ctx->progcache, topo, pc_scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT );
 
   void * _txncache_shmem = fd_topo_obj_laddr( topo, tile->execle.txncache_obj_id );
   fd_txncache_shmem_t * txncache_shmem = fd_txncache_shmem_join( _txncache_shmem );
@@ -627,7 +624,7 @@ unprivileged_init( fd_topo_t *      topo,
   }
 
   ctx->runtime->accdb                    = ctx->accdb;
-  ctx->runtime->progcache                = progcache;
+  ctx->runtime->progcache                = ctx->progcache;
   ctx->runtime->status_cache             = txncache;
   ctx->runtime->acc_pool                 = acc_pool;
   ctx->runtime->log.log_collector        = ctx->log_collector;

--- a/src/discof/execrp/fd_execrp_tile.c
+++ b/src/discof/execrp/fd_execrp_tile.c
@@ -336,10 +336,7 @@ unprivileged_init( fd_topo_t *      topo,
 
   fd_accdb_init_from_topo( ctx->accdb, topo, tile, tile->execrp.accdb_max_depth );
 
-  void * shprogcache = fd_topo_obj_laddr( topo, tile->execrp.progcache_obj_id );
-  if( FD_UNLIKELY( !fd_progcache_join( ctx->progcache, shprogcache, pc_scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) ) ) {
-    FD_LOG_CRIT(( "fd_progcache_join() failed" ));
-  }
+  fd_progcache_init_from_topo( ctx->progcache, topo, pc_scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT );
 
   void * _txncache_shmem = fd_topo_obj_laddr( topo, tile->execrp.txncache_obj_id );
   fd_txncache_shmem_t * txncache_shmem = fd_txncache_shmem_join( _txncache_shmem );

--- a/src/discof/fd_accdb_topo.c
+++ b/src/discof/fd_accdb_topo.c
@@ -1,6 +1,7 @@
 #include "fd_accdb_topo.h"
 #include "../flamenco/accdb/fd_accdb_impl_v1.h"
 #include "../flamenco/accdb/fd_accdb_impl_v2.h"
+#include "../flamenco/progcache/fd_progcache_user.h"
 #include "../util/pod/fd_pod.h"
 
 void
@@ -9,19 +10,41 @@ fd_accdb_init_from_topo( fd_accdb_user_t *      accdb,
                          fd_topo_tile_t const * tile,
                          ulong                  max_depth ) {
   ulong funk_obj_id;
-  FD_TEST( (funk_obj_id = fd_pod_query_ulong( topo->props, "funk", ULONG_MAX ))!=ULONG_MAX );
+  ulong locks_obj_id;
+  FD_TEST( (funk_obj_id  = fd_pod_query_ulong( topo->props, "funk",       ULONG_MAX ))!=ULONG_MAX );
+  FD_TEST( (locks_obj_id = fd_pod_query_ulong( topo->props, "funk_locks", ULONG_MAX ))!=ULONG_MAX );
   fd_topo_obj_t const * vinyl_data = fd_topo_find_tile_obj( topo, tile, "vinyl_data" );
   if( !vinyl_data ) {
-    FD_TEST( fd_accdb_user_v1_init( accdb, fd_topo_obj_laddr( topo, funk_obj_id ), max_depth ) );
+    FD_TEST( fd_accdb_user_v1_init( accdb,
+        fd_topo_obj_laddr( topo, funk_obj_id  ),
+        fd_topo_obj_laddr( topo, locks_obj_id ),
+        max_depth ) );
   } else {
     fd_topo_obj_t const * vinyl_rq       = fd_topo_find_tile_obj( topo, tile, "vinyl_rq"    );
     fd_topo_obj_t const * vinyl_req_pool = fd_topo_find_tile_obj( topo, tile, "vinyl_rpool" );
     FD_TEST( fd_accdb_user_v2_init( accdb,
-        fd_topo_obj_laddr( topo, funk_obj_id ),
+        fd_topo_obj_laddr( topo, funk_obj_id  ),
+        fd_topo_obj_laddr( topo, locks_obj_id ),
         fd_topo_obj_laddr( topo, vinyl_rq->id ),
         topo->workspaces[ vinyl_data->wksp_id ].wksp,
         fd_topo_obj_laddr( topo, vinyl_req_pool->id ),
         vinyl_rq->id,
         max_depth ) );
   }
+}
+
+void
+fd_progcache_init_from_topo( fd_progcache_t *  progcache,
+                             fd_topo_t const * topo,
+                             uchar *           scratch,
+                             ulong             scratch_sz ) {
+  ulong funk_obj_id;
+  ulong locks_obj_id;
+  FD_TEST( (funk_obj_id  = fd_pod_query_ulong( topo->props, "progcache",       ULONG_MAX ))!=ULONG_MAX );
+  FD_TEST( (locks_obj_id = fd_pod_query_ulong( topo->props, "progcache_locks", ULONG_MAX ))!=ULONG_MAX );
+  FD_TEST( fd_progcache_join( progcache,
+      fd_topo_obj_laddr( topo, funk_obj_id  ),
+      fd_topo_obj_laddr( topo, locks_obj_id ),
+      scratch,
+      scratch_sz ) );
 }

--- a/src/discof/fd_accdb_topo.h
+++ b/src/discof/fd_accdb_topo.h
@@ -14,6 +14,12 @@ fd_accdb_init_from_topo( fd_accdb_user_t *      accdb,
                          fd_topo_tile_t const * tile,
                          ulong                  max_depth );
 
+void
+fd_progcache_init_from_topo( fd_progcache_t *  progcache,
+                             fd_topo_t const * topo,
+                             uchar *           scratch,
+                             ulong             scratch_sz );
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_discof_fd_accdb_topo_h */

--- a/src/discof/genesis/fd_genesi_tile.c
+++ b/src/discof/genesis/fd_genesi_tile.c
@@ -462,9 +462,9 @@ unprivileged_init( fd_topo_t *      topo,
                            FD_SCRATCH_ALLOC_APPEND( l, fd_genesis_client_align(),   fd_genesis_client_footprint() );
   void * _alloc          = FD_SCRATCH_ALLOC_APPEND( l, fd_alloc_align(),            fd_alloc_footprint()          );
 
-  ulong funk_obj_id;
-  FD_TEST( (funk_obj_id = fd_pod_query_ulong( topo->props, "funk", ULONG_MAX ) )!=ULONG_MAX );
-  FD_TEST( fd_accdb_admin_v1_init( ctx->accdb_admin, fd_topo_obj_laddr( topo, funk_obj_id ) ) );
+  ulong funk_obj_id;  FD_TEST( (funk_obj_id  = fd_pod_query_ulong( topo->props, "funk",       ULONG_MAX ) )!=ULONG_MAX );
+  ulong locks_obj_id; FD_TEST( (locks_obj_id = fd_pod_query_ulong( topo->props, "funk_locks", ULONG_MAX ) )!=ULONG_MAX );
+  FD_TEST( fd_accdb_admin_v1_init( ctx->accdb_admin, fd_topo_obj_laddr( topo, funk_obj_id ), fd_topo_obj_laddr( topo, locks_obj_id ) ) );
   fd_accdb_init_from_topo( ctx->accdb, topo, tile, tile->genesi.accdb_max_depth );
 
   fd_lthash_zero( ctx->lthash );

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -2632,19 +2632,26 @@ unprivileged_init( fd_topo_t *      topo,
 
   fd_topo_obj_t const * vinyl_data = fd_topo_find_tile_obj( topo, tile, "vinyl_data" );
 
-  FD_TEST( fd_progcache_admin_join( ctx->progcache_admin, fd_topo_obj_laddr( topo, tile->replay.progcache_obj_id ) ) );
+  ulong progcache_obj_id;       FD_TEST( (progcache_obj_id       = fd_pod_query_ulong( topo->props, "progcache",       ULONG_MAX ) )!=ULONG_MAX );
+  ulong progcache_locks_obj_id; FD_TEST( (progcache_locks_obj_id = fd_pod_query_ulong( topo->props, "progcache_locks", ULONG_MAX ) )!=ULONG_MAX );
+  FD_TEST( fd_progcache_admin_join( ctx->progcache_admin,
+      fd_topo_obj_laddr( topo, progcache_obj_id       ),
+      fd_topo_obj_laddr( topo, progcache_locks_obj_id ) ) );
 
-  ulong funk_obj_id;
-  FD_TEST( (funk_obj_id = fd_pod_query_ulong( topo->props, "funk", ULONG_MAX ) )!=ULONG_MAX );
+  ulong funk_obj_id;       FD_TEST( (funk_obj_id       = fd_pod_query_ulong( topo->props, "funk",       ULONG_MAX ) )!=ULONG_MAX );
+  ulong funk_locks_obj_id; FD_TEST( (funk_locks_obj_id = fd_pod_query_ulong( topo->props, "funk_locks", ULONG_MAX ) )!=ULONG_MAX );
   ulong max_depth = tile->replay.max_live_slots + tile->replay.write_delay_slots;
   if( !vinyl_data ) {
-    FD_TEST( fd_accdb_admin_v1_init( ctx->accdb_admin, fd_topo_obj_laddr( topo,funk_obj_id ) ) );
+    FD_TEST( fd_accdb_admin_v1_init( ctx->accdb_admin,
+        fd_topo_obj_laddr( topo, funk_obj_id       ),
+        fd_topo_obj_laddr( topo, funk_locks_obj_id ) ) );
   } else {
     fd_topo_obj_t const * vinyl_rq       = fd_topo_find_tile_obj( topo, tile, "vinyl_rq" );
     fd_topo_obj_t const * vinyl_req_pool = fd_topo_find_tile_obj( topo, tile, "vinyl_rpool" );
     FD_TEST( fd_accdb_admin_v2_init( ctx->accdb_admin,
-        fd_topo_obj_laddr( topo, funk_obj_id ),
-        fd_topo_obj_laddr( topo, vinyl_rq->id ),
+        fd_topo_obj_laddr( topo, funk_obj_id       ),
+        fd_topo_obj_laddr( topo, funk_locks_obj_id ),
+        fd_topo_obj_laddr( topo, vinyl_rq->id      ),
         topo->workspaces[ vinyl_data->wksp_id ].wksp,
         fd_topo_obj_laddr( topo, vinyl_req_pool->id ),
         vinyl_rq->id,

--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -12,6 +12,7 @@
 #include "../../flamenco/runtime/fd_system_ids.h"
 #include "../../flamenco/runtime/sysvar/fd_sysvar_slot_history.h"
 #include "../../flamenco/types/fd_types.h"
+#include "../../util/pod/fd_pod.h"
 
 #include "generated/fd_snapin_tile_seccomp.h"
 
@@ -938,8 +939,12 @@ unprivileged_init( fd_topo_t *      topo,
 
   ctx->boot_timestamp = fd_log_wallclock();
 
-  FD_TEST( fd_accdb_admin_v1_init( ctx->accdb_admin, fd_topo_obj_laddr( topo, tile->snapin.funk_obj_id ) ) );
-  FD_TEST( fd_accdb_user_v1_init ( ctx->accdb,       fd_topo_obj_laddr( topo, tile->snapin.funk_obj_id ), tile->snapin.accdb_max_depth ) );
+  ulong funk_obj_id;       FD_TEST( (funk_obj_id       = fd_pod_query_ulong( topo->props, "funk",       ULONG_MAX ) )!=ULONG_MAX );
+  ulong funk_locks_obj_id; FD_TEST( (funk_locks_obj_id = fd_pod_query_ulong( topo->props, "funk_locks", ULONG_MAX ) )!=ULONG_MAX );
+  void * shfunk       = fd_topo_obj_laddr( topo, funk_obj_id       );
+  void * shfunk_locks = fd_topo_obj_laddr( topo, funk_locks_obj_id );
+  FD_TEST( fd_accdb_admin_v1_init( ctx->accdb_admin, shfunk, shfunk_locks ) );
+  FD_TEST( fd_accdb_user_v1_init ( ctx->accdb,       shfunk, shfunk_locks, tile->snapin.accdb_max_depth ) );
   ctx->funk = fd_accdb_user_v1_funk( ctx->accdb );
   fd_funk_txn_xid_copy( ctx->xid, fd_funk_root( ctx->funk ) );
 

--- a/src/discof/restore/fd_snapin_tile_funk.c
+++ b/src/discof/restore/fd_snapin_tile_funk.c
@@ -191,17 +191,19 @@ fd_snapin_process_account_batch_funk( fd_snapin_tile_t *            ctx,
     if( FD_LIKELY( !r ) ) {  /* optimize for new account */
       r = fd_funk_rec_pool_acquire( funk->rec_pool, NULL, 0, NULL );
       FD_TEST( r );
+      ulong rec_idx = (ulong)( r - rec_tbl );
 
       fd_funk_txn_xid_copy( r->pair.xid, ctx->xid );
       fd_funk_rec_key_copy( r->pair.key, &key );
       r->map_next  = 0U;
-      r->ver_lock  = fd_funk_rec_ver_lock( 1UL, 0UL );
       r->next_idx  = UINT_MAX;
       r->prev_idx  = UINT_MAX;
       r->val_sz    = 0;
       r->val_max   = 0;
       r->tag       = 0;
       r->val_gaddr = 0UL;
+
+      funk->rec_lock[ rec_idx ] = fd_funk_rec_ver_lock( 1UL, 0UL );
 
       /* Insert to hash map.  In theory, a key could appear twice in the
          same batch.  All accounts in a batch are guaranteed to be from

--- a/src/discof/rpc/test_rpc_tile.c
+++ b/src/discof/rpc/test_rpc_tile.c
@@ -129,12 +129,20 @@ main( int     argc,
 
   ulong const funk_txn_max = 16UL;
   ulong const funk_rec_max = 16UL;
-  void * shfunk = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint( funk_txn_max, funk_rec_max ), 1UL );
-  FD_TEST( fd_funk_new( shfunk, 1UL, 1UL, funk_txn_max, funk_rec_max ) );
+  void * shfunk = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_shmem_footprint( funk_txn_max, funk_rec_max ), 1UL );
+  FD_TEST( fd_funk_shmem_new( shfunk, 1UL, 1UL, funk_txn_max, funk_rec_max ) );
   fd_topo_obj_t * funk_obj = fd_topob_obj( topo, "funk", "wksp" );
   funk_obj->wksp_id = topo_wksp->id;
   funk_obj->offset  = fd_wksp_gaddr_fast( wksp, shfunk );
   fd_pod_insert_ulong( topo->props, "funk", funk_obj->id );
+
+  void * shlocks = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_locks_footprint( funk_txn_max, funk_rec_max ), 1UL );
+  FD_TEST( shlocks );
+  FD_TEST( fd_funk_locks_new( shlocks, funk_txn_max, funk_rec_max ) );
+  fd_topo_obj_t * funk_locks_obj = fd_topob_obj( topo, "funk_locks", "wksp" );
+  funk_locks_obj->wksp_id = topo_wksp->id;
+  funk_locks_obj->offset  = fd_wksp_gaddr_fast( wksp, shlocks );
+  fd_pod_insert_ulong( topo->props, "funk_locks", funk_locks_obj->id );
 
   fd_topo_link_t * link_rpc_replay = create_link( topo, wksp, "rpc_replay", 4UL, 0UL, 1UL );
   (void)link_rpc_replay;

--- a/src/flamenco/accdb/fd_accdb_admin_v1.h
+++ b/src/flamenco/accdb/fd_accdb_admin_v1.h
@@ -23,7 +23,8 @@ extern fd_accdb_admin_vt_t const fd_accdb_admin_v1_vt;
 
 fd_accdb_admin_t *
 fd_accdb_admin_v1_init( fd_accdb_admin_t * ljoin,
-                        void *             shfunk );
+                        void *             shfunk,
+                        void *             shlocks );
 
 void
 fd_accdb_admin_v1_fini( fd_accdb_admin_t * admin );

--- a/src/flamenco/accdb/fd_accdb_admin_v2.h
+++ b/src/flamenco/accdb/fd_accdb_admin_v2.h
@@ -12,7 +12,8 @@ extern fd_accdb_admin_vt_t const fd_accdb_admin_v2_vt;
 
 fd_accdb_admin_t *
 fd_accdb_admin_v2_init( fd_accdb_admin_t * admin_,
-                        void *             funk,
+                        void *             shfunk,
+                        void *             shlocks,
                         void *             vinyl_rq,
                         void *             vinyl_data,
                         void *             vinyl_req_pool,

--- a/src/flamenco/accdb/fd_accdb_funk.c
+++ b/src/flamenco/accdb/fd_accdb_funk.c
@@ -45,11 +45,12 @@ fd_accdb_funk_prep_create( fd_accdb_rw_t *       rw,
 
   fd_funk_rec_t * rec = fd_funk_rec_pool_acquire( funk->rec_pool, NULL, 1, NULL );
   if( FD_UNLIKELY( !rec ) ) FD_LOG_CRIT(( "Failed to modify account: DB record pool is out of memory" ));
+  ulong rec_idx = (ulong)( rec - funk->rec_pool->ele );
+  funk->rec_lock[ rec_idx ] = fd_funk_rec_ver_lock( fd_funk_rec_ver_inc( fd_funk_rec_ver_bits( funk->rec_lock[ rec_idx ] ) ), FD_FUNK_REC_LOCK_MASK );
 
   fd_funk_txn_xid_copy( rec->pair.xid, &txn->xid );
   memcpy( rec->pair.key->uc, address, 32UL );
   rec->map_next  = 0U;
-  rec->ver_lock  = fd_funk_rec_ver_lock( fd_funk_rec_ver_inc( fd_funk_rec_ver_bits( rec->ver_lock ) ), FD_FUNK_REC_LOCK_MASK );
   rec->next_idx  = FD_FUNK_REC_IDX_NULL;
   rec->prev_idx  = FD_FUNK_REC_IDX_NULL;
   rec->val_sz    = (uint)( fd_ulong_min( val_sz,  FD_FUNK_REC_VAL_MAX ) & FD_FUNK_REC_VAL_MAX );

--- a/src/flamenco/accdb/fd_accdb_impl_v1.c
+++ b/src/flamenco/accdb/fd_accdb_impl_v1.c
@@ -118,7 +118,7 @@ void
 fd_accdb_user_v1_fini( fd_accdb_user_t * accdb ) {
   fd_accdb_user_v1_t * user = (fd_accdb_user_v1_t *)accdb;
 
-  if( FD_UNLIKELY( !fd_funk_leave( user->funk, NULL ) ) ) FD_LOG_CRIT(( "fd_funk_leave failed" ));
+  if( FD_UNLIKELY( !fd_funk_leave( user->funk, NULL, NULL ) ) ) FD_LOG_CRIT(( "fd_funk_leave failed" ));
 }
 
 void
@@ -348,6 +348,7 @@ fd_accdb_user_vt_t const fd_accdb_user_v1_vt = {
 fd_accdb_user_t *
 fd_accdb_user_v1_init( fd_accdb_user_t * accdb,
                        void *            shfunk,
+                       void *            shlocks,
                        ulong             max_depth ) {
   fd_accdb_user_v1_t * ljoin = (fd_accdb_user_v1_t *)accdb;
 
@@ -361,7 +362,7 @@ fd_accdb_user_v1_init( fd_accdb_user_t * accdb,
   }
 
   memset( ljoin, 0, sizeof(fd_accdb_user_v1_t) );
-  if( FD_UNLIKELY( !fd_funk_join( ljoin->funk, shfunk ) ) ) {
+  if( FD_UNLIKELY( !fd_funk_join( ljoin->funk, shfunk, shlocks ) ) ) {
     FD_LOG_CRIT(( "fd_funk_join failed" ));
   }
 

--- a/src/flamenco/accdb/fd_accdb_impl_v1.h
+++ b/src/flamenco/accdb/fd_accdb_impl_v1.h
@@ -27,6 +27,7 @@ extern fd_accdb_user_vt_t const fd_accdb_user_v1_vt;
 fd_accdb_user_t *
 fd_accdb_user_v1_init( fd_accdb_user_t * ljoin,
                        void *            shfunk,
+                       void *            shlocks,
                        ulong             max_depth );
 
 fd_funk_t *

--- a/src/flamenco/accdb/fd_accdb_impl_v2.c
+++ b/src/flamenco/accdb/fd_accdb_impl_v2.c
@@ -22,8 +22,10 @@ FD_STATIC_ASSERT( sizeof (fd_accdb_user_v2_t)<=sizeof(fd_accdb_user_t),  layout 
      current thread to signal completion before attempting to access) */
 
 static void
-fd_funk_rec_write_lock( fd_funk_rec_t * rec ) {
-  ulong volatile * vl = &rec->ver_lock;
+fd_funk_rec_write_lock( fd_funk_t const * funk,
+                        fd_funk_rec_t *   rec ) {
+  ulong rec_idx = (ulong)( rec - funk->rec_pool->ele );
+  ulong volatile * vl = &funk->rec_lock[ rec_idx ];
   ulong val = FD_VOLATILE_CONST( *vl );
   if( FD_UNLIKELY( fd_funk_rec_lock_bits( val ) ) ) {
     FD_LOG_CRIT(( "fd_funk_rec_write_lock(" FD_FUNK_REC_PAIR_FMT ") failed: record has active readers",
@@ -37,15 +39,19 @@ fd_funk_rec_write_lock( fd_funk_rec_t * rec ) {
 }
 
 static void
-fd_funk_rec_write_lock_uncontended( fd_funk_rec_t * rec ) {
-  ulong val     = rec->ver_lock;
+fd_funk_rec_write_lock_uncontended( fd_funk_t const * funk,
+                                    fd_funk_rec_t *   rec ) {
+  ulong rec_idx = (ulong)( rec - funk->rec_pool->ele );
+  ulong val     = funk->rec_lock[ rec_idx ];
   ulong val_ver = fd_funk_rec_ver_bits( val );
-  rec->ver_lock = fd_funk_rec_ver_lock( val_ver, FD_FUNK_REC_LOCK_MASK );
+  funk->rec_lock[ rec_idx ] = fd_funk_rec_ver_lock( val_ver, FD_FUNK_REC_LOCK_MASK );
 }
 
 static void
-fd_funk_rec_write_unlock( fd_funk_rec_t * rec ) {
-  ulong volatile * vl = &rec->ver_lock;
+fd_funk_rec_write_unlock( fd_funk_t const * funk,
+                          fd_funk_rec_t *   rec ) {
+  ulong rec_idx = (ulong)( rec - funk->rec_pool->ele );
+  ulong volatile * vl = &funk->rec_lock[ rec_idx ];
   ulong val = FD_VOLATILE_CONST( *vl );
   if( FD_UNLIKELY( fd_funk_rec_lock_bits( val )!=FD_FUNK_REC_LOCK_MASK ) ) {
     FD_LOG_CRIT(( "fd_funk_rec_write_unlock(" FD_FUNK_REC_PAIR_FMT ") failed: record is not write locked",
@@ -65,8 +71,10 @@ fd_funk_rec_write_unlock( fd_funk_rec_t * rec ) {
    may concurrently root the txn as we are querying. */
 
 static int
-fd_funk_rec_read_lock( fd_funk_rec_t * rec ) {
-  ulong volatile * vl = &rec->ver_lock;
+fd_funk_rec_read_lock( fd_funk_t const * funk,
+                       fd_funk_rec_t *   rec ) {
+  ulong rec_idx = (ulong)( rec - funk->rec_pool->ele );
+  ulong volatile * vl = &funk->rec_lock[ rec_idx ];
   for(;;) {
     ulong val      = FD_VOLATILE_CONST( *vl );
     ulong val_ver  = fd_funk_rec_ver_bits ( val );
@@ -86,8 +94,10 @@ fd_funk_rec_read_lock( fd_funk_rec_t * rec ) {
 }
 
 static void
-fd_funk_rec_read_unlock( fd_funk_rec_t * rec ) {
-  ulong volatile * vl = &rec->ver_lock;
+fd_funk_rec_read_unlock( fd_funk_t const * funk,
+                         fd_funk_rec_t *   rec ) {
+  ulong rec_idx = (ulong)( rec - funk->rec_pool->ele );
+  ulong volatile * vl = &funk->rec_lock[ rec_idx ];
   for(;;) {
     ulong val      = FD_VOLATILE_CONST( *vl );
     ulong val_ver  = fd_funk_rec_ver_bits ( val );
@@ -193,9 +203,9 @@ next:
       is_write = 0;
     }
     if( is_write ) {
-      fd_funk_rec_write_lock( best );
+      fd_funk_rec_write_lock( accdb->funk, best );
     } else {
-      if( fd_funk_rec_read_lock( best )!=FD_MAP_SUCCESS ) {
+      if( fd_funk_rec_read_lock( accdb->funk, best )!=FD_MAP_SUCCESS ) {
         return ACQUIRE_FAILED; /* record about to be moved to vinyl */
       }
     }
@@ -204,8 +214,8 @@ next:
   /* Retry if there was contention at the hash map */
   if( FD_UNLIKELY( atomic_load_explicit( ver_cnt_p, memory_order_acquire )!=ver_cnt ) ) {
     if( best ) {
-      if( is_write ) fd_funk_rec_write_unlock( best );
-      else           fd_funk_rec_read_unlock ( best );
+      if( is_write ) fd_funk_rec_write_unlock( accdb->funk, best );
+      else           fd_funk_rec_read_unlock ( accdb->funk, best );
     }
     return ACQUIRE_FAILED;
   }
@@ -464,7 +474,7 @@ fd_accdb_user_v2_open_rw_multi( fd_accdb_user_t *         accdb,
 
       if( FD_UNLIKELY( !flag_create && fd_accdb_ref_lamports( rw->ro )==0UL ) ) {
         /* Tombstone */
-        fd_funk_rec_write_unlock( rec );
+        fd_funk_rec_write_unlock( v2->funk, rec );
         goto not_found;
       }
 
@@ -491,7 +501,7 @@ fd_accdb_user_v2_open_rw_multi( fd_accdb_user_t *         accdb,
       fd_accdb_ro_t * ro = rw->ro;
       if( FD_UNLIKELY( !flag_create && fd_accdb_ref_lamports( ro )==0UL ) ) {
         /* Tombstone */
-        fd_funk_rec_read_unlock( rec );
+        fd_funk_rec_read_unlock( v2->funk, rec );
         goto not_found;
       }
 
@@ -520,7 +530,7 @@ fd_accdb_user_v2_open_rw_multi( fd_accdb_user_t *         accdb,
       accdb->base.rw_active++;
 
       FD_COMPILER_MFENCE();
-      fd_funk_rec_read_unlock( rec );
+      fd_funk_rec_read_unlock( v2->funk, rec );
 
       continue; /* next account */
     }
@@ -537,7 +547,7 @@ fd_accdb_user_v2_open_rw_multi( fd_accdb_user_t *         accdb,
 not_found:
       if( flag_create ) {
         fd_accdb_funk_create( v2->funk, rw, txn, addr_i, data_max0[ i ] );
-        fd_funk_rec_write_lock_uncontended( (fd_funk_rec_t *)rw->ref->user_data );
+        fd_funk_rec_write_lock_uncontended( v2->funk, (fd_funk_rec_t *)rw->ref->user_data );
         accdb->base.rw_active++;
       } else {
         memset( rw, 0, sizeof(fd_accdb_ref_t) );
@@ -577,7 +587,7 @@ not_found:
     }
 
     fd_accdb_funk_prep_create( rw, v2->funk, txn, addr_i, val, val_sz, val_max );
-    fd_funk_rec_write_lock_uncontended( (fd_funk_rec_t *)rw->ref->user_data );
+    fd_funk_rec_write_lock_uncontended( v2->funk, (fd_funk_rec_t *)rw->ref->user_data );
 
     req_cnt++;
     accdb->base.rw_active++;
@@ -621,7 +631,7 @@ funk_close_rw( fd_accdb_user_v2_t * accdb,
     fd_funk_rec_publish( accdb->funk, &prepare );
   }
 
-  fd_funk_rec_write_unlock( rec );
+  fd_funk_rec_write_unlock( accdb->funk, rec );
   accdb->base.rw_active--;
 }
 
@@ -686,7 +696,7 @@ fd_accdb_user_v2_close_ref_multi( fd_accdb_user_t * accdb,
     switch( ref0[ i ].ref_type ) {
     case FD_ACCDB_REF_RO:
       accdb->base.ro_active--;
-      fd_funk_rec_read_unlock( (fd_funk_rec_t *)ref->user_data );
+      fd_funk_rec_read_unlock( v2->funk, (fd_funk_rec_t *)ref->user_data );
       break;
     case FD_ACCDB_REF_RW:
       funk_close_rw( v2, (fd_accdb_rw_t *)ref );
@@ -764,6 +774,7 @@ fd_accdb_user_v2_rw_data_sz_set( fd_accdb_user_t * accdb,
 fd_accdb_user_t *
 fd_accdb_user_v2_init( fd_accdb_user_t * accdb_,
                        void *            shfunk,
+                       void *            shlocks,
                        void *            vinyl_rq,
                        void *            vinyl_data,
                        void *            vinyl_req_pool,
@@ -785,7 +796,7 @@ fd_accdb_user_v2_init( fd_accdb_user_t * accdb_,
   fd_accdb_user_v2_t * accdb = fd_type_pun( accdb_ );
   memset( accdb, 0, sizeof(fd_accdb_user_v2_t) );
 
-  if( FD_UNLIKELY( !fd_funk_join( accdb->funk, shfunk ) ) ) {
+  if( FD_UNLIKELY( !fd_funk_join( accdb->funk, shfunk, shlocks ) ) ) {
     FD_LOG_CRIT(( "fd_funk_join failed" ));
   }
 
@@ -815,7 +826,7 @@ fd_accdb_user_v2_fini( fd_accdb_user_t * accdb ) {
 
   fd_vinyl_rq_leave( user->vinyl_rq );
 
-  if( FD_UNLIKELY( !fd_funk_leave( user->funk, NULL ) ) ) FD_LOG_CRIT(( "fd_funk_leave failed" ));
+  if( FD_UNLIKELY( !fd_funk_leave( user->funk, NULL, NULL ) ) ) FD_LOG_CRIT(( "fd_funk_leave failed" ));
 }
 
 ulong

--- a/src/flamenco/accdb/fd_accdb_impl_v2.h
+++ b/src/flamenco/accdb/fd_accdb_impl_v2.h
@@ -57,7 +57,8 @@ extern fd_accdb_user_vt_t const fd_accdb_user_v2_vt;
 
 fd_accdb_user_t *
 fd_accdb_user_v2_init( fd_accdb_user_t * ljoin,
-                       void *            funk,
+                       void *            shfunk,
+                       void *            shlocks,
                        void *            vinyl_rq,
                        void *            vinyl_data,
                        void *            vinyl_req_pool,

--- a/src/flamenco/progcache/fd_progcache_admin.h
+++ b/src/flamenco/progcache/fd_progcache_admin.h
@@ -36,13 +36,15 @@ fd_progcache_est_rec_max( ulong wksp_footprint,
 
 fd_progcache_admin_t *
 fd_progcache_admin_join( fd_progcache_admin_t * ljoin,
-                         void *                 shfunk );
+                         void *                 shfunk,
+                         void *                 shlocks );
 
 /* fd_progcache_admin_leave detaches the caller from a program cache. */
 
 void *
 fd_progcache_admin_leave( fd_progcache_admin_t * cache,
-                          void **                opt_shfunk );
+                          void **                opt_shfunk,
+                          void **                opt_shlocks );
 
 /* Transaction-level operations ***************************************/
 

--- a/src/flamenco/progcache/fd_progcache_user.h
+++ b/src/flamenco/progcache/fd_progcache_user.h
@@ -125,6 +125,7 @@ fd_progcache_delete( void * ljoin ) {
 fd_progcache_t *
 fd_progcache_join( fd_progcache_t * ljoin,
                    void *           shfunk,
+                   void *           shlocks,
                    uchar *          scratch,
                    ulong            scratch_sz );
 
@@ -135,7 +136,8 @@ fd_progcache_join( fd_progcache_t * ljoin,
 
 void *
 fd_progcache_leave( fd_progcache_t * cache,
-                    void **          opt_shfunk );
+                    void **          opt_shfunk,
+                    void **          opt_shlocks );
 
 /* Record-level operations ********************************************/
 

--- a/src/flamenco/runtime/program/test_vote_program.c
+++ b/src/flamenco/runtime/program/test_vote_program.c
@@ -35,9 +35,11 @@ struct test_env {
   fd_banks_t           banks[1];
   fd_bank_t            bank[1];
   void *               funk_mem;
+  void *               funk_locks;
   fd_accdb_admin_t     accdb_admin[1];
   fd_accdb_user_t      accdb[1];
   void *               pcache_mem;
+  void *               pcache_locks;
   fd_progcache_admin_t progcache_admin[1];
   fd_progcache_t       progcache[1];
   uchar *              progcache_scratch;
@@ -130,19 +132,25 @@ test_env_init( test_env_t * env, fd_wksp_t * wksp, int enable_loader_v4 ) {
   ulong const max_total_banks = 2UL;
   ulong const max_fork_width  = 2UL;
 
-  env->funk_mem = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), env->tag );
+  env->funk_mem   = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_shmem_footprint( txn_max, rec_max ), env->tag );
+  env->funk_locks = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_locks_footprint( txn_max, rec_max ), env->tag );
   FD_TEST( env->funk_mem );
-  FD_TEST( fd_funk_new( env->funk_mem, env->tag, funk_seed, txn_max, rec_max ) );
-  FD_TEST( fd_accdb_admin_v1_init( env->accdb_admin, env->funk_mem ) );
-  FD_TEST( fd_accdb_user_v1_init( env->accdb, env->funk_mem, txn_max ) );
+  FD_TEST( env->funk_locks );
+  FD_TEST( fd_funk_shmem_new( env->funk_mem, env->tag, funk_seed, txn_max, rec_max ) );
+  FD_TEST( fd_funk_locks_new( env->funk_locks, txn_max, rec_max ) );
+  FD_TEST( fd_accdb_admin_v1_init( env->accdb_admin, env->funk_mem, env->funk_locks ) );
+  FD_TEST( fd_accdb_user_v1_init( env->accdb, env->funk_mem, env->funk_locks, txn_max ) );
 
-  env->pcache_mem = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), env->tag );
+  env->pcache_mem   = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_shmem_footprint( txn_max, rec_max ), env->tag );
+  env->pcache_locks = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_locks_footprint( txn_max, rec_max ), env->tag );
   FD_TEST( env->pcache_mem );
-  FD_TEST( fd_funk_new( env->pcache_mem, env->tag, funk_seed+1, txn_max, rec_max ) );
+  FD_TEST( env->pcache_locks );
+  FD_TEST( fd_funk_shmem_new( env->pcache_mem, env->tag, funk_seed+1, txn_max, rec_max ) );
+  FD_TEST( fd_funk_locks_new( env->pcache_locks, txn_max, rec_max ) );
   env->progcache_scratch = fd_wksp_alloc_laddr( wksp, FD_PROGCACHE_SCRATCH_ALIGN, FD_PROGCACHE_SCRATCH_FOOTPRINT, env->tag );
   FD_TEST( env->progcache_scratch );
-  FD_TEST( fd_progcache_join( env->progcache, env->pcache_mem, env->progcache_scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
-  FD_TEST( fd_progcache_admin_join( env->progcache_admin, env->pcache_mem ) );
+  FD_TEST( fd_progcache_join( env->progcache, env->pcache_mem, env->pcache_locks, env->progcache_scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
+  FD_TEST( fd_progcache_admin_join( env->progcache_admin, env->pcache_mem, env->pcache_locks ) );
 
   fd_banks_data_t * banks_data = fd_wksp_alloc_laddr( wksp, fd_banks_align(), fd_banks_footprint( max_total_banks, max_fork_width ), env->tag );
   FD_TEST( banks_data );
@@ -223,15 +231,17 @@ test_env_cleanup( test_env_t * env ) {
   fd_wksp_free_laddr( env->banks->data );
   fd_wksp_free_laddr( env->banks->locks );
 
-  fd_progcache_leave( env->progcache, NULL );
+  fd_progcache_leave( env->progcache, NULL, NULL );
   void * pcache_funk = NULL;
-  fd_progcache_admin_leave( env->progcache_admin, &pcache_funk );
+  fd_progcache_admin_leave( env->progcache_admin, &pcache_funk, NULL );
+  fd_wksp_free_laddr( env->pcache_locks );
   fd_wksp_free_laddr( fd_funk_delete( pcache_funk ) );
   fd_wksp_free_laddr( env->progcache_scratch );
 
   void * accdb_shfunk = fd_accdb_admin_v1_funk( env->accdb_admin )->shmem;
   fd_accdb_admin_fini( env->accdb_admin );
   fd_accdb_user_fini( env->accdb );
+  fd_wksp_free_laddr( env->funk_locks );
   fd_wksp_free_laddr( fd_funk_delete( accdb_shfunk ) );
 
   fd_wksp_reset( env->wksp, (uint)env->tag );

--- a/src/flamenco/runtime/sysvar/test_sysvar.c
+++ b/src/flamenco/runtime/sysvar/test_sysvar.c
@@ -20,7 +20,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong const wksp_part_max = 16UL;
+  ulong const wksp_part_max = 32UL;
   ulong const wksp_data_max = fd_wksp_data_max_est( sizeof(wksp_mem), wksp_part_max );
   fd_wksp_t * wksp = fd_wksp_join( fd_wksp_new( wksp_mem, "wksp", 1U, wksp_part_max, wksp_data_max ) );
   FD_TEST( wksp );

--- a/src/flamenco/runtime/sysvar/test_sysvar_cache.c
+++ b/src/flamenco/runtime/sysvar/test_sysvar_cache.c
@@ -17,10 +17,13 @@ test_sysvar_cache_env_create( test_sysvar_cache_env_t * env,
   ulong const txn_max   =  2UL;
   ulong const rec_max   = 32UL;
 
-  void * funk_mem = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), funk_tag );
+  void * funk_mem = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_shmem_footprint( txn_max, rec_max ), funk_tag );
   FD_TEST( funk_mem );
-  FD_TEST( fd_funk_new( funk_mem, funk_tag, funk_seed, txn_max, rec_max ) );
-  fd_accdb_user_t * accdb = fd_accdb_user_v1_init( env->accdb, funk_mem, txn_max );
+  FD_TEST( fd_funk_shmem_new( funk_mem, funk_tag, funk_seed, txn_max, rec_max ) );
+  void * shlocks = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_locks_footprint( txn_max, rec_max ), funk_tag );
+  FD_TEST( shlocks );
+  FD_TEST( fd_funk_locks_new( shlocks, txn_max, rec_max ) );
+  fd_accdb_user_t * accdb = fd_accdb_user_v1_init( env->accdb, funk_mem, shlocks, txn_max );
   FD_TEST( accdb );
 
   fd_banks_locks_t * bank_locks = fd_wksp_alloc_laddr( wksp, alignof(fd_banks_locks_t), sizeof(fd_banks_locks_t), wksp_tag );
@@ -34,12 +37,13 @@ test_sysvar_cache_env_create( test_sysvar_cache_env_t * env,
   bank->locks = bank_locks;
 
   env->shfunk       = funk_mem;
+  env->shlocks      = shlocks;
   env->bank         = bank;
   env->xid          = (fd_funk_txn_xid_t) { .ul={ 0UL, 0UL } };
   env->sysvar_cache = fd_sysvar_cache_join( fd_sysvar_cache_new( bank->data->non_cow.sysvar_cache ) );
 
   fd_accdb_admin_t admin[1];
-  FD_TEST( fd_accdb_admin_v1_init( admin, funk_mem ) );
+  FD_TEST( fd_accdb_admin_v1_init( admin, funk_mem, shlocks ) );
   fd_funk_txn_xid_t root = fd_accdb_root_get( admin );
   fd_accdb_attach_child( admin, &root, &env->xid );
   fd_accdb_admin_fini( admin );

--- a/src/flamenco/runtime/sysvar/test_sysvar_cache_util.h
+++ b/src/flamenco/runtime/sysvar/test_sysvar_cache_util.h
@@ -9,6 +9,7 @@
 
 struct test_sysvar_cache_env {
   void *              shfunk;
+  void *              shlocks;
   fd_accdb_user_t     accdb[1];
   fd_funk_txn_xid_t   xid;
   fd_bank_t *         bank;

--- a/src/flamenco/runtime/test_bundle_exec.c
+++ b/src/flamenco/runtime/test_bundle_exec.c
@@ -32,6 +32,7 @@ struct test_env {
   fd_banks_t           banks[1];
   fd_bank_t            bank[1];
   void *               funk_mem;
+  void *               funk_locks;
   fd_accdb_admin_t     accdb_admin[1];
   fd_accdb_user_t      accdb[1];
   fd_funk_txn_xid_t    xid;
@@ -127,12 +128,15 @@ init_rent_sysvar( test_env_t * env,
     ulong const max_total_banks = 2UL;
     ulong const max_fork_width  = 2UL;
 
-    env->funk_mem = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), env->tag );
+    env->funk_mem = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_shmem_footprint( txn_max, rec_max ), env->tag );
     FD_TEST( env->funk_mem );
-    FD_TEST( fd_funk_new( env->funk_mem, env->tag, funk_seed, txn_max, rec_max ) );
+    env->funk_locks = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_locks_footprint( txn_max, rec_max ), env->tag );
+    FD_TEST( env->funk_locks );
+    FD_TEST( fd_funk_shmem_new( env->funk_mem, env->tag, funk_seed, txn_max, rec_max ) );
+    FD_TEST( fd_funk_locks_new( env->funk_locks, txn_max, rec_max ) );
 
-    FD_TEST( fd_accdb_admin_v1_init( env->accdb_admin, env->funk_mem ) );
-    FD_TEST( fd_accdb_user_v1_init( env->accdb, env->funk_mem, txn_max ) );
+    FD_TEST( fd_accdb_admin_v1_init( env->accdb_admin, env->funk_mem, env->funk_locks ) );
+    FD_TEST( fd_accdb_user_v1_init( env->accdb, env->funk_mem, env->funk_locks, txn_max ) );
 
     fd_banks_data_t * banks_data = fd_wksp_alloc_laddr( wksp, fd_banks_align(), fd_banks_footprint( max_total_banks, max_fork_width ), env->tag );
     FD_TEST( banks_data );

--- a/src/flamenco/runtime/test_deprecate_rent_exemption_threshold.c
+++ b/src/flamenco/runtime/test_deprecate_rent_exemption_threshold.c
@@ -44,6 +44,7 @@ struct test_env {
   fd_banks_t           banks[1];
   fd_bank_t            bank[1];
   void *               funk_mem;
+  void *               funk_locks;
   fd_accdb_admin_t     accdb_admin[1];
   fd_accdb_user_t      accdb[1];
   fd_funk_txn_xid_t    xid;
@@ -118,12 +119,15 @@ test_env_create( test_env_t * env,
   ulong const max_total_banks = 2UL;
   ulong const max_fork_width  = 2UL;
 
-  env->funk_mem = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), env->tag );
+  env->funk_mem = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_shmem_footprint( txn_max, rec_max ), env->tag );
   FD_TEST( env->funk_mem );
-  FD_TEST( fd_funk_new( env->funk_mem, env->tag, funk_seed, txn_max, rec_max ) );
+  env->funk_locks = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_locks_footprint( txn_max, rec_max ), env->tag );
+  FD_TEST( env->funk_locks );
+  FD_TEST( fd_funk_shmem_new( env->funk_mem, env->tag, funk_seed, txn_max, rec_max ) );
+  FD_TEST( fd_funk_locks_new( env->funk_locks, txn_max, rec_max ) );
 
-  FD_TEST( fd_accdb_admin_v1_init( env->accdb_admin, env->funk_mem ) );
-  FD_TEST( fd_accdb_user_v1_init( env->accdb, env->funk_mem, txn_max ) );
+  FD_TEST( fd_accdb_admin_v1_init( env->accdb_admin, env->funk_mem, env->funk_locks ) );
+  FD_TEST( fd_accdb_user_v1_init( env->accdb, env->funk_mem, env->funk_locks, txn_max ) );
 
   fd_banks_data_t * banks_data = fd_wksp_alloc_laddr( wksp, fd_banks_align(), fd_banks_footprint( max_total_banks, max_fork_width ), env->tag );
   FD_TEST( banks_data );
@@ -174,6 +178,7 @@ test_env_destroy( test_env_t * env ) {
   fd_accdb_admin_fini( env->accdb_admin );
   fd_accdb_user_fini( env->accdb );
   fd_wksp_free_laddr( fd_funk_delete( env->funk_mem ) );
+  fd_wksp_free_laddr( env->funk_locks );
 
   fd_wksp_usage_t usage[1];
   fd_wksp_usage( env->wksp, &env->tag, 1UL, usage );

--- a/src/flamenco/runtime/test_runtime_alut.c
+++ b/src/flamenco/runtime/test_runtime_alut.c
@@ -24,6 +24,7 @@ typedef struct {
   fd_wksp_t *         wksp;
   void *              funk_mem;
   void *              funk_shmem;
+  void *              funk_locks;
   fd_funk_t           funk_join[1];
   fd_funk_t *         funk;
   fd_accdb_user_t     accdb[1];
@@ -43,21 +44,25 @@ test_setup( fd_wksp_t * wksp ) {
   ulong txn_max        = 10;
   ulong rec_max        = TEST_FUNK_REC_CNT;
   ulong funk_align     = fd_funk_align();
-  ulong funk_footprint = fd_funk_footprint( txn_max, rec_max );
+  ulong funk_footprint = fd_funk_shmem_footprint( txn_max, rec_max );
+  ulong lock_footprint = fd_funk_locks_footprint( txn_max, rec_max );
   ctx->funk_mem = fd_wksp_alloc_laddr( wksp, funk_align, funk_footprint, 1UL );
   FD_TEST( ctx->funk_mem );
+  ctx->funk_locks = fd_wksp_alloc_laddr( wksp, funk_align, lock_footprint, 1UL );
+  FD_TEST( ctx->funk_locks );
 
-  ctx->funk_shmem = fd_funk_new( ctx->funk_mem, 1UL, 1234UL /* seed */, txn_max, rec_max );
+  ctx->funk_shmem = fd_funk_shmem_new( ctx->funk_mem, 1UL, 1234UL /* seed */, txn_max, rec_max );
   FD_TEST( ctx->funk_shmem );
+  FD_TEST( fd_funk_locks_new( ctx->funk_locks, txn_max, rec_max ) );
 
   /* Check alignment before join */
   FD_TEST( fd_ulong_is_aligned( (ulong)ctx->funk_shmem, funk_align ) );
 
-  ctx->funk = fd_funk_join( ctx->funk_join, ctx->funk_shmem );
+  ctx->funk = fd_funk_join( ctx->funk_join, ctx->funk_shmem, ctx->funk_locks );
   FD_TEST( ctx->funk );
 
   /* Set up accdb interface */
-  FD_TEST( fd_accdb_user_v1_init( ctx->accdb, ctx->funk_shmem, txn_max ) );
+  FD_TEST( fd_accdb_user_v1_init( ctx->accdb, ctx->funk_shmem, ctx->funk_locks, txn_max ) );
 
   /* Set up root transaction and target transaction ID */
   fd_funk_txn_xid_t root_xid;
@@ -79,8 +84,9 @@ test_teardown( test_ctx_t * ctx ) {
   if( !ctx ) return;
 
   void * shfunk = NULL;
-  fd_funk_leave( ctx->funk, &shfunk );
+  fd_funk_leave( ctx->funk, &shfunk, NULL );
   fd_funk_delete( shfunk );
+  fd_wksp_free_laddr( ctx->funk_locks );
   fd_wksp_free_laddr( ctx->funk_mem );
   fd_wksp_free_laddr( ctx );
 }

--- a/src/flamenco/runtime/tests/test_accounts_resize_delta.c
+++ b/src/flamenco/runtime/tests/test_accounts_resize_delta.c
@@ -36,9 +36,11 @@ struct test_env {
   fd_banks_t           banks[1];
   fd_bank_t            bank[1];
   void *               funk_mem;
+  void *               funk_locks;
   fd_accdb_admin_t     accdb_admin[1];
   fd_accdb_user_t      accdb[1];
   void *               pcache_mem;
+  void *               pcache_locks;
   fd_progcache_admin_t progcache_admin[1];
   fd_progcache_t       progcache[1];
   uchar *              progcache_scratch;
@@ -130,19 +132,25 @@ test_env_init( test_env_t * env, fd_wksp_t * wksp, int enable_loader_v4 ) {
   ulong const max_total_banks = 2UL;
   ulong const max_fork_width  = 2UL;
 
-  env->funk_mem = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), env->tag );
+  env->funk_mem   = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_shmem_footprint( txn_max, rec_max ), env->tag );
+  env->funk_locks = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_locks_footprint( txn_max, rec_max ), env->tag );
   FD_TEST( env->funk_mem );
-  FD_TEST( fd_funk_new( env->funk_mem, env->tag, funk_seed, txn_max, rec_max ) );
-  FD_TEST( fd_accdb_admin_v1_init( env->accdb_admin, env->funk_mem ) );
-  FD_TEST( fd_accdb_user_v1_init( env->accdb, env->funk_mem, txn_max ) );
+  FD_TEST( env->funk_locks );
+  FD_TEST( fd_funk_shmem_new( env->funk_mem, env->tag, funk_seed, txn_max, rec_max ) );
+  FD_TEST( fd_funk_locks_new( env->funk_locks, txn_max, rec_max ) );
+  FD_TEST( fd_accdb_admin_v1_init( env->accdb_admin, env->funk_mem, env->funk_locks ) );
+  FD_TEST( fd_accdb_user_v1_init( env->accdb, env->funk_mem, env->funk_locks, txn_max ) );
 
-  env->pcache_mem = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), env->tag );
+  env->pcache_mem   = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_shmem_footprint( txn_max, rec_max ), env->tag );
+  env->pcache_locks = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_locks_footprint( txn_max, rec_max ), env->tag );
   FD_TEST( env->pcache_mem );
-  FD_TEST( fd_funk_new( env->pcache_mem, env->tag, funk_seed+1, txn_max, rec_max ) );
+  FD_TEST( env->pcache_locks );
+  FD_TEST( fd_funk_shmem_new( env->pcache_mem, env->tag, funk_seed+1, txn_max, rec_max ) );
+  FD_TEST( fd_funk_locks_new( env->pcache_locks, txn_max, rec_max ) );
   env->progcache_scratch = fd_wksp_alloc_laddr( wksp, FD_PROGCACHE_SCRATCH_ALIGN, FD_PROGCACHE_SCRATCH_FOOTPRINT, env->tag );
   FD_TEST( env->progcache_scratch );
-  FD_TEST( fd_progcache_join( env->progcache, env->pcache_mem, env->progcache_scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
-  FD_TEST( fd_progcache_admin_join( env->progcache_admin, env->pcache_mem ) );
+  FD_TEST( fd_progcache_join( env->progcache, env->pcache_mem, env->pcache_locks, env->progcache_scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
+  FD_TEST( fd_progcache_admin_join( env->progcache_admin, env->pcache_mem, env->pcache_locks ) );
 
   fd_banks_data_t * banks_data = fd_wksp_alloc_laddr( wksp, fd_banks_align(), fd_banks_footprint( max_total_banks, max_fork_width ), env->tag );
   FD_TEST( banks_data );
@@ -223,15 +231,17 @@ test_env_cleanup( test_env_t * env ) {
   fd_wksp_free_laddr( env->banks->data );
   fd_wksp_free_laddr( env->banks->locks );
 
-  fd_progcache_leave( env->progcache, NULL );
+  fd_progcache_leave( env->progcache, NULL, NULL );
   void * pcache_funk = NULL;
-  fd_progcache_admin_leave( env->progcache_admin, &pcache_funk );
+  fd_progcache_admin_leave( env->progcache_admin, &pcache_funk, NULL );
+  fd_wksp_free_laddr( env->pcache_locks );
   fd_wksp_free_laddr( fd_funk_delete( pcache_funk ) );
   fd_wksp_free_laddr( env->progcache_scratch );
 
   void * accdb_shfunk = fd_accdb_admin_v1_funk( env->accdb_admin )->shmem;
   fd_accdb_admin_fini( env->accdb_admin );
   fd_accdb_user_fini( env->accdb );
+  fd_wksp_free_laddr( env->funk_locks );
   fd_wksp_free_laddr( fd_funk_delete( accdb_shfunk ) );
 
   fd_wksp_reset( env->wksp, (uint)env->tag );

--- a/src/flamenco/vm/syscall/test_cpi_shared_data_addr.c
+++ b/src/flamenco/vm/syscall/test_cpi_shared_data_addr.c
@@ -203,9 +203,11 @@ build_elf( uchar * buf,
 struct test_env {
   fd_wksp_t *          wksp;
   void *               funk_mem;
+  void *               funk_locks;
   fd_accdb_admin_t     accdb_admin[1];
   fd_accdb_user_t      accdb[1];
   void *               pcache_mem;
+  void *               pcache_locks;
   fd_progcache_admin_t progcache_admin[1];
   fd_progcache_t       progcache[1];
   uchar *              progcache_scratch;
@@ -316,20 +318,26 @@ test_env_create( test_env_t * env,
   ulong rec_max   = 1024UL;
 
   /* Account database */
-  env->funk_mem = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), TEST_WKSP_TAG );
+  env->funk_mem = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_shmem_footprint( txn_max, rec_max ), TEST_WKSP_TAG );
   FD_TEST( env->funk_mem );
-  FD_TEST( fd_funk_new( env->funk_mem, TEST_WKSP_TAG, funk_seed, txn_max, rec_max ) );
-  FD_TEST( fd_accdb_admin_v1_init( env->accdb_admin, env->funk_mem ) );
-  FD_TEST( fd_accdb_user_v1_init( env->accdb, env->funk_mem, txn_max ) );
+  FD_TEST( fd_funk_shmem_new( env->funk_mem, TEST_WKSP_TAG, funk_seed, txn_max, rec_max ) );
+  env->funk_locks = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_locks_footprint( txn_max, rec_max ), TEST_WKSP_TAG );
+  FD_TEST( env->funk_locks );
+  FD_TEST( fd_funk_locks_new( env->funk_locks, txn_max, rec_max ) );
+  FD_TEST( fd_accdb_admin_v1_init( env->accdb_admin, env->funk_mem, env->funk_locks ) );
+  FD_TEST( fd_accdb_user_v1_init( env->accdb, env->funk_mem, env->funk_locks, txn_max ) );
 
   /* Program cache */
-  env->pcache_mem = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_footprint( txn_max, rec_max ), TEST_WKSP_TAG );
+  env->pcache_mem = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_shmem_footprint( txn_max, rec_max ), TEST_WKSP_TAG );
   FD_TEST( env->pcache_mem );
-  FD_TEST( fd_funk_new( env->pcache_mem, TEST_WKSP_TAG, funk_seed + 1UL, txn_max, rec_max ) );
+  FD_TEST( fd_funk_shmem_new( env->pcache_mem, TEST_WKSP_TAG, funk_seed + 1UL, txn_max, rec_max ) );
+  env->pcache_locks = fd_wksp_alloc_laddr( wksp, fd_funk_align(), fd_funk_locks_footprint( txn_max, rec_max ), TEST_WKSP_TAG );
+  FD_TEST( env->pcache_locks );
+  FD_TEST( fd_funk_locks_new( env->pcache_locks, txn_max, rec_max ) );
   env->progcache_scratch = fd_wksp_alloc_laddr( wksp, FD_PROGCACHE_SCRATCH_ALIGN, FD_PROGCACHE_SCRATCH_FOOTPRINT, TEST_WKSP_TAG );
   FD_TEST( env->progcache_scratch );
-  FD_TEST( fd_progcache_join( env->progcache, env->pcache_mem, env->progcache_scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
-  FD_TEST( fd_progcache_admin_join( env->progcache_admin, env->pcache_mem ) );
+  FD_TEST( fd_progcache_join( env->progcache, env->pcache_mem, env->pcache_locks, env->progcache_scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
+  FD_TEST( fd_progcache_admin_join( env->progcache_admin, env->pcache_mem, env->pcache_locks ) );
 
   /* Banks */
   ulong max_total_banks = 1UL;
@@ -526,16 +534,18 @@ test_env_destroy( test_env_t * env ) {
   fd_wksp_free_laddr( env->banks->data );
   fd_wksp_free_laddr( env->banks->locks );
 
-  fd_progcache_leave( env->progcache, NULL );
+  fd_progcache_leave( env->progcache, NULL, NULL );
   void * pcache_funk = NULL;
-  fd_progcache_admin_leave( env->progcache_admin, &pcache_funk );
+  fd_progcache_admin_leave( env->progcache_admin, &pcache_funk, NULL );
   fd_wksp_free_laddr( fd_funk_delete( pcache_funk ) );
+  fd_wksp_free_laddr( env->pcache_locks );
   fd_wksp_free_laddr( env->progcache_scratch );
 
   void * accdb_shfunk = fd_accdb_admin_v1_funk( env->accdb_admin )->shmem;
   fd_accdb_admin_fini( env->accdb_admin );
   fd_accdb_user_fini( env->accdb );
   fd_wksp_free_laddr( fd_funk_delete( accdb_shfunk ) );
+  fd_wksp_free_laddr( env->funk_locks );
 }
 
 static void

--- a/src/funk/fd_funk_rec.h
+++ b/src/funk/fd_funk_rec.h
@@ -10,7 +10,7 @@
    multiple of align.  These are provided to facilitate compile time
    declarations. */
 
-#define FD_FUNK_REC_ALIGN     (32UL)
+#define FD_FUNK_REC_ALIGN     (16UL)
 
 /* FD_FUNK_REC_IDX_NULL gives the map record idx value used to represent
    NULL.  This value also set a limit on how large rec_max can be. */
@@ -26,13 +26,7 @@ struct __attribute__((aligned(FD_FUNK_REC_ALIGN))) fd_funk_rec {
   fd_funk_xid_key_pair_t pair;     /* Transaction id and record key pair */
   uint                   map_next; /* Internal use by map */
 
-  /* These fields are managed by the user */
-
-  uchar user[ 4 ];
-
   /* These fields are managed by funk */
-
-  ulong ver_lock;  /* Record version and lock bits */
 
   uint  next_idx;  /* Record map index of next record in its transaction */
   uint  prev_idx;  /* Record map index of previous record in its transaction */
@@ -52,7 +46,7 @@ struct __attribute__((aligned(FD_FUNK_REC_ALIGN))) fd_funk_rec {
 
 typedef struct fd_funk_rec fd_funk_rec_t;
 
-FD_STATIC_ASSERT( sizeof(fd_funk_rec_t) == 3U*FD_FUNK_REC_ALIGN, record size is wrong );
+FD_STATIC_ASSERT( sizeof(fd_funk_rec_t) == 5U*FD_FUNK_REC_ALIGN, record size is wrong );
 
 #define FD_FUNK_REC_PAIR_FMT "xid=%lu:%lu,key=%016lx:%016lx:%016lx:%016lx"
 #define FD_FUNK_REC_PAIR_FMT_ARGS(p) \

--- a/src/funk/fd_funk_txn.h
+++ b/src/funk/fd_funk_txn.h
@@ -55,8 +55,6 @@ struct __attribute__((aligned(FD_FUNK_TXN_ALIGN))) fd_funk_txn_private {
   uint  rec_tail_idx;       /* "                       last          " */
 
   uint  state;              /* one of FD_FUNK_TXN_STATE_* */
-
-  fd_rwlock_t lock[1];
 };
 
 typedef struct fd_funk_txn_private fd_funk_txn_t;

--- a/src/funk/test_funk.c
+++ b/src/funk/test_funk.c
@@ -37,25 +37,30 @@ main( int     argc,
   FD_LOG_NOTICE(( "Testing with --wksp-tag %lu --seed %lu --txn-max %lu --rec-max %u", wksp_tag, seed, txn_max, rec_max ));
 
   ulong align     = fd_funk_align();     FD_TEST( align    ==FD_FUNK_ALIGN     );
-  ulong footprint = fd_funk_footprint(txn_max, rec_max);
+  ulong footprint = fd_funk_shmem_footprint(txn_max, rec_max);
   FD_TEST( fd_ulong_is_pow2( align ) && footprint && fd_ulong_is_aligned( footprint, align ) );
 
   void * shmem = fd_wksp_alloc_laddr( wksp, align, footprint, wksp_tag );
   if( FD_UNLIKELY( !shmem ) ) FD_LOG_ERR(( "Unable to allocate shmem" ));
 
-  FD_TEST( !fd_funk_new( NULL,          wksp_tag, seed, txn_max, rec_max ) ); /* NULL shmem */
-  FD_TEST( !fd_funk_new( (void *)1UL,   wksp_tag, seed, txn_max, rec_max ) ); /* misaligned shmem */
-  FD_TEST( !fd_funk_new( (void *)align, wksp_tag, seed, txn_max, rec_max ) ); /* not a wksp addr */
-  FD_TEST( !fd_funk_new( shmem,         0UL,      seed, txn_max, rec_max ) ); /* bad tag */
+  ulong lock_footprint = fd_funk_locks_footprint( txn_max, rec_max );
+  void * shlocks = fd_wksp_alloc_laddr( wksp, align, lock_footprint, wksp_tag );
+  if( FD_UNLIKELY( !shlocks ) ) FD_LOG_ERR(( "Unable to allocate shlocks" ));
+
+  FD_TEST( !fd_funk_shmem_new( NULL,          wksp_tag, seed, txn_max, rec_max ) ); /* NULL shmem */
+  FD_TEST( !fd_funk_shmem_new( (void *)1UL,   wksp_tag, seed, txn_max, rec_max ) ); /* misaligned shmem */
+  FD_TEST( !fd_funk_shmem_new( (void *)align, wksp_tag, seed, txn_max, rec_max ) ); /* not a wksp addr */
+  FD_TEST( !fd_funk_shmem_new( shmem,         0UL,      seed, txn_max, rec_max ) ); /* bad tag */
   /* seed is arbitrary */
-  FD_TEST( !fd_funk_new( shmem,         wksp_tag, seed, FD_FUNK_TXN_IDX_NULL+1UL,             rec_max ) ); /* idx compr limited */
-  void * shfunk = fd_funk_new( shmem, wksp_tag, seed, txn_max, rec_max ); FD_TEST( shfunk==shmem );
+  FD_TEST( !fd_funk_shmem_new( shmem,         wksp_tag, seed, FD_FUNK_TXN_IDX_NULL+1UL,             rec_max ) ); /* idx compr limited */
+  void * shfunk = fd_funk_shmem_new( shmem, wksp_tag, seed, txn_max, rec_max ); FD_TEST( shfunk==shmem );
+  FD_TEST( fd_funk_locks_new( shlocks, txn_max, rec_max ) );
 
   fd_funk_t funk_[1];
-  FD_TEST( !fd_funk_join( funk_, NULL          ) ); /* NULL shmem */
-  FD_TEST( !fd_funk_join( funk_, (void *)1UL   ) ); /* misaligned shmem */
-  FD_TEST( !fd_funk_join( funk_, (void *)align ) ); /* not a wksp addr */
-  fd_funk_t * funk = fd_funk_join( funk_, shfunk ); FD_TEST( funk );
+  FD_TEST( !fd_funk_join( funk_, NULL,          shlocks ) ); /* NULL shmem */
+  FD_TEST( !fd_funk_join( funk_, (void *)1UL,   shlocks ) ); /* misaligned shmem */
+  FD_TEST( !fd_funk_join( funk_, (void *)align, shlocks ) ); /* not a wksp addr */
+  fd_funk_t * funk = fd_funk_join( funk_, shfunk, shlocks ); FD_TEST( funk );
 
   FD_TEST( fd_funk_wksp    ( funk )==wksp     );
   FD_TEST( fd_funk_wksp_tag( funk )==wksp_tag );
@@ -75,8 +80,8 @@ main( int     argc,
 
   FD_TEST( !fd_funk_verify( funk ) );
 
-  FD_TEST( !fd_funk_leave( NULL, NULL )        ); /* Not a join */
-  FD_TEST(  fd_funk_leave( funk, NULL )==funk_ );
+  FD_TEST( !fd_funk_leave( NULL, NULL, NULL )        ); /* Not a join */
+  FD_TEST(  fd_funk_leave( funk, NULL, NULL )==funk_ );
 
   FD_TEST( !fd_funk_delete( NULL          )        ); /* NULL shmem */
   FD_TEST( !fd_funk_delete( (void *)1UL   )        ); /* misaligned shmem */
@@ -84,9 +89,10 @@ main( int     argc,
   FD_TEST( !fd_funk_delete( (void *)align )        ); /* not wksp addr */
   FD_TEST(  fd_funk_delete( shfunk        )==shmem ); /* NULL shmem */
 
-  FD_TEST( !fd_funk_join  ( funk_, shfunk )        ); /* Can't join deleted */
+  FD_TEST( !fd_funk_join  ( funk_, shfunk, shlocks ) ); /* Can't join deleted */
   FD_TEST( !fd_funk_delete( shfunk        )        ); /* Can't delete twice */
 
+  fd_wksp_free_laddr( shlocks );
   fd_wksp_free_laddr( shmem );
   if( name ) fd_wksp_detach( wksp );
   else       fd_wksp_delete_anonymous( wksp );


### PR DESCRIPTION
Improves security architecture (allows tiles to read-only map database cache)

Closes #7712