### PR TITLE
ci: add CBMC proofs

### DIFF
--- a/.github/workflows/cbmc.yml
+++ b/.github/workflows/cbmc.yml
@@ -1,0 +1,23 @@
+name: CBMC Proofs
+on:
+  pull_request:
+
+jobs:
+  check-cbmc:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup CBMC
+        run: |
+          wget https://github.com/diffblue/cbmc/releases/download/cbmc-6.8.0/ubuntu-24.04-cbmc-6.8.0-Linux.deb
+          sudo dpkg -i ubuntu-24.04-cbmc-6.8.0-Linux.deb
+
+      - name: Check Proofs
+        run: |
+          cbmc --version
+          make -j proof

--- a/config/base.mk
+++ b/config/base.mk
@@ -25,6 +25,7 @@ FIND:=find
 SCRUB:=$(FIND) . -type f -name "*~" -o -name "\#*" | xargs $(RM)
 DATE:=date
 CAT:=cat
+CBMC?=cbmc
 
 # Default compiler configuration, if not already set
 CC?=gcc

--- a/config/everything.mk
+++ b/config/everything.mk
@@ -1,4 +1,4 @@
-.PHONY: all info check bin rust include lib unit-test integration-test fuzz-test help clean distclean asm ppp show-deps
+.PHONY: all info check bin rust include lib unit-test integration-test fuzz-test help clean distclean asm ppp show-deps proof
 .PHONY: run-unit-test run-integration-test run-script-test run-fuzz-test
 .PHONY: seccomp-policies cov-report dist-cov-report frontend frontend-clean
 
@@ -19,7 +19,7 @@ CPPFLAGS+=$(EXTRA_CPPFLAGS)
 AUX_RULES:=clean distclean help run-unit-test run-integration-test cov-report dist-cov-report seccomp-policies frontend
 
 # Dry rules that should set up dependency targets, but not generate them
-DRY_RULES:=check show-deps
+DRY_RULES:=check show-deps proof
 
 all: info bin include lib unit-test fuzz-test
 
@@ -263,6 +263,21 @@ run-unit-test  = $(eval $(call _run-unit-test,$(1)))
 make-integration-test = $(eval $(call _make-exe,$(1),$(2),$(3),integration-test,integration-test,$(4) $(LDFLAGS_EXE)))
 run-integration-test  = $(eval $(call _run-integration-test,$(1)))
 make-fuzz-test = $(eval $(call _fuzz-test,$(1),$(2),$(3),$(4) $(LDFLAGS_EXE)))
+
+##############################
+# Usage: $(call make-proof,name,source_file)
+
+define _make-proof
+
+.PHONY: $(1)
+$(1):
+	$(CBMC) $(MKPATH)$(2) --c17 -DCBMC --function cbmc_main
+
+proof: $(1)
+
+endef
+
+make-proof = $(eval $(call _make-proof,$(1),$(2)))
 
 ##############################
 ## GENERIC RULES


### PR DESCRIPTION
- Adds a workflow for checking CBMC proofs.
   
- Introduces a helper in the build system for adding
    CBMC proofs. To use, you specify the file containing
    said proofs, and a list of the function names within
    that are the entrypoints. CBMC will be invoked for
    each entrypoint listed.