### PR TITLE
http: enforce client request timeout

### DIFF
--- a/src/waltz/http/fd_http_server.c
+++ b/src/waltz/http/fd_http_server.c
@@ -84,6 +84,7 @@ fd_http_server_connection_close_reason_str( int reason ) {
     case FD_HTTP_SERVER_CONNECTION_CLOSE_WS_EXPECTED_TEXT_OPCODE:      return "WS_EXPECTED_TEXT_OPCODE-Expected text opcode in websocket frame";
     case FD_HTTP_SERVER_CONNECTION_CLOSE_WS_CONTROL_FRAME_TOO_LARGE:   return "WS_CONTROL_FRAME_TOO_LARGE-Websocket control frame was too large";
     case FD_HTTP_SERVER_CONNECTION_CLOSE_WS_CHANGED_OPCODE:            return "FD_HTTP_SERVER_CONNECTION_CLOSE_WS_CHANGED_OPCODE-Websocket frame type changed unexpectedly";
+    case FD_HTTP_SERVER_CONNECTION_CLOSE_TIMEOUT:                      return "TIMEOUT-Connection timed out while reading request";
     default: break;
   }
 
@@ -419,6 +420,7 @@ accept_conns( fd_http_server_t * http ) {
 
     http->pollfds[ conn_id ].fd = fd;
     http->conns[ conn_id ].state                  = FD_HTTP_SERVER_CONNECTION_STATE_READING;
+    http->conns[ conn_id ].read_deadline          = fd_log_wallclock() + FD_HTTP_SERVER_READ_TIMEOUT_NANOS;
     http->conns[ conn_id ].request_bytes_read     = 0UL;
     http->conns[ conn_id ].response_bytes_written = 0UL;
 
@@ -1165,6 +1167,17 @@ write_conn( fd_http_server_t * http,
 int
 fd_http_server_poll( fd_http_server_t * http,
                      int                poll_timeout ) {
+  /* Close connections stuck in the READING state past their deadline
+     to prevent Slowloris-style denial of service. */
+  long now = fd_log_wallclock();
+  for( ulong i=0UL; i<http->max_conns; i++ ) {
+    if( FD_UNLIKELY( -1==http->pollfds[ i ].fd ) ) continue;
+    struct fd_http_server_connection * conn = &http->conns[ i ];
+    if( FD_UNLIKELY( conn->state==FD_HTTP_SERVER_CONNECTION_STATE_READING && now>=conn->read_deadline ) ) {
+      close_conn( http, i, FD_HTTP_SERVER_CONNECTION_CLOSE_TIMEOUT );
+    }
+  }
+
   int nfds = fd_syscall_poll( http->pollfds, (uint)( http->max_conns+http->max_ws_conns+1UL ), poll_timeout );
   if( FD_UNLIKELY( 0==nfds ) ) return 0;
   else if( FD_UNLIKELY( -1==nfds && errno==EINTR ) ) return 0;

--- a/src/waltz/http/fd_http_server.h
+++ b/src/waltz/http/fd_http_server.h
@@ -61,6 +61,7 @@
 #define FD_HTTP_SERVER_CONNECTION_CLOSE_WS_EXPECTED_TEXT_OPCODE      (-21)
 #define FD_HTTP_SERVER_CONNECTION_CLOSE_WS_CONTROL_FRAME_TOO_LARGE   (-22)
 #define FD_HTTP_SERVER_CONNECTION_CLOSE_WS_CHANGED_OPCODE            (-23)
+#define FD_HTTP_SERVER_CONNECTION_CLOSE_TIMEOUT                      (-24)
 
 /* Given a FD_HTTP_SERVER_CONNECTION_CLOSE_* reason code, a reason that
    a HTTP connection a client was closed, produce a human readable

--- a/src/waltz/http/fd_http_server_private.h
+++ b/src/waltz/http/fd_http_server_private.h
@@ -14,6 +14,8 @@
 #define FD_HTTP_SERVER_CONNECTION_STATE_WRITING_HEADER 1
 #define FD_HTTP_SERVER_CONNECTION_STATE_WRITING_BODY   2
 
+#define FD_HTTP_SERVER_READ_TIMEOUT_NANOS (5L*1000L*1000L*1000L) /* 5 seconds */
+
 #define FD_HTTP_SERVER_PONG_STATE_NONE    0
 #define FD_HTTP_SERVER_PONG_STATE_WAITING 1
 #define FD_HTTP_SERVER_PONG_STATE_WRITING 2
@@ -23,6 +25,7 @@
 
 struct fd_http_server_connection {
   int          state;
+  long         read_deadline; /* Wallclock nanos deadline for completing the read */
 
   int          upgrade_websocket;
   int          compress_websocket;

--- a/src/waltz/http/test_http_server.c
+++ b/src/waltz/http/test_http_server.c
@@ -4,9 +4,12 @@
 
 #include <arpa/inet.h>
 #include <errno.h>
+#include <poll.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <unistd.h>
+
+static uchar scratch[ 2UL<<20 ] __attribute__((aligned(128UL)));
 
 struct overflow_close_state {
   ulong close_cnt;
@@ -67,8 +70,7 @@ test_oring( void ) {
     .ws_message = NULL,
   };
 
-  uchar scratch[ 1633024 ] __attribute__((aligned(128UL)));
-  FD_TEST( fd_http_server_footprint( params )==1633024 );
+  FD_TEST( fd_http_server_footprint( params )<=sizeof(scratch) );
   fd_http_server_t * http = fd_http_server_join( fd_http_server_new( scratch, params, callbacks, NULL ) );
 
   http->stage_off = 6UL;
@@ -148,9 +150,7 @@ test_content_length_overflow_close( void ) {
     .ws_message = NULL,
   };
 
-  FD_LOG_NOTICE(( "footprint %lu", fd_http_server_footprint( params ) ));
-  uchar scratch[ 1306624 ] __attribute__((aligned(128UL)));
-  FD_TEST( fd_http_server_footprint( params )==1306624 );
+  FD_TEST( fd_http_server_footprint( params )<=sizeof(scratch) );
 
   fd_http_server_t * http = fd_http_server_join( fd_http_server_new( scratch, params, callbacks, &state ) );
   FD_TEST( http );
@@ -193,12 +193,95 @@ test_content_length_overflow_close( void ) {
   fd_http_server_delete( fd_http_server_leave( http ) );
 }
 
+void
+test_read_timeout( void ) {
+  fd_http_server_params_t params = {
+    .max_connection_cnt    = 2UL,
+    .max_ws_connection_cnt = 0UL,
+    .max_request_len       = 1024UL,
+    .max_ws_recv_frame_len = 1024UL,
+    .max_ws_send_frame_cnt = 1UL,
+    .outgoing_buffer_sz    = 1024UL,
+  };
+
+  overflow_close_state_t state = {0};
+  fd_http_server_callbacks_t callbacks = {
+    .request    = request_noop,
+    .close      = close_capture,
+    .ws_open    = NULL,
+    .ws_close   = NULL,
+    .ws_message = NULL,
+  };
+
+  FD_TEST( fd_http_server_footprint( params )<=sizeof(scratch) );
+
+  fd_http_server_t * http = fd_http_server_join( fd_http_server_new( scratch, params, callbacks, &state ) );
+  FD_TEST( http );
+  FD_TEST( fd_http_server_listen( http, 0U, 0U ) );
+
+  struct sockaddr_in server_addr = {0};
+  socklen_t server_addr_sz = sizeof( server_addr );
+  FD_TEST( !getsockname( fd_http_server_fd( http ), fd_type_pun( &server_addr ), &server_addr_sz ) );
+  ushort server_port = ntohs( server_addr.sin_port );
+
+  /* Connect a client and send a partial HTTP request (no terminating
+     \r\n\r\n), simulating a Slowloris attack. */
+  int slow_fd = socket( AF_INET, SOCK_STREAM, 0 );
+  FD_TEST( slow_fd>=0 );
+
+  struct sockaddr_in connect_addr = {
+    .sin_family      = AF_INET,
+    .sin_port        = htons( server_port ),
+    .sin_addr.s_addr = htonl( INADDR_LOOPBACK ),
+  };
+  FD_TEST( !connect( slow_fd, fd_type_pun( &connect_addr ), sizeof( connect_addr ) ) );
+
+  /* Send partial request — no \r\n\r\n so the server stays in READING */
+  char const * partial = "GET / HTTP/1.1\r\nHost: localhost\r\n";
+  send_all( slow_fd, partial, strlen( partial ) );
+
+  /* Accept the connection */
+  for( ulong i=0UL; i<10UL; i++ ) fd_http_server_poll( http, 1 );
+
+  /* The connection should still be open (no close callback yet) */
+  FD_TEST( state.close_cnt==0UL );
+
+  /* Force the read deadline into the past to simulate timeout without
+     actually waiting 5 seconds. */
+  for( ulong i=0UL; i<http->max_conns; i++ ) {
+    if( http->pollfds[ i ].fd!=-1 && http->conns[ i ].state==FD_HTTP_SERVER_CONNECTION_STATE_READING ) {
+      http->conns[ i ].read_deadline = fd_log_wallclock() - 1L;
+    }
+  }
+
+  /* Next poll should close the timed-out connection */
+  fd_http_server_poll( http, 0 );
+
+  FD_TEST( state.close_cnt==1UL );
+  FD_TEST( state.last_reason==FD_HTTP_SERVER_CONNECTION_CLOSE_TIMEOUT );
+
+  close( slow_fd );
+  close( fd_http_server_fd( http ) );
+  fd_http_server_delete( fd_http_server_leave( http ) );
+}
+
 int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
+  /* Suppress warnings from tests that intentionally trigger error paths */
+  int old_stderr  = fd_log_level_stderr();
+  int old_logfile = fd_log_level_logfile();
+  fd_log_level_stderr_set ( 4 );
+  fd_log_level_logfile_set( 4 );
+
   test_oring();
+
+  fd_log_level_stderr_set ( old_stderr );
+  fd_log_level_logfile_set( old_logfile );
+
+  test_read_timeout();
   test_content_length_overflow_close();
 
   FD_LOG_NOTICE(( "pass" ));


### PR DESCRIPTION
Add a hardcoded 5 second request timeout for any client request to
http_server.  Fixes a design flaw where a malicious client could
indefinitely stall a HTTP connection.

Also removes WARNING log spam from test_http_server
