### PR TITLE
accdb: fix spurious txn cancel

### DIFF
--- a/src/flamenco/accdb/fd_accdb_admin_v1.c
+++ b/src/flamenco/accdb/fd_accdb_admin_v1.c
@@ -248,7 +248,6 @@ fd_accdb_v1_cancel( fd_accdb_admin_t *        accdb_,
   }
   fd_funk_txn_t * txn = fd_funk_txn_map_query_ele( query );
 
-  fd_accdb_txn_cancel_next_list( accdb, txn );
   fd_accdb_txn_cancel_tree( accdb, txn );
 }
 

--- a/src/flamenco/progcache/fd_progcache_admin.c
+++ b/src/flamenco/progcache/fd_progcache_admin.c
@@ -207,7 +207,6 @@ fd_progcache_txn_cancel( fd_progcache_admin_t * cache,
   }
   fd_funk_txn_t * txn = fd_funk_txn_map_query_ele( query );
 
-  fd_progcache_txn_cancel_next_list( cache, txn );
   fd_progcache_txn_cancel_tree( cache, txn );
 }
 


### PR DESCRIPTION
Fixes a bug that results in unrelated fork graph nodes getting
dropped on accdb_cancel.
