### PR TITLE
cnc: align implementation with documentation

### DIFF
--- a/src/tango/cnc/fd_cnc.c
+++ b/src/tango/cnc/fd_cnc.c
@@ -298,7 +298,7 @@ fd_cnc_wait( fd_cnc_t const * cnc,
   ulong obs;
   for(;;) {
     obs = fd_cnc_signal_query( cnc );
-    int done = ((obs!=test) | ((now-then)>dt));
+    int done = ((obs!=test) | ((now-then)>=dt));
     FD_COMPILER_FORGET( done ); /* avoid compiler misoptimization */
     if( FD_LIKELY( done ) ) break; /* optimize for exit, single exit to optimize spin pause hinting */
     FD_YIELD();


### PR DESCRIPTION
The API says that dt<=0 polls once, but implementation uses ((now-then)>dt) with now==then initially, so for dt==0 and unchanged signal it always does at least one extra loop/yield.