### PR TITLE
Fix uninitialized read in fd_runtime_t

### DIFF
--- a/src/discof/execle/fd_execle_tile.c
+++ b/src/discof/execle/fd_execle_tile.c
@@ -637,12 +637,8 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->runtime->progcache                = ctx->progcache;
   ctx->runtime->status_cache             = txncache;
   ctx->runtime->acc_pool                 = acc_pool;
+  memset( &ctx->runtime->log, 0, sizeof(ctx->runtime->log) );
   ctx->runtime->log.log_collector        = ctx->log_collector;
-  ctx->runtime->log.enable_log_collector = 0;
-  ctx->runtime->log.capture_ctx          = NULL;
-  ctx->runtime->log.dumping_mem          = NULL;
-  ctx->runtime->log.tracing_mem          = NULL;
-  ctx->runtime->log.txn_dump_ctx         = NULL;
 
   ulong banks_obj_id = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "banks" );
   FD_TEST( banks_obj_id!=ULONG_MAX );
@@ -655,7 +651,8 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->busy_fseq = fd_fseq_join( fd_topo_obj_laddr( topo, busy_obj_id ) );
   if( FD_UNLIKELY( !ctx->busy_fseq ) ) FD_LOG_ERR(( "execle tile %lu has no busy flag", tile->kind_id ));
 
-  memset( &ctx->metrics, 0, sizeof( ctx->metrics ) );
+  memset( &ctx->metrics,          0, sizeof( ctx->metrics )          );
+  memset( &ctx->runtime->metrics, 0, sizeof( ctx->runtime->metrics ) );
 
   ctx->pack_in_mem = topo->workspaces[ topo->objs[ topo->links[ tile->in_link_id[ 0UL ] ].dcache_obj_id ].wksp_id ].wksp;
   ctx->pack_in_chunk0 = fd_dcache_compact_chunk0( ctx->pack_in_mem, topo->links[ tile->in_link_id[ 0UL ] ].dcache );

--- a/src/discof/execrp/fd_execrp_tile.c
+++ b/src/discof/execrp/fd_execrp_tile.c
@@ -448,10 +448,9 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->runtime->progcache                = ctx->progcache;
   ctx->runtime->status_cache             = ctx->txncache;
   ctx->runtime->acc_pool                 = ctx->acc_pool;
+  memset( &ctx->runtime->log, 0, sizeof(ctx->runtime->log) );
   ctx->runtime->log.log_collector        = &ctx->log_collector;
-  ctx->runtime->log.enable_log_collector = 0;
   ctx->runtime->log.dumping_mem          = ctx->dumping_mem;
-  ctx->runtime->log.enable_vm_tracing    = 0;
   ctx->runtime->log.tracing_mem          = &ctx->tracing_mem[0][0];
   ctx->runtime->log.capture_ctx          = ctx->capture_ctx;
   ctx->runtime->log.dump_proto_ctx       = ctx->dump_proto_ctx;

--- a/src/flamenco/runtime/program/test_vote_program.c
+++ b/src/flamenco/runtime/program/test_vote_program.c
@@ -199,13 +199,8 @@ test_env_init( test_env_t * env, fd_wksp_t * wksp, int enable_loader_v4 ) {
   env->runtime->status_cache             = NULL;
   env->runtime->acc_pool                 = acc_pool;
   fd_log_collector_init( env->log_collector, 0 );
+  memset( &env->runtime->log, 0, sizeof(env->runtime->log) );
   env->runtime->log.log_collector        = env->log_collector;
-  env->runtime->log.enable_log_collector = 0;
-  env->runtime->log.dumping_mem          = NULL;
-  env->runtime->log.enable_vm_tracing    = 0;
-  env->runtime->log.tracing_mem          = NULL;
-  env->runtime->log.capture_ctx          = NULL;
-  env->runtime->log.txn_dump_ctx         = NULL;
 
   return env;
 }

--- a/src/flamenco/runtime/test_bundle_exec.c
+++ b/src/flamenco/runtime/test_bundle_exec.c
@@ -183,13 +183,7 @@ init_rent_sysvar( test_env_t * env,
     env->runtime->progcache                = NULL;
     env->runtime->status_cache             = NULL;
     env->runtime->acc_pool                 = acc_pool;
-    env->runtime->log.log_collector        = NULL;
-    env->runtime->log.enable_log_collector = 0;
-    env->runtime->log.dumping_mem          = NULL;
-    env->runtime->log.enable_vm_tracing    = 0;
-    env->runtime->log.tracing_mem          = NULL;
-    env->runtime->log.capture_ctx          = NULL;
-    env->runtime->log.txn_dump_ctx         = NULL;
+    memset( &env->runtime->log, 0, sizeof(env->runtime->log) );
 
     return env;
   }

--- a/src/flamenco/runtime/tests/test_accounts_resize_delta.c
+++ b/src/flamenco/runtime/tests/test_accounts_resize_delta.c
@@ -198,13 +198,8 @@ test_env_init( test_env_t * env, fd_wksp_t * wksp, int enable_loader_v4 ) {
   env->runtime->status_cache             = NULL;
   env->runtime->acc_pool                 = acc_pool;
   fd_log_collector_init( env->log_collector, 0 );
+  memset( &env->runtime->log, 0, sizeof(env->runtime->log) );
   env->runtime->log.log_collector        = env->log_collector;
-  env->runtime->log.enable_log_collector = 0;
-  env->runtime->log.dumping_mem          = NULL;
-  env->runtime->log.enable_vm_tracing    = 0;
-  env->runtime->log.tracing_mem          = NULL;
-  env->runtime->log.capture_ctx          = NULL;
-  env->runtime->log.txn_dump_ctx         = NULL;
 
   return env;
 }

--- a/src/flamenco/vm/syscall/test_cpi_shared_data_addr.c
+++ b/src/flamenco/vm/syscall/test_cpi_shared_data_addr.c
@@ -378,6 +378,7 @@ test_env_create( test_env_t * env,
   env->runtime->acc_pool     = env->acc_pool;
 
   fd_log_collector_init( env->log_collector, 0 );
+  memset( &env->runtime->log, 0, sizeof(env->runtime->log) );
   env->runtime->log.log_collector = env->log_collector;
 
   /* Features: legacy mode (no direct_mapping, no stricter_abi) */

--- a/src/flamenco/vm/syscall/test_vm_increase_cpi_account_info_limit.c
+++ b/src/flamenco/vm/syscall/test_vm_increase_cpi_account_info_limit.c
@@ -166,6 +166,7 @@ test_env_create( test_env_t * env,
   FD_TEST( env->runtime );
 
   fd_log_collector_init( env->log_collector, 0 );
+  memset( &env->runtime->log, 0, sizeof(env->runtime->log) );
   env->runtime->log.log_collector = env->log_collector;
 
   fd_sha256_t * sha = fd_sha256_join( fd_sha256_new( env->sha ) );


### PR DESCRIPTION
fd_runtime_t has no constructor, has plenty global mutating state,
and is partially initialized at times.  This fixes an uninit read.
