### PR TITLE
util/log: don't print full source path to stderr

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -93,7 +93,7 @@ dynamic_port_range = "8900-9000"
 # STDERR and STDOUT from the launcher.  An example log message would
 # look something like:
 #
-#    NOTICE  01-23 04:56:07.890123 45678 f0 0 src/file.c(901): 1 is the loneliest number
+#    NOTICE  01-23 04:56:07.890123 45678 f0 0 file.c(901): 1 is the loneliest number
 #
 # to the ephemeral log (stderr) and log something like:
 #

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -231,7 +231,7 @@ telemetry = true
 # STDERR and STDOUT from the launcher.  An example log message would
 # look something like:
 #
-#    NOTICE  01-23 04:56:07.890123 45678 f0 0 src/file.c(901): 1 is the loneliest number
+#    NOTICE  01-23 04:56:07.890123 45678 f0 0 file.c(901): 1 is the loneliest number
 #
 # to the ephemeral log (stderr) and log something like:
 #

--- a/src/util/log/fd_log.c
+++ b/src/util/log/fd_log.c
@@ -833,9 +833,11 @@ fd_log_private_1( int          level,
       /* 7 */ TEXT_RED TEXT_BOLD TEXT_UNDERLINE TEXT_BLINK "EMERG  " TEXT_NORMAL
     };
     char * now_short_cstr = now_cstr+5; now_short_cstr[21] = '\0'; /* Lop off the year, ns resolution and timezone */
+    char const * stem = strrchr( file, '/' );
+    char const * file_name = stem ? stem+1 : file;
     fd_log_private_fprintf_0( fd_log_private_stderr_fileno, "%s %s %-6lu %-4s %-4s %s(%i): %s\n",
                               fd_log_private_colorize ? color_level_cstr[level] : level_cstr[level],
-                              now_short_cstr, tid,cpu,thread, file, line, msg );
+                              now_short_cstr, tid,cpu,thread, file_name, line, msg );
   }
 
   if( level<fd_log_level_flush() ) return;
@@ -870,20 +872,6 @@ fd_log_private_2( int          level,
     exit(1); /* atexit will call fd_log_private_cleanup implicitly */
   }
 
-  abort();
-}
-
-void
-fd_log_private_raw_2( char const * file,
-                      int          line,
-                      char const * func,
-                      char const * msg ) {
-  fd_log_private_fprintf_0( fd_log_private_stderr_fileno, "%s(%i)[%s]: %s\n", file, line, func, msg );
-# if defined(__linux__)
-  syscall( SYS_exit_group, 1 );
-# else
-  exit(1);
-# endif
   abort();
 }
 

--- a/src/util/log/fd_log.h
+++ b/src/util/log/fd_log.h
@@ -151,7 +151,7 @@
 
    would log something like:
 
-     NOTICE  01-23 04:56:07.890123 45678 f0 0 src/file.c(901): 1 is the loneliest number
+     NOTICE  01-23 04:56:07.890123 45678 f0 0 file.c(901): 1 is the loneliest number
 
    to the ephemeral log (stderr) and log something like:
 
@@ -195,7 +195,7 @@
 
    would log something like:
 
-     WARNING 01-23 04:56:07.890123 75779 f0 0 src/file.c(901): HEXDUMP "bad_pkt" (96 bytes at 0x555555561a4e)
+     WARNING 01-23 04:56:07.890123 75779 f0 0 file.c(901): HEXDUMP "bad_pkt" (96 bytes at 0x555555561a4e)
              0000:  30 31 32 33 34 35 36 37 38 39 41 42 43 44 45 46  0123456789ABCDEF
              0010:  47 48 49 4a 4b 4c 4d 4e 4f 50 51 52 53 54 55 56  GHIJKLMNOPQRSTUV
              0020:  57 58 59 5a 61 62 63 64 65 66 67 68 69 6a 6b 6c  WXYZabcdefghijkl
@@ -250,7 +250,7 @@
    would typically cause the program to exit with error code 1, logging
    something like:
 
-     ERR     01-23 04:56:07.890123 45678 f0 0 src/foo.c(901): FAIL: func_that_should_return_zero( arg1, arg2 )!=0 (it's bad you know)
+     ERR     01-23 04:56:07.890123 45678 f0 0 foo.c(901): FAIL: func_that_should_return_zero( arg1, arg2 )!=0 (it's bad you know)
 
    to the ephemeral log (stderr) and something like:
 
@@ -341,7 +341,7 @@
 
    would log something like:
 
-     NOTICE  01-23 04:56:07.890123 45678 f0 0 src/foo.c(901): cache line 0123456789abcd00
+     NOTICE  01-23 04:56:07.890123 45678 f0 0 foo.c(901): cache line 0123456789abcd00
              00: 00 01 02 03 04 05 06 07  08 09 0a 0b 0c 0d 0e 0f
              10: 10 11 12 13 14 15 16 17  18 19 1a 1b 1c 1d 1e 1f
              20: 20 21 22 23 24 25 26 27  28 29 2a 2b 2c 2d 2e 2f
@@ -683,12 +683,6 @@ fd_log_private_2( int          level,
                   int          line,
                   char const * func,
                   char const * msg ) __attribute__((noreturn)); /* Let compiler know this will not be returning */
-
-void
-fd_log_private_raw_2( char const * file,
-                      int          line,
-                      char const * func,
-                      char const * msg ) __attribute__((noreturn)); /* Let compiler know this will not be returning */
 
 char const *
 fd_log_private_hexdump_msg( char const * tag,


### PR DESCRIPTION
Only print the source file name, but not the full source path, to stderr log.

This works because according to C coding best practices compile unit names should be unique.

Before

<img width="1192" height="415" alt="Screenshot 2026-03-16 at 11 10 43 AM" src="https://github.com/user-attachments/assets/9df9ea8c-6320-4a33-9031-1b305821da6e" />

After

<img width="1313" height="264" alt="Screenshot 2026-03-16 at 11 35 55 AM" src="https://github.com/user-attachments/assets/05feb8f5-a61f-4af1-a090-4f85744e9950" />
