### PR TITLE
runtime: fix missing serialization and address in builtin-to-core-bpf…

### DIFF
--- a/src/flamenco/runtime/fd_core_bpf_migration.c
+++ b/src/flamenco/runtime/fd_core_bpf_migration.c
@@ -461,6 +461,7 @@ migrate_builtin_to_core_bpf1( fd_core_bpf_migration_config_t const * config,
       rent,
       slot ) ) )
     return;
+  new_target_program_data->addr = target->program_data_address;
 
   ulong old_data_sz;
   if( FD_UNLIKELY( fd_ulong_checked_add( target->program_account->data_sz, source->data_sz, &old_data_sz ) ) ) return;


### PR DESCRIPTION
… migration

new_target_program_account() constructs an UpgradeableLoaderState::Program state but never serializes it into acc->data, leaving the account with all-zero data after migration. The sister function new_target_program_data_account() correctly calls
fd_bpf_upgradeable_loader_state_encode(). In Agave, AccountSharedData::new_data() handles both allocation and serialization atomically.

Additionally, the call site in migrate_builtin_to_core_bpf1() never sets new_target_program->addr to the builtin program address, so tmp_account_store() writes the account to an uninitialized address. Agave stores to target.program_address explicitly.

Add the encode call in new_target_program_account() and set the address at the call site.