### PR TITLE
gui: fix txn_entry->flags bleed

### DIFF
--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -3090,8 +3090,7 @@ fd_gui_microblock_execution_begin( fd_gui_t *   gui,
     txn_entry->source_ipv4                 = txn_payload->source_ipv4;
     txn_entry->source_tpu                  = txn_payload->source_tpu;
     txn_entry->microblock_idx              = microblock_idx;
-    txn_entry->flags                      |= (uchar)FD_GUI_TXN_FLAGS_STARTED;
-    txn_entry->flags                      &= (uchar)(~(uchar)(FD_GUI_TXN_FLAGS_IS_SIMPLE_VOTE | FD_GUI_TXN_FLAGS_FROM_BUNDLE));
+    txn_entry->flags                       = (uchar)FD_GUI_TXN_FLAGS_STARTED;
     txn_entry->flags                      |= (uchar)fd_uint_if(txn_payload->flags & FD_TXN_P_FLAGS_IS_SIMPLE_VOTE, FD_GUI_TXN_FLAGS_IS_SIMPLE_VOTE, 0U);
     txn_entry->flags                      |= (uchar)fd_uint_if((txn_payload->flags & FD_TXN_P_FLAGS_BUNDLE) || (txn_payload->flags & FD_TXN_P_FLAGS_INITIALIZER_BUNDLE), FD_GUI_TXN_FLAGS_FROM_BUNDLE, 0U);
   }


### PR DESCRIPTION
Fixes txn flags bleeding between different entries, practically
meaning that FD_GUI_TXN_FLAGS_ENDED is set always after the GUI has
been up for a while
