### PR TITLE
app: validate repair tile link count limits

### DIFF
--- a/src/app/shared/fd_config.c
+++ b/src/app/shared/fd_config.c
@@ -454,6 +454,9 @@ fd_config_fill( fd_config_t * config,
   }                                                    \
 } while(0)
 
+#define FD_REPAIR_MAX_SHRED_LINK_CNT (16U)
+#define FD_REPAIR_MAX_SIGN_LINK_CNT  (16U)
+
 static void
 fd_config_validatef( fd_configf_t const * config ) {
   CFG_HAS_NON_ZERO( layout.sign_tile_count );
@@ -533,6 +536,15 @@ fd_config_validate( fd_config_t const * config ) {
   CFG_HAS_NON_ZERO ( layout.quic_tile_count );
   CFG_HAS_NON_ZERO ( layout.verify_tile_count );
   CFG_HAS_NON_ZERO ( layout.shred_tile_count );
+  if( FD_UNLIKELY( config->is_firedancer ) ) {
+    /* repair tile has fixed-size arrays for these links */
+    if( FD_UNLIKELY( config->layout.shred_tile_count > FD_REPAIR_MAX_SHRED_LINK_CNT ) ) {
+      FD_LOG_ERR(( "`layout.shred_tile_count` must be <= %u", FD_REPAIR_MAX_SHRED_LINK_CNT ));
+    }
+    if( FD_UNLIKELY( config->firedancer.layout.sign_tile_count > (FD_REPAIR_MAX_SIGN_LINK_CNT + 1U) ) ) {
+      FD_LOG_ERR(( "`firedancer.layout.sign_tile_count` must be <= %u", FD_REPAIR_MAX_SIGN_LINK_CNT + 1U ));
+    }
+  }
 
   CFG_HAS_NON_EMPTY( hugetlbfs.mount_path );
   CFG_HAS_NON_EMPTY( hugetlbfs.max_page_size );
@@ -599,6 +611,8 @@ fd_config_validate( fd_config_t const * config ) {
 #undef CFG_HAS_NON_EMPTY
 #undef CFG_HAS_NON_ZERO
 #undef CFG_HAS_POW2
+#undef FD_REPAIR_MAX_SHRED_LINK_CNT
+#undef FD_REPAIR_MAX_SIGN_LINK_CNT
 
 void
 fd_config_load( int           is_firedancer,


### PR DESCRIPTION
Reject firedancer configs with shred_tile_count>16 or sign_tile_count>17 to prevent repair init out-of-bounds writes. No really a likely real world config, but we should not oob in any case.