### PR TITLE
stem: tune lazy values to remove excessive housekeeping

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -3084,10 +3084,10 @@ during_housekeeping( fd_replay_tile_t * ctx ) {
    is a conservative bound. */
 #define STEM_BURST (14UL)
 
-/* TODO: calculate this properly/fix stem to work with larger numbers of links */
-/* 1000 chosen empirically as anything larger slowed down replay times. Need to calculate
-   this properly. */
-#define STEM_LAZY ((long)10e3)
+/* fd_tempo_lazy_default( 16384 ) where 16384 is the minimum out-link
+   depth (i.e. cr_max) but excludes replay_epoch, which is so infrequent
+   credit availability is a non-issue.   */
+#define STEM_LAZY ((long)36865)
 
 #define STEM_CALLBACK_CONTEXT_TYPE  fd_replay_tile_t
 #define STEM_CALLBACK_CONTEXT_ALIGN alignof(fd_replay_tile_t)

--- a/src/discof/rpc/fd_rpc_tile.c
+++ b/src/discof/rpc/fd_rpc_tile.c
@@ -1932,7 +1932,17 @@ rlimit_file_cnt( fd_topo_t const *      topo FD_PARAM_UNUSED,
 }
 
 #define STEM_BURST (1UL)
-#define STEM_LAZY  (50UL)
+
+/* The default STEM_LAZY is based on cr_max, which is the minimum depth
+   across all output links that have at least one reliable consumer.
+   RPC has one tiny output link used to release banks, with a
+   significantly slower line rate than assumed in the formula for the
+   default STEM_LAZY value.
+
+   Instead, lazy just needs to be frequent enough to relinquish credits
+   to upstream producers faster than they are exhausted. 384us is a
+   reasonable default used in many other non-critical tiles. */
+#define STEM_LAZY  (128L*3000L)
 
 #define STEM_CALLBACK_CONTEXT_TYPE  fd_rpc_tile_t
 #define STEM_CALLBACK_CONTEXT_ALIGN alignof(fd_rpc_tile_t)


### PR DESCRIPTION
closes https://github.com/firedancer-io/firedancer/issues/8285

before -> after
rpc: ~40% -> 0.1%
replay: 11%-> 3.5%