### PR TITLE
restore: snapwm txn_commit cleanup

### DIFF
--- a/src/discof/restore/fd_snapwm_tile.c
+++ b/src/discof/restore/fd_snapwm_tile.c
@@ -225,7 +225,7 @@ handle_control_frag( fd_snapwm_tile_t *  ctx,
       ctx->state = FD_SNAPSHOT_STATE_FINISHING;
       fd_snapwm_vinyl_wd_fini( ctx );
       if( ctx->vinyl.txn_active ) {
-        fd_snapwm_vinyl_txn_commit( ctx, stem );
+        fd_snapwm_vinyl_txn_commit( ctx );
       }
       break;
     }

--- a/src/discof/restore/fd_snapwm_tile_private.h
+++ b/src/discof/restore/fd_snapwm_tile_private.h
@@ -24,7 +24,6 @@
 #define FD_SNAPWM_DUP_META_BATCH_SZ       (FD_SNAPWM_DUP_META_BATCH_CNT_MAX*FD_SNAPWM_DUP_META_SZ)
 
 #define FD_SNAPWM_DUP_BATCH_CREDIT_MIN  (1UL)
-#define FD_SNAPWM_DUP_LTHASH_CREDIT_MIN ((sizeof(fd_ssctrl_hash_result_t)+(ctx->hash_out.mtu-1))/ctx->hash_out.mtu)
 
 struct fd_snapwm_out_link {
   ulong         idx;
@@ -152,7 +151,10 @@ fd_snapwm_vinyl_reset( fd_snapwm_tile_t * ctx );
 /* fd_snapwm_vinyl_txn_begin starts a transactional burst write.
    Assumes vinyl uses the io_mm backend.  The write can then either be
    committed or cancelled.  There is no practical limit on the size of
-   this burst. */
+   this burst.  Vinyl txn_{begin,commit,cancel} cannot be invoked when
+   lthash verification is enabled, since a recovery mechanism on failed
+   snapshots becomes computationally expensive at runtime.  Further
+   details can be found in the recovery code inside the snapwm tile. */
 
 void
 fd_snapwm_vinyl_txn_begin( fd_snapwm_tile_t * ctx );
@@ -162,7 +164,7 @@ fd_snapwm_vinyl_txn_begin( fd_snapwm_tile_t * ctx );
    written since txn_begin was called and updates the vinyl_meta index. */
 
 void
-fd_snapwm_vinyl_txn_commit( fd_snapwm_tile_t * ctx, fd_stem_context_t * stem );
+fd_snapwm_vinyl_txn_commit( fd_snapwm_tile_t * ctx );
 
 /* fd_snapwm_vinyl_txn_cancel abandons a transactional burst write.
    Assumes vinyl uses the io_mm backend.  Reverts the bstream state to
@@ -243,36 +245,6 @@ fd_snapwm_vinyl_duplicate_accounts_batch_append( fd_snapwm_tile_t *        ctx,
 int
 fd_snapwm_vinyl_duplicate_accounts_batch_fini( fd_snapwm_tile_t *  ctx,
                                                fd_stem_context_t * stem );
-
-/* fd_snapwm_vinyl_duplicate_accounts_lthash_{init,append,fini} handle
-   duplicate accounts lthash local calculation when lthash computation
-   is enabled.  This is typically only needed when the account is an
-   "old" duplicate (meaning that it corresponds to an older slot than
-   what is currently in the database).  _fini is responsible for
-   sending the message downstream.
-
-   Typical usage:
-     fd_snapwm_vinyl_duplicate_accounts_lthash_init( ctx, stem );
-     for(...) {
-       ...
-       fd_snapwm_vinyl_duplicate_accounts_lthash_append( ctx, pair );
-     }
-     fd_snapwm_vinyl_duplicate_accounts_lthash_fini( ctx, stem );
-
-   They all return 1 on success, and 0 otherwise.
-
-   IMPORTANT: the fseq check happens only inside fini, since append
-   only operates on internal variables.  Therefore, it is safe to have
-   fd_stem_publish in between init and fini. */
-int
-fd_snapwm_vinyl_duplicate_accounts_lthash_init( fd_snapwm_tile_t *  ctx,
-                                                fd_stem_context_t * stem );
-int
-fd_snapwm_vinyl_duplicate_accounts_lthash_append( fd_snapwm_tile_t * ctx,
-                                                  uchar *            pair );
-int
-fd_snapwm_vinyl_duplicate_accounts_lthash_fini( fd_snapwm_tile_t *  ctx,
-                                                fd_stem_context_t * stem );
 
 /* fd_snapwm_vinyl_{init,update}_admin provide init and update helper
    functions on the vinyl admin object.  do_rwlock is a flag indicating

--- a/src/discof/restore/fd_snapwm_tile_vinyl.c
+++ b/src/discof/restore/fd_snapwm_tile_vinyl.c
@@ -301,6 +301,11 @@ fd_snapwm_vinyl_txn_begin( fd_snapwm_tile_t * ctx ) {
     return;
   }
 
+  if( FD_UNLIKELY( !ctx->lthash_disabled ) ) {
+    FD_LOG_CRIT(( "vinyl txn cannot be initialized when lthash verification is enabled" ));
+    return;
+  }
+
   /* Finish any outstanding writes */
   int commit_err = fd_vinyl_io_commit( io, FD_VINYL_IO_FLAG_BLOCKING );
   if( FD_UNLIKELY( commit_err ) ) FD_LOG_CRIT(( "fd_vinyl_io_commit failed (%i-%s)", commit_err, fd_vinyl_strerror( commit_err ) ));
@@ -309,41 +314,8 @@ fd_snapwm_vinyl_txn_begin( fd_snapwm_tile_t * ctx ) {
   ctx->vinyl.txn_active = 1;
 }
 
-FD_FN_UNUSED static void
-streamlined_hash( fd_snapwm_tile_t *  restrict ctx,
-                  fd_lthash_adder_t * restrict adder,
-                  fd_lthash_value_t * restrict running_lthash,
-                  uchar const *       restrict _pair ) {
-  uchar const * pair = _pair;
-  fd_vinyl_bstream_phdr_t const * phdr = (fd_vinyl_bstream_phdr_t const *)pair;
-  pair += sizeof(fd_vinyl_bstream_phdr_t);
-  fd_account_meta_t const * meta = (fd_account_meta_t const *)pair;
-  pair += sizeof(fd_account_meta_t);
-  uchar const * data = pair;
-
-  ulong data_len      = meta->dlen;
-  const char * pubkey = phdr->key.c;
-  ulong lamports      = meta->lamports;
-  const uchar * owner = meta->owner;
-  uchar executable = (uchar)( !meta->executable ? 0U : 1U) ;
-
-  if( FD_UNLIKELY( data_len > FD_RUNTIME_ACC_SZ_MAX ) ) FD_LOG_ERR(( "Found unusually large account (data_sz=%lu), aborting", data_len ));
-  if( FD_UNLIKELY( lamports==0UL ) ) return;
-
-  fd_lthash_adder_push_solana_account( adder,
-                                       running_lthash,
-                                       pubkey,
-                                       data,
-                                       data_len,
-                                       lamports,
-                                       executable,
-                                       owner );
-  ctx->vinyl.running_capitalization = fd_ulong_sat_add( ctx->vinyl.running_capitalization, lamports );
-}
-
 void
-fd_snapwm_vinyl_txn_commit( fd_snapwm_tile_t * ctx,
-                            fd_stem_context_t * stem ) {
+fd_snapwm_vinyl_txn_commit( fd_snapwm_tile_t * ctx ) {
   FD_CRIT( ctx->vinyl.txn_active, "txn_commit called while not in txn" );
   FD_CRIT( ctx->vinyl.io==ctx->vinyl.io_mm, "vinyl not in io_mm mode" );
   fd_vinyl_io_t * io = ctx->vinyl.io_mm;
@@ -377,9 +349,6 @@ fd_snapwm_vinyl_txn_commit( fd_snapwm_tile_t * ctx,
   }
 
   /* Replay incremental account updates */
-  fd_snapwm_vinyl_duplicate_accounts_batch_init( ctx, stem );
-  fd_snapwm_vinyl_duplicate_accounts_lthash_init( ctx, stem );
-  ulong dup_batch_cnt = 0UL;
 
   fd_vinyl_meta_t * meta_map = ctx->vinyl.map;
   for( ulong seq=txn_seq0; fd_vinyl_seq_lt( seq, txn_seq1 ); ) {
@@ -405,13 +374,8 @@ fd_snapwm_vinyl_txn_commit( fd_snapwm_tile_t * ctx,
         ulong cur_slot   = fd_snapin_vinyl_pair_info_slot( &phdr.info );
         if( exist_slot > cur_slot ) {
           ctx->metrics.accounts_ignored++;
-          FD_COMPILER_MFENCE();
-          fd_snapwm_vinyl_duplicate_accounts_lthash_append( ctx, (uchar*)block/*pair*/ );
-          FD_COMPILER_MFENCE();
           fd_memset( block, 0, block_sz );
           goto next;
-        } else {
-          dup_batch_cnt += (ulong)fd_snapwm_vinyl_duplicate_accounts_batch_append( ctx, &ele->phdr, ele->seq );
         }
         ctx->metrics.accounts_replaced++;
       } else {
@@ -440,21 +404,7 @@ fd_snapwm_vinyl_txn_commit( fd_snapwm_tile_t * ctx,
 
 next:
     seq += block_sz;
-
-    if( FD_UNLIKELY( dup_batch_cnt >= FD_SNAPWM_DUP_META_BATCH_CNT_MAX ) ) {
-      fd_snapwm_vinyl_duplicate_accounts_batch_fini( ctx, stem );
-      FD_COMPILER_MFENCE();
-      fd_snapwm_vinyl_duplicate_accounts_batch_init( ctx, stem );
-      dup_batch_cnt = 0UL;
-    }
   }
-
-  /* Batch fini must be invoked before lthash fini for two reasons:
-     the batch still needs to be processed downstream and there should
-     be no fd_stem_publish between batch init and fini. */
-  fd_snapwm_vinyl_duplicate_accounts_batch_fini( ctx, stem );
-  FD_COMPILER_MFENCE();
-  fd_snapwm_vinyl_duplicate_accounts_lthash_fini( ctx, stem );
 
   /* Persist above erases to disk */
 
@@ -765,44 +715,6 @@ fd_snapwm_vinyl_duplicate_accounts_batch_fini( fd_snapwm_tile_t * ctx,
   if( FD_UNLIKELY( !batch_sz ) ) return 0;
   fd_stem_publish( stem, ctx->hash_out.idx, FD_SNAPSHOT_HASH_MSG_SUB_META_BATCH, ctx->hash_out.chunk, batch_sz, 0UL, 0UL, batch_cnt/*tspub*/ );
   ctx->hash_out.chunk = fd_dcache_compact_next( ctx->hash_out.chunk, batch_sz, ctx->hash_out.chunk0, ctx->hash_out.wmark );
-  return 1;
-}
-
-int
-fd_snapwm_vinyl_duplicate_accounts_lthash_init( fd_snapwm_tile_t *  ctx,
-                                                fd_stem_context_t * stem ) {
-  if( FD_UNLIKELY( ctx->lthash_disabled ) ) return 0;
-  fd_lthash_zero( &ctx->vinyl.running_lthash );
-  ctx->vinyl.running_capitalization = 0UL;
-
-  (void)stem;
-  /* There is no fseq check in lthash_init, since append uses internal
-     adder and running_lthash, without accessing the dcache. */
-  return 1;
-}
-
-int
-fd_snapwm_vinyl_duplicate_accounts_lthash_append( fd_snapwm_tile_t * ctx,
-                                                  uchar *            pair ) {
-  if( FD_UNLIKELY( ctx->lthash_disabled ) ) return 0;
-  streamlined_hash( ctx, &ctx->vinyl.adder, &ctx->vinyl.running_lthash, pair );
-  return 1;
-}
-
-int
-fd_snapwm_vinyl_duplicate_accounts_lthash_fini( fd_snapwm_tile_t * ctx,
-                                               fd_stem_context_t * stem ) {
-  if( FD_UNLIKELY( ctx->lthash_disabled ) ) return 0;
-
-  /* fseq check is mandatory here. */
-  handle_hash_out_fseq_check( ctx, stem, FD_SNAPWM_DUP_LTHASH_CREDIT_MIN );
-
-  fd_lthash_adder_flush( &ctx->vinyl.adder, &ctx->vinyl.running_lthash );
-  fd_ssctrl_hash_result_t * res = fd_chunk_to_laddr( ctx->hash_out.mem, ctx->hash_out.chunk );
-  fd_memcpy( res->lthash.bytes, &ctx->vinyl.running_lthash, FD_LTHASH_LEN_BYTES );
-  res->capitalization = (long)ctx->vinyl.running_capitalization;
-  fd_stem_publish( stem, ctx->hash_out.idx, FD_SNAPSHOT_HASH_MSG_RESULT_SUB, ctx->hash_out.chunk, sizeof(fd_ssctrl_hash_result_t), 0UL, 0UL, 0UL );
-  ctx->hash_out.chunk = fd_dcache_compact_next( ctx->hash_out.chunk, sizeof(fd_ssctrl_hash_result_t), ctx->hash_out.chunk0, ctx->hash_out.wmark );
   return 1;
 }
 


### PR DESCRIPTION
snapwm vinyl `txn_commit` does not need to handle duplicates anymore, and a cleanup was pending after the latest upgrade.

Closes https://github.com/firedancer-io/firedancer/issues/8844.