### PR TITLE
gui: fix possible infinite loop

### DIFF
--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -1528,7 +1528,7 @@ fd_gui_request_slot_shreds( fd_gui_t *    gui,
   ulong _slot = slot_param->valueulong;
 
   fd_gui_slot_t const * slot = fd_gui_get_slot( gui, _slot );
-  if( FD_UNLIKELY( !slot || gui->shreds.history_tail > slot->shreds.end_offset + FD_GUI_SHREDS_HISTORY_SZ ) ) {
+  if( FD_UNLIKELY( !slot || slot->shreds.end_offset || gui->shreds.history_tail > slot->shreds.end_offset + FD_GUI_SHREDS_HISTORY_SZ ) ) {
     fd_gui_printf_null_query_response( gui->http, "slot", "query_shreds", request_id );
     FD_TEST( !fd_http_server_ws_send( gui->http, ws_conn_id ) );
     return 0;


### PR DESCRIPTION
`end_offset` is initially set to ULONG_MAX via `fd_gui_clear_slot()`, which has multiple pathways (slot start, shred arrival,...) after which a user can query the slot via websocket. 

`end_offset` is only set in `fd_gui_handle_rooted_slot`.

So there is a time window for a user to call `fd_gui_request_slot_shreds`. Since `slot->shreds.end_offset` is ULONG_MAX.
`history_tail` starts from 0 and increase with shred arrival. So there's a 2nd time window where we have `slot->shreds.end_offset + FD_GUI_SHREDS_HISTORY_SZ` overflow to a value bigger than `history_tail`, then the user can enter  `fd_gui_printf_slot_query_shreds`. 

In `fd_gui_printf_shreds_history()`, this loop will spin ULONG_MAX DOSing the GUI: 
```C
for( ulong i=start_offset; i<end_offset; i++ ) {
```