### PR TITLE
restore: snapwm logging upgrades

### DIFF
--- a/src/discof/restore/fd_snapwm_tile.c
+++ b/src/discof/restore/fd_snapwm_tile.c
@@ -115,7 +115,9 @@ verify_slot_deltas_with_slot_history( fd_snapwm_tile_t * ctx ) {
   }
 
   ulong txncache_entries_len = fd_ulong_load_8( ctx->txncache_entries_len_ptr );
-  if( FD_UNLIKELY( !txncache_entries_len ) ) FD_LOG_WARNING(( "txncache_entries_len %lu", txncache_entries_len ));
+  if( FD_UNLIKELY( !txncache_entries_len ) ) {
+    FD_LOG_WARNING(( "unexpected txncache entries length %lu. continue...", txncache_entries_len ));
+  }
 
   for( ulong i=0UL; i<txncache_entries_len; i++ ) {
     fd_sstxncache_entry_t const * entry = &ctx->txncache_entries[i];
@@ -134,6 +136,8 @@ handle_data_frag( fd_snapwm_tile_t *  ctx,
                   fd_stem_context_t * stem ) {
 
   if( FD_UNLIKELY( ctx->state==FD_SNAPSHOT_STATE_FINISHING ) ) {
+    FD_LOG_WARNING(( "received unexpected data frag while in state %s (%lu)",
+                     fd_ssctrl_state_str( (ulong)ctx->state ), (ulong)ctx->state ));
     transition_malformed( ctx, stem );
     return 0;
   }
@@ -143,7 +147,8 @@ handle_data_frag( fd_snapwm_tile_t *  ctx,
     return 0;
   }
   if( FD_UNLIKELY( ctx->state!=FD_SNAPSHOT_STATE_PROCESSING ) ) {
-    FD_LOG_ERR(( "invalid state for data frag %d", ctx->state ));
+    FD_LOG_ERR(( "received data frag during invalid state %s (%lu)",
+                 fd_ssctrl_state_str( (ulong)ctx->state ), (ulong)ctx->state ));
   }
 
   FD_TEST( chunk>=ctx->in.chunk0 && chunk<=ctx->in.wmark && acc_cnt<=FD_SNAPWM_PAIR_BATCH_CNT_MAX );
@@ -288,7 +293,9 @@ handle_control_frag( fd_snapwm_tile_t *  ctx,
     }
 
     default: {
-      FD_LOG_ERR(( "unexpected control sig %lu", sig ));
+      FD_LOG_ERR(( "unexpected control frag %s (%lu) in state %s (%lu)",
+                   fd_ssctrl_msg_ctrl_str( sig ), sig,
+                   fd_ssctrl_state_str( (ulong)ctx->state ), (ulong)ctx->state ));
       break;
     }
   }
@@ -345,7 +352,7 @@ populate_allowed_fds( fd_topo_t      const * topo FD_PARAM_UNUSED,
                       fd_topo_tile_t const * tile FD_PARAM_UNUSED,
                       ulong                  out_fds_cnt,
                       int *                  out_fds ) {
-  if( FD_UNLIKELY( out_fds_cnt<2UL ) ) FD_LOG_ERR(( "out_fds_cnt %lu", out_fds_cnt ));
+  if( FD_UNLIKELY( out_fds_cnt<2UL ) ) FD_LOG_ERR(( "invalid out_fds_cnt %lu", out_fds_cnt ));
 
   ulong out_cnt = 0;
   out_fds[ out_cnt++ ] = 2UL; /* stderr */

--- a/src/discof/restore/fd_snapwm_tile_vinyl.c
+++ b/src/discof/restore/fd_snapwm_tile_vinyl.c
@@ -227,7 +227,7 @@ fd_snapwm_vinyl_unprivileged_init( fd_snapwm_tile_t * ctx,
     /* There is no need for rw_lock here, since every other consumer
        is waiting for the completion of this initialization step and
        this can be done without a lock. */
-    fd_snapwm_vinyl_init_admin( ctx, 0/*do_rwlock*/ );
+    FD_TEST( fd_snapwm_vinyl_init_admin( ctx, 0/*do_rwlock*/ ) );
   }
 
   ctx->vinyl.txn_active = 0;
@@ -808,9 +808,16 @@ fd_snapwm_vinyl_init_admin( fd_snapwm_tile_t * ctx,
   if( FD_UNLIKELY( !!do_rwlock ) ) fd_rwlock_write( &ctx->vinyl.admin->lock );
 
   ulong status = fd_vinyl_admin_ulong_query( &ctx->vinyl.admin->status );
-  if( FD_UNLIKELY( status!=FD_VINYL_ADMIN_STATUS_INIT_PENDING ) ) goto init_admin_error;
+  if( FD_UNLIKELY( status!=FD_VINYL_ADMIN_STATUS_INIT_PENDING ) ) {
+    FD_LOG_WARNING(( "vinyl admin unexpected status %s (%lu) during initialization",
+                     fd_vinyl_admin_status_str( status ), status ));
+    goto init_admin_error;
+  }
 
-  if( FD_UNLIKELY( !ctx->vinyl.wr_cnt ) ) goto init_admin_error;
+  if( FD_UNLIKELY( !ctx->vinyl.wr_cnt ) ) {
+    FD_LOG_WARNING(( "vinyl admin sees unexpected write tile count %lu", ctx->vinyl.wr_cnt ));
+    goto init_admin_error;
+  }
   fd_vinyl_admin_ulong_update( &ctx->vinyl.admin->wr_cnt, ctx->vinyl.wr_cnt );
 
   for( ulong i=0UL; i<ctx->vinyl.wr_cnt; i++ ) {
@@ -1020,7 +1027,7 @@ fd_snapwm_vinyl_revert_incr( fd_snapwm_tile_t * ctx ) {
           ulong full_slot = fd_snapin_vinyl_pair_info_slot( &full_phdr.info );
 
           if( FD_UNLIKELY( full_slot>=incr_slot ) ) {
-            FD_LOG_CRIT(( "revert incr snapshot full_slot %lu >= incr_slot %lu", full_slot, incr_slot ));
+            FD_LOG_CRIT(( "revert incremental snapshot full_slot %lu >= incr_slot %lu", full_slot, incr_slot ));
           }
 
           /* Update meta map element. */

--- a/src/discof/restore/utils/fd_vinyl_admin.h
+++ b/src/discof/restore/utils/fd_vinyl_admin.h
@@ -32,6 +32,19 @@ struct fd_vinyl_admin {
 };
 typedef struct fd_vinyl_admin fd_vinyl_admin_t;
 
+static inline const char *
+fd_vinyl_admin_status_str( ulong status ) {
+  switch( status ) {
+    case FD_VINYL_ADMIN_STATUS_INIT_PENDING:  return "init_pending";
+    case FD_VINYL_ADMIN_STATUS_INIT_DONE:     return "init_done";
+    case FD_VINYL_ADMIN_STATUS_UPDATING:      return "updating";
+    case FD_VINYL_ADMIN_STATUS_SNAPSHOT_FULL: return "snapshot_full";
+    case FD_VINYL_ADMIN_STATUS_SNAPSHOT_INCR: return "snapshot_incr";
+    case FD_VINYL_ADMIN_STATUS_ERROR:         return "error";
+    default:                                  return "unknown";
+  }
+}
+
 FD_PROTOTYPES_BEGIN
 
 /* fd_vinyl_admin_{align, footprint} return align and footprint */


### PR DESCRIPTION
Upgrading snapwm logging.
Addresses https://github.com/firedancer-io/firedancer/issues/8811 partially.