### PR TITLE
restore: snapwm msync seccomp update

### DIFF
--- a/src/discof/restore/fd_snapwm_tile_vinyl.seccomppolicy
+++ b/src/discof/restore/fd_snapwm_tile_vinyl.seccomppolicy
@@ -21,7 +21,7 @@ fsync: (eq (arg 0) logfile_fd)
 madvise: (eq (arg 2) MADV_SEQUENTIAL)
 
 # snapshot: flush mmap writes
-msync: (eq (arg 2) MS_SYNC)
+msync: (eq (arg 2) "MS_SYNC|MS_INVALIDATE")
 
 # shutdown: exit is called on shutdown
 exit: (eq (arg 0) 0)

--- a/src/discof/restore/generated/fd_snapwm_tile_vinyl_seccomp.h
+++ b/src/discof/restore/generated/fd_snapwm_tile_vinyl_seccomp.h
@@ -65,7 +65,7 @@ static void populate_sock_filter_policy_fd_snapwm_tile_vinyl( ulong out_cnt, str
 //  check_msync:
     /* load syscall argument 2 in accumulator */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[2])),
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, MS_SYNC, /* RET_ALLOW */ 3, /* RET_KILL_PROCESS */ 2 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, MS_SYNC|MS_INVALIDATE, /* RET_ALLOW */ 3, /* RET_KILL_PROCESS */ 2 ),
 //  check_exit:
     /* load syscall argument 0 in accumulator */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),


### PR DESCRIPTION
snapwm vinyl seccomppolicy update following https://github.com/firedancer-io/firedancer/pull/8542.