### PR TITLE
vm: correct bls curve opcode

### DIFF
--- a/src/flamenco/vm/syscall/fd_vm_syscall.h
+++ b/src/flamenco/vm/syscall/fd_vm_syscall.h
@@ -907,12 +907,12 @@ FD_VM_SYSCALL_DECL( sol_secp256k1_recover );
 
 #define FD_VM_SYSCALL_SOL_CURVE_CURVE25519_EDWARDS   ( 0UL        ) /* ed25519 */
 #define FD_VM_SYSCALL_SOL_CURVE_CURVE25519_RISTRETTO ( 1UL        ) /* ristretto255 */
-#define FD_VM_SYSCALL_SOL_CURVE_BLS12_381_BE         ( 4UL        ) /* bls12-381 big endian */
-#define FD_VM_SYSCALL_SOL_CURVE_BLS12_381_LE         ( 4UL | 0x80 ) /* bls12-381 little endian */
-#define FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G1_BE      ( 5UL        ) /* bls12-381 G1 big endian */
-#define FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G1_LE      ( 5UL | 0x80 ) /* bls12-381 G1 little endian */
-#define FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G2_BE      ( 6UL        ) /* bls12-381 G2 big endian */
-#define FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G2_LE      ( 6UL | 0x80 ) /* bls12-381 G2 little endian */
+#define FD_VM_SYSCALL_SOL_CURVE_BLS12_381_BE         ( 4UL | 0x80 ) /* bls12-381 big endian */
+#define FD_VM_SYSCALL_SOL_CURVE_BLS12_381_LE         ( 4UL        ) /* bls12-381 little endian */
+#define FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G1_BE      ( 5UL | 0x80 ) /* bls12-381 G1 big endian */
+#define FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G1_LE      ( 5UL        ) /* bls12-381 G1 little endian */
+#define FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G2_BE      ( 6UL | 0x80 ) /* bls12-381 G2 big endian */
+#define FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G2_LE      ( 6UL        ) /* bls12-381 G2 little endian */
 
 /* FD_VM_SYSCALL_SOL_CURVE_{...} specifies the curve operation */
 

--- a/src/flamenco/vm/syscall/fd_vm_syscall_curve.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_curve.c
@@ -53,7 +53,7 @@ fd_vm_syscall_sol_curve_validate_point( /**/            void *  _vm,
   case FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G1_BE:
   case FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G1_LE: {
 
-    int big_endian = ( curve_id & 0x80 ) ? 0 : 1;
+    int big_endian = ( curve_id & 0x80 ) ? 1 : 0;
     FD_VM_CU_UPDATE( vm, FD_VM_CURVE_BLS12_381_G1_VALIDATE_COST );
     point = FD_VM_MEM_HADDR_LD( vm, point_addr, FD_VM_ALIGN_RUST_POD_U8_ARRAY, FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G1_POINT_SZ );
     ret = (ulong)!fd_bls12_381_g1_validate_syscall( point, big_endian ); /* 0 if valid point, 1 if not */
@@ -62,7 +62,7 @@ fd_vm_syscall_sol_curve_validate_point( /**/            void *  _vm,
   case FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G2_BE:
   case FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G2_LE: {
 
-    int big_endian = ( curve_id & 0x80 ) ? 0 : 1;
+    int big_endian = ( curve_id & 0x80 ) ? 1 : 0;
     FD_VM_CU_UPDATE( vm, FD_VM_CURVE_BLS12_381_G2_VALIDATE_COST );
     point = FD_VM_MEM_HADDR_LD( vm, point_addr, FD_VM_ALIGN_RUST_POD_U8_ARRAY, FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G2_POINT_SZ );
     ret = (ulong)!fd_bls12_381_g2_validate_syscall( point, big_endian ); /* 0 if valid point, 1 if not */
@@ -244,7 +244,7 @@ fd_vm_syscall_sol_curve_group_op( void *  _vm,
   uchar const * inputR = FD_VM_MEM_HADDR_LD( vm, right_input_addr, FD_VM_ALIGN_RUST_POD_U8_ARRAY, inputR_sz );
 
 #if FD_HAS_BLST
-  int big_endian = ( curve_id & 0x80 ) ? 0 : 1;
+  int big_endian = ( curve_id & 0x80 ) ? 1 : 0;
 #endif
 
   switch( MATCH_ID_OP( curve_id, group_op ) ) {
@@ -666,7 +666,7 @@ fd_vm_syscall_sol_curve_decompress( /**/            void *  _vm,
   fd_vm_t * vm = (fd_vm_t *)_vm;
   ulong     ret = 1UL; /* by default return Ok(1) == error */
 
-  int big_endian = ( curve_id & 0x80 ) ? 0 : 1;
+  int big_endian = ( curve_id & 0x80 ) ? 1 : 0;
 
   uchar const * point = NULL;
   switch( curve_id ) {
@@ -719,7 +719,7 @@ fd_vm_syscall_sol_curve_pairing_map( /**/            void *  _vm,
   fd_vm_t * vm = (fd_vm_t *)_vm;
   ulong     ret = 1UL; /* by default return Ok(1) == error */
 
-  int big_endian = ( curve_id & 0x80 ) ? 0 : 1;
+  int big_endian = ( curve_id & 0x80 ) ? 1 : 0;
 
   switch( curve_id ) {
 


### PR DESCRIPTION
Unlike alt_bn128 little-endian, the top bit is set for big-endian curve operations when dealing with sol_curve_group_op. This was done in order to retain consistency within the specific syscall, even if it is backwards to what alt_bn128 does.