### PR TITLE
replay, snapshots: mix hard forks into bank hash

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -926,8 +926,7 @@ replay_block_finalize( fd_replay_tile_t *  ctx,
   fd_bank_shred_cnt_set( bank, fd_sched_get_shred_cnt( ctx->sched, bank->data->idx ) );
 
   /* Do hashing and other end-of-block processing. */
-  fd_runtime_block_execute_finalize( bank, ctx->accdb, ctx->capture_ctx,
-                                     ctx->hard_forks, ctx->hard_forks_cnts, ctx->hard_forks_cnt );
+  fd_runtime_block_execute_finalize( bank, ctx->accdb, ctx->capture_ctx );
 
   /* Copy out cost tracker fields before freezing */
   fd_replay_slot_completed_t * slot_info = fd_chunk_to_laddr( ctx->replay_out->mem, ctx->replay_out->chunk );
@@ -1078,8 +1077,7 @@ fini_leader_bank( fd_replay_tile_t *  ctx,
 
   fd_sched_block_add_done( ctx->sched, ctx->leader_bank->data->idx, ctx->leader_bank->data->parent_idx, curr_slot );
 
-  fd_runtime_block_execute_finalize( ctx->leader_bank, ctx->accdb, ctx->capture_ctx,
-                                     ctx->hard_forks, ctx->hard_forks_cnts, ctx->hard_forks_cnt );
+  fd_runtime_block_execute_finalize( ctx->leader_bank, ctx->accdb, ctx->capture_ctx );
 
   fd_replay_slot_completed_t * slot_info = fd_chunk_to_laddr( ctx->replay_out->mem, ctx->replay_out->chunk );
   cost_tracker_snap( ctx->leader_bank, slot_info );
@@ -1252,8 +1250,7 @@ init_after_snapshot( fd_replay_tile_t * ctx ) {
     int is_epoch_boundary = 0;
     fd_runtime_block_execute_prepare( ctx->banks, bank, ctx->accdb, &ctx->runtime_stack, ctx->capture_ctx, &is_epoch_boundary );
     FD_TEST( !is_epoch_boundary );
-    fd_runtime_block_execute_finalize( bank, ctx->accdb, ctx->capture_ctx,
-                                       ctx->hard_forks, ctx->hard_forks_cnts, ctx->hard_forks_cnt );
+    fd_runtime_block_execute_finalize( bank, ctx->accdb, ctx->capture_ctx );
 
     snapshot_slot = 0UL;
   }
@@ -1508,10 +1505,6 @@ boot_genesis( fd_replay_tile_t *        ctx,
 
   publish_epoch_info( ctx, stem, bank, 0 );
   publish_epoch_info( ctx, stem, bank, 1 );
-
-  /* Genesis has no hard forks.  Normalize from ULONG_MAX sentinel
-     (set during init) before init_after_snapshot calls finalize. */
-  ctx->hard_forks_cnt = 0UL;
 
   /* We call this after fd_runtime_read_genesis, which sets up the
      slot_bank needed in blockstore_init. */

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -784,10 +784,7 @@ fd_runtime_block_execute_prepare( fd_banks_t *         banks,
 
 static void
 fd_runtime_update_bank_hash( fd_bank_t *        bank,
-                             fd_capture_ctx_t * capture_ctx,
-                             ulong const *      hard_forks,
-                             ulong const *      hard_forks_cnts,
-                             ulong              hard_forks_cnt ) {
+                             fd_capture_ctx_t * capture_ctx ) {
   /* Save the previous bank hash, and the parents signature count */
   fd_hash_t const * prev_bank_hash = NULL;
   if( FD_LIKELY( fd_bank_slot_get( bank )!=0UL ) ) {
@@ -799,9 +796,6 @@ fd_runtime_update_bank_hash( fd_bank_t *        bank,
 
   fd_bank_parent_signature_cnt_set( bank, fd_bank_signature_count_get( bank ) );
 
-  /* hard_forks_cnt must be a real count, not a sentinel value. */
-  FD_TEST( hard_forks_cnt!=ULONG_MAX );
-
   /* Compute the new bank hash */
   fd_lthash_value_t const * lthash = fd_bank_lthash_locking_query( bank );
   fd_hash_t new_bank_hash[1] = { 0 };
@@ -811,13 +805,6 @@ fd_runtime_update_bank_hash( fd_bank_t *        bank,
       (fd_hash_t *)fd_bank_poh_query( bank )->hash,
       fd_bank_signature_count_get( bank ),
       new_bank_hash );
-  fd_hashes_apply_hard_forks(
-      new_bank_hash,
-      fd_bank_slot_get( bank ),
-      fd_bank_parent_slot_get( bank ),
-      hard_forks,
-      hard_forks_cnts,
-      hard_forks_cnt );
 
   /* Update the bank hash */
   fd_bank_bank_hash_set( bank, *new_bank_hash );
@@ -1723,15 +1710,12 @@ fd_runtime_read_genesis( fd_banks_t *              banks,
 void
 fd_runtime_block_execute_finalize( fd_bank_t *        bank,
                                    fd_accdb_user_t *  accdb,
-                                   fd_capture_ctx_t * capture_ctx,
-                                   ulong const *      hard_forks,
-                                   ulong const *      hard_forks_cnts,
-                                   ulong              hard_forks_cnt ) {
+                                   fd_capture_ctx_t * capture_ctx ) {
 
   /* This slot is now "frozen" and can't be changed anymore. */
   fd_runtime_freeze( bank, accdb, capture_ctx );
 
-  fd_runtime_update_bank_hash( bank, capture_ctx, hard_forks, hard_forks_cnts, hard_forks_cnt );
+  fd_runtime_update_bank_hash( bank, capture_ctx );
 }
 
 

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -353,18 +353,13 @@ fd_runtime_block_execute_prepare( fd_banks_t *         banks,
 
 /* fd_runtime_block_execute_finalize finishes the execution of the block
    by paying a fee out to the block leader, updating any sysvars, and
-   updating the bank hash.  hard_forks, hard_forks_cnts, and
-   hard_forks_cnt are passed through to the hard-fork bank hash mixing
-   step.  The required updates are made to the bank and the accounts
-   database. */
+   updating the bank hash.  The required updates are made to the bank
+   and the accounts database. */
 
 void
 fd_runtime_block_execute_finalize( fd_bank_t *        bank,
-                                   fd_accdb_user_t *  accdb,
-                                   fd_capture_ctx_t * capture_ctx,
-                                   ulong const *      hard_forks,
-                                   ulong const *      hard_forks_cnts,
-                                   ulong              hard_forks_cnt );
+                                   fd_accdb_user_t  * accdb,
+                                   fd_capture_ctx_t * capture_ctx );
 
 /* fd_runtime_prepare_and_execute_txn is responsible for executing a
    fd_txn_in_t against a fd_runtime_t and a fd_bank_t.  The results of

--- a/src/flamenco/runtime/tests/fd_block_harness.c
+++ b/src/flamenco/runtime/tests/fd_block_harness.c
@@ -487,8 +487,7 @@ fd_solfuzz_block_ctx_exec( fd_solfuzz_runner_t * runner,
        updated in the blockhash queue. */
     fd_bank_poh_set( runner->bank, *poh );
     /* Finalize the block */
-    fd_runtime_block_execute_finalize( runner->bank, runner->accdb, capture_ctx,
-                                       NULL, NULL, 0UL );
+    fd_runtime_block_execute_finalize( runner->bank, runner->accdb, capture_ctx );
   } FD_SPAD_FRAME_END;
 
   return 1;


### PR DESCRIPTION
## Summary of changes
- Mix hard-fork count into the bank hash during replay finalization, matching Agave's `parent_slot < fork_slot <= slot` logic.
- Apply the same mixing in snapshot bank-hash verification.

## Assumptions
- Hard forks are usually empty in practice; this fixes a latent consensus gap when they are not.
- Snapshot manifests store the already-mixed frozen bank hash, consistent with Agave's serialization chain.
- Genesis needs no special handling.

## Tests
Added test_fd_hashes_apply_hard_forks in test_hashes.c:

- Added `test_fd_hashes_apply_hard_forks` in `test_hashes.c`
- Verified Agave reference outputs for fork-count 1 and 2 cases.
- Full Firedancer test execution is pending CI.

closes #8815

cc @cali-jumptrading 