### PR TITLE
fuzz: resolve Dalek library path from env, if present

### DIFF
--- a/src/ballet/ed25519/fuzz_ed25519_sigverify_diff.c
+++ b/src/ballet/ed25519/fuzz_ed25519_sigverify_diff.c
@@ -11,6 +11,8 @@
 #include "../../util/sanitize/fd_fuzz.h"
 #include "fd_ed25519.h"
 
+#define DALEK_SO_DEFAULT "contrib/ed25519/dalek_target/target/x86_64-unknown-linux-gnu/release/libdalek_target.so"
+
 typedef int
 (* verify_fn_t)( uchar const * msg,
                  ulong         sz,
@@ -45,7 +47,11 @@ LLVMFuzzerInitialize( int  *   argc,
   atexit( fd_halt );
   fd_log_level_core_set(3); /* crash on warning log */
 
-  void * dalek = dlopen( "contrib/ed25519/dalek_target/target/x86_64-unknown-linux-gnu/release/libdalek_target.so", RTLD_LAZY );
+  char const * dalek_path = getenv( "DALEK_TARGET_SO" );
+  if( !dalek_path ) {
+    dalek_path = DALEK_SO_DEFAULT;
+  }
+  void * dalek = dlopen( dalek_path, RTLD_LAZY );
   if( FD_UNLIKELY( !dalek ) )
     FD_LOG_CRIT(( "%s", dlerror() ));
 


### PR DESCRIPTION
The ed25519 fuzzing harness hardcodes a relative path for the Dalek reference library, which fails in orchestrator environments with an overridden CWD. Add a `DALEK_TARGET_SO` environment variable override so orchestrators can provide the correct absolute path.