### PR TITLE
codeql: ban usage of `explicit_bzero` and `memset_explicit`

### DIFF
--- a/contrib/codeql/nightly/BanExplicitBzero.ql
+++ b/contrib/codeql/nightly/BanExplicitBzero.ql
@@ -4,12 +4,15 @@
  * @kind problem
  * @id asymmetric-research/ban-explicit-bzero
  * @tags maintainability
+ * @precision high
  * @severity warning
  */
 
 import cpp
+import filter
 
 from FunctionCall fc
 where fc.getTarget().getName() = ["explicit_bzero", "memset_explicit"]
+  and included(fc.getLocation())
 select fc,
   "Usage of `" + fc.getTarget().getName() + "` is not allowed. Use `fd_memzero_explicit` instead."


### PR DESCRIPTION
Quick 2 minutes query to enforce that `fd_memzero_explicit` is used:
https://github.com/firedancer-io/firedancer/pull/8517