### PR TITLE
Fix firedancer-dev bench startup crash

### DIFF
--- a/src/app/fdctl/main.c
+++ b/src/app/fdctl/main.c
@@ -149,7 +149,6 @@ add_bench_topo( fd_topo_t  * topo,
                 uint         send_to_ip_addr,
                 ushort       rpc_port,
                 uint         rpc_ip_addr,
-                int          no_quic,
                 int          reserve_agave_cores ) {
   (void)topo;
   (void)affinity;
@@ -164,6 +163,5 @@ add_bench_topo( fd_topo_t  * topo,
   (void)send_to_ip_addr;
   (void)rpc_port;
   (void)rpc_ip_addr;
-  (void)no_quic;
   (void)reserve_agave_cores;
 }

--- a/src/app/fddev/commands/bench.c
+++ b/src/app/fddev/commands/bench.c
@@ -20,7 +20,8 @@ agave_thread_main( void * _args ) {
 void
 fddev_bench_cmd_fn( args_t *   args,
                     config_t * config ) {
-  bench_cmd_fn( args, config, 0 );
+  args->load.no_watch = 1;
+  bench_cmd_fn( args, config );
 
   pthread_t agave;
   pthread_create( &agave, NULL, agave_thread_main, (void *)config );
@@ -32,6 +33,7 @@ fddev_bench_cmd_fn( args_t *   args,
 action_t fd_action_bench = {
   .name             = "bench",
   .args             = bench_cmd_args,
+  .topo             = bench_topo,
   .fn               = fddev_bench_cmd_fn,
   .perm             = dev_cmd_perm,
   .is_local_cluster = 1,

--- a/src/app/firedancer-dev/commands/bench.c
+++ b/src/app/firedancer-dev/commands/bench.c
@@ -3,16 +3,10 @@
 
 #include <unistd.h>
 
-static void
-bench_cmd_topo( config_t * config ) {
-  config->development.sandbox  = 0;
-  config->development.no_clone = 1;
-}
-
 void
 firedancer_dev_bench_cmd_fn( args_t *   args,
                              config_t * config ) {
-  bench_cmd_fn( args, config, 1 );
+  bench_cmd_fn( args, config );
 
   /* Sleep parent thread forever, Ctrl+C will terminate. */
   for(;;) pause();
@@ -21,9 +15,9 @@ firedancer_dev_bench_cmd_fn( args_t *   args,
 action_t fd_action_bench = {
   .name             = "bench",
   .args             = bench_cmd_args,
+  .topo             = bench_topo,
   .fn               = firedancer_dev_bench_cmd_fn,
   .perm             = dev_cmd_perm,
-  .topo             = bench_cmd_topo,
   .is_local_cluster = 1,
   .description      = "Test validator TPS benchmark"
 };

--- a/src/app/firedancer/main.c
+++ b/src/app/firedancer/main.c
@@ -240,7 +240,6 @@ add_bench_topo( fd_topo_t  * topo,
                 uint         send_to_ip_addr,
                 ushort       rpc_port,
                 uint         rpc_ip_addr,
-                int          no_quic,
                 int          reserve_agave_cores ) {
   (void)topo;
   (void)affinity;
@@ -255,6 +254,5 @@ add_bench_topo( fd_topo_t  * topo,
   (void)send_to_ip_addr;
   (void)rpc_port;
   (void)rpc_ip_addr;
-  (void)no_quic;
   (void)reserve_agave_cores;
 }

--- a/src/app/shared/commands/monitor/monitor.c
+++ b/src/app/shared/commands/monitor/monitor.c
@@ -515,7 +515,6 @@ monitor_cmd_fn( args_t *   args,
                     0U,
                     0,
                     0U,
-                    1,
                     !config->is_firedancer );
   }
 

--- a/src/app/shared/fd_action.h
+++ b/src/app/shared/fd_action.h
@@ -103,6 +103,7 @@ union fdctl_args {
     ulong   benchg;
     ulong   benchs;
     int     no_quic;
+    int     no_watch;
     int     transaction_mode;
     float   contending_fraction;
     float   cu_price_spread;

--- a/src/app/shared_dev/commands/bench/bench.h
+++ b/src/app/shared_dev/commands/bench/bench.h
@@ -6,7 +6,8 @@
 
 FD_PROTOTYPES_BEGIN
 
-void bench_cmd_fn( args_t * args, config_t * config, int watch );
+void bench_topo( config_t * config );
+void bench_cmd_fn( args_t * args, config_t * config );
 void bench_cmd_args( int * pargc, char *** pargv, args_t * args );
 
 void
@@ -23,7 +24,6 @@ add_bench_topo( fd_topo_t  * topo,
                 uint         send_to_ip_addr,
                 ushort       rpc_port,
                 uint         rpc_ip_addr,
-                int          no_quic,
                 int          reserve_agave_cores );
 
 FD_PROTOTYPES_END

--- a/src/app/shared_dev/commands/bench/fd_bencho.c
+++ b/src/app/shared_dev/commands/bench/fd_bencho.c
@@ -74,7 +74,9 @@ service_block_hash( fd_bencho_ctx_t *   ctx,
       return did_work;
     }
 
-    if( FD_UNLIKELY( fd_log_wallclock()<ctx->rpc_ready_deadline && response->status==FD_RPC_CLIENT_ERR_NETWORK ) ) {
+    if( FD_UNLIKELY( fd_log_wallclock()<ctx->rpc_ready_deadline &&
+                     ( response->status==FD_RPC_CLIENT_ERR_NETWORK ||
+                       response->status==FD_RPC_CLIENT_ERR_MALFORMED ) ) ) {
       /* RPC server not yet responding, give it some more time... */
       ctx->blockhash_state = FD_BENCHO_STATE_WAIT;
       ctx->blockhash_deadline = fd_log_wallclock() + 100L * 1000L * 1000L; /* 100 millis to retry */

--- a/src/app/shared_dev/commands/load.c
+++ b/src/app/shared_dev/commands/load.c
@@ -118,7 +118,6 @@ load_cmd_fn( args_t *   args,
                   args->load.tpu_ip,
                   args->load.rpc_port,
                   args->load.rpc_ip,
-                  args->load.no_quic,
                   0 );
   config->topo = *topo;
 


### PR DESCRIPTION
- Enable sandbox when watch is disabled
- Add support for 'firedancer-dev mem --topo bench'
- Fix segfault on startup
