### PR TITLE
forest: tighten sentinel block conditions

### DIFF
--- a/src/discof/forest/fd_forest.c
+++ b/src/discof/forest/fd_forest.c
@@ -515,18 +515,17 @@ fd_forest_query( fd_forest_t * forest, ulong slot ) {
   return query( forest, slot );
 }
 
-static ulong
-clear_leaf( fd_forest_t * forest, ulong slot ) {
-  VER_INC;
-
+/* remove_and_unlink removes a block from the forest and unlinks it from
+   its parent.  Also removes from sibling chain, consumed map, and
+   requests map if needed.  Does NOT release the block from the pool. */
+static void
+remove_and_unlink( fd_forest_t * forest, fd_forest_blk_t * blk ) {
   fd_forest_blk_t      * pool     = fd_forest_pool( forest );
   fd_forest_orphaned_t * orphaned = fd_forest_orphaned( forest );
   fd_forest_frontier_t * frontier = fd_forest_frontier( forest );
   fd_forest_ancestry_t * ancestry = fd_forest_ancestry( forest );
   fd_forest_consumed_t * consumed = fd_forest_consumed( forest );
   fd_forest_ref_t *      conspool = fd_forest_conspool( forest );
-  fd_forest_blk_t * blk  = query( forest, slot );
-  FD_TEST( blk );
 
   /* Clean up the parent, and remove block from the maps */
   int is_orphan_req = 1;
@@ -550,6 +549,7 @@ clear_leaf( fd_forest_t * forest, ulong slot ) {
         sibling = fd_forest_pool_ele( pool, sibling->sibling );
       }
     }
+    blk->sibling = fd_forest_pool_idx_null( pool );
 
     /* remove the block itself from the maps */
 
@@ -559,7 +559,7 @@ clear_leaf( fd_forest_t * forest, ulong slot ) {
       removed = ancestry_frontier_remove( forest, blk->slot ); FD_TEST( removed );
 
       /* We removed from the main tree, so we possible need to insert parent into the frontier.
-         Only need to add parent to the frontier if it doesn't have any other children. */
+          Only need to add parent to the frontier if it doesn't have any other children. */
 
       if( parent->child == fd_forest_pool_idx_null( pool ) ) {
         parent = fd_forest_ancestry_ele_remove( ancestry, &blk->parent_slot, NULL, pool );
@@ -584,6 +584,17 @@ clear_leaf( fd_forest_t * forest, ulong slot ) {
   consumed_remove( forest, fd_forest_pool_idx( pool, blk ) );
   if( is_orphan_req ) requests_remove( forest, fd_forest_orphreqs( forest ), fd_forest_orphlist( forest ), &forest->orphiter, fd_forest_pool_idx( pool, blk ) );
   else                requests_remove( forest, fd_forest_requests( forest ), fd_forest_reqslist( forest ), &forest->iter,     fd_forest_pool_idx( pool, blk ) );
+}
+
+static ulong
+clear_leaf( fd_forest_t * forest, ulong slot ) {
+  VER_INC;
+
+  fd_forest_blk_t * pool = fd_forest_pool( forest );
+  fd_forest_blk_t * blk  = query( forest, slot );
+  FD_TEST( blk );
+
+  remove_and_unlink( forest, blk );
   fd_forest_pool_ele_release( pool, blk );
 
   return slot;
@@ -915,21 +926,6 @@ fd_forest_blk_insert( fd_forest_t * forest, ulong slot, ulong parent_slot, ulong
   FD_TEST( slot > fd_forest_root_slot( forest ) ); /* caller error - inval */
 # endif
 
-  fd_forest_blk_t * ele = query( forest, slot );
-  if( FD_LIKELY( ele ) ) {
-    // potentially may need to update the parent_slot, if this
-    // this was a sentinel block that was created for a confirmed msg
-    if( FD_UNLIKELY( parent_slot != ele->parent_slot ) ) {
-      ele->parent_slot = parent_slot;
-      subtrees_orphaned_remove( forest, slot ); // if this is a sentinel block, then it must be in subtrees
-    } else {
-      return ele;
-    }
-  } else {
-    ele = acquire( forest, slot, parent_slot, evicted );
-    if( FD_UNLIKELY( !ele ) ) return NULL; /* no space in pool, so we can't add this slot */
-  }
-
   fd_forest_ancestry_t * ancestry = fd_forest_ancestry( forest );
   fd_forest_frontier_t * frontier = fd_forest_frontier( forest );
   fd_forest_subtrees_t * subtrees = fd_forest_subtrees( forest );
@@ -939,9 +935,28 @@ fd_forest_blk_insert( fd_forest_t * forest, ulong slot, ulong parent_slot, ulong
   fd_forest_ref_t *      conspool = fd_forest_conspool( forest );
   fd_forest_requests_t * requests = fd_forest_requests( forest );
   fd_forest_ref_t *      reqspool = fd_forest_reqspool( forest );
-  fd_forest_blk_t *      pool     = fd_forest_pool ( forest );
+  fd_forest_blk_t *      pool     = fd_forest_pool    ( forest );
   ulong *                bfs      = fd_forest_deque( forest );
   ulong                  null     = fd_forest_pool_idx_null( pool );
+
+  fd_forest_blk_t * ele = query( forest, slot );
+  if( FD_LIKELY( ele ) ) {
+    /* May need to update the parent_slot, if this
+       this was a sentinel block that was created for a confirmed msg.
+       A parent update for a sentinel block only occurs once.  This
+       is separate from the parent update for a confirmed equivocating
+       block. */
+    if( FD_UNLIKELY( ele->parent_slot == ULONG_MAX && parent_slot != ULONG_MAX ) ) {
+      ele->parent_slot = parent_slot;
+      FD_TEST( fd_forest_subtrees_ele_query( subtrees, &slot, NULL, pool ) || fd_forest_orphaned_ele_query( orphaned, &slot, NULL, pool ) );
+      subtrees_orphaned_remove( forest, slot ); // if this is a sentinel block, then it must be orphaned
+    } else {
+      return ele;
+    }
+  } else {
+    ele = acquire( forest, slot, parent_slot, evicted );
+    if( FD_UNLIKELY( !ele ) ) return NULL; /* no space in pool, so we can't add this slot */
+  }
 
   fd_forest_blk_t * parent = NULL;
 
@@ -1047,6 +1062,75 @@ fd_forest_blk_insert( fd_forest_t * forest, ulong slot, ulong parent_slot, ulong
   return ele;
 }
 
+/* Updates a forest_blk_t's parent, which requires updates to the blk
+   itself, the blk's old parent, the new parent, and all its
+   descendants. */
+static fd_forest_blk_t *
+verified_parent_update( fd_forest_t * forest, fd_forest_blk_t * ele, ulong parent_slot ) {
+  fd_forest_blk_t *      pool     = fd_forest_pool( forest );
+  fd_forest_subtrees_t * subtrees = fd_forest_subtrees( forest );
+  fd_forest_orphaned_t * orphaned = fd_forest_orphaned( forest );
+
+  /* remove from maps, unlink from old parent. children subtree still in maps */
+  remove_and_unlink( forest, ele );
+
+  /* the only info that is verified and should be saved is the confirmed
+     bid, and verified status if the confirmed bid already exists. */
+  fd_hash_t confirmed_bid       = ele->confirmed_bid;       /* save confirmation status for later */
+  uint      lowest_verified_fec = ele->lowest_verified_fec; /* save lowest verified fec for later */
+  uchar     merkle_roots[ sizeof(ele->merkle_roots) ]; /* save merkle roots for later */
+  if( FD_LIKELY( lowest_verified_fec != UINT_MAX ) ) {
+    memcpy( merkle_roots, ele->merkle_roots, sizeof(ele->merkle_roots) );
+  }
+
+  /* orphan/subtree all the descendants of ele */
+  ulong * queue = fd_forest_deque( forest );
+  fd_forest_deque_push_tail( queue, fd_forest_pool_idx( pool, ele ) );
+
+  while( FD_LIKELY( fd_forest_deque_cnt( queue ) ) ) {
+    fd_forest_blk_t * blk = fd_forest_pool_ele( pool, fd_forest_deque_pop_head( queue ) );
+    fd_forest_blk_t * child = fd_forest_pool_ele( pool, blk->child );
+    while( FD_LIKELY( child ) ) {
+      /* remove child from all structures */
+      ancestry_frontier_remove( forest, child->slot );
+      subtrees_orphaned_remove( forest, child->slot );
+      consumed_remove( forest, fd_forest_pool_idx( pool, child ) );
+      requests_remove( forest, fd_forest_requests( forest ), fd_forest_reqslist( forest ), &forest->iter, fd_forest_pool_idx( pool, child ) );
+
+      fd_forest_deque_push_tail( queue, fd_forest_pool_idx( pool, child ) );
+      child = fd_forest_pool_ele( pool, child->sibling );
+    }
+    /* this is the ele itself, do not reinsert */
+    if( FD_UNLIKELY( blk == ele ) ) continue;
+
+    /* direct child of the ele, insert it into subtrees */
+    else if( FD_UNLIKELY( fd_forest_pool_ele( pool, blk->parent ) == ele ) ) {
+      blk->parent = fd_forest_pool_idx_null( pool );
+      fd_forest_subtrees_ele_insert( subtrees, blk, pool );
+      fd_forest_subtlist_ele_push_tail( fd_forest_subtlist( forest ), blk, pool );
+      requests_insert( forest, fd_forest_orphreqs( forest ), fd_forest_orphlist( forest ), fd_forest_pool_idx( pool, blk ) );
+
+    /* otherwise, not direct descendant of ele, insert it into orphaned */
+
+    } else {
+      fd_forest_orphaned_ele_insert( orphaned, blk, pool );
+    }
+  }
+
+  ulong slot = ele->slot;
+  fd_forest_pool_ele_release( pool, ele );
+
+  /* ele is now gone. blk_insert it! and then restore saved verified state */
+
+  fd_forest_blk_t * new_ele = fd_forest_blk_insert( forest, slot, parent_slot, NULL );
+  new_ele->lowest_verified_fec = lowest_verified_fec;
+  if( FD_UNLIKELY( lowest_verified_fec != UINT_MAX ) ) {
+    new_ele->confirmed_bid = confirmed_bid;
+    memcpy( new_ele->merkle_roots, merkle_roots, sizeof(merkle_roots) );
+  }
+  return new_ele;
+}
+
 static inline int
 merkle_recvd( fd_forest_blk_t * ele, uint fec_idx ) {
   return memcmp( &ele->merkle_roots[fec_idx].mr, &empty_mr, sizeof(fd_hash_t) ) != 0;
@@ -1094,8 +1178,18 @@ fd_forest_data_shred_insert( fd_forest_t * forest,
       /* merkle root doesn't match the verified CMR  */
       return NULL; /* do not accept this shred. */
     } else {
+      /* A validated mr, but the parent slot is wrong.  This means we
+         initially received a the wrong version of the slot that also
+         had a different parent slot.  We need to update the parent slot
+         to the correct one.  We can _probably_ get away with not doing
+         this update (it wouldn't cause the validator to halt), but for
+         the sake of correctness, we'll do it.  It is theoretically only
+         possible for the parent_slot update to happen once, after
+         the fec_chain_verify has identified an incorrect FEC. */
+      if( FD_UNLIKELY( ele->parent_slot != parent_slot ) ) ele = verified_parent_update( forest, ele, parent_slot );
       ele->merkle_roots[fec_idx].mr = *mr;
       ele->merkle_roots[fec_idx].cmr = *cmr;
+
     }
   }
   else { /* No verification / knowledge of canonical merkle root */
@@ -1164,16 +1258,12 @@ fd_forest_fec_insert( fd_forest_t * forest, ulong slot, ulong parent_slot, uint 
        (2) the second case is that we get two FEC completion msgs:
            one for both version B and A. They get completed, one after
            the other. In this case we've first overwritten from { 0 } to
-           B.  But when version A arrives, what should we do? If A is
-           the correct version but we ignore it, when we chain verify
-           down the line, we'll evict B and try to repair for A, but
-           fec_resolver is not going to let it through! Vice versa if B
+           B.  But if version A arrives, what should we do?  If B
            is the correct version, but we choose to overwrite the fec
-           when A arrive. No way around it (unless) we ask shred to
-           re-deliver the FEC set. In practice, we'll likely still
-           progress because reasm will have information about both B and
-           A, but if reasm has evicted it. (unlikely, but possible),
-           then we'll stall. */
+           when A arrive, then we need to ask ask shred to
+           re-deliver the FEC set.  Since we don't know at this time if
+           B or A is correct, we optimize for case 1, and overwrite the
+           merkle root with the new one. */
     // overwrite the merkle root with the new one
     ele->merkle_roots[fec_idx].mr  = *mr;
     ele->merkle_roots[fec_idx].cmr = *cmr;
@@ -1276,8 +1366,12 @@ fd_forest_fec_clear( fd_forest_t * forest, ulong slot, uint fec_set_idx, uint ma
      iterator's next_shred_idx, then the iterator will pop the slot as
      "done" (next_shred_idx > complete_idx) without ever rerequesting
      this fec. We must mark the slot incomplete so that the iterator can
-     re-request everything. */
-  ele->complete_idx = UINT_MAX;
+     re-request everything.  Don't particularly care about the clear of
+     orphan slots as they are guaranteed to be iterated again. */
+
+  if( FD_UNLIKELY( forest->iter.ele_idx == fd_forest_pool_idx( fd_forest_pool( forest ), ele ) ) ) {
+    forest->iter.shred_idx = UINT_MAX;
+  }
 
   if( FD_UNLIKELY( fec_set_idx == 0 ) ) ele->buffered_idx = UINT_MAX;
   else                                  ele->buffered_idx = fd_uint_if( ele->buffered_idx != UINT_MAX, fd_uint_min( ele->buffered_idx, fec_set_idx - 1 ), UINT_MAX );

--- a/src/discof/forest/fd_forest.h
+++ b/src/discof/forest/fd_forest.h
@@ -236,9 +236,10 @@ typedef struct fd_forest_blk fd_forest_blk_t;
    The following maps/pools are used to track future requests.
 
    Requests:
-    - slots that branch from the main tree (ancestry) that are being repaired /
-      have yet to be repaired.  Maintained in a dlist, where the head
-      is the current slot being repaired.
+    - slots that branch from the main tree (ancestry) that are being
+      repaired / have yet to be repaired.  Maintained in a dlist, where
+      the head is the current slot being repaired.  Any slot in the
+      requests list must be in ancestry or frontier.
 
    Orphreqs (orphaned requests):
     - slots that branch from the unconnected trees (subtrees/orphans) that are being repaired /
@@ -257,8 +258,7 @@ typedef struct fd_forest_blk fd_forest_blk_t;
 
     Consumed:
     - slots where the entire ancestry up to the root has been completed.
-      This is what we are repairing next.  There should be <= num forks
-      elements in the consumed map.
+      There should be <= num forks elements in the consumed map.
 */
 struct fd_forest_ref {
   ulong idx;             /* forest pool idx of the ele this ref refers to */
@@ -723,10 +723,22 @@ fd_forest_query( fd_forest_t * forest, ulong slot );
 /* Operations */
 
 /* fd_forest_blk_insert inserts a new block into the forest.  Assumes
-   slot >= forest->smr, and the blk pool has a free element (if
-   handholding is enabled, explicitly checks and errors).  This blk
-   insert is idempotent, and can be called multiple times with the same
-   slot. Returns the inserted forest ele. */
+   slot >= forest->root.  blk_insert can also be called to create a
+   sentinel block, i.e. a placeholder block that we know exists but
+   don't know the parent slot of.  The caller should pass in parent_slot
+   == ULONG_MAX.  In this case, the block inserted will remain an
+   orphan/subtree at least until the next blk_insert is called with a
+   different parent_slot, after which point no more updates to the
+   parent_slot will be allowed.  For non-sentinel blocks, blk insert is
+   idempotent, and can be called multiple times with the same slot.
+
+   If the forest pool is full at the time of insertion, a block will be
+   chosen for eviction (see fd_forest.c:evict for more details).  If the
+   caller passes in a non-NULL evicted pointer, the evicted slot will be
+   stored to the pointer.
+
+   Returns the inserted (or existing) forest ele.  NULL if the forest
+   pool is full and no block could be evicted. */
 
 fd_forest_blk_t *
 fd_forest_blk_insert( fd_forest_t * forest, ulong slot, ulong parent_slot, ulong * evicted );
@@ -735,10 +747,21 @@ fd_forest_blk_insert( fd_forest_t * forest, ulong slot, ulong parent_slot, ulong
 #define SHRED_SRC_REPAIR    1
 #define SHRED_SRC_RECOVERED 2
 
-/* fd_forest_shred_insert inserts a new shred into the forest.
-   Assumes slot is already in forest, and should typically be called
-   directly after fd_forest_block_insert. Returns the forest ele
-   corresponding to the shred slot. */
+/* fd_forest_shred_insert inserts a new shred into the forest. Assumes
+   slot is already in forest, and should typically be preceded by a
+   fd_forest_blk_insert. Returns the forest ele corresponding to the
+   shred slot if the shred is accepted, and NULL if the shred is
+   rejected.  A shred can only be rejected if slot is able to verify
+   that this shred does not belong to the canonical FEC set.
+
+   A possible side effect of data_shred_insert is that it may update the
+   parent slot of the block IF the inserted shred has a verifiably
+   correct merkle root.  Note this is different from a sentinel block
+   parent update. A data shred insert can only update the parent slot if
+   the data shred has a verified merkle root, and the parent slot is
+   incorrect.  A sentinel block will update its parent with the first
+   parent slot it receives, but it can be later updated with a
+   data_shred_insert.  Each update type can only be performed once. */
 
 fd_forest_blk_t *
 fd_forest_data_shred_insert( fd_forest_t * forest,
@@ -752,7 +775,6 @@ fd_forest_data_shred_insert( fd_forest_t * forest,
                              fd_hash_t *   mr,
                              fd_hash_t *   cmr );
 
-/* TODO: Does merkle validation need to happen for coding shreds as well*/
 fd_forest_blk_t *
 fd_forest_code_shred_insert( fd_forest_t * forest, ulong slot, uint shred_idx );
 
@@ -791,14 +813,18 @@ fd_forest_fec_insert( fd_forest_t * forest,
 void
 fd_forest_fec_clear( fd_forest_t * forest, ulong slot, uint fec_set_idx, uint max_shred_idx );
 
-/* fd_forest_fec_chain_verify verifies the chain of merkle roots for a given block.
-   Returns a pointer to the first slot that does not confirm, or NULL if the chain is valid. */
+/* fd_forest_fec_chain_verify verifies the chain of merkle roots for a
+   given block. Should only be called on a block that has all the shreds
+   received. Returns a pointer to the first slot that does not confirm,
+   or NULL if the chain is valid. */
 fd_forest_blk_t *
 fd_forest_fec_chain_verify( fd_forest_t * forest, fd_forest_blk_t * ele, fd_hash_t const * mr );
 
 void
 fd_forest_confirm( fd_forest_t * forest, fd_forest_blk_t * ele, fd_hash_t const * bid );
 
+/* fd_forest_merkle_last_incorrect_idx returns the highest incorrect FEC
+   index for a given block. */
 static inline uint
 fd_forest_merkle_last_incorrect_idx( fd_forest_blk_t * ele ) {
   ulong first_verified_fec = ele->lowest_verified_fec;

--- a/src/discof/forest/test_forest.c
+++ b/src/discof/forest/test_forest.c
@@ -1288,6 +1288,144 @@ test_eviction_deep( fd_wksp_t * wksp ) {
   fd_forest_print( forest );
 }
 
+void
+test_sentinel_blocks( fd_wksp_t * wksp ) {
+  ulong ele_max = 16;
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  FD_TEST( mem );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_init( forest, 0 );
+
+  fd_forest_subtrees_t * subtrees = fd_forest_subtrees( forest );
+
+  /* insert sentinel blocks */
+  for( ulong i = 1; i <= 5; i++ ) {
+    FD_TEST( fd_forest_blk_insert( forest, i, ULONG_MAX, NULL ) );
+    FD_TEST( fd_forest_subtrees_ele_query( subtrees, &i, NULL, fd_forest_pool( forest ) ) );
+  }
+
+  FD_TEST( fd_forest_blk_insert( forest, 2, 0, NULL ) );
+  FD_TEST( fd_forest_query( forest, 2 )->parent_slot == 0 );
+  FD_TEST( fd_forest_blk_insert( forest, 2, 0, NULL ) == fd_forest_query( forest, 2 ) );
+  FD_TEST( fd_forest_blk_insert( forest, 2, 1, NULL ) );
+  FD_TEST( fd_forest_query( forest, 2 )->parent_slot == 0 ); /* parent slot should not change */
+  FD_TEST( !fd_forest_verify( forest ) );
+}
+
+void
+test_parent_update( fd_wksp_t * wksp ) {
+  /*   o o
+        _ ` */
+
+  ulong ele_max = 8;
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  FD_TEST( mem );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_init( forest, 0 );
+
+  fd_hash_t mr_1 = (fd_hash_t){ .key = { 1 } };
+  fd_hash_t mr_2 = (fd_hash_t){ .key = { 2 } };
+  fd_hash_t mr_3_2 = (fd_hash_t){ .key = { 3, 2 } };
+  fd_hash_t mr_3 = (fd_hash_t){ .key = { 3 } };
+  fd_hash_t mr_7_0 = (fd_hash_t){ .key = { 7, 0 } };
+  fd_hash_t mr_7_1 = (fd_hash_t){ .key = { 7, 1 } };
+  fd_hash_t mr_6_0  = (fd_hash_t){ .key = { 6, 0 } };
+  fd_hash_t mr_8_0 = (fd_hash_t){ .key =  { 8, 0 } };
+
+  fd_forest_blk_insert( forest, 1, 0, NULL );
+  fd_forest_blk_insert( forest, 3, 1, NULL );
+  fd_forest_fec_insert( forest, 3, 1, 31, 0, 1, 0, &mr_3_2, &mr_1 );
+  /* orphans */
+  fd_forest_blk_insert( forest, 7, 6, NULL );
+  fd_forest_fec_insert( forest, 7, 6, 31, 0, 1, 0, &mr_7_0, &mr_6_0 );
+  fd_forest_blk_insert( forest, 8, 7, NULL );
+  fd_forest_data_shred_insert( forest, 8, 7, 31, 0, 0, 0, SHRED_SRC_REPAIR, &mr_8_0, &mr_7_0 );
+
+  /* now confirm 7 with a different block id. */
+  FD_TEST( fd_forest_fec_chain_verify( forest, fd_forest_query( forest, 7 ), &mr_7_1 ) );
+  FD_TEST( fd_forest_merkle_last_incorrect_idx( fd_forest_query( forest, 7 ) ) == 0UL ); /* INCORRECT. */
+
+  /* now clear 7, 0. */
+  fd_forest_fec_clear( forest, 7, 0, 31 );
+
+  /* now get a data shred that is correct. */
+  fd_forest_fec_insert( forest, 7, 3, 31, 0, 1, 0, &mr_7_1, &mr_3 );
+  FD_TEST( fd_forest_query( forest, 7 )->parent_slot == 3 ); /* parent slot should be updated */
+  ulong _8 = 8;
+  FD_TEST( fd_forest_frontier_ele_query( fd_forest_frontier( forest ), &_8, NULL, fd_forest_pool( forest ) ) );
+  FD_TEST( !fd_forest_verify( forest ) );
+
+  /* an old data shred with the wrong parent_slot shouldn't cause the
+     parent_slot to update */
+  fd_forest_data_shred_insert( forest, 7, 6, 31, 0, 1, 0, 0, &mr_7_0, &mr_6_0 );
+  FD_TEST( fd_forest_query( forest, 7 )->parent_slot == 3 );
+  FD_TEST( fd_forest_fec_chain_verify( forest, fd_forest_query( forest, 7 ), &mr_7_1 ) == fd_forest_query( forest, 3 ) );
+  FD_TEST( fd_forest_merkle_last_incorrect_idx( fd_forest_query( forest, 3 ) ) == 0UL );
+
+  /* SURPRISE! let's say slot 3's real parent should be slot 2 */
+
+  fd_forest_data_shred_insert( forest, 3, 2, 31, 0, 0, 0, SHRED_SRC_REPAIR, &mr_3, &mr_2 );
+  /*should get accepted*/
+  FD_TEST( fd_forest_query( forest, 3 )->parent_slot == 2 );
+  ulong _3 = 3; ulong _7 = 7;
+  fd_forest_print( forest );
+  FD_TEST( fd_forest_subtrees_ele_query( fd_forest_subtrees( forest ), &_3, NULL, fd_forest_pool( forest ) ) );
+  FD_TEST( fd_forest_orphaned_ele_query( fd_forest_orphaned( forest ), &_8, NULL, fd_forest_pool( forest ) ) );
+  FD_TEST( fd_forest_orphaned_ele_query( fd_forest_orphaned( forest ), &_7, NULL, fd_forest_pool( forest ) ) );
+  FD_TEST( !fd_forest_verify( forest ) );
+
+  /* now get something thats an orphan, real parent keeps it an orphan */
+  ulong _9 = 9;
+  fd_hash_t mr_9_0 = (fd_hash_t){ .key = { 9, 0 } };
+  fd_forest_blk_insert( forest, 9, 8, NULL );
+  fd_forest_data_shred_insert( forest, 9, 8, 31, 0, 1, 1, SHRED_SRC_REPAIR, &mr_9_0, &mr_8_0 );
+
+  fd_hash_t mr_9_1 = (fd_hash_t){ .key = { 9, 1 } };
+  fd_hash_t mr_5   = (fd_hash_t){ .key = { 5 } };
+  FD_TEST( fd_forest_fec_chain_verify( forest, fd_forest_query( forest, 9 ), &mr_9_1 ) == fd_forest_query( forest, 9 ) );
+  FD_TEST( fd_forest_merkle_last_incorrect_idx( fd_forest_query( forest, 9 ) ) == 0UL );
+  fd_forest_fec_clear( forest, 9, 0, 31 );
+
+  fd_forest_data_shred_insert( forest, 9, 5, 31, 0, 0, 1, SHRED_SRC_REPAIR, &mr_9_1, &mr_5 );
+  FD_TEST( fd_forest_query( forest, 9 )->parent_slot == 5 );
+  FD_TEST( fd_forest_subtrees_ele_query( fd_forest_subtrees( forest ), &_9, NULL, fd_forest_pool( forest ) ) );
+  FD_TEST( !fd_forest_verify( forest ) );
+}
+
+void
+test_eqvoc_blk_wrong_parent( fd_wksp_t * wksp ) {
+  /* initial block 3 version has slot 1 as parent. correct version has slot 2 as parent. */
+  ulong ele_max = 8;
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  FD_TEST( mem );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_init( forest, 0 );
+  fd_forest_blk_data_shred_insert( forest, 1, 0, 31, 0, 0, 1 );
+  fd_forest_blk_data_shred_insert( forest, 2, 1, 31, 0, 0, 1 );
+
+  fd_hash_t mr1     = (fd_hash_t){ .key = { 1 } };
+  fd_hash_t mr_3_32 = (fd_hash_t){ .key = { 3, 1 } };
+  fd_hash_t mr_3_0  = (fd_hash_t){ .key = { 3, 0 } };
+  fd_forest_blk_insert( forest, 3, 1, NULL );
+  fd_forest_data_shred_insert( forest, 3, 1, 63, 32, 1, 0, SHRED_SRC_REPAIR, &mr_3_32, &mr_3_0 );
+  fd_forest_fec_insert( forest, 3, 1, 31, 0, 0, 0, &mr_3_0, &mr1 );
+
+  fd_hash_t mr_3_32_ = (fd_hash_t){ .key = { 3, 1, 1 } };
+  fd_hash_t mr_3_0_  = (fd_hash_t){ .key = { 3, 0, 1 } };
+
+  FD_TEST( fd_forest_fec_chain_verify( forest, fd_forest_query( forest, 3 ), &mr_3_32_ ) );
+  FD_TEST( fd_forest_merkle_last_incorrect_idx( fd_forest_query( forest, 3 ) ) == 32UL );
+
+  fd_forest_fec_clear( forest, 3, 32, 31 );
+  fd_forest_data_shred_insert( forest, 3, 2, 63, 32, 1, 0, SHRED_SRC_REPAIR, &mr_3_32_, &mr_3_0_ );
+  FD_TEST( fd_forest_query( forest, 3 )->parent_slot == 2 ); /* parent slot should be updated */
+  FD_TEST( !fd_forest_verify( forest ) );
+
+  fd_forest_fec_insert( forest, 3, 2, 63, 32, 1, 0, &mr_3_32_, &mr_3_0_ );
+  FD_TEST( fd_forest_fec_chain_verify( forest, fd_forest_query( forest, 3 ), &mr_3_32_ ) );
+  FD_TEST( fd_forest_merkle_last_incorrect_idx( fd_forest_query( forest, 3 ) ) == 0UL );
+}
+
 int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
@@ -1317,6 +1455,9 @@ main( int argc, char ** argv ) {
   test_eviction_confirmations( wksp );
   test_verify_orphans( wksp );
   test_eviction_deep( wksp );
+  test_sentinel_blocks( wksp );
+  test_eqvoc_blk_wrong_parent( wksp );
+  test_parent_update( wksp );
 
   fd_halt();
   return 0;

--- a/src/discof/repair/fd_repair_tile.c
+++ b/src/discof/repair/fd_repair_tile.c
@@ -834,7 +834,7 @@ after_fec( ctx_t      * ctx,
   }
 
   /* re-trigger continuation of chained merkle verification if this FEC
-     set enables it */
+     set enables it  TODO MOVE TO AFTER_SHRED? */
   if( FD_UNLIKELY( ele->lowest_verified_fec == (shred->fec_set_idx / 32UL) + 1 ) &&
                    ele->buffered_idx == ele->complete_idx ) {
     check_confirmed( ctx, ele, &ele->confirmed_bid /* if lowest_verified_fec is not UINT_MAX, confirmed_bid must be populated */ );
@@ -950,17 +950,16 @@ after_frag( ctx_t *             ctx,
         if( msg->slot > fd_forest_root_slot( ctx->forest ) && (msg->level >= FD_TOWER_SLOT_CONFIRMED_DUPLICATE ) ) {
           fd_forest_blk_t * blk = fd_forest_query( ctx->forest, msg->slot );
           if( FD_UNLIKELY( !blk ) ) {
-
             /* If we receive a confirmation for a slot we don't have,
                create a sentinel forest block that we can repair from. */
-
             ulong evicted = ULONG_MAX;
-            blk = fd_forest_blk_insert( ctx->forest, msg->slot, msg->slot, &evicted );
-            if( FD_LIKELY( blk_insert_check( ctx, blk, msg->slot, evicted ) ) ) {
-              blk->confirmed_bid = msg->block_id;
-              check_confirmed( ctx, blk, &msg->block_id );
-            }
+            blk = fd_forest_blk_insert( ctx->forest, msg->slot, ULONG_MAX, &evicted );
+            if( FD_UNLIKELY( !blk_insert_check( ctx, blk, msg->slot, evicted ) ) ) break;
           }
+
+          /* Confirm the block */
+          blk->confirmed_bid = msg->block_id;
+          check_confirmed( ctx, blk, &msg->block_id );
         }
       }
       break;


### PR DESCRIPTION
fixes https://github.com/firedancer-io/auditor-internal/issues/457 and missing check confirm case.

Also explicitly fixes equivocating blocks where two versions have different parents. i.e. ability to update parent if the FEC set is a confirmed one.