### PR TITLE
fuzzing: fix false-positive crashes in fuzz_secp256k1_recover

### DIFF
--- a/src/ballet/secp256k1/fuzz_secp256k1_recover.c
+++ b/src/ballet/secp256k1/fuzz_secp256k1_recover.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 
 #include "../../util/fd_util.h"
+#include "../../util/sanitize/fd_fuzz.h"
 #include "fd_secp256k1.h"
 
 int
@@ -20,28 +21,24 @@ LLVMFuzzerInitialize( int  *   argc,
   return 0;
 }
 
-struct verification_test {
+struct recovery_test {
   uchar msg[ 32 ];
   uchar sig[ 64 ];
-  uchar pub[ 64 ];
 };
-typedef struct verification_test verification_test_t;
+typedef struct recovery_test recovery_test_t;
 
 int
 LLVMFuzzerTestOneInput( uchar const * data,
                         ulong         size ) {
-  if( FD_UNLIKELY( size<sizeof(verification_test_t) ) ) return -1;
+  if( FD_UNLIKELY( size<sizeof(recovery_test_t) ) ) return -1;
 
-  verification_test_t * const test = ( verification_test_t * const ) data;
-  uchar _pub[ 64 ]; uchar * pub = _pub;
+  recovery_test_t const * test = (recovery_test_t const *)data;
+  uchar pub[ 64 ];
 
   for( int recid=0; recid<=3; recid++ ) {
-    void * res = fd_secp256k1_recover(pub, test->msg, test->sig, recid);
-    if( FD_UNLIKELY( res != NULL && !memcmp( pub, test->pub, 64UL ) ) ) {
-      // was able to verify fuzz input
-      __builtin_trap();
-    }
+    fd_secp256k1_recover( pub, test->msg, test->sig, recid );
   }
 
+  FD_FUZZ_MUST_BE_COVERED;
   return 0;
 }


### PR DESCRIPTION
The fuzzer used `__builtin_trap()` when recovery succeeded and the recovered key matched the fuzz input's `pub` field. 

Unlike ed25519 verification, secp256k1 recovery deterministically computes a public key from `(msg, sig)`, so the fuzzer trivially evolves `pub` to match, causing false-positive crashes.

Remove the pub field from the test struct and the bogus trap. The fuzzer now tests that `fd_secp256k1_recover` is crash-free on arbitrary inputs across all 4 recovery IDs.