### PR TITLE
restore: enforce max_accounts

### DIFF
--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -1573,6 +1573,7 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
   } else if( FD_UNLIKELY( !strcmp( tile->name, "snapwm" ) ) ) {
 
     strcpy( tile->snapwm.vinyl_path, config->paths.accounts );
+    tile->snapwm.max_accounts = config->firedancer.accounts.max_accounts;
     tile->snapwm.vinyl_meta_map_obj_id  = fd_pod_query_ulong( config->topo.props, "accdb.meta_map",  ULONG_MAX );
     tile->snapwm.vinyl_meta_pool_obj_id = fd_pod_query_ulong( config->topo.props, "accdb.meta_pool", ULONG_MAX );
 

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -595,6 +595,7 @@ struct fd_topo_tile {
       ulong snapwr_depth;
       char  vinyl_path[ PATH_MAX ];
       uint  lthash_disabled : 1;
+      ulong max_accounts;
     } snapwm;
 
     struct {

--- a/src/discof/restore/fd_snapwm_tile_private.h
+++ b/src/discof/restore/fd_snapwm_tile_private.h
@@ -78,6 +78,7 @@ struct fd_snapwm_tile {
 
     ulong pair_cnt;
     ulong full_pair_cnt;
+    ulong pair_cnt_max;
 
     /* Vinyl in either io_wd or io_mm mode */
     fd_vinyl_io_t * io;

--- a/src/discof/restore/fd_snapwm_tile_vinyl.c
+++ b/src/discof/restore/fd_snapwm_tile_vinyl.c
@@ -207,7 +207,8 @@ fd_snapwm_vinyl_unprivileged_init( fd_snapwm_tile_t * ctx,
   ctx->vinyl.duplicate_accounts_batch_sz  = 0UL;
   ctx->vinyl.duplicate_accounts_batch_cnt = 0UL;
 
-  ctx->vinyl.pair_cnt = 0UL;
+  ctx->vinyl.pair_cnt     = 0UL;
+  ctx->vinyl.pair_cnt_max = tile->snapwm.max_accounts;
 
   fd_lthash_adder_new( &ctx->vinyl.adder );
   fd_lthash_zero( &ctx->vinyl.running_lthash );
@@ -412,7 +413,9 @@ fd_snapwm_vinyl_txn_commit( fd_snapwm_tile_t * ctx,
         }
         ctx->metrics.accounts_replaced++;
       } else {
-        ctx->vinyl.pair_cnt++;
+        if( FD_UNLIKELY( ctx->vinyl.pair_cnt++ > ctx->vinyl.pair_cnt_max ) ) {
+          FD_LOG_ERR(( "failed to load snapshot: exceeded [accounts.max_accounts] (%lu)", ctx->vinyl.pair_cnt_max ));
+        }
       }
 
       /* Overwrite map entry */
@@ -585,7 +588,9 @@ fd_snapwm_vinyl_process_account( fd_snapwm_tile_t *  ctx,
         }
         ctx->metrics.accounts_replaced++;
       } else {
-        ctx->vinyl.pair_cnt++;
+        if( FD_UNLIKELY( ctx->vinyl.pair_cnt++ > ctx->vinyl.pair_cnt_max ) ) {
+          FD_LOG_ERR(( "failed to load snapshot: exceeded [accounts.max_accounts] (%lu)", ctx->vinyl.pair_cnt_max ));
+        }
       }
 
       fd_snapin_vinyl_pair_info_update_recovery_seq( &phdr.info, recovery_seq );


### PR DESCRIPTION
Fixes a bug where a snapshot load stalls for a long time when the
vinyl_meta hash map fills up.  (Linear probed hash map insert
complexity approaches O(n) with high fill ratio, which practically
takes minutes)  Instead crash fast.

Closes #8501
