### PR TITLE
codeql: update version, fix breaking change

### DIFF
--- a/contrib/codeql/dev/codeql-pack.lock.yml
+++ b/contrib/codeql/dev/codeql-pack.lock.yml
@@ -2,27 +2,27 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/controlflow:
-    version: 2.0.14
+    version: 2.0.27
   codeql/cpp-all:
-    version: 5.5.0
+    version: 8.0.0
   codeql/dataflow:
-    version: 2.0.14
+    version: 2.0.27
   codeql/mad:
-    version: 1.0.30
+    version: 1.0.43
   codeql/quantum:
-    version: 0.0.8
+    version: 0.0.21
   codeql/rangeanalysis:
-    version: 1.0.30
+    version: 1.0.43
   codeql/ssa:
-    version: 2.0.6
+    version: 2.0.19
   codeql/tutorial:
-    version: 1.0.30
+    version: 1.0.43
   codeql/typeflow:
-    version: 1.0.30
+    version: 1.0.43
   codeql/typetracking:
-    version: 2.0.14
+    version: 2.0.27
   codeql/util:
-    version: 2.0.17
+    version: 2.0.30
   codeql/xml:
-    version: 1.0.30
+    version: 1.0.43
 compiled: false

--- a/contrib/codeql/nightly/AddressOfNullCheck.ql
+++ b/contrib/codeql/nightly/AddressOfNullCheck.ql
@@ -20,23 +20,14 @@ import semmle.code.cpp.controlflow.Guards
  * Models flows from address-of expressions to NULL/non-NULL checks that
  * always hold.
  */
-private class MustFlowConfig extends MustFlowConfiguration {
-  MustFlowConfig() { this = "SuspiciousAddressOfNullCheckMustFlow" }
-
-  override predicate isSource(Instruction source) {
+module MustFlowConfig implements MustFlow::ConfigSig {
+  predicate isSource(Instruction source) {
     source.getUnconvertedResultExpression() instanceof ValidAddressOfExpr
   }
 
-  override predicate isSink(Operand sink) { isNullOrNonNullCheck(sink) }
+  predicate isSink(Operand sink) { isNullOrNonNullCheck(sink) }
 
-  override predicate allowInterproceduralFlow() { none() }
-
-  override predicate isBarrier(Instruction instr) {
-    // Temporary workaround for bug in the library where interprocedural flow
-    // in recursive functions is not handled correctly.
-    // Tracking issue: https://github.com/github/codeql/issues/21240
-    instr instanceof InitializeParameterInstruction
-  }
+  predicate allowInterproceduralFlow() { none() }
 }
 
 /**
@@ -51,9 +42,11 @@ predicate isNullOrNonNullCheck(Operand operand) {
   any(IRGuardCondition gc).comparesEq(operand, 0, _, _)
 }
 
-from MustFlowPathNode source, MustFlowPathNode sink, MustFlowConfig cfg
+module Flow = MustFlow::Global<MustFlowConfig>;
+
+from Flow::PathNode source, Flow::PathNode sink
 where
-  cfg.hasFlowPath(source, sink) and
+  Flow::flowPath(source, sink) and
   not source.getInstruction().getUnconvertedResultExpression().isInMacroExpansion() and
   source.getInstruction().getEnclosingFunction() = sink.getInstruction().getEnclosingFunction()
 select sink, "Taking the address of $@ always produces a non-NULL pointer, but it is checked $@.",

--- a/contrib/codeql/nightly/codeql-pack.lock.yml
+++ b/contrib/codeql/nightly/codeql-pack.lock.yml
@@ -2,27 +2,27 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/controlflow:
-    version: 2.0.14
+    version: 2.0.27
   codeql/cpp-all:
-    version: 5.5.0
+    version: 8.0.0
   codeql/dataflow:
-    version: 2.0.14
+    version: 2.0.27
   codeql/mad:
-    version: 1.0.30
+    version: 1.0.43
   codeql/quantum:
-    version: 0.0.8
+    version: 0.0.21
   codeql/rangeanalysis:
-    version: 1.0.30
+    version: 1.0.43
   codeql/ssa:
-    version: 2.0.6
+    version: 2.0.19
   codeql/tutorial:
-    version: 1.0.30
+    version: 1.0.43
   codeql/typeflow:
-    version: 1.0.30
+    version: 1.0.43
   codeql/typetracking:
-    version: 2.0.14
+    version: 2.0.27
   codeql/util:
-    version: 2.0.17
+    version: 2.0.30
   codeql/xml:
-    version: 1.0.30
+    version: 1.0.43
 compiled: false

--- a/contrib/codeql/test/codeql-pack.lock.yml
+++ b/contrib/codeql/test/codeql-pack.lock.yml
@@ -2,27 +2,27 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/controlflow:
-    version: 2.0.14
+    version: 2.0.27
   codeql/cpp-all:
-    version: 5.5.0
+    version: 8.0.0
   codeql/dataflow:
-    version: 2.0.14
+    version: 2.0.27
   codeql/mad:
-    version: 1.0.30
+    version: 1.0.43
   codeql/quantum:
-    version: 0.0.8
+    version: 0.0.21
   codeql/rangeanalysis:
-    version: 1.0.30
+    version: 1.0.43
   codeql/ssa:
-    version: 2.0.6
+    version: 2.0.19
   codeql/tutorial:
-    version: 1.0.30
+    version: 1.0.43
   codeql/typeflow:
-    version: 1.0.30
+    version: 1.0.43
   codeql/typetracking:
-    version: 2.0.14
+    version: 2.0.27
   codeql/util:
-    version: 2.0.17
+    version: 2.0.30
   codeql/xml:
-    version: 1.0.30
+    version: 1.0.43
 compiled: false


### PR DESCRIPTION
Fix the breaking change caused by the fix of https://github.com/github/codeql/issues/21240#issuecomment-3925953290
Allows us to remove the workaround as well.