### PR TITLE
Fix various cryptography link errors

### DIFF
--- a/src/app/firedancer-dev/Local.mk
+++ b/src/app/firedancer-dev/Local.mk
@@ -20,7 +20,11 @@ $(call add-objs,commands/gossip_dump,fd_firedancer_dev)
 $(call add-objs,commands/reasm,fd_firedancer_dev)
 
 ifdef FD_HAS_SSE
+# ifdef FD_HAS_BLST -- will be a required dependency soon
+ifdef FD_HAS_S2NBIGNUM
 $(call make-bin,firedancer-dev,main,fd_firedancer_dev fd_firedancer fddev_shared fdctl_shared fdctl_platform fd_discof fd_disco fd_choreo fd_flamenco fd_vinyl fd_funk fd_quic fd_tls fd_reedsol fd_waltz fd_tango fd_ballet fd_util firedancer_version,$(SECP256K1_LIBS) $(ROCKSDB_LIBS) $(OPENSSL_LIBS))
+endif
+# endif
 endif
 
 $(call make-integration-test,test_firedancer_dev,tests/test_firedancer_dev,fd_firedancer_dev fd_firedancer fddev_shared fdctl_shared fdctl_platform fd_discof fd_disco fd_choreo fd_flamenco fd_vinyl fd_funk fd_quic fd_tls fd_reedsol fd_waltz fd_tango fd_ballet fd_util firedancer_version, $(SECP256K1_LIBS) $(ROCKSDB_LIBS) $(OPENSSL_LIBS))

--- a/src/app/firedancer/Local.mk
+++ b/src/app/firedancer/Local.mk
@@ -46,7 +46,11 @@ $(call make-lib,firedancer_version)
 $(call add-objs,version,firedancer_version)
 
 ifdef FD_HAS_SSE
+# ifdef FD_HAS_BLST -- will be a required dependency soon
+ifdef FD_HAS_S2NBIGNUM
 $(call make-bin,firedancer,main,fd_firedancer fdctl_shared fdctl_platform fd_discof fd_disco fd_choreo fd_flamenco fd_vinyl fd_funk fd_quic fd_tls fd_reedsol fd_waltz fd_tango fd_ballet fd_util firedancer_version,$(SECP256K1_LIBS) $(OPENSSL_LIBS))
+endif
+# endif
 endif
 
 else

--- a/src/ballet/secp256k1/Local.mk
+++ b/src/ballet/secp256k1/Local.mk
@@ -1,3 +1,4 @@
+ifdef FD_HAS_S2NBIGNUM
 $(call add-hdrs,fd_secp256k1.h)
 $(call add-objs,fd_secp256k1,fd_ballet)
 $(call make-unit-test,test_secp256k1,test_secp256k1,fd_ballet fd_util)
@@ -7,3 +8,4 @@ $(call make-fuzz-test,fuzz_secp256k1_recover,fuzz_secp256k1_recover,fd_ballet fd
 endif
 
 $(call run-unit-test,test_secp256k1)
+endif

--- a/src/ballet/secp256r1/Local.mk
+++ b/src/ballet/secp256r1/Local.mk
@@ -1,4 +1,6 @@
+ifdef FD_HAS_S2NBIGNUM
 $(call add-hdrs,fd_secp256r1.h)
 $(call add-objs,fd_secp256r1,fd_ballet)
 $(call make-unit-test,test_secp256r1,test_secp256r1,fd_ballet fd_util)
 $(call run-unit-test,test_secp256r1)
+endif

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -35,6 +35,7 @@
 #include "../../flamenco/runtime/fd_genesis_parse.h"
 #include "../../flamenco/fd_flamenco_base.h"
 #include "../../flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.h"
+#include "../../flamenco/runtime/program/fd_precompiles.h"
 
 #include "../../flamenco/runtime/tests/fd_dump_pb.h"
 
@@ -2888,6 +2889,9 @@ unprivileged_init( fd_topo_t *      topo,
                                                                 FD_MHIST_SECONDS_MAX( REPLAY, ROOT_SLOT_DURATION_SECONDS ) ) );
   fd_histf_join( fd_histf_new( ctx->metrics.root_account_dur,   FD_MHIST_SECONDS_MIN( REPLAY, ROOT_ACCOUNT_DURATION_SECONDS ),
                                                                 FD_MHIST_SECONDS_MAX( REPLAY, ROOT_ACCOUNT_DURATION_SECONDS ) ) );
