### PR TITLE
solfuzz: bounds check when appending program_id in fuzz harness

### DIFF
--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -13,7 +13,7 @@
 #include "../../log_collector/fd_log_collector.h"
 #include <assert.h>
 
-void
+int
 fd_solfuzz_pb_instr_ctx_create( fd_solfuzz_runner_t *                runner,
                                 fd_exec_instr_ctx_t *                ctx,
                                 fd_exec_test_instr_context_t const * test_ctx,
@@ -163,12 +163,15 @@ fd_solfuzz_pb_instr_ctx_create( fd_solfuzz_runner_t *                runner,
 
     if( !memcmp( acc_key, test_ctx->program_id, sizeof(fd_pubkey_t) ) ) {
       has_program_id = 1;
-      info->program_id = (uchar)txn_out->accounts.cnt;
+      info->program_id = (uchar)j;
     }
   }
 
   /* If the program id is not in the set of accounts it must be added to the set of accounts. */
   if( FD_UNLIKELY( !has_program_id ) ) {
+    if( FD_UNLIKELY( txn_out->accounts.cnt >= MAX_TX_ACCOUNT_LOCKS ) ) {
+      return -1;
+    }
     fd_pubkey_t * program_key = &txn_out->accounts.keys[ txn_out->accounts.cnt ];
     memcpy( program_key, test_ctx->program_id, sizeof(fd_pubkey_t) );
 
@@ -340,6 +343,7 @@ fd_solfuzz_pb_instr_ctx_create( fd_solfuzz_runner_t *                runner,
 
   fd_log_collector_init( ctx->runtime->log.log_collector, 1 );
   fd_base58_encode_32( txn_out->accounts.keys[ ctx->instr->program_id ].uc, NULL, ctx->program_id_base58 );
+  return 0;
 }
 
 void
@@ -367,7 +371,10 @@ fd_solfuzz_pb_instr_run( fd_solfuzz_runner_t * runner,
 
   /* Convert the Protobuf inputs to a fd_exec context */
   fd_exec_instr_ctx_t ctx[1];
-  fd_solfuzz_pb_instr_ctx_create( runner, ctx, input, false );
+  if( fd_solfuzz_pb_instr_ctx_create( runner, ctx, input, false ) ) {
+    fd_solfuzz_pb_instr_ctx_destroy( runner, ctx );
+    return 0UL;
+  }
 
   fd_instr_info_t * instr = (fd_instr_info_t *) ctx->instr;
 

--- a/src/flamenco/runtime/tests/fd_instr_harness.h
+++ b/src/flamenco/runtime/tests/fd_instr_harness.h
@@ -16,12 +16,14 @@ FD_PROTOTYPES_BEGIN
    Setting is_syscall avoids some operations/checks only relevant for
    program instructions.
 
-   This function is infallible, it will abort with FD_LOG_ERR on
-   invariant violations (malformed test inputs).
+   Returns 0 on success, non-zero if the input is malformed and the
+   context could not be created (e.g. too many accounts).  On error,
+   the caller must still call fd_solfuzz_pb_instr_ctx_destroy to
+   release any partially initialized resources.
 
    Should be coupled with fd_solfuzz_pb_instr_ctx_destroy when the
    instr_ctx is no longer needed. */
-void
+int
 fd_solfuzz_pb_instr_ctx_create( fd_solfuzz_runner_t *                runner,
                                 fd_exec_instr_ctx_t *                ctx,
                                 fd_exec_test_instr_context_t const * test_ctx,

--- a/src/flamenco/runtime/tests/fd_vm_harness.c
+++ b/src/flamenco/runtime/tests/fd_vm_harness.c
@@ -93,7 +93,10 @@ fd_solfuzz_pb_syscall_run( fd_solfuzz_runner_t * runner,
   int is_cpi            = !strncmp( (const char *)input->syscall_invocation.function_name.bytes, "sol_invoke_signed", 17 );
   int skip_extra_checks = !is_cpi;
 
-  fd_solfuzz_pb_instr_ctx_create( runner, ctx, input_instr_ctx, skip_extra_checks );
+  if( fd_solfuzz_pb_instr_ctx_create( runner, ctx, input_instr_ctx, skip_extra_checks ) ) {
+    fd_solfuzz_pb_instr_ctx_destroy( runner, ctx );
+    return 0;
+  }
 
   ctx->txn_out->err.exec_err = 0;
   ctx->txn_out->err.exec_err_kind = FD_EXECUTOR_ERR_KIND_NONE;


### PR DESCRIPTION
decided against evicting an account in solfuzz because we might evict an important account / sysvar and solfuzz-agave does not respect the same `MAX_TX_ACCOUNT_LOCKS` cap, open to other ideas though...