### PR TITLE
net: preferred busy polling

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -977,12 +977,43 @@ dynamic_port_range = "8900-9000"
         # "operation not supported".
         xdp_zero_copy = false
 
+        # The poll_mode option determines how Firedancer polls NAPI (Linux's
+        # high perf networking mechanisms). Its possible values are:
+        #
+        #  "softirq" (default)
+        #   Relies significantly more on Linux to manage NAPI through wakeups,
+        #   softirqs, and under higher network load, a separate ksoftirqd
+        #   thread which Linux schedules onto a separate core. If a ksoftirqd
+        #   is scheduled by Linux onto a core corresponding to a different
+        #   tile, the performance of that tile is significantly degraded.
+        #
+        #  "prefbusy"
+        #   Experimental option which gives Firedancer significantly more
+        #   control over how and when NAPI is polled, leading to much less
+        #   IRQs and ksoftirqds on well supported drivers (like mlx5 and i40e).
+        #
+        #   Its main benefit is signifciantly increased IRQ/ksoftirqd livelock
+        #   protection, which is important during DOS attacks and high net load.
+        #
+        #   Depending on exact driver, Copy Mode usually experiences significant
+        #   performance increases (like 2x throughput on mlx5). Zero copy
+        #   throughput generally stays around the same across the poll modes.
+        #
+        # Extra info
+        #
+        #  Older kernels: If your kernel is too old (< v5.11), Firedancer will
+        #  automatically fall back to "softirq" mode and emit a warning.
+        #
+        #  SSH minor lag: You may notice a small increase in SSH lag if
+        #  using the same interface(s) as Firedancer for SSH.
+        poll_mode = "softirq"
+
         # XDP uses metadata queues shared across the kernel and
         # userspace to relay events about incoming and outgoing packets.
         # This setting defines the number of entries in these metadata
         # queues, which has to be a power of two.
         #
-        # Smaller values use less memory.  Larger values reduce packet
+        # Smaller values use less memory. Larger values reduce packet
         # loss caused by excessive scheduling or inter-CPU latency.
         xdp_rx_queue_size = 32768
         xdp_tx_queue_size = 32768

--- a/src/app/fdctl/main.c
+++ b/src/app/fdctl/main.c
@@ -39,6 +39,7 @@ configure_stage_t * STAGES[] = {
   &fd_cfg_stage_ethtool_channels,
   &fd_cfg_stage_ethtool_offloads,
   &fd_cfg_stage_ethtool_loopback,
+  &fd_cfg_stage_sysfs_poll,
   NULL,
 };
 

--- a/src/app/fddev/main.h
+++ b/src/app/fddev/main.h
@@ -34,6 +34,7 @@ extern configure_stage_t fd_cfg_stage_kill;
 extern configure_stage_t fd_cfg_stage_genesis;
 extern configure_stage_t fd_cfg_stage_keys;
 extern configure_stage_t fd_cfg_stage_blockstore;
