### PR TITLE
chore: move magic checks before member accesses

### DIFF
--- a/src/discof/replay/fd_sched.c
+++ b/src/discof/replay/fd_sched.c
@@ -643,10 +643,9 @@ fd_sched_join( void * mem ) {
   }
 
   fd_sched_t * sched         = (fd_sched_t *)mem;
+  FD_TEST( sched->canary==FD_SCHED_MAGIC );
   ulong        depth         = sched->depth;
   ulong        block_cnt_max = sched->block_cnt_max;
-
-  FD_TEST( sched->canary==FD_SCHED_MAGIC );
 
   FD_SCRATCH_ALLOC_INIT( l, mem );
   /*           */ FD_SCRATCH_ALLOC_APPEND( l, fd_sched_align(),          sizeof(fd_sched_t)                         );

--- a/src/flamenco/runtime/fd_acc_pool.c
+++ b/src/flamenco/runtime/fd_acc_pool.c
@@ -90,8 +90,6 @@ fd_acc_pool_new( void * shmem,
 fd_acc_pool_t *
 fd_acc_pool_join( void * mem ) {
 
-  fd_acc_pool_t * acc_pool = (fd_acc_pool_t *)mem;
-
   if( FD_UNLIKELY( !mem ) ) {
     FD_LOG_WARNING(( "NULL mem" ));
     return NULL;
@@ -99,6 +97,13 @@ fd_acc_pool_join( void * mem ) {
 
   if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)mem, fd_acc_pool_align() ) ) ) {
     FD_LOG_WARNING(( "misaligned mem" ));
+    return NULL;
+  }
+
+  fd_acc_pool_t * acc_pool = (fd_acc_pool_t *)mem;
+
+  if( FD_UNLIKELY( FD_VOLATILE_CONST( acc_pool->magic )!=FD_ACC_POOL_MAGIC ) ) {
+    FD_LOG_WARNING(( "Invalid acc pool magic" ));
     return NULL;
   }
 
@@ -114,11 +119,6 @@ fd_acc_pool_join( void * mem ) {
       FD_LOG_WARNING(( "Invalid acc entry magic" ));
       return NULL;
     }
-  }
-
-  if( FD_UNLIKELY( acc_pool->magic!=FD_ACC_POOL_MAGIC ) ) {
-    FD_LOG_WARNING(( "Invalid acc pool magic" ));
-    return NULL;
   }
 
   return acc_pool;


### PR DESCRIPTION
really a nit that doesn't matter, but kinda more correct code to check the magic, that is supposed to prevent type confusions, before assuming the layout