### PR TITLE
gui: incrementally index votes

### DIFF
--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -40,7 +40,7 @@ $(call add-objs,commands/set_identityh,fd_fdctl)
 $(call make-lib,fdctl_version)
 $(call add-objs,version,fdctl_version)
 
-$(call make-bin-rust,fdctl,main,fd_fdctl fdctl_shared fdctl_platform fd_discoh fd_disco agave_validator fd_flamenco fd_funk fd_quic fd_tls fd_reedsol fd_waltz fd_tango fd_ballet fd_util fdctl_version)
+$(call make-bin-rust,fdctl,main,fd_fdctl fdctl_shared fdctl_platform fd_discoh fd_disco fd_choreo agave_validator fd_flamenco fd_funk fd_quic fd_tls fd_reedsol fd_waltz fd_tango fd_ballet fd_util fdctl_version)
 
 check-agave-hash:
 	@$(eval AGAVE_COMMIT_LS_TREE=$(shell git ls-tree HEAD | grep agave | awk '{print $$3}'))

--- a/src/app/fddev/Local.mk
+++ b/src/app/fddev/Local.mk
@@ -11,7 +11,7 @@ $(call add-objs,commands/configure/blockstore,fd_fddev)
 $(call add-objs,commands/bench,fd_fddev)
 $(call add-objs,commands/dev,fd_fddev)
 
-$(call make-bin-rust,fddev,main,fd_fddev fd_fdctl fddev_shared fdctl_shared fdctl_platform fd_discoh fd_disco agave_validator fd_flamenco fd_funk fd_quic fd_tls fd_reedsol fd_waltz fd_tango fd_ballet fd_util fdctl_version)
+$(call make-bin-rust,fddev,main,fd_fddev fd_fdctl fddev_shared fdctl_shared fdctl_platform fd_discoh fd_disco fd_choreo agave_validator fd_flamenco fd_funk fd_quic fd_tls fd_reedsol fd_waltz fd_tango fd_ballet fd_util fdctl_version)
 
 ifeq (run,$(firstword $(MAKECMDGOALS)))
   RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
@@ -35,7 +35,7 @@ endif
 monitor: bin
 	$(OBJDIR)/bin/fddev monitor $(MONITOR_ARGS)
 
