### PR TITLE
restore: snapin stem burst 2

### DIFF
--- a/src/app/firedancer-dev/commands/backtest.c
+++ b/src/app/firedancer-dev/commands/backtest.c
@@ -294,7 +294,7 @@ backtest_topo( config_t * config ) {
       fd_topob_tile_out( topo, "snapin", 0UL,              "snapin_wm", 0UL );
       fd_topob_tile_in ( topo, "snapwm", 0UL, "metric_in", "snapin_wm", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
       fd_topob_tile_out( topo, "snapin", 0UL,              "snapin_txn",0UL );
-      fd_topob_tile_in ( topo, "snapwm", 0UL, "metric_in", "snapin_txn",0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
+      fd_topob_tile_in ( topo, "snapwm", 0UL, "metric_in", "snapin_txn",0UL, FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
       fd_topob_tile_out( topo, "snapwm", 0UL,              "snapwm_wh", 0UL );
       fd_topob_tile_in ( topo, "snapwh", 0UL, "metric_in", "snapwm_wh", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
       fd_topob_tile_out( topo, "snapwh", 0UL,              "snapwh_wr", 0UL );

--- a/src/app/firedancer-dev/commands/snapshot_load.c
+++ b/src/app/firedancer-dev/commands/snapshot_load.c
@@ -219,7 +219,7 @@ snapshot_load_topo( config_t * config ) {
     fd_topob_tile_out( topo, "snapin", 0UL,              "snapin_wm", 0UL );
     fd_topob_tile_in ( topo, "snapwm", 0UL, "metric_in", "snapin_wm", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
     fd_topob_tile_out( topo, "snapin", 0UL,              "snapin_txn",0UL );
-    fd_topob_tile_in ( topo, "snapwm", 0UL, "metric_in", "snapin_txn",0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
+    fd_topob_tile_in ( topo, "snapwm", 0UL, "metric_in", "snapin_txn",0UL, FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
     fd_topob_tile_out( topo, "snapwm", 0UL,              "snapwm_wh", 0UL );
     fd_topob_tile_in ( topo, "snapwh", 0UL, "metric_in", "snapwm_wh", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
     fd_topob_tile_out( topo, "snapwh", 0UL,              "snapwh_wr", 0UL );

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -852,7 +852,7 @@ fd_topo_initialize( config_t * config ) {
       /**/            fd_topob_tile_out(    topo, "snapin",  0UL,                       "snapin_wm",     0UL                                                );
       /**/            fd_topob_tile_in (    topo, "snapwm",  0UL,          "metric_in", "snapin_wm",     0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
       /**/            fd_topob_tile_out(    topo, "snapin",  0UL,                       "snapin_txn",    0UL                                                );
-      /**/            fd_topob_tile_in (    topo, "snapwm",  0UL,          "metric_in", "snapin_txn",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+      /**/            fd_topob_tile_in (    topo, "snapwm",  0UL,          "metric_in", "snapin_txn",    0UL,          FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
       /**/            fd_topob_tile_out(    topo, "snapwm",  0UL,                       "snapwm_wh",     0UL                                                );
       /**/            fd_topob_tile_in (    topo, "snapwh",  0UL,          "metric_in", "snapwm_wh",     0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
       /**/            fd_topob_tile_out(    topo, "snapwh",  0UL,                       "snapwh_wr",     0UL                                                );

--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -572,6 +572,13 @@ process_manifest( fd_snapin_tile_t * ctx ) {
 
   ctx->bank_slot = manifest->slot;
   ctx->manifest_capitalization = manifest->capitalization;
+  if( FD_UNLIKELY( ctx->manifest_capitalization>LONG_MAX ) ) {
+    /* Calculations downstream require capitalization to be treated
+       as long (to handle addition and subtraction). */
+    FD_LOG_WARNING(( "snapshot manifest capitalization %lu exceeds LONG_MAX", ctx->manifest_capitalization ));
+    transition_malformed( ctx, ctx->stem );
+    return;
+  }
   fd_epoch_schedule_t epoch_schedule = (fd_epoch_schedule_t){
     .slots_per_epoch             = manifest->epoch_schedule_params.slots_per_epoch,
     .leader_schedule_slot_offset = manifest->epoch_schedule_params.leader_schedule_slot_offset,
@@ -619,16 +626,21 @@ process_manifest( fd_snapin_tile_t * ctx ) {
   manifest->txncache_fork_id = ctx->txncache_root_fork_id.val;
 
   if( FD_LIKELY( !ctx->lthash_disabled ) ) {
-    fd_lthash_value_t * expected_lthash = fd_chunk_to_laddr( ctx->hash_out.mem, ctx->hash_out.chunk );
-    fd_memcpy( expected_lthash, manifest->accounts_lthash, sizeof(fd_lthash_value_t) );
-    fd_stem_publish( ctx->stem, ctx->out_ct_idx, FD_SNAPSHOT_HASH_MSG_EXPECTED, ctx->hash_out.chunk, sizeof(fd_lthash_value_t), 0UL, 0UL, 0UL );
-    ctx->hash_out.chunk = fd_dcache_compact_next( ctx->hash_out.chunk, sizeof(fd_lthash_value_t), ctx->hash_out.chunk0, ctx->hash_out.wmark );
-
     if( FD_LIKELY( ctx->use_vinyl ) ) {
-      fd_ssctrl_capitalization_t * cap = fd_chunk_to_laddr( ctx->hash_out.mem, ctx->hash_out.chunk );
-      cap->capitalization = manifest->capitalization;
-      fd_stem_publish( ctx->stem, ctx->out_ct_idx, FD_SNAPSHOT_MSG_EXP_CAPITALIZATION, ctx->hash_out.chunk, sizeof(fd_ssctrl_capitalization_t), 0UL, 0UL, 0UL );
-      ctx->hash_out.chunk = fd_dcache_compact_next( ctx->hash_out.chunk, sizeof(fd_ssctrl_capitalization_t), ctx->hash_out.chunk0, ctx->hash_out.wmark );
+      fd_ssctrl_hash_result_t * data = fd_chunk_to_laddr( ctx->hash_out.mem, ctx->hash_out.chunk );
+      /* There is padding in this struct, due to alignment, requiring
+         initialization to zero.  This message is infrequent, so the
+         overhead is negligible. */
+      fd_memset( data, 0, sizeof(fd_ssctrl_hash_result_t) );
+      fd_memcpy( &data->lthash, manifest->accounts_lthash, sizeof(fd_lthash_value_t) );
+      data->capitalization = (long)manifest->capitalization;
+      fd_stem_publish( ctx->stem, ctx->out_ct_idx, FD_SNAPSHOT_HASH_MSG_EXP_AND_CAPITAL, ctx->hash_out.chunk, sizeof(fd_ssctrl_hash_result_t), 0UL, 0UL, 0UL );
+      ctx->hash_out.chunk = fd_dcache_compact_next( ctx->hash_out.chunk, sizeof(fd_ssctrl_hash_result_t), ctx->hash_out.chunk0, ctx->hash_out.wmark );
+    } else {
+      fd_lthash_value_t * expected_lthash = fd_chunk_to_laddr( ctx->hash_out.mem, ctx->hash_out.chunk );
+      fd_memcpy( expected_lthash, manifest->accounts_lthash, sizeof(fd_lthash_value_t) );
+      fd_stem_publish( ctx->stem, ctx->out_ct_idx, FD_SNAPSHOT_HASH_MSG_EXPECTED, ctx->hash_out.chunk, sizeof(fd_lthash_value_t), 0UL, 0UL, 0UL );
+      ctx->hash_out.chunk = fd_dcache_compact_next( ctx->hash_out.chunk, sizeof(fd_lthash_value_t), ctx->hash_out.chunk0, ctx->hash_out.wmark );
     }
   }
 
@@ -1150,6 +1162,7 @@ unprivileged_init( fd_topo_t *      topo,
   if( ( 0==strcmp( snapin_out_link->name, "snapin_ls" ) ) ||
       ( 0==strcmp( snapin_out_link->name, "snapin_wm" ) ) ) {
     ctx->hash_out = out1( topo, tile, snapin_out_link->name );
+    FD_TEST( ctx->hash_out.idx==out_link_ct_idx );
   }
 
   fd_ssparse_reset( ctx->ssparse );
@@ -1185,10 +1198,19 @@ unprivileged_init( fd_topo_t *      topo,
   }
 }
 
-/* Control fragments can result in one extra publish to forward the
-   message down the pipeline, in addition to the result / malformed
-   message. Can send one duplicate account message as well. */
-#define STEM_BURST 3UL
+/* There are 3 output links that affect the calculation of STEM_BURST:
+    1. topology-dependent link:
+    | 1a. snapin_ct (no lthash verification)
+    | 1b. snapin_ls (with lthash verification, funk)
+    | 1c. snapin_wm (with lthash verification, vinyl)
+    | - worst case: 2 messages, e.g. process_manifest (lthash) +
+    |            FD_SSPARSE_ADVANCE_ACCOUNT_{HEADER,DATA,BATCH,ERROR}
+    2. snapin_manif - worst case: 1 message
+    3. snapin_gui   - worst case: 1 message (config program account)
+   The STEM_BURST is the max value across these 3 links (not the sum).
+   Note that snapin_txn is excluded from this calculation, since it is
+   an unreliable link, working as a dcache place holder. */
+#define STEM_BURST 2UL
 
 #define STEM_LAZY  1000L
 

--- a/src/discof/restore/fd_snaplv_tile.c
+++ b/src/discof/restore/fd_snaplv_tile.c
@@ -43,7 +43,7 @@ struct fd_snaplv_tile {
 
   long running_capitalization;
   long dup_capitalization;
-  ulong manifest_capitalization;
+  long manifest_capitalization;
 
   struct {
     ulong             bstream_seq_last;
@@ -470,13 +470,6 @@ handle_hash_frag( fd_snaplv_t *       ctx,
       ctx->dup_capitalization = fd_long_sat_add( ctx->dup_capitalization, result->capitalization );
       break;
     }
-    case FD_SNAPSHOT_HASH_MSG_EXPECTED: {
-      FD_TEST( sz==sizeof(fd_lthash_value_t) );
-      FD_TEST( ctx->in_kind[ in_idx ]==IN_KIND_SNAPWM );
-      fd_lthash_value_t const * result = fd_chunk_to_laddr_const( ctx->in.wksp, chunk );
-      ctx->hash_accum.expected_lthash = *result;
-      break;
-    }
     default: {
       FD_LOG_ERR(( "unexpected hash frag %s (%lu) in state %s (%lu)",
                    fd_ssctrl_msg_ctrl_str( sig ), sig,
@@ -487,21 +480,32 @@ handle_hash_frag( fd_snaplv_t *       ctx,
 }
 
 static inline void
-handle_expected_capitalization_message( fd_snaplv_t * ctx,
-                                        ulong         chunk,
-                                        ulong         sz ) {
+handle_expected_hash_and_capitalization_message( fd_snaplv_t *       ctx,
+                                                 fd_stem_context_t * stem,
+                                                 ulong               sig,
+                                                 ulong               chunk,
+                                                 ulong               sz ) {
   if( FD_UNLIKELY( ctx->state==FD_SNAPSHOT_STATE_ERROR ) ) {
-    /* skip all hash frags when in error state. */
+    /* skip this message when in error state. */
     return;
   }
 
-  if( FD_UNLIKELY( sz!=sizeof(fd_ssctrl_capitalization_t) ) ) {
-    FD_LOG_ERR(( "unexpected msg sz %lu for sig FD_SNAPSHOT_MSG_EXP_CAPITALIZATION", sz ));
+  if( FD_UNLIKELY( ctx->state!=FD_SNAPSHOT_STATE_PROCESSING ) ) {
+    FD_LOG_WARNING(( "received invalid message %s (%lu) from snapwm in state %s (%u)",
+                     fd_ssctrl_msg_ctrl_str( sig ), sig,
+                     fd_ssctrl_state_str( (ulong)ctx->state ), ctx->state ));
+    transition_malformed( ctx, stem );
     return;
   }
 
-  fd_ssctrl_capitalization_t const * expected_cap = fd_chunk_to_laddr_const( ctx->in.wksp, chunk );
-  ctx->manifest_capitalization = expected_cap->capitalization;
+  if( FD_UNLIKELY( sz!=sizeof(fd_ssctrl_hash_result_t) ) ) {
+    FD_LOG_ERR(( "unexpected msg sz %lu for sig FD_SNAPSHOT_HASH_MSG_EXP_AND_CAPITAL", sz ));
+    return;
+  }
+
+  fd_ssctrl_hash_result_t const * expected = fd_chunk_to_laddr_const( ctx->in.wksp, chunk );
+  ctx->hash_accum.expected_lthash = expected->lthash;
+  ctx->manifest_capitalization    = expected->capitalization;
 }
 
 static inline int
@@ -517,12 +521,11 @@ returnable_frag( fd_snaplv_t *       ctx,
                  fd_stem_context_t * stem ) {
   FD_TEST( ctx->state!=FD_SNAPSHOT_STATE_SHUTDOWN );
 
-  if( FD_LIKELY( sig==FD_SNAPSHOT_HASH_MSG_SUB_META_BATCH ) ) handle_data_frag( ctx, stem, sig, chunk, sz, tspub );
+  if( FD_LIKELY( sig==FD_SNAPSHOT_HASH_MSG_SUB_META_BATCH ) )       handle_data_frag( ctx, stem, sig, chunk, sz, tspub );
   else if( FD_LIKELY( sig==FD_SNAPSHOT_HASH_MSG_RESULT_ADD ||
-                      sig==FD_SNAPSHOT_HASH_MSG_RESULT_SUB ||
-                      sig==FD_SNAPSHOT_HASH_MSG_EXPECTED ) )      handle_hash_frag( ctx, stem, in_idx, sig, chunk, sz );
-  else if( FD_LIKELY( sig==FD_SNAPSHOT_MSG_EXP_CAPITALIZATION ) ) handle_expected_capitalization_message( ctx, chunk, sz );
-  else                                                            handle_control_frag( ctx, stem, sig, in_idx, tsorig, tspub );
+                      sig==FD_SNAPSHOT_HASH_MSG_RESULT_SUB ) )      handle_hash_frag( ctx, stem, in_idx, sig, chunk, sz );
+  else if( FD_LIKELY( sig==FD_SNAPSHOT_HASH_MSG_EXP_AND_CAPITAL ) ) handle_expected_hash_and_capitalization_message( ctx, stem, sig, chunk, sz );
+  else                                                              handle_control_frag( ctx, stem, sig, in_idx, tsorig, tspub );
 
   return 0;
 }
@@ -558,8 +561,8 @@ after_credit( fd_snaplv_t *        ctx,
       transition_malformed( ctx, stem );
       return;
     }
-    ulong computed_capitalization = (ulong)ctx->running_capitalization;
-    int capitalization_match      = computed_capitalization==ctx->manifest_capitalization;
+    long computed_capitalization = ctx->running_capitalization;
+    int capitalization_match     = computed_capitalization==ctx->manifest_capitalization;
 
     int lthash_match = !memcmp( &ctx->hash_accum.expected_lthash, &ctx->hash_accum.calculated_lthash, sizeof(fd_lthash_value_t) );
 
@@ -582,7 +585,7 @@ after_credit( fd_snaplv_t *        ctx,
     if( FD_UNLIKELY( !capitalization_match ) ) {
       /* SnapshotError::MismatchedCapitalization
          https://github.com/anza-xyz/agave/blob/v4.0.0-beta.2/runtime/src/snapshot_bank_utils.rs#L217 */
-      FD_LOG_WARNING(( "%s snapshot manifest capitalization %lu does not match computed capitalization %lu",
+      FD_LOG_WARNING(( "%s snapshot manifest capitalization %ld does not match computed capitalization %ld",
                        ctx->full?"full":"incremental", ctx->manifest_capitalization, computed_capitalization ));
       transition_malformed( ctx, stem );
       return;
@@ -728,7 +731,7 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->recovery.capitalization = 0L;
   ctx->running_capitalization  = 0L;
   ctx->dup_capitalization      = 0L;
-  ctx->manifest_capitalization = 0UL;
+  ctx->manifest_capitalization = 0L;
 
   ctx->fail.exp_sig = 0UL;
   ctx->fail.ack_cnt = 0UL;

--- a/src/discof/restore/fd_snaplv_tile_private.h
+++ b/src/discof/restore/fd_snaplv_tile_private.h
@@ -18,9 +18,10 @@
 #define FD_SNAPLV_DUP_BATCH_OUT_CNT_MAX (FD_SNAPLV_DUP_PENDING_CNT_MAX+FD_SNAPLV_DUP_BATCH_IN_CNT_MAX)
 #define FD_SNAPLV_DUP_META_SZ           (sizeof(ulong)+sizeof(fd_vinyl_bstream_phdr_t))
 
-/* Maximum burst may contain one control message and one malformed
-   message, in addition to FD_SNAPLV_DUP_BATCH_OUT_CNT_MAX requests to
-   be forwarded. */
-#define FD_SNAPLV_STEM_BURST (2UL+FD_SNAPLV_DUP_BATCH_OUT_CNT_MAX)
+/* Maximum burst is governed by FD_SNAPLV_DUP_BATCH_OUT_CNT_MAX on
+   snaplv_lh, where the worst case arises from after_credit pending
+   drain (8) plus returnable_frag data frag (8), in comparison to the
+   output control link snaplv_ct (worst case there is 3). */
+#define FD_SNAPLV_STEM_BURST (FD_SNAPLV_DUP_BATCH_OUT_CNT_MAX)
 
 #endif /* HEADER_fd_discof_restore_fd_snaplv_tile_private_h */

--- a/src/discof/restore/fd_snapwm_tile.c
+++ b/src/discof/restore/fd_snapwm_tile.c
@@ -314,37 +314,20 @@ handle_control_frag( fd_snapwm_tile_t *  ctx,
 }
 
 static inline void
-handle_expected_hash_message( fd_snapwm_tile_t *  ctx,
-                              ulong               chunk,
-                              ulong               sz,
-                              fd_stem_context_t * stem ) {
-  if( FD_UNLIKELY( ctx->lthash_disabled ) ) return;
-  if( FD_UNLIKELY( sz!=sizeof(fd_lthash_value_t) ) ) {
-    FD_LOG_ERR(( "unexpected msg sz %lu for sig FD_SNAPSHOT_HASH_MSG_EXPECTED", sz ));
+handle_expected_hash_and_capitalization_message( fd_snapwm_tile_t *  ctx,
+                                                 ulong               chunk,
+                                                 ulong               sz,
+                                                 fd_stem_context_t * stem ) {
+  if( FD_UNLIKELY( ctx->state==FD_SNAPSHOT_STATE_ERROR ) ) return;
+  if( FD_UNLIKELY( sz!=sizeof(fd_ssctrl_hash_result_t) ) ) {
+    FD_LOG_ERR(( "unexpected msg sz %lu for sig FD_SNAPSHOT_HASH_MSG_EXP_AND_CAPITAL", sz ));
     return;
   }
 
-  uchar * src = fd_chunk_to_laddr( ctx->in.wksp, chunk );
-  uchar * dst = fd_chunk_to_laddr( ctx->hash_out.mem, ctx->hash_out.chunk );
+  fd_ssctrl_hash_result_t const * src = fd_chunk_to_laddr_const( ctx->in.wksp, chunk );
+  fd_ssctrl_hash_result_t * dst = fd_chunk_to_laddr( ctx->hash_out.mem, ctx->hash_out.chunk );
   memcpy( dst, src, sz );
-  fd_stem_publish( stem, ctx->out_ct_idx, FD_SNAPSHOT_HASH_MSG_EXPECTED, ctx->hash_out.chunk, sz, 0UL, 0UL, 0UL );
-  ctx->hash_out.chunk = fd_dcache_compact_next( ctx->hash_out.chunk, sz, ctx->hash_out.chunk0, ctx->hash_out.wmark );
-}
-
-static inline void
-handle_expected_capitalization_message( fd_snapwm_tile_t *  ctx,
-                                        ulong               chunk,
-                                        ulong               sz,
-                                        fd_stem_context_t * stem ) {
-  if( FD_UNLIKELY( sz!=sizeof(fd_ssctrl_capitalization_t) ) ) {
-    FD_LOG_ERR(( "unexpected msg sz %lu for sig FD_SNAPSHOT_MSG_EXP_CAPITALIZATION", sz ));
-    return;
-  }
-
-  fd_ssctrl_capitalization_t const * src = fd_chunk_to_laddr_const( ctx->in.wksp, chunk );
-  fd_ssctrl_capitalization_t * dst = fd_chunk_to_laddr( ctx->hash_out.mem, ctx->hash_out.chunk );
-  memcpy( dst, src, sz );
-  fd_stem_publish( stem, ctx->out_ct_idx, FD_SNAPSHOT_MSG_EXP_CAPITALIZATION, ctx->hash_out.chunk, sz, 0UL, 0UL, 0UL );
+  fd_stem_publish( stem, ctx->out_ct_idx, FD_SNAPSHOT_HASH_MSG_EXP_AND_CAPITAL, ctx->hash_out.chunk, sz, 0UL, 0UL, 0UL );
   ctx->hash_out.chunk = fd_dcache_compact_next( ctx->hash_out.chunk, sz, ctx->hash_out.chunk0, ctx->hash_out.wmark );
 }
 
@@ -361,13 +344,11 @@ returnable_frag( fd_snapwm_tile_t *  ctx,
                  fd_stem_context_t * stem ) {
   FD_TEST( ctx->state!=FD_SNAPSHOT_STATE_SHUTDOWN );
 
-  int ret = 0;
-  if( FD_LIKELY( sig==FD_SNAPSHOT_MSG_DATA ) )                      ret = handle_data_frag( ctx, chunk, sz/*acc_cnt*/, stem );
-  else if( FD_UNLIKELY( sig==FD_SNAPSHOT_HASH_MSG_EXPECTED ) )      handle_expected_hash_message( ctx, chunk, sz, stem );
-  else if( FD_UNLIKELY( sig==FD_SNAPSHOT_MSG_EXP_CAPITALIZATION ) ) handle_expected_capitalization_message( ctx, chunk, sz, stem );
-  else                                                              handle_control_frag( ctx, sig, stem );
+  if( FD_LIKELY( sig==FD_SNAPSHOT_MSG_DATA ) )                        return handle_data_frag( ctx, chunk, sz/*acc_cnt*/, stem );
+  else if( FD_UNLIKELY( sig==FD_SNAPSHOT_HASH_MSG_EXP_AND_CAPITAL ) ) handle_expected_hash_and_capitalization_message( ctx, chunk, sz, stem );
+  else                                                                handle_control_frag( ctx, sig, stem );
 
-  return ret;
+  return 0;
 }
 
 static ulong
@@ -506,13 +487,11 @@ unprivileged_init( fd_topo_t *      topo,
   fd_snapwm_vinyl_unprivileged_init( ctx, topo, tile, _io_mm, _io_wd );
 }
 
-/* Control fragments can result in one extra publish to forward the
-   message down the pipeline, in addition to the result / malformed
-   message. It can send one duplicate account message as well.
-   When fd_snapwm_vinyl_txn_commit is invoked, the latter will handle
-   fseq checks internally, since the amount of messages it needs to
-   send far exceed the STEM_BURST. */
-#define STEM_BURST 3UL
+/* Only one message is expected to be sent out in any stem cycle, plus
+   (possibly) a subsequent error message.  Excluded from this analysis
+   is fd_snapwm_vinyl_txn_commit, which only executes when lthash
+   verification is disabled, therefore not affecting STEM_BURST. */
+#define STEM_BURST 2UL
 
 #define STEM_LAZY  1000L
 

--- a/src/discof/restore/utils/fd_ssctrl.h
+++ b/src/discof/restore/utils/fd_ssctrl.h
@@ -82,9 +82,9 @@
 #define FD_SNAPSHOT_MSG_CTRL_FINI              (9UL) /* Current snapshot has been fully loaded, finish processing */
 
 /* snapin -> snapls */
+#define FD_SNAPSHOT_HASH_MSG_EXPECTED         (10UL) /* Expected accounts hash sent from snapin to snapls */
 /* snapin -> snapwm -> snaplv */
-#define FD_SNAPSHOT_HASH_MSG_EXPECTED         (10UL) /* Hash result sent from snapin to snapls or from snapin to snapwm to snaplv */
-#define FD_SNAPSHOT_MSG_EXP_CAPITALIZATION    (11UL) /* Capitalization sent from snapin to snapwm in vinyl mode to verify capitalization */
+#define FD_SNAPSHOT_HASH_MSG_EXP_AND_CAPITAL  (11UL) /* Combined expected hash and capitalization message sent from snapin to snapwm to snaplv */
 
 /* snapin -> snapls */
 #define FD_SNAPSHOT_HASH_MSG_SUB              (12UL) /* Duplicate account sent from snapin to snapls, includes account header and data */
@@ -118,10 +118,6 @@ typedef struct fd_ssctrl_init {
 typedef struct fd_ssctrl_meta {
   ulong total_sz;
 } fd_ssctrl_meta_t;
-
-typedef struct fd_ssctrl_capitalization {
-  ulong capitalization;
-} fd_ssctrl_capitalization_t;
 
 typedef struct fd_ssctrl_hash_result {
   fd_lthash_value_t lthash;
@@ -185,25 +181,25 @@ fd_ssctrl_state_str( ulong state ) {
 static inline const char *
 fd_ssctrl_msg_ctrl_str( ulong sig ) {
   switch( sig ) {
-    case FD_SNAPSHOT_MSG_DATA:                return "data";
-    case FD_SNAPSHOT_MSG_META:                return "meta";
-    case FD_SNAPSHOT_MSG_CTRL_INIT_FULL:      return "init_full";
-    case FD_SNAPSHOT_MSG_CTRL_INIT_INCR:      return "init_incr";
-    case FD_SNAPSHOT_MSG_CTRL_FAIL:           return "fail";
-    case FD_SNAPSHOT_MSG_CTRL_NEXT:           return "next";
-    case FD_SNAPSHOT_MSG_CTRL_DONE:           return "done";
-    case FD_SNAPSHOT_MSG_CTRL_SHUTDOWN:       return "shutdown";
-    case FD_SNAPSHOT_MSG_CTRL_ERROR:          return "error";
-    case FD_SNAPSHOT_MSG_CTRL_FINI:           return "fini";
-    case FD_SNAPSHOT_HASH_MSG_EXPECTED:       return "hash_expected";
-    case FD_SNAPSHOT_MSG_EXP_CAPITALIZATION:  return "exp_capitalization";
-    case FD_SNAPSHOT_HASH_MSG_SUB:            return "hash_sub";
-    case FD_SNAPSHOT_HASH_MSG_SUB_HDR:        return "hash_sub_hdr";
-    case FD_SNAPSHOT_HASH_MSG_SUB_DATA:       return "hash_sub_data";
-    case FD_SNAPSHOT_HASH_MSG_RESULT_SUB:     return "hash_result_sub";
-    case FD_SNAPSHOT_HASH_MSG_SUB_META_BATCH: return "hash_sub_meta_batch";
-    case FD_SNAPSHOT_HASH_MSG_RESULT_ADD:     return "hash_result_add";
-    default:                                  return "unknown";
+    case FD_SNAPSHOT_MSG_DATA:                  return "data";
+    case FD_SNAPSHOT_MSG_META:                  return "meta";
+    case FD_SNAPSHOT_MSG_CTRL_INIT_FULL:        return "init_full";
+    case FD_SNAPSHOT_MSG_CTRL_INIT_INCR:        return "init_incr";
+    case FD_SNAPSHOT_MSG_CTRL_FAIL:             return "fail";
+    case FD_SNAPSHOT_MSG_CTRL_NEXT:             return "next";
+    case FD_SNAPSHOT_MSG_CTRL_DONE:             return "done";
+    case FD_SNAPSHOT_MSG_CTRL_SHUTDOWN:         return "shutdown";
+    case FD_SNAPSHOT_MSG_CTRL_ERROR:            return "error";
+    case FD_SNAPSHOT_MSG_CTRL_FINI:             return "fini";
+    case FD_SNAPSHOT_HASH_MSG_EXPECTED:         return "hash_expected";
+    case FD_SNAPSHOT_HASH_MSG_EXP_AND_CAPITAL:  return "hash_exp_and_capital";
+    case FD_SNAPSHOT_HASH_MSG_SUB:              return "hash_sub";
+    case FD_SNAPSHOT_HASH_MSG_SUB_HDR:          return "hash_sub_hdr";
+    case FD_SNAPSHOT_HASH_MSG_SUB_DATA:         return "hash_sub_data";
+    case FD_SNAPSHOT_HASH_MSG_RESULT_SUB:       return "hash_result_sub";
+    case FD_SNAPSHOT_HASH_MSG_SUB_META_BATCH:   return "hash_sub_meta_batch";
+    case FD_SNAPSHOT_HASH_MSG_RESULT_ADD:       return "hash_result_add";
+    default:                                    return "unknown";
   }
 }
 


### PR DESCRIPTION
Minimizing `snapin` STEM_BURST to 2.
This reduces pressure on `cr_avail` on `snapin` output links.
Combining `expected hash` and `expected capitalization` into a single message (reusing existing `fd_ssctrl_hash_result_t`).
Updating `snapin_txn` link as unreliable in topology.
Minor updates to `snapwm` and `snaplv` STEM_BURST as well.
