### PR TITLE
replay: prevent dangling temporary

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -1496,9 +1496,10 @@ on_snapshot_message( fd_replay_tile_t *  ctx,
 
     ulong snapshot_slot = fd_bank_slot_get( bank );
 
-    if( FD_UNLIKELY( ctx->wfs_enabled && memcmp( ctx->expected_bank_hash.uc, fd_bank_bank_hash_get( bank ).uc, sizeof(fd_hash_t) ) ) ) {
+    fd_hash_t bank_hash = fd_bank_bank_hash_get( bank );
+    if( FD_UNLIKELY( ctx->wfs_enabled && memcmp( ctx->expected_bank_hash.uc, bank_hash.uc, sizeof(fd_hash_t) ) ) ) {
       FD_BASE58_ENCODE_32_BYTES( ctx->expected_bank_hash.uc, expected_bank_hash_cstr );
-      FD_BASE58_ENCODE_32_BYTES( fd_bank_bank_hash_get( bank ).uc, actual_bank_hash_cstr );
+      FD_BASE58_ENCODE_32_BYTES( bank_hash.uc,                 actual_bank_hash_cstr );
       FD_LOG_ERR(( "[consensus.wait_for_supermajority_with_bank_hash] expected_bank_hash=%s does not match snapshot slot"
                    "=%lu bank_hash=%s. If you are loading a snapshot from the network, check that the slot matches the "
                    "cluster restart slot. ", expected_bank_hash_cstr, snapshot_slot, actual_bank_hash_cstr ));


### PR DESCRIPTION
Appease clang:
"temporary whose address is used as value of local variable 'b' will be destroyed at the end of the full-expression" aka
const * b = (fd_bank_bank_hash_get( bank ).uc);
after expanding the FD_BASE58_ENCODE... macro