-$(call make-integration-test,test_fddev,tests/test_fddev,fd_fddev fd_fdctl fddev_shared fdctl_shared fdctl_platform fd_discoh fd_disco agave_validator fd_flamenco fd_funk fd_quic fd_tls fd_reedsol fd_waltz fd_tango fd_ballet fd_util fdctl_version)
+$(call make-integration-test,test_fddev,tests/test_fddev,fd_fddev fd_fdctl fddev_shared fdctl_shared fdctl_platform fd_discoh fd_disco fd_choreo agave_validator fd_flamenco fd_funk fd_quic fd_tls fd_reedsol fd_waltz fd_tango fd_ballet fd_util fdctl_version)
 $(call run-integration-test,test_fddev)
 
 endif

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -1299,43 +1299,32 @@ fd_topo_initialize( config_t * config ) {
 
   if( FD_LIKELY( config->tiles.gui.enabled ) ) {
     fd_topob_wksp( topo, "gui"        );
-    fd_topob_wksp( topo, "gui_replay" );
 
     /**/                 fd_topob_tile(     topo, "gui",     "gui",     "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0, 1, 0 );
 
-    /* Read banks */
-    /**/                 fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "gui", 0UL ) ], banks_obj,       FD_SHMEM_JOIN_MODE_READ_ONLY  );
-    /**/                 fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "gui", 0UL ) ], banks_locks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
-
-    /* release ownership of banks */
-    /**/                 fd_topob_link( topo, "gui_replay", "gui_replay", 128, 0UL,2UL ); /* burst==2 since a bank and its parent may be sent in one burst */
-
-    /**/                 fd_topob_tile_out( topo, "gui",    0UL,                        "gui_replay", 0UL                                                );
-    /**/                 fd_topob_tile_in ( topo, "replay", 0UL,           "metric_in", "gui_replay", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-
-    /*                                        topo, tile_name, tile_kind_id, fseq_wksp,   link_name,      link_kind_id, reliable,            polled */
-    FOR(net_tile_cnt)      fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "net_gossvf",   i,            FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED ); /* No reliable consumers of networking fragments, may be dropped or overrun */
-    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "repair_net",   0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
-    FOR(shred_tile_cnt)    fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "shred_out",    i,            FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "gossip_net",   0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
-    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "gossip_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "tower_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "replay_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "replay_epoch", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "genesi_out",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+    /*                                        topo, tile_name, tile_kind_id, fseq_wksp,   link_name,       link_kind_id, reliable,            polled */
+    FOR(net_tile_cnt)      fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "net_gossvf",    i,            FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED ); /* No reliable consumers of networking fragments, may be dropped or overrun */
+    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "repair_net",    0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
+    FOR(shred_tile_cnt)    fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "shred_out",     i,            FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "gossip_net",    0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
+    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "gossip_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "tower_out",     0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "replay_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "replay_epoch",  0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "genesi_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     if( leader_enabled ) {
-      /**/                 fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "pack_poh",     0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-      /**/                 fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "pack_execle",  0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-      FOR(execle_tile_cnt) fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "execle_poh",     i,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+      /**/                 fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "pack_poh",      0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+      /**/                 fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "pack_execle",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+      FOR(execle_tile_cnt) fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "execle_poh",    i,            FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     }
-    FOR(execrp_tile_cnt)   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "execrp_replay",  i,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+    FOR(execrp_tile_cnt)   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "execrp_replay", i,            FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
 
     if( FD_LIKELY( snapshots_enabled ) ) {
-    /**/                   fd_topob_tile_in ( topo, "gui",    0UL,           "metric_in", "snapct_gui",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-    /**/                   fd_topob_tile_in ( topo, "gui",    0UL,           "metric_in", "snapin_gui",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "snapct_gui",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "snapin_gui",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     }
     if( FD_UNLIKELY( config->tiles.bundle.enabled ) ) {
-    /**/                 fd_topob_tile_in( topo, "gui",     0UL,           "metric_in", "bundle_status", 0UL,         FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+    /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "bundle_status", 0UL,         FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     }
   }
 

--- a/src/choreo/tower/fd_tower_serdes.c
+++ b/src/choreo/tower/fd_tower_serdes.c
@@ -167,3 +167,38 @@ fd_vote_acc_root_slot( uchar const * vote_account_data ) {
   default:          FD_LOG_CRIT(( "unhandled kind %u", voter->kind ));
   }
 }
+
+int
+fd_txn_parse_simple_vote( fd_txn_t const * txn,
+                          uchar    const * payload,
+                          fd_pubkey_t *    opt_identity,
+                          fd_pubkey_t *    opt_vote_acct,
+                          ulong *          opt_vote_slot ) {
+  fd_txn_instr_t const * instr      = &txn->instr[ 0 ];
+  ulong required_accts = txn->signature_cnt==1 ? 2UL : 3UL;
+  if( FD_UNLIKELY( !fd_txn_is_simple_vote_transaction( txn, payload ) || instr->data_sz < sizeof(uint) || txn->acct_addr_cnt < required_accts ) ) return 0;
+
+  uchar const *          instr_data = payload + instr->data_off;
+  uint                   kind       = fd_uint_load_4_fast( instr_data );
+  /* Older vote instruction kinds are deprecated / ignored */
+  if( FD_UNLIKELY( kind == FD_VOTE_IX_KIND_TOWER_SYNC || kind == FD_VOTE_IX_KIND_TOWER_SYNC_SWITCH ) ) {
+    fd_compact_tower_sync_serde_t compact_tower_sync_serde[ 1 ];
+    int err = fd_compact_tower_sync_de( compact_tower_sync_serde, instr_data + sizeof(uint), instr->data_sz - sizeof(uint) );
+    if( FD_LIKELY( !err ) ) {
+      if( !!opt_vote_slot ) {
+        *opt_vote_slot = compact_tower_sync_serde->root;
+        for( ulong i = 0; i < compact_tower_sync_serde->lockouts_cnt; i++ ) *opt_vote_slot += compact_tower_sync_serde->lockouts[ i ].offset;
+      }
+      fd_pubkey_t const * accs = (fd_pubkey_t const *)fd_type_pun_const( payload + txn->acct_addr_off );
+      if( !!opt_vote_acct ) {
+        if( FD_UNLIKELY( txn->signature_cnt==1 ) ) *opt_vote_acct = *(fd_pubkey_t const *)fd_type_pun_const( &accs[ 1 ] ); /* identity and authority same, account idx 1 is the vote account address */
+        else                                       *opt_vote_acct = *(fd_pubkey_t const *)fd_type_pun_const( &accs[ 2 ] ); /* identity and authority diff, account idx 2 is the vote account address */
+      }
+      if( !!opt_identity ) {
+        *opt_identity = *(fd_pubkey_t const *)fd_type_pun_const( &accs[ 0 ] );
+      }
+      return 1;
+    }
+  }
+  return 0;
+}

--- a/src/choreo/tower/fd_tower_serdes.h
+++ b/src/choreo/tower/fd_tower_serdes.h
@@ -2,6 +2,7 @@
 #define HEADER_fd_src_choreo_tower_fd_tower_serdes_h
 
 #include "../fd_choreo_base.h"
+#include "../../ballet/txn/fd_txn.h"
 
 #define FD_VOTE_IX_KIND_TOWER_SYNC        (14)
 #define FD_VOTE_IX_KIND_TOWER_SYNC_SWITCH (15)
@@ -140,5 +141,14 @@ fd_vote_acc_vote_slot( uchar const * vote_account_data );
 
 FD_FN_PURE ulong
 fd_vote_acc_root_slot( uchar const * vote_account_data );
+
+/* fd_txn_parse_simple_vote optionally extracts the vote account pubkey,
+   identity pubkey, and largest voted-for slot from a vote transaction. */
+int
+fd_txn_parse_simple_vote( fd_txn_t const * txn,
+                          uchar    const * payload,
+                          fd_pubkey_t *    opt_identity,
+                          fd_pubkey_t *    opt_vote_acct,
+                          ulong *          opt_vote_slot );
 
 #endif /* HEADER_fd_src_choreo_tower_fd_tower_serdes_h */

--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -348,9 +348,10 @@ fd_gui_scheduler_counts_snap( fd_gui_t * gui, long now ) {
 
 static void
 fd_gui_estimated_tps_snap( fd_gui_t * gui ) {
-  ulong total_txn_cnt          = 0UL;
-  ulong vote_txn_cnt           = 0UL;
-  ulong nonvote_failed_txn_cnt = 0UL;
+  ulong vote_failed     = 0UL;
+  ulong vote_success    = 0UL;
+  ulong nonvote_success = 0UL;
+  ulong nonvote_failed  = 0UL;
 
   if( FD_LIKELY( gui->summary.slot_completed==ULONG_MAX ) ) return;
   for( ulong i=0UL; i<fd_ulong_min( gui->summary.slot_completed+1UL, FD_GUI_SLOTS_CNT ); i++ ) {
@@ -360,15 +361,16 @@ fd_gui_estimated_tps_snap( fd_gui_t * gui ) {
     if( FD_UNLIKELY( slot->completed_time==LONG_MAX ) ) continue; /* Slot is on this fork but was never completed, must have been in root path on boot. */
     if( FD_UNLIKELY( slot->completed_time+FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS*1000L*1000L*1000L<gui->next_sample_400millis ) ) break; /* Slot too old. */
     if( FD_UNLIKELY( slot->skipped ) ) continue; /* Skipped slots don't count to TPS. */
-
-    total_txn_cnt          += slot->total_txn_cnt;
-    vote_txn_cnt           += slot->vote_txn_cnt;
-    nonvote_failed_txn_cnt += slot->nonvote_failed_txn_cnt;
+    vote_failed     += slot->vote_failed;
+    vote_success    += slot->vote_success;
+    nonvote_success += slot->nonvote_success;
+    nonvote_failed  += slot->nonvote_failed;
   }
 
-  gui->summary.estimated_tps_history[ gui->summary.estimated_tps_history_idx ][ 0 ] = total_txn_cnt;
-  gui->summary.estimated_tps_history[ gui->summary.estimated_tps_history_idx ][ 1 ] = vote_txn_cnt;
-  gui->summary.estimated_tps_history[ gui->summary.estimated_tps_history_idx ][ 2 ] = nonvote_failed_txn_cnt;
+  gui->summary.estimated_tps_history[ gui->summary.estimated_tps_history_idx ].vote_failed = vote_failed;
+  gui->summary.estimated_tps_history[ gui->summary.estimated_tps_history_idx ].vote_success = vote_success;
+  gui->summary.estimated_tps_history[ gui->summary.estimated_tps_history_idx ].nonvote_success = nonvote_success;
+  gui->summary.estimated_tps_history[ gui->summary.estimated_tps_history_idx ].nonvote_failed = nonvote_failed;
   gui->summary.estimated_tps_history_idx = (gui->summary.estimated_tps_history_idx+1UL) % FD_GUI_TPS_HISTORY_SAMPLE_CNT;
 }
 
@@ -1637,10 +1639,10 @@ fd_gui_clear_slot( fd_gui_t *      gui,
   slot->skipped                = 0;
   slot->must_republish         = 1;
   slot->level                  = FD_GUI_SLOT_LEVEL_INCOMPLETE;
-  slot->total_txn_cnt          = UINT_MAX;
-  slot->vote_txn_cnt           = UINT_MAX;
-  slot->failed_txn_cnt         = UINT_MAX;
-  slot->nonvote_failed_txn_cnt = UINT_MAX;
+  slot->vote_failed            = UINT_MAX;
+  slot->vote_success           = UINT_MAX;
+  slot->nonvote_success        = UINT_MAX;
+  slot->nonvote_failed         = UINT_MAX;
   slot->compute_units          = UINT_MAX;
   slot->transaction_fee        = ULONG_MAX;
   slot->priority_fee           = ULONG_MAX;
@@ -2184,10 +2186,12 @@ fd_gui_handle_completed_slot( fd_gui_t * gui,
       slot->level = FD_GUI_SLOT_LEVEL_COMPLETED;
     }
   }
-  slot->total_txn_cnt          = total_txn_count;
-  slot->vote_txn_cnt           = total_txn_count - nonvote_txn_count;
-  slot->failed_txn_cnt         = failed_txn_count;
-  slot->nonvote_failed_txn_cnt = nonvote_failed_txn_count;
+
+  slot->nonvote_success = nonvote_txn_count - nonvote_failed_txn_count;
+  slot->nonvote_failed  = nonvote_failed_txn_count;
+  slot->vote_success    = failed_txn_count - nonvote_failed_txn_count;
+  slot->vote_failed     = total_txn_count - nonvote_txn_count - slot->vote_success;
+
   slot->transaction_fee        = transaction_fee;
   slot->priority_fee           = priority_fee;
   slot->tips                   = tips;
@@ -2830,28 +2834,24 @@ fd_gui_handle_tower_update( fd_gui_t *                   gui,
 }
 
 void
-fd_gui_handle_replay_update( fd_gui_t *                gui,
-                             fd_gui_slot_completed_t * slot_completed,
-                             fd_hash_t const *         block_hash,
-                             ulong                     vote_slot,
-                             ulong                     storage_slot,
-                             ulong                     rooted_slot,
-                             ulong                     identity_balance,
-                             long                      now ) {
+fd_gui_handle_replay_update( fd_gui_t *                         gui,
+                             fd_replay_slot_completed_t const * slot_completed,
+                             ulong                              vote_slot,
+                             long                               now ) {
   (void)now;
 
-  if( FD_LIKELY( rooted_slot!=ULONG_MAX && gui->summary.slot_rooted!=rooted_slot ) ) {
-    fd_gui_handle_rooted_slot( gui, rooted_slot );
+  if( FD_LIKELY( slot_completed->root_slot!=ULONG_MAX && gui->summary.slot_rooted!=slot_completed->root_slot ) ) {
+    fd_gui_handle_rooted_slot( gui, slot_completed->root_slot );
   }
 
-  if( FD_LIKELY( gui->summary.slot_storage!=storage_slot ) ) {
-    gui->summary.slot_storage = storage_slot;
+  if( FD_LIKELY( gui->summary.slot_storage!=slot_completed->storage_slot ) ) {
+    gui->summary.slot_storage = slot_completed->storage_slot;
     fd_gui_printf_storage_slot( gui );
     fd_http_server_ws_broadcast( gui->http );
   }
 
-  if( FD_UNLIKELY( identity_balance!=ULONG_MAX && gui->summary.identity_account_balance!=identity_balance ) ) {
-    gui->summary.identity_account_balance = identity_balance;
+  if( FD_UNLIKELY( slot_completed->identity_balance!=ULONG_MAX && gui->summary.identity_account_balance!=slot_completed->identity_balance ) ) {
+    gui->summary.identity_account_balance = slot_completed->identity_balance;
 
     fd_gui_printf_identity_balance( gui );
     fd_http_server_ws_broadcast( gui->http );
@@ -2873,12 +2873,12 @@ fd_gui_handle_replay_update( fd_gui_t *                gui,
 
   if( FD_UNLIKELY( slot->mine ) ) {
     fd_gui_leader_slot_t * lslot = fd_gui_get_leader_slot( gui, slot->slot );
-    if( FD_LIKELY( lslot ) ) fd_memcpy( lslot->block_hash.uc, block_hash->uc, sizeof(fd_hash_t) );
+    if( FD_LIKELY( lslot ) ) fd_memcpy( lslot->block_hash.uc, slot_completed->block_hash.uc, sizeof(fd_hash_t) );
   }
 
-  slot->completed_time    = slot_completed->completed_time;
+  slot->completed_time    = slot_completed->completion_time_nanos;
   slot->parent_slot       = slot_completed->parent_slot;
-  slot->max_compute_units = fd_uint_if( slot_completed->max_compute_units==UINT_MAX, slot->max_compute_units, slot_completed->max_compute_units );
+  slot->max_compute_units = fd_uint_if( slot_completed->cost_tracker.block_cost_limit==ULONG_MAX, slot->max_compute_units, (uint)slot_completed->cost_tracker.block_cost_limit );
   if( FD_LIKELY( slot->level<FD_GUI_SLOT_LEVEL_COMPLETED ) ) {
     /* Typically a slot goes from INCOMPLETE to COMPLETED but it can
        happen that it starts higher.  One such case is when we
@@ -2893,15 +2893,16 @@ fd_gui_handle_replay_update( fd_gui_t *                gui,
       slot->level = FD_GUI_SLOT_LEVEL_COMPLETED;
     }
   }
-  slot->total_txn_cnt          = slot_completed->total_txn_cnt;
-  slot->vote_txn_cnt           = slot_completed->vote_txn_cnt;
-  slot->failed_txn_cnt         = slot_completed->failed_txn_cnt;
-  slot->nonvote_failed_txn_cnt = slot_completed->nonvote_failed_txn_cnt;
+  slot->vote_failed     = fd_uint_if( slot_completed->vote_failed==ULONG_MAX,     slot->vote_failed,     (uint)slot_completed->vote_failed     );
+  slot->vote_success    = fd_uint_if( slot_completed->vote_success==ULONG_MAX,    slot->vote_success,    (uint)slot_completed->vote_success    );
+  slot->nonvote_success = fd_uint_if( slot_completed->nonvote_success==ULONG_MAX, slot->nonvote_success, (uint)slot_completed->nonvote_success );
+  slot->nonvote_failed  = fd_uint_if( slot_completed->nonvote_failed==ULONG_MAX,  slot->nonvote_failed,  (uint)slot_completed->nonvote_failed  );
+
   slot->transaction_fee        = slot_completed->transaction_fee;
   slot->priority_fee           = slot_completed->priority_fee;
   slot->tips                   = slot_completed->tips;
-  slot->compute_units          = slot_completed->compute_units;
-  slot->shred_cnt              = slot_completed->shred_cnt;
+  slot->compute_units          = fd_uint_if( slot_completed->cost_tracker.block_cost==ULONG_MAX, slot->compute_units, (uint)slot_completed->cost_tracker.block_cost );
+  slot->shred_cnt              = fd_uint_if( slot_completed->shred_cnt==ULONG_MAX, slot->shred_cnt, (uint)slot_completed->shred_cnt );
   slot->vote_slot              = vote_slot;
 
   try_publish_vote_status( gui, slot_completed->slot );
@@ -2935,7 +2936,7 @@ fd_gui_handle_replay_update( fd_gui_t *                gui,
   fd_gui_slot_staged_shred_event_t * slot_complete_event = &gui->shreds.staged[ gui->shreds.staged_tail % FD_GUI_SHREDS_STAGING_SZ ];
   gui->shreds.staged_tail++;
   slot_complete_event->event     = FD_GUI_SLOT_SHRED_SHRED_SLOT_COMPLETE;
-  slot_complete_event->timestamp = slot_completed->completed_time;
+  slot_complete_event->timestamp = slot_completed->completion_time_nanos;
   slot_complete_event->shred_idx = USHORT_MAX;
   slot_complete_event->slot      = slot->slot;
 

--- a/src/disco/gui/fd_gui.h
+++ b/src/disco/gui/fd_gui.h
@@ -11,6 +11,7 @@
 #include "../../disco/bundle/fd_bundle_tile.h"
 #include "../../discof/restore/fd_snapct_tile.h"
 #include "../../discof/tower/fd_tower_tile.h"
+#include "../../discof/replay/fd_replay_tile.h"
 #include "../../choreo/tower/fd_tower.h"
 #include "../../choreo/tower/fd_tower_serdes.h"
 #include "../../flamenco/leaders/fd_leaders.h"
@@ -341,24 +342,6 @@ struct fd_gui_turbine_slot {
 
 typedef struct fd_gui_turbine_slot fd_gui_turbine_slot_t;
 
-struct fd_gui_slot_completed {
-  ulong slot;
-  long  completed_time;
-  ulong parent_slot;
-  uint  max_compute_units;
-  uint  total_txn_cnt;
-  uint  vote_txn_cnt;
-  uint  failed_txn_cnt;
-  uint  nonvote_failed_txn_cnt;
-  ulong transaction_fee;
-  ulong priority_fee;
-  ulong tips;
-  uint  compute_units;
-  uint  shred_cnt;
-};
-
-typedef struct fd_gui_slot_completed fd_gui_slot_completed_t;
-
 struct fd_gui_slot_staged_shred_event {
   long   timestamp;
   ulong  slot;
@@ -517,16 +500,17 @@ struct fd_gui_slot {
   int   skipped;
   int   must_republish;
   int   level;
-  uint  total_txn_cnt;
-  uint  vote_txn_cnt;
-  uint  failed_txn_cnt;
-  uint  nonvote_failed_txn_cnt;
   uint  compute_units;
   ulong transaction_fee;
   ulong priority_fee;
   ulong tips;
   uint  shred_cnt;
   uchar vote_latency;
+
+  uint vote_success;
+  uint vote_failed;
+  uint nonvote_success;
+  uint nonvote_failed;
 
   /* Some slot info is only tracked for our own leader slots. These
      slots are kept in a separate buffer. */
@@ -675,7 +659,12 @@ struct fd_gui {
     ulong late_votes_sz;
 
     ulong estimated_tps_history_idx;
-    ulong estimated_tps_history[ FD_GUI_TPS_HISTORY_SAMPLE_CNT ][ 3UL ];
+    struct {
+     ulong vote_failed;
+     ulong vote_success;
+     ulong nonvote_success;
+     ulong nonvote_failed;
+    } estimated_tps_history[ FD_GUI_TPS_HISTORY_SAMPLE_CNT ];
 
     fd_gui_network_stats_t network_stats_current[ 1 ];
 
@@ -923,14 +912,10 @@ fd_gui_handle_tower_update( fd_gui_t *                   gui,
                             long                         now );
 
 void
-fd_gui_handle_replay_update( fd_gui_t *                gui,
-                             fd_gui_slot_completed_t * slot_completed,
-                             fd_hash_t const *         block_hash,
-                             ulong                     vote_slot,
-                             ulong                     storage_slot,
-                             ulong                     root_slot,
-                             ulong                     identity_balance,
-                             long                      now );
+fd_gui_handle_replay_update( fd_gui_t *                         gui,
+                             fd_replay_slot_completed_t const * slot_completed,
+                             ulong                              vote_slot,
+                             long                               now );
 
 void
 fd_gui_handle_genesis_hash( fd_gui_t *        gui,

--- a/src/disco/gui/fd_gui_peers.c
+++ b/src/disco/gui/fd_gui_peers.c
@@ -243,6 +243,11 @@ fd_gui_peers_new( void *             shmem,
 
     ctx->slot_voted = ULONG_MAX;
 
+    for( ulong i=0UL; i<2UL; i++ ) {
+      ctx->epochs[ i ].epoch      = ULONG_MAX;
+      ctx->epochs[ i ].stakes_cnt = 0UL;
+    }
+
     ctx->next_client_nanos              = now;
     ctx->next_metric_rate_update_nanos  = now;
     ctx->next_gossip_stats_update_nanos = now;
@@ -704,6 +709,7 @@ fd_gui_peers_handle_gossip_update( fd_gui_peers_ctx_t *               peers,
           memset( &peer->gossvf_rx_sum, 0, sizeof(peer->gossvf_rx_sum) );
           memset( &peer->gossip_tx_sum, 0, sizeof(peer->gossip_tx_sum) );
           peer->has_vote_info = 0;
+          peer->delinquent = 0;
           peer->stake = ULONG_MAX;
 
           fd_gui_config_parse_info_t * info =  fd_gui_peers_node_info_map_ele_query( peers->node_info_map, fd_type_pun_const(update->origin ), NULL, peers->node_info_pool );
@@ -786,134 +792,189 @@ fd_gui_peers_handle_gossip_update( fd_gui_peers_ctx_t *               peers,
     }
 }
 
-#define SORT_NAME fd_gui_peers_votes_slot_sort
-#define SORT_KEY_T fd_gui_peers_vote_t
-#define SORT_BEFORE(a,b) ((a).last_vote_slot<(b).last_vote_slot)
+#define SORT_NAME fd_gui_peers_voter_sort_iden_desc
+#define SORT_KEY_T fd_gui_peers_voter_t
+#define SORT_BEFORE(a,b) (memcmp( (a).weight.id_key.uc, (b).weight.id_key.uc, 32UL )>0)
 #include "../../util/tmpl/fd_sort.c"
 
-#define SORT_NAME fd_gui_peers_votes_stake_sort
-#define SORT_KEY_T fd_gui_peers_vote_t
-#define SORT_BEFORE(a,b) ((a).stake>(b).stake)
-#include "../../util/tmpl/fd_sort.c"
-
-#define SORT_NAME fd_gui_peers_votes_pkey_sort
-#define SORT_KEY_T fd_gui_peers_vote_t
-#define SORT_BEFORE(a,b) ( memcmp((a).node_account.uc, (b).node_account.uc, sizeof(fd_pubkey_t) ) < 0 )
+#define SORT_NAME fd_gui_peers_voter_sort_vote_desc
+#define SORT_KEY_T fd_gui_peers_voter_t
+#define SORT_BEFORE(a,b) (memcmp( (a).weight.vote_key.uc, (b).weight.vote_key.uc, 32UL )>0)
 #include "../../util/tmpl/fd_sort.c"
 
 void
-fd_gui_peers_handle_vote_update( fd_gui_peers_ctx_t *  peers,
-                                 fd_gui_peers_vote_t * votes,
-                                 ulong                 vote_cnt,
-                                 long                  now,
-                                 fd_pubkey_t *         identity ) {
-  (void)now;
-  fd_gui_peers_vote_t * votes_sorted  = votes;
-  fd_gui_peers_vote_t * votes_scratch = peers->votes_scratch;
-
-  /* deduplicate node accounts, keeping the vote accounts with largest stake */
-  fd_gui_peers_votes_stake_sort_inplace( votes_sorted, vote_cnt );
-  fd_gui_peers_votes_pkey_sort_stable( votes_sorted, vote_cnt, votes_scratch );
-
-  ulong total_stake = 0UL;
-  fd_pubkey_t prev_peer = { 0 };
-  for( ulong i=0UL; i<vote_cnt; i++ ) {
-    if( FD_UNLIKELY( !memcmp( prev_peer.uc, votes_sorted[ i ].node_account.uc, sizeof(fd_pubkey_t) ) ) ) {
-      votes_sorted[ i ].stake = ULONG_MAX; /* flag as duplicate */
-    } else {
-      total_stake += votes_sorted[ i ].stake;
-    }
-    prev_peer = votes_sorted[ i ].node_account;
-  }
-
-  /* get stake-weighted 67th percentile last_vote_slot */
-  fd_gui_peers_votes_slot_sort_inplace( votes_sorted, vote_cnt );
-
-  ulong cumulative_stake = 0UL;
-  ulong last_vote_slot_p67 = ULONG_MAX;
-  for( ulong i=0UL; i<vote_cnt; i++ ) {
-    if( FD_UNLIKELY( votes_sorted[ i ].stake==ULONG_MAX ) ) continue;
-    cumulative_stake += votes_sorted[ i ].stake;
-    if( FD_LIKELY( 3*cumulative_stake>2*total_stake ) ) {
-      last_vote_slot_p67 = votes_sorted[ i ].last_vote_slot;
-    }
-  }
-
-  /* resuse scratch to for publish state */
-  int * actions = (void *)votes_scratch;
-  ulong * idxs = (ulong *)((uchar *)votes_scratch + FD_RUNTIME_MAX_VOTE_ACCOUNTS*sizeof(int));
-  FD_STATIC_ASSERT( sizeof(peers->votes_scratch)>=(FD_RUNTIME_MAX_VOTE_ACCOUNTS*(sizeof(int) + sizeof(ulong))), "scratch too small" );
-
-  ulong count = 0UL;
-  for( ulong i=0UL; i<vote_cnt; i++ ) {
-    if( FD_UNLIKELY( votes_sorted[ i ].stake==ULONG_MAX ) ) continue;
-
-    /* votes_sorted is a copy of the vote_states bank field that has
-       been sorted by stake descending and deduplicated.  Deduplicated
-       here means if multiple vote accounts point to the same identity
-       key, we go with the one with the most stake.  TODO: This logic
-       will need to change once SIMD-0180 hits mainnet.
-
-       As long as the vote account exists, it will be in vote_states,
-       which get initialized at snapshot load and gets updated by the
-       runtime. So, on any given fork, `last_voted_slot` should reflect
-       the last landed vote for ALL the vote accounts (including those
-       referencing identity->uc) from the perspective of that fork's
-       bank, even if that slot didn't have landed votes for some of
-       those accounts. */
-    if( FD_UNLIKELY( !memcmp( &votes_sorted[ i ].node_account, identity->uc, sizeof(fd_pubkey_t) ) && peers->slot_voted!=votes_sorted[ i ].last_vote_slot ) ) {
-      peers->slot_voted = fd_ulong_if( votes_sorted[ i ].last_vote_slot==0UL, ULONG_MAX, votes_sorted[ i ].last_vote_slot );
-      fd_gui_peers_printf_vote_slot( peers );
-      fd_http_server_ws_broadcast( peers->http );
-    }
-
-    ulong peer_idx = fd_gui_peers_node_pubkey_map_idx_query( peers->node_pubkey_map, &votes_sorted[ i ].node_account, ULONG_MAX, peers->contact_info_table );
-    if( FD_UNLIKELY( peer_idx==ULONG_MAX ) ) continue; /* peer not on gossip */
-
-    fd_gui_peers_node_t * peer = peers->contact_info_table + peer_idx;
-
-    /* TODO: we only publish updates when stake changes, otherwise we'd
-       have to republish for every peer every slot, which ends up being
-       too much bandwidth because we republish all the peer info.
-       Ideally, we decouple the vote updates from the reset of the peer
-       info which would let us make updates quickly. */
-    int is_delinquent = ((long)last_vote_slot_p67 - (long)votes_sorted[ i ].last_vote_slot) > 150L;
-    int vote_eq = peer->has_vote_info
-               && !memcmp( peer->vote_account.uc, votes_sorted[ i ].vote_account.uc, sizeof(fd_pubkey_t) )
-               && peer->stake                   ==votes_sorted[ i ].stake
-            // && peer->last_vote_slot          ==votes_sorted[ i ].last_vote_slot
-            // && peer->last_vote_timestamp     ==votes_sorted[ i ].last_vote_timestamp
-            // && peer->epoch_credits           ==votes_sorted[ i ].epoch_credits
-               && peer->commission              ==votes_sorted[ i ].commission
-               && peer->epoch                   ==votes_sorted[ i ].epoch
-               && peer->delinquent              ==is_delinquent;
-
-    if( FD_LIKELY( vote_eq ) ) continue; /* nop */
-
-    peer->has_vote_info = 1;
-    peer->vote_account        = votes_sorted[ i ].vote_account;
-    peer->last_vote_slot      = votes_sorted[ i ].last_vote_slot;
-    peer->last_vote_timestamp = votes_sorted[ i ].last_vote_timestamp;
-    peer->epoch_credits       = votes_sorted[ i ].epoch_credits;
-    peer->commission          = votes_sorted[ i ].commission;
-    peer->epoch               = votes_sorted[ i ].epoch;
-    peer->delinquent          = is_delinquent;
-
-    if( FD_UNLIKELY( peer->stake!=votes_sorted[ i ].stake ) ) {
-      fd_gui_peers_live_table_idx_remove( peers->live_table, peer_idx, peers->contact_info_table );
-      peer->stake = votes_sorted[ i ].stake;
-      fd_gui_peers_live_table_idx_insert( peers->live_table, peer_idx, peers->contact_info_table );
-    }
-
-    actions[ count ] = FD_GUI_PEERS_NODE_UPDATE;
-    idxs   [ count ] = peer_idx;
-    count++;
-  }
-
-  if( FD_UNLIKELY( count ) ) {
-    fd_gui_peers_printf_nodes( peers, actions, idxs, count );
+fd_gui_peers_handle_vote( fd_gui_peers_ctx_t * peers,
+                          fd_pubkey_t const *  vote_account,
+                          ulong                vote_slot,
+                          int                  is_us ) {
+  if( FD_UNLIKELY( is_us && peers->slot_voted!=vote_slot ) ) {
+    peers->slot_voted = fd_ulong_if( vote_slot==0UL, ULONG_MAX, vote_slot );
+    fd_gui_peers_printf_vote_slot( peers );
     fd_http_server_ws_broadcast( peers->http );
   }
+
+  for( ulong i=0UL; i<2UL; i++ ) {
+    ulong peer_idx = fd_gui_peers_voter_sort_vote_desc_split( peers->epochs[ i ].stakes, peers->epochs[ i ].stakes_cnt, (fd_gui_peers_voter_t){ .weight = { .vote_key = *vote_account } } );
+    if( FD_UNLIKELY( peer_idx>=peers->epochs[ i ].stakes_cnt || memcmp( peers->epochs[ i ].stakes[ peer_idx ].weight.vote_key.uc, vote_account->uc, sizeof(fd_pubkey_t) ) ) ) continue;
+
+    fd_gui_peers_voter_t * voter = &peers->epochs[ i ].stakes[ peer_idx ];
+    voter->vote_slot = fd_ulong_if( voter->vote_slot==ULONG_MAX, vote_slot, fd_ulong_max( voter->vote_slot, vote_slot ) );
+  }
+}
+
+static inline fd_gui_peers_voter_t const *
+fd_gui_peers_voter_best_for_identity( fd_gui_peers_voter_t const * voters,
+                                      ulong                        voter_cnt,
+                                      ulong *                      p_i ) {
+  ulong i = *p_i;
+  ulong j = i + 1UL;
+  fd_gui_peers_voter_t const * best = &voters[ i ];
+  while( j<voter_cnt && !memcmp( voters[ j ].weight.id_key.uc, best->weight.id_key.uc, 32UL ) ) {
+    fd_gui_peers_voter_t const * candidate  = &voters[ j ];
+    ulong                        slot_best  = fd_ulong_if( best->vote_slot==ULONG_MAX, 0UL, best->vote_slot );
+    ulong                        slot_cand  = fd_ulong_if( candidate->vote_slot==ULONG_MAX, 0UL, candidate->vote_slot );
+    if( ( slot_cand>slot_best ) || ( ( slot_cand==slot_best ) && ( candidate->weight.stake>best->weight.stake ) ) ) {
+      best = candidate;
+    }
+    j++;
+  }
+  *p_i = j;
+  return best;
+}
+
+void
+fd_gui_peers_handle_epoch_info( fd_gui_peers_ctx_t *        peers,
+                                fd_epoch_info_msg_t const * epoch_info,
+                                long                        now FD_PARAM_UNUSED ) {
+  ulong epoch_idx = epoch_info->epoch % 2UL;
+  if( FD_UNLIKELY( peers->epochs[ epoch_idx ].epoch!=ULONG_MAX && peers->epochs[ epoch_idx ].epoch>=epoch_info->epoch ) ) return;
+
+  if( FD_UNLIKELY( epoch_info->staked_cnt>FD_RUNTIME_MAX_VOTE_ACCOUNTS ) )
+    FD_LOG_WARNING(( "epoch stakes exceed FD_RUNTIME_MAX_VOTE_ACCOUNTS=%lu", FD_RUNTIME_MAX_VOTE_ACCOUNTS ));
+
+  peers->epochs[ epoch_idx ].epoch = epoch_info->epoch;
+  peers->epochs[ epoch_idx ].stakes_cnt = fd_ulong_min( epoch_info->staked_cnt, FD_RUNTIME_MAX_VOTE_ACCOUNTS );
+  for( ulong i=0UL; i<peers->epochs[ epoch_idx ].stakes_cnt; i++ ) {
+    peers->epochs[ epoch_idx ].stakes[ i ] = (fd_gui_peers_voter_t){
+      .weight           = epoch_info->weights[ i ],
+      .vote_slot        = ULONG_MAX,
+    };
+  }
+
+  /* sort for deduplication */
+  fd_gui_peers_voter_sort_iden_desc_inplace( peers->epochs[ epoch_idx ].stakes, peers->epochs[ epoch_idx ].stakes_cnt );
+
+  ulong updated_cnt = 0UL;
+  ulong i=0UL;
+  while( i<peers->epochs[ epoch_idx ].stakes_cnt ) {
+    fd_gui_peers_voter_t const * best = fd_gui_peers_voter_best_for_identity( peers->epochs[ epoch_idx ].stakes, peers->epochs[ epoch_idx ].stakes_cnt, &i );
+
+    ulong peer_idx = fd_gui_peers_node_pubkey_map_idx_query(
+        peers->node_pubkey_map, &best->weight.id_key, ULONG_MAX,
+        peers->contact_info_table );
+    if( FD_UNLIKELY( peer_idx==ULONG_MAX ) ) continue;
+
+    fd_gui_peers_node_t * peer = &peers->contact_info_table[ peer_idx ];
+
+    int vote_eq = peer->has_vote_info
+               && !memcmp( peer->vote_account.uc, best->weight.vote_key.uc, sizeof(fd_pubkey_t) )
+               && peer->stake==best->weight.stake;
+    if( FD_LIKELY( vote_eq ) ) continue;
+
+    fd_gui_peers_live_table_idx_remove( peers->live_table, peer_idx, peers->contact_info_table );
+
+    peer->has_vote_info = 1;
+    peer->vote_account  = best->weight.vote_key;
+    peer->stake         = best->weight.stake;
+
+    fd_gui_peers_live_table_idx_insert( peers->live_table, peer_idx, peers->contact_info_table );
+
+    peers->scratch.actions[ updated_cnt ] = FD_GUI_PEERS_NODE_UPDATE;
+    peers->scratch.idxs   [ updated_cnt ] = peer_idx;
+    updated_cnt++;
+  }
+
+  if( FD_UNLIKELY( updated_cnt ) ) {
+    fd_gui_peers_printf_nodes( peers, peers->scratch.actions, peers->scratch.idxs, updated_cnt );
+    fd_http_server_ws_broadcast( peers->http );
+  }
+
+  /* maintain invariant for fd_gui_peers_handle_vote */
+  fd_gui_peers_voter_sort_vote_desc_inplace( peers->epochs[ epoch_idx ].stakes, peers->epochs[ epoch_idx ].stakes_cnt );
+}
+
+#define SORT_NAME        fd_gui_peers_voter_sort_slot_stake_desc
+#define SORT_KEY_T       fd_gui_peers_voter_t
+#define SORT_BEFORE(a,b) ((a).vote_slot>(b).vote_slot ? 1 : (a).vote_slot<(b).vote_slot ? 0 : (a).weight.stake>(b).weight.stake)
+#include "../../util/tmpl/fd_sort.c"
+
+void
+fd_gui_peers_update_delinquency( fd_gui_peers_ctx_t * peers,
+                                 long                 now FD_PARAM_UNUSED ) {
+  ulong epoch_t_2     = ULONG_MAX;
+  for( ulong i=0UL; i<2UL; i++ ) if( epoch_t_2==ULONG_MAX || peers->epochs[ i ].epoch<epoch_t_2 ) epoch_t_2 = peers->epochs[ i ].epoch;
+  ulong epoch_idx = epoch_t_2 % 2UL;
+
+  fd_gui_peers_voter_t * voters     = peers->epochs[ epoch_idx ].stakes;
+  ulong                  voters_cnt = peers->epochs[ epoch_idx ].stakes_cnt;
+
+  /* Sort for p67 computation */
+  fd_gui_peers_voter_sort_slot_stake_desc_inplace( voters, voters_cnt );
+
+  ulong total_stake = 0UL;
+  for( ulong i=0UL; i<voters_cnt; i++ ) total_stake += voters[ i ].weight.stake;
+
+  ulong cumulative_stake   = 0UL;
+  ulong last_vote_slot_p33 = ULONG_MAX;
+  for( ulong i=0UL; i<voters_cnt; i++ ) {
+    if( FD_UNLIKELY( voters[ i ].vote_slot==ULONG_MAX ) ) continue;
+    cumulative_stake += voters[ i ].weight.stake;
+    if( FD_LIKELY( 3UL*cumulative_stake > 1UL*total_stake ) ) {
+      last_vote_slot_p33 = voters[ i ].vote_slot;
+      break;
+    }
+  }
+  if( FD_UNLIKELY( last_vote_slot_p33==ULONG_MAX ) ) {
+    /* maintain invariant for fd_gui_peers_handle_vote */
+    fd_gui_peers_voter_sort_vote_desc_inplace( voters, voters_cnt );
+
+    return; /* not enough observed votes */
+  }
+
+  /* sort by identity for deduplication */
+  fd_gui_peers_voter_sort_iden_desc_inplace( voters, voters_cnt );
+
+  ulong updated_cnt = 0UL;
+  for( ulong i=0UL; i<voters_cnt; i++ ) {
+    ulong peer_idx = fd_gui_peers_node_pubkey_map_idx_query(
+        peers->node_pubkey_map, &voters[ i ].weight.id_key, ULONG_MAX,
+        peers->contact_info_table );
+    if( FD_UNLIKELY( peer_idx==ULONG_MAX ) ) continue;
+
+    fd_gui_peers_node_t * peer = &peers->contact_info_table[ peer_idx ];
+
+    /* Only update peers whose vote_account was already set by
+       handle_epoch_info and matches this voter */
+    if( FD_UNLIKELY( !peer->has_vote_info ) ) continue;
+    if( FD_UNLIKELY( memcmp( peer->vote_account.uc, voters[ i ].weight.vote_key.uc, sizeof(fd_pubkey_t) ) ) ) continue;
+
+    int is_delinquent = fd_int_if( voters[ i ].vote_slot==ULONG_MAX, 1, ((long)last_vote_slot_p33 - (long)voters[ i ].vote_slot) > 150L );
+    if( FD_LIKELY( peer->delinquent==is_delinquent ) ) continue;
+
+    peer->delinquent = is_delinquent;
+
+    peers->scratch.actions[ updated_cnt ] = FD_GUI_PEERS_NODE_UPDATE;
+    peers->scratch.idxs   [ updated_cnt ] = peer_idx;
+    updated_cnt++;
+  }
+
+  if( FD_UNLIKELY( updated_cnt ) ) {
+    fd_gui_peers_printf_nodes( peers, peers->scratch.actions, peers->scratch.idxs, updated_cnt );
+    fd_http_server_ws_broadcast( peers->http );
+  }
+
+  /* maintain invariant for fd_gui_peers_handle_vote */
+  fd_gui_peers_voter_sort_vote_desc_inplace( voters, voters_cnt );
 }
 
 void

--- a/src/disco/gui/fd_gui_peers.h
+++ b/src/disco/gui/fd_gui_peers.h
@@ -131,18 +131,11 @@ fd_gui_peers_adaptive_ema( long last_update_time,
     return (long)(alpha * (double)current_value + (1.0 - alpha) * (double)value_at_last_update);
 }
 
-struct fd_gui_peers_vote {
-  fd_pubkey_t node_account;
-  fd_pubkey_t vote_account;
-  ulong       stake;
-  ulong       last_vote_slot;
-  long        last_vote_timestamp;
-  uchar       commission;
-  ulong       epoch;
-  ulong       epoch_credits;
+struct fd_gui_peers_voter {
+  fd_vote_stake_weight_t weight;
+  ulong vote_slot;
 };
-
-typedef struct fd_gui_peers_vote fd_gui_peers_vote_t;
+typedef struct fd_gui_peers_voter fd_gui_peers_voter_t;
 
 struct fd_gui_peers_node {
   int valid;
@@ -159,15 +152,11 @@ struct fd_gui_peers_node {
 
   int         has_vote_info;
   fd_pubkey_t vote_account;
-  ulong       stake; /* if has_vote_info==0 then stake==ULONG_MAX */
-  ulong       last_vote_slot;
-  long        last_vote_timestamp;
-  uchar       commission;
-  ulong       epoch;
-  ulong       epoch_credits;
+  int         delinquent;
+  ulong       stake;
+
   uchar       country_code_idx;
   uint        city_name_idx;
-  int         delinquent;
 
   struct {
     ulong next;
@@ -387,8 +376,23 @@ struct fd_gui_peers_ctx {
 
   ulong slot_voted; /* last vote slot for this validator */
 
-  fd_gui_peers_vote_t votes        [ FD_RUNTIME_MAX_VOTE_ACCOUNTS ];
-  fd_gui_peers_vote_t votes_scratch[ FD_RUNTIME_MAX_VOTE_ACCOUNTS ]; /* for fast stable sort */
+  /* We want the gui to reflect stakes_t_2 since this is what matters
+     consequentially for delinquency / leader schedule info.
+
+     All arrays are sorted descending by vote pubkey. */
+  struct {
+    ulong epoch;
+
+    ulong                stakes_cnt;
+    fd_gui_peers_voter_t stakes[ FD_RUNTIME_MAX_VOTE_ACCOUNTS ];
+  } epochs[ 2 ];
+
+  union {
+    struct {
+      int   actions[ FD_CONTACT_INFO_TABLE_SIZE ];
+      ulong idxs   [ FD_CONTACT_INFO_TABLE_SIZE ];
+    };
+  } scratch;
 
 #if FD_HAS_ZSTD
   ZSTD_DCtx * zstd_dctx;
@@ -445,11 +449,24 @@ fd_gui_peers_handle_gossip_update( fd_gui_peers_ctx_t *               peers,
                                    long                               now );
 
 void
-fd_gui_peers_handle_vote_update( fd_gui_peers_ctx_t *  peers,
-                                 fd_gui_peers_vote_t * votes,
-                                 ulong                 vote_cnt,
-                                 long                  now,
-                                 fd_pubkey_t *         identity );
+fd_gui_peers_handle_vote( fd_gui_peers_ctx_t * peers,
+                          fd_pubkey_t const *  vote_account,
+                          ulong                vote_slot,
+                          int                  is_us );
+
+/* fd_gui_peers_update_delinquency is called infrequently (currently,
+   once per slot) and scans the cluster for any nodes that are
+   delinquent, publishing delinquency updates to the frontend. */
+void
+fd_gui_peers_update_delinquency( fd_gui_peers_ctx_t * peers,
+                                 long                 now );
+
+/* fd_gui_peers_handle_epoch_info is called at the epoch boundary and
+   publishes updates for peer stake information. */
+void
+fd_gui_peers_handle_epoch_info( fd_gui_peers_ctx_t *        peers,
+                                fd_epoch_info_msg_t const * epoch_info,
+                                long                        now );
 
 void
 fd_gui_peers_handle_config_account( fd_gui_peers_ctx_t *  peers,

--- a/src/disco/gui/fd_gui_printf.c
+++ b/src/disco/gui/fd_gui_printf.c
@@ -496,11 +496,16 @@ fd_gui_printf_tps_history( fd_gui_t * gui ) {
 
     for( ulong i=0UL; i<FD_GUI_TPS_HISTORY_SAMPLE_CNT; i++ ) {
       ulong idx = (gui->summary.estimated_tps_history_idx+i) % FD_GUI_TPS_HISTORY_SAMPLE_CNT;
+      ulong vote_cnt = gui->summary.estimated_tps_history[ idx ].vote_failed
+                     + gui->summary.estimated_tps_history[ idx ].vote_success;
+      ulong total_cnt = vote_cnt
+                      + gui->summary.estimated_tps_history[ idx ].nonvote_success
+                      + gui->summary.estimated_tps_history[ idx ].nonvote_failed;
       jsonp_open_array( gui->http, NULL );
-        jsonp_double( gui->http, NULL, (double)gui->summary.estimated_tps_history[ idx ][ 0 ]/(double)FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS );
-        jsonp_double( gui->http, NULL, (double)gui->summary.estimated_tps_history[ idx ][ 1 ]/(double)FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS );
-        jsonp_double( gui->http, NULL, (double)(gui->summary.estimated_tps_history[ idx ][ 0 ] - gui->summary.estimated_tps_history[ idx ][ 1 ] - gui->summary.estimated_tps_history[ idx ][ 2 ])/(double)FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS );
-        jsonp_double( gui->http, NULL, (double)gui->summary.estimated_tps_history[ idx ][ 2 ]/(double)FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS );
+        jsonp_double( gui->http, NULL, (double)total_cnt/(double)FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS );
+        jsonp_double( gui->http, NULL, (double)vote_cnt/(double)FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS );
+        jsonp_double( gui->http, NULL, (double)gui->summary.estimated_tps_history[ idx ].nonvote_success/(double)FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS );
+        jsonp_double( gui->http, NULL, (double)gui->summary.estimated_tps_history[ idx ].nonvote_failed/(double)FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS );
       jsonp_close_array( gui->http );
     }
 
@@ -1077,10 +1082,15 @@ fd_gui_printf_estimated_tps( fd_gui_t * gui ) {
 
   jsonp_open_envelope( gui->http, "summary", "estimated_tps" );
     jsonp_open_object( gui->http, "value" );
-      jsonp_double( gui->http, "total",           (double)gui->summary.estimated_tps_history[ idx ][ 0 ]/(double)FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS );
-      jsonp_double( gui->http, "vote",            (double)gui->summary.estimated_tps_history[ idx ][ 1 ]/(double)FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS );
-      jsonp_double( gui->http, "nonvote_success", (double)(gui->summary.estimated_tps_history[ idx ][ 0 ] - gui->summary.estimated_tps_history[ idx ][ 1 ] - gui->summary.estimated_tps_history[ idx ][ 2 ])/(double)FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS );
-      jsonp_double( gui->http, "nonvote_failed",  (double)gui->summary.estimated_tps_history[ idx ][ 2 ]/(double)FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS );
+      ulong vote_cnt = gui->summary.estimated_tps_history[ idx ].vote_failed
+                    + gui->summary.estimated_tps_history[ idx ].vote_success;
+      ulong total_cnt = vote_cnt
+                      + gui->summary.estimated_tps_history[ idx ].nonvote_success
+                      + gui->summary.estimated_tps_history[ idx ].nonvote_failed;
+      jsonp_double( gui->http, "total",           (double)total_cnt/(double)FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS );
+      jsonp_double( gui->http, "vote",            (double)vote_cnt/(double)FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS );
+      jsonp_double( gui->http, "nonvote_success", (double)gui->summary.estimated_tps_history[ idx ].nonvote_success/(double)FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS );
+      jsonp_double( gui->http, "nonvote_failed",  (double)gui->summary.estimated_tps_history[ idx ].nonvote_failed/(double)FD_GUI_TPS_HISTORY_WINDOW_DURATION_SECONDS );
     jsonp_close_object( gui->http );
   jsonp_close_envelope( gui->http );
 }
@@ -1286,11 +1296,11 @@ peers_printf_node( fd_gui_peers_ctx_t *  peers,
           char vote_account_base58[ FD_BASE58_ENCODED_32_SZ ];
           fd_base58_encode_32( peer->vote_account.uc, NULL, vote_account_base58 );
           jsonp_string( peers->http, "vote_account", vote_account_base58 );
-          jsonp_ulong_as_str( peers->http, "activated_stake", peer->stake );
-          jsonp_ulong( peers->http, "last_vote", peer->last_vote_slot );
-          jsonp_ulong( peers->http, "epoch_credits", peer->epoch_credits );
-          jsonp_ulong( peers->http, "commission", peer->commission );
-          jsonp_ulong( peers->http, "root_slot", 0UL );
+          jsonp_ulong_as_str( peers->http, "activated_stake", fd_ulong_if( peer->stake==ULONG_MAX, 0UL, peer->stake ) );
+          jsonp_ulong( peers->http, "last_vote", 0UL ); /* todo: deprecate */
+          jsonp_ulong( peers->http, "epoch_credits", 0UL ); /* todo: deprecate */
+          jsonp_ulong( peers->http, "commission", 0UL ); /* todo: deprecate */
+          jsonp_ulong( peers->http, "root_slot", 0UL ); /* todo: deprecate */
           jsonp_bool( peers->http,  "delinquent", peer->delinquent );
         jsonp_close_object( peers->http );
       jsonp_close_array( peers->http );
@@ -1594,19 +1604,14 @@ fd_gui_printf_slot( fd_gui_t * gui,
         if( FD_UNLIKELY( slot->completed_time==LONG_MAX ) ) jsonp_null( gui->http, "completed_time_nanos" );
         else                                                jsonp_long_as_str( gui->http, "completed_time_nanos", slot->completed_time );
         jsonp_string( gui->http, "level", level );
-        if( FD_UNLIKELY( slot->total_txn_cnt==UINT_MAX
-                         || slot->vote_txn_cnt==UINT_MAX
-                         || slot->nonvote_failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui->http, "success_nonvote_transaction_cnt" );
-        else                                                           jsonp_ulong( gui->http, "success_nonvote_transaction_cnt", slot->total_txn_cnt - slot->vote_txn_cnt - slot->nonvote_failed_txn_cnt );
-        if( FD_UNLIKELY( slot->nonvote_failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui->http, "failed_nonvote_transaction_cnt" );
-        else                                                        jsonp_ulong( gui->http, "failed_nonvote_transaction_cnt", slot->nonvote_failed_txn_cnt );
-        if( FD_UNLIKELY( slot->vote_txn_cnt==UINT_MAX
-                         || slot->failed_txn_cnt==UINT_MAX
-                         || slot->nonvote_failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui->http, "success_vote_transaction_cnt" );
-        else                                                           jsonp_ulong( gui->http, "success_vote_transaction_cnt", slot->vote_txn_cnt - (slot->failed_txn_cnt - slot->nonvote_failed_txn_cnt) );
-        if( FD_UNLIKELY( slot->failed_txn_cnt==UINT_MAX
-                         || slot->nonvote_failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui->http, "failed_vote_transaction_cnt" );
-        else                                                           jsonp_ulong( gui->http, "failed_vote_transaction_cnt", slot->failed_txn_cnt - slot->nonvote_failed_txn_cnt );
+        if( FD_UNLIKELY( slot->nonvote_success==UINT_MAX ) ) jsonp_null( gui->http, "success_nonvote_transaction_cnt" );
+        else                                                           jsonp_ulong( gui->http, "success_nonvote_transaction_cnt", slot->nonvote_success );
+        if( FD_UNLIKELY( slot->nonvote_failed==UINT_MAX ) ) jsonp_null( gui->http, "failed_nonvote_transaction_cnt" );
+        else                                                jsonp_ulong( gui->http, "failed_nonvote_transaction_cnt", slot->nonvote_failed );
+        if( FD_UNLIKELY( slot->vote_success==UINT_MAX ) ) jsonp_null( gui->http, "success_vote_transaction_cnt" );
+        else                                              jsonp_ulong( gui->http, "success_vote_transaction_cnt", slot->vote_success );
+        if( FD_UNLIKELY( slot->vote_failed==UINT_MAX ) ) jsonp_null( gui->http, "failed_vote_transaction_cnt" );
+        else                                             jsonp_ulong( gui->http, "failed_vote_transaction_cnt", slot->vote_failed );
         if( FD_UNLIKELY( slot->max_compute_units==UINT_MAX ) ) jsonp_null( gui->http, "max_compute_units" );
         else                                                   jsonp_ulong( gui->http, "max_compute_units", slot->max_compute_units );
         if( FD_UNLIKELY( slot->compute_units==UINT_MAX ) ) jsonp_null( gui->http, "compute_units" );
@@ -1733,19 +1738,14 @@ fd_gui_printf_slot_request( fd_gui_t * gui,
         else                                          jsonp_long( gui->http, "duration_nanos", duration_nanos );
         if( FD_UNLIKELY( slot->completed_time==LONG_MAX ) ) jsonp_null( gui->http, "completed_time_nanos" );
         else                                                jsonp_long_as_str( gui->http, "completed_time_nanos", slot->completed_time );
-        if( FD_UNLIKELY( slot->total_txn_cnt==UINT_MAX
-                         || slot->vote_txn_cnt==UINT_MAX
-                         || slot->nonvote_failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui->http, "success_nonvote_transaction_cnt" );
-        else                                                           jsonp_ulong( gui->http, "success_nonvote_transaction_cnt", slot->total_txn_cnt - slot->vote_txn_cnt - slot->nonvote_failed_txn_cnt );
-        if( FD_UNLIKELY( slot->nonvote_failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui->http, "failed_nonvote_transaction_cnt" );
-        else                                                        jsonp_ulong( gui->http, "failed_nonvote_transaction_cnt", slot->nonvote_failed_txn_cnt );
-        if( FD_UNLIKELY( slot->vote_txn_cnt==UINT_MAX
-                         || slot->failed_txn_cnt==UINT_MAX
-                         || slot->nonvote_failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui->http, "success_vote_transaction_cnt" );
-        else                                                           jsonp_ulong( gui->http, "success_vote_transaction_cnt", slot->vote_txn_cnt - (slot->failed_txn_cnt - slot->nonvote_failed_txn_cnt) );
-        if( FD_UNLIKELY( slot->failed_txn_cnt==UINT_MAX
-                         || slot->nonvote_failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui->http, "failed_vote_transaction_cnt" );
-        else                                                           jsonp_ulong( gui->http, "failed_vote_transaction_cnt", slot->failed_txn_cnt - slot->nonvote_failed_txn_cnt );
+        if( FD_UNLIKELY( slot->nonvote_success==UINT_MAX ) ) jsonp_null( gui->http, "success_nonvote_transaction_cnt" );
+        else                                                 jsonp_ulong( gui->http, "success_nonvote_transaction_cnt", slot->nonvote_success );
+        if( FD_UNLIKELY( slot->nonvote_failed==UINT_MAX ) ) jsonp_null( gui->http, "failed_nonvote_transaction_cnt" );
+        else                                                        jsonp_ulong( gui->http, "failed_nonvote_transaction_cnt", slot->nonvote_failed );
+        if( FD_UNLIKELY( slot->vote_success==UINT_MAX ) ) jsonp_null( gui->http, "success_vote_transaction_cnt" );
+        else                                              jsonp_ulong( gui->http, "success_vote_transaction_cnt", slot->vote_success );
+        if( FD_UNLIKELY( slot->vote_failed==UINT_MAX ) ) jsonp_null( gui->http, "failed_vote_transaction_cnt" );
+        else                                             jsonp_ulong( gui->http, "failed_vote_transaction_cnt", slot->vote_failed );
         if( FD_UNLIKELY( slot->max_compute_units==UINT_MAX ) ) jsonp_null( gui->http, "max_compute_units" );
         else                                                   jsonp_ulong( gui->http, "max_compute_units", slot->max_compute_units );
         if( FD_UNLIKELY( slot->compute_units==UINT_MAX ) ) jsonp_null( gui->http, "compute_units" );
@@ -1810,19 +1810,14 @@ fd_gui_printf_slot_transactions_request( fd_gui_t * gui,
         else                                          jsonp_long( gui->http, "duration_nanos", duration_nanos );
         if( FD_UNLIKELY( slot->completed_time==LONG_MAX ) ) jsonp_null( gui->http, "completed_time_nanos" );
         else                                                jsonp_long_as_str( gui->http, "completed_time_nanos", slot->completed_time );
-        if( FD_UNLIKELY( slot->total_txn_cnt==UINT_MAX
-                         || slot->vote_txn_cnt==UINT_MAX
-                         || slot->nonvote_failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui->http, "success_nonvote_transaction_cnt" );
-        else                                                           jsonp_ulong( gui->http, "success_nonvote_transaction_cnt", slot->total_txn_cnt - slot->vote_txn_cnt - slot->nonvote_failed_txn_cnt );
-        if( FD_UNLIKELY( slot->nonvote_failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui->http, "failed_nonvote_transaction_cnt" );
-        else                                                        jsonp_ulong( gui->http, "failed_nonvote_transaction_cnt", slot->nonvote_failed_txn_cnt );
-        if( FD_UNLIKELY( slot->vote_txn_cnt==UINT_MAX
-                         || slot->failed_txn_cnt==UINT_MAX
-                         || slot->nonvote_failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui->http, "success_vote_transaction_cnt" );
-        else                                                           jsonp_ulong( gui->http, "success_vote_transaction_cnt", slot->vote_txn_cnt - (slot->failed_txn_cnt - slot->nonvote_failed_txn_cnt) );
-        if( FD_UNLIKELY( slot->failed_txn_cnt==UINT_MAX
-                         || slot->nonvote_failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui->http, "failed_vote_transaction_cnt" );
-        else                                                           jsonp_ulong( gui->http, "failed_vote_transaction_cnt", slot->failed_txn_cnt - slot->nonvote_failed_txn_cnt );
+        if( FD_UNLIKELY( slot->nonvote_success==UINT_MAX ) ) jsonp_null( gui->http, "success_nonvote_transaction_cnt" );
+        else                                                 jsonp_ulong( gui->http, "success_nonvote_transaction_cnt", slot->nonvote_success );
+        if( FD_UNLIKELY( slot->nonvote_failed==UINT_MAX ) ) jsonp_null( gui->http, "failed_nonvote_transaction_cnt" );
+        else                                                        jsonp_ulong( gui->http, "failed_nonvote_transaction_cnt", slot->nonvote_failed );
+        if( FD_UNLIKELY( slot->vote_success==UINT_MAX ) ) jsonp_null( gui->http, "success_vote_transaction_cnt" );
+        else                                              jsonp_ulong( gui->http, "success_vote_transaction_cnt", slot->vote_success );
+        if( FD_UNLIKELY( slot->vote_failed==UINT_MAX ) ) jsonp_null( gui->http, "failed_vote_transaction_cnt" );
+        else                                             jsonp_ulong( gui->http, "failed_vote_transaction_cnt", slot->vote_failed );
         if( FD_UNLIKELY( slot->max_compute_units==UINT_MAX ) ) jsonp_null( gui->http, "max_compute_units" );
         else                                                   jsonp_ulong( gui->http, "max_compute_units", slot->max_compute_units );
         if( FD_UNLIKELY( slot->compute_units==UINT_MAX ) ) jsonp_null( gui->http, "compute_units" );
@@ -2092,19 +2087,14 @@ fd_gui_printf_slot_request_detailed( fd_gui_t * gui,
         else                                          jsonp_long( gui->http, "duration_nanos", duration_nanos );
         if( FD_UNLIKELY( slot->completed_time==LONG_MAX ) ) jsonp_null( gui->http, "completed_time_nanos" );
         else                                                jsonp_long_as_str( gui->http, "completed_time_nanos", slot->completed_time );
-        if( FD_UNLIKELY( slot->total_txn_cnt==UINT_MAX
-                         || slot->vote_txn_cnt==UINT_MAX
-                         || slot->nonvote_failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui->http, "success_nonvote_transaction_cnt" );
-        else                                                           jsonp_ulong( gui->http, "success_nonvote_transaction_cnt", slot->total_txn_cnt - slot->vote_txn_cnt - slot->nonvote_failed_txn_cnt );
-        if( FD_UNLIKELY( slot->nonvote_failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui->http, "failed_nonvote_transaction_cnt" );
-        else                                                        jsonp_ulong( gui->http, "failed_nonvote_transaction_cnt", slot->nonvote_failed_txn_cnt );
-        if( FD_UNLIKELY( slot->vote_txn_cnt==UINT_MAX
-                         || slot->failed_txn_cnt==UINT_MAX
-                         || slot->nonvote_failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui->http, "success_vote_transaction_cnt" );
-        else                                                           jsonp_ulong( gui->http, "success_vote_transaction_cnt", slot->vote_txn_cnt - (slot->failed_txn_cnt - slot->nonvote_failed_txn_cnt) );
-        if( FD_UNLIKELY( slot->failed_txn_cnt==UINT_MAX
-                         || slot->nonvote_failed_txn_cnt==UINT_MAX ) ) jsonp_null( gui->http, "failed_vote_transaction_cnt" );
-        else                                                           jsonp_ulong( gui->http, "failed_vote_transaction_cnt", slot->failed_txn_cnt - slot->nonvote_failed_txn_cnt );
+        if( FD_UNLIKELY( slot->nonvote_success==UINT_MAX ) ) jsonp_null( gui->http, "success_nonvote_transaction_cnt" );
+        else                                                 jsonp_ulong( gui->http, "success_nonvote_transaction_cnt", slot->nonvote_success );
+        if( FD_UNLIKELY( slot->nonvote_failed==UINT_MAX ) ) jsonp_null( gui->http, "failed_nonvote_transaction_cnt" );
+        else                                                        jsonp_ulong( gui->http, "failed_nonvote_transaction_cnt", slot->nonvote_failed );
+        if( FD_UNLIKELY( slot->vote_success==UINT_MAX ) ) jsonp_null( gui->http, "success_vote_transaction_cnt" );
+        else                                              jsonp_ulong( gui->http, "success_vote_transaction_cnt", slot->vote_success );
+        if( FD_UNLIKELY( slot->vote_failed==UINT_MAX ) ) jsonp_null( gui->http, "failed_vote_transaction_cnt" );
+        else                                             jsonp_ulong( gui->http, "failed_vote_transaction_cnt", slot->vote_failed );
         if( FD_UNLIKELY( slot->max_compute_units==UINT_MAX ) ) jsonp_null( gui->http, "max_compute_units" );
         else                                                   jsonp_ulong( gui->http, "max_compute_units", slot->max_compute_units );
         if( FD_UNLIKELY( slot->compute_units==UINT_MAX ) ) jsonp_null( gui->http, "compute_units" );

--- a/src/disco/gui/fd_gui_tile.c
+++ b/src/disco/gui/fd_gui_tile.c
@@ -15,10 +15,10 @@
 static fd_http_static_file_t * STATIC_FILES;
 
 #include <sys/socket.h> /* SOCK_CLOEXEC, SOCK_NONBLOCK needed for seccomp filter */
-#include <stdlib.h>
 
 #include "generated/fd_gui_tile_seccomp.h"
 
+#include "../../choreo/tower/fd_tower_serdes.h"
 #include "../../disco/tiles.h"
 #include "../../disco/keyguard/fd_keyload.h"
 #include "../../disco/keyguard/fd_keyswitch.h"
@@ -34,9 +34,6 @@ static fd_http_static_file_t * STATIC_FILES;
 #include "../../util/clock/fd_clock.h"
 #include "../../discof/repair/fd_repair.h"
 #include "../../discof/replay/fd_replay_tile.h"
-#include "../../util/pod/fd_pod_format.h"
-
-#include "../../flamenco/runtime/fd_bank.h"
 
 #define IN_KIND_PLUGIN        ( 0UL)
 #define IN_KIND_POH_PACK      ( 1UL)
@@ -97,7 +94,6 @@ typedef struct fd_gui_out_ctx fd_gui_out_ctx_t;
 
 typedef struct {
   fd_topo_t * topo;
-  fd_banks_t  banks[1];
 
   int is_full_client;
   int snapshots_enabled;
@@ -148,8 +144,6 @@ typedef struct {
   fd_gui_in_ctx_t in[ 64UL ];
 
   fd_net_rx_bounds_t net_in_bounds[ 64UL ];
-
-  fd_gui_out_ctx_t replay_out[ 1 ];
 } fd_gui_ctx_t;
 
 FD_FN_CONST static inline ulong
@@ -349,6 +343,14 @@ after_frag( fd_gui_ctx_t *      ctx,
         long tsorig_ns = ctx->ref_wallclock + (long)((double)(fd_frag_meta_ts_decomp( tsorig, tickcount ) - ctx->ref_tickcount) / ctx->tick_per_ns);
         long tspub_ns = ctx->ref_wallclock + (long)((double)(fd_frag_meta_ts_decomp( tspub, tickcount ) - ctx->ref_tickcount) / ctx->tick_per_ns);
         fd_gui_handle_exec_txn_done( ctx->gui, msg->txn_exec->slot, msg->txn_exec->start_shred_idx, msg->txn_exec->end_shred_idx, tsorig_ns, tspub_ns );
+
+        int txn_succeeded = msg->txn_exec->is_committable && !msg->txn_exec->is_fees_only && !msg->txn_exec->txn_err;
+        if( FD_UNLIKELY( msg->txn_exec->vote.slot!=ULONG_MAX && txn_succeeded ) ) {
+          fd_gui_peers_handle_vote( ctx->peers,
+                                    msg->txn_exec->vote.vote_acct,
+                                    msg->txn_exec->vote.slot,
+                                    !memcmp(ctx->gui->summary.identity_key->uc, msg->txn_exec->vote.identity->uc, sizeof(fd_pubkey_t) ) );
+        }
       }
 
       break;
@@ -356,72 +358,11 @@ after_frag( fd_gui_ctx_t *      ctx,
     case IN_KIND_REPLAY_OUT: {
       FD_TEST( ctx->is_full_client );
       if( FD_UNLIKELY( sig==REPLAY_SIG_SLOT_COMPLETED ) ) {
-        fd_replay_slot_completed_t const * replay =  (fd_replay_slot_completed_t const *)src;
+        fd_replay_slot_completed_t const * slot_completed =  (fd_replay_slot_completed_t const *)src;
 
+        fd_gui_peers_update_delinquency( ctx->peers, fd_clock_now( ctx->clock ) );
 
-        /* bank should already have positive refcnt */
-        fd_bank_t bank[1];
-        FD_TEST( fd_banks_bank_query( bank, ctx->banks, replay->bank_idx ) );
-        FD_TEST( bank->data->refcnt!=0 );
-
-        fd_vote_stakes_t * vote_stakes = fd_bank_vote_stakes_locking_modify( bank );
-
-        ulong vote_count = 0UL;
-        uchar __attribute__((aligned(FD_VOTE_STAKES_ITER_ALIGN))) iter_mem[ FD_VOTE_STAKES_ITER_FOOTPRINT ];
-        for( fd_vote_stakes_iter_t * iter = fd_vote_stakes_fork_iter_init( vote_stakes, bank->data->vote_stakes_fork_id, iter_mem );
-             !fd_vote_stakes_fork_iter_done( vote_stakes, bank->data->vote_stakes_fork_id, iter );
-             fd_vote_stakes_fork_iter_next( vote_stakes, bank->data->vote_stakes_fork_id, iter ) ) {
-          fd_pubkey_t pubkey;
-          ulong       stake_t_1;
-          fd_pubkey_t node_account_t_1;
-          fd_vote_stakes_fork_iter_ele( vote_stakes, bank->data->vote_stakes_fork_id, iter, &pubkey, &stake_t_1, NULL, &node_account_t_1, NULL );
-
-          ctx->peers->votes[ vote_count ].vote_account = pubkey;
-          ctx->peers->votes[ vote_count ].node_account = node_account_t_1;
-          ctx->peers->votes[ vote_count ].stake        = stake_t_1;
-
-          vote_count++;
-        }
-        fd_bank_vote_stakes_end_locking_modify( bank );
-
-        fd_gui_slot_completed_t slot_completed;
-        if( FD_LIKELY( replay->parent_bank_idx!=ULONG_MAX ) ) {
-          fd_bank_t parent_bank[1];
-          FD_TEST( fd_banks_bank_query( parent_bank, ctx->banks, replay->parent_bank_idx ) );
-
-          slot_completed.total_txn_cnt          = (uint)(fd_bank_txn_count_get( bank )                 - fd_bank_txn_count_get( parent_bank ));
-          slot_completed.vote_txn_cnt           = slot_completed.total_txn_cnt - (uint)(fd_bank_nonvote_txn_count_get( bank ) - fd_bank_nonvote_txn_count_get( parent_bank ));
-          slot_completed.failed_txn_cnt         = (uint)(fd_bank_failed_txn_count_get( bank )          - fd_bank_failed_txn_count_get( parent_bank ));
-          slot_completed.nonvote_failed_txn_cnt = (uint)(fd_bank_nonvote_failed_txn_count_get( bank )  - fd_bank_nonvote_failed_txn_count_get( parent_bank ));
-
-          fd_stem_publish( stem, ctx->replay_out->idx, replay->parent_bank_idx, 0UL, 0UL, 0UL, 0UL, 0UL );
-        } else {
-          slot_completed.total_txn_cnt          = (uint)fd_bank_txn_count_get( bank );
-          slot_completed.vote_txn_cnt           = slot_completed.total_txn_cnt - (uint)fd_bank_nonvote_txn_count_get( bank );
-          slot_completed.failed_txn_cnt         = (uint)fd_bank_failed_txn_count_get( bank );
-          slot_completed.nonvote_failed_txn_cnt = (uint)fd_bank_nonvote_failed_txn_count_get( bank );
-        }
-
-        slot_completed.slot              = fd_bank_slot_get( bank );
-        slot_completed.completed_time    = replay->completion_time_nanos;
-        slot_completed.parent_slot       = fd_bank_parent_slot_get( bank );
-        slot_completed.max_compute_units = fd_uint_if( replay->cost_tracker.block_cost_limit==0UL, UINT_MAX, (uint)replay->cost_tracker.block_cost_limit );
-        slot_completed.transaction_fee   = fd_bank_execution_fees_get( bank );
-        slot_completed.transaction_fee   = slot_completed.transaction_fee - (slot_completed.transaction_fee>>1); /* burn */
-        slot_completed.priority_fee      = fd_bank_priority_fees_get( bank );
-        slot_completed.tips              = fd_bank_tips_get( bank );
-        slot_completed.compute_units     = fd_uint_if( replay->cost_tracker.block_cost==0UL, UINT_MAX, (uint)replay->cost_tracker.block_cost );
-        slot_completed.shred_cnt         = (uint)fd_bank_shred_cnt_get( bank );
-
-        /* release shared ownership of bank and parent_bank */
-        fd_stem_publish( stem, ctx->replay_out->idx, replay->bank_idx, 0UL, 0UL, 0UL, 0UL, 0UL );
-
-        /* update vote info */
-        fd_gui_peers_handle_vote_update( ctx->peers, ctx->peers->votes, vote_count, fd_clock_now( ctx->clock ), ctx->gui->summary.identity_key );
-
-        /* update slot data */
-        fd_gui_handle_replay_update( ctx->gui, &slot_completed, &replay->block_hash, ctx->peers->slot_voted, replay->storage_slot, replay->root_slot, replay->identity_balance, fd_clock_now( ctx->clock ) );
-
+        fd_gui_handle_replay_update( ctx->gui, slot_completed, ctx->peers->slot_voted, fd_clock_now( ctx->clock ) );
       } else if( FD_UNLIKELY( sig==REPLAY_SIG_BECAME_LEADER ) ) {
         fd_became_leader_t * became_leader = (fd_became_leader_t *)src;
         fd_gui_became_leader( ctx->gui, became_leader->slot, became_leader->slot_start_ns, became_leader->slot_end_ns, became_leader->limits.slot_max_cost, became_leader->max_microblocks_in_slot );
@@ -435,6 +376,7 @@ after_frag( fd_gui_ctx_t *      ctx,
 
       fd_epoch_info_msg_t * epoch_info = (fd_epoch_info_msg_t *)src;
       fd_gui_handle_epoch_info( ctx->gui, epoch_info, fd_clock_now( ctx->clock ) );
+      fd_gui_peers_handle_epoch_info( ctx->peers, epoch_info, fd_clock_now( ctx->clock ) );
       break;
     }
     case IN_KIND_SNAPIN: {
@@ -533,6 +475,9 @@ after_frag( fd_gui_ctx_t *      ctx,
       break;
     }
     case IN_KIND_PACK_EXECLE: {
+      FD_TEST( sz>=sizeof(fd_microblock_execle_trailer_t) );
+      FD_TEST( (sz-sizeof(fd_microblock_execle_trailer_t))%sizeof(fd_txn_e_t)==0UL );
+
       if( FD_LIKELY( fd_disco_poh_sig_pkt_type( sig )==POH_PKT_TYPE_MICROBLOCK ) ) {
         fd_microblock_execle_trailer_t * trailer = (fd_microblock_execle_trailer_t *)( src+sz-sizeof(fd_microblock_execle_trailer_t) );
         long now = ctx->ref_wallclock + (long)((double)(fd_frag_meta_ts_decomp( tspub, fd_tickcount() ) - ctx->ref_tickcount) / ctx->tick_per_ns);
@@ -549,13 +494,17 @@ after_frag( fd_gui_ctx_t *      ctx,
       break;
     }
     case IN_KIND_EXECLE_POH: {
+      FD_TEST( sz>=sizeof(fd_microblock_trailer_t) );
+      FD_TEST( (sz-sizeof(fd_microblock_trailer_t))%sizeof(fd_txn_p_t)==0UL );
+
       fd_microblock_trailer_t * trailer = (fd_microblock_trailer_t *)( src+sz-sizeof( fd_microblock_trailer_t ) );
       long now = ctx->ref_wallclock + (long)((double)(fd_frag_meta_ts_decomp( tspub, fd_tickcount() ) - ctx->ref_tickcount) / ctx->tick_per_ns);
+      ulong txn_cnt = (sz-sizeof( fd_microblock_trailer_t ))/sizeof(fd_txn_p_t);
       fd_gui_microblock_execution_end( ctx->gui,
                                       now,
                                       ctx->in_bank_idx[ in_idx ],
                                       fd_disco_execle_sig_slot( sig ),
-                                      (sz-sizeof( fd_microblock_trailer_t ))/sizeof( fd_txn_p_t ),
+                                      txn_cnt,
                                       (fd_txn_p_t *)src,
                                       trailer->pack_txn_idx,
                                       trailer->txn_start_pct,
@@ -792,16 +741,6 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->idle_cnt = 0UL;
   ctx->in_cnt = tile->in_cnt;
 
-  ulong banks_obj_id       = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "banks" );
-  ulong banks_locks_obj_id = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "banks_locks" );
-
-  if( FD_UNLIKELY( ctx->is_full_client ) ) {
-    FD_TEST( banks_obj_id!=ULONG_MAX );
-    FD_TEST( banks_locks_obj_id!=ULONG_MAX );
-    FD_TEST( fd_banks_join( ctx->banks, fd_topo_obj_laddr( topo, banks_obj_id ), fd_topo_obj_laddr( topo, banks_locks_obj_id ) ) );
-    FD_TEST( ctx->banks );
-  }
-
   for( ulong i=0UL; i<tile->in_cnt; i++ ) {
     fd_topo_link_t * link = &topo->links[ tile->in_link_id[ i ] ];
     fd_topo_wksp_t * link_wksp = &topo->workspaces[ topo->objs[ link->dcache_obj_id ].wksp_id ];
@@ -842,13 +781,6 @@ unprivileged_init( fd_topo_t *      topo,
     ctx->in[ i ].mtu    = link->mtu;
     ctx->in[ i ].chunk0 = fd_dcache_compact_chunk0( ctx->in[ i ].mem, link->dcache );
     ctx->in[ i ].wmark  = fd_dcache_compact_wmark ( ctx->in[ i ].mem, link->dcache, link->mtu );
-  }
-
-  if( FD_UNLIKELY( ctx->is_full_client ) ) {
-    ulong idx = fd_topo_find_tile_out_link( topo, tile, "gui_replay", 0UL );
-    FD_TEST( idx!=ULONG_MAX );
-    fd_gui_out_ctx_t * replay_out = ctx->replay_out;
-    replay_out->idx    = idx;
   }
 
   ulong scratch_top = FD_SCRATCH_ALLOC_FINI( l, 1UL );

--- a/src/discof/execrp/fd_execrp_tile.c
+++ b/src/discof/execrp/fd_execrp_tile.c
@@ -3,6 +3,7 @@
 #include "generated/fd_execrp_tile_seccomp.h"
 
 #include "../../ballet/sha256/fd_sha256.h" /* fd_sha256_hash_32_repeated */
+#include "../../choreo/tower/fd_tower_serdes.h"
 #include "../../discof/fd_accdb_topo.h"
 #include "../../discof/replay/fd_execrp.h"
 #include "../../flamenco/capture/fd_capture_ctx.h"
@@ -158,6 +159,13 @@ publish_txn_finalized_msg( fd_execrp_tile_t *  ctx,
   msg->txn_exec->slot            = ctx->slot;
   msg->txn_exec->start_shred_idx = ctx->txn_in.txn->start_shred_idx;
   msg->txn_exec->end_shred_idx   = ctx->txn_in.txn->end_shred_idx;
+
+  if( FD_UNLIKELY( !ctx->txn_out.details.is_simple_vote || !fd_txn_parse_simple_vote( TXN( ctx->txn_in.txn ), ctx->txn_in.txn->payload, msg->txn_exec->vote.identity, msg->txn_exec->vote.vote_acct, &msg->txn_exec->vote.slot ) ) ) {
+    msg->txn_exec->vote.slot       = ULONG_MAX;
+    *msg->txn_exec->vote.identity  = (fd_pubkey_t){ 0 };
+    *msg->txn_exec->vote.vote_acct = (fd_pubkey_t){ 0 };
+  }
+
   if( FD_UNLIKELY( !msg->txn_exec->is_committable ) ) {
     uchar * signature = (uchar *)ctx->txn_in.txn->payload + TXN( ctx->txn_in.txn )->signature_off;
     FD_BASE58_ENCODE_64_BYTES( signature, signature_b58 );

--- a/src/discof/replay/fd_execrp.h
+++ b/src/discof/replay/fd_execrp.h
@@ -84,9 +84,16 @@ struct fd_execrp_txn_exec_done_msg {
   int txn_err;
 
   /* used by monitoring tools */
-  ulong slot;
+  ulong  slot;
   ushort start_shred_idx;
   ushort end_shred_idx;
+
+  /* vote.slot==ULONG_MAX if this was not a vote transaction */
+  struct {
+    ulong slot;
+    fd_pubkey_t identity[ 1 ];
+    fd_pubkey_t vote_acct[ 1 ];
+  } vote;
 };
 typedef struct fd_execrp_txn_exec_done_msg fd_execrp_txn_exec_done_msg_t;
 

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -90,9 +90,8 @@
 #define IN_KIND_EXECRP     ( 6)
 #define IN_KIND_REPAIR     ( 7)
 #define IN_KIND_TXSEND     ( 8)
-#define IN_KIND_GUI        ( 9)
-#define IN_KIND_RPC        (10)
-#define IN_KIND_GOSSIP_OUT (11)
+#define IN_KIND_RPC        ( 9)
+#define IN_KIND_GOSSIP_OUT (10)
 
 #define DEBUG_LOGGING 0
 
@@ -421,12 +420,9 @@ struct fd_replay_tile {
 
   fd_replay_out_link_t epoch_out[1];
 
-
-  /* The gui tile needs to reliably own a reference to the most recent
-     completed active bank.  Replay needs to know if the gui as a
-     consumer is enabled so it can increment the bank's refcnt before
-     publishing the bank_idx to the gui. */
-  int gui_enabled;
+  /* The rpc tile needs to occasionally own a reference to a live bank.
+     Replay needs to know if the rpc as a consumer is enabled so it can
+     increment the bank's refcnt before publishing bank_idx. */
   int rpc_enabled;
 
 # if FD_HAS_FLATCC
@@ -721,15 +717,19 @@ static void
 cost_tracker_snap( fd_bank_t * bank, fd_replay_slot_completed_t * slot_info ) {
   if( bank->data->cost_tracker_pool_idx!=fd_bank_cost_tracker_pool_idx_null( fd_bank_get_cost_tracker_pool( bank->data ) ) ) {
     fd_cost_tracker_t const * cost_tracker = fd_bank_cost_tracker_locking_query( bank );
-    slot_info->cost_tracker.block_cost                   = cost_tracker->block_cost;
-    slot_info->cost_tracker.vote_cost                    = cost_tracker->vote_cost;
-    slot_info->cost_tracker.allocated_accounts_data_size = cost_tracker->allocated_accounts_data_size;
-    slot_info->cost_tracker.block_cost_limit             = cost_tracker->block_cost_limit;
-    slot_info->cost_tracker.vote_cost_limit              = cost_tracker->vote_cost_limit;
-    slot_info->cost_tracker.account_cost_limit           = cost_tracker->account_cost_limit;
+    if( FD_UNLIKELY( cost_tracker->block_cost_limit==0UL ) ) {
+      memset( &slot_info->cost_tracker, -1 /* ULONG_MAX */, sizeof(slot_info->cost_tracker) );
+    } else {
+      slot_info->cost_tracker.block_cost                   = cost_tracker->block_cost;
+      slot_info->cost_tracker.vote_cost                    = cost_tracker->vote_cost;
+      slot_info->cost_tracker.allocated_accounts_data_size = cost_tracker->allocated_accounts_data_size;
+      slot_info->cost_tracker.block_cost_limit             = cost_tracker->block_cost_limit;
+      slot_info->cost_tracker.vote_cost_limit              = cost_tracker->vote_cost_limit;
+      slot_info->cost_tracker.account_cost_limit           = cost_tracker->account_cost_limit;
+    }
     fd_bank_cost_tracker_end_locking_query( bank );
   } else {
-    memset( &slot_info->cost_tracker, 0, sizeof(slot_info->cost_tracker) );
+    memset( &slot_info->cost_tracker, -1 /* ULONG_MAX */, sizeof(slot_info->cost_tracker) );
   }
 }
 
@@ -814,19 +814,33 @@ publish_slot_completed( fd_replay_tile_t *  ctx,
      they are done using the bank. */
   bank->data->refcnt++; /* tower_tile */
   if( FD_LIKELY( ctx->rpc_enabled ) ) bank->data->refcnt++; /* rpc tile */
-  if( FD_LIKELY( ctx->gui_enabled ) ) bank->data->refcnt++; /* gui tile */
   slot_info->bank_idx = bank->data->idx;
-  FD_LOG_DEBUG(( "bank (idx=%lu, slot=%lu) refcnt incremented to %lu for tower, rpc, gui", bank->data->idx, slot, bank->data->refcnt ));
+  FD_LOG_DEBUG(( "bank (idx=%lu, slot=%lu) refcnt incremented to %lu for tower, rpc", bank->data->idx, slot, bank->data->refcnt ));
 
-  slot_info->parent_bank_idx = ULONG_MAX;
   fd_bank_t parent_bank[1];
-  if( FD_LIKELY( fd_banks_get_parent( parent_bank, ctx->banks, bank ) && ctx->gui_enabled ) ) {
-    parent_bank->data->refcnt++;
-    FD_LOG_DEBUG(( "bank (idx=%lu, slot=%lu) refcnt incremented to %lu for gui", parent_bank->data->idx, fd_bank_slot_get( parent_bank ), parent_bank->data->refcnt ));
-    slot_info->parent_bank_idx = parent_bank->data->idx;
+  if( FD_LIKELY( fd_banks_get_parent( parent_bank, ctx->banks, bank ) ) ) {
+    ulong total_txn_cnt          = fd_bank_txn_count_get( bank )                 - fd_bank_txn_count_get( parent_bank );
+    ulong nonvote_txn_cnt        = fd_bank_nonvote_txn_count_get( bank ) - fd_bank_nonvote_txn_count_get( parent_bank );
+    ulong failed_txn_cnt         = fd_bank_failed_txn_count_get( bank )          - fd_bank_failed_txn_count_get( parent_bank );
+    ulong nonvote_failed_txn_cnt = fd_bank_nonvote_failed_txn_count_get( bank )  - fd_bank_nonvote_failed_txn_count_get( parent_bank );
+
+    slot_info->nonvote_success = nonvote_txn_cnt - nonvote_failed_txn_cnt;
+    slot_info->nonvote_failed  = nonvote_failed_txn_cnt;
+    slot_info->vote_failed     = failed_txn_cnt - nonvote_failed_txn_cnt;
+    slot_info->vote_success    = total_txn_cnt - nonvote_txn_cnt - slot_info->vote_failed;
+  } else {
+    slot_info->vote_failed     = ULONG_MAX;
+    slot_info->vote_success    = ULONG_MAX;
+    slot_info->nonvote_success = ULONG_MAX;
+    slot_info->nonvote_failed  = ULONG_MAX;
   }
 
   slot_info->is_leader = is_leader;
+  slot_info->transaction_fee = fd_bank_execution_fees_get( bank );
+  slot_info->transaction_fee -= (slot_info->transaction_fee>>1); /* burn */
+  slot_info->priority_fee = fd_bank_priority_fees_get( bank );
+  slot_info->tips = fd_bank_tips_get( bank );
+  slot_info->shred_cnt = fd_bank_shred_cnt_get( bank );
 
   FD_BASE58_ENCODE_32_BYTES( ctx->block_id_arr[ bank->data->idx ].latest_mr.uc, block_id_cstr );
   FD_BASE58_ENCODE_32_BYTES( fd_bank_bank_hash_query( bank )->uc, bank_hash_cstr );
@@ -1073,7 +1087,7 @@ publish_root_advanced( fd_replay_tile_t *  ctx,
 
   if( ctx->rpc_enabled ) {
     bank->data->refcnt++;
-    FD_LOG_DEBUG(( "bank (idx=%lu, slot=%lu) refcnt incremented to %lu for gui", bank->data->idx, fd_bank_slot_get( bank ), bank->data->refcnt ));
+    FD_LOG_DEBUG(( "bank (idx=%lu, slot=%lu) refcnt incremented to %lu for rpc", bank->data->idx, fd_bank_slot_get( bank ), bank->data->refcnt ));
   }
 
   /* Increment the reference count on the consensus root bank to account
@@ -1493,6 +1507,7 @@ boot_genesis( fd_replay_tile_t *        ctx,
   FD_TEST( fd_block_id_map_ele_insert( ctx->block_id_map, block_id_ele, ctx->block_id_arr ) );
 
   fd_replay_slot_completed_t * slot_info = fd_chunk_to_laddr( ctx->replay_out->mem, ctx->replay_out->chunk );
+  cost_tracker_snap( bank, slot_info );
   slot_info->identity_balance = get_identity_balance( ctx, xid );
 
   publish_slot_completed( ctx, stem, bank, 1, 0 /* is_leader */ );
@@ -1611,6 +1626,7 @@ on_snapshot_message( fd_replay_tile_t *  ctx,
     init_after_snapshot( ctx );
 
     fd_replay_slot_completed_t * slot_info = fd_chunk_to_laddr( ctx->replay_out->mem, ctx->replay_out->chunk );
+    cost_tracker_snap( bank, slot_info );
     slot_info->identity_balance = get_identity_balance( ctx, xid );
 
     publish_slot_completed( ctx, stem, bank, 1, 0 /* is_leader */ );
@@ -2709,8 +2725,7 @@ returnable_frag( fd_replay_tile_t *  ctx,
       FD_LOG_NOTICE(( "Done waiting for supermajority. More than 80 percent of cluster stake has joined." ));
       break;
     }
-    case IN_KIND_RPC:
-    case IN_KIND_GUI: {
+    case IN_KIND_RPC: {
       fd_bank_t bank[1];
       FD_TEST( fd_banks_bank_query( bank, ctx->banks, sig ) );
       bank->data->refcnt--;
@@ -3007,7 +3022,6 @@ unprivileged_init( fd_topo_t *      topo,
     else if( !strcmp( link->name, "resolv_replay" ) ) ctx->in_kind[ i ] = IN_KIND_RESOLV;
     else if( !strcmp( link->name, "repair_out"    ) ) ctx->in_kind[ i ] = IN_KIND_REPAIR;
     else if( !strcmp( link->name, "txsend_out"    ) ) ctx->in_kind[ i ] = IN_KIND_TXSEND;
-    else if( !strcmp( link->name, "gui_replay"    ) ) ctx->in_kind[ i ] = IN_KIND_GUI;
     else if( !strcmp( link->name, "rpc_replay"    ) ) ctx->in_kind[ i ] = IN_KIND_RPC;
     else if( !strcmp( link->name, "gossip_out"    ) ) ctx->in_kind[ i ] = IN_KIND_GOSSIP_OUT;
     else FD_LOG_ERR(( "unexpected input link name %s", link->name ));
@@ -3017,7 +3031,6 @@ unprivileged_init( fd_topo_t *      topo,
   *ctx->replay_out = out1( topo, tile, "replay_out"   ); FD_TEST( ctx->replay_out->idx!=ULONG_MAX );
   *ctx->exec_out   = out1( topo, tile, "replay_execrp"  ); FD_TEST( ctx->exec_out->idx!=ULONG_MAX );
 
-  ctx->gui_enabled = fd_topo_find_tile( topo, "gui", 0UL )!=ULONG_MAX;
   ctx->rpc_enabled = fd_topo_find_tile( topo, "rpc", 0UL )!=ULONG_MAX;
 
   if( FD_UNLIKELY( strcmp( "", tile->replay.solcap_capture ) ) ) {

--- a/src/discof/replay/fd_replay_tile.h
+++ b/src/discof/replay/fd_replay_tile.h
@@ -35,7 +35,7 @@ struct fd_replay_slot_completed {
   fd_hash_t parent_block_id; /* parent block id of the slot received from replay */
   fd_hash_t bank_hash;       /* bank hash of the slot received from replay */
   fd_hash_t block_hash;      /* last microblock header hash of slot received from replay */
-  ulong transaction_count;
+  ulong     transaction_count;   /* since genesis */
 
   struct {
     double initial;
@@ -55,7 +55,6 @@ struct fd_replay_slot_completed {
      eliminate non-timestamp fields and have consumers just use
      bank_idx. */
   ulong bank_idx;
-  ulong parent_bank_idx; /* ULONG_MAX if unavailable */
 
   long first_fec_set_received_nanos;      /* timestamp when replay received the first fec of the slot from turbine or repair */
   long preparation_begin_nanos;           /* timestamp when replay began preparing the state to begin execution of the slot */
@@ -65,6 +64,17 @@ struct fd_replay_slot_completed {
 
   int is_leader; /* whether we were leader for this slot */
   ulong identity_balance;
+
+  /* since slot start, default ULONG_MAX */
+  ulong vote_success;
+  ulong vote_failed;
+  ulong nonvote_success;
+  ulong nonvote_failed;
+
+  ulong transaction_fee;
+  ulong priority_fee;
+  ulong tips;
+  ulong shred_cnt;
 
   struct {
     ulong block_cost;


### PR DESCRIPTION
Eliminate GUI dependence on replay banks and get vote updates from votes on
- replay->execrp / execrp->replay
- pack->bank | bank->poh

Technically, votes on a non-canonical fork can show up in the GUI vote index but since we use this info for the purposes of monitoring delinquency, this is a non-issue.

closes https://github.com/firedancer-io/firedancer/issues/8692