### PR TITLE
restore: snapld and snapdc logging upgrade

### DIFF
--- a/src/discof/restore/fd_snapdc_tile.c
+++ b/src/discof/restore/fd_snapdc_tile.c
@@ -180,7 +180,7 @@ handle_control_frag( fd_snapdc_tile_t *  ctx,
     }
 
     default: {
-      FD_LOG_ERR(( "unexpected control sig %s (%lu) in state %s (%lu)",
+      FD_LOG_ERR(( "unexpected control frag %s (%lu) in state %s (%lu)",
                    fd_ssctrl_msg_ctrl_str( sig ), sig,
                    fd_ssctrl_state_str( (ulong)ctx->state ), (ulong)ctx->state ));
       break;

--- a/src/discof/restore/fd_snapld_tile.c
+++ b/src/discof/restore/fd_snapld_tile.c
@@ -485,7 +485,9 @@ returnable_frag( fd_snapld_tile_t *  ctx,
 
     /* FD_SNAPSHOT_MSG_DATA is not possible */
     default: {
-      FD_LOG_ERR(( "unexpected control sig %lu in state %lu", sig, (ulong)ctx->state ));
+      FD_LOG_ERR(( "unexpected control frag %s (%lu) in state %s (%lu)",
+                   fd_ssctrl_msg_ctrl_str( sig ), sig,
+                   fd_ssctrl_state_str( (ulong)ctx->state ), (ulong)ctx->state ));
       break;
     }
   }


### PR DESCRIPTION
Minor further upgrades to snapld and snapdc logs.
Addresses https://github.com/firedancer-io/firedancer/issues/8811 partially.