### PR TITLE
Reduce Makefile stdout spam

### DIFF
--- a/config/everything.mk
+++ b/config/everything.mk
@@ -79,29 +79,17 @@ help:
 info: $(OBJDIR)/info
 
 clean: frontend-clean
-	#######################################################################
-	# Cleaning $(OBJDIR)
-	#######################################################################
 	$(RMDIR) $(OBJDIR) && $(RMDIR) target && $(RMDIR) agave/target && \
 $(SCRUB)
 
 distclean:
-	#######################################################################
-	# Cleaning $(BASEDIR)
-	#######################################################################
 	$(RMDIR) $(BASEDIR) && $(RMDIR) target && $(RMDIR) agave/target && \
 $(SCRUB)
 
 run-unit-test:
-	#######################################################################
-	# Running unit tests
-	#######################################################################
 	contrib/test/run_unit_tests.sh --tests $(OBJDIR)/unit-test/automatic.txt $(TEST_OPTS)
 
 run-integration-test:
-	#######################################################################
-	# Running integration tests
-	#######################################################################
 	contrib/test/run_integration_tests.sh --tests $(OBJDIR)/integration-test/automatic.txt $(TEST_OPTS)
 
 ##############################
@@ -170,9 +158,6 @@ add-examples = $(eval $(call _add-examples,$(1)))
 define _add-script
 
 $(OBJDIR)/$(1)/$(2): $(MKPATH)$(2)
-	#######################################################################
-	# Copying script $$^ to $$@
-	#######################################################################
 	$(MKDIR) $$(dir $$@) && \
 $(CP) $$< $$@ && \
 chmod 755 $$@ && \