+
+  /* Ensure precompiles are available, crash fast otherwise */
+  fd_precompiles();
 
   ulong scratch_top = FD_SCRATCH_ALLOC_FINI( l, 1UL );
   if( FD_UNLIKELY( scratch_top > (ulong)scratch + scratch_footprint( tile ) ) )

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -37,14 +37,6 @@
 #include <unistd.h>  /* write(3) */
 #include <time.h>
 
-struct fd_native_prog_info {
-  fd_pubkey_t key;
-  fd_exec_instr_fn_t fn;
-  uchar is_bpf_loader;
-  ulong feature_enable_offset; /* offset to the feature that enables this program, if any */
-};
-typedef struct fd_native_prog_info fd_native_prog_info_t;
-
 /* https://github.com/anza-xyz/agave/blob/v2.2.13/svm-rent-collector/src/rent_state.rs#L5-L15 */
 struct fd_rent_state {
   uint  discriminant;
@@ -88,36 +80,6 @@ typedef struct fd_rent_state fd_rent_state_t;
 
 #include "../../util/tmpl/fd_map_perfect.c"
 #undef PERFECT_HASH
-
-#define MAP_PERFECT_NAME fd_native_precompile_program_fn_lookup_tbl
-#define MAP_PERFECT_LG_TBL_SZ 2
-#define MAP_PERFECT_T fd_native_prog_info_t
-#define MAP_PERFECT_HASH_C 63546U
-#define MAP_PERFECT_KEY key.uc
-#define MAP_PERFECT_KEY_T fd_pubkey_t const *
-#define MAP_PERFECT_ZERO_KEY  (0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0)
-#define MAP_PERFECT_COMPLEX_KEY 1
-#define MAP_PERFECT_KEYS_EQUAL(k1,k2) (!memcmp( (k1), (k2), 32UL ))
-
-#define PERFECT_HASH( u ) (((MAP_PERFECT_HASH_C*(u))>>30)&0x3U)
-
-#define MAP_PERFECT_HASH_PP( a00,a01,a02,a03,a04,a05,a06,a07,a08,a09,a10,a11,a12,a13,a14,a15, \
-                             a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31) \
-                                          PERFECT_HASH( (a00 | (a01<<8)) )
-#define MAP_PERFECT_HASH_R( ptr ) PERFECT_HASH( fd_uint_load_2( (uchar const *)ptr ) )
-
-#define MAP_PERFECT_0      ( ED25519_SV_PROG_ID      ), .fn = fd_precompile_ed25519_verify
-#define MAP_PERFECT_1      ( KECCAK_SECP_PROG_ID     ), .fn = fd_precompile_secp256k1_verify
-#define MAP_PERFECT_2      ( SECP256R1_PROG_ID       ), .fn = fd_precompile_secp256r1_verify
-
-#include "../../util/tmpl/fd_map_perfect.c"
-#undef PERFECT_HASH
-
-fd_exec_instr_fn_t
-fd_executor_lookup_native_precompile_program( fd_pubkey_t const * pubkey ) {
-  const fd_native_prog_info_t null_function = {0};
-  return fd_native_precompile_program_fn_lookup_tbl_query( pubkey, &null_function )->fn;
-}
 
 uchar
 fd_executor_pubkey_is_bpf_loader( fd_pubkey_t const * pubkey ) {

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -31,9 +31,6 @@ FD_PROTOTYPES_BEGIN
 
 typedef int (* fd_exec_instr_fn_t)( fd_exec_instr_ctx_t * ctx );
 
-fd_exec_instr_fn_t
-fd_executor_lookup_native_precompile_program( fd_pubkey_t const * pubkey );
-
 /* Returns 1 if the given pubkey matches one of the BPF loader v1/v2/v3/v4
    program IDs, and 0 otherwise. */
 uchar

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -23,6 +23,7 @@
 
 #include "program/fd_stake_program.h"
 #include "program/fd_builtin_programs.h"
+#include "program/fd_precompiles.h"
 #include "program/fd_program_util.h"
 
 #include "sysvar/fd_sysvar_clock.h"
@@ -421,10 +422,10 @@ fd_apply_builtin_program_feature_transitions( fd_bank_t *               bank,
   }
 
   /* https://github.com/anza-xyz/agave/blob/c1080de464cfb578c301e975f498964b5d5313db/runtime/src/bank.rs#L6795-L6805 */
-  fd_precompile_program_t const * precompiles = fd_precompiles();
-  for( ulong i=0UL; i<fd_num_precompiles(); i++ ) {
-    if( precompiles[i].feature_offset != NO_ENABLE_FEATURE_ID && FD_FEATURE_JUST_ACTIVATED_OFFSET( bank, precompiles[i].feature_offset ) ) {
-      fd_write_builtin_account( bank, accdb, xid, capture_ctx, *precompiles[i].pubkey, "", 0 );
+  for( fd_precompile_program_t const * precompiles = fd_precompiles(); precompiles->verify_fn; precompiles++ ) {
+    if( precompiles->feature_offset != NO_ENABLE_FEATURE_ID &&
+        FD_FEATURE_JUST_ACTIVATED_OFFSET( bank, precompiles->feature_offset ) ) {
+      fd_write_builtin_account( bank, accdb, xid, capture_ctx, *precompiles->pubkey, "", 0 );
     }
   }
 }

--- a/src/flamenco/runtime/program/fd_builtin_programs.c
+++ b/src/flamenco/runtime/program/fd_builtin_programs.c
@@ -26,13 +26,6 @@
         builtin_program_id                                                                                                     \
     }
 
-#define PRECOMPILE(program_id, feature_offset, verify_fn) \
-    {                                                     \
-        program_id,                                       \
-        feature_offset,                                   \
-        verify_fn                                         \
-    }
-
 /* Core BPF migration configs */
 static const fd_core_bpf_migration_config_t BUILTIN_TO_CORE_BPF_STAKE_PROGRAM_CONFIG = {
     &fd_solana_stake_program_buffer_address,
@@ -104,23 +97,12 @@ static const fd_core_bpf_migration_config_t * const MIGRATE_STATELESS_TO_CORE_BP
 #define FEATURE_PROGRAM_BUILTIN               STATELESS_BUILTIN(&fd_solana_feature_program_id,  MIGRATE_STATELESS_TO_CORE_BPF_FEATURE_GATE_PROGRAM_CONFIG)
 #define SLASHING_PROGRAM_BUILTIN              STATELESS_BUILTIN(&fd_solana_slashing_program_id, MIGRATE_STATELESS_TO_CORE_BPF_SLASHING_PROGRAM_CONFIG)
 
-#define SECP256R1_PROGRAM_PRECOMPILE          PRECOMPILE(&fd_solana_secp256r1_program_id,          offsetof(fd_features_t, enable_secp256r1_precompile), fd_precompile_secp256r1_verify)
-#define KECCAK_SECP_PROGRAM_PRECOMPILE        PRECOMPILE(&fd_solana_keccak_secp_256k_program_id,   NO_ENABLE_FEATURE_ID,                                 fd_precompile_secp256k1_verify)
-#define ED25519_SV_PROGRAM_PRECOMPILE         PRECOMPILE(&fd_solana_ed25519_sig_verify_program_id, NO_ENABLE_FEATURE_ID,                                 fd_precompile_ed25519_verify)
-
 /* https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank/builtins/mod.rs#L133-L143 */
 static const fd_stateless_builtin_program_t stateless_programs_builtins[] = {
     FEATURE_PROGRAM_BUILTIN,
     SLASHING_PROGRAM_BUILTIN
 };
 #define STATELESS_BUILTINS_COUNT (sizeof(stateless_programs_builtins) / sizeof(fd_stateless_builtin_program_t))
-
-static const fd_precompile_program_t precompiles[] = {
-    SECP256R1_PROGRAM_PRECOMPILE,
-    KECCAK_SECP_PROGRAM_PRECOMPILE,
-    ED25519_SV_PROGRAM_PRECOMPILE
-};
-#define PRECOMPILE_PROGRAMS_COUNT (sizeof(precompiles) / sizeof(fd_precompile_program_t))
 
 /* https://github.com/anza-xyz/agave/blob/v2.1.0/runtime/src/bank/builtins/mod.rs#L34-L131 */
 static fd_builtin_program_t const builtin_programs[] = {
@@ -277,16 +259,6 @@ fd_stateless_builtins( void ) {
 ulong
 fd_num_stateless_builtins( void ) {
   return STATELESS_BUILTINS_COUNT;
-}
-
-fd_precompile_program_t const *
-fd_precompiles( void ) {
-  return precompiles;
-}
-
-ulong
-fd_num_precompiles( void ) {
-  return PRECOMPILE_PROGRAMS_COUNT;
 }
 
 uchar

--- a/src/flamenco/runtime/program/fd_builtin_programs.h
+++ b/src/flamenco/runtime/program/fd_builtin_programs.h
@@ -5,7 +5,6 @@
 #include "../fd_bank.h"
 #include "../fd_system_ids_pp.h"
 
-#define NO_ENABLE_FEATURE_ID ULONG_MAX
 #define FD_CORE_BPF_MIGRATION_TARGET_BUILTIN   (0)
 #define FD_CORE_BPF_MIGRATION_TARGET_STATELESS (1)
 
@@ -40,13 +39,6 @@ struct fd_stateless_builtin_program {
   fd_core_bpf_migration_config_t const * core_bpf_migration_config;
 };
 typedef struct fd_stateless_builtin_program fd_stateless_builtin_program_t;
-
-struct fd_precompile_program {
-  fd_pubkey_t const * pubkey;
-  ulong               feature_offset;
-  int                 (*verify_fn)(fd_exec_instr_ctx_t*);
-};
-typedef struct fd_precompile_program fd_precompile_program_t;
 
 struct fd_tmp_account {
   fd_pubkey_t       addr;
@@ -101,12 +93,6 @@ fd_is_migrating_builtin_program( fd_bank_t const *   bank,
 
 uchar
 fd_is_non_migrating_builtin_program( fd_pubkey_t const * pubkey );
-
-fd_precompile_program_t const *
-fd_precompiles( void );
-
-ulong
-fd_num_precompiles( void );
 
 void
 fd_migrate_builtin_to_core_bpf( fd_bank_t *                            bank,

--- a/src/flamenco/runtime/program/fd_precompiles.h
+++ b/src/flamenco/runtime/program/fd_precompiles.h
@@ -1,6 +1,17 @@
 #ifndef HEADER_fd_src_flamenco_runtime_program_fd_precompiles_h
 #define HEADER_fd_src_flamenco_runtime_program_fd_precompiles_h
 
+/* fd_precompiles.h provides APIs for "precompiled"-type builtin
+   programs.  These programs undergo special treatment during cost
+   tracking and transaction execution.
+
+   The current set of precompiles requires external cryptography code
+   in Firedancer (installed via ./deps.sh), namely s2n-bignum.  In some
+   testing scenarios, the developer may not have this dependency
+   installed because it won't be used.  To avoid link errors in such a
+   situation, precompiles are resolved at runtime (as opposed to
+   compile-time). */
+
 #include "../fd_runtime.h"
 #include "../context/fd_exec_instr_ctx.h"
 
@@ -17,7 +28,41 @@
 #define FD_EXECUTOR_PRECOMPILE_ERR_DATA_OFFSET                   ( 3 )
 #define FD_EXECUTOR_PRECOMPILE_ERR_INSTR_DATA_SIZE               ( 4 )
 
+#define NO_ENABLE_FEATURE_ID ULONG_MAX
+
+struct fd_precompile_program {
+  fd_pubkey_t const * pubkey;
+  ulong               feature_offset;
+  int                 (* verify_fn )( fd_exec_instr_ctx_t * ctx );
+};
+typedef struct fd_precompile_program fd_precompile_program_t;
+
+struct fd_native_prog_info {
+  fd_pubkey_t        key;
+  fd_exec_instr_fn_t fn;
+  uchar              is_bpf_loader;
+  ulong              feature_enable_offset; /* offset to the feature that enables this program, if any */
+};
+typedef struct fd_native_prog_info fd_native_prog_info_t;
+
 FD_PROTOTYPES_BEGIN
+
+/* High-level precompile API
+
+   These symbols are always available.  If precompiles are requested but
+   the user has not installed them / does not have necessary deps,
+   terminates with FD_LOG_ERR. */
+
+fd_precompile_program_t const *
+fd_precompiles( void );
+
+fd_exec_instr_fn_t
+fd_executor_lookup_native_precompile_program( fd_pubkey_t const * pubkey );
+
+/* Raw precompile symbols
+
+   These might not be linked into the binary depending on build
+   configuration. */
 
 /* fd_precompile_ed25519_verify is the instruction processing entrypoint
    for the Ed25519 precompile. */

--- a/src/flamenco/runtime/program/fd_vote_program.c
+++ b/src/flamenco/runtime/program/fd_vote_program.c
@@ -758,6 +758,16 @@ process_new_vote_state( fd_exec_instr_ctx_t *       ctx,
   return FD_EXECUTOR_INSTR_SUCCESS;
 }
 
+__attribute__((weak)) int
+fd_bls12_381_proof_of_possession_verify( uchar const msg[],
+                                         ulong       msg_sz,
+                                         uchar const proof[ 96 ],
+                                         uchar const public_key[ 48 ] ) {
+  (void)msg; (void)msg_sz; (void)proof; (void)public_key;
+  FD_LOG_ERR(( "This build does not include BLST, which is required to run a validator.\n"
+               "To install BLST, re-run ./deps.sh, make distclean, and make -j" ));
+}
+
 /* https://github.com/firedancer-io/agave/blob/v4.0.0-prerelease/programs/vote/src/vote_state/mod.rs#L1053-L1102 */
 #define FD_VOTE_BLS_MSG_SZ ( 9 + 32 + 48 )
 static int

--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -7,6 +7,7 @@
 #include "../fd_runtime.h"
 #include "../program/fd_bpf_loader_program.h"
 #include "../program/fd_loader_v4_program.h"
+#include "../program/fd_precompiles.h"
 #include "../fd_system_ids.h"
 #include "../../accdb/fd_accdb_admin_v1.h"
 #include "../../log_collector/fd_log_collector.h"

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -4,6 +4,7 @@
 #include "../fd_runtime.h"
 #include "../fd_executor.h"
 #include "../program/fd_builtin_programs.h"
+#include "../program/fd_precompiles.h"
 #include "../sysvar/fd_sysvar_clock.h"
 #include "../sysvar/fd_sysvar_epoch_schedule.h"
 #include "../sysvar/fd_sysvar_recent_hashes.h"

--- a/src/flamenco/vm/syscall/fd_vm_syscall.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall.c
@@ -92,7 +92,12 @@ fd_vm_syscall_register_slot( fd_sbpf_syscalls_t *      syscalls,
   REGISTER( "sol_try_find_program_address",          fd_vm_syscall_sol_try_find_program_address );
   REGISTER( "sol_sha256",                            fd_vm_syscall_sol_sha256 );
   REGISTER( "sol_keccak256",                         fd_vm_syscall_sol_keccak256 );
+# if FD_HAS_S2NBIGNUM
   REGISTER( "sol_secp256k1_recover",                 fd_vm_syscall_sol_secp256k1_recover );
+# else
+  FD_LOG_ERR(( "This build does not include s2n-bignum, which is required to run a validator.\n"
+               "To install s2n-bignum, re-run ./deps.sh, make distclean, and make -j" ));
+# endif
 
   if( enable_blake3_syscall )
     REGISTER( "sol_blake3",                          fd_vm_syscall_sol_blake3 );

--- a/src/flamenco/vm/syscall/fd_vm_syscall_crypto.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_crypto.c
@@ -389,6 +389,8 @@ soft_error:
   return FD_VM_SUCCESS; /* Ok(1) == error */
 }
 
+#if FD_HAS_S2NBIGNUM
+
 int
 fd_vm_syscall_sol_secp256k1_recover( /**/            void *  _vm,
                                      /**/            ulong   hash_vaddr,
@@ -463,3 +465,5 @@ fd_vm_syscall_sol_secp256k1_recover( /**/            void *  _vm,
   *_ret = 0UL;
   return FD_VM_SUCCESS;
 }
+
+#endif /* FD_HAS_S2NBIGNUM */


### PR DESCRIPTION
- Fixes build without ./deps.sh (useful for various security tools)
- Allows lots more compile units to build that don't depend on
  cryptography directly
- Resolve builtin programs at runtime in case s2n-bignum is missing
- Use a weak symbol as a fallback in case blst is missing
- Guard firedancer and firedancer-dev build targets behind
  FD_HAS_S2NBIGNUM
