### PR TITLE
bench: prevent re-computing agave_affinity_cnt value

### DIFF
--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -565,6 +565,7 @@ fd_topob_auto_layout_cpus( fd_topo_t *      topo,
     if( FD_UNLIKELY( !found ) ) FD_LOG_WARNING(( "auto layout cannot affine tile `%s:%lu` because it is unknown. Leaving it floating", tile->name, tile->kind_id ));
   }
 
+  topo->agave_affinity_cnt = 0UL;
   if( FD_UNLIKELY( reserve_agave_cores ) ) {
     for( ulong i=cpu_idx; i<cpus->cpu_cnt; i++ ) {
       if( FD_UNLIKELY( !cpus->cpu[ cpu_ordering[ i ] ].online ) ) continue;


### PR DESCRIPTION
Since the `bench` command calls the `fd_topob_auto_layout_cpus` a second time after boot (without calling `fd_topob_new` a second time as well), this value was getting calculated twice and was double the correct value. Fixes `fddev bench` command (also needs https://github.com/firedancer-io/firedancer/pull/8925)