@@ -212,9 +197,6 @@ DEPFILES+=$(foreach obj,$(2),$(patsubst $(OBJDIR)/src/%,$(OBJDIR)/obj/%,$(OBJDIR
 $(1): $(OBJDIR)/$(5)/$(1)
 
 $(OBJDIR)/$(5)/$(1): $(foreach obj,$(2),$(patsubst $(OBJDIR)/src/%,$(OBJDIR)/obj/%,$(OBJDIR)/$(MKPATH)$(obj).o)) $(foreach lib,$(3),$(OBJDIR)/lib/lib$(lib).a)
-	#######################################################################
-	# Creating $(5) $$@ from $$^
-	#######################################################################
 	$(MKDIR) $$(dir $$@) && \
 $(LD) -L$(OBJDIR)/lib $(foreach obj,$(2),$(patsubst $(OBJDIR)/src/%,$(OBJDIR)/obj/%,$(OBJDIR)/$(MKPATH)$(obj).o)) $(foreach lib,$(3),-l$(lib)) $(6) $(LDFLAGS) -o $$@
 
@@ -286,9 +268,6 @@ make-fuzz-test = $(eval $(call _fuzz-test,$(1),$(2),$(3),$(4) $(LDFLAGS_EXE)))
 ## GENERIC RULES
 
 $(OBJDIR)/info :
-	#######################################################################
-	# Saving build info to $(OBJDIR)/info
-	#######################################################################
 	$(MKDIR) $(dir $@) && \
 echo -e \
 "# date     `date +'%Y-%m-%d %H:%M:%S %z'`\n"\
@@ -298,73 +277,46 @@ echo -e \
 git status --porcelain=2 --branch >> $(OBJDIR)/info
 
 $(OBJDIR)/obj/%.d : src/%.c $(OBJDIR)/info
-	#######################################################################
-	# Generating dependencies for C source $< to $@
-	#######################################################################
 	$(MKDIR) $(dir $@) && \
 $(CC) $(CPPFLAGS) $(CFLAGS) -M -MP $< -o $@.tmp && \
 $(SED) 's,\($(notdir $*)\)\.o[ :]*,$(OBJDIR)/obj/$*.o $(OBJDIR)/obj/$*.S $(OBJDIR)/obj/$*.i $@ : ,g' < $@.tmp > $@ && \
 $(RM) $@.tmp
 
 $(OBJDIR)/obj/%.d : src/%.cxx $(OBJDIR)/info
-	#######################################################################
-	# Generating dependencies for C++ source $< to $@
-	#######################################################################
 	$(MKDIR) $(dir $@) && \
 $(CXX) $(CPPFLAGS) $(CXXFLAGS) -M -MP $< -o $@.tmp && \
 $(SED) 's,\($(notdir $*)\)\.o[ :]*,$(OBJDIR)/obj/$*.o $(OBJDIR)/obj/$*.S $(OBJDIR)/obj/$*.i $@ : ,g' < $@.tmp > $@ && \
 $(RM) $@.tmp
 
 $(OBJDIR)/obj/%.o : src/%.c $(OBJDIR)/info
-	#######################################################################
-	# Compiling C source $< to $@
-	#######################################################################
 	$(MKDIR) $(dir $@) && \
 $(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR)/obj/%.o : src/%.cxx $(OBJDIR)/info
-	#######################################################################
-	# Compiling C++ source $< to $@
-	#######################################################################
 	$(MKDIR) $(dir $@) && \
 $(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
 $(OBJDIR)/obj/%.o : src/%.S $(OBJDIR)/info
-	#######################################################################
-	# Compiling asm source $< to $@
-	#######################################################################
 	$(MKDIR) $(dir $@) && \
 $(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR)/obj/%.S : src/%.c $(OBJDIR)/info
-	#######################################################################
-	# Compiling C source $< to assembly $@
-	#######################################################################
 	$(MKDIR) $(dir $@) && \
 $(CC) $(patsubst -g,,$(CPPFLAGS) $(CFLAGS)) -S -fverbose-asm $< -o $@.tmp && \
 $(SED) 's,^#,                                                                                               #,g' < $@.tmp > $@ && \
 $(RM) $@.tmp
 
 $(OBJDIR)/obj/%.S : src/%.cxx $(OBJDIR)/info
-	#######################################################################
-	# Compiling C++ source $< to assembly $@
-	#######################################################################
 	$(MKDIR) $(dir $@) && \
 $(CXX) $(patsubst -g,,$(CPPFLAGS) $(CXXFLAGS)) -S -fverbose-asm $< -o $@.tmp && \
 $(SED) 's,^#,                                                                                               #,g' < $@.tmp > $@ && \
 $(RM) $@.tmp
 
 $(OBJDIR)/obj/%.i : src/%.c $(OBJDIR)/info
-	#######################################################################
-	# Preprocessing C source $< to $@
-	#######################################################################
 	$(MKDIR) $(dir $@) && \
 $(CC) $(CPPFLAGS) $(CFLAGS) -E $< -o $@
 
 $(OBJDIR)/obj/%.i : src/%.cxx $(OBJDIR)/info
-	#######################################################################
-	# Preprocessing C++ source $< to $@
-	#######################################################################
 	$(MKDIR) $(dir $@) && \
 $(CXX) $(CPPFLAGS) $(CXXFLAGS) -E $< -o $@
 
@@ -375,26 +327,17 @@ $(OBJDIR)/obj/%.check : src/%.cxx
 	@$(CXX) $(CPPFLAGS) $(CXXFLAGS) -fsyntax-only $<
 
 $(OBJDIR)/lib/%.a :
-	#######################################################################
-	# Creating library $@ from $^
-	#######################################################################
 	$(MKDIR) $(dir $@) && \
 $(RM) $@ && \
 $(AR) $(ARFLAGS) $@ $^ && \
 $(RANLIB)  $@
 
 $(OBJDIR)/include/firedancer/% : src/%
-	#######################################################################
-	# Copying header $^ to $@
-	#######################################################################
 	$(MKDIR) $(dir $@) && \
 $(CP) $^ $@ && \
 $(TOUCH) $@
 
 $(OBJDIR)/example/% : src/%
-	#######################################################################
-	# Copying example $^ to $@
-	#######################################################################
 	$(MKDIR) $(dir $@) && \
 $(CP) $^ $@ && \
 $(TOUCH) $@


### PR DESCRIPTION
`make -j` prints a ton of pound characters with lines randomly
garbled.  The pound separators do more harm than good and should
be removed.
