### PR TITLE
bls: reject compressed or parity encodings while deserializing

### DIFF
--- a/src/ballet/bls/fd_bls12_381.c
+++ b/src/ballet/bls/fd_bls12_381.c
@@ -64,6 +64,13 @@ fd_bls12_381_g1_frombytes_unchecked( fd_bls12_381_g1aff_t * r,
     fd_bls12_381_g1_bswap( (uchar *)be, _in );
     in = (uchar *)be;
   }
+
+  /* Reject the point if the compressed or parity flag is set.
+     https://github.com/anza-xyz/agave/blob/v4.0.0-beta.2/bls12-381/src/encoding.rs#L57-L60 */
+  if( FD_UNLIKELY( in[ 0 ] & 0xA0 ) ) {
+    return NULL;
+  }
+
   if( FD_UNLIKELY( blst_p1_deserialize( r, in )!=BLST_SUCCESS ) ) {
     return NULL;
   }
@@ -232,6 +239,13 @@ fd_bls12_381_g2_frombytes_unchecked( fd_bls12_381_g2aff_t * r,
     fd_bls12_381_g2_bswap( (uchar *)be, _in );
     in = (uchar *)be;
   }
+
+  /* Reject the point if the compressed or parity flag is set.
+     https://github.com/anza-xyz/agave/blob/v4.0.0-beta.2/bls12-381/src/encoding.rs#L103-L106 */
+  if( FD_UNLIKELY( in[ 0 ] & 0xA0 ) ) {
+    return NULL;
+  }
+
   if( FD_UNLIKELY( blst_p2_deserialize( r, in )!=BLST_SUCCESS ) ) {
     return NULL;
   }

--- a/src/ballet/bls/test_bls12_381.c
+++ b/src/ballet/bls/test_bls12_381.c
@@ -1104,6 +1104,38 @@ test_proof_of_possession( FD_FN_UNUSED fd_rng_t * rng ) {
     log_bench( "fd_bls12_381_proof_of_possession", iter, dt );
   }
 }
+static void
+test_reject_flags( FD_FN_UNUSED fd_rng_t * rng ) {
+
+  /* Ensure that we disallow compressed/parity bits. If we didn't, then
+     blst would automatically try decompressing the point based off of the
+     encoding. This would allow the second half of the bytes to be garbage,
+     as they wouldn't be read, giving malleable points. */
+
+  {
+    /* Take a valid compressed point, and fill the second half with garbage. */
+    uchar g1[ 96 ];
+    fd_hex_decode( g1, "af9ff5448e60bc9a718f463ac102bd6f8772e6460c19076a6c89d5806e5a8ef44b6f3b8af09e37a4e564987a26b9deda", 48 );
+    fd_memset( g1+48UL, 0xAA, 48 );
+
+    /* Give it the compressed flag. */
+    g1[0] |= 0x80;
+
+    /* Make sure we fail. */
+    FD_TEST( fd_bls12_381_g1_validate_syscall( g1, 1 /*BE*/ )==0 );
+  }
+  {
+    /* Same test for G2 */
+    uchar g2[ 192 ];
+    fd_hex_decode( g2, "8f6a12dc289804e48b236892b34acdac92890b6a4a2a878935f940fbade830d17dde0dd179eeb9b36f6947df2730c3681718aa3b6f6aa733e7bae0b6ac490f12d38f3b0273bec4a36f0b24855660bc871025d8af47b6de1fcf9b10ff704ef26f", 96 );
+    fd_memset( g2+96UL, 0xAA, 96 );
+
+    /* Set the compressed flag. */
+    g2[0] |= 0x80;
+
+    FD_TEST( fd_bls12_381_g2_validate_syscall( g2, 1 /*BE*/ )==0 );
+  }
+}
 
 /**********************************************************************/
 
