### PR TITLE
url: refactor common parser between event and bundle tile

### DIFF
--- a/src/disco/bundle/fd_bundle_tile.c
+++ b/src/disco/bundle/fd_bundle_tile.c
@@ -159,77 +159,18 @@ after_credit( fd_bundle_tile_t *  ctx,
 }
 
 static void
-parse_url( fd_url_t *   url_,
-           char const * url_str,
-           ulong        url_str_len,
-           ushort *     tcp_port,
-           _Bool *      is_ssl ) {
-
-  /* Parse URL */
-
-  int url_err[1];
-  fd_url_t * url = fd_url_parse_cstr( url_, url_str, url_str_len, url_err );
-  if( FD_UNLIKELY( !url ) ) {
-    switch( *url_err ) {
-    scheme_err:
-    case FD_URL_ERR_SCHEME:
-      FD_LOG_ERR(( "Invalid [tiles.bundle.url] `%.*s`: must start with `http://` or `https://`", (int)url_str_len, url_str ));
-      break;
-    case FD_URL_ERR_HOST_OVERSZ:
-      FD_LOG_ERR(( "Invalid [tiles.bundle.url] `%.*s`: domain name is too long", (int)url_str_len, url_str ));
-      break;
-    default:
-      FD_LOG_ERR(( "Invalid [tiles.bundle.url] `%.*s`", (int)url_str_len, url_str ));
-      break;
-    }
-  }
-
-  /* FIXME the URL scheme path technically shouldn't contain slashes */
-  if( url->scheme_len==8UL && fd_memeq( url->scheme, "https://", 8UL ) ) {
-    *is_ssl = 1;
-  } else if( url->scheme_len==7UL && fd_memeq( url->scheme, "http://", 7UL ) ) {
-    *is_ssl = 0;
-  } else {
-    goto scheme_err;
-  }
-
-  /* Parse port number */
-
-  *tcp_port = 443;
-  if( url->port_len ) {
-    if( FD_UNLIKELY( url->port_len > 5 ) ) {
-    invalid_port:
-      FD_LOG_ERR(( "Invalid [tiles.bundle.url] `%.*s`: invalid port number", (int)url_str_len, url_str ));
-    }
-
-    char port_cstr[6];
-    fd_cstr_fini( fd_cstr_append_text( fd_cstr_init( port_cstr ), url->port, url->port_len ) );
-    ulong port_no = fd_cstr_to_ulong( port_cstr );
-    if( FD_UNLIKELY( !port_no || port_no>USHORT_MAX ) ) goto invalid_port;
-
-    *tcp_port = (ushort)port_no;
-  }
-
-  /* Resolve domain */
-
-  if( FD_UNLIKELY( url->host_len > 255 ) ) {
-    FD_LOG_CRIT(( "Invalid url->host_len" )); /* unreachable */
-  }
-  char host_cstr[ 256 ];
-  fd_cstr_fini( fd_cstr_append_text( fd_cstr_init( host_cstr ), url->host, url->host_len ) );
-}
-
-static void
 fd_bundle_tile_parse_endpoint( fd_bundle_tile_t *     ctx,
                                fd_topo_tile_t const * tile ) {
   fd_url_t url[1];
   _Bool is_ssl = 0;
-  parse_url(
-      url,
-      tile->bundle.url, tile->bundle.url_len,
-      &ctx->server_tcp_port,
-      &is_ssl
-  );
+  if( FD_UNLIKELY( fd_url_parse_endpoint( url,
+                                          tile->bundle.url,
+                                          tile->bundle.url_len,
+                                          &ctx->server_tcp_port,
+                                          &is_ssl,
+                                          "[tiles.bundle.url]" ) ) ) {
+    FD_LOG_ERR(( "Could not parse [tiles.bundle.url]" ));
+  }
   if( FD_UNLIKELY( url->host_len > 255 ) ) {
     FD_LOG_CRIT(( "Invalid url->host_len" )); /* unreachable */
   }

--- a/src/disco/events/fd_event_client.c
+++ b/src/disco/events/fd_event_client.c
@@ -97,63 +97,6 @@ fd_event_client_footprint( ulong buf_max ) {
   return FD_LAYOUT_FINI( l, alignof(fd_event_client_t) );
 }
 
-static void
-parse_url( fd_url_t *   url_,
-           char const * url_str,
-           ulong        url_str_len,
-           ushort *     tcp_port ) {
-
-  /* Parse URL */
-
-  int url_err[1];
-  fd_url_t * url = fd_url_parse_cstr( url_, url_str, url_str_len, url_err );
-  if( FD_UNLIKELY( !url ) ) {
-    switch( *url_err ) {
-    scheme_err:
-    case FD_URL_ERR_SCHEME:
-      FD_LOG_ERR(( "Invalid [tiles.event.url] `%.*s`: must start with `http://`", (int)url_str_len, url_str ));
-      break;
-    case FD_URL_ERR_HOST_OVERSZ:
-      FD_LOG_ERR(( "Invalid [tiles.event.url] `%.*s`: domain name is too long", (int)url_str_len, url_str ));
-      break;
-    default:
-      FD_LOG_ERR(( "Invalid [tiles.event.url] `%.*s`", (int)url_str_len, url_str ));
-      break;
-    }
-  }
-
-  /* FIXME the URL scheme path technically shouldn't contain slashes */
-  if( url->scheme_len==7UL && fd_memeq( url->scheme, "http://", 7UL ) ) {
-  } else {
-    goto scheme_err;
-  }
-
-  /* Parse port number */
-
-  *tcp_port = 7878;
-  if( url->port_len ) {
-    if( FD_UNLIKELY( url->port_len > 5 ) ) {
-    invalid_port:
-      FD_LOG_ERR(( "Invalid [tiles.event.url] `%.*s`: invalid port number", (int)url_str_len, url_str ));
-    }
-
-    char port_cstr[6];
-    fd_cstr_fini( fd_cstr_append_text( fd_cstr_init( port_cstr ), url->port, url->port_len ) );
-    ulong port_no = fd_cstr_to_ulong( port_cstr );
-    if( FD_UNLIKELY( !port_no || port_no>USHORT_MAX ) ) goto invalid_port;
-
-    *tcp_port = (ushort)port_no;
-  }
-
-  /* Resolve domain */
-
-  if( FD_UNLIKELY( url->host_len > 255 ) ) {
-    FD_LOG_CRIT(( "Invalid url->host_len" )); /* unreachable */
-  }
-  char host_cstr[ 256 ];
-  fd_cstr_fini( fd_cstr_append_text( fd_cstr_init( host_cstr ), url->host, url->host_len ) );
-}
-
 void *
 fd_event_client_new( void *                 shmem,
                      fd_keyguard_client_t * keyguard_client,
@@ -182,11 +125,16 @@ fd_event_client_new( void *                 shmem,
   void * grpc_client_mem     = FD_SCRATCH_ALLOC_APPEND( l, fd_grpc_client_align(),     fd_grpc_client_footprint( buf_max ) );
 
   fd_url_t url[1];
-  parse_url(
-      url,
-      _url,
-      strlen( _url ),
-      &client->server_tcp_port );
+  _Bool _is_ssl = 0;
+  if( FD_UNLIKELY( fd_url_parse_endpoint( url,
+                                          _url,
+                                          strlen( _url ),
+                                          &client->server_tcp_port,
+                                          &_is_ssl,
+                                          "[tiles.event.url]" ) ) ) {
+    FD_LOG_ERR(( "Could not parse [tiles.event.url]" ));
+  }
+  client->server_tcp_port = 7878;
   if( FD_UNLIKELY( url->host_len > 255 ) ) {
     FD_LOG_CRIT(( "Invalid url->host_len" )); /* unreachable */
   }

--- a/src/waltz/http/fd_url.c
+++ b/src/waltz/http/fd_url.c
@@ -1,4 +1,6 @@
 #include "fd_url.h"
+#include "../../util/cstr/fd_cstr.h"
+#include "../../util/log/fd_log.h"
 
 fd_url_t *
 fd_url_parse_cstr( fd_url_t *   const url,
@@ -69,6 +71,56 @@ fd_url_parse_cstr( fd_url_t *   const url,
   };
 
   return url;
+}
+
+int
+fd_url_parse_endpoint( fd_url_t *   url_,
+                       char const * url_str,
+                       ulong        url_str_len,
+                       ushort *     tcp_port,
+                       _Bool *      is_ssl,
+                       char const * context ) {
+  char const * ctx = context ? context : "URL";
+
+  int url_err[1];
+  fd_url_t * url = fd_url_parse_cstr( url_, url_str, url_str_len, url_err );
+  if( FD_UNLIKELY( !url ) ) {
+    switch( *url_err ) {
+    case FD_URL_ERR_SCHEME:
+      FD_LOG_WARNING(( "Invalid %s `%.*s`: must start with `http://` or `https://`", ctx, (int)url_str_len, url_str ));
+      return -1;
+    case FD_URL_ERR_HOST_OVERSZ:
+      FD_LOG_WARNING(( "Invalid %s `%.*s`: domain name is too long", ctx, (int)url_str_len, url_str ));
+      return -1;
+    case FD_URL_ERR_USERINFO:
+      FD_LOG_WARNING(( "Invalid %s `%.*s`: userinfo is not supported", ctx, (int)url_str_len, url_str ));
+      return -1;
+    default:
+      FD_LOG_WARNING(( "Invalid %s `%.*s`", ctx, (int)url_str_len, url_str ));
+      return -1;
+    }
+  }
+
+  /* fd_url_parse_cstr() already guarantees http:// or https:// */
+  *is_ssl = ( url->scheme_len==8UL );
+
+  *tcp_port = *is_ssl ? 443 : 80;
+  if( url->port_len ) {
+    if( FD_UNLIKELY( url->port_len > 5 ) ) {
+    invalid_port:
+      FD_LOG_WARNING(( "Invalid %s `%.*s`: invalid port number", ctx, (int)url_str_len, url_str ));
+      return -1;
+    }
+
+    char port_cstr[6];
+    fd_cstr_fini( fd_cstr_append_text( fd_cstr_init( port_cstr ), url->port, url->port_len ) );
+    ulong port_no = fd_cstr_to_ulong( port_cstr );
+    if( FD_UNLIKELY( !port_no || port_no>USHORT_MAX ) ) goto invalid_port;
+
+    *tcp_port = (ushort)port_no;
+  }
+
+  return 0;
 }
 
 

--- a/src/waltz/http/fd_url.h
+++ b/src/waltz/http/fd_url.h
@@ -47,6 +47,29 @@ fd_url_parse_cstr( fd_url_t *   url,
                    ulong        url_str_len,
                    int *        opt_err );
 
+/* Shared validator/runtime URL gate.
+   Accepts a http(s):// URL, fills fd_url_t `url` parameter.
+     - Only `http://` and `https://` schemes are permitted.  Anything
+       else (including missing schemes or stray slashes) is rejected.
+       The `context` string is echoed in the log so operators know which
+       knob supplied the bad value.
+     - If the URL omits an explicit port we default to 443/80 and then flip
+       `is_ssl` based on the scheme so downstream sockets know whether
+       to open TLS.
+     - Host names larger than 255 bytes are rejected
+   The function does not enforce the host being non-empty; that is left to
+   the caller because some control paths treat an empty host differently
+   (e.g. surfacing a custom error message).
+   Returns 0 on success, -1 on failure (and logs a warning). */
+
+int
+fd_url_parse_endpoint( fd_url_t *   url,
+                       char const * url_str,
+                       ulong        url_str_len,
+                       ushort *     tcp_port,
+                       _Bool *      is_ssl,
+                       char const * context );
+
 /* fd_url_unescape undoes % escapes in-place. */
 
 ulong


### PR DESCRIPTION
This PR deduplicates endpoint URL parsing logic by moving it into shared HTTP URL utilities and updating both event and bundle tiles to use the shared helper.

  ## Changes

  - Added fd_url_parse_endpoint(...) to shared URL code (fd_url.c/fd_url.h).
  - Removed tile-local parse_url(...) implementations from:

  1. Event client
  2. Bundle tile

  - Updated both call sites to use the shared parser.

## Logic changes:
1. Removed dead scheme fallback path

  - Deleted scheme_err: label and else { goto scheme_err; }.
  - Replaced scheme branching with:
      - *is_ssl = (url->scheme_len==8UL);
  - Reason: fd_url_parse_cstr() already guarantees only http:// or https://.

  2. Removed redundant host-length validation

  - Deleted:
      - if( url->host_len > 255 ) { ... return -1; }
  - Reason: fd_url_parse_cstr() already enforces host length limit and fails earlier with FD_URL_ERR_HOST_OVERSZ.