### PR TITLE
zksdk: fix transcript order for handles proofs

### DIFF
--- a/src/ballet/zksdk/instructions/fd_zksdk_grouped_ciphertext_2_handles_validity.c
+++ b/src/ballet/zksdk/instructions/fd_zksdk_grouped_ciphertext_2_handles_validity.c
@@ -180,8 +180,8 @@ fd_zksdk_verify_proof_direct_grouped_ciphertext_2_handles_validity(
   uchar w[ 32 ];
   fd_zksdk_transcript_challenge_scalar( c, transcript, FD_TRANSCRIPT_LITERAL("c") );
 
-  fd_zksdk_transcript_append_scalar( transcript, FD_TRANSCRIPT_LITERAL("z_x"), proof->zx );
   fd_zksdk_transcript_append_scalar( transcript, FD_TRANSCRIPT_LITERAL("z_r"), proof->zr );
+  fd_zksdk_transcript_append_scalar( transcript, FD_TRANSCRIPT_LITERAL("z_x"), proof->zx );
 
   fd_zksdk_transcript_challenge_scalar( w, transcript, FD_TRANSCRIPT_LITERAL("w") );
 

--- a/src/ballet/zksdk/instructions/fd_zksdk_grouped_ciphertext_3_handles_validity.c
+++ b/src/ballet/zksdk/instructions/fd_zksdk_grouped_ciphertext_3_handles_validity.c
@@ -183,8 +183,8 @@ fd_zksdk_verify_proof_direct_grouped_ciphertext_3_handles_validity(
   uchar w[ 32 ];
   fd_zksdk_transcript_challenge_scalar( c, transcript, FD_TRANSCRIPT_LITERAL("c") );
 
-  fd_zksdk_transcript_append_scalar( transcript, FD_TRANSCRIPT_LITERAL("z_x"), proof->zx );
   fd_zksdk_transcript_append_scalar( transcript, FD_TRANSCRIPT_LITERAL("z_r"), proof->zr );
+  fd_zksdk_transcript_append_scalar( transcript, FD_TRANSCRIPT_LITERAL("z_x"), proof->zx );
 
   fd_zksdk_transcript_challenge_scalar( w, transcript, FD_TRANSCRIPT_LITERAL("w") );
 


### PR DESCRIPTION
The order of these params is irrelevant, but it's better to match agave's behavior.
(But this is the reason why all test vectors are passing)