### PR TITLE
pktgen: Add credit check to pktgen packet producer

### DIFF
--- a/src/app/shared_dev/commands/pktgen/fd_pktgen_tile.c
+++ b/src/app/shared_dev/commands/pktgen/fd_pktgen_tile.c
@@ -53,12 +53,14 @@ unprivileged_init( fd_topo_t *      topo,
 }
 
 static void
-before_credit( fd_pktgen_tile_ctx_t * ctx,
-               fd_stem_context_t *    stem,
-               int *                  charge_busy ) {
+after_credit( fd_pktgen_tile_ctx_t * ctx,
+              fd_stem_context_t *    stem,
+              int *                  opt_poll_in,
+              int *                  charge_busy ) {
   if( FD_VOLATILE_CONST( fd_pktgen_active )!=1U ) return;
 
   *charge_busy = 1;
+  *opt_poll_in = 0;
 
   /* Select an arbitrary public IP as the fake destination.  The outgoing
      packet has an an invalid ip header, so it will not reach that
@@ -90,7 +92,7 @@ before_credit( fd_pktgen_tile_ctx_t * ctx,
 #define STEM_CALLBACK_CONTEXT_TYPE fd_pktgen_tile_ctx_t
 #define STEM_CALLBACK_CONTEXT_ALIGN alignof(fd_pktgen_tile_ctx_t)
 
-#define STEM_CALLBACK_BEFORE_CREDIT before_credit
+#define STEM_CALLBACK_AFTER_CREDIT after_credit
 
 #define STEM_LAZY ((ulong)1e9) /* max possible */
 

--- a/src/app/shared_dev/commands/pktgen/pktgen.c
+++ b/src/app/shared_dev/commands/pktgen/pktgen.c
@@ -63,11 +63,11 @@ pktgen_topo( config_t * config ) {
   }
   fd_topob_link( topo, "pktgen_out", "pktgen", 2048UL, FD_NET_MTU, 1UL );
   fd_topob_tile_out( topo, "pktgen", 0UL, "pktgen_out", 0UL );
-  fd_topob_tile_in( topo, "net", 0UL, "metric_in", "pktgen_out", 0UL, FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
+  fd_topob_tile_in( topo, "net", 0UL, "metric_in", "pktgen_out", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
 
   /* Create dummy RX link */
   fd_topos_net_rx_link( topo, "net_quic", 0UL, config->net.ingress_buffer_size );
-  fd_topob_tile_in( topo, "pktgen", 0UL, "metric_in", "net_quic", 0UL, FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
+  fd_topob_tile_in( topo, "pktgen", 0UL, "metric_in", "net_quic", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
 
   fd_topos_net_tile_finish( topo, 0UL );
   if( FD_UNLIKELY( is_auto_affinity ) ) fd_topob_auto_layout( topo, 0 );


### PR DESCRIPTION
Adds credit check prior to producing an eth packet to stop pktgen crashing when consumer is broken or not fast enough.