### PR TITLE
bn254: fix g1/g2 add syscall benchmarks

### DIFF
--- a/src/ballet/bn254/test_bn254.c
+++ b/src/ballet/bn254/test_bn254.c
@@ -143,7 +143,7 @@ int main( int     argc,
       ulong iter = 10000UL;
       long dt = fd_log_wallclock();
       for( ulong rem=iter; rem; rem-- ) {
-        fd_bn254_g1_add_syscall( res, in, 64, 0 /*LE*/ );
+        fd_bn254_g1_add_syscall( res, in, 128, 0 /*LE*/ );
       }
       dt = fd_log_wallclock() - dt;
       log_bench( "fd_bn254_g1_add_syscall", iter, dt );
@@ -214,10 +214,10 @@ int main( int     argc,
     }
 
     {
-      ulong iter = 10000000UL;
+      ulong iter = 10000UL;
       long dt = fd_log_wallclock();
       for( ulong rem=iter; rem; rem-- ) {
-        fd_bn254_g2_add_syscall( res, in, 128, 0 /*LE*/ );
+        fd_bn254_g2_add_syscall( res, in, 256, 0 /*LE*/ );
       }
       dt = fd_log_wallclock() - dt;
       log_bench( "fd_bn254_g2_add_syscall", iter, dt );
@@ -360,7 +360,7 @@ int main( int     argc,
     }
 
     {
-      ulong iter = 1000UL;
+      ulong iter = 10000UL;
       long dt = fd_log_wallclock();
       for( ulong rem=iter; rem; rem-- ) {
         fd_bn254_g1_scalar_mul_syscall( res, in, 96, 0 /*LE*/ );


### PR DESCRIPTION
The syscalls expect the input size of {128,256}, not {64,128}. This was making the inner function to fail immediately thus not giving accurate results.