### PR TITLE
pktgen: increase buffer depth & housekeeping freq

### DIFF
--- a/src/app/shared_dev/commands/pktgen/fd_pktgen_tile.c
+++ b/src/app/shared_dev/commands/pktgen/fd_pktgen_tile.c
@@ -94,7 +94,7 @@ after_credit( fd_pktgen_tile_ctx_t * ctx,
 
 #define STEM_CALLBACK_AFTER_CREDIT after_credit
 
-#define STEM_LAZY ((ulong)1e9) /* max possible */
+#define STEM_LAZY ((ulong)384e3) /* 384us, same as shred tile */
 
 #include "../../../../disco/stem/fd_stem.c"
 

--- a/src/app/shared_dev/commands/pktgen/pktgen.c
+++ b/src/app/shared_dev/commands/pktgen/pktgen.c
@@ -61,7 +61,7 @@ pktgen_topo( config_t * config ) {
   if( FD_UNLIKELY( !fd_cstr_to_ip4_addr( config->development.pktgen.fake_dst_ip, &pktgen_tile->pktgen.fake_dst_ip ) ) ) {
     FD_LOG_ERR(( "Invalid [development.pktgen.fake_dst_ip]" ));
   }
-  fd_topob_link( topo, "pktgen_out", "pktgen", 2048UL, FD_NET_MTU, 1UL );
+  fd_topob_link( topo, "pktgen_out", "pktgen", 32768UL, FD_NET_MTU, 1UL );
   fd_topob_tile_out( topo, "pktgen", 0UL, "pktgen_out", 0UL );
   fd_topob_tile_in( topo, "net", 0UL, "metric_in", "pktgen_out", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
 


### PR DESCRIPTION
Replicates the shred tile's house keeping frequency (shown [here](https://github.com/firedancer-io/firedancer/blob/642533473e7b672a1efb64faf488903118c5f44b/src/disco/shred/fd_shred_tile.c#L1524)) and link ring depth (shown [here](https://github.com/firedancer-io/firedancer/blob/642533473e7b672a1efb64faf488903118c5f44b/src/app/fdctl/topology.c#L89C77-L89C84))to solve pktgen running out of producer credits near continuously thus stalling pktgen tx to the net tile. Currently this a blocker for pktgen to work.

Edit: Since Stem has now been changed to not track credits for unreliable links by this [commit](https://github.com/firedancer-io/firedancer/commit/9214aad2f482e8cd2be234de679b211e3dbcbb41), making pktgen unreliable again doesn't carry the same issue of pktgen consistently crashing as before if it outpaced the net tile, so may be a good idea.

Even if we do make pktgen unreliable again I think this PR should still go ahead to better replicate a real validator's net tile behaviour with shred.