### PR TITLE
Revert "gossip: jitter pull response values"

### DIFF
--- a/src/discof/gossip/fd_gossip_tile.c
+++ b/src/discof/gossip/fd_gossip_tile.c
@@ -233,7 +233,8 @@ static void
 handle_shred_version( fd_gossip_tile_ctx_t * ctx,
                        ulong                 sig ) {
   long now = ctx->last_wallclock + (long)((double)(fd_tickcount()-ctx->last_tickcount)/ctx->ticks_per_ns);
-  fd_gossip_set_shred_version( ctx->gossip, (ushort)sig, now );
+  ctx->my_contact_info->shred_version = (ushort)sig;
+  fd_gossip_set_my_contact_info( ctx->gossip, ctx->my_contact_info, now );
 }
 
 static void

--- a/src/flamenco/gossip/fd_crds.c
+++ b/src/flamenco/gossip/fd_crds.c
@@ -887,11 +887,6 @@ fd_crds_entry_value( fd_crds_entry_t const * entry,
   *value_sz    = entry->value_sz;
 }
 
-ulong
-fd_crds_entry_wallclock( fd_crds_entry_t const * entry ) {
-  return entry->wallclock;
-}
-
 uchar const *
 fd_crds_entry_hash( fd_crds_entry_t const * entry ) {
   return entry->value_hash;

--- a/src/flamenco/gossip/fd_crds.h
+++ b/src/flamenco/gossip/fd_crds.h
@@ -130,13 +130,6 @@ fd_crds_entry_value( fd_crds_entry_t const * entry,
                      uchar const **          value_bytes,
                      ulong *                 value_sz );
 
-/* fd_crds_entry_wallclock returns the originator's wallclock timestamp
-   for this entry, in milliseconds.  This is the wallclock the
-   originator attached when they created the CRDS value. */
-
-ulong
-fd_crds_entry_wallclock( fd_crds_entry_t const * entry );
-
 /* fd_crds_entry_hash returns a pointer to the 32b sha256 hash of the
    entry's value hash. This is used for constructing a bloom filter. */
 

--- a/src/flamenco/gossip/fd_gossip.c
+++ b/src/flamenco/gossip/fd_gossip.c
@@ -168,26 +168,6 @@ ping_tracker_change( void *        _ctx,
   ctx->ping_tracker_change_fn( ctx->ping_tracker_change_fn_ctx, peer_pubkey, peer_address, now, change_type );
 }
 
-static inline void
-refresh_contact_info( fd_gossip_t * gossip,
-                      long          now ) {
-  fd_memcpy( gossip->my_contact_info.ci->origin, gossip->identity_pubkey, 32UL );
-  gossip->my_contact_info.ci->wallclock = (ulong)FD_NANOSEC_TO_MILLI( now );
-  long sz = fd_gossip_value_serialize( gossip->my_contact_info.ci, gossip->my_contact_info.crds_val, FD_GOSSIP_VALUE_MAX_SZ );
-  FD_TEST( sz!=-1L );
-  gossip->my_contact_info.crds_val_sz = (ulong)sz;
-
-  gossip->sign_fn( gossip->sign_ctx,
-                   gossip->my_contact_info.crds_val+64UL,
-                   gossip->my_contact_info.crds_val_sz-64UL,
-                   FD_KEYGUARD_SIGN_TYPE_ED25519,
-                   gossip->my_contact_info.crds_val );
-
-  /* We don't have stem_ctx here so we pre-empt in next
-     fd_gossip_advance iteration instead. */
-  gossip->timers.next_contact_info_refresh = now;
-}
-
 void *
 fd_gossip_new( void *                           shmem,
                fd_rng_t *                       rng,
@@ -286,9 +266,8 @@ fd_gossip_new( void *                           shmem,
   gossip->ping_tracker_change_fn_ctx = ping_tracker_change_fn_ctx;
 
   gossip->my_contact_info.ci->tag = FD_GOSSIP_VALUE_CONTACT_INFO;
-  *gossip->my_contact_info.ci->contact_info = *my_contact_info;
   fd_memcpy( gossip->identity_pubkey, identity_pubkey, 32UL );
-  refresh_contact_info( gossip, now );
+  fd_gossip_set_my_contact_info( gossip, my_contact_info, now );
 
   fd_memset( gossip->metrics, 0, sizeof(fd_gossip_metrics_t) );
 
@@ -341,6 +320,34 @@ random_entrypoint( fd_gossip_t const * gossip ) {
   return gossip->entrypoints[ idx ];
 }
 
+static inline void
+refresh_contact_info( fd_gossip_t * gossip,
+                      long          now ) {
+  fd_memcpy( gossip->my_contact_info.ci->origin, gossip->identity_pubkey, 32UL );
+  gossip->my_contact_info.ci->wallclock = (ulong)FD_NANOSEC_TO_MILLI( now );
+  long sz = fd_gossip_value_serialize( gossip->my_contact_info.ci, gossip->my_contact_info.crds_val, FD_GOSSIP_VALUE_MAX_SZ );
+  FD_TEST( sz!=-1L );
+  gossip->my_contact_info.crds_val_sz = (ulong)sz;
+
+  gossip->sign_fn( gossip->sign_ctx,
+                   gossip->my_contact_info.crds_val+64UL,
+                   gossip->my_contact_info.crds_val_sz-64UL,
+                   FD_KEYGUARD_SIGN_TYPE_ED25519,
+                   gossip->my_contact_info.crds_val );
+
+  /* We don't have stem_ctx here so we pre-empt in next
+     fd_gossip_advance iteration instead. */
+  gossip->timers.next_contact_info_refresh = now;
+}
+
+void
+fd_gossip_set_my_contact_info( fd_gossip_t *                    gossip,
+                               fd_gossip_contact_info_t const * contact_info,
+                               long                             now ) {
+  *gossip->my_contact_info.ci->contact_info = *contact_info;
+  refresh_contact_info( gossip, now );
+}
+
 ulong
 get_stake( fd_gossip_t const * gossip,
            uchar const *       pubkey ) {
@@ -389,14 +396,6 @@ fd_gossip_set_identity( fd_gossip_t * gossip,
        allows the old identity through (correct). */
     if( FD_LIKELY( old_identity_active && old_ci_idx!=ULONG_MAX ) ) fd_gossip_wsample_active( gossip->wsample, old_ci_idx, 1 );
   }
-}
-
-void
-fd_gossip_set_shred_version( fd_gossip_t * gossip,
-                             ushort        shred_version,
-                             long          now ) {
-  gossip->my_contact_info.ci->contact_info->shred_version = shred_version;
-  refresh_contact_info( gossip, now );
 }
 
 void
@@ -484,23 +483,6 @@ rx_pull_request( fd_gossip_t *                    gossip,
      exhausted, skip generating pull responses entirely. */
   if( FD_UNLIKELY( !outbound_budget_replenish( gossip, now ) ) ) return;
 
-  /* When responding to a pull request, we skip CRDS entries whose
-     wallclock is newer than the caller's wallclock + a random jitter.
-     The jitter is drawn uniformly from [0, TIMEOUT/4) ms, matching
-     Agave's behavior (CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS = 15000ms).
-     This prevents all responders from consistently excluding the same
-     set of very-recent CRDS values. */
-#define FD_GOSSIP_PULL_JITTER_BOUND_MS  (15000UL/4UL)
-
-  /* Generate a random jitter in [0, 3750) ms, added to the caller's
-     wallclock.  CRDS entries newer than this adjusted threshold are
-     excluded from the response.  The jitter prevents all responders
-     from consistently excluding the same near-boundary entries,
-     improving cluster-wide convergence of recent values. */
-  ulong caller_wallclock_ms    = pr_view->contact_info->wallclock;
-  ulong jitter_ms              = fd_rng_ulong_roll( gossip->rng, FD_GOSSIP_PULL_JITTER_BOUND_MS );
-  ulong adjusted_wallclock_ms  = caller_wallclock_ms + jitter_ms;
-
   ulong keys[ sizeof(pr_view->crds_filter->filter->keys)/sizeof(ulong) ];
   ulong bits[ sizeof(pr_view->crds_filter->filter->bits)/sizeof(ulong) ];
   fd_memcpy( keys, pr_view->crds_filter->filter->keys, sizeof(pr_view->crds_filter->filter->keys) );
@@ -523,10 +505,8 @@ rx_pull_request( fd_gossip_t *                    gossip,
        it=fd_crds_mask_iter_next( it, gossip->crds ) ) {
     fd_crds_entry_t const * candidate = fd_crds_mask_iter_entry( it, gossip->crds );
 
-    /* Skip CRDS entries whose originator wallclock is newer than the
-       caller's wallclock + jitter.  The caller hasn't had time to
-       observe these values yet, so including them would be wasteful. */
-    if( FD_UNLIKELY( fd_crds_entry_wallclock( candidate )>adjusted_wallclock_ms ) ) continue;
+    /* TODO: Add jitter here? */
+    // if( FD_UNLIKELY( fd_crds_value_wallclock( candidate )>contact_info->wallclock_nanos ) ) continue;
 
     if( FD_UNLIKELY( fd_bloom_contains( filter, fd_crds_entry_hash( candidate ), 32UL ) ) ) continue;
 

--- a/src/flamenco/gossip/fd_gossip.h
+++ b/src/flamenco/gossip/fd_gossip.h
@@ -130,15 +130,31 @@ fd_gossip_purged_metrics2( fd_gossip_t const * gossip );
 fd_active_set_metrics_t const *
 fd_gossip_active_set_metrics2( fd_gossip_t const * gossip );
 
+/* fd_gossip stores the node's contact info for various purposes:
+
+      - The pubkey specified in contact_info will serve as the
+        identity key, used in various checks of the rx path.
+
+      - If the shred version specified in the contact_info is non-zero,
+        it will be used to determine whether to accept or drop incoming
+        messages from peers.
+
+      - The contact info will be periodically gossiped to peers via
+        push messages.
+
+        - contact_info should have its wallclock correctly updated
+          in order to avoid timeouts on peers
+
+          TODO: update wallclock ourselves? */
+void
+fd_gossip_set_my_contact_info( fd_gossip_t *                    gossip,
+                               fd_gossip_contact_info_t const * contact_info,
+                               long                             now );
+
 void
 fd_gossip_set_identity( fd_gossip_t * gossip,
                         uchar const * identity_pubkey,
                         long          now );
-
-void
-fd_gossip_set_shred_version( fd_gossip_t * gossip,
-                             ushort        shred_version,
-                             long          now );
 
 void
 fd_gossip_stakes_update( fd_gossip_t *             gossip,


### PR DESCRIPTION
Reverts firedancer-io/firedancer#8524

This commit causes #8538

This line in `returnable_frag` (check whether self contact info has a shred version) fails, which causes the gossip tile to stop processing messages

https://github.com/firedancer-io/firedancer/blob/e60a2ced4b6d36dd55edbf1b430905ce61923ac1/src/discof/gossip/fd_gossip_tile.c#L307

This in turn backpressures snapin (because stem's flow control is too naive), which indefinitely blocks the snapshot pipeline