### PR TITLE
disco, flamenco, shred: implement discard_unexpected_data_complete_shreds

### DIFF
--- a/src/disco/shred/fd_fec_resolver.c
+++ b/src/disco/shred/fd_fec_resolver.c
@@ -250,6 +250,14 @@ struct __attribute__((aligned(FD_FEC_RESOLVER_ALIGN))) fd_fec_resolver {
      signature. */
   ulong seed;
 
+  /* discard_unexpected_data_complete_shreds: activation slot for
+     discard_unexpected_data_complete_shreds.
+
+     This feature rejects data shreds with the DATA_COMPLETE flag set
+     at the wrong position within an FEC set (i.e. not the last data
+     shred). */
+  ulong discard_unexpected_data_complete_shreds;
+
   /* sha512 and reedsol are used for calculations while adding a shred.
      Their state outside a call to add_shred is indeterminate. */
   fd_sha512_t   sha512[1];
@@ -356,17 +364,18 @@ fd_fec_resolver_new( void                    * shmem,
 
   fd_sha512_new( resolver->sha512 );
 
-  resolver->depth                  = depth;
-  resolver->partial_depth          = partial_depth;
-  resolver->complete_depth         = complete_depth;
-  resolver->done_depth             = done_depth;
-  resolver->expected_shred_version = 0;
-  resolver->free_list_cnt          = depth+partial_depth;
-  resolver->signer                 = signer;
-  resolver->sign_ctx               = sign_ctx;
-  resolver->max_shred_idx          = max_shred_idx;
-  resolver->slot_old               = 0UL;
-  resolver->seed                   = seed3;
+  resolver->depth                                   = depth;
+  resolver->partial_depth                           = partial_depth;
+  resolver->complete_depth                          = complete_depth;
+  resolver->done_depth                              = done_depth;
+  resolver->expected_shred_version                  = 0;
+  resolver->free_list_cnt                           = depth+partial_depth;
+  resolver->signer                                  = signer;
+  resolver->sign_ctx                                = sign_ctx;
+  resolver->max_shred_idx                           = max_shred_idx;
+  resolver->slot_old                                = 0UL;
+  resolver->seed                                    = seed3;
+  resolver->discard_unexpected_data_complete_shreds = ULONG_MAX;
   return shmem;
 }
 
@@ -409,6 +418,12 @@ void
 fd_fec_resolver_set_shred_version( fd_fec_resolver_t * resolver,
                                    ushort              expected_shred_version ) {
   resolver->expected_shred_version = expected_shred_version;
+}
+
+void
+fd_fec_resolver_set_discard_unexpected_data_complete_shreds( fd_fec_resolver_t * resolver,
+                                                             ulong               activation_slot ) {
+  resolver->discard_unexpected_data_complete_shreds = activation_slot;
 }
 
 void
@@ -563,9 +578,19 @@ fd_fec_resolver_add_shred( fd_fec_resolver_t         * resolver,
   if( FD_UNLIKELY( ( shred->fec_set_idx % FD_FEC_SHRED_CNT ) != 0UL ) ) return FD_FEC_RESOLVER_SHRED_REJECTED;
   if( FD_UNLIKELY( in_type_idx >= FD_FEC_SHRED_CNT ) )                  return FD_FEC_RESOLVER_SHRED_REJECTED;
   if( is_data_shred ) {
-    /* if it has data complete, it must be the last one in the FEC. */
-    if( FD_UNLIKELY( (shred->data.flags & FD_SHRED_DATA_FLAG_SLOT_COMPLETE) && ((1UL+shred->idx) % FD_FEC_SHRED_CNT) ) )
+    /* if it has slot complete, it must be the last one in the FEC. */
+    if( FD_UNLIKELY( (shred->data.flags & FD_SHRED_DATA_FLAG_SLOT_COMPLETE) && ((1UL+shred->idx) % FD_FEC_SHRED_CNT) ) ) {
       return FD_FEC_RESOLVER_SHRED_REJECTED;
+    }
+
+    /* discard_unexpected_data_complete_shreds:
+       if it has data complete, it must be the last data shred in the FEC set
+       https://github.com/anza-xyz/agave/blob/v4.0.0-beta.1/ledger/src/shred.rs#L817-L825 */
+    if( FD_UNLIKELY( ( shred->slot >= resolver->discard_unexpected_data_complete_shreds ) &&
+                     ( shred->data.flags & FD_SHRED_DATA_FLAG_DATA_COMPLETE )             &&
+                     ( shred->idx != ( shred->fec_set_idx + ( FD_FEC_SHRED_CNT - 1UL ) ) ) ) ) {
+      return FD_FEC_RESOLVER_SHRED_REJECTED;
+    }
   }
 
   /* This, combined with the check on shred->code.data_cnt implies that

--- a/src/disco/shred/fd_fec_resolver.h
+++ b/src/disco/shred/fd_fec_resolver.h
@@ -172,6 +172,13 @@ void
 fd_fec_resolver_set_shred_version( fd_fec_resolver_t * resolver,
                                    ushort              expected_shred_version );
 
+/* fd_fec_resolver_set_discard_unexpected_data_complete_shreds updates
+   the activation slot used by the FEC resolver for the
+   discard_unexpected_data_complete_shreds feature. */
+void
+fd_fec_resolver_set_discard_unexpected_data_complete_shreds( fd_fec_resolver_t * resolver,
+                                                             ulong               activation_slot );
+
 /* fd_fec_resolver_advance_slot_old advances slot_old, discarding any
    in progress FEC sets with a slot strictly less than slot_old.
    Additionally, causes the FEC resolver to ignore any future shreds

--- a/src/disco/shred/fd_shred_tile.c
+++ b/src/disco/shred/fd_shred_tile.c
@@ -489,6 +489,11 @@ during_frag( fd_shred_ctx_t * ctx,
       epoch_msg->features.enforce_fixed_fec_set, ctx );
     ctx->features_activation->switch_to_chacha8_turbine = fd_shred_get_feature_activation_slot0(
       epoch_msg->features.switch_to_chacha8_turbine, ctx );
+    ctx->features_activation->discard_unexpected_data_complete_shreds = fd_shred_get_feature_activation_slot0(
+      epoch_msg->features.discard_unexpected_data_complete_shreds, ctx );
+
+    fd_fec_resolver_set_discard_unexpected_data_complete_shreds( ctx->resolver,
+      ctx->features_activation->discard_unexpected_data_complete_shreds );
 
     return;
   }
@@ -518,6 +523,10 @@ during_frag( fd_shred_ctx_t * ctx,
 
       fd_shred_features_activation_t const * act_data = (fd_shred_features_activation_t const *)dcache_entry;
       memcpy( ctx->features_activation, act_data, sizeof(fd_shred_features_activation_t) );
+
+      /* TODO: call fd_fec_resolver_set_discard_unexpected_data_complete_shreds
+         when discard_unexpected_data_complete_shreds is added to
+         the features of interest in the Rust shim. */
     }
     else { /* (fd_disco_poh_sig_pkt_type( sig )==POH_PKT_TYPE_MICROBLOCK) */
       /* This is a frag from the PoH tile.  We'll copy it to our pending

--- a/src/disco/shred/fd_shredder.h
+++ b/src/disco/shred/fd_shredder.h
@@ -25,7 +25,7 @@
 
 typedef void (fd_shredder_sign_fn)( void * ctx, uchar * sig, uchar const * merkle_root );
 
-#define FD_SHRED_FEATURES_ACTIVATION_SLOT_CNT      (2UL)
+#define FD_SHRED_FEATURES_ACTIVATION_SLOT_CNT      (3UL)
 #define FD_SHRED_FEATURES_ACTIVATION_SLOT_SZ       (8UL)
 #define FD_SHRED_FEATURES_ACTIVATION_SLOT_DISABLED (ULONG_MAX)
 
@@ -35,6 +35,7 @@ union fd_shred_features_activation_private {
    struct {
       /* 0 */ ulong enforce_fixed_fec_set;
       /* 1 */ ulong switch_to_chacha8_turbine;
+      /* 2 */ ulong discard_unexpected_data_complete_shreds;
    };
 };
 typedef union fd_shred_features_activation_private fd_shred_features_activation_t;

