### PR TITLE
poh: fix too small fd_poh_footprint

### DIFF
--- a/src/discof/poh/fd_poh.c
+++ b/src/discof/poh/fd_poh.c
@@ -61,7 +61,7 @@ fd_poh_align( void ) {
 
 FD_FN_CONST ulong
 fd_poh_footprint( void ) {
-  return FD_POH_FOOTPRINT;
+  return sizeof(fd_poh_t);
 }
 
 void *

--- a/src/discof/poh/fd_poh.h
+++ b/src/discof/poh/fd_poh.h
@@ -312,13 +312,9 @@
 #include "../../util/fd_util_base.h"
 #include "../../ballet/sha256/fd_sha256.h"
 
-/* FD_POH_{ALIGN,FOOTPRINT} describe the alignment and footprint needed
-   for a memory region to hold a fd_poh_t.  ALIGN is a positive
-   integer power of 2.  FOOTPRINT is a multiple of align.  These are
-   provided to facilitate compile time declarations. */
-
-#define FD_POH_ALIGN     (128UL)
-#define FD_POH_FOOTPRINT (128UL)
+/* FD_POH_ALIGN is the alignment needed for a memory region to hold a
+   fd_poh_t.  It is a positive integer power of 2. */
+#define FD_POH_ALIGN (128UL)
 
 #define FD_POH_MAGIC (0xF17EDA2CE580A000) /* FIREDANCE POH V0 */
 


### PR DESCRIPTION
while never used, the tile directly uses the struct, fd_poh_footprint reported a significantly too small value. This would risk bugs when used for future code