### PR TITLE
sched: reduce footprint

### DIFF
--- a/src/discof/replay/fd_sched.h
+++ b/src/discof/replay/fd_sched.h
@@ -229,7 +229,9 @@ fd_sched_fec_can_ingest( fd_sched_t * sched, fd_sched_fec_t * fec );
 ulong
 fd_sched_can_ingest_cnt( fd_sched_t * sched );
 
-/* Returns 1 if sched is drained, 0 otherwise. */
+/* Returns 1 if sched is drained, 0 otherwise.  A drained scheduler will
+   not return more work.  Otherwise, next_ready will return more work,
+   so long as there are exec tiles available. */
 int
 fd_sched_is_drained( fd_sched_t * sched );
 


### PR DESCRIPTION
Pool microblock descriptors.  Reduces per-block footprint from 16 MB to 1 MB.