### PR TITLE
config: remove redundant snapshot config

### DIFF
--- a/src/app/firedancer/config/mainnet-jito.toml
+++ b/src/app/firedancer/config/mainnet-jito.toml
@@ -14,9 +14,6 @@
 [snapshots]
     [snapshots.sources]
         servers = [ "http://solana-mainnet-rpc.jumpisolated.com:8899" ]
-        [snapshots.sources.gossip]
-            allow_any = false
-            allow_list = []
 [tiles.bundle]
     enabled = true
     url = "https://mainnet.block-engine.jito.wtf"

--- a/src/app/firedancer/config/mainnet.toml
+++ b/src/app/firedancer/config/mainnet.toml
@@ -14,6 +14,3 @@
 [snapshots]
     [snapshots.sources]
         servers = [ "http://solana-mainnet-rpc.jumpisolated.com:8899" ]
-        [snapshots.sources.gossip]
-            allow_any = false
-            allow_list = []

--- a/src/app/firedancer/config/testnet-jito.toml
+++ b/src/app/firedancer/config/testnet-jito.toml
@@ -11,9 +11,6 @@
 [snapshots]
     [snapshots.sources]
         servers = [ "http://solana-testnet-rpc.jumpisolated.com:8899" ]
-        [snapshots.sources.gossip]
-            allow_any = false
-            allow_list = []
 [tiles.bundle]
     enabled = true
     url = "https://testnet.block-engine.jito.wtf"

--- a/src/app/firedancer/config/testnet.toml
+++ b/src/app/firedancer/config/testnet.toml
@@ -11,6 +11,3 @@
 [snapshots]
     [snapshots.sources]
         servers = [ "http://solana-testnet-rpc.jumpisolated.com:8899", "https://solana-testnet-tls.jumpisolated.com" ]
-        [snapshots.sources.gossip]
-            allow_any = false
-            allow_list = []


### PR DESCRIPTION
Use defaults for snapshots.sources.gossip