@@ -1128,6 +1160,8 @@ main( int     argc,
   test_pairing( rng );
 
   test_proof_of_possession( rng );
+
+  test_reject_flags( rng );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/flamenco/features/fd_features_generated.c
+++ b/src/flamenco/features/fd_features_generated.c
@@ -1748,8 +1748,8 @@ fd_feature_id_t const ids[] = {
     .cleaned_up                = 0 },
 
   { .index                     = offsetof(fd_features_t, enable_bls12_381_syscall)>>3,
-    .id                        = {"\x08\xb6\xbd\x29\xaa\xb4\x9d\x6a\x7c\x4d\x8f\xb2\xc3\x1f\xd1\x9e\xfc\xda\x3c\xc8\xe3\x6f\x1c\x9a\x8d\x0f\x74\x62\xea\x21\xaf\x87"},
-                                 /* b1sraWPVFdcUizB2LV5wQTeMuK8M313bi5bHjco5eVU */
+    .id                        = {"\x08\xb6\xbc\x4b\x2f\xee\x11\x9e\x1b\x44\xd1\x6a\x49\x13\x1a\x27\xbc\xe5\x5e\xb4\xe3\xae\x15\x5b\x28\x0a\x77\x38\x47\xda\x4b\xdd"},
+                                 /* b1sgUiJ3qu7hYm3tNDyyqZNQd6gLGJmJppnLNa93PCQ */
     .name                      = "enable_bls12_381_syscall",
     .cleaned_up                = 0 },
 
@@ -2072,7 +2072,7 @@ typedef struct fd_feature_id_lookup_entry fd_feature_id_lookup_entry_t;
 #define MAP_PERFECT_252 0xdab5b6a991a03e4bUL, .val = &ids[252]
 #define MAP_PERFECT_253 0x8921a3abf23afaecUL, .val = &ids[253]
 #define MAP_PERFECT_254 0x640dddd90caae808UL, .val = &ids[254]
-#define MAP_PERFECT_255 0x6a9db4aa29bdb608UL, .val = &ids[255]
+#define MAP_PERFECT_255 0x9e11ee2f4bbcb608UL, .val = &ids[255]
 #define MAP_PERFECT_256 0x010f656d89a4e808UL, .val = &ids[256]
 #define MAP_PERFECT_257 0xfc12b1cef363afa7UL, .val = &ids[257]
 #define MAP_PERFECT_258 0x3727b6b01b8a6c1cUL, .val = &ids[258]

--- a/src/flamenco/features/fd_features_generated.h
+++ b/src/flamenco/features/fd_features_generated.h
@@ -271,7 +271,7 @@ union fd_features {
     /* 0xdab5b6a991a03e4b */ ulong static_instruction_limit;
     /* 0x8921a3abf23afaec */ ulong vote_state_v4;
     /* 0x640dddd90caae808 */ ulong alt_bn128_little_endian;
-    /* 0x6a9db4aa29bdb608 */ ulong enable_bls12_381_syscall;
+    /* 0x9e11ee2f4bbcb608 */ ulong enable_bls12_381_syscall;
     /* 0x010f656d89a4e808 */ ulong enable_alt_bn128_g2_syscalls;
     /* 0xfc12b1cef363afa7 */ ulong switch_to_chacha8_turbine;
     /* 0x3727b6b01b8a6c1c */ ulong bls_pubkey_management_in_vote_account;

--- a/src/flamenco/features/feature_map.json
+++ b/src/flamenco/features/feature_map.json
@@ -254,7 +254,7 @@
   {"name":"static_instruction_limit","pubkey":"64ixypL1HPu8WtJhNSMb9mSgfFaJvsANuRkTbHyuLfnx","cleaned_up":1,"hardcode_for_fuzzing":1},
   {"name":"vote_state_v4","pubkey":"Gx4XFcrVMt4HUvPzTpTSVkdDVgcDSjKhDN1RqRS6KDuZ","hardcode_for_fuzzing":1},
   {"name":"alt_bn128_little_endian","pubkey":"bn2oPgpkzQPT3tohMaAsMVGjhDmmDa4jCaVPqCFmtxM"},
-  {"name":"enable_bls12_381_syscall","pubkey":"b1sraWPVFdcUizB2LV5wQTeMuK8M313bi5bHjco5eVU"},
+  {"name":"enable_bls12_381_syscall","pubkey":"b1sgUiJ3qu7hYm3tNDyyqZNQd6gLGJmJppnLNa93PCQ"},
   {"name":"enable_alt_bn128_g2_syscalls","pubkey":"bn1hKNURMGQaQoEVxahcEAcqiX3NwRs6hgKKNSLeKxH"},
   {"name":"switch_to_chacha8_turbine","pubkey":"CHaChatUnR3s6cPyPMMGNJa3VdQQ8PNH2JqdD4LpCKnB"},
   {"name":"bls_pubkey_management_in_vote_account","pubkey":"2uxQgtKa2ECHGs67Zdj7dgmzn2w9HiqhdcedwCWfYzzq"},


### PR DESCRIPTION
https://github.com/anza-xyz/agave/pull/11155

Maybe don't merge yet, Anza may rekey the bls syscall gate to keep the -beta.0 min version, TBD.