### PR TITLE
gossip: fix my_contact_info uninit read

### DIFF
--- a/src/discof/gossip/fd_gossip_tile.c
+++ b/src/discof/gossip/fd_gossip_tile.c
@@ -468,6 +468,7 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->last_wallclock = fd_log_wallclock();
   ctx->last_tickcount = fd_tickcount();
 
+  memset( ctx->my_contact_info, 0, sizeof(fd_gossip_contact_info_t) );
   ctx->my_contact_info->shred_version = tile->gossip.shred_version;
 
   ctx->my_contact_info->outset = (ulong)FD_NANOSEC_TO_MICRO( tile->gossip.boot_timestamp_nanos );


### PR DESCRIPTION
Fixes an uninit read bug that results in gossip failing to connect
to peers (presumably sending out garbage).
