### PR TITLE
events: remove hardcoded server TCP port

### DIFF
--- a/src/disco/events/fd_event_client.c
+++ b/src/disco/events/fd_event_client.c
@@ -134,7 +134,6 @@ fd_event_client_new( void *                 shmem,
                                           "[tiles.event.url]" ) ) ) {
     FD_LOG_ERR(( "Could not parse [tiles.event.url]" ));
   }
-  client->server_tcp_port = 7878;
   if( FD_UNLIKELY( url->host_len > 255 ) ) {
     FD_LOG_CRIT(( "Invalid url->host_len" )); /* unreachable */
   }


### PR DESCRIPTION
Looks like leftover debug code.  If the event server listens on a
non-standard port, we should specify that in the configured URL.
