### PR TITLE
gossip: fix gossvf crash; fix use-after-release when evicting peers

### DIFF
--- a/src/flamenco/gossip/fd_gossip.c
+++ b/src/flamenco/gossip/fd_gossip.c
@@ -367,6 +367,14 @@ fd_gossip_set_identity( fd_gossip_t * gossip,
   int identity_changed = memcmp( gossip->identity_pubkey, identity_pubkey, 32UL );
   if( FD_UNLIKELY( !identity_changed ) ) return;
 
+  /* Remove the old identity from the ping tracker before changing
+     identity_pubkey.  ping_tracker_change filters callbacks where
+     peer_pubkey == identity_pubkey, so an ACTIVE for the old identity
+     was suppressed.  If we don't remove it here, a later INACTIVE
+     would pass through (identity_pubkey has changed) and crash gossvf
+     which never received the corresponding ACTIVE. */
+  fd_ping_tracker_remove( gossip->ping_tracker, gossip->identity_pubkey, now );
+
   ulong new_ci_idx = fd_crds_ci_idx( gossip->crds, identity_pubkey );
 
   /* The new identity may already exist in CRDS as a normal peer (active
@@ -374,6 +382,13 @@ fd_gossip_set_identity( fd_gossip_t * gossip,
      must deactivate it before updating identity_pubkey to maintain the
      invariant that our own identity is never sampleable. */
   if( FD_UNLIKELY( new_ci_idx!=ULONG_MAX ) ) fd_active_set_remove_peer( gossip->active_set, new_ci_idx );
+
+  /* Also remove the new identity from the ping tracker.  It may have
+     been tracked as a peer and received an ACTIVE callback.  After
+     identity change, ping_tracker_change would suppress future
+     callbacks for it (it's now self), but it would remain in gossvf's
+     ping map forever, leaking a slot. */
+  fd_ping_tracker_remove( gossip->ping_tracker, identity_pubkey, now );
 
   fd_memcpy( gossip->identity_pubkey, identity_pubkey, 32UL );
   gossip->identity_stake = get_stake( gossip, identity_pubkey );

--- a/src/flamenco/gossip/fd_ping_tracker.c
+++ b/src/flamenco/gossip/fd_ping_tracker.c
@@ -259,6 +259,31 @@ is_entrypoint( fd_ping_tracker_t const * ping_tracker,
   return 0;
 }
 
+/* evict_peer removes a peer from the map, LRU, and tracking list,
+   fires the change callback if the peer was active, decrements the
+   state metric counter, and releases the pool element. */
+
+static inline void
+evict_peer( fd_ping_tracker_t * ping_tracker,
+            fd_ping_peer_t *    peer,
+            long                now,
+            int                 change_type ) {
+  peer_map_ele_remove_fast( ping_tracker->peers, peer, ping_tracker->pool );
+  lru_list_ele_remove( ping_tracker->lru, peer, ping_tracker->pool );
+  remove_tracking( ping_tracker, peer );
+  if( FD_LIKELY( peer->state==FD_PING_TRACKER_STATE_VALID || peer->state==FD_PING_TRACKER_STATE_VALID_REFRESHING ) ) {
+    ping_tracker->change_fn( ping_tracker->change_fn_ctx, peer->identity_pubkey.b, peer->address, now, change_type );
+  }
+  switch( peer->state ) {
+    case FD_PING_TRACKER_STATE_UNPINGED:         ping_tracker->metrics->unpinged_cnt--; break;
+    case FD_PING_TRACKER_STATE_INVALID:          ping_tracker->metrics->invalid_cnt--; break;
+    case FD_PING_TRACKER_STATE_VALID:            ping_tracker->metrics->valid_cnt--; break;
+    case FD_PING_TRACKER_STATE_VALID_REFRESHING: ping_tracker->metrics->refreshing_cnt--; break;
+    default: FD_LOG_ERR(( "Unknown state %d", peer->state )); return;
+  }
+  pool_ele_release( ping_tracker->pool, peer );
+}
+
 void
 fd_ping_tracker_track( fd_ping_tracker_t * ping_tracker,
                        uchar const *       peer_pubkey,
@@ -308,21 +333,8 @@ fd_ping_tracker_track( fd_ping_tracker_t * ping_tracker,
     if( FD_LIKELY( peer_stake>=1000000000UL || is_entrypoint( ping_tracker, peer_address ) ) ) {
       /* Node went from unstaked (or low staked) to >=1 SOL, or to being
          an entrypoint.  No longer need to ping it. */
-      peer_map_ele_remove_fast( ping_tracker->peers, peer, ping_tracker->pool );
-      lru_list_ele_remove( ping_tracker->lru, peer, ping_tracker->pool );
-      remove_tracking( ping_tracker, peer );
-      pool_ele_release( ping_tracker->pool, peer );
-      if( FD_LIKELY( peer->state==FD_PING_TRACKER_STATE_VALID || peer->state==FD_PING_TRACKER_STATE_VALID_REFRESHING ) ) {
-        ping_tracker->change_fn( ping_tracker->change_fn_ctx, peer->identity_pubkey.b, peer->address, now, FD_PING_TRACKER_CHANGE_TYPE_INACTIVE_STAKED );
-      }
+      evict_peer( ping_tracker, peer, now, FD_PING_TRACKER_CHANGE_TYPE_INACTIVE_STAKED );
       ping_tracker->metrics->stake_changed_cnt++;
-      switch( peer->state ) {
-        case FD_PING_TRACKER_STATE_UNPINGED:         ping_tracker->metrics->unpinged_cnt--; break;
-        case FD_PING_TRACKER_STATE_INVALID:          ping_tracker->metrics->invalid_cnt--; break;
-        case FD_PING_TRACKER_STATE_VALID:            ping_tracker->metrics->valid_cnt--; break;
-        case FD_PING_TRACKER_STATE_VALID_REFRESHING: ping_tracker->metrics->refreshing_cnt--; break;
-        default: FD_LOG_ERR(( "Unknown state %d", peer->state )); return;
-      }
       return;
     }
 
@@ -416,6 +428,15 @@ fd_ping_tracker_active( fd_ping_tracker_t * ping_tracker,
   return peer->state==FD_PING_TRACKER_STATE_VALID || peer->state==FD_PING_TRACKER_STATE_VALID_REFRESHING;
 }
 
+void
+fd_ping_tracker_remove( fd_ping_tracker_t * ping_tracker,
+                        uchar const *       peer_pubkey,
+                        long                now ) {
+  fd_ping_peer_t * peer = peer_map_ele_query( ping_tracker->peers, fd_type_pun_const( peer_pubkey ), NULL, ping_tracker->pool );
+  if( FD_UNLIKELY( !peer ) ) return;
+  evict_peer( ping_tracker, peer, now, FD_PING_TRACKER_CHANGE_TYPE_INACTIVE );
+}
+
 int
 fd_ping_tracker_pop_request( fd_ping_tracker_t *    ping_tracker,
                              long                   now,
@@ -457,20 +478,7 @@ fd_ping_tracker_pop_request( fd_ping_tracker_t *    ping_tracker,
     if( FD_UNLIKELY( next->last_rx_nanos<now-20L*1000L*1000L*1000L ) ) {
       /* The peer is no longer sending us contact information, no need
          to ping it and instead remove it from the table. */
-      peer_map_ele_remove_fast( ping_tracker->peers, next, ping_tracker->pool );
-      lru_list_ele_remove( ping_tracker->lru, next, ping_tracker->pool );
-      remove_tracking( ping_tracker, next );
-      pool_ele_release( ping_tracker->pool, next );
-      if( FD_LIKELY( next->state==FD_PING_TRACKER_STATE_VALID || next->state==FD_PING_TRACKER_STATE_VALID_REFRESHING ) ) {
-        ping_tracker->change_fn( ping_tracker->change_fn_ctx, next->identity_pubkey.b, next->address, now, FD_PING_TRACKER_CHANGE_TYPE_INACTIVE );
-      }
-      switch( next->state ) {
-        case FD_PING_TRACKER_STATE_UNPINGED:         ping_tracker->metrics->unpinged_cnt--; break;
-        case FD_PING_TRACKER_STATE_INVALID:          ping_tracker->metrics->invalid_cnt--; break;
-        case FD_PING_TRACKER_STATE_VALID:            ping_tracker->metrics->valid_cnt--; break;
-        case FD_PING_TRACKER_STATE_VALID_REFRESHING: ping_tracker->metrics->refreshing_cnt--; break;
-        default: FD_LOG_ERR(( "Unknown state %d", next->state ));
-      }
+      evict_peer( ping_tracker, next, now, FD_PING_TRACKER_CHANGE_TYPE_INACTIVE );
       continue;
     }
 

--- a/src/flamenco/gossip/fd_ping_tracker.h
+++ b/src/flamenco/gossip/fd_ping_tracker.h
@@ -145,6 +145,16 @@ fd_ping_tracker_pop_request( fd_ping_tracker_t *    ping_tracker,
                              fd_ip4_port_t const ** out_peer_address,
                              uchar const **         out_token );
 
+/* fd_ping_tracker_remove removes a peer from the ping tracker.  If the
+   peer was active (VALID or VALID_REFRESHING), the change callback will
+   be fired with FD_PING_TRACKER_CHANGE_TYPE_INACTIVE.  If the peer is
+   not tracked, this is a no-op. */
+
+void
+fd_ping_tracker_remove( fd_ping_tracker_t * ping_tracker,
+                        uchar const *       peer_pubkey,
+                        long                now );
+
 fd_ping_tracker_metrics_t const *
 fd_ping_tracker_metrics( fd_ping_tracker_t const * ping_tracker );
 

--- a/src/flamenco/gossip/test_ping_tracker.c
+++ b/src/flamenco/gossip/test_ping_tracker.c
@@ -278,6 +278,110 @@ test_random( void ) {
 }
 
 void
+test_remove( void ) {
+  fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
+  FD_TEST( rng );
+
+  const ulong         entrypoints_len = 1UL;
+  const fd_ip4_port_t entrypoints[1]  = { {.addr=fd_rng_uint(rng), .port=fd_rng_ushort(rng)} };
+  void * bytes = aligned_alloc( fd_ping_tracker_align(), fd_ping_tracker_footprint( entrypoints_len ) );
+  FD_TEST( bytes );
+
+  ping_tracker_change_ctx_t change_ctx[1] = {0};
+  fd_ping_tracker_t * ping_tracker = fd_ping_tracker_join( fd_ping_tracker_new( bytes, rng, entrypoints_len, entrypoints, test_change, change_ctx ) );
+  FD_TEST( ping_tracker );
+
+  long now = fd_log_wallclock();
+
+  /* Removing a non-existent peer is a no-op */
+  peer_t ghost = generate_random_peer( rng );
+  fd_ping_tracker_remove( ping_tracker, ghost.pubkey, now );
+  FD_TEST( change_ctx->invoke_cnt==0UL );
+
+  /* Track a peer and validate it (UNPINGED -> INVALID -> VALID) */
+  peer_t p = generate_random_peer( rng );
+  fd_ping_tracker_track( ping_tracker, p.pubkey, 0UL, p.address, now );
+
+  uchar const *         out_pubkey;
+  fd_ip4_port_t const * out_address;
+  uchar const *         out_token;
+  FD_TEST( fd_ping_tracker_pop_request( ping_tracker, now+seconds(1), &out_pubkey, &out_address, &out_token ) );
+
+  uchar valid_pong_token[ 32UL ];
+  fd_sha256_t sha[1];
+  FD_TEST( fd_sha256_join( fd_sha256_new( sha ) ) );
+  fd_sha256_init( sha );
+  fd_sha256_append( sha, "SOLANA_PING_PONG", 16UL );
+  fd_sha256_append( sha, out_token, 32UL );
+  fd_sha256_fini( sha, valid_pong_token );
+
+  fd_ping_tracker_register( ping_tracker, p.pubkey, 0UL, p.address, valid_pong_token, now+seconds(2) );
+  FD_TEST( change_ctx->invoke_cnt==1UL );
+  FD_TEST( change_ctx->last.change_type==FD_PING_TRACKER_CHANGE_TYPE_ACTIVE );
+  FD_TEST( fd_ping_tracker_active( ping_tracker, p.pubkey ) );
+
+  /* Remove the validated peer — should fire INACTIVE */
+  fd_ping_tracker_remove( ping_tracker, p.pubkey, now+seconds(3) );
+  FD_TEST( change_ctx->invoke_cnt==2UL );
+  FD_TEST( change_ctx->last.change_type==FD_PING_TRACKER_CHANGE_TYPE_INACTIVE );
+  FD_TEST( !memcmp( change_ctx->last.pubkey, p.pubkey, 32UL ) );
+  FD_TEST( change_ctx->last.now==now+seconds(3) );
+  FD_TEST( !fd_ping_tracker_active( ping_tracker, p.pubkey ) );
+
+  /* Removing again is a no-op */
+  fd_ping_tracker_remove( ping_tracker, p.pubkey, now+seconds(4) );
+  FD_TEST( change_ctx->invoke_cnt==2UL );
+
+  /* Remove a peer still in UNPINGED state — no INACTIVE callback */
+  peer_t p2 = generate_random_peer( rng );
+  fd_ping_tracker_track( ping_tracker, p2.pubkey, 0UL, p2.address, now+seconds(5) );
+  FD_TEST( change_ctx->invoke_cnt==2UL );
+  fd_ping_tracker_remove( ping_tracker, p2.pubkey, now+seconds(6) );
+  FD_TEST( change_ctx->invoke_cnt==2UL );
+  FD_TEST( !fd_ping_tracker_active( ping_tracker, p2.pubkey ) );
+
+  /* Remove a peer in INVALID state — no INACTIVE callback */
+  peer_t p3 = generate_random_peer( rng );
+  fd_ping_tracker_track( ping_tracker, p3.pubkey, 0UL, p3.address, now+seconds(7) );
+  FD_TEST( fd_ping_tracker_pop_request( ping_tracker, now+seconds(8), &out_pubkey, &out_address, &out_token ) );
+  FD_TEST( change_ctx->invoke_cnt==2UL );
+  fd_ping_tracker_remove( ping_tracker, p3.pubkey, now+seconds(9) );
+  FD_TEST( change_ctx->invoke_cnt==2UL );
+  FD_TEST( !fd_ping_tracker_active( ping_tracker, p3.pubkey ) );
+
+  /* Remove a peer in VALID_REFRESHING state — should fire INACTIVE */
+  peer_t p4 = generate_random_peer( rng );
+  fd_ping_tracker_track( ping_tracker, p4.pubkey, 0UL, p4.address, now+seconds(10) );
+  FD_TEST( fd_ping_tracker_pop_request( ping_tracker, now+seconds(11), &out_pubkey, &out_address, &out_token ) );
+
+  uchar valid_pong_token2[ 32UL ];
+  fd_sha256_init( sha );
+  fd_sha256_append( sha, "SOLANA_PING_PONG", 16UL );
+  fd_sha256_append( sha, out_token, 32UL );
+  fd_sha256_fini( sha, valid_pong_token2 );
+
+  fd_ping_tracker_register( ping_tracker, p4.pubkey, 0UL, p4.address, valid_pong_token2, now+seconds(12) );
+  FD_TEST( change_ctx->invoke_cnt==3UL );
+  FD_TEST( change_ctx->last.change_type==FD_PING_TRACKER_CHANGE_TYPE_ACTIVE );
+  FD_TEST( fd_ping_tracker_active( ping_tracker, p4.pubkey ) );
+
+  /* Advance past 18min to trigger VALID -> VALID_REFRESHING */
+  fd_ping_tracker_track( ping_tracker, p4.pubkey, 0UL, p4.address, now+seconds(18*60) );
+  fd_ping_tracker_pop_request( ping_tracker, now+seconds(18*60+4), &out_pubkey, &out_address, &out_token );
+  FD_TEST( change_ctx->invoke_cnt==3UL ); /* no callback for VALID -> VALID_REFRESHING */
+  FD_TEST( fd_ping_tracker_active( ping_tracker, p4.pubkey ) );
+
+  /* Remove while VALID_REFRESHING */
+  fd_ping_tracker_remove( ping_tracker, p4.pubkey, now+seconds(18*60+5) );
+  FD_TEST( change_ctx->invoke_cnt==4UL );
+  FD_TEST( change_ctx->last.change_type==FD_PING_TRACKER_CHANGE_TYPE_INACTIVE );
+  FD_TEST( !memcmp( change_ctx->last.pubkey, p4.pubkey, 32UL ) );
+  FD_TEST( !fd_ping_tracker_active( ping_tracker, p4.pubkey ) );
+
+  free( bytes );
+}
+
+void
 test_invalid_transitions( void ) {
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
   FD_TEST( rng );
@@ -357,6 +461,9 @@ main( int     argc,
 
   test_change_address();
   FD_LOG_NOTICE(( "test_change_address() passed" ));
+
+  test_remove();
+  FD_LOG_NOTICE(( "test_remove() passed" ));
 
   test_invalid_transitions();
   FD_LOG_NOTICE(( "test_invalid_transitions() passed" ));


### PR DESCRIPTION
ping_tracker_change() in fd_gossip.c filters callbacks where peer_pubkey == identity_pubkey.  When identity changes from B to A, an ACTIVE for peer B was suppressed (B was self), but the later INACTIVE passes through (identity is now A), with the result that `gossvf` crashes on FD_TEST(ping) trying to remove a peer it never added.

Fix: add fd_ping_tracker_remove() and call it in fd_gossip_set_identity for both old and new identity before updating identity_pubkey.  The old identity's INACTIVE is still filtered (identity hasn't changed yet), and the peer is gone from the tracker so no future INACTIVE can fire.  The new identity is also removed to prevent a leak (it would stay in gossvf's ping map forever since future INACTIVEs would be filtered).