### PR TITLE
bn254: minor tweak for easier coverage

### DIFF
--- a/src/ballet/bn254/fd_bn254.c
+++ b/src/ballet/bn254/fd_bn254.c
@@ -336,7 +336,7 @@ fd_bn254_pairing_is_one_syscall( uchar       out[32],
     }
     ++sz;
     /* Compute the Miller loop and aggregate into r */
-    if( sz==FD_BN254_PAIRING_BATCH_MAX || i==elements_len-1 ) {
+    if( sz==FD_BN254_PAIRING_BATCH_MAX ) {
       fd_bn254_fp12_t tmp[1];
       fd_bn254_miller_loop( tmp, p, q, sz );
       fd_bn254_fp12_mul( r, r, tmp );


### PR DESCRIPTION
Minor improvement to highlight code cov.

The condition `i==elements_len-1` is unnecessary because it's covered by the `if` block following the `for` loop.
(the `if` block is necessary due to `continue` inside the `for` loop).

Moreover, running standard cov tools the condition `i==elements_len-1` hides the other condition `sz==FD_BN254_PAIRING_BATCH_MAX`, at the risk of not testing that case.