### PR TITLE
replay: init sysvar cache on boot

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -665,12 +665,6 @@ replay_block_start( fd_replay_tile_t *  ctx,
 
   /* Update required runtime state and handle potential boundary. */
 
-  fd_bank_shred_cnt_set( bank, 0UL );
-  fd_bank_execution_fees_set( bank, 0UL );
-  fd_bank_priority_fees_set( bank, 0UL );
-  fd_bank_tips_set( bank, 0UL );
-  fd_bank_identity_vote_idx_set( bank, ULONG_MAX );
-
   fd_bank_block_height_set( bank, fd_bank_block_height_get( bank ) + 1UL );
 
   int is_epoch_boundary = 0;
@@ -958,13 +952,6 @@ prepare_leader_bank( fd_replay_tile_t *  ctx,
   fd_accdb_attach_child( ctx->accdb_admin, &parent_xid, &xid );
   fd_progcache_txn_attach_child( ctx->progcache, &parent_xid, &xid );
 
-  fd_bank_execution_fees_set( ctx->leader_bank, 0UL );
-  fd_bank_priority_fees_set( ctx->leader_bank, 0UL );
-  fd_bank_shred_cnt_set( ctx->leader_bank, 0UL );
-  fd_bank_tips_set( ctx->leader_bank, 0UL );
-  fd_bank_identity_vote_idx_set( ctx->leader_bank, ULONG_MAX );
-
-  /* Update block height. */
   fd_bank_block_height_set( ctx->leader_bank, fd_bank_block_height_get( ctx->leader_bank ) + 1UL );
 
   int is_epoch_boundary = 0;
@@ -1574,6 +1561,8 @@ on_snapshot_message( fd_replay_tile_t *  ctx,
 
     fd_funk_txn_xid_t xid = { .ul = { snapshot_slot, FD_REPLAY_BOOT_BANK_IDX } };
     fd_features_restore( bank, ctx->accdb, &xid );
+
+    FD_TEST( fd_sysvar_cache_restore( bank, ctx->accdb, &xid ) );
 
     ctx->consensus_root          = manifest_block_id;
     ctx->consensus_root_slot     = snapshot_slot;

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -840,14 +840,17 @@ fd_runtime_block_execute_prepare( fd_banks_t *         banks,
                                   fd_capture_ctx_t *   capture_ctx,
                                   int *                is_epoch_boundary ) {
 
+  fd_bank_execution_fees_set( bank, 0UL );
+  fd_bank_priority_fees_set( bank, 0UL );
+  fd_bank_tips_set( bank, 0UL );
+  fd_bank_signature_count_set( bank, 0UL );
+  fd_bank_total_compute_units_used_set( bank, 0UL );
+  fd_bank_shred_cnt_set( bank, 0UL );
+  fd_bank_identity_vote_idx_set( bank, ULONG_MAX );
+
   fd_funk_txn_xid_t const xid = { .ul = { fd_bank_slot_get( bank ), bank->data->idx } };
 
   fd_runtime_block_pre_execute_process_new_epoch( banks, bank, accdb, &xid, capture_ctx, runtime_stack, is_epoch_boundary );
-
-  fd_bank_execution_fees_set( bank, 0UL );
-  fd_bank_priority_fees_set( bank, 0UL );
-  fd_bank_signature_count_set( bank, 0UL );
-  fd_bank_total_compute_units_used_set( bank, 0UL );
 
   if( FD_LIKELY( fd_bank_slot_get( bank ) ) ) {
     fd_cost_tracker_t * cost_tracker = fd_bank_cost_tracker_locking_modify( bank );


### PR DESCRIPTION
The resolv tile queries the sysvar cache for slot hashes.  Upon receiving the first rooted bank, which is the snapshot bank, the resolv tile will start processing transactions.  If the sysvar cache in the snapshot bank isn't initialized, the resolv tile would crash if any alut expansion is needed in the window between the snapshot bank is received by resolv and the root advances to one past the snapshot bank.