### PR TITLE
restore: capitalization verif under funk

### DIFF
--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -772,6 +772,23 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
   return reprocess_frag;
 }
 
+static int
+validate_capitalization( fd_snapin_tile_t * ctx ) {
+  /* Capitalization is checked only when lthash verification is
+     enabled, since a snapshot that fails lthash would most probably
+     fail capitalization as well.  This also matches the snapshot
+     load pipeline check under vinyl. */
+  if( FD_UNLIKELY( ctx->lthash_disabled ) ) return 0;
+  if( FD_UNLIKELY( ctx->capitalization!=ctx->manifest_capitalization ) ) {
+    /* SnapshotError::MismatchedCapitalization
+        https://github.com/anza-xyz/agave/blob/v4.0.0-beta.2/runtime/src/snapshot_bank_utils.rs#L217 */
+    FD_LOG_WARNING(( "%s snapshot manifest capitalization %lu does not match computed capitalization %lu",
+                     ctx->full?"full":"incr", ctx->manifest_capitalization, ctx->capitalization ));
+    return -1;
+  }
+  return 0;
+}
+
 static void
 handle_control_frag( fd_snapin_tile_t *  ctx,
                      fd_stem_context_t * stem,
@@ -862,11 +879,7 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
         }
 
         ctx->capitalization = fd_ulong_sat_sub( ctx->capitalization, ctx->dup_capitalization );
-        if( FD_UNLIKELY( ctx->capitalization!=ctx->manifest_capitalization ) ) {
-          /* SnapshotError::MismatchedCapitalization
-             https://github.com/anza-xyz/agave/blob/v4.0.0-beta.2/runtime/src/snapshot_bank_utils.rs#L217 */
-          FD_LOG_WARNING(( "snapshot manifest capitalization %lu does not match computed capitalization %lu",
-                           ctx->manifest_capitalization, ctx->capitalization ));
+        if( FD_UNLIKELY( validate_capitalization( ctx )!=0 ) ) {
           transition_malformed( ctx, stem );
           forward_msg = 0;
           break;
@@ -896,11 +909,7 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
         }
 
         ctx->capitalization = fd_ulong_sat_sub( ctx->capitalization, ctx->dup_capitalization );
-        if( FD_UNLIKELY( ctx->capitalization!=ctx->manifest_capitalization ) ) {
-          /* SnapshotError::MismatchedCapitalization
-             https://github.com/anza-xyz/agave/blob/v4.0.0-beta.2/runtime/src/snapshot_bank_utils.rs#L217 */
-          FD_LOG_WARNING(( "snapshot manifest capitalization %lu does not match computed capitalization %lu",
-                           ctx->manifest_capitalization, ctx->capitalization ));
+        if( FD_UNLIKELY( validate_capitalization( ctx )!=0 ) ) {
           transition_malformed( ctx, stem );
           forward_msg = 0;
           break;

--- a/src/discof/restore/fd_snaplv_tile.c
+++ b/src/discof/restore/fd_snaplv_tile.c
@@ -553,28 +553,17 @@ after_credit( fd_snaplv_t *        ctx,
       transition_malformed( ctx, stem );
       return;
     }
-
     if( FD_UNLIKELY( ctx->running_capitalization<0L ) ) {
       FD_LOG_WARNING(( "computed capitalization %ld is invalid", ctx->running_capitalization ));
       transition_malformed( ctx, stem );
       return;
     }
-
     ulong computed_capitalization = (ulong)ctx->running_capitalization;
     int capitalization_match      = computed_capitalization==ctx->manifest_capitalization;
 
-    if( FD_UNLIKELY( !capitalization_match ) ) {
-      /* SnapshotError::MismatchedCapitalization
-         https://github.com/anza-xyz/agave/blob/v4.0.0-beta.2/runtime/src/snapshot_bank_utils.rs#L217 */
-      FD_LOG_WARNING(( "snapshot manifest capitalization %lu does not match computed capitalization %lu",
-                       ctx->manifest_capitalization, computed_capitalization ));
-      transition_malformed( ctx, stem );
-      return;
-    }
+    int lthash_match = !memcmp( &ctx->hash_accum.expected_lthash, &ctx->hash_accum.calculated_lthash, sizeof(fd_lthash_value_t) );
 
-    int test = memcmp( &ctx->hash_accum.expected_lthash, &ctx->hash_accum.calculated_lthash, sizeof(fd_lthash_value_t) );
-
-    if( FD_UNLIKELY( test ) ) {
+    if( FD_UNLIKELY( !lthash_match ) ) {
       /* SnapshotError::MismatchedHash
          https://github.com/anza-xyz/agave/blob/v3.1.8/runtime/src/snapshot_bank_utils.rs#L479 */
       FD_LOG_WARNING(( "calculated accounts lthash %s does not match accounts lthash %s in %s snapshot manifest",
@@ -588,6 +577,15 @@ after_credit( fd_snaplv_t *        ctx,
                      FD_LTHASH_ENC_32_ALLOCA( &ctx->hash_accum.calculated_lthash ),
                      FD_LTHASH_ENC_32_ALLOCA( &ctx->hash_accum.expected_lthash ),
                      ctx->full?"full":"incremental" ));
+    }
+
+    if( FD_UNLIKELY( !capitalization_match ) ) {
+      /* SnapshotError::MismatchedCapitalization
+         https://github.com/anza-xyz/agave/blob/v4.0.0-beta.2/runtime/src/snapshot_bank_utils.rs#L217 */
+      FD_LOG_WARNING(( "%s snapshot manifest capitalization %lu does not match computed capitalization %lu",
+                       ctx->full?"full":"incremental", ctx->manifest_capitalization, computed_capitalization ));
+      transition_malformed( ctx, stem );
+      return;
     }
 
     fd_stem_publish( stem, ctx->out_link[ OUT_LINK_CT ].idx, ctx->hash_accum.ack_sig, 0UL, 0UL, 0UL, 0UL, 0UL );


### PR DESCRIPTION
- under funk, validate capitalization check only when lthash verification is enabled. (this matches the behavior under vinyl, and allows backtests to keep running older tests).
- under vinyl, validate (and log) lthash before validating capitalization.