--- a/src/flamenco/features/fd_features_generated.c
+++ b/src/flamenco/features/fd_features_generated.c
@@ -1795,6 +1795,12 @@ fd_feature_id_t const ids[] = {
     .name                      = "validator_admission_ticket",
     .cleaned_up                = 0 },
 
+  { .index                     = offsetof(fd_features_t, discard_unexpected_data_complete_shreds)>>3,
+    .id                        = {"\x6d\x4f\x66\x60\x03\xae\x08\x49\xbd\xeb\xc0\x85\x5b\xa1\x4d\x71\x09\xb7\x24\x73\x65\xd1\xee\x41\x73\x7b\x8f\xb1\x5e\x5e\x9f\x89"},
+                                 /* 8MhfKhoZEoiySpVe248bDkisyEcBA7JQLyUS94xoTSqN */
+    .name                      = "discard_unexpected_data_complete_shreds",
+    .cleaned_up                = 0 },
+
   { .index = ULONG_MAX }
 };
 
@@ -2074,6 +2080,7 @@ typedef struct fd_feature_id_lookup_entry fd_feature_id_lookup_entry_t;
 #define MAP_PERFECT_260 0xf55c421c9eccc012UL, .val = &ids[260]
 #define MAP_PERFECT_261 0x73869887e8eb4903UL, .val = &ids[261]
 #define MAP_PERFECT_262 0x8b0786cd93f63607UL, .val = &ids[262]
+#define MAP_PERFECT_263 0x4908ae0360664f6dUL, .val = &ids[263]
 
 #include "../../util/tmpl/fd_map_perfect.c"
 
@@ -2347,4 +2354,5 @@ FD_STATIC_ASSERT( offsetof( fd_features_t, relax_programdata_account_check_migra
 FD_STATIC_ASSERT( offsetof( fd_features_t, remove_simple_vote_from_cost_model                      )>>3==260UL, layout );
 FD_STATIC_ASSERT( offsetof( fd_features_t, limit_instruction_accounts                              )>>3==261UL, layout );
 FD_STATIC_ASSERT( offsetof( fd_features_t, validator_admission_ticket                              )>>3==262UL, layout );
+FD_STATIC_ASSERT( offsetof( fd_features_t, discard_unexpected_data_complete_shreds                 )>>3==263UL, layout );
 FD_STATIC_ASSERT( sizeof( fd_features_t )>>3==FD_FEATURE_ID_CNT, layout );

--- a/src/flamenco/features/fd_features_generated.h
+++ b/src/flamenco/features/fd_features_generated.h
@@ -8,10 +8,10 @@
 #endif
 
 /* FEATURE_ID_CNT is the number of features in ids */
-#define FD_FEATURE_ID_CNT (263UL)
+#define FD_FEATURE_ID_CNT (264UL)
 
 /* Feature set ID calculated from all feature names */
-#define FD_FEATURE_SET_ID (3735554381U)
+#define FD_FEATURE_SET_ID (2244883607U)
 
 union fd_features {
   ulong f[ FD_FEATURE_ID_CNT ];
@@ -279,5 +279,6 @@ union fd_features {
     /* 0xf55c421c9eccc012 */ ulong remove_simple_vote_from_cost_model;
     /* 0x73869887e8eb4903 */ ulong limit_instruction_accounts;
     /* 0x8b0786cd93f63607 */ ulong validator_admission_ticket;
+    /* 0x4908ae0360664f6d */ ulong discard_unexpected_data_complete_shreds;
   };
 };

--- a/src/flamenco/features/feature_map.json
+++ b/src/flamenco/features/feature_map.json
@@ -261,5 +261,6 @@
   {"name":"relax_programdata_account_check_migration","pubkey":"rexav5eNTUSNT1K2N7cfRjnthwhcP5BC25v2tA4rW4h"},
   {"name":"remove_simple_vote_from_cost_model","pubkey":"2GCrNXbzmt4xrwdcKS2RdsLzsgu4V5zHAemW57pcHT6a"},
   {"name":"limit_instruction_accounts","pubkey":"DqbnFPASg7tHmZ6qfpdrt2M6MWoSeiicWPXxPhxqFCQ"},
-  {"name":"validator_admission_ticket","pubkey":"VATtb1DepUwdPh5bFVasdtkbeDNsftZSRzr2aKpKWJA"}
+  {"name":"validator_admission_ticket","pubkey":"VATtb1DepUwdPh5bFVasdtkbeDNsftZSRzr2aKpKWJA"},
+  {"name":"discard_unexpected_data_complete_shreds","pubkey":"8MhfKhoZEoiySpVe248bDkisyEcBA7JQLyUS94xoTSqN"}
 ]


### PR DESCRIPTION
Frankendancer change (adding `discard_unexpected_data_complete_shreds` to the features of interest) will be PR'd into main later to avoid conflicts. Without the Frankendancer change this PR is safe, the feature will just always be deactivated on Frankendancer.