### PR TITLE
genesis: prefix genesis file path by network

### DIFF
--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -72,7 +72,7 @@ telemetry = true
     # /home/fire/.firedancer/fd1
     #  +-- identity.json
     #  +-- vote-account.json
-    #  +-- genesis.bin
+    #  +-- mainnet-genesis.bin (or testnet-, devnet-, local-)
     #  +-- snapshots
     #      +-- snapshot-368327930-E5ZsnTCNX7WToyrP4ZQYJj7pPii6Ssa7UnNcV7HZ3iAf.tar.zst
     #      +-- incremental-snapshot-368327930-368400391-8ybYYVq7Ecui9TLj13SvzXjTX7JiGP65f4KrtNRCPajW.tar.zst
@@ -147,11 +147,10 @@ telemetry = true
     # below.
     snapshots = ""
 
-    # Absolute path where to store the `genesis.bin` file for the chain.
-    # If no path is provided, it defaults to the `genesis.bin` path
-    # within the base directory above.  The `genesis.bin` file contains
-    # the exact parameters used to create the genesis block of the
-    # chain.
+    # Absolute path where to store the genesis file for the chain.
+    # If no path is provided, it defaults to `{network}-genesis.bin`
+    # within the base directory above.  The genesis file contains the
+    # exact parameters used to create the genesis block of the chain.
     #
     # The genesis file must be known so that the validator can verify
     # the genesis hash matches the expected genesis hash specified in

--- a/src/app/shared/fd_config.c
+++ b/src/app/shared/fd_config.c
@@ -347,6 +347,16 @@ fd_config_fill( fd_config_t * config,
   if( FD_UNLIKELY( strcmp( config->paths.genesis, "" ) ) ) {
     replace( config->paths.genesis, "{user}", config->user );
     replace( config->paths.genesis, "{name}", config->name );
+  } else if( FD_LIKELY( config->is_firedancer ) ) {
+    ulong genesis_cluster = fd_genesis_cluster_identify( config->consensus.expected_genesis_hash );
+    char const * prefix;
+    switch( genesis_cluster ) {
+      case FD_CLUSTER_MAINNET_BETA: prefix = "mainnet";  break;
+      case FD_CLUSTER_TESTNET:      prefix = "testnet";  break;
+      case FD_CLUSTER_DEVNET:       prefix = "devnet";   break;
+      default:                      prefix = "local";    break;
+    }
+    FD_TEST( fd_cstr_printf_check( config->paths.genesis, sizeof(config->paths.genesis), NULL, "%s/%s-genesis.bin", config->paths.base, prefix ) );
   } else {
     FD_TEST( fd_cstr_printf_check( config->paths.genesis, sizeof(config->paths.genesis), NULL, "%s/genesis.bin", config->paths.base ) );
   }

--- a/src/discof/genesis/fd_genesi_tile.c
+++ b/src/discof/genesis/fd_genesi_tile.c
@@ -440,10 +440,13 @@ privileged_init( fd_topo_t *      topo,
           if( FD_LIKELY( !gid && -1==syscall( __NR_setresgid, -1, tile->genesi.target_gid, -1 ) ) ) FD_LOG_ERR(( "setresgid() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
           if( FD_LIKELY( !uid && -1==syscall( __NR_setresuid, -1, tile->genesi.target_uid, -1 ) ) ) FD_LOG_ERR(( "setresuid() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
 
+          char const * genesis_basename = strrchr( tile->genesi.genesis_path, '/' );
+          genesis_basename = genesis_basename ? genesis_basename+1UL : tile->genesi.genesis_path;
+
           char partialname[ PATH_MAX ];
-          FD_TEST( fd_cstr_printf_check( partialname, PATH_MAX, NULL, "%s.partial", tile->genesi.genesis_path ) );
-          ctx->out_fd = openat( ctx->out_dir_fd, "genesis.bin.partial", O_CREAT|O_WRONLY|O_CLOEXEC|O_TRUNC, S_IRUSR|S_IWUSR );
-          if( FD_UNLIKELY( -1==ctx->out_fd ) ) FD_LOG_ERR(( "openat() failed for genesis file `%s` (%i-%s)", partialname, errno, fd_io_strerror( errno ) ));
+          FD_TEST( fd_cstr_printf_check( partialname, PATH_MAX, NULL, "%s.partial", genesis_basename ) );
+          ctx->out_fd = openat( ctx->out_dir_fd, partialname, O_CREAT|O_WRONLY|O_CLOEXEC|O_TRUNC, S_IRUSR|S_IWUSR );
+          if( FD_UNLIKELY( -1==ctx->out_fd ) ) FD_LOG_ERR(( "openat() failed for genesis file `%s/%s` (%i-%s)", basename, partialname, errno, fd_io_strerror( errno ) ));
 
           if( FD_UNLIKELY( -1==syscall( __NR_setresuid, -1, uid, -1 ) ) ) FD_LOG_ERR(( "setresuid() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
           if( FD_UNLIKELY( -1==syscall( __NR_setresgid, -1, gid, -1 ) ) ) FD_LOG_ERR(( "setresgid() failed (%i-%s)", errno, fd_io_strerror( errno ) ));


### PR DESCRIPTION
Create files such as mainnet-genesis.bin instead of genesis.bin.
This makes it easier to switch clusters during development.
