### PR TITLE
eqvoc: fix DuplicateShred proof handling

### DIFF
--- a/src/choreo/eqvoc/Local.mk
+++ b/src/choreo/eqvoc/Local.mk
@@ -3,5 +3,6 @@ $(call add-hdrs,fd_eqvoc.h)
 $(call add-objs,fd_eqvoc,fd_choreo)
 ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_eqvoc,test_eqvoc,fd_choreo fd_flamenco fd_ballet fd_util)
+$(call make-fuzz-test,fuzz_eqvoc,fuzz_eqvoc,fd_choreo fd_flamenco fd_ballet fd_util)
 endif
 endif

--- a/src/choreo/eqvoc/fd_eqvoc.c
+++ b/src/choreo/eqvoc/fd_eqvoc.c
@@ -507,6 +507,8 @@ fd_eqvoc_chunk_insert( fd_eqvoc_t                        * eqvoc,
                        fd_pubkey_t const                 * from,
                        fd_gossip_duplicate_shred_t const * chunk ) {
 
+  if( FD_UNLIKELY( fd_pubkey_eq( from, &pubkey_null ) ) ) return FD_EQVOC_ERR_SER; /* from_map sentinel */
+
   verified_t * verified = verified_map_ele_query( eqvoc->verified_map, &chunk->slot, NULL, eqvoc->verified_pool );
   if( FD_UNLIKELY( verified && verified->err > FD_EQVOC_SUCCESS ) ) return FD_EQVOC_SUCCESS; /* already verified equivocation for this verified */
 
@@ -559,6 +561,9 @@ fd_eqvoc_chunk_insert( fd_eqvoc_t                        * eqvoc,
 
   ulong              shred1_sz = fd_ulong_load_8( proof->buf );
   fd_shred_t const * shred1    = (fd_shred_t const *)fd_type_pun_const( proof->buf + sizeof(ulong) );
+
+  if( FD_UNLIKELY( shred1_sz < FD_SHRED_MIN_SZ || shred1_sz > FD_SHRED_MAX_SZ ) ) return FD_EQVOC_ERR_SER;
+
   ulong              shred2_sz = fd_ulong_load_8( proof->buf + sizeof(ulong) + shred1_sz );
   fd_shred_t const * shred2    = (fd_shred_t const *)fd_type_pun_const( proof->buf + sizeof(ulong) + shred1_sz + sizeof(ulong) );
 

--- a/src/choreo/eqvoc/fuzz_eqvoc.c
+++ b/src/choreo/eqvoc/fuzz_eqvoc.c
@@ -1,0 +1,104 @@
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "fd_eqvoc.h"
+#include "fd_eqvoc_private.h"
+#include "../../util/fd_util.h"
+#include "../../util/sanitize/fd_fuzz.h"
+
+#define SHRED_MAX 4
+#define SLOT_MAX  4
+#define FROM_MAX  4
+
+static fd_pubkey_t        leader[1]  = {{{ 0 }}};
+static uint               sched[100] = { 0 };
+static fd_epoch_leaders_t leaders    = { .slot0 = 0, .slot_cnt = 100, .pub = leader, .pub_cnt = 1, .sched = sched, .sched_cnt = 4 };
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  putenv( "FD_LOG_BACKTRACE=0" );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+  fd_log_level_core_set(3); /* crash on warning log */
+  return 0;
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         size ) {
+  ulong chunk_sz = sizeof(fd_gossip_duplicate_shred_t);
+  if( FD_UNLIKELY( size < 32UL + 3UL * chunk_sz ) ) return -1;
+
+  ulong   footprint = fd_eqvoc_footprint( SHRED_MAX, SLOT_MAX, FROM_MAX );
+  uchar * mem       = aligned_alloc( fd_eqvoc_align(), footprint );
+
+  fd_eqvoc_t * eqvoc = fd_eqvoc_join( fd_eqvoc_new( mem, SHRED_MAX, SLOT_MAX, FROM_MAX, 0UL ) );
+  fd_eqvoc_set_shred_version( eqvoc, 42 );
+  fd_eqvoc_set_leader_schedule( eqvoc, &leaders );
+
+  fd_pubkey_t from;
+  memcpy( &from, data, 32UL );
+  data += 32UL;
+  size -= 32UL;
+
+  while( size >= sizeof(fd_gossip_duplicate_shred_t) ) {
+    fd_gossip_duplicate_shred_t chunk;
+    memcpy( &chunk, data, sizeof(fd_gossip_duplicate_shred_t) );
+    fd_eqvoc_chunk_insert( eqvoc, &from, &chunk );
+    data += sizeof(fd_gossip_duplicate_shred_t);
+    size -= sizeof(fd_gossip_duplicate_shred_t);
+  }
+
+  fd_eqvoc_delete( fd_eqvoc_leave( eqvoc ) );
+  free( mem );
+
+  FD_FUZZ_MUST_BE_COVERED;
+  return 0;
+}
+
+ulong
+LLVMFuzzerCustomMutator( uchar * data,
+                         ulong   size,
+                         ulong   max_size,
+                         uint    seed ) {
+  (void)seed;
+
+  ulong chunk_sz = sizeof(fd_gossip_duplicate_shred_t);
+  ulong min_sz   = 32UL + 3UL * chunk_sz;
+
+  if( FD_UNLIKELY( max_size < min_sz ) ) return 0;
+
+  if( size < min_sz ) {
+    memset( data + size, 0, min_sz - size );
+    size = min_sz;
+  }
+
+  size = LLVMFuzzerMutate( data, size, max_size );
+
+  if( size < min_sz ) {
+    memset( data + size, 0, min_sz - size );
+    size = min_sz;
+  }
+
+  /* Fix up structural invariants so chunks reach the reassembly path. */
+
+  fd_gossip_duplicate_shred_t chunk;
+  memcpy( &chunk, data + 32UL, chunk_sz );
+  ulong slot = chunk.slot;
+
+  for( uchar i = 0; i < 3; i++ ) {
+    memcpy( &chunk, data + 32UL + (ulong)i * chunk_sz, chunk_sz );
+    chunk.slot        = slot;
+    chunk.chunk_index = i;
+    chunk.num_chunks  = FD_EQVOC_CHUNK_CNT;
+    if( chunk.chunk_len > sizeof(chunk.chunk) ) chunk.chunk_len = sizeof(chunk.chunk);
+    memcpy( data + 32UL + (ulong)i * chunk_sz, &chunk, chunk_sz );
+  }
+
+  return size;
+}


### PR DESCRIPTION
Add a fuzzer for handling DuplicateShred proofs and fix bugs
