### PR TITLE
ballet: speedup UTF-8 validation for all cases

### DIFF
--- a/src/ballet/utf8/fd_utf8.c
+++ b/src/ballet/utf8/fd_utf8.c
@@ -1,86 +1,235 @@
 #include "fd_utf8.h"
 
-/* Basic UTF-8 validator imported from Rust's core/src/str/validations.rs */
-
-/* FIXME: Add high-performance AVX version */
-
-static uchar const fd_utf8_char_width[ 256 ] = {
-  // 1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 1
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 2
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 3
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 4
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 5
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 6
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 7
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 8
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 9
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // A
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // B
-  0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // C
-  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // D
-  3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, // E
-  4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // F
+static uchar const fd_utf8_dfa[ 256 + 9*16 ] = {
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,
+  0xa,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x4,0x3,0x3,
+  0xb,0x6,0x6,0x6,0x5,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,
+  0x0,0x1,0x2,0x3,0x5,0x8,0x7,0x1,0x1,0x1,0x4,0x6,0x1,0x1,0x1,0x1,
+  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,0,1,0,1,1,1,1,1,1,
+  1,2,1,1,1,1,1,2,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1,
+  1,2,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,3,1,3,1,1,1,1,1,1,
+  1,3,1,1,1,1,1,3,1,3,1,1,1,1,1,1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
 };
+
+#if FD_HAS_AVX512
+#include "../../util/simd/fd_avx512.h"
+
+/* AVX512 UTF-8 validator based on https://arxiv.org/pdf/2010.03090
+   "Validating UTF-8 In Less Than One Instruction Per Byte"  */
+
+static inline wwb_t
+prev_carry( wwb_t cur,
+            wwb_t prev ) {
+  wwb_t idx = _mm512_set_epi64( 5, 4, 3, 2, 1, 0, 15, 14 );
+  return _mm512_permutex2var_epi64( cur, idx, prev );
+}
+
+static inline wwb_t
+prev1_byte( wwb_t cur,
+            wwb_t prev ) {
+  return _mm512_alignr_epi8( cur, prev_carry( cur, prev ), 15 );
+}
+
+static inline wwb_t
+prev2_byte( wwb_t cur,
+            wwb_t prev ) {
+  return _mm512_alignr_epi8( cur, prev_carry( cur, prev ), 14 );
+}
+
+static inline wwb_t
+prev3_byte( wwb_t cur,
+            wwb_t prev ) {
+  return _mm512_alignr_epi8( cur, prev_carry( cur, prev ), 13 );
+}
+
+/* Check for special-case invalid byte sequences.  These arise from
+   overlong encodings, surrogates, and codepoints > U+10FFFF.
+
+   After certain lead bytes, the valid range of the next byte is
+   restricted:
+    E0 xx: second byte must be in [A0,BF] (not [80,9F] -> overlong)
+    ED xx: second byte must be in [80,9F] (not [A0,BF] -> surrogates)
+    F0 xx: second byte must be in [90,BF] (not [80,8F] -> overlong)
+    F4 xx: second byte must be in [80,8F] (not [90,BF] -> out of range) */
+static inline wwb_t
+check_special( wwb_t cur,
+               wwb_t prev ) {
+  wwb_t prev_hi  = wwb_shr( prev, 4 );
+  wwb_t prev_lo  = wwb_and( prev, wwb_bcast( 0x0F ) );
+  wwb_t cur_hi   = wwb_shr( cur,  4 );
+
+  /* High nibble of prev: which category of checks apply.
+     nibble E -> bits 0,1 (overlong-3 / surrogate checks)
+     nibble F -> bits 2,3 (overlong-4 / too-large checks) */
+  wwb_t hi_lut = wwb_bcast_hex( 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x0C );
+
+  /* Low nibble of prev: which specific byte within the category.
+     0x0     -> bits 0,2   (E0 overlong-3, F0 overlong-4)
+     0x4     -> bit  3     (F4 too-large)
+     0x5-0xC -> bits 2,3   (F5-FC: entirely invalid, catch all conts)
+     0xD     -> bits 1,2,3 (ED surrogate; FD entirely invalid)
+     0xE-0xF -> bits 2,3   (FE-FF: entirely invalid)
+     The E-nibble category uses bits 0,1 so the bits 2,3 entries for
+     F5-FF do not interfere with E5-EF (0x03 & 0x0C == 0). */
+  wwb_t lo_lut = wwb_bcast_hex( 0x05, 0x00, 0x00, 0x00, 0x08, 0x0C, 0x0C, 0x0C,
+                                0x0C, 0x0C, 0x0C, 0x0C, 0x0C, 0x0E, 0x0C, 0x0C );
+
+  /* High nibble of cur: which continuation byte ranges are bad.
+     nibble 8 -> bits 0,2   (80..8F: bad after E0 and F0)
+     nibble 9 -> bits 0,3   (90..9F: bad after E0 and F4+)
+     nibble A -> bits 1,3   (A0..AF: bad after ED and F4+)
+     nibble B -> bits 1,3   (B0..BF: bad after ED and F4+) */
+  wwb_t cur_lut = wwb_bcast_hex( 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                 0x05, 0x09, 0x0A, 0x0A, 0x00, 0x00, 0x00, 0x00 );
+
+  wwb_t r1 = _mm512_shuffle_epi8( hi_lut,  prev_hi );
+  wwb_t r2 = _mm512_shuffle_epi8( lo_lut,  prev_lo );
+  wwb_t r3 = _mm512_shuffle_epi8( cur_lut, cur_hi  );
+  return _mm512_ternarylogic_epi64( r1, r2, r3, 0x80 ); /* r1 & r2 & r3 */
+}
+
+/* A 2-byte lead (110xxxxx, C2..DF) must be followed by 1 continuation.
+   A 3-byte lead (1110xxxx, E0..EF) must be followed by 2 continuations.
+   A 4-byte lead (11110xxx, F0..F4) must be followed by 3 continuations. */
+static inline wwb_t
+check_continuations( wwb_t cur,
+                     wwb_t prev ) {
+  wwb_t p1 = prev1_byte( cur, prev );
+  wwb_t p2 = prev2_byte( cur, prev );
+  wwb_t p3 = prev3_byte( cur, prev );
+
+  /* 2+ byte lead: byte >= C2 (C0,C1 are overlong, never valid)
+     3+ byte lead: byte >= E0
+     4  byte lead: byte >= F0 (only F0..F4 valid, but DFA handles that) */
+  wwb_t is_2_3_4_lead = wwb_subs( p1, wwb_bcast( 0xC1 ) );
+  wwb_t is_3_4_lead   = wwb_subs( p2, wwb_bcast( 0xDF ) );
+  wwb_t is_4_lead     = wwb_subs( p3, wwb_bcast( 0xEF ) );
+
+  /* OR all together */
+  wwb_t must_be_cont = _mm512_ternarylogic_epi64( is_2_3_4_lead,
+                                                    is_3_4_lead,
+                                                      is_4_lead, 0xFE );
+
+  /* is_cont = sub(byte ^ 0x80, 0x3F). 0 means IS continuation, otherwise NOT. */
+  wwb_t xor     = wwb_xor( cur, wwb_bcast( 0x80 ) );
+  wwb_t is_cont = wwb_subs( xor, wwb_bcast( 0x3F ) );
+
+  ulong must_mask = wwb_ne( must_be_cont, wwb_zero() );
+  ulong cont_mask = wwb_eq( is_cont,      wwb_zero() );
+  return _mm512_movm_epi8( must_mask ^ cont_mask );
+}
 
 FD_FN_PURE int
 fd_utf8_verify( char const * str,
                 ulong        sz ) {
 
-  uchar const *       cur = (uchar const *)str;
-  if( FD_UNLIKELY( cur==NULL ) ) {
-    return 1;
+  uchar const * cur = (uchar const *)str;
+  if( FD_UNLIKELY( cur==NULL ) ) return !sz;
+  uchar const * const end = cur + sz;
+
+  wwb_t prev_chunk = wwb_zero();
+  wwb_t error      = wwb_zero();
+
+  while( cur+64<=end ) { /* While we have a zmm register of unicode left. */
+    wwb_t chunk = wwb_ldu( cur );
+
+    /* Fast path, we've loaded an entire chunk of ASCII */
+    if( FD_LIKELY( !_mm512_test_epi8_mask( chunk, wwb_bcast( 0x80 ) ) ) ) {
+      /* Make sure we aren't mid-sequence from the previous chunk.
+         If prev_chunk ended with a lead byte (>= C2), that's an error
+         because the expected continuations landed in this all-ASCII chunk.
+
+         check_continuations() would have caught this, but we skip it on
+         the fast path, so check if any byte in prev_chunk's last 3
+         positions is a lead byte. */
+      wwb_t p1 = prev1_byte( chunk, prev_chunk );
+      wwb_t p2 = prev2_byte( chunk, prev_chunk );
+      wwb_t p3 = prev3_byte( chunk, prev_chunk );
+
+      error = wwb_or( error, wwb_subs( p1, wwb_bcast( 0xC1 ) ) );
+      error = wwb_or( error, wwb_subs( p2, wwb_bcast( 0xDF ) ) );
+      error = wwb_or( error, wwb_subs( p3, wwb_bcast( 0xEF ) ) );
+
+      prev_chunk = chunk;
+      cur += 64;
+      continue;
+    }
+
+    error = wwb_or( error, check_special( chunk, prev1_byte( chunk, prev_chunk ) ) );
+    error = wwb_or( error, check_continuations( chunk, prev_chunk ) );
+    /* C0 and C1 are not valid in any context (overlong 2-byte leads).
+       check_continuations skips them (threshold 0xC2), so detect them
+       explicitly. (byte & 0xFE) == 0xC0 matches exactly C0 and C1. */
+    error = wwb_or( error, _mm512_movm_epi8(
+        wwb_eq( wwb_and( chunk, wwb_bcast( 0xFE ) ), wwb_bcast( 0xC0 ) ) ) );
+    prev_chunk = chunk;
+    cur += 64;
   }
 
-  uchar const * const end = cur+sz;
+  if( cur >= end ) {
+    /* No tail bytes remain, so we check for an incomplete sequence at
+       the end of the last chunk. We simply ignore all bytes other than
+       the 4/3/2-byte leads. */
+    wwb_t max_val = wwb(
+      -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+      -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+      -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+      -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+      (char)0xEF, (char)0xDF, (char)0xBF );
+    error = wwb_or( error, wwb_subs( prev_chunk, max_val ) );
+  }
 
-  while( cur<end ) {
-    uint c0 = *cur;
-    if( c0>=0x80U ) {
-      ulong width = fd_utf8_char_width[ c0 ];
-      if( FD_UNLIKELY( width > (ulong)(end-cur) ) )
-        return 0;
-      cur++;
-      switch( width ) {
-      case 2: {
-        schar c1 = (schar)( *cur++ );
-        if( FD_UNLIKELY( (c1>=-64) ) )
-          return 0;
-        break;
-      }
-      case 3: {
-        uint c1 =          *cur++;
-         int c2 = (schar)( *cur++ );
-        if( FD_UNLIKELY(
-            !(   ( (c0==0xe0)&           (c1>=0xa0)&(c1<=0xbf) )
-               | ( (c0>=0xe1)&(c0<=0xec)&(c1>=0x80)&(c1<=0xbf) )
-               | ( (c0==0xed)&           (c1>=0x80)&(c1<=0x9f) )
-               | ( (c0>=0xee)&(c0<=0xef)&(c1>=0x80)&(c1<=0xbf) ) )
-            | (c2>=-64) ) )
-          return 0;
-        break;
-      }
-      case 4: {
-        uint c1 =          *cur++;
-         int c2 = (schar)( *cur++ );
-         int c3 = (schar)( *cur++ );
-        if( FD_UNLIKELY(
-            !(   ( (c0==0xf0)&           (c1>=0x90)&(c1<=0xbf) )
-               | ( (c0>=0xf1)&(c0<=0xf3)&(c1>=0x80)&(c1<=0xbf) )
-               | ( (c0==0xf4)&           (c1>=0x80)&(c1<=0x8f) ) )
-            | (c2>=-64)
-            | (c3>=-64) ) )
-          return 0;
-        break;
-      }
-      default:
-        return 0;
-      }
-    } else {
-      cur++;
+  if( FD_UNLIKELY( _mm512_test_epi8_mask( error, error ) ) ) return 0;
+
+  if( cur < end ) {
+    /* There are still tail bytes left, which could contain an
+       incomplete multi-byte sequence from the end of the last SIMD
+       chunk. We need to backup the current pointer so that the DFA
+       will re-validate, starting from a known valid point. */
+    uchar const * base = (uchar const *)str;
+    if( cur > base ) {
+      if(      cur[-1] >= 0xC0U )
+        cur -= 1;
+      else if( cur[-1] >= 0x80U && cur > base+1 && cur[-2] >= 0xE0U )
+        cur -= 2;
+      else if( cur[-1] >= 0x80U && cur > base+2 &&
+               cur[-2] >= 0x80U && cur[-3] >= 0xF0U )
+        cur -= 3;
     }
+    uint state = 0;
+    while( cur<end ) {
+      uint type = fd_utf8_dfa[ *cur++ ];
+      state = fd_utf8_dfa[ 256 + state*16 + type ];
+    }
+    if( state!=0 ) return 0;
   }
 
   return 1;
 }
+
+#else
+
+FD_FN_PURE int
+fd_utf8_verify( char const * str,
+                ulong        sz ) {
+
+  uchar const * cur = (uchar const *)str;
+  if( FD_UNLIKELY( cur==NULL ) ) return !sz;
+  uchar const * const end = cur + sz;
+
+  uint state = 0;
+  while( cur<end ) {
+    uint type = fd_utf8_dfa[ *cur++ ];
+    state = fd_utf8_dfa[ 256 + state*16 + type ];
+  }
+  return state == 0;
+}
+
+#endif /* FD_HAS_AVX512 */

--- a/src/ballet/utf8/fd_utf8.h
+++ b/src/ballet/utf8/fd_utf8.h
@@ -34,7 +34,8 @@ FD_PROTOTYPES_BEGIN
 
    str points to the first byte of the UTF-8 string (not a C string).
    sz is the number of bytes in the string.  Assumes that str+sz does
-   not overflow.  str is ignored if sz==0UL. */
+   not overflow.  str may be NULL only when sz==0UL;  NULL with
+   nonzero sz is rejected. */
 
 FD_FN_PURE int
 fd_utf8_verify( char const * str,

--- a/src/ballet/utf8/test_utf8.c
+++ b/src/ballet/utf8/test_utf8.c
@@ -6,11 +6,42 @@ struct fd_utf8_test_vector {
   uint         sz;
   int          result;
 };
-
 typedef struct fd_utf8_test_vector fd_utf8_test_vector_t;
 
+struct fd_utf8_patch {
+  ushort idx;
+  uchar  val;
+};
+typedef struct fd_utf8_patch fd_utf8_patch_t;
+
+struct fd_utf8_buf_case {
+  char const *    name;
+  ushort          sz;
+  uchar           fill;
+  uchar           patch_cnt;
+  uchar           expect;
+  fd_utf8_patch_t patch[ 8 ];
+};
+typedef struct fd_utf8_buf_case fd_utf8_buf_case_t;
+
+
+static void
+run_utf8_buf_cases( uchar *                    buf,
+                    fd_utf8_buf_case_t const * tc,
+                    ulong                      tc_cnt ) {
+  for( ulong i=0UL; i<tc_cnt; i++ ) {
+    fd_utf8_buf_case_t const * c = tc + i;
+    fd_memset( buf, c->fill, c->sz );
+    for( ulong j=0UL; j<c->patch_cnt; j++ ) buf[ c->patch[j].idx ] = c->patch[j].val;
+
+    int got = fd_utf8_verify( (char const *)buf, c->sz );
+    if( FD_UNLIKELY( got!=c->expect ) )
+      FD_LOG_ERR(( "%s (sz=%u got=%d expect=%u)", c->name, (uint)c->sz, got, (uint)c->expect ));
+    }
+}
+
 /* Test vectors imported from
-   https://github.com/rust-lang/rust/blob/master/library/alloc/tests/str.rs */
+   https://github.com/rust-lang/rust/blob/8b86f48958be8c3473c979e0b5504c2d2e0fd4fd/library/alloctests/tests/str.rs#L860 */
 
 static fd_utf8_test_vector_t const _single_glyph_vec[] = {
   { "\xc0\x80",         2UL, 0 },
@@ -34,30 +65,24 @@ static fd_utf8_test_vector_t const _single_glyph_vec[] = {
   {0}
 };
 
-int
-main( int     argc,
-      char ** argv ) {
-  fd_boot( &argc, &argv );
-
-  /* Check single glyphs */
-
+static void
+test_single_glyphs( void ) {
   FD_TEST( fd_utf8_verify( NULL, 0UL )==1 );
   for( fd_utf8_test_vector_t const * vec = _single_glyph_vec; vec->input; vec++ ) {
     FD_TEST( fd_utf8_verify( vec->input, vec->sz ) == vec->result );
 
     for( ulong sz=1UL; sz < vec->sz; sz++ ) {
-      /* Smaller size */
       FD_TEST( fd_utf8_verify( vec->input, sz )==0 );
-      /* Insert null byte */
       char input[ 8 ];
       fd_memcpy( input, vec->input, vec->sz );
       input[ sz-1UL ] = '\0';
       FD_TEST( fd_utf8_verify( input, vec->sz )==0 );
     }
   }
+}
 
-  /* Check any combination of (single glyph, single glyph) -- O(n^2) */
-
+static void
+test_glyph_pairs( void ) {
   for( fd_utf8_test_vector_t const * vec0 = _single_glyph_vec; vec0->input; vec0++ ) {
     for( fd_utf8_test_vector_t const * vec1 = _single_glyph_vec; vec1->input; vec1++ ) {
       char  input[8];
@@ -73,16 +98,16 @@ main( int     argc,
       FD_TEST( fd_utf8_verify( input, input_sz ) == (vec0->result & vec1->result) );
     }
   }
+}
 
-  /* Prevent OOB reads (caught by ASan) */
-
+static void
+test_oob( void ) {
   for( ulong j=0UL; j<=UCHAR_MAX; j++ ) {
     uchar oob[1] = { (uchar)j };
     int res = fd_utf8_verify( (char const *)oob, 1 );
-    FD_TEST( res==0 || res==1 );  /* prevent optimizing out value */
+    FD_TEST( res==0 || res==1 );
   }
 
-  /* Explicit test that \0 in the middle is a valid utf8 string */
   uchar t0[17] = { 0x67, 0x72, 0xc3, 0xbc, 0x65, 0x7a, 0x69, 0x00, 0x0a, 0xf0, 0x9f, 0x94, 0xa5, 0xf0, 0x9f, 0x92, 0x83 };
   FD_TEST( fd_utf8_verify( (char const *)t0, 17 ) );
 
@@ -94,9 +119,289 @@ main( int     argc,
 
   uchar oob4[3] = { (uchar)0xf0, (uchar)0x90, (uchar)0x80 };
   FD_TEST( !fd_utf8_verify( (char const *)oob4, 3 ) );
+}
+
+static void
+test_avx512_boundaries( void ) {
+  uchar buf[ 256 ];
+  static fd_utf8_buf_case_t const tc[] = {
+    { "lane boundary 15-16 2-byte",   64U, 'A', 2U, 1U, {{15U,0xC3U},{16U,0xA9U}} },
+    { "lane boundary 14-16 3-byte",   64U, 'A', 3U, 1U, {{14U,0xE1U},{15U,0x9BU},{16U,0x89U}} },
+    { "lane boundary 13-16 4-byte",   64U, 'A', 4U, 1U, {{13U,0xF0U},{14U,0x90U},{15U,0x80U},{16U,0x80U}} },
+    { "lane boundary 31-32 2-byte",   64U, 'A', 2U, 1U, {{31U,0xC3U},{32U,0xA9U}} },
+    { "lane boundary 47-48 2-byte",   64U, 'A', 2U, 1U, {{47U,0xC3U},{48U,0xA9U}} },
+    { "tail boundary 63-64 2-byte",   66U, 'A', 2U, 1U, {{63U,0xC3U},{64U,0xA9U}} },
+    { "tail boundary 62-64 3-byte",   66U, 'A', 3U, 1U, {{62U,0xE1U},{63U,0x9BU},{64U,0x89U}} },
+    { "tail boundary 61-64 4-byte",   66U, 'A', 4U, 1U, {{61U,0xF0U},{62U,0x90U},{63U,0x80U},{64U,0x80U}} },
+    { "chunk boundary 63-64 2-byte", 128U, 'A', 2U, 1U, {{63U,0xC3U},{64U,0xA9U}} },
+    { "stray continuation in SIMD",   64U, 'A', 1U, 0U, {{20U,0x80U}} },
+    { "incomplete 2-byte at sz 64",   64U, 'A', 1U, 0U, {{63U,0xC3U}} },
+    { "overlong E0 80 80",            64U, 'A', 3U, 0U, {{20U,0xE0U},{21U,0x80U},{22U,0x80U}} },
+    { "surrogate ED A0 80",           64U, 'A', 3U, 0U, {{20U,0xEDU},{21U,0xA0U},{22U,0x80U}} },
+    { "too large F4 A0 80 80",        64U, 'A', 4U, 0U, {{20U,0xF4U},{21U,0xA0U},{22U,0x80U},{23U,0x80U}} },
+    { "too large F4 BF 80 80",        64U, 'A', 4U, 0U, {{20U,0xF4U},{21U,0xBFU},{22U,0x80U},{23U,0x80U}} },
+    { "max valid F4 8F BF BF",        64U, 'A', 4U, 1U, {{20U,0xF4U},{21U,0x8FU},{22U,0xBFU},{23U,0xBFU}} },
+    { "invalid lead F5",              64U, 'A', 4U, 0U, {{20U,0xF5U},{21U,0x80U},{22U,0x80U},{23U,0x80U}} },
+    { "invalid lead F7",              64U, 'A', 4U, 0U, {{20U,0xF7U},{21U,0x80U},{22U,0x80U},{23U,0x80U}} },
+    { "invalid lead FE",              64U, 'A', 4U, 0U, {{20U,0xFEU},{21U,0x80U},{22U,0x80U},{23U,0x80U}} },
+    { "invalid lead FF",              64U, 'A', 4U, 0U, {{20U,0xFFU},{21U,0x80U},{22U,0x80U},{23U,0x80U}} },
+    { "invalid C0",                   64U, 'A', 1U, 0U, {{20U,0xC0U}} },
+    { "invalid C1",                   64U, 'A', 1U, 0U, {{20U,0xC1U}} },
+  };
+
+  run_utf8_buf_cases( buf, tc, sizeof(tc)/sizeof(tc[0]) );
+
+  FD_LOG_NOTICE(( "test_avx512_boundaries passed" ));
+}
+
+/* Exhaustive edge-case tests derived from comparison with the simdutf
+   reference implementation (icelake_utf8_validation.inl.cpp). */
+static void
+test_edge_cases( void ) {
+  uchar buf[ 512 ];
+  static fd_utf8_buf_case_t const tc[] = {
+    { "eof 64 incomplete C3",             64U, 'A', 1U, 0U, {{63U,0xC3U}} },
+    { "eof 64 incomplete E1",             64U, 'A', 1U, 0U, {{63U,0xE1U}} },
+    { "eof 64 incomplete F1",             64U, 'A', 1U, 0U, {{63U,0xF1U}} },
+    { "eof 64 incomplete E1 9B",          64U, 'A', 2U, 0U, {{62U,0xE1U},{63U,0x9BU}} },
+    { "eof 64 incomplete F0 90",          64U, 'A', 2U, 0U, {{62U,0xF0U},{63U,0x90U}} },
+    { "eof 64 incomplete F0 90 80",       64U, 'A', 3U, 0U, {{61U,0xF0U},{62U,0x90U},{63U,0x80U}} },
+    { "eof 64 complete C3 A9",            64U, 'A', 2U, 1U, {{62U,0xC3U},{63U,0xA9U}} },
+    { "eof 64 complete E1 9B 89",         64U, 'A', 3U, 1U, {{61U,0xE1U},{62U,0x9BU},{63U,0x89U}} },
+    { "eof 64 complete F0 90 80 80",      64U, 'A', 4U, 1U, {{60U,0xF0U},{61U,0x90U},{62U,0x80U},{63U,0x80U}} },
+    { "eof 128 incomplete C3",           128U, 'A', 1U, 0U, {{127U,0xC3U}} },
+    { "eof 128 incomplete E1",           128U, 'A', 1U, 0U, {{127U,0xE1U}} },
+    { "eof 128 incomplete F1",           128U, 'A', 1U, 0U, {{127U,0xF1U}} },
+    { "eof 128 incomplete E1 9B",        128U, 'A', 2U, 0U, {{126U,0xE1U},{127U,0x9BU}} },
+    { "eof 128 incomplete F0 90 80",     128U, 'A', 3U, 0U, {{125U,0xF0U},{126U,0x90U},{127U,0x80U}} },
+    { "cross chunk C3 A9",               128U, 'A', 2U, 1U, {{63U,0xC3U},{64U,0xA9U}} },
+    { "cross chunk E1 9B 89 from 62",    128U, 'A', 3U, 1U, {{62U,0xE1U},{63U,0x9BU},{64U,0x89U}} },
+    { "cross chunk E1 9B 89 from 63",    128U, 'A', 3U, 1U, {{63U,0xE1U},{64U,0x9BU},{65U,0x89U}} },
+    { "cross chunk F0 from 61",          128U, 'A', 4U, 1U, {{61U,0xF0U},{62U,0x90U},{63U,0x80U},{64U,0x80U}} },
+    { "cross chunk F0 from 62",          128U, 'A', 4U, 1U, {{62U,0xF0U},{63U,0x90U},{64U,0x80U},{65U,0x80U}} },
+    { "cross chunk F0 from 63",          128U, 'A', 4U, 1U, {{63U,0xF0U},{64U,0x90U},{65U,0x80U},{66U,0x80U}} },
+    { "cross chunk missing cont",        128U, 'A', 1U, 0U, {{63U,0xC3U}} },
+    { "cross chunk missing 3rd",         128U, 'A', 2U, 0U, {{63U,0xE1U},{64U,0x9BU}} },
+    { "cross chunk missing 4th",         128U, 'A', 3U, 0U, {{63U,0xF0U},{64U,0x90U},{65U,0x80U}} },
+    { "ascii after incomplete C3",       128U, 'A', 3U, 0U, {{10U,0xC3U},{11U,0xA9U},{63U,0xC3U}} },
+    { "ascii after incomplete E1",       128U, 'A', 4U, 0U, {{10U,0xC3U},{11U,0xA9U},{62U,0xE1U},{63U,0x9BU}} },
+    { "ascii after incomplete F0",       128U, 'A', 5U, 0U, {{10U,0xC3U},{11U,0xA9U},{61U,0xF0U},{62U,0x90U},{63U,0x80U}} },
+    { "tail 65 C3 A9",                    65U, 'A', 2U, 1U, {{63U,0xC3U},{64U,0xA9U}} },
+    { "tail 67 E1 9B 89",                 67U, 'A', 3U, 1U, {{63U,0xE1U},{64U,0x9BU},{65U,0x89U}} },
+    { "tail 67 F0 90 80 80",              67U, 'A', 4U, 1U, {{63U,0xF0U},{64U,0x90U},{65U,0x80U},{66U,0x80U}} },
+    { "tail 65 incomplete E1 9B",         65U, 'A', 2U, 0U, {{63U,0xE1U},{64U,0x9BU}} },
+    { "tail 66 incomplete F0 90 80",      66U, 'A', 3U, 0U, {{63U,0xF0U},{64U,0x90U},{65U,0x80U}} },
+    { "bare continuation at 0",           64U, 'A', 1U, 0U, {{ 0U,0x80U}} },
+    { "bare continuation at 63",          64U, 'A', 1U, 0U, {{63U,0x80U}} },
+    { "bare continuation at 64",         128U, 'A', 1U, 0U, {{64U,0x80U}} },
+    { "multiple stray continuations",     64U, 'A', 3U, 0U, {{10U,0x80U},{11U,0x80U},{12U,0x80U}} },
+    { "bare continuation BF",             64U, 'A', 1U, 0U, {{30U,0xBFU}} },
+    { "C3 followed by ASCII",             64U, 'A', 1U, 0U, {{20U,0xC3U}} },
+    { "E1 followed by ASCII",             64U, 'A', 1U, 0U, {{20U,0xE1U}} },
+    { "E1 9B followed by ASCII",          64U, 'A', 2U, 0U, {{20U,0xE1U},{21U,0x9BU}} },
+    { "F0 followed by ASCII",             64U, 'A', 1U, 0U, {{20U,0xF0U}} },
+    { "F0 90 80 followed by ASCII",       64U, 'A', 3U, 0U, {{20U,0xF0U},{21U,0x90U},{22U,0x80U}} },
+    { "lead followed by lead",            64U, 'A', 3U, 0U, {{20U,0xC3U},{21U,0xC3U},{22U,0xA9U}} },
+    { "C0 80",                            64U, 'A', 2U, 0U, {{20U,0xC0U},{21U,0x80U}} },
+    { "C1 BF",                            64U, 'A', 2U, 0U, {{20U,0xC1U},{21U,0xBFU}} },
+    { "C0 followed by ASCII",             64U, 'A', 1U, 0U, {{20U,0xC0U}} },
+    { "C1 at end of 64-byte chunk",       64U, 'A', 1U, 0U, {{63U,0xC1U}} },
+    { "C0 across chunk boundary",        128U, 'A', 2U, 0U, {{63U,0xC0U},{64U,0x80U}} },
+    { "E0 9F BF",                         64U, 'A', 3U, 0U, {{20U,0xE0U},{21U,0x9FU},{22U,0xBFU}} },
+    { "E0 A0 80",                         64U, 'A', 3U, 1U, {{20U,0xE0U},{21U,0xA0U},{22U,0x80U}} },
+    { "ED 9F BF",                         64U, 'A', 3U, 1U, {{20U,0xEDU},{21U,0x9FU},{22U,0xBFU}} },
+    { "ED A0 80",                         64U, 'A', 3U, 0U, {{20U,0xEDU},{21U,0xA0U},{22U,0x80U}} },
+    { "ED BF BF",                         64U, 'A', 3U, 0U, {{20U,0xEDU},{21U,0xBFU},{22U,0xBFU}} },
+    { "F0 8F BF BF",                      64U, 'A', 4U, 0U, {{20U,0xF0U},{21U,0x8FU},{22U,0xBFU},{23U,0xBFU}} },
+    { "F0 90 80 80",                      64U, 'A', 4U, 1U, {{20U,0xF0U},{21U,0x90U},{22U,0x80U},{23U,0x80U}} },
+    { "F4 8F BF BF",                      64U, 'A', 4U, 1U, {{20U,0xF4U},{21U,0x8FU},{22U,0xBFU},{23U,0xBFU}} },
+    { "F4 90 80 80",                      64U, 'A', 4U, 0U, {{20U,0xF4U},{21U,0x90U},{22U,0x80U},{23U,0x80U}} },
+  };
+
+  run_utf8_buf_cases( buf, tc, sizeof(tc)/sizeof(tc[0]) );
+
+  for( uint lead = 0xF5U; lead <= 0xFFU; lead++ ) {
+    fd_memset( buf, 'A', 64 );
+    buf[20] = (uchar)lead; buf[21] = 0x80; buf[22] = 0x80; buf[23] = 0x80;
+    FD_TEST( fd_utf8_verify( (char const *)buf, 64 )==0 );
+  }
+
+  /* Small inputs. */
+  FD_TEST( fd_utf8_verify( "", 0 )==1 );
+  FD_TEST( fd_utf8_verify( "A", 1 )==1 );
+  FD_TEST( fd_utf8_verify( "\xC3\xA9", 2 )==1 );
+  FD_TEST( fd_utf8_verify( "\xE1\x9B\x89", 3 )==1 );
+  FD_TEST( fd_utf8_verify( "\xF0\x90\x80\x80", 4 )==1 );
+  FD_TEST( fd_utf8_verify( "\x80", 1 )==0 );
+  FD_TEST( fd_utf8_verify( "\xC3", 1 )==0 );
+  FD_TEST( fd_utf8_verify( "\xE1\x9B", 2 )==0 );
+  FD_TEST( fd_utf8_verify( "\xF0\x90\x80", 3 )==0 );
+
+  {
+    /* Fill 64 bytes with valid 2-byte sequences (32 of them) */
+    for( ulong i=0; i<64; i+=2 ) { buf[i] = 0xC3; buf[i+1] = 0xA9; }
+    FD_TEST( fd_utf8_verify( (char const *)buf, 64 )==1 );
+  }
+  {
+    /* Fill 192 bytes with valid 3-byte sequences */
+    for( ulong i=0; i<192; i+=3 ) { buf[i] = 0xE1; buf[i+1] = 0x9B; buf[i+2] = 0x89; }
+    FD_TEST( fd_utf8_verify( (char const *)buf, 192 )==1 );
+  }
+  {
+    /* Fill 256 bytes with valid 4-byte sequences */
+    for( ulong i=0; i<256; i+=4 ) { buf[i] = 0xF0; buf[i+1] = 0x90; buf[i+2] = 0x80; buf[i+3] = 0x80; }
+    FD_TEST( fd_utf8_verify( (char const *)buf, 256 )==1 );
+  }
+
+  {
+    fd_memset( buf, 'A', 256 );
+    /* Sprinkle valid multi-byte at various positions */
+    buf[10] = 0xC3; buf[11] = 0xA9;       /* 2-byte in chunk 0 */
+    buf[50] = 0xE1; buf[51] = 0x9B; buf[52] = 0x89; /* 3-byte in chunk 0 */
+    buf[63] = 0xC3; buf[64] = 0xA9;       /* 2-byte crossing chunk 0-1 */
+    buf[100] = 0xF0; buf[101] = 0x90; buf[102] = 0x80; buf[103] = 0x80; /* 4-byte in chunk 1 */
+    buf[127] = 0xE1; buf[128] = 0x9B; buf[129] = 0x89; /* 3-byte crossing chunk 1-2 */
+    buf[200] = 0xC3; buf[201] = 0xA9;     /* 2-byte in chunk 3 */
+    FD_TEST( fd_utf8_verify( (char const *)buf, 256 )==1 );
+  }
+
+  {
+    fd_memset( buf, 'A', 64 );
+    buf[20] = 0x00;
+    FD_TEST( fd_utf8_verify( (char const *)buf, 64 )==1 );
+  }
+  {
+    fd_memset( buf, 0x00, 64 );
+    FD_TEST( fd_utf8_verify( (char const *)buf, 64 )==1 );
+  }
+
+  for( uint b=0; b<=0xFF; b++ ) {
+    uchar byte = (uchar)b;
+    int expect = (b < 0x80) ? 1 : 0;
+    FD_TEST( fd_utf8_verify( (char const *)&byte, 1 )==expect );
+  }
+
+  FD_LOG_NOTICE(( "test_edge_cases passed" ));
+}
+
+static void
+test_null_input_semantics( void ) {
+  FD_TEST( fd_utf8_verify( NULL, 0UL )==1 );
+  FD_TEST( fd_utf8_verify( NULL, 1UL )==0 );
+  FD_TEST( fd_utf8_verify( NULL, 64UL )==0 );
+}
+
+static void
+bench_utf8_verify( uchar const * buf,
+                   ulong         buf_sz,
+                   char const *  label ) {
+  static ulong const sizes[] = { 32UL, 128UL, 512UL, 1024UL, 4096UL };
+
+  FD_LOG_NOTICE(( "Benchmarking fd_utf8_verify (%s)", label ));
+  for( ulong idx=0UL; idx<sizeof(sizes)/sizeof(sizes[0]); idx++ ) {
+    ulong sz = sizes[ idx ];
+    if( sz>buf_sz ) break;
+
+    for( ulong rem=1000UL; rem; rem-- ) {
+      int r = fd_utf8_verify( (char const *)buf, sz );
+      FD_COMPILER_UNPREDICTABLE( r );
+    }
+
+    ulong iter = 1000000UL;
+    long  dt   = -fd_log_wallclock();
+    for( ulong rem=iter; rem; rem-- ) {
+      int r = fd_utf8_verify( (char const *)buf, sz );
+      FD_COMPILER_UNPREDICTABLE( r );
+    }
+    dt += fd_log_wallclock();
+    double ns_per_call = (double)dt / (double)iter;
+    double gbps        = ((double)(8UL*sz*iter)) / ((double)dt);
+    FD_LOG_NOTICE(( "  sz %4lu: ~%8.3f ns/call  ~%6.3f Gbps", sz, ns_per_call, gbps ));
+  }
+}
+
+static void
+fill_ascii( uchar * buf, ulong sz, fd_rng_t * rng ) {
+  for( ulong i=0UL; i<sz; i++ ) buf[i] = (uchar)( 0x20U + (fd_rng_uint( rng ) % 0x5fU) );
+}
+
+static void
+fill_mixed_utf8( uchar * buf, ulong sz, fd_rng_t * rng ) {
+  ulong j = 0UL;
+  while( j<sz ) {
+    ulong j0 = j;
+    uint  r  = fd_rng_uint( rng ) % 4U;
+    if( r==0U ) {
+      buf[j++] = (uchar)(0x20U + (fd_rng_uint( rng ) % 0x5fU));
+    } else if( r==1U && j+1UL<sz ) {
+      buf[j++] = (uchar)(0xc2U + (fd_rng_uint( rng ) % 0x1eU));
+      buf[j++] = (uchar)(0x80U + (fd_rng_uint( rng ) % 0x40U));
+    } else if( r==2U && j+2UL<sz ) {
+      buf[j++] = (uchar)0xe1U;
+      buf[j++] = (uchar)(0x80U + (fd_rng_uint( rng ) % 0x40U));
+      buf[j++] = (uchar)(0x80U + (fd_rng_uint( rng ) % 0x40U));
+    } else if( r==3U && j+3UL<sz ) {
+      buf[j++] = (uchar)0xf1U;
+      buf[j++] = (uchar)(0x80U + (fd_rng_uint( rng ) % 0x40U));
+      buf[j++] = (uchar)(0x80U + (fd_rng_uint( rng ) % 0x40U));
+      buf[j++] = (uchar)(0x80U + (fd_rng_uint( rng ) % 0x40U));
+    }
+    if( j==j0 ) {
+      buf[j++] = (uchar)(0x20U + (fd_rng_uint( rng ) % 0x5fU));
+    }
+  }
+}
+
+static void
+bench_early_reject( uchar const * ascii_buf ) {
+  uchar bad_buf[ 4096 ];
+  fd_memcpy( bad_buf, ascii_buf, sizeof(bad_buf) );
+  bad_buf[0] = 0x80U;
+
+  FD_LOG_NOTICE(( "Benchmarking fd_utf8_verify (early reject)" ));
+
+  for( ulong rem=1000UL; rem; rem-- ) {
+    int r = fd_utf8_verify( (char const *)bad_buf, 4096UL );
+    FD_COMPILER_UNPREDICTABLE( r );
+  }
+
+  ulong iter = 10000000UL;
+  long  dt   = -fd_log_wallclock();
+  for( ulong rem=iter; rem; rem-- ) {
+    int r = fd_utf8_verify( (char const *)bad_buf, 4096UL );
+    FD_COMPILER_UNPREDICTABLE( r );
+  }
+  dt += fd_log_wallclock();
+  double ns_per_call = (double)dt / (double)iter;
+  FD_LOG_NOTICE(( "  ~%8.3f ns/call", ns_per_call ));
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+  fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
+
+  test_single_glyphs();
+  test_glyph_pairs();
+  test_oob();
+  test_null_input_semantics();
+  test_avx512_boundaries();
+  test_edge_cases();
+
+  uchar ascii_buf[ 4096 ];
+  fill_ascii( ascii_buf, sizeof(ascii_buf), rng );
+
+  uchar mixed_buf[ 4096 ];
+  fill_mixed_utf8( mixed_buf, sizeof(mixed_buf), rng );
+
+  bench_utf8_verify( ascii_buf, sizeof(ascii_buf), "pure ASCII" );
+  bench_utf8_verify( mixed_buf, sizeof(mixed_buf), "mixed UTF-8" );
+  bench_early_reject( ascii_buf );
+
+  fd_rng_delete( fd_rng_leave( rng ) );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();
   return 0;
 }
-

--- a/src/util/simd/fd_avx512_wwb.h
+++ b/src/util/simd/fd_avx512_wwb.h
@@ -105,6 +105,17 @@ wwb_bcast_hex( uchar b0, uchar b1, uchar b2,  uchar b3,  uchar b4,  uchar b5,  u
 #define wwb_or(a,b)     _mm512_or_si512(     (a), (b) ) /* [   a0 |b0    a1 |b1 ...   a63 |b63 ] */
 #define wwb_xor(a,b)    _mm512_xor_si512(    (a), (b) ) /* [   a0 ^b0    a1 ^b1 ...   a63 ^b63 ] */
 
+/* Arithmetic operations */
+
+#define wwb_subs(a,b) _mm512_subs_epu8( (a), (b) ) /* [ a0-b0, a1-b1, ... a63-b63 ] */
+
+
+/* Comparison operations */
+/* mask(c0,c1,...) means (((ulong)c0)<<0) | (((ulong)c1)<<1) | ... */
+
+#define wwb_eq(x,y) ((ulong)_mm512_cmpeq_epi8_mask(  (x), (y) )) /* mask( x0==y0, x1==y1, ... ) */
+#define wwb_ne(x,y) ((ulong)_mm512_cmpneq_epi8_mask( (x), (y) )) /* mask( x0!=y0, x1!=y1, ... ) */
+
 /* Memory operations */
 
 /* wwb_ld returns the 64 uchars at the 64-byte aligned / 64-byte sized


### PR DESCRIPTION
When AVX512 is available, uses an accelerated UTF-8 validation algorithm. This is roughly ported over from how simdutf has implemented it, but is mainly based on the paper proposing it.

For the non-AVX512 fallback, uses an extremely simple DFA based UTF-8 validator, which is usually faster than taking more branches on older CPUs.

Before:
```
Benchmarking fd_utf8_verify (pure ASCII)
  sz   32: ~  17.667 ns/call  ~14.490 Gbps
  sz  128: ~  64.021 ns/call  ~15.995 Gbps
  sz  512: ~ 253.374 ns/call  ~16.166 Gbps
  sz 1024: ~ 500.668 ns/call  ~16.362 Gbps
  sz 4096: ~1984.662 ns/call  ~16.511 Gbps
Benchmarking fd_utf8_verify (mixed UTF-8)
  sz   32: ~  17.404 ns/call  ~14.709 Gbps
  sz  128: ~  65.069 ns/call  ~15.737 Gbps
  sz  512: ~ 271.761 ns/call  ~15.072 Gbps
  sz 1024: ~ 573.573 ns/call  ~14.282 Gbps
  sz 4096: ~2525.660 ns/call  ~12.974 Gbps
Benchmarking fd_utf8_verify (early reject)
  ~   2.175 ns/call
```

After:
```
Benchmarking fd_utf8_verify (pure ASCII)
  sz   32: ~  31.983 ns/call  ~ 8.004 Gbps
  sz  128: ~   4.485 ns/call  ~228.321 Gbps
  sz  512: ~  14.636 ns/call  ~279.853 Gbps
  sz 1024: ~  28.248 ns/call  ~290.001 Gbps
  sz 4096: ~ 113.391 ns/call  ~288.982 Gbps
Benchmarking fd_utf8_verify (mixed UTF-8)
  sz   32: ~  32.001 ns/call  ~ 8.000 Gbps
  sz  128: ~   9.254 ns/call  ~110.655 Gbps
  sz  512: ~  32.468 ns/call  ~126.155 Gbps
  sz 1024: ~  63.234 ns/call  ~129.551 Gbps
  sz 4096: ~ 246.613 ns/call  ~132.872 Gbps
Benchmarking fd_utf8_verify (early reject)
  ~ 115.312 ns/call
```