### PR TITLE
ghost: fix stale vote filtering

### DIFF
--- a/src/choreo/ghost/fd_ghost.c
+++ b/src/choreo/ghost/fd_ghost.c
@@ -338,6 +338,7 @@ fd_ghost_count_vote( fd_ghost_t *        ghost,
   }
   vtr->prev_block_id = blk->id;
   vtr->prev_stake    = stake;
+  vtr->prev_slot     = slot;
 }
 
 void


### PR DESCRIPTION
stale-vote filtering uses slot > vtr->prev_slot, but prev_slot was never written