### PR TITLE
quic: fix integer underflow in ACK handler

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -4791,8 +4791,8 @@ fd_quic_handle_ack_frame( fd_quic_frame_ctx_t * context,
      We unfortunately can't just use 'largest_ack-3' because 1) largest_ack'd
      may have been previously acknowledged and 2) we may have skipped pkt_nums.
    */
-  ulong skip_ceil;
-  {
+  ulong skip_ceil = 0UL;
+  if( FD_LIKELY( largest_ack > 0UL ) ) {
     #define FD_QUIC_K_PACKET_THRESHOLD 3
     fd_quic_pkt_meta_tracker_t * tracker  = &conn->pkt_meta_tracker;
     fd_quic_pkt_meta_t         * pool     = tracker->pool;


### PR DESCRIPTION
When a peer ACKs packet number 0 (the first packet in a connection),
the expression `largest_ack-1` wraps to ULONG_MAX. The subsequent
treap lookup idx_le(~0UL) returns the element with the largest key,
causing the skip_ceil computation to iterate from the wrong end of
the data structure. This incorrectly marks unrelated packets as
"lost", triggering spurious retransmissions.