+extern configure_stage_t fd_cfg_stage_sysfs_poll;
 
 configure_stage_t * STAGES[] = {
   &fd_cfg_stage_kill,
@@ -47,6 +48,7 @@ configure_stage_t * STAGES[] = {
   &fd_cfg_stage_keys,
   &fd_cfg_stage_genesis,
   &fd_cfg_stage_blockstore,
+  &fd_cfg_stage_sysfs_poll,
   NULL,
 };
 

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -1058,6 +1058,37 @@ telemetry = true
         # "operation not supported".
         xdp_zero_copy = false
 
+        # The poll_mode option determines how Firedancer polls NAPI (Linux's
+        # high perf networking mechanisms). Its possible values are:
+        #
+        #  "softirq" (default)
+        #   Relies significantly more on Linux to manage NAPI through wakeups,
+        #   softirqs, and under higher network load, a separate ksoftirqd
+        #   thread which Linux schedules onto a separate core. If a ksoftirqd
+        #   is scheduled by Linux onto a core corresponding to a different
+        #   tile, the performance of that tile is significantly degraded.
+        #
+        #  "prefbusy"
+        #   Experimental option which gives Firedancer significantly more
+        #   control over how and when NAPI is polled, leading to much less
+        #   IRQs and ksoftirqds on well supported drivers (like mlx5 and i40e).
+        #
+        #   Its main benefit is signifciantly increased IRQ/ksoftirqd livelock
+        #   protection, which is important during DOS attacks and high net load.
+        #
+        #   Depending on exact driver, Copy Mode usually experiences significant
+        #   performance increases (like 2x throughput on mlx5). Zero copy
+        #   throughput generally stays around the same across the poll modes.
+        #
+        # Extra info
+        #
+        #  Older kernels: If your kernel is too old (< v5.11), Firedancer will
+        #  automatically fall back to "softirq" mode and emit a warning.
+        #
+        #  SSH minor lag: You may notice a small increase in SSH lag if
+        #  using the same interface(s) as Firedancer for SSH.
+        poll_mode = "softirq"
+
         # XDP uses metadata queues shared across the kernel and
         # userspace to relay events about incoming and outgoing packets.
         # This setting defines the number of entries in these metadata

--- a/src/app/firedancer/main.c
+++ b/src/app/firedancer/main.c
@@ -56,6 +56,7 @@ configure_stage_t * STAGES[] = {
   &fd_cfg_stage_irq_balance,
   &fd_cfg_stage_irq_affinity,
   &fd_cfg_stage_snapshots,
+  &fd_cfg_stage_sysfs_poll,
   NULL,
 };
 

--- a/src/app/shared/Local.mk
+++ b/src/app/shared/Local.mk
@@ -31,6 +31,7 @@ $(call add-objs,commands/configure/fd_irqbalance_client,fdctl_shared)
 $(call add-objs,commands/configure/hugetlbfs,fdctl_shared)
 $(call add-objs,commands/configure/hyperthreads,fdctl_shared)
 $(call add-objs,commands/configure/sysctl,fdctl_shared)
+$(call add-objs,commands/configure/sysfs-poll,fdctl_shared)
 $(call add-objs,commands/configure/snapshots,fdctl_shared)
 ifdef FD_HAS_ALLOCA
 $(call add-objs,commands/monitor/monitor commands/monitor/helper,fdctl_shared)

--- a/src/app/shared/commands/configure/configure.h
+++ b/src/app/shared/commands/configure/configure.h
@@ -86,6 +86,7 @@ extern configure_stage_t fd_cfg_stage_ethtool_offloads;
 extern configure_stage_t fd_cfg_stage_ethtool_loopback;
 extern configure_stage_t fd_cfg_stage_irq_affinity;
 extern configure_stage_t fd_cfg_stage_irq_balance;
+extern configure_stage_t fd_cfg_stage_sysfs_poll;
 extern configure_stage_t fd_cfg_stage_snapshots;
 
 extern configure_stage_t * STAGES[];

--- a/src/app/shared/commands/configure/sysfs-poll.c
+++ b/src/app/shared/commands/configure/sysfs-poll.c
@@ -1,0 +1,91 @@
+/* This stage configures the OS to support effective preferred busy
+   polling, allowing for significantly improved network stack (XDP)
+   reliability under high load if enabled on a well supported driver. */
+
+#include "configure.h"
+
+#define NAME "sysfs-poll"
+
+#include "../../../platform/fd_file_util.h"
+
+#include <string.h> /* strcmp */
+#include <unistd.h> /* access */
+#include <linux/capability.h>
+
+/* Values below based on a mix of testing on a wide range of hardware
+   and authoratative reccommendations (Linux + doc.DPDK ) */
+#define NAPI_DEFER_HARD_IRQS 1000U
+#define GRO_FLUSH_TIMEOUT    200000U
+
+static char const setting_napi_defer_hard_irqs[] = "napi_defer_hard_irqs";
+static char const setting_gro_flush_timeout[]    = "gro_flush_timeout";
+
+static int
+enabled( config_t const * config FD_PARAM_UNUSED ) {
+  return 1;
+}
+
+static void
+init_perm( fd_cap_chk_t   * chk,
+           config_t const * config FD_PARAM_UNUSED ) {
+  fd_cap_chk_cap( chk, NAME, CAP_NET_ADMIN, "configure preferred busy polling via `/sys/class/net/*/{napi_defer_hard_irqs, gro_flush_timeout}`" );
+}
+
+static void
+sysfs_net_set( char const * device,
+               char const * setting,
+               ulong        value ) {
+  char path[ PATH_MAX ];
+  fd_cstr_printf_check( path, PATH_MAX, NULL, "/sys/class/net/%s/%s", device, setting );
+  FD_LOG_NOTICE(( "RUN: `echo \"%lu\" > %s`", value, path ));
+  fd_file_util_write_uint( path, (uint)value );
+}
+
+static void
+init( config_t const * config ) {
+  int is_prefbusy = !strcmp( config->net.xdp.poll_mode, "prefbusy" );
+  sysfs_net_set( config->net.interface, setting_napi_defer_hard_irqs,
+      is_prefbusy ? NAPI_DEFER_HARD_IRQS : 0 );
+
+  sysfs_net_set( config->net.interface, setting_gro_flush_timeout,
+      is_prefbusy ? GRO_FLUSH_TIMEOUT : 0 );
+}
+
+static int
+fini( config_t const * config,
+      int              pre_init FD_PARAM_UNUSED ) {
+  sysfs_net_set( config->net.interface, setting_napi_defer_hard_irqs, 0U );
+  sysfs_net_set( config->net.interface, setting_gro_flush_timeout,    0U );
+  return 1;
+}
+
+static configure_result_t
+check( config_t const * config,
+       int              check_type FD_PARAM_UNUSED ) {
+  char path[ PATH_MAX ];
+  uint value;
+  int is_prefbusy = !strcmp( config->net.xdp.poll_mode, "prefbusy" );
+  fd_cstr_printf_check( path, PATH_MAX, NULL, "/sys/class/net/%s/%s", config->net.interface, setting_napi_defer_hard_irqs );
+  if( fd_file_util_read_uint( path, &value )
+      || value != ( is_prefbusy ? NAPI_DEFER_HARD_IRQS : 0 ) ) {
+    NOT_CONFIGURED("Setting napi_defer_hard_irqs failed.");
+  }
+
+  fd_cstr_printf_check( path, PATH_MAX, NULL, "/sys/class/net/%s/%s", config->net.interface, setting_gro_flush_timeout );
+  if( fd_file_util_read_uint( path, &value )
+      || value != ( is_prefbusy ? GRO_FLUSH_TIMEOUT : 0 ) ) {
+    NOT_CONFIGURED("Setting gro_flush_timeout failed.");
+  }
+
+  CONFIGURE_OK();
+}
+
+configure_stage_t fd_cfg_stage_sysfs_poll = {
+  .name      = NAME,
+  .enabled   = enabled,
+  .init_perm = init_perm,
+  .fini_perm = init_perm,
+  .init      = init,
+  .fini      = fini,
+  .check     = check,
+};

--- a/src/app/shared/fd_config.c
+++ b/src/app/shared/fd_config.c
@@ -531,6 +531,11 @@ fd_config_validate( fd_config_t const * config ) {
   CFG_HAS_NON_ZERO( net.ingress_buffer_size );
   if( 0==strcmp( config->net.provider, "xdp" ) ) {
     CFG_HAS_NON_EMPTY( net.xdp.xdp_mode );
+
+    if( 0!=strcmp( config->net.xdp.poll_mode, "prefbusy" ) && 0!=strcmp( config->net.xdp.poll_mode, "softirq" ) ) {
+FD_LOG_ERR(( "invalid `net.xdp.poll_mode`: must be \"prefbusy\" or \"softirq\"" ));
+    }
+
     CFG_HAS_POW2     ( net.xdp.xdp_rx_queue_size );
     CFG_HAS_POW2     ( net.xdp.xdp_tx_queue_size );
     if( 0!=strcmp( config->net.xdp.rss_queue_mode, "dedicated" ) &&

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -206,6 +206,7 @@ struct fd_config_net {
   struct {
     char xdp_mode[ 8 ];
     int  xdp_zero_copy;
+    char poll_mode[ 16 ]; /* "prefbusy" or "softirq" */
 
     uint xdp_rx_queue_size;
     uint xdp_tx_queue_size;

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -186,6 +186,7 @@ fd_config_extract_pod( uchar *       pod,
   CFG_POP      ( uint,   net.ingress_buffer_size                          );
   CFG_POP      ( cstr,   net.xdp.xdp_mode                                 );
   CFG_POP      ( bool,   net.xdp.xdp_zero_copy                            );
+  CFG_POP      ( cstr,   net.xdp.poll_mode                                );
   CFG_POP      ( uint,   net.xdp.xdp_rx_queue_size                        );
   CFG_POP      ( uint,   net.xdp.xdp_tx_queue_size                        );
   CFG_POP      ( uint,   net.xdp.flush_timeout_micros                     );

--- a/src/app/shared_dev/commands/pktgen/pktgen.c
+++ b/src/app/shared_dev/commands/pktgen/pktgen.c
@@ -208,6 +208,7 @@ pktgen_cmd_fn( args_t *   args FD_PARAM_UNUSED,
   configure_stage( &fd_cfg_stage_bonding,          CONFIGURE_CMD_INIT, config );
   configure_stage( &fd_cfg_stage_ethtool_channels, CONFIGURE_CMD_INIT, config );
   configure_stage( &fd_cfg_stage_ethtool_offloads, CONFIGURE_CMD_INIT, config );
+  configure_stage( &fd_cfg_stage_sysfs_poll,       CONFIGURE_CMD_INIT, config );
 
   fdctl_check_configure( config );
   /* FIXME this allocates lots of memory unnecessarily */

--- a/src/app/shared_dev/commands/udpecho/udpecho.c
+++ b/src/app/shared_dev/commands/udpecho/udpecho.c
@@ -100,6 +100,7 @@ udpecho_cmd_fn( args_t *   args,
   configure_stage( &fd_cfg_stage_ethtool_channels, CONFIGURE_CMD_INIT, config );
   configure_stage( &fd_cfg_stage_ethtool_offloads, CONFIGURE_CMD_INIT, config );
   configure_stage( &fd_cfg_stage_ethtool_loopback, CONFIGURE_CMD_INIT, config );
+  configure_stage( &fd_cfg_stage_sysfs_poll,       CONFIGURE_CMD_INIT, config );
 
   fdctl_check_configure( config );
   /* FIXME this allocates lots of memory unnecessarily */

--- a/src/disco/net/fd_net_tile_topo.c
+++ b/src/disco/net/fd_net_tile_topo.c
@@ -45,6 +45,13 @@ setup_xdp_tile( fd_topo_t *             topo,
   tile->xdp.zero_copy           = net_cfg->xdp.xdp_zero_copy;
   fd_cstr_ncpy( tile->xdp.xdp_mode, net_cfg->xdp.xdp_mode, sizeof(tile->xdp.xdp_mode) );
 
+  fd_cstr_ncpy( tile->xdp.poll_mode, net_cfg->xdp.poll_mode, sizeof(tile->xdp.poll_mode) );
+
+  tile->xdp.prefbusy_timebudget_micros   = 80L;
+  tile->xdp.prefbusy_rx_budget           = 64L;
+  tile->xdp.prefbusy_min_interval_nanos  = 5000L;
+  tile->xdp.prefbusy_stall_timeout_nanos = 150000L;
+
   tile->xdp.net.umem_dcache_obj_id = umem_obj->id;
   tile->xdp.netdev_tbl_obj_id      = netlink_tile->netlink.netdev_tbl_obj_id;
   tile->xdp.fib4_main_obj_id       = netlink_tile->netlink.fib4_main_obj_id;

--- a/src/disco/net/xdp/fd_xdp_tile.c
+++ b/src/disco/net/xdp/fd_xdp_tile.c
@@ -94,10 +94,17 @@ struct fd_net_flusher {
      wakeup.  This can result in the tail of a burst getting delayed or
      overrun.  If more than tail_flush_backoff ticks pass since the last
      sendto() wakeup and there are still unacknowledged packets in the
-     TX ring, issues another wakeup. */
+     TX ring, issues another wakeup. Only used by "softirq" poll mode. */
   long next_tail_flush_ticks;
   long tail_flush_backoff;
 
+  /* Used to keep track of when the most recent prefbusy poll was. */
+  long prefbusy_last_poll_ticks;
+  /* Maintains the configured prefbusy_min_interval_micros between
+     each prefbusy poll to protect against livelocks. */
+  long prefbusy_min_interval_ticks;
+  /* Stall timeout, configured with prefbusy_stall_timeout_micros. */
+  long prefbusy_stall_timeout_ticks;
 };
 
 typedef struct fd_net_flusher fd_net_flusher_t;
@@ -211,6 +218,10 @@ typedef struct {
   ushort repair_client_listen_port;
   ushort repair_serve_listen_port;
   ushort txsend_src_port;
+
+  char poll_mode[ 16 ];
+  int prefbusy_timebudget_micros;
+  int prefbusy_rx_budget;
 
   ulong in_cnt;
   fd_net_in_ctx_t in[ MAX_NET_INS ];
@@ -1122,6 +1133,104 @@ net_rx_event( fd_net_ctx_t * ctx,
   fill_ring->cached_prod = fill_prod+1U;
 }
 
+/* before_credit_softirq is called every loop iteration if net tile
+   is in softirq polling mode (fallback if prefbusy polling mode
+   is not enabled). */
+
+static void
+before_credit_softirq( fd_net_ctx_t *      ctx,
+                       int *               charge_busy,
+                       uint                rr_idx,
+                       fd_xsk_t *          rr_xsk ) {
+
+  net_tx_periodic_wakeup( ctx, rr_idx, fd_tickcount(), charge_busy );
+
+  /* Fire RX event if we have RX desc avail */
+  if( !fd_xdp_ring_empty( &rr_xsk->ring_rx, FD_XDP_RING_ROLE_CONS ) ) {
+    *charge_busy = 1;
+    net_rx_event( ctx, rr_xsk, rr_xsk->ring_rx.cached_cons );
+  } else {
+    net_rx_wakeup( ctx, rr_xsk, charge_busy );
+
+    /* Iterate onto the next NAPI queue. */
+    ctx->rr_idx++;
+    ctx->rr_idx = fd_uint_if( ctx->rr_idx>=ctx->xsk_cnt, 0, ctx->rr_idx );
+  }
+}
+
+static int
+net_prefbusy_poll_ready( fd_xsk_t *         rr_xsk,
+                         fd_net_flusher_t * flusher,
+                         long               now ) {
+
+  if( FD_UNLIKELY( now < ( flusher->prefbusy_last_poll_ticks + flusher->prefbusy_min_interval_ticks ) ) ) return 0;
+  if( FD_UNLIKELY( now > ( flusher->prefbusy_last_poll_ticks + flusher->prefbusy_stall_timeout_ticks ) ) ) return 1;
+
+  if( FD_UNLIKELY( fd_xdp_ring_empty( &rr_xsk->ring_tx, FD_XDP_RING_ROLE_PROD ) ) ) {
+    flusher->pending_cnt = 0UL;
+  }
+
+  int rx_empty = fd_xdp_ring_empty( &rr_xsk->ring_rx, FD_XDP_RING_ROLE_CONS );
+
+  return rx_empty;
+}
+
+static void
+net_prefbusy_poll_flush( fd_net_flusher_t * flusher,
+                         long               now ) {
+  flusher->pending_cnt              = 0UL;
+  flusher->prefbusy_last_poll_ticks = now;
+}
+
+/* before_credit_prefbusy is called every loop iteration if net
+   tile is in preferred busy (often referred to as "prefbusy" in
+   Firedancer) polling mode. */
+
+static void
+before_credit_prefbusy( fd_net_ctx_t *      ctx,
+                        int *               charge_busy,
+                        uint                rr_idx,
+                        fd_xsk_t *          rr_xsk ) {
+
+  fd_net_flusher_t * flusher = ctx->tx_flusher+rr_idx;
+  if( FD_UNLIKELY( net_prefbusy_poll_ready( rr_xsk, flusher, fd_tickcount() ) ) ) {
+    /* NAPI needs to be polled to process new TX from
+       Firedancer's net tile and process new RX from the NIC. */
+
+    FD_VOLATILE( *rr_xsk->ring_tx.prod ) = rr_xsk->ring_tx.cached_prod; /* write-back local copies to fseqs */
+    FD_VOLATILE( *rr_xsk->ring_cr.cons ) = rr_xsk->ring_cr.cached_cons;
+    FD_VOLATILE( *rr_xsk->ring_rx.cons ) = rr_xsk->ring_rx.cached_cons;
+    FD_VOLATILE( *rr_xsk->ring_fr.prod ) = rr_xsk->ring_fr.cached_prod;
+
+    if( FD_UNLIKELY( -1==sendto( rr_xsk->xsk_fd, NULL, 0, MSG_DONTWAIT, NULL, 0 ) ) ) {
+      if( FD_UNLIKELY( net_is_fatal_xdp_error( errno ) ) ) {
+        FD_LOG_ERR(( "xsk sendto failed xsk_fd=%d (%i-%s)", rr_xsk->xsk_fd, errno, fd_io_strerror( errno ) ));
+      }
+      if( FD_UNLIKELY( errno!=EAGAIN ) ) {
+        long ts = fd_log_wallclock();
+        if( ts > rr_xsk->log_suppress_until_ns ) {
+          FD_LOG_WARNING(( "xsk sendto failed xsk_fd=%d (%i-%s)", rr_xsk->xsk_fd, errno, fd_io_strerror( errno ) ));
+          rr_xsk->log_suppress_until_ns = ts + (long)1e9;
+        }
+      }
+    }
+    net_prefbusy_poll_flush( flusher, fd_tickcount() );
+
+    /* Since xsk sendmsg in prefbusy mode drives both rx and tx, both are incremented */
+    ctx->metrics.xsk_tx_wakeup_cnt++;
+    ctx->metrics.xsk_rx_wakeup_cnt++;
+  }
+
+  /* Process new RX from xsk ring if there is any. */
+  if( !fd_xdp_ring_empty( &rr_xsk->ring_rx, FD_XDP_RING_ROLE_CONS ) ) {
+    *charge_busy = 1;
+    net_rx_event( ctx, rr_xsk, rr_xsk->ring_rx.cached_cons );
+  }
+  /* Iterate onto the next NAPI queue. */
+  ctx->rr_idx++;
+  ctx->rr_idx = fd_uint_if( ctx->rr_idx>=ctx->xsk_cnt, 0, ctx->rr_idx );
+}
+
 /* before_credit is called every loop iteration. */
 
 static void
@@ -1148,16 +1257,11 @@ before_credit( fd_net_ctx_t *      ctx,
   uint       rr_idx = ctx->rr_idx;
   fd_xsk_t * rr_xsk = &ctx->xsk[ rr_idx ];
 
-  net_tx_periodic_wakeup( ctx, rr_idx, fd_tickcount(), charge_busy );
-
-  /* Fire RX event if we have RX desc avail */
-  if( !fd_xdp_ring_empty( &rr_xsk->ring_rx, FD_XDP_RING_ROLE_CONS ) ) {
-    *charge_busy = 1;
-    net_rx_event( ctx, rr_xsk, rr_xsk->ring_rx.cached_cons );
+  if( FD_LIKELY( rr_xsk->prefbusy_poll_enabled ) ) {
+    before_credit_prefbusy( ctx, charge_busy, rr_idx, rr_xsk );
   } else {
-    net_rx_wakeup( ctx, rr_xsk, charge_busy );
-    ctx->rr_idx++;
-    ctx->rr_idx = fd_uint_if( ctx->rr_idx>=ctx->xsk_cnt, 0, ctx->rr_idx );
+    /* Fallback poll mode which relies on linux irqs and wakeups */
+    before_credit_softirq( ctx, charge_busy, rr_idx, rr_xsk );
   }
 
   /* Fire comp event if we have comp desc avail */
@@ -1288,6 +1392,9 @@ privileged_init( fd_topo_t const *      topo,
        (e.g. 5.14.0-503.23.1.el9_5 with i40e) */
     .bind_flags  = tile->xdp.zero_copy ? XDP_ZEROCOPY : XDP_COPY,
 
+    .prefbusy_timebudget_micros = tile->xdp.prefbusy_timebudget_micros,
+    .prefbusy_rx_budget         = tile->xdp.prefbusy_rx_budget,
+
     .fr_depth  = tile->xdp.xdp_rx_queue_size*2,
     .rx_depth  = tile->xdp.xdp_rx_queue_size,
     .cr_depth  = tile->xdp.xdp_tx_queue_size,
@@ -1299,6 +1406,8 @@ privileged_init( fd_topo_t const *      topo,
 
     .core_dump = tile->xdp.xsk_core_dump,
   };
+
+  fd_cstr_ncpy( params0.poll_mode, tile->xdp.poll_mode, sizeof(params0.poll_mode) );
 
   /* Re-derive XDP file descriptors */
 
@@ -1408,6 +1517,10 @@ unprivileged_init( fd_topo_t const *      topo,
   ctx->repair_serve_listen_port       = tile->net.repair_serve_listen_port;
   ctx->txsend_src_port                = tile->net.txsend_src_port;
 
+  fd_cstr_ncpy( ctx->poll_mode, tile->xdp.poll_mode, sizeof(ctx->poll_mode) );
+  ctx->prefbusy_timebudget_micros = tile->xdp.prefbusy_timebudget_micros;
+  ctx->prefbusy_rx_budget         = tile->xdp.prefbusy_rx_budget;
+
   /* Put a bound on chunks we read from the input, to make sure they
      are within in the data region of the workspace. */
 
@@ -1496,6 +1609,10 @@ unprivileged_init( fd_topo_t const *      topo,
     ctx->tx_flusher[ j ].pending_wmark         = (ulong)( (double)tile->xdp.xdp_tx_queue_size * 0.7 );
     ctx->tx_flusher[ j ].tail_flush_backoff    = (long)( (double)tile->xdp.tx_flush_timeout_ns * fd_tempo_tick_per_ns( NULL ) );
     ctx->tx_flusher[ j ].next_tail_flush_ticks = LONG_MAX;
+
+    ctx->tx_flusher[ j ].prefbusy_last_poll_ticks     = 0UL;
+    ctx->tx_flusher[ j ].prefbusy_min_interval_ticks  = (long)( (double)tile->xdp.prefbusy_min_interval_nanos * fd_tempo_tick_per_ns( NULL ) );
+    ctx->tx_flusher[ j ].prefbusy_stall_timeout_ticks = (long)( (double)tile->xdp.prefbusy_stall_timeout_nanos * fd_tempo_tick_per_ns( NULL ) );
   }
 
   /* Join netbase objects */

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -190,6 +190,13 @@ struct fd_topo_tile {
       int    zero_copy;
 
       ulong netdev_tbl_obj_id;
+
+      char poll_mode[ 16 ]; /* "prefbusy" or "softirq" */
+      int prefbusy_timebudget_micros;
+      int prefbusy_rx_budget;
+      long prefbusy_min_interval_nanos;
+      long prefbusy_stall_timeout_nanos;
+
       ulong fib4_main_obj_id;      /* fib4 containing main route table */
       ulong fib4_local_obj_id;     /* fib4 containing local route table */
       ulong neigh4_obj_id;         /* neigh4 hash map */

--- a/src/waltz/xdp/fd_xsk.c
+++ b/src/waltz/xdp/fd_xsk.c
@@ -6,7 +6,9 @@
 
 #include <errno.h>
 #include <stdio.h> /* snprintf */
+#include <string.h> /* strcmp */
 #include <unistd.h>
+#include <fcntl.h>
 #include <sys/mman.h> /* mmap */
 #include <sys/types.h>
 #include <sys/socket.h> /* sendto */
@@ -14,6 +16,24 @@
 
 #include "../../util/log/fd_log.h"
 #include "fd_xsk.h"
+
+/* Support for older kernels */
+
+#ifndef SO_BUSY_POLL
+#define SO_BUSY_POLL 46
+#endif
+
+#ifndef SO_INCOMING_NAPI_ID
+#define SO_INCOMING_NAPI_ID	56
+#endif
+
+#ifndef SO_PREFER_BUSY_POLL
+#define SO_PREFER_BUSY_POLL	69
+#endif
+
+#ifndef SO_BUSY_POLL_BUDGET
+#define SO_BUSY_POLL_BUDGET	70
+#endif
 
 /* Join/leave *********************************************************/
 
@@ -187,6 +207,57 @@ fd_xsk_setup_umem( fd_xsk_t *              xsk,
   return 0;
 }
 
+/* fd_xsk_setup_poll: Setup preferred busy polling if the user has
+   set that to be their preferred polling method */
+
+static void
+fd_xsk_setup_poll( fd_xsk_t *              xsk,
+                   fd_xsk_params_t const * params ) {
+  xsk->prefbusy_poll_enabled = 0;
+  if( 0!=strcmp( params->poll_mode, "prefbusy" ) ) return;
+
+  /* Configure socket options for preferred busy polling */
+
+  int prefbusy_poll = 1;
+  if( FD_UNLIKELY( 0!=setsockopt( xsk->xsk_fd, SOL_SOCKET, SO_PREFER_BUSY_POLL, &prefbusy_poll, sizeof(int) ) ) ) {
+    int err = errno;
+    FD_LOG_WARNING(( "setsockopt(xsk_fd,SOL_SOCKET,SO_PREFER_BUSY_POLL,1) failed (%i-%s)", err, fd_io_strerror( err ) ));
+    if( err==EINVAL ) {
+      FD_LOG_WARNING(( "Hint: Does your kernel support preferred busy polling? SO_PREFER_BUSY_POLL is available from Linux 5.11 onwards" ));
+    }
+    return;
+  }
+
+  if( FD_UNLIKELY( 0!=setsockopt( xsk->xsk_fd, SOL_SOCKET, SO_BUSY_POLL, &params->prefbusy_timebudget_micros, sizeof(int) ) ) ) {
+    FD_LOG_WARNING(( "setsockopt(xsk_fd,SOL_SOCKET,SO_BUSY_POLL,%i) failed (%i-%s)",
+                     params->prefbusy_timebudget_micros, errno, fd_io_strerror( errno ) ));
+    return;
+  }
+
+  if( FD_UNLIKELY( 0!=setsockopt( xsk->xsk_fd, SOL_SOCKET, SO_BUSY_POLL_BUDGET, &params->prefbusy_rx_budget, sizeof(int) ) ) ) {
+    FD_LOG_WARNING(( "setsockopt(xsk_fd,SOL_SOCKET,SO_BUSY_POLL_BUDGET,%i) failed (%i-%s)",
+                     params->prefbusy_rx_budget , errno, fd_io_strerror( errno ) ));
+    return;
+  }
+
+  /* Set socket non blocking */
+
+  int sk_flags = fcntl( xsk->xsk_fd, F_GETFL, 0 );
+  if( FD_UNLIKELY( -1==sk_flags ) ) {
+    FD_LOG_WARNING(( "fcntl(xsk->xsk_fd, F_GETFL, 0) failed (%i-%s)",
+                     errno, fd_io_strerror( errno ) ));
+    return;
+  }
+  if( FD_UNLIKELY( -1==fcntl( xsk->xsk_fd, F_SETFL, sk_flags | O_NONBLOCK ) ) ) {
+    FD_LOG_WARNING(( "fcntl(xsk->xsk_fd, F_SETFL, sk_flags | O_NONBLOCK) failed (%i-%s)",
+                     errno, fd_io_strerror( errno ) ));
+    return;
+  }
+
+  /* Successfully finished setting up prefbusy polling */
+  xsk->prefbusy_poll_enabled = 1U;
+}
+
 /* fd_xsk_init: Creates and configures an XSK socket object, and
    attaches to a preinstalled XDP program.  The various steps are
    implemented in fd_xsk_setup_{...}. */
@@ -288,6 +359,10 @@ fd_xsk_init( fd_xsk_t *              xsk,
 
   FD_LOG_INFO(( "AF_XDP socket initialized: bind( PF_XDP, ifindex=%u (%s), queue_id=%u, flags=%x ) success",
                 xsk->if_idx, if_indextoname( xsk->if_idx, if_name ), xsk->if_queue_id, flags ));
+
+  /* If requested, enable preferred busy polling */
+
+  fd_xsk_setup_poll( xsk, params );
 
   return xsk;
 

--- a/src/waltz/xdp/fd_xsk.h
+++ b/src/waltz/xdp/fd_xsk.h
@@ -187,8 +187,8 @@ fd_xdp_ring_full( fd_xdp_ring_t * ring ) {
   return ring->cached_prod - ring->cached_cons >= ring->depth;
 }
 
-/* fd_xsk_params_t: Memory layout parameters of XSK.
-   Can be retrieved using fd_xsk_get_params() */
+/* fd_xsk_params_t: XSK poll configuration and memory layout
+   parameters. Can be retrieved using fd_xsk_get_params() */
 
 struct fd_xsk_params {
   /* {fr,rx,tx,cr}_depth: Number of frames allocated for the Fill, RX,
@@ -217,6 +217,17 @@ struct fd_xsk_params {
   /* sockaddr_xdp.sxdp_flags additional params, e.g. XDP_ZEROCOPY */
   uint bind_flags;
 
+  /* Whether to use softirqs to poll napi or prefbusy poll */
+  char poll_mode[ 16 ];
+
+  /* Max time during prefbusy napi poll. Referred to as
+     busy_poll_usecs within Linux. */
+  int prefbusy_timebudget_micros;
+
+  /* Max RX processing budget during prefbusy napi poll.
+     Referred to as busy_poll_budget within Linux. */
+  int prefbusy_rx_budget;
+
   /* whether the xsk memory should be included in core dumps */
   int core_dump;
 };
@@ -235,6 +246,10 @@ struct fd_xsk {
 
   /* AF_XDP socket file descriptor */
   int xsk_fd;
+
+  /* Whether preferred busy polling was successfully enabled
+     during XSK socket setup. */
+  int prefbusy_poll_enabled;
 
   /* ring_{rx,tx,fr,cr}: XSK ring descriptors */
 


### PR DESCRIPTION
Implements https://github.com/firedancer-io/firedancer/issues/3618

Softirq poll mode is identical to what Firedancer currently uses and is set to be the default poll mode in this PR since it is more well tested. Prefbusy is the new poll mode this PR adds.

Prefbusy poll mode gives Firedancer significantly more control over how and when NAPI is polled, with no networking related IRQs or ksoftirqds during main runtime when used on a well supported driver.

Even when used on a less well supported driver inwhich ksoftirqds still occur like bnxt_en (Broadcom), the poll scheduling code used with prefbusy in this PR have been shown to be beneficial to RX throughput robustness as demonstrated in the test results below.
(bnxt_en Copy Mode)
<img width="526" height="371" alt="image" src="https://github.com/user-attachments/assets/9a333036-0aa1-43f0-869b-8346dad9e011" />
(note TX still degraded towards 0Mpps like in softirq mode)

Prefbusy when well supported, removes Firedancer’s reliance on softirqs and ksoftirqds to poll NAPI. ksoftirqds are separate threads which softirqs execute inside of instead of the net tile's thread once network load is medium-high.

ksoftirqds are bad for a few reasons:
1. They (generally but not always) run on a different core to the net tile so each net tile in softirq poll mode effectively occupies two cores (when under medium-high network load) or if multiple ksoftirqd threads are running on the same core (polling for separate net tiles), only one of those net tiles can poll NAPI at a time.
2. If Linux schedules a ksoftirqd onto a core corresponding to a Firedancer tile, the performance of that tile will significantly degrade as network load increases, this situation is analysed and tested in the mlx5 testing pdf with the net tile being the example choked Firedancer tile.
3. Linux decides how much the ksoftirqd thread runs vs other irq/house keeping threads, creating unwanted dependence on scheduling algorithms designed to prioritise fairness over performance.

[ixgbe PrefBusy Tests.pdf](https://github.com/user-attachments/files/29358809/ixgbe.PrefBusy.Tests.pdf)
[mlx5 PrefBusy Tests.pdf](https://github.com/user-attachments/files/29358810/mlx5.PrefBusy.Tests.pdf)
[i40e PrefBusy Tests.pdf](https://github.com/user-attachments/files/29358811/i40e.PrefBusy.Tests.pdf)

