### PR TITLE
txsend, rpc: fix contact info union access

### DIFF
--- a/src/discof/rpc/fd_rpc_tile.c
+++ b/src/discof/rpc/fd_rpc_tile.c
@@ -494,10 +494,10 @@ returnable_frag( fd_rpc_tile_t *     ctx,
       }
       case FD_GOSSIP_UPDATE_TAG_CONTACT_INFO_REMOVE: {
         if( FD_UNLIKELY( update->contact_info_remove->idx>=FD_CONTACT_INFO_TABLE_SIZE ) ) FD_LOG_ERR(( "unexpected remove_contact_info_idx %lu >= %lu", update->contact_info_remove->idx, FD_CONTACT_INFO_TABLE_SIZE ));
-        fd_rpc_cluster_node_t * node = &ctx->cluster_nodes[ update->contact_info->idx ];
+        fd_rpc_cluster_node_t * node = &ctx->cluster_nodes[ update->contact_info_remove->idx ];
         FD_TEST( node->valid );
         node->valid = 0;
-        fd_rpc_cluster_node_dlist_idx_remove( ctx->cluster_nodes_dlist, update->contact_info->idx, ctx->cluster_nodes );
+        fd_rpc_cluster_node_dlist_idx_remove( ctx->cluster_nodes_dlist, update->contact_info_remove->idx, ctx->cluster_nodes );
         break;
       }
       default: break;

--- a/src/discof/txsend/fd_txsend_tile.c
+++ b/src/discof/txsend/fd_txsend_tile.c
@@ -423,7 +423,7 @@ handle_contact_info_update( fd_txsend_tile_t *                 ctx,
 static inline void
 handle_contact_info_remove( fd_txsend_tile_t *                 ctx,
                             fd_gossip_update_message_t const * msg ) {
-  peer_entry_t * entry = &ctx->peers[ msg->contact_info->idx ];
+  peer_entry_t * entry = &ctx->peers[ msg->contact_info_remove->idx ];
   entry->tombstoned = 1;
 }
 


### PR DESCRIPTION
Both contact_info and contact_info_remove are union variants whose first field is ulong idx, so the memory access is identical. But it's technically UB and a regression risk