### PR TITLE
gui: remove unused code

### DIFF
--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -1518,28 +1518,6 @@ fd_gui_request_slot_rankings( fd_gui_t *    gui,
 }
 
 int
-fd_gui_request_slot_shreds( fd_gui_t *    gui,
-                            ulong         ws_conn_id,
-                            ulong         request_id,
-                            cJSON const * params ) {
-  const cJSON * slot_param = cJSON_GetObjectItemCaseSensitive( params, "slot" );
-  if( FD_UNLIKELY( !cJSON_IsNumber( slot_param ) ) ) return FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST;
-
-  ulong _slot = slot_param->valueulong;
-
-  fd_gui_slot_t const * slot = fd_gui_get_slot( gui, _slot );
-  if( FD_UNLIKELY( !slot || slot->shreds.end_offset || gui->shreds.history_tail > slot->shreds.end_offset + FD_GUI_SHREDS_HISTORY_SZ ) ) {
-    fd_gui_printf_null_query_response( gui->http, "slot", "query_shreds", request_id );
-    FD_TEST( !fd_http_server_ws_send( gui->http, ws_conn_id ) );
-    return 0;
-  }
-
-  fd_gui_printf_slot_query_shreds( gui, _slot, request_id );
-  FD_TEST( !fd_http_server_ws_send( gui->http, ws_conn_id ) );
-  return 0;
-}
-
-int
 fd_gui_ws_message( fd_gui_t *    gui,
                    ulong         ws_conn_id,
                    uchar const * data,


### PR DESCRIPTION
Validation logic in fd_gui_request_slot_shreds was broken leading
to practically any request failing.
