### PR TITLE
restore: fix accdb startup race

### DIFF
--- a/src/discof/restore/fd_snapwm_tile_vinyl.c
+++ b/src/discof/restore/fd_snapwm_tile_vinyl.c
@@ -243,8 +243,8 @@ fd_snapwm_vinyl_seccomp( ulong                out_cnt,
 
 static void
 vinyl_mm_sync( fd_snapwm_tile_t * ctx ) {
-  if( FD_UNLIKELY( 0!=msync( ctx->vinyl.bstream_mem, ctx->vinyl.bstream_sz, MS_SYNC ) ) ) {
-    FD_LOG_ERR(( "msync(addr=%p,sz=%lu,MS_SYNC) failed (%i-%s)",
+  if( FD_UNLIKELY( 0!=msync( ctx->vinyl.bstream_mem, ctx->vinyl.bstream_sz, MS_SYNC|MS_INVALIDATE ) ) ) {
+    FD_LOG_ERR(( "msync(addr=%p,sz=%lu,MS_SYNC|MS_INVALIDATE) failed (%i-%s)",
                  (void *)ctx->vinyl.bstream_mem, ctx->vinyl.bstream_sz,
                  errno, fd_io_strerror( errno ) ));
   }
@@ -518,6 +518,8 @@ fd_snapwm_vinyl_wd_fini( fd_snapwm_tile_t * ctx ) {
   ctx->vinyl.io_mm->spad_used   = 0UL;
 
   ctx->vinyl.io = ctx->vinyl.io_mm;
+
+  vinyl_mm_sync( ctx );
 }
 
 /* bstream_alloc is a faster version of fd_vinyl_io_alloc.  Indirect


### PR DESCRIPTION
Fixes a race condition where the accdb tile starts up before the
snapwm tile finishes updating the sync block.  This causes accdb
to read an old sync block missing most of the accounts.

This happens due to the following buggy sequence:
- the full snapshot load completes
- snapwm forwards "full snapshot load done" signal, but does not
  update the sync block
- snapct decides it is done and starts the shutdown procedure
  (no incremental snapshot case)
- snapct enters SHUTDOWN status
- this triggers accdb to start up
- accdb reads the sync block ... CRASH HERE ...

This patch hardens the pipeline in two ways:
- Only start up accdb once snapwm has exited its run loop (and not
  just when snapct starts shutting down)
- Always let snapwm update the sync block when transitioning
  between snapshot loading states

Closes #8539