### PR TITLE
restore: snapwm revert incr log update

### DIFF
--- a/src/discof/restore/fd_snapwm_tile_vinyl.c
+++ b/src/discof/restore/fd_snapwm_tile_vinyl.c
@@ -900,7 +900,7 @@ fd_snapwm_vinyl_revert_full( fd_snapwm_tile_t * ctx  ) {
 
 void
 fd_snapwm_vinyl_revert_incr( fd_snapwm_tile_t * ctx ) {
-  FD_CRIT( ctx->vinyl.txn_active, "txn_commit called while not in txn" );
+  FD_CRIT( !ctx->vinyl.txn_active, "revert_incr called while txn_active" );
   FD_CRIT( ctx->vinyl.io==ctx->vinyl.io_mm, "vinyl not in io_mm mode" );
   fd_vinyl_io_t * io = ctx->vinyl.io_mm;
 


### PR DESCRIPTION
Log / check correction.

Update: addressed point 14 in https://github.com/firedancer-io/firedancer/issues/9176.