### PR TITLE
single-target fuzzing: avoid FD logging in fuzzing harnesses

### DIFF
--- a/src/app/shared/fuzz_fdctl_config.c
+++ b/src/app/shared/fuzz_fdctl_config.c
@@ -9,6 +9,7 @@ int
 LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_logfile_set( 4 );

--- a/src/ballet/base58/fuzz_base58_garbage.c
+++ b/src/ballet/base58/fuzz_base58_garbage.c
@@ -14,6 +14,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/base58/fuzz_base58_roundtrip.c
+++ b/src/ballet/base58/fuzz_base58_roundtrip.c
@@ -15,6 +15,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/base64/fuzz_base64_dec.c
+++ b/src/ballet/base64/fuzz_base64_dec.c
@@ -18,6 +18,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/base64/fuzz_base64_enc.c
+++ b/src/ballet/base64/fuzz_base64_enc.c
@@ -19,6 +19,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/blake3/fuzz_blake3.c
+++ b/src/ballet/blake3/fuzz_blake3.c
@@ -15,6 +15,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   fd_log_level_core_set(3); /* crash on warning log */
   atexit( fd_halt );

--- a/src/ballet/bmtree/fuzz_bmtree.c
+++ b/src/ballet/bmtree/fuzz_bmtree.c
@@ -23,6 +23,7 @@ LLVMFuzzerInitialize( int  *   pargc,
                       char *** pargv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( pargc, pargv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/ed25519/fuzz_ed25519_sigverify.c
+++ b/src/ballet/ed25519/fuzz_ed25519_sigverify.c
@@ -15,6 +15,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/ed25519/fuzz_ed25519_sigverify_diff.c
+++ b/src/ballet/ed25519/fuzz_ed25519_sigverify_diff.c
@@ -40,6 +40,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/ed25519/fuzz_ed25519_verify.c
+++ b/src/ballet/ed25519/fuzz_ed25519_verify.c
@@ -15,6 +15,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/hex/fuzz_hex.c
+++ b/src/ballet/hex/fuzz_hex.c
@@ -15,6 +15,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/hmac/fuzz_hmac.c
+++ b/src/ballet/hmac/fuzz_hmac.c
@@ -17,6 +17,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */
@@ -42,7 +43,7 @@ LLVMFuzzerTestOneInput( uchar const * data,
   if( FD_UNLIKELY( size<(64UL+key_size) ) ) return -1;
   char const * key = key_size ? ( char const * ) test->key : NULL;
 
-  ulong msg_size = size-(64UL+key_size); 
+  ulong msg_size = size-(64UL+key_size);
   char const * msg = msg_size ? ( char const * ) test->key + key_size : NULL;
 
   uchar hash1[ 64 ] __attribute__((aligned(64)));

--- a/src/ballet/keccak256/fuzz_keccak256.c
+++ b/src/ballet/keccak256/fuzz_keccak256.c
@@ -15,6 +15,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/pb/fuzz_pb_tokenize.c
+++ b/src/ballet/pb/fuzz_pb_tokenize.c
@@ -11,6 +11,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/reedsol/fuzz_reedsol.c
+++ b/src/ballet/reedsol/fuzz_reedsol.c
@@ -14,6 +14,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */
@@ -47,7 +48,7 @@ LLVMFuzzerTestOneInput( uchar const * data,
   uchar const * data_shreds = test->data;
   uchar parity_shreds[ SHRED_SZ_MAX * FD_REEDSOL_PARITY_SHREDS_MAX ];
   uchar recovered_shreds[ SHRED_SZ_MAX * ( FD_REEDSOL_PARITY_SHREDS_MAX+1UL ) ];
-  
+
   uchar const * d[ FD_REEDSOL_DATA_SHREDS_MAX   ];
   uchar *       p[ FD_REEDSOL_PARITY_SHREDS_MAX ];
   uchar *       r[ FD_REEDSOL_PARITY_SHREDS_MAX+1UL ];

--- a/src/ballet/sbpf/fuzz_sbpf_loader.c
+++ b/src/ballet/sbpf/fuzz_sbpf_loader.c
@@ -24,6 +24,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/secp256k1/fuzz_secp256k1_recover.c
+++ b/src/ballet/secp256k1/fuzz_secp256k1_recover.c
@@ -13,6 +13,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/sha256/fuzz_sha256.c
+++ b/src/ballet/sha256/fuzz_sha256.c
@@ -26,6 +26,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/sha512/fuzz_sha384.c
+++ b/src/ballet/sha512/fuzz_sha384.c
@@ -15,6 +15,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/sha512/fuzz_sha512.c
+++ b/src/ballet/sha512/fuzz_sha512.c
@@ -26,6 +26,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/shred/fuzz_shred_parse.c
+++ b/src/ballet/shred/fuzz_shred_parse.c
@@ -15,6 +15,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/siphash13/fuzz_siphash13.c
+++ b/src/ballet/siphash13/fuzz_siphash13.c
@@ -18,6 +18,7 @@ LLVMFuzzerInitialize( int  *   pargc,
                       char *** pargv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( pargc, pargv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/ballet/toml/fuzz_toml.c
+++ b/src/ballet/toml/fuzz_toml.c
@@ -15,6 +15,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
 

--- a/src/ballet/txn/fuzz_txn_parse.c
+++ b/src/ballet/txn/fuzz_txn_parse.c
@@ -14,6 +14,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   fd_log_level_core_set(3); /* crash on warning log */
   atexit( fd_halt );

--- a/src/choreo/eqvoc/fuzz_eqvoc.c
+++ b/src/choreo/eqvoc/fuzz_eqvoc.c
@@ -22,6 +22,7 @@ int
 LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/choreo/tower/fuzz_tower_serdes.c
+++ b/src/choreo/tower/fuzz_tower_serdes.c
@@ -15,6 +15,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/disco/bundle/fuzz_bundle_auth_resp.c
+++ b/src/disco/bundle/fuzz_bundle_auth_resp.c
@@ -11,6 +11,7 @@
 
 int LLVMFuzzerInitialize( int *argc, char ***argv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
 
   fd_boot( argc, argv );
 

--- a/src/disco/bundle/fuzz_bundle_client.c
+++ b/src/disco/bundle/fuzz_bundle_client.c
@@ -19,6 +19,7 @@ int
 LLVMFuzzerInitialize( int *    pargc,
                       char *** pargv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
 
   fd_boot( pargc, pargv );
 

--- a/src/disco/gui/fuzz_config_parser.c
+++ b/src/disco/gui/fuzz_config_parser.c
@@ -15,7 +15,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
-  putenv( "FD_LOG_PATH=" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   fd_log_level_core_set(0); /* crash on debug log */
   return 0;

--- a/src/disco/pack/fuzz_chkdup.c
+++ b/src/disco/pack/fuzz_chkdup.c
@@ -15,6 +15,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set( 3 ); /* crash on warning log */

--- a/src/disco/pack/fuzz_compute_budget_program_parse.c
+++ b/src/disco/pack/fuzz_compute_budget_program_parse.c
@@ -15,6 +15,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/discof/genesis/fuzz_genesis_client.c
+++ b/src/discof/genesis/fuzz_genesis_client.c
@@ -22,7 +22,7 @@ int
 LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
-  putenv( "FD_LOG_PATH=" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_stderr_set(4);

--- a/src/discof/ipecho/fuzz_ipecho_client.c
+++ b/src/discof/ipecho/fuzz_ipecho_client.c
@@ -12,6 +12,7 @@ int
 LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   return 0;

--- a/src/discof/ipecho/fuzz_ipecho_server.c
+++ b/src/discof/ipecho/fuzz_ipecho_server.c
@@ -27,6 +27,7 @@ int
 LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_stderr_set( 4 );

--- a/src/discof/restore/utils/fuzz_slot_delta_parser.c
+++ b/src/discof/restore/utils/fuzz_slot_delta_parser.c
@@ -15,6 +15,7 @@ int
 LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
 

--- a/src/discof/restore/utils/fuzz_snapshot_parser.c
+++ b/src/discof/restore/utils/fuzz_snapshot_parser.c
@@ -16,6 +16,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set   ( 4 );

--- a/src/discof/restore/utils/fuzz_ssarchive_parser.c
+++ b/src/discof/restore/utils/fuzz_ssarchive_parser.c
@@ -12,6 +12,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set   ( 4 );

--- a/src/discof/restore/utils/fuzz_sshttp.c
+++ b/src/discof/restore/utils/fuzz_sshttp.c
@@ -20,7 +20,7 @@ int
 LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
-  putenv( "FD_LOG_PATH=" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_stderr_set(4);

--- a/src/discof/restore/utils/fuzz_ssmanifest_parser.c
+++ b/src/discof/restore/utils/fuzz_ssmanifest_parser.c
@@ -15,6 +15,7 @@ int
 LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
 

--- a/src/discof/rpc/fuzz_rpc.c
+++ b/src/discof/rpc/fuzz_rpc.c
@@ -107,7 +107,7 @@ LLVMFuzzerInitialize( int  *   argc,
 
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
-  putenv( "FD_LOG_PATH=" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   fd_log_level_core_set(5);  /* abort on FD_LOG_ERR */
 

--- a/src/discof/rpc/fuzz_rpc_tarball.c
+++ b/src/discof/rpc/fuzz_rpc_tarball.c
@@ -59,7 +59,7 @@ LLVMFuzzerInitialize( int  *   argc,
 
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
-  putenv( "FD_LOG_PATH=" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   fd_log_level_core_set(0); /* crash on debug log */
 

--- a/src/flamenco/gossip/fuzz_gossip_message_deserialize.c
+++ b/src/flamenco/gossip/fuzz_gossip_message_deserialize.c
@@ -16,6 +16,7 @@ int
 LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set( 3 );

--- a/src/flamenco/gossip/fuzz_gossip_message_serialize.c
+++ b/src/flamenco/gossip/fuzz_gossip_message_serialize.c
@@ -13,6 +13,7 @@ int
 LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set( 3 );

--- a/src/flamenco/runtime/fuzz_genesis_parse.c
+++ b/src/flamenco/runtime/fuzz_genesis_parse.c
@@ -10,6 +10,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   fd_log_level_stderr_set(4);
   atexit( fd_halt );

--- a/src/util/archive/fuzz_ar.c
+++ b/src/util/archive/fuzz_ar.c
@@ -14,6 +14,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_stderr_set( 4 );

--- a/src/util/fuzz_hash.c
+++ b/src/util/fuzz_hash.c
@@ -7,6 +7,7 @@ int
 LLVMFuzzerInitialize( int *argc,
                       char ***argv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   (void) atexit( fd_halt );
   fd_log_level_core_set( 1 );

--- a/src/util/net/fuzz_pcap.c
+++ b/src/util/net/fuzz_pcap.c
@@ -15,6 +15,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
 

--- a/src/util/net/fuzz_pcapng.c
+++ b/src/util/net/fuzz_pcapng.c
@@ -15,7 +15,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
-  putenv( "FD_LOG_PATH=" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
 

--- a/src/waltz/grpc/fuzz_grpc_client.c
+++ b/src/waltz/grpc/fuzz_grpc_client.c
@@ -53,6 +53,7 @@ LLVMFuzzerInitialize( int *argc,
                       char ***argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   (void) atexit( fd_halt );
   fd_log_level_core_set( 3 ); /* crash on warning log */

--- a/src/waltz/grpc/fuzz_grpc_codec.c
+++ b/src/waltz/grpc/fuzz_grpc_codec.c
@@ -10,6 +10,7 @@ int
 LLVMFuzzerInitialize( int *argc,
                       char ***argv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   (void) atexit( fd_halt );
   fd_log_level_core_set( 4 );

--- a/src/waltz/grpc/fuzz_grpc_h2_gen_req_hdr.c
+++ b/src/waltz/grpc/fuzz_grpc_h2_gen_req_hdr.c
@@ -15,6 +15,7 @@ LLVMFuzzerInitialize( int *argc,
                       char ***argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   (void) atexit( fd_halt );
   fd_log_level_core_set( 1 ); /* crash on info log */

--- a/src/waltz/h2/fuzz_h2.c
+++ b/src/waltz/h2/fuzz_h2.c
@@ -177,6 +177,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   (void)atexit( fd_halt );
   fd_log_level_core_set(1); /* crash on info log */

--- a/src/waltz/h2/fuzz_hpack_rd.c
+++ b/src/waltz/h2/fuzz_hpack_rd.c
@@ -13,6 +13,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(1); /* crash on info log */

--- a/src/waltz/http/fuzz_httpserver.c
+++ b/src/waltz/http/fuzz_httpserver.c
@@ -99,6 +99,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/waltz/http/fuzz_picohttpparser.c
+++ b/src/waltz/http/fuzz_picohttpparser.c
@@ -16,6 +16,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
 

--- a/src/waltz/http/fuzz_url_parse.c
+++ b/src/waltz/http/fuzz_url_parse.c
@@ -13,7 +13,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
-  putenv( "FD_LOG_PATH=" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   fd_log_level_core_set(0); /* crash on debug log */
   return 0;

--- a/src/waltz/quic/templ/fuzz_quic_parse_transport_params.c
+++ b/src/waltz/quic/templ/fuzz_quic_parse_transport_params.c
@@ -12,6 +12,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/waltz/quic/tests/fuzz_quic.c
+++ b/src/waltz/quic/tests/fuzz_quic.c
@@ -110,6 +110,7 @@ destroy_quic( void ) {
 int LLVMFuzzerInitialize(int *argc, char ***argv) {
   /* Set up shell without signal handlers */
   putenv("FD_LOG_BACKTRACE=0");
+  putenv("FD_LOG_PATH=");
   fd_boot(argc, argv);
 # ifndef FD_DEBUG_MODE
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/waltz/quic/tests/fuzz_quic_actor.c
+++ b/src/waltz/quic/tests/fuzz_quic_actor.c
@@ -950,6 +950,7 @@ int
 LLVMFuzzerInitialize( int *    pargc,
                       char *** pargv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( pargc, pargv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/waltz/quic/tests/fuzz_quic_wire.c
+++ b/src/waltz/quic/tests/fuzz_quic_wire.c
@@ -32,6 +32,7 @@ int
 LLVMFuzzerInitialize( int *    pargc,
                       char *** pargv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( pargc, pargv );
   atexit( fd_halt );
 # ifndef FD_DEBUG_MODE

--- a/src/waltz/resolv/fuzz_dn_expand.c
+++ b/src/waltz/resolv/fuzz_dn_expand.c
@@ -17,6 +17,7 @@ LLVMFuzzerInitialize( int *argc,
                       char ***argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   (void) atexit( fd_halt );
   fd_log_level_core_set( 1 ); /* crash on info log */

--- a/src/waltz/resolv/fuzz_dns_parse.c
+++ b/src/waltz/resolv/fuzz_dns_parse.c
@@ -10,6 +10,7 @@ LLVMFuzzerInitialize( int *argc,
                       char ***argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   (void) atexit( fd_halt );
   fd_log_level_core_set( 1 ); /* crash on info log */

--- a/src/waltz/resolv/fuzz_lookup_literal.c
+++ b/src/waltz/resolv/fuzz_lookup_literal.c
@@ -13,6 +13,7 @@ int
 LLVMFuzzerInitialize( int *argc,
                       char ***argv ) {
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   (void) atexit( fd_halt );
   fd_log_level_core_set( 1 );

--- a/src/waltz/tls/fuzz_tls.c
+++ b/src/waltz/tls/fuzz_tls.c
@@ -75,6 +75,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */

--- a/src/waltz/tls/fuzz_tls_msg_parser.c
+++ b/src/waltz/tls/fuzz_tls_msg_parser.c
@@ -14,6 +14,7 @@ LLVMFuzzerInitialize( int  *   argc,
                       char *** argv ) {
   /* Set up shell without signal handlers */
   putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
   fd_boot( argc, argv );
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */


### PR DESCRIPTION
these log files just clog up /tmp/ when we fuzz at 10k-100k execs/second with zillions of small log files, making short work of the host filesystem inode limit... if we want to reproduce a specific run / crash found during fuzzing to get the logs, we should just use the existing tooling we have for that...

it's interesting, some of the fuzzers, but not all of the fuzzers used putenv, so I changed them to setenv, thanks @nick@asymmetric.re