### PR TITLE
Rewrite rwlock with stdatomic

### DIFF
--- a/src/flamenco/Local.mk
+++ b/src/flamenco/Local.mk
@@ -1,3 +1,8 @@
 $(call make-lib,fd_flamenco)
 $(call add-hdrs,fd_flamenco_base.h fd_flamenco.h)
 $(call add-hdrs,fd_rwlock.h)
+$(call make-unit-test,test_rwlock,test_rwlock,fd_flamenco fd_util)
+$(call run-unit-test,test_rwlock)
+ifdef FD_HAS_RACESAN
+$(call make-unit-test,test_rwlock_racesan,test_rwlock_racesan,fd_flamenco fd_util)
+endif

--- a/src/flamenco/fd_rwlock.h
+++ b/src/flamenco/fd_rwlock.h
@@ -6,79 +6,66 @@
 #include "../util/fd_util_base.h"
 #include "../util/sanitize/fd_tsa.h"
 #include "../util/racesan/fd_racesan_target.h"
+#include <stdatomic.h>
 
 #define FD_RWLOCK_WRITE_LOCK ((ushort)0xFFFF)
 
 struct FD_CAPABILITY("fd_rwlock") fd_rwlock {
-  ushort value; /* Bits 0..16 are
-
-                    0: Unlocked
-                    1..=0xFFFE: Locked by N readers
-                    0xFFFF: Write locked */
+  atomic_ushort value; /* 0: Unlocked
+                          1..=0xFFFE: Locked by N readers
+                          0xFFFF: Write locked */
 };
 
 typedef struct fd_rwlock fd_rwlock_t;
 
 static inline fd_rwlock_t *
 fd_rwlock_new( fd_rwlock_t * lock ) FD_NO_THREAD_SAFETY_ANALYSIS {
-  lock->value = 0;
+  atomic_store_explicit( &lock->value, 0, memory_order_relaxed );
   return lock;
 }
 
 static inline void
-fd_rwlock_write( fd_rwlock_t * lock ) FD_ACQUIRE( lock )  FD_NO_THREAD_SAFETY_ANALYSIS {
-# if FD_HAS_THREADS
+fd_rwlock_write( fd_rwlock_t * lock ) FD_ACQUIRE( lock ) FD_NO_THREAD_SAFETY_ANALYSIS {
   for(;;) {
-    ushort value = lock->value;
+    ushort value = atomic_load_explicit( &lock->value, memory_order_relaxed );
     fd_racesan_hook( "rwlock_write:pre_cas" );
     if( FD_LIKELY( !value ) ) {
-      if( FD_LIKELY( FD_ATOMIC_CAS( &lock->value, 0, 0xFFFF )==0 ) ) {
-        FD_COMPILER_MFENCE();
+      ushort expected = 0;
+      if( FD_LIKELY( atomic_compare_exchange_weak_explicit( &lock->value, &expected, FD_RWLOCK_WRITE_LOCK, memory_order_acquire, memory_order_relaxed ) ) ) {
         fd_racesan_hook( "rwlock_write:post_acquire" );
         return;
       }
     }
     FD_SPIN_PAUSE();
   }
-# else
-  lock->value = 0xFFFF;
-  FD_COMPILER_MFENCE();
-# endif
 }
 
 static inline void
 fd_rwlock_unwrite( fd_rwlock_t * lock ) FD_RELEASE( lock ) FD_NO_THREAD_SAFETY_ANALYSIS {
   fd_racesan_hook( "rwlock_unwrite:pre_release" );
-  FD_COMPILER_MFENCE();
-  FD_VOLATILE( lock->value ) = 0;
+  atomic_store_explicit( &lock->value, 0, memory_order_release );
 }
 
 static inline void
 fd_rwlock_demote( fd_rwlock_t * lock ) FD_RELEASE( lock ) FD_ACQUIRE_SHARED( lock ) FD_NO_THREAD_SAFETY_ANALYSIS {
   fd_racesan_hook( "rwlock_demote:pre_release" );
-  FD_COMPILER_MFENCE();
-  FD_VOLATILE( lock->value ) = 1;
+  atomic_store_explicit( &lock->value, 1, memory_order_release );
 }
 
 static inline void
-fd_rwlock_read( fd_rwlock_t * lock ) FD_ACQUIRE_SHARED( lock ) FD_NO_THREAD_SAFETY_ANALYSIS  {
-# if FD_HAS_THREADS
+fd_rwlock_read( fd_rwlock_t * lock ) FD_ACQUIRE_SHARED( lock ) FD_NO_THREAD_SAFETY_ANALYSIS {
   for(;;) {
-    ushort value = lock->value;
+    ushort value = atomic_load_explicit( &lock->value, memory_order_relaxed );
     fd_racesan_hook( "rwlock_read:pre_cas" );
     if( FD_LIKELY( value<0xFFFE ) ) {
-      if( FD_LIKELY( FD_ATOMIC_CAS( &lock->value, value, value+1 )==value ) ) {
-        FD_COMPILER_MFENCE();
+      ushort expected = value;
+      if( FD_LIKELY( atomic_compare_exchange_weak_explicit( &lock->value, &expected, (ushort)(value+1), memory_order_acquire, memory_order_relaxed ) ) ) {
         fd_racesan_hook( "rwlock_read:post_acquire" );
         return;
       }
     }
     FD_SPIN_PAUSE();
   }
-# else
-  lock->value++;
-  FD_COMPILER_MFENCE();
-# endif
 }
 
 /* fd_rwlock_tryread attempts to acquire a shared read lock without
@@ -87,44 +74,26 @@ fd_rwlock_read( fd_rwlock_t * lock ) FD_ACQUIRE_SHARED( lock ) FD_NO_THREAD_SAFE
 
 static inline int
 fd_rwlock_tryread( fd_rwlock_t * lock ) FD_TRY_ACQUIRE_SHARED(1, lock) FD_NO_THREAD_SAFETY_ANALYSIS {
-# if FD_HAS_THREADS
-  ushort value = lock->value;
+  ushort value = atomic_load_explicit( &lock->value, memory_order_relaxed );
   fd_racesan_hook( "rwlock_tryread:pre_cas" );
   if( FD_UNLIKELY( value>=0xFFFE ) ) return 0;
-  if( FD_UNLIKELY( FD_ATOMIC_CAS( &lock->value, value, (ushort)(value+1) )!=value ) ) return 0;
-  FD_COMPILER_MFENCE();
+  ushort expected = value;
+  if( FD_UNLIKELY( !atomic_compare_exchange_strong_explicit( &lock->value, &expected, (ushort)(value+1), memory_order_acquire, memory_order_relaxed ) ) ) return 0;
   return 1;
-# else
-  lock->value++;
-  FD_COMPILER_MFENCE();
-  return 1;
-# endif
 }
 
 static inline int
 fd_rwlock_trywrite( fd_rwlock_t * lock ) FD_TRY_ACQUIRE(1, lock) FD_NO_THREAD_SAFETY_ANALYSIS {
-# if FD_HAS_THREADS
   fd_racesan_hook( "rwlock_trywrite:pre_cas" );
-  if( FD_UNLIKELY( FD_ATOMIC_CAS( &lock->value, 0, FD_RWLOCK_WRITE_LOCK )!=0 ) ) return 0;
-  FD_COMPILER_MFENCE();
+  ushort expected = 0;
+  if( FD_UNLIKELY( !atomic_compare_exchange_strong_explicit( &lock->value, &expected, FD_RWLOCK_WRITE_LOCK, memory_order_acquire, memory_order_relaxed ) ) ) return 0;
   return 1;
-# else
-  if( FD_UNLIKELY( lock->value ) ) return 0;
-  lock->value = FD_RWLOCK_WRITE_LOCK;
-  FD_COMPILER_MFENCE();
-  return 1;
-# endif
 }
 
 static inline void
 fd_rwlock_unread( fd_rwlock_t * lock ) FD_RELEASE_SHARED( lock ) FD_NO_THREAD_SAFETY_ANALYSIS {
   fd_racesan_hook( "rwlock_unread:pre_release" );
-  FD_COMPILER_MFENCE();
-# if FD_HAS_THREADS
-  FD_ATOMIC_FETCH_AND_SUB( &lock->value, 1 );
-# else
-  lock->value--;
-# endif
+  atomic_fetch_sub_explicit( &lock->value, 1, memory_order_release );
 }
 
 #endif /* HEADER_fd_src_flamenco_fd_rwlock_h */

--- a/src/flamenco/test_rwlock.c
+++ b/src/flamenco/test_rwlock.c
@@ -1,0 +1,136 @@
+#include "../util/fd_util.h"
+#include "fd_rwlock.h"
+
+/* Basic single-threaded correctness tests for fd_rwlock. */
+
+static void
+test_rwlock_new( void ) {
+  fd_rwlock_t lock[1];
+  FD_TEST( fd_rwlock_new( lock ) );
+  FD_TEST( atomic_load( &lock->value )==0 );
+}
+
+static void
+test_rwlock_write_unwrite( void ) {
+  fd_rwlock_t lock[1];
+  fd_rwlock_new( lock );
+
+  fd_rwlock_write( lock );
+  FD_TEST( atomic_load( &lock->value )==FD_RWLOCK_WRITE_LOCK );
+
+  fd_rwlock_unwrite( lock );
+  FD_TEST( atomic_load( &lock->value )==0 );
+}
+
+static void
+test_rwlock_read_unread( void ) {
+  fd_rwlock_t lock[1];
+  fd_rwlock_new( lock );
+
+  fd_rwlock_read( lock );
+  FD_TEST( atomic_load( &lock->value )==1 );
+
+  fd_rwlock_read( lock );
+  FD_TEST( atomic_load( &lock->value )==2 );
+
+  fd_rwlock_read( lock );
+  FD_TEST( atomic_load( &lock->value )==3 );
+
+  fd_rwlock_unread( lock );
+  FD_TEST( atomic_load( &lock->value )==2 );
+
+  fd_rwlock_unread( lock );
+  FD_TEST( atomic_load( &lock->value )==1 );
+
+  fd_rwlock_unread( lock );
+  FD_TEST( atomic_load( &lock->value )==0 );
+}
+
+static void
+test_rwlock_demote( void ) {
+  fd_rwlock_t lock[1];
+  fd_rwlock_new( lock );
+
+  fd_rwlock_write( lock );
+  FD_TEST( atomic_load( &lock->value )==FD_RWLOCK_WRITE_LOCK );
+
+  fd_rwlock_demote( lock );
+  FD_TEST( atomic_load( &lock->value )==1 );
+
+  /* Should be able to acquire another read lock now */
+  fd_rwlock_read( lock );
+  FD_TEST( atomic_load( &lock->value )==2 );
+
+  fd_rwlock_unread( lock );
+  fd_rwlock_unread( lock );
+  FD_TEST( atomic_load( &lock->value )==0 );
+}
+
+static void
+test_rwlock_trywrite( void ) {
+  fd_rwlock_t lock[1];
+  fd_rwlock_new( lock );
+
+  /* trywrite on unlocked should succeed */
+  FD_TEST( fd_rwlock_trywrite( lock )==1 );
+  FD_TEST( atomic_load( &lock->value )==FD_RWLOCK_WRITE_LOCK );
+
+  /* trywrite on write-locked should fail */
+  FD_TEST( fd_rwlock_trywrite( lock )==0 );
+
+  fd_rwlock_unwrite( lock );
+
+  /* trywrite after unlock should succeed again */
+  FD_TEST( fd_rwlock_trywrite( lock )==1 );
+  fd_rwlock_unwrite( lock );
+}
+
+static void
+test_rwlock_tryread( void ) {
+  fd_rwlock_t lock[1];
+  fd_rwlock_new( lock );
+
+  /* tryread on unlocked should succeed */
+  FD_TEST( fd_rwlock_tryread( lock )==1 );
+  FD_TEST( atomic_load( &lock->value )==1 );
+
+  /* tryread again should succeed (multiple readers) */
+  FD_TEST( fd_rwlock_tryread( lock )==1 );
+  FD_TEST( atomic_load( &lock->value )==2 );
+
+  fd_rwlock_unread( lock );
+  fd_rwlock_unread( lock );
+
+  /* tryread on write-locked should fail */
+  fd_rwlock_write( lock );
+  FD_TEST( fd_rwlock_tryread( lock )==0 );
+  fd_rwlock_unwrite( lock );
+}
+
+static void
+test_rwlock_trywrite_while_read( void ) {
+  fd_rwlock_t lock[1];
+  fd_rwlock_new( lock );
+
+  fd_rwlock_read( lock );
+  FD_TEST( fd_rwlock_trywrite( lock )==0 );
+  fd_rwlock_unread( lock );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  test_rwlock_new();
+  test_rwlock_write_unwrite();
+  test_rwlock_read_unread();
+  test_rwlock_demote();
+  test_rwlock_trywrite();
+  test_rwlock_tryread();
+  test_rwlock_trywrite_while_read();
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}

--- a/src/flamenco/test_rwlock_racesan.c
+++ b/src/flamenco/test_rwlock_racesan.c
@@ -1,0 +1,313 @@
+#include "../util/racesan/fd_racesan_async.h"
+#include "../util/racesan/fd_racesan_weave.h"
+#include "../util/fd_util.h"
+#include "fd_rwlock.h"
+
+/* Racesan interleaving tests for fd_rwlock.
+   Each test runs many random interleavings of concurrent lock
+   operations and validates that invariants are maintained. */
+
+#define FIBER_MAX       4
+#define FIBER_STACK_MAX (1UL<<20)
+#define ITER_MAX        (10000UL)
+#define STEP_MAX        (4096UL)
+
+static void * g_fiber_stack[ FIBER_MAX ];
+
+/* Shared state for fibers */
+
+struct test_ctx {
+  fd_rwlock_t lock[1];
+  uint        shared_ctr;  /* Protected by lock */
+};
+
+typedef struct test_ctx test_ctx_t;
+
+/* async_write_inc: acquire write lock, increment counter, release */
+
+static void
+async_write_inc( void * _ctx ) {
+  test_ctx_t * ctx = _ctx;
+  fd_rwlock_write( ctx->lock );
+  ctx->shared_ctr++;
+  fd_rwlock_unwrite( ctx->lock );
+}
+
+/* async_read_check: acquire read lock, observe counter, release */
+
+static void
+async_read_check( void * _ctx ) {
+  test_ctx_t * ctx = _ctx;
+  fd_rwlock_read( ctx->lock );
+  /* Under read lock, counter should not change.
+     Just touch it to generate memory accesses. */
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE_CONST( ctx->shared_ctr );
+  fd_rwlock_unread( ctx->lock );
+}
+
+/* async_trywrite_inc: attempt write lock, increment if acquired */
+
+static void
+async_trywrite_inc( void * _ctx ) {
+  test_ctx_t * ctx = _ctx;
+  if( fd_rwlock_trywrite( ctx->lock ) ) {
+    ctx->shared_ctr++;
+    fd_rwlock_unwrite( ctx->lock );
+  }
+}
+
+/* async_tryread_check: attempt read lock, observe if acquired */
+
+static void
+async_tryread_check( void * _ctx ) {
+  test_ctx_t * ctx = _ctx;
+  if( fd_rwlock_tryread( ctx->lock ) ) {
+    FD_COMPILER_MFENCE();
+    FD_VOLATILE_CONST( ctx->shared_ctr );
+    fd_rwlock_unread( ctx->lock );
+  }
+}
+
+/* async_demote: acquire write lock, increment, demote to read, observe,
+   release read */
+
+static void
+async_demote( void * _ctx ) {
+  test_ctx_t * ctx = _ctx;
+  fd_rwlock_write( ctx->lock );
+  ctx->shared_ctr++;
+  fd_rwlock_demote( ctx->lock );
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE_CONST( ctx->shared_ctr );
+  fd_rwlock_unread( ctx->lock );
+}
+
+/* Test: two concurrent writers */
+
+static void
+test_write_write( void ) {
+  FD_LOG_NOTICE(( "Testing write vs write" ));
+
+  test_ctx_t ctx[1];
+  fd_rwlock_new( ctx->lock );
+
+  fd_racesan_async_t async0[1];
+  fd_racesan_async_t async1[1];
+
+  fd_racesan_weave_t weave[1];
+  fd_racesan_weave_new( weave );
+  fd_racesan_async_new( async0, g_fiber_stack[0], FIBER_STACK_MAX, async_write_inc, ctx );
+  fd_racesan_async_new( async1, g_fiber_stack[1], FIBER_STACK_MAX, async_write_inc, ctx );
+  fd_racesan_weave_add( weave, async0 );
+  fd_racesan_weave_add( weave, async1 );
+
+  for( ulong i=0UL; i<ITER_MAX; i++ ) {
+    ctx->shared_ctr = 0U;
+    atomic_store_explicit( &ctx->lock->value, 0, memory_order_relaxed );
+    fd_racesan_weave_exec_rand( weave, i, STEP_MAX );
+    FD_TEST( !weave->rem_cnt );
+    FD_TEST( ctx->shared_ctr==2U );
+    fd_racesan_async_reset( async0 );
+    fd_racesan_async_reset( async1 );
+  }
+
+  fd_racesan_weave_delete( weave );
+  fd_racesan_async_delete( async1 );
+  fd_racesan_async_delete( async0 );
+}
+
+/* Test: two concurrent readers */
+
+static void
+test_read_read( void ) {
+  FD_LOG_NOTICE(( "Testing read vs read" ));
+
+  test_ctx_t ctx[1];
+  fd_rwlock_new( ctx->lock );
+  ctx->shared_ctr = 42U;
+
+  fd_racesan_async_t async0[1];
+  fd_racesan_async_t async1[1];
+
+  fd_racesan_weave_t weave[1];
+  fd_racesan_weave_new( weave );
+  fd_racesan_async_new( async0, g_fiber_stack[0], FIBER_STACK_MAX, async_read_check, ctx );
+  fd_racesan_async_new( async1, g_fiber_stack[1], FIBER_STACK_MAX, async_read_check, ctx );
+  fd_racesan_weave_add( weave, async0 );
+  fd_racesan_weave_add( weave, async1 );
+
+  for( ulong i=0UL; i<ITER_MAX; i++ ) {
+    atomic_store_explicit( &ctx->lock->value, 0, memory_order_relaxed );
+    fd_racesan_weave_exec_rand( weave, i, STEP_MAX );
+    FD_TEST( !weave->rem_cnt );
+    fd_racesan_async_reset( async0 );
+    fd_racesan_async_reset( async1 );
+  }
+
+  fd_racesan_weave_delete( weave );
+  fd_racesan_async_delete( async1 );
+  fd_racesan_async_delete( async0 );
+}
+
+/* Test: reader vs writer contention */
+
+static void
+test_read_write( void ) {
+  FD_LOG_NOTICE(( "Testing read vs write" ));
+
+  test_ctx_t ctx[1];
+  fd_rwlock_new( ctx->lock );
+
+  fd_racesan_async_t async0[1];
+  fd_racesan_async_t async1[1];
+
+  fd_racesan_weave_t weave[1];
+  fd_racesan_weave_new( weave );
+  fd_racesan_async_new( async0, g_fiber_stack[0], FIBER_STACK_MAX, async_write_inc, ctx );
+  fd_racesan_async_new( async1, g_fiber_stack[1], FIBER_STACK_MAX, async_read_check, ctx );
+  fd_racesan_weave_add( weave, async0 );
+  fd_racesan_weave_add( weave, async1 );
+
+  for( ulong i=0UL; i<ITER_MAX; i++ ) {
+    ctx->shared_ctr = 0U;
+    atomic_store_explicit( &ctx->lock->value, 0, memory_order_relaxed );
+    fd_racesan_weave_exec_rand( weave, i, STEP_MAX );
+    FD_TEST( !weave->rem_cnt );
+    FD_TEST( ctx->shared_ctr==1U );
+    fd_racesan_async_reset( async0 );
+    fd_racesan_async_reset( async1 );
+  }
+
+  fd_racesan_weave_delete( weave );
+  fd_racesan_async_delete( async1 );
+  fd_racesan_async_delete( async0 );
+}
+
+/* Test: trywrite vs trywrite */
+
+static void
+test_trywrite_trywrite( void ) {
+  FD_LOG_NOTICE(( "Testing trywrite vs trywrite" ));
+
+  test_ctx_t ctx[1];
+  fd_rwlock_new( ctx->lock );
+
+  fd_racesan_async_t async0[1];
+  fd_racesan_async_t async1[1];
+
+  fd_racesan_weave_t weave[1];
+  fd_racesan_weave_new( weave );
+  fd_racesan_async_new( async0, g_fiber_stack[0], FIBER_STACK_MAX, async_trywrite_inc, ctx );
+  fd_racesan_async_new( async1, g_fiber_stack[1], FIBER_STACK_MAX, async_trywrite_inc, ctx );
+  fd_racesan_weave_add( weave, async0 );
+  fd_racesan_weave_add( weave, async1 );
+
+  for( ulong i=0UL; i<ITER_MAX; i++ ) {
+    ctx->shared_ctr = 0U;
+    atomic_store_explicit( &ctx->lock->value, 0, memory_order_relaxed );
+    fd_racesan_weave_exec_rand( weave, i, STEP_MAX );
+    FD_TEST( !weave->rem_cnt );
+    /* Each trywrite either succeeds or fails, so counter is 0, 1, or 2 */
+    FD_TEST( ctx->shared_ctr<=2U );
+    fd_racesan_async_reset( async0 );
+    fd_racesan_async_reset( async1 );
+  }
+
+  fd_racesan_weave_delete( weave );
+  fd_racesan_async_delete( async1 );
+  fd_racesan_async_delete( async0 );
+}
+
+/* Test: tryread vs write */
+
+static void
+test_tryread_write( void ) {
+  FD_LOG_NOTICE(( "Testing tryread vs write" ));
+
+  test_ctx_t ctx[1];
+  fd_rwlock_new( ctx->lock );
+
+  fd_racesan_async_t async0[1];
+  fd_racesan_async_t async1[1];
+
+  fd_racesan_weave_t weave[1];
+  fd_racesan_weave_new( weave );
+  fd_racesan_async_new( async0, g_fiber_stack[0], FIBER_STACK_MAX, async_write_inc,    ctx );
+  fd_racesan_async_new( async1, g_fiber_stack[1], FIBER_STACK_MAX, async_tryread_check, ctx );
+  fd_racesan_weave_add( weave, async0 );
+  fd_racesan_weave_add( weave, async1 );
+
+  for( ulong i=0UL; i<ITER_MAX; i++ ) {
+    ctx->shared_ctr = 0U;
+    atomic_store_explicit( &ctx->lock->value, 0, memory_order_relaxed );
+    fd_racesan_weave_exec_rand( weave, i, STEP_MAX );
+    FD_TEST( !weave->rem_cnt );
+    FD_TEST( ctx->shared_ctr==1U );
+    fd_racesan_async_reset( async0 );
+    fd_racesan_async_reset( async1 );
+  }
+
+  fd_racesan_weave_delete( weave );
+  fd_racesan_async_delete( async1 );
+  fd_racesan_async_delete( async0 );
+}
+
+/* Test: demote vs read */
+
+static void
+test_demote_read( void ) {
+  FD_LOG_NOTICE(( "Testing demote vs read" ));
+
+  test_ctx_t ctx[1];
+  fd_rwlock_new( ctx->lock );
+
+  fd_racesan_async_t async0[1];
+  fd_racesan_async_t async1[1];
+
+  fd_racesan_weave_t weave[1];
+  fd_racesan_weave_new( weave );
+  fd_racesan_async_new( async0, g_fiber_stack[0], FIBER_STACK_MAX, async_demote,     ctx );
+  fd_racesan_async_new( async1, g_fiber_stack[1], FIBER_STACK_MAX, async_read_check, ctx );
+  fd_racesan_weave_add( weave, async0 );
+  fd_racesan_weave_add( weave, async1 );
+
+  for( ulong i=0UL; i<ITER_MAX; i++ ) {
+    ctx->shared_ctr = 0U;
+    atomic_store_explicit( &ctx->lock->value, 0, memory_order_relaxed );
+    fd_racesan_weave_exec_rand( weave, i, STEP_MAX );
+    FD_TEST( !weave->rem_cnt );
+    FD_TEST( ctx->shared_ctr==1U );
+    fd_racesan_async_reset( async0 );
+    fd_racesan_async_reset( async1 );
+  }
+
+  fd_racesan_weave_delete( weave );
+  fd_racesan_async_delete( async1 );
+  fd_racesan_async_delete( async0 );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  for( ulong i=0UL; i<FIBER_MAX; i++ ) {
+    g_fiber_stack[ i ] = fd_racesan_stack_create( FIBER_STACK_MAX );
+  }
+
+  test_write_write();
+  test_read_read();
+  test_read_write();
+  test_trywrite_trywrite();
+  test_tryread_write();
+  test_demote_read();
+
+  for( ulong i=0UL; i<FIBER_MAX; i++ ) {
+    fd_racesan_stack_destroy( g_fiber_stack[ i ], FIBER_STACK_MAX );
+  }
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
Adds ThreadSanitizer compatibility to rwlock

Leaves underlying algorithms/design identical (which is inefficient but it